### PR TITLE
feat: add the Weyl element of a Kostant root subgroup pair

### DIFF
--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -400,7 +400,6 @@ theorem weylUnit_conj_h (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNil
 
 /-- The Weyl element carries the raising element of the triple to the negated lowering element.
 This is the group-level statement that `n_α` interchanges the root subgroups of `α` and `-α`. -/
-@[simp]
 theorem weylUnit_conj_e (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
     IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E * E *
       (IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E)) = -F := by
@@ -409,7 +408,6 @@ theorem weylUnit_conj_e (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNil
   exact weylAut_apply_e _ _ t
 
 /-- The Weyl element carries the lowering element of the triple to the negated raising element. -/
-@[simp]
 theorem weylUnit_conj_f (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
     IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E * F *
       (IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E)) = -E := by

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Algebra.Lie.Weights.Killing
 public import TauCeti.Algebra.Lie.InnerAutomorphism
+public import TauCeti.RingTheory.Nilpotent.Exp
 
 public section
 
@@ -50,10 +51,18 @@ under the Weyl group: `weylAut` matches a root vector of `β` with one of `s_α 
 the triple of `α` itself it is the source of the relation `N (α, β) = -N (-α, -β)` between
 structure constants (Humphreys §25.2).
 
+A final section takes `L` to be the commutator algebra of an associative `ℚ`-algebra `A`, the case
+of a representation. There the Weyl automorphism is inner: `TauCeti.weylUnit` is the unit
+`exp E · exp (-F) · exp E` of `A`, Chevalley's group element `n_α = x_α(1) x_{-α}(-1) x_α(1)`, and
+`TauCeti.weylAut_apply_eq_weylUnit_conj` identifies the automorphism with conjugation by it. Every
+statement above then reads as a relation in the group of units rather than in the Lie algebra.
+
 ## Main definitions
 
 * `TauCeti.weylAut`: the automorphism `exp (ad e) ∘ exp (ad (-f)) ∘ exp (ad e)` of an `sl₂`
   triple `t : IsSl2Triple h e f`.
+* `TauCeti.weylUnit`: the unit `exp E · exp (-F) · exp E` of an associative algebra containing the
+  triple.
 
 ## Main results
 
@@ -65,6 +74,10 @@ structure constants (Humphreys §25.2).
 * `TauCeti.weylAut_mem_rootSpace`, `TauCeti.weylAut_map_rootSpace` and
   `TauCeti.exists_lieEquiv_forall_mem_rootSpace`: in the Killing setting, `weylAut` carries root
   spaces onto reflected root spaces.
+* `TauCeti.weylAut_apply_eq_weylUnit_conj`: in an associative algebra the Weyl automorphism is
+  conjugation by the Weyl element.
+* `TauCeti.weylUnit_conj_h`, `TauCeti.weylUnit_conj_e`, `TauCeti.weylUnit_conj_f` and
+  `TauCeti.lie_weylUnit_conj`: the conjugation form of the four statements above.
 
 ## References
 
@@ -319,5 +332,98 @@ theorem exists_lieEquiv_forall_mem_rootSpace {α : Weight K H L} (hα : α.IsNon
     fun β z hz ↦ weylAut_mem_rootSpace t heα hfα hα hz⟩
 
 end Killing
+
+/-! ## The Weyl element of a triple in an associative algebra
+
+When the ambient Lie algebra is the commutator algebra of an associative `ℚ`-algebra `A` — the
+case of a representation, where `A = Module.End ℚ V` — the Weyl automorphism is *inner*: it is
+conjugation by the unit
+
+```text
+n = exp E · exp (-F) · exp E,
+```
+
+Chevalley's `n_α = x_α(1) x_{-α}(-1) x_α(1)`. This is the passage from the Lie algebra to the
+group, and it is what makes the reflection an element of a Chevalley group rather than only an
+automorphism of its Lie algebra. -/
+
+section Associative
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {A : Type*} [Ring A] [Algebra ℚ A] {H E F : A}
+
+/-- **The Weyl element of an `sl₂` triple in an associative algebra**: the unit
+`exp E · exp (-F) · exp E`, whose inverse is `exp (-E) · exp F · exp (-E)`.
+
+For the images of a Chevalley root pair in a representation this is `n_α = x_α(1) x_{-α}(-1)
+x_α(1)`, the representative of the reflection `s_α` inside the Chevalley group. As with
+`TauCeti.weylAut`, the triple is an argument although the composite depends only on `E` and `F`:
+it is the input the results below are about. -/
+noncomputable def weylUnit (_t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
+    Aˣ :=
+  nilpotentExpUnit hE * nilpotentExpUnit hF.neg * nilpotentExpUnit hE
+
+variable (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F)
+
+/-- The Weyl element is the threefold product of exponentials it is defined to be. -/
+@[simp]
+theorem coe_weylUnit :
+    ((weylUnit t hE hF : Aˣ) : A) =
+      IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E := by
+  simp [weylUnit]
+
+/-- The inverse of the Weyl element is obtained by negating every exponent. -/
+@[simp]
+theorem coe_inv_weylUnit :
+    (((weylUnit t hE hF)⁻¹ : Aˣ) : A) =
+      IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E) := by
+  simp [weylUnit, mul_inv_rev, mul_assoc]
+
+/-- **The Weyl automorphism is conjugation by the Weyl element.** Each of the three exponentials
+of `TauCeti.weylAut` acts by conjugation on an associative algebra, so their composite does
+too. -/
+theorem weylAut_apply_eq_weylUnit_conj (y : A) :
+    weylAut (K := ℚ) t (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hE)
+        (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hF) y =
+      ((weylUnit t hE hF : Aˣ) : A) * y * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) := by
+  rw [weylAut_apply (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hE)
+      (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hF) t,
+    expAd_apply_eq_exp_mul_exp_neg hE, expAd_apply_eq_exp_mul_exp_neg hF.neg,
+    expAd_apply_eq_exp_mul_exp_neg hE, coe_weylUnit, coe_inv_weylUnit]
+  simp only [neg_neg, mul_assoc]
+
+/-- The Weyl element negates the Cartan element of the triple. -/
+theorem weylUnit_conj_h :
+    ((weylUnit t hE hF : Aˣ) : A) * H * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -H := by
+  rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
+  exact weylAut_apply_h _ _ t
+
+/-- The Weyl element carries the raising element of the triple to the negated lowering element.
+This is the group-level statement that `n_α` interchanges the root subgroups of `α` and `-α`. -/
+theorem weylUnit_conj_e :
+    ((weylUnit t hE hF : Aˣ) : A) * E * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -F := by
+  rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
+  exact weylAut_apply_e _ _ t
+
+/-- The Weyl element carries the lowering element of the triple to the negated raising element. -/
+theorem weylUnit_conj_f :
+    ((weylUnit t hE hF : Aˣ) : A) * F * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -E := by
+  rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
+  exact weylAut_apply_f _ _ t
+
+/-- **The reflected weight, at the group level.** If `y` acts on the triple by the scalars `c` and
+`-c` and `z` is a simultaneous eigenvector of `y` and `H` with eigenvalues `d` and `m`, then the
+conjugate of `z` by the Weyl element is again an eigenvector of `y`, with eigenvalue `d - c * m`.
+
+For a Cartan element `y` this is the reflection `β ↦ β - β(α^∨) • α` of weights. -/
+theorem lie_weylUnit_conj {y z : A} {c d m : ℚ} (hye : ⁅y, E⁆ = c • E) (hyf : ⁅y, F⁆ = -(c • F))
+    (hyz : ⁅y, z⁆ = d • z) (hhz : ⁅H, z⁆ = m • z) :
+    ⁅y, ((weylUnit t hE hF : Aˣ) : A) * z * (((weylUnit t hE hF)⁻¹ : Aˣ) : A)⁆ =
+      (d - c * m) • (((weylUnit t hE hF : Aˣ) : A) * z * (((weylUnit t hE hF)⁻¹ : Aˣ) : A)) := by
+  rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
+  exact lie_weylAut_apply _ _ t hye hyf hyz hhz
+
+end Associative
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -400,6 +400,7 @@ theorem weylUnit_conj_h (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNil
 
 /-- The Weyl element carries the raising element of the triple to the negated lowering element.
 This is the group-level statement that `n_α` interchanges the root subgroups of `α` and `-α`. -/
+@[simp]
 theorem weylUnit_conj_e (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
     IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E * E *
       (IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E)) = -F := by
@@ -408,6 +409,7 @@ theorem weylUnit_conj_e (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNil
   exact weylAut_apply_e _ _ t
 
 /-- The Weyl element carries the lowering element of the triple to the negated raising element. -/
+@[simp]
 theorem weylUnit_conj_f (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
     IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E * F *
       (IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E)) = -E := by

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -367,14 +367,12 @@ noncomputable def weylUnit (_t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : I
 variable (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F)
 
 /-- The Weyl element is the threefold product of exponentials it is defined to be. -/
-@[simp]
 theorem coe_weylUnit :
     ((weylUnit t hE hF : Aˣ) : A) =
       IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E := by
   simp [weylUnit]
 
 /-- The inverse of the Weyl element is obtained by negating every exponent. -/
-@[simp]
 theorem coe_inv_weylUnit :
     (((weylUnit t hE hF)⁻¹ : Aˣ) : A) =
       IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E) := by
@@ -394,6 +392,7 @@ theorem weylAut_apply_eq_weylUnit_conj (y : A) :
   simp only [neg_neg, mul_assoc]
 
 /-- The Weyl element negates the Cartan element of the triple. -/
+@[simp]
 theorem weylUnit_conj_h :
     ((weylUnit t hE hF : Aˣ) : A) * H * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -H := by
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
@@ -401,12 +400,14 @@ theorem weylUnit_conj_h :
 
 /-- The Weyl element carries the raising element of the triple to the negated lowering element.
 This is the group-level statement that `n_α` interchanges the root subgroups of `α` and `-α`. -/
+@[simp]
 theorem weylUnit_conj_e :
     ((weylUnit t hE hF : Aˣ) : A) * E * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -F := by
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
   exact weylAut_apply_e _ _ t
 
 /-- The Weyl element carries the lowering element of the triple to the negated raising element. -/
+@[simp]
 theorem weylUnit_conj_f :
     ((weylUnit t hE hF : Aˣ) : A) * F * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -E := by
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -353,38 +353,36 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable {A : Type*} [Ring A] [Algebra ℚ A] {H E F : A}
 
-/-- **The Weyl element of an `sl₂` triple in an associative algebra**: the unit
+/-- **The Weyl element attached to two nilpotent elements in an associative algebra**: the unit
 `exp E · exp (-F) · exp E`, whose inverse is `exp (-E) · exp F · exp (-E)`.
 
 For the images of a Chevalley root pair in a representation this is `n_α = x_α(1) x_{-α}(-1)
-x_α(1)`, the representative of the reflection `s_α` inside the Chevalley group. As with
-`TauCeti.weylAut`, the triple is an argument although the composite depends only on `E` and `F`:
-it is the input the results below are about. -/
-noncomputable def weylUnit (_t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
-    Aˣ :=
+x_α(1)`, the representative of the reflection `s_α` inside the Chevalley group. -/
+noncomputable def weylUnit (hE : IsNilpotent E) (hF : IsNilpotent F) : Aˣ :=
   nilpotentExpUnit hE * nilpotentExpUnit hF.neg * nilpotentExpUnit hE
 
-variable (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F)
-
 /-- The Weyl element is the threefold product of exponentials it is defined to be. -/
-theorem coe_weylUnit :
-    ((weylUnit t hE hF : Aˣ) : A) =
+@[simp]
+theorem coe_weylUnit (hE : IsNilpotent E) (hF : IsNilpotent F) :
+    ((weylUnit hE hF : Aˣ) : A) =
       IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E := by
   simp [weylUnit]
 
 /-- The inverse of the Weyl element is obtained by negating every exponent. -/
-theorem coe_inv_weylUnit :
-    (((weylUnit t hE hF)⁻¹ : Aˣ) : A) =
+@[simp]
+theorem coe_inv_weylUnit (hE : IsNilpotent E) (hF : IsNilpotent F) :
+    (((weylUnit hE hF)⁻¹ : Aˣ) : A) =
       IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E) := by
   simp [weylUnit, mul_inv_rev, mul_assoc]
 
 /-- **The Weyl automorphism is conjugation by the Weyl element.** Each of the three exponentials
 of `TauCeti.weylAut` acts by conjugation on an associative algebra, so their composite does
 too. -/
-theorem weylAut_apply_eq_weylUnit_conj (y : A) :
+theorem weylAut_apply_eq_weylUnit_conj (t : IsSl2Triple H E F) (hE : IsNilpotent E)
+    (hF : IsNilpotent F) (y : A) :
     weylAut (K := ℚ) t (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hE)
         (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hF) y =
-      ((weylUnit t hE hF : Aˣ) : A) * y * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) := by
+      ((weylUnit hE hF : Aˣ) : A) * y * (((weylUnit hE hF)⁻¹ : Aˣ) : A) := by
   rw [weylAut_apply (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hE)
       (LieAlgebra.ad_nilpotent_of_nilpotent (R := ℚ) hF) t,
     expAd_apply_eq_exp_mul_exp_neg hE, expAd_apply_eq_exp_mul_exp_neg hF.neg,
@@ -393,23 +391,23 @@ theorem weylAut_apply_eq_weylUnit_conj (y : A) :
 
 /-- The Weyl element negates the Cartan element of the triple. -/
 @[simp]
-theorem weylUnit_conj_h :
-    ((weylUnit t hE hF : Aˣ) : A) * H * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -H := by
+theorem weylUnit_conj_h (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
+    ((weylUnit hE hF : Aˣ) : A) * H * (((weylUnit hE hF)⁻¹ : Aˣ) : A) = -H := by
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
   exact weylAut_apply_h _ _ t
 
 /-- The Weyl element carries the raising element of the triple to the negated lowering element.
 This is the group-level statement that `n_α` interchanges the root subgroups of `α` and `-α`. -/
 @[simp]
-theorem weylUnit_conj_e :
-    ((weylUnit t hE hF : Aˣ) : A) * E * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -F := by
+theorem weylUnit_conj_e (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
+    ((weylUnit hE hF : Aˣ) : A) * E * (((weylUnit hE hF)⁻¹ : Aˣ) : A) = -F := by
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
   exact weylAut_apply_e _ _ t
 
 /-- The Weyl element carries the lowering element of the triple to the negated raising element. -/
 @[simp]
-theorem weylUnit_conj_f :
-    ((weylUnit t hE hF : Aˣ) : A) * F * (((weylUnit t hE hF)⁻¹ : Aˣ) : A) = -E := by
+theorem weylUnit_conj_f (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
+    ((weylUnit hE hF : Aˣ) : A) * F * (((weylUnit hE hF)⁻¹ : Aˣ) : A) = -E := by
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
   exact weylAut_apply_f _ _ t
 
@@ -418,10 +416,12 @@ theorem weylUnit_conj_f :
 conjugate of `z` by the Weyl element is again an eigenvector of `y`, with eigenvalue `d - c * m`.
 
 For a Cartan element `y` this is the reflection `β ↦ β - β(α^∨) • α` of weights. -/
-theorem lie_weylUnit_conj {y z : A} {c d m : ℚ} (hye : ⁅y, E⁆ = c • E) (hyf : ⁅y, F⁆ = -(c • F))
+theorem lie_weylUnit_conj (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F)
+    {y z : A} {c d m : ℚ}
+    (hye : ⁅y, E⁆ = c • E) (hyf : ⁅y, F⁆ = -(c • F))
     (hyz : ⁅y, z⁆ = d • z) (hhz : ⁅H, z⁆ = m • z) :
-    ⁅y, ((weylUnit t hE hF : Aˣ) : A) * z * (((weylUnit t hE hF)⁻¹ : Aˣ) : A)⁆ =
-      (d - c * m) • (((weylUnit t hE hF : Aˣ) : A) * z * (((weylUnit t hE hF)⁻¹ : Aˣ) : A)) := by
+    ⁅y, ((weylUnit hE hF : Aˣ) : A) * z * (((weylUnit hE hF)⁻¹ : Aˣ) : A)⁆ =
+      (d - c * m) • (((weylUnit hE hF : Aˣ) : A) * z * (((weylUnit hE hF)⁻¹ : Aˣ) : A)) := by
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
   exact lie_weylAut_apply _ _ t hye hyf hyz hhz
 

--- a/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean
@@ -392,22 +392,26 @@ theorem weylAut_apply_eq_weylUnit_conj (t : IsSl2Triple H E F) (hE : IsNilpotent
 /-- The Weyl element negates the Cartan element of the triple. -/
 @[simp]
 theorem weylUnit_conj_h (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
-    ((weylUnit hE hF : Aˣ) : A) * H * (((weylUnit hE hF)⁻¹ : Aˣ) : A) = -H := by
+    IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E * H *
+      (IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E)) = -H := by
+  rw [← coe_weylUnit hE hF, ← coe_inv_weylUnit hE hF]
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
   exact weylAut_apply_h _ _ t
 
 /-- The Weyl element carries the raising element of the triple to the negated lowering element.
 This is the group-level statement that `n_α` interchanges the root subgroups of `α` and `-α`. -/
-@[simp]
 theorem weylUnit_conj_e (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
-    ((weylUnit hE hF : Aˣ) : A) * E * (((weylUnit hE hF)⁻¹ : Aˣ) : A) = -F := by
+    IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E * E *
+      (IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E)) = -F := by
+  rw [← coe_weylUnit hE hF, ← coe_inv_weylUnit hE hF]
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
   exact weylAut_apply_e _ _ t
 
 /-- The Weyl element carries the lowering element of the triple to the negated raising element. -/
-@[simp]
 theorem weylUnit_conj_f (t : IsSl2Triple H E F) (hE : IsNilpotent E) (hF : IsNilpotent F) :
-    ((weylUnit hE hF : Aˣ) : A) * F * (((weylUnit hE hF)⁻¹ : Aˣ) : A) = -E := by
+    IsNilpotent.exp E * IsNilpotent.exp (-F) * IsNilpotent.exp E * F *
+      (IsNilpotent.exp (-E) * IsNilpotent.exp F * IsNilpotent.exp (-E)) = -E := by
+  rw [← coe_weylUnit hE hF, ← coe_inv_weylUnit hE hF]
   rw [← weylAut_apply_eq_weylUnit_conj t hE hF]
   exact weylAut_apply_f _ _ t
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
@@ -262,7 +262,7 @@ theorem kostantWeylPoints_conj_baseChangeExp (u : A) :
     exact hMneg
   rw [kostantWeylPoints_toLinearMap, kostantWeylPoints_symm_toLinearMap, kostantWeylRestrict,
     baseChange_integralUnitRestrict_conj_baseChangeExp
-      (R := A) _ M _ _ _ _ hMconj hi u,
+      (R := A) _ M _ _ _ _ hi u,
     baseChangeExp_congr hconj M hMconj hMneg, baseChangeExp_neg _ M hMneg hMj hj]
 
 /-- The Weyl element is natural in the ring of points: it is the scalar extension of a single

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
@@ -41,9 +41,10 @@ characteristic two and three, where the exponential series itself is unavailable
 
 The same mechanism gives the action on weights:
 `TauCeti.UniversalEnvelopingAlgebra.weylUnit_apply_eigenvector` says that `n` carries an
-eigenvector of `ρ(h c)` of eigenvalue `m` inside `M` to an eigenvector of eigenvalue `-m`, again
-inside `M`. That is the reflection `s_α` acting on the weight lattice, realised by an element of the
-Chevalley group rather than only by an automorphism of the Lie algebra.
+eigenvector of `ρ(h c)` of eigenvalue `m` to an eigenvector of eigenvalue `-m`. When the original
+vector lies in `M`, `TauCeti.UniversalEnvelopingAlgebra.weylUnit_smul_mem` separately shows that its
+image again lies in `M`. That is the reflection `s_α` acting on the weight lattice, realised by an
+element of the Chevalley group rather than only by an automorphism of the Lie algebra.
 
 This is the normaliser-of-the-torus half of the pinning data of Layer 9 of the ReductiveGroups
 roadmap: the Chevalley commutator relations of
@@ -97,7 +98,7 @@ variable (hT : IsSl2Triple (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)))
   (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)))
   (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
 
-include hM hi hj hT
+include hM hi hj
 
 -- Match tensor products to the `ℤ`-algebra instance stored by `CommAlgCat` objects.
 attribute [local instance high] Algebra.toModule
@@ -107,44 +108,50 @@ attribute [local instance high] Algebra.toModule
 /-- The Weyl element of a Kostant root pair preserves the lattice: it is a product of root
 subgroup elements at integer parameters, each of which does. -/
 theorem weylUnit_smul_mem {v : V} (hv : v ∈ M) :
-    ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) • v ∈ M := by
+    ((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) • v ∈ M := by
   rw [coe_weylUnit, mul_smul, mul_smul]
-  exact exp_smul_mem hi (fun n _ hw =>
-      dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw)
-    (exp_neg_smul_mem hj (fun n _ hw =>
-      dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hw)
-      (exp_smul_mem hi (fun n _ hw =>
-        dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw) hv))
+  simpa using
+    (exp_zsmul_smul_mem hi (fun n _ hw =>
+        dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw) 1
+      (by simpa using
+        (exp_zsmul_smul_mem hj (fun n _ hw =>
+            dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hw) (-1)
+          (by simpa using
+            (exp_zsmul_smul_mem hi (fun n _ hw =>
+              dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw) 1 hv)))))
 
 /-- The inverse of the Weyl element preserves the lattice, by the same computation with every
 exponent negated. -/
 theorem inv_weylUnit_smul_mem {v : V} (hv : v ∈ M) :
-    (((weylUnit hT hi hj : (Module.End ℚ V)ˣ)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) • v ∈ M := by
+    (((weylUnit hi hj : (Module.End ℚ V)ˣ)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) • v ∈ M := by
   rw [coe_inv_weylUnit, mul_smul, mul_smul]
-  exact exp_neg_smul_mem hi (fun n _ hw =>
-      dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw)
-    (exp_smul_mem hj (fun n _ hw =>
-      dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hw)
-      (exp_neg_smul_mem hi (fun n _ hw =>
-        dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw) hv))
+  simpa using
+    (exp_zsmul_smul_mem hi (fun n _ hw =>
+        dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw) (-1)
+      (by simpa using
+        (exp_zsmul_smul_mem hj (fun n _ hw =>
+            dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hw) 1
+          (by simpa using
+            (exp_zsmul_smul_mem hi (fun n _ hw =>
+              dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw) (-1) hv)))))
 
 /-- The Weyl element restricted to an integral automorphism of the lattice. -/
 noncomputable def kostantWeylRestrict : M ≃ₗ[ℤ] M :=
-  integralUnitRestrict (weylUnit hT hi hj) M
-    (fun _ hv => weylUnit_smul_mem e h ρ M hM hi hj hT hv)
-    (fun _ hv => inv_weylUnit_smul_mem e h ρ M hM hi hj hT hv)
+  integralUnitRestrict (weylUnit hi hj) M
+    (fun _ hv => weylUnit_smul_mem e h ρ M hM hi hj hv)
+    (fun _ hv => inv_weylUnit_smul_mem e h ρ M hM hi hj hv)
 
 @[simp]
 theorem coe_kostantWeylRestrict_apply (v : M) :
-    ((kostantWeylRestrict e h ρ M hM hi hj hT v : M) : V) =
-      ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) • (v : V) := by
+    ((kostantWeylRestrict e h ρ M hM hi hj v : M) : V) =
+      ((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) • (v : V) := by
   simp [kostantWeylRestrict]
 
 /-- The inverse of the restricted Weyl element acts by the inverse of the Weyl element. -/
 @[simp]
 theorem coe_kostantWeylRestrict_symm_apply (v : M) :
-    (((kostantWeylRestrict e h ρ M hM hi hj hT).symm v : M) : V) =
-      (((weylUnit hT hi hj : (Module.End ℚ V)ˣ)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) •
+    (((kostantWeylRestrict e h ρ M hM hi hj).symm v : M) : V) =
+      (((weylUnit hi hj : (Module.End ℚ V)ˣ)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) •
         (v : V) := by
   simp [kostantWeylRestrict]
 
@@ -161,24 +168,24 @@ the Chevalley product `x_i(1) x_j(-1) x_i(1)` of root subgroup elements is
 `TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints_toLinearMap_eq`. -/
 noncomputable def kostantWeylPoints (A : Type*) [CommRing A] [Algebra ℤ A] :
     A ⊗[ℤ] M ≃ₗ[A] A ⊗[ℤ] M :=
-  (kostantWeylRestrict e h ρ M hM hi hj hT).baseChange ℤ A
+  (kostantWeylRestrict e h ρ M hM hi hj).baseChange ℤ A
 
 @[simp]
 theorem kostantWeylPoints_toLinearMap :
-    (kostantWeylPoints e h ρ M hM hi hj hT A).toLinearMap =
-      (kostantWeylRestrict e h ρ M hM hi hj hT : M →ₗ[ℤ] M).baseChange A :=
+    (kostantWeylPoints e h ρ M hM hi hj A).toLinearMap =
+      (kostantWeylRestrict e h ρ M hM hi hj : M →ₗ[ℤ] M).baseChange A :=
   (rfl)
 
 @[simp]
 theorem kostantWeylPoints_symm_toLinearMap :
-    (kostantWeylPoints e h ρ M hM hi hj hT A).symm.toLinearMap =
-      ((kostantWeylRestrict e h ρ M hM hi hj hT).symm : M →ₗ[ℤ] M).baseChange A :=
+    (kostantWeylPoints e h ρ M hM hi hj A).symm.toLinearMap =
+      ((kostantWeylRestrict e h ρ M hM hi hj).symm : M →ₗ[ℤ] M).baseChange A :=
   (rfl)
 
 @[simp]
 theorem kostantWeylPoints_apply_tmul (r : A) (v : M) :
-    kostantWeylPoints e h ρ M hM hi hj hT A (r ⊗ₜ[ℤ] v) =
-      r ⊗ₜ[ℤ] kostantWeylRestrict e h ρ M hM hi hj hT v := by
+    kostantWeylPoints e h ρ M hM hi hj A (r ⊗ₜ[ℤ] v) =
+      r ⊗ₜ[ℤ] kostantWeylRestrict e h ρ M hM hi hj v := by
   rw [← LinearEquiv.coe_coe, kostantWeylPoints_toLinearMap, LinearMap.baseChange_tmul,
     LinearEquiv.coe_coe]
 
@@ -186,8 +193,8 @@ theorem kostantWeylPoints_apply_tmul (r : A) (v : M) :
 automorphism. -/
 @[simp]
 theorem kostantWeylPoints_symm_apply_tmul (r : A) (v : M) :
-    (kostantWeylPoints e h ρ M hM hi hj hT A).symm (r ⊗ₜ[ℤ] v) =
-      r ⊗ₜ[ℤ] (kostantWeylRestrict e h ρ M hM hi hj hT).symm v := by
+    (kostantWeylPoints e h ρ M hM hi hj A).symm (r ⊗ₜ[ℤ] v) =
+      r ⊗ₜ[ℤ] (kostantWeylRestrict e h ρ M hM hi hj).symm v := by
   rw [← LinearEquiv.coe_coe, kostantWeylPoints_symm_toLinearMap, LinearMap.baseChange_tmul,
     LinearEquiv.coe_coe]
 
@@ -197,7 +204,7 @@ Each factor is a root subgroup element at an integer parameter, hence already de
 this identifies their product with the scalar extension of the integral automorphism
 `TauCeti.UniversalEnvelopingAlgebra.kostantWeylRestrict`. -/
 theorem kostantWeylPoints_toLinearMap_eq :
-    (kostantWeylPoints e h ρ M hM hi hj hT A).toLinearMap =
+    (kostantWeylPoints e h ρ M hM hi hj A).toLinearMap =
       baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
           (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
           (1 : A) *
@@ -218,16 +225,17 @@ theorem kostantWeylPoints_toLinearMap_eq :
   simp only [LinearEquiv.coe_coe, coe_kostantWeylRestrict_apply, coe_integralExpZSMul_apply,
     coe_weylUnit, one_zsmul, neg_one_zsmul, mul_smul]
 
+include hT in
 /-- **Conjugation by the Weyl element interchanges the two root subgroups.** Over every ring of
 points, `n x_i(u) n⁻¹ = x_j(-u)`.
 
 Only the Lie-algebra relation `n ρ(eᵢ) n⁻¹ = -ρ(eⱼ)` is used, so the identity is insensitive to
 the characteristic of the ring of points. -/
 theorem kostantWeylPoints_conj_baseChangeExp (u : A) :
-    (kostantWeylPoints e h ρ M hM hi hj hT A).toLinearMap *
+    (kostantWeylPoints e h ρ M hM hi hj A).toLinearMap *
           baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
             (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv) u *
-        (kostantWeylPoints e h ρ M hM hi hj hT A).symm.toLinearMap =
+        (kostantWeylPoints e h ρ M hM hi hj A).symm.toLinearMap =
       baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))) M
         (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hv) (-u) := by
   have hMj : ∀ n, ∀ v ∈ M,
@@ -241,14 +249,14 @@ theorem kostantWeylPoints_conj_baseChangeExp (u : A) :
       exact hMj n v hv
     · rw [Associative.dividedPower_neg, hn.neg_one_pow, neg_one_smul, neg_smul]
       exact neg_mem (hMj n v hv)
-  have hconj : ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
+  have hconj : ((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
       ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) *
-      (((weylUnit hT hi hj)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) =
+      (((weylUnit hi hj)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) =
         -ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j)) := weylUnit_conj_e hT hi hj
   have hMconj : ∀ n, ∀ v ∈ M, Associative.dividedPower n
-      (((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
+      (((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
         ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) *
-        (((weylUnit hT hi hj)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V)) • v ∈ M := by
+        (((weylUnit hi hj)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V)) • v ∈ M := by
     rw [hconj]
     exact hMneg
   rw [kostantWeylPoints_toLinearMap, kostantWeylPoints_symm_toLinearMap, kostantWeylRestrict,
@@ -265,8 +273,8 @@ arbitrary ring homomorphism is `TauCeti.UniversalEnvelopingAlgebra.map_kostantWe
 theorem map_kostantWeylPoints_algHom {B : Type*} [CommRing B] [Algebra ℤ B] (φ : A →ₐ[ℤ] B)
     (z : A ⊗[ℤ] M) :
     TensorProduct.map φ.toLinearMap LinearMap.id
-        (kostantWeylPoints e h ρ M hM hi hj hT A z) =
-      kostantWeylPoints e h ρ M hM hi hj hT B
+        (kostantWeylPoints e h ρ M hM hi hj A z) =
+      kostantWeylPoints e h ρ M hM hi hj B
         (TensorProduct.map φ.toLinearMap LinearMap.id z) := by
   induction z using TensorProduct.induction_on with
   | zero => simp
@@ -284,20 +292,22 @@ of points: a `ℤ`-algebra structure on a ring is unique, so no compatibility wi
 needed. -/
 theorem map_kostantWeylPoints {B : Type*} [CommRing B] (φ : A →+* B) (z : A ⊗[ℤ] M) :
     TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id
-        (kostantWeylPoints e h ρ M hM hi hj hT A z) =
-      kostantWeylPoints e h ρ M hM hi hj hT B
+        (kostantWeylPoints e h ρ M hM hi hj A z) =
+      kostantWeylPoints e h ρ M hM hi hj B
         (TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id z) :=
-  map_kostantWeylPoints_algHom e h ρ M hM hi hj hT φ.toIntAlgHom z
+  map_kostantWeylPoints_algHom e h ρ M hM hi hj φ.toIntAlgHom z
 
 end RingHomPoints
 
 /-! ## The reflected weight -/
 
 omit hM in
+include hT in
 /-- **The Weyl element reflects weights.** If `v` is an eigenvector of a distinguished Cartan
 vector with eigenvalue `m`, then its image under the Weyl element is an eigenvector with the
-reflected eigenvalue `-m`; by `TauCeti.UniversalEnvelopingAlgebra.weylUnit_smul_mem` that image
-again lies in the lattice.
+reflected eigenvalue `-m`. If additionally `v ∈ M`, then
+`TauCeti.UniversalEnvelopingAlgebra.weylUnit_smul_mem` separately shows that the image lies in
+the lattice.
 
 For the `sl₂` triple of a root `α` this is the reflection `s_α` acting on the weight lattice of
 `M`, realised by an element of the Chevalley group rather than only by an automorphism of the Lie
@@ -305,18 +315,18 @@ algebra. -/
 theorem weylUnit_apply_eigenvector {v : V} {m : ℚ}
     (hmv : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) v = m • v) :
     ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c))
-        (((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) =
-      (-m) • (((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) := by
-  have hw : ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
+        (((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) =
+      (-m) • (((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) := by
+  have hw : ((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
       ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) =
         -ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) *
-          ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) := by
+          ((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) := by
     rw [← weylUnit_conj_h hT hi hj, mul_assoc, mul_assoc, Units.inv_mul, mul_one]
   have happ := congrArg (fun f : Module.End ℚ V => f v) hw
   simp only [Module.End.mul_apply, LinearMap.neg_apply] at happ
   have key : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c))
-      (((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) =
-        -(((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V)
+      (((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) =
+        -(((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V)
           (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) v)) := by
     rw [happ, neg_neg]
   rw [key, hmv, map_smul, ← neg_smul]

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
@@ -140,6 +140,14 @@ theorem coe_kostantWeylRestrict_apply (v : M) :
       ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) • (v : V) := by
   simp [kostantWeylRestrict]
 
+/-- The inverse of the restricted Weyl element acts by the inverse of the Weyl element. -/
+@[simp]
+theorem coe_kostantWeylRestrict_symm_apply (v : M) :
+    (((kostantWeylRestrict e h ρ M hM hi hj hT).symm v : M) : V) =
+      (((weylUnit hT hi hj : (Module.End ℚ V)ˣ)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) •
+        (v : V) := by
+  simp [kostantWeylRestrict]
+
 section Points
 
 variable {A : Type*} [CommRing A] [Algebra ℤ A]
@@ -153,21 +161,7 @@ the Chevalley product `x_i(1) x_j(-1) x_i(1)` of root subgroup elements is
 `TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints_toLinearMap_eq`. -/
 noncomputable def kostantWeylPoints (A : Type*) [CommRing A] [Algebra ℤ A] :
     A ⊗[ℤ] M ≃ₗ[A] A ⊗[ℤ] M :=
-  LinearEquiv.ofLinearMap
-    ((kostantWeylRestrict e h ρ M hM hi hj hT : M →ₗ[ℤ] M).baseChange A)
-    (((kostantWeylRestrict e h ρ M hM hi hj hT).symm : M →ₗ[ℤ] M).baseChange A)
-    (by
-      refine LinearMap.ext fun z => ?_
-      induction z using TensorProduct.induction_on with
-      | zero => simp
-      | tmul r v => simp
-      | add a b ha hb => rw [map_add, map_add, ha, hb])
-    (by
-      refine LinearMap.ext fun z => ?_
-      induction z using TensorProduct.induction_on with
-      | zero => simp
-      | tmul r v => simp
-      | add a b ha hb => rw [map_add, map_add, ha, hb])
+  (kostantWeylRestrict e h ρ M hM hi hj hT).baseChange ℤ A
 
 @[simp]
 theorem kostantWeylPoints_toLinearMap :
@@ -186,6 +180,15 @@ theorem kostantWeylPoints_apply_tmul (r : A) (v : M) :
     kostantWeylPoints e h ρ M hM hi hj hT A (r ⊗ₜ[ℤ] v) =
       r ⊗ₜ[ℤ] kostantWeylRestrict e h ρ M hM hi hj hT v := by
   rw [← LinearEquiv.coe_coe, kostantWeylPoints_toLinearMap, LinearMap.baseChange_tmul,
+    LinearEquiv.coe_coe]
+
+/-- The inverse Weyl element on points acts on a pure tensor through the inverse of the integral
+automorphism. -/
+@[simp]
+theorem kostantWeylPoints_symm_apply_tmul (r : A) (v : M) :
+    (kostantWeylPoints e h ρ M hM hi hj hT A).symm (r ⊗ₜ[ℤ] v) =
+      r ⊗ₜ[ℤ] (kostantWeylRestrict e h ρ M hM hi hj hT).symm v := by
+  rw [← LinearEquiv.coe_coe, kostantWeylPoints_symm_toLinearMap, LinearMap.baseChange_tmul,
     LinearEquiv.coe_coe]
 
 /-- **The Weyl element is the Chevalley product `x_i(1) x_j(-1) x_i(1)`.**
@@ -255,8 +258,11 @@ theorem kostantWeylPoints_conj_baseChangeExp (u : A) :
 
 /-- The Weyl element is natural in the ring of points: it is the scalar extension of a single
 integral automorphism, so applying a ring homomorphism to the scalar coordinate of every tensor
-intertwines the two. -/
-theorem map_kostantWeylPoints {B : Type*} [CommRing B] [Algebra ℤ B] (φ : A →ₐ[ℤ] B)
+intertwines the two.
+
+This is the form for parameter rings carrying explicit `ℤ`-algebra structures; the version for an
+arbitrary ring homomorphism is `TauCeti.UniversalEnvelopingAlgebra.map_kostantWeylPoints`. -/
+theorem map_kostantWeylPoints_algHom {B : Type*} [CommRing B] [Algebra ℤ B] (φ : A →ₐ[ℤ] B)
     (z : A ⊗[ℤ] M) :
     TensorProduct.map φ.toLinearMap LinearMap.id
         (kostantWeylPoints e h ρ M hM hi hj hT A z) =
@@ -268,6 +274,22 @@ theorem map_kostantWeylPoints {B : Type*} [CommRing B] [Algebra ℤ B] (φ : A �
   | add a b ha hb => simp [ha, hb]
 
 end Points
+
+section RingHomPoints
+
+variable {A : Type*} [CommRing A]
+
+/-- The Weyl element is natural in the ring of points, for every homomorphism of commutative rings
+of points: a `ℤ`-algebra structure on a ring is unique, so no compatibility with a chosen one is
+needed. -/
+theorem map_kostantWeylPoints {B : Type*} [CommRing B] (φ : A →+* B) (z : A ⊗[ℤ] M) :
+    TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id
+        (kostantWeylPoints e h ρ M hM hi hj hT A z) =
+      kostantWeylPoints e h ρ M hM hi hj hT B
+        (TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id z) :=
+  map_kostantWeylPoints_algHom e h ρ M hM hi hj hT φ.toIntAlgHom z
+
+end RingHomPoints
 
 /-! ## The reflected weight -/
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
@@ -252,7 +252,8 @@ theorem kostantWeylPoints_conj_baseChangeExp (u : A) :
   have hconj : ((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
       ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) *
       (((weylUnit hi hj)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) =
-        -ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j)) := weylUnit_conj_e hT hi hj
+        -ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j)) := by
+    simpa only [coe_weylUnit, coe_inv_weylUnit] using weylUnit_conj_e hT hi hj
   have hMconj : ∀ n, ∀ v ∈ M, Associative.dividedPower n
       (((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
         ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) *
@@ -321,7 +322,12 @@ theorem weylUnit_apply_eigenvector {v : V} {m : ℚ}
       ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) =
         -ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) *
           ((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) := by
-    rw [← weylUnit_conj_h hT hi hj, mul_assoc, mul_assoc, Units.inv_mul, mul_one]
+    have hconj : ((weylUnit hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
+        ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) *
+        (((weylUnit hi hj)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) =
+          -ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) := by
+      simpa only [coe_weylUnit, coe_inv_weylUnit] using weylUnit_conj_h hT hi hj
+    rw [← hconj, mul_assoc, mul_assoc, Units.inv_mul, mul_one]
   have happ := congrArg (fun f : Module.End ℚ V => f v) hw
   simp only [Module.End.mul_apply, LinearMap.neg_apply] at happ
   have key : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c))

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean
@@ -1,0 +1,302 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Algebra.Lie.Sl2.WeylAutomorphism
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Basic
+
+/-!
+# The Weyl element of a Kostant root subgroup pair
+
+Let `U_ℤ = kostantForm e h` act on a rational vector space `V` through `ρ`, let `M ≤ V` be a
+`U_ℤ`-stable additive subgroup, and let `eᵢ`, `eⱼ` be distinguished root vectors whose images span,
+together with a distinguished Cartan vector `h c`, an `sl₂` triple in `Module.End ℚ V`. Chevalley's
+**Weyl element** is the product of root subgroup elements
+
+```text
+n = x_i(1) x_j(-1) x_i(1),
+```
+
+the group-level representative of the reflection `s_α` for `α` the root of `eᵢ`.
+
+Its two defining properties are proved here over an *arbitrary* commutative ring of points, not
+only over `ℚ`. First, `n` is defined over `ℤ`: the three exponentials have integer parameters, so
+`TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints` is the scalar extension of one integral
+automorphism of the lattice `M`, namely the restriction of the unit
+`TauCeti.weylUnit = exp ρ(eᵢ) · exp (-ρ(eⱼ)) · exp ρ(eᵢ)` of `Module.End ℚ V`. Second, conjugation
+by it interchanges the two root subgroups with a sign,
+
+```text
+n x_i(u) n⁻¹ = x_j(-u)     for every u in the ring of points,
+```
+
+which is `TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints_conj_baseChangeExp`. Nothing about
+the parameter ring enters that proof: the whole content is the Lie-algebra identity
+`n ρ(eᵢ) n⁻¹ = -ρ(eⱼ)` of `TauCeti.weylUnit_conj_e`, which passes through the divided powers
+because conjugation by a unit is an algebra automorphism. In particular the relation holds in
+characteristic two and three, where the exponential series itself is unavailable.
+
+The same mechanism gives the action on weights:
+`TauCeti.UniversalEnvelopingAlgebra.weylUnit_apply_eigenvector` says that `n` carries an
+eigenvector of `ρ(h c)` of eigenvalue `m` inside `M` to an eigenvector of eigenvalue `-m`, again
+inside `M`. That is the reflection `s_α` acting on the weight lattice, realised by an element of the
+Chevalley group rather than only by an automorphism of the Lie algebra.
+
+This is the normaliser-of-the-torus half of the pinning data of Layer 9 of the ReductiveGroups
+roadmap: the Chevalley commutator relations of
+`TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean` describe how two
+root subgroups interact, and the relations here describe how the reflection permutes them.
+
+## Main definitions
+
+* `TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints`: the Weyl element on points valued in an
+  arbitrary commutative ring.
+
+## Main results
+
+* `TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints_toLinearMap_eq`: it is the product
+  `x_i(1) x_j(-1) x_i(1)` of root subgroup elements.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints_conj_baseChangeExp`: conjugating the root
+  subgroup of `eᵢ` by it gives the root subgroup of `eⱼ` with a negated parameter.
+* `TauCeti.UniversalEnvelopingAlgebra.map_kostantWeylPoints`: it is natural in the ring of points.
+* `TauCeti.UniversalEnvelopingAlgebra.weylUnit_apply_eigenvector`: it reflects the weight of an
+  eigenvector of a distinguished Cartan vector.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* R. W. Carter, *Simple Groups of Lie Type*, §§6.4 and 7.2.
+* R. Steinberg, *Lectures on Chevalley Groups*, §3.
+-/
+
+public section
+
+open TensorProduct
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe u v w
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {ι : Type w} {κ : Type*}
+variable {V : Type v} [AddCommGroup V] [Module ℚ V]
+
+variable (e : ι → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+variable {i j : ι} {c : κ}
+variable (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+variable (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+variable (hT : IsSl2Triple (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)))
+  (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)))
+  (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+
+include hM hi hj hT
+
+-- Match tensor products to the `ℤ`-algebra instance stored by `CommAlgCat` objects.
+attribute [local instance high] Algebra.toModule
+
+/-! ## Stability of the lattice under the Weyl element -/
+
+/-- The Weyl element of a Kostant root pair preserves the lattice: it is a product of root
+subgroup elements at integer parameters, each of which does. -/
+theorem weylUnit_smul_mem {v : V} (hv : v ∈ M) :
+    ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) • v ∈ M := by
+  rw [coe_weylUnit, mul_smul, mul_smul]
+  exact exp_smul_mem hi (fun n _ hw =>
+      dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw)
+    (exp_neg_smul_mem hj (fun n _ hw =>
+      dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hw)
+      (exp_smul_mem hi (fun n _ hw =>
+        dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw) hv))
+
+/-- The inverse of the Weyl element preserves the lattice, by the same computation with every
+exponent negated. -/
+theorem inv_weylUnit_smul_mem {v : V} (hv : v ∈ M) :
+    (((weylUnit hT hi hj : (Module.End ℚ V)ˣ)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) • v ∈ M := by
+  rw [coe_inv_weylUnit, mul_smul, mul_smul]
+  exact exp_neg_smul_mem hi (fun n _ hw =>
+      dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw)
+    (exp_smul_mem hj (fun n _ hw =>
+      dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hw)
+      (exp_neg_smul_mem hi (fun n _ hw =>
+        dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hw) hv))
+
+/-- The Weyl element restricted to an integral automorphism of the lattice. -/
+noncomputable def kostantWeylRestrict : M ≃ₗ[ℤ] M :=
+  integralUnitRestrict (weylUnit hT hi hj) M
+    (fun _ hv => weylUnit_smul_mem e h ρ M hM hi hj hT hv)
+    (fun _ hv => inv_weylUnit_smul_mem e h ρ M hM hi hj hT hv)
+
+@[simp]
+theorem coe_kostantWeylRestrict_apply (v : M) :
+    ((kostantWeylRestrict e h ρ M hM hi hj hT v : M) : V) =
+      ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) • (v : V) := by
+  simp [kostantWeylRestrict]
+
+section Points
+
+variable {A : Type*} [CommRing A] [Algebra ℤ A]
+
+/-! ## The Weyl element on points -/
+
+/-- **The Weyl element of a Kostant root pair**, on points valued in a commutative ring `A`.
+
+It is the scalar extension of a single integral automorphism of the lattice `M`. That it is also
+the Chevalley product `x_i(1) x_j(-1) x_i(1)` of root subgroup elements is
+`TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints_toLinearMap_eq`. -/
+noncomputable def kostantWeylPoints (A : Type*) [CommRing A] [Algebra ℤ A] :
+    A ⊗[ℤ] M ≃ₗ[A] A ⊗[ℤ] M :=
+  LinearEquiv.ofLinearMap
+    ((kostantWeylRestrict e h ρ M hM hi hj hT : M →ₗ[ℤ] M).baseChange A)
+    (((kostantWeylRestrict e h ρ M hM hi hj hT).symm : M →ₗ[ℤ] M).baseChange A)
+    (by
+      refine LinearMap.ext fun z => ?_
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | tmul r v => simp
+      | add a b ha hb => rw [map_add, map_add, ha, hb])
+    (by
+      refine LinearMap.ext fun z => ?_
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | tmul r v => simp
+      | add a b ha hb => rw [map_add, map_add, ha, hb])
+
+@[simp]
+theorem kostantWeylPoints_toLinearMap :
+    (kostantWeylPoints e h ρ M hM hi hj hT A).toLinearMap =
+      (kostantWeylRestrict e h ρ M hM hi hj hT : M →ₗ[ℤ] M).baseChange A :=
+  (rfl)
+
+@[simp]
+theorem kostantWeylPoints_symm_toLinearMap :
+    (kostantWeylPoints e h ρ M hM hi hj hT A).symm.toLinearMap =
+      ((kostantWeylRestrict e h ρ M hM hi hj hT).symm : M →ₗ[ℤ] M).baseChange A :=
+  (rfl)
+
+@[simp]
+theorem kostantWeylPoints_apply_tmul (r : A) (v : M) :
+    kostantWeylPoints e h ρ M hM hi hj hT A (r ⊗ₜ[ℤ] v) =
+      r ⊗ₜ[ℤ] kostantWeylRestrict e h ρ M hM hi hj hT v := by
+  rw [← LinearEquiv.coe_coe, kostantWeylPoints_toLinearMap, LinearMap.baseChange_tmul,
+    LinearEquiv.coe_coe]
+
+/-- **The Weyl element is the Chevalley product `x_i(1) x_j(-1) x_i(1)`.**
+
+Each factor is a root subgroup element at an integer parameter, hence already defined over `ℤ`;
+this identifies their product with the scalar extension of the integral automorphism
+`TauCeti.UniversalEnvelopingAlgebra.kostantWeylRestrict`. -/
+theorem kostantWeylPoints_toLinearMap_eq :
+    (kostantWeylPoints e h ρ M hM hi hj hT A).toLinearMap =
+      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+          (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+          (1 : A) *
+        baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))) M
+          (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hv)
+          (-1 : A) *
+        baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+          (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+          (1 : A) := by
+  have hone : ((1 : ℤ) : A) = (1 : A) := Int.cast_one
+  have hneg : ((-1 : ℤ) : A) = (-1 : A) := by rw [Int.cast_neg, Int.cast_one]
+  rw [kostantWeylPoints_toLinearMap, ← hneg, ← hone,
+    baseChangeExp_intCast (R := A) _ M _ hi 1, baseChangeExp_intCast (R := A) _ M _ hj (-1),
+    ← LinearMap.baseChange_mul, ← LinearMap.baseChange_mul]
+  congr 1
+  refine LinearMap.ext fun v => Subtype.ext ?_
+  rw [Module.End.mul_apply, Module.End.mul_apply]
+  simp only [LinearEquiv.coe_coe, coe_kostantWeylRestrict_apply, coe_integralExpZSMul_apply,
+    coe_weylUnit, one_zsmul, neg_one_zsmul, mul_smul]
+
+/-- **Conjugation by the Weyl element interchanges the two root subgroups.** Over every ring of
+points, `n x_i(u) n⁻¹ = x_j(-u)`.
+
+Only the Lie-algebra relation `n ρ(eᵢ) n⁻¹ = -ρ(eⱼ)` is used, so the identity is insensitive to
+the characteristic of the ring of points. -/
+theorem kostantWeylPoints_conj_baseChangeExp (u : A) :
+    (kostantWeylPoints e h ρ M hM hi hj hT A).toLinearMap *
+          baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+            (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv) u *
+        (kostantWeylPoints e h ρ M hM hi hj hT A).symm.toLinearMap =
+      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))) M
+        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hv) (-u) := by
+  have hMj : ∀ n, ∀ v ∈ M,
+      Associative.dividedPower n (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))) • v ∈ M :=
+    fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM j n hv
+  have hMneg : ∀ n, ∀ v ∈ M,
+      Associative.dividedPower n (-ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))) • v ∈ M := by
+    intro n v hv
+    rcases Nat.even_or_odd n with hn | hn
+    · rw [Associative.dividedPower_neg, hn.neg_one_pow, one_smul]
+      exact hMj n v hv
+    · rw [Associative.dividedPower_neg, hn.neg_one_pow, neg_one_smul, neg_smul]
+      exact neg_mem (hMj n v hv)
+  have hconj : ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) *
+      (((weylUnit hT hi hj)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V) =
+        -ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j)) := weylUnit_conj_e hT hi hj
+  have hMconj : ∀ n, ∀ v ∈ M, Associative.dividedPower n
+      (((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
+        ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) *
+        (((weylUnit hT hi hj)⁻¹ : (Module.End ℚ V)ˣ) : Module.End ℚ V)) • v ∈ M := by
+    rw [hconj]
+    exact hMneg
+  rw [kostantWeylPoints_toLinearMap, kostantWeylPoints_symm_toLinearMap, kostantWeylRestrict,
+    baseChange_integralUnitRestrict_conj_baseChangeExp
+      (R := A) _ M _ _ _ _ hMconj hi u,
+    baseChangeExp_congr hconj M hMconj hMneg, baseChangeExp_neg _ M hMneg hMj hj]
+
+/-- The Weyl element is natural in the ring of points: it is the scalar extension of a single
+integral automorphism, so applying a ring homomorphism to the scalar coordinate of every tensor
+intertwines the two. -/
+theorem map_kostantWeylPoints {B : Type*} [CommRing B] [Algebra ℤ B] (φ : A →ₐ[ℤ] B)
+    (z : A ⊗[ℤ] M) :
+    TensorProduct.map φ.toLinearMap LinearMap.id
+        (kostantWeylPoints e h ρ M hM hi hj hT A z) =
+      kostantWeylPoints e h ρ M hM hi hj hT B
+        (TensorProduct.map φ.toLinearMap LinearMap.id z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul r v => simp
+  | add a b ha hb => simp [ha, hb]
+
+end Points
+
+/-! ## The reflected weight -/
+
+omit hM in
+/-- **The Weyl element reflects weights.** If `v` is an eigenvector of a distinguished Cartan
+vector with eigenvalue `m`, then its image under the Weyl element is an eigenvector with the
+reflected eigenvalue `-m`; by `TauCeti.UniversalEnvelopingAlgebra.weylUnit_smul_mem` that image
+again lies in the lattice.
+
+For the `sl₂` triple of a root `α` this is the reflection `s_α` acting on the weight lattice of
+`M`, realised by an element of the Chevalley group rather than only by an automorphism of the Lie
+algebra. -/
+theorem weylUnit_apply_eigenvector {v : V} {m : ℚ}
+    (hmv : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) v = m • v) :
+    ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c))
+        (((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) =
+      (-m) • (((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) := by
+  have hw : ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) *
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) =
+        -ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) *
+          ((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) := by
+    rw [← weylUnit_conj_h hT hi hj, mul_assoc, mul_assoc, Units.inv_mul, mul_one]
+  have happ := congrArg (fun f : Module.End ℚ V => f v) hw
+  simp only [Module.End.mul_apply, LinearMap.neg_apply] at happ
+  have key : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c))
+      (((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V) v) =
+        -(((weylUnit hT hi hj : (Module.End ℚ V)ˣ) : Module.End ℚ V)
+          (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h c)) v)) := by
+    rw [happ, neg_neg]
+  rw [key, hmv, map_smul, ← neg_smul]
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/RingTheory/DividedPowers/Associative.lean
+++ b/TauCeti/RingTheory/DividedPowers/Associative.lean
@@ -115,6 +115,7 @@ theorem dividedPower_smul (q : ℚ) (n : ℕ) (x : A) :
 
 Conjugation is an algebra automorphism, so it commutes with the rational scalar as well as with
 the power. This is what lets a Chevalley group element move past a root subgroup. -/
