### PR TITLE
refactor(Process): define empiricalMeasure as a case of empiricalPopulation

### DIFF
--- a/TauCeti/Probability/Process/EmpiricalMeasure.lean
+++ b/TauCeti/Probability/Process/EmpiricalMeasure.lean
@@ -12,10 +12,14 @@ public import Mathlib.Probability.UniformOn
 /-!
 # Empirical measures of sequences
 
-This file defines the empirical probability measure of the first `n + 1` terms of a sequence and
-gives its basic evaluation, integration, and measurability API.  The successor indexing makes the
-object a probability measure without a nonemptiness side condition and matches the form used in
-limit theorems.
+This file defines the empirical probability measure of a nonempty finite population
+(`empiricalPopulation`) and, as its `κ := Fin (n + 1)` case, of the first `n + 1` terms of a
+sequence (`empiricalMeasure`), together with their evaluation, integration, and measurability API.
+The successor indexing is what supplies the `Nonempty` instance for the sequence form, so it needs
+no side condition, and it matches the shape used in limit theorems.
+
+There is one construction, not two: the sequence form is *defined* as the specialization, so the
+two can never drift apart.
 
 It also provides `empiricalPopulation` for a population indexed by an arbitrary nonempty finite
 type. This is the finite-population form used by quantitative sampling arguments.
@@ -37,79 +41,6 @@ namespace Probability
 
 variable {α Ω E : Type*} [MeasurableSpace α] [MeasurableSpace Ω]
 
