### PR TITLE
feat: trivialize unipotent subgroups of diagonalizable groups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/GeometricSemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/GeometricSemisimplePoint.lean
@@ -85,7 +85,10 @@ theorem geometricallySemisimplePointsCommHopfAlgProperty_of_surjective
     geometricallySemisimplePointsCommHopfAlgProperty k K := by
   rw [geometricallySemisimplePointsCommHopfAlgProperty_iff] at hH ⊢
   intro g
-  exact (HopfAlgebra.isSemisimplePoint_mapDomain_iff_of_surjective f.hom hf g).mp (hH _)
+  apply (HopfAlgebra.isSemisimplePoint_mapDomain_iff_of_surjective f.hom hf g).mp
+  rw [← AlgHom.mapDomain_apply, ← HopfAlgebra.Point.unipotentPart_mapDomain,
+    ← HopfAlgebra.isSemisimplePoint_iff_unipotentPart_eq_one]
+  exact hH _
 
 /-- The tensor product of two coordinate Hopf algebras with semisimple geometric points again has
 only semisimple geometric points. Contravariantly, geometric-point semisimplicity is closed under

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/GeometricSemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/GeometricSemisimplePoint.lean
@@ -7,7 +7,7 @@ module
 public import Mathlib.Algebra.Category.CommHopfAlgCat
 public import Mathlib.CategoryTheory.ObjectProperty.CompleteLattice
 public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
-public import TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition.Naturality
 public import TauCeti.Algebra.AlgebraicGroup.Representation.SemisimplePoint
 
 /-!
@@ -21,6 +21,8 @@ that this object property is invariant under isomorphisms and closed under tenso
 
 * `TauCeti.geometricallySemisimplePointsCommHopfAlgProperty`: the object property asserting that
   every algebraic-closure-valued point is semisimple.
+* `TauCeti.geometricallySemisimplePointsCommHopfAlgProperty_of_surjective`: closed subgroups of a
+  group with semisimple geometric points again have semisimple geometric points.
 * `TauCeti.geometricallySemisimplePointsCommHopfAlgProperty.tensorProduct`: geometric semisimplicity
   is closed under direct products of affine groups.
 
