### PR TITLE
feat: prove the identity component is normal

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Comultiplication.lean
@@ -65,31 +65,6 @@ variable {k : Type u} [Field k] [IsAlgClosed k]
 variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H] [Algebra.FiniteType k H]
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
-private theorem rightTranslationHomeomorph_kernelPoint
-    (g h : WithConv (H →ₐ[k] k)) :
-    rightTranslationHomeomorph h (AlgHom.kernelPoint g.ofConv) =
-      AlgHom.kernelPoint (g * h).ofConv := by
-  rw [rightTranslationHomeomorph_apply]
-  -- `Spec (CommRingCat.of H)` has `PrimeSpectrum H` as its reducible carrier; expose that carrier
-  -- and the algebra-hom composition before applying the kernel-point API.
-  change PrimeSpectrum.comap
-      ((rightTranslationAlgEquiv h).toAlgHom : H →+* H)
-        (AlgHom.kernelPoint g.ofConv) = _
-  rw [AlgHom.comap_kernelPoint, rightTranslationAlgEquiv_toAlgHom]
-  congr 1
-  ext x
-  -- Composition of algebra homomorphisms must be exposed at application level before the
-  -- translation formula can rewrite it.
-  change g.ofConv (rightTranslationAlgHom h x) = (g * h).ofConv x
-  rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
-  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simp [hx, hy]
-  | tmul x y =>
-      simp [TensorProduct.map_tmul, TensorProduct.rid_tmul,
-        Algebra.TensorProduct.lift_tmul, Algebra.smul_def, mul_comm]
-
-omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem kernelPoint_mul_mem_connectedComponent_augmentationPoint
     (g h : WithConv (H →ₐ[k] k))
     (hg : AlgHom.kernelPoint g.ofConv ∈
@@ -102,17 +77,6 @@ private theorem kernelPoint_mul_mem_connectedComponent_augmentationPoint
     rightTranslationHomeomorph_image_connectedComponent_augmentationPoint_eq_self h hh
   rw [← himage]
   exact ⟨AlgHom.kernelPoint g.ofConv, hg, rightTranslationHomeomorph_kernelPoint g h⟩
-
-omit [IsAlgClosed k] [Algebra.FiniteType k H] in
-private theorem map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem
-    [LocallyConnectedSpace (PrimeSpectrum H)]
-    (g : WithConv (H →ₐ[k] k))
-    (hg : AlgHom.kernelPoint g.ofConv ∈
-      connectedComponent (Bialgebra.augmentationPoint k H)) :
-    g.ofConv
-        (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) = 1 := by
-  rw [← connectedComponentIdempotent_kernelPoint_eq_augmentationPoint g hg]
-  exact AlgHom.map_connectedComponentIdempotent_kernelPoint_eq_one g.ofConv
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem map_tensorSquare_comul_apply
@@ -137,34 +101,6 @@ private theorem map_tensorSquare_comul_apply
       congr 1
       simp
 
-omit [IsAlgClosed k] [Algebra.FiniteType k H] in
-private theorem kernelPoint_comp_quotient_mem_connectedComponent
-    [LocallyConnectedSpace (PrimeSpectrum H)]
-    (f : (H ⧸ PrimeSpectrum.connectedComponentIdeal
-      (Bialgebra.augmentationPoint k H)) →ₐ[k] k) :
-    AlgHom.kernelPoint
-        (f.comp (Ideal.Quotient.mkₐ k
-          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) ∈
-      connectedComponent (Bialgebra.augmentationPoint k H) := by
-  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  let y : PrimeSpectrum (H ⧸ PrimeSpectrum.connectedComponentIdeal z) :=
-    AlgHom.kernelPoint f
-  have hy := (PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent z y).property
-  rw [PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent_apply_coe] at hy
-  dsimp only [y, z] at hy
-  have hcomap :
-      PrimeSpectrum.comap
-          (Ideal.Quotient.mk
-            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
-          (AlgHom.kernelPoint f) =
-        AlgHom.kernelPoint
-          (f.comp (Ideal.Quotient.mkₐ k
-            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) :=
-    AlgHom.comap_kernelPoint f (Ideal.Quotient.mkₐ k
-      (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
-  rw [hcomap] at hy
-  exact hy
-
 private theorem map_tensorSquare_quotient_comul_connectedComponentIdempotent_eq_one
     [LocallyConnectedSpace (PrimeSpectrum H)] :
     Algebra.TensorProduct.map
@@ -186,9 +122,8 @@ private theorem map_tensorSquare_quotient_comul_connectedComponentIdempotent_eq_
       (Bialgebra.augmentationPoint k H)).map
         (_root_.Bialgebra.comulAlgHom k H).toRingHom).map F.toRingHom
   have ha_eq_one : F (Coalgebra.comul (R := k) e) = 1 := by
-    apply _root_.eq_of_isNilpotent_sub_of_isIdempotentElem
-      ha_idem IsIdempotentElem.one
-    rw [← forall_algHom_apply_eq_zero_iff_isNilpotent (k := k) (K := k)]
+    apply eq_one_of_isIdempotentElem_of_forall_algHom_apply_eq_one
+      (k := k) (A := B ⊗[k] B) (K := k) ha_idem
     intro f
     let f₁ : B →ₐ[k] k :=
       f.comp (Algebra.TensorProduct.includeLeft (R := k) (S := k) (A := B) (B := B))
@@ -198,14 +133,15 @@ private theorem map_tensorSquare_quotient_comul_connectedComponentIdempotent_eq_
     let h : WithConv (H →ₐ[k] k) := WithConv.toConv (f₂.comp q)
     have hg : AlgHom.kernelPoint g.ofConv ∈
         connectedComponent (Bialgebra.augmentationPoint k H) := by
-      exact kernelPoint_comp_quotient_mem_connectedComponent f₁
+      exact AlgHom.kernelPoint_comp_connectedComponentQuotient_mem
+        (Bialgebra.augmentationPoint k H) f₁
     have hh : AlgHom.kernelPoint h.ofConv ∈
         connectedComponent (Bialgebra.augmentationPoint k H) := by
-      exact kernelPoint_comp_quotient_mem_connectedComponent f₂
+      exact AlgHom.kernelPoint_comp_connectedComponentQuotient_mem
+        (Bialgebra.augmentationPoint k H) f₂
     have hmul := kernelPoint_mul_mem_connectedComponent_augmentationPoint g h hg hh
     have heval :=
       map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem (g * h) hmul
-    rw [map_sub, map_one, sub_eq_zero]
     rw [map_tensorSquare_comul_apply q f e]
     exact heval
   -- Expose the local quotient and tensor-square abbreviations to return the public expression.

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Normal.lean
@@ -33,7 +33,7 @@ to membership in `H ⊗ I`.
 
 ## Main declaration
 
-* `TauCeti.HopfAlgebra.identityComponentHopfIdeal_isNormal`: the Hopf ideal defining the identity
+* `TauCeti.HopfAlgebra.isNormal_identityComponentHopfIdeal`: the Hopf ideal defining the identity
   component is stable under conjugation.
 
 ## References
@@ -57,123 +57,91 @@ universe u v
 variable {k : Type u} [Field k] [IsAlgClosed k]
 variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H] [Algebra.FiniteType k H]
 
-/-- The prime of `H` cut out by a `k`-valued point, with the carrier stated directly as
-`PrimeSpectrum H` rather than through the definitionally equal scheme carrier. -/
-private def kernelPrime {K A : Type*} [Field K] [CommRing A] [Algebra K A]
-    (f : A →ₐ[K] K) : PrimeSpectrum A :=
-  PrimeSpectrum.comap (f : A →+* K) (IsLocalRing.closedPoint K)
-
 /-- Inversion on the prime spectrum of a commutative Hopf algebra. -/
 private noncomputable def inversionHomeomorph :
-    PrimeSpectrum H ≃ₜ PrimeSpectrum H :=
+    Spec (CommRingCat.of H) ≃ₜ Spec (CommRingCat.of H) :=
   PrimeSpectrum.homeomorphOfRingEquiv
     (antipodeAlgEquiv (R := k) (A := H)).symm.toRingEquiv
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem inversionHomeomorph_apply (x : Spec (CommRingCat.of H)) :
+    inversionHomeomorph (k := k) (H := H) x =
+      PrimeSpectrum.comap
+        ((antipodeAlgEquiv (R := k) (A := H)).toRingEquiv : H →+* H) x := by
+  rw [inversionHomeomorph]
+  rfl
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem inversionHomeomorph_kernelPoint (g : WithConv (H →ₐ[k] k)) :
     inversionHomeomorph (k := k) (H := H)
-        (kernelPrime g.ofConv) = kernelPrime g⁻¹.ofConv := by
-  change PrimeSpectrum.comap
-      ((antipodeAlgEquiv (R := k) (A := H)).toRingEquiv : H →+* H)
-        (kernelPrime g.ofConv) = kernelPrime g⁻¹.ofConv
-  rw [AlgEquiv.toRingEquiv_toRingHom, antipodeAlgEquiv_toRingHom]
-  rw [kernelPrime, kernelPrime]
-  calc
-    PrimeSpectrum.comap
-          (_root_.HopfAlgebra.antipodeAlgHom k H : H →+* H)
-          (PrimeSpectrum.comap (g.ofConv : H →+* k) (IsLocalRing.closedPoint k)) =
-        PrimeSpectrum.comap
-          ((g.ofConv : H →+* k).comp
-            (_root_.HopfAlgebra.antipodeAlgHom k H : H →+* H))
-          (IsLocalRing.closedPoint k) :=
-      (PrimeSpectrum.comap_comp_apply _ _ _).symm
-    _ = PrimeSpectrum.comap (g⁻¹.ofConv : H →+* k) (IsLocalRing.closedPoint k) := by
-      congr 1
+        (AlgHom.kernelPoint g.ofConv) = AlgHom.kernelPoint g⁻¹.ofConv := by
+  rw [inversionHomeomorph_apply, AlgEquiv.toRingEquiv_toRingHom,
+    antipodeAlgEquiv_toRingHom, AlgHom.comap_kernelPoint]
+  congr 1
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
-/-- Right translation on `PrimeSpectrum H`, without the scheme carrier wrapper. -/
-private noncomputable def rightTranslationPrimeHomeomorph (g : WithConv (H →ₐ[k] k)) :
-    PrimeSpectrum H ≃ₜ PrimeSpectrum H :=
-  PrimeSpectrum.homeomorphOfRingEquiv (rightTranslationAlgEquiv g).symm.toRingEquiv
-
-omit [IsAlgClosed k] [Algebra.FiniteType k H] in
-private theorem rightTranslationPrimeHomeomorph_kernelPoint
+private theorem rightTranslationHomeomorph_kernelPoint
     (g h : WithConv (H →ₐ[k] k)) :
-    rightTranslationPrimeHomeomorph h (kernelPrime g.ofConv) =
-      kernelPrime (g * h).ofConv := by
+    rightTranslationHomeomorph h (AlgHom.kernelPoint g.ofConv) =
+      AlgHom.kernelPoint (g * h).ofConv := by
+  rw [rightTranslationHomeomorph_apply]
+  -- `Spec (CommRingCat.of H)` has `PrimeSpectrum H` as its reducible carrier; expose that carrier
+  -- and the algebra-hom composition before applying the kernel-point API.
   change PrimeSpectrum.comap
       ((rightTranslationAlgEquiv h).toAlgHom : H →+* H)
-        (kernelPrime g.ofConv) = _
-  rw [rightTranslationAlgEquiv_toAlgHom]
-  rw [kernelPrime, kernelPrime]
-  calc
-    PrimeSpectrum.comap (rightTranslationAlgHom h : H →+* H)
-          (PrimeSpectrum.comap (g.ofConv : H →+* k) (IsLocalRing.closedPoint k)) =
-        PrimeSpectrum.comap
-          ((g.ofConv : H →+* k).comp (rightTranslationAlgHom h : H →+* H))
-          (IsLocalRing.closedPoint k) := (PrimeSpectrum.comap_comp_apply _ _ _).symm
-    _ = PrimeSpectrum.comap ((g * h).ofConv : H →+* k) (IsLocalRing.closedPoint k) := by
-      congr 1
-      ext x
-      change g.ofConv (rightTranslationAlgHom h x) = (g * h).ofConv x
-      rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
-      induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
-      | zero => simp
-      | add x y hx hy => simp [hx, hy]
-      | tmul x y =>
-          simp [TensorProduct.map_tmul, TensorProduct.rid_tmul,
-            Algebra.TensorProduct.lift_tmul, Algebra.smul_def, mul_comm]
+        (AlgHom.kernelPoint g.ofConv) = _
+  rw [AlgHom.comap_kernelPoint, rightTranslationAlgEquiv_toAlgHom]
+  congr 1
+  ext x
+  -- Composition of algebra homomorphisms must be exposed at application level before the
+  -- translation formula can rewrite it.
+  change g.ofConv (rightTranslationAlgHom h x) = (g * h).ofConv x
+  rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
+  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp [hx, hy]
+  | tmul x y =>
+      simp [TensorProduct.map_tmul, TensorProduct.rid_tmul,
+        Algebra.TensorProduct.lift_tmul, Algebra.smul_def, mul_comm]
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 /-- Left translation, expressed as inversion followed by right translation and inversion. -/
 private noncomputable def leftTranslationHomeomorph (g : WithConv (H →ₐ[k] k)) :
-    PrimeSpectrum H ≃ₜ PrimeSpectrum H :=
+    Spec (CommRingCat.of H) ≃ₜ Spec (CommRingCat.of H) :=
   (inversionHomeomorph (k := k) (H := H)).trans
-    ((rightTranslationPrimeHomeomorph g⁻¹).trans
+    ((rightTranslationHomeomorph g⁻¹).trans
       (inversionHomeomorph (k := k) (H := H)))
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem leftTranslationHomeomorph_kernelPoint
     (g h : WithConv (H →ₐ[k] k)) :
-    leftTranslationHomeomorph g (kernelPrime h.ofConv) =
-      kernelPrime (g * h).ofConv := by
+    leftTranslationHomeomorph g (AlgHom.kernelPoint h.ofConv) =
+      AlgHom.kernelPoint (g * h).ofConv := by
+  have hinv : (h⁻¹ * g⁻¹)⁻¹ = g * h := by group
   rw [leftTranslationHomeomorph, Homeomorph.trans_apply,
     Homeomorph.trans_apply, inversionHomeomorph_kernelPoint,
-    rightTranslationPrimeHomeomorph_kernelPoint, inversionHomeomorph_kernelPoint]
-  have hinv : (h⁻¹ * g⁻¹)⁻¹ = g * h := by group
-  rw [hinv]
+    rightTranslationHomeomorph_kernelPoint, inversionHomeomorph_kernelPoint, hinv]
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 /-- Conjugation by a rational point, as a homeomorphism of the prime spectrum. -/
 private noncomputable def conjugationHomeomorph (g : WithConv (H →ₐ[k] k)) :
-    PrimeSpectrum H ≃ₜ PrimeSpectrum H :=
-  (leftTranslationHomeomorph g).trans (rightTranslationPrimeHomeomorph g⁻¹)
+    Spec (CommRingCat.of H) ≃ₜ Spec (CommRingCat.of H) :=
+  (leftTranslationHomeomorph g).trans (rightTranslationHomeomorph g⁻¹)
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem conjugationHomeomorph_kernelPoint
     (g h : WithConv (H →ₐ[k] k)) :
-    conjugationHomeomorph g (kernelPrime h.ofConv) =
-      kernelPrime (g * h * g⁻¹).ofConv := by
+    conjugationHomeomorph g (AlgHom.kernelPoint h.ofConv) =
+      AlgHom.kernelPoint (g * h * g⁻¹).ofConv := by
   rw [conjugationHomeomorph, Homeomorph.trans_apply,
-    leftTranslationHomeomorph_kernelPoint, rightTranslationPrimeHomeomorph_kernelPoint]
+    leftTranslationHomeomorph_kernelPoint, rightTranslationHomeomorph_kernelPoint]
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem conjugationHomeomorph_image_identityComponent (g : WithConv (H →ₐ[k] k)) :
     conjugationHomeomorph g ''
-        connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) =
-      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) := by
-  let z : PrimeSpectrum H := kernelPrime (_root_.Bialgebra.counitAlgHom k H)
-  have hz : (Bialgebra.augmentationPoint k H : PrimeSpectrum H) = z := by
-    apply PrimeSpectrum.ext
-    change (AlgHom.kernelPoint (_root_.Bialgebra.counitAlgHom k H)).asIdeal = z.asIdeal
-    rw [AlgHom.kernelPoint_asIdeal]
-    change RingHom.ker (_root_.Bialgebra.counitAlgHom k H : H →+* k) = z.asIdeal
-    dsimp only [z, kernelPrime]
-    rw [PrimeSpectrum.comap_asIdeal]
-    dsimp only [IsLocalRing.closedPoint]
-    rw [IsLocalRing.maximalIdeal_eq_bot]
-    rfl
-  rw [hz]
+        connectedComponent (Bialgebra.augmentationPoint k H) =
+      connectedComponent (Bialgebra.augmentationPoint k H) := by
+  let z : Spec (CommRingCat.of H) := Bialgebra.augmentationPoint k H
   have himage : conjugationHomeomorph g '' connectedComponent z =
       connectedComponent (conjugationHomeomorph g z) := by
     simpa only [connectedComponentIn_univ,
@@ -183,72 +151,60 @@ private theorem conjugationHomeomorph_image_identityComponent (g : WithConv (H �
   have hfix : conjugationHomeomorph g z = z := by
     dsimp only [z]
     rw [conjugationHomeomorph_kernelPoint]
-    change kernelPrime (g * 1 * g⁻¹).ofConv =
-      kernelPrime (1 : WithConv (H →ₐ[k] k)).ofConv
+    -- The convolution identity is the counit algebra homomorphism only after unfolding `ofConv`.
+    change AlgHom.kernelPoint (g * 1 * g⁻¹).ofConv =
+      AlgHom.kernelPoint (1 : WithConv (H →ₐ[k] k)).ofConv
     simp
   rw [himage, hfix]
-  rfl
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem kernelPoint_conj_mem_identityComponent
     (g h : WithConv (H →ₐ[k] k))
-    (hh : kernelPrime h.ofConv ∈
-      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H)) :
-    kernelPrime (g * h * g⁻¹).ofConv ∈
-      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) := by
+    (hh : AlgHom.kernelPoint h.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    AlgHom.kernelPoint (g * h * g⁻¹).ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H) := by
   rw [← conjugationHomeomorph_image_identityComponent g]
-  exact ⟨kernelPrime h.ofConv, hh, conjugationHomeomorph_kernelPoint g h⟩
+  exact ⟨AlgHom.kernelPoint h.ofConv, hh, conjugationHomeomorph_kernelPoint g h⟩
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem kernelPoint_comp_componentQuotient_mem_identityComponent
     [LocallyConnectedSpace (PrimeSpectrum H)]
     (f : (H ⧸ PrimeSpectrum.connectedComponentIdeal
       (Bialgebra.augmentationPoint k H)) →ₐ[k] k) :
-    kernelPrime
+    AlgHom.kernelPoint
         (f.comp (Ideal.Quotient.mkₐ k
           (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) ∈
-      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) := by
+      connectedComponent (Bialgebra.augmentationPoint k H) := by
   let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
   let y : PrimeSpectrum (H ⧸ PrimeSpectrum.connectedComponentIdeal z) :=
-    kernelPrime f
+    AlgHom.kernelPoint f
   have hy := (PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent z y).property
   rw [PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent_apply_coe] at hy
-  change PrimeSpectrum.comap
-      (Ideal.Quotient.mk (PrimeSpectrum.connectedComponentIdeal z)) (kernelPrime f) ∈
-    connectedComponent z at hy
-  rw [kernelPrime, ← PrimeSpectrum.comap_comp_apply] at hy
+  dsimp only [y, z] at hy
+  have hcomap :
+      PrimeSpectrum.comap
+          (Ideal.Quotient.mk
+            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
+          (AlgHom.kernelPoint f) =
+        AlgHom.kernelPoint
+          (f.comp (Ideal.Quotient.mkₐ k
+            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) :=
+    AlgHom.comap_kernelPoint f (Ideal.Quotient.mkₐ k
+      (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
+  rw [hcomap] at hy
   exact hy
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 private theorem map_connectedComponentIdempotent_eq_one_of_mem
     [LocallyConnectedSpace (PrimeSpectrum H)]
     (g : WithConv (H →ₐ[k] k))
-    (hg : kernelPrime g.ofConv ∈
-      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H)) :
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
     g.ofConv
         (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) = 1 := by
-  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  let p : PrimeSpectrum H := kernelPrime g.ofConv
-  have hpz : connectedComponent p = connectedComponent z := (connectedComponent_eq hg).symm
-  have he : PrimeSpectrum.connectedComponentIdempotent p =
-      PrimeSpectrum.connectedComponentIdempotent z := by
-    apply (PrimeSpectrum.eq_connectedComponentIdempotent_iff
-      (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p) z).mpr
-    rw [PrimeSpectrum.basicOpen_connectedComponentIdempotent]
-    exact hpz
-  rw [← he]
-  have hnot : PrimeSpectrum.connectedComponentIdempotent p ∉ p.asIdeal :=
-    PrimeSpectrum.connectedComponentIdempotent_notMem_asIdeal p
-  have hpker : p.asIdeal = RingHom.ker (g.ofConv : H →+* k) := by
-    change Ideal.comap (g.ofConv : H →+* k) (IsLocalRing.maximalIdeal k) =
-      RingHom.ker (g.ofConv : H →+* k)
-    rw [IsLocalRing.maximalIdeal_eq_bot]
-    rfl
-  rw [hpker, RingHom.mem_ker] at hnot
-  have hidem : IsIdempotentElem
-      (g.ofConv (PrimeSpectrum.connectedComponentIdempotent p)) :=
-    (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p).map g.ofConv.toRingHom
-  exact (IsIdempotentElem.iff_eq_zero_or_one.mp hidem).resolve_left hnot
+  rw [← connectedComponentIdempotent_kernelPoint_eq_augmentationPoint g hg]
+  exact AlgHom.map_connectedComponentIdempotent_kernelPoint_eq_one g.ofConv
 
 private theorem map_id_quotient_conjugation_componentIdempotent_eq_one
     [LocallyConnectedSpace (PrimeSpectrum H)] :
@@ -278,8 +234,8 @@ private theorem map_id_quotient_conjugation_componentIdempotent_eq_one
   let hQ : Q →ₐ[k] k :=
     f.comp (Algebra.TensorProduct.includeRight (R := k) (A := H) (B := Q))
   let h : WithConv (H →ₐ[k] k) := toConv (hQ.comp q)
-  have hh : kernelPrime h.ofConv ∈
-      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) := by
+  have hh : AlgHom.kernelPoint h.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H) := by
     exact kernelPoint_comp_componentQuotient_mem_identityComponent hQ
   have hconj := kernelPoint_conj_mem_identityComponent g h hh
   have heval := map_connectedComponentIdempotent_eq_one_of_mem (g * h * g⁻¹) hconj
@@ -299,7 +255,7 @@ private theorem map_id_quotient_conjugation_componentIdempotent_eq_one
 
 /-- The Hopf ideal cutting out the identity component is normal: its coordinate ideal is stable
 under conjugation. Consequently it may be used in the normal fppf quotient construction. -/
-theorem identityComponentHopfIdeal_isNormal :
+theorem isNormal_identityComponentHopfIdeal :
     letI : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
     letI : LocallyConnectedSpace (PrimeSpectrum H) := inferInstance
     (identityComponentHopfIdeal (k := k) (H := H)).IsNormal := by
@@ -317,6 +273,8 @@ theorem identityComponentHopfIdeal_isNormal :
   have hxI : x ∈ I := by
     exact (mem_identityComponentHopfIdeal (k := k) (H := H)).mp hx
   rw [identityComponentHopfIdeal_toIdeal]
+  -- Unfold the Hopf-ideal carrier and the local abbreviation `I` to state the elementwise
+  -- conjugation condition in the ideal expected by the kernel lemma below.
   change conjugationAlgHom (R := k) (H := H) x ∈
     HopfIdeal.rightTensorIdeal (R := k) (H := H) I
   obtain ⟨a, rfl⟩ :=
@@ -325,12 +283,14 @@ theorem identityComponentHopfIdeal_isNormal :
   apply Ideal.mul_mem_left
   have hker : F (conjugationAlgHom (R := k) (H := H) (1 - e)) = 0 := by
     rw [map_sub, map_one, map_sub, map_one]
+    -- Expose the local tensor-map abbreviation at its argument so the pointwise identity rewrites.
     change 1 - F (conjugationAlgHom (R := k) (H := H) e) = 0
     rw [map_id_quotient_conjugation_componentIdempotent_eq_one, sub_self]
   have hmem : conjugationAlgHom (R := k) (H := H) (1 - e) ∈ RingHom.ker F.toRingHom :=
     RingHom.mem_ker.mpr hker
   have hker_eq : RingHom.ker F.toRingHom =
       HopfIdeal.rightTensorIdeal (R := k) (H := H) I := by
+    -- Unfold `F` and its ring-hom coercion to match the tensor-product quotient kernel API.
     change RingHom.ker (Algebra.TensorProduct.map (AlgHom.id k H) q) = _
     rw [HopfIdeal.ker_tensorProduct_map_id_quotient]
   rw [hker_eq] at hmem

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Normal.lean
@@ -80,31 +80,6 @@ private theorem inversionHomeomorph_kernelPoint (g : WithConv (H →ₐ[k] k)) :
   congr 1
 
 omit [IsAlgClosed k] [Algebra.FiniteType k H] in
-private theorem rightTranslationHomeomorph_kernelPoint
-    (g h : WithConv (H →ₐ[k] k)) :
-    rightTranslationHomeomorph h (AlgHom.kernelPoint g.ofConv) =
-      AlgHom.kernelPoint (g * h).ofConv := by
-  rw [rightTranslationHomeomorph_apply]
-  -- `Spec (CommRingCat.of H)` has `PrimeSpectrum H` as its reducible carrier; expose that carrier
-  -- and the algebra-hom composition before applying the kernel-point API.
-  change PrimeSpectrum.comap
-      ((rightTranslationAlgEquiv h).toAlgHom : H →+* H)
-        (AlgHom.kernelPoint g.ofConv) = _
-  rw [AlgHom.comap_kernelPoint, rightTranslationAlgEquiv_toAlgHom]
-  congr 1
-  ext x
-  -- Composition of algebra homomorphisms must be exposed at application level before the
-  -- translation formula can rewrite it.
-  change g.ofConv (rightTranslationAlgHom h x) = (g * h).ofConv x
-  rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
-  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simp [hx, hy]
-  | tmul x y =>
-      simp [TensorProduct.map_tmul, TensorProduct.rid_tmul,
-        Algebra.TensorProduct.lift_tmul, Algebra.smul_def, mul_comm]
-
-omit [IsAlgClosed k] [Algebra.FiniteType k H] in
 /-- Left translation, expressed as inversion followed by right translation and inversion. -/
 private noncomputable def leftTranslationHomeomorph (g : WithConv (H →ₐ[k] k)) :
     Spec (CommRingCat.of H) ≃ₜ Spec (CommRingCat.of H) :=
@@ -144,10 +119,7 @@ private theorem conjugationHomeomorph_image_identityComponent (g : WithConv (H �
   let z : Spec (CommRingCat.of H) := Bialgebra.augmentationPoint k H
   have himage : conjugationHomeomorph g '' connectedComponent z =
       connectedComponent (conjugationHomeomorph g z) := by
-    simpa only [connectedComponentIn_univ,
-      Set.image_univ_of_surjective (conjugationHomeomorph g).surjective] using
-      (conjugationHomeomorph g).image_connectedComponentIn
-        (s := Set.univ) (x := z) (Set.mem_univ _)
+    exact TauCeti.Homeomorph.image_connectedComponent (conjugationHomeomorph g) z
   have hfix : conjugationHomeomorph g z = z := by
     dsimp only [z]
     rw [conjugationHomeomorph_kernelPoint]
@@ -166,45 +138,6 @@ private theorem kernelPoint_conj_mem_identityComponent
       connectedComponent (Bialgebra.augmentationPoint k H) := by
   rw [← conjugationHomeomorph_image_identityComponent g]
   exact ⟨AlgHom.kernelPoint h.ofConv, hh, conjugationHomeomorph_kernelPoint g h⟩
-
-omit [IsAlgClosed k] [Algebra.FiniteType k H] in
-private theorem kernelPoint_comp_componentQuotient_mem_identityComponent
-    [LocallyConnectedSpace (PrimeSpectrum H)]
-    (f : (H ⧸ PrimeSpectrum.connectedComponentIdeal
-      (Bialgebra.augmentationPoint k H)) →ₐ[k] k) :
-    AlgHom.kernelPoint
-        (f.comp (Ideal.Quotient.mkₐ k
-          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) ∈
-      connectedComponent (Bialgebra.augmentationPoint k H) := by
-  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
-  let y : PrimeSpectrum (H ⧸ PrimeSpectrum.connectedComponentIdeal z) :=
-    AlgHom.kernelPoint f
-  have hy := (PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent z y).property
-  rw [PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent_apply_coe] at hy
-  dsimp only [y, z] at hy
-  have hcomap :
-      PrimeSpectrum.comap
-          (Ideal.Quotient.mk
-            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
-          (AlgHom.kernelPoint f) =
-        AlgHom.kernelPoint
-          (f.comp (Ideal.Quotient.mkₐ k
-            (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) :=
-    AlgHom.comap_kernelPoint f (Ideal.Quotient.mkₐ k
-      (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))
-  rw [hcomap] at hy
-  exact hy
-
-omit [IsAlgClosed k] [Algebra.FiniteType k H] in
-private theorem map_connectedComponentIdempotent_eq_one_of_mem
-    [LocallyConnectedSpace (PrimeSpectrum H)]
-    (g : WithConv (H →ₐ[k] k))
-    (hg : AlgHom.kernelPoint g.ofConv ∈
-      connectedComponent (Bialgebra.augmentationPoint k H)) :
-    g.ofConv
-        (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) = 1 := by
-  rw [← connectedComponentIdempotent_kernelPoint_eq_augmentationPoint g hg]
-  exact AlgHom.map_connectedComponentIdempotent_kernelPoint_eq_one g.ofConv
 
 private theorem map_id_quotient_conjugation_componentIdempotent_eq_one
     [LocallyConnectedSpace (PrimeSpectrum H)] :
@@ -226,8 +159,8 @@ private theorem map_id_quotient_conjugation_componentIdempotent_eq_one
     ((PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent
       (Bialgebra.augmentationPoint k H)).map
         (conjugationAlgHom (R := k) (H := H)).toRingHom).map F.toRingHom
-  apply _root_.eq_of_isNilpotent_sub_of_isIdempotentElem ha_idem IsIdempotentElem.one
-  rw [← forall_algHom_apply_eq_zero_iff_isNilpotent (k := k) (K := k)]
+  apply eq_one_of_isIdempotentElem_of_forall_algHom_apply_eq_one
+    (k := k) (A := H ⊗[k] Q) (K := k) ha_idem
   intro f
   let g : WithConv (H →ₐ[k] k) :=
     toConv (f.comp (Algebra.TensorProduct.includeLeft (R := k) (S := k) (A := H) (B := Q)))
@@ -236,22 +169,18 @@ private theorem map_id_quotient_conjugation_componentIdempotent_eq_one
   let h : WithConv (H →ₐ[k] k) := toConv (hQ.comp q)
   have hh : AlgHom.kernelPoint h.ofConv ∈
       connectedComponent (Bialgebra.augmentationPoint k H) := by
-    exact kernelPoint_comp_componentQuotient_mem_identityComponent hQ
+    exact AlgHom.kernelPoint_comp_connectedComponentQuotient_mem
+      (Bialgebra.augmentationPoint k H) hQ
   have hconj := kernelPoint_conj_mem_identityComponent g h hh
-  have heval := map_connectedComponentIdempotent_eq_one_of_mem (g * h * g⁻¹) hconj
-  rw [map_sub, map_one, sub_eq_zero]
-  have hproduct : f.comp F =
-      Algebra.TensorProduct.productMap g.ofConv h.ofConv := by
-    apply Algebra.TensorProduct.ext'
-    intro a b
-    simp only [F, g, h, hQ, q, AlgHom.comp_apply, Algebra.TensorProduct.map_tmul,
-      AlgHom.id_apply, Algebra.TensorProduct.productMap_apply_tmul]
-    rw [← map_mul]
-    congr 1
-    simp
-  rw [← AlgHom.comp_apply, hproduct]
-  exact (AlgHom.congr_fun
-    (productMap_comp_conjugationAlgHom (R := k) (H := H) g h) e).trans heval
+  have heval := map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem
+    (g * h * g⁻¹) hconj
+  have hleft : (f.comp F).comp Algebra.TensorProduct.includeLeft = g.ofConv := by
+    simp [F, g, AlgHom.comp_assoc]
+  have hright : (f.comp F).comp Algebra.TensorProduct.includeRight = h.ofConv := by
+    simp [F, h, hQ, q, AlgHom.comp_assoc]
+  have hcomp := AlgHom.congr_fun (comp_conjugationAlgHom (f.comp F)) e
+  rw [hleft, hright, toConv_ofConv] at hcomp
+  exact hcomp.trans heval
 
 /-- The Hopf ideal cutting out the identity component is normal: its coordinate ideal is stable
 under conjugation. Consequently it may be used in the normal fppf quotient construction. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Normal.lean
@@ -1,0 +1,339 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.Comultiplication
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal
+import Mathlib.RingTheory.FiniteStability
+import Mathlib.RingTheory.Idempotents
+import TauCeti.Algebra.AlgebraicGroup.Connected.Translation
+import TauCeti.AlgebraicGeometry.AugmentationPoint.ConnectedComponent
+import TauCeti.RingTheory.FiniteType.PointSeparation
+
+/-!
+# Normality of the identity component
+
+Let `H` be a commutative Hopf algebra of finite type over an algebraically closed field. The
+connected component of the counit point is preserved by conjugation, so its defining Hopf ideal
+is normal.
+
+The proof first constructs the homeomorphism of `Spec H` induced by conjugation by a rational
+point, using inversion and right translation. It then tests the universal conjugate of the
+component idempotent on algebraically closed points of
+
+```text
+H ⊗[k] (H / I),
+```
+
+where `I` cuts out the identity component. Conjugation preserves that component, so every such
+evaluation is one. The affine Nullstellensatz and idempotence promote this pointwise calculation
+to membership in `H ⊗ I`.
+
+## Main declaration
+
+* `TauCeti.HopfAlgebra.identityComponentHopfIdeal_isNormal`: the Hopf ideal defining the identity
+  component is stable under conjugation.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 6.7.
+
+This supplies the normal-subgroup input for the component-group quotient in Layer 3, “Identity
+component `G°` and component group `π₀(G)`”, of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open AlgebraicGeometry WithConv
+open scoped TensorProduct
+
+namespace TauCeti.HopfAlgebra
+
+universe u v
+
+variable {k : Type u} [Field k] [IsAlgClosed k]
+variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H] [Algebra.FiniteType k H]
+
+/-- The prime of `H` cut out by a `k`-valued point, with the carrier stated directly as
+`PrimeSpectrum H` rather than through the definitionally equal scheme carrier. -/
+private def kernelPrime {K A : Type*} [Field K] [CommRing A] [Algebra K A]
+    (f : A →ₐ[K] K) : PrimeSpectrum A :=
+  PrimeSpectrum.comap (f : A →+* K) (IsLocalRing.closedPoint K)
+
+/-- Inversion on the prime spectrum of a commutative Hopf algebra. -/
+private noncomputable def inversionHomeomorph :
+    PrimeSpectrum H ≃ₜ PrimeSpectrum H :=
+  PrimeSpectrum.homeomorphOfRingEquiv
+    (antipodeAlgEquiv (R := k) (A := H)).symm.toRingEquiv
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem inversionHomeomorph_kernelPoint (g : WithConv (H →ₐ[k] k)) :
+    inversionHomeomorph (k := k) (H := H)
+        (kernelPrime g.ofConv) = kernelPrime g⁻¹.ofConv := by
+  change PrimeSpectrum.comap
+      ((antipodeAlgEquiv (R := k) (A := H)).toRingEquiv : H →+* H)
+        (kernelPrime g.ofConv) = kernelPrime g⁻¹.ofConv
+  rw [AlgEquiv.toRingEquiv_toRingHom, antipodeAlgEquiv_toRingHom]
+  rw [kernelPrime, kernelPrime]
+  calc
+    PrimeSpectrum.comap
+          (_root_.HopfAlgebra.antipodeAlgHom k H : H →+* H)
+          (PrimeSpectrum.comap (g.ofConv : H →+* k) (IsLocalRing.closedPoint k)) =
+        PrimeSpectrum.comap
+          ((g.ofConv : H →+* k).comp
+            (_root_.HopfAlgebra.antipodeAlgHom k H : H →+* H))
+          (IsLocalRing.closedPoint k) :=
+      (PrimeSpectrum.comap_comp_apply _ _ _).symm
+    _ = PrimeSpectrum.comap (g⁻¹.ofConv : H →+* k) (IsLocalRing.closedPoint k) := by
+      congr 1
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+/-- Right translation on `PrimeSpectrum H`, without the scheme carrier wrapper. -/
+private noncomputable def rightTranslationPrimeHomeomorph (g : WithConv (H →ₐ[k] k)) :
+    PrimeSpectrum H ≃ₜ PrimeSpectrum H :=
+  PrimeSpectrum.homeomorphOfRingEquiv (rightTranslationAlgEquiv g).symm.toRingEquiv
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem rightTranslationPrimeHomeomorph_kernelPoint
+    (g h : WithConv (H →ₐ[k] k)) :
+    rightTranslationPrimeHomeomorph h (kernelPrime g.ofConv) =
+      kernelPrime (g * h).ofConv := by
+  change PrimeSpectrum.comap
+      ((rightTranslationAlgEquiv h).toAlgHom : H →+* H)
+        (kernelPrime g.ofConv) = _
+  rw [rightTranslationAlgEquiv_toAlgHom]
+  rw [kernelPrime, kernelPrime]
+  calc
+    PrimeSpectrum.comap (rightTranslationAlgHom h : H →+* H)
+          (PrimeSpectrum.comap (g.ofConv : H →+* k) (IsLocalRing.closedPoint k)) =
+        PrimeSpectrum.comap
+          ((g.ofConv : H →+* k).comp (rightTranslationAlgHom h : H →+* H))
+          (IsLocalRing.closedPoint k) := (PrimeSpectrum.comap_comp_apply _ _ _).symm
+    _ = PrimeSpectrum.comap ((g * h).ofConv : H →+* k) (IsLocalRing.closedPoint k) := by
+      congr 1
+      ext x
+      change g.ofConv (rightTranslationAlgHom h x) = (g * h).ofConv x
+      rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
+      induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
+      | zero => simp
+      | add x y hx hy => simp [hx, hy]
+      | tmul x y =>
+          simp [TensorProduct.map_tmul, TensorProduct.rid_tmul,
+            Algebra.TensorProduct.lift_tmul, Algebra.smul_def, mul_comm]
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+/-- Left translation, expressed as inversion followed by right translation and inversion. -/
+private noncomputable def leftTranslationHomeomorph (g : WithConv (H →ₐ[k] k)) :
+    PrimeSpectrum H ≃ₜ PrimeSpectrum H :=
+  (inversionHomeomorph (k := k) (H := H)).trans
+    ((rightTranslationPrimeHomeomorph g⁻¹).trans
+      (inversionHomeomorph (k := k) (H := H)))
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem leftTranslationHomeomorph_kernelPoint
+    (g h : WithConv (H →ₐ[k] k)) :
+    leftTranslationHomeomorph g (kernelPrime h.ofConv) =
+      kernelPrime (g * h).ofConv := by
+  rw [leftTranslationHomeomorph, Homeomorph.trans_apply,
+    Homeomorph.trans_apply, inversionHomeomorph_kernelPoint,
+    rightTranslationPrimeHomeomorph_kernelPoint, inversionHomeomorph_kernelPoint]
+  have hinv : (h⁻¹ * g⁻¹)⁻¹ = g * h := by group
+  rw [hinv]
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+/-- Conjugation by a rational point, as a homeomorphism of the prime spectrum. -/
+private noncomputable def conjugationHomeomorph (g : WithConv (H →ₐ[k] k)) :
+    PrimeSpectrum H ≃ₜ PrimeSpectrum H :=
+  (leftTranslationHomeomorph g).trans (rightTranslationPrimeHomeomorph g⁻¹)
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem conjugationHomeomorph_kernelPoint
+    (g h : WithConv (H →ₐ[k] k)) :
+    conjugationHomeomorph g (kernelPrime h.ofConv) =
+      kernelPrime (g * h * g⁻¹).ofConv := by
+  rw [conjugationHomeomorph, Homeomorph.trans_apply,
+    leftTranslationHomeomorph_kernelPoint, rightTranslationPrimeHomeomorph_kernelPoint]
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem conjugationHomeomorph_image_identityComponent (g : WithConv (H →ₐ[k] k)) :
+    conjugationHomeomorph g ''
+        connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) =
+      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) := by
+  let z : PrimeSpectrum H := kernelPrime (_root_.Bialgebra.counitAlgHom k H)
+  have hz : (Bialgebra.augmentationPoint k H : PrimeSpectrum H) = z := by
+    apply PrimeSpectrum.ext
+    change (AlgHom.kernelPoint (_root_.Bialgebra.counitAlgHom k H)).asIdeal = z.asIdeal
+    rw [AlgHom.kernelPoint_asIdeal]
+    change RingHom.ker (_root_.Bialgebra.counitAlgHom k H : H →+* k) = z.asIdeal
+    dsimp only [z, kernelPrime]
+    rw [PrimeSpectrum.comap_asIdeal]
+    dsimp only [IsLocalRing.closedPoint]
+    rw [IsLocalRing.maximalIdeal_eq_bot]
+    rfl
+  rw [hz]
+  have himage : conjugationHomeomorph g '' connectedComponent z =
+      connectedComponent (conjugationHomeomorph g z) := by
+    simpa only [connectedComponentIn_univ,
+      Set.image_univ_of_surjective (conjugationHomeomorph g).surjective] using
+      (conjugationHomeomorph g).image_connectedComponentIn
+        (s := Set.univ) (x := z) (Set.mem_univ _)
+  have hfix : conjugationHomeomorph g z = z := by
+    dsimp only [z]
+    rw [conjugationHomeomorph_kernelPoint]
+    change kernelPrime (g * 1 * g⁻¹).ofConv =
+      kernelPrime (1 : WithConv (H →ₐ[k] k)).ofConv
+    simp
+  rw [himage, hfix]
+  rfl
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem kernelPoint_conj_mem_identityComponent
+    (g h : WithConv (H →ₐ[k] k))
+    (hh : kernelPrime h.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H)) :
+    kernelPrime (g * h * g⁻¹).ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) := by
+  rw [← conjugationHomeomorph_image_identityComponent g]
+  exact ⟨kernelPrime h.ofConv, hh, conjugationHomeomorph_kernelPoint g h⟩
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem kernelPoint_comp_componentQuotient_mem_identityComponent
+    [LocallyConnectedSpace (PrimeSpectrum H)]
+    (f : (H ⧸ PrimeSpectrum.connectedComponentIdeal
+      (Bialgebra.augmentationPoint k H)) →ₐ[k] k) :
+    kernelPrime
+        (f.comp (Ideal.Quotient.mkₐ k
+          (PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)))) ∈
+      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) := by
+  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  let y : PrimeSpectrum (H ⧸ PrimeSpectrum.connectedComponentIdeal z) :=
+    kernelPrime f
+  have hy := (PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent z y).property
+  rw [PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent_apply_coe] at hy
+  change PrimeSpectrum.comap
+      (Ideal.Quotient.mk (PrimeSpectrum.connectedComponentIdeal z)) (kernelPrime f) ∈
+    connectedComponent z at hy
+  rw [kernelPrime, ← PrimeSpectrum.comap_comp_apply] at hy
+  exact hy
+
+omit [IsAlgClosed k] [Algebra.FiniteType k H] in
+private theorem map_connectedComponentIdempotent_eq_one_of_mem
+    [LocallyConnectedSpace (PrimeSpectrum H)]
+    (g : WithConv (H →ₐ[k] k))
+    (hg : kernelPrime g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H)) :
+    g.ofConv
+        (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) = 1 := by
+  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  let p : PrimeSpectrum H := kernelPrime g.ofConv
+  have hpz : connectedComponent p = connectedComponent z := (connectedComponent_eq hg).symm
+  have he : PrimeSpectrum.connectedComponentIdempotent p =
+      PrimeSpectrum.connectedComponentIdempotent z := by
+    apply (PrimeSpectrum.eq_connectedComponentIdempotent_iff
+      (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p) z).mpr
+    rw [PrimeSpectrum.basicOpen_connectedComponentIdempotent]
+    exact hpz
+  rw [← he]
+  have hnot : PrimeSpectrum.connectedComponentIdempotent p ∉ p.asIdeal :=
+    PrimeSpectrum.connectedComponentIdempotent_notMem_asIdeal p
+  have hpker : p.asIdeal = RingHom.ker (g.ofConv : H →+* k) := by
+    change Ideal.comap (g.ofConv : H →+* k) (IsLocalRing.maximalIdeal k) =
+      RingHom.ker (g.ofConv : H →+* k)
+    rw [IsLocalRing.maximalIdeal_eq_bot]
+    rfl
+  rw [hpker, RingHom.mem_ker] at hnot
+  have hidem : IsIdempotentElem
+      (g.ofConv (PrimeSpectrum.connectedComponentIdempotent p)) :=
+    (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p).map g.ofConv.toRingHom
+  exact (IsIdempotentElem.iff_eq_zero_or_one.mp hidem).resolve_left hnot
+
+private theorem map_id_quotient_conjugation_componentIdempotent_eq_one
+    [LocallyConnectedSpace (PrimeSpectrum H)] :
+    let I := PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)
+    let q : H →ₐ[k] H ⧸ I := Ideal.Quotient.mkₐ k I
+    Algebra.TensorProduct.map (AlgHom.id k H) q
+        (conjugationAlgHom (R := k) (H := H)
+          (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H))) = 1 := by
+  dsimp only
+  let I := PrimeSpectrum.connectedComponentIdeal (Bialgebra.augmentationPoint k H)
+  let e := PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)
+  let Q := H ⧸ I
+  let q : H →ₐ[k] Q := Ideal.Quotient.mkₐ k I
+  let F : H ⊗[k] H →ₐ[k] H ⊗[k] Q :=
+    Algebra.TensorProduct.map (AlgHom.id k H) q
+  let _ : Algebra.FiniteType k (H ⊗[k] Q) :=
+    Algebra.FiniteType.trans (R := k) (S := H) (A := H ⊗[k] Q) inferInstance inferInstance
+  have ha_idem : IsIdempotentElem (F (conjugationAlgHom (R := k) (H := H) e)) :=
+    ((PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent
+      (Bialgebra.augmentationPoint k H)).map
+        (conjugationAlgHom (R := k) (H := H)).toRingHom).map F.toRingHom
+  apply _root_.eq_of_isNilpotent_sub_of_isIdempotentElem ha_idem IsIdempotentElem.one
+  rw [← forall_algHom_apply_eq_zero_iff_isNilpotent (k := k) (K := k)]
+  intro f
+  let g : WithConv (H →ₐ[k] k) :=
+    toConv (f.comp (Algebra.TensorProduct.includeLeft (R := k) (S := k) (A := H) (B := Q)))
+  let hQ : Q →ₐ[k] k :=
+    f.comp (Algebra.TensorProduct.includeRight (R := k) (A := H) (B := Q))
+  let h : WithConv (H →ₐ[k] k) := toConv (hQ.comp q)
+  have hh : kernelPrime h.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H : PrimeSpectrum H) := by
+    exact kernelPoint_comp_componentQuotient_mem_identityComponent hQ
+  have hconj := kernelPoint_conj_mem_identityComponent g h hh
+  have heval := map_connectedComponentIdempotent_eq_one_of_mem (g * h * g⁻¹) hconj
+  rw [map_sub, map_one, sub_eq_zero]
+  have hproduct : f.comp F =
+      Algebra.TensorProduct.productMap g.ofConv h.ofConv := by
+    apply Algebra.TensorProduct.ext'
+    intro a b
+    simp only [F, g, h, hQ, q, AlgHom.comp_apply, Algebra.TensorProduct.map_tmul,
+      AlgHom.id_apply, Algebra.TensorProduct.productMap_apply_tmul]
+    rw [← map_mul]
+    congr 1
+    simp
+  rw [← AlgHom.comp_apply, hproduct]
+  exact (AlgHom.congr_fun
+    (productMap_comp_conjugationAlgHom (R := k) (H := H) g h) e).trans heval
+
+/-- The Hopf ideal cutting out the identity component is normal: its coordinate ideal is stable
+under conjugation. Consequently it may be used in the normal fppf quotient construction. -/
+theorem identityComponentHopfIdeal_isNormal :
+    letI : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+    letI : LocallyConnectedSpace (PrimeSpectrum H) := inferInstance
+    (identityComponentHopfIdeal (k := k) (H := H)).IsNormal := by
+  let _ : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+  let _ : LocallyConnectedSpace (PrimeSpectrum H) := inferInstance
+  rw [HopfIdeal.isNormal_iff_conjugation_mem]
+  intro x hx
+  let z : PrimeSpectrum H := Bialgebra.augmentationPoint k H
+  let I := PrimeSpectrum.connectedComponentIdeal z
+  let e := PrimeSpectrum.connectedComponentIdempotent z
+  let Q := H ⧸ I
+  let q : H →ₐ[k] Q := Ideal.Quotient.mkₐ k I
+  let F : H ⊗[k] H →ₐ[k] H ⊗[k] Q :=
+    Algebra.TensorProduct.map (AlgHom.id k H) q
+  have hxI : x ∈ I := by
+    exact (mem_identityComponentHopfIdeal (k := k) (H := H)).mp hx
+  rw [identityComponentHopfIdeal_toIdeal]
+  change conjugationAlgHom (R := k) (H := H) x ∈
+    HopfIdeal.rightTensorIdeal (R := k) (H := H) I
+  obtain ⟨a, rfl⟩ :=
+    (PrimeSpectrum.mem_connectedComponentIdeal_iff (x := z) (r := x)).mp hxI
+  rw [map_mul]
+  apply Ideal.mul_mem_left
+  have hker : F (conjugationAlgHom (R := k) (H := H) (1 - e)) = 0 := by
+    rw [map_sub, map_one, map_sub, map_one]
+    change 1 - F (conjugationAlgHom (R := k) (H := H) e) = 0
+    rw [map_id_quotient_conjugation_componentIdempotent_eq_one, sub_self]
+  have hmem : conjugationAlgHom (R := k) (H := H) (1 - e) ∈ RingHom.ker F.toRingHom :=
+    RingHom.mem_ker.mpr hker
+  have hker_eq : RingHom.ker F.toRingHom =
+      HopfIdeal.rightTensorIdeal (R := k) (H := H) I := by
+    change RingHom.ker (Algebra.TensorProduct.map (AlgHom.id k H) q) = _
+    rw [HopfIdeal.ker_tensorProduct_map_id_quotient]
+  rw [hker_eq] at hmem
+  exact hmem
+
+end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -6,6 +6,8 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Connected.IdentityComponent
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.Translation
+public import TauCeti.Topology.ConnectedComponents
+import TauCeti.AlgebraicGeometry.AugmentationPoint.ConnectedComponent
 
 /-!
 # Translations of the identity component