-/-- The empirical probability measure of the first `n + 1` terms of a sequence. -/
-def empiricalMeasure (x : ℕ → α) (n : ℕ) : ProbabilityMeasure α :=
-  ⟨∑ i ∈ Finset.range (n + 1), (((n + 1 : ℕ) : ℝ≥0∞)⁻¹ • Measure.dirac (x i)), by
-    refine ⟨?_⟩
-    have hn0 : ((n + 1 : ℕ) : ℝ≥0∞) ≠ 0 := by simp
-    have hntop : ((n + 1 : ℕ) : ℝ≥0∞) ≠ ∞ := by simp
-    simpa using ENNReal.mul_inv_cancel hn0 hntop⟩
-
-/-- The measure underlying an empirical measure is the uniform finite sum of Dirac measures. -/
-@[simp]
-theorem empiricalMeasure_toMeasure (x : ℕ → α) (n : ℕ) : (empiricalMeasure x n : Measure α) =
-      ∑ i ∈ Finset.range (n + 1), (((n + 1 : ℕ) : ℝ≥0∞)⁻¹ • Measure.dirac (x i)) :=
-  (rfl)
-
-/-- Evaluation of an empirical measure on a measurable set is its empirical frequency. -/
-theorem empiricalMeasure_apply {x : ℕ → α} {n : ℕ} {s : Set α} (hs : MeasurableSet s) :
-    (empiricalMeasure x n : Measure α) s = ((n + 1 : ℕ) : ℝ≥0∞)⁻¹ *
-        ∑ i ∈ Finset.range (n + 1), s.indicator (1 : α → ℝ≥0∞) (x i) := by
-  rw [empiricalMeasure_toMeasure]
-  simp only [Measure.coe_finsetSum, Measure.coe_smul, Finset.sum_apply, Pi.smul_apply,
-    smul_eq_mul, Measure.dirac_apply' _ hs, Finset.mul_sum]
-
-/-- The real-valued form of `empiricalMeasure_apply`. -/
-theorem empiricalMeasure_apply_toReal {x : ℕ → α} {n : ℕ} {s : Set α} (hs : MeasurableSet s) :
-    ((empiricalMeasure x n : Measure α) s).toReal = ((n + 1 : ℕ) : ℝ)⁻¹ *
-        ∑ i ∈ Finset.range (n + 1), s.indicator (1 : α → ℝ) (x i) := by
-  rw [empiricalMeasure_apply hs, ENNReal.toReal_mul, ENNReal.toReal_inv]
-  · rw [ENNReal.toReal_natCast, ENNReal.toReal_sum]
-    · congr 1
-      apply Finset.sum_congr rfl
-      intro i hi
-      by_cases hxi : x i ∈ s <;> simp [hxi]
-    · intro i hi
-      by_cases hxi : x i ∈ s <;> simp [hxi]
-
-omit [MeasurableSpace Ω] in
-/-- Evaluation of a path's empirical measure, written as indicators on the sample space. -/
-theorem empiricalMeasure_process_apply_toReal {X : ℕ → Ω → α} {ω : Ω} {n : ℕ}
-    {s : Set α} (hs : MeasurableSet s) :
-    ((empiricalMeasure (fun i => X i ω) n : Measure α) s).toReal = ((n + 1 : ℕ) : ℝ)⁻¹ *
-        ∑ i ∈ Finset.range (n + 1), (X i ⁻¹' s).indicator (1 : Ω → ℝ) ω := by
-  rw [empiricalMeasure_apply_toReal hs]
-  refine congrArg (fun z : ℝ => ((n + 1 : ℕ) : ℝ)⁻¹ * z) ?_
-  apply Finset.sum_congr rfl
-  intro i hi
-  by_cases hxi : X i ω ∈ s <;> simp [hxi]
-
-/-- Integrating against an empirical measure is averaging over the sampled values. -/
-theorem integral_empiricalMeasure [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
-    {x : ℕ → α} {n : ℕ} {f : α → E} (hf : StronglyMeasurable f) :
-    ∫ y, f y ∂(empiricalMeasure x n : Measure α) =
-      ((n + 1 : ℕ) : ℝ)⁻¹ • ∑ i ∈ Finset.range (n + 1), f (x i) := by
-  rw [empiricalMeasure_toMeasure, integral_finsetSum_measure]
-  · simp_rw [integral_smul_measure, integral_dirac' f _ hf]
-    rw [← Finset.smul_sum]
-    congr 1
-    rw [ENNReal.toReal_inv]
-    norm_cast
-  · intro i hi
-    exact (integrable_dirac' hf (by simp)).smul_measure (by simp)
-
-/-- Empirical measures depend measurably on a sequence of measurable observations. -/
-theorem measurable_empiricalMeasure {X : ℕ → Ω → α}
-    (n : ℕ) (hX : ∀ i ∈ Finset.range (n + 1), Measurable (X i)) :
-    Measurable fun ω => empiricalMeasure (fun i => X i ω) n := by
-  have hmeasure : Measurable fun ω =>
-      (empiricalMeasure (fun i => X i ω) n : Measure α) := by
-    simp_rw [empiricalMeasure_toMeasure]
-    exact Finset.measurable_fun_sum _ fun i hi =>
-      Measure.measurable_of_measurable_coe _ fun s hs => by
-        simp only [Measure.smul_apply, smul_eq_mul, Measure.dirac_apply' _ hs]
-        exact measurable_const.mul (measurable_one.indicator (hX i hi hs))
-  exact hmeasure.subtype_mk
 
 section FinitePopulation
 
@@ -187,6 +118,82 @@ theorem measurable_empiricalPopulation :
   fun_prop
 
 end FinitePopulation
+
+/-- The empirical probability measure of the first `n + 1` terms of a sequence.
+
+This is the `κ := Fin (n + 1)` case of `empiricalPopulation`; the successor indexing is what
+supplies the `Nonempty` instance, so no side condition is needed. -/
+def empiricalMeasure (x : ℕ → α) (n : ℕ) : ProbabilityMeasure α :=
+  empiricalPopulation (fun i : Fin (n + 1) => x i)
+
+/-- The measure underlying an empirical measure is the uniform finite sum of Dirac measures. -/
+@[simp]
+theorem empiricalMeasure_toMeasure (x : ℕ → α) (n : ℕ) : (empiricalMeasure x n : Measure α) =
+      ∑ i ∈ Finset.range (n + 1), (((n + 1 : ℕ) : ℝ≥0∞)⁻¹ • Measure.dirac (x i)) := by
+  rw [empiricalMeasure, empiricalPopulation_toMeasure]
+  simp only [Fintype.card_fin]
+  exact Fin.sum_univ_eq_sum_range
+    (fun i => ((n + 1 : ℕ) : ℝ≥0∞)⁻¹ • Measure.dirac (x i)) (n + 1)
+
+/-- Evaluation of an empirical measure on a measurable set is its empirical frequency. -/
+theorem empiricalMeasure_apply {x : ℕ → α} {n : ℕ} {s : Set α} (hs : MeasurableSet s) :
+    (empiricalMeasure x n : Measure α) s = ((n + 1 : ℕ) : ℝ≥0∞)⁻¹ *
+        ∑ i ∈ Finset.range (n + 1), s.indicator (1 : α → ℝ≥0∞) (x i) := by
+  rw [empiricalMeasure_toMeasure]
+  simp only [Measure.coe_finsetSum, Measure.coe_smul, Finset.sum_apply, Pi.smul_apply,
+    smul_eq_mul, Measure.dirac_apply' _ hs, Finset.mul_sum]
+
+/-- The real-valued form of `empiricalMeasure_apply`. -/
+theorem empiricalMeasure_apply_toReal {x : ℕ → α} {n : ℕ} {s : Set α} (hs : MeasurableSet s) :
+    ((empiricalMeasure x n : Measure α) s).toReal = ((n + 1 : ℕ) : ℝ)⁻¹ *
+        ∑ i ∈ Finset.range (n + 1), s.indicator (1 : α → ℝ) (x i) := by
+  rw [empiricalMeasure_apply hs, ENNReal.toReal_mul, ENNReal.toReal_inv]
+  · rw [ENNReal.toReal_natCast, ENNReal.toReal_sum]
+    · congr 1
+      apply Finset.sum_congr rfl
+      intro i hi
+      by_cases hxi : x i ∈ s <;> simp [hxi]
+    · intro i hi
+      by_cases hxi : x i ∈ s <;> simp [hxi]
+
+omit [MeasurableSpace Ω] in
+/-- Evaluation of a path's empirical measure, written as indicators on the sample space. -/
+theorem empiricalMeasure_process_apply_toReal {X : ℕ → Ω → α} {ω : Ω} {n : ℕ}
+    {s : Set α} (hs : MeasurableSet s) :
+    ((empiricalMeasure (fun i => X i ω) n : Measure α) s).toReal = ((n + 1 : ℕ) : ℝ)⁻¹ *
+        ∑ i ∈ Finset.range (n + 1), (X i ⁻¹' s).indicator (1 : Ω → ℝ) ω := by
+  rw [empiricalMeasure_apply_toReal hs]
+  refine congrArg (fun z : ℝ => ((n + 1 : ℕ) : ℝ)⁻¹ * z) ?_
+  apply Finset.sum_congr rfl
+  intro i hi
+  by_cases hxi : X i ω ∈ s <;> simp [hxi]
+
+/-- Integrating against an empirical measure is averaging over the sampled values. -/
+theorem integral_empiricalMeasure [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    {x : ℕ → α} {n : ℕ} {f : α → E} (hf : StronglyMeasurable f) :
+    ∫ y, f y ∂(empiricalMeasure x n : Measure α) =
+      ((n + 1 : ℕ) : ℝ)⁻¹ • ∑ i ∈ Finset.range (n + 1), f (x i) := by
+  rw [empiricalMeasure_toMeasure, integral_finsetSum_measure]
+  · simp_rw [integral_smul_measure, integral_dirac' f _ hf]
+    rw [← Finset.smul_sum]
+    congr 1
+    rw [ENNReal.toReal_inv]
+    norm_cast
+  · intro i hi
+    exact (integrable_dirac' hf (by simp)).smul_measure (by simp)
+
+/-- Empirical measures depend measurably on a sequence of measurable observations. -/
+theorem measurable_empiricalMeasure {X : ℕ → Ω → α}
+    (n : ℕ) (hX : ∀ i ∈ Finset.range (n + 1), Measurable (X i)) :
+    Measurable fun ω => empiricalMeasure (fun i => X i ω) n := by
+  have hmeasure : Measurable fun ω =>
+      (empiricalMeasure (fun i => X i ω) n : Measure α) := by
+    simp_rw [empiricalMeasure_toMeasure]
+    exact Finset.measurable_fun_sum _ fun i hi =>
+      Measure.measurable_of_measurable_coe _ fun s hs => by
+        simp only [Measure.smul_apply, smul_eq_mul, Measure.dirac_apply' _ hs]
+        exact measurable_const.mul (measurable_one.indicator (hX i hi hs))
+  exact hmeasure.subtype_mk
 
 end Probability
 


### PR DESCRIPTION
#3538 added `empiricalPopulation` for a nonempty finite population but left the sequence-specific
`empiricalMeasure` as an independent implementation of the same construction, so `main` now carries
two. This collapses them to one.

```lean
def empiricalMeasure (x : ℕ → α) (n : ℕ) : ProbabilityMeasure α :=
  empiricalPopulation (fun i : Fin (n + 1) => x i)
```

The successor indexing is exactly what supplies the `Nonempty` instance, so the specialization
carries no side condition.

## What changed, and what did not

Every existing sequence declaration and statement is **preserved verbatim** — `empiricalMeasure`,
`empiricalMeasure_toMeasure`, `empiricalMeasure_apply`, `empiricalMeasure_apply_toReal`,
`empiricalMeasure_process_apply_toReal`, `integral_empiricalMeasure`,
`measurable_empiricalMeasure`.

Only one proof changed: `empiricalMeasure_toMeasure` was `(rfl)` against the old body and is now
derived through `Fin.sum_univ_eq_sum_range` and `Fintype.card_fin`. The other five sequence lemmas
were already routed through it and go through untouched.

**No alias, no compatibility shim, and no bridge declaration.** The definition-level identification
is definitional, so there is nothing to name.

## One structural change

`empiricalPopulation` sits below `empiricalMeasure` in the merged file, so the `FinitePopulation`
section moves above the sequence section — a definition must precede its specialization. That is
the whole of the reordering; no declaration in either section is otherwise altered, which is why
the diff looks larger than the change is.

## Verification

`TauCeti.Probability.Exchangeability.ConditionallyIID.StrongLaw`, the main downstream consumer,
builds unchanged.

Roadmap: Exchangeability

Ordinary cleanup of existing code: this removes a duplicate implementation and adds no new
mathematics, so it needs no roadmap claim. Roadmap intention #241, which had covered the generic
finite empirical measure, was released and closed once #3538 supplied it under the name
`empiricalPopulation`.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
