### PR TITLE
feat: add geometric solvability

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+public import Mathlib.GroupTheory.Solvable
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Product
+
+/-!
+# Geometric solvability of affine groups
+
+For a commutative Hopf algebra `H` over a field `k`, this file records the geometric-points
+solvability condition: the convolution group of `AlgebraicClosure k`-valued points of `H` is a
+solvable abstract group. Smoothness and finite type are deliberately not built into this property;
+consumers must state them separately when interpreting it as the classical notion of a solvable
+algebraic group.
+
+The property is invariant under coordinate-Hopf-algebra isomorphisms. It is preserved by closed
+subgroups, represented contravariantly by surjective coordinate morphisms, and a product has the
+property exactly when both factors do. These are the first subgroup-calculus operations needed for
+Lie--Kolchin theory and the construction of the solvable radical.
+
+## Main declarations
+
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty`: solvability of the geometric point
+  group.
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_of_surjective`: closure under closed
+  subgroups.
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_tensorProduct_iff`: solvability of a
+  product is equivalent to solvability of both factors.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+
+This begins the "Lie--Kolchin; solvable groups" milestone in Layer 5 of the ReductiveGroups
+roadmap. The scheme-theoretic derived subgroup and its comparison with this geometric-points
+criterion remain to be constructed.
+-/
+
+public section
+
+open CategoryTheory TensorProduct WithConv
+
+namespace TauCeti
+
+universe u v
+
+/-- The object property asserting that the group of algebraic-closure-valued points of a
+commutative Hopf algebra is solvable.
+
+This property packages only the geometric-points condition. In applications to classical
+algebraic groups, finite type and smoothness are separate hypotheses. -/
+def geometricallySolvablePointsCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (CommHopfAlgCat.{v} k) :=
+  fun H ↦ Group.IsSolvable (WithConv (H →ₐ[k] AlgebraicClosure k))
+
+/-- Membership in the geometric-points solvability property means that the convolution group of
+points over an algebraic closure is solvable. -/
+@[simp]
+theorem geometricallySolvablePointsCommHopfAlgProperty_iff
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k) :
+    geometricallySolvablePointsCommHopfAlgProperty k H ↔
+      Group.IsSolvable (WithConv (H →ₐ[k] AlgebraicClosure k)) :=
+  Iff.rfl
+
+/-- Geometric-points solvability is invariant under isomorphisms of commutative Hopf algebras. -/
+instance (k : Type u) [Field k] :
+    (geometricallySolvablePointsCommHopfAlgProperty k :
+      ObjectProperty (CommHopfAlgCat.{v} k)).IsClosedUnderIsomorphisms where
+  of_iso {H K} e hH := by
+    rw [geometricallySolvablePointsCommHopfAlgProperty_iff] at hH ⊢
+    let e' : H ≃ₐc[k] K := CommHopfAlgCat.ofIso e
+    let _ : Group.IsSolvable (WithConv (H →ₐ[k] AlgebraicClosure k)) := hH
+    exact Group.isSolvable_of_isSolvable_injective
+      (f := (AlgHom.mapDomainMulEquiv (A := AlgebraicClosure k) e').toMonoidHom)
+      (AlgHom.mapDomainMulEquiv (A := AlgebraicClosure k) e').injective
+
+/-- Geometric-points solvability descends along a surjective coordinate Hopf-algebra morphism.
+
+Contravariantly, the target coordinate algebra represents a closed subgroup of the source affine
+group. Its geometric point group embeds into the solvable point group of the ambient object. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_of_surjective
+    (k : Type u) [Field k] {H K : CommHopfAlgCat.{v} k}
+    (f : H ⟶ K) (hf : Function.Surjective f.hom)
+    (hH : geometricallySolvablePointsCommHopfAlgProperty k H) :
+    geometricallySolvablePointsCommHopfAlgProperty k K := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff] at hH ⊢
+  let _ : Group.IsSolvable (WithConv (H →ₐ[k] AlgebraicClosure k)) := hH
+  exact Group.isSolvable_of_isSolvable_injective
+    (f := AlgHom.mapDomain (H₁ := H) (H₂ := K) (A := AlgebraicClosure k) f.hom)
+    (CommHopfAlgCat.mapPointsFunctor_app_injective_of_surjective f hf
+      (CommAlgCat.of k (AlgebraicClosure k)))
+
+/-- The closed subgroup cut out by a Hopf ideal has solvable geometric points whenever the
+ambient affine group does. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_quotient
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k) (I : HopfIdeal k H)
+    (hH : geometricallySolvablePointsCommHopfAlgProperty k H) :
+    geometricallySolvablePointsCommHopfAlgProperty k (CommHopfAlgCat.quotient H I) := by
+  apply geometricallySolvablePointsCommHopfAlgProperty_of_surjective k
+    (CommHopfAlgCat.mkQuotient H I) _ hH
+  exact Ideal.Quotient.mkₐ_surjective k I.toIdeal
+
+/-- The tensor-product coordinate algebra has solvable geometric points exactly when both
+factors do. Contravariantly, this is closure and reflection of solvability by direct products of
+affine groups. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_tensorProduct_iff
+    (k : Type u) [Field k] (H K : CommHopfAlgCat.{v} k) :
+    geometricallySolvablePointsCommHopfAlgProperty k
+        (CommHopfAlgCat.of k (H ⊗[k] K)) ↔
+      geometricallySolvablePointsCommHopfAlgProperty k H ∧
+        geometricallySolvablePointsCommHopfAlgProperty k K := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff,
+    geometricallySolvablePointsCommHopfAlgProperty_iff,
+    geometricallySolvablePointsCommHopfAlgProperty_iff]
+  let e := AffineGroup.Product.pointsMulEquiv
+    (R := k) (H₁ := (H : Type v)) (H₂ := (K : Type v))
+    (A := AlgebraicClosure k)
+  let f :
+      WithConv (((H : Type v) ⊗[k] (K : Type v)) →ₐ[k] AlgebraicClosure k) →*
+        WithConv (H →ₐ[k] AlgebraicClosure k) ×
+          WithConv (K →ₐ[k] AlgebraicClosure k) :=
+    e.toMonoidHom
+  have hf_injective : Function.Injective f := e.injective
+  let finv :
+      (WithConv (H →ₐ[k] AlgebraicClosure k) ×
+          WithConv (K →ₐ[k] AlgebraicClosure k)) →*
+        WithConv (((H : Type v) ⊗[k] (K : Type v)) →ₐ[k] AlgebraicClosure k) :=
+    e.symm.toMonoidHom
+  have hfinv_injective : Function.Injective finv := e.symm.injective
+  constructor
+  · intro h
+    let _ : Group.IsSolvable
+        (WithConv (((H : Type v) ⊗[k] (K : Type v)) →ₐ[k] AlgebraicClosure k)) := h
+    let hprod : Group.IsSolvable
+        (WithConv (H →ₐ[k] AlgebraicClosure k) ×
+          WithConv (K →ₐ[k] AlgebraicClosure k)) :=
+      Group.isSolvable_of_isSolvable_injective
+        (G := WithConv (H →ₐ[k] AlgebraicClosure k) ×
+          WithConv (K →ₐ[k] AlgebraicClosure k))
+        (G' := WithConv (((H : Type v) ⊗[k] (K : Type v)) →ₐ[k] AlgebraicClosure k))
+        (f := finv) hfinv_injective
+    let _ : Group.IsSolvable
+        (WithConv (H →ₐ[k] AlgebraicClosure k) ×
+          WithConv (K →ₐ[k] AlgebraicClosure k)) := hprod
+    constructor
+    · exact Group.isSolvable_of_surjective
+        (G := WithConv (H →ₐ[k] AlgebraicClosure k) ×
+          WithConv (K →ₐ[k] AlgebraicClosure k))
+        (G' := WithConv (H →ₐ[k] AlgebraicClosure k))
+        (f := MonoidHom.fst _ _) (fun x ↦ ⟨(x, 1), rfl⟩)
+    · exact Group.isSolvable_of_surjective
+        (G := WithConv (H →ₐ[k] AlgebraicClosure k) ×
+          WithConv (K →ₐ[k] AlgebraicClosure k))
+        (G' := WithConv (K →ₐ[k] AlgebraicClosure k))
+        (f := MonoidHom.snd _ _) (fun x ↦ ⟨(1, x), rfl⟩)
+  · rintro ⟨hH, hK⟩
+    let _ : Group.IsSolvable (WithConv (H →ₐ[k] AlgebraicClosure k)) := hH
+    let _ : Group.IsSolvable (WithConv (K →ₐ[k] AlgebraicClosure k)) := hK
+    exact Group.isSolvable_of_isSolvable_injective
+      (G := WithConv (((H : Type v) ⊗[k] (K : Type v)) →ₐ[k] AlgebraicClosure k))
+      (G' := WithConv (H →ₐ[k] AlgebraicClosure k) ×
+        WithConv (K →ₐ[k] AlgebraicClosure k))
+      (f := f) hf_injective
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Borel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Borel.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Borel
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
+
+/-!
+# Geometric solvability of the upper-triangular Borel of `GL₂`
+
+The coordinate Hopf algebra of the upper-triangular Borel subgroup of `GL₂` has a solvable group
+of geometric points. The existing point equivalence identifies that group with `GL2Borel` over an
+algebraic closure, while the latter is solvable because its diagonal quotient and unipotent kernel
+are abelian.
+
+## Main declaration
+
+* `geometricallySolvablePointsCommHopfAlgProperty_coordinateHopfAlgebra`:
+  the `GL₂` Borel has solvable geometric points.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+
+This is the standard Borel example for the "Lie--Kolchin; solvable groups" milestone in Layer 5
+of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti.GeneralLinear.Borel
+
+universe u
+
+/-- The upper-triangular Borel subgroup of `GL₂` has a solvable group of geometric points. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_coordinateHopfAlgebra
+    (k : Type u) [Field k] :
+    geometricallySolvablePointsCommHopfAlgProperty k (coordinateHopfAlgebra k) := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff]
+  let e := pointsMulEquiv (R := k) (A := AlgebraicClosure k)
+  exact Group.isSolvable_of_isSolvable_injective (f := e.toMonoidHom) e.injective
+
+end TauCeti.GeneralLinear.Borel

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Borel.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Borel.lean
@@ -11,6 +11,8 @@ module
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.FinTwo
 -- `Subgroup.index` occurs in the statements below.
 public import Mathlib.GroupTheory.Index
+-- `Group.IsSolvable` occurs in the statement of `TauCeti.GL2Borel.instIsSolvable`.
+public import Mathlib.GroupTheory.Solvable
 -- `Matrix.BlockTriangular` occurs in the statement of `TauCeti.blockTriangular_id_iff`.
 public import Mathlib.LinearAlgebra.Matrix.Block
 -- `TauCeti.diagGL` is the body of `TauCeti.GL2Borel.torusHom`, so it must be imported publicly.
@@ -67,6 +69,7 @@ q + 1`, the number of points of the projective line.
 * `TauCeti.GL2Borel.mem_ker_diag_iff`: the kernel of `TauCeti.GL2Borel.diag` is the unipotent
   radical, the image of `TauCeti.GL2Borel.unipotentHom`.
 * `TauCeti.GL2Borel.eq_torusHom_mul_unipotentHom`: the decomposition `B = T U`.
