### PR TITLE
refactor: separate universes in induction plumbing

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries.lean
@@ -60,15 +60,10 @@ numbers, and neither does its bundled form `TauCeti.GL2BorelRep`, which is there
 `CommRing F`; the field and finiteness hypotheses enter only with `TauCeti.GL2PrincipalSeries`,
 where they supply the finite index that makes induction finite-dimensional.
 
-Only the principal series restricts `F` to `Type`; everything up to and including
-`TauCeti.GL2BorelRep` is universe-polymorphic in `F`, since `FDRep ℂ G` accepts a group in any
-universe. The restriction on the principal series is forced by induction, not chosen: an object of
-`FDRep ℂ G` carries a module in the universe of `ℂ`, namely `Type`, since
-`FDRep R G = Action (FGModuleCat.{u} R) G` for `R : Type u`, whereas the induced representation
-`(ℂ[G] ⊗[ℂ] A)_B` built by `TauCeti.indFDRep` lives in the universe of `G`. So induction into
-`FDRep ℂ (GL (Fin 2) F)` needs `GL (Fin 2) F` — hence `F` — in the universe of `ℂ`. Lifting the
-induced representation back down along a basis would be a genuine addition to the induction API,
-not a change of binders here.
+The construction is universe-polymorphic in `F`. Although Mathlib's raw induced representation
+has a carrier in the universe of the group, `TauCeti.indFDRep` transports it to an equivalent small
+model whose carrier lies in the universe of the coefficient ring. It therefore produces an object
+of `FDRep ℂ (GL (Fin 2) F)` without restricting the universe of `F`.
 
 `TauCetiRoadmap/RepresentationTheory/CharacterTheory/Suggested.lean` pins `GL2PrincipalSeries`
 with a `[DecidableEq F]` hypothesis. It is not needed: `GL (Fin 2) F` needs decidable equality only
@@ -218,7 +213,7 @@ end CommRing
 
 section FiniteField
 
-variable (F : Type) [Field F] [Fintype F]
+variable (F : Type*) [Field F] [Fintype F]
 
 /-- **The principal series** `Ind_B^{GL₂}(α ⊗ β)`: the representation of `GL₂(𝔽_q)` induced from
 the one-dimensional character `α ⊗ β` of the Borel subgroup. This is parabolic induction in rank

--- a/TauCeti/RepresentationTheory/FDRep.lean
+++ b/TauCeti/RepresentationTheory/FDRep.lean
@@ -21,7 +21,7 @@ open CategoryTheory
 
 universe u v
 
-/-- Forgetting finite generation keeps the finite-generation instance on the carrier. -/
+/-- Forgetting finite-dimensionality keeps the finite-generation instance on the carrier. -/
 instance moduleFinite_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
     (A : FDRep R G) : Module.Finite R ((forget₂ (FDRep R G) (Rep R G)).obj A) :=
   inferInstanceAs (Module.Finite R A)

--- a/TauCeti/RepresentationTheory/FDRep.lean
+++ b/TauCeti/RepresentationTheory/FDRep.lean
@@ -10,27 +10,34 @@ public import Mathlib.RepresentationTheory.FDRep
 /-!
 # Finite-dimensional representations
 
-This file supplies general-purpose facts about Mathlib's category `FDRep`.
+This file records how the forgetful functor `FDRep R G ⥤ Rep R G` preserves module-finiteness and
+finrank. These facts let results proved for representation carriers transfer back to `FDRep`, in
+particular in `TauCeti.RepresentationTheory.Induction.FiniteDimensional`.
+
+## Main statements
+
+* `FDRep.moduleFinite_forget₂_obj`: the forgotten carrier is module-finite.
+* `FDRep.finrank_forget₂_obj`: forgetting does not change finrank.
 -/
 
 public section
 
-namespace TauCeti
+namespace FDRep
 
 open CategoryTheory
 
 universe u v
 
 /-- Forgetting finite-dimensionality keeps the finite-generation instance on the carrier. -/
-instance moduleFinite_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
+instance moduleFinite_forget₂_obj {R : Type u} {G : Type v} [CommRing R] [Monoid G]
     (A : FDRep R G) : Module.Finite R ((forget₂ (FDRep R G) (Rep R G)).obj A) :=
   inferInstanceAs (Module.Finite R A)
 
 /-- Forgetting finite-dimensionality does not change the dimension of the carrier. -/
 @[simp]
-theorem finrank_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
+theorem finrank_forget₂_obj {R : Type u} {G : Type v} [CommRing R] [Monoid G]
     (A : FDRep R G) :
     Module.finrank R ((forget₂ (FDRep R G) (Rep R G)).obj A) = Module.finrank R A :=
   rfl
 
-end TauCeti
+end FDRep

--- a/TauCeti/RepresentationTheory/FDRep.lean
+++ b/TauCeti/RepresentationTheory/FDRep.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.FDRep
+
+/-!
+# Finite-dimensional representations
+
+This file supplies general-purpose facts about Mathlib's category `FDRep`.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v
+
+/-- Forgetting finite generation keeps the finite-generation instance on the carrier. -/
+instance moduleFinite_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
+    (A : FDRep R G) : Module.Finite R ((forget₂ (FDRep R G) (Rep R G)).obj A) :=
+  inferInstanceAs (Module.Finite R A)
+
+/-- Forgetting finite-dimensionality does not change the dimension of the carrier. -/
+@[simp]
+theorem finrank_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
+    (A : FDRep R G) :
+    Module.finrank R ((forget₂ (FDRep R G) (Rep R G)).obj A) = Module.finrank R A :=
+  rfl
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Artin.lean
+++ b/TauCeti/RepresentationTheory/Induction/Artin.lean
@@ -54,6 +54,9 @@ Brauer's integral induction theorem, whose denominator is `1`.
   are exactly Artin's target.
 * `TauCeti.ClassFunction.exists_zsmul_mem_indVirtualCharacters_isElementary`: Artin's rational
   theorem, read for the elementary subgroups.
+
+## Implementation notes
+
 The lattice descent is a general statement about a `ℤ`-lattice inside a finite-dimensional vector
 space and has nothing to do with characters, but it is kept `private` here rather than given a home
 of its own in the linear-algebra hierarchy, there being exactly one use of it.

--- a/TauCeti/RepresentationTheory/Induction/Artin.lean
+++ b/TauCeti/RepresentationTheory/Induction/Artin.lean
@@ -54,12 +54,6 @@ Brauer's integral induction theorem, whose denominator is `1`.
   are exactly Artin's target.
 * `TauCeti.ClassFunction.exists_zsmul_mem_indVirtualCharacters_isElementary`: Artin's rational
   theorem, read for the elementary subgroups.
-## Implementation notes
-
-`k` and `G` lie in the same universe here, unlike in
-`TauCeti.RepresentationTheory.Induction.Spanning`, because the FDRep-level induction API used here
-(`TauCeti.indFDRep` and `TauCeti.ClassFunction.ind_ofFDRep`) is currently stated in one universe.
-
 The lattice descent is a general statement about a `ℤ`-lattice inside a finite-dimensional vector
 space and has nothing to do with characters, but it is kept `private` here rather than given a home
 of its own in the linear-algebra hierarchy, there being exactly one use of it.
