### PR TITLE
Complete the Frobenius inseparability API

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
@@ -33,7 +33,7 @@ instance Mathlib's map needs is installed locally where it is required.
   `q`-power map `FiniteField.frobeniusAlgHom F W.FunctionField`.
 * `TauCeti.Isogeny.fieldPullback_frobeniusIsogeny_apply`: the same result pointwise, with no
   choice of a `Fintype` instance exposed in its statement.
-* `TauCeti.Isogeny.frobeniusIsogeny_isPurelyInseparable`: the induced function-field extension
+* `TauCeti.Isogeny.isPurelyInseparable_frobeniusIsogeny`: the induced function-field extension
   is purely inseparable.
 * `TauCeti.Isogeny.degree_frobeniusIsogeny`: the Frobenius isogeny has degree `q`.
 * `TauCeti.Isogeny.separableDegree_frobeniusIsogeny` and
@@ -126,17 +126,12 @@ theorem fieldPullback_frobeniusIsogeny_apply (x : W.FunctionField) :
 /-- **The Frobenius isogeny is purely inseparable.** Every `x` in the function field has
 `x ^ q` in the pullback's field range, and the finite-field cardinality `q` is a power of the
 exponential characteristic. -/
-noncomputable instance frobeniusIsogeny_isPurelyInseparable :
+instance isPurelyInseparable_frobeniusIsogeny :
     IsPurelyInseparable (frobeniusIsogeny W).fieldPullback.fieldRange W.FunctionField := by
   let _ := Fintype.ofFinite F
   obtain ⟨p, hpF, n, hp, hcard⟩ := FiniteField.card' F
   let _ : CharP F p := hpF
   let _ : ExpChar F p := ExpChar.prime hp
-  let _ : ExpChar W.FunctionField p :=
-    expChar_of_injective_algebraMap (algebraMap F W.FunctionField).injective p
-  let _ : ExpChar (frobeniusIsogeny W).fieldPullback.fieldRange p :=
-    expChar_of_injective_algebraMap
-      (algebraMap F (frobeniusIsogeny W).fieldPullback.fieldRange).injective p
   rw [isPurelyInseparable_iff_pow_mem _ p]
   intro x
   refine ⟨(n : ℕ), ⟨⟨x ^ p ^ (n : ℕ), ?_⟩, rfl⟩⟩
@@ -153,12 +148,10 @@ theorem degree_frobeniusIsogeny : (frobeniusIsogeny W).degree = Nat.card F := by
   exact WeierstrassCurve.Affine.finrank_fieldRange_frobeniusAlgHom W
 
 /-- **The Frobenius isogeny has separable degree one.** -/
-@[simp]
 theorem separableDegree_frobeniusIsogeny : (frobeniusIsogeny W).separableDegree = 1 :=
   separableDegree_eq_one_of_isPurelyInseparable (frobeniusIsogeny W)
 
 /-- **The Frobenius isogeny has inseparable degree `q`.** -/
-@[simp]
 theorem inseparableDegree_frobeniusIsogeny :
     (frobeniusIsogeny W).inseparableDegree = Nat.card F := by
   rw [inseparableDegree_eq_degree_of_isPurelyInseparable, degree_frobeniusIsogeny]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FrobeniusTower
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Separability
-public import Mathlib.FieldTheory.Finite.Basic
+public import TauCeti.FieldTheory.Finite.Frobenius
 
 /-!
 # The Frobenius isogeny
@@ -56,8 +56,14 @@ coordinate ring, and only one extension to the fraction field exists.
 This is the `frobeniusIsogeny` seed of `TauCetiRoadmap/EllipticCurves/README.md` §Layer 1, where
 it is described as "`f ↦ f ^ q` out of the coordinate ring into the function field … whose
 `MapsInfinity` is the integrality of the coordinates over their `q`-th powers". The seed follows
-Silverman, *The Arithmetic of Elliptic Curves*, II.2.11, whose part (c) is the degree. The
-roadmap's `Suggested.lean` states both with `sorry`; the proofs here are original.
+Silverman, *The Arithmetic of Elliptic Curves*, II.2.11: part (a) identifies the pullback image
+with the `q`-th powers, part (b) proves pure inseparability, and part (c) computes the degree. The
+roadmap's `Suggested.lean` states the pullback and degree with `sorry`; the formal proofs here are
+original.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.
 -/
 
 public section
