### PR TITLE
feat: package linearly reductive affine groups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/LinearlyReductive.lean
@@ -55,7 +55,8 @@ theorem linearlyReductiveAffineGroupSchemeProperty_groupScheme
     ⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩
   have hS : linearlyReductiveAffineGroupSchemeProperty k S :=
     (linearlyReductiveAffineGroupSchemeProperty_hopfSpec_iff k (coordinateRing k G).obj).2
-      (Coalgebra.isLinearlyReductive_monoidAlgebra k G)
+      ((linearlyReductiveCommHopfAlgProperty_iff k _).1
+        (linearlyReductiveCommHopfAlgProperty_monoidAlgebra k G))
   let e : S ≅ D :=
     (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
       (eqToIso (groupScheme_def k G).symm)

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/LinearlyReductive.lean
@@ -20,7 +20,7 @@ diagonalizable-group-scheme property.
 
 * `TauCeti.DiagonalizableGroup.linearlyReductiveAffineGroupSchemeProperty_groupScheme`: the
   canonical diagonalizable group scheme `D(G)` is linearly reductive.
-* `TauCeti.DiagonalizableGroup.linearlyReductive_of_diagonalizableGroupSchemeProperty`: every
+* `linearlyReductiveAffineGroupSchemeProperty_of_diagonalizableGroupSchemeProperty`: every
   affine group scheme satisfying the diagonalizable property is linearly reductive.
 
 ## References
@@ -54,7 +54,7 @@ theorem linearlyReductiveAffineGroupSchemeProperty_groupScheme
   let D : AffineGroupSchemeCat (CommRingCat.of k) :=
     ⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩
   have hS : linearlyReductiveAffineGroupSchemeProperty k S :=
-    (linearlyReductiveAffineGroupSchemeProperty_hopfSpec k (coordinateRing k G).obj).2
+    (linearlyReductiveAffineGroupSchemeProperty_hopfSpec_iff k (coordinateRing k G).obj).2
       (Coalgebra.isLinearlyReductive_monoidAlgebra k G)
   let e : S ≅ D :=
     (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
@@ -64,7 +64,7 @@ theorem linearlyReductiveAffineGroupSchemeProperty_groupScheme
 
 /-- Every affine group scheme satisfying the finite-type diagonalizable-group property is
 linearly reductive. -/
-theorem linearlyReductive_of_diagonalizableGroupSchemeProperty
+theorem linearlyReductiveAffineGroupSchemeProperty_of_diagonalizableGroupSchemeProperty
     (k : Type u) [Field k] (G : AffineGroupSchemeCat (CommRingCat.of k))
     (hG : diagonalizableGroupSchemeProperty k G.obj) :
     linearlyReductiveAffineGroupSchemeProperty k G := by

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/LinearlyReductive.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Equivalence
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.LinearlyReductive
+
+/-!
+# Linear reductivity of diagonalizable group schemes
+
+Every finite-type diagonalizable group scheme over a field is linearly reductive. On the
+canonical object `D(G) = Spec k[G]`, this follows from complete reducibility of comodules over a
+monoid-algebra coalgebra. Isomorphism invariance then extends the result to the full
+diagonalizable-group-scheme property.
+
+## Main declarations
+
+* `TauCeti.DiagonalizableGroup.linearlyReductiveAffineGroupSchemeProperty_groupScheme`: the
+  canonical diagonalizable group scheme `D(G)` is linearly reductive.
+* `TauCeti.DiagonalizableGroup.linearlyReductive_of_diagonalizableGroupSchemeProperty`: every
+  affine group scheme satisfying the diagonalizable property is linearly reductive.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 3.2.
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.12.
+
+This is the diagonalizable-group example for the complete-reducibility characterization in
+Layer 6 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory AlgebraicGeometry Opposite
+
+universe u
+
+namespace DiagonalizableGroup
+
+/-- The canonical finite-type diagonalizable group scheme `D(G)` is linearly reductive. -/
+theorem linearlyReductiveAffineGroupSchemeProperty_groupScheme
+    (k : Type u) [Field k] (G : FGCommGrpCat.{u}) :
+    linearlyReductiveAffineGroupSchemeProperty k
+      ⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩ := by
+  let S : AffineGroupSchemeCat (CommRingCat.of k) :=
+    ⟨(hopfSpec (CommRingCat.of k)).obj (op (coordinateRing k G).obj), by
+      rw [affineGroupSchemeProperty_iff, hopfSpec_obj_X_left]
+      infer_instance⟩
+  let D : AffineGroupSchemeCat (CommRingCat.of k) :=
+    ⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩
+  have hS : linearlyReductiveAffineGroupSchemeProperty k S :=
+    (linearlyReductiveAffineGroupSchemeProperty_hopfSpec k (coordinateRing k G).obj).2
+      (Coalgebra.isLinearlyReductive_monoidAlgebra k G)
+  let e : S ≅ D :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      (eqToIso (groupScheme_def k G).symm)
+  change linearlyReductiveAffineGroupSchemeProperty k D
+  exact (linearlyReductiveAffineGroupSchemeProperty k).prop_of_iso e hS
+
+/-- Every affine group scheme satisfying the finite-type diagonalizable-group property is
+linearly reductive. -/
+theorem linearlyReductive_of_diagonalizableGroupSchemeProperty
+    (k : Type u) [Field k] (G : AffineGroupSchemeCat (CommRingCat.of k))
+    (hG : diagonalizableGroupSchemeProperty k G.obj) :
+    linearlyReductiveAffineGroupSchemeProperty k G := by
+  have hEssImage : (schemeFunctor k).essImage G.obj := by
+    rw [essImage_schemeFunctor]
+    exact hG
+  obtain ⟨M, ⟨e⟩⟩ := hEssImage
+  let D : AffineGroupSchemeCat (CommRingCat.of k) :=
+    ⟨groupScheme k M.unop, (affineGroupSchemeProperty_iff _).2 inferInstance⟩
+  let e' : D ≅ G :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      (eqToIso (schemeFunctor_obj k M).symm ≪≫ e)
+  exact (linearlyReductiveAffineGroupSchemeProperty k).prop_of_iso e'
+    (linearlyReductiveAffineGroupSchemeProperty_groupScheme k M.unop)
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/LinearlyReductive.lean
@@ -59,8 +59,8 @@ theorem linearlyReductiveAffineGroupSchemeProperty_groupScheme
   let e : S ≅ D :=
     (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
       (eqToIso (groupScheme_def k G).symm)
-  change linearlyReductiveAffineGroupSchemeProperty k D
-  exact (linearlyReductiveAffineGroupSchemeProperty k).prop_of_iso e hS
+  simpa only [D] using
+    (linearlyReductiveAffineGroupSchemeProperty k).prop_of_iso e hS
 
 /-- Every affine group scheme satisfying the finite-type diagonalizable-group property is
 linearly reductive. -/

--- a/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 
@@ -10,14 +11,17 @@ public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
 /-!
 # Linearly reductive commutative Hopf algebras
 
-An affine group over a field is linearly reductive when every finite-dimensional rational
-representation is completely reducible. This file packages the existing comodule formulation as
-an isomorphism-invariant object property on commutative Hopf algebras.
+An affine group over a field is linearly reductive when its finite-dimensional rational
+representations are completely reducible. This file packages the existing comodule formulation
+as an isomorphism-invariant object property on commutative Hopf algebras. For a Hopf algebra in
+`Type v`, the property tests comodule carriers in `Type v`; no universe-transfer result is
+asserted here.
 
 The property is deliberately separate from smoothness, connectedness, and finite type. In
 positive characteristic a torus is linearly reductive, while a general reductive group need not
-be. The comparison with geometric reductivity therefore requires characteristic hypotheses and
-belongs later in the theory.
+be. The comparison with reductivity defined by a trivial geometric unipotent radical belongs
+later in the theory: for smooth connected affine groups, reductive and linearly reductive are
+equivalent in characteristic zero.
 
 ## Main declarations
 
@@ -39,33 +43,33 @@ namespace TauCeti
 
 open CategoryTheory
 
-universe u v w
+universe u v
 
 /-- The object property selecting commutative Hopf algebras for which every finite-dimensional
-comodule is completely reducible. On coordinate rings, this is linear reductivity of the
-represented affine group. -/
+comodule with carrier in `Type v` is completely reducible. On coordinate rings, this is linear
+reductivity of the represented affine group at that fixed carrier universe. -/
 def linearlyReductiveCommHopfAlgProperty (k : Type u) [Field k] :
     ObjectProperty (CommHopfAlgCat.{v} k) :=
-  fun H ↦ Coalgebra.IsLinearlyReductive.{u, v, w} k H
+  fun H ↦ Coalgebra.IsLinearlyReductive.{u, v, v} k H
 
 /-- Membership in the linearly reductive commutative-Hopf-algebra property means that every
-finite-dimensional comodule is completely reducible. -/
+finite-dimensional comodule with carrier in `Type v` is completely reducible. -/
 @[simp]
 theorem linearlyReductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
     (H : CommHopfAlgCat.{v} k) :
-    linearlyReductiveCommHopfAlgProperty.{u, v, w} k H ↔
-      Coalgebra.IsLinearlyReductive.{u, v, w} k H :=
+    linearlyReductiveCommHopfAlgProperty.{u, v} k H ↔
+      Coalgebra.IsLinearlyReductive.{u, v, v} k H :=
   Iff.rfl
 
 /-- Linear reductivity is invariant under isomorphism of commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :
-    (linearlyReductiveCommHopfAlgProperty.{u, v, w} k).IsClosedUnderIsomorphisms where
+    (linearlyReductiveCommHopfAlgProperty.{u, v} k).IsClosedUnderIsomorphisms where
   of_iso e hH :=
     (Coalgebra.isLinearlyReductive_iff_of_coalgEquiv
       k (CommHopfAlgCat.ofIso e).toCoalgEquiv).mp hH
 
 /-- The category of linearly reductive commutative Hopf algebras over a field. -/
 abbrev LinearlyReductiveCommHopfAlgCat (k : Type u) [Field k] :=
-  (linearlyReductiveCommHopfAlgProperty.{u, v, w} k).FullSubcategory
+  (linearlyReductiveCommHopfAlgProperty.{u, v} k).FullSubcategory
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.FiniteType
+public import Mathlib.Algebra.Category.CommHopfAlgCat
 public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
 
 /-!
@@ -12,8 +12,7 @@ public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
 
 An affine group over a field is linearly reductive when every finite-dimensional rational
 representation is completely reducible. This file packages the existing comodule formulation as
-an isomorphism-invariant object property on commutative Hopf algebras. It also records that the
-coordinate Hopf algebra of every finite-type diagonalizable group has the property.
+an isomorphism-invariant object property on commutative Hopf algebras.
 
 The property is deliberately separate from smoothness, connectedness, and finite type. In
 positive characteristic a torus is linearly reductive, while a general reductive group need not
@@ -24,8 +23,6 @@ belongs later in the theory.
 
 * `TauCeti.linearlyReductiveCommHopfAlgProperty`: linear reductivity as an object property.
 * `TauCeti.LinearlyReductiveCommHopfAlgCat`: the corresponding full subcategory.
-* `TauCeti.DiagonalizableGroup.linearlyReductiveCommHopfAlgProperty_coordinateRing`: every
-  diagonalizable coordinate Hopf algebra is linearly reductive.
 
 ## References
 
@@ -70,17 +67,5 @@ instance (k : Type u) [Field k] :
 /-- The category of linearly reductive commutative Hopf algebras over a field. -/
 abbrev LinearlyReductiveCommHopfAlgCat (k : Type u) [Field k] :=
   (linearlyReductiveCommHopfAlgProperty.{u, v, w} k).FullSubcategory
-
-namespace DiagonalizableGroup
-
-/-- The coordinate Hopf algebra of a finite-type diagonalizable group is linearly reductive.
-Equivalently, every finite-dimensional representation of `D(G)` splits as a direct sum of
-weight spaces. -/
-theorem linearlyReductiveCommHopfAlgProperty_coordinateRing
-    (k : Type u) [Field k] (G : FGCommGrpCat.{v}) :
-    linearlyReductiveCommHopfAlgProperty.{u, max u v, w} k (coordinateRing k G).obj :=
-  Coalgebra.isLinearlyReductive_monoidAlgebra k G
-
-end DiagonalizableGroup
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.FiniteType
+public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
+
+/-!
+# Linearly reductive commutative Hopf algebras
+
+An affine group over a field is linearly reductive when every finite-dimensional rational
+representation is completely reducible. This file packages the existing comodule formulation as
+an isomorphism-invariant object property on commutative Hopf algebras. It also records that the
+coordinate Hopf algebra of every finite-type diagonalizable group has the property.
+
+The property is deliberately separate from smoothness, connectedness, and finite type. In
+positive characteristic a torus is linearly reductive, while a general reductive group need not
+be. The comparison with geometric reductivity therefore requires characteristic hypotheses and
+belongs later in the theory.
+
+## Main declarations
+
+* `TauCeti.linearlyReductiveCommHopfAlgProperty`: linear reductivity as an object property.
+* `TauCeti.LinearlyReductiveCommHopfAlgCat`: the corresponding full subcategory.
+* `TauCeti.DiagonalizableGroup.linearlyReductiveCommHopfAlgProperty_coordinateRing`: every
+  diagonalizable coordinate Hopf algebra is linearly reductive.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 3.2.
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.12.
+
+This is the complete-reducibility side of Layer 6, "Reductive and semisimple groups", in the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v w
+
+/-- The object property selecting commutative Hopf algebras for which every finite-dimensional
+comodule is completely reducible. On coordinate rings, this is linear reductivity of the
+represented affine group. -/
+def linearlyReductiveCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (CommHopfAlgCat.{v} k) :=
+  fun H ↦ Coalgebra.IsLinearlyReductive.{u, v, w} k H
+
+/-- Membership in the linearly reductive commutative-Hopf-algebra property means that every
+finite-dimensional comodule is completely reducible. -/
+@[simp]
+theorem linearlyReductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
+    (H : CommHopfAlgCat.{v} k) :
+    linearlyReductiveCommHopfAlgProperty.{u, v, w} k H ↔
+      Coalgebra.IsLinearlyReductive.{u, v, w} k H :=
+  Iff.rfl
+
+/-- Linear reductivity is invariant under isomorphism of commutative Hopf algebras. -/
+instance (k : Type u) [Field k] :
+    (linearlyReductiveCommHopfAlgProperty.{u, v, w} k).IsClosedUnderIsomorphisms where
+  of_iso e hH :=
+    (Coalgebra.isLinearlyReductive_iff_of_coalgEquiv
+      k (CommHopfAlgCat.ofIso e).toCoalgEquiv).mp hH
+
+/-- The category of linearly reductive commutative Hopf algebras over a field. -/
+abbrev LinearlyReductiveCommHopfAlgCat (k : Type u) [Field k] :=
+  (linearlyReductiveCommHopfAlgProperty.{u, v, w} k).FullSubcategory
+
+namespace DiagonalizableGroup
+
+/-- The coordinate Hopf algebra of a finite-type diagonalizable group is linearly reductive.
+Equivalently, every finite-dimensional representation of `D(G)` splits as a direct sum of
+weight spaces. -/
+theorem linearlyReductiveCommHopfAlgProperty_coordinateRing
+    (k : Type u) [Field k] (G : FGCommGrpCat.{v}) :
+    linearlyReductiveCommHopfAlgProperty.{u, max u v, w} k (coordinateRing k G).obj :=
+  Coalgebra.isLinearlyReductive_monoidAlgebra k G
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
@@ -14,8 +14,9 @@ public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
 An affine group over a field is linearly reductive when its finite-dimensional rational
 representations are completely reducible. This file packages the existing comodule formulation
 as an isomorphism-invariant object property on commutative Hopf algebras. For a Hopf algebra in
-`Type v`, the property tests comodule carriers in `Type v`; no universe-transfer result is
-asserted here.
+`Type v`, the property tests comodule carriers in `Type v`. At the scheme-level specialization
+`v = u`, transport to a finite standard basis shows that this test covers carriers in every
+universe.
 
 The property is deliberately separate from smoothness, connectedness, and finite type. In
 positive characteristic a torus is linearly reductive, while a general reductive group need not

--- a/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Category.CommHopfAlgCat
+public import Mathlib.RingTheory.HopfAlgebra.MonoidAlgebra
 public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
 
 /-!
@@ -26,6 +27,8 @@ equivalent in characteristic zero.
 ## Main declarations
 
 * `TauCeti.linearlyReductiveCommHopfAlgProperty`: linear reductivity as an object property.
+* `TauCeti.linearlyReductiveCommHopfAlgProperty_monoidAlgebra`: every commutative group algebra
+  has the property.
 * `TauCeti.LinearlyReductiveCommHopfAlgCat`: the corresponding full subcategory.
 
 ## References
@@ -44,8 +47,9 @@ public section
 namespace TauCeti
 
 open CategoryTheory
+open scoped MonoidAlgebra
 
-universe u v w
+universe u v
 
 /-- The object property selecting commutative Hopf algebras for which every finite-dimensional
 comodule is completely reducible. It tests carriers in the base field's universe, which suffices
@@ -63,21 +67,21 @@ theorem linearlyReductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
       Coalgebra.IsLinearlyReductive.{u, v, u} k H :=
   Iff.rfl
 
-/-- A linearly reductive commutative Hopf algebra has completely reducible finite-dimensional
-comodules in every carrier universe. -/
-theorem linearlyReductiveCommHopfAlgProperty.isCompletelyReducible
-    (k : Type u) [Field k] {H : CommHopfAlgCat.{v} k}
-    (hH : linearlyReductiveCommHopfAlgProperty k H)
-    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k H V] [Module.Finite k V] :
-    Comodule.IsCompletelyReducible k H V :=
-  Coalgebra.IsLinearlyReductive.isCompletelyReducible k hH
-
 /-- Linear reductivity is invariant under isomorphism of commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :
     (linearlyReductiveCommHopfAlgProperty.{u, v} k).IsClosedUnderIsomorphisms where
   of_iso e hH :=
     (Coalgebra.isLinearlyReductive_iff_of_coalgEquiv
       k (CommHopfAlgCat.ofIso e).toCoalgEquiv).mp hH
+
+/-- The monoid algebra of a commutative group is a linearly reductive commutative Hopf
+algebra. -/
+theorem linearlyReductiveCommHopfAlgProperty_monoidAlgebra
+    (k : Type u) [Field k] (G : Type v) [CommGroup G] :
+    linearlyReductiveCommHopfAlgProperty k
+      (CommHopfAlgCat.of k (MonoidAlgebra k G)) :=
+  (linearlyReductiveCommHopfAlgProperty_iff k _).2
+    (Coalgebra.isLinearlyReductive_monoidAlgebra k G)
 
 /-- The category of linearly reductive commutative Hopf algebras over a field. -/
 abbrev LinearlyReductiveCommHopfAlgCat (k : Type u) [Field k] :=

--- a/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean
@@ -13,10 +13,9 @@ public import TauCeti.Algebra.Coalgebra.Comodule.LinearlyReductive
 
 An affine group over a field is linearly reductive when its finite-dimensional rational
 representations are completely reducible. This file packages the existing comodule formulation
-as an isomorphism-invariant object property on commutative Hopf algebras. For a Hopf algebra in
-`Type v`, the property tests comodule carriers in `Type v`. At the scheme-level specialization
-`v = u`, transport to a finite standard basis shows that this test covers carriers in every
-universe.
+as an isomorphism-invariant object property on commutative Hopf algebras. The property tests
+comodule carriers in the base field's universe; transport to a finite standard basis then shows
+that this covers carriers in every universe.
 
 The property is deliberately separate from smoothness, connectedness, and finite type. In
 positive characteristic a torus is linearly reductive, while a general reductive group need not
@@ -36,6 +35,8 @@ equivalent in characteristic zero.
 
 This is the complete-reducibility side of Layer 6, "Reductive and semisimple groups", in the
 ReductiveGroups roadmap.
+
+The organization follows `TauCeti/Algebra/AlgebraicGroup/Unipotent/Basic.lean`.
 -/
 
 public section
@@ -44,23 +45,32 @@ namespace TauCeti
 
 open CategoryTheory
 
-universe u v
+universe u v w
 
 /-- The object property selecting commutative Hopf algebras for which every finite-dimensional
-comodule with carrier in `Type v` is completely reducible. On coordinate rings, this is linear
-reductivity of the represented affine group at that fixed carrier universe. -/
+comodule is completely reducible. It tests carriers in the base field's universe, which suffices
+for carriers in every universe by finite-dimensional transport. -/
 def linearlyReductiveCommHopfAlgProperty (k : Type u) [Field k] :
     ObjectProperty (CommHopfAlgCat.{v} k) :=
-  fun H ↦ Coalgebra.IsLinearlyReductive.{u, v, v} k H
+  fun H ↦ Coalgebra.IsLinearlyReductive.{u, v, u} k H
 
 /-- Membership in the linearly reductive commutative-Hopf-algebra property means that every
-finite-dimensional comodule with carrier in `Type v` is completely reducible. -/
+finite-dimensional comodule with carrier in the base field's universe is completely reducible. -/
 @[simp]
 theorem linearlyReductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
     (H : CommHopfAlgCat.{v} k) :
     linearlyReductiveCommHopfAlgProperty.{u, v} k H ↔
-      Coalgebra.IsLinearlyReductive.{u, v, v} k H :=
+      Coalgebra.IsLinearlyReductive.{u, v, u} k H :=
   Iff.rfl
+
+/-- A linearly reductive commutative Hopf algebra has completely reducible finite-dimensional
+comodules in every carrier universe. -/
+theorem linearlyReductiveCommHopfAlgProperty.isCompletelyReducible
+    (k : Type u) [Field k] {H : CommHopfAlgCat.{v} k}
+    (hH : linearlyReductiveCommHopfAlgProperty k H)
+    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k H V] [Module.Finite k V] :
+    Comodule.IsCompletelyReducible k H V :=
+  Coalgebra.IsLinearlyReductive.isCompletelyReducible k hH
 
 /-- Linear reductivity is invariant under isomorphism of commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -7,7 +7,6 @@ module
 
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra.Basic
-public import TauCeti.Algebra.Coalgebra.Comodule.Transport
 public import TauCeti.Algebra.Coalgebra.Subcomodule.Corestrict
 public import TauCeti.Algebra.Coalgebra.Subcomodule.Transport
 import TauCeti.Algebra.Coalgebra.Subcomodule.Comap

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -167,9 +167,11 @@ theorem isCompletelyReducible_corestrict_iff_of_coalgEquiv (e : C ≃ₗc[k] D)
     Subcomodule.corestrictOrderIso e.symm
   constructor
   · exact isCompletelyReducible_of_orderIso k subcomoduleEquiv.symm (OrderIso.refl _)
-      (fun A ↦ Subcomodule.corestrictOrderIso_symm_apply_toSubmodule e.symm A)
+      (fun A ↦ by simp [subcomoduleEquiv])
   · exact isCompletelyReducible_of_orderIso k subcomoduleEquiv (OrderIso.refl _)
-      (fun A ↦ Subcomodule.corestrictOrderIso_apply_toSubmodule e.symm A)
+      (fun A ↦ by
+        simpa [subcomoduleEquiv] using
+          Subcomodule.corestrict_toSubmodule e.symm.toCoalgHom A)
 
 end Equiv
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -140,6 +140,21 @@ private def uncorestrictSubcomodule (e : C ≃ₗc[k] D)
           | tmul x c => simp
           | add x y hx hy => simpa using congrArg₂ (· + ·) hx hy
 
+private theorem corestrictSubcomodule_toSubmodule (e : C ≃ₗc[k] D)
+    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V]
+    (W : Subcomodule k C V) :
+    letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
+    (corestrictSubcomodule k e W).toSubmodule = W.toSubmodule :=
+  rfl
+
+private theorem uncorestrictSubcomodule_toSubmodule (e : C ≃ₗc[k] D)
+    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V]
+    (W : letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
+      Subcomodule k D V) :
+    letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
+    (uncorestrictSubcomodule k e W).toSubmodule = W.toSubmodule :=
+  rfl
+
 /-- Complete reducibility is unchanged by corestricting a comodule along a coalgebra
 equivalence. -/
 theorem isCompletelyReducible_corestrict_iff (e : C ≃ₗc[k] D)
