### PR TITLE
feat: the symmetric powers of the standard representation of SU(2) are irreducible

### DIFF
--- a/TauCeti/LinearAlgebra/SymmetricPower/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower/Coordinates.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.SymmetricPower.Basis
+
+/-!
+# The coordinates of a pure symmetric tensor
+
+`TauCeti/LinearAlgebra/SymmetricPower/Basis.lean` builds the basis `Module.Basis.symmetricPower`
+of `Sym[R]^n M` induced by a basis `b : Basis κ R M`, and reads off the coordinates of a pure
+symmetric tensor whose factors are *basis vectors*: it is a basis vector.  This file reads off the
+coordinates of a pure symmetric tensor `⨂ₛ v` whose factors are arbitrary.
+
+Expanding each factor in the basis and using multilinearity writes `⨂ₛ v` as a sum, over the
+ordered tuples `p : Fin n → κ`, of the pure tensors `⨂ₛ i, b (p i)`, each scaled by
+`∏ i, b.repr (v i) (p i)`.  Collecting the terms by the unordered tuple `TauCeti.Sym.ofFn p`
+underlying `p` gives the coordinate at `s` as a sum over the orderings of `s`.
+
+Two consequences are what the file exists for.
+
+* **At a constant index the sum has one term.**  Only the constant tuple orders the unordered
+  tuple `(k, …, k)`, so the coordinate of `⨂ₛ v` there is the plain product `∏ i, b.repr (v i) k`
+  of one coordinate of each factor.
+* **A pure power has no vanishing coordinate.**  The product `∏ i, b.repr (v i) (p i)` depends
+  only on `TauCeti.Sym.ofFn p` when all the factors `v i` are equal, so the sum over the orderings
+  of `s` has all its terms equal and no cancellation is possible: over a domain of characteristic
+  zero, `⨂ₛ (u, …, u)` has a nonzero coordinate at *every* `s` as soon as every coordinate of `u`
+  is nonzero.  For a general pure tensor this fails, the terms attached to different orderings
+  being unrelated.
+
+## Main results
+
+* `SymmetricPower.repr_basis_symmetricPower_tprod`: the coordinate of a pure symmetric tensor at
+  `s` is the sum, over the orderings of `s`, of the products of the corresponding coordinates of
+  the factors.
+* `SymmetricPower.repr_basis_symmetricPower_tprod_ofFn_const`: its value at a constant unordered
+  tuple is a single product.
+* `SymmetricPower.repr_basis_symmetricPower_tprod_const_ne_zero`: a pure power of a vector with
+  nonzero coordinates has nonzero coordinates.
+
+## References
+
+* W. Fulton, J. Harris, *Representation Theory: A First Course*, Springer GTM 129 (1991),
+  Appendix B, for the monomial basis of a symmetric power.
+-/
+
+public section
+
+open Finset Module
+
+universe v w
+
+variable {R : Type} {M : Type v} {κ : Type w} {n : ℕ}
+
+namespace SymmetricPower
+
+section CommSemiring
+
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
+
+/-- The product of the coordinates listed by an ordered tuple depends only on the unordered tuple
+underlying it: reordering the factors permutes the terms of the product. -/
+private theorem prod_eq_of_ofFn_eq (c : κ → R) {p q : Fin n → κ}
+    (h : TauCeti.Sym.ofFn p = TauCeti.Sym.ofFn q) : ∏ i, c (p i) = ∏ i, c (q i) := by
+  obtain ⟨σ, rfl⟩ := TauCeti.Sym.ofFn_eq_ofFn_iff.1 h
+  exact (Equiv.prod_comp σ fun i => c (p i)).symm
+
+/-- Two ordered tuples underlying the same unordered tuple as a constant one are equal to it. -/
+private theorem eq_const_of_ofFn_eq_ofFn_const {p : Fin n → κ} {k : κ}
+    (h : TauCeti.Sym.ofFn p = TauCeti.Sym.ofFn fun _ => k) : p = fun _ => k := by
+  obtain ⟨σ, hσ⟩ := TauCeti.Sym.ofFn_eq_ofFn_iff.1 h
+  exact funext fun i => by simpa using congrFun hσ (σ.symm i)
+
+variable (b : Basis κ R M)
+
+/-- **The coordinates of a pure symmetric tensor.**  Expanding each factor of `⨂ₛ v` in the basis
+`b` and collecting the resulting pure tensors of basis vectors by the unordered tuple of indices
+they use, the coordinate at `s` is the sum, over the ordered tuples `p` underlying `s`, of the
+products of the corresponding coordinates of the factors.
+
+For factors that are themselves basis vectors this recovers `Module.Basis.symmetricPower_apply`;
+the content here is the general case. -/
+theorem repr_basis_symmetricPower_tprod [Fintype κ] [DecidableEq κ] (v : Fin n → M) (s : Sym κ n) :
+    (b.symmetricPower n).repr (⨂ₛ[R] i, v i) s =
+      ∑ p ∈ {p : Fin n → κ | TauCeti.Sym.ofFn p = s}, ∏ i, b.repr (v i) (p i) := by
+  have hv : (fun i => v i) = fun i => ∑ k, b.repr (v i) k • b k :=
+    funext fun i => (b.sum_repr (v i)).symm
+  rw [show (⨂ₛ[R] i, v i) = tprod R fun i => v i from rfl, hv,
+    (tprod R).map_sum fun (i : Fin n) (k : κ) => b.repr (v i) k • b k, map_sum,
+    Finsupp.finsetSum_apply, Finset.sum_filter]
+  refine Finset.sum_congr rfl fun p _ => ?_
+  have hbasis : (tprod R fun i => b (p i)) = b.symmetricPower n (TauCeti.Sym.ofFn p) := by
+    rw [Basis.symmetricPower_apply, tprodOfSym_ofFn]
+  rw [(tprod R).map_smul_univ (fun i => b.repr (v i) (p i)) fun i => b (p i), hbasis, map_smul,
+    Basis.repr_self, Finsupp.smul_single, smul_eq_mul, mul_one, Finsupp.single_apply]
+
+/-- **The coordinates of a pure symmetric tensor at a constant unordered tuple.**  The only
+ordering of `(k, …, k)` is the constant tuple, so the sum of
+`SymmetricPower.repr_basis_symmetricPower_tprod` collapses to a single product: one coordinate of
+each factor. -/
+theorem repr_basis_symmetricPower_tprod_ofFn_const [Finite κ] (v : Fin n → M) (k : κ) :
+    (b.symmetricPower n).repr (⨂ₛ[R] i, v i) (TauCeti.Sym.ofFn fun _ => k) =
+      ∏ i, b.repr (v i) k := by
+  classical
+  have := Fintype.ofFinite κ
+  rw [repr_basis_symmetricPower_tprod]
+  exact Finset.sum_eq_single_of_mem (fun _ => k) (by simp) fun p hp hne =>
+    absurd (eq_const_of_ofFn_eq_ofFn_const (Finset.mem_filter.1 hp).2) hne
+
+end CommSemiring
+
+section CommRing
+
+variable [CommRing R] [IsDomain R] [CharZero R] [AddCommMonoid M] [Module R M]
+variable (b : Basis κ R M)
+
+/-- **A pure power has no vanishing coordinate.**  When all the factors are the same vector `u`,
+every term of the sum of `SymmetricPower.repr_basis_symmetricPower_tprod` is the same product of
+coordinates of `u`, so the coordinate at `s` is that product times the number of orderings of `s`,
+which is positive.  Over a domain of characteristic zero neither factor vanishes.
+
+Nothing like this holds for a general pure tensor: the terms attached to different orderings of
+`s` can cancel. -/
+theorem repr_basis_symmetricPower_tprod_const_ne_zero [Finite κ] {u : M}
+    (hu : ∀ k, b.repr u k ≠ 0) (s : Sym κ n) :
+    (b.symmetricPower n).repr (⨂ₛ[R] (_ : Fin n), u) s ≠ 0 := by
+  classical
+  have := Fintype.ofFinite κ
+  obtain ⟨p₀, hp₀⟩ := TauCeti.Sym.ofFn_surjective s
+  have hne : ({p : Fin n → κ | TauCeti.Sym.ofFn p = s} : Finset (Fin n → κ)).Nonempty :=
+    ⟨p₀, by simp [hp₀]⟩
+  rw [repr_basis_symmetricPower_tprod,
+    Finset.sum_congr rfl fun p hp => prod_eq_of_ofFn_eq (fun k => b.repr u k) (p := p) (q := p₀)
+      (by rw [(Finset.mem_filter.1 hp).2, hp₀]),
+    Finset.sum_const, nsmul_eq_mul]
+  exact mul_ne_zero (Nat.cast_ne_zero.2 (Finset.card_pos.2 hne).ne')
+    (Finset.prod_ne_zero_iff.2 fun i _ => hu _)
+
+end CommRing
+
+end SymmetricPower

--- a/TauCeti/LinearAlgebra/SymmetricPower/Coordinates.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower/Coordinates.lean
@@ -76,6 +76,18 @@ private theorem eq_const_of_ofFn_eq_ofFn_const {p : Fin n → κ} {k : κ}
 
 variable (b : Basis κ R M)
 
+/-- The single expansion step behind everything below: the coordinate at `s` of a pure symmetric
+tensor of *scaled* basis vectors is the product of the scalars when the indices order `s`, and
+zero otherwise. -/
+private theorem repr_basis_symmetricPower_tprod_smul_basis [DecidableEq κ] (c : Fin n → R)
+    (p : Fin n → κ) (s : Sym κ n) :
+    (b.symmetricPower n).repr (⨂ₛ[R] i, c i • b (p i)) s =
+      if TauCeti.Sym.ofFn p = s then ∏ i, c i else 0 := by
+  have hbasis : (tprod R fun i => b (p i)) = b.symmetricPower n (TauCeti.Sym.ofFn p) := by
+    rw [Basis.symmetricPower_apply, tprodOfSym_ofFn]
+  rw [(tprod R).map_smul_univ c fun i => b (p i), hbasis, map_smul, Basis.repr_self,
+    Finsupp.smul_single, smul_eq_mul, mul_one, Finsupp.single_apply]
+
 /-- **The coordinates of a pure symmetric tensor.**  Expanding each factor of `⨂ₛ v` in the basis
 `b` and collecting the resulting pure tensors of basis vectors by the unordered tuple of indices
 they use, the coordinate at `s` is the sum, over the ordered tuples `p` underlying `s`, of the
@@ -86,35 +98,46 @@ the content here is the general case. -/
 theorem repr_basis_symmetricPower_tprod [Fintype κ] [DecidableEq κ] (v : Fin n → M) (s : Sym κ n) :
     (b.symmetricPower n).repr (⨂ₛ[R] i, v i) s =
       ∑ p ∈ {p : Fin n → κ | TauCeti.Sym.ofFn p = s}, ∏ i, b.repr (v i) (p i) := by
-  have hv : (fun i => v i) = fun i => ∑ k, b.repr (v i) k • b k :=
-    funext fun i => (b.sum_repr (v i)).symm
-  rw [show (⨂ₛ[R] i, v i) = tprod R fun i => v i from rfl, hv,
-    (tprod R).map_sum fun (i : Fin n) (k : κ) => b.repr (v i) k • b k, map_sum,
+  have hv : (⨂ₛ[R] i, v i) = ⨂ₛ[R] i, ∑ k, b.repr (v i) k • b k :=
+    congrArg _ (funext fun i => (b.sum_repr (v i)).symm)
+  rw [hv, (tprod R).map_sum fun (i : Fin n) (k : κ) => b.repr (v i) k • b k, map_sum,
     Finsupp.finsetSum_apply, Finset.sum_filter]
-  refine Finset.sum_congr rfl fun p _ => ?_
-  have hbasis : (tprod R fun i => b (p i)) = b.symmetricPower n (TauCeti.Sym.ofFn p) := by
-    rw [Basis.symmetricPower_apply, tprodOfSym_ofFn]
-  rw [(tprod R).map_smul_univ (fun i => b.repr (v i) (p i)) fun i => b (p i), hbasis, map_smul,
-    Basis.repr_self, Finsupp.smul_single, smul_eq_mul, mul_one, Finsupp.single_apply]
+  exact Finset.sum_congr rfl fun p _ =>
+    repr_basis_symmetricPower_tprod_smul_basis b (fun i => b.repr (v i) (p i)) p s
 
 /-- **The coordinates of a pure symmetric tensor at a constant unordered tuple.**  The only
 ordering of `(k, …, k)` is the constant tuple, so the sum of
 `SymmetricPower.repr_basis_symmetricPower_tprod` collapses to a single product: one coordinate of
-each factor. -/
-theorem repr_basis_symmetricPower_tprod_ofFn_const [Finite κ] (v : Fin n → M) (k : κ) :
+each factor.
+
+The basis index type need not be finite: it is enough to expand each factor over the finitely many
+indices it uses, together with `k`. -/
+@[simp]
+theorem repr_basis_symmetricPower_tprod_ofFn_const (v : Fin n → M) (k : κ) :
     (b.symmetricPower n).repr (⨂ₛ[R] i, v i) (TauCeti.Sym.ofFn fun _ => k) =
       ∏ i, b.repr (v i) k := by
   classical
-  have := Fintype.ofFinite κ
-  rw [repr_basis_symmetricPower_tprod]
-  exact Finset.sum_eq_single_of_mem (fun _ => k) (by simp) fun p hp hne =>
-    absurd (eq_const_of_ofFn_eq_ofFn_const (Finset.mem_filter.1 hp).2) hne
+  have hvi : ∀ i, ∑ j ∈ insert k (b.repr (v i)).support, b.repr (v i) j • b j = v i := fun i => by
+    conv_rhs => rw [← b.linearCombination_repr (v i), Finsupp.linearCombination_apply, Finsupp.sum]
+    exact (Finset.sum_subset (Finset.subset_insert k _)
+      fun j _ hj => by rw [Finsupp.notMem_support_iff.1 hj, zero_smul]).symm
+  have hv : (⨂ₛ[R] i, v i) =
+      ⨂ₛ[R] i, ∑ j ∈ insert k (b.repr (v i)).support, b.repr (v i) j • b j :=
+    congrArg _ (funext fun i => (hvi i).symm)
+  rw [hv, (tprod R).map_sum_finset (fun (i : Fin n) (j : κ) => b.repr (v i) j • b j)
+      fun i => insert k (b.repr (v i)).support, map_sum, Finsupp.finsetSum_apply,
+    Finset.sum_congr rfl fun p _ =>
+      repr_basis_symmetricPower_tprod_smul_basis b (fun i => b.repr (v i) (p i)) p _,
+    Finset.sum_eq_single_of_mem (fun _ => k) (by simp)]
+  · simp
+  · intro p _ hne
+    simpa using fun h => absurd (eq_const_of_ofFn_eq_ofFn_const h) hne
 
 end CommSemiring
 
-section CommRing
+section Domain
 
-variable [CommRing R] [IsDomain R] [CharZero R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring R] [IsDomain R] [CharZero R] [AddCommMonoid M] [Module R M]
 variable (b : Basis κ R M)
 
 /-- **A pure power has no vanishing coordinate.**  When all the factors are the same vector `u`,
@@ -124,10 +147,14 @@ which is positive.  Over a domain of characteristic zero neither factor vanishes
 
 Nothing like this holds for a general pure tensor: the terms attached to different orderings of
 `s` can cancel. -/
-theorem repr_basis_symmetricPower_tprod_const_ne_zero [Finite κ] {u : M}
+theorem repr_basis_symmetricPower_tprod_const_ne_zero {u : M}
     (hu : ∀ k, b.repr u k ≠ 0) (s : Sym κ n) :
     (b.symmetricPower n).repr (⨂ₛ[R] (_ : Fin n), u) s ≠ 0 := by
   classical
+  -- no coordinate of `u` vanishes, so the index type embeds in the finite support of `b.repr u`
+  have : Finite κ := Finite.of_injective
+    (fun k : κ => (⟨k, Finsupp.mem_support_iff.2 (hu k)⟩ : {j // j ∈ (b.repr u).support}))
+    fun _ _ h => congrArg Subtype.val h
   have := Fintype.ofFinite κ
   obtain ⟨p₀, hp₀⟩ := TauCeti.Sym.ofFn_surjective s
   have hne : ({p : Fin n → κ | TauCeti.Sym.ofFn p = s} : Finset (Fin n → κ)).Nonempty :=
@@ -139,6 +166,6 @@ theorem repr_basis_symmetricPower_tprod_const_ne_zero [Finite κ] {u : M}
   exact mul_ne_zero (Nat.cast_ne_zero.2 (Finset.card_pos.2 hne).ne')
     (Finset.prod_ne_zero_iff.2 fun i _ => hu _)
 
-end CommRing
+end Domain
 
 end SymmetricPower

--- a/TauCeti/RepresentationTheory/SU2/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/SU2/Irreducible.lean
@@ -133,11 +133,12 @@ private theorem exists_weightBasis_eq_tprod (i : Fin (d + 1)) :
   exact ⟨f, by rw [weightBasis_apply, ← hf, Basis.symmetricPower_apply,
     SymmetricPower.tprodOfSym_ofFn]⟩
 
-/-! ### The rotation reaches the highest weight, and the highest weight reaches everything -/
+/-! ### The rotated weight vectors have nonzero coordinates -/
 
-/-- **The rotation moves every weight vector onto the highest weight.**  The highest weight is
-indexed by a constant unordered tuple, whose only ordering is the constant one, so the coordinate
-there is a single product of entries of `TauCeti.SU2.mixMatrix`, and no entry vanishes. -/
+/-- **The image of a weight vector has a nonzero coordinate at the highest weight.**  The highest
+weight is indexed by a constant unordered tuple, whose only ordering is the constant one, so that
+coordinate is a single product of entries of `TauCeti.SU2.mixMatrix`, and no entry vanishes.  The
+image itself is of course not a weight vector, only a combination with this coordinate nonzero. -/
 private theorem repr_symPower_mixElement_weightBasis_last_ne_zero (i : Fin (d + 1)) :
     (weightBasis d).repr (symPower d mixElement (weightBasis d i)) (Fin.last d) ≠ 0 := by
   obtain ⟨f, hf⟩ := exists_weightBasis_eq_tprod d i
@@ -146,9 +147,9 @@ private theorem repr_symPower_mixElement_weightBasis_last_ne_zero (i : Fin (d + 
   exact Finset.prod_ne_zero_iff.2 fun j _ => by
     rw [repr_mulVec_basisFun]; exact mixMatrix_apply_ne_zero 0 (f j)
 
-/-- **The rotation moves the highest weight vector onto every weight.**  The image of the highest
-weight vector is the pure power `(u e₀)^d`, and every coordinate of a pure power of a vector with
-nonzero coordinates is nonzero. -/
+/-- **The image of the highest weight vector has a nonzero coordinate at every weight.**  That
+image is the pure power `(u e₀)^d`, and every coordinate of a pure power of a vector with nonzero
+coordinates is nonzero. -/
 private theorem repr_symPower_mixElement_weightBasis_last_ne_zero' (i : Fin (d + 1)) :
     (weightBasis d).repr (symPower d mixElement (weightBasis d (Fin.last d))) i ≠ 0 := by
   have hf : weightBasis d (Fin.last d) =
@@ -162,9 +163,11 @@ private theorem repr_symPower_mixElement_weightBasis_last_ne_zero' (i : Fin (d +
 /-! ### Irreducibility -/
 
 /-- **The symmetric powers of the standard representation of `SU(2)` are irreducible.**  A nonzero
-invariant subspace is torus-stable, hence spanned by the weight vectors it contains; the rotation
-`TauCeti.SU2.mixMatrix` carries one of them onto the highest weight and the highest weight onto
-all of them, so the subspace is everything.
+invariant subspace is torus-stable, hence spanned by the weight vectors it contains.  The image
+under the rotation `TauCeti.SU2.mixMatrix` of one of those weight vectors has a nonzero coordinate
+at the highest weight, which puts the highest weight vector in the subspace; the image of the
+highest weight vector in turn has a nonzero coordinate at *every* weight, which puts every weight
+vector in the subspace.  So the subspace is everything.
 
 This is the highest-weight half of the classification of the irreducibles of `SU(2)`; the
 character orthonormality of `TauCeti/RepresentationTheory/SU2/Weyl/Orthogonality.lean` validates
@@ -187,12 +190,13 @@ theorem isIrreducible_symPower : Representation.IsIrreducible (symPower d) := by
   -- a nonzero invariant subspace contains a weight vector
   have hex : ∃ i, weightBasis d i ∈ σ.toSubmodule := by
     by_contra hcon
+    -- otherwise the set of weight vectors lying in `σ`, which spans it, is empty
+    have hempty : {v : Sym[ℂ]^d(Fin 2 → ℂ) | ∃ i, weightBasis d i = v ∧ v ∈ σ.toSubmodule} = ∅ :=
+      Set.eq_empty_iff_forall_notMem.2 (by rintro v ⟨i, rfl, hv⟩; exact hcon ⟨i, hv⟩)
     refine hσ (Subrepresentation.toSubmodule_injective ?_)
-    rw [Subrepresentation.toSubmodule_bot, eq_span_weightBasis_mem hW,
-      show {v : Sym[ℂ]^d(Fin 2 → ℂ) | ∃ i, weightBasis d i = v ∧ v ∈ σ.toSubmodule} = ∅ from
-        Set.eq_empty_iff_forall_notMem.2 (by rintro v ⟨i, rfl, hv⟩; exact hcon ⟨i, hv⟩),
+    rw [Subrepresentation.toSubmodule_bot, eq_span_weightBasis_mem hW, hempty,
       Submodule.span_empty]
-  -- the rotation carries it onto the highest weight vector, and that onto every weight vector
+  -- the image of that weight vector reaches the highest weight, and its image reaches every weight
   obtain ⟨i, hi⟩ := hex
   have hlast : weightBasis d (Fin.last d) ∈ σ.toSubmodule :=
     weightBasis_mem_of_repr_ne_zero hW (σ.apply_mem_toSubmodule mixElement hi)
@@ -207,6 +211,7 @@ theorem isIrreducible_symPower : Representation.IsIrreducible (symPower d) := by
 the same degree, their dimensions `d + 1` being distinct.  With
 `TauCeti.SU2.isIrreducible_symPower` this exhibits `Symᵈ(ℂ²)` as a family of pairwise
 non-isomorphic irreducibles of `SU(2)`, one in each dimension. -/
+@[simp]
 theorem nonempty_equiv_symPower_iff (e : ℕ) :
     Nonempty ((symPower d).Equiv (symPower e)) ↔ d = e := by
   refine ⟨fun ⟨f⟩ => ?_, fun h => h ▸ ⟨Representation.Equiv.refl _⟩⟩

--- a/TauCeti/RepresentationTheory/SU2/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/SU2/Irreducible.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.SymmetricPower.Coordinates
+public import TauCeti.RepresentationTheory.Irreducible
+public import TauCeti.RepresentationTheory.SU2.Weight
+
+/-!
+# The symmetric powers of the standard representation of `SU(2)` are irreducible
+
+`TauCeti/RepresentationTheory/SU2/Weight.lean` decomposes `Symᵈ(ℂ²)` under the maximal torus: the
+monomial basis `TauCeti.SU2.weightBasis` consists of weight vectors, the `d + 1` weights are
+pairwise distinct, and consequently a torus-stable subspace is spanned by the weight vectors it
+contains.  That is one half of the highest-weight argument; this file supplies the other half and
+concludes that `Symᵈ(ℂ²)` is an **irreducible** representation of `SU(2)`, for every `d`.
+
+The torus alone cannot see irreducibility: it is abelian, and every span of weight vectors is
+torus-stable.  What breaks the weight vectors apart is a single element of `SU(2)` off the torus.
+Fix the rotation `u = !![3/5, -4/5; 4/5, 3/5]`, an element of `SU(2)` **none of whose entries
+vanishes**, and let `W ≠ 0` be an invariant subspace.  Then:
+
+* `W` is torus-stable, so it contains some weight vector, `TauCeti.SU2.weightBasis d i`.
+* The coordinate of `u · (weight vector)` at the **highest** weight is a product of entries of `u`,
+  one for each tensor factor, hence nonzero: the highest weight is indexed by a *constant*
+  unordered tuple, and only the constant ordered tuple orders it, so the coordinate is the single
+  product `∏ⱼ u₀,ₖⱼ` with no cancellation
+  (`SymmetricPower.repr_basis_symmetricPower_tprod_ofFn_const`).  Torus-stability then puts the
+  highest weight vector `e₀^d` into `W`.
+* `u · e₀^d` is the **pure power** `(u e₀)^d`, and a pure power of a vector with nonzero
+  coordinates has *every* coordinate nonzero
+  (`SymmetricPower.repr_basis_symmetricPower_tprod_const_ne_zero`); the terms of the coordinate sum
+  all coincide, so again nothing cancels.  Torus-stability now puts **every** weight vector into
+  `W`, so `W` is everything.
+
+The choice of `u` matters only through the non-vanishing of its four entries, and the rational
+rotation is taken to keep that check arithmetic.  It is a device of the proof and stays private to
+this file, as `TauCeti.SU2.genericTorus` does in the weight file.
+
+## Main results
+
+* `TauCeti.SU2.isIrreducible_symPower`: `Symᵈ(ℂ²)` is an irreducible representation of `SU(2)`.
+* `TauCeti.SU2.nonempty_equiv_symPower_iff`: two of them are equivalent exactly when they have the
+  same degree, so the `Symᵈ(ℂ²)` are pairwise inequivalent.
+
+Exhaustion -- that every finite-dimensional irreducible representation of `SU(2)` is one of these
+-- is *not* proved here; it is the remaining half of the classification.
+
+## References
+
+This is the "the `su2Irrep n` are irreducible, pairwise inequivalent" half of the classification
+asked for by the `SU(2)` engine case of
+`TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, which insists that the
+classification be proved by the weight/highest-weight argument rather than read off Peter-Weyl.
+
+* D. Bump, *Lie Groups*, 2nd ed., Springer GTM 225 (2013), Chapter 3.
+* T. Bröcker, T. tom Dieck, *Representations of Compact Lie Groups*, Springer GTM 98 (1985),
+  Chapter II, §5.
+-/
+
+public section
+
+open Finset Matrix Module
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace SU2
+
+variable (d : ℕ)
+
+/-! ### A rotation with no zero entry -/
+
+/-- **The separating element of the proof**: the rotation `!![3/5, -4/5; 4/5, 3/5]`, an element of
+`SU(2)` none of whose entries vanishes.  Only that non-vanishing is used; the rational entries
+keep the check that it lies in `SU(2)` arithmetic. -/
+private noncomputable def mixMatrix : Matrix (Fin 2) (Fin 2) ℂ :=
+  !![3 / 5, -(4 / 5); 4 / 5, 3 / 5]
+
+private theorem mixMatrix_apply_ne_zero (i j : Fin 2) : mixMatrix i j ≠ 0 := by
+  fin_cases i <;> fin_cases j <;> norm_num [mixMatrix]
+
+private theorem mixMatrix_mem : mixMatrix ∈ Matrix.specialUnitaryGroup (Fin 2) ℂ := by
+  refine Matrix.mem_specialUnitaryGroup_iff.mpr ⟨Matrix.mem_unitaryGroup_iff.mpr ?_, ?_⟩
+  · ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [mixMatrix, Matrix.mul_apply, Fin.sum_univ_two, map_ofNat] <;> norm_num
+  · rw [mixMatrix, Matrix.det_fin_two_of]
+    norm_num
+
+/-- The rotation `TauCeti.SU2.mixMatrix`, as an element of `SU(2)`. -/
+private noncomputable def mixElement : SU2 := ⟨mixMatrix, mixMatrix_mem⟩
+
+/-- The matrix underlying `TauCeti.SU2.mixElement`. -/
+private theorem coe_mixElement :
+    (mixElement : Matrix (Fin 2) (Fin 2) ℂ) = mixMatrix := (rfl)
+
+/-- The rotation acts on a pure symmetric tensor factor by factor. -/
+private theorem symPower_mixElement_tprod (v : Fin d → (Fin 2 → ℂ)) :
+    symPower d mixElement (⨂ₛ[ℂ] i, v i) = ⨂ₛ[ℂ] i, mixMatrix *ᵥ v i := by
+  simp only [symPower_apply, symPowerRep, Representation.symmetricPower_apply_tprod,
+    stdRep_apply_apply, coe_toGL, coe_mixElement]
+
+/-- The coordinates of the image of a standard basis vector are the entries of the matrix. -/
+private theorem repr_mulVec_basisFun (A : Matrix (Fin 2) (Fin 2) ℂ) (k l : Fin 2) :
+    (Pi.basisFun ℂ (Fin 2)).repr (A *ᵥ Pi.basisFun ℂ (Fin 2) k) l = A l k := by
+  simp [Matrix.mulVec_single]
+
+/-! ### The weight basis as the monomial basis -/
+
+/-- The weight basis is the monomial basis of `Symᵈ(ℂ²)` reindexed by the number of factors equal
+to the first standard basis vector; this is `TauCeti.SU2.weightBasis_apply` promoted from the
+basis vectors to the basis itself, so that coordinates may be compared. -/
+private theorem weightBasis_eq_reindex :
+    weightBasis d = ((Pi.basisFun ℂ (Fin 2)).symmetricPower d).reindex (symFinTwoEquiv d) :=
+  DFunLike.coe_injective (funext fun i => (weightBasis_apply d i).trans
+    (Basis.reindex_apply _ _ i).symm)
+
+/-- The index of the highest weight is the constant unordered tuple `(0, …, 0)`: the monomial that
+is the `d`-th power of the first standard basis vector. -/
+private theorem symFinTwoEquiv_symm_last :
+    (symFinTwoEquiv d).symm (Fin.last d) = TauCeti.Sym.ofFn fun _ : Fin d => (0 : Fin 2) := by
+  refine Sym.coe_injective ?_
+  rw [coe_symFinTwoEquiv_symm_apply, TauCeti.Sym.coe_ofFn, List.ofFn_const, Multiset.coe_replicate]
+  simp
+
+/-- Every weight vector is a pure symmetric tensor of standard basis vectors. -/
+private theorem exists_weightBasis_eq_tprod (i : Fin (d + 1)) :
+    ∃ f : Fin d → Fin 2, weightBasis d i = ⨂ₛ[ℂ] j, Pi.basisFun ℂ (Fin 2) (f j) := by
+  obtain ⟨f, hf⟩ := TauCeti.Sym.ofFn_surjective ((symFinTwoEquiv d).symm i)
+  exact ⟨f, by rw [weightBasis_apply, ← hf, Basis.symmetricPower_apply,
+    SymmetricPower.tprodOfSym_ofFn]⟩
+
+/-! ### The rotation reaches the highest weight, and the highest weight reaches everything -/
+
+/-- **The rotation moves every weight vector onto the highest weight.**  The highest weight is
+indexed by a constant unordered tuple, whose only ordering is the constant one, so the coordinate
+there is a single product of entries of `TauCeti.SU2.mixMatrix`, and no entry vanishes. -/
+private theorem repr_symPower_mixElement_weightBasis_last_ne_zero (i : Fin (d + 1)) :
+    (weightBasis d).repr (symPower d mixElement (weightBasis d i)) (Fin.last d) ≠ 0 := by
+  obtain ⟨f, hf⟩ := exists_weightBasis_eq_tprod d i
+  rw [hf, weightBasis_eq_reindex, Basis.repr_reindex_apply, symFinTwoEquiv_symm_last,
+    symPower_mixElement_tprod, SymmetricPower.repr_basis_symmetricPower_tprod_ofFn_const]
+  exact Finset.prod_ne_zero_iff.2 fun j _ => by
+    rw [repr_mulVec_basisFun]; exact mixMatrix_apply_ne_zero 0 (f j)
+
+/-- **The rotation moves the highest weight vector onto every weight.**  The image of the highest
+weight vector is the pure power `(u e₀)^d`, and every coordinate of a pure power of a vector with
+nonzero coordinates is nonzero. -/
+private theorem repr_symPower_mixElement_weightBasis_last_ne_zero' (i : Fin (d + 1)) :
+    (weightBasis d).repr (symPower d mixElement (weightBasis d (Fin.last d))) i ≠ 0 := by
+  have hf : weightBasis d (Fin.last d) =
+      ⨂ₛ[ℂ] (_ : Fin d), Pi.basisFun ℂ (Fin 2) 0 := by
+    rw [weightBasis_apply, symFinTwoEquiv_symm_last, Basis.symmetricPower_apply,
+      SymmetricPower.tprodOfSym_ofFn]
+  rw [hf, weightBasis_eq_reindex, Basis.repr_reindex_apply, symPower_mixElement_tprod]
+  exact SymmetricPower.repr_basis_symmetricPower_tprod_const_ne_zero _
+    (fun l => by rw [repr_mulVec_basisFun]; exact mixMatrix_apply_ne_zero l 0) _
+
+/-! ### Irreducibility -/
+
+/-- **The symmetric powers of the standard representation of `SU(2)` are irreducible.**  A nonzero
+invariant subspace is torus-stable, hence spanned by the weight vectors it contains; the rotation
+`TauCeti.SU2.mixMatrix` carries one of them onto the highest weight and the highest weight onto
+all of them, so the subspace is everything.
+
+This is the highest-weight half of the classification of the irreducibles of `SU(2)`; the
+character orthonormality of `TauCeti/RepresentationTheory/SU2/Weyl/Orthogonality.lean` validates
+it but does not prove it. -/
+theorem isIrreducible_symPower : Representation.IsIrreducible (symPower d) := by
+  have hnt : Nontrivial (Sym[ℂ]^d(Fin 2 → ℂ)) :=
+    Module.nontrivial_of_finrank_pos (R := ℂ) (by rw [finrank_symPower]; omega)
+  have hntsub : Nontrivial (Subrepresentation (symPower d)) := by
+    refine ⟨⊥, ⊤, fun hbot => absurd (congrArg Subrepresentation.toSubmodule hbot) ?_⟩
+    rw [Subrepresentation.toSubmodule_bot, Subrepresentation.toSubmodule_top]
+    exact bot_ne_top
+  refine { eq_bot_or_eq_top := fun σ => ?_ }
+  rcases eq_or_ne σ ⊥ with hσ | hσ
+  · exact Or.inl hσ
+  refine Or.inr (Subrepresentation.toSubmodule_injective ?_)
+  rw [Subrepresentation.toSubmodule_top]
+  have hW : ∀ (z : Circle) (v : Sym[ℂ]^d(Fin 2 → ℂ)), v ∈ σ.toSubmodule →
+      symPower d (torusHom z) v ∈ σ.toSubmodule :=
+    fun z _ hv => σ.apply_mem_toSubmodule (torusHom z) hv
+  -- a nonzero invariant subspace contains a weight vector
+  have hex : ∃ i, weightBasis d i ∈ σ.toSubmodule := by
+    by_contra hcon
+    refine hσ (Subrepresentation.toSubmodule_injective ?_)
+    rw [Subrepresentation.toSubmodule_bot, eq_span_weightBasis_mem hW,
+      show {v : Sym[ℂ]^d(Fin 2 → ℂ) | ∃ i, weightBasis d i = v ∧ v ∈ σ.toSubmodule} = ∅ from
+        Set.eq_empty_iff_forall_notMem.2 (by rintro v ⟨i, rfl, hv⟩; exact hcon ⟨i, hv⟩),
+      Submodule.span_empty]
+  -- the rotation carries it onto the highest weight vector, and that onto every weight vector
+  obtain ⟨i, hi⟩ := hex
+  have hlast : weightBasis d (Fin.last d) ∈ σ.toSubmodule :=
+    weightBasis_mem_of_repr_ne_zero hW (σ.apply_mem_toSubmodule mixElement hi)
+      (repr_symPower_mixElement_weightBasis_last_ne_zero d i)
+  have hall : ∀ i, weightBasis d i ∈ σ.toSubmodule := fun i =>
+    weightBasis_mem_of_repr_ne_zero hW (σ.apply_mem_toSubmodule mixElement hlast)
+      (repr_symPower_mixElement_weightBasis_last_ne_zero' d i)
+  rw [eq_top_iff, ← (weightBasis d).span_eq]
+  exact Submodule.span_le.2 (by rintro _ ⟨i, rfl⟩; exact hall i)
+
+/-- **The symmetric powers are pairwise inequivalent**: they are equivalent exactly when they have
+the same degree, their dimensions `d + 1` being distinct.  With
+`TauCeti.SU2.isIrreducible_symPower` this exhibits `Symᵈ(ℂ²)` as a family of pairwise
+non-isomorphic irreducibles of `SU(2)`, one in each dimension. -/
+theorem nonempty_equiv_symPower_iff (e : ℕ) :
+    Nonempty ((symPower d).Equiv (symPower e)) ↔ d = e := by
+  refine ⟨fun ⟨f⟩ => ?_, fun h => h ▸ ⟨Representation.Equiv.refl _⟩⟩
+  have hrank : Module.finrank ℂ (Sym[ℂ]^d(Fin 2 → ℂ)) = Module.finrank ℂ (Sym[ℂ]^e(Fin 2 → ℂ)) :=
+    f.toLinearEquiv.finrank_eq
+  rw [finrank_symPower, finrank_symPower] at hrank
+  omega
+
+end SU2
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the symmetric powers `Symᵈ(ℂ²)` of the standard representation of `SU(2)` are irreducible, and that they are pairwise inequivalent. This is the `su2Irrep_irreducible` / `su2Irrep_inequiv` milestone of the `SU(2)` engine case of `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md` (Layer 6, "Engine case: `SU(2)` and the maximal torus"), whose `Suggested.lean` pins `su2Irrep_irreducible` and `su2Irrep_inequiv` and whose README insists that "the classification is proved, not assumed": Peter-Weyl decomposes `L²(G)` into *some* irreducibles but does not identify them, and character orthonormality (already in `TauCeti/RepresentationTheory/SU2/Weyl/Orthogonality.lean`) validates the classification rather than proving it. Exhaustion, the remaining half, is not attempted here.

`TauCeti/RepresentationTheory/SU2/Weight.lean` already supplies the torus half of the highest-weight argument: the monomial basis is a basis of weight vectors with `d + 1` pairwise distinct weights, so a torus-stable subspace is spanned by the weight vectors it contains. That alone cannot see irreducibility — the torus is abelian and every span of weight vectors is torus-stable. `TauCeti/RepresentationTheory/SU2/Irreducible.lean` supplies the missing element off the torus: the rational rotation `!![3/5, -4/5; 4/5, 3/5]`, an element of `SU(2)` none of whose entries vanishes. Given a nonzero invariant subspace `W`, it contains a weight vector; the coordinate of its rotate at the highest weight is a single product of matrix entries, so the highest weight vector `e₀^d` lands in `W`; and the rotate of `e₀^d` is a pure power, whose coordinates are all nonzero, so every weight vector lands in `W`. The rotation is a device of the proof and stays private to the file, as `genericTorus` does in the weight file. Inequivalence is then the dimension count `finrank ℂ Symᵈ(ℂ²) = d + 1`, giving a family of pairwise non-isomorphic irreducibles of `SU(2)`, one in each dimension.

The two coordinate facts the argument runs on are general statements about the monomial basis `Module.Basis.symmetricPower`, and are collected in the new `TauCeti/LinearAlgebra/SymmetricPower/Coordinates.lean` beside the existing `TauCeti/LinearAlgebra/SymmetricPower/Basis.lean`, which reads off only the coordinates of pure tensors *of basis vectors*. Expanding each factor and using multilinearity gives the coordinate of an arbitrary pure symmetric tensor at `s` as a sum over the orderings of `s`; at a constant index that sum has one term, and for a pure power all its terms coincide, so in both cases no cancellation is possible. The second fails for a general pure tensor, and the file says so.

No Mathlib infrastructure was vendored; the new file consumes `MultilinearMap.map_sum` and `MultilinearMap.map_smul_univ` from Mathlib and `TauCeti.Sym.ofFn` with its fibre description from `TauCeti/Data/Sym/Basic.lean`.

`lake build` and `lake exe axioms` are green (50740 declarations audited, all within `propext`, `Classical.choice`, `Quot.sound`).

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"su2irrep-irreducible"}-->

🤖 Prepared with Claude Code
