### PR TITLE
feat: prove the finite bilinear double-perp formula

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -59,7 +59,7 @@ private theorem radical_toIntSubmodule_le_ker :
   exact A.mem_radical_iff x |>.mp hx y
 
 /-- The underlying additive quotient of a finite bilinear module by its radical. -/
-abbrev RadicalQuotient := A.carrier ⧸ A.radical.toIntSubmodule
+private abbrev RadicalQuotient := A.carrier ⧸ A.radical.toIntSubmodule
 
 private noncomputable def radicalQuotientBilin :
     A.RadicalQuotient →ₗ[ℤ] A.RadicalQuotient →ₗ[ℤ] AddCircle (1 : ℚ) :=

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -76,6 +76,8 @@ private theorem radicalQuotientMkAux_ker :
     A.radical.toIntSubmodule.mkQ.toAddMonoidHom.ker = A.radical := by
   ext x
   rw [AddMonoidHom.mem_ker]
+  -- Expose the quotient map and the common carrier of `radical` and `toIntSubmodule`;
+  -- both bundled wrappers preserve these data definitionally.
   change Submodule.Quotient.mk x = 0 ↔ x ∈ A.radical
   rw [Submodule.Quotient.mk_eq_zero]
   rfl

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -129,6 +129,7 @@ theorem radicalQuotientMk_surjective : Function.Surjective (radicalQuotientMk A)
   A.radical.toIntSubmodule.mkQ_surjective
 
 /-- The kernel of the radical quotient map is the radical. -/
+@[simp]
 theorem radicalQuotientMk_ker : (radicalQuotientMk A).ker = A.radical := by
   exact radicalQuotientMkAux_ker A
 
@@ -167,6 +168,7 @@ theorem pairingRestrict_apply (H : AddSubgroup A) (x : A) (y : H) :
   (rfl)
 
 /-- The kernel of the restricted pairing is the orthogonal complement. -/
+@[simp]
 theorem pairingRestrict_ker (H : AddSubgroup A) :
     (A.pairingRestrict H).ker = A.orthogonalComplement H := by
   ext x

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -221,6 +221,7 @@ theorem IsNondegenerate.orthogonalComplement_orthogonalComplement
   exact hcard.symm.le
 
 /-- Orthogonal complementation commutes with mapping to the radical quotient. -/
+@[simp]
 theorem orthogonalComplement_map_radicalQuotient (H : AddSubgroup A) :
     (radicalQuotient A).orthogonalComplement (H.map (radicalQuotientMk A)) =
       (A.orthogonalComplement H).map (radicalQuotientMk A) := by
@@ -247,6 +248,7 @@ theorem orthogonalComplement_map_radicalQuotient (H : AddSubgroup A) :
 
 /-- For every subgroup of a finite bilinear module, the double orthogonal complement is the
 subgroup enlarged by the radical. -/
+@[simp]
 theorem orthogonalComplement_orthogonalComplement (H : AddSubgroup A) :
     A.orthogonalComplement (A.orthogonalComplement H) = H ⊔ A.radical := by
   apply le_antisymm

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -75,12 +75,9 @@ private theorem radicalQuotientBilin_mk (x y : A) :
 private theorem radicalQuotientMkAux_ker :
     A.radical.toIntSubmodule.mkQ.toAddMonoidHom.ker = A.radical := by
   ext x
-  rw [AddMonoidHom.mem_ker]
-  -- Expose the quotient map and the common carrier of `radical` and `toIntSubmodule`;
-  -- both bundled wrappers preserve these data definitionally.
-  change Submodule.Quotient.mk x = 0 ↔ x ∈ A.radical
-  rw [Submodule.Quotient.mk_eq_zero]
-  rfl
+  rw [AddMonoidHom.mem_ker, LinearMap.toAddMonoidHom_coe, Submodule.mkQ_apply,
+    Submodule.Quotient.mk_eq_zero, ← SetLike.mem_coe, AddSubgroup.coe_toIntSubmodule,
+    SetLike.mem_coe]
 
 /-- The finite bilinear module obtained by quotienting by the radical. -/
 noncomputable def radicalQuotient : FiniteBilinearModule where

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -50,8 +50,7 @@ variable (A : FiniteBilinearModule.{u})
 
 /-! ## Quotient by the radical -/
 
-/-- The radical, regarded as an integer submodule, lies in the kernel of the bilinear map. -/
-theorem radical_toIntSubmodule_le_ker :
+private theorem radical_toIntSubmodule_le_ker :
     A.radical.toIntSubmodule ≤ A.toBilin.ker := by
   intro x hx
   rw [LinearMap.mem_ker]
@@ -62,15 +61,27 @@ theorem radical_toIntSubmodule_le_ker :
 /-- The underlying additive quotient of a finite bilinear module by its radical. -/
 abbrev RadicalQuotient := A.carrier ⧸ A.radical.toIntSubmodule
 