@@ -151,10 +166,14 @@ theorem isCompletelyReducible_corestrict_iff (e : C ≃ₗc[k] D)
   constructor
   · intro h W
     obtain ⟨Q, hQ⟩ := h (corestrictSubcomodule k e.symm W)
-    exact ⟨uncorestrictSubcomodule k e.symm Q, hQ⟩
+    refine ⟨uncorestrictSubcomodule k e.symm Q, ?_⟩
+    simpa only [corestrictSubcomodule_toSubmodule,
+      uncorestrictSubcomodule_toSubmodule] using hQ
   · intro h W
     obtain ⟨Q, hQ⟩ := h (uncorestrictSubcomodule k e.symm W)
-    exact ⟨corestrictSubcomodule k e.symm Q, hQ⟩
+    refine ⟨corestrictSubcomodule k e.symm Q, ?_⟩
+    simpa only [corestrictSubcomodule_toSubmodule,
+      uncorestrictSubcomodule_toSubmodule] using hQ
 
 end Equiv
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -33,11 +33,13 @@ milestone in Layer 6 of the ReductiveGroups roadmap.
 ## Main declarations
 
 * `TauCeti.Comodule.IsCompletelyReducible`: every subcomodule has a subcomodule complement.
+* `TauCeti.Comodule.isCompletelyReducible_of_orderIso`: transfer complete reducibility across
+  compatible order isomorphisms of subcomodules and underlying submodules.
 * `TauCeti.Comodule.isCompletelyReducible_transport_iff`: complete reducibility is invariant
   under transport along a linear equivalence.
 * `TauCeti.Coalgebra.IsLinearlyReductive`: every finite-dimensional comodule is completely
   reducible.
-* `TauCeti.Coalgebra.isCompletelyReducible_of_isLinearlyReductive`: testing finite-dimensional
+* `TauCeti.Coalgebra.IsLinearlyReductive.isCompletelyReducible`: testing finite-dimensional
   comodules in the base-field universe suffices for comodules in every universe.
 * `TauCeti.Comodule.isCompletelyReducible_corestrict_iff_of_coalgEquiv`: complete reducibility
   is invariant under a coalgebra equivalence.
@@ -96,6 +98,31 @@ end Coalgebra
 
 namespace Comodule
 
+section OrderIso
+
+variable (k : Type u) [CommSemiring k]
+variable {C : Type v} {D : Type*} {V : Type w} {W : Type*}
+variable [AddCommMonoid C] [Module k C] [Coalgebra k C]
+variable [AddCommMonoid D] [Module k D] [Coalgebra k D]
+variable [AddCommMonoid V] [Module k V] [Comodule k C V]
+variable [AddCommMonoid W] [Module k W] [Comodule k D W]
+
+/-- Complete reducibility transfers across compatible order isomorphisms of subcomodules and
+their underlying submodules. -/
+theorem isCompletelyReducible_of_orderIso
+    (Φ : Subcomodule k C V ≃o Subcomodule k D W)
+    (E : Submodule k V ≃o Submodule k W)
+    (hΦ : ∀ A, (Φ A).toSubmodule = E A.toSubmodule)
+    (h : IsCompletelyReducible k C V) : IsCompletelyReducible k D W := by
+  intro A
+  obtain ⟨Q, hQ⟩ := h (Φ.symm A)
+  refine ⟨Φ Q, ?_⟩
+  have hQ' := E.isCompl_iff.mp hQ
+  rw [← hΦ (Φ.symm A), ← hΦ Q, Φ.apply_symm_apply] at hQ'
+  exact hQ'
+
+end OrderIso
+
 section Transport
 
 variable (k : Type u) [CommSemiring k]
@@ -103,6 +130,49 @@ variable {C : Type v} [AddCommMonoid C] [Module k C] [Coalgebra k C]
 variable {V : Type w} {W : Type*}
 variable [AddCommMonoid V] [Module k V] [Comodule k C V]
 variable [AddCommMonoid W] [Module k W]
+
+/-- Transporting a comodule along a linear equivalence identifies its subcomodule lattice with
+the original one. -/
+private def transportSubcomoduleOrderIso (e : V ≃ₗ[k] W) :
+    letI : Comodule k C W := Transport e
+    Subcomodule k C V ≃o Subcomodule k C W := by
+  letI : Comodule k C W := Transport e
+  let f : Hom k C W V := transportInvHom e
+  let g : Hom k C V W := transportToHom e
+  exact
+    { toFun := fun A ↦ A.map g
+      invFun := fun A ↦ A.map f
+      left_inv := by
+        intro A
+        ext v
+        simp only [Subcomodule.mem_map]
+        constructor
+        · rintro ⟨w, ⟨v', hv', rfl⟩, h⟩
+          have hv'v : v' = v := by simpa [f, g] using h
+          exact hv'v ▸ hv'
+        · intro hv
+          refine ⟨g v, ⟨v, hv, rfl⟩, ?_⟩
+          simp [f, g]
+      right_inv := by
+        intro A
+        ext w
+        simp only [Subcomodule.mem_map]
+        constructor
+        · rintro ⟨v, ⟨w', hw', rfl⟩, h⟩
+          have hw'w : w' = w := by simpa [f, g] using h
+          exact hw'w ▸ hw'
+        · intro hw
+          refine ⟨f w, ⟨w, hw, rfl⟩, ?_⟩
+          simp [f, g]
+      map_rel_iff' := by
+        intro A B
+        constructor
+        · intro h v hv
+          have hgv : g v ∈ A.map g := Subcomodule.mem_map_of_mem g hv
+          rcases (Subcomodule.mem_map.mp (h hgv)) with ⟨b, hb, hbv⟩
+          have hbv' : b = v := e.injective (by simpa [g] using hbv)
+          exact hbv' ▸ hb
+        · exact Subcomodule.map_mono g }
 
 /-- Complete reducibility is invariant under transporting a comodule structure along a linear
 equivalence. -/
@@ -112,6 +182,7 @@ theorem isCompletelyReducible_transport_iff (e : V ≃ₗ[k] W) :
   let _ : Comodule k C W := Transport e
   let f : Hom k C W V := transportInvHom e
   let g : Hom k C V W := transportToHom e
+  let Φ : Subcomodule k C V ≃o Subcomodule k C W := transportSubcomoduleOrderIso k e
   let E : Submodule k V ≃o Submodule k W := Submodule.orderIsoMapComap e
   have hmap_f (A : Subcomodule k C W) :
       (A.map f).toSubmodule = E.symm A.toSubmodule := by
@@ -122,20 +193,8 @@ theorem isCompletelyReducible_transport_iff (e : V ≃ₗ[k] W) :
     simp only [Subcomodule.map_toSubmodule, g, transportToHom_toLinearMap,
       E, Submodule.orderIsoMapComap_apply]
   constructor
-  · intro h A
-    obtain ⟨Q, hQ⟩ := h (A.map g)
-    refine ⟨Q.map f, ?_⟩
-    have hQ' := E.symm.isCompl_iff.mp hQ
-    rw [hmap_g, E.symm_apply_apply] at hQ'
-    rw [hmap_f]
-    exact hQ'
-  · intro h A
-    obtain ⟨Q, hQ⟩ := h (A.map f)
-    refine ⟨Q.map g, ?_⟩
-    have hQ' := E.isCompl_iff.mp hQ
-    rw [hmap_f, E.apply_symm_apply] at hQ'
-    rw [hmap_g]
-    exact hQ'
+  · exact isCompletelyReducible_of_orderIso k Φ.symm E.symm hmap_f
+  · exact isCompletelyReducible_of_orderIso k Φ E hmap_g
 
 end Transport
 
@@ -157,16 +216,10 @@ theorem isCompletelyReducible_corestrict_iff_of_coalgEquiv (e : C ≃ₗc[k] D)
   let subcomoduleEquiv : Subcomodule k D V ≃o Subcomodule k C V :=
     Subcomodule.corestrictOrderIso e.symm
   constructor
-  · intro h W
-    obtain ⟨Q, hQ⟩ := h (subcomoduleEquiv W)
-    refine ⟨subcomoduleEquiv.symm Q, ?_⟩
-    simpa only [subcomoduleEquiv, Subcomodule.corestrictOrderIso_apply_toSubmodule,
-      Subcomodule.corestrictOrderIso_symm_apply_toSubmodule] using hQ
-  · intro h W
-    obtain ⟨Q, hQ⟩ := h (subcomoduleEquiv.symm W)
-    refine ⟨subcomoduleEquiv Q, ?_⟩
-    simpa only [subcomoduleEquiv, Subcomodule.corestrictOrderIso_apply_toSubmodule,
-      Subcomodule.corestrictOrderIso_symm_apply_toSubmodule] using hQ
+  · exact isCompletelyReducible_of_orderIso k subcomoduleEquiv.symm (OrderIso.refl _)
+      (fun A ↦ Subcomodule.corestrictOrderIso_symm_apply_toSubmodule e.symm A)
+  · exact isCompletelyReducible_of_orderIso k subcomoduleEquiv (OrderIso.refl _)
+      (fun A ↦ Subcomodule.corestrictOrderIso_apply_toSubmodule e.symm A)
 
 end Equiv
 
@@ -179,10 +232,12 @@ variable {C : Type v} {D : Type*}
 variable [AddCommMonoid C] [Module k C] [Coalgebra k C]
 variable [AddCommMonoid D] [Module k D] [Coalgebra k D]
 
+namespace IsLinearlyReductive
+
 /-- If every finite-dimensional comodule whose carrier is in the base-field universe is
 completely reducible, then every finite-dimensional comodule is completely reducible, regardless
 of its carrier universe. -/
-theorem isCompletelyReducible_of_isLinearlyReductive
+theorem isCompletelyReducible
     (h : IsLinearlyReductive.{u, v, u} k C)
     {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V] [Module.Finite k V] :
     Comodule.IsCompletelyReducible k C V := by
