### PR TITLE
chore: normalize copyright Authors lines (part 1/4)

### DIFF
--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/End/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/End/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/End/Trivial.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/End/Trivial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/Iso.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Isogeny.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Isogeny.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/MorphismGroup.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/MorphismGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Product.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/TangentSpace.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/TangentSpace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Trivial.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Trivial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Antigravity
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/BaseChange/Coordinate.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality/FiniteLocallyFree.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/CartierDuality/FiniteLocallyFree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/ClosedImmersion.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/ClosedImmersion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Components/Finite.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Components/Finite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/FiniteType.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/FiniteType.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/GeometricallyReduced.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/GeometricallyReduced.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AugmentationPoint/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AugmentationPoint/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/AugmentationPoint/ConnectedComponent.lean
+++ b/TauCeti/AlgebraicGeometry/AugmentationPoint/ConnectedComponent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRingMap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FinitePoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FinitePoint.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Formula/VariableChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FrobeniusTower.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FrobeniusTower.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Norm.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Norm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/LocalRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/LocalRing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/MapAlong.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/MapAlong.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/VariableChange.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/VariableChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/XYIdealMaximal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Cusp.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Cusp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Discriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Discriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Expand.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Dedekind.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Finite.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Finite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/IntegrallyClosed.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/VariableChange.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/VariableChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/FinitelyPresentedSheaf/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/FinitelyPresentedSheaf/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/Geometrically/Integral.lean
+++ b/TauCeti/AlgebraicGeometry/Geometrically/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/GroupScheme/ClosedSubgroup.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/ClosedSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/IrreducibleOfConnectedDomainStalk.lean
+++ b/TauCeti/AlgebraicGeometry/IrreducibleOfConnectedDomainStalk.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 daouid. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: daouid
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/LineBundle/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/LineBundle/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/PullbackSpecMap.lean
+++ b/TauCeti/AlgebraicGeometry/PullbackSpecMap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/RationalPoint/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/RationalPoint/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/RationalPoint/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/RationalPoint/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/ResidueDegree.lean
+++ b/TauCeti/AlgebraicGeometry/ResidueDegree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/TangentSpace/Affine.lean
+++ b/TauCeti/AlgebraicGeometry/TangentSpace/Affine.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/TangentSpace/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/TangentSpace/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/DegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/DegreeSplitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/FiniteSum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/FixedDegree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/LinearSystem.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/LinearSystem.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Quotient.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Quotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/BasepointChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Common.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Common.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/ClassGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/Image/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/Image/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/Image/Splitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/Image/Splitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/Splitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/Splitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/ZeroGenerators.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Degree/ZeroGenerators.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Addition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Addition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Subtraction.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Subtraction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/Effectivity.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/Effectivity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/NthRoot.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/NthRoot.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Addition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Addition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Monotone.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Monotone.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PicZeroQuotient.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PicZeroQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PositiveNegativeFixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PositiveNegativeFixedDegree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Principal/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Principal/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Principal/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Principal/Kernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Principal.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Principal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Union.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Union.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/BasepointChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/Homeomorph.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/FundamentalGroup/Product.lean
+++ b/TauCeti/AlgebraicTopology/FundamentalGroup/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SemilocallySimplyConnected/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SemilocallySimplyConnected/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Cone.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Cone.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/FaceCount.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/FaceCount.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Map.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Collapse/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Cone.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Cone.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Dimension.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Dimension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/ElementaryCollapse.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/IsCone.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/IsCone.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Join.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/LinkStar.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/LinkStar.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Maps.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/OrderComplex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Product.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Realization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex/Link.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex/Link.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Simplex/Realization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Realization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/EilenbergMacLane.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/NotSimplyConnected.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/DeckGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/DeckGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Existence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Pointed.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Pointed.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Reconstruction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Reconstruction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Regular.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Regular.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Unpointed.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Unpointed.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Conjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Conjugation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected/Torsor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected/Torsor.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Monodromy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Monodromy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Orbit.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Orbit.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/TorsorTransport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/TorsorTransport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Transport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Transport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/Opposite.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/Opposite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient/Equivariance.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient/Equivariance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient/Conjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient/Conjugation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient/FiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient/FiberAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/ActingGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/ActingGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Covering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Covering.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Homeomorph.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Normalizer.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Normalizer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Torsor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Torsor.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit/QuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit/QuotientGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Circle.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Circle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Deck.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Deck.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Line.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Line.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/FundamentalGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/HigherHomotopy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Exact/Abelian.lean
+++ b/TauCeti/CategoryTheory/Exact/Abelian.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Exact/Functor.lean
+++ b/TauCeti/CategoryTheory/Exact/Functor.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
+++ b/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Exact/Opposite.lean
+++ b/TauCeti/CategoryTheory/Exact/Opposite.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Exact/Split.lean
+++ b/TauCeti/CategoryTheory/Exact/Split.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Limits/Shapes/Pullback/SplitEpi.lean
+++ b/TauCeti/CategoryTheory/Limits/Shapes/Pullback/SplitEpi.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Monoidal/Mon.lean
+++ b/TauCeti/CategoryTheory/Monoidal/Mon.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
+++ b/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/MayerVietoris.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/Terminal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Brauer/Boundary.lean
+++ b/TauCeti/Combinatorics/Brauer/Boundary.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Brauer/Compose.lean
+++ b/TauCeti/Combinatorics/Brauer/Compose.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Brauer/Diagram.lean
+++ b/TauCeti/Combinatorics/Brauer/Diagram.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Brauer/LoopCount.lean
+++ b/TauCeti/Combinatorics/Brauer/LoopCount.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Brauer/Relabel.lean
+++ b/TauCeti/Combinatorics/Brauer/Relabel.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Enumerative/Partition/Basic.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Enumerative/Partition/Dominance.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Dominance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Quiver/BoundedPaths.lean
+++ b/TauCeti/Combinatorics/Quiver/BoundedPaths.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/Acyclic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/SimpleGraph/BranchComponents.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/BranchComponents.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/SimpleGraph/PathGraph.lean
+++ b/TauCeti/Combinatorics/SimpleGraph/PathGraph.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/Corner.lean
+++ b/TauCeti/Combinatorics/Young/Corner.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/Diagram.lean
+++ b/TauCeti/Combinatorics/Young/Diagram.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/Dominance.lean
+++ b/TauCeti/Combinatorics/Young/Dominance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/HookLength.lean
+++ b/TauCeti/Combinatorics/Young/HookLength.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/Interlacing.lean
+++ b/TauCeti/Combinatorics/Young/Interlacing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/OfRowLens.lean
+++ b/TauCeti/Combinatorics/Young/OfRowLens.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/Partitions.lean
+++ b/TauCeti/Combinatorics/Young/Partitions.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/SemistandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/SemistandardTableau.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/StandardTableau/Basic.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/StandardTableau/Corner.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Corner.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/StandardTableau/Order.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/StandardTableau/Reading.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Reading.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Combinatorics/Young/Tableau.lean
+++ b/TauCeti/Combinatorics/Young/Tableau.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Data/Fin/Basic.lean
+++ b/TauCeti/Data/Fin/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Data/Finset/Basic.lean
+++ b/TauCeti/Data/Finset/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Data/Int/CongrAllPrimes.lean
+++ b/TauCeti/Data/Int/CongrAllPrimes.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Data/Setoid/Basic.lean
+++ b/TauCeti/Data/Setoid/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Data/Sym/Basic.lean
+++ b/TauCeti/Data/Sym/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Data/ZMod/ValMinAbs.lean
+++ b/TauCeti/Data/ZMod/ValMinAbs.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Examples/Probability/DeFinetti.lean
+++ b/TauCeti/Examples/Probability/DeFinetti.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
+++ b/TauCeti/FieldTheory/Finite/FrobeniusFixed.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/Galois/Basic.lean
+++ b/TauCeti/FieldTheory/Galois/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/IntermediateField/AdjoinEqTop.lean
+++ b/TauCeti/FieldTheory/IntermediateField/AdjoinEqTop.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/IntermediateField/Card.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Card.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 


### PR DESCRIPTION
This PR normalizes copyright blocks and `Authors:` lines in the first of four disjoint source batches required before enabling the header linter in CI.

Roadmap: none

:robot: Prepared with OpenAI Codex