@@ -18,6 +20,10 @@ and preserves its defining idempotent and ideal.
 
 * `rightTranslationHomeomorph_image_connectedComponent_augmentationPoint_eq_self`: a point in the
   identity component translates that component to itself.
+* `rightTranslationHomeomorph_kernelPoint`: right translation sends the kernel point of `g` to
+  the kernel point of the convolution product.
+* `map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem`: a point in the identity
+  component evaluates its component idempotent to one.
 * `map_rightTranslationAlgEquiv_connectedComponentIdeal_eq_self`: translation by an
   identity-component point fixes its defining ideal.
 
@@ -35,6 +41,7 @@ component, giving comultiplication closure of its defining ideal.
 public section
 
 open AlgebraicGeometry
+open scoped TensorProduct
 
 namespace TauCeti.HopfAlgebra
 
@@ -43,16 +50,39 @@ universe u v
 variable {k : Type u} [Field k]
 variable {H : Type v} [CommRing H] [_root_.HopfAlgebra k H]
 
+/-- Right translation sends the kernel point of `g` to the kernel point of the convolution
+product `g * h`. -/
+theorem rightTranslationHomeomorph_kernelPoint
+    (g h : WithConv (H →ₐ[k] k)) :
+    rightTranslationHomeomorph h (AlgHom.kernelPoint g.ofConv) =
+      AlgHom.kernelPoint (g * h).ofConv := by
+  rw [rightTranslationHomeomorph_apply]
+  -- `Spec (CommRingCat.of H)` has `PrimeSpectrum H` as its reducible carrier; expose that carrier
+  -- and the algebra-hom composition before applying the kernel-point API.
+  change PrimeSpectrum.comap
+      ((rightTranslationAlgEquiv h).toAlgHom : H →+* H)
+        (AlgHom.kernelPoint g.ofConv) = _
+  rw [AlgHom.comap_kernelPoint, rightTranslationAlgEquiv_toAlgHom]
+  congr 1
+  ext x
+  -- Composition of algebra homomorphisms must be exposed at application level before the
+  -- translation formula can rewrite it.
+  change g.ofConv (rightTranslationAlgHom h x) = (g * h).ofConv x
+  rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
+  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp [hx, hy]
+  | tmul x y =>
+      simp [TensorProduct.map_tmul, TensorProduct.rid_tmul,
+        Algebra.TensorProduct.lift_tmul, Algebra.smul_def, mul_comm]
+
 /-- Right translation transports the connected component of a point to the connected component
 of its translate. -/
 theorem rightTranslationHomeomorph_image_connectedComponent
     (g : WithConv (H →ₐ[k] k)) (x : Spec (CommRingCat.of H)) :
     rightTranslationHomeomorph g '' connectedComponent x =
       connectedComponent (rightTranslationHomeomorph g x) := by
