### PR TITLE
feat: state Krull-Schmidt for external direct sums and bridge indecomposability to ModuleCat

### DIFF
--- a/TauCeti/Algebra/Category/ModuleCat/Indecomposable.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Indecomposable.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Abelian
+public import TauCeti.CategoryTheory.Preadditive.Indecomposable
+public import TauCeti.RingTheory.KrullSchmidt.Indecomposable
+
+/-!
+# Indecomposable modules are the indecomposable objects of `ModuleCat`
+
+`TauCeti.IsIndecomposableModule A M` says that `M` is nonzero and is not the internal direct sum of
+two nonzero submodules; `CategoryTheory.Indecomposable X` says that `X` is not a zero object and
+that in every decomposition `X ≅ Y ⊞ Z` one of `Y`, `Z` is zero. This file identifies the two for
+objects of `ModuleCat A`, so that a client working with representations — where categorical
+indecomposability is the natural interface — can reach Fitting's lemma and the Krull-Schmidt
+theorem, which are stated for the module predicate.
+
+## Main results
+
+* `TauCeti.indecomposable_iff_isIndecomposableModule`: an object of `ModuleCat A` is indecomposable
+  exactly when its underlying module is, with
+  `TauCeti.isIndecomposableModule_iff_indecomposable` reading the same equivalence off a bare
+  module through `ModuleCat.of`.
+* `TauCeti.indecomposable_iff_isLocalRing_end`: an object of `ModuleCat A` whose underlying module
+  has finite length is indecomposable exactly when `CategoryTheory.End` of it is local, which is
+  Fitting's lemma stated categorically.
+
+## Implementation notes
+
+Both sides reduce to the triviality of the idempotent endomorphisms, by
+`TauCeti.isIndecomposableModule_iff_nontrivial_and_forall_isIdempotentElem` on the module side and
+`TauCeti.indecomposable_iff_idempotent_eq_zero_or_id` on the categorical side; the latter needs
+idempotents to split, which holds because `ModuleCat A` is abelian
+(`CategoryTheory.Idempotents.isIdempotentComplete_of_abelian`). The two idempotent conditions match
+because `ModuleCat.Hom.hom` is a ring isomorphism `End M ≃+* Module.End A M`
+(`ModuleCat.endRingEquiv`), and the remaining halves match because a module object is a zero object
+exactly when its carrier is subsingleton (`ModuleCat.isZero_iff_subsingleton`).
+
+## References
+
+This supplies the categorical reading of Layer 2 ("the Krull-Schmidt theorem") of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose uniqueness bullet asks
+for the module-level theory to be transported "to `QuiverRep k Q` and to categorical biproducts";
+`QuiverRep k Q` is identified with `ModuleCat (pathAlgebra k Q)` there, so this equivalence is the
+step that carries indecomposability across.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v
+
+variable {A : Type u} [Ring A]
+
+/-- **An object of `ModuleCat A` is indecomposable exactly when its underlying module is.** Both
+sides say that the object is nonzero and carries no idempotent endomorphism other than `0` and the
+identity; on the categorical side that reformulation is
+`TauCeti.indecomposable_iff_idempotent_eq_zero_or_id`, available because `ModuleCat A` is
+abelian, hence idempotent complete. -/
+theorem indecomposable_iff_isIndecomposableModule (M : ModuleCat.{v} A) :
+    Indecomposable M ↔ IsIndecomposableModule A M := by
+  rw [indecomposable_iff_idempotent_eq_zero_or_id,
+    isIndecomposableModule_iff_nontrivial_and_forall_isIdempotentElem,
+    ← not_subsingleton_iff_nontrivial, ← ModuleCat.isZero_iff_subsingleton]
+  refine and_congr_right fun _ ↦ ⟨fun h f hf ↦ ?_, fun h e he ↦ ?_⟩
+  · exact (h (ModuleCat.ofHom f) (ModuleCat.hom_ext hf)).imp (congrArg ModuleCat.Hom.hom)
+      (congrArg ModuleCat.Hom.hom)
+  · exact (h e.hom (ModuleCat.hom_ext_iff.mp he)).imp ModuleCat.hom_ext ModuleCat.hom_ext
+
+/-- **A module is indecomposable exactly when the object it presents in `ModuleCat A` is**, the
+reading of `TauCeti.indecomposable_iff_isIndecomposableModule` for a bare module. -/
+theorem isIndecomposableModule_iff_indecomposable (M : Type v) [AddCommGroup M] [Module A M] :
+    IsIndecomposableModule A M ↔ Indecomposable (ModuleCat.of A M) :=
+  (indecomposable_iff_isIndecomposableModule (ModuleCat.of A M)).symm
+
+/-- **Fitting's lemma, categorically**: an object of `ModuleCat A` whose underlying module has
+finite length is indecomposable exactly when its ring of endomorphisms in the category is local. -/
+theorem indecomposable_iff_isLocalRing_end (M : ModuleCat.{v} A) (hM : IsFiniteLength A M) :
+    Indecomposable M ↔ IsLocalRing (End M) := by
+  rw [indecomposable_iff_isIndecomposableModule, isIndecomposableModule_iff_isLocalRing_end hM]
+  exact ⟨fun _ ↦ IsLocalRing.of_ringEquiv M.endRingEquiv.symm,
+    fun _ ↦ IsLocalRing.of_ringEquiv M.endRingEquiv⟩
+
+end TauCeti

