### PR TITLE
feat: classify two-step grid swap intermediates

### DIFF
--- a/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
@@ -327,21 +327,6 @@ theorem swapColumns_swapColumns_conj (x : GridState n) (a b c d : Fin n) :
   simpa using
     ((Equiv.swap c d).injective.swap_apply (Equiv.swap c d a) (Equiv.swap c d b) k)
 
-/-- Column swaps commute when every column in the first pair differs from every column in the
-second pair. -/
-theorem swapColumns_swapColumns_comm_of_ne (x : GridState n) {a b c d : Fin n}
-    (hac : a ≠ c) (had : a ≠ d) (hbc : b ≠ c) (hbd : b ≠ d) :
-    (x.swapColumns a b).swapColumns c d = (x.swapColumns c d).swapColumns a b := by
-  rw [x.swapColumns_swapColumns_conj a b c d,
-    Equiv.swap_apply_of_ne_of_ne hac had, Equiv.swap_apply_of_ne_of_ne hbc hbd]
-
-/-- Two swaps sharing a column can be reordered using the third pair of columns. -/
-theorem swapColumns_swapColumns_eq_of_ne (x : GridState n) {a b c : Fin n}
-    (hab : a ≠ b) (hac : a ≠ c) :
-    (x.swapColumns a b).swapColumns b c = (x.swapColumns b c).swapColumns a c := by
-  rw [x.swapColumns_swapColumns_conj a b b c,
-    Equiv.swap_apply_of_ne_of_ne hab hac, Equiv.swap_apply_left]
-
 /-- The grid states obtained from `x` by transposing a pair of distinct columns.
 
 These are exactly the states a single grid rectangle can reach from `x`: the fully blocked

--- a/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
@@ -315,6 +315,33 @@ theorem swapColumns_swapColumns (a b : Fin n) (x : GridState n) :
   ext c
   simp [swapColumns]
 
