### PR TITLE
feat: close conflations under biproducts

### DIFF
--- a/TauCeti/Algebra/Homology/ShortComplex/Biproduct.lean
+++ b/TauCeti/Algebra/Homology/ShortComplex/Biproduct.lean
@@ -51,14 +51,6 @@ theorem shortComplexBiprod_zero (S₁ S₂ : ShortComplex C)
   ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
     (shortComplexBiprod_zero S₁ S₂)
 
-/-- The componentwise biproduct as an explicitly constructed short complex. -/
-theorem shortComplexBiprod_eq_mk (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    shortComplexBiprod S₁ S₂ =
-      ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
-        (shortComplexBiprod_zero S₁ S₂) := (rfl)
-
 /-- The left object of the componentwise biproduct of two short complexes. -/
 @[simp]
 theorem shortComplexBiprod_X₁ (S₁ S₂ : ShortComplex C)

--- a/TauCeti/Algebra/Homology/ShortComplex/Biproduct.lean
+++ b/TauCeti/Algebra/Homology/ShortComplex/Biproduct.lean
@@ -18,6 +18,13 @@ projection lemmas identifying its objects and maps.
 ## Main definitions
 
 * `TauCeti.shortComplexBiprod`: the componentwise binary direct sum of two short complexes.
+
+## Implementation notes
+
+`shortComplexBiprod` is `@[expose]`d so that its objects are definitionally the corresponding
+biproducts outside this file. Without that, the type of `(shortComplexBiprod S₁ S₂).f` could not
+be seen to be `S₁.X₁ ⊞ S₂.X₁ ⟶ S₁.X₂ ⊞ S₂.X₂`, and the projection lemmas for the two maps would
+have to be stated with a heterogeneous equality.
 -/
 
 public section
@@ -38,7 +45,7 @@ theorem shortComplexBiprod_zero (S₁ S₂ : ShortComplex C)
   ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero]
 
 /-- The componentwise binary direct sum of two short complexes. -/
