### PR TITLE
feat: construct numbered-symmetry automorphisms of Kostant elementary groups

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Diagram.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Diagram.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Elementary
+public import TauCeti.RingTheory.Nilpotent.Conjugation
+
+/-!
+# Graph automorphisms of a Kostant elementary group
+
+Let `U_ℤ = kostantForm e h` act on a rational representation `V` preserving an additive subgroup
+`M ≤ V`, so that the divided-power exponentials of the distinguished root vectors `eᵢ` generate the
+elementary group `E(A) ≤ Aut_A(A ⊗[ℤ] M)` of
+`TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Elementary`.
+
+A *symmetry of the numbered data* is a permutation `σ` of the index set together with a `ℚ`-linear
+automorphism `θ` of `V` that preserves `M` and carries the action of `eᵢ` to the action of
+`e_{σ i}`. Conjugating by the scalar extension of `θ` is then an automorphism of `E(A)` which
+permutes the root subgroups by `σ` without touching their parameters:
+
+```text
+γ (xᵢ(t)) = x_{σ i}(t).
+```
+
+These are exactly the equations a graph automorphism of a Chevalley group is pinned by, restricted
+to the simple root subgroups: `γ` is *defined* here from a symmetry of the underlying data rather
+than obtained from the isomorphism theorem for pinned groups, and no uniqueness statement is
+claimed. Two further properties are what a Steinberg endomorphism built from `γ` needs. The
+automorphism commutes with every base change of the value ring, hence in particular with the
+`q`-power Frobenius endomorphism of `E(A)`; and if `θ ^ n = 1` then `γ ^ n = 1`, so an involution
+or a triality of the numbered data produces a `γ` with `γ ^ 2 = 1` or `γ ^ 3 = 1`.
+
+Nothing here assumes that `σ` is induced by a symmetry of a Dynkin diagram, nor that `θ` is unique:
+both are supplied by the caller as data, and the intertwining hypothesis is the whole input.
+
+## Main declarations
+
+* `TauCeti.UniversalEnvelopingAlgebra.invariantRestrictUnit_conj_kostantRootSubgroupParam`: the
+  pinning equation `γ (xᵢ(t)) = x_{σ i}(t)`.
+* `TauCeti.UniversalEnvelopingAlgebra.map_kostantElementarySubgroup_conj`: the conjugation
+  preserves the elementary group.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryDiagramAut`: the resulting automorphism of
+  the elementary group, with `kostantElementaryDiagramAut_pow_eq_one` for its order.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryMap_kostantElementaryDiagramAut` and
+  `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryFrobenius_kostantElementaryDiagramAut`:
+  the automorphism commutes with base change of the value ring, and with Frobenius.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §12.2.
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.15.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §27.
+-/
+
+public section
+
+open CategoryTheory TensorProduct WithConv
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe u v w
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {I : Type*} {κ : Type*}
+variable {V : Type v} [AddCommGroup V] [Module ℚ V]
+
+variable (e : I → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+variable (hnil : ∀ i, IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+variable (σ : Equiv.Perm I) (θ : V ≃ₗ[ℚ] V) (hθM : ∀ v, θ v ∈ M ↔ v ∈ M)
+variable (hθe : ∀ i, ∀ v : V,
+  θ (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) v) =
+    ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) (θ v))
+
+-- Match tensor products to the `ℤ`-algebra instance stored by `CommAlgCat` objects.
+attribute [local instance high] Algebra.toModule
+
+/-! ## The pinning equation -/
+
+private theorem val_kostantRootSubgroupParam (i : I)
+    (hnili : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (A : CommAlgCat.{w} ℤ) (t : Multiplicative A) :
+    (kostantRootSubgroupParam e h ρ M hM i hnili A t).val =
+      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+        (Multiplicative.toAdd t) := by
+  rw [kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val, MulEquiv.apply_symm_apply]
+
+include hθe in
+/-- Conjugation by the scalar extension of `θ` carries the root subgroup at `i` to the root
+subgroup at `σ i`, leaving the parameter untouched.
+
+This is the multiplicative form of the pinning equation; the conjugated form is
+`invariantRestrictUnit_conj_kostantRootSubgroupParam`. -/
+theorem invariantRestrictUnit_mul_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
+    (t : Multiplicative A) :
+    invariantRestrictUnit (R := A) θ M hθM *
+        kostantRootSubgroupParam e h ρ M hM i (hnil i) A t =
+      kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t *
+        invariantRestrictUnit (R := A) θ M hθM := by
+  have hk : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) ^
+      nilpotencyClass (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 0 :=
+    pow_nilpotencyClass (hnil i)
+  have hint : ∀ v : V,
+      θ (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) • v) =
+        ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) • θ v := hθe i
+  have hky : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) ^
+      nilpotencyClass (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 0 :=
+    pow_eq_zero_of_intertwines θ hint hk
+  refine Units.ext (LinearMap.ext fun z => ?_)
+  rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
+    val_kostantRootSubgroupParam, val_kostantRootSubgroupParam,
+    val_invariantRestrictUnit_apply, val_invariantRestrictUnit_apply]
+  exact baseChange_invariantRestrict_baseChangeExp θ M hθM hint _ _ hk hky _ z
+
+include hθe in
+/-- The pinning equation for a graph automorphism: conjugation by the scalar extension of `θ`
+sends `xᵢ(t)` to `x_{σ i}(t)`. -/
+theorem invariantRestrictUnit_conj_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
+    (t : Multiplicative A) :
+    invariantRestrictUnit (R := A) θ M hθM *
+        kostantRootSubgroupParam e h ρ M hM i (hnil i) A t *
+        (invariantRestrictUnit (R := A) θ M hθM)⁻¹ =
+      kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t := by
+  rw [invariantRestrictUnit_mul_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe,
+    mul_assoc, mul_inv_cancel, mul_one]
+
+/-! ## The automorphism of the elementary group -/
+
+include hθe in
+/-- Conjugation by the scalar extension of `θ` preserves the elementary group.
+
+Both inclusions come from the pinning equation: the generators at `i` go to the generators at
+`σ i`, and every generator is hit because `σ` is a permutation. -/
+theorem map_kostantElementarySubgroup_conj (A : CommAlgCat.{w} ℤ) :
+    (kostantElementarySubgroup e h ρ M hM hnil A).map
+        (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM) : _ →* _) =
+      kostantElementarySubgroup e h ρ M hM hnil A := by
+  have hconj : ∀ (i : I) (t : Multiplicative A),
+      (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM) : _ →* _)
+          (kostantRootSubgroupParam e h ρ M hM i (hnil i) A t) =
+        kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t := fun i t =>
+    invariantRestrictUnit_conj_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe A i t
+  refine le_antisymm ?_ ?_
+  · rw [kostantElementarySubgroup_eq_closure, MonoidHom.map_closure, Subgroup.closure_le]
+    rintro - ⟨-, ⟨-, ⟨i, rfl⟩, t, rfl⟩, rfl⟩
+    rw [hconj i t]
+    exact Subgroup.subset_closure (Set.mem_iUnion.2 ⟨σ i, Set.mem_range_self t⟩)
+  · rw [kostantElementarySubgroup_eq_closure, Subgroup.closure_le]
+    rintro - ⟨-, ⟨i, rfl⟩, t, rfl⟩
+    refine ⟨kostantRootSubgroupParam e h ρ M hM (σ.symm i) (hnil (σ.symm i)) A t,
+      Subgroup.subset_closure (Set.mem_iUnion.2 ⟨σ.symm i, Set.mem_range_self t⟩), ?_⟩
+    rw [hconj (σ.symm i) t, Equiv.apply_symm_apply]
+
+/-- The graph automorphism of the elementary group attached to a symmetry `(σ, θ)` of the numbered
+Kostant data: conjugation by the scalar extension of `θ`. -/
+noncomputable def kostantElementaryDiagramAut (A : CommAlgCat.{w} ℤ) :
+    MulAut (kostantElementarySubgroup e h ρ M hM hnil A) :=
+  (MulEquiv.subgroupMap (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM))
+      (kostantElementarySubgroup e h ρ M hM hnil A)).trans
+    (MulEquiv.subgroupCongr
+      (map_kostantElementarySubgroup_conj e h ρ M hM hnil σ θ hθM hθe A))
+
+private theorem val_kostantElementaryDiagramAut_def (A : CommAlgCat.{w} ℤ)
+    (g : kostantElementarySubgroup e h ρ M hM hnil A) :
+    (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A g :
+        LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
+      invariantRestrictUnit (R := A) θ M hθM * (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
+        (invariantRestrictUnit (R := A) θ M hθM)⁻¹ :=
+  (rfl)
+
+/-- The graph automorphism acts by conjugation inside the ambient automorphism group. -/
+@[simp]
+theorem val_kostantElementaryDiagramAut (A : CommAlgCat.{w} ℤ)
+    (g : kostantElementarySubgroup e h ρ M hM hnil A) :
+    (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A g :
+        LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
+      invariantRestrictUnit (R := A) θ M hθM * (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
+        (invariantRestrictUnit (R := A) θ M hθM)⁻¹ :=
+  val_kostantElementaryDiagramAut_def e h ρ M hM hnil σ θ hθM hθe A g
+
+/-- The graph automorphism permutes the root subgroups by `σ`, leaving parameters untouched. -/
+theorem kostantElementaryDiagramAut_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
+    (t : Multiplicative A) :
+    (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A
+        ⟨kostantRootSubgroupParam e h ρ M hM i (hnil i) A t,
+          kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A i t⟩ :
+        LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
+      kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t := by
+  rw [val_kostantElementaryDiagramAut,
+    invariantRestrictUnit_conj_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe]
+
+/-- A symmetry of order `n` produces a graph automorphism of order dividing `n`.
+
+This is what makes the order relations `γ ^ 2 = 1` and `γ ^ 3 = 1` available for the graph-twisted
+families, where `θ` realizes an involution or a triality of the numbered data. -/
+theorem kostantElementaryDiagramAut_pow_eq_one (A : CommAlgCat.{w} ℤ) {n : ℕ}
+    (hn : ∀ v, (θ ^ n) v = v) :
+    kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A ^ n = 1 := by
+  refine MulEquiv.ext fun g => Subtype.ext ?_
+  have hpow : ∀ m : ℕ, ∀ g : kostantElementarySubgroup e h ρ M hM hnil A,
+      ((kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A ^ m) g :
+          LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
+        invariantRestrictUnit (R := A) θ M hθM ^ m *
+          (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
+          (invariantRestrictUnit (R := A) θ M hθM ^ m)⁻¹ := by
+    intro m
+    induction m with
+    | zero => intro g; simp
+    | succ m ih =>
+        intro g
+        rw [pow_succ', MulAut.mul_apply, val_kostantElementaryDiagramAut, ih g, pow_succ']
+        group
+  rw [hpow n g, invariantRestrictUnit_pow_eq_one θ M hθM hn, one_mul, inv_one, mul_one]
+  rfl
+
+/-! ## Compatibility with base change and Frobenius -/
+
+private theorem mapScalarExtensionAutomorphisms_invariantRestrictUnit
+    {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B) :
+    GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ
+        (invariantRestrictUnit (R := A) θ M hθM) =
+      invariantRestrictUnit (R := B) θ M hθM := by
+  refine (GeneralLinear.eq_mapScalarExtensionAutomorphisms_of_apply_scalarExtensionMap_eq
+    φ _ _ fun z => ?_).symm
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a m =>
+      rw [GeneralLinear.scalarExtensionMap_tmul, val_invariantRestrictUnit_tmul,
+        val_invariantRestrictUnit_tmul, GeneralLinear.scalarExtensionMap_tmul]
+  | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
+
+/-- The graph automorphism commutes with base change of the value ring.
+
+The scalar extension of `θ` is defined over `ℤ`, so extending scalars along `φ` leaves it
+unchanged, and conjugation by it is therefore natural. -/
+theorem kostantElementaryMap_kostantElementaryDiagramAut {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B)
+    (g : kostantElementarySubgroup e h ρ M hM hnil A) :
+    kostantElementaryMap e h ρ M hM hnil φ
+        (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A g) =
+      kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe B
+        (kostantElementaryMap e h ρ M hM hnil φ g) := by
+  refine Subtype.ext ?_
+  rw [val_kostantElementaryMap, val_kostantElementaryDiagramAut, val_kostantElementaryDiagramAut,
+    val_kostantElementaryMap, map_mul, map_mul, map_inv,
+    mapScalarExtensionAutomorphisms_invariantRestrictUnit M θ hθM φ]
+
+/-- The graph automorphism commutes with the `p ^ n`-power Frobenius endomorphism.
+
+Together with the pinning equation and the order relation, this is the compatibility a Steinberg
+endomorphism of the form `γ ∘ Frob_q` is built from. -/
+theorem kostantElementaryFrobenius_kostantElementaryDiagramAut (p n : ℕ) (A : CommAlgCat.{w} ℤ)
+    [ExpChar A p] (g : kostantElementarySubgroup e h ρ M hM hnil A) :
+    kostantElementaryFrobenius e h ρ M hM hnil p n A
+        (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A g) =
+      kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A
+        (kostantElementaryFrobenius e h ρ M hM hnil p n A g) := by
+  obtain ⟨φ, hφ⟩ :=
+    exists_kostantElementaryFrobenius_eq_kostantElementaryMap e h ρ M hM hnil p n A
+  rw [hφ]
+  exact kostantElementaryMap_kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe φ g
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean
@@ -311,8 +311,8 @@ noncomputable def kostantElementaryFrobenius :
 ring.
 
 This is the interface through which statements about `kostantElementaryMap` that hold uniformly in
-the morphism of value rings — naturality of a graph automorphism, for instance — specialize to
-Frobenius. The morphism is `x ↦ x ^ p ^ n` and is deliberately not itself exposed. -/
+the morphism of value rings specialize to Frobenius from another module. The morphism is
+`x ↦ x ^ p ^ n` and is deliberately not itself exposed. -/
 theorem exists_kostantElementaryFrobenius_eq_kostantElementaryMap :
     ∃ φ : A ⟶ A, kostantElementaryFrobenius e h ρ M hM hnil p n A =
       kostantElementaryMap e h ρ M hM hnil φ :=

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean
@@ -44,7 +44,8 @@ is built from; it is injective as soon as the value ring is reduced.
   morphism of value rings.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryFunctor`: the resulting group-valued functor.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryFrobenius`: the `p ^ n`-power Frobenius
-  endomorphism, with `kostantElementaryFrobenius_injective` on a reduced value ring.
+  endomorphism, with `kostantElementaryFrobenius_injective` on a reduced value ring and
+  `exists_kostantElementaryFrobenius_eq_kostantElementaryMap` exhibiting it as a base change.
 
 ## References
 
@@ -305,6 +306,17 @@ noncomputable def kostantElementaryFrobenius :
     kostantElementarySubgroup e h ρ M hM hnil A →*
       kostantElementarySubgroup e h ρ M hM hnil A :=
   kostantElementaryMap e h ρ M hM hnil (iterateFrobeniusValueHom p n A)
+
+/-- The Frobenius endomorphism of the elementary group is induced by an endomorphism of the value
+ring.
+
+This is the interface through which statements about `kostantElementaryMap` that hold uniformly in
+the morphism of value rings — naturality of a graph automorphism, for instance — specialize to
+Frobenius. The morphism is `x ↦ x ^ p ^ n` and is deliberately not itself exposed. -/
+theorem exists_kostantElementaryFrobenius_eq_kostantElementaryMap :
+    ∃ φ : A ⟶ A, kostantElementaryFrobenius e h ρ M hM hnil p n A =
+      kostantElementaryMap e h ρ M hM hnil φ :=
+  ⟨iterateFrobeniusValueHom p n A, rfl⟩
 
 /-- The Frobenius endomorphism raises the parameter of a root-subgroup element to the
 `p ^ n`-th power. -/

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean
@@ -45,7 +45,7 @@ is built from; it is injective as soon as the value ring is reduced.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryFunctor`: the resulting group-valued functor.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryFrobenius`: the `p ^ n`-power Frobenius
   endomorphism, with `kostantElementaryFrobenius_injective` on a reduced value ring and
-  `exists_kostantElementaryFrobenius_eq_kostantElementaryMap` exhibiting it as a base change.
+  `kostantElementaryFrobenius_eq_kostantElementaryMap` exhibiting it as a base change.
 
 ## References
 
@@ -104,6 +104,17 @@ theorem kostantRootSubgroupParam_apply (A : CommAlgCat.{w} ℤ) (t : Multiplicat
         ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm t) :=
   kostantRootSubgroupParam_apply_def e h ρ M hM i hnil A t
 
+/-- The parametrized root-subgroup element acts through the corresponding base-changed
+divided-power exponential. -/
+theorem kostantRootSubgroupParam_val_apply (A : CommAlgCat.{w} ℤ) (t : Multiplicative A)
+    (z : A ⊗[ℤ] M) :
+    (kostantRootSubgroupParam e h ρ M hM i hnil A t).val z =
+      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+        (Multiplicative.toAdd t) z := by
+  rw [kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val,
+    MulEquiv.apply_symm_apply]
+
 /-- Scalar extension of automorphisms along a morphism of value rings carries the root-subgroup
 element with parameter `t` to the one with parameter `φ t`.
 
@@ -150,17 +161,53 @@ theorem kostantElementarySubgroup_eq_closure (A : CommAlgCat.{w} ℤ) :
       Subgroup.closure (⋃ i, Set.range (kostantRootSubgroupParam e h ρ M hM i (hnil i) A)) :=
   kostantElementarySubgroup_eq_closure_def e h ρ M hM hnil A
 
+/-- A homomorphism carrying every parametrized root-subgroup element to another such element
+carries the generated elementary group into the target elementary group. -/
+theorem map_kostantElementarySubgroup_le_of_map_param {A B : CommAlgCat.{w} ℤ}
+    (f : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M) →*
+      LinearMap.GeneralLinearGroup B (B ⊗[ℤ] M))
+    (σ : I → I) (τ : Multiplicative A → Multiplicative B)
+    (hf : ∀ i t, f (kostantRootSubgroupParam e h ρ M hM i (hnil i) A t) =
+      kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) B (τ t)) :
+    (kostantElementarySubgroup e h ρ M hM hnil A).map f ≤
+      kostantElementarySubgroup e h ρ M hM hnil B := by
+  rw [kostantElementarySubgroup_eq_closure, MonoidHom.map_closure, Subgroup.closure_le]
+  rintro - ⟨-, ⟨-, ⟨i, rfl⟩, t, rfl⟩, rfl⟩
+  rw [hf]
+  exact kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil B (σ i) (τ t)
+
+/-- If the index and parameter maps are surjective, a homomorphism with the specified action on
+root-subgroup elements carries the elementary group onto the target elementary group. -/
+theorem map_kostantElementarySubgroup_eq_of_map_param_of_surjective
+    {A B : CommAlgCat.{w} ℤ}
+    (f : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M) →*
+      LinearMap.GeneralLinearGroup B (B ⊗[ℤ] M))
+    (σ : I → I) (τ : Multiplicative A → Multiplicative B)
+    (hf : ∀ i t, f (kostantRootSubgroupParam e h ρ M hM i (hnil i) A t) =
+      kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) B (τ t))
+    (hσ : Function.Surjective σ) (hτ : Function.Surjective τ) :
+    (kostantElementarySubgroup e h ρ M hM hnil A).map f =
+      kostantElementarySubgroup e h ρ M hM hnil B := by
+  refine le_antisymm
+    (map_kostantElementarySubgroup_le_of_map_param e h ρ M hM hnil f σ τ hf) ?_
+  rw [kostantElementarySubgroup_eq_closure, Subgroup.closure_le]
+  rintro - ⟨-, ⟨i, rfl⟩, t, rfl⟩
+  obtain ⟨j, rfl⟩ := hσ i
+  obtain ⟨u, rfl⟩ := hτ t
+  exact ⟨kostantRootSubgroupParam e h ρ M hM j (hnil j) A u,
+    kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A j u, hf j u⟩
+
 /-- Scalar extension along a morphism of value rings carries the elementary group into the
 elementary group. -/
 theorem map_kostantElementarySubgroup_le {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B) :
     (kostantElementarySubgroup e h ρ M hM hnil A).map
         (GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ).hom ≤
-      kostantElementarySubgroup e h ρ M hM hnil B := by
-  rw [kostantElementarySubgroup_eq_closure, MonoidHom.map_closure, Subgroup.closure_le]
-  rintro - ⟨-, ⟨-, ⟨i, rfl⟩, t, rfl⟩, rfl⟩
-  exact (mapScalarExtensionAutomorphisms_kostantRootSubgroupParam
-      e h ρ M hM i (hnil i) φ t) ▸
-    kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil B i _
+      kostantElementarySubgroup e h ρ M hM hnil B :=
+  map_kostantElementarySubgroup_le_of_map_param e h ρ M hM hnil
+    (GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ).hom id
+    (fun t => Multiplicative.ofAdd (φ.hom (Multiplicative.toAdd t)))
+    (fun i t => mapScalarExtensionAutomorphisms_kostantRootSubgroupParam
+      e h ρ M hM i (hnil i) φ t)
 
 /-- A surjective morphism of value rings carries the elementary group *onto* the elementary group:
 every generator of the target is the image of a generator. -/
@@ -169,13 +216,14 @@ theorem map_kostantElementarySubgroup_of_surjective {A B : CommAlgCat.{w} ℤ} (
     (kostantElementarySubgroup e h ρ M hM hnil A).map
         (GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ).hom =
       kostantElementarySubgroup e h ρ M hM hnil B := by
-  refine le_antisymm (map_kostantElementarySubgroup_le e h ρ M hM hnil φ) ?_
-  rw [kostantElementarySubgroup_eq_closure, Subgroup.closure_le]
-  rintro - ⟨-, ⟨i, rfl⟩, u, rfl⟩
-  obtain ⟨t, rfl⟩ := hφ (Multiplicative.toAdd u)
-  exact ⟨kostantRootSubgroupParam e h ρ M hM i (hnil i) A (Multiplicative.ofAdd t),
-    kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A i _,
-    mapScalarExtensionAutomorphisms_kostantRootSubgroupParam e h ρ M hM i (hnil i) φ _⟩
+  apply map_kostantElementarySubgroup_eq_of_map_param_of_surjective e h ρ M hM hnil
+    (GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ).hom id
+    (fun t => Multiplicative.ofAdd (φ.hom (Multiplicative.toAdd t)))
+    (fun i t => mapScalarExtensionAutomorphisms_kostantRootSubgroupParam
+      e h ρ M hM i (hnil i) φ t) Function.surjective_id
+  intro u
+  obtain ⟨t, ht⟩ := hφ (Multiplicative.toAdd u)
+  exact ⟨Multiplicative.ofAdd t, by simpa using congrArg Multiplicative.ofAdd ht⟩
 
 /-- The group homomorphism between elementary groups induced by a morphism of value rings. -/
 noncomputable def kostantElementaryMap {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B) :
@@ -280,20 +328,15 @@ section Frobenius
 
 variable (p n : ℕ) (A : CommAlgCat.{w} ℤ) [ExpChar A p]
 
-/-- The `p ^ n`-power Frobenius as an endomorphism of the value ring.
-
-Kept private: it is the value-ring input to `kostantElementaryFrobenius`, and every statement
-below is about the induced endomorphism of the elementary group. A ring endomorphism of a
-`ℤ`-algebra commutes with the structure map because ring homomorphisms preserve integer casts, so
-no characteristic hypothesis enters the `ℤ`-algebra structure. -/
-private noncomputable def iterateFrobeniusValueHom : A ⟶ A :=
+/-- The `p ^ n`-power Frobenius as an endomorphism of the value ring. -/
+noncomputable def iterateFrobeniusValueHom : A ⟶ A :=
   CommAlgCat.ofHom
     { iterateFrobenius (A : Type w) p n with
       commutes' := fun r => by simp }
 
-/-- The underlying algebra map of the Frobenius endomorphism of the value ring is the
-`p ^ n`-th power map. Kept private alongside `iterateFrobeniusValueHom`. -/
-private theorem hom_iterateFrobeniusValueHom (x : A) :
+/-- The Frobenius endomorphism of the value ring raises elements to their `p ^ n`-th powers. -/
+@[simp]
+theorem iterateFrobeniusValueHom_apply (x : A) :
     (iterateFrobeniusValueHom p n A).hom x = x ^ p ^ n :=
   iterateFrobenius_def p n x
 
@@ -307,16 +350,12 @@ noncomputable def kostantElementaryFrobenius :
       kostantElementarySubgroup e h ρ M hM hnil A :=
   kostantElementaryMap e h ρ M hM hnil (iterateFrobeniusValueHom p n A)
 
-/-- The Frobenius endomorphism of the elementary group is induced by an endomorphism of the value
-ring.
-
-This is the interface through which statements about `kostantElementaryMap` that hold uniformly in
-the morphism of value rings specialize to Frobenius from another module. The morphism is
-`x ↦ x ^ p ^ n` and is deliberately not itself exposed. -/
-theorem exists_kostantElementaryFrobenius_eq_kostantElementaryMap :
-    ∃ φ : A ⟶ A, kostantElementaryFrobenius e h ρ M hM hnil p n A =
-      kostantElementaryMap e h ρ M hM hnil φ :=
-  ⟨iterateFrobeniusValueHom p n A, rfl⟩
+/-- The Frobenius endomorphism of the elementary group is induced by the Frobenius endomorphism of
+the value ring. -/
+theorem kostantElementaryFrobenius_eq_kostantElementaryMap :
+    kostantElementaryFrobenius e h ρ M hM hnil p n A =
+      kostantElementaryMap e h ρ M hM hnil (iterateFrobeniusValueHom p n A) :=
+  by rfl
 
 /-- The Frobenius endomorphism raises the parameter of a root-subgroup element to the
 `p ^ n`-th power. -/
@@ -328,14 +367,14 @@ theorem kostantElementaryFrobenius_kostantRootSubgroupParam (i : I) (t : Multipl
       kostantRootSubgroupParam e h ρ M hM i (hnil i) A
         (Multiplicative.ofAdd (Multiplicative.toAdd t ^ p ^ n)) := by
   rw [kostantElementaryFrobenius, kostantElementaryMap_kostantRootSubgroupParam,
-    hom_iterateFrobeniusValueHom]
+    iterateFrobeniusValueHom_apply]
 
 /-- The zeroth Frobenius iterate is the identity. -/
 @[simp] theorem kostantElementaryFrobenius_zero :
     kostantElementaryFrobenius e h ρ M hM hnil p 0 A = MonoidHom.id _ := by
   have hid : iterateFrobeniusValueHom p 0 A = 𝟙 A :=
     CommAlgCat.hom_ext <| AlgHom.ext fun x => by
-      rw [hom_iterateFrobeniusValueHom, pow_zero, pow_one]
+      rw [iterateFrobeniusValueHom_apply, pow_zero, pow_one]
       rfl
   rw [kostantElementaryFrobenius, hid, kostantElementaryMap_id]
 
@@ -347,8 +386,8 @@ theorem kostantElementaryFrobenius_add (m : ℕ) :
   have hadd : iterateFrobeniusValueHom p (n + m) A =
       iterateFrobeniusValueHom p m A ≫ iterateFrobeniusValueHom p n A :=
     CommAlgCat.hom_ext <| AlgHom.ext fun x => by
-      rw [hom_iterateFrobeniusValueHom, CommAlgCat.hom_comp, AlgHom.comp_apply,
-        hom_iterateFrobeniusValueHom, hom_iterateFrobeniusValueHom, ← pow_mul, ← pow_add,
+      rw [iterateFrobeniusValueHom_apply, CommAlgCat.hom_comp, AlgHom.comp_apply,
+        iterateFrobeniusValueHom_apply, iterateFrobeniusValueHom_apply, ← pow_mul, ← pow_add,
         Nat.add_comm n m]
   rw [kostantElementaryFrobenius, kostantElementaryFrobenius, kostantElementaryFrobenius, hadd,
     kostantElementaryMap_comp]
@@ -364,8 +403,8 @@ theorem kostantElementaryFrobenius_injective [IsReduced A] :
   have hφ : Function.Injective (iterateFrobeniusValueHom p n A).hom := by
     intro x y hxy
     refine iterateFrobenius_inj (A : Type w) p n ?_
-    rw [iterateFrobenius_def, iterateFrobenius_def, ← hom_iterateFrobeniusValueHom p n A,
-      ← hom_iterateFrobeniusValueHom p n A]
+    rw [iterateFrobenius_def, iterateFrobenius_def, ← iterateFrobeniusValueHom_apply p n A,
+      ← iterateFrobeniusValueHom_apply p n A]
     exact hxy
   intro g g' hgg'
   refine Subtype.ext (GeneralLinear.mapScalarExtensionAutomorphisms_injective _

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
@@ -167,6 +167,8 @@ theorem val_kostantElementaryNumberedSymmetry (A : CommAlgCat.{w} ℤ)
         LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
       invariantRestrictUnit (R := A) θ M hθM * (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
         (invariantRestrictUnit (R := A) θ M hθM)⁻¹ := by
+  -- Traverse each equivalence wrapper explicitly; this formula should not depend on their
+  -- definitional transparency.
   rw [kostantElementaryNumberedSymmetry, MulEquiv.trans_apply,
     MulEquiv.subgroupCongr_apply, MulEquiv.coe_subgroupMap_apply, MulAut.conj_apply]
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
@@ -9,7 +9,7 @@ public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Eleme
 public import TauCeti.RingTheory.Nilpotent.Conjugation
 
 /-!
-# Graph automorphisms of a Kostant elementary group
+# Numbered symmetries of a Kostant elementary group
 
 Let `U_ℤ = kostantForm e h` act on a rational representation `V` preserving an additive subgroup
 `M ≤ V`, so that the divided-power exponentials of the distinguished root vectors `eᵢ` generate the
@@ -25,10 +25,11 @@ permutes the root subgroups by `σ` without touching their parameters:
 γ (xᵢ(t)) = x_{σ i}(t).
 ```
 
-These are exactly the equations a graph automorphism of a Chevalley group is pinned by, restricted
-to the simple root subgroups: `γ` is *defined* here from a symmetry of the underlying data rather
-than obtained from the isomorphism theorem for pinned groups, and no uniqueness statement is
-claimed. Two further properties are what a Steinberg endomorphism built from `γ` needs. The
+These include the equations that a graph automorphism of a Chevalley group is pinned by, restricted
+to the simple root subgroups, when the numbered symmetry comes from a Dynkin-diagram symmetry.
+Here `γ` is *defined* from a symmetry of the underlying data rather than obtained from the
+isomorphism theorem for pinned groups, and no uniqueness statement is claimed. Two further
+properties are what a Steinberg endomorphism built from `γ` needs. The
 automorphism commutes with every base change of the value ring, hence in particular with the
 `q`-power Frobenius endomorphism of `E(A)`; and if `θ ^ n = 1` then `γ ^ n = 1`, so an involution
 or a triality of the numbered data produces a `γ` with `γ ^ 2 = 1` or `γ ^ 3 = 1`.
@@ -42,10 +43,10 @@ both are supplied by the caller as data, and the intertwining hypothesis is the 
   pinning equation `γ (xᵢ(t)) = x_{σ i}(t)`.
 * `TauCeti.UniversalEnvelopingAlgebra.map_kostantElementarySubgroup_conj`: the conjugation
   preserves the elementary group.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryDiagramAut`: the resulting automorphism of
-  the elementary group, with `kostantElementaryDiagramAut_pow_eq_one` for its order.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryMap_kostantElementaryDiagramAut` and
-  `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryFrobenius_kostantElementaryDiagramAut`:
+* `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryNumberedSymmetry`: the resulting automorphism
+  of the elementary group, with `kostantElementaryNumberedSymmetry_pow_eq_one` for its order.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryMap_kostantElementaryNumberedSymmetry` and
+  `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryFrobenius_kostantElementaryNumberedSymmetry`:
   the automorphism commutes with base change of the value ring, and with Frobenius.
 
 ## References
@@ -82,15 +83,6 @@ attribute [local instance high] Algebra.toModule
 
 /-! ## The pinning equation -/
 
-private theorem val_kostantRootSubgroupParam (i : I)
-    (hnili : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
-    (A : CommAlgCat.{w} ℤ) (t : Multiplicative A) :
-    (kostantRootSubgroupParam e h ρ M hM i hnili A t).val =
-      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
-        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
-        (Multiplicative.toAdd t) := by
-  rw [kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val, MulEquiv.apply_symm_apply]
-
 include hθe in
 /-- Conjugation by the scalar extension of `θ` carries the root subgroup at `i` to the root
 subgroup at `σ i`, leaving the parameter untouched.
@@ -114,12 +106,13 @@ theorem invariantRestrictUnit_mul_kostantRootSubgroupParam (A : CommAlgCat.{w} �
     pow_eq_zero_of_intertwines θ hint hk
   refine Units.ext (LinearMap.ext fun z => ?_)
   rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
-    val_kostantRootSubgroupParam, val_kostantRootSubgroupParam,
+    kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val, MulEquiv.apply_symm_apply,
+    kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val, MulEquiv.apply_symm_apply,
     val_invariantRestrictUnit_apply, val_invariantRestrictUnit_apply]
   exact baseChange_invariantRestrict_baseChangeExp θ M hθM hint _ _ hk hky _ z
 
 include hθe in
-/-- The pinning equation for a graph automorphism: conjugation by the scalar extension of `θ`
+/-- The pinning equation for a numbered symmetry: conjugation by the scalar extension of `θ`
 sends `xᵢ(t)` to `x_{σ i}(t)`. -/
 theorem invariantRestrictUnit_conj_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
     (t : Multiplicative A) :
@@ -157,54 +150,50 @@ theorem map_kostantElementarySubgroup_conj (A : CommAlgCat.{w} ℤ) :
       Subgroup.subset_closure (Set.mem_iUnion.2 ⟨σ.symm i, Set.mem_range_self t⟩), ?_⟩
     rw [hconj (σ.symm i) t, Equiv.apply_symm_apply]
 
-/-- The graph automorphism of the elementary group attached to a symmetry `(σ, θ)` of the numbered
+/-- The automorphism of the elementary group attached to a symmetry `(σ, θ)` of the numbered
 Kostant data: conjugation by the scalar extension of `θ`. -/
-noncomputable def kostantElementaryDiagramAut (A : CommAlgCat.{w} ℤ) :
+noncomputable def kostantElementaryNumberedSymmetry (A : CommAlgCat.{w} ℤ) :
     MulAut (kostantElementarySubgroup e h ρ M hM hnil A) :=
   (MulEquiv.subgroupMap (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM))
       (kostantElementarySubgroup e h ρ M hM hnil A)).trans
     (MulEquiv.subgroupCongr
       (map_kostantElementarySubgroup_conj e h ρ M hM hnil σ θ hθM hθe A))
 
-private theorem val_kostantElementaryDiagramAut_def (A : CommAlgCat.{w} ℤ)
-    (g : kostantElementarySubgroup e h ρ M hM hnil A) :
-    (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A g :
-        LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
-      invariantRestrictUnit (R := A) θ M hθM * (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
-        (invariantRestrictUnit (R := A) θ M hθM)⁻¹ :=
-  (rfl)
-
-/-- The graph automorphism acts by conjugation inside the ambient automorphism group. -/
+/-- The numbered symmetry acts by conjugation inside the ambient automorphism group. -/
 @[simp]
-theorem val_kostantElementaryDiagramAut (A : CommAlgCat.{w} ℤ)
+theorem val_kostantElementaryNumberedSymmetry (A : CommAlgCat.{w} ℤ)
     (g : kostantElementarySubgroup e h ρ M hM hnil A) :
-    (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A g :
+    (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A g :
         LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
       invariantRestrictUnit (R := A) θ M hθM * (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
-        (invariantRestrictUnit (R := A) θ M hθM)⁻¹ :=
-  val_kostantElementaryDiagramAut_def e h ρ M hM hnil σ θ hθM hθe A g
+        (invariantRestrictUnit (R := A) θ M hθM)⁻¹ := by
+  rw [kostantElementaryNumberedSymmetry, MulEquiv.trans_apply,
+    MulEquiv.subgroupCongr_apply, MulEquiv.coe_subgroupMap_apply, MulAut.conj_apply]
 
-/-- The graph automorphism permutes the root subgroups by `σ`, leaving parameters untouched. -/
-theorem kostantElementaryDiagramAut_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
+/-- The numbered symmetry permutes the root subgroups by `σ`, leaving parameters untouched. -/
+@[simp]
+theorem kostantElementaryNumberedSymmetry_kostantRootSubgroupParam
+    (A : CommAlgCat.{w} ℤ) (i : I)
     (t : Multiplicative A) :
-    (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A
+    kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A
         ⟨kostantRootSubgroupParam e h ρ M hM i (hnil i) A t,
-          kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A i t⟩ :
-        LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
-      kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t := by
-  rw [val_kostantElementaryDiagramAut,
+          kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A i t⟩ =
+      ⟨kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t,
+        kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A (σ i) t⟩ := by
+  apply Subtype.ext
+  rw [val_kostantElementaryNumberedSymmetry,
     invariantRestrictUnit_conj_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe]
 
-/-- A symmetry of order `n` produces a graph automorphism of order dividing `n`.
+/-- A numbered symmetry of order `n` produces an automorphism of order dividing `n`.
 
 This is what makes the order relations `γ ^ 2 = 1` and `γ ^ 3 = 1` available for the graph-twisted
 families, where `θ` realizes an involution or a triality of the numbered data. -/
-theorem kostantElementaryDiagramAut_pow_eq_one (A : CommAlgCat.{w} ℤ) {n : ℕ}
+theorem kostantElementaryNumberedSymmetry_pow_eq_one (A : CommAlgCat.{w} ℤ) {n : ℕ}
     (hn : ∀ v, (θ ^ n) v = v) :
-    kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A ^ n = 1 := by
+    kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A ^ n = 1 := by
   refine MulEquiv.ext fun g => Subtype.ext ?_
   have hpow : ∀ m : ℕ, ∀ g : kostantElementarySubgroup e h ρ M hM hnil A,
-      ((kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A ^ m) g :
+      ((kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A ^ m) g :
           LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
         invariantRestrictUnit (R := A) θ M hθM ^ m *
           (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
@@ -214,7 +203,7 @@ theorem kostantElementaryDiagramAut_pow_eq_one (A : CommAlgCat.{w} ℤ) {n : ℕ
     | zero => intro g; simp
     | succ m ih =>
         intro g
-        rw [pow_succ', MulAut.mul_apply, val_kostantElementaryDiagramAut, ih g, pow_succ']
+        rw [pow_succ', MulAut.mul_apply, val_kostantElementaryNumberedSymmetry, ih g, pow_succ']
         group
   rw [hpow n g, invariantRestrictUnit_pow_eq_one θ M hθM hn, one_mul, inv_one, mul_one]
   rfl
@@ -235,34 +224,38 @@ private theorem mapScalarExtensionAutomorphisms_invariantRestrictUnit
         val_invariantRestrictUnit_tmul, GeneralLinear.scalarExtensionMap_tmul]
   | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
 
-/-- The graph automorphism commutes with base change of the value ring.
+/-- The numbered symmetry commutes with base change of the value ring.
 
 The scalar extension of `θ` is defined over `ℤ`, so extending scalars along `φ` leaves it
 unchanged, and conjugation by it is therefore natural. -/
-theorem kostantElementaryMap_kostantElementaryDiagramAut {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B)
+theorem kostantElementaryMap_kostantElementaryNumberedSymmetry
+    {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B)
     (g : kostantElementarySubgroup e h ρ M hM hnil A) :
     kostantElementaryMap e h ρ M hM hnil φ
-        (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A g) =
-      kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe B
+        (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A g) =
+      kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe B
         (kostantElementaryMap e h ρ M hM hnil φ g) := by
   refine Subtype.ext ?_
-  rw [val_kostantElementaryMap, val_kostantElementaryDiagramAut, val_kostantElementaryDiagramAut,
+  rw [val_kostantElementaryMap, val_kostantElementaryNumberedSymmetry,
+    val_kostantElementaryNumberedSymmetry,
     val_kostantElementaryMap, map_mul, map_mul, map_inv,
     mapScalarExtensionAutomorphisms_invariantRestrictUnit M θ hθM φ]
 
-/-- The graph automorphism commutes with the `p ^ n`-power Frobenius endomorphism.
+/-- The numbered symmetry commutes with the `p ^ n`-power Frobenius endomorphism.
 
 Together with the pinning equation and the order relation, this is the compatibility a Steinberg
 endomorphism of the form `γ ∘ Frob_q` is built from. -/
-theorem kostantElementaryFrobenius_kostantElementaryDiagramAut (p n : ℕ) (A : CommAlgCat.{w} ℤ)
+theorem kostantElementaryFrobenius_kostantElementaryNumberedSymmetry
+    (p n : ℕ) (A : CommAlgCat.{w} ℤ)
     [ExpChar A p] (g : kostantElementarySubgroup e h ρ M hM hnil A) :
     kostantElementaryFrobenius e h ρ M hM hnil p n A
-        (kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A g) =
-      kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe A
+        (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A g) =
+      kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A
         (kostantElementaryFrobenius e h ρ M hM hnil p n A g) := by
   obtain ⟨φ, hφ⟩ :=
     exists_kostantElementaryFrobenius_eq_kostantElementaryMap e h ρ M hM hnil p n A
   rw [hφ]
-  exact kostantElementaryMap_kostantElementaryDiagramAut e h ρ M hM hnil σ θ hθM hθe φ g
+  exact kostantElementaryMap_kostantElementaryNumberedSymmetry
+    e h ρ M hM hnil σ θ hθM hθe φ g
 
 end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
@@ -39,15 +39,15 @@ both are supplied by the caller as data, and the intertwining hypothesis is the 
 
 ## Main declarations
 
-* `TauCeti.UniversalEnvelopingAlgebra.invariantRestrictUnit_conj_kostantRootSubgroupParam`: the
-  pinning equation `γ (xᵢ(t)) = x_{σ i}(t)`.
-* `TauCeti.UniversalEnvelopingAlgebra.map_kostantElementarySubgroup_conj`: the conjugation
+* `baseChangeInvariantRestrictUnit_conj_kostantRootSubgroupParam`:
+  the pinning equation `γ (xᵢ(t)) = x_{σ i}(t)`.
+* `map_kostantElementarySubgroup_conj`: the conjugation
   preserves the elementary group.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryNumberedSymmetry`: the resulting automorphism
-  of the elementary group, with `kostantElementaryNumberedSymmetry_pow_eq_one` for its order.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryMap_kostantElementaryNumberedSymmetry` and
-  `TauCeti.UniversalEnvelopingAlgebra.kostantElementaryFrobenius_kostantElementaryNumberedSymmetry`:
-  the automorphism commutes with base change of the value ring, and with Frobenius.
+* `kostantElementaryNumberedSymmetryAut`: the resulting
+  automorphism, with `kostantElementaryNumberedSymmetryAut_pow_eq_one` for its order.
+* `kostantElementaryMap_kostantElementaryNumberedSymmetryAut` and
+  `kostantElementaryFrobenius_kostantElementaryNumberedSymmetryAut`:
+  commutation with base change of the value ring and with Frobenius.
 
 ## References
 
@@ -61,6 +61,8 @@ public section
 open CategoryTheory TensorProduct WithConv
 
 namespace TauCeti.UniversalEnvelopingAlgebra
+
+open TauCeti.GeneralLinearGroup
 
 universe u v w
 
@@ -84,53 +86,48 @@ attribute [local instance high] Algebra.toModule
 
 /-! ## The pinning equation -/
 
-private theorem kostantRootSubgroupParam_val_apply (A : CommAlgCat.{w} ℤ) (i : I)
-    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
-    (t : Multiplicative A) (z : A ⊗[ℤ] M) :
-    (kostantRootSubgroupParam e h ρ M hM i hi A t).val z =
-      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
-        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
-        (Multiplicative.toAdd t) z := by
-  rw [kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val,
-    MulEquiv.apply_symm_apply]
-
 include hθe in
 /-- Conjugation by the scalar extension of `θ` carries the root subgroup at `i` to the root
 subgroup at `σ i`, leaving the parameter untouched.
 
 This is the multiplicative form of the pinning equation; the conjugated form is
-`invariantRestrictUnit_conj_kostantRootSubgroupParam`. -/
-theorem invariantRestrictUnit_mul_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
+`baseChangeInvariantRestrictUnit_conj_kostantRootSubgroupParam`. -/
+theorem baseChangeInvariantRestrictUnit_mul_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
     (t : Multiplicative A) :
-    invariantRestrictUnit (R := A) θ M hθM *
+    baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM *
         kostantRootSubgroupParam e h ρ M hM i (hnil i) A t =
       kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t *
-        invariantRestrictUnit (R := A) θ M hθM := by
+        baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM := by
   have hk : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) ^
       nilpotencyClass (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 0 :=
     pow_nilpotencyClass (hnil i)
   have hint : ∀ v : V,
       θ (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) • v) =
-        ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) • θ v := hθe i
+        ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) • θ v :=
+    fun v => by simpa only [Module.End.smul_def] using hθe i v
+  have hY : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) =
+      θ.conjAlgEquiv ℚ (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) := by
+    ext v
+    simpa [LinearEquiv.conjAlgEquiv_apply] using (hθe i (θ.symm v)).symm
   have hky : ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) ^
-      nilpotencyClass (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 0 :=
-    pow_eq_zero_of_intertwines θ hint hk
+      nilpotencyClass (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 0 := by
+    rw [hY, ← map_pow, hk, map_zero]
   refine Units.ext (LinearMap.ext fun z => ?_)
   rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
     kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
-    val_invariantRestrictUnit_apply, val_invariantRestrictUnit_apply]
+    val_baseChangeInvariantRestrictUnit_apply, val_baseChangeInvariantRestrictUnit_apply]
   exact baseChange_invariantRestrict_baseChangeExp θ M hθM hint _ _ hk hky _ z
 
 include hθe in
 /-- The pinning equation for a numbered symmetry: conjugation by the scalar extension of `θ`
 sends `xᵢ(t)` to `x_{σ i}(t)`. -/
-theorem invariantRestrictUnit_conj_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
+theorem baseChangeInvariantRestrictUnit_conj_kostantRootSubgroupParam (A : CommAlgCat.{w} ℤ) (i : I)
     (t : Multiplicative A) :
-    invariantRestrictUnit (R := A) θ M hθM *
+    baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM *
         kostantRootSubgroupParam e h ρ M hM i (hnil i) A t *
-        (invariantRestrictUnit (R := A) θ M hθM)⁻¹ =
+        (baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM)⁻¹ =
       kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t := by
-  rw [invariantRestrictUnit_mul_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe,
+  rw [baseChangeInvariantRestrictUnit_mul_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe,
     mul_assoc, mul_inv_cancel, mul_one]
 
 /-! ## The automorphism of the elementary group -/
@@ -142,133 +139,126 @@ Both inclusions come from the pinning equation: the generators at `i` go to the 
 `σ i`, and every generator is hit because `σ` is surjective. -/
 theorem map_kostantElementarySubgroup_conj (A : CommAlgCat.{w} ℤ) :
     (kostantElementarySubgroup e h ρ M hM hnil A).map
-        (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM) : _ →* _) =
+        (MulAut.conj (baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM) : _ →* _) =
       kostantElementarySubgroup e h ρ M hM hnil A := by
   have hconj : ∀ (i : I) (t : Multiplicative A),
-      (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM) : _ →* _)
+      (MulAut.conj (baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM) : _ →* _)
           (kostantRootSubgroupParam e h ρ M hM i (hnil i) A t) =
         kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t := fun i t =>
-    invariantRestrictUnit_conj_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe A i t
-  refine le_antisymm ?_ ?_
-  · rw [kostantElementarySubgroup_eq_closure, MonoidHom.map_closure, Subgroup.closure_le]
-    rintro - ⟨-, ⟨-, ⟨i, rfl⟩, t, rfl⟩, rfl⟩
-    rw [hconj i t]
-    exact Subgroup.subset_closure (Set.mem_iUnion.2 ⟨σ i, Set.mem_range_self t⟩)
-  · rw [kostantElementarySubgroup_eq_closure, Subgroup.closure_le]
-    rintro - ⟨-, ⟨i, rfl⟩, t, rfl⟩
-    obtain ⟨j, rfl⟩ := hσ i
-    exact ⟨kostantRootSubgroupParam e h ρ M hM j (hnil j) A t,
-      Subgroup.subset_closure (Set.mem_iUnion.2 ⟨j, Set.mem_range_self t⟩), hconj j t⟩
+    baseChangeInvariantRestrictUnit_conj_kostantRootSubgroupParam
+      e h ρ M hM hnil σ θ hθM hθe A i t
+  exact map_kostantElementarySubgroup_eq_of_map_param_of_surjective
+    e h ρ M hM hnil _ σ id hconj hσ Function.surjective_id
 
 /-- The automorphism of the elementary group attached to a symmetry `(σ, θ)` of the numbered
 Kostant data: conjugation by the scalar extension of `θ`. -/
-noncomputable def kostantElementaryNumberedSymmetry (A : CommAlgCat.{w} ℤ) :
+noncomputable def kostantElementaryNumberedSymmetryAut (A : CommAlgCat.{w} ℤ) :
     MulAut (kostantElementarySubgroup e h ρ M hM hnil A) :=
-  (MulEquiv.subgroupMap (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM))
+  (MulEquiv.subgroupMap (MulAut.conj
+      (baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM))
       (kostantElementarySubgroup e h ρ M hM hnil A)).trans
     (MulEquiv.subgroupCongr
       (map_kostantElementarySubgroup_conj e h ρ M hM hnil σ θ hθM hθe hσ A))
 
 /-- The numbered symmetry acts by conjugation inside the ambient automorphism group. -/
 @[simp]
-theorem val_kostantElementaryNumberedSymmetry (A : CommAlgCat.{w} ℤ)
+theorem val_kostantElementaryNumberedSymmetryAut (A : CommAlgCat.{w} ℤ)
     (g : kostantElementarySubgroup e h ρ M hM hnil A) :
-    (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A g :
+    (kostantElementaryNumberedSymmetryAut e h ρ M hM hnil σ θ hθM hθe hσ A g :
         LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
-      invariantRestrictUnit (R := A) θ M hθM * (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
-        (invariantRestrictUnit (R := A) θ M hθM)⁻¹ := by
+      baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM *
+          (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
+        (baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM)⁻¹ := by
   -- Traverse each equivalence wrapper explicitly; this formula should not depend on their
   -- definitional transparency.
-  rw [kostantElementaryNumberedSymmetry, MulEquiv.trans_apply,
+  rw [kostantElementaryNumberedSymmetryAut, MulEquiv.trans_apply,
     MulEquiv.subgroupCongr_apply, MulEquiv.coe_subgroupMap_apply, MulAut.conj_apply]
 
 /-- The numbered symmetry sends the root subgroup at `i` to the one at `σ i`, leaving parameters
 untouched. -/
 @[simp]
-theorem kostantElementaryNumberedSymmetry_kostantRootSubgroupParam
+theorem kostantElementaryNumberedSymmetryAut_kostantRootSubgroupParam
     (A : CommAlgCat.{w} ℤ) (i : I)
     (t : Multiplicative A) :
-    kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A
+    kostantElementaryNumberedSymmetryAut e h ρ M hM hnil σ θ hθM hθe hσ A
         ⟨kostantRootSubgroupParam e h ρ M hM i (hnil i) A t,
           kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A i t⟩ =
       ⟨kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t,
         kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A (σ i) t⟩ := by
   apply Subtype.ext
-  rw [val_kostantElementaryNumberedSymmetry,
-    invariantRestrictUnit_conj_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe]
+  rw [val_kostantElementaryNumberedSymmetryAut,
+    baseChangeInvariantRestrictUnit_conj_kostantRootSubgroupParam e h ρ M hM hnil σ θ hθM hθe]
 
 /-- A numbered symmetry of order `n` produces an automorphism of order dividing `n`.
 
 This is what makes the order relations `γ ^ 2 = 1` and `γ ^ 3 = 1` available for the graph-twisted
 families, where `θ` realizes an involution or a triality of the numbered data. -/
-theorem kostantElementaryNumberedSymmetry_pow_eq_one (A : CommAlgCat.{w} ℤ) {n : ℕ}
+theorem kostantElementaryNumberedSymmetryAut_pow_eq_one (A : CommAlgCat.{w} ℤ) {n : ℕ}
     (hn : ∀ v, (θ ^ n) v = v) :
-    kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A ^ n = 1 := by
+    kostantElementaryNumberedSymmetryAut e h ρ M hM hnil σ θ hθM hθe hσ A ^ n = 1 := by
   refine MulEquiv.ext fun g => Subtype.ext ?_
   have hpow : ∀ m : ℕ, ∀ g : kostantElementarySubgroup e h ρ M hM hnil A,
-      ((kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A ^ m) g :
+      ((kostantElementaryNumberedSymmetryAut e h ρ M hM hnil σ θ hθM hθe hσ A ^ m) g :
           LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
-        invariantRestrictUnit (R := A) θ M hθM ^ m *
+        baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM ^ m *
           (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
-          (invariantRestrictUnit (R := A) θ M hθM ^ m)⁻¹ := by
+          (baseChangeInvariantRestrictUnit (R := A) θ.toAddEquiv M hθM ^ m)⁻¹ := by
     intro m
     induction m with
     | zero => intro g; simp
     | succ m ih =>
         intro g
-        rw [pow_succ', MulAut.mul_apply, val_kostantElementaryNumberedSymmetry, ih g, pow_succ']
+        rw [pow_succ', MulAut.mul_apply, val_kostantElementaryNumberedSymmetryAut, ih g, pow_succ']
         group
-  rw [hpow n g, invariantRestrictUnit_pow_eq_one θ M hθM hn, one_mul, inv_one, mul_one]
+  have hn' : ∀ v, (θ.toAddEquiv.toIntLinearEquiv ^ n) v = v := by
+    intro v
+    have hpowθ : ∀ m : ℕ, ∀ w : V,
+        (θ.toAddEquiv.toIntLinearEquiv ^ m) w = (θ ^ m) w := by
+      intro m
+      induction m with
+      | zero => simp
+      | succ m ih =>
+          intro w
+          rw [pow_succ, LinearEquiv.mul_apply, pow_succ, LinearEquiv.mul_apply, ih]
+          rfl
+    exact (hpowθ n v).trans (hn v)
+  rw [hpow n g, baseChangeInvariantRestrictUnit_pow_eq_one θ.toAddEquiv M hθM hn', one_mul,
+    inv_one, mul_one]
   rfl
 
 /-! ## Compatibility with base change and Frobenius -/
-
-private theorem mapScalarExtensionAutomorphisms_invariantRestrictUnit
-    {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B) :
-    GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ
-        (invariantRestrictUnit (R := A) θ M hθM) =
-      invariantRestrictUnit (R := B) θ M hθM := by
-  refine (GeneralLinear.eq_mapScalarExtensionAutomorphisms_of_apply_scalarExtensionMap_eq
-    φ _ _ fun z => ?_).symm
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a m =>
-      rw [GeneralLinear.scalarExtensionMap_tmul, val_invariantRestrictUnit_tmul,
-        val_invariantRestrictUnit_tmul, GeneralLinear.scalarExtensionMap_tmul]
-  | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
 
 /-- The numbered symmetry commutes with base change of the value ring.
 
 The scalar extension of `θ` is defined over `ℤ`, so extending scalars along `φ` leaves it
 unchanged, and conjugation by it is therefore natural. -/
-theorem kostantElementaryMap_kostantElementaryNumberedSymmetry
+theorem kostantElementaryMap_kostantElementaryNumberedSymmetryAut
     {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B)
     (g : kostantElementarySubgroup e h ρ M hM hnil A) :
     kostantElementaryMap e h ρ M hM hnil φ
-        (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A g) =
-      kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ B
+        (kostantElementaryNumberedSymmetryAut e h ρ M hM hnil σ θ hθM hθe hσ A g) =
+      kostantElementaryNumberedSymmetryAut e h ρ M hM hnil σ θ hθM hθe hσ B
         (kostantElementaryMap e h ρ M hM hnil φ g) := by
   refine Subtype.ext ?_
-  rw [val_kostantElementaryMap, val_kostantElementaryNumberedSymmetry,
-    val_kostantElementaryNumberedSymmetry,
+  rw [val_kostantElementaryMap, val_kostantElementaryNumberedSymmetryAut,
+    val_kostantElementaryNumberedSymmetryAut,
     val_kostantElementaryMap, map_mul, map_mul, map_inv,
-    mapScalarExtensionAutomorphisms_invariantRestrictUnit M θ hθM φ]
+    TauCeti.GeneralLinearGroup.mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit
+      θ.toAddEquiv M hθM φ]
 
 /-- The numbered symmetry commutes with the `p ^ n`-power Frobenius endomorphism.
 
 Together with the pinning equation and the order relation, this is the compatibility a Steinberg
 endomorphism of the form `γ ∘ Frob_q` is built from. -/
-theorem kostantElementaryFrobenius_kostantElementaryNumberedSymmetry
+theorem kostantElementaryFrobenius_kostantElementaryNumberedSymmetryAut
     (p n : ℕ) (A : CommAlgCat.{w} ℤ)
     [ExpChar A p] (g : kostantElementarySubgroup e h ρ M hM hnil A) :
     kostantElementaryFrobenius e h ρ M hM hnil p n A
-        (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A g) =
-      kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A
+        (kostantElementaryNumberedSymmetryAut e h ρ M hM hnil σ θ hθM hθe hσ A g) =
+      kostantElementaryNumberedSymmetryAut e h ρ M hM hnil σ θ hθM hθe hσ A
         (kostantElementaryFrobenius e h ρ M hM hnil p n A g) := by
-  obtain ⟨φ, hφ⟩ :=
-    exists_kostantElementaryFrobenius_eq_kostantElementaryMap e h ρ M hM hnil p n A
-  rw [hφ]
-  exact kostantElementaryMap_kostantElementaryNumberedSymmetry
-    e h ρ M hM hnil σ θ hθM hθe hσ φ g
+  rw [kostantElementaryFrobenius_eq_kostantElementaryMap]
+  exact kostantElementaryMap_kostantElementaryNumberedSymmetryAut
+    e h ρ M hM hnil σ θ hθM hθe hσ (iterateFrobeniusValueHom p n A) g
 
 end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
@@ -116,7 +116,7 @@ theorem baseChangeInvariantRestrictUnit_mul_kostantRootSubgroupParam (A : CommAl
   rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
     kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
     val_baseChangeInvariantRestrictUnit_apply, val_baseChangeInvariantRestrictUnit_apply]
-  exact baseChange_invariantRestrict_baseChangeExp θ M hθM hint _ _ hk hky _ z
+  exact baseChange_invariantRestrict_baseChangeExp θ M hθM hint _ hk hky _ z
 
 include hθe in
 /-- The pinning equation for a numbered symmetry: conjugation by the scalar extension of `θ`

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
@@ -16,10 +16,10 @@ Let `U_ℤ = kostantForm e h` act on a rational representation `V` preserving an
 elementary group `E(A) ≤ Aut_A(A ⊗[ℤ] M)` of
 `TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Elementary`.
 
-A *symmetry of the numbered data* is a permutation `σ` of the index set together with a `ℚ`-linear
-automorphism `θ` of `V` that preserves `M` and carries the action of `eᵢ` to the action of
-`e_{σ i}`. Conjugating by the scalar extension of `θ` is then an automorphism of `E(A)` which
-permutes the root subgroups by `σ` without touching their parameters:
+A *symmetry of the numbered data* is a surjective self-map `σ` of the index set together with a
+`ℚ`-linear automorphism `θ` of `V` that preserves `M` and carries the action of `eᵢ` to the action
+of `e_{σ i}`. Conjugating by the scalar extension of `θ` is then an automorphism of `E(A)` which
+sends each root subgroup to the one indexed by `σ` without touching its parameters:
 
 ```text
 γ (xᵢ(t)) = x_{σ i}(t).
@@ -73,15 +73,26 @@ variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End �
 variable (M : AddSubgroup V)
 variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
 variable (hnil : ∀ i, IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
-variable (σ : Equiv.Perm I) (θ : V ≃ₗ[ℚ] V) (hθM : ∀ v, θ v ∈ M ↔ v ∈ M)
+variable (σ : I → I) (θ : V ≃ₗ[ℚ] V) (hθM : ∀ v, θ v ∈ M ↔ v ∈ M)
 variable (hθe : ∀ i, ∀ v : V,
   θ (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) v) =
     ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e (σ i))) (θ v))
+variable (hσ : Function.Surjective σ)
 
 -- Match tensor products to the `ℤ`-algebra instance stored by `CommAlgCat` objects.
 attribute [local instance high] Algebra.toModule
 
 /-! ## The pinning equation -/
+
+private theorem kostantRootSubgroupParam_val_apply (A : CommAlgCat.{w} ℤ) (i : I)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (t : Multiplicative A) (z : A ⊗[ℤ] M) :
+    (kostantRootSubgroupParam e h ρ M hM i hi A t).val z =
+      baseChangeExp (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M
+        (fun n _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+        (Multiplicative.toAdd t) z := by
+  rw [kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val,
+    MulEquiv.apply_symm_apply]
 
 include hθe in
 /-- Conjugation by the scalar extension of `θ` carries the root subgroup at `i` to the root
@@ -106,8 +117,7 @@ theorem invariantRestrictUnit_mul_kostantRootSubgroupParam (A : CommAlgCat.{w} �
     pow_eq_zero_of_intertwines θ hint hk
   refine Units.ext (LinearMap.ext fun z => ?_)
   rw [Units.val_mul, Units.val_mul, Module.End.mul_apply, Module.End.mul_apply,
-    kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val, MulEquiv.apply_symm_apply,
-    kostantRootSubgroupParam_apply, kostantRootSubgroupPoints_val, MulEquiv.apply_symm_apply,
+    kostantRootSubgroupParam_val_apply, kostantRootSubgroupParam_val_apply,
     val_invariantRestrictUnit_apply, val_invariantRestrictUnit_apply]
   exact baseChange_invariantRestrict_baseChangeExp θ M hθM hint _ _ hk hky _ z
 
@@ -125,11 +135,11 @@ theorem invariantRestrictUnit_conj_kostantRootSubgroupParam (A : CommAlgCat.{w} 
 
 /-! ## The automorphism of the elementary group -/
 
-include hθe in
+include hθe hσ in
 /-- Conjugation by the scalar extension of `θ` preserves the elementary group.
 
 Both inclusions come from the pinning equation: the generators at `i` go to the generators at
-`σ i`, and every generator is hit because `σ` is a permutation. -/
+`σ i`, and every generator is hit because `σ` is surjective. -/
 theorem map_kostantElementarySubgroup_conj (A : CommAlgCat.{w} ℤ) :
     (kostantElementarySubgroup e h ρ M hM hnil A).map
         (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM) : _ →* _) =
@@ -146,9 +156,9 @@ theorem map_kostantElementarySubgroup_conj (A : CommAlgCat.{w} ℤ) :
     exact Subgroup.subset_closure (Set.mem_iUnion.2 ⟨σ i, Set.mem_range_self t⟩)
   · rw [kostantElementarySubgroup_eq_closure, Subgroup.closure_le]
     rintro - ⟨-, ⟨i, rfl⟩, t, rfl⟩
-    refine ⟨kostantRootSubgroupParam e h ρ M hM (σ.symm i) (hnil (σ.symm i)) A t,
-      Subgroup.subset_closure (Set.mem_iUnion.2 ⟨σ.symm i, Set.mem_range_self t⟩), ?_⟩
-    rw [hconj (σ.symm i) t, Equiv.apply_symm_apply]
+    obtain ⟨j, rfl⟩ := hσ i
+    exact ⟨kostantRootSubgroupParam e h ρ M hM j (hnil j) A t,
+      Subgroup.subset_closure (Set.mem_iUnion.2 ⟨j, Set.mem_range_self t⟩), hconj j t⟩
 
 /-- The automorphism of the elementary group attached to a symmetry `(σ, θ)` of the numbered
 Kostant data: conjugation by the scalar extension of `θ`. -/
@@ -157,13 +167,13 @@ noncomputable def kostantElementaryNumberedSymmetry (A : CommAlgCat.{w} ℤ) :
   (MulEquiv.subgroupMap (MulAut.conj (invariantRestrictUnit (R := A) θ M hθM))
       (kostantElementarySubgroup e h ρ M hM hnil A)).trans
     (MulEquiv.subgroupCongr
-      (map_kostantElementarySubgroup_conj e h ρ M hM hnil σ θ hθM hθe A))
+      (map_kostantElementarySubgroup_conj e h ρ M hM hnil σ θ hθM hθe hσ A))
 
 /-- The numbered symmetry acts by conjugation inside the ambient automorphism group. -/
 @[simp]
 theorem val_kostantElementaryNumberedSymmetry (A : CommAlgCat.{w} ℤ)
     (g : kostantElementarySubgroup e h ρ M hM hnil A) :
-    (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A g :
+    (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A g :
         LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
       invariantRestrictUnit (R := A) θ M hθM * (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
         (invariantRestrictUnit (R := A) θ M hθM)⁻¹ := by
@@ -172,12 +182,13 @@ theorem val_kostantElementaryNumberedSymmetry (A : CommAlgCat.{w} ℤ)
   rw [kostantElementaryNumberedSymmetry, MulEquiv.trans_apply,
     MulEquiv.subgroupCongr_apply, MulEquiv.coe_subgroupMap_apply, MulAut.conj_apply]
 
-/-- The numbered symmetry permutes the root subgroups by `σ`, leaving parameters untouched. -/
+/-- The numbered symmetry sends the root subgroup at `i` to the one at `σ i`, leaving parameters
+untouched. -/
 @[simp]
 theorem kostantElementaryNumberedSymmetry_kostantRootSubgroupParam
     (A : CommAlgCat.{w} ℤ) (i : I)
     (t : Multiplicative A) :
-    kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A
+    kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A
         ⟨kostantRootSubgroupParam e h ρ M hM i (hnil i) A t,
           kostantRootSubgroupParam_mem_kostantElementarySubgroup e h ρ M hM hnil A i t⟩ =
       ⟨kostantRootSubgroupParam e h ρ M hM (σ i) (hnil (σ i)) A t,
@@ -192,10 +203,10 @@ This is what makes the order relations `γ ^ 2 = 1` and `γ ^ 3 = 1` available f
 families, where `θ` realizes an involution or a triality of the numbered data. -/
 theorem kostantElementaryNumberedSymmetry_pow_eq_one (A : CommAlgCat.{w} ℤ) {n : ℕ}
     (hn : ∀ v, (θ ^ n) v = v) :
-    kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A ^ n = 1 := by
+    kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A ^ n = 1 := by
   refine MulEquiv.ext fun g => Subtype.ext ?_
   have hpow : ∀ m : ℕ, ∀ g : kostantElementarySubgroup e h ρ M hM hnil A,
-      ((kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A ^ m) g :
+      ((kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A ^ m) g :
           LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) =
         invariantRestrictUnit (R := A) θ M hθM ^ m *
           (g : LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)) *
@@ -234,8 +245,8 @@ theorem kostantElementaryMap_kostantElementaryNumberedSymmetry
     {A B : CommAlgCat.{w} ℤ} (φ : A ⟶ B)
     (g : kostantElementarySubgroup e h ρ M hM hnil A) :
     kostantElementaryMap e h ρ M hM hnil φ
-        (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A g) =
-      kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe B
+        (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A g) =
+      kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ B
         (kostantElementaryMap e h ρ M hM hnil φ g) := by
   refine Subtype.ext ?_
   rw [val_kostantElementaryMap, val_kostantElementaryNumberedSymmetry,
@@ -251,13 +262,13 @@ theorem kostantElementaryFrobenius_kostantElementaryNumberedSymmetry
     (p n : ℕ) (A : CommAlgCat.{w} ℤ)
     [ExpChar A p] (g : kostantElementarySubgroup e h ρ M hM hnil A) :
     kostantElementaryFrobenius e h ρ M hM hnil p n A
-        (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A g) =
-      kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe A
+        (kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A g) =
+      kostantElementaryNumberedSymmetry e h ρ M hM hnil σ θ hθM hθe hσ A
         (kostantElementaryFrobenius e h ρ M hM hnil p n A g) := by
   obtain ⟨φ, hφ⟩ :=
     exists_kostantElementaryFrobenius_eq_kostantElementaryMap e h ρ M hM hnil p n A
   rw [hφ]
   exact kostantElementaryMap_kostantElementaryNumberedSymmetry
-    e h ρ M hM hnil σ θ hθM hθe φ g
+    e h ρ M hM hnil σ θ hθM hθe hσ φ g
 
 end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/InvariantRestrict.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/InvariantRestrict.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude, Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.ScalarExtension
+
+/-!
+# Restricting additive automorphisms to invariant subgroups
+
+An additive automorphism of an abelian group which preserves an additive subgroup restricts to an
+integral linear automorphism of that subgroup. Base change gives an automorphism of every scalar
+extension of the subgroup, compatibly with further scalar extension.
+
+## Main declarations
+
+* `TauCeti.GeneralLinearGroup.invariantRestrict`: restriction to an invariant additive subgroup.
+* `TauCeti.GeneralLinearGroup.baseChangeInvariantRestrictUnit`: the induced automorphism after
+  scalar extension.
+* `TauCeti.GeneralLinearGroup.baseChangeInvariantRestrictUnit_pow_eq_one`: transport of an
+  exponent bound to scalar extensions.
+* `TauCeti.GeneralLinearGroup.mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit`:
+  compatibility with further scalar extension.
+-/
+
+public section
+
+open CategoryTheory TensorProduct
+
+namespace TauCeti.GeneralLinearGroup
+
+universe u v w
+
+variable {V : Type u} [AddCommGroup V]
+variable {S : Type*} [SetLike S V] [AddSubgroupClass S V]
+
+/-! ## Restriction to an invariant subgroup -/
+
+/-- An additive automorphism of `V` that restricts to a bijection of an additive subgroup `M`,
+viewed as an integral linear automorphism of `M`. -/
+def invariantRestrict (θ : V ≃+ V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) : M ≃ₗ[ℤ] M where
+  toFun v := ⟨θ v, (hθ v).2 v.2⟩
+  invFun v := ⟨θ.symm v, (hθ _).1 (by rw [θ.apply_symm_apply]; exact v.2)⟩
+  left_inv v := Subtype.ext (θ.symm_apply_apply _)
+  right_inv v := Subtype.ext (θ.apply_symm_apply _)
+  map_add' v w := Subtype.ext (map_add θ _ _)
+  map_smul' t v := Subtype.ext (map_zsmul θ _ _)
+
+/-- The restriction of `θ` to an invariant subgroup acts by `θ`. -/
+@[simp]
+theorem coe_invariantRestrict_apply (θ : V ≃+ V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    (v : M) : ((invariantRestrict θ M hθ v : M) : V) = θ (v : V) :=
+  by rfl
+
+/-- The inverse of the restriction of `θ` acts by `θ.symm`. -/
+@[simp]
+theorem coe_invariantRestrict_symm_apply (θ : V ≃+ V) (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (v : M) :
+    (((invariantRestrict θ M hθ).symm v : M) : V) = θ.symm (v : V) :=
+  by rfl
+
+/-- Restriction commutes with taking the inverse automorphism. -/
+theorem invariantRestrict_symm (θ : V ≃+ V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    (hθ' : ∀ v, θ.symm v ∈ M ↔ v ∈ M) :
+    (invariantRestrict θ M hθ).symm = invariantRestrict θ.symm M hθ' := by
+  ext v
+  rfl
+
+/-- Powers of the restriction of `θ` act by the corresponding powers of `θ`. -/
+theorem coe_invariantRestrict_pow_apply (θ : V ≃+ V) (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (n : ℕ) (v : M) :
+    (((invariantRestrict θ M hθ ^ n) v : M) : V) =
+      (θ.toIntLinearEquiv ^ n) (v : V) := by
+  induction n generalizing v with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, LinearEquiv.mul_apply, ih, pow_succ, LinearEquiv.mul_apply,
+        coe_invariantRestrict_apply]
+      simp only [AddEquiv.coe_toIntLinearEquiv]
+
+/-! ## Base change -/
+
+attribute [local instance high] Algebra.toModule
+
+variable {R : Type v} [CommRing R] [Algebra ℤ R]
+
+/-- The automorphism of `R ⊗[ℤ] M` obtained by base-changing the restriction of `θ`. -/
+noncomputable def baseChangeInvariantRestrictUnit (θ : V ≃+ V) (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) :
+    LinearMap.GeneralLinearGroup R (R ⊗[ℤ] M) :=
+  LinearMap.GeneralLinearGroup.ofLinearEquiv ((invariantRestrict θ M hθ).baseChange ℤ R M M)
+
+/-- The induced automorphism is the base change of the restriction of `θ`. -/
+theorem val_baseChangeInvariantRestrictUnit_apply (θ : V ≃+ V) (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (z : R ⊗[ℤ] M) :
+    (baseChangeInvariantRestrictUnit (R := R) θ M hθ).val z =
+      (invariantRestrict θ M hθ).baseChange ℤ R M M z := by
+  exact congrFun (LinearMap.GeneralLinearGroup.coe_ofLinearEquiv _) z
+
+/-- The induced automorphism acts on a pure tensor through the restriction of `θ`. -/
+@[simp]
+theorem val_baseChangeInvariantRestrictUnit_tmul (θ : V ≃+ V) (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (r : R) (v : M) :
+    (baseChangeInvariantRestrictUnit (R := R) θ M hθ).val (r ⊗ₜ[ℤ] v) =
+      r ⊗ₜ[ℤ] invariantRestrict θ M hθ v := by
+  rw [val_baseChangeInvariantRestrictUnit_apply, LinearEquiv.baseChange_tmul]
+
+/-- The inverse induced automorphism acts on a pure tensor through the inverse restriction. -/
+@[simp]
+theorem val_baseChangeInvariantRestrictUnit_inv_tmul (θ : V ≃+ V) (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (r : R) (v : M) :
+    ((baseChangeInvariantRestrictUnit (R := R) θ M hθ)⁻¹).val (r ⊗ₜ[ℤ] v) =
+      r ⊗ₜ[ℤ] (invariantRestrict θ M hθ).symm v := by
+  rw [baseChangeInvariantRestrictUnit, ← LinearMap.GeneralLinearGroup.ofLinearEquiv_inv,
+    LinearMap.GeneralLinearGroup.coe_ofLinearEquiv, ← LinearEquiv.baseChange_inv,
+    LinearEquiv.baseChange_tmul]
+  simp only [LinearEquiv.coe_inv]
+
+/-- An exponent bound on `θ` is preserved by restriction and scalar extension. -/
+theorem baseChangeInvariantRestrictUnit_pow_eq_one (θ : V ≃+ V) (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) {n : ℕ}
+    (hn : ∀ v, (θ.toIntLinearEquiv ^ n) v = v) :
+    baseChangeInvariantRestrictUnit (R := R) θ M hθ ^ n = 1 := by
+  have h1 : invariantRestrict θ M hθ ^ n = 1 :=
+    LinearEquiv.ext fun v => Subtype.ext ((coe_invariantRestrict_pow_apply θ M hθ n v).trans
+      (hn (v : V)))
+  rw [baseChangeInvariantRestrictUnit]
+  change ((LinearMap.GeneralLinearGroup.generalLinearEquiv R (R ⊗[ℤ] M)).symm
+    ((invariantRestrict θ M hθ).baseChange ℤ R M M)) ^ n = 1
+  rw [← map_pow (LinearMap.GeneralLinearGroup.generalLinearEquiv R (R ⊗[ℤ] M)).symm,
+    ← LinearEquiv.baseChange_pow, h1, LinearEquiv.baseChange_one]
+  rfl
+
+/-- Further scalar extension leaves the base-changed restriction unchanged. -/
+theorem mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit
+    {A B : CommAlgCat.{w} ℤ} (θ : V ≃+ V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    (φ : A ⟶ B) :
+    GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ
+        (baseChangeInvariantRestrictUnit (R := A) θ M hθ) =
+      baseChangeInvariantRestrictUnit (R := B) θ M hθ := by
+  refine (GeneralLinear.eq_mapScalarExtensionAutomorphisms_of_apply_scalarExtensionMap_eq
+    φ _ _ fun z => ?_).symm
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a m =>
+      rw [GeneralLinear.scalarExtensionMap_tmul, val_baseChangeInvariantRestrictUnit_tmul,
+        val_baseChangeInvariantRestrictUnit_tmul, GeneralLinear.scalarExtensionMap_tmul]
+  | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
+
+end TauCeti.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/InvariantRestrict.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/InvariantRestrict.lean
@@ -62,9 +62,9 @@ theorem coe_invariantRestrict_symm_apply (θ : V ≃+ V) (M : S)
   by rfl
 
 /-- Restriction commutes with taking the inverse automorphism. -/
-theorem invariantRestrict_symm (θ : V ≃+ V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
-    (hθ' : ∀ v, θ.symm v ∈ M ↔ v ∈ M) :
-    (invariantRestrict θ M hθ).symm = invariantRestrict θ.symm M hθ' := by
+theorem invariantRestrict_symm (θ : V ≃+ V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) :
+    (invariantRestrict θ M hθ).symm = invariantRestrict θ.symm M
+      (fun v => by simpa only [θ.apply_symm_apply] using (hθ (θ.symm v)).symm) := by
   ext v
   rfl
 
@@ -127,11 +127,15 @@ theorem baseChangeInvariantRestrictUnit_pow_eq_one (θ : V ≃+ V) (M : S)
     LinearEquiv.ext fun v => Subtype.ext ((coe_invariantRestrict_pow_apply θ M hθ n v).trans
       (hn (v : V)))
   rw [baseChangeInvariantRestrictUnit]
-  change ((LinearMap.GeneralLinearGroup.generalLinearEquiv R (R ⊗[ℤ] M)).symm
-    ((invariantRestrict θ M hθ).baseChange ℤ R M M)) ^ n = 1
-  rw [← map_pow (LinearMap.GeneralLinearGroup.generalLinearEquiv R (R ⊗[ℤ] M)).symm,
-    ← LinearEquiv.baseChange_pow, h1, LinearEquiv.baseChange_one]
-  rfl
+  calc
+    LinearMap.GeneralLinearGroup.ofLinearEquiv
+          ((invariantRestrict θ M hθ).baseChange ℤ R M M) ^ n =
+        LinearMap.GeneralLinearGroup.ofLinearEquiv
+          ((invariantRestrict θ M hθ).baseChange ℤ R M M ^ n) :=
+      (map_pow (LinearMap.GeneralLinearGroup.generalLinearEquiv R (R ⊗[ℤ] M)).symm _ n).symm
+    _ = 1 := by
+      rw [← LinearEquiv.baseChange_pow, h1, LinearEquiv.baseChange_one]
+      rfl
 
 /-- Further scalar extension leaves the base-changed restriction unchanged. -/
 theorem mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit

--- a/TauCeti/RingTheory/Nilpotent/Conjugation.lean
+++ b/TauCeti/RingTheory/Nilpotent/Conjugation.lean
@@ -25,10 +25,10 @@ The intertwining hypothesis is imposed only on `x` itself. Divided powers divide
 `A`, so `θ` must be `ℚ`-linear for the transported statement to make sense; the *conclusion* is
 nonetheless an identity of integral operators on `R ⊗[ℤ] M` over an arbitrary commutative ring `R`.
 
-This is the mechanism behind a graph automorphism of a Chevalley group: a symmetry of the ambient
-Lie-algebra data that permutes the distinguished root vectors conjugates the corresponding root
-subgroups into one another, permuted the same way. Its application to Kostant root subgroups is in
-`TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Diagram.lean`.
+This is a mechanism used to construct graph automorphisms of Chevalley groups: a symmetry of the
+ambient Lie-algebra data that permutes the distinguished root vectors conjugates the corresponding
+root subgroups into one another, permuted the same way. Its application to Kostant root subgroups
+is in `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean`.
 
 ## Main definitions and results
 
@@ -39,7 +39,7 @@ subgroups into one another, permuted the same way. Its application to Kostant ro
 * `TauCeti.pow_eq_zero_of_intertwines`: over a faithful module, nilpotency transfers along an
   intertwiner.
 * `TauCeti.invariantRestrictUnit`: the resulting automorphism of the scalar extension `R ⊗[ℤ] M`,
-  with `TauCeti.invariantRestrictUnit_pow_eq_one` transporting the order of `θ`.
+  with `TauCeti.invariantRestrictUnit_pow_eq_one` transporting an `n`th-power-one relation of `θ`.
 * `TauCeti.baseChange_invariantRestrict_baseChangeExp`: the conjugation formula for the
   base-changed exponential.
 
@@ -101,10 +101,10 @@ theorem coe_invariantRestrict_pow_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : �
 
 /-! ## Transporting powers and divided powers -/
 
-variable (θ : V ≃ₗ[ℚ] V) {x y : A}
+variable (θ : V →ₗ[ℚ] V) {x y : A}
 
 omit [Algebra ℚ A] [IsScalarTower ℚ A V] in
-/-- An automorphism intertwining the actions of `x` and `y` intertwines the actions of their
+/-- A linear map intertwining the actions of `x` and `y` intertwines the actions of their
 powers. -/
 theorem apply_pow_smul_of_intertwines (hxy : ∀ v, θ (x • v) = y • θ v) (n : ℕ) (v : V) :
     θ (x ^ n • v) = y ^ n • θ v := by
@@ -113,7 +113,7 @@ theorem apply_pow_smul_of_intertwines (hxy : ∀ v, θ (x • v) = y • θ v) (
   | succ n ih =>
       rw [pow_succ x n, mul_smul, ih (x • v), hxy, pow_succ y n, mul_smul]
 
-/-- An automorphism intertwining the actions of `x` and `y` intertwines the actions of their
+/-- A linear map intertwining the actions of `x` and `y` intertwines the actions of their
 divided powers.
 
 The divided powers involve division by factorials, which is why the intertwiner is required to be
@@ -123,13 +123,16 @@ theorem apply_dividedPower_smul_of_intertwines (hxy : ∀ v, θ (x • v) = y �
   rw [Associative.dividedPower_def, Associative.dividedPower_def, smul_assoc, smul_assoc,
     map_smul, apply_pow_smul_of_intertwines θ hxy]
 
+variable (θ : V ≃ₗ[ℚ] V)
+
 omit [Algebra ℚ A] [IsScalarTower ℚ A V] in
 /-- Over a faithful module, nilpotency transfers along an intertwiner: if `θ` carries the action of
 `x` to the action of `y`, then a vanishing power of `x` forces the same power of `y` to vanish. -/
 theorem pow_eq_zero_of_intertwines [FaithfulSMul A V] (hxy : ∀ v, θ (x • v) = y • θ v) {k : ℕ}
     (hkx : x ^ k = 0) : y ^ k = 0 := by
   refine eq_of_smul_eq_smul (α := V) fun v => ?_
-  have hv := apply_pow_smul_of_intertwines θ hxy k (θ.symm v)
+  have hv := apply_pow_smul_of_intertwines θ.toLinearMap hxy k (θ.symm v)
+  simp only [LinearEquiv.coe_toLinearMap] at hv
   rw [hkx, zero_smul, map_zero, θ.apply_symm_apply] at hv
   rw [zero_smul]
   exact hv.symm
@@ -176,11 +179,11 @@ private theorem val_invariantRestrictUnit_pow_tmul (θ : V ≃ₗ[ℚ] V) (M : S
       rw [pow_succ, Units.val_mul, Module.End.mul_apply, val_invariantRestrictUnit_tmul, ih,
         pow_succ, LinearEquiv.mul_apply]
 
-/-- An automorphism of finite order induces an automorphism of the same finite order on every
-scalar extension.
+/-- If an automorphism has `n`th power one, then the induced automorphism on every scalar extension
+also has `n`th power one.
 
-This is what makes a diagram automorphism of order two or three into a group automorphism of the
-same order. -/
+Thus the order of the induced automorphism divides `n`; restriction or scalar extension may lower
+the exact order. -/
 theorem invariantRestrictUnit_pow_eq_one (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
     {n : ℕ} (hn : ∀ v, (θ ^ n) v = v) :
     invariantRestrictUnit (R := R) θ M hθ ^ n = 1 := by
@@ -215,8 +218,9 @@ theorem baseChange_invariantRestrict_baseChangeExp (M : S) (hθ : ∀ v, θ v �
       congr 1
       refine Subtype.ext ?_
       rw [coe_invariantRestrict_apply, coe_integralDividedPower_apply,
-        coe_integralDividedPower_apply, coe_invariantRestrict_apply,
-        apply_dividedPower_smul_of_intertwines θ hxy]
+        coe_integralDividedPower_apply, coe_invariantRestrict_apply]
+      simpa only [LinearEquiv.coe_toLinearMap] using
+        apply_dividedPower_smul_of_intertwines θ.toLinearMap hxy n (v : V)
   | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
 
 end TauCeti

--- a/TauCeti/RingTheory/Nilpotent/Conjugation.lean
+++ b/TauCeti/RingTheory/Nilpotent/Conjugation.lean
@@ -5,7 +5,7 @@ Authors: Claude
 -/
 module
 
-public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+public import TauCeti.LinearAlgebra.GeneralLinearGroup.InvariantRestrict
 public import TauCeti.RingTheory.Nilpotent.BaseChangeAction
 
 /-!
@@ -32,14 +32,8 @@ is in `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymm
 
 ## Main definitions and results
 
-* `TauCeti.invariantRestrict`: a `ℚ`-linear automorphism restricted to an invariant additive
-  subgroup, as an integral automorphism of that subgroup.
 * `TauCeti.apply_pow_smul_of_intertwines` and `TauCeti.apply_dividedPower_smul_of_intertwines`:
   an intertwiner for `x` and `y` intertwines their powers and their divided powers.
-* `TauCeti.pow_eq_zero_of_intertwines`: over a faithful module, nilpotency transfers along an
-  intertwiner.
-* `TauCeti.invariantRestrictUnit`: the resulting automorphism of the scalar extension `R ⊗[ℤ] M`,
-  with `TauCeti.invariantRestrictUnit_pow_eq_one` transporting an `n`th-power-one relation of `θ`.
 * `TauCeti.baseChange_invariantRestrict_baseChangeExp`: the conjugation formula for the
   base-changed exponential.
 
@@ -61,57 +55,24 @@ variable {A : Type*} [Ring A] [Algebra ℚ A]
 variable {V : Type u} [AddCommGroup V] [Module ℚ V] [Module A V] [IsScalarTower ℚ A V]
 variable {S : Type*} [SetLike S V] [AddSubgroupClass S V]
 
-/-! ## Restricting an automorphism to an invariant subgroup -/
-
-/-- A `ℚ`-linear automorphism of `V` that restricts to a bijection of an additive subgroup `M`,
-viewed as an integral automorphism of `M`.
-
-The subgroup `M` is not a `ℚ`-submodule — in the intended application it is a lattice — so this is
-genuinely a restriction of scalars to `ℤ` and not an instance of `LinearEquiv.ofSubmodule'`. -/
-def invariantRestrict (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) : M ≃ₗ[ℤ] M where
-  toFun v := ⟨θ v, (hθ v).2 v.2⟩
-  invFun v := ⟨θ.symm v, (hθ _).1 (by rw [θ.apply_symm_apply]; exact v.2)⟩
-  left_inv v := Subtype.ext (θ.symm_apply_apply _)
-  right_inv v := Subtype.ext (θ.apply_symm_apply _)
-  map_add' v w := Subtype.ext (map_add θ _ _)
-  map_smul' t v := Subtype.ext (map_zsmul θ _ _)
-
-/-- The restriction of `θ` to an invariant subgroup acts by `θ`. -/
-@[simp]
-theorem coe_invariantRestrict_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (v : M) :
-    ((invariantRestrict θ M hθ v : M) : V) = θ (v : V) :=
-  (rfl)
-
-/-- The inverse of the restriction of `θ` to an invariant subgroup acts by `θ.symm`. -/
-@[simp]
-theorem coe_invariantRestrict_symm_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
-    (v : M) :
-    (((invariantRestrict θ M hθ).symm v : M) : V) = θ.symm (v : V) :=
-  (rfl)
-
-/-- Powers of the restriction of `θ` act by the corresponding powers of `θ`. -/
-theorem coe_invariantRestrict_pow_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
-    (n : ℕ) (v : M) :
-    (((invariantRestrict θ M hθ ^ n) v : M) : V) = (θ ^ n) (v : V) := by
-  induction n generalizing v with
-  | zero => simp
-  | succ n ih =>
-      rw [pow_succ, LinearEquiv.mul_apply, ih, pow_succ, LinearEquiv.mul_apply,
-        coe_invariantRestrict_apply]
-
 /-! ## Transporting powers and divided powers -/
 
-variable (θ : V →ₗ[ℚ] V) {x y : A}
+section Powers
 
-omit [Algebra ℚ A] [IsScalarTower ℚ A V] in
-/-- A linear map intertwining the actions of `x` and `y` intertwines the actions of their
-powers. -/
-theorem apply_pow_smul_of_intertwines (hxy : ∀ v, θ (x • v) = y • θ v) (n : ℕ) (v : V) :
-    θ (x ^ n • v) = y ^ n • θ v := by
+variable {B X Y : Type*} [Monoid B] [MulAction B X] [MulAction B Y]
+variable (f : X → Y) {x y : B}
+
+/-- A map intertwining the actions of `x` and `y` intertwines the actions of their powers. -/
+theorem apply_pow_smul_of_intertwines (hxy : ∀ v, f (x • v) = y • f v) (n : ℕ) (v : X) :
+    f (x ^ n • v) = y ^ n • f v := by
   induction n generalizing v with
   | zero => simp
   | succ n ih =>
       rw [pow_succ x n, mul_smul, ih (x • v), hxy, pow_succ y n, mul_smul]
+
+end Powers
+
+variable (θ : V →ₗ[ℚ] V) {x y : A}
 
 /-- A linear map intertwining the actions of `x` and `y` intertwines the actions of their
 divided powers.
@@ -125,18 +86,6 @@ theorem apply_dividedPower_smul_of_intertwines (hxy : ∀ v, θ (x • v) = y �
 
 variable (θ : V ≃ₗ[ℚ] V)
 
-omit [Algebra ℚ A] [IsScalarTower ℚ A V] in
-/-- Over a faithful module, nilpotency transfers along an intertwiner: if `θ` carries the action of
-`x` to the action of `y`, then a vanishing power of `x` forces the same power of `y` to vanish. -/
-theorem pow_eq_zero_of_intertwines [FaithfulSMul A V] (hxy : ∀ v, θ (x • v) = y • θ v) {k : ℕ}
-    (hkx : x ^ k = 0) : y ^ k = 0 := by
-  refine eq_of_smul_eq_smul (α := V) fun v => ?_
-  have hv := apply_pow_smul_of_intertwines θ.toLinearMap hxy k (θ.symm v)
-  simp only [LinearEquiv.coe_toLinearMap] at hv
-  rw [hkx, zero_smul, map_zero, θ.apply_symm_apply] at hv
-  rw [zero_smul]
-  exact hv.symm
-
 /-! ## Conjugating the base-changed exponential -/
 
 -- Use the module structure carried by the explicit `ℤ`-algebra, matching `baseChangeExp`.
@@ -144,70 +93,20 @@ attribute [local instance high] Algebra.toModule
 
 variable {R : Type v} [CommRing R] [Algebra ℤ R]
 
-/-- The automorphism of the scalar extension `R ⊗[ℤ] M` induced by a `ℚ`-linear automorphism of `V`
-preserving `M`.
-
-Only the integral restriction of `θ` is used, so this is defined over every commutative ring `R`,
-just like the exponentials it conjugates. -/
-noncomputable def invariantRestrictUnit (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) :
-    LinearMap.GeneralLinearGroup R (R ⊗[ℤ] M) :=
-  LinearMap.GeneralLinearGroup.ofLinearEquiv ((invariantRestrict θ M hθ).baseChange ℤ R M M)
-
-/-- The induced automorphism of a scalar extension is the base change of the restriction of `θ`. -/
-theorem val_invariantRestrictUnit_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
-    (z : R ⊗[ℤ] M) :
-    (invariantRestrictUnit (R := R) θ M hθ).val z =
-      (invariantRestrict θ M hθ).baseChange ℤ R M M z :=
-  (rfl)
-
-/-- The induced automorphism of a scalar extension acts on a pure tensor through the restriction
-of `θ`. -/
-@[simp]
-theorem val_invariantRestrictUnit_tmul (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
-    (r : R) (v : M) :
-    (invariantRestrictUnit (R := R) θ M hθ).val (r ⊗ₜ[ℤ] v) =
-      r ⊗ₜ[ℤ] invariantRestrict θ M hθ v :=
-  (rfl)
-
-private theorem val_invariantRestrictUnit_pow_tmul (θ : V ≃ₗ[ℚ] V) (M : S)
-    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (n : ℕ) (r : R) (v : M) :
-    (invariantRestrictUnit (R := R) θ M hθ ^ n).val (r ⊗ₜ[ℤ] v) =
-      r ⊗ₜ[ℤ] ((invariantRestrict θ M hθ ^ n) v) := by
-  induction n generalizing v with
-  | zero => simp
-  | succ n ih =>
-      rw [pow_succ, Units.val_mul, Module.End.mul_apply, val_invariantRestrictUnit_tmul, ih,
-        pow_succ, LinearEquiv.mul_apply]
-
-/-- If an automorphism has `n`th power one, then the induced automorphism on every scalar extension
-also has `n`th power one.
-
-Thus the order of the induced automorphism divides `n`; restriction or scalar extension may lower
-the exact order. -/
-theorem invariantRestrictUnit_pow_eq_one (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
-    {n : ℕ} (hn : ∀ v, (θ ^ n) v = v) :
-    invariantRestrictUnit (R := R) θ M hθ ^ n = 1 := by
-  refine Units.ext (LinearMap.ext fun z => ?_)
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | tmul r v =>
-      rw [val_invariantRestrictUnit_pow_tmul, Units.val_one, Module.End.one_apply]
-      exact congrArg (fun w : M => r ⊗ₜ[ℤ] w)
-        (Subtype.ext ((coe_invariantRestrict_pow_apply θ M hθ n v).trans (hn (v : V))))
-  | add z w hz hw => rw [map_add, map_add, hz, hw]
-
 /-- Conjugating the base-changed divided-power exponential of `x` by an intertwiner produces the
 base-changed divided-power exponential of `y`, with the same parameter.
 
-Both exponentials are truncated at a common bound `k`, which is available in practice because
-nilpotency transfers along the intertwiner (`pow_eq_zero_of_intertwines`). -/
+Both exponentials are truncated at a common bound `k`; in the intended application, the second
+bound follows structurally by conjugating the first nilpotent endomorphism. -/
 theorem baseChange_invariantRestrict_baseChangeExp (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
     (hxy : ∀ v, θ (x • v) = y • θ v)
     (hx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
     (hy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
     {k : ℕ} (hkx : x ^ k = 0) (hky : y ^ k = 0) (t : R) (z : R ⊗[ℤ] M) :
-    (invariantRestrict θ M hθ).baseChange ℤ R M M (baseChangeExp x M hx t z) =
-      baseChangeExp y M hy t ((invariantRestrict θ M hθ).baseChange ℤ R M M z) := by
+    (GeneralLinearGroup.invariantRestrict θ.toAddEquiv M hθ).baseChange ℤ R M M
+        (baseChangeExp x M hx t z) =
+      baseChangeExp y M hy t
+        ((GeneralLinearGroup.invariantRestrict θ.toAddEquiv M hθ).baseChange ℤ R M M z) := by
   induction z using TensorProduct.induction_on with
   | zero => simp
   | tmul r v =>
@@ -217,8 +116,10 @@ theorem baseChange_invariantRestrict_baseChangeExp (M : S) (hθ : ∀ v, θ v �
       rw [LinearEquiv.baseChange_tmul]
       congr 1
       refine Subtype.ext ?_
-      rw [coe_invariantRestrict_apply, coe_integralDividedPower_apply,
-        coe_integralDividedPower_apply, coe_invariantRestrict_apply]
+      rw [GeneralLinearGroup.coe_invariantRestrict_apply, coe_integralDividedPower_apply,
+        coe_integralDividedPower_apply, GeneralLinearGroup.coe_invariantRestrict_apply]
+      change θ (Associative.dividedPower n x • (v : V)) =
+        Associative.dividedPower n y • θ (v : V)
       simpa only [LinearEquiv.coe_toLinearMap] using
         apply_dividedPower_smul_of_intertwines θ.toLinearMap hxy n (v : V)
   | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]

--- a/TauCeti/RingTheory/Nilpotent/Conjugation.lean
+++ b/TauCeti/RingTheory/Nilpotent/Conjugation.lean
@@ -93,6 +93,23 @@ attribute [local instance high] Algebra.toModule
 
 variable {R : Type v} [CommRing R] [Algebra ℤ R]
 
+omit [AddSubgroupClass S V] in
+/-- An invariant equivalence carries preservation of a set by the divided powers of
+one element to preservation by the divided powers of an intertwined element. -/
+theorem dividedPower_smul_mem_of_intertwines (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (hxy : ∀ v, θ (x • v) = y • θ v)
+    (hx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M) :
+    ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M := by
+  intro n v hv
+  have hv' : θ.symm (v : V) ∈ M :=
+    (hθ (θ.symm v)).1 (by simpa only [θ.apply_symm_apply] using hv)
+  have hdp : θ (Associative.dividedPower n x • θ.symm v) =
+      Associative.dividedPower n y • v := by
+    simpa only [LinearEquiv.coe_toLinearMap, θ.apply_symm_apply] using
+      apply_dividedPower_smul_of_intertwines θ.toLinearMap hxy n (θ.symm v)
+  rw [← hdp]
+  exact (hθ _).2 (hx n (θ.symm v) hv')
+
 /-- Conjugating the base-changed divided-power exponential of `x` by an intertwiner produces the
 base-changed divided-power exponential of `y`, with the same parameter.
 
@@ -101,27 +118,24 @@ bound follows structurally by conjugating the first nilpotent endomorphism. -/
 theorem baseChange_invariantRestrict_baseChangeExp (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
     (hxy : ∀ v, θ (x • v) = y • θ v)
     (hx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
-    (hy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
     {k : ℕ} (hkx : x ^ k = 0) (hky : y ^ k = 0) (t : R) (z : R ⊗[ℤ] M) :
     (GeneralLinearGroup.invariantRestrict θ.toAddEquiv M hθ).baseChange ℤ R M M
         (baseChangeExp x M hx t z) =
-      baseChangeExp y M hy t
+      baseChangeExp y M (dividedPower_smul_mem_of_intertwines θ M hθ hxy hx) t
         ((GeneralLinearGroup.invariantRestrict θ.toAddEquiv M hθ).baseChange ℤ R M M z) := by
   induction z using TensorProduct.induction_on with
   | zero => simp
   | tmul r v =>
       rw [baseChangeExp_tmul_of_pow_eq_zero x M hx hkx, map_sum,
-        LinearEquiv.baseChange_tmul, baseChangeExp_tmul_of_pow_eq_zero y M hy hky]
+        LinearEquiv.baseChange_tmul, baseChangeExp_tmul_of_pow_eq_zero y M
+          (dividedPower_smul_mem_of_intertwines θ M hθ hxy hx) hky]
       refine Finset.sum_congr rfl fun n _ => ?_
       rw [LinearEquiv.baseChange_tmul]
       congr 1
       refine Subtype.ext ?_
       rw [GeneralLinearGroup.coe_invariantRestrict_apply, coe_integralDividedPower_apply,
         coe_integralDividedPower_apply, GeneralLinearGroup.coe_invariantRestrict_apply]
-      change θ (Associative.dividedPower n x • (v : V)) =
-        Associative.dividedPower n y • θ (v : V)
-      simpa only [LinearEquiv.coe_toLinearMap] using
-        apply_dividedPower_smul_of_intertwines θ.toLinearMap hxy n (v : V)
+      convert apply_dividedPower_smul_of_intertwines θ.toLinearMap hxy n (v : V) using 1 <;> rfl
   | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
 
 end TauCeti

--- a/TauCeti/RingTheory/Nilpotent/Conjugation.lean
+++ b/TauCeti/RingTheory/Nilpotent/Conjugation.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+public import TauCeti.RingTheory.Nilpotent.BaseChangeAction
+
+/-!
+# Conjugating an integral nilpotent exponential by an intertwining automorphism
+
+Let `V` be a module over a `ℚ`-algebra `A`, let `M ≤ V` be an additive subgroup, and let
+`θ : V ≃ₗ[ℚ] V` be a `ℚ`-linear automorphism restricting to a bijection of `M`. If `θ` carries the
+action of `x : A` to the action of `y : A`, in the sense that `θ (x • v) = y • θ v`, then it carries
+every divided power of `x` to the corresponding divided power of `y`, and hence conjugates the
+base-changed divided-power exponential of `x` into that of `y`:
+
+```text
+θ_R ∘ E_R(x, t) = E_R(y, t) ∘ θ_R,     θ_R = R ⊗ θ|_M.
+```
+
+The intertwining hypothesis is imposed only on `x` itself. Divided powers divide by factorials in
+`A`, so `θ` must be `ℚ`-linear for the transported statement to make sense; the *conclusion* is
+nonetheless an identity of integral operators on `R ⊗[ℤ] M` over an arbitrary commutative ring `R`.
+
+This is the mechanism behind a graph automorphism of a Chevalley group: a symmetry of the ambient
+Lie-algebra data that permutes the distinguished root vectors conjugates the corresponding root
+subgroups into one another, permuted the same way. Its application to Kostant root subgroups is in
+`TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Diagram.lean`.
+
+## Main definitions and results
+
+* `TauCeti.invariantRestrict`: a `ℚ`-linear automorphism restricted to an invariant additive
+  subgroup, as an integral automorphism of that subgroup.
+* `TauCeti.apply_pow_smul_of_intertwines` and `TauCeti.apply_dividedPower_smul_of_intertwines`:
+  an intertwiner for `x` and `y` intertwines their powers and their divided powers.
+* `TauCeti.pow_eq_zero_of_intertwines`: over a faithful module, nilpotency transfers along an
+  intertwiner.
+* `TauCeti.invariantRestrictUnit`: the resulting automorphism of the scalar extension `R ⊗[ℤ] M`,
+  with `TauCeti.invariantRestrictUnit_pow_eq_one` transporting the order of `θ`.
+* `TauCeti.baseChange_invariantRestrict_baseChangeExp`: the conjugation formula for the
+  base-changed exponential.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §12.2.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §26.
+-/
+
+public section
+
+namespace TauCeti
+
+open TensorProduct
+
+universe u v
+
+variable {A : Type*} [Ring A] [Algebra ℚ A]
+variable {V : Type u} [AddCommGroup V] [Module ℚ V] [Module A V] [IsScalarTower ℚ A V]
+variable {S : Type*} [SetLike S V] [AddSubgroupClass S V]
+
+/-! ## Restricting an automorphism to an invariant subgroup -/
+
+/-- A `ℚ`-linear automorphism of `V` that restricts to a bijection of an additive subgroup `M`,
+viewed as an integral automorphism of `M`.
+
+The subgroup `M` is not a `ℚ`-submodule — in the intended application it is a lattice — so this is
+genuinely a restriction of scalars to `ℤ` and not an instance of `LinearEquiv.ofSubmodule'`. -/
+def invariantRestrict (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) : M ≃ₗ[ℤ] M where
+  toFun v := ⟨θ v, (hθ v).2 v.2⟩
+  invFun v := ⟨θ.symm v, (hθ _).1 (by rw [θ.apply_symm_apply]; exact v.2)⟩
+  left_inv v := Subtype.ext (θ.symm_apply_apply _)
+  right_inv v := Subtype.ext (θ.apply_symm_apply _)
+  map_add' v w := Subtype.ext (map_add θ _ _)
+  map_smul' t v := Subtype.ext (map_zsmul θ _ _)
+
+/-- The restriction of `θ` to an invariant subgroup acts by `θ`. -/
+@[simp]
+theorem coe_invariantRestrict_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (v : M) :
+    ((invariantRestrict θ M hθ v : M) : V) = θ (v : V) :=
+  (rfl)
+
+/-- The inverse of the restriction of `θ` to an invariant subgroup acts by `θ.symm`. -/
+@[simp]
+theorem coe_invariantRestrict_symm_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    (v : M) :
+    (((invariantRestrict θ M hθ).symm v : M) : V) = θ.symm (v : V) :=
+  (rfl)
+
+/-- Powers of the restriction of `θ` act by the corresponding powers of `θ`. -/
+theorem coe_invariantRestrict_pow_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    (n : ℕ) (v : M) :
+    (((invariantRestrict θ M hθ ^ n) v : M) : V) = (θ ^ n) (v : V) := by
+  induction n generalizing v with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, LinearEquiv.mul_apply, ih, pow_succ, LinearEquiv.mul_apply,
+        coe_invariantRestrict_apply]
+
+/-! ## Transporting powers and divided powers -/
+
+variable (θ : V ≃ₗ[ℚ] V) {x y : A}
+
+omit [Algebra ℚ A] [IsScalarTower ℚ A V] in
+/-- An automorphism intertwining the actions of `x` and `y` intertwines the actions of their
+powers. -/
+theorem apply_pow_smul_of_intertwines (hxy : ∀ v, θ (x • v) = y • θ v) (n : ℕ) (v : V) :
+    θ (x ^ n • v) = y ^ n • θ v := by
+  induction n generalizing v with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ x n, mul_smul, ih (x • v), hxy, pow_succ y n, mul_smul]
+
+/-- An automorphism intertwining the actions of `x` and `y` intertwines the actions of their
+divided powers.
+
+The divided powers involve division by factorials, which is why the intertwiner is required to be
+`ℚ`-linear rather than merely additive. -/
+theorem apply_dividedPower_smul_of_intertwines (hxy : ∀ v, θ (x • v) = y • θ v) (n : ℕ) (v : V) :
+    θ (Associative.dividedPower n x • v) = Associative.dividedPower n y • θ v := by
+  rw [Associative.dividedPower_def, Associative.dividedPower_def, smul_assoc, smul_assoc,
+    map_smul, apply_pow_smul_of_intertwines θ hxy]
+
+omit [Algebra ℚ A] [IsScalarTower ℚ A V] in
+/-- Over a faithful module, nilpotency transfers along an intertwiner: if `θ` carries the action of
+`x` to the action of `y`, then a vanishing power of `x` forces the same power of `y` to vanish. -/
+theorem pow_eq_zero_of_intertwines [FaithfulSMul A V] (hxy : ∀ v, θ (x • v) = y • θ v) {k : ℕ}
+    (hkx : x ^ k = 0) : y ^ k = 0 := by
+  refine eq_of_smul_eq_smul (α := V) fun v => ?_
+  have hv := apply_pow_smul_of_intertwines θ hxy k (θ.symm v)
+  rw [hkx, zero_smul, map_zero, θ.apply_symm_apply] at hv
+  rw [zero_smul]
+  exact hv.symm
+
+/-! ## Conjugating the base-changed exponential -/
+
+-- Use the module structure carried by the explicit `ℤ`-algebra, matching `baseChangeExp`.
+attribute [local instance high] Algebra.toModule
+
+variable {R : Type v} [CommRing R] [Algebra ℤ R]
+
+/-- The automorphism of the scalar extension `R ⊗[ℤ] M` induced by a `ℚ`-linear automorphism of `V`
+preserving `M`.
+
+Only the integral restriction of `θ` is used, so this is defined over every commutative ring `R`,
+just like the exponentials it conjugates. -/
+noncomputable def invariantRestrictUnit (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) :
+    LinearMap.GeneralLinearGroup R (R ⊗[ℤ] M) :=
+  LinearMap.GeneralLinearGroup.ofLinearEquiv ((invariantRestrict θ M hθ).baseChange ℤ R M M)
+
+/-- The induced automorphism of a scalar extension is the base change of the restriction of `θ`. -/
+theorem val_invariantRestrictUnit_apply (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    (z : R ⊗[ℤ] M) :
+    (invariantRestrictUnit (R := R) θ M hθ).val z =
+      (invariantRestrict θ M hθ).baseChange ℤ R M M z :=
+  (rfl)
+
+/-- The induced automorphism of a scalar extension acts on a pure tensor through the restriction
+of `θ`. -/
+@[simp]
+theorem val_invariantRestrictUnit_tmul (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    (r : R) (v : M) :
+    (invariantRestrictUnit (R := R) θ M hθ).val (r ⊗ₜ[ℤ] v) =
+      r ⊗ₜ[ℤ] invariantRestrict θ M hθ v :=
+  (rfl)
+
+private theorem val_invariantRestrictUnit_pow_tmul (θ : V ≃ₗ[ℚ] V) (M : S)
+    (hθ : ∀ v, θ v ∈ M ↔ v ∈ M) (n : ℕ) (r : R) (v : M) :
+    (invariantRestrictUnit (R := R) θ M hθ ^ n).val (r ⊗ₜ[ℤ] v) =
+      r ⊗ₜ[ℤ] ((invariantRestrict θ M hθ ^ n) v) := by
+  induction n generalizing v with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, Units.val_mul, Module.End.mul_apply, val_invariantRestrictUnit_tmul, ih,
+        pow_succ, LinearEquiv.mul_apply]
+
+/-- An automorphism of finite order induces an automorphism of the same finite order on every
+scalar extension.
+
+This is what makes a diagram automorphism of order two or three into a group automorphism of the
+same order. -/
+theorem invariantRestrictUnit_pow_eq_one (θ : V ≃ₗ[ℚ] V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    {n : ℕ} (hn : ∀ v, (θ ^ n) v = v) :
+    invariantRestrictUnit (R := R) θ M hθ ^ n = 1 := by
+  refine Units.ext (LinearMap.ext fun z => ?_)
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul r v =>
+      rw [val_invariantRestrictUnit_pow_tmul, Units.val_one, Module.End.one_apply]
+      exact congrArg (fun w : M => r ⊗ₜ[ℤ] w)
+        (Subtype.ext ((coe_invariantRestrict_pow_apply θ M hθ n v).trans (hn (v : V))))
+  | add z w hz hw => rw [map_add, map_add, hz, hw]
+
+/-- Conjugating the base-changed divided-power exponential of `x` by an intertwiner produces the
+base-changed divided-power exponential of `y`, with the same parameter.
+
+Both exponentials are truncated at a common bound `k`, which is available in practice because
+nilpotency transfers along the intertwiner (`pow_eq_zero_of_intertwines`). -/
+theorem baseChange_invariantRestrict_baseChangeExp (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
+    (hxy : ∀ v, θ (x • v) = y • θ v)
+    (hx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    (hy : ∀ n, ∀ v ∈ M, Associative.dividedPower n y • v ∈ M)
+    {k : ℕ} (hkx : x ^ k = 0) (hky : y ^ k = 0) (t : R) (z : R ⊗[ℤ] M) :
+    (invariantRestrict θ M hθ).baseChange ℤ R M M (baseChangeExp x M hx t z) =
+      baseChangeExp y M hy t ((invariantRestrict θ M hθ).baseChange ℤ R M M z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul r v =>
+      rw [baseChangeExp_tmul_of_pow_eq_zero x M hx hkx, map_sum,
+        LinearEquiv.baseChange_tmul, baseChangeExp_tmul_of_pow_eq_zero y M hy hky]
+      refine Finset.sum_congr rfl fun n _ => ?_
+      rw [LinearEquiv.baseChange_tmul]
+      congr 1
+      refine Subtype.ext ?_
+      rw [coe_invariantRestrict_apply, coe_integralDividedPower_apply,
+        coe_integralDividedPower_apply, coe_invariantRestrict_apply,
+        apply_dividedPower_smul_of_intertwines θ hxy]
+  | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
+
+end TauCeti


### PR DESCRIPTION
This PR constructs numbered-symmetry automorphisms of Kostant elementary Chevalley groups and proves the three equations a graph-twisted Steinberg endomorphism is built from. A *symmetry of the numbered data* is a surjective self-map `σ` of the root-vector index set together with a `ℚ`-linear automorphism `θ` of the representation that preserves the Kostant-stable lattice `M` and carries the action of `eᵢ` to the action of `e_{σ i}`. Conjugation by the scalar extension of `θ` is then shown to satisfy the pinning equation `γ (xᵢ(t)) = x_{σ i}(t)`, to carry the elementary group `E(A) = ⟨xᵢ(t)⟩ ≤ Aut_A(A ⊗[ℤ] M)` onto itself, to commute with every base change of the value ring and hence with the `p ^ n`-power Frobenius endomorphism, and to satisfy `γ ^ n = 1` whenever `θ ^ n = 1`.

This advances the **reductive-groups roadmap, Layer 9** (`ReductiveGroups/README.md`), whose bullet "The isomorphism theorem for pinned groups … is what makes a diagram automorphism into a named group automorphism" is the milestone served: this PR supplies a construction used by that target — a numbered symmetry gives an explicit group automorphism pinned by its action on the distinguished root subgroups — for the elementary group built by `kostantElementarySubgroup`. Uniqueness (that `γ` is the only automorphism with that action on the simple root subgroups) is *not* claimed here and remains open, together with the rest of Layer 9: the assembled pinned group scheme with torus and Borel, integral PBW and a finite free admissible lattice, base change with pinning compatibility, the char 2/3 special isogenies, and identifying `E(k)` with the full points of the scheme over a field.

Consumer roadmap: CFSGStatement

The dependency edge: CFSGStatement milestone `L1` ("ordinary and graph Steinberg maps") requires, for the families `²A`, `²D`, `²E₆` and `³D₄`, a Steinberg map `γ ∘ Frob_q` whose factor `γ` satisfies exactly `γ (x_α(t)) = x_{γ α}(t)` for `α` simple, together with `γ ^ 2 = 1` (resp. `γ ^ 3 = 1`) and commutation with `Frob_q`. The CFSGStatement README assigns the automorphism itself to reductive groups Layer 9 rather than to the consumer, and `L0` lists the Layer 9 declarations it consumes. `TauCeti.UniversalEnvelopingAlgebra.baseChangeInvariantRestrictUnit_conj_kostantRootSubgroupParam`, `kostantElementaryNumberedSymmetryAut_pow_eq_one` and `kostantElementaryFrobenius_kostantElementaryNumberedSymmetryAut` are the three statements the `L1` map `steinberg` will consume once `L0` has an ambient group; the declaration that will consume them is `ValidLieTypeIndex.steinberg` on its `GraphTwistedIndex` branches.

Files added: `TauCeti/LinearAlgebra/GeneralLinearGroup/InvariantRestrict.lean`, the generic restriction and scalar-extension mechanism; `TauCeti/RingTheory/Nilpotent/Conjugation.lean`, transport of divided powers and the conjugation formula for `baseChangeExp`; and `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean`, the Kostant-level numbered-symmetry construction. `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Elementary.lean` gains the generator-transport interface and the public Frobenius value-ring morphism used by the new module.

Nothing is vendored from Mathlib. The symmetry `(σ, θ)` is data supplied by the caller: no claim is made that `σ` comes from a Dynkin diagram symmetry or that `θ` is unique, and no finiteness or simplicity statement is involved.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"graph-automorphism-elementary-chevalley-group"}-->

🤖 Prepared with Claude Code

