### PR TITLE
feat: factor faithful representations through upper unitriangular groups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.lean
@@ -172,15 +172,9 @@ and only if its coordinate Hopf-algebra morphism is surjective. -/
 theorem isClosedImmersion_coordinateGroupSchemeHom_iff (b : Basis (Fin n) k M) :
     IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left ↔
       Function.Surjective (coordinateBialgHom (H := H) b) := by
-  let _ : IsIso
-      (eqToHom (GeneralLinear.groupScheme_def k n).symm).hom.hom.left :=
-    ((Over.forget (Spec (CommRingCat.of k))).mapIso
-      ((Grp.forget (Over (Spec (CommRingCat.of k)))).mapIso
-        (eqToIso (GeneralLinear.groupScheme_def k n).symm))).isIso_hom
   rw [coordinateGroupSchemeHom_def]
-  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
-  rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
-  exact CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _
+  exact CommHopfAlgCat.isClosedImmersion_hopfSpec_map_comp_eqToHom_iff
+    (GeneralLinear.groupScheme_def k n) _
 
 end GroupScheme
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean
@@ -1,0 +1,261 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Faithful
+public import TauCeti.Algebra.AlgebraicGroup.UpperUnitriangular.Scheme
+
+/-!
+# Representations with upper-unitriangular coefficient matrices
+
+Let `M` be a finite free comodule over a commutative Hopf algebra `H`. If the coefficient matrix
+of `M` in a basis `b` is upper unitriangular, evaluation at its strict-upper entries defines a
+coordinate Hopf-algebra morphism
+
+```text
+O(U_n) ⟶ H.
+```
+
+This morphism factors the usual coordinate morphism `O(GL_n) ⟶ H` through the quotient
+`O(GL_n) ⟶ O(U_n)`. Consequently, if `M` is faithful, the represented affine group embeds as
+a closed subgroup of `U_n`.
+
+This is the coordinate-algebra bridge needed for the upper-unitriangular embedding
+characterization in Layer 5, "Unipotent groups", of the ReductiveGroups roadmap. The remaining
+Kolchin step must produce a basis with upper-unitriangular coefficient matrix for a faithful
+representation of a unipotent group.
+
+## Main declarations
+
+* `TauCeti.Comodule.upperUnitriangularCoordinateBialgHom`: the coordinate morphism to an
+  upper-unitriangular representation.
+* `TauCeti.Comodule.upperUnitriangularCoordinateBialgHom_comp_coordinateMap`: its factorization of
+  the general-linear coordinate morphism.
+* `TauCeti.Comodule.upperUnitriangularGroupSchemeHom`: the corresponding group-scheme morphism.
+* `TauCeti.Comodule.isClosedImmersion_upperUnitriangularGroupSchemeHom_of_isFaithful`: a faithful
+  upper-unitriangular representation is a closed immersion into `U_n`.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+open CategoryTheory AlgebraicGeometry Module
+
+universe u
+
+noncomputable section
+
+variable {R H M : Type u} {n : ℕ}
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- Evaluate the strict-upper coordinates of `O(U_n)` at the corresponding entries of the
+coefficient matrix. The upper-unitriangular hypothesis is used below to prove this algebra map
+respects the coalgebra structure. -/
+private def upperUnitriangularCoordinateAlgHom (b : Basis (Fin n) R M) :
+    UpperUnitriangular.coordinateHopfAlgebra R (Fin n) →ₐ[R] H :=
+  (MvPolynomial.aeval fun ij : UpperUnitriangular.Index (Fin n) ↦
+      coefficientMatrix (C := H) b ij.1.1 ij.1.2).comp
+    (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)).symm.toAlgHom
+
+private theorem upperUnitriangularCoordinateAlgHom_genericMatrix_apply
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
+    (i j : Fin n) :
+    upperUnitriangularCoordinateAlgHom (H := H) b
+        (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)
+          (UpperUnitriangular.genericMatrix R (Fin n) i j)) =
+      coefficientMatrix (C := H) b i j := by
+  rw [upperUnitriangularCoordinateAlgHom, AlgHom.comp_apply]
+  calc
+    _ = (MvPolynomial.aeval fun ij : UpperUnitriangular.Index (Fin n) ↦
+          coefficientMatrix (C := H) b ij.1.1 ij.1.2)
+        (UpperUnitriangular.genericMatrix R (Fin n) i j) :=
+      congrArg _ ((UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)).symm_apply_apply _)
+    _ = _ := congrFun
+      (congrFun (UpperUnitriangular.map_aeval_genericMatrix R (Fin n) _ h) i) j
+
+private theorem upperUnitriangularCoordinateAlgHom_X
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
+    (ij : UpperUnitriangular.Index (Fin n)) :
+    upperUnitriangularCoordinateAlgHom (H := H) b
+        (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)
+          (MvPolynomial.X ij)) =
+      coefficientMatrix (C := H) b ij.1.1 ij.1.2 := by
+  rw [← UpperUnitriangular.genericMatrix_apply_of_lt R (Fin n) ij.2]
+  exact upperUnitriangularCoordinateAlgHom_genericMatrix_apply b h _ _
+
+private theorem upperUnitriangularCoordinateAlgHom_counit
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (Bialgebra.counitAlgHom R H).comp
+        (upperUnitriangularCoordinateAlgHom (H := H) b) =
+      Bialgebra.counitAlgHom R
+        (UpperUnitriangular.coordinateHopfAlgebra R (Fin n)) := by
+  apply UpperUnitriangular.coordinateHopfAlgebra_algHom_ext R (Fin n)
+  intro ij
+  rw [AlgHom.comp_apply, Bialgebra.counitAlgHom_apply,
+    upperUnitriangularCoordinateAlgHom_X b h, counit_coefficientMatrix]
+  simp [Bialgebra.counitAlgHom_apply, ij.2.ne]
+
+private theorem upperUnitriangularCoordinateAlgHom_comul
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (Algebra.TensorProduct.map
+        (upperUnitriangularCoordinateAlgHom (H := H) b)
+        (upperUnitriangularCoordinateAlgHom (H := H) b)).comp
+        (Bialgebra.comulAlgHom R
+          (UpperUnitriangular.coordinateHopfAlgebra R (Fin n))) =
+      (Bialgebra.comulAlgHom R H).comp
+        (upperUnitriangularCoordinateAlgHom (H := H) b) := by
+  apply UpperUnitriangular.coordinateHopfAlgebra_algHom_ext R (Fin n)
+  intro ij
+  simp only [AlgHom.comp_apply, Bialgebra.comulAlgHom_apply,
+    UpperUnitriangular.coordinateHopfAlgebra_comul_X, map_sum,
+    Algebra.TensorProduct.map_tmul,
+    upperUnitriangularCoordinateAlgHom_genericMatrix_apply b h,
+    upperUnitriangularCoordinateAlgHom_X b h]
+  exact (comul_coefficientMatrix_eq_sum (C := H) b ij.1.1 ij.1.2).symm
+
+/-- The coordinate Hopf-algebra morphism of a comodule whose coefficient matrix is upper
+unitriangular in the chosen basis. It sends each strict-upper coordinate of `U_n` to the
+corresponding matrix coefficient. -/
+def upperUnitriangularCoordinateBialgHom
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    UpperUnitriangular.coordinateHopfAlgebra R (Fin n) →ₐc[R] H :=
+  BialgHom.ofAlgHom (upperUnitriangularCoordinateAlgHom b)
+    (upperUnitriangularCoordinateAlgHom_counit b h)
+    (upperUnitriangularCoordinateAlgHom_comul b h)
+
+/-- The upper-unitriangular coordinate morphism sends every entry of the generic matrix to the
+corresponding coefficient-matrix entry. -/
+@[simp]
+theorem upperUnitriangularCoordinateBialgHom_genericMatrix_apply
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
+    (i j : Fin n) :
+    upperUnitriangularCoordinateBialgHom (H := H) b h
+        (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)
+          (UpperUnitriangular.genericMatrix R (Fin n) i j)) =
+      coefficientMatrix (C := H) b i j := by
+  exact upperUnitriangularCoordinateAlgHom_genericMatrix_apply b h i j
+
+/-- The coordinate morphism of an upper-unitriangular representation factors the ordinary
+general-linear coordinate morphism through `O(U_n)`. -/
+theorem upperUnitriangularCoordinateBialgHom_comp_coordinateMap
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (upperUnitriangularCoordinateBialgHom (H := H) b h).comp
+        (UpperUnitriangular.coordinateMap R n).hom =
+      coordinateBialgHom (H := H) b := by
+  apply BialgHom.ext
+  intro x
+  have hAlg :
+      ((upperUnitriangularCoordinateBialgHom (H := H) b h).comp
+        (UpperUnitriangular.coordinateMap R n).hom).toAlgHom =
+        (coordinateBialgHom (H := H) b).toAlgHom := by
+    apply GeneralLinear.coordinateHopfAlgebra_algHom_ext R n
+    intro i j
+    rw [BialgHom.comp_toAlgHom, AlgHom.comp_apply]
+    calc
+      _ = upperUnitriangularCoordinateBialgHom (H := H) b h
+          (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)
+            (UpperUnitriangular.genericMatrix R (Fin n) i j)) :=
+        congrArg (upperUnitriangularCoordinateBialgHom (H := H) b h)
+          (UpperUnitriangular.coordinateMap_genericMatrix_apply R n i j)
+      _ = coefficientMatrix (C := H) b i j :=
+        upperUnitriangularCoordinateBialgHom_genericMatrix_apply b h i j
+      _ = _ := (coordinateBialgHom_X b i j).symm
+  exact AlgHom.congr_fun hAlg x
+
+/-- For an upper-unitriangular representation, faithfulness makes its coordinate morphism
+`O(U_n) ⟶ H` surjective. -/
+theorem upperUnitriangularCoordinateBialgHom_surjective_of_isFaithful
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
+    (hM : IsFaithful (k := R) (H := H) (V := M)) :
+    Function.Surjective (upperUnitriangularCoordinateBialgHom (H := H) b h) := by
+  have hb : IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left :=
+    (isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom b).mp hM
+  have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) :=
+    (isClosedImmersion_coordinateGroupSchemeHom_iff b).mp hb
+  intro y
+  obtain ⟨x, rfl⟩ := hsurj y
+  refine ⟨(UpperUnitriangular.coordinateMap R n).hom x, ?_⟩
+  exact DFunLike.congr_fun
+    (upperUnitriangularCoordinateBialgHom_comp_coordinateMap b h) x
+
+/-- The morphism from the affine group represented by `H` to `U_n` associated to a basis in
+which the coefficient matrix is upper unitriangular. -/
+def upperUnitriangularGroupSchemeHom
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (hopfSpec (CommRingCat.of R)).obj (Opposite.op (CommHopfAlgCat.of R H)) ⟶
+      UpperUnitriangular.groupScheme R (Fin n) :=
+  (hopfSpec (CommRingCat.of R)).map
+      (CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom b h)).op ≫
+    eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm
+
+/-- The upper-unitriangular representation morphism is relative spectrum applied to its
+coordinate morphism, followed by the defining identification of `U_n`. -/
+theorem upperUnitriangularGroupSchemeHom_def
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    upperUnitriangularGroupSchemeHom (H := H) b h =
+      (hopfSpec (CommRingCat.of R)).map
+          (CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom b h)).op ≫
+        eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm :=
+  (rfl)
+
+/-- Composing the upper-unitriangular representation with `U_n ⟶ GL_n` recovers the usual
+general-linear representation. -/
+theorem upperUnitriangularGroupSchemeHom_comp_inclusion
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    upperUnitriangularGroupSchemeHom (H := H) b h ≫
+        UpperUnitriangular.inclusion R n =
+      coordinateGroupSchemeHom (H := H) b := by
+  rw [upperUnitriangularGroupSchemeHom_def, UpperUnitriangular.inclusion_def,
+    coordinateGroupSchemeHom_def]
+  simp only [Category.assoc]
+  rw [← Category.assoc
+    (eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm)
+    (eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)))]
+  simp only [eqToHom_trans, eqToHom_refl, Category.id_comp]
+  rw [← Category.assoc, ← Functor.map_comp]
+  congr 2
+  apply Quiver.Hom.unop_inj
+  simp only [CategoryTheory.unop_comp, Quiver.Hom.unop_op]
+  apply CommHopfAlgCat.hom_ext
+  exact upperUnitriangularCoordinateBialgHom_comp_coordinateMap b h
+
+/-- The upper-unitriangular representation morphism is a closed immersion exactly when its
+coordinate Hopf-algebra morphism is surjective. -/
+@[simp]
+theorem isClosedImmersion_upperUnitriangularGroupSchemeHom_iff
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    IsClosedImmersion (upperUnitriangularGroupSchemeHom (H := H) b h).hom.hom.left ↔
+      Function.Surjective (upperUnitriangularCoordinateBialgHom (H := H) b h) := by
+  let _ : IsIso
+      (eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm).hom.hom.left :=
+    ((Over.forget (Spec (CommRingCat.of R))).mapIso
+      ((Grp.forget (Over (Spec (CommRingCat.of R)))).mapIso
+        (eqToIso (UpperUnitriangular.groupScheme_def R (Fin n)).symm))).isIso_hom
+  rw [upperUnitriangularGroupSchemeHom]
+  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
+  rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
+  exact CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _
+
+/-- A faithful comodule whose coefficient matrix is upper unitriangular defines a closed
+immersion of the represented affine group into `U_n`. -/
+theorem isClosedImmersion_upperUnitriangularGroupSchemeHom_of_isFaithful
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
+    (hM : IsFaithful (k := R) (H := H) (V := M)) :
+    IsClosedImmersion (upperUnitriangularGroupSchemeHom (H := H) b h).hom.hom.left := by
+  rw [isClosedImmersion_upperUnitriangularGroupSchemeHom_iff]
+  exact upperUnitriangularCoordinateBialgHom_surjective_of_isFaithful b h hM
+
+end
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean
@@ -31,11 +31,14 @@ representation of a unipotent group.
 
 * `TauCeti.Comodule.upperUnitriangularCoordinateBialgHom`: the coordinate morphism to an
   upper-unitriangular representation.
