### PR TITLE
feat: prove the Chevalley commutator relations for Kostant root subgroups

### DIFF
--- a/TauCeti/Algebra/Lie/InnerAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/InnerAutomorphism.lean
@@ -8,6 +8,7 @@ public import Mathlib.Algebra.Algebra.Rat
 public import Mathlib.Algebra.Lie.AdjointAction.Basic
 public import Mathlib.Algebra.Lie.AdjointAction.Derivation
 import Mathlib.Algebra.Ring.Action.ConjAct
+import TauCeti.Algebra.Ring.Commutator
 
 public section
 
@@ -235,68 +236,6 @@ private theorem exp_mul_exp_mul_exp_neg {x y : A} (hx : IsNilpotent x)
         (expAd (K := ℚ) x (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hx) y) := by
       rw [expAd_apply_eq_exp_mul_exp_neg hx, he]
 
-omit [Algebra ℚ A] in
-private lemma lie_mul (y a b : A) : ⁅y, a * b⁆ = ⁅y, a⁆ * b + a * ⁅y, b⁆ := by
-  simp only [Ring.lie_def, mul_sub, sub_mul, mul_assoc]
-  abel
-
-omit [Algebra ℚ A] in
-private lemma lie_mul_z_pow {y z : A} (hyz : ⁅y, z⁆ = 0) (a : A) :
-    ∀ k : ℕ, ⁅y, a * z ^ k⁆ = ⁅y, a⁆ * z ^ k
-  | 0 => by simp
-  | k + 1 => by
-    rw [pow_succ z k, ← mul_assoc a (z ^ k) z, lie_mul y (a * z ^ k) z, hyz, mul_zero, add_zero,
-      lie_mul_z_pow hyz a k, mul_assoc, ← pow_succ z k]
-
-private lemma lie_pow_succ {x y z : A} (hyx : ⁅y, x⁆ = -z) (hxz : Commute x z) :
-    ∀ m : ℕ, ⁅y, x ^ (m + 1)⁆ = - ((m + 1 : ℚ) • (x ^ m * z))
-  | 0 => by
-    simp [hyx]
-  | m + 1 => by
-    rw [pow_succ x (m + 1), lie_mul y (x ^ (m + 1)) x, lie_pow_succ hyx hxz m, hyx]
-    have hcomm : x ^ m * z * x = x ^ (m + 1) * z := by
-      rw [mul_assoc, hxz.symm.eq, ← mul_assoc, ← pow_succ x m]
-    rw [neg_mul, smul_mul_assoc, hcomm, mul_neg, ← neg_add]
-    congr 1
-    nth_rw 2 [← one_smul ℚ (x ^ (m + 1) * z)]
-    rw [← add_smul]
-    congr 1
-    push_cast
-    ring
-
-private lemma isNilpotent_of_lie_eq_of_commute {x y z : A}
-    (hxy : ⁅x, y⁆ = z) (hxz : Commute x z) (hyz : Commute y z)
-    (hx : IsNilpotent x) : IsNilpotent z := by
-  obtain ⟨n, hn⟩ := hx
-  have hyz' : ⁅y, z⁆ = 0 := hyz.lie_eq
-  have hyx : ⁅y, x⁆ = -z := by rw [← neg_inj, lie_skew, hxy, neg_neg]
-  have hstep (m k : ℕ) (h : x ^ (m + 1) * z ^ k = 0) : x ^ m * z ^ (k + 1) = 0 := by
-    have hlie : ⁅y, x ^ (m + 1) * z ^ k⁆ = 0 := by rw [h, lie_zero]
-    rw [lie_mul_z_pow hyz', lie_pow_succ hyx hxz, neg_mul, smul_mul_assoc,
-      mul_assoc (x ^ m) z (z ^ k), ← pow_succ' z k, neg_eq_zero] at hlie
-    have hc : (m + 1 : ℚ) ≠ 0 := by positivity
-    have := congr_arg ((m + 1 : ℚ)⁻¹ • ·) hlie
-    rwa [inv_smul_smul₀ hc, smul_zero] at this
-  have hpow : ∀ k ≤ n, x ^ (n - k) * z ^ k = 0 := by
-    intro k
-    induction k with
-    | zero =>
-      intro _
-      simpa using hn
-    | succ k ih =>
-      intro hk
-      have hlt : k < n := Nat.lt_of_succ_le hk
-      have hle : k ≤ n := Nat.le_of_lt hlt
-      have heq : n - k = (n - k - 1) + 1 := by omega
-      have hprev := ih hle
-      rw [heq] at hprev
-      have hnext := hstep (n - k - 1) k hprev
-      have heq2 : n - (k + 1) = n - k - 1 := by omega
-      rwa [heq2]
-  refine ⟨n, ?_⟩
-  have htop := hpow n (le_refl n)
-  simpa using htop
-
 /-- **The central-commutator exponential relation.** If `[x, y] = z`, the element `z` commutes
 with `x` and `y`, and `x` and `y` are nilpotent, then
 `exp(x) exp(y) = exp(y) exp(z) exp(x)`.
@@ -309,7 +248,8 @@ theorem exp_mul_exp_eq_exp_mul_exp_mul_of_lie_eq_of_commute {x y z : A}
     (hx : IsNilpotent x) (hy : IsNilpotent y) :
     IsNilpotent.exp x * IsNilpotent.exp y =
       IsNilpotent.exp y * IsNilpotent.exp z * IsNilpotent.exp x := by
-  have hz : IsNilpotent z := isNilpotent_of_lie_eq_of_commute hxy hxz hyz hx
+  have hz : IsNilpotent z :=
+    Associative.isNilpotent_of_commutator_eq (by rw [← hxy, Ring.lie_def]; abel) hxz hyz hx
   have hconj : IsNilpotent.exp x * IsNilpotent.exp y * IsNilpotent.exp (-x) =
       IsNilpotent.exp y * IsNilpotent.exp z := by
     rw [exp_mul_exp_mul_exp_neg hx hy,

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Basic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Basic.lean
@@ -90,6 +90,17 @@ divided-power exponential with the corresponding `𝔾ₐ` parameter. -/
   rw [kostantRootSubgroupPoints]
   exact (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[ℤ] M)).apply_symm_apply _
 
+/-- The invertible linear map underlying a Kostant root-subgroup point is the base-changed
+divided-power exponential at the corresponding parameter. -/
+theorem kostantRootSubgroupPoints_val (f : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    (kostantRootSubgroupPoints e h ρ M hM i hnil f).val =
+      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+        (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f)) := by
+  refine LinearMap.ext fun z => ?_
+  rw [← LinearMap.GeneralLinearGroup.coe_toLinearEquiv, kostantRootSubgroupPoints_toLinearEquiv,
+    coe_baseChangeKostantExpHom]
+
 /-- On an elementary tensor, a Kostant root-subgroup point acts by the expected finite
 divided-power formula. -/
 @[simp] theorem kostantRootSubgroupPoints_tmul
@@ -102,9 +113,7 @@ divided-power formula. -/
             (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M n
             (fun _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem
               e h ρ hM i n hv) m := by
-  rw [← LinearMap.GeneralLinearGroup.coe_toLinearEquiv,
-    kostantRootSubgroupPoints_toLinearEquiv]
-  rw [coe_baseChangeKostantExpHom]
+  rw [kostantRootSubgroupPoints_val]
   exact baseChangeExp_tmul
     (R := A) (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
       (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem
@@ -129,10 +138,7 @@ theorem map_kostantRootSubgroupPoints_algHom
             (AlgHom.mapValue (H := SymmetricAlgebra ℤ ℤ) φ f)).val
           (TensorProduct.map φ.toLinearMap LinearMap.id z) := by
   intro z
-  rw [← LinearMap.GeneralLinearGroup.coe_toLinearEquiv,
-    kostantRootSubgroupPoints_toLinearEquiv, coe_baseChangeKostantExpHom,
-    ← LinearMap.GeneralLinearGroup.coe_toLinearEquiv,
-    kostantRootSubgroupPoints_toLinearEquiv, coe_baseChangeKostantExpHom,
+  rw [kostantRootSubgroupPoints_val, kostantRootSubgroupPoints_val,
     AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue]
   exact map_baseChangeExp_algHom φ _ _ _ _ z
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean
@@ -47,6 +47,8 @@ Lie-theoretic hypotheses and transports the identity to the root subgroups in
   with that point written out.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupPoints_conj_of_lie_eq`: its conjugation
   form.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupPoints_conj_of_lie_eq'`: the conjugation
+  form with that point written out.
 
 ## References
 
@@ -81,19 +83,6 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable {A : Type*} [CommRing A] [Algebra ℤ A]
 
-/-- The invertible linear map underlying a Kostant root-subgroup point is the base-changed
-divided-power exponential at the corresponding parameter. -/
-private theorem val_kostantRootSubgroupPoints (i : ι)
-    (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
-    (f : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
-    (kostantRootSubgroupPoints e h ρ M hM i hnil f).val =
-      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
-        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
-        (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f)) := by
-  refine LinearMap.ext fun z => ?_
-  rw [← LinearMap.GeneralLinearGroup.coe_toLinearEquiv, kostantRootSubgroupPoints_toLinearEquiv,
-    coe_baseChangeKostantExpHom]
-
 /-- **The degenerate Chevalley commutator relation for Kostant root subgroups.** Root subgroups
 attached to commuting root vectors commute. For a root system this is the case of two roots whose
 sum is not a root and which are not opposite. -/
@@ -111,7 +100,7 @@ theorem commute_kostantRootSubgroupPoints {i j : ι} (hij : ⁅e i, e j⁆ = 0)
     rw [map_sub, map_mul, map_mul, map_zero] at this
     exact sub_eq_zero.mp this
   refine Units.ext ?_
-  simp only [Units.val_mul, val_kostantRootSubgroupPoints]
+  simp only [Units.val_mul, kostantRootSubgroupPoints_val]
   exact commute_baseChangeExp M hcomm hi hj _ _ _ _
 
 /-- **The Chevalley commutator relation for Kostant root subgroups.** Suppose the distinguished
@@ -167,21 +156,18 @@ theorem kostantRootSubgroupPoints_mul_of_lie_eq {i j k : ι} {c : ℤ}
     have := hbr (e j) (e k)
     rw [hjk, map_zero, map_zero] at this
     exact sub_eq_zero.mp this
-  -- Nilpotency and stability for the scaled commutator.
-  have hznil : IsNilpotent (c • ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))) := by
-    obtain ⟨N, hN⟩ := hk
-    exact ⟨N, by rw [smul_pow, hN, smul_zero]⟩
+  -- Stability of `M` under the divided powers of the scaled commutator.
   have hMz : ∀ n, ∀ v ∈ M,
       Associative.dividedPower n (c • ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))) • v ∈ M := by
     intro n v hv
     rw [Associative.dividedPower_zsmul, smul_assoc]
     exact M.zsmul_mem (dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM k n hv) _
   refine Units.ext ?_
-  simp only [Units.val_mul, val_kostantRootSubgroupPoints]
+  simp only [Units.val_mul, kostantRootSubgroupPoints_val]
   rw [hw, ← baseChangeExp_zsmul c M
       (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM k n hv) hMz hk]
   exact baseChangeExp_mul_baseChangeExp_of_commutator_eq M hxy (Commute.smul_right hcxz c)
-    (Commute.smul_right hcyz c) hi hj hznil _ _ hMz _ _
+    (Commute.smul_right hcyz c) hi hj _ _ hMz _ _
 
 /-- The Chevalley commutator relation with the third `𝔾ₐ`-point written out: it is the point whose
 parameter is `c` times the product of the parameters of `f` and `g`. -/
@@ -223,5 +209,26 @@ theorem kostantRootSubgroupPoints_conj_of_lie_eq {i j k : ι} {c : ℤ}
         kostantRootSubgroupPoints e h ρ M hM k hk w := by
   rw [kostantRootSubgroupPoints_mul_of_lie_eq e h ρ M hM hij hik hjk hi hj hk f g w hw,
     mul_inv_cancel_right]
+
+/-- The conjugation form of the Chevalley commutator relation with the third `𝔾ₐ`-point written
+out: it is the point whose parameter is `c` times the product of the parameters of `f` and `g`. -/
+theorem kostantRootSubgroupPoints_conj_of_lie_eq' {i j k : ι} {c : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hik : ⁅e i, e k⁆ = 0) (hjk : ⁅e j, e k⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (f g : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    kostantRootSubgroupPoints e h ρ M hM i hi f *
+        kostantRootSubgroupPoints e h ρ M hM j hj g *
+        (kostantRootSubgroupPoints e h ρ M hM i hi f)⁻¹ =
+      kostantRootSubgroupPoints e h ρ M hM j hj g *
+        kostantRootSubgroupPoints e h ρ M hM k hk
+          ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+            (Multiplicative.ofAdd ((c : A) *
+              (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) *
+                Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))))) :=
+  kostantRootSubgroupPoints_conj_of_lie_eq e h ρ M hM hij hik hjk hi hj hk f g _
+    (congrArg Multiplicative.toAdd
+      ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).apply_symm_apply _))
 
 end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Basic
