### PR TITLE
Complete the Hille–Yosida generator API

### DIFF
--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
@@ -38,8 +38,10 @@ This proves the Hille--Yosida milestone in Part A of the
   generator `A`.
 * `TauCeti.Semigroups.hilleYosidaSemigroup`: the general `(M, omega)` constructed semigroup.
 * `TauCeti.Semigroups.hilleYosidaSemigroup_apply`: evaluation of the constructed semigroup.
-* `TauCeti.Semigroups.tendsto_shiftedYosidaApproximation_hilleYosidaSemigroup`: convergence of the
-  shifted Yosida approximations.
+* `TauCeti.Semigroups.hilleYosidaSemigroup_realOperator_apply_of_nonneg`: real-time evaluation at
+  nonnegative times.
+* `TauCeti.Semigroups.tendsto_hilleYosidaSemigroup`: convergence of the shifted Yosida
+  approximating orbits.
 * `TauCeti.Semigroups.hilleYosidaSemigroup_generator`: identification of its generator.
 * `TauCeti.Semigroups.hasGrowthBound_hilleYosidaSemigroup`: its prescribed growth bound.
 * `TauCeti.Semigroups.hilleYosida_generation`: the general `(M, omega)` Hille--Yosida generation
@@ -120,14 +122,26 @@ variable (hdense : Dense (A.domain : Set X))
 
 include hM hres hpow hdense
 
+omit [CompleteSpace X] hM hres hpow in
+private theorem dense_subScalar_domain :
+    Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
+  simpa using hdense
+
 /-- The strongly continuous semigroup constructed by the general `(M, omega)` Hille--Yosida
 theorem. It is the exponential unshift of the exponent-zero limit semigroup for
 `A - omega I`. -/
 def hilleYosidaSemigroup : StronglyContinuousSemigroup X :=
-  let hzero := LinearPMap.hilleYosida_zero_of hres hpow
-  let hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
-    simpa using hdense
-  (hilleYosidaLimitSemigroup hM hzero.1 hzero.2 hdense₀).expShift (-omega)
+  (hilleYosidaLimitSemigroup hM
+    (LinearPMap.hilleYosida_zero_of hres hpow).1
+    (LinearPMap.hilleYosida_zero_of hres hpow).2
+    (dense_subScalar_domain hdense)).expShift (-omega)
+
+private theorem hilleYosidaSemigroup_eq :
+    hilleYosidaSemigroup hM hres hpow hdense =
+      (hilleYosidaLimitSemigroup hM
+        (LinearPMap.hilleYosida_zero_of hres hpow).1
+        (LinearPMap.hilleYosida_zero_of hres hpow).2
+        (dense_subScalar_domain hdense)).expShift (-omega) := rfl
 
 /-- Evaluating the general Hille--Yosida semigroup gives the exponentially shifted
 exponent-zero Yosida limit. -/
@@ -135,7 +149,7 @@ exponent-zero Yosida limit. -/
 theorem hilleYosidaSemigroup_apply (t : ℝ≥0) (x : X) :
     hilleYosidaSemigroup hM hres hpow hdense t x =
       Real.exp (omega * (t : ℝ)) • yosidaLimit (LinearPMap.subScalar A omega) t x := by
