### PR TITLE
feat: rationalize the Chevalley Lie lattice

### DIFF
--- a/TauCeti/Algebra/Lie/Subalgebra/Rationalization.lean
+++ b/TauCeti/Algebra/Lie/Subalgebra/Rationalization.lean
@@ -53,53 +53,29 @@ variable {R : Type u} {K : Type v} {L : Type w}
   [CommRing R] [IsDomain R] [Field K] [Algebra R K] [IsFractionRing R K]
   [LieRing L] [LieAlgebra R L] [LieAlgebra K L] [IsScalarTower R K L]
 
--- Mathlib's scalar-extension bracket and the bracket of the automatically inferred self-module
--- are propositionally equal but not definitionally equal. These elementary consequences of the
--- `LieRing` fields keep the proof on the scalar-extension bracket selected by the goal.
-private theorem bracket_zero {A : Type*} [LieRing A] (x : A) : ⁅x, (0 : A)⁆ = 0 := by
-  have h := LieRing.lie_add x (0 : A) (0 : A)
-  rw [zero_add] at h
-  exact (sub_eq_of_eq_add h).symm.trans (sub_self _)
-
-private theorem zero_bracket {A : Type*} [LieRing A] (x : A) : ⁅(0 : A), x⁆ = 0 := by
-  have h := LieRing.add_lie (0 : A) (0 : A) x
-  rw [zero_add] at h
-  exact (sub_eq_of_eq_add h).symm.trans (sub_self _)
-
-private theorem neg_bracket_swap {A : Type*} [LieRing A] (x y : A) : -⁅y, x⁆ = ⁅x, y⁆ := by
-  have h := LieRing.lie_self (x + y)
-  rw [LieRing.add_lie, LieRing.lie_add, LieRing.lie_add, LieRing.lie_self, LieRing.lie_self,
-    zero_add, add_zero] at h
-  exact neg_eq_iff_add_eq_zero.mpr (by simpa only [add_comm] using h)
-
-private theorem bracket_smul_left {R A : Type*} [CommRing R] [LieRing A] [LieAlgebra R A]
-    (r : R) (x y : A) : ⁅r • x, y⁆ = r • ⁅x, y⁆ := by
-  calc
-    ⁅r • x, y⁆ = -⁅y, r • x⁆ := (neg_bracket_swap (r • x) y).symm
-    _ = -(r • ⁅y, x⁆) := by rw [LieAlgebra.lie_smul]
-    _ = r • -⁅y, x⁆ := by rw [smul_neg]
-    _ = r • ⁅x, y⁆ := by rw [neg_bracket_swap]
-
 private theorem rationalizationEquiv_map_lie (M : LieSubalgebra R L)
     [Module.Free R M] [M.toSubmodule.IsLattice K] (x y : K ⊗[R] M) :
     Submodule.rationalizationEquiv M.toSubmodule ⁅x, y⁆ =
       ⁅Submodule.rationalizationEquiv M.toSubmodule x,
         Submodule.rationalizationEquiv M.toSubmodule y⁆ := by
+  -- `rw` cannot key Mathlib's Lie-module lemmas against the scalar-extension bracket, whose
+  -- `Bracket` instance is not syntactically a `LieRingModule.toBracket` projection, so the
+  -- rewrites on `K ⊗[R] M` name their arguments explicitly.
   induction x using TensorProduct.induction_on with
   | zero =>
-      rw [zero_bracket, map_zero, zero_bracket]
+      rw [zero_lie y, map_zero, zero_lie]
   | tmul q x =>
       induction y using TensorProduct.induction_on with
-      | zero => rw [bracket_zero, map_zero, bracket_zero]
+      | zero => rw [lie_zero (q ⊗ₜ[R] x), map_zero, lie_zero]
       | tmul r y =>
           rw [LieAlgebra.ExtendScalars.bracket_tmul]
           rw [Submodule.rationalizationEquiv_tmul, Submodule.rationalizationEquiv_tmul,
             Submodule.rationalizationEquiv_tmul]