@@ -191,6 +246,8 @@ theorem isCompletelyReducible_of_isLinearlyReductive
   let e : V ≃ₗ[k] (Fin (Module.finrank k V) → k) := (Module.finBasis k V).equivFun
   let _ : Comodule k C (Fin (Module.finrank k V) → k) := Comodule.Transport e
   exact (Comodule.isCompletelyReducible_transport_iff k e).mp (h _)
+
+end IsLinearlyReductive
 
 /-- Linear reductivity is invariant under equivalence of coalgebras. -/
 theorem isLinearlyReductive_iff_of_coalgEquiv (e : C ≃ₗc[k] D) :

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -98,7 +98,7 @@ namespace Comodule
 
 section Transport
 
-variable (k : Type u) [Field k]
+variable (k : Type u) [CommSemiring k]
 variable {C : Type v} [AddCommMonoid C] [Module k C] [Coalgebra k C]
 variable {V : Type w} {W : Type*}
 variable [AddCommMonoid V] [Module k V] [Comodule k C V]

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 import Mathlib.LinearAlgebra.Basis.VectorSpace
+public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra.Basic
 import TauCeti.Algebra.Coalgebra.Subcomodule.Comap
 
@@ -32,6 +33,10 @@ milestone in Layer 6 of the ReductiveGroups roadmap.
 * `TauCeti.Comodule.IsCompletelyReducible`: every subcomodule has a subcomodule complement.
 * `TauCeti.Coalgebra.IsLinearlyReductive`: every finite-dimensional comodule is completely
   reducible.
+* `TauCeti.Comodule.isCompletelyReducible_corestrict_iff`: complete reducibility is invariant
+  under a coalgebra equivalence.
+* `TauCeti.Coalgebra.isLinearlyReductive_iff_of_coalgEquiv`: linear reductivity is invariant
+  under a coalgebra equivalence.
 * `TauCeti.Coalgebra.isLinearlyReductive_monoidAlgebra`: monoid-algebra coalgebras are linearly
   reductive over a field.
 
@@ -79,6 +84,99 @@ usual complete-reducibility definition of a linearly reductive group. -/
 def IsLinearlyReductive : Prop :=
   ∀ (V : Type w) [AddCommMonoid V] [Module k V] [Comodule k C V] [Module.Finite k V],
     Comodule.IsCompletelyReducible k C V
+
+end Coalgebra
+
+namespace Comodule
+
+section Equiv
+
+variable (k : Type u) [Field k]
+variable {C : Type v} {D : Type*}
+variable [AddCommMonoid C] [Module k C] [Coalgebra k C]
+variable [AddCommMonoid D] [Module k D] [Coalgebra k D]
+
+/-- A subcomodule remains stable after corestriction along a coalgebra equivalence. -/
+private def corestrictSubcomodule (e : C ≃ₗc[k] D)
+    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V]
+    (W : Subcomodule k C V) :
+    letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
+    Subcomodule k D V :=
+  letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
+  Subcomodule.ofSubmodule W.carrier fun v hv ↦ by
+    obtain ⟨t, ht⟩ := W.coact_mem hv
+    refine ⟨TensorProduct.map LinearMap.id e.toLinearMap t, ?_⟩
+    rw [Comodule.corestrict_coact_apply]
+    calc
+      _ = TensorProduct.map LinearMap.id e.toLinearMap
+          (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
+            simp [TensorProduct.map_map]
+      _ = _ := congrArg (TensorProduct.map LinearMap.id e.toLinearMap) ht
+
+/-- A subcomodule corestricted along a coalgebra equivalence is stable for the original
+coaction. -/
+private def uncorestrictSubcomodule (e : C ≃ₗc[k] D)
+    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V]
+    (W : letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
+      Subcomodule k D V) : Subcomodule k C V :=
+  by
+    let _ : Comodule k D V := Comodule.Corestrict e.toCoalgHom
+    exact Subcomodule.ofSubmodule W.carrier fun v hv ↦ by
+      obtain ⟨t, ht⟩ := W.coact_mem hv
+      rw [Comodule.corestrict_coact_apply] at ht
+      refine ⟨TensorProduct.map LinearMap.id e.symm.toLinearMap t, ?_⟩
+      calc
+        _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
+            (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
+              simp [TensorProduct.map_map]
+        _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
+            (TensorProduct.map LinearMap.id e.toLinearMap
+              (Comodule.coact (R := k) (C := C) (M := V) v)) :=
+          congrArg (TensorProduct.map LinearMap.id e.symm.toLinearMap) ht
+        _ = _ := by
+          induction Comodule.coact (R := k) (C := C) (M := V) v using
+            TensorProduct.induction_on with
+          | zero => simp
+          | tmul x c => simp
+          | add x y hx hy => simpa using congrArg₂ (· + ·) hx hy
+
+/-- Complete reducibility is unchanged by corestricting a comodule along a coalgebra
+equivalence. -/
+theorem isCompletelyReducible_corestrict_iff (e : C ≃ₗc[k] D)
+    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k D V] :
+    (letI : Comodule k C V := Comodule.Corestrict e.symm.toCoalgHom;
+      Comodule.IsCompletelyReducible k C V) ↔
+      Comodule.IsCompletelyReducible k D V := by
+  let _ : Comodule k C V := Comodule.Corestrict e.symm.toCoalgHom
+  constructor
+  · intro h W
+    obtain ⟨Q, hQ⟩ := h (corestrictSubcomodule k e.symm W)
+    exact ⟨uncorestrictSubcomodule k e.symm Q, hQ⟩
+  · intro h W
+    obtain ⟨Q, hQ⟩ := h (uncorestrictSubcomodule k e.symm W)
+    exact ⟨corestrictSubcomodule k e.symm Q, hQ⟩
+
+end Equiv
+
+end Comodule
+
+namespace Coalgebra
+
+variable (k : Type u) [Field k]
+variable {C : Type v} {D : Type*}
+variable [AddCommMonoid C] [Module k C] [Coalgebra k C]
+variable [AddCommMonoid D] [Module k D] [Coalgebra k D]
+
+/-- Linear reductivity is invariant under equivalence of coalgebras. -/
+theorem isLinearlyReductive_iff_of_coalgEquiv (e : C ≃ₗc[k] D) :
+    IsLinearlyReductive.{u, v, w} k C ↔ IsLinearlyReductive.{u, _, w} k D := by
+  constructor
+  · intro h V _ _ _ _
+    let _ : Comodule k C V := Comodule.Corestrict e.symm.toCoalgHom
+    exact (Comodule.isCompletelyReducible_corestrict_iff k e).mp (h V)
+  · intro h V _ _ _ _
+    let _ : Comodule k D V := Comodule.Corestrict e.toCoalgHom
+    exact (Comodule.isCompletelyReducible_corestrict_iff k e.symm).mp (h V)
 
 end Coalgebra
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -9,6 +9,7 @@ import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra.Basic
 public import TauCeti.Algebra.Coalgebra.Comodule.Transport
 public import TauCeti.Algebra.Coalgebra.Subcomodule.Corestrict
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Transport
 import TauCeti.Algebra.Coalgebra.Subcomodule.Comap
 
 /-!
@@ -131,70 +132,19 @@ variable {V : Type w} {W : Type*}
 variable [AddCommMonoid V] [Module k V] [Comodule k C V]
 variable [AddCommMonoid W] [Module k W]
 
-/-- Transporting a comodule along a linear equivalence identifies its subcomodule lattice with
-the original one. -/
-private def transportSubcomoduleOrderIso (e : V ≃ₗ[k] W) :
-    letI : Comodule k C W := Transport e
-    Subcomodule k C V ≃o Subcomodule k C W := by
-  letI : Comodule k C W := Transport e
-  let f : Hom k C W V := transportInvHom e
-  let g : Hom k C V W := transportToHom e
-  exact
-    { toFun := fun A ↦ A.map g
-      invFun := fun A ↦ A.map f
-      left_inv := by
-        intro A
-        ext v
-        simp only [Subcomodule.mem_map]
-        constructor
-        · rintro ⟨w, ⟨v', hv', rfl⟩, h⟩
-          have hv'v : v' = v := by simpa [f, g] using h
-          exact hv'v ▸ hv'
-        · intro hv
-          refine ⟨g v, ⟨v, hv, rfl⟩, ?_⟩
-          simp [f, g]
-      right_inv := by
-        intro A
-        ext w
-        simp only [Subcomodule.mem_map]
-        constructor
-        · rintro ⟨v, ⟨w', hw', rfl⟩, h⟩
-          have hw'w : w' = w := by simpa [f, g] using h
-          exact hw'w ▸ hw'
-        · intro hw
-          refine ⟨f w, ⟨w, hw, rfl⟩, ?_⟩
-          simp [f, g]
-      map_rel_iff' := by
-        intro A B
-        constructor
-        · intro h v hv
-          have hgv : g v ∈ A.map g := Subcomodule.mem_map_of_mem g hv
-          rcases (Subcomodule.mem_map.mp (h hgv)) with ⟨b, hb, hbv⟩
-          have hbv' : b = v := e.injective (by simpa [g] using hbv)
-          exact hbv' ▸ hb
-        · exact Subcomodule.map_mono g }
-
 /-- Complete reducibility is invariant under transporting a comodule structure along a linear
 equivalence. -/
 theorem isCompletelyReducible_transport_iff (e : V ≃ₗ[k] W) :
     (letI : Comodule k C W := Transport e;
       IsCompletelyReducible k C W) ↔ IsCompletelyReducible k C V := by
   let _ : Comodule k C W := Transport e
-  let f : Hom k C W V := transportInvHom e
-  let g : Hom k C V W := transportToHom e
-  let Φ : Subcomodule k C V ≃o Subcomodule k C W := transportSubcomoduleOrderIso k e
+  let Φ : Subcomodule k C V ≃o Subcomodule k C W := Subcomodule.transportOrderIso e
   let E : Submodule k V ≃o Submodule k W := Submodule.orderIsoMapComap e
-  have hmap_f (A : Subcomodule k C W) :
-      (A.map f).toSubmodule = E.symm A.toSubmodule := by
-    simp only [Subcomodule.map_toSubmodule, f, transportInvHom_toLinearMap]
-    exact (Submodule.orderIsoMapComap_symm_apply' e A.toSubmodule).symm
-  have hmap_g (A : Subcomodule k C V) :
-      (A.map g).toSubmodule = E A.toSubmodule := by
-    simp only [Subcomodule.map_toSubmodule, g, transportToHom_toLinearMap,
-      E, Submodule.orderIsoMapComap_apply]
   constructor
-  · exact isCompletelyReducible_of_orderIso k Φ.symm E.symm hmap_f
-  · exact isCompletelyReducible_of_orderIso k Φ E hmap_g
+  · exact isCompletelyReducible_of_orderIso k Φ.symm E.symm
+      (Subcomodule.transportOrderIso_symm_apply_toSubmodule e)
+  · exact isCompletelyReducible_of_orderIso k Φ E
+      (Subcomodule.transportOrderIso_apply_toSubmodule e)
 
 end Transport
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -7,6 +7,7 @@ module
 
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule.Transport
 public import TauCeti.Algebra.Coalgebra.Subcomodule.Corestrict
 import TauCeti.Algebra.Coalgebra.Subcomodule.Comap
 
@@ -32,8 +33,12 @@ milestone in Layer 6 of the ReductiveGroups roadmap.
 ## Main declarations
 
 * `TauCeti.Comodule.IsCompletelyReducible`: every subcomodule has a subcomodule complement.
+* `TauCeti.Comodule.isCompletelyReducible_transport_iff`: complete reducibility is invariant
+  under transport along a linear equivalence.
 * `TauCeti.Coalgebra.IsLinearlyReductive`: every finite-dimensional comodule is completely
   reducible.
+* `TauCeti.Coalgebra.isCompletelyReducible_of_isLinearlyReductive`: testing finite-dimensional
+  comodules in the base-field universe suffices for comodules in every universe.
 * `TauCeti.Comodule.isCompletelyReducible_corestrict_iff_of_coalgEquiv`: complete reducibility
   is invariant under a coalgebra equivalence.
 * `TauCeti.Coalgebra.isLinearlyReductive_iff_of_coalgEquiv`: linear reductivity is invariant
@@ -91,6 +96,49 @@ end Coalgebra
 
 namespace Comodule
 
+section Transport
+
+variable (k : Type u) [Field k]
+variable {C : Type v} [AddCommMonoid C] [Module k C] [Coalgebra k C]
+variable {V : Type w} {W : Type*}
+variable [AddCommMonoid V] [Module k V] [Comodule k C V]
+variable [AddCommMonoid W] [Module k W]
+
+/-- Complete reducibility is invariant under transporting a comodule structure along a linear
+equivalence. -/
+theorem isCompletelyReducible_transport_iff (e : V ≃ₗ[k] W) :
+    (letI : Comodule k C W := Transport e;
+      IsCompletelyReducible k C W) ↔ IsCompletelyReducible k C V := by
+  let _ : Comodule k C W := Transport e
+  let f : Hom k C W V := transportInvHom e
+  let g : Hom k C V W := transportToHom e
+  let E : Submodule k V ≃o Submodule k W := Submodule.orderIsoMapComap e
+  have hmap_f (A : Subcomodule k C W) :
+      (A.map f).toSubmodule = E.symm A.toSubmodule := by
+    simp only [Subcomodule.map_toSubmodule, f, transportInvHom_toLinearMap]
+    exact (Submodule.orderIsoMapComap_symm_apply' e A.toSubmodule).symm
+  have hmap_g (A : Subcomodule k C V) :
+      (A.map g).toSubmodule = E A.toSubmodule := by
+    simp only [Subcomodule.map_toSubmodule, g, transportToHom_toLinearMap,
+      E, Submodule.orderIsoMapComap_apply]
+  constructor
+  · intro h A
+    obtain ⟨Q, hQ⟩ := h (A.map g)
+    refine ⟨Q.map f, ?_⟩
+    have hQ' := E.symm.isCompl_iff.mp hQ
+    rw [hmap_g, E.symm_apply_apply] at hQ'
+    rw [hmap_f]
+    exact hQ'
+  · intro h A
+    obtain ⟨Q, hQ⟩ := h (A.map f)
+    refine ⟨Q.map g, ?_⟩
+    have hQ' := E.isCompl_iff.mp hQ
+    rw [hmap_f, E.apply_symm_apply] at hQ'
+    rw [hmap_g]
+    exact hQ'
+
+end Transport
+
 section Equiv
 
 variable (k : Type u) [CommSemiring k]
@@ -130,6 +178,19 @@ variable (k : Type u) [Field k]
 variable {C : Type v} {D : Type*}
 variable [AddCommMonoid C] [Module k C] [Coalgebra k C]
 variable [AddCommMonoid D] [Module k D] [Coalgebra k D]
+
+/-- If every finite-dimensional comodule whose carrier is in the base-field universe is
+completely reducible, then every finite-dimensional comodule is completely reducible, regardless
+of its carrier universe. -/
+theorem isCompletelyReducible_of_isLinearlyReductive
+    (h : IsLinearlyReductive.{u, v, u} k C)
+    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V] [Module.Finite k V] :
+    Comodule.IsCompletelyReducible k C V := by
+  let : AddCommGroup V := Module.addCommMonoidToAddCommGroup k
+  let : Module.Free k V := Module.Free.of_divisionRing k V
+  let e : V ≃ₗ[k] (Fin (Module.finrank k V) → k) := (Module.finBasis k V).equivFun
+  let _ : Comodule k C (Fin (Module.finrank k V) → k) := Comodule.Transport e
+  exact (Comodule.isCompletelyReducible_transport_iff k e).mp (h _)
 
 /-- Linear reductivity is invariant under equivalence of coalgebras. -/
 theorem isLinearlyReductive_iff_of_coalgEquiv (e : C ≃ₗc[k] D) :

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -6,22 +6,23 @@ Authors: The Tau Ceti contributors
 module
 
 import Mathlib.LinearAlgebra.Basis.VectorSpace
-public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.MonoidAlgebra.Basic
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Corestrict
 import TauCeti.Algebra.Coalgebra.Subcomodule.Comap
 
 /-!
-# Linear reductivity of diagonalizable groups
+# Complete reducibility and linear reductivity
 
 An affine group over a field is linearly reductive when every finite-dimensional rational
 representation is completely reducible. On coordinate rings, rational representations are
 comodules, and complete reducibility says that every subcomodule has a subcomodule complement.
 
-This file introduces that intrinsic comodule formulation and proves it for every monoid-algebra
-coalgebra `k[G]`. The proof makes an arbitrary linear projection onto a subcomodule equivariant:
-decompose a vector into its weights, apply the projection separately on each weight, and project
-the result back to that weight. The resulting idempotent comodule endomorphism has the original
-subcomodule as its range, so its kernel is an invariant complement.
+This file introduces that intrinsic comodule formulation, proves that complete reducibility is
+invariant under corestriction along a coalgebra equivalence, and proves linear reductivity for
+every monoid-algebra coalgebra `k[G]`. The last proof makes an arbitrary linear projection onto a
+subcomodule equivariant: decompose a vector into its weights, apply the projection separately on
+each weight, and project the result back to that weight. The resulting idempotent comodule
+endomorphism has the original subcomodule as its range, so its kernel is an invariant complement.
 
 For an abelian group `G`, `k[G]` is the coordinate Hopf algebra of the diagonalizable group
 `D(G)`. Thus every diagonalizable group, and in particular every split torus, is linearly
@@ -33,8 +34,8 @@ milestone in Layer 6 of the ReductiveGroups roadmap.
 * `TauCeti.Comodule.IsCompletelyReducible`: every subcomodule has a subcomodule complement.
 * `TauCeti.Coalgebra.IsLinearlyReductive`: every finite-dimensional comodule is completely
   reducible.
-* `TauCeti.Comodule.isCompletelyReducible_corestrict_iff`: complete reducibility is invariant
-  under a coalgebra equivalence.
+* `TauCeti.Comodule.isCompletelyReducible_corestrict_iff_of_coalgEquiv`: complete reducibility
+  is invariant under a coalgebra equivalence.
 * `TauCeti.Coalgebra.isLinearlyReductive_iff_of_coalgEquiv`: linear reductivity is invariant
   under a coalgebra equivalence.
 * `TauCeti.Coalgebra.isLinearlyReductive_monoidAlgebra`: monoid-algebra coalgebras are linearly
@@ -78,9 +79,10 @@ variable (k : Type u) (C : Type v)
 variable [Field k]
 variable [AddCommMonoid C] [Module k C] [Coalgebra k C]
 
-/-- A coalgebra is linearly reductive when every finite-dimensional comodule over it is
-completely reducible. For a commutative Hopf algebra representing an affine group, this is the
-usual complete-reducibility definition of a linearly reductive group. -/
+/-- A coalgebra is linearly reductive in carrier universe `w` when every finite-dimensional
+comodule over it whose carrier lies in `Type w` is completely reducible. For a commutative Hopf
+algebra representing an affine group, this is the usual complete-reducibility definition of a
+linearly reductive group at that universe. -/
 def IsLinearlyReductive : Prop :=
   ∀ (V : Type w) [AddCommMonoid V] [Module k V] [Comodule k C V] [Module.Finite k V],
     Comodule.IsCompletelyReducible k C V
@@ -91,89 +93,32 @@ namespace Comodule
 
 section Equiv
 
-variable (k : Type u) [Field k]
+variable (k : Type u) [CommSemiring k]
 variable {C : Type v} {D : Type*}
 variable [AddCommMonoid C] [Module k C] [Coalgebra k C]
 variable [AddCommMonoid D] [Module k D] [Coalgebra k D]
 
-/-- A subcomodule remains stable after corestriction along a coalgebra equivalence. -/
-private def corestrictSubcomodule (e : C ≃ₗc[k] D)
-    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V]
-    (W : Subcomodule k C V) :
-    letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
-    Subcomodule k D V :=
-  letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
-  Subcomodule.ofSubmodule W.carrier fun v hv ↦ by
-    obtain ⟨t, ht⟩ := W.coact_mem hv
-    refine ⟨TensorProduct.map LinearMap.id e.toLinearMap t, ?_⟩
-    rw [Comodule.corestrict_coact_apply]
-    calc
-      _ = TensorProduct.map LinearMap.id e.toLinearMap
-          (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
-            simp [TensorProduct.map_map]
-      _ = _ := congrArg (TensorProduct.map LinearMap.id e.toLinearMap) ht
-
-/-- A subcomodule corestricted along a coalgebra equivalence is stable for the original
-coaction. -/
-private def uncorestrictSubcomodule (e : C ≃ₗc[k] D)
-    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V]
-    (W : letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
-      Subcomodule k D V) : Subcomodule k C V :=
-  by
-    let _ : Comodule k D V := Comodule.Corestrict e.toCoalgHom
-    exact Subcomodule.ofSubmodule W.carrier fun v hv ↦ by
-      obtain ⟨t, ht⟩ := W.coact_mem hv
-      rw [Comodule.corestrict_coact_apply] at ht
-      refine ⟨TensorProduct.map LinearMap.id e.symm.toLinearMap t, ?_⟩
-      calc
-        _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
-            (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
-              simp [TensorProduct.map_map]
-        _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
-            (TensorProduct.map LinearMap.id e.toLinearMap
-              (Comodule.coact (R := k) (C := C) (M := V) v)) :=
-          congrArg (TensorProduct.map LinearMap.id e.symm.toLinearMap) ht
-        _ = _ := by
-          induction Comodule.coact (R := k) (C := C) (M := V) v using
-            TensorProduct.induction_on with
-          | zero => simp
-          | tmul x c => simp
-          | add x y hx hy => simpa using congrArg₂ (· + ·) hx hy
-
-private theorem corestrictSubcomodule_toSubmodule (e : C ≃ₗc[k] D)
-    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V]
-    (W : Subcomodule k C V) :
-    letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
-    (corestrictSubcomodule k e W).toSubmodule = W.toSubmodule :=
-  rfl
-
-private theorem uncorestrictSubcomodule_toSubmodule (e : C ≃ₗc[k] D)
-    {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k C V]
-    (W : letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
-      Subcomodule k D V) :
-    letI : Comodule k D V := Comodule.Corestrict e.toCoalgHom
-    (uncorestrictSubcomodule k e W).toSubmodule = W.toSubmodule :=
-  rfl
-
 /-- Complete reducibility is unchanged by corestricting a comodule along a coalgebra
 equivalence. -/