+* `TauCeti.Comodule.upperUnitriangularCoordinateBialgHom_X`: its value on strict-upper
+  coordinate generators.
 * `TauCeti.Comodule.upperUnitriangularCoordinateBialgHom_comp_coordinateMap`: its factorization of
   the general-linear coordinate morphism.
-* `TauCeti.Comodule.upperUnitriangularGroupSchemeHom`: the corresponding group-scheme morphism.
-* `TauCeti.Comodule.isClosedImmersion_upperUnitriangularGroupSchemeHom_of_isFaithful`: a faithful
-  upper-unitriangular representation is a closed immersion into `U_n`.
+* `TauCeti.Comodule.upperUnitriangularCoordinateGroupSchemeHom`: the corresponding group-scheme
+  morphism into `U_n`.
+* `TauCeti.Comodule.isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff_isFaithful`:
+  the morphism into `U_n` is a closed immersion exactly when the comodule is faithful.
 
 ## References
 
@@ -51,100 +54,109 @@ namespace TauCeti.Comodule
 
 open CategoryTheory AlgebraicGeometry Module
 
-universe u
+universe u v w x
 
 noncomputable section
 
-variable {R H M : Type u} {n : ℕ}
+section CoordinateAlgebra
+
+variable {R : Type u} {H : Type v} {M : Type w} {m : Type x} {n : ℕ}
 variable [CommRing R] [CommRing H] [HopfAlgebra R H]
 variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+variable [Fintype m] [LinearOrder m]
 
 /-- Evaluate the strict-upper coordinates of `O(U_n)` at the corresponding entries of the
 coefficient matrix. The upper-unitriangular hypothesis is used below to prove this algebra map
 respects the coalgebra structure. -/
