### PR TITLE
feat(DoubleCoset): the fibres of orbitOfCosetTranslate are the stabiliser orbits

### DIFF
--- a/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
@@ -40,6 +40,8 @@ numbers, which is the group-theoretic half of the statement that the permutation
 * `TauCeti.orbitRel_smul_iff_mem_doubleCoset_stabilizer`: the same for an arbitrary action —
   two translates of a point share a `K`-orbit exactly when the translating elements share a
   `K`-`stabilizer` double coset.
+* `TauCeti.orbitOfCosetTranslate_eq_iff`: the fibres of that index map are the orbits of
+  `stabilizer ℋ p` on `ℋ ⧸ 𝒢.subgroupOf ℋ`, so a fibre count is an orbit-stabiliser count.
 * `TauCeti.preimage_orbit_eq_doubleCoset`: the double coset `KsH` is the preimage of the
   `K`-orbit of `sH`.
 * `TauCeti.card_doubleCosetQuotient_eq_card_orbitQuotient`: the two sides of that bijection have
@@ -220,6 +222,43 @@ noncomputable def orbitOfCosetTranslate {𝒢 ℋ : Subgroup G} (p : α) (q : �
 theorem orbitOfCosetTranslate_mk {𝒢 ℋ : Subgroup G} (p : α) (h : ℋ) :
     orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = Quotient.mk'' ((h : G)⁻¹ • p) :=
   (rfl)
+
+/-- **The fibres of `orbitOfCosetTranslate` are the `stabilizer ℋ p`-orbits.** Two classes have
+the same image exactly when they differ by left multiplication by an element stabilising `p`.
+
+This is the fibre description the definition exists for: it turns a fibre of that index map into
+an orbit, so that a fibre count becomes an orbit-stabiliser count.
+
+Two things to know when applying it. The right-hand side is existential rather than
+`r ∈ MulAction.orbit (stabilizer ℋ p) ⟦h⟧` because the `•` of that action does not elaborate
+against the `⟦·⟧` spelling used here. And `hle : 𝒢 ≤ ℋ` is what puts the translating element back
+inside `ℋ`: the witness `orbitRel_smul_iff_mem_doubleCoset_stabilizer` produces lies in `𝒢`, and
+the stabilising factor is an element of `ℋ` only once `𝒢` is. -/
+theorem orbitOfCosetTranslate_eq_iff {𝒢 ℋ : Subgroup G} (hle : 𝒢 ≤ ℋ) (p : α) (h r : ℋ) :
+    orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦r⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) =
+        orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) ↔
+      ∃ s ∈ stabilizer ℋ p, (⟦r⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = ⟦s * h⟧ := by
+  rw [orbitOfCosetTranslate_mk, orbitOfCosetTranslate_mk, Quotient.eq'',
+    orbitRel_smul_iff_mem_doubleCoset_stabilizer, DoubleCoset.mem_doubleCoset]
+  constructor
+  · rintro ⟨x, hx, y, hy, hr⟩
+    -- `y` lies in `ℋ`: solving `hr` for it gives `y = h * x⁻¹ * r⁻¹`, and `𝒢 ≤ ℋ` puts `x` there
+    have hyH : y ∈ ℋ := by
+      have hy2 : y = (h : G) * x⁻¹ * (r : G)⁻¹ := by rw [hr]; simp [mul_assoc]
+      exact hy2 ▸ mul_mem (mul_mem h.2 (inv_mem (hle (SetLike.mem_coe.1 hx)))) (inv_mem r.2)
+    refine ⟨(⟨y, hyH⟩ : ℋ)⁻¹, inv_mem hy, ?_⟩
+    -- the coset witness is `x` on the nose: `r⁻¹ * (y⁻¹ * h) = (x * h⁻¹ * y) * y⁻¹ * h = x`
+    rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]
+    have hval : ((r⁻¹ * ((⟨y, hyH⟩ : ℋ)⁻¹ * h) : ℋ) : G) = x := by
+      rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv, Subgroup.coe_inv, hr]
+      simp [mul_assoc]
+    exact hval ▸ SetLike.mem_coe.1 hx
+  · rintro ⟨s, hs, hrs⟩
+    rw [QuotientGroup.eq, Subgroup.mem_subgroupOf] at hrs
+    refine ⟨((r⁻¹ * (s * h) : ℋ) : G), SetLike.mem_coe.2 hrs, (s : G)⁻¹,
+      SetLike.mem_coe.2 (inv_mem hs), ?_⟩
+    rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv]
+    simp [mul_assoc]
 
 end GeneralAction
 

