### PR TITLE
feat: state Bochner's theorem in a usable positive-definite predicate and name its representing measure

### DIFF
--- a/TauCeti/Analysis/Bochner/BochnerTheorem.lean
+++ b/TauCeti/Analysis/Bochner/BochnerTheorem.lean
@@ -386,16 +386,36 @@ theorem isProbabilityMeasure_bochnerMeasure (hcont : Continuous F)
   isProbabilityMeasure_iff_real.mpr <| by
     rw [bochnerMeasure_real_univ hcont hpd, hF0, Complex.one_re]
 
-/-- Scaling a continuous positive-definite function by a nonnegative real scales its Bochner
-measure by the same factor. -/
-theorem bochnerMeasure_const_mul (hcont : Continuous F) (hpd : IsPositiveDefiniteSub F) {r : ℝ}
-    (hr : 0 ≤ r) :
+/-- The Bochner measure of the zero function is the zero measure. -/
+@[simp]
+theorem bochnerMeasure_zero : bochnerMeasure (fun _ : V => (0 : ℂ)) = 0 :=
+  (eq_bochnerMeasure 0 fun v => by simp).symm
+
+/-- Scaling a function by a nonnegative real scales its Bochner measure by the same factor. No
+hypothesis on `F` is needed: for a positive factor the two sides are simultaneously outside the
+hypotheses of Bochner's theorem, where both are `0`. -/
+theorem bochnerMeasure_const_mul (F : V → ℂ) {r : ℝ} (hr : 0 ≤ r) :
     bochnerMeasure (fun v => (r : ℂ) * F v) = ENNReal.ofReal r • bochnerMeasure F := by
-  have hfin : IsFiniteMeasure (ENNReal.ofReal r • bochnerMeasure F) :=
-    Measure.smul_finite _ ENNReal.ofReal_ne_top
-  refine (eq_bochnerMeasure (F := fun v => (r : ℂ) * F v) _ fun v => ?_).symm
-  rw [integral_smul_measure, ENNReal.toReal_ofReal hr, Complex.real_smul,
-    integral_fourierAtom_bochnerMeasure hcont hpd]
+  rcases hr.eq_or_lt with rfl | hpos
+  · simp
+  by_cases h : Continuous F ∧ IsPositiveDefiniteSub F
+  · have hfin : IsFiniteMeasure (ENNReal.ofReal r • bochnerMeasure F) :=
+      Measure.smul_finite _ ENNReal.ofReal_ne_top
+    refine (eq_bochnerMeasure (F := fun v => (r : ℂ) * F v) _ fun v => ?_).symm
+    rw [integral_smul_measure, ENNReal.toReal_ofReal hpos.le, Complex.real_smul,
+      integral_fourierAtom_bochnerMeasure h.1 h.2]
+  · -- rescaling by `r > 0` is invertible, so `r • F` fails Bochner's hypotheses along with `F`
+    rw [bochnerMeasure_eq_zero_of_not h, smul_zero, bochnerMeasure_eq_zero_of_not]
+    rintro ⟨hrcont, hrpd⟩
+    have hrne : (r : ℂ) ≠ 0 := by exact_mod_cast hpos.ne'
+    have hFeq : (fun v => ((r : ℂ)⁻¹ * ((r : ℂ) * F v))) = F := by
+      funext v
+      rw [← mul_assoc, inv_mul_cancel₀ hrne, one_mul]
+    have hcont : Continuous fun v => (r : ℂ)⁻¹ * ((r : ℂ) * F v) := continuous_const.mul hrcont
+    have hpd : IsPositiveDefiniteSub fun v => (r : ℂ)⁻¹ * ((r : ℂ) * F v) :=
+      hrpd.const_mul (inv_nonneg.mpr ((RCLike.ofReal_nonneg (K := ℂ)).mpr hpos.le))
+    rw [hFeq] at hcont hpd
+    exact h ⟨hcont, hpd⟩
 
 /-- The Bochner measure of a sum of continuous positive-definite functions is the sum of their
 Bochner measures. -/
