### PR TITLE
feat: assemble pinned root data by Dynkin type

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
@@ -34,6 +34,7 @@ make this explicit data available without requiring downstream users to unfold t
 
 * `TauCeti.DynkinType.simplyConnectedRootDatum`: the pinned datum of a valid Dynkin type.
 * `TauCeti.DynkinType.simplyConnectedBase`: its Bourbaki-numbered base.
+* `TauCeti.DynkinType.simpleIndex`: the first `t.rank` root indices in Bourbaki order.
 
 ## Main results
 
@@ -41,6 +42,8 @@ make this explicit data available without requiring downstream users to unfold t
   indexing Dynkin type.
 * `TauCeti.DynkinType.span_coroot_simplyConnectedRootDatum`: its coroots span the cocharacter
   lattice.
+* `TauCeti.DynkinType.root_simpleIndex`, `coroot_simpleIndex`, and
+  `mem_support_simplyConnectedBase`: the entrywise pinning of the simple roots and base.
 
 ## References
 
@@ -146,23 +149,215 @@ root indices. -/
 @[simp] theorem simplyConnectedBase_G2 (ht : G2.Valid) :
     G2.simplyConnectedBase ht = g2SimplyConnectedBase := (rfl)
 
+/-! ## The uniform Bourbaki pinning -/
+
+/-- The index of the `i`-th Bourbaki simple root in the pinned root enumeration. -/
+@[expose] def simpleIndex (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) : Fin t.numRoots :=
+  Fin.castLE (rank_le_numRoots ht) i
+
+/-- The root enumeration index of a simple root has the same zero-based value as its node. -/
+@[simp] theorem simpleIndex_val (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) :
+    (t.simpleIndex ht i : ℕ) = i := (rfl)
+
+/-- The simple coroots of the pinned datum are the standard basis of the cocharacter lattice. -/
+@[simp] theorem coroot_simpleIndex (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) :
+    (t.simplyConnectedRootDatum ht).coroot (t.simpleIndex ht i) = Pi.single i 1 := by
+  cases t with
+  | A n =>
+    change Fin n at i
+    change (typeASimplyConnectedRootDatum n).coroot ((A n).simpleIndex ht i) = Pi.single i 1
+    have hi : (A n).simpleIndex ht i = typeASimpleIndex n i := by
+      apply Fin.ext
+      rw [typeASimpleIndex_val]
+      rfl
+    rw [hi, coroot_typeASimpleIndex]
+  | B n =>
+    change Fin n at i
+    change (typeBSimplyConnectedRootDatum n).coroot ((B n).simpleIndex ht i) = Pi.single i 1
+    have hi : (B n).simpleIndex ht i = typeBSimpleIndex n i := by
+      apply Fin.ext
+      rw [typeBSimpleIndex_val]
+      rfl
+    rw [hi, coroot_typeBSimpleIndex]
+  | C n =>
+    change Fin n at i
+    change (typeCSimplyConnectedRootDatum n).coroot ((C n).simpleIndex ht i) = Pi.single i 1
+    have hi : (C n).simpleIndex ht i = typeCSimpleIndex n i := by
+      apply Fin.ext
+      rw [typeCSimpleIndex_val]
+      rfl
+    rw [hi, coroot_typeCSimpleIndex]
+  | D n =>
+    change Fin n at i
+    change (typeDSimplyConnectedRootDatum n (valid_D.mp ht)).coroot
+      ((D n).simpleIndex ht i) = Pi.single i 1
+    have hi : (D n).simpleIndex ht i = typeDSimpleIndex n (valid_D.mp ht) i := by
+      apply Fin.ext
+      rw [typeDSimpleIndex_val]
+      rfl
+    rw [hi, coroot_typeDSimpleIndex]
+  | E6 =>
+    change Fin 6 at i
+    change e6SimplyConnectedRootDatum.coroot (E6.simpleIndex ht i) = Pi.single i 1
+    have hi : E6.simpleIndex ht i = e6SimpleIndex i := by
+      apply Fin.ext
+      rw [e6SimpleIndex_val]
+      rfl
+    rw [hi, e6SimplyConnectedRootDatum_coroot, coroot_e6SimpleIndex]
+  | E7 =>
+    change Fin 7 at i
+    change e7SimplyConnectedRootDatum.coroot (E7.simpleIndex ht i) = Pi.single i 1
+    have hi : E7.simpleIndex ht i = e7SimpleIndex i := by
+      apply Fin.ext
+      rw [e7SimpleIndex_val]
+      rfl
+    rw [hi, e7SimplyConnectedRootDatum_coroot, coroot_e7SimpleIndex]
+  | E8 =>
+    change Fin 8 at i
+    change e8SimplyConnectedRootDatum.coroot (E8.simpleIndex ht i) = Pi.single i 1
+    have hi : E8.simpleIndex ht i = e8SimpleIndex i := by
+      apply Fin.ext
+      rw [e8SimpleIndex_val]
+      rfl
+    rw [hi, e8SimplyConnectedRootDatum_coroot, coroot_e8SimpleIndex]
+  | F4 =>
+    change Fin 4 at i
+    change f4SimplyConnectedRootDatum.coroot (F4.simpleIndex ht i) = Pi.single i 1
+    have hi : F4.simpleIndex ht i = Fin.castAdd 44 i := Fin.ext rfl
+    rw [hi, f4SimplyConnectedRootDatum_coroot, f4Coroot_castAdd]
+  | G2 =>
+    change Fin 2 at i
+    change g2SimplyConnectedRootDatum.coroot (G2.simpleIndex ht i) = Pi.single i 1
+    have hi : G2.simpleIndex ht i = Fin.castAdd 10 i := Fin.ext rfl
+    rw [hi, g2SimplyConnectedRootDatum_coroot, g2Coroot_castAdd]
+
+/-- The simple roots of the pinned datum are the rows of its Bourbaki-numbered Cartan matrix. -/
+@[simp] theorem root_simpleIndex (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) :
+    (t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i) =
+      fun k => t.cartanMatrix i k := by
+  cases t with
+  | A n =>
+    change Fin n at i
+    rw [simplyConnectedRootDatum_A, cartanMatrix_A]
+    change (typeASimplyConnectedRootDatum n).root ((A n).simpleIndex ht i) =
+      fun k => CartanMatrix.A n i k
+    have hi : (A n).simpleIndex ht i = typeASimpleIndex n i := by
+      apply Fin.ext
+      rw [typeASimpleIndex_val]
+      rfl
+    rw [hi, root_typeASimpleIndex]
+  | B n =>
+    change Fin n at i
+    rw [simplyConnectedRootDatum_B, cartanMatrix_B]
+    change (typeBSimplyConnectedRootDatum n).root ((B n).simpleIndex ht i) =
+      fun k => CartanMatrix.B n i k
+    have hi : (B n).simpleIndex ht i = typeBSimpleIndex n i := by
+      apply Fin.ext
+      rw [typeBSimpleIndex_val]
+      rfl
+    rw [hi, root_typeBSimpleIndex]
+  | C n =>
+    change Fin n at i
+    rw [simplyConnectedRootDatum_C, cartanMatrix_C]
+    change (typeCSimplyConnectedRootDatum n).root ((C n).simpleIndex ht i) =
+      fun k => CartanMatrix.C n i k
+    have hi : (C n).simpleIndex ht i = typeCSimpleIndex n i := by
+      apply Fin.ext
+      rw [typeCSimpleIndex_val]
+      rfl
+    rw [hi, root_typeCSimpleIndex]
+  | D n =>
+    change Fin n at i
+    rw [simplyConnectedRootDatum_D, cartanMatrix_D]
+    change (typeDSimplyConnectedRootDatum n (valid_D.mp ht)).root
+      ((D n).simpleIndex ht i) = fun k => CartanMatrix.D n i k
+    have hi : (D n).simpleIndex ht i = typeDSimpleIndex n (valid_D.mp ht) i := by
+      apply Fin.ext
+      rw [typeDSimpleIndex_val]
+      rfl
+    rw [hi, root_typeDSimpleIndex]
+  | E6 =>
+    change Fin 6 at i
+    rw [simplyConnectedRootDatum_E6, cartanMatrix_E6]
+    change e6SimplyConnectedRootDatum.root (E6.simpleIndex ht i) = CartanMatrix.E₆ i
+    have hi : E6.simpleIndex ht i = e6SimpleIndex i := by
+      apply Fin.ext
+      rw [e6SimpleIndex_val]
+      rfl
+    rw [hi, e6SimplyConnectedRootDatum_root, root_e6SimpleIndex]
+  | E7 =>
+    change Fin 7 at i
+    rw [simplyConnectedRootDatum_E7, cartanMatrix_E7]
+    change e7SimplyConnectedRootDatum.root (E7.simpleIndex ht i) = CartanMatrix.E₇ i
+    have hi : E7.simpleIndex ht i = e7SimpleIndex i := by
+      apply Fin.ext
+      rw [e7SimpleIndex_val]
+      rfl
+    rw [hi, e7SimplyConnectedRootDatum_root, root_e7SimpleIndex]
+  | E8 =>
+    change Fin 8 at i
+    rw [simplyConnectedRootDatum_E8, cartanMatrix_E8]
+    change e8SimplyConnectedRootDatum.root (E8.simpleIndex ht i) = CartanMatrix.E₈ i
+    have hi : E8.simpleIndex ht i = e8SimpleIndex i := by
+      apply Fin.ext
+      rw [e8SimpleIndex_val]
+      rfl
+    rw [hi, e8SimplyConnectedRootDatum_root, root_e8SimpleIndex]
+  | F4 =>
+    change Fin 4 at i
+    rw [simplyConnectedRootDatum_F4, cartanMatrix_F4]
+    change f4SimplyConnectedRootDatum.root (F4.simpleIndex ht i) = CartanMatrix.F₄ i
+    have hi : F4.simpleIndex ht i = Fin.castAdd 44 i := Fin.ext rfl
+    rw [hi, f4SimplyConnectedRootDatum_root, f4Root_castAdd]
+  | G2 =>
+    change Fin 2 at i
+    rw [simplyConnectedRootDatum_G2, cartanMatrix_G2]
+    change g2SimplyConnectedRootDatum.root (G2.simpleIndex ht i) =
+      fun k => CartanMatrix.G₂.transpose i k
+    have hi : G2.simpleIndex ht i = Fin.castAdd 10 i := Fin.ext rfl
+    rw [hi, g2SimplyConnectedRootDatum_root, g2Root_castAdd]
+
+/-- The pinned base is supported exactly on the first `t.rank` root indices. -/
+@[simp] theorem mem_support_simplyConnectedBase (t : DynkinType) (ht : t.Valid)
+    {k : Fin t.numRoots} :
+    k ∈ (t.simplyConnectedBase ht).support ↔ (k : ℕ) < t.rank := by
+  cases t with
+  | A n => exact mem_typeASimplyConnectedBase_support
+  | B n => exact mem_typeBSimplyConnectedBase_support
+  | C n => exact mem_support_typeCSimplyConnectedBase
+  | D n => exact mem_typeDSimplyConnectedBase_support (valid_D.mp ht)
+  | E6 => exact mem_e6SimplyConnectedBase_support
+  | E7 => exact mem_support_e7SimplyConnectedBase
+  | E8 => exact mem_support_e8SimplyConnectedBase
+  | F4 =>
+    change Fin 48 at k
+    change k ∈ f4SimplyConnectedBase.support ↔ (k : ℕ) < 4
+    rw [f4SimplyConnectedBase_support]
+    exact mem_f4Support
+  | G2 =>
+    change Fin 12 at k
+    change k ∈ g2SimplyConnectedBase.support ↔ (k : ℕ) < 2
+    rw [g2SimplyConnectedBase_support]
+    simp only [Finset.mem_insert, Finset.mem_singleton]
+    omega
+
 /-! ## Uniform acceptance theorems -/
 
