### PR TITLE
feat: preserve discriminant forms under lattice operations

### DIFF
--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Operations.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Operations.lean
@@ -85,7 +85,7 @@ theorem mem_dualCarrier_orthogonalSum (L : IntegralLattice V) (M : IntegralLatti
     exact Submodule.add_mem _ (hx z.1 hz.1) (hy z.2 hz.2)
 
 /-- The dual carrier of an orthogonal sum is canonically the product of the dual carriers. -/
-@[expose] def orthogonalSumDualCarrierEquiv (L : IntegralLattice V) (M : IntegralLattice W) :
+def orthogonalSumDualCarrierEquiv (L : IntegralLattice V) (M : IntegralLattice W) :
     (L.orthogonalSum M).dualCarrier ≃ₗ[ℤ] L.dualCarrier × M.dualCarrier where
   toFun x :=
     (⟨x.1.1, (L.mem_dualCarrier_orthogonalSum M x.1).mp x.2 |>.1⟩,
@@ -107,6 +107,14 @@ theorem orthogonalSumDualCarrierEquiv_apply (L : IntegralLattice V) (M : Integra
   by
     apply Prod.ext <;> apply Subtype.ext <;> rfl
 
+/-- The inverse dual-carrier product equivalence acts by assembling the two ambient coordinates. -/
+@[simp]
+theorem coe_orthogonalSumDualCarrierEquiv_symm_apply
+    (L : IntegralLattice V) (M : IntegralLattice W) (x : L.dualCarrier × M.dualCarrier) :
+    ((L.orthogonalSumDualCarrierEquiv M).symm x : V × W) = (x.1.1, x.2.1) :=
+  by
+    apply Prod.ext <;> rfl
+
 /-- Under the dual-carrier product equivalence, the embedded carrier of an orthogonal sum is the
 product of the two embedded carriers. -/
 theorem map_carrierInDual_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
@@ -126,7 +134,6 @@ private def quotientProdLinearEquiv (L : IntegralLattice V) (M : IntegralLattice
   { QuotientAddGroup.prodAddEquiv L.carrierInDual.toAddSubgroup
       M.carrierInDual.toAddSubgroup with
     map_smul' := fun n x ↦ by
-      change _ = n • _
       exact map_zsmul
         (QuotientAddGroup.prodAddEquiv L.carrierInDual.toAddSubgroup
           M.carrierInDual.toAddSubgroup) n x }
@@ -172,11 +179,14 @@ noncomputable def discriminantBilinearIsometryOrthogonalSum
     | _ x =>
       induction y using Submodule.Quotient.induction_on with
       | _ y =>
+        -- The isometry's carrier is definitionally the discriminant group, but this conversion
+        -- is intentionally not part of the public reduction API.
         change (L.discriminantBilinearModule.prod M.discriminantBilinearModule).pairing
             (L.discriminantGroupOrthogonalSumEquiv M (Submodule.Quotient.mk x))
             (L.discriminantGroupOrthogonalSumEquiv M (Submodule.Quotient.mk y)) = _
         rw [discriminantGroupOrthogonalSumEquiv_mk,
           discriminantGroupOrthogonalSumEquiv_mk]
+        -- Use the characteristic pairing lemmas after crossing the bundled-carrier boundary.
         change L.discriminantPairing
             (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).1)
             (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M y).1) +
@@ -198,6 +208,18 @@ theorem discriminantBilinearIsometryOrthogonalSum_toAddEquiv
     (L.discriminantBilinearIsometryOrthogonalSum M).toAddEquiv =
       (L.discriminantGroupOrthogonalSumEquiv M).toAddEquiv :=
   by rw [discriminantBilinearIsometryOrthogonalSum]
+
+/-- The orthogonal-sum discriminant-bilinear isometry acts through the canonical discriminant-group
+equivalence. -/
+@[simp]
+theorem discriminantBilinearIsometryOrthogonalSum_apply
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
+    (x : (L.orthogonalSum M).DiscriminantGroup) :
+    L.discriminantBilinearIsometryOrthogonalSum M x =
+      L.discriminantGroupOrthogonalSumEquiv M x :=
+  by
+    exact congrArg (fun e ↦ e x)
+      (L.discriminantBilinearIsometryOrthogonalSum_toAddEquiv M)
 
 /-- The orthogonal-sum discriminant-bilinear isometry maps a representative to the pair of its
 component classes. -/
@@ -225,10 +247,13 @@ noncomputable def discriminantQuadraticIsometryOrthogonalSum
     intro x
     induction x using Submodule.Quotient.induction_on with
     | _ x =>
+      -- The isometry's carrier is definitionally the discriminant group, but this conversion
+      -- is intentionally not part of the public reduction API.
       change ((L.discriminantQuadraticModule hL).prod
           (M.discriminantQuadraticModule hM)).quadratic
           (L.discriminantGroupOrthogonalSumEquiv M (Submodule.Quotient.mk x)) = _
       rw [discriminantGroupOrthogonalSumEquiv_mk]
+      -- Use the characteristic quadratic-map lemmas after crossing the bundled-carrier boundary.
       change L.discriminantQuadraticMap hL
           (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).1) +
         M.discriminantQuadraticMap hM
@@ -252,6 +277,30 @@ theorem discriminantQuadraticIsometryOrthogonalSum_toAddEquiv
   by
     rw [discriminantQuadraticIsometryOrthogonalSum]
     rfl
+
+/-- The orthogonal-sum discriminant-quadratic isometry acts through the canonical
+discriminant-group equivalence. -/
+@[simp]
+theorem discriminantQuadraticIsometryOrthogonalSum_apply
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
+    (hL : L.IsEven) (hM : M.IsEven) (x : (L.orthogonalSum M).DiscriminantGroup) :
+    L.discriminantQuadraticIsometryOrthogonalSum M hL hM x =
+      L.discriminantGroupOrthogonalSumEquiv M x :=
+  by
+    exact congrArg (fun e ↦ e x)
+      (L.discriminantQuadraticIsometryOrthogonalSum_toAddEquiv M hL hM)
+
+/-- The orthogonal-sum discriminant-quadratic isometry maps a representative to the pair of its
+component classes. -/
+@[simp]
+theorem discriminantQuadraticIsometryOrthogonalSum_mk
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
+    (hL : L.IsEven) (hM : M.IsEven) (x : (L.orthogonalSum M).dualCarrier) :
+    L.discriminantQuadraticIsometryOrthogonalSum M hL hM (Submodule.Quotient.mk x) =
+      (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).1,
+        Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).2) := by
+  rw [discriminantQuadraticIsometryOrthogonalSum_apply,
+    discriminantGroupOrthogonalSumEquiv_mk]
 
 /-- Forgetting the quadratic maps from the orthogonal-sum discriminant isometry recovers the
 orthogonal-sum discriminant-bilinear isometry. -/
