### PR TITLE
feat(DenseGraphLimits): the strict symmetric-kernel carrier

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Basic.lean
@@ -41,7 +41,7 @@ Consequently the algebra below needs no hypothesis on `μ` at all — in particu
 
 * `AddCommGroup` and `Module ℝ` instances, defined pointwise. The `coe_zero`, `coe_add`, `coe_neg`,
   `coe_sub` and `coe_smul` simp lemmas identify every operation with the corresponding operation on
-  `Ω → Ω → ℝ`, so the module structure can be computed with entirely by `simp`.
+  `Ω → Ω → ℝ`, so the module structure can be computed entirely by `simp`.
 
 ## Implementation
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Basic.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+
+/-!
+# Symmetric kernels
+
+A **symmetric kernel** on a measure space `(Ω, μ)` is an honest, everywhere-defined function
+`Ω → Ω → ℝ` that is symmetric, jointly measurable, and uniformly bounded. It is the carrier the
+dense graph limit theory is built on: a graphon is a `[0, 1]`-valued symmetric kernel, and the cut
+norm is defined on kernels rather than on graphons precisely so that a *difference* `U - W` of two
+graphons is in its domain.
+
+**Strict, not `AEEqFun`.** The kernel carries a genuine function, not an a.e.-equivalence class.
+The a.e. identification is taken once and later, at `GraphonSpace`, rather than being built into the
+basic object. Two things follow, and they are why the roadmap makes this choice. First, the strict
+kernel is a *pointwise* `ℝ`-module — `(U - W) x y = U x y - W x y` holds on the nose, so cut-norm
+estimates never carry a null-set side condition. Second, pointwise hypotheses such as
+`∀ x y, W x y ∈ Set.Icc 0 1` are stateable at all, which an a.e. class cannot support without
+choosing a representative.
+
+**The measure is a phantom parameter.** `SymmKernel Ω μ` does not mention `μ` in any field: none of
+symmetry, measurability, or boundedness refers to it. It is carried in the type so that kernels over
+different measures on the same space are not silently interchangeable, and so that later
+measure-dependent structure (the cut norm, the `GraphonSpace` quotient) has somewhere to attach.
+Consequently the algebra below needs no hypothesis on `μ` at all — in particular not
+`IsProbabilityMeasure`.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.SymmKernel` — the strict symmetric kernel structure, with a `FunLike`
+  coercion, extensionality by the underlying function, and `symm` / `measurable` / `exists_bound`
+  accessors.
+
+## Main results
+
+* `AddCommGroup` and `Module ℝ` instances, defined pointwise. The `coe_zero`, `coe_add`, `coe_neg`,
+  `coe_sub` and `coe_smul` simp lemmas identify every operation with the corresponding operation on
+  `Ω → Ω → ℝ`, so the module structure can be computed with entirely by `simp`.
+
+## Implementation
+
+Each operation must re-establish all three fields. Symmetry and measurability are immediate.
+Boundedness is where the constants are chosen: `C + D` for a sum or difference, `C` for a negation,
+and `|c| * C` for a scalar multiple. Since the bound is existential (`∃ C, ∀ x y, |K x y| ≤ C`)
+rather than a fixed constant, no sharpness is claimed or needed.
+
+The algebraic instances are then transported along the injective coercion with
+`Function.Injective.addCommGroup` and `Function.Injective.module`, which is what makes the pointwise
+formulas definitional.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 1 — the strict kernel carrier. The
+  `Graphon` structure, `cutNorm`, homomorphism densities, and the `L⁰`-to-strict representative
+  bridge are separate targets and are not built here.
+* S. Janson, *Graphons, cut norm and distance, couplings and rearrangements*, NYJM Monographs 4
+  (2013).
+-/
+
+public section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- A **symmetric kernel**: an everywhere-defined symmetric, jointly measurable, uniformly bounded
+function `Ω → Ω → ℝ`.
+
+The measure is a phantom parameter — no field mentions it — but it is carried in the type so that
+kernels over different measures do not unify, and so that the measure-dependent theory built on top
+has somewhere to attach. -/
+structure SymmKernel (Ω : Type*) [MeasurableSpace Ω] (_μ : Measure Ω) where
+  /-- The underlying function. Use the `FunLike` coercion rather than this field. -/
+  toFun : Ω → Ω → ℝ
+  /-- The kernel is symmetric. Stated via `SymmKernel.symm`. -/
+  symm' : ∀ x y, toFun x y = toFun y x
+  /-- The kernel is jointly measurable. Stated via `SymmKernel.measurable`. -/
+  meas' : Measurable (Function.uncurry toFun)
+  /-- The kernel is uniformly bounded. Stated via `SymmKernel.exists_bound`. -/
+  bdd' : ∃ C, ∀ x y, |toFun x y| ≤ C
+
+namespace SymmKernel
+
+instance instFunLike : FunLike (SymmKernel Ω μ) Ω (Ω → ℝ) where
+  coe := SymmKernel.toFun
+  coe_injective K L h := by cases K; cases L; congr
+
+@[simp]
+theorem coe_mk (f : Ω → Ω → ℝ) (hs hm hb) : ⇑(mk f hs hm hb : SymmKernel Ω μ) = f := rfl
+
+@[ext]
+theorem ext {K L : SymmKernel Ω μ} (h : ∀ x y, K x y = L x y) : K = L :=
+  DFunLike.ext _ _ fun x => funext fun y => h x y
+
+/-- A symmetric kernel is symmetric. -/
+theorem symm (K : SymmKernel Ω μ) (x y : Ω) : K x y = K y x := K.symm' x y
+
+/-- A symmetric kernel is jointly measurable. -/
+theorem measurable (K : SymmKernel Ω μ) : Measurable (Function.uncurry (K : Ω → Ω → ℝ)) := K.meas'
+
+/-- A symmetric kernel is uniformly bounded. The constant is not canonical. -/
+theorem exists_bound (K : SymmKernel Ω μ) : ∃ C, ∀ x y, |K x y| ≤ C := K.bdd'
+
+section Algebra
+
+instance : Zero (SymmKernel Ω μ) :=
+  ⟨⟨fun _ _ => 0, fun _ _ => rfl, measurable_const, 0, by simp⟩⟩
+
+instance : Add (SymmKernel Ω μ) :=
+  ⟨fun K L => ⟨fun x y => K x y + L x y, fun x y => by rw [K.symm, L.symm],
+    by exact K.measurable.add L.measurable,
+    by obtain ⟨C, hC⟩ := K.exists_bound; obtain ⟨D, hD⟩ := L.exists_bound
+       exact ⟨C + D, fun x y => (abs_add_le _ _).trans (add_le_add (hC x y) (hD x y))⟩⟩⟩
+
+instance : Neg (SymmKernel Ω μ) :=
+  ⟨fun K => ⟨fun x y => -K x y, fun x y => by rw [K.symm],
+    by exact K.measurable.neg,
+    by obtain ⟨C, hC⟩ := K.exists_bound; exact ⟨C, fun x y => by simpa using hC x y⟩⟩⟩
+
+instance : Sub (SymmKernel Ω μ) :=
+  ⟨fun K L => ⟨fun x y => K x y - L x y, fun x y => by rw [K.symm, L.symm],
+    by exact K.measurable.sub L.measurable,
+    by obtain ⟨C, hC⟩ := K.exists_bound; obtain ⟨D, hD⟩ := L.exists_bound
+       exact ⟨C + D, fun x y => (abs_sub _ _).trans (add_le_add (hC x y) (hD x y))⟩⟩⟩
+
+instance : SMul ℝ (SymmKernel Ω μ) :=
+  ⟨fun c K => ⟨fun x y => c * K x y, fun x y => by rw [K.symm],
+    by exact K.measurable.const_mul c,
+    by obtain ⟨C, hC⟩ := K.exists_bound
+       exact ⟨|c| * C, fun x y => by
+         rw [abs_mul]; exact mul_le_mul_of_nonneg_left (hC x y) (abs_nonneg c)⟩⟩⟩
+
+instance : SMul ℕ (SymmKernel Ω μ) :=
+  ⟨fun n K => ⟨fun x y => n • K x y, fun x y => by rw [K.symm],
+    by exact K.measurable.const_smul (n : ℕ),
+    by obtain ⟨C, hC⟩ := K.exists_bound
+       exact ⟨n * C, fun x y => by
+         simpa [abs_mul, nsmul_eq_mul] using
+           mul_le_mul_of_nonneg_left (hC x y) (Nat.cast_nonneg (α := ℝ) n)⟩⟩⟩
+
+instance : SMul ℤ (SymmKernel Ω μ) :=
+  ⟨fun n K => ⟨fun x y => n • K x y, fun x y => by rw [K.symm],
+    by exact K.measurable.const_smul (n : ℤ),
+    by obtain ⟨C, hC⟩ := K.exists_bound
+       exact ⟨|(n : ℝ)| * C, fun x y => by
+         simpa [abs_mul, zsmul_eq_mul] using
+           mul_le_mul_of_nonneg_left (hC x y) (abs_nonneg ((n : ℝ)))⟩⟩⟩
+
+@[simp] theorem coe_zero : ⇑(0 : SymmKernel Ω μ) = 0 := rfl
+
+@[simp] theorem coe_add (K L : SymmKernel Ω μ) : ⇑(K + L) = ⇑K + ⇑L := rfl
+
+@[simp] theorem coe_neg (K : SymmKernel Ω μ) : ⇑(-K) = -⇑K := rfl
+
+@[simp] theorem coe_sub (K L : SymmKernel Ω μ) : ⇑(K - L) = ⇑K - ⇑L := rfl
+
+@[simp] theorem coe_smul (c : ℝ) (K : SymmKernel Ω μ) : ⇑(c • K) = c • ⇑K := rfl
+
+@[simp] theorem coe_nsmul (n : ℕ) (K : SymmKernel Ω μ) : ⇑(n • K) = n • ⇑K := rfl
+
+@[simp] theorem coe_zsmul (n : ℤ) (K : SymmKernel Ω μ) : ⇑(n • K) = n • ⇑K := rfl
+
+instance : AddCommGroup (SymmKernel Ω μ) :=
+  DFunLike.coe_injective.addCommGroup _ coe_zero coe_add coe_neg coe_sub
+    (fun K n => coe_nsmul n K) (fun K n => coe_zsmul n K)
+
+instance : Module ℝ (SymmKernel Ω μ) :=
+  DFunLike.coe_injective.module ℝ
+    ({ toFun := DFunLike.coe, map_zero' := coe_zero, map_add' := coe_add } :
+      SymmKernel Ω μ →+ (Ω → Ω → ℝ)) coe_smul
+
+end Algebra
+
+end SymmKernel
+
+end DenseGraphLimits
+
+end TauCeti


### PR DESCRIPTION
The Layer 1 carrier for dense graph limits. `SymmKernel Ω μ` bundles an everywhere-defined
`Ω → Ω → ℝ` with symmetry, joint measurability, and uniform boundedness:

```lean
structure SymmKernel (Ω : Type*) [MeasurableSpace Ω] (_μ : Measure Ω) where
  toFun : Ω → Ω → ℝ
  symm' : ∀ x y, toFun x y = toFun y x
  meas' : Measurable (Function.uncurry toFun)
  bdd'  : ∃ C, ∀ x y, |toFun x y| ≤ C