-/-- The pinned simply connected root datum realizes the Dynkin type that indexes it, against the
-same Bourbaki numbering. -/
+/-- The pinned datum has Cartan type `t`: its base Cartan matrix agrees with the standard one after
+a relabelling of the support. The entrywise Bourbaki pinning is given by `root_simpleIndex` and
+`coroot_simpleIndex`. -/
 theorem hasCartanType_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
-    ∃ _hcrys : (t.simplyConnectedRootDatum ht).IsCrystallographic,
-      HasCartanType (t.simplyConnectedRootDatum ht) (t.simplyConnectedBase ht) t := by
+    HasCartanType (t.simplyConnectedRootDatum ht) (t.simplyConnectedBase ht) t := by
   cases t with
-  | A n => exact ⟨inferInstance, hasCartanType_typeASimplyConnectedRootDatum n⟩
-  | B n => exact ⟨inferInstance, hasCartanType_typeBSimplyConnectedRootDatum n⟩
-  | C n => exact ⟨inferInstance, hasCartanType_typeCSimplyConnectedRootDatum n⟩
-  | D n => exact ⟨inferInstance, hasCartanType_typeDSimplyConnectedRootDatum n (valid_D.mp ht)⟩
-  | E6 => exact ⟨inferInstance, hasCartanType_e6SimplyConnectedRootDatum⟩
-  | E7 => exact ⟨inferInstance, hasCartanType_e7SimplyConnectedRootDatum⟩
-  | E8 => exact ⟨inferInstance, hasCartanType_e8SimplyConnectedRootDatum⟩
-  | F4 => exact ⟨inferInstance, hasCartanType_f4SimplyConnectedRootDatum⟩
-  | G2 => exact ⟨inferInstance, hasCartanType_g2SimplyConnectedRootDatum⟩
+  | A n => exact hasCartanType_typeASimplyConnectedRootDatum n
+  | B n => exact hasCartanType_typeBSimplyConnectedRootDatum n
+  | C n => exact hasCartanType_typeCSimplyConnectedRootDatum n
+  | D n => exact hasCartanType_typeDSimplyConnectedRootDatum n (valid_D.mp ht)
+  | E6 => exact hasCartanType_e6SimplyConnectedRootDatum
+  | E7 => exact hasCartanType_e7SimplyConnectedRootDatum
+  | E8 => exact hasCartanType_e8SimplyConnectedRootDatum
+  | F4 => exact hasCartanType_f4SimplyConnectedRootDatum
+  | G2 => exact hasCartanType_g2SimplyConnectedRootDatum
 
 /-- The coroots of the pinned datum span the cocharacter lattice. This is the simply connected
 lattice condition consumed by the pinned Chevalley--Demazure construction. -/
@@ -171,13 +366,17 @@ theorem span_coroot_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
   cases t with
   | A n => exact corootSpan_typeASimplyConnectedRootDatum_eq_top n
   | B n => exact corootSpan_typeBSimplyConnectedRootDatum_eq_top n
-  | C n => exact typeCSimplyConnectedRootDatum_corootSpan_eq_top n
+  | C n => exact corootSpan_typeCSimplyConnectedRootDatum_eq_top n
   | D n => exact corootSpan_typeDSimplyConnectedRootDatum_eq_top n (valid_D.mp ht)
   | E6 => exact corootSpan_e6SimplyConnectedRootDatum_eq_top
   | E7 => exact corootSpan_e7SimplyConnectedRootDatum_eq_top
   | E8 => exact corootSpan_e8SimplyConnectedRootDatum_eq_top
-  | F4 => exact corootSpan_f4SimplyConnectedRootDatum_eq_top
-  | G2 => exact corootSpan_g2SimplyConnectedRootDatum_eq_top
+  | F4 =>
+    exact simplyConnectedRootDatum_F4 ht ▸
+      RootPairing.IsRootSystem.span_coroot_eq_top (P := f4SimplyConnectedRootDatum)
+  | G2 =>
+    exact simplyConnectedRootDatum_G2 ht ▸
+      RootPairing.IsRootSystem.span_coroot_eq_top (P := g2SimplyConnectedRootDatum)
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
@@ -40,7 +40,7 @@ make this explicit data available without requiring downstream users to unfold t
 
 * `TauCeti.DynkinType.hasCartanType_simplyConnectedRootDatum`: the pinned datum realizes its
   indexing Dynkin type.
-* `TauCeti.DynkinType.corootSpan_simplyConnectedRootDatum_eq_top`: its coroots span the cocharacter
+* `TauCeti.DynkinType.span_coroot_simplyConnectedRootDatum`: its coroots span the cocharacter
   lattice.
 * `TauCeti.DynkinType.root_simpleIndex`, `coroot_simpleIndex`, and
   `mem_support_simplyConnectedBase`: the entrywise pinning of the simple roots and base.
@@ -405,7 +405,7 @@ theorem hasCartanType_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
 
 /-- The coroots of the pinned datum span the cocharacter lattice. This is the simply connected
 lattice condition consumed by the pinned Chevalley--Demazure construction. -/