@@ -102,9 +108,9 @@ noncomputable def frobeniusIsogeny : Isogeny W W where
 @[simp]
 theorem frobeniusIsogeny_pullback : (frobeniusIsogeny W).pullback = frobeniusPullback W := (rfl)
 
-/-- The function field pullback of the Frobenius isogeny is the `q`-power map of the function
-field: the two agree on the coordinate ring, and an isogeny's `fieldPullback` is the only such
-extension. -/
+/-- The function field pullback of the Frobenius isogeny is the `q`-power map on the function
+field (Silverman II.2.11(a)): the two maps agree on the coordinate ring, and an isogeny's
+`fieldPullback` is the only such extension. -/
 theorem fieldPullback_frobeniusIsogeny :
     letI := Fintype.ofFinite F
     (frobeniusIsogeny W).fieldPullback = FiniteField.frobeniusAlgHom F W.FunctionField := by
@@ -113,7 +119,8 @@ theorem fieldPullback_frobeniusIsogeny :
   simp only [FiniteField.coe_frobeniusAlgHom, frobeniusIsogeny_pullback, frobeniusPullback_apply,
     Nat.card_eq_fintype_card, map_pow]
 
-/-- **The function-field pullback raises every element to the `q`-th power.** Unlike
+/-- **The function-field pullback raises every element to the `q`-th power** (Silverman
+II.2.11(a)). Unlike
 `fieldPullback_frobeniusIsogeny`, this consumer-facing pointwise form depends only on `[Finite F]`
 and `Nat.card F`; the locally chosen enumeration of `F` does not occur in its statement. -/
 @[simp]
@@ -123,23 +130,17 @@ theorem fieldPullback_frobeniusIsogeny_apply (x : W.FunctionField) :
   rw [fieldPullback_frobeniusIsogeny W, FiniteField.coe_frobeniusAlgHom,
     Nat.card_eq_fintype_card]
 
-/-- **The Frobenius isogeny is purely inseparable.** Every `x` in the function field has
-`x ^ q` in the pullback's field range, and the finite-field cardinality `q` is a power of the
-exponential characteristic. -/
+/-- **The Frobenius isogeny is purely inseparable** (Silverman II.2.11(b)). This is the
+field-generic pure-inseparability of the `q`-power map, transported across the identification of
+that map with the function-field pullback. -/
 instance isPurelyInseparable_frobeniusIsogeny :
     IsPurelyInseparable (frobeniusIsogeny W).fieldPullback.fieldRange W.FunctionField := by
   let _ := Fintype.ofFinite F
-  obtain ⟨p, hpF, n, hp, hcard⟩ := FiniteField.card' F
-  let _ : CharP F p := hpF
-  let _ : ExpChar F p := ExpChar.prime hp
-  rw [isPurelyInseparable_iff_pow_mem _ p]
-  intro x
-  refine ⟨(n : ℕ), ⟨⟨x ^ p ^ (n : ℕ), ?_⟩, rfl⟩⟩
-  rw [AlgHom.mem_fieldRange]
-  exact ⟨x, by
-    rw [fieldPullback_frobeniusIsogeny_apply W, Nat.card_eq_fintype_card, hcard]⟩
+  rw [fieldPullback_frobeniusIsogeny W]
+  exact TauCeti.FiniteField.isPurelyInseparable_fieldRange_frobeniusAlgHom
 
-/-- **The Frobenius isogeny has degree `q`.** Its function-field pullback is the `q`-power map,
+/-- **The Frobenius isogeny has degree `q`** (Silverman II.2.11(c)). Its function-field pullback is
+the `q`-power map,
 so the extension the degree measures is `K(W)` over its subfield of `q`-th powers. -/
 @[simp]
 theorem degree_frobeniusIsogeny : (frobeniusIsogeny W).degree = Nat.card F := by