+/-- Conjugating the first transposition by the second reorders two column swaps.
+
+When the pairs are disjoint this is commutation. When they share a column, the conjugated pair is
+the third pair among the three involved columns. -/
+theorem swapColumns_swapColumns_conj (x : GridState n) (a b c d : Fin n) :
+    (x.swapColumns a b).swapColumns c d =
+      (x.swapColumns c d).swapColumns (Equiv.swap c d a) (Equiv.swap c d b) := by
+  refine GridState.ext fun k => ?_
+  simp only [swapColumns_apply]
+  simpa using
+    ((Equiv.swap c d).injective.swap_apply (Equiv.swap c d a) (Equiv.swap c d b) k)
+
+/-- Column swaps commute when every column in the first pair differs from every column in the
+second pair. -/
+theorem swapColumns_swapColumns_comm_of_ne (x : GridState n) {a b c d : Fin n}
+    (hac : a ≠ c) (had : a ≠ d) (hbc : b ≠ c) (hbd : b ≠ d) :
+    (x.swapColumns a b).swapColumns c d = (x.swapColumns c d).swapColumns a b := by
+  rw [x.swapColumns_swapColumns_conj a b c d,
+    Equiv.swap_apply_of_ne_of_ne hac had, Equiv.swap_apply_of_ne_of_ne hbc hbd]
+
+/-- Two swaps sharing a column can be reordered using the third pair of columns. -/
+theorem swapColumns_swapColumns_eq_of_ne (x : GridState n) {a b c : Fin n}
+    (hab : a ≠ b) (hac : a ≠ c) :
+    (x.swapColumns a b).swapColumns b c = (x.swapColumns b c).swapColumns a c := by
+  rw [x.swapColumns_swapColumns_conj a b b c,
+    Equiv.swap_apply_of_ne_of_ne hab hac, Equiv.swap_apply_left]
+
 /-- The grid states obtained from `x` by transposing a pair of distinct columns.
 
 These are exactly the states a single grid rectangle can reach from `x`: the fully blocked

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.Differential.Square.Backtracking
+
+/-!
+# Intermediate states in two column swaps
+
+The support of the square of the fully blocked grid differential consists of paths of two
+nontrivial column swaps. This file records the exact finite set of possible intermediate states
+between a source `x` and a target `z`: the intersection of their one-swap neighbour sets.
+
+For a diagonal path `x → y → x`, this set is exactly the full one-swap neighbour set of
+`x`. For a nondiagonal path, conjugating the first transposition by the second gives another
+factorization through a distinct intermediate state. Consequently every nonempty nondiagonal
+intermediate set has at least two elements. The conjugation argument treats both geometric cases
+needed later: disjoint transpositions commute, while transpositions sharing one column satisfy
+the three-column braid relation.
+
+These state-level factorizations do not yet pair rectangles: a later juxtaposition argument must
+also track which of the two rectangles with given corners is used and whether its domain avoids
+the markings. They provide the finite diagonal/nondiagonal case split on which that argument is
+built.
+
+## Main definitions
+
+* `TauCeti.GridState.twoStepColumnSwapIntermediates`: the possible middle states in a two-swap
+  path from `x` to `z`.
+
+## Main results
+
+* `TauCeti.GridState.nonempty_twoStepColumnSwapIntermediates_iff`: the intermediate set is
+  nonempty exactly for a two-step neighbour.
+* `TauCeti.GridState.twoStepColumnSwapIntermediates_self`: diagonal paths are precisely the
+  backtracking paths through an arbitrary one-swap neighbour.
+* `TauCeti.GridState.swapColumns_swapColumns_conj`: the transposition-conjugation identity that
+  reorders any two column swaps.
+* `TauCeti.GridState.swapColumns_swapColumns_of_disjoint` and
+  `TauCeti.GridState.swapColumns_swapColumns_overlap`: its disjoint- and shared-column forms.
+* `TauCeti.GridState.one_lt_card_twoStepColumnSwapIntermediates_of_ne`: a nondiagonal two-step
+  path has at least two possible intermediate states.
+
+## References
+
+This supplies the state-level two-step case split for
+`TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and `∂² = 0`".
+The later differential proof pairs juxtaposed rectangle decompositions as in
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.6.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridState
+
+variable {n : ℕ}
+
+/-- The grid states that can occur between `x` and `z` in a path of two nontrivial column swaps.
+
+The definition is symmetric in the endpoints: an intermediate state is a one-swap neighbour of
+both. -/
+def twoStepColumnSwapIntermediates (x z : GridState n) : Finset (GridState n) :=
+  x.columnSwapNeighbors ∩ z.columnSwapNeighbors
+
+/-- A state is an intermediate between `x` and `z` exactly when it is a one-swap neighbour of
+both endpoints. -/
+@[simp]
+theorem mem_twoStepColumnSwapIntermediates {x y z : GridState n} :
+    y ∈ x.twoStepColumnSwapIntermediates z ↔
+      y ∈ x.columnSwapNeighbors ∧ y ∈ z.columnSwapNeighbors := by
+  simp [twoStepColumnSwapIntermediates]
+
+/-- Swapping the two endpoints does not change their set of two-step intermediate states. -/
+theorem twoStepColumnSwapIntermediates_comm (x z : GridState n) :
+    x.twoStepColumnSwapIntermediates z = z.twoStepColumnSwapIntermediates x := by
+  rw [twoStepColumnSwapIntermediates, twoStepColumnSwapIntermediates, Finset.inter_comm]
+
+/-- The possible intermediate states between `x` and itself are exactly its one-swap
+neighbours. -/
+@[simp]
+theorem twoStepColumnSwapIntermediates_self (x : GridState n) :
+    x.twoStepColumnSwapIntermediates x = x.columnSwapNeighbors := by
+  rw [twoStepColumnSwapIntermediates, Finset.inter_self]
+
+/-- There is a two-step intermediate between `x` and `z` exactly when `z` is a two-step
+column-swap neighbour of `x`. -/
+theorem nonempty_twoStepColumnSwapIntermediates_iff {x z : GridState n} :
+    (x.twoStepColumnSwapIntermediates z).Nonempty ↔ z ∈ x.twoStepColumnSwapNeighbors := by
+  rw [mem_twoStepColumnSwapNeighbors]
+  constructor
+  · rintro ⟨y, hy⟩
+    rw [mem_twoStepColumnSwapIntermediates] at hy
+    exact ⟨y, hy.1, mem_columnSwapNeighbors_comm.mpr hy.2⟩
+  · rintro ⟨y, hyx, hzy⟩
+    exact ⟨y, mem_twoStepColumnSwapIntermediates.mpr
+      ⟨hyx, mem_columnSwapNeighbors_comm.mp hzy⟩⟩
+
+/-- Conjugating the first transposition by the second reorders two column swaps.
+
+When the pairs are disjoint this is commutation. When they share a column, the conjugated pair is
+the third pair among the three involved columns. -/
+theorem swapColumns_swapColumns_conj (x : GridState n) (a b c d : Fin n) :
+    (x.swapColumns a b).swapColumns c d =
+      (x.swapColumns c d).swapColumns (Equiv.swap c d a) (Equiv.swap c d b) := by
+  ext k
+  simp only [swapColumns_apply]
+  apply congrArg Fin.val
+  apply x.toPerm.injective
+  simpa using
+    ((Equiv.swap c d).injective.swap_apply (Equiv.swap c d a) (Equiv.swap c d b)
+      k)
+
+/-- Column swaps on four distinct columns commute.
+
+This is the disjoint-rectangle state factorization: the same endpoint is reached by applying the
+two swaps in the opposite order. -/
+theorem swapColumns_swapColumns_of_disjoint (x : GridState n) {a b c d : Fin n}
+    (h : [a, b, c, d].Nodup) :
+    (x.swapColumns a b).swapColumns c d = (x.swapColumns c d).swapColumns a b := by
+  rw [x.swapColumns_swapColumns_conj a b c d]
+  have hac : a ≠ c := by grind
+  have had : a ≠ d := by grind
+  have hbc : b ≠ c := by grind
+  have hbd : b ≠ d := by grind
+  rw [Equiv.swap_apply_of_ne_of_ne hac had, Equiv.swap_apply_of_ne_of_ne hbc hbd]
+
+/-- Two swaps sharing one column can be reordered by using the third pair of columns.
+
+For distinct `a`, `b`, and `c`, the path that swaps `a,b` and then `b,c` has the same endpoint as
+the path that swaps `b,c` and then `a,c`. This is the three-column case of transposition
+conjugation used for overlapping rectangles. -/
+theorem swapColumns_swapColumns_overlap (x : GridState n) {a b c : Fin n}
+    (h : [a, b, c].Nodup) :
+    (x.swapColumns a b).swapColumns b c = (x.swapColumns b c).swapColumns a c := by
+  rw [x.swapColumns_swapColumns_conj a b b c]
+  have hab : a ≠ b := by grind
+  have hac : a ≠ c := by grind
+  rw [Equiv.swap_apply_of_ne_of_ne hab hac, Equiv.swap_apply_left]
+
+/-- Reordering two distinct nontrivial column swaps produces a distinct intermediate state.
+
+The new intermediate is obtained by applying the second swap first. The remaining swap is the
+conjugate of the first one. -/
+theorem exists_alternate_twoStepColumnSwapIntermediate (x : GridState n) {a b c d : Fin n}
+    (hab : a ≠ b) (hcd : c ≠ d) (hpairs : s(a, b) ≠ s(c, d)) :
+    ∃ y' ∈ x.columnSwapNeighbors,
+      y' ≠ x.swapColumns a b ∧
+        (x.swapColumns a b).swapColumns c d ∈ y'.columnSwapNeighbors := by
+  refine ⟨x.swapColumns c d, mem_columnSwapNeighbors.mpr ⟨c, d, hcd, rfl⟩, ?_, ?_⟩
+  · intro h
+    exact hpairs (sym2_mk_eq_of_swapColumns_eq (x := x) hcd hab h).symm
+  · rw [mem_columnSwapNeighbors]
+    refine ⟨Equiv.swap c d a, Equiv.swap c d b, (Equiv.swap c d).injective.ne hab, ?_⟩
+    exact x.swapColumns_swapColumns_conj a b c d
+
+/-- Every intermediate state on a nondiagonal two-step path has a distinct alternative
+intermediate state. -/
+theorem exists_ne_mem_twoStepColumnSwapIntermediates_of_mem_of_ne
+    {x y z : GridState n} (hy : y ∈ x.twoStepColumnSwapIntermediates z) (hzx : z ≠ x) :
+    ∃ y' ∈ x.twoStepColumnSwapIntermediates z, y' ≠ y := by
+  rw [mem_twoStepColumnSwapIntermediates] at hy
+  obtain ⟨a, b, hab, rfl⟩ := mem_columnSwapNeighbors.mp hy.1
+  obtain ⟨c, d, hcd, rfl⟩ :=
+    mem_columnSwapNeighbors.mp (mem_columnSwapNeighbors_comm.mpr hy.2)
+  have hpairs : s(a, b) ≠ s(c, d) := by
+    intro hpairs
+    exact hzx ((swapColumns_swapColumns_eq_self_iff_sym2_mk_eq x hab hcd).mpr hpairs)
+  obtain ⟨y', hy'x, hy'ne, hy'z⟩ :=
+    x.exists_alternate_twoStepColumnSwapIntermediate hab hcd hpairs
+  refine ⟨y', mem_twoStepColumnSwapIntermediates.mpr ⟨hy'x, ?_⟩, hy'ne⟩
+  rw [mem_columnSwapNeighbors_comm]
+  exact hy'z
+
+/-- A nonempty nondiagonal set of two-step intermediates contains at least two states. -/
+theorem one_lt_card_twoStepColumnSwapIntermediates_of_ne {x z : GridState n}
+    (hne : (x.twoStepColumnSwapIntermediates z).Nonempty) (hzx : z ≠ x) :
+    1 < (x.twoStepColumnSwapIntermediates z).card := by
+  obtain ⟨y, hy⟩ := hne
+  obtain ⟨y', hy', hy'ne⟩ :=
+    exists_ne_mem_twoStepColumnSwapIntermediates_of_mem_of_ne hy hzx
+  exact Finset.one_lt_card.mpr ⟨y, hy, y', hy', hy'ne.symm⟩
+
+/-- A nondiagonal two-step neighbour has at least two possible intermediate states. -/
+theorem one_lt_card_twoStepColumnSwapIntermediates {x z : GridState n}
+    (hz : z ∈ x.twoStepColumnSwapNeighbors) (hzx : z ≠ x) :
+    1 < (x.twoStepColumnSwapIntermediates z).card :=
+  one_lt_card_twoStepColumnSwapIntermediates_of_ne
+    (nonempty_twoStepColumnSwapIntermediates_iff.mpr hz) hzx
+
+end GridState
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean
@@ -18,7 +18,7 @@ For a diagonal path `x → y → x`, this set is exactly the full one-swap neigh
 factorization through a distinct intermediate state. Consequently every nonempty nondiagonal
 intermediate set has at least two elements. The conjugation argument treats both geometric cases
 needed later: disjoint transpositions commute, while transpositions sharing one column satisfy
-the three-column braid relation.
+the three-column conjugation identity.
 
 These state-level factorizations do not yet pair rectangles: a later juxtaposition argument must
 also track which of the two rectangles with given corners is used and whether its domain avoids
@@ -34,13 +34,9 @@ built.
 
 * `TauCeti.GridState.nonempty_twoStepColumnSwapIntermediates_iff`: the intermediate set is
   nonempty exactly for a two-step neighbour.
-* `TauCeti.GridState.twoStepColumnSwapIntermediates_self`: diagonal paths are precisely the
-  backtracking paths through an arbitrary one-swap neighbour.
-* `TauCeti.GridState.swapColumns_swapColumns_conj`: the transposition-conjugation identity that
-  reorders any two column swaps.
-* `TauCeti.GridState.swapColumns_swapColumns_of_disjoint` and
-  `TauCeti.GridState.swapColumns_swapColumns_overlap`: its disjoint- and shared-column forms.
-* `TauCeti.GridState.one_lt_card_twoStepColumnSwapIntermediates_of_ne`: a nondiagonal two-step
+* `TauCeti.GridState.twoStepColumnSwapIntermediates_self`: the intermediates between `x` and
+  itself are exactly its one-swap neighbours.
+* `TauCeti.GridState.one_lt_card_twoStepColumnSwapIntermediates`: a nondiagonal two-step
   path has at least two possible intermediate states.
 
 ## References
@@ -99,53 +95,12 @@ theorem nonempty_twoStepColumnSwapIntermediates_iff {x z : GridState n} :
     exact ⟨y, mem_twoStepColumnSwapIntermediates.mpr
       ⟨hyx, mem_columnSwapNeighbors_comm.mp hzy⟩⟩
 
-/-- Conjugating the first transposition by the second reorders two column swaps.
-
-When the pairs are disjoint this is commutation. When they share a column, the conjugated pair is
-the third pair among the three involved columns. -/
-theorem swapColumns_swapColumns_conj (x : GridState n) (a b c d : Fin n) :
-    (x.swapColumns a b).swapColumns c d =
-      (x.swapColumns c d).swapColumns (Equiv.swap c d a) (Equiv.swap c d b) := by
-  ext k
-  simp only [swapColumns_apply]
-  apply congrArg Fin.val
-  apply x.toPerm.injective
-  simpa using
-    ((Equiv.swap c d).injective.swap_apply (Equiv.swap c d a) (Equiv.swap c d b)
-      k)
-
-/-- Column swaps on four distinct columns commute.
-
-This is the disjoint-rectangle state factorization: the same endpoint is reached by applying the
-two swaps in the opposite order. -/
-theorem swapColumns_swapColumns_of_disjoint (x : GridState n) {a b c d : Fin n}
-    (h : [a, b, c, d].Nodup) :
-    (x.swapColumns a b).swapColumns c d = (x.swapColumns c d).swapColumns a b := by
-  rw [x.swapColumns_swapColumns_conj a b c d]
-  have hac : a ≠ c := by grind
-  have had : a ≠ d := by grind
-  have hbc : b ≠ c := by grind
-  have hbd : b ≠ d := by grind
-  rw [Equiv.swap_apply_of_ne_of_ne hac had, Equiv.swap_apply_of_ne_of_ne hbc hbd]
-
-/-- Two swaps sharing one column can be reordered by using the third pair of columns.
-
-For distinct `a`, `b`, and `c`, the path that swaps `a,b` and then `b,c` has the same endpoint as
-the path that swaps `b,c` and then `a,c`. This is the three-column case of transposition
-conjugation used for overlapping rectangles. -/
-theorem swapColumns_swapColumns_overlap (x : GridState n) {a b c : Fin n}
-    (h : [a, b, c].Nodup) :
-    (x.swapColumns a b).swapColumns b c = (x.swapColumns b c).swapColumns a c := by
-  rw [x.swapColumns_swapColumns_conj a b b c]
-  have hab : a ≠ b := by grind
-  have hac : a ≠ c := by grind
-  rw [Equiv.swap_apply_of_ne_of_ne hab hac, Equiv.swap_apply_left]
-
 /-- Reordering two distinct nontrivial column swaps produces a distinct intermediate state.
 
 The new intermediate is obtained by applying the second swap first. The remaining swap is the
 conjugate of the first one. -/
-theorem exists_alternate_twoStepColumnSwapIntermediate (x : GridState n) {a b c d : Fin n}
+private theorem exists_mem_columnSwapNeighbors_ne_swapColumns
+    (x : GridState n) {a b c d : Fin n}
     (hab : a ≠ b) (hcd : c ≠ d) (hpairs : s(a, b) ≠ s(c, d)) :
     ∃ y' ∈ x.columnSwapNeighbors,
       y' ≠ x.swapColumns a b ∧
@@ -170,26 +125,19 @@ theorem exists_ne_mem_twoStepColumnSwapIntermediates_of_mem_of_ne
     intro hpairs
     exact hzx ((swapColumns_swapColumns_eq_self_iff_sym2_mk_eq x hab hcd).mpr hpairs)
   obtain ⟨y', hy'x, hy'ne, hy'z⟩ :=
-    x.exists_alternate_twoStepColumnSwapIntermediate hab hcd hpairs
+    x.exists_mem_columnSwapNeighbors_ne_swapColumns hab hcd hpairs
   refine ⟨y', mem_twoStepColumnSwapIntermediates.mpr ⟨hy'x, ?_⟩, hy'ne⟩
   rw [mem_columnSwapNeighbors_comm]
   exact hy'z
 
-/-- A nonempty nondiagonal set of two-step intermediates contains at least two states. -/
-theorem one_lt_card_twoStepColumnSwapIntermediates_of_ne {x z : GridState n}
-    (hne : (x.twoStepColumnSwapIntermediates z).Nonempty) (hzx : z ≠ x) :
-    1 < (x.twoStepColumnSwapIntermediates z).card := by
-  obtain ⟨y, hy⟩ := hne
-  obtain ⟨y', hy', hy'ne⟩ :=
-    exists_ne_mem_twoStepColumnSwapIntermediates_of_mem_of_ne hy hzx
-  exact Finset.one_lt_card.mpr ⟨y, hy, y', hy', hy'ne.symm⟩
-
 /-- A nondiagonal two-step neighbour has at least two possible intermediate states. -/
 theorem one_lt_card_twoStepColumnSwapIntermediates {x z : GridState n}
     (hz : z ∈ x.twoStepColumnSwapNeighbors) (hzx : z ≠ x) :
-    1 < (x.twoStepColumnSwapIntermediates z).card :=
-  one_lt_card_twoStepColumnSwapIntermediates_of_ne
-    (nonempty_twoStepColumnSwapIntermediates_iff.mpr hz) hzx
+    1 < (x.twoStepColumnSwapIntermediates z).card := by
+  obtain ⟨y, hy⟩ := nonempty_twoStepColumnSwapIntermediates_iff.mpr hz
+  obtain ⟨y', hy', hy'ne⟩ :=
+    exists_ne_mem_twoStepColumnSwapIntermediates_of_mem_of_ne hy hzx
+  exact Finset.one_lt_card.mpr ⟨y, hy, y', hy', hy'ne.symm⟩
 
 end GridState
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean
@@ -9,16 +9,15 @@ public import TauCeti.KnotTheory.Grid.Differential.Square.Backtracking
 /-!
 # Intermediate states in two column swaps
 
-The support of the square of the fully blocked grid differential consists of paths of two
-nontrivial column swaps. This file records the exact finite set of possible intermediate states
-between a source `x` and a target `z`: the intersection of their one-swap neighbour sets.
+The support of the square of the fully blocked grid differential is contained in the states
+reached from `x` by two nontrivial column swaps. This file records the exact finite set of possible
+intermediate states between a source `x` and a target `z`: the intersection of their one-swap
+neighbour sets.
 
 For a diagonal path `x → y → x`, this set is exactly the full one-swap neighbour set of
 `x`. For a nondiagonal path, conjugating the first transposition by the second gives another
 factorization through a distinct intermediate state. Consequently every nonempty nondiagonal
-intermediate set has at least two elements. The conjugation argument treats both geometric cases
-needed later: disjoint transpositions commute, while transpositions sharing one column satisfy
-the three-column conjugation identity.
+intermediate set has at least two elements.
 
 These state-level factorizations do not yet pair rectangles: a later juxtaposition argument must
 also track which of the two rectangles with given corners is used and whether its domain avoids
@@ -70,6 +69,29 @@ theorem mem_twoStepColumnSwapIntermediates {x y z : GridState n} :
       y ∈ x.columnSwapNeighbors ∧ y ∈ z.columnSwapNeighbors := by
   simp [twoStepColumnSwapIntermediates]
 
+/-- A state is an intermediate between `x` and `z` exactly when it is reached from `x` by one
+nontrivial column swap and `z` is reached from it by another. -/
+theorem mem_twoStepColumnSwapIntermediates_iff_mem_columnSwapNeighbors {x y z : GridState n} :
+    y ∈ x.twoStepColumnSwapIntermediates z ↔
+      y ∈ x.columnSwapNeighbors ∧ z ∈ y.columnSwapNeighbors := by
+  rw [mem_twoStepColumnSwapIntermediates]
+  constructor
+  · exact fun h => ⟨h.1, mem_columnSwapNeighbors_comm.mp h.2⟩
+  · exact fun h => ⟨h.1, mem_columnSwapNeighbors_comm.mpr h.2⟩
+
+/-- An expanded membership form for the intermediate states in a two-swap path. -/
+theorem mem_twoStepColumnSwapIntermediates_iff_exists_swaps {x y z : GridState n} :
+    y ∈ x.twoStepColumnSwapIntermediates z ↔
+      ∃ a b c d : Fin n,
+        a ≠ b ∧ c ≠ d ∧ y = x.swapColumns a b ∧ z = y.swapColumns c d := by
+  rw [mem_twoStepColumnSwapIntermediates_iff_mem_columnSwapNeighbors]
+  simp only [mem_columnSwapNeighbors]
+  constructor
+  · rintro ⟨⟨a, b, hab, hy⟩, c, d, hcd, hz⟩
+    exact ⟨a, b, c, d, hab, hcd, hy, hz⟩
+  · rintro ⟨a, b, c, d, hab, hcd, hy, hz⟩
+    exact ⟨⟨a, b, hab, hy⟩, c, d, hcd, hz⟩
+
 /-- Swapping the two endpoints does not change their set of two-step intermediate states. -/
 theorem twoStepColumnSwapIntermediates_comm (x z : GridState n) :
     x.twoStepColumnSwapIntermediates z = z.twoStepColumnSwapIntermediates x := by
@@ -95,40 +117,37 @@ theorem nonempty_twoStepColumnSwapIntermediates_iff {x z : GridState n} :
     exact ⟨y, mem_twoStepColumnSwapIntermediates.mpr
       ⟨hyx, mem_columnSwapNeighbors_comm.mp hzy⟩⟩
 
-/-- Reordering two distinct nontrivial column swaps produces a distinct intermediate state.
+/-- Applying the second of two distinct nontrivial column swaps first produces a distinct
+intermediate state.
 
-The new intermediate is obtained by applying the second swap first. The remaining swap is the
-conjugate of the first one. -/
-private theorem exists_mem_columnSwapNeighbors_ne_swapColumns
+The remaining swap is the conjugate of the first one. -/
+theorem swapColumns_mem_twoStepColumnSwapIntermediates_ne
     (x : GridState n) {a b c d : Fin n}
     (hab : a ≠ b) (hcd : c ≠ d) (hpairs : s(a, b) ≠ s(c, d)) :
-    ∃ y' ∈ x.columnSwapNeighbors,
-      y' ≠ x.swapColumns a b ∧
-        (x.swapColumns a b).swapColumns c d ∈ y'.columnSwapNeighbors := by
-  refine ⟨x.swapColumns c d, mem_columnSwapNeighbors.mpr ⟨c, d, hcd, rfl⟩, ?_, ?_⟩
-  · intro h
-    exact hpairs (sym2_mk_eq_of_swapColumns_eq (x := x) hcd hab h).symm
-  · rw [mem_columnSwapNeighbors]
+    x.swapColumns c d ∈
+        x.twoStepColumnSwapIntermediates ((x.swapColumns a b).swapColumns c d) ∧
+      x.swapColumns c d ≠ x.swapColumns a b := by
+  constructor
+  · rw [mem_twoStepColumnSwapIntermediates_iff_mem_columnSwapNeighbors]
+    refine ⟨mem_columnSwapNeighbors.mpr ⟨c, d, hcd, rfl⟩, ?_⟩
+    rw [mem_columnSwapNeighbors]
     refine ⟨Equiv.swap c d a, Equiv.swap c d b, (Equiv.swap c d).injective.ne hab, ?_⟩
     exact x.swapColumns_swapColumns_conj a b c d
+  · intro h
+    exact hpairs (sym2_mk_eq_of_swapColumns_eq (x := x) hcd hab h).symm
 
 /-- Every intermediate state on a nondiagonal two-step path has a distinct alternative
 intermediate state. -/
-theorem exists_ne_mem_twoStepColumnSwapIntermediates_of_mem_of_ne
+theorem exists_mem_twoStepColumnSwapIntermediates_ne_of_mem_of_ne
     {x y z : GridState n} (hy : y ∈ x.twoStepColumnSwapIntermediates z) (hzx : z ≠ x) :
     ∃ y' ∈ x.twoStepColumnSwapIntermediates z, y' ≠ y := by
-  rw [mem_twoStepColumnSwapIntermediates] at hy
-  obtain ⟨a, b, hab, rfl⟩ := mem_columnSwapNeighbors.mp hy.1
-  obtain ⟨c, d, hcd, rfl⟩ :=
-    mem_columnSwapNeighbors.mp (mem_columnSwapNeighbors_comm.mpr hy.2)
+  rw [mem_twoStepColumnSwapIntermediates_iff_exists_swaps] at hy
+  obtain ⟨a, b, c, d, hab, hcd, rfl, rfl⟩ := hy
   have hpairs : s(a, b) ≠ s(c, d) := by
     intro hpairs
     exact hzx ((swapColumns_swapColumns_eq_self_iff_sym2_mk_eq x hab hcd).mpr hpairs)
-  obtain ⟨y', hy'x, hy'ne, hy'z⟩ :=
-    x.exists_mem_columnSwapNeighbors_ne_swapColumns hab hcd hpairs
-  refine ⟨y', mem_twoStepColumnSwapIntermediates.mpr ⟨hy'x, ?_⟩, hy'ne⟩
-  rw [mem_columnSwapNeighbors_comm]
-  exact hy'z
+  exact ⟨x.swapColumns c d,
+    x.swapColumns_mem_twoStepColumnSwapIntermediates_ne hab hcd hpairs⟩
 
 /-- A nondiagonal two-step neighbour has at least two possible intermediate states. -/
 theorem one_lt_card_twoStepColumnSwapIntermediates {x z : GridState n}
@@ -136,7 +155,7 @@ theorem one_lt_card_twoStepColumnSwapIntermediates {x z : GridState n}
     1 < (x.twoStepColumnSwapIntermediates z).card := by
   obtain ⟨y, hy⟩ := nonempty_twoStepColumnSwapIntermediates_iff.mpr hz
   obtain ⟨y', hy', hy'ne⟩ :=
-    exists_ne_mem_twoStepColumnSwapIntermediates_of_mem_of_ne hy hzx
+    exists_mem_twoStepColumnSwapIntermediates_ne_of_mem_of_ne hy hzx
   exact Finset.one_lt_card.mpr ⟨y, hy, y', hy', hy'ne.symm⟩
 
 end GridState


### PR DESCRIPTION
This PR classifies the intermediate grid states in a path of two nontrivial column swaps and provides the state-level reordering identities used by the rectangle-juxtaposition proof. It defines `twoStepColumnSwapIntermediates x z` as the intersection of the endpoints' one-swap neighbour sets; characterizes membership and nonemptiness; identifies the diagonal intermediate set with the one-swap neighbour set; proves the general transposition-conjugation formula; characterizes intermediate paths by their two explicit swaps; and shows that every nonempty nondiagonal intermediate set has at least two states.

This advances the exact target in `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G milestone 3, “The complexes and `∂² = 0`,” specifically the finite disjoint/overlapping/backtracking case split needed before pairing two-step rectangle decompositions. It is the most effective distinct step available on current `main`: the marking-region correction required for the final square-zero statement is in flight in #3135, while this PR supplies the independent state-factorization layer that its later juxtaposition proof consumes without touching the corrected marking definitions. After this PR, milestone G.3 still needs #3135 to land, the rectangle-domain pairing proving every coefficient sum even, packaging the fully blocked differential as a chain complex, and the unblocked and simply blocked complexes.