-theorem isCompletelyReducible_corestrict_iff (e : C ≃ₗc[k] D)
+theorem isCompletelyReducible_corestrict_iff_of_coalgEquiv (e : C ≃ₗc[k] D)
     {V : Type w} [AddCommMonoid V] [Module k V] [Comodule k D V] :
     (letI : Comodule k C V := Comodule.Corestrict e.symm.toCoalgHom;
       Comodule.IsCompletelyReducible k C V) ↔
       Comodule.IsCompletelyReducible k D V := by
   let _ : Comodule k C V := Comodule.Corestrict e.symm.toCoalgHom
+  let subcomoduleEquiv : Subcomodule k D V ≃o Subcomodule k C V :=
+    Subcomodule.corestrictOrderIso e.symm
   constructor
   · intro h W
-    obtain ⟨Q, hQ⟩ := h (corestrictSubcomodule k e.symm W)
-    refine ⟨uncorestrictSubcomodule k e.symm Q, ?_⟩
-    simpa only [corestrictSubcomodule_toSubmodule,
-      uncorestrictSubcomodule_toSubmodule] using hQ
+    obtain ⟨Q, hQ⟩ := h (subcomoduleEquiv W)
+    refine ⟨subcomoduleEquiv.symm Q, ?_⟩
+    simpa only [subcomoduleEquiv, Subcomodule.corestrictOrderIso_apply_toSubmodule,
+      Subcomodule.corestrictOrderIso_symm_apply_toSubmodule] using hQ
   · intro h W
-    obtain ⟨Q, hQ⟩ := h (uncorestrictSubcomodule k e.symm W)
-    refine ⟨corestrictSubcomodule k e.symm Q, ?_⟩
-    simpa only [corestrictSubcomodule_toSubmodule,
-      uncorestrictSubcomodule_toSubmodule] using hQ
+    obtain ⟨Q, hQ⟩ := h (subcomoduleEquiv.symm W)
+    refine ⟨subcomoduleEquiv Q, ?_⟩
+    simpa only [subcomoduleEquiv, Subcomodule.corestrictOrderIso_apply_toSubmodule,
+      Subcomodule.corestrictOrderIso_symm_apply_toSubmodule] using hQ
 
 end Equiv
 
@@ -192,10 +137,10 @@ theorem isLinearlyReductive_iff_of_coalgEquiv (e : C ≃ₗc[k] D) :
   constructor
   · intro h V _ _ _ _
     let _ : Comodule k C V := Comodule.Corestrict e.symm.toCoalgHom
-    exact (Comodule.isCompletelyReducible_corestrict_iff k e).mp (h V)
+    exact (Comodule.isCompletelyReducible_corestrict_iff_of_coalgEquiv k e).mp (h V)
   · intro h V _ _ _ _
     let _ : Comodule k D V := Comodule.Corestrict e.toCoalgHom
-    exact (Comodule.isCompletelyReducible_corestrict_iff k e.symm).mp (h V)
+    exact (Comodule.isCompletelyReducible_corestrict_iff_of_coalgEquiv k e.symm).mp (h V)
 
 end Coalgebra
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -85,10 +85,11 @@ corestriction, without changing their underlying submodules. -/
                 (Comodule.coact (R := R) (C := C) (M := M) m)) :=
             congrArg (TensorProduct.map LinearMap.id e.symm.toLinearMap) ht
           _ = _ := by
-            rw [TensorProduct.map_map]
-            rw [show e.symm.toLinearMap.comp e.toLinearMap = LinearMap.id by
+            have hinv : e.symm.toLinearMap.comp e.toLinearMap = LinearMap.id := by
               ext c
-              simp]
+              simp
+            rw [TensorProduct.map_map]
+            rw [hinv]
             simp
     left_inv := by
       intro W

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -43,7 +43,7 @@ variable [AddCommMonoid D] [Module R D] [Coalgebra R D]
 variable {M : Type x} [AddCommMonoid M] [Module R M] [Comodule R C M]
 
 /-- Corestriction along a coalgebra morphism preserves a subcomodule and its carrier. -/
-@[expose] def corestrict (f : C →ₗc[R] D) (W : Subcomodule R C M) :
+def corestrict (f : C →ₗc[R] D) (W : Subcomodule R C M) :
     letI : Comodule R D M := Comodule.Corestrict f
     Subcomodule R D M :=
   letI : Comodule R D M := Comodule.Corestrict f
@@ -62,11 +62,11 @@ variable {M : Type x} [AddCommMonoid M] [Module R M] [Comodule R C M]
 theorem corestrict_toSubmodule (f : C →ₗc[R] D) (W : Subcomodule R C M) :
     letI : Comodule R D M := Comodule.Corestrict f
     (W.corestrict f).toSubmodule = W.toSubmodule :=
-  rfl
+  (rfl)
 
 /-- A coalgebra equivalence identifies the subcomodules of a comodule with those of its
 corestriction, without changing their underlying submodules. -/
-@[expose] def corestrictOrderIso (e : C ≃ₗc[R] D) :
+def corestrictOrderIso (e : C ≃ₗc[R] D) :
     letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
     Subcomodule R C M ≃o Subcomodule R D M :=
   letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
@@ -108,7 +108,7 @@ theorem corestrictOrderIso_apply_toSubmodule (e : C ≃ₗc[R] D)
     (W : Subcomodule R C M) :
     letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
     (corestrictOrderIso e W).toSubmodule = W.toSubmodule :=
-  rfl
+  (rfl)
 
 /-- The inverse subcomodule correspondence preserves the underlying submodule. -/
 @[simp]
@@ -117,7 +117,7 @@ theorem corestrictOrderIso_symm_apply_toSubmodule (e : C ≃ₗc[R] D)
       Subcomodule R D M) :
     letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
     ((corestrictOrderIso e).symm W).toSubmodule = W.toSubmodule :=
-  rfl
+  (rfl)
 
 end Subcomodule
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -182,41 +182,6 @@ theorem corestrictOrderIso_symm_apply (e : C ≃ₗc[R] D)
     ext m
     rfl
 
-/-- Membership is unchanged by the forward subcomodule correspondence. -/
-theorem mem_corestrictOrderIso (e : C ≃ₗc[R] D) (W : Subcomodule R C M) (m : M) :
-    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-    m ∈ corestrictOrderIso e W ↔ m ∈ W :=
-  by
-    let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-    rw [corestrictOrderIso_apply, mem_corestrict]
-
-/-- Membership is unchanged by the inverse subcomodule correspondence. -/
-theorem mem_corestrictOrderIso_symm (e : C ≃ₗc[R] D)
-    (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-      Subcomodule R D M) (m : M) :
-    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-    m ∈ (corestrictOrderIso e).symm W ↔ m ∈ W :=
-  by
-    let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-    -- Expose subcomodule membership as submodule membership so the carrier lemma can rewrite it.
-    change m ∈ (corestrictSymm e W).toSubmodule ↔ m ∈ W.toSubmodule
-    rw [corestrictSymm_toSubmodule]
-
-/-- The forward subcomodule correspondence preserves the underlying submodule. -/
-theorem corestrictOrderIso_apply_toSubmodule (e : C ≃ₗc[R] D)
-    (W : Subcomodule R C M) :
-    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-    (corestrictOrderIso e W).toSubmodule = W.toSubmodule :=
-  (rfl)
-
-/-- The inverse subcomodule correspondence preserves the underlying submodule. -/
-theorem corestrictOrderIso_symm_apply_toSubmodule (e : C ≃ₗc[R] D)
-    (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-      Subcomodule R D M) :
-    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-    ((corestrictOrderIso e).symm W).toSubmodule = W.toSubmodule :=
-  (rfl)
-
 end Subcomodule
 
 end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -22,8 +22,14 @@ coalgebras must preserve the invariant subspaces of their comodules.
 ## Main declarations
 
 * `TauCeti.Subcomodule.corestrict`: corestrict a subcomodule along a coalgebra morphism.
+* `TauCeti.Subcomodule.corestrictSymm`: recover a subcomodule before corestriction along a
+  coalgebra equivalence.
 * `TauCeti.Subcomodule.corestrictOrderIso`: the carrier-preserving order isomorphism induced
   by a coalgebra equivalence.
+
+## References
+
+* M. Sweedler, *Hopf Algebras*, Chapter 2.
 -/
 
 public section
@@ -64,6 +70,49 @@ theorem corestrict_toSubmodule (f : C →ₗc[R] D) (W : Subcomodule R C M) :
     (W.corestrict f).toSubmodule = W.toSubmodule :=
   (rfl)
 