+public import TauCeti.RingTheory.Nilpotent.ChevalleyCommutator
+
+/-!
+# Chevalley commutator relations for Kostant root subgroups
+
+Let `U_ℤ = kostantForm e h` act on a rational vector space `V` through `ρ`, let `M ≤ V` be a
+`U_ℤ`-stable additive subgroup, and let `eᵢ`, `eⱼ`, `eₖ` be distinguished root vectors with
+nilpotent images. If
+
+```text
+⁅eᵢ, eⱼ⁆ = c • eₖ,   ⁅eᵢ, eₖ⁆ = 0,   ⁅eⱼ, eₖ⁆ = 0
+```
+
+for an integer `c` — the situation of two roots `α`, `β` with `α + β` a root but neither
+`2α + β` nor `α + 2β` a root, `c` being the Chevalley structure constant `N_{α β}` — then the
+root subgroups on the points of `M ⊗ A` satisfy the Chevalley commutator relation
+
+```text
+x_α(t) x_β(u) x_α(t)⁻¹ = x_β(u) x_{α+β}(c t u).
+```
+
+This is the case of the Chevalley commutator formula in which only one further root subgroup
+occurs; in a simply-laced root system every pair of non-proportional roots falls under it or under
+the commuting case. The relation holds over every commutative ring `A`, with no factorial
+inverted, because it descends from the coefficient-one normal-ordering rule for divided powers.
+
+The general statement about integral nilpotent exponentials is
+`TauCeti.baseChangeExp_mul_baseChangeExp_of_commutator_eq`; this file only supplies the
+Lie-theoretic hypotheses and transports the identity to the root subgroups in
+`LinearMap.GeneralLinearGroup`.
+
+## Main results
+
+* `TauCeti.UniversalEnvelopingAlgebra.commute_kostantRootSubgroupPoints`: root subgroups of
+  commuting root vectors commute.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupPoints_mul_of_lie_eq`: the Chevalley
+  commutator relation, for any `𝔾ₐ`-point carrying the parameter `c * t * u`.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupPoints_mul_of_lie_eq'`: the same relation
+  with that point written out.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupPoints_conj_of_lie_eq`: its conjugation
+  form.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* R. W. Carter, *Simple Groups of Lie Type*, Theorem 5.2.2.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+open TensorProduct WithConv
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe u v w
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {ι : Type w} {κ : Type*}
+variable {V : Type v} [AddCommGroup V] [Module ℚ V]
+
+variable (e : ι → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+
+-- Match tensor products to the `ℤ`-algebra instance stored by `CommAlgCat` objects.
+attribute [local instance high] Algebra.toModule
+
+-- Mathlib does not register the Lie ring of an associative ring as a global instance; the
+-- commutator of two elements of the enveloping algebra is written with it below.
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {A : Type*} [CommRing A] [Algebra ℤ A]
+
+/-- The invertible linear map underlying a Kostant root-subgroup point is the base-changed
+divided-power exponential at the corresponding parameter. -/
+private theorem val_kostantRootSubgroupPoints (i : ι)
+    (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (f : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    (kostantRootSubgroupPoints e h ρ M hM i hnil f).val =
+      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+        (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f)) := by
+  refine LinearMap.ext fun z => ?_
+  rw [← LinearMap.GeneralLinearGroup.coe_toLinearEquiv, kostantRootSubgroupPoints_toLinearEquiv,
+    coe_baseChangeKostantExpHom]
+
+/-- **The degenerate Chevalley commutator relation for Kostant root subgroups.** Root subgroups
+attached to commuting root vectors commute. For a root system this is the case of two roots whose
+sum is not a root and which are not opposite. -/
+theorem commute_kostantRootSubgroupPoints {i j : ι} (hij : ⁅e i, e j⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (f g : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    Commute (kostantRootSubgroupPoints e h ρ M hM i hi f)
+      (kostantRootSubgroupPoints e h ρ M hM j hj g) := by
+  have hcomm : Commute (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)))
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))) := by
+    have hb := LieHom.map_lie (_root_.UniversalEnvelopingAlgebra.ι ℚ) (e i) (e j)
+    rw [hij, map_zero, LieRing.of_associative_ring_bracket] at hb
+    have := congrArg ρ hb.symm
+    rw [map_sub, map_mul, map_mul, map_zero] at this
+    exact sub_eq_zero.mp this
+  refine Units.ext ?_
+  simp only [Units.val_mul, val_kostantRootSubgroupPoints]
+  exact commute_baseChangeExp M hcomm hi hj _ _ _ _
+
+/-- **The Chevalley commutator relation for Kostant root subgroups.** Suppose the distinguished
+root vectors satisfy `⁅eᵢ, eⱼ⁆ = c • eₖ` with `eₖ` central for both, and let `w` be any
+`𝔾ₐ`-point whose parameter is `c` times the product of the parameters of `f` and `g`. Then
+
+```text
+xᵢ(f) xⱼ(g) = xⱼ(g) xₖ(w) xᵢ(f).
+```
+
+The hypotheses are exactly the class-two case of the Chevalley commutator formula: `α + β` is a
+root, while `2α + β` and `α + 2β` are not. -/
+theorem kostantRootSubgroupPoints_mul_of_lie_eq {i j k : ι} {c : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hik : ⁅e i, e k⁆ = 0) (hjk : ⁅e j, e k⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (f g w : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A))
+    (hw : Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) w) =
+      (c : A) * (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) *
+        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))) :
+    kostantRootSubgroupPoints e h ρ M hM i hi f *
+        kostantRootSubgroupPoints e h ρ M hM j hj g =
+      kostantRootSubgroupPoints e h ρ M hM j hj g *
+        kostantRootSubgroupPoints e h ρ M hM k hk w *
+        kostantRootSubgroupPoints e h ρ M hM i hi f := by
+  -- Abbreviations for the three images of the root vectors.
+  have hbr : ∀ a b : L,
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ a) * ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ b) -
+          ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ b) *
+            ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ a) =
+        ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ ⁅a, b⁆) := by
+    intro a b
+    rw [LieHom.map_lie (_root_.UniversalEnvelopingAlgebra.ι ℚ) a b,
+      LieRing.of_associative_ring_bracket, map_sub, map_mul, map_mul]
+  -- The commutator of the first two root vectors is `c` times the third.
+  have hxy : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) *
+        ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j)) =
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j)) *
+          ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) +
+        c • ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k)) := by
+    have hb := hbr (e i) (e j)
+    rw [hij, map_zsmul, map_zsmul] at hb
+    exact sub_eq_iff_eq_add'.mp hb
+  -- The third root vector commutes with the other two.
+  have hcxz : Commute (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)))
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))) := by
+    have := hbr (e i) (e k)
+    rw [hik, map_zero, map_zero] at this
+    exact sub_eq_zero.mp this
+  have hcyz : Commute (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j)))
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))) := by
+    have := hbr (e j) (e k)
+    rw [hjk, map_zero, map_zero] at this
+    exact sub_eq_zero.mp this
+  -- Nilpotency and stability for the scaled commutator.
+  have hznil : IsNilpotent (c • ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))) := by
+    obtain ⟨N, hN⟩ := hk
+    exact ⟨N, by rw [smul_pow, hN, smul_zero]⟩
+  have hMz : ∀ n, ∀ v ∈ M,
+      Associative.dividedPower n (c • ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))) • v ∈ M := by
+    intro n v hv
+    rw [Associative.dividedPower_zsmul, smul_assoc]
+    exact M.zsmul_mem (dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM k n hv) _
+  refine Units.ext ?_
+  simp only [Units.val_mul, val_kostantRootSubgroupPoints]
+  rw [hw, ← baseChangeExp_zsmul c M
+      (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM k n hv) hMz hk]
+  exact baseChangeExp_mul_baseChangeExp_of_commutator_eq M hxy (Commute.smul_right hcxz c)
+    (Commute.smul_right hcyz c) hi hj hznil _ _ hMz _ _
+
+/-- The Chevalley commutator relation with the third `𝔾ₐ`-point written out: it is the point whose
+parameter is `c` times the product of the parameters of `f` and `g`. -/
+theorem kostantRootSubgroupPoints_mul_of_lie_eq' {i j k : ι} {c : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hik : ⁅e i, e k⁆ = 0) (hjk : ⁅e j, e k⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (f g : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    kostantRootSubgroupPoints e h ρ M hM i hi f *
+        kostantRootSubgroupPoints e h ρ M hM j hj g =
+      kostantRootSubgroupPoints e h ρ M hM j hj g *
+        kostantRootSubgroupPoints e h ρ M hM k hk
+          ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+            (Multiplicative.ofAdd ((c : A) *
+              (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) *
+                Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))))) *
+        kostantRootSubgroupPoints e h ρ M hM i hi f :=
+  kostantRootSubgroupPoints_mul_of_lie_eq e h ρ M hM hij hik hjk hi hj hk f g _
+    (congrArg Multiplicative.toAdd
+      ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).apply_symm_apply _))
+
+/-- The conjugation form of the Chevalley commutator relation: conjugating the root subgroup of
+`eⱼ` by the root subgroup of `eᵢ` multiplies it by the root subgroup of `eₖ`, at the parameter
+`c * t * u`. -/
+theorem kostantRootSubgroupPoints_conj_of_lie_eq {i j k : ι} {c : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hik : ⁅e i, e k⁆ = 0) (hjk : ⁅e j, e k⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (f g w : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A))
+    (hw : Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) w) =
+      (c : A) * (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) *
+        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))) :
+    kostantRootSubgroupPoints e h ρ M hM i hi f *
+        kostantRootSubgroupPoints e h ρ M hM j hj g *
+        (kostantRootSubgroupPoints e h ρ M hM i hi f)⁻¹ =
+      kostantRootSubgroupPoints e h ρ M hM j hj g *
+        kostantRootSubgroupPoints e h ρ M hM k hk w := by
+  rw [kostantRootSubgroupPoints_mul_of_lie_eq e h ρ M hM hij hik hjk hi hj hk f g w hw,
+    mul_inv_cancel_right]
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Ring/Commutator.lean
+++ b/TauCeti/Algebra/Ring/Commutator.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Algebra.Algebra.Basic
+public import Mathlib.Algebra.Algebra.Rat
+public import Mathlib.RingTheory.Nilpotent.Defs
 import Mathlib.Tactic.Abel
 import Mathlib.Tactic.Ring
 
@@ -12,13 +14,15 @@ import Mathlib.Tactic.Ring
 # Commutators in associative rings
 
 This file records identities for moving elements past powers when their ring commutator is a
-scalar multiple of one of the elements.
+scalar multiple of one of the elements, or is central for the two elements it is built from.
 
 ## Main results
 
 * `TauCeti.Associative.mul_pow_eq_pow_mul_add_zsmul`: moving an element past a power of an
   integer-eigenvector for its commutator.
 * `TauCeti.Associative.mul_pow_eq_pow_mul_add_intCast`: the same identity in shifted-factor form.
+* `TauCeti.Associative.isNilpotent_of_commutator_eq`: a commutator commuting with both of its
+  arguments is nilpotent as soon as one of them is.
 -/
 
 public section
@@ -53,5 +57,60 @@ theorem mul_pow_eq_pow_mul_add_intCast (hxy : x * y - y * x = c • y) (n : ℕ)
     x * y ^ n = y ^ n * (x + (c : A) * (n : A)) := by
   rw [mul_pow_eq_pow_mul_add_zsmul hxy, zsmul_eq_mul', mul_add, Int.cast_mul,
     Int.cast_natCast, (Nat.cast_commute n (c : A)).eq]
+
+section CentralCommutator
+
+variable {A : Type*} [Ring A] [Algebra ℚ A] {x y z : A}
+
+/-- **Nilpotency of a central commutator.** If `x * y = y * x + z` with `z` commuting with both `x`
+and `y`, then `z` is nilpotent as soon as `x` is, with the same nilpotency exponent: over a
+`ℚ`-algebra, moving `y` past `xⁿ` releases `n` copies of `z`, and `xⁿ = 0` propagates down to
+`zⁿ = 0`. -/
+theorem isNilpotent_of_commutator_eq (hxy : x * y = y * x + z) (hxz : Commute x z)
+    (hyz : Commute y z) (hx : IsNilpotent x) : IsNilpotent z := by
+  obtain ⟨n, hn⟩ := hx
+  -- Moving `y` past a power of `x` releases that many copies of the commutator.
+  have hpow : ∀ m : ℕ, x ^ (m + 1) * y = y * x ^ (m + 1) + (m + 1) • (z * x ^ m) := by
+    intro m
+    induction m with
+    | zero => simpa using hxy
+    | succ m ih =>
+      have hzx : x * (z * x ^ m) = z * x ^ (m + 1) := by
+        rw [← mul_assoc, hxz.eq, mul_assoc, ← pow_succ']
+      calc x ^ (m + 1 + 1) * y = x * (x ^ (m + 1) * y) := by rw [← mul_assoc, ← pow_succ']
+        _ = x * y * x ^ (m + 1) + (m + 1) • (z * x ^ (m + 1)) := by
+            rw [ih, mul_add, ← mul_assoc, mul_smul_comm, hzx]
+        _ = y * x ^ (m + 1 + 1) + (z * x ^ (m + 1) + (m + 1) • (z * x ^ (m + 1))) := by
+            rw [hxy, add_mul, mul_assoc, ← pow_succ', add_assoc]
+        _ = y * x ^ (m + 1 + 1) + (m + 1 + 1) • (z * x ^ (m + 1)) := by
+            rw [← succ_nsmul']
+  -- Each copy of `z` extracted this way lowers the power of `x` that annihilates it.
+  have hstep : ∀ m k : ℕ, x ^ (m + 1) * z ^ k = 0 → x ^ m * z ^ (k + 1) = 0 := by
+    intro m k h
+    -- Pushing `y` to the right kills the product outright.
+    have hA : x ^ (m + 1) * y * z ^ k = 0 := by
+      rw [mul_assoc, ← (hyz.symm.pow_left k).eq, ← mul_assoc, h, zero_mul]
+    -- Pushing it to the left leaves the released copies of `z`.
+    have hB : x ^ (m + 1) * y * z ^ k = (m + 1) • (x ^ m * z ^ (k + 1)) := by
+      rw [hpow m, add_mul, mul_assoc, h, mul_zero, zero_add, smul_mul_assoc,
+        (hxz.symm.pow_right m).eq, mul_assoc, ← pow_succ']
+    have hkey : ((m + 1 : ℕ) : ℚ) • (x ^ m * z ^ (k + 1)) = 0 := by
+      rw [Nat.cast_smul_eq_nsmul ℚ, ← hB]
+      exact hA
+    have hc : (((m + 1 : ℕ) : ℚ))⁻¹ • (((m + 1 : ℕ) : ℚ) • (x ^ m * z ^ (k + 1))) = 0 := by
+      rw [hkey, smul_zero]
+    rwa [inv_smul_smul₀ (Nat.cast_ne_zero.mpr m.succ_ne_zero)] at hc
+  -- Peel the powers of `x` off one at a time.
+  have hpeel : ∀ k ≤ n, x ^ (n - k) * z ^ k = 0 := by
+    intro k
+    induction k with
+    | zero => intro _; simpa using hn
+    | succ k ih =>
+      intro hk
+      have heq : n - k = n - (k + 1) + 1 := by omega
+      exact hstep (n - (k + 1)) k (by rw [← heq]; exact ih (by omega))
+  exact ⟨n, by simpa using hpeel n le_rfl⟩
+
+end CentralCommutator
 
 end TauCeti.Associative

--- a/TauCeti/RingTheory/DividedPowers/Associative.lean
+++ b/TauCeti/RingTheory/DividedPowers/Associative.lean
@@ -221,6 +221,15 @@ theorem mul_dividedPower_eq_dividedPower_mul_add_intCast
   rw [mul_dividedPower_eq_dividedPower_mul_add_zsmul hxy, zsmul_eq_mul', mul_add,
     Int.cast_mul, Int.cast_natCast, (Nat.cast_commute n (c : A)).eq]
 
+/-- Scaling an element by an integer scales its `n`-th divided power by the `n`-th power of that
+integer. This is the integral companion of `dividedPower_smul`, and is what lets a Chevalley
+structure constant be moved from a root vector to the parameter of its exponential. -/
+theorem dividedPower_zsmul (d : ℤ) (n : ℕ) (x : A) :
+    dividedPower n (d • x) = d ^ n • dividedPower n x := by
+  rw [← Int.cast_smul_eq_zsmul ℚ d x, dividedPower_smul,
+    ← Int.cast_smul_eq_zsmul ℚ (d ^ n) (dividedPower n x)]
+  norm_cast
+
 /-- Divided powers of a negated element acquire the expected sign. -/
 @[simp]
 theorem dividedPower_neg (n : ℕ) (x : A) :

--- a/TauCeti/RingTheory/DividedPowers/Associative.lean
+++ b/TauCeti/RingTheory/DividedPowers/Associative.lean
@@ -223,7 +223,10 @@ theorem mul_dividedPower_eq_dividedPower_mul_add_intCast
 
 /-- Scaling an element by an integer scales its `n`-th divided power by the `n`-th power of that
 integer. This is the integral companion of `dividedPower_smul`, and is what lets a Chevalley
-structure constant be moved from a root vector to the parameter of its exponential. -/
+structure constant be moved from a root vector to the parameter of its exponential.
+
+This is deliberately not a `simp` lemma: `zsmul_eq_mul` rewrites the argument `d • x` of the
+left-hand side to `↑d * x`, so the statement is not in simp-normal form. -/
 theorem dividedPower_zsmul (d : ℤ) (n : ℕ) (x : A) :
     dividedPower n (d • x) = d ^ n • dividedPower n x := by
   rw [← Int.cast_smul_eq_zsmul ℚ d x, dividedPower_smul,

--- a/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
+++ b/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
@@ -133,14 +133,6 @@ theorem baseChangeExp_zsmul (c : ℤ) {x : A} (M : S)
   congr 1
   ring
 
-/-- The truncated exponential of a nilpotent element, over any bound killing that element. -/
-private theorem baseChangeExp_eq_sum {x : A} (M : S)
-    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
-    {N : ℕ} (hN : x ^ N = 0) (t : R) :
-    baseChangeExp x M hM t =
-      ∑ n ∈ range N, t ^ n • (integralDividedPower x M n (hM n)).baseChange R :=
-  baseChangeExp_of_pow_eq_zero x M hM hN t
-
 end BaseChange
 
 /-! ## The generating-function form of normal ordering -/
@@ -191,7 +183,7 @@ private theorem sum_smul_mul_sum_smul_of_normalOrder {R : Type*} [CommRing R]
     · rintro ⟨⟨m, n⟩, k⟩ hw
       simp only [Finset.mem_sigma, Finset.mem_product, Finset.mem_range, Nat.lt_succ_iff,
         le_min_iff] at hw
-      change (⟨(m - k + k, n - k + k), k⟩ : Σ _ : ℕ × ℕ, ℕ) = ⟨(m, n), k⟩
+      dsimp only
       rw [Nat.sub_add_cancel hw.2.1, Nat.sub_add_cancel hw.2.2]
     · rintro ⟨p, k, q⟩ _
       simp
@@ -247,8 +239,9 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq
   have hxN : x ^ N = 0 := pow_eq_zero_of_le (by omega) hkx
   have hyN : y ^ N = 0 := pow_eq_zero_of_le (by omega) hky
   have hzN : z ^ N = 0 := pow_eq_zero_of_le (by omega) hkz
-  rw [baseChangeExp_eq_sum M hMx hxN, baseChangeExp_eq_sum M hMy hyN,
-    baseChangeExp_eq_sum M hMz hzN]
+  rw [baseChangeExp_of_pow_eq_zero x M hMx hxN,
+    baseChangeExp_of_pow_eq_zero y M hMy hyN,
+    baseChangeExp_of_pow_eq_zero z M hMz hzN]
   refine sum_smul_mul_sum_smul_of_normalOrder (R := R)
     (fun n => (integralDividedPower x M n (hMx n)).baseChange R)
     (fun n => (integralDividedPower y M n (hMy n)).baseChange R)
@@ -286,7 +279,8 @@ theorem commute_baseChangeExp {x y : A} (M : S) (hxy : Commute x y)
     Commute (baseChangeExp x M hMx t) (baseChangeExp y M hMy u) := by
   obtain ⟨kx, hkx⟩ := hx
   obtain ⟨ky, hky⟩ := hy
-  rw [baseChangeExp_eq_sum M hMx hkx, baseChangeExp_eq_sum M hMy hky]
+  rw [baseChangeExp_of_pow_eq_zero x M hMx hkx,
+    baseChangeExp_of_pow_eq_zero y M hMy hky]
   refine Commute.sum_left _ _ _ fun m _ => Commute.sum_right _ _ _ fun n _ => ?_
   refine Commute.smul_left (Commute.smul_right ?_ _) _
   have hcomm : integralDividedPower x M m (hMx m) * integralDividedPower y M n (hMy n) =

--- a/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
+++ b/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
@@ -1,0 +1,319 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.RingTheory.DividedPowers.NormalOrdering
+public import TauCeti.RingTheory.Nilpotent.BaseChangeAction
+
+/-!
+# The Chevalley commutator relation for integral nilpotent exponentials
+
+Let `V` be a module over a `ℚ`-algebra `A`, let `M ≤ V` be an additive subgroup, and let
+`x`, `y`, `z` be elements of `A` with
+
+```text
+x * y = y * x + z,   z commuting with both x and y.
+```
+
+The integral divided-power exponentials of `x`, `y`, `z` act on the scalar extension `R ⊗[ℤ] M`
+over every commutative ring `R`, by `TauCeti.baseChangeExp`. The main result below is that they
+satisfy the **Chevalley commutator relation**
+
+```text
+E_x(t) E_y(u) = E_y(u) E_z(t * u) E_x(t).
+```
+
+Equivalently `E_x(t) E_y(u) E_x(t)⁻¹ = E_y(u) E_z(t * u)`: conjugating the one-parameter subgroup
+of `y` by the one-parameter subgroup of `x` multiplies it by the one-parameter subgroup of the
+commutator, at the product parameter. This is the class-two case of the Chevalley commutator
+formula, the case in which the only root of the form `i α + j β` besides `α` and `β` is `α + β`;
+in a simply-laced root system it is the only case that occurs.
+
+Nothing here divides by a factorial in `R`, so the relation holds over a ring of arbitrary
+characteristic. The whole point is the coefficient-one normal-ordering rule
+`TauCeti.Associative.dividedPower_mul_dividedPower_of_commutator_eq`, which says that the
+rational divided powers reorder with integral structure constants; the exponential identity is
+its generating-function form.
+
+## Main results
+
+* `TauCeti.integralDividedPower_mul_integralDividedPower_of_commutator_eq`: normal ordering for the
+  integral operators restricted to `M`.
+* `TauCeti.baseChangeExp_zsmul`: rescaling an element by an integer rescales the parameter of its
+  exponential, which is how a structure constant `± 1` enters.
+* `TauCeti.baseChangeExp_mul_baseChangeExp_of_commutator_eq`: the Chevalley commutator relation.
+* `TauCeti.commute_baseChangeExp`: its degenerate case, when the commutator vanishes.
+* `TauCeti.baseChangeExp_conj_of_commutator_eq`: its conjugation form.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* R. W. Carter, *Simple Groups of Lie Type*, §4.4 and Theorem 5.2.2.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset TensorProduct
+
+universe u v
+
+variable {A : Type*} [Ring A] [Algebra ℚ A]
+variable {V : Type u} [AddCommGroup V] [Module A V]
+variable {S : Type*} [SetLike S V] [AddSubgroupClass S V]
+
+/-! ## Normal ordering the restricted operators -/
+
+/-- **Normal ordering for restricted divided powers.** If `x * y = y * x + z` and `z` commutes with
+both `x` and `y`, the integral operators obtained by restricting divided powers to a stable additive
+subgroup satisfy the coefficient-one straightening rule. -/
+theorem integralDividedPower_mul_integralDividedPower_of_commutator_eq
+    {x y z : A} (M : S) (hxy : x * y = y * x + z) (hxz : Commute x z) (hyz : Commute y z)
+    (hMx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hMy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
+    (hMz : ∀ n, ∀ v ∈ M, Associative.dividedPower n z • v ∈ M)
+    (m n : ℕ) :
+    integralDividedPower x M m (hMx m) * integralDividedPower y M n (hMy n) =
+      ∑ k ∈ range (min m n + 1),
+        integralDividedPower y M (n - k) (hMy (n - k)) *
+          integralDividedPower z M k (hMz k) *
+          integralDividedPower x M (m - k) (hMx (m - k)) := by
+  ext v
+  simp only [Module.End.mul_apply, LinearMap.sum_apply, AddSubmonoidClass.coe_finsetSum,
+    coe_integralDividedPower_apply, ← mul_smul, ← Finset.sum_smul]
+  congr 1
+  simpa only [mul_assoc] using
+    Associative.dividedPower_mul_dividedPower_of_commutator_eq hxy hxz hyz m n
+
+/-! ## Rescaling by an integer -/
+
+/-- Restricting the divided power of an integer multiple scales the restricted operator by the
+same power of that integer. -/
+theorem integralDividedPower_zsmul (c : ℤ) {x : A} (M : S) (n : ℕ)
+    (hM : ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hcM : ∀ v ∈ M, Associative.dividedPower n (c • x) • v ∈ M) :
+    integralDividedPower (c • x) M n hcM = c ^ n • integralDividedPower x M n hM := by
+  ext v
+  rw [coe_integralDividedPower_apply, Associative.dividedPower_zsmul, smul_assoc,
+    LinearMap.smul_apply, ← coe_integralDividedPower_apply x M n hM v]
+  rfl
+
+-- Match tensor products to the module structure carried by the explicit `ℤ`-algebra.
+attribute [local instance high] Algebra.toModule
+
+section BaseChange
+
+variable {R : Type v} [CommRing R] [Algebra ℤ R]
+
+/-- Rescaling an element by an integer `c` rescales the parameter of its integral exponential by
+`c`. This is how a Chevalley structure constant `± 1` is absorbed into the parameter of a root
+subgroup. -/
+theorem baseChangeExp_zsmul (c : ℤ) {x : A} (M : S)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hcM : ∀ n, ∀ v ∈ M, Associative.dividedPower n (c • x) • v ∈ M)
+    (hx : IsNilpotent x) (t : R) :
+    baseChangeExp (c • x) M hcM t = baseChangeExp x M hM ((c : R) * t) := by
+  obtain ⟨k, hk⟩ := hx
+  have hck : (c • x) ^ k = 0 := by
+    rw [smul_pow, hk, smul_zero]
+  rw [baseChangeExp_of_pow_eq_zero (c • x) M hcM hck,
+    baseChangeExp_of_pow_eq_zero x M hM hk]
+  refine Finset.sum_congr rfl fun n _ => ?_
+  have hb : ((c ^ n • integralDividedPower x M n (hM n)).baseChange R :
+      Module.End R (R ⊗[ℤ] M)) = c ^ n • (integralDividedPower x M n (hM n)).baseChange R :=
+    map_zsmul (Module.End.baseChangeHom ℤ R M) _ _
+  rw [integralDividedPower_zsmul c M n (hM n) (hcM n), hb,
+    ← Int.cast_smul_eq_zsmul R (c ^ n) ((integralDividedPower x M n (hM n)).baseChange R),
+    smul_smul, Int.cast_pow]
+  congr 1
+  ring
+
+/-- The truncated exponential of a nilpotent element, over any bound killing that element. -/
+private theorem baseChangeExp_eq_sum {x : A} (M : S)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    {N : ℕ} (hN : x ^ N = 0) (t : R) :
+    baseChangeExp x M hM t =
+      ∑ n ∈ range N, t ^ n • (integralDividedPower x M n (hM n)).baseChange R :=
+  baseChangeExp_of_pow_eq_zero x M hM hN t
+
+end BaseChange
+
+/-! ## The generating-function form of normal ordering -/
+
+-- The combinatorial core: a truncated left factor times a truncated right factor is the reordered
+-- triple product, once the truncation is wide enough that the reindexed square contains no extra
+-- nonzero terms. The reindexing is `(m, n, k) ↦ (n - k, k, m - k)`.
+private theorem sum_smul_mul_sum_smul_of_normalOrder {R : Type*} [CommRing R]
+    {B : Type*} [Ring B] [Algebra R B] (Dx Dy Dz : ℕ → B) (N : ℕ)
+    (hno : ∀ m n, Dx m * Dy n =
+      ∑ k ∈ range (min m n + 1), Dy (n - k) * Dz k * Dx (m - k))
+    (hzero : ∀ p k q : ℕ, N ≤ p + k ∨ N ≤ q + k → Dy p * Dz k * Dx q = 0)
+    (t u : R) :
+    (∑ m ∈ range N, t ^ m • Dx m) * (∑ n ∈ range N, u ^ n • Dy n) =
+      (∑ p ∈ range N, u ^ p • Dy p) * (∑ k ∈ range N, (t * u) ^ k • Dz k) *
+        (∑ q ∈ range N, t ^ q • Dx q) := by
+  classical
+  set G : ℕ × ℕ × ℕ → B := fun w =>
+    (u ^ w.1 * (t * u) ^ w.2.1 * t ^ w.2.2) • (Dy w.1 * Dz w.2.1 * Dx w.2.2) with hG
+  -- Step 1: expand the reordered product over the full cube of indices.
+  have hbox : ∑ w ∈ range N ×ˢ range N ×ˢ range N, G w =
+      (∑ p ∈ range N, u ^ p • Dy p) * (∑ k ∈ range N, (t * u) ^ k • Dz k) *
+        (∑ q ∈ range N, t ^ q • Dx q) := by
+    rw [mul_assoc, Finset.sum_mul_sum, Finset.sum_mul_sum]
+    simp only [hG, Finset.sum_product, Finset.mul_sum, smul_mul_smul_comm, mul_assoc]
+  -- Step 2: expand the original product over the reindexing domain.
+  have hsrc : ∑ w ∈ (range N ×ˢ range N).sigma (fun mn => range (min mn.1 mn.2 + 1)),
+        (t ^ w.1.1 * u ^ w.1.2) • (Dy (w.1.2 - w.2) * Dz w.2 * Dx (w.1.1 - w.2)) =
+      (∑ m ∈ range N, t ^ m • Dx m) * (∑ n ∈ range N, u ^ n • Dy n) := by
+    rw [Finset.sum_sigma, Finset.sum_mul_sum]
+    simp only [Finset.sum_product, smul_mul_smul_comm, hno, Finset.smul_sum]
+  -- Step 3: the reindexing itself, onto the part of the cube it covers.
+  have hbij : ∑ w ∈ (range N ×ˢ range N).sigma (fun mn => range (min mn.1 mn.2 + 1)),
+        (t ^ w.1.1 * u ^ w.1.2) • (Dy (w.1.2 - w.2) * Dz w.2 * Dx (w.1.1 - w.2)) =
+      ∑ w ∈ range N ×ˢ range N ×ˢ range N with w.1 + w.2.1 < N ∧ w.2.2 + w.2.1 < N, G w := by
+    refine Finset.sum_nbij' (fun w => (w.1.2 - w.2, w.2, w.1.1 - w.2))
+      (fun w => ⟨(w.2.2 + w.2.1, w.1 + w.2.1), w.2.1⟩) ?_ ?_ ?_ ?_ ?_
+    · rintro ⟨⟨m, n⟩, k⟩ hw
+      simp only [Finset.mem_sigma, Finset.mem_product, Finset.mem_range, Nat.lt_succ_iff,
+        le_min_iff] at hw
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range]
+      omega
+    · rintro ⟨p, k, q⟩ hw
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range] at hw
+      simp only [Finset.mem_sigma, Finset.mem_product, Finset.mem_range, Nat.lt_succ_iff,
+        le_min_iff]
+      omega
+    · rintro ⟨⟨m, n⟩, k⟩ hw
+      simp only [Finset.mem_sigma, Finset.mem_product, Finset.mem_range, Nat.lt_succ_iff,
+        le_min_iff] at hw
+      change (⟨(m - k + k, n - k + k), k⟩ : Σ _ : ℕ × ℕ, ℕ) = ⟨(m, n), k⟩
+      rw [Nat.sub_add_cancel hw.2.1, Nat.sub_add_cancel hw.2.2]
+    · rintro ⟨p, k, q⟩ _
+      simp
+    · rintro ⟨⟨m, n⟩, k⟩ hw
+      simp only [Finset.mem_sigma, Finset.mem_product, Finset.mem_range, Nat.lt_succ_iff,
+        le_min_iff] at hw
+      obtain ⟨a, rfl⟩ : ∃ a, m = a + k := ⟨m - k, (Nat.sub_add_cancel hw.2.1).symm⟩
+      obtain ⟨b, rfl⟩ : ∃ b, n = b + k := ⟨n - k, (Nat.sub_add_cancel hw.2.2).symm⟩
+      simp only [hG, Nat.add_sub_cancel]
+      congr 1
+      rw [mul_pow]
+      ring
+  -- Step 4: the terms of the cube outside that part vanish.
+  have hsub : ∑ w ∈ range N ×ˢ range N ×ˢ range N with w.1 + w.2.1 < N ∧ w.2.2 + w.2.1 < N,
+        G w = ∑ w ∈ range N ×ˢ range N ×ˢ range N, G w := by
+    refine Finset.sum_subset (Finset.filter_subset _ _) ?_
+    rintro ⟨p, k, q⟩ hmem hnot
+    simp only [Finset.mem_product, Finset.mem_range] at hmem
+    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range] at hnot
+    have hor : N ≤ p + k ∨ N ≤ q + k := by omega
+    simp [hG, hzero p k q hor]
+  rw [← hsrc, hbij, hsub, hbox]
+
+/-! ## The Chevalley commutator relation -/
+
+section Commutator
+
+variable {R : Type v} [CommRing R] [Algebra ℤ R]
+
+/-- **The Chevalley commutator relation for integral nilpotent exponentials.** If
+`x * y = y * x + z` with `z` commuting with `x` and with `y`, then over every commutative ring `R`
+the integral divided-power exponentials on `R ⊗[ℤ] M` satisfy
+
+```text
+E_x(t) E_y(u) = E_y(u) E_z(t * u) E_x(t).
+```
+
+No factorial is inverted in `R`: the relation holds in every characteristic. -/
+theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq
+    {x y z : A} (M : S) (hxy : x * y = y * x + z) (hxz : Commute x z) (hyz : Commute y z)
+    (hx : IsNilpotent x) (hy : IsNilpotent y) (hz : IsNilpotent z)
+    (hMx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hMy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
+    (hMz : ∀ n, ∀ v ∈ M, Associative.dividedPower n z • v ∈ M)
+    (t u : R) :
+    baseChangeExp x M hMx t * baseChangeExp y M hMy u =
+      baseChangeExp y M hMy u * baseChangeExp z M hMz (t * u) * baseChangeExp x M hMx t := by
+  classical
+  obtain ⟨kx, hkx⟩ := hx
+  obtain ⟨ky, hky⟩ := hy
+  obtain ⟨kz, hkz⟩ := hz
+  set N := kx + ky + kz with hNdef
+  have hxN : x ^ N = 0 := pow_eq_zero_of_le (by omega) hkx
+  have hyN : y ^ N = 0 := pow_eq_zero_of_le (by omega) hky
+  have hzN : z ^ N = 0 := pow_eq_zero_of_le (by omega) hkz
+  rw [baseChangeExp_eq_sum M hMx hxN, baseChangeExp_eq_sum M hMy hyN,
+    baseChangeExp_eq_sum M hMz hzN]
+  refine sum_smul_mul_sum_smul_of_normalOrder (R := R)
+    (fun n => (integralDividedPower x M n (hMx n)).baseChange R)
+    (fun n => (integralDividedPower y M n (hMy n)).baseChange R)
+    (fun n => (integralDividedPower z M n (hMz n)).baseChange R) N ?_ ?_ t u
+  · intro m n
+    have h := congrArg (fun f : Module.End ℤ M => (Module.End.baseChangeHom ℤ R M) f)
+      (integralDividedPower_mul_integralDividedPower_of_commutator_eq M hxy hxz hyz hMx hMy hMz m n)
+    simp only [map_mul, map_sum] at h
+    exact h
+  · -- Outside the truncation the reordered triple has a vanishing factor.
+    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 := by
+      intro q hq
+      rw [integralDividedPower_eq_zero_of_le x M q (hMx q) hkx hq, LinearMap.baseChange_zero]
+    have hvy : ∀ p, ky ≤ p → (integralDividedPower y M p (hMy p)).baseChange R = 0 := by
+      intro p hp
+      rw [integralDividedPower_eq_zero_of_le y M p (hMy p) hky hp, LinearMap.baseChange_zero]
+    have hvz : ∀ k, kz ≤ k → (integralDividedPower z M k (hMz k)).baseChange R = 0 := by
+      intro k hk
+      rw [integralDividedPower_eq_zero_of_le z M k (hMz k) hkz hk, LinearMap.baseChange_zero]
+    rintro p k q (hpk | hqk)
+    · rcases le_or_gt ky p with hp | hp
+      · rw [hvy p hp, zero_mul, zero_mul]
+      · rw [hvz k (by omega), mul_zero, zero_mul]
+    · rcases le_or_gt kx q with hq | hq
+      · rw [hvx q hq, mul_zero]
+      · rw [hvz k (by omega), mul_zero, zero_mul]
+
+/-- **The degenerate Chevalley commutator relation.** Exponentials of commuting elements commute.
+For root subgroups this is the case of two roots whose sum is not a root. -/
+theorem commute_baseChangeExp {x y : A} (M : S) (hxy : Commute x y)
+    (hx : IsNilpotent x) (hy : IsNilpotent y)
+    (hMx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hMy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
+    (t u : R) :
+    Commute (baseChangeExp x M hMx t) (baseChangeExp y M hMy u) := by
+  obtain ⟨kx, hkx⟩ := hx
+  obtain ⟨ky, hky⟩ := hy
+  rw [baseChangeExp_eq_sum M hMx hkx, baseChangeExp_eq_sum M hMy hky]
+  refine Commute.sum_left _ _ _ fun m _ => Commute.sum_right _ _ _ fun n _ => ?_
+  refine Commute.smul_left (Commute.smul_right ?_ _) _
+  have hcomm : integralDividedPower x M m (hMx m) * integralDividedPower y M n (hMy n) =
+      integralDividedPower y M n (hMy n) * integralDividedPower x M m (hMx m) := by
+    ext v
+    simp only [Module.End.mul_apply, coe_integralDividedPower_apply, ← mul_smul]
+    rw [(Associative.commute_dividedPower_dividedPower hxy m n).eq]
+  have h := congrArg (fun f : Module.End ℤ M => (Module.End.baseChangeHom ℤ R M) f) hcomm
+  simp only [map_mul] at h
+  exact h
+
+/-- The conjugation form of the Chevalley commutator relation: conjugating the one-parameter
+subgroup of `y` by that of `x` multiplies it by the one-parameter subgroup of the commutator `z`,
+at the product parameter. -/
+theorem baseChangeExp_conj_of_commutator_eq
+    {x y z : A} (M : S) (hxy : x * y = y * x + z) (hxz : Commute x z) (hyz : Commute y z)
+    (hx : IsNilpotent x) (hy : IsNilpotent y) (hz : IsNilpotent z)
+    (hMx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hMy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
+    (hMz : ∀ n, ∀ v ∈ M, Associative.dividedPower n z • v ∈ M)
+    (t u : R) :
+    baseChangeExp x M hMx t * baseChangeExp y M hMy u * baseChangeExp x M hMx (-t) =
+      baseChangeExp y M hMy u * baseChangeExp z M hMz (t * u) := by
+  rw [baseChangeExp_mul_baseChangeExp_of_commutator_eq M hxy hxz hyz hx hy hz hMx hMy hMz t u,
+    mul_assoc, ← baseChangeExp_add x M hMx hx t (-t), add_neg_cancel,
+    baseChangeExp_zero x M hMx hx, mul_one]
+
+end Commutator
+
+end TauCeti

--- a/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
+++ b/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
@@ -30,7 +30,8 @@ Equivalently `E_x(t) E_y(u) E_x(t)⁻¹ = E_y(u) E_z(t * u)`: conjugating the on
 of `y` by the one-parameter subgroup of `x` multiplies it by the one-parameter subgroup of the
 commutator, at the product parameter. This is the class-two case of the Chevalley commutator
 formula, the case in which the only root of the form `i α + j β` besides `α` and `β` is `α + β`;
-in a simply-laced root system it is the only case that occurs.
+in a simply-laced root system every pair of non-proportional roots falls under it or under the
+degenerate case below.
 
 Nothing here divides by a factorial in `R`, so the relation holds over a ring of arbitrary
 characteristic. The whole point is the coefficient-one normal-ordering rule
@@ -224,7 +225,7 @@ E_x(t) E_y(u) = E_y(u) E_z(t * u) E_x(t).
 No factorial is inverted in `R`: the relation holds in every characteristic. -/
 theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq
     {x y z : A} (M : S) (hxy : x * y = y * x + z) (hxz : Commute x z) (hyz : Commute y z)
-    (hx : IsNilpotent x) (hy : IsNilpotent y) (hz : IsNilpotent z)
+    (hx : IsNilpotent x) (hy : IsNilpotent y)
     (hMx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
     (hMy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
     (hMz : ∀ n, ∀ v ∈ M, Associative.dividedPower n z • v ∈ M)
@@ -232,9 +233,9 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq
     baseChangeExp x M hMx t * baseChangeExp y M hMy u =
       baseChangeExp y M hMy u * baseChangeExp z M hMz (t * u) * baseChangeExp x M hMx t := by
   classical
+  obtain ⟨kz, hkz⟩ := Associative.isNilpotent_of_commutator_eq hxy hxz hyz hx
   obtain ⟨kx, hkx⟩ := hx
   obtain ⟨ky, hky⟩ := hy
-  obtain ⟨kz, hkz⟩ := hz
   set N := kx + ky + kz with hNdef
   have hxN : x ^ N = 0 := pow_eq_zero_of_le (by omega) hkx
   have hyN : y ^ N = 0 := pow_eq_zero_of_le (by omega) hky
@@ -270,7 +271,8 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq
       · rw [hvz k (by omega), mul_zero, zero_mul]
 
 /-- **The degenerate Chevalley commutator relation.** Exponentials of commuting elements commute.
-For root subgroups this is the case of two roots whose sum is not a root. -/
+For root subgroups this is the case of two roots which are not opposite and whose sum is not a
+root. -/
 theorem commute_baseChangeExp {x y : A} (M : S) (hxy : Commute x y)
     (hx : IsNilpotent x) (hy : IsNilpotent y)
     (hMx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
@@ -297,14 +299,14 @@ subgroup of `y` by that of `x` multiplies it by the one-parameter subgroup of th
 at the product parameter. -/
 theorem baseChangeExp_conj_of_commutator_eq
     {x y z : A} (M : S) (hxy : x * y = y * x + z) (hxz : Commute x z) (hyz : Commute y z)
-    (hx : IsNilpotent x) (hy : IsNilpotent y) (hz : IsNilpotent z)
+    (hx : IsNilpotent x) (hy : IsNilpotent y)
     (hMx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
     (hMy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
     (hMz : ∀ n, ∀ v ∈ M, Associative.dividedPower n z • v ∈ M)
     (t u : R) :
     baseChangeExp x M hMx t * baseChangeExp y M hMy u * baseChangeExp x M hMx (-t) =
       baseChangeExp y M hMy u * baseChangeExp z M hMz (t * u) := by
-  rw [baseChangeExp_mul_baseChangeExp_of_commutator_eq M hxy hxz hyz hx hy hz hMx hMy hMz t u,
+  rw [baseChangeExp_mul_baseChangeExp_of_commutator_eq M hxy hxz hyz hx hy hMx hMy hMz t u,
     mul_assoc, ← baseChangeExp_add x M hMx hx t (-t), add_neg_cancel,
     baseChangeExp_zero x M hMx hx, mul_one]
 

--- a/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
+++ b/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
@@ -44,7 +44,7 @@ its generating-function form.
 * `TauCeti.integralDividedPower_mul_integralDividedPower_of_commutator_eq`: normal ordering for the
   integral operators restricted to `M`.
 * `TauCeti.baseChangeExp_zsmul`: rescaling an element by an integer rescales the parameter of its
-  exponential, which is how a structure constant `± 1` enters.
+  exponential, which is how an integer structure constant enters.
 * `TauCeti.baseChangeExp_mul_baseChangeExp_of_commutator_eq`: the Chevalley commutator relation.
 * `TauCeti.commute_baseChangeExp`: its degenerate case, when the commutator vanishes.
 * `TauCeti.baseChangeExp_conj_of_commutator_eq`: its conjugation form.
@@ -112,7 +112,7 @@ section BaseChange
 variable {R : Type v} [CommRing R] [Algebra ℤ R]
 
 /-- Rescaling an element by an integer `c` rescales the parameter of its integral exponential by
-`c`. This is how a Chevalley structure constant `± 1` is absorbed into the parameter of a root
+`c`. This is how an integer Chevalley structure constant is absorbed into the parameter of a root
 subgroup. -/
 theorem baseChangeExp_zsmul (c : ℤ) {x : A} (M : S)
     (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)


### PR DESCRIPTION
This PR proves the Chevalley commutator relations satisfied by the Kostant root subgroups, over an arbitrary commutative base ring. Two roots whose sum is not a root give commuting root subgroups, and when `⁅eᵢ, eⱼ⁆ = c • eₖ` with `eₖ` bracketing to zero against both, the relation is `xᵢ(t) xⱼ(u) xᵢ(t)⁻¹ = xⱼ(u) xₖ(c t u)`, with `c` the Chevalley structure constant `N_{αβ}` carried into the parameter. The underlying statement is about integral divided-power exponentials of a nilpotent element acting on a stable additive subgroup `M ≤ V`, so no factorial is inverted in the base ring and the relation holds in every characteristic; it is the generating-function form of the already merged coefficient-one straightening rule `TauCeti.Associative.dividedPower_mul_dividedPower_of_commutator_eq`.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 9 "pinned Chevalley--Demazure group schemes over `ℤ`", bullet "**Root subgroup maps.** `x_α : 𝔾_a → G` for each root `α`, the Chevalley commutator relations they satisfy, and the equations pinning them against the pinning. Downstream work states its conventions against these, so they are part of the interface, not an implementation detail." This is the most effective current step on that milestone because the maps themselves already exist on `main` — `kostantRootSubgroupPoints` with its value-ring naturality, its matrix coordinates and its packaging as a natural point representation — as does the normal-ordering rule the relations descend from, while nothing yet connected the two; the remaining representability step for those maps is already in flight in #3463 and is disjoint from this one. After this PR, Layer 9 still needs integral PBW and a finite free admissible lattice, the assembled pinned group scheme with its split torus and Borel, base change together with pinning compatibility, the pinned isomorphism theorem, and the characteristic two and three special isogenies; the commutator formula for the longer root strings occurring in types `B`, `C`, `F₄` and `G₂` also remains, the class-two case proved here being the only one that occurs in the simply-laced types.

The dependency edge is: `CFSGStatement` milestone L0, "explicit pinned Chevalley--Demazure groups", lists among the declarations it consumes "root-subgroup maps `x_α` and the equations expressing their compatibility with the pinning" from reductive groups Layer 9, and uses them to give the bodies of `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup`. The equations proved here are those relations for the class-two root pairs. `CFSGStatement` itself has no unclaimed step: its sporadic lane `S0`/`S1` is finished, `A0` waits on `L3`, and `L0` is blocked precisely on this layer, so this PR follows the dependency the roadmap declares rather than working in the preferred roadmap.

`TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean` (319 lines) proves normal ordering for the operators restricted to `M`, the rescaling law `baseChangeExp_zsmul` that absorbs an integer structure constant into the parameter, the relation `E_x(t) E_y(u) = E_y(u) E_z(t u) E_x(t)` and its conjugation form, and the degenerate case `commute_baseChangeExp`. Its combinatorial core reindexes a truncated double sum as a triple sum by `(m, n, k) ↦ (n - k, k, m - k)` and discards the terms of the enlarged cube that carry a vanishing divided power. `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean` (227 lines) supplies the Lie-theoretic hypotheses from brackets of the distinguished root vectors and transports the identities to `LinearMap.GeneralLinearGroup`. `TauCeti/RingTheory/DividedPowers/Associative.lean` gains the nine-line companion `dividedPower_zsmul` of the existing `dividedPower_smul`, next to it.

The work reuses Tau Ceti's `Associative.dividedPower_mul_dividedPower_of_commutator_eq`, `baseChangeExp` with its truncation and one-parameter-group lemmas, `integralDividedPower`, and `kostantRootSubgroupPoints`, together with Mathlib's `Module.End.baseChangeHom`, `Finset.sum_nbij'`, `Finset.sum_mul_sum` and `Commute.smul_right`. No Mathlib infrastructure is vendored. The mathematics is the class-two case of Chevalley's commutator formula as in Carter, *Simple Groups of Lie Type*, Theorem 5.2.2, with the integrality of the divided-power form following Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27 and Jantzen, *Representations of Algebraic Groups*, II.1.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"chevalley-commutator-relation-kostant-root-subgroups"}-->

🤖 Prepared with Claude Code
