### PR TITLE
feat: add separable action fields

### DIFF
--- a/TauCeti/RepresentationTheory/GaloisLattice/SeparableActionField.lean
+++ b/TauCeti/RepresentationTheory/GaloisLattice/SeparableActionField.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.PurelyInseparable.Basic
+public import TauCeti.RepresentationTheory.GaloisLattice.ActionField
+
+/-!
+# Separable action fields of Galois lattices
+
+The continuous absolute-Galois action on an integral Galois lattice factors through the
+automorphism group of the finite normal field `GaloisLatticeCat.actionField`. Over an imperfect
+base that field need not itself be separable. This file replaces it by its maximal separable
+subextension.
+
+The original action field is purely inseparable over this subextension. Consequently restriction
+induces an isomorphism between their automorphism groups: an automorphism of the action field is
+uniquely determined on the separable subextension, and every automorphism of the latter extends by
+normality. Transporting the lattice action across this isomorphism gives a realization over a
+finite Galois extension of the base field.
+
+## Main declarations
+
+* `TauCeti.GaloisLatticeCat.separableActionField`: the maximal separable subextension of the
+  finite normal action field.
+* `TauCeti.GaloisLatticeCat.actionFieldGalEquivSeparableActionField`: restriction identifies the
+  two automorphism groups.
+* `TauCeti.GaloisLatticeCat.separableActionFieldRepresentation`: the lattice action by the
+  automorphism group of the finite Galois action field.
+* `TauCeti.GaloisLatticeCat.separableActionFieldRepresentation_comp_restriction`: pulling this
+  action back to the absolute Galois group recovers the original representation.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Corollary 12.24.
+
+This supplies the finite Galois splitting field needed before constructing the semilinear descent
+datum on the split coordinate Hopf algebra in Layer 4, "Tori: split and non-split", of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti.GaloisLatticeCat
+
+universe u
+
+variable {k : Type u} [Field k]
+
+/-- The module structure stored in the bundled representation. -/
+noncomputable local instance separableActionFieldStoredModule (M : GaloisLatticeCat k) :
+    Module ℤ M.obj :=
+  M.obj.hV2
+
+/-- The maximal separable subextension of the finite normal action field of a Galois lattice. -/
+noncomputable def separableActionField (M : GaloisLatticeCat k) :
+    IntermediateField k (actionField M) :=
+  separableClosure k (actionField M)
+
+/-- The separable action field is finite-dimensional over the base field. -/
+noncomputable instance instFiniteDimensionalSeparableActionField (M : GaloisLatticeCat k) :
+    FiniteDimensional k (separableActionField M) := by
+  unfold separableActionField
+  infer_instance
+
+/-- The separable action field is a finite Galois extension of the base field. -/
+noncomputable instance instIsGaloisSeparableActionField (M : GaloisLatticeCat k) :
+    IsGalois k (separableActionField M) := by
+  unfold separableActionField
+  infer_instance
+
+/-- Restriction from the original action field to its maximal separable subextension. -/
+noncomputable def actionFieldGalToSeparableActionField (M : GaloisLatticeCat k) :
+    Gal(actionField M/k) →* Gal(separableActionField M/k) :=
+  AlgEquiv.restrictNormalHom (separableActionField M)
+
+/-- Every automorphism of the separable action field extends to the original normal action
+field. -/
+theorem actionFieldGalToSeparableActionField_surjective (M : GaloisLatticeCat k) :
+    Function.Surjective (actionFieldGalToSeparableActionField M) := by
+  unfold actionFieldGalToSeparableActionField
+  exact AlgEquiv.restrictNormalHom_surjective (actionField M)
+
+/-- Restriction to the separable action field is injective. The remaining extension is purely
+inseparable, so an automorphism fixing the separable action field is the identity. -/
+theorem actionFieldGalToSeparableActionField_injective (M : GaloisLatticeCat k) :
+    Function.Injective (actionFieldGalToSeparableActionField M) := by
+  rw [← MonoidHom.ker_eq_bot_iff]
+  apply le_antisymm
+  · intro sigma hsigma
+    rw [MonoidHom.mem_ker] at hsigma
+    let _ : IsPurelyInseparable (separableActionField M) (actionField M) := by
+      unfold separableActionField
+      infer_instance
+    let sigma' : actionField M →ₐ[separableActionField M] actionField M :=
+      { sigma.toAlgHom with
+        commutes' := fun x ↦ by
+          have hx := congrArg Subtype.val (DFunLike.congr_fun hsigma x)
+          simp only [actionFieldGalToSeparableActionField,
+            AlgEquiv.restrictNormalHom_apply, AlgEquiv.one_apply] at hx
+          -- Cross the bundled homomorphism and intermediate-field coercions in the structure field.
+          change sigma (x : actionField M) = (x : actionField M)
+          exact hx }
+    have hsigma' : sigma' = AlgHom.id (separableActionField M) (actionField M) :=
+      Subsingleton.elim _ _
+    rw [Subgroup.mem_bot]
+    apply AlgEquiv.ext
+    intro x
+    exact DFunLike.congr_fun hsigma' x
+  · exact bot_le
+
+/-- Restriction identifies the automorphism group of the finite normal action field with that of
+its finite Galois separable subextension. -/
+noncomputable def actionFieldGalEquivSeparableActionField (M : GaloisLatticeCat k) :
+    Gal(actionField M/k) ≃* Gal(separableActionField M/k) :=
+  MulEquiv.ofBijective (actionFieldGalToSeparableActionField M)
+    ⟨actionFieldGalToSeparableActionField_injective M,
+      actionFieldGalToSeparableActionField_surjective M⟩
+
+/-- The isomorphism of automorphism groups is restriction to the separable action field. -/
+@[simp]
+theorem actionFieldGalEquivSeparableActionField_apply (M : GaloisLatticeCat k)
+    (sigma : Gal(actionField M/k)) :
+    actionFieldGalEquivSeparableActionField M sigma =
+      actionFieldGalToSeparableActionField M sigma :=
+  by
+    rw [actionFieldGalEquivSeparableActionField]
+    rfl
+
+/-- The automorphism group of the separable action field maps onto the faithful finite quotient
+acting on the lattice. -/
+noncomputable def separableActionFieldToActionQuotient (M : GaloisLatticeCat k) :
+    Gal(separableActionField M/k) →* actionQuotient M :=
+  (actionFieldToActionQuotient M).comp
+    (actionFieldGalEquivSeparableActionField M).symm.toMonoidHom
+
+/-- The map from the separable action field's automorphism group to the action quotient is
+surjective. -/
+theorem separableActionFieldToActionQuotient_surjective (M : GaloisLatticeCat k) :
+    Function.Surjective (separableActionFieldToActionQuotient M) :=
+  (actionFieldToActionQuotient_surjective M).comp
+    (actionFieldGalEquivSeparableActionField M).symm.surjective
+
+/-- Restriction of an absolute Galois automorphism to the separable action field, through the
+original action field. -/
+noncomputable def separableActionFieldRestriction (M : GaloisLatticeCat k) :
+    Field.absoluteGaloisGroup k →* Gal(separableActionField M/k) :=
+  (actionFieldGalEquivSeparableActionField M).toMonoidHom.comp (actionFieldRestriction M)
+
+/-- Restriction from the absolute Galois group onto the separable action field is surjective. -/
+theorem separableActionFieldRestriction_surjective (M : GaloisLatticeCat k) :
+    Function.Surjective (separableActionFieldRestriction M) :=
+  (actionFieldGalEquivSeparableActionField M).surjective.comp
+    (actionFieldRestriction_surjective M)
+
+/-- Restriction to the separable action field followed by the quotient map is the original class
+in the faithful finite action quotient. -/
+@[simp]
+theorem separableActionFieldToActionQuotient_restrict (M : GaloisLatticeCat k)
+    (sigma : Field.absoluteGaloisGroup k) :
+    separableActionFieldToActionQuotient M (separableActionFieldRestriction M sigma) =
+      (sigma : actionQuotient M) := by
+  rw [separableActionFieldToActionQuotient, separableActionFieldRestriction]
+  simp only [MonoidHom.coe_comp, MulEquiv.coe_toMonoidHom, Function.comp_apply,
+    MulEquiv.symm_apply_apply, actionFieldToActionQuotient_restrict]
+
+/-- The representation of the finite Galois action field obtained from the original action-field
+representation through the restriction isomorphism. -/
+noncomputable def separableActionFieldRepresentation (M : GaloisLatticeCat k) :
+    Representation ℤ Gal(separableActionField M/k) M.obj :=
+  (actionQuotientRepresentation M).comp (separableActionFieldToActionQuotient M)
+
+/-- Restricting an absolute Galois automorphism to the separable action field and then acting on
+the lattice recovers the original absolute-Galois action. -/
+@[simp]
+theorem separableActionFieldRepresentation_restrict_apply (M : GaloisLatticeCat k)
+    (sigma : Field.absoluteGaloisGroup k) (x : M.obj) :
+    separableActionFieldRepresentation M (separableActionFieldRestriction M sigma) x =
+      M.obj.ρ sigma x := by
+  rw [separableActionFieldRepresentation]
+  -- Expose composition of the bundled representation before applying the pointwise quotient API.
+  change actionQuotientRepresentation M
+      (separableActionFieldToActionQuotient M (separableActionFieldRestriction M sigma)) x = _
+  rw [separableActionFieldToActionQuotient_restrict, actionQuotientRepresentation_mk_apply]
+
+/-- The original absolute-Galois representation is the pullback of the representation over the
+finite Galois separable action field. -/
+theorem separableActionFieldRepresentation_comp_restriction (M : GaloisLatticeCat k) :
+    (separableActionFieldRepresentation M).comp (separableActionFieldRestriction M) =
+      M.obj.ρ := by
+  ext sigma x
+  exact separableActionFieldRepresentation_restrict_apply M sigma x
+
+/-- An automorphism of the separable action field acts trivially exactly when it maps to the
+identity in the faithful finite action quotient. -/
+theorem separableActionFieldRepresentation_ker (M : GaloisLatticeCat k) :
+    (separableActionFieldRepresentation M).ker =
+      (separableActionFieldToActionQuotient M).ker := by
+  rw [separableActionFieldRepresentation]
+  exact MonoidHom.ker_comp_of_injective (separableActionFieldToActionQuotient M)
+    (actionQuotientRepresentation M) (actionQuotientRepresentation_injective M)
+
+end TauCeti.GaloisLatticeCat


