### PR TITLE
feat: define reductive commutative Hopf algebras

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -6,7 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.Conjugation
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Comap
 
 /-!
 # Normal Hopf ideals
@@ -28,6 +30,8 @@ Normal Hopf ideals are closed under arbitrary suprema.
 
 * `TauCeti.HopfIdeal.IsNormal`: stability under the coordinate conjugation action.
 * `TauCeti.HopfIdeal.isNormal_iSup`: arbitrary suprema of normal Hopf ideals are normal.
+* `TauCeti.HopfIdeal.IsNormal.comap_bijective`: normality is preserved by pullback along a
+  bijective bialgebra morphism.
 * `TauCeti.CommHopfAlgCat.quotientPointsSubgroup_normal`: a normal Hopf ideal cuts out a normal
   subgroup on points over every commutative value algebra.
 
@@ -171,5 +175,46 @@ theorem isNormal_iff_quotientPointsSubgroup_normal
     fun hnormal => isNormal_of_quotientPointsSubgroup_normal H I (hnormal _)⟩
 
 end CommHopfAlgCat
+
+namespace HopfIdeal
+
+variable {R : Type u} [CommRing R]
+variable {H K : Type v} [CommRing H] [CommRing K]
+variable [HopfAlgebra R H] [HopfAlgebra R K]
+
+/-- Pulling a normal Hopf ideal back along a bijective bialgebra morphism preserves normality. -/
+theorem IsNormal.comap_bijective (I : HopfIdeal R K) (f : H →ₐc[R] K)
+    (hinj : Function.Injective f) (hsurj : Function.Surjective f) (hI : I.IsNormal) :
+    (I.comap f hsurj).IsNormal := by
+  apply (CommHopfAlgCat.isNormal_iff_quotientPointsSubgroup_normal
+    (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj)).mpr
+  intro A
+  let e := BialgEquiv.ofBijective f ⟨hinj, hsurj⟩
+  let E := AlgHom.mapDomainMulEquiv (A := A) e
+  have hmem (g : HopfAlgebra.points (R := R) (H := K) A) :
+      E g ∈ CommHopfAlgCat.quotientPointsSubgroup
+          (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A ↔
+        g ∈ CommHopfAlgCat.quotientPointsSubgroup
+          (_root_.CommHopfAlgCat.of R K) I A := by
+    rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff,
+      CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
+    constructor
+    · intro hg y hy
+      obtain ⟨x, rfl⟩ := hsurj y
+      exact hg x (mem_comap.mpr hy)
+    · intro hg x hx
+      exact hg (f x) (mem_comap.mp hx)
+  constructor
+  intro n hn g
+  have hn' : E.symm n ∈ CommHopfAlgCat.quotientPointsSubgroup
+      (_root_.CommHopfAlgCat.of R K) I A := by
+    rw [← hmem]
+    simpa using hn
+  have hconj := (CommHopfAlgCat.quotientPointsSubgroup_normal
+    (_root_.CommHopfAlgCat.of R K) I hI A).conj_mem (E.symm n) hn' (E.symm g)
+  rw [← hmem] at hconj
+  simpa using hconj
+
+end HopfIdeal
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -80,6 +80,12 @@ theorem IsNormal.conjugation_mem {I : HopfIdeal R H} (hI : I.IsNormal) {x : H} (
       rightTensorIdeal (R := R) (H := H) I.toIdeal :=
   (isNormal_iff_conjugation_mem I).mp hI hx
 
+/-- The zero Hopf ideal cuts out the whole affine group, hence is normal. -/
+@[simp]
+theorem isNormal_bot : (⊥ : HopfIdeal R H).IsNormal := by
+  rw [isNormal_def, bot_toIdeal, Ideal.map_bot]
+  exact bot_le
+
 /-- An arbitrary supremum of normal Hopf ideals is normal. -/
 theorem isNormal_iSup {i : Sort*} {I : i → HopfIdeal R H} (hI : ∀ j, (I j).IsNormal) :
     (⨆ j, I j).IsNormal := by

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.lean
@@ -29,8 +29,9 @@ Normal Hopf ideals are closed under arbitrary suprema.
 ## Main declarations
 
 * `TauCeti.HopfIdeal.IsNormal`: stability under the coordinate conjugation action.
+* `TauCeti.HopfIdeal.isNormal_bot`: the zero Hopf ideal is normal.
 * `TauCeti.HopfIdeal.isNormal_iSup`: arbitrary suprema of normal Hopf ideals are normal.
-* `TauCeti.HopfIdeal.IsNormal.comap_bijective`: normality is preserved by pullback along a
+* `TauCeti.HopfIdeal.IsNormal.comap_of_bijective`: normality is preserved by pullback along a
   bijective bialgebra morphism.
 * `TauCeti.CommHopfAlgCat.quotientPointsSubgroup_normal`: a normal Hopf ideal cuts out a normal
   subgroup on points over every commutative value algebra.
@@ -183,8 +184,8 @@ variable {H K : Type v} [CommRing H] [CommRing K]
 variable [HopfAlgebra R H] [HopfAlgebra R K]
 
 /-- Pulling a normal Hopf ideal back along a bijective bialgebra morphism preserves normality. -/
-theorem IsNormal.comap_bijective (I : HopfIdeal R K) (f : H →ₐc[R] K)
-    (hinj : Function.Injective f) (hsurj : Function.Surjective f) (hI : I.IsNormal) :
+theorem IsNormal.comap_of_bijective {I : HopfIdeal R K} (hI : I.IsNormal) (f : H →ₐc[R] K)
+    (hinj : Function.Injective f) (hsurj : Function.Surjective f) :
     (I.comap f hsurj).IsNormal := by
   apply (CommHopfAlgCat.isNormal_iff_quotientPointsSubgroup_normal
     (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj)).mpr

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -147,14 +147,40 @@ lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
     _ = (liftQuotient I f hf).hom (Ideal.Quotient.mkₐ R I.toIdeal h) :=
       (liftQuotient_mk I f hf h).symm
 
+private noncomputable def quotientIsoOfSurjectiveAux (f : H ⟶ K)
+    (hf : Function.Surjective f.hom) (I : HopfIdeal R K) (J : HopfIdeal R H)
+    (hJ : J = HopfIdeal.kerOfSurjective
+      ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+      ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf)) :
+    quotient H J ≅ quotient K I :=
+  _root_.CommHopfAlgCat.isoMk <| hJ.symm ▸
+    HopfIdeal.kerLiftBialgEquiv
+      ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+      ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf)
+
+private lemma quotientIsoOfSurjectiveAux_hom_mk (f : H ⟶ K)
+    (hf : Function.Surjective f.hom) (I : HopfIdeal R K) (J : HopfIdeal R H)
+    (hJ : J = HopfIdeal.kerOfSurjective
+      ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+      ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf)) (x : H) :
+    (quotientIsoOfSurjectiveAux f hf I J hJ).hom.hom
+        (Ideal.Quotient.mk J.toIdeal x) =
+      Ideal.Quotient.mkₐ R I.toIdeal (f.hom x) := by
+  subst J
+  rw [quotientIsoOfSurjectiveAux]
+  exact HopfIdeal.kerLiftBialgEquiv_apply
+    ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+    ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) _ |>.trans <|
+      HopfIdeal.kerLiftBialgHom_mk
+        ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+        ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) x
+
 /-- A surjective morphism of commutative Hopf algebras identifies the quotient by the
 inverse-image Hopf ideal with the corresponding quotient of the target. -/
 noncomputable def quotientIsoOfSurjective (f : H ⟶ K) (hf : Function.Surjective f.hom)
     (I : HopfIdeal R K) : quotient H (I.comap f.hom hf) ≅ quotient K I :=
-  _root_.CommHopfAlgCat.isoMk <|
-    HopfIdeal.kerLiftBialgEquiv
-      ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
-      ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf)
+  quotientIsoOfSurjectiveAux f hf I (I.comap f.hom hf)
+    (HopfIdeal.comap_eq_kerOfSurjective I f.hom hf)
 
 /-- The forward quotient isomorphism induced by a surjective morphism commutes with the
 quotient morphisms. -/
@@ -166,12 +192,7 @@ lemma mkQuotient_comp_quotientIsoOfSurjective_hom (f : H ⟶ K)
   ext x
   rw [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.comp_apply,
     mkQuotient_apply, mkQuotient_apply, quotientIsoOfSurjective]