-noncomputable def shortComplexBiprod (S₁ S₂ : ShortComplex C)
+@[expose] noncomputable def shortComplexBiprod (S₁ S₂ : ShortComplex C)
     [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
     [HasBinaryBiproduct S₁.X₃ S₂.X₃] : ShortComplex C :=
   ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
@@ -78,13 +85,13 @@ theorem shortComplexBiprod_X₃ (S₁ S₂ : ShortComplex C)
 theorem shortComplexBiprod_f (S₁ S₂ : ShortComplex C)
     [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
     [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    HEq (shortComplexBiprod S₁ S₂).f (biprod.map S₁.f S₂.f) := (HEq.rfl)
+    (shortComplexBiprod S₁ S₂).f = biprod.map S₁.f S₂.f := (rfl)
 
 /-- The second map of the componentwise biproduct of two short complexes. -/
 @[simp]
 theorem shortComplexBiprod_g (S₁ S₂ : ShortComplex C)
     [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
     [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    HEq (shortComplexBiprod S₁ S₂).g (biprod.map S₁.g S₂.g) := (HEq.rfl)
+    (shortComplexBiprod S₁ S₂).g = biprod.map S₁.g S₂.g := (rfl)
 
 end TauCeti

--- a/TauCeti/Algebra/Homology/ShortComplex/Biproduct.lean
+++ b/TauCeti/Algebra/Homology/ShortComplex/Biproduct.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Algebra.Homology.ShortComplex.Basic
+public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
+
+/-!
+# Binary biproducts of short complexes
+
+Two short complexes in a category with zero morphisms have a componentwise binary direct sum,
+provided the three relevant binary biproducts exist. This file constructs it and records the
+projection lemmas identifying its objects and maps.
+
+## Main definitions
+
+* `TauCeti.shortComplexBiprod`: the componentwise binary direct sum of two short complexes.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [HasZeroMorphisms C]
+
+/-- The two maps in the componentwise biproduct of short complexes have zero composite. -/
+theorem shortComplexBiprod_zero (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    biprod.map S₁.f S₂.f ≫ biprod.map S₁.g S₂.g = 0 := by
+  ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero]
+
+/-- The componentwise binary direct sum of two short complexes. -/
+noncomputable def shortComplexBiprod (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] : ShortComplex C :=
+  ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
+    (shortComplexBiprod_zero S₁ S₂)
+
+/-- The componentwise biproduct as an explicitly constructed short complex. -/
+theorem shortComplexBiprod_eq_mk (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    shortComplexBiprod S₁ S₂ =
+      ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
+        (shortComplexBiprod_zero S₁ S₂) := (rfl)
+
+/-- The left object of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_X₁ (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    (shortComplexBiprod S₁ S₂).X₁ = (S₁.X₁ ⊞ S₂.X₁) := (rfl)
+
+/-- The middle object of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_X₂ (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    (shortComplexBiprod S₁ S₂).X₂ = (S₁.X₂ ⊞ S₂.X₂) := (rfl)
+
+/-- The right object of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_X₃ (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    (shortComplexBiprod S₁ S₂).X₃ = (S₁.X₃ ⊞ S₂.X₃) := (rfl)
+
+/-- The first map of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_f (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    HEq (shortComplexBiprod S₁ S₂).f (biprod.map S₁.f S₂.f) := (HEq.rfl)
+
+/-- The second map of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_g (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    HEq (shortComplexBiprod S₁ S₂).g (biprod.map S₁.g S₂.g) := (HEq.rfl)
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Exact/Biproduct.lean
+++ b/TauCeti/CategoryTheory/Exact/Biproduct.lean
@@ -6,6 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.CategoryTheory.Exact.ExactStructure
+public import TauCeti.CategoryTheory.Limits.Shapes.Biproduct
 
 /-!
 # Binary biproducts of conflations
@@ -78,8 +79,7 @@ theorem isInflation_biprod (E : ExactStructure C)
     E.isInflation_biprod_id hi₁ X₂
   have h₂ : E.IsInflation (Limits.biprod.map (𝟙 Y₁) i₂) :=
     E.isInflation_id_biprod hi₂ Y₁
-  rw [show Limits.biprod.map i₁ i₂ =
-    Limits.biprod.map i₁ (𝟙 X₂) ≫ Limits.biprod.map (𝟙 Y₁) i₂ by ext <;> simp]
+  rw [biprod_map_factor]
   exact E.isInflation_comp _ _ h₁ h₂
 
 /-- Adjoining an identity map as the second summand preserves deflations.  This is E2op applied
@@ -111,17 +111,18 @@ theorem isDeflation_biprod (E : ExactStructure C)
     E.isDeflation_biprod_id hp₁ Y₂
   have h₂ : E.IsDeflation (Limits.biprod.map (𝟙 Z₁) p₂) :=
     E.isDeflation_id_biprod hp₂ Z₁
-  rw [show Limits.biprod.map p₁ p₂ =
-    Limits.biprod.map p₁ (𝟙 Y₂) ≫ Limits.biprod.map (𝟙 Z₁) p₂ by ext <;> simp]
+  rw [biprod_map_factor]
   exact E.isDeflation_comp _ _ h₁ h₂
 
 /-- A binary direct sum of conflations is a conflation. -/
 theorem conflation_biprod (E : ExactStructure C) {S₁ S₂ : ShortComplex C}
     (hS₁ : E.Conflation S₁) (hS₂ : E.Conflation S₂) :
     E.Conflation (shortComplexBiprod S₁ S₂) :=
-  E.conflation_of_isKernelCokernelPair
+  E.conflation_of_isKernelCokernelPair_of_isInflation
     ((E.isKernelCokernelPair S₁ hS₁).biprod (E.isKernelCokernelPair S₂ hS₂))
-    (E.isInflation_biprod (E.isInflation_f hS₁) (E.isInflation_f hS₂))
+    (by
+      rw [shortComplexBiprod_eq_mk]
+      exact E.isInflation_biprod (E.isInflation_f hS₁) (E.isInflation_f hS₂))
 
 end ExactStructure
 

--- a/TauCeti/CategoryTheory/Exact/Biproduct.lean
+++ b/TauCeti/CategoryTheory/Exact/Biproduct.lean
@@ -25,9 +25,9 @@ so the componentwise short complex itself is a conflation.
 
 ## Main declarations
 
-* `TauCeti.ShortComplex.biprod`: the componentwise binary direct sum of two short complexes.
-* `TauCeti.ExactStructure.IsInflation.biprod`: binary direct sums preserve inflations.
-* `TauCeti.ExactStructure.IsDeflation.biprod`: binary direct sums preserve deflations.
+* `TauCeti.shortComplexBiprod`: the componentwise binary direct sum of two short complexes.
+* `TauCeti.ExactStructure.isInflation_biprod`: binary direct sums preserve inflations.
+* `TauCeti.ExactStructure.isDeflation_biprod`: binary direct sums preserve deflations.
 * `TauCeti.ExactStructure.conflation_biprod`: binary direct sums preserve conflations.
 
 ## References
@@ -45,126 +45,83 @@ universe v u
 
 variable {C : Type u} [Category.{v} C] [Preadditive C]
 
-namespace ShortComplex
-
-/-- The componentwise binary direct sum of two short complexes. -/
-noncomputable def biprod (S₁ S₂ : CategoryTheory.ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] : CategoryTheory.ShortComplex C :=
-  CategoryTheory.ShortComplex.mk (Limits.biprod.map S₁.f S₂.f)
-    (Limits.biprod.map S₁.g S₂.g)
-    (by ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero])
-
-end ShortComplex
-
 namespace ExactStructure
 
-variable [HasZeroObject C] [HasBinaryBiproducts C] (E : ExactStructure C)
-
-namespace IsInflation
+variable [HasZeroObject C] [HasBinaryBiproducts C]
 
 /-- Adjoining an identity map as the second summand preserves inflations.  This is E2 applied to
 the biproduct pushout square. -/
-theorem biprod_id {X Y : C} {i : X ⟶ Y} (hi : E.IsInflation i) (Z : C) :
+theorem isInflation_biprod_id (E : ExactStructure C) {X Y : C} {i : X ⟶ Y}
+    (hi : E.IsInflation i) (Z : C) :
     E.IsInflation (Limits.biprod.map i (𝟙 Z)) := by
   have sq : IsPushout (Limits.biprod.inl : X ⟶ X ⊞ Z) i
       (Limits.biprod.map i (𝟙 Z)) (Limits.biprod.inl : Y ⟶ Y ⊞ Z) :=
-    (IsPushout.of_coprod_inl_with_id i Z).of_iso
-      (Iso.refl X) (Limits.biprod.isoCoprod X Z).symm
-      (Iso.refl Y) (Limits.biprod.isoCoprod Y Z).symm
-      (by simp [Limits.coprod.inl_desc]) (by simp) (by ext <;> simp)
-      (by simp [Limits.coprod.inl_desc])
+    isPushout_biprod_inl_map i Z
   exact E.isStableUnderCobaseChange_inflations.of_isPushout sq hi
 
 /-- Adjoining an identity map as the first summand preserves inflations. -/
-theorem id_biprod {X Y : C} {i : X ⟶ Y} (hi : E.IsInflation i) (Z : C) :
+theorem isInflation_id_biprod (E : ExactStructure C) {X Y : C} {i : X ⟶ Y}
+    (hi : E.IsInflation i) (Z : C) :
     E.IsInflation (Limits.biprod.map (𝟙 Z) i) := by
   rw [← Limits.biprod.braiding_map_braiding i (𝟙 Z)]
-  -- Expose the morphism property so its generic isomorphism-cancellation API applies.
-  change E.inflations
-    ((Limits.biprod.braiding Z X).hom ≫ Limits.biprod.map i (𝟙 Z) ≫
-      (Limits.biprod.braiding Y Z).hom)
+  -- `rw` cannot key through the `IsInflation` abbrev, so expose the morphism property.
+  change E.inflations _
   rw [E.inflations.cancel_left_of_respectsIso, E.inflations.cancel_right_of_respectsIso]
-  exact biprod_id (E := E) hi Z
+  exact E.isInflation_biprod_id hi Z
 
 /-- A binary direct sum of inflations is an inflation. -/
-theorem biprod {X₁ Y₁ X₂ Y₂ : C} {i₁ : X₁ ⟶ Y₁} {i₂ : X₂ ⟶ Y₂}
+theorem isInflation_biprod (E : ExactStructure C)
+    {X₁ Y₁ X₂ Y₂ : C} {i₁ : X₁ ⟶ Y₁} {i₂ : X₂ ⟶ Y₂}
     (hi₁ : E.IsInflation i₁) (hi₂ : E.IsInflation i₂) :
     E.IsInflation (Limits.biprod.map i₁ i₂) := by
   have h₁ : E.IsInflation (Limits.biprod.map i₁ (𝟙 X₂)) :=
-    biprod_id (E := E) hi₁ X₂
+    E.isInflation_biprod_id hi₁ X₂
   have h₂ : E.IsInflation (Limits.biprod.map (𝟙 Y₁) i₂) :=
-    id_biprod (E := E) hi₂ Y₁
+    E.isInflation_id_biprod hi₂ Y₁
   rw [show Limits.biprod.map i₁ i₂ =
     Limits.biprod.map i₁ (𝟙 X₂) ≫ Limits.biprod.map (𝟙 Y₁) i₂ by ext <;> simp]
   exact E.isInflation_comp _ _ h₁ h₂
 
-end IsInflation
-
-namespace IsDeflation
-
 /-- Adjoining an identity map as the second summand preserves deflations.  This is E2op applied
 to the biproduct pullback square. -/
-theorem biprod_id {Y Z : C} {p : Y ⟶ Z} (hp : E.IsDeflation p) (W : C) :
+theorem isDeflation_biprod_id (E : ExactStructure C) {Y Z : C} {p : Y ⟶ Z}
+    (hp : E.IsDeflation p) (W : C) :
     E.IsDeflation (Limits.biprod.map p (𝟙 W)) := by
   have sq : IsPullback (Limits.biprod.fst : Y ⊞ W ⟶ Y)
       (Limits.biprod.map p (𝟙 W)) p (Limits.biprod.fst : Z ⊞ W ⟶ Z) :=
-    (IsPullback.of_prod_fst_with_id p W).of_iso
-      (Limits.biprod.isoProd Y W).symm (Iso.refl Y)
-      (Limits.biprod.isoProd Z W).symm (Iso.refl Z)
-      (by simp) (by ext <;> simp) (by simp) (by simp)
+    isPullback_biprod_map_fst p W
   exact E.isStableUnderBaseChange_deflations.of_isPullback sq hp
 
 /-- Adjoining an identity map as the first summand preserves deflations. -/
-theorem id_biprod {Y Z : C} {p : Y ⟶ Z} (hp : E.IsDeflation p) (W : C) :
+theorem isDeflation_id_biprod (E : ExactStructure C) {Y Z : C} {p : Y ⟶ Z}
+    (hp : E.IsDeflation p) (W : C) :
     E.IsDeflation (Limits.biprod.map (𝟙 W) p) := by
   rw [← Limits.biprod.braiding_map_braiding p (𝟙 W)]
-  -- Expose the morphism property so its generic isomorphism-cancellation API applies.
-  change E.deflations
-    ((Limits.biprod.braiding W Y).hom ≫ Limits.biprod.map p (𝟙 W) ≫
-      (Limits.biprod.braiding Z W).hom)
+  -- `rw` cannot key through the `IsDeflation` abbrev, so expose the morphism property.
+  change E.deflations _
   rw [E.deflations.cancel_left_of_respectsIso, E.deflations.cancel_right_of_respectsIso]
-  exact biprod_id (E := E) hp W
+  exact E.isDeflation_biprod_id hp W
 
 /-- A binary direct sum of deflations is a deflation. -/
-theorem biprod {Y₁ Z₁ Y₂ Z₂ : C} {p₁ : Y₁ ⟶ Z₁} {p₂ : Y₂ ⟶ Z₂}
+theorem isDeflation_biprod (E : ExactStructure C)
+    {Y₁ Z₁ Y₂ Z₂ : C} {p₁ : Y₁ ⟶ Z₁} {p₂ : Y₂ ⟶ Z₂}
     (hp₁ : E.IsDeflation p₁) (hp₂ : E.IsDeflation p₂) :
     E.IsDeflation (Limits.biprod.map p₁ p₂) := by
   have h₁ : E.IsDeflation (Limits.biprod.map p₁ (𝟙 Y₂)) :=
-    biprod_id (E := E) hp₁ Y₂
+    E.isDeflation_biprod_id hp₁ Y₂
   have h₂ : E.IsDeflation (Limits.biprod.map (𝟙 Z₁) p₂) :=
-    id_biprod (E := E) hp₂ Z₁
+    E.isDeflation_id_biprod hp₂ Z₁
   rw [show Limits.biprod.map p₁ p₂ =
     Limits.biprod.map p₁ (𝟙 Y₂) ≫ Limits.biprod.map (𝟙 Z₁) p₂ by ext <;> simp]
   exact E.isDeflation_comp _ _ h₁ h₂
 
-end IsDeflation
-
 /-- A binary direct sum of conflations is a conflation. -/
-theorem conflation_biprod {S₁ S₂ : ShortComplex C} (hS₁ : E.Conflation S₁)
-    (hS₂ : E.Conflation S₂) : E.Conflation (TauCeti.ShortComplex.biprod S₁ S₂) := by
-  rw [TauCeti.ShortComplex.biprod]
-  let S : ShortComplex C :=
-    ShortComplex.mk (Limits.biprod.map S₁.f S₂.f) (Limits.biprod.map S₁.g S₂.g)
-      (by ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero])
-  suffices hS : E.Conflation S by simpa [S] using hS
-  have hi : E.IsInflation S.f :=
-    IsInflation.biprod (E := E) (E.isInflation_f hS₁) (E.isInflation_f hS₂)
-  obtain ⟨Z, q, hq, hT⟩ := (ConflationClass.isInflation_iff E.toConflationClass _).mp hi
-  let T := ShortComplex.mk S.f q hq
-  have hT' : E.Conflation T := by simpa [T] using hT
-  have hpairT : IsKernelCokernelPair T := E.isKernelCokernelPair T hT'
-  have hpair : IsKernelCokernelPair S :=
-    IsKernelCokernelPair.biprod (E.isKernelCokernelPair S₁ hS₁)
-      (E.isKernelCokernelPair S₂ hS₂)
-  let e : Z ≅ S.X₃ :=
-    IsColimit.coconePointUniqueUpToIso hpairT.gIsCokernel hpair.gIsCokernel
-  have he : q ≫ e.hom = S.g :=
-    IsColimit.comp_coconePointUniqueUpToIso_hom hpairT.gIsCokernel hpair.gIsCokernel
-      WalkingParallelPair.one
-  exact E.conflation_of_iso (S := T) (T := S)
-    (ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e
-      (by simp [T]) (by simpa [T] using he.symm)) hT'
+theorem conflation_biprod (E : ExactStructure C) {S₁ S₂ : ShortComplex C}
+    (hS₁ : E.Conflation S₁) (hS₂ : E.Conflation S₂) :
+    E.Conflation (shortComplexBiprod S₁ S₂) :=
+  E.conflation_of_isKernelCokernelPair
+    ((E.isKernelCokernelPair S₁ hS₁).biprod (E.isKernelCokernelPair S₂ hS₂))
+    (E.isInflation_biprod (E.isInflation_f hS₁) (E.isInflation_f hS₂))
 
 end ExactStructure
 

--- a/TauCeti/CategoryTheory/Exact/Biproduct.lean
+++ b/TauCeti/CategoryTheory/Exact/Biproduct.lean
@@ -120,7 +120,9 @@ theorem conflation_biprod (E : ExactStructure C) {S₁ S₂ : ShortComplex C}
   E.conflation_of_isKernelCokernelPair_of_isInflation
     ((E.isKernelCokernelPair S₁ hS₁).biprod (E.isKernelCokernelPair S₂ hS₂))
     (by
-      change E.IsInflation (Limits.biprod.map S₁.f S₂.f)
+      -- Rewriting cannot key through the unexposed `IsInflation` abbrev.
+      change E.inflations (shortComplexBiprod S₁ S₂).f
+      rw [shortComplexBiprod_f]
       exact E.isInflation_biprod (E.isInflation_f hS₁) (E.isInflation_f hS₂))
 
 end ExactStructure

--- a/TauCeti/CategoryTheory/Exact/Biproduct.lean
+++ b/TauCeti/CategoryTheory/Exact/Biproduct.lean
@@ -22,11 +22,10 @@ X₁ ⊞ X₂  --(i₁ ⊞ 1)-->  Y₁ ⊞ X₂  --(1 ⊞ i₂)-->  Y₁ ⊞ Y�
 
 The dual argument applies to deflations.  Finally, the direct sum of the two underlying
 kernel--cokernel pairs identifies the cokernel supplied by E1 with the componentwise direct sum,
-so the componentwise short complex itself is a conflation.
+so the componentwise short complex `TauCeti.shortComplexBiprod` itself is a conflation.
 
 ## Main declarations
 
-* `TauCeti.shortComplexBiprod`: the componentwise binary direct sum of two short complexes.
 * `TauCeti.ExactStructure.isInflation_biprod`: binary direct sums preserve inflations.
 * `TauCeti.ExactStructure.isDeflation_biprod`: binary direct sums preserve deflations.
 * `TauCeti.ExactStructure.conflation_biprod`: binary direct sums preserve conflations.

--- a/TauCeti/CategoryTheory/Exact/Biproduct.lean
+++ b/TauCeti/CategoryTheory/Exact/Biproduct.lean
@@ -120,7 +120,7 @@ theorem conflation_biprod (E : ExactStructure C) {S₁ S₂ : ShortComplex C}
   E.conflation_of_isKernelCokernelPair_of_isInflation
     ((E.isKernelCokernelPair S₁ hS₁).biprod (E.isKernelCokernelPair S₂ hS₂))
     (by
-      rw [shortComplexBiprod_eq_mk]
+      change E.IsInflation (Limits.biprod.map S₁.f S₂.f)
       exact E.isInflation_biprod (E.isInflation_f hS₁) (E.isInflation_f hS₂))
 
 end ExactStructure

--- a/TauCeti/CategoryTheory/Exact/Biproduct.lean
+++ b/TauCeti/CategoryTheory/Exact/Biproduct.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.CategoryTheory.Exact.ExactStructure
+
+/-!
+# Binary biproducts of conflations
+
+Distinguished conflations in an exact category are closed under binary direct sums.  The proof
+uses only Quillen's axioms.  First, E2 shows that adjoining an identity summand to an inflation
+again gives an inflation: the relevant square is a biproduct pushout.  E1 then gives the direct
+sum of two inflations by factoring it as
+
+```text
+X₁ ⊞ X₂  --(i₁ ⊞ 1)-->  Y₁ ⊞ X₂  --(1 ⊞ i₂)-->  Y₁ ⊞ Y₂.
+```
+
+The dual argument applies to deflations.  Finally, the direct sum of the two underlying
+kernel--cokernel pairs identifies the cokernel supplied by E1 with the componentwise direct sum,
+so the componentwise short complex itself is a conflation.
+
+## Main declarations
+
+* `TauCeti.ShortComplex.biprod`: the componentwise binary direct sum of two short complexes.
+* `TauCeti.ExactStructure.IsInflation.biprod`: binary direct sums preserve inflations.
+* `TauCeti.ExactStructure.IsDeflation.biprod`: binary direct sums preserve deflations.
+* `TauCeti.ExactStructure.conflation_biprod`: binary direct sums preserve conflations.
+
+## References
+
+* Theo Bühler, *Exact categories*, Expositiones Mathematicae **28** (2010), Proposition 2.9.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+namespace ShortComplex
+
+/-- The componentwise binary direct sum of two short complexes. -/
+noncomputable def biprod (S₁ S₂ : CategoryTheory.ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] : CategoryTheory.ShortComplex C :=
+  CategoryTheory.ShortComplex.mk (Limits.biprod.map S₁.f S₂.f)
+    (Limits.biprod.map S₁.g S₂.g)
+    (by ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero])
+
+end ShortComplex
+
+namespace ExactStructure
+
+variable [HasZeroObject C] [HasBinaryBiproducts C] (E : ExactStructure C)
+
+namespace IsInflation
+
+/-- Adjoining an identity map as the second summand preserves inflations.  This is E2 applied to
+the biproduct pushout square. -/
+theorem biprod_id {X Y : C} {i : X ⟶ Y} (hi : E.IsInflation i) (Z : C) :
+    E.IsInflation (Limits.biprod.map i (𝟙 Z)) := by
+  have sq : IsPushout (Limits.biprod.inl : X ⟶ X ⊞ Z) i
+      (Limits.biprod.map i (𝟙 Z)) (Limits.biprod.inl : Y ⟶ Y ⊞ Z) :=
+    (IsPushout.of_coprod_inl_with_id i Z).of_iso
+      (Iso.refl X) (Limits.biprod.isoCoprod X Z).symm
+      (Iso.refl Y) (Limits.biprod.isoCoprod Y Z).symm
+      (by simp [Limits.coprod.inl_desc]) (by simp) (by ext <;> simp)
+      (by simp [Limits.coprod.inl_desc])
+  exact E.isStableUnderCobaseChange_inflations.of_isPushout sq hi
+
+/-- Adjoining an identity map as the first summand preserves inflations. -/
+theorem id_biprod {X Y : C} {i : X ⟶ Y} (hi : E.IsInflation i) (Z : C) :
+    E.IsInflation (Limits.biprod.map (𝟙 Z) i) := by
+  rw [← Limits.biprod.braiding_map_braiding i (𝟙 Z)]
+  -- Expose the morphism property so its generic isomorphism-cancellation API applies.
+  change E.inflations
+    ((Limits.biprod.braiding Z X).hom ≫ Limits.biprod.map i (𝟙 Z) ≫
+      (Limits.biprod.braiding Y Z).hom)
+  rw [E.inflations.cancel_left_of_respectsIso, E.inflations.cancel_right_of_respectsIso]
+  exact biprod_id (E := E) hi Z
+
+/-- A binary direct sum of inflations is an inflation. -/
+theorem biprod {X₁ Y₁ X₂ Y₂ : C} {i₁ : X₁ ⟶ Y₁} {i₂ : X₂ ⟶ Y₂}
+    (hi₁ : E.IsInflation i₁) (hi₂ : E.IsInflation i₂) :
+    E.IsInflation (Limits.biprod.map i₁ i₂) := by
+  have h₁ : E.IsInflation (Limits.biprod.map i₁ (𝟙 X₂)) :=
+    biprod_id (E := E) hi₁ X₂
+  have h₂ : E.IsInflation (Limits.biprod.map (𝟙 Y₁) i₂) :=
+    id_biprod (E := E) hi₂ Y₁
+  rw [show Limits.biprod.map i₁ i₂ =
+    Limits.biprod.map i₁ (𝟙 X₂) ≫ Limits.biprod.map (𝟙 Y₁) i₂ by ext <;> simp]
+  exact E.isInflation_comp _ _ h₁ h₂
+
+end IsInflation
+
+namespace IsDeflation
+
+/-- Adjoining an identity map as the second summand preserves deflations.  This is E2op applied
+to the biproduct pullback square. -/
+theorem biprod_id {Y Z : C} {p : Y ⟶ Z} (hp : E.IsDeflation p) (W : C) :
+    E.IsDeflation (Limits.biprod.map p (𝟙 W)) := by
+  have sq : IsPullback (Limits.biprod.fst : Y ⊞ W ⟶ Y)
+      (Limits.biprod.map p (𝟙 W)) p (Limits.biprod.fst : Z ⊞ W ⟶ Z) :=
+    (IsPullback.of_prod_fst_with_id p W).of_iso
+      (Limits.biprod.isoProd Y W).symm (Iso.refl Y)
+      (Limits.biprod.isoProd Z W).symm (Iso.refl Z)
+      (by simp) (by ext <;> simp) (by simp) (by simp)
+  exact E.isStableUnderBaseChange_deflations.of_isPullback sq hp
+
+/-- Adjoining an identity map as the first summand preserves deflations. -/
+theorem id_biprod {Y Z : C} {p : Y ⟶ Z} (hp : E.IsDeflation p) (W : C) :
+    E.IsDeflation (Limits.biprod.map (𝟙 W) p) := by
+  rw [← Limits.biprod.braiding_map_braiding p (𝟙 W)]
+  -- Expose the morphism property so its generic isomorphism-cancellation API applies.
+  change E.deflations
+    ((Limits.biprod.braiding W Y).hom ≫ Limits.biprod.map p (𝟙 W) ≫
+      (Limits.biprod.braiding Z W).hom)
+  rw [E.deflations.cancel_left_of_respectsIso, E.deflations.cancel_right_of_respectsIso]
+  exact biprod_id (E := E) hp W
+
+/-- A binary direct sum of deflations is a deflation. -/
+theorem biprod {Y₁ Z₁ Y₂ Z₂ : C} {p₁ : Y₁ ⟶ Z₁} {p₂ : Y₂ ⟶ Z₂}
+    (hp₁ : E.IsDeflation p₁) (hp₂ : E.IsDeflation p₂) :
+    E.IsDeflation (Limits.biprod.map p₁ p₂) := by
+  have h₁ : E.IsDeflation (Limits.biprod.map p₁ (𝟙 Y₂)) :=
+    biprod_id (E := E) hp₁ Y₂
+  have h₂ : E.IsDeflation (Limits.biprod.map (𝟙 Z₁) p₂) :=
+    id_biprod (E := E) hp₂ Z₁
+  rw [show Limits.biprod.map p₁ p₂ =
+    Limits.biprod.map p₁ (𝟙 Y₂) ≫ Limits.biprod.map (𝟙 Z₁) p₂ by ext <;> simp]
+  exact E.isDeflation_comp _ _ h₁ h₂
+
+end IsDeflation
+
+/-- A binary direct sum of conflations is a conflation. -/
+theorem conflation_biprod {S₁ S₂ : ShortComplex C} (hS₁ : E.Conflation S₁)
+    (hS₂ : E.Conflation S₂) : E.Conflation (TauCeti.ShortComplex.biprod S₁ S₂) := by
+  rw [TauCeti.ShortComplex.biprod]
+  let S : ShortComplex C :=
+    ShortComplex.mk (Limits.biprod.map S₁.f S₂.f) (Limits.biprod.map S₁.g S₂.g)
+      (by ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero])
+  suffices hS : E.Conflation S by simpa [S] using hS
+  have hi : E.IsInflation S.f :=
+    IsInflation.biprod (E := E) (E.isInflation_f hS₁) (E.isInflation_f hS₂)
+  obtain ⟨Z, q, hq, hT⟩ := (ConflationClass.isInflation_iff E.toConflationClass _).mp hi
+  let T := ShortComplex.mk S.f q hq
+  have hT' : E.Conflation T := by simpa [T] using hT
+  have hpairT : IsKernelCokernelPair T := E.isKernelCokernelPair T hT'
+  have hpair : IsKernelCokernelPair S :=
+    IsKernelCokernelPair.biprod (E.isKernelCokernelPair S₁ hS₁)
+      (E.isKernelCokernelPair S₂ hS₂)
+  let e : Z ≅ S.X₃ :=
+    IsColimit.coconePointUniqueUpToIso hpairT.gIsCokernel hpair.gIsCokernel
+  have he : q ≫ e.hom = S.g :=
+    IsColimit.comp_coconePointUniqueUpToIso_hom hpairT.gIsCokernel hpair.gIsCokernel
+      WalkingParallelPair.one
+  exact E.conflation_of_iso (S := T) (T := S)
+    (ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e
+      (by simp [T]) (by simpa [T] using he.symm)) hT'
+
+end ExactStructure
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -174,32 +174,6 @@ instance (E : ConflationClass C) : E.deflations.RespectsIso := by
 
 end ConflationClass
 
-section BiproductSquares
-
-variable {D : Type u} [Category.{v} D] [HasZeroMorphisms D]
-
-/-- The square formed by a morphism and the corresponding biproduct inclusions is a pushout. -/
-theorem isPushout_biprod_inl_map {X Y : D} (f : X ⟶ Y) (Z : D)
-    [HasBinaryBiproduct X Z] [HasBinaryBiproduct Y Z] :
-    IsPushout (biprod.inl : X ⟶ X ⊞ Z) f (biprod.map f (𝟙 Z))
-      (biprod.inl : Y ⟶ Y ⊞ Z) :=
-  (IsPushout.of_coprod_inl_with_id f Z).of_iso
-    (Iso.refl X) (biprod.isoCoprod X Z).symm
-    (Iso.refl Y) (biprod.isoCoprod Y Z).symm
-    (by simp [coprod.inl_desc]) (by simp) (by ext <;> simp) (by simp [coprod.inl_desc])
-
-/-- The square formed by a morphism and the corresponding biproduct projections is a pullback. -/
-theorem isPullback_biprod_map_fst {X Y : D} (f : X ⟶ Y) (Z : D)
-    [HasBinaryBiproduct X Z] [HasBinaryBiproduct Y Z] :
-    IsPullback (biprod.fst : X ⊞ Z ⟶ X) (biprod.map f (𝟙 Z)) f
-      (biprod.fst : Y ⊞ Z ⟶ Y) :=
-  (IsPullback.of_prod_fst_with_id f Z).of_iso
-    (biprod.isoProd X Z).symm (Iso.refl X)
-    (biprod.isoProd Y Z).symm (Iso.refl Y)
-    (by simp) (by ext <;> simp) (by simp) (by simp)
-
-end BiproductSquares
-
 /-- A Quillen exact structure on an additive category, in the self-dual E0/E1/E2
 presentation.
 
@@ -251,7 +225,8 @@ abbrev IsDeflation (E : ExactStructure C) {Y Z : C} (p : Y ⟶ Z) : Prop :=
   E.toConflationClass.IsDeflation p
 
 /-- A kernel–cokernel pair whose first map is an inflation is a conflation. -/
-theorem conflation_of_isKernelCokernelPair (E : ExactStructure C) {S : ShortComplex C}
+theorem conflation_of_isKernelCokernelPair_of_isInflation (E : ExactStructure C)
+    {S : ShortComplex C}
     (hS : IsKernelCokernelPair S) (hf : E.IsInflation S.f) : E.Conflation S := by
   obtain ⟨Z, q, hq, hT⟩ := (ConflationClass.isInflation_iff E.toConflationClass _).mp hf
   let T := ShortComplex.mk S.f q hq

--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -174,6 +174,32 @@ instance (E : ConflationClass C) : E.deflations.RespectsIso := by
 
 end ConflationClass
 
+section BiproductSquares
+
+variable {D : Type u} [Category.{v} D] [HasZeroMorphisms D]
+
+/-- The square formed by a morphism and the corresponding biproduct inclusions is a pushout. -/
+theorem isPushout_biprod_inl_map {X Y : D} (f : X ⟶ Y) (Z : D)
+    [HasBinaryBiproduct X Z] [HasBinaryBiproduct Y Z] :
+    IsPushout (biprod.inl : X ⟶ X ⊞ Z) f (biprod.map f (𝟙 Z))
+      (biprod.inl : Y ⟶ Y ⊞ Z) :=
+  (IsPushout.of_coprod_inl_with_id f Z).of_iso
+    (Iso.refl X) (biprod.isoCoprod X Z).symm
+    (Iso.refl Y) (biprod.isoCoprod Y Z).symm
+    (by simp [coprod.inl_desc]) (by simp) (by ext <;> simp) (by simp [coprod.inl_desc])
+
+/-- The square formed by a morphism and the corresponding biproduct projections is a pullback. -/
+theorem isPullback_biprod_map_fst {X Y : D} (f : X ⟶ Y) (Z : D)
+    [HasBinaryBiproduct X Z] [HasBinaryBiproduct Y Z] :
+    IsPullback (biprod.fst : X ⊞ Z ⟶ X) (biprod.map f (𝟙 Z)) f
+      (biprod.fst : Y ⊞ Z ⟶ Y) :=
+  (IsPullback.of_prod_fst_with_id f Z).of_iso
+    (biprod.isoProd X Z).symm (Iso.refl X)
+    (biprod.isoProd Y Z).symm (Iso.refl Y)
+    (by simp) (by ext <;> simp) (by simp) (by simp)
+
+end BiproductSquares
+
 /-- A Quillen exact structure on an additive category, in the self-dual E0/E1/E2
 presentation.
 
@@ -223,6 +249,22 @@ abbrev IsInflation (E : ExactStructure C) {X Y : C} (i : X ⟶ Y) : Prop :=
 /-- The predicate that a morphism is the second map of a distinguished conflation. -/
 abbrev IsDeflation (E : ExactStructure C) {Y Z : C} (p : Y ⟶ Z) : Prop :=
   E.toConflationClass.IsDeflation p
+
+/-- A kernel–cokernel pair whose first map is an inflation is a conflation. -/
+theorem conflation_of_isKernelCokernelPair (E : ExactStructure C) {S : ShortComplex C}
+    (hS : IsKernelCokernelPair S) (hf : E.IsInflation S.f) : E.Conflation S := by
+  obtain ⟨Z, q, hq, hT⟩ := (ConflationClass.isInflation_iff E.toConflationClass _).mp hf
+  let T := ShortComplex.mk S.f q hq
+  have hT' : E.Conflation T := by simpa [T] using hT
+  have hpairT : IsKernelCokernelPair T := E.isKernelCokernelPair T hT'
+  let e : Z ≅ S.X₃ :=
+    IsColimit.coconePointUniqueUpToIso hpairT.gIsCokernel hS.gIsCokernel
+  have he : q ≫ e.hom = S.g :=
+    IsColimit.comp_coconePointUniqueUpToIso_hom hpairT.gIsCokernel hS.gIsCokernel
+      WalkingParallelPair.one
+  exact E.conflation_of_iso (S := T) (T := S)
+    (ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e
+      (by simp [T]) (by simpa [T] using he.symm)) hT'
 
 /-- E0, as the statement that the inflations contain the identities. -/
 instance (E : ExactStructure C) : E.inflations.ContainsIdentities where

--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -150,6 +150,42 @@ theorem conflation_iff_of_iso (E : ConflationClass C) {S T : ShortComplex C} (e 
     E.Conflation S ↔ E.Conflation T :=
   E.Conflation.prop_iff_of_iso e
 
+/-- A kernel–cokernel pair whose first map is an inflation is a conflation: the conflation
+witnessing the inflation has the same cokernel, so the two short complexes are isomorphic. -/
+theorem conflation_of_isKernelCokernelPair_of_isInflation (E : ConflationClass C)
+    {S : ShortComplex C}
+    (hS : IsKernelCokernelPair S) (hf : E.IsInflation S.f) : E.Conflation S := by
+  obtain ⟨Z, q, hq, hT⟩ := (E.isInflation_iff _).mp hf
+  let T := ShortComplex.mk S.f q hq
+  have hT' : E.Conflation T := by simpa [T] using hT
+  have hpairT : IsKernelCokernelPair T := E.isKernelCokernelPair T hT'
+  let e : Z ≅ S.X₃ :=
+    IsColimit.coconePointUniqueUpToIso hpairT.gIsCokernel hS.gIsCokernel
+  have he : q ≫ e.hom = S.g :=
+    IsColimit.comp_coconePointUniqueUpToIso_hom hpairT.gIsCokernel hS.gIsCokernel
+      WalkingParallelPair.one
+  exact E.conflation_of_iso (S := T) (T := S)
+    (ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e
+      (by simp [T]) (by simpa [T] using he.symm)) hT'
+
+/-- A kernel–cokernel pair whose second map is a deflation is a conflation: the conflation
+witnessing the deflation has the same kernel, so the two short complexes are isomorphic. -/
+theorem conflation_of_isKernelCokernelPair_of_isDeflation (E : ConflationClass C)
+    {S : ShortComplex C}
+    (hS : IsKernelCokernelPair S) (hg : E.IsDeflation S.g) : E.Conflation S := by
+  obtain ⟨X, i, hi, hT⟩ := (E.isDeflation_iff _).mp hg
+  let T := ShortComplex.mk i S.g hi
+  have hT' : E.Conflation T := by simpa [T] using hT
+  have hpairT : IsKernelCokernelPair T := E.isKernelCokernelPair T hT'
+  let e : X ≅ S.X₁ :=
+    IsLimit.conePointUniqueUpToIso hpairT.fIsKernel hS.fIsKernel
+  have he : e.hom ≫ S.f = i :=
+    IsLimit.conePointUniqueUpToIso_hom_comp hpairT.fIsKernel hS.fIsKernel
+      WalkingParallelPair.zero
+  exact E.conflation_of_iso (S := T) (T := S)
+    (ShortComplex.isoMk e (Iso.refl _) (Iso.refl _)
+      (by simpa [T] using he) (by simp [T])) hT'
+
 /-- Being an inflation is invariant under composing with isomorphisms on either side: the
 witnessing conflation transports along the isomorphism. -/
 instance (E : ConflationClass C) : E.inflations.RespectsIso := by
@@ -223,23 +259,6 @@ abbrev IsInflation (E : ExactStructure C) {X Y : C} (i : X ⟶ Y) : Prop :=
 /-- The predicate that a morphism is the second map of a distinguished conflation. -/
 abbrev IsDeflation (E : ExactStructure C) {Y Z : C} (p : Y ⟶ Z) : Prop :=
   E.toConflationClass.IsDeflation p
-
-/-- A kernel–cokernel pair whose first map is an inflation is a conflation. -/
-theorem conflation_of_isKernelCokernelPair_of_isInflation (E : ExactStructure C)
-    {S : ShortComplex C}
-    (hS : IsKernelCokernelPair S) (hf : E.IsInflation S.f) : E.Conflation S := by
-  obtain ⟨Z, q, hq, hT⟩ := (ConflationClass.isInflation_iff E.toConflationClass _).mp hf
-  let T := ShortComplex.mk S.f q hq
-  have hT' : E.Conflation T := by simpa [T] using hT
-  have hpairT : IsKernelCokernelPair T := E.isKernelCokernelPair T hT'
-  let e : Z ≅ S.X₃ :=
-    IsColimit.coconePointUniqueUpToIso hpairT.gIsCokernel hS.gIsCokernel
-  have he : q ≫ e.hom = S.g :=
-    IsColimit.comp_coconePointUniqueUpToIso_hom hpairT.gIsCokernel hS.gIsCokernel
-      WalkingParallelPair.one
-  exact E.conflation_of_iso (S := T) (T := S)
-    (ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e
-      (by simp [T]) (by simpa [T] using he.symm)) hT'
 
 /-- E0, as the statement that the inflations contain the identities. -/
 instance (E : ExactStructure C) : E.inflations.ContainsIdentities where

--- a/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
+++ b/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
@@ -5,6 +5,7 @@ Authors: Claude
 -/
 module
 
+public import TauCeti.Algebra.Homology.ShortComplex.Biproduct
 public import Mathlib.Algebra.Homology.ShortComplex.ShortExact
 public import Mathlib.CategoryTheory.Limits.Shapes.Opposites.Kernels
 
@@ -31,7 +32,6 @@ category with homology the notion coincides with Mathlib's
   its two morphisms form a kernel–cokernel pair. Its noncomputable accessors
   `TauCeti.IsKernelCokernelPair.fIsKernel` and `TauCeti.IsKernelCokernelPair.gIsCokernel`
   produce the two universal properties.
-* `TauCeti.shortComplexBiprod`: the componentwise binary direct sum of two short complexes.
 * `TauCeti.IsKernelCokernelPair.lift` and `TauCeti.IsKernelCokernelPair.desc`: the two
   factorizations, with their defining equations and their uniqueness.
 
@@ -96,63 +96,6 @@ variable {C : Type u} [Category.{v} C]
 section HasZeroMorphisms
 
 variable [HasZeroMorphisms C] {S S₁ S₂ : ShortComplex C}
-
-/-- The two maps in the componentwise biproduct of short complexes have zero composite. -/
-theorem shortComplexBiprod_zero (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    biprod.map S₁.f S₂.f ≫ biprod.map S₁.g S₂.g = 0 := by
-  ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero]
-
-/-- The componentwise binary direct sum of two short complexes. -/
-noncomputable def shortComplexBiprod (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] : ShortComplex C :=
-  ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
-    (shortComplexBiprod_zero S₁ S₂)
-
-/-- The componentwise biproduct as an explicitly constructed short complex. -/
-theorem shortComplexBiprod_eq_mk (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    shortComplexBiprod S₁ S₂ =
-      ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
-        (shortComplexBiprod_zero S₁ S₂) := (rfl)
-
-/-- The left object of the componentwise biproduct of two short complexes. -/
-@[simp]
-theorem shortComplexBiprod_X₁ (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    (shortComplexBiprod S₁ S₂).X₁ = (S₁.X₁ ⊞ S₂.X₁) := (rfl)
-
-/-- The middle object of the componentwise biproduct of two short complexes. -/
-@[simp]
-theorem shortComplexBiprod_X₂ (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    (shortComplexBiprod S₁ S₂).X₂ = (S₁.X₂ ⊞ S₂.X₂) := (rfl)
-
-/-- The right object of the componentwise biproduct of two short complexes. -/
-@[simp]
-theorem shortComplexBiprod_X₃ (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    (shortComplexBiprod S₁ S₂).X₃ = (S₁.X₃ ⊞ S₂.X₃) := (rfl)
-
-/-- The first map of the componentwise biproduct of two short complexes. -/
-@[simp]
-theorem shortComplexBiprod_f (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    HEq (shortComplexBiprod S₁ S₂).f (biprod.map S₁.f S₂.f) := (HEq.rfl)
-
-/-- The second map of the componentwise biproduct of two short complexes. -/
-@[simp]
-theorem shortComplexBiprod_g (S₁ S₂ : ShortComplex C)
-    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
-    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
-    HEq (shortComplexBiprod S₁ S₂).g (biprod.map S₁.g S₂.g) := (HEq.rfl)
 
 /-- A short complex `S : X₁ ⟶ X₂ ⟶ X₃` is a **kernel–cokernel pair** when `S.f` is a kernel of
 `S.g` and `S.g` is a cokernel of `S.f`. This is Bühler's notion of a kernel–cokernel pair; the

--- a/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
+++ b/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
@@ -31,6 +31,7 @@ category with homology the notion coincides with Mathlib's
   its two morphisms form a kernel–cokernel pair. Its noncomputable accessors
   `TauCeti.IsKernelCokernelPair.fIsKernel` and `TauCeti.IsKernelCokernelPair.gIsCokernel`
   produce the two universal properties.
+* `TauCeti.shortComplexBiprod`: the componentwise binary direct sum of two short complexes.
 * `TauCeti.IsKernelCokernelPair.lift` and `TauCeti.IsKernelCokernelPair.desc`: the two
   factorizations, with their defining equations and their uniqueness.
 
@@ -95,6 +96,13 @@ variable {C : Type u} [Category.{v} C]
 section HasZeroMorphisms
 
 variable [HasZeroMorphisms C] {S S₁ S₂ : ShortComplex C}
+
+/-- The componentwise binary direct sum of two short complexes. -/
+noncomputable abbrev shortComplexBiprod (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] : ShortComplex C :=
+  ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
+    (by ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero])
 
 /-- A short complex `S : X₁ ⟶ X₂ ⟶ X₃` is a **kernel–cokernel pair** when `S.f` is a kernel of
 `S.g` and `S.g` is a cokernel of `S.f`. This is Bühler's notion of a kernel–cokernel pair; the
@@ -215,8 +223,7 @@ theorem of_hasBinaryBiproduct (X₁ X₂ : C) [HasBinaryBiproduct X₁ X₂] :
 theorem biprod [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
     [HasBinaryBiproduct S₁.X₃ S₂.X₃] (h₁ : IsKernelCokernelPair S₁)
     (h₂ : IsKernelCokernelPair S₂) :
-    IsKernelCokernelPair (ShortComplex.mk (biprod.map S₁.f S₂.f)
-      (biprod.map S₁.g S₂.g) (by ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero])) :=
+    IsKernelCokernelPair (shortComplexBiprod S₁ S₂) :=
   have := h₁.mono_f
   have := h₂.mono_f
   have := h₁.epi_g

--- a/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
+++ b/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
@@ -217,7 +217,9 @@ theorem biprod [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁
     [HasBinaryBiproduct S₁.X₃ S₂.X₃] (h₁ : IsKernelCokernelPair S₁)
     (h₂ : IsKernelCokernelPair S₂) :
     IsKernelCokernelPair (shortComplexBiprod S₁ S₂) := by
-  rw [shortComplexBiprod_eq_mk]
+  change IsKernelCokernelPair
+    (ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
+      (shortComplexBiprod_zero S₁ S₂))
   have := h₁.mono_f
   have := h₂.mono_f
   have := h₁.epi_g

--- a/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
+++ b/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
@@ -97,12 +97,62 @@ section HasZeroMorphisms
 
 variable [HasZeroMorphisms C] {S S₁ S₂ : ShortComplex C}
 
+/-- The two maps in the componentwise biproduct of short complexes have zero composite. -/
+theorem shortComplexBiprod_zero (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    biprod.map S₁.f S₂.f ≫ biprod.map S₁.g S₂.g = 0 := by
+  ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero]
+
 /-- The componentwise binary direct sum of two short complexes. -/
-noncomputable abbrev shortComplexBiprod (S₁ S₂ : ShortComplex C)
+noncomputable def shortComplexBiprod (S₁ S₂ : ShortComplex C)
     [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
     [HasBinaryBiproduct S₁.X₃ S₂.X₃] : ShortComplex C :=
   ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
-    (by ext <;> simp [reassoc_of% S₁.zero, reassoc_of% S₂.zero])
+    (shortComplexBiprod_zero S₁ S₂)
+
+/-- The componentwise biproduct as an explicitly constructed short complex. -/
+theorem shortComplexBiprod_eq_mk (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    shortComplexBiprod S₁ S₂ =
+      ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
+        (shortComplexBiprod_zero S₁ S₂) := (rfl)
+
+/-- The left object of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_X₁ (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    (shortComplexBiprod S₁ S₂).X₁ = (S₁.X₁ ⊞ S₂.X₁) := (rfl)
+
+/-- The middle object of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_X₂ (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    (shortComplexBiprod S₁ S₂).X₂ = (S₁.X₂ ⊞ S₂.X₂) := (rfl)
+
+/-- The right object of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_X₃ (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    (shortComplexBiprod S₁ S₂).X₃ = (S₁.X₃ ⊞ S₂.X₃) := (rfl)
+
+/-- The first map of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_f (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    HEq (shortComplexBiprod S₁ S₂).f (biprod.map S₁.f S₂.f) := (HEq.rfl)
+
+/-- The second map of the componentwise biproduct of two short complexes. -/
+@[simp]
+theorem shortComplexBiprod_g (S₁ S₂ : ShortComplex C)
+    [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
+    [HasBinaryBiproduct S₁.X₃ S₂.X₃] :
+    HEq (shortComplexBiprod S₁ S₂).g (biprod.map S₁.g S₂.g) := (HEq.rfl)
 
 /-- A short complex `S : X₁ ⟶ X₂ ⟶ X₃` is a **kernel–cokernel pair** when `S.f` is a kernel of
 `S.g` and `S.g` is a cokernel of `S.f`. This is Bühler's notion of a kernel–cokernel pair; the
@@ -223,25 +273,31 @@ theorem of_hasBinaryBiproduct (X₁ X₂ : C) [HasBinaryBiproduct X₁ X₂] :
 theorem biprod [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁.X₂ S₂.X₂]
     [HasBinaryBiproduct S₁.X₃ S₂.X₃] (h₁ : IsKernelCokernelPair S₁)
     (h₂ : IsKernelCokernelPair S₂) :
-    IsKernelCokernelPair (shortComplexBiprod S₁ S₂) :=
+    IsKernelCokernelPair (shortComplexBiprod S₁ S₂) := by
+  rw [shortComplexBiprod_eq_mk]
   have := h₁.mono_f
   have := h₂.mono_f
   have := h₁.epi_g
   have := h₂.epi_g
-  { nonempty_fIsKernel := ⟨KernelFork.IsLimit.ofι' _ _ fun k hk =>
-      ⟨biprod.lift
-        (h₁.lift (k ≫ biprod.fst) (by
-          rw [Category.assoc, ← biprod.map_fst S₁.g S₂.g, ← Category.assoc, hk, zero_comp]))
-        (h₂.lift (k ≫ biprod.snd) (by
-          rw [Category.assoc, ← biprod.map_snd S₁.g S₂.g, ← Category.assoc, hk, zero_comp])),
-        by apply biprod.hom_ext <;> simp⟩⟩
-    nonempty_gIsCokernel := ⟨CokernelCofork.IsColimit.ofπ' _ _ fun k hk =>
-      ⟨biprod.desc
-        (h₁.desc (biprod.inl ≫ k) (by
-          rw [← Category.assoc, ← biprod.inl_map S₁.f S₂.f, Category.assoc, hk, comp_zero]))
-        (h₂.desc (biprod.inr ≫ k) (by
-          rw [← Category.assoc, ← biprod.inr_map S₁.f S₂.f, Category.assoc, hk, comp_zero])),
-        by apply biprod.hom_ext' <;> simp⟩⟩ }
+  exact
+    { nonempty_fIsKernel := ⟨KernelFork.IsLimit.ofι' _ _ fun k hk =>
+        ⟨biprod.lift
+          (h₁.lift (k ≫ biprod.fst) (by
+            rw [Category.assoc, ← biprod.map_fst S₁.g S₂.g, ← Category.assoc, hk,
+              zero_comp]))
+          (h₂.lift (k ≫ biprod.snd) (by
+            rw [Category.assoc, ← biprod.map_snd S₁.g S₂.g, ← Category.assoc, hk,
+              zero_comp])),
+          by apply biprod.hom_ext <;> simp⟩⟩
+      nonempty_gIsCokernel := ⟨CokernelCofork.IsColimit.ofπ' _ _ fun k hk =>
+        ⟨biprod.desc
+          (h₁.desc (biprod.inl ≫ k) (by
+            rw [← Category.assoc, ← biprod.inl_map S₁.f S₂.f, Category.assoc, hk,
+              comp_zero]))
+          (h₂.desc (biprod.inr ≫ k) (by
+            rw [← Category.assoc, ← biprod.inr_map S₁.f S₂.f, Category.assoc, hk,
+              comp_zero])),
+          by apply biprod.hom_ext' <;> simp⟩⟩ }
 
 end IsKernelCokernelPair
 

--- a/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
+++ b/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
@@ -217,6 +217,8 @@ theorem biprod [HasBinaryBiproduct S₁.X₁ S₂.X₁] [HasBinaryBiproduct S₁
     [HasBinaryBiproduct S₁.X₃ S₂.X₃] (h₁ : IsKernelCokernelPair S₁)
     (h₂ : IsKernelCokernelPair S₂) :
     IsKernelCokernelPair (shortComplexBiprod S₁ S₂) := by
+  -- The projection lemmas cannot rewrite this dependent predicate: its kernel and cokernel
+  -- forks also depend on the composite-zero proof. Expose the short complex once here.
   change IsKernelCokernelPair
     (ShortComplex.mk (biprod.map S₁.f S₂.f) (biprod.map S₁.g S₂.g)
       (shortComplexBiprod_zero S₁ S₂))

--- a/TauCeti/CategoryTheory/Exact/Split.lean
+++ b/TauCeti/CategoryTheory/Exact/Split.lean
@@ -6,6 +6,7 @@ Authors: Claude
 module
 
 public import TauCeti.CategoryTheory.Exact.ExactStructure
+public import TauCeti.CategoryTheory.Limits.Shapes.Biproduct
 public import Mathlib.CategoryTheory.Preadditive.Biproducts
 
 /-!
@@ -368,7 +369,7 @@ theorem conflation_biprodShortComplex (E : ExactStructure C) (X Z : C) :
   have hpair' : IsKernelCokernelPair
       (ShortComplex.mk (biprod.inl : X ⟶ X ⊞ Z) biprod.snd hzero) :=
     IsKernelCokernelPair.of_hasBinaryBiproduct X Z
-  exact E.conflation_of_isKernelCokernelPair hpair' hinl
+  exact E.conflation_of_isKernelCokernelPair_of_isInflation hpair' hinl
 
 /-- **A short complex with a splitting is a conflation of every exact structure.**
 Equivalently, the split exact structure is the smallest exact structure on `C`. -/

--- a/TauCeti/CategoryTheory/Exact/Split.lean
+++ b/TauCeti/CategoryTheory/Exact/Split.lean
@@ -260,12 +260,8 @@ theorem exists_isPushout_of_split_isInflation {A B A' : C} {i : A ⟶ B}
   obtain ⟨Z, e, he⟩ := (split_isInflation_iff i).mp hi
   have hi' : biprod.inl ≫ e.inv = i := by
     rw [← he, Category.assoc, e.hom_inv_id, Category.comp_id]
-  -- Mathlib's pushout square for `coprod.inl`, transported along `A ⨿ Z ≅ A ⊞ Z`.
   have hbase : IsPushout (biprod.inl : A ⟶ A ⊞ Z) g (biprod.map g (𝟙 Z))
-      (biprod.inl : A' ⟶ A' ⊞ Z) :=
-    (IsPushout.of_coprod_inl_with_id g Z).of_iso (Iso.refl A) (biprod.isoCoprod A Z).symm
-      (Iso.refl A') (biprod.isoCoprod A' Z).symm (by simp [coprod.inl_desc]) (by simp)
-      (by ext <;> simp) (by simp [coprod.inl_desc])
+      (biprod.inl : A' ⟶ A' ⊞ Z) := isPushout_biprod_inl_map g Z
   refine ⟨A' ⊞ Z, e.hom ≫ biprod.map g (𝟙 Z), biprod.inl, ?_, split_isInflation_biprod_inl A' Z⟩
   exact hbase.of_iso (Iso.refl A) e.symm (Iso.refl A') (Iso.refl _) (by simpa using hi')
     (by simp) (by simp) (by simp)
@@ -278,12 +274,10 @@ theorem exists_isPullback_of_split_isDeflation {Y Z A : C} {p : Y ⟶ Z}
     ∃ (T : C) (fst : T ⟶ A) (snd : T ⟶ Y),
       IsPullback fst snd f p ∧ (split C).IsDeflation fst := by
   obtain ⟨X, e, he⟩ := (split_isDeflation_iff p).mp hp
-  -- Mathlib's pullback square for `prod.fst`, transported along `A ⨯ X ≅ A ⊞ X ≅ X ⊞ A`.
   have hbase : IsPullback (biprod.snd : X ⊞ A ⟶ A) (biprod.map (𝟙 X) f) f
       (biprod.snd : X ⊞ Z ⟶ Z) :=
-    (IsPullback.of_prod_fst_with_id f X).of_iso
-      ((biprod.isoProd A X).symm ≪≫ biprod.braiding A X) (Iso.refl A)
-      ((biprod.isoProd Z X).symm ≪≫ biprod.braiding Z X) (Iso.refl Z)
+    (isPullback_biprod_map_fst f X).of_iso
+      (biprod.braiding A X) (Iso.refl A) (biprod.braiding Z X) (Iso.refl Z)
       (by simp) (by ext <;> simp) (by simp) (by simp)
   refine ⟨X ⊞ A, biprod.snd, biprod.map (𝟙 X) f ≫ e.inv, ?_, split_isDeflation_biprod_snd X A⟩
   exact hbase.of_iso (Iso.refl _) (Iso.refl A) e.symm (Iso.refl Z) (by simp) (by simp) (by simp)
@@ -370,19 +364,11 @@ theorem conflation_biprodShortComplex (E : ExactStructure C) (X Z : C) :
   have hinl : E.IsInflation (biprod.inl : X ⟶ X ⊞ Z) :=
     E.isStableUnderCobaseChange_inflations.of_isPushout sq
       (E.toConflationClass.isInflation_f hK)
-  obtain ⟨Z', q, hq, hQ⟩ := (ConflationClass.isInflation_iff E.toConflationClass _).mp hinl
-  -- Both `q` and `biprod.snd` are cokernels of `biprod.inl`, hence canonically isomorphic.
-  have hpair := E.isKernelCokernelPair _ hQ
   have hzero : (biprod.inl : X ⟶ X ⊞ Z) ≫ (biprod.snd : X ⊞ Z ⟶ Z) = 0 := by simp
   have hpair' : IsKernelCokernelPair
       (ShortComplex.mk (biprod.inl : X ⟶ X ⊞ Z) biprod.snd hzero) :=
     IsKernelCokernelPair.of_hasBinaryBiproduct X Z
-  let e : Z' ≅ Z := IsColimit.coconePointUniqueUpToIso hpair.gIsCokernel hpair'.gIsCokernel
-  have hd : q ≫ e.hom = biprod.snd :=
-    IsColimit.comp_coconePointUniqueUpToIso_hom hpair.gIsCokernel hpair'.gIsCokernel
-      WalkingParallelPair.one
-  refine E.toConflationClass.conflation_of_iso ?_ hQ
-  exact ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e (by simp) (by simpa using hd.symm)
+  exact E.conflation_of_isKernelCokernelPair hpair' hinl
 
 /-- **A short complex with a splitting is a conflation of every exact structure.**
 Equivalently, the split exact structure is the smallest exact structure on `C`. -/

--- a/TauCeti/CategoryTheory/Limits/Shapes/Biproduct.lean
+++ b/TauCeti/CategoryTheory/Limits/Shapes/Biproduct.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.IsPullback.Basic
+
+/-!
+# Binary biproduct squares
+
+This file records generic categorical properties of binary biproducts. A biproduct map factors
+through the maps obtained by changing one summand at a time, and the squares obtained by adjoining
+an identity summand are pushouts or pullbacks.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [HasZeroMorphisms C]
+
+/-- A binary biproduct map factors by changing its first and second summands in succession. -/
+theorem biprod_map_factor {X₁ X₂ Y₁ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂)
+    [HasBinaryBiproduct X₁ X₂] [HasBinaryBiproduct Y₁ X₂]
+    [HasBinaryBiproduct Y₁ Y₂] :
+    biprod.map f g = biprod.map f (𝟙 X₂) ≫ biprod.map (𝟙 Y₁) g := by
+  ext <;> simp
+
+/-- The square formed by a morphism and the corresponding biproduct inclusions is a pushout. -/
+theorem isPushout_biprod_inl_map {X Y : C} (f : X ⟶ Y) (Z : C)
+    [HasBinaryBiproduct X Z] [HasBinaryBiproduct Y Z] :
+    IsPushout (biprod.inl : X ⟶ X ⊞ Z) f (biprod.map f (𝟙 Z))
+      (biprod.inl : Y ⟶ Y ⊞ Z) :=
+  (IsPushout.of_coprod_inl_with_id f Z).of_iso
+    (Iso.refl X) (biprod.isoCoprod X Z).symm
+    (Iso.refl Y) (biprod.isoCoprod Y Z).symm
+    (by simp [coprod.inl_desc]) (by simp) (by ext <;> simp) (by simp [coprod.inl_desc])
+
+/-- The square formed by a morphism and the corresponding biproduct projections is a pullback. -/
+theorem isPullback_biprod_map_fst {X Y : C} (f : X ⟶ Y) (Z : C)
+    [HasBinaryBiproduct X Z] [HasBinaryBiproduct Y Z] :
+    IsPullback (biprod.fst : X ⊞ Z ⟶ X) (biprod.map f (𝟙 Z)) f
+      (biprod.fst : Y ⊞ Z ⟶ Y) :=
+  (IsPullback.of_prod_fst_with_id f Z).of_iso
+    (biprod.isoProd X Z).symm (Iso.refl X)
+    (biprod.isoProd Y Z).symm (Iso.refl Y)
+    (by simp) (by ext <;> simp) (by simp) (by simp)
+
+end TauCeti


### PR DESCRIPTION
This PR proves that binary direct sums of conflations are conflations. It advances the Layer 0 “Exact structures” milestone in `TauCetiRoadmap/GrothendieckEulerForms/README.md`, specifically its standard consequence that direct sums of conflations are conflations.

The new module defines the componentwise biproduct of short complexes, proves that inflations and deflations are closed under adjoining an identity summand and under binary biproducts, and combines those results with the existing biproduct theorem for kernel-cokernel pairs to obtain `ExactStructure.conflation_biprod`. The proof derives the one-sided closure from Quillen's pushout/pullback axioms and the general binary case from the biproduct braiding, rather than adding new assumptions.

The preferred `CFSGStatement` roadmap has no viable unclaimed main-ready step: its next local lane is already in flight, while its remaining Lie-type path explicitly depends on ReductiveGroups Layer 9 work that is currently covered by open PRs. `GrothendieckEulerForms` therefore supplies the next coherent unclaimed foundational step.

After this PR, Layer 0 still needs the roadmap's remaining admissible-morphism calculus, bicartesian characterization, exact-equivalence transfer and preservation results, and extension-closed induced exact structures.

The implementation reuses Mathlib's `IsPushout.of_coprod_inl_with_id`, `IsPullback.of_prod_fst_with_id`, biproduct braiding, and morphism-property cancellation APIs, together with Tau Ceti's existing `IsKernelCokernelPair.biprod`; the module documentation attributes the standard argument to Bühler, Proposition 2.9. No Mathlib code is vendored.

Adds `TauCeti/CategoryTheory/Exact/Biproduct.lean` (171 lines).

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"conflation-biprod"}-->

🤖 Prepared with Codex
