### PR TITLE
feat: give connected components their group structure

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Basic.lean
@@ -123,12 +123,40 @@ noncomputable abbrev componentGroupPoints (H : FiniteTypeCommHopfAlgCat.{u, u} k
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
     (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k)
 
+/-- Locally expose the group structure carried by the bundled rational component group. -/
+noncomputable local instance componentGroupPointsGroup
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) : Group (componentGroupPoints H) :=
+  (componentGroupPoints H).str
+
 /-- The quotient homomorphism from rational points to the rational pointwise component group. -/
 noncomputable def componentGroupPointsMk (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k) ⟶ componentGroupPoints H :=
   CommHopfAlgCat.pointwiseQuotientMk H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
     (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k)
+
+/-- The quotient homomorphism from rational points to the rational component group is
+surjective. -/
+theorem componentGroupPointsMk_surjective (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Function.Surjective (componentGroupPointsMk H) := by
+  unfold componentGroupPointsMk
+  exact CommHopfAlgCat.pointwiseQuotientMk_surjective H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k)
+
+/-- A rational point maps to the identity of the rational component group exactly when it lies
+in the identity-component subgroup. -/
+@[simp]
+theorem componentGroupPointsMk_eq_one_iff (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
+    componentGroupPointsMk H g = 1 ↔
+      g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (CommAlgCat.of k k) := by
+  unfold componentGroupPointsMk
+  exact CommHopfAlgCat.pointwiseQuotientMk_eq_one_iff H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (isNormal_identityComponentHopfIdeal H) (CommAlgCat.of k k) g
 
 /-- A rational point belongs to `H⁰(k)` exactly when its kernel point belongs to the identity
 component of `Spec H`. -/
@@ -293,6 +321,15 @@ noncomputable def componentGroupPointsEquivConnectedComponents
   Equiv.ofBijective (componentGroupPointsToConnectedComponents H)
     ⟨componentGroupPointsToConnectedComponents_injective H,
       componentGroupPointsToConnectedComponents_surjective H⟩
+
+/-- The canonical equivalence from the rational pointwise component group is the component map
+on elements. -/
+@[simp]
+theorem componentGroupPointsEquivConnectedComponents_apply
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (q : componentGroupPoints H) :
+    componentGroupPointsEquivConnectedComponents H q =
+      componentGroupPointsToConnectedComponents H q :=
+  (rfl)
 
 /-- The rational pointwise component group of a finite-type affine group over an algebraically
 closed field is finite. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean
@@ -150,7 +150,8 @@ theorem rationalComponentMap_apply (H : FiniteTypeCommHopfAlgCat.{u, u} k)
 group. -/
 @[simp]
 theorem rationalKernelPoint_one_component (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    (rationalKernelPoint H 1 : ConnectedComponents (PrimeSpectrum H)) = 1 := by
+    ConnectedComponents.mk (α := PrimeSpectrum H) (Bialgebra.augmentationPoint k H) = 1 := by
+  rw [← rationalKernelPoint_one H]
   rw [← rationalComponentMap_apply]
   exact map_one (rationalComponentMap H)
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.Basic
+
+/-!
+# The group structure on connected components of an affine group
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over an algebraically closed
+field. Every connected component of `Spec H` contains a rational point, and two rational points
+lie in the same component exactly when they differ by a point of the identity component. Thus the
+canonical equivalence
+
+```text
+H(k) / H⁰(k) ≃ ConnectedComponents (Spec H)
+```
+
+transports the quotient-group structure to the connected components. This file records that
+structure and its characteristic API: the component of a product is the product of the
+components, and the component map from rational points is a surjective group homomorphism whose
+kernel is exactly `H⁰(k)`.
+
+This is the group-theoretic input for representing `π₀(H)` by the finite constant group scheme
+on the connected components. The coordinate-algebra comparison additionally needs the orthogonal
+component-idempotent decomposition.
+
+## Main declarations
+
+* `TauCeti.FiniteTypeCommHopfAlgCat.instGroupConnectedComponents`: the component-group structure
+  on `ConnectedComponents (PrimeSpectrum H)`.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupPointsMulEquivConnectedComponents`: the
+  multiplicative equivalence from the rational pointwise quotient to connected components.
+* `TauCeti.FiniteTypeCommHopfAlgCat.rationalComponentMap`: the surjective homomorphism sending a
+  rational point to its connected component.
+* `TauCeti.FiniteTypeCommHopfAlgCat.rationalComponentMap_ker`: its kernel is the rational points
+  of the identity component.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37 and Section 5.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Sections 6.7 and 14.
+
+This advances Layer 3, "Identity component `G°` and component group `π₀(G)`", of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.FiniteTypeCommHopfAlgCat
+
+universe u
+
+variable {k : Type u} [Field k] [IsAlgClosed k]
+
+/-- Locally expose the group structure carried by the bundled rational component group. -/
+noncomputable local instance componentGroupPointsGroupForTransfer
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) : Group (componentGroupPoints H) :=
+  (componentGroupPoints H).str
+
+/-- The group structure on the connected components of the spectrum of a finite-type affine
+group. It is characterized by the requirement that the canonical bijection from
+`H(k) / H⁰(k)` be multiplicative. -/
+noncomputable instance instGroupConnectedComponents
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Group (ConnectedComponents (PrimeSpectrum H)) :=
+  (componentGroupPointsEquivConnectedComponents H).symm.group
+
+/-- The canonical equivalence from the rational pointwise component group to the connected
+components of the spectrum, as a multiplicative equivalence. -/
+noncomputable def componentGroupPointsMulEquivConnectedComponents
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupPoints H ≃* ConnectedComponents (PrimeSpectrum H) :=
+  ((componentGroupPointsEquivConnectedComponents H).symm.mulEquiv).symm
+
+/-- The multiplicative component-group equivalence is the canonical component map on elements.
+-/
+@[simp]
+theorem componentGroupPointsMulEquivConnectedComponents_apply
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (q : componentGroupPoints H) :
+    componentGroupPointsMulEquivConnectedComponents H q =
+      componentGroupPointsToConnectedComponents H q := by
+  simp only [componentGroupPointsMulEquivConnectedComponents,
+    Equiv.mulEquiv_symm_apply, Equiv.symm_symm]
+  exact componentGroupPointsEquivConnectedComponents_apply H q
+
+/-- The canonical bijection from the rational pointwise quotient to connected components
+preserves multiplication. -/
+@[simp]
+theorem componentGroupPointsToConnectedComponents_mul
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (q r : componentGroupPoints H) :
+    componentGroupPointsToConnectedComponents H (q * r) =
+      componentGroupPointsToConnectedComponents H q *
+        componentGroupPointsToConnectedComponents H r := by
+  calc
+    componentGroupPointsToConnectedComponents H (q * r) =
+        componentGroupPointsMulEquivConnectedComponents H (q * r) :=
+      (componentGroupPointsMulEquivConnectedComponents_apply H (q * r)).symm
+    _ = componentGroupPointsMulEquivConnectedComponents H q *
+        componentGroupPointsMulEquivConnectedComponents H r :=
+      map_mul (componentGroupPointsMulEquivConnectedComponents H) q r
+    _ = componentGroupPointsToConnectedComponents H q *
+        componentGroupPointsToConnectedComponents H r := by
+      rw [componentGroupPointsMulEquivConnectedComponents_apply,
+        componentGroupPointsMulEquivConnectedComponents_apply]
+
+/-- Send a rational point of a finite-type affine group to the connected component containing
+its kernel point. -/
+noncomputable def rationalComponentMap (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k) →*
+      ConnectedComponents (PrimeSpectrum H) :=
+  (componentGroupPointsMulEquivConnectedComponents H).toMonoidHom.comp
+    (componentGroupPointsMk H).hom
+
+/-- The rational component map sends a point to the component containing its kernel point. -/
+@[simp]
+theorem rationalComponentMap_apply (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
+    rationalComponentMap H g =
+      (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H)) := by
+  change componentGroupPointsMulEquivConnectedComponents H (componentGroupPointsMk H g) = _
+  rw [componentGroupPointsMulEquivConnectedComponents_apply,
+    componentGroupPointsToConnectedComponents_mk]
+
+/-- The component containing the identity rational point is the identity of the component
+group. -/
+theorem rationalKernelPoint_one_component (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (rationalKernelPoint H 1 : ConnectedComponents (PrimeSpectrum H)) = 1 := by
+  rw [← rationalComponentMap_apply]
+  exact map_one (rationalComponentMap H)
+
+/-- The component of a product of rational points is the product of their components. -/
+@[simp]
+theorem rationalKernelPoint_mul_component (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g h : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
+    (rationalKernelPoint H (g * h) : ConnectedComponents (PrimeSpectrum H)) =
+      (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H)) *
+        (rationalKernelPoint H h : ConnectedComponents (PrimeSpectrum H)) := by
+  rw [← rationalComponentMap_apply, map_mul, rationalComponentMap_apply,
+    rationalComponentMap_apply]
+
+/-- The component of the inverse of a rational point is the inverse component. -/
+@[simp]
+theorem rationalKernelPoint_inv_component (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
+    (rationalKernelPoint H g⁻¹ : ConnectedComponents (PrimeSpectrum H)) =
+      (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H))⁻¹ := by
+  rw [← rationalComponentMap_apply, map_inv, rationalComponentMap_apply]
+
+/-- Every connected component of the spectrum contains the kernel point of a rational point. -/
+theorem rationalComponentMap_surjective (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Function.Surjective (rationalComponentMap H) :=
+  (componentGroupPointsMulEquivConnectedComponents H).surjective.comp <|
+    componentGroupPointsMk_surjective H
+
+/-- A rational point maps to the identity component exactly when it belongs to the rational
+points of `H⁰`. -/
+@[simp]
+theorem rationalComponentMap_eq_one_iff (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
+    rationalComponentMap H g = 1 ↔
+      g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (CommAlgCat.of k k) := by
+  change componentGroupPointsMulEquivConnectedComponents H (componentGroupPointsMk H g) = 1 ↔ _
+  rw [(componentGroupPointsMulEquivConnectedComponents H).map_eq_one_iff,
+    componentGroupPointsMk_eq_one_iff]
+
+/-- The kernel of the rational component map is the rational-point subgroup of the identity
+component. -/
+theorem rationalComponentMap_ker (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (rationalComponentMap H).ker =
+      CommHopfAlgCat.quotientPointsSubgroup H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (CommAlgCat.of k k) := by
+  ext g
+  change rationalComponentMap H g = 1 ↔ _
+  exact rationalComponentMap_eq_one_iff H g
+
+end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean
@@ -123,7 +123,7 @@ theorem rationalComponentMap_apply (H : FiniteTypeCommHopfAlgCat.{u, u} k)
     (g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k)) :
     rationalComponentMap H g =
       (rationalKernelPoint H g : ConnectedComponents (PrimeSpectrum H)) := by
-  change componentGroupPointsMulEquivConnectedComponents H (componentGroupPointsMk H g) = _
+  dsimp [rationalComponentMap]
   rw [componentGroupPointsMulEquivConnectedComponents_apply,
     componentGroupPointsToConnectedComponents_mk]
 
@@ -167,7 +167,7 @@ theorem rationalComponentMap_eq_one_iff (H : FiniteTypeCommHopfAlgCat.{u, u} k)
       g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
         (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
         (CommAlgCat.of k k) := by
-  change componentGroupPointsMulEquivConnectedComponents H (componentGroupPointsMk H g) = 1 ↔ _
+  dsimp [rationalComponentMap]
   rw [(componentGroupPointsMulEquivConnectedComponents H).map_eq_one_iff,
     componentGroupPointsMk_eq_one_iff]
 
@@ -179,7 +179,7 @@ theorem rationalComponentMap_ker (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
         (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
         (CommAlgCat.of k k) := by
   ext g
-  change rationalComponentMap H g = 1 ↔ _
+  rw [MonoidHom.mem_ker]
   exact rationalComponentMap_eq_one_iff H g
 
 end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean
@@ -90,6 +90,15 @@ theorem componentGroupPointsMulEquivConnectedComponents_apply
   exact componentGroupPointsEquivConnectedComponents_apply H q
 
 /-- The canonical bijection from the rational pointwise quotient to connected components
+sends the identity to the identity component. -/
+@[simp]
+theorem componentGroupPointsToConnectedComponents_one
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupPointsToConnectedComponents H 1 = 1 := by
+  rw [← componentGroupPointsMulEquivConnectedComponents_apply]
+  exact map_one (componentGroupPointsMulEquivConnectedComponents H)
+
+/-- The canonical bijection from the rational pointwise quotient to connected components
 preserves multiplication. -/
 @[simp]
 theorem componentGroupPointsToConnectedComponents_mul
@@ -108,6 +117,16 @@ theorem componentGroupPointsToConnectedComponents_mul
         componentGroupPointsToConnectedComponents H r := by
       rw [componentGroupPointsMulEquivConnectedComponents_apply,
         componentGroupPointsMulEquivConnectedComponents_apply]
+
+/-- The canonical bijection from the rational pointwise quotient to connected components
+preserves inverses. -/
+@[simp]
+theorem componentGroupPointsToConnectedComponents_inv
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (q : componentGroupPoints H) :
+    componentGroupPointsToConnectedComponents H q⁻¹ =
+      (componentGroupPointsToConnectedComponents H q)⁻¹ := by
+  rw [← componentGroupPointsMulEquivConnectedComponents_apply, map_inv,
+    componentGroupPointsMulEquivConnectedComponents_apply]
 
 /-- Send a rational point of a finite-type affine group to the connected component containing
 its kernel point. -/
@@ -129,6 +148,7 @@ theorem rationalComponentMap_apply (H : FiniteTypeCommHopfAlgCat.{u, u} k)
 
 /-- The component containing the identity rational point is the identity of the component
 group. -/
+@[simp]
 theorem rationalKernelPoint_one_component (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     (rationalKernelPoint H 1 : ConnectedComponents (PrimeSpectrum H)) = 1 := by
   rw [← rationalComponentMap_apply]


### PR DESCRIPTION
This PR equips the connected components of the spectrum of a finite-type commutative Hopf algebra over an algebraically closed field with their canonical component-group structure. Transport the group law across the existing canonical equivalence `H(k) / H⁰(k) ≃ ConnectedComponents (Spec H)`, upgrade that equivalence to a multiplicative equivalence, and package the rational component map as a surjective group homomorphism whose kernel is exactly `H⁰(k)`.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 3 milestone “Identity component `G°` and component group `π₀(G)`.” This is the most effective distinct current step because the finite rational quotient and its canonical bijection with connected components are on `main`, while the in-flight idempotent decomposition in #3524 independently supplies the ring decomposition; the missing group law is what lets the next step use those idempotents to construct the component-coordinate bialgebra morphism into the finite constant group. After this PR, Layer 3 still needs that bialgebra morphism and its identity-component kernel, representability and finite étaleness of the fppf quotient, and geometric base-change/descent beyond the algebraically closed case.

Add `TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Group.lean` (185 lines) and extend the relocated basic module by 37 lines with the quotient projection’s surjectivity, identity-kernel criterion, and the evaluation theorem for its canonical equivalence. The shared `ComponentGroup` prefix requires this module move, with no declaration renames:

| Old module | New module |
| --- | --- |
| `TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup` | `TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.Basic` |

Reuse Mathlib’s `Equiv.group` transport and `MulEquiv` API together with Tau Ceti’s existing quotient-group projection, identity-component subgroup, and canonical component equivalence. No Mathlib infrastructure or external formalization is vendored. The mathematical construction follows Milne, *Algebraic Groups* (2017), Proposition 2.37 and Section 5, and Waterhouse, *Introduction to Affine Group Schemes*, Sections 6.7 and 14, as credited in the module documentation.

The targeted module build, changed-declaration axiom audit, and changed-module lint environment pass.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"connected-components-group-structure"}-->

🤖 Prepared with Codex