-theorem corootSpan_simplyConnectedRootDatum_eq_top (t : DynkinType) (ht : t.Valid) :
+theorem span_coroot_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
     Submodule.span ℤ (Set.range (t.simplyConnectedRootDatum ht).coroot) = ⊤ := by
   cases t with
   | A n => exact corootSpan_typeASimplyConnectedRootDatum_eq_top n

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.NumberOfRoots
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.A
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.B.Datum
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.C.Datum
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.D
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E7.Datum
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E8.Datum
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.F4
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.G2
+
+public section
+
+/-!
+# The pinned simply connected root datum of a Dynkin type
+
+This file assembles the explicit simply connected root data for the nine irreducible
+crystallographic Dynkin families into one construction indexed by a valid
+`TauCeti.DynkinType`. Both lattices are `Fin t.rank → ℤ`: the character lattice uses the
+fundamental-weight basis and the cocharacter lattice uses the simple-coroot basis. Roots are
+indexed by `Fin t.numRoots`, with the first `t.rank` indices the Bourbaki-numbered simple roots.
+
+The construction dispatches directly to the coordinate data in the family modules imported
+above. It does not choose a root datum from a realization theorem. The branch equations below
+make this explicit data available without requiring downstream users to unfold the dispatcher.
+
+## Main definitions
+
+* `TauCeti.DynkinType.simplyConnectedRootDatum`: the pinned datum of a valid Dynkin type.
+* `TauCeti.DynkinType.simplyConnectedBase`: its Bourbaki-numbered base.
+
+## Main results
+
+* `TauCeti.DynkinType.hasCartanType_simplyConnectedRootDatum`: the pinned datum realizes its
+  indexing Dynkin type.
+* `TauCeti.DynkinType.span_coroot_simplyConnectedRootDatum`: its coroots span the cocharacter
+  lattice.
+
+## References
+
+The family data and numbering follow N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*,
+Plates I--IX, and J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*,
+Chapter 11. This assembles the target "a named datum per valid type" in Layer 6 of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md` for its consumer,
+`CFSGStatement` milestone L0.
+-/
+
+namespace TauCeti.DynkinType
+
+noncomputable section
+
+/-! ## The uniform pinned datum -/
+
+/-- The pinned simply connected root datum attached to a valid Dynkin type.
+
+This is a definition by cases into the nine explicit family data. The validity proof is used only
+by the type `D` construction, whose coordinate model requires `4 ≤ n`; the other family models are
+defined at every rank, while validity controls which of them enter the classification list. -/
+@[expose] def simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
+    RootDatum (Fin t.numRoots) (Fin t.rank → ℤ) (Fin t.rank → ℤ) :=
+  match t with
+  | .A n => typeASimplyConnectedRootDatum n
+  | .B n => typeBSimplyConnectedRootDatum n
+  | .C n => typeCSimplyConnectedRootDatum n
+  | .D n => typeDSimplyConnectedRootDatum n (valid_D.mp ht)
+  | .E6 => e6SimplyConnectedRootDatum
+  | .E7 => e7SimplyConnectedRootDatum
+  | .E8 => e8SimplyConnectedRootDatum
+  | .F4 => f4SimplyConnectedRootDatum
+  | .G2 => g2SimplyConnectedRootDatum
+
+/-- The Bourbaki-numbered base of `simplyConnectedRootDatum`, supported on its first `t.rank`
+root indices. -/
+@[expose] def simplyConnectedBase (t : DynkinType) (ht : t.Valid) :
+    (t.simplyConnectedRootDatum ht).Base :=
+  match t with
+  | .A n => typeASimplyConnectedBase n
+  | .B n => typeBSimplyConnectedBase n
+  | .C n => typeCSimplyConnectedBase n
+  | .D n => typeDSimplyConnectedBase n (valid_D.mp ht)
+  | .E6 => e6SimplyConnectedBase
+  | .E7 => e7SimplyConnectedBase
+  | .E8 => e8SimplyConnectedBase
+  | .F4 => f4SimplyConnectedBase
+  | .G2 => g2SimplyConnectedBase
+
+/-! ## Branch equations -/
+
+@[simp] theorem simplyConnectedRootDatum_A (n : ℕ) (ht : (A n).Valid) :
+    (A n).simplyConnectedRootDatum ht = typeASimplyConnectedRootDatum n := (rfl)
+
+@[simp] theorem simplyConnectedRootDatum_B (n : ℕ) (ht : (B n).Valid) :
+    (B n).simplyConnectedRootDatum ht = typeBSimplyConnectedRootDatum n := (rfl)
+
+@[simp] theorem simplyConnectedRootDatum_C (n : ℕ) (ht : (C n).Valid) :
+    (C n).simplyConnectedRootDatum ht = typeCSimplyConnectedRootDatum n := (rfl)
+
+@[simp] theorem simplyConnectedRootDatum_D (n : ℕ) (ht : (D n).Valid) :
+    (D n).simplyConnectedRootDatum ht = typeDSimplyConnectedRootDatum n (valid_D.mp ht) := (rfl)
+
+@[simp] theorem simplyConnectedRootDatum_E6 (ht : E6.Valid) :
+    E6.simplyConnectedRootDatum ht = e6SimplyConnectedRootDatum := (rfl)
+
+@[simp] theorem simplyConnectedRootDatum_E7 (ht : E7.Valid) :
+    E7.simplyConnectedRootDatum ht = e7SimplyConnectedRootDatum := (rfl)
+
+@[simp] theorem simplyConnectedRootDatum_E8 (ht : E8.Valid) :
+    E8.simplyConnectedRootDatum ht = e8SimplyConnectedRootDatum := (rfl)
+
+@[simp] theorem simplyConnectedRootDatum_F4 (ht : F4.Valid) :
+    F4.simplyConnectedRootDatum ht = f4SimplyConnectedRootDatum := (rfl)
+
+@[simp] theorem simplyConnectedRootDatum_G2 (ht : G2.Valid) :
+    G2.simplyConnectedRootDatum ht = g2SimplyConnectedRootDatum := (rfl)
+
+@[simp] theorem simplyConnectedBase_A (n : ℕ) (ht : (A n).Valid) :
+    (A n).simplyConnectedBase ht = typeASimplyConnectedBase n := (rfl)
+
+@[simp] theorem simplyConnectedBase_B (n : ℕ) (ht : (B n).Valid) :
+    (B n).simplyConnectedBase ht = typeBSimplyConnectedBase n := (rfl)
+
+@[simp] theorem simplyConnectedBase_C (n : ℕ) (ht : (C n).Valid) :
+    (C n).simplyConnectedBase ht = typeCSimplyConnectedBase n := (rfl)
+
+@[simp] theorem simplyConnectedBase_D (n : ℕ) (ht : (D n).Valid) :
+    (D n).simplyConnectedBase ht = typeDSimplyConnectedBase n (valid_D.mp ht) := (rfl)
+
+@[simp] theorem simplyConnectedBase_E6 (ht : E6.Valid) :
+    E6.simplyConnectedBase ht = e6SimplyConnectedBase := (rfl)
+
+@[simp] theorem simplyConnectedBase_E7 (ht : E7.Valid) :
+    E7.simplyConnectedBase ht = e7SimplyConnectedBase := (rfl)
+
+@[simp] theorem simplyConnectedBase_E8 (ht : E8.Valid) :
+    E8.simplyConnectedBase ht = e8SimplyConnectedBase := (rfl)
+
+@[simp] theorem simplyConnectedBase_F4 (ht : F4.Valid) :
+    F4.simplyConnectedBase ht = f4SimplyConnectedBase := (rfl)
+
+@[simp] theorem simplyConnectedBase_G2 (ht : G2.Valid) :
+    G2.simplyConnectedBase ht = g2SimplyConnectedBase := (rfl)
+
+/-! ## Uniform acceptance theorems -/
+
+/-- The pinned simply connected root datum realizes the Dynkin type that indexes it, against the
+same Bourbaki numbering. -/
+theorem hasCartanType_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
+    ∃ _hcrys : (t.simplyConnectedRootDatum ht).IsCrystallographic,
+      HasCartanType (t.simplyConnectedRootDatum ht) (t.simplyConnectedBase ht) t := by
+  cases t with
+  | A n => exact ⟨inferInstance, hasCartanType_typeASimplyConnectedRootDatum n⟩
+  | B n => exact ⟨inferInstance, hasCartanType_typeBSimplyConnectedRootDatum n⟩
+  | C n => exact ⟨inferInstance, hasCartanType_typeCSimplyConnectedRootDatum n⟩
+  | D n => exact ⟨inferInstance, hasCartanType_typeDSimplyConnectedRootDatum n (valid_D.mp ht)⟩
+  | E6 => exact ⟨inferInstance, hasCartanType_e6SimplyConnectedRootDatum⟩
+  | E7 => exact ⟨inferInstance, hasCartanType_e7SimplyConnectedRootDatum⟩
+  | E8 => exact ⟨inferInstance, hasCartanType_e8SimplyConnectedRootDatum⟩
+  | F4 => exact ⟨inferInstance, hasCartanType_f4SimplyConnectedRootDatum⟩
+  | G2 => exact ⟨inferInstance, hasCartanType_g2SimplyConnectedRootDatum⟩
+
+/-- The coroots of the pinned datum span the cocharacter lattice. This is the simply connected
+lattice condition consumed by the pinned Chevalley--Demazure construction. -/
+theorem span_coroot_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
+    Submodule.span ℤ (Set.range (t.simplyConnectedRootDatum ht).coroot) = ⊤ := by
+  cases t with
+  | A n => exact corootSpan_typeASimplyConnectedRootDatum_eq_top n
+  | B n => exact corootSpan_typeBSimplyConnectedRootDatum_eq_top n
+  | C n => exact typeCSimplyConnectedRootDatum_corootSpan_eq_top n
+  | D n => exact corootSpan_typeDSimplyConnectedRootDatum_eq_top n (valid_D.mp ht)
+  | E6 => exact corootSpan_e6SimplyConnectedRootDatum_eq_top
+  | E7 => exact corootSpan_e7SimplyConnectedRootDatum_eq_top
+  | E8 => exact corootSpan_e8SimplyConnectedRootDatum_eq_top
+  | F4 => exact corootSpan_f4SimplyConnectedRootDatum_eq_top
+  | G2 => exact corootSpan_g2SimplyConnectedRootDatum_eq_top
+
+end
+
+end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
@@ -40,7 +40,7 @@ make this explicit data available without requiring downstream users to unfold t
 
 * `TauCeti.DynkinType.hasCartanType_simplyConnectedRootDatum`: the pinned datum realizes its
   indexing Dynkin type.
-* `TauCeti.DynkinType.span_coroot_simplyConnectedRootDatum`: its coroots span the cocharacter
+* `TauCeti.DynkinType.corootSpan_simplyConnectedRootDatum_eq_top`: its coroots span the cocharacter
   lattice.
 * `TauCeti.DynkinType.root_simpleIndex`, `coroot_simpleIndex`, and
   `mem_support_simplyConnectedBase`: the entrywise pinning of the simple roots and base.
@@ -65,7 +65,7 @@ noncomputable section
 This is a definition by cases into the nine explicit family data. The validity proof is used only
 by the type `D` construction, whose coordinate model requires `4 ≤ n`; the other family models are
 defined at every rank, while validity controls which of them enter the classification list. -/
-@[expose] def simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
+def simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
     RootDatum (Fin t.numRoots) (Fin t.rank → ℤ) (Fin t.rank → ℤ) :=
   match t with
   | .A n => typeASimplyConnectedRootDatum n
@@ -80,7 +80,7 @@ defined at every rank, while validity controls which of them enter the classific
 
 /-- The Bourbaki-numbered base of `simplyConnectedRootDatum`, supported on its first `t.rank`
 root indices. -/
-@[expose] def simplyConnectedBase (t : DynkinType) (ht : t.Valid) :
+def simplyConnectedBase (t : DynkinType) (ht : t.Valid) :
     (t.simplyConnectedRootDatum ht).Base :=
   match t with
   | .A n => typeASimplyConnectedBase n
@@ -122,200 +122,241 @@ root indices. -/
 @[simp] theorem simplyConnectedRootDatum_G2 (ht : G2.Valid) :
     G2.simplyConnectedRootDatum ht = g2SimplyConnectedRootDatum := (rfl)
 
+-- A base is indexed by its datum, so each base equation explicitly transports along the
+-- corresponding datum equation instead of exposing either dispatcher's implementation.
 @[simp] theorem simplyConnectedBase_A (n : ℕ) (ht : (A n).Valid) :
-    (A n).simplyConnectedBase ht = typeASimplyConnectedBase n := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_A n ht))
+      ((A n).simplyConnectedBase ht) = typeASimplyConnectedBase n := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 @[simp] theorem simplyConnectedBase_B (n : ℕ) (ht : (B n).Valid) :
-    (B n).simplyConnectedBase ht = typeBSimplyConnectedBase n := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_B n ht))
+      ((B n).simplyConnectedBase ht) = typeBSimplyConnectedBase n := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 @[simp] theorem simplyConnectedBase_C (n : ℕ) (ht : (C n).Valid) :
-    (C n).simplyConnectedBase ht = typeCSimplyConnectedBase n := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_C n ht))
+      ((C n).simplyConnectedBase ht) = typeCSimplyConnectedBase n := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 @[simp] theorem simplyConnectedBase_D (n : ℕ) (ht : (D n).Valid) :
-    (D n).simplyConnectedBase ht = typeDSimplyConnectedBase n (valid_D.mp ht) := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_D n ht))
+      ((D n).simplyConnectedBase ht) =
+        typeDSimplyConnectedBase n (valid_D.mp ht) := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 @[simp] theorem simplyConnectedBase_E6 (ht : E6.Valid) :
-    E6.simplyConnectedBase ht = e6SimplyConnectedBase := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_E6 ht))
+      (E6.simplyConnectedBase ht) = e6SimplyConnectedBase := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 @[simp] theorem simplyConnectedBase_E7 (ht : E7.Valid) :
-    E7.simplyConnectedBase ht = e7SimplyConnectedBase := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_E7 ht))
+      (E7.simplyConnectedBase ht) = e7SimplyConnectedBase := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 @[simp] theorem simplyConnectedBase_E8 (ht : E8.Valid) :
-    E8.simplyConnectedBase ht = e8SimplyConnectedBase := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_E8 ht))
+      (E8.simplyConnectedBase ht) = e8SimplyConnectedBase := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 @[simp] theorem simplyConnectedBase_F4 (ht : F4.Valid) :
-    F4.simplyConnectedBase ht = f4SimplyConnectedBase := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_F4 ht))
+      (F4.simplyConnectedBase ht) = f4SimplyConnectedBase := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 @[simp] theorem simplyConnectedBase_G2 (ht : G2.Valid) :
-    G2.simplyConnectedBase ht = g2SimplyConnectedBase := (rfl)
+    Eq.mp (congrArg (fun P => P.Base) (simplyConnectedRootDatum_G2 ht))
+      (G2.simplyConnectedBase ht) = g2SimplyConnectedBase := by
+  apply eq_of_heq
+  simp only [simplyConnectedBase, simplyConnectedRootDatum]
+  exact HEq.rfl
 
 /-! ## The uniform Bourbaki pinning -/
 
 /-- The index of the `i`-th Bourbaki simple root in the pinned root enumeration. -/
-@[expose] def simpleIndex (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) : Fin t.numRoots :=
+def simpleIndex (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) : Fin t.numRoots :=
   Fin.castLE (rank_le_numRoots ht) i
 
 /-- The root enumeration index of a simple root has the same zero-based value as its node. -/
 @[simp] theorem simpleIndex_val (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) :
     (t.simpleIndex ht i : ℕ) = i := (rfl)
 
+private theorem simpleIndex_A (n : ℕ) (ht : (A n).Valid) (i : Fin n) :
+    (A n).simpleIndex ht i = typeASimpleIndex n i := by
+  apply Fin.ext
+  rw [typeASimpleIndex_val]
+  exact simpleIndex_val (A n) ht i
+
+private theorem simpleIndex_B (n : ℕ) (ht : (B n).Valid) (i : Fin n) :
+    (B n).simpleIndex ht i = typeBSimpleIndex n i := by
+  apply Fin.ext
+  rw [typeBSimpleIndex_val]
+  exact simpleIndex_val (B n) ht i
+
+private theorem simpleIndex_C (n : ℕ) (ht : (C n).Valid) (i : Fin n) :
+    (C n).simpleIndex ht i = typeCSimpleIndex n i := by
+  apply Fin.ext
+  rw [typeCSimpleIndex_val]
+  exact simpleIndex_val (C n) ht i
+
+private theorem simpleIndex_D (n : ℕ) (ht : (D n).Valid) (i : Fin n) :
+    (D n).simpleIndex ht i = typeDSimpleIndex n (valid_D.mp ht) i := by
+  apply Fin.ext
+  rw [typeDSimpleIndex_val]
+  exact simpleIndex_val (D n) ht i
+
+private theorem simpleIndex_E6 (ht : E6.Valid) (i : Fin 6) :
+    E6.simpleIndex ht i = e6SimpleIndex i := by
+  apply Fin.ext
+  rw [e6SimpleIndex_val]
+  exact simpleIndex_val E6 ht i
+
+private theorem simpleIndex_E7 (ht : E7.Valid) (i : Fin 7) :
+    E7.simpleIndex ht i = e7SimpleIndex i := by
+  apply Fin.ext
+  rw [e7SimpleIndex_val]
+  exact simpleIndex_val E7 ht i
+
+private theorem simpleIndex_E8 (ht : E8.Valid) (i : Fin 8) :
+    E8.simpleIndex ht i = e8SimpleIndex i := by
+  apply Fin.ext
+  rw [e8SimpleIndex_val]
+  exact simpleIndex_val E8 ht i
+
+private theorem simpleIndex_F4 (ht : F4.Valid) (i : Fin 4) :
+    F4.simpleIndex ht i = Fin.castAdd 44 i := Fin.ext rfl
+
+private theorem simpleIndex_G2 (ht : G2.Valid) (i : Fin 2) :
+    G2.simpleIndex ht i = Fin.castAdd 10 i := Fin.ext rfl
+
 /-- The simple coroots of the pinned datum are the standard basis of the cocharacter lattice. -/
 @[simp] theorem coroot_simpleIndex (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) :
     (t.simplyConnectedRootDatum ht).coroot (t.simpleIndex ht i) = Pi.single i 1 := by
+  -- Case splitting refines `rank`, but Lean retains `i` in the dependent motive. Each first
+  -- `change` records the resulting concrete index type; the dispatcher itself is rewritten by its
+  -- public branch equation.
   cases t with
   | A n =>
     change Fin n at i
-    change (typeASimplyConnectedRootDatum n).coroot ((A n).simpleIndex ht i) = Pi.single i 1
-    have hi : (A n).simpleIndex ht i = typeASimpleIndex n i := by
-      apply Fin.ext
-      rw [typeASimpleIndex_val]
-      rfl
-    rw [hi, coroot_typeASimpleIndex]
+    rw [simplyConnectedRootDatum_A, simpleIndex_A]
+    change (typeASimplyConnectedRootDatum n).coroot (typeASimpleIndex n i) = Pi.single i 1
+    rw [coroot_typeASimpleIndex]
   | B n =>
     change Fin n at i
-    change (typeBSimplyConnectedRootDatum n).coroot ((B n).simpleIndex ht i) = Pi.single i 1
-    have hi : (B n).simpleIndex ht i = typeBSimpleIndex n i := by
-      apply Fin.ext
-      rw [typeBSimpleIndex_val]
-      rfl
-    rw [hi, coroot_typeBSimpleIndex]
+    rw [simplyConnectedRootDatum_B, simpleIndex_B]
+    change (typeBSimplyConnectedRootDatum n).coroot (typeBSimpleIndex n i) = Pi.single i 1
+    rw [coroot_typeBSimpleIndex]
   | C n =>
     change Fin n at i
-    change (typeCSimplyConnectedRootDatum n).coroot ((C n).simpleIndex ht i) = Pi.single i 1
-    have hi : (C n).simpleIndex ht i = typeCSimpleIndex n i := by
-      apply Fin.ext
-      rw [typeCSimpleIndex_val]
-      rfl
-    rw [hi, coroot_typeCSimpleIndex]
+    rw [simplyConnectedRootDatum_C, simpleIndex_C]
+    change (typeCSimplyConnectedRootDatum n).coroot (typeCSimpleIndex n i) = Pi.single i 1
+    rw [coroot_typeCSimpleIndex]
   | D n =>
     change Fin n at i
+    rw [simplyConnectedRootDatum_D, simpleIndex_D]
     change (typeDSimplyConnectedRootDatum n (valid_D.mp ht)).coroot
-      ((D n).simpleIndex ht i) = Pi.single i 1
-    have hi : (D n).simpleIndex ht i = typeDSimpleIndex n (valid_D.mp ht) i := by
-      apply Fin.ext
-      rw [typeDSimpleIndex_val]
-      rfl
-    rw [hi, coroot_typeDSimpleIndex]
+      (typeDSimpleIndex n (valid_D.mp ht) i) = Pi.single i 1
+    rw [coroot_typeDSimpleIndex]
   | E6 =>
     change Fin 6 at i
-    change e6SimplyConnectedRootDatum.coroot (E6.simpleIndex ht i) = Pi.single i 1
-    have hi : E6.simpleIndex ht i = e6SimpleIndex i := by
-      apply Fin.ext
-      rw [e6SimpleIndex_val]
-      rfl
-    rw [hi, e6SimplyConnectedRootDatum_coroot, coroot_e6SimpleIndex]
+    rw [simplyConnectedRootDatum_E6, simpleIndex_E6]
+    change e6SimplyConnectedRootDatum.coroot (e6SimpleIndex i) = Pi.single i 1
+    rw [e6SimplyConnectedRootDatum_coroot, coroot_e6SimpleIndex]
   | E7 =>
     change Fin 7 at i
-    change e7SimplyConnectedRootDatum.coroot (E7.simpleIndex ht i) = Pi.single i 1
-    have hi : E7.simpleIndex ht i = e7SimpleIndex i := by
-      apply Fin.ext
-      rw [e7SimpleIndex_val]
-      rfl
-    rw [hi, e7SimplyConnectedRootDatum_coroot, coroot_e7SimpleIndex]
+    rw [simplyConnectedRootDatum_E7, simpleIndex_E7]
+    change e7SimplyConnectedRootDatum.coroot (e7SimpleIndex i) = Pi.single i 1
+    rw [e7SimplyConnectedRootDatum_coroot, coroot_e7SimpleIndex]
   | E8 =>
     change Fin 8 at i
-    change e8SimplyConnectedRootDatum.coroot (E8.simpleIndex ht i) = Pi.single i 1
-    have hi : E8.simpleIndex ht i = e8SimpleIndex i := by
-      apply Fin.ext
-      rw [e8SimpleIndex_val]
-      rfl
-    rw [hi, e8SimplyConnectedRootDatum_coroot, coroot_e8SimpleIndex]
+    rw [simplyConnectedRootDatum_E8, simpleIndex_E8]
+    change e8SimplyConnectedRootDatum.coroot (e8SimpleIndex i) = Pi.single i 1
+    rw [e8SimplyConnectedRootDatum_coroot, coroot_e8SimpleIndex]
   | F4 =>
     change Fin 4 at i
-    change f4SimplyConnectedRootDatum.coroot (F4.simpleIndex ht i) = Pi.single i 1
-    have hi : F4.simpleIndex ht i = Fin.castAdd 44 i := Fin.ext rfl
-    rw [hi, f4SimplyConnectedRootDatum_coroot, f4Coroot_castAdd]
+    rw [simplyConnectedRootDatum_F4, simpleIndex_F4]
+    change f4SimplyConnectedRootDatum.coroot (Fin.castAdd 44 i) = Pi.single i 1
+    rw [f4SimplyConnectedRootDatum_coroot, f4Coroot_castAdd]
   | G2 =>
     change Fin 2 at i
-    change g2SimplyConnectedRootDatum.coroot (G2.simpleIndex ht i) = Pi.single i 1
-    have hi : G2.simpleIndex ht i = Fin.castAdd 10 i := Fin.ext rfl
-    rw [hi, g2SimplyConnectedRootDatum_coroot, g2Coroot_castAdd]
+    rw [simplyConnectedRootDatum_G2, simpleIndex_G2]
+    change g2SimplyConnectedRootDatum.coroot (Fin.castAdd 10 i) = Pi.single i 1
+    rw [g2SimplyConnectedRootDatum_coroot, g2Coroot_castAdd]
 
 /-- The simple roots of the pinned datum are the rows of its Bourbaki-numbered Cartan matrix. -/
 @[simp] theorem root_simpleIndex (t : DynkinType) (ht : t.Valid) (i : Fin t.rank) :
     (t.simplyConnectedRootDatum ht).root (t.simpleIndex ht i) =
       fun k => t.cartanMatrix i k := by
+  -- As above, these type annotations expose the concrete rank carried by the dependent motive;
+  -- all substantive reductions use named branch and family equations.
   cases t with
   | A n =>
     change Fin n at i
-    rw [simplyConnectedRootDatum_A, cartanMatrix_A]
-    change (typeASimplyConnectedRootDatum n).root ((A n).simpleIndex ht i) =
+    rw [simplyConnectedRootDatum_A, simpleIndex_A, cartanMatrix_A]
+    change (typeASimplyConnectedRootDatum n).root (typeASimpleIndex n i) =
       fun k => CartanMatrix.A n i k
-    have hi : (A n).simpleIndex ht i = typeASimpleIndex n i := by
-      apply Fin.ext
-      rw [typeASimpleIndex_val]
-      rfl
-    rw [hi, root_typeASimpleIndex]
+    rw [root_typeASimpleIndex]
   | B n =>
     change Fin n at i
-    rw [simplyConnectedRootDatum_B, cartanMatrix_B]
-    change (typeBSimplyConnectedRootDatum n).root ((B n).simpleIndex ht i) =
+    rw [simplyConnectedRootDatum_B, simpleIndex_B, cartanMatrix_B]
+    change (typeBSimplyConnectedRootDatum n).root (typeBSimpleIndex n i) =
       fun k => CartanMatrix.B n i k
-    have hi : (B n).simpleIndex ht i = typeBSimpleIndex n i := by
-      apply Fin.ext
-      rw [typeBSimpleIndex_val]
-      rfl
-    rw [hi, root_typeBSimpleIndex]
+    rw [root_typeBSimpleIndex]
   | C n =>
     change Fin n at i
-    rw [simplyConnectedRootDatum_C, cartanMatrix_C]
-    change (typeCSimplyConnectedRootDatum n).root ((C n).simpleIndex ht i) =
+    rw [simplyConnectedRootDatum_C, simpleIndex_C, cartanMatrix_C]
+    change (typeCSimplyConnectedRootDatum n).root (typeCSimpleIndex n i) =
       fun k => CartanMatrix.C n i k
-    have hi : (C n).simpleIndex ht i = typeCSimpleIndex n i := by
-      apply Fin.ext
-      rw [typeCSimpleIndex_val]
-      rfl
-    rw [hi, root_typeCSimpleIndex]
+    rw [root_typeCSimpleIndex]
   | D n =>
     change Fin n at i
-    rw [simplyConnectedRootDatum_D, cartanMatrix_D]
+    rw [simplyConnectedRootDatum_D, simpleIndex_D, cartanMatrix_D]
     change (typeDSimplyConnectedRootDatum n (valid_D.mp ht)).root
-      ((D n).simpleIndex ht i) = fun k => CartanMatrix.D n i k
-    have hi : (D n).simpleIndex ht i = typeDSimpleIndex n (valid_D.mp ht) i := by
-      apply Fin.ext
-      rw [typeDSimpleIndex_val]
-      rfl
-    rw [hi, root_typeDSimpleIndex]
+      (typeDSimpleIndex n (valid_D.mp ht) i) = fun k => CartanMatrix.D n i k
+    rw [root_typeDSimpleIndex]
   | E6 =>
     change Fin 6 at i
-    rw [simplyConnectedRootDatum_E6, cartanMatrix_E6]
-    change e6SimplyConnectedRootDatum.root (E6.simpleIndex ht i) = CartanMatrix.E₆ i
-    have hi : E6.simpleIndex ht i = e6SimpleIndex i := by
-      apply Fin.ext
-      rw [e6SimpleIndex_val]
-      rfl
-    rw [hi, e6SimplyConnectedRootDatum_root, root_e6SimpleIndex]
+    rw [simplyConnectedRootDatum_E6, simpleIndex_E6, cartanMatrix_E6]
+    change e6SimplyConnectedRootDatum.root (e6SimpleIndex i) = CartanMatrix.E₆ i
+    rw [e6SimplyConnectedRootDatum_root, root_e6SimpleIndex]
   | E7 =>
     change Fin 7 at i
-    rw [simplyConnectedRootDatum_E7, cartanMatrix_E7]
-    change e7SimplyConnectedRootDatum.root (E7.simpleIndex ht i) = CartanMatrix.E₇ i
-    have hi : E7.simpleIndex ht i = e7SimpleIndex i := by
-      apply Fin.ext
-      rw [e7SimpleIndex_val]
-      rfl
-    rw [hi, e7SimplyConnectedRootDatum_root, root_e7SimpleIndex]
+    rw [simplyConnectedRootDatum_E7, simpleIndex_E7, cartanMatrix_E7]
+    change e7SimplyConnectedRootDatum.root (e7SimpleIndex i) = CartanMatrix.E₇ i
+    rw [e7SimplyConnectedRootDatum_root, root_e7SimpleIndex]
   | E8 =>
     change Fin 8 at i
-    rw [simplyConnectedRootDatum_E8, cartanMatrix_E8]
-    change e8SimplyConnectedRootDatum.root (E8.simpleIndex ht i) = CartanMatrix.E₈ i
-    have hi : E8.simpleIndex ht i = e8SimpleIndex i := by
-      apply Fin.ext
-      rw [e8SimpleIndex_val]
-      rfl
-    rw [hi, e8SimplyConnectedRootDatum_root, root_e8SimpleIndex]
+    rw [simplyConnectedRootDatum_E8, simpleIndex_E8, cartanMatrix_E8]
+    change e8SimplyConnectedRootDatum.root (e8SimpleIndex i) = CartanMatrix.E₈ i
+    rw [e8SimplyConnectedRootDatum_root, root_e8SimpleIndex]
   | F4 =>
     change Fin 4 at i
-    rw [simplyConnectedRootDatum_F4, cartanMatrix_F4]
-    change f4SimplyConnectedRootDatum.root (F4.simpleIndex ht i) = CartanMatrix.F₄ i
-    have hi : F4.simpleIndex ht i = Fin.castAdd 44 i := Fin.ext rfl
-    rw [hi, f4SimplyConnectedRootDatum_root, f4Root_castAdd]
+    rw [simplyConnectedRootDatum_F4, simpleIndex_F4, cartanMatrix_F4]
+    change f4SimplyConnectedRootDatum.root (Fin.castAdd 44 i) = CartanMatrix.F₄ i
+    rw [f4SimplyConnectedRootDatum_root, f4Root_castAdd]
   | G2 =>
     change Fin 2 at i
-    rw [simplyConnectedRootDatum_G2, cartanMatrix_G2]
-    change g2SimplyConnectedRootDatum.root (G2.simpleIndex ht i) =
+    rw [simplyConnectedRootDatum_G2, simpleIndex_G2, cartanMatrix_G2]
+    change g2SimplyConnectedRootDatum.root (Fin.castAdd 10 i) =
       fun k => CartanMatrix.G₂.transpose i k
-    have hi : G2.simpleIndex ht i = Fin.castAdd 10 i := Fin.ext rfl
-    rw [hi, g2SimplyConnectedRootDatum_root, g2Root_castAdd]
+    rw [g2SimplyConnectedRootDatum_root, g2Root_castAdd]
 
 /-- The pinned base is supported exactly on the first `t.rank` root indices. -/
 @[simp] theorem mem_support_simplyConnectedBase (t : DynkinType) (ht : t.Valid)
@@ -330,11 +371,14 @@ root indices. -/
   | E7 => exact mem_support_e7SimplyConnectedBase
   | E8 => exact mem_support_e8SimplyConnectedBase
   | F4 =>
+    -- The case split leaves `k` in the dependent motive; expose its concrete index type before
+    -- applying the family support equation.
     change Fin 48 at k
     change k ∈ f4SimplyConnectedBase.support ↔ (k : ℕ) < 4
     rw [f4SimplyConnectedBase_support]
     exact mem_f4Support
   | G2 =>
+    -- As in the `F4` branch, this only refines the index type retained by the dependent motive.
     change Fin 12 at k
     change k ∈ g2SimplyConnectedBase.support ↔ (k : ℕ) < 2
     rw [g2SimplyConnectedBase_support]
@@ -361,7 +405,7 @@ theorem hasCartanType_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
 
 /-- The coroots of the pinned datum span the cocharacter lattice. This is the simply connected
 lattice condition consumed by the pinned Chevalley--Demazure construction. -/
-theorem span_coroot_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
+theorem corootSpan_simplyConnectedRootDatum_eq_top (t : DynkinType) (ht : t.Valid) :
     Submodule.span ℤ (Set.range (t.simplyConnectedRootDatum ht).coroot) = ⊤ := by
   cases t with
   | A n => exact corootSpan_typeASimplyConnectedRootDatum_eq_top n

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
@@ -37,7 +37,7 @@ records. The `b` of the `a`-th simple root is the Bourbaki successor `min (a + 1
 moves that successor to the first slot of the enumeration.
 
 Only the coroots are asked to span their lattice, and only that half is recorded, in
-`typeCSimplyConnectedRootDatum_corootSpan_eq_top`. The roots span the root lattice, which sits
+`corootSpan_typeCSimplyConnectedRootDatum_eq_top`. The roots span the root lattice, which sits
 inside the weight lattice with index `2` whenever `0 < n` (Bourbaki, Plate III; at `n = 0` both
 lattices are trivial and the index is `1`), so the datum is a `RootDatum` carrying no
 `RootPairing.IsRootSystem` instance. That asymmetry is what "simply connected" means here.
@@ -62,7 +62,7 @@ lattices are trivial and the index is `1`), so the datum is a `RootDatum` carryi
   set of the first `n` root indices.
 * `TauCeti.DynkinType.hasCartanType_typeCSimplyConnectedRootDatum`: the pinned base has Cartan type
   `C n`.
