### PR TITLE
refactor: give invariant restriction dot notation

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/NumberedSymmetry.lean
@@ -62,7 +62,7 @@ open CategoryTheory TensorProduct WithConv
 
 namespace TauCeti.UniversalEnvelopingAlgebra
 
-open TauCeti.GeneralLinearGroup
+open AddEquiv
 
 universe u v w
 
@@ -243,7 +243,7 @@ theorem kostantElementaryMap_kostantElementaryNumberedSymmetryAut
   rw [val_kostantElementaryMap, val_kostantElementaryNumberedSymmetryAut,
     val_kostantElementaryNumberedSymmetryAut,
     val_kostantElementaryMap, map_mul, map_mul, map_inv,
-    TauCeti.GeneralLinearGroup.mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit
+    AddEquiv.mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit
       θ.toAddEquiv M hθM φ]
 
 /-- The numbered symmetry commutes with the `p ^ n`-power Frobenius endomorphism.

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/InvariantRestrict.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/InvariantRestrict.lean
@@ -16,12 +16,12 @@ extension of the subgroup, compatibly with further scalar extension.
 
 ## Main declarations
 
-* `TauCeti.GeneralLinearGroup.invariantRestrict`: restriction to an invariant additive subgroup.
-* `TauCeti.GeneralLinearGroup.baseChangeInvariantRestrictUnit`: the induced automorphism after
+* `AddEquiv.invariantRestrict`: restriction to an invariant additive subgroup.
+* `AddEquiv.baseChangeInvariantRestrictUnit`: the induced automorphism after
   scalar extension.
-* `TauCeti.GeneralLinearGroup.baseChangeInvariantRestrictUnit_pow_eq_one`: transport of an
+* `AddEquiv.baseChangeInvariantRestrictUnit_pow_eq_one`: transport of an
   exponent bound to scalar extensions.
-* `TauCeti.GeneralLinearGroup.mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit`:
+* `AddEquiv.mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit`:
   compatibility with further scalar extension.
 -/
 
@@ -29,7 +29,7 @@ public section
 
 open CategoryTheory TensorProduct
 
-namespace TauCeti.GeneralLinearGroup
+namespace AddEquiv
 
 universe u v w
 
@@ -141,16 +141,16 @@ theorem baseChangeInvariantRestrictUnit_pow_eq_one (θ : V ≃+ V) (M : S)
 theorem mapScalarExtensionAutomorphisms_baseChangeInvariantRestrictUnit
     {A B : CommAlgCat.{w} ℤ} (θ : V ≃+ V) (M : S) (hθ : ∀ v, θ v ∈ M ↔ v ∈ M)
     (φ : A ⟶ B) :
-    GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ
+    TauCeti.GeneralLinear.mapScalarExtensionAutomorphisms (V := M) φ
         (baseChangeInvariantRestrictUnit (R := A) θ M hθ) =
       baseChangeInvariantRestrictUnit (R := B) θ M hθ := by
-  refine (GeneralLinear.eq_mapScalarExtensionAutomorphisms_of_apply_scalarExtensionMap_eq
+  refine (TauCeti.GeneralLinear.eq_mapScalarExtensionAutomorphisms_of_apply_scalarExtensionMap_eq
     φ _ _ fun z => ?_).symm
   induction z using TensorProduct.induction_on with
   | zero => simp
   | tmul a m =>
-      rw [GeneralLinear.scalarExtensionMap_tmul, val_baseChangeInvariantRestrictUnit_tmul,
-        val_baseChangeInvariantRestrictUnit_tmul, GeneralLinear.scalarExtensionMap_tmul]
+      rw [TauCeti.GeneralLinear.scalarExtensionMap_tmul, val_baseChangeInvariantRestrictUnit_tmul,
+        val_baseChangeInvariantRestrictUnit_tmul, TauCeti.GeneralLinear.scalarExtensionMap_tmul]
   | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
 
-end TauCeti.GeneralLinearGroup
+end AddEquiv

--- a/TauCeti/RingTheory/Nilpotent/Conjugation.lean
+++ b/TauCeti/RingTheory/Nilpotent/Conjugation.lean
@@ -119,10 +119,10 @@ theorem baseChange_invariantRestrict_baseChangeExp (M : S) (hθ : ∀ v, θ v �
     (hxy : ∀ v, θ (x • v) = y • θ v)
     (hx : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
     {k : ℕ} (hkx : x ^ k = 0) (hky : y ^ k = 0) (t : R) (z : R ⊗[ℤ] M) :
-    (GeneralLinearGroup.invariantRestrict θ.toAddEquiv M hθ).baseChange ℤ R M M
+    (θ.toAddEquiv.invariantRestrict M hθ).baseChange ℤ R M M
         (baseChangeExp x M hx t z) =
       baseChangeExp y M (dividedPower_smul_mem_of_intertwines θ M hθ hxy hx) t
-        ((GeneralLinearGroup.invariantRestrict θ.toAddEquiv M hθ).baseChange ℤ R M M z) := by
+        ((θ.toAddEquiv.invariantRestrict M hθ).baseChange ℤ R M M z) := by
   induction z using TensorProduct.induction_on with
   | zero => simp
   | tmul r v =>
@@ -133,8 +133,8 @@ theorem baseChange_invariantRestrict_baseChangeExp (M : S) (hθ : ∀ v, θ v �
       rw [LinearEquiv.baseChange_tmul]
       congr 1
       refine Subtype.ext ?_
-      rw [GeneralLinearGroup.coe_invariantRestrict_apply, coe_integralDividedPower_apply,
-        coe_integralDividedPower_apply, GeneralLinearGroup.coe_invariantRestrict_apply]
+      rw [AddEquiv.coe_invariantRestrict_apply, coe_integralDividedPower_apply,
+        coe_integralDividedPower_apply, AddEquiv.coe_invariantRestrict_apply]
       convert apply_dividedPower_smul_of_intertwines θ.toLinearMap hxy n (v : V) using 1 <;> rfl
   | add z w hz hw => rw [map_add, map_add, map_add, map_add, hz, hw]
 


### PR DESCRIPTION
This PR moves the invariant-subgroup restriction API from the recreated `TauCeti.GeneralLinearGroup` namespace to its canonical `AddEquiv` receiver namespace, restoring `θ.invariantRestrict` dot notation and updating both consumers. It follows up #3553 and addresses the GeneralLinearGroup refill in #3547.

Local verification: `lake build` (8,209 jobs) and `python3 scripts/lint-dot-notation.py` (zero new or ratchetable findings).

Roadmap: ReductiveGroups

:robot: Prepared with OpenAI Codex