--- a/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
@@ -40,8 +40,6 @@ numbers, which is the group-theoretic half of the statement that the permutation
 * `TauCeti.orbitRel_smul_iff_mem_doubleCoset_stabilizer`: the same for an arbitrary action —
   two translates of a point share a `K`-orbit exactly when the translating elements share a
   `K`-`stabilizer` double coset.
-* `TauCeti.mem_stabilizer_subgroup_iff`: membership in a subgroup's stabilizer, read in the
-  ambient group.
 * `TauCeti.orbitOfCosetTranslate_eq_iff`: the fibres of that index map are the orbits of
   `stabilizer ℋ p` on `ℋ ⧸ 𝒢.subgroupOf ℋ`, so a fibre count is an orbit-stabiliser count.
 * `TauCeti.preimage_orbit_eq_doubleCoset`: the double coset `KsH` is the preimage of the
@@ -225,12 +223,6 @@ theorem orbitOfCosetTranslate_mk {𝒢 ℋ : Subgroup G} (p : α) (h : ℋ) :
     orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = Quotient.mk'' ((h : G)⁻¹ • p) :=
   (rfl)
 
-/-- Membership in the stabilizer of a subgroup, read in the ambient group. Stated so that proofs
-do not have to rely on the two memberships happening to unfold to the same thing. -/
-theorem mem_stabilizer_subgroup_iff {ℋ : Subgroup G} (p : α) (s : ℋ) :
-    s ∈ stabilizer ℋ p ↔ (s : G) ∈ stabilizer G p := by
-  rw [mem_stabilizer_iff, mem_stabilizer_iff, Subgroup.smul_def]
-
 /-- **The fibres of `orbitOfCosetTranslate` are the `stabilizer ℋ p`-orbits.** Two classes have
 the same image exactly when they lie in one orbit of the stabilizer of `p`, acting on the coset
 space by left translation.