-* `TauCeti.DynkinType.typeCSimplyConnectedRootDatum_corootSpan_eq_top`: the coroots span the
+* `TauCeti.DynkinType.corootSpan_typeCSimplyConnectedRootDatum_eq_top`: the coroots span the
   cocharacter lattice, the simply connected condition.
 
 ## References
@@ -785,7 +785,7 @@ connected lattice condition required by the pinned Chevalley--Demazure construct
 counterpart for the roots is deliberately absent: they span the root lattice, which sits inside the
 weight lattice with index `2` whenever `0 < n` (Bourbaki, Plate III; at `n = 0` both lattices are
 trivial). -/
-theorem typeCSimplyConnectedRootDatum_corootSpan_eq_top (n : ℕ) :
+theorem corootSpan_typeCSimplyConnectedRootDatum_eq_top (n : ℕ) :
     (typeCSimplyConnectedRootDatum n).corootSpan ℤ = ⊤ := by
   refine top_unique ?_
   rw [← (Pi.basisFun ℤ (Fin n)).span_eq]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/F4.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/F4.lean
@@ -27,11 +27,9 @@ the last two are short.
 
 * `TauCeti.DynkinType.f4SimplyConnectedRootDatum` is the pinned forty-eight-root datum.
 * `TauCeti.DynkinType.f4ReflectionIndex` is its explicit action on root indices.