+* `TauCeti.GL2Borel.instIsSolvable`: the Borel subgroup is solvable over every commutative ring.
 * `TauCeti.GL2Borel.det_diag`: the determinant of an element of `B` is the product of its two
   diagonal entries.
 * `TauCeti.GL2Borel.exists_det_sub_algebraMap_eq_zero`: a matrix with an upper-triangular conjugate
@@ -337,6 +340,16 @@ theorem mem_ker_diag_iff (g : GL2Borel R) :
       simp [Matrix.GeneralLinearGroup.upperRightHom, h₀, h₁, apply_one_zero g]
   · rintro ⟨b, rfl⟩
     exact MonoidHom.mem_ker.mpr (diag_unipotentHom b)
+
+/-- The upper-triangular Borel subgroup of `GL₂` is solvable over every commutative ring.
+
+Its diagonal quotient is abelian, and the kernel of the diagonal projection is the image of the
+abelian additive group of the ring under `unipotentHom`. -/
+instance instIsSolvable : Group.IsSolvable (GL2Borel R) := by
+  apply Group.isSolvable_of_ker_le_range (unipotentHom (R := R)).toMonoidHom (diag (R := R))
+  intro g hg
+  obtain ⟨b, rfl⟩ := (mem_ker_diag_iff g).mp hg
+  exact ⟨Multiplicative.ofAdd b, rfl⟩
 
 /-- **The Borel subgroup is `T U`**: every element of `B` is the diagonal matrix carrying its two
 torus coordinates times the unipotent matrix carrying the remaining upper-right coordinate. -/