@@ -260,21 +252,22 @@ theorem orbitOfCosetTranslate_eq_iff {𝒢 ℋ : Subgroup G} (hle : 𝒢 ≤ ℋ
           exact hy2 ▸ mul_mem (mul_mem b.2 (inv_mem (hle (SetLike.mem_coe.1 hx)))) (inv_mem a.2)
         have ha : (a : G) = y⁻¹ * (b : G) * x⁻¹ := by
           rw [← inv_inv (a : G), hr]; simp [mul_assoc]
-        refine ⟨⟨(⟨y, hyH⟩ : ℋ)⁻¹, inv_mem ((mem_stabilizer_subgroup_iff p _).2
+        refine ⟨⟨(⟨y, hyH⟩ : ℋ)⁻¹, inv_mem ((Subgroup.mem_subgroupOf (H := stabilizer G p)).2
           (SetLike.mem_coe.1 hy))⟩, ?_⟩
-        -- the action is left translation, so the goal is a coset equality with witness `x⁻¹`
-        change (((⟨y, hyH⟩ : ℋ)⁻¹ * b : ℋ) : ℋ ⧸ 𝒢.subgroupOf ℋ) = (a : ℋ ⧸ 𝒢.subgroupOf ℋ)
-        rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]
+        -- the action is left translation (the idiom at `mem_doubleCoset_iff_mk_mem_orbit`), so
+        -- the goal is a coset equality, with witness `x⁻¹`
+        rw [compHom_smul_def (Subgroup.subtype (stabilizer ℋ p)), Subgroup.coe_subtype,
+          Quotient.smul_coe, smul_eq_mul, QuotientGroup.eq, Subgroup.mem_subgroupOf]
         have hval : ((((⟨y, hyH⟩ : ℋ)⁻¹ * b)⁻¹ * a : ℋ) : G) = x⁻¹ := by
           rw [Subgroup.coe_mul, Subgroup.coe_inv, Subgroup.coe_mul, Subgroup.coe_inv, ha]
           simp [mul_assoc]
         exact hval ▸ SetLike.mem_coe.1 (inv_mem hx)
       · rintro ⟨s, hs⟩
-        rw [show (s • (b : ℋ ⧸ 𝒢.subgroupOf ℋ)) = (((s : ℋ) * b : ℋ) :
-          ℋ ⧸ 𝒢.subgroupOf ℋ) from rfl, QuotientGroup.eq, Subgroup.mem_subgroupOf] at hs
+        rw [compHom_smul_def (Subgroup.subtype (stabilizer ℋ p)), Subgroup.coe_subtype,
+          Quotient.smul_coe, smul_eq_mul, QuotientGroup.eq, Subgroup.mem_subgroupOf] at hs
         refine ⟨(((((s : ℋ) * b)⁻¹ * a : ℋ)⁻¹ : ℋ) : G), SetLike.mem_coe.2 (inv_mem hs),
           ((s : ℋ) : G)⁻¹,
-          SetLike.mem_coe.2 (inv_mem ((mem_stabilizer_subgroup_iff p _).1 s.2)), ?_⟩
+          SetLike.mem_coe.2 (inv_mem ((Subgroup.mem_subgroupOf (H := stabilizer G p)).1 s.2)), ?_⟩
         rw [Subgroup.coe_inv, Subgroup.coe_mul, Subgroup.coe_inv, Subgroup.coe_mul]
         simp [mul_assoc]
 

--- a/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
@@ -40,6 +40,8 @@ numbers, which is the group-theoretic half of the statement that the permutation
 * `TauCeti.orbitRel_smul_iff_mem_doubleCoset_stabilizer`: the same for an arbitrary action —
   two translates of a point share a `K`-orbit exactly when the translating elements share a
   `K`-`stabilizer` double coset.
+* `TauCeti.mem_stabilizer_subgroup_iff`: membership in a subgroup's stabilizer, read in the
+  ambient group.
 * `TauCeti.orbitOfCosetTranslate_eq_iff`: the fibres of that index map are the orbits of
   `stabilizer ℋ p` on `ℋ ⧸ 𝒢.subgroupOf ℋ`, so a fibre count is an orbit-stabiliser count.
 * `TauCeti.preimage_orbit_eq_doubleCoset`: the double coset `KsH` is the preimage of the
@@ -223,42 +225,58 @@ theorem orbitOfCosetTranslate_mk {𝒢 ℋ : Subgroup G} (p : α) (h : ℋ) :
     orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = Quotient.mk'' ((h : G)⁻¹ • p) :=
   (rfl)
 
+/-- Membership in the stabilizer of a subgroup, read in the ambient group. Stated so that proofs
+do not have to rely on the two memberships happening to unfold to the same thing. -/
+theorem mem_stabilizer_subgroup_iff {ℋ : Subgroup G} (p : α) (s : ℋ) :
+    s ∈ stabilizer ℋ p ↔ (s : G) ∈ stabilizer G p := by
+  rw [mem_stabilizer_iff, mem_stabilizer_iff, Subgroup.smul_def]
+
 /-- **The fibres of `orbitOfCosetTranslate` are the `stabilizer ℋ p`-orbits.** Two classes have
-the same image exactly when they differ by left multiplication by an element stabilising `p`.
+the same image exactly when they lie in one orbit of the stabilizer of `p`, acting on the coset
+space by left translation.
 
 This is the fibre description the definition exists for: it turns a fibre of that index map into
-an orbit, so that a fibre count becomes an orbit-stabiliser count.
+an orbit, so that a fibre count becomes an orbit-stabiliser count via
+`MulAction.index_stabilizer`.
 
-Two things to know when applying it. The right-hand side is existential rather than
-`r ∈ MulAction.orbit (stabilizer ℋ p) ⟦h⟧` because the `•` of that action does not elaborate
-against the `⟦·⟧` spelling used here. And `hle : 𝒢 ≤ ℋ` is what puts the translating element back
-inside `ℋ`: the witness `orbitRel_smul_iff_mem_doubleCoset_stabilizer` produces lies in `𝒢`, and
-the stabilising factor is an element of `ℋ` only once `𝒢` is. -/
-theorem orbitOfCosetTranslate_eq_iff {𝒢 ℋ : Subgroup G} (hle : 𝒢 ≤ ℋ) (p : α) (h r : ℋ) :
-    orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦r⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) =
-        orbitOfCosetTranslate (𝒢 := 𝒢) p (⟦h⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) ↔
-      ∃ s ∈ stabilizer ℋ p, (⟦r⟧ : ℋ ⧸ 𝒢.subgroupOf ℋ) = ⟦s * h⟧ := by
-  rw [orbitOfCosetTranslate_mk, orbitOfCosetTranslate_mk, Quotient.eq'',
-    orbitRel_smul_iff_mem_doubleCoset_stabilizer, DoubleCoset.mem_doubleCoset]
-  constructor
-  · rintro ⟨x, hx, y, hy, hr⟩
-    -- `y` lies in `ℋ`: solving `hr` for it gives `y = h * x⁻¹ * r⁻¹`, and `𝒢 ≤ ℋ` puts `x` there
-    have hyH : y ∈ ℋ := by
-      have hy2 : y = (h : G) * x⁻¹ * (r : G)⁻¹ := by rw [hr]; simp [mul_assoc]
-      exact hy2 ▸ mul_mem (mul_mem h.2 (inv_mem (hle (SetLike.mem_coe.1 hx)))) (inv_mem r.2)
-    refine ⟨(⟨y, hyH⟩ : ℋ)⁻¹, inv_mem hy, ?_⟩
-    -- the coset witness is `x` on the nose: `r⁻¹ * (y⁻¹ * h) = (x * h⁻¹ * y) * y⁻¹ * h = x`
-    rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]
-    have hval : ((r⁻¹ * ((⟨y, hyH⟩ : ℋ)⁻¹ * h) : ℋ) : G) = x := by
-      rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv, Subgroup.coe_inv, hr]
-      simp [mul_assoc]
-    exact hval ▸ SetLike.mem_coe.1 hx
-  · rintro ⟨s, hs, hrs⟩
-    rw [QuotientGroup.eq, Subgroup.mem_subgroupOf] at hrs
-    refine ⟨((r⁻¹ * (s * h) : ℋ) : G), SetLike.mem_coe.2 hrs, (s : G)⁻¹,
-      SetLike.mem_coe.2 (inv_mem hs), ?_⟩
-    rw [Subgroup.coe_mul, Subgroup.coe_mul, Subgroup.coe_inv]
-    simp [mul_assoc]
+`hle : 𝒢 ≤ ℋ` is what puts the translating element back inside `ℋ`: the witness
+`orbitRel_smul_iff_mem_doubleCoset_stabilizer` produces lies in `𝒢`, and the stabilising factor
+is an element of `ℋ` only once `𝒢` is. -/
+theorem orbitOfCosetTranslate_eq_iff {𝒢 ℋ : Subgroup G} (hle : 𝒢 ≤ ℋ) (p : α)
+    (q r : ℋ ⧸ 𝒢.subgroupOf ℋ) :
+    orbitOfCosetTranslate p q = orbitOfCosetTranslate (𝒢 := 𝒢) p r ↔
+      q ∈ MulAction.orbit (stabilizer ℋ p) r := by
+  induction q using QuotientGroup.induction_on with
+  | H a =>
+    induction r using QuotientGroup.induction_on with
+    | H b =>
+      rw [orbitOfCosetTranslate_mk, orbitOfCosetTranslate_mk, Quotient.eq'',
+        orbitRel_smul_iff_mem_doubleCoset_stabilizer, DoubleCoset.mem_doubleCoset, mem_orbit_iff]
+      constructor
+      · rintro ⟨x, hx, y, hy, hr⟩
+        -- `y` lies in `ℋ`: solving `hr` gives `y = b * x⁻¹ * a⁻¹`, and `𝒢 ≤ ℋ` puts `x` there
+        have hyH : y ∈ ℋ := by
+          have hy2 : y = (b : G) * x⁻¹ * (a : G)⁻¹ := by rw [hr]; simp [mul_assoc]
+          exact hy2 ▸ mul_mem (mul_mem b.2 (inv_mem (hle (SetLike.mem_coe.1 hx)))) (inv_mem a.2)
+        have ha : (a : G) = y⁻¹ * (b : G) * x⁻¹ := by
+          rw [← inv_inv (a : G), hr]; simp [mul_assoc]
+        refine ⟨⟨(⟨y, hyH⟩ : ℋ)⁻¹, inv_mem ((mem_stabilizer_subgroup_iff p _).2
+          (SetLike.mem_coe.1 hy))⟩, ?_⟩
+        -- the action is left translation, so the goal is a coset equality with witness `x⁻¹`
+        change (((⟨y, hyH⟩ : ℋ)⁻¹ * b : ℋ) : ℋ ⧸ 𝒢.subgroupOf ℋ) = (a : ℋ ⧸ 𝒢.subgroupOf ℋ)
+        rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]
+        have hval : ((((⟨y, hyH⟩ : ℋ)⁻¹ * b)⁻¹ * a : ℋ) : G) = x⁻¹ := by
+          rw [Subgroup.coe_mul, Subgroup.coe_inv, Subgroup.coe_mul, Subgroup.coe_inv, ha]
+          simp [mul_assoc]
+        exact hval ▸ SetLike.mem_coe.1 (inv_mem hx)
+      · rintro ⟨s, hs⟩
+        rw [show (s • (b : ℋ ⧸ 𝒢.subgroupOf ℋ)) = (((s : ℋ) * b : ℋ) :
+          ℋ ⧸ 𝒢.subgroupOf ℋ) from rfl, QuotientGroup.eq, Subgroup.mem_subgroupOf] at hs
+        refine ⟨(((((s : ℋ) * b)⁻¹ * a : ℋ)⁻¹ : ℋ) : G), SetLike.mem_coe.2 (inv_mem hs),
+          ((s : ℋ) : G)⁻¹,
+          SetLike.mem_coe.2 (inv_mem ((mem_stabilizer_subgroup_iff p _).1 s.2)), ?_⟩
+        rw [Subgroup.coe_inv, Subgroup.coe_mul, Subgroup.coe_inv, Subgroup.coe_mul]
+        simp [mul_assoc]
 
 end GeneralAction
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-orbit-coset-fibre-description"}-->

