### PR TITLE
feat: rationalize abstract integral forms

### DIFF
--- a/TauCeti/Algebra/Module/Lattice.lean
+++ b/TauCeti/Algebra/Module/Lattice.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Algebra.EuclideanDomain.Int
 public import Mathlib.Algebra.Module.Lattice
 public import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
+public import Mathlib.RingTheory.Flat.Basic
 public import Mathlib.RingTheory.IsTensorProduct
 
 /-!
@@ -30,6 +31,10 @@ domain rationalizes to its ambient vector space over the fraction field.
   submodule into its ambient vector space over the fraction field is a base change.
 * `TauCeti.Submodule.rationalizationEquiv`: the canonical equivalence from the scalar extension
   of a free full lattice submodule to its ambient vector space.
+* `TauCeti.TensorProduct.unitTmulEquiv`: a finite free module is the full lattice of unit pure
+  tensors in its scalar extension.
+* `TauCeti.TensorProduct.rationalizationEquiv_baseChange_unitTmulEquiv`: rationalizing that
+  unit-tensor lattice returns the scalar extension one started from.
 
 ## References
 
@@ -200,5 +205,89 @@ theorem IsLattice.map (S : Submodule ℤ V) [S.IsLattice ℚ] (e : V ≃ₗ[ℚ]
       _root_.Submodule.IsLattice.span_eq_top]
 
 end Submodule