@@ -147,11 +148,12 @@ theorem degree_frobeniusIsogeny : (frobeniusIsogeny W).degree = Nat.card F := by
   rw [degree_def, fieldPullback_frobeniusIsogeny W]
   exact WeierstrassCurve.Affine.finrank_fieldRange_frobeniusAlgHom W
 
-/-- **The Frobenius isogeny has separable degree one.** -/
+/-- **The Frobenius isogeny has separable degree one**, as pure inseparability in Silverman
+II.2.11(b) requires. -/
 theorem separableDegree_frobeniusIsogeny : (frobeniusIsogeny W).separableDegree = 1 :=
   separableDegree_eq_one_of_isPurelyInseparable (frobeniusIsogeny W)
 
-/-- **The Frobenius isogeny has inseparable degree `q`.** -/
+/-- **The Frobenius isogeny has inseparable degree `q`**, combining Silverman II.2.11(b,c). -/
 theorem inseparableDegree_frobeniusIsogeny :
     (frobeniusIsogeny W).inseparableDegree = Nat.card F := by
   rw [inseparableDegree_eq_degree_of_isPurelyInseparable, degree_frobeniusIsogeny]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Frobenius.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FrobeniusTower
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Separability
 public import Mathlib.FieldTheory.Finite.Basic
 
 /-!
@@ -14,8 +14,8 @@ public import Mathlib.FieldTheory.Finite.Basic
 Over a finite field `F` with `q = Nat.card F` elements, raising to the `q`-th power is an
 `F`-algebra endomorphism of any `F`-algebra (`FiniteField.frobeniusAlgHom`). Composing it with
 the embedding of the coordinate ring into the function field gives a coordinate pullback, and
-that pullback maps infinity to infinity, so it is an isogeny of `W` with itself. Its degree
-is `q`.
+that pullback maps infinity to infinity, so it is an isogeny of `W` with itself. It is purely
+inseparable of degree `q`.
 
 The declarations take `[Finite F]` rather than `[Fintype F]`, matching
 `Affine/FrobeniusTower.lean`, and state the exponent as `Nat.card F`: a `Fintype` instance is
@@ -31,14 +31,23 @@ instance Mathlib's map needs is installed locally where it is required.
 
 * `TauCeti.Isogeny.fieldPullback_frobeniusIsogeny`: the induced map of function fields is the
   `q`-power map `FiniteField.frobeniusAlgHom F W.FunctionField`.
+* `TauCeti.Isogeny.fieldPullback_frobeniusIsogeny_apply`: the same result pointwise, with no
+  choice of a `Fintype` instance exposed in its statement.
+* `TauCeti.Isogeny.frobeniusIsogeny_isPurelyInseparable`: the induced function-field extension
+  is purely inseparable.
 * `TauCeti.Isogeny.degree_frobeniusIsogeny`: the Frobenius isogeny has degree `q`.
+* `TauCeti.Isogeny.separableDegree_frobeniusIsogeny` and
+  `TauCeti.Isogeny.inseparableDegree_frobeniusIsogeny`: its separable and inseparable degrees
+  are `1` and `q`, respectively.
 
 The `MapsInfinity` condition says that each `x` of the coordinate ring is integral over the
 pulled-back copy. It holds because `x` is a `q`-th root of its own pullback, so `IsIntegral.of_pow`
 reduces it to integrality of an element the pullback already produces. That is what "Frobenius
 fixes the point at infinity" amounts to here.
 
-The degree is the field-theoretic
+Pure inseparability follows because every function `x` has its `q`-th power in the image of the
+pullback, and `q` is a power of the exponential characteristic of `F`. The degree is the
+field-theoretic
 `TauCeti.WeierstrassCurve.Affine.finrank_fieldRange_frobeniusAlgHom`, `[K(W) : K(W)^q] = q`,
 transported along the identification of `fieldPullback` with the `q`-power map on `K(W)`. That
 identification is `Isogeny.fieldPullback_unique`: both maps restrict to `x ↦ x ^ q` on the
@@ -104,6 +113,37 @@ theorem fieldPullback_frobeniusIsogeny :
   simp only [FiniteField.coe_frobeniusAlgHom, frobeniusIsogeny_pullback, frobeniusPullback_apply,
     Nat.card_eq_fintype_card, map_pow]
 