@@ -406,10 +426,5 @@ theorem bochnerMeasure_add {H : V → ℂ} (hFcont : Continuous F) (hFpd : IsPos
   rw [integral_add_measure (integrable_fourierAtom _ v) (integrable_fourierAtom _ v),
     integral_fourierAtom_bochnerMeasure hFcont hFpd,
     integral_fourierAtom_bochnerMeasure hHcont hHpd]
-
-/-- The Bochner measure of the zero function is the zero measure. -/
-@[simp]
-theorem bochnerMeasure_zero : bochnerMeasure (fun _ : V => (0 : ℂ)) = 0 :=
-  (eq_bochnerMeasure 0 fun v => by simp).symm
 
 end TauCeti

--- a/TauCeti/Analysis/Bochner/BochnerTheorem.lean
+++ b/TauCeti/Analysis/Bochner/BochnerTheorem.lean
@@ -61,9 +61,9 @@ functions. Uniqueness is `Measure.ext_of_forall_integral_fourierAtom_eq` from
 
 Adapted (Apache 2.0) from the Bochner–Minlos formalization by Michael R. Douglas
 (https://github.com/mrdouglasny/bochner, revision `08eb302`), source file `Bochner/Main.lean`;
-the positive-definiteness hypotheses are restated through `Matrix.PosSemidef`,
-and the representation is stated in the `fourierAtom` convention rather than through
-`MeasureTheory.charFun`.
+the positive-definiteness hypotheses are restated through `TauCeti.IsPositiveDefiniteSub` and
+`Matrix.PosSemidef`, and the representation is stated in the `fourierAtom` convention rather
+than through `MeasureTheory.charFun`.
 
 ## Main declarations
 

--- a/TauCeti/Analysis/Bochner/BochnerTheorem.lean
+++ b/TauCeti/Analysis/Bochner/BochnerTheorem.lean
@@ -9,8 +9,8 @@ public import Mathlib.Analysis.Fourier.FourierTransform
 public import Mathlib.MeasureTheory.Integral.Bochner.Basic
 public import Mathlib.MeasureTheory.Measure.Haar.OfBasis
 public import Mathlib.MeasureTheory.Measure.WithDensity
+public import TauCeti.Analysis.PositiveDefinite.AddGroup
 public import TauCeti.Analysis.PositiveDefinite.FourierAtom
-public import TauCeti.Analysis.PositiveDefinite.Function.Kernel
 -- The remaining imports are proof-only: Fourier inversion, the characteristic-function API, the
 -- Lévy continuity theorem, Prokhorov's theorem with the Lévy–Prokhorov metrizability of the
 -- space of probability measures, sequential compactness, the Fourier-convention bridge with its
@@ -30,10 +30,17 @@ import TauCeti.Analysis.PositiveDefinite.Kernel.Bounds
 /-!
 # Bochner's theorem
 
-A function `F : V → ℂ` on a finite-dimensional real inner-product space is continuous with a
-positive-definite subtraction kernel `(a, b) ↦ F (a - b)` if and only if it is the
-Fourier-convention transform `v ↦ ∫ q, fourierAtom v q ∂μ` of a unique finite Borel measure `μ`
-on `V`. This file assembles the final statement from the two analytic predecessors.
+A function `F : V → ℂ` on a finite-dimensional real inner-product space is continuous and
+positive definite if and only if it is the Fourier-convention transform
+`v ↦ ∫ q, fourierAtom v q ∂μ` of a unique finite Borel measure `μ` on `V`. This file assembles
+the final statement from the two analytic predecessors, names the representing measure
+`TauCeti.bochnerMeasure`, and records its transform, total mass, scaling, and normalization.
+
+Positive definiteness is `TauCeti.IsPositiveDefiniteSub`, the classical subtraction-form
+predicate on an additive commutative group; the equivalent positive-semidefiniteness of the
+subtraction kernel `(a, b) ↦ F (a - b)` is available through
+`TauCeti.isPositiveDefiniteSub_iff_posSemidef` and is the hypothesis of the kernel-form
+statement `TauCeti.bochner_posSemidef`.
 
 The `L¹` case comes first: for a continuous *integrable* positive-definite `F`, the finite
 measure with density `(𝓕⁻ F).re` against Lebesgue measure recovers `F` as the
@@ -63,14 +70,22 @@ and the representation is stated in the `fourierAtom` convention rather than thr
 * `TauCeti.integral_fourierAtom_withDensity_re_fourierInv`: the measure
   `volume.withDensity (ENNReal.ofReal (𝓕⁻ F ·).re)` recovers `F` through the Fourier atom — the
   `L¹` case of Bochner's theorem.
-* `TauCeti.exists_isFiniteMeasure_integral_fourierAtom_eq_of_posSemidef`:
+* `TauCeti.exists_isFiniteMeasure_integral_fourierAtom_eq`:
   existence of a finite representing measure for a continuous positive-definite function.
 * `TauCeti.bochner`, with the Euclidean specialization
   `TauCeti.bochner_euclideanSpace`:
-  **Bochner's theorem**, the equivalence between continuity together with
-  positive definiteness of the subtraction kernel and the unique Fourier representation.
-* `TauCeti.bochner_of_forall_star_eq_neg`: the same equivalence for the involutive
-  positive-definiteness predicate under the negation involution.
+  **Bochner's theorem**, the equivalence between continuity together with positive definiteness
+  and the unique Fourier representation.
+* `TauCeti.bochner_posSemidef`: the same equivalence with positive definiteness written as
+  positive semidefiniteness of the subtraction kernel.
+* `TauCeti.bochner_probabilityMeasure`: the normalized form — a positive-definite function with
+  `F 0 = 1` is the transform of a unique probability measure.
+* `TauCeti.bochnerMeasure`: the representing measure itself, with
+  `TauCeti.integral_fourierAtom_bochnerMeasure` (its transform),
+  `TauCeti.eq_bochnerMeasure` (uniqueness), `TauCeti.bochnerMeasure_univ` and
+  `TauCeti.bochnerMeasure_real_univ` (total mass),
+  `TauCeti.bochnerMeasure_const_mul` (nonnegative real scaling), and
+  `TauCeti.isProbabilityMeasure_bochnerMeasure` (normalization).
 
 ## References
 
@@ -194,57 +209,61 @@ private theorem exists_probabilityMeasure_integral_fourierAtom_eq {G : V → ℂ
 
 /-! ### Bochner's theorem -/
 
-/-- **Existence half of Bochner's theorem.** A continuous function `F` on a finite-dimensional
-real inner-product space whose subtraction kernel `(a, b) ↦ F (a - b)` is positive definite is
-the Fourier-convention transform `v ↦ ∫ q, fourierAtom v q ∂μ` of a finite Borel measure `μ`.
-Rudin, *Fourier Analysis on Groups*, Theorem 1.4.3. -/
-theorem exists_isFiniteMeasure_integral_fourierAtom_eq_of_posSemidef
-    (F : V → ℂ) (hcont : Continuous F)
-    (hpd : Matrix.PosSemidef fun a b : V => F (a - b)) :
+/-- **Existence half of Bochner's theorem.** A continuous positive-definite function `F` on a
+finite-dimensional real inner-product space is the Fourier-convention transform
+`v ↦ ∫ q, fourierAtom v q ∂μ` of a finite Borel measure `μ`. Rudin, *Fourier Analysis on Groups*,
+Theorem 1.4.3. -/
+theorem exists_isFiniteMeasure_integral_fourierAtom_eq
+    (F : V → ℂ) (hcont : Continuous F) (hpd : IsPositiveDefiniteSub F) :
     ∃ μ : Measure V, IsFiniteMeasure μ ∧ ∀ v, F v = ∫ q, fourierAtom v q ∂μ := by
-  have h0re : 0 ≤ (F 0).re := by
-    simpa using map_zero_re_nonneg_of_posSemidef hpd
-  have h0eq : F 0 = ((F 0).re : ℂ) := by
-    simpa using map_zero_eq_ofReal_re_of_posSemidef hpd
+  have h0re : 0 ≤ (F 0).re := hpd.map_zero_re_nonneg
+  have h0eq : F 0 = ((F 0).re : ℂ) := hpd.map_zero_eq_ofReal_re
   rcases h0re.eq_or_lt with hzero | hpos
   · -- degenerate case: `F 0 = 0` forces `F = 0`, represented by the zero measure
-    have hF0 : F 0 = 0 := by rw [h0eq, ← hzero, Complex.ofReal_zero]
-    have hFv : ∀ v : V, F v = 0 := fun v => by
-      simpa using hpd.eq_zero_of_apply_self_eq_zero_right
-        (a := v) (b := (0 : V)) (by simpa using hF0)
+    have hFv : ∀ v : V, F v = 0 :=
+      hpd.apply_eq_zero_of_map_zero_re_eq_zero hzero.symm
     exact ⟨0, inferInstance, fun v => by simp [hFv v]⟩
   · -- main case: normalize to value `1` at the origin and scale the measure back
     set c : ℝ := (F 0).re
     have hcne : (c : ℂ) ≠ 0 := by exact_mod_cast hpos.ne'
+    have hF0 : F 0 ≠ 0 := by
+      rw [h0eq]
+      exact hcne
     set G : V → ℂ := fun v => (c : ℂ)⁻¹ * F v with hG_def
-    have hG_pd : Matrix.PosSemidef fun a b : V => G (a - b) := by
-      simp only [hG_def]
-      exact hpd.smul
-        (inv_nonneg.mpr ((RCLike.ofReal_nonneg (K := ℂ)).mpr hpos.le))
+    have hG_pd : IsPositiveDefiniteSub G := hpd.normalize
     have hG_cont : Continuous G := continuous_const.mul hcont
-    have hG0 : G 0 = 1 := by
-      rw [hG_def]
-      simp only [h0eq]
-      exact inv_mul_cancel₀ hcne
+    have hG0 : G 0 = 1 := hpd.normalize_apply_zero hF0
     obtain ⟨μ, hμ_prob, hμ_rep⟩ :=
-      exists_probabilityMeasure_integral_fourierAtom_eq hG_pd hG_cont hG0
-    refine ⟨ENNReal.ofReal c • μ, ⟨?_⟩, fun v => ?_⟩
-    · rw [Measure.smul_apply, smul_eq_mul]
-      exact ENNReal.mul_lt_top ENNReal.ofReal_lt_top (measure_lt_top μ _)
-    · rw [integral_smul_measure, ENNReal.toReal_ofReal hpos.le, hμ_rep v, hG_def,
-        Complex.real_smul, ← mul_assoc, mul_inv_cancel₀ hcne, one_mul]
+      exists_probabilityMeasure_integral_fourierAtom_eq hG_pd.posSemidef hG_cont hG0
+    refine ⟨ENNReal.ofReal c • μ, Measure.smul_finite _ ENNReal.ofReal_ne_top, fun v => ?_⟩
+    rw [integral_smul_measure, ENNReal.toReal_ofReal hpos.le, hμ_rep v, hG_def,
+      Complex.real_smul, ← mul_assoc, mul_inv_cancel₀ hcne, one_mul]
+
+/-- **Converse half of Bochner's theorem.** The Fourier-convention transform of a finite Borel
+measure is continuous and positive definite. -/
+theorem continuous_and_isPositiveDefiniteSub_of_integral_fourierAtom_eq {F : V → ℂ}
+    (μ : Measure V) [IsFiniteMeasure μ] (hrep : ∀ v, F v = ∫ q, fourierAtom v q ∂μ) :
+    Continuous F ∧ IsPositiveDefiniteSub F := by
+  refine ⟨?_, IsPositiveDefiniteSub.of_posSemidef ?_⟩
+  · rw [funext hrep]
+    exact continuous_fourierConventionCharFun
+  · have hfun : (fun a b : V => F (a - b)) =
+        fun a b : V => ∫ q, fourierAtom (a - b) q ∂μ := by
+      funext a b
+      exact hrep (a - b)
+    rw [hfun]
+    exact posSemidef_fourierConventionCharFun_sub
 
 /-- **Bochner's theorem.** A function `F` on a finite-dimensional real inner-product space is
-continuous with a positive-definite subtraction kernel `(a, b) ↦ F (a - b)` if and only if it
-is the Fourier-convention transform `v ↦ ∫ q, fourierAtom v q ∂μ` of a unique finite Borel
-measure `μ`. Bochner (1932); Rudin, *Fourier Analysis on Groups*, Theorem 1.4.3. -/
+continuous and positive definite if and only if it is the Fourier-convention transform
+`v ↦ ∫ q, fourierAtom v q ∂μ` of a unique finite Borel measure `μ`. Bochner (1932); Rudin,
+*Fourier Analysis on Groups*, Theorem 1.4.3. -/
 theorem bochner (F : V → ℂ) :
-    (Continuous F ∧ Matrix.PosSemidef fun a b : V => F (a - b)) ↔
+    (Continuous F ∧ IsPositiveDefiniteSub F) ↔
       ∃! μ : Measure V, IsFiniteMeasure μ ∧ ∀ v, F v = ∫ q, fourierAtom v q ∂μ := by
   constructor
   · rintro ⟨hcont, hpd⟩
-    obtain ⟨μ, hfin, hrep⟩ :=
-      exists_isFiniteMeasure_integral_fourierAtom_eq_of_posSemidef F hcont hpd
+    obtain ⟨μ, hfin, hrep⟩ := exists_isFiniteMeasure_integral_fourierAtom_eq F hcont hpd
     refine ⟨μ, ⟨hfin, hrep⟩, ?_⟩
     rintro ν ⟨hνfin, hνrep⟩
     have := hfin
@@ -253,33 +272,122 @@ theorem bochner (F : V → ℂ) :
       fun v => (hνrep v).symm.trans (hrep v)
   · rintro ⟨μ, ⟨hfin, hrep⟩, -⟩
     have := hfin
-    refine ⟨?_, ?_⟩
-    · rw [funext hrep]
-      exact continuous_fourierConventionCharFun
-    · have hfun : (fun a b : V => F (a - b)) =
-          fun a b : V => ∫ q, fourierAtom (a - b) q ∂μ := by
-        funext a b
-        exact hrep (a - b)
-      rw [hfun]
-      exact posSemidef_fourierConventionCharFun_sub
+    exact continuous_and_isPositiveDefiniteSub_of_integral_fourierAtom_eq μ hrep
 
-/-- **Bochner's theorem for the involutive predicate.** Under the negation involution
-`star x = -x`, a function is continuous and positive definite in the involutive sense if and
-only if it is the Fourier-convention transform of a unique finite Borel measure. -/
-theorem bochner_of_forall_star_eq_neg [StarAddMonoid V] (hstar : ∀ x : V, star x = -x)
-    (F : V → ℂ) :
-    (Continuous F ∧ IsPositiveDefinite F) ↔
+/-- **Bochner's theorem, kernel form.** The subtraction kernel `(a, b) ↦ F (a - b)` of a
+continuous function is positive semidefinite if and only if `F` is the Fourier-convention
+transform of a unique finite Borel measure. This is `TauCeti.bochner` read through the
+PD-function ↔ PD-kernel correspondence `TauCeti.isPositiveDefiniteSub_iff_posSemidef`. -/
+theorem bochner_posSemidef (F : V → ℂ) :
+    (Continuous F ∧ Matrix.PosSemidef fun a b : V => F (a - b)) ↔
       ∃! μ : Measure V, IsFiniteMeasure μ ∧ ∀ v, F v = ∫ q, fourierAtom v q ∂μ :=
-  (and_congr_right fun _ =>
-    isPositiveDefinite_iff_posSemidef_sub hstar).trans (bochner F)
+  (and_congr_right fun _ => isPositiveDefiniteSub_iff_posSemidef.symm).trans (bochner F)
 
 /-- **Bochner's theorem on `ℝᵈ`**: the specialization of `bochner` to Euclidean space. A
-function on `EuclideanSpace ℝ (Fin d)` is continuous with positive-definite subtraction kernel
-if and only if it is the Fourier transform of a unique finite positive measure. -/
+function on `EuclideanSpace ℝ (Fin d)` is continuous and positive definite if and only if it is
+the Fourier transform of a unique finite positive measure. -/
 theorem bochner_euclideanSpace (d : ℕ) (F : EuclideanSpace ℝ (Fin d) → ℂ) :
-    (Continuous F ∧ Matrix.PosSemidef fun a b => F (a - b)) ↔
+    (Continuous F ∧ IsPositiveDefiniteSub F) ↔
       ∃! μ : Measure (EuclideanSpace ℝ (Fin d)), IsFiniteMeasure μ ∧
         ∀ v, F v = ∫ q, fourierAtom v q ∂μ :=
   bochner F
+
+/-- **Bochner's theorem for normalized functions.** A function with `F 0 = 1` is continuous and
+positive definite if and only if it is the Fourier-convention transform of a unique
+*probability* measure; this is the characteristic-function form of the theorem. -/
+theorem bochner_probabilityMeasure (F : V → ℂ) (hF0 : F 0 = 1) :
+    (Continuous F ∧ IsPositiveDefiniteSub F) ↔
+      ∃! μ : Measure V, IsProbabilityMeasure μ ∧ ∀ v, F v = ∫ q, fourierAtom v q ∂μ := by
+  constructor
+  · rintro ⟨hcont, hpd⟩
+    obtain ⟨μ, hprob, hrep⟩ :=
+      exists_probabilityMeasure_integral_fourierAtom_eq hpd.posSemidef hcont hF0
+    refine ⟨μ, ⟨hprob, fun v => (hrep v).symm⟩, ?_⟩
+    rintro ν ⟨hνprob, hνrep⟩
+    have := hprob
+    have := hνprob
+    exact Measure.ext_of_forall_integral_fourierAtom_eq
+      fun v => (hνrep v).symm.trans (hrep v).symm
+  · rintro ⟨μ, ⟨hprob, hrep⟩, -⟩
+    have := hprob
+    exact continuous_and_isPositiveDefiniteSub_of_integral_fourierAtom_eq μ hrep
+
+/-! ### The representing measure -/
+
+open Classical in
+/-- **The representing measure of Bochner's theorem**: the unique finite Borel measure whose
+Fourier-convention transform is `F`, when `F` is continuous and positive definite, and the zero
+measure otherwise. -/
+noncomputable def bochnerMeasure (F : V → ℂ) : Measure V :=
+  if h : Continuous F ∧ IsPositiveDefiniteSub F then ((bochner F).mp h).exists.choose else 0
+
+variable {F : V → ℂ}
+
+private theorem bochnerMeasure_rep (hcont : Continuous F) (hpd : IsPositiveDefiniteSub F) (v : V) :
+    F v = ∫ q, fourierAtom v q ∂(bochnerMeasure F) := by
+  classical
+  rw [bochnerMeasure, dite_eq_left ⟨hcont, hpd⟩]
+  exact ((bochner F).mp ⟨hcont, hpd⟩).exists.choose_spec.2 v
+
+/-- The Bochner measure of any function is finite: for a continuous positive-definite function
+this is the finiteness of its representing measure, and otherwise the measure is `0`. -/
+instance isFiniteMeasure_bochnerMeasure (F : V → ℂ) : IsFiniteMeasure (bochnerMeasure F) := by
+  classical
+  rw [bochnerMeasure]
+  split
+  · rename_i h
+    exact ((bochner F).mp h).exists.choose_spec.1
+  · infer_instance
+
+/-- **The Bochner measure represents its function.** -/
+theorem integral_fourierAtom_bochnerMeasure (hcont : Continuous F) (hpd : IsPositiveDefiniteSub F)
+    (v : V) : ∫ q, fourierAtom v q ∂(bochnerMeasure F) = F v :=
+  (bochnerMeasure_rep hcont hpd v).symm
+
+/-- **Uniqueness of the Bochner measure.** Any finite Borel measure whose Fourier-convention
+transform is `F` is the Bochner measure of `F`; no hypothesis on `F` is needed, since a function
+represented by a finite measure is automatically continuous and positive definite. -/
+theorem eq_bochnerMeasure (μ : Measure V) [IsFiniteMeasure μ]
+    (hrep : ∀ v, F v = ∫ q, fourierAtom v q ∂μ) : μ = bochnerMeasure F := by
+  obtain ⟨hcont, hpd⟩ := continuous_and_isPositiveDefiniteSub_of_integral_fourierAtom_eq μ hrep
+  exact Measure.ext_of_forall_integral_fourierAtom_eq
+    fun v => (hrep v).symm.trans (bochnerMeasure_rep hcont hpd v)
+
+/-- The total mass of the Bochner measure is the value of the function at the origin. -/
+theorem bochnerMeasure_real_univ (hcont : Continuous F) (hpd : IsPositiveDefiniteSub F) :
+    (bochnerMeasure F).real Set.univ = (F 0).re := by
+  have h0 := bochnerMeasure_rep hcont hpd 0
+  simp only [fourierAtom_zero_left, integral_const, Complex.real_smul, mul_one] at h0
+  rw [h0, Complex.ofReal_re]
+
+/-- The total mass of the Bochner measure, as an extended nonnegative real. -/
+theorem bochnerMeasure_univ (hcont : Continuous F) (hpd : IsPositiveDefiniteSub F) :
+    bochnerMeasure F Set.univ = ENNReal.ofReal (F 0).re := by
+  rw [← bochnerMeasure_real_univ hcont hpd, measureReal_def,
+    ENNReal.ofReal_toReal (measure_ne_top _ _)]
+
+/-- **The normalized case.** The Bochner measure of a positive-definite function with `F 0 = 1`
+is a probability measure. -/
+theorem isProbabilityMeasure_bochnerMeasure (hcont : Continuous F)
+    (hpd : IsPositiveDefiniteSub F) (hF0 : F 0 = 1) :
+    IsProbabilityMeasure (bochnerMeasure F) :=
+  isProbabilityMeasure_iff_real.mpr <| by
+    rw [bochnerMeasure_real_univ hcont hpd, hF0, Complex.one_re]
+
+/-- Scaling a continuous positive-definite function by a nonnegative real scales its Bochner
+measure by the same factor. -/
+theorem bochnerMeasure_const_mul (hcont : Continuous F) (hpd : IsPositiveDefiniteSub F) {r : ℝ}
+    (hr : 0 ≤ r) :
+    bochnerMeasure (fun v => (r : ℂ) * F v) = ENNReal.ofReal r • bochnerMeasure F := by
+  have hfin : IsFiniteMeasure (ENNReal.ofReal r • bochnerMeasure F) :=
+    Measure.smul_finite _ ENNReal.ofReal_ne_top
+  refine (eq_bochnerMeasure (F := fun v => (r : ℂ) * F v) _ fun v => ?_).symm
+  rw [integral_smul_measure, ENNReal.toReal_ofReal hr, Complex.real_smul,
+    integral_fourierAtom_bochnerMeasure hcont hpd]
+
+/-- The Bochner measure of the zero function is the zero measure. -/
+@[simp]
+theorem bochnerMeasure_zero : bochnerMeasure (fun _ : V => (0 : ℂ)) = 0 :=
+  (eq_bochnerMeasure 0 fun v => by simp).symm
 
 end TauCeti

--- a/TauCeti/Analysis/Bochner/BochnerTheorem.lean
+++ b/TauCeti/Analysis/Bochner/BochnerTheorem.lean
@@ -82,7 +82,9 @@ than through `MeasureTheory.charFun`.
   `F 0 = 1` is the transform of a unique probability measure.
 * `TauCeti.bochnerMeasure`: the representing measure itself, with
   `TauCeti.integral_fourierAtom_bochnerMeasure` (its transform),
-  `TauCeti.eq_bochnerMeasure` (uniqueness), `TauCeti.bochnerMeasure_univ` and
+  `TauCeti.eq_bochnerMeasure` (uniqueness),
+  `TauCeti.bochnerMeasure_eq_zero_of_not` (the fallback branch),
+  `TauCeti.bochnerMeasure_univ` and
   `TauCeti.bochnerMeasure_real_univ` (total mass),
   `TauCeti.bochnerMeasure_const_mul` and `TauCeti.bochnerMeasure_add` (nonnegative real scaling
   and additivity), and `TauCeti.isProbabilityMeasure_bochnerMeasure` (normalization).
@@ -332,6 +334,12 @@ private theorem bochnerMeasure_rep (hcont : Continuous F) (hpd : IsPositiveDefin
   classical
   rw [bochnerMeasure, dite_eq_left ⟨hcont, hpd⟩]
   exact ((bochner F).mp ⟨hcont, hpd⟩).exists.choose_spec.2 v
+
+/-- Outside the hypotheses of Bochner's theorem the Bochner measure is `0`. -/
+theorem bochnerMeasure_eq_zero_of_not (h : ¬(Continuous F ∧ IsPositiveDefiniteSub F)) :
+    bochnerMeasure F = 0 := by
+  classical
+  rw [bochnerMeasure, dite_eq_right h]
 
 /-- The Bochner measure of any function is finite: for a continuous positive-definite function
 this is the finiteness of its representing measure, and otherwise the measure is `0`. -/

--- a/TauCeti/Analysis/Bochner/BochnerTheorem.lean
+++ b/TauCeti/Analysis/Bochner/BochnerTheorem.lean
@@ -84,8 +84,8 @@ and the representation is stated in the `fourierAtom` convention rather than thr
   `TauCeti.integral_fourierAtom_bochnerMeasure` (its transform),
   `TauCeti.eq_bochnerMeasure` (uniqueness), `TauCeti.bochnerMeasure_univ` and
   `TauCeti.bochnerMeasure_real_univ` (total mass),
-  `TauCeti.bochnerMeasure_const_mul` (nonnegative real scaling), and
-  `TauCeti.isProbabilityMeasure_bochnerMeasure` (normalization).
+  `TauCeti.bochnerMeasure_const_mul` and `TauCeti.bochnerMeasure_add` (nonnegative real scaling
+  and additivity), and `TauCeti.isProbabilityMeasure_bochnerMeasure` (normalization).
 
 ## References
 
@@ -292,14 +292,15 @@ theorem bochner_euclideanSpace (d : ℕ) (F : EuclideanSpace ℝ (Fin d) → ℂ
         ∀ v, F v = ∫ q, fourierAtom v q ∂μ :=
   bochner F
 
-/-- **Bochner's theorem for normalized functions.** A function with `F 0 = 1` is continuous and
-positive definite if and only if it is the Fourier-convention transform of a unique
-*probability* measure; this is the characteristic-function form of the theorem. -/
-theorem bochner_probabilityMeasure (F : V → ℂ) (hF0 : F 0 = 1) :
-    (Continuous F ∧ IsPositiveDefiniteSub F) ↔
+/-- **Bochner's theorem for normalized functions.** A function is continuous, positive definite
+and normalized by `F 0 = 1` if and only if it is the Fourier-convention transform of a unique
+*probability* measure; this is the characteristic-function form of the theorem. Normalization is
+part of the equivalence: a probability representation forces `F 0 = 1`. -/
+theorem bochner_probabilityMeasure (F : V → ℂ) :
+    (Continuous F ∧ IsPositiveDefiniteSub F ∧ F 0 = 1) ↔
       ∃! μ : Measure V, IsProbabilityMeasure μ ∧ ∀ v, F v = ∫ q, fourierAtom v q ∂μ := by
   constructor
-  · rintro ⟨hcont, hpd⟩
+  · rintro ⟨hcont, hpd, hF0⟩
     obtain ⟨μ, hprob, hrep⟩ :=
       exists_probabilityMeasure_integral_fourierAtom_eq hpd.posSemidef hcont hF0
     refine ⟨μ, ⟨hprob, fun v => (hrep v).symm⟩, ?_⟩
@@ -310,7 +311,10 @@ theorem bochner_probabilityMeasure (F : V → ℂ) (hF0 : F 0 = 1) :
       fun v => (hνrep v).symm.trans (hrep v).symm
   · rintro ⟨μ, ⟨hprob, hrep⟩, -⟩
     have := hprob
-    exact continuous_and_isPositiveDefiniteSub_of_integral_fourierAtom_eq μ hrep
+    obtain ⟨hcont, hpd⟩ := continuous_and_isPositiveDefiniteSub_of_integral_fourierAtom_eq μ hrep
+    refine ⟨hcont, hpd, ?_⟩
+    rw [hrep 0]
+    simp
 
 /-! ### The representing measure -/
 
@@ -384,6 +388,16 @@ theorem bochnerMeasure_const_mul (hcont : Continuous F) (hpd : IsPositiveDefinit
   refine (eq_bochnerMeasure (F := fun v => (r : ℂ) * F v) _ fun v => ?_).symm
   rw [integral_smul_measure, ENNReal.toReal_ofReal hr, Complex.real_smul,
     integral_fourierAtom_bochnerMeasure hcont hpd]
+
+/-- The Bochner measure of a sum of continuous positive-definite functions is the sum of their
+Bochner measures. -/
+theorem bochnerMeasure_add {H : V → ℂ} (hFcont : Continuous F) (hFpd : IsPositiveDefiniteSub F)
+    (hHcont : Continuous H) (hHpd : IsPositiveDefiniteSub H) :
+    bochnerMeasure (fun v => F v + H v) = bochnerMeasure F + bochnerMeasure H := by
+  refine (eq_bochnerMeasure (F := fun v => F v + H v) _ fun v => ?_).symm
+  rw [integral_add_measure (integrable_fourierAtom _ v) (integrable_fourierAtom _ v),
+    integral_fourierAtom_bochnerMeasure hFcont hFpd,
+    integral_fourierAtom_bochnerMeasure hHcont hHpd]
 
 /-- The Bochner measure of the zero function is the zero measure. -/
 @[simp]

--- a/TauCeti/Analysis/Bochner/Fourier/Convention.lean
+++ b/TauCeti/Analysis/Bochner/Fourier/Convention.lean
@@ -35,7 +35,6 @@ function API item asking for "a stated Fourier-convention conversion lemma betwe
   `charFun μ ((-2π) • a)`.
 * `TauCeti.fourier_eq_integral_fourierAtom_mul`: the Fourier transform `𝓕 F` is the
   integral of `F` against the Fourier atom.
-* `TauCeti.integrable_fourierAtom`: a Fourier atom is integrable against a finite measure.
 * `TauCeti.posSemidef_fourierConventionCharFun_sub`: the Fourier-convention
   translation-invariant kernel of a finite measure is positive definite.
 * `TauCeti.Measure.ext_of_forall_integral_fourierAtom_eq`: a finite measure is determined by its
@@ -113,13 +112,6 @@ theorem fourierConventionCharFun_isPositiveDefinite_of_star_eq_neg [StarAddMonoi
   convert hchar using 1
   ext a
   exact integral_fourierAtom_eq_charFun_neg_two_pi_smul (μ := ν) a
-
-/-- A Fourier atom, having unit norm and being continuous, is integrable against a finite
-measure. -/
-theorem integrable_fourierAtom (ν : Measure W) [IsFiniteMeasure ν] (a : W) :
-    Integrable (fourierAtom a) ν :=
-  (integrable_const (1 : ℝ)).mono' (continuous_fourierAtom a).aestronglyMeasurable
-    (.of_forall fun q => (norm_fourierAtom a q).le)
 
 /-- The translation-invariant kernel attached to the Fourier-convention transform of a finite
 measure is positive definite. This is the kernel form of

--- a/TauCeti/Analysis/Bochner/Fourier/Convention.lean
+++ b/TauCeti/Analysis/Bochner/Fourier/Convention.lean
@@ -35,6 +35,7 @@ function API item asking for "a stated Fourier-convention conversion lemma betwe
   `charFun μ ((-2π) • a)`.
 * `TauCeti.fourier_eq_integral_fourierAtom_mul`: the Fourier transform `𝓕 F` is the
   integral of `F` against the Fourier atom.
+* `TauCeti.integrable_fourierAtom`: a Fourier atom is integrable against a finite measure.
 * `TauCeti.posSemidef_fourierConventionCharFun_sub`: the Fourier-convention
   translation-invariant kernel of a finite measure is positive definite.
 * `TauCeti.Measure.ext_of_forall_integral_fourierAtom_eq`: a finite measure is determined by its
@@ -112,6 +113,13 @@ theorem fourierConventionCharFun_isPositiveDefinite_of_star_eq_neg [StarAddMonoi
   convert hchar using 1
   ext a
   exact integral_fourierAtom_eq_charFun_neg_two_pi_smul (μ := ν) a
+
+/-- A Fourier atom, having unit norm and being continuous, is integrable against a finite
+measure. -/
+theorem integrable_fourierAtom (ν : Measure W) [IsFiniteMeasure ν] (a : W) :
+    Integrable (fourierAtom a) ν :=
+  (integrable_const (1 : ℝ)).mono' (continuous_fourierAtom a).aestronglyMeasurable
+    (.of_forall fun q => (norm_fourierAtom a q).le)
 
 /-- The translation-invariant kernel attached to the Fourier-convention transform of a finite
 measure is positive definite. This is the kernel form of

--- a/TauCeti/Analysis/PositiveDefinite/AddGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/AddGroup.lean
@@ -98,16 +98,18 @@ instance : StarAddMonoid (WithNegStar G) where
   star_add a b := neg_add a b
 
 /-- The identity additive equivalence from `G` to its negation-involution copy. -/
-@[expose] def toNegStar : G ≃+ WithNegStar G := AddEquiv.refl G
+def toNegStar : G ≃+ WithNegStar G := AddEquiv.refl G
 
 /-- The identity additive equivalence from the negation-involution copy of `G` back to `G`. -/
-@[expose] def ofNegStar : WithNegStar G ≃+ G := AddEquiv.refl G
+def ofNegStar : WithNegStar G ≃+ G := toNegStar.symm
 
 @[simp]
-theorem ofNegStar_toNegStar (a : G) : ofNegStar (toNegStar a) = a := rfl
+theorem ofNegStar_toNegStar (a : G) : ofNegStar (toNegStar a) = a :=
+  toNegStar.symm_apply_apply a
 
 @[simp]
-theorem toNegStar_ofNegStar (a : WithNegStar G) : toNegStar (ofNegStar a) = a := rfl
+theorem toNegStar_ofNegStar (a : WithNegStar G) : toNegStar (ofNegStar a) = a :=
+  toNegStar.apply_symm_apply a
 
 end AddCommGroup
 

--- a/TauCeti/Analysis/PositiveDefinite/AddGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/AddGroup.lean
@@ -1,0 +1,368 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.PositiveDefinite.Continuity
+public import TauCeti.Analysis.PositiveDefinite.Function.Closure
+public import TauCeti.Analysis.PositiveDefinite.Function.Kernel
+public import TauCeti.Analysis.PositiveDefinite.Limits
+public import TauCeti.Analysis.PositiveDefinite.Normalize
+
+/-!
+# Positive-definite functions on an additive commutative group
+
+On an additive commutative group `G` the classical positive-definiteness condition for
+`F : G → ℂ` reads `∑_{i,j} cᵢ · conj(cⱼ) · F(aᵢ - aⱼ) ≥ 0`: the involution is negation, so the
+kernel is the translation-invariant `K(a, b) = F(a - b)`. Mathlib's `star` on a real vector space
+is the identity, not negation, so the generic involutive predicate
+`TauCeti.IsPositiveDefinite` does *not* express this condition for the canonical instances on
+`ℝ` or on a Euclidean space. This file supplies the subtraction-form predicate
+`TauCeti.IsPositiveDefiniteSub` that does, and connects it to the generic theory.
+
+The connection runs through the type synonym `TauCeti.WithNegStar G`, a copy of `G` carrying the
+negation involution `star a = -a` as a genuine `StarAddMonoid` instance. Installing that
+involution on `G` itself would clash with Mathlib's star conventions, so it is installed on the
+synonym instead, and `TauCeti.isPositiveDefiniteSub_iff_isPositiveDefinite` transports statements
+across. The synonym is public: a generic lemma with no transfer lemma here can still be applied to
+`fun a : WithNegStar G => F (WithNegStar.ofNegStar a)`.
+
+This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Objects, which asks for
+`IsPositiveDefinite` to be defined generically and then *instantiated* on a finite-dimensional real
+inner-product space with the involution `a⋆ = -a`, and the `API to develop` items (closure
+properties, the value bounds at the origin, continuity at `0` implying uniform continuity, the
+PD-function ↔ PD-kernel equivalence `F(a - b)`, and normalization) at that instantiation. It is
+the predicate in which Bochner's theorem is stated, in
+`TauCeti/Analysis/Bochner/BochnerTheorem.lean`.
+
+## Main declarations
+
+* `TauCeti.WithNegStar`: the type synonym carrying the negation involution.
+* `TauCeti.IsPositiveDefiniteSub`: the subtraction-form positive-definiteness predicate.
+* `TauCeti.isPositiveDefiniteSub_iff_isPositiveDefinite`: the transfer to the generic predicate.
+* `TauCeti.isPositiveDefiniteSub_iff_posSemidef`: the PD-function ↔ PD-kernel equivalence.
+* `TauCeti.isPositiveDefinite_iff_isPositiveDefiniteSub`: agreement with the generic predicate on
+  a group whose own involution is negation.
+* `TauCeti.IsPositiveDefiniteSub.map_zero_nonneg`, `map_zero_re_nonneg`, `map_zero_eq_ofReal_re`,
+  `map_neg`, `conj_symm`, `normSq_le`, `norm_apply_le_map_zero_re`: values at and around the
+  origin.
+* `TauCeti.IsPositiveDefiniteSub.add`, `const_mul`, `real_smul`, `mul`, `sum`, `prod`,
+  `TauCeti.isPositiveDefiniteSub_const`: closure properties.
+* `TauCeti.IsPositiveDefiniteSub.of_tendsto`: pointwise limits.
+* `TauCeti.IsPositiveDefiniteSub.normalize`: normalization to value `1` at the origin.
+* `TauCeti.IsPositiveDefiniteSub.uniformContinuous_of_continuousAt_zero`: continuity at `0`
+  implies uniform continuity.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Chapter 3.
+* W. Rudin, *Fourier Analysis on Groups* (1962), §1.4.
+-/
+
+public section
+
+open ComplexConjugate Filter
+open scoped ComplexOrder Topology
+
+namespace TauCeti
+
+/-! ### The negation involution -/
+
+/-- `WithNegStar G` is a type synonym for an additive commutative group `G`, carrying the negation
+involution `star a = -a`.
+
+Mathlib pins no negation `StarAddMonoid` instance on an additive group — on a real vector space
+`star` is the identity — so the involution used by classical positive definiteness is installed on
+this synonym rather than on `G` itself. -/
+@[expose] def WithNegStar (G : Type*) : Type _ := G
+
+namespace WithNegStar
+
+section AddCommGroup
+
+variable {G : Type*} [AddCommGroup G]
+
+instance : AddCommGroup (WithNegStar G) := inferInstanceAs (AddCommGroup G)
+
+instance : Star (WithNegStar G) := ⟨fun a => -a⟩
+
+@[simp]
+theorem star_eq_neg (a : WithNegStar G) : star a = -a := rfl
+
+instance : StarAddMonoid (WithNegStar G) where
+  star_involutive a := neg_neg a
+  star_add a b := neg_add a b
+
+/-- The identity additive equivalence from `G` to its negation-involution copy. -/
+@[expose] def toNegStar : G ≃+ WithNegStar G := AddEquiv.refl G
+
+/-- The identity additive equivalence from the negation-involution copy of `G` back to `G`. -/
+@[expose] def ofNegStar : WithNegStar G ≃+ G := AddEquiv.refl G
+
+@[simp]
+theorem ofNegStar_toNegStar (a : G) : ofNegStar (toNegStar a) = a := rfl
+
+@[simp]
+theorem toNegStar_ofNegStar (a : WithNegStar G) : toNegStar (ofNegStar a) = a := rfl
+
+end AddCommGroup
+
+section Seminormed
+
+variable {G : Type*} [SeminormedAddCommGroup G]
+
+instance : SeminormedAddCommGroup (WithNegStar G) :=
+  inferInstanceAs (SeminormedAddCommGroup G)
+
+end Seminormed
+
+end WithNegStar
+
+/-! ### The subtraction-form predicate -/
+
+variable {G : Type*} [AddCommGroup G] {F H : G → ℂ}
+
+/-- A function `F : G → ℂ` on an additive commutative group is **positive definite** when, for
+every finite family of scalars `c : Fin n → ℂ` and points `v : Fin n → G`, the Hermitian form
+`∑_{i,j} c i · conj (c j) * F (v i - v j)` is a nonnegative real number (using the order on `ℂ`
+for which `0 ≤ z` means `z` is real and nonnegative).
+
+This is the classical translation-invariant condition, the one Bochner's theorem is stated in. It
+is `TauCeti.IsPositiveDefinite` for the negation involution; see
+`TauCeti.isPositiveDefiniteSub_iff_isPositiveDefinite`. -/
+@[expose] def IsPositiveDefiniteSub (F : G → ℂ) : Prop :=
+  ∀ (n : ℕ) (c : Fin n → ℂ) (v : Fin n → G),
+    0 ≤ ∑ i, ∑ j, c i * conj (c j) * F (v i - v j)
+
+/-- Subtraction-form positive definiteness is the generic involutive predicate for the negation
+involution, read on the type synonym `TauCeti.WithNegStar`. -/
+theorem isPositiveDefiniteSub_iff_isPositiveDefinite :
+    IsPositiveDefiniteSub F ↔
+      IsPositiveDefinite fun a : WithNegStar G => F (WithNegStar.ofNegStar a) := by
+  constructor
+  · intro hF n c v
+    simpa [sub_eq_add_neg] using hF n c fun i => WithNegStar.ofNegStar (v i)
+  · intro hF n c v
+    simpa [sub_eq_add_neg] using hF n c fun i => WithNegStar.toNegStar (v i)
+
+namespace IsPositiveDefiniteSub
+
+/-- The generic involutive predicate attached to a subtraction-form positive-definite function.
+This is the workhorse for transporting the generic API. -/
+theorem isPositiveDefinite (hF : IsPositiveDefiniteSub F) :
+    IsPositiveDefinite fun a : WithNegStar G => F (WithNegStar.ofNegStar a) :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mp hF
+
+/-- Positive-definiteness holds for an arbitrary finite index type, not just `Fin n`. -/
+theorem sum_nonneg (hF : IsPositiveDefiniteSub F) {ι : Type*} [Fintype ι] (c : ι → ℂ) (v : ι → G) :
+    0 ≤ ∑ i, ∑ j, c i * conj (c j) * F (v i - v j) := by
+  simpa [sub_eq_add_neg] using
+    hF.isPositiveDefinite.sum_nonneg c fun i => WithNegStar.toNegStar (v i)
+
+/-- A subtraction-form positive-definite function gives the translation-invariant
+positive-definite kernel `K(a, b) = F (a - b)`. -/
+theorem posSemidef (hF : IsPositiveDefiniteSub F) :
+    Matrix.PosSemidef fun a b : G => F (a - b) := by
+  have h := hF.isPositiveDefinite.posSemidef.submatrix fun a : G => WithNegStar.toNegStar a
+  have heq : Matrix.submatrix
+      (Matrix.of fun a b : WithNegStar G =>
+        F (WithNegStar.ofNegStar (a + star b)))
+      (fun a : G => WithNegStar.toNegStar a) (fun a : G => WithNegStar.toNegStar a) =
+      fun a b : G => F (a - b) := by
+    ext a b
+    simp [sub_eq_add_neg]
+  exact heq ▸ h
+
+/-- A function whose translation-invariant kernel `K(a, b) = F (a - b)` is positive definite is
+positive definite. -/
+theorem of_posSemidef (hK : Matrix.PosSemidef fun a b : G => F (a - b)) :
+    IsPositiveDefiniteSub F := by
+  refine isPositiveDefiniteSub_iff_isPositiveDefinite.mpr
+    (IsPositiveDefinite.of_posSemidef ?_)
+  have h := hK.submatrix fun a : WithNegStar G => WithNegStar.ofNegStar a
+  have heq : Matrix.submatrix (Matrix.of fun a b : G => F (a - b))
+      (fun a : WithNegStar G => WithNegStar.ofNegStar a)
+      (fun a : WithNegStar G => WithNegStar.ofNegStar a) =
+      fun a b : WithNegStar G => F (WithNegStar.ofNegStar (a + star b)) := by
+    ext a b
+    simp [sub_eq_add_neg]
+  exact heq ▸ h
+
+end IsPositiveDefiniteSub
+
+/-- The PD-function ↔ PD-kernel equivalence in its classical translation-invariant form: `F` is
+positive definite if and only if the kernel `K(a, b) = F (a - b)` is positive definite. -/
+theorem isPositiveDefiniteSub_iff_posSemidef :
+    IsPositiveDefiniteSub F ↔ Matrix.PosSemidef fun a b : G => F (a - b) :=
+  ⟨IsPositiveDefiniteSub.posSemidef, IsPositiveDefiniteSub.of_posSemidef⟩
+
+/-- On a group whose own involution is negation, the generic involutive predicate and the
+subtraction-form predicate agree. -/
+theorem isPositiveDefinite_iff_isPositiveDefiniteSub [StarAddMonoid G]
+    (hstar : ∀ a : G, star a = -a) : IsPositiveDefinite F ↔ IsPositiveDefiniteSub F :=
+  (isPositiveDefinite_iff_posSemidef_sub hstar).trans isPositiveDefiniteSub_iff_posSemidef.symm
+
+/-! ### Values at and around the origin -/
+
+namespace IsPositiveDefiniteSub
+
+/-- The value of a positive-definite function at `0` is real and nonnegative. -/
+theorem map_zero_nonneg (hF : IsPositiveDefiniteSub F) : 0 ≤ F 0 := by
+  simpa using hF.isPositiveDefinite.map_zero_nonneg
+
+/-- The value of a positive-definite function at `0` has zero imaginary part. -/
+@[simp]
+theorem map_zero_im (hF : IsPositiveDefiniteSub F) : (F 0).im = 0 :=
+  ((Complex.nonneg_iff.mp hF.map_zero_nonneg).2).symm
+
+/-- The real part of the value of a positive-definite function at `0` is nonnegative. -/
+theorem map_zero_re_nonneg (hF : IsPositiveDefiniteSub F) : 0 ≤ (F 0).re :=
+  (Complex.nonneg_iff.mp hF.map_zero_nonneg).1
+
+/-- The value at the origin of a positive-definite function is the real number `(F 0).re`, viewed
+as a complex number. -/
+theorem map_zero_eq_ofReal_re (hF : IsPositiveDefiniteSub F) : F 0 = ((F 0).re : ℂ) := by
+  simpa using hF.isPositiveDefinite.map_zero_eq_ofReal_re
+
+/-- If a positive-definite function is nonzero at the origin, then the real part of that value is
+strictly positive. -/
+theorem map_zero_re_pos_of_ne_zero (hF : IsPositiveDefiniteSub F) (h0 : F 0 ≠ 0) :
+    0 < (F 0).re := by
+  refine hF.isPositiveDefinite.map_zero_re_pos_of_ne_zero ?_
+  simpa using h0
+
+/-- A positive-definite function is conjugate symmetric: `conj (F (b - a)) = F (a - b)`. -/
+theorem conj_symm (hF : IsPositiveDefiniteSub F) (a b : G) : conj (F (b - a)) = F (a - b) := by
+  simpa [sub_eq_add_neg] using
+    hF.isPositiveDefinite.conj_symm (WithNegStar.toNegStar a) (WithNegStar.toNegStar b)
+
+/-- A positive-definite function satisfies `F (-a) = conj (F a)`. -/
+theorem map_neg (hF : IsPositiveDefiniteSub F) (a : G) : F (-a) = conj (F a) := by
+  simpa using (hF.conj_symm 0 a).symm
+
+/-- The Cauchy–Schwarz inequality for a positive-definite function: the squared norm of any value
+is bounded by the square of the value at the origin. -/
+theorem normSq_le (hF : IsPositiveDefiniteSub F) (a b : G) :
+    Complex.normSq (F (a - b)) ≤ (F 0).re * (F 0).re := by
+  simpa [sub_eq_add_neg] using
+    hF.isPositiveDefinite.normSq_le (WithNegStar.toNegStar a) (WithNegStar.toNegStar b)
+
+/-- A positive-definite function is bounded by its value at the origin. -/
+theorem norm_apply_le_map_zero_re (hF : IsPositiveDefiniteSub F) (a : G) : ‖F a‖ ≤ (F 0).re := by
+  simpa using hF.isPositiveDefinite.norm_apply_le_map_zero_re_of_star_eq_neg
+    (WithNegStar.toNegStar a) rfl
+
+-- Not a `simp` lemma: the conclusion `F a = 0` has a variable head symbol, which Lean rejects.
+/-- **A positive-definite function with `(F 0).re = 0` vanishes identically.** -/
+theorem apply_eq_zero_of_map_zero_re_eq_zero (hF : IsPositiveDefiniteSub F) (h0 : (F 0).re = 0)
+    (a : G) : F a = 0 := by
+  simpa using hF.isPositiveDefinite.apply_eq_zero_of_map_zero_re_eq_zero (by simpa using h0)
+    (WithNegStar.toNegStar a)
+
+/-! ### Closure properties -/
+
+/-- Positive-definite functions are closed under addition. -/
+theorem add (hF : IsPositiveDefiniteSub F) (hH : IsPositiveDefiniteSub H) :
+    IsPositiveDefiniteSub fun x => F x + H x :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr
+    (hF.isPositiveDefinite.add hH.isPositiveDefinite)
+
+/-- Positive-definite functions are closed under multiplication by a nonnegative complex
+scalar. -/
+theorem const_mul {k : ℂ} (hk : 0 ≤ k) (hF : IsPositiveDefiniteSub F) :
+    IsPositiveDefiniteSub fun x => k * F x :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr (hF.isPositiveDefinite.const_mul hk)
+
+/-- Positive-definite functions are closed under multiplication by a nonnegative real scalar. -/
+theorem real_smul {r : ℝ} (hr : 0 ≤ r) (hF : IsPositiveDefiniteSub F) :
+    IsPositiveDefiniteSub fun x => r • F x :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr (hF.isPositiveDefinite.real_smul hr)
+
+/-- Positive-definite functions are closed under pointwise multiplication (Schur product). -/
+theorem mul (hF : IsPositiveDefiniteSub F) (hH : IsPositiveDefiniteSub H) :
+    IsPositiveDefiniteSub fun x => F x * H x :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr
+    (hF.isPositiveDefinite.mul hH.isPositiveDefinite)
+
+/-- Positive-definite functions are closed under finite sums. -/
+theorem sum {ι : Type*} {s : Finset ι} {F : ι → G → ℂ}
+    (hF : ∀ i ∈ s, IsPositiveDefiniteSub (F i)) :
+    IsPositiveDefiniteSub fun x => ∑ i ∈ s, F i x :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr
+    (IsPositiveDefinite.sum fun i hi => (hF i hi).isPositiveDefinite)
+
+/-- Positive-definite functions are closed under finite products (Schur products). -/
+theorem prod {ι : Type*} {s : Finset ι} {F : ι → G → ℂ}
+    (hF : ∀ i ∈ s, IsPositiveDefiniteSub (F i)) :
+    IsPositiveDefiniteSub fun x => ∏ i ∈ s, F i x :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr
+    (IsPositiveDefinite.prod fun i hi => (hF i hi).isPositiveDefinite)
+
+/-- Positive definiteness is preserved under pointwise limits along a nontrivial filter. -/
+theorem of_tendsto {ι : Type*} {l : Filter ι} [NeBot l] {F : ι → G → ℂ} {H : G → ℂ}
+    (hF : ∀ᶠ i in l, IsPositiveDefiniteSub (F i))
+    (hlim : ∀ x : G, Tendsto (fun i => F i x) l (𝓝 (H x))) :
+    IsPositiveDefiniteSub H :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr
+    (IsPositiveDefinite.of_tendsto (hF.mono fun _ hi => hi.isPositiveDefinite)
+      fun a => hlim (WithNegStar.ofNegStar a))
+
+/-! ### Normalization -/
+
+/-- Multiplying a positive-definite function by the reciprocal of its real value at the origin
+preserves positive definiteness. -/
+theorem normalize (hF : IsPositiveDefiniteSub F) :
+    IsPositiveDefiniteSub fun x => (((F 0).re)⁻¹ : ℂ) * F x :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr (by
+    simpa using hF.isPositiveDefinite.normalize)
+
+/-- The normalized function has value `1` at the origin. -/
+theorem normalize_apply_zero (hF : IsPositiveDefiniteSub F) (h0 : F 0 ≠ 0) :
+    (((F 0).re)⁻¹ : ℂ) * F 0 = 1 := by
+  have hpos := hF.map_zero_re_pos_of_ne_zero h0
+  rw [hF.map_zero_eq_ofReal_re]
+  norm_cast
+  exact inv_mul_cancel₀ hpos.ne'
+
+/-- A normalized positive-definite function is bounded by `1`. -/
+theorem norm_normalize_apply_le_one (hF : IsPositiveDefiniteSub F) (a : G) :
+    ‖(((F 0).re)⁻¹ : ℂ) * F a‖ ≤ 1 := by
+  simpa using hF.isPositiveDefinite.norm_normalize_apply_le_one_of_star_eq_neg
+    (WithNegStar.toNegStar a) rfl
+
+end IsPositiveDefiniteSub
+
+/-! ### Continuity -/
+
+namespace IsPositiveDefiniteSub
+
+variable {G : Type*} [SeminormedAddCommGroup G] {F : G → ℂ}
+
+/-- A positive-definite function on a seminormed additive commutative group is uniformly
+continuous as soon as it is continuous at the origin. -/
+theorem uniformContinuous_of_continuousAt_zero (hF : IsPositiveDefiniteSub F)
+    (hcont : ContinuousAt F 0) : UniformContinuous F :=
+  hF.isPositiveDefinite.uniformContinuous_of_continuousAt_zero_of_forall_star_eq_neg
+    (fun _ => rfl) hcont
+
+/-- A positive-definite function on a seminormed additive commutative group is continuous as soon
+as it is continuous at the origin. -/
+theorem continuous_of_continuousAt_zero (hF : IsPositiveDefiniteSub F)
+    (hcont : ContinuousAt F 0) : Continuous F :=
+  (hF.uniformContinuous_of_continuousAt_zero hcont).continuous
+
+end IsPositiveDefiniteSub
+
+/-- A nonnegative real constant is a positive-definite function. -/
+theorem isPositiveDefiniteSub_const {k : ℂ} (hk : 0 ≤ k) :
+    IsPositiveDefiniteSub (fun _ : G => k) :=
+  isPositiveDefiniteSub_iff_isPositiveDefinite.mpr (isPositiveDefinite_const hk)
+
+/-- The zero function is positive definite. -/
+theorem isPositiveDefiniteSub_zero : IsPositiveDefiniteSub (fun _ : G => (0 : ℂ)) :=
+  isPositiveDefiniteSub_const le_rfl
+
+end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/AddGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/AddGroup.lean
@@ -50,6 +50,7 @@ the predicate in which Bochner's theorem is stated, in
   origin.
 * `TauCeti.IsPositiveDefiniteSub.add`, `const_mul`, `real_smul`, `mul`, `sum`, `prod`,
   `TauCeti.isPositiveDefiniteSub_const`: closure properties.
+* `TauCeti.IsPositiveDefiniteSub.comp_addMonoidHom`, `comp_smul`, `comp_neg`: pullbacks.
 * `TauCeti.IsPositiveDefiniteSub.of_tendsto`: pointwise limits.
 * `TauCeti.IsPositiveDefiniteSub.normalize`: normalization to value `1` at the origin.
 * `TauCeti.IsPositiveDefiniteSub.uniformContinuous_of_continuousAt_zero`: continuity at `0`
@@ -235,6 +236,7 @@ theorem map_zero_re_pos_of_ne_zero (hF : IsPositiveDefiniteSub F) (h0 : F 0 ≠ 
   simpa using h0
 
 /-- A positive-definite function is conjugate symmetric: `conj (F (b - a)) = F (a - b)`. -/
+@[simp]
 theorem conj_symm (hF : IsPositiveDefiniteSub F) (a b : G) : conj (F (b - a)) = F (a - b) := by
   simpa [sub_eq_add_neg] using
     hF.isPositiveDefinite.conj_symm (WithNegStar.toNegStar a) (WithNegStar.toNegStar b)
@@ -301,6 +303,29 @@ theorem prod {ι : Type*} {s : Finset ι} {F : ι → G → ℂ}
   isPositiveDefiniteSub_iff_isPositiveDefinite.mpr
     (IsPositiveDefinite.prod fun i hi => (hF i hi).isPositiveDefinite)
 
+/-! ### Pullbacks -/
+
+/-- Positive definiteness is preserved by precomposition with an additive homomorphism; no
+compatibility with an involution is needed, since an additive homomorphism automatically
+commutes with negation. -/
+theorem comp_addMonoidHom {N : Type*} [AddCommGroup N] (hF : IsPositiveDefiniteSub F)
+    (φ : N →+ G) : IsPositiveDefiniteSub fun x => F (φ x) := by
+  intro n c v
+  simpa [← map_sub] using hF n c fun i => φ (v i)
+
+/-- Positive definiteness is preserved by rescaling the argument. -/
+theorem comp_smul {R : Type*} [DistribSMul R G] (hF : IsPositiveDefiniteSub F) (r : R) :
+    IsPositiveDefiniteSub fun x => F (r • x) := by
+  intro n c v
+  simpa [← smul_sub] using hF n c fun i => r • v i
+
+/-- Positive definiteness is preserved by negating the argument. -/
+theorem comp_neg (hF : IsPositiveDefiniteSub F) : IsPositiveDefiniteSub fun x => F (-x) := by
+  intro n c v
+  simpa [neg_sub, sub_eq_neg_add, add_comm] using hF n c fun i => -v i
+
+/-! ### Limits -/
+
 /-- Positive definiteness is preserved under pointwise limits along a nontrivial filter. -/
 theorem of_tendsto {ι : Type*} {l : Filter ι} [NeBot l] {F : ι → G → ℂ} {H : G → ℂ}
     (hF : ∀ᶠ i in l, IsPositiveDefiniteSub (F i))
@@ -320,6 +345,7 @@ theorem normalize (hF : IsPositiveDefiniteSub F) :
     simpa using hF.isPositiveDefinite.normalize)
 
 /-- The normalized function has value `1` at the origin. -/
+@[simp]
 theorem normalize_apply_zero (hF : IsPositiveDefiniteSub F) (h0 : F 0 ≠ 0) :
     (((F 0).re)⁻¹ : ℂ) * F 0 = 1 := by
   have hpos := hF.map_zero_re_pos_of_ne_zero h0

--- a/TauCeti/Analysis/PositiveDefinite/AddGroup.lean
+++ b/TauCeti/Analysis/PositiveDefinite/AddGroup.lean
@@ -41,6 +41,7 @@ the predicate in which Bochner's theorem is stated, in
 
 * `TauCeti.WithNegStar`: the type synonym carrying the negation involution.
 * `TauCeti.IsPositiveDefiniteSub`: the subtraction-form positive-definiteness predicate.
+* `TauCeti.isPositiveDefiniteSub_iff_forall_sum_nonneg`: the defining finite-family condition.
 * `TauCeti.isPositiveDefiniteSub_iff_isPositiveDefinite`: the transfer to the generic predicate.
 * `TauCeti.isPositiveDefiniteSub_iff_posSemidef`: the PD-function ↔ PD-kernel equivalence.
 * `TauCeti.isPositiveDefinite_iff_isPositiveDefiniteSub`: agreement with the generic predicate on
@@ -136,9 +137,16 @@ for which `0 ≤ z` means `z` is real and nonnegative).
 This is the classical translation-invariant condition, the one Bochner's theorem is stated in. It
 is `TauCeti.IsPositiveDefinite` for the negation involution; see
 `TauCeti.isPositiveDefiniteSub_iff_isPositiveDefinite`. -/
-@[expose] def IsPositiveDefiniteSub (F : G → ℂ) : Prop :=
+def IsPositiveDefiniteSub (F : G → ℂ) : Prop :=
   ∀ (n : ℕ) (c : Fin n → ℂ) (v : Fin n → G),
     0 ≤ ∑ i, ∑ j, c i * conj (c j) * F (v i - v j)
+
+/-- The defining finite-family characterization, for building a positive-definite function
+directly from the quadratic-form condition. -/
+theorem isPositiveDefiniteSub_iff_forall_sum_nonneg :
+    IsPositiveDefiniteSub F ↔ ∀ (n : ℕ) (c : Fin n → ℂ) (v : Fin n → G),
+      0 ≤ ∑ i, ∑ j, c i * conj (c j) * F (v i - v j) :=
+  Iff.rfl
 
 /-- Subtraction-form positive definiteness is the generic involutive predicate for the negation
 involution, read on the type synonym `TauCeti.WithNegStar`. -/

--- a/TauCeti/Analysis/PositiveDefinite/FourierAtom.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FourierAtom.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.LinearAlgebra.Matrix.PosSemidef
 public import Mathlib.Analysis.Complex.Circle
 public import Mathlib.Analysis.InnerProductSpace.Basic
+public import Mathlib.MeasureTheory.Function.L1Space.Integrable
 
 /-!
 # Fourier atoms
@@ -22,6 +23,7 @@ It uses Mathlib's `2π` Fourier convention.
   Fourier atom is positive definite.
 * `TauCeti.continuous_fourierAtom`: Fourier atoms are continuous in the spatial variable.
 * `TauCeti.norm_fourierAtom`: Fourier atoms have unit norm.
+* `TauCeti.integrable_fourierAtom`: Fourier atoms are integrable against a finite measure.
 * `TauCeti.fourierAtom_zero_left` and `TauCeti.fourierAtom_zero_right`: a Fourier atom is `1`
   when either argument is `0`.
 -/
@@ -100,5 +102,14 @@ theorem continuous_fourierAtom (q : V) : Continuous (fourierAtom q) := by
       Continuous fun v : V => ((Real.fourierChar (-(inner ℝ v q)) : Circle) : ℂ)) using 1
   ext v
   exact (fourierAtom_eq_fourierChar q v).symm
+
+/-- A Fourier atom, having unit norm and being continuous, is integrable against a finite
+measure. -/
+theorem integrable_fourierAtom [MeasurableSpace V] [OpensMeasurableSpace V]
+    (μ : MeasureTheory.Measure V) [MeasureTheory.IsFiniteMeasure μ] (q : V) :
+    MeasureTheory.Integrable (fourierAtom q) μ :=
+  (MeasureTheory.integrable_const (1 : ℝ)).mono'
+    (continuous_fourierAtom q).aestronglyMeasurable
+    (.of_forall fun v => (norm_fourierAtom q v).le)
 
 end TauCeti

--- a/TauCeti/Analysis/PositiveDefinite/FourierAtom.lean
+++ b/TauCeti/Analysis/PositiveDefinite/FourierAtom.lean
@@ -21,6 +21,7 @@ It uses Mathlib's `2π` Fourier convention.
 * `TauCeti.posSemidef_fourierAtom`: the subtraction kernel attached to a
   Fourier atom is positive definite.
 * `TauCeti.continuous_fourierAtom`: Fourier atoms are continuous in the spatial variable.
+* `TauCeti.norm_fourierAtom`: Fourier atoms have unit norm.
 * `TauCeti.fourierAtom_zero_left` and `TauCeti.fourierAtom_zero_right`: a Fourier atom is `1`
   when either argument is `0`.
 -/
@@ -83,6 +84,14 @@ theorem posSemidef_fourierAtom (q : V) :
   simp_rw [fourierAtom_sub]
   simpa only [RCLike.star_def] using posSemidef_rankOne
     (fun v : V => Complex.exp (2 * ((Real.pi : ℝ) : ℂ) * Complex.I * ((inner ℝ v q : ℝ) : ℂ)))
+
+/-- Fourier atoms take values on the unit circle.
+
+Not a `@[simp]` lemma: `simp` rewrites the atom through `fourierAtom_apply` first, and the
+simpNF linter reports the tagged form as unusable for the same reason as
+`fourierAtom_zero_left`. -/
+theorem norm_fourierAtom (q v : V) : ‖fourierAtom q v‖ = 1 := by
+  rw [fourierAtom_eq_fourierChar, Circle.norm_coe]
 
 /-- Fourier atoms are continuous in the spatial variable. -/
 theorem continuous_fourierAtom (q : V) : Continuous (fourierAtom q) := by


### PR DESCRIPTION
This PR gives Bochner's theorem a positive-definite-function predicate that its own vector spaces can satisfy, and names the representing measure.

`TauCeti.IsPositiveDefinite` tests the kernel `F (a + star b)`, and Mathlib's `star` on a real vector space is the identity, so on `ℝ` or a Euclidean space it does not express the classical condition `∑ᵢⱼ cᵢ conj(cⱼ) F(aᵢ - aⱼ) ≥ 0`, and the previous `bochner_of_forall_star_eq_neg` carried a hypothesis `∀ x, star x = -x` that no canonical instance discharges. `TauCeti/Analysis/PositiveDefinite/AddGroup.lean` adds `IsPositiveDefiniteSub`, the subtraction-form predicate on an additive commutative group, together with the type synonym `WithNegStar G` that carries the negation involution as a genuine `StarAddMonoid` instance and transports the generic theory: the kernel correspondence, the values at the origin, conjugate symmetry, the Cauchy–Schwarz bound, closure under sums, products, nonnegative scalars and pointwise limits, pullbacks along additive homomorphisms and rescalings, normalization, and continuity at `0` implying uniform continuity.

Bochner's theorem is then stated in that predicate, with the kernel statement kept as `bochner_posSemidef`; `bochner_probabilityMeasure` exposes the normalized form, previously available only as a private lemma; and `bochnerMeasure F` names the representing measure, with lemmas for its transform, finiteness, uniqueness, total mass, nonnegative-real scaling, additivity, and probability normalization. Fourier atoms gain their unit norm and their integrability against a finite measure.

Closes #3567

Roadmap: OneParameterSemigroups

🤖 Prepared with Claude Code
