### PR TITLE
refactor: give the general linear group API dot notation

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.lean
@@ -52,7 +52,7 @@ inside each ambient general linear group.
 
 public section
 
-open WithConv
+open LinearMap WithConv
 open scoped TensorProduct
 
 namespace TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/SemisimplePoint.lean
@@ -54,7 +54,7 @@ built in Layer 1.
 
 public section
 
-open WithConv
+open LinearMap WithConv
 open scoped TensorProduct
 
 namespace TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/JordanDecomposition.lean
@@ -49,7 +49,7 @@ representation-theoretic bridge in Layer 4 of the ReductiveGroups roadmap.
 
 public section
 
-open CategoryTheory
+open CategoryTheory LinearMap
 open scoped TensorProduct
 
 namespace TauCeti.Tannaka

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/SemisimplePoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/SemisimplePoint.lean
@@ -32,7 +32,7 @@ Layer 4 of the ReductiveGroups roadmap.
 
 public section
 
-open CategoryTheory WithConv
+open CategoryTheory LinearMap WithConv
 open scoped TensorProduct
 
 namespace TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Basic.lean
@@ -57,7 +57,7 @@ ReductiveGroups roadmap. It uses the representation--comodule dictionary built i
 
 public section
 
-open WithConv
+open LinearMap WithConv
 
 namespace TauCeti
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Faithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/UnipotentPoint/Faithful.lean
@@ -43,7 +43,7 @@ characterization is still to come.
 
 public section
 
-open WithConv
+open LinearMap WithConv
 
 namespace TauCeti.HopfAlgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Unipotent.lean
@@ -42,7 +42,7 @@ direction of the roadmap's upper-unitriangular embedding characterization.
 
 public section
 
-open Module WithConv
+open LinearMap Module WithConv
 open scoped TensorProduct
 
 namespace TauCeti.UpperUnitriangular

--- a/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Unipotent.lean
@@ -42,7 +42,7 @@ direction of the roadmap's upper-unitriangular embedding characterization.
 
 public section
 
-open LinearMap Module WithConv
+open Module WithConv
 open scoped TensorProduct
 
 namespace TauCeti.UpperUnitriangular
@@ -211,10 +211,10 @@ theorem congrLinearEquiv_pointsAction_eq_toLin
 /-- The standard representation sends every point of `U_n` to a unipotent automorphism. -/
 theorem isUnipotent_pointsAction
     (g : WithConv (coordinateHopfAlgebra R (Fin n) →ₐ[R] A)) :
-    GeneralLinearGroup.IsUnipotent
+    LinearMap.GeneralLinearGroup.IsUnipotent
       (LinearMap.GeneralLinearGroup.ofLinearEquiv
         (Comodule.pointsAction (Fin n → R) g)) := by