--- a/TauCeti/Algebra/Category/ModuleCat/Indecomposable.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Indecomposable.lean
@@ -21,9 +21,8 @@ theorem, which are stated for the module predicate.
 ## Main results
 
 * `TauCeti.indecomposable_iff_isIndecomposableModule`: an object of `ModuleCat A` is indecomposable
-  exactly when its underlying module is, with
-  `TauCeti.isIndecomposableModule_iff_indecomposable` reading the same equivalence off a bare
-  module through `ModuleCat.of`.
+  exactly when its underlying module is. A bare module `M` reads the same equivalence off as
+  `indecomposable_iff_isIndecomposableModule (ModuleCat.of A M)`.
 * `TauCeti.indecomposable_iff_isLocalRing_end`: an object of `ModuleCat A` whose underlying module
   has finite length is indecomposable exactly when `CategoryTheory.End` of it is local, which is
   Fitting's lemma stated categorically.
@@ -72,12 +71,6 @@ theorem indecomposable_iff_isIndecomposableModule (M : ModuleCat.{v} A) :
   · exact (h (ModuleCat.ofHom f) (ModuleCat.hom_ext hf)).imp (congrArg ModuleCat.Hom.hom)
       (congrArg ModuleCat.Hom.hom)
   · exact (h e.hom (ModuleCat.hom_ext_iff.mp he)).imp ModuleCat.hom_ext ModuleCat.hom_ext
-
-/-- **A module is indecomposable exactly when the object it presents in `ModuleCat A` is**, the
-reading of `TauCeti.indecomposable_iff_isIndecomposableModule` for a bare module. -/
-theorem isIndecomposableModule_iff_indecomposable (M : Type v) [AddCommGroup M] [Module A M] :
-    IsIndecomposableModule A M ↔ Indecomposable (ModuleCat.of A M) :=
-  (indecomposable_iff_isIndecomposableModule (ModuleCat.of A M)).symm
 
 /-- **Fitting's lemma, categorically**: an object of `ModuleCat A` whose underlying module has
 finite length is indecomposable exactly when its ring of endomorphisms in the category is local. -/

--- a/TauCeti/RingTheory/KrullSchmidt/DirectSum.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/DirectSum.lean
@@ -25,13 +25,15 @@ external direct sums.
   spans `M`, and whose `i`-th member is isomorphic to `N i`. This is the transport the two theorems
   below run on, and it is stated separately because it is what a client needs in order to reach any
   other statement about internal decompositions.
-* `TauCeti.exists_linearEquiv_directSum_isIndecomposableModule`: **existence**, externally: a module
-  of finite length is isomorphic to a direct sum of indecomposable modules.
+* `TauCeti.exists_linearEquiv_directSum_isIndecomposableModule`: **existence**, externally: an
+  Artinian module is isomorphic to a direct sum of indecomposable modules.
 * `TauCeti.exists_equiv_linearEquiv_of_directSum`: **the Krull-Schmidt theorem**, externally: two
   decompositions `M ≃ₗ[A] ⨁ i, N i` and `M ≃ₗ[A] ⨁ j, Q j` of a module of finite length into
   indecomposable summands are matched by a bijection `ι ≃ κ` under which corresponding summands are
   isomorphic, with `TauCeti.exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end` in Azumaya's
   generality and `TauCeti.card_eq_card_of_directSum` for the number of summands.
+* `TauCeti.exists_equiv_linearEquiv_of_directSumEquiv`: the same for two abstract families of
+  summands compared by an isomorphism `(⨁ i, N i) ≃ₗ[A] ⨁ j, Q j`, with no ambient module.
 
 ## Implementation notes
 
