### PR TITLE
feat: construct the split torus acting on a Kostant weight lattice

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
@@ -1,0 +1,425 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Elementary
+public import TauCeti.LinearAlgebra.Basis.DiagonalTorus
+public import Mathlib.LinearAlgebra.Eigenspace.Basic
+
+/-!
+# The split maximal torus of a Kostant elementary group
+
+Let `U_ℤ = kostantForm e h` act on a rational representation `V` through `ρ` and preserve an
+additive subgroup `M ≤ V`. A **weight basis** of `M` is an integral basis `b : Basis η ℤ M` each of
+whose vectors is a joint eigenvector of the designated Cartan operators `ρ(hⱼ)`, with integer
+eigenvalues recorded by `wt : η → κ → ℤ`. Over any commutative ring `A` of points, the split torus
+`𝔾ₘ^κ` then acts diagonally on `A ⊗[ℤ] M`: a point `s : κ → Aˣ` scales the basis vector `b x` by
+the value `∏ⱼ sⱼ ^ wt x j` of the character `wt x`.
+
+This is the split maximal torus of the pinning. What makes it a *pinned* torus rather than an
+arbitrary diagonal group is its interaction with the root subgroups. If the designated root vector
+`eᵢ` has weight `α`, meaning `⁅hⱼ, eᵢ⁆ = αⱼ eᵢ` for every `j`, then
+
+```text
+t(s) xᵢ(u) t(s)⁻¹ = xᵢ(α(s) u),
+```
+
+with `α(s) = ∏ⱼ sⱼ ^ αⱼ` the value at `s` of the same character. So the torus normalizes each root
+subgroup, acting on its parameter by the root, and consequently normalizes the whole elementary
+group `E(A) = ⟨xᵢ(u)⟩`. Nothing here divides by a factorial, so the equations hold over a value
+ring of any characteristic.
+
+The analogous statement for the worked `GLₙ` example is
+`TauCeti.GeneralLinear.diagonalTorusPoints_mul_rootSubgroupPoints_mul_inv`; here the diagonal group
+is cut down to rank `κ` by the weight function, and the character by which it acts on a root
+subgroup is the root rather than a difference `εᵢ - εⱼ` of coordinates.
+
+## Main declarations
+
+* `TauCeti.UniversalEnvelopingAlgebra.IsCartanWeightVector`: a joint eigenvector of the designated
+  Cartan operators with prescribed integer eigenvalues.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantCartanOperator`: a designated Cartan vector as an
+  integral operator on a Kostant-stable subgroup.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints`: the split torus of rank `κ` on the
+  points of a Kostant-stable lattice presented in a weight basis.
+
+## Main results
+
+* `TauCeti.UniversalEnvelopingAlgebra.IsCartanWeightVector.integralDividedPower`: a divided power
+  of a root vector of weight `α` raises the weight of a weight vector by a multiple of `α`.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints_tmul_of_isCartanWeightVector`: a torus
+  point acts on a weight vector by the value of its character.
+* `TauCeti.UniversalEnvelopingAlgebra.map_kostantTorusPoints`: naturality in the value ring.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints_conj_kostantRootSubgroupParam`: the
+  pinning equation `t(s) xᵢ(u) t(s)⁻¹ = xᵢ(α(s) u)`.
+* `TauCeti.UniversalEnvelopingAlgebra.map_kostantElementarySubgroup_conj_kostantTorusPoints`: the
+  torus normalizes the elementary group.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+open TensorProduct WithConv
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe u v w
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {ι : Type*} {κ : Type*}
+variable {V : Type v} [AddCommGroup V] [Module ℚ V]
+
+variable (e : ι → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+
+-- Match tensor products to the `ℤ`-algebra instance stored by `CommAlgCat` objects.
+attribute [local instance high] Algebra.toModule
+
+-- Mathlib does not register the Lie ring of an associative ring as a global instance; the
+-- commutator of two elements of the enveloping algebra is written with it below.
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+/-! ## Weight vectors -/
+
+/-- A vector of `V` is a **weight vector of weight `μ`** when it is a joint eigenvector of the
+designated Cartan operators `ρ(hⱼ)` with the integer eigenvalues `μ j`. -/
+def IsCartanWeightVector (h : κ → L)
+    (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V) (μ : κ → ℤ) (m : V) : Prop :=
+  ∀ j, ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) m = (μ j : ℚ) • m
+
+/-- Being a weight vector is joint membership in the eigenspaces of the Cartan operators. -/
+theorem isCartanWeightVector_iff_mem_eigenspace {μ : κ → ℤ} {m : V} :
+    IsCartanWeightVector h ρ μ m ↔
+      ∀ j, m ∈ Module.End.eigenspace (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)))
+        ((μ j : ℚ)) := by
+  simp [IsCartanWeightVector]
+
+namespace IsCartanWeightVector
+
+variable {h ρ}
+
+/-- A rational multiple of a weight vector is a weight vector of the same weight. -/
+theorem smul {μ : κ → ℤ} {m : V} (hm : IsCartanWeightVector h ρ μ m) (c : ℚ) :
+    IsCartanWeightVector h ρ μ (c • m) := fun j => by
+  rw [map_smul, hm j, smul_comm]
+
+/-- If the root vector `eᵢ` has weight `α`, then applying its action `n` times to a weight vector
+of weight `μ` produces a weight vector of weight `μ + n α`. -/
+theorem pow_rootVector {i : ι} {α μ : κ → ℤ} {m : V}
+    (hα : ∀ j, ⁅h j, e i⁆ = (α j : ℚ) • e i) (hm : IsCartanWeightVector h ρ μ m) (n : ℕ) :
+    IsCartanWeightVector h ρ (μ + n • α)
+      ((ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) ^ n) m) := by
+  -- The image of `eᵢ` is an eigenvector of weight `α` for the adjoint action of the Cartan family.
+  have hbr : ∀ j, ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) *
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) -
+        ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) *
+          ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) =
+      (α j : ℚ) • ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) := by
+    intro j
+    have := LieHom.map_lie (_root_.UniversalEnvelopingAlgebra.ι ℚ) (h j) (e i)
+    rw [hα j, LieRing.of_associative_ring_bracket, map_smul] at this
+    have h2 := congrArg ρ this
+    rw [map_sub, map_mul, map_mul, map_smul] at h2
+    exact h2.symm
+  induction n with
+  | zero => simpa using hm
+  | succ n ih =>
+      intro j
+      have hpow : (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) ^ (n + 1)) m =
+          ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))
+            ((ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) ^ n) m) := by
+        rw [pow_succ', Module.End.mul_apply]
+      have happ := congrArg (fun f : Module.End ℚ V =>
+        f ((ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) ^ n) m)) (hbr j)
+      simp only [LinearMap.sub_apply, Module.End.mul_apply, LinearMap.smul_apply] at happ
+      rw [ih j, map_smul, sub_eq_iff_eq_add, ← add_smul] at happ
+      have hstep : (μ + (n + 1) • α) j = α j + (μ + n • α) j := by
+        simp only [Pi.add_apply, Pi.smul_apply, succ_nsmul]
+        abel
+      rw [hpow, happ, hstep]
+      push_cast
+      module
+
+/-- If the root vector `eᵢ` has weight `α`, its `n`-th divided power raises the weight of a weight
+vector by `n α`. This is the statement that makes the torus act on a root subgroup through the
+root. -/
+theorem integralDividedPower {i : ι} {α μ : κ → ℤ} {m : V}
+    (hα : ∀ j, ⁅h j, e i⁆ = (α j : ℚ) • e i) (hm : IsCartanWeightVector h ρ μ m) (n : ℕ) :
+    IsCartanWeightVector h ρ (μ + n • α)
+      (Associative.dividedPower n (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) • m) := by
+  rw [Associative.dividedPower_def, smul_assoc]
+  exact (pow_rootVector e hα hm n).smul _
+
+end IsCartanWeightVector
+
+/-! ## Cartan operators on a stable subgroup -/
+
+variable {η : Type*} (b : Module.Basis η ℤ M) (wt : η → κ → ℤ)
+
+/-- A designated Cartan vector acting on a Kostant-stable additive subgroup, as an integral
+operator. It is the restriction of `ρ(hⱼ)`, which preserves `M` because `hⱼ` lies in the Kostant
+form. -/
+@[expose] noncomputable def kostantCartanOperator (j : κ) : Module.End ℤ M where
+  toFun v := ⟨ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) (v : V),
+    hM _ (cartanVector_mem_kostantForm e h j) v v.2⟩
+  map_add' v w := Subtype.ext (map_add _ (v : V) (w : V))
+  map_smul' z v := Subtype.ext (map_zsmul _ z (v : V))
+
+/-- The integral Cartan operator acts by the ambient representation. -/
+@[simp] theorem coe_kostantCartanOperator_apply (j : κ) (v : M) :
+    ((kostantCartanOperator e h ρ M hM j v : M) : V) =
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) (v : V) := rfl
+
+/-- On a weight vector the integral Cartan operator is multiplication by the integer weight. -/
+theorem kostantCartanOperator_apply_of_isCartanWeightVector {μ : κ → ℤ} {v : M}
+    (hv : IsCartanWeightVector h ρ μ (v : V)) (j : κ) :
+    kostantCartanOperator e h ρ M hM j v = μ j • v :=
+  Subtype.ext (by rw [coe_kostantCartanOperator_apply, hv j, AddSubgroup.coe_zsmul,
+    Int.cast_smul_eq_zsmul])
+
+/-- In a weight basis, the integral Cartan operator is diagonal: it multiplies the `y`-th
+coordinate by `wt y j`. -/
+theorem repr_kostantCartanOperator
+    (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V)) (j : κ) (m : M) (y : η) :
+    b.repr (kostantCartanOperator e h ρ M hM j m) y = wt y j * b.repr m y := by
+  have key : (Finsupp.lapply y).comp
+        (b.repr.toLinearMap.comp (kostantCartanOperator e h ρ M hM j)) =
+      wt y j • (Finsupp.lapply y).comp b.repr.toLinearMap := by
+    refine b.ext fun x => ?_
+    rw [LinearMap.comp_apply, LinearMap.comp_apply,
+      kostantCartanOperator_apply_of_isCartanWeightVector e h ρ M hM (hwt x) j]
+    rcases eq_or_ne x y with rfl | hxy
+    · simp
+    · simp [hxy]
+  exact congrArg (fun f : M →ₗ[ℤ] ℤ => f m) key
+
+include e hM in
+/-- A weight basis separates weights: a weight vector of weight `μ` has vanishing coordinates at
+every basis vector of a different weight. -/
+theorem repr_eq_zero_of_isCartanWeightVector
+    (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
+    {μ : κ → ℤ} {m : M} (hm : IsCartanWeightVector h ρ μ (m : V)) {y : η} (hy : wt y ≠ μ) :
+    b.repr m y = 0 := by
+  obtain ⟨j, hj⟩ : ∃ j, wt y j ≠ μ j := Function.ne_iff.1 hy
+  have h1 : b.repr (kostantCartanOperator e h ρ M hM j m) y = wt y j * b.repr m y :=
+    repr_kostantCartanOperator e h ρ M hM b wt hwt j m y
+  have h2 : b.repr (kostantCartanOperator e h ρ M hM j m) y = μ j * b.repr m y := by
+    rw [kostantCartanOperator_apply_of_isCartanWeightVector e h ρ M hM hm j]
+    simp
+  have := sub_eq_zero.2 (h1.symm.trans h2)
+  rw [← sub_mul] at this
+  exact (mul_eq_zero.1 this).resolve_left (sub_ne_zero.2 hj)
+
+/-! ## The split torus on points -/
+
+section Torus
+
+variable [Fintype κ]
+
+/-- The split maximal torus of rank `κ` on the `A`-points of a Kostant-stable lattice presented in
+a weight basis: the point `s` scales the base-changed basis vector `b x` by the value at `s` of the
+character `wt x`. -/
+noncomputable def kostantTorusPoints (A : Type*) [CommRing A] [Algebra ℤ A] :
+    (κ → Aˣ) →* LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M) :=
+  (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[ℤ] M)).symm.toMonoidHom.comp
+    (basisWeightTorus (b.baseChange A) wt)
+
+section Pointwise
+
+variable {A : Type*} [CommRing A] [Algebra ℤ A]
+
+omit [Module ℚ V] in
+/-- The linear automorphism underlying a torus point is the diagonal weight automorphism. -/
+@[simp] theorem kostantTorusPoints_toLinearEquiv (s : κ → Aˣ) :
+    (kostantTorusPoints M b wt A s).toLinearEquiv = basisWeightTorus (b.baseChange A) wt s := by
+  rw [kostantTorusPoints]
+  exact (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[ℤ] M)).apply_symm_apply _
+
+omit [Module ℚ V] in
+/-- A torus point acts by the diagonal weight automorphism of the base-changed basis. -/
+theorem kostantTorusPoints_apply (s : κ → Aˣ) (z : A ⊗[ℤ] M) :
+    (kostantTorusPoints M b wt A s).val z = basisWeightTorus (b.baseChange A) wt s z := by
+  rw [← LinearMap.GeneralLinearGroup.coe_toLinearEquiv, kostantTorusPoints_toLinearEquiv]
+
+include e hM in
+/-- A torus point acts on a weight vector by the value of the corresponding character. -/
+theorem kostantTorusPoints_tmul_of_isCartanWeightVector
+    (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
+    {μ : κ → ℤ} {m : M} (hm : IsCartanWeightVector h ρ μ (m : V)) (s : κ → Aˣ) (a : A) :
+    (kostantTorusPoints M b wt A s).val (a ⊗ₜ[ℤ] m) =
+      ((torusCharacter s μ : A) * a) ⊗ₜ[ℤ] m := by
+  rw [kostantTorusPoints_apply,
+    basisWeightTorus_apply_of_repr_eq_zero (b.baseChange A) wt s (μ := μ) (m := a ⊗ₜ[ℤ] m)
+      (fun x hx => by
+        rw [Module.Basis.baseChange_repr_tmul,
+          repr_eq_zero_of_isCartanWeightVector e h ρ M hM b wt hwt hm hx]
+        simp [Algebra.smul_def]),
+    smul_tmul', smul_eq_mul]
+
+omit [Module ℚ V] in
+/-- A torus point scales a base-changed basis vector by the value of its weight character. -/
+@[simp] theorem kostantTorusPoints_tmul_basis (s : κ → Aˣ) (a : A) (x : η) :
+    (kostantTorusPoints M b wt A s).val (a ⊗ₜ[ℤ] b x) =
+      ((torusCharacter s (wt x) : A) * a) ⊗ₜ[ℤ] b x := by
+  rw [kostantTorusPoints_apply,
+    basisWeightTorus_apply_of_repr_eq_zero (b.baseChange A) wt s (μ := wt x)
+      (m := a ⊗ₜ[ℤ] (b x : M)) (fun y hy => by
+        rw [Module.Basis.baseChange_repr_tmul, b.repr_self,
+          Finsupp.single_eq_of_ne (show y ≠ x from fun hxy => hy (by rw [hxy]))]
+        simp [Algebra.smul_def]),
+    smul_tmul', smul_eq_mul]
+
+end Pointwise
+
+section Naturality
+
+variable {A B : Type*} [CommRing A] [CommRing B]
+
+omit [Module ℚ V] in
+/-- Naturality of the torus in the value ring, on a base-changed basis vector. -/
+theorem map_kostantTorusPoints_tmul_basis (φ : A →+* B) (s : κ → Aˣ)
+    (a : A) (x : η) :
+    TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id
+        ((kostantTorusPoints M b wt A s).val (a ⊗ₜ[ℤ] b x)) =
+      (kostantTorusPoints M b wt B fun j => Units.map (φ : A →* B) (s j)).val
+        (TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id (a ⊗ₜ[ℤ] b x)) := by
+  rw [kostantTorusPoints_tmul_basis, TensorProduct.map_tmul, TensorProduct.map_tmul]
+  simp only [LinearMap.id_coe, id_eq, AlgHom.toLinearMap_apply, RingHom.toIntAlgHom_apply,
+    map_mul, kostantTorusPoints_tmul_basis]
+  rw [← map_torusCharacter φ s (wt x)]
+  simp
+
+omit [Module ℚ V] in
+/-- The torus on points is natural in the value ring. -/
+theorem map_kostantTorusPoints (φ : A →+* B) (s : κ → Aˣ) (z : A ⊗[ℤ] M) :
+    TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id
+        ((kostantTorusPoints M b wt A s).val z) =
+      (kostantTorusPoints M b wt B fun j => Units.map (φ : A →* B) (s j)).val
+        (TensorProduct.map φ.toIntAlgHom.toLinearMap LinearMap.id z) := by
+  -- Both sides are additive, so it suffices to treat a pure tensor, and then to expand its
+  -- second factor in the basis.
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add y z hy hz => simp only [map_add, hy, hz]
+  | tmul a m =>
+      conv_lhs => rw [← b.linearCombination_repr m]
+      conv_rhs => rw [← b.linearCombination_repr m]
+      rw [Finsupp.linearCombination_apply, Finsupp.sum, TensorProduct.tmul_sum]
+      simp only [map_sum]
+      refine Finset.sum_congr rfl fun x _ => ?_
+      rw [TensorProduct.tmul_smul, map_zsmul, map_zsmul, map_zsmul, map_zsmul,
+        map_kostantTorusPoints_tmul_basis]
+
+end Naturality
+
+end Torus
+
+/-! ## The pinning equation -/
+
+section Pinning
+
+variable [Fintype κ] {A : Type*} [CommRing A] [Algebra ℤ A]
+
+/-- **The pinning equation for the torus and a root subgroup.** If the designated root vector `eᵢ`
+has weight `α`, then the torus point `s` conjugates the root-subgroup element with parameter `u`
+into the one with parameter `α(s) u`. -/
+theorem kostantTorusPoints_mul_kostantRootSubgroupPoints
+    (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
+    {i : ι} {α : κ → ℤ} (hα : ∀ j, ⁅h j, e i⁆ = (α j : ℚ) • e i)
+    (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (s : κ → Aˣ) (f g : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A))
+    (hg : Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g) =
+      (torusCharacter s α : A) *
+        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f)) :
+    kostantTorusPoints M b wt A s * kostantRootSubgroupPoints e h ρ M hM i hnil f =
+      kostantRootSubgroupPoints e h ρ M hM i hnil g * kostantTorusPoints M b wt A s := by
+  refine Units.ext (Module.Basis.ext (b.baseChange A) fun x => ?_)
+  simp only [Units.val_mul, Module.End.mul_apply, Module.Basis.baseChange_apply,
+    kostantRootSubgroupPoints_tmul, kostantTorusPoints_tmul_basis, map_sum]
+  refine Finset.sum_congr rfl fun n _ => ?_
+  have hw : IsCartanWeightVector h ρ (wt x + n • α)
+      ((integralDividedPower (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M n
+        (fun _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i n hv)
+          (b x) : M) : V) := by
+    rw [coe_integralDividedPower_apply]
+    exact IsCartanWeightVector.integralDividedPower e hα (hwt x) n
+  rw [kostantTorusPoints_tmul_of_isCartanWeightVector e h ρ M hM b wt hwt hw, hg]
+  have hchar : (torusCharacter s (wt x + n • α) : A) =
+      (torusCharacter s (wt x) : A) * (torusCharacter s α : A) ^ n := by
+    rw [torusCharacter_add, torusCharacter_nsmul]
+    push_cast
+    ring
+  rw [hchar]
+  ring_nf
+
+end Pinning
+
+/-! ## The torus inside the elementary group -/
+
+section Elementary
+
+variable [Fintype κ]
+
+/-- **The pinning equation with the parameter read in the value ring.** Conjugation by the torus
+point `s` carries the root-subgroup element `xᵢ(u)` to `xᵢ(α(s) u)`, where `α` is the weight of the
+root vector `eᵢ`. -/
+theorem kostantTorusPoints_conj_kostantRootSubgroupParam
+    (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
+    {i : ι} {α : κ → ℤ} (hα : ∀ j, ⁅h j, e i⁆ = (α j : ℚ) • e i)
+    (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (A : CommAlgCat.{w} ℤ) (s : κ → Aˣ) (t : Multiplicative A) :
+    kostantTorusPoints M b wt A s * kostantRootSubgroupParam e h ρ M hM i hnil A t *
+        (kostantTorusPoints M b wt A s)⁻¹ =
+      kostantRootSubgroupParam e h ρ M hM i hnil A
+        (Multiplicative.ofAdd ((torusCharacter s α : A) * Multiplicative.toAdd t)) := by
+  rw [mul_inv_eq_iff_eq_mul, kostantRootSubgroupParam_apply, kostantRootSubgroupParam_apply]
+  refine kostantTorusPoints_mul_kostantRootSubgroupPoints e h ρ M hM b wt hwt hα hnil s _ _ ?_
+  simp
+
+include e hM in
+/-- **The torus normalizes the elementary group.** Conjugation by a torus point permutes the root
+subgroups, acting on the parameter of the `i`-th one through the root `α i`, so it carries the
+group they generate onto itself. -/
+theorem map_kostantElementarySubgroup_conj_kostantTorusPoints
+    (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V))
+    (α : ι → κ → ℤ) (hα : ∀ i j, ⁅h j, e i⁆ = (α i j : ℚ) • e i)
+    (hnil : ∀ i, IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (A : CommAlgCat.{w} ℤ) (s : κ → Aˣ) :
+    Subgroup.map (MulAut.conj (kostantTorusPoints M b wt A s)).toMonoidHom
+        (kostantElementarySubgroup e h ρ M hM hnil A) =
+      kostantElementarySubgroup e h ρ M hM hnil A := by
+  have hconj : ∀ (i : ι) (t : Multiplicative A),
+      (MulAut.conj (kostantTorusPoints M b wt A s)).toMonoidHom
+          (kostantRootSubgroupParam e h ρ M hM i (hnil i) A t) =
+        kostantRootSubgroupParam e h ρ M hM i (hnil i) A
+          (Multiplicative.ofAdd ((torusCharacter s (α i) : A) * Multiplicative.toAdd t)) :=
+    fun i t => kostantTorusPoints_conj_kostantRootSubgroupParam e h ρ M hM b wt hwt (hα i)
+      (hnil i) A s t
+  rw [kostantElementarySubgroup_eq_closure, MonoidHom.map_closure]
+  congr 1
+  refine Set.Subset.antisymm ?_ ?_
+  · rintro _ ⟨z, hz, rfl⟩
+    obtain ⟨i, t, rfl⟩ := by simpa only [Set.mem_iUnion, Set.mem_range] using hz
+    exact Set.mem_iUnion.2 ⟨i, _, (hconj i t).symm⟩
+  · intro y hy
+    obtain ⟨i, t, rfl⟩ := by simpa only [Set.mem_iUnion, Set.mem_range] using hy
+    refine ⟨kostantRootSubgroupParam e h ρ M hM i (hnil i) A
+      (Multiplicative.ofAdd ((↑(torusCharacter s (α i))⁻¹ : A) * Multiplicative.toAdd t)),
+      Set.mem_iUnion.2 ⟨i, Set.mem_range_self _⟩, ?_⟩
+    rw [hconj i]
+    congr 1
+    simp only [toAdd_ofAdd, ← mul_assoc, Units.mul_inv, one_mul, ofAdd_toAdd]
+
+end Elementary
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
@@ -10,7 +10,7 @@ public import TauCeti.LinearAlgebra.Basis.DiagonalTorus
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
 
 /-!
-# The split maximal torus of a Kostant elementary group
+# The split torus of a Kostant elementary group
 
 Let `U_ℤ = kostantForm e h` act on a rational representation `V` through `ρ` and preserve an
 additive subgroup `M ≤ V`. A **weight basis** of `M` is an integral basis `b : Basis η ℤ M` each of
@@ -19,9 +19,8 @@ eigenvalues recorded by `wt : η → κ → ℤ`. Over any commutative ring `A` 
 `𝔾ₘ^κ` then acts diagonally on `A ⊗[ℤ] M`: a point `s : κ → Aˣ` scales the basis vector `b x` by
 the value `∏ⱼ sⱼ ^ wt x j` of the character `wt x`.
 
-This is the split maximal torus of the pinning. What makes it a *pinned* torus rather than an
-arbitrary diagonal group is its interaction with the root subgroups. If the designated root vector
-`eᵢ` has weight `α`, meaning `⁅hⱼ, eᵢ⁆ = αⱼ eᵢ` for every `j`, then
+What ties this diagonal group to the pinning is its interaction with the root subgroups. If the
+designated root vector `eᵢ` has weight `α`, meaning `⁅hⱼ, eᵢ⁆ = αⱼ eᵢ` for every `j`, then
 
 ```text
 t(s) xᵢ(u) t(s)⁻¹ = xᵢ(α(s) u),
@@ -31,6 +30,14 @@ with `α(s) = ∏ⱼ sⱼ ^ αⱼ` the value at `s` of the same character. So th
 subgroup, acting on its parameter by the root, and consequently normalizes the whole elementary
 group `E(A) = ⟨xᵢ(u)⟩`. Nothing here divides by a factorial, so the equations hold over a value
 ring of any characteristic.
+
+The weight basis is taken as data here, and no hypothesis relates `wt` to a root datum, so nothing
+below asserts that this action of `𝔾ₘ^κ` is faithful or that its image is a *maximal* torus of the
+elementary group: for `wt = 0` every point acts as the identity. Faithfulness and maximality are
+properties of the particular lattice and weight function that a Chevalley basis supplies — the
+setting in which this is the split maximal torus of the pinning — and are to be stated where that
+data is constructed, against a root datum. What is proved here is the diagonal action, its
+naturality, and the pinning equation relating it to the root subgroups.
 
 The analogous statement for the worked `GLₙ` example is
 `TauCeti.GeneralLinear.diagonalTorusPoints_mul_rootSubgroupPoints_mul_inv`; here the diagonal group
@@ -43,8 +50,8 @@ subgroup is the root rather than a difference `εᵢ - εⱼ` of coordinates.
   Cartan operators with prescribed integer eigenvalues.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantCartanOperator`: a designated Cartan vector as an
   integral operator on a Kostant-stable subgroup.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints`: the split torus of rank `κ` on the
-  points of a Kostant-stable lattice presented in a weight basis.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints`: the action of the split torus `𝔾ₘ^κ` on
+  the points of a Kostant-stable lattice presented in a weight basis.
 
 ## Main results
 
@@ -237,9 +244,13 @@ section Torus
 
 variable [Fintype κ]
 
-/-- The split maximal torus of rank `κ` on the `A`-points of a Kostant-stable lattice presented in
+/-- The action of the split torus `𝔾ₘ^κ` on the `A`-points of a Kostant-stable lattice presented in
 a weight basis: the point `s` scales the base-changed basis vector `b x` by the value at `s` of the
-character `wt x`. -/
+character `wt x`.
+
+For the weight function of a Chevalley basis this is how the split maximal torus of the pinning
+acts, but nothing here constrains `wt`, so the homomorphism is not claimed to be faithful — for
+`wt = 0` it is trivial — nor its image to be a maximal torus. -/
 noncomputable def kostantTorusPoints (A : Type*) [CommRing A] [Algebra ℤ A] :
     (κ → Aˣ) →* LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M) :=
   (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[ℤ] M)).symm.toMonoidHom.comp

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
@@ -108,6 +108,25 @@ namespace IsCartanWeightVector
 
 variable {h ρ}
 
+/-- Zero is a weight vector of every weight. -/
+theorem zero (μ : κ → ℤ) : IsCartanWeightVector h ρ μ (0 : V) := fun j => by simp
+
+/-- The sum of two weight vectors of the same weight has that weight. -/
+theorem add {μ : κ → ℤ} {m n : V} (hm : IsCartanWeightVector h ρ μ m)
+    (hn : IsCartanWeightVector h ρ μ n) : IsCartanWeightVector h ρ μ (m + n) := fun j => by
+  rw [map_add, hm j, hn j, smul_add]
+
+/-- The negation of a weight vector has the same weight. -/
+theorem neg {μ : κ → ℤ} {m : V} (hm : IsCartanWeightVector h ρ μ m) :
+    IsCartanWeightVector h ρ μ (-m) := fun j => by
+  rw [map_neg, hm j, smul_neg]
+
+/-- The difference of two weight vectors of the same weight has that weight. -/
+theorem sub {μ : κ → ℤ} {m n : V} (hm : IsCartanWeightVector h ρ μ m)
+    (hn : IsCartanWeightVector h ρ μ n) : IsCartanWeightVector h ρ μ (m - n) := by
+  rw [sub_eq_add_neg]
+  exact hm.add hn.neg
+
 /-- A rational multiple of a weight vector is a weight vector of the same weight. -/
 theorem smul {μ : κ → ℤ} {m : V} (hm : IsCartanWeightVector h ρ μ m) (c : ℚ) :
     IsCartanWeightVector h ρ μ (c • m) := fun j => by
@@ -169,7 +188,7 @@ variable {η : Type*} (b : Module.Basis η ℤ M) (wt : η → κ → ℤ)
 /-- A designated Cartan vector acting on a Kostant-stable additive subgroup, as an integral
 operator. It is the restriction of `ρ(hⱼ)`, which preserves `M` because `hⱼ` lies in the Kostant
 form. -/
-@[expose] noncomputable def kostantCartanOperator (j : κ) : Module.End ℤ M where
+noncomputable def kostantCartanOperator (j : κ) : Module.End ℤ M where
   toFun v := ⟨ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) (v : V),
     hM _ (cartanVector_mem_kostantForm e h j) v v.2⟩
   map_add' v w := Subtype.ext (map_add _ (v : V) (w : V))
@@ -178,7 +197,7 @@ form. -/
 /-- The integral Cartan operator acts by the ambient representation. -/
 @[simp] theorem coe_kostantCartanOperator_apply (j : κ) (v : M) :
     ((kostantCartanOperator e h ρ M hM j v : M) : V) =
-      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) (v : V) := rfl
+      ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (h j)) (v : V) := (rfl)
 
 /-- On a weight vector the integral Cartan operator is multiplication by the integer weight. -/
 theorem kostantCartanOperator_apply_of_isCartanWeightVector {μ : κ → ℤ} {v : M}
