### PR TITLE
feat(DoubleCoset): the index map along which a coset sum regroups into an orbit sum

### DIFF
--- a/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
@@ -30,6 +30,8 @@ numbers, which is the group-theoretic half of the statement that the permutation
 
 * `TauCeti.doubleCosetEquivOrbitQuotient`: the bijection
   `H \ G / K ≃ ((G ⧸ H) × (G ⧸ K)) / G`.
+* `TauCeti.orbitOfCosetTranslate`: the `𝒢`-orbit a class in `ℋ ⧸ 𝒢.subgroupOf ℋ` translates a
+  point into — the index map along which a coset sum is regrouped into an orbit sum.
 
 ## Main statements
 
@@ -191,6 +193,33 @@ theorem orbitRel_smul_iff_mem_doubleCoset_stabilizer (K : Subgroup G) (p : α) (
   · rintro ⟨a, ha, b, hb, rfl⟩
     refine ⟨⟨a, ha⟩, ?_⟩
     rw [Subgroup.smul_def, mul_smul, mul_smul, mem_stabilizer_iff.mp (SetLike.mem_coe.mp hb)]
+
+/-- **The `𝒢`-orbit that a coset translates a point into.** For `𝒢 ≤ ℋ ≤ G` acting on `α` and a
+point `p`, a class in `ℋ ⧸ 𝒢.subgroupOf ℋ` determines the `𝒢`-orbit of `h⁻¹ • p`, independently
+of the representative `h`.
+
+Well-definedness is the content: another representative is `h * g` with `g ∈ 𝒢`, and
+`(h * g)⁻¹ • p = g⁻¹ • (h⁻¹ • p)` lies in the same `𝒢`-orbit. This is the index map along which
+a sum over the coset space `ℋ ⧸ 𝒢.subgroupOf ℋ` is regrouped into a sum over `𝒢`-orbits, with
+`orbitRel_smul_iff_mem_doubleCoset_stabilizer` identifying its fibres as double cosets. -/
+noncomputable def orbitOfCosetTranslate {𝒢 ℋ : Subgroup G} (p : α) (q : ℋ ⧸ 𝒢.subgroupOf ℋ) :
+    orbitRel.Quotient 𝒢 α :=
+  Quotient.liftOn' q (fun h ↦ Quotient.mk'' ((h : G)⁻¹ • p))
+    fun a b hab ↦ by
+      refine Quotient.sound' ?_
+      rw [orbitRel_apply, mem_orbit_iff]
+      exact ⟨⟨(a : G)⁻¹ * (b : G),
+        (Subgroup.mem_subgroupOf.mp (QuotientGroup.leftRel_apply.mp hab))⟩, by
+        simp [Subgroup.smul_def, mul_smul]⟩
+
+/-- Evaluating `orbitOfCosetTranslate` on the class of `h` gives the orbit of `h⁻¹ • p`. -/
+-- The two sides are the same term after `Quotient.liftOn'` reduces on a representative. The
+-- definition is deliberately not `@[expose]`d, so the parentheses in `(rfl)` keep the
+-- definitional step inside this module and leave this lemma as the whole interface for importers.
+@[simp]
+theorem orbitOfCosetTranslate_mk {𝒢 ℋ : Subgroup G} (p : α) (h : ℋ) :
+    orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = Quotient.mk'' ((h : G)⁻¹ • p) :=
+  (rfl)
 
 end GeneralAction
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"grouptheory-orbit-of-coset-translate"}-->

### What this adds

One definition and its evaluation lemma, in the `GeneralAction` section of
`GroupTheory/DoubleCoset/Orbits.lean`:

```lean
noncomputable def orbitOfCosetTranslate {𝒢 ℋ : Subgroup G} (p : α) (q : ℋ ⧸ 𝒢.subgroupOf ℋ) :
    orbitRel.Quotient 𝒢 α

@[simp] theorem orbitOfCosetTranslate_mk {𝒢 ℋ : Subgroup G} (p : α) (h : ℋ) :
    orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = Quotient.mk'' ((h : G)⁻¹ • p)
```

`+29/-0` in that one file.

For `𝒢 ≤ ℋ ≤ G` acting on any `G`-set, a class in `ℋ ⧸ 𝒢.subgroupOf ℋ` determines the `𝒢`-orbit
of `h⁻¹ • p`, independently of the representative `h`.

### What it asserts that nothing else does

**The content is the well-definedness.** A different representative is `h * g` with `g ∈ 𝒢`, and
`(h * g)⁻¹ • p = g⁻¹ • (h⁻¹ • p)` lies in the same `𝒢`-orbit — so the assignment descends to the
coset space. That is a fact about the two subgroups and the action; no existing declaration
states it, and it is not a restatement or specialisation of one.

It is placed beside `orbitRel_smul_iff_mem_doubleCoset_stabilizer` (merged in #3458), which
describes this map's **fibres**: two translates share a `𝒢`-orbit exactly when the translating
elements share a double coset. Index map and fibre description of one regrouping, in one section.

### Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, **Layer 1: the valence formula (general level)**
(line 292). Layer 1 reaches the general-level formula by applying the level-one valence formula to
the coset norm and distributing orders over the product, which turns a sum indexed by cosets of
`Γ` into a sum indexed by `Γ`-orbits. This is the index map that regrouping runs along.

The declaration is general group theory, so the attribution follows the precedent of #3458
(merged): `Roadmap: ModularForms` with a `grouptheory-`-prefixed target id, for general
group-theoretic material whose motivating roadmap is ModularForms.

### Stated plainly: no in-repository consumer yet

The consumer is the regrouping step itself, which is the next PR in this chain. I am not claiming
otherwise. What earns this its place now is the paragraph above — it asserts something no located
declaration states — rather than a use site.

One thing this deliberately does **not** carry: an accompanying multiplicity theorem. An earlier
attempt in this chain stated the double-coset size formula at a point as "the orbit weight", and a
`correctness` block showed it is vacuous exactly where it was meant to apply — a finite-index
`Γ ≤ SL(2, ℤ)` is infinite, so `Nat.card Γ = 0` and the identity reduces to `0 = 0`. The genuine
multiplicity is a **relative index** — a count of cosets, finite even when `Γ` is not — and it
belongs with the consumer that uses it. Nothing here makes a cardinality claim.

### Implementation note

The evaluation lemma is proved by `(rfl)`, not `rfl`. Everything in this file lives inside
`public section`, and an exported theorem cannot unfold an unexposed body — the parentheses keep
the definitional step inside the module, leaving the `@[simp]` lemma as the whole interface for
importers. This follows `Perm/FiberSubgroup.lean:131` rather than `@[expose]`
(`Presentation/Coxeter.lean:89`), which would enlarge the public surface for no gain, and `(rfl)`
already has precedent at line 163 of this same file.

### Verification

Measured on this head:

* `lake build` green — 8101 jobs, 0 error lines
* `lake exe axioms` — 50155 TauCeti declarations, all within the allowlist
  `[propext, Classical.choice, Quot.sound]`
* `lake exe module-system` — all 2383 TauCeti modules opt into the module system
* `LINT-ENV: PASS` — no new violations (67 grandfathered, 3 ratchetable)

Longest line 98 codepoints, measured with `wc -m`.