@@ -46,9 +48,14 @@ instead of appearing as a hypothesis. This matches the choice made in
 with `⨆ i, P i = ⊤` rather than as `DirectSum.IsInternal`.
 
 Comparing two abstract families `N` and `Q` directly, with no ambient module, is the case
-`M := ⨁ i, N i` of these statements, taking the first equivalence to be `LinearEquiv.refl`; the
-finiteness hypothesis is then read on the direct sum itself, which is why the statements are given
-with an ambient `M` rather than in that special case.
+`M := ⨁ i, N i`, taking the first equivalence to be `LinearEquiv.refl`; that is
+`TauCeti.exists_equiv_linearEquiv_of_directSumEquiv`. The statements are given with an ambient `M`
+rather than only in that special case because the finiteness hypothesis is then read on the direct
+sum itself, which is not where a client holds it.
+
+The transport lemmas need no subtraction, so they are stated for a semimodule over a semiring; the
+decomposition theorems are over a ring, which is the generality of the internal statements they
+consume.
 
 ## References
 
@@ -69,13 +76,12 @@ open DirectSum
 
 universe u v w x y z
 
-variable {A : Type u} [Ring A] {M : Type v} [AddCommGroup M] [Module A M]
-
 /-! ### An external decomposition induces an internal one -/
 
 section Transport
 
-variable {ι : Type w} {N : ι → Type y} [∀ i, AddCommGroup (N i)] [∀ i, Module A (N i)]
+variable {A : Type u} [Semiring A] {M : Type v} [AddCommMonoid M] [Module A M]
+variable {ι : Type w} {N : ι → Type y} [∀ i, AddCommMonoid (N i)] [∀ i, Module A (N i)]
 
 /-- The copies of the summands inside an external direct sum are independent: an element of the
 `i`-th copy meeting the span of the others has vanishing `i`-th component. -/
@@ -119,17 +125,20 @@ end Transport
 
 /-! ### The two halves of the Krull-Schmidt theorem, externally -/
 
-/-- **Existence of an indecomposable decomposition**, externally: a module of finite length is
-isomorphic to the direct sum of a finite family of indecomposable modules.
+variable {A : Type u} [Ring A] {M : Type v} [AddCommGroup M] [Module A M]
+
+/-- **Existence of an indecomposable decomposition**, externally: an Artinian module — in
+particular one of finite length — is isomorphic to the direct sum of a finite family of
+indecomposable modules.
 
 The summands are produced as submodules of `M`, by
-`TauCeti.exists_indecomposable_decomposition`; the point of this form is that the conclusion is a
-linear equivalence with a direct sum, which is what
+`TauCeti.exists_isInternal_isIndecomposableModule`; the point of this form is that the conclusion
+is a linear equivalence with a direct sum, which is what
 `TauCeti.exists_equiv_linearEquiv_of_directSum` consumes. -/
-theorem exists_linearEquiv_directSum_isIndecomposableModule (hM : IsFiniteLength A M) :
+theorem exists_linearEquiv_directSum_isIndecomposableModule [IsArtinian A M] :
     ∃ s : Finset (Submodule A M), (∀ N ∈ s, IsIndecomposableModule A N) ∧
       Nonempty (M ≃ₗ[A] ⨁ N : s, (N : Submodule A M)) := by
-  obtain ⟨s, hs, hsi⟩ := exists_indecomposable_decomposition hM
+  obtain ⟨s, hs, hsi⟩ := exists_isInternal_isIndecomposableModule (A := A) (M := M)
   exact ⟨s, hs, ⟨(LinearEquiv.ofBijective (coeLinearMap fun N : s ↦ (N : Submodule A M)) hsi).symm⟩⟩
 
 variable {ι : Type w} {κ : Type x} [Finite ι] [Finite κ]
@@ -155,6 +164,18 @@ theorem exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end
     (fun j ↦ (hQ j).of_linearEquiv (hRe j).some)
   exact ⟨e, fun i ↦ ⟨(hPe i).some ≪≫ₗ (he i).some ≪≫ₗ (hRe (e i)).some.symm⟩⟩
 
+/-- **The Krull-Schmidt theorem for two abstract families of summands**: a direct sum of modules
+with local endomorphism rings that is isomorphic to a direct sum of indecomposable modules has its
+summands matched by a bijection of the index sets.
+
+This is `TauCeti.exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end` with the ambient module
+taken to be the first direct sum; it is the form to use when no ambient module is in play. -/
+theorem exists_equiv_linearEquiv_of_directSumEquiv (e : (⨁ i, N i) ≃ₗ[A] ⨁ j, Q j)
+    (hN : ∀ i, IsLocalRing (Module.End A (N i)))
+    (hQ : ∀ j, IsIndecomposableModule A (Q j)) :
+    ∃ f : ι ≃ κ, ∀ i, Nonempty (N i ≃ₗ[A] Q (f i)) :=
+  exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end (LinearEquiv.refl A _) e hN hQ
+
 /-- **The Krull-Schmidt theorem for external direct sums.** Two decompositions of a module of finite
 length as a direct sum of indecomposable modules are matched by a bijection of their index sets
 under which corresponding summands are isomorphic.