```

with a `FunLike` coercion, `@[ext]` by the underlying function, and `symm` / `measurable` /
`exists_bound` accessors, plus pointwise `AddCommGroup` and `Module ℝ` instances.

## Strict, not `AEEqFun`

The kernel carries a genuine function; the a.e. identification happens once and later, at
`GraphonSpace`. Two consequences are what the roadmap is buying:

- the kernel is a **pointwise** `ℝ`-module, so `(U - W) x y = U x y - W x y` holds on the nose and
  cut-norm estimates carry no null-set side condition;
- pointwise hypotheses such as `∀ x y, W x y ∈ Set.Icc 0 1` are stateable at all, which an a.e.
  class cannot support without choosing a representative.

## The measure is a phantom parameter

No field mentions `μ`. It is carried in the type so kernels over different measures do not unify,
and so the later measure-dependent theory (cut norm, the `GraphonSpace` quotient) has somewhere to
attach. **The algebra therefore assumes nothing about `μ` — in particular not
`IsProbabilityMeasure`.**

## Pointwise formulas are definitional

`AddCommGroup` and `Module ℝ` are transported along the injective coercion with
`Function.Injective.addCommGroup` / `.module`, so `coe_zero`, `coe_add`, `coe_neg`, `coe_sub`,
`coe_smul`, `coe_nsmul` and `coe_zsmul` are all `rfl` and the module structure computes by `simp`.

Every operation re-establishes all three fields. Symmetry and measurability are immediate;
boundedness is where constants are chosen — `C + D` for a sum or difference, `C` for a negation,
`|c| * C` for a scalar multiple. The bound is existential, so no sharpness is claimed.

## Scope

Excludes `Graphon`, `cutNorm`, homomorphism densities, and the later `L⁰`-to-strict representative
bridge. The `Graphon` carrier and its constructors are the natural follow-up and are deliberately
not claimed here.

Closes TauCetiProject/TauCetiRoadmap#239

Roadmap: DenseGraphLimits

Authorized by `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 1; the signature matches
`Suggested.lean`.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