@@ -160,7 +154,7 @@ private theorem exists_zsmul_mem_span_int {k V ι : Type*} [Field k] [CharZero k
     rw [smul_comm]
     exact Submodule.smul_mem _ _ hx
 
-variable {k G : Type u} [Field k] [Group G]
+variable {k : Type u} {G : Type v} [Field k] [Group G]
 variable [Finite G]
 
 variable (k G)

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -39,11 +39,11 @@ namespace TauCeti
 
 open CategoryTheory
 
-universe u
+universe u v
 
 namespace Rep
 
-variable {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+variable {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
 
 private abbrev RightCosets (S : Subgroup G) := Quotient (QuotientGroup.rightRel S)
 
@@ -144,7 +144,7 @@ end Rep
 
 section Forget
 
-variable {k G : Type u} [Field k] [Group G] (A : FDRep k G)
+variable {k : Type u} {G : Type v} [Field k] [Group G] (A : FDRep k G)
 
 /-- Forgetting finite-dimensionality keeps the same underlying module, so it keeps the
 `FiniteDimensional` instance. -/
@@ -165,7 +165,7 @@ end Forget
 open scoped Classical in
 /-- The induced character at `g` is the sum of the original character over those left coset
 representatives `t` for which `t⁻¹ g t` belongs to the subgroup. -/
-theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
+theorem character_indFDRep_sum_quotient {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) (g : G) :
     (indFDRep (k := k) (G := G) A).character g =
       letI := Fintype.ofFinite (G ⧸ S)
@@ -174,10 +174,10 @@ theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
           A.character ⟨(Quotient.out t)⁻¹ * g * Quotient.out t, h⟩
         else 0 := by
   have hindCharacter :
-      (indFDRep (k := k) (G := G) A).character g =
+    (indFDRep (k := k) (G := G) A).character g =
         (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ.character g :=
     (character_forget₂ (indFDRep (k := k) (G := G) A) g).symm.trans (congrFun
-      (Representation.char_iso (Representation.equivOfIso (indFDRepForgetIso A))) g)
+      (Representation.char_iso (indFDRepForgetEquiv A)) g)
   let := Fintype.ofFinite (G ⧸ S)
   let A' : Rep.{u} k S := (forget₂ (FDRep k S) (Rep k S)).obj A
   let : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
@@ -212,7 +212,7 @@ theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
 
 section ClassFun
 
-variable {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+variable {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
 
 /-- The character of an induced representation is the induced class function of its character. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -146,11 +146,6 @@ section Forget
 
 variable {k : Type u} {G : Type v} [Field k] [Group G] (A : FDRep k G)
 
-/-- Forgetting finite-dimensionality keeps the same underlying module, so it keeps the
-`FiniteDimensional` instance. -/
-private instance : FiniteDimensional k ((forget₂ (FDRep k G) (Rep k G)).obj A) :=
-  inferInstanceAs (FiniteDimensional k A)
-
 /-- The forgetful functor `FDRep k G ⥤ Rep k G` preserves characters. -/
 private theorem character_forget₂ (g : G) :
     ((forget₂ (FDRep k G) (Rep k G)).obj A).ρ.character g = A.character g := by

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -314,20 +314,6 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
   Rep.mkIso (indFDRepForgetEquiv A)
 
-/-- The hom of the categorical comparison applies its underlying equivariant equivalence. -/
-private theorem indFDRepForgetIso_hom_hom_apply {k G : Type u} [Field k] [Group G]
-    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S)
-    (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
-    (Rep.Hom.hom (indFDRepForgetIso A).hom) x = indFDRepForgetEquiv A x :=
-  rfl
-
-/-- The inverse of the categorical comparison applies the inverse equivariant equivalence. -/
-private theorem indFDRepForgetIso_inv_hom_apply {k G : Type u} [Field k] [Group G]
-    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S)
-    (x : Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)) :
-    (Rep.Hom.hom (indFDRepForgetIso A).inv) x = (indFDRepForgetEquiv A).symm x :=
-  rfl
-
 /-- `FDRep.forget₂HomLinearEquiv` is inverse to the forgetful functor on morphisms. -/
 private theorem forget₂_map_forget₂HomLinearEquiv {R : Type u} {G : Type v}
     [CommRing R] [Monoid G] (X Y : FDRep R G)
@@ -370,11 +356,14 @@ theorem forget₂_map_indFDRepMap {k G : Type u} [Field k] [Group G] {S : Subgro
           (indFDRepForgetIso B).inv := by
   apply Rep.hom_ext
   ext x
-  simp only [FGModuleCat.obj_carrier, Rep.hom_comp,
-    Representation.IntertwiningMap.comp_toLinearMap, LinearMap.coe_comp,
-    Representation.IntertwiningMap.coe_toLinearMap, Function.comp_apply,
-    indFDRepMap_apply, Rep.indFunctor_map]
-  rw [indFDRepForgetIso_hom_hom_apply, indFDRepForgetIso_inv_hom_apply]
+  -- Mathlib's `Rep.mkIso` projection lemmas do not match across the definitionally equal
+  -- `Field`- and `CommRing`-derived representation structures here, so normalize the categorical
+  -- composites to the characteristic pointwise statement in one step.
+  change ((forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f)).hom x =
+    (indFDRepForgetEquiv B).symm
+      ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
+        (indFDRepForgetEquiv A x))
+  exact indFDRepMap_apply f x
 
 /-- Induction of intertwiners preserves identities. -/
 private theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
@@ -413,28 +402,23 @@ noncomputable def indFDRepFunctor {k : Type u} {G : Type v} [Field k] [Group G]
   map_id A := indFDRepMap_id A
   map_comp f g := indFDRepMap_comp f g
 
-/-- `indFDRepFunctor` acts on objects by `indFDRep`. This projection theorem exposes the defining
-object field while the functor construction remains opaque, so its proof is definitionally
-`rfl`. -/
+/-- `indFDRepFunctor` acts on objects by `indFDRep`. -/
 @[simp]
 theorem indFDRepFunctor_obj {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
-    (indFDRepFunctor (k := k) (S := S)).obj A = indFDRep A :=
-  (rfl)
+    (indFDRepFunctor (k := k) (S := S)).obj A = indFDRep A := by
+  -- This theorem exposes the defining object field while the functor itself remains opaque.
+  rfl
 
-/-- `indFDRepFunctor` acts on morphisms by `indFDRepMap`.
-
-The `eqToHom` transports are needed because `indFDRepFunctor` is opaque and its object projection
-is exposed propositionally by `indFDRepFunctor_obj`. Both projection proofs are definitionally
-`rfl`, so the transports and identity compositions reduce when this defining map field is proved.
-This lemma is intentionally not a simp rule because its propositionally necessary transports are
-not a useful normal form. -/
+/-- `indFDRepFunctor` acts on morphisms by `indFDRepMap`. -/
 theorem indFDRepFunctor_map {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :
     (indFDRepFunctor (k := k) (S := S)).map f =
       eqToHom (indFDRepFunctor_obj A) ≫ indFDRepMap f ≫
-        eqToHom (indFDRepFunctor_obj B).symm :=
-  (rfl)
+        eqToHom (indFDRepFunctor_obj B).symm := by
+  -- The transports reconcile the opaque object projections with the types of `indFDRepMap`.
+  -- They are not a useful simp normal form, so this projection is intentionally not a simp rule.
+  rfl
 
 /-- Under the forgetful functor to `Rep k G`, `indFDRepFunctor` is naturally isomorphic to
 Mathlib's induction functor, componentwise by `indFDRepForgetIso`. -/

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -6,9 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Dimension.Constructions
-public import Mathlib.RepresentationTheory.FDRep
 public import Mathlib.RepresentationTheory.FiniteIndex
 public import Mathlib.RingTheory.Finiteness.Small
+public import TauCeti.RepresentationTheory.FDRep
 
 /-!
 # Finite-dimensional induced representations
@@ -260,18 +260,6 @@ end Dimension
 
 end Rep
 
-/-- Forgetting finite generation keeps the finite-generation instance on the carrier. -/
-instance moduleFinite_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
-    (A : FDRep R G) : Module.Finite R ((forget₂ (FDRep R G) (Rep R G)).obj A) :=
-  inferInstanceAs (Module.Finite R A)
-
-/-- Forgetting finite-dimensionality does not change the dimension of the carrier. -/
-@[simp]
-theorem finrank_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
-    (A : FDRep R G) :
-    Module.finrank R ((forget₂ (FDRep R G) (Rep R G)).obj A) = Module.finrank R A :=
-  rfl
-
 /-- Conjugation by `Shrink.linearEquiv` gives an equivariant equivalence from the shrunk model
 back to the original representation. -/
 private noncomputable def shrinkRepEquiv {k : Type u} {G : Type v} {V : Type w}
@@ -392,14 +380,7 @@ theorem indFDRepMap_comp {k : Type u} {G : Type v} [Field k] [Group G] {S : Subg
   simp [hInd, f', g']
 
 /-- Induction from a finite-index subgroup, as a functor on finite-dimensional representations.
-It acts on objects as `indFDRep` and on intertwiners as `indFDRepMap`.
-
-`@[simps obj map]` supplies the projection lemmas `indFDRepFunctor_obj` and
-`indFDRepFunctor_map`. Both are proved by `rfl`, and the type of the second needs
-`indFDRepFunctor.obj A` to reduce to `indFDRep A`, so this definition is `@[expose]`. Exposing it
-publishes exactly those two projections: the construction of the morphism map lives in
-`indFDRepMap`, which stays opaque behind `indFDRepMap_apply`. -/
-@[expose, simps obj map]
+It acts on objects as `indFDRep` and on intertwiners as `indFDRepMap`. -/
 noncomputable def indFDRepFunctor {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G}
     [S.FiniteIndex] : FDRep k S ⥤ FDRep k G where
@@ -407,6 +388,22 @@ noncomputable def indFDRepFunctor {k : Type u} {G : Type v} [Field k] [Group G]
   map f := indFDRepMap f
   map_id A := indFDRepMap_id A
   map_comp f g := indFDRepMap_comp f g
+
+/-- `indFDRepFunctor` acts on objects by `indFDRep`. -/
+@[simp]
+theorem indFDRepFunctor_obj {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
+    (indFDRepFunctor (k := k) (S := S)).obj A = indFDRep A :=
+  (rfl)
+
+/-- `indFDRepFunctor` acts on morphisms by `indFDRepMap`. -/
+@[simp]
+theorem indFDRepFunctor_map {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :
+    (indFDRepFunctor (k := k) (S := S)).map f =
+      eqToHom (indFDRepFunctor_obj A) ≫ indFDRepMap f ≫
+        eqToHom (indFDRepFunctor_obj B).symm :=
+  (rfl)
 
 /-- Under the forgetful functor to `Rep k G`, `indFDRepFunctor` is naturally isomorphic to
 Mathlib's induction functor, componentwise by `indFDRepForgetIso`. -/

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -324,6 +324,14 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
   Rep.mkIso (indFDRepForgetEquiv A)
 
+/-- The hom of the categorical comparison applies its underlying equivariant equivalence. -/
+@[simp]
+private theorem indFDRepForgetIso_hom_hom_apply {k G : Type u} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S)
+    (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
+    (indFDRepForgetIso A).hom.hom x = indFDRepForgetEquiv A x :=
+  rfl
+
 /-- `FDRep.forget₂HomLinearEquiv` is inverse to the forgetful functor on morphisms. -/
 private theorem forget₂_map_forget₂HomLinearEquiv {R : Type u} {G : Type v}
     [CommRing R] [Monoid G] (X Y : FDRep R G)
@@ -354,7 +362,7 @@ theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Sub
         (indFDRepForgetEquiv A x)) := by
   simp only [indFDRepMap]
   rw [forget₂_map_forget₂HomLinearEquiv]
-  rfl
+  simp
 
 /-- Induction of intertwiners preserves identities. -/
 theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
@@ -407,19 +415,16 @@ noncomputable def indFDRepForgetNatIso {k G : Type u} [Field k] [Group G] {S : S
     indFDRepFunctor (k := k) (S := S) ⋙ forget₂ (FDRep k G) (Rep k G) ≅
       forget₂ (FDRep k S) (Rep k S) ⋙ Rep.indFunctor k S.subtype :=
   NatIso.ofComponents (fun A ↦ indFDRepForgetIso A) fun {A B} f ↦ by
-    -- Naturality is the cancellation of the conjugating isomorphisms in `indFDRepMap`.
     change (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) ≫ (indFDRepForgetIso B).hom =
       (indFDRepForgetIso A).hom ≫
         (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f)
     ext x
-    simp only [FGModuleCat.obj_carrier, Rep.hom_comp, Rep.indFunctor_obj, Rep.indFunctor_map]
-    -- `Rep.mkIso_hom_hom_apply` does not rewrite across the `CommRing`-derived representation
-    -- structure of `Rep` and the definitionally distinct `Field`-derived comparison structure.
-    change (indFDRepForgetEquiv B) ((indFDRepForgetEquiv B).symm
-        ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
-          (indFDRepForgetEquiv A x))) =
-      (Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
-        (indFDRepForgetEquiv A x)
+    rw [Rep.hom_comp, Rep.hom_comp, Representation.IntertwiningMap.comp_toLinearMap,
+      Representation.IntertwiningMap.comp_toLinearMap, LinearMap.comp_apply,
+      LinearMap.comp_apply]
+    simp only [Representation.IntertwiningMap.toLinearMap_apply]
+    rw [indFDRepMap_apply,
+      indFDRepForgetIso_hom_hom_apply, indFDRepForgetIso_hom_hom_apply]
     simp
 
 /-- The dimension of an induced representation is the subgroup index times the dimension of the

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -353,7 +353,7 @@ theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Sub
   simp
 
 /-- Induction of intertwiners preserves identities. -/
-theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
+private theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] (A : FDRep k S) : indFDRepMap (𝟙 A) = 𝟙 (indFDRep A) := by
   let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
   have hInd : Rep.indMap S.subtype (𝟙 A') = 𝟙 (Rep.ind S.subtype A') := by
@@ -365,7 +365,7 @@ theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgro
   simp [A', hInd]
 
 /-- Induction of intertwiners preserves composition. -/
-theorem indFDRepMap_comp {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
+private theorem indFDRepMap_comp {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] {A B C : FDRep k S} (f : A ⟶ B) (g : B ⟶ C) :
     indFDRepMap (f ≫ g) = indFDRepMap f ≫ indFDRepMap g := by
   let f' := (forget₂ (FDRep k S) (Rep k S)).map f

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -260,16 +260,16 @@ end Dimension
 
 end Rep
 
-/-- Forgetting finite-dimensionality keeps the finite-dimensional instance on the carrier. -/
-instance finiteDimensional_forgetFDRep {k : Type u} {G : Type v} [Field k] [Monoid G]
-    (A : FDRep k G) : FiniteDimensional k ((forget₂ (FDRep k G) (Rep k G)).obj A) :=
-  inferInstanceAs (FiniteDimensional k A)
+/-- Forgetting finite generation keeps the finite-generation instance on the carrier. -/
+instance moduleFinite_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
+    (A : FDRep R G) : Module.Finite R ((forget₂ (FDRep R G) (Rep R G)).obj A) :=
+  inferInstanceAs (Module.Finite R A)
 
 /-- Forgetting finite-dimensionality does not change the dimension of the carrier. -/
 @[simp]
-theorem finrank_forgetFDRep {k : Type u} {G : Type v} [Field k] [Monoid G]
-    (A : FDRep k G) :
-    Module.finrank k ((forget₂ (FDRep k G) (Rep k G)).obj A) = Module.finrank k A :=
+theorem finrank_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
+    (A : FDRep R G) :
+    Module.finrank R ((forget₂ (FDRep R G) (Rep R G)).obj A) = Module.finrank R A :=
   rfl
 
 /-- Conjugation by `Shrink.linearEquiv` gives an equivariant equivalence from the shrunk model
@@ -323,22 +323,23 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
   Rep.mkIso (indFDRepForgetEquiv A)
 
-/-- The linear map underlying the categorical comparison is the linear map of the equivariant
-comparison. -/
-private theorem indFDRepForgetIso_hom_toLinearMap {k G : Type u} [Field k] [Group G]
-    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
-    (indFDRepForgetIso A).hom.hom.toLinearMap = (indFDRepForgetEquiv A).toLinearMap := by
-  rw [indFDRepForgetIso]
+/-- `FDRep.forget₂HomLinearEquiv` is inverse to the forgetful functor on morphisms. -/
+private theorem forget₂_map_forget₂HomLinearEquiv {R : Type u} {G : Type v}
+    [CommRing R] [Monoid G] (X Y : FDRep R G)
+    (f : (forget₂ (FDRep R G) (Rep R G)).obj X ⟶
+      (forget₂ (FDRep R G) (Rep R G)).obj Y) :
+    (forget₂ (FDRep R G) (Rep R G)).map (FDRep.forget₂HomLinearEquiv X Y f) = f :=
   rfl
 
 /-- Induction of an intertwiner of finite-dimensional representations, obtained by conjugating
 Mathlib's induced intertwiner by the small-carrier comparison equivalences. -/
 noncomputable def indFDRepMap {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
-    [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) : indFDRep A ⟶ indFDRep B :=
-  FDRep.forget₂HomLinearEquiv _ _ (Rep.ofHom
+    [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) : indFDRep A ⟶ indFDRep B := by
+  let f' := Rep.ofHom
     ((indFDRepForgetEquiv B).symm.toIntertwiningMap.comp
       ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom.comp
-        (indFDRepForgetEquiv A).toIntertwiningMap)))
+        (indFDRepForgetEquiv A).toIntertwiningMap))
+  exact FDRep.forget₂HomLinearEquiv _ _ f'
 
 /-- `indFDRepMap` applies Mathlib's induced intertwiner between the two small-carrier comparison
 equivalences. -/
@@ -350,7 +351,8 @@ theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Sub
       (indFDRepForgetEquiv B).symm
       ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
         (indFDRepForgetEquiv A x)) := by
-  rw [indFDRepMap]
+  simp only [indFDRepMap]
+  rw [forget₂_map_forget₂HomLinearEquiv]
   rfl
 
 /-- Induction of intertwiners preserves identities. -/
@@ -363,8 +365,7 @@ theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgro
       𝟙 ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :=
     (forget₂ (FDRep k G) (Rep k G)).map_id (indFDRep A)
   have hInd : Rep.indMap S.subtype (𝟙 A') = 𝟙 (Rep.ind S.subtype A') := by
-    ext
-    rfl
+    simpa using (Rep.indFunctor k S.subtype).map_id A'
   apply (forget₂ (FDRep k G) (Rep k G)).map_injective
   apply Rep.hom_ext
   ext x
@@ -381,8 +382,7 @@ theorem indFDRepMap_comp {k : Type u} {G : Type v} [Field k] [Group G] {S : Subg
   let g' := (forget₂ (FDRep k S) (Rep k S)).map g
   have hInd : Rep.indMap S.subtype (f' ≫ g') =
       Rep.indMap S.subtype f' ≫ Rep.indMap S.subtype g' := by
-    ext
-    rfl
+    simpa using (Rep.indFunctor k S.subtype).map_comp f' g'
   apply (forget₂ (FDRep k G) (Rep k G)).map_injective
   apply Rep.hom_ext
   ext x
@@ -422,10 +422,14 @@ noncomputable def indFDRepForgetNatIso {k G : Type u} [Field k] [Group G] {S : S
     ext x
     rw [Rep.hom_comp, Rep.hom_comp, Representation.IntertwiningMap.comp_toLinearMap,
       Representation.IntertwiningMap.comp_toLinearMap, LinearMap.comp_apply,
-      LinearMap.comp_apply, indFDRepMap_apply, indFDRepForgetIso_hom_toLinearMap,
-      indFDRepForgetIso_hom_toLinearMap]
-    -- The remaining equation is exactly cancellation of the comparison equivalence and its inverse.
-    change (indFDRepForgetEquiv B) ((indFDRepForgetEquiv B).symm _) = _
+      LinearMap.comp_apply, indFDRepMap_apply]
+    simp only [indFDRepForgetIso]
+    -- Unpack the `Rep.mkIso` applications; no public lemma states this mixed wrapper equation.
+    change (indFDRepForgetEquiv B) ((indFDRepForgetEquiv B).symm
+        ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
+          (indFDRepForgetEquiv A x))) =
+      (Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
+        (indFDRepForgetEquiv A x)
     simp
 
 /-- The dimension of an induced representation is the subgroup index times the dimension of the
@@ -434,7 +438,6 @@ original representation. -/
 theorem finrank_indFDRep {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] (A : FDRep k S) :
     Module.finrank k (indFDRep A) = S.index * Module.finrank k A := by
-  let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
   rw [← finrank_forgetFDRep (indFDRep A),
     LinearEquiv.finrank_eq (indFDRepForgetEquiv A).toLinearEquiv,
     Rep.finrank_ind, finrank_forgetFDRep]

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -261,58 +261,59 @@ end Dimension
 end Rep
 
 /-- Forgetting finite-dimensionality keeps the finite-dimensional instance on the carrier. -/
-instance finiteDimensional_forgetFDRep {k : Type u} {G : Type v} [Field k] [Group G]
+instance finiteDimensional_forgetFDRep {k : Type u} {G : Type v} [Field k] [Monoid G]
     (A : FDRep k G) : FiniteDimensional k ((forget₂ (FDRep k G) (Rep k G)).obj A) :=
   inferInstanceAs (FiniteDimensional k A)
 
-/-- The small model used to realize Mathlib's possibly universe-large induced representation as
-an object of `FDRep`. -/
-private noncomputable def indShrunkFDRep {k : Type u} {G : Type v} [Field k] [Group G]
-    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) : FDRep k G := by
-  let V := Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)
-  letI : FiniteDimensional k V :=
-    @Rep.finiteDimensional_ind.{u, v, 0} k G inferInstance S inferInstance inferInstance _
-      inferInstance
+/-- Forgetting finite-dimensionality does not change the dimension of the carrier. -/
+@[simp]
+theorem finrank_forgetFDRep {k : Type u} {G : Type v} [Field k] [Monoid G]
+    (A : FDRep k G) :
+    Module.finrank k ((forget₂ (FDRep k G) (Rep k G)).obj A) = Module.finrank k A :=
+  rfl
+
+/-- Conjugation by `Shrink.linearEquiv` gives an equivariant equivalence from the shrunk model
+back to the original representation. -/
+private noncomputable def shrinkRepEquiv {k : Type u} {G : Type v} {V : Type w}
+    [Field k] [Group G] [AddCommGroup V] [Module k V] [Small.{u} V]
+    (ρ : Representation k G V) :
+    Representation.Equiv
+      ((Shrink.linearEquiv k V).symm.conjRingEquiv.toMonoidHom.comp ρ) ρ := by
+  apply Representation.Equiv.mk (Shrink.linearEquiv k V)
+  intro g
+  ext x
+  simp
+
+/-- The small induced object together with its comparison to Mathlib's induced representation. -/
+private structure IndSmallModel {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) where
+  object : FDRep k G
+  equiv : ((forget₂ (FDRep k G) (Rep k G)).obj object).ρ.Equiv
+    (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ
+
+/-- Construct the small induced object and comparison equivalence with one choice of shrinking
+data. -/
+private noncomputable def indSmallModel {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) : IndSmallModel A := by
+  let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
+  let V := Rep.ind S.subtype A'
+  letI : FiniteDimensional k V := Rep.finiteDimensional_ind.{u, v, 0} A'
   letI : Small.{u} V := Module.Finite.small k V
-  exact FDRep.of ((Shrink.linearEquiv k V).symm.conjRingEquiv.toMonoidHom.comp V.ρ)
+  let ρ := (Shrink.linearEquiv k V).symm.conjRingEquiv.toMonoidHom.comp V.ρ
+  exact { object := FDRep.of ρ, equiv := shrinkRepEquiv V.ρ }
 
 /-- The finite-dimensional representation induced from a finite-index subgroup. -/
 noncomputable def indFDRep {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] (A : FDRep k S) : FDRep k G :=
-  indShrunkFDRep A
-
-/-- The action of `indFDRep` is the action of its shrunk model. -/
-private theorem indFDRep_ρ {k : Type u} {G : Type v} [Field k] [Group G]
-    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
-    (indFDRep A).ρ = (indShrunkFDRep A).ρ :=
-  rfl
+  (indSmallModel A).object
 
 /-- The small carrier chosen by `indFDRep` is equivariantly linearly equivalent to Mathlib's
 possibly universe-large induced representation. -/
 noncomputable def indFDRepForgetEquiv {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
     ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)).ρ.Equiv
-      (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ := by
-  let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
-  let V := Rep.ind S.subtype A'
-  letI : FiniteDimensional k V :=
-    @Rep.finiteDimensional_ind.{u, v, 0} k G inferInstance S inferInstance inferInstance _
-      inferInstance
-  letI : Small.{u} V := Module.Finite.small k V
-  apply Representation.Equiv.mk (Shrink.linearEquiv k V)
-  intro g
-  ext x
-  change (Shrink.linearEquiv k V)
-      ((Shrink.linearEquiv k V).symm.conj (V.ρ g) x) =
-    V.ρ g (Shrink.linearEquiv k V x)
-  simp
-
-/-- The carrier of `indFDRep A` is linearly equivalent to the carrier of Mathlib's induced
-representation. -/
-noncomputable def indFDRepForgetLinearEquiv {k : Type u} {G : Type v} [Field k] [Group G]
-    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
-    indFDRep A ≃ₗ[k] Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
-  (indFDRepForgetEquiv A).toLinearEquiv
+      (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ :=
+  (indSmallModel A).equiv
 
 /-- Same-universe categorical wrapper around `indFDRepForgetEquiv`: forgetting
 finite-dimensionality from `indFDRep` recovers Mathlib's induced representation. -/
@@ -321,6 +322,14 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
     (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A) ≅
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
   Rep.mkIso (indFDRepForgetEquiv A)
+
+/-- The linear map underlying the categorical comparison is the linear map of the equivariant
+comparison. -/
+private theorem indFDRepForgetIso_hom_toLinearMap {k G : Type u} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
+    (indFDRepForgetIso A).hom.hom.toLinearMap = (indFDRepForgetEquiv A).toLinearMap := by
+  rw [indFDRepForgetIso]
+  rfl
 
 /-- Induction of an intertwiner of finite-dimensional representations, obtained by conjugating
 Mathlib's induced intertwiner by the small-carrier comparison equivalences. -/
@@ -331,56 +340,56 @@ noncomputable def indFDRepMap {k : Type u} {G : Type v} [Field k] [Group G] {S :
       ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom.comp
         (indFDRepForgetEquiv A).toIntertwiningMap)))
 
-/-- The underlying intertwiner of `indFDRepMap` is Mathlib's induced intertwiner conjugated by the
-small-carrier comparison equivalences. -/
+/-- `indFDRepMap` applies Mathlib's induced intertwiner between the two small-carrier comparison
+equivalences. -/
 @[simp]
-theorem forget₂_map_indFDRepMap_hom {k : Type u} {G : Type v} [Field k] [Group G]
-    {S : Subgroup G}
-    [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :
-    ((forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f)).hom =
-      (indFDRepForgetEquiv B).symm.toIntertwiningMap.comp
-        ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom.comp
-          (indFDRepForgetEquiv A).toIntertwiningMap) := by
+theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
+    [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B)
+    (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
+    ((forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f)).hom.toLinearMap x =
+      (indFDRepForgetEquiv B).symm
+      ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
+        (indFDRepForgetEquiv A x)) := by
   rw [indFDRepMap]
   rfl
 
 /-- Induction of intertwiners preserves identities. -/
 theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] (A : FDRep k S) : indFDRepMap (𝟙 A) = 𝟙 (indFDRep A) := by
+  let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
+  have hForget : (forget₂ (FDRep k S) (Rep k S)).map (𝟙 A) = 𝟙 A' :=
+    (forget₂ (FDRep k S) (Rep k S)).map_id A
+  have hForgetInd : (forget₂ (FDRep k G) (Rep k G)).map (𝟙 (indFDRep A)) =
+      𝟙 ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :=
+    (forget₂ (FDRep k G) (Rep k G)).map_id (indFDRep A)
+  have hInd : Rep.indMap S.subtype (𝟙 A') = 𝟙 (Rep.ind S.subtype A') := by
+    ext
+    rfl
   apply (forget₂ (FDRep k G) (Rep k G)).map_injective
   apply Rep.hom_ext
-  rw [forget₂_map_indFDRepMap_hom]
-  let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
-  have hInd := (Rep.indFunctor k S.subtype).map_id A'
-  change Rep.indMap S.subtype (𝟙 A') = 𝟙 (Rep.ind S.subtype A') at hInd
-  change (indFDRepForgetEquiv A).symm.toIntertwiningMap.comp
-      ((Rep.indMap S.subtype (𝟙 A')).hom.comp
-        (indFDRepForgetEquiv A).toIntertwiningMap) =
-    Representation.IntertwiningMap.id
-      ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)).ρ
-  rw [hInd]
   ext x
+  rw [indFDRepMap_apply, hForget, hInd, hForgetInd]
+  -- Unpack the identity intertwiner before cancelling the comparison equivalence.
+  change (indFDRepForgetEquiv A).symm (indFDRepForgetEquiv A x) = x
   simp
 
 /-- Induction of intertwiners preserves composition. -/
 theorem indFDRepMap_comp {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] {A B C : FDRep k S} (f : A ⟶ B) (g : B ⟶ C) :
     indFDRepMap (f ≫ g) = indFDRepMap f ≫ indFDRepMap g := by
+  let f' := (forget₂ (FDRep k S) (Rep k S)).map f
+  let g' := (forget₂ (FDRep k S) (Rep k S)).map g
+  have hInd : Rep.indMap S.subtype (f' ≫ g') =
+      Rep.indMap S.subtype f' ≫ Rep.indMap S.subtype g' := by
+    ext
+    rfl
   apply (forget₂ (FDRep k G) (Rep k G)).map_injective
   apply Rep.hom_ext
-  rw [forget₂_map_indFDRepMap_hom]
-  simp only [Functor.map_comp, Rep.hom_comp, forget₂_map_indFDRepMap_hom]
-  have hInd := (Rep.indFunctor k S.subtype).map_comp
-    ((forget₂ (FDRep k S) (Rep k S)).map f)
-    ((forget₂ (FDRep k S) (Rep k S)).map g)
-  change Rep.indMap S.subtype
-      (((forget₂ (FDRep k S) (Rep k S)).map f) ≫
-        (forget₂ (FDRep k S) (Rep k S)).map g) =
-    Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f) ≫
-      Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map g) at hInd
-  rw [hInd, Rep.hom_comp]
   ext x
-  simp
+  rw [Functor.map_comp, Rep.hom_comp, Representation.IntertwiningMap.comp_toLinearMap,
+    LinearMap.comp_apply, indFDRepMap_apply, Functor.map_comp, hInd, Rep.hom_comp,
+    Representation.IntertwiningMap.comp_apply, indFDRepMap_apply, indFDRepMap_apply]
+  simp [f', g']
 
 /-- Induction from a finite-index subgroup, as a functor on finite-dimensional representations.
 It acts on objects as `indFDRep` and on intertwiners as `indFDRepMap`.
@@ -389,7 +398,7 @@ It acts on objects as `indFDRep` and on intertwiners as `indFDRepMap`.
 `indFDRepFunctor_map`. Both are proved by `rfl`, and the type of the second needs
 `indFDRepFunctor.obj A` to reduce to `indFDRep A`, so this definition is `@[expose]`. Exposing it
 publishes exactly those two projections: the construction of the morphism map lives in
-`indFDRepMap`, which stays opaque behind `forget₂_map_indFDRepMap_hom`. -/
+`indFDRepMap`, which stays opaque behind `indFDRepMap_apply`. -/
 @[expose, simps obj map]
 noncomputable def indFDRepFunctor {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G}
@@ -410,15 +419,13 @@ noncomputable def indFDRepForgetNatIso {k G : Type u} [Field k] [Group G] {S : S
     change (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) ≫ (indFDRepForgetIso B).hom =
       (indFDRepForgetIso A).hom ≫
         (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f)
-    rw [indFDRepForgetIso, indFDRepForgetIso]
-    apply Rep.hom_ext
-    rw [Rep.hom_comp, Rep.hom_comp, forget₂_map_indFDRepMap_hom]
     ext x
-    change (indFDRepForgetEquiv B) ((indFDRepForgetEquiv B).symm
-        ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
-          ((indFDRepForgetEquiv A) x))) =
-      (Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
-        ((indFDRepForgetEquiv A) x)
+    rw [Rep.hom_comp, Rep.hom_comp, Representation.IntertwiningMap.comp_toLinearMap,
+      Representation.IntertwiningMap.comp_toLinearMap, LinearMap.comp_apply,
+      LinearMap.comp_apply, indFDRepMap_apply, indFDRepForgetIso_hom_toLinearMap,
+      indFDRepForgetIso_hom_toLinearMap]
+    -- The remaining equation is exactly cancellation of the comparison equivalence and its inverse.
+    change (indFDRepForgetEquiv B) ((indFDRepForgetEquiv B).symm _) = _
     simp
 
 /-- The dimension of an induced representation is the subgroup index times the dimension of the
@@ -428,9 +435,8 @@ theorem finrank_indFDRep {k : Type u} {G : Type v} [Field k] [Group G] {S : Subg
     [S.FiniteIndex] (A : FDRep k S) :
     Module.finrank k (indFDRep A) = S.index * Module.finrank k A := by
   let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
-  rw [LinearEquiv.finrank_eq (indFDRepForgetLinearEquiv A)]
-  convert Rep.finrank_ind A' using 1
-  change S.index * Module.finrank k A = S.index * Module.finrank k A
-  rfl
+  rw [← finrank_forgetFDRep (indFDRep A),
+    LinearEquiv.finrank_eq (indFDRepForgetEquiv A).toLinearEquiv,
+    Rep.finrank_ind, finrank_forgetFDRep]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.Dimension.Constructions
 public import Mathlib.RepresentationTheory.FDRep
 public import Mathlib.RepresentationTheory.FiniteIndex
+public import Mathlib.RingTheory.Finiteness.Small
 
 /-!
 # Finite-dimensional induced representations
@@ -20,6 +21,11 @@ dimension formula
 Induction on finite-dimensional representations is packaged both objectwise, as `indFDRep`, and
 functorially, as `indFDRepFunctor`, the latter naturally isomorphic to `Rep.indFunctor` under the
 forgetful functor to `Rep k G`.
+
+The objectwise construction, its character formula, and its dimension theorem allow the scalar
+field and group to live in separate universes.  It uses a small model of Mathlib's induced carrier,
+compared by `indFDRepForgetEquiv`.  The categorical functor and natural isomorphism retain a common
+universe because a `Rep`-category is indexed by one carrier universe.
 
 ## References
 
@@ -90,7 +96,7 @@ theorem rightCosetFactor_out (q : Quotient (QuotientGroup.rightRel S)) :
 /-- Coinduction from a subgroup is linearly equivalent to a product of copies of the original
 representation indexed by the right cosets. The forward map evaluates an equivariant function at
 the chosen representative of each right coset. -/
-noncomputable def coindSubtypeEquivPi (A : Rep.{max u v w} k S) :
+noncomputable def coindSubtypeEquivPi (A : Rep.{max w u} k S) :
     Rep.coind S.subtype A ≃ₗ[k]
       (Quotient (QuotientGroup.rightRel S) → A) where
   toFun f q := f.1 q.out
@@ -126,7 +132,7 @@ noncomputable def coindSubtypeEquivPi (A : Rep.{max u v w} k S) :
 
 /-- The coset model evaluates a coinduced function at the chosen representative. -/
 @[simp]
-theorem coindSubtypeEquivPi_apply (A : Rep.{max u v w} k S)
+theorem coindSubtypeEquivPi_apply (A : Rep.{max w u} k S)
     (f : Rep.coind S.subtype A) (q : Quotient (QuotientGroup.rightRel S)) :
     coindSubtypeEquivPi A f q = f.1 q.out := by
   rw [coindSubtypeEquivPi]
@@ -134,7 +140,7 @@ theorem coindSubtypeEquivPi_apply (A : Rep.{max u v w} k S)
 
 /-- The inverse coset model extends a value from each representative by `S`-equivariance. -/
 @[simp]
-theorem coindSubtypeEquivPi_symm_apply (A : Rep.{max u v w} k S)
+theorem coindSubtypeEquivPi_symm_apply (A : Rep.{max w u} k S)
     (x : Quotient (QuotientGroup.rightRel S) → A) (g : G) : ((coindSubtypeEquivPi A).symm x).1 g =
       A.ρ (rightCosetFactor (S := S) g) (x (Quotient.mk'' g)) := by
   rw [coindSubtypeEquivPi]
@@ -146,7 +152,7 @@ theorem coindSubtypeEquivPi_symm_apply (A : Rep.{max u v w} k S)
 Not a `simp` lemma: Mathlib's `@[simps]` on `Representation.coind` rewrites
 `(Rep.coind φ A).ρ g` to its underlying `LinearMap`, so this left-hand side is not in `simp`
 normal form. Mathlib states its own action lemma `Representation.ind_mk` the same way. -/
-theorem coindSubtypeEquivPi_ρ_apply (A : Rep.{max u v w} k S) (g : G)
+theorem coindSubtypeEquivPi_ρ_apply (A : Rep.{max w u} k S) (g : G)
     (f : Rep.coind S.subtype A) (q : Quotient (QuotientGroup.rightRel S)) :
     coindSubtypeEquivPi A ((Rep.coind S.subtype A).ρ g f) q =
       A.ρ (rightCosetFactor (S := S) (q.out * g))
@@ -168,13 +174,13 @@ theorem coindSubtypeEquivPi_ρ_apply (A : Rep.{max u v w} k S) (g : G)
 
 /-- The underlying vector space of induction from a finite-index subgroup is a product of copies
 of the original representation indexed by the right cosets. -/
-noncomputable def indSubtypeEquivPi [S.FiniteIndex] (A : Rep.{max u v w} k S) :
+noncomputable def indSubtypeEquivPi [S.FiniteIndex] (A : Rep.{max w u} k S) :
     Rep.ind S.subtype A ≃ₗ[k]
       (Quotient (QuotientGroup.rightRel S) → A) := by
   letI : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
   exact
     ((forget₂ (Rep k G) (ModuleCat k)).mapIso
-      (Rep.indCoindIso.{max u v w, u, v} A)).toLinearEquiv.trans (coindSubtypeEquivPi A)
+      (Rep.indCoindIso.{w, u, v} A)).toLinearEquiv.trans (coindSubtypeEquivPi A)
 
 /-- The coset model of induction transports along `Rep.indCoindIso` and then evaluates at the
 chosen representative of each right coset.
@@ -182,11 +188,11 @@ chosen representative of each right coset.
 Not a `simp` lemma: its right-hand side names `Rep.indCoindIso`, so rewriting with it replaces
 the coset model by the comparison isomorphism it is built from. The intended interface is
 `indSubtypeEquivPi_ρ_apply`, which stays inside the coset model. -/
-theorem indSubtypeEquivPi_apply [S.FiniteIndex] (A : Rep.{max u v w} k S)
+theorem indSubtypeEquivPi_apply [S.FiniteIndex] (A : Rep.{max w u} k S)
     (x : Rep.ind S.subtype A) (q : Quotient (QuotientGroup.rightRel S)) :
     indSubtypeEquivPi A x q =
       ((letI : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
-        Rep.indCoindIso.{max u v w, u, v} A).hom.hom x).1 q.out := by
+        Rep.indCoindIso.{w, u, v} A).hom.hom x).1 q.out := by
   let : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
   rw [indSubtypeEquivPi]
   rfl
@@ -196,10 +202,10 @@ along `Rep.indCoindIso`.
 
 Not a `simp` lemma, for the same reason as `indSubtypeEquivPi_apply`: it rewrites the coset
 model into the comparison isomorphism. -/
-theorem indSubtypeEquivPi_symm_apply [S.FiniteIndex] (A : Rep.{max u v w} k S)
+theorem indSubtypeEquivPi_symm_apply [S.FiniteIndex] (A : Rep.{max w u} k S)
     (x : Quotient (QuotientGroup.rightRel S) → A) : (indSubtypeEquivPi A).symm x =
       (letI : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
-       Rep.indCoindIso.{max u v w, u, v} A).inv.hom
+       Rep.indCoindIso.{w, u, v} A).inv.hom
         ((coindSubtypeEquivPi A).symm x) := by
   let : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
   rw [indSubtypeEquivPi]
