### PR TITLE
feat: prove commuting unipotents share a fixed line

### DIFF
--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Exists
+public import TauCeti.LinearAlgebra.GeneralLinearGroup.Unipotent
+
+/-!
+# Common fixed vectors for commuting unipotent automorphisms
+
+A unipotent automorphism has only the eigenvalue one.  Consequently, the joint eigenvector of a
+commuting family of unipotent automorphisms is fixed by every member of the family.  We record both
+the resulting common fixed vector and the one-dimensional fixed submodule that it spans.
+
+For a representation of a commutative group, commutativity of the image is automatic.  The final
+two results therefore give the fixed-vector and fixed-line forms used as the abelian base case in
+the fixed-line induction for the Lie--Kolchin theorem.
+
+## Main declarations
+
+* `TauCeti.GeneralLinearGroup.IsUnipotent.eigenvalue_eq_one`: every eigenvalue of a unipotent
+  automorphism is one.
+* `TauCeti.exists_common_fixedVector_of_pairwise_commute_of_isUnipotent`: a commuting family of
+  unipotent automorphisms of a nonzero finite-dimensional space has a common nonzero fixed vector.
+* `TauCeti.exists_fixedLine_of_pairwise_commute_of_isUnipotent`: such a family fixes a
+  one-dimensional submodule pointwise.
+* `TauCeti.exists_fixedLine_of_isUnipotent`: a unipotent representation of a commutative group has
+  a pointwise-fixed line.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap
+
+universe u v w
+
+noncomputable section
+
+namespace GeneralLinearGroup
+
+variable {K : Type u} {V : Type v}
+variable [Field K] [AddCommGroup V] [Module K V]
+
+/-- The maximal generalized eigenspace for the eigenvalue one of a unipotent automorphism is the
+whole space. -/
+theorem IsUnipotent.maxGenEigenspace_one_eq_top {g : GeneralLinearGroup K V}
+    (hg : IsUnipotent g) :
+    Module.End.maxGenEigenspace (g : Module.End K V) 1 = ⊤ := by
+  rw [eq_top_iff]
+  intro x _
+  rw [Module.End.mem_maxGenEigenspace]
+  rw [isUnipotent_def] at hg
+  obtain ⟨n, hn⟩ := hg
+  refine ⟨n, ?_⟩
+  simpa using LinearMap.congr_fun hn x
+
+/-- The generalized eigenspaces of a unipotent automorphism span the whole space.  This is the
+triangularizability hypothesis needed by the joint-eigenvector existence theorem. -/
+theorem IsUnipotent.iSup_maxGenEigenspace_eq_top {g : GeneralLinearGroup K V}
+    (hg : IsUnipotent g) :
+    ⨆ μ, Module.End.maxGenEigenspace (g : Module.End K V) μ = ⊤ := by
+  apply top_unique
+  rw [← hg.maxGenEigenspace_one_eq_top]
+  exact le_iSup (fun μ ↦ Module.End.maxGenEigenspace (g : Module.End K V) μ) 1
+
+/-- Every eigenvalue of a unipotent automorphism is one. -/
+theorem IsUnipotent.eigenvalue_eq_one {g : GeneralLinearGroup K V} (hg : IsUnipotent g)
+    {v : V} (hv : v ≠ 0) {μ : K} (heigen : (g : Module.End K V) v = μ • v) :
+    μ = 1 := by
+  have hpow_apply (m : ℕ) : (((g : Module.End K V) - 1) ^ m) v = (μ - 1) ^ m • v := by
+    induction m with
+    | zero => simp
+    | succ m ih =>
+        have hsub : μ • v - v = (μ - 1) • v := by rw [sub_smul, one_smul]
+        rw [pow_succ', Module.End.mul_apply, ih, map_smul, LinearMap.sub_apply,
+          Module.End.one_apply, heigen, hsub, smul_smul, pow_succ]
+  rw [isUnipotent_def] at hg
+  obtain ⟨n, hn⟩ := hg
+  have hzero : (μ - 1) ^ n • v = 0 := by
+    rw [← hpow_apply n, hn]
+    rfl
+  have hpow : (μ - 1) ^ n = 0 :=
+    (smul_eq_zero.mp hzero).resolve_right hv
+  exact sub_eq_zero.mp (eq_zero_of_pow_eq_zero hpow)
+
+end GeneralLinearGroup
+
+variable {K : Type u} {V : Type v} {ι : Type w}
+variable [Field K] [AddCommGroup V] [Module K V]
+
+/-- A pairwise-commuting family of unipotent automorphisms of a nonzero finite-dimensional vector
+space has a common nonzero fixed vector. -/
+theorem exists_common_fixedVector_of_pairwise_commute_of_isUnipotent
+    [FiniteDimensional K V] [Nontrivial V] (f : ι → GeneralLinearGroup K V)
+    (hcomm : Pairwise fun i j ↦ Commute (f i) (f j))
+    (hunipotent : ∀ i, GeneralLinearGroup.IsUnipotent (f i)) :
+    ∃ v : V, v ≠ 0 ∧ ∀ i, (f i : Module.End K V) v = v := by
+  let fEnd : ι → Module.End K V := fun i ↦ f i
+  have hcommEnd : Pairwise fun i j ↦ Commute (fEnd i) (fEnd j) := fun i j hij ↦
+    (hcomm hij).units_val
+  have htri (i : ι) : ⨆ μ, (fEnd i).maxGenEigenspace μ = ⊤ :=
+    (hunipotent i).iSup_maxGenEigenspace_eq_top
+  obtain ⟨χ, v, hv, heigen⟩ :=
+    exists_jointEigenvector_of_pairwise_commute fEnd hcommEnd htri
+  refine ⟨v, hv, fun i ↦ ?_⟩
+  have hχ : χ i = 1 :=
+    (hunipotent i).eigenvalue_eq_one hv (Module.End.mem_eigenspace_iff.mp (heigen i))
+  simpa [fEnd, hχ] using Module.End.mem_eigenspace_iff.mp (heigen i)
+
+/-- A pairwise-commuting family of unipotent automorphisms of a nonzero finite-dimensional vector
+space fixes a one-dimensional submodule pointwise. -/
+theorem exists_fixedLine_of_pairwise_commute_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
+    (f : ι → GeneralLinearGroup K V) (hcomm : Pairwise fun i j ↦ Commute (f i) (f j))
+    (hunipotent : ∀ i, GeneralLinearGroup.IsUnipotent (f i)) :
+    ∃ p : Submodule K V, Module.finrank K p = 1 ∧
+      ∀ i, ∀ x ∈ p, (f i : Module.End K V) x = x := by
+  obtain ⟨v, hv, hfixed⟩ :=
+    exists_common_fixedVector_of_pairwise_commute_of_isUnipotent f hcomm hunipotent
+  refine ⟨K ∙ v, finrank_span_singleton hv, fun i x hx ↦ ?_⟩
+  rw [Submodule.mem_span_singleton] at hx
+  obtain ⟨a, rfl⟩ := hx
+  simp [hfixed]
+
+variable {G : Type w} [CommGroup G]
+
+/-- A unipotent representation of a commutative group on a nonzero finite-dimensional vector space
+has a common nonzero fixed vector. -/
+theorem exists_common_fixedVector_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
+    (ρ : G →* GeneralLinearGroup K V)
+    (hunipotent : ∀ g, GeneralLinearGroup.IsUnipotent (ρ g)) :
+    ∃ v : V, v ≠ 0 ∧ ∀ g, (ρ g : Module.End K V) v = v := by
+  apply exists_common_fixedVector_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
+  intro g h _
+  change ρ g * ρ h = ρ h * ρ g
+  rw [← map_mul, mul_comm g h, map_mul]
+
+/-- A unipotent representation of a commutative group on a nonzero finite-dimensional vector space
+fixes a one-dimensional submodule pointwise. -/
+theorem exists_fixedLine_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
+    (ρ : G →* GeneralLinearGroup K V)
+    (hunipotent : ∀ g, GeneralLinearGroup.IsUnipotent (ρ g)) :
+    ∃ p : Submodule K V, Module.finrank K p = 1 ∧
+      ∀ g, ∀ x ∈ p, (ρ g : Module.End K V) x = x := by
+  apply exists_fixedLine_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
+  intro g h _
+  change ρ g * ρ h = ρ h * ρ g
+  rw [← map_mul, mul_comm g h, map_mul]
+
+end
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Exists
-public import TauCeti.LinearAlgebra.GeneralLinearGroup.Unipotent
+public import TauCeti.LinearAlgebra.Eigenspace.Unipotent
 
 /-!
 # Common fixed vectors for commuting unipotent automorphisms
