### PR TITLE
refactor(ModularForms): name the positive determinant of 𝒮ℒ elements once

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Basic.lean
@@ -60,6 +60,22 @@ open Matrix Matrix.SpecialLinearGroup UpperHalfPlane
 
 open scoped MatrixGroups ModularForm
 
+/-- **Every element of `𝒮ℒ` has positive determinant**: it is the image of a matrix of
+determinant `1`.
+
+This is the hypothesis the positive-determinant slash lemmas take — `σ_eq_refl_of_det_pos` just
+below, and `orderOfVanishingAt_slash` / `orderOfVanishingAt_smul` in
+`TauCeti.NumberTheory.ModularForms.Order.OfVanishing` — and every modular call site discharges
+it the same way. Keying it on membership in `𝒮ℒ` rather than on
+`Matrix.SpecialLinearGroup.mapGL` covers both shapes the call sites come in: a direct image
+`mapGL ℝ γ` (via `MonoidHom.mem_range.mpr ⟨γ, rfl⟩`) and an element of the image of a subgroup
+`Γ ≤ SL(2, ℤ)` (via `Subgroup.map_le_range`). -/
+theorem det_pos_of_mem_slGL {g : GL (Fin 2) ℝ} (hg : g ∈ 𝒮ℒ) :
+    0 < (g : Matrix (Fin 2) (Fin 2) ℝ).det := by
+  obtain ⟨γ, rfl⟩ := hg
+  rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL]
+  exact one_pos
+
 /-- The slash-action conjugation `σ` is the identity for matrices coming from
 `SL₂(ℤ)`: their determinant is `1 > 0`, so the `σ` branch picks `ContinuousAlgEquiv.refl ℝ ℂ`.
 