`orbitOfCosetTranslate` (added in #3477) is the index map along which a sum over the coset
space `ℋ ⧸ 𝒢.subgroupOf ℋ` is regrouped into a sum over `𝒢`-orbits. Its own docstring already
advertises that its fibres are double cosets; this PR proves the fibre description in the form
the regrouping consumes.

One new declaration:

```lean
theorem orbitOfCosetTranslate_eq_iff {𝒢 ℋ : Subgroup G} (hle : 𝒢 ≤ ℋ) (p : α)
    (q r : ℋ ⧸ 𝒢.subgroupOf ℋ) :
    orbitOfCosetTranslate p q = orbitOfCosetTranslate (𝒢 := 𝒢) p r ↔
      q ∈ MulAction.orbit (stabilizer ℋ p) r
```

**The fibres are the `stabilizer ℋ p`-orbits.** That is what converts a fibre count into an
orbit–stabiliser count, which is how the general-level valence formula's `Nat.card` fibre
weights become the ramification weights `1 / e_P`.

It takes arbitrary quotient elements `q r`, not chosen representatives, so a consumer holding
classes can rewrite directly without doing quotient induction itself. The right-hand side is
`MulAction.orbit`, so the count goes through `MulAction.index_stabilizer` with no reshaping.

One file, no new imports. The input is this file's own
`orbitRel_smul_iff_mem_doubleCoset_stabilizer`.

### `hle : 𝒢 ≤ ℋ` is load-bearing

The witness that `orbitRel_smul_iff_mem_doubleCoset_stabilizer` produces lies in `𝒢`; the
stabilising factor is an element of `ℋ` only once `𝒢` is. Without the hypothesis the `s` in the
conclusion cannot be constructed.

### On the stabiliser transfer

The proof moves membership between `stabilizer ℋ p` and `stabilizer G p` twice. Both go through
Mathlib's `Subgroup.mem_subgroupOf`, since `stabilizer ↥ℋ p` *is* `(stabilizer G p).subgroupOf ℋ`
definitionally — no local helper is introduced for it.

Worth recording, because the obvious form does not work: bare `Subgroup.mem_subgroupOf` fails to
elaborate at these sites, since the unifier cannot solve the subgroup metavariable out of
`stabilizer ↥ℋ p`. It needs the explicit `(H := stabilizer G p)`.

### Gates at this head

`lake build` 8111 jobs · `lake exe axioms` 50427 declarations, allowlist only ·
`lake exe module-system` 2393 modules · `LINT-ENV: PASS` (0 new violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