-private def upperUnitriangularCoordinateAlgHom (b : Basis (Fin n) R M) :
-    UpperUnitriangular.coordinateHopfAlgebra R (Fin n) →ₐ[R] H :=
-  (MvPolynomial.aeval fun ij : UpperUnitriangular.Index (Fin n) ↦
-      coefficientMatrix (C := H) b ij.1.1 ij.1.2).comp
-    (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)).symm.toAlgHom
-
-private theorem upperUnitriangularCoordinateAlgHom_genericMatrix_apply
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
-    (i j : Fin n) :
-    upperUnitriangularCoordinateAlgHom (H := H) b
-        (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)
-          (UpperUnitriangular.genericMatrix R (Fin n) i j)) =
-      coefficientMatrix (C := H) b i j := by
-  rw [upperUnitriangularCoordinateAlgHom, AlgHom.comp_apply]
-  calc
-    _ = (MvPolynomial.aeval fun ij : UpperUnitriangular.Index (Fin n) ↦
-          coefficientMatrix (C := H) b ij.1.1 ij.1.2)
-        (UpperUnitriangular.genericMatrix R (Fin n) i j) :=
-      congrArg _ ((UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)).symm_apply_apply _)
-    _ = _ := congrFun
-      (congrFun (UpperUnitriangular.map_aeval_genericMatrix R (Fin n) _ h) i) j
-
-private theorem upperUnitriangularCoordinateAlgHom_X
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
-    (ij : UpperUnitriangular.Index (Fin n)) :
-    upperUnitriangularCoordinateAlgHom (H := H) b
-        (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)
-          (MvPolynomial.X ij)) =
-      coefficientMatrix (C := H) b ij.1.1 ij.1.2 := by
-  rw [← UpperUnitriangular.genericMatrix_apply_of_lt R (Fin n) ij.2]
-  exact upperUnitriangularCoordinateAlgHom_genericMatrix_apply b h _ _
+private def upperUnitriangularCoordinateAlgHom
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    UpperUnitriangular.coordinateHopfAlgebra R m →ₐ[R] H :=
+  (UpperUnitriangular.upperUnitriangularToPoint R m
+    ⟨h.toGL, UpperUnitriangularGroup.toGL_mem_upperUnitriangularGroup h⟩).ofConv
 
 private theorem upperUnitriangularCoordinateAlgHom_counit
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
     (Bialgebra.counitAlgHom R H).comp