@@ -73,6 +75,18 @@ instance :
     apply (HopfAlgebra.isSemisimplePoint_mapDomain_iff e' g).mp
     exact hH _
 
+/-- Geometric-point semisimplicity descends along a surjective morphism of coordinate Hopf
+algebras. Contravariantly, closed subgroups of a group with semisimple geometric points again
+have semisimple geometric points. -/
+theorem geometricallySemisimplePointsCommHopfAlgProperty_of_surjective
+    {H K : CommHopfAlgCat.{u} k}
+    (f : H ⟶ K) (hf : Function.Surjective f.hom)
+    (hH : geometricallySemisimplePointsCommHopfAlgProperty k H) :
+    geometricallySemisimplePointsCommHopfAlgProperty k K := by
+  rw [geometricallySemisimplePointsCommHopfAlgProperty_iff] at hH ⊢
+  intro g
+  exact (HopfAlgebra.isSemisimplePoint_mapDomain_iff_of_surjective f.hom hf g).mp (hH _)
+
 /-- The tensor product of two coordinate Hopf algebras with semisimple geometric points again has
 only semisimple geometric points. Contravariantly, geometric-point semisimplicity is closed under
 direct products of affine groups. -/
@@ -97,23 +111,7 @@ theorem geometricallySemisimplePointsCommHopfAlgProperty_iff_forall_unipotentPar
   rw [geometricallySemisimplePointsCommHopfAlgProperty_iff]
   apply forall_congr'
   intro g
-  constructor
-  · intro hg
-    exact HopfAlgebra.Point.unipotentPart_eq_one_of_isSemisimple k H (AlgebraicClosure k)
-      (fun M ↦ (HopfAlgebra.isSemisimplePoint_def g).mp hg M)
-  · intro hu
-    rw [HopfAlgebra.isSemisimplePoint_def]
-    intro M
-    have hdecomp := HopfAlgebra.Point.jordanDecomposition_spec k H (AlgebraicClosure k) g
-    have hs := hdecomp.1 M
-    have hg_eq : g = (HopfAlgebra.Point.jordanDecomposition k H (AlgebraicClosure k) g).1 := by
-      have hmul := hdecomp.2.2.2
-      have h2 : (HopfAlgebra.Point.jordanDecomposition k H (AlgebraicClosure k) g).2 = 1 := by
-        rw [HopfAlgebra.Point.jordanDecomposition_snd, hu]
-      rw [h2, mul_one] at hmul
-      exact hmul
-    rw [hg_eq]
-    exact hs
+  exact HopfAlgebra.isSemisimplePoint_iff_unipotentPart_eq_one g
 
 /-- Every geometric point is semisimple exactly when the semisimple part of every geometric point
 is the point itself. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/GeometricSemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/GeometricSemisimplePoint.lean
@@ -86,8 +86,6 @@ theorem geometricallySemisimplePointsCommHopfAlgProperty_of_surjective
   rw [geometricallySemisimplePointsCommHopfAlgProperty_iff] at hH ⊢
   intro g
   apply (HopfAlgebra.isSemisimplePoint_mapDomain_iff_of_surjective f.hom hf g).mp
-  rw [← AlgHom.mapDomain_apply, ← HopfAlgebra.Point.unipotentPart_mapDomain,
-    ← HopfAlgebra.isSemisimplePoint_iff_unipotentPart_eq_one]
   exact hH _
 
 /-- The tensor product of two coordinate Hopf algebras with semisimple geometric points again has

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Representation.JordanDecomposition.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Representation.SemisimplePoint
 
@@ -31,6 +32,8 @@ ReductiveGroups roadmap.
 * `TauCeti.HopfAlgebra.Point.semisimplePart_mapDomain` and
   `TauCeti.HopfAlgebra.Point.unipotentPart_mapDomain`: the two component formulas, with
   `semisimplePart_toConv_comp` and `unipotentPart_toConv_comp` as their simp-normal forms.
+* `TauCeti.HopfAlgebra.isSemisimplePoint_mapDomain_iff_of_surjective`: precomposition by a
+  surjective coordinate morphism detects semisimple points.
 
 ## References
 
@@ -127,5 +130,55 @@ theorem unipotentPart_toConv_comp (φ : H₁ →ₐc[k] H₂)
   simpa only [AlgHom.mapDomain_apply] using unipotentPart_mapDomain φ g
 
 end Point
+
+variable [PerfectField K]
+
+/-- A point is semisimple exactly when its unipotent part is the identity. -/
+theorem isSemisimplePoint_iff_unipotentPart_eq_one (g : WithConv (H₁ →ₐ[k] K)) :
+    IsSemisimplePoint g ↔ Point.unipotentPart k H₁ K g = 1 := by
+  constructor
+  · intro hg
+    exact Point.unipotentPart_eq_one_of_isSemisimple k H₁ K
+      ((isSemisimplePoint_def g).mp hg)
+  · intro hu
+    rw [isSemisimplePoint_def]
+    intro M
+    have hdecomp := Point.jordanDecomposition_spec k H₁ K g
+    have hg_eq : g = (Point.jordanDecomposition k H₁ K g).1 := by
+      have hmul := hdecomp.2.2.2
+      rw [Point.jordanDecomposition_snd, hu, mul_one] at hmul
+      exact hmul
+    rw [hg_eq]
+    exact hdecomp.1 M
+
+/-- Precomposition with a surjective coordinate Hopf-algebra morphism detects semisimple points.
+
+Contravariantly, this says that a point of a closed subgroup is semisimple exactly when its image
+in the ambient affine group is semisimple. -/
+@[simp]
+theorem isSemisimplePoint_mapDomain_iff_of_surjective
+    (f : H₁ →ₐc[k] H₂) (hf : Function.Surjective f)
+    (g : WithConv (H₂ →ₐ[k] K)) :
+    IsSemisimplePoint (toConv (g.ofConv.comp (f : H₁ →ₐ[k] H₂))) ↔
+      IsSemisimplePoint g := by
+  rw [← AlgHom.mapDomain_apply]
+  constructor
+  · intro hg
+    rw [isSemisimplePoint_iff_unipotentPart_eq_one] at hg ⊢
+    let f' : CommHopfAlgCat.of k H₁ ⟶ CommHopfAlgCat.of k H₂ := CommHopfAlgCat.ofHom f
+    apply CommHopfAlgCat.mapPointsFunctor_app_injective_of_surjective f' hf
+      (CommAlgCat.of k K)
+    have hmap :
+        (CommHopfAlgCat.mapPointsFunctor f').app (CommAlgCat.of k K)
+            (Point.unipotentPart k H₂ K g) = 1 := by
+      rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
+      simp only [pointsFunctor_obj]
+      dsimp [f']
+      rw [← AlgHom.mapDomain_apply, ← Point.unipotentPart_mapDomain]
+      exact hg
+    exact hmap.trans (map_one _).symm
+  · intro hg
+    exact hg.mapDomain f
+
 end HopfAlgebra
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -134,7 +134,6 @@ end Point
 variable [PerfectField K]
 
 /-- A point is semisimple exactly when its unipotent part is the identity. -/
-@[simp]
 theorem isSemisimplePoint_iff_unipotentPart_eq_one (g : WithConv (H₁ →ₐ[k] K)) :
     IsSemisimplePoint g ↔ Point.unipotentPart k H₁ K g = 1 := by
   constructor
@@ -160,12 +159,11 @@ in the ambient affine group is semisimple. -/
 theorem isSemisimplePoint_mapDomain_iff_of_surjective
     (f : H₁ →ₐc[k] H₂) (hf : Function.Surjective f)
     (g : WithConv (H₂ →ₐ[k] K)) :
-    toConv ((Point.unipotentPart k H₂ K g).ofConv.comp (f : H₁ →ₐ[k] H₂)) = 1 ↔
-      IsSemisimplePoint g := by
-  rw [← AlgHom.mapDomain_apply]
+    IsSemisimplePoint (toConv (g.ofConv.comp (f : H₁ →ₐ[k] H₂))) ↔ IsSemisimplePoint g := by
   constructor
   · intro hg
-    rw [isSemisimplePoint_iff_unipotentPart_eq_one]
+    rw [isSemisimplePoint_iff_unipotentPart_eq_one] at hg ⊢
+    rw [Point.unipotentPart_toConv_comp, ← AlgHom.mapDomain_apply] at hg
     let f' : CommHopfAlgCat.of k H₁ ⟶ CommHopfAlgCat.of k H₂ := CommHopfAlgCat.ofHom f
     apply CommHopfAlgCat.mapPointsFunctor_app_injective_of_surjective f' hf
       (CommAlgCat.of k K)
@@ -179,8 +177,6 @@ theorem isSemisimplePoint_mapDomain_iff_of_surjective
       exact hg
     exact hmap.trans (map_one _).symm
   · intro hg
-    rw [← Point.unipotentPart_mapDomain,
-      ← isSemisimplePoint_iff_unipotentPart_eq_one]
     exact hg.mapDomain f
 
 end HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Naturality.lean
@@ -134,6 +134,7 @@ end Point
 variable [PerfectField K]
 
 /-- A point is semisimple exactly when its unipotent part is the identity. -/
+@[simp]
 theorem isSemisimplePoint_iff_unipotentPart_eq_one (g : WithConv (H₁ →ₐ[k] K)) :
     IsSemisimplePoint g ↔ Point.unipotentPart k H₁ K g = 1 := by
   constructor
@@ -159,12 +160,12 @@ in the ambient affine group is semisimple. -/
 theorem isSemisimplePoint_mapDomain_iff_of_surjective
     (f : H₁ →ₐc[k] H₂) (hf : Function.Surjective f)
     (g : WithConv (H₂ →ₐ[k] K)) :
-    IsSemisimplePoint (toConv (g.ofConv.comp (f : H₁ →ₐ[k] H₂))) ↔
+    toConv ((Point.unipotentPart k H₂ K g).ofConv.comp (f : H₁ →ₐ[k] H₂)) = 1 ↔
       IsSemisimplePoint g := by
   rw [← AlgHom.mapDomain_apply]
   constructor
   · intro hg
-    rw [isSemisimplePoint_iff_unipotentPart_eq_one] at hg ⊢
+    rw [isSemisimplePoint_iff_unipotentPart_eq_one]
     let f' : CommHopfAlgCat.of k H₁ ⟶ CommHopfAlgCat.of k H₂ := CommHopfAlgCat.ofHom f
     apply CommHopfAlgCat.mapPointsFunctor_app_injective_of_surjective f' hf
       (CommAlgCat.of k K)
@@ -174,10 +175,12 @@ theorem isSemisimplePoint_mapDomain_iff_of_surjective
       rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
       simp only [pointsFunctor_obj]
       dsimp [f']
-      rw [← AlgHom.mapDomain_apply, ← Point.unipotentPart_mapDomain]
+      rw [← AlgHom.mapDomain_apply]
       exact hg
     exact hmap.trans (map_one _).symm
   · intro hg
+    rw [← Point.unipotentPart_mapDomain,
+      ← isSemisimplePoint_iff_unipotentPart_eq_one]
     exact hg.mapDomain f
 
 end HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Semisimple.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Semisimple.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.FiniteType
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Semisimple
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+public import TauCeti.RingTheory.FiniteType.PointSeparation
+
+/-!
+# Semisimple unipotent affine groups are trivial
+
+Over a perfect field, a point that is both semisimple and unipotent is the identity. This file
+turns that pointwise fact into a scheme-theoretic rigidity statement: if a reduced finite-type
+commutative Hopf algebra has only semisimple and unipotent geometric points, then its counit is an
+isomorphism with the base field. Reducedness is essential because geometric points do not detect
+infinitesimal group schemes such as `μₚ` and `αₚ` in characteristic `p`.
+
+The main application is to diagonalizable groups. Every point of a diagonalizable group is
+semisimple, and semisimplicity is reflected by a closed immersion. It follows that every reduced
+finite-type closed subgroup of a diagonalizable group whose geometric points are unipotent is the
+trivial group. This is the rigidity input for the reductive-groups roadmap: once the unipotent
+radical is constructed, it proves that the unipotent radical of a torus is trivial.
+
+## Main declarations
+
+* `TauCeti.FiniteTypeCommHopfAlgCat.counitBialgEquivOfGeometricallySemisimpleUnipotent`: the
+  counit equivalence for a reduced group with semisimple and unipotent geometric points.
+* `TauCeti.DiagonalizableGroup.quotientCounitBialgEquivOfGeometricallyUnipotent`: a reduced
+  unipotent closed subgroup of a finite-type diagonalizable group is trivial.
+* `TauCeti.DiagonalizableGroup.eq_augmentation_of_geometricallyUnipotent`: its
+  defining Hopf ideal is the augmentation ideal.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 12.40.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+
+This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap. It
+supplies the trivial-unipotent-subgroup argument needed to prove that tori are reductive, using
+the geometric unipotence and diagonalizable-group semisimplicity developed in Layers 4 and 5.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u
+
+namespace HopfAlgebra
+
+variable {k H L : Type u} [Field k]
+variable [CommRing H] [_root_.HopfAlgebra k H]
+variable [Field L] [Algebra k L] [PerfectField L]
+
+/-- A point that is both semisimple and unipotent is the identity. -/
+theorem IsSemisimplePoint.eq_one_of_isUnipotent {g : WithConv (H →ₐ[k] L)}
+    (hsemisimple : IsSemisimplePoint g) (hunipotent : IsUnipotentPoint g) :
+    g = 1 := by
+  rw [isSemisimplePoint_iff_unipotentPart_eq_one] at hsemisimple
+  rw [Point.isUnipotentPoint_iff_unipotentPart_eq_self] at hunipotent
+  exact hunipotent.symm.trans hsemisimple
+
+end HopfAlgebra
+
+namespace FiniteTypeCommHopfAlgCat
+
+variable {k : Type u} [Field k]
+
+/-- The counit of a reduced finite-type commutative Hopf algebra is bijective when every
+geometric point is both semisimple and unipotent. -/
+theorem counitBialgHom_bijective_of_geometricallySemisimple_of_geometricallyUnipotent
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) [IsReduced H]
+    (hsemisimple : geometricallySemisimplePointsCommHopfAlgProperty k H.obj)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k H.obj) :
+    Function.Bijective (Bialgebra.counitBialgHom k H) := by
+  constructor
+  · intro x y hxy
+    apply eq_of_forall_algHom_apply_eq (k := k) (A := H) (K := AlgebraicClosure k)
+    intro f
+    let g : WithConv (H →ₐ[k] AlgebraicClosure k) := toConv f
+    have hgsemisimple :=
+      (geometricallySemisimplePointsCommHopfAlgProperty_iff k H.obj).mp hsemisimple g
+    have hgunipotent :=
+      (geometricallyUnipotentPointsCommHopfAlgProperty_iff k H.obj).mp hunipotent g
+    have hg : g = 1 := hgsemisimple.eq_one_of_isUnipotent hgunipotent
+    have hfx : f x = algebraMap k (AlgebraicClosure k) (Coalgebra.counit x) := by
+      have := congrArg (fun q : WithConv (H →ₐ[k] AlgebraicClosure k) ↦ q.ofConv x) hg
+      simpa [g, AlgHom.convOne_apply] using this
+    have hfy : f y = algebraMap k (AlgebraicClosure k) (Coalgebra.counit y) := by
+      have := congrArg (fun q : WithConv (H →ₐ[k] AlgebraicClosure k) ↦ q.ofConv y) hg
+      simpa [g, AlgHom.convOne_apply] using this
+    rw [hfx, hfy]
+    change Coalgebra.counit x = Coalgebra.counit y at hxy
+    rw [hxy]
+  · intro r
+    exact ⟨algebraMap k H r, by simp⟩
+
+/-- A reduced finite-type affine group whose geometric points are all semisimple and unipotent is
+the trivial group: its counit is a bialgebra equivalence with the base field. -/
+noncomputable def counitBialgEquivOfGeometricallySemisimpleUnipotent
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) [IsReduced H]
+    (hsemisimple : geometricallySemisimplePointsCommHopfAlgProperty k H.obj)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k H.obj) :
+    H ≃ₐc[k] k :=
+  BialgEquiv.ofBijective (Bialgebra.counitBialgHom k H)
+    (counitBialgHom_bijective_of_geometricallySemisimple_of_geometricallyUnipotent
+      H hsemisimple hunipotent)
+
+/-- The equivalence from a geometrically semisimple and unipotent affine group to the base field
+is its counit. -/
+@[simp]
+theorem counitBialgEquivOfGeometricallySemisimpleUnipotent_apply
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) [IsReduced H]
+    (hsemisimple : geometricallySemisimplePointsCommHopfAlgProperty k H.obj)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k H.obj) (x : H) :
+    counitBialgEquivOfGeometricallySemisimpleUnipotent H hsemisimple hunipotent x =
+      Coalgebra.counit x := by
+  rfl
+
+/-- The inverse counit equivalence is the structure map from the base field. -/
+@[simp]
+theorem counitBialgEquivOfGeometricallySemisimpleUnipotent_symm_apply
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) [IsReduced H]
+    (hsemisimple : geometricallySemisimplePointsCommHopfAlgProperty k H.obj)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k H.obj) (r : k) :
+    (counitBialgEquivOfGeometricallySemisimpleUnipotent H hsemisimple hunipotent).symm r =
+      algebraMap k H r := by
+  let e := counitBialgEquivOfGeometricallySemisimpleUnipotent H hsemisimple hunipotent
+  apply e.injective
+  change e (e.symm r) = e (algebraMap k H r)
+  rw [e.apply_symm_apply]
+  exact (Bialgebra.counit_algebraMap (R := k) (A := H) r).symm
+
+/-- A Hopf ideal is the augmentation ideal when its quotient is reduced, finite type, and has
+only semisimple and unipotent geometric points. Equivalently, the closed subgroup cut out by the
+ideal is trivial. -/
+theorem eq_augmentation_of_geometricallySemisimple_of_geometricallyUnipotent
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (I : HopfIdeal k H)
+    [IsReduced (quotient H I)]
+    (hsemisimple : geometricallySemisimplePointsCommHopfAlgProperty k (quotient H I).obj)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k (quotient H I).obj) :
+    I = HopfIdeal.augmentation k H := by
+  apply HopfIdeal.ext
+  intro x
+  rw [HopfIdeal.mem_augmentation]
+  constructor
+  · exact I.counit_eq_zero
+  · intro hx
+    rw [← HopfIdeal.mem_toIdeal]
+    apply (mkQuotient_eq_zero_iff H I x).mp
+    let e := counitBialgEquivOfGeometricallySemisimpleUnipotent
+      (quotient H I) hsemisimple hunipotent
+    apply e.injective
+    change Coalgebra.counit (R := k) (toBialgHom (mkQuotient H I) x) =
+      Coalgebra.counit (R := k) (0 : quotient H I)
+    simpa only [CoalgHomClass.counit_comp_apply, map_zero] using hx
+
+end FiniteTypeCommHopfAlgCat
+
+namespace DiagonalizableGroup
+
+variable (k : Type u) [Field k]
+
+/-- A reduced finite-type closed subgroup of a diagonalizable group is trivial when all of its
+geometric points are unipotent.
+
+The closed subgroup is represented by the quotient of `k[G]` by `I`. No normality or connectedness
+hypothesis is needed: every quotient point embeds into the diagonalizable ambient group, hence is
+semisimple, and a semisimple unipotent point is the identity. -/
+noncomputable def quotientCounitBialgEquivOfGeometricallyUnipotent
+    (G : FGCommGrpCat.{u})
+    (I : HopfIdeal k (coordinateRing k G))
+    [IsReduced (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I)]
+    (hI : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I).obj) :
+    FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I ≃ₐc[k] k := by
+  apply FiniteTypeCommHopfAlgCat.counitBialgEquivOfGeometricallySemisimpleUnipotent _ _ hI
+  apply geometricallySemisimplePointsCommHopfAlgProperty_of_surjective k
+    (FiniteTypeCommHopfAlgCat.mkQuotient (coordinateRing k G) I).hom
+    (Ideal.Quotient.mkₐ_surjective k I.toIdeal)
+  exact geometricallySemisimplePointsCommHopfAlgProperty k G
+
+/-- The defining Hopf ideal of a reduced finite-type unipotent closed subgroup of a
+diagonalizable group is the augmentation ideal. Thus the closed subgroup is the identity
+subgroup, not merely abstractly isomorphic to it. -/
+theorem eq_augmentation_of_geometricallyUnipotent
+    (G : FGCommGrpCat.{u})
+    (I : HopfIdeal k (coordinateRing k G))
+    [IsReduced (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I)]
+    (hI : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I).obj) :
+    I = HopfIdeal.augmentation k (coordinateRing k G) := by
+  apply
+    FiniteTypeCommHopfAlgCat.eq_augmentation_of_geometricallySemisimple_of_geometricallyUnipotent
+      (coordinateRing k G) I _ hI
+  apply geometricallySemisimplePointsCommHopfAlgProperty_of_surjective k
+    (FiniteTypeCommHopfAlgCat.mkQuotient (coordinateRing k G) I).hom
+    (Ideal.Quotient.mkₐ_surjective k I.toIdeal)
+  exact geometricallySemisimplePointsCommHopfAlgProperty k G
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Semisimple.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Semisimple.lean
@@ -198,6 +198,31 @@ noncomputable def quotientCounitBialgEquivOfGeometricallyUnipotent
     (Ideal.Quotient.mkₐ_surjective k I.toIdeal)
   exact geometricallySemisimplePointsCommHopfAlgProperty k G
 
