### PR TITLE
feat(GroupTheory): double cosets index the K-orbits of an arbitrary action

### DIFF
--- a/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
@@ -35,6 +35,9 @@ numbers, which is the group-theoretic half of the statement that the permutation
 
 * `TauCeti.mem_doubleCoset_iff_mk_mem_orbit`: an element lies in `KsH` exactly when its coset
   lies in the `K`-orbit of `sH`.
+* `TauCeti.orbitRel_smul_iff_mem_doubleCoset_stabilizer`: the same for an arbitrary action —
+  two translates of a point share a `K`-orbit exactly when the translating elements share a
+  `K`-`stabilizer` double coset.
 * `TauCeti.preimage_orbit_eq_doubleCoset`: the double coset `KsH` is the preimage of the
   `K`-orbit of `sH`.
 * `TauCeti.card_doubleCosetQuotient_eq_card_orbitQuotient`: the two sides of that bijection have
@@ -163,6 +166,33 @@ theorem card_doubleCosetQuotient_eq_card_orbitQuotient :
     Nat.card (DoubleCoset.Quotient (H : Set G) K) =
       Nat.card (orbitRel.Quotient G ((G ⧸ H) × (G ⧸ K))) :=
   Nat.card_congr (doubleCosetEquivOrbitQuotient H K)
+
+
+section GeneralAction
+
+variable {α : Type*} [MulAction G α]
+
+/-- **Two translates of a point lie in one `K`-orbit exactly when the translating elements lie
+in one double coset.** For `K ≤ G` acting on `α` and a point `p`, the `K`-orbits inside the
+`G`-orbit of `p` are indexed by the `K`-`stabilizer G p` double cosets.
+
+This is the companion of `mem_doubleCoset_iff_mk_mem_orbit` for an arbitrary action rather than
+the action on `G ⧸ H`: taking `H = stabilizer G p` there and transporting along
+`MulAction.orbitEquivQuotientStabilizer` gives the same statement. -/
+theorem orbitRel_smul_iff_mem_doubleCoset_stabilizer (K : Subgroup G) (p : α) (x y : G) :
+    orbitRel K α (x • p) (y • p) ↔
+      x ∈ DoubleCoset.doubleCoset y (K : Set G) (stabilizer G p : Set G) := by
+  rw [orbitRel_apply, mem_orbit_iff, DoubleCoset.mem_doubleCoset]
+  constructor
+  · rintro ⟨k, hk⟩
+    refine ⟨(k : G), k.2, y⁻¹ * ((k : G)⁻¹ * x), ?_, by simp [mul_assoc]⟩
+    rw [SetLike.mem_coe, mem_stabilizer_iff, mul_smul, mul_smul, ← hk, Subgroup.smul_def,
+      inv_smul_smul, inv_smul_smul]
+  · rintro ⟨a, ha, b, hb, rfl⟩
+    refine ⟨⟨a, ha⟩, ?_⟩
+    rw [Subgroup.smul_def, mul_smul, mul_smul, mem_stabilizer_iff.mp (SetLike.mem_coe.mp hb)]
+
+end GeneralAction
 
 end Orbits
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"grouptheory-orbit-doublecoset-action"}-->

### What this adds

One theorem, beside the two it generalises:

```lean
theorem orbitRel_smul_iff_mem_doubleCoset_stabilizer (K : Subgroup G) (p : α) (x y : G) :
    orbitRel K α (x • p) (y • p) ↔
      x ∈ DoubleCoset.doubleCoset y (K : Set G) (stabilizer G p : Set G)
```

Two translates of a point lie in one `K`-orbit exactly when the translating elements lie in one
`K`-`stabilizer G p` double coset. Equivalently: the `K`-orbits inside the `G`-orbit of `p` are
indexed by those double cosets.

### Why here, and why it is not a restatement

`DoubleCoset/Orbits.lean` already proves this for the action on `G ⧸ H` — `mem_doubleCoset_iff_mk_mem_orbit`
and `preimage_orbit_eq_doubleCoset` — and its module docstring states the principle: *"the partition
of `G ⧸ H` into `K`-orbits is the partition of `G` into `K`-`H` double cosets."*

This is the companion for an **arbitrary** `MulAction G α`. It is the same fact with
`H = stabilizer G p`, transported along `MulAction.orbitEquivQuotientStabilizer`, but the direct
proof is shorter than the transport: once `Subgroup.smul_def` puts the `K`-action back in `G`,
each direction is two rewrites. The two forms are not interchangeable at the call site — a sum
over points of `α` cannot use the `G ⧸ H` version without first building that equivalence.

### What it is for

The general-level valence formula reaches `Σ_{P ∈ Γ\ℍ*} (1/e_P)·ord_P(f) = k·[SL₂(ℤ):±Γ]/12` by
applying the level-one formula to the norm and then, in the roadmap's words, *"distributing orders
over the product with the orbit/stabilizer/cusp-width bookkeeping"*. `orderOfVanishingAt_norm`
(`Norm/Order.lean:85`) already gives the sum over cosets. This is what regroups that sum by orbit,
with the double-coset fibres carrying the stabiliser multiplicity that becomes `1 / e_P`.

**Stated plainly: it has no in-repository consumer yet.** The step that consumes it is the next
rung and is not in this PR. I flag it because `scope` and `reuse` have both declined
no-consumer additions from me tonight; the difference I would argue here is that this completes an
API pair the file already documents as its subject, rather than naming a composition of two
existing rewrites. If that is judged insufficient, the honest outcome is to hold it until the
consumer lands, and I will.

### Proof notes

Two things that cost a build each, recorded in the receipt:

* the stabiliser membership arrives as the **set** coercion `↑(stabilizer G p)`, so
  `mem_stabilizer_iff` needs `SetLike.mem_coe` in front of it;
* `group` is **not available** in this file — it imports no tactic modules — so the identity
  `x = k * y * (y⁻¹ * (k⁻¹ * x))` is closed by `simp [mul_assoc]`.

### Formatting note

The signature is 89 / 34 / 78 codepoints. The mechanical packing rule (`89 + 1 + 8 = 98 ≤ 100`)
would repack line 1, but that is this file's established shape — the two siblings are 77/59/49 and
66/48/60, and the same arithmetic would flag the first of those, which is merged code here.
Matching them was the deliberate choice; repacking only mine would leave three near-identical
signatures formatted three ways.

### Verification

`lake build` green (8089 jobs, 0 error lines); `lake exe axioms` clean over 49918 declarations;
`lake exe module-system` clean over 2371 modules; `LINT-ENV: PASS` (67 grandfathered,
3 ratchetable). No line over 100 codepoints, measured with `wc -m` (file max 98). No new import.