+/-- **The function-field pullback raises every element to the `q`-th power.** Unlike
+`fieldPullback_frobeniusIsogeny`, this consumer-facing pointwise form depends only on `[Finite F]`
+and `Nat.card F`; the locally chosen enumeration of `F` does not occur in its statement. -/
+@[simp]
+theorem fieldPullback_frobeniusIsogeny_apply (x : W.FunctionField) :
+    (frobeniusIsogeny W).fieldPullback x = x ^ Nat.card F := by
+  let _ := Fintype.ofFinite F
+  rw [fieldPullback_frobeniusIsogeny W, FiniteField.coe_frobeniusAlgHom,
+    Nat.card_eq_fintype_card]
+
+/-- **The Frobenius isogeny is purely inseparable.** Every `x` in the function field has
+`x ^ q` in the pullback's field range, and the finite-field cardinality `q` is a power of the
+exponential characteristic. -/
+noncomputable instance frobeniusIsogeny_isPurelyInseparable :
+    IsPurelyInseparable (frobeniusIsogeny W).fieldPullback.fieldRange W.FunctionField := by
+  let _ := Fintype.ofFinite F
+  obtain ⟨p, hpF, n, hp, hcard⟩ := FiniteField.card' F
+  let _ : CharP F p := hpF
+  let _ : ExpChar F p := ExpChar.prime hp
+  let _ : ExpChar W.FunctionField p :=
+    expChar_of_injective_algebraMap (algebraMap F W.FunctionField).injective p
+  let _ : ExpChar (frobeniusIsogeny W).fieldPullback.fieldRange p :=
+    expChar_of_injective_algebraMap
+      (algebraMap F (frobeniusIsogeny W).fieldPullback.fieldRange).injective p
+  rw [isPurelyInseparable_iff_pow_mem _ p]
+  intro x
+  refine ⟨(n : ℕ), ⟨⟨x ^ p ^ (n : ℕ), ?_⟩, rfl⟩⟩
+  rw [AlgHom.mem_fieldRange]
+  exact ⟨x, by
+    rw [fieldPullback_frobeniusIsogeny_apply W, Nat.card_eq_fintype_card, hcard]⟩
+
 /-- **The Frobenius isogeny has degree `q`.** Its function-field pullback is the `q`-power map,
 so the extension the degree measures is `K(W)` over its subfield of `q`-th powers. -/
 @[simp]
@@ -111,6 +151,17 @@ theorem degree_frobeniusIsogeny : (frobeniusIsogeny W).degree = Nat.card F := by
   let _ := Fintype.ofFinite F
   rw [degree_def, fieldPullback_frobeniusIsogeny W]
   exact WeierstrassCurve.Affine.finrank_fieldRange_frobeniusAlgHom W
+
+/-- **The Frobenius isogeny has separable degree one.** -/
+@[simp]
+theorem separableDegree_frobeniusIsogeny : (frobeniusIsogeny W).separableDegree = 1 :=
+  separableDegree_eq_one_of_isPurelyInseparable (frobeniusIsogeny W)
+
+/-- **The Frobenius isogeny has inseparable degree `q`.** -/
+@[simp]
+theorem inseparableDegree_frobeniusIsogeny :
+    (frobeniusIsogeny W).inseparableDegree = Nat.card F := by
+  rw [inseparableDegree_eq_degree_of_isPurelyInseparable, degree_frobeniusIsogeny]
 
 end Isogeny
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
@@ -42,8 +42,9 @@ this file names those two parts and records that they multiply to the degree.
   whole degree in the separable part.
 * `TauCeti.Isogeny.separableDegree_eq_one_of_isPurelyInseparable` and
   `TauCeti.Isogeny.inseparableDegree_eq_degree_of_isPurelyInseparable`: the purely inseparable