+/-- The equivalence for a geometrically unipotent closed subgroup is its counit. -/
+@[simp]
+theorem quotientCounitBialgEquivOfGeometricallyUnipotent_apply
+    (G : FGCommGrpCat.{u})
+    (I : HopfIdeal k (coordinateRing k G))
+    [IsReduced (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I)]
+    (hI : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I).obj)
+    (x : FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I) :
+    quotientCounitBialgEquivOfGeometricallyUnipotent k G I hI x = Coalgebra.counit x := by
+  rfl
+
+/-- The inverse equivalence for a geometrically unipotent closed subgroup is the structure map. -/
+@[simp]
+theorem quotientCounitBialgEquivOfGeometricallyUnipotent_symm_apply
+    (G : FGCommGrpCat.{u})
+    (I : HopfIdeal k (coordinateRing k G))
+    [IsReduced (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I)]
+    (hI : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I).obj)
+    (r : k) :
+    (quotientCounitBialgEquivOfGeometricallyUnipotent k G I hI).symm r =
+      algebraMap k (FiniteTypeCommHopfAlgCat.quotient (coordinateRing k G) I) r := by
+  apply FiniteTypeCommHopfAlgCat.counitBialgEquivOfGeometricallySemisimpleUnipotent_symm_apply
+
 /-- The defining Hopf ideal of a reduced finite-type unipotent closed subgroup of a
 diagonalizable group is the augmentation ideal. Thus the closed subgroup is the identity
 subgroup, not merely abstractly isomorphic to it. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Semisimple.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Semisimple.lean