+
+namespace TensorProduct
+
+variable {R : Type u} {K : Type v} {M : Type w}
+variable [CommRing R] [IsDomain R]
+variable [Field K] [Algebra R K] [IsFractionRing R K]
+variable [AddCommGroup M] [Module R M] [Module.Free R M] [Module.Finite R M]
+
+omit [IsDomain R] [IsFractionRing R K] [Module.Free R M] [Module.Finite R M] in
+/-- The unit pure tensors are the `R`-span of the base change of any basis. -/
+theorem range_mk_one_eq_span {ι : Type*} (b : Basis ι R M) :
+    LinearMap.range (TensorProduct.mk R K M 1) =
+      Submodule.span R (Set.range (b.baseChange K)) := by
+  rw [LinearMap.range_eq_map, ← b.span_eq, Submodule.map_span, ← Set.range_comp]
+  exact congrArg (Submodule.span R)
+    (congrArg Set.range (funext fun i ↦ (Basis.baseChange_apply K b i).symm))
+
+/-- The unit pure tensors form a full lattice in the scalar extension of a finite free module. -/
+instance isLattice_range_mk_one :
+    (LinearMap.range (TensorProduct.mk R K M 1)).IsLattice K where
+  fg := by
+    rw [LinearMap.range_eq_map]
+    exact Module.Finite.fg_top.map _
+  span_eq_top := by
+    rw [eq_top_iff]
+    rintro x -
+    induction x using TensorProduct.induction_on with
+    | zero => exact zero_mem _
+    | add x y hx hy => exact add_mem hx hy
+    | tmul k m =>
+      rw [tmul_eq_smul_one_tmul]
+      exact Submodule.smul_mem _ k (Submodule.subset_span ⟨m, rfl⟩)
+
+variable (R K M) in
+/-- A finite free module is canonically isomorphic to the lattice of unit pure tensors in its
+scalar extension. -/
+noncomputable def unitTmulEquiv : M ≃ₗ[R] LinearMap.range (TensorProduct.mk R K M 1) :=
+  LinearEquiv.ofInjective _ (Module.Flat.tensorProduct_mk_injective R M K)
+
+/-- The lattice of unit pure tensors is free, being a copy of the module it comes from. -/
+instance free_range_mk_one :
+    Module.Free R (LinearMap.range (TensorProduct.mk R K M 1)) :=
+  Module.Free.of_equiv (unitTmulEquiv R K M)
+
+omit [IsDomain R] [Module.Finite R M] in
+/-- The unit-tensor equivalence sends a vector to its unit pure tensor. This equation
+characterizes the equivalence. -/
+@[simp]
+theorem coe_unitTmulEquiv_apply (m : M) :
+    (unitTmulEquiv R K M m : K ⊗[R] M) = 1 ⊗ₜ[R] m := by
+  rw [unitTmulEquiv, LinearEquiv.ofInjective_apply, TensorProduct.mk_apply]
+
+omit [IsDomain R] [Module.Finite R M] in
+/-- The inverse unit-tensor equivalence recovers a vector from its unit pure tensor. -/
+@[simp]
+theorem unitTmulEquiv_symm_tmul (m : M)
+    (h : (1 : K) ⊗ₜ[R] m ∈ LinearMap.range (TensorProduct.mk R K M 1)) :
+    (unitTmulEquiv R K M).symm ⟨1 ⊗ₜ[R] m, h⟩ = m := by
+  apply (unitTmulEquiv R K M).injective
+  rw [LinearEquiv.apply_symm_apply]
+  exact Subtype.ext (coe_unitTmulEquiv_apply m).symm
+
+/-- Rationalizing the unit-tensor lattice recovers the scalar extension it sits in: base-changing
+the unit-tensor equivalence and then rationalizing is the identity. -/
+@[simp]
+theorem rationalizationEquiv_baseChange_unitTmulEquiv (x : K ⊗[R] M) :
+    Submodule.rationalizationEquiv (LinearMap.range (TensorProduct.mk R K M 1))
+        (LinearEquiv.baseChange R K M _ (unitTmulEquiv R K M) x) = x := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [map_add, hx, hy]
+  | tmul k m =>
+    rw [LinearEquiv.baseChange_tmul, Submodule.rationalizationEquiv_tmul,
+      coe_unitTmulEquiv_apply]
+    exact (tmul_eq_smul_one_tmul k m).symm
+
+/-- The bundled form of `rationalizationEquiv_baseChange_unitTmulEquiv`. -/
+theorem unitTmulEquiv_baseChange_trans_rationalizationEquiv :
+    (LinearEquiv.baseChange R K M _ (unitTmulEquiv R K M)).trans
+        (Submodule.rationalizationEquiv (LinearMap.range (TensorProduct.mk R K M 1))) =
+      LinearEquiv.refl K (K ⊗[R] M) :=
+  LinearEquiv.ext rationalizationEquiv_baseChange_unitTmulEquiv
+
+end TensorProduct
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
@@ -133,7 +133,6 @@ theorem ofIntegralForm_form (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
   IntegralLattice.ofBasis_form _ _ _ _
 
 /-- The carrier of a rationalized integral form is the lattice of unit pure tensors. -/
-@[simp]
 theorem ofIntegralForm_carrier (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     (ofIntegralForm B hB).carrier = LinearMap.range (TensorProduct.mk ℤ ℚ M 1) :=
   (IntegralLattice.ofBasis_carrier _ _ _ _).trans

--- a/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
@@ -17,6 +17,11 @@ base-change equivalence identifies `V` with the scalar extension `ℚ ⊗[ℤ] L
 that this equivalence identifies the scalar extension of `L.integralForm` with the ambient rational
 form `L.form`.
 
+Conversely, an integral symmetric form on a finite free `ℤ`-module `M` defines an integral lattice
+in `ℚ ⊗[ℤ] M`. Its carrier is the image of `M` under `m ↦ 1 ⊗ₜ m`, and its restricted integral
+form recovers the original form. Rationalizing that embedded carrier gives back the original tensor
+product, so the abstract and embedded models are inverse constructions at the level of forms.
+
 Mathlib already supplies `LinearMap.BilinForm.baseChange`; the point here is to connect that
 abstract tensor-product construction to the embedded-carrier model used by integral lattices.
 In particular, no choice of carrier basis appears in the resulting equivalence or its
@@ -28,6 +33,12 @@ characteristic equations.
   the ambient form under the equivalence.
 * `TauCeti.IntegralLattice.rationalizationIsometry`: this equivalence is an isometry from
   `L.integralForm.baseChange ℚ` to `L.form`.
+* `TauCeti.IntegralLattice.ofIntegralForm`: the integral lattice obtained by rationalizing an
+  abstract finite free integral form.
+* `TauCeti.IntegralLattice.ofIntegralForm.carrierEquiv`: the original module identified with the
+  embedded carrier.
+* `TauCeti.IntegralLattice.ofIntegralForm.carrierIsometry`: that equivalence as an isometry of
+  integral forms.
 
 ## References
 
@@ -91,6 +102,150 @@ equivalence. -/
 theorem rationalizationIsometry_symm_apply (L : IntegralLattice V) (y : V) :
     L.rationalizationIsometry.symm y = (Submodule.rationalizationEquiv L.carrier).symm y := by
   rfl
+
+section AbstractIntegralForm
+
+variable {M : Type u} [AddCommGroup M] [Module.Free ℤ M] [Module.Finite ℤ M]
+
+omit [Module.Free ℤ M] [Module.Finite ℤ M] in
+private theorem isSymm_baseChange (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    (B.baseChange ℚ).IsSymm := by
+  constructor
+  intro x y
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | add x₁ x₂ hx₁ hx₂ => simp only [map_add, LinearMap.add_apply, hx₁, hx₂]
+  | tmul q m =>
+    induction y using TensorProduct.induction_on with
+    | zero => simp
+    | add y₁ y₂ hy₁ hy₂ =>
+      rw [map_add, map_add, LinearMap.add_apply, hy₁, hy₂]
+    | tmul r n =>
+      rw [LinearMap.BilinForm.baseChange_tmul, LinearMap.BilinForm.baseChange_tmul,
+        hB.eq m n, mul_comm q r]
+
+/-- Rationalizing an integral symmetric form on a finite free `ℤ`-module produces an integral
+lattice in its scalar extension to `ℚ`. -/
+noncomputable def ofIntegralForm (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    IntegralLattice (ℚ ⊗[ℤ] M) :=
+  ofBasis ((Module.Free.chooseBasis ℤ M).baseChange ℚ) (B.baseChange ℚ)
+    (isSymm_baseChange B hB)
+    fun i j ↦ by
+      rw [Basis.baseChange_apply, Basis.baseChange_apply,
+        LinearMap.BilinForm.baseChange_tmul]
+      simp only [one_mul, Int.smul_one_eq_cast, Submodule.mem_one]
+      exact ⟨B (Module.Free.chooseBasis ℤ M i) (Module.Free.chooseBasis ℤ M j), rfl⟩
+
+@[simp]
+theorem ofIntegralForm_form (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    (ofIntegralForm B hB).form = B.baseChange ℚ :=
+  IntegralLattice.ofBasis_form _ _ _ _
+
+private theorem ofIntegralForm_carrier (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    (ofIntegralForm B hB).carrier =
+      Submodule.span ℤ (Set.range ((Module.Free.chooseBasis ℤ M).baseChange ℚ)) := by
+  unfold ofIntegralForm
+  exact IntegralLattice.ofBasis_carrier _ _ _ _
+
+namespace ofIntegralForm
+
+/-- The carrier basis of a rationalized integral form induced by the chosen basis of the abstract
+module. -/
+noncomputable def basis (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    Basis (Module.Free.ChooseBasisIndex ℤ M) ℤ (ofIntegralForm B hB) :=
+  ((Module.Free.chooseBasis ℤ M).baseChange ℚ).restrictScalars ℤ |>.map
+    (LinearEquiv.ofEq
+      (Submodule.span ℤ (Set.range ((Module.Free.chooseBasis ℤ M).baseChange ℚ)))
+      (ofIntegralForm B hB).carrier (ofIntegralForm_carrier B hB).symm)
+
+/-- A basis vector of the embedded carrier is the unit pure tensor of the corresponding abstract
+basis vector. -/
+@[simp]
+theorem coe_basis (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
+    (i : Module.Free.ChooseBasisIndex ℤ M) :
+    (basis B hB i : ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] Module.Free.chooseBasis ℤ M i := by
+  rw [basis, Basis.map_apply, LinearEquiv.coe_ofEq_apply,
+    Basis.restrictScalars_apply, Basis.baseChange_apply]
+
+/-- The abstract integral module is canonically equivalent to the carrier of its rationalized
+integral lattice. -/
+noncomputable def carrierEquiv (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    M ≃ₗ[ℤ] ofIntegralForm B hB :=
+  (Module.Free.chooseBasis ℤ M).equiv (basis B hB) (Equiv.refl _)
+
+/-- The carrier equivalence sends an abstract vector to its unit pure tensor. -/
+@[simp]
+theorem coe_carrierEquiv_apply (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x : M) :
+    (carrierEquiv B hB x : ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] x := by
+  have hmap :
+      (Submodule.subtype (ofIntegralForm B hB).carrier).comp
+          (carrierEquiv B hB).toLinearMap =
+        (TensorProduct.mk ℤ ℚ M 1).toAddMonoidHom.toIntLinearMap := by
+    apply (Module.Free.chooseBasis ℤ M).ext
+    intro i
+    rw [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap, carrierEquiv,
+      Basis.equiv_apply, Equiv.refl_apply]
+    -- Forget the implementation wrappers on the subtype inclusion and integer-linear map.
+    change (basis B hB i : ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] Module.Free.chooseBasis ℤ M i
+    exact coe_basis B hB i
+  exact LinearMap.congr_fun hmap x
+
+/-- The carrier of a rationalized integral form consists exactly of the unit pure tensors. -/
+theorem mem_carrier_iff (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x : ℚ ⊗[ℤ] M) :
+    x ∈ (ofIntegralForm B hB).carrier ↔ ∃ m : M, 1 ⊗ₜ[ℤ] m = x := by
+  constructor
+  · intro hx
+    obtain ⟨m, hm⟩ := (carrierEquiv B hB).surjective
+      (⟨x, hx⟩ : ofIntegralForm B hB)
+    exact ⟨m, (coe_carrierEquiv_apply B hB m).symm.trans (congrArg Subtype.val hm)⟩
+  · rintro ⟨m, rfl⟩
+    rw [← coe_carrierEquiv_apply B hB m]
+    exact (carrierEquiv B hB m).2
+
+/-- Restricting the rationalized form along the carrier equivalence recovers the original
+integral form. -/
+@[simp]
+theorem integralForm_carrierEquiv (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x y : M) :
+    (ofIntegralForm B hB).integralForm (carrierEquiv B hB x) (carrierEquiv B hB y) = B x y := by
+  apply Int.cast_injective (α := ℚ)
+  rw [IntegralLattice.integralForm_cast, ofIntegralForm_form,
+    coe_carrierEquiv_apply, coe_carrierEquiv_apply,
+    LinearMap.BilinForm.baseChange_tmul]
+  simp
+
+/-- The carrier equivalence is an isometry from the abstract integral form to the restricted form
+of its rationalized lattice. -/
+noncomputable def carrierIsometry (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    B.IsometryEquiv (ofIntegralForm B hB).integralForm where
+  toLinearEquiv := carrierEquiv B hB
+  map_app' := integralForm_carrierEquiv B hB
+
+/-- The carrier isometry acts through the canonical carrier equivalence. -/
+@[simp]
+theorem carrierIsometry_apply (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x : M) :
+    carrierIsometry B hB x = carrierEquiv B hB x :=
+  (rfl)
+
+/-- Base-changing the carrier equivalence and then applying the lattice's rationalization
+equivalence is the identity on the original rationalization. -/
+theorem carrierEquiv_baseChange_trans_rationalizationEquiv
+    (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    (LinearEquiv.baseChange ℤ ℚ M (ofIntegralForm B hB) (carrierEquiv B hB)).trans
+      (Submodule.rationalizationEquiv (ofIntegralForm B hB).carrier) = LinearEquiv.refl ℚ _ := by
+  apply LinearEquiv.ext
+  intro x
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy => simp only [map_add, hx, hy]
+  | tmul q m =>
+    rw [LinearEquiv.trans_apply, LinearEquiv.baseChange_tmul,
+      Submodule.rationalizationEquiv_tmul, coe_carrierEquiv_apply,
+      LinearEquiv.refl_apply]
+    exact (tmul_eq_smul_one_tmul q m).symm
+
+end ofIntegralForm
+
+end AbstractIntegralForm
 
 end IntegralLattice
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
@@ -136,6 +136,7 @@ noncomputable def ofIntegralForm (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
       simp only [one_mul, Int.smul_one_eq_cast, Submodule.mem_one]
       exact ⟨B (Module.Free.chooseBasis ℤ M i) (Module.Free.chooseBasis ℤ M j), rfl⟩
 
+/-- The ambient rational form of a rationalized integral form is the base change to `ℚ`. -/
 @[simp]
 theorem ofIntegralForm_form (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     (ofIntegralForm B hB).form = B.baseChange ℚ :=
@@ -149,19 +150,15 @@ private theorem ofIntegralForm_carrier (B : LinearMap.BilinForm ℤ M) (hB : B.I
 
 namespace ofIntegralForm
 
-/-- The carrier basis of a rationalized integral form induced by the chosen basis of the abstract
-module. -/
-noncomputable def basis (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+private noncomputable def basis (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     Basis (Module.Free.ChooseBasisIndex ℤ M) ℤ (ofIntegralForm B hB) :=
   ((Module.Free.chooseBasis ℤ M).baseChange ℚ).restrictScalars ℤ |>.map
     (LinearEquiv.ofEq
       (Submodule.span ℤ (Set.range ((Module.Free.chooseBasis ℤ M).baseChange ℚ)))
       (ofIntegralForm B hB).carrier (ofIntegralForm_carrier B hB).symm)
 
-/-- A basis vector of the embedded carrier is the unit pure tensor of the corresponding abstract
-basis vector. -/
 @[simp]
-theorem coe_basis (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
+private theorem coe_basis (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
     (i : Module.Free.ChooseBasisIndex ℤ M) :
     (basis B hB i : ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] Module.Free.chooseBasis ℤ M i := by
   rw [basis, Basis.map_apply, LinearEquiv.coe_ofEq_apply,
@@ -191,6 +188,7 @@ theorem coe_carrierEquiv_apply (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (
   exact LinearMap.congr_fun hmap x
 
 /-- The carrier of a rationalized integral form consists exactly of the unit pure tensors. -/
+@[simp]
 theorem mem_carrier_iff (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x : ℚ ⊗[ℤ] M) :
     x ∈ (ofIntegralForm B hB).carrier ↔ ∃ m : M, 1 ⊗ₜ[ℤ] m = x := by
   constructor

--- a/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
@@ -18,14 +18,16 @@ that this equivalence identifies the scalar extension of `L.integralForm` with t
 form `L.form`.
 
 Conversely, an integral symmetric form on a finite free `ℤ`-module `M` defines an integral lattice
-in `ℚ ⊗[ℤ] M`. Its carrier is the image of `M` under `m ↦ 1 ⊗ₜ m`, and its restricted integral
-form recovers the original form. Rationalizing that embedded carrier gives back the original tensor
-product, so the abstract and embedded models are inverse constructions at the level of forms.
+in `ℚ ⊗[ℤ] M`. Its carrier consists exactly of the unit pure tensors `1 ⊗ₜ m`, so that
+`TauCeti.TensorProduct.unitTmulEquiv` identifies `M` with it, and its restricted integral form
+recovers the original form. Base-changing that carrier equivalence and then rationalizing is the
+identity on `ℚ ⊗[ℤ] M`; at the level of forms the two models are related by the isometries
+`rationalizationIsometry` and `carrierIsometry`.
 
 Mathlib already supplies `LinearMap.BilinForm.baseChange`; the point here is to connect that
 abstract tensor-product construction to the embedded-carrier model used by integral lattices.
-In particular, no choice of carrier basis appears in the resulting equivalence or its
-characteristic equations.
+The lattice `ofIntegralForm` is built from an arbitrary chosen basis of `M`, but no choice of basis
+appears in the resulting equivalences or in the equations characterizing them.
 
 ## Main results
 
@@ -35,10 +37,14 @@ characteristic equations.
   `L.integralForm.baseChange ℚ` to `L.form`.
 * `TauCeti.IntegralLattice.ofIntegralForm`: the integral lattice obtained by rationalizing an
   abstract finite free integral form.
+* `TauCeti.IntegralLattice.mem_ofIntegralForm_carrier_iff`: its carrier consists exactly of the
+  unit pure tensors.
 * `TauCeti.IntegralLattice.ofIntegralForm.carrierEquiv`: the original module identified with the
   embedded carrier.
 * `TauCeti.IntegralLattice.ofIntegralForm.carrierIsometry`: that equivalence as an isometry of
   integral forms.
+* `TauCeti.IntegralLattice.ofIntegralForm.carrierEquiv_baseChange_trans_rationalizationEquiv`:
+  base-changing the carrier equivalence and then rationalizing is the identity.
 
 ## References
 
@@ -118,7 +124,7 @@ noncomputable def ofIntegralForm (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
       rw [Basis.baseChange_apply, Basis.baseChange_apply,
         LinearMap.BilinForm.baseChange_tmul]
       simp only [one_mul, Int.smul_one_eq_cast, Submodule.mem_one]
-      exact ⟨B (Module.Free.chooseBasis ℤ M i) (Module.Free.chooseBasis ℤ M j), rfl⟩
+      exact ⟨B (Module.Free.chooseBasis ℤ M i) (Module.Free.chooseBasis ℤ M j), by simp⟩
 
 /-- The ambient rational form of a rationalized integral form is the base change to `ℚ`. -/
 @[simp]
@@ -126,48 +132,44 @@ theorem ofIntegralForm_form (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     (ofIntegralForm B hB).form = B.baseChange ℚ :=
   IntegralLattice.ofBasis_form _ _ _ _
 
+/-- The carrier of a rationalized integral form is the lattice of unit pure tensors. -/
+@[simp]
+theorem ofIntegralForm_carrier (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    (ofIntegralForm B hB).carrier = LinearMap.range (TensorProduct.mk ℤ ℚ M 1) :=
+  (IntegralLattice.ofBasis_carrier _ _ _ _).trans
+    (TensorProduct.range_mk_one_eq_span (Module.Free.chooseBasis ℤ M)).symm
+
+/-- The carrier of a rationalized integral form consists exactly of the unit pure tensors. -/
+theorem mem_ofIntegralForm_carrier_iff (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
+    (x : ℚ ⊗[ℤ] M) : x ∈ (ofIntegralForm B hB).carrier ↔ ∃ m : M, 1 ⊗ₜ[ℤ] m = x := by
+  rw [ofIntegralForm_carrier]
+  exact LinearMap.mem_range
+
 namespace ofIntegralForm
 
 /-- The abstract integral module is canonically equivalent to the carrier of its rationalized
-integral lattice. -/
+integral lattice: this is `TauCeti.TensorProduct.unitTmulEquiv` read through
+`ofIntegralForm_carrier`. -/
 noncomputable def carrierEquiv (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     M ≃ₗ[ℤ] ofIntegralForm B hB :=
-  (Module.Free.chooseBasis ℤ M).equiv
-    (IntegralLattice.ofBasis.basis ((Module.Free.chooseBasis ℤ M).baseChange ℚ)
-      (B.baseChange ℚ) _ _) (Equiv.refl _)
+  (TensorProduct.unitTmulEquiv ℤ ℚ M).trans
+    (LinearEquiv.ofEq _ _ (ofIntegralForm_carrier B hB).symm)
 
 /-- The carrier equivalence sends an abstract vector to its unit pure tensor. -/
 @[simp]
 theorem coe_carrierEquiv_apply (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x : M) :
-    (carrierEquiv B hB x : ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] x := by
-  have hmap :
-      (Submodule.subtype (ofIntegralForm B hB).carrier).comp
-          (carrierEquiv B hB).toLinearMap =
-        (TensorProduct.mk ℤ ℚ M 1).toAddMonoidHom.toIntLinearMap := by
-    apply (Module.Free.chooseBasis ℤ M).ext
-    intro i
-    have hbasis : carrierEquiv B hB (Module.Free.chooseBasis ℤ M i) =
-        IntegralLattice.ofBasis.basis ((Module.Free.chooseBasis ℤ M).baseChange ℚ)
-          (B.baseChange ℚ) _ _ i :=
-      Basis.equiv_apply _ _ _ _
-    -- Forget the implementation wrappers on the subtype inclusion and integer-linear map.
-    change ((carrierEquiv B hB (Module.Free.chooseBasis ℤ M i) : ofIntegralForm B hB) :
-      ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] Module.Free.chooseBasis ℤ M i
-    rw [hbasis, IntegralLattice.ofBasis.coe_basis, Basis.baseChange_apply]
-  exact LinearMap.congr_fun hmap x
+    (carrierEquiv B hB x : ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] x :=
+  (LinearEquiv.coe_ofEq_apply (ofIntegralForm_carrier B hB).symm _).trans
+    (TensorProduct.coe_unitTmulEquiv_apply x)
 
-/-- The carrier of a rationalized integral form consists exactly of the unit pure tensors. -/
+/-- The inverse carrier equivalence recovers an abstract vector from its unit pure tensor. -/
 @[simp]
-theorem mem_carrier_iff (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x : ℚ ⊗[ℤ] M) :
-    x ∈ (ofIntegralForm B hB).carrier ↔ ∃ m : M, 1 ⊗ₜ[ℤ] m = x := by
-  constructor
-  · intro hx
-    obtain ⟨m, hm⟩ := (carrierEquiv B hB).surjective
-      (⟨x, hx⟩ : ofIntegralForm B hB)
-    exact ⟨m, (coe_carrierEquiv_apply B hB m).symm.trans (congrArg Subtype.val hm)⟩
-  · rintro ⟨m, rfl⟩
-    rw [← coe_carrierEquiv_apply B hB m]
-    exact (carrierEquiv B hB m).2
+theorem carrierEquiv_symm_tmul (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x : M)
+    (h : (1 : ℚ) ⊗ₜ[ℤ] x ∈ (ofIntegralForm B hB).carrier) :
+    (carrierEquiv B hB).symm ⟨1 ⊗ₜ[ℤ] x, h⟩ = x := by
+  apply (carrierEquiv B hB).injective
+  rw [LinearEquiv.apply_symm_apply]
+  exact Subtype.ext (coe_carrierEquiv_apply B hB x).symm
 
 /-- Restricting the rationalized form along the carrier equivalence recovers the original
 integral form. -/
@@ -193,22 +195,36 @@ theorem carrierIsometry_apply (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x
     carrierIsometry B hB x = carrierEquiv B hB x :=
   (rfl)
 
+/-- Evaluating the inverse carrier isometry coincides with the inverse carrier equivalence. -/
+-- BilinForm.IsometryEquiv has no symm_toLinearEquiv lemma; definition unfolding is canonical.
+@[simp]
+theorem carrierIsometry_symm_apply (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
+    (y : ofIntegralForm B hB) :
+    (carrierIsometry B hB).symm y = (carrierEquiv B hB).symm y :=
+  (rfl)
+
 /-- Base-changing the carrier equivalence and then applying the lattice's rationalization
-equivalence is the identity on the original rationalization. -/
-theorem carrierEquiv_baseChange_trans_rationalizationEquiv
-    (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
-    (LinearEquiv.baseChange ℤ ℚ M (ofIntegralForm B hB) (carrierEquiv B hB)).trans
-      (Submodule.rationalizationEquiv (ofIntegralForm B hB).carrier) = LinearEquiv.refl ℚ _ := by
-  apply LinearEquiv.ext
-  intro x
+equivalence returns the vector one started from. -/
+@[simp]
+theorem rationalizationEquiv_baseChange_carrierEquiv
+    (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (x : ℚ ⊗[ℤ] M) :
+    Submodule.rationalizationEquiv (ofIntegralForm B hB).carrier
+        (LinearEquiv.baseChange ℤ ℚ M _ (carrierEquiv B hB) x) = x := by
   induction x using TensorProduct.induction_on with
   | zero => simp
   | add x y hx hy => simp only [map_add, hx, hy]
   | tmul q m =>
-    rw [LinearEquiv.trans_apply, LinearEquiv.baseChange_tmul,
-      Submodule.rationalizationEquiv_tmul, coe_carrierEquiv_apply,
-      LinearEquiv.refl_apply]
+    rw [LinearEquiv.baseChange_tmul, Submodule.rationalizationEquiv_tmul,
+      coe_carrierEquiv_apply]
     exact (tmul_eq_smul_one_tmul q m).symm
+
+/-- The bundled form of `rationalizationEquiv_baseChange_carrierEquiv`: base-changing the carrier
+equivalence and then rationalizing is the identity on the original rationalization. -/
+theorem carrierEquiv_baseChange_trans_rationalizationEquiv
+    (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
+    (LinearEquiv.baseChange ℤ ℚ M (ofIntegralForm B hB) (carrierEquiv B hB)).trans
+      (Submodule.rationalizationEquiv (ofIntegralForm B hB).carrier) = LinearEquiv.refl ℚ _ :=
+  LinearEquiv.ext (rationalizationEquiv_baseChange_carrierEquiv B hB)
 
 end ofIntegralForm
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
@@ -107,29 +107,13 @@ section AbstractIntegralForm
 
 variable {M : Type u} [AddCommGroup M] [Module.Free ℤ M] [Module.Finite ℤ M]
 
-omit [Module.Free ℤ M] [Module.Finite ℤ M] in
-private theorem isSymm_baseChange (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
-    (B.baseChange ℚ).IsSymm := by
-  constructor
-  intro x y
-  induction x using TensorProduct.induction_on with
-  | zero => simp
-  | add x₁ x₂ hx₁ hx₂ => simp only [map_add, LinearMap.add_apply, hx₁, hx₂]
-  | tmul q m =>
-    induction y using TensorProduct.induction_on with
-    | zero => simp
-    | add y₁ y₂ hy₁ hy₂ =>
-      rw [map_add, map_add, LinearMap.add_apply, hy₁, hy₂]
-    | tmul r n =>
-      rw [LinearMap.BilinForm.baseChange_tmul, LinearMap.BilinForm.baseChange_tmul,
-        hB.eq m n, mul_comm q r]
-
 /-- Rationalizing an integral symmetric form on a finite free `ℤ`-module produces an integral
 lattice in its scalar extension to `ℚ`. -/
 noncomputable def ofIntegralForm (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     IntegralLattice (ℚ ⊗[ℤ] M) :=
   ofBasis ((Module.Free.chooseBasis ℤ M).baseChange ℚ) (B.baseChange ℚ)
-    (isSymm_baseChange B hB)
+    (LinearMap.BilinForm.isSymm_iff.mpr
+      (LinearMap.BilinForm.IsSymm.baseChange ℚ (LinearMap.BilinForm.isSymm_iff.mp hB)))
     fun i j ↦ by
       rw [Basis.baseChange_apply, Basis.baseChange_apply,
         LinearMap.BilinForm.baseChange_tmul]
@@ -142,33 +126,15 @@ theorem ofIntegralForm_form (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     (ofIntegralForm B hB).form = B.baseChange ℚ :=
   IntegralLattice.ofBasis_form _ _ _ _
 
-private theorem ofIntegralForm_carrier (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
-    (ofIntegralForm B hB).carrier =
-      Submodule.span ℤ (Set.range ((Module.Free.chooseBasis ℤ M).baseChange ℚ)) := by
-  unfold ofIntegralForm
-  exact IntegralLattice.ofBasis_carrier _ _ _ _
-
 namespace ofIntegralForm
-
-private noncomputable def basis (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
-    Basis (Module.Free.ChooseBasisIndex ℤ M) ℤ (ofIntegralForm B hB) :=
-  ((Module.Free.chooseBasis ℤ M).baseChange ℚ).restrictScalars ℤ |>.map
-    (LinearEquiv.ofEq
-      (Submodule.span ℤ (Set.range ((Module.Free.chooseBasis ℤ M).baseChange ℚ)))
-      (ofIntegralForm B hB).carrier (ofIntegralForm_carrier B hB).symm)
-
-@[simp]
-private theorem coe_basis (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
-    (i : Module.Free.ChooseBasisIndex ℤ M) :
-    (basis B hB i : ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] Module.Free.chooseBasis ℤ M i := by
-  rw [basis, Basis.map_apply, LinearEquiv.coe_ofEq_apply,
-    Basis.restrictScalars_apply, Basis.baseChange_apply]
 
 /-- The abstract integral module is canonically equivalent to the carrier of its rationalized
 integral lattice. -/
 noncomputable def carrierEquiv (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     M ≃ₗ[ℤ] ofIntegralForm B hB :=
-  (Module.Free.chooseBasis ℤ M).equiv (basis B hB) (Equiv.refl _)
+  (Module.Free.chooseBasis ℤ M).equiv
+    (IntegralLattice.ofBasis.basis ((Module.Free.chooseBasis ℤ M).baseChange ℚ)
+      (B.baseChange ℚ) _ _) (Equiv.refl _)
 
 /-- The carrier equivalence sends an abstract vector to its unit pure tensor. -/
 @[simp]
@@ -180,11 +146,14 @@ theorem coe_carrierEquiv_apply (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) (
         (TensorProduct.mk ℤ ℚ M 1).toAddMonoidHom.toIntLinearMap := by
     apply (Module.Free.chooseBasis ℤ M).ext
     intro i
-    rw [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap, carrierEquiv,
-      Basis.equiv_apply, Equiv.refl_apply]
+    have hbasis : carrierEquiv B hB (Module.Free.chooseBasis ℤ M i) =
+        IntegralLattice.ofBasis.basis ((Module.Free.chooseBasis ℤ M).baseChange ℚ)
+          (B.baseChange ℚ) _ _ i :=
+      Basis.equiv_apply _ _ _ _
     -- Forget the implementation wrappers on the subtype inclusion and integer-linear map.
-    change (basis B hB i : ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] Module.Free.chooseBasis ℤ M i
-    exact coe_basis B hB i
+    change ((carrierEquiv B hB (Module.Free.chooseBasis ℤ M i) : ofIntegralForm B hB) :
+      ℚ ⊗[ℤ] M) = 1 ⊗ₜ[ℤ] Module.Free.chooseBasis ℤ M i
+    rw [hbasis, IntegralLattice.ofBasis.coe_basis, Basis.baseChange_apply]
   exact LinearMap.congr_fun hmap x
 
 /-- The carrier of a rationalized integral form consists exactly of the unit pure tensors. -/

--- a/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean
@@ -140,6 +140,7 @@ theorem ofIntegralForm_carrier (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm) :
     (TensorProduct.range_mk_one_eq_span (Module.Free.chooseBasis ℤ M)).symm
 
 /-- The carrier of a rationalized integral form consists exactly of the unit pure tensors. -/
+@[simp]
 theorem mem_ofIntegralForm_carrier_iff (B : LinearMap.BilinForm ℤ M) (hB : B.IsSymm)
     (x : ℚ ⊗[ℤ] M) : x ∈ (ofIntegralForm B hB).carrier ↔ ∃ m : M, 1 ⊗ₜ[ℤ] m = x := by
   rw [ofIntegralForm_carrier]


### PR DESCRIPTION
This PR constructs the converse rationalization of an integral lattice form: from a symmetric bilinear form on an abstract finite free `ℤ`-module `M`, build an integral lattice in `ℚ ⊗[ℤ] M`, identify its carrier exactly with the unit pure tensors, and recover the original integral form through a bundled carrier isometry. It also proves that base-changing the carrier equivalence and then applying the existing embedded-lattice rationalization equivalence is the identity.

The exact target is `TauCetiRoadmap/IntegralLattices/README.md`, Layer 1 milestone “lattices with forms,” specifically “Conversely, extend an integral form on a finite free `ℤ`-module to its rationalization and relate the abstract rationalization to the embedded carrier model.” This closes that converse rationalization target on the already-merged carrier, basis, and bilinear-base-change foundations. After this PR, Layer 1 still needs the orthogonal-sum radical and signature laws currently in flight in #3479 before the layer is complete.

This is the most effective current step because the other immediate Integral Lattices fronts—orthogonal-sum signatures, discriminant forms, double orthogonal complements, and primary components—are already represented by open PRs, while this explicit Layer 1 target had no implementation or competing claim. The construction reuses Mathlib’s `LinearMap.BilinForm.baseChange`, `Basis.baseChange`, `Basis.restrictScalars`, and `LinearEquiv.baseChange`, together with Tau Ceti’s existing `IntegralLattice.ofBasis` and `Submodule.rationalizationEquiv`; no Mathlib infrastructure is vendored. The mathematical construction follows W. Ebeling, *Lattices and Codes*, Chapter 1, as credited in the module documentation.

Extend `TauCeti/LinearAlgebra/IntegralLattice/Rationalization.lean` by 155 lines, to 252 lines total.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"integral-form-rationalization"}-->

🤖 Prepared with Codex