@@ -70,7 +86,7 @@ determinant of a mapped `SL(2, ℤ)` matrix reduces through `GeneralLinearGroup.
 @[simp]
 lemma σ_mapGL_real_eq_refl (s : SL(2, ℤ)) :
     UpperHalfPlane.σ (mapGL ℝ s) = ContinuousAlgEquiv.refl ℝ ℂ :=
-  σ_eq_refl_of_det_pos (by rw [← Matrix.GeneralLinearGroup.val_det_apply]; simp)
+  σ_eq_refl_of_det_pos (det_pos_of_mem_slGL (MonoidHom.mem_range.mpr ⟨s, rfl⟩))
 
 /-- `CuspForm.mcast` does not change the pointwise values of a cusp form: the `CuspForm`
 analogue of Mathlib's `ModularForm.mcast_apply`, which Mathlib does not yet provide. -/

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/BoundaryPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/BoundaryPairing.lean
@@ -134,8 +134,7 @@ private lemma orderOfVanishingAt_S_smul [SlashInvariantFormClass F Γ k] (f : F)
   rw [MulAction.compHom_smul_def]
   exact orderOfVanishingAt_smul f (γ := Matrix.SpecialLinearGroup.mapGL ℝ ModularGroup.S)
     (Subgroup.mem_map_of_mem _ hSmem)
-    (by rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL]
-        exact one_pos) p
+    (det_pos_of_mem_slGL (MonoidHom.mem_range.mpr ⟨ModularGroup.S, rfl⟩)) p
 
 /-- Over a divisor set complete for `𝒟`, a nonzero-order point of the unit arc is carried by the
 inversion back into the set, again on the unit arc, with the real part flipped. -/

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -222,6 +222,20 @@ lemma orderOfVanishingAt_slash (g : ℍ → ℂ) {γ : GL (Fin 2) ℝ}
     meromorphicOrderAt_mul_of_ne_zero h_an h_ne, meromorphicOrderAt_comp_smul hdet,
     Function.comp_def]
 
+/-- **Every element of `𝒮ℒ` has positive determinant**: it is the image of a matrix of
+determinant `1`.
+
+This is the hypothesis `orderOfVanishingAt_slash` and `orderOfVanishingAt_smul` below take, and
+every modular call site discharges it the same way. Keying it on membership in `𝒮ℒ` rather than
+on `Matrix.SpecialLinearGroup.mapGL` covers both shapes the call sites come in: a direct image
+`mapGL ℝ γ` (via `MonoidHom.mem_range.mpr ⟨γ, rfl⟩`) and an element of the image of a subgroup
+`Γ ≤ SL(2, ℤ)` (via `Subgroup.map_le_range`). -/
+theorem det_pos_of_mem_slGL {g : GL (Fin 2) ℝ} (hg : g ∈ 𝒮ℒ) :
+    0 < (g : Matrix (Fin 2) (Fin 2) ℝ).det := by
+  obtain ⟨γ, rfl⟩ := hg
+  rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL]
+  exact one_pos
+
 /-- The vanishing order of a slash-invariant form is constant along the action of any
 positive-determinant element of the group. -/
 -- Not a `simp` lemma: the subgroup `Γ` occurs only in the hypotheses, so `simpNF` rejects

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -222,20 +222,6 @@ lemma orderOfVanishingAt_slash (g : ℍ → ℂ) {γ : GL (Fin 2) ℝ}
     meromorphicOrderAt_mul_of_ne_zero h_an h_ne, meromorphicOrderAt_comp_smul hdet,
     Function.comp_def]
 
-/-- **Every element of `𝒮ℒ` has positive determinant**: it is the image of a matrix of
-determinant `1`.
-
-This is the hypothesis `orderOfVanishingAt_slash` and `orderOfVanishingAt_smul` below take, and
-every modular call site discharges it the same way. Keying it on membership in `𝒮ℒ` rather than
-on `Matrix.SpecialLinearGroup.mapGL` covers both shapes the call sites come in: a direct image
-`mapGL ℝ γ` (via `MonoidHom.mem_range.mpr ⟨γ, rfl⟩`) and an element of the image of a subgroup
-`Γ ≤ SL(2, ℤ)` (via `Subgroup.map_le_range`). -/
-theorem det_pos_of_mem_slGL {g : GL (Fin 2) ℝ} (hg : g ∈ 𝒮ℒ) :
-    0 < (g : Matrix (Fin 2) (Fin 2) ℝ).det := by
-  obtain ⟨γ, rfl⟩ := hg
-  rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL]
-  exact one_pos
-
 /-- The vanishing order of a slash-invariant form is constant along the action of any
 positive-determinant element of the group. -/
 -- Not a `simp` lemma: the subgroup `Γ` occurs only in the hypotheses, so `simpNF` rejects

--- a/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
@@ -66,9 +66,8 @@ def orderOfVanishingOnOrbit [SlashInvariantFormClass F 𝒮ℒ k]
     have hg' : g • b = _ := hg
     rw [← hg', MulAction.compHom_smul_def,
       orderOfVanishingAt_smul f (γ := Matrix.SpecialLinearGroup.mapGL ℝ g)
-        (MonoidHom.mem_range.mpr ⟨g, rfl⟩) (by
-          rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL]
-          exact one_pos) b]
+        (MonoidHom.mem_range.mpr ⟨g, rfl⟩)
+        (det_pos_of_mem_slGL (MonoidHom.mem_range.mpr ⟨g, rfl⟩)) b]
 
 /-- Evaluating the descended order on the orbit of `p` recovers the vanishing order at
 `p`. -/

--- a/TauCeti/NumberTheory/ModularForms/Order/SubgroupOrbits.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/SubgroupOrbits.lean
@@ -84,12 +84,9 @@ public def orderOfVanishingOnSubgroupOrbit
     [SlashInvariantFormClass F (Γ : Subgroup (GL (Fin 2) ℝ)) k] (f : F)
     (q : MulAction.orbitRel.Quotient (Γ : Subgroup (GL (Fin 2) ℝ)) ℍ) : ℤ :=
   Quotient.liftOn' q (orderOfVanishingAt f) fun _ b ⟨g, hg⟩ ↦ by
-    obtain ⟨γ, -, hγ⟩ := Subgroup.mem_map.1 g.2
     have hg' : g • b = _ := hg
     rw [← hg', Subgroup.smul_def,
-      orderOfVanishingAt_smul f g.2
-        (by rw [← hγ, ← Matrix.GeneralLinearGroup.val_det_apply,
-          Matrix.SpecialLinearGroup.det_mapGL]; exact one_pos) b]
+      orderOfVanishingAt_smul f g.2 (det_pos_of_mem_slGL (Subgroup.map_le_range _ _ g.2)) b]
 
 /-- Evaluating the descended order on the orbit of `p` recovers the vanishing order at `p`. -/
 @[simp]
@@ -114,12 +111,8 @@ public lemma orderOfVanishingAt_quotientFunc_eq_orderOfVanishingOnSubgroupOrbit
   | h h =>
     rw [_root_.SlashInvariantForm.quotientFunc_mk, orbitOfCosetTranslate_mk,
       orderOfVanishingOnSubgroupOrbit_mk, orderOfVanishingAt_slash (k := k)]
-    -- the slash acts by `h⁻¹`, so what is left is that it has positive determinant: it is the
-    -- image of some `γ ∈ SL(2, ℤ)`, whose determinant is `1`
-    obtain ⟨γ, hγ⟩ := (h⁻¹).2
-    rw [← Subgroup.coe_inv, ← hγ, ← Matrix.GeneralLinearGroup.val_det_apply,
-      Matrix.SpecialLinearGroup.det_mapGL]
-    exact one_pos
+    -- the slash acts by `h⁻¹`, which lies in `𝒮ℒ` and so has positive determinant
+    exact det_pos_of_mem_slGL (inv_mem h.2)
 
 /-- A modular form for a finite-index subgroup `Γ ≤ SL(2, ℤ)` has nonzero vanishing order on
 only finitely many `Γ`-orbits in the upper half-plane.


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"modularforms-det-pos-slgl"}-->

Five call sites each inlined the same chain to discharge the positive-determinant hypothesis of
`σ_eq_refl_of_det_pos` / `orderOfVanishingAt_slash` / `orderOfVanishingAt_smul`:

```lean
rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL]
exact one_pos
```

This names it once, in `ModularForms/Basic.lean`:

```lean
theorem det_pos_of_mem_slGL {g : GL (Fin 2) ℝ} (hg : g ∈ 𝒮ℒ) :
    0 < (g : Matrix (Fin 2) (Fin 2) ℝ).det