-* The `RootPairing.IsRootSystem` instance for `TauCeti.DynkinType.f4SimplyConnectedRootDatum` says
-  that its roots span the character lattice and its coroots span the cocharacter lattice. The
-  latter, `span_coroot_eq_top`, is the simply connected condition the file is named for: the datum
-  has cocharacter lattice equal to the coroot lattice, so no central isogeny quotient of the simply
-  connected form is taken.
+* `TauCeti.DynkinType.corootSpan_f4SimplyConnectedRootDatum_eq_top` says that the coroots span the
+  cocharacter lattice, the simply connected condition the file is named for. Together with root
+  spanning it supplies the `RootPairing.IsRootSystem` instance.
 * `TauCeti.DynkinType.f4SimplyConnectedBase` is its Bourbaki-numbered base.
 * `TauCeti.DynkinType.f4SimplyConnectedRootDatum_pairing_eq_cartanMatrix_F₄` pins the numbering.
 * `TauCeti.DynkinType.hasCartanType_f4SimplyConnectedRootDatum` identifies its Cartan type.
@@ -334,7 +332,10 @@ private lemma span_f4Root_eq_top : span ℤ (range f4Root) = ⊤ := by
   · exact f4Root_19_add_20 ▸ (span ℤ (range ⇑f4Root)).add_mem (hr 19) (hr 20)
   · exact f4Root_20 ▸ hr 20
 