@@ -98,8 +98,9 @@ theorem counitBialgHom_bijective_of_geometricallySemisimple_of_geometricallyUnip
       have := congrArg (fun q : WithConv (H →ₐ[k] AlgebraicClosure k) ↦ q.ofConv y) hg
       simpa [g, AlgHom.convOne_apply] using this
     rw [hfx, hfy]
-    change Coalgebra.counit x = Coalgebra.counit y at hxy
-    rw [hxy]
+    have hxy' : Coalgebra.counit (R := k) x = Coalgebra.counit (R := k) y := by
+      simpa only [Bialgebra.counitBialgHom_apply] using hxy
+    rw [hxy']
   · intro r
     exact ⟨algebraMap k H r, by simp⟩
 
@@ -134,10 +135,13 @@ theorem counitBialgEquivOfGeometricallySemisimpleUnipotent_symm_apply
     (counitBialgEquivOfGeometricallySemisimpleUnipotent H hsemisimple hunipotent).symm r =
       algebraMap k H r := by
   let e := counitBialgEquivOfGeometricallySemisimpleUnipotent H hsemisimple hunipotent
-  apply e.injective
-  change e (e.symm r) = e (algebraMap k H r)
-  rw [e.apply_symm_apply]
-  exact (Bialgebra.counit_algebraMap (R := k) (A := H) r).symm
+  refine e.toMulEquiv.symm_apply_eq.mpr ?_
+  calc
+    r = Coalgebra.counit (R := k) (algebraMap k H r) :=
+      (Bialgebra.counit_algebraMap (R := k) (A := H) r).symm
+    _ = e (algebraMap k H r) :=
+      (counitBialgEquivOfGeometricallySemisimpleUnipotent_apply
+        H hsemisimple hunipotent (algebraMap k H r)).symm
 
 /-- A Hopf ideal is the augmentation ideal when its quotient is reduced, finite type, and has
 only semisimple and unipotent geometric points. Equivalently, the closed subgroup cut out by the
@@ -158,10 +162,16 @@ theorem eq_augmentation_of_geometricallySemisimple_of_geometricallyUnipotent
     apply (mkQuotient_eq_zero_iff H I x).mp
     let e := counitBialgEquivOfGeometricallySemisimpleUnipotent
       (quotient H I) hsemisimple hunipotent
-    apply e.injective
-    change Coalgebra.counit (R := k) (toBialgHom (mkQuotient H I) x) =
-      Coalgebra.counit (R := k) (0 : quotient H I)
-    simpa only [CoalgHomClass.counit_comp_apply, map_zero] using hx
+    calc
+      toBialgHom (mkQuotient H I) x =
+          e.symm (e (toBialgHom (mkQuotient H I) x)) :=
+        (e.symm_apply_apply (toBialgHom (mkQuotient H I) x)).symm
+      _ = algebraMap k (quotient H I)
+          (Coalgebra.counit (R := k) (toBialgHom (mkQuotient H I) x)) := by
+        rw [counitBialgEquivOfGeometricallySemisimpleUnipotent_apply,
+          counitBialgEquivOfGeometricallySemisimpleUnipotent_symm_apply]
+      _ = 0 := by
+        rw [CoalgHomClass.counit_comp_apply, hx, map_zero]
 
 end FiniteTypeCommHopfAlgCat
 


### PR DESCRIPTION
This PR proves that every reduced finite-type closed subgroup of a diagonalizable group with geometrically unipotent points is the identity subgroup. It targets `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, “Reductive and semisimple groups,” specifically the `R_u(G_{k̄}) = 1` condition needed to show that tori are reductive.

The proof first characterizes semisimple points by trivial unipotent part and shows that a surjective coordinate Hopf-algebra morphism reflects semisimplicity. It packages the latter as closure of geometric-point semisimplicity under closed subgroups. A point that is both semisimple and unipotent is then the identity; point separation for reduced finite-type algebras makes the counit injective, while its algebra section makes it surjective. For a Hopf-ideal quotient of a diagonalizable coordinate ring, this identifies the quotient with the base field through the counit and proves that the defining ideal is exactly the augmentation ideal.

This is the most effective current bridge from the completed Layer 4 diagonalizable-group semisimplicity API and Layer 5 geometric-unipotence API to Layer 6: it establishes the rigidity conclusion the unipotent radical of a torus will consume without prematurely choosing a construction of that radical.

The arguments reuse Tau Ceti's Jordan-decomposition naturality, geometric semisimple and unipotent object properties, Hopf-ideal quotient API, augmentation ideal, and reduced finite-type point-separation theorem. No Mathlib infrastructure is vendored. The mathematical argument follows Milne, *Algebraic Groups* (2017), Proposition 12.40, and Springer, *Linear Algebraic Groups*, §2.4.

After this PR, Layer 6 still needs the geometric or perfect-field unipotent-radical construction, the reductive predicate built from it, and the remaining radical, centre, derived-group, and isogeny theory; once the radical exists, this result supplies the immediate torus reductivity proof.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"diagonalizable-unipotent-closed-subgroup-trivial"}-->

🤖 Prepared with Codex