### PR DESCRIPTION
This PR introduces geometric solvability for affine groups: define the property that the convolution group of algebraic-closure-valued points is solvable, prove invariance under coordinate Hopf-algebra isomorphisms, prove closure under closed subgroups, and characterize products. It advances the exact target in `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5 milestone “Lie–Kolchin; solvable groups.”

This is the most effective current step because the functor-of-points, closed-subgroup, product, and `GL₂` Borel APIs are already on `main`, while the occupied ReductiveGroups fronts concern component groups, upper-unitriangular nilpotence, torus cocharacters, and Kostant root subgroups. The new interface turns Mathlib's abstract derived-series notion into the geometric point-group predicate that the upcoming Lie–Kolchin and solvable-radical developments can consume, and exercises it on a noncommutative algebraic-group example rather than leaving the predicate untested.

The `GL₂` Borel witness is proved over every commutative ring: its diagonal quotient is abelian and the kernel of the diagonal projection is the image of the abelian additive group under the existing unipotent-root homomorphism. The existing point equivalence then identifies algebraic-closure-valued Borel points with this solvable matrix group. The mathematical formulation follows J. C. Jantzen, *Representations of Algebraic Groups*, I.2, and T. A. Springer, *Linear Algebraic Groups*, §2.4, as credited in both new module docstrings; no Mathlib infrastructure or external formalization is vendored.

Add `TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean` (171 lines) and `TauCeti/Algebra/AlgebraicGroup/Solvable/Borel.lean` (48 lines), and extend `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Borel.lean` by 13 lines with the reusable solvability instance. After this PR, the Layer 5 milestone still needs the common-fixed-vector and invariant-flag argument, Lie–Kolchin itself, comparison with a scheme-theoretic derived subgroup, extension closure at the algebraic-group level, and construction and maximality of the solvable and unipotent radicals.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometric-solvability"}-->

🤖 Prepared with Codex