+@[simp]
 theorem dividedPower_units_conj (u : Aˣ) (n : ℕ) (x : A) :
     dividedPower n ((u : A) * x * ↑u⁻¹) = (u : A) * dividedPower n x * ↑u⁻¹ := by
   rw [dividedPower_def, dividedPower_def, Units.conj_pow, mul_smul_comm, smul_mul_assoc]

--- a/TauCeti/RingTheory/DividedPowers/Associative.lean
+++ b/TauCeti/RingTheory/DividedPowers/Associative.lean
@@ -40,6 +40,8 @@ definition is made here.
   antidiagonal sum.
 * `TauCeti.Associative.dividedPower_sub`: the corresponding signed expansion for a difference.
 * `TauCeti.Associative.map_dividedPower`: divided powers are natural under algebra homomorphisms.
+* `TauCeti.Associative.dividedPower_units_conj`: divided powers are equivariant for conjugation by
+  a unit.
 
 ## References
 
@@ -108,6 +110,14 @@ theorem dividedPower_smul (q : ℚ) (n : ℕ) (x : A) :
     dividedPower n (q • x) = q ^ n • dividedPower n x := by
   simpa only [Algebra.smul_def, map_pow] using
     dividedPower_mul_left (Algebra.commutes q x) n
+
+/-- Divided powers are equivariant for conjugation by a unit.
+
+Conjugation is an algebra automorphism, so it commutes with the rational scalar as well as with
+the power. This is what lets a Chevalley group element move past a root subgroup. -/
+theorem dividedPower_units_conj (u : Aˣ) (n : ℕ) (x : A) :
+    dividedPower n ((u : A) * x * ↑u⁻¹) = (u : A) * dividedPower n x * ↑u⁻¹ := by
+  rw [dividedPower_def, dividedPower_def, Units.conj_pow, mul_smul_comm, smul_mul_assoc]
 
 /-- Divided powers preserve commutation of their underlying elements. -/
 theorem commute_dividedPower_dividedPower {x y : A} (hxy : Commute x y) (m n : ℕ) :