Add `TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean` and place its general column-swap identities beside `swapColumns` in `TauCeti/KnotTheory/Grid/Diagram/Basic.lean`. The implementation reuses Mathlib's `Function.Injective.swap_apply` conjugation identity, `Equiv.swap`, and finite-set API together with Tau Ceti's existing exact column-swap-neighbour and backtracking lemmas; no Mathlib implementation or external formalization is vendored. The rectangle-decomposition strategy follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.6, as credited in the module documentation.

Concrete G.3 handoff: the immediate downstream result is the planned on-support companion to `GridDiagram.sum_fullyBlockedRectangleCount_mul_eq_zero_of_notMem_twoStep`, namely `sum_fullyBlockedRectangleCount_mul_eq_zero_of_mem_twoStep`. In that proof, `twoStepColumnSwapIntermediates` restricts the coefficient sum to middle states whose two rectangle-count factors can be nonzero; `mem_twoStepColumnSwapIntermediates` exposes those two support conditions; `twoStepColumnSwapIntermediates_comm` normalizes the endpoint order; `twoStepColumnSwapIntermediates_self` is the state-level split for the diagonal/annular case; and `nonempty_twoStepColumnSwapIntermediates_iff` selects the on-support branch. In the nondiagonal branch, `exists_mem_twoStepColumnSwapIntermediates_ne_of_mem_of_ne` constructs the alternate state factorization and `one_lt_card_twoStepColumnSwapIntermediates` records that this support cannot be a singleton. The generic conjugation identity constructs that alternate factorization and can be specialized at the downstream disjoint and overlapping rectangle-domain call sites. Rectangle orientations and marking avoidance must still be added before these state pairings induce the required fixed-point-free pairing of summands.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"two-step-column-swap-classification"}-->

🤖 Prepared with Codex



