### PR TITLE
feat: add the fppf component group quotient

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup.lean
@@ -79,7 +79,7 @@ theorem rationalKernelPoint_one (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
   exact AlgHom.convOne_apply
 
 /-- The identity-component Hopf ideal is normal over an algebraically closed field. -/
-theorem identityComponentNormality (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+theorem isNormal_identityComponentHopfIdeal (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)).IsNormal := by
   let : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
   exact HopfAlgebra.isNormal_identityComponentHopfIdeal (k := k) (H := H)
@@ -89,14 +89,14 @@ closed field. Its representability by a finite étale group scheme is not assert
 noncomputable abbrev componentGroupFppfSheaf (H : FiniteTypeCommHopfAlgCat.{u, u} k) :=
   CommHopfAlgCat.fppfQuotientSheaf H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-    (identityComponentNormality H)
+    (isNormal_identityComponentHopfIdeal H)
 
 /-- The canonical morphism from the fppf sheaf of points of `H` to its component group sheaf. -/
 noncomputable def componentGroupFppfProjection (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     CommHopfAlgCat.pointsFppfGroupObject H.obj ⟶ componentGroupFppfSheaf H :=
   CommHopfAlgCat.fppfQuotientProjection H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-    (identityComponentNormality H)
+    (isNormal_identityComponentHopfIdeal H)
 
 /-- The projection to the component group is an epimorphism of group objects in fppf sheaves. -/
 instance instEpiComponentGroupFppfProjection (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
@@ -111,7 +111,7 @@ theorem isLocallySurjective_componentGroupFppfProjection
   unfold componentGroupFppfProjection
   exact CommHopfAlgCat.isLocallySurjective_fppfQuotientProjection H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-    (identityComponentNormality H)
+    (isNormal_identityComponentHopfIdeal H)
 
 /-- The rational pointwise component group `H(k) / H⁰(k)`.
 
@@ -120,14 +120,14 @@ This is the value at `k` of the pointwise quotient presheaf whose sheafification
 noncomputable abbrev componentGroupPoints (H : FiniteTypeCommHopfAlgCat.{u, u} k) : GrpCat.{u} :=
   CommHopfAlgCat.pointwiseQuotientGroup H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-    (identityComponentNormality H) (CommAlgCat.of k k)
+    (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k)
 
 /-- The quotient homomorphism from rational points to the rational pointwise component group. -/
 noncomputable def componentGroupPointsMk (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k) ⟶ componentGroupPoints H :=
   CommHopfAlgCat.pointwiseQuotientMk H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-    (identityComponentNormality H) (CommAlgCat.of k k)
+    (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k)
 
 /-- A rational point belongs to `H⁰(k)` exactly when its kernel point belongs to the identity
 component of `Spec H`. -/
@@ -137,7 +137,7 @@ theorem mem_identityComponentPointsSubgroup_iff
     g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
         (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) (CommAlgCat.of k k) ↔
       rationalKernelPoint H g ∈ connectedComponent (rationalKernelPoint H 1) := by
-  rw [← identityComponentPointsHom_range H (CommAlgCat.of k k)]
+  rw [← range_identityComponentPointsHom H (CommAlgCat.of k k)]
   -- The range is stored as a monoid-hom range, while the existing point criterion uses `Set.range`.
   change g ∈ Set.range (identityComponentPointsHom H (CommAlgCat.of k k)) ↔ _
   rw [rationalKernelPoint_one]
@@ -145,7 +145,7 @@ theorem mem_identityComponentPointsSubgroup_iff
 
 /-- Two rational points have kernel points in the same connected component exactly when their
 left quotient belongs to the identity-component subgroup. -/
-theorem connectedComponents_kernelPoint_eq_iff
+theorem connectedComponents_rationalKernelPoint_eq_iff
     (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (g h : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
     (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H)) =
@@ -156,7 +156,7 @@ theorem connectedComponents_kernelPoint_eq_iff
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) (CommAlgCat.of k k)
   let hN : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-    (identityComponentNormality H) (CommAlgCat.of k k)
+    (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k)
   have hright :
       rationalKernelPoint H h ∈ connectedComponent (rationalKernelPoint H g) ↔
         h * g⁻¹ ∈ N := by
@@ -222,7 +222,7 @@ noncomputable def componentGroupPointsToConnectedComponents
   fun q ↦ Quotient.liftOn' q
     (fun g ↦ (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H)))
     (fun g h hgh ↦ by
-      rw [connectedComponents_kernelPoint_eq_iff H g h]
+      rw [connectedComponents_rationalKernelPoint_eq_iff H g h]
       exact (QuotientGroup.leftRel_apply.mp hgh))
 
 /-- The component map sends the class of a rational point to the component containing its kernel
@@ -267,16 +267,16 @@ private theorem componentGroupPointsToConnectedComponents_injective
   intro x y hxy
   obtain ⟨g, rfl⟩ := CommHopfAlgCat.pointwiseQuotientMk_surjective H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-    (identityComponentNormality H) (CommAlgCat.of k k) x
+    (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k) x
   obtain ⟨h, rfl⟩ := CommHopfAlgCat.pointwiseQuotientMk_surjective H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-    (identityComponentNormality H) (CommAlgCat.of k k) y
+    (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k) y
   -- Surjectivity exposes the raw quotient map; refold the component-group projection wrapper.
   change componentGroupPointsToConnectedComponents H (componentGroupPointsMk H g) =
     componentGroupPointsToConnectedComponents H (componentGroupPointsMk H h) at hxy
   rw [componentGroupPointsToConnectedComponents_mk,
     componentGroupPointsToConnectedComponents_mk,
-    connectedComponents_kernelPoint_eq_iff] at hxy
+    connectedComponents_rationalKernelPoint_eq_iff] at hxy
   -- Refold the same wrapper in the equality of quotient classes.
   change componentGroupPointsMk H g = componentGroupPointsMk H h
   rw [componentGroupPointsMk, CommHopfAlgCat.pointwiseQuotientMk_apply,

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup.lean
@@ -1,0 +1,303 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.GroupTheory.QuotientGroup.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Connected.GroupScheme
+public import TauCeti.Algebra.AlgebraicGroup.Connected.Normal
+public import TauCeti.Algebra.AlgebraicGroup.Connected.Translation
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.ConnectedComponents
+public import TauCeti.Algebra.AlgebraicGroup.Fppf.Quotient.Projection
+public import TauCeti.RingTheory.FiniteType.PointSeparation
+
+/-!
+# The component group of an affine group
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over an algebraically closed
+field. Its identity component is a normal closed subgroup, so the fppf quotient construction
+defines the component group sheaf `π₀(H) = H / H⁰`.
+
+On rational points, the corresponding pointwise quotient is canonically equivalent to the
+connected components of `Spec H`. The proof uses translation to identify two rational points
+modulo `H⁰` exactly when their kernel points lie in the same connected component. Every connected
+component contains a rational point: its component idempotent is non-nilpotent, so the affine
+Nullstellensatz detects it at an algebraically closed point. Consequently the rational component
+group is finite.
+
+No representability is asserted here. Showing that the fppf quotient is represented by a finite
+étale group scheme is the remaining scheme-theoretic part of the component-group construction.
+
+## Main declarations
+
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfSheaf`: the fppf quotient by the identity
+  component.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfProjection`: its locally surjective quotient
+  projection.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupPoints`: its pointwise precursor on rational
+  points.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupPointsEquivConnectedComponents`: the canonical
+  equivalence between that quotient and the connected components of `Spec H`.
+* `TauCeti.FiniteTypeCommHopfAlgCat.instFiniteComponentGroupPoints`: finiteness of the rational
+  component group.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37 and Section 5.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Sections 6.7 and 14.
+
+This advances Layer 3, "Identity component `G°` and component group `π₀(G)`", of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory WithConv
+
+namespace TauCeti.FiniteTypeCommHopfAlgCat
+
+universe u
+
+variable {k : Type u} [Field k] [IsAlgClosed k]
+
+/-- The prime-spectrum point underlying a rational point of a finite-type affine group.
+
+The explicit `PrimeSpectrum` return type bridges the scheme-point spelling of `AlgHom.kernelPoint`
+to the connected-component API. -/
+abbrev rationalKernelPoint (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) : PrimeSpectrum H :=
+  AlgHom.kernelPoint g.ofConv
+
+omit [IsAlgClosed k] in
+/-- The prime-spectrum point underlying the identity rational point is the augmentation point. -/
+@[simp]
+theorem rationalKernelPoint_one (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    rationalKernelPoint H 1 = Bialgebra.augmentationPoint k H := by
+  apply congrArg AlgHom.kernelPoint
+  apply AlgHom.ext
+  exact AlgHom.convOne_apply
+
+/-- The identity-component Hopf ideal is normal over an algebraically closed field. -/
+theorem identityComponentNormality (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)).IsNormal := by
+  let : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+  exact HopfAlgebra.isNormal_identityComponentHopfIdeal (k := k) (H := H)
+
+/-- The component group fppf sheaf `H / H⁰` of a finite-type affine group over an algebraically
+closed field. Its representability by a finite étale group scheme is not asserted here. -/
+noncomputable abbrev componentGroupFppfSheaf (H : FiniteTypeCommHopfAlgCat.{u, u} k) :=
+  CommHopfAlgCat.fppfQuotientSheaf H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (identityComponentNormality H)
+
+/-- The canonical morphism from the fppf sheaf of points of `H` to its component group sheaf. -/
+noncomputable def componentGroupFppfProjection (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.pointsFppfGroupObject H.obj ⟶ componentGroupFppfSheaf H :=
+  CommHopfAlgCat.fppfQuotientProjection H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (identityComponentNormality H)
+
+/-- The projection to the component group is an epimorphism of group objects in fppf sheaves. -/
+instance instEpiComponentGroupFppfProjection (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Epi (componentGroupFppfProjection H) := by
+  unfold componentGroupFppfProjection
+  infer_instance
+
+/-- Every section of the component group lifts to an ambient-group section after an fppf cover. -/
+theorem isLocallySurjective_componentGroupFppfProjection
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Sheaf.IsLocallySurjective (componentGroupFppfProjection H).hom.hom := by
+  unfold componentGroupFppfProjection
+  exact CommHopfAlgCat.isLocallySurjective_fppfQuotientProjection H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (identityComponentNormality H)
+
+/-- The rational pointwise component group `H(k) / H⁰(k)`.
+
+This is the value at `k` of the pointwise quotient presheaf whose sheafification is
+`componentGroupFppfSheaf`. -/
+noncomputable abbrev componentGroupPoints (H : FiniteTypeCommHopfAlgCat.{u, u} k) : GrpCat.{u} :=
+  CommHopfAlgCat.pointwiseQuotientGroup H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (identityComponentNormality H) (CommAlgCat.of k k)
+
+/-- The quotient homomorphism from rational points to the rational pointwise component group. -/
+noncomputable def componentGroupPointsMk (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k) ⟶ componentGroupPoints H :=
+  CommHopfAlgCat.pointwiseQuotientMk H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (identityComponentNormality H) (CommAlgCat.of k k)
+
+/-- A rational point belongs to `H⁰(k)` exactly when its kernel point belongs to the identity
+component of `Spec H`. -/
+theorem mem_identityComponentPointsSubgroup_iff
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
+    g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) (CommAlgCat.of k k) ↔
+      rationalKernelPoint H g ∈ connectedComponent (rationalKernelPoint H 1) := by
+  rw [← identityComponentPointsHom_range H (CommAlgCat.of k k)]
+  -- The range is stored as a monoid-hom range, while the existing point criterion uses `Set.range`.
+  change g ∈ Set.range (identityComponentPointsHom H (CommAlgCat.of k k)) ↔ _
+  rw [rationalKernelPoint_one]
+  exact mem_range_identityComponentPointsHom_iff H g
+
+/-- Two rational points have kernel points in the same connected component exactly when their
+left quotient belongs to the identity-component subgroup. -/
+theorem connectedComponents_kernelPoint_eq_iff
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g h : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
+    (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H)) =
+      rationalKernelPoint H h ↔
+      g⁻¹ * h ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) (CommAlgCat.of k k) := by
+  let N := CommHopfAlgCat.quotientPointsSubgroup H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) (CommAlgCat.of k k)
+  let hN : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (identityComponentNormality H) (CommAlgCat.of k k)
+  have hright :
+      rationalKernelPoint H h ∈ connectedComponent (rationalKernelPoint H g) ↔
+        h * g⁻¹ ∈ N := by
+    constructor
+    · intro hh
+      have himage := TauCeti.HopfAlgebra.rightTranslationHomeomorph_image_connectedComponent g⁻¹
+        (rationalKernelPoint H g)
+      have hmem : TauCeti.HopfAlgebra.rightTranslationHomeomorph g⁻¹
+          (rationalKernelPoint H h) ∈
+          TauCeti.HopfAlgebra.rightTranslationHomeomorph g⁻¹ ''
+            connectedComponent (rationalKernelPoint H g) :=
+        ⟨rationalKernelPoint H h, hh, rfl⟩
+      rw [himage, TauCeti.HopfAlgebra.rightTranslationHomeomorph_kernelPoint,
+        TauCeti.HopfAlgebra.rightTranslationHomeomorph_kernelPoint, mul_inv_cancel] at hmem
+      -- Translation simplifies the identity to `ofConv 1`; restore the bundled point spelling.
+      change rationalKernelPoint H (h * g⁻¹) ∈
+        connectedComponent (rationalKernelPoint H 1) at hmem
+      exact (mem_identityComponentPointsSubgroup_iff H (h * g⁻¹)).mpr hmem
+    · intro hh
+      have hh' := (mem_identityComponentPointsSubgroup_iff H (h * g⁻¹)).mp hh
+      have himage := TauCeti.HopfAlgebra.rightTranslationHomeomorph_image_connectedComponent g
+        (rationalKernelPoint H 1)
+      have hmem : TauCeti.HopfAlgebra.rightTranslationHomeomorph g
+          (rationalKernelPoint H (h * g⁻¹)) ∈
+          TauCeti.HopfAlgebra.rightTranslationHomeomorph g ''
+            connectedComponent (rationalKernelPoint H 1) :=
+        ⟨rationalKernelPoint H (h * g⁻¹), hh', rfl⟩
+      rw [himage, TauCeti.HopfAlgebra.rightTranslationHomeomorph_kernelPoint,
+        TauCeti.HopfAlgebra.rightTranslationHomeomorph_kernelPoint, mul_assoc,
+        inv_mul_cancel, mul_one, one_mul] at hmem
+      exact hmem
+  rw [ConnectedComponents.coe_eq_coe]
+  have hmem_swap :
+      rationalKernelPoint H g ∈ connectedComponent (rationalKernelPoint H h) ↔
+        rationalKernelPoint H h ∈ connectedComponent (rationalKernelPoint H g) := by
+    calc
+      rationalKernelPoint H g ∈ connectedComponent (rationalKernelPoint H h) ↔
+          connectedComponent (rationalKernelPoint H g) =
+            connectedComponent (rationalKernelPoint H h) :=
+        connectedComponent_eq_iff_mem.symm
+      _ ↔ connectedComponent (rationalKernelPoint H h) =
+          connectedComponent (rationalKernelPoint H g) := eq_comm
+      _ ↔ rationalKernelPoint H h ∈ connectedComponent (rationalKernelPoint H g) :=
+        connectedComponent_eq_iff_mem
+  rw [connectedComponent_eq_iff_mem, hmem_swap, hright]
+  constructor
+  · intro hh
+    have hc := hN.conj_mem (h * g⁻¹) hh g⁻¹
+    have heq : g⁻¹ * (h * g⁻¹) * (g⁻¹)⁻¹ = g⁻¹ * h := by group
+    rw [heq] at hc
+    exact hc
+  · intro hh
+    have hc := hN.conj_mem (g⁻¹ * h) hh g
+    have heq : g * (g⁻¹ * h) * g⁻¹ = h * g⁻¹ := by group
+    rw [heq] at hc
+    exact hc
+
+/-- Send a rational point to the connected component containing its kernel point. This descends
+to the quotient by `H⁰(k)`. -/
+noncomputable def componentGroupPointsToConnectedComponents
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupPoints H → ConnectedComponents (PrimeSpectrum H) :=
+  fun q ↦ Quotient.liftOn' q
+    (fun g ↦ (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H)))
+    (fun g h hgh ↦ by
+      rw [connectedComponents_kernelPoint_eq_iff H g h]
+      exact (QuotientGroup.leftRel_apply.mp hgh))
+
+/-- The component map sends the class of a rational point to the component containing its kernel
+point. -/
+@[simp]
+theorem componentGroupPointsToConnectedComponents_mk
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
+    componentGroupPointsToConnectedComponents H (componentGroupPointsMk H g) =
+      (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H)) := by
+  rw [componentGroupPointsMk, CommHopfAlgCat.pointwiseQuotientMk_apply]
+  rfl
+
+private theorem componentGroupPointsToConnectedComponents_surjective
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Function.Surjective (componentGroupPointsToConnectedComponents H) := by
+  intro C
+  obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe C
+  let e := PrimeSpectrum.connectedComponentIdempotent x
+  have he_ne_zero : e ≠ 0 := by
+    intro he
+    have he_mem : e ∈ x.asIdeal := he ▸ x.asIdeal.zero_mem
+    exact PrimeSpectrum.connectedComponentIdempotent_notMem_asIdeal x he_mem
+  have he_not_nilpotent : ¬ IsNilpotent e := by
+    intro he
+    exact he_ne_zero
+      (he.eq_zero_of_isIdempotentElem
+        (PrimeSpectrum.isIdempotentElem_connectedComponentIdempotent x))
+  obtain ⟨f, hf⟩ :=
+    exists_algHom_apply_ne_zero_of_not_isNilpotent (k := k) (K := k) he_not_nilpotent
+  let g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k) := toConv f
+  refine ⟨componentGroupPointsMk H g, ?_⟩
+  rw [componentGroupPointsToConnectedComponents_mk, ConnectedComponents.coe_eq_coe']
+  rw [← PrimeSpectrum.basicOpen_connectedComponentIdempotent]
+  apply (PrimeSpectrum.mem_basicOpen e (rationalKernelPoint H g)).mpr
+  rw [rationalKernelPoint, AlgHom.kernelPoint_asIdeal, RingHom.mem_ker]
+  exact hf
+
+private theorem componentGroupPointsToConnectedComponents_injective
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Function.Injective (componentGroupPointsToConnectedComponents H) := by
+  intro x y hxy
+  obtain ⟨g, rfl⟩ := CommHopfAlgCat.pointwiseQuotientMk_surjective H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (identityComponentNormality H) (CommAlgCat.of k k) x
+  obtain ⟨h, rfl⟩ := CommHopfAlgCat.pointwiseQuotientMk_surjective H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (identityComponentNormality H) (CommAlgCat.of k k) y
+  -- Surjectivity exposes the raw quotient map; refold the component-group projection wrapper.
+  change componentGroupPointsToConnectedComponents H (componentGroupPointsMk H g) =
+    componentGroupPointsToConnectedComponents H (componentGroupPointsMk H h) at hxy
+  rw [componentGroupPointsToConnectedComponents_mk,
+    componentGroupPointsToConnectedComponents_mk,
+    connectedComponents_kernelPoint_eq_iff] at hxy
+  -- Refold the same wrapper in the equality of quotient classes.
+  change componentGroupPointsMk H g = componentGroupPointsMk H h
+  rw [componentGroupPointsMk, CommHopfAlgCat.pointwiseQuotientMk_apply,
+    CommHopfAlgCat.pointwiseQuotientMk_apply,
+    QuotientGroup.mk'_eq_mk']
+  exact ⟨g⁻¹ * h, hxy, by group⟩
+
+/-- Over an algebraically closed field, the rational pointwise component group is canonically
+equivalent to the connected components of the prime spectrum. -/
+noncomputable def componentGroupPointsEquivConnectedComponents
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupPoints H ≃ ConnectedComponents (PrimeSpectrum H) :=
+  Equiv.ofBijective (componentGroupPointsToConnectedComponents H)
+    ⟨componentGroupPointsToConnectedComponents_injective H,
+      componentGroupPointsToConnectedComponents_surjective H⟩
+
+/-- The rational pointwise component group of a finite-type affine group over an algebraically
+closed field is finite. -/
+noncomputable instance instFiniteComponentGroupPoints
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) : Finite (componentGroupPoints H) :=
+  Finite.of_equiv (ConnectedComponents (PrimeSpectrum H))
+    (componentGroupPointsEquivConnectedComponents H).symm
+
+end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/GroupScheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/GroupScheme.lean
@@ -219,6 +219,16 @@ noncomputable def identityComponentPointsHom
   CommHopfAlgCat.quotientPointsHom H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A
 