### PR DESCRIPTION
This PR replaces the finite normal action field of an integral Galois lattice by its maximal separable subextension and transports the lattice action to that finite Galois field. Prove that restriction induces an isomorphism of automorphism groups: surjectivity follows from normality, while injectivity uses that the original action field is purely inseparable over its separable closure, so it has a unique endomorphism over that subfield. Expose the resulting surjection onto the faithful finite action quotient and prove that pulling the finite-field representation back along absolute-Galois restriction recovers the original action.

The exact target is `ReductiveGroups/README.md`, Layer 4 milestone “Tori: split and non-split,” specifically the inverse Galois-descent construction behind the anti-equivalence between tori and integral Galois lattices. The character-lattice action and its finite normal action field are on `main`, but semilinear descent requires a finite Galois splitting field; `GaloisLatticeCat.separableActionField` supplies that field together with its action and comparison API. After this PR, the milestone still needs the semilinear descent datum on the split coordinate Hopf algebra, its invariant descended Hopf algebra, and the resulting anti-equivalence between tori and integral Galois lattices.

Add `TauCeti/RepresentationTheory/GaloisLattice/SeparableActionField.lean` (206 lines). The construction follows J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Corollary 12.24, as credited in the module documentation. It reuses Mathlib's maximal separable subextension, its finite-Galois instance inside a normal extension, uniqueness of homomorphisms out of a purely inseparable extension, and restriction-of-automorphisms API; no Mathlib infrastructure or external formalization is vendored.

The targeted module build, changed-declaration axiom audit, and changed-module lint environment pass.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"separable-action-field"}-->

🤖 Prepared with Codex
