### PR TITLE
feat: the twelve positive roots of the D₄ quiver

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/D4/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/D4/Basic.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Acyclic.Basic
+public import TauCeti.RepresentationTheory.Quiver.Reflection.Basic
+public import Mathlib.Data.Fintype.BigOperators
+public import Mathlib.Data.Fintype.Option
+
+/-!
+# The `D₄` quiver
+
+The `D₄` quiver has a central vertex and three outer vertices, with one arrow running from each
+outer vertex into the centre. Its underlying graph is the simply-laced Dynkin diagram `D₄`, the
+smallest one that is not of type `A`, which makes it the standard test of the positive-root count
+beyond type `A`.
+
+This file constructs the quiver and its combinatorics: the centre is a sink and the outer vertices
+are sources, so the quiver is acyclic and its only nontrivial paths are the three arrows. The
+dimension of its path algebra is computed in `TauCeti.RepresentationTheory.Quiver.D4.PathAlgebra`,
+and its Euler and Tits forms, with the twelve positive roots they cut out, in
+`TauCeti.RepresentationTheory.Quiver.D4.EulerForm`.
+
+## Main definitions
+
+* `TauCeti.Quiver.D4`: the vertex type, with constructors `center` and `outer`, and a `Quiver`
+  instance whose only arrows are the three `outer i ⟶ center`.
+* `TauCeti.Quiver.D4.vertexEquiv`: the vertices as `Option (Fin 3)`, the centre being `none`.
+* `TauCeti.Quiver.D4.arrow` and `TauCeti.Quiver.D4.arrowPath`: the arrow attached to an outer
+  vertex, and the length-one path it traces.
+
+## Main results
+
+* `TauCeti.Quiver.D4.isSink_center` and `TauCeti.Quiver.D4.isSource_outer`: the centre is a sink
+  and each outer vertex is a source.
+* `TauCeti.Quiver.D4.isAcyclic`: the quiver is acyclic, since all of its arrows run the same way.
+* `TauCeti.Quiver.D4.instUniquePathOuterCenter`: the only path from an outer vertex to the centre
+  is the arrow there, so the quiver has seven paths in all.
+
+## References
+
+This file supplies the vertex and arrow data of the “`D₄` quiver” worked example of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, alongside the generalized
+Kronecker quiver of `TauCeti.RepresentationTheory.Quiver.Kronecker.Basic`. See Derksen--Weyman,
+*An Introduction to Quiver Representations*, and Assem--Simson--Skowroński, *Elements of the
+Representation Theory of Associative Algebras I*, Ch. II.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Quiver
+
+namespace Quiver
+
+/-- The `D₄` quiver: a central vertex together with three outer vertices, with one arrow from each
+outer vertex into the centre. Its underlying graph is the Dynkin diagram `D₄`. -/
+inductive D4 : Type
+  | /-- The central vertex, the head of every arrow. -/ center : D4
+  | /-- The `i`-th outer vertex, the tail of the `i`-th arrow. -/ outer (i : Fin 3) : D4
+  deriving DecidableEq
+
+namespace D4
+
+/-! ### The four vertices -/
+
+/-- The vertices of the `D₄` quiver as `Option (Fin 3)`: the centre is `none`, and the `i`-th outer
+vertex is `some i`. -/
+def vertexEquiv : D4 ≃ Option (Fin 3) where
+  toFun
+    | .center => none
+    | .outer i => some i
+  invFun
+    | none => center
+    | some i => outer i
+  left_inv v := by cases v <;> rfl
+  right_inv o := by cases o <;> rfl
+
+@[simp]
+theorem vertexEquiv_center : vertexEquiv center = none :=
+  -- The parentheses keep this an ordinary proof term rather than an exported `rfl` theorem, which
+  -- would force `vertexEquiv` to be `@[expose]`.
+  (rfl)
+
+@[simp]
+theorem vertexEquiv_outer (i : Fin 3) : vertexEquiv (outer i) = some i := (rfl)
+
+@[simp]
+theorem vertexEquiv_symm_none : vertexEquiv.symm none = center := (rfl)
+
+@[simp]
+theorem vertexEquiv_symm_some (i : Fin 3) : vertexEquiv.symm (some i) = outer i := (rfl)
+
+instance : Fintype D4 := Fintype.ofEquiv _ vertexEquiv.symm
+
+@[simp]
+theorem card_eq_four : Fintype.card D4 = 4 := by
+  rw [Fintype.card_congr vertexEquiv]
+  simp
+
+/-- A sum over the vertices of `D₄` splits into the value at the centre and a sum over the three
+outer vertices. -/
+@[simp]
+theorem sum_univ {M : Type*} [AddCommMonoid M] (f : D4 → M) :
+    ∑ v, f v = f center + ∑ i, f (outer i) := by
+  rw [Fintype.sum_equiv vertexEquiv f (fun o => f (vertexEquiv.symm o)) (by simp),
+    Fintype.sum_option]
+  simp
+
+/-- A function on the vertices vanishes exactly when all four of its values do. -/
+theorem eq_zero_iff {M : Type*} [Zero M] {f : D4 → M} :
+    f = 0 ↔ f center = 0 ∧ ∀ i, f (outer i) = 0 := by
+  refine ⟨fun h => h ▸ ⟨rfl, fun _ => rfl⟩, fun h => funext fun v => ?_⟩
+  cases v
+  · exact h.1
+  · exact h.2 _
+
+/-! ### The three arrows -/
+
+instance : _root_.Quiver.{1} D4 where
+  Hom a b :=
+    match a, b with
+    | .outer _, .center => PUnit
+    | _, _ => PEmpty
+
+/-- The arrow running from the `i`-th outer vertex into the centre. -/
+def arrow (i : Fin 3) : outer i ⟶ center := PUnit.unit
+
+instance instUniqueHomOuterCenter (i : Fin 3) : Unique (outer i ⟶ center) :=
+  inferInstanceAs (Unique PUnit)
+
+instance : IsEmpty (center ⟶ center) := inferInstanceAs (IsEmpty PEmpty)
+
+instance (i : Fin 3) : IsEmpty (center ⟶ outer i) := inferInstanceAs (IsEmpty PEmpty)
+
+instance (i j : Fin 3) : IsEmpty (outer i ⟶ outer j) := inferInstanceAs (IsEmpty PEmpty)
+
+/-- No arrow leaves the centre. -/
+theorem isEmpty_hom_from_center (b : D4) : IsEmpty (center ⟶ b) := by
+  cases b <;> infer_instance
+
+/-- No arrow ends at an outer vertex. -/
+theorem isEmpty_hom_to_outer (a : D4) (i : Fin 3) : IsEmpty (a ⟶ outer i) := by
+  cases a <;> infer_instance
+
+/-- The centre is a sink: every arrow of `D₄` ends there. -/
+theorem isSink_center : IsSink center :=
+  (IsSink_def _).mpr isEmpty_hom_from_center
+
+/-- Each outer vertex is a source: every arrow of `D₄` starts at one. -/
+theorem isSource_outer (i : Fin 3) : IsSource (outer i) :=
+  (IsSource_def _).mpr fun a => isEmpty_hom_to_outer a i
+
+instance instFintypeHom : ∀ a b : D4, Fintype (a ⟶ b)
+  | .center, .center => Fintype.ofIsEmpty
+  | .center, .outer _ => Fintype.ofIsEmpty
+  | .outer _, .center => inferInstanceAs (Fintype PUnit)
+  | .outer _, .outer _ => Fintype.ofIsEmpty
+
+/-! ### The paths -/
+
+/-- The only closed path at the centre is the trivial one, the centre being a sink. -/
+theorem path_center_center_eq_nil (p : Path center center) : p = Path.nil :=
+  isSink_center.path_self_eq_nil p
+
+/-- The only closed path at an outer vertex is the trivial one, an outer vertex being a source. -/
+theorem path_outer_outer_eq_nil (i : Fin 3) (p : Path (outer i) (outer i)) : p = Path.nil :=
+  (isSource_outer i).path_self_eq_nil p
+
+/-- The `D₄` quiver is acyclic: all of its arrows run into the centre. -/
+theorem isAcyclic : Quiver.IsAcyclic D4 :=
+  isAcyclic_def.mpr fun a p => by
+    cases a
+    · exact path_center_center_eq_nil p
+    · exact path_outer_outer_eq_nil _ p
+
+instance : Unique (Path center center) where
+  default := Path.nil
+  uniq := path_center_center_eq_nil
+
+instance instUniquePathOuterSelf (i : Fin 3) : Unique (Path (outer i) (outer i)) where
+  default := Path.nil
+  uniq := path_outer_outer_eq_nil i
+
+instance (i : Fin 3) : IsEmpty (Path center (outer i)) :=
+  ⟨fun p => by simpa using isSink_center.eq_of_path p⟩
+
+/-- There is no path between two distinct outer vertices: a path out of an outer vertex reaches
+the centre and stops there. -/
+theorem isEmpty_path_outer_outer {i j : Fin 3} (h : i ≠ j) : IsEmpty (Path (outer i) (outer j)) :=
+  ⟨fun p => h (by simpa using (isSource_outer j).eq_of_path p)⟩
+
+/-- The length-one path traced by the arrow at an outer vertex. -/
+def arrowPath (i : Fin 3) : Path (outer i) center := (arrow i).toPath
+
+/-- The only path from an outer vertex to the centre is the arrow there: that arrow is the only
+one leaving the vertex, and nothing can be appended to it because the centre is a sink. -/
+instance instUniquePathOuterCenter (i : Fin 3) : Unique (Path (outer i) center) where
+  default := arrowPath i
+  uniq p := by
+    cases p with
+    | @cons b _ q e =>
+        cases b with
+        | center => exact (isEmpty_hom_from_center _).elim e
+        | outer j =>
+            obtain rfl : i = j := by simpa using (isSource_outer j).eq_of_path q
+            rw [path_outer_outer_eq_nil _ q, Subsingleton.elim e (arrow i)]
+            rfl
+
+instance instFintypePath : ∀ a b : D4, Fintype (Path a b)
+  | .center, .center => Unique.fintype
+  | .center, .outer _ => Fintype.ofIsEmpty
+  | .outer _, .center => Unique.fintype
+  | .outer i, .outer j =>
+      if h : i = j then by subst h; exact Unique.fintype
+      else @Fintype.ofIsEmpty _ (isEmpty_path_outer_outer h)
+
+/-- The only path between two outer vertices is the trivial one at a single vertex. The other
+three path counts of `D₄` are read off by `simp` from the `Unique` and `IsEmpty` instances
+above. -/
+@[simp]
+theorem card_path_outer_outer (i j : Fin 3) :
+    Fintype.card (Path (outer i) (outer j)) = if i = j then 1 else 0 := by
+  split
+  · next h => subst h; exact Fintype.card_unique
+  · next h => exact Fintype.card_eq_zero_iff.mpr (isEmpty_path_outer_outer h)
+
+end D4
+
+end Quiver
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/D4/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/D4/EulerForm.lean
@@ -1,0 +1,396 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.D4.Basic
+public import TauCeti.RepresentationTheory.Quiver.EulerForm
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+
+/-!
+# The Euler and Tits forms of the `D₄` quiver
+
+This file evaluates the Euler and Tits forms of the `D₄` quiver in the coordinates of its four
+vertices and reads off their positive roots. Writing `c` for the value at the centre and `aᵢ` for
+the values at the three outer vertices,
+
+* `titsForm d = c ^ 2 + ∑ᵢ aᵢ ^ 2 - c * ∑ᵢ aᵢ`, and four times it is the sum of squares
+  `c ^ 2 + ∑ᵢ (2 aᵢ - c) ^ 2`, so the form is **positive definite**: `D₄` is a Dynkin quiver;
+* consequently a dimension vector `d ≥ 0` of Tits norm one has `c ≤ 2`, and the **nonnegative**
+  vectors of Tits norm one are exactly **twelve** in number -- the three outer simple roots, the
+  eight vectors with a `1` at the centre and an arbitrary `0/1` pattern outside (`s = ∅` being the
+  central simple root), and the highest root `(1,1,1;2)`.
+
+Twelve is the number of positive roots of the root system `D₄`, so this is the standard check that
+the positive-root count of a quiver is correct beyond type `A`, where
+`TauCeti.Quiver.Kronecker.EulerForm` already tests it.
+
+## Main definitions
+
+* `TauCeti.Quiver.D4.rootVector`: the dimension vector with a given value at the centre and a `1`
+  at each outer vertex of a given set. Every positive root has this shape.
+* `TauCeti.Quiver.D4.posRoot`: the twelve positive roots, indexed by
+  `Fin 3 ⊕ Finset (Fin 3) ⊕ Unit`.
+
+## Main results
+
+* `TauCeti.Quiver.D4.eulerForm_apply` and `TauCeti.Quiver.D4.titsForm_apply`: the two forms in
+  coordinates, and `TauCeti.Quiver.D4.four_mul_titsForm` the sum-of-squares identity behind
+  everything else.
+* `TauCeti.Quiver.D4.titsForm_posDef`: the Tits form of `D₄` is positive definite.
+* `TauCeti.Quiver.D4.titsForm_eq_one_iff_of_nonneg`: a nonnegative dimension vector has Tits norm
+  one exactly when it is one of the listed positive roots.
+* `TauCeti.Quiver.D4.card_positiveRoots`: there are exactly twelve of them.
+
+## References
+
+This file supplies the “`D₄` quiver” worked example of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, which asks for the twelve
+positive roots of `D₄` -- the four simple roots, those with a `1` at the centre and a `1` on a
+subset of the outer vertices, and the highest root with coefficient `2` at the centre. See
+Derksen--Weyman, *An Introduction to Quiver Representations*, and Assem--Simson--Skowroński,
+*Elements of the Representation Theory of Associative Algebras I*, Ch. VII.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Quiver
+
+namespace Quiver.D4
+
+/-! ### The two forms in coordinates -/
+
+/-- The Euler form of the `D₄` quiver in the coordinates of its four vertices: the three arrows
+contribute the single term `(∑ᵢ dᵢ) · e_center`. -/
+-- Deliberately not `@[simp]`: `TauCeti.eulerForm_def` is already `simp` and rewrites `eulerForm`
+-- to its defining sums, which is the normal form this lemma also produces.
+theorem eulerForm_apply (d e : D4 → ℤ) :
+    eulerForm D4 d e =
+      d center * e center + ∑ i, d (outer i) * e (outer i) - (∑ i, d (outer i)) * e center := by
+  rw [eulerForm_eq_sum_card]
+  simp [Finset.sum_mul]
+
+/-- The Tits form of the `D₄` quiver: `q(d) = c ^ 2 + ∑ᵢ aᵢ ^ 2 - c * ∑ᵢ aᵢ` for `c` the value at
+the centre and `aᵢ` the values at the outer vertices. -/
+-- Deliberately not `@[simp]`, for the same reason as `eulerForm_apply`.
+theorem titsForm_apply (d : D4 → ℤ) :
+    titsForm D4 d = d center ^ 2 + ∑ i, d (outer i) ^ 2 - d center * ∑ i, d (outer i) := by
+  rw [titsForm_def, eulerForm_apply]
+  simp only [← pow_two]
+  ring
+
+/-- **Four times the Tits form of `D₄` is a sum of four squares.** This single identity carries the
+positive definiteness of the form and the bound `c ≤ 2` on the central coordinate of a root. -/
+theorem four_mul_titsForm (d : D4 → ℤ) :
+    4 * titsForm D4 d = d center ^ 2 + ∑ i, (2 * d (outer i) - d center) ^ 2 := by
+  rw [titsForm_apply]
+  simp only [Fin.sum_univ_three]
+  ring
+
+/-- The Tits form of `D₄` is positive semidefinite. -/
+theorem titsForm_nonneg (d : D4 → ℤ) : 0 ≤ titsForm D4 d := by
+  have hsum : 0 ≤ ∑ i, (2 * d (outer i) - d center) ^ 2 :=
+    Finset.sum_nonneg fun i _ => sq_nonneg _
+  have hc := sq_nonneg (d center)
+  have h := four_mul_titsForm d
+  linarith
+
+/-- **The Tits form of `D₄` is positive definite**, so `D₄` is a Dynkin quiver and, by Gabriel's
+dichotomy, of finite representation type. -/
+theorem titsForm_posDef : (titsForm D4).PosDef := by
+  intro d hd
+  rcases (titsForm_nonneg d).lt_or_eq with h | h
+  · exact h
+  refine absurd ?_ hd
+  have h4 := four_mul_titsForm d
+  rw [← h] at h4
+  have hsum : 0 ≤ ∑ i, (2 * d (outer i) - d center) ^ 2 :=
+    Finset.sum_nonneg fun i _ => sq_nonneg _
+  have hcsq : d center ^ 2 = 0 := by
+    have := sq_nonneg (d center)
+    linarith
+  have hzero : ∑ i, (2 * d (outer i) - d center) ^ 2 = 0 := by linarith
+  have hc : d center = 0 := pow_eq_zero_iff two_ne_zero |>.mp hcsq
+  refine eq_zero_iff.mpr ⟨hc, fun i => ?_⟩
+  have hi := (Finset.sum_eq_zero_iff_of_nonneg fun j _ =>
+    sq_nonneg (2 * d (outer j) - d center)).mp hzero i (Finset.mem_univ i)
+  have h2 : 2 * d (outer i) - d center = 0 := pow_eq_zero_iff two_ne_zero |>.mp hi
+  omega
+
+/-! ### The shape of a positive root -/
+
+/-- The dimension vector of `D₄` with the value `c` at the centre and a `1` at each outer vertex
+lying in `s`. Every nonnegative dimension vector of Tits norm one has this shape. -/
+def rootVector (c : ℤ) (s : Finset (Fin 3)) : D4 → ℤ
+  | .center => c
+  | .outer j => if j ∈ s then 1 else 0
+
+@[simp]
+theorem rootVector_center (c : ℤ) (s : Finset (Fin 3)) : rootVector c s center = c :=
+  -- The parentheses keep this an ordinary proof term rather than an exported `rfl` theorem, which
+  -- would force `rootVector` to be `@[expose]`.
+  (rfl)
+
+@[simp]
+theorem rootVector_outer (c : ℤ) (s : Finset (Fin 3)) (j : Fin 3) :
+    rootVector c s (outer j) = if j ∈ s then 1 else 0 := (rfl)
+
+/-- A root vector with a nonnegative central coordinate is a nonnegative dimension vector. -/
+theorem rootVector_nonneg {c : ℤ} (hc : 0 ≤ c) (s : Finset (Fin 3)) : 0 ≤ rootVector c s := by
+  rw [Pi.le_def]
+  intro v
+  cases v with
+  | center => simpa using hc
+  | outer j =>
+      rw [Pi.zero_apply, rootVector_outer]
+      split <;> norm_num
+
+/-- The sum of a root vector over the outer vertices is the size of its defining set. -/
+theorem sum_rootVector_outer (c : ℤ) (s : Finset (Fin 3)) :
+    ∑ j, rootVector c s (outer j) = (s.card : ℤ) := by
+  simp only [rootVector_outer]
+  rw [Finset.sum_ite_mem, Finset.univ_inter, Finset.sum_const, nsmul_eq_mul, mul_one]
+
+/-- **The Tits form on a root vector.** Because the outer coordinates are `0` or `1`, they are
+their own squares, and `q(rootVector c s) = c ^ 2 + (1 - c) * #s`. -/
+theorem titsForm_rootVector (c : ℤ) (s : Finset (Fin 3)) :
+    titsForm D4 (rootVector c s) = c ^ 2 + (1 - c) * s.card := by
+  have hsq : ∀ j : Fin 3, rootVector c s (outer j) ^ 2 = rootVector c s (outer j) := by
+    intro j
+    rw [rootVector_outer]
+    split <;> ring
+  rw [titsForm_apply, rootVector_center, Finset.sum_congr rfl fun j _ => hsq j,
+    sum_rootVector_outer]
+  ring
+
+/-- Two root vectors agree exactly when both of their data do: the central coordinate is read off
+at the centre, and the defining set from the outer coordinates. -/
+theorem rootVector_eq_iff {c c' : ℤ} {s s' : Finset (Fin 3)} :
+    rootVector c s = rootVector c' s' ↔ c = c' ∧ s = s' := by
+  refine ⟨fun h => ⟨by simpa using congrFun h center, ?_⟩, ?_⟩
+  · ext j
+    have hj := congrFun h (outer j)
+    rw [rootVector_outer, rootVector_outer] at hj
+    by_cases h₁ : j ∈ s <;> by_cases h₂ : j ∈ s' <;> simp_all
+  · rintro ⟨rfl, rfl⟩
+    rfl
+
+/-- A dimension vector all of whose outer coordinates are `0` or `1` is the root vector at its own
+central coordinate and the set of outer vertices where it takes the value `1`. -/
+private theorem eq_rootVector_filter {d : D4 → ℤ}
+    (hbin : ∀ i, d (outer i) = 0 ∨ d (outer i) = 1) :
+    d = rootVector (d center) (Finset.univ.filter fun i => d (outer i) = 1) := by
+  funext v
+  cases v with
+  | center => rw [rootVector_center]
+  | outer j =>
+      rw [rootVector_outer]
+      rcases hbin j with h | h <;> simp [h]
+
+/-- For such a vector the size of that set is the sum of the outer coordinates. -/
+private theorem card_filter_eq_sum {d : D4 → ℤ}
+    (hbin : ∀ i, d (outer i) = 0 ∨ d (outer i) = 1) :
+    (((Finset.univ.filter fun i => d (outer i) = 1).card : ℤ)) = ∑ i, d (outer i) := by
+  rw [Finset.card_filter]
+  push_cast
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rcases hbin i with h | h <;> simp [h]
+
+/-! ### The twelve positive roots -/
+
+/-- **The positive roots of the `D₄` Tits form.** A nonnegative dimension vector has Tits norm one
+exactly when it is a root vector of one of three kinds: an outer simple root (`0` at the centre and
+a single outer `1`), a vector with a `1` at the centre and an arbitrary `0/1` pattern outside, or
+the highest root (`2` at the centre and a `1` at every outer vertex). -/
+theorem titsForm_eq_one_iff_of_nonneg {d : D4 → ℤ} (hd : 0 ≤ d) :
+    titsForm D4 d = 1 ↔ ∃ (c : ℤ) (s : Finset (Fin 3)),
+      d = rootVector c s ∧ ((c = 0 ∧ s.card = 1) ∨ c = 1 ∨ (c = 2 ∧ s = Finset.univ)) := by
+  rw [Pi.le_def] at hd
+  simp only [Pi.zero_apply] at hd
+  constructor
+  · intro h
+    -- The central coordinate is bounded by the sum-of-squares identity.
+    have h4 := four_mul_titsForm d
+    rw [h] at h4
+    have hsum : 0 ≤ ∑ i, (2 * d (outer i) - d center) ^ 2 :=
+      Finset.sum_nonneg fun i _ => sq_nonneg _
+    have hcsq : d center ^ 2 ≤ 4 := by linarith
+    have hc2 : d center ≤ 2 := by nlinarith [hd center]
+    have ht := titsForm_apply d
+    rw [h] at ht
+    have hcases : d center = 0 ∨ d center = 1 ∨ d center = 2 := by
+      have := hd center
+      omega
+    -- In each case the outer coordinates are forced to be `0` or `1`.
+    have main : ∀ hbin : ∀ i, d (outer i) = 0 ∨ d (outer i) = 1,
+        ∃ (c : ℤ) (s : Finset (Fin 3)), d = rootVector c s ∧ c = d center ∧
+          ((s.card : ℤ) = ∑ i, d (outer i)) :=
+      fun hbin => ⟨d center, _, eq_rootVector_filter hbin, rfl, card_filter_eq_sum hbin⟩
+    rcases hcases with hc | hc | hc
+    · -- `c = 0`: the outer coordinates square-sum to one, so exactly one of them is `1`.
+      rw [hc] at ht
+      have hle : ∀ i : Fin 3, d (outer i) ^ 2 ≤ 1 := by
+        intro i
+        have hsingle := Finset.single_le_sum (f := fun j : Fin 3 => d (outer j) ^ 2)
+          (fun j _ => sq_nonneg _) (Finset.mem_univ i)
+        linarith
+      have hbin : ∀ i : Fin 3, d (outer i) = 0 ∨ d (outer i) = 1 := by
+        intro i
+        have h₀ := hd (outer i)
+        have h₁ : d (outer i) ≤ 1 := by nlinarith [hle i]
+        omega
+      have hsq : ∀ i : Fin 3, d (outer i) ^ 2 = d (outer i) := by
+        intro i
+        rcases hbin i with h' | h' <;> rw [h'] <;> ring
+      have hsumone : ∑ i, d (outer i) = 1 := by
+        rw [← Finset.sum_congr rfl fun i _ => hsq i]
+        linarith
+      obtain ⟨c, s, hds, hcc, hcard⟩ := main hbin
+      refine ⟨c, s, hds, Or.inl ⟨by rw [hcc, hc], ?_⟩⟩
+      have : (s.card : ℤ) = 1 := by rw [hcard, hsumone]
+      exact_mod_cast this
+    · -- `c = 1`: each outer coordinate satisfies `aᵢ ^ 2 = aᵢ`.
+      rw [hc] at ht
+      have hnn : ∀ i : Fin 3, (0 : ℤ) ≤ d (outer i) ^ 2 - d (outer i) := by
+        intro i
+        have h₀ := hd (outer i)
+        rcases eq_or_lt_of_le h₀ with h' | h'
+        · rw [← h']
+          norm_num
+        · have h₁ : 1 ≤ d (outer i) := by omega
+          nlinarith
+      have hz : ∑ i, (d (outer i) ^ 2 - d (outer i)) = 0 := by
+        rw [Finset.sum_sub_distrib]
+        linarith
+      have hbin : ∀ i : Fin 3, d (outer i) = 0 ∨ d (outer i) = 1 := by
+        intro i
+        have hi := (Finset.sum_eq_zero_iff_of_nonneg fun j _ => hnn j).mp hz i (Finset.mem_univ i)
+        have hfac : d (outer i) * (d (outer i) - 1) = 0 := by linear_combination hi
+        rcases mul_eq_zero.mp hfac with h' | h'
+        · exact Or.inl h'
+        · exact Or.inr (by omega)
+      obtain ⟨c, s, hds, hcc, -⟩ := main hbin
+      exact ⟨c, s, hds, Or.inr (Or.inl (by rw [hcc, hc]))⟩
+    · -- `c = 2`: the outer coordinates square-sum to their doubles less three, forcing each to
+      -- be `1`.
+      rw [hc] at ht
+      have hz : ∑ i, (d (outer i) - 1) ^ 2 = 0 := by
+        simp only [Fin.sum_univ_three] at ht ⊢
+        linarith
+      have hone : ∀ i : Fin 3, d (outer i) = 1 := by
+        intro i
+        have hi := (Finset.sum_eq_zero_iff_of_nonneg fun j _ =>
+          sq_nonneg (d (outer j) - 1)).mp hz i (Finset.mem_univ i)
+        have := pow_eq_zero_iff two_ne_zero |>.mp hi
+        omega
+      obtain ⟨c, s, hds, hcc, hcard⟩ := main fun i => Or.inr (hone i)
+      refine ⟨c, s, hds, Or.inr (Or.inr ⟨by rw [hcc, hc], ?_⟩)⟩
+      refine Finset.eq_univ_of_card s ?_
+      have : (s.card : ℤ) = 3 := by
+        rw [hcard]
+        simp [hone]
+      simp only [Fintype.card_fin]
+      exact_mod_cast this
+  · rintro ⟨c, s, rfl, hcond⟩
+    rw [titsForm_rootVector]
+    rcases hcond with ⟨rfl, hcard⟩ | rfl | ⟨rfl, rfl⟩
+    · rw [hcard]
+      norm_num
+    · ring
+    · simp
+
+/-- The twelve positive roots of `D₄`, indexed: `inl i` is the simple root at the `i`-th outer
+vertex, `inr (inl s)` carries a `1` at the centre and a `1` at each outer vertex of `s` (so
+`s = ∅` gives the simple root at the centre), and `inr (inr ())` is the highest root. -/
+def posRoot : Fin 3 ⊕ Finset (Fin 3) ⊕ Unit → D4 → ℤ
+  | .inl i => rootVector 0 {i}
+  | .inr (.inl s) => rootVector 1 s
+  | .inr (.inr _) => rootVector 2 Finset.univ
+
+@[simp]
+theorem posRoot_inl (i : Fin 3) : posRoot (.inl i) = rootVector 0 {i} :=
+  -- The parentheses keep this an ordinary proof term rather than an exported `rfl` theorem, which
+  -- would force `posRoot` to be `@[expose]`.
+  (rfl)
+
+@[simp]
+theorem posRoot_inr_inl (s : Finset (Fin 3)) : posRoot (.inr (.inl s)) = rootVector 1 s := (rfl)
+
+@[simp]
+theorem posRoot_inr_inr (u : Unit) : posRoot (.inr (.inr u)) = rootVector 2 Finset.univ := (rfl)
+
+/-- Each of the twelve listed vectors is nonnegative. -/
+theorem posRoot_nonneg (x : Fin 3 ⊕ Finset (Fin 3) ⊕ Unit) : 0 ≤ posRoot x := by
+  rcases x with i | s | u <;> simp only [posRoot_inl, posRoot_inr_inl, posRoot_inr_inr] <;>
+    exact rootVector_nonneg (by norm_num) _
+
+/-- Each of the twelve listed vectors has Tits norm one. -/
+theorem titsForm_posRoot (x : Fin 3 ⊕ Finset (Fin 3) ⊕ Unit) : titsForm D4 (posRoot x) = 1 := by
+  rcases x with i | s | u <;>
+    simp only [posRoot_inl, posRoot_inr_inl, posRoot_inr_inr, titsForm_rootVector]
+  · simp
+  · ring
+  · simp
+
+/-- The twelve listed vectors are pairwise distinct. -/
+theorem posRoot_injective : Function.Injective posRoot := by
+  rintro (i | s | ⟨⟩) (j | t | ⟨⟩) h
+  · rw [posRoot_inl, posRoot_inl, rootVector_eq_iff] at h
+    rw [Finset.singleton_inj.mp h.2]
+  · rw [posRoot_inl, posRoot_inr_inl, rootVector_eq_iff] at h
+    exact absurd h.1 (by norm_num)
+  · rw [posRoot_inl, posRoot_inr_inr, rootVector_eq_iff] at h
+    exact absurd h.1 (by norm_num)
+  · rw [posRoot_inr_inl, posRoot_inl, rootVector_eq_iff] at h
+    exact absurd h.1 (by norm_num)
+  · rw [posRoot_inr_inl, posRoot_inr_inl, rootVector_eq_iff] at h
+    rw [h.2]
+  · rw [posRoot_inr_inl, posRoot_inr_inr, rootVector_eq_iff] at h
+    exact absurd h.1 (by norm_num)
+  · rw [posRoot_inr_inr, posRoot_inl, rootVector_eq_iff] at h
+    exact absurd h.1 (by norm_num)
+  · rw [posRoot_inr_inr, posRoot_inr_inl, rootVector_eq_iff] at h
+    exact absurd h.1 (by norm_num)
+  · rfl
+
+/-- **The positive roots of `D₄`, as the range of the indexing map.** -/
+theorem titsForm_eq_one_iff_exists_posRoot {d : D4 → ℤ} (hd : 0 ≤ d) :
+    titsForm D4 d = 1 ↔ ∃ x, posRoot x = d := by
+  rw [titsForm_eq_one_iff_of_nonneg hd]
+  constructor
+  · rintro ⟨c, s, rfl, ⟨rfl, hcard⟩ | rfl | ⟨rfl, rfl⟩⟩
+    · obtain ⟨i, rfl⟩ := Finset.card_eq_one.mp hcard
+      exact ⟨.inl i, rfl⟩
+    · exact ⟨.inr (.inl s), rfl⟩
+    · exact ⟨.inr (.inr ()), rfl⟩
+  · rintro ⟨x, rfl⟩
+    rcases x with i | s | u
+    · exact ⟨0, {i}, rfl, Or.inl ⟨rfl, Finset.card_singleton i⟩⟩
+    · exact ⟨1, s, rfl, Or.inr (Or.inl rfl)⟩
+    · exact ⟨2, Finset.univ, rfl, Or.inr (Or.inr ⟨rfl, rfl⟩)⟩
+
+/-- **The `D₄` quiver has exactly twelve positive roots**, matching the twelve positive roots of
+the root system `D₄`: the four simple roots, the six further vectors with a `1` at the centre and
+a `1` at one or two outer vertices, the vector `(1,1,1;1)`, and the highest root `(1,1,1;2)`. -/
+theorem card_positiveRoots :
+    Nat.card {d : D4 → ℤ // 0 ≤ d ∧ titsForm D4 d = 1} = 12 := by
+  have hbij : Function.Bijective
+      (fun x : Fin 3 ⊕ Finset (Fin 3) ⊕ Unit =>
+        (⟨posRoot x, posRoot_nonneg x, titsForm_posRoot x⟩ :
+          {d : D4 → ℤ // 0 ≤ d ∧ titsForm D4 d = 1})) := by
+    constructor
+    · exact fun x y hxy => posRoot_injective (Subtype.ext_iff.mp hxy)
+    · rintro ⟨d, hd, h1⟩
+      obtain ⟨x, hx⟩ := (titsForm_eq_one_iff_exists_posRoot hd).mp h1
+      exact ⟨x, Subtype.ext hx⟩
+  rw [← Nat.card_eq_of_bijective _ hbij]
+  simp
+
+end Quiver.D4
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/D4/PathAlgebra.lean
+++ b/TauCeti/RepresentationTheory/Quiver/D4/PathAlgebra.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.D4.Basic
+public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.Basic
+
+/-!
+# The path algebra of the `D₄` quiver
+
+The `D₄` quiver has seven paths: the four trivial ones and the three arrows. So its path algebra
+is seven-dimensional. Finite-dimensionality needs nothing specific to this quiver: it is acyclic,
+so `TauCeti.finiteDimensional_pathAlgebra_of_isAcyclic` applies to it as it stands, via
+`TauCeti.Quiver.D4.isAcyclic`.
+
+## Main results
+
+* `TauCeti.Quiver.D4.card_totalPath` and `TauCeti.Quiver.D4.finrank_pathAlgebra`: there are seven
+  paths, so the path algebra is seven-dimensional.
+
+## References
+
+This file supplies the path algebra of the “`D₄` quiver” worked example of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`. See Derksen--Weyman, *An
+Introduction to Quiver Representations*, and Assem--Simson--Skowroński, *Elements of the
+Representation Theory of Associative Algebras I*, Ch. II.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Quiver
+
+universe w
+
+namespace Quiver.D4
+
+/-- The `D₄` quiver has seven paths: the four trivial ones and the three arrows. -/
+theorem card_totalPath : Fintype.card (Quiver.TotalPath D4) = 7 := by
+  have h : Fintype.card (Quiver.TotalPath D4)
+      = ∑ a : D4, ∑ b : D4, Fintype.card (Path a b) := by
+    rw [Fintype.card_sigma]
+    exact Finset.sum_congr rfl fun _ _ => Fintype.card_sigma
+  rw [h]
+  simp
+
+/-- The path algebra of the `D₄` quiver is seven-dimensional: four trivial paths and three
+arrows. -/
+theorem finrank_pathAlgebra (k : Type w) [DivisionRing k] :
+    Module.finrank k (pathAlgebra k D4) = 7 := by
+  rw [TauCeti.finrank_pathAlgebra k D4, card_totalPath]
+
+end Quiver.D4
+
+end TauCeti


### PR DESCRIPTION
This PR builds the `D₄` quiver -- a central vertex with three arrows running into it -- and reads off the positive roots of its Tits form, supplying the "`D₄` quiver (three arrows into a central sink)" worked example of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose acceptance criterion asks for the **twelve positive roots of `D₄`**: "the four simple roots (dimension vector a single `1`), and the further roots supported on the centre -- those with a `1` at the centre and at some subset of the outer vertices, and the highest root `(1,1,1;2)` with coefficient `2` at the centre. This is the standard test that the positive-root count and the Coxeter-functor orbit are correct beyond type `A`." It sits beside the generalized Kronecker quiver of `TauCeti/RepresentationTheory/Quiver/Kronecker/`, which already covers the `A₂` and `Ã₁` ends of the same acceptance list, and consumes the Layer 4 Euler/Tits form API of `TauCeti/RepresentationTheory/Quiver/EulerForm.lean` unchanged.

`TauCeti/RepresentationTheory/Quiver/D4/Basic.lean` defines the vertex type (`center`, `outer : Fin 3 → D4`) with its `Quiver` instance, identifies the vertices with `Option (Fin 3)`, and classifies the arrows and paths: the centre is a sink and each outer vertex a source, so the quiver is acyclic (`isAcyclic`) and the only path from an outer vertex to the centre is its arrow. `TauCeti/RepresentationTheory/Quiver/D4/PathAlgebra.lean` counts the seven paths -- four trivial, three arrows -- so the path algebra is seven-dimensional.

`TauCeti/RepresentationTheory/Quiver/D4/EulerForm.lean` carries the mathematics. Writing `c` for the value at the centre and `aᵢ` for the outer values, `titsForm d = c ^ 2 + ∑ᵢ aᵢ ^ 2 - c * ∑ᵢ aᵢ`, and the load-bearing identity `four_mul_titsForm` says four times it is the sum of four squares `c ^ 2 + ∑ᵢ (2 aᵢ - c) ^ 2`. That single identity gives positive definiteness (`titsForm_posDef`, so `D₄` is a Dynkin quiver and by Gabriel's dichotomy of finite representation type) and the bound `0 ≤ c ≤ 2` on a nonnegative root. Splitting on `c` and using only index-free sum arguments -- `Finset.single_le_sum` for the coordinatewise bound and `Finset.sum_eq_zero_iff_of_nonneg` for the vanishing cases -- forces every outer coordinate to be `0` or `1`, so every positive root is `rootVector c s`, the vector with `c` at the centre and a `1` at each outer vertex of `s`, whose Tits norm is exactly `c ^ 2 + (1 - c) * #s`. Hence `titsForm_eq_one_iff_of_nonneg`: a nonnegative dimension vector has Tits norm one exactly when `c = 0` and `#s = 1`, or `c = 1`, or `c = 2` and `s` is everything. Indexing those by `Fin 3 ⊕ Finset (Fin 3) ⊕ Unit` and proving the indexing injective and surjective yields `card_positiveRoots`: `Nat.card {d // 0 ≤ d ∧ titsForm D4 d = 1} = 12`, the three outer simple roots, the eight vectors with a `1` at the centre (the empty set giving the central simple root), and the highest root.

The statement is deliberately confined to the *nonnegative* vectors of Tits norm one -- the positive roots; the full root set of `D₄` has twenty-four elements, twelve of them negatives of these. Nothing here classifies the indecomposable representations: that is Gabriel's theorem, a Layer 5 target, and this PR supplies only the root-system side that `gabriel_indecomposable_equiv_posRoot` will be matched against.

No Mathlib infrastructure was vendored; the proofs consume `Finset` big-operator lemmas, `QuadraticMap.PosDef`, and `Nat.card_eq_of_bijective` as they stand. `lake build`, `lake exe axioms` (allowlist only) and `lake exe module-system` are green, and a targeted `#lint` over the new modules with the default environment-linter set reports no violations.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"d4-quiver-positive-roots"}-->

🤖 Prepared with Claude Code