-  exact HopfIdeal.kerLiftBialgEquiv_apply
-    ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
-    ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) _ |>.trans <|
-      HopfIdeal.kerLiftBialgHom_mk
-        ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
-        ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) x
+  exact quotientIsoOfSurjectiveAux_hom_mk f hf I _ _ x
 
 /-- The forward quotient isomorphism induced by a surjective morphism evaluates on quotient
 classes by applying the morphism before taking the target quotient. -/
@@ -182,12 +203,7 @@ lemma quotientIsoOfSurjective_hom_mk (f : H ⟶ K) (hf : Function.Surjective f.h
         (Ideal.Quotient.mk (I.comap f.hom hf).toIdeal x) =
       Ideal.Quotient.mkₐ R I.toIdeal (f.hom x) := by
   rw [quotientIsoOfSurjective]
-  exact HopfIdeal.kerLiftBialgEquiv_apply
-    ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
-    ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) _ |>.trans <|
-      HopfIdeal.kerLiftBialgHom_mk
-        ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
-        ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) x
+  exact quotientIsoOfSurjectiveAux_hom_mk f hf I _ _ x
 
 /-- An isomorphism of commutative Hopf algebras induces an isomorphism from the quotient by
 the inverse-image Hopf ideal to the corresponding quotient of the target. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -33,6 +33,8 @@ the finite-type coordinate-Hopf-algebra category.
 * `TauCeti.FiniteTypeCommHopfAlgCat.liftQuotient`: the induced morphism out of a quotient.
 * `TauCeti.CommHopfAlgCat.quotientMapOfLe`: the morphism `H ⧸ I ⟶ H ⧸ J` induced by
   `I ≤ J`.
+* `TauCeti.CommHopfAlgCat.quotientBotIso`: quotienting by the zero Hopf ideal does not
+  change a commutative Hopf algebra.
 
 ## References
 
@@ -134,6 +136,27 @@ lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
     _ = (liftQuotient I f hf).hom (Ideal.Quotient.mkₐ R I.toIdeal h) :=
       (liftQuotient_mk I f hf h).symm
 