-  simpa only [connectedComponentIn_univ,
-    Set.image_univ_of_surjective (rightTranslationHomeomorph g).surjective] using
-    (rightTranslationHomeomorph g).image_connectedComponentIn
-      (s := Set.univ) (x := x) (Set.mem_univ x)
+  exact TauCeti.Homeomorph.image_connectedComponent (rightTranslationHomeomorph g) x
 
 /-- A point in the identity component right-translates that component onto itself. -/
 theorem rightTranslationHomeomorph_image_connectedComponent_augmentationPoint_eq_self
@@ -90,6 +120,17 @@ theorem connectedComponentIdempotent_kernelPoint_eq_augmentationPoint
     (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent p) e).mpr
   rw [PrimeSpectrum.basicOpen_connectedComponentIdempotent]
   exact (connectedComponent_eq hg).symm
+
+/-- A rational point in the identity component evaluates the idempotent selecting that component
+to one. -/
+theorem map_connectedComponentIdempotent_augmentationPoint_eq_one_of_mem
+    (g : WithConv (H →ₐ[k] k))
+    (hg : AlgHom.kernelPoint g.ofConv ∈
+      connectedComponent (Bialgebra.augmentationPoint k H)) :
+    g.ofConv
+        (PrimeSpectrum.connectedComponentIdempotent (Bialgebra.augmentationPoint k H)) = 1 := by
+  rw [← connectedComponentIdempotent_kernelPoint_eq_augmentationPoint g hg]
+  exact AlgHom.map_connectedComponentIdempotent_kernelPoint_eq_one g.ofConv
 
 private theorem connectedComponentIdeal_kernelPoint_eq_augmentationPoint
     (g : WithConv (H →ₐ[k] k))

