### PR TITLE
feat: add orthogonal-sum signature laws

### DIFF
--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.LinearAlgebra.IntegralLattice.Even
 public import TauCeti.LinearAlgebra.IntegralLattice.Gram
 public import TauCeti.LinearAlgebra.IntegralLattice.Isometry
+public import TauCeti.LinearAlgebra.IntegralLattice.Signature
 import Mathlib.LinearAlgebra.Basis.Prod
 
 /-!
@@ -16,9 +17,8 @@ The orthogonal sum has product carrier and block-diagonal form. This file constr
 its canonical carrier maps and product bases, and proves several invariant laws: rank is additive,
 Gram matrices are block diagonal, determinant and discriminant are multiplicative, and evenness
 and nondegeneracy are componentwise. Orthogonal sums are functorial under lattice isometries and
-are associative and commutative up to canonical lattice isometry.
-
-Signature additivity remains to be developed with the signature API targeted by the same roadmap.
+are associative and commutative up to canonical lattice isometry. The radical is the product of
+the component radicals, and the signature is componentwise additive.
 
 ## Main definitions
 
@@ -26,6 +26,7 @@ Signature additivity remains to be developed with the signature API targeted by 
 * `TauCeti.IntegralLattice.orthogonalSum`: the orthogonal sum lattice.
 * `TauCeti.IntegralLattice.orthogonalSumCarrierEquiv`: the carrier-product equivalence.
 * `TauCeti.IntegralLattice.orthogonalSumBasis`: the product of two carrier bases.
+* `TauCeti.IntegralLattice.signature_orthogonalSum`: signature is additive componentwise.
 * `TauCeti.IntegralLattice.Isometry.orthogonalSum`: the product of two lattice isometries.
 * `TauCeti.IntegralLattice.Isometry.orthogonalSumComm`: the canonical commutativity isometry.
 * `TauCeti.IntegralLattice.Isometry.orthogonalSumAssoc`: the canonical associativity isometry.
