### PR TITLE
feat: expose the classified Dynkin type of a base

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Basic.lean
@@ -52,6 +52,10 @@ denominators. The symmetrization itself is not redone here: Mathlib packages it 
 * `TauCeti.IsFiniteType.apply_mul_apply_mem_of_ne`: the rank-two bound. For `i ≠ j` the Cartan
   product `A i j * A j i` lies in `{0, 1, 2, 3}`, so every edge of the diagram is single, double or
   triple.
+* `TauCeti.IsFiniteType.isSimplyLaced_iff`: **a finite-type matrix is simply laced exactly when
+  none of its edges is multiple**, that is, when no Cartan product of two distinct indices exceeds
+  `1`. Together with the rank-two bound this is how the classification enters its simply-laced
+  branch, having excluded the Cartan products `2` and `3`.
 * `TauCeti.IsFiniteType.exists_apply_succ_eq_zero`: **a finite-type diagram carries no cycle**. A
   cyclic list of at least three distinct indices has a missing edge. This is the second estimate:
   the test vector is supported on the indices of the putative cycle, its coordinate at each of them
@@ -353,6 +357,31 @@ theorem apply_mul_apply_mem_of_ne (h : IsFiniteType A) {i j : B} (hij : i ≠ j)
     mul_nonneg_of_nonpos_of_nonpos (h.apply_le_zero_of_ne hij) (h.apply_le_zero_of_ne hij.symm)
   simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
   omega