--- a/TauCeti/AlgebraicGeometry/AugmentationPoint/ConnectedComponent.lean
+++ b/TauCeti/AlgebraicGeometry/AugmentationPoint/ConnectedComponent.lean
@@ -21,6 +21,8 @@ component when the prime spectrum is locally connected.
   component idempotent of its kernel point to one.
 * `TauCeti.AlgHom.kernelPointConnectedComponentAlgHom`: the augmentation factored through the
   quotient cutting out the connected component of its kernel point.
+* `TauCeti.AlgHom.kernelPoint_comp_connectedComponentQuotient_mem`: a point of the component
+  quotient maps into the selected connected component.
 
 ## References
 
@@ -89,5 +91,27 @@ theorem kernelPointConnectedComponentAlgHom_mk (h : H) :
     kernelPointConnectedComponentAlgHom f
         (Ideal.Quotient.mk (PrimeSpectrum.connectedComponentIdeal (kernelPoint f)) h) = f h :=
   DFunLike.congr_fun (kernelPointConnectedComponentAlgHom_comp_mk f) h
+
+/-- A rational point of the quotient cutting out a connected component maps into that component
+under the quotient map. -/
+theorem kernelPoint_comp_connectedComponentQuotient_mem (z : PrimeSpectrum H)
+    (g : (H ⧸ PrimeSpectrum.connectedComponentIdeal z) →ₐ[k] k) :
+    kernelPoint
+        (g.comp (Ideal.Quotient.mkₐ k (PrimeSpectrum.connectedComponentIdeal z))) ∈
+      connectedComponent z := by
+  let y : PrimeSpectrum (H ⧸ PrimeSpectrum.connectedComponentIdeal z) := kernelPoint g
+  have hy := (PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent z y).property
+  rw [PrimeSpectrum.primeSpectrumQuotientHomeomorphConnectedComponent_apply_coe] at hy
+  dsimp only [y] at hy
+  have hcomap :
+      PrimeSpectrum.comap
+          (Ideal.Quotient.mk (PrimeSpectrum.connectedComponentIdeal z))
+          (kernelPoint g) =
+        kernelPoint
+          (g.comp (Ideal.Quotient.mkₐ k (PrimeSpectrum.connectedComponentIdeal z))) :=
+    AlgHom.comap_kernelPoint g
+      (Ideal.Quotient.mkₐ k (PrimeSpectrum.connectedComponentIdeal z))
+  rw [hcomap] at hy
+  exact hy
 
 end TauCeti.AlgHom