+/-- Membership is unchanged by corestriction of a subcomodule. -/
+@[simp]
+theorem mem_corestrict (f : C →ₗc[R] D) (W : Subcomodule R C M) (m : M) :
+    letI : Comodule R D M := Comodule.Corestrict f
+    m ∈ W.corestrict f ↔ m ∈ W :=
+  Iff.rfl
+
+/-- Pull a subcomodule of a corestricted comodule back along a coalgebra equivalence. -/
+def corestrictSymm (e : C ≃ₗc[R] D)
+    (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+      Subcomodule R D M) : Subcomodule R C M :=
+  letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+  Subcomodule.ofSubmodule W.carrier fun m hm ↦ by
+    obtain ⟨t, ht⟩ := W.coact_mem hm
+    rw [Comodule.corestrict_coact_apply] at ht
+    refine ⟨TensorProduct.map LinearMap.id e.symm.toLinearMap t, ?_⟩
+    calc
+      _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
+          (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
+            simp [TensorProduct.map_map]
+      _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
+          (TensorProduct.map LinearMap.id e.toLinearMap
+            (Comodule.coact (R := R) (C := C) (M := M) m)) :=
+        congrArg (TensorProduct.map LinearMap.id e.symm.toLinearMap) ht
+      _ = _ := by
+        have hinv : e.symm.toLinearMap.comp e.toLinearMap = LinearMap.id := by
+          ext c
+          simp
+        rw [TensorProduct.map_map]
+        rw [hinv]
+        simp
+
+/-- Pulling a subcomodule back from a corestriction preserves its underlying submodule. -/
+@[simp]
+theorem corestrictSymm_toSubmodule (e : C ≃ₗc[R] D)
+    (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+      Subcomodule R D M) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    (corestrictSymm e W).toSubmodule = W.toSubmodule :=
+  by
+    ext m
+    rfl
+
 /-- A coalgebra equivalence identifies the subcomodules of a comodule with those of its
 corestriction, without changing their underlying submodules. -/
 def corestrictOrderIso (e : C ≃ₗc[R] D) :
@@ -71,26 +120,9 @@ def corestrictOrderIso (e : C ≃ₗc[R] D) :
     Subcomodule R C M ≃o Subcomodule R D M :=
   letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
   { toFun := fun W ↦ W.corestrict e.toCoalgHom
-    invFun := fun W ↦
-      Subcomodule.ofSubmodule W.carrier fun m hm ↦ by
-        obtain ⟨t, ht⟩ := W.coact_mem hm
-        rw [Comodule.corestrict_coact_apply] at ht
-        refine ⟨TensorProduct.map LinearMap.id e.symm.toLinearMap t, ?_⟩
-        calc
-          _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
-              (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
-                simp [TensorProduct.map_map]
-          _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
-              (TensorProduct.map LinearMap.id e.toLinearMap
-                (Comodule.coact (R := R) (C := C) (M := M) m)) :=
-            congrArg (TensorProduct.map LinearMap.id e.symm.toLinearMap) ht
-          _ = _ := by
-            have hinv : e.symm.toLinearMap.comp e.toLinearMap = LinearMap.id := by
-              ext c
-              simp
-            rw [TensorProduct.map_map]
-            rw [hinv]
-            simp
+    invFun := corestrictSymm e
+    -- Both directions are built with `ofSubmodule W.carrier`, so carrier equality and order
+    -- reflection hold definitionally.
     left_inv := by
       intro W
       ext m
@@ -102,8 +134,37 @@ def corestrictOrderIso (e : C ≃ₗc[R] D) :
     map_rel_iff' := by
       rfl }
 
-/-- The forward subcomodule correspondence preserves the underlying submodule. -/
+/-- The forward order correspondence is corestriction. -/
 @[simp]
+theorem corestrictOrderIso_apply (e : C ≃ₗc[R] D) (W : Subcomodule R C M) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    corestrictOrderIso e W = W.corestrict e.toCoalgHom :=
+  by
+    let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    ext m
+    rfl
+
+/-- Membership is unchanged by the forward subcomodule correspondence. -/
+theorem mem_corestrictOrderIso (e : C ≃ₗc[R] D) (W : Subcomodule R C M) (m : M) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    m ∈ corestrictOrderIso e W ↔ m ∈ W :=
+  by
+    let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    rw [corestrictOrderIso_apply, mem_corestrict]
+
+/-- Membership is unchanged by the inverse subcomodule correspondence. -/
+@[simp]
+theorem mem_corestrictOrderIso_symm (e : C ≃ₗc[R] D)
+    (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+      Subcomodule R D M) (m : M) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    m ∈ (corestrictOrderIso e).symm W ↔ m ∈ W :=
+  by
+    let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    change m ∈ (corestrictSymm e W).toSubmodule ↔ m ∈ W.toSubmodule
+    rw [corestrictSymm_toSubmodule]
+
+/-- The forward subcomodule correspondence preserves the underlying submodule. -/
 theorem corestrictOrderIso_apply_toSubmodule (e : C ≃ₗc[R] D)
     (W : Subcomodule R C M) :
     letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Coalgebra.Equiv
+public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Basic
+
+/-!
+# Corestriction of subcomodules
+
+Corestriction of a comodule along a coalgebra morphism preserves every subcomodule and its
+underlying submodule. When the coalgebra morphism is an equivalence, this gives an order
+isomorphism between the subcomodule lattices before and after corestriction.
+
+This is Layer 1 infrastructure for the reductive-groups roadmap: changing coordinate
+coalgebras must preserve the invariant subspaces of their comodules.
+
+## Main declarations
+
+* `TauCeti.Subcomodule.corestrict`: corestrict a subcomodule along a coalgebra morphism.
+* `TauCeti.Subcomodule.corestrictOrderIso`: the carrier-preserving order isomorphism induced
+  by a coalgebra equivalence.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w x
+
+namespace Subcomodule
+
+variable {R : Type u} [CommSemiring R]
+variable {C : Type v} {D : Type w}
+variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable [AddCommMonoid D] [Module R D] [Coalgebra R D]
+variable {M : Type x} [AddCommMonoid M] [Module R M] [Comodule R C M]
+
+/-- Corestriction along a coalgebra morphism preserves a subcomodule and its carrier. -/
+@[expose] def corestrict (f : C →ₗc[R] D) (W : Subcomodule R C M) :
+    letI : Comodule R D M := Comodule.Corestrict f
+    Subcomodule R D M :=
+  letI : Comodule R D M := Comodule.Corestrict f
+  Subcomodule.ofSubmodule W.carrier fun m hm ↦ by
+    obtain ⟨t, ht⟩ := W.coact_mem hm
+    refine ⟨TensorProduct.map LinearMap.id f.toLinearMap t, ?_⟩
+    rw [Comodule.corestrict_coact_apply]
+    calc
+      _ = TensorProduct.map LinearMap.id f.toLinearMap
+          (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
+            simp [TensorProduct.map_map]
+      _ = _ := congrArg (TensorProduct.map LinearMap.id f.toLinearMap) ht
+
+/-- Corestriction of a subcomodule does not change its underlying submodule. -/
+@[simp]
+theorem corestrict_toSubmodule (f : C →ₗc[R] D) (W : Subcomodule R C M) :
+    letI : Comodule R D M := Comodule.Corestrict f
+    (W.corestrict f).toSubmodule = W.toSubmodule :=
+  rfl
+
+/-- A coalgebra equivalence identifies the subcomodules of a comodule with those of its
+corestriction, without changing their underlying submodules. -/
+@[expose] def corestrictOrderIso (e : C ≃ₗc[R] D) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    Subcomodule R C M ≃o Subcomodule R D M :=
+  letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+  { toFun := fun W ↦ W.corestrict e.toCoalgHom
+    invFun := fun W ↦
+      Subcomodule.ofSubmodule W.carrier fun m hm ↦ by
+        obtain ⟨t, ht⟩ := W.coact_mem hm
+        rw [Comodule.corestrict_coact_apply] at ht
+        refine ⟨TensorProduct.map LinearMap.id e.symm.toLinearMap t, ?_⟩
+        calc
+          _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
+              (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
+                simp [TensorProduct.map_map]
+          _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
+              (TensorProduct.map LinearMap.id e.toLinearMap
+                (Comodule.coact (R := R) (C := C) (M := M) m)) :=
+            congrArg (TensorProduct.map LinearMap.id e.symm.toLinearMap) ht
+          _ = _ := by
+            rw [TensorProduct.map_map]
+            rw [show e.symm.toLinearMap.comp e.toLinearMap = LinearMap.id by
+              ext c
+              simp]
+            simp
+    left_inv := by
+      intro W
+      ext m
+      rfl
+    right_inv := by
+      intro W
+      ext m
+      rfl
+    map_rel_iff' := by
+      rfl }
+
+/-- The forward subcomodule correspondence preserves the underlying submodule. -/
+@[simp]
+theorem corestrictOrderIso_apply_toSubmodule (e : C ≃ₗc[R] D)
+    (W : Subcomodule R C M) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    (corestrictOrderIso e W).toSubmodule = W.toSubmodule :=
+  rfl
+
+/-- The inverse subcomodule correspondence preserves the underlying submodule. -/
+@[simp]
+theorem corestrictOrderIso_symm_apply_toSubmodule (e : C ≃ₗc[R] D)
+    (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+      Subcomodule R D M) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    ((corestrictOrderIso e).symm W).toSubmodule = W.toSubmodule :=
+  rfl
+
+end Subcomodule
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -110,6 +110,9 @@ def corestrictSymm (e : C ≃ₗc[R] D)
         (TensorProduct.map W.carrier.subtype (LinearMap.id : C →ₗ[R] C)) := by
       let _ : Comodule R C M := instDouble
       have hmem' := W'.coact_mem hm
+      -- The source of `hmem'` contains `W'.carrier`, while the target contains `W.carrier`.
+      -- These subcomodules have different dependent comodule-instance indices, so expose the
+      -- carrier equality explicitly before rewriting it with the corestriction API.
       rw [show W'.carrier = W.carrier by
         exact corestrict_toSubmodule e.symm.toCoalgHom W] at hmem'
       exact hmem'
@@ -136,6 +139,8 @@ theorem mem_corestrictSymm (e : C ≃ₗc[R] D)
     m ∈ corestrictSymm e W ↔ m ∈ W :=
   by
     let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    -- Membership notation hides the underlying submodules behind subcomodules indexed by
+    -- dependent comodule instances; expose those carriers so the preservation lemma can rewrite.
     change m ∈ (corestrictSymm e W).toSubmodule ↔ m ∈ W.toSubmodule
     rw [corestrictSymm_toSubmodule]
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -161,6 +161,7 @@ theorem mem_corestrictOrderIso_symm (e : C ≃ₗc[R] D)
     m ∈ (corestrictOrderIso e).symm W ↔ m ∈ W :=
   by
     let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    -- Expose subcomodule membership as submodule membership so the carrier lemma can rewrite it.
     change m ∈ (corestrictSymm e W).toSubmodule ↔ m ∈ W.toSubmodule
     rw [corestrictSymm_toSubmodule]
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -82,6 +82,8 @@ private theorem corestrict_symm_instance_eq (e : C ≃ₗc[R] D) :
     Comodule.Corestrict e.symm.toCoalgHom = (inferInstance : Comodule R C M) := by
   let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
   apply Comodule.ext
+  -- `Comodule.ext` presents the goal through the inferred instance projection. Unfolding that
+  -- projection is necessary to expose the named corestriction coaction lemmas used below.
   change Comodule.corestrictCoact e.symm.toCoalgHom = Comodule.coact
   rw [← Comodule.corestrictCoact_comp e.toCoalgHom e.symm.toCoalgHom]
   have hcomp : e.symm.toCoalgHom.comp e.toCoalgHom = CoalgHom.id R C := by
@@ -108,9 +110,7 @@ def corestrictSymm (e : C ≃ₗc[R] D)
         (TensorProduct.map W.carrier.subtype (LinearMap.id : C →ₗ[R] C)) := by
       let _ : Comodule R C M := instDouble
       have hmem' := W'.coact_mem hm
-      change instDouble.coact m ∈ LinearMap.range
-        (TensorProduct.map W'.toSubmodule.subtype (LinearMap.id : C →ₗ[R] C)) at hmem'
-      rw [show W'.toSubmodule = W.toSubmodule by
+      rw [show W'.carrier = W.carrier by
         exact corestrict_toSubmodule e.symm.toCoalgHom W] at hmem'
       exact hmem'
     rw [congrArg (fun rho : Comodule R C M => rho.coact) h] at hmem

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Corestrict.lean
@@ -77,30 +77,44 @@ theorem mem_corestrict (f : C →ₗc[R] D) (W : Subcomodule R C M) (m : M) :
     m ∈ W.corestrict f ↔ m ∈ W :=
   Iff.rfl
 
+private theorem corestrict_symm_instance_eq (e : C ≃ₗc[R] D) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    Comodule.Corestrict e.symm.toCoalgHom = (inferInstance : Comodule R C M) := by
+  let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+  apply Comodule.ext
+  change Comodule.corestrictCoact e.symm.toCoalgHom = Comodule.coact
+  rw [← Comodule.corestrictCoact_comp e.toCoalgHom e.symm.toCoalgHom]
+  have hcomp : e.symm.toCoalgHom.comp e.toCoalgHom = CoalgHom.id R C := by
+    ext c
+    simp
+  rw [hcomp, Comodule.corestrictCoact_id]
+
 /-- Pull a subcomodule of a corestricted comodule back along a coalgebra equivalence. -/
 def corestrictSymm (e : C ≃ₗc[R] D)
     (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
       Subcomodule R D M) : Subcomodule R C M :=
+  let instOriginal : Comodule R C M := inferInstance
   letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
-  Subcomodule.ofSubmodule W.carrier fun m hm ↦ by
-    obtain ⟨t, ht⟩ := W.coact_mem hm
-    rw [Comodule.corestrict_coact_apply] at ht
-    refine ⟨TensorProduct.map LinearMap.id e.symm.toLinearMap t, ?_⟩
-    calc
-      _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
-          (TensorProduct.map W.carrier.subtype LinearMap.id t) := by
-            simp [TensorProduct.map_map]
-      _ = TensorProduct.map LinearMap.id e.symm.toLinearMap
-          (TensorProduct.map LinearMap.id e.toLinearMap
-            (Comodule.coact (R := R) (C := C) (M := M) m)) :=
-        congrArg (TensorProduct.map LinearMap.id e.symm.toLinearMap) ht
-      _ = _ := by
-        have hinv : e.symm.toLinearMap.comp e.toLinearMap = LinearMap.id := by
-          ext c
-          simp
-        rw [TensorProduct.map_map]
-        rw [hinv]
-        simp
+  let instDouble : Comodule R C M := Comodule.Corestrict e.symm.toCoalgHom
+  let W' : @Subcomodule R C M _ _ _ _ _ _ instDouble := by
+    letI : Comodule R C M := instDouble
+    exact W.corestrict e.symm.toCoalgHom
+  have h : instDouble = instOriginal := by
+    let _ : Comodule R C M := instOriginal
+    exact corestrict_symm_instance_eq e
+  letI : Comodule R C M := instOriginal
+  Subcomodule.ofSubmodule W.carrier fun m hm => by
+    have hmem : instDouble.coact m ∈ LinearMap.range
+        (TensorProduct.map W.carrier.subtype (LinearMap.id : C →ₗ[R] C)) := by
+      let _ : Comodule R C M := instDouble
+      have hmem' := W'.coact_mem hm
+      change instDouble.coact m ∈ LinearMap.range
+        (TensorProduct.map W'.toSubmodule.subtype (LinearMap.id : C →ₗ[R] C)) at hmem'
+      rw [show W'.toSubmodule = W.toSubmodule by
+        exact corestrict_toSubmodule e.symm.toCoalgHom W] at hmem'
+      exact hmem'
+    rw [congrArg (fun rho : Comodule R C M => rho.coact) h] at hmem
+    exact hmem
 
 /-- Pulling a subcomodule back from a corestriction preserves its underlying submodule. -/
 @[simp]
@@ -112,6 +126,18 @@ theorem corestrictSymm_toSubmodule (e : C ≃ₗc[R] D)
   by
     ext m
     rfl
+
+/-- Membership is unchanged when pulling a subcomodule back from a corestriction. -/
+@[simp]
+theorem mem_corestrictSymm (e : C ≃ₗc[R] D)
+    (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+      Subcomodule R D M) (m : M) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    m ∈ corestrictSymm e W ↔ m ∈ W :=
+  by
+    let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    change m ∈ (corestrictSymm e W).toSubmodule ↔ m ∈ W.toSubmodule
+    rw [corestrictSymm_toSubmodule]
 
 /-- A coalgebra equivalence identifies the subcomodules of a comodule with those of its
 corestriction, without changing their underlying submodules. -/
@@ -144,6 +170,18 @@ theorem corestrictOrderIso_apply (e : C ≃ₗc[R] D) (W : Subcomodule R C M) :
     ext m
     rfl
 
+/-- The inverse order correspondence is pullback from the corestriction. -/
+@[simp]
+theorem corestrictOrderIso_symm_apply (e : C ≃ₗc[R] D)
+    (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+      Subcomodule R D M) :
+    letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    (corestrictOrderIso e).symm W = corestrictSymm e W :=
+  by
+    let _ : Comodule R D M := Comodule.Corestrict e.toCoalgHom
+    ext m
+    rfl
+
 /-- Membership is unchanged by the forward subcomodule correspondence. -/
 theorem mem_corestrictOrderIso (e : C ≃ₗc[R] D) (W : Subcomodule R C M) (m : M) :
     letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
@@ -153,7 +191,6 @@ theorem mem_corestrictOrderIso (e : C ≃ₗc[R] D) (W : Subcomodule R C M) (m :
     rw [corestrictOrderIso_apply, mem_corestrict]
 
 /-- Membership is unchanged by the inverse subcomodule correspondence. -/
-@[simp]
 theorem mem_corestrictOrderIso_symm (e : C ≃ₗc[R] D)
     (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
       Subcomodule R D M) (m : M) :
@@ -173,7 +210,6 @@ theorem corestrictOrderIso_apply_toSubmodule (e : C ≃ₗc[R] D)
   (rfl)
 
 /-- The inverse subcomodule correspondence preserves the underlying submodule. -/
-@[simp]
 theorem corestrictOrderIso_symm_apply_toSubmodule (e : C ≃ₗc[R] D)
     (W : letI : Comodule R D M := Comodule.Corestrict e.toCoalgHom
       Subcomodule R D M) :

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Transport.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Transport.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.Transport
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Basic
+
+/-!
+# Transport of subcomodules
+
+Mutually inverse comodule morphisms identify the corresponding subcomodule lattices by taking
+images. In particular, transporting a comodule structure along a linear equivalence preserves
+its subcomodules and their underlying submodules.
+
+This is Layer 1 infrastructure for the reductive-groups roadmap: changing the carrier of a
+comodule must preserve its invariant subspaces.
+
+## Main declarations
+
+* `TauCeti.Subcomodule.mapOrderIso`: the order isomorphism induced by mutually inverse comodule
+  morphisms.
+* `TauCeti.Subcomodule.transportOrderIso`: the carrier-compatible order isomorphism induced by
+  transport along a linear equivalence.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w x
+
+namespace Subcomodule
+
+variable {R : Type u} [CommSemiring R]
+variable {C : Type v} [AddCommMonoid C] [Module R C] [Coalgebra R C]
+variable {M : Type w} {N : Type x}
+variable [AddCommMonoid M] [Module R M] [Comodule R C M]
+variable [AddCommMonoid N] [Module R N]
+
+/-- Mutually inverse comodule morphisms identify the lattices of subcomodules by taking images. -/
+@[expose] def mapOrderIso [Comodule R C N]
+    (f : Comodule.Hom R C M N) (g : Comodule.Hom R C N M)
+    (hgf : g.comp f = Comodule.Hom.id R C M)
+    (hfg : f.comp g = Comodule.Hom.id R C N) :
+    Subcomodule R C M ≃o Subcomodule R C N where
+  toFun A := A.map f
+  invFun A := A.map g
+  left_inv A := by
+    change (A.map f).map g = A
+    rw [map_map, hgf, map_id]
+  right_inv A := by
+    change (A.map g).map f = A
+    rw [map_map, hfg, map_id]
+  map_rel_iff' := by
+    intro A B
+    constructor
+    · intro h
+      change A.map f ≤ B.map f at h
+      have hg := map_mono g h
+      change (A.map f).map g ≤ (B.map f).map g at hg
+      rwa [map_map, hgf, map_id, map_map, hgf, map_id] at hg
+    · intro h
+      change A.map f ≤ B.map f
+      exact map_mono f h
+
+/-- Transporting a comodule along a linear equivalence identifies its subcomodule lattice with
+the original one. -/
+@[expose] def transportOrderIso (e : M ≃ₗ[R] N) :
+    letI : Comodule R C N := Comodule.Transport e
+    Subcomodule R C M ≃o Subcomodule R C N := by
+  letI : Comodule R C N := Comodule.Transport e
+  exact mapOrderIso (Comodule.transportToHom e) (Comodule.transportInvHom e)
+    (Comodule.Hom.ext fun m => e.symm_apply_apply m)
+    (Comodule.Hom.ext fun n => e.apply_symm_apply n)
+
+/-- The forward transport correspondence is image under the transport equivalence. -/
+@[simp]
+theorem transportOrderIso_apply (e : M ≃ₗ[R] N) (A : Subcomodule R C M) :
+    letI : Comodule R C N := Comodule.Transport e
+    transportOrderIso e A = A.map (Comodule.transportToHom e) :=
+  rfl
+
+/-- The inverse transport correspondence is image under the inverse transport equivalence. -/
+@[simp]
+theorem transportOrderIso_symm_apply (e : M ≃ₗ[R] N)
+    (A : letI : Comodule R C N := Comodule.Transport e; Subcomodule R C N) :
+    letI : Comodule R C N := Comodule.Transport e
+    (transportOrderIso e).symm A = A.map (Comodule.transportInvHom e) :=
+  rfl
+
+/-- The forward transport correspondence maps the underlying submodule along the linear
+equivalence. -/
+theorem transportOrderIso_apply_toSubmodule (e : M ≃ₗ[R] N) (A : Subcomodule R C M) :
+    letI : Comodule R C N := Comodule.Transport e
+    (transportOrderIso e A).toSubmodule = Submodule.orderIsoMapComap e A.toSubmodule := by
+  let _ : Comodule R C N := Comodule.Transport e
+  rw [transportOrderIso_apply, map_toSubmodule, Comodule.transportToHom_toLinearMap,
+    Submodule.orderIsoMapComap_apply]
+
+/-- The inverse transport correspondence maps the underlying submodule along the inverse linear
+equivalence. -/
+theorem transportOrderIso_symm_apply_toSubmodule (e : M ≃ₗ[R] N)
+    (A : letI : Comodule R C N := Comodule.Transport e; Subcomodule R C N) :
+    letI : Comodule R C N := Comodule.Transport e
+    ((transportOrderIso e).symm A).toSubmodule =
+      (Submodule.orderIsoMapComap e).symm A.toSubmodule := by
+  let _ : Comodule R C N := Comodule.Transport e
+  rw [transportOrderIso_symm_apply, map_toSubmodule,
+    Comodule.transportInvHom_toLinearMap]
+  exact (Submodule.orderIsoMapComap_symm_apply' e A.toSubmodule).symm
+
+end Subcomodule
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Transport.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Transport.lean
@@ -41,7 +41,7 @@ variable [AddCommMonoid M] [Module R M] [Comodule R C M]
 variable [AddCommMonoid N] [Module R N]
 
 /-- Mutually inverse comodule morphisms identify the lattices of subcomodules by taking images. -/
-@[expose] def mapOrderIso [Comodule R C N]
+def mapOrderIso [Comodule R C N]
     (f : Comodule.Hom R C M N) (g : Comodule.Hom R C N M)
     (hgf : g.comp f = Comodule.Hom.id R C M)
     (hfg : f.comp g = Comodule.Hom.id R C N) :
@@ -49,15 +49,18 @@ variable [AddCommMonoid N] [Module R N]
   toFun A := A.map f
   invFun A := A.map g
   left_inv A := by
-    change (A.map f).map g = A
+    dsimp only
     rw [map_map, hgf, map_id]
   right_inv A := by
-    change (A.map g).map f = A
+    dsimp only
     rw [map_map, hfg, map_id]
   map_rel_iff' := by
     intro A B
     constructor
     · intro h
+      -- While constructing the `OrderIso`, this field sees coercions through the partially built
+      -- `Equiv`. Its application lemmas can only be stated after the definition is complete, so
+      -- expose precisely the fresh `toFun` projection here.
       change A.map f ≤ B.map f at h
       have hg := map_mono g h
       change (A.map f).map g ≤ (B.map f).map g at hg
@@ -66,9 +69,29 @@ variable [AddCommMonoid N] [Module R N]
       change A.map f ≤ B.map f
       exact map_mono f h
 
+/-- The forward correspondence induced by mutually inverse comodule morphisms is image under the
+forward morphism. -/
+@[simp]
+theorem mapOrderIso_apply [Comodule R C N]
+    (f : Comodule.Hom R C M N) (g : Comodule.Hom R C N M)
+    (hgf : g.comp f = Comodule.Hom.id R C M)
+    (hfg : f.comp g = Comodule.Hom.id R C N) (A : Subcomodule R C M) :
+    mapOrderIso f g hgf hfg A = A.map f :=
+  (rfl)
+
+/-- The inverse correspondence induced by mutually inverse comodule morphisms is image under the
+inverse morphism. -/
+@[simp]
+theorem mapOrderIso_symm_apply [Comodule R C N]
+    (f : Comodule.Hom R C M N) (g : Comodule.Hom R C N M)
+    (hgf : g.comp f = Comodule.Hom.id R C M)
+    (hfg : f.comp g = Comodule.Hom.id R C N) (A : Subcomodule R C N) :
+    (mapOrderIso f g hgf hfg).symm A = A.map g :=
+  (rfl)
+
 /-- Transporting a comodule along a linear equivalence identifies its subcomodule lattice with
 the original one. -/
-@[expose] def transportOrderIso (e : M ≃ₗ[R] N) :
+def transportOrderIso (e : M ≃ₗ[R] N) :
     letI : Comodule R C N := Comodule.Transport e
     Subcomodule R C M ≃o Subcomodule R C N := by
   letI : Comodule R C N := Comodule.Transport e
@@ -81,7 +104,7 @@ the original one. -/
 theorem transportOrderIso_apply (e : M ≃ₗ[R] N) (A : Subcomodule R C M) :
     letI : Comodule R C N := Comodule.Transport e
     transportOrderIso e A = A.map (Comodule.transportToHom e) :=
-  rfl
+  (rfl)
 
 /-- The inverse transport correspondence is image under the inverse transport equivalence. -/
 @[simp]
@@ -89,7 +112,7 @@ theorem transportOrderIso_symm_apply (e : M ≃ₗ[R] N)
     (A : letI : Comodule R C N := Comodule.Transport e; Subcomodule R C N) :
     letI : Comodule R C N := Comodule.Transport e
     (transportOrderIso e).symm A = A.map (Comodule.transportInvHom e) :=
-  rfl
+  (rfl)
 
 /-- The forward transport correspondence maps the underlying submodule along the linear
 equivalence. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
@@ -62,6 +62,19 @@ noncomputable def commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso (S 
     Functor.isoWhiskerLeft (hopfSpec S).toEssImage (ObjectProperty.ιOfLECompιIso _) ≪≫
     (hopfSpec S).toEssImageCompι
 
+/-- The object produced by the affine Hopf/group-scheme anti-equivalence is the bundled Hopf
+spectrum. -/
+noncomputable def commHopfAlgCatOpEquivAffineGroupSchemeCat.functorObjIso
+    (R : Type u) [CommRing R] (H : (CommHopfAlgCat.{u} R)ᵒᵖ) :
+    (commHopfAlgCatOpEquivAffineGroupSchemeCat
+        (CommRingCat.of R)).functor.obj H ≅
+      ⟨(hopfSpec (CommRingCat.of R)).obj H, by
+        rw [affineGroupSchemeProperty_iff, hopfSpec_obj_X_left]
+        infer_instance⟩ :=
+  (affineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
+    ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+      (CommRingCat.of R)).app H)
+
 /-- To identify the inverse image of an isomorphism-invariant property of affine group schemes
 under the Hopf-algebra/group-scheme anti-equivalence, it suffices to identify that property on
 Hopf spectra. -/
@@ -81,9 +94,7 @@ theorem objectProperty_inverseImage_commHopfAlgCatOpEquiv
       infer_instance⟩
   let e : (commHopfAlgCatOpEquivAffineGroupSchemeCat
       (CommRingCat.of R)).functor.obj H ≅ G :=
-    (affineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
-      ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-        (CommRingCat.of R)).app H)
+    commHopfAlgCatOpEquivAffineGroupSchemeCat.functorObjIso R H
   rw [ObjectProperty.prop_inverseImage_iff, ObjectProperty.op_iff]
   exact (P.prop_iff_of_iso e).trans (h H.unop)
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
@@ -30,12 +30,21 @@ namespace TauCeti
 
 open CategoryTheory AlgebraicGeometry Opposite
 
-universe u v
+universe u u₁ v₁ u₂ v₂
 
 /-- Pulling an isomorphism-invariant object property forward and then backward along an
 equivalence recovers the original property. -/
 theorem objectProperty_inverseImage_equivalence_inverse
-    {C : Type u} {D : Type v} [Category C] [Category D]
+    {C : Type u₁} {D : Type u₂} [Category.{v₁} C] [Category.{v₂} D]
+    (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
+    (P.inverseImage e.inverse).inverseImage e.functor = P := by
+  ext X
+  exact (P.prop_iff_of_iso (e.unitIso.app X)).symm
+
+/-- Pulling an isomorphism-invariant object property backward along both functors of an
+equivalence recovers the original property. -/
+theorem ObjectProperty.inverseImage_equivalence_inverseImage
+    {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
     (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
     (P.inverseImage e.inverse).inverseImage e.functor = P := by
   ext X

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.CategoryTheory.ObjectProperty
+public import Mathlib.CategoryTheory.ObjectProperty.Opposite
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.CategoryTheory.ObjectProperty.Opposite
+public import TauCeti.CategoryTheory.ObjectProperty
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
@@ -30,25 +30,7 @@ namespace TauCeti
 
 open CategoryTheory AlgebraicGeometry Opposite
 
-universe u u₁ v₁ u₂ v₂
-
-/-- Pulling an isomorphism-invariant object property forward and then backward along an
-equivalence recovers the original property. -/
-theorem objectProperty_inverseImage_equivalence_inverse
-    {C : Type u₁} {D : Type u₂} [Category.{v₁} C] [Category.{v₂} D]
-    (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
-    (P.inverseImage e.inverse).inverseImage e.functor = P := by
-  ext X
-  exact (P.prop_iff_of_iso (e.unitIso.app X)).symm
-
-/-- Pulling an isomorphism-invariant object property backward along both functors of an
-equivalence recovers the original property. -/
-theorem ObjectProperty.inverseImage_equivalence_inverseImage
-    {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
-    (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
-    (P.inverseImage e.inverse).inverseImage e.functor = P := by
-  ext X
-  exact (P.prop_iff_of_iso (e.unitIso.app X)).symm
+universe u
 
 /-- `Spec` as an anti-equivalence from commutative `S`-Hopf algebras onto affine group
 schemes over `Spec S`. The underlying functor is Mathlib's `AlgebraicGeometry.hopfSpec`,

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.CategoryTheory.ObjectProperty
 public import TauCeti.Algebra.AlgebraicGroup.LinearlyReductive
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
@@ -30,8 +30,6 @@ unfolding either restricted equivalence.
 * `TauCeti.LinearlyReductiveAffineGroupSchemeCat`: the corresponding full subcategory.
 * `TauCeti.linearlyReductiveAffineGroupSchemeProperty_hopfSpec_iff`: the characterization on a
   canonical Hopf spectrum.
-* `TauCeti.linearlyReductiveAffineGroupSchemeProperty.isCompletelyReducible`: every
-  finite-dimensional coordinate-ring comodule is completely reducible, in any carrier universe.
 * `TauCeti.linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat`: the
   restricted Hopf-algebra/group-scheme anti-equivalence.
 
@@ -52,7 +50,7 @@ namespace TauCeti
 
 open CategoryTheory AlgebraicGeometry Opposite
 
-universe u w
+universe u
 
 /-- The object property selecting affine group schemes whose finite-dimensional coordinate-ring
 comodules with carriers in `Type u` are completely reducible.
@@ -78,20 +76,6 @@ theorem linearlyReductiveAffineGroupSchemeProperty_iff
     rw [linearlyReductiveAffineGroupSchemeProperty,
       ObjectProperty.prop_inverseImage_iff, ObjectProperty.op_iff,
       linearlyReductiveCommHopfAlgProperty_iff]
-
-/-- A linearly reductive affine group scheme has completely reducible finite-dimensional
-coordinate-ring comodules in every carrier universe. -/
-theorem linearlyReductiveAffineGroupSchemeProperty.isCompletelyReducible
-    (k : Type u) [Field k] {G : AffineGroupSchemeCat (CommRingCat.of k)}
-    (hG : linearlyReductiveAffineGroupSchemeProperty k G)
-    {V : Type w} [AddCommMonoid V] [Module k V]
-    [Comodule k
-      ((commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).inverse.obj G).unop V]
-    [Module.Finite k V] :
-    Comodule.IsCompletelyReducible k
-      ((commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).inverse.obj G).unop V :=
-  Coalgebra.IsLinearlyReductive.isCompletelyReducible k
-    ((linearlyReductiveAffineGroupSchemeProperty_iff k G).mp hG)
 
 /-- Linear reductivity of affine group schemes is invariant under isomorphism. -/
 instance (k : Type u) [Field k] :

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
@@ -1,20 +1,21 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.LinearlyReductive
-public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Scheme.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
 
 /-!
 # Linearly reductive affine group schemes
 
 This file transports linear reductivity from commutative Hopf algebras to affine group schemes
-over a field. The coordinate-ring predicate says that every finite-dimensional comodule is
-completely reducible; the affine Hopf/group-scheme anti-equivalence makes this an intrinsic,
-isomorphism-invariant property of the represented group scheme.
+over a field. The coordinate-ring predicate tests finite-dimensional comodules whose carriers
+lie in `Type u`, the universe of the base field and coordinate ring; the affine Hopf/group-scheme
+anti-equivalence makes this an intrinsic, isomorphism-invariant property of the represented
+group scheme. No universe-transfer result is asserted here.
 
 The resulting full subcategories remain anti-equivalent. The compatibility isomorphism with
 `hopfSpec` is provided so later comparison theorems can compute on coordinate rings without
@@ -25,10 +26,10 @@ unfolding either restricted equivalence.
 * `TauCeti.linearlyReductiveAffineGroupSchemeProperty`: linear reductivity of affine group
   schemes over a field.
 * `TauCeti.LinearlyReductiveAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.linearlyReductiveAffineGroupSchemeProperty_hopfSpec`: the characterization on a
+  canonical Hopf spectrum.
 * `TauCeti.linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat`: the
   restricted Hopf-algebra/group-scheme anti-equivalence.
-* `TauCeti.DiagonalizableGroup.linearlyReductiveAffineGroupSchemeProperty_groupScheme`: every
-  finite-type diagonalizable group scheme is linearly reductive.
 
 ## References
 
@@ -47,17 +48,19 @@ open CategoryTheory AlgebraicGeometry Opposite
 
 universe u
 
-/-- The object property selecting linearly reductive affine group schemes over a field.
+/-- The object property selecting affine group schemes whose finite-dimensional coordinate-ring
+comodules with carriers in `Type u` are completely reducible.
 
 The property is transported through the affine Hopf/group-scheme anti-equivalence and therefore
 does not add smoothness, connectedness, or finite type to the ambient affine group. -/
 def linearlyReductiveAffineGroupSchemeProperty (k : Type u) [Field k] :
     ObjectProperty (AffineGroupSchemeCat (CommRingCat.of k)) :=
-  (linearlyReductiveCommHopfAlgProperty.{u, u, u} k).op.inverseImage
+  (linearlyReductiveCommHopfAlgProperty.{u, u} k).op.inverseImage
     (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).inverse
 
-/-- An affine group scheme is linearly reductive exactly when the coordinate Hopf algebra
-recovered by the affine anti-equivalence is linearly reductive. -/
+/-- An affine group scheme is linearly reductive exactly when finite-dimensional comodules over
+the coordinate Hopf algebra recovered by the affine anti-equivalence, with carriers in `Type u`,
+are completely reducible. -/
 @[simp]
 theorem linearlyReductiveAffineGroupSchemeProperty_iff
     (k : Type u) [Field k] (G : AffineGroupSchemeCat (CommRingCat.of k)) :
@@ -87,21 +90,45 @@ theorem linearlyReductiveAffineGroupSchemeProperty_inverseImage
     (linearlyReductiveAffineGroupSchemeProperty k).inverseImage
         (commHopfAlgCatOpEquivAffineGroupSchemeCat
           (CommRingCat.of k)).functor =
-      (linearlyReductiveCommHopfAlgProperty.{u, u, u} k).op := by
-  ext H
-  exact ((linearlyReductiveCommHopfAlgProperty.{u, u, u} k).op.prop_iff_of_iso
-    ((commHopfAlgCatOpEquivAffineGroupSchemeCat
-      (CommRingCat.of k)).unitIso.app H)).symm
+      (linearlyReductiveCommHopfAlgProperty.{u, u} k).op := by
+  unfold linearlyReductiveAffineGroupSchemeProperty
+  exact ObjectProperty.inverseImage_equivalence_inverseImage _ _
+
+/-- A canonical Hopf spectrum is linearly reductive exactly when its coordinate Hopf algebra is
+linearly reductive for finite-dimensional comodules with carriers in `Type u`. -/
+theorem linearlyReductiveAffineGroupSchemeProperty_hopfSpec
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
+    linearlyReductiveAffineGroupSchemeProperty k
+        ⟨(hopfSpec (CommRingCat.of k)).obj (op H), by
+          rw [affineGroupSchemeProperty_iff, hopfSpec_obj_X_left]
+          infer_instance⟩ ↔
+      Coalgebra.IsLinearlyReductive.{u, u, u} k H := by
+  let E := commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)
+  let G : AffineGroupSchemeCat (CommRingCat.of k) :=
+    ⟨(hopfSpec (CommRingCat.of k)).obj (op H), by
+      rw [affineGroupSchemeProperty_iff, hopfSpec_obj_X_left]
+      infer_instance⟩
+  let e : E.functor.obj (op H) ≅ G :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+        (CommRingCat.of k)).app (op H))
+  change linearlyReductiveAffineGroupSchemeProperty k G ↔ _
+  refine ((linearlyReductiveAffineGroupSchemeProperty k).prop_iff_of_iso e).symm.trans ?_
+  change ((linearlyReductiveAffineGroupSchemeProperty k).inverseImage
+      (commHopfAlgCatOpEquivAffineGroupSchemeCat
+        (CommRingCat.of k)).functor) (op H) ↔ _
+  rw [linearlyReductiveAffineGroupSchemeProperty_inverseImage,
+    ObjectProperty.op_iff, linearlyReductiveCommHopfAlgProperty_iff]
 
 /-- `Spec` restricts to an anti-equivalence from linearly reductive commutative Hopf algebras to
 linearly reductive affine group schemes. -/
 noncomputable def
     linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat
     (k : Type u) [Field k] :
-    (LinearlyReductiveCommHopfAlgCat.{u, u, u} k)ᵒᵖ ≌
+    (LinearlyReductiveCommHopfAlgCat.{u, u} k)ᵒᵖ ≌
       LinearlyReductiveAffineGroupSchemeCat k :=
   (ObjectProperty.opEquivalence
-      (linearlyReductiveCommHopfAlgProperty.{u, u, u} k)).symm.trans <|
+      (linearlyReductiveCommHopfAlgProperty.{u, u} k)).symm.trans <|
     (commHopfAlgCatOpEquivAffineGroupSchemeCat
       (CommRingCat.of k)).congrFullSubcategory
         (linearlyReductiveAffineGroupSchemeProperty_inverseImage k)
@@ -114,7 +141,7 @@ private noncomputable def
     (k : Type u) [Field k] :
     (linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat k).functor ⋙
         (linearlyReductiveAffineGroupSchemeProperty k).ι ≅
-      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u, u} k)
+      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u} k)
           (CommHopfAlgCat.{u} k)).op ⋙
         (commHopfAlgCatOpEquivAffineGroupSchemeCat
           (CommRingCat.of k)).functor :=
@@ -128,7 +155,7 @@ noncomputable def
     (linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat k).functor ⋙
         (linearlyReductiveAffineGroupSchemeProperty k).ι ⋙
         (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
-      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u, u} k)
+      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u} k)
           (CommHopfAlgCat.{u} k)).op ⋙
         hopfSpec (CommRingCat.of k) :=
   Functor.isoWhiskerRight
@@ -137,36 +164,9 @@ noncomputable def
       ((affineGroupSchemeProperty (CommRingCat.of k)).ι) ≪≫
     Functor.associator _ _ _ ≪≫
     Functor.isoWhiskerLeft
-      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u, u} k)
+      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u} k)
         (CommHopfAlgCat.{u} k)).op
       (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
         (CommRingCat.of k))