```

### Why it is keyed on `𝒮ℒ`-membership

That choice is what lets **one** lemma serve every site. They come in two shapes:

* three hold a direct image `mapGL ℝ γ` — entry point `MonoidHom.mem_range.mpr ⟨γ, rfl⟩`;
* two hold an element of the image of a subgroup `Γ ≤ SL(2, ℤ)` — entry point
  `Subgroup.map_le_range _ _ hg`.

Keying it on `Matrix.SpecialLinearGroup.mapGL` instead would have closed only the first three
and left the others needing a `← hγ` rewrite first. Both entry points are one term.

Two sites additionally lose the destructuring they performed *only* to reach the matrix —
`Subgroup.mem_map.1 g.2` and `obtain ⟨γ, hγ⟩ := (h⁻¹).2` — because membership is now the
hypothesis rather than an intermediate step.

### Placement

`ModularForms/Basic.lean`, not the vanishing-order files that consume it. It is a general
property of `𝒮ℒ` with no vanishing-order content, so siting it in analytic order theory would
force unrelated consumers onto later theory. `Basic.lean` is foundational, has `𝒮ℒ` in scope,
is already imported by every consumer, and already contained a fifth instance of the same
discharge — `σ_mapGL_real_eq_refl`, which now uses the lemma too.

A consequence worth noting: `Order/OfVanishing.lean` is untouched by this PR. The lemma's home
is upstream of it, so the file that motivated the extraction does not itself change.

### Scope

Refactor of existing code, which needs no roadmap entry; the attribution above names the roadmap
it serves. No declaration's statement changes — all five consumers keep byte-identical
signatures and only their proof bodies move. No new imports anywhere.

### On generality

Mathlib's `det_mapGL` is general in the target ring, so an ℝ-free positivity lemma is possible
in principle. It is not what is wanted here: `𝒮ℒ` is *by definition* `(mapGL ℝ).range`, so the
membership-keyed statement is ℝ-specific by construction and every consumer is at `ℝ`. Worth
recording for anyone who tries: `LinearOrderedCommRing` no longer exists in this Mathlib — a
probe using it fails with `invalid binder annotation, type is not a class instance`; the current
idiom is `[CommRing S] [LinearOrder S] [IsStrictOrderedRing S]`.

### Gates at this head

`lake build` 8113 jobs · `lake exe axioms` 50482 declarations, allowlist only ·
`lake exe module-system` 2395 modules · `LINT-ENV: PASS` (0 new violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