-  apply (GeneralLinearGroup.isUnipotent_congrLinearEquiv_iff
+  apply (LinearMap.GeneralLinearGroup.isUnipotent_congrLinearEquiv_iff
     (standardScalarExtensionEquiv R n)
     (LinearMap.GeneralLinearGroup.ofLinearEquiv
       (Comodule.pointsAction (Fin n → R) g))).mp

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
@@ -17,17 +17,15 @@ different modules, so the relation is not a statement inside one monoid and Math
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.comp_inv_eq_of_comp_eq`: an intertwiner of two automorphisms also
+* `LinearMap.GeneralLinearGroup.comp_inv_eq_of_comp_eq`: an intertwiner of two automorphisms also
   intertwines their inverses.
 -/
 
 public section
 
-namespace TauCeti
-
 open LinearMap
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 universe u v w
 
@@ -52,6 +50,4 @@ theorem comp_inv_eq_of_comp_eq (f : V →ₗ[K] W) (a : GeneralLinearGroup K V)
     _ = (↑b⁻¹ : Module.End K W).comp f := by
         rw [LinearMap.comp_assoc, ha, LinearMap.comp_id]
 
-end GeneralLinearGroup
-
-end TauCeti
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Intertwining.lean
@@ -23,8 +23,6 @@ different modules, so the relation is not a statement inside one monoid and Math
 
 public section
 
-open LinearMap
-
 namespace LinearMap.GeneralLinearGroup
 
 universe u v w

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Prod.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Prod.lean
@@ -22,8 +22,6 @@ compatibility with the group operations.
 
 public section
 
-open LinearMap
-
 namespace LinearMap.GeneralLinearGroup
 
 universe u v w

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Prod.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Prod.lean
@@ -16,17 +16,15 @@ compatibility with the group operations.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.prodMap`: the componentwise product of two linear automorphisms.
-* `TauCeti.GeneralLinearGroup.prodMap_apply`: the product automorphism acts componentwise.
+* `LinearMap.GeneralLinearGroup.prodMap`: the componentwise product of two linear automorphisms.
+* `LinearMap.GeneralLinearGroup.prodMap_apply`: the product automorphism acts componentwise.
 -/
 
 public section
 
-namespace TauCeti
-
 open LinearMap
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 universe u v w
 
@@ -68,6 +66,4 @@ theorem prodMap_inv (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K W) :
     prodMap g⁻¹ h⁻¹ = (prodMap g h)⁻¹ := by
   ext x <;> rfl
 
-end GeneralLinearGroup
-
-end TauCeti
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -22,7 +22,6 @@ its compatibility with multiplication, inverses, and pure tensors.
 
 public section
 
-open LinearMap
 open scoped TensorProduct
 
 namespace LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/TensorProduct.lean
@@ -16,18 +16,16 @@ its compatibility with multiplication, inverses, and pure tensors.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.tensorProduct`: the tensor product of two linear automorphisms.
-* `TauCeti.GeneralLinearGroup.tensorProduct_tmul`: its action on a pure tensor.
+* `LinearMap.GeneralLinearGroup.tensorProduct`: the tensor product of two linear automorphisms.
+* `LinearMap.GeneralLinearGroup.tensorProduct_tmul`: its action on a pure tensor.
 -/
 
 public section
 
-namespace TauCeti
-
 open LinearMap
 open scoped TensorProduct
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 universe u v w
 
@@ -82,6 +80,4 @@ theorem tensorProduct_inv (g : GeneralLinearGroup K V) (h : GeneralLinearGroup K
   exact eq_inv_of_mul_eq_one_left <| by
     rw [← tensorProduct_mul, inv_mul_cancel, inv_mul_cancel, tensorProduct_one]
 
-end GeneralLinearGroup
-
-end TauCeti
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
@@ -28,25 +28,25 @@ Products require commutativity. Indeed, writing `g = 1 + x` and `h = 1 + y`, the
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.IsUnipotent`: a linear automorphism is unipotent when its
+* `LinearMap.GeneralLinearGroup.IsUnipotent`: a linear automorphism is unipotent when its
   difference from the identity is nilpotent.
-* `TauCeti.GeneralLinearGroup.isUnipotent_def`: the defining nilpotence criterion.
-* `TauCeti.GeneralLinearGroup.isUnipotent_one`: the identity automorphism is unipotent.
-* `TauCeti.GeneralLinearGroup.IsUnipotent.inv`: the inverse of a unipotent automorphism is
+* `LinearMap.GeneralLinearGroup.isUnipotent_def`: the defining nilpotence criterion.
+* `LinearMap.GeneralLinearGroup.isUnipotent_one`: the identity automorphism is unipotent.
+* `LinearMap.GeneralLinearGroup.IsUnipotent.inv`: the inverse of a unipotent automorphism is
   unipotent.
-* `TauCeti.GeneralLinearGroup.isUnipotent_ofLinearEquiv_iff`: unipotence after converting a
+* `LinearMap.GeneralLinearGroup.isUnipotent_ofLinearEquiv_iff`: unipotence after converting a
   linear equivalence to a general-linear-group element.
-* `TauCeti.GeneralLinearGroup.isUnipotent_congrLinearEquiv_iff`: unipotence is invariant under
+* `LinearMap.GeneralLinearGroup.isUnipotent_congrLinearEquiv_iff`: unipotence is invariant under
   transport by a linear equivalence.
-* `TauCeti.GeneralLinearGroup.isUnipotent_inv_iff`: an automorphism is unipotent exactly when
+* `LinearMap.GeneralLinearGroup.isUnipotent_inv_iff`: an automorphism is unipotent exactly when
   its inverse is.
-* `TauCeti.GeneralLinearGroup.IsUnipotent.mul_of_commute`: commuting unipotent automorphisms have
+* `LinearMap.GeneralLinearGroup.IsUnipotent.mul_of_commute`: commuting unipotent automorphisms have
   unipotent product.
-* `TauCeti.GeneralLinearGroup.IsUnipotent.pow` and `.zpow`: every natural or integer power of a
+* `LinearMap.GeneralLinearGroup.IsUnipotent.pow` and `.zpow`: every natural or integer power of a
   unipotent automorphism is unipotent.
-* `TauCeti.GeneralLinearGroup.isUnipotent_conj_iff`: unipotence is invariant under
+* `LinearMap.GeneralLinearGroup.isUnipotent_conj_iff`: unipotence is invariant under
   conjugation.
-* `TauCeti.GeneralLinearGroup.IsUnipotent.eq_one_of_finrank_eq_one`: a unipotent automorphism
+* `LinearMap.GeneralLinearGroup.IsUnipotent.eq_one_of_finrank_eq_one`: a unipotent automorphism
   of a free rank-one module over a reduced commutative ring is the identity.
 
 ## References
@@ -56,11 +56,9 @@ Products require commutativity. Indeed, writing `g = 1 + x` and `h = 1 + y`, the
 
 public section
 
-namespace TauCeti
-
 open LinearMap
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 open _root_.Module
 
@@ -233,6 +231,4 @@ theorem IsUnipotent.eq_one_of_finrank_eq_one
   ext w
   simp
 
-end GeneralLinearGroup
-
-end TauCeti
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
@@ -56,8 +56,6 @@ Products require commutativity. Indeed, writing `g = 1 + x` and `h = 1 + y`, the
 
 public section
 
-open LinearMap
-
 namespace LinearMap.GeneralLinearGroup
 
 open _root_.Module

--- a/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
@@ -46,7 +46,7 @@ representation of an affine algebraic group.
 
 public section
 
-open LinearMap Polynomial
+open Polynomial
 
 namespace LinearMap.GeneralLinearGroup
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Functoriality.lean
@@ -26,17 +26,17 @@ representation of an affine algebraic group.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.isSemisimple_congrLinearEquiv_iff`: semisimplicity is invariant
+* `LinearMap.GeneralLinearGroup.isSemisimple_congrLinearEquiv_iff`: semisimplicity is invariant
   under linear conjugation.
-* `TauCeti.GeneralLinearGroup.isSemisimple_conj_iff`: semisimplicity is invariant under
+* `LinearMap.GeneralLinearGroup.isSemisimple_conj_iff`: semisimplicity is invariant under
   conjugation within the general linear group.
-* `TauCeti.GeneralLinearGroup.jordanDecomposition_congrLinearEquiv`: the canonical pair is
+* `LinearMap.GeneralLinearGroup.jordanDecomposition_congrLinearEquiv`: the canonical pair is
   equivariant under linear conjugation.
-* `TauCeti.GeneralLinearGroup.semisimplePart_congrLinearEquiv` and
-  `TauCeti.GeneralLinearGroup.unipotentPart_congrLinearEquiv`: the two factor formulas.
-* `TauCeti.GeneralLinearGroup.comp_semisimplePart_eq_of_comp_eq`: intertwiners commute with
+* `LinearMap.GeneralLinearGroup.semisimplePart_congrLinearEquiv` and
+  `LinearMap.GeneralLinearGroup.unipotentPart_congrLinearEquiv`: the two factor formulas.
+* `LinearMap.GeneralLinearGroup.comp_semisimplePart_eq_of_comp_eq`: intertwiners commute with
   semisimple factors.
-* `TauCeti.GeneralLinearGroup.comp_unipotentPart_eq_of_comp_eq`: intertwiners commute with
+* `LinearMap.GeneralLinearGroup.comp_unipotentPart_eq_of_comp_eq`: intertwiners commute with
   unipotent factors.
 
 ## References
@@ -46,11 +46,9 @@ representation of an affine algebraic group.
 
 public section
 
-namespace TauCeti
-
 open LinearMap Polynomial
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 open _root_.Module
 
@@ -217,6 +215,4 @@ end Intertwining
 
 end PerfectField
 
-end GeneralLinearGroup
-
-end TauCeti
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
@@ -27,15 +27,15 @@ through faithful representations of affine algebraic groups.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.IsSemisimple`: a linear automorphism is semisimple when its
+* `LinearMap.GeneralLinearGroup.IsSemisimple`: a linear automorphism is semisimple when its
   underlying endomorphism is semisimple.
-* `TauCeti.GeneralLinearGroup.IsSemisimple.inv` and `.zpow`: semisimple automorphisms are closed
+* `LinearMap.GeneralLinearGroup.IsSemisimple.inv` and `.zpow`: semisimple automorphisms are closed
   under inverses and integer powers.
-* `TauCeti.GeneralLinearGroup.IsSemisimple.mul_of_commute`: commuting semisimple automorphisms
+* `LinearMap.GeneralLinearGroup.IsSemisimple.mul_of_commute`: commuting semisimple automorphisms
   have semisimple product.
-* `TauCeti.GeneralLinearGroup.jordanDecomposition`: the canonical commuting semisimple and
+* `LinearMap.GeneralLinearGroup.jordanDecomposition`: the canonical commuting semisimple and
   unipotent factors.
-* `TauCeti.GeneralLinearGroup.eq_jordanDecomposition_iff`: the existence and uniqueness
+* `LinearMap.GeneralLinearGroup.eq_jordanDecomposition_iff`: the existence and uniqueness
   characterization of those factors.
 
 ## References
@@ -47,11 +47,9 @@ through faithful representations of affine algebraic groups.
 
 public section
 
-namespace TauCeti
-
 open LinearMap
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 open Module
 
@@ -90,7 +88,7 @@ theorem IsSemisimple.inv {g : GeneralLinearGroup K V} (hg : IsSemisimple g) :
     IsSemisimple g⁻¹ := by
   rw [isSemisimple_def] at hg ⊢
   exact hg.of_mem_adjoin_singleton
-    (Units.coe_inv_mem_adjoin g (IsIntegral.of_finite K (g : End K V)))
+    (TauCeti.Units.coe_inv_mem_adjoin g (IsIntegral.of_finite K (g : End K V)))
 
 /-- A linear automorphism is semisimple if and only if its inverse is semisimple. -/
 @[simp]
@@ -395,6 +393,4 @@ theorem unipotentPart_eq_self {g : GeneralLinearGroup K V} (hg : IsUnipotent g) 
 
 end PerfectField
 
-end GeneralLinearGroup
-
-end TauCeti
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Multiplicative.lean
@@ -47,8 +47,6 @@ through faithful representations of affine algebraic groups.
 
 public section
 
-open LinearMap
-
 namespace LinearMap.GeneralLinearGroup
 
 open Module

--- a/TauCeti/LinearAlgebra/JordanChevalley/Prod.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Prod.lean
@@ -21,7 +21,7 @@ ReductiveGroups roadmap.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.jordanDecomposition_prodMap`: Jordan decomposition is componentwise
+* `LinearMap.GeneralLinearGroup.jordanDecomposition_prodMap`: Jordan decomposition is componentwise
   on product modules.
 
 ## References
@@ -31,11 +31,9 @@ ReductiveGroups roadmap.
 
 public section
 
-namespace TauCeti
-
 open LinearMap Polynomial
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 universe u v w
 
@@ -49,7 +47,7 @@ theorem IsSemisimple.prodMap {g : GeneralLinearGroup K V} {h : GeneralLinearGrou
     (hg : IsSemisimple g) (hh : IsSemisimple h) : IsSemisimple (prodMap g h) := by
   rw [isSemisimple_def] at hg hh ⊢
   rw [coe_prodMap]
-  exact Module.End.IsSemisimple.prodMap hg hh
+  exact TauCeti.Module.End.IsSemisimple.prodMap hg hh
 
 /-- The product map of two unipotent automorphisms is unipotent. -/
 theorem IsUnipotent.prodMap {g : GeneralLinearGroup K V} {h : GeneralLinearGroup K W}
@@ -95,6 +93,4 @@ theorem unipotentPart_prodMap (g : GeneralLinearGroup K V) (h : GeneralLinearGro
 
 end PerfectField
 
-end GeneralLinearGroup
-
-end TauCeti
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/JordanChevalley/Prod.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/Prod.lean
@@ -31,7 +31,7 @@ ReductiveGroups roadmap.
 
 public section
 
-open LinearMap Polynomial
+open Polynomial
 
 namespace LinearMap.GeneralLinearGroup
 

--- a/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
@@ -38,7 +38,6 @@ Tannakian reconstruction.
 
 public section
 
-open LinearMap
 open scoped TensorProduct
 
 namespace LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/JordanChevalley/TensorProduct.lean
@@ -24,11 +24,11 @@ Tannakian reconstruction.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.IsSemisimple.tensorProduct`: tensor products of semisimple
+* `LinearMap.GeneralLinearGroup.IsSemisimple.tensorProduct`: tensor products of semisimple
   automorphisms are semisimple.
-* `TauCeti.GeneralLinearGroup.IsUnipotent.tensorProduct`: tensor products of unipotent
+* `LinearMap.GeneralLinearGroup.IsUnipotent.tensorProduct`: tensor products of unipotent
   automorphisms are unipotent.
-* `TauCeti.GeneralLinearGroup.jordanDecomposition_tensorProduct`: the canonical decomposition is
+* `LinearMap.GeneralLinearGroup.jordanDecomposition_tensorProduct`: the canonical decomposition is
   factorwise on tensor products.
 
 ## References
@@ -38,12 +38,10 @@ Tannakian reconstruction.
 
 public section
 
-namespace TauCeti
-
 open LinearMap
 open scoped TensorProduct
 
-namespace GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 universe u v w
 
@@ -60,7 +58,7 @@ theorem IsSemisimple.tensorProduct {g : GeneralLinearGroup K V}
     IsSemisimple (tensorProduct g h) := by
   rw [isSemisimple_def] at hg hh ⊢
   rw [coe_tensorProduct]
-  exact Module.End.IsSemisimple.tensorProduct hg hh
+  exact TauCeti.Module.End.IsSemisimple.tensorProduct hg hh
 
 end Semisimple
 
@@ -113,6 +111,4 @@ theorem unipotentPart_tensorProduct
 
 end PerfectField
 
-end GeneralLinearGroup
-
-end TauCeti
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Unipotent.lean
@@ -17,13 +17,13 @@ of the matrix obtained by subtracting the identity.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.isUnipotent_toLin_iff` — a matrix acts unipotently exactly when
+* `LinearMap.GeneralLinearGroup.isUnipotent_toLin_iff` — a matrix acts unipotently exactly when
   subtracting the identity from the matrix gives a nilpotent matrix.
 -/
 
 public section
 
-namespace TauCeti.GeneralLinearGroup
+namespace LinearMap.GeneralLinearGroup
 
 universe u
 
@@ -37,4 +37,4 @@ theorem isUnipotent_toLin_iff
   simp only [Matrix.GeneralLinearGroup.coe_toLin, Matrix.toLin'_apply',
     Module.End.one_eq_id]
 
-end TauCeti.GeneralLinearGroup
+end LinearMap.GeneralLinearGroup

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/UpperUnitriangular/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/UpperUnitriangular/Basic.lean
@@ -238,9 +238,9 @@ theorem map_comp {S T : Type*} [CommRing S] [CommRing T]
 
 /-- The natural linear action of every upper-unitriangular matrix is unipotent. -/
 theorem isUnipotent_toLin (g : upperUnitriangularGroup m R) :
-    GeneralLinearGroup.IsUnipotent
+    LinearMap.GeneralLinearGroup.IsUnipotent
       (Matrix.GeneralLinearGroup.toLin (g : GL m R)) :=
-  (TauCeti.GeneralLinearGroup.isUnipotent_toLin_iff m R (g : GL m R)).2
+  (LinearMap.GeneralLinearGroup.isUnipotent_toLin_iff m R (g : GL m R)).2
     (isUpperUnitriangular g).isNilpotent_sub_one
 
 end CommRing


### PR DESCRIPTION
This PR moves the declarations extending Mathlib's `LinearMap.GeneralLinearGroup` out of the enclosing `TauCeti` namespace, so receiver notation such as `g.IsUnipotent`, `g.semisimplePart`, and `g.tensorProduct h` elaborates. It also hoists `open LinearMap` in downstream algebraic-group consumers and fully qualifies the few Tau Ceti declarations whose old resolution depended on the wrapper.

This is the `GeneralLinearGroup` namespace-migration slice of #3547. Locally verified with the full `lake build` (8,178 jobs) and direct dot-notation elaboration checks.

Roadmap: ReductiveGroups

:robot: Prepared with OpenAI Codex