+
+/-- **A finite-type matrix is simply laced exactly when none of its edges is multiple.** The Cartan
+product `A i j * A j i` is the multiplicity of the edge joining `i` and `j`, so the condition on the
+right says that every edge is single: no double edge, and no triple edge.
+
+Only the off-diagonal entries are constrained, one entry of a transposed pair at a time, and that
+is enough because the entries of such a pair vanish together and a product of two nonpositive
+integers is `1` only when both are `-1`. -/
+theorem isSimplyLaced_iff (h : IsFiniteType A) :
+    A.IsSimplyLaced ↔ ∀ i j, i ≠ j → A i j * A j i ≤ 1 := by
+  constructor
+  · intro hsl i j hij
+    rcases hsl hij with hij' | hij' <;> rcases hsl hij.symm with hji | hji <;> simp [hij', hji]
+  · intro hle i j hij
+    have hbound := hle i j hij
+    have hnonneg : 0 ≤ A i j * A j i :=
+      mul_nonneg_of_nonpos_of_nonpos (h.apply_le_zero_of_ne hij) (h.apply_le_zero_of_ne hij.symm)
+    rcases (by omega : A i j * A j i = 0 ∨ A i j * A j i = 1) with hzero | hone
+    · rcases mul_eq_zero.mp hzero with hij' | hji
+      · exact Or.inl hij'
+      · exact Or.inl (h.apply_eq_zero_symm hji)
+    · rcases Int.eq_one_or_neg_one_of_mul_eq_one' hone with ⟨hij', -⟩ | ⟨hij', -⟩
+      · have := h.apply_le_zero_of_ne hij
+        omega
+      · exact Or.inr hij'
 
 /-- **On a cycle of length at least three an index and its two cyclic neighbours are pairwise
 distinct.** Successor and predecessor are the cyclic ones, taken in the additive group `Fin m`.

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
@@ -8,6 +8,10 @@ module
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.DoubleEdge.Classification
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Star.Reindex
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.TripleEdge
+-- `TauCeti.LinearAlgebra.RootSystem.Isomorphism` supplies the rigidity theorem
+-- `TauCeti.nonempty_equiv_of_hasCartanType`, which `nonempty_equiv_of_classifiedDynkinType_eq`
+-- feeds the selected type to.
+public import TauCeti.LinearAlgebra.RootSystem.Isomorphism
 
 public section
 
@@ -42,6 +46,19 @@ Uniqueness among valid types is supplied by `TauCeti.DynkinType.eq_of_valid_of_f
   has a unique valid Dynkin type.
 * `TauCeti.existsUnique_dynkinType`: the Cartan-Killing classification for irreducible reduced
   crystallographic finite root systems.
+* `TauCeti.classifiedDynkinType`: the selected type as data, with
+  `TauCeti.valid_classifiedDynkinType`, `TauCeti.hasCartanType_classifiedDynkinType` and
+  `TauCeti.hasCartanType_iff_eq_classifiedDynkinType` characterizing it. This is what a consumer
+  names instead of rechoosing a witness out of the existence statement.
+* `TauCeti.nonempty_equiv_of_classifiedDynkinType_eq`: two root systems whose bases have the same
+  Dynkin type are isomorphic, the classification combined with the rigidity theorem
+  `TauCeti.nonempty_equiv_of_hasCartanType`.
+
+The roadmap's summit needs one more ingredient than these: the coordinate realization of each valid
+type over `ℚ`, which would turn the type of a base into a model root system and the statements here
+into a bijection between isomorphism classes and valid types. That realization, and the
+independence of the type from the chosen base, are separate roadmap targets and are not proved
+here.
 
 ## References
 
@@ -73,36 +90,14 @@ theorem existsUnique_dynkinType (h : IsFiniteType A) (hconn : (diagramGraph A).C
   · by_cases h2 : ∃ u v : B, A u v * A v u = 2
     · obtain ⟨u, v, huv⟩ := h2
       exact h.existsUnique_dynkinType_of_apply_mul_apply_eq_two hconn.preconnected huv
-    · have hsl : A.IsSimplyLaced := by
-        intro i j hij
+    · -- With the Cartan products `2` and `3` excluded, the rank-two bound leaves only `0` and `1`,
+      -- and a finite-type matrix all of whose edges are single is simply laced.
+      have hsl : A.IsSimplyLaced := h.isSimplyLaced_iff.mpr fun i j hij ↦ by
         have hmem := h.apply_mul_apply_mem_of_ne hij
-        have hle_i : A i j ≤ 0 := h.apply_le_zero_of_ne hij
-        have hle_j : A j i ≤ 0 := h.apply_le_zero_of_ne hij.symm
-        have hnot3 : A i j * A j i ≠ 3 := fun h' ↦ h3 ⟨i, j, h'⟩
         have hnot2 : A i j * A j i ≠ 2 := fun h' ↦ h2 ⟨i, j, h'⟩
+        have hnot3 : A i j * A j i ≠ 3 := fun h' ↦ h3 ⟨i, j, h'⟩
         simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
-        rcases hmem with h0 | h1 | h2' | h3'
-        · have hz : A i j = 0 := by
-            by_contra hnz
-            have hjz : A j i = 0 := by
-              cases mul_eq_zero.mp h0 with
-              | inl h' => contradiction
-              | inr h' => exact h'
-            have hsymm := h.apply_eq_zero_symm hjz
-            exact hnz hsymm
-          left; exact hz
-        · have : A i j = -1 := by
-            have hne : A i j ≠ 0 := fun hc ↦ by rw [hc, zero_mul] at h1; contradiction
-            have hlt : A i j ≤ -1 := by omega
-            have hne' : A j i ≠ 0 := fun hc ↦ by rw [hc, mul_zero] at h1; contradiction
-            have hlt' : A j i ≤ -1 := by omega
-            by_contra hc
-            have : A i j ≤ -2 := by omega
-            have : 2 ≤ A i j * A j i := by nlinarith
-            omega
-          right; exact this
-        · contradiction
-        · contradiction
+        omega
       by_cases hc : ∃ c : B, (diagramGraph A).degree c = 3
       · obtain ⟨c, hc3⟩ := hc
         exact h.existsUnique_dynkinType_of_isSimplyLaced_of_degree_eq_three hconn hsl hc3
@@ -133,6 +128,64 @@ theorem existsUnique_dynkinType (b : P.Base) :
     (isFiniteType_cartanMatrix b).existsUnique_dynkinType
       (connected_diagramGraph_cartanMatrix b)
   exact ((hasCartanType_iff b t).mpr ⟨e, he⟩).existsUnique_of_valid ht
+
+/-- **The Dynkin type of a base**, the valid type that `TauCeti.existsUnique_dynkinType` selects,
+as data rather than as an existence statement. Its two defining properties are
+`TauCeti.valid_classifiedDynkinType` and `TauCeti.hasCartanType_classifiedDynkinType`, and
+`TauCeti.hasCartanType_iff_eq_classifiedDynkinType` says they pin it down.
+
+It is noncomputable: the classification says which types occur and that the type of a base is
+unique, not how to read it off a root system.
+
+The type is attached to a base, not to the root system. Classically it does not depend on the base,
+since the Weyl group acts transitively on bases, but that independence is a roadmap target of its
+own and nothing here assumes it. -/
+noncomputable def classifiedDynkinType (b : P.Base) : DynkinType :=
+  (existsUnique_dynkinType b).choose
+
+/-- The Dynkin type of a base is valid: it is one of `Aₙ` (`n ≥ 1`), `Bₙ` (`n ≥ 2`), `Cₙ`
+(`n ≥ 3`), `Dₙ` (`n ≥ 4`), `E₆`, `E₇`, `E₈`, `F₄`, `G₂`. -/
+lemma valid_classifiedDynkinType (b : P.Base) : (classifiedDynkinType b).Valid :=
+  (existsUnique_dynkinType b).choose_spec.1.1
+
+/-- The Cartan matrix of a base is the standard Cartan matrix of its Dynkin type, up to a
+relabelling of the simple roots by the nodes of that type. -/
+lemma hasCartanType_classifiedDynkinType (b : P.Base) :
+    HasCartanType P b (classifiedDynkinType b) :=
+  (existsUnique_dynkinType b).choose_spec.1.2
+
+/-- **A valid Cartan type of a base is its Dynkin type.** This is the uniqueness half of
+`TauCeti.existsUnique_dynkinType`, in the form that identifies a type produced elsewhere - by a
+coordinate model, say - with the selected one. -/
+lemma HasCartanType.classifiedDynkinType_eq {b : P.Base} {t : DynkinType}
+    (h : HasCartanType P b t) (ht : t.Valid) : classifiedDynkinType b = t :=
+  (hasCartanType_classifiedDynkinType b).eq_of_valid h (valid_classifiedDynkinType b) ht
+
+/-- A base has a given valid Cartan type exactly when that type is its Dynkin type. -/
+lemma hasCartanType_iff_eq_classifiedDynkinType (b : P.Base) {t : DynkinType} (ht : t.Valid) :
+    HasCartanType P b t ↔ t = classifiedDynkinType b :=
+  ⟨fun h ↦ (h.classifiedDynkinType_eq ht).symm, fun h ↦ h ▸ hasCartanType_classifiedDynkinType b⟩
+
+/-- The rank of the Dynkin type of a base is the number of simple roots. -/
+lemma rank_classifiedDynkinType (b : P.Base) :
+    (classifiedDynkinType b).rank = b.support.card :=
+  (hasCartanType_classifiedDynkinType b).card_support.symm
+
+variable {ι₂ M₂ N₂ : Type*} [AddCommGroup M₂] [Module R M₂] [AddCommGroup N₂] [Module R N₂]
+  {P₂ : RootPairing ι₂ R M₂ N₂} [Finite ι₂] [P₂.IsRootSystem] [P₂.IsCrystallographic]
+  [P₂.IsReduced] [P₂.IsIrreducible] [Nonempty ι₂]
+
+/-- **Two root systems whose bases have the same Dynkin type are isomorphic.** This is the
+classification and the rigidity theorem `TauCeti.nonempty_equiv_of_hasCartanType` in one statement:
+the Dynkin type of a base determines the root system it comes from, up to isomorphism.
+
+The converse - isomorphic root systems have bases of the same Dynkin type - needs the Dynkin type
+to be independent of the base, which is not proved here. -/
+theorem nonempty_equiv_of_classifiedDynkinType_eq (b : P.Base) (b₂ : P₂.Base)
+    (h : classifiedDynkinType b = classifiedDynkinType b₂) : Nonempty (P.Equiv P₂) :=
+  nonempty_equiv_of_hasCartanType b b₂ (classifiedDynkinType b)
+    (hasCartanType_classifiedDynkinType b)
+    ((hasCartanType_iff_eq_classifiedDynkinType b₂ (valid_classifiedDynkinType b)).mpr h)
 
 end RootPairing
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Classification.lean
@@ -10,8 +10,9 @@ public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Star.Reindex
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.TripleEdge
 -- `TauCeti.LinearAlgebra.RootSystem.Isomorphism` supplies the rigidity theorem
 -- `TauCeti.nonempty_equiv_of_hasCartanType`, which `nonempty_equiv_of_classifiedDynkinType_eq`
--- feeds the selected type to.
-public import TauCeti.LinearAlgebra.RootSystem.Isomorphism
+-- feeds the selected type to. Nothing from it appears in a statement here, so the import stays
+-- private.
+import TauCeti.LinearAlgebra.RootSystem.Isomorphism
 
 public section
 
@@ -54,11 +55,12 @@ Uniqueness among valid types is supplied by `TauCeti.DynkinType.eq_of_valid_of_f
   Dynkin type are isomorphic, the classification combined with the rigidity theorem
   `TauCeti.nonempty_equiv_of_hasCartanType`.
 
-The roadmap's summit needs one more ingredient than these: the coordinate realization of each valid
-type over `ℚ`, which would turn the type of a base into a model root system and the statements here
-into a bijection between isomorphism classes and valid types. That realization, and the
-independence of the type from the chosen base, are separate roadmap targets and are not proved
-here.
+The roadmap's summit needs two ingredients beyond these, and neither is proved here. One is the
+coordinate realization of each valid type over `ℚ`, which turns a type into a model root system and
+so supplies the existence half. The other is the independence of the type from the chosen base,
+without which the classifier below classifies bases rather than root systems. With both, the
+statements here become the advertised bijection between isomorphism classes of irreducible reduced
+crystallographic finite root systems and valid Dynkin types.
 
 ## References
 


### PR DESCRIPTION
This PR packages the Cartan-Killing classification as data a consumer can name: `TauCeti.classifiedDynkinType b` is the valid Dynkin type that `TauCeti.existsUnique_dynkinType` selects for a base, characterized by `valid_classifiedDynkinType`, `hasCartanType_classifiedDynkinType`, `HasCartanType.classifiedDynkinType_eq` and `hasCartanType_iff_eq_classifiedDynkinType`, with `rank_classifiedDynkinType` reading its rank off the number of simple roots. Downstream code no longer has to rechoose a witness out of the existence statement. Feeding the selected type to the rigidity theorem gives `TauCeti.nonempty_equiv_of_classifiedDynkinType_eq`: two root systems whose bases have the same Dynkin type are isomorphic.

It also extracts the simply-laced criterion that sat inside the classifier into the finite-type matrix API as `TauCeti.IsFiniteType.isSimplyLaced_iff`: a finite-type matrix is simply laced exactly when no Cartan product of two distinct indices exceeds `1`. The classifier's simply-laced branch is now the four lines that discharge the Cartan products `2` and `3` against the rank-two bound.

Base independence of the type, the coordinate realization of each valid type over `ℚ`, and the bijection between isomorphism classes and valid types that those two would unlock remain separate roadmap targets; the module docstring now says what the roadmap's summit is still missing.

Closes #3563.

Roadmap: RepresentationTheory

🤖 Prepared with Claude Code