### PR TITLE
feat: close geometric solvability under extensions

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Extension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Extension.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
+
+/-!
+# Extensions of geometrically solvable affine groups
+
+Let `f : H ⟶ K` be a morphism of commutative Hopf algebras over a field `k`. Contravariantly,
+it represents a homomorphism from the affine group represented by `K` to the one represented by
+`H`. This file proves that the source group of geometric points is solvable when the target and
+the scheme-theoretic kernel are solvable.
+
+On coordinate rings, the kernel has algebra
+
+```text
+K / K·f(H⁺),
+```
+
+implemented as `CommHopfAlgCat.quotient K (CommHopfAlgCat.kernelHopfIdeal f)`. Its geometric
+points map injectively into those of `K`, with image exactly the kernel of the map induced by
+`f`. Mathlib's abstract extension theorem for solvable groups then applies directly. Conversely,
+a closed subgroup of a geometrically solvable affine group has solvable geometric points, so the
+kernel condition is also necessary once the source is solvable.
+
+## Main declarations
+
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_of_kernel`: geometric solvability is
+  closed under extensions.
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_iff_kernel`: when the target is
+  geometrically solvable, the source is geometrically solvable exactly when its kernel is.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+
+This supplies extension closure for the "Lie--Kolchin; solvable groups" milestone in Layer 5 of
+the ReductiveGroups roadmap. Together with closed-subgroup and product closure, it is part of the
+subgroup calculus needed for the solvable radical in Layer 6.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u
+
+/-- Geometric-point solvability is closed under extensions.
+
+For the group homomorphism represented by `f : H ⟶ K`, assume that the target `Spec H` and
+the scheme-theoretic kernel `Spec (K / K·f(H⁺))` have solvable groups of geometric points.
+Then the geometric point group of the source `Spec K` is solvable. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_of_kernel
+    (k : Type u) [Field k] {H K : CommHopfAlgCat.{u} k} (f : H ⟶ K)
+    (hH : geometricallySolvablePointsCommHopfAlgProperty k H)
+    (hkernel : geometricallySolvablePointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient K (CommHopfAlgCat.kernelHopfIdeal f))) :
+    geometricallySolvablePointsCommHopfAlgProperty k K := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff] at hH hkernel ⊢
+  let i : WithConv ((CommHopfAlgCat.quotient K
+      (CommHopfAlgCat.kernelHopfIdeal f)) →ₐ[k] AlgebraicClosure k) →*
+      WithConv (K →ₐ[k] AlgebraicClosure k) :=
+    (CommHopfAlgCat.quotientPointsHom K (CommHopfAlgCat.kernelHopfIdeal f)
+      (CommAlgCat.of k (AlgebraicClosure k))).hom
+  let p : WithConv (K →ₐ[k] AlgebraicClosure k) →*
+      WithConv (H →ₐ[k] AlgebraicClosure k) :=
+    AlgHom.mapDomain (H₁ := H) (H₂ := K) (A := AlgebraicClosure k) f.hom
+  refine @Group.isSolvable_of_ker_le_range
+    (WithConv (K →ₐ[k] AlgebraicClosure k)) _
+    (WithConv ((CommHopfAlgCat.quotient K
+      (CommHopfAlgCat.kernelHopfIdeal f)) →ₐ[k] AlgebraicClosure k))
+    (WithConv (H →ₐ[k] AlgebraicClosure k)) _ _ i p ?_ hkernel hH
+  intro g hg
+  have hp : p g = 1 := MonoidHom.mem_ker.mp hg
+  have hp' : toConv (g.ofConv.comp (f.hom : H →ₐ[k] K)) = 1 := by
+    simpa only [p, AlgHom.mapDomain_apply] using hp
+  dsimp only [i]
+  exact (CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff f
+    (CommAlgCat.of k (AlgebraicClosure k)) g).mp hp'
+
+/-- If the target of a homomorphism is geometrically solvable, then its source is geometrically
+solvable exactly when its scheme-theoretic kernel is.
+
+The forward implication is closed-subgroup stability, applied to the quotient coordinate map.
+The reverse implication is extension closure. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_iff_kernel
+    (k : Type u) [Field k] {H K : CommHopfAlgCat.{u} k} (f : H ⟶ K)
+    (hH : geometricallySolvablePointsCommHopfAlgProperty k H) :
+    geometricallySolvablePointsCommHopfAlgProperty k K ↔
+      geometricallySolvablePointsCommHopfAlgProperty k
+        (CommHopfAlgCat.quotient K (CommHopfAlgCat.kernelHopfIdeal f)) := by
+  constructor
+  · intro hK
+    exact geometricallySolvablePointsCommHopfAlgProperty_quotient k K
+      (CommHopfAlgCat.kernelHopfIdeal f) hK
+  · exact geometricallySolvablePointsCommHopfAlgProperty_of_kernel k f hH
+
+end TauCeti


### PR DESCRIPTION
This PR adds extension closure for geometric solvability of affine groups: for a coordinate Hopf-algebra morphism `f : H ⟶ K`, prove that solvability of the geometric points of `Spec H` and of the scheme-theoretic kernel `Spec (K / K·f(H⁺))` implies solvability of the geometric points of `Spec K`, and characterize solvability of the source by solvability of that kernel when the target is solvable.

The exact target is `ReductiveGroups/README.md`, Layer 5 milestone “Lie–Kolchin; solvable groups.” This is the most effective distinct current step because closed-subgroup and product closure are on `main`, the scheme-theoretic kernel already has its functor-of-points universal property, and the neighboring open work develops the invariant-flag side of Lie–Kolchin rather than the extension calculus needed later by the solvable radical.

After this PR, the milestone still needs Lie–Kolchin and the scheme-theoretic derived subgroup with its comparison to the geometric-points criterion; Layer 6 then needs construction of the solvable radical itself.

Add `TauCeti/Algebra/AlgebraicGroup/Solvable/Extension.lean` (105 lines). The proof reuses Mathlib's `Group.isSolvable_of_ker_le_range`, Tau Ceti's identification of quotient-Hopf-algebra points with the kernel of the induced points homomorphism, and the existing closed-subgroup stability theorem. The mathematical presentation follows J. C. Jantzen, *Representations of Algebraic Groups*, I.2, and T. A. Springer, *Linear Algebraic Groups*, §2.4, as credited in the module documentation; no external formalization or Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometric-solvability-extensions"}-->

🤖 Prepared with Codex