+private lemma bot_le_ker_id (H : _root_.CommHopfAlgCat.{v} R) :
+    (⊥ : HopfIdeal R H).toIdeal ≤
+      RingHom.ker (𝟙 H : H ⟶ H).hom.toAlgHom.toRingHom := by
+  simp
+
+/-- Quotienting a commutative Hopf algebra by the zero Hopf ideal gives an isomorphic object
+of `CommHopfAlgCat`. -/
+noncomputable def quotientBotIso (H : _root_.CommHopfAlgCat.{v} R) :
+    quotient H (⊥ : HopfIdeal R H) ≅ H where
+  hom := liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (bot_le_ker_id H)
+  inv := mkQuotient H (⊥ : HopfIdeal R H)
+  hom_inv_id := by
+    ext q
+    obtain ⟨h, rfl⟩ :=
+      Ideal.Quotient.mkₐ_surjective R (⊥ : HopfIdeal R H).toIdeal q
+    rw [_root_.CommHopfAlgCat.comp_apply,
+      liftQuotient_mk (hf := bot_le_ker_id H), mkQuotient_apply]
+    rfl
+  inv_hom_id := mkQuotient_comp_liftQuotient
+    (⊥ : HopfIdeal R H) (𝟙 H) (bot_le_ker_id H)
+
 /-- If `I ≤ J`, then the quotient map by `J` kills every element of `I`. -/
 lemma toIdeal_le_ker_mkQuotient_of_le
     (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
@@ -199,6 +222,12 @@ finite-type commutative Hopf algebra. -/
 noncomputable abbrev quotient (H : FiniteTypeCommHopfAlgCat.{u, v} R) (I : HopfIdeal R H) :
     FiniteTypeCommHopfAlgCat.{u, v} R :=
   ⟨CommHopfAlgCat.quotient H.obj I, inferInstanceAs (Algebra.FiniteType R (H ⧸ I.toIdeal))⟩
+
+/-- Quotienting a finite-type commutative Hopf algebra by the zero Hopf ideal gives an
+isomorphic finite-type commutative Hopf algebra. -/
+noncomputable def quotientBotIso (H : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    quotient H (⊥ : HopfIdeal R H) ≅ H :=
+  ObjectProperty.isoMk _ (CommHopfAlgCat.quotientBotIso H.obj)
 
 /-- The quotient morphism `H ⟶ H ⧸ I` in `FiniteTypeCommHopfAlgCat`. -/
 noncomputable abbrev mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -6,9 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.FiniteType
+public import Mathlib.CategoryTheory.ConcreteCategory.EpiMono
 public import TauCeti.Algebra.AlgebraicGroup.FiniteType.CommHopfAlgCat
 public import TauCeti.Algebra.Bialgebra.Quotient
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Comap
 
 /-!
 # Hopf-ideal quotients of finite-type commutative Hopf algebras
@@ -35,6 +37,8 @@ the finite-type coordinate-Hopf-algebra category.
   `I ≤ J`.
 * `TauCeti.CommHopfAlgCat.quotientBotIso`: quotienting by the zero Hopf ideal does not
   change a commutative Hopf algebra.
+* `TauCeti.CommHopfAlgCat.quotientIsoOfIso`: an ambient isomorphism induces an isomorphism
+  between the corresponding Hopf-ideal quotients.
 
 ## References
 
@@ -135,6 +139,40 @@ lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
     _ = f.hom h := by rw [hg]
     _ = (liftQuotient I f hf).hom (Ideal.Quotient.mkₐ R I.toIdeal h) :=
       (liftQuotient_mk I f hf h).symm
+
+/-- An isomorphism of commutative Hopf algebras induces an isomorphism from the quotient by
+the inverse-image Hopf ideal to the corresponding quotient of the target. -/
+noncomputable def quotientIsoOfIso (e : H ≅ K) (I : HopfIdeal R K) :
+    quotient H (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2) ≅
+      quotient K I := by
+  let J := I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2
+  let φ : quotient H J ⟶ quotient K I :=
+    liftQuotient J (e.hom ≫ mkQuotient K I) (by
+      intro x hx
+      rw [RingHom.mem_ker]
+      change (mkQuotient K I).hom (e.hom.hom x) = 0
+      rw [mkQuotient_eq_zero_iff]
+      exact HopfIdeal.mem_toIdeal.mpr (HopfIdeal.mem_comap.mp (HopfIdeal.mem_toIdeal.mp hx)))
+  let ψ : quotient K I ⟶ quotient H J :=
+    liftQuotient I (e.inv ≫ mkQuotient H J) (by
+      intro y hy
+      rw [RingHom.mem_ker]
+      change (mkQuotient H J).hom (e.inv.hom y) = 0
+      rw [mkQuotient_eq_zero_iff]
+      apply HopfIdeal.mem_toIdeal.mpr
+      apply HopfIdeal.mem_comap.mpr
+      simpa using HopfIdeal.mem_toIdeal.mp hy)
+  exact
+    { hom := φ
+      inv := ψ
+      hom_inv_id := by
+        ext q
+        obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective R J.toIdeal q
+        simp [φ, ψ]
+      inv_hom_id := by
+        ext q
+        obtain ⟨y, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+        simp [φ, ψ] }
 
 private lemma bot_le_ker_id (H : _root_.CommHopfAlgCat.{v} R) :
     (⊥ : HopfIdeal R H).toIdeal ≤

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -18,7 +18,9 @@ public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Comap
 This file packages the quotient of a finite-type commutative Hopf algebra by a Hopf ideal
 as another object of `FiniteTypeCommHopfAlgCat`. The Hopf algebra structure and quotient
 bialgebra morphism are supplied by Mathlib's quotient instances and morphisms; the only extra
-ingredient here is that finite type descends along the surjective quotient algebra map.
+ingredient needed for the finite-type wrapper is that finite type descends along the surjective
+quotient algebra map. The file also transports quotients along surjective ambient morphisms and
+identifies the quotient by the zero Hopf ideal with the original Hopf algebra.
 
 This is a small Layer 3 prerequisite for the reductive-groups roadmap target
 "Hopf ideals ↔ closed subgroup schemes": once closed subgroup schemes are represented by
@@ -37,8 +39,13 @@ the finite-type coordinate-Hopf-algebra category.
   `I ≤ J`.
 * `TauCeti.CommHopfAlgCat.quotientBotIso`: quotienting by the zero Hopf ideal does not
   change a commutative Hopf algebra.
-* `TauCeti.CommHopfAlgCat.quotientIsoOfIso`: an ambient isomorphism induces an isomorphism
-  between the corresponding Hopf-ideal quotients.
+* `TauCeti.CommHopfAlgCat.quotientIsoOfSurjective`: a surjective ambient morphism identifies
+  the source quotient by an inverse-image Hopf ideal with the target quotient.
+* `TauCeti.CommHopfAlgCat.quotientIsoOfIso`: the specialization to an ambient isomorphism.
+* `TauCeti.FiniteTypeCommHopfAlgCat.quotientIsoOfIso`: an ambient isomorphism induces an
+  isomorphism between the corresponding finite-type Hopf-ideal quotients.
+* `TauCeti.FiniteTypeCommHopfAlgCat.quotientBotIso`: quotienting by the zero Hopf ideal does
+  not change a finite-type commutative Hopf algebra.
 
 ## References
 
@@ -140,48 +147,63 @@ lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
     _ = (liftQuotient I f hf).hom (Ideal.Quotient.mkₐ R I.toIdeal h) :=
       (liftQuotient_mk I f hf h).symm
 
+/-- A surjective morphism of commutative Hopf algebras identifies the quotient by the
+inverse-image Hopf ideal with the corresponding quotient of the target. -/
+noncomputable def quotientIsoOfSurjective (f : H ⟶ K) (hf : Function.Surjective f.hom)
+    (I : HopfIdeal R K) : quotient H (I.comap f.hom hf) ≅ quotient K I :=
+  _root_.CommHopfAlgCat.isoMk <|
+    HopfIdeal.kerLiftBialgEquiv
+      ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+      ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf)
+
+/-- The forward quotient isomorphism induced by a surjective morphism commutes with the
+quotient morphisms. -/
+@[simp]
+lemma mkQuotient_comp_quotientIsoOfSurjective_hom (f : H ⟶ K)
+    (hf : Function.Surjective f.hom) (I : HopfIdeal R K) :
+    mkQuotient H (I.comap f.hom hf) ≫ (quotientIsoOfSurjective f hf I).hom =
+      f ≫ mkQuotient K I := by
+  ext x
+  rw [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.comp_apply,
+    mkQuotient_apply, mkQuotient_apply, quotientIsoOfSurjective]
+  exact HopfIdeal.kerLiftBialgEquiv_apply
+    ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+    ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) _ |>.trans <|
+      HopfIdeal.kerLiftBialgHom_mk
+        ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+        ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) x
+
+/-- The forward quotient isomorphism induced by a surjective morphism evaluates on quotient
+classes by applying the morphism before taking the target quotient. -/
+@[simp]
+lemma quotientIsoOfSurjective_hom_mk (f : H ⟶ K) (hf : Function.Surjective f.hom)
+    (I : HopfIdeal R K) (x : H) :
+    (quotientIsoOfSurjective f hf I).hom.hom
+        (Ideal.Quotient.mkₐ R (I.comap f.hom hf).toIdeal x) =
+      Ideal.Quotient.mkₐ R I.toIdeal (f.hom x) := by
+  rw [quotientIsoOfSurjective]
+  exact HopfIdeal.kerLiftBialgEquiv_apply
+    ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+    ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) _ |>.trans <|
+      HopfIdeal.kerLiftBialgHom_mk
+        ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f.hom)
+        ((Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) x
+
 /-- An isomorphism of commutative Hopf algebras induces an isomorphism from the quotient by
 the inverse-image Hopf ideal to the corresponding quotient of the target. -/
 noncomputable def quotientIsoOfIso (e : H ≅ K) (I : HopfIdeal R K) :
     quotient H (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2) ≅
-      quotient K I := by
-  let J := I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2
-  let φ : quotient H J ⟶ quotient K I :=
-    liftQuotient J (e.hom ≫ mkQuotient K I) (by
-      intro x hx
-      rw [RingHom.mem_ker]
-      change (mkQuotient K I).hom (e.hom.hom x) = 0
-      rw [mkQuotient_eq_zero_iff]
-      exact HopfIdeal.mem_toIdeal.mpr (HopfIdeal.mem_comap.mp (HopfIdeal.mem_toIdeal.mp hx)))
-  let ψ : quotient K I ⟶ quotient H J :=
-    liftQuotient I (e.inv ≫ mkQuotient H J) (by
-      intro y hy
-      rw [RingHom.mem_ker]
-      change (mkQuotient H J).hom (e.inv.hom y) = 0
-      rw [mkQuotient_eq_zero_iff]
-      apply HopfIdeal.mem_toIdeal.mpr
-      apply HopfIdeal.mem_comap.mpr
-      simpa using HopfIdeal.mem_toIdeal.mp hy)
-  exact
-    { hom := φ
-      inv := ψ
-      hom_inv_id := by
-        ext q
-        obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective R J.toIdeal q
-        simp [φ, ψ]
-      inv_hom_id := by
-        ext q
-        obtain ⟨y, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-        simp [φ, ψ] }
+      quotient K I :=
+  quotientIsoOfSurjective e.hom (ConcreteCategory.bijective_of_isIso e.hom).2 I
 
 /-- The forward map of the quotient isomorphism commutes with the quotient morphisms. -/
 @[simp]
 lemma mkQuotient_comp_quotientIsoOfIso_hom (e : H ≅ K) (I : HopfIdeal R K) :
     mkQuotient H (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2) ≫
         (quotientIsoOfIso e I).hom =
-      e.hom ≫ mkQuotient K I := by
-  simp only [quotientIsoOfIso]
-  apply mkQuotient_comp_liftQuotient
+      e.hom ≫ mkQuotient K I :=
+  mkQuotient_comp_quotientIsoOfSurjective_hom e.hom
+    (ConcreteCategory.bijective_of_isIso e.hom).2 I
 
 /-- The inverse map of the quotient isomorphism commutes with the quotient morphisms. -/
 @[simp]
@@ -189,10 +211,43 @@ lemma mkQuotient_comp_quotientIsoOfIso_inv (e : H ≅ K) (I : HopfIdeal R K) :
     mkQuotient K I ≫ (quotientIsoOfIso e I).inv =
       e.inv ≫ mkQuotient H
         (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2) := by
-  simp only [quotientIsoOfIso]
-  apply mkQuotient_comp_liftQuotient
+  rw [← cancel_mono (quotientIsoOfIso e I).hom]
+  simp only [Category.assoc, Iso.inv_hom_id, Category.comp_id,
+    mkQuotient_comp_quotientIsoOfIso_hom, Iso.inv_hom_id_assoc]
 
-private lemma bot_le_ker_id (H : _root_.CommHopfAlgCat.{v} R) :
+/-- The forward quotient isomorphism induced by an ambient isomorphism evaluates on quotient
+classes by applying the ambient isomorphism before taking the target quotient. -/
+@[simp]
+lemma quotientIsoOfIso_hom_mk (e : H ≅ K) (I : HopfIdeal R K) (x : H) :
+    (quotientIsoOfIso e I).hom.hom
+        (Ideal.Quotient.mkₐ R
+          (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2).toIdeal x) =
+      Ideal.Quotient.mkₐ R I.toIdeal (e.hom.hom x) :=
+  quotientIsoOfSurjective_hom_mk e.hom
+    (ConcreteCategory.bijective_of_isIso e.hom).2 I x
+
+/-- The inverse quotient isomorphism induced by an ambient isomorphism evaluates on quotient
+classes by applying the inverse ambient isomorphism before taking the source quotient. -/
+@[simp]
+lemma quotientIsoOfIso_inv_mk (e : H ≅ K) (I : HopfIdeal R K) (y : K) :
+    (quotientIsoOfIso e I).inv.hom (Ideal.Quotient.mkₐ R I.toIdeal y) =
+      Ideal.Quotient.mkₐ R
+        (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2).toIdeal
+        (e.inv.hom y) := by
+  calc
+    (quotientIsoOfIso e I).inv.hom (Ideal.Quotient.mkₐ R I.toIdeal y) =
+        (mkQuotient K I ≫ (quotientIsoOfIso e I).inv).hom y := by
+      rw [_root_.CommHopfAlgCat.comp_apply, mkQuotient_apply]
+    _ = (e.inv ≫ mkQuotient H
+        (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2)).hom y := by
+      rw [mkQuotient_comp_quotientIsoOfIso_inv]
+    _ = Ideal.Quotient.mkₐ R
+        (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2).toIdeal
+        (e.inv.hom y) := by
+      rw [_root_.CommHopfAlgCat.comp_apply, mkQuotient_apply]
+
+/-- The zero Hopf ideal is contained in the kernel of the identity morphism. -/
+lemma bot_le_ker_id (H : _root_.CommHopfAlgCat.{v} R) :
     (⊥ : HopfIdeal R H).toIdeal ≤
       RingHom.ker (𝟙 H : H ⟶ H).hom.toAlgHom.toRingHom := by
   simp
@@ -217,7 +272,7 @@ noncomputable def quotientBotIso (H : _root_.CommHopfAlgCat.{v} R) :
 @[simp]
 lemma quotientBotIso_hom (H : _root_.CommHopfAlgCat.{v} R) :
     (quotientBotIso H).hom =
-      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (by simp) :=
+      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (bot_le_ker_id H) :=
   by rw [quotientBotIso]
 
 /-- The inverse map of the quotient-by-zero isomorphism is the quotient morphism. -/
@@ -332,6 +387,42 @@ lemma mkQuotient_eq_zero_iff (H : FiniteTypeCommHopfAlgCat.{u, v} R)
 
 variable {H K : FiniteTypeCommHopfAlgCat.{u, v} R}
 
+/-- An isomorphism of finite-type commutative Hopf algebras induces an isomorphism from the
+quotient by the inverse-image Hopf ideal to the corresponding quotient of the target. -/
+noncomputable def quotientIsoOfIso (e : H ≅ K) (I : HopfIdeal R K) :
+    quotient H
+        (I.comap (toBialgHom e.hom) (ConcreteCategory.bijective_of_isIso e.hom).2) ≅
+      quotient K I :=
+  ObjectProperty.isoMk _ <|
+    CommHopfAlgCat.quotientIsoOfIso
+      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+        (_root_.CommHopfAlgCat.{v} R)).mapIso e) I
+
+/-- The forward finite-type quotient isomorphism commutes with the quotient morphisms. -/
+@[simp]
+lemma mkQuotient_comp_quotientIsoOfIso_hom (e : H ≅ K) (I : HopfIdeal R K) :
+    mkQuotient H
+          (I.comap (toBialgHom e.hom) (ConcreteCategory.bijective_of_isIso e.hom).2) ≫
+        (quotientIsoOfIso e I).hom =
+      e.hom ≫ mkQuotient K I := by
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (_root_.CommHopfAlgCat.{v} R)).map_injective
+  exact CommHopfAlgCat.mkQuotient_comp_quotientIsoOfIso_hom
+    ((forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+      (_root_.CommHopfAlgCat.{v} R)).mapIso e) I
+
+/-- The inverse finite-type quotient isomorphism commutes with the quotient morphisms. -/
+@[simp]
+lemma mkQuotient_comp_quotientIsoOfIso_inv (e : H ≅ K) (I : HopfIdeal R K) :
+    mkQuotient K I ≫ (quotientIsoOfIso e I).inv =
+      e.inv ≫ mkQuotient H
+        (I.comap (toBialgHom e.hom) (ConcreteCategory.bijective_of_isIso e.hom).2) := by
+  apply (forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+    (_root_.CommHopfAlgCat.{v} R)).map_injective
+  exact CommHopfAlgCat.mkQuotient_comp_quotientIsoOfIso_inv
+    ((forget₂ (FiniteTypeCommHopfAlgCat.{u, v} R)
+      (_root_.CommHopfAlgCat.{v} R)).mapIso e) I
+
 /-- A morphism of finite-type commutative Hopf algebras out of `H` which kills a Hopf ideal
 factors through the quotient object. -/
 noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