-private lemma span_f4Coroot_eq_top : span ℤ (range f4Coroot) = ⊤ :=
+/-- **The coroots of the pinned type `F4` datum span the cocharacter lattice.** This is the
+simply connected lattice condition required by the pinned Chevalley--Demazure construction. -/
+theorem corootSpan_f4SimplyConnectedRootDatum_eq_top :
+    f4SimplyConnectedRootDatum.corootSpan ℤ = ⊤ :=
   corootSpan_eq_top_of_coroot_eq_single (P := f4SimplyConnectedRootDatum) (e := Fin.castAdd 44)
     f4Coroot_castAdd
 
@@ -342,7 +343,7 @@ private lemma span_f4Coroot_eq_top : span ℤ (range f4Coroot) = ⊤ :=
 cocharacter lattices. Coroot spanning is the simply connected lattice condition. -/
 instance : f4SimplyConnectedRootDatum.IsRootSystem where
   span_root_eq_top := span_f4Root_eq_top
-  span_coroot_eq_top := span_f4Coroot_eq_top
+  span_coroot_eq_top := corootSpan_f4SimplyConnectedRootDatum_eq_top
 
 /-- The support of the Bourbaki-numbered base of the pinned `F4` datum: the first four root
 indices, which carry the simple roots. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/F4.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/F4.lean