-  simp only [hilleYosidaSemigroup, StronglyContinuousSemigroup.expShift_apply_apply,
+  simp only [hilleYosidaSemigroup_eq, StronglyContinuousSemigroup.expShift_apply_apply,
     hilleYosidaLimitSemigroup_apply, neg_mul, neg_neg]
 
 /-- Real-time evaluation of the general Hille--Yosida semigroup at a nonnegative time. -/
@@ -143,42 +157,42 @@ theorem hilleYosidaSemigroup_apply (t : ℝ≥0) (x : X) :
 theorem hilleYosidaSemigroup_realOperator_apply_of_nonneg {t : ℝ} (ht : 0 ≤ t) (x : X) :
     (hilleYosidaSemigroup hM hres hpow hdense).realOperator t x =
       Real.exp (omega * t) • yosidaLimit (LinearPMap.subScalar A omega) t x := by
-  simp only [hilleYosidaSemigroup,
+  simp only [hilleYosidaSemigroup_eq,
     StronglyContinuousSemigroup.expShift_realOperator_apply_of_nonneg _ _ _ ht,
     hilleYosidaLimitSemigroup_realOperator_apply_of_nonneg _ _ _ _ ht, neg_mul, neg_neg]
 
 /-- The shifted Yosida approximations converge pointwise to the general Hille--Yosida semigroup. -/
-theorem tendsto_shiftedYosidaApproximation_hilleYosidaSemigroup
-    (t : ℝ≥0) (x : X) :
+theorem tendsto_hilleYosidaSemigroup (t : ℝ≥0) (x : X) :
     Tendsto (fun lambda : ℝ => Real.exp (omega * (t : ℝ)) •
         exp ((t : ℝ) • yosidaApproximation (LinearPMap.subScalar A omega) lambda) x)
       atTop (𝓝 (hilleYosidaSemigroup hM hres hpow hdense t x)) := by
-  obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
-  have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
-    simpa using hdense
   rw [hilleYosidaSemigroup_apply]
-  exact (tendsto_yosidaLimit_of_norm_resolvent_pow_le hM hres₀ hpow₀ hdense₀ t.2 x).const_smul
-    (Real.exp (omega * (t : ℝ)) : ℝ)
+  exact (tendsto_yosidaLimit_of_norm_resolvent_pow_le hM
+    (LinearPMap.hilleYosida_zero_of hres hpow).1
+    (LinearPMap.hilleYosida_zero_of hres hpow).2
+    (dense_subScalar_domain hdense) t.2 x).const_smul
+      (Real.exp (omega * (t : ℝ)) : ℝ)
 
 /-- The general Hille--Yosida semigroup has generator `A`. -/
 @[simp]
 theorem hilleYosidaSemigroup_generator :
     (hilleYosidaSemigroup hM hres hpow hdense).generator = A := by
-  obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
-  have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
-    simpa using hdense
-  rw [hilleYosidaSemigroup, StronglyContinuousSemigroup.generator_expShift,
-    hilleYosidaLimitSemigroup_generator hM hres₀ hpow₀ hdense₀,
+  rw [hilleYosidaSemigroup_eq, StronglyContinuousSemigroup.generator_expShift,
+    hilleYosidaLimitSemigroup_generator hM
+      (LinearPMap.hilleYosida_zero_of hres hpow).1
+      (LinearPMap.hilleYosida_zero_of hres hpow).2
+      (dense_subScalar_domain hdense),
     LinearPMap.subScalar_subScalar, add_neg_cancel, LinearPMap.subScalar_zero]
 
 /-- The general Hille--Yosida semigroup has the prescribed growth bound `(omega, M)`. -/
 theorem hasGrowthBound_hilleYosidaSemigroup :
     (hilleYosidaSemigroup hM hres hpow hdense).HasGrowthBound omega M := by
-  obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
-  have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
-    simpa using hdense
-  have hzero := hasGrowthBound_hilleYosidaLimitSemigroup hM hres₀ hpow₀ hdense₀
-  simpa only [hilleYosidaSemigroup, zero_sub, neg_neg] using hzero.expShift (lambda := -omega)
+  rw [hilleYosidaSemigroup_eq]
+  have hzero := hasGrowthBound_hilleYosidaLimitSemigroup hM
+    (LinearPMap.hilleYosida_zero_of hres hpow).1
+    (LinearPMap.hilleYosida_zero_of hres hpow).2
+    (dense_subScalar_domain hdense)
+  simpa only [zero_sub, neg_neg] using hzero.expShift (lambda := -omega)
 
 /-- **Hille--Yosida generation theorem.** Let `A` be a densely defined operator on a real Banach
 space, let `1 ≤ M`, and suppose that every real `lambda > omega` belongs to the resolvent set of
@@ -208,11 +222,8 @@ theorem hilleYosida_generation_iff (A : X →ₗ.[ℝ] X) (M omega : ℝ) :
           ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n := by
   constructor
   · rintro ⟨S, rfl, hb⟩
-    refine ⟨hb.one_le, ?_, (fun _ hlambda => S.mem_resolventSet_generator hb hlambda), ?_⟩
-    · have hdom : (S.generator.domain : Set X) = (S.domain : Set X) := by
-        rw [S.generator_domain]
-      rw [hdom]
-      exact S.dense_domain
+    refine ⟨hb.one_le, (by simpa only [S.generator_domain] using S.dense_domain),
+      (fun _ hlambda => S.Ioi_subset_resolventSet_generator hb hlambda), ?_⟩
     · intro n _hn lambda hlambda
       exact S.norm_generator_resolvent_pow_le hb hlambda n
   · rintro ⟨hM, hdense, hres, hpow⟩

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
@@ -9,7 +9,7 @@ public import TauCeti.Analysis.Semigroups.Generation.HilleYosida.Limit
 public import TauCeti.Analysis.Semigroups.Generation.HilleYosida.Shift
 public import TauCeti.Analysis.Semigroups.Generation.Yosida.Generator
 public import TauCeti.Analysis.Semigroups.Generator.ExponentialShift
-public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+public import TauCeti.Analysis.Semigroups.Resolvent.PowerBounds
 
 /-!
 # The Hille--Yosida generation theorem
@@ -23,10 +23,11 @@ produce the semigroup `hilleYosidaLimitSemigroup`. The compact-time convergence 
 approximations and the shared positive resolvent half-line identify the generator of that
 semigroup with `A`.
 
-For a general growth exponent `omega`, apply the zero-exponent construction to
-`A - omega I`, then exponentially shift the resulting semigroup back. The scalar-shift identities
-for partial linear maps and semigroup generators show that the final generator is exactly `A`,
-while the growth bound becomes `(omega, M)`.
+For a general growth exponent `omega`, `hilleYosidaSemigroup` applies the zero-exponent
+construction to `A - omega I`, then exponentially shifts the resulting semigroup back. The
+scalar-shift identities for partial linear maps and semigroup generators show that its generator
+is exactly `A`, while its growth bound becomes `(omega, M)`. The final characterization combines
+this construction with density and the sharp generator-resolvent estimates for every C₀-semigroup.
 
 This proves the Hille--Yosida milestone in Part A of the
 [one-parameter-semigroups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/OneParameterSemigroups/README.md#part-a--strongly-continuous-semigroups).
@@ -35,8 +36,11 @@ This proves the Hille--Yosida milestone in Part A of the
 
 * `TauCeti.Semigroups.hilleYosidaLimitSemigroup_generator`: the exponent-zero limit semigroup has
   generator `A`.
+* `TauCeti.Semigroups.hilleYosidaSemigroup`: the general `(M, omega)` constructed semigroup.
 * `TauCeti.Semigroups.hilleYosida_generation`: the general `(M, omega)` Hille--Yosida generation
   theorem.
+* `TauCeti.Semigroups.exists_semigroup_generator_eq_and_hasGrowthBound_iff`: the Hille--Yosida
+  characterization.
 
 ## References
 
@@ -101,6 +105,93 @@ theorem hilleYosidaLimitSemigroup_generator {A : X →ₗ.[ℝ] X} {M : ℝ}
 
 /-! ## The general generation theorem -/
 
+/-- The strongly continuous semigroup constructed by the general `(M, omega)` Hille--Yosida
+theorem. It is the exponential unshift of the exponent-zero limit semigroup for
+`A - omega I`. -/
+def hilleYosidaSemigroup {A : X →ₗ.[ℝ] X} {M omega : ℝ}
+    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
+    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
+    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
+    StronglyContinuousSemigroup X :=
+  let hzero := LinearPMap.hilleYosida_zero_of hres hpow
+  let hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
+    simpa using hdense
+  (hilleYosidaLimitSemigroup hM hzero.1 hzero.2 hdense₀).expShift (-omega)
+
+/-- Evaluating the general Hille--Yosida semigroup gives the exponentially shifted
+exponent-zero Yosida limit. -/
+@[simp]
+theorem hilleYosidaSemigroup_apply {A : X →ₗ.[ℝ] X} {M omega : ℝ}
+    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
+    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
+    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n)
+    (t : ℝ≥0) (x : X) :
+    hilleYosidaSemigroup hM hdense hres hpow t x =
+      Real.exp (omega * (t : ℝ)) • yosidaLimit (LinearPMap.subScalar A omega) t x := by
+  simp only [hilleYosidaSemigroup, StronglyContinuousSemigroup.expShift_apply_apply,
+    hilleYosidaLimitSemigroup_apply, neg_mul, neg_neg]
+
+/-- Real-time evaluation of the general Hille--Yosida semigroup at a nonnegative time. -/
+@[simp]
+theorem hilleYosidaSemigroup_realOperator_apply_of_nonneg {A : X →ₗ.[ℝ] X} {M omega : ℝ}
+    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
+    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
+    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n)
+    {t : ℝ} (ht : 0 ≤ t) (x : X) :
+    (hilleYosidaSemigroup hM hdense hres hpow).realOperator t x =
+      Real.exp (omega * t) • yosidaLimit (LinearPMap.subScalar A omega) t x := by
+  simp only [hilleYosidaSemigroup,
+    StronglyContinuousSemigroup.expShift_realOperator_apply_of_nonneg _ _ _ ht,
+    hilleYosidaLimitSemigroup_realOperator_apply_of_nonneg _ _ _ _ ht, neg_mul, neg_neg]
+
+/-- The shifted Yosida approximations converge pointwise to the general Hille--Yosida semigroup. -/
+theorem tendsto_hilleYosidaSemigroup {A : X →ₗ.[ℝ] X} {M omega : ℝ}
+    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
+    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
+    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n)
+    (t : ℝ≥0) (x : X) :
+    Tendsto (fun lambda : ℝ => Real.exp (omega * (t : ℝ)) •
+        exp ((t : ℝ) • yosidaApproximation (LinearPMap.subScalar A omega) lambda) x)
+      atTop (𝓝 (hilleYosidaSemigroup hM hdense hres hpow t x)) := by
+  obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
+  have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
+    simpa using hdense
+  rw [hilleYosidaSemigroup_apply]
+  exact (tendsto_yosidaLimit_of_norm_resolvent_pow_le hM hres₀ hpow₀ hdense₀ t.2 x).const_smul
+    (Real.exp (omega * (t : ℝ)) : ℝ)
+
+/-- The general Hille--Yosida semigroup has generator `A`. -/
+@[simp]
+theorem hilleYosidaSemigroup_generator {A : X →ₗ.[ℝ] X} {M omega : ℝ}
+    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
+    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
+    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
+    (hilleYosidaSemigroup hM hdense hres hpow).generator = A := by
+  obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
+  have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
+    simpa using hdense
+  rw [hilleYosidaSemigroup, StronglyContinuousSemigroup.generator_expShift,
+    hilleYosidaLimitSemigroup_generator hM hres₀ hpow₀ hdense₀,
+    LinearPMap.subScalar_subScalar, add_neg_cancel, LinearPMap.subScalar_zero]
+
+/-- The general Hille--Yosida semigroup has the prescribed growth bound `(omega, M)`. -/
+theorem hasGrowthBound_hilleYosidaSemigroup {A : X →ₗ.[ℝ] X} {M omega : ℝ}
+    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
+    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
+    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
+    (hilleYosidaSemigroup hM hdense hres hpow).HasGrowthBound omega M := by
+  obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
+  have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
+    simpa using hdense
+  have hzero := hasGrowthBound_hilleYosidaLimitSemigroup hM hres₀ hpow₀ hdense₀
+  simpa only [hilleYosidaSemigroup, zero_sub, neg_neg] using hzero.expShift (lambda := -omega)
+
 /-- **Hille--Yosida generation theorem.** Let `A` be a densely defined operator on a real Banach
 space, let `1 ≤ M`, and suppose that every real `lambda > omega` belongs to the resolvent set of
 `A`, with the power estimates
@@ -114,19 +205,32 @@ theorem hilleYosida_generation {A : X →ₗ.[ℝ] X} {M omega : ℝ}
     (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
     (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
       ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
-    ∃ S : StronglyContinuousSemigroup X, S.generator = A ∧ S.HasGrowthBound omega M := by
-  obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
-  have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
-    simpa using hdense
-  let T := hilleYosidaLimitSemigroup hM hres₀ hpow₀ hdense₀
-  refine ⟨T.expShift (-omega), ?_, ?_⟩
-  · rw [StronglyContinuousSemigroup.generator_expShift]
-    dsimp only [T]
-    rw [hilleYosidaLimitSemigroup_generator hM hres₀ hpow₀ hdense₀,
-      LinearPMap.subScalar_subScalar, add_neg_cancel, LinearPMap.subScalar_zero]
-  · have hT : T.HasGrowthBound 0 M := by
-      exact hasGrowthBound_hilleYosidaLimitSemigroup hM hres₀ hpow₀ hdense₀
-    simpa using hT.expShift (lambda := -omega)
+    ∃ S : StronglyContinuousSemigroup X, S.generator = A ∧ S.HasGrowthBound omega M :=
+  ⟨hilleYosidaSemigroup hM hdense hres hpow,
+    hilleYosidaSemigroup_generator hM hdense hres hpow,
+    hasGrowthBound_hilleYosidaSemigroup hM hdense hres hpow⟩
+
+/-- **Hille--Yosida characterization.** An unbounded operator is the generator of a strongly
+continuous semigroup with growth bound `(omega, M)` if and only if `1 ≤ M`, its domain is dense,
+the half-line `(omega, ∞)` lies in its resolvent set, and its resolvent powers satisfy the sharp
+Hille--Yosida estimates. -/
+theorem exists_semigroup_generator_eq_and_hasGrowthBound_iff (A : X →ₗ.[ℝ] X) (M omega : ℝ) :
+    (∃ S : StronglyContinuousSemigroup X, S.generator = A ∧ S.HasGrowthBound omega M) ↔
+      1 ≤ M ∧ Dense (A.domain : Set X) ∧
+        (∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A) ∧
+        ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+          ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n := by
+  constructor
+  · rintro ⟨S, rfl, hb⟩
+    refine ⟨hb.one_le, ?_, S.Ioi_subset_resolventSet_generator hb, ?_⟩
+    · have hdom : (S.generator.domain : Set X) = (S.domain : Set X) := by
+        rw [S.generator_domain]
+      rw [hdom]
+      exact S.dense_domain
+    · intro n _hn lambda hlambda
+      exact S.norm_generator_resolvent_pow_le hb n hlambda
+  · rintro ⟨hM, hdense, hres, hpow⟩
+    exact hilleYosida_generation hM hdense hres hpow
 
 end TauCeti.Semigroups
 

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
@@ -37,10 +37,14 @@ This proves the Hille--Yosida milestone in Part A of the
 * `TauCeti.Semigroups.hilleYosidaLimitSemigroup_generator`: the exponent-zero limit semigroup has
   generator `A`.
 * `TauCeti.Semigroups.hilleYosidaSemigroup`: the general `(M, omega)` constructed semigroup.
+* `TauCeti.Semigroups.hilleYosidaSemigroup_apply`: evaluation of the constructed semigroup.
+* `TauCeti.Semigroups.tendsto_shiftedYosidaApproximation_hilleYosidaSemigroup`: convergence of the
+  shifted Yosida approximations.
+* `TauCeti.Semigroups.hilleYosidaSemigroup_generator`: identification of its generator.
+* `TauCeti.Semigroups.hasGrowthBound_hilleYosidaSemigroup`: its prescribed growth bound.
 * `TauCeti.Semigroups.hilleYosida_generation`: the general `(M, omega)` Hille--Yosida generation
   theorem.
-* `TauCeti.Semigroups.exists_semigroup_generator_eq_and_hasGrowthBound_iff`: the Hille--Yosida
-  characterization.
+* `TauCeti.Semigroups.hilleYosida_generation_iff`: the Hille--Yosida characterization.
 
 ## References
 
@@ -105,15 +109,21 @@ theorem hilleYosidaLimitSemigroup_generator {A : X →ₗ.[ℝ] X} {M : ℝ}
 
 /-! ## The general generation theorem -/
 
+section
+
+variable {A : X →ₗ.[ℝ] X} {M omega : ℝ}
+variable (hM : 1 ≤ M)
+variable (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
+variable (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
+  ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n)
+variable (hdense : Dense (A.domain : Set X))
+
+include hM hres hpow hdense
+
 /-- The strongly continuous semigroup constructed by the general `(M, omega)` Hille--Yosida
 theorem. It is the exponential unshift of the exponent-zero limit semigroup for
 `A - omega I`. -/
-def hilleYosidaSemigroup {A : X →ₗ.[ℝ] X} {M omega : ℝ}
-    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
-    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
-    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
-      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
-    StronglyContinuousSemigroup X :=
+def hilleYosidaSemigroup : StronglyContinuousSemigroup X :=
   let hzero := LinearPMap.hilleYosida_zero_of hres hpow
   let hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
     simpa using hdense
@@ -122,41 +132,27 @@ def hilleYosidaSemigroup {A : X →ₗ.[ℝ] X} {M omega : ℝ}
 /-- Evaluating the general Hille--Yosida semigroup gives the exponentially shifted
 exponent-zero Yosida limit. -/
 @[simp]
-theorem hilleYosidaSemigroup_apply {A : X →ₗ.[ℝ] X} {M omega : ℝ}
-    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
-    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
-    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
-      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n)
-    (t : ℝ≥0) (x : X) :
-    hilleYosidaSemigroup hM hdense hres hpow t x =
+theorem hilleYosidaSemigroup_apply (t : ℝ≥0) (x : X) :
+    hilleYosidaSemigroup hM hres hpow hdense t x =
       Real.exp (omega * (t : ℝ)) • yosidaLimit (LinearPMap.subScalar A omega) t x := by
   simp only [hilleYosidaSemigroup, StronglyContinuousSemigroup.expShift_apply_apply,
     hilleYosidaLimitSemigroup_apply, neg_mul, neg_neg]
 
 /-- Real-time evaluation of the general Hille--Yosida semigroup at a nonnegative time. -/
 @[simp]
-theorem hilleYosidaSemigroup_realOperator_apply_of_nonneg {A : X →ₗ.[ℝ] X} {M omega : ℝ}
-    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
-    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
-    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
-      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n)
-    {t : ℝ} (ht : 0 ≤ t) (x : X) :
-    (hilleYosidaSemigroup hM hdense hres hpow).realOperator t x =
+theorem hilleYosidaSemigroup_realOperator_apply_of_nonneg {t : ℝ} (ht : 0 ≤ t) (x : X) :
+    (hilleYosidaSemigroup hM hres hpow hdense).realOperator t x =
       Real.exp (omega * t) • yosidaLimit (LinearPMap.subScalar A omega) t x := by
   simp only [hilleYosidaSemigroup,
     StronglyContinuousSemigroup.expShift_realOperator_apply_of_nonneg _ _ _ ht,
     hilleYosidaLimitSemigroup_realOperator_apply_of_nonneg _ _ _ _ ht, neg_mul, neg_neg]
 
 /-- The shifted Yosida approximations converge pointwise to the general Hille--Yosida semigroup. -/
-theorem tendsto_hilleYosidaSemigroup {A : X →ₗ.[ℝ] X} {M omega : ℝ}
-    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
-    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
-    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
-      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n)
+theorem tendsto_shiftedYosidaApproximation_hilleYosidaSemigroup
     (t : ℝ≥0) (x : X) :
     Tendsto (fun lambda : ℝ => Real.exp (omega * (t : ℝ)) •
         exp ((t : ℝ) • yosidaApproximation (LinearPMap.subScalar A omega) lambda) x)
-      atTop (𝓝 (hilleYosidaSemigroup hM hdense hres hpow t x)) := by
+      atTop (𝓝 (hilleYosidaSemigroup hM hres hpow hdense t x)) := by
   obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
   have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
     simpa using hdense
@@ -166,12 +162,8 @@ theorem tendsto_hilleYosidaSemigroup {A : X →ₗ.[ℝ] X} {M omega : ℝ}
 
 /-- The general Hille--Yosida semigroup has generator `A`. -/
 @[simp]
-theorem hilleYosidaSemigroup_generator {A : X →ₗ.[ℝ] X} {M omega : ℝ}
-    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
-    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
-    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
-      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
-    (hilleYosidaSemigroup hM hdense hres hpow).generator = A := by
+theorem hilleYosidaSemigroup_generator :
+    (hilleYosidaSemigroup hM hres hpow hdense).generator = A := by
   obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
   have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
     simpa using hdense
@@ -179,13 +171,23 @@ theorem hilleYosidaSemigroup_generator {A : X →ₗ.[ℝ] X} {M omega : ℝ}
     hilleYosidaLimitSemigroup_generator hM hres₀ hpow₀ hdense₀,
     LinearPMap.subScalar_subScalar, add_neg_cancel, LinearPMap.subScalar_zero]
 
