### PR TITLE
feat(Mackey): the Mackey subgroup as a stabilizer at a translate, for an arbitrary G-set

### DIFF
--- a/TauCeti/RepresentationTheory/Induction/Mackey/Subgroup.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/Subgroup.lean
@@ -74,8 +74,6 @@ roadmap-specific subgroup the induction and restriction of that layer run along.
   `|KsH| · |K ⊓ sHs⁻¹| = |K| · |H|`.
 * `TauCeti.stabilizer_smul_eq_mackeySubgroup_subgroupOf`: the same stabilizer description for an
   arbitrary `G`-set, at a translate `s • p`.
-* `TauCeti.card_doubleCoset_mul_card_stabilizer_smul`: the size formula read at such a point,
-  `|Γ s Stab(p)| · |Stab_Γ(s • p)| = |Γ| · |Stab_G(p)|`.
 
 ## References
 
@@ -365,26 +363,6 @@ theorem stabilizer_smul_eq_mackeySubgroup_subgroupOf (s : G) (Γ : Subgroup G) (
   rw [Subgroup.mem_subgroupOf, mem_mackeySubgroup_iff, mem_stabilizer_iff, Subgroup.smul_def,
     mem_stabilizer_iff, mul_smul, mul_smul]
   exact ⟨fun hg => ⟨g.2, inv_smul_eq_iff.mpr hg⟩, fun hg => inv_smul_eq_iff.mp hg.2⟩
-
-/-- **The double-coset size formula at a point of an arbitrary `G`-set**:
-`|Γ s Stab(p)| · |Stab_Γ(s • p)| = |Γ| · |Stab_G(p)|`.
-
-This is `card_doubleCoset_mul_card_mackeySubgroup` with `H = stabilizer G p`, read through
-`stabilizer_smul_eq_mackeySubgroup_subgroupOf` so that the second factor is a stabilizer rather
-than a Mackey subgroup. It is the multiplicity with which a `Γ`-orbit inside the `G`-orbit of `p`
-is counted when a sum over `Γ`-cosets is regrouped into a sum over `Γ`-orbits: rearranged, it
-reads `|Γ s Stab(p)| / (|Γ| · |Stab_G(p)|) = 1 / |Stab_Γ(s • p)|`, so the double coset carries
-exactly the weight `1 / |Stab_Γ(s • p)|` once normalised by `|Γ| · |Stab_G(p)|` — both of which
-are independent of `s`.
-
-As with the formula it comes from, `Nat.card`'s convention that an infinite type has cardinality
-`0` means no finiteness hypothesis is needed. -/
-theorem card_doubleCoset_mul_card_stabilizer_smul (s : G) (Γ : Subgroup G) (p : α) :
-    Nat.card (DoubleCoset.doubleCoset s (Γ : Set G) (stabilizer G p : Set G)) *
-        Nat.card (stabilizer (↥Γ) (s • p)) = Nat.card Γ * Nat.card (stabilizer G p) := by
-  rw [stabilizer_smul_eq_mackeySubgroup_subgroupOf,
-    Nat.card_congr (Subgroup.subgroupOfEquivOfLe mackeySubgroup_le_right).toEquiv]
-  exact card_doubleCoset_mul_card_mackeySubgroup s (stabilizer G p) Γ
 
 end Translate
 

--- a/TauCeti/RepresentationTheory/Induction/Mackey/Subgroup.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/Subgroup.lean
@@ -372,8 +372,10 @@ theorem stabilizer_smul_eq_mackeySubgroup_subgroupOf (s : G) (Γ : Subgroup G) (
 This is `card_doubleCoset_mul_card_mackeySubgroup` with `H = stabilizer G p`, read through
 `stabilizer_smul_eq_mackeySubgroup_subgroupOf` so that the second factor is a stabilizer rather
 than a Mackey subgroup. It is the multiplicity with which a `Γ`-orbit inside the `G`-orbit of `p`
-is counted when a sum over `Γ`-cosets is regrouped into a sum over `Γ`-orbits: dividing by
-`Nat.card Γ` turns the coset count into the weight `1 / |Stab_Γ(s • p)|`.
+is counted when a sum over `Γ`-cosets is regrouped into a sum over `Γ`-orbits: rearranged, it
+reads `|Γ s Stab(p)| / (|Γ| · |Stab_G(p)|) = 1 / |Stab_Γ(s • p)|`, so the double coset carries
+exactly the weight `1 / |Stab_Γ(s • p)|` once normalised by `|Γ| · |Stab_G(p)|` — both of which
+are independent of `s`.
 
 As with the formula it comes from, `Nat.card`'s convention that an infinite type has cardinality
 `0` means no finiteness hypothesis is needed. -/

--- a/TauCeti/RepresentationTheory/Induction/Mackey/Subgroup.lean
+++ b/TauCeti/RepresentationTheory/Induction/Mackey/Subgroup.lean
@@ -72,6 +72,10 @@ roadmap-specific subgroup the induction and restriction of that layer run along.
 * `TauCeti.relIndex_mackeySubgroup_conj`: that index depends only on the double coset.
 * `TauCeti.card_doubleCoset_mul_card_mackeySubgroup`: the double-coset size formula
   `|KsH| · |K ⊓ sHs⁻¹| = |K| · |H|`.
+* `TauCeti.stabilizer_smul_eq_mackeySubgroup_subgroupOf`: the same stabilizer description for an
+  arbitrary `G`-set, at a translate `s • p`.
+* `TauCeti.card_doubleCoset_mul_card_stabilizer_smul`: the size formula read at such a point,
+  `|Γ s Stab(p)| · |Stab_Γ(s • p)| = |Γ| · |Stab_G(p)|`.
 
 ## References
 
@@ -341,6 +345,46 @@ theorem relIndex_mackeySubgroup_conj {s k h : G} {H K : Subgroup G} (hk : k ∈ 
       = (MulAut.conj k • mackeySubgroup s H K).relIndex (MulAut.conj k • K) := by
         rw [mackeySubgroup_conj hk hh, Subgroup.conj_smul_eq_self_of_mem hk]
     _ = (mackeySubgroup s H K).relIndex K := Subgroup.relIndex_pointwise_smul _ _ _
+
+section Translate
+
+variable {α : Type*} [MulAction G α]
+
+/-- **The Mackey subgroup is a stabilizer, for an arbitrary action.** For a point `p` of any
+`G`-set and `s : G`, the stabilizer of the translate `s • p` in a subgroup `Γ` is the Mackey
+subgroup of `Γ` and `stabilizer G p` at `s`, read inside `Γ`.
+
+`stabilizer_eq_mackeySubgroup_subgroupOf` above is the same statement for the translation action
+of `Γ` on `G ⧸ H`. Neither implies the other: that one is stated for Mathlib's
+`mulLeftCosetsCompSubtypeVal` action on cosets, this one for the restriction of scalars
+`Subgroup.instMulAction`, and `MulAction ↥Γ (G ⧸ H)` has both. The general form is the one a sum
+over the points of an arbitrary `G`-set needs. -/
+theorem stabilizer_smul_eq_mackeySubgroup_subgroupOf (s : G) (Γ : Subgroup G) (p : α) :
+    stabilizer (↥Γ) (s • p) = (mackeySubgroup s (stabilizer G p) Γ).subgroupOf Γ := by
+  ext g
+  rw [Subgroup.mem_subgroupOf, mem_mackeySubgroup_iff, mem_stabilizer_iff, Subgroup.smul_def,
+    mem_stabilizer_iff, mul_smul, mul_smul]
+  exact ⟨fun hg => ⟨g.2, inv_smul_eq_iff.mpr hg⟩, fun hg => inv_smul_eq_iff.mp hg.2⟩
+
+/-- **The double-coset size formula at a point of an arbitrary `G`-set**:
+`|Γ s Stab(p)| · |Stab_Γ(s • p)| = |Γ| · |Stab_G(p)|`.
+
+This is `card_doubleCoset_mul_card_mackeySubgroup` with `H = stabilizer G p`, read through
+`stabilizer_smul_eq_mackeySubgroup_subgroupOf` so that the second factor is a stabilizer rather
+than a Mackey subgroup. It is the multiplicity with which a `Γ`-orbit inside the `G`-orbit of `p`
+is counted when a sum over `Γ`-cosets is regrouped into a sum over `Γ`-orbits: dividing by
+`Nat.card Γ` turns the coset count into the weight `1 / |Stab_Γ(s • p)|`.
+
+As with the formula it comes from, `Nat.card`'s convention that an infinite type has cardinality
+`0` means no finiteness hypothesis is needed. -/
+theorem card_doubleCoset_mul_card_stabilizer_smul (s : G) (Γ : Subgroup G) (p : α) :
+    Nat.card (DoubleCoset.doubleCoset s (Γ : Set G) (stabilizer G p : Set G)) *
+        Nat.card (stabilizer (↥Γ) (s • p)) = Nat.card Γ * Nat.card (stabilizer G p) := by
+  rw [stabilizer_smul_eq_mackeySubgroup_subgroupOf,
+    Nat.card_congr (Subgroup.subgroupOfEquivOfLe mackeySubgroup_le_right).toEquiv]
+  exact card_doubleCoset_mul_card_mackeySubgroup s (stabilizer G p) Γ
+
+end Translate
 
 end Orbit
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"grouptheory-mackey-stabilizer-translate"}-->

### What this adds

One theorem, at the end of `section Orbit`, for an arbitrary `G`-set:

```lean
theorem stabilizer_smul_eq_mackeySubgroup_subgroupOf (s : G) (Γ : Subgroup G) (p : α) :
    stabilizer (↥Γ) (s • p) = (mackeySubgroup s (stabilizer G p) Γ).subgroupOf Γ
```

The file already proves this for the translation action on `G ⧸ H`. This is the companion for a
point of an arbitrary `G`-set, which is the form a sum over points needs.

### Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, **Layer 1: the valence formula (general level)**
(line 292). Layer 1 obtains the general-level formula by applying the level-one valence formula
to the coset norm and distributing orders over the product, which converts a sum indexed by
cosets of `Γ` into a sum indexed by `Γ`-orbits. Identifying the stabiliser of a translated point
is a step in that conversion.

The declaration is general group theory living in the Mackey file, so the attribution follows the
precedent of #3458 (merged): `Roadmap: ModularForms` with a `grouptheory-`-prefixed id, for
general group-theoretic material whose motivating roadmap is ModularForms. The file's module
docstring separately cites the RepresentationTheory Mackey roadmap for content already there;
this PR claims no target under it.

### Why this is not the merged sibling specialised

`stabilizer_eq_mackeySubgroup_subgroupOf` (`:286`) neither implies this nor follows from it.
Mathlib carries **two** `MulAction ↥K (G ⧸ H)` instances — `mulLeftCosetsCompSubtypeVal`
(= `MulAction.compHom (G ⧸ H) (Subgroup.subtype K)`, `Quotient.lean:136`), which the merged lemma
is stated for, and `Subgroup.instMulAction`, the restriction of scalars this one uses. Established
with `set_option pp.explicit true` on the failing instantiation; the docstring records it.

### Mathlib works around the `s = 1` case twice

Mathlib proves the special case **inline, in two unrelated files**, never as a lemma:

* `Mathlib/GroupTheory/GroupAction/Blocks.lean:650` —
  `have key : (stabilizer G x).subgroupOf (stabilizer G B) = stabilizer (stabilizer G B) x := by ext; rfl`
* `Mathlib/NumberTheory/RamificationInertia/Galois.lean:266` —
  `have stabilizer_eq : stabilizer H Q = (stabilizer GAC Q).subgroupOf H := by simp [...]`

This subsumes both — verified by compiled probe:

```lean
example (Γ : Subgroup G) (p : α) : stabilizer (↥Γ) p = (stabilizer G p).subgroupOf Γ := by
  have h := stabilizer_smul_eq_mackeySubgroup_subgroupOf (1 : G) Γ p
  rwa [one_smul, mackeySubgroup_one, Subgroup.inf_subgroupOf_left] at h
```

### A second theorem was here and has been withdrawn

An earlier head also carried `card_doubleCoset_mul_card_stabilizer_smul`, the double-coset size
formula read at a point, advertised as supplying the orbit weight. **A `correctness` block was
right that it is vacuous in exactly that application**, and it is now deleted.

A finite-index `Γ ≤ SL(2, ℤ)` is infinite, so `Nat.card Γ = 0`; the double coset contains `Γs` and
is infinite, so its `Nat.card` is `0` too; both stabilisers are finite. The identity therefore
reduces to `0 = 0` and cannot be rearranged into a reciprocal stabiliser weight. `documentation`
flagged the same defect from the other side — the rearrangement divides by zero on infinite types
— and `reuse` asked for the deletion independently, as a thin restatement of
`card_doubleCoset_mul_card_mackeySubgroup` with no consumer.

The correct multiplicity for the regrouping is a **relative index** — the number of `Γ`-cosets
landing in a given orbit, which stays finite when `Γ` does not — and it belongs with the consumer
that uses it, not here.

### Verification

Measured on this head:

* `lake build` green — 8101 jobs, 0 error lines
* `lake exe axioms` — 50153 TauCeti declarations, all within the allowlist
  `[propext, Classical.choice, Quot.sound]`
* `lake exe module-system` — all 2383 TauCeti modules opt into the module system
* `LINT-ENV: PASS` — no new violations (67 grandfathered, 3 ratchetable)

Longest line 99 codepoints, measured with `wc -m`.