@@ -342,7 +433,7 @@ noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
 @[simp]
 lemma quotientBotIso_hom (H : FiniteTypeCommHopfAlgCat.{u, v} R) :
     (quotientBotIso H).hom =
-      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (by simp) :=
+      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (CommHopfAlgCat.bot_le_ker_id H.obj) :=
   by
     rw [quotientBotIso]
     apply ObjectProperty.hom_ext

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -174,6 +174,24 @@ noncomputable def quotientIsoOfIso (e : H ≅ K) (I : HopfIdeal R K) :
         obtain ⟨y, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
         simp [φ, ψ] }
 
+/-- The forward map of the quotient isomorphism commutes with the quotient morphisms. -/
+@[simp]
+lemma mkQuotient_comp_quotientIsoOfIso_hom (e : H ≅ K) (I : HopfIdeal R K) :
+    mkQuotient H (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2) ≫
+        (quotientIsoOfIso e I).hom =
+      e.hom ≫ mkQuotient K I := by
+  simp only [quotientIsoOfIso]
+  apply mkQuotient_comp_liftQuotient
+
+/-- The inverse map of the quotient isomorphism commutes with the quotient morphisms. -/
+@[simp]
+lemma mkQuotient_comp_quotientIsoOfIso_inv (e : H ≅ K) (I : HopfIdeal R K) :
+    mkQuotient K I ≫ (quotientIsoOfIso e I).inv =
+      e.inv ≫ mkQuotient H
+        (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2) := by
+  simp only [quotientIsoOfIso]
+  apply mkQuotient_comp_liftQuotient
+
 private lemma bot_le_ker_id (H : _root_.CommHopfAlgCat.{v} R) :
     (⊥ : HopfIdeal R H).toIdeal ≤
       RingHom.ker (𝟙 H : H ⟶ H).hom.toAlgHom.toRingHom := by

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -179,7 +179,7 @@ classes by applying the morphism before taking the target quotient. -/
 lemma quotientIsoOfSurjective_hom_mk (f : H ⟶ K) (hf : Function.Surjective f.hom)
     (I : HopfIdeal R K) (x : H) :
     (quotientIsoOfSurjective f hf I).hom.hom
-        (Ideal.Quotient.mkₐ R (I.comap f.hom hf).toIdeal x) =
+        (Ideal.Quotient.mk (I.comap f.hom hf).toIdeal x) =
       Ideal.Quotient.mkₐ R I.toIdeal (f.hom x) := by
   rw [quotientIsoOfSurjective]
   exact HopfIdeal.kerLiftBialgEquiv_apply
@@ -220,7 +220,7 @@ classes by applying the ambient isomorphism before taking the target quotient. -
 @[simp]
 lemma quotientIsoOfIso_hom_mk (e : H ≅ K) (I : HopfIdeal R K) (x : H) :
     (quotientIsoOfIso e I).hom.hom
-        (Ideal.Quotient.mkₐ R
+        (Ideal.Quotient.mk
           (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2).toIdeal x) =
       Ideal.Quotient.mkₐ R I.toIdeal (e.hom.hom x) :=
   quotientIsoOfSurjective_hom_mk e.hom
@@ -230,7 +230,7 @@ lemma quotientIsoOfIso_hom_mk (e : H ≅ K) (I : HopfIdeal R K) (x : H) :
 classes by applying the inverse ambient isomorphism before taking the source quotient. -/
 @[simp]
 lemma quotientIsoOfIso_inv_mk (e : H ≅ K) (I : HopfIdeal R K) (y : K) :
-    (quotientIsoOfIso e I).inv.hom (Ideal.Quotient.mkₐ R I.toIdeal y) =
+    (quotientIsoOfIso e I).inv.hom (Ideal.Quotient.mk I.toIdeal y) =
       Ideal.Quotient.mkₐ R
         (I.comap e.hom.hom (ConcreteCategory.bijective_of_isIso e.hom).2).toIdeal
         (e.inv.hom y) := by

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -147,6 +147,8 @@ lemma liftQuotient_unique (I : HopfIdeal R H) (f : H ⟶ K)
     _ = (liftQuotient I f hf).hom (Ideal.Quotient.mkₐ R I.toIdeal h) :=
       (liftQuotient_mk I f hf h).symm
 
+/-- Auxiliary quotient isomorphism when the source ideal is the kernel of the composite
+with the target quotient morphism. -/
 private noncomputable def quotientIsoOfSurjectiveAux (f : H ⟶ K)
     (hf : Function.Surjective f.hom) (I : HopfIdeal R K) (J : HopfIdeal R H)
     (hJ : J = HopfIdeal.kerOfSurjective

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -264,33 +264,27 @@ lemma quotientIsoOfIso_inv_mk (e : H ≅ K) (I : HopfIdeal R K) (y : K) :
         (e.inv.hom y) := by
       rw [_root_.CommHopfAlgCat.comp_apply, mkQuotient_apply]
 
-/-- The zero Hopf ideal is contained in the kernel of the identity morphism. -/
-lemma bot_le_ker_id (H : _root_.CommHopfAlgCat.{v} R) :
-    (⊥ : HopfIdeal R H).toIdeal ≤
-      RingHom.ker (𝟙 H : H ⟶ H).hom.toAlgHom.toRingHom := by
-  simp
-
 /-- Quotienting a commutative Hopf algebra by the zero Hopf ideal gives an isomorphic object
 of `CommHopfAlgCat`. -/
 noncomputable def quotientBotIso (H : _root_.CommHopfAlgCat.{v} R) :
     quotient H (⊥ : HopfIdeal R H) ≅ H where
-  hom := liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (bot_le_ker_id H)
+  hom := liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) bot_le
   inv := mkQuotient H (⊥ : HopfIdeal R H)
   hom_inv_id := by
     ext q
     obtain ⟨h, rfl⟩ :=
       Ideal.Quotient.mkₐ_surjective R (⊥ : HopfIdeal R H).toIdeal q
     rw [_root_.CommHopfAlgCat.comp_apply,
-      liftQuotient_mk (hf := bot_le_ker_id H), mkQuotient_apply]
+      liftQuotient_mk (hf := bot_le), mkQuotient_apply]
     rfl
   inv_hom_id := mkQuotient_comp_liftQuotient