+/-- The domain of the general Hille--Yosida semigroup is the prescribed operator domain. -/
+@[simp]
+theorem hilleYosidaSemigroup_domain :
+    (hilleYosidaSemigroup hM hres hpow hdense).domain = A.domain := by
+  rw [← StronglyContinuousSemigroup.generator_domain,
+    hilleYosidaSemigroup_generator hM hres hpow hdense]
+
+/-- A strongly continuous semigroup with generator `A` is the Hille--Yosida semigroup constructed
+from any valid Hille--Yosida data for `A`. -/
+theorem eq_hilleYosidaSemigroup {S : StronglyContinuousSemigroup X} (hS : S.generator = A) :
+    S = hilleYosidaSemigroup hM hres hpow hdense :=
+  StronglyContinuousSemigroup.eq_of_generator_eq
+    (hS.trans (hilleYosidaSemigroup_generator hM hres hpow hdense).symm)
+
 /-- The general Hille--Yosida semigroup has the prescribed growth bound `(omega, M)`. -/
-theorem hasGrowthBound_hilleYosidaSemigroup {A : X →ₗ.[ℝ] X} {M omega : ℝ}
-    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
-    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
-    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
-      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
-    (hilleYosidaSemigroup hM hdense hres hpow).HasGrowthBound omega M := by
+theorem hasGrowthBound_hilleYosidaSemigroup :
+    (hilleYosidaSemigroup hM hres hpow hdense).HasGrowthBound omega M := by
   obtain ⟨hres₀, hpow₀⟩ := LinearPMap.hilleYosida_zero_of hres hpow
   have hdense₀ : Dense ((LinearPMap.subScalar A omega).domain : Set X) := by
     simpa using hdense
