### PR TITLE
feat: prove the Co1 relators are cyclically reduced

### DIFF
--- a/TauCeti/GroupTheory/Presentation/Relator.lean
+++ b/TauCeti/GroupTheory/Presentation/Relator.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Group.Commutator
 public import Mathlib.GroupTheory.FreeGroup.Basic
+public import Mathlib.GroupTheory.FreeGroup.CyclicallyReduced
 
 /-!
 # Auditable relator expressions
@@ -119,6 +120,18 @@ theorem toWord_mul {α : Type*} (r s : Relator α) :
 theorem toWord_pow {α : Type*} (r : Relator α) (n : ℕ) :
     (Relator.pow r n).toWord = (List.replicate n r.toWord).flatten := by
   rw [toWord]
+
+/-- A power of a relator compiles to a cyclically reduced word as soon as its base does.
+
+Published relators are often a single large power, and checking the base is much cheaper than
+checking the expansion: the base of the longest `TauCeti.Sporadic.co1Presentation` relator has
+nine letters where its expansion has three hundred and fifty-one.
+`TauCeti.isCyclicallyReduced_toWord_coxeterRelator` is the case of a base with two letters. -/
+theorem isCyclicallyReduced_toWord_pow {α : Type*} {r : Relator α}
+    (h : FreeGroup.IsCyclicallyReduced r.toWord) (n : ℕ) :
+    FreeGroup.IsCyclicallyReduced (Relator.pow r n).toWord := by
+  rw [toWord_pow]
+  exact h.flatten_replicate n
 
 /-- Compilation of a commutator. -/
 @[simp]

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/One.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/One.lean
@@ -176,4 +176,49 @@ theorem co1Presentation_totalLength : co1Presentation.totalLength = 611 := by
     List.sum_nil]
   norm_num
 
+/-- The involution and labeled-edge relators compile to cyclically reduced words. -/
+private theorem isCyclicallyReduced_toWord_of_mem_co1NodeAndEdgeRelators :
+    ∀ r ∈ co1NodeAndEdgeRelators, FreeGroup.IsCyclicallyReduced (Relator.toWord r) := by
+  simp [co1NodeAndEdgeRelators, FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]
+
+/-- The omitted-edge relators compile to cyclically reduced words. -/
+private theorem isCyclicallyReduced_toWord_of_mem_co1NonedgeRelators :
+    ∀ r ∈ co1NonedgeRelators, FreeGroup.IsCyclicallyReduced (Relator.toWord r) := by
+  simp [co1NonedgeRelators, FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]
+
+/-- The relators taken from `presdef[3]` compile to cyclically reduced words.
+
+The last of them is a thirty-ninth power, whose expansion has three hundred and fifty-one letters;
+it is handled by `TauCeti.Relator.isCyclicallyReduced_toWord_pow`, which reduces the check to its
+nine-letter base. Expanding it instead exhausts the elaborator. -/
+private theorem isCyclicallyReduced_toWord_of_mem_co1AdditionalRelators :
+    ∀ r ∈ co1AdditionalRelators, FreeGroup.IsCyclicallyReduced (Relator.toWord r) := by
+  intro r hr
+  simp only [co1AdditionalRelators, List.mem_cons, List.not_mem_nil, or_false] at hr
+  rcases hr with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+  on_goal 9 =>
+    exact Relator.isCyclicallyReduced_toWord_pow
+      (by simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]) 39
+  all_goals simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced, FreeGroup.invRev]
+
+/-- Every transcribed `Co₁` relator expression compiles to a cyclically reduced word. -/
+private theorem isCyclicallyReduced_toWord_of_mem_co1Transcribed :
+    ∀ r ∈ co1Presentation.transcribed, FreeGroup.IsCyclicallyReduced (Relator.toWord r) := by
+  intro r hr
+  rcases List.mem_append.mp hr with h | h
+  · rcases List.mem_append.mp h with h | h
+    · exact isCyclicallyReduced_toWord_of_mem_co1NodeAndEdgeRelators r h
+    · exact isCyclicallyReduced_toWord_of_mem_co1NonedgeRelators r h
+  · exact isCyclicallyReduced_toWord_of_mem_co1AdditionalRelators r h
+
+/-- Every compiled `Co₁` relator is cyclically reduced, so the letter count recorded by
+`TauCeti.Sporadic.co1Presentation_totalLength` is comparable with a published presentation length,
+which is measured after free and cyclic reduction of each relator. -/
+theorem co1Presentation_relatorsCyclicallyReduced :
+    co1Presentation.relatorsCyclicallyReduced := by
+  rw [GroupPresentation.relatorsCyclicallyReduced_iff, GroupPresentation.relators_def]
+  intro w hw
+  obtain ⟨r, hr, rfl⟩ := List.mem_map.mp hw
+  exact isCyclicallyReduced_toWord_of_mem_co1Transcribed r hr
+
 end TauCeti.Sporadic

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/One.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/One.lean
@@ -188,18 +188,21 @@ private theorem isCyclicallyReduced_toWord_of_mem_co1NonedgeRelators :
 
 /-- The relators taken from `presdef[3]` compile to cyclically reduced words.
 