-        (upperUnitriangularCoordinateAlgHom (H := H) b) =
+        (upperUnitriangularCoordinateAlgHom (H := H) b h) =
       Bialgebra.counitAlgHom R
-        (UpperUnitriangular.coordinateHopfAlgebra R (Fin n)) := by
-  apply UpperUnitriangular.coordinateHopfAlgebra_algHom_ext R (Fin n)
+        (UpperUnitriangular.coordinateHopfAlgebra R m) := by
+  apply UpperUnitriangular.coordinateHopfAlgebra_algHom_ext R m
   intro ij
   rw [AlgHom.comp_apply, Bialgebra.counitAlgHom_apply,
-    upperUnitriangularCoordinateAlgHom_X b h, counit_coefficientMatrix]
+    upperUnitriangularCoordinateAlgHom, UpperUnitriangular.upperUnitriangularToPoint_apply,
+    h.coe_toGL, counit_coefficientMatrix]
   simp [Bialgebra.counitAlgHom_apply, ij.2.ne]
 
 private theorem upperUnitriangularCoordinateAlgHom_comul
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
     (Algebra.TensorProduct.map
-        (upperUnitriangularCoordinateAlgHom (H := H) b)
-        (upperUnitriangularCoordinateAlgHom (H := H) b)).comp
+        (upperUnitriangularCoordinateAlgHom (H := H) b h)
+        (upperUnitriangularCoordinateAlgHom (H := H) b h)).comp
         (Bialgebra.comulAlgHom R
-          (UpperUnitriangular.coordinateHopfAlgebra R (Fin n))) =
+          (UpperUnitriangular.coordinateHopfAlgebra R m)) =
       (Bialgebra.comulAlgHom R H).comp
-        (upperUnitriangularCoordinateAlgHom (H := H) b) := by
-  apply UpperUnitriangular.coordinateHopfAlgebra_algHom_ext R (Fin n)
+        (upperUnitriangularCoordinateAlgHom (H := H) b h) := by
+  have hgeneric (i j : m) :
+      upperUnitriangularCoordinateAlgHom (H := H) b h
+          (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R m
+            (UpperUnitriangular.genericMatrix R m i j)) =
+        coefficientMatrix (C := H) b i j := by
+    rw [upperUnitriangularCoordinateAlgHom]
+    rw [← UpperUnitriangular.pointToUpperUnitriangular_apply]
+    simp only [UpperUnitriangular.pointToUpperUnitriangular_upperUnitriangularToPoint,
+      h.coe_toGL]
+  have hX (ij : UpperUnitriangular.Index m) :
+      upperUnitriangularCoordinateAlgHom (H := H) b h
+          (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R m (MvPolynomial.X ij)) =
+        coefficientMatrix (C := H) b ij.1.1 ij.1.2 := by
+    rw [upperUnitriangularCoordinateAlgHom,
+      UpperUnitriangular.upperUnitriangularToPoint_apply, h.coe_toGL]
+  apply UpperUnitriangular.coordinateHopfAlgebra_algHom_ext R m
   intro ij
   simp only [AlgHom.comp_apply, Bialgebra.comulAlgHom_apply,
     UpperUnitriangular.coordinateHopfAlgebra_comul_X, map_sum,
     Algebra.TensorProduct.map_tmul,
-    upperUnitriangularCoordinateAlgHom_genericMatrix_apply b h,
-    upperUnitriangularCoordinateAlgHom_X b h]
+    hgeneric, hX]
   exact (comul_coefficientMatrix_eq_sum (C := H) b ij.1.1 ij.1.2).symm
 
 /-- The coordinate Hopf-algebra morphism of a comodule whose coefficient matrix is upper
 unitriangular in the chosen basis. It sends each strict-upper coordinate of `U_n` to the
 corresponding matrix coefficient. -/
 def upperUnitriangularCoordinateBialgHom
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
-    UpperUnitriangular.coordinateHopfAlgebra R (Fin n) →ₐc[R] H :=
-  BialgHom.ofAlgHom (upperUnitriangularCoordinateAlgHom b)
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    UpperUnitriangular.coordinateHopfAlgebra R m →ₐc[R] H :=
+  BialgHom.ofAlgHom (upperUnitriangularCoordinateAlgHom b h)
     (upperUnitriangularCoordinateAlgHom_counit b h)
     (upperUnitriangularCoordinateAlgHom_comul b h)