--- a/TauCeti/RingTheory/FiniteType/PointSeparation.lean
+++ b/TauCeti/RingTheory/FiniteType/PointSeparation.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
 public import Mathlib.RingTheory.Jacobson.Ring
+public import Mathlib.RingTheory.Idempotents
 
 /-!
 # Separation by algebraically closed points
@@ -29,6 +30,8 @@ that ideal is finite over `k` by Zariski's lemma and therefore embeds into `K`.
   some algebraically closed point.
 * `TauCeti.forall_algHom_apply_eq_zero_iff_isNilpotent`: the common kernel of all algebraically
   closed points is the nilradical.
+* `TauCeti.eq_one_of_isIdempotentElem_of_forall_algHom_apply_eq_one`: an idempotent evaluating to
+  one at every algebraically closed point is one.
 * `TauCeti.exists_algHom_apply_ne_of_ne`: points of a reduced finite-type algebra distinguish
   distinct elements.
 * `TauCeti.eq_of_forall_algHom_apply_eq`: the corresponding point-separation principle.
@@ -115,6 +118,16 @@ theorem forall_algHom_apply_eq_zero_iff_isNilpotent (x : A) :
     exact hf (h f)
   · intro hx f
     exact isNilpotent_iff_eq_zero.mp (hx.map f)