-/-- The bilinear map on the quotient of a finite bilinear module by its radical. -/
-noncomputable def radicalQuotientBilin :
+private noncomputable def radicalQuotientBilin :
     A.RadicalQuotient →ₗ[ℤ] A.RadicalQuotient →ₗ[ℤ] AddCircle (1 : ℚ) :=
   A.toBilin.liftQ₂ A.radical.toIntSubmodule A.radical.toIntSubmodule
     (radical_toIntSubmodule_le_ker A)
     (A.isRefl_toBilin.ker_flip ▸ radical_toIntSubmodule_le_ker A)
 
+private theorem radicalQuotientBilin_mk (x y : A) :
+    A.radicalQuotientBilin (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
+      A.pairing x y := by
+  rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
+
+private theorem radicalQuotientMkAux_ker :
+    A.radical.toIntSubmodule.mkQ.toAddMonoidHom.ker = A.radical := by
+  ext x
+  rw [AddMonoidHom.mem_ker]
+  change Submodule.Quotient.mk x = 0 ↔ x ∈ A.radical
+  rw [Submodule.Quotient.mk_eq_zero]
+  rfl
+
 /-- The finite bilinear module obtained by quotienting by the radical. -/
-noncomputable abbrev radicalQuotient : FiniteBilinearModule where
+noncomputable def radicalQuotient : FiniteBilinearModule where
   carrier := A.RadicalQuotient
   finite := Finite.of_surjective A.radical.toIntSubmodule.mkQ
     A.radical.toIntSubmodule.mkQ_surjective
@@ -101,55 +112,42 @@ noncomputable abbrev radicalQuotient : FiniteBilinearModule where
       A.toBilin_apply, A.toBilin_apply]
     exact A.pairing_comm x y
 
-/-- The quotient pairing is represented by the original pairing on representatives.
-
-This is an explicit rewrite lemma: simplifying the reducible quotient bundle first exposes its
-bilinear-map implementation, so the displayed left-hand side is not a simp normal form. -/
-theorem radicalQuotient_pairing_mk (x y : A) :
-    (radicalQuotient A).pairing (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
-      A.pairing x y :=
-  by
-    -- Expose the quotient lift behind the bundled pairing.
-    change A.radicalQuotientBilin (Submodule.Quotient.mk x)
-      (Submodule.Quotient.mk y) = A.pairing x y
-    rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
-
 /-- The quotient map from a finite bilinear module to its radical quotient. -/
-noncomputable def radicalQuotientMk : A →+ A.RadicalQuotient :=
-  A.radical.toIntSubmodule.mkQ.toAddMonoidHom
+noncomputable def radicalQuotientMk : A →+ radicalQuotient A := by
+  rw [radicalQuotient]
+  exact A.radical.toIntSubmodule.mkQ.toAddMonoidHom
 
-/-- The radical quotient map sends an element to its quotient class. -/
+/-- The quotient pairing is represented by the original pairing on representatives. -/
 @[simp]
-theorem radicalQuotientMk_apply (x : A) :
-    radicalQuotientMk A x = Submodule.Quotient.mk x :=
-  by simp [radicalQuotientMk]
+theorem radicalQuotient_pairing_mk (x y : A) :
+    (radicalQuotient A).pairing (radicalQuotientMk A x) (radicalQuotientMk A y) =
+      A.pairing x y :=
+  radicalQuotientBilin_mk A x y
 
-/-- An element maps to zero in the radical quotient exactly when it lies in the radical.
+/-- The quotient map to the radical quotient is surjective. -/
+theorem radicalQuotientMk_surjective : Function.Surjective (radicalQuotientMk A) :=
+  A.radical.toIntSubmodule.mkQ_surjective
 
-This is an explicit named criterion; the basic quotient-map simp lemmas already normalize its
-left-hand side. -/
-theorem radicalQuotientMk_eq_zero_iff (x : A) :
-    radicalQuotientMk A x = 0 ↔ x ∈ A.radical := by
-  rw [radicalQuotientMk_apply, Submodule.Quotient.mk_eq_zero]
-  rfl
+/-- The kernel of the radical quotient map is the radical. -/
+theorem radicalQuotientMk_ker : (radicalQuotientMk A).ker = A.radical := by
+  exact radicalQuotientMkAux_ker A
 
 /-- Quotienting a finite bilinear module by its radical produces a nondegenerate module. -/
 theorem isNondegenerate_radicalQuotient : (radicalQuotient A).IsNondegenerate := by
   apply (radicalQuotient A).isNondegenerate_of_injective
   rw [injective_iff_map_eq_zero]
   intro x hx
-  induction x using Submodule.Quotient.induction_on with | H x =>
-  rw [Submodule.Quotient.mk_eq_zero]
-  -- Identify the kernel condition for the quotient map with radical membership.
-  change x ∈ A.radical
+  obtain ⟨x, rfl⟩ := radicalQuotientMk_surjective A x
+  rw [← AddMonoidHom.mem_ker, radicalQuotientMk_ker]
   rw [A.mem_radical_iff]
   intro y
-  have hxy := DFunLike.congr_fun hx (Submodule.Quotient.mk y)
-  -- Expose the quotient lift behind the bundled pairing.
-  change A.radicalQuotientBilin (Submodule.Quotient.mk x)
-    (Submodule.Quotient.mk y) = 0 at hxy
-  rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply] at hxy
-  exact hxy
+  have hxy := DFunLike.congr_fun hx (radicalQuotientMk A y)
+  calc
+    A.pairing x y =
+        (radicalQuotient A).pairing (radicalQuotientMk A x) (radicalQuotientMk A y) :=
+      (radicalQuotient_pairing_mk A x y).symm
+    _ = (0 : CharacterModule (radicalQuotient A)) (radicalQuotientMk A y) := hxy
+    _ = 0 := rfl
 
 /-! ## Character restriction and cardinality -/
 