-    (⊥ : HopfIdeal R H) (𝟙 H) (bot_le_ker_id H)
+    (⊥ : HopfIdeal R H) (𝟙 H) bot_le
 
 /-- The forward map of the quotient-by-zero isomorphism is the lift of the identity. -/
 @[simp]
 lemma quotientBotIso_hom (H : _root_.CommHopfAlgCat.{v} R) :
     (quotientBotIso H).hom =
-      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (bot_le_ker_id H) :=
+      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) bot_le :=
   by rw [quotientBotIso]
 
 /-- The inverse map of the quotient-by-zero isomorphism is the quotient morphism. -/
@@ -451,7 +445,7 @@ noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
 @[simp]
 lemma quotientBotIso_hom (H : FiniteTypeCommHopfAlgCat.{u, v} R) :
     (quotientBotIso H).hom =
-      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (CommHopfAlgCat.bot_le_ker_id H.obj) :=
+      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) bot_le :=
   by
     rw [quotientBotIso]
     apply ObjectProperty.hom_ext

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -157,6 +157,19 @@ noncomputable def quotientBotIso (H : _root_.CommHopfAlgCat.{v} R) :
   inv_hom_id := mkQuotient_comp_liftQuotient
     (⊥ : HopfIdeal R H) (𝟙 H) (bot_le_ker_id H)
 
+/-- The forward map of the quotient-by-zero isomorphism is the lift of the identity. -/
+@[simp]
+lemma quotientBotIso_hom (H : _root_.CommHopfAlgCat.{v} R) :
+    (quotientBotIso H).hom =
+      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (by simp) :=
+  by rw [quotientBotIso]
+
+/-- The inverse map of the quotient-by-zero isomorphism is the quotient morphism. -/
+@[simp]
+lemma quotientBotIso_inv (H : _root_.CommHopfAlgCat.{v} R) :
+    (quotientBotIso H).inv = mkQuotient H (⊥ : HopfIdeal R H) :=
+  by rw [quotientBotIso]
+
 /-- If `I ≤ J`, then the quotient map by `J` kills every element of `I`. -/
 lemma toIdeal_le_ker_mkQuotient_of_le
     (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H} (hIJ : I ≤ J) :
@@ -234,6 +247,15 @@ noncomputable abbrev mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
     (I : HopfIdeal R H) : H ⟶ quotient H I :=
   ObjectProperty.homMk (CommHopfAlgCat.mkQuotient H.obj I)
 
+/-- The inverse map of the finite-type quotient-by-zero isomorphism is the quotient morphism. -/
+@[simp]
+lemma quotientBotIso_inv (H : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    (quotientBotIso H).inv = mkQuotient H (⊥ : HopfIdeal R H) :=
+  by
+    rw [quotientBotIso]
+    apply ObjectProperty.hom_ext
+    exact CommHopfAlgCat.quotientBotIso_inv H.obj
+
 /-- The finite-type quotient morphism forgets to the `CommHopfAlgCat` quotient morphism. -/
 lemma forget₂_commHopfAlgCat_map_mkQuotient (H : FiniteTypeCommHopfAlgCat.{u, v} R)
     (I : HopfIdeal R H) :
@@ -259,6 +281,16 @@ factors through the quotient object. -/
 noncomputable abbrev liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)
     (hf : I.toIdeal ≤ RingHom.ker (toBialgHom f).toAlgHom.toRingHom) : quotient H I ⟶ K :=
   ObjectProperty.homMk (CommHopfAlgCat.liftQuotient I f.hom hf)
+
+/-- The forward map of the finite-type quotient-by-zero isomorphism is the lift of the identity. -/
+@[simp]
+lemma quotientBotIso_hom (H : FiniteTypeCommHopfAlgCat.{u, v} R) :
+    (quotientBotIso H).hom =
+      liftQuotient (⊥ : HopfIdeal R H) (𝟙 H) (by simp) :=
+  by
+    rw [quotientBotIso]
+    apply ObjectProperty.hom_ext
+    exact CommHopfAlgCat.quotientBotIso_hom H.obj
 
 /-- The finite-type quotient lift forgets to the `CommHopfAlgCat` quotient lift. -/
 lemma forget₂_commHopfAlgCat_map_liftQuotient (I : HopfIdeal R H) (f : H ⟶ K)

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -24,10 +24,10 @@ This formulation is equivalent to triviality of the geometric unipotent radical 
 has been constructed, but it does not make the definition wait for that construction. It also
 avoids asserting descent of the geometric unipotent radical over an imperfect field.
 
-The first structural consequence verifies that the predicate has its intended force: if the
-geometric fibre of a reductive group is itself unipotent, its coordinate Hopf algebra is the base
-field. The resulting bialgebra equivalence is the precise affine-group statement that the
-geometric fibre is the trivial group.
+Instantiating the definition at the zero Hopf ideal—the whole geometric fibre as a subgroup of
+itself—shows that if the geometric fibre of a reductive group is itself unipotent, its coordinate
+Hopf algebra is the algebraic closure of the ground field. The resulting bialgebra equivalence is
+the precise affine-group statement that the geometric fibre is the trivial group.
 
 ## Main declarations
 
@@ -35,12 +35,14 @@ geometric fibre is the trivial group.
   over a field.
 * `TauCeti.reductiveCommHopfAlgProperty.eq_augmentation`: every connected normal smooth
   unipotent closed subgroup of a reductive group's geometric fibre is trivial.
-* `TauCeti.reductiveCommHopfAlgProperty.geometricFiberBialgEquivBase`: a reductive group with
+* `TauCeti.reductiveCommHopfAlgProperty.bot_eq_augmentation`: the zero Hopf ideal of a reductive
+  group with unipotent geometric fibre is its augmentation ideal.
+* `TauCeti.reductiveCommHopfAlgProperty.geometricFiberCounitBialgEquiv`: a reductive group with
   geometrically unipotent geometric fibre has trivial geometric fibre.
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), Definition 17.1.
+* J. S. Milne, *Algebraic Groups* (2017), §6.46 and §19.b.
 * T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
 * B. Conrad, *Reductive Group Schemes*, Section 3.
 
@@ -121,23 +123,20 @@ instance (k : Type u) [Field k] :
       (ConcreteCategory.bijective_of_isIso ebar₀.hom).1
     have hfsurjective : Function.Surjective f :=
       (ConcreteCategory.bijective_of_isIso ebar₀.hom).2
