### PR TITLE
feat: prove the type-G₂ Chevalley commutator relation

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Commutator.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Basic
 public import TauCeti.RingTheory.Nilpotent.ChevalleyCommutator
-public import TauCeti.RingTheory.Nilpotent.RootString
+public import TauCeti.RingTheory.Nilpotent.RootString.Basic
 import Mathlib.RingTheory.Nilpotent.Basic
 
 /-!
@@ -48,8 +48,10 @@ factor:
 x_α(t) x_β(u) x_α(t)⁻¹ = x_β(u) x_{α+β}(c t u) x_{2α+β}(d t² u).
 ```
 
-Type `G₂` additionally needs the longer chain with factors at `3α + β` and `3α + 2β`, which
-is not treated here.
+Type `G₂` additionally needs the longer chain with factors at `3α + β` and `3α + 2β`. That
+relation is proved for the underlying integral exponentials in
+`TauCeti.RingTheory.Nilpotent.RootString.G2`; only its transport to the root subgroups here is
+still missing.
 
 The general statements about integral nilpotent exponentials are
 `TauCeti.baseChangeExp_mul_baseChangeExp_of_commutator_eq` and

--- a/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
+++ b/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
@@ -48,6 +48,8 @@ class-two formula is the case `d k = y⁽ⁿ⁻ᵏ⁾ z⁽ᵏ⁾`, truncated to 
 
 * `TauCeti.Associative.mul_dividedPower_of_commutator_eq`: move one element across a divided power
   when its commutator with the base commutes with that base.
+* `TauCeti.Associative.mul_dividedPower_of_commutator_eq'`: the same identity for an exponent that
+  is not syntactically a successor.
 * `TauCeti.Associative.dividedPower_mul_of_ad_dividedPower_series`: coefficient-one normal ordering
   against an arbitrary divided-power series for the inner derivation.
 * `TauCeti.Associative.dividedPower_mul_dividedPower_of_commutator_eq`: the coefficient-one
@@ -112,6 +114,17 @@ theorem mul_dividedPower_of_commutator_eq {x y z : A} (hxy : x * y = y * x + z)
   congr 1
   rw [Nat.factorial_succ, Nat.cast_mul, Nat.cast_add, Nat.cast_one]
   field_simp
+
+/-- The form of `mul_dividedPower_of_commutator_eq` for an exponent that is not syntactically a
+successor: the commutator term is present exactly when the exponent is positive. This is the shape
+needed when the exponent is a summation variable. -/
+theorem mul_dividedPower_of_commutator_eq' {x y z : A} (hxy : x * y = y * x + z)
+    (hyz : Commute y z) (n : ℕ) :
+    x * dividedPower n y =
+      dividedPower n y * x + if 0 < n then dividedPower (n - 1) y * z else 0 := by
+  cases n with
+  | zero => simp
+  | succ n => simpa using mul_dividedPower_of_commutator_eq hxy hyz n
 
 -- This weighted-sum identity is the bookkeeping behind the induction in the normal-ordering
 -- theorem. The first sum records the term in which `x` passes through `y`; the second records the

--- a/TauCeti/RingTheory/DividedPowers/RootString/Basic.lean
+++ b/TauCeti/RingTheory/DividedPowers/RootString/Basic.lean
@@ -33,7 +33,9 @@ so it holds in a Kostant integral form and, after base change, over a ring of an
 The class-two rule `TauCeti.Associative.dividedPower_mul_dividedPower_of_commutator_eq` is the
 degenerate case `w = 0`, and covers every pair of non-proportional roots in a simply-laced root
 system; the rule proved here covers the additional chains in types `B`, `C`, and `F₄`. Type `G₂`
-also needs the longer chain containing `3α + β`, which is not treated here.
+also needs the longer chain containing `3α + β` and `3α + 2β`, which is
+`TauCeti.Associative.dividedPower_mul_dividedPower_of_commutator_eq_three_nsmul` in
+`TauCeti.RingTheory.DividedPowers.RootString.G2`.
 
 The proof feeds `TauCeti.Associative.dividedPower_mul_of_ad_dividedPower_series` the sequence
 
@@ -67,16 +69,6 @@ open Finset
 variable {A : Type*} [Semiring A] [Algebra ℚ A] {x y z w : A}
 
 /-! ## Moving one element across a single normal-ordered monomial -/
-
--- The one-sided normal-ordering rule of `NormalOrdering`, stated without a successor pattern so
--- that it can be applied to an exponent that is only known at run time.
-private theorem mul_dividedPower_of_commutator_eq' (hxy : x * y = y * x + z) (hyz : Commute y z)
-    (n : ℕ) :
-    x * dividedPower n y =
-      dividedPower n y * x + if 0 < n then dividedPower (n - 1) y * z else 0 := by
-  cases n with
-  | zero => simp
-  | succ n => simpa using mul_dividedPower_of_commutator_eq hxy hyz n
 
 -- Moving `x` across a normal-ordered monomial `y⁽ᵃ⁾ z⁽ᵇ⁾ w⁽ᶜ⁾` releases at most two terms: one
 -- that trades a `y` for a `z`, and one that trades a `z` for a `w`. The coefficient `2` of the