+
+/-- An idempotent in a finite-type algebra that evaluates to one at every algebraically closed
+point is one. -/
+theorem eq_one_of_isIdempotentElem_of_forall_algHom_apply_eq_one {a : A}
+    (ha : IsIdempotentElem a) (h : ∀ f : A →ₐ[k] K, f a = 1) : a = 1 := by
+  apply _root_.eq_of_isNilpotent_sub_of_isIdempotentElem ha IsIdempotentElem.one
+  rw [← forall_algHom_apply_eq_zero_iff_isNilpotent (k := k) (K := K)]
+  intro f
+  rw [map_sub, map_one, sub_eq_zero]
+  exact h f
 
 variable [IsReduced A]
 

--- a/TauCeti/Topology/ConnectedComponents.lean
+++ b/TauCeti/Topology/ConnectedComponents.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Topology.Connected.Clopen
 public import Mathlib.Topology.Irreducible
+import Mathlib.Topology.Homeomorph.Lemmas
 
 /-!
 # Connected components
@@ -15,6 +16,8 @@ components.
 
 ## Main declarations
 
+* `TauCeti.Homeomorph.image_connectedComponent`: a homeomorphism maps a connected component onto
+  the connected component of the image point.
 * `TauCeti.instT1SpaceConnectedComponents`: the connected-components quotient of any topological
   space is a T1 space.
 * `TauCeti.finite_connectedComponents_of_finite_irreducibleComponents`: finiteness of the