@@ -211,7 +217,7 @@ trace computation over the coset model consumes.
 
 Not a `simp` lemma, for the same reason as `coindSubtypeEquivPi_ρ_apply`: `@[simps]` on
 `Representation.ind` takes `(Rep.ind φ A).ρ g` out of `simp` normal form. -/
-theorem indSubtypeEquivPi_ρ_apply [S.FiniteIndex] (A : Rep.{max u v w} k S) (g : G)
+theorem indSubtypeEquivPi_ρ_apply [S.FiniteIndex] (A : Rep.{max w u} k S) (g : G)
     (x : Rep.ind S.subtype A) (q : Quotient (QuotientGroup.rightRel S)) :
     indSubtypeEquivPi A ((Rep.ind S.subtype A).ρ g x) q =
       A.ρ (rightCosetFactor (S := S) (q.out * g))
@@ -226,7 +232,7 @@ section Dimension
 variable [Field k]
 
 /-- Induction from a finite-index subgroup preserves finite-dimensionality. -/
-noncomputable instance finiteDimensional_ind [S.FiniteIndex] (A : Rep.{max u v w} k S)
+noncomputable instance finiteDimensional_ind [S.FiniteIndex] (A : Rep.{max w u} k S)
     [FiniteDimensional k A] : FiniteDimensional k (Rep.ind S.subtype A) := by
   let : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
   let := S.fintypeQuotientOfFiniteIndex