--- a/TauCeti/RingTheory/DividedPowers/RootString/G2.lean
+++ b/TauCeti/RingTheory/DividedPowers/RootString/G2.lean
@@ -1,0 +1,593 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.RingTheory.DividedPowers.RootString.Basic
+
+/-!
+# Normal ordering divided powers along the type-`G₂` root string
+
+Let `x`, `y`, `z`, `w`, `v`, and `s` belong to an associative algebra over `ℚ`, with
+
+```text
+x * y = y * x + z,   x * z = z * x + 2 • w,   x * w = w * x + 3 • v,   w * z = z * w + 3 • s,
+```
+
+`v` and `s` commuting with `x`, `y` commuting with `z`, `w` commuting with `v`, and `s` commuting
+with `z`, `w`, and `v`. This is the situation of the two simple roots of a root system of type `G₂`,
+`α` short and `β` long: with `x` and `y` the Chevalley root vectors of `α` and `β`, the divided
+powers `(ad x)ᵏ y / k!` of the inner derivation are the root vectors of `α + β`, `2α + β`, and
+`3α + β` up to sign, and `s` is the root vector of `3α + 2β`. Every one of the four brackets above
+is integral.
+
+The resulting straightening rule is again coefficient-one,
+
+```text
+x⁽ᵐ⁾ y⁽ⁿ⁾ = ∑ b + c + d + 2e ≤ n, b + 2c + 3d + 3e ≤ m,
+              y⁽ⁿ⁻ᵇ⁻ᶜ⁻ᵈ⁻²ᵉ⁾ z⁽ᵇ⁾ w⁽ᶜ⁾ v⁽ᵈ⁾ s⁽ᵉ⁾ x⁽ᵐ⁻ᵇ⁻²ᶜ⁻³ᵈ⁻³ᵉ⁾,
+```
+
+so it holds in a Kostant integral form and, after base change, over a ring of any characteristic.
+The two exponents attached to a summand are the pair `(i, j)` of the root `i α + j β` it comes from:
+`z` contributes `(1, 1)`, `w` contributes `(2, 1)`, `v` contributes `(3, 1)`, and `s` contributes
+`(3, 2)`. That last root is what makes the type-`G₂` case genuinely longer than the chain treated in
+`TauCeti.RingTheory.DividedPowers.RootString.Basic`: `3α + 2β` is not on the `α`-string through `β`,
+and it enters through the bracket `w * z = z * w + 3 • s` rather than through `ad x`.
+
+Type `G₂` has one further configuration, not treated here: for the pair `α`, `α + β` the roots
+`i α + j (α + β)` with `i, j > 0` are `2α + β`, `3α + β`, and `3α + 2β`, the last of them carrying
+the exponents `(i, j) = (1, 2)` and arising from `⁅y, ⁅x, y⁆⁆` rather than from `⁅w, z⁆`.
+
+The proof feeds `TauCeti.Associative.dividedPower_mul_of_ad_dividedPower_series` the sequence
+
+```text
+d k = ∑ b + 2c + 3d + 3e = k,  y⁽ⁿ⁻ᵇ⁻ᶜ⁻ᵈ⁻²ᵉ⁾ z⁽ᵇ⁾ w⁽ᶜ⁾ v⁽ᵈ⁾ s⁽ᵉ⁾,
+```
+
+which is the `k`-th divided power of the inner derivation `ad x` applied to `y⁽ⁿ⁾`. Verifying its
+defining recurrence is the whole content: moving `x` across one normal-ordered monomial lengthens
+the `z`-power with coefficient `b + 1`, the `w`-power with coefficient `2 (c + 1)`, the `v`-power
+with coefficient `3 (d + 1)`, or the `s`-power with coefficient `3 (e + 1)`, and the four
+contributions to a summand of `d (k + 1)` add up to `b + 2c + 3d + 3e = k + 1`.
+
+## Main results
+
+* `TauCeti.Associative.mul_dividedPower_of_commutator_eq_two_nsmul`: moving one element across a
+  divided power when the commutator itself has a central second commutator.
+* `TauCeti.Associative.commutator_eq_three_nsmul_of_commute`: the bracket `w * z = z * w + 3 • s`
+  is forced by the other type-`G₂` brackets, so a consumer holding a Chevalley basis need not
+  supply it separately.
+* `TauCeti.Associative.dividedPower_mul_dividedPower_of_commutator_eq_three_nsmul`: the
+  coefficient-one straightening rule for the type-`G₂` root string.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §4.2 and Theorem 5.2.2.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§25--26.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+namespace TauCeti.Associative
+
+open Finset
+
+variable {A : Type*} [Semiring A] [Algebra ℚ A] {x y z w v s : A}
+
+/-! ## Moving one element across a power whose commutator is not central -/
+
+-- The ordinary-power form, stated with an exponent of the shape `b + 2` so that no truncated
+-- subtraction appears. Both released terms are present from that exponent on.
+omit [Algebra ℚ A] in
+private theorem mul_pow_of_commutator_eq_two_nsmul {a d : A} (hxz : x * z = z * x + a)
+    (haz : a * z = z * a + 2 • d) (hzd : Commute z d) (b : ℕ) :
+    x * z ^ (b + 2) =
+      z ^ (b + 2) * x + (b + 2) • (z ^ (b + 1) * a) + ((b + 2) * (b + 1)) • (z ^ b * d) := by
+  induction b with
+  | zero =>
+      change x * z ^ 2 = z ^ 2 * x + 2 • (z ^ 1 * a) + 2 • (z ^ 0 * d)
+      rw [pow_two, pow_one, pow_zero, one_mul]
+      calc x * (z * z) = (x * z) * z := (mul_assoc _ _ _).symm
+        _ = (z * x + a) * z := by rw [hxz]
+        _ = z * (x * z) + a * z := by rw [add_mul, mul_assoc]
+        _ = z * (z * x + a) + (z * a + 2 • d) := by rw [hxz, haz]
+        _ = _ := by rw [mul_add, ← mul_assoc]; abel
+  | succ b ih =>
+      have hp3 : z ^ (b + 3) = z ^ (b + 2) * z := by
+        rw [show b + 3 = b + 2 + 1 from by omega, pow_succ]
+      have hp2 : z ^ (b + 2) = z ^ (b + 1) * z := by
+        rw [show b + 2 = b + 1 + 1 from by omega, pow_succ]
+      have hp1 : z ^ (b + 1) = z ^ b * z := by rw [pow_succ]
+      have hfin : ∀ T P Q : A,
+          T + P + ((b + 2) • P + (2 * (b + 2)) • Q) + ((b + 2) * (b + 1)) • Q =
+            T + (b + 3) • P + ((b + 3) * (b + 2)) • Q := by
+        intro T P Q
+        have h1 : (b + 3) • P = P + (b + 2) • P := by
+          rw [show b + 3 = 1 + (b + 2) from by omega, add_smul, one_smul]
+        have h2 : ((b + 3) * (b + 2)) • Q = (2 * (b + 2)) • Q + ((b + 2) * (b + 1)) • Q := by
+          rw [← add_smul, show 2 * (b + 2) + (b + 2) * (b + 1) = (b + 3) * (b + 2) from by ring]
+        rw [h1, h2]
+        abel
+      rw [show b + 1 + 2 = b + 3 from by omega, show b + 1 + 1 = b + 2 from by omega]
+      calc x * z ^ (b + 3)
+          = (x * z ^ (b + 2)) * z := by rw [hp3, ← mul_assoc]
+        _ = z ^ (b + 2) * (x * z) + (b + 2) • (z ^ (b + 1) * (a * z)) +
+              ((b + 2) * (b + 1)) • (z ^ b * (d * z)) := by
+            rw [ih, add_mul, add_mul, smul_mul_assoc, smul_mul_assoc, mul_assoc, mul_assoc,
+              mul_assoc]
+        _ = z ^ (b + 2) * (z * x + a) + (b + 2) • (z ^ (b + 1) * (z * a + 2 • d)) +
+              ((b + 2) * (b + 1)) • (z ^ b * (z * d)) := by rw [hxz, haz, hzd.eq]
+        _ = (z ^ (b + 3) * x + z ^ (b + 2) * a) +
+              ((b + 2) • (z ^ (b + 2) * a) + (2 * (b + 2)) • (z ^ (b + 1) * d)) +
+              ((b + 2) * (b + 1)) • (z ^ (b + 1) * d) := by
+            rw [mul_add, ← mul_assoc, ← hp3, mul_add, ← mul_assoc, ← hp2, mul_smul_comm, smul_add,
+              smul_smul, mul_comm (b + 2) 2, ← mul_assoc, ← hp1]
+        _ = _ := hfin _ _ _
+
+/-- **Moving one element across a divided power with a non-central commutator.** Suppose
+`x * z = z * x + a` and `a * z = z * a + 2 • d`, with `d` commuting with `z`. Then
+
+```text
+x z⁽ᵇ⁾ = z⁽ᵇ⁾ x + z⁽ᵇ⁻¹⁾ a + z⁽ᵇ⁻²⁾ d,
+```
+
+both released terms being present exactly when their exponent is defined. Every coefficient is `1`:
+the factor `2` in the second hypothesis is exactly what the divided powers absorb, which is why
+`d` rather than `a * z - z * a` is the integral datum. Taking `d = 0` recovers
+`mul_dividedPower_of_commutator_eq'`. -/
+theorem mul_dividedPower_of_commutator_eq_two_nsmul {a d : A} (hxz : x * z = z * x + a)
+    (haz : a * z = z * a + 2 • d) (hzd : Commute z d) (b : ℕ) :
+    x * dividedPower b z =
+      dividedPower b z * x + (if 0 < b then dividedPower (b - 1) z * a else 0) +
+        (if 1 < b then dividedPower (b - 2) z * d else 0) := by
+  match b with
+  | 0 => simp
+  | 1 => simpa using hxz
+  | (b + 2) =>
+      have key : ∀ c F G : ℚ, c ≠ 0 → F = c * G → F⁻¹ * c = G⁻¹ := by
+        intro c F G hc hF
+        subst hF
+        rw [mul_inv, mul_comm c⁻¹ G⁻¹, mul_assoc, inv_mul_cancel₀ hc, mul_one]
+      have hsucc : ((b + 2).factorial : ℚ) = ((b + 2 : ℕ) : ℚ) * ((b + 1).factorial : ℚ) := by
+        exact_mod_cast congrArg (fun n : ℕ => (n : ℚ)) (Nat.factorial_succ (b + 1))
+      have hsucc2 : ((b + 2).factorial : ℚ) =
+          (((b + 2) * (b + 1) : ℕ) : ℚ) * (b.factorial : ℚ) := by
+        have hnat : (b + 2).factorial = (b + 2) * (b + 1) * b.factorial := by
+          rw [Nat.factorial_succ (b + 1), Nat.factorial_succ b, mul_assoc]
+        exact_mod_cast congrArg (fun n : ℕ => (n : ℚ)) hnat
+      have hfac1 : ((b + 2).factorial : ℚ)⁻¹ * ((b + 2 : ℕ) : ℚ) = ((b + 1).factorial : ℚ)⁻¹ :=
+        key _ _ _ (Nat.cast_ne_zero.mpr (by omega)) hsucc
+      have hfac2 : ((b + 2).factorial : ℚ)⁻¹ * (((b + 2) * (b + 1) : ℕ) : ℚ) =
+          (b.factorial : ℚ)⁻¹ :=
+        key _ _ _ (Nat.cast_ne_zero.mpr (Nat.mul_ne_zero (by omega) (by omega))) hsucc2
+      rw [ite_eq_left (by omega : 0 < b + 2), ite_eq_left (by omega : 1 < b + 2),
+        show b + 2 - 1 = b + 1 from by omega, show b + 2 - 2 = b from by omega]
+      simp only [dividedPower_def, smul_mul_assoc]
+      rw [mul_smul_comm, mul_pow_of_commutator_eq_two_nsmul hxz haz hzd b, smul_add, smul_add]
+      congr 1
+      · congr 1
+        rw [← Nat.cast_smul_eq_nsmul ℚ, smul_smul, hfac1]
+      · rw [← Nat.cast_smul_eq_nsmul ℚ, smul_smul, hfac2]
+
+/-! ## The bracket at the root `3α + 2β` -/
+
+/-- **The fifth bracket is forced.** In the type-`G₂` configuration the bracket of the root vectors
+of `α + β` and `2α + β` is not an independent datum: it is three times the root vector of `3α + 2β`
+that already appears as `⁅y, v⁆`. The proof is the Jacobi identity applied to `⁅x, ⁅y, w⁆⁆ = 0`.
+
+A consumer holding a Chevalley basis therefore supplies the four brackets along the `α`-string
+together with `⁅e_β, e_{3α+β}⁆`, and reads off the hypothesis
+`w * z = z * w + 3 • s` of the straightening rule below. -/
+theorem commutator_eq_three_nsmul_of_commute {B : Type*} [Ring B] {x y z w v s : B}
+    (hxy : x * y = y * x + z) (hxw : x * w = w * x + 3 • v) (hyw : Commute y w)
+    (hyv : y * v = v * y + s) :
+    w * z = z * w + 3 • s := by
+  have h1 : x * y * w = w * y * x + 3 • (v * y) + 3 • s + z * w := by
+    calc x * y * w = (y * x + z) * w := by rw [hxy]
+      _ = y * (x * w) + z * w := by rw [add_mul, mul_assoc]
+      _ = y * (w * x + 3 • v) + z * w := by rw [hxw]
+      _ = y * w * x + 3 • (y * v) + z * w := by rw [mul_add, mul_smul_comm, ← mul_assoc]
+      _ = w * y * x + 3 • (v * y + s) + z * w := by rw [hyw.eq, hyv]
+      _ = _ := by rw [smul_add]; abel
+  have h2 : x * y * w = w * y * x + 3 • (v * y) + w * z := by
+    calc x * y * w = x * (w * y) := by rw [mul_assoc, hyw.eq]
+      _ = (w * x + 3 • v) * y := by rw [← mul_assoc, hxw]
+      _ = w * (y * x + z) + 3 • (v * y) := by rw [add_mul, mul_assoc, hxy, smul_mul_assoc]
+      _ = w * y * x + w * z + 3 • (v * y) := by rw [mul_add, ← mul_assoc]
+      _ = _ := by abel
+  have h3 : w * y * x + 3 • (v * y) + (3 • s + z * w) =
+      w * y * x + 3 • (v * y) + w * z := by
+    rw [← add_assoc]
+    exact h1.symm.trans h2
+  rw [← add_left_cancel h3]
+  abel
+
+/-! ## Moving one element across a single normal-ordered monomial -/
+
+-- Moving `x` across a normal-ordered monomial `y⁽ᵃ⁾ z⁽ᵇ⁾ w⁽ᶜ⁾ v⁽ᵈ⁾ s⁽ᵉ⁾ releases four terms: one
+-- trading a `y` for a `z`, one trading a `z` for a `w`, one trading two `z`s for an `s`, and one
+-- trading a `w` for a `v`. The monomials are written right-associated, which is the order in which
+-- `x` meets their factors.
+private theorem mul_dividedPower_quintuple (hxy : x * y = y * x + z)
+    (hxz : x * z = z * x + 2 • w) (hxw : x * w = w * x + 3 • v) (hwz : w * z = z * w + 3 • s)
+    (hxv : Commute x v) (hxs : Commute x s) (hyz : Commute y z) (hwv : Commute w v)
+    (hzs : Commute z s) (hws : Commute w s) (hvs : Commute v s) (a b c d e : ℕ) :
+    x * (dividedPower a y * (dividedPower b z * (dividedPower c w *
+        (dividedPower d v * dividedPower e s)))) =
+      dividedPower a y * (dividedPower b z * (dividedPower c w *
+          (dividedPower d v * dividedPower e s))) * x +
+        (if 0 < a then (b + 1) • (dividedPower (a - 1) y * (dividedPower (b + 1) z *
+          (dividedPower c w * (dividedPower d v * dividedPower e s)))) else 0) +
+        (if 0 < b then (2 * (c + 1)) • (dividedPower a y * (dividedPower (b - 1) z *
+          (dividedPower (c + 1) w * (dividedPower d v * dividedPower e s)))) else 0) +
+        (if 1 < b then (3 * (e + 1)) • (dividedPower a y * (dividedPower (b - 2) z *
+          (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)))) else 0) +
+        (if 0 < c then (3 * (d + 1)) • (dividedPower a y * (dividedPower b z *
+          (dividedPower (c - 1) w * (dividedPower (d + 1) v * dividedPower e s)))) else 0) := by
+  have hxV : Commute x (dividedPower d v) := by
+    simpa using commute_dividedPower_dividedPower hxv 1 d
+  have hxS : Commute x (dividedPower e s) := by
+    simpa using commute_dividedPower_dividedPower hxs 1 e
+  have hsW : Commute s (dividedPower c w) := by
+    simpa using commute_dividedPower_dividedPower hws.symm 1 c
+  have hsV : Commute s (dividedPower d v) := by
+    simpa using commute_dividedPower_dividedPower hvs.symm 1 d
+  -- The second commutator of `x` with `z` is `2 • (3 • s)`, which is what the divided powers of
+  -- `z` absorb into a single copy of `s`.
+  have haz : (2 • w) * z = z * (2 • w) + 2 • (3 • s) := by
+    rw [smul_mul_assoc, hwz, mul_smul_comm, smul_add]
+  -- Push `x` rightwards through the monomial, one factor at a time.
+  have e0 : x * (dividedPower d v * dividedPower e s) =
+      dividedPower d v * dividedPower e s * x := by
+    rw [← mul_assoc, hxV.eq, mul_assoc, hxS.eq, ← mul_assoc]
+  have e1 : x * (dividedPower c w * (dividedPower d v * dividedPower e s)) =
+      dividedPower c w * (dividedPower d v * dividedPower e s) * x +
+        (if 0 < c then dividedPower (c - 1) w * (3 • v) else 0) *
+          (dividedPower d v * dividedPower e s) := by
+    rw [← mul_assoc, mul_dividedPower_of_commutator_eq' hxw (hwv.smul_right 3) c, add_mul,
+      mul_assoc, e0, ← mul_assoc]
+  have e2 : x * (dividedPower b z * (dividedPower c w *
+        (dividedPower d v * dividedPower e s))) =
+      dividedPower b z * (dividedPower c w * (dividedPower d v * dividedPower e s)) * x +
+        dividedPower b z * ((if 0 < c then dividedPower (c - 1) w * (3 • v) else 0) *
+          (dividedPower d v * dividedPower e s)) +
+        (if 0 < b then dividedPower (b - 1) z * (2 • w) else 0) *
+          (dividedPower c w * (dividedPower d v * dividedPower e s)) +
+        (if 1 < b then dividedPower (b - 2) z * (3 • s) else 0) *
+          (dividedPower c w * (dividedPower d v * dividedPower e s)) := by
+    rw [← mul_assoc, mul_dividedPower_of_commutator_eq_two_nsmul hxz haz (hzs.smul_right 3) b,
+      add_mul, add_mul, mul_assoc, e1, mul_add, ← mul_assoc]
+  rw [← mul_assoc, mul_dividedPower_of_commutator_eq' hxy hyz a, add_mul, mul_assoc, e2,
+    mul_add, mul_add, mul_add, ← mul_assoc]
+  -- Now evaluate the four released terms, absorbing each new factor into its own divided power.
+  have tA : (if 0 < a then dividedPower (a - 1) y * z else 0) *
+      (dividedPower b z * (dividedPower c w * (dividedPower d v * dividedPower e s))) =
+      if 0 < a then (b + 1) • (dividedPower (a - 1) y * (dividedPower (b + 1) z *
+        (dividedPower c w * (dividedPower d v * dividedPower e s)))) else 0 := by
+    split_ifs with ha
+    · rw [mul_assoc, ← mul_assoc z, self_mul_dividedPower, smul_mul_assoc, mul_smul_comm]
+    · rw [zero_mul]
+  have tB : dividedPower a y * ((if 0 < b then dividedPower (b - 1) z * (2 • w) else 0) *
+      (dividedPower c w * (dividedPower d v * dividedPower e s))) =
+      if 0 < b then (2 * (c + 1)) • (dividedPower a y * (dividedPower (b - 1) z *
+        (dividedPower (c + 1) w * (dividedPower d v * dividedPower e s)))) else 0 := by
+    split_ifs with hb
+    · rw [mul_assoc, smul_mul_assoc, ← mul_assoc w, self_mul_dividedPower, smul_mul_assoc,
+        smul_smul, mul_smul_comm, mul_smul_comm]
+    · rw [zero_mul, mul_zero]
+  have hmove : s * (dividedPower c w * (dividedPower d v * dividedPower e s)) =
+      (e + 1) • (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)) := by
+    rw [← mul_assoc, hsW.eq, mul_assoc, ← mul_assoc s, hsV.eq, mul_assoc,
+      self_mul_dividedPower, mul_smul_comm, mul_smul_comm]
+  have tC : dividedPower a y * ((if 1 < b then dividedPower (b - 2) z * (3 • s) else 0) *
+      (dividedPower c w * (dividedPower d v * dividedPower e s))) =
+      if 1 < b then (3 * (e + 1)) • (dividedPower a y * (dividedPower (b - 2) z *
+        (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)))) else 0 := by
+    split_ifs with hb
+    · rw [mul_assoc, smul_mul_assoc, hmove, smul_smul, mul_smul_comm, mul_smul_comm]
+    · rw [zero_mul, mul_zero]
+  have tD : dividedPower a y * (dividedPower b z *
+      ((if 0 < c then dividedPower (c - 1) w * (3 • v) else 0) *
+        (dividedPower d v * dividedPower e s))) =
+      if 0 < c then (3 * (d + 1)) • (dividedPower a y * (dividedPower b z *
+        (dividedPower (c - 1) w * (dividedPower (d + 1) v * dividedPower e s)))) else 0 := by
+    split_ifs with hc
+    · rw [mul_assoc, smul_mul_assoc, ← mul_assoc v, self_mul_dividedPower, smul_mul_assoc,
+        smul_smul, mul_smul_comm, mul_smul_comm, mul_smul_comm]
+    · rw [zero_mul, mul_zero, mul_zero]
+  rw [tA, tB, tC, tD]
+  abel
+
+/-! ## The divided-power series of the inner derivation -/
+
+/-- The exponents occurring in the `k`-th divided power of `ad x` applied to `y⁽ⁿ⁾`: quadruples
+`(b, c, d, e)` with `b + c + d + 2e ≤ n` and `b + 2c + 3d + 3e = k`. -/
+private def g2SeriesIndex (n k : ℕ) : Finset (ℕ × ℕ × ℕ × ℕ) :=
+  {p ∈ range (n + 1) ×ˢ range (n + 1) ×ˢ range (n + 1) ×ˢ range (n + 1) |
+    p.1 + p.2.1 + p.2.2.1 + 2 * p.2.2.2 ≤ n ∧
+      p.1 + 2 * p.2.1 + 3 * p.2.2.1 + 3 * p.2.2.2 = k}
+
+private theorem mem_g2SeriesIndex {n k : ℕ} {p : ℕ × ℕ × ℕ × ℕ} :
+    p ∈ g2SeriesIndex n k ↔
+      p.1 + p.2.1 + p.2.2.1 + 2 * p.2.2.2 ≤ n ∧
+        p.1 + 2 * p.2.1 + 3 * p.2.2.1 + 3 * p.2.2.2 = k := by
+  simp only [g2SeriesIndex, Finset.mem_filter, Finset.mem_product, Finset.mem_range]
+  omega
+
+/-- The normal-ordered monomial attached to a quadruple of exponents, the `y`-exponent being
+whatever is left of `n`. -/
+private noncomputable def g2Monomial (y z w v s : A) (n : ℕ) (p : ℕ × ℕ × ℕ × ℕ) : A :=
+  dividedPower (n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2) y *
+    (dividedPower p.1 z * (dividedPower p.2.1 w *
+      (dividedPower p.2.2.1 v * dividedPower p.2.2.2 s)))
+
+/-- The `k`-th divided power of the inner derivation `ad x`, applied to `y⁽ⁿ⁾`. -/
+private noncomputable def g2Series (y z w v s : A) (n k : ℕ) : A :=
+  ∑ p ∈ g2SeriesIndex n k, g2Monomial y z w v s n p
+
+private theorem g2Series_zero (n : ℕ) : g2Series y z w v s n 0 = dividedPower n y := by
+  have hindex : g2SeriesIndex n 0 = {(0, 0, 0, 0)} := by
+    ext ⟨b, c, d, e⟩
+    simp only [mem_g2SeriesIndex, Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  rw [g2Series, hindex]
+  simp [g2Monomial]
+
+-- The defining recurrence of the sequence: it is what `dividedPower_mul_of_ad_dividedPower_series`
+-- consumes. Each summand of `g2Series n (k + 1)` is reached in four ways, with coefficients
+-- `b`, `2c`, `3d`, and `3e`, which add up to `k + 1`.
+private theorem mul_g2Series (hxy : x * y = y * x + z) (hxz : x * z = z * x + 2 • w)
+    (hxw : x * w = w * x + 3 • v) (hwz : w * z = z * w + 3 • s) (hxv : Commute x v)
+    (hxs : Commute x s) (hyz : Commute y z) (hwv : Commute w v) (hzs : Commute z s)
+    (hws : Commute w s) (hvs : Commute v s) (n k : ℕ) :
+    x * g2Series y z w v s n k =
+      g2Series y z w v s n k * x + (k + 1) • g2Series y z w v s n (k + 1) := by
+  classical
+  have hterm : ∀ p ∈ g2SeriesIndex n k,
+      x * g2Monomial y z w v s n p =
+        g2Monomial y z w v s n p * x +
+          (if 0 < n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2 then
+            (p.1 + 1) • g2Monomial y z w v s n (p.1 + 1, p.2.1, p.2.2.1, p.2.2.2) else 0) +
+          (if 0 < p.1 then
+            (2 * (p.2.1 + 1)) •
+              g2Monomial y z w v s n (p.1 - 1, p.2.1 + 1, p.2.2.1, p.2.2.2) else 0) +
+          (if 1 < p.1 then
+            (3 * (p.2.2.2 + 1)) •
+              g2Monomial y z w v s n (p.1 - 2, p.2.1, p.2.2.1, p.2.2.2 + 1) else 0) +
+          (if 0 < p.2.1 then
+            (3 * (p.2.2.1 + 1)) •
+              g2Monomial y z w v s n (p.1, p.2.1 - 1, p.2.2.1 + 1, p.2.2.2) else 0) := by
+    rintro ⟨b, c, d, e⟩ _
+    have hA : n - (b + 1) - c - d - 2 * e = n - b - c - d - 2 * e - 1 := by omega
+    have hB : 0 < b → n - (b - 1) - (c + 1) - d - 2 * e = n - b - c - d - 2 * e := by omega
+    have hC : 1 < b → n - (b - 2) - c - d - 2 * (e + 1) = n - b - c - d - 2 * e := by omega
+    have hD : 0 < c → n - b - (c - 1) - (d + 1) - 2 * e = n - b - c - d - 2 * e := by omega
+    have eqB : (if 0 < b then (2 * (c + 1)) •
+          (dividedPower (n - (b - 1) - (c + 1) - d - 2 * e) y * (dividedPower (b - 1) z *
+            (dividedPower (c + 1) w * (dividedPower d v * dividedPower e s)))) else 0) =
+        (if 0 < b then (2 * (c + 1)) •
+          (dividedPower (n - b - c - d - 2 * e) y * (dividedPower (b - 1) z *
+            (dividedPower (c + 1) w * (dividedPower d v * dividedPower e s)))) else 0) := by
+      split_ifs with h
+      · rw [hB h]
+      · rfl
+    have eqC : (if 1 < b then (3 * (e + 1)) •
+          (dividedPower (n - (b - 2) - c - d - 2 * (e + 1)) y * (dividedPower (b - 2) z *
+            (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)))) else 0) =
+        (if 1 < b then (3 * (e + 1)) •
+          (dividedPower (n - b - c - d - 2 * e) y * (dividedPower (b - 2) z *
+            (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)))) else 0) := by
+      split_ifs with h
+      · rw [hC h]
+      · rfl
+    have eqD : (if 0 < c then (3 * (d + 1)) •
+          (dividedPower (n - b - (c - 1) - (d + 1) - 2 * e) y * (dividedPower b z *
+            (dividedPower (c - 1) w * (dividedPower (d + 1) v * dividedPower e s)))) else 0) =
+        (if 0 < c then (3 * (d + 1)) •
+          (dividedPower (n - b - c - d - 2 * e) y * (dividedPower b z *
+            (dividedPower (c - 1) w * (dividedPower (d + 1) v * dividedPower e s)))) else 0) := by
+      split_ifs with h
+      · rw [hD h]
+      · rfl
+    simp only [g2Monomial]
+    rw [mul_dividedPower_quintuple hxy hxz hxw hwz hxv hxs hyz hwv hzs hws hvs
+      (n - b - c - d - 2 * e) b c d e, hA, eqB, eqC, eqD]
+  -- The four reindexings that identify the released families with the summands of the next term.
+  have hshiftA : ∑ p ∈ {p ∈ g2SeriesIndex n k | 0 < n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2},
+        (p.1 + 1) • g2Monomial y z w v s n (p.1 + 1, p.2.1, p.2.2.1, p.2.2.2) =
+      ∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.1}, q.1 • g2Monomial y z w v s n q := by
+    refine Finset.sum_nbij' (fun p => (p.1 + 1, p.2.1, p.2.2.1, p.2.2.2))
+      (fun q => (q.1 - 1, q.2.1, q.2.2.1, q.2.2.2)) ?_ ?_ ?_ ?_ ?_
+    · rintro ⟨b, c, d, e⟩ hp
+      simp only [Finset.mem_filter, mem_g2SeriesIndex] at hp ⊢
+      omega
+    · rintro ⟨b, c, d, e⟩ hq
+      simp only [Finset.mem_filter, mem_g2SeriesIndex] at hq ⊢
+      omega
+    · rintro ⟨b, c, d, e⟩ _
+      simp
+    · rintro ⟨b, c, d, e⟩ hq
+      have hb : 0 < b := by
+        simp only [Finset.mem_filter, mem_g2SeriesIndex] at hq
+        omega
+      simp [Nat.sub_add_cancel hb]
+    · rintro ⟨b, c, d, e⟩ _
+      simp
+  have hshiftB : ∑ p ∈ {p ∈ g2SeriesIndex n k | 0 < p.1},
+        (2 * (p.2.1 + 1)) • g2Monomial y z w v s n (p.1 - 1, p.2.1 + 1, p.2.2.1, p.2.2.2) =
+      ∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.2.1},
+        (2 * q.2.1) • g2Monomial y z w v s n q := by
+    refine Finset.sum_nbij' (fun p => (p.1 - 1, p.2.1 + 1, p.2.2.1, p.2.2.2))
+      (fun q => (q.1 + 1, q.2.1 - 1, q.2.2.1, q.2.2.2)) ?_ ?_ ?_ ?_ ?_
+    · rintro ⟨b, c, d, e⟩ hp
+      simp only [Finset.mem_filter, mem_g2SeriesIndex] at hp ⊢
+      omega
+    · rintro ⟨b, c, d, e⟩ hq
+      simp only [Finset.mem_filter, mem_g2SeriesIndex] at hq ⊢
+      omega
+    · rintro ⟨b, c, d, e⟩ hp
+      have hb : 0 < b := by
+        simp only [Finset.mem_filter, mem_g2SeriesIndex] at hp
+        omega
+      simp [Nat.sub_add_cancel hb]
+    · rintro ⟨b, c, d, e⟩ hq
+      have hc : 0 < c := by
+        simp only [Finset.mem_filter, mem_g2SeriesIndex] at hq
+        omega
+      simp [Nat.sub_add_cancel hc]
+    · rintro ⟨b, c, d, e⟩ _
+      simp
+  have hshiftC : ∑ p ∈ {p ∈ g2SeriesIndex n k | 1 < p.1},
+        (3 * (p.2.2.2 + 1)) • g2Monomial y z w v s n (p.1 - 2, p.2.1, p.2.2.1, p.2.2.2 + 1) =
+      ∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.2.2.2},
+        (3 * q.2.2.2) • g2Monomial y z w v s n q := by
+    refine Finset.sum_nbij' (fun p => (p.1 - 2, p.2.1, p.2.2.1, p.2.2.2 + 1))
+      (fun q => (q.1 + 2, q.2.1, q.2.2.1, q.2.2.2 - 1)) ?_ ?_ ?_ ?_ ?_
+    · rintro ⟨b, c, d, e⟩ hp
+      simp only [Finset.mem_filter, mem_g2SeriesIndex] at hp ⊢
+      omega
+    · rintro ⟨b, c, d, e⟩ hq
+      simp only [Finset.mem_filter, mem_g2SeriesIndex] at hq ⊢
+      omega
+    · rintro ⟨b, c, d, e⟩ hp
+      have hb : 1 < b := by
+        simp only [Finset.mem_filter, mem_g2SeriesIndex] at hp
+        omega
+      simp [show b - 2 + 2 = b from by omega]
+    · rintro ⟨b, c, d, e⟩ hq
+      have he : 0 < e := by
+        simp only [Finset.mem_filter, mem_g2SeriesIndex] at hq
+        omega
+      simp [Nat.sub_add_cancel he]
+    · rintro ⟨b, c, d, e⟩ _
+      simp
+  have hshiftD : ∑ p ∈ {p ∈ g2SeriesIndex n k | 0 < p.2.1},
+        (3 * (p.2.2.1 + 1)) • g2Monomial y z w v s n (p.1, p.2.1 - 1, p.2.2.1 + 1, p.2.2.2) =
+      ∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.2.2.1},
+        (3 * q.2.2.1) • g2Monomial y z w v s n q := by
+    refine Finset.sum_nbij' (fun p => (p.1, p.2.1 - 1, p.2.2.1 + 1, p.2.2.2))
+      (fun q => (q.1, q.2.1 + 1, q.2.2.1 - 1, q.2.2.2)) ?_ ?_ ?_ ?_ ?_
+    · rintro ⟨b, c, d, e⟩ hp
+      simp only [Finset.mem_filter, mem_g2SeriesIndex] at hp ⊢
+      omega
+    · rintro ⟨b, c, d, e⟩ hq
+      simp only [Finset.mem_filter, mem_g2SeriesIndex] at hq ⊢
+      omega
+    · rintro ⟨b, c, d, e⟩ hp
+      have hc : 0 < c := by
+        simp only [Finset.mem_filter, mem_g2SeriesIndex] at hp
+        omega
+      simp [Nat.sub_add_cancel hc]
+    · rintro ⟨b, c, d, e⟩ hq
+      have hd : 0 < d := by
+        simp only [Finset.mem_filter, mem_g2SeriesIndex] at hq
+        omega
+      simp [Nat.sub_add_cancel hd]
+    · rintro ⟨b, c, d, e⟩ _
+      simp
+  -- Every summand of the next term is reached with total coefficient `b + 2c + 3d + 3e = k + 1`.
+  have hcombine : ∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.1}, q.1 • g2Monomial y z w v s n q +
+        ∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.2.1},
+          (2 * q.2.1) • g2Monomial y z w v s n q +
+        ∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.2.2.2},
+          (3 * q.2.2.2) • g2Monomial y z w v s n q +
+        ∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.2.2.1},
+          (3 * q.2.2.1) • g2Monomial y z w v s n q =
+      (k + 1) • g2Series y z w v s n (k + 1) := by
+    rw [Finset.sum_filter_of_ne (fun q _ hq => Nat.pos_of_ne_zero fun h => hq (by simp [h])),
+      Finset.sum_filter_of_ne (fun q _ hq => Nat.pos_of_ne_zero fun h => hq (by simp [h])),
+      Finset.sum_filter_of_ne (fun q _ hq => Nat.pos_of_ne_zero fun h => hq (by simp [h])),
+      Finset.sum_filter_of_ne (fun q _ hq => Nat.pos_of_ne_zero fun h => hq (by simp [h])),
+      g2Series, Finset.smul_sum, ← Finset.sum_add_distrib, ← Finset.sum_add_distrib,
+      ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun q hq => ?_
+    rw [← add_smul, ← add_smul, ← add_smul]
+    congr 1
+    have := (mem_g2SeriesIndex.mp hq).2
+    omega
+  rw [g2Series, Finset.mul_sum, Finset.sum_mul, Finset.sum_congr rfl hterm]
+  simp only [Finset.sum_add_distrib, ← Finset.sum_filter]
+  rw [hshiftA, hshiftB, hshiftC, hshiftD, add_assoc, add_assoc, add_assoc, ← add_assoc _ _
+    (∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.2.2.1}, (3 * q.2.2.1) • g2Monomial y z w v s n q),
+    ← add_assoc, ← hcombine]
+  abel
+
+/-! ## The straightening rule -/
+
+/-- The quadruples of exponents in the straightening rule for the type-`G₂` root string, one
+coordinate for each of the roots `α + β`, `2α + β`, `3α + β`, and `3α + 2β`. -/
+def chainG2Index (m n : ℕ) : Finset (ℕ × ℕ × ℕ × ℕ) :=
+  {p ∈ range (n + 1) ×ˢ range (n + 1) ×ˢ range (n + 1) ×ˢ range (n + 1) |
+    p.1 + p.2.1 + p.2.2.1 + 2 * p.2.2.2 ≤ n ∧
+      p.1 + 2 * p.2.1 + 3 * p.2.2.1 + 3 * p.2.2.2 ≤ m}
+
+/-- Membership in `chainG2Index` in terms of its two mathematical inequalities. -/
+@[simp]
+theorem mem_chainG2Index {m n : ℕ} {p : ℕ × ℕ × ℕ × ℕ} :
+    p ∈ chainG2Index m n ↔
+      p.1 + p.2.1 + p.2.2.1 + 2 * p.2.2.2 ≤ n ∧
+        p.1 + 2 * p.2.1 + 3 * p.2.2.1 + 3 * p.2.2.2 ≤ m := by
+  simp only [chainG2Index, Finset.mem_filter, Finset.mem_product, Finset.mem_range]
+  omega
+
+/-- **Coefficient-one normal ordering along the type-`G₂` root string.** Suppose
+
+```text
+x * y = y * x + z,   x * z = z * x + 2 • w,   x * w = w * x + 3 • v,   w * z = z * w + 3 • s,
+```
+
+that `v` and `s` commute with `x`, that `y` commutes with `z`, that `w` commutes with `v`, and that
+`s` commutes with `z`, `w`, and `v`. Then
+
+```text
+x⁽ᵐ⁾ y⁽ⁿ⁾ = ∑ b + c + d + 2e ≤ n, b + 2c + 3d + 3e ≤ m,
+              y⁽ⁿ⁻ᵇ⁻ᶜ⁻ᵈ⁻²ᵉ⁾ z⁽ᵇ⁾ w⁽ᶜ⁾ v⁽ᵈ⁾ s⁽ᵉ⁾ x⁽ᵐ⁻ᵇ⁻²ᶜ⁻³ᵈ⁻³ᵉ⁾.
+```
+
+Every coefficient in the divided-power basis is `1`, so the identity survives restriction to a
+Kostant integral lattice and base change to a ring of arbitrary characteristic. Taking `v = 0` and
+`s = 0` and discarding the terms with `d ≠ 0` or `e ≠ 0` recovers the chain rule
+`dividedPower_mul_dividedPower_of_commutator_eq_two_nsmul`. -/
+theorem dividedPower_mul_dividedPower_of_commutator_eq_three_nsmul (hxy : x * y = y * x + z)
+    (hxz : x * z = z * x + 2 • w) (hxw : x * w = w * x + 3 • v) (hwz : w * z = z * w + 3 • s)
+    (hxv : Commute x v) (hxs : Commute x s) (hyz : Commute y z) (hwv : Commute w v)
+    (hzs : Commute z s) (hws : Commute w s) (hvs : Commute v s) (m n : ℕ) :
+    dividedPower m x * dividedPower n y =
+      ∑ p ∈ chainG2Index m n,
+        dividedPower (n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2) y * dividedPower p.1 z *
+          dividedPower p.2.1 w * dividedPower p.2.2.1 v * dividedPower p.2.2.2 s *
+          dividedPower (m - p.1 - 2 * p.2.1 - 3 * p.2.2.1 - 3 * p.2.2.2) x := by
+  classical
+  have hseries := dividedPower_mul_of_ad_dividedPower_series (x := x)
+    (d := g2Series y z w v s n)
+    (fun k => mul_g2Series hxy hxz hxw hwz hxv hxs hyz hwv hzs hws hvs n k) m
+  rw [g2Series_zero] at hseries
+  rw [hseries]
+  simp only [mul_assoc]
+  rw [← Finset.sum_fiberwise_of_maps_to
+    (g := fun p : ℕ × ℕ × ℕ × ℕ => p.1 + 2 * p.2.1 + 3 * p.2.2.1 + 3 * p.2.2.2)
+    (t := range (m + 1))
+    (fun p hp => Finset.mem_range.mpr (by have := mem_chainG2Index.mp hp; omega))
+    (fun p => dividedPower (n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2) y *
+      (dividedPower p.1 z * (dividedPower p.2.1 w * (dividedPower p.2.2.1 v *
+        (dividedPower p.2.2.2 s *
+          dividedPower (m - p.1 - 2 * p.2.1 - 3 * p.2.2.1 - 3 * p.2.2.2) x)))))]
+  refine Finset.sum_congr rfl fun k hk => ?_
+  have hkm : k ≤ m := Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)
+  have hfib : {p ∈ chainG2Index m n | p.1 + 2 * p.2.1 + 3 * p.2.2.1 + 3 * p.2.2.2 = k} =
+      g2SeriesIndex n k := by
+    ext p
+    simp only [Finset.mem_filter, mem_chainG2Index, mem_g2SeriesIndex]
+    omega
+  rw [hfib, g2Series, Finset.sum_mul]
+  refine Finset.sum_congr rfl fun p hp => ?_
+  have hp' := (mem_g2SeriesIndex.mp hp).2
+  have hq : m - p.1 - 2 * p.2.1 - 3 * p.2.2.1 - 3 * p.2.2.2 = m - k := by omega
+  rw [hq, g2Monomial]
+  simp only [mul_assoc]
+
+end TauCeti.Associative

--- a/TauCeti/RingTheory/Nilpotent/RootString/Basic.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/Basic.lean
@@ -5,7 +5,7 @@ Authors: Claude
 -/
 module
 
-public import TauCeti.RingTheory.DividedPowers.RootString
+public import TauCeti.RingTheory.DividedPowers.RootString.Basic
 public import TauCeti.RingTheory.Nilpotent.BaseChangeAction
 
 /-!
@@ -29,8 +29,9 @@ E_x(t) E_y(u) = E_y(u) E_z(t * u) E_w(t ^ 2 * u) E_x(t).
 
 This is the case of the Chevalley commutator formula in which the roots of the form `i α + j β`
 with `i, j > 0` are exactly `α + β` and `2 α + β`, covering the additional chains in types
-`B`, `C`, and `F₄`. Type `G₂` also needs the longer chain containing `3α + β`, which is not
-treated here. This extends the class-two case of
+`B`, `C`, and `F₄`. Type `G₂` also needs the longer chain containing `3α + β` and `3α + 2β`,
+which is `TauCeti.baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul` in
+`TauCeti.RingTheory.Nilpotent.RootString.G2`. This extends the class-two case of
 `TauCeti.baseChangeExp_mul_baseChangeExp_of_commutator_eq`. The parameter of the extra factor is
 `t ^ 2 * u`, matching the exponents `(i, j) = (2, 1)` of the root `2 α + β`.
 

--- a/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.RingTheory.DividedPowers.RootString.G2
+public import TauCeti.RingTheory.Nilpotent.RootString.Basic
+
+/-!
+# The Chevalley commutator relation in type `G₂`
+
+Let `V` be a module over a `ℚ`-algebra `A`, let `M ≤ V` be an additive subgroup, and let `x`, `y`,
+`z`, `w`, `v`, `s` be elements of `A` with
+
+```text
+x * y = y * x + z,   x * z = z * x + 2 • w,   x * w = w * x + 3 • v,   w * z = z * w + 3 • s,
+```
+
+`v` and `s` commuting with `x`, `y` commuting with `z`, `w` commuting with `v`, and `s` commuting
+with `z`, `w`, and `v`. The integral divided-power exponentials of the six elements act on
+`R ⊗[ℤ] M` over every commutative ring `R`, by `TauCeti.baseChangeExp`. The main result below is the
+**Chevalley commutator relation in type `G₂`**
+
+```text
+E_x(t) E_y(u) = E_y(u) E_z(t * u) E_w(t ^ 2 * u) E_v(t ^ 3 * u) E_s(t ^ 3 * u ^ 2) E_x(t).
+```
+
+This is the case of the Chevalley commutator formula in which the roots of the form `i α + j β`
+with `i, j > 0` are `α + β`, `2α + β`, `3α + β`, and `3α + 2β`. It occurs for the two simple roots
+of a root system of type `G₂`, `α` short and `β` long, and in no other type; it extends the chain
+`β`, `α + β`, `2α + β` of
+`TauCeti.baseChangeExp_mul_baseChangeExp_of_commutator_eq_two_nsmul`. The parameter of each factor
+is `t ^ i * u ^ j` for the root `i α + j β` it belongs to; in particular the last factor has the
+parameter `t ^ 3 * u ^ 2`, which is what makes this case not a chain in `ad x` alone. The one
+remaining type-`G₂` configuration, the pair `α`, `α + β`, is not treated here; see
+`TauCeti.RingTheory.DividedPowers.RootString.G2` for what it needs instead.
+
+Nothing here divides by a factorial in `R`, so the relation holds over a ring of arbitrary
+characteristic. The whole point is the coefficient-one straightening rule
+`TauCeti.Associative.dividedPower_mul_dividedPower_of_commutator_eq_three_nsmul`; the exponential
+identity is its generating-function form, and the parameters `u`, `t * u`, `t ^ 2 * u`, `t ^ 3 * u`,
+`t ^ 3 * u ^ 2`, `t` are exactly the six monomials into which `t ^ m u ^ n` factors.
+
+## Main results
+
+* `TauCeti.integralDividedPower_mul_integralDividedPower_of_commutator_eq_three_nsmul`: the
+  straightening rule for the integral operators restricted to `M`.
+* `TauCeti.baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul`: the Chevalley commutator
+  relation in type `G₂`.
+* `TauCeti.baseChangeExp_conj_of_commutator_eq_three_nsmul`: its conjugation form.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §4.2 and Theorem 5.2.2.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§25--26.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset TensorProduct
+
+universe u v
+
+variable {A : Type*} [Ring A] [Algebra ℚ A]
+variable {V : Type u} [AddCommGroup V] [Module A V]
+variable {S : Type*} [SetLike S V] [AddSubgroupClass S V]
+
+/-! ## Straightening the restricted operators -/
+
+/-- **Straightening restricted divided powers in type `G₂`.** The type-`G₂` straightening rule
+transported to the integral operators obtained by restricting divided powers to a stable additive
+subgroup. -/
+theorem integralDividedPower_mul_integralDividedPower_of_commutator_eq_three_nsmul
+    {x y z w v s : A} (M : S) (hxy : x * y = y * x + z) (hxz : x * z = z * x + 2 • w)
+    (hxw : x * w = w * x + 3 • v) (hwz : w * z = z * w + 3 • s) (hxv : Commute x v)
+    (hxs : Commute x s) (hyz : Commute y z) (hwv : Commute w v) (hzs : Commute z s)
+    (hws : Commute w s) (hvs : Commute v s)
+    (hMx : ∀ n, ∀ a ∈ M, Associative.dividedPower n x • a ∈ M)
+    (hMy : ∀ n, ∀ a ∈ M, Associative.dividedPower n y • a ∈ M)
+    (hMz : ∀ n, ∀ a ∈ M, Associative.dividedPower n z • a ∈ M)
+    (hMw : ∀ n, ∀ a ∈ M, Associative.dividedPower n w • a ∈ M)
+    (hMv : ∀ n, ∀ a ∈ M, Associative.dividedPower n v • a ∈ M)
+    (hMs : ∀ n, ∀ a ∈ M, Associative.dividedPower n s • a ∈ M)
+    (m n : ℕ) :
+    integralDividedPower x M m (hMx m) * integralDividedPower y M n (hMy n) =
+      ∑ p ∈ Associative.chainG2Index m n,
+        integralDividedPower y M (n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2)
+            (hMy (n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2)) *
+          integralDividedPower z M p.1 (hMz p.1) *
+          integralDividedPower w M p.2.1 (hMw p.2.1) *
+          integralDividedPower v M p.2.2.1 (hMv p.2.2.1) *
+          integralDividedPower s M p.2.2.2 (hMs p.2.2.2) *
+          integralDividedPower x M (m - p.1 - 2 * p.2.1 - 3 * p.2.2.1 - 3 * p.2.2.2)
+            (hMx (m - p.1 - 2 * p.2.1 - 3 * p.2.2.1 - 3 * p.2.2.2)) := by
+  ext a
+  simp only [Module.End.mul_apply, LinearMap.sum_apply, AddSubmonoidClass.coe_finsetSum,
+    coe_integralDividedPower_apply, ← mul_smul, ← Finset.sum_smul]
+  congr 1
+  simpa only [mul_assoc] using
+    Associative.dividedPower_mul_dividedPower_of_commutator_eq_three_nsmul
+      hxy hxz hxw hwz hxv hxs hyz hwv hzs hws hvs m n
+
+/-! ## The generating-function form of the straightening rule -/
+
+-- The combinatorial core: a truncated left factor times a truncated right factor is the reordered
+-- sextuple product, once the truncation is wide enough that the reindexed hypercube contains no
+-- extra nonzero terms. The reindexing is
+-- `(m, n, b, c, d, e) ↦ (n - b - c - d - 2e, b, c, d, e, m - b - 2c - 3d - 3e)`, and the monomial
+-- `t ^ m u ^ n` factors accordingly as
+-- `u ^ a (t u) ^ b (t ^ 2 u) ^ c (t ^ 3 u) ^ d (t ^ 3 u ^ 2) ^ e t ^ q`.
+-- The proof is the six-factor analogue of the argument in
+-- `TauCeti.RingTheory.Nilpotent.RootString.Basic`, and follows it step for step.
+private theorem sum_smul_mul_sum_smul_of_chainG2Order {R : Type*} [CommRing R]
+    {B : Type*} [Ring B] [Algebra R B] (Dx Dy Dz Dw Dv Ds : ℕ → B) (N : ℕ)
+    (hno : ∀ m n, Dx m * Dy n =
+      ∑ p ∈ Associative.chainG2Index m n,
+        Dy (n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2) * Dz p.1 * Dw p.2.1 * Dv p.2.2.1 *
+          Ds p.2.2.2 * Dx (m - p.1 - 2 * p.2.1 - 3 * p.2.2.1 - 3 * p.2.2.2))
+    (hzero : ∀ a b c d e q : ℕ,
+      N ≤ a + b + c + d + 2 * e ∨ N ≤ q + b + 2 * c + 3 * d + 3 * e →
+      Dy a * Dz b * Dw c * Dv d * Ds e * Dx q = 0)
+    (t u : R) :
+    (∑ m ∈ range N, t ^ m • Dx m) * (∑ n ∈ range N, u ^ n • Dy n) =
+      (∑ a ∈ range N, u ^ a • Dy a) * (∑ b ∈ range N, (t * u) ^ b • Dz b) *
+        (∑ c ∈ range N, (t ^ 2 * u) ^ c • Dw c) * (∑ d ∈ range N, (t ^ 3 * u) ^ d • Dv d) *
+        (∑ e ∈ range N, (t ^ 3 * u ^ 2) ^ e • Ds e) * (∑ q ∈ range N, t ^ q • Dx q) := by
+  classical
+  set G : ℕ × ℕ × ℕ × ℕ × ℕ × ℕ → B := fun w =>
+    (u ^ w.1 * (t * u) ^ w.2.1 * (t ^ 2 * u) ^ w.2.2.1 * (t ^ 3 * u) ^ w.2.2.2.1 *
+        (t ^ 3 * u ^ 2) ^ w.2.2.2.2.1 * t ^ w.2.2.2.2.2) •
+      (Dy w.1 * Dz w.2.1 * Dw w.2.2.1 * Dv w.2.2.2.1 * Ds w.2.2.2.2.1 * Dx w.2.2.2.2.2) with hG
+  -- Step 1: expand the reordered product over the full hypercube of indices.
+  have hbox : ∑ w ∈ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N, G w =
+      (∑ a ∈ range N, u ^ a • Dy a) * (∑ b ∈ range N, (t * u) ^ b • Dz b) *
+        (∑ c ∈ range N, (t ^ 2 * u) ^ c • Dw c) * (∑ d ∈ range N, (t ^ 3 * u) ^ d • Dv d) *
+        (∑ e ∈ range N, (t ^ 3 * u ^ 2) ^ e • Ds e) * (∑ q ∈ range N, t ^ q • Dx q) := by
+    rw [mul_assoc, mul_assoc, mul_assoc, mul_assoc, Finset.sum_mul_sum, Finset.sum_mul_sum,
+      Finset.sum_mul_sum, Finset.sum_mul_sum, Finset.sum_mul_sum]
+    simp only [hG, Finset.sum_product, Finset.mul_sum, smul_mul_smul_comm, mul_assoc]
+  -- Step 2: expand the original product over the reindexing domain.
+  have hsrc : ∑ w ∈ (range N ×ˢ range N).sigma
+        (fun mn => Associative.chainG2Index mn.1 mn.2),
+        (t ^ w.1.1 * u ^ w.1.2) •
+          (Dy (w.1.2 - w.2.1 - w.2.2.1 - w.2.2.2.1 - 2 * w.2.2.2.2) * Dz w.2.1 * Dw w.2.2.1 *
+            Dv w.2.2.2.1 * Ds w.2.2.2.2 *
+            Dx (w.1.1 - w.2.1 - 2 * w.2.2.1 - 3 * w.2.2.2.1 - 3 * w.2.2.2.2)) =
+      (∑ m ∈ range N, t ^ m • Dx m) * (∑ n ∈ range N, u ^ n • Dy n) := by
+    rw [Finset.sum_sigma, Finset.sum_mul_sum]
+    simp only [Finset.sum_product, smul_mul_smul_comm, hno, Finset.smul_sum]
+  -- Step 3: the reindexing itself, onto the part of the hypercube it covers.
+  have hbij : ∑ w ∈ (range N ×ˢ range N).sigma
+        (fun mn => Associative.chainG2Index mn.1 mn.2),
+        (t ^ w.1.1 * u ^ w.1.2) •
+          (Dy (w.1.2 - w.2.1 - w.2.2.1 - w.2.2.2.1 - 2 * w.2.2.2.2) * Dz w.2.1 * Dw w.2.2.1 *
+            Dv w.2.2.2.1 * Ds w.2.2.2.2 *
+            Dx (w.1.1 - w.2.1 - 2 * w.2.2.1 - 3 * w.2.2.2.1 - 3 * w.2.2.2.2)) =
+      ∑ w ∈ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N with
+        w.1 + w.2.1 + w.2.2.1 + w.2.2.2.1 + 2 * w.2.2.2.2.1 < N ∧
+          w.2.2.2.2.2 + w.2.1 + 2 * w.2.2.1 + 3 * w.2.2.2.1 + 3 * w.2.2.2.2.1 < N, G w := by
+    refine Finset.sum_nbij'
+      (fun w => (w.1.2 - w.2.1 - w.2.2.1 - w.2.2.2.1 - 2 * w.2.2.2.2, w.2.1, w.2.2.1, w.2.2.2.1,
+        w.2.2.2.2, w.1.1 - w.2.1 - 2 * w.2.2.1 - 3 * w.2.2.2.1 - 3 * w.2.2.2.2))
+      (fun w => ⟨(w.2.2.2.2.2 + w.2.1 + 2 * w.2.2.1 + 3 * w.2.2.2.1 + 3 * w.2.2.2.2.1,
+        w.1 + w.2.1 + w.2.2.1 + w.2.2.2.1 + 2 * w.2.2.2.2.1),
+        (w.2.1, w.2.2.1, w.2.2.2.1, w.2.2.2.2.1)⟩) ?_ ?_ ?_ ?_ ?_
+    · rintro ⟨⟨m, n⟩, b, c, d, e⟩ hw
+      simp only [Finset.mem_sigma, Finset.mem_product, Finset.mem_range,
+        Associative.mem_chainG2Index] at hw
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range]
+      omega
+    · rintro ⟨a, b, c, d, e, q⟩ hw
+      simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range] at hw
+      simp only [Finset.mem_sigma, Finset.mem_product, Finset.mem_range,
+        Associative.mem_chainG2Index]
+      omega
+    · rintro ⟨⟨m, n⟩, b, c, d, e⟩ hw
+      obtain ⟨h1, h2⟩ := Associative.mem_chainG2Index.mp (Finset.mem_sigma.mp hw).2
+      have hbn : b + c + d + 2 * e ≤ n := h1
+      have hbm : b + 2 * c + 3 * d + 3 * e ≤ m := h2
+      have e1 : m - b - 2 * c - 3 * d - 3 * e + b + 2 * c + 3 * d + 3 * e = m := by omega
+      have e2 : n - b - c - d - 2 * e + b + c + d + 2 * e = n := by omega
+      simp [e1, e2]
+    · rintro ⟨a, b, c, d, e, q⟩ _
+      have e1 : a + b + c + d + 2 * e - b - c - d - 2 * e = a := by omega
+      have e2 : q + b + 2 * c + 3 * d + 3 * e - b - 2 * c - 3 * d - 3 * e = q := by omega
+      simp [e1, e2]
+    · rintro ⟨⟨m, n⟩, b, c, d, e⟩ hw
+      simp only [Finset.mem_sigma, Finset.mem_product, Finset.mem_range,
+        Associative.mem_chainG2Index] at hw
+      obtain ⟨a, rfl⟩ : ∃ a, n = a + (b + c + d + 2 * e) := ⟨n - b - c - d - 2 * e, by omega⟩
+      obtain ⟨q, rfl⟩ : ∃ q, m = q + (b + 2 * c + 3 * d + 3 * e) :=
+        ⟨m - b - 2 * c - 3 * d - 3 * e, by omega⟩
+      have h1 : a + (b + c + d + 2 * e) - b - c - d - 2 * e = a := by omega
+      have h2 : q + (b + 2 * c + 3 * d + 3 * e) - b - 2 * c - 3 * d - 3 * e = q := by omega
+      simp only [hG, h1, h2]
+      congr 1
+      simp only [mul_pow, pow_add, pow_mul]
+      ring
+  -- Step 4: the terms of the hypercube outside that part vanish.
+  have hsub : ∑ w ∈ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N with
+        w.1 + w.2.1 + w.2.2.1 + w.2.2.2.1 + 2 * w.2.2.2.2.1 < N ∧
+          w.2.2.2.2.2 + w.2.1 + 2 * w.2.2.1 + 3 * w.2.2.2.1 + 3 * w.2.2.2.2.1 < N, G w =
+      ∑ w ∈ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N ×ˢ range N, G w := by
+    refine Finset.sum_subset (Finset.filter_subset _ _) ?_
+    rintro ⟨a, b, c, d, e, q⟩ hmem hnot
+    simp only [Finset.mem_product, Finset.mem_range] at hmem
+    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_range] at hnot
+    have hor : N ≤ a + b + c + d + 2 * e ∨ N ≤ q + b + 2 * c + 3 * d + 3 * e := by omega
+    simp [hG, hzero a b c d e q hor]
+  rw [← hsrc, hbij, hsub, hbox]
+
+/-! ## The Chevalley commutator relation -/
+
+section Commutator
+
+variable {R : Type v} [CommRing R] [Algebra ℤ R]
+
+-- Match tensor products to the module structure carried by the explicit `ℤ`-algebra.
+attribute [local instance high] Algebra.toModule
+
+/-- **The Chevalley commutator relation in type `G₂`.** If
+
+```text
+x * y = y * x + z,   x * z = z * x + 2 • w,   x * w = w * x + 3 • v,   w * z = z * w + 3 • s,
+```
+
+with `v` and `s` commuting with `x`, `y` commuting with `z`, `w` commuting with `v`, and `s`
+commuting with `z`, `w`, and `v`, then over every commutative ring `R` the integral divided-power
+exponentials on `R ⊗[ℤ] M` satisfy
+
+```text
+E_x(t) E_y(u) = E_y(u) E_z(t * u) E_w(t ^ 2 * u) E_v(t ^ 3 * u) E_s(t ^ 3 * u ^ 2) E_x(t).
+```
+
+No factorial is inverted in `R`: the relation holds in every characteristic. -/
+theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul
+    {x y z w v s : A} (M : S) (hxy : x * y = y * x + z) (hxz : x * z = z * x + 2 • w)
+    (hxw : x * w = w * x + 3 • v) (hwz : w * z = z * w + 3 • s) (hxv : Commute x v)
+    (hxs : Commute x s) (hyz : Commute y z) (hwv : Commute w v) (hzs : Commute z s)
+    (hws : Commute w s) (hvs : Commute v s)
+    (hx : IsNilpotent x) (hy : IsNilpotent y) (hz : IsNilpotent z) (hw : IsNilpotent w)
+    (hMx : ∀ n, ∀ a ∈ M, Associative.dividedPower n x • a ∈ M)
+    (hMy : ∀ n, ∀ a ∈ M, Associative.dividedPower n y • a ∈ M)
+    (hMz : ∀ n, ∀ a ∈ M, Associative.dividedPower n z • a ∈ M)
+    (hMw : ∀ n, ∀ a ∈ M, Associative.dividedPower n w • a ∈ M)
+    (hMv : ∀ n, ∀ a ∈ M, Associative.dividedPower n v • a ∈ M)
+    (hMs : ∀ n, ∀ a ∈ M, Associative.dividedPower n s • a ∈ M)
+    (t u : R) :
+    baseChangeExp x M hMx t * baseChangeExp y M hMy u =
+      baseChangeExp y M hMy u * baseChangeExp z M hMz (t * u) *
+        baseChangeExp w M hMw (t ^ 2 * u) * baseChangeExp v M hMv (t ^ 3 * u) *
+        baseChangeExp s M hMs (t ^ 3 * u ^ 2) * baseChangeExp x M hMx t := by
+  classical
+  obtain ⟨kx, hkx⟩ := hx
+  obtain ⟨ky, hky⟩ := hy
+  obtain ⟨kz, hkz⟩ := hz
+  obtain ⟨kw, hkw⟩ := hw
+  obtain ⟨kv, hkv⟩ := Associative.isNilpotent_of_commutator_eq_nsmul (by decide)
+    hxw hxv hwv ⟨kx, hkx⟩
+  obtain ⟨ks, hks⟩ := Associative.isNilpotent_of_commutator_eq_nsmul (by decide)
+    hwz hws hzs ⟨kw, hkw⟩
+  set N := kx + ky + kz + 2 * kw + 3 * kv + 3 * ks with hNdef
+  have hxN : x ^ N = 0 := pow_eq_zero_of_le (by omega) hkx
+  have hyN : y ^ N = 0 := pow_eq_zero_of_le (by omega) hky
+  have hzN : z ^ N = 0 := pow_eq_zero_of_le (by omega) hkz
+  have hwN : w ^ N = 0 := pow_eq_zero_of_le (by omega) hkw
+  have hvN : v ^ N = 0 := pow_eq_zero_of_le (by omega) hkv
+  have hsN : s ^ N = 0 := pow_eq_zero_of_le (by omega) hks
+  rw [baseChangeExp_of_pow_eq_zero x M hMx hxN, baseChangeExp_of_pow_eq_zero y M hMy hyN,
+    baseChangeExp_of_pow_eq_zero z M hMz hzN, baseChangeExp_of_pow_eq_zero w M hMw hwN,
+    baseChangeExp_of_pow_eq_zero v M hMv hvN, baseChangeExp_of_pow_eq_zero s M hMs hsN]
+  refine sum_smul_mul_sum_smul_of_chainG2Order (R := R)
+    (fun n => (integralDividedPower x M n (hMx n)).baseChange R)
+    (fun n => (integralDividedPower y M n (hMy n)).baseChange R)
+    (fun n => (integralDividedPower z M n (hMz n)).baseChange R)
+    (fun n => (integralDividedPower w M n (hMw n)).baseChange R)
+    (fun n => (integralDividedPower v M n (hMv n)).baseChange R)
+    (fun n => (integralDividedPower s M n (hMs n)).baseChange R) N ?_ ?_ t u
+  · intro m n
+    have h := congrArg (fun f : Module.End ℤ M => (Module.End.baseChangeHom ℤ R M) f)
+      (integralDividedPower_mul_integralDividedPower_of_commutator_eq_three_nsmul
+        M hxy hxz hxw hwz hxv hxs hyz hwv hzs hws hvs hMx hMy hMz hMw hMv hMs m n)
+    simp only [map_mul, map_sum] at h
+    exact h
+  · -- Outside the truncation the reordered sextuple has a vanishing factor.
+    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 := by
+      intro q hq
+      rw [integralDividedPower_eq_zero_of_le x M q (hMx q) hkx hq, LinearMap.baseChange_zero]
+    have hvy : ∀ a, ky ≤ a → (integralDividedPower y M a (hMy a)).baseChange R = 0 := by
+      intro a ha
+      rw [integralDividedPower_eq_zero_of_le y M a (hMy a) hky ha, LinearMap.baseChange_zero]
+    have hvz : ∀ b, kz ≤ b → (integralDividedPower z M b (hMz b)).baseChange R = 0 := by
+      intro b hb
+      rw [integralDividedPower_eq_zero_of_le z M b (hMz b) hkz hb, LinearMap.baseChange_zero]
+    have hvw : ∀ c, kw ≤ c → (integralDividedPower w M c (hMw c)).baseChange R = 0 := by
+      intro c hc
+      rw [integralDividedPower_eq_zero_of_le w M c (hMw c) hkw hc, LinearMap.baseChange_zero]
+    have hvv : ∀ d, kv ≤ d → (integralDividedPower v M d (hMv d)).baseChange R = 0 := by
+      intro d hd
+      rw [integralDividedPower_eq_zero_of_le v M d (hMv d) hkv hd, LinearMap.baseChange_zero]
+    have hvs' : ∀ e, ks ≤ e → (integralDividedPower s M e (hMs e)).baseChange R = 0 := by
+      intro e he
+      rw [integralDividedPower_eq_zero_of_le s M e (hMs e) hks he, LinearMap.baseChange_zero]
+    rintro a b c d e q (habc | hqbc)
+    · rcases le_or_gt ky a with ha | ha
+      · simp [hvy a ha]
+      · rcases le_or_gt kz b with hb | hb
+        · simp [hvz b hb]
+        · rcases le_or_gt kw c with hc | hc
+          · simp [hvw c hc]
+          · rcases le_or_gt kv d with hd | hd
+            · simp [hvv d hd]
+            · simp [hvs' e (by omega)]
+    · rcases le_or_gt kx q with hq | hq
+      · simp [hvx q hq]
+      · rcases le_or_gt kz b with hb | hb
+        · simp [hvz b hb]
+        · rcases le_or_gt kw c with hc | hc
+          · simp [hvw c hc]
+          · rcases le_or_gt kv d with hd | hd
+            · simp [hvv d hd]
+            · simp [hvs' e (by omega)]
+
+/-- The conjugation form of the Chevalley commutator relation in type `G₂`: conjugating the
+one-parameter subgroup of `y` by that of `x` multiplies it by the one-parameter subgroups of `z`,
+`w`, `v`, and `s`, at the parameters `t * u`, `t ^ 2 * u`, `t ^ 3 * u`, and `t ^ 3 * u ^ 2`. -/
+theorem baseChangeExp_conj_of_commutator_eq_three_nsmul
+    {x y z w v s : A} (M : S) (hxy : x * y = y * x + z) (hxz : x * z = z * x + 2 • w)
+    (hxw : x * w = w * x + 3 • v) (hwz : w * z = z * w + 3 • s) (hxv : Commute x v)
+    (hxs : Commute x s) (hyz : Commute y z) (hwv : Commute w v) (hzs : Commute z s)
+    (hws : Commute w s) (hvs : Commute v s)
+    (hx : IsNilpotent x) (hy : IsNilpotent y) (hz : IsNilpotent z) (hw : IsNilpotent w)
+    (hMx : ∀ n, ∀ a ∈ M, Associative.dividedPower n x • a ∈ M)
+    (hMy : ∀ n, ∀ a ∈ M, Associative.dividedPower n y • a ∈ M)
+    (hMz : ∀ n, ∀ a ∈ M, Associative.dividedPower n z • a ∈ M)
+    (hMw : ∀ n, ∀ a ∈ M, Associative.dividedPower n w • a ∈ M)
+    (hMv : ∀ n, ∀ a ∈ M, Associative.dividedPower n v • a ∈ M)
+    (hMs : ∀ n, ∀ a ∈ M, Associative.dividedPower n s • a ∈ M)
+    (t u : R) :
+    baseChangeExp x M hMx t * baseChangeExp y M hMy u * baseChangeExp x M hMx (-t) =
+      baseChangeExp y M hMy u * baseChangeExp z M hMz (t * u) *
+        baseChangeExp w M hMw (t ^ 2 * u) * baseChangeExp v M hMv (t ^ 3 * u) *
+        baseChangeExp s M hMs (t ^ 3 * u ^ 2) := by
+  rw [baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul M hxy hxz hxw hwz hxv hxs hyz
+      hwv hzs hws hvs hx hy hz hw hMx hMy hMz hMw hMv hMs t u,
+    mul_assoc, ← baseChangeExp_add x M hMx hx t (-t), add_neg_cancel,
+    baseChangeExp_zero x M hMx hx, mul_one]
+
+end Commutator
+
+end TauCeti


### PR DESCRIPTION
This PR proves the Chevalley commutator relation in type `G₂`, the one case of the Chevalley commutator formula that the repository did not yet cover. For the two simple roots of `G₂`, `α` short and `β` long, the roots `iα + jβ` with `i, j > 0` are `α + β`, `2α + β`, `3α + β`, and `3α + 2β`, and the integral divided-power exponentials satisfy `E_x(t) E_y(u) = E_y(u) E_z(t u) E_w(t² u) E_v(t³ u) E_s(t³ u²) E_x(t)` over a commutative ring of any characteristic. Underneath it is the coefficient-one straightening rule `x⁽ᵐ⁾ y⁽ⁿ⁾ = ∑ y⁽ⁿ⁻ᵇ⁻ᶜ⁻ᵈ⁻²ᵉ⁾ z⁽ᵇ⁾ w⁽ᶜ⁾ v⁽ᵈ⁾ s⁽ᵉ⁾ x⁽ᵐ⁻ᵇ⁻²ᶜ⁻³ᵈ⁻³ᵉ⁾ over `b + c + d + 2e ≤ n`, `b + 2c + 3d + 3e ≤ m`, proved by feeding the existing `dividedPower_mul_of_ad_dividedPower_series` the sequence `d k = ∑_{b + 2c + 3d + 3e = k} y⁽ⁿ⁻ᵇ⁻ᶜ⁻ᵈ⁻²ᵉ⁾ z⁽ᵇ⁾ w⁽ᶜ⁾ v⁽ᵈ⁾ s⁽ᵉ⁾`.