-
-namespace DiagonalizableGroup
-
-/-- Every finite-type diagonalizable group scheme is linearly reductive. -/
-theorem linearlyReductiveAffineGroupSchemeProperty_groupScheme
-    (k : Type u) [Field k] (G : FGCommGrpCat.{u}) :
-    linearlyReductiveAffineGroupSchemeProperty k
-      ⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩ := by
-  let H : CommHopfAlgCat.{u} k := (coordinateRing k G).obj
-  let E := commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)
-  have hE : linearlyReductiveAffineGroupSchemeProperty k (E.functor.obj (op H)) := by
-    have h : ((linearlyReductiveAffineGroupSchemeProperty k).inverseImage E.functor) (op H) := by
-      rw [linearlyReductiveAffineGroupSchemeProperty_inverseImage, ObjectProperty.op_iff]
-      exact (linearlyReductiveCommHopfAlgProperty_iff k H).2
-        (Coalgebra.isLinearlyReductive_monoidAlgebra k G)
-    exact h
-  let e : E.functor.obj (op H) ≅
-      (⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩ :
-        AffineGroupSchemeCat (CommRingCat.of k)) :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
-      ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-          (CommRingCat.of k)).app (op H) ≪≫
-        (schemeFunctorIsoHopfSpec k).symm.app (op G) ≪≫
-        eqToIso (schemeFunctor_obj k (op G)))
-  exact (linearlyReductiveAffineGroupSchemeProperty k).prop_of_iso e hE
-
-end DiagonalizableGroup
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.LinearlyReductive
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Scheme.Basic
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
+
+/-!
+# Linearly reductive affine group schemes
+
+This file transports linear reductivity from commutative Hopf algebras to affine group schemes
+over a field. The coordinate-ring predicate says that every finite-dimensional comodule is
+completely reducible; the affine Hopf/group-scheme anti-equivalence makes this an intrinsic,
+isomorphism-invariant property of the represented group scheme.
+
+The resulting full subcategories remain anti-equivalent. The compatibility isomorphism with
+`hopfSpec` is provided so later comparison theorems can compute on coordinate rings without
+unfolding either restricted equivalence.
+
+## Main declarations
+
+* `TauCeti.linearlyReductiveAffineGroupSchemeProperty`: linear reductivity of affine group
+  schemes over a field.
+* `TauCeti.LinearlyReductiveAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat`: the
+  restricted Hopf-algebra/group-scheme anti-equivalence.
+* `TauCeti.DiagonalizableGroup.linearlyReductiveAffineGroupSchemeProperty_groupScheme`: every
+  finite-type diagonalizable group scheme is linearly reductive.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 3.2.
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.12.
+
+This synchronizes the coordinate-ring and group-scheme views for the complete-reducibility
+characterization in Layer 6 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory AlgebraicGeometry Opposite
+
+universe u
+
+/-- The object property selecting linearly reductive affine group schemes over a field.
+
+The property is transported through the affine Hopf/group-scheme anti-equivalence and therefore
+does not add smoothness, connectedness, or finite type to the ambient affine group. -/
+def linearlyReductiveAffineGroupSchemeProperty (k : Type u) [Field k] :
+    ObjectProperty (AffineGroupSchemeCat (CommRingCat.of k)) :=
+  (linearlyReductiveCommHopfAlgProperty.{u, u, u} k).op.inverseImage
+    (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).inverse
+
+/-- An affine group scheme is linearly reductive exactly when the coordinate Hopf algebra
+recovered by the affine anti-equivalence is linearly reductive. -/
+@[simp]
+theorem linearlyReductiveAffineGroupSchemeProperty_iff
+    (k : Type u) [Field k] (G : AffineGroupSchemeCat (CommRingCat.of k)) :
+    linearlyReductiveAffineGroupSchemeProperty k G ↔
+      Coalgebra.IsLinearlyReductive.{u, u, u} k
+        ((commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of k)).inverse.obj G).unop :=
+  by
+    rw [linearlyReductiveAffineGroupSchemeProperty,
+      ObjectProperty.prop_inverseImage_iff, ObjectProperty.op_iff,
+      linearlyReductiveCommHopfAlgProperty_iff]
+
+/-- Linear reductivity of affine group schemes is invariant under isomorphism. -/
+instance (k : Type u) [Field k] :
+    (linearlyReductiveAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms := by
+  unfold linearlyReductiveAffineGroupSchemeProperty
+  infer_instance
+
+/-- The category of linearly reductive affine group schemes over a field. -/
+abbrev LinearlyReductiveAffineGroupSchemeCat (k : Type u) [Field k] :=
+  (linearlyReductiveAffineGroupSchemeProperty k).FullSubcategory
+
+/-- Under the affine Hopf/group-scheme anti-equivalence, the inverse image of linear reductivity
+on group schemes is linear reductivity of coordinate Hopf algebras. -/
+theorem linearlyReductiveAffineGroupSchemeProperty_inverseImage
+    (k : Type u) [Field k] :
+    (linearlyReductiveAffineGroupSchemeProperty k).inverseImage
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of k)).functor =
+      (linearlyReductiveCommHopfAlgProperty.{u, u, u} k).op := by
+  ext H
+  exact ((linearlyReductiveCommHopfAlgProperty.{u, u, u} k).op.prop_iff_of_iso
+    ((commHopfAlgCatOpEquivAffineGroupSchemeCat
+      (CommRingCat.of k)).unitIso.app H)).symm
+
+/-- `Spec` restricts to an anti-equivalence from linearly reductive commutative Hopf algebras to
+linearly reductive affine group schemes. -/
+noncomputable def
+    linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat
+    (k : Type u) [Field k] :
+    (LinearlyReductiveCommHopfAlgCat.{u, u, u} k)ᵒᵖ ≌
+      LinearlyReductiveAffineGroupSchemeCat k :=
+  (ObjectProperty.opEquivalence
+      (linearlyReductiveCommHopfAlgProperty.{u, u, u} k)).symm.trans <|
+    (commHopfAlgCatOpEquivAffineGroupSchemeCat
+      (CommRingCat.of k)).congrFullSubcategory
+        (linearlyReductiveAffineGroupSchemeProperty_inverseImage k)
+
+/-- The restricted anti-equivalence followed by the inclusion is the unrestricted
+anti-equivalence after forgetting linear reductivity. This private isomorphism isolates the
+definitional boundary of `opEquivalence` and `congrFullSubcategory`. -/
+private noncomputable def
+    linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCatFunctorCompιIso
+    (k : Type u) [Field k] :
+    (linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat k).functor ⋙
+        (linearlyReductiveAffineGroupSchemeProperty k).ι ≅
+      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u, u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of k)).functor :=
+  Iso.refl _
+
+/-- The restricted anti-equivalence followed by the inclusions into affine group schemes is
+`hopfSpec` after forgetting the proof of linear reductivity. -/
+noncomputable def
+    linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat.functorCompιIso
+    (k : Type u) [Field k] :
+    (linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat k).functor ⋙
+        (linearlyReductiveAffineGroupSchemeProperty k).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
+      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u, u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙
+        hopfSpec (CommRingCat.of k) :=
+  Functor.isoWhiskerRight
+      (linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCatFunctorCompιIso
+        k)
+      ((affineGroupSchemeProperty (CommRingCat.of k)).ι) ≪≫
+    Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft
+      (forget₂ (LinearlyReductiveCommHopfAlgCat.{u, u, u} k)
+        (CommHopfAlgCat.{u} k)).op
+      (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+        (CommRingCat.of k))
+
+namespace DiagonalizableGroup
+
+/-- Every finite-type diagonalizable group scheme is linearly reductive. -/
+theorem linearlyReductiveAffineGroupSchemeProperty_groupScheme
+    (k : Type u) [Field k] (G : FGCommGrpCat.{u}) :
+    linearlyReductiveAffineGroupSchemeProperty k
+      ⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩ := by
+  let H : CommHopfAlgCat.{u} k := (coordinateRing k G).obj
+  let E := commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)
+  have hE : linearlyReductiveAffineGroupSchemeProperty k (E.functor.obj (op H)) := by
+    have h : ((linearlyReductiveAffineGroupSchemeProperty k).inverseImage E.functor) (op H) := by
+      rw [linearlyReductiveAffineGroupSchemeProperty_inverseImage, ObjectProperty.op_iff]
+      exact linearlyReductiveCommHopfAlgProperty_coordinateRing k G
+    exact h
+  let e : E.functor.obj (op H) ≅
+      (⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩ :
+        AffineGroupSchemeCat (CommRingCat.of k)) :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+          (CommRingCat.of k)).app (op H) ≪≫
+        (schemeFunctorIsoHopfSpec k).symm.app (op G) ≪≫
+        eqToIso (schemeFunctor_obj k (op G)))
+  exact (linearlyReductiveAffineGroupSchemeProperty k).prop_of_iso e hE
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
@@ -154,7 +154,8 @@ theorem linearlyReductiveAffineGroupSchemeProperty_groupScheme
   have hE : linearlyReductiveAffineGroupSchemeProperty k (E.functor.obj (op H)) := by
     have h : ((linearlyReductiveAffineGroupSchemeProperty k).inverseImage E.functor) (op H) := by
       rw [linearlyReductiveAffineGroupSchemeProperty_inverseImage, ObjectProperty.op_iff]