+/-- The range of the identity-component point inclusion is the subgroup cut out by the
+identity-component Hopf ideal. -/
+@[simp]
+theorem identityComponentPointsHom_range
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    (identityComponentPointsHom H A).hom.range =
+      CommHopfAlgCat.quotientPointsSubgroup H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A := by
+  rfl
+
 /-- A rational point of the ambient affine group lies in the image of the identity-component
 points exactly when its kernel point belongs to the connected component of the augmentation
 point. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/GroupScheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/GroupScheme.lean
@@ -222,7 +222,7 @@ noncomputable def identityComponentPointsHom
 /-- The range of the identity-component point inclusion is the subgroup cut out by the
 identity-component Hopf ideal. -/
 @[simp]
-theorem identityComponentPointsHom_range
+theorem range_identityComponentPointsHom
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
     (identityComponentPointsHom H A).hom.range =
       CommHopfAlgCat.quotientPointsSubgroup H.obj


### PR DESCRIPTION
This PR forms the component group of a finite-type affine group over an algebraically closed field as the fppf quotient by its normal identity component, and identifies the rational pointwise quotient `H(k) / H⁰(k)` with the connected components of `Spec H`. The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3 milestone “Identity component `G°` and component group `π₀(G)`.”

This is the most effective current step because the identity-component affine group scheme and its normality are now on `main`, as are the general normal fppf quotient and locally-surjective projection constructions. The new equivalence proves that two rational points have the same component exactly when their left quotient lies in `H⁰(k)`; surjectivity uses the component idempotent and the affine Nullstellensatz to place an algebraically closed rational point in every component. Consequently the rational pointwise component group is finite.

After this PR, the Layer 3 component-group milestone still needs representability of this fppf quotient and the theorem that the representing group scheme is finite étale under the roadmap’s smoothness hypotheses; geometric base-change and descent beyond the algebraically closed case also remain.

Add `TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup.lean` (303 lines) and add the 10-line characteristic range lemma `identityComponentPointsHom_range` to `Connected/GroupScheme.lean`. Reuse Tau Ceti’s identity-component Hopf ideal and normality, fppf quotient projection, connected-component idempotents, and algebraically closed point-separation theorem, together with Mathlib’s connected-components quotient and quotient-group APIs. No Mathlib infrastructure or external formalization is vendored. The mathematical formulation follows Milne, *Algebraic Groups* (2017), Proposition 2.37 and Section 5, and Waterhouse, *Introduction to Affine Group Schemes*, Sections 6.7 and 14, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"component-group-fppf-quotient"}-->

🤖 Prepared with Codex