What is genuinely new over the chain `β`, `α + β`, `2α + β` of TauCeti#3513 is that `3α + 2β` does not lie on the `α`-string through `β`. It enters through the bracket `w * z = z * w + 3 • s` of the root vectors of `α + β` and `2α + β`, which the Jacobi identity forces from the other brackets (`commutator_eq_three_nsmul_of_commute`). Consequently `z` no longer commutes with `w`, and moving `x` across `z⁽ᵇ⁾` releases two terms rather than one: `x z⁽ᵇ⁾ = z⁽ᵇ⁾ x + 2 z⁽ᵇ⁻¹⁾ w + 3 z⁽ᵇ⁻²⁾ s`, again with integral coefficients (`mul_dividedPower_of_commutator_eq_two_nsmul`). Every hypothesis is a bracket of Chevalley root vectors in `G₂` and nothing is divided by a factorial in the value ring, so the relation restricts to a Kostant integral form and survives base change to any characteristic.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 9 "pinned Chevalley–Demazure group schemes over `ℤ`", the bullet "Root subgroup maps. `x_α : 𝔾_a → G` for each root `α`, the Chevalley commutator relations they satisfy". The designated consumer is `CFSGStatement` milestone L0, "pinned ambient groups", whose `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup` are built from these root subgroups, and whose Lie-type families include `G₂(q)` and `²G₂(3^(2m+1))`; the relations are the interface L1 and L2 state their Steinberg-map conventions against. I switched from `CFSGStatement` to this prerequisite because L0 there consumes Layer 9 rather than restating it, so `CFSGStatement` cannot advance until Layer 9 supplies the pinned group and its root-subgroup relations. This was the most effective step because the `G₂` relation is the one Chevalley commutator case still named as outstanding in the Layer 9 work in flight (TauCeti#3559 lists "the remaining `G₂` commutator relation"), and no open pull request touches it.

