### PR TITLE
feat: prove primary restrictions are nondegenerate

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/PrimaryComponent.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/PrimaryComponent.lean
@@ -101,15 +101,14 @@ private theorem ordCompl_natCard_nsmul_mem_primaryComponent (p : ℕ) (x : A) :
   rw [← mul_nsmul, Nat.mul_comm, Nat.ordProj_mul_ordCompl_eq_self, card_nsmul_eq_zero']
 
 /-- The restriction of a nondegenerate finite bilinear module to any prime-primary component is
-nondegenerate.
-
-Indeed, let `x` lie in the radical of the restricted pairing. Pairing `x` with
-`ordCompl[p] (Nat.card A) • y` shows that the prime-to-`p` part of the cardinality annihilates
-`b(x,y)`. A power of `p` also annihilates it because `x` is `p`-primary. These two integers are
-coprime, so `b(x,y) = 0` for every `y`; ambient nondegeneracy then gives `x = 0`. -/
+nondegenerate. -/
 theorem isNondegenerate_restrict_primaryComponent (hA : A.IsNondegenerate) {p : ℕ}
     (hp : p.Prime) :
     (A.restrict (AddCommGroup.primaryComponent A p)).IsNondegenerate := by
+  -- For `x` in the radical of the restricted pairing and arbitrary `z`, pairing `x` with
+  -- `ordCompl[p] (Nat.card A) • z` shows the prime-to-`p` part of the cardinality annihilates
+  -- `A.pairing x z`, while a power of `p` annihilates it because `x` is `p`-primary.  Those two
+  -- integers are coprime, so `A.pairing x z = 0` for every `z` and ambient nondegeneracy applies.
   rw [(A.restrict (AddCommGroup.primaryComponent A p)).isNondegenerate_iff_injective]
   intro x y hxy
   apply Subtype.ext

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/PrimaryComponent.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/PrimaryComponent.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
 public import Mathlib.GroupTheory.Torsion
+import Mathlib.Data.Nat.Factorization.Basic
 
 /-!
 # Primary components of finite bilinear and quadratic modules
@@ -27,6 +28,8 @@ in pairwise distinct primary components.
   components are orthogonal elementwise.
 * `TauCeti.FiniteBilinearModule.primaryComponent_le_orthogonalComplement_primaryComponent`: the
   corresponding inclusion of additive subgroups.
+* `TauCeti.FiniteBilinearModule.isNondegenerate_restrict_primaryComponent`: a nondegenerate
+  pairing restricts nondegenerately to each prime-primary component.
 * `TauCeti.FiniteBilinearModule.pairing_sum_eq_sum_pairing_of_mem_primaryComponent`: a bilinear
   pairing of primary decompositions is the sum of the component pairings.
 * `TauCeti.FiniteQuadraticModule.quadratic_sum_of_mem_primaryComponent`: a quadratic value on a
@@ -84,6 +87,55 @@ theorem primaryComponent_le_orthogonalComplement_primaryComponent {p q : ℕ}
   intro y hy
   exact A.pairing_eq_zero_of_mem_primaryComponent hp hq hpq hx hy
 
+/-! ## Nondegeneracy of the restricted pairing -/
+
+/-- Multiplication by the prime-to-`p` part of the group cardinality sends every element into the
+`p`-primary component.
+
+This is the elementary projection onto the primary part needed to detect the radical of the
+restricted pairing. It is stated for the underlying group because it is independent of the form. -/
+private theorem ordCompl_natCard_nsmul_mem_primaryComponent (p : ℕ) (x : A) :
+    ordCompl[p] (Nat.card A) • x ∈ AddCommGroup.primaryComponent A p := by
+  rw [AddCommGroup.mem_primaryComponent]
+  refine ⟨(Nat.card A).factorization p, ?_⟩
+  rw [← mul_nsmul, Nat.mul_comm, Nat.ordProj_mul_ordCompl_eq_self, card_nsmul_eq_zero']
+
+/-- The restriction of a nondegenerate finite bilinear module to any prime-primary component is
+nondegenerate.
+
+Indeed, let `x` lie in the radical of the restricted pairing. Pairing `x` with
+`ordCompl[p] (Nat.card A) • y` shows that the prime-to-`p` part of the cardinality annihilates
+`b(x,y)`. A power of `p` also annihilates it because `x` is `p`-primary. These two integers are
+coprime, so `b(x,y) = 0` for every `y`; ambient nondegeneracy then gives `x = 0`. -/
+theorem isNondegenerate_restrict_primaryComponent (hA : A.IsNondegenerate) {p : ℕ}
+    (hp : p.Prime) :
+    (A.restrict (AddCommGroup.primaryComponent A p)).IsNondegenerate := by
+  rw [(A.restrict (AddCommGroup.primaryComponent A p)).isNondegenerate_iff_injective]
+  intro x y hxy
+  apply Subtype.ext
+  apply sub_eq_zero.mp
+  apply hA.eq_zero_of_forall_pairing_eq_zero
+  intro z
+  obtain ⟨k, hk⟩ := AddCommGroup.mem_primaryComponent.mp (sub_mem x.property y.property)
+  have hcard : Nat.card A ≠ 0 := Nat.card_ne_zero.mpr ⟨⟨0⟩, inferInstance⟩
+  apply eq_zero_of_coprime_nsmul_eq_zero
+      ((Nat.coprime_ordCompl hp hcard).pow_left k)
+  · have hmap := DFunLike.congr_fun
+      (map_nsmul A.pairing (p ^ k) (x.1 - y.1)) z
+    rw [hk, map_zero] at hmap
+    calc
+      p ^ k • A.pairing (x.1 - y.1) z =
+          (p ^ k • A.pairing (x.1 - y.1)) z :=
+        (AddMonoidHom.nsmul_apply _ _ _).symm
+      _ = (0 : CharacterModule A) z := hmap.symm
+      _ = 0 := AddMonoidHom.zero_apply z
+  · rw [← map_nsmul (A.pairing (x.1 - y.1))]
+    have hz := ordCompl_natCard_nsmul_mem_primaryComponent A p z
+    have heval := DFunLike.congr_fun hxy
+      (⟨ordCompl[p] (Nat.card A) • z, hz⟩ : AddCommGroup.primaryComponent A p)
+    rw [map_sub]
+    exact sub_eq_zero.mpr heval
+
 /-! ## Finite sums -/
 
 /-- Pairing sums of elements from pairwise distinct primary components keeps only the diagonal
@@ -114,6 +166,13 @@ end FiniteBilinearModule
 namespace FiniteQuadraticModule
 
 variable (A : FiniteQuadraticModule)
+
+/-- The polar pairing of a nondegenerate finite quadratic module restricts nondegenerately to each
+prime-primary component. -/
+theorem isNondegenerate_restrict_primaryComponent (hA : A.IsNondegenerate) {p : ℕ}
+    (hp : p.Prime) :
+    (A.restrict (AddCommGroup.primaryComponent A p)).IsNondegenerate :=
+  A.toFiniteBilinearModule.isNondegenerate_restrict_primaryComponent hA hp
 
 /-- A quadratic map is additive on elements belonging to primary components for distinct primes. -/
 theorem quadratic_add_of_mem_primaryComponent {p q : ℕ} (hp : p.Prime) (hq : q.Prime)


### PR DESCRIPTION
This PR proves that a nondegenerate finite bilinear module restricts nondegenerately to every prime-primary component, and supplies the corresponding finite quadratic-module theorem. For an element in the radical of the restricted pairing, multiply an arbitrary ambient element by `ordCompl[p] (Nat.card A)` to put it in the `p`-primary component; the pairing value is then annihilated both by that prime-to-`p` factor and by a power of `p`, so coprimality forces it to vanish. Ambient nondegeneracy finishes the argument.

The exact roadmap target is `TauCetiRoadmap/IntegralLattices/README.md`, Layer 3 milestone “finite bilinear and quadratic modules,” specifically “Under `IsNondegenerate A`, prove each restricted primary form is nondegenerate.” This is the next step after #3499 established orthogonality of distinct primary components and the raw finite-sum formulas. After this PR, the primary-decomposition target still needs the canonical additive decomposition, its packaging as a bilinear and quadratic isometry, and the componentwise isotropy and orthogonal-complement statements.

The preferred `CFSGStatement` roadmap has no viable direct unclaimed small step on current `main`: I0 and S1 are complete, `classificationStatement_of_zero` remains in flight in #3058, and L0 still explicitly waits on the ReductiveGroups Layer 9 construction whose PBW/Kostant and represented-root-subgroup fronts are already in flight. The selected IntegralLattices theorem is an exact unclaimed milestone target on merged foundations and is independent of the open double-perp and discriminant-form work.

Extend `TauCeti/LinearAlgebra/FiniteBilinearModule/PrimaryComponent.lean` by 59 lines. Reuse Mathlib's `AddCommGroup.primaryComponent`, `Nat.ordCompl`, `Nat.coprime_ordCompl`, and the finite-group cardinality annihilation theorem; no Mathlib infrastructure is vendored. The primary-decomposition argument follows Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1, and Ebeling, *Lattices and Codes*, Chapter 1, as credited in the module documentation.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"primary-component-nondegenerate"}-->

🤖 Prepared with Codex