@@ -200,21 +202,19 @@ space, let `1 ≤ M`, and suppose that every real `lambda > omega` belongs to th
 
 Then `A` generates a strongly continuous semigroup with growth bound `(omega, M)`. The produced
 semigroup is the exponential unshift of the exponent-zero Yosida limit for `A - omega I`. -/
-theorem hilleYosida_generation {A : X →ₗ.[ℝ] X} {M omega : ℝ}
-    (hM : 1 ≤ M) (hdense : Dense (A.domain : Set X))
-    (hres : ∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A)
-    (hpow : ∀ n : ℕ, 1 ≤ n → ∀ lambda : ℝ, omega < lambda →
-      ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n) :
+theorem hilleYosida_generation :
     ∃ S : StronglyContinuousSemigroup X, S.generator = A ∧ S.HasGrowthBound omega M :=
-  ⟨hilleYosidaSemigroup hM hdense hres hpow,
-    hilleYosidaSemigroup_generator hM hdense hres hpow,
-    hasGrowthBound_hilleYosidaSemigroup hM hdense hres hpow⟩
+  ⟨hilleYosidaSemigroup hM hres hpow hdense,
+    hilleYosidaSemigroup_generator hM hres hpow hdense,
+    hasGrowthBound_hilleYosidaSemigroup hM hres hpow hdense⟩
+
+end
 
 /-- **Hille--Yosida characterization.** An unbounded operator is the generator of a strongly
 continuous semigroup with growth bound `(omega, M)` if and only if `1 ≤ M`, its domain is dense,
 the half-line `(omega, ∞)` lies in its resolvent set, and its resolvent powers satisfy the sharp
 Hille--Yosida estimates. -/