-The last of them is a thirty-ninth power, whose expansion has three hundred and fifty-one letters;
-it is handled by `TauCeti.Relator.isCyclicallyReduced_toWord_pow`, which reduces the check to its
-nine-letter base. Expanding it instead exhausts the elaborator. -/
+Each alternative is dispatched by the shape of its relator, not by goal position: a relator that
+is a power is checked on its base through `TauCeti.Relator.isCyclicallyReduced_toWord_pow`, and
+every other relator is checked by direct computation, so inserting, removing, or reordering
+relators cannot redirect a branch. The power route is also what makes the last relator tractable
+at all: it is a thirty-ninth power whose expansion has three hundred and fifty-one of the
+presentation's letters, and expanding it exhausts the elaborator. -/
 private theorem isCyclicallyReduced_toWord_of_mem_co1AdditionalRelators :
     ∀ r ∈ co1AdditionalRelators, FreeGroup.IsCyclicallyReduced (Relator.toWord r) := by
   intro r hr
   simp only [co1AdditionalRelators, List.mem_cons, List.not_mem_nil, or_false] at hr
-  rcases hr with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
-  on_goal 9 =>
-    exact Relator.isCyclicallyReduced_toWord_pow
-      (by simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]) 39
-  all_goals simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced, FreeGroup.invRev]
+  rcases hr with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+  first
+  | exact Relator.isCyclicallyReduced_toWord_pow
+      (by simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced]) _
+  | simp [FreeGroup.IsCyclicallyReduced, FreeGroup.IsReduced, FreeGroup.invRev]
 
 /-- Every transcribed `Co₁` relator expression compiles to a cyclically reduced word. -/
 private theorem isCyclicallyReduced_toWord_of_mem_co1Transcribed :


### PR DESCRIPTION
`TauCeti.Sporadic.co1Presentation` records `co1Presentation_totalLength : co1Presentation.totalLength = 611`, but not that its compiled relators are cyclically reduced. The docstring of `TauCeti.GroupPresentation.totalLength` asks for exactly that pairing:

> Sources for finite presentations customarily publish this figure, usually calling it the length of the presentation, so comparing it with the transcribed data is a third decidable check on a transcription alongside the two counts of `TauCeti.GroupPresentation.matchesMetadata`. A published length is normally measured after free and cyclic reduction of each relator, so a row using it as a check should also record that its compiled words are reduced.

Co₁ is the only sporadic row that records a length without the accompanying reduction check; every other row records both or neither. Without it the comparison of `611` against the published figure rests on an unstated assumption, since a relator that is merely reduced can still be padded by a conjugation, and a padded transcription would have a larger letter count than the source reports.

Add `TauCeti.Sporadic.co1Presentation_relatorsCyclicallyReduced`, together with three private per-block lemmas mirroring the three parts of `co1Presentation.transcribed`.

The last relator of `presdef[3]` is `(a d e f c e f g h) ^ 39`, whose expansion has 351 of the presentation's 611 letters, and deciding or simplifying that expansion exhausts the elaborator. So this PR also adds the general lemma `TauCeti.Relator.isCyclicallyReduced_toWord_pow`: a power of a relator compiles to a cyclically reduced word as soon as its base does. Its proof is `Relator.toWord_pow` followed by Mathlib's `FreeGroup.IsCyclicallyReduced.flatten_replicate`, and it reduces the check on that relator to its nine-letter base. It is the general form of the existing `TauCeti.isCyclicallyReduced_toWord_coxeterRelator`, which is the case of a two-letter base, and it should serve any future row whose source publishes a single large power. That is the only new declaration outside the `Co₁` file; it needs `Mathlib.GroupTheory.FreeGroup.CyclicallyReduced`, which `TauCeti.GroupTheory.Presentation.Relator` did not previously import.

Nothing here asserts a property of the presented group: like the counts and the length, this is a check on the transcribed data only. The independent source-to-Lean read-through recorded in the row's `transcriptionNotes` remains an S1 review obligation.

Roadmap: CFSGStatement

🤖 Prepared with Claude Code
