### PR TITLE
feat: complete Hille-Yosida generation

### DIFF
--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Convergence.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Convergence.lean
@@ -32,9 +32,9 @@ alone.
 Completeness then turns this Cauchy property into a candidate pointwise limit family.
 `TauCeti.Semigroups.hilleYosidaLimitSemigroup` in
 `TauCeti/Analysis/Semigroups/Generation/HilleYosida/Limit.lean` packages this family into a
-strongly continuous semigroup and establishes its growth bound `(0, M)`. Identifying its
-generator as `A`, and reducing the general growth exponent to zero
-(`TauCeti.LinearPMap.hilleYosida_zero_of`), remain separate steps of the generation theorem.
+strongly continuous semigroup and establishes its growth bound `(0, M)`. Its generator is
+identified as `A`, and the reduction from a general growth exponent is reversed, in
+`TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean`.
 
 ## Main results
 

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.Generation.HilleYosida.Limit
+public import TauCeti.Analysis.Semigroups.Generation.HilleYosida.Shift
+public import TauCeti.Analysis.Semigroups.Generation.Yosida.Generator
+public import TauCeti.Analysis.Semigroups.Generator.ExponentialShift
+public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+
+/-!
+# The Hille--Yosida generation theorem
+
+This file completes the Yosida construction for a densely defined operator `A` on a real Banach
+space. At growth exponent zero, the resolvent-power estimates
+
+`‖R(lambda, A) ^ n‖ ≤ M / lambda ^ n`
+
+produce the semigroup `hilleYosidaLimitSemigroup`. The compact-time convergence of its bounded
+approximations and the shared positive resolvent half-line identify the generator of that
+semigroup with `A`.
+
+For a general growth exponent `omega`, apply the zero-exponent construction to
+`A - omega I`, then exponentially shift the resulting semigroup back. The scalar-shift identities
+for partial linear maps and semigroup generators show that the final generator is exactly `A`,
+while the growth bound becomes `(omega, M)`.
+
+This proves the Hille--Yosida milestone in Part A of the
+[one-parameter-semigroups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/OneParameterSemigroups/README.md#part-a--strongly-continuous-semigroups).
+
+## Main results
+
+* `TauCeti.Semigroups.hilleYosidaLimitSemigroup_generator`: the exponent-zero limit semigroup has
+  generator `A`.
+* `TauCeti.Semigroups.hilleYosida_generation`: the general `(M, omega)` Hille--Yosida generation
+  theorem.
+
+## References
+
+* K.-J. Engel and R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations*,
+  Theorem II.3.8.
+* A. Pazy, *Semigroups of Linear Operators and Applications to Partial Differential Equations*,
+  Chapter 1, Theorem 5.3.
+-/
+
+public section
+
+noncomputable section
+
+open Filter NormedSpace
+open scoped NNReal Topology
+
+namespace TauCeti.Semigroups
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
+
+/-! ## Generator identification at exponent zero -/
+
+/-- **The exponent-zero Hille--Yosida limit semigroup has generator `A`.**
+
+The first resolvent-power estimate makes the Yosida approximations converge to `A` on its dense
+domain. All power estimates together bound their exponentials by `M`, and the compact-time limit
+theorems identify those exponentials with the orbits of `hilleYosidaLimitSemigroup`. Finally,
+`1` is a resolvent point of both `A` and the limit generator, so the inclusion obtained from the
+integrated Cauchy equation is an equality. -/
+@[simp]
+theorem hilleYosidaLimitSemigroup_generator {A : X →ₗ.[ℝ] X} {M : ℝ}
+    (hM : 1 ≤ M)
+    (hres : ∀ lambda : ℝ, 0 < lambda → lambda ∈ LinearPMap.resolventSet A)
+    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, 0 < lambda →
+      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / lambda ^ n)
+    (hdense : Dense (A.domain : Set X)) :
+    (hilleYosidaLimitSemigroup hM hres hpow hdense).generator = A := by
+  let S := hilleYosidaLimitSemigroup hM hres hpow hdense
+  have hbound : ∀ lambda : ℝ, 0 < lambda →
+      ‖LinearPMap.resolvent A lambda‖ ≤ M / lambda := by
+    intro lambda hlambda
+    simpa using hpow 1 le_rfl lambda hlambda
+  apply S.generator_eq_of_yosidaApproximation (lambda := 1)
+    (hres 1 one_pos)
+    (S.mem_resolventSet_generator
+      (hasGrowthBound_hilleYosidaLimitSemigroup hM hres hpow hdense) one_pos)
+  · exact tendsto_yosidaApproximation_apply_atTop hres hbound hdense
+  · intro x t ht
+    simpa only [S, hilleYosidaLimitSemigroup_realOperator_apply_of_nonneg hM hres hpow hdense
+      ht (x : X)] using
+      tendsto_yosidaLimit_of_norm_resolvent_pow_le hM hres hpow hdense ht (x : X)
+  · intro x T hT
+    refine (tendstoUniformlyOn_exp_yosidaApproximation_of_norm_resolvent_pow_le
+      hM hres hpow hdense (A x) hT).congr_right fun u hu => ?_
+    exact (hilleYosidaLimitSemigroup_realOperator_apply_of_nonneg hM hres hpow hdense
+      hu.1 (A x)).symm
+  · intro T _hT
+    refine ⟨M, ?_⟩
+    filter_upwards [eventually_gt_atTop (0 : ℝ)] with lambda hlambda u hu
+    exact norm_exp_smul_yosidaApproximation_le hM hlambda hu.1
+      fun n hn => hpow n hn lambda hlambda
+
+/-! ## The general generation theorem -/
+
+/-- **Hille--Yosida generation theorem.** Let `A` be a densely defined operator on a real Banach
+space, let `1 ≤ M`, and suppose that every real `lambda > omega` belongs to the resolvent set of
+`A`, with the power estimates
+
+`‖R(lambda, A) ^ n‖ ≤ M / (lambda - omega) ^ n` for every `n ≥ 1`.
+
+Then `A` generates a strongly continuous semigroup with growth bound `(omega, M)`. The produced
+semigroup is the exponential unshift of the exponent-zero Yosida limit for `A - omega I`. -/
+theorem hilleYosida_generation {A : X →ₗ.[ℝ] X} {M omega : ℝ}
+    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
+    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
+    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
+    ∃ S : StronglyContinuousSemigroup X, S.generator = A ∧ S.HasGrowthBound omega M := by
+  obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
+  have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
+    simpa using hdense
+  let T := hilleYosidaLimitSemigroup hM hres₀ hpow₀ hdense₀
+  refine ⟨T.expShift (-omega), ?_, ?_⟩
+  · rw [StronglyContinuousSemigroup.generator_expShift]
+    change LinearPMap.subScalar T.generator (-omega) = A
+    dsimp only [T]
+    rw [hilleYosidaLimitSemigroup_generator hM hres₀ hpow₀ hdense₀,
+      LinearPMap.subScalar_subScalar, add_neg_cancel, LinearPMap.subScalar_zero]
+  · have hT : T.HasGrowthBound 0 M := by
+      exact hasGrowthBound_hilleYosidaLimitSemigroup hM hres₀ hpow₀ hdense₀
+    simpa using hT.expShift (lambda := -omega)
+
+end TauCeti.Semigroups
+
+end

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
@@ -121,7 +121,6 @@ theorem hilleYosida_generation {A : X →ₗ.[ℝ] X} {M omega : ℝ}
   let T := hilleYosidaLimitSemigroup hM hres₀ hpow₀ hdense₀
   refine ⟨T.expShift (-omega), ?_, ?_⟩
   · rw [StronglyContinuousSemigroup.generator_expShift]