@@ -220,17 +218,12 @@ theorem IsNondegenerate.orthogonalComplement_orthogonalComplement
     exact hH.trans hHperp.symm
   exact hcard.symm.le
 
-/-- The kernel of the radical quotient map is the radical. -/
-theorem radicalQuotientMk_ker : (radicalQuotientMk A).ker = A.radical := by
-  ext x
-  rw [AddMonoidHom.mem_ker, radicalQuotientMk_eq_zero_iff]
-
 /-- Orthogonal complementation commutes with mapping to the radical quotient. -/
 theorem orthogonalComplement_map_radicalQuotient (H : AddSubgroup A) :
     (radicalQuotient A).orthogonalComplement (H.map (radicalQuotientMk A)) =
       (A.orthogonalComplement H).map (radicalQuotientMk A) := by
   ext x
-  induction x using Submodule.Quotient.induction_on with | H x =>
+  obtain ⟨x, rfl⟩ := radicalQuotientMk_surjective A x
   constructor
   · intro hx
     refine ⟨x, ?_, rfl⟩
@@ -239,26 +232,16 @@ theorem orthogonalComplement_map_radicalQuotient (H : AddSubgroup A) :
     rw [A.mem_orthogonalComplement_iff]
     intro y hy
     have hxy := (radicalQuotient A).mem_orthogonalComplement_iff
-      (H.map (radicalQuotientMk A)) (Submodule.Quotient.mk x) |>.mp hx
-      (Submodule.Quotient.mk y) ⟨y, hy, rfl⟩
-    -- Expose the quotient lift behind the bundled pairing.
-    change A.radicalQuotientBilin (Submodule.Quotient.mk x)
-      (Submodule.Quotient.mk y) = 0 at hxy
-    rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply] at hxy
-    exact hxy
+      (H.map (radicalQuotientMk A)) (radicalQuotientMk A x) |>.mp hx
+      (radicalQuotientMk A y) ⟨y, hy, rfl⟩
+    simpa using hxy
   · rintro ⟨z, hz, hzx⟩
     rw [(radicalQuotient A).mem_orthogonalComplement_iff]
     intro y hy
     obtain ⟨w, hw, rfl⟩ := hy
     have hzw := A.mem_orthogonalComplement_iff H z |>.mp hz w hw