@@ -239,7 +245,7 @@ noncomputable instance finiteDimensional_ind [S.FiniteIndex] (A : Rep.{max u v w
 /-- The dimension of induction from a finite-index subgroup is the index times the original
 dimension. -/
 @[simp]
-theorem finrank_ind [S.FiniteIndex] (A : Rep.{max u v w} k S) [FiniteDimensional k A] :
+theorem finrank_ind [S.FiniteIndex] (A : Rep.{max w u} k S) [FiniteDimensional k A] :
     Module.finrank k (Rep.ind S.subtype A) = S.index * Module.finrank k A := by
   let : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
   let := S.fintypeQuotientOfFiniteIndex
@@ -254,23 +260,48 @@ end Dimension
 end Rep
 
 /-- The finite-dimensional representation induced from a finite-index subgroup. -/
-noncomputable def indFDRep {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+noncomputable def indFDRep {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] (A : FDRep k S) : FDRep k G := by
   let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
   -- Register the finite-dimensional structure hidden behind the forgetful object's wrapper.
   letI : FiniteDimensional k A' := by
+    -- The forgetful functor preserves the carrier, but its object wrapper hides that fact.
     change FiniteDimensional k A
     infer_instance
-  exact FDRep.of (Rep.ind S.subtype A').ρ
+  let V := Rep.ind S.subtype A'
+  letI : Small.{u} V := Module.Finite.small k V
+  let e := Shrink.linearEquiv k V
+  exact FDRep.of (e.symm.conjRingEquiv.toMonoidHom.comp V.ρ)
 
-/-- Forgetting finite-dimensionality from `indFDRep` recovers Mathlib's induced representation.
-This is the one place where the two objects are identified; everything below about `indFDRep` is
-stated and proved through this isomorphism. -/
+/-- The small carrier chosen by `indFDRep` is equivariantly linearly equivalent to Mathlib's
+possibly universe-large induced representation. -/
+noncomputable def indFDRepForgetEquiv {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
+    ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)).ρ.Equiv
+      (Representation.ind S.subtype A.ρ) := by
+  let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
+  letI : FiniteDimensional k A' := by
+    -- The forgetful functor preserves the carrier, but its object wrapper hides that fact.
+    change FiniteDimensional k A
+    infer_instance
+  let V := Rep.ind S.subtype A'
+  letI : Small.{u} V := Module.Finite.small k V
+  apply Representation.Equiv.mk (Shrink.linearEquiv k V)
+  intro g
+  ext x
+  -- Unfold the action chosen by `FDRep.of`; it is conjugation along the shrink equivalence.
+  change (Shrink.linearEquiv k V)
+      ((Shrink.linearEquiv k V).symm.conj (V.ρ g) x) =
+    V.ρ g (Shrink.linearEquiv k V x)
+  simp
+
+/-- Same-universe categorical wrapper around `indFDRepForgetEquiv`: forgetting
+finite-dimensionality from `indFDRep` recovers Mathlib's induced representation. -/
 noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
     (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A) ≅
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
-  Iso.refl _
+  Rep.mkIso (indFDRepForgetEquiv A)
 
 /-- Induction of an intertwiner of finite-dimensional representations: Mathlib's `Rep.indFunctor`
 on the underlying intertwiner, conjugated by `indFDRepForgetIso` and transported back along the
@@ -343,14 +374,19 @@ noncomputable def indFDRepForgetNatIso {k G : Type u} [Field k] [Group G] {S : S
 /-- The dimension of an induced representation is the subgroup index times the dimension of the
 original representation. -/
 @[simp]
-theorem finrank_indFDRep {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+theorem finrank_indFDRep {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] (A : FDRep k S) :
     Module.finrank k (indFDRep A) = S.index * Module.finrank k A := by
   let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
   -- Register the finite-dimensional structure hidden behind the forgetful object's wrapper.
   let : FiniteDimensional k A' := by
+    -- The forgetful functor preserves the carrier, but its object wrapper hides that fact.
     change FiniteDimensional k A
     infer_instance
+  -- Reveal the forgetful carrier before transporting dimension along `indFDRepForgetEquiv`.
+  change Module.finrank k ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) =
+    S.index * Module.finrank k A'
+  rw [LinearEquiv.finrank_eq (indFDRepForgetEquiv A).toLinearEquiv]
   exact Rep.finrank_ind A'
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -275,7 +275,7 @@ theorem finrank_forgetFDRep {R : Type u} {G : Type v} [CommRing R] [Monoid G]
 /-- Conjugation by `Shrink.linearEquiv` gives an equivariant equivalence from the shrunk model
 back to the original representation. -/
 private noncomputable def shrinkRepEquiv {k : Type u} {G : Type v} {V : Type w}
-    [Field k] [Group G] [AddCommGroup V] [Module k V] [Small.{u} V]
+    [CommSemiring k] [Monoid G] [AddCommMonoid V] [Module k V] [Small.{u} V]
     (ρ : Representation k G V) :
     Representation.Equiv
       ((Shrink.linearEquiv k V).symm.conjRingEquiv.toMonoidHom.comp ρ) ρ := by
@@ -297,6 +297,7 @@ private noncomputable def indSmallModel {k : Type u} {G : Type v} [Field k] [Gro
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) : IndSmallModel A := by
   let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
   let V := Rep.ind S.subtype A'
+  -- The forgotten carrier lies in `u`, so `w := 0` specializes `max w u` to `u`.
   letI : FiniteDimensional k V := Rep.finiteDimensional_ind.{u, v, 0} A'
   letI : Small.{u} V := Module.Finite.small k V
   let ρ := (Shrink.linearEquiv k V).symm.conjRingEquiv.toMonoidHom.comp V.ρ
@@ -347,7 +348,7 @@ equivalences. -/
 theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B)
     (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
-    ((forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f)).hom.toLinearMap x =
+    ((forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f)).hom x =
       (indFDRepForgetEquiv B).symm
       ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
         (indFDRepForgetEquiv A x)) := by
@@ -359,20 +360,13 @@ theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Sub
 theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] (A : FDRep k S) : indFDRepMap (𝟙 A) = 𝟙 (indFDRep A) := by
   let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
-  have hForget : (forget₂ (FDRep k S) (Rep k S)).map (𝟙 A) = 𝟙 A' :=
-    (forget₂ (FDRep k S) (Rep k S)).map_id A
-  have hForgetInd : (forget₂ (FDRep k G) (Rep k G)).map (𝟙 (indFDRep A)) =
-      𝟙 ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :=
-    (forget₂ (FDRep k G) (Rep k G)).map_id (indFDRep A)
   have hInd : Rep.indMap S.subtype (𝟙 A') = 𝟙 (Rep.ind S.subtype A') := by
     simpa using (Rep.indFunctor k S.subtype).map_id A'
   apply (forget₂ (FDRep k G) (Rep k G)).map_injective
   apply Rep.hom_ext
   ext x
-  rw [indFDRepMap_apply, hForget, hInd, hForgetInd]
-  -- Unpack the identity intertwiner before cancelling the comparison equivalence.
-  change (indFDRepForgetEquiv A).symm (indFDRepForgetEquiv A x) = x
-  simp
+  simp only [Representation.IntertwiningMap.toLinearMap_apply]
+  simp [A', hInd]
 
 /-- Induction of intertwiners preserves composition. -/
 theorem indFDRepMap_comp {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
@@ -386,10 +380,8 @@ theorem indFDRepMap_comp {k : Type u} {G : Type v} [Field k] [Group G] {S : Subg
   apply (forget₂ (FDRep k G) (Rep k G)).map_injective
   apply Rep.hom_ext
   ext x
-  rw [Functor.map_comp, Rep.hom_comp, Representation.IntertwiningMap.comp_toLinearMap,
-    LinearMap.comp_apply, indFDRepMap_apply, Functor.map_comp, hInd, Rep.hom_comp,
-    Representation.IntertwiningMap.comp_apply, indFDRepMap_apply, indFDRepMap_apply]
-  simp [f', g']
+  simp only [Representation.IntertwiningMap.toLinearMap_apply]
+  simp [hInd, f', g']
 
 /-- Induction from a finite-index subgroup, as a functor on finite-dimensional representations.
 It acts on objects as `indFDRep` and on intertwiners as `indFDRepMap`.
@@ -420,11 +412,9 @@ noncomputable def indFDRepForgetNatIso {k G : Type u} [Field k] [Group G] {S : S
       (indFDRepForgetIso A).hom ≫
         (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f)
     ext x
-    rw [Rep.hom_comp, Rep.hom_comp, Representation.IntertwiningMap.comp_toLinearMap,
-      Representation.IntertwiningMap.comp_toLinearMap, LinearMap.comp_apply,
-      LinearMap.comp_apply, indFDRepMap_apply]
-    simp only [indFDRepForgetIso]
-    -- Unpack the `Rep.mkIso` applications; no public lemma states this mixed wrapper equation.
+    simp only [FGModuleCat.obj_carrier, Rep.hom_comp, Rep.indFunctor_obj, Rep.indFunctor_map]
+    -- `Rep.mkIso_hom_hom_apply` does not rewrite across the `CommRing`-derived representation
+    -- structure of `Rep` and the definitionally distinct `Field`-derived comparison structure.
     change (indFDRepForgetEquiv B) ((indFDRepForgetEquiv B).symm
         ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
           (indFDRepForgetEquiv A x))) =

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -289,6 +289,8 @@ private noncomputable def indSmallModel {k : Type u} {G : Type v} [Field k] [Gro
   letI : FiniteDimensional k V := Rep.finiteDimensional_ind.{u, v, 0} A'
   letI : Small.{u} V := Module.Finite.small k V
   let ρ := (Shrink.linearEquiv k V).symm.conjRingEquiv.toMonoidHom.comp V.ρ
+  -- `FDRep.of ρ` forgets back to `ρ` definitionally; Mathlib records the same identification as
+  -- `FDRep.forget₂_ρ` for rewriting outside this construction.
   exact { object := FDRep.of ρ, equiv := shrinkRepEquiv V.ρ }
 
 /-- The finite-dimensional representation induced from a finite-index subgroup. -/
@@ -389,14 +391,20 @@ noncomputable def indFDRepFunctor {k : Type u} {G : Type v} [Field k] [Group G]
   map_id A := indFDRepMap_id A
   map_comp f g := indFDRepMap_comp f g
 
-/-- `indFDRepFunctor` acts on objects by `indFDRep`. -/
+/-- `indFDRepFunctor` acts on objects by `indFDRep`. This projection theorem exposes the defining
+object field while the functor construction remains opaque, so its proof is definitionally
+`rfl`. -/
 @[simp]
 theorem indFDRepFunctor_obj {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
     (indFDRepFunctor (k := k) (S := S)).obj A = indFDRep A :=
   (rfl)
 
-/-- `indFDRepFunctor` acts on morphisms by `indFDRepMap`. -/
+/-- `indFDRepFunctor` acts on morphisms by `indFDRepMap`.
+
+The `eqToHom` transports are needed because `indFDRepFunctor` is opaque and its object projection
+is exposed propositionally by `indFDRepFunctor_obj`. Both projection proofs are definitionally
+`rfl`, so the transports and identity compositions reduce when this defining map field is proved. -/
 @[simp]
 theorem indFDRepFunctor_map {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -329,7 +329,7 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
 private theorem indFDRepForgetIso_hom_hom_apply {k G : Type u} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S)
     (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
-    (indFDRepForgetIso A).hom.hom x = indFDRepForgetEquiv A x :=
+    (Rep.Hom.hom (indFDRepForgetIso A).hom) x = indFDRepForgetEquiv A x :=
   rfl
 
 /-- `FDRep.forget₂HomLinearEquiv` is inverse to the forgetful functor on morphisms. -/
@@ -415,16 +415,20 @@ noncomputable def indFDRepForgetNatIso {k G : Type u} [Field k] [Group G] {S : S
     indFDRepFunctor (k := k) (S := S) ⋙ forget₂ (FDRep k G) (Rep k G) ≅
       forget₂ (FDRep k S) (Rep k S) ⋙ Rep.indFunctor k S.subtype :=
   NatIso.ofComponents (fun A ↦ indFDRepForgetIso A) fun {A B} f ↦ by
-    change (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) ≫ (indFDRepForgetIso B).hom =
+    -- The projection lemmas cannot rewrite the dependent source and target object casts in this
+    -- naturality goal, so expose those definitionally equal objects before simplifying morphisms.
+    change (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) ≫
+        (indFDRepForgetIso B).hom =
       (indFDRepForgetIso A).hom ≫
         (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f)
     ext x
-    rw [Rep.hom_comp, Rep.hom_comp, Representation.IntertwiningMap.comp_toLinearMap,
-      Representation.IntertwiningMap.comp_toLinearMap, LinearMap.comp_apply,
-      LinearMap.comp_apply]
-    simp only [Representation.IntertwiningMap.toLinearMap_apply]
-    rw [indFDRepMap_apply,
-      indFDRepForgetIso_hom_hom_apply, indFDRepForgetIso_hom_hom_apply]
+    simp only [FGModuleCat.obj_carrier, Rep.hom_comp,
+      Representation.IntertwiningMap.comp_toLinearMap, LinearMap.coe_comp,
+      Representation.IntertwiningMap.coe_toLinearMap, Function.comp_apply,
+      indFDRepMap_apply, Rep.indFunctor_obj, Rep.indFunctor_map]
+    -- These two rewrites bridge definitionally distinct representation structures induced by the
+    -- `Field` and `CommRing` instances; `simp` cannot match them before this normalization.
+    rw [indFDRepForgetIso_hom_hom_apply, indFDRepForgetIso_hom_hom_apply]
     simp
 
 /-- The dimension of an induced representation is the subgroup index times the dimension of the

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -22,10 +22,11 @@ Induction on finite-dimensional representations is packaged both objectwise, as 
 functorially, as `indFDRepFunctor`, the latter naturally isomorphic to `Rep.indFunctor` under the
 forgetful functor to `Rep k G`.
 
-The objectwise construction, its character formula, and its dimension theorem allow the scalar
-field and group to live in separate universes.  It uses a small model of Mathlib's induced carrier,
-compared by `indFDRepForgetEquiv`.  The categorical functor and natural isomorphism retain a common
-universe because a `Rep`-category is indexed by one carrier universe.
+The objectwise construction, its character formula, dimension theorem, and functor on `FDRep`
+allow the scalar field and group to live in separate universes. It uses a small model of Mathlib's
+induced carrier, compared by `indFDRepForgetEquiv`. The comparison isomorphism and natural
+isomorphism into Mathlib's `Rep` category retain a common universe because that category is indexed
+by one carrier universe.
 
 ## References
 
@@ -96,7 +97,7 @@ theorem rightCosetFactor_out (q : Quotient (QuotientGroup.rightRel S)) :
 /-- Coinduction from a subgroup is linearly equivalent to a product of copies of the original
 representation indexed by the right cosets. The forward map evaluates an equivariant function at
 the chosen representative of each right coset. -/
-noncomputable def coindSubtypeEquivPi (A : Rep.{max w u} k S) :
+noncomputable def coindSubtypeEquivPi (A : Rep.{w} k S) :
     Rep.coind S.subtype A ≃ₗ[k]
       (Quotient (QuotientGroup.rightRel S) → A) where
   toFun f q := f.1 q.out
@@ -132,7 +133,7 @@ noncomputable def coindSubtypeEquivPi (A : Rep.{max w u} k S) :
 
 /-- The coset model evaluates a coinduced function at the chosen representative. -/
 @[simp]
-theorem coindSubtypeEquivPi_apply (A : Rep.{max w u} k S)
+theorem coindSubtypeEquivPi_apply (A : Rep.{w} k S)
     (f : Rep.coind S.subtype A) (q : Quotient (QuotientGroup.rightRel S)) :
     coindSubtypeEquivPi A f q = f.1 q.out := by
   rw [coindSubtypeEquivPi]
@@ -140,7 +141,7 @@ theorem coindSubtypeEquivPi_apply (A : Rep.{max w u} k S)
 
 /-- The inverse coset model extends a value from each representative by `S`-equivariance. -/
 @[simp]
-theorem coindSubtypeEquivPi_symm_apply (A : Rep.{max w u} k S)
+theorem coindSubtypeEquivPi_symm_apply (A : Rep.{w} k S)
     (x : Quotient (QuotientGroup.rightRel S) → A) (g : G) : ((coindSubtypeEquivPi A).symm x).1 g =
       A.ρ (rightCosetFactor (S := S) g) (x (Quotient.mk'' g)) := by
   rw [coindSubtypeEquivPi]
@@ -152,7 +153,7 @@ theorem coindSubtypeEquivPi_symm_apply (A : Rep.{max w u} k S)
 Not a `simp` lemma: Mathlib's `@[simps]` on `Representation.coind` rewrites
 `(Rep.coind φ A).ρ g` to its underlying `LinearMap`, so this left-hand side is not in `simp`
 normal form. Mathlib states its own action lemma `Representation.ind_mk` the same way. -/
-theorem coindSubtypeEquivPi_ρ_apply (A : Rep.{max w u} k S) (g : G)
+theorem coindSubtypeEquivPi_ρ_apply (A : Rep.{w} k S) (g : G)
     (f : Rep.coind S.subtype A) (q : Quotient (QuotientGroup.rightRel S)) :
     coindSubtypeEquivPi A ((Rep.coind S.subtype A).ρ g f) q =
       A.ρ (rightCosetFactor (S := S) (q.out * g))
@@ -259,41 +260,59 @@ end Dimension
 
 end Rep
 
+/-- Forgetting finite-dimensionality keeps the finite-dimensional instance on the carrier. -/
+instance finiteDimensional_forgetFDRep {k : Type u} {G : Type v} [Field k] [Group G]
+    (A : FDRep k G) : FiniteDimensional k ((forget₂ (FDRep k G) (Rep k G)).obj A) :=
+  inferInstanceAs (FiniteDimensional k A)
+
+/-- The small model used to realize Mathlib's possibly universe-large induced representation as
+an object of `FDRep`. -/
+private noncomputable def indShrunkFDRep {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) : FDRep k G := by
+  let V := Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)
+  letI : FiniteDimensional k V :=
+    @Rep.finiteDimensional_ind.{u, v, 0} k G inferInstance S inferInstance inferInstance _
+      inferInstance
+  letI : Small.{u} V := Module.Finite.small k V
+  exact FDRep.of ((Shrink.linearEquiv k V).symm.conjRingEquiv.toMonoidHom.comp V.ρ)
+
 /-- The finite-dimensional representation induced from a finite-index subgroup. -/
 noncomputable def indFDRep {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
-    [S.FiniteIndex] (A : FDRep k S) : FDRep k G := by
-  let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
-  -- Register the finite-dimensional structure hidden behind the forgetful object's wrapper.
-  letI : FiniteDimensional k A' := by
-    -- The forgetful functor preserves the carrier, but its object wrapper hides that fact.
-    change FiniteDimensional k A
-    infer_instance
-  let V := Rep.ind S.subtype A'
-  letI : Small.{u} V := Module.Finite.small k V
-  let e := Shrink.linearEquiv k V
-  exact FDRep.of (e.symm.conjRingEquiv.toMonoidHom.comp V.ρ)
+    [S.FiniteIndex] (A : FDRep k S) : FDRep k G :=
+  indShrunkFDRep A
+
+/-- The action of `indFDRep` is the action of its shrunk model. -/
+private theorem indFDRep_ρ {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
+    (indFDRep A).ρ = (indShrunkFDRep A).ρ :=
+  rfl
 
 /-- The small carrier chosen by `indFDRep` is equivariantly linearly equivalent to Mathlib's
 possibly universe-large induced representation. -/
 noncomputable def indFDRepForgetEquiv {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
     ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)).ρ.Equiv
-      (Representation.ind S.subtype A.ρ) := by
+      (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ := by
   let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
-  letI : FiniteDimensional k A' := by
-    -- The forgetful functor preserves the carrier, but its object wrapper hides that fact.
-    change FiniteDimensional k A
-    infer_instance
   let V := Rep.ind S.subtype A'
+  letI : FiniteDimensional k V :=
+    @Rep.finiteDimensional_ind.{u, v, 0} k G inferInstance S inferInstance inferInstance _
+      inferInstance
   letI : Small.{u} V := Module.Finite.small k V
   apply Representation.Equiv.mk (Shrink.linearEquiv k V)
   intro g
   ext x
-  -- Unfold the action chosen by `FDRep.of`; it is conjugation along the shrink equivalence.
   change (Shrink.linearEquiv k V)
       ((Shrink.linearEquiv k V).symm.conj (V.ρ g) x) =
     V.ρ g (Shrink.linearEquiv k V x)
   simp
+
+/-- The carrier of `indFDRep A` is linearly equivalent to the carrier of Mathlib's induced
+representation. -/
+noncomputable def indFDRepForgetLinearEquiv {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) :
+    indFDRep A ≃ₗ[k] Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
+  (indFDRepForgetEquiv A).toLinearEquiv
 
 /-- Same-universe categorical wrapper around `indFDRepForgetEquiv`: forgetting
 finite-dimensionality from `indFDRep` recovers Mathlib's induced representation. -/
@@ -303,44 +322,65 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
   Rep.mkIso (indFDRepForgetEquiv A)
 
-/-- Induction of an intertwiner of finite-dimensional representations: Mathlib's `Rep.indFunctor`
-on the underlying intertwiner, conjugated by `indFDRepForgetIso` and transported back along the
-fully faithful forgetful functor `FDRep k G ⥤ Rep k G`. Its characterizing property is
-`forget₂_map_indFDRepMap`; the definition itself is not exposed. -/
-noncomputable def indFDRepMap {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+/-- Induction of an intertwiner of finite-dimensional representations, obtained by conjugating
+Mathlib's induced intertwiner by the small-carrier comparison equivalences. -/
+noncomputable def indFDRepMap {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) : indFDRep A ⟶ indFDRep B :=
-  (forget₂ (FDRep k G) (Rep k G)).preimage
-    ((indFDRepForgetIso A).hom ≫
-      (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f) ≫
-        (indFDRepForgetIso B).inv)
+  FDRep.forget₂HomLinearEquiv _ _ (Rep.ofHom
+    ((indFDRepForgetEquiv B).symm.toIntertwiningMap.comp
+      ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom.comp
+        (indFDRepForgetEquiv A).toIntertwiningMap)))
 
-/-- Forgetting finite-dimensionality from `indFDRepMap` gives Mathlib's induced intertwiner,
-conjugated by `indFDRepForgetIso`. This is the only fact about `indFDRepMap` used below. -/
+/-- The underlying intertwiner of `indFDRepMap` is Mathlib's induced intertwiner conjugated by the
+small-carrier comparison equivalences. -/
 @[simp]
-theorem forget₂_map_indFDRepMap {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+theorem forget₂_map_indFDRepMap_hom {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G}
     [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :
-    (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) = (indFDRepForgetIso A).hom ≫
-        (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f) ≫
-          (indFDRepForgetIso B).inv := by
+    ((forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f)).hom =
+      (indFDRepForgetEquiv B).symm.toIntertwiningMap.comp
+        ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom.comp
+          (indFDRepForgetEquiv A).toIntertwiningMap) := by
   rw [indFDRepMap]
-  exact (forget₂ (FDRep k G) (Rep k G)).map_preimage _
+  rfl
 
 /-- Induction of intertwiners preserves identities. -/
-theorem indFDRepMap_id {k G : Type u} [Field k] [Group G] {S : Subgroup G}
-    [S.FiniteIndex] (A : FDRep k S) : indFDRepMap (𝟙 A) = 𝟙 (indFDRep A) :=
-  -- The law holds after applying the forgetful functor: the conjugating copies of
-  -- `indFDRepForgetIso` cancel, so the proof does not unfold `indFDRep`.
-  (forget₂ (FDRep k G) (Rep k G)).map_injective (by
-    simp only [forget₂_map_indFDRepMap, CategoryTheory.Functor.map_id, Rep.indFunctor_obj,
-      Category.id_comp, Iso.hom_inv_id])
+theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
+    [S.FiniteIndex] (A : FDRep k S) : indFDRepMap (𝟙 A) = 𝟙 (indFDRep A) := by
+  apply (forget₂ (FDRep k G) (Rep k G)).map_injective
+  apply Rep.hom_ext
+  rw [forget₂_map_indFDRepMap_hom]
+  let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
+  have hInd := (Rep.indFunctor k S.subtype).map_id A'
+  change Rep.indMap S.subtype (𝟙 A') = 𝟙 (Rep.ind S.subtype A') at hInd
+  change (indFDRepForgetEquiv A).symm.toIntertwiningMap.comp
+      ((Rep.indMap S.subtype (𝟙 A')).hom.comp
+        (indFDRepForgetEquiv A).toIntertwiningMap) =
+    Representation.IntertwiningMap.id
+      ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)).ρ
+  rw [hInd]
+  ext x
+  simp
 
 /-- Induction of intertwiners preserves composition. -/
-theorem indFDRepMap_comp {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+theorem indFDRepMap_comp {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] {A B C : FDRep k S} (f : A ⟶ B) (g : B ⟶ C) :
-    indFDRepMap (f ≫ g) = indFDRepMap f ≫ indFDRepMap g :=
-  (forget₂ (FDRep k G) (Rep k G)).map_injective (by
-    simp only [forget₂_map_indFDRepMap, CategoryTheory.Functor.map_comp, Category.assoc,
-      Iso.inv_hom_id_assoc])
+    indFDRepMap (f ≫ g) = indFDRepMap f ≫ indFDRepMap g := by
+  apply (forget₂ (FDRep k G) (Rep k G)).map_injective
+  apply Rep.hom_ext
+  rw [forget₂_map_indFDRepMap_hom]
+  simp only [Functor.map_comp, Rep.hom_comp, forget₂_map_indFDRepMap_hom]
+  have hInd := (Rep.indFunctor k S.subtype).map_comp
+    ((forget₂ (FDRep k S) (Rep k S)).map f)
+    ((forget₂ (FDRep k S) (Rep k S)).map g)
+  change Rep.indMap S.subtype
+      (((forget₂ (FDRep k S) (Rep k S)).map f) ≫
+        (forget₂ (FDRep k S) (Rep k S)).map g) =
+    Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f) ≫
+      Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map g) at hInd
+  rw [hInd, Rep.hom_comp]
+  ext x
+  simp
 
 /-- Induction from a finite-index subgroup, as a functor on finite-dimensional representations.
 It acts on objects as `indFDRep` and on intertwiners as `indFDRepMap`.
@@ -349,9 +389,10 @@ It acts on objects as `indFDRep` and on intertwiners as `indFDRepMap`.
 `indFDRepFunctor_map`. Both are proved by `rfl`, and the type of the second needs
 `indFDRepFunctor.obj A` to reduce to `indFDRep A`, so this definition is `@[expose]`. Exposing it
 publishes exactly those two projections: the construction of the morphism map lives in
-`indFDRepMap`, which stays opaque behind `forget₂_map_indFDRepMap`. -/
+`indFDRepMap`, which stays opaque behind `forget₂_map_indFDRepMap_hom`. -/
 @[expose, simps obj map]
-noncomputable def indFDRepFunctor {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+noncomputable def indFDRepFunctor {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G}
     [S.FiniteIndex] : FDRep k S ⥤ FDRep k G where
   obj A := indFDRep A
   map f := indFDRepMap f
@@ -369,7 +410,16 @@ noncomputable def indFDRepForgetNatIso {k G : Type u} [Field k] [Group G] {S : S
     change (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) ≫ (indFDRepForgetIso B).hom =
       (indFDRepForgetIso A).hom ≫
         (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f)
-    rw [forget₂_map_indFDRepMap, Category.assoc, Category.assoc, Iso.inv_hom_id, Category.comp_id]
+    rw [indFDRepForgetIso, indFDRepForgetIso]
+    apply Rep.hom_ext
+    rw [Rep.hom_comp, Rep.hom_comp, forget₂_map_indFDRepMap_hom]
+    ext x
+    change (indFDRepForgetEquiv B) ((indFDRepForgetEquiv B).symm
+        ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
+          ((indFDRepForgetEquiv A) x))) =
+      (Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
+        ((indFDRepForgetEquiv A) x)
+    simp
 
 /-- The dimension of an induced representation is the subgroup index times the dimension of the
 original representation. -/
@@ -378,15 +428,9 @@ theorem finrank_indFDRep {k : Type u} {G : Type v} [Field k] [Group G] {S : Subg
     [S.FiniteIndex] (A : FDRep k S) :
     Module.finrank k (indFDRep A) = S.index * Module.finrank k A := by
   let A' := (forget₂ (FDRep k S) (Rep k S)).obj A
-  -- Register the finite-dimensional structure hidden behind the forgetful object's wrapper.
-  let : FiniteDimensional k A' := by
-    -- The forgetful functor preserves the carrier, but its object wrapper hides that fact.
-    change FiniteDimensional k A
-    infer_instance
-  -- Reveal the forgetful carrier before transporting dimension along `indFDRepForgetEquiv`.
-  change Module.finrank k ((forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) =
-    S.index * Module.finrank k A'
-  rw [LinearEquiv.finrank_eq (indFDRepForgetEquiv A).toLinearEquiv]
-  exact Rep.finrank_ind A'
+  rw [LinearEquiv.finrank_eq (indFDRepForgetLinearEquiv A)]
+  convert Rep.finrank_ind A' using 1
+  change S.index * Module.finrank k A = S.index * Module.finrank k A
+  rfl
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -22,11 +22,11 @@ Induction on finite-dimensional representations is packaged both objectwise, as 
 functorially, as `indFDRepFunctor`, the latter naturally isomorphic to `Rep.indFunctor` under the
 forgetful functor to `Rep k G`.
 
-The objectwise construction, its character formula, dimension theorem, and functor on `FDRep`
-allow the scalar field and group to live in separate universes. It uses a small model of Mathlib's
-induced carrier, compared by `indFDRepForgetEquiv`. The comparison isomorphism and natural
-isomorphism into Mathlib's `Rep` category retain a common universe because that category is indexed
-by one carrier universe.
+The objectwise construction, dimension theorem, and functor on `FDRep` allow the scalar field and
+group to live in separate universes. It uses a small model of Mathlib's induced carrier, compared by
+`indFDRepForgetEquiv`. The comparison isomorphism and natural isomorphism into Mathlib's `Rep`
+category retain a common universe because that category is indexed by one carrier universe. The
+corresponding character formula is in `TauCeti.RepresentationTheory.Induction.Character`.
 
 ## References
 
@@ -366,7 +366,8 @@ noncomputable def indFDRepMap {k : Type u} {G : Type v} [Field k] [Group G] {S :
 /-- `indFDRepMap` applies Mathlib's induced intertwiner between the two small-carrier comparison
 equivalences. -/
 @[simp]
-theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
+theorem forget₂_map_indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G}
     [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B)
     (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
     ((forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f)).hom x =
@@ -388,7 +389,7 @@ theorem forget₂_map_indFDRepMap {k G : Type u} [Field k] [Group G] {S : Subgro
   simp only [FGModuleCat.obj_carrier, Rep.hom_comp,
     Representation.IntertwiningMap.comp_toLinearMap, LinearMap.coe_comp,
     Representation.IntertwiningMap.coe_toLinearMap, Function.comp_apply,
-    indFDRepMap_apply, Rep.indFunctor_map]
+    forget₂_map_indFDRepMap_apply, Rep.indFunctor_map]
   rw [indFDRepForgetIso_hom_hom_apply, indFDRepForgetIso_inv_hom_apply]
 
 /-- Induction of intertwiners preserves identities. -/
@@ -468,8 +469,8 @@ original representation. -/
 theorem finrank_indFDRep {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] (A : FDRep k S) :
     Module.finrank k (indFDRep A) = S.index * Module.finrank k A := by
-  rw [← finrank_forgetFDRep (indFDRep A),
+  rw [← FDRep.finrank_forget₂_obj (indFDRep A),
     LinearEquiv.finrank_eq (indFDRepForgetEquiv A).toLinearEquiv,
-    Rep.finrank_ind, finrank_forgetFDRep]
+    Rep.finrank_ind, FDRep.finrank_forget₂_obj]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -338,6 +338,25 @@ private noncomputable def indFDRepMapUnderlying {k : Type u} {G : Type v} [Field
       ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom.comp
         (indFDRepForgetEquiv A).toIntertwiningMap))
 
+/-- `indFDRepMapUnderlying` acts pointwise as Mathlib's induced intertwiner conjugated by the
+small-carrier comparison equivalences. -/
+private theorem indFDRepMapUnderlying_hom_apply {k : Type u} {G : Type v} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B)
+    (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
+    (indFDRepMapUnderlying f).hom x =
+      (indFDRepForgetEquiv B).symm
+        ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
+          (indFDRepForgetEquiv A x)) :=
+  -- This unfolds the single `Rep.ofHom` wrapper of `indFDRepMapUnderlying`. Rewriting with
+  -- `Rep.hom_ofHom`, `Representation.IntertwiningMap.comp_apply` and
+  -- `Representation.Equiv.coe_toIntertwiningMap` states the same steps but does not elaborate:
+  -- `forget₂ (FDRep k G) (Rep k G)` presents the carrier through
+  -- `(forget₂ (FGModuleCat k) (ModuleCat k)).mapAction G`, whose `Semiring k` argument comes from
+  -- `CommRing` while the statement's comes from `Field`, so each rewrite reports an application
+  -- type mismatch on the intertwining maps. Isolating the unfolding here keeps that mismatch out
+  -- of the proofs below, which rewrite with this lemma instead.
+  rfl
+
 /-- Induction of an intertwiner of finite-dimensional representations, obtained by conjugating
 Mathlib's induced intertwiner by the small-carrier comparison equivalences. -/
 noncomputable def indFDRepMap {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
@@ -354,12 +373,7 @@ theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Sub
       (indFDRepForgetEquiv B).symm
       ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
         (indFDRepForgetEquiv A x)) := by
-  rw [indFDRepMap, Functor.map_preimage]
-  -- Normalize the `Rep.ofHom` of a composite intertwiner to its pointwise action.
-  change (indFDRepForgetEquiv B).symm
-      ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
-        (indFDRepForgetEquiv A x)) = _
-  rfl
+  rw [indFDRepMap, Functor.map_preimage, indFDRepMapUnderlying_hom_apply]
 
 /-- After forgetting finite-dimensionality, `indFDRepMap` is Mathlib's induced intertwiner
 transported across the small-carrier comparison isomorphisms. -/

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -314,23 +314,35 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
   Rep.mkIso (indFDRepForgetEquiv A)
 
-/-- `FDRep.forget₂HomLinearEquiv` is inverse to the forgetful functor on morphisms. -/
-private theorem forget₂_map_forget₂HomLinearEquiv {R : Type u} {G : Type v}
-    [CommRing R] [Monoid G] (X Y : FDRep R G)
-    (f : (forget₂ (FDRep R G) (Rep R G)).obj X ⟶
-      (forget₂ (FDRep R G) (Rep R G)).obj Y) :
-    (forget₂ (FDRep R G) (Rep R G)).map (FDRep.forget₂HomLinearEquiv X Y f) = f :=
+/-- The hom of the categorical comparison applies its underlying equivariant equivalence. -/
+private theorem indFDRepForgetIso_hom_hom_apply {k G : Type u} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S)
+    (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
+    (Rep.Hom.hom (indFDRepForgetIso A).hom) x = indFDRepForgetEquiv A x :=
   rfl
+
+/-- The inverse of the categorical comparison applies the inverse equivariant equivalence. -/
+private theorem indFDRepForgetIso_inv_hom_apply {k G : Type u} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S)
+    (x : Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)) :
+    (Rep.Hom.hom (indFDRepForgetIso A).inv) x = (indFDRepForgetEquiv A).symm x :=
+  rfl
+
+/-- The conjugated induced intertwiner between the forgotten small-carrier models. -/
+private noncomputable def indFDRepMapUnderlying {k : Type u} {G : Type v} [Field k]
+    [Group G] {S : Subgroup G} [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :
+    (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A) ⟶
+      (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep B) :=
+  Rep.ofHom
+    ((indFDRepForgetEquiv B).symm.toIntertwiningMap.comp
+      ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom.comp
+        (indFDRepForgetEquiv A).toIntertwiningMap))
 
 /-- Induction of an intertwiner of finite-dimensional representations, obtained by conjugating
 Mathlib's induced intertwiner by the small-carrier comparison equivalences. -/
 noncomputable def indFDRepMap {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
-    [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) : indFDRep A ⟶ indFDRep B := by
-  let f' := Rep.ofHom
-    ((indFDRepForgetEquiv B).symm.toIntertwiningMap.comp
-      ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom.comp
-        (indFDRepForgetEquiv A).toIntertwiningMap))
-  exact FDRep.forget₂HomLinearEquiv _ _ f'
+    [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) : indFDRep A ⟶ indFDRep B :=
+  (forget₂ (FDRep k G) (Rep k G)).preimage (indFDRepMapUnderlying f)
 
 /-- `indFDRepMap` applies Mathlib's induced intertwiner between the two small-carrier comparison
 equivalences. -/
@@ -342,9 +354,12 @@ theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Sub
       (indFDRepForgetEquiv B).symm
       ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
         (indFDRepForgetEquiv A x)) := by
-  simp only [indFDRepMap]
-  rw [forget₂_map_forget₂HomLinearEquiv]
-  simp
+  rw [indFDRepMap, Functor.map_preimage]
+  -- Normalize the `Rep.ofHom` of a composite intertwiner to its pointwise action.
+  change (indFDRepForgetEquiv B).symm
+      ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
+        (indFDRepForgetEquiv A x)) = _
+  rfl
 
 /-- After forgetting finite-dimensionality, `indFDRepMap` is Mathlib's induced intertwiner
 transported across the small-carrier comparison isomorphisms. -/
@@ -356,14 +371,11 @@ theorem forget₂_map_indFDRepMap {k G : Type u} [Field k] [Group G] {S : Subgro
           (indFDRepForgetIso B).inv := by
   apply Rep.hom_ext
   ext x
-  -- Mathlib's `Rep.mkIso` projection lemmas do not match across the definitionally equal
-  -- `Field`- and `CommRing`-derived representation structures here, so normalize the categorical
-  -- composites to the characteristic pointwise statement in one step.
-  change ((forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f)).hom x =
-    (indFDRepForgetEquiv B).symm
-      ((Rep.indMap S.subtype ((forget₂ (FDRep k S) (Rep k S)).map f)).hom
-        (indFDRepForgetEquiv A x))
-  exact indFDRepMap_apply f x
+  simp only [FGModuleCat.obj_carrier, Rep.hom_comp,
+    Representation.IntertwiningMap.comp_toLinearMap, LinearMap.coe_comp,
+    Representation.IntertwiningMap.coe_toLinearMap, Function.comp_apply,
+    indFDRepMap_apply, Rep.indFunctor_map]
+  rw [indFDRepForgetIso_hom_hom_apply, indFDRepForgetIso_inv_hom_apply]
 
 /-- Induction of intertwiners preserves identities. -/
 private theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -315,11 +315,17 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
   Rep.mkIso (indFDRepForgetEquiv A)
 
 /-- The hom of the categorical comparison applies its underlying equivariant equivalence. -/
-@[simp]
 private theorem indFDRepForgetIso_hom_hom_apply {k G : Type u} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S)
     (x : (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A)) :
     (Rep.Hom.hom (indFDRepForgetIso A).hom) x = indFDRepForgetEquiv A x :=
+  rfl
+
+/-- The inverse of the categorical comparison applies the inverse equivariant equivalence. -/
+private theorem indFDRepForgetIso_inv_hom_apply {k G : Type u} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S)
+    (x : Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)) :
+    (Rep.Hom.hom (indFDRepForgetIso A).inv) x = (indFDRepForgetEquiv A).symm x :=
   rfl
 
 /-- `FDRep.forget₂HomLinearEquiv` is inverse to the forgetful functor on morphisms. -/
@@ -353,6 +359,22 @@ theorem indFDRepMap_apply {k : Type u} {G : Type v} [Field k] [Group G] {S : Sub
   simp only [indFDRepMap]
   rw [forget₂_map_forget₂HomLinearEquiv]
   simp
+
+/-- After forgetting finite-dimensionality, `indFDRepMap` is Mathlib's induced intertwiner
+transported across the small-carrier comparison isomorphisms. -/
+theorem forget₂_map_indFDRepMap {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+    [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :
+    (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) =
+      (indFDRepForgetIso A).hom ≫
+        (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f) ≫
+          (indFDRepForgetIso B).inv := by
+  apply Rep.hom_ext
+  ext x
+  simp only [FGModuleCat.obj_carrier, Rep.hom_comp,
+    Representation.IntertwiningMap.comp_toLinearMap, LinearMap.coe_comp,
+    Representation.IntertwiningMap.coe_toLinearMap, Function.comp_apply,
+    indFDRepMap_apply, Rep.indFunctor_map]
+  rw [indFDRepForgetIso_hom_hom_apply, indFDRepForgetIso_inv_hom_apply]
 
 /-- Induction of intertwiners preserves identities. -/
 private theorem indFDRepMap_id {k : Type u} {G : Type v} [Field k] [Group G] {S : Subgroup G}
@@ -404,8 +426,9 @@ theorem indFDRepFunctor_obj {k : Type u} {G : Type v} [Field k] [Group G]
 
 The `eqToHom` transports are needed because `indFDRepFunctor` is opaque and its object projection
 is exposed propositionally by `indFDRepFunctor_obj`. Both projection proofs are definitionally
-`rfl`, so the transports and identity compositions reduce when this defining map field is proved. -/
-@[simp]
+`rfl`, so the transports and identity compositions reduce when this defining map field is proved.
+This lemma is intentionally not a simp rule because its propositionally necessary transports are
+not a useful normal form. -/
 theorem indFDRepFunctor_map {k : Type u} {G : Type v} [Field k] [Group G]
     {S : Subgroup G} [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :
     (indFDRepFunctor (k := k) (S := S)).map f =
@@ -426,15 +449,8 @@ noncomputable def indFDRepForgetNatIso {k G : Type u} [Field k] [Group G] {S : S
         (indFDRepForgetIso B).hom =
       (indFDRepForgetIso A).hom ≫
         (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f)
-    ext x
-    simp only [FGModuleCat.obj_carrier, Rep.hom_comp,
-      Representation.IntertwiningMap.comp_toLinearMap, LinearMap.coe_comp,
-      Representation.IntertwiningMap.coe_toLinearMap, Function.comp_apply,
-      indFDRepMap_apply, Rep.indFunctor_obj, Rep.indFunctor_map]
-    -- These two rewrites bridge definitionally distinct representation structures induced by the
-    -- `Field` and `CommRing` instances; `simp` cannot match them before this normalization.
-    rw [indFDRepForgetIso_hom_hom_apply, indFDRepForgetIso_hom_hom_apply]
-    simp
+    rw [forget₂_map_indFDRepMap, Category.assoc, Category.assoc, Iso.inv_hom_id,
+      Category.comp_id]
 
 /-- The dimension of an induced representation is the subgroup index times the dimension of the
 original representation. -/

--- a/TauCeti/RepresentationTheory/Induction/Ideal.lean
+++ b/TauCeti/RepresentationTheory/Induction/Ideal.lean
@@ -57,9 +57,9 @@ namespace TauCeti
 
 namespace ClassFunction
 
-universe u
+universe u v
 
-variable {k G : Type u} [Field k] [Group G] [Finite G]
+variable {k : Type u} {G : Type v} [Field k] [Group G] [Finite G]
 
 variable (k G) in
 /-- The set of class functions on `G` induced from a virtual character of a subgroup satisfying

--- a/TauCeti/RepresentationTheory/Induction/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Induction/Restriction.lean
@@ -62,9 +62,9 @@ open CategoryTheory
 
 namespace TauCeti
 
-universe u
+universe u v
 
-variable {k G : Type u} [Group G]
+variable {k : Type u} {G : Type v} [Group G]
 
 section Functor
 

--- a/TauCeti/RepresentationTheory/Induction/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Induction/Restriction.lean
@@ -120,7 +120,7 @@ end Functor
 
 section Intertwining
 
-variable [Field k] {M M' : Type u} [Group M] [Group M']
+variable [Field k] {M M' : Type*} [Group M] [Group M']
 
 /-- Restriction along an isomorphism of groups is an equivalence of representation categories, so
 it leaves the dimension of an intertwining space unchanged. -/

--- a/TauCeti/RepresentationTheory/Induction/VirtualCharacter.lean
+++ b/TauCeti/RepresentationTheory/Induction/VirtualCharacter.lean
@@ -42,9 +42,9 @@ namespace TauCeti
 
 namespace ClassFunction
 
-universe u
+universe u v
 
-variable {k G : Type u} [Field k] [Group G]
+variable {k : Type u} {G : Type v} [Field k] [Group G]
 
 /-- **A character induced from a subgroup is a virtual character.**  Inducing the class function of
 a finite-dimensional representation gives the class function of the induced representation
@@ -63,7 +63,7 @@ theorem ind_ofFDRep_mem_virtualCharacters (S : Subgroup G) [S.FiniteIndex] (A : 
 
 end ClassFunction
 
-variable {k G : Type u} [Field k] [Group G]
+variable {k : Type u} {G : Type v} [Field k] [Group G]
 
 /-- Restriction of functions along the inclusion of a subgroup, as an additive map.  It is the
 vehicle for propagating a property through the additive generation of the virtual-character


### PR DESCRIPTION
Generalize the existing finite-dimensional induction plumbing so the scalar field and group may live in separate universes. The objectwise induced FDRep uses a small model of Mathlib's induced carrier, while the coset model continues to reuse `Rep.indCoindIso`.

This is the prerequisite split requested by review on #3590 and addresses the universe limitation in #3568. The Artin API remains in #3590.

Roadmap: RepresentationTheory