-          rw [bracket_smul_left, LieAlgebra.lie_smul, LieSubalgebra.coe_bracket, smul_smul]
+          rw [smul_lie, lie_smul, LieSubalgebra.coe_bracket, smul_smul]
       | add y z hy hz =>
-          rw [LieRing.lie_add, map_add, hy, hz, map_add, LieRing.lie_add]
-  | add x y hx hy =>
-      rw [LieRing.add_lie, map_add, hx, hy, map_add, LieRing.add_lie]
+          rw [lie_add (q ⊗ₜ[R] x) y z, map_add, hy, hz, map_add, lie_add]
+  | add x₁ x₂ hx₁ hx₂ =>
+      rw [add_lie x₁ x₂ y, map_add, hx₁, hx₂, map_add, add_lie]
 
 /-- The canonical rationalization of a free full integral Lie subalgebra, as a Lie algebra
 equivalence.

--- a/TauCeti/Algebra/Lie/Subalgebra/Rationalization.lean
+++ b/TauCeti/Algebra/Lie/Subalgebra/Rationalization.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Algebra.Lie.BaseChange
+public import TauCeti.Algebra.Module.Lattice
+
+/-!
+# Rationalizing integral Lie lattices
+
+Let `M` be a free full Lie lattice over a domain `R` in a Lie algebra `L` over its fraction field
+`K`. The underlying submodule inclusion exhibits `L` as the scalar extension `K ⊗[R] M`. This file
+proves that the canonical rationalization equivalence respects the Lie bracket, giving
+
+```text
+K ⊗[R] M ≃ₗ⁅K⁆ L.
+```
+
+The source carries Mathlib's scalar-extended Lie bracket. Thus the result identifies the generic
+fibre as a Lie algebra, rather than only as a vector space. Its pure-tensor and inverse equations
+make the equivalence usable without unfolding either the tensor-product bracket or the lattice
+rationalization construction.
+
+## Main declaration
+
+* `TauCeti.LieSubalgebra.rationalizationEquiv`: the canonical Lie equivalence from the scalar
+  extension of a free full integral Lie subalgebra to its ambient rational Lie algebra.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §25.2.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+
+This is the generic-fibre step for the Chevalley integral form used in Layer 9 of the
+`ReductiveGroups` roadmap. That pinned Chevalley--Demazure construction is consumed by milestone
+L0 of the `CFSGStatement` roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace LieSubalgebra
+
+universe u v w
+
+variable {R : Type u} {K : Type v} {L : Type w}
+  [CommRing R] [IsDomain R] [Field K] [Algebra R K] [IsFractionRing R K]
+  [LieRing L] [LieAlgebra R L] [LieAlgebra K L] [IsScalarTower R K L]
+
+-- Mathlib's scalar-extension bracket and the bracket of the automatically inferred self-module
+-- are propositionally equal but not definitionally equal. These elementary consequences of the
+-- `LieRing` fields keep the proof on the scalar-extension bracket selected by the goal.
+private theorem bracket_zero {A : Type*} [LieRing A] (x : A) : ⁅x, (0 : A)⁆ = 0 := by
+  have h := LieRing.lie_add x (0 : A) (0 : A)
+  rw [zero_add] at h
+  exact (sub_eq_of_eq_add h).symm.trans (sub_self _)
+
+private theorem zero_bracket {A : Type*} [LieRing A] (x : A) : ⁅(0 : A), x⁆ = 0 := by
+  have h := LieRing.add_lie (0 : A) (0 : A) x
+  rw [zero_add] at h
+  exact (sub_eq_of_eq_add h).symm.trans (sub_self _)
+
+private theorem neg_bracket_swap {A : Type*} [LieRing A] (x y : A) : -⁅y, x⁆ = ⁅x, y⁆ := by
+  have h := LieRing.lie_self (x + y)
+  rw [LieRing.add_lie, LieRing.lie_add, LieRing.lie_add, LieRing.lie_self, LieRing.lie_self,
+    zero_add, add_zero] at h
+  exact neg_eq_iff_add_eq_zero.mpr (by simpa only [add_comm] using h)
+
+private theorem bracket_smul_left {R A : Type*} [CommRing R] [LieRing A] [LieAlgebra R A]
+    (r : R) (x y : A) : ⁅r • x, y⁆ = r • ⁅x, y⁆ := by
+  calc
+    ⁅r • x, y⁆ = -⁅y, r • x⁆ := (neg_bracket_swap (r • x) y).symm
+    _ = -(r • ⁅y, x⁆) := by rw [LieAlgebra.lie_smul]
+    _ = r • -⁅y, x⁆ := by rw [smul_neg]
+    _ = r • ⁅x, y⁆ := by rw [neg_bracket_swap]
+
+private theorem rationalizationEquiv_map_lie (M : LieSubalgebra R L)
+    [Module.Free R M] [M.toSubmodule.IsLattice K] (x y : K ⊗[R] M) :
+    Submodule.rationalizationEquiv M.toSubmodule ⁅x, y⁆ =
+      ⁅Submodule.rationalizationEquiv M.toSubmodule x,
+        Submodule.rationalizationEquiv M.toSubmodule y⁆ := by
+  induction x using TensorProduct.induction_on with
+  | zero =>
+      rw [zero_bracket, map_zero, zero_bracket]
+  | tmul q x =>
+      induction y using TensorProduct.induction_on with
+      | zero => rw [bracket_zero, map_zero, bracket_zero]
+      | tmul r y =>
+          rw [LieAlgebra.ExtendScalars.bracket_tmul]
+          rw [Submodule.rationalizationEquiv_tmul, Submodule.rationalizationEquiv_tmul,
+            Submodule.rationalizationEquiv_tmul]
+          rw [bracket_smul_left, LieAlgebra.lie_smul, LieSubalgebra.coe_bracket, smul_smul]
+      | add y z hy hz =>
+          rw [LieRing.lie_add, map_add, hy, hz, map_add, LieRing.lie_add]
+  | add x y hx hy =>
+      rw [LieRing.add_lie, map_add, hx, hy, map_add, LieRing.add_lie]
+
+/-- The canonical rationalization of a free full integral Lie subalgebra, as a Lie algebra
+equivalence.
+
+The underlying linear equivalence is `TauCeti.Submodule.rationalizationEquiv`. The bracket on its
+source is Mathlib's scalar-extension bracket on `K ⊗[R] M`. -/
+noncomputable def rationalizationEquiv (M : LieSubalgebra R L)
+    [Module.Free R M] [M.toSubmodule.IsLattice K] :
+    K ⊗[R] M ≃ₗ⁅K⁆ L where
+  __ := Submodule.rationalizationEquiv M.toSubmodule
+  map_lie' := by
+    intro x y
+    -- `LieEquiv` exposes the underlying `LinearEquiv` through a generated coercion wrapper.
+    change Submodule.rationalizationEquiv M.toSubmodule ⁅x, y⁆ =
+      ⁅Submodule.rationalizationEquiv M.toSubmodule x,
+        Submodule.rationalizationEquiv M.toSubmodule y⁆
+    exact rationalizationEquiv_map_lie M x y
+
+/-- Rationalization sends a pure tensor to scalar multiplication of the embedded integral
+element. -/
+@[simp]
+theorem rationalizationEquiv_tmul (M : LieSubalgebra R L)
+    [Module.Free R M] [M.toSubmodule.IsLattice K] (q : K) (x : M) :
+    rationalizationEquiv M (q ⊗ₜ[R] x) = q • (x : L) :=
+  Submodule.rationalizationEquiv_tmul M.toSubmodule q x
+
+/-- The inverse rationalization sends an embedded integral element to its unit pure tensor. -/
+@[simp]
+theorem rationalizationEquiv_symm_coe (M : LieSubalgebra R L)
+    [Module.Free R M] [M.toSubmodule.IsLattice K] (x : M) :
+    (rationalizationEquiv M).symm (x : L) = 1 ⊗ₜ[R] x :=
+  Submodule.rationalizationEquiv_symm_coe M.toSubmodule x
+
+end LieSubalgebra
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Weights/Root/Rationalization.lean
+++ b/TauCeti/Algebra/Lie/Weights/Root/Rationalization.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.Lie.Subalgebra.Rationalization
+public import TauCeti.Algebra.Lie.Weights.Root.IntegralLattice
+
+/-!
+# Rationalizing the Chevalley Lie lattice
+
+A Chevalley system supplies the integral root--coroot Lie lattice
+`IsChevalleySystem.chevalleyLieLattice`. Its underlying integer module is finite and free, and its
+rational span is the whole ambient Lie algebra. This file packages those facts as a full lattice
+instance and applies the generic Lie-lattice rationalization theorem to obtain
+
+```text
+ℚ ⊗[ℤ] hx.chevalleyLieLattice ≃ₗ⁅ℚ⁆ L.
+```
+
+It also selects a finite basis of the integral lattice, indexed by the dimension of `L`. This is
+the basis shape required by the matrix-coordinate and Kostant root-subgroup constructions. The
+basis is not claimed to be an additional root-vector normalization: all pinned mathematical data
+remain in the Chevalley system and in the named root and coroot generators.
+
+## Main declarations
+
+* `TauCeti.IsChevalleySystem.instIsLatticeChevalleyLieLattice`: the root--coroot Lie lattice is a
+  full integral lattice.
+* `TauCeti.IsChevalleySystem.chevalleyLieLatticeRationalization`: its scalar extension recovers
+  the ambient rational Lie algebra as a Lie algebra.
+* `TauCeti.IsChevalleySystem.chevalleyLieLatticeFinBasis`: a finite basis indexed by
+  `Fin (finrank ℚ L)` for use in matrix constructions.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§25--26.
+* R. W. Carter, *Simple Groups of Lie Type*, §4.1.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+
+This advances the Chevalley-basis and generic-fibre part of the explicit pinned
+Chevalley--Demazure construction in Layer 9 of the `ReductiveGroups` roadmap. That construction is
+the declared input to milestone L0 of the `CFSGStatement` roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+open LieAlgebra LieAlgebra.IsKilling LieModule
+
+universe u
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L] [LieAlgebra.IsKilling ℚ L]
+  [FiniteDimensional ℚ L]
+  {H : LieSubalgebra ℚ L} [H.IsCartanSubalgebra] [LieModule.IsTriangularizable ℚ H L]
+  {ω : L ≃ₗ⁅ℚ⁆ L} {x : Weight ℚ H L → L}
+
+namespace IsChevalleySystem
+
+variable (hx : IsChevalleySystem ω x)
+
+include hx
+
+/-- The Chevalley root--coroot Lie lattice is a full integral lattice in the ambient rational Lie
+algebra. -/
+instance instIsLatticeChevalleyLieLattice :
+    hx.chevalleyLieLattice.toSubmodule.IsLattice ℚ where
+  fg := by
+    rw [hx.chevalleyLieLattice_toSubmodule, rootCorootSpan_eq_span_generators]
+    exact Submodule.fg_span (finite_rootCorootGenerators x)
+  span_eq_top := hx.span_chevalleyLieLattice_eq_top
+
+/-- The scalar extension of the Chevalley Lie lattice recovers the ambient rational Lie algebra,
+including its Lie bracket. -/
+noncomputable def chevalleyLieLatticeRationalization :
+    ℚ ⊗[ℤ] hx.chevalleyLieLattice ≃ₗ⁅ℚ⁆ L :=
+  LieSubalgebra.rationalizationEquiv hx.chevalleyLieLattice
+
+/-- On pure tensors, the Chevalley-lattice rationalization is the ambient scalar action. -/
+@[simp]
+theorem chevalleyLieLatticeRationalization_tmul (q : ℚ) (z : hx.chevalleyLieLattice) :
+    hx.chevalleyLieLatticeRationalization (q ⊗ₜ[ℤ] z) = q • (z : L) :=
+  by
+    rw [chevalleyLieLatticeRationalization]
+    exact LieSubalgebra.rationalizationEquiv_tmul hx.chevalleyLieLattice q z
+
+/-- The inverse Chevalley-lattice rationalization sends an integral vector to its unit pure
+tensor. -/
+@[simp]
+theorem chevalleyLieLatticeRationalization_symm_coe (z : hx.chevalleyLieLattice) :
+    hx.chevalleyLieLatticeRationalization.symm (z : L) = 1 ⊗ₜ[ℤ] z :=
+  by
+    rw [chevalleyLieLatticeRationalization]
+    exact LieSubalgebra.rationalizationEquiv_symm_coe hx.chevalleyLieLattice z
+
+/-- A finite basis of the Chevalley Lie lattice indexed by the dimension of the ambient rational
+Lie algebra.
+
+This is an arbitrary module basis of the already pinned root--coroot lattice. It is intended for
+matrix coordinates; it does not replace or renormalize the Chevalley system's named root vectors
+and coroots. -/
+noncomputable def chevalleyLieLatticeFinBasis :
+    Module.Basis (Fin (Module.finrank ℚ L)) ℤ hx.chevalleyLieLattice :=
+  Module.finBasisOfFinrankEq ℤ hx.chevalleyLieLattice
+    (Submodule.IsLattice.finrank_eq_finrank hx.chevalleyLieLattice.toSubmodule)
+
+end IsChevalleySystem
+
+end TauCeti