@@ -340,6 +389,8 @@ noncomputable def discriminantBilinearIsometryNeg (L : IntegralLattice V)
     | _ x =>
       induction y using Submodule.Quotient.induction_on with
       | _ y =>
+        -- The source and target carriers are definitionally discriminant groups, while their
+        -- bundled pairings are intentionally accessed through characteristic lemmas.
         change -L.discriminantPairing
             (L.discriminantGroupNegEquiv (Submodule.Quotient.mk x))
             (L.discriminantGroupNegEquiv (Submodule.Quotient.mk y)) =
@@ -348,9 +399,11 @@ noncomputable def discriminantBilinearIsometryNeg (L : IntegralLattice V)
         rw [discriminantGroupNegEquiv_mk,
           discriminantGroupNegEquiv_mk, discriminantPairing_mk, discriminantPairing_mk,
           neg_form]
+        -- Coercion into `AddCircle` preserves negation, but its two sides are not syntactically
+        -- identical until the ambient bilinear-form application is exposed.
         change -((L.form (x : V) (y : V) : ℚ) : AddCircle (1 : ℚ)) =
           ((-(L.form (x : V) (y : V)) : ℚ) : AddCircle (1 : ℚ))
-        rfl
+        rw [← AddCircle.coe_neg]
 
 /-- The underlying additive equivalence of the discriminant-bilinear isometry for form negation
 is the canonical equivalence of discriminant groups. -/
@@ -359,6 +412,15 @@ theorem discriminantBilinearIsometryNeg_toAddEquiv (L : IntegralLattice V)
     [L.IsNondegenerate] :
     L.discriminantBilinearIsometryNeg.toAddEquiv = L.discriminantGroupNegEquiv.toAddEquiv :=
   (rfl)
+
+/-- The discriminant-bilinear isometry for form negation acts through the canonical
+discriminant-group equivalence. -/
+@[simp]
+theorem discriminantBilinearIsometryNeg_apply (L : IntegralLattice V) [L.IsNondegenerate]
+    (x : (-L).DiscriminantGroup) :
+    L.discriminantBilinearIsometryNeg x = L.discriminantGroupNegEquiv x :=
+  by
+    exact congrArg (fun e ↦ e x) L.discriminantBilinearIsometryNeg_toAddEquiv
 
 /-- The discriminant-bilinear isometry for form negation maps every representative to the same
 ambient representative. -/
@@ -382,12 +444,16 @@ noncomputable def discriminantQuadraticIsometryNeg (L : IntegralLattice V)
     intro x
     induction x using Submodule.Quotient.induction_on with
     | _ x =>
+      -- The source and target carriers are definitionally discriminant groups, while their
+      -- bundled quadratic maps are intentionally accessed through characteristic lemmas.
       change -L.discriminantQuadraticMap hL
           (L.discriminantGroupNegEquiv (Submodule.Quotient.mk x)) =
         (-L).discriminantQuadraticMap (L.isEven_neg_iff.mpr hL)
           (Submodule.Quotient.mk x)
       rw [discriminantGroupNegEquiv_mk, discriminantQuadraticMap_mk,
         discriminantQuadraticMap_mk, neg_form]
+      -- Coercion into `AddCircle` preserves negation; the remaining rational identity is the
+      -- distribution of negation across division by two.
       change -(((L.form (x : V) (x : V) / 2 : ℚ)) : AddCircle (1 : ℚ)) =
         (((-(L.form (x : V) (x : V)) / 2 : ℚ)) : AddCircle (1 : ℚ))
       rw [← AddCircle.coe_neg]
@@ -402,6 +468,24 @@ theorem discriminantQuadraticIsometryNeg_toAddEquiv (L : IntegralLattice V)
     (L.discriminantQuadraticIsometryNeg hL).toAddEquiv =
       L.discriminantGroupNegEquiv.toAddEquiv :=
   (rfl)
