### PR TITLE
feat: represent the Kostant weight torus

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
@@ -74,6 +74,13 @@ def diagonalTorusCoordinates {A : Type w} [Monoid A] :
   map_one' := rfl
   map_mul' _ _ := rfl
 
+/-- Restricting a universe-lifted coordinate family evaluates it at the canonical lift. -/
+@[simp]
+theorem diagonalTorusCoordinates_apply {A : Type w} [Monoid A]
+    (t : ULift.{u} (Fin N) → Aˣ) (i : Fin N) :
+    diagonalTorusCoordinates t i = t (ULift.up i) :=
+  (rfl)
+
 section Points
 
 variable {A : Type w} [CommRing A] [Algebra R A]

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/WeightTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/WeightTorus.lean
@@ -86,14 +86,12 @@ noncomputable def weightTorus (wt : Fin N → κ → ℤ) :
       (FGCommGrpCat.ofHom (weightCharacterMap wt)) ≫
     diagonalTorus
 
-/-- The weight-torus morphism is the diagonal-torus embedding after the contravariant morphism
-induced by its map on character lattices. -/
-theorem weightTorus_def (wt : Fin N → κ → ℤ) :
-    weightTorus (R := R) wt =
-      DiagonalizableGroup.groupSchemeMap R
-          (FGCommGrpCat.ofHom (weightCharacterMap wt)) ≫
-        diagonalTorus :=
-  (rfl)
+private theorem weightTorus_hom (wt : Fin N → κ → ℤ) :
+    (weightTorus (R := R) wt).hom.hom =
+      (DiagonalizableGroup.groupSchemeMap R
+          (FGCommGrpCat.ofHom (weightCharacterMap wt))).hom.hom ≫
+        diagonalTorus.hom.hom :=
+  rfl
 
 end Construction
 
@@ -109,12 +107,7 @@ theorem schemePointsMulEquiv_weightTorus (wt : Fin N → κ → ℤ)
     schemePointsMulEquiv N A (p ≫ (weightTorus (R := R) wt).hom.hom) =
       diagGL (fun i => torusCharacter
         (SplitTorus.schemePointsMulEquiv (R := R) (A := A) p) (wt i)) := by