@@ -30,6 +33,13 @@ universe u
 variable {X : Type u} [TopologicalSpace X]
 
 namespace TauCeti
+
+/-- A homeomorphism maps a connected component onto the connected component of the image point. -/
+theorem Homeomorph.image_connectedComponent {Y : Type*} [TopologicalSpace Y]
+    (e : X ≃ₜ Y) (x : X) :
+    e '' connectedComponent x = connectedComponent (e x) := by
+  simpa only [connectedComponentIn_univ, Set.image_univ_of_surjective e.surjective] using
+    e.image_connectedComponentIn (s := Set.univ) (x := x) (Set.mem_univ x)
 
 /-- The quotient of a topological space by its connected components is a T1 space. -/
 instance instT1SpaceConnectedComponents : T1Space (ConnectedComponents X) :=


### PR DESCRIPTION
This PR proves that the Hopf ideal cutting out the identity component of an affine group scheme of finite type over an algebraically closed field is normal. It expresses conjugation on the prime spectrum through inversion and translation, proves that it preserves the counit component, and uses the affine Nullstellensatz on `H ⊗[k] (H / I)` to upgrade the pointwise result to stability under the adjoint coaction.

This advances the ReductiveGroups Layer 3 milestone, “Identity component `G°` and component group `π₀(G)`,” by supplying the normality prerequisite consumed by the normal fppf quotient construction. After this PR, constructing the component-group quotient and proving its finite-étale and geometric connectedness properties under the roadmap’s stated hypotheses remain.

The implementation builds on Tau Ceti’s existing connected-component idempotent, translation, Hopf-ideal normality, quotient, and finite-type point-separation APIs; the mathematical argument follows Milne, *Algebraic Groups*, Proposition 2.37, and Waterhouse, *Introduction to Affine Group Schemes*, Section 6.7.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"identity-component-normal"}-->

🤖 Prepared with Codex
