### PR TITLE
refactor: give additive circle API its canonical namespace

### DIFF
--- a/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
@@ -16,8 +16,8 @@ contractible, and it is not homeomorphic to any simply connected space — in pa
 any real topological vector space nor to `ℝ`.
 
 These facts use the space only through the (non-)triviality of its fundamental group, so they
-are stated once here for an arbitrary space and then specialised to concrete circles
-(`AddCircle.*`, `UnitAddCircle.*`, `TauCeti.Circle.*`). Non-simple-connectivity
+are stated once here for an arbitrary space and then specialised to concrete circles (`AddCircle.*`,
+`UnitAddCircle.*`, `TauCeti.Circle.*`). Non-simple-connectivity
 follows because a simply connected space has a subsingleton fundamental group; the
 homeomorphism statements consume Mathlib's transfer of `SimplyConnectedSpace` along a homotopy
 equivalence (`ContinuousMap.HomotopyEquiv.simplyConnectedSpace`, via

--- a/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
@@ -17,7 +17,7 @@ any real topological vector space nor to `ℝ`.
 
 These facts use the space only through the (non-)triviality of its fundamental group, so they
 are stated once here for an arbitrary space and then specialised to concrete circles
-(`TauCeti.AddCircle.*`, `TauCeti.UnitAddCircle.*`, `TauCeti.Circle.*`). Non-simple-connectivity
+(`AddCircle.*`, `TauCeti.UnitAddCircle.*`, `TauCeti.Circle.*`). Non-simple-connectivity
 follows because a simply connected space has a subsingleton fundamental group; the
 homeomorphism statements consume Mathlib's transfer of `SimplyConnectedSpace` along a homotopy
 equivalence (`ContinuousMap.HomotopyEquiv.simplyConnectedSpace`, via

--- a/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/NotSimplyConnected.lean
@@ -17,7 +17,7 @@ any real topological vector space nor to `ℝ`.
 
 These facts use the space only through the (non-)triviality of its fundamental group, so they
 are stated once here for an arbitrary space and then specialised to concrete circles
-(`AddCircle.*`, `TauCeti.UnitAddCircle.*`, `TauCeti.Circle.*`). Non-simple-connectivity
+(`AddCircle.*`, `UnitAddCircle.*`, `TauCeti.Circle.*`). Non-simple-connectivity
 follows because a simply connected space has a subsingleton fundamental group; the
 homeomorphism statements consume Mathlib's transfer of `SimplyConnectedSpace` along a homotopy
 equivalence (`ContinuousMap.HomotopyEquiv.simplyConnectedSpace`, via

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/EilenbergMacLane.lean
@@ -24,8 +24,7 @@ This realizes `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13,
 ## Main declarations
 
 * `AddCircle.isAspherical`: every real additive circle is aspherical.
-* `AddCircle.isEilenbergMacLaneSpaceOne`: a nondegenerate real circle is a
-  `K(ℤ, 1)`.
+* `AddCircle.isEilenbergMacLaneSpaceOne`: a nondegenerate real circle is a `K(ℤ, 1)`.
 -/
 
 public section

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/EilenbergMacLane.lean
@@ -15,22 +15,20 @@ A real additive circle of nonzero period is a `K(ℤ, 1)`: it is path-connected,
 fundamental group is infinite cyclic, and all its higher homotopy groups vanish.
 
 These results package the existing circle calculations into the Eilenberg--Mac Lane API. The
-fundamental-group witness is `TauCeti.AddCircle.fundamentalGroupMulEquiv`, and higher homotopy
-vanishing is supplied by `TauCeti.AddCircle.subsingleton_homotopyGroup`.
+fundamental-group witness is `AddCircle.fundamentalGroupMulEquiv`, and higher homotopy
+vanishing is supplied by `AddCircle.subsingleton_homotopyGroup`.
 
 This realizes `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13,
 "`K(G, 1)` spaces", for circles.
 
 ## Main declarations
 
-* `TauCeti.AddCircle.isAspherical`: every real additive circle is aspherical.
-* `TauCeti.AddCircle.isEilenbergMacLaneSpaceOne`: a nondegenerate real circle is a
+* `AddCircle.isAspherical`: every real additive circle is aspherical.
+* `AddCircle.isEilenbergMacLaneSpaceOne`: a nondegenerate real circle is a
   `K(ℤ, 1)`.
 -/
 
 public section
-
-namespace TauCeti
 
 open scoped Topology Topology.Homotopy
 
@@ -55,5 +53,3 @@ theorem isEilenbergMacLaneSpaceOne (p : ℝ) (hp : p ≠ 0) (x : AddCircle p) :
 end AddCircle
 
 end
-
-end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
@@ -35,15 +35,15 @@ transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on ev
 
 ## Main declarations
 
-* `AddCircle.fundamentalGroupMulEquivZMultiples`: for a covering projection from a
-  simply connected additive group, the fundamental group of `AddCircle p` is the period subgroup.
-* `AddCircle.fundamentalGroupMulEquivInt`: for a covering projection from a
-  simply connected additive group with non-torsion period, the fundamental group of
-  `AddCircle p` is `Multiplicative ℤ`.
-* `AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
-  group of `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
-* `AddCircle.fundamentalGroupMulEquivZero`: the basepoint-`0` specialisation, using
-  the lift `0 : ℝ`.
+* `AddCircle.fundamentalGroupMulEquivZMultiples`: for a covering projection from a simply
+  connected additive group, the fundamental group of `AddCircle p` is the period subgroup.
+* `AddCircle.fundamentalGroupMulEquivInt`: for a covering projection from a simply connected
+  additive group with non-torsion period, the fundamental group of `AddCircle p` is
+  `Multiplicative ℤ`.
+* `AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental group of
+  `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
+* `AddCircle.fundamentalGroupMulEquivZero`: the basepoint-`0` specialisation, using the lift
+  `0 : ℝ`.
 * `UnitAddCircle.fundamentalGroupMulEquiv`: `π₁(S¹) ≅ ℤ` for the unit circle.
 
 ## References

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
@@ -35,14 +35,14 @@ transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on ev
 
 ## Main declarations
 
-* `TauCeti.AddCircle.fundamentalGroupMulEquivZMultiples`: for a covering projection from a
+* `AddCircle.fundamentalGroupMulEquivZMultiples`: for a covering projection from a
   simply connected additive group, the fundamental group of `AddCircle p` is the period subgroup.
-* `TauCeti.AddCircle.fundamentalGroupMulEquivInt`: for a covering projection from a
+* `AddCircle.fundamentalGroupMulEquivInt`: for a covering projection from a
   simply connected additive group with non-torsion period, the fundamental group of
   `AddCircle p` is `Multiplicative ℤ`.
-* `TauCeti.AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
+* `AddCircle.fundamentalGroupMulEquiv`: for a nonzero real period, the fundamental
   group of `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
-* `TauCeti.AddCircle.fundamentalGroupMulEquivZero`: the basepoint-`0` specialisation, using
+* `AddCircle.fundamentalGroupMulEquivZero`: the basepoint-`0` specialisation, using
   the lift `0 : ℝ`.
 * `TauCeti.UnitAddCircle.fundamentalGroupMulEquiv`: `π₁(S¹) ≅ ℤ` for the unit circle.
 
@@ -57,9 +57,7 @@ vector space, together with the Tau Ceti deck-transformation theory of Stages 0.
 
 public section
 
-namespace TauCeti
-
-open AddSubgroup
+open TauCeti AddSubgroup
 
 namespace AddCircle
 
@@ -273,7 +271,7 @@ lemma fundamentalGroupMulEquivZero_eq_one_iff (hp : p ≠ 0) (γ : FundamentalGr
 
 end AddCircle
 
-namespace UnitAddCircle
+namespace TauCeti.UnitAddCircle
 
 /-- The fundamental group of the unit circle `S¹ = ℝ ⧸ ℤ` is `ℤ`:
 `FundamentalGroup UnitAddCircle 0 ≃* Multiplicative ℤ`. This is the classical `π₁(S¹) ≅ ℤ`. -/
@@ -303,6 +301,4 @@ lemma fundamentalGroupMulEquiv_eq_one_iff (γ : FundamentalGroup UnitAddCircle 0
   simpa [fundamentalGroupMulEquiv] using
     AddCircle.fundamentalGroupMulEquivZero_eq_one_iff 1 one_ne_zero γ
 
-end UnitAddCircle
-
-end TauCeti
+end TauCeti.UnitAddCircle

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
@@ -44,7 +44,7 @@ transformation, so `Deck ((↑) : 𝕜 → AddCircle p)` acts transitively on ev
   group of `AddCircle p` (based at any point with a chosen lift) is `Multiplicative ℤ`.
 * `AddCircle.fundamentalGroupMulEquivZero`: the basepoint-`0` specialisation, using
   the lift `0 : ℝ`.
-* `TauCeti.UnitAddCircle.fundamentalGroupMulEquiv`: `π₁(S¹) ≅ ℤ` for the unit circle.
+* `UnitAddCircle.fundamentalGroupMulEquiv`: `π₁(S¹) ≅ ℤ` for the unit circle.
 
 ## References
 
@@ -271,7 +271,7 @@ lemma fundamentalGroupMulEquivZero_eq_one_iff (hp : p ≠ 0) (γ : FundamentalGr
 
 end AddCircle
 
-namespace TauCeti.UnitAddCircle
+namespace UnitAddCircle
 
 /-- The fundamental group of the unit circle `S¹ = ℝ ⧸ ℤ` is `ℤ`:
 `FundamentalGroup UnitAddCircle 0 ≃* Multiplicative ℤ`. This is the classical `π₁(S¹) ≅ ℤ`. -/
@@ -301,4 +301,4 @@ lemma fundamentalGroupMulEquiv_eq_one_iff (γ : FundamentalGroup UnitAddCircle 0
   simpa [fundamentalGroupMulEquiv] using
     AddCircle.fundamentalGroupMulEquivZero_eq_one_iff 1 one_ne_zero γ
 
-end TauCeti.UnitAddCircle
+end UnitAddCircle

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
@@ -27,9 +27,9 @@ This proves Stage 4, item 11 of the Tau Ceti universal-covers roadmap
 
 ## Main declarations
 
-* `TauCeti.AddCircle.subsingleton_homotopyGroup`: `π_N(AddCircle p)` is trivial when `N` has
+* `AddCircle.subsingleton_homotopyGroup`: `π_N(AddCircle p)` is trivial when `N` has
   at least two elements; instance resolution specializes it to `π_(n + 2)`.
-* `TauCeti.AddCircle.homotopyGroup_eq_one`, `TauCeti.AddCircle.homotopyGroupPi_eq_one`: the
+* `AddCircle.homotopyGroup_eq_one`, `AddCircle.homotopyGroupPi_eq_one`: the
   corresponding equalities.
 
 The covering map is Junyan Xu's `AddCircle.isCoveringMap_coe` in
@@ -37,8 +37,6 @@ The covering map is Junyan Xu's `AddCircle.isCoveringMap_coe` in
 -/
 
 public section
-
-namespace TauCeti
 
 open scoped unitInterval Topology Topology.Homotopy
 open Topology.Homotopy
@@ -64,5 +62,3 @@ theorem homotopyGroupPi_eq_one (n : ℕ) (a : π_ (n + 2) (AddCircle p) x) : a =
   homotopyGroup_eq_one p x a
 
 end AddCircle
-
-end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
@@ -27,10 +27,10 @@ This proves Stage 4, item 11 of the Tau Ceti universal-covers roadmap
 
 ## Main declarations
 
-* `AddCircle.subsingleton_homotopyGroup`: `π_N(AddCircle p)` is trivial when `N` has
-  at least two elements; instance resolution specializes it to `π_(n + 2)`.
-* `AddCircle.homotopyGroup_eq_one`, `AddCircle.homotopyGroupPi_eq_one`: the
-  corresponding equalities.
+* `AddCircle.subsingleton_homotopyGroup`: `π_N(AddCircle p)` is trivial when `N` has at least two
+  elements; instance resolution specializes it to `π_(n + 2)`.
+* `AddCircle.homotopyGroup_eq_one`, `AddCircle.homotopyGroupPi_eq_one`: the corresponding
+  equalities.
 
 The covering map is Junyan Xu's `AddCircle.isCoveringMap_coe` in
 `Mathlib.Topology.Covering.AddCircle`.
@@ -51,7 +51,7 @@ instance subsingleton_homotopyGroup : Subsingleton (HomotopyGroup N (AddCircle p
   classical
   obtain ⟨x, rfl⟩ := QuotientAddGroup.mk_surjective x
   exact (TauCeti.IsCoveringMap.homotopyGroupMulEquiv (N := N)
-    (_root_.AddCircle.isCoveringMap_coe p) x).toEquiv.subsingleton_congr.mp inferInstance
+    (AddCircle.isCoveringMap_coe p) x).toEquiv.subsingleton_congr.mp inferInstance
 
 /-- Every higher homotopy class of a real circle is the identity. -/
 theorem homotopyGroup_eq_one [DecidableEq N] (a : HomotopyGroup N (AddCircle p) x) : a = 1 :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/NotSimplyConnected.lean
@@ -32,9 +32,8 @@ contractibility of a real topological vector space
 
 ## Main declarations
 
-* `AddCircle.nontrivial_fundamentalGroup`,
-  `AddCircle.infinite_fundamentalGroup`: the fundamental group of `AddCircle p`
-  (`p ≠ 0`), at any basepoint, is nontrivial and infinite.
+* `AddCircle.nontrivial_fundamentalGroup`, `AddCircle.infinite_fundamentalGroup`: the fundamental
+  group of `AddCircle p` (`p ≠ 0`), at any basepoint, is nontrivial and infinite.
 * `AddCircle.not_simplyConnectedSpace`: `AddCircle p` is not simply connected.
 * `AddCircle.not_contractibleSpace`: `AddCircle p` is not contractible.
 * `AddCircle.isEmpty_homeomorph_of_simplyConnectedSpace`,
@@ -45,8 +44,6 @@ contractibility of a real topological vector space
 -/
 
 public section
-
-open TauCeti
 
 namespace AddCircle
 
@@ -80,12 +77,12 @@ theorem infinite_fundamentalGroup_zero (hp : p ≠ 0) :
 nontrivial, whereas a simply connected space has a subsingleton fundamental group. -/
 theorem not_simplyConnectedSpace (hp : p ≠ 0) : ¬ SimplyConnectedSpace (AddCircle p) :=
   haveI := nontrivial_fundamentalGroup_zero p hp
-  not_simplyConnectedSpace_of_nontrivial_fundamentalGroup (0 : AddCircle p)
+  TauCeti.not_simplyConnectedSpace_of_nontrivial_fundamentalGroup (0 : AddCircle p)
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is **not contractible**: a contractible space is simply
 connected, and the circle is not. -/
 theorem not_contractibleSpace (hp : p ≠ 0) : ¬ ContractibleSpace (AddCircle p) :=
-  not_contractibleSpace_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp)
+  TauCeti.not_contractibleSpace_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp)
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to any simply connected space: a
 homeomorphism is in particular a homotopy equivalence, and simple connectivity transfers along
@@ -93,7 +90,7 @@ homotopy equivalences, which the circle does not enjoy. -/
 theorem isEmpty_homeomorph_of_simplyConnectedSpace (hp : p ≠ 0)
     (Y : Type*) [TopologicalSpace Y] [SimplyConnectedSpace Y] :
     IsEmpty (AddCircle p ≃ₜ Y) :=
-  isEmpty_homeomorph_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp) Y
+  TauCeti.isEmpty_homeomorph_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp) Y
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to any real topological vector space
 (in particular, to any real normed space), since such a space is contractible, hence simply
@@ -101,13 +98,13 @@ connected. -/
 theorem isEmpty_homeomorph_realTopologicalVectorSpace (hp : p ≠ 0) (E : Type*)
     [AddCommGroup E] [Module ℝ E] [TopologicalSpace E] [ContinuousAdd E] [ContinuousSMul ℝ E] :
     IsEmpty (AddCircle p ≃ₜ E) :=
-  isEmpty_homeomorph_realTopologicalVectorSpace_of_not_simplyConnectedSpace
+  TauCeti.isEmpty_homeomorph_realTopologicalVectorSpace_of_not_simplyConnectedSpace
     (not_simplyConnectedSpace p hp) E
 
 /-- The circle `AddCircle p` (`p ≠ 0`) is not homeomorphic to the real line: the circle is not
 simply connected but `ℝ` is contractible. -/
 theorem isEmpty_homeomorph_real (hp : p ≠ 0) : IsEmpty (AddCircle p ≃ₜ ℝ) :=
-  isEmpty_homeomorph_real_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp)
+  TauCeti.isEmpty_homeomorph_real_of_not_simplyConnectedSpace (not_simplyConnectedSpace p hp)
 
 end AddCircle
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/NotSimplyConnected.lean
@@ -11,7 +11,7 @@ public import TauCeti.AlgebraicTopology.UniversalCover.Circle.FundamentalGroup
 # The circle is not simply connected
 
 The circle computation `π₁(AddCircle p) ≃* Multiplicative ℤ`
-(`TauCeti.AddCircle.fundamentalGroupMulEquiv`) has an immediate qualitative payoff: since
+(`AddCircle.fundamentalGroupMulEquiv`) has an immediate qualitative payoff: since
 `Multiplicative ℤ` is nontrivial and infinite, so is the fundamental group of the circle, and
 therefore the circle is **not simply connected**. Being non-simply-connected, it is not
 contractible, and it is not homeomorphic to any simply connected space; in particular the
@@ -32,21 +32,21 @@ contractibility of a real topological vector space
 
 ## Main declarations
 
-* `TauCeti.AddCircle.nontrivial_fundamentalGroup`,
-  `TauCeti.AddCircle.infinite_fundamentalGroup`: the fundamental group of `AddCircle p`
+* `AddCircle.nontrivial_fundamentalGroup`,
+  `AddCircle.infinite_fundamentalGroup`: the fundamental group of `AddCircle p`
   (`p ≠ 0`), at any basepoint, is nontrivial and infinite.
-* `TauCeti.AddCircle.not_simplyConnectedSpace`: `AddCircle p` is not simply connected.
-* `TauCeti.AddCircle.not_contractibleSpace`: `AddCircle p` is not contractible.
-* `TauCeti.AddCircle.isEmpty_homeomorph_of_simplyConnectedSpace`,
-  `TauCeti.AddCircle.isEmpty_homeomorph_realTopologicalVectorSpace`,
-  `TauCeti.AddCircle.isEmpty_homeomorph_real`: `AddCircle p` is not homeomorphic to a simply
+* `AddCircle.not_simplyConnectedSpace`: `AddCircle p` is not simply connected.
+* `AddCircle.not_contractibleSpace`: `AddCircle p` is not contractible.
+* `AddCircle.isEmpty_homeomorph_of_simplyConnectedSpace`,
+  `AddCircle.isEmpty_homeomorph_realTopologicalVectorSpace`,
+  `AddCircle.isEmpty_homeomorph_real`: `AddCircle p` is not homeomorphic to a simply
   connected space, to a real topological vector space, or to `ℝ`.
 * `TauCeti.UnitAddCircle.*`: the specialisations to the unit circle `S¹ = ℝ ⧸ ℤ`.
 -/
 
 public section
 
-namespace TauCeti
+open TauCeti
 
 namespace AddCircle
 
@@ -111,7 +111,7 @@ theorem isEmpty_homeomorph_real (hp : p ≠ 0) : IsEmpty (AddCircle p ≃ₜ ℝ
 
 end AddCircle
 
-namespace UnitAddCircle
+namespace TauCeti.UnitAddCircle
 
 /-- The fundamental group of the unit circle `S¹ = ℝ ⧸ ℤ`, based at `0`, is nontrivial. -/
 theorem nontrivial_fundamentalGroup_zero : Nontrivial (FundamentalGroup UnitAddCircle 0) :=
@@ -133,6 +133,4 @@ theorem not_contractibleSpace : ¬ ContractibleSpace UnitAddCircle :=
 theorem isEmpty_homeomorph_real : IsEmpty (UnitAddCircle ≃ₜ ℝ) :=
   AddCircle.isEmpty_homeomorph_real 1 one_ne_zero
 
-end UnitAddCircle
-
-end TauCeti
+end TauCeti.UnitAddCircle

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/NotSimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/NotSimplyConnected.lean
@@ -41,7 +41,7 @@ contractibility of a real topological vector space
   `AddCircle.isEmpty_homeomorph_realTopologicalVectorSpace`,
   `AddCircle.isEmpty_homeomorph_real`: `AddCircle p` is not homeomorphic to a simply
   connected space, to a real topological vector space, or to `ℝ`.
-* `TauCeti.UnitAddCircle.*`: the specialisations to the unit circle `S¹ = ℝ ⧸ ℤ`.
+* `UnitAddCircle.*`: the specialisations to the unit circle `S¹ = ℝ ⧸ ℤ`.
 -/
 
 public section
@@ -111,7 +111,7 @@ theorem isEmpty_homeomorph_real (hp : p ≠ 0) : IsEmpty (AddCircle p ≃ₜ ℝ
 
 end AddCircle
 
-namespace TauCeti.UnitAddCircle
+namespace UnitAddCircle
 
 /-- The fundamental group of the unit circle `S¹ = ℝ ⧸ ℤ`, based at `0`, is nontrivial. -/
 theorem nontrivial_fundamentalGroup_zero : Nontrivial (FundamentalGroup UnitAddCircle 0) :=
@@ -133,4 +133,4 @@ theorem not_contractibleSpace : ¬ ContractibleSpace UnitAddCircle :=
 theorem isEmpty_homeomorph_real : IsEmpty (UnitAddCircle ≃ₜ ℝ) :=
   AddCircle.isEmpty_homeomorph_real 1 one_ne_zero
 
-end TauCeti.UnitAddCircle
+end UnitAddCircle

--- a/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/ComplexCircleFundamentalGroup.lean
@@ -13,7 +13,7 @@ public import TauCeti.AlgebraicTopology.UniversalCover.Circle.FundamentalGroup
 # The fundamental group of the complex unit circle is `ℤ`
 
 The additive-circle computation `π₁(AddCircle p) ≃* Multiplicative ℤ`
-(`TauCeti.AddCircle.fundamentalGroupMulEquiv`) lives on the quotient `ℝ ⧸ (p • ℤ)`. Mathlib's
+(`AddCircle.fundamentalGroupMulEquiv`) lives on the quotient `ℝ ⧸ (p • ℤ)`. Mathlib's
 canonical circle is instead `Circle`, the unit sphere `{z : ℂ | ‖z‖ = 1}` with its complex
 multiplicative group structure, and the two are identified by the homeomorphism
 `AddCircle.homeomorphCircle : AddCircle (2 * π) ≃ₜ Circle` (which sends `0` to `1`).
@@ -26,7 +26,7 @@ group at the canonical basepoint `1 : Circle`. Mathlib's basepoint-change isomor
   `π₁(Circle, x) ≃* Multiplicative ℤ`.
 
 The canonical-basepoint computation uses the concrete lift `0 : ℝ` through
-`TauCeti.AddCircle.fundamentalGroupMulEquivZero`.
+`AddCircle.fundamentalGroupMulEquivZero`.
 
 This is the `Circle ⊆ ℂ` instance of the universal-covers roadmap Stage 4 target `π₁(S¹) ≅ ℤ`
 (`TauCetiRoadmap/UniversalCovers/README.md`, item 12), realised on the standard Mathlib circle

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
@@ -21,8 +21,8 @@ This realizes `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13,
 ## Main declarations
 
 * `AddCircle.isAspherical_pi`: an indexed product of real circles is aspherical.
-* `AddCircle.isEilenbergMacLaneSpaceOne_pi`: an indexed product of nondegenerate
-  real circles is a `K(Π i, ℤ, 1)`.
+* `AddCircle.isEilenbergMacLaneSpaceOne_pi`: an indexed product of nondegenerate real circles is a
+  `K(Π i, ℤ, 1)`.
 -/
 
 public section

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
@@ -20,14 +20,12 @@ This realizes `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13,
 
 ## Main declarations
 
-* `TauCeti.AddCircle.isAspherical_pi`: an indexed product of real circles is aspherical.
-* `TauCeti.AddCircle.isEilenbergMacLaneSpaceOne_pi`: an indexed product of nondegenerate
+* `AddCircle.isAspherical_pi`: an indexed product of real circles is aspherical.
+* `AddCircle.isEilenbergMacLaneSpaceOne_pi`: an indexed product of nondegenerate
   real circles is a `K(Π i, ℤ, 1)`.
 -/
 
 public section
-
-namespace TauCeti
 
 open scoped Topology Topology.Homotopy
 
@@ -53,5 +51,3 @@ theorem isEilenbergMacLaneSpaceOne_pi (p : ι → ℝ) (hp : ∀ i, p i ≠ 0) (
 end AddCircle
 
 end
-
-end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/FundamentalGroup.lean
@@ -12,7 +12,7 @@ public import TauCeti.AlgebraicTopology.UniversalCover.Circle.FundamentalGroup
 
 Combining the product formula for fundamental groups
 (`TauCeti.FundamentalGroup.prodMulEquiv`, `…piMulEquiv`) with the circle computation
-`π₁(AddCircle p) ≃* Multiplicative ℤ` (`TauCeti.AddCircle.fundamentalGroupMulEquivZero`)
+`π₁(AddCircle p) ≃* Multiplicative ℤ` (`AddCircle.fundamentalGroupMulEquivZero`)
 gives the fundamental group of a torus. For a finite product of circles this is the free
 abelian group `(Multiplicative ℤ)ᵏ`; in particular the standard two-torus
 `AddCircle p × AddCircle q` has fundamental group `Multiplicative ℤ × Multiplicative ℤ`.
@@ -22,17 +22,15 @@ This realises the universal-covers roadmap Stage 4 "applications" target `π_n(T
 
 ## Main declarations
 
-* `TauCeti.AddCircle.prodFundamentalGroupMulEquiv`:
+* `AddCircle.prodFundamentalGroupMulEquiv`:
   `π₁(AddCircle p × AddCircle q, (x, y)) ≃* Multiplicative ℤ × Multiplicative ℤ`.
-* `TauCeti.AddCircle.piFundamentalGroupMulEquiv`:
+* `AddCircle.piFundamentalGroupMulEquiv`:
   `π₁(Π i, AddCircle (p i), x) ≃* Π i, Multiplicative ℤ`, the fundamental group of a torus.
-* `TauCeti.AddCircle.prodFundamentalGroupMulEquivZero`,
-  `TauCeti.AddCircle.piFundamentalGroupMulEquivZero`: the basepoint-`0` specialisations.
+* `AddCircle.prodFundamentalGroupMulEquivZero`,
+  `AddCircle.piFundamentalGroupMulEquivZero`: the basepoint-`0` specialisations.
 -/
 
 public section
-
-namespace TauCeti
 
 open Path.Homotopic
 
@@ -49,7 +47,7 @@ def prodFundamentalGroupMulEquiv {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0)
     (ex : ((↑) : ℝ → AddCircle p) ⁻¹' {x}) (ey : ((↑) : ℝ → AddCircle q) ⁻¹' {y}) :
     FundamentalGroup (AddCircle p × AddCircle q) (x, y) ≃*
       Multiplicative ℤ × Multiplicative ℤ :=
-  (FundamentalGroup.prodMulEquiv x y).trans
+  (TauCeti.FundamentalGroup.prodMulEquiv x y).trans
     ((fundamentalGroupMulEquiv p hp ex).prodCongr (fundamentalGroupMulEquiv q hq ey))
 
 @[simp]
@@ -63,7 +61,7 @@ theorem prodFundamentalGroupMulEquiv_apply {p q : ℝ} (hp : p ≠ 0) (hq : q �
         fundamentalGroupMulEquiv q hq ey
           (FundamentalGroup.map (ContinuousMap.snd : C(AddCircle p × AddCircle q, _)) (x, y) γ)) :=
   congrArg ((fundamentalGroupMulEquiv p hp ex).prodCongr (fundamentalGroupMulEquiv q hq ey))
-    (FundamentalGroup.prodMulEquiv_apply x y γ)
+    (TauCeti.FundamentalGroup.prodMulEquiv_apply x y γ)
 
 @[simp]
 theorem prodFundamentalGroupMulEquiv_symm_apply {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0)
@@ -73,7 +71,7 @@ theorem prodFundamentalGroupMulEquiv_symm_apply {p q : ℝ} (hp : p ≠ 0) (hq :
     (prodFundamentalGroupMulEquiv hp hq ex ey).symm mn =
       prod ((fundamentalGroupMulEquiv p hp ex).symm mn.1)
         ((fundamentalGroupMulEquiv q hq ey).symm mn.2) :=
-  FundamentalGroup.prodMulEquiv_symm_apply x y
+  TauCeti.FundamentalGroup.prodMulEquiv_symm_apply x y
     (((fundamentalGroupMulEquiv p hp ex).prodCongr (fundamentalGroupMulEquiv q hq ey)).symm mn)
 
 /-- The fundamental group of a torus `Π i, AddCircle (p i)`, based at any point `x` with chosen
@@ -84,7 +82,7 @@ loop. -/
 def piFundamentalGroupMulEquiv {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0)
     {x : ∀ i, AddCircle (p i)} (e : ∀ i, ((↑) : ℝ → AddCircle (p i)) ⁻¹' {x i}) :
     FundamentalGroup (∀ i, AddCircle (p i)) x ≃* ∀ _ : ι, Multiplicative ℤ :=
-  (FundamentalGroup.piMulEquiv x).trans
+  (TauCeti.FundamentalGroup.piMulEquiv x).trans
     (MulEquiv.piCongrRight fun i => fundamentalGroupMulEquiv (p i) (hp i) (e i))
 
 @[simp]
@@ -95,14 +93,14 @@ theorem piFundamentalGroupMulEquiv_apply {ι : Type*} {p : ι → ℝ} (hp : ∀
       fundamentalGroupMulEquiv (p i) (hp i) (e i)
         (FundamentalGroup.map (ContinuousMap.eval i) x γ) :=
   congrArg (fundamentalGroupMulEquiv (p i) (hp i) (e i))
-    (FundamentalGroup.piMulEquiv_apply x γ i)
+    (TauCeti.FundamentalGroup.piMulEquiv_apply x γ i)
 
 @[simp]
 theorem piFundamentalGroupMulEquiv_symm_apply {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0)
     {x : ∀ i, AddCircle (p i)} (e : ∀ i, ((↑) : ℝ → AddCircle (p i)) ⁻¹' {x i})
     (n : ∀ _ : ι, Multiplicative ℤ) : (piFundamentalGroupMulEquiv hp e).symm n =
       pi fun i => (fundamentalGroupMulEquiv (p i) (hp i) (e i)).symm (n i) :=
-  FundamentalGroup.piMulEquiv_symm_apply x
+  TauCeti.FundamentalGroup.piMulEquiv_symm_apply x
     ((MulEquiv.piCongrRight fun i => fundamentalGroupMulEquiv (p i) (hp i) (e i)).symm n)
 
 /-- The fundamental group of the two-torus `AddCircle p × AddCircle q`, based at `(0, 0)`, is
@@ -159,5 +157,3 @@ theorem piFundamentalGroupMulEquivZero_symm_apply {ι : Type*} {p : ι → ℝ}
 end AddCircle
 
 end
-
-end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/HigherHomotopy.lean
@@ -21,15 +21,13 @@ Together with the fundamental-group computation in
 
 ## Main declarations
 
-* `TauCeti.AddCircle.subsingleton_homotopyGroup_pi`: every homotopy group in dimension at
+* `AddCircle.subsingleton_homotopyGroup_pi`: every homotopy group in dimension at
   least two of an indexed product of real circles is trivial.
-* `TauCeti.AddCircle.homotopyGroup_pi_eq_one`,
-  `TauCeti.AddCircle.homotopyGroupPi_pi_eq_one`: the corresponding equality statements.
+* `AddCircle.homotopyGroup_pi_eq_one`,
+  `AddCircle.homotopyGroupPi_pi_eq_one`: the corresponding equality statements.
 -/
 
 public section
-
-namespace TauCeti
 
 open scoped Topology Topology.Homotopy
 
@@ -53,5 +51,3 @@ theorem homotopyGroupPi_pi_eq_one (n : ℕ) (a : π_ (n + 2) (∀ i, AddCircle (
   homotopyGroup_pi_eq_one p x a
 
 end AddCircle
-
-end TauCeti


### PR DESCRIPTION
This PR moves the circle and torus extension APIs from the recreated `TauCeti.AddCircle` and `TauCeti.UnitAddCircle` namespaces to Mathlib's canonical root `AddCircle` and `UnitAddCircle` namespaces. It updates all qualified documentation and explicitly qualifies the `TauCeti.FundamentalGroup` dependencies exposed by closing the wrapper, addressing the AddCircle slice of #3547.

All moved `AddCircle` and `UnitAddCircle` names were checked against the pinned Mathlib environment with no collisions. Local verification: `lake build` (8,212 jobs), `python3 scripts/lint-dot-notation.py` (seven ratchetable findings removed, zero new findings), and direct root-namespace elaboration checks.

Roadmap: UniversalCovers

:robot: Prepared with OpenAI Codex