### PR TITLE
feat: prove a finite de Finetti bound

### DIFF
--- a/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
@@ -95,7 +95,7 @@ def sampleWithReplacement (ρ : Measure (κ → α)) : Measure (ι → α) :=
   ρ.bind fun x => (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure
 
 /-- The product-measure mixture defining sampling with replacement is a measurable kernel. -/
-theorem aemeasurable_pi_empiricalPopulation (ρ : Measure (κ → α)) :
+private theorem aemeasurable_pi_empiricalPopulation (ρ : Measure (κ → α)) :
     AEMeasurable
       (fun x => (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure) ρ :=
   (TauCeti.MeasureTheory.measurable_probabilityMeasure_pi_toMeasure

--- a/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
@@ -75,7 +75,7 @@ theorem pi_empiricalPopulation_eq_map_uniformOn (x : κ → α) :
     (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure =
       (uniformOn (Set.univ : Set (ι → κ))).map fun k i => x (k i) := by
   rw [ProbabilityMeasure.toMeasure_pi]
-  simp_rw [empiricalPopulation_toMeasure]
+  simp_rw [empiricalPopulation_eq_map_uniformOn]
   rw [← Measure.pi_map_pi fun _ : ι => (measurable_of_countable x).aemeasurable]
   rw [← uniformOn_pi (f := fun _ : ι => (Set.univ : Set κ))]
   congr 2
@@ -86,7 +86,6 @@ end EmpiricalPopulation
 section Sampling
 
 variable {ι κ : Type*} [Fintype ι] [Fintype κ] [Nonempty κ]
-  [MeasurableSpace κ] [MeasurableSingletonClass κ]
 
 /-- Sampling with replacement from a random finite population.
 
@@ -110,6 +109,17 @@ theorem isProbabilityMeasure_sampleWithReplacement (ρ : Measure (κ → α))
     (aemeasurable_pi_empiricalPopulation (ι := ι) (κ := κ) (α := α) ρ)
     (.of_forall fun _ => inferInstance)
 
+/-- Evaluation of the with-replacement law as an average over the random finite population. -/
+theorem sampleWithReplacement_apply {ρ : Measure (κ → α)} {A : Set (ι → α)}
+    (hA : MeasurableSet A) :
+    sampleWithReplacement ρ A =
+      ∫⁻ x, (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure A ∂ρ :=
+  Measure.bind_apply hA (aemeasurable_pi_empiricalPopulation ρ)
+
+section DiscretePopulation
+
+variable [MeasurableSpace κ] [MeasurableSingletonClass κ]
+
 /-- Sampling with replacement is the pushforward obtained by first choosing a uniform map into
 the population and independently drawing the population itself. -/
 theorem sampleWithReplacement_eq_map_prod (ρ : Measure (κ → α)) [SFinite ρ] :
@@ -131,13 +141,6 @@ theorem sampleWithReplacement_eq_map_prod (ρ : Measure (κ → α)) [SFinite ρ
       (measurable_pi_lambda _ fun i =>
         (measurable_of_countable x).comp (measurable_pi_apply i)) hA,
     ← pi_empiricalPopulation_eq_map_uniformOn]
-
-/-- Evaluation of the with-replacement law as an average over the random finite population. -/
-theorem sampleWithReplacement_apply {ρ : Measure (κ → α)} {A : Set (ι → α)}
-    (hA : MeasurableSet A) :
-    sampleWithReplacement ρ A =
-      ∫⁻ x, (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure A ∂ρ :=
-  Measure.bind_apply hA (aemeasurable_pi_empiricalPopulation ρ)
 
 omit [Nonempty κ] [Fintype ι] [Fintype κ] in
 /-- Evaluation of the without-replacement law by conditioning first on the population. -/
@@ -202,6 +205,8 @@ theorem sampleWithReplacement_le_sampleWithoutReplacement_add
       lintegral_mono fun x => uniformOn_univ_le_injective_add_choose_two_div _
     _ = (∫⁻ x, f x ∂ρ) + ∫⁻ _x, c ∂ρ := lintegral_add_left hf _
     _ = (∫⁻ x, f x ∂ρ) + c := by simp
+
+end DiscretePopulation
 
 end Sampling
 

--- a/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
@@ -1,0 +1,249 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.MeasureTheory.Measure.ProductKernel
+public import TauCeti.Probability.Exchangeability.SamplingWithoutReplacement
+public import TauCeti.Probability.Process.EmpiricalMeasure
+
+/-!
+# Quantitative finite de Finetti approximation
+
+Let `x : κ → α` be a nonempty finite population. Its empirical distribution is the pushforward
+of the uniform law on `κ` by `x`. Sampling `ι` entries from that distribution independently is
+therefore the same as choosing a uniform map `ι → κ` and reading the selected entries of `x`.
+
+For a random population with law `ρ`, `sampleWithReplacement ρ` mixes these finite product laws
+over `ρ`. The law `sampleWithoutReplacement ρ` already represents every shorter marginal of a
+finite exchangeable process. The collision coupling between uniform maps and uniform injective
+maps consequently gives, for every measurable event `A`,
+
+```text
+prefixLaw μ X m A ≤ sampleWithReplacement (prefixLaw μ X n) A + choose(m, 2) / n
+sampleWithReplacement (prefixLaw μ X n) A ≤ prefixLaw μ X m A + choose(m, 2) / n.
+```
+
+Thus every `m`-coordinate marginal of an `n`-exchangeable process is quantitatively approximated
+by a mixture of `m`-fold product measures of empirical distributions. The bound is deliberately
+eventwise rather than packaged in a new total-variation definition.
+
+## Main declarations
+
+* `TauCeti.Probability.empiricalPopulation`: the empirical probability measure of a nonempty
+  finite population;
+* `TauCeti.Probability.sampleWithReplacement`: the mixture of finite powers of those empirical
+  measures;
+* `TauCeti.Probability.ExchangeableAt.prefixLaw_le_sampleWithReplacement_add` and
+  `TauCeti.Probability.ExchangeableAt.sampleWithReplacement_le_prefixLaw_add`: the two sides of
+  the finite de Finetti bound.
+
+## References
+
+* P. Diaconis and D. Freedman, “Finite exchangeable sequences”, *Annals of Probability* 8
+  (1980), 745–764.
+
+No material is adapted from `cameronfreer/exchangeability`; that development concerns infinite
+exchangeable sequences rather than quantitative finite approximation.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α : Type*} [MeasurableSpace α]
+
+section EmpiricalPopulation
+
+variable {κ : Type*} [Fintype κ] [Nonempty κ] [MeasurableSpace κ]
+  [MeasurableSingletonClass κ]
+
+variable {ι : Type*} [Fintype ι]
+
+/-- Independently sampling from a finite empirical population is the same as choosing a uniform
+map into the population and reading the selected entries. -/
+theorem pi_empiricalPopulation_eq_map_uniformOn (x : κ → α) :
+    (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure =
+      (uniformOn (Set.univ : Set (ι → κ))).map fun k i => x (k i) := by
+  rw [ProbabilityMeasure.toMeasure_pi]
+  simp_rw [empiricalPopulation_toMeasure]
+  rw [← Measure.pi_map_pi fun _ : ι => (measurable_of_countable x).aemeasurable]
+  rw [← uniformOn_pi (f := fun _ : ι => (Set.univ : Set κ))]
+  congr 2
+  simp
+
+end EmpiricalPopulation
+
+section Sampling
+
+variable {ι κ : Type*} [Fintype ι] [Fintype κ] [Nonempty κ]
+  [MeasurableSpace κ] [MeasurableSingletonClass κ]
+
+/-- Sampling with replacement from a random finite population.
+
+For a population law `ρ`, this is the `ρ`-mixture of the `ι`-fold product of each population's
+empirical probability measure. -/
+def sampleWithReplacement (ρ : Measure (κ → α)) : Measure (ι → α) :=
+  ρ.bind fun x => (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure
+
+/-- The product-measure mixture defining sampling with replacement is a measurable kernel. -/
+theorem aemeasurable_pi_empiricalPopulation (ρ : Measure (κ → α)) :
+    AEMeasurable
+      (fun x => (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure) ρ :=
+  (TauCeti.MeasureTheory.measurable_probabilityMeasure_pi_toMeasure
+      (fun _ : ι => empiricalPopulation) (fun _ => measurable_empiricalPopulation)).aemeasurable
+
+/-- Sampling with replacement from a random population preserves probability mass. -/
+theorem isProbabilityMeasure_sampleWithReplacement (ρ : Measure (κ → α))
+    [IsProbabilityMeasure ρ] :
+    IsProbabilityMeasure (sampleWithReplacement (ι := ι) ρ) :=
+  isProbabilityMeasure_bind
+    (aemeasurable_pi_empiricalPopulation (ι := ι) (κ := κ) (α := α) ρ)
+    (.of_forall fun _ => inferInstance)
+
+/-- Sampling with replacement is the pushforward obtained by first choosing a uniform map into
+the population and independently drawing the population itself. -/
+theorem sampleWithReplacement_eq_map_prod (ρ : Measure (κ → α)) [SFinite ρ] :
+    sampleWithReplacement ρ =
+      ((uniformOn (Set.univ : Set (ι → κ))).prod ρ).map
+        fun p i => p.2 (p.1 i) := by
+  apply Measure.ext fun A hA => ?_
+  rw [sampleWithReplacement, Measure.bind_apply hA (aemeasurable_pi_empiricalPopulation ρ)]
+  rw [Measure.map_apply measurable_reindexPopulation hA]
+  rw [Measure.prod_apply_symm (measurable_reindexPopulation hA)]
+  apply lintegral_congr
+  intro x
+  -- Expose the fixed-population section of the joint preimage so `Measure.map_apply` matches it.
+  change (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure A =
+    uniformOn (Set.univ : Set (ι → κ)) ((fun k i => x (k i)) ⁻¹' A)
+  rw [← Measure.map_apply
+      (μ := uniformOn (Set.univ : Set (ι → κ)))
+      (f := fun k i => x (k i))
+      (measurable_pi_lambda _ fun i =>
+        (measurable_of_countable x).comp (measurable_pi_apply i)) hA,
+    ← pi_empiricalPopulation_eq_map_uniformOn]
+
+/-- Evaluation of the with-replacement law as an average over the random finite population. -/
+theorem sampleWithReplacement_apply {ρ : Measure (κ → α)} {A : Set (ι → α)}
+    (hA : MeasurableSet A) :
+    sampleWithReplacement ρ A =
+      ∫⁻ x, (ProbabilityMeasure.pi fun _ : ι => empiricalPopulation x).toMeasure A ∂ρ :=
+  Measure.bind_apply hA (aemeasurable_pi_empiricalPopulation ρ)
+
+omit [Nonempty κ] [Fintype ι] [Fintype κ] in
+/-- Evaluation of the without-replacement law by conditioning first on the population. -/
+theorem sampleWithoutReplacement_apply_population [Finite κ]
+    {ρ : Measure (κ → α)} [SFinite ρ]
+    {A : Set (ι → α)} (hA : MeasurableSet A) :
+    sampleWithoutReplacement ρ A =
+      ∫⁻ x, uniformOn {k : ι → κ | Function.Injective k}
+        ((fun k i => x (k i)) ⁻¹' A) ∂ρ := by
+  rw [sampleWithoutReplacement_def, Measure.map_apply measurable_reindexPopulation hA]
+  rw [Measure.prod_apply_symm (measurable_reindexPopulation hA)]
+  rfl
+
+/-- Evaluation of the with-replacement law by conditioning first on the population. -/
+theorem sampleWithReplacement_apply_population {ρ : Measure (κ → α)} [SFinite ρ]
+    {A : Set (ι → α)} (hA : MeasurableSet A) :
+    sampleWithReplacement ρ A =
+      ∫⁻ x, uniformOn (Set.univ : Set (ι → κ))
+        ((fun k i => x (k i)) ⁻¹' A) ∂ρ := by
+  rw [sampleWithReplacement_eq_map_prod, Measure.map_apply measurable_reindexPopulation hA]
+  rw [Measure.prod_apply_symm (measurable_reindexPopulation hA)]
+  rfl
+
+/-- **Finite sampling bound, without replacement to with replacement.** For every measurable
+event, sampling without replacement from a random finite population has mass at most its
+with-replacement mass plus the collision bound `choose |ι| 2 / |κ|`. -/
+theorem sampleWithoutReplacement_le_sampleWithReplacement_add
+    {ρ : Measure (κ → α)} [IsProbabilityMeasure ρ] {A : Set (ι → α)} (hA : MeasurableSet A) :
+    sampleWithoutReplacement ρ A ≤ sampleWithReplacement ρ A +
+      (Fintype.card ι).choose 2 / Fintype.card κ := by
+  rw [sampleWithoutReplacement_apply_population hA,
+    sampleWithReplacement_apply_population hA]
+  let c : ℝ≥0∞ := (Fintype.card ι).choose 2 / Fintype.card κ
+  let f : (κ → α) → ℝ≥0∞ := fun x =>
+    uniformOn (Set.univ : Set (ι → κ)) ((fun k i => x (k i)) ⁻¹' A)
+  have hf : Measurable f := by
+    exact measurable_measure_prodMk_right (measurable_reindexPopulation hA)
+  calc
+    (∫⁻ x, uniformOn {k : ι → κ | Function.Injective k}
+        ((fun k i => x (k i)) ⁻¹' A) ∂ρ) ≤ ∫⁻ x, f x + c ∂ρ :=
+      lintegral_mono fun x => uniformOn_injective_le_add_choose_two_div _
+    _ = (∫⁻ x, f x ∂ρ) + ∫⁻ _x, c ∂ρ := lintegral_add_left hf _
+    _ = (∫⁻ x, f x ∂ρ) + c := by simp
+
+/-- **Finite sampling bound, with replacement to without replacement.** For every measurable
+event, sampling with replacement from a random finite population has mass at most its
+without-replacement mass plus the collision bound `choose |ι| 2 / |κ|`. -/
+theorem sampleWithReplacement_le_sampleWithoutReplacement_add
+    {ρ : Measure (κ → α)} [IsProbabilityMeasure ρ] {A : Set (ι → α)} (hA : MeasurableSet A) :
+    sampleWithReplacement ρ A ≤ sampleWithoutReplacement ρ A +
+      (Fintype.card ι).choose 2 / Fintype.card κ := by
+  rw [sampleWithoutReplacement_apply_population hA,
+    sampleWithReplacement_apply_population hA]
+  let c : ℝ≥0∞ := (Fintype.card ι).choose 2 / Fintype.card κ
+  let f : (κ → α) → ℝ≥0∞ := fun x =>
+    uniformOn {k : ι → κ | Function.Injective k} ((fun k i => x (k i)) ⁻¹' A)
+  have hf : Measurable f := by
+    exact measurable_measure_prodMk_right (measurable_reindexPopulation hA)
+  calc
+    (∫⁻ x, uniformOn (Set.univ : Set (ι → κ))
+        ((fun k i => x (k i)) ⁻¹' A) ∂ρ) ≤ ∫⁻ x, f x + c ∂ρ :=
+      lintegral_mono fun x => uniformOn_univ_le_injective_add_choose_two_div _
+    _ = (∫⁻ x, f x ∂ρ) + ∫⁻ _x, c ∂ρ := lintegral_add_left hf _
+    _ = (∫⁻ x, f x ∂ρ) + c := by simp
+
+end Sampling
+
+section FiniteExchangeability
+
+/-- **Quantitative finite de Finetti bound, exchangeable law to empirical mixture.** If the first
+`n` coordinates of a process are exchangeable and `m ≤ n`, then every measurable event under the
+`m`-prefix law has mass at most its mass under the mixture of `m`-fold products of the empirical
+distribution of the first `n` coordinates, plus `choose m 2 / n`. -/
+theorem ExchangeableAt.prefixLaw_le_sampleWithReplacement_add
+    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → α} {m n : ℕ} [NeZero n] (h : ExchangeableAt μ X n) (hmn : m ≤ n)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) {A : Set (Fin m → α)}
+    (hA : MeasurableSet A) :
+    prefixLaw μ X m A ≤ sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A +
+      m.choose 2 / n := by
+  let _ : IsProbabilityMeasure (prefixLaw μ X n) := by
+    rw [prefixLaw_def, blockLaw_def]
+    exact Measure.isProbabilityMeasure_map (aemeasurable_pi_lambda _ hX)
+  rw [← h.sampleWithoutReplacement_eq_prefixLaw hmn hX]
+  simpa using sampleWithoutReplacement_le_sampleWithReplacement_add
+    (ρ := prefixLaw μ X n) hA
+
+/-- **Quantitative finite de Finetti bound, empirical mixture to exchangeable law.** Under the
+same hypotheses, every measurable event under the empirical-product mixture has mass at most its
+mass under the `m`-prefix law plus `choose m 2 / n`. -/
+theorem ExchangeableAt.sampleWithReplacement_le_prefixLaw_add
+    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → α} {m n : ℕ} [NeZero n] (h : ExchangeableAt μ X n) (hmn : m ≤ n)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) {A : Set (Fin m → α)}
+    (hA : MeasurableSet A) :
+    sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A ≤ prefixLaw μ X m A +
+      m.choose 2 / n := by
+  let _ : IsProbabilityMeasure (prefixLaw μ X n) := by
+    rw [prefixLaw_def, blockLaw_def]
+    exact Measure.isProbabilityMeasure_map (aemeasurable_pi_lambda _ hX)
+  rw [← h.sampleWithoutReplacement_eq_prefixLaw hmn hX]
+  simpa using sampleWithReplacement_le_sampleWithoutReplacement_add
+    (ρ := prefixLaw μ X n) hA
+
+end FiniteExchangeability
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/SamplingWithoutReplacement.lean
+++ b/TauCeti/Probability/Exchangeability/SamplingWithoutReplacement.lean
@@ -29,6 +29,7 @@ same law by `ExchangeableAt.blockLaw_eq_prefixLaw_of_injective`, so the average 
 
 * `sampleWithoutReplacement` — sample a random finite population at uniformly chosen distinct
   indices;
+* `measurable_reindexPopulation` — measurability of the joint selection/population evaluation;
 * `sampleWithoutReplacement_apply` — its evaluation as the average of the selected laws;
 * `ExchangeableAt.sampleWithoutReplacement_eq_prefixLaw` — the finite exchangeable
   without-replacement representation.
@@ -55,12 +56,11 @@ namespace Probability
 
 variable {α : Type*} [MeasurableSpace α]
 
-/-- Reindex a finite population by a simultaneously supplied selection of its indices.
+/-- Reindexing a population by a simultaneously supplied selection of its indices is measurable.
 
-This lemma is private because the function is only the implementation map in
-`sampleWithoutReplacement`. The measurable-space hypothesis on the finite population index is
-discrete: it lets the variable index be split into countably many measurable fibres. -/
-private theorem measurable_samplePopulation {ι κ : Type*} [Countable κ] [MeasurableSpace κ]
+The measurable-space hypothesis on the population index is discrete: it lets the variable index
+be split into countably many measurable fibres. -/
+theorem measurable_reindexPopulation {ι κ : Type*} [Countable κ] [MeasurableSpace κ]
     [MeasurableSingletonClass κ] :
     Measurable (fun p : (ι → κ) × (κ → α) => fun i : ι => p.2 (p.1 i)) := by
   refine measurable_pi_lambda _ fun i => ?_
@@ -87,13 +87,13 @@ Mathlib's `uniformOn` convention makes this the zero measure.
 The assumptions on the population index are part of the definition, not just of its API. The
 population index is finite because uniform counting only distributes mass over finitely many
 injective selections, and its singletons are measurable because that is what
-`measurable_samplePopulation` uses to establish measurability of the pushforward map for an
+`measurable_reindexPopulation` uses to establish measurability of the pushforward map for an
 arbitrary `α`. -/
 def sampleWithoutReplacement {ι κ : Type*} [Finite κ] [MeasurableSpace κ]
     [MeasurableSingletonClass κ] (ρ : Measure (κ → α)) : Measure (ι → α) :=
   let ν := (uniformOn {k : ι → κ | Function.Injective k}).prod ρ
   let f := fun p i => p.2 (p.1 i)
-  let hf : AEMeasurable f ν := measurable_samplePopulation.aemeasurable
+  let hf : AEMeasurable f ν := measurable_reindexPopulation.aemeasurable
   Measure.mapₗ (hf.mk f) ν
 
 /-- The defining pushforward form of `sampleWithoutReplacement`. -/
@@ -103,7 +103,7 @@ theorem sampleWithoutReplacement_def {ι κ : Type*} [Finite κ] [MeasurableSpac
     sampleWithoutReplacement ρ =
       ((uniformOn {k : ι → κ | Function.Injective k}).prod ρ).map
         fun p i => p.2 (p.1 i) :=
-  Measure.mapₗ_mk_apply_of_aemeasurable measurable_samplePopulation.aemeasurable
+  Measure.mapₗ_mk_apply_of_aemeasurable measurable_reindexPopulation.aemeasurable
 
 /-- Sampling without replacement preserves probability mass whenever an injective selection
 exists. -/
@@ -117,7 +117,7 @@ theorem isProbabilityMeasure_sampleWithoutReplacement {ι κ : Type*} [Finite κ
   let _ : IsProbabilityMeasure (uniformOn E) :=
     isProbabilityMeasure_uniformOn (Set.toFinite E) ⟨e, e.injective⟩
   rw [sampleWithoutReplacement_def]
-  exact Measure.isProbabilityMeasure_map measurable_samplePopulation.aemeasurable
+  exact Measure.isProbabilityMeasure_map measurable_reindexPopulation.aemeasurable
 
 /-- Evaluating the without-replacement law averages the selected population laws over uniform
 injective selections. -/
@@ -127,8 +127,8 @@ theorem sampleWithoutReplacement_apply {ι κ : Type*} [Finite κ]
     sampleWithoutReplacement ρ A =
       ∫⁻ k, ρ ((fun x : κ → α => fun i : ι => x (k i)) ⁻¹' A)
         ∂uniformOn {k : ι → κ | Function.Injective k} := by
-  rw [sampleWithoutReplacement_def, Measure.map_apply measurable_samplePopulation hA,
-    Measure.prod_apply (measurable_samplePopulation hA)]
+  rw [sampleWithoutReplacement_def, Measure.map_apply measurable_reindexPopulation hA,
+    Measure.prod_apply (measurable_reindexPopulation hA)]
   rfl
 
 /-- **Finite exchangeability is sampling without replacement.** If the first `n` coordinates are

--- a/TauCeti/Probability/Process/EmpiricalMeasure.lean
+++ b/TauCeti/Probability/Process/EmpiricalMeasure.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.MeasureTheory.Measure.GiryMonad
 public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 public import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
+public import Mathlib.Probability.UniformOn
 
 /-!
 # Empirical measures of sequences
@@ -15,6 +16,9 @@ This file defines the empirical probability measure of the first `n + 1` terms o
 gives its basic evaluation, integration, and measurability API.  The successor indexing makes the
 object a probability measure without a nonemptiness side condition and matches the form used in
 limit theorems.
+
+It also provides `empiricalPopulation` for a population indexed by an arbitrary nonempty finite
+type. This is the finite-population form used by quantitative sampling arguments.
 
 The construction is a uniform finite sum of Dirac measures.  It is the process-level prerequisite
 for the empirical-measure form of de Finetti's theorem in the `Exchangeability` roadmap.
@@ -106,6 +110,60 @@ theorem measurable_empiricalMeasure {X : ℕ → Ω → α}
         simp only [Measure.smul_apply, smul_eq_mul, Measure.dirac_apply' _ hs]
         exact measurable_const.mul (measurable_one.indicator (hX i hi hs))
   exact hmeasure.subtype_mk
+
+section FinitePopulation
+
+variable {κ : Type*} [Fintype κ] [Nonempty κ] [MeasurableSpace κ]
+  [MeasurableSingletonClass κ]
+
+/-- The empirical probability measure of a nonempty finite population `x : κ → α`.
+
+It is the pushforward of the uniform probability measure on `κ` by `x`. Unlike
+`empiricalMeasure`, its population can have an arbitrary nonempty finite index type rather than a
+natural-number prefix. -/
+def empiricalPopulation (x : κ → α) : ProbabilityMeasure α :=
+  MeasureTheory.ProbabilityMeasure.map
+    (⟨ProbabilityTheory.uniformOn (Set.univ : Set κ), inferInstance⟩ : ProbabilityMeasure κ)
+    (measurable_of_countable x).aemeasurable
+
+/-- The measure underlying a finite empirical population is the pushforward of the uniform law. -/
+@[simp]
+theorem empiricalPopulation_toMeasure (x : κ → α) :
+    (empiricalPopulation x : Measure α) =
+      (ProbabilityTheory.uniformOn (Set.univ : Set κ)).map x :=
+  (rfl)
+
+/-- Finite empirical distributions depend measurably on the population. -/
+theorem measurable_empiricalPopulation :
+    Measurable (empiricalPopulation : (κ → α) → ProbabilityMeasure α) := by
+  apply Measurable.subtype_mk
+  refine Measure.measurable_of_measurable_coe _ fun s hs => ?_
+  -- The measurable structure on `ProbabilityMeasure` is induced by evaluation of its measure.
+  change Measurable fun x : κ → α =>
+    ((ProbabilityTheory.uniformOn (Set.univ : Set κ)).map x) s
+  have heval (x : κ → α) :
+      ((ProbabilityTheory.uniformOn (Set.univ : Set κ)).map x) s =
+        ProbabilityTheory.uniformOn Set.univ (x ⁻¹' s) :=
+    Measure.map_apply (measurable_of_countable x) hs
+  simp_rw [heval, ProbabilityTheory.uniformOn_univ]
+  classical
+  rw [show (fun x : κ → α => Measure.count (x ⁻¹' s) / Fintype.card κ) =
+      fun x => (∑ i, s.indicator (1 : α → ℝ≥0∞) (x i)) / Fintype.card κ by
+    funext x
+    rw [show x ⁻¹' s = (Finset.univ.filter fun i => x i ∈ s : Finset κ) by
+      ext i
+      simp]
+    rw [Measure.count_apply_finset]
+    congr 1
+    have hcount :
+        ((Finset.univ.filter fun i => x i ∈ s).card : ℝ≥0∞) =
+          ∑ i, if x i ∈ s then 1 else 0 := by
+      norm_cast
+      simp
+    simpa only [Set.indicator_apply, Pi.one_apply] using hcount]
+  fun_prop
+
+end FinitePopulation
 
 end Probability
 

--- a/TauCeti/Probability/Process/EmpiricalMeasure.lean
+++ b/TauCeti/Probability/Process/EmpiricalMeasure.lean
@@ -183,8 +183,7 @@ theorem measurable_empiricalPopulation :
     Measurable (empiricalPopulation : (κ → α) → ProbabilityMeasure α) := by
   apply Measurable.subtype_mk
   refine Measure.measurable_of_measurable_coe _ fun s hs => ?_
-  change Measurable fun x : κ → α => (empiricalPopulation x : Measure α) s
-  simp_rw [empiricalPopulation_apply hs]
+  simp_rw [← empiricalPopulation_toMeasure, empiricalPopulation_apply hs]
   fun_prop
 
 end FinitePopulation

--- a/TauCeti/Probability/Process/EmpiricalMeasure.lean
+++ b/TauCeti/Probability/Process/EmpiricalMeasure.lean
@@ -113,54 +113,78 @@ theorem measurable_empiricalMeasure {X : ℕ → Ω → α}
 
 section FinitePopulation
 
-variable {κ : Type*} [Fintype κ] [Nonempty κ] [MeasurableSpace κ]
-  [MeasurableSingletonClass κ]
+variable {κ : Type*} [Fintype κ] [Nonempty κ]
 
 /-- The empirical probability measure of a nonempty finite population `x : κ → α`.
 
-It is the pushforward of the uniform probability measure on `κ` by `x`. Unlike
-`empiricalMeasure`, its population can have an arbitrary nonempty finite index type rather than a
-natural-number prefix. -/
+Unlike `empiricalMeasure`, its population can have an arbitrary nonempty finite index type rather
+than a natural-number prefix. -/
 def empiricalPopulation (x : κ → α) : ProbabilityMeasure α :=
-  MeasureTheory.ProbabilityMeasure.map
-    (⟨ProbabilityTheory.uniformOn (Set.univ : Set κ), inferInstance⟩ : ProbabilityMeasure κ)
-    (measurable_of_countable x).aemeasurable
+  ⟨∑ i, ((Fintype.card κ : ℕ) : ℝ≥0∞)⁻¹ • Measure.dirac (x i), by
+    refine ⟨?_⟩
+    have hκ0 : ((Fintype.card κ : ℕ) : ℝ≥0∞) ≠ 0 := by simp
+    have hκtop : ((Fintype.card κ : ℕ) : ℝ≥0∞) ≠ ∞ := by simp
+    simpa using ENNReal.mul_inv_cancel hκ0 hκtop⟩
 
-/-- The measure underlying a finite empirical population is the pushforward of the uniform law. -/
+/-- The measure underlying a finite empirical population is the normalized sum of its Dirac
+masses. -/
 @[simp]
 theorem empiricalPopulation_toMeasure (x : κ → α) :
     (empiricalPopulation x : Measure α) =
-      (ProbabilityTheory.uniformOn (Set.univ : Set κ)).map x :=
+      ∑ i, ((Fintype.card κ : ℕ) : ℝ≥0∞)⁻¹ • Measure.dirac (x i) :=
   (rfl)
+
+/-- Evaluation of a finite empirical population on a measurable set is its empirical
+frequency. -/
+theorem empiricalPopulation_apply {x : κ → α} {s : Set α} (hs : MeasurableSet s) :
+    (empiricalPopulation x : Measure α) s = ((Fintype.card κ : ℕ) : ℝ≥0∞)⁻¹ *
+      ∑ i, s.indicator (1 : α → ℝ≥0∞) (x i) := by
+  rw [empiricalPopulation_toMeasure]
+  simp only [Measure.coe_finsetSum, Measure.coe_smul, Finset.sum_apply, Pi.smul_apply,
+    smul_eq_mul, Measure.dirac_apply' _ hs, Finset.mul_sum]
+
+/-- On a discrete finite index type, a finite empirical population is the pushforward of the
+uniform law on its indices. -/
+theorem empiricalPopulation_eq_map_uniformOn [MeasurableSpace κ] [MeasurableSingletonClass κ]
+    (x : κ → α) :
+    (empiricalPopulation x : Measure α) =
+      (ProbabilityTheory.uniformOn (Set.univ : Set κ)).map x := by
+  ext s hs
+  rw [empiricalPopulation_apply hs, Measure.map_apply (measurable_of_countable x) hs,
+    ProbabilityTheory.uniformOn_univ]
+  classical
+  have hpreimage :
+      x ⁻¹' s = (Finset.univ.filter fun i => x i ∈ s : Finset κ) := by
+    ext i
+    simp
+  rw [hpreimage, Measure.count_apply_finset]
+  simp only [Set.indicator_apply, Pi.one_apply]
+  rw [← ENNReal.div_eq_inv_mul]
+  congr 1
+  norm_cast
+  simp
+
+/-- Integrating against a finite empirical population is averaging over its values. -/
+theorem integral_empiricalPopulation [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    {x : κ → α} {f : α → E} (hf : StronglyMeasurable f) :
+    ∫ y, f y ∂(empiricalPopulation x : Measure α) =
+      ((Fintype.card κ : ℕ) : ℝ)⁻¹ • ∑ i, f (x i) := by
+  rw [empiricalPopulation_toMeasure, integral_finsetSum_measure]
+  · simp_rw [integral_smul_measure, integral_dirac' f _ hf]
+    rw [← Finset.smul_sum]
+    congr 1
+    rw [ENNReal.toReal_inv]
+    norm_cast
+  · intro i hi
+    exact (integrable_dirac' hf (by simp)).smul_measure (by simp)
 
 /-- Finite empirical distributions depend measurably on the population. -/
 theorem measurable_empiricalPopulation :
     Measurable (empiricalPopulation : (κ → α) → ProbabilityMeasure α) := by
   apply Measurable.subtype_mk
   refine Measure.measurable_of_measurable_coe _ fun s hs => ?_
-  -- The measurable structure on `ProbabilityMeasure` is induced by evaluation of its measure.
-  change Measurable fun x : κ → α =>
-    ((ProbabilityTheory.uniformOn (Set.univ : Set κ)).map x) s
-  have heval (x : κ → α) :
-      ((ProbabilityTheory.uniformOn (Set.univ : Set κ)).map x) s =
-        ProbabilityTheory.uniformOn Set.univ (x ⁻¹' s) :=
-    Measure.map_apply (measurable_of_countable x) hs
-  simp_rw [heval, ProbabilityTheory.uniformOn_univ]
-  classical
-  rw [show (fun x : κ → α => Measure.count (x ⁻¹' s) / Fintype.card κ) =
-      fun x => (∑ i, s.indicator (1 : α → ℝ≥0∞) (x i)) / Fintype.card κ by
-    funext x
-    rw [show x ⁻¹' s = (Finset.univ.filter fun i => x i ∈ s : Finset κ) by
-      ext i
-      simp]
-    rw [Measure.count_apply_finset]
-    congr 1
-    have hcount :
-        ((Finset.univ.filter fun i => x i ∈ s).card : ℝ≥0∞) =
-          ∑ i, if x i ∈ s then 1 else 0 := by
-      norm_cast
-      simp
-    simpa only [Set.indicator_apply, Pi.one_apply] using hcount]
+  change Measurable fun x : κ → α => (empiricalPopulation x : Measure α) s
+  simp_rw [empiricalPopulation_apply hs]
   fun_prop
 
 end FinitePopulation


### PR DESCRIPTION
This PR proves the quantitative finite de Finetti approximation: for `m ≤ n`, every measurable event under the `m`-prefix law of an `n`-exchangeable process differs in either direction from the mixture of `m`-fold products of the empirical `n`-population by at most `Nat.choose m 2 / n`.

The exact roadmap target is `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, milestone “finite de Finetti bounds, including quantitative approximation by mixtures of products.” This is the most effective current step because `sampleWithoutReplacement_eq_prefixLaw` and the uniform-map collision estimate are already on `main`, and the former explicitly identifies the missing with-replacement empirical-product mixture as its companion. After this PR, that milestone can still add sharper or alternative metric formulations, while Layer 8’s independent countable-index, Markov-exchangeable, and exchangeable-array targets remain.

The preferred `CFSGStatement` roadmap has no viable independent unclaimed step on current `main`: I0 and the sporadic lane are complete, universe transport is in flight in #3058, and L0–L3 wait on ReductiveGroups Layer 9, whose currently executable Kostant construction, torus, Borel, graph-automorphism, PBW, and root-string fronts are already in flight; the remaining `G₂` relation in particular depends on #3513. I therefore fall back to this explicit next Exchangeability milestone rather than duplicate or build on unmerged CFSG prerequisites.

Add `TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean` (249 lines). It defines `sampleWithReplacement` as a measurable mixture of finite product measures, identifies that mixture with uniform sampling by arbitrary maps, proves both eventwise collision bounds for random populations, and transfers them to `ExchangeableAt` prefix laws. Extend `TauCeti/Probability/Process/EmpiricalMeasure.lean` by 58 lines with the canonical empirical probability measure of an arbitrary nonempty finite population and its measurability, and promote the existing 11-line joint reindexing measurability proof in `SamplingWithoutReplacement.lean` from a private helper to the shared public lemma consumed by both sampling constructions.

The proof follows Diaconis and Freedman, “Finite exchangeable sequences,” *Annals of Probability* 8 (1980), 745–764, as credited in the new module. It reuses Mathlib’s `ProbabilityMeasure.pi`, `uniformOn_pi`, `Measure.pi_map_pi`, `Measure.bind`, and Tonelli/product-measure API together with Tau Ceti’s existing uniform collision estimates and without-replacement representation; no Mathlib infrastructure or external Lean formalization is vendored.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"finite-de-finette-bound"}-->

🤖 Prepared with Codex