-      exact linearlyReductiveCommHopfAlgProperty_coordinateRing k G
+      exact (linearlyReductiveCommHopfAlgProperty_iff k H).2
+        (Coalgebra.isLinearlyReductive_monoidAlgebra k G)
     exact h
   let e : E.functor.obj (op H) ≅
       (⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩ :

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
@@ -13,9 +13,10 @@ public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
 
 This file transports linear reductivity from commutative Hopf algebras to affine group schemes
 over a field. The coordinate-ring predicate tests finite-dimensional comodules whose carriers
-lie in `Type u`, the universe of the base field and coordinate ring; the affine Hopf/group-scheme
-anti-equivalence makes this an intrinsic, isomorphism-invariant property of the represented
-group scheme. No universe-transfer result is asserted here.
+lie in `Type u`, the universe of the base field and coordinate ring; transport to a finite
+standard basis shows that this implies complete reducibility in every carrier universe. The
+affine Hopf/group-scheme anti-equivalence makes this an intrinsic, isomorphism-invariant property
+of the represented group scheme.
 
 The resulting full subcategories remain anti-equivalent. The compatibility isomorphism with
 `hopfSpec` is provided so later comparison theorems can compute on coordinate rings without
@@ -28,6 +29,8 @@ unfolding either restricted equivalence.
 * `TauCeti.LinearlyReductiveAffineGroupSchemeCat`: the corresponding full subcategory.
 * `TauCeti.linearlyReductiveAffineGroupSchemeProperty_hopfSpec`: the characterization on a
   canonical Hopf spectrum.
+* `TauCeti.linearlyReductiveAffineGroupSchemeProperty.isCompletelyReducible`: every
+  finite-dimensional coordinate-ring comodule is completely reducible, in any carrier universe.
 * `TauCeti.linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCat`: the
   restricted Hopf-algebra/group-scheme anti-equivalence.
 
@@ -46,7 +49,7 @@ namespace TauCeti
 
 open CategoryTheory AlgebraicGeometry Opposite
 
-universe u
+universe u w
 
 /-- The object property selecting affine group schemes whose finite-dimensional coordinate-ring
 comodules with carriers in `Type u` are completely reducible.
@@ -72,6 +75,20 @@ theorem linearlyReductiveAffineGroupSchemeProperty_iff
     rw [linearlyReductiveAffineGroupSchemeProperty,
       ObjectProperty.prop_inverseImage_iff, ObjectProperty.op_iff,
       linearlyReductiveCommHopfAlgProperty_iff]
+
+/-- A linearly reductive affine group scheme has completely reducible finite-dimensional
+coordinate-ring comodules in every carrier universe. -/
+theorem linearlyReductiveAffineGroupSchemeProperty.isCompletelyReducible
+    (k : Type u) [Field k] {G : AffineGroupSchemeCat (CommRingCat.of k)}
+    (hG : linearlyReductiveAffineGroupSchemeProperty k G)
+    {V : Type w} [AddCommMonoid V] [Module k V]
+    [Comodule k
+      ((commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).inverse.obj G).unop V]
+    [Module.Finite k V] :
+    Comodule.IsCompletelyReducible k
+      ((commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).inverse.obj G).unop V :=
+  Coalgebra.isCompletelyReducible_of_isLinearlyReductive k
+    ((linearlyReductiveAffineGroupSchemeProperty_iff k G).mp hG)
 
 /-- Linear reductivity of affine group schemes is invariant under isomorphism. -/
 instance (k : Type u) [Field k] :
@@ -112,13 +129,14 @@ theorem linearlyReductiveAffineGroupSchemeProperty_hopfSpec
     (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
       ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
         (CommRingCat.of k)).app (op H))