-  rw [weightTorus_def]
-  -- The group-object composition wrapper hides the two underlying scheme morphisms from the
-  -- point-comparison rewrite, so display that definitional composite explicitly.
-  change schemePointsMulEquiv N A
-      ((p ≫ (DiagonalizableGroup.groupSchemeMap R
-        (FGCommGrpCat.ofHom (weightCharacterMap wt))).hom.hom) ≫ diagonalTorus.hom.hom) = _
+  rw [weightTorus_hom, ← Category.assoc]
   rw [schemePointsMulEquiv_diagonalTorus]
   congr 1
   funext i

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/WeightTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/WeightTorus.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.DiagonalTorus
+public import TauCeti.LinearAlgebra.Basis.DiagonalTorus
+
+/-!
+# Weight tori in the general linear group scheme
+
+Let `wt : Fin N → κ → ℤ` be a finite family of characters of the split torus `𝔾ₘ^κ`. Each
+character gives a diagonal entry, and together they define a group-scheme morphism
+
+```text
+𝔾ₘ^κ → GL_N,     s ↦ diag(∏_j s_j ^ wt(i,j)).
+```
+
+This file constructs the morphism by factoring it through the diagonal torus of `GL_N`. On
+character lattices, the factorization is the homomorphism sending the `i`-th coordinate character
+to `wt i`; contravariance of diagonalizable groups gives the required map of split tori. The
+scheme-valued point formula then follows from the existing point comparisons for diagonalizable
+groups and the diagonal torus.
+
+The construction is the scheme-level realization of `TauCeti.basisWeightTorus`. In particular,
+when `wt` is the weight function of a finite free admissible lattice, it supplies the split-torus
+morphism in the pinned Chevalley--Demazure construction of Layer 9 of the ReductiveGroups roadmap.
+No faithfulness is asserted: an arbitrary weight family may have a common kernel.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.weightCharacterMap`: the homomorphism on character lattices.
+* `TauCeti.GeneralLinear.weightTorus`: the represented morphism `𝔾ₘ^κ → GL_N`.
+* `TauCeti.GeneralLinear.schemePointsMulEquiv_weightTorus`: its diagonal matrix on
+  scheme-valued points.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§12 and 21.
+* R. W. Carter, *Simple Groups of Lie Type* (1972), §§4.4 and 7.1.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+variable {R κ : Type u} [CommRing R] {N : ℕ}
+
+section Construction
+
+variable [Finite κ]
+
+/-- The character-lattice map associated to a family of weights. It sends the standard
+character at `i : Fin N` to the finitely supported function corresponding to `wt i`.
+
+Contravariance turns this map into a morphism from the rank-`κ` split torus to the rank-`N`
+diagonal torus. -/
+noncomputable def weightCharacterMap (wt : Fin N → κ → ℤ) :
+    Multiplicative (ULift.{u} (Fin N) →₀ ℤ) →*
+      Multiplicative (κ →₀ ℤ) :=
+  AddMonoidHom.toMultiplicative
+    (Finsupp.linearCombination ℤ fun i : ULift.{u} (Fin N) =>
+      Finsupp.equivFunOnFinite.symm (wt i.down)).toAddMonoidHom
+
+/-- The weight character-lattice map takes a standard character to the corresponding weight. -/
+@[simp]
+theorem weightCharacterMap_ofAdd_single (wt : Fin N → κ → ℤ) (i : Fin N) :
+    weightCharacterMap wt
+        (Multiplicative.ofAdd (Finsupp.single (ULift.up i) 1)) =
+      Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm (wt i)) := by
+  apply congrArg Multiplicative.ofAdd
+  simp
+
+/-- The group-scheme morphism from a split torus to `GL_N` prescribed by a family of weights.
+It factors through the diagonal torus: the `i`-th diagonal entry is the character `wt i`. -/
+noncomputable def weightTorus (wt : Fin N → κ → ℤ) :
+    SplitTorus.groupScheme R κ ⟶ groupScheme R N :=
+  DiagonalizableGroup.groupSchemeMap R
+      (FGCommGrpCat.ofHom (weightCharacterMap wt)) ≫
+    diagonalTorus
+
+/-- The weight-torus morphism is the diagonal-torus embedding after the contravariant morphism
+induced by its map on character lattices. -/
+theorem weightTorus_def (wt : Fin N → κ → ℤ) :
+    weightTorus (R := R) wt =
+      DiagonalizableGroup.groupSchemeMap R
+          (FGCommGrpCat.ofHom (weightCharacterMap wt)) ≫
+        diagonalTorus :=
+  (rfl)
+
+end Construction
+
+variable [Fintype κ]
+variable {A : Type u} [CommRing A] [Algebra R A]
+
+/-- On scheme-valued points, the weight torus is the diagonal matrix whose `i`-th diagonal entry
+is the value of the character `wt i`. -/
+@[simp]
+theorem schemePointsMulEquiv_weightTorus (wt : Fin N → κ → ℤ)
+    (p : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
+      (SplitTorus.groupScheme R κ).X) :
+    schemePointsMulEquiv N A (p ≫ (weightTorus (R := R) wt).hom.hom) =
+      diagGL (fun i => torusCharacter
+        (SplitTorus.schemePointsMulEquiv (R := R) (A := A) p) (wt i)) := by
+  rw [weightTorus_def]
+  -- The group-object composition wrapper hides the two underlying scheme morphisms from the
+  -- point-comparison rewrite, so display that definitional composite explicitly.
+  change schemePointsMulEquiv N A
+      ((p ≫ (DiagonalizableGroup.groupSchemeMap R
+        (FGCommGrpCat.ofHom (weightCharacterMap wt))).hom.hom) ≫ diagonalTorus.hom.hom) = _
+  rw [schemePointsMulEquiv_diagonalTorus]
+  congr 1
+  funext i
+  rw [diagonalTorusCoordinates_apply]
+  let chi := DiagonalizableGroup.schemePointsMulEquiv
+    (R := R) (A := A) (SplitTorus.characterGroup κ) p
+  have hcoordinate :
+      SplitTorus.schemePointsMulEquiv (R := R) (A := A)
+          (p ≫ (DiagonalizableGroup.groupSchemeMap R
+            (FGCommGrpCat.ofHom (weightCharacterMap wt))).hom.hom) (ULift.up i) =
+        chi (weightCharacterMap wt
+          (Multiplicative.ofAdd (Finsupp.single (ULift.up i) 1))) := by
+    calc
+      _ = DiagonalizableGroup.schemePointsMulEquiv
+          (R := R) (A := A) (SplitTorus.characterGroup (ULift.{u} (Fin N)))
+            (p ≫ (DiagonalizableGroup.groupSchemeMap R
+              (FGCommGrpCat.ofHom (weightCharacterMap wt))).hom.hom)
+              (Multiplicative.ofAdd (Finsupp.single (ULift.up i) 1) :
+                SplitTorus.characterGroup (ULift.{u} (Fin N))) := by
+        apply Units.ext
+        rw [SplitTorus.schemePointsMulEquiv_apply_coe]
+        exact (DiagonalizableGroup.schemePointsMulEquiv_apply_coe
+          (R := R) (A := A) (SplitTorus.characterGroup (ULift.{u} (Fin N))) _ _).symm
+      _ = _ := by
+        rw [DiagonalizableGroup.schemePointsMulEquiv_groupSchemeMap]
+        rfl
+  rw [hcoordinate, weightCharacterMap_ofAdd_single]
+  let m := Finsupp.equivFunOnFinite.symm (wt i)
+  calc
+    chi (Multiplicative.ofAdd m) =
+        DiagonalizableGroup.multiplicativeGroupSchemePointsMulEquiv
+          (R := R) (A := A)
+            (p ≫ (SplitTorus.characterGroupSchemeMap (R := R) m).hom.hom) := by
+      rw [SplitTorus.characterGroupSchemeMap_def]
+      exact (DiagonalizableGroup.multiplicativeGroupSchemePointsMulEquiv_characterGroupSchemeMap
+          (R := R) (A := A) (SplitTorus.characterGroup κ)
+            (Multiplicative.ofAdd m) p).symm
+    _ = m.prod fun j n =>
+        SplitTorus.schemePointsMulEquiv (R := R) (A := A) p j ^ n :=
+      SplitTorus.multiplicativeGroupSchemePointsMulEquiv_characterGroupSchemeMap m p
+    _ = ∏ j, SplitTorus.schemePointsMulEquiv (R := R) (A := A) p j ^ wt i j := by
+      rw [Finsupp.prod_fintype _ _ (fun _ => zpow_zero _)]
+      simp only [m, Finsupp.equivFunOnFinite_symm_apply_apply]
+    _ = torusCharacter
+        (SplitTorus.schemePointsMulEquiv (R := R) (A := A) p) (wt i) := by
+      rw [torusCharacter_def]
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Torus.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.WeightTorus
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Torus
+
+/-!
+# The Kostant weight torus as a group-scheme morphism
+
+A finite weight basis `b : Basis (Fin n) ℤ M` of a Kostant-stable lattice gives a diagonal action
+of the split torus `𝔾ₘ^κ` on every scalar extension of `M`. The pointwise action is
+`TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints`, and its matrix in the base-changed basis
+is `TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix`.
+
+The same weight function defines the group-scheme morphism
+
+```text
+TauCeti.GeneralLinear.weightTorus wt : 𝔾ₘ^κ → GL_n.
+```
+
+This file identifies that represented morphism on scheme-valued points with the Kostant action.
+Thus the torus constructed from the weight lattice is not merely a natural family of abstract
+linear automorphisms: it is the `A`-point action of one explicit morphism over `ℤ`. Together with
+the pointwise conjugation theorem in `RootSubgroup/Torus.lean`, this supplies the split-torus side
+of the pinning interface in Layer 9 of the ReductiveGroups roadmap.
+
+No faithfulness or maximality is claimed for an arbitrary weight function. Those properties
+require the particular weights furnished by the Chevalley root datum.
+
+## Main result
+
+* `TauCeti.UniversalEnvelopingAlgebra.schemePointsMulEquiv_weightTorus_eq_kostantTorusMatrix`:
+  composing a scheme-valued torus point with the represented weight torus gives the matrix of the
+  existing Kostant torus action.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type* (1972), §§4.4 and 7.1.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26--27.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe v
+
+variable {κ : Type} [Fintype κ]
+variable {V : Type v} [AddCommGroup V]
+variable (M : AddSubgroup V)
+variable {n : ℕ} (b : Module.Basis (Fin n) ℤ M) (wt : Fin n → κ → ℤ)
+
+variable (A : Type) [CommRing A] [Algebra ℤ A]
+
+/-- Scheme-valued points of the represented weight torus are exactly the matrices of the
+pointwise Kostant torus action in the given weight basis. -/
+theorem schemePointsMulEquiv_weightTorus_eq_kostantTorusMatrix
+    (p : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ κ).X) :
+    GeneralLinear.schemePointsMulEquiv n A
+        (p ≫ (GeneralLinear.weightTorus (R := ℤ) wt).hom.hom) =
+      kostantTorusMatrix M b wt
+        (SplitTorus.schemePointsMulEquiv (R := ℤ) (A := A) p) := by
+  rw [GeneralLinear.schemePointsMulEquiv_weightTorus, kostantTorusMatrix_apply]
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
@@ -6,7 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Elementary
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Coordinate
 public import TauCeti.LinearAlgebra.Basis.DiagonalTorus
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
 
 /-!
@@ -45,6 +47,7 @@ subgroup is the root rather than a difference `εᵢ - εⱼ` of coordinates.
   integral operator on a Kostant-stable subgroup.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints`: the split torus of rank `κ` on the
   points of a Kostant-stable lattice presented in a weight basis.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix`: the same action in matrix coordinates.
 
 ## Main results
 
@@ -334,6 +337,49 @@ theorem map_kostantTorusPoints (φ : A →+* B) (s : κ → Aˣ) (z : A ⊗[ℤ]
 end Naturality
 
 end Torus
+
+/-! ## Matrix coordinates -/
+
+section Matrix
+
+variable [Fintype κ] {n : ℕ} (b : Module.Basis (Fin n) ℤ M) (wt : Fin n → κ → ℤ)
+variable {A : Type*} [CommRing A] [Algebra ℤ A]
+
+omit [Module ℚ V] in
+/-- The torus attached to a weight basis, in the matrix coordinates of that basis. -/
+noncomputable def kostantTorusMatrix :
+    (κ → Aˣ) →* Matrix.GeneralLinearGroup (Fin n) A :=
+  (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom).comp
+    (kostantTorusPoints M b wt A)
+
+omit [Module ℚ V] in
+/-- The matrix-valued weight torus is obtained by applying the basis-coordinate equivalence to
+the linear action of `kostantTorusPoints`. -/
+theorem kostantTorusMatrix_def :
+    kostantTorusMatrix M b wt =
+      (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom).comp
+        (kostantTorusPoints M b wt A) :=
+  (rfl)
+
+omit [Module ℚ V] in
+/-- In a weight basis, a torus point is the diagonal matrix of its weight characters. -/
+@[simp]
+theorem kostantTorusMatrix_apply (s : κ → Aˣ) :
+    kostantTorusMatrix M b wt s =
+      diagGL fun i => torusCharacter s (wt i) := by
+  apply Units.ext
+  rw [kostantTorusMatrix_def, MonoidHom.comp_apply, Units.coe_map]
+  change LinearMap.toMatrix (b.baseChange A) (b.baseChange A)
+      (kostantTorusPoints M b wt A s).val = _
+  have hlinear := congrArg LinearEquiv.toLinearMap
+    (kostantTorusPoints_toLinearEquiv M b wt s)
+  -- The general-linear unit and its bundled linear equivalence carry the same linear map;
+  -- display the latter so the public comparison theorem can rewrite it.
+  change LinearMap.toMatrix (b.baseChange A) (b.baseChange A)
+      (kostantTorusPoints M b wt A s).toLinearEquiv.toLinearMap = _
+  rw [hlinear, basisWeightTorus_apply, toMatrix_basisDiagonal, diagGL_coe]
+
+end Matrix
 
 /-! ## The pinning equation -/
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Elementary
-public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Coordinate
 public import TauCeti.LinearAlgebra.Basis.DiagonalTorus
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
@@ -353,13 +352,11 @@ noncomputable def kostantTorusMatrix :
     (kostantTorusPoints M b wt A)
 
 omit [Module ℚ V] in
-/-- The matrix-valued weight torus is obtained by applying the basis-coordinate equivalence to
-the linear action of `kostantTorusPoints`. -/
-theorem kostantTorusMatrix_def :
-    kostantTorusMatrix M b wt =
-      (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom).comp
-        (kostantTorusPoints M b wt A) :=
-  (rfl)
+private theorem kostantTorusMatrix_coe (s : κ → Aˣ) :
+    (kostantTorusMatrix M b wt s : Matrix (Fin n) (Fin n) A) =
+      LinearMap.toMatrix (b.baseChange A) (b.baseChange A)
+        (kostantTorusPoints M b wt A s).toLinearEquiv.toLinearMap :=
+  rfl
 
 omit [Module ℚ V] in
 /-- In a weight basis, a torus point is the diagonal matrix of its weight characters. -/
@@ -368,15 +365,9 @@ theorem kostantTorusMatrix_apply (s : κ → Aˣ) :
     kostantTorusMatrix M b wt s =
       diagGL fun i => torusCharacter s (wt i) := by
   apply Units.ext
-  rw [kostantTorusMatrix_def, MonoidHom.comp_apply, Units.coe_map]
-  change LinearMap.toMatrix (b.baseChange A) (b.baseChange A)
-      (kostantTorusPoints M b wt A s).val = _
+  rw [kostantTorusMatrix_coe]
   have hlinear := congrArg LinearEquiv.toLinearMap
     (kostantTorusPoints_toLinearEquiv M b wt s)
-  -- The general-linear unit and its bundled linear equivalence carry the same linear map;
-  -- display the latter so the public comparison theorem can rewrite it.
-  change LinearMap.toMatrix (b.baseChange A) (b.baseChange A)
-      (kostantTorusPoints M b wt A s).toLinearEquiv.toLinearMap = _
   rw [hlinear, basisWeightTorus_apply, toMatrix_basisDiagonal, diagGL_coe]
 
 end Matrix

--- a/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
+++ b/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Module.Equiv.Basic
 public import Mathlib.LinearAlgebra.Basis.SMul
+public import Mathlib.LinearAlgebra.Matrix.Basis
 public import TauCeti.LinearAlgebra.Eigenspace.DiagonalBasis
 
 /-!
@@ -64,6 +65,11 @@ variable [Fintype κ]
 `∏ j, s j ^ μ j`. Weights of a representation are exactly such characters, so this is the scalar
 by which a torus point acts on a weight vector. -/
 def torusCharacter (s : κ → Rˣ) (μ : κ → ℤ) : Rˣ := ∏ j, s j ^ μ j
+
+/-- A split-torus character evaluates as the product of its coordinate powers. -/
+theorem torusCharacter_def (s : κ → Rˣ) (μ : κ → ℤ) :
+    torusCharacter s μ = ∏ j, s j ^ μ j :=
+  (rfl)
 
 /-- The trivial character takes the value one at every point. -/
 @[simp] theorem torusCharacter_zero (s : κ → Rˣ) : torusCharacter s (0 : κ → ℤ) = 1 := by
@@ -169,6 +175,22 @@ theorem repr_basisDiagonal (b : Basis ι R M) (w : ι → Rˣ) (m : M) (i : ι) 
 theorem basisDiagonal_inv (b : Basis ι R M) (w : ι → Rˣ) :
     (basisDiagonal b w)⁻¹ = basisDiagonal b w⁻¹ := by
   simpa only [basisDiagonalHom_apply] using (map_inv (basisDiagonalHom b) w).symm
+
+/-- The matrix of a diagonal basis automorphism in that basis is the diagonal matrix of its
+scaling units. -/
+theorem toMatrix_basisDiagonal [Fintype ι] [DecidableEq ι]
+    (b : Basis ι R M) (w : ι → Rˣ) :
+    LinearMap.toMatrix b b (basisDiagonal b w).toLinearMap =
+      Matrix.diagonal fun i => (w i : R) := by
+  calc
+    _ = b.toMatrix (b.unitsSMul w) := by
+      ext i j
+      rw [LinearMap.toMatrix_apply, Basis.toMatrix_apply]
+      -- The linear-map coercion and basis family hide the two defining applications.
+      change b.repr (basisDiagonal b w (b j)) i =
+        b.repr ((b.unitsSMul w) j) i
+      rw [basisDiagonal_basis, Basis.unitsSMul_apply, Units.smul_def]
+    _ = _ := b.toMatrix_unitsSMul w
 
 /-- A diagonal automorphism scales by a single unit any vector whose coordinates vanish outside
 the basis vectors carrying that unit. Applied to a weight basis, this says that a torus point acts

--- a/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
+++ b/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
@@ -186,10 +186,10 @@ theorem toMatrix_basisDiagonal [Fintype ι] [DecidableEq ι]
     _ = b.toMatrix (b.unitsSMul w) := by
       ext i j
       rw [LinearMap.toMatrix_apply, Basis.toMatrix_apply]
-      -- The linear-map coercion and basis family hide the two defining applications.
-      change b.repr (basisDiagonal b w (b j)) i =
-        b.repr ((b.unitsSMul w) j) i
-      rw [basisDiagonal_basis, Basis.unitsSMul_apply, Units.smul_def]
+      have hbasis : (basisDiagonal b w).toLinearMap (b j) = (b.unitsSMul w) j := by
+        rw [LinearEquiv.coe_toLinearMap, basisDiagonal_basis, Basis.unitsSMul_apply,
+          Units.smul_def]
+      rw [hbasis]
     _ = _ := b.toMatrix_unitsSMul w
 
 /-- A diagonal automorphism scales by a single unit any vector whose coordinates vanish outside


### PR DESCRIPTION
This PR represents the weight torus of a finite Kostant weight basis as an explicit group-scheme morphism `𝔾ₘ^κ → GLₙ` over `ℤ`, and identifies its scheme-valued points with the existing `kostantTorusPoints` action. Send each standard coordinate character to its basis weight, apply the existing contravariant diagonalizable-group construction, and compose with the diagonal torus of `GLₙ`; the resulting point formula is `diag(∏ⱼ sⱼ ^ wt(i, j))`.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 9 “pinned Chevalley–Demazure group schemes over `ℤ`”, specifically “Pinnings” (the split maximal torus as data) and “The Chevalley–Demazure construction” (an explicitly constructed group scheme, not only pointwise maps). The designated consumer milestone is `CFSGStatement` L0, “pinned ambient groups,” which consumes the explicit pinned Chevalley–Demazure group and its root-subgroup conventions. This is the most effective current step because PR #3536 already supplies the weight-lattice torus on algebra-valued points and the torus/root-subgroup conjugation equation, while no open PR represents that natural family by one morphism of schemes.

After this PR, Layer 9 still needs the finite free admissible lattice and integral PBW completion, assembly of the torus, Borel, and root subgroups into the pinned group scheme, pinning-compatible base change, the pinned isomorphism theorem, the remaining `G₂` commutator relation, and the characteristic-two/three special isogenies.

Add `GeneralLinear/WeightTorus.lean` (165 lines) for the reusable representation of a split torus defined by a finite family of weights, and `RootSubgroup/Scheme/Torus.lean` (73 lines) for the Kostant specialization. Extend the existing diagonal-torus and basis APIs only with the computational lemmas needed to connect the scheme morphism to the already-proved Kostant action matrix. Reuse Mathlib's `DiagonalizableGroup.groupSchemeMap`, `Basis.toMatrix_unitsSMul`, and Tau Ceti's existing split-torus character and diagonal-torus infrastructure; no Mathlib infrastructure is vendored.

The targeted builds, changed-module axiom audit, and changed-environment lint pass.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"kostant-torus-scheme-morphism"}-->

🤖 Prepared with Codex