+
+/-- The upper-unitriangular coordinate morphism sends each strict-upper coordinate generator
+to the corresponding coefficient-matrix entry. -/
+@[simp]
+theorem upperUnitriangularCoordinateBialgHom_X
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
+    (ij : UpperUnitriangular.Index m) :
+    upperUnitriangularCoordinateBialgHom (H := H) b h
+        (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R m (MvPolynomial.X ij)) =
+      coefficientMatrix (C := H) b ij.1.1 ij.1.2 := by
+  simp only [upperUnitriangularCoordinateBialgHom, BialgHom.ofAlgHom_apply,
+    upperUnitriangularCoordinateAlgHom, UpperUnitriangular.upperUnitriangularToPoint_apply,
+    h.coe_toGL]
 
 /-- The upper-unitriangular coordinate morphism sends every entry of the generic matrix to the
 corresponding coefficient-matrix entry. -/
 @[simp]
 theorem upperUnitriangularCoordinateBialgHom_genericMatrix_apply
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
-    (i j : Fin n) :
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
+    (i j : m) :
     upperUnitriangularCoordinateBialgHom (H := H) b h
-        (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R (Fin n)
-          (UpperUnitriangular.genericMatrix R (Fin n) i j)) =
+        (UpperUnitriangular.coordinateHopfAlgebraAlgEquiv R m
+          (UpperUnitriangular.genericMatrix R m i j)) =
       coefficientMatrix (C := H) b i j := by
-  exact upperUnitriangularCoordinateAlgHom_genericMatrix_apply b h i j
+  simp only [upperUnitriangularCoordinateBialgHom, BialgHom.ofAlgHom_apply]
+  rw [upperUnitriangularCoordinateAlgHom]
+  rw [← UpperUnitriangular.pointToUpperUnitriangular_apply]
+  simp only [UpperUnitriangular.pointToUpperUnitriangular_upperUnitriangularToPoint,
+    h.coe_toGL]
 
 /-- The coordinate morphism of an upper-unitriangular representation factors the ordinary
 general-linear coordinate morphism through `O(U_n)`. -/
@@ -173,25 +185,49 @@ theorem upperUnitriangularCoordinateBialgHom_comp_coordinateMap
       _ = _ := (coordinateBialgHom_X b i j).symm
   exact AlgHom.congr_fun hAlg x
 
-/-- For an upper-unitriangular representation, faithfulness makes its coordinate morphism
-`O(U_n) ⟶ H` surjective. -/
-theorem upperUnitriangularCoordinateBialgHom_surjective_of_isFaithful
+/-- If the ordinary coordinate morphism of an upper-unitriangular representation is surjective,
+then its factored coordinate morphism `O(U_n) ⟶ H` is surjective. -/
+theorem upperUnitriangularCoordinateBialgHom_surjective_of_surjective
     (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
-    (hM : IsFaithful (k := R) (H := H) (V := M)) :
+    (hsurj : Function.Surjective (coordinateBialgHom (H := H) b)) :
     Function.Surjective (upperUnitriangularCoordinateBialgHom (H := H) b h) := by
-  have hb : IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left :=
-    (isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom b).mp hM
-  have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) :=
-    (isClosedImmersion_coordinateGroupSchemeHom_iff b).mp hb
   intro y
   obtain ⟨x, rfl⟩ := hsurj y
   refine ⟨(UpperUnitriangular.coordinateMap R n).hom x, ?_⟩
   exact DFunLike.congr_fun
     (upperUnitriangularCoordinateBialgHom_comp_coordinateMap b h) x
 
+end CoordinateAlgebra
+
+section GroupScheme
+
+variable {R H M : Type u} {n : ℕ}
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- The upper-unitriangular coordinate morphism is surjective exactly when the comodule is
+faithful. -/
+theorem upperUnitriangularCoordinateBialgHom_surjective_iff_isFaithful
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    Function.Surjective (upperUnitriangularCoordinateBialgHom (H := H) b h) ↔
+      IsFaithful (k := R) (H := H) (V := M) := by
+  rw [isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom b,
+    isClosedImmersion_coordinateGroupSchemeHom_iff]
+  constructor
+  · intro hsurj
+    rw [← upperUnitriangularCoordinateBialgHom_comp_coordinateMap b h]
+    intro y
+    obtain ⟨x, hx⟩ := hsurj y
+    obtain ⟨z, hz⟩ := UpperUnitriangular.coordinateMap_surjective R n x
+    refine ⟨z, ?_⟩
+    change upperUnitriangularCoordinateBialgHom (H := H) b h
+      ((UpperUnitriangular.coordinateMap R n).hom z) = y
+    rw [hz, hx]
+  · exact upperUnitriangularCoordinateBialgHom_surjective_of_surjective b h
+
 /-- The morphism from the affine group represented by `H` to `U_n` associated to a basis in
 which the coefficient matrix is upper unitriangular. -/
-def upperUnitriangularGroupSchemeHom
+def upperUnitriangularCoordinateGroupSchemeHom
     (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
     (hopfSpec (CommRingCat.of R)).obj (Opposite.op (CommHopfAlgCat.of R H)) ⟶
       UpperUnitriangular.groupScheme R (Fin n) :=
@@ -201,9 +237,9 @@ def upperUnitriangularGroupSchemeHom
 
 /-- The upper-unitriangular representation morphism is relative spectrum applied to its
 coordinate morphism, followed by the defining identification of `U_n`. -/
-theorem upperUnitriangularGroupSchemeHom_def
+theorem upperUnitriangularCoordinateGroupSchemeHom_def
     (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
-    upperUnitriangularGroupSchemeHom (H := H) b h =
+    upperUnitriangularCoordinateGroupSchemeHom (H := H) b h =
       (hopfSpec (CommRingCat.of R)).map
           (CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom b h)).op ≫
         eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm :=
@@ -211,50 +247,48 @@ theorem upperUnitriangularGroupSchemeHom_def
 
 /-- Composing the upper-unitriangular representation with `U_n ⟶ GL_n` recovers the usual
 general-linear representation. -/
-theorem upperUnitriangularGroupSchemeHom_comp_inclusion
+theorem upperUnitriangularCoordinateGroupSchemeHom_comp_inclusion
     (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
-    upperUnitriangularGroupSchemeHom (H := H) b h ≫
+    upperUnitriangularCoordinateGroupSchemeHom (H := H) b h ≫
         UpperUnitriangular.inclusion R n =
       coordinateGroupSchemeHom (H := H) b := by
-  rw [upperUnitriangularGroupSchemeHom_def, UpperUnitriangular.inclusion_def,
+  rw [upperUnitriangularCoordinateGroupSchemeHom_def, UpperUnitriangular.inclusion_def,
     coordinateGroupSchemeHom_def]
-  simp only [Category.assoc]
-  rw [← Category.assoc
-    (eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm)
-    (eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)))]
-  simp only [eqToHom_trans, eqToHom_refl, Category.id_comp]
-  rw [← Category.assoc, ← Functor.map_comp]
-  congr 2
-  apply Quiver.Hom.unop_inj
-  simp only [CategoryTheory.unop_comp, Quiver.Hom.unop_op]
-  apply CommHopfAlgCat.hom_ext
-  exact upperUnitriangularCoordinateBialgHom_comp_coordinateMap b h
+  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+  have hcoordinate :
+      CommHopfAlgCat.ofHom (coordinateBialgHom (H := H) b) =
+        UpperUnitriangular.coordinateMap R n ≫
+          CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom (H := H) b h) := by
+    apply CommHopfAlgCat.hom_ext
+    change coordinateBialgHom (H := H) b =
+      (upperUnitriangularCoordinateBialgHom (H := H) b h).comp
+        (UpperUnitriangular.coordinateMap R n).hom
+    exact (upperUnitriangularCoordinateBialgHom_comp_coordinateMap b h).symm
+  rw [← Category.assoc, ← Functor.map_comp, ← op_comp, ← hcoordinate]
 
 /-- The upper-unitriangular representation morphism is a closed immersion exactly when its
 coordinate Hopf-algebra morphism is surjective. -/
 @[simp]
-theorem isClosedImmersion_upperUnitriangularGroupSchemeHom_iff
+theorem isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff
     (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
-    IsClosedImmersion (upperUnitriangularGroupSchemeHom (H := H) b h).hom.hom.left ↔
+    IsClosedImmersion
+        (upperUnitriangularCoordinateGroupSchemeHom (H := H) b h).hom.hom.left ↔
       Function.Surjective (upperUnitriangularCoordinateBialgHom (H := H) b h) := by
-  let _ : IsIso
-      (eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm).hom.hom.left :=
-    ((Over.forget (Spec (CommRingCat.of R))).mapIso
-      ((Grp.forget (Over (Spec (CommRingCat.of R)))).mapIso
-        (eqToIso (UpperUnitriangular.groupScheme_def R (Fin n)).symm))).isIso_hom
-  rw [upperUnitriangularGroupSchemeHom]
-  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
-  rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
-  exact CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _
+  rw [upperUnitriangularCoordinateGroupSchemeHom]
+  exact CommHopfAlgCat.isClosedImmersion_hopfSpec_map_comp_eqToHom_iff
+    (UpperUnitriangular.groupScheme_def R (Fin n)) _
 
-/-- A faithful comodule whose coefficient matrix is upper unitriangular defines a closed
-immersion of the represented affine group into `U_n`. -/
-theorem isClosedImmersion_upperUnitriangularGroupSchemeHom_of_isFaithful
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
-    (hM : IsFaithful (k := R) (H := H) (V := M)) :
-    IsClosedImmersion (upperUnitriangularGroupSchemeHom (H := H) b h).hom.hom.left := by
-  rw [isClosedImmersion_upperUnitriangularGroupSchemeHom_iff]
-  exact upperUnitriangularCoordinateBialgHom_surjective_of_isFaithful b h hM
+/-- The morphism into `U_n` defined by an upper-unitriangular coefficient matrix is a closed
+immersion exactly when the comodule is faithful. -/
+theorem isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff_isFaithful
+    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    IsClosedImmersion
+        (upperUnitriangularCoordinateGroupSchemeHom (H := H) b h).hom.hom.left ↔
+      IsFaithful (k := R) (H := H) (V := M) := by
+  rw [isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff,
+    upperUnitriangularCoordinateBialgHom_surjective_iff_isFaithful]
+
+end GroupScheme
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean
@@ -187,7 +187,7 @@ theorem upperUnitriangularCoordinateBialgHom_comp_coordinateMap
 
 /-- If the ordinary coordinate morphism of an upper-unitriangular representation is surjective,
 then its factored coordinate morphism `O(U_n) ⟶ H` is surjective. -/
-theorem upperUnitriangularCoordinateBialgHom_surjective_of_surjective
+theorem upperUnitriangularCoordinateBialgHom_surjective_of_coordinateBialgHom_surjective
     (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
     (hsurj : Function.Surjective (coordinateBialgHom (H := H) b)) :
     Function.Surjective (upperUnitriangularCoordinateBialgHom (H := H) b h) := by
@@ -220,29 +220,30 @@ theorem upperUnitriangularCoordinateBialgHom_surjective_iff_isFaithful
     obtain ⟨x, hx⟩ := hsurj y
     obtain ⟨z, hz⟩ := UpperUnitriangular.coordinateMap_surjective R n x
     refine ⟨z, ?_⟩
-    change upperUnitriangularCoordinateBialgHom (H := H) b h
-      ((UpperUnitriangular.coordinateMap R n).hom z) = y
-    rw [hz, hx]
-  · exact upperUnitriangularCoordinateBialgHom_surjective_of_surjective b h
+    simpa only [BialgHom.comp_apply, hz] using hx
+  · exact
+      upperUnitriangularCoordinateBialgHom_surjective_of_coordinateBialgHom_surjective b h
 
-/-- The morphism from the affine group represented by `H` to `U_n` associated to a basis in
-which the coefficient matrix is upper unitriangular. -/
+variable {m : Type} [Fintype m] [LinearOrder m]
+
+/-- The morphism from the affine group represented by `H` to the upper-unitriangular group
+associated to a basis in which the coefficient matrix is upper unitriangular. -/
 def upperUnitriangularCoordinateGroupSchemeHom
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
     (hopfSpec (CommRingCat.of R)).obj (Opposite.op (CommHopfAlgCat.of R H)) ⟶
-      UpperUnitriangular.groupScheme R (Fin n) :=
+      UpperUnitriangular.groupScheme R m :=
   (hopfSpec (CommRingCat.of R)).map
       (CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom b h)).op ≫
-    eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm
+    eqToHom (UpperUnitriangular.groupScheme_def R m).symm
 
 /-- The upper-unitriangular representation morphism is relative spectrum applied to its
-coordinate morphism, followed by the defining identification of `U_n`. -/
+coordinate morphism, followed by the defining identification of the upper-unitriangular group. -/
 theorem upperUnitriangularCoordinateGroupSchemeHom_def
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
     upperUnitriangularCoordinateGroupSchemeHom (H := H) b h =
       (hopfSpec (CommRingCat.of R)).map
           (CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom b h)).op ≫
