### PR TITLE
feat: construct lattice-induced conjugation

### DIFF
--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -225,7 +225,6 @@ theorem latticeConjugation_toEquiv_apply (hℂ : IsBaseChange ℂ ιℂ) (x : V�
   by simp [latticeConjugation]
 
 /-- Bundled lattice conjugation fixes the image of the integral module. -/
-@[simp]
 theorem latticeConjugation_ι (hℂ : IsBaseChange ℂ ιℂ) (v : V) :
     (latticeConjugation hℂ).toEquiv (ιℂ v) = ιℂ v := by
   simp

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -88,7 +88,7 @@ def complexificationMap : V →ₗ[ℤ] Complexification V :=
   (TensorProduct.mk ℤ ℂ V) 1
 
 /-- The tensor-product complexification satisfies the abstract base-change interface. -/
-theorem complexificationMap_isBaseChange :
+theorem isBaseChange_complexificationMap :
     IsBaseChange ℂ (complexificationMap (V := V)) :=
   TensorProduct.isBaseChange ℤ V ℂ
 
@@ -208,9 +208,9 @@ theorem latticeConj_unique (hℂ : IsBaseChange ℂ ιℂ)
 /-- On the canonical tensor-product model, abstract lattice-induced conjugation is the concrete
 tensor map. -/
 theorem latticeConj_complexificationMap :
-    latticeConj (complexificationMap_isBaseChange (V := V)) =
+    latticeConj (isBaseChange_complexificationMap (V := V)) =
       concreteLatticeConj (V := V) :=
-  (latticeConj_unique complexificationMap_isBaseChange concreteLatticeConj
+  (latticeConj_unique isBaseChange_complexificationMap concreteLatticeConj
     concreteLatticeConj_complexificationMap).symm
 
 /-- Lattice-induced conjugation on an abstract complexification, bundled as a conjugation. -/

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -1,0 +1,235 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Module.Submodule.Map
+public import Mathlib.Data.Complex.Basic
+public import Mathlib.LinearAlgebra.TensorProduct.Map
+public import Mathlib.RingTheory.IsTensorProduct
+
+/-!
+# Conjugation on complexifications of integral modules
+
+This file packages a conjugation on a complex vector space as a conjugate-linear involution and
+constructs the canonical conjugation on any abstract complexification of an integral module.
+The construction uses Mathlib's `IsBaseChange` interface: it transports coordinatewise conjugation
+on `ℂ ⊗[ℤ] V` to an arbitrary complex base-change model and is uniquely characterized by fixing the
+image of `V`.
+
+## Main declarations
+
+* `TauCeti.Hodge.Conjugation`: a conjugate-linear involution of a complex vector space.
+* `TauCeti.Hodge.concreteLatticeConj`: conjugation on the tensor model `ℂ ⊗[ℤ] V`.
+* `TauCeti.Hodge.latticeConj`: conjugation on an abstract complex base-change model.
+* `TauCeti.Hodge.latticeConj_unique`: uniqueness among conjugate-linear maps fixing the integral
+  module.
+* `TauCeti.Hodge.latticeConjugation`: the abstract map bundled as a `Conjugation`.
+
+The base-change design follows the Hodge structures roadmap and the discussion by Johan Commelin,
+Andrew Yang, Kevin Buzzard, and Joël Riou in the `#mathlib4` Zulip thread *Complexifications with a
+view towards Hodge theory*. The opposed-filtration formulation that consumes this conjugation is
+Deligne's, *Théorie de Hodge II*, §1.2.1.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+open scoped TensorProduct
+
+universe u v
+
+/-- A conjugation on a complex vector space: a conjugate-linear involution. -/
+@[ext]
+structure Conjugation (W : Type u) [AddCommGroup W] [Module ℂ W] where
+  /-- The conjugate-linear equivalence underlying the conjugation. -/
+  toEquiv : W ≃ₛₗ[starRingEnd ℂ] W
+  /-- Applying the conjugation twice is the identity. -/
+  involutive : Function.Involutive toEquiv
+
+namespace Conjugation
+
+variable {W : Type u} [AddCommGroup W] [Module ℂ W]
+
+/-- The inverse of a conjugation is the conjugation itself. -/
+@[simp]
+theorem symm_toEquiv (ω : Conjugation W) : ω.toEquiv.symm = ω.toEquiv := by
+  ext x
+  apply ω.toEquiv.injective
+  simp [ω.involutive x]
+
+/-- Applying a conjugation twice returns the original vector. -/
+@[simp]
+theorem apply_apply (ω : Conjugation W) (x : W) : ω.toEquiv (ω.toEquiv x) = x :=
+  ω.involutive x
+
+/-- Mapping a complex subspace twice by a conjugation returns the original subspace. -/
+@[simp]
+theorem map_map (ω : Conjugation W) (U : Submodule ℂ W) :
+    (U.map ω.toEquiv.toLinearMap).map ω.toEquiv.toLinearMap = U := by
+  have h : (U.map ω.toEquiv.toLinearMap).map ω.toEquiv.symm.toLinearMap = U :=
+    (Submodule.map_symm_eq_iff ω.toEquiv).2 rfl
+  simpa only [ω.symm_toEquiv] using h
+
+end Conjugation
+
+section Concrete
+
+variable {V : Type u} [AddCommGroup V] [Module ℤ V]
+
+/-- The canonical complexification `ℂ ⊗[ℤ] V` of an integral module. -/
+abbrev Complexification (V : Type u) [AddCommGroup V] [Module ℤ V] :=
+  TensorProduct ℤ ℂ V
+
+/-- The canonical map from an integral module to its tensor-product complexification. -/
+def complexificationMap : V →ₗ[ℤ] Complexification V :=
+  (TensorProduct.mk ℤ ℂ V) 1
+
+/-- The tensor-product complexification satisfies the abstract base-change interface. -/
+theorem complexificationMap_isBaseChange :
+    IsBaseChange ℂ (complexificationMap (V := V)) :=
+  TensorProduct.isBaseChange ℤ V ℂ
+
+/-- The integral-linear map underlying conjugation on the tensor-product complexification. -/
+private noncomputable def concreteLatticeConjIntLinear :=
+  TensorProduct.map (starRingEnd ℂ).toAddMonoidHom.toIntLinearMap
+    (LinearMap.id : V →ₗ[ℤ] V)
+
+/-- Lattice-induced conjugation on the tensor model `ℂ ⊗[ℤ] V`, acting by complex conjugation on
+the scalar tensor factor and by the identity on the integral module. -/
+noncomputable def concreteLatticeConj :
+    Complexification V →ₛₗ[starRingEnd ℂ] Complexification V where
+  toFun := concreteLatticeConjIntLinear
+  map_add' := concreteLatticeConjIntLinear.map_add
+  map_smul' c x := by
+    refine TensorProduct.induction_on x ?_ ?_ ?_
+    · simp
+    · intro z v
+      simp only [TensorProduct.smul_tmul']
+      unfold concreteLatticeConjIntLinear
+      rw [TensorProduct.map_tmul, TensorProduct.map_tmul]
+      simp [map_mul, TensorProduct.smul_tmul']
+    · intro x y hx hy
+      simp [map_add, hx, hy]
+
+/-- Conjugation on the tensor model conjugates the scalar in a pure tensor. -/
+@[simp]
+theorem concreteLatticeConj_tmul (z : ℂ) (v : V) :
+    concreteLatticeConj (V := V) (z ⊗ₜ[ℤ] v) = (starRingEnd ℂ z) ⊗ₜ[ℤ] v :=
+  by
+    -- The tensor map is `ℤ`-linear while the bundled result is conjugate-linear over `ℂ`, so the
+    -- public pure-tensor equation is the stable bridge between the two scalar interfaces.
+    change concreteLatticeConjIntLinear (z ⊗ₜ[ℤ] v) = _
+    unfold concreteLatticeConjIntLinear
+    rw [TensorProduct.map_tmul]
+    simp
+
+/-- Conjugation on the tensor model fixes the image of the integral module. -/
+@[simp]
+theorem concreteLatticeConj_complexificationMap (v : V) :
+    concreteLatticeConj (complexificationMap v) = complexificationMap v := by
+  -- `Complexification V` has both the tensor-product and canonical integer-module instances;
+  -- restating the goal as a pure tensor avoids exposing that harmless instance diamond.
+  change concreteLatticeConj (1 ⊗ₜ[ℤ] v) = 1 ⊗ₜ[ℤ] v
+  simpa only [map_one] using concreteLatticeConj_tmul (V := V) 1 v
+
+private theorem concreteLatticeConjIntLinear_comp :
+    concreteLatticeConjIntLinear (V := V) ∘ₗ concreteLatticeConjIntLinear = LinearMap.id := by
+  unfold concreteLatticeConjIntLinear
+  rw [← TensorProduct.map_comp]
+  have hstar : (starRingEnd ℂ).toAddMonoidHom.toIntLinearMap ∘ₗ
+      (starRingEnd ℂ).toAddMonoidHom.toIntLinearMap = LinearMap.id := by
+    ext z
+    simp
+  rw [hstar]
+  exact TensorProduct.map_id
+
+/-- Conjugation on the tensor model is involutive. -/
+theorem concreteLatticeConj_involutive :
+    Function.Involutive (concreteLatticeConj (V := V)) := by
+  intro x
+  exact LinearMap.congr_fun (concreteLatticeConjIntLinear_comp (V := V)) x
+
+/-- Applying conjugation on the tensor model twice returns the original vector. -/
+@[simp]
+theorem concreteLatticeConj_apply_apply (x : Complexification V) :
+    concreteLatticeConj (concreteLatticeConj x) = x :=
+  concreteLatticeConj_involutive x
+
+end Concrete
+
+section Abstract
+
+variable {V : Type u} {Vℂ : Type v}
+variable [AddCommGroup V] [Module ℤ V]
+variable [AddCommGroup Vℂ] [Module ℂ Vℂ]
+variable {ιℂ : V →ₗ[ℤ] Vℂ}
+
+/-- Lattice-induced conjugation on an abstract complex base-change model. -/
+noncomputable def latticeConj (hℂ : IsBaseChange ℂ ιℂ) :
+    Vℂ →ₛₗ[starRingEnd ℂ] Vℂ :=
+  hℂ.equiv.toLinearMap.comp
+    ((concreteLatticeConj (V := V)).comp hℂ.equiv.symm.toLinearMap)
+
+/-- Abstract lattice-induced conjugation fixes the image of the integral module. -/
+@[simp]
+theorem latticeConj_ι (hℂ : IsBaseChange ℂ ιℂ) (v : V) :
+    latticeConj hℂ (ιℂ v) = ιℂ v := by
+  simp [latticeConj]
+
+/-- Abstract lattice-induced conjugation is involutive. -/
+theorem latticeConj_involutive (hℂ : IsBaseChange ℂ ιℂ) :
+    Function.Involutive (latticeConj hℂ) := by
+  intro x
+  simp only [latticeConj, LinearMap.comp_apply, LinearEquiv.coe_coe]
+  rw [hℂ.equiv.symm_apply_apply, concreteLatticeConj_involutive,
+    hℂ.equiv.apply_symm_apply]
+
+/-- Applying abstract lattice-induced conjugation twice returns the original vector. -/
+@[simp]
+theorem latticeConj_apply_apply (hℂ : IsBaseChange ℂ ιℂ) (x : Vℂ) :
+    latticeConj hℂ (latticeConj hℂ x) = x :=
+  latticeConj_involutive hℂ x
+
+/-- Lattice-induced conjugation is the unique conjugate-linear map on an abstract complexification
+that fixes every integral vector. -/
+theorem latticeConj_unique (hℂ : IsBaseChange ℂ ιℂ)
+    (c : Vℂ →ₛₗ[starRingEnd ℂ] Vℂ) (hc : ∀ v, c (ιℂ v) = ιℂ v) :
+    c = latticeConj hℂ := by
+  ext x
+  induction x using hℂ.inductionOn with
+  | zero => simp
+  | tmul v => simp [hc]
+  | smul z x hx => simp [hx]
+  | add x y hx hy => simp [hx, hy]
+
+/-- On the canonical tensor-product model, abstract lattice-induced conjugation is the concrete
+tensor map. -/
+theorem latticeConj_complexificationMap :
+    latticeConj (complexificationMap_isBaseChange (V := V)) =
+      concreteLatticeConj (V := V) :=
+  (latticeConj_unique complexificationMap_isBaseChange concreteLatticeConj
+    concreteLatticeConj_complexificationMap).symm
+
+/-- Lattice-induced conjugation on an abstract complexification, bundled as a conjugation. -/
+noncomputable def latticeConjugation (hℂ : IsBaseChange ℂ ιℂ) : Conjugation Vℂ where
+  toEquiv := LinearEquiv.ofInvolutive (latticeConj hℂ) (latticeConj_involutive hℂ)
+  involutive := latticeConj_involutive hℂ
+
+/-- The equivalence underlying bundled lattice conjugation applies as `latticeConj`. -/
+@[simp]
+theorem latticeConjugation_toEquiv_apply (hℂ : IsBaseChange ℂ ιℂ) (x : Vℂ) :
+    (latticeConjugation hℂ).toEquiv x = latticeConj hℂ x :=
+  by simp [latticeConjugation]
+
+/-- Bundled lattice conjugation fixes the image of the integral module. -/
+@[simp]
+theorem latticeConjugation_ι (hℂ : IsBaseChange ℂ ιℂ) (v : V) :
+    (latticeConjugation hℂ).toEquiv (ιℂ v) = ιℂ v := by
+  simp
+
+end Abstract
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -55,7 +55,7 @@ variable {W : Type u} [AddCommGroup W] [Module ℂ W]
 
 /-- The inverse of a conjugation is the conjugation itself. -/
 @[simp]
-theorem symm_toEquiv (ω : Conjugation W) : ω.toEquiv.symm = ω.toEquiv := by
+theorem toEquiv_symm (ω : Conjugation W) : ω.toEquiv.symm = ω.toEquiv := by
   ext x
   apply ω.toEquiv.injective
   simp [ω.involutive x]
@@ -67,20 +67,20 @@ theorem apply_apply (ω : Conjugation W) (x : W) : ω.toEquiv (ω.toEquiv x) = x
 
 /-- Mapping a complex subspace twice by a conjugation returns the original subspace. -/
 @[simp]
-theorem map_map (ω : Conjugation W) (U : Submodule ℂ W) :
+theorem map_map_eq_self (ω : Conjugation W) (U : Submodule ℂ W) :
     (U.map ω.toEquiv.toLinearMap).map ω.toEquiv.toLinearMap = U := by
   have h : (U.map ω.toEquiv.toLinearMap).map ω.toEquiv.symm.toLinearMap = U :=
     (Submodule.map_symm_eq_iff ω.toEquiv).2 rfl
-  simpa only [ω.symm_toEquiv] using h
+  simpa only [ω.toEquiv_symm] using h
 
 end Conjugation
 
 section Concrete
 
-variable {V : Type u} [AddCommGroup V] [Module ℤ V]
+variable {V : Type u} [AddCommGroup V]
 
 /-- The canonical complexification `ℂ ⊗[ℤ] V` of an integral module. -/
-abbrev Complexification (V : Type u) [AddCommGroup V] [Module ℤ V] :=
+abbrev Complexification (V : Type u) [AddCommGroup V] :=
   TensorProduct ℤ ℂ V
 
 /-- The canonical map from an integral module to its tensor-product complexification. -/
@@ -163,7 +163,7 @@ end Concrete
 section Abstract
 
 variable {V : Type u} {Vℂ : Type v}
-variable [AddCommGroup V] [Module ℤ V]
+variable [AddCommGroup V]
 variable [AddCommGroup Vℂ] [Module ℂ Vℂ]
 variable {ιℂ : V →ₗ[ℤ] Vℂ}
 
@@ -225,7 +225,7 @@ theorem latticeConjugation_toEquiv_apply (hℂ : IsBaseChange ℂ ιℂ) (x : V�
   by simp [latticeConjugation]
 
 /-- Bundled lattice conjugation fixes the image of the integral module. -/
-theorem latticeConjugation_ι (hℂ : IsBaseChange ℂ ιℂ) (v : V) :
+theorem latticeConjugation_toEquiv_ι (hℂ : IsBaseChange ℂ ιℂ) (v : V) :
     (latticeConjugation hℂ).toEquiv (ιℂ v) = ιℂ v := by
   simp
 


### PR DESCRIPTION
This PR defines conjugation on a complex vector space as a conjugate-linear involution and constructs the canonical lattice-induced conjugation on every abstract `IsBaseChange` complexification. It advances `HodgeStructures/README.md`, Core definitions target “Conjugation is defined, not assumed,” including its L0 companion requiring uniqueness of `latticeConj`; this is the next prerequisite for the L0 pure-Hodge-structure milestone `DirectSum.IsInternal hs.piece` because opposedness and every `(p,q)`-piece use this involution.

Construct `concreteLatticeConj` on `ℂ ⊗[ℤ] V`, prove its pure-tensor formula and involutivity, transport it through `IsBaseChange.equiv`, and prove that the transported map is uniquely characterized by fixing the integral image. Bundle the result as `Conjugation`, provide its extensional and submodule-map API, and prove that the abstract construction specializes back to the concrete tensor map.

This is the most effective current step toward L0 because only the independent rational-to-complex base-change layer is present on `main`, no Hodge work is open, and the opposed-filtration object cannot yet be stated with the roadmap's required canonical involution. After this PR, L0 still needs `HodgeStructureOn` and the finite-free integral abbreviation, the opposed-filtration decomposition proof, and the blocking Tate example.

The construction reuses Mathlib's `IsBaseChange.equiv` and induction principle, `TensorProduct.map` and `TensorProduct.map_comp`, `LinearEquiv.ofInvolutive`, and the semilinear submodule-map equivalence API; no Mathlib infrastructure is vendored. The design follows the Hodge structures roadmap and the `#mathlib4` Zulip discussion *Complexifications with a view towards Hodge theory* by Johan Commelin, Andrew Yang, Kevin Buzzard, and Joël Riou; the consuming opposed-filtration convention is Deligne, *Théorie de Hodge II*, §1.2.1.

Add `TauCeti/Geometry/Hodge/Conjugation.lean` (235 lines).

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"lattice-conjugation"}-->

🤖 Prepared with Codex