-    change LinearPMap.subScalar T.generator (-omega) = A
     dsimp only [T]
     rw [hilleYosidaLimitSemigroup_generator hM hres₀ hpow₀ hdense₀,
       LinearPMap.subScalar_subScalar, add_neg_cancel, LinearPMap.subScalar_zero]

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Limit.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Limit.lean
@@ -24,8 +24,9 @@ The underlying limit is `TauCeti.Semigroups.yosidaLimit`, shared with the Lumer-
 construction. The semigroup packaging is obtained from the shared constructor
 `TauCeti.Semigroups.yosidaLimitSemigroupOfTendsto` in `LimitSemigroup.lean`.
 
-This is the limit stage of the Hille--Yosida generation theorem. Identifying the generator with
-`A`, and then undoing the scalar shift, remain separate steps.
+This is the limit stage of the Hille--Yosida generation theorem. The generator identification and
+the scalar unshift are carried out in
+`TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean`.
 
 ## Main results
 

--- a/TauCeti/Analysis/Semigroups/Generation/Yosida/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/Yosida/Generator.lean
@@ -35,8 +35,8 @@ identity makes the generator difference quotients converge to `A x`. A shared re
 This is the generator-identification rung that follows the construction of the limit semigroup in
 a generation theorem. The Lumer--Phillips theorem in
 `TauCeti/Analysis/Semigroups/Generation/LumerPhillips.lean` supplies the hypotheses with the
-contraction bound `1`; the planned general Hille--Yosida construction will supply them with its
-growth constant `M`.
+contraction bound `1`; `TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean`
+supplies them with the general Hille--Yosida growth constant `M`.
 
 ## Main results
 


### PR DESCRIPTION
This PR completes the Hille--Yosida generation theorem for densely defined real-linear partial operators: identify the generator of the exponent-zero Yosida limit semigroup, then undo the scalar shift to produce a strongly continuous semigroup with the prescribed general `(M, omega)` growth bound.

The exact roadmap target is `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A, milestone “Hille--Yosida generation theorem.” The new `hilleYosidaLimitSemigroup_generator` theorem instantiates the shared Yosida generator-identification argument using compact-time convergence, the `M`-bound on approximating exponentials, and the common resolvent point `1`. The headline `hilleYosida_generation` theorem applies that result to `A - omega I`, then uses `generator_expShift`, `subScalar_subScalar`, and `HasGrowthBound.expShift` to recover generator `A` and growth bound `(omega, M)`.

This closes the Hille--Yosida milestone. Nothing remains for that milestone; later Part A work consists of independent API targets such as complex resolvent analyticity and further concrete examples.

The preferred `CFSGStatement` roadmap has no viable unclaimed direct step: its classification statement is already in flight, and its next CFSG layer is explicitly blocked on ReductiveGroups Layer 9, whose immediate construction fronts are also in flight. `OneParameterSemigroups` therefore supplies the next coherent fallback milestone, and this PR closes it rather than adding peripheral scaffolding.

The implementation adds `TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean` (134 lines) and refreshes three nearby module docstrings that previously described generator identification as future work. No Mathlib infrastructure is vendored; the proof consumes Tau Ceti’s existing Yosida convergence, limit-semigroup, scalar-shift, generator-shift, and resolvent APIs.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"hille-yosida-generation"}-->

🤖 Prepared with Codex