@@ -167,10 +188,10 @@ theorem exists_equiv_linearEquiv_of_directSum [IsNoetherian A M] [IsArtinian A M
     (hN : ∀ i, IsIndecomposableModule A (N i))
     (hQ : ∀ j, IsIndecomposableModule A (Q j)) :
     ∃ e : ι ≃ κ, ∀ i, Nonempty (N i ≃ₗ[A] Q (e i)) := by
-  refine exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end eN eQ (fun i ↦ ?_) hQ
   -- Each summand is isomorphic to a submodule of `M`, hence of finite length, so Fitting's lemma
   -- makes its endomorphism ring local.
   obtain ⟨P, -, -, hPe⟩ := exists_iSupIndep_linearEquiv_of_directSum eN
+  refine exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end eN eQ (fun i ↦ ?_) hQ
   have e := (hPe i).some.symm
   exact isLocalRing_end_of_isIndecomposable
     (isFiniteLength_iff_isNoetherian_isArtinian.mpr

--- a/TauCeti/RingTheory/KrullSchmidt/DirectSum.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/DirectSum.lean
@@ -38,7 +38,8 @@ external direct sums.
 ## Implementation notes
 
 The transport goes through `LinearMap.range (DirectSum.lof A ι N i)`, the copy of `N i` inside
-`⨁ i, N i`. That these ranges span is Mathlib's `DFinsupp.iSup_range_lsingle`; that they are
+`⨁ i, N i`. That these ranges span is Mathlib's `DFinsupp.iSup_range_lsingle`, `DirectSum.lof`
+being by definition `DFinsupp.lsingle`; that they are
 independent is the one private lemma below, read off the components. Their images under `e.symm`
 are the internal decomposition of `M`, independent by `LinearMap.iSupIndep_map`. The transport is
 stated existentially rather than as a named family of submodules, so that `DecidableEq ι` — which
@@ -98,12 +99,6 @@ private theorem iSupIndep_range_lof [DecidableEq ι] :
   have hb : b = 0 := by simpa using hle hx
   rw [hb, map_zero]
 
-/-- The copies of the summands inside an external direct sum span it. This is Mathlib's
-`DFinsupp.iSup_range_lsingle`, read through `DirectSum.lof`. -/
-private theorem iSup_range_lof [DecidableEq ι] :
-    ⨆ i, LinearMap.range (lof A ι N i) = ⊤ :=
-  DFinsupp.iSup_range_lsingle
-
 /-- **An external direct-sum decomposition induces an internal one.** An isomorphism
 `M ≃ₗ[A] ⨁ i, N i` carries the copies of the summands to a family of submodules of `M` that is
 independent, spans `M`, and reproduces the `N i` up to isomorphism.
@@ -116,7 +111,10 @@ theorem exists_iSupIndep_linearEquiv_of_directSum (e : M ≃ₗ[A] ⨁ i, N i) :
   refine ⟨fun i ↦ (LinearMap.range (lof A ι N i)).map (e.symm : (⨁ i, N i) →ₗ[A] M), ?_, ?_,
     fun i ↦ ⟨?_⟩⟩
   · exact LinearMap.iSupIndep_map _ e.symm.injective iSupIndep_range_lof
-  · rw [← Submodule.map_iSup, iSup_range_lof, Submodule.map_top]
+  · -- `DirectSum.lof` is by definition `DFinsupp.lsingle`, but `rw` does not unfold it, so
+    -- Mathlib's spanning statement is transferred by ascription rather than rewritten in place.
+    have htop : ⨆ i, LinearMap.range (lof A ι N i) = ⊤ := DFinsupp.iSup_range_lsingle
+    rw [← Submodule.map_iSup, htop, Submodule.map_top]
     exact LinearMap.range_eq_top.mpr e.symm.surjective
   · exact (LinearEquiv.ofInjective (lof A ι N i) DFinsupp.single_injective).trans
       (Submodule.equivMapOfInjective _ e.symm.injective _)

--- a/TauCeti/RingTheory/KrullSchmidt/DirectSum.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/DirectSum.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RingTheory.KrullSchmidt.Existence
+public import TauCeti.RingTheory.KrullSchmidt.Uniqueness
+
+/-!
+# The Krull-Schmidt theorem for external direct sums
+
+`TauCeti.exists_indecomposable_decomposition` and
+`TauCeti.exists_equiv_linearEquiv_of_iSupIndep` state the two halves of the Krull-Schmidt theorem
+for families of *submodules* of one fixed module. A client that starts from an external
+decomposition `M ≃ₗ[A] ⨁ i, N i`, with the summands `N i` abstract modules of their own, cannot
+apply them without first transporting every summand into the submodule lattice of `M` and rebuilding
+the independence data by hand. This file does that transport once and restates both halves against
+external direct sums.
+
+## Main results
+
+* `TauCeti.exists_iSupIndep_linearEquiv_of_directSum`: an external decomposition
+  `M ≃ₗ[A] ⨁ i, N i` induces an internal one, a family of submodules of `M` that is `iSupIndep`,
+  spans `M`, and whose `i`-th member is isomorphic to `N i`. This is the transport the two theorems
+  below run on, and it is stated separately because it is what a client needs in order to reach any
+  other statement about internal decompositions.
+* `TauCeti.exists_linearEquiv_directSum_isIndecomposableModule`: **existence**, externally: a module
+  of finite length is isomorphic to a direct sum of indecomposable modules.
+* `TauCeti.exists_equiv_linearEquiv_of_directSum`: **the Krull-Schmidt theorem**, externally: two
+  decompositions `M ≃ₗ[A] ⨁ i, N i` and `M ≃ₗ[A] ⨁ j, Q j` of a module of finite length into
+  indecomposable summands are matched by a bijection `ι ≃ κ` under which corresponding summands are
+  isomorphic, with `TauCeti.exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end` in Azumaya's
+  generality and `TauCeti.card_eq_card_of_directSum` for the number of summands.
+
+## Implementation notes
+
+The transport goes through `LinearMap.range (DirectSum.lof A ι N i)`, the copy of `N i` inside
+`⨁ i, N i`. That these ranges span is Mathlib's `DFinsupp.iSup_range_lsingle`; that they are
+independent is the one private lemma below, read off the components. Their images under `e.symm`
+are the internal decomposition of `M`, independent by `LinearMap.iSupIndep_map`. The transport is
+stated existentially rather than as a named family of submodules, so that `DecidableEq ι` — which
+`DirectSum.lof` needs but no statement here does — can be produced by `classical` inside the proof
+instead of appearing as a hypothesis. This matches the choice made in
+`TauCeti/RingTheory/KrullSchmidt/Uniqueness.lean` to spell decompositions as `iSupIndep` together
+with `⨆ i, P i = ⊤` rather than as `DirectSum.IsInternal`.
+
+Comparing two abstract families `N` and `Q` directly, with no ambient module, is the case
+`M := ⨁ i, N i` of these statements, taking the first equivalence to be `LinearEquiv.refl`; the
+finiteness hypothesis is then read on the direct sum itself, which is why the statements are given
+with an ambient `M` rather than in that special case.
+
+## References
+
+This supplies the external interface to Layer 2 ("the Krull-Schmidt theorem") of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose uniqueness bullet asks
+for the theorem to be proved "at the module level with submodules and linear equivalences", then
+transported.
+
+See I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+Algebras, Vol. 1*, Section I.4.
+-/
+
+public section
+
+namespace TauCeti
+
+open DirectSum
+
+universe u v w x y z
+
+variable {A : Type u} [Ring A] {M : Type v} [AddCommGroup M] [Module A M]
+
+/-! ### An external decomposition induces an internal one -/
+
+section Transport
+
+variable {ι : Type w} {N : ι → Type y} [∀ i, AddCommGroup (N i)] [∀ i, Module A (N i)]
+
+/-- The copies of the summands inside an external direct sum are independent: an element of the
+`i`-th copy meeting the span of the others has vanishing `i`-th component. -/
+private theorem iSupIndep_range_lof [DecidableEq ι] :
+    iSupIndep fun i ↦ LinearMap.range (lof A ι N i) := by
+  intro i
+  rw [Submodule.disjoint_def]
+  rintro x ⟨b, rfl⟩ hx
+  have hle : (⨆ j, ⨆ (_ : j ≠ i), LinearMap.range (lof A ι N j)) ≤
+      LinearMap.ker (component A ι N i) := by
+    refine iSup_le fun j ↦ iSup_le fun hj ↦ ?_
+    rw [LinearMap.range_le_ker_iff]
+    simp [component_comp_lof, hj]
+  have hb : b = 0 := by simpa using hle hx
+  rw [hb, map_zero]
+
+/-- The copies of the summands inside an external direct sum span it. This is Mathlib's
+`DFinsupp.iSup_range_lsingle`, read through `DirectSum.lof`. -/
+private theorem iSup_range_lof [DecidableEq ι] :
+    ⨆ i, LinearMap.range (lof A ι N i) = ⊤ :=
+  DFinsupp.iSup_range_lsingle
+
+/-- **An external direct-sum decomposition induces an internal one.** An isomorphism
+`M ≃ₗ[A] ⨁ i, N i` carries the copies of the summands to a family of submodules of `M` that is
+independent, spans `M`, and reproduces the `N i` up to isomorphism.
+
+This is the transport that lets the internal statements of the Krull-Schmidt theorem be applied to
+an external decomposition; `TauCeti.exists_equiv_linearEquiv_of_directSum` is that application. -/
+theorem exists_iSupIndep_linearEquiv_of_directSum (e : M ≃ₗ[A] ⨁ i, N i) :
+    ∃ P : ι → Submodule A M, iSupIndep P ∧ ⨆ i, P i = ⊤ ∧ ∀ i, Nonempty (N i ≃ₗ[A] P i) := by
+  classical
+  refine ⟨fun i ↦ (LinearMap.range (lof A ι N i)).map (e.symm : (⨁ i, N i) →ₗ[A] M), ?_, ?_,
+    fun i ↦ ⟨?_⟩⟩
+  · exact LinearMap.iSupIndep_map _ e.symm.injective iSupIndep_range_lof
+  · rw [← Submodule.map_iSup, iSup_range_lof, Submodule.map_top]
+    exact LinearMap.range_eq_top.mpr e.symm.surjective
+  · exact (LinearEquiv.ofInjective (lof A ι N i) DFinsupp.single_injective).trans
+      (Submodule.equivMapOfInjective _ e.symm.injective _)
+
+end Transport
+
+/-! ### The two halves of the Krull-Schmidt theorem, externally -/
+
+/-- **Existence of an indecomposable decomposition**, externally: a module of finite length is
+isomorphic to the direct sum of a finite family of indecomposable modules.
+
+The summands are produced as submodules of `M`, by
+`TauCeti.exists_indecomposable_decomposition`; the point of this form is that the conclusion is a
+linear equivalence with a direct sum, which is what
+`TauCeti.exists_equiv_linearEquiv_of_directSum` consumes. -/
+theorem exists_linearEquiv_directSum_isIndecomposableModule (hM : IsFiniteLength A M) :
+    ∃ s : Finset (Submodule A M), (∀ N ∈ s, IsIndecomposableModule A N) ∧
+      Nonempty (M ≃ₗ[A] ⨁ N : s, (N : Submodule A M)) := by
+  obtain ⟨s, hs, hsi⟩ := exists_indecomposable_decomposition hM
+  exact ⟨s, hs, ⟨(LinearEquiv.ofBijective (coeLinearMap fun N : s ↦ (N : Submodule A M)) hsi).symm⟩⟩
+
+variable {ι : Type w} {κ : Type x} [Finite ι] [Finite κ]
+variable {N : ι → Type y} [∀ i, AddCommGroup (N i)] [∀ i, Module A (N i)]
+variable {Q : κ → Type z} [∀ j, AddCommGroup (Q j)] [∀ j, Module A (Q j)]
+
+/-- **The Krull-Schmidt theorem for external direct sums**, in Azumaya's generality: if a module is
+isomorphic to a finite direct sum of modules with local endomorphism rings, and also to a finite
+direct sum of indecomposable modules, then the two families are matched by a bijection of their
+index sets under which corresponding summands are isomorphic.
+
+No finiteness hypothesis on `M` is needed; for a module of finite length Fitting's lemma supplies
+the locality hypothesis, which is `TauCeti.exists_equiv_linearEquiv_of_directSum` below. -/
+theorem exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end
+    (eN : M ≃ₗ[A] ⨁ i, N i) (eQ : M ≃ₗ[A] ⨁ j, Q j)
+    (hN : ∀ i, IsLocalRing (Module.End A (N i)))
+    (hQ : ∀ j, IsIndecomposableModule A (Q j)) :
+    ∃ e : ι ≃ κ, ∀ i, Nonempty (N i ≃ₗ[A] Q (e i)) := by
+  obtain ⟨P, hPi, hPt, hPe⟩ := exists_iSupIndep_linearEquiv_of_directSum eN
+  obtain ⟨R, hRi, hRt, hRe⟩ := exists_iSupIndep_linearEquiv_of_directSum eQ
+  obtain ⟨e, he⟩ := exists_equiv_linearEquiv_of_isLocalRing_end hPi hPt
+    (fun i ↦ have := hN i; IsLocalRing.of_ringEquiv (hPe i).some.conjRingEquiv) hRi hRt
+    (fun j ↦ (hQ j).of_linearEquiv (hRe j).some)
+  exact ⟨e, fun i ↦ ⟨(hPe i).some ≪≫ₗ (he i).some ≪≫ₗ (hRe (e i)).some.symm⟩⟩
+
+/-- **The Krull-Schmidt theorem for external direct sums.** Two decompositions of a module of finite
+length as a direct sum of indecomposable modules are matched by a bijection of their index sets
+under which corresponding summands are isomorphic.
+
+`TauCeti.exists_linearEquiv_directSum_isIndecomposableModule` supplies such a decomposition, and
+`TauCeti.exists_equiv_linearEquiv_of_iSupIndep` is the same statement for families of submodules of
+`M`. -/
+theorem exists_equiv_linearEquiv_of_directSum [IsNoetherian A M] [IsArtinian A M]
+    (eN : M ≃ₗ[A] ⨁ i, N i) (eQ : M ≃ₗ[A] ⨁ j, Q j)
+    (hN : ∀ i, IsIndecomposableModule A (N i))
+    (hQ : ∀ j, IsIndecomposableModule A (Q j)) :
+    ∃ e : ι ≃ κ, ∀ i, Nonempty (N i ≃ₗ[A] Q (e i)) := by
+  refine exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end eN eQ (fun i ↦ ?_) hQ
+  -- Each summand is isomorphic to a submodule of `M`, hence of finite length, so Fitting's lemma
+  -- makes its endomorphism ring local.
+  obtain ⟨P, -, -, hPe⟩ := exists_iSupIndep_linearEquiv_of_directSum eN
+  have e := (hPe i).some.symm
+  exact isLocalRing_end_of_isIndecomposable
+    (isFiniteLength_iff_isNoetherian_isArtinian.mpr
+      ⟨isNoetherian_of_linearEquiv e, isArtinian_of_linearEquiv e⟩) (hN i)
+
+/-- Two decompositions of a module of finite length as a direct sum of indecomposable modules have
+the same number of summands. -/
+theorem card_eq_card_of_directSum [IsNoetherian A M] [IsArtinian A M]
+    (eN : M ≃ₗ[A] ⨁ i, N i) (eQ : M ≃ₗ[A] ⨁ j, Q j)
+    (hN : ∀ i, IsIndecomposableModule A (N i))
+    (hQ : ∀ j, IsIndecomposableModule A (Q j)) : Nat.card ι = Nat.card κ :=
+  let ⟨e, _⟩ := exists_equiv_linearEquiv_of_directSum eN eQ hN hQ
+  Nat.card_eq_of_bijective e e.bijective
+
+end TauCeti


### PR DESCRIPTION
This PR restates both halves of the Krull-Schmidt theorem against *external* direct sums, and identifies Tau Ceti's `IsIndecomposableModule` with Mathlib's `CategoryTheory.Indecomposable` for objects of `ModuleCat`. Both changes are packaging: nothing new is proved about decompositions themselves, but the existing theorems become applicable to the two interfaces clients actually hold — an isomorphism `M ≃ₗ[A] ⨁ i, N i` whose summands are modules of their own, and a categorical indecomposability hypothesis.

Add `TauCeti/RingTheory/KrullSchmidt/DirectSum.lean` (207 lines). Until now `TauCeti.exists_equiv_linearEquiv_of_iSupIndep` compared two families of `Submodule A M`, and `TauCeti.exists_indecomposable_decomposition` returned a `Finset (Submodule A M)` with a `DirectSum.IsInternal` witness, so a client starting from `M ≃ₗ[A] ⨁ i, N i` had to transport every summand into the submodule lattice of `M` and rebuild the independence data by hand. `TauCeti.exists_iSupIndep_linearEquiv_of_directSum` does that once: an external decomposition yields a family of submodules of `M` that is `iSupIndep`, spans `M`, and reproduces each `N i` up to isomorphism. On top of it,

* `TauCeti.exists_linearEquiv_directSum_isIndecomposableModule` is existence, externally: an Artinian module is isomorphic to a direct sum of indecomposable modules;
* `TauCeti.exists_equiv_linearEquiv_of_directSum_of_isLocalRing_end` is uniqueness in Azumaya's generality, needing no finiteness hypothesis on `M`, and `TauCeti.exists_equiv_linearEquiv_of_directSumEquiv` is its carrier-free form, comparing two abstract families of summands across an isomorphism `(⨁ i, N i) ≃ₗ[A] ⨁ j, Q j`;
* `TauCeti.exists_equiv_linearEquiv_of_directSum` and `TauCeti.card_eq_card_of_directSum` are uniqueness, and the count of summands, for a module of finite length.

The statements carry an ambient `M` rather than being stated only for the direct sums themselves because in the carrier-free case the finiteness hypothesis has to be read on `⨁ i, N i`, which is not where a client holds it. The transport lemmas need no subtraction and are stated for a semimodule over a semiring; the decomposition theorems are over a ring, the generality of the internal statements they consume.

The transport runs through `LinearMap.range (DirectSum.lof A ι N i)`, the copy of `N i` inside the direct sum. That these ranges span is Mathlib's `DFinsupp.iSup_range_lsingle`; that they are independent is the one private lemma here, read off the components through `DirectSum.component_comp_lof`; their images under `e.symm` inherit independence by Mathlib's `LinearMap.iSupIndep_map`, and reproduce the summands by `LinearEquiv.ofInjective` and `Submodule.equivMapOfInjective`. The transport is stated existentially rather than as a named family of submodules, so that the `DecidableEq ι` that `DirectSum.lof` needs is discharged by `classical` inside the proof instead of appearing on statements that do not need it — the same choice `Uniqueness.lean` already makes in spelling decompositions as `iSupIndep` with `⨆ i, P i = ⊤` rather than as `DirectSum.IsInternal`.

Add `TauCeti/Algebra/Category/ModuleCat/Indecomposable.lean` (83 lines). `TauCeti.indecomposable_iff_isIndecomposableModule` proves `Indecomposable M ↔ IsIndecomposableModule A M` for `M : ModuleCat A`; a bare module reads it off as `indecomposable_iff_isIndecomposableModule (ModuleCat.of A M)`. Both sides reduce to the triviality of the idempotent endomorphisms: `TauCeti.isIndecomposableModule_iff_nontrivial_and_forall_isIdempotentElem` on the module side, and on the categorical side `TauCeti.indecomposable_iff_idempotent_eq_zero_or_id` from `TauCeti/CategoryTheory/Preadditive/Indecomposable.lean`, whose idempotent-splitting hypothesis is discharged because `ModuleCat A` is abelian (Mathlib's `CategoryTheory.Idempotents.isIdempotentComplete_of_abelian`). The two idempotent conditions match because `ModuleCat.endRingEquiv` is a ring isomorphism `End M ≃+* Module.End A M`, and the two nonvanishing conditions match by `ModuleCat.isZero_iff_subsingleton`. `TauCeti.indecomposable_iff_isLocalRing_end` then states Fitting's lemma categorically: an object of `ModuleCat A` whose underlying module has finite length is indecomposable exactly when `CategoryTheory.End` of it is a local ring. This is the missing half of a connection the repository already relies on in one direction: `TauCeti/RepresentationTheory/Quiver/Reflection/Indecomposable.lean` states the reflection functor's hypotheses with `CategoryTheory.Indecomposable`, while Fitting's lemma and Krull-Schmidt are stated with `IsIndecomposableModule`, and no lemma related them.

No bundled `IndecomposableDecomposition` object is added, which the issue floats as an optional third change. Such a structure would carry its index type and its summand types as fields, so every statement about it would still be the existential statements above with the fields projected out; nothing in the repository consumes it, and the later roadmap layers ask for "the multiset of indecomposable summands" as the invariant, not for a bundled decomposition. `TauCeti/RingTheory/KrullSchmidt/DirectSum.lean` is instead the single discoverable place where a decomposition is produced and compared. If a client turns up that wants the bundle, it can be added then, over these theorems.

No existing file is modified, no Mathlib infrastructure is vendored, and no `sorry` or `set_option` is introduced. The targeted module builds, and the full `lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all pass locally.

This targets Layer 2 ("the Krull-Schmidt theorem") of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose uniqueness bullet asks for the theorem to be proved "at the module level with submodules and linear equivalences, then transport to `QuiverRep k Q` and to categorical biproducts". The module-level proof landed in #2082; this PR is the transport step, which had nothing supporting it on `main`. What that bullet still lacks afterwards is the transport to `QuiverRep k Q` itself, which waits on the Layer 1 target `quiverRepEquivalence` identifying representations with modules over the path algebra.

Closes #3569.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"krull-schmidt-external-direct-sums"}-->

🤖 Prepared with Claude Code
