### PR TITLE
feat: decompose a Kostant-stable lattice into weight components

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/WeightDecomposition.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/WeightDecomposition.lean
@@ -1,0 +1,260 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.DFinsupp
+public import Mathlib.LinearAlgebra.Eigenspace.Basic
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.Form
+public import TauCeti.LinearAlgebra.Eigenspace.Binomial
+
+/-!
+# Admissible lattices decompose into weight components
+
+Let `U_ℤ = kostantForm e h` be a Kostant integral form in `U(L)`, acting through `ρ` on a rational
+vector space `V`, and let `M ≤ V` be a `U_ℤ`-stable additive subgroup — an *admissible lattice*
+once it is also a lattice. A designated Cartan vector `h j` acts on `V` by an operator whose
+eigenvalues on a representation with integral weights are integers, and the question this file
+answers is whether an element of `M` has *all* of its weight components in `M`. It does, and this
+is what makes the weight components of an admissible lattice into lattices themselves.
+
+Nothing about `M` forces this: `M` is only assumed stable, and the projection onto a weight space
+is a Lagrange interpolation polynomial in the Cartan operator with rational coefficients, so it
+does not obviously preserve an integral structure. The point is that the Kostant form contains not
+just the Cartan vector `h j` but all of its binomial coefficients `(h j choose k)`, and even all
+the coefficients `(h j - a choose k)` of its integer translates
+(`TauCeti.UniversalEnvelopingAlgebra.ringChoose_ι_sub_intCast_mem_kostantForm`). Those act on a
+vector of weight `a + i` by the ordinary binomial coefficient `(i choose k)`, and Newton's
+forward-difference formula (`TauCeti.exists_forall_sum_mul_choose_eq`) writes *any* prescribed
+integer values on `i = 0, …, N` as an integral combination of them. Choosing the values to be the
+indicator of a single weight produces a genuine projector inside `U_ℤ`, which is
+`TauCeti.UniversalEnvelopingAlgebra.exists_mem_kostantForm_forall_apply_eq`.
+
+A weight of the whole Cartan family is an integer-valued function on the Cartan indices, and two
+distinct weights differ at some single index, so grouping summands by their value there reduces
+the simultaneous statement
+`TauCeti.UniversalEnvelopingAlgebra.jointWeightComponent_mem_of_kostantStable`
+to the one-index one. That is Humphreys' Lemma 27.1: an admissible lattice contains every joint
+weight component of each of its elements, so it is the direct sum of the lattices it cuts out of the
+weight spaces. For a single Cartan direction the decomposition is packaged as a submodule identity,
+`TauCeti.UniversalEnvelopingAlgebra.iSup_weightComponent_eq` together with
+`TauCeti.UniversalEnvelopingAlgebra.iSupIndep_weightComponent`.
+
+This is the input the pinned Chevalley--Demazure group scheme of Layer 9 needs before its split
+maximal torus can be written down, since the torus is exactly what acts by a character on each
+weight component.
+
+## Main declarations
+
+* `TauCeti.UniversalEnvelopingAlgebra.exists_mem_kostantForm_forall_apply_eq`: prescribed integer
+  scalars on a window of consecutive weights are realized by a single element of the Kostant form.
+* `TauCeti.UniversalEnvelopingAlgebra.weightComponent_mem_of_kostantStable`: every weight component
+  for one Cartan vector of an element of a Kostant-stable subgroup lies in that subgroup.
+* `TauCeti.UniversalEnvelopingAlgebra.jointWeightComponent_mem_of_kostantStable`: the same for the
+  joint weight components of the whole Cartan family.
+* `TauCeti.UniversalEnvelopingAlgebra.weightComponent`: the weight components of a `ℤ`-submodule.
+* `TauCeti.UniversalEnvelopingAlgebra.iSup_weightComponent_eq` and
+  `TauCeti.UniversalEnvelopingAlgebra.iSupIndep_weightComponent`: a Kostant-stable `ℤ`-submodule of
+  a module with integral weights is the direct sum of its weight components.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §27.1.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+open Finset
+
+universe u v w
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {ι : Type w} {κ : Type*}
+variable {V : Type v} [AddCommGroup V] [Module ℚ V]
+
+attribute [local instance] TauCeti.moduleNNRat
+
+variable (e : ι → L) (h : κ → L)
+  (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+
+/-! ## Separating weights inside the Kostant form -/
+
+/-- **The Kostant form separates the weights in a window.** Given a base weight `a`, a window
+length `N` and prescribed integer values `g 0, …, g N`, some element of the Kostant integral form
+acts by the scalar `g i` on every vector of weight `a + i`, simultaneously for all `i ≤ N`.
+
+The element is the integral combination `∑ k ≤ N, c k • (h j - a choose k)` supplied by Newton's
+forward-difference formula; each summand lies in the form because the Cartan binomial coefficients
+of a designated Cartan vector survive integer translation of their argument. -/
+theorem exists_mem_kostantForm_forall_apply_eq (j : κ) (a : ℤ) (N : ℕ) (g : ℕ → ℤ) :
+    ∃ u ∈ kostantForm e h, ∀ i ≤ N, ∀ x : V,
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) x = ((a + i : ℤ) : ℚ) • x →
+        ρ u x = (g i : ℚ) • x := by
+  obtain ⟨c, hc⟩ := TauCeti.exists_forall_sum_mul_choose_eq N g
+  refine ⟨∑ k ∈ range (N + 1), c k •
+    Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j) -
+      (a : _root_.UniversalEnvelopingAlgebra ℚ L)) k, ?_, ?_⟩
+  · exact sum_mem fun k _ =>
+      zsmul_mem (ringChoose_ι_sub_intCast_mem_kostantForm e h j a k) (c k)
+  · intro i hi x hx
+    have hshift : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j) -
+        (a : _root_.UniversalEnvelopingAlgebra ℚ L)) x = (i : ℚ) • x := by
+      rw [map_sub, map_intCast, LinearMap.sub_apply, hx, Module.End.intCast_apply,
+        ← Int.cast_smul_eq_zsmul ℚ a x, ← sub_smul]
+      norm_num
+    have hterm : ∀ k ∈ range (N + 1),
+        (ρ (c k • Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j) -
+          (a : _root_.UniversalEnvelopingAlgebra ℚ L)) k)) x =
+          ((c k : ℚ) * (i.choose k : ℚ)) • x := by
+      intro k _
+      rw [map_zsmul, LinearMap.smul_apply, Ring.map_choose,
+        TauCeti.ringChoose_end_apply_of_apply_eq_natCast_smul hshift k,
+        ← Int.cast_smul_eq_zsmul ℚ (c k), smul_smul]
+    rw [map_sum, LinearMap.sum_apply, sum_congr rfl hterm, ← sum_smul]
+    congr 1
+    exact_mod_cast hc i hi
+
+/-! ## Weight components of a stable subgroup -/
+
+/-- **A Kostant-stable subgroup contains the weight components of its elements.** If a vector of
+`M` is written as a finite sum of vectors of pairwise distinct integer weights for the Cartan
+vector `h j`, then each of those vectors already lies in `M`.
+
+This is the integrality statement behind Humphreys' Lemma 27.1: the projector onto a single weight
+has rational coefficients as a polynomial in the Cartan operator, yet it is realized inside the
+Kostant integral form. -/
+theorem weightComponent_mem_of_kostantStable
+    {S : Type*} [SetLike S V] {M : S}
+    (hM : ∀ u ∈ kostantForm e h, ∀ x ∈ M, ρ u x ∈ M) (j : κ)
+    {s : Finset ℤ} {w : ℤ → V}
+    (hw : ∀ m ∈ s, ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) (w m) = (m : ℚ) • w m)
+    (hv : (∑ m ∈ s, w m) ∈ M) {m₀ : ℤ} (hm₀ : m₀ ∈ s) : w m₀ ∈ M := by
+  classical
+  have hs : s.Nonempty := ⟨m₀, hm₀⟩
+  obtain ⟨u, hu, hu'⟩ := exists_mem_kostantForm_forall_apply_eq e h ρ j (s.min' hs)
+    (s.max' hs - s.min' hs).toNat (fun i => if s.min' hs + i = m₀ then 1 else 0)
+  have hterm : ∀ m ∈ s, ρ u (w m) = if m = m₀ then w m else 0 := by
+    intro m hm
+    have hmin : s.min' hs ≤ m := s.min'_le m hm
+    have hmax : m ≤ s.max' hs := s.le_max' m hm
+    have hval : s.min' hs + ((m - s.min' hs).toNat : ℤ) = m := by
+      rw [Int.toNat_of_nonneg (by omega)]; ring
+    have hle : (m - s.min' hs).toNat ≤ (s.max' hs - s.min' hs).toNat := by omega
+    have := hu' _ hle (w m) (by rw [hw m hm, hval])
+    rw [this, hval]
+    by_cases hmm : m = m₀ <;> simp [hmm]
+  have key : ρ u (∑ m ∈ s, w m) = w m₀ := by
+    rw [map_sum, sum_congr rfl hterm, sum_ite_eq' s m₀ w]
+    simp [hm₀]
+  exact key ▸ hM u hu _ hv
+
+/-- **A Kostant-stable subgroup contains the joint weight components of its elements.** A weight
+is an integer-valued function on the designated Cartan vectors, and a vector of `M` written as a
+finite sum of simultaneous eigenvectors of pairwise distinct weights has each summand in `M`.
+
+Two distinct weights differ at some Cartan index, so grouping the summands by their value at that
+index and applying the one-index statement strips off at least one weight while keeping `l₀`. The
+induction is on the set of weights involved, which shrinks strictly at every step. -/
+theorem jointWeightComponent_mem_of_kostantStable
+    {S : Type*} [SetLike S V] {M : S}
+    (hM : ∀ u ∈ kostantForm e h, ∀ x ∈ M, ρ u x ∈ M)
+    {s : Finset (κ → ℤ)} {w : (κ → ℤ) → V}
+    (hw : ∀ l ∈ s, ∀ j : κ,
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) (w l) = (l j : ℚ) • w l)
+    (hv : (∑ l ∈ s, w l) ∈ M) {l₀ : κ → ℤ} (hl₀ : l₀ ∈ s) : w l₀ ∈ M := by
+  classical
+  revert hw hv hl₀
+  induction s using Finset.strongInduction with
+  | _ s ih =>
+    intro hw hv hl₀
+    by_cases hcase : ∀ l ∈ s, l = l₀
+    · rw [Finset.eq_singleton_iff_unique_mem.2 ⟨hl₀, hcase⟩, Finset.sum_singleton] at hv
+      exact hv
+    · push Not at hcase
+      obtain ⟨l₁, hl₁s, hl₁⟩ := hcase
+      obtain ⟨j, hj⟩ : ∃ j : κ, l₁ j ≠ l₀ j := by
+        by_contra hcon
+        push Not at hcon
+        exact hl₁ (funext hcon)
+      refine ih (s.filter fun l => l j = l₀ j) (Finset.filter_ssubset.2 ⟨l₁, hl₁s, hj⟩)
+        (fun l hl j' => hw l (Finset.mem_filter.1 hl).1 j') ?_
+        (Finset.mem_filter.2 ⟨hl₀, rfl⟩)
+      refine weightComponent_mem_of_kostantStable e h ρ hM j (s := s.image fun l => l j)
+        (w := fun m => ∑ l ∈ s.filter fun l => l j = m, w l) (fun m _ => ?_) ?_
+        (Finset.mem_image_of_mem _ hl₀)
+      · simp only [map_sum, Finset.smul_sum]
+        exact Finset.sum_congr rfl fun l hl => by
+          rw [hw l (Finset.mem_filter.1 hl).1 j, (Finset.mem_filter.1 hl).2]
+      · rw [Finset.sum_fiberwise_of_maps_to (fun l hl => Finset.mem_image_of_mem _ hl) w]
+        exact hv
+
+/-! ## The direct-sum decomposition -/
+
+/-- The `m`-th weight component of a `ℤ`-submodule `M` of `V`: the part of `M` lying in the
+`m`-eigenspace of the operator by which the Cartan vector `h j` acts. -/
+def weightComponent (M : Submodule ℤ V) (j : κ) (m : ℤ) : Submodule ℤ V :=
+  M ⊓ (Module.End.eigenspace (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)))
+    (m : ℚ)).restrictScalars ℤ
+
+/-- Membership in a weight component: an element of `M` whose weight for the Cartan vector `h j`
+is `m`. -/
+@[simp]
+theorem mem_weightComponent_iff {M : Submodule ℤ V} {j : κ} {m : ℤ} {x : V} :
+    x ∈ weightComponent h ρ M j m ↔
+      x ∈ M ∧ ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) x = (m : ℚ) • x := by
+  rw [weightComponent, Submodule.mem_inf]
+  exact and_congr_right fun _ => Module.End.mem_eigenspace_iff
+
+/-- A weight component of `M` is contained in `M`. -/
+theorem weightComponent_le (M : Submodule ℤ V) (j : κ) (m : ℤ) :
+    weightComponent h ρ M j m ≤ M := inf_le_left
+
+/-- **A Kostant-stable lattice is spanned by its weight components.** If the Cartan vector `h j`
+acts on `V` with integral weights, then a `ℤ`-submodule stable under the Kostant integral form is
+the sum of the pieces it cuts out of the weight spaces. -/
+theorem iSup_weightComponent_eq {M : Submodule ℤ V}
+    (hM : ∀ u ∈ kostantForm e h, ∀ x ∈ M, ρ u x ∈ M) (j : κ)
+    (hV : ⨆ m : ℤ, Module.End.eigenspace
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j))) (m : ℚ) = ⊤) :
+    ⨆ m : ℤ, weightComponent h ρ M j m = M := by
+  classical
+  refine le_antisymm (iSup_le fun m => weightComponent_le h ρ M j m) fun x hx => ?_
+  have hxV : x ∈ ⨆ m : ℤ, Module.End.eigenspace
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j))) (m : ℚ) := hV ▸ Submodule.mem_top
+  rw [Submodule.mem_iSup_iff_exists_dfinsupp'] at hxV
+  obtain ⟨f, hf⟩ := hxV
+  rw [DFinsupp.sum] at hf
+  have hw : ∀ m ∈ f.support,
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) (f m : V) = (m : ℚ) • (f m : V) :=
+    fun m _ => Module.End.mem_eigenspace_iff.1 (f m).2
+  rw [← hf]
+  refine sum_mem fun m hm => Submodule.mem_iSup_of_mem m ?_
+  rw [mem_weightComponent_iff]
+  exact ⟨weightComponent_mem_of_kostantStable e h ρ hM j hw (hf ▸ hx) hm, hw m hm⟩
+
+/-- **The weight components of a `ℤ`-submodule are independent.** They inherit independence from
+the eigenspaces of the Cartan operator, so the sum in
+`TauCeti.UniversalEnvelopingAlgebra.iSup_weightComponent_eq` is direct. -/
+theorem iSupIndep_weightComponent (M : Submodule ℤ V) (j : κ) :
+    iSupIndep (weightComponent h ρ M j) := by
+  have hQ : iSupIndep fun m : ℤ => Module.End.eigenspace
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j))) (m : ℚ) :=
+    (Module.End.eigenspaces_iSupIndep _).comp fun _ _ hab => by exact_mod_cast hab
+  intro m
+  rw [Submodule.disjoint_def]
+  intro x hx hx'
+  have hle : (⨆ n, ⨆ (_ : n ≠ m), weightComponent h ρ M j n) ≤
+      (⨆ n, ⨆ (_ : n ≠ m), Module.End.eigenspace
+        (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j))) (n : ℚ)).restrictScalars ℤ :=
+    iSup_le fun n => iSup_le fun hn =>
+      le_trans inf_le_right (Submodule.restrictScalars_mono ℤ (le_iSup₂ (f := fun n (_ : n ≠ m) =>
+        Module.End.eigenspace (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j))) (n : ℚ))
+        n hn))
+  exact Submodule.disjoint_def.1 (hQ m) x
+    (Module.End.mem_eigenspace_iff.2 ((mem_weightComponent_iff h ρ).1 hx).2) (hle hx')
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/LinearAlgebra/Eigenspace/Binomial.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Binomial.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Binomial
+public import TauCeti.Algebra.Module.Rat
+
+/-!
+# Generalized binomial coefficients of an endomorphism at an eigenvector
+
+An endomorphism `f` of a rational vector space is an element of the `ℚ`-algebra
+`Module.End ℚ V`, which is a binomial ring, so the generalized binomial coefficients
+`Ring.choose f n = f (f - 1) ⋯ (f - n + 1) / n !` are again endomorphisms. This file records that
+they are computed on eigenvectors by the same expression in the eigenvalue:
+
+```text
+f v = μ • v   →   (f choose n) v = (μ choose n) • v.
+```
+
+The mechanism is Mathlib's characterization of `Ring.choose` by
+`Ring.descPochhammer_eq_factorial_smul_choose`: the descending Pochhammer polynomial has integer
+coefficients, so it is evaluated on an eigenvector by evaluating it at the eigenvalue, and the
+factorial is then cancelled because a rational vector space is torsion-free.
+
+Integer eigenvalues are the case of interest: the coefficient is then an ordinary natural-number
+binomial coefficient, which is what makes the Cartan generators `(h choose n)` of a Kostant
+integral form act integrally on weight vectors. `TauCeti.Sl2Std.ringChoose_diag_apply` is the
+coordinate form of the same computation for the standard `sl₂`-modules, where the endomorphism is
+diagonal in a fixed basis rather than merely applied to one eigenvector.
+
+## Main results
+
+* `TauCeti.ringChoose_end_apply_of_apply_eq_smul`: the binomial coefficient of an endomorphism
+  scales an eigenvector by the binomial coefficient of its eigenvalue.
+* `TauCeti.ringChoose_end_apply_of_apply_eq_natCast_smul`: the specialization to a natural-number
+  eigenvalue, where the scalar is `Nat.choose`.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §26.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+namespace TauCeti
+
+open Polynomial
+
+attribute [local instance] TauCeti.moduleNNRat
+
+variable {V : Type*} [AddCommGroup V] [Module ℚ V]
+
+private theorem pow_apply_of_apply_eq_smul {f : Module.End ℚ V} {v : V} {μ : ℚ}
+    (h : f v = μ • v) : ∀ k : ℕ, (f ^ k) v = μ ^ k • v
+  | 0 => by simp
+  | k + 1 => by
+    rw [pow_succ, Module.End.mul_apply, h, map_smul, pow_apply_of_apply_eq_smul h k, smul_smul,
+      ← pow_succ']
+
+private theorem smeval_apply_of_apply_eq_smul {f : Module.End ℚ V} {v : V} {μ : ℚ}
+    (h : f v = μ • v) (p : ℤ[X]) : (p.smeval f) v = (p.smeval μ) • v := by
+  induction p using Polynomial.induction_on' with
+  | add p q hp hq => rw [smeval_add, LinearMap.add_apply, hp, hq, smeval_add, add_smul]
+  | monomial k z =>
+    rw [smeval_monomial, smeval_monomial, LinearMap.smul_apply, pow_apply_of_apply_eq_smul h,
+      smul_assoc]
+
+/-- **A binomial coefficient of an endomorphism acts on an eigenvector through its eigenvalue.**
+If `f v = μ • v` then `(f choose n) v = (μ choose n) • v`.
+
+Both sides are `n !`-th multiples of the descending Pochhammer expression, which is a polynomial
+with integer coefficients and hence is evaluated on `v` by evaluating it at `μ`. -/
+theorem ringChoose_end_apply_of_apply_eq_smul {f : Module.End ℚ V} {v : V} {μ : ℚ}
+    (h : f v = μ • v) (n : ℕ) : (Ring.choose f n) v = Ring.choose μ n • v := by
+  have : IsAddTorsionFree V := .of_module_rat V
+  refine (nsmul_right_inj (Nat.factorial_ne_zero n)).mp ?_
+  have hf : ((descPochhammer ℤ n).smeval f) v =
+      n.factorial • ((Ring.choose f n : Module.End ℚ V) v) := by
+    rw [Ring.descPochhammer_eq_factorial_smul_choose, LinearMap.smul_apply]
+  have hμ : ((descPochhammer ℤ n).smeval μ) • v = n.factorial • (Ring.choose μ n • v) := by
+    rw [Ring.descPochhammer_eq_factorial_smul_choose, smul_assoc]
+  rw [← hf, ← hμ, smeval_apply_of_apply_eq_smul h]
+
+/-- The binomial coefficients of an endomorphism act on an eigenvector with natural-number
+eigenvalue `j` by the ordinary binomial coefficients `(j choose n)`; in particular they act
+integrally. -/
+theorem ringChoose_end_apply_of_apply_eq_natCast_smul {f : Module.End ℚ V} {v : V} {j : ℕ}
+    (h : f v = (j : ℚ) • v) (n : ℕ) : (Ring.choose f n) v = (j.choose n : ℚ) • v := by
+  rw [ringChoose_end_apply_of_apply_eq_smul h, Ring.choose_natCast]
+
+end TauCeti

--- a/TauCeti/RingTheory/Binomial.lean
+++ b/TauCeti/RingTheory/Binomial.lean
@@ -56,6 +56,8 @@ integrality input for commuting Cartan binomial coefficients past divided powers
   the integral span of the original coefficients.
 * `TauCeti.ringChooseSpan_add_intCast` and `TauCeti.ringChooseSpan_sub_intCast`: integer
   translation leaves that integral span unchanged.
+* `TauCeti.exists_forall_sum_mul_choose_eq`: prescribed integer values on an initial segment are
+  attained by an integral combination of binomial coefficients.
 
 ## References
 
@@ -416,5 +418,44 @@ theorem ringChooseSpan_neg [Ring R] [BinomialRing R] (r : R) :
     have h := Ring.choose_neg_mem (A := ringChooseSpan (-r)) (r := -r) (n := n)
       fun k _ => ringChoose_mem_ringChooseSpan (-r) k
     simpa using h
+
+/-!
+# Integral interpolation on an initial segment
+
+The generalized binomial coefficients are the integrally interpolating family: prescribing
+arbitrary integer values on `0, 1, …, N` is always solvable in *integer* coefficients, even
+though the interpolating polynomial itself has non-integral coefficients. This is Newton's
+forward-difference formula, and it is what lets integral combinations of the binomial
+coefficients `(h choose k)` of a Cartan vector separate the integer weights of a
+representation, one weight at a time.
+-/
+
+/-- **Integral interpolation by binomial coefficients.** Arbitrary integer values on the initial
+segment `0, 1, …, N` are attained by an integral combination of the binomial coefficients
+`(· choose k)` for `k ≤ N`.
+
+The matrix `(j choose k)` is lower unitriangular, so the coefficients are read off one at a time:
+the induction step solves for `c (N + 1)` using `(N + 1 choose N + 1) = 1`, and the added term
+does not disturb the smaller values because `(j choose N + 1) = 0` for `j ≤ N`. -/
+theorem exists_forall_sum_mul_choose_eq (N : ℕ) (g : ℕ → ℤ) :
+    ∃ c : ℕ → ℤ, ∀ j ≤ N, ∑ k ∈ range (N + 1), c k * (j.choose k : ℤ) = g j := by
+  induction N with
+  | zero => exact ⟨fun _ => g 0, fun j hj => by simp [Nat.le_zero.1 hj]⟩
+  | succ N ih =>
+    obtain ⟨c, hc⟩ := ih
+    classical
+    refine ⟨Function.update c (N + 1)
+      (g (N + 1) - ∑ i ∈ range (N + 1), c i * ((N + 1).choose i : ℤ)), fun j hj => ?_⟩
+    have hrestrict : ∀ k ∈ range (N + 1),
+        Function.update c (N + 1)
+            (g (N + 1) - ∑ i ∈ range (N + 1), c i * ((N + 1).choose i : ℤ)) k *
+          (j.choose k : ℤ) = c k * (j.choose k : ℤ) := fun k hk => by
+      rw [Function.update_of_ne (Nat.ne_of_lt (mem_range.1 hk))]
+    rw [Finset.sum_range_succ, Finset.sum_congr rfl hrestrict, Function.update_self]
+    rcases eq_or_lt_of_le hj with rfl | hjN
+    · rw [Nat.choose_self, Nat.cast_one, mul_one]
+      ring
+    · rw [Nat.choose_eq_zero_of_lt hjN, Nat.cast_zero, mul_zero, add_zero]
+      exact hc j (Nat.lt_succ_iff.1 hjN)
 
 end TauCeti


### PR DESCRIPTION
This PR proves that an additive subgroup stable under a Kostant integral form contains every weight component of each of its elements, so that an admissible lattice is the direct sum of the lattices it cuts out of the weight spaces. Concretely, `TauCeti.UniversalEnvelopingAlgebra.weightComponent_mem_of_kostantStable` says that if `x ∈ M` is written as a finite sum of eigenvectors of the operator by which a designated Cartan vector `h j` acts, with distinct integer eigenvalues, then every summand is already in `M`; `TauCeti.UniversalEnvelopingAlgebra.jointWeightComponent_mem_of_kostantStable` is the same for simultaneous eigenvectors of the whole Cartan family, which is Humphreys' Lemma 27.1; and `TauCeti.UniversalEnvelopingAlgebra.iSup_weightComponent_eq` together with `TauCeti.UniversalEnvelopingAlgebra.iSupIndep_weightComponent` packages the single-Cartan-vector case as a direct-sum decomposition of a stable `ℤ`-submodule.

Nothing about a stable subgroup makes this automatic: the projector onto a weight space is a Lagrange interpolation polynomial in the Cartan operator, with rational coefficients, so it has no reason to preserve an integral structure. The proof instead builds a genuine projector *inside* the form. The Kostant form contains all the binomial coefficients `(h j - a choose k)` of the integer translates of a designated Cartan vector, already available on `main` as `ringChoose_ι_sub_intCast_mem_kostantForm`; those act on a vector of weight `a + i` by the ordinary binomial coefficient `(i choose k)`; and Newton's forward-difference formula writes any prescribed integer values on `i = 0, …, N` as an integral combination of them. Taking the values to be the indicator of one weight gives the separating element, `TauCeti.UniversalEnvelopingAlgebra.exists_mem_kostantForm_forall_apply_eq`. The joint statement then follows by grouping summands according to their value at a Cartan index where two weights differ, and inducting on the (strictly shrinking) set of weights involved.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, whose second and third items are "**Pinnings.** A pinning `(G, T, B, {X_α})` of a split reductive group scheme: the torus, a Borel containing it, and a choice of root vector for each simple root" and "**The Chevalley--Demazure construction** … via a Chevalley basis and the Kostant `ℤ`-form of the enveloping algebra". The split maximal torus of that pinning is precisely what acts by a character on each weight component of the admissible lattice, so the lattice has to be known to *be* the direct sum of those components before the torus can be constructed rather than asserted; likewise the ordered weight basis in which the Chevalley group is written in coordinates. What remains on that milestone after this PR: the torus itself and the assembled pinned group scheme with its Borel, integral PBW and the finite free admissible lattice (in flight in #3053 and #3061), base change with pinning compatibility, the pinned isomorphism theorem, and the characteristic two and three special isogenies.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

The dependency edge is the one `CFSGStatement` declares. Its milestone **L0, "pinned ambient groups"**, produces `ValidLieTypeIndex.AmbientGroup` and states that it consumes "the pinned Chevalley--Demazure group scheme over `ℤ` (reductive groups Layer 9)" and "base change to the prime field and its algebraic closure (Layer 9)", consuming them rather than restating them. `CFSGStatement` has no unclaimed local step: `I0` and the twenty-six `S1` sporadic presentations are complete on `main` with their dispatcher, `A0` and `L1`--`L3` all wait on `L0`, and the root-systems Layer 6 input `DynkinType.simplyConnectedRootDatum` landed in #3485. So the whole remaining critical path runs through this Layer 9 lane.

This was the most effective current step because the Kostant root-subgroup lane is otherwise crowded — `kostantRootSubgroupPoints` with its naturality, matrix coordinates, comodule point representation, scheme representability (#3463) and the Chevalley commutator relations (#3490, #3505, #3513) are all landed or in flight — while the *torus* side of the pinning had no support at all, and its missing prerequisite was exactly this integrality statement about weight components. `ringChoose_ι_sub_intCast_mem_kostantForm` sat unused on `main`; this PR is its first consumer.

Add `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/WeightDecomposition.lean` (260 lines) and `TauCeti/LinearAlgebra/Eigenspace/Binomial.lean` (94 lines), and extend `TauCeti/RingTheory/Binomial.lean` by 41 lines, to 461 total.

The extension to `TauCeti/RingTheory/Binomial.lean` is the integrality half of Newton interpolation, `TauCeti.exists_forall_sum_mul_choose_eq`: the matrix `(j choose k)` is lower unitriangular, so the coefficients are solved for one at a time. That belongs beside the existing results in that file, which are all about which combinations of binomial coefficients stay integral. `TauCeti/LinearAlgebra/Eigenspace/Binomial.lean` records that `Ring.choose f n` acts on an eigenvector of `f` by `Ring.choose μ n`, proved through Mathlib's `Ring.descPochhammer_eq_factorial_smul_choose` and cancellation of `n !` in a torsion-free module; `TauCeti.Sl2Std.ringChoose_diag_apply` on `main` is the rank-one coordinate version of the same computation, and the module docstring says so.

No Mathlib infrastructure is vendored. The proofs consume Mathlib's `Ring.map_choose`, `Ring.choose_natCast`, `Ring.descPochhammer_eq_factorial_smul_choose`, `Module.End.eigenspaces_iSupIndep`, `Submodule.mem_iSup_iff_exists_dfinsupp'`, `Submodule.restrictScalars_mono`, `Finset.sum_fiberwise_of_maps_to` and `Finset.strongInduction`, together with Tau Ceti's existing `kostantForm` with `ringChoose_ι_sub_intCast_mem_kostantForm`, and `TauCeti.moduleNNRat` for the `BinomialRing` instances. The mathematics follows J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §27.1, and J. C. Jantzen, *Representations of Algebraic Groups*, II.1, both credited in the module documentation.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"admissible-lattice-weight-decomposition"}-->

🤖 Prepared with Claude Code