+
+/-- The discriminant-quadratic isometry for form negation acts through the canonical
+discriminant-group equivalence. -/
+@[simp]
+theorem discriminantQuadraticIsometryNeg_apply (L : IntegralLattice V)
+    [L.IsNondegenerate] (hL : L.IsEven) (x : (-L).DiscriminantGroup) :
+    L.discriminantQuadraticIsometryNeg hL x = L.discriminantGroupNegEquiv x :=
+  by
+    exact congrArg (fun e ↦ e x) (L.discriminantQuadraticIsometryNeg_toAddEquiv hL)
+
+/-- The discriminant-quadratic isometry for form negation maps every representative to the same
+ambient representative. -/
+@[simp]
+theorem discriminantQuadraticIsometryNeg_mk (L : IntegralLattice V)
+    [L.IsNondegenerate] (hL : L.IsEven) (x : (-L).dualCarrier) :
+    L.discriminantQuadraticIsometryNeg hL (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (L.negDualCarrierEquiv x) := by
+  rw [discriminantQuadraticIsometryNeg_apply, discriminantGroupNegEquiv_mk]
 
 /-- Forgetting the quadratic maps from the discriminant isometry for form negation recovers the
 corresponding discriminant-bilinear isometry. -/

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Operations.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Operations.lean
@@ -223,7 +223,6 @@ theorem discriminantBilinearIsometryOrthogonalSum_apply
 
 /-- The orthogonal-sum discriminant-bilinear isometry maps a representative to the pair of its
 component classes. -/
-@[simp]
 theorem discriminantBilinearIsometryOrthogonalSum_mk
     (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
     (x : (L.orthogonalSum M).dualCarrier) :
@@ -292,7 +291,6 @@ theorem discriminantQuadraticIsometryOrthogonalSum_apply
 
 /-- The orthogonal-sum discriminant-quadratic isometry maps a representative to the pair of its
 component classes. -/
-@[simp]
 theorem discriminantQuadraticIsometryOrthogonalSum_mk
     (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
     (hL : L.IsEven) (hM : M.IsEven) (x : (L.orthogonalSum M).dualCarrier) :
@@ -424,7 +422,6 @@ theorem discriminantBilinearIsometryNeg_apply (L : IntegralLattice V) [L.IsNonde
 
 /-- The discriminant-bilinear isometry for form negation maps every representative to the same
 ambient representative. -/
-@[simp]
 theorem discriminantBilinearIsometryNeg_mk (L : IntegralLattice V) [L.IsNondegenerate]
     (x : (-L).dualCarrier) :
     L.discriminantBilinearIsometryNeg (Submodule.Quotient.mk x) =
@@ -480,7 +477,6 @@ theorem discriminantQuadraticIsometryNeg_apply (L : IntegralLattice V)
 
 /-- The discriminant-quadratic isometry for form negation maps every representative to the same
 ambient representative. -/
-@[simp]
 theorem discriminantQuadraticIsometryNeg_mk (L : IntegralLattice V)
     [L.IsNondegenerate] (hL : L.IsEven) (x : (-L).dualCarrier) :
     L.discriminantQuadraticIsometryNeg hL (Submodule.Quotient.mk x) =

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Operations.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Operations.lean
@@ -1,0 +1,418 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Quadratic
+public import TauCeti.LinearAlgebra.IntegralLattice.OrthogonalSum
+public import TauCeti.LinearAlgebra.IntegralLattice.Scaling
+
+/-!
+# Discriminant forms under orthogonal sums and negation
+
+The dual carrier of an orthogonal sum is the product of the two dual carriers.  Passing the
+embedded original carriers through this equivalence and then quotienting gives the canonical
+equivalence
+
+```text
+A_(L ⊥ M) ≃ A_L × A_M.
+```
+
+This file proves that the equivalence is an isometry for both discriminant pairings and, when the
+lattices are even, their half-norm quadratic forms.  It also identifies the discriminant form of
+the form-negated lattice `-L`: the quotient group is unchanged, while both its bilinear and
+quadratic forms are negated.
+
+## Main declarations
+
+* `TauCeti.IntegralLattice.discriminantGroupOrthogonalSumEquiv`: the discriminant group of an
+  orthogonal sum is the product of the discriminant groups.
+* `TauCeti.IntegralLattice.discriminantBilinearIsometryOrthogonalSum`: the preceding equivalence
+  preserves the product discriminant pairing.
+* `TauCeti.IntegralLattice.discriminantQuadraticIsometryOrthogonalSum`: the corresponding
+  isometry of half-norm discriminant quadratic modules.
+* `TauCeti.IntegralLattice.discriminantBilinearIsometryNeg` and
+  `TauCeti.IntegralLattice.discriminantQuadraticIsometryNeg`: form negation negates the
+  discriminant pairing and quadratic map.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+* `TauCetiRoadmap/IntegralLattices/README.md`, Layers 2 and 3.
+-/
+
+public section
+
+namespace TauCeti.IntegralLattice
+
+universe u v
+
+variable {V : Type u} {W : Type v}
+variable [AddCommGroup V] [Module ℚ V] [AddCommGroup W] [Module ℚ W]
+
+/-! ## Orthogonal sums -/
+
+/-- Membership in the dual carrier of an orthogonal sum is componentwise membership in the two
+dual carriers. -/
+@[simp]
+theorem mem_dualCarrier_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W)
+    (x : V × W) :
+    x ∈ (L.orthogonalSum M).dualCarrier ↔ x.1 ∈ L.dualCarrier ∧ x.2 ∈ M.dualCarrier := by
+  rw [dualCarrier, LinearMap.BilinForm.mem_dualSubmodule]
+  constructor
+  · intro hx
+    constructor
+    · rw [dualCarrier, LinearMap.BilinForm.mem_dualSubmodule]
+      intro y hy
+      have hmem : (y, 0) ∈ (L.orthogonalSum M).carrier := by
+        rw [orthogonalSum_carrier, Submodule.mem_prod]
+        exact ⟨hy, M.carrier.zero_mem⟩
+      have h := hx (y, 0) hmem
+      simpa using h
+    · rw [dualCarrier, LinearMap.BilinForm.mem_dualSubmodule]
+      intro y hy
+      have hmem : (0, y) ∈ (L.orthogonalSum M).carrier := by
+        rw [orthogonalSum_carrier, Submodule.mem_prod]
+        exact ⟨L.carrier.zero_mem, hy⟩
+      have h := hx (0, y) hmem
+      simpa using h
+  · rintro ⟨hx, hy⟩ z hz
+    rw [orthogonalSum_carrier, Submodule.mem_prod] at hz
+    rw [orthogonalSum_form, orthogonalSumForm_apply]
+    exact Submodule.add_mem _ (hx z.1 hz.1) (hy z.2 hz.2)
+
+/-- The dual carrier of an orthogonal sum is canonically the product of the dual carriers. -/
+@[expose] def orthogonalSumDualCarrierEquiv (L : IntegralLattice V) (M : IntegralLattice W) :
+    (L.orthogonalSum M).dualCarrier ≃ₗ[ℤ] L.dualCarrier × M.dualCarrier where
+  toFun x :=
+    (⟨x.1.1, (L.mem_dualCarrier_orthogonalSum M x.1).mp x.2 |>.1⟩,
+      ⟨x.1.2, (L.mem_dualCarrier_orthogonalSum M x.1).mp x.2 |>.2⟩)
+  invFun x :=
+    ⟨(x.1, x.2), (L.mem_dualCarrier_orthogonalSum M (x.1, x.2)).mpr ⟨x.1.2, x.2.2⟩⟩
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- The dual-carrier product equivalence acts by taking the two ambient coordinates. -/
+@[simp]
+theorem orthogonalSumDualCarrierEquiv_apply (L : IntegralLattice V) (M : IntegralLattice W)
+    (x : (L.orthogonalSum M).dualCarrier) :
+    L.orthogonalSumDualCarrierEquiv M x =
+      (⟨x.1.1, (L.mem_dualCarrier_orthogonalSum M x.1).mp x.2 |>.1⟩,
+        ⟨x.1.2, (L.mem_dualCarrier_orthogonalSum M x.1).mp x.2 |>.2⟩) :=
+  by
+    apply Prod.ext <;> apply Subtype.ext <;> rfl
+
+/-- Under the dual-carrier product equivalence, the embedded carrier of an orthogonal sum is the
+product of the two embedded carriers. -/
+theorem map_carrierInDual_orthogonalSum (L : IntegralLattice V) (M : IntegralLattice W) :
+    (L.orthogonalSum M).carrierInDual.map
+        (L.orthogonalSumDualCarrierEquiv M).toLinearMap =
+      L.carrierInDual.prod M.carrierInDual := by
+  ext x
+  rw [Submodule.mem_map_equiv, Submodule.mem_prod]
+  simp only [mem_carrierInDual_iff]
+  rw [orthogonalSum_carrier, Submodule.mem_prod]
+  rfl
+
+private def quotientProdLinearEquiv (L : IntegralLattice V) (M : IntegralLattice W) :
+    ((L.dualCarrier × M.dualCarrier) ⧸
+        L.carrierInDual.prod M.carrierInDual) ≃ₗ[ℤ]
+      L.DiscriminantGroup × M.DiscriminantGroup :=
+  { QuotientAddGroup.prodAddEquiv L.carrierInDual.toAddSubgroup
+      M.carrierInDual.toAddSubgroup with
+    map_smul' := fun n x ↦ by
+      change _ = n • _
+      exact map_zsmul
+        (QuotientAddGroup.prodAddEquiv L.carrierInDual.toAddSubgroup
+          M.carrierInDual.toAddSubgroup) n x }
+
+private theorem quotientProdLinearEquiv_mk (L : IntegralLattice V) (M : IntegralLattice W)
+    (x : L.dualCarrier × M.dualCarrier) :
+    L.quotientProdLinearEquiv M (Submodule.Quotient.mk x) =
+      (Submodule.Quotient.mk x.1, Submodule.Quotient.mk x.2) := by
+  rfl
+
+/-- The discriminant group of an orthogonal sum is canonically the product of the discriminant
+groups of its summands. -/
+def discriminantGroupOrthogonalSumEquiv (L : IntegralLattice V) (M : IntegralLattice W) :
+    (L.orthogonalSum M).DiscriminantGroup ≃ₗ[ℤ]
+      L.DiscriminantGroup × M.DiscriminantGroup :=
+  (Submodule.Quotient.equiv (L.orthogonalSum M).carrierInDual
+      (L.carrierInDual.prod M.carrierInDual) (L.orthogonalSumDualCarrierEquiv M)
+      (L.map_carrierInDual_orthogonalSum M)).trans (quotientProdLinearEquiv L M)
+
+/-- The orthogonal-sum discriminant-group equivalence maps a representative to the pair of its
+component classes. -/
+@[simp]
+theorem discriminantGroupOrthogonalSumEquiv_mk (L : IntegralLattice V) (M : IntegralLattice W)
+    (x : (L.orthogonalSum M).dualCarrier) :
+    L.discriminantGroupOrthogonalSumEquiv M (Submodule.Quotient.mk x) =
+      (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).1,
+        Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).2) := by
+  rw [discriminantGroupOrthogonalSumEquiv, LinearEquiv.trans_apply]
+  rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply,
+    quotientProdLinearEquiv_mk]
+  congr 1
+
+/-- The product equivalence of discriminant groups is an isometry from the discriminant pairing
+of an orthogonal sum to the orthogonal product of the two discriminant pairings. -/
+noncomputable def discriminantBilinearIsometryOrthogonalSum
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate] :
+    FiniteBilinearModule.Isometry (L.orthogonalSum M).discriminantBilinearModule
+      (L.discriminantBilinearModule.prod M.discriminantBilinearModule) where
+  toAddEquiv := (L.discriminantGroupOrthogonalSumEquiv M).toAddEquiv
+  map_pairing' := by
+    intro x y
+    induction x using Submodule.Quotient.induction_on with
+    | _ x =>
+      induction y using Submodule.Quotient.induction_on with
+      | _ y =>
+        change (L.discriminantBilinearModule.prod M.discriminantBilinearModule).pairing
+            (L.discriminantGroupOrthogonalSumEquiv M (Submodule.Quotient.mk x))
+            (L.discriminantGroupOrthogonalSumEquiv M (Submodule.Quotient.mk y)) = _
+        rw [discriminantGroupOrthogonalSumEquiv_mk,
+          discriminantGroupOrthogonalSumEquiv_mk]
+        change L.discriminantPairing
+            (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).1)
+            (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M y).1) +
+          M.discriminantPairing
+            (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).2)
+            (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M y).2) =
+          (L.orthogonalSum M).discriminantPairing
+            (Submodule.Quotient.mk x) (Submodule.Quotient.mk y)
+        rw [discriminantPairing_mk, discriminantPairing_mk, discriminantPairing_mk,
+          orthogonalSum_form, orthogonalSumForm_apply,
+          orthogonalSumDualCarrierEquiv_apply]
+        rw [L.orthogonalSumDualCarrierEquiv_apply M y, ← AddCircle.coe_add]
+
+/-- The underlying additive equivalence of the orthogonal-sum discriminant-bilinear isometry is
+the canonical product equivalence of discriminant groups. -/
+@[simp]
+theorem discriminantBilinearIsometryOrthogonalSum_toAddEquiv
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate] :
+    (L.discriminantBilinearIsometryOrthogonalSum M).toAddEquiv =
+      (L.discriminantGroupOrthogonalSumEquiv M).toAddEquiv :=
+  by rw [discriminantBilinearIsometryOrthogonalSum]
+
+/-- The orthogonal-sum discriminant-bilinear isometry maps a representative to the pair of its
+component classes. -/
+@[simp]
+theorem discriminantBilinearIsometryOrthogonalSum_mk
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
+    (x : (L.orthogonalSum M).dualCarrier) :
+    L.discriminantBilinearIsometryOrthogonalSum M (Submodule.Quotient.mk x) =
+      (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).1,
+        Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).2) :=
+  L.discriminantGroupOrthogonalSumEquiv_mk M x
+
+/-- The product equivalence of discriminant groups is an isometry from the half-norm
+discriminant quadratic module of an orthogonal sum to the orthogonal product of the two
+discriminant quadratic modules. -/
+noncomputable def discriminantQuadraticIsometryOrthogonalSum
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
+    (hL : L.IsEven) (hM : M.IsEven) :
+    FiniteQuadraticModule.Isometry
+      ((L.orthogonalSum M).discriminantQuadraticModule
+        ((L.isEven_orthogonalSum_iff M).mpr ⟨hL, hM⟩))
+      ((L.discriminantQuadraticModule hL).prod (M.discriminantQuadraticModule hM)) where
+  toLinearEquiv := L.discriminantGroupOrthogonalSumEquiv M
+  map_app' := by
+    intro x
+    induction x using Submodule.Quotient.induction_on with
+    | _ x =>
+      change ((L.discriminantQuadraticModule hL).prod
+          (M.discriminantQuadraticModule hM)).quadratic
+          (L.discriminantGroupOrthogonalSumEquiv M (Submodule.Quotient.mk x)) = _
+      rw [discriminantGroupOrthogonalSumEquiv_mk]
+      change L.discriminantQuadraticMap hL
+          (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).1) +
+        M.discriminantQuadraticMap hM
+          (Submodule.Quotient.mk (L.orthogonalSumDualCarrierEquiv M x).2) =
+        (L.orthogonalSum M).discriminantQuadraticMap _ (Submodule.Quotient.mk x)
+      rw [discriminantQuadraticMap_mk, discriminantQuadraticMap_mk,
+        discriminantQuadraticMap_mk, orthogonalSum_form, orthogonalSumForm_apply,
+        orthogonalSumDualCarrierEquiv_apply]
+      rw [← AddCircle.coe_add]
+      congr 1
+      ring
+
+/-- The underlying additive equivalence of the orthogonal-sum discriminant-quadratic isometry is
+the canonical product equivalence of discriminant groups. -/
+@[simp]
+theorem discriminantQuadraticIsometryOrthogonalSum_toAddEquiv
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
+    (hL : L.IsEven) (hM : M.IsEven) :
+    (L.discriminantQuadraticIsometryOrthogonalSum M hL hM).toAddEquiv =
+      (L.discriminantGroupOrthogonalSumEquiv M).toAddEquiv :=
+  by
+    rw [discriminantQuadraticIsometryOrthogonalSum]
+    rfl
+
+/-- Forgetting the quadratic maps from the orthogonal-sum discriminant isometry recovers the
+orthogonal-sum discriminant-bilinear isometry. -/
+@[simp]
+theorem discriminantQuadraticIsometryOrthogonalSum_toFiniteBilinearModule
+    (L : IntegralLattice V) (M : IntegralLattice W) [L.IsNondegenerate] [M.IsNondegenerate]
+    (hL : L.IsEven) (hM : M.IsEven) :
+    (L.discriminantQuadraticIsometryOrthogonalSum M hL hM).toFiniteBilinearModule =
+      L.discriminantBilinearIsometryOrthogonalSum M := by
+  apply FiniteBilinearModule.Isometry.toAddEquiv_injective
+  rw [FiniteQuadraticModule.Isometry.toFiniteBilinearModule_toAddEquiv,
+    discriminantQuadraticIsometryOrthogonalSum_toAddEquiv,
+    discriminantBilinearIsometryOrthogonalSum_toAddEquiv]
+
+/-! ## Form negation -/
+
+/-- Negating a lattice form does not change its dual carrier. -/
+@[simp]
+theorem dualCarrier_neg (L : IntegralLattice V) : (-L).dualCarrier = L.dualCarrier := by
+  ext x
+  simp only [dualCarrier, LinearMap.BilinForm.mem_dualSubmodule, neg_carrier, neg_form,
+    LinearMap.neg_apply]
+  constructor
+  · intro hx y hy
+    exact (Submodule.neg_mem_iff (1 : Submodule ℤ ℚ)).mp (hx y hy)
+  · intro hx y hy
+    exact (Submodule.neg_mem_iff (1 : Submodule ℤ ℚ)).mpr (hx y hy)
+
+/-- The dual carrier of a form-negated lattice is canonically identified with the original dual
+carrier by the identity on ambient vectors. -/
+def negDualCarrierEquiv (L : IntegralLattice V) :
+    (-L).dualCarrier ≃ₗ[ℤ] L.dualCarrier where
+  toFun x := ⟨x, by simpa using x.2⟩
+  invFun x := ⟨x, by simp only [dualCarrier_neg]; exact x.2⟩
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- The dual-carrier equivalence for form negation is the identity on ambient vectors. -/
+@[simp]
+theorem coe_negDualCarrierEquiv_apply (L : IntegralLattice V) (x : (-L).dualCarrier) :
+    (L.negDualCarrierEquiv x : V) = x :=
+  (rfl)
+
+/-- The inverse dual-carrier equivalence for form negation is also the identity on ambient
+vectors. -/
+@[simp]
+theorem coe_negDualCarrierEquiv_symm_apply (L : IntegralLattice V) (x : L.dualCarrier) :
+    (L.negDualCarrierEquiv.symm x : V) = x :=
+  (rfl)
+
+/-- Under the dual-carrier equivalence for form negation, the embedded carrier maps to the
+original embedded carrier. -/
+theorem map_carrierInDual_neg (L : IntegralLattice V) :
+    (-L).carrierInDual.map L.negDualCarrierEquiv.toLinearMap = L.carrierInDual := by
+  ext x
+  rw [Submodule.mem_map_equiv]
+  simp only [mem_carrierInDual_iff, neg_carrier, coe_negDualCarrierEquiv_symm_apply]
+
+/-- Negating a lattice form leaves its discriminant group canonically unchanged. -/
+def discriminantGroupNegEquiv (L : IntegralLattice V) :
+    (-L).DiscriminantGroup ≃ₗ[ℤ] L.DiscriminantGroup :=
+  Submodule.Quotient.equiv (-L).carrierInDual L.carrierInDual L.negDualCarrierEquiv
+    L.map_carrierInDual_neg
+
+/-- The discriminant-group equivalence for form negation maps every representative to the same
+ambient representative. -/
+@[simp]
+theorem discriminantGroupNegEquiv_mk (L : IntegralLattice V) (x : (-L).dualCarrier) :
+    L.discriminantGroupNegEquiv (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (L.negDualCarrierEquiv x) := by
+  rw [discriminantGroupNegEquiv, Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  congr 1
+
+/-- The canonical discriminant-group equivalence is an isometry from the discriminant pairing
+of the form-negated lattice to the negative of the original discriminant pairing. -/
+noncomputable def discriminantBilinearIsometryNeg (L : IntegralLattice V)
+    [L.IsNondegenerate] :
+    FiniteBilinearModule.Isometry (-L).discriminantBilinearModule
+      L.discriminantBilinearModule.neg where
+  toAddEquiv := L.discriminantGroupNegEquiv.toAddEquiv
+  map_pairing' := by
+    intro x y
+    induction x using Submodule.Quotient.induction_on with
+    | _ x =>
+      induction y using Submodule.Quotient.induction_on with
+      | _ y =>
+        change -L.discriminantPairing
+            (L.discriminantGroupNegEquiv (Submodule.Quotient.mk x))
+            (L.discriminantGroupNegEquiv (Submodule.Quotient.mk y)) =
+          (-L).discriminantPairing
+            (Submodule.Quotient.mk x) (Submodule.Quotient.mk y)
+        rw [discriminantGroupNegEquiv_mk,
+          discriminantGroupNegEquiv_mk, discriminantPairing_mk, discriminantPairing_mk,
+          neg_form]
+        change -((L.form (x : V) (y : V) : ℚ) : AddCircle (1 : ℚ)) =
+          ((-(L.form (x : V) (y : V)) : ℚ) : AddCircle (1 : ℚ))
+        rfl
+
+/-- The underlying additive equivalence of the discriminant-bilinear isometry for form negation
+is the canonical equivalence of discriminant groups. -/
+@[simp]
+theorem discriminantBilinearIsometryNeg_toAddEquiv (L : IntegralLattice V)
+    [L.IsNondegenerate] :
+    L.discriminantBilinearIsometryNeg.toAddEquiv = L.discriminantGroupNegEquiv.toAddEquiv :=
+  (rfl)
+
+/-- The discriminant-bilinear isometry for form negation maps every representative to the same
+ambient representative. -/
+@[simp]
+theorem discriminantBilinearIsometryNeg_mk (L : IntegralLattice V) [L.IsNondegenerate]
+    (x : (-L).dualCarrier) :
+    L.discriminantBilinearIsometryNeg (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (L.negDualCarrierEquiv x) :=
+  L.discriminantGroupNegEquiv_mk x
+
+/-- The canonical discriminant-group equivalence is an isometry from the half-norm
+discriminant quadratic module of a form-negated lattice to the negative of the original
+discriminant quadratic module. -/
+noncomputable def discriminantQuadraticIsometryNeg (L : IntegralLattice V)
+    [L.IsNondegenerate] (hL : L.IsEven) :
+    FiniteQuadraticModule.Isometry
+      ((-L).discriminantQuadraticModule (L.isEven_neg_iff.mpr hL))
+      (L.discriminantQuadraticModule hL).neg where
+  toLinearEquiv := L.discriminantGroupNegEquiv
+  map_app' := by
+    intro x
+    induction x using Submodule.Quotient.induction_on with
+    | _ x =>
+      change -L.discriminantQuadraticMap hL
+          (L.discriminantGroupNegEquiv (Submodule.Quotient.mk x)) =
+        (-L).discriminantQuadraticMap (L.isEven_neg_iff.mpr hL)
+          (Submodule.Quotient.mk x)
+      rw [discriminantGroupNegEquiv_mk, discriminantQuadraticMap_mk,
+        discriminantQuadraticMap_mk, neg_form]
+      change -(((L.form (x : V) (x : V) / 2 : ℚ)) : AddCircle (1 : ℚ)) =
+        (((-(L.form (x : V) (x : V)) / 2 : ℚ)) : AddCircle (1 : ℚ))
+      rw [← AddCircle.coe_neg]
+      congr 1
+      ring
+
+/-- The underlying additive equivalence of the discriminant-quadratic isometry for form
+negation is the canonical equivalence of discriminant groups. -/
+@[simp]
+theorem discriminantQuadraticIsometryNeg_toAddEquiv (L : IntegralLattice V)
+    [L.IsNondegenerate] (hL : L.IsEven) :
+    (L.discriminantQuadraticIsometryNeg hL).toAddEquiv =
+      L.discriminantGroupNegEquiv.toAddEquiv :=
+  (rfl)
+
+/-- Forgetting the quadratic maps from the discriminant isometry for form negation recovers the
+corresponding discriminant-bilinear isometry. -/
+@[simp]
+theorem discriminantQuadraticIsometryNeg_toFiniteBilinearModule
+    (L : IntegralLattice V) [L.IsNondegenerate] (hL : L.IsEven) :
+    (L.discriminantQuadraticIsometryNeg hL).toFiniteBilinearModule =
+      L.discriminantBilinearIsometryNeg := by
+  apply FiniteBilinearModule.Isometry.toAddEquiv_injective
+  rw [FiniteQuadraticModule.Isometry.toFiniteBilinearModule_toAddEquiv,
+    discriminantQuadraticIsometryNeg_toAddEquiv,
+    discriminantBilinearIsometryNeg_toAddEquiv]
+
+end TauCeti.IntegralLattice

--- a/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/OrthogonalSum.lean
@@ -346,6 +346,12 @@ theorem nondegenerate_orthogonalSum_iff (L : IntegralLattice V) (M : IntegralLat
       L.form.Nondegenerate ∧ M.form.Nondegenerate := by
   rw [orthogonalSum_form, nondegenerate_orthogonalSumForm_iff]
 
+/-- The orthogonal sum of two nondegenerate integral lattices is nondegenerate. -/
+instance instIsNondegenerateOrthogonalSum (L : IntegralLattice V) (M : IntegralLattice W)
+    [L.IsNondegenerate] [M.IsNondegenerate] : (L.orthogonalSum M).IsNondegenerate :=
+  ⟨(L.nondegenerate_orthogonalSum_iff M).mpr
+    ⟨L.form_nondegenerate, M.form_nondegenerate⟩⟩
+
 /-! ## Radical and signature -/
 
 /-- The radical of an orthogonal sum is the product of the component radicals. -/

--- a/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
@@ -6,6 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.LinearAlgebra.BilinearForm.Basic
+public import TauCeti.LinearAlgebra.IntegralLattice.Even
 public import TauCeti.LinearAlgebra.IntegralLattice.Gram
 public import TauCeti.LinearAlgebra.IntegralLattice.Signature
 
@@ -29,6 +30,7 @@ the canonical operation internal to integral lattices is the integer action defi
 * `TauCeti.IntegralLattice.instMulActionInt`: the integer multiplicative action on integral
   lattices.
 * `TauCeti.IntegralLattice.instInvolutiveNeg`: form negation, defined as scaling by `-1`.
+* `TauCeti.IntegralLattice.isEven_neg_iff`: form negation preserves evenness.
 * `TauCeti.IntegralLattice.gramMatrix_smul`: scaling multiplies every Gram-matrix entry.
 * `TauCeti.IntegralLattice.determinant_smul`: the determinant is multiplied by the scalar to the
   lattice rank.
@@ -297,6 +299,29 @@ theorem integralForm_neg (L : IntegralLattice V) :
   change ((-1 : ℤ) • L).integralForm = -L.integralForm
   rw [integralForm_smul, neg_one_smul ℤ]
 
+/-- An integral lattice is even if and only if its form negation is even. -/
+@[simp]
+theorem isEven_neg_iff (L : IntegralLattice V) : (-L).IsEven ↔ L.IsEven := by
+  rw [(-L).isEven_iff_forall_norm, L.isEven_iff_forall_norm]
+  constructor
+  · intro h x
+    obtain ⟨z, hz⟩ := h x
+    refine ⟨-z, ?_⟩
+    rw [norm_apply] at hz ⊢
+    rw [neg_form] at hz
+    change -(L.form (x : V) (x : V)) = 2 * (z : ℚ) at hz
+    push_cast
+    linarith
+  · intro h x
+    obtain ⟨z, hz⟩ := h x
+    refine ⟨-z, ?_⟩
+    rw [norm_apply] at hz ⊢
+    rw [neg_form]
+    change -(L.form (x : V) (x : V)) = 2 * ((-z : ℤ) : ℚ)
+    push_cast
+    rw [hz]
+    ring
+
 /-- Negation multiplies every Gram-matrix entry by `-1`. -/
 @[simp]
 theorem gramMatrix_neg (L : IntegralLattice V) {ι : Type v} (e : Basis ι ℤ L) :
@@ -328,6 +353,11 @@ theorem nondegenerate_neg_iff (L : IntegralLattice V) :
     (-L).form.Nondegenerate ↔ L.form.Nondegenerate := by
   rw [neg_def]
   exact nondegenerate_smul_iff (by norm_num) L
+
+/-- Negating the form of a nondegenerate integral lattice preserves nondegeneracy. -/
+instance instIsNondegenerateNeg (L : IntegralLattice V) [L.IsNondegenerate] :
+    (-L).IsNondegenerate :=
+  ⟨L.nondegenerate_neg_iff.mpr L.form_nondegenerate⟩
 
 /-- Form negation preserves the radical. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Scaling.lean
@@ -309,7 +309,7 @@ theorem isEven_neg_iff (L : IntegralLattice V) : (-L).IsEven ↔ L.IsEven := by
     refine ⟨-z, ?_⟩
     rw [norm_apply] at hz ⊢
     rw [neg_form] at hz
-    change -(L.form (x : V) (x : V)) = 2 * (z : ℚ) at hz
+    simp only [LinearMap.neg_apply] at hz
     push_cast
     linarith
   · intro h x
@@ -317,7 +317,7 @@ theorem isEven_neg_iff (L : IntegralLattice V) : (-L).IsEven ↔ L.IsEven := by
     refine ⟨-z, ?_⟩
     rw [norm_apply] at hz ⊢
     rw [neg_form]
-    change -(L.form (x : V) (x : V)) = 2 * ((-z : ℤ) : ℚ)
+    simp only [LinearMap.neg_apply]
     push_cast
     rw [hz]
     ring


### PR DESCRIPTION
This PR proves that discriminant bilinear and half-norm quadratic modules commute with orthogonal sums and form negation. Construct the canonical quotient equivalence `A_(L ⊥ M) ≃ A_L × A_M`, prove that it preserves the product pairing and quadratic map, identify `A_(-L)` with `A_L`, and prove that the transported bilinear and quadratic forms are the negatives of the original forms.

The exact roadmap target is `TauCetiRoadmap/IntegralLattices/README.md`, Layer 3, milestone “Construct the discriminant bilinear module of every integral lattice … [and] prove functoriality under lattice isometry and compatibility with orthogonal sum and negation, always in the half-norm convention.” This PR completes the orthogonal-sum and negation compatibility clause. After this PR, Layer 3 still needs the canonical primary decomposition packaged as an isometry together with the requested componentwise isotropy and orthogonal-complement API.

The preferred `CFSGStatement` roadmap has no viable independent unclaimed step on current `main`: I0 and the sporadic S1 lane are complete, `classificationStatement_of_zero` is in flight, and L0–L3 depend on ReductiveGroups Layer 9, whose executable Chevalley–Demazure, torus, Borel, root-subgroup, graph-automorphism, Weyl, PBW, and root-string fronts are already in flight. The IntegralLattices Layer 3 compatibility clause is therefore the most effective coherent fallback: its abstract finite bilinear/quadratic operations and discriminant modules are merged, and no open PR overlaps the missing transport theorem.

Add `TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Operations.lean` (418 lines). The module first identifies the dual carrier of an orthogonal sum with the product of dual carriers, maps the embedded carrier through that equivalence, descends it through the quotient, and proves representative formulas before packaging bilinear and quadratic isometries. It then performs the analogous identity transport for form negation. Extend `OrthogonalSum.lean` by 6 lines and `Scaling.lean` by 30 lines with the nondegeneracy instances needed by those packages and the natural evenness theorem for negation.

The quotient construction reuses Mathlib’s `Submodule.Quotient.equiv`, `Submodule.mapQ_apply`, and `QuotientAddGroup.prodAddEquiv`; no Mathlib infrastructure or external formalization is vendored. The mathematics follows Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1, and Ebeling, *Lattices and Codes*, Chapter 1, as credited in the module documentation.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"discriminant-form-orthogonal-sum-negation"}-->

🤖 Prepared with Codex