-        eqToHom (UpperUnitriangular.groupScheme_def R (Fin n)).symm :=
+        eqToHom (UpperUnitriangular.groupScheme_def R m).symm :=
   (rfl)
 
 /-- Composing the upper-unitriangular representation with `U_n ⟶ GL_n` recovers the usual
@@ -259,24 +260,23 @@ theorem upperUnitriangularCoordinateGroupSchemeHom_comp_inclusion
       CommHopfAlgCat.ofHom (coordinateBialgHom (H := H) b) =
         UpperUnitriangular.coordinateMap R n ≫
           CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom (H := H) b h) := by
-    apply CommHopfAlgCat.hom_ext
-    change coordinateBialgHom (H := H) b =
-      (upperUnitriangularCoordinateBialgHom (H := H) b h).comp
-        (UpperUnitriangular.coordinateMap R n).hom
-    exact (upperUnitriangularCoordinateBialgHom_comp_coordinateMap b h).symm
+    rw [← CommHopfAlgCat.ofHom_hom (UpperUnitriangular.coordinateMap R n),
+      ← CommHopfAlgCat.ofHom_comp]
+    exact congrArg CommHopfAlgCat.ofHom
+      (upperUnitriangularCoordinateBialgHom_comp_coordinateMap b h).symm
   rw [← Category.assoc, ← Functor.map_comp, ← op_comp, ← hcoordinate]
 
 /-- The upper-unitriangular representation morphism is a closed immersion exactly when its
 coordinate Hopf-algebra morphism is surjective. -/
 @[simp]
 theorem isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff
-    (b : Basis (Fin n) R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
+    (b : Basis m R M) (h : (coefficientMatrix (C := H) b).IsUpperUnitriangular) :
     IsClosedImmersion
         (upperUnitriangularCoordinateGroupSchemeHom (H := H) b h).hom.hom.left ↔
       Function.Surjective (upperUnitriangularCoordinateBialgHom (H := H) b h) := by
   rw [upperUnitriangularCoordinateGroupSchemeHom]
   exact CommHopfAlgCat.isClosedImmersion_hopfSpec_map_comp_eqToHom_iff
-    (UpperUnitriangular.groupScheme_def R (Fin n)) _
+    (UpperUnitriangular.groupScheme_def R m) _
 
 /-- The morphism into `U_n` defined by an upper-unitriangular coefficient matrix is a closed
 immersion exactly when the comodule is faithful. -/

--- a/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Scheme.lean
@@ -283,29 +283,22 @@ instance isClosedImmersion_inclusion :
     AlgebraicGeometry.IsClosedImmersion (inclusion R n).hom.hom.left := by
   let e₁ := (eqToHom (groupScheme_def R (Fin n))).hom.hom.left
   let c := ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
-    (coordinateMap R n).op).hom.hom.left
-  let e₂ := (eqToHom (GeneralLinear.groupScheme_def R n).symm).hom.hom.left
+    (coordinateMap R n).op ≫
+      eqToHom (GeneralLinear.groupScheme_def R n).symm).hom.hom.left
   have he₁ : IsIso e₁ :=
     ((Over.forget (AlgebraicGeometry.Spec (CommRingCat.of R))).mapIso
       ((Grp.forget (Over (AlgebraicGeometry.Spec (CommRingCat.of R)))).mapIso
         (eqToIso (groupScheme_def R (Fin n))))).isIso_hom