-    have hzx' : Submodule.Quotient.mk z = Submodule.Quotient.mk x := hzx
-    rw [← hzx']
-    rw [radicalQuotientMk_apply]
-    -- Expose the quotient lift behind the bundled pairing.
-    change A.radicalQuotientBilin (Submodule.Quotient.mk z)
-      (Submodule.Quotient.mk w) = 0
-    rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
-    exact hzw
+    rw [← hzx]
+    simpa using hzw
 
 /-- For every subgroup of a finite bilinear module, the double orthogonal complement is the
 subgroup enlarged by the radical. -/

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -1,0 +1,296 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.LinearAlgebra.Quotient.Bilinear
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Basic
+
+/-!
+# Orthogonal complements in finite bilinear modules
+
+This file develops the cardinality and double-complement theory of subgroups of a finite
+bilinear module.  For a subgroup `H` of a possibly degenerate module `A`, the radical is the
+only obstruction to recovering `H` from its orthogonal complement:
+
+```text
+H⊥⊥ = H + rad(A).
+```
+
+The proof first quotients the pairing by its radical.  The induced finite bilinear module is
+nondegenerate, so restriction of characters shows that `|H| |H⊥| = |A|`.  Applying this
+identity in the radical quotient gives the general double-complement formula.  In particular,
+for a nondegenerate module, double orthogonal complementation is the identity and a Lagrangian
+subgroup has order whose square is the order of the ambient group.
+
+## Main declarations
+
+* `TauCeti.FiniteBilinearModule.radicalQuotient`: the nondegenerate quotient by the radical.
+* `TauCeti.FiniteBilinearModule.orthogonalComplement_orthogonalComplement`: the formula
+  `H⊥⊥ = H ⊔ rad(A)`.
+* `TauCeti.FiniteBilinearModule.IsNondegenerate.card_mul_card_orthogonalComplement`: the
+  cardinality identity `|H| |H⊥| = |A|` for a nondegenerate module.
+* `TauCeti.FiniteBilinearModule.IsLagrangian.card_sq`: a Lagrangian has squared order `|A|`.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+-/
+
+public section
+
+namespace TauCeti.FiniteBilinearModule
+
+universe u
+
+variable (A : FiniteBilinearModule.{u})
+
+/-! ## Quotient by the radical -/
+
+/-- The radical, regarded as an integer submodule, lies in the kernel of the bilinear map. -/
+theorem radical_toIntSubmodule_le_ker :
+    A.radical.toIntSubmodule ≤ A.toBilin.ker := by
+  intro x hx
+  rw [LinearMap.mem_ker]
+  ext y
+  rw [LinearMap.zero_apply, A.toBilin_apply]
+  exact A.mem_radical_iff x |>.mp hx y
+
+/-- The underlying additive quotient of a finite bilinear module by its radical. -/
+abbrev RadicalQuotient := A.carrier ⧸ A.radical.toIntSubmodule
+
+/-- The bilinear map on the quotient of a finite bilinear module by its radical. -/
+noncomputable def radicalQuotientBilin :
+    A.RadicalQuotient →ₗ[ℤ] A.RadicalQuotient →ₗ[ℤ] AddCircle (1 : ℚ) :=
+  A.toBilin.liftQ₂ A.radical.toIntSubmodule A.radical.toIntSubmodule
+    (radical_toIntSubmodule_le_ker A)
+    (A.isRefl_toBilin.ker_flip ▸ radical_toIntSubmodule_le_ker A)
+
+/-- The finite bilinear module obtained by quotienting by the radical. -/
+noncomputable abbrev radicalQuotient : FiniteBilinearModule where
+  carrier := A.RadicalQuotient
+  finite := Finite.of_surjective A.radical.toIntSubmodule.mkQ
+    A.radical.toIntSubmodule.mkQ_surjective
+  pairing :=
+    { toFun := fun x ↦
+        (A.radicalQuotientBilin x).toAddMonoidHom
+      map_zero' := by
+        ext y
+        -- Expose evaluation through the `LinearMap`/`CharacterModule` wrapper.
+        change A.radicalQuotientBilin 0 y = 0
+        rw [map_zero, LinearMap.zero_apply]
+      map_add' := by
+        intro x y
+        ext z
+        -- Expose evaluation through the `LinearMap`/`CharacterModule` wrapper.
+        change A.radicalQuotientBilin (x + y) z =
+          A.radicalQuotientBilin x z + A.radicalQuotientBilin y z
+        rw [map_add, LinearMap.add_apply] }
+  pairing_comm := by
+    intro x y
+    induction x using Submodule.Quotient.induction_on with | H x =>
+    induction y using Submodule.Quotient.induction_on with | H y =>
+    -- Expose the quotient lift so `LinearMap.liftQ₂_mk` applies to both representatives.
+    change A.radicalQuotientBilin (Submodule.Quotient.mk x)
+      (Submodule.Quotient.mk y) = A.radicalQuotientBilin (Submodule.Quotient.mk y)
+        (Submodule.Quotient.mk x)
+    rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, LinearMap.liftQ₂_mk,
+      A.toBilin_apply, A.toBilin_apply]
+    exact A.pairing_comm x y
+
+/-- The quotient pairing is represented by the original pairing on representatives. -/
+@[simp]
+theorem radicalQuotient_pairing_mk (x y : A) :
+    (radicalQuotient A).pairing (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
+      A.pairing x y :=
+  by
+    -- Expose the quotient lift behind the bundled pairing.
+    change A.radicalQuotientBilin (Submodule.Quotient.mk x)
+      (Submodule.Quotient.mk y) = A.pairing x y
+    rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
+
+/-- The quotient map from a finite bilinear module to its radical quotient. -/
+noncomputable def radicalQuotientMk : A →+ A.RadicalQuotient :=
+  A.radical.toIntSubmodule.mkQ.toAddMonoidHom
+
+/-- The radical quotient map sends an element to its quotient class. -/
+@[simp]
+theorem radicalQuotientMk_apply (x : A) :
+    radicalQuotientMk A x = Submodule.Quotient.mk x :=
+  by simp [radicalQuotientMk]
+
+/-- An element maps to zero in the radical quotient exactly when it lies in the radical. -/
+@[simp]
+theorem radicalQuotientMk_eq_zero_iff (x : A) :
+    radicalQuotientMk A x = 0 ↔ x ∈ A.radical := by
+  rw [radicalQuotientMk_apply, Submodule.Quotient.mk_eq_zero]
+  rfl
+
+/-- Quotienting a finite bilinear module by its radical produces a nondegenerate module. -/
+theorem isNondegenerate_radicalQuotient : (radicalQuotient A).IsNondegenerate := by
+  apply (radicalQuotient A).isNondegenerate_of_injective
+  rw [injective_iff_map_eq_zero]
+  intro x hx
+  induction x using Submodule.Quotient.induction_on with | H x =>
+  rw [Submodule.Quotient.mk_eq_zero]
+  -- Identify the kernel condition for the quotient map with radical membership.
+  change x ∈ A.radical
+  rw [A.mem_radical_iff]
+  intro y
+  have hxy := DFunLike.congr_fun hx (Submodule.Quotient.mk y)
+  -- Expose the quotient lift behind the bundled pairing.
+  change A.radicalQuotientBilin (Submodule.Quotient.mk x)
+    (Submodule.Quotient.mk y) = 0 at hxy
+  rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply] at hxy
+  exact hxy
+
+/-! ## Character restriction and cardinality -/
+
+/-- Pair an element of `A` against a subgroup `H`, regarded as a character of `H`. -/
+def pairingRestrict (H : AddSubgroup A) : A →+ CharacterModule H where
+  toFun x :=
+    { toFun := fun y ↦ A.pairing x y
+      map_zero' := A.pairing_zero_right x
+      map_add' := fun y z ↦ A.pairing_add_right x (y : A) (z : A) }
+  map_zero' := by ext y; exact A.pairing_zero_left y
+  map_add' x y := by ext z; exact A.pairing_add_left x y z
+
+/-- Evaluating the restricted pairing is evaluating the original pairing on the subtype. -/
+@[simp]
+theorem pairingRestrict_apply (H : AddSubgroup A) (x : A) (y : H) :
+    A.pairingRestrict H x y = A.pairing x y :=
+  (rfl)
+
+/-- The kernel of the restricted pairing is the orthogonal complement. -/
+theorem pairingRestrict_ker (H : AddSubgroup A) :
+    (A.pairingRestrict H).ker = A.orthogonalComplement H := by
+  ext x
+  rw [AddMonoidHom.mem_ker, A.mem_orthogonalComplement_iff]
+  exact ⟨fun hx y hy ↦ DFunLike.congr_fun hx ⟨y, hy⟩,
+    fun hx ↦ CharacterModule.ext H fun (y : H) ↦ hx y y.2⟩
+
+/-- In a nondegenerate finite bilinear module, every character of a subgroup is pairing with an
+element of the ambient module. -/
+theorem IsNondegenerate.pairingRestrict_surjective (hA : A.IsNondegenerate)
+    (H : AddSubgroup A) : Function.Surjective (A.pairingRestrict H) := by
+  intro c
+  obtain ⟨d, hd⟩ := CharacterModule.dual_surjective_of_injective
+    H.toIntSubmodule.subtype (Submodule.injective_subtype H.toIntSubmodule) c
+  obtain ⟨x, hx⟩ := hA.bijective.2 d
+  refine ⟨x, CharacterModule.ext H fun y ↦ ?_⟩
+  -- Expose evaluation through the bundled character maps.
+  change A.pairing x y = c y
+  rw [DFunLike.congr_fun hx (y : A)]
+  have hy := DFunLike.congr_fun hd y
+  exact hy
+
+/-- In a nondegenerate finite bilinear module, the orders of a subgroup and its orthogonal
+complement multiply to the order of the ambient module. -/
+theorem IsNondegenerate.card_mul_card_orthogonalComplement (hA : A.IsNondegenerate)
+    (H : AddSubgroup A) :
+    Nat.card H * Nat.card (A.orthogonalComplement H) = Nat.card A := by
+  have hs := IsNondegenerate.pairingRestrict_surjective A hA H
+  have hindex : (A.pairingRestrict H).ker.index = Nat.card H := by
+    rw [AddSubgroup.index_ker, AddMonoidHom.range_eq_top.mpr hs]
+    simpa using natCard_characterModule H
+  rw [mul_comm, ← A.pairingRestrict_ker H, ← hindex]
+  exact (A.pairingRestrict H).ker.card_mul_index
+
+/-- Double orthogonal complementation is the identity in a nondegenerate finite bilinear module. -/
+theorem IsNondegenerate.orthogonalComplement_orthogonalComplement
+    (hA : A.IsNondegenerate) (H : AddSubgroup A) :
+    A.orthogonalComplement (A.orthogonalComplement H) = H := by
+  symm
+  apply AddSubgroup.eq_of_le_of_card_ge
+    (A.le_orthogonalComplement_orthogonalComplement H)
+  have hH := IsNondegenerate.card_mul_card_orthogonalComplement A hA H
+  have hHperp := IsNondegenerate.card_mul_card_orthogonalComplement A hA
+    (A.orthogonalComplement H)
+  rw [mul_comm] at hHperp
+  have hcard : Nat.card H =
+      Nat.card (A.orthogonalComplement (A.orthogonalComplement H)) := by
+    apply Nat.mul_right_cancel (Nat.card_pos (α := A.orthogonalComplement H))
+    exact hH.trans hHperp.symm
+  exact hcard.symm.le
+
+/-- The kernel of the radical quotient map is the radical. -/
+theorem radicalQuotientMk_ker : (radicalQuotientMk A).ker = A.radical := by
+  ext x
+  rw [AddMonoidHom.mem_ker, radicalQuotientMk_eq_zero_iff]
+
+/-- Orthogonal complementation commutes with mapping to the radical quotient. -/
+theorem orthogonalComplement_map_radicalQuotient (H : AddSubgroup A) :
+    (radicalQuotient A).orthogonalComplement (H.map (radicalQuotientMk A)) =
+      (A.orthogonalComplement H).map (radicalQuotientMk A) := by
+  ext x
+  induction x using Submodule.Quotient.induction_on with | H x =>
+  constructor
+  · intro hx
+    refine ⟨x, ?_, rfl⟩
+    -- Identify membership with the pointwise orthogonality condition in the original module.
+    change x ∈ A.orthogonalComplement H
+    rw [A.mem_orthogonalComplement_iff]
+    intro y hy
+    have hxy := (radicalQuotient A).mem_orthogonalComplement_iff
+      (H.map (radicalQuotientMk A)) (Submodule.Quotient.mk x) |>.mp hx
+      (Submodule.Quotient.mk y) ⟨y, hy, rfl⟩
+    -- Expose the quotient lift behind the bundled pairing.
+    change A.radicalQuotientBilin (Submodule.Quotient.mk x)
+      (Submodule.Quotient.mk y) = 0 at hxy
+    rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply] at hxy
+    exact hxy
+  · rintro ⟨z, hz, hzx⟩
+    rw [(radicalQuotient A).mem_orthogonalComplement_iff]
+    intro y hy
+    obtain ⟨w, hw, rfl⟩ := hy
+    have hzw := A.mem_orthogonalComplement_iff H z |>.mp hz w hw
+    have hzx' : Submodule.Quotient.mk z = Submodule.Quotient.mk x := hzx
+    rw [← hzx']
+    rw [radicalQuotientMk_apply]
+    -- Expose the quotient lift behind the bundled pairing.
+    change A.radicalQuotientBilin (Submodule.Quotient.mk z)
+      (Submodule.Quotient.mk w) = 0
+    rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
+    exact hzw
+
+/-- For every subgroup of a finite bilinear module, the double orthogonal complement is the
+subgroup enlarged by the radical. -/
+theorem orthogonalComplement_orthogonalComplement (H : AddSubgroup A) :
+    A.orthogonalComplement (A.orthogonalComplement H) = H ⊔ A.radical := by
+  apply le_antisymm
+  · intro x hx
+    have hxq : radicalQuotientMk A x ∈
+        (radicalQuotient A).orthogonalComplement
+          ((radicalQuotient A).orthogonalComplement (H.map (radicalQuotientMk A))) := by
+      rw [(radicalQuotient A).mem_orthogonalComplement_iff]
+      intro y hy
+      rw [orthogonalComplement_map_radicalQuotient] at hy
+      obtain ⟨z, hz, rfl⟩ := hy
+      exact radicalQuotient_pairing_mk A x z ▸
+        (A.mem_orthogonalComplement_iff (A.orthogonalComplement H) x |>.mp hx z hz)
+    rw [IsNondegenerate.orthogonalComplement_orthogonalComplement
+      (radicalQuotient A) A.isNondegenerate_radicalQuotient] at hxq
+    rw [← A.radicalQuotientMk_ker, ← AddSubgroup.comap_map_eq]
+    exact hxq
+  · refine sup_le (A.le_orthogonalComplement_orthogonalComplement H) ?_
+    intro x hx
+    rw [A.mem_orthogonalComplement_iff]
+    intro y _
+    exact A.mem_radical_iff x |>.mp hx y
+
+/-- A Lagrangian subgroup of a nondegenerate finite bilinear module has squared order equal to the
+order of the ambient group. -/
+theorem IsLagrangian.card_sq (hH : A.IsLagrangian H) (hA : A.IsNondegenerate) :
+    Nat.card H ^ 2 = Nat.card A := by
+  have hEq := A.isLagrangian_def H |>.mp hH
+  have hcard : Nat.card H = Nat.card (A.orthogonalComplement H) :=
+    Nat.card_congr (AddEquiv.addSubgroupCongr hEq).toEquiv
+  calc
+    Nat.card H ^ 2 = Nat.card H * Nat.card H := pow_two _
+    _ = Nat.card H * Nat.card (A.orthogonalComplement H) := congrArg _ hcard
+    _ = Nat.card A := IsNondegenerate.card_mul_card_orthogonalComplement A hA H
+
+end TauCeti.FiniteBilinearModule

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -101,8 +101,10 @@ noncomputable abbrev radicalQuotient : FiniteBilinearModule where
       A.toBilin_apply, A.toBilin_apply]
     exact A.pairing_comm x y
 