-    have hsmooth : Algebra.Smooth k
-        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k) (CommHopfAlgCat.{u} k)).obj K) := by
-      let _ : Algebra.Smooth k
-          ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k) (CommHopfAlgCat.{u} k)).obj H) := hH.1
-      exact Algebra.Smooth.of_equiv (CommHopfAlgCat.ofIso e₀).toAlgEquiv
-    refine ⟨hsmooth,
+    refine ⟨(smoothCommHopfAlgProperty_iff K.obj).mp <|
+        (smoothCommHopfAlgProperty k).prop_of_iso e₀
+          ((smoothCommHopfAlgProperty_iff H.obj).mpr hH.1),
       (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀ hH.2.1, ?_⟩
     intro I hnormal hconnected hunipotent
     let J := I.comap f hfsurjective
-    have hnormalJ : J.IsNormal := HopfIdeal.IsNormal.comap_bijective
-      I f hfinjective hfsurjective hnormal
-    let qIso₀ : CommHopfAlgCat.quotient Hbar.obj J ≅
-        CommHopfAlgCat.quotient Kbar.obj I :=
-      CommHopfAlgCat.quotientIsoOfIso ebar₀ I
+    have hnormalJ : J.IsNormal :=
+      hnormal.comap_of_bijective f hfinjective hfsurjective
     let qIso : FiniteTypeCommHopfAlgCat.quotient Hbar J ≅
         FiniteTypeCommHopfAlgCat.quotient Kbar I :=
-      ObjectProperty.isoMk _ qIso₀
+      FiniteTypeCommHopfAlgCat.quotientIsoOfIso ebar I
+    let qIso₀ := (forget₂
+      (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso qIso
     have hconnectedJ : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj :=
       (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
@@ -147,21 +146,9 @@ instance (k : Type u) [Field k] :
       (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
         qIso.symm hunipotent
     have hJ := hH.2.2 J hnormalJ hconnectedJ hunipotentJ
-    change J = HopfIdeal.augmentation (AlgebraicClosure k) Hbar at hJ
-    have haugmentation :
-        (HopfIdeal.augmentation (AlgebraicClosure k) Kbar).comap f hfsurjective =
-          HopfIdeal.augmentation (AlgebraicClosure k) Hbar := by
-      ext x
-      rw [HopfIdeal.mem_comap, HopfIdeal.mem_augmentation, HopfIdeal.mem_augmentation,
-        CoalgHomClass.counit_comp_apply]
-    change I = HopfIdeal.augmentation (AlgebraicClosure k) Kbar
-    apply le_antisymm
-    · apply HopfIdeal.le_of_comap_le_comap_of_surjective f hfsurjective
-      change J ≤ (HopfIdeal.augmentation (AlgebraicClosure k) Kbar).comap f hfsurjective
-      rw [hJ, haugmentation]
-    · apply HopfIdeal.le_of_comap_le_comap_of_surjective f hfsurjective
-      change (HopfIdeal.augmentation (AlgebraicClosure k) Kbar).comap f hfsurjective ≤ J
-      rw [haugmentation, hJ]
+    rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hfsurjective,
+      HopfIdeal.comap_augmentation]
+    exact hJ
 
 namespace reductiveCommHopfAlgProperty
 
@@ -221,36 +208,27 @@ theorem bot_eq_augmentation (hH : reductiveCommHopfAlgProperty k H)
 /-- A reductive group whose geometric fibre has only unipotent geometric points has trivial
 geometric fibre: its coordinate Hopf algebra is bialgebra-equivalent to the algebraic closure of
 the ground field via the counit. -/
-noncomputable def geometricFiberBialgEquivBase
+noncomputable def geometricFiberCounitBialgEquiv
     (hH : reductiveCommHopfAlgProperty k H)
     (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
     FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H ≃ₐc[AlgebraicClosure k]
-      AlgebraicClosure k := by
-  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
-  have hbijective : Function.Bijective
-      (Bialgebra.counitBialgHom (AlgebraicClosure k) Hbar) := by
-    constructor
-    · apply (HopfIdeal.ker_eq_bot_iff
-        (Bialgebra.counitBialgHom (AlgebraicClosure k) Hbar)
-        Bialgebra.counit_surjective).mp
-      rw [← HopfIdeal.augmentation_def]
-      exact (hH.bot_eq_augmentation hunipotent).symm
-    · exact Bialgebra.counit_surjective
-  exact BialgEquiv.ofBijective
-    (Bialgebra.counitBialgHom (AlgebraicClosure k) Hbar) hbijective
+      AlgebraicClosure k :=
+  HopfIdeal.counitBialgEquivOfAugmentationEqBot
+    (hH.bot_eq_augmentation hunipotent).symm
 
-/-- The equivalence from the geometric fibre to the base field is its counit. -/
+/-- The equivalence from the geometric fibre to the algebraic closure is its counit. -/
 @[simp]
-theorem geometricFiberBialgEquivBase_apply
+theorem geometricFiberCounitBialgEquiv_apply
     (hH : reductiveCommHopfAlgProperty k H)
     (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)
     (x : FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :
-    hH.geometricFiberBialgEquivBase hunipotent x =
+    hH.geometricFiberCounitBialgEquiv hunipotent x =
       Bialgebra.counitBialgHom (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) x := by
-  rfl
+  rw [geometricFiberCounitBialgEquiv]
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_apply _ _
 
 end reductiveCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -230,6 +230,19 @@ theorem geometricFiberCounitBialgEquiv_apply
   rw [geometricFiberCounitBialgEquiv]
   exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_apply _ _
 
+/-- The inverse equivalence from the algebraic closure is the geometric fibre's structure map. -/
+@[simp]
+theorem geometricFiberCounitBialgEquiv_symm_apply
+    (hH : reductiveCommHopfAlgProperty k H)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)
+    (r : AlgebraicClosure k) :
+    (hH.geometricFiberCounitBialgEquiv hunipotent).symm r =
+      algebraMap (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) r := by
+  rw [geometricFiberCounitBialgEquiv]
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_symm_apply _ _
+
 end reductiveCommHopfAlgProperty
 
 end

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -103,6 +103,66 @@ theorem reductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
                 (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
   Iff.rfl
 
+/-- Reductivity is invariant under isomorphisms of finite-type commutative Hopf algebras. -/
+instance (k : Type u) [Field k] :
+    (reductiveCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
+  of_iso {H K} e hH := by
+    rw [reductiveCommHopfAlgProperty_iff] at hH ⊢
+    let e₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+      (CommHopfAlgCat.{u} k)).mapIso e
+    let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+    let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
+    let ebar := (FiniteTypeCommHopfAlgCat.baseChangeFunctor
+      (K := AlgebraicClosure k)).mapIso e
+    let ebar₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso ebar
+    let f : Hbar →ₐc[AlgebraicClosure k] Kbar := ebar₀.hom.hom
+    have hfinjective : Function.Injective f :=
+      (ConcreteCategory.bijective_of_isIso ebar₀.hom).1
+    have hfsurjective : Function.Surjective f :=
+      (ConcreteCategory.bijective_of_isIso ebar₀.hom).2
+    have hsmooth : Algebra.Smooth k
+        ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k) (CommHopfAlgCat.{u} k)).obj K) := by
+      let _ : Algebra.Smooth k
+          ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k) (CommHopfAlgCat.{u} k)).obj H) := hH.1
+      exact Algebra.Smooth.of_equiv (CommHopfAlgCat.ofIso e₀).toAlgEquiv
+    refine ⟨hsmooth,
+      (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀ hH.2.1, ?_⟩
+    intro I hnormal hconnected hunipotent
+    let J := I.comap f hfsurjective
+    have hnormalJ : J.IsNormal := HopfIdeal.IsNormal.comap_bijective
+      I f hfinjective hfsurjective hnormal
+    let qIso₀ : CommHopfAlgCat.quotient Hbar.obj J ≅
+        CommHopfAlgCat.quotient Kbar.obj I :=
+      CommHopfAlgCat.quotientIsoOfIso ebar₀ I
+    let qIso : FiniteTypeCommHopfAlgCat.quotient Hbar J ≅
+        FiniteTypeCommHopfAlgCat.quotient Kbar I :=
+      ObjectProperty.isoMk _ qIso₀
+    have hconnectedJ : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj :=
+      (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+        qIso₀.symm hconnected
+    have hunipotentJ : smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient Hbar J) :=
+      (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+        qIso.symm hunipotent
+    have hJ := hH.2.2 J hnormalJ hconnectedJ hunipotentJ
+    change J = HopfIdeal.augmentation (AlgebraicClosure k) Hbar at hJ
+    have haugmentation :
+        (HopfIdeal.augmentation (AlgebraicClosure k) Kbar).comap f hfsurjective =
+          HopfIdeal.augmentation (AlgebraicClosure k) Hbar := by
+      ext x
+      rw [HopfIdeal.mem_comap, HopfIdeal.mem_augmentation, HopfIdeal.mem_augmentation,
+        CoalgHomClass.counit_comp_apply]
+    change I = HopfIdeal.augmentation (AlgebraicClosure k) Kbar
+    apply le_antisymm
+    · apply HopfIdeal.le_of_comap_le_comap_of_surjective f hfsurjective
+      change J ≤ (HopfIdeal.augmentation (AlgebraicClosure k) Kbar).comap f hfsurjective
+      rw [hJ, haugmentation]
+    · apply HopfIdeal.le_of_comap_le_comap_of_surjective f hfsurjective
+      change (HopfIdeal.augmentation (AlgebraicClosure k) Kbar).comap f hfsurjective ≤ J
+      rw [haugmentation, hJ]
+
 namespace reductiveCommHopfAlgProperty
 
 variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+
+/-!
+# Reductive affine groups
+
+A finite-type affine group over a field is reductive when it is smooth and geometrically
+connected and, after extension to an algebraic closure, it has no nontrivial connected normal
+smooth unipotent closed subgroup. In coordinate-Hopf-algebra terms, a closed subgroup of the
+geometric fibre is a Hopf-ideal quotient. The subgroup is trivial exactly when its defining Hopf
+ideal is the augmentation ideal.
+
+This formulation is equivalent to triviality of the geometric unipotent radical once that radical
+has been constructed, but it does not make the definition wait for that construction. It also
+avoids asserting descent of the geometric unipotent radical over an imperfect field.
+
+The first structural consequence verifies that the predicate has its intended force: if the
+geometric fibre of a reductive group is itself unipotent, its coordinate Hopf algebra is the base
+field. The resulting bialgebra equivalence is the precise affine-group statement that the
+geometric fibre is the trivial group.
+
+## Main declarations
+
+* `TauCeti.reductiveCommHopfAlgProperty`: reductivity for finite-type commutative Hopf algebras
+  over a field.
+* `TauCeti.reductiveCommHopfAlgProperty.eq_augmentation`: every connected normal smooth
+  unipotent closed subgroup of a reductive group's geometric fibre is trivial.
+* `TauCeti.reductiveCommHopfAlgProperty.geometricFiberBialgEquivBase`: a reductive group with
+  geometrically unipotent geometric fibre has trivial geometric fibre.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Definition 17.1.
+* T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
+* B. Conrad, *Reductive Group Schemes*, Section 3.
+
+This is the definition target in Layer 6, "Reductive and semisimple groups", of the
+ReductiveGroups roadmap. The geometric formulation is the roadmap's prescribed alternative while
+the descended unipotent radical is unavailable.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+/-- The object property selecting reductive finite-type commutative Hopf algebras over a field.
+
+The first two conjuncts express smoothness and geometric connectedness of the ambient group. The
+last says that every connected normal smooth unipotent closed subgroup of the geometric fibre is
+the identity subgroup. A Hopf ideal `I` cuts out that subgroup contravariantly, so identity means
+`I` is the augmentation ideal, not the zero ideal. -/
+def reductiveCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
+  fun H ↦
+    Algebra.Smooth k H ∧
+      geometricallyConnectedCommHopfAlgProperty k H.obj ∧
+        ∀ I : HopfIdeal (AlgebraicClosure k)
+            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H),
+          I.IsNormal →
+            geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
+            smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
+            I = HopfIdeal.augmentation (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+
+/-- Reductivity means smoothness, geometric connectedness, and absence of nontrivial connected
+normal smooth unipotent closed subgroups after extension to an algebraic closure. -/
+theorem reductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    reductiveCommHopfAlgProperty k H ↔
+      Algebra.Smooth k H ∧
+        geometricallyConnectedCommHopfAlgProperty k H.obj ∧
+          ∀ I : HopfIdeal (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H),
+            I.IsNormal →
+              geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.quotient
+                  (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
+              smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.quotient
+                  (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
+              I = HopfIdeal.augmentation (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  Iff.rfl
+
+namespace reductiveCommHopfAlgProperty
+
+variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
+
+/-- A reductive finite-type commutative Hopf algebra is smooth over its ground field. -/
+theorem smooth (hH : reductiveCommHopfAlgProperty k H) : Algebra.Smooth k H :=
+  hH.1
+
+/-- A reductive finite-type commutative Hopf algebra is geometrically connected. -/
+theorem geometricallyConnected (hH : reductiveCommHopfAlgProperty k H) :
+    geometricallyConnectedCommHopfAlgProperty k H.obj :=
+  hH.2.1
+
+/-- Every connected normal smooth unipotent closed subgroup of the geometric fibre of a
+reductive group is the identity subgroup. -/
+theorem eq_augmentation (hH : reductiveCommHopfAlgProperty k H)
+    (I : HopfIdeal (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
+    (hI : I.IsNormal)
+    (hconnected : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj)
+    (hunipotent : smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I)) :
+    I = HopfIdeal.augmentation (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  hH.2.2 I hI hconnected hunipotent
+
+/-- If the geometric fibre of a reductive group has only unipotent geometric points, its zero
+Hopf ideal is the augmentation ideal. Equivalently, the whole geometric fibre is the identity
+subgroup. -/
+theorem bot_eq_augmentation (hH : reductiveCommHopfAlgProperty k H)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
+    (⊥ : HopfIdeal (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) =
+        HopfIdeal.augmentation (AlgebraicClosure k)
+          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+  apply hH.eq_augmentation (I := (⊥ : HopfIdeal (AlgebraicClosure k) Hbar))
+  · exact HopfIdeal.isNormal_bot
+  · exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+        (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso
+          (FiniteTypeCommHopfAlgCat.quotientBotIso Hbar)).symm
+      (geometricallyConnectedCommHopfAlgProperty.baseChange k (AlgebraicClosure k) H.obj
+        hH.geometricallyConnected)
+  · apply (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+      (FiniteTypeCommHopfAlgCat.quotientBotIso Hbar).symm
+    rw [smoothUnipotentCommHopfAlgProperty_iff]
+    refine ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, ?_⟩
+    exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff
+      (AlgebraicClosure k) Hbar.obj).mp hunipotent
+
+/-- A reductive group whose geometric fibre has only unipotent geometric points has trivial
+geometric fibre: its coordinate Hopf algebra is bialgebra-equivalent to the algebraic closure of
+the ground field via the counit. -/
+noncomputable def geometricFiberBialgEquivBase
+    (hH : reductiveCommHopfAlgProperty k H)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
+    FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H ≃ₐc[AlgebraicClosure k]
+      AlgebraicClosure k := by
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+  have hbijective : Function.Bijective
+      (Bialgebra.counitBialgHom (AlgebraicClosure k) Hbar) := by
+    constructor
+    · apply (HopfIdeal.ker_eq_bot_iff
+        (Bialgebra.counitBialgHom (AlgebraicClosure k) Hbar)
+        Bialgebra.counit_surjective).mp
+      rw [← HopfIdeal.augmentation_def]
+      exact (hH.bot_eq_augmentation hunipotent).symm
+    · exact Bialgebra.counit_surjective
+  exact BialgEquiv.ofBijective
+    (Bialgebra.counitBialgHom (AlgebraicClosure k) Hbar) hbijective
+
+end reductiveCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -84,6 +84,7 @@ def reductiveCommHopfAlgProperty (k : Type u) [Field k] :
 
 /-- Reductivity means smoothness, geometric connectedness, and absence of nontrivial connected
 normal smooth unipotent closed subgroups after extension to an algebraic closure. -/
+@[simp]
 theorem reductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     reductiveCommHopfAlgProperty k H ↔

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -180,6 +180,18 @@ noncomputable def geometricFiberBialgEquivBase
   exact BialgEquiv.ofBijective
     (Bialgebra.counitBialgHom (AlgebraicClosure k) Hbar) hbijective
 
+/-- The equivalence from the geometric fibre to the base field is its counit. -/
+@[simp]
+theorem geometricFiberBialgEquivBase_apply
+    (hH : reductiveCommHopfAlgProperty k H)
+    (hunipotent : geometricallyUnipotentPointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)
+    (x : FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :
+    hH.geometricFiberBialgEquivBase hunipotent x =
+      Bialgebra.counitBialgHom (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) x := by
+  rfl
+
 end reductiveCommHopfAlgProperty
 
 end

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -93,7 +93,8 @@ via the counit. -/
 noncomputable def counitBialgEquivOfAugmentationEqBot
     (h : augmentation S K = ⊥) : K ≃ₐc[S] S :=
   BialgEquiv.ofBijective (Bialgebra.counitBialgHom S K)
-    ⟨(ker_eq_bot_iff (Bialgebra.counitBialgHom S K) Bialgebra.counit_surjective).mp
+    ⟨(kerOfSurjective_eq_bot_iff
+        (Bialgebra.counitBialgHom S K) Bialgebra.counit_surjective).mp
         ((augmentation_def S K).symm.trans h),
       Bialgebra.counit_surjective⟩
 
@@ -105,6 +106,18 @@ theorem counitBialgEquivOfAugmentationEqBot_apply
     counitBialgEquivOfAugmentationEqBot h x = Bialgebra.counitBialgHom S K x := by
   rw [counitBialgEquivOfAugmentationEqBot]
   exact congrFun (BialgEquiv.coe_ofBijective (Bialgebra.counitBialgHom S K) _) x
+
+/-- The inverse equivalence from the base ring is the structure map. -/
+@[simp]
+theorem counitBialgEquivOfAugmentationEqBot_symm_apply
+    (h : augmentation S K = ⊥) (r : S) :
+    (counitBialgEquivOfAugmentationEqBot h).symm r = algebraMap S K r := by
+  let e := counitBialgEquivOfAugmentationEqBot h
+  refine e.toMulEquiv.symm_apply_eq.mpr ?_
+  calc
+    r = Bialgebra.counitBialgHom S K (algebraMap S K r) := by simp
+    _ = e (algebraMap S K r) :=
+      (counitBialgEquivOfAugmentationEqBot_apply h (algebraMap S K r)).symm
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.HopfAlgebra.Kernel
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Comap
 
 /-!
 # The augmentation Hopf ideal
@@ -24,6 +24,10 @@ induced morphism of affine group schemes (`TauCeti.CommHopfAlgCat.kernelHopfIdea
 * `TauCeti.HopfIdeal.augmentation`: the augmentation ideal as a Hopf ideal.
 * `TauCeti.HopfIdeal.mem_augmentation` and `TauCeti.HopfIdeal.augmentation_toIdeal`:
   characteristic API.
+* `TauCeti.HopfIdeal.comap_augmentation`: the augmentation ideal is preserved by pullback
+  along a surjective bialgebra morphism.
+* `TauCeti.HopfIdeal.counitBialgEquivOfAugmentationEqBot`: a Hopf algebra with zero
+  augmentation ideal is bialgebra-equivalent to its base ring via the counit.
 
 ## References
 
@@ -37,7 +41,7 @@ namespace TauCeti
 
 namespace HopfIdeal
 
-universe u v
+universe u v w
 
 variable (R : Type u) (H : Type v) [CommRing R] [Ring H] [HopfAlgebra R H]
 
@@ -72,6 +76,35 @@ theorem augmentation_toIdeal :
   ext x
   rw [mem_toIdeal, mem_augmentation, RingHom.mem_ker]
   exact Iff.rfl
+
+variable {S : Type u} {K : Type v} {L : Type w}
+variable [CommRing S] [Ring K] [Ring L]
+variable [HopfAlgebra S K] [HopfAlgebra S L]
+
+/-- Pulling the augmentation ideal back along a surjective bialgebra morphism gives the
+augmentation ideal. -/
+theorem comap_augmentation (f : K →ₐc[S] L) (hf : Function.Surjective f) :
+    (augmentation S L).comap f hf = augmentation S K := by
+  ext x
+  rw [mem_comap, mem_augmentation, mem_augmentation, CoalgHomClass.counit_comp_apply]
+
+/-- A Hopf algebra whose augmentation ideal is zero is bialgebra-equivalent to its base ring
+via the counit. -/
+noncomputable def counitBialgEquivOfAugmentationEqBot
+    (h : augmentation S K = ⊥) : K ≃ₐc[S] S :=
+  BialgEquiv.ofBijective (Bialgebra.counitBialgHom S K)
+    ⟨(ker_eq_bot_iff (Bialgebra.counitBialgHom S K) Bialgebra.counit_surjective).mp
+        ((augmentation_def S K).symm.trans h),
+      Bialgebra.counit_surjective⟩
+
+/-- The equivalence from a Hopf algebra with zero augmentation ideal to its base ring is the
+counit. -/
+@[simp]
+theorem counitBialgEquivOfAugmentationEqBot_apply
+    (h : augmentation S K = ⊥) (x : K) :
+    counitBialgEquivOfAugmentationEqBot h x = Bialgebra.counitBialgHom S K x := by
+  rw [counitBialgEquivOfAugmentationEqBot]
+  exact congrFun (BialgEquiv.coe_ofBijective (Bialgebra.counitBialgHom S K) _) x
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -61,7 +61,7 @@ variable [HopfAlgebra R H] [HopfAlgebra R K] [HopfAlgebra R L]
 
 It is defined as the kernel of the composite `H → K → K/I`; its underlying ideal is the
 ordinary ideal comap of `I.toIdeal`. -/
-@[expose] noncomputable def comap (I : HopfIdeal R K) (f : H →ₐc[R] K)
+noncomputable def comap (I : HopfIdeal R K) (f : H →ₐc[R] K)
     (hf : Function.Surjective f) : HopfIdeal R H :=
   kerOfSurjective ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f)
     (by
@@ -87,6 +87,18 @@ theorem mem_comap {I : HopfIdeal R K} {f : H →ₐc[R] K} {hf : Function.Surjec
     {h : H} : h ∈ I.comap f hf ↔ f h ∈ I := by
   rw [← mem_toIdeal, comap_toIdeal, Ideal.mem_comap]
   exact mem_toIdeal
+
+/-- The inverse image is the kernel of the composite with the quotient morphism. -/
+theorem comap_eq_kerOfSurjective (I : HopfIdeal R K) (f : H →ₐc[R] K)
+    (hf : Function.Surjective f) :
+    I.comap f hf =
+      kerOfSurjective ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f)
+        (by
+          rw [BialgHom.coe_comp]
+          exact (Ideal.Quotient.mkₐ_surjective R I.toIdeal).comp hf) := by
+  ext h
+  rw [mem_comap, mem_kerOfSurjective, BialgHom.comp_apply,
+    Bialgebra.Quotient.mkBialgHom_apply, Ideal.Quotient.eq_zero_iff_mem, mem_toIdeal]
 
 /-- Inverse image of Hopf ideals is monotone. -/
 theorem comap_mono (f : H →ₐc[R] K) (hf : Function.Surjective f)

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.lean
@@ -61,7 +61,7 @@ variable [HopfAlgebra R H] [HopfAlgebra R K] [HopfAlgebra R L]
 
 It is defined as the kernel of the composite `H → K → K/I`; its underlying ideal is the
 ordinary ideal comap of `I.toIdeal`. -/
-noncomputable def comap (I : HopfIdeal R K) (f : H →ₐc[R] K)
+@[expose] noncomputable def comap (I : HopfIdeal R K) (f : H →ₐc[R] K)
     (hf : Function.Surjective f) : HopfIdeal R H :=
   kerOfSurjective ((Bialgebra.Quotient.mkBialgHom I.toIdeal).comp f)
     (by


### PR DESCRIPTION
This PR defines reductivity for finite-type commutative Hopf algebras as smoothness, geometric connectedness, and the absence of nontrivial connected normal smooth unipotent closed subgroups in the geometric fibre, using the geometric formulation explicitly permitted when a descended unipotent radical is unavailable. It adds the canonical quotient-by-zero isomorphism and normality of the zero Hopf ideal, then exercises the definition by proving that a reductive group with unipotent geometric fibre has coordinate Hopf algebra bialgebra-equivalent to the algebraic closure via its counit.

The exact roadmap target is Layer 6, “Reductive and semisimple groups”: “Reductive: smooth, connected, with `R_u(G_{k̄})` trivial.” After this PR, that milestone still needs the semisimple/radical, centre, derived-group, central-isogeny, simply-connected/adjoint, and linearly-reductive characterization developments.

The implementation reuses Mathlib's quotient bialgebra, `BialgEquiv.ofBijective`, and smooth base-change infrastructure; it vendors no Mathlib declarations.

Verified with targeted `lake build`, `tauceti-axioms --changed-since-merge-base origin/main`, and `tauceti-lint-env --changed-since-merge-base origin/main`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"reductivecommhopfalgproperty"}-->

🤖 Prepared with Codex