@@ -21,8 +21,6 @@ the fixed-line induction for the Lie--Kolchin theorem.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.IsUnipotent.eigenvalue_eq_one`: every eigenvalue of a unipotent
-  automorphism is one.
 * `TauCeti.exists_common_fixedVector_of_pairwise_commute_of_isUnipotent`: a commuting family of
   unipotent automorphisms of a nonzero finite-dimensional space has a common nonzero fixed vector.
 * `TauCeti.exists_fixedLine_of_pairwise_commute_of_isUnipotent`: such a family fixes a
@@ -46,55 +44,6 @@ universe u v w
 
 noncomputable section
 
-namespace GeneralLinearGroup
-
-variable {K : Type u} {V : Type v}
-variable [Field K] [AddCommGroup V] [Module K V]
-
-/-- The maximal generalized eigenspace for the eigenvalue one of a unipotent automorphism is the
-whole space. -/
-theorem IsUnipotent.maxGenEigenspace_one_eq_top {g : GeneralLinearGroup K V}
-    (hg : IsUnipotent g) :
-    Module.End.maxGenEigenspace (g : Module.End K V) 1 = ⊤ := by
-  rw [eq_top_iff]
-  intro x _
-  rw [Module.End.mem_maxGenEigenspace]
-  rw [isUnipotent_def] at hg
-  obtain ⟨n, hn⟩ := hg
-  refine ⟨n, ?_⟩
-  simpa using LinearMap.congr_fun hn x
-
-/-- The generalized eigenspaces of a unipotent automorphism span the whole space.  This is the
-triangularizability hypothesis needed by the joint-eigenvector existence theorem. -/
-theorem IsUnipotent.iSup_maxGenEigenspace_eq_top {g : GeneralLinearGroup K V}
-    (hg : IsUnipotent g) :
-    ⨆ μ, Module.End.maxGenEigenspace (g : Module.End K V) μ = ⊤ := by
-  apply top_unique
-  rw [← hg.maxGenEigenspace_one_eq_top]
-  exact le_iSup (fun μ ↦ Module.End.maxGenEigenspace (g : Module.End K V) μ) 1
-
-/-- Every eigenvalue of a unipotent automorphism is one. -/
-theorem IsUnipotent.eigenvalue_eq_one {g : GeneralLinearGroup K V} (hg : IsUnipotent g)
-    {v : V} (hv : v ≠ 0) {μ : K} (heigen : (g : Module.End K V) v = μ • v) :
-    μ = 1 := by
-  have hpow_apply (m : ℕ) : (((g : Module.End K V) - 1) ^ m) v = (μ - 1) ^ m • v := by
-    induction m with
-    | zero => simp
-    | succ m ih =>
-        have hsub : μ • v - v = (μ - 1) • v := by rw [sub_smul, one_smul]
-        rw [pow_succ', Module.End.mul_apply, ih, map_smul, LinearMap.sub_apply,
-          Module.End.one_apply, heigen, hsub, smul_smul, pow_succ]
-  rw [isUnipotent_def] at hg
-  obtain ⟨n, hn⟩ := hg
-  have hzero : (μ - 1) ^ n • v = 0 := by
-    rw [← hpow_apply n, hn]
-    rfl
-  have hpow : (μ - 1) ^ n = 0 :=
-    (smul_eq_zero.mp hzero).resolve_right hv
-  exact sub_eq_zero.mp (eq_zero_of_pow_eq_zero hpow)
-
-end GeneralLinearGroup
-
 variable {K : Type u} {V : Type v} {ι : Type w}
 variable [Field K] [AddCommGroup V] [Module K V]
 
@@ -108,8 +57,10 @@ theorem exists_common_fixedVector_of_pairwise_commute_of_isUnipotent
   let fEnd : ι → Module.End K V := fun i ↦ f i
   have hcommEnd : Pairwise fun i j ↦ Commute (fEnd i) (fEnd j) := fun i j hij ↦
     (hcomm hij).units_val
-  have htri (i : ι) : ⨆ μ, (fEnd i).maxGenEigenspace μ = ⊤ :=
-    (hunipotent i).iSup_maxGenEigenspace_eq_top
+  have htri (i : ι) : ⨆ μ, (fEnd i).maxGenEigenspace μ = ⊤ := by
+    apply top_unique
+    rw [← (hunipotent i).maxGenEigenspace_one_eq_top]
+    exact le_iSup (fun μ ↦ (fEnd i).maxGenEigenspace μ) 1
   obtain ⟨χ, v, hv, heigen⟩ :=
     exists_jointEigenvector_of_pairwise_commute fEnd hcommEnd htri
   refine ⟨v, hv, fun i ↦ ?_⟩
@@ -141,8 +92,7 @@ theorem exists_common_fixedVector_of_isUnipotent [FiniteDimensional K V] [Nontri
     ∃ v : V, v ≠ 0 ∧ ∀ g, (ρ g : Module.End K V) v = v := by
   apply exists_common_fixedVector_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
   intro g h _
-  change ρ g * ρ h = ρ h * ρ g
-  rw [← map_mul, mul_comm g h, map_mul]
+  exact (ρ.map_mul g h).symm.trans ((congrArg ρ (mul_comm g h)).trans (ρ.map_mul h g))
 
 /-- A unipotent representation of a commutative group on a nonzero finite-dimensional vector space
 fixes a one-dimensional submodule pointwise. -/
@@ -153,8 +103,7 @@ theorem exists_fixedLine_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
       ∀ g, ∀ x ∈ p, (ρ g : Module.End K V) x = x := by
   apply exists_fixedLine_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
   intro g h _
-  change ρ g * ρ h = ρ h * ρ g
-  rw [← map_mul, mul_comm g h, map_mul]
+  exact (ρ.map_mul g h).symm.trans ((congrArg ρ (mul_comm g h)).trans (ρ.map_mul h g))
 
 end
 

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
@@ -15,7 +15,7 @@ A unipotent automorphism has only the eigenvalue one.  Consequently, the joint e
 commuting family of unipotent automorphisms is fixed by every member of the family.  We record both
 the resulting common fixed vector and the one-dimensional fixed submodule that it spans.
 
-For a representation of a commutative group, commutativity of the image is automatic.  The final
+For a representation of a commutative monoid, commutativity of the image is automatic.  The final
 two results therefore give the fixed-vector and fixed-line forms used as the abelian base case in
 the fixed-line induction for the Lie--Kolchin theorem.
 
@@ -25,7 +25,7 @@ the fixed-line induction for the Lie--Kolchin theorem.
   unipotent automorphisms of a nonzero finite-dimensional space has a common nonzero fixed vector.
 * `TauCeti.exists_fixedLine_of_pairwise_commute_of_isUnipotent`: such a family fixes a
   one-dimensional submodule pointwise.
-* `TauCeti.exists_fixedLine_of_isUnipotent`: a unipotent representation of a commutative group has
+* `TauCeti.exists_fixedLine_of_isUnipotent`: a unipotent representation of a commutative monoid has
   a pointwise-fixed line.
 
 ## References
@@ -83,9 +83,9 @@ theorem exists_fixedLine_of_pairwise_commute_of_isUnipotent [FiniteDimensional K
   obtain ⟨a, rfl⟩ := hx
   simp [hfixed]
 
-variable {G : Type w} [CommGroup G]
+variable {G : Type w} [CommMonoid G]
 
-/-- A unipotent representation of a commutative group on a nonzero finite-dimensional vector space
+/-- A unipotent representation of a commutative monoid on a nonzero finite-dimensional vector space
 has a common nonzero fixed vector. -/
 theorem exists_common_fixedVector_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
     (ρ : G →* GeneralLinearGroup K V)
@@ -95,7 +95,7 @@ theorem exists_common_fixedVector_of_isUnipotent [FiniteDimensional K V] [Nontri
   intro g h _
   exact (ρ.map_mul g h).symm.trans ((congrArg ρ (mul_comm g h)).trans (ρ.map_mul h g))
 
-/-- A unipotent representation of a commutative group on a nonzero finite-dimensional vector space
+/-- A unipotent representation of a commutative monoid on a nonzero finite-dimensional vector space
 fixes a one-dimensional submodule pointwise. -/
 theorem exists_fixedLine_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
     (ρ : G →* GeneralLinearGroup K V)

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
@@ -21,12 +21,12 @@ the fixed-line induction for the Lie--Kolchin theorem.
 
 ## Main declarations
 
-* `TauCeti.exists_common_fixedVector_of_pairwise_commute_of_isUnipotent`: a commuting family of
+* `TauCeti.exists_common_fixed_vector_of_pairwise_commute_of_isUnipotent`: a commuting family of
   unipotent automorphisms of a nonzero finite-dimensional space has a common nonzero fixed vector.
-* `TauCeti.exists_fixedLine_of_pairwise_commute_of_isUnipotent`: such a family fixes a
-  one-dimensional submodule pointwise.
-* `TauCeti.exists_fixedLine_of_isUnipotent`: a unipotent representation of a commutative monoid has
-  a pointwise-fixed line.
+* `TauCeti.exists_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent`: such a family fixes
+  a one-dimensional submodule pointwise.
+* `TauCeti.exists_submodule_finrank_eq_one_of_isUnipotent`: a unipotent representation of a
+  commutative monoid has a pointwise-fixed line.
 
 ## References
 
@@ -49,7 +49,7 @@ variable [Field K] [AddCommGroup V] [Module K V]
 
 /-- A pairwise-commuting family of unipotent automorphisms of a nonzero finite-dimensional vector
 space has a common nonzero fixed vector. -/
-theorem exists_common_fixedVector_of_pairwise_commute_of_isUnipotent
+theorem exists_common_fixed_vector_of_pairwise_commute_of_isUnipotent
     [FiniteDimensional K V] [Nontrivial V] (f : ι → GeneralLinearGroup K V)
     (hcomm : Pairwise fun i j ↦ Commute (f i) (f j))
     (hunipotent : ∀ i, GeneralLinearGroup.IsUnipotent (f i)) :
@@ -71,13 +71,14 @@ theorem exists_common_fixedVector_of_pairwise_commute_of_isUnipotent
 
 /-- A pairwise-commuting family of unipotent automorphisms of a nonzero finite-dimensional vector
 space fixes a one-dimensional submodule pointwise. -/
-theorem exists_fixedLine_of_pairwise_commute_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
+theorem exists_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent
+    [FiniteDimensional K V] [Nontrivial V]
     (f : ι → GeneralLinearGroup K V) (hcomm : Pairwise fun i j ↦ Commute (f i) (f j))
     (hunipotent : ∀ i, GeneralLinearGroup.IsUnipotent (f i)) :
     ∃ p : Submodule K V, Module.finrank K p = 1 ∧
       ∀ i, ∀ x ∈ p, (f i : Module.End K V) x = x := by
   obtain ⟨v, hv, hfixed⟩ :=
-    exists_common_fixedVector_of_pairwise_commute_of_isUnipotent f hcomm hunipotent
+    exists_common_fixed_vector_of_pairwise_commute_of_isUnipotent f hcomm hunipotent
   refine ⟨K ∙ v, finrank_span_singleton hv, fun i x hx ↦ ?_⟩
   rw [Submodule.mem_span_singleton] at hx
   obtain ⟨a, rfl⟩ := hx
@@ -87,22 +88,22 @@ variable {G : Type w} [CommMonoid G]
 
 /-- A unipotent representation of a commutative monoid on a nonzero finite-dimensional vector space
 has a common nonzero fixed vector. -/
-theorem exists_common_fixedVector_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
+theorem exists_common_fixed_vector_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
     (ρ : G →* GeneralLinearGroup K V)
     (hunipotent : ∀ g, GeneralLinearGroup.IsUnipotent (ρ g)) :
     ∃ v : V, v ≠ 0 ∧ ∀ g, (ρ g : Module.End K V) v = v := by
-  apply exists_common_fixedVector_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
+  apply exists_common_fixed_vector_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
   intro g h _
   exact (ρ.map_mul g h).symm.trans ((congrArg ρ (mul_comm g h)).trans (ρ.map_mul h g))
 
 /-- A unipotent representation of a commutative monoid on a nonzero finite-dimensional vector space
 fixes a one-dimensional submodule pointwise. -/
-theorem exists_fixedLine_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
+theorem exists_submodule_finrank_eq_one_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
     (ρ : G →* GeneralLinearGroup K V)
     (hunipotent : ∀ g, GeneralLinearGroup.IsUnipotent (ρ g)) :
     ∃ p : Submodule K V, Module.finrank K p = 1 ∧
       ∀ g, ∀ x ∈ p, (ρ g : Module.End K V) x = x := by
-  apply exists_fixedLine_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
+  apply exists_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
   intro g h _
   exact (ρ.map_mul g h).symm.trans ((congrArg ρ (mul_comm g h)).trans (ρ.map_mul h g))
 

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
@@ -23,9 +23,9 @@ the fixed-line induction for the Lie--Kolchin theorem.
 
 * `TauCeti.exists_common_fixed_vector_of_pairwise_commute_of_isUnipotent`: a commuting family of
   unipotent automorphisms of a nonzero finite-dimensional space has a common nonzero fixed vector.
-* `TauCeti.exists_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent`: such a family fixes
-  a one-dimensional submodule pointwise.
-* `TauCeti.exists_submodule_finrank_eq_one_of_isUnipotent`: a unipotent representation of a
+* `TauCeti.exists_fixed_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent`: such a family
+  fixes a one-dimensional submodule pointwise.
+* `TauCeti.exists_fixed_submodule_finrank_eq_one_of_isUnipotent`: a unipotent representation of a
   commutative monoid has a pointwise-fixed line.
 
 ## References
@@ -71,7 +71,7 @@ theorem exists_common_fixed_vector_of_pairwise_commute_of_isUnipotent
 
 /-- A pairwise-commuting family of unipotent automorphisms of a nonzero finite-dimensional vector
 space fixes a one-dimensional submodule pointwise. -/
-theorem exists_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent
+theorem exists_fixed_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent
     [FiniteDimensional K V] [Nontrivial V]
     (f : ι → GeneralLinearGroup K V) (hcomm : Pairwise fun i j ↦ Commute (f i) (f j))
     (hunipotent : ∀ i, GeneralLinearGroup.IsUnipotent (f i)) :
@@ -98,12 +98,13 @@ theorem exists_common_fixed_vector_of_isUnipotent [FiniteDimensional K V] [Nontr
 
 /-- A unipotent representation of a commutative monoid on a nonzero finite-dimensional vector space
 fixes a one-dimensional submodule pointwise. -/
-theorem exists_submodule_finrank_eq_one_of_isUnipotent [FiniteDimensional K V] [Nontrivial V]
+theorem exists_fixed_submodule_finrank_eq_one_of_isUnipotent
+    [FiniteDimensional K V] [Nontrivial V]
     (ρ : G →* GeneralLinearGroup K V)
     (hunipotent : ∀ g, GeneralLinearGroup.IsUnipotent (ρ g)) :
     ∃ p : Submodule K V, Module.finrank K p = 1 ∧
       ∀ g, ∀ x ∈ p, (ρ g : Module.End K V) x = x := by
-  apply exists_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
+  apply exists_fixed_submodule_finrank_eq_one_of_pairwise_commute_of_isUnipotent ρ _ hunipotent
   intro g h _
   exact (ρ.map_mul g h).symm.trans ((congrArg ρ (mul_comm g h)).trans (ρ.map_mul h g))
 

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Unipotent.lean
@@ -59,13 +59,14 @@ theorem exists_common_fixedVector_of_pairwise_commute_of_isUnipotent
     (hcomm hij).units_val
   have htri (i : ι) : ⨆ μ, (fEnd i).maxGenEigenspace μ = ⊤ := by
     apply top_unique
-    rw [← (hunipotent i).maxGenEigenspace_one_eq_top]
+    rw [← TauCeti.GeneralLinearGroup.IsUnipotent.maxGenEigenspace_one_eq_top (hunipotent i)]
     exact le_iSup (fun μ ↦ (fEnd i).maxGenEigenspace μ) 1
   obtain ⟨χ, v, hv, heigen⟩ :=
     exists_jointEigenvector_of_pairwise_commute fEnd hcommEnd htri
   refine ⟨v, hv, fun i ↦ ?_⟩
   have hχ : χ i = 1 :=
-    (hunipotent i).eigenvalue_eq_one hv (Module.End.mem_eigenspace_iff.mp (heigen i))
+    TauCeti.GeneralLinearGroup.IsUnipotent.eigenvalue_eq_one (hunipotent i) hv
+      (Module.End.mem_eigenspace_iff.mp (heigen i))
   simpa [fEnd, hχ] using Module.End.mem_eigenspace_iff.mp (heigen i)
 
 /-- A pairwise-commuting family of unipotent automorphisms of a nonzero finite-dimensional vector

--- a/TauCeti/LinearAlgebra/Eigenspace/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Unipotent.lean
@@ -39,45 +39,49 @@ noncomputable section
 namespace GeneralLinearGroup
 
 variable {K : Type u} {V : Type v}
-variable [Field K] [AddCommGroup V] [Module K V]
+
+section CommRing
+
+variable [CommRing K] [AddCommGroup V] [Module K V]
 
 /-- The maximal generalized eigenspace for the eigenvalue one of a unipotent automorphism is the
 whole space. -/
+@[simp]
 theorem IsUnipotent.maxGenEigenspace_one_eq_top {g : GeneralLinearGroup K V}
-    (hg : IsUnipotent g) :
+    (hg : LinearMap.GeneralLinearGroup.IsUnipotent g) :
     Module.End.maxGenEigenspace (g : Module.End K V) 1 = ⊤ := by
   rw [eq_top_iff]
   intro x _
   rw [Module.End.mem_maxGenEigenspace]
-  rw [isUnipotent_def] at hg
+  rw [LinearMap.GeneralLinearGroup.isUnipotent_def] at hg
   obtain ⟨n, hn⟩ := hg
   refine ⟨n, ?_⟩
   simpa using LinearMap.congr_fun hn x
 
+end CommRing
+
+section Field
+
+variable [Field K] [AddCommGroup V] [Module K V]
+
 /-- Every eigenvalue of a unipotent automorphism is one. -/
-theorem IsUnipotent.eigenvalue_eq_one {g : GeneralLinearGroup K V} (hg : IsUnipotent g)
+theorem IsUnipotent.eigenvalue_eq_one {g : GeneralLinearGroup K V}
+    (hg : LinearMap.GeneralLinearGroup.IsUnipotent g)
     {v : V} (hv : v ≠ 0) {μ : K} (heigen : (g : Module.End K V) v = μ • v) :
     μ = 1 := by
-  have hpow_apply (m : ℕ) : (((g : Module.End K V) - 1) ^ m) v = (μ - 1) ^ m • v := by
-    induction m with
-    | zero => simp
-    | succ m ih =>
-        calc
-          (((g : Module.End K V) - 1) ^ m.succ) v =
-              ((g : Module.End K V) - 1) ((μ - 1) ^ m • v) := by
-            rw [pow_succ', Module.End.mul_apply, ih]
-          _ = (μ - 1) ^ m • ((μ - 1) • v) := by
-            simp only [map_smul, LinearMap.sub_apply, Module.End.one_apply, heigen, sub_smul,
-              one_smul]
-          _ = (μ - 1) ^ m.succ • v := by rw [smul_smul, pow_succ]
-  rw [isUnipotent_def] at hg
-  obtain ⟨n, hn⟩ := hg
-  have hzero : (μ - 1) ^ n • v = 0 := by
-    rw [← hpow_apply n, hn]
-    rfl
-  have hpow : (μ - 1) ^ n = 0 :=
-    (smul_eq_zero.mp hzero).resolve_right hv
-  exact sub_eq_zero.mp (eq_zero_of_pow_eq_zero hpow)
+  rw [LinearMap.GeneralLinearGroup.isUnipotent_def] at hg
+  have heigenvalue : Module.End.HasEigenvalue (g : Module.End K V) μ :=
+    Module.End.hasEigenvalue_of_hasEigenvector
+      ⟨Module.End.mem_eigenspace_iff.mpr heigen, hv⟩
+  have hsub : Module.End.HasEigenvalue ((g : Module.End K V) - 1) (μ - 1) := by
+    have hshift : Module.End.HasEigenvalue (g : Module.End K V) ((μ - 1) + 1) := by
+      simpa using heigenvalue
+    simpa only [one_smul, Module.End.one_eq_id] using
+      (Module.End.hasEigenvalue_sub_iff (f := (g : Module.End K V))
+        (ρ := (1 : K)) (μ := μ - 1)).mpr hshift
+  exact sub_eq_zero.mp (hsub.isNilpotent_of_isNilpotent hg).eq_zero
+
+end Field
 
 end GeneralLinearGroup
 

--- a/TauCeti/LinearAlgebra/Eigenspace/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Unipotent.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Eigenspace.Basic
+public import TauCeti.LinearAlgebra.GeneralLinearGroup.Unipotent
+
+/-!
+# Eigenspaces of unipotent automorphisms
+
+A unipotent automorphism has maximal generalized `1`-eigenspace equal to the whole space and has
+no eigenvalues other than one.
+
+## Main declarations
+
+* `TauCeti.GeneralLinearGroup.IsUnipotent.maxGenEigenspace_one_eq_top`: the maximal generalized
+  `1`-eigenspace of a unipotent automorphism is the whole space.
+* `TauCeti.GeneralLinearGroup.IsUnipotent.eigenvalue_eq_one`: every eigenvalue of a unipotent
+  automorphism is one.
+
+## References
+
+* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+-/
+
+public section
+
+namespace TauCeti
+
+open LinearMap
+
+universe u v
+
+noncomputable section
+
+namespace GeneralLinearGroup
+
+variable {K : Type u} {V : Type v}
+variable [Field K] [AddCommGroup V] [Module K V]
+
+/-- The maximal generalized eigenspace for the eigenvalue one of a unipotent automorphism is the
+whole space. -/
+theorem IsUnipotent.maxGenEigenspace_one_eq_top {g : GeneralLinearGroup K V}
+    (hg : IsUnipotent g) :
+    Module.End.maxGenEigenspace (g : Module.End K V) 1 = ⊤ := by
+  rw [eq_top_iff]
+  intro x _
+  rw [Module.End.mem_maxGenEigenspace]
+  rw [isUnipotent_def] at hg
+  obtain ⟨n, hn⟩ := hg
+  refine ⟨n, ?_⟩
+  simpa using LinearMap.congr_fun hn x
+
+/-- Every eigenvalue of a unipotent automorphism is one. -/
+theorem IsUnipotent.eigenvalue_eq_one {g : GeneralLinearGroup K V} (hg : IsUnipotent g)
+    {v : V} (hv : v ≠ 0) {μ : K} (heigen : (g : Module.End K V) v = μ • v) :
+    μ = 1 := by
+  have hpow_apply (m : ℕ) : (((g : Module.End K V) - 1) ^ m) v = (μ - 1) ^ m • v := by
+    induction m with
+    | zero => simp
+    | succ m ih =>
+        calc
+          (((g : Module.End K V) - 1) ^ m.succ) v =
+              ((g : Module.End K V) - 1) ((μ - 1) ^ m • v) := by
+            rw [pow_succ', Module.End.mul_apply, ih]
+          _ = (μ - 1) ^ m • ((μ - 1) • v) := by
+            simp only [map_smul, LinearMap.sub_apply, Module.End.one_apply, heigen, sub_smul,
+              one_smul]
+          _ = (μ - 1) ^ m.succ • v := by rw [smul_smul, pow_succ]
+  rw [isUnipotent_def] at hg
+  obtain ⟨n, hn⟩ := hg
+  have hzero : (μ - 1) ^ n • v = 0 := by
+    rw [← hpow_apply n, hn]
+    rfl
+  have hpow : (μ - 1) ^ n = 0 :=
+    (smul_eq_zero.mp hzero).resolve_right hv
+  exact sub_eq_zero.mp (eq_zero_of_pow_eq_zero hpow)
+
+end GeneralLinearGroup
+
+end
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Eigenspace/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Unipotent.lean
@@ -60,9 +60,9 @@ theorem IsUnipotent.maxGenEigenspace_one_eq_top {g : GeneralLinearGroup K V}
 
 end CommRing
 
-section Field
+section IsDomain
 
-variable [Field K] [AddCommGroup V] [Module K V]
+variable [CommRing K] [IsDomain K] [AddCommGroup V] [Module K V] [Module.IsTorsionFree K V]
 
 /-- Every eigenvalue of a unipotent automorphism is one. -/
 theorem IsUnipotent.eigenvalue_eq_one {g : GeneralLinearGroup K V}
@@ -81,7 +81,7 @@ theorem IsUnipotent.eigenvalue_eq_one {g : GeneralLinearGroup K V}
         (ρ := (1 : K)) (μ := μ - 1)).mpr hshift
   exact sub_eq_zero.mp (hsub.isNilpotent_of_isNilpotent hg).eq_zero
 
-end Field
+end IsDomain
 
 end GeneralLinearGroup
 


### PR DESCRIPTION
This PR proves that every pairwise-commuting family of unipotent automorphisms of a nonzero finite-dimensional vector space has a common nonzero fixed vector and fixes its spanning line pointwise, then specializes the result to unipotent representations of commutative groups. It advances the exact `ReductiveGroups/README.md` Layer 5 milestone “Lie–Kolchin; solvable groups” by closing the abelian common-fixed-line step consumed by the fixed-line induction, and it directly supports the Layer 5 target that a smooth connected group is unipotent iff it embeds in the upper-triangular unipotent group `Uₙ`.

The proof reuses `TauCeti.exists_jointEigenvector_of_pairwise_commute`: unipotence makes the maximal generalized `1`-eigenspace the whole space over any field, and nilpotence forces the resulting joint eigenvalues to equal one. No algebraic-closure hypothesis is needed.

After this PR, the noncommutative solvable-group induction and its assembly into a complete invariant flag and upper-unitriangular basis remain for the Lie–Kolchin milestone.

Verified with the targeted module build, `tauceti-axioms --changed-since-merge-base origin/main`, and `tauceti-lint-env --changed-since-merge-base origin/main`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"commuting-unipotent-common-fixed-vector"}-->

🤖 Prepared with Codex