@@ -27,9 +27,11 @@ the last two are short.
 
 * `TauCeti.DynkinType.f4SimplyConnectedRootDatum` is the pinned forty-eight-root datum.
 * `TauCeti.DynkinType.f4ReflectionIndex` is its explicit action on root indices.
-* `TauCeti.DynkinType.corootSpan_f4SimplyConnectedRootDatum_eq_top` says that the coroots span the
-  cocharacter lattice, the simply connected condition the file is named for. Together with root
-  spanning it supplies the `RootPairing.IsRootSystem` instance.
+* The `RootPairing.IsRootSystem` instance for `TauCeti.DynkinType.f4SimplyConnectedRootDatum` says
+  that its roots span the character lattice and its coroots span the cocharacter lattice. The
+  latter, `span_coroot_eq_top`, is the simply connected condition the file is named for: the datum
+  has cocharacter lattice equal to the coroot lattice, so no central isogeny quotient of the simply
+  connected form is taken.
 * `TauCeti.DynkinType.f4SimplyConnectedBase` is its Bourbaki-numbered base.
 * `TauCeti.DynkinType.f4SimplyConnectedRootDatum_pairing_eq_cartanMatrix_F₄` pins the numbering.
 * `TauCeti.DynkinType.hasCartanType_f4SimplyConnectedRootDatum` identifies its Cartan type.
@@ -332,10 +334,7 @@ private lemma span_f4Root_eq_top : span ℤ (range f4Root) = ⊤ := by
   · exact f4Root_19_add_20 ▸ (span ℤ (range ⇑f4Root)).add_mem (hr 19) (hr 20)
   · exact f4Root_20 ▸ hr 20
 
-/-- **The coroots of the pinned type `F4` datum span the cocharacter lattice.** This is the
-simply connected lattice condition required by the pinned Chevalley--Demazure construction. -/
-theorem corootSpan_f4SimplyConnectedRootDatum_eq_top :
-    f4SimplyConnectedRootDatum.corootSpan ℤ = ⊤ :=
+private lemma span_f4Coroot_eq_top : span ℤ (range f4Coroot) = ⊤ :=
   corootSpan_eq_top_of_coroot_eq_single (P := f4SimplyConnectedRootDatum) (e := Fin.castAdd 44)
     f4Coroot_castAdd
 
@@ -343,7 +342,7 @@ theorem corootSpan_f4SimplyConnectedRootDatum_eq_top :
 cocharacter lattices. Coroot spanning is the simply connected lattice condition. -/
 instance : f4SimplyConnectedRootDatum.IsRootSystem where
   span_root_eq_top := span_f4Root_eq_top
-  span_coroot_eq_top := corootSpan_f4SimplyConnectedRootDatum_eq_top
+  span_coroot_eq_top := span_f4Coroot_eq_top
 
 /-- The support of the Bourbaki-numbered base of the pinned `F4` datum: the first four root
 indices, which carry the simple roots. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/G2.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/G2.lean