-theorem exists_semigroup_generator_eq_and_hasGrowthBound_iff (A : X →ₗ.[ℝ] X) (M omega : ℝ) :
+theorem hilleYosida_generation_iff (A : X →ₗ.[ℝ] X) (M omega : ℝ) :
     (∃ S : StronglyContinuousSemigroup X, S.generator = A ∧ S.HasGrowthBound omega M) ↔
       1 ≤ M ∧ Dense (A.domain : Set X) ∧
         (∀ lambda : ℝ, omega < lambda → lambda ∈ LinearPMap.resolventSet A) ∧
@@ -222,15 +222,15 @@ theorem exists_semigroup_generator_eq_and_hasGrowthBound_iff (A : X →ₗ.[ℝ]
           ‖LinearPMap.resolvent A lambda ^ n‖ ≤ M / (lambda - omega) ^ n := by
   constructor
   · rintro ⟨S, rfl, hb⟩
-    refine ⟨hb.one_le, ?_, S.Ioi_subset_resolventSet_generator hb, ?_⟩
+    refine ⟨hb.one_le, ?_, (fun _ hlambda => S.mem_resolventSet_generator hb hlambda), ?_⟩
     · have hdom : (S.generator.domain : Set X) = (S.domain : Set X) := by
         rw [S.generator_domain]
       rw [hdom]
       exact S.dense_domain
     · intro n _hn lambda hlambda
-      exact S.norm_generator_resolvent_pow_le hb n hlambda
+      exact S.norm_generator_resolvent_pow_le hb hlambda n
   · rintro ⟨hM, hdense, hres, hpow⟩
-    exact hilleYosida_generation hM hdense hres hpow
+    exact hilleYosida_generation hM hres hpow hdense
 
 end TauCeti.Semigroups
 

--- a/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/HilleYosida/Generation.lean
@@ -171,20 +171,6 @@ theorem hilleYosidaSemigroup_generator :
     hilleYosidaLimitSemigroup_generator hM hres₀ hpow₀ hdense₀,
     LinearPMap.subScalar_subScalar, add_neg_cancel, LinearPMap.subScalar_zero]
 