-  case. No declaration consumes these yet; they are the shape the roadmap's Frobenius milestone
-  ("`π_q`, purely inseparable of degree `q`") will need.
+  case, consumed by `separableDegree_frobeniusIsogeny` and
+  `inseparableDegree_frobeniusIsogeny` for the roadmap's Frobenius milestone
+  ("`π_q`, purely inseparable of degree `q`").
 * `TauCeti.Isogeny.separableDegree_eq_one_iff_isPurelyInseparable` and
   `TauCeti.Isogeny.inseparableDegree_eq_one_iff_isSeparable`:
   the biconditional forms, for a consumer holding a computed degree rather than an assumed class.

--- a/TauCeti/FieldTheory/Finite/Frobenius.lean
+++ b/TauCeti/FieldTheory/Finite/Frobenius.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.FieldTheory.Finite.Basic
+public import Mathlib.FieldTheory.PurelyInseparable.Basic
+
+/-!
+# Pure inseparability above the range of finite-field Frobenius
+
+Let `K` be a finite field with `q` elements and let `L` be any field extension of `K`. The image
+of the `q`-power endomorphism of `L` is a subfield over which `L` is purely inseparable: every
+`x : L` has `x ^ q` in that image, and `q` is a power of the exponential characteristic.
+
+## Main result
+
+* `TauCeti.FiniteField.isPurelyInseparable_fieldRange_frobeniusAlgHom`: `L` is purely
+  inseparable over the field range of `FiniteField.frobeniusAlgHom K L`.
+
+## Roadmap
+
+This is the field-theoretic input to the Frobenius isogeny in Layer 1 of
+`TauCetiRoadmap/EllipticCurves/README.md`, which requires `π_q` to be purely inseparable of degree
+`q`. Stating it before specializing to a curve keeps the argument independent of the particular
+function field, just as the degree computation first identifies the field range of the same
+`q`-power map.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.
+-/
+
+public section
+
+namespace TauCeti.FiniteField
+
+variable {K L : Type*} [Field K] [Finite K] [Field L] [Algebra K L]
+
+/-- **A field is purely inseparable over the image of its finite-base-field Frobenius**
+(the field-theoretic statement in Silverman II.2.11(b)). Every element has its `q`-th power in
+the image, where `q = Nat.card K` is a power of the exponential characteristic. -/
+theorem isPurelyInseparable_fieldRange_frobeniusAlgHom :
+    letI := Fintype.ofFinite K
+    IsPurelyInseparable (_root_.FiniteField.frobeniusAlgHom K L).fieldRange L := by
+  let _ := Fintype.ofFinite K
+  obtain ⟨p, hpK, n, hp, hcard⟩ := _root_.FiniteField.card' K
+  let _ : CharP K p := hpK
+  let _ : ExpChar K p := ExpChar.prime hp
+  have hcard' : Nat.card K = p ^ (n : ℕ) := by
+    rw [Nat.card_eq_fintype_card, hcard]
+  rw [isPurelyInseparable_iff_pow_mem _ p]
+  intro x
+  have hx : x ^ p ^ (n : ℕ) ∈
+      (_root_.FiniteField.frobeniusAlgHom K L).fieldRange := by
+    rw [AlgHom.mem_fieldRange]
+    refine ⟨x, ?_⟩
+    rw [_root_.FiniteField.coe_frobeniusAlgHom, ← Nat.card_eq_fintype_card, hcard']
+  refine ⟨(n : ℕ), ?_⟩
+  refine ⟨⟨x ^ p ^ (n : ℕ), hx⟩, ?_⟩
+  exact IntermediateField.algebraMap_apply
+    (S := (_root_.FiniteField.frobeniusAlgHom K L).fieldRange) _
+
+end TauCeti.FiniteField
+
+end


### PR DESCRIPTION
## Summary

- add an instance-free pointwise formula for the Frobenius function-field pullback
- prove the Frobenius function-field extension is purely inseparable
- expose simp lemmas computing its separable and inseparable degrees as 1 and Nat.card F
- update the module documentation to describe the completed API

This advances the Frobenius isogeny target in TauCetiRoadmap/EllipticCurves/README.md §Layer 1: the roadmap specifies π_q as purely inseparable of degree q.

Closes #3572.

## Verification

- lake build TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Frobenius
- lake build
- git diff --check

Roadmap: EllipticCurves