### PR DESCRIPTION
This PR packages the Chevalley root--coroot lattice as a full integral Lie lattice, identifies its scalar extension with the ambient rational Lie algebra by a canonical Lie equivalence, and selects a finite integral basis for the matrix-coordinate constructions that follow. It targets ReductiveGroups Layer 9, specifically “The Chevalley--Demazure construction … via a Chevalley basis and the Kostant `ℤ`-form of the enveloping algebra.”

The preferred CFSGStatement roadmap has its independent I0 and sporadic prerequisites landed or in flight, while L0 is explicitly blocked on ReductiveGroups Layer 9. The dependency edge is CFSGStatement milestone L0 (“pinned ambient groups”) → ReductiveGroups Layer 9 (“pinned Chevalley--Demazure group schemes over `ℤ`”); L0 will consume the resulting pinning, base change, points, and root subgroup maps.

The generic module proves that the existing full-lattice rationalization linear equivalence preserves Mathlib's scalar-extension Lie bracket. The Chevalley specialization proves finite generation from the named root--coroot generators, installs the full-lattice instance, and exposes pure-tensor and inverse formulas. The selected finite basis is deliberately an arbitrary basis of the already pinned lattice for matrix coordinates, not a second normalization of the Chevalley vectors.

This is the next effective step after the Chevalley Lie lattice was proved finite free and full: it supplies the integral-to-generic-fibre identification needed to compare the forthcoming Kostant representation with the rational Lie algebra. After this PR, Layer 9 still needs the Kostant divided-power representation and lattice-stability proofs, followed by the integral group scheme, pinning, base-change, points, root subgroups, isomorphism theorem, and special isogenies.

The implementation reuses `TauCeti.Submodule.rationalizationEquiv` and Mathlib's `LieAlgebra.ExtendScalars` tensor-product bracket; no Mathlib infrastructure is vendored. Mathematical references are Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§25--26; Carter, *Simple Groups of Lie Type*, §4.1; and Jantzen, *Representations of Algebraic Groups*, II.1.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"chevalley-lie-lattice-rationalization"}-->

🤖 Prepared with Codex