@@ -191,17 +210,9 @@ theorem kostantCartanOperator_apply_of_isCartanWeightVector {μ : κ → ℤ} {v
 coordinate by `wt y j`. -/
 theorem repr_kostantCartanOperator
     (hwt : ∀ x, IsCartanWeightVector h ρ (wt x) ((b x : M) : V)) (j : κ) (m : M) (y : η) :
-    b.repr (kostantCartanOperator e h ρ M hM j m) y = wt y j * b.repr m y := by
-  have key : (Finsupp.lapply y).comp
-        (b.repr.toLinearMap.comp (kostantCartanOperator e h ρ M hM j)) =
-      wt y j • (Finsupp.lapply y).comp b.repr.toLinearMap := by
-    refine b.ext fun x => ?_
-    rw [LinearMap.comp_apply, LinearMap.comp_apply,
-      kostantCartanOperator_apply_of_isCartanWeightVector e h ρ M hM (hwt x) j]
-    rcases eq_or_ne x y with rfl | hxy
-    · simp
-    · simp [hxy]
-  exact congrArg (fun f : M →ₗ[ℤ] ℤ => f m) key
+    b.repr (kostantCartanOperator e h ρ M hM j m) y = wt y j * b.repr m y :=
+  b.repr_apply_of_apply_basis
+    (fun x => kostantCartanOperator_apply_of_isCartanWeightVector e h ρ M hM (hwt x) j) m y
 
 include e hM in
 /-- A weight basis separates weights: a weight vector of weight `μ` has vanishing coordinates at

--- a/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
+++ b/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
@@ -19,10 +19,16 @@ group `ι → Rˣ` — the `R`-points of the split torus `𝔾ₘ^ι` — inside
 Weights cut this down to a torus of smaller rank. A weight function `wt : ι → κ → ℤ` assigns to
 each basis vector a character of `𝔾ₘ^κ`, and evaluating those characters at a point
 `s : κ → Rˣ` gives the family of units the diagonal automorphism is built from. The resulting
-homomorphism `TauCeti.basisWeightTorus` is the split maximal torus of a Chevalley group written
-in a weight basis of an admissible lattice, and `TauCeti.basisDiagonal_apply_of_repr_eq_zero` is
-the statement that it acts on a weight vector by the corresponding character — which is what makes
-the conjugation formula against a root subgroup come out.
+homomorphism `TauCeti.basisWeightTorus` is the action of `𝔾ₘ^κ` that `wt` prescribes, and
+`TauCeti.basisDiagonal_apply_of_repr_eq_zero` is the statement that it acts on a weight vector by
+the corresponding character — which is what makes the conjugation formula against a root subgroup
+come out.
+
+Nothing is assumed about `wt`, so nothing here asserts that this action is faithful or that its
+image is a maximal torus of anything: for `wt = 0` every point acts as the identity. Those are
+properties of a particular weight function — for the weights of an admissible lattice of a
+Chevalley group the action is the one its split maximal torus performs — and any statement of them
+belongs with the data that supplies `wt`, not here.
 
 ## Main definitions
 
@@ -192,11 +198,12 @@ section WeightTorus
 
 variable [Fintype κ]
 
-/-- The split torus of rank `κ` acting on `M` through a weight function on a basis: the point
-`s` acts on the `i`-th basis vector by the value at `s` of the character `wt i`.
+/-- The action on `M` of the split torus `𝔾ₘ^κ` prescribed by a weight function on a basis: the
+point `s` acts on the `i`-th basis vector by the value at `s` of the character `wt i`.
 
 This is how the split maximal torus of a Chevalley group acts on an admissible lattice written in
-a weight basis. -/
+a weight basis. For an arbitrary `wt` the homomorphism need not be injective — it is trivial for
+`wt = 0` — so faithfulness and maximality are not claimed here. -/
 noncomputable def basisWeightTorus (b : Basis ι R M) (wt : ι → κ → ℤ) :
     (κ → Rˣ) →* (M ≃ₗ[R] M) :=
   (basisDiagonalHom b).comp (torusCharacterHom (R := R) wt)

--- a/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
+++ b/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Algebra.Module.Equiv.Basic
+public import Mathlib.LinearAlgebra.Basis.SMul
+
+/-!
+# The diagonal torus attached to a weighted basis
+
+A basis `b : Basis ι R M` and a family of units `w : ι → Rˣ` determine the automorphism of `M`
+scaling the `i`-th basis vector by `w i`. Letting `w` range over all such families realizes the
+group `ι → Rˣ` — the `R`-points of the split torus `𝔾ₘ^ι` — inside the automorphism group of `M`.
+
+Weights cut this down to a torus of smaller rank. A weight function `wt : ι → κ → ℤ` assigns to
+each basis vector a character of `𝔾ₘ^κ`, and evaluating those characters at a point
+`s : κ → Rˣ` gives the family of units the diagonal automorphism is built from. The resulting
+homomorphism `TauCeti.basisWeightTorus` is the split maximal torus of a Chevalley group written
+in a weight basis of an admissible lattice, and `TauCeti.basisDiagonal_apply_of_repr_eq_zero` is
+the statement that it acts on a weight vector by the corresponding character — which is what makes
+the conjugation formula against a root subgroup come out.
+
+## Main definitions
+
+* `TauCeti.torusCharacter`: the value at `s : κ → Rˣ` of the character `μ : κ → ℤ` of `𝔾ₘ^κ`.
+* `TauCeti.basisDiagonal`: the automorphism scaling each basis vector by a prescribed unit.
+* `TauCeti.basisDiagonalHom`: the resulting homomorphism from `ι → Rˣ`.
+* `TauCeti.basisWeightTorus`: the homomorphism from `κ → Rˣ` determined by a weight function.
+
+## Main results
+
+* `TauCeti.basisDiagonal_apply_of_repr_eq_zero`: a diagonal automorphism acts by a single scalar
+  on any vector whose coordinates are supported where that scalar is attained.
+* `TauCeti.basisWeightTorus_apply_of_repr_eq_zero`: the special case for a weight vector.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+* R. W. Carter, *Simple Groups of Lie Type*, §4.4 and §7.1.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset Module
+
+universe u v w
+
+variable {ι : Type u} {κ : Type v} {R : Type w} {M : Type*}
+variable [CommRing R] [AddCommGroup M] [Module R M]
+
+/-! ## Characters of a split torus -/
+
+section TorusCharacter
+
+variable [Fintype κ]
+
+/-- The value at the point `s` of the character `μ` of the split torus `𝔾ₘ^κ`, namely
+`∏ j, s j ^ μ j`. Weights of a representation are exactly such characters, so this is the scalar
+by which a torus point acts on a weight vector. -/
+def torusCharacter (s : κ → Rˣ) (μ : κ → ℤ) : Rˣ := ∏ j, s j ^ μ j
+
+/-- The trivial character takes the value one at every point. -/
+@[simp] theorem torusCharacter_zero (s : κ → Rˣ) : torusCharacter s (0 : κ → ℤ) = 1 := by
+  simp [torusCharacter]
+
+/-- Characters multiply when weights are added. -/
+theorem torusCharacter_add (s : κ → Rˣ) (μ ν : κ → ℤ) :
+    torusCharacter s (μ + ν) = torusCharacter s μ * torusCharacter s ν := by
+  simp [torusCharacter, zpow_add, prod_mul_distrib]
+
+/-- Scaling a weight by a natural number raises its value to that power. -/
+theorem torusCharacter_nsmul (s : κ → Rˣ) (μ : κ → ℤ) (n : ℕ) :
+    torusCharacter s (n • μ) = torusCharacter s μ ^ n := by
+  simp only [torusCharacter, Pi.smul_apply, nsmul_eq_mul, ← prod_pow]
+  refine prod_congr rfl fun j _ => ?_
+  rw [mul_comm, zpow_mul, zpow_natCast]
+
+/-- Every character takes the value one at the identity point. -/
+@[simp] theorem torusCharacter_one (μ : κ → ℤ) : torusCharacter (1 : κ → Rˣ) μ = 1 := by
+  simp [torusCharacter]
+
+/-- A character is a homomorphism on the points of the torus. -/
+theorem torusCharacter_mul (s t : κ → Rˣ) (μ : κ → ℤ) :
+    torusCharacter (s * t) μ = torusCharacter s μ * torusCharacter t μ := by
+  simp [torusCharacter, mul_zpow, prod_mul_distrib]
+
+/-- The family of characters attached to a weight function, as a homomorphism from the points of
+the split torus `𝔾ₘ^κ` to families of units indexed by the basis. -/
+@[expose] def torusCharacterHom (wt : ι → κ → ℤ) : (κ → Rˣ) →* (ι → Rˣ) where
+  toFun s i := torusCharacter s (wt i)
+  map_one' := funext fun i => torusCharacter_one (R := R) (wt i)
+  map_mul' s t := funext fun i => torusCharacter_mul s t (wt i)
+
+/-- The value of the weight-character homomorphism at a point and a basis index. -/
+@[simp] theorem torusCharacterHom_apply (wt : ι → κ → ℤ) (s : κ → Rˣ) (i : ι) :
+    torusCharacterHom (R := R) wt s i = torusCharacter s (wt i) := rfl
+
+/-- Torus characters are natural in the ring of values. -/
+theorem map_torusCharacter {S : Type*} [CommRing S] (φ : R →+* S) (s : κ → Rˣ) (μ : κ → ℤ) :
+    Units.map (φ : R →* S) (torusCharacter s μ) =
+      torusCharacter (fun j => Units.map (φ : R →* S) (s j)) μ := by
+  simp [torusCharacter, map_prod, map_zpow]
+
+end TorusCharacter
+
+/-! ## Diagonal automorphisms -/
+
+/-- The automorphism of `M` scaling the `i`-th vector of the basis `b` by the unit `w i`. -/
+noncomputable def basisDiagonal (b : Basis ι R M) (w : ι → Rˣ) : M ≃ₗ[R] M :=
+  b.equiv (b.unitsSMul w) (Equiv.refl ι)
+
+/-- The defining action of a diagonal automorphism on a basis vector. -/
+@[simp] theorem basisDiagonal_basis (b : Basis ι R M) (w : ι → Rˣ) (i : ι) :
+    basisDiagonal b w (b i) = (w i : R) • b i := by
+  rw [basisDiagonal, Basis.equiv_apply, Equiv.refl_apply, Basis.unitsSMul_apply, Units.smul_def]
+
+/-- The diagonal automorphism attached to the constant family `1` is the identity. -/
+@[simp] theorem basisDiagonal_one (b : Basis ι R M) : basisDiagonal b 1 = 1 := by
+  refine LinearEquiv.toLinearMap_injective (b.ext fun i => ?_)
+  simp
+
+/-- Diagonal automorphisms multiply pointwise in the family of scaling units. -/
+theorem basisDiagonal_mul (b : Basis ι R M) (w v : ι → Rˣ) :
+    basisDiagonal b (w * v) = basisDiagonal b w * basisDiagonal b v := by
+  refine LinearEquiv.toLinearMap_injective (b.ext fun i => ?_)
+  simp only [LinearEquiv.coe_coe, basisDiagonal_basis, LinearEquiv.mul_eq_trans,
+    LinearEquiv.trans_apply, Pi.mul_apply, Units.val_mul, map_smul]
+  rw [smul_smul, mul_comm]
+
+/-- The diagonal automorphisms as a homomorphism from the group of families of units. -/
+@[expose] noncomputable def basisDiagonalHom (b : Basis ι R M) : (ι → Rˣ) →* (M ≃ₗ[R] M) where
+  toFun := basisDiagonal b
+  map_one' := basisDiagonal_one b
+  map_mul' := basisDiagonal_mul b
+
+/-- The homomorphism of diagonal automorphisms evaluates to `TauCeti.basisDiagonal`. -/
+@[simp] theorem basisDiagonalHom_apply (b : Basis ι R M) (w : ι → Rˣ) :
+    basisDiagonalHom b w = basisDiagonal b w := rfl
+
+/-- A diagonal automorphism scales by a single unit any vector whose coordinates vanish outside
+the basis vectors carrying that unit. Applied to a weight basis, this says that a torus point acts
+on a weight vector by the value of the corresponding character. -/
+theorem basisDiagonal_apply_of_repr_eq_zero (b : Basis ι R M) (w : ι → Rˣ) {c : Rˣ} {m : M}
+    (hm : ∀ i, w i ≠ c → b.repr m i = 0) :
+    basisDiagonal b w m = (c : R) • m := by
+  have key : ∀ i ∈ (b.repr m).support, (w i : R) = (c : R) := by
+    intro i hi
+    by_contra hne
+    exact Finsupp.mem_support_iff.1 hi (hm i fun hwc => hne (congrArg Units.val hwc))
+  conv_lhs => rw [← b.linearCombination_repr m]
+  conv_rhs => rw [← b.linearCombination_repr m]
+  rw [Finsupp.linearCombination_apply, Finsupp.sum, map_sum, smul_sum]
+  refine sum_congr rfl fun i hi => ?_
+  rw [map_smul, basisDiagonal_basis, smul_smul, smul_smul, key i hi, mul_comm]
+
+/-! ## The torus of a weighted basis -/
+
+section WeightTorus
+
+variable [Fintype κ]
+
+/-- The split torus of rank `κ` acting on `M` through a weight function on a basis: the point
+`s` acts on the `i`-th basis vector by the value at `s` of the character `wt i`.
+
+This is how the split maximal torus of a Chevalley group acts on an admissible lattice written in
+a weight basis. -/
+@[expose] noncomputable def basisWeightTorus (b : Basis ι R M) (wt : ι → κ → ℤ) :
+    (κ → Rˣ) →* (M ≃ₗ[R] M) :=
+  (basisDiagonalHom b).comp (torusCharacterHom (R := R) wt)
+
+/-- The weight torus at a point is the diagonal automorphism scaling by the weight characters. -/
+theorem basisWeightTorus_apply (b : Basis ι R M) (wt : ι → κ → ℤ) (s : κ → Rˣ) :
+    basisWeightTorus b wt s = basisDiagonal b fun i => torusCharacter s (wt i) := rfl
+
+/-- A torus point scales the `i`-th basis vector by the value at it of the character `wt i`. -/
+@[simp] theorem basisWeightTorus_basis (b : Basis ι R M) (wt : ι → κ → ℤ) (s : κ → Rˣ) (i : ι) :
+    basisWeightTorus b wt s (b i) = (torusCharacter s (wt i) : R) • b i :=
+  basisDiagonal_basis b _ i
+
+/-- A torus point acts on a weight vector by the value of the corresponding character. -/
+theorem basisWeightTorus_apply_of_repr_eq_zero (b : Basis ι R M) (wt : ι → κ → ℤ) (s : κ → Rˣ)
+    {μ : κ → ℤ} {m : M} (hm : ∀ i, wt i ≠ μ → b.repr m i = 0) :
+    basisWeightTorus b wt s m = (torusCharacter s μ : R) • m := by
+  rw [basisWeightTorus_apply]
+  exact basisDiagonal_apply_of_repr_eq_zero b _ fun i hi => hm i fun hwt => hi (by rw [hwt])
+
+end WeightTorus
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
+++ b/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Module.Equiv.Basic
 public import Mathlib.LinearAlgebra.Basis.SMul
+public import TauCeti.LinearAlgebra.Eigenspace.DiagonalBasis
 
 /-!
 # The diagonal torus attached to a weighted basis
@@ -80,6 +81,23 @@ theorem torusCharacter_nsmul (s : κ → Rˣ) (μ : κ → ℤ) (n : ℕ) :
   refine prod_congr rfl fun j _ => ?_
   rw [mul_comm, zpow_mul, zpow_natCast]
 
+/-- Negating a weight inverts the value of its character. -/
+theorem torusCharacter_neg (s : κ → Rˣ) (μ : κ → ℤ) :
+    torusCharacter s (-μ) = (torusCharacter s μ)⁻¹ := by
+  simp [torusCharacter, ← prod_inv_distrib]
+
+/-- Subtracting weights divides the values of their characters. -/
+theorem torusCharacter_sub (s : κ → Rˣ) (μ ν : κ → ℤ) :
+    torusCharacter s (μ - ν) = torusCharacter s μ / torusCharacter s ν := by
+  rw [sub_eq_add_neg, torusCharacter_add, torusCharacter_neg, div_eq_mul_inv]
+
+/-- Scaling a weight by an integer raises its value to that integer power. -/
+theorem torusCharacter_zsmul (s : κ → Rˣ) (μ : κ → ℤ) (z : ℤ) :
+    torusCharacter s (z • μ) = torusCharacter s μ ^ z := by
+  simp only [torusCharacter, Pi.smul_apply, smul_eq_mul, ← prod_zpow]
+  refine prod_congr rfl fun j _ => ?_
+  rw [mul_comm, zpow_mul]
+
 /-- Every character takes the value one at the identity point. -/
 @[simp] theorem torusCharacter_one (μ : κ → ℤ) : torusCharacter (1 : κ → Rˣ) μ = 1 := by
   simp [torusCharacter]
@@ -91,14 +109,14 @@ theorem torusCharacter_mul (s t : κ → Rˣ) (μ : κ → ℤ) :
 
 /-- The family of characters attached to a weight function, as a homomorphism from the points of
 the split torus `𝔾ₘ^κ` to families of units indexed by the basis. -/
-@[expose] def torusCharacterHom (wt : ι → κ → ℤ) : (κ → Rˣ) →* (ι → Rˣ) where
+def torusCharacterHom (wt : ι → κ → ℤ) : (κ → Rˣ) →* (ι → Rˣ) where
   toFun s i := torusCharacter s (wt i)
   map_one' := funext fun i => torusCharacter_one (R := R) (wt i)
   map_mul' s t := funext fun i => torusCharacter_mul s t (wt i)
 
 /-- The value of the weight-character homomorphism at a point and a basis index. -/
 @[simp] theorem torusCharacterHom_apply (wt : ι → κ → ℤ) (s : κ → Rˣ) (i : ι) :
-    torusCharacterHom (R := R) wt s i = torusCharacter s (wt i) := rfl
+    torusCharacterHom (R := R) wt s i = torusCharacter s (wt i) := (rfl)
 
 /-- Torus characters are natural in the ring of values. -/
 theorem map_torusCharacter {S : Type*} [CommRing S] (φ : R →+* S) (s : κ → Rˣ) (μ : κ → ℤ) :
@@ -133,14 +151,24 @@ theorem basisDiagonal_mul (b : Basis ι R M) (w v : ι → Rˣ) :
   rw [smul_smul, mul_comm]
 
 /-- The diagonal automorphisms as a homomorphism from the group of families of units. -/
-@[expose] noncomputable def basisDiagonalHom (b : Basis ι R M) : (ι → Rˣ) →* (M ≃ₗ[R] M) where
+noncomputable def basisDiagonalHom (b : Basis ι R M) : (ι → Rˣ) →* (M ≃ₗ[R] M) where
   toFun := basisDiagonal b
   map_one' := basisDiagonal_one b
   map_mul' := basisDiagonal_mul b
 
 /-- The homomorphism of diagonal automorphisms evaluates to `TauCeti.basisDiagonal`. -/
 @[simp] theorem basisDiagonalHom_apply (b : Basis ι R M) (w : ι → Rˣ) :
-    basisDiagonalHom b w = basisDiagonal b w := rfl
+    basisDiagonalHom b w = basisDiagonal b w := (rfl)
+
+/-- A diagonal automorphism scales each coordinate by its corresponding unit. -/
+theorem repr_basisDiagonal (b : Basis ι R M) (w : ι → Rˣ) (m : M) (i : ι) :
+    b.repr (basisDiagonal b w m) i = (w i : R) * b.repr m i :=
+  b.repr_apply_of_apply_basis (basisDiagonal_basis b w) m i
+
+/-- Inverting a diagonal automorphism inverts each of its diagonal entries. -/
+theorem basisDiagonal_inv (b : Basis ι R M) (w : ι → Rˣ) :
+    (basisDiagonal b w)⁻¹ = basisDiagonal b w⁻¹ := by
+  simpa only [basisDiagonalHom_apply] using (map_inv (basisDiagonalHom b) w).symm
 
 /-- A diagonal automorphism scales by a single unit any vector whose coordinates vanish outside
 the basis vectors carrying that unit. Applied to a weight basis, this says that a torus point acts
@@ -169,13 +197,13 @@ variable [Fintype κ]
 
 This is how the split maximal torus of a Chevalley group acts on an admissible lattice written in
 a weight basis. -/
-@[expose] noncomputable def basisWeightTorus (b : Basis ι R M) (wt : ι → κ → ℤ) :
+noncomputable def basisWeightTorus (b : Basis ι R M) (wt : ι → κ → ℤ) :
     (κ → Rˣ) →* (M ≃ₗ[R] M) :=
   (basisDiagonalHom b).comp (torusCharacterHom (R := R) wt)
 
 /-- The weight torus at a point is the diagonal automorphism scaling by the weight characters. -/
 theorem basisWeightTorus_apply (b : Basis ι R M) (wt : ι → κ → ℤ) (s : κ → Rˣ) :
-    basisWeightTorus b wt s = basisDiagonal b fun i => torusCharacter s (wt i) := rfl
+    basisWeightTorus b wt s = basisDiagonal b fun i => torusCharacter s (wt i) := (rfl)
 
 /-- A torus point scales the `i`-th basis vector by the value at it of the character `wt i`. -/
 @[simp] theorem basisWeightTorus_basis (b : Basis ι R M) (wt : ι → κ → ℤ) (s : κ → Rˣ) (i : ι) :


### PR DESCRIPTION
This PR constructs the diagonal action of the split torus `𝔾ₘ^κ` on a Kostant-stable lattice presented in a weight basis, and proves the equation that pins it against the root subgroups. The weight function is taken as data and is unconstrained, so nothing here asserts that the action is faithful or that its image is a *maximal* torus — for `wt = 0` every point acts as the identity. Those are properties of the particular lattice and weight function a Chevalley basis supplies, to be stated against a root datum where that data is built; the module docstrings say so explicitly. Let `U_ℤ = kostantForm e h` act on a rational representation `V` through `ρ` and preserve an additive subgroup `M ≤ V`. A *weight basis* of `M` is an integral basis `b : Basis η ℤ M` each of whose vectors is a joint eigenvector of the designated Cartan operators `ρ(hⱼ)`, with integer eigenvalues recorded by `wt : η → κ → ℤ`. Over every commutative ring `A` of points, `TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints` is then the resulting action of `𝔾ₘ^κ` on `A ⊗[ℤ] M`: the point `s : κ → Aˣ` scales `b x` by the value `∏ⱼ sⱼ ^ wt x j` of the character `wt x`. It is a homomorphism of groups, natural in the value ring (`map_kostantTorusPoints`), and — this is the pinning content — if the designated root vector `eᵢ` has weight `α`, meaning `⁅hⱼ, eᵢ⁆ = αⱼ eᵢ` for every `j`, then `kostantTorusPoints_conj_kostantRootSubgroupParam` proves `t(s) xᵢ(u) t(s)⁻¹ = xᵢ(α(s) u)` with `α(s) = ∏ⱼ sⱼ ^ αⱼ`. Since `α(s)` is a unit, conjugation permutes each root subgroup bijectively, so `map_kostantElementarySubgroup_conj_kostantTorusPoints` concludes that the torus carries the elementary group `E(A) = ⟨xᵢ(u)⟩` onto itself.

Nothing divides by a factorial anywhere, so all of this holds over a value ring of arbitrary characteristic, which is what a Chevalley group in characteristic two or three needs. The mathematical work is in getting the torus to see the root subgroups at all: the divided power `eᵢ⁽ⁿ⁾` has to be shown to raise weights by `n α` (`IsCartanWeightVector.integralDividedPower`), and a weight vector has to be shown to have vanishing coordinates at every basis vector of a different weight (`repr_eq_zero_of_isCartanWeightVector`). The latter is not formal: it is proved by restricting `ρ(hⱼ)` to `M` — legitimate because `hⱼ` lies in the Kostant form — and observing that this integral operator is diagonal in the weight basis, so a coordinate of a weight-`μ` vector satisfies `wt y j · c = μ j · c` and vanishes as soon as the two weights differ at `j`.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, "pinned Chevalley--Demazure group schemes over `ℤ`", whose second item is "**Pinnings.** A pinning `(G, T, B, {X_α})` of a split reductive group scheme: the torus, a Borel containing it, and a choice of root vector for each simple root. This is what makes 'the' graph automorphism well defined, so it is data, not a property", and whose fifth item asks for the root subgroup maps together with "the equations pinning them against the pinning. Downstream work states its conventions against these, so they are part of the interface, not an implementation detail." The torus half of that pinning had nothing supporting it in the Kostant lane before this PR: `grep` for `torus` or `weight` under `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/` returned nothing on `main`. What remains on that milestone afterwards: the Borel and the assembled pinned group scheme, integral PBW with the finite free admissible lattice that supplies the weight basis this PR takes as a hypothesis (in flight in #3053 and #3061), base change of the assembled scheme with pinning compatibility, the pinned isomorphism theorem, the remaining `G₂` root-string commutator relation, and the characteristic two and three special isogenies.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

The dependency edge is the one `CFSGStatement` declares. Its milestone **L0, "pinned ambient groups"**, produces `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup`, and states that it consumes "the pinned Chevalley--Demazure group scheme over `ℤ` (reductive groups Layer 9)" and "root-subgroup maps `x_α` and the equations expressing their compatibility with the pinning (Layer 9)", consuming them rather than restating them. `CFSGStatement` has no unclaimed local step: `I0` is complete on `main` (indices, the duplicate and small-field examples, `dynkinType_valid`, the graph and length permutations with their Cartan-matrix and order theorems), the twenty-six `S1` sporadic presentations are complete with their dispatcher, `A0`'s universe transport is in flight in #3058, and `L1`--`L3` all wait on `L0`. So the remaining critical path runs through this Layer 9 lane.

This was the most effective current step because the rest of that lane is crowded but the torus was untouched. `kostantRootSubgroupPoints` with its naturality, matrix coordinates, comodule point representation and scheme representability are landed; the Chevalley commutator relations are landed or in flight (#3505, #3513); the elementary group with its functoriality and Frobenius is landed; the Weyl element (#3522), the graph automorphism (#3531) and the weight decomposition of a stable lattice (#3518) are in flight. None of those supplies a torus or the character by which it acts on a root subgroup, and none of their files is touched here. The relationship to #3518 is complementary rather than overlapping: that PR proves a stable lattice *is* the direct sum of its weight components, while this one takes a weight basis as data and builds the torus out of it, so the two compose once both land.

Add `TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean` (194 lines) and `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean` (425 lines). No existing file is modified. The first file is the reusable, Lie-free half: `TauCeti.torusCharacter` with its homomorphism and naturality laws, `TauCeti.basisDiagonal` and `TauCeti.basisDiagonalHom` for the automorphism scaling each basis vector by a unit, `TauCeti.basisWeightTorus` for the rank-`κ` torus action a weight function prescribes, and `TauCeti.basisDiagonal_apply_of_repr_eq_zero`, which says a diagonal automorphism acts by one scalar on any vector supported where that scalar is attained. It belongs in `LinearAlgebra/` rather than in the Kostant directory because none of it mentions a Lie algebra; `TauCeti/LinearAlgebra/Basis/` is a new directory and no flat `Basis*.lean` sibling exists to relocate.

The construction consumes Mathlib's `Module.Basis.unitsSMul`, `Module.Basis.equiv`, `Module.Basis.baseChange` with `baseChange_repr_tmul`, `Finsupp.linearCombination_repr`, `LinearMap.GeneralLinearGroup.generalLinearEquiv`, `MonoidHom.map_closure` and `Module.End.eigenspace`, together with Tau Ceti's existing `kostantForm` with `cartanVector_mem_kostantForm`, `integralDividedPower`, `kostantRootSubgroupPoints`, `kostantRootSubgroupParam` and `kostantElementarySubgroup`. No Mathlib infrastructure is vendored. The worked `GLₙ` analogue of the same equation, `TauCeti.GeneralLinear.diagonalTorusPoints_mul_rootSubgroupPoints_mul_inv`, is cited in the module docstring and is not reused: it is `Matrix.diagonal` on `Fin N` with the coordinate characters `εᵢ - εⱼ`, whereas the group here is cut down to rank `κ` by a weight function on an arbitrary basis, and the root subgroups it must meet live in `LinearMap.GeneralLinearGroup A (A ⊗[ℤ] M)` rather than in `Matrix.GeneralLinearGroup`. The mathematics follows R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1; J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27; and J. C. Jantzen, *Representations of Algebraic Groups*, II.1, all credited in the module documentation.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"kostant-split-maximal-torus"}-->

🤖 Prepared with Claude Code