-  change linearlyReductiveAffineGroupSchemeProperty k G ↔ _
-  refine ((linearlyReductiveAffineGroupSchemeProperty k).prop_iff_of_iso e).symm.trans ?_
-  change ((linearlyReductiveAffineGroupSchemeProperty k).inverseImage
-      (commHopfAlgCatOpEquivAffineGroupSchemeCat
-        (CommRingCat.of k)).functor) (op H) ↔ _
-  rw [linearlyReductiveAffineGroupSchemeProperty_inverseImage,
-    ObjectProperty.op_iff, linearlyReductiveCommHopfAlgProperty_iff]
+  have hE : linearlyReductiveAffineGroupSchemeProperty k G ↔
+      Coalgebra.IsLinearlyReductive.{u, u, u} k H := by
+    refine ((linearlyReductiveAffineGroupSchemeProperty k).prop_iff_of_iso e).symm.trans ?_
+    rw [← ObjectProperty.prop_inverseImage_iff
+        (linearlyReductiveAffineGroupSchemeProperty k) E.functor (op H),
+      linearlyReductiveAffineGroupSchemeProperty_inverseImage,
+      ObjectProperty.op_iff, linearlyReductiveCommHopfAlgProperty_iff]
+  simpa only [G] using hE
 
 /-- `Spec` restricts to an anti-equivalence from linearly reductive commutative Hopf algebras to
 linearly reductive affine group schemes. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
@@ -28,7 +28,7 @@ unfolding either restricted equivalence.
 * `TauCeti.linearlyReductiveAffineGroupSchemeProperty`: linear reductivity of affine group
   schemes over a field.
 * `TauCeti.LinearlyReductiveAffineGroupSchemeCat`: the corresponding full subcategory.
-* `TauCeti.linearlyReductiveAffineGroupSchemeProperty_hopfSpec`: the characterization on a
+* `TauCeti.linearlyReductiveAffineGroupSchemeProperty_hopfSpec_iff`: the characterization on a
   canonical Hopf spectrum.
 * `TauCeti.linearlyReductiveAffineGroupSchemeProperty.isCompletelyReducible`: every
   finite-dimensional coordinate-ring comodule is completely reducible, in any carrier universe.
@@ -42,6 +42,8 @@ unfolding either restricted equivalence.
 
 This synchronizes the coordinate-ring and group-scheme views for the complete-reducibility
 characterization in Layer 6 of the ReductiveGroups roadmap.
+
+The organization follows `TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean`.
 -/
 
 public section
@@ -88,7 +90,7 @@ theorem linearlyReductiveAffineGroupSchemeProperty.isCompletelyReducible
     [Module.Finite k V] :
     Comodule.IsCompletelyReducible k
       ((commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).inverse.obj G).unop V :=
-  Coalgebra.isCompletelyReducible_of_isLinearlyReductive k
+  Coalgebra.IsLinearlyReductive.isCompletelyReducible k
     ((linearlyReductiveAffineGroupSchemeProperty_iff k G).mp hG)
 
 /-- Linear reductivity of affine group schemes is invariant under isomorphism. -/
@@ -110,11 +112,11 @@ theorem linearlyReductiveAffineGroupSchemeProperty_inverseImage
           (CommRingCat.of k)).functor =
       (linearlyReductiveCommHopfAlgProperty.{u, u} k).op := by
   unfold linearlyReductiveAffineGroupSchemeProperty
-  exact ObjectProperty.inverseImage_equivalence_inverseImage _ _
+  exact ObjectProperty.inverseImage_functor_inverseImage_inverse _ _
 
 /-- A canonical Hopf spectrum is linearly reductive exactly when its coordinate Hopf algebra is
 linearly reductive for finite-dimensional comodules with carriers in `Type u`. -/
-theorem linearlyReductiveAffineGroupSchemeProperty_hopfSpec
+theorem linearlyReductiveAffineGroupSchemeProperty_hopfSpec_iff
     (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) :
     linearlyReductiveAffineGroupSchemeProperty k
         ⟨(hopfSpec (CommRingCat.of k)).obj (op H), by
@@ -122,22 +124,12 @@ theorem linearlyReductiveAffineGroupSchemeProperty_hopfSpec
           infer_instance⟩ ↔
       Coalgebra.IsLinearlyReductive.{u, u, u} k H := by
   let E := commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)
-  let G : AffineGroupSchemeCat (CommRingCat.of k) :=
-    ⟨(hopfSpec (CommRingCat.of k)).obj (op H), by
-      rw [affineGroupSchemeProperty_iff, hopfSpec_obj_X_left]
-      infer_instance⟩
-  let e : E.functor.obj (op H) ≅ G :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
-      ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-        (CommRingCat.of k)).app (op H))
-  have hE : linearlyReductiveAffineGroupSchemeProperty k G ↔
-      Coalgebra.IsLinearlyReductive.{u, u, u} k H := by
-    refine ((linearlyReductiveAffineGroupSchemeProperty k).prop_iff_of_iso e).symm.trans ?_
-    rw [← ObjectProperty.prop_inverseImage_iff
-        (linearlyReductiveAffineGroupSchemeProperty k) E.functor (op H),
-      linearlyReductiveAffineGroupSchemeProperty_inverseImage,
-      ObjectProperty.op_iff, linearlyReductiveCommHopfAlgProperty_iff]
-  simpa only [G] using hE
+  refine ((linearlyReductiveAffineGroupSchemeProperty k).prop_iff_of_iso
+    (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorObjIso k (op H))).symm.trans ?_
+  rw [← ObjectProperty.prop_inverseImage_iff
+      (linearlyReductiveAffineGroupSchemeProperty k) E.functor (op H),
+    linearlyReductiveAffineGroupSchemeProperty_inverseImage,
+    ObjectProperty.op_iff, linearlyReductiveCommHopfAlgProperty_iff]
 
 /-- `Spec` restricts to an anti-equivalence from linearly reductive commutative Hopf algebras to
 linearly reductive affine group schemes. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean
@@ -129,8 +129,9 @@ noncomputable def
         (linearlyReductiveAffineGroupSchemeProperty_inverseImage k)
 
 /-- The restricted anti-equivalence followed by the inclusion is the unrestricted
-anti-equivalence after forgetting linear reductivity. This private isomorphism isolates the
-definitional boundary of `opEquivalence` and `congrFullSubcategory`. -/
+anti-equivalence after forgetting linear reductivity. This private isomorphism composes the
+canonical comparison isomorphisms for the lifts used by `opEquivalence` and
+`congrFullSubcategory`. -/
 private noncomputable def
     linearlyReductiveCommHopfAlgCatOpEquivLinearlyReductiveAffineGroupSchemeCatFunctorCompιIso
     (k : Type u) [Field k] :
@@ -140,7 +141,16 @@ private noncomputable def
           (CommHopfAlgCat.{u} k)).op ⋙
         (commHopfAlgCatOpEquivAffineGroupSchemeCat
           (CommRingCat.of k)).functor :=
-  Iso.refl _
+  Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft
+      (ObjectProperty.opEquivalence
+        (linearlyReductiveCommHopfAlgProperty.{u, u} k)).inverse
+      ((linearlyReductiveAffineGroupSchemeProperty k).liftCompιIso _ _) ≪≫
+    (Functor.associator _ _ _).symm ≪≫
+    Functor.isoWhiskerRight
+      ((linearlyReductiveCommHopfAlgProperty.{u, u} k).op.liftCompιIso _ _)
+      (commHopfAlgCatOpEquivAffineGroupSchemeCat
+        (CommRingCat.of k)).functor
 
 /-- The restricted anti-equivalence followed by the inclusions into affine group schemes is
 `hopfSpec` after forgetting the proof of linear reductivity. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
@@ -5,6 +5,7 @@ Authors: Codex
 -/
 module
 
+import TauCeti.CategoryTheory.ObjectProperty
 public import TauCeti.Algebra.AlgebraicGroup.Semisimple.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
@@ -127,9 +128,8 @@ theorem semisimpleAffineGroupSchemeProperty_inverseImage
     (semisimpleAffineGroupSchemeProperty k).inverseImage
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
       (semisimpleCommHopfAlgProperty k).op := by
-  exact objectProperty_inverseImage_equivalence_inverse
-    (semisimpleCommHopfAlgProperty k).op
-    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k)
+  unfold semisimpleAffineGroupSchemeProperty
+  exact ObjectProperty.inverseImage_functor_inverseImage_inverse _ _
 
 /-- `Spec` restricts to an anti-equivalence from semisimple finite-type commutative Hopf algebras
 to semisimple affine group schemes. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
@@ -109,9 +109,8 @@ theorem smoothUnipotentAffineGroupSchemeProperty_inverseImage
     (smoothUnipotentAffineGroupSchemeProperty k).inverseImage
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
       (smoothUnipotentCommHopfAlgProperty k).op := by
-  exact objectProperty_inverseImage_equivalence_inverse
-    (smoothUnipotentCommHopfAlgProperty k).op
-    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k)
+  unfold smoothUnipotentAffineGroupSchemeProperty
+  exact ObjectProperty.inverseImage_equivalence_inverseImage _ _
 
 /-- `Spec` restricts to an anti-equivalence from smooth unipotent finite-type commutative Hopf
 algebras to smooth unipotent affine group schemes. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import TauCeti.CategoryTheory.ObjectProperty
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
 
@@ -109,9 +110,8 @@ theorem smoothUnipotentAffineGroupSchemeProperty_inverseImage
     (smoothUnipotentAffineGroupSchemeProperty k).inverseImage
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
       (smoothUnipotentCommHopfAlgProperty k).op := by
-  ext H
-  exact ((smoothUnipotentCommHopfAlgProperty k).op.prop_iff_of_iso
-    ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).unitIso.app H)).symm
+  unfold smoothUnipotentAffineGroupSchemeProperty
+  exact ObjectProperty.inverseImage_functor_inverseImage_inverse _ _
 
 /-- `Spec` restricts to an anti-equivalence from smooth unipotent finite-type commutative Hopf
 algebras to smooth unipotent affine group schemes. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
@@ -111,7 +111,7 @@ theorem smoothUnipotentAffineGroupSchemeProperty_inverseImage
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
       (smoothUnipotentCommHopfAlgProperty k).op := by
   unfold smoothUnipotentAffineGroupSchemeProperty
-  exact ObjectProperty.inverseImage_equivalence_inverseImage _ _
+  exact ObjectProperty.inverseImage_functor_inverseImage_inverse _ _
 
 /-- `Spec` restricts to an anti-equivalence from smooth unipotent finite-type commutative Hopf
 algebras to smooth unipotent affine group schemes. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.CategoryTheory.ObjectProperty
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
 
@@ -110,8 +109,9 @@ theorem smoothUnipotentAffineGroupSchemeProperty_inverseImage
     (smoothUnipotentAffineGroupSchemeProperty k).inverseImage
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
       (smoothUnipotentCommHopfAlgProperty k).op := by
-  unfold smoothUnipotentAffineGroupSchemeProperty
-  exact ObjectProperty.inverseImage_functor_inverseImage_inverse _ _
+  ext H
+  exact ((smoothUnipotentCommHopfAlgProperty k).op.prop_iff_of_iso
+    ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).unitIso.app H)).symm
 
 /-- `Spec` restricts to an anti-equivalence from smooth unipotent finite-type commutative Hopf
 algebras to smooth unipotent affine group schemes. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.CategoryTheory.ObjectProperty
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
 

--- a/TauCeti/CategoryTheory/ObjectProperty.lean
+++ b/TauCeti/CategoryTheory/ObjectProperty.lean
@@ -14,25 +14,25 @@ This file contains general lemmas about transporting object properties along equ
 
 ## Main declarations
 
-* `TauCeti.ObjectProperty.inverseImage_equivalence_inverseImage`: pulling an
+* `ObjectProperty.inverseImage_equivalence_inverseImage`: pulling an
   isomorphism-invariant property backward along both functors of an equivalence recovers it.
 -/
 
 public section
 
-namespace TauCeti
-
 open CategoryTheory
 
 universe u₁ v₁ u₂ v₂
 
+namespace ObjectProperty
+
 /-- Pulling an isomorphism-invariant object property backward along both functors of an
 equivalence recovers the original property. -/
-theorem ObjectProperty.inverseImage_equivalence_inverseImage
+theorem inverseImage_equivalence_inverseImage
     {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
     (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
     (P.inverseImage e.inverse).inverseImage e.functor = P := by
   ext X
   exact (P.prop_iff_of_iso (e.unitIso.app X)).symm
 
-end TauCeti
+end ObjectProperty

--- a/TauCeti/CategoryTheory/ObjectProperty.lean
+++ b/TauCeti/CategoryTheory/ObjectProperty.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.ObjectProperty.Opposite
+
+/-!
+# Object properties and equivalences
+
+This file contains general lemmas about transporting object properties along equivalences.
+
+## Main declarations
+
+* `TauCeti.ObjectProperty.inverseImage_equivalence_inverseImage`: pulling an
+  isomorphism-invariant property backward along both functors of an equivalence recovers it.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u₁ v₁ u₂ v₂
+
+/-- Pulling an isomorphism-invariant object property backward along both functors of an
+equivalence recovers the original property. -/
+theorem ObjectProperty.inverseImage_equivalence_inverseImage
+    {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+    (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
+    (P.inverseImage e.inverse).inverseImage e.functor = P := by
+  ext X
+  exact (P.prop_iff_of_iso (e.unitIso.app X)).symm
+
+end TauCeti

--- a/TauCeti/CategoryTheory/ObjectProperty.lean
+++ b/TauCeti/CategoryTheory/ObjectProperty.lean
@@ -5,7 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.CategoryTheory.ObjectProperty.Opposite
+public import Mathlib.CategoryTheory.Equivalence
+public import Mathlib.CategoryTheory.ObjectProperty.ClosedUnderIsomorphisms
 
 /-!
 # Object properties and equivalences

--- a/TauCeti/CategoryTheory/ObjectProperty.lean
+++ b/TauCeti/CategoryTheory/ObjectProperty.lean
@@ -14,21 +14,21 @@ This file contains general lemmas about transporting object properties along equ
 
 ## Main declarations
 
-* `ObjectProperty.inverseImage_equivalence_inverseImage`: pulling an
+* `CategoryTheory.ObjectProperty.inverseImage_functor_inverseImage_inverse`: pulling an
   isomorphism-invariant property backward along both functors of an equivalence recovers it.
 -/
 
 public section
 
-open CategoryTheory
-
 universe u₁ v₁ u₂ v₂
+
+namespace CategoryTheory
 
 namespace ObjectProperty
 
 /-- Pulling an isomorphism-invariant object property backward along both functors of an
 equivalence recovers the original property. -/
-theorem inverseImage_equivalence_inverseImage
+theorem inverseImage_functor_inverseImage_inverse
     {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
     (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
     (P.inverseImage e.inverse).inverseImage e.functor = P := by
@@ -36,3 +36,5 @@ theorem inverseImage_equivalence_inverseImage
   exact (P.prop_iff_of_iso (e.unitIso.app X)).symm
 
 end ObjectProperty
+
+end CategoryTheory


### PR DESCRIPTION
This PR packages linear reductivity as an isomorphism-invariant property of commutative Hopf algebras and transports it across the affine Hopf/group-scheme anti-equivalence. Prove complete reducibility invariant under corestriction along a coalgebra equivalence, define the coordinate and scheme object properties and their full subcategories, restrict `Spec` to an anti-equivalence between them, and prove that every finite-type diagonalizable group scheme `D(G)` is linearly reductive.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Alternative characterization, linearly reductive: every f.d. representation is completely reducible,” including the requirement to keep the representation/comodule and group-scheme views synchronized. After this PR, the milestone still needs the characteristic-zero equivalence between reductivity and linear reductivity and the positive-characteristic classification of connected linearly reductive groups as tori.

This is the most effective unclaimed current step because `Coalgebra.IsLinearlyReductive` and the complete-reducibility theorem for monoid-algebra coalgebras are already on `main`, but the predicate was not invariant under coordinate changes, was not available on affine group schemes, and had no `Spec`-compatible categorical interface. The open reductive-property PR #3541 develops the geometric-unipotent-radical definition and explicitly leaves the linearly reductive characterization outstanding, so the two branches are disjoint prerequisites for the later comparison theorem.

Add `TauCeti/Algebra/AlgebraicGroup/LinearlyReductive.lean` (86 lines) and `TauCeti/AlgebraicGeometry/AffineGroupScheme/LinearlyReductive.lean` (171 lines), and extend `TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean` by 98 lines with equivalence invariance. The proof transports subcomodule complements through the existing `Comodule.Corestrict` construction; the scheme layer reuses `commHopfAlgCatOpEquivAffineGroupSchemeCat`, `ObjectProperty.opEquivalence`, and `Equivalence.congrFullSubcategory`. No Mathlib infrastructure or external formalization is vendored. The mathematics follows Waterhouse, *Introduction to Affine Group Schemes*, Section 3.2, and Milne, *Algebraic Groups* (2017), Theorem 12.12, as credited in both new module docstrings.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"linearly-reductive-affine-group-schemes"}-->

🤖 Prepared with Codex