@@ -336,6 +337,62 @@ theorem nondegenerate_orthogonalSum_iff (L : IntegralLattice V) (M : IntegralLat
     (L.orthogonalSum M).form.Nondegenerate ↔
       L.form.Nondegenerate ∧ M.form.Nondegenerate := by
   rw [orthogonalSum_form, nondegenerate_orthogonalSumForm_iff]
+
+/-! ## Radical and signature -/
+
+/-- The radical of an orthogonal sum is the product of the component radicals. -/
+@[simp]
+theorem radical_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
+    (L.orthogonalSum M).radical = L.radical.prod M.radical := by
+  have hform : (orthogonalSumForm L M).toQuadraticMap =
+      L.form.toQuadraticMap.prod M.form.toQuadraticMap := by
+    ext p
+    rfl
+  rw [← (L.orthogonalSum M).radical_toQuadraticMap, orthogonalSum_form, hform,
+    QuadraticMap.radical_prod, L.radical_toQuadraticMap, M.radical_toQuadraticMap]
+
+/-- The positive index of an orthogonal sum is the sum of the positive indices. -/
+@[simp]
+theorem sigPos_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
+    (L.orthogonalSum M).sigPos = L.sigPos + M.sigPos := by
+  let _ := L.finiteDimensional
+  let _ := M.finiteDimensional
+  have hform : (orthogonalSumForm L M).toQuadraticMap =
+      L.form.toQuadraticMap.prod M.form.toQuadraticMap := by
+    ext p
+    rfl
+  rw [sigPos, orthogonalSum_form, hform, TauCeti.QuadraticForm.sigPos_prod]
+
+/-- The negative index of an orthogonal sum is the sum of the negative indices. -/
+@[simp]
+theorem sigNeg_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
+    (L.orthogonalSum M).sigNeg = L.sigNeg + M.sigNeg := by
+  let _ := L.finiteDimensional
+  let _ := M.finiteDimensional
+  have hform : (orthogonalSumForm L M).toQuadraticMap =
+      L.form.toQuadraticMap.prod M.form.toQuadraticMap := by
+    ext p
+    rfl
+  rw [sigNeg, orthogonalSum_form, hform, TauCeti.QuadraticForm.sigNeg_prod]
+
+/-- The null index of an orthogonal sum is the sum of the null indices. -/
+@[simp]
+theorem sigNull_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
+    (L.orthogonalSum M).sigNull = L.sigNull + M.sigNull := by
+  let _ := L.finiteDimensional
+  let _ := M.finiteDimensional
+  have hsum := (L.orthogonalSum M).signature_sum_eq_finrank
+  have hsumL := L.signature_sum_eq_finrank
+  have hsumM := M.signature_sum_eq_finrank
+  rw [sigPos_orthogonalSum, sigNeg_orthogonalSum, Module.finrank_prod] at hsum
+  omega
+
+/-- The signature of an orthogonal sum is the componentwise sum of the two signatures. -/
+@[simp]
+theorem signature_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
+    (L.orthogonalSum M).signature =
+      (L.sigPos + M.sigPos, L.sigNull + M.sigNull, L.sigNeg + M.sigNeg) := by
+  simp only [signature, sigPos_orthogonalSum, sigNull_orthogonalSum, sigNeg_orthogonalSum]
 
 /-! ## Isometries of orthogonal sums -/
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -108,6 +108,13 @@ theorem orthogonalSum_form (L : IntegralLattice V) (M : IntegralLattice W) :
     (L.orthogonalSum M).form = orthogonalSumForm L M :=
   (rfl)
 
+/-- The quadratic map of the block-diagonal form is the product of the component quadratic maps. -/
+theorem orthogonalSumForm_toQuadraticMap (L : IntegralLattice V) (M : IntegralLattice W) :
+    (orthogonalSumForm L M).toQuadraticMap =
+      L.form.toQuadraticMap.prod M.form.toQuadraticMap := by
+  ext p
+  rfl
+
 /-- The carrier of an orthogonal sum is canonically the product of the carrier types. -/
 def orthogonalSumCarrierEquiv (L : IntegralLattice V) (M : IntegralLattice W) :
     L.orthogonalSum M ≃ₗ[ℤ] L × M :=
@@ -344,12 +351,9 @@ theorem nondegenerate_orthogonalSum_iff (L : IntegralLattice V) (M : IntegralLat
 @[simp]
 theorem radical_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
     (L.orthogonalSum M).radical = L.radical.prod M.radical := by
-  have hform : (orthogonalSumForm L M).toQuadraticMap =
-      L.form.toQuadraticMap.prod M.form.toQuadraticMap := by
-    ext p
-    rfl
-  rw [← (L.orthogonalSum M).radical_toQuadraticMap, orthogonalSum_form, hform,
-    QuadraticMap.radical_prod, L.radical_toQuadraticMap, M.radical_toQuadraticMap]
+  rw [← (L.orthogonalSum M).radical_toQuadraticMap, orthogonalSum_form,
+    orthogonalSumForm_toQuadraticMap, QuadraticMap.radical_prod, L.radical_toQuadraticMap,
+    M.radical_toQuadraticMap]
 
 /-- The positive index of an orthogonal sum is the sum of the positive indices. -/
 @[simp]
@@ -357,11 +361,8 @@ theorem sigPos_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
     (L.orthogonalSum M).sigPos = L.sigPos + M.sigPos := by
   let _ := L.finiteDimensional
   let _ := M.finiteDimensional
-  have hform : (orthogonalSumForm L M).toQuadraticMap =
-      L.form.toQuadraticMap.prod M.form.toQuadraticMap := by
-    ext p
-    rfl
-  rw [sigPos, orthogonalSum_form, hform, TauCeti.QuadraticForm.sigPos_prod]
+  rw [sigPos, orthogonalSum_form, orthogonalSumForm_toQuadraticMap,
+    TauCeti.QuadraticForm.sigPos_prod]
 
 /-- The negative index of an orthogonal sum is the sum of the negative indices. -/
 @[simp]
@@ -369,11 +370,8 @@ theorem sigNeg_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
     (L.orthogonalSum M).sigNeg = L.sigNeg + M.sigNeg := by
   let _ := L.finiteDimensional
   let _ := M.finiteDimensional
-  have hform : (orthogonalSumForm L M).toQuadraticMap =
-      L.form.toQuadraticMap.prod M.form.toQuadraticMap := by
-    ext p
-    rfl
-  rw [sigNeg, orthogonalSum_form, hform, TauCeti.QuadraticForm.sigNeg_prod]
+  rw [sigNeg, orthogonalSum_form, orthogonalSumForm_toQuadraticMap,
+    TauCeti.QuadraticForm.sigNeg_prod]
 
 /-- The null index of an orthogonal sum is the sum of the null indices. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -109,6 +109,7 @@ theorem orthogonalSum_form (L : IntegralLattice V) (M : IntegralLattice W) :
   (rfl)
 
 /-- The quadratic map of the block-diagonal form is the product of the component quadratic maps. -/
+@[simp]
 theorem orthogonalSumForm_toQuadraticMap (L : IntegralLattice V) (M : IntegralLattice W) :
     (orthogonalSumForm L M).toQuadraticMap =
       L.form.toQuadraticMap.prod M.form.toQuadraticMap := by

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -6,19 +6,22 @@ module
 
 public import Mathlib.Algebra.CharP.Invertible
 public import Mathlib.LinearAlgebra.BilinearForm.Properties
+public import Mathlib.LinearAlgebra.QuadraticForm.Prod
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 
 /-!
 # Radical API for quadratic forms
 
 This file records basic properties of the radical of a quadratic form (such as its invariance under
-negation) and general consequences of nondegeneracy, together with the two facts about the
+negation and orthogonal products) and general consequences of nondegeneracy, together with the two
+facts about the
 quadratic form `x ↦ B x x` of a *symmetric* bilinear form `B` that a Clifford construction consumes:
 its polar form is `2 • B`, and nondegeneracy passes from `B` to it as soon as `2` is invertible.
 
 ## Main results
 
 * `QuadraticMap.radical_neg`: negating a quadratic map does not change its radical.
+* `QuadraticMap.radical_prod`: the radical of an orthogonal product is the product of the radicals.
 * `QuadraticMap.Nondegenerate.ne_zero`: a nondegenerate quadratic form on a nontrivial module is
   nonzero.
 * `LinearMap.BilinMap.polarBilin_toQuadraticMap_of_flip`: the polar form of the quadratic form of a
@@ -41,6 +44,23 @@ variable {R M P : Type*} [CommRing R] [AddCommGroup M] [AddCommGroup P]
 theorem radical_neg (Q : QuadraticMap R M P) : (-Q).radical = Q.radical := by
   ext x
   simp only [QuadraticMap.mem_radical_iff', neg_apply, neg_eq_zero, neg_inj]
+
+variable {M' : Type*} [AddCommGroup M'] [Module R M']
+
+/-- The radical of an orthogonal product is the product of the two radicals when two is
+invertible. -/
+@[simp]
+theorem radical_prod [Invertible (2 : R)] (Q : QuadraticForm R M) (Q' : QuadraticForm R M') :
+    (Q.prod Q').radical = Q.radical.prod Q'.radical := by
+  rw [radical_eq_ker_polarBilin, radical_eq_ker_polarBilin, radical_eq_ker_polarBilin]
+  ext p
+  simp only [Submodule.mem_prod, LinearMap.mem_ker, LinearMap.ext_iff,
+    LinearMap.zero_apply]
+  constructor
+  · intro hp
+    exact ⟨fun x ↦ by simpa using hp (x, 0), fun x ↦ by simpa using hp (0, x)⟩
+  · rintro ⟨hp, hp'⟩ x
+    simpa using congrArg₂ (· + ·) (hp x.1) (hp' x.2)
 
 end QuadraticMap
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -50,7 +50,7 @@ variable {M' : Type*} [AddCommGroup M'] [Module R M']
 /-- The radical of an orthogonal product is the product of the two radicals when two is
 invertible. -/
 @[simp]
-theorem radical_prod [Invertible (2 : R)] (Q : QuadraticForm R M) (Q' : QuadraticForm R M') :
+theorem radical_prod [Invertible (2 : R)] (Q : QuadraticMap R M P) (Q' : QuadraticMap R M' P) :
     (Q.prod Q').radical = Q.radical.prod Q'.radical := by
   rw [radical_eq_ker_polarBilin, radical_eq_ker_polarBilin, radical_eq_ker_polarBilin]
   ext p

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -21,6 +21,7 @@ complement Mathlib's definitions of `QuadraticMap.PosDef`, `sigPos`, and `sigNeg
 It also proves that restriction to a subspace cannot increase either index of inertia, that
 quotienting a quadratic form by its radical preserves both indices, and that multiplication by a
 positive scalar preserves both indices while multiplication by a negative scalar exchanges them.
+Finally, both indices are additive under orthogonal products.
 
 ## Main results
 
@@ -40,6 +41,8 @@ positive scalar preserves both indices while multiplication by a negative scalar
   index of inertia.
 * `TauCeti.QuadraticForm.sigNeg_lift_radical`: quotienting by the radical preserves the negative
   index of inertia.
+* `TauCeti.QuadraticForm.sigPos_prod` and `TauCeti.QuadraticForm.sigNeg_prod`: the indices of
+  inertia are additive under orthogonal products.
 * `TauCeti.QuadraticForm.posDef_iff_sigNeg_eq_zero_and_radical_eq_bot`: positive-definiteness
   is characterized by vanishing negative index and trivial radical.
 
@@ -172,6 +175,91 @@ theorem sigNeg_restrict_le (Q : _root_.QuadraticForm K M) (W : Subspace K M) :
     ext x
     simp only [QuadraticMap.restrict_apply, neg_apply]
   simpa only [hneg, sigPos_neg] using sigPos_restrict_le (-Q) W
+
+section Prod
+
+variable {M' : Type*} [AddCommGroup M'] [Module K M'] [FiniteDimensional K M']
+
+/-- The product of two subspaces, as a subspace of the product ambient space, is linearly
+equivalent to the product of their underlying types. -/
+private def subspaceProdEquiv (U : Subspace K M) (W : Subspace K M') :
+    (U × W) ≃ₗ[K] U.prod W where
+  toFun p := ⟨(p.1, p.2), p.1.2, p.2.2⟩
+  invFun p := (⟨p.1.1, p.2.1⟩, ⟨p.1.2, p.2.2⟩)
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- The sum of the positive indices of two quadratic forms is a lower bound for the positive
+index of their orthogonal product. -/
+private theorem add_sigPos_le_sigPos_prod (Q : _root_.QuadraticForm K M)
+    (Q' : _root_.QuadraticForm K M') :
+    sigPos Q + sigPos Q' ≤ sigPos (Q.prod Q') := by
+  obtain ⟨U, hUrank, hUpos⟩ := exists_finrank_eq_sigPos_and_posDef Q
+  obtain ⟨W, hWrank, hWpos⟩ := exists_finrank_eq_sigPos_and_posDef Q'
+  have hprod : ((Q.prod Q').restrict (U.prod W)).PosDef := by
+    intro p hp
+    let u : U := ⟨p.1.1, p.2.1⟩
+    let w : W := ⟨p.1.2, p.2.2⟩
+    have hp' : u ≠ 0 ∨ w ≠ 0 := by
+      contrapose! hp
+      apply Subtype.ext
+      exact Prod.ext (congrArg Subtype.val hp.1) (congrArg Subtype.val hp.2)
+    rcases hp' with hp' | hp'
+    · have hpos := hUpos u hp'
+      have hnonneg := hWpos.nonneg w
+      simpa only [QuadraticMap.restrict_apply, QuadraticMap.prod_apply] using
+        add_pos_of_pos_of_nonneg hpos hnonneg
+    · have hnonneg := hUpos.nonneg u
+      have hpos := hWpos w hp'
+      simpa only [QuadraticMap.restrict_apply, QuadraticMap.prod_apply] using
+        add_pos_of_nonneg_of_pos hnonneg hpos
+  calc
+    sigPos Q + sigPos Q' = Module.finrank K U + Module.finrank K W := by
+      rw [hUrank, hWrank]
+    _ = Module.finrank K (U × W) := Module.finrank_prod.symm
+    _ = Module.finrank K (U.prod W) := LinearEquiv.finrank_eq (subspaceProdEquiv U W)
+    _ ≤ sigPos (Q.prod Q') := le_sigPos_of_posDef (Q := Q.prod Q') hprod
+
+/-- The sum of the negative indices of two quadratic forms is a lower bound for the negative
+index of their orthogonal product. -/
+private theorem add_sigNeg_le_sigNeg_prod (Q : _root_.QuadraticForm K M)
+    (Q' : _root_.QuadraticForm K M') :
+    sigNeg Q + sigNeg Q' ≤ sigNeg (Q.prod Q') := by
+  have hneg : (-Q).prod (-Q') = -(Q.prod Q') := by
+    ext p
+    simp only [QuadraticMap.prod_apply, neg_apply, neg_add]
+  simpa only [← sigPos_neg, hneg] using add_sigPos_le_sigPos_prod (-Q) (-Q')
+
+/-- The positive index of inertia is additive under orthogonal products. -/
+@[simp]
+theorem sigPos_prod (Q : _root_.QuadraticForm K M) (Q' : _root_.QuadraticForm K M') :
+    sigPos (Q.prod Q') = sigPos Q + sigPos Q' := by
+  have hpos := add_sigPos_le_sigPos_prod Q Q'
+  have hneg := add_sigNeg_le_sigNeg_prod Q Q'
+  have hsum := _root_.QuadraticForm.sigPos_add_sigNeg_add_radical (Q := Q.prod Q')
+  have hsumQ := _root_.QuadraticForm.sigPos_add_sigNeg_add_radical (Q := Q)
+  have hsumQ' := _root_.QuadraticForm.sigPos_add_sigNeg_add_radical (Q := Q')
+  have hrad : Module.finrank K (Q.prod Q').radical =
+      Module.finrank K Q.radical + Module.finrank K Q'.radical := by
+    let _ : Invertible (2 : K) := invertibleOfNonzero (by norm_num)
+    rw [QuadraticMap.radical_prod, ← LinearEquiv.finrank_eq
+      (subspaceProdEquiv Q.radical Q'.radical),
+      Module.finrank_prod]
+  rw [hrad, Module.finrank_prod] at hsum
+  omega
+
+/-- The negative index of inertia is additive under orthogonal products. -/
+@[simp]
+theorem sigNeg_prod (Q : _root_.QuadraticForm K M) (Q' : _root_.QuadraticForm K M') :
+    sigNeg (Q.prod Q') = sigNeg Q + sigNeg Q' := by
+  have hneg : (-Q).prod (-Q') = -(Q.prod Q') := by
+    ext p
+    simp only [QuadraticMap.prod_apply, neg_apply, neg_add]
+  rw [← sigPos_neg, ← hneg, sigPos_prod, sigPos_neg, sigPos_neg]
+
+end Prod
 
 end QuadraticForm
 


### PR DESCRIPTION
This PR proves the exact `TauCetiRoadmap/IntegralLattices/README.md` Layer 1 target requiring the radical and signature to be additive under orthogonal direct sums. Prove first at the natural quadratic-form level that the radical of `Q.prod Q'` is the product of the radicals and that `sigPos` and `sigNeg` add; then specialize these results to integral lattices to obtain `radical_orthogonalSum`, the three index formulas, and `signature_orthogonalSum`.

The preferred `CFSGStatement` roadmap has no viable unclaimed main-ready step: I0 and S1 are complete, `classificationStatement_of_zero` is in flight in #3058, RootSystems Layer 6 still waits on the open E7 datum #3461 before its uniform dispatcher, and the ReductiveGroups Layer 9 PBW/Kostant and root-subgroup fronts are occupied by #3053, #3061, and #3463. Starting CFSG L0 before those explicit dependencies land would violate the roadmap order, so this PR falls back to the independent IntegralLattices Layer 1 milestone “lattices with forms.”

This is the most effective current step because the orthogonal-sum construction, signature API, canonical isometries, and all other componentwise invariant laws are already merged, and those files explicitly leave only radical and signature additivity outstanding. After this PR, the orthogonal-sum portion of Layer 1 is complete; the broader layer still needs the remaining isometry-invariance laws for evenness, nondegeneracy, radicals, signatures, determinants, and discriminants.

Extend `TauCeti/LinearAlgebra/QuadraticForm/Radical.lean`, `TauCeti/LinearAlgebra/QuadraticForm/Signature.lean`, and `TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean` with 169 insertions and four deletions. Reuse Mathlib's product quadratic form and polarization, maximal positive-definite subspace API, Sylvester inertia identity, and finite-dimensional product formulas; no Mathlib implementation or external formalization is vendored. The mathematical conventions follow W. Ebeling, *Lattices and Codes*, Chapter 1, as already credited in the module documentation.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"orthogonal-sum-signature"}-->

🤖 Prepared with Codex