--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -43,6 +43,8 @@ characteristic.
 * `TauCeti.baseChangeExpHom`: the additive one-parameter subgroup over `R`.
 * `TauCeti.integralUnitRestrict`: a unit of `A` preserving `M` restricted to an integral
   automorphism of `M`.
+* `TauCeti.dividedPower_conj_smul_mem`: conjugating by such a unit preserves the stability of `M`
+  under divided powers.
 * `TauCeti.baseChangeExp_intCast`: at an integer parameter the exponential is the base change of a
   single integral automorphism.
 * `TauCeti.baseChange_integralUnitRestrict_conj_baseChangeExp`: conjugating a one-parameter
@@ -155,6 +157,20 @@ theorem coe_integralUnitRestrict_symm_apply (u : Aˣ) (M : S)
     (((integralUnitRestrict u M hu hu').symm v : M) : V) = ((u⁻¹ : Aˣ) : A) • (v : V) :=
   (rfl)
 
+omit [AddSubgroupClass S V] in
+/-- A unit preserving `M` together with its inverse also transports the stability of `M` under
+the divided powers of `x` to stability under the divided powers of the conjugate `u x u⁻¹`.
+
+Conjugation passes through a divided power, so the conjugated operator acts by `u⁻¹`, then a
+divided power of `x`, then `u`, and each of the three maps `M` into `M`. -/
+theorem dividedPower_conj_smul_mem (x : A) (M : S) (u : Aˣ)
+    (hu : ∀ v ∈ M, (u : A) • v ∈ M) (hu' : ∀ v ∈ M, ((u⁻¹ : Aˣ) : A) • v ∈ M)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) :
+    ∀ n, ∀ v ∈ M, Associative.dividedPower n ((u : A) * x * ↑u⁻¹) • v ∈ M := by
+  intro n v hv
+  rw [Associative.dividedPower_units_conj, mul_smul, mul_smul]
+  exact hu _ (hM n _ (hu' v hv))
+
 /-- The restriction to `M` of the exponential `exp (t • x)` of an integral multiple of a nilpotent
 element whose divided powers preserve `M`.
 
@@ -172,6 +188,14 @@ theorem coe_integralExpZSMul_apply (x : A) (M : S)
     (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) (hx : IsNilpotent x) (t : ℤ)
     (v : M) :
     ((integralExpZSMul x M hM hx t v : M) : V) = IsNilpotent.exp (t • x) • (v : V) := by
+  simp [integralExpZSMul]
+
+/-- The inverse of the integral exponential is the exponential of the negated element. -/
+@[simp]
+theorem coe_integralExpZSMul_symm_apply (x : A) (M : S)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) (hx : IsNilpotent x) (t : ℤ)
+    (v : M) :
+    (((integralExpZSMul x M hM hx t).symm v : M) : V) = IsNilpotent.exp (-(t • x)) • (v : V) := by
   simp [integralExpZSMul]
 
 /-- Negating the element leaves the even restricted divided powers unchanged. -/
@@ -569,11 +593,11 @@ alone: conjugation is an algebra automorphism, so it passes through the divided 
 theorem baseChange_integralUnitRestrict_conj_baseChangeExp (x : A) (M : S) (u : Aˣ)
     (hu : ∀ v ∈ M, (u : A) • v ∈ M) (hu' : ∀ v ∈ M, ((u⁻¹ : Aˣ) : A) • v ∈ M)
     (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
-    (hM' : ∀ n, ∀ v ∈ M, Associative.dividedPower n ((u : A) * x * ↑u⁻¹) • v ∈ M)
     (hx : IsNilpotent x) (t : R) :
     ((integralUnitRestrict u M hu hu' : M →ₗ[ℤ] M).baseChange R) * baseChangeExp x M hM t *
         (((integralUnitRestrict u M hu hu').symm : M →ₗ[ℤ] M).baseChange R) =
-      baseChangeExp ((u : A) * x * ↑u⁻¹) M hM' t := by
+      baseChangeExp ((u : A) * x * ↑u⁻¹) M (dividedPower_conj_smul_mem x M u hu hu' hM) t := by
+  have hM' := dividedPower_conj_smul_mem x M u hu hu' hM
   obtain ⟨k, hk⟩ := id hx
   have hk' : ((u : A) * x * ↑u⁻¹) ^ k = 0 := by rw [Units.conj_pow, hk, mul_zero, zero_mul]
   refine LinearMap.ext fun z => ?_

--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -5,7 +5,7 @@ Authors: Codex
 -/
 module
 
-public import TauCeti.RingTheory.DividedPowers.Associative
+public import TauCeti.RingTheory.Nilpotent.Exp
 public import Mathlib.RingTheory.Nilpotent.Defs
 public import Mathlib.LinearAlgebra.TensorProduct.Tower
 
@@ -41,6 +41,12 @@ characteristic.
 * `TauCeti.baseChangeExp_add`: its one-parameter group law.
 * `TauCeti.baseChangeExpLinearEquiv`: the resulting linear automorphism.
 * `TauCeti.baseChangeExpHom`: the additive one-parameter subgroup over `R`.
+* `TauCeti.integralUnitRestrict`: a unit of `A` preserving `M` restricted to an integral
+  automorphism of `M`.
+* `TauCeti.baseChangeExp_intCast`: at an integer parameter the exponential is the base change of a
+  single integral automorphism.
+* `TauCeti.baseChange_integralUnitRestrict_conj_baseChangeExp`: conjugating a one-parameter
+  subgroup by such a unit gives the one-parameter subgroup of the conjugated element.
 
 ## References
 
@@ -117,6 +123,91 @@ theorem integralDividedPower_eq_zero_of_le (x : A)
   ext v
   simp [coe_integralDividedPower_apply, Associative.dividedPower_def,
     pow_eq_zero_of_le hkn hk]
+
+/-! ## Restricting a unit to an invariant additive subgroup -/
+
+/-- The restriction to `M` of the action of a unit of `A` that preserves `M` together with its
+inverse, as an integral linear automorphism.
+
+Scalar multiplication by a ring element is additive, and an additive map of abelian groups is
+exactly a `ℤ`-linear map, so no divisibility is involved: this automorphism survives base change to
+an arbitrary commutative ring. -/
+noncomputable def integralUnitRestrict (u : Aˣ) (M : S)
+    (hu : ∀ v ∈ M, (u : A) • v ∈ M) (hu' : ∀ v ∈ M, ((u⁻¹ : Aˣ) : A) • v ∈ M) : M ≃ₗ[ℤ] M :=
+  AddEquiv.toIntLinearEquiv
+    { toFun := fun v => ⟨(u : A) • (v : V), hu v v.2⟩
+      invFun := fun v => ⟨((u⁻¹ : Aˣ) : A) • (v : V), hu' v v.2⟩
+      left_inv := fun v => Subtype.ext (by simp [smul_smul])
+      right_inv := fun v => Subtype.ext (by simp [smul_smul])
+      map_add' := fun a b => Subtype.ext (smul_add _ _ _) }
+
+omit [Algebra ℚ A] in
+@[simp]
+theorem coe_integralUnitRestrict_apply (u : Aˣ) (M : S)
+    (hu : ∀ v ∈ M, (u : A) • v ∈ M) (hu' : ∀ v ∈ M, ((u⁻¹ : Aˣ) : A) • v ∈ M) (v : M) :
+    ((integralUnitRestrict u M hu hu' v : M) : V) = (u : A) • (v : V) :=
+  (rfl)
+
+omit [Algebra ℚ A] in
+@[simp]
+theorem coe_integralUnitRestrict_symm_apply (u : Aˣ) (M : S)
+    (hu : ∀ v ∈ M, (u : A) • v ∈ M) (hu' : ∀ v ∈ M, ((u⁻¹ : Aˣ) : A) • v ∈ M) (v : M) :
+    (((integralUnitRestrict u M hu hu').symm v : M) : V) = ((u⁻¹ : Aˣ) : A) • (v : V) :=
+  (rfl)
+
+/-- The restriction to `M` of the exponential `exp (t • x)` of an integral multiple of a nilpotent
+element whose divided powers preserve `M`.
+
+The coefficients of the divided-power expansion of `exp (t • x)` are the integers `tⁿ`, so this
+automorphism is defined over `ℤ` even though the exponential itself divides by factorials. -/
+noncomputable def integralExpZSMul (x : A) (M : S)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) (hx : IsNilpotent x) (t : ℤ) :
+    M ≃ₗ[ℤ] M :=
+  integralUnitRestrict (nilpotentExpUnit (hx.smul t)) M
+    (fun _ hv => by simpa using exp_zsmul_smul_mem hx hM t hv)
+    (fun _ hv => by simpa [neg_zsmul] using exp_zsmul_smul_mem hx hM (-t) hv)
+
+@[simp]
+theorem coe_integralExpZSMul_apply (x : A) (M : S)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) (hx : IsNilpotent x) (t : ℤ)
+    (v : M) :
+    ((integralExpZSMul x M hM hx t v : M) : V) = IsNilpotent.exp (t • x) • (v : V) := by
+  simp [integralExpZSMul]
+
+/-- Negating the element leaves the even restricted divided powers unchanged. -/
+theorem integralDividedPower_neg_of_even (x : A) (M : S) {n : ℕ} (hn : Even n)
+    (hM' : ∀ v ∈ M, Associative.dividedPower n (-x) • v ∈ M)
+    (hM : ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) :
+    integralDividedPower (-x) M n hM' = integralDividedPower x M n hM := by
+  refine LinearMap.ext fun v => Subtype.ext ?_
+  rw [coe_integralDividedPower_apply, coe_integralDividedPower_apply,
+    Associative.dividedPower_neg, hn.neg_one_pow, one_smul]
+
+/-- Negating the element negates the odd restricted divided powers. -/
+theorem integralDividedPower_neg_of_odd (x : A) (M : S) {n : ℕ} (hn : Odd n)
+    (hM' : ∀ v ∈ M, Associative.dividedPower n (-x) • v ∈ M)
+    (hM : ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) :
+    integralDividedPower (-x) M n hM' = -integralDividedPower x M n hM := by
+  refine LinearMap.ext fun v => Subtype.ext ?_
+  rw [coe_integralDividedPower_apply, LinearMap.neg_apply, NegMemClass.coe_neg,
+    coe_integralDividedPower_apply, Associative.dividedPower_neg, hn.neg_one_pow, neg_one_smul,
+    neg_smul]
+
+/-- The integral exponential expanded over any truncation bound. -/
+theorem integralExpZSMul_eq_sum (x : A) (M : S)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) (hx : IsNilpotent x)
+    {k : ℕ} (hk : x ^ k = 0) (t : ℤ) :
+    (integralExpZSMul x M hM hx t : M →ₗ[ℤ] M) =
+      ∑ n ∈ range k, t ^ n • integralDividedPower x M n (hM n) := by
+  refine LinearMap.ext fun v => Subtype.ext ?_
+  have hsum : (((∑ n ∈ range k, t ^ n • integralDividedPower x M n (hM n)) v : M) : V) =
+      ∑ n ∈ range k, t ^ n • (Associative.dividedPower n x • (v : V)) := by
+    rw [LinearMap.sum_apply, AddSubmonoidClass.coe_finsetSum]
+    exact Finset.sum_congr rfl fun n _ => by
+      rw [LinearMap.smul_apply, AddSubgroupClass.coe_zsmul, coe_integralDividedPower_apply]
+  rw [hsum, LinearEquiv.coe_coe, coe_integralExpZSMul_apply,
+    exp_zsmul_eq_sum_zsmul_dividedPower hk, Finset.sum_smul]
+  exact Finset.sum_congr rfl fun n _ => (smul_assoc _ _ _)
 
 /-! ## The divided-power exponential after base change -/
 
@@ -398,6 +489,107 @@ theorem coe_baseChangeExpHom (x : A) (M : S)
     ⇑(baseChangeExpHom x M hM hx t) =
       ⇑(baseChangeExp x M hM (Multiplicative.toAdd t)) :=
   (rfl)
+
+/-- The base-changed exponential depends only on the element, not on the stability proof. -/
+theorem baseChangeExp_congr {x y : A} (hxy : x = y) (M : S)
+    (hMx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hMy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M) (t : R) :
+    baseChangeExp x M hMx t = baseChangeExp y M hMy t := by
+  subst hxy
+  rfl
+
+/-- Negating the element inverts the parameter: `E_{-x}(t) = E_x(-t)`. -/
+theorem baseChangeExp_neg (x : A) (M : S)
+    (hM' : ∀ n, ∀ v ∈ M, Associative.dividedPower n (-x) • v ∈ M)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) (hx : IsNilpotent x) (t : R) :
+    baseChangeExp (-x) M hM' t = baseChangeExp x M hM (-t) := by
+  obtain ⟨k, hk⟩ := id hx
+  have hk' : (-x) ^ k = 0 := by rw [neg_pow, hk, mul_zero]
+  refine LinearMap.ext fun z => ?_
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul r v =>
+      rw [baseChangeExp_tmul_of_pow_eq_zero (-x) M hM' hk',
+        baseChangeExp_tmul_of_pow_eq_zero x M hM hk]
+      refine Finset.sum_congr rfl fun n _ => ?_
+      rcases Nat.even_or_odd n with hn | hn
+      · rw [integralDividedPower_neg_of_even x M hn (hM' n) (hM n), hn.neg_pow]
+      · rw [integralDividedPower_neg_of_odd x M hn (hM' n) (hM n), hn.neg_pow,
+          LinearMap.neg_apply, TensorProduct.tmul_neg, neg_mul, TensorProduct.neg_tmul]
+  | add a b ha hb => rw [map_add, map_add, ha, hb]
+
+/-! ## Conjugating the exponential by an integral unit -/
+
+-- Moving an integer scalar across `⊗[ℤ]` by hand. The `ℤ`-module structure on `R` here is the one
+-- carried by its explicit `ℤ`-algebra, so it is not the `AddCommGroup.toIntModule` structure that
+-- `TensorProduct.CompatibleSMul.int` is stated for, and `TensorProduct.smul_tmul` does not apply.
+private theorem intCast_mul_tmul (M : S) (z : ℤ) (r : R) (w : M) :
+    (((z : R) * r) ⊗ₜ[ℤ] w : R ⊗[ℤ] M) = r ⊗ₜ[ℤ] (z • w) := by
+  induction z using Int.induction_on with
+  | zero =>
+      rw [Int.cast_zero, zero_mul, TensorProduct.zero_tmul, zero_smul, TensorProduct.tmul_zero]
+  | succ i ih =>
+      rw [Int.cast_add, Int.cast_one, add_mul, one_mul, TensorProduct.add_tmul, ih,
+        add_smul, one_smul, TensorProduct.tmul_add]
+  | pred i ih =>
+      rw [Int.cast_sub, Int.cast_one, sub_mul, one_mul, TensorProduct.sub_tmul, ih,
+        sub_smul, one_smul, TensorProduct.tmul_sub]
+
+/-- At an integer parameter the base-changed exponential is the base change of a single integral
+automorphism of `M`, namely the restriction of `exp (t • x)`.
+
+This is what makes a Chevalley group element defined over `ℤ`: its value at an integral parameter
+does not depend on the ring the points are taken in. -/
+theorem baseChangeExp_intCast (x : A) (M : S)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) (hx : IsNilpotent x) (t : ℤ) :
+    baseChangeExp x M hM ((t : R)) =
+      ((integralExpZSMul x M hM hx t : M →ₗ[ℤ] M).baseChange R) := by
+  obtain ⟨k, hk⟩ := id hx
+  refine LinearMap.ext fun z => ?_
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul r v =>
+      have hE : ((integralExpZSMul x M hM hx t : M →ₗ[ℤ] M) v : M) =
+          ∑ n ∈ range k, t ^ n • integralDividedPower x M n (hM n) v := by
+        rw [integralExpZSMul_eq_sum x M hM hx hk t, LinearMap.sum_apply]
+        exact Finset.sum_congr rfl fun n _ => LinearMap.smul_apply _ _ _
+      rw [baseChangeExp_tmul_of_pow_eq_zero x M hM hk, LinearMap.baseChange_tmul, hE,
+        TensorProduct.tmul_sum]
+      refine Finset.sum_congr rfl fun n _ => ?_
+      rw [← Int.cast_pow, intCast_mul_tmul]
+  | add a b ha hb => rw [map_add, map_add, ha, hb]
+
+/-- **Conjugating a base-changed exponential by an integral unit.** If a unit `u` of `A` preserves
+`M` together with its inverse, then conjugating the one-parameter subgroup of `x` by the induced
+automorphism of `R ⊗[ℤ] M` gives the one-parameter subgroup of the conjugate `u x u⁻¹`.
+
+For the Weyl element `n_α` and a root vector `eα` this is Chevalley's relation
+`n_α x_α(t) n_α⁻¹ = x_{-α}(-t)`, obtained from the Lie-algebra identity `n_α eα n_α⁻¹ = -e_{-α}`
+alone: conjugation is an algebra automorphism, so it passes through the divided powers. -/
+theorem baseChange_integralUnitRestrict_conj_baseChangeExp (x : A) (M : S) (u : Aˣ)
+    (hu : ∀ v ∈ M, (u : A) • v ∈ M) (hu' : ∀ v ∈ M, ((u⁻¹ : Aˣ) : A) • v ∈ M)
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hM' : ∀ n, ∀ v ∈ M, Associative.dividedPower n ((u : A) * x * ↑u⁻¹) • v ∈ M)
+    (hx : IsNilpotent x) (t : R) :
+    ((integralUnitRestrict u M hu hu' : M →ₗ[ℤ] M).baseChange R) * baseChangeExp x M hM t *
+        (((integralUnitRestrict u M hu hu').symm : M →ₗ[ℤ] M).baseChange R) =
+      baseChangeExp ((u : A) * x * ↑u⁻¹) M hM' t := by
+  obtain ⟨k, hk⟩ := id hx
+  have hk' : ((u : A) * x * ↑u⁻¹) ^ k = 0 := by rw [Units.conj_pow, hk, mul_zero, zero_mul]
+  refine LinearMap.ext fun z => ?_
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul r v =>
+      rw [Module.End.mul_apply, Module.End.mul_apply, LinearMap.baseChange_tmul,
+        baseChangeExp_tmul_of_pow_eq_zero x M hM hk,
+        baseChangeExp_tmul_of_pow_eq_zero ((u : A) * x * ↑u⁻¹) M hM' hk', map_sum]
+      refine Finset.sum_congr rfl fun n _ => ?_
+      rw [LinearMap.baseChange_tmul]
+      refine congrArg _ (Subtype.ext ?_)
+      simp only [LinearEquiv.coe_coe, coe_integralUnitRestrict_apply,
+        coe_integralDividedPower_apply, coe_integralUnitRestrict_symm_apply,
+        Associative.dividedPower_units_conj, mul_smul]
+  | add a b ha hb => rw [map_add, map_add, ha, hb]
 
 end ExplicitAlgebra
 

--- a/TauCeti/RingTheory/Nilpotent/Exp.lean
+++ b/TauCeti/RingTheory/Nilpotent/Exp.lean
@@ -37,6 +37,7 @@ the exponentials above preserve an integral lattice. The application to the Kost
   of `x`.
 * `TauCeti.exp_zsmul_smul_mem`: `exp (t • x)` preserves an additive subgroup that the divided
   powers of `x` preserve.
+* `TauCeti.nilpotentExpUnit`: the exponential of a nilpotent element as a unit.
 * `TauCeti.expZSMulHom`: the integer-parameter group of units `t ↦ exp (t • x)`.
 * `TauCeti.expZSMulAddAut`: the induced action by additive automorphisms on an additive subgroup
   preserved by the divided powers of `x`.
@@ -105,20 +106,55 @@ theorem exp_zsmul_smul_mem {x : A} (hx : IsNilpotent x) {S : Type*} [SetLike S V
     rw [← Int.cast_smul_eq_zsmul A, smul_assoc, Int.cast_smul_eq_zsmul]
     exact zsmul_mem (hM n v hv) _
 
+/-- The exponential of a nilpotent element preserves an additive subgroup preserved by every
+divided power of it. -/
+theorem exp_smul_mem {x : A} (hx : IsNilpotent x) {S : Type*} [SetLike S V]
+    [AddSubgroupClass S V] {M : S}
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    {v : V} (hv : v ∈ M) : exp x • v ∈ M := by
+  simpa using exp_zsmul_smul_mem hx hM 1 hv
+
+/-- The exponential of the negative of a nilpotent element preserves an additive subgroup
+preserved by every divided power of it. -/
+theorem exp_neg_smul_mem {x : A} (hx : IsNilpotent x) {S : Type*} [SetLike S V]
+    [AddSubgroupClass S V] {M : S}
+    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    {v : V} (hv : v ∈ M) : exp (-x) • v ∈ M := by
+  simpa using exp_zsmul_smul_mem hx hM (-1) hv
+
 end Modules
 
 /-! ## The one-parameter group of units -/
+
+/-- The unit `exp x` attached to a nilpotent element `x`, with inverse `exp (-x)`.
+
+For a Chevalley root vector this is the root subgroup element `x_α (1)`. -/
+noncomputable def nilpotentExpUnit {x : A} (hx : IsNilpotent x) : Aˣ where
+  val := exp x
+  inv := exp (-x)
+  val_inv := exp_mul_exp_neg_self hx
+  inv_val := exp_neg_mul_exp_self hx
+
+/-- Coercing `nilpotentExpUnit hx` to `A` yields `exp x`. -/
+@[simp]
+theorem coe_nilpotentExpUnit {x : A} (hx : IsNilpotent x) :
+    ((nilpotentExpUnit hx : Aˣ) : A) = exp x :=
+  -- The parentheses opt out of the exported-theorem exposure check, so that `nilpotentExpUnit`
+  -- can stay sealed and this `@[simp]` lemma remain its public characterization.
+  (rfl)
+
+/-- Coercing the inverse of `nilpotentExpUnit hx` to `A` yields `exp (-x)`. -/
+@[simp]
+theorem coe_inv_nilpotentExpUnit {x : A} (hx : IsNilpotent x) :
+    (((nilpotentExpUnit hx)⁻¹ : Aˣ) : A) = exp (-x) :=
+  (rfl)
 
 /-- The one-parameter group of units `t ↦ exp (t • x)` attached to a nilpotent element `x`.
 
 For a Chevalley root vector this is the root subgroup map `x_α` evaluated on the integral points of
 the additive group. -/
 noncomputable def expZSMulHom {x : A} (hx : IsNilpotent x) : Multiplicative ℤ →* Aˣ where
-  toFun t :=
-    { val := exp ((Multiplicative.toAdd t : ℤ) • x)
-      inv := exp (-((Multiplicative.toAdd t : ℤ) • x))
-      val_inv := exp_mul_exp_neg_self (hx.smul _)
-      inv_val := exp_neg_mul_exp_self (hx.smul _) }
+  toFun t := nilpotentExpUnit (hx.smul (Multiplicative.toAdd t : ℤ))
   map_one' := by
     ext
     simp

--- a/TauCeti/RingTheory/Nilpotent/Exp.lean
+++ b/TauCeti/RingTheory/Nilpotent/Exp.lean
@@ -106,22 +106,6 @@ theorem exp_zsmul_smul_mem {x : A} (hx : IsNilpotent x) {S : Type*} [SetLike S V
     rw [← Int.cast_smul_eq_zsmul A, smul_assoc, Int.cast_smul_eq_zsmul]
     exact zsmul_mem (hM n v hv) _
 
-/-- The exponential of a nilpotent element preserves an additive subgroup preserved by every
-divided power of it. -/
-theorem exp_smul_mem {x : A} (hx : IsNilpotent x) {S : Type*} [SetLike S V]
-    [AddSubgroupClass S V] {M : S}
-    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
-    {v : V} (hv : v ∈ M) : exp x • v ∈ M := by
-  simpa using exp_zsmul_smul_mem hx hM 1 hv
-
-/-- The exponential of the negative of a nilpotent element preserves an additive subgroup
-preserved by every divided power of it. -/
-theorem exp_neg_smul_mem {x : A} (hx : IsNilpotent x) {S : Type*} [SetLike S V]
-    [AddSubgroupClass S V] {M : S}
-    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
-    {v : V} (hv : v ∈ M) : exp (-x) • v ∈ M := by
-  simpa using exp_zsmul_smul_mem hx hM (-1) hv
-
 end Modules
 
 /-! ## The one-parameter group of units -/


### PR DESCRIPTION
This PR constructs the Weyl element of a pair of Kostant root subgroups and proves the two relations that make it usable as pinning data. Let `U_ℤ = kostantForm e h` act on a rational vector space `V` through `ρ`, let `M ≤ V` be a `U_ℤ`-stable additive subgroup, and let the images of two distinguished root vectors `eᵢ`, `eⱼ` form, with a distinguished Cartan vector `h c`, an `sl₂` triple in `Module.End ℚ V`. `TauCeti.UniversalEnvelopingAlgebra.kostantWeylPoints` is the resulting automorphism of `A ⊗[ℤ] M` for every commutative ring `A` of points; `kostantWeylPoints_toLinearMap_eq` identifies it with Chevalley's product `x_i(1) x_j(-1) x_i(1)` of root subgroup elements, and `kostantWeylPoints_conj_baseChangeExp` proves the relation `n x_i(u) n⁻¹ = x_j(-u)` for every parameter `u : A`. `weylUnit_apply_eigenvector` records the induced action on weights: `n` sends an eigenvector of `ρ(h c)` of eigenvalue `m` to one of eigenvalue `-m`, and `weylUnit_smul_mem` says that image is still in the lattice.

The point of doing this integrally is that the ring of points is arbitrary. The three exponentials have integer parameters, so `kostantWeylPoints` is the scalar extension of one automorphism of the lattice `M` itself, namely the restriction of the unit `exp ρ(eᵢ) · exp (-ρ(eⱼ)) · exp ρ(eᵢ)` of `Module.End ℚ V`; and the conjugation relation reduces entirely to the Lie-algebra identity `n ρ(eᵢ) n⁻¹ = -ρ(eⱼ)`, because conjugation by a unit is an algebra automorphism and therefore commutes with divided powers. Nothing divides by a factorial in `A`, so the relations hold in characteristic two and three, where the exponential series itself does not exist.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, whose fifth item is "**Root subgroup maps.** `x_α : 𝔾_a → G` for each root `α`, the Chevalley commutator relations they satisfy, and the equations pinning them against the pinning. Downstream work states its conventions against these, so they are part of the interface, not an implementation detail." The commutator relations of that item are on `main` (`Kostant/RootSubgroup/Commutator.lean`) and describe how two root subgroups interact; what was missing was how the reflection permutes them, which is the normaliser-of-the-torus half of the second item, "**Pinnings.** A pinning `(G, T, B, {X_α})` of a split reductive group scheme". What remains on that milestone after this PR: the split maximal torus and the assembled pinned group scheme with its Borel, integral PBW with the finite free admissible lattice (in flight in #3053 and #3061), base change with pinning compatibility, the pinned isomorphism theorem, and the characteristic two and three special isogenies.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

The dependency edge is the one `CFSGStatement` declares. Its milestone **L0, "pinned ambient groups"**, produces `ValidLieTypeIndex.AmbientGroup` and states that it consumes "the pinned Chevalley--Demazure group scheme over `ℤ` (reductive groups Layer 9)", consuming it rather than restating it. `CFSGStatement` has no unclaimed local step: `I0` and the twenty-six `S1` sporadic presentations are complete on `main` with their dispatcher, `A0` and `L1`--`L3` all wait on `L0`, and the root-systems Layer 6 input `DynkinType.simplyConnectedRootDatum` landed in #3485. So the whole remaining critical path runs through this Layer 9 lane.

This was the most effective current step because the surrounding lane is crowded but this link was empty. `kostantRootSubgroupPoints` with its naturality, matrix coordinates, comodule point representation and scheme representability are landed, and the Chevalley commutator relations are landed or in flight (#3490, #3505, #3513); the elementary group of the root subgroups is in flight (#3506) and the weight decomposition of a stable lattice is in flight (#3518). None of those supplies a Weyl-group element, and none of them is touched here: the only Kostant file this PR adds is `RootSubgroup/Weyl.lean`.

Add `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Weyl.lean` (302 lines), extend `TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean` by 194 lines, `TauCeti/Algebra/Lie/Sl2/WeylAutomorphism.lean` by 106, `TauCeti/RingTheory/Nilpotent/Exp.lean` by 46, and `TauCeti/RingTheory/DividedPowers/Associative.lean` by 10.

The additions outside the Kostant file are the reusable half of the argument, and are placed with the definitions they are about. `TauCeti.Associative.dividedPower_units_conj` says a conjugation passes through a divided power, and sits beside the existing `map_dividedPower` in the divided-powers file; its proof is Mathlib's `Units.conj_pow`. `TauCeti.nilpotentExpUnit` bundles `IsNilpotent.exp x` as a unit and now also defines the existing `expZSMulHom`, which used to inline it; the name is `nilpotentExpUnit` rather than `expUnit` because `TauCeti.expUnit` already names the normed-space exponential in `TauCeti/Geometry/Lie/Exponential/Units/Basic.lean`. `TauCeti.integralUnitRestrict` and `TauCeti.baseChangeExp_intCast` express a unit preserving the lattice, and a one-parameter subgroup at an integer parameter, as integral operators, and `TauCeti.baseChange_integralUnitRestrict_conj_baseChangeExp` is the general conjugation lemma of which the Chevalley relation is one instance; these belong with `baseChangeExp`. `TauCeti.weylUnit` and `TauCeti.weylAut_apply_eq_weylUnit_conj` add the associative-algebra section to the file that already defines the Weyl automorphism `TauCeti.weylAut`, so that the group-level statements `weylUnit_conj_h`, `weylUnit_conj_e`, `weylUnit_conj_f` and `lie_weylUnit_conj` are corollaries of the Lie-level ones rather than reproofs of them.

Two implementation notes for reviewers. `TauCeti.baseChangeExp_congr` exists because the base-changed exponential carries its own stability proof, so rewriting the element it is attached to needs a congruence lemma rather than `rw`. The private `intCast_mul_tmul` moves an integer scalar across `⊗[ℤ]` by hand: the `ℤ`-module structure on the ring of points is the one carried by its explicit `ℤ`-algebra, which is not the `AddCommGroup.toIntModule` structure that `TensorProduct.CompatibleSMul.int` is stated for, so `TensorProduct.smul_tmul` does not apply.

No Mathlib infrastructure is vendored. The proofs consume Mathlib's `IsNilpotent.exp` with `exp_mul_exp_neg_self` and `map_exp`, `Units.conj_pow`, `AddEquiv.toIntLinearEquiv`, `LinearMap.baseChange`, `LinearEquiv.ofLinearMap` and `IsSl2Triple`, together with Tau Ceti's existing `kostantForm`, `baseChangeExp`, `expAd` with `expAd_apply_eq_exp_mul_exp_neg`, and `weylAut` with its values on the triple. The mathematics follows R. W. Carter, *Simple Groups of Lie Type*, §§6.4 and 7.2, R. Steinberg, *Lectures on Chevalley Groups*, §3, and J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27, all credited in the module documentation.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"kostant-weyl-element"}-->

🤖 Prepared with Claude Code