After this PR, the relation holds for `TauCeti.baseChangeExp`, which is exactly what `kostantRootSubgroupPoints` is defined from. What remains for this bullet of Layer 9 is transporting it to `kostantRootSubgroupPoints` in `Kostant/RootSubgroup/Commutator.lean` alongside the class-two and chain-`2α + β` relations already there — that needs a decision about how to normalise the integer structure constants of the two deepest brackets on the Lie side, which is why it is left out here rather than guessed at — and the one remaining `G₂` configuration, the pair `α`, `α + β`, whose extra factor at `3α + 2β` carries the exponents `(1, 2)` and comes from `⁅y, ⁅x, y⁆⁆`. Both are recorded in the module docs. Layer 9 as a whole still needs the finite free admissible lattice, assembly of the pinned group scheme, the pinned isomorphism theorem, and the characteristic-two and -three special isogenies.

Two files are added, `TauCeti/RingTheory/DividedPowers/RootString/G2.lean` (593 lines) and `TauCeti/RingTheory/Nilpotent/RootString/G2.lean` (356 lines). Since the tree may not hold two flat `RootString*.lean` siblings, the two existing modules move as I add:

| old module | new module |
| --- | --- |
| `TauCeti.RingTheory.DividedPowers.RootString` | `TauCeti.RingTheory.DividedPowers.RootString.Basic` |
| `TauCeti.RingTheory.Nilpotent.RootString` | `TauCeti.RingTheory.Nilpotent.RootString.Basic` |

Only imports and module headers change; no declaration is renamed. The private helper `mul_dividedPower_of_commutator_eq'` moves from the first of those files to `NormalOrdering.lean`, beside the theorem whose successor pattern it removes, and becomes public so both root-string files use one copy. Prose cross-references in the two moved modules and in `Kostant/RootSubgroup/Commutator.lean` are updated to point at the new material instead of saying `G₂` is untreated.

No Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

Dependency edge: `CFSGStatement` L0 ("pinned ambient groups", producing `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup`) depends on `ReductiveGroups` Layer 9 ("Root subgroup maps ... the Chevalley commutator relations they satisfy"), which this PR advances.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"g2-chevalley-commutator-relation"}-->

🤖 Prepared with Claude Code