-  have he₂ : IsIso e₂ :=
-    ((Over.forget (AlgebraicGeometry.Spec (CommRingCat.of R))).mapIso
-      ((Grp.forget (Over (AlgebraicGeometry.Spec (CommRingCat.of R)))).mapIso
-        (eqToIso (GeneralLinear.groupScheme_def R n).symm))).isIso_hom
   have hc : AlgebraicGeometry.IsClosedImmersion c := by
     dsimp only [c]
-    rw [CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff]
-    exact coordinateMap_surjective R n
+    exact (CommHopfAlgCat.isClosedImmersion_hopfSpec_map_comp_eqToHom_iff
+      (GeneralLinear.groupScheme_def R n) _).2 (coordinateMap_surjective R n)
   have he₁c : AlgebraicGeometry.IsClosedImmersion (e₁ ≫ c) :=
     (@MorphismProperty.cancel_left_of_respectsIso
       _ _ @AlgebraicGeometry.IsClosedImmersion inferInstance _ _ _ e₁ c he₁).2 hc
-  have he₁ce₂ : AlgebraicGeometry.IsClosedImmersion ((e₁ ≫ c) ≫ e₂) :=
-    (@MorphismProperty.cancel_right_of_respectsIso
-      _ _ @AlgebraicGeometry.IsClosedImmersion inferInstance _ _ _ (e₁ ≫ c) e₂ he₂).2 he₁c
   rw [inclusion_def]
   simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
-  exact he₁ce₂
+  exact he₁c
 
 /-! ### Scheme-valued points -/
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/ClosedImmersion.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/ClosedImmersion.lean
@@ -25,6 +25,8 @@ the same universe, which is reflected in the declaration in this file.
 
 * `TauCeti.CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff`: the coordinate criterion for a
   morphism of Hopf spectra to be a closed immersion.
+* `TauCeti.CommHopfAlgCat.isClosedImmersion_hopfSpec_map_comp_eqToHom_iff`: the same criterion
+  after identifying the target group scheme.
 -/
 
 public section
@@ -55,6 +57,24 @@ lemma isClosedImmersion_hopfSpec_map_iff {S : CommRingCat.{u}}
   rw [hopfSpec_map_left]
   exact IsClosedImmersion.hasAffineProperty.SpecMap_iff_of_affineAnd
     RingHom.surjective_respectsIso _
+
+/-- Composing the `hopfSpec` image of a Hopf-algebra morphism with an identification of its
+target group scheme does not change the closed-immersion criterion. -/
+@[simp↓]
+lemma isClosedImmersion_hopfSpec_map_comp_eqToHom_iff {S : CommRingCat.{u}}
+    {A B : _root_.CommHopfAlgCat.{u} S}
+    {G : Grp (Over (AlgebraicGeometry.Spec S))}
+    (hG : G = (AlgebraicGeometry.hopfSpec S).obj (Opposite.op A)) (f : A ⟶ B) :
+    IsClosedImmersion
+        (((AlgebraicGeometry.hopfSpec S).map f.op ≫ eqToHom hG.symm).hom.hom.left) ↔
+      Function.Surjective f.hom := by
+  let _ : IsIso (eqToHom hG.symm).hom.hom.left :=
+    ((Over.forget (AlgebraicGeometry.Spec S)).mapIso
+      ((Grp.forget (Over (AlgebraicGeometry.Spec S))).mapIso
+        (eqToIso hG.symm))).isIso_hom
+  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
+  rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
+  exact isClosedImmersion_hopfSpec_map_iff f
 
 end CommHopfAlgCat
 


### PR DESCRIPTION
This PR constructs the coordinate and group-scheme factorization of a finite free comodule representation whose coefficient matrix is upper unitriangular, and proves that faithfulness makes the resulting morphism a closed immersion into `U_n`. It advances the exact target in `ReductiveGroups/README.md`, Layer 5 milestone “Unipotent groups”: “a smooth connected group is unipotent iff it embeds in the upper-triangular unipotent `U_n`.” This is the most effective current step because the faithful-representation criterion and the smooth unipotence of `U_n` are on `main`: the remaining converse now reduces to the Kolchin/common-flag theorem that produces an upper-unitriangular basis for a faithful representation, after which Layer 5 still needs Lie–Kolchin, solvability, and the unipotent radical.

Define `Comodule.upperUnitriangularCoordinateBialgHom` by evaluating the polynomial coordinates of `O(U_n)` at the strict-upper matrix coefficients. Prove from the comodule counit and coassociativity identities that it is a bialgebra morphism, prove that its composite with `O(GL_n) ⟶ O(U_n)` is the usual representation coordinate morphism, and transport that factorization through relative spectrum. The resulting `upperUnitriangularGroupSchemeHom` composes with `U_n ⟶ GL_n` to the ordinary representation morphism and is a closed immersion whenever the comodule is faithful.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/UpperUnitriangular.lean` (261 lines). Reuse Tau Ceti's existing coefficient-matrix coalgebra identities, faithful-representation criterion, upper-unitriangular coordinate Hopf algebra, and relative-spectrum closed-immersion criterion; no Mathlib infrastructure is vendored. The construction follows Jantzen, *Representations of Algebraic Groups*, I.2, and Springer, *Linear Algebraic Groups*, §2.4, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"faithful-upper-unitriangular-representation-embedding"}-->

🤖 Prepared with Codex