-/-- The domain of the general Hille--Yosida semigroup is the prescribed operator domain. -/
-@[simp]
-theorem hilleYosidaSemigroup_domain :
-    (hilleYosidaSemigroup hM hres hpow hdense).domain = A.domain := by
-  rw [← StronglyContinuousSemigroup.generator_domain,
-    hilleYosidaSemigroup_generator hM hres hpow hdense]
-
-/-- A strongly continuous semigroup with generator `A` is the Hille--Yosida semigroup constructed
-from any valid Hille--Yosida data for `A`. -/
-theorem eq_hilleYosidaSemigroup {S : StronglyContinuousSemigroup X} (hS : S.generator = A) :
-    S = hilleYosidaSemigroup hM hres hpow hdense :=
-  StronglyContinuousSemigroup.eq_of_generator_eq
-    (hS.trans (hilleYosidaSemigroup_generator hM hres hpow hdense).symm)
-
 /-- The general Hille--Yosida semigroup has the prescribed growth bound `(omega, M)`. -/
 theorem hasGrowthBound_hilleYosidaSemigroup :
     (hilleYosidaSemigroup hM hres hpow hdense).HasGrowthBound omega M := by

--- a/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
@@ -167,7 +167,7 @@ theorem mem_resolventSet_generator (S : StronglyContinuousSemigroup X) [Complete
     lambda ∈ LinearPMap.resolventSet S.generator :=
   (S.isResolventAt_generator hb hlambda).mem_resolventSet
 
-/-- The half-line `(omega, ∞)` lies in the resolvent set of the generator — the hypothesis `hρ`
+/-- The half-line `(omega, ∞)` lies in the resolvent set of the generator — the hypothesis `hres`
 of the Hille--Yosida generation theorem, here in its (already available) converse direction. -/
 theorem Ioi_subset_resolventSet_generator (S : StronglyContinuousSemigroup X) [CompleteSpace X]
     {omega M : ℝ} (hb : S.HasGrowthBound omega M) :

--- a/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
@@ -26,12 +26,9 @@ Everything else here is read off that bridge. The resolvent identity
 abstract `LinearPMap.resolvent_sub_resolvent` and `LinearPMap.resolvent_comm` transported along
 it, rather than separate arguments; the identity is recorded both for `resolvent` and for
 `resolventFun`, the resolvent seen as a function of the spectral parameter alone. The bridge
-also transports the Laplace-transform norm estimates to the abstract resolvent: the Hille--Yosida
-resolvent bound `‖R(lambda, A)‖ ≤ M / (lambda - omega)`, and the elementary power bound
-`‖R(lambda, A) ^ n‖ ≤ (M / (lambda - omega)) ^ n` that submultiplicativity of the operator norm
-draws from it. The latter is *weaker* than the generation theorem's hypothesis
-`‖R(lambda, A) ^ n‖ ≤ M / (lambda - omega) ^ n` as soon as `M > 1`; the two agree in the
-contraction case `(M, omega) = (1, 0)`, which is where the hypothesis is supplied here.
+also transports the Laplace-transform norm estimate to the abstract resolvent:
+`‖R(lambda, A)‖ ≤ M / (lambda - omega)`. The sharp power estimate is proved from the integral
+power formula in `TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean`.
 
 ## References
 
@@ -192,28 +189,6 @@ theorem norm_generator_resolvent_le (S : StronglyContinuousSemigroup X) [Complet
   rw [S.generator_resolvent_eq hb hlambda]
   exact S.resolvent_norm_le hb lambda hlambda
 
-/-- **Power bound** for the resolvent of the generator:
-`‖R(lambda, A) ^ n‖ ≤ (M / (lambda - omega)) ^ n`, the elementary consequence of
-`TauCeti.Semigroups.StronglyContinuousSemigroup.norm_generator_resolvent_le` and
-submultiplicativity of the operator norm.
-
-This is *not* the hypothesis `hbound` of the Hille--Yosida generation theorem, which asks for
-`‖R(lambda, A) ^ n‖ ≤ M / (lambda - omega) ^ n`: that is strictly stronger once `M > 1`, it does
-not follow from `‖R(lambda, A)‖ ≤ M / (lambda - omega)`, and it needs the estimate for
-`∫₀^∞ tⁿ e^{-λt} S(t) x dt`, which the repository does not yet have. The two bounds agree in the
-contraction case `(M, omega) = (1, 0)`, where
-`TauCeti.Semigroups.ContractionSemigroup.norm_generator_resolvent_pow_le` does supply
-`hbound`. -/
-theorem norm_generator_resolvent_pow_le (S : StronglyContinuousSemigroup X) [CompleteSpace X]
-    {omega M : ℝ} (hb : S.HasGrowthBound omega M) {lambda : ℝ} (hlambda : omega < lambda)
-    (n : ℕ) :
-    ‖LinearPMap.resolvent S.generator lambda ^ n‖ ≤ (M / (lambda - omega)) ^ n := by
-  cases n with
-  | zero => exact ContinuousLinearMap.norm_id_le
-  | succ n =>
-      exact (norm_pow_le' _ n.succ_pos).trans
-        (pow_le_pow_left₀ (norm_nonneg _) (S.norm_generator_resolvent_le hb hlambda) (n + 1))
-
 /-! ## The resolvent identity -/
 
 /-- Pointwise form of the resolvent identity
@@ -331,18 +306,6 @@ theorem generator_resolvent_eq (S : ContractionSemigroup X) [CompleteSpace X] {l
   rw [S.resolvent_eq_stronglyContinuousSemigroup_resolvent,
     S.toStronglyContinuousSemigroup.generator_resolvent_eq S.hasGrowthBound
       (by simpa using hlambda)]
-
-/-- **The Hille--Yosida power bound in the contraction case**, `(M, omega) = (1, 0)`:
-`‖R(lambda, A) ^ n‖ ≤ (1 / lambda) ^ n` for `lambda > 0`; the specialization of
-`TauCeti.Semigroups.StronglyContinuousSemigroup.norm_generator_resolvent_pow_le`. Here `M = 1`
-makes `(1 / lambda) ^ n` and `1 / lambda ^ n` the same number, so this is the generation
-theorem's hypothesis `hbound` for contraction semigroups. -/
-theorem norm_generator_resolvent_pow_le (S : ContractionSemigroup X) [CompleteSpace X]
-    {lambda : ℝ} (hlambda : 0 < lambda) (n : ℕ) :
-    ‖LinearPMap.resolvent S.toStronglyContinuousSemigroup.generator lambda ^ n‖
-      ≤ (1 / lambda) ^ n := by
-  simpa using S.toStronglyContinuousSemigroup.norm_generator_resolvent_pow_le S.hasGrowthBound
-    (by simpa using hlambda) n
 
 end ContractionSemigroup
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
@@ -274,8 +274,8 @@ growth bound `(omega, M)` and `lambda > omega`,
 
 This is the necessity estimate in exactly the form consumed by the Hille--Yosida generation
 theorem. -/
-theorem norm_generator_resolvent_pow_le (hb : S.HasGrowthBound omega M) (n : ℕ)
-    {lambda : ℝ} (hlambda : omega < lambda) :
+theorem norm_generator_resolvent_pow_le (hb : S.HasGrowthBound omega M)
+    {lambda : ℝ} (hlambda : omega < lambda) (n : ℕ) :
     ‖LinearPMap.resolvent S.generator lambda ^ n‖ ≤ M / (lambda - omega) ^ n := by
   rw [S.generator_resolvent_eq hb hlambda]
   exact S.resolvent_pow_norm_le hb n hlambda
@@ -326,7 +326,7 @@ theorem norm_generator_resolvent_pow_le (S : ContractionSemigroup X) {lambda : �
     ‖LinearPMap.resolvent S.toStronglyContinuousSemigroup.generator lambda ^ n‖
       ≤ (1 / lambda) ^ n := by
   have h := S.toStronglyContinuousSemigroup.norm_generator_resolvent_pow_le
-    S.hasGrowthBound n hlambda
+    S.hasGrowthBound hlambda n
   simpa only [sub_zero, one_div_pow] using h
 
 /-- The Hille--Yosida derivative bound in the contraction case. -/

--- a/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
@@ -29,10 +29,16 @@ For a contraction semigroup, this specializes to
 
 `‖R(lambda)^n‖ ≤ lambda⁻ⁿ`.
 
+Using `generator_resolvent_eq`, the sharp bound is also transported to the generator resolvent,
+
+`‖R(lambda, generator S)^n‖ ≤ M / (lambda - omega)^n`,
+
+with the corresponding contraction-semigroup specialization.
+
 The corresponding pointwise estimates and the bound for the scaled contraction resolvent
 `lambda R(lambda)` are also recorded. This is the necessity half of the Hille--Yosida generation
-theorem: every C₀-semigroup's Laplace-transform resolvent satisfies the power bound that the
-generation theorem assumes for an abstract operator.
+theorem: every C₀-semigroup's Laplace-transform resolvent, and hence its generator resolvent,
+satisfies the sharp power bound used by the generation theorem.
 
 The sharp derivative bound obtained from the power formula is recorded here in both the general
 growth-bound and contraction cases.

--- a/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/PowerBounds.lean
@@ -268,6 +268,18 @@ theorem resolvent_pow_norm_le (hb : S.HasGrowthBound omega M) (n : ℕ)
       · intro x
         exact S.norm_resolvent_pow_succ_apply_le hb n hlambda x
 
+/-- **Sharp Hille--Yosida power bound for the generator resolvent.** For a C₀-semigroup with
+growth bound `(omega, M)` and `lambda > omega`,
+`‖R(lambda, generator S) ^ n‖ ≤ M / (lambda - omega) ^ n`.
+
+This is the necessity estimate in exactly the form consumed by the Hille--Yosida generation
+theorem. -/
+theorem norm_generator_resolvent_pow_le (hb : S.HasGrowthBound omega M) (n : ℕ)
+    {lambda : ℝ} (hlambda : omega < lambda) :
+    ‖LinearPMap.resolvent S.generator lambda ^ n‖ ≤ M / (lambda - omega) ^ n := by
+  rw [S.generator_resolvent_eq hb hlambda]
+  exact S.resolvent_pow_norm_le hb n hlambda
+
 /-- The sharp Hille--Yosida derivative bound obtained from the resolvent power formula. -/
 theorem norm_iteratedDeriv_resolventFun_le (hb : S.HasGrowthBound omega M) (n : ℕ)
     {lambda : ℝ} (hlambda : omega < lambda) :
@@ -305,6 +317,16 @@ theorem resolvent_pow_norm_le (S : ContractionSemigroup X) (lambda : ℝ) (hlamb
     ‖S.resolvent lambda hlambda ^ n‖ ≤ (1 / lambda) ^ n := by
   have h := S.toStronglyContinuousSemigroup.resolvent_pow_norm_le S.hasGrowthBound n hlambda
   rw [← S.resolvent_eq_stronglyContinuousSemigroup_resolvent] at h
+  simpa only [sub_zero, one_div_pow] using h
+
+/-- The sharp Hille--Yosida power bound for the generator of a contraction semigroup:
+`‖R(lambda, generator S) ^ n‖ ≤ lambda⁻ⁿ` for `lambda > 0`. -/
+theorem norm_generator_resolvent_pow_le (S : ContractionSemigroup X) {lambda : ℝ}
+    (hlambda : 0 < lambda) (n : ℕ) :
+    ‖LinearPMap.resolvent S.toStronglyContinuousSemigroup.generator lambda ^ n‖
+      ≤ (1 / lambda) ^ n := by
+  have h := S.toStronglyContinuousSemigroup.norm_generator_resolvent_pow_le
+    S.hasGrowthBound n hlambda
   simpa only [sub_zero, one_div_pow] using h
 
 /-- The Hille--Yosida derivative bound in the contraction case. -/


### PR DESCRIPTION
## Summary

- expose the sharp generator-resolvent power bound under the existing natural theorem name
- add the standard Hille–Yosida characterization, with `1 ≤ M` stated explicitly
- name the general shifted Hille–Yosida semigroup and expose evaluation, convergence, generator, and growth-bound lemmas
- remove the stale weaker theorem and documentation from the lower import layer

## Roadmap target

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A, specifically the general `(M, ω)` iterated-resolvent bounds, Hille–Yosida generation milestone, and the surrounding reusable semigroup API.

## Verification

- `lake build`
- `lake exe axioms`
- `lake exe module-system`
- `scripts/lint-env.sh` (no new violations)

Closes #3564

Roadmap: OneParameterSemigroups