-/-- The quotient pairing is represented by the original pairing on representatives. -/
-@[simp]
+/-- The quotient pairing is represented by the original pairing on representatives.
+
+This is an explicit rewrite lemma: simplifying the reducible quotient bundle first exposes its
+bilinear-map implementation, so the displayed left-hand side is not a simp normal form. -/
 theorem radicalQuotient_pairing_mk (x y : A) :
     (radicalQuotient A).pairing (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
       A.pairing x y :=
@@ -122,8 +124,10 @@ theorem radicalQuotientMk_apply (x : A) :
     radicalQuotientMk A x = Submodule.Quotient.mk x :=
   by simp [radicalQuotientMk]
 
-/-- An element maps to zero in the radical quotient exactly when it lies in the radical. -/
-@[simp]
+/-- An element maps to zero in the radical quotient exactly when it lies in the radical.
+
+This is an explicit named criterion; the basic quotient-map simp lemmas already normalize its
+left-hand side. -/
 theorem radicalQuotientMk_eq_zero_iff (x : A) :
     radicalQuotientMk A x = 0 ↔ x ∈ A.radical := by
   rw [radicalQuotientMk_apply, Submodule.Quotient.mk_eq_zero]

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -63,21 +63,8 @@ private abbrev RadicalQuotient := A.carrier ⧸ A.radical.toIntSubmodule
 
 private noncomputable def radicalQuotientBilin :
     A.RadicalQuotient →ₗ[ℤ] A.RadicalQuotient →ₗ[ℤ] AddCircle (1 : ℚ) :=
-  A.toBilin.liftQ₂ A.radical.toIntSubmodule A.radical.toIntSubmodule
+  LinearMap.IsRefl.liftQ₂ A.toBilin A.radical.toIntSubmodule A.isRefl_toBilin
     (radical_toIntSubmodule_le_ker A)
-    (A.isRefl_toBilin.ker_flip ▸ radical_toIntSubmodule_le_ker A)
-
-private theorem radicalQuotientBilin_mk (x y : A) :
-    A.radicalQuotientBilin (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
-      A.pairing x y := by
-  rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
-
-private theorem radicalQuotientMkAux_ker :
-    A.radical.toIntSubmodule.mkQ.toAddMonoidHom.ker = A.radical := by
-  ext x
-  rw [AddMonoidHom.mem_ker, LinearMap.toAddMonoidHom_coe, Submodule.mkQ_apply,
-    Submodule.Quotient.mk_eq_zero, ← SetLike.mem_coe, AddSubgroup.coe_toIntSubmodule,
-    SetLike.mem_coe]
 
 /-- The finite bilinear module obtained by quotienting by the radical. -/
 noncomputable def radicalQuotient : FiniteBilinearModule where
@@ -88,22 +75,16 @@ noncomputable def radicalQuotient : FiniteBilinearModule where
     { toFun := fun x ↦
         (A.radicalQuotientBilin x).toAddMonoidHom
       map_zero' := by
-        ext y
-        -- Expose evaluation through the `LinearMap`/`CharacterModule` wrapper.
-        change A.radicalQuotientBilin 0 y = 0
-        rw [map_zero, LinearMap.zero_apply]
+        exact congrArg LinearMap.toAddMonoidHom (map_zero A.radicalQuotientBilin)
       map_add' := by
         intro x y
-        ext z
-        -- Expose evaluation through the `LinearMap`/`CharacterModule` wrapper.
-        change A.radicalQuotientBilin (x + y) z =
-          A.radicalQuotientBilin x z + A.radicalQuotientBilin y z
-        rw [map_add, LinearMap.add_apply] }
+        exact congrArg LinearMap.toAddMonoidHom (map_add A.radicalQuotientBilin x y) }
   pairing_comm := by
     intro x y
     induction x using Submodule.Quotient.induction_on with | H x =>
     induction y using Submodule.Quotient.induction_on with | H y =>
-    -- Expose the quotient lift so `LinearMap.liftQ₂_mk` applies to both representatives.
+    -- `CharacterModule` is an opaque `def` alias for additive homomorphisms, so its evaluation
+    -- cannot be simplified to the quotient bilinear map by a public rewrite lemma.
     change A.radicalQuotientBilin (Submodule.Quotient.mk x)
       (Submodule.Quotient.mk y) = A.radicalQuotientBilin (Submodule.Quotient.mk y)
         (Submodule.Quotient.mk x)
@@ -112,16 +93,18 @@ noncomputable def radicalQuotient : FiniteBilinearModule where
     exact A.pairing_comm x y
 
 /-- The quotient map from a finite bilinear module to its radical quotient. -/
-noncomputable def radicalQuotientMk : A →+ radicalQuotient A := by
-  rw [radicalQuotient]
-  exact A.radical.toIntSubmodule.mkQ.toAddMonoidHom
+noncomputable def radicalQuotientMk : A →+ radicalQuotient A :=
+  A.radical.toIntSubmodule.mkQ.toAddMonoidHom
 
 /-- The quotient pairing is represented by the original pairing on representatives. -/
 @[simp]
 theorem radicalQuotient_pairing_mk (x y : A) :
     (radicalQuotient A).pairing (radicalQuotientMk A x) (radicalQuotientMk A y) =
-      A.pairing x y :=
-  radicalQuotientBilin_mk A x y
+      A.pairing x y := by
+  -- Unfold the opaque `CharacterModule` alias to expose evaluation of the quotient lift.
+  change A.radicalQuotientBilin (Submodule.Quotient.mk x)
+    (Submodule.Quotient.mk y) = A.pairing x y
+  rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
 
 /-- The quotient map to the radical quotient is surjective. -/
 theorem radicalQuotientMk_surjective : Function.Surjective (radicalQuotientMk A) :=
@@ -130,7 +113,8 @@ theorem radicalQuotientMk_surjective : Function.Surjective (radicalQuotientMk A)
 /-- The kernel of the radical quotient map is the radical. -/
 @[simp]
 theorem radicalQuotientMk_ker : (radicalQuotientMk A).ker = A.radical := by
-  exact radicalQuotientMkAux_ker A
+  rw [← A.radical.toIntSubmodule_toAddSubgroup]
+  exact congrArg Submodule.toAddSubgroup A.radical.toIntSubmodule.ker_mkQ
 
 /-- Quotienting a finite bilinear module by its radical produces a nondegenerate module. -/
 theorem isNondegenerate_radicalQuotient : (radicalQuotient A).IsNondegenerate := by
@@ -184,8 +168,7 @@ theorem IsNondegenerate.pairingRestrict_surjective (hA : A.IsNondegenerate)
     H.toIntSubmodule.subtype (Submodule.injective_subtype H.toIntSubmodule) c
   obtain ⟨x, hx⟩ := hA.bijective.2 d
   refine ⟨x, CharacterModule.ext H fun y ↦ ?_⟩
-  -- Expose evaluation through the bundled character maps.
-  change A.pairing x y = c y
+  rw [pairingRestrict_apply]
   rw [DFunLike.congr_fun hx (y : A)]
   have hy := DFunLike.congr_fun hd y
   exact hy
@@ -229,9 +212,7 @@ theorem orthogonalComplement_map_radicalQuotient (H : AddSubgroup A) :
   constructor
   · intro hx
     refine ⟨x, ?_, rfl⟩
-    -- Identify membership with the pointwise orthogonality condition in the original module.
-    change x ∈ A.orthogonalComplement H
-    rw [A.mem_orthogonalComplement_iff]
+    refine (A.mem_orthogonalComplement_iff H x).mpr ?_
     intro y hy
     have hxy := (radicalQuotient A).mem_orthogonalComplement_iff
       (H.map (radicalQuotientMk A)) (radicalQuotientMk A x) |>.mp hx


### PR DESCRIPTION
This PR proves the IntegralLattices Layer 3 finite-bilinear-module target: for every subgroup `H`, establish `H^⊥⊥ = H ⊔ rad(b)`; under nondegeneracy, establish `H^⊥⊥ = H` and `|H| |H^⊥| = |A|`; and deduce `|H|² = |A|` for a Lagrangian.

The preferred `CFSGStatement` roadmap has no viable unclaimed critical-path step: its next classification and root-system/reductive-group prerequisites are already represented by open work. The next effective unclaimed milestone step is therefore this explicit Layer 3 target from `IntegralLattices`.

The proof quotients a finite bilinear module by its radical, proves the quotient pairing nondegenerate, and obtains the cardinality formula by restricting characters to a subgroup. It reuses Mathlib's `LinearMap.liftQ₂`, `CharacterModule.dual_surjective_of_injective`, and finite-index API rather than introducing parallel infrastructure.

After this PR, Layer 3 still needs compatibility with primary decomposition and the discriminant bilinear and quadratic module constructions.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"finite-bilinear-double-orthogonal-complement"}-->

🤖 Prepared with Codex
