### PR TITLE
feat: define pure Hodge structures

### DIFF
--- a/TauCeti/Geometry/Hodge/Structure.lean
+++ b/TauCeti/Geometry/Hodge/Structure.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Hodge.Conjugation
+
+/-!
+# Pure Hodge structures
+
+This file defines a pure Hodge structure of arbitrary integral weight on a complex vector space
+with a specified conjugation. The primary datum is a bounded decreasing filtration `F`; purity is
+the condition that `F p` and the conjugate of `F (n + 1 - p)` are complementary for every `p`.
+
+Keeping the ambient conjugation as a parameter gives one definition for both integral and rational
+Hodge structures. `TauCeti.Hodge.HodgeStructure` specializes it to an abstract complexification of
+an integral module using the canonical lattice-induced conjugation. Finiteness and freeness of a
+lattice are imposed by the arithmetic results that use them, rather than being redundant parameters
+of this abbreviation.
+
+The opposed-filtration convention follows Deligne, *Théorie de Hodge II*, §1.2.1. It is the
+convention fixed by the Hodge structures roadmap and by the `#mathlib4` discussion
+*Complexifications with a view towards Hodge theory* involving Johan Commelin, Andrew Yang, Kevin
+Buzzard, and Joël Riou.
+
+## Main declarations
+
+* `TauCeti.Hodge.HodgeStructureOn`: a bounded `n`-opposed decreasing filtration on a complex
+  vector space with conjugation.
+* `TauCeti.Hodge.HodgeStructure`: the specialization to the canonical conjugation of an integral
+  complexification.
+* `TauCeti.Hodge.HodgeStructureOn.piece`: the Hodge component `H^{p,n-p}`.
+* `TauCeti.Hodge.HodgeStructureOn.conj_piece`: conjugation exchanges `H^{p,n-p}` and
+  `H^{n-p,p}`.
+* `TauCeti.Hodge.HodgeStructureOn.IsEffective`: the filtration is supported in bidegrees with
+  both indices nonnegative.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+universe u v
+
+/-- A pure Hodge structure of weight `n` on a complex vector space with conjugation `ω`.
+
+The decreasing filtration `F` is bounded and `n`-opposed to its conjugate: for every `p`,
+`F p` is complementary to the conjugate of `F (n + 1 - p)`. -/
+@[ext]
+structure HodgeStructureOn (W : Type u) [AddCommGroup W] [Module ℂ W]
+    (ω : Conjugation W) (n : ℤ) where
+  /-- The decreasing Hodge filtration. -/
+  F : ℤ → Submodule ℂ W
+  /-- The Hodge filtration is decreasing. -/
+  F_antitone : Antitone F
+  /-- The filtration is exhaustive: some step is the whole space. -/
+  F_top : ∃ p, F p = ⊤
+  /-- The filtration is separated: some step is zero. -/
+  F_bot : ∃ p, F p = ⊥
+  /-- The filtration is opposed to its conjugate in weight `n`. -/
+  opposed : ∀ p, IsCompl (F p) ((F (n + 1 - p)).map ω.toEquiv.toLinearMap)
+
+/-- A pure integral Hodge structure expressed in an arbitrary abstract complexification. Its
+conjugation is induced canonically by the integral module. Arithmetic results impose finite
+freeness on that module when they need it. -/
+abbrev HodgeStructure {V : Type u} {Vℂ : Type v} [AddCommGroup V]
+    [AddCommGroup Vℂ] [Module ℂ Vℂ] {ιℂ : V →ₗ[ℤ] Vℂ}
+    (hℂ : IsBaseChange ℂ ιℂ) (n : ℤ) :=
+  HodgeStructureOn Vℂ (latticeConjugation hℂ) n
+
+namespace HodgeStructureOn
+
+variable {W : Type u} [AddCommGroup W] [Module ℂ W]
+variable {ω : Conjugation W} {n : ℤ}
+
+/-- The conjugate of the `p`-th step of the Hodge filtration. -/
+noncomputable def conjF (hs : HodgeStructureOn W ω n) (p : ℤ) : Submodule ℂ W :=
+  (hs.F p).map ω.toEquiv.toLinearMap
+
+/-- The conjugate filtration step is the image under the specified conjugation. -/
+theorem conjF_def (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    hs.conjF p = (hs.F p).map ω.toEquiv.toLinearMap :=
+  (rfl)
+
+/-- Conjugating a filtration step twice recovers that step. -/
+@[simp]
+theorem conjF_conjF (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    (hs.conjF p).map ω.toEquiv.toLinearMap = hs.F p := by
+  exact ω.map_map_eq_self (hs.F p)
+
+/-- Opposedness expressed using `conjF`. -/
+theorem isCompl_F_conjF (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    IsCompl (hs.F p) (hs.conjF (n + 1 - p)) := by
+  exact hs.opposed p
+
+/-- At every index below a top step, the decreasing filtration is also the whole space. -/
+theorem F_eq_top_of_le (hs : HodgeStructureOn W ω n) {p q : ℤ}
+    (hq : hs.F q = ⊤) (hpq : p ≤ q) : hs.F p = ⊤ := by
+  apply top_unique
+  rw [← hq]
+  exact hs.F_antitone hpq
+
+/-- At every index above a bottom step, the decreasing filtration is also zero. -/
+theorem F_eq_bot_of_le (hs : HodgeStructureOn W ω n) {p q : ℤ}
+    (hp : hs.F p = ⊥) (hpq : p ≤ q) : hs.F q = ⊥ := by
+  apply bot_unique
+  rw [← hp]
+  exact hs.F_antitone hpq
+
+/-- Exhaustiveness holds uniformly below a suitable filtration index. -/
+theorem exists_forall_le_F_eq_top (hs : HodgeStructureOn W ω n) :
+    ∃ q, ∀ p ≤ q, hs.F p = ⊤ := by
+  obtain ⟨q, hq⟩ := hs.F_top
+  exact ⟨q, fun _ hpq ↦ hs.F_eq_top_of_le hq hpq⟩
+
+/-- Separatedness holds uniformly above a suitable filtration index. -/
+theorem exists_forall_F_eq_bot_of_le (hs : HodgeStructureOn W ω n) :
+    ∃ p, ∀ q, p ≤ q → hs.F q = ⊥ := by
+  obtain ⟨p, hp⟩ := hs.F_bot
+  exact ⟨p, fun _ hpq ↦ hs.F_eq_bot_of_le hp hpq⟩
+
+/-- The Hodge component `H^{p,n-p} = F^p ∩ overline{F^{n-p}}`. -/
+noncomputable def piece (hs : HodgeStructureOn W ω n) (p : ℤ) : Submodule ℂ W :=
+  hs.F p ⊓ hs.conjF (n - p)
+
+/-- The `p`-th Hodge component is the intersection of `F p` with the conjugate of
+`F (n - p)`. -/
+theorem piece_def (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    hs.piece p = hs.F p ⊓ hs.conjF (n - p) :=
+  (rfl)
+
+/-- A Hodge component lies in its corresponding filtration step. -/
+theorem piece_le_F (hs : HodgeStructureOn W ω n) (p : ℤ) : hs.piece p ≤ hs.F p :=
+  inf_le_left
+
+/-- A Hodge component lies in the conjugate filtration step of complementary index. -/
+theorem piece_le_conjF (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    hs.piece p ≤ hs.conjF (n - p) :=
+  inf_le_right
+
+/-- Conjugation exchanges the Hodge components `H^{p,n-p}` and `H^{n-p,p}`. -/
+@[simp]
+theorem conj_piece (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    (hs.piece p).map ω.toEquiv.toLinearMap = hs.piece (n - p) := by
+  rw [piece_def, Submodule.map_inf _ ω.toEquiv.injective, conjF_def, ω.map_map_eq_self,
+    piece_def, conjF_def, sub_sub_cancel, inf_comm]
+
+/-- A weight-`n` Hodge structure is effective when its Hodge filtration begins at `F 0 = ⊤`
+and ends at `F (n + 1) = ⊥`. Equivalently, its Hodge components can occur only when both
+bidegrees are nonnegative. -/
+def IsEffective (hs : HodgeStructureOn W ω n) : Prop :=
+  hs.F 0 = ⊤ ∧ hs.F (n + 1) = ⊥
+
+/-- Effectivity is exactly the conjunction of the two endpoint conditions. -/
+theorem isEffective_iff (hs : HodgeStructureOn W ω n) :
+    hs.IsEffective ↔ hs.F 0 = ⊤ ∧ hs.F (n + 1) = ⊥ :=
+  Iff.rfl
+
+/-- An effective Hodge filtration is the whole space in every nonpositive degree. -/
+theorem IsEffective.F_eq_top_of_nonpos {hs : HodgeStructureOn W ω n}
+    (h : hs.IsEffective) {p : ℤ} (hp : p ≤ 0) : hs.F p = ⊤ :=
+  hs.F_eq_top_of_le h.1 hp
+
+/-- An effective Hodge filtration vanishes in every degree strictly above its weight. -/
+theorem IsEffective.F_eq_bot_of_weight_lt {hs : HodgeStructureOn W ω n}
+    (h : hs.IsEffective) {p : ℤ} (hp : n < p) : hs.F p = ⊥ := by
+  exact hs.F_eq_bot_of_le h.2 (by omega)
+
+/-- In an effective Hodge structure, a component with negative first index vanishes. -/
+theorem IsEffective.piece_eq_bot_of_neg {hs : HodgeStructureOn W ω n}
+    (h : hs.IsEffective) {p : ℤ} (hp : p < 0) : hs.piece p = ⊥ := by
+  rw [piece_def, h.F_eq_top_of_nonpos hp.le, top_inf_eq]
+  rw [conjF_def, h.F_eq_bot_of_weight_lt (by omega), Submodule.map_bot]
+
+/-- In an effective Hodge structure, a component with first index above the weight vanishes. -/
+theorem IsEffective.piece_eq_bot_of_weight_lt {hs : HodgeStructureOn W ω n}
+    (h : hs.IsEffective) {p : ℤ} (hp : n < p) : hs.piece p = ⊥ := by
+  rw [piece_def, h.F_eq_bot_of_weight_lt hp, bot_inf_eq]
+
+end HodgeStructureOn
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Structure.lean
+++ b/TauCeti/Geometry/Hodge/Structure.lean
@@ -175,6 +175,7 @@ def IsEffective (hs : HodgeStructureOn W ω n) : Prop :=
   hs.F 0 = ⊤
 
 /-- Effectivity is the condition that the Hodge filtration begins at the whole space. -/
+@[simp]
 theorem isEffective_iff (hs : HodgeStructureOn W ω n) :
     hs.IsEffective ↔ hs.F 0 = ⊤ :=
   Iff.rfl
@@ -182,7 +183,7 @@ theorem isEffective_iff (hs : HodgeStructureOn W ω n) :
 /-- An effective Hodge filtration vanishes immediately above its weight. -/
 theorem IsEffective.F_eq_bot {hs : HodgeStructureOn W ω n} (h : hs.IsEffective) :
     hs.F (n + 1) = ⊥ := by
-  change hs.F 0 = ⊤ at h
+  rw [hs.isEffective_iff] at h
   have hconj : hs.conjF (n + 1) = ⊥ := by
     apply eq_bot_of_top_isCompl
     simpa only [h, sub_zero] using hs.isCompl_F_conjF 0
@@ -198,7 +199,7 @@ theorem isEffective_iff_F_eq_bot (hs : HodgeStructureOn W ω n) :
   constructor
   · exact IsEffective.F_eq_bot
   · intro h
-    change hs.F 0 = ⊤
+    rw [hs.isEffective_iff]
     apply eq_top_of_isCompl_bot
     simpa only [conjF_def, h, Submodule.map_bot, sub_zero] using hs.isCompl_F_conjF 0
 

--- a/TauCeti/Geometry/Hodge/Structure.lean
+++ b/TauCeti/Geometry/Hodge/Structure.lean
@@ -56,14 +56,11 @@ structure HodgeStructureOn (W : Type u) [AddCommGroup W] [Module ℂ W]
   F_antitone : Antitone F
   /-- The filtration is exhaustive: some step is the whole space. -/
   F_top : ∃ p, F p = ⊤
-  /-- The filtration is separated: some step is zero. -/
-  F_bot : ∃ p, F p = ⊥
   /-- The filtration is opposed to its conjugate in weight `n`. -/
   opposed : ∀ p, IsCompl (F p) ((F (n + 1 - p)).map ω.toEquiv.toLinearMap)
 
-/-- A pure integral Hodge structure expressed in an arbitrary abstract complexification. Its
-conjugation is induced canonically by the integral module. Arithmetic results impose finite
-freeness on that module when they need it. -/
+/-- The specialization of a pure Hodge structure to an abelian group with an arbitrary abstract
+complexification. Its conjugation is induced canonically by the abelian group. -/
 abbrev HodgeStructure {V : Type u} {Vℂ : Type v} [AddCommGroup V]
     [AddCommGroup Vℂ] [Module ℂ Vℂ] {ιℂ : V →ₗ[ℤ] Vℂ}
     (hℂ : IsBaseChange ℂ ιℂ) (n : ℤ) :=
@@ -83,6 +80,12 @@ theorem conjF_def (hs : HodgeStructureOn W ω n) (p : ℤ) :
     hs.conjF p = (hs.F p).map ω.toEquiv.toLinearMap :=
   (rfl)
 
+/-- Membership in a conjugate filtration step is detected by applying the conjugation. -/
+@[simp]
+theorem mem_conjF_iff (hs : HodgeStructureOn W ω n) (p : ℤ) (x : W) :
+    x ∈ hs.conjF p ↔ ω.toEquiv x ∈ hs.F p := by
+  simp [conjF, ω.toEquiv_symm]
+
 /-- Conjugating a filtration step twice recovers that step. -/
 @[simp]
 theorem conjF_conjF (hs : HodgeStructureOn W ω n) (p : ℤ) :
@@ -93,6 +96,19 @@ theorem conjF_conjF (hs : HodgeStructureOn W ω n) (p : ℤ) :
 theorem isCompl_F_conjF (hs : HodgeStructureOn W ω n) (p : ℤ) :
     IsCompl (hs.F p) (hs.conjF (n + 1 - p)) := by
   exact hs.opposed p
+
+/-- The Hodge filtration is separated: some step is zero. -/
+theorem F_bot (hs : HodgeStructureOn W ω n) : ∃ p, hs.F p = ⊥ := by
+  obtain ⟨q, hq⟩ := hs.F_top
+  have hconj : hs.conjF (n + 1 - q) = ⊥ := by
+    apply eq_bot_of_top_isCompl
+    simpa only [hq] using hs.isCompl_F_conjF q
+  refine ⟨n + 1 - q, ?_⟩
+  calc
+    hs.F (n + 1 - q) =
+        (hs.conjF (n + 1 - q)).map ω.toEquiv.toLinearMap :=
+      (hs.conjF_conjF (n + 1 - q)).symm
+    _ = ⊥ := by rw [hconj, Submodule.map_bot]
 
 /-- At every index below a top step, the decreasing filtration is also the whole space. -/
 theorem F_eq_top_of_le (hs : HodgeStructureOn W ω n) {p q : ℤ}
@@ -130,6 +146,12 @@ theorem piece_def (hs : HodgeStructureOn W ω n) (p : ℤ) :
     hs.piece p = hs.F p ⊓ hs.conjF (n - p) :=
   (rfl)
 
+/-- Membership in a Hodge component is membership in both defining filtration steps. -/
+@[simp]
+theorem mem_piece_iff (hs : HodgeStructureOn W ω n) (p : ℤ) (x : W) :
+    x ∈ hs.piece p ↔ x ∈ hs.F p ∧ x ∈ hs.conjF (n - p) := by
+  simp only [piece_def, Submodule.mem_inf]
+
 /-- A Hodge component lies in its corresponding filtration step. -/
 theorem piece_le_F (hs : HodgeStructureOn W ω n) (p : ℤ) : hs.piece p ≤ hs.F p :=
   inf_le_left
@@ -146,26 +168,49 @@ theorem conj_piece (hs : HodgeStructureOn W ω n) (p : ℤ) :
   rw [piece_def, Submodule.map_inf _ ω.toEquiv.injective, conjF_def, ω.map_map_eq_self,
     piece_def, conjF_def, sub_sub_cancel, inf_comm]
 
-/-- A weight-`n` Hodge structure is effective when its Hodge filtration begins at `F 0 = ⊤`
-and ends at `F (n + 1) = ⊥`. Equivalently, its Hodge components can occur only when both
+/-- A weight-`n` Hodge structure is effective when its Hodge filtration begins at `F 0 = ⊤`.
+Equivalently, it ends at `F (n + 1) = ⊥`, and its Hodge components can occur only when both
 bidegrees are nonnegative. -/
 def IsEffective (hs : HodgeStructureOn W ω n) : Prop :=
-  hs.F 0 = ⊤ ∧ hs.F (n + 1) = ⊥
+  hs.F 0 = ⊤
 
-/-- Effectivity is exactly the conjunction of the two endpoint conditions. -/
+/-- Effectivity is the condition that the Hodge filtration begins at the whole space. -/
 theorem isEffective_iff (hs : HodgeStructureOn W ω n) :
-    hs.IsEffective ↔ hs.F 0 = ⊤ ∧ hs.F (n + 1) = ⊥ :=
+    hs.IsEffective ↔ hs.F 0 = ⊤ :=
   Iff.rfl
+
+/-- An effective Hodge filtration vanishes immediately above its weight. -/
+theorem IsEffective.F_eq_bot {hs : HodgeStructureOn W ω n} (h : hs.IsEffective) :
+    hs.F (n + 1) = ⊥ := by
+  change hs.F 0 = ⊤ at h
+  have hconj : hs.conjF (n + 1) = ⊥ := by
+    apply eq_bot_of_top_isCompl
+    simpa only [h, sub_zero] using hs.isCompl_F_conjF 0
+  calc
+    hs.F (n + 1) = (hs.conjF (n + 1)).map ω.toEquiv.toLinearMap :=
+      (hs.conjF_conjF (n + 1)).symm
+    _ = ⊥ := by rw [hconj, Submodule.map_bot]
+
+/-- Effectivity is equivalently the condition that the Hodge filtration vanishes immediately
+above its weight. -/
+theorem isEffective_iff_F_eq_bot (hs : HodgeStructureOn W ω n) :
+    hs.IsEffective ↔ hs.F (n + 1) = ⊥ := by
+  constructor
+  · exact IsEffective.F_eq_bot
+  · intro h
+    change hs.F 0 = ⊤
+    apply eq_top_of_isCompl_bot
+    simpa only [conjF_def, h, Submodule.map_bot, sub_zero] using hs.isCompl_F_conjF 0
 
 /-- An effective Hodge filtration is the whole space in every nonpositive degree. -/
 theorem IsEffective.F_eq_top_of_nonpos {hs : HodgeStructureOn W ω n}
     (h : hs.IsEffective) {p : ℤ} (hp : p ≤ 0) : hs.F p = ⊤ :=
-  hs.F_eq_top_of_le h.1 hp
+  hs.F_eq_top_of_le h hp
 
 /-- An effective Hodge filtration vanishes in every degree strictly above its weight. -/
 theorem IsEffective.F_eq_bot_of_weight_lt {hs : HodgeStructureOn W ω n}
     (h : hs.IsEffective) {p : ℤ} (hp : n < p) : hs.F p = ⊥ := by
-  exact hs.F_eq_bot_of_le h.2 (by omega)
+  exact hs.F_eq_bot_of_le h.F_eq_bot (by omega)
 
 /-- In an effective Hodge structure, a component with negative first index vanishes. -/
 theorem IsEffective.piece_eq_bot_of_neg {hs : HodgeStructureOn W ω n}

--- a/TauCeti/Geometry/Hodge/Tate.lean
+++ b/TauCeti/Geometry/Hodge/Tate.lean
@@ -42,11 +42,11 @@ theorem isBaseChange_tateLatticeMap : IsBaseChange ℂ tateLatticeMap :=
   IsBaseChange.linearMap ℤ ℂ
 
 /-- The Hodge filtration of `ℤ(m)`: the whole complex line through degree `-m`, and zero above. -/
-def tateFiltration (m p : ℤ) : Submodule ℂ ℂ :=
+private def tateFiltration (m p : ℤ) : Submodule ℂ ℂ :=
   if p ≤ -m then ⊤ else ⊥
 
 /-- The Tate filtration is decreasing. -/
-theorem antitone_tateFiltration (m : ℤ) : Antitone (tateFiltration m) := by
+private theorem antitone_tateFiltration (m : ℤ) : Antitone (tateFiltration m) := by
   intro p q hpq
   by_cases hq : q ≤ -m
   · have hp : p ≤ -m := hpq.trans hq
@@ -54,7 +54,7 @@ theorem antitone_tateFiltration (m : ℤ) : Antitone (tateFiltration m) := by
   · simp [tateFiltration, hq]
 
 /-- The filtration of `ℤ(m)` is opposed to its conjugate in weight `-2m`. -/
-theorem isCompl_tateFiltration (m p : ℤ) :
+private theorem isCompl_tateFiltration (m p : ℤ) :
     IsCompl (tateFiltration m p)
       ((tateFiltration m (-2 * m + 1 - p)).map
         (latticeConjugation isBaseChange_tateLatticeMap).toEquiv.toLinearMap) := by
@@ -86,7 +86,6 @@ noncomputable def tate (m : ℤ) :
   F := tateFiltration m
   F_antitone := antitone_tateFiltration m
   F_top := ⟨-m, by simp [tateFiltration]⟩
-  F_bot := ⟨-m + 1, by simp [tateFiltration]⟩
   opposed := isCompl_tateFiltration m
 
 /-- The Hodge filtration of `ℤ(m)` is the whole line exactly through degree `-m`. -/
@@ -99,14 +98,7 @@ theorem tate_F (m p : ℤ) :
 @[simp]
 theorem tate_isEffective_iff (m : ℤ) : (tate m).IsEffective ↔ m ≤ 0 := by
   rw [HodgeStructureOn.isEffective_iff]
-  constructor
-  · intro h
-    simpa [tate_F] using h.1
-  · intro hm
-    constructor
-    · simpa [tate_F] using hm
-    · have hineq : 2 * m < 1 + m := by omega
-      simpa [tate_F] using hineq
+  simp [tate_F]
 
 /-- The only nonzero Hodge component of `ℤ(m)` is `H^{-m,-m}`. -/
 @[simp]

--- a/TauCeti/Geometry/Hodge/Tate.lean
+++ b/TauCeti/Geometry/Hodge/Tate.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Hodge.Structure
+public import Mathlib.LinearAlgebra.Dimension.Finite
+
+/-!
+# Tate Hodge structures
+
+The Tate structure `ℤ(m)` is the rank-one pure Hodge structure of weight `-2m` and type
+`(-m,-m)`. Its complexification is `ℂ`, with the integral lattice embedded by the usual map
+`ℤ → ℂ`; its decreasing filtration is the whole line through degree `-m` and zero above it.
+
+This is the first concrete nonzero inhabitant of `TauCeti.Hodge.HodgeStructure`. Besides fixing the
+weight and filtration-shift conventions needed by later Tate twists, it verifies directly that the
+opposed-filtration definition has the intended rank-one objects.
+
+The convention follows the Hodge structures roadmap and standard Hodge-theory notation; see
+Voisin, *Hodge Theory and Complex Algebraic Geometry I*, §7.
+
+## Main declarations
+
+* `TauCeti.Hodge.tate`: the Tate Hodge structure `ℤ(m)` of weight `-2m`.
+* `TauCeti.Hodge.tate_F`: its filtration is `⊤` exactly in degrees at most `-m`.
+* `TauCeti.Hodge.tate_piece`: its only nonzero Hodge component has bidegree `(-m,-m)`.
+* `TauCeti.Hodge.finrank_tate_piece`: its Hodge number there is one and all others are zero.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+/-- The integral lattice map `ℤ → ℂ` used by the Tate Hodge structure. -/
+abbrev tateLatticeMap : ℤ →ₗ[ℤ] ℂ :=
+  Algebra.linearMap ℤ ℂ
+
+/-- The usual inclusion `ℤ → ℂ` exhibits `ℂ` as the complexification of the rank-one lattice. -/
+theorem isBaseChange_tateLatticeMap : IsBaseChange ℂ tateLatticeMap :=
+  IsBaseChange.linearMap ℤ ℂ
+
+/-- The Hodge filtration of `ℤ(m)`: the whole complex line through degree `-m`, and zero above. -/
+def tateFiltration (m p : ℤ) : Submodule ℂ ℂ :=
+  if p ≤ -m then ⊤ else ⊥
+
+/-- The Tate filtration is decreasing. -/
+theorem antitone_tateFiltration (m : ℤ) : Antitone (tateFiltration m) := by
+  intro p q hpq
+  by_cases hq : q ≤ -m
+  · have hp : p ≤ -m := hpq.trans hq
+    simp [tateFiltration, hp, hq]
+  · simp [tateFiltration, hq]
+
+/-- The filtration of `ℤ(m)` is opposed to its conjugate in weight `-2m`. -/
+theorem isCompl_tateFiltration (m p : ℤ) :
+    IsCompl (tateFiltration m p)
+      ((tateFiltration m (-2 * m + 1 - p)).map
+        (latticeConjugation isBaseChange_tateLatticeMap).toEquiv.toLinearMap) := by
+  by_cases hp : p ≤ -m
+  · have hq : ¬ -2 * m + 1 - p ≤ -m := by omega
+    have hleft : tateFiltration m p = (⊤ : Submodule ℂ ℂ) := by
+      simp [tateFiltration, hp]
+    have hright : tateFiltration m (-2 * m + 1 - p) = (⊥ : Submodule ℂ ℂ) := by
+      rw [tateFiltration]
+      split
+      · contradiction
+      · rfl
+    rw [hleft, hright, Submodule.map_bot]
+    exact isCompl_top_bot
+  · have hq : -2 * m + 1 - p ≤ -m := by omega
+    have hleft : tateFiltration m p = (⊥ : Submodule ℂ ℂ) := by
+      simp [tateFiltration, hp]
+    have hright : tateFiltration m (-2 * m + 1 - p) = (⊤ : Submodule ℂ ℂ) := by
+      rw [tateFiltration]
+      split
+      · rfl
+      · contradiction
+    rw [hleft, hright]
+    simpa using (isCompl_bot_top : IsCompl (⊥ : Submodule ℂ ℂ) ⊤)
+
+/-- The Tate Hodge structure `ℤ(m)`, of weight `-2m` and Hodge type `(-m,-m)`. -/
+noncomputable def tate (m : ℤ) :
+    HodgeStructure (V := ℤ) (Vℂ := ℂ) isBaseChange_tateLatticeMap (-2 * m) where
+  F := tateFiltration m
+  F_antitone := antitone_tateFiltration m
+  F_top := ⟨-m, by simp [tateFiltration]⟩
+  F_bot := ⟨-m + 1, by simp [tateFiltration]⟩
+  opposed := isCompl_tateFiltration m
+
+/-- The Hodge filtration of `ℤ(m)` is the whole line exactly through degree `-m`. -/
+@[simp]
+theorem tate_F (m p : ℤ) :
+    (tate m).F p = if p ≤ -m then (⊤ : Submodule ℂ ℂ) else ⊥ :=
+  (rfl)
+
+/-- The Tate Hodge structure is effective exactly when `m ≤ 0`. -/
+@[simp]
+theorem tate_isEffective_iff (m : ℤ) : (tate m).IsEffective ↔ m ≤ 0 := by
+  rw [HodgeStructureOn.isEffective_iff]
+  constructor
+  · intro h
+    simpa [tate_F] using h.1
+  · intro hm
+    constructor
+    · simpa [tate_F] using hm
+    · have hineq : 2 * m < 1 + m := by omega
+      simpa [tate_F] using hineq
+
+/-- The only nonzero Hodge component of `ℤ(m)` is `H^{-m,-m}`. -/
+@[simp]
+theorem tate_piece (m p : ℤ) :
+    (tate m).piece p = if p = -m then (⊤ : Submodule ℂ ℂ) else ⊥ := by
+  rw [HodgeStructureOn.piece_def, HodgeStructureOn.conjF_def]
+  by_cases heq : p = -m
+  · subst p
+    simp [two_mul]
+  · by_cases hp : p ≤ -m
+    · have hq : ¬ -2 * m - p ≤ -m := by omega
+      have hleft : (tate m).F p = (⊤ : Submodule ℂ ℂ) := by simp [hp]
+      have hright : (tate m).F (-2 * m - p) = (⊥ : Submodule ℂ ℂ) := by
+        rw [tate_F]
+        split
+        · contradiction
+        · rfl
+      rw [hleft, hright, Submodule.map_bot, top_inf_eq]
+      simp [heq]
+    · have hleft : (tate m).F p = (⊥ : Submodule ℂ ℂ) := by simp [hp]
+      rw [hleft, bot_inf_eq]
+      simp [heq]
+
+/-- The Hodge number of `ℤ(m)` is one in bidegree `(-m,-m)` and zero elsewhere. -/
+@[simp]
+theorem finrank_tate_piece (m p : ℤ) :
+    Module.finrank ℂ ((tate m).piece p) = if p = -m then 1 else 0 := by
+  by_cases hp : p = -m
+  · have hpiece : (tate m).piece p = (⊤ : Submodule ℂ ℂ) := by
+      rw [tate_piece]
+      simp [hp]
+    rw [hpiece]
+    simp [hp]
+  · have hpiece : (tate m).piece p = (⊥ : Submodule ℂ ℂ) := by
+      rw [tate_piece]
+      simp [hp]
+    rw [hpiece]
+    simp [hp]
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Tate.lean
+++ b/TauCeti/Geometry/Hodge/Tate.lean
@@ -94,10 +94,9 @@ theorem tate_F (m p : ℤ) :
     (tate m).F p = if p ≤ -m then (⊤ : Submodule ℂ ℂ) else ⊥ :=
   (rfl)
 
-/-- The Tate Hodge structure is effective exactly when `m ≤ 0`. -/
-@[simp]
+/-- The Tate Hodge structure is effective exactly when `m ≤ 0`. This is not a `simp` lemma: with
+`HodgeStructureOn.isEffective_iff` tagged, `simp` already normalizes the left-hand side. -/
 theorem tate_isEffective_iff (m : ℤ) : (tate m).IsEffective ↔ m ≤ 0 := by
-  rw [HodgeStructureOn.isEffective_iff]
   simp [tate_F]
 
 /-- The only nonzero Hodge component of `ℤ(m)` is `H^{-m,-m}`. -/
@@ -126,16 +125,7 @@ theorem tate_piece (m p : ℤ) :
 @[simp]
 theorem finrank_tate_piece (m p : ℤ) :
     Module.finrank ℂ ((tate m).piece p) = if p = -m then 1 else 0 := by
-  by_cases hp : p = -m
-  · have hpiece : (tate m).piece p = (⊤ : Submodule ℂ ℂ) := by
-      rw [tate_piece]
-      simp [hp]
-    rw [hpiece]
-    simp [hp]
-  · have hpiece : (tate m).piece p = (⊥ : Submodule ℂ ℂ) := by
-      rw [tate_piece]
-      simp [hp]
-    rw [hpiece]
-    simp [hp]
+  rw [tate_piece, apply_ite (fun S : Submodule ℂ ℂ ↦ Module.finrank ℂ S)]
+  simp
 
 end TauCeti.Hodge


### PR DESCRIPTION
This PR defines the one pure-Hodge object required by `TauCetiRoadmap/HodgeStructures/README.md`, Core definitions target “One pure-Hodge object, parametric in the conjugation,” specializes it to the canonical conjugation on an abstract integral complexification, and supplies the roadmap’s blocking rank-one Tate structure `ℤ(m)`. It advances milestone L0, “Pure Hodge structures; the Hodge decomposition.” After this PR, L0 still needs the proof `DirectSum.IsInternal hs.piece`, followed by its morphism, tensor, dual, and Tate-twist companions.

Represent a weight-`n` pure Hodge structure as a bounded antitone filtration `F` satisfying Deligne’s opposedness condition `IsCompl (F p) (conj F (n + 1 - p))`. Define the pieces `H^{p,n-p}`, prove conjugation exchanges the complementary pieces, expose uniform boundedness and effectivity APIs, and derive the expected vanishing outside the effective range. Keep `HodgeStructureOn` at the natural complex-vector-space level and make `HodgeStructure` an abbreviation using `latticeConjugation`; finite-freeness remains a hypothesis of arithmetic consumers rather than an unused parameter of the alias.

Construct `tate m` on the rank-one lattice `ℤ → ℂ`, prove it has weight `-2m`, filtration cutoff `-m`, unique nonzero piece `H^{-m,-m}`, and Hodge number one there. The calculation also records the convention-sensitive fact that `ℤ(m)` is effective exactly when `m ≤ 0`.

The preferred CFSGStatement roadmap has no viable unclaimed main-ready step: I0 and the sporadic lane are complete, `classificationStatement_of_zero` is in flight, and L0 depends on ReductiveGroups Layer 9, whose current PBW/integral-form, weight-decomposition/torus, point-group/Frobenius, and remaining commutator fronts are already covered by open PRs. HodgeStructures therefore provides the next coherent unclaimed critical-path unit rather than duplicating that work.

Reuse Mathlib’s `IsBaseChange.linearMap`, semilinear submodule-map API, `IsCompl`, and finite-dimensional rank calculations; no Mathlib infrastructure is vendored. The opposed-filtration convention follows Deligne, *Théorie de Hodge II*, §1.2.1, and the complexification design follows the `#mathlib4` discussion *Complexifications with a view towards Hodge theory* involving Johan Commelin, Andrew Yang, Kevin Buzzard, and Joël Riou, as credited in the module documentation. The Tate convention follows Voisin, *Hodge Theory and Complex Algebraic Geometry I*, §7.

Add `TauCeti/Geometry/Hodge/Structure.lean` (183 lines) and `TauCeti/Geometry/Hodge/Tate.lean` (149 lines), 332 lines total.

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"hodge-structure-on"}-->

🤖 Prepared with Codex