@@ -37,8 +37,8 @@ also make the reflection-stability axioms of `RootPairing` decidable finite calc
   and `g2Coroot` its coordinate tables and `g2SimplyConnectedRootDatum_root`,
   `g2SimplyConnectedRootDatum_coroot`, `g2SimplyConnectedRootDatum_toLinearMap` and
   `g2SimplyConnectedRootDatum_pairing` the lemmas that expose them.
-* `TauCeti.DynkinType.corootSpan_g2SimplyConnectedRootDatum_eq_top` records the simply connected
-  coroot-spanning condition and contributes to the `RootPairing.IsRootSystem` instance.
+* Its `RootPairing.IsRootSystem` instance records that the roots and the coroots span their
+  lattices; coroot spanning is the simply connected condition.
 * `TauCeti.DynkinType.g2SimplyConnectedBase` is its Bourbaki-numbered base.
 * `TauCeti.DynkinType.g2SimplyConnectedRootDatum_pairing_eq_cartanMatrix_G2` pins that numbering
   entrywise: on the two base indices the Cartan integers are the Bourbaki matrix `!![2, -1; -3, 2]`.
@@ -75,6 +75,18 @@ def g2Coroot : Fin 12 ↪ (Fin 2 → ℤ) where
     ![1, 0], ![0, 1], ![1, 3], ![2, 3], ![1, 1], ![1, 2],
     ![-1, 0], ![0, -1], ![-1, -3], ![-2, -3], ![-1, -1], ![-1, -2]]
   inj' := by decide
+
+/-- The simple roots of `G2` sit at the first two indices, where they are the rows of its
+Bourbaki-numbered Cartan matrix. -/
+@[simp] lemma g2Root_castAdd (i : Fin 2) :
+    g2Root (Fin.castAdd 10 i) = CartanMatrix.G₂ᵀ i := by
+  fin_cases i <;> decide
+
+/-- The simple coroots of `G2` sit at the first two indices, where they are the standard basis of
+the cocharacter lattice. -/
+@[simp] lemma g2Coroot_castAdd (i : Fin 2) :
+    g2Coroot (Fin.castAdd 10 i) = Pi.single i 1 := by
+  fin_cases i <;> decide
 
 /-- The permutation table for reflection in each of the twelve `G2` roots. -/
 private def g2ReflectionIndex : Fin 12 → Fin 12 → Fin 12 := ![
@@ -158,10 +170,7 @@ private lemma span_g2Root_eq_top : span ℤ (range g2Root) = ⊤ := by
   · exact ⟨3, by decide⟩
   · exact ⟨5, by decide⟩
 
-/-- **The coroots of the pinned type `G2` datum span the cocharacter lattice.** This is the
-simply connected lattice condition required by the pinned Chevalley--Demazure construction. -/
-theorem corootSpan_g2SimplyConnectedRootDatum_eq_top :
-    g2SimplyConnectedRootDatum.corootSpan ℤ = ⊤ := by
+private lemma span_g2Coroot_eq_top : span ℤ (range g2Coroot) = ⊤ := by
   apply top_unique
   rw [← (Pi.basisFun ℤ (Fin 2)).span_eq]
   apply span_mono
@@ -176,7 +185,7 @@ spanning is the simply connected lattice condition required by the pinned Cheval
 construction. -/
 instance : g2SimplyConnectedRootDatum.IsRootSystem where
   span_root_eq_top := span_g2Root_eq_top
-  span_coroot_eq_top := corootSpan_g2SimplyConnectedRootDatum_eq_top
+  span_coroot_eq_top := span_g2Coroot_eq_top
 
 /-- A family indexed by `Fin 12` whose members are, up to sign, prescribed `ℕ`-combinations of its
 first two members satisfies the base condition of `RootPairing.Base` at the support `{0, 1}`. The

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/G2.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/G2.lean
@@ -37,8 +37,8 @@ also make the reflection-stability axioms of `RootPairing` decidable finite calc
   and `g2Coroot` its coordinate tables and `g2SimplyConnectedRootDatum_root`,
   `g2SimplyConnectedRootDatum_coroot`, `g2SimplyConnectedRootDatum_toLinearMap` and
   `g2SimplyConnectedRootDatum_pairing` the lemmas that expose them.
-* Its `RootPairing.IsRootSystem` instance records that the roots and the coroots span their
-  lattices; coroot spanning is the simply connected condition.
+* `TauCeti.DynkinType.corootSpan_g2SimplyConnectedRootDatum_eq_top` records the simply connected
+  coroot-spanning condition and contributes to the `RootPairing.IsRootSystem` instance.
 * `TauCeti.DynkinType.g2SimplyConnectedBase` is its Bourbaki-numbered base.
 * `TauCeti.DynkinType.g2SimplyConnectedRootDatum_pairing_eq_cartanMatrix_G2` pins that numbering
   entrywise: on the two base indices the Cartan integers are the Bourbaki matrix `!![2, -1; -3, 2]`.
@@ -158,7 +158,10 @@ private lemma span_g2Root_eq_top : span ℤ (range g2Root) = ⊤ := by
   · exact ⟨3, by decide⟩
   · exact ⟨5, by decide⟩
 
-private lemma span_g2Coroot_eq_top : span ℤ (range g2Coroot) = ⊤ := by
+/-- **The coroots of the pinned type `G2` datum span the cocharacter lattice.** This is the
+simply connected lattice condition required by the pinned Chevalley--Demazure construction. -/
+theorem corootSpan_g2SimplyConnectedRootDatum_eq_top :
+    g2SimplyConnectedRootDatum.corootSpan ℤ = ⊤ := by
   apply top_unique
   rw [← (Pi.basisFun ℤ (Fin 2)).span_eq]
   apply span_mono
@@ -173,7 +176,7 @@ spanning is the simply connected lattice condition required by the pinned Cheval
 construction. -/
 instance : g2SimplyConnectedRootDatum.IsRootSystem where
   span_root_eq_top := span_g2Root_eq_top
-  span_coroot_eq_top := span_g2Coroot_eq_top
+  span_coroot_eq_top := corootSpan_g2SimplyConnectedRootDatum_eq_top
 
 /-- A family indexed by `Fin 12` whose members are, up to sign, prescribed `ℕ`-combinations of its
 first two members satisfies the base condition of `RootPairing.Base` at the support `{0, 1}`. The


### PR DESCRIPTION
This PR assembles the nine explicit pinned simply connected root data into `DynkinType.simplyConnectedRootDatum` and their Bourbaki-numbered bases into `DynkinType.simplyConnectedBase`. Keep the dispatcher visibly casewise, expose simp-normal branch equations for every family, prove that the assembled base has the indexing Cartan type, and prove that the assembled coroots span the cocharacter lattice. Promote the already-proved `F4` and `G2` coroot-span facts to named public theorems so the uniform proof reuses the same interface as the other seven families.

The exact target is `RepresentationTheory/RootSystems/README.md`, Layer 6 milestone “A named datum per valid type”: `DynkinType.simplyConnectedRootDatum`, `DynkinType.simplyConnectedBase`, `DynkinType.hasCartanType_simplyConnectedRootDatum`, and `DynkinType.span_coroot_simplyConnectedRootDatum`. This is the most effective current step because the final missing per-type datum, `E7`, has just landed in #3461, leaving this uniform consumer API as the next unmet Layer 6 target. After this PR, the named-data portion of Root Systems Layer 6 is complete; `CFSGStatement` L0 still needs the pinned Chevalley--Demazure group schemes, base change, points, and root-subgroup maps from Reductive Groups Layer 9.

The dependency edge is: `CFSGStatement` milestone L0, “pinned ambient groups,” consumes `DynkinType.simplyConnectedRootDatum`, `DynkinType.simplyConnectedBase`, their Cartan-type identification, and coroot spanning to attach the explicit Layer 9 Chevalley--Demazure construction to every `ValidLieTypeIndex`. This PR supplies that Root Systems Layer 6 input without choosing a carrier from `exists_rootPairing_of_dynkinType`.

The assembly reuses the nine explicit Tau Ceti coordinate models and Mathlib's `RootDatum`, `RootPairing.Base`, crystallographic predicate, and submodule-span API; no Mathlib implementation or external formalization is vendored. The coordinate conventions and formulas follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plates I--IX, and Humphreys, *Introduction to Lie Algebras and Representation Theory*, Chapter 11, as credited in the module documentation.

Add `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean` (184 lines) and make the existing `F4` and `G2` coroot-span results public and named (15 insertions, 11 deletions across those two modules).

Roadmap: RepresentationTheory

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"dynkintype-simplyconnectedrootdatum"}-->

🤖 Prepared with Codex
