### PR TITLE
Complete operator-level Marcinkiewicz and Lp maximal APIs

### DIFF
--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -326,20 +326,16 @@ theorem mul_measure_ofReal_lt_operator_le_setLIntegral
   set g₁ : α → G := S.indicator g with hg₁def
   set g₂ : α → G := Sᶜ.indicator g with hg₂def
   have hsplit : g₁ + g₂ = g := by
-    funext x
-    exact Set.indicator_self_add_compl_apply S g x
+    rw [hg₁def, hg₂def, Set.indicator_self_add_compl]
   have hTv : T v =ᵐ[ν] T (g₁ + g₂) := by
     apply hcongr
     filter_upwards [hvg] with x hx
     rw [hsplit, hx]
   have hg₂bound : ∀ x, ‖g₂ x‖ₑ ≤ ENNReal.ofReal (c * t) := by
     intro x
-    rw [hg₂def]
-    by_cases hxS : x ∈ S
-    · rw [Set.indicator_of_notMem (by simp [hxS]), enorm_zero]
-      exact zero_le
-    · rw [Set.indicator_of_mem (by simp [hxS])]
-      exact not_lt.1 (by simpa [hSdef] using hxS)
+    rw [hg₂def, enorm_indicator_eq_indicator_enorm]
+    exact Set.indicator_apply_le'
+      (fun hx => not_lt.1 (by simpa [hSdef] using hx)) (fun _ => zero_le)
   have hTg₂ : ∀ᵐ y ∂ν, T g₂ y ≤ ENNReal.ofReal (b * (c * t)) := by
     filter_upwards [hinfty g₂] with y hy
     exact hy.trans (calc
@@ -372,10 +368,9 @@ theorem mul_measure_ofReal_lt_operator_le_setLIntegral
       exact congrArg (fun z : ℝ≥0∞ => ENNReal.ofReal (c * t) < z) hx
     calc ∫⁻ x, ‖g₁ x‖ₑ ∂μ
         = ∫⁻ x in S, ‖g x‖ₑ ∂μ := by
-          rw [← lintegral_indicator hSmeas]
-          congr 1
-          funext x
-          by_cases hx : x ∈ S <;> simp [hg₁def, hx]
+          rw [hg₁def]
+          simp_rw [enorm_indicator_eq_indicator_enorm]
+          exact lintegral_indicator hSmeas _
       _ = ∫⁻ x in S, ‖v x‖ₑ ∂μ :=
         (lintegral_congr_ae (ae_restrict_of_ae henorm)).symm
       _ = ∫⁻ x in {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ}, ‖v x‖ₑ ∂μ := by

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -6,8 +6,6 @@ module
 
 public import TauCeti.Analysis.SpecialFunctions.Pow.Integral
 public import Mathlib.MeasureTheory.Function.LpSeminorm.Defs
--- The stronger seminorm API is used only in the operator-level proof.
-import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 -- `Mathlib.MeasureTheory.Measure.Prod` is imported privately: the product measure and
 -- Tonelli's theorem appear only inside the proof below.
 import Mathlib.MeasureTheory.Measure.Prod
@@ -26,13 +24,13 @@ The analytic engine is stated in terms of the **distribution functions** of `T f
 The operator-level theorem then derives its hypothesis from subadditivity, weak type `(1,1)`, and
 an `L^∞` bound. For each height `t`, these hypotheses produce the single inequality
 
-`t * ν {T f > t} ≤ A * ∫⁻ x in {‖f‖ > c * t}, ‖f‖ ∂μ`,
+`t * ν {T f > t} ≤ d⁻¹ * A * ∫⁻ x in {‖f‖ > c * t}, ‖f‖ ∂μ`,
 
 which says that only the part of `f` above the height `c * t` can push `T f` above `t`. That
 inequality is the hypothesis of `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`, and its
 conclusion is the `L^p` bound
 
-`∫⁻ (T f) ^ p ∂ν ≤ (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ ‖f‖ ^ p ∂μ`.
+`∫⁻ (T f) ^ p ∂ν ≤ (p * c ^ (1 - p) / (p - 1)) * d⁻¹ * A * ∫⁻ ‖f‖ ^ p ∂μ`.
 
 Retaining this distributional lemma keeps the analytic engine usable even when `T` is not defined
 on a whole function space. The operator theorem lets `μ` and `ν` live on different spaces and makes
@@ -57,9 +55,10 @@ exhausted by the level sets `{f ≥ 1 / (n + 1)}`, each of finite measure by Che
 ## Main declarations
 
 * `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`: the interpolation estimate.
-* `TauCeti.mul_measure_ofReal_lt_operator_le_setLIntegral`: the reusable truncation argument from
+* `TauCeti.mul_meas_ofReal_lt_le_setLIntegral`: the reusable truncation argument from
   subadditivity and the two endpoint bounds.
-* `TauCeti.lintegral_rpow_operator_le`: operator-level Marcinkiewicz interpolation.
+* `TauCeti.lintegral_rpow_le_of_mul_meas_lt_le_of_le_eLpNormEssSup`: operator-level
+  Marcinkiewicz interpolation.
 
 ## References
 
@@ -286,13 +285,13 @@ theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le
 
 section Operator
 
-variable {G : Type*} [MeasurableSpace G] [TopologicalSpace G] [BorelSpace G]
+variable {G : Type*} [MeasurableSpace G] [TopologicalSpace G] [OpensMeasurableSpace G]
   [ESeminormedAddMonoid G] {T : (α → G) → β → ℝ≥0∞} {v : α → G} {b d t : ℝ}
 
 /-- The reusable operator-level truncation argument for Marcinkiewicz interpolation.
 
-Suppose `T` respects almost-everywhere equality, is subadditive, is of weak type `(1,1)` with
-constant `A`, and obeys the `L^∞` bound `T g ≤ b · ‖g‖_∞`. Split `v` according to whether its
+Suppose `T` is subadditive, is of weak type `(1,1)` with constant `A`, and obeys the `L^∞`
+bound `T g ≤ b · ‖g‖_∞`. Split `v` according to whether its
 extended norm exceeds `c * t`. If `b * c + d ≤ 1`, then the low part contributes at most
 `b * c * t`, so `T v > t` forces the image of the high part to exceed `d * t`. Applying the
 weak-type bound to that high part gives
@@ -301,15 +300,14 @@ weak-type bound to that high part gives
 
 The parameters `c` and `d` expose the choice of truncation rather than fixing the customary
 `c = d = 1 / 2` for a normalized `L^∞` bound. -/
-theorem mul_measure_ofReal_lt_operator_le_setLIntegral
+theorem mul_meas_ofReal_lt_le_setLIntegral
     (hv : AEMeasurable v μ) (ht : 0 < t) (hb : 0 ≤ b) (hc : 0 < c) (hd : 0 < d)
     (hbcd : b * c + d ≤ 1)
-    (hcongr : ∀ {g h : α → G}, g =ᵐ[μ] h → T g =ᵐ[ν] T h)
-    (hadd : ∀ (g h : α → G), AEMeasurable g μ →
+    (hadd : ∀ (g h : α → G), AEMeasurable g μ → AEMeasurable h μ →
       T (g + h) ≤ᵐ[ν] T g + T h)
     (hweak : ∀ (g : α → G), AEMeasurable g μ → ∀ s : ℝ≥0∞,
       s * ν {y | s < T g y} ≤ A * ∫⁻ x, ‖g x‖ₑ ∂μ)
-    (hinfty : ∀ (g : α → G), T g ≤ᵐ[ν]
+    (hinfty : ∀ (g : α → G), AEMeasurable g μ → T g ≤ᵐ[ν]
       fun _ => ENNReal.ofReal b * eLpNormEssSup g μ) :
     ENNReal.ofReal t * ν {y | ENNReal.ofReal t < T v y} ≤
       ENNReal.ofReal d⁻¹ * A *
@@ -323,33 +321,35 @@ theorem mul_measure_ofReal_lt_operator_le_setLIntegral
   have hgmeas : Measurable g := hv.measurable_mk
   set S : Set α := {x | ENNReal.ofReal (c * t) < ‖g x‖ₑ} with hSdef
   have hSmeas : MeasurableSet S := measurableSet_lt measurable_const hgmeas.enorm
-  set g₁ : α → G := S.indicator g with hg₁def
-  set g₂ : α → G := Sᶜ.indicator g with hg₂def
-  have hsplit : g₁ + g₂ = g := by
+  set g₁ : α → G := S.indicator v with hg₁def
+  set g₂ : α → G := Sᶜ.indicator v with hg₂def
+  have hg₁meas : AEMeasurable g₁ μ := hv.indicator hSmeas
+  have hg₂meas : AEMeasurable g₂ μ := hv.indicator hSmeas.compl
+  have hsplit : g₁ + g₂ = v := by
     rw [hg₁def, hg₂def, Set.indicator_self_add_compl]
-  have hTv : T v =ᵐ[ν] T (g₁ + g₂) := by
-    apply hcongr
+  have hTv : T v ≤ᵐ[ν] T g₁ + T g₂ := by
+    rw [← hsplit]
+    exact hadd g₁ g₂ hg₁meas hg₂meas
+  have hg₂bound : ∀ᵐ x ∂μ, ‖g₂ x‖ₑ ≤ ENNReal.ofReal (c * t) := by
     filter_upwards [hvg] with x hx
-    rw [hsplit, hx]
-  have hg₂bound : ∀ x, ‖g₂ x‖ₑ ≤ ENNReal.ofReal (c * t) := by
-    intro x
-    rw [hg₂def, enorm_indicator_eq_indicator_enorm]
-    exact Set.indicator_apply_le'
-      (fun hx => not_lt.1 (by simpa [hSdef] using hx)) (fun _ => zero_le)
+    rw [hg₂def]
+    by_cases hxS : x ∈ S
+    · rw [Set.indicator_of_notMem (by simp [hxS]), enorm_zero]
+      exact zero_le
+    · rw [Set.indicator_of_mem (by simp [hxS]), hx]
+      exact not_lt.1 (by simpa [hSdef] using hxS)
   have hTg₂ : ∀ᵐ y ∂ν, T g₂ y ≤ ENNReal.ofReal (b * (c * t)) := by
-    filter_upwards [hinfty g₂] with y hy
+    filter_upwards [hinfty g₂ hg₂meas] with y hy
     exact hy.trans (calc
       ENNReal.ofReal b * eLpNormEssSup g₂ μ
           ≤ ENNReal.ofReal b * ENNReal.ofReal (c * t) := by
             gcongr
-            exact essSup_le_of_ae_le _ (.of_forall hg₂bound)
+            exact essSup_le_of_ae_le _ hg₂bound
       _ = ENNReal.ofReal (b * (c * t)) := by rw [ENNReal.ofReal_mul hb])
   have hincl : {y | ENNReal.ofReal t < T v y} ≤ᵐ[ν]
       {y | ENNReal.ofReal (d * t) < T g₁ y} := by
-    filter_upwards [hTv, hadd g₁ g₂ (hgmeas.indicator hSmeas).aemeasurable, hTg₂]
-      with y hTy hsum hlow
+    filter_upwards [hTv, hTg₂] with y hsum hlow
     intro hy
-    have hsum' : T v y ≤ T g₁ y + T g₂ y := hTy.le.trans hsum
     have hconst : ENNReal.ofReal (d * t) + ENNReal.ofReal (b * (c * t)) ≤
         ENNReal.ofReal t := by
       rw [← ENNReal.ofReal_add hdt hbct]
@@ -357,7 +357,7 @@ theorem mul_measure_ofReal_lt_operator_le_setLIntegral
       nlinarith [mul_nonneg (sub_nonneg.2 hbcd) ht.le]
     have hlt : ENNReal.ofReal (d * t) + ENNReal.ofReal (b * (c * t)) <
         T g₁ y + ENNReal.ofReal (b * (c * t)) :=
-      hconst.trans_lt (hy.trans_le (hsum'.trans (add_le_add le_rfl hlow)))
+      hconst.trans_lt (hy.trans_le (hsum.trans (add_le_add le_rfl hlow)))
     exact (ENNReal.add_lt_add_iff_right ENNReal.ofReal_ne_top).1 hlt
   have hint : ∫⁻ x, ‖g₁ x‖ₑ ∂μ =
       ∫⁻ x in {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ}, ‖v x‖ₑ ∂μ := by
@@ -367,12 +367,10 @@ theorem mul_measure_ofReal_lt_operator_le_setLIntegral
       filter_upwards [henorm] with x hx
       exact congrArg (fun z : ℝ≥0∞ => ENNReal.ofReal (c * t) < z) hx
     calc ∫⁻ x, ‖g₁ x‖ₑ ∂μ
-        = ∫⁻ x in S, ‖g x‖ₑ ∂μ := by
+        = ∫⁻ x in S, ‖v x‖ₑ ∂μ := by
           rw [hg₁def]
           simp_rw [enorm_indicator_eq_indicator_enorm]
           exact lintegral_indicator hSmeas _
-      _ = ∫⁻ x in S, ‖v x‖ₑ ∂μ :=
-        (lintegral_congr_ae (ae_restrict_of_ae henorm)).symm
       _ = ∫⁻ x in {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ}, ‖v x‖ₑ ∂μ := by
           rw [Measure.restrict_congr_set hsets]
   calc ENNReal.ofReal t * ν {y | ENNReal.ofReal t < T v y}
@@ -387,7 +385,7 @@ theorem mul_measure_ofReal_lt_operator_le_setLIntegral
           (ENNReal.ofReal d⁻¹)
     _ ≤ ENNReal.ofReal d⁻¹ * (A * ∫⁻ x, ‖g₁ x‖ₑ ∂μ) := by
         exact mul_le_mul_right
-          (hweak g₁ (hgmeas.indicator hSmeas).aemeasurable (ENNReal.ofReal (d * t)))
+          (hweak g₁ hg₁meas (ENNReal.ofReal (d * t)))
           (ENNReal.ofReal d⁻¹)
     _ = ENNReal.ofReal d⁻¹ * A *
           ∫⁻ x in {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ}, ‖v x‖ₑ ∂μ := by
@@ -395,27 +393,25 @@ theorem mul_measure_ofReal_lt_operator_le_setLIntegral
 
 /-- **Marcinkiewicz interpolation at operator level**, between weak type `(1,1)` and `L^∞`.
 
-This packages the operator-specific truncation step: a subadditive operator which respects a.e.
-equality, has weak-type constant `A`, and has `L^∞` constant `b` is strong type `(p,p)` for
+This packages the operator-specific truncation step: a subadditive operator with weak-type
+constant `A` and `L^∞` constant `b` is strong type `(p,p)` for
 `1 < p < ∞`. The positive splitting parameters `c, d` may be chosen arbitrarily subject to
 `b * c + d ≤ 1`. -/
-theorem lintegral_rpow_operator_le
+theorem lintegral_rpow_le_of_mul_meas_lt_le_of_le_eLpNormEssSup
     (hv : AEMeasurable v μ) (hTv : AEMeasurable (T v) ν) (hp : 1 < p)
     (hb : 0 ≤ b) (hc : 0 < c) (hd : 0 < d) (hbcd : b * c + d ≤ 1)
-    (hcongr : ∀ {g h : α → G}, g =ᵐ[μ] h → T g =ᵐ[ν] T h)
-    (hadd : ∀ (g h : α → G), AEMeasurable g μ →
+    (hadd : ∀ (g h : α → G), AEMeasurable g μ → AEMeasurable h μ →
       T (g + h) ≤ᵐ[ν] T g + T h)
     (hweak : ∀ (g : α → G), AEMeasurable g μ → ∀ s : ℝ≥0∞,
       s * ν {y | s < T g y} ≤ A * ∫⁻ x, ‖g x‖ₑ ∂μ)
-    (hinfty : ∀ (g : α → G), T g ≤ᵐ[ν]
+    (hinfty : ∀ (g : α → G), AEMeasurable g μ → T g ≤ᵐ[ν]
       fun _ => ENNReal.ofReal b * eLpNormEssSup g μ) :
     ∫⁻ y, T v y ^ p ∂ν ≤
       ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * (ENNReal.ofReal d⁻¹ * A) *
         ∫⁻ x, ‖v x‖ₑ ^ p ∂μ := by
   apply lintegral_rpow_le_of_mul_meas_ofReal_lt_le hv.enorm hTv hp hc
   intro t ht
-  exact mul_measure_ofReal_lt_operator_le_setLIntegral
-    hv ht hb hc hd hbcd hcongr hadd hweak hinfty
+  exact mul_meas_ofReal_lt_le_setLIntegral hv ht hb hc hd hbcd hadd hweak hinfty
 
 end Operator
 

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.SpecialFunctions.Pow.Integral
+public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 -- `Mathlib.MeasureTheory.Measure.Prod` is imported privately: the product measure and
 -- Tonelli's theorem appear only inside the proof below.
 import Mathlib.MeasureTheory.Measure.Prod
@@ -17,11 +18,11 @@ is bounded on `L^p` for every `1 < p < ∞`. This is the diagonal case `p₀ = 1
 Marcinkiewicz interpolation theorem, and it is the mechanism that turns the Hardy–Littlewood
 maximal inequality into the strong `(p,p)` bounds, item 9 of Lane B of the PDE roadmap.
 
-## The statement proved here
+## The statements proved here
 
-Interpolation arguments run entirely on the **distribution functions** of `T f` and of `f`, so the
-theorem is stated in that form rather than in terms of a bundled operator: the sublinearity of `T`
-and its two endpoint bounds are used only to produce, for each height `t`, the single inequality
+The analytic engine is stated in terms of the **distribution functions** of `T f` and of `f`.
+The operator-level theorem then derives its hypothesis from subadditivity, weak type `(1,1)`, and
+an `L^∞` bound. For each height `t`, these hypotheses produce the single inequality
 
 `t * ν {T f > t} ≤ A * ∫⁻ x in {‖f‖ > c * t}, ‖f‖ ∂μ`,
 
@@ -31,11 +32,10 @@ conclusion is the `L^p` bound
 
 `∫⁻ (T f) ^ p ∂ν ≤ (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ ‖f‖ ^ p ∂μ`.
 
-Keeping the hypothesis in this form has three advantages. It does not force `T` to be defined on
-all of a function space; it lets `μ` and `ν` live on different spaces, as a genuine interpolation
-statement should; and it makes the dependence of the constant on `p`, on the weak-type constant
-`A` and on the truncation ratio `c` completely explicit, which matters because the constant blows
-up as `p → 1`, exactly as it must — an operator of weak type `(1,1)` need not be bounded on `L¹`.
+Retaining this distributional lemma keeps the analytic engine usable even when `T` is not defined
+on a whole function space. The operator theorem lets `μ` and `ν` live on different spaces and makes
+the dependence on the endpoint and splitting constants explicit. Its constant blows up as
+`p → 1`, exactly as it must — an operator of weak type `(1,1)` need not be bounded on `L¹`.
 
 ## The proof
 
@@ -55,6 +55,9 @@ exhausted by the level sets `{f ≥ 1 / (n + 1)}`, each of finite measure by Che
 ## Main declarations
 
 * `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`: the interpolation estimate.
+* `TauCeti.mul_meas_ofReal_lt_operator_le_setLIntegral`: the reusable truncation argument from
+  subadditivity and the two endpoint bounds.
+* `TauCeti.lintegral_rpow_operator_le`: operator-level Marcinkiewicz interpolation.
 
 ## References
 
@@ -278,5 +281,135 @@ theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le
     fun t ht => ?_
   rw [← hset]
   exact h t ht
+
+section Operator
+
+variable {T : (α → ℝ≥0∞) → β → ℝ≥0∞} {b d : ℝ}
+
+/-- The reusable operator-level truncation argument for Marcinkiewicz interpolation.
+
+Suppose `T` respects almost-everywhere equality, is subadditive, is of weak type `(1,1)` with
+constant `A`, and obeys the `L^∞` bound `T g ≤ b · ‖g‖_∞`. Split `f` at height `c * t`.
+If `b * c + d ≤ 1`, then the low part contributes at most `b * c * t`, so `T f > t` forces
+`T (f · 1_{f > c t}) > d * t`. Applying the weak-type bound to that high part gives
+
+`t * ν {T f > t} ≤ d⁻¹ * A * ∫⁻ x in {f > c * t}, f x ∂μ`.
+
+The parameters `c` and `d` expose the choice of truncation rather than fixing the customary
+`c = d = 1 / 2` for a normalized `L^∞` bound. -/
+theorem mul_meas_ofReal_lt_operator_le_setLIntegral
+    (hf : AEMeasurable f μ) (ht : 0 < t) (hb : 0 ≤ b) (hc : 0 < c) (hd : 0 < d)
+    (hbcd : b * c + d ≤ 1)
+    (hcongr : ∀ {g h : α → ℝ≥0∞}, g =ᵐ[μ] h → T g =ᵐ[ν] T h)
+    (hadd : ∀ (g h : α → ℝ≥0∞), AEMeasurable g μ →
+      ∀ y, T (g + h) y ≤ T g y + T h y)
+    (hweak : ∀ (g : α → ℝ≥0∞) (s : ℝ≥0∞),
+      s * ν {y | s < T g y} ≤ A * ∫⁻ x, g x ∂μ)
+    (hinfty : ∀ (g : α → ℝ≥0∞) (y : β),
+      T g y ≤ ENNReal.ofReal b * eLpNormEssSup g μ) :
+    ENNReal.ofReal t * ν {y | ENNReal.ofReal t < T f y} ≤
+      ENNReal.ofReal d⁻¹ * A *
+        ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
+  have hct : 0 ≤ c * t := (mul_pos hc ht).le
+  have hdt : 0 ≤ d * t := (mul_pos hd ht).le
+  have hbct : 0 ≤ b * (c * t) := mul_nonneg hb hct
+  have hdinv : 0 ≤ d⁻¹ := inv_nonneg.2 hd.le
+  set g : α → ℝ≥0∞ := hf.mk f with hgdef
+  have hfg : f =ᵐ[μ] g := hf.ae_eq_mk
+  have hgmeas : Measurable g := hf.measurable_mk
+  set S : Set α := {x | ENNReal.ofReal (c * t) < g x} with hSdef
+  have hSmeas : MeasurableSet S := measurableSet_lt measurable_const hgmeas
+  set g₁ : α → ℝ≥0∞ := S.indicator g with hg₁def
+  set g₂ : α → ℝ≥0∞ := Sᶜ.indicator g with hg₂def
+  have hsplit : g₁ + g₂ = g := by
+    funext x
+    exact Set.indicator_self_add_compl_apply S g x
+  have hTf : T f =ᵐ[ν] T (g₁ + g₂) := by
+    apply hcongr
+    filter_upwards [hfg] with x hx
+    rw [hsplit, hx]
+  have hg₂bound : ∀ x, g₂ x ≤ ENNReal.ofReal (c * t) := by
+    intro x
+    rw [hg₂def]
+    by_cases hxS : x ∈ S
+    · rw [Set.indicator_of_notMem (by simp [hxS])]
+      exact zero_le
+    · rw [Set.indicator_of_mem (by simp [hxS])]
+      exact not_lt.1 (by simpa [hSdef] using hxS)
+  have hTg₂ : ∀ y, T g₂ y ≤ ENNReal.ofReal (b * (c * t)) := by
+    intro y
+    calc T g₂ y
+        ≤ ENNReal.ofReal b * eLpNormEssSup g₂ μ := hinfty g₂ y
+      _ ≤ ENNReal.ofReal b * ENNReal.ofReal (c * t) := by
+          gcongr
+          exact essSup_le_of_ae_le _ (.of_forall hg₂bound)
+      _ = ENNReal.ofReal (b * (c * t)) := by
+          rw [ENNReal.ofReal_mul hb]
+  have hincl : {y | ENNReal.ofReal t < T f y} ≤ᵐ[ν]
+      {y | ENNReal.ofReal (d * t) < T g₁ y} := by
+    filter_upwards [hTf] with y hTy
+    intro hy
+    have hsum : T f y ≤ T g₁ y + T g₂ y := by
+      rw [hTy]
+      exact hadd g₁ g₂ (hgmeas.indicator hSmeas).aemeasurable y
+    have hconst : ENNReal.ofReal (d * t) + ENNReal.ofReal (b * (c * t)) ≤
+        ENNReal.ofReal t := by
+      rw [← ENNReal.ofReal_add hdt hbct]
+      gcongr
+      nlinarith [mul_nonneg (sub_nonneg.2 hbcd) ht.le]
+    have hlt : ENNReal.ofReal (d * t) + ENNReal.ofReal (b * (c * t)) <
+        T g₁ y + ENNReal.ofReal (b * (c * t)) :=
+      hconst.trans_lt (hy.trans_le (hsum.trans (add_le_add le_rfl (hTg₂ y))))
+    exact (ENNReal.add_lt_add_iff_right ENNReal.ofReal_ne_top).1 hlt
+  have hint : ∫⁻ x, g₁ x ∂μ =
+      ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
+    have hsets : {x | ENNReal.ofReal (c * t) < f x} =ᵐ[μ] S := by
+      filter_upwards [hfg] with x hx
+      exact congrArg (fun z : ℝ≥0∞ => ENNReal.ofReal (c * t) < z) hx
+    calc ∫⁻ x, g₁ x ∂μ
+        = ∫⁻ x in S, g x ∂μ := lintegral_indicator hSmeas g
+      _ = ∫⁻ x in S, f x ∂μ := (lintegral_congr_ae (ae_restrict_of_ae hfg)).symm
+      _ = ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
+          rw [Measure.restrict_congr_set hsets]
+  calc ENNReal.ofReal t * ν {y | ENNReal.ofReal t < T f y}
+      = ENNReal.ofReal d⁻¹ *
+          (ENNReal.ofReal (d * t) * ν {y | ENNReal.ofReal t < T f y}) := by
+        have hscale : d⁻¹ * (d * t) = t := by field_simp
+        rw [← mul_assoc, ← ENNReal.ofReal_mul hdinv, hscale]
+    _ ≤ ENNReal.ofReal d⁻¹ *
+          (ENNReal.ofReal (d * t) * ν {y | ENNReal.ofReal (d * t) < T g₁ y}) := by
+        exact mul_le_mul_right
+          (mul_le_mul_right (measure_mono_ae hincl) (ENNReal.ofReal (d * t)))
+          (ENNReal.ofReal d⁻¹)
+    _ ≤ ENNReal.ofReal d⁻¹ * (A * ∫⁻ x, g₁ x ∂μ) := by
+        exact mul_le_mul_right (hweak g₁ (ENNReal.ofReal (d * t))) (ENNReal.ofReal d⁻¹)
+    _ = ENNReal.ofReal d⁻¹ * A *
+          ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
+        rw [hint, mul_assoc]
+
+/-- **Marcinkiewicz interpolation at operator level**, between weak type `(1,1)` and `L^∞`.
+
+This packages the operator-specific truncation step: a subadditive operator which respects a.e.
+equality, has weak-type constant `A`, and has `L^∞` constant `b` is strong type `(p,p)` for
+`1 < p < ∞`. The positive splitting parameters `c, d` may be chosen arbitrarily subject to
+`b * c + d ≤ 1`. -/
+theorem lintegral_rpow_operator_le
+    (hf : AEMeasurable f μ) (hTf : AEMeasurable (T f) ν) (hp : 1 < p)
+    (hb : 0 ≤ b) (hc : 0 < c) (hd : 0 < d) (hbcd : b * c + d ≤ 1)
+    (hcongr : ∀ {g h : α → ℝ≥0∞}, g =ᵐ[μ] h → T g =ᵐ[ν] T h)
+    (hadd : ∀ (g h : α → ℝ≥0∞), AEMeasurable g μ →
+      ∀ y, T (g + h) y ≤ T g y + T h y)
+    (hweak : ∀ (g : α → ℝ≥0∞) (s : ℝ≥0∞),
+      s * ν {y | s < T g y} ≤ A * ∫⁻ x, g x ∂μ)
+    (hinfty : ∀ (g : α → ℝ≥0∞) (y : β),
+      T g y ≤ ENNReal.ofReal b * eLpNormEssSup g μ) :
+    ∫⁻ y, T f y ^ p ∂ν ≤
+      ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * (ENNReal.ofReal d⁻¹ * A) *
+        ∫⁻ x, f x ^ p ∂μ := by
+  apply lintegral_rpow_le_of_mul_meas_ofReal_lt_le hf hTf hp hc
+  intro t ht
+  exact mul_meas_ofReal_lt_operator_le_setLIntegral hf ht hb hc hd hbcd hcongr hadd hweak hinfty
+
+end Operator
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -5,7 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.SpecialFunctions.Pow.Integral
-public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+public import Mathlib.MeasureTheory.Function.LpSeminorm.Defs
+-- The stronger seminorm API is used only in the operator-level proof.
+import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 -- `Mathlib.MeasureTheory.Measure.Prod` is imported privately: the product measure and
 -- Tonelli's theorem appear only inside the proof below.
 import Mathlib.MeasureTheory.Measure.Prod
@@ -55,7 +57,7 @@ exhausted by the level sets `{f ≥ 1 / (n + 1)}`, each of finite measure by Che
 ## Main declarations
 
 * `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`: the interpolation estimate.
-* `TauCeti.mul_meas_ofReal_lt_operator_le_setLIntegral`: the reusable truncation argument from
+* `TauCeti.mul_measure_ofReal_lt_operator_le_setLIntegral`: the reusable truncation argument from
   subadditivity and the two endpoint bounds.
 * `TauCeti.lintegral_rpow_operator_le`: operator-level Marcinkiewicz interpolation.
 
@@ -284,74 +286,74 @@ theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le
 
 section Operator
 
-variable {T : (α → ℝ≥0∞) → β → ℝ≥0∞} {b d : ℝ}
+variable {G : Type*} [MeasurableSpace G] [TopologicalSpace G] [BorelSpace G]
+  [ESeminormedAddMonoid G] {T : (α → G) → β → ℝ≥0∞} {v : α → G} {b d t : ℝ}
 
 /-- The reusable operator-level truncation argument for Marcinkiewicz interpolation.
 
 Suppose `T` respects almost-everywhere equality, is subadditive, is of weak type `(1,1)` with
-constant `A`, and obeys the `L^∞` bound `T g ≤ b · ‖g‖_∞`. Split `f` at height `c * t`.
-If `b * c + d ≤ 1`, then the low part contributes at most `b * c * t`, so `T f > t` forces
-`T (f · 1_{f > c t}) > d * t`. Applying the weak-type bound to that high part gives
+constant `A`, and obeys the `L^∞` bound `T g ≤ b · ‖g‖_∞`. Split `v` according to whether its
+extended norm exceeds `c * t`. If `b * c + d ≤ 1`, then the low part contributes at most
+`b * c * t`, so `T v > t` forces the image of the high part to exceed `d * t`. Applying the
+weak-type bound to that high part gives
 
-`t * ν {T f > t} ≤ d⁻¹ * A * ∫⁻ x in {f > c * t}, f x ∂μ`.
+`t * ν {T v > t} ≤ d⁻¹ * A * ∫⁻ x in {‖v‖ₑ > c * t}, ‖v x‖ₑ ∂μ`.
 
 The parameters `c` and `d` expose the choice of truncation rather than fixing the customary
 `c = d = 1 / 2` for a normalized `L^∞` bound. -/
-theorem mul_meas_ofReal_lt_operator_le_setLIntegral
-    (hf : AEMeasurable f μ) (ht : 0 < t) (hb : 0 ≤ b) (hc : 0 < c) (hd : 0 < d)
+theorem mul_measure_ofReal_lt_operator_le_setLIntegral
+    (hv : AEMeasurable v μ) (ht : 0 < t) (hb : 0 ≤ b) (hc : 0 < c) (hd : 0 < d)
     (hbcd : b * c + d ≤ 1)
-    (hcongr : ∀ {g h : α → ℝ≥0∞}, g =ᵐ[μ] h → T g =ᵐ[ν] T h)
-    (hadd : ∀ (g h : α → ℝ≥0∞), AEMeasurable g μ →
-      ∀ y, T (g + h) y ≤ T g y + T h y)
-    (hweak : ∀ (g : α → ℝ≥0∞) (s : ℝ≥0∞),
-      s * ν {y | s < T g y} ≤ A * ∫⁻ x, g x ∂μ)
-    (hinfty : ∀ (g : α → ℝ≥0∞) (y : β),
-      T g y ≤ ENNReal.ofReal b * eLpNormEssSup g μ) :
-    ENNReal.ofReal t * ν {y | ENNReal.ofReal t < T f y} ≤
+    (hcongr : ∀ {g h : α → G}, g =ᵐ[μ] h → T g =ᵐ[ν] T h)
+    (hadd : ∀ (g h : α → G), AEMeasurable g μ →
+      T (g + h) ≤ᵐ[ν] T g + T h)
+    (hweak : ∀ (g : α → G), AEMeasurable g μ → ∀ s : ℝ≥0∞,
+      s * ν {y | s < T g y} ≤ A * ∫⁻ x, ‖g x‖ₑ ∂μ)
+    (hinfty : ∀ (g : α → G), T g ≤ᵐ[ν]
+      fun _ => ENNReal.ofReal b * eLpNormEssSup g μ) :
+    ENNReal.ofReal t * ν {y | ENNReal.ofReal t < T v y} ≤
       ENNReal.ofReal d⁻¹ * A *
-        ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
+        ∫⁻ x in {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ}, ‖v x‖ₑ ∂μ := by
   have hct : 0 ≤ c * t := (mul_pos hc ht).le
   have hdt : 0 ≤ d * t := (mul_pos hd ht).le
   have hbct : 0 ≤ b * (c * t) := mul_nonneg hb hct
   have hdinv : 0 ≤ d⁻¹ := inv_nonneg.2 hd.le
-  set g : α → ℝ≥0∞ := hf.mk f with hgdef
-  have hfg : f =ᵐ[μ] g := hf.ae_eq_mk
-  have hgmeas : Measurable g := hf.measurable_mk
-  set S : Set α := {x | ENNReal.ofReal (c * t) < g x} with hSdef
-  have hSmeas : MeasurableSet S := measurableSet_lt measurable_const hgmeas
-  set g₁ : α → ℝ≥0∞ := S.indicator g with hg₁def
-  set g₂ : α → ℝ≥0∞ := Sᶜ.indicator g with hg₂def
+  set g : α → G := hv.mk v with hgdef
+  have hvg : v =ᵐ[μ] g := hv.ae_eq_mk
+  have hgmeas : Measurable g := hv.measurable_mk
+  set S : Set α := {x | ENNReal.ofReal (c * t) < ‖g x‖ₑ} with hSdef
+  have hSmeas : MeasurableSet S := measurableSet_lt measurable_const hgmeas.enorm
+  set g₁ : α → G := S.indicator g with hg₁def
+  set g₂ : α → G := Sᶜ.indicator g with hg₂def
   have hsplit : g₁ + g₂ = g := by
     funext x
     exact Set.indicator_self_add_compl_apply S g x
-  have hTf : T f =ᵐ[ν] T (g₁ + g₂) := by
+  have hTv : T v =ᵐ[ν] T (g₁ + g₂) := by
     apply hcongr
-    filter_upwards [hfg] with x hx
+    filter_upwards [hvg] with x hx
     rw [hsplit, hx]
-  have hg₂bound : ∀ x, g₂ x ≤ ENNReal.ofReal (c * t) := by
+  have hg₂bound : ∀ x, ‖g₂ x‖ₑ ≤ ENNReal.ofReal (c * t) := by
     intro x
     rw [hg₂def]
     by_cases hxS : x ∈ S
-    · rw [Set.indicator_of_notMem (by simp [hxS])]
+    · rw [Set.indicator_of_notMem (by simp [hxS]), enorm_zero]
       exact zero_le
     · rw [Set.indicator_of_mem (by simp [hxS])]
       exact not_lt.1 (by simpa [hSdef] using hxS)
-  have hTg₂ : ∀ y, T g₂ y ≤ ENNReal.ofReal (b * (c * t)) := by
-    intro y
-    calc T g₂ y
-        ≤ ENNReal.ofReal b * eLpNormEssSup g₂ μ := hinfty g₂ y
-      _ ≤ ENNReal.ofReal b * ENNReal.ofReal (c * t) := by
-          gcongr
-          exact essSup_le_of_ae_le _ (.of_forall hg₂bound)
-      _ = ENNReal.ofReal (b * (c * t)) := by
-          rw [ENNReal.ofReal_mul hb]
-  have hincl : {y | ENNReal.ofReal t < T f y} ≤ᵐ[ν]
+  have hTg₂ : ∀ᵐ y ∂ν, T g₂ y ≤ ENNReal.ofReal (b * (c * t)) := by
+    filter_upwards [hinfty g₂] with y hy
+    exact hy.trans (calc
+      ENNReal.ofReal b * eLpNormEssSup g₂ μ
+          ≤ ENNReal.ofReal b * ENNReal.ofReal (c * t) := by
+            gcongr
+            exact essSup_le_of_ae_le _ (.of_forall hg₂bound)
+      _ = ENNReal.ofReal (b * (c * t)) := by rw [ENNReal.ofReal_mul hb])
+  have hincl : {y | ENNReal.ofReal t < T v y} ≤ᵐ[ν]
       {y | ENNReal.ofReal (d * t) < T g₁ y} := by
-    filter_upwards [hTf] with y hTy
+    filter_upwards [hTv, hadd g₁ g₂ (hgmeas.indicator hSmeas).aemeasurable, hTg₂]
+      with y hTy hsum hlow
     intro hy
-    have hsum : T f y ≤ T g₁ y + T g₂ y := by
-      rw [hTy]
-      exact hadd g₁ g₂ (hgmeas.indicator hSmeas).aemeasurable y
+    have hsum' : T v y ≤ T g₁ y + T g₂ y := hTy.le.trans hsum
     have hconst : ENNReal.ofReal (d * t) + ENNReal.ofReal (b * (c * t)) ≤
         ENNReal.ofReal t := by
       rw [← ENNReal.ofReal_add hdt hbct]
@@ -359,21 +361,28 @@ theorem mul_meas_ofReal_lt_operator_le_setLIntegral
       nlinarith [mul_nonneg (sub_nonneg.2 hbcd) ht.le]
     have hlt : ENNReal.ofReal (d * t) + ENNReal.ofReal (b * (c * t)) <
         T g₁ y + ENNReal.ofReal (b * (c * t)) :=
-      hconst.trans_lt (hy.trans_le (hsum.trans (add_le_add le_rfl (hTg₂ y))))
+      hconst.trans_lt (hy.trans_le (hsum'.trans (add_le_add le_rfl hlow)))
     exact (ENNReal.add_lt_add_iff_right ENNReal.ofReal_ne_top).1 hlt
-  have hint : ∫⁻ x, g₁ x ∂μ =
-      ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
-    have hsets : {x | ENNReal.ofReal (c * t) < f x} =ᵐ[μ] S := by
-      filter_upwards [hfg] with x hx
+  have hint : ∫⁻ x, ‖g₁ x‖ₑ ∂μ =
+      ∫⁻ x in {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ}, ‖v x‖ₑ ∂μ := by
+    have henorm : (fun x => ‖v x‖ₑ) =ᵐ[μ] fun x => ‖g x‖ₑ :=
+      hvg.mono fun _ hx => congrArg enorm hx
+    have hsets : {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ} =ᵐ[μ] S := by
+      filter_upwards [henorm] with x hx
       exact congrArg (fun z : ℝ≥0∞ => ENNReal.ofReal (c * t) < z) hx
-    calc ∫⁻ x, g₁ x ∂μ
-        = ∫⁻ x in S, g x ∂μ := lintegral_indicator hSmeas g
-      _ = ∫⁻ x in S, f x ∂μ := (lintegral_congr_ae (ae_restrict_of_ae hfg)).symm
-      _ = ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
+    calc ∫⁻ x, ‖g₁ x‖ₑ ∂μ
+        = ∫⁻ x in S, ‖g x‖ₑ ∂μ := by
+          rw [← lintegral_indicator hSmeas]
+          congr 1
+          funext x
+          by_cases hx : x ∈ S <;> simp [hg₁def, hx]
+      _ = ∫⁻ x in S, ‖v x‖ₑ ∂μ :=
+        (lintegral_congr_ae (ae_restrict_of_ae henorm)).symm
+      _ = ∫⁻ x in {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ}, ‖v x‖ₑ ∂μ := by
           rw [Measure.restrict_congr_set hsets]
-  calc ENNReal.ofReal t * ν {y | ENNReal.ofReal t < T f y}
+  calc ENNReal.ofReal t * ν {y | ENNReal.ofReal t < T v y}
       = ENNReal.ofReal d⁻¹ *
-          (ENNReal.ofReal (d * t) * ν {y | ENNReal.ofReal t < T f y}) := by
+          (ENNReal.ofReal (d * t) * ν {y | ENNReal.ofReal t < T v y}) := by
         have hscale : d⁻¹ * (d * t) = t := by field_simp
         rw [← mul_assoc, ← ENNReal.ofReal_mul hdinv, hscale]
     _ ≤ ENNReal.ofReal d⁻¹ *
@@ -381,10 +390,12 @@ theorem mul_meas_ofReal_lt_operator_le_setLIntegral
         exact mul_le_mul_right
           (mul_le_mul_right (measure_mono_ae hincl) (ENNReal.ofReal (d * t)))
           (ENNReal.ofReal d⁻¹)
-    _ ≤ ENNReal.ofReal d⁻¹ * (A * ∫⁻ x, g₁ x ∂μ) := by
-        exact mul_le_mul_right (hweak g₁ (ENNReal.ofReal (d * t))) (ENNReal.ofReal d⁻¹)
+    _ ≤ ENNReal.ofReal d⁻¹ * (A * ∫⁻ x, ‖g₁ x‖ₑ ∂μ) := by
+        exact mul_le_mul_right
+          (hweak g₁ (hgmeas.indicator hSmeas).aemeasurable (ENNReal.ofReal (d * t)))
+          (ENNReal.ofReal d⁻¹)
     _ = ENNReal.ofReal d⁻¹ * A *
-          ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
+          ∫⁻ x in {x | ENNReal.ofReal (c * t) < ‖v x‖ₑ}, ‖v x‖ₑ ∂μ := by
         rw [hint, mul_assoc]
 
 /-- **Marcinkiewicz interpolation at operator level**, between weak type `(1,1)` and `L^∞`.
@@ -394,21 +405,22 @@ equality, has weak-type constant `A`, and has `L^∞` constant `b` is strong typ
 `1 < p < ∞`. The positive splitting parameters `c, d` may be chosen arbitrarily subject to
 `b * c + d ≤ 1`. -/
 theorem lintegral_rpow_operator_le
-    (hf : AEMeasurable f μ) (hTf : AEMeasurable (T f) ν) (hp : 1 < p)
+    (hv : AEMeasurable v μ) (hTv : AEMeasurable (T v) ν) (hp : 1 < p)
     (hb : 0 ≤ b) (hc : 0 < c) (hd : 0 < d) (hbcd : b * c + d ≤ 1)
-    (hcongr : ∀ {g h : α → ℝ≥0∞}, g =ᵐ[μ] h → T g =ᵐ[ν] T h)
-    (hadd : ∀ (g h : α → ℝ≥0∞), AEMeasurable g μ →
-      ∀ y, T (g + h) y ≤ T g y + T h y)
-    (hweak : ∀ (g : α → ℝ≥0∞) (s : ℝ≥0∞),
-      s * ν {y | s < T g y} ≤ A * ∫⁻ x, g x ∂μ)
-    (hinfty : ∀ (g : α → ℝ≥0∞) (y : β),
-      T g y ≤ ENNReal.ofReal b * eLpNormEssSup g μ) :
-    ∫⁻ y, T f y ^ p ∂ν ≤
+    (hcongr : ∀ {g h : α → G}, g =ᵐ[μ] h → T g =ᵐ[ν] T h)
+    (hadd : ∀ (g h : α → G), AEMeasurable g μ →
+      T (g + h) ≤ᵐ[ν] T g + T h)
+    (hweak : ∀ (g : α → G), AEMeasurable g μ → ∀ s : ℝ≥0∞,
+      s * ν {y | s < T g y} ≤ A * ∫⁻ x, ‖g x‖ₑ ∂μ)
+    (hinfty : ∀ (g : α → G), T g ≤ᵐ[ν]
+      fun _ => ENNReal.ofReal b * eLpNormEssSup g μ) :
+    ∫⁻ y, T v y ^ p ∂ν ≤
       ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * (ENNReal.ofReal d⁻¹ * A) *
-        ∫⁻ x, f x ^ p ∂μ := by
-  apply lintegral_rpow_le_of_mul_meas_ofReal_lt_le hf hTf hp hc
+        ∫⁻ x, ‖v x‖ₑ ^ p ∂μ := by
+  apply lintegral_rpow_le_of_mul_meas_ofReal_lt_le hv.enorm hTv hp hc
   intro t ht
-  exact mul_meas_ofReal_lt_operator_le_setLIntegral hf ht hb hc hd hbcd hcongr hadd hweak hinfty
+  exact mul_measure_ofReal_lt_operator_le_setLIntegral
+    hv ht hb hc hd hbcd hcongr hadd hweak hinfty
 
 end Operator
 

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -5,16 +5,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
-public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 public import Mathlib.MeasureTheory.Integral.Average
 public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 public import Mathlib.Topology.Semicontinuity.Defs
 -- `TauCeti.MeasureTheory.Integral.Marcinkiewicz` is imported privately: its operator-level
 -- interpolation API is used only to prove the strong maximal inequality below.
 import TauCeti.MeasureTheory.Integral.Marcinkiewicz
--- `Mathlib.Analysis.Normed.Group.Real` is imported privately for the extended norm of
--- `ENNReal.toReal`, used to descend the maximal function to `Lp`.
-import Mathlib.Analysis.Normed.Group.Real
 -- `Mathlib.MeasureTheory.Constructions.BorelSpace.Order` is imported privately: it is used only
 -- for `LowerSemicontinuous.measurable`, inside the proof of `TauCeti.measurable_maximalFunction`.
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Order
@@ -91,14 +87,8 @@ never reaches `t`, and the weak-type bound applied to the high part gives
   **maximal inequality**, in product and in quotient form.
 * `TauCeti.ae_maximalFunction_lt_top`: the maximal function of an `L¹` function is finite almost
   everywhere.
-* `TauCeti.mul_measure_lt_maximalFunction_le_setLIntegral`: the weak-type bound against the
-  truncation of `f` at half the height, the form Marcinkiewicz interpolation consumes.
 * `TauCeti.lintegral_rpow_maximalFunction_le`, `TauCeti.eLpNorm_maximalFunction_le`: the
   **strong type `(p, p)` maximal inequality** for `1 < p < ∞`, with an explicit constant.
-* `TauCeti.ae_maximalFunction_lt_top_of_memLp`, `TauCeti.memLp_maximalFunction_toReal`,
-  `TauCeti.maximalFunctionLp`: the maximal function is finite almost everywhere on `Lᵖ`; its
-  real-valued representative preserves `MemLp` and descends to a nonlinear map
-  `Lp F p μ → Lp ℝ p μ`.
 
 The maximal function defined here is the *centred* one, whose averages are over the balls centred
 at the point. The uncentred variant, over all balls containing the point, is comparable to it with
@@ -441,33 +431,6 @@ theorem ae_maximalFunction_lt_top (μ : Measure E) [μ.IsAddHaarMeasure] (f : E 
 
 section StrongType
 
-/-- The weak-type `(1,1)` bound in **truncated** form: only the part of `f` above the height
-`t / 2` can push `M f` above `t`, so
-
-`t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
-
-This is a specialization of `TauCeti.mul_measure_ofReal_lt_operator_le_setLIntegral`; the
-reusable theorem carries out the split in `ℝ≥0∞`, using subadditivity and the `L^∞` endpoint. The
-half-height split is conventional and keeps the resulting explicit constant simple; it is not
-claimed to optimize that constant. -/
-theorem mul_measure_lt_maximalFunction_le_setLIntegral (μ : Measure E) [μ.IsAddHaarMeasure]
-    {f : E → F} (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {t : ℝ} (ht : 0 < t) :
-    ENNReal.ofReal t * μ {x | ENNReal.ofReal t < maximalFunction μ f x} ≤
-      2 * 4 ^ finrank ℝ E * ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
-  rw [← maximalFunction_enorm μ f]
-  simpa only [inv_inv, ENNReal.ofReal_ofNat, enorm_eq_self]
-    using mul_measure_ofReal_lt_operator_le_setLIntegral
-      (T := fun g => maximalFunction μ g) (A := 4 ^ finrank ℝ E) (b := 1)
-      (c := 2⁻¹) (d := 2⁻¹)
-      hf ht (by norm_num) (by norm_num) (by norm_num) (by norm_num)
-      (fun hgh => .of_forall fun x => maximalFunction_congr_ae
-        (hgh.mono fun y hy => by simpa only [enorm_eq_self] using hy))
-      (fun g h hg => .of_forall fun y => maximalFunction_add_le hg y)
-      (fun g _hg s => by
-        simpa only [enorm_eq_self] using mul_measure_lt_maximalFunction_le μ g s)
-      (fun g => .of_forall fun y => by simpa only [ENNReal.ofReal_one, one_mul] using
-        maximalFunction_le_eLpNormEssSup μ g y)
-
 /-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
 as an inequality between the integrals `∫⁻ ‖·‖ₑ ^ p`:
 
@@ -508,8 +471,8 @@ theorem lintegral_rpow_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure]
 in terms of representative-level `Lᵖ` seminorms.
 
 Together with `TauCeti.maximalFunction_le_eLpNormEssSup` (the case `p = ∞`) and
-`TauCeti.mul_measure_lt_maximalFunction_le` (the weak-type substitute at `p = 1`), this supplies
-the estimate used below to define the bounded nonlinear map `TauCeti.maximalFunctionLp`. -/
+`TauCeti.mul_measure_lt_maximalFunction_le` (the weak-type substitute at `p = 1`), this gives the
+representative-level strong estimate for the maximal function. -/
 theorem eLpNorm_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E → F}
     (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {p : ℝ≥0∞} (hp : 1 < p) (hp_top : p ≠ ∞) :
     eLpNorm (maximalFunction μ f) p μ ≤
@@ -526,84 +489,5 @@ theorem eLpNorm_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E
 end StrongType
 
 end Haar
-
-section Lp
-
-variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E]
-  [BorelSpace E] [FiniteDimensional ℝ E] [NormedAddCommGroup F] {p : ℝ≥0∞} {f : E → F}
-  {μ : Measure E} [μ.IsAddHaarMeasure]
-
-/-- The maximal function of an `Lᵖ` function is finite almost everywhere when `1 < p < ∞`. -/
-theorem ae_maximalFunction_lt_top_of_memLp (hf : MemLp f p μ) (hp : 1 < p)
-    (hp_top : p ≠ ∞) : ∀ᵐ x ∂μ, maximalFunction μ f x < ∞ := by
-  have hp₀ : p ≠ 0 := (zero_lt_one.trans hp).ne'
-  have hpr : 0 < p.toReal := ENNReal.toReal_pos hp₀ hp_top
-  have hMnorm : eLpNorm (maximalFunction μ f) p μ < ∞ :=
-    (eLpNorm_maximalFunction_le μ hf.aestronglyMeasurable.enorm hp hp_top).trans_lt (by finiteness)
-  have hMint : ∫⁻ x, maximalFunction μ f x ^ p.toReal ∂μ < ∞ :=
-    (eLpNorm_lt_top_iff_lintegral_rpow_enorm_lt_top hp₀ hp_top).mp hMnorm
-  have hrpow : ∀ᵐ x ∂μ, maximalFunction μ f x ^ p.toReal < ∞ :=
-    ae_lt_top' ((measurable_maximalFunction μ f).pow_const p.toReal).aemeasurable hMint.ne
-  exact hrpow.mono fun _ hx => (ENNReal.rpow_lt_top_iff_of_pos hpr).mp hx
-
-/-- Converting the maximal function to a real-valued function does not change its `Lᵖ` seminorm
-when the input belongs to `Lᵖ` and `1 < p < ∞`. The strong-type estimate makes the extended-valued
-maximal function finite almost everywhere. -/
-theorem eLpNorm_maximalFunction_toReal_eq (hf : MemLp f p μ) (hp : 1 < p)
-    (hp_top : p ≠ ∞) :
-    eLpNorm (fun x => (maximalFunction μ f x).toReal) p μ =
-      eLpNorm (maximalFunction μ f) p μ := by
-  apply eLpNorm_congr_enorm_ae
-  filter_upwards [ae_maximalFunction_lt_top_of_memLp hf hp hp_top] with x hx
-  exact Real.enorm_toReal hx.ne
-
-/-- The real-valued representative of the maximal function of an `Lᵖ` function is again in
-`Lᵖ`, for `1 < p < ∞`. -/
-theorem memLp_maximalFunction_toReal (hf : MemLp f p μ) (hp : 1 < p) (hp_top : p ≠ ∞) :
-    MemLp (fun x => (maximalFunction μ f x).toReal) p μ := by
-  refine ⟨(measurable_maximalFunction μ f).ennreal_toReal.aestronglyMeasurable, ?_⟩
-  rw [eLpNorm_maximalFunction_toReal_eq hf hp hp_top]
-  exact (eLpNorm_maximalFunction_le μ hf.aestronglyMeasurable.enorm hp hp_top).trans_lt
-    (by finiteness)
-
-/-- The Hardy–Littlewood maximal function as a well-defined nonlinear map on `Lᵖ`.
-
-Its values use the almost-everywhere-finite real representative
-`x ↦ (maximalFunction μ f x).toReal`; representative independence is inherited from
-`maximalFunction_congr_ae`. -/
-noncomputable def maximalFunctionLp (μ : Measure E) [μ.IsAddHaarMeasure] (p : ℝ≥0∞)
-    (hp : 1 < p) (hp_top : p ≠ ∞) : Lp F p μ → Lp ℝ p μ := fun f =>
-  (memLp_maximalFunction_toReal (Lp.memLp f) hp hp_top).toLp
-    (fun x => (maximalFunction μ f x).toReal)
-
-/-- The `Lp` maximal-function map is represented by the real-valued maximal function. -/
-@[simp]
-theorem coeFn_maximalFunctionLp (μ : Measure E) [μ.IsAddHaarMeasure] (hp : 1 < p)
-    (hp_top : p ≠ ∞) (f : Lp F p μ) :
-    maximalFunctionLp μ p hp hp_top f =ᵐ[μ]
-      fun x => (maximalFunction μ f x).toReal :=
-  MemLp.coeFn_toLp (memLp_maximalFunction_toReal (Lp.memLp f) hp hp_top)
-
-/-- On an `Lᵖ` element built from a `MemLp` representative, `maximalFunctionLp` is represented by
-the real-valued maximal function of that representative. -/
-theorem maximalFunctionLp_toLp (hf : MemLp f p μ) (hp : 1 < p) (hp_top : p ≠ ∞) :
-    maximalFunctionLp μ p hp hp_top (hf.toLp f) =ᵐ[μ]
-      fun x => (maximalFunction μ f x).toReal := by
-  refine (coeFn_maximalFunctionLp μ hp hp_top (hf.toLp f)).trans ?_
-  exact .of_forall fun x => congrArg ENNReal.toReal (maximalFunction_congr_ae
-    (hf.coeFn_toLp.mono fun _ hy => congrArg enorm hy))
-
-/-- The quotient-level maximal-function map satisfies the strong `(p,p)` bound. -/
-theorem enorm_maximalFunctionLp_le (μ : Measure E) [μ.IsAddHaarMeasure] (hp : 1 < p)
-    (hp_top : p ≠ ∞) (f : Lp F p μ) :
-    ‖maximalFunctionLp μ p hp hp_top f‖ₑ ≤
-      (ENNReal.ofReal (2 * p.toReal * 2 ^ (p.toReal - 1) / (p.toReal - 1)) *
-        4 ^ finrank ℝ E) ^ (1 / p.toReal) * ‖f‖ₑ := by
-  rw [Lp.enorm_def, Lp.enorm_def,
-    eLpNorm_congr_ae (coeFn_maximalFunctionLp μ hp hp_top f)]
-  rw [eLpNorm_maximalFunction_toReal_eq (Lp.memLp f) hp hp_top]
-  exact eLpNorm_maximalFunction_le μ (Lp.memLp f).aestronglyMeasurable.enorm hp hp_top
-
-end Lp
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -9,9 +9,8 @@ public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 public import Mathlib.MeasureTheory.Integral.Average
 public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 public import Mathlib.Topology.Semicontinuity.Defs
--- `TauCeti.MeasureTheory.Integral.Marcinkiewicz` is imported privately: it supplies
--- `TauCeti.lintegral_rpow_operator_le`, used only inside the proof of
--- `TauCeti.lintegral_rpow_maximalFunction_le`.
+-- `TauCeti.MeasureTheory.Integral.Marcinkiewicz` is imported privately: its operator-level
+-- interpolation API is used only to prove the strong maximal inequality below.
 import TauCeti.MeasureTheory.Integral.Marcinkiewicz
 -- `Mathlib.MeasureTheory.Constructions.BorelSpace.Order` is imported privately: it is used only
 -- for `LowerSemicontinuous.measurable`, inside the proof of `TauCeti.measurable_maximalFunction`.
@@ -76,6 +75,8 @@ never reaches `t`, and the weak-type bound applied to the high part gives
   normalisation is the intended one.
 * `TauCeti.maximalFunction_mono_ae`, `TauCeti.maximalFunction_congr_ae`: `M` is monotone in `‖f‖ₑ`
   almost everywhere, so `M f` depends on `f` only through `‖f‖ₑ` and only up to a null set.
+* `TauCeti.maximalFunction_enorm`: replacing a function by its extended norm leaves its maximal
+  function unchanged.
 * `TauCeti.maximalFunction_zero`, `TauCeti.maximalFunction_add_le`,
   `TauCeti.maximalFunction_const_smul`: `M` is sublinear. Subadditivity and the endpoint bounds
   feed directly into `TauCeti.lintegral_rpow_operator_le`.
@@ -91,8 +92,10 @@ never reaches `t`, and the weak-type bound applied to the high part gives
   truncation of `f` at half the height, the form Marcinkiewicz interpolation consumes.
 * `TauCeti.lintegral_rpow_maximalFunction_le`, `TauCeti.eLpNorm_maximalFunction_le`: the
   **strong type `(p, p)` maximal inequality** for `1 < p < ∞`, with an explicit constant.
-* `TauCeti.memLp_maximalFunction_toReal`, `TauCeti.maximalFunctionLp`: the real-valued maximal
-  function preserves `MemLp` and therefore descends to a nonlinear map `Lp F p μ → Lp ℝ p μ`.
+* `TauCeti.ae_maximalFunction_lt_top_of_memLp`, `TauCeti.memLp_maximalFunction_toReal`,
+  `TauCeti.maximalFunctionLp`: the maximal function is finite almost everywhere on `Lᵖ`; its
+  real-valued representative preserves `MemLp` and descends to a nonlinear map
+  `Lp F p μ → Lp ℝ p μ`.
 
 The maximal function defined here is the *centred* one, whose averages are over the balls centred
 at the point. The uncentred variant, over all balls containing the point, is comparable to it with
@@ -157,6 +160,12 @@ theorem maximalFunction_congr_ae (h : ∀ᵐ y ∂μ, ‖f y‖ₑ = ‖g y‖�
     maximalFunction μ f x = maximalFunction μ g x :=
   le_antisymm (maximalFunction_mono_ae (h.mono fun _ hy => hy.le))
     (maximalFunction_mono_ae (h.mono fun _ hy => hy.ge))
+
+/-- Replacing a function by its extended norm leaves its maximal function unchanged. -/
+@[simp]
+theorem maximalFunction_enorm (μ : Measure X) (f : X → F) :
+    maximalFunction μ (fun x => ‖f x‖ₑ) = maximalFunction μ f :=
+  funext fun _ => maximalFunction_congr_ae (.of_forall fun _ => by simp)
 
 /-- The `L^∞` endpoint of the maximal inequality: the maximal function of `f` is bounded by the
 essential supremum of `‖f‖`, with constant `1`. -/
@@ -434,25 +443,26 @@ section StrongType
 
 `t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
 
-This is a specialization of `TauCeti.mul_meas_ofReal_lt_operator_le_setLIntegral`; the reusable
-theorem carries out the split in `ℝ≥0∞`, using subadditivity and the `L^∞` endpoint. -/
+This is a specialization of `TauCeti.mul_measure_ofReal_lt_operator_le_setLIntegral`; the
+reusable theorem carries out the split in `ℝ≥0∞`, using subadditivity and the `L^∞` endpoint. The
+half-height split is conventional and keeps the resulting explicit constant simple; it is not
+claimed to optimize that constant. -/
 theorem mul_measure_lt_maximalFunction_le_setLIntegral (μ : Measure E) [μ.IsAddHaarMeasure]
     {f : E → F} (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {t : ℝ} (ht : 0 < t) :
     ENNReal.ofReal t * μ {x | ENNReal.ofReal t < maximalFunction μ f x} ≤
       2 * 4 ^ finrank ℝ E * ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
-  have hM : maximalFunction μ (fun x => ‖f x‖ₑ) = maximalFunction μ f :=
-    funext fun x => maximalFunction_congr_ae (.of_forall fun y => by simp)
-  rw [← hM]
+  rw [← maximalFunction_enorm μ f]
   simpa only [inv_inv, ENNReal.ofReal_ofNat, enorm_eq_self]
-    using mul_meas_ofReal_lt_operator_le_setLIntegral
+    using mul_measure_ofReal_lt_operator_le_setLIntegral
       (T := fun g => maximalFunction μ g) (A := 4 ^ finrank ℝ E) (b := 1)
       (c := 2⁻¹) (d := 2⁻¹)
       hf ht (by norm_num) (by norm_num) (by norm_num) (by norm_num)
       (fun hgh => .of_forall fun x => maximalFunction_congr_ae
         (hgh.mono fun y hy => by simpa only [enorm_eq_self] using hy))
-      (fun g h hg y => maximalFunction_add_le hg y)
-      (fun g s => by simpa only [enorm_eq_self] using mul_measure_lt_maximalFunction_le μ g s)
-      (fun g y => by simpa only [ENNReal.ofReal_one, one_mul] using
+      (fun g h hg => .of_forall fun y => maximalFunction_add_le hg y)
+      (fun g _hg s => by
+        simpa only [enorm_eq_self] using mul_measure_lt_maximalFunction_le μ g s)
+      (fun g => .of_forall fun y => by simpa only [ENNReal.ofReal_one, one_mul] using
         maximalFunction_le_eLpNormEssSup μ g y)
 
 /-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
@@ -476,19 +486,9 @@ theorem lintegral_rpow_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure]
     rw [hinv, hsplit, ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2), ENNReal.ofReal_ofNat]
     ring
   rw [← hconst]
-  have hM : maximalFunction μ (fun x => ‖f x‖ₑ) = maximalFunction μ f :=
-    funext fun x => maximalFunction_congr_ae (.of_forall fun y => by simp)
-  rw [← hM]
-  simpa only [inv_inv, ENNReal.ofReal_ofNat, enorm_eq_self] using lintegral_rpow_operator_le
-      (T := fun g => maximalFunction μ g) (A := 4 ^ finrank ℝ E) (b := 1)
-      (c := 2⁻¹) (d := 2⁻¹) hf (measurable_maximalFunction μ f).aemeasurable hp
-      (by norm_num) (by norm_num) (by norm_num) (by norm_num)
-      (fun hgh => .of_forall fun x => maximalFunction_congr_ae
-        (hgh.mono fun y hy => by simpa only [enorm_eq_self] using hy))
-      (fun g h hg y => maximalFunction_add_le hg y)
-      (fun g s => by simpa only [enorm_eq_self] using mul_measure_lt_maximalFunction_le μ g s)
-      (fun g y => by simpa only [ENNReal.ofReal_one, one_mul] using
-        maximalFunction_le_eLpNormEssSup μ g y)
+  refine lintegral_rpow_le_of_mul_meas_ofReal_lt_le hf
+    (measurable_maximalFunction μ f).aemeasurable hp (by norm_num) fun t ht => ?_
+  simpa using mul_measure_lt_maximalFunction_le_setLIntegral μ hf ht
 
 /-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
 in terms of representative-level `Lᵖ` seminorms.
@@ -517,66 +517,78 @@ section Lp
 
 variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E]
   [BorelSpace E] [FiniteDimensional ℝ E] [NormedAddCommGroup F] {p : ℝ≥0∞} {f : E → F}
-  {mu : Measure E} [mu.IsAddHaarMeasure]
+  {μ : Measure E} [μ.IsAddHaarMeasure]
+
+/-- The maximal function of an `Lᵖ` function is finite almost everywhere when `1 < p < ∞`. -/
+theorem ae_maximalFunction_lt_top_of_memLp (hf : MemLp f p μ) (hp : 1 < p)
+    (hp_top : p ≠ ∞) : ∀ᵐ x ∂μ, maximalFunction μ f x < ∞ := by
+  have hp₀ : p ≠ 0 := (zero_lt_one.trans hp).ne'
+  have hpr : 0 < p.toReal := ENNReal.toReal_pos hp₀ hp_top
+  have hMnorm : eLpNorm (maximalFunction μ f) p μ < ∞ :=
+    (eLpNorm_maximalFunction_le μ hf.aestronglyMeasurable.enorm hp hp_top).trans_lt (by finiteness)
+  have hMint : ∫⁻ x, maximalFunction μ f x ^ p.toReal ∂μ < ∞ :=
+    (eLpNorm_lt_top_iff_lintegral_rpow_enorm_lt_top hp₀ hp_top).mp hMnorm
+  have hrpow : ∀ᵐ x ∂μ, maximalFunction μ f x ^ p.toReal < ∞ :=
+    ae_lt_top' ((measurable_maximalFunction μ f).pow_const p.toReal).aemeasurable hMint.ne
+  exact hrpow.mono fun _ hx => (ENNReal.rpow_lt_top_iff_of_pos hpr).mp hx
 
 /-- Converting the maximal function to a real-valued function does not change its `Lᵖ` seminorm
 when the input belongs to `Lᵖ` and `1 < p < ∞`. The strong-type estimate makes the extended-valued
 maximal function finite almost everywhere. -/
-theorem eLpNorm_maximalFunction_toReal_eq (hf : MemLp f p mu) (hp : 1 < p)
+theorem eLpNorm_maximalFunction_toReal_eq (hf : MemLp f p μ) (hp : 1 < p)
     (hp_top : p ≠ ∞) :
-    eLpNorm (fun x => (maximalFunction mu f x).toReal) p mu =
-      eLpNorm (maximalFunction mu f) p mu := by
-  have hp₀ : p ≠ 0 := (zero_lt_one.trans hp).ne'
-  have hpr : 0 < p.toReal := ENNReal.toReal_pos hp₀ hp_top
-  have hfmeas : AEMeasurable (fun x => ‖f x‖ₑ) mu := hf.aestronglyMeasurable.enorm
-  have hMnorm : eLpNorm (maximalFunction mu f) p mu < ∞ :=
-    (eLpNorm_maximalFunction_le mu hfmeas hp hp_top).trans_lt (by finiteness)
-  have hMint : ∫⁻ x, maximalFunction mu f x ^ p.toReal ∂mu < ∞ :=
-    (eLpNorm_lt_top_iff_lintegral_rpow_enorm_lt_top hp₀ hp_top).mp hMnorm
-  have hMfinite : ∀ᵐ x ∂mu, maximalFunction mu f x < ∞ := by
-    have hrpow : ∀ᵐ x ∂mu, maximalFunction mu f x ^ p.toReal < ∞ :=
-      ae_lt_top' ((measurable_maximalFunction mu f).pow_const p.toReal).aemeasurable hMint.ne
-    exact hrpow.mono fun _ hx => (ENNReal.rpow_lt_top_iff_of_pos hpr).mp hx
+    eLpNorm (fun x => (maximalFunction μ f x).toReal) p μ =
+      eLpNorm (maximalFunction μ f) p μ := by
   apply eLpNorm_congr_enorm_ae
-  filter_upwards [hMfinite] with x hx
+  filter_upwards [ae_maximalFunction_lt_top_of_memLp hf hp hp_top] with x hx
   simp [Real.enorm_of_nonneg ENNReal.toReal_nonneg, ENNReal.ofReal_toReal hx.ne]
 
 /-- The real-valued representative of the maximal function of an `Lᵖ` function is again in
 `Lᵖ`, for `1 < p < ∞`. -/
-theorem memLp_maximalFunction_toReal (hf : MemLp f p mu) (hp : 1 < p) (hp_top : p ≠ ∞) :
-    MemLp (fun x => (maximalFunction mu f x).toReal) p mu := by
-  refine ⟨(measurable_maximalFunction mu f).ennreal_toReal.aestronglyMeasurable, ?_⟩
+theorem memLp_maximalFunction_toReal (hf : MemLp f p μ) (hp : 1 < p) (hp_top : p ≠ ∞) :
+    MemLp (fun x => (maximalFunction μ f x).toReal) p μ := by
+  refine ⟨(measurable_maximalFunction μ f).ennreal_toReal.aestronglyMeasurable, ?_⟩
   rw [eLpNorm_maximalFunction_toReal_eq hf hp hp_top]
-  exact (eLpNorm_maximalFunction_le mu hf.aestronglyMeasurable.enorm hp hp_top).trans_lt
+  exact (eLpNorm_maximalFunction_le μ hf.aestronglyMeasurable.enorm hp hp_top).trans_lt
     (by finiteness)
 
 /-- The Hardy–Littlewood maximal function as a well-defined nonlinear map on `Lᵖ`.
 
 Its values use the almost-everywhere-finite real representative
-`x ↦ (maximalFunction mu f x).toReal`; representative independence is inherited from
+`x ↦ (maximalFunction μ f x).toReal`; representative independence is inherited from
 `maximalFunction_congr_ae`. -/
-noncomputable def maximalFunctionLp (mu : Measure E) [mu.IsAddHaarMeasure] (p : ℝ≥0∞)
-    (hp : 1 < p) (hp_top : p ≠ ∞) : Lp F p mu → Lp ℝ p mu := fun f =>
+noncomputable def maximalFunctionLp (μ : Measure E) [μ.IsAddHaarMeasure] (p : ℝ≥0∞)
+    (hp : 1 < p) (hp_top : p ≠ ∞) : Lp F p μ → Lp ℝ p μ := fun f =>
   (memLp_maximalFunction_toReal (Lp.memLp f) hp hp_top).toLp
-    (fun x => (maximalFunction mu f x).toReal)
+    (fun x => (maximalFunction μ f x).toReal)
 
 /-- The `Lp` maximal-function map is represented by the real-valued maximal function. -/
-theorem coeFn_maximalFunctionLp (mu : Measure E) [mu.IsAddHaarMeasure] (hp : 1 < p)
-    (hp_top : p ≠ ∞) (f : Lp F p mu) :
-    maximalFunctionLp mu p hp hp_top f =ᵐ[mu]
-      fun x => (maximalFunction mu f x).toReal :=
+@[simp]
+theorem coeFn_maximalFunctionLp (μ : Measure E) [μ.IsAddHaarMeasure] (hp : 1 < p)
+    (hp_top : p ≠ ∞) (f : Lp F p μ) :
+    maximalFunctionLp μ p hp hp_top f =ᵐ[μ]
+      fun x => (maximalFunction μ f x).toReal :=
   MemLp.coeFn_toLp (memLp_maximalFunction_toReal (Lp.memLp f) hp hp_top)
 
+/-- On an `Lᵖ` element built from a `MemLp` representative, `maximalFunctionLp` is represented by
+the real-valued maximal function of that representative. -/
+theorem maximalFunctionLp_toLp (hf : MemLp f p μ) (hp : 1 < p) (hp_top : p ≠ ∞) :
+    maximalFunctionLp μ p hp hp_top (hf.toLp f) =ᵐ[μ]
+      fun x => (maximalFunction μ f x).toReal := by
+  refine (coeFn_maximalFunctionLp μ hp hp_top (hf.toLp f)).trans ?_
+  exact .of_forall fun x => congrArg ENNReal.toReal (maximalFunction_congr_ae
+    (hf.coeFn_toLp.mono fun _ hy => congrArg enorm hy))
+
 /-- The quotient-level maximal-function map satisfies the strong `(p,p)` bound. -/
-theorem enorm_maximalFunctionLp_le (mu : Measure E) [mu.IsAddHaarMeasure] (hp : 1 < p)
-    (hp_top : p ≠ ∞) (f : Lp F p mu) :
-    ‖maximalFunctionLp mu p hp hp_top f‖ₑ ≤
+theorem enorm_maximalFunctionLp_le (μ : Measure E) [μ.IsAddHaarMeasure] (hp : 1 < p)
+    (hp_top : p ≠ ∞) (f : Lp F p μ) :
+    ‖maximalFunctionLp μ p hp hp_top f‖ₑ ≤
       (ENNReal.ofReal (2 * p.toReal * 2 ^ (p.toReal - 1) / (p.toReal - 1)) *
         4 ^ finrank ℝ E) ^ (1 / p.toReal) * ‖f‖ₑ := by
   rw [Lp.enorm_def, Lp.enorm_def,
-    eLpNorm_congr_ae (coeFn_maximalFunctionLp mu hp hp_top f)]
+    eLpNorm_congr_ae (coeFn_maximalFunctionLp μ hp hp_top f)]
   rw [eLpNorm_maximalFunction_toReal_eq (Lp.memLp f) hp hp_top]
-  exact eLpNorm_maximalFunction_le mu (Lp.memLp f).aestronglyMeasurable.enorm hp hp_top
+  exact eLpNorm_maximalFunction_le μ (Lp.memLp f).aestronglyMeasurable.enorm hp hp_top
 
 end Lp
 

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -12,6 +12,9 @@ public import Mathlib.Topology.Semicontinuity.Defs
 -- `TauCeti.MeasureTheory.Integral.Marcinkiewicz` is imported privately: its operator-level
 -- interpolation API is used only to prove the strong maximal inequality below.
 import TauCeti.MeasureTheory.Integral.Marcinkiewicz
+-- `Mathlib.Analysis.Normed.Group.Real` is imported privately for the extended norm of
+-- `ENNReal.toReal`, used to descend the maximal function to `Lp`.
+import Mathlib.Analysis.Normed.Group.Real
 -- `Mathlib.MeasureTheory.Constructions.BorelSpace.Order` is imported privately: it is used only
 -- for `LowerSemicontinuous.measurable`, inside the proof of `TauCeti.measurable_maximalFunction`.
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Order
@@ -486,9 +489,20 @@ theorem lintegral_rpow_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure]
     rw [hinv, hsplit, ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2), ENNReal.ofReal_ofNat]
     ring
   rw [← hconst]
-  refine lintegral_rpow_le_of_mul_meas_ofReal_lt_le hf
-    (measurable_maximalFunction μ f).aemeasurable hp (by norm_num) fun t ht => ?_
-  simpa using mul_measure_lt_maximalFunction_le_setLIntegral μ hf ht
+  rw [← maximalFunction_enorm μ f]
+  simpa only [inv_inv, ENNReal.ofReal_ofNat, enorm_eq_self] using
+    lintegral_rpow_operator_le
+      (T := fun g => maximalFunction μ g) (A := 4 ^ finrank ℝ E) (b := 1)
+      (c := 2⁻¹) (d := 2⁻¹) hf
+      (measurable_maximalFunction μ fun x => ‖f x‖ₑ).aemeasurable hp
+      (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+      (fun hgh => .of_forall fun x => maximalFunction_congr_ae hgh)
+      (fun g h hg => .of_forall fun y => maximalFunction_add_le
+        (by simpa only [enorm_eq_self] using hg) y)
+      (fun g _hg s => by
+        simpa only [enorm_eq_self] using mul_measure_lt_maximalFunction_le μ g s)
+      (fun g => .of_forall fun y => by simpa only [ENNReal.ofReal_one, one_mul] using
+        maximalFunction_le_eLpNormEssSup μ g y)
 
 /-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
 in terms of representative-level `Lᵖ` seminorms.
@@ -541,7 +555,7 @@ theorem eLpNorm_maximalFunction_toReal_eq (hf : MemLp f p μ) (hp : 1 < p)
       eLpNorm (maximalFunction μ f) p μ := by
   apply eLpNorm_congr_enorm_ae
   filter_upwards [ae_maximalFunction_lt_top_of_memLp hf hp hp_top] with x hx
-  simp [Real.enorm_of_nonneg ENNReal.toReal_nonneg, ENNReal.ofReal_toReal hx.ne]
+  exact Real.enorm_toReal hx.ne
 
 /-- The real-valued representative of the maximal function of an `Lᵖ` function is again in
 `Lᵖ`, for `1 < p < ∞`. -/

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -59,10 +59,11 @@ where finiteness of `∫⁻ ‖f‖ₑ` enters: a ball whose average exceeds `t`
 `∫⁻ ‖f‖ₑ / t`, which in positive dimension bounds its radius. In dimension `0` it does not — every
 ball is the whole space — and that degenerate case is proved separately.
 
-The strong type `(p, p)` bound then comes from `TauCeti.lintegral_rpow_operator_le`, the
-operator-level diagonal case of Marcinkiewicz interpolation. That theorem performs the reusable
-split of `‖f‖ₑ` at the height `t / 2`: the low part is bounded by `t / 2`, so its maximal function
-never reaches `t`, and the weak-type bound applied to the high part gives
+The strong type `(p, p)` bound then comes from
+`TauCeti.lintegral_rpow_le_of_mul_meas_lt_le_of_le_eLpNormEssSup`, the operator-level diagonal
+case of Marcinkiewicz interpolation. That theorem performs the reusable split at height `c * t`.
+Here `c = d = 2⁻¹`, so the low part is bounded by `t / 2`, its maximal function never reaches
+`t`, and the weak-type bound applied to the high part gives
 `t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
 
 ## Main declarations
@@ -78,7 +79,7 @@ never reaches `t`, and the weak-type bound applied to the high part gives
   function unchanged.
 * `TauCeti.maximalFunction_zero`, `TauCeti.maximalFunction_add_le`,
   `TauCeti.maximalFunction_const_smul`: `M` is sublinear. Subadditivity and the endpoint bounds
-  feed directly into `TauCeti.lintegral_rpow_operator_le`.
+  feed directly into `TauCeti.lintegral_rpow_le_of_mul_meas_lt_le_of_le_eLpNormEssSup`.
 * `TauCeti.maximalFunction_le_eLpNormEssSup`: the `L^∞` endpoint.
 * `TauCeti.lowerSemicontinuous_maximalFunction`, `TauCeti.measurable_maximalFunction`: the
   superlevel sets `{x | t < M f x}` are open, so `M f` is Borel measurable.
@@ -454,18 +455,18 @@ theorem lintegral_rpow_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure]
   rw [← hconst]
   rw [← maximalFunction_enorm μ f]
   simpa only [inv_inv, ENNReal.ofReal_ofNat, enorm_eq_self] using
-    lintegral_rpow_operator_le
+    lintegral_rpow_le_of_mul_meas_lt_le_of_le_eLpNormEssSup
       (T := fun g => maximalFunction μ g) (A := 4 ^ finrank ℝ E) (b := 1)
       (c := 2⁻¹) (d := 2⁻¹) hf
       (measurable_maximalFunction μ fun x => ‖f x‖ₑ).aemeasurable hp
       (by norm_num) (by norm_num) (by norm_num) (by norm_num)
-      (fun hgh => .of_forall fun x => maximalFunction_congr_ae hgh)
-      (fun g h hg => .of_forall fun y => maximalFunction_add_le
+      (fun g h hg _hh => .of_forall fun y => maximalFunction_add_le
         (by simpa only [enorm_eq_self] using hg) y)
       (fun g _hg s => by
         simpa only [enorm_eq_self] using mul_measure_lt_maximalFunction_le μ g s)
-      (fun g => .of_forall fun y => by simpa only [ENNReal.ofReal_one, one_mul] using
-        maximalFunction_le_eLpNormEssSup μ g y)
+      (fun (g : E → ℝ≥0∞) (_hg : AEMeasurable g μ) =>
+        .of_forall fun y : E => by simpa only [ENNReal.ofReal_one, one_mul] using
+          maximalFunction_le_eLpNormEssSup μ g y)
 
 /-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
 in terms of representative-level `Lᵖ` seminorms.

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -5,11 +5,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 public import Mathlib.MeasureTheory.Integral.Average
 public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 public import Mathlib.Topology.Semicontinuity.Defs
 -- `TauCeti.MeasureTheory.Integral.Marcinkiewicz` is imported privately: it supplies
--- `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`, used only inside the proof of
+-- `TauCeti.lintegral_rpow_operator_le`, used only inside the proof of
 -- `TauCeti.lintegral_rpow_maximalFunction_le`.
 import TauCeti.MeasureTheory.Integral.Marcinkiewicz
 -- `Mathlib.MeasureTheory.Constructions.BorelSpace.Order` is imported privately: it is used only
@@ -60,11 +61,10 @@ where finiteness of `∫⁻ ‖f‖ₑ` enters: a ball whose average exceeds `t`
 `∫⁻ ‖f‖ₑ / t`, which in positive dimension bounds its radius. In dimension `0` it does not — every
 ball is the whole space — and that degenerate case is proved separately.
 
-The strong type `(p, p)` bound then comes from
-`TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`, the diagonal case of Marcinkiewicz
-interpolation. Its hypothesis is supplied by splitting `‖f‖ₑ` at the height `t / 2`: the low part
-is bounded by `t / 2`, so its maximal function never reaches `t`, and the weak-type bound applied
-to the high part gives
+The strong type `(p, p)` bound then comes from `TauCeti.lintegral_rpow_operator_le`, the
+operator-level diagonal case of Marcinkiewicz interpolation. That theorem performs the reusable
+split of `‖f‖ₑ` at the height `t / 2`: the low part is bounded by `t / 2`, so its maximal function
+never reaches `t`, and the weak-type bound applied to the high part gives
 `t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
 
 ## Main declarations
@@ -77,9 +77,8 @@ to the high part gives
 * `TauCeti.maximalFunction_mono_ae`, `TauCeti.maximalFunction_congr_ae`: `M` is monotone in `‖f‖ₑ`
   almost everywhere, so `M f` depends on `f` only through `‖f‖ₑ` and only up to a null set.
 * `TauCeti.maximalFunction_zero`, `TauCeti.maximalFunction_add_le`,
-  `TauCeti.maximalFunction_const_smul`: `M` is sublinear. Subadditivity is what
-  `TauCeti.mul_measure_lt_maximalFunction_le_setLIntegral` uses to build the hypothesis of
-  `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`.
+  `TauCeti.maximalFunction_const_smul`: `M` is sublinear. Subadditivity and the endpoint bounds
+  feed directly into `TauCeti.lintegral_rpow_operator_le`.
 * `TauCeti.maximalFunction_le_eLpNormEssSup`: the `L^∞` endpoint.
 * `TauCeti.lowerSemicontinuous_maximalFunction`, `TauCeti.measurable_maximalFunction`: the
   superlevel sets `{x | t < M f x}` are open, so `M f` is Borel measurable.
@@ -92,6 +91,8 @@ to the high part gives
   truncation of `f` at half the height, the form Marcinkiewicz interpolation consumes.
 * `TauCeti.lintegral_rpow_maximalFunction_le`, `TauCeti.eLpNorm_maximalFunction_le`: the
   **strong type `(p, p)` maximal inequality** for `1 < p < ∞`, with an explicit constant.
+* `TauCeti.memLp_maximalFunction_toReal`, `TauCeti.maximalFunctionLp`: the real-valued maximal
+  function preserves `MemLp` and therefore descends to a nonlinear map `Lp F p μ → Lp ℝ p μ`.
 
 The maximal function defined here is the *centred* one, whose averages are over the balls centred
 at the point. The uncentred variant, over all balls containing the point, is comparable to it with
@@ -433,83 +434,26 @@ section StrongType
 
 `t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
 
-Splitting `‖f‖ₑ` at the height `t / 2` and discarding the low part, whose maximal function is at
-most `t / 2` by the `L^∞` endpoint, is what turns
-`TauCeti.mul_measure_lt_maximalFunction_le` into the hypothesis of Marcinkiewicz
-interpolation. The split is carried out in `ℝ≥0∞`, since `M f` depends on `f` only through
-`‖f‖ₑ`. -/
+This is a specialization of `TauCeti.mul_meas_ofReal_lt_operator_le_setLIntegral`; the reusable
+theorem carries out the split in `ℝ≥0∞`, using subadditivity and the `L^∞` endpoint. -/
 theorem mul_measure_lt_maximalFunction_le_setLIntegral (μ : Measure E) [μ.IsAddHaarMeasure]
     {f : E → F} (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {t : ℝ} (ht : 0 < t) :
     ENNReal.ofReal t * μ {x | ENNReal.ofReal t < maximalFunction μ f x} ≤
       2 * 4 ^ finrank ℝ E * ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
-  have hhalf : (0 : ℝ) ≤ 2⁻¹ * t := by positivity
-  have htwo : ENNReal.ofReal t = 2 * ENNReal.ofReal (2⁻¹ * t) := by
-    rw [← ENNReal.ofReal_ofNat 2, ← ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2)]
-    ring_nf
-  -- Split `‖f‖ₑ` at the height `t / 2`, cutting along a measurable representative `g`.
-  set g : E → ℝ≥0∞ := hf.mk (fun x => ‖f x‖ₑ) with hgdef
-  have hfg : (fun x => ‖f x‖ₑ) =ᵐ[μ] g := hf.ae_eq_mk
-  have hgmeas : Measurable g := hf.measurable_mk
-  set S : Set E := {x | ENNReal.ofReal (2⁻¹ * t) < g x} with hSdef
-  have hSmeas : MeasurableSet S := measurableSet_lt measurable_const hgmeas
-  set g₁ : E → ℝ≥0∞ := S.indicator g with hg₁def
-  set g₂ : E → ℝ≥0∞ := Sᶜ.indicator g with hg₂def
-  have hsplit : ∀ x, g₁ x + g₂ x = g x := by
-    rw [hg₁def, hg₂def]
-    exact Set.indicator_self_add_compl_apply S g
-  -- `M f = M (g₁ + g₂)`, because `M` sees `f` only through `‖f‖ₑ`, which is `g` almost everywhere.
-  have hMf : ∀ x, maximalFunction μ f x = maximalFunction μ (g₁ + g₂) x := fun x =>
-    maximalFunction_congr_ae (by
-      filter_upwards [hfg] with y hy
-      rw [hy, enorm_eq_self, Pi.add_apply, hsplit y])
-  -- The low part is bounded by `t / 2`, hence so is its maximal function.
-  have hM₂ : ∀ x, maximalFunction μ g₂ x ≤ ENNReal.ofReal (2⁻¹ * t) := by
-    have hbound : ∀ x, ‖g₂ x‖ₑ ≤ ENNReal.ofReal (2⁻¹ * t) := by
-      intro x
-      rw [enorm_eq_self, hg₂def]
-      by_cases hxS : x ∈ S
-      · rw [Set.indicator_of_notMem (by simp [hxS])]
-        exact zero_le
-      · rw [Set.indicator_of_mem (by simp [hxS])]
-        exact not_lt.1 (by simpa [hSdef] using hxS)
-    exact fun x => (maximalFunction_le_eLpNormEssSup μ g₂ x).trans
-      (essSup_le_of_ae_le _ (.of_forall hbound))
-  -- Hence `M f > t` forces `M g₁ > t / 2`.
-  have hincl : {x | ENNReal.ofReal t < maximalFunction μ f x} ⊆
-      {x | ENNReal.ofReal (2⁻¹ * t) < maximalFunction μ g₁ x} := by
-    intro x hx
-    have h1 : maximalFunction μ f x ≤ maximalFunction μ g₁ x + maximalFunction μ g₂ x := by
-      rw [hMf x]
-      exact maximalFunction_add_le (hgmeas.indicator hSmeas).aemeasurable x
-    have h2 : ENNReal.ofReal (2⁻¹ * t) + ENNReal.ofReal (2⁻¹ * t) <
-        maximalFunction μ g₁ x + ENNReal.ofReal (2⁻¹ * t) := by
-      have hsum : 2⁻¹ * t + 2⁻¹ * t = t := by ring
-      rw [← ENNReal.ofReal_add hhalf hhalf, hsum]
-      exact lt_of_lt_of_le hx (h1.trans (add_le_add le_rfl (hM₂ x)))
-    exact (ENNReal.add_lt_add_iff_right ENNReal.ofReal_ne_top).1 h2
-  -- The `L¹` norm of the high part is the truncated integral.
-  have hint : ∫⁻ x, ‖g₁ x‖ₑ ∂μ =
-      ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
-    have hsets : {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ} =ᵐ[μ] S := by
-      filter_upwards [hfg] with x hx
-      exact congrArg (fun z : ℝ≥0∞ => ENNReal.ofReal (2⁻¹ * t) < z) hx
-    calc ∫⁻ x, ‖g₁ x‖ₑ ∂μ
-        = ∫⁻ x in S, g x ∂μ := by
-          simp only [enorm_eq_self, hg₁def]
-          exact lintegral_indicator hSmeas g
-      _ = ∫⁻ x in S, ‖f x‖ₑ ∂μ := (lintegral_congr_ae (ae_restrict_of_ae hfg)).symm
-      _ = ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
-          rw [Measure.restrict_congr_set hsets]
-  calc ENNReal.ofReal t * μ {x | ENNReal.ofReal t < maximalFunction μ f x}
-      = 2 * (ENNReal.ofReal (2⁻¹ * t) * μ {x | ENNReal.ofReal t < maximalFunction μ f x}) := by
-        rw [htwo, mul_assoc]
-    _ ≤ 2 * (ENNReal.ofReal (2⁻¹ * t) *
-          μ {x | ENNReal.ofReal (2⁻¹ * t) < maximalFunction μ g₁ x}) :=
-        mul_le_mul_right (mul_le_mul_right (measure_mono hincl) _) 2
-    _ ≤ 2 * (4 ^ finrank ℝ E * ∫⁻ x, ‖g₁ x‖ₑ ∂μ) :=
-        mul_le_mul_right (mul_measure_lt_maximalFunction_le μ g₁ _) 2
-    _ = 2 * 4 ^ finrank ℝ E * ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
-        rw [hint, mul_assoc]
+  have hM : maximalFunction μ (fun x => ‖f x‖ₑ) = maximalFunction μ f :=
+    funext fun x => maximalFunction_congr_ae (.of_forall fun y => by simp)
+  rw [← hM]
+  simpa only [inv_inv, ENNReal.ofReal_ofNat, enorm_eq_self]
+    using mul_meas_ofReal_lt_operator_le_setLIntegral
+      (T := fun g => maximalFunction μ g) (A := 4 ^ finrank ℝ E) (b := 1)
+      (c := 2⁻¹) (d := 2⁻¹)
+      hf ht (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+      (fun hgh => .of_forall fun x => maximalFunction_congr_ae
+        (hgh.mono fun y hy => by simpa only [enorm_eq_self] using hy))
+      (fun g h hg y => maximalFunction_add_le hg y)
+      (fun g s => by simpa only [enorm_eq_self] using mul_measure_lt_maximalFunction_le μ g s)
+      (fun g y => by simpa only [ENNReal.ofReal_one, one_mul] using
+        maximalFunction_le_eLpNormEssSup μ g y)
 
 /-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
 as an inequality between the integrals `∫⁻ ‖·‖ₑ ^ p`:
@@ -532,16 +476,26 @@ theorem lintegral_rpow_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure]
     rw [hinv, hsplit, ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2), ENNReal.ofReal_ofNat]
     ring
   rw [← hconst]
-  refine lintegral_rpow_le_of_mul_meas_ofReal_lt_le hf
-    (measurable_maximalFunction μ f).aemeasurable hp (by norm_num) fun t ht => ?_
-  simpa using mul_measure_lt_maximalFunction_le_setLIntegral μ hf ht
+  have hM : maximalFunction μ (fun x => ‖f x‖ₑ) = maximalFunction μ f :=
+    funext fun x => maximalFunction_congr_ae (.of_forall fun y => by simp)
+  rw [← hM]
+  simpa only [inv_inv, ENNReal.ofReal_ofNat, enorm_eq_self] using lintegral_rpow_operator_le
+      (T := fun g => maximalFunction μ g) (A := 4 ^ finrank ℝ E) (b := 1)
+      (c := 2⁻¹) (d := 2⁻¹) hf (measurable_maximalFunction μ f).aemeasurable hp
+      (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+      (fun hgh => .of_forall fun x => maximalFunction_congr_ae
+        (hgh.mono fun y hy => by simpa only [enorm_eq_self] using hy))
+      (fun g h hg y => maximalFunction_add_le hg y)
+      (fun g s => by simpa only [enorm_eq_self] using mul_measure_lt_maximalFunction_le μ g s)
+      (fun g y => by simpa only [ENNReal.ofReal_one, one_mul] using
+        maximalFunction_le_eLpNormEssSup μ g y)
 
 /-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
-in terms of the `Lᵖ` seminorms: `M` is a bounded (nonlinear) operator on `Lᵖ`.
+in terms of representative-level `Lᵖ` seminorms.
 
 Together with `TauCeti.maximalFunction_le_eLpNormEssSup` (the case `p = ∞`) and
-`TauCeti.mul_measure_lt_maximalFunction_le` (the weak-type substitute at `p = 1`), this completes
-the `Lᵖ` theory of the maximal function. -/
+`TauCeti.mul_measure_lt_maximalFunction_le` (the weak-type substitute at `p = 1`), this supplies
+the estimate used below to define the bounded nonlinear map `TauCeti.maximalFunctionLp`. -/
 theorem eLpNorm_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E → F}
     (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {p : ℝ≥0∞} (hp : 1 < p) (hp_top : p ≠ ∞) :
     eLpNorm (maximalFunction μ f) p μ ≤
@@ -558,5 +512,72 @@ theorem eLpNorm_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E
 end StrongType
 
 end Haar
+
+section Lp
+
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E]
+  [BorelSpace E] [FiniteDimensional ℝ E] [NormedAddCommGroup F] {p : ℝ≥0∞} {f : E → F}
+  {mu : Measure E} [mu.IsAddHaarMeasure]
+
+/-- Converting the maximal function to a real-valued function does not change its `Lᵖ` seminorm
+when the input belongs to `Lᵖ` and `1 < p < ∞`. The strong-type estimate makes the extended-valued
+maximal function finite almost everywhere. -/
+theorem eLpNorm_maximalFunction_toReal_eq (hf : MemLp f p mu) (hp : 1 < p)
+    (hp_top : p ≠ ∞) :
+    eLpNorm (fun x => (maximalFunction mu f x).toReal) p mu =
+      eLpNorm (maximalFunction mu f) p mu := by
+  have hp₀ : p ≠ 0 := (zero_lt_one.trans hp).ne'
+  have hpr : 0 < p.toReal := ENNReal.toReal_pos hp₀ hp_top
+  have hfmeas : AEMeasurable (fun x => ‖f x‖ₑ) mu := hf.aestronglyMeasurable.enorm
+  have hMnorm : eLpNorm (maximalFunction mu f) p mu < ∞ :=
+    (eLpNorm_maximalFunction_le mu hfmeas hp hp_top).trans_lt (by finiteness)
+  have hMint : ∫⁻ x, maximalFunction mu f x ^ p.toReal ∂mu < ∞ :=
+    (eLpNorm_lt_top_iff_lintegral_rpow_enorm_lt_top hp₀ hp_top).mp hMnorm
+  have hMfinite : ∀ᵐ x ∂mu, maximalFunction mu f x < ∞ := by
+    have hrpow : ∀ᵐ x ∂mu, maximalFunction mu f x ^ p.toReal < ∞ :=
+      ae_lt_top' ((measurable_maximalFunction mu f).pow_const p.toReal).aemeasurable hMint.ne
+    exact hrpow.mono fun _ hx => (ENNReal.rpow_lt_top_iff_of_pos hpr).mp hx
+  apply eLpNorm_congr_enorm_ae
+  filter_upwards [hMfinite] with x hx
+  simp [Real.enorm_of_nonneg ENNReal.toReal_nonneg, ENNReal.ofReal_toReal hx.ne]
+
+/-- The real-valued representative of the maximal function of an `Lᵖ` function is again in
+`Lᵖ`, for `1 < p < ∞`. -/
+theorem memLp_maximalFunction_toReal (hf : MemLp f p mu) (hp : 1 < p) (hp_top : p ≠ ∞) :
+    MemLp (fun x => (maximalFunction mu f x).toReal) p mu := by
+  refine ⟨(measurable_maximalFunction mu f).ennreal_toReal.aestronglyMeasurable, ?_⟩
+  rw [eLpNorm_maximalFunction_toReal_eq hf hp hp_top]
+  exact (eLpNorm_maximalFunction_le mu hf.aestronglyMeasurable.enorm hp hp_top).trans_lt
+    (by finiteness)
+
+/-- The Hardy–Littlewood maximal function as a well-defined nonlinear map on `Lᵖ`.
+
+Its values use the almost-everywhere-finite real representative
+`x ↦ (maximalFunction mu f x).toReal`; representative independence is inherited from
+`maximalFunction_congr_ae`. -/
+noncomputable def maximalFunctionLp (mu : Measure E) [mu.IsAddHaarMeasure] (p : ℝ≥0∞)
+    (hp : 1 < p) (hp_top : p ≠ ∞) : Lp F p mu → Lp ℝ p mu := fun f =>
+  (memLp_maximalFunction_toReal (Lp.memLp f) hp hp_top).toLp
+    (fun x => (maximalFunction mu f x).toReal)
+
+/-- The `Lp` maximal-function map is represented by the real-valued maximal function. -/
+theorem coeFn_maximalFunctionLp (mu : Measure E) [mu.IsAddHaarMeasure] (hp : 1 < p)
+    (hp_top : p ≠ ∞) (f : Lp F p mu) :
+    maximalFunctionLp mu p hp hp_top f =ᵐ[mu]
+      fun x => (maximalFunction mu f x).toReal :=
+  MemLp.coeFn_toLp (memLp_maximalFunction_toReal (Lp.memLp f) hp hp_top)
+
+/-- The quotient-level maximal-function map satisfies the strong `(p,p)` bound. -/
+theorem enorm_maximalFunctionLp_le (mu : Measure E) [mu.IsAddHaarMeasure] (hp : 1 < p)
+    (hp_top : p ≠ ∞) (f : Lp F p mu) :
+    ‖maximalFunctionLp mu p hp hp_top f‖ₑ ≤
+      (ENNReal.ofReal (2 * p.toReal * 2 ^ (p.toReal - 1) / (p.toReal - 1)) *
+        4 ^ finrank ℝ E) ^ (1 / p.toReal) * ‖f‖ₑ := by
+  rw [Lp.enorm_def, Lp.enorm_def,
+    eLpNorm_congr_ae (coeFn_maximalFunctionLp mu hp hp_top f)]
+  rw [eLpNorm_maximalFunction_toReal_eq (Lp.memLp f) hp hp_top]
+  exact eLpNorm_maximalFunction_le mu (Lp.memLp f).aestronglyMeasurable.enorm hp hp_top
+
+end Lp
 
 end TauCeti


### PR DESCRIPTION
## Summary

- add an operator-level Marcinkiewicz theorem deriving the truncated distribution estimate and strong `(p,p)` bound from a.e. congruence, subadditivity, weak `(1,1)`, and `L∞` endpoint bounds
- specialize the reusable theorem directly in the Hardy–Littlewood strong maximal inequality, removing the duplicated operator-specific truncation proof
- generalize the input to any measurable extended-seminormed additive monoid and formulate the operator laws almost everywhere

## Verification

- `lake build --iofail`
- `bash scripts/lint-env.sh`
- `lake exe axioms`

This advances `TauCetiRoadmap/PDE/README.md`, Lane B target 9 (Marcinkiewicz interpolation), and uses the existing Lane B target 8 maximal theorem as its concrete specialization.

Roadmap: PDE

Part of #3566
