### PR TITLE
refactor: give the valuation API dot notation

### DIFF
--- a/TauCeti/Algebra/Order/Group/Cofinal.lean
+++ b/TauCeti/Algebra/Order/Group/Cofinal.lean
@@ -75,7 +75,7 @@ def IsCofinalElement (H : Subgroup Γ) (γ : Γ) : Prop :=
 
 Deliberately not `@[simp]`: the right-hand side is the unfolded bounded quantifier, so tagging
 it rewrites uses of the named predicate into raw `∀ … ∃ …` form. This mirrors
-`TauCeti.Valuation.cofinalValueFor_def`, which is not `@[simp]` for the same reason. -/
+`Valuation.cofinalValueFor_def`, which is not `@[simp]` for the same reason. -/
 theorem isCofinalElement_def {H : Subgroup Γ} {γ : Γ} :
     IsCofinalElement H γ ↔ ∀ h ∈ H, ∃ n : ℕ, γ ^ n < h :=
   Iff.rfl

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Cont/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Cont/Basic.lean
@@ -26,7 +26,7 @@ continuous ring homomorphism (Remark 7.9).
 A point of `Spv A` is a valuative relation, so a predicate on valuations descends to it only if
 equivalent valuations agree on the predicate. For continuity as Wedhorn states it — the
 quantifier running over the value group `Γ_v` — that holds, and
-`TauCeti.Valuation.IsEquiv.isContinuous_iff` says so. Had continuity instead been asked of every
+`Valuation.IsEquiv.isContinuous_iff` says so. Had continuity instead been asked of every
 `γ` in the ambient codomain, it would **not** descend, and `Cont A` would not be well defined;
 the module docstring of `TauCeti.RingTheory.Valuation.Continuous.Basic` carries the
 counterexample.
@@ -75,12 +75,12 @@ public section
 
 namespace TauCeti.ValuationSpectrum
 
-open TauCeti TauCeti.Valuation
+open TauCeti Valuation
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 
 /-- **Continuity of a point of `Spv A`.** A point is *continuous* when its canonical valuation
-is, in the attained-value sense of `TauCeti.Valuation.IsContinuous`. Any representative would do
+is, in the attained-value sense of `Valuation.IsContinuous`. Any representative would do
 — that is `isContinuous_ofValuation_iff` — but the canonical one makes the definition depend on
 nothing chosen.
 
@@ -97,7 +97,7 @@ theorem isContinuous_def (v : Spv A) : v.IsContinuous ↔ v.valuation.IsContinuo
 it a subspace; here it is the underlying set, and the subspace topology is the one the *coercion*
 `↥(cont A)` carries as a subtype of `Spv A`.
 
-Membership is the attained-value test of `TauCeti.Valuation.IsContinuous`, which is Wedhorn's
+Membership is the attained-value test of `Valuation.IsContinuous`, which is Wedhorn's
 Definition 7.7 once right multiplication is continuous —
 `isContinuous_iff_forall_isOpen_lt_div` is that step, and it is where
 `[ContinuousConstSMul Aᵐᵒᵖ A]` is asked for. It is *not* asked for
@@ -111,7 +111,7 @@ theorem mem_cont_iff (v : Spv A) : v ∈ cont A ↔ v.IsContinuous := Iff.rfl
 
 /-- **Continuity may be tested on any representative.** This is what makes `cont` well defined:
 the point `ofValuation w` is continuous exactly when `w` is, for every `w` in the class, not
-merely for the canonical one. It rests on `TauCeti.Valuation.IsEquiv.isContinuous_iff`, and
+merely for the canonical one. It rests on `Valuation.IsEquiv.isContinuous_iff`, and
 would fail for a continuity predicate quantified over the ambient codomain.
 
 Not `@[simp]`: `isContinuous_def` already rewrites the left-hand side, so this would not be in

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Cont/OfIdeal.lean
@@ -64,7 +64,7 @@ public section
 
 namespace TauCeti.ValuationSpectrum
 
-open TauCeti TauCeti.Huber TauCeti.Valuation
+open TauCeti TauCeti.Huber Valuation
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/RestrictToIdeal.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/RestrictToIdeal.lean
@@ -42,7 +42,7 @@ compute; the retraction property is the content of the two theorems, not of the 
   point, in terms of the original one.
 * `TauCeti.ValuationSpectrum.restrictToIdeal_mem_spvOfIdeal` : the restriction lands in
   `Spv (A, I)`. The mathematics is valuation-level and proved there, as
-  `TauCeti.Valuation.characteristicSubgroupOfIdeal_restrictToIdeal_eq_top`; this only adds that
+  `Valuation.characteristicSubgroupOfIdeal_restrictToIdeal_eq_top`; this only adds that
   membership may be tested on the canonical valuation of the point.
 * `TauCeti.ValuationSpectrum.coe_restrictToIdealCodRestrict` : the corestriction read back in
   `Spv A`.
@@ -60,7 +60,7 @@ public section
 
 namespace TauCeti.ValuationSpectrum
 
-open MonoidWithZeroHom TauCeti TauCeti.Valuation
+open MonoidWithZeroHom TauCeti Valuation
 
 variable {A : Type*} [CommRing A]
 
@@ -83,14 +83,14 @@ theorem restrictToIdeal_def (v : Spv A) (I : Ideal A)
 content of a point of `Spv A`, so this is the interface to `restrictToIdeal` at the level of
 points: `a ≤ b` after restriction exactly when `a`'s value is discarded, or `b`'s is kept and
 `a ≤ b` held already. The side conditions are discharged by
-`TauCeti.Valuation.restrictToIdeal_eq_zero_iff`. -/
+`Valuation.restrictToIdeal_eq_zero_iff`. -/
 @[simp]
 theorem vle_restrictToIdeal (v : Spv A) (I : Ideal A)
     (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) (a b : A) :
     (restrictToIdeal v I hfg).toValuativeRel.vle a b ↔
       v.valuation.restrictToIdeal I hfg a = 0 ∨
         v.valuation.restrictToIdeal I hfg b ≠ 0 ∧ v.toValuativeRel.vle a b := by
-  rw [restrictToIdeal_def, vle_ofValuation, TauCeti.Valuation.restrictToIdeal_le_iff]
+  rw [restrictToIdeal_def, vle_ofValuation, Valuation.restrictToIdeal_le_iff]
   exact or_congr_right (and_congr_right fun _ ↦ valuation_le_iff v a b)
 
 /-- **Wedhorn §7.1.2: the restriction lands in `Spv (A, I)`.** This is the substantive half of
@@ -98,14 +98,14 @@ the roadmap's `r_I : Spv A → Spv (A, I)`: the point `restrictToIdeal v I` real
 condition cutting out the subspace.
 
 The mathematics is valuation-level and lives there, as
-`TauCeti.Valuation.characteristicSubgroupOfIdeal_restrictToIdeal_eq_top`; all this adds is that
+`Valuation.characteristicSubgroupOfIdeal_restrictToIdeal_eq_top`; all this adds is that
 membership of a point may be tested on its canonical valuation. -/
 @[simp]
 theorem restrictToIdeal_mem_spvOfIdeal (v : Spv A) (I : Ideal A)
     (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) :
     restrictToIdeal v I hfg ∈ spvOfIdeal I hfg := by
   rw [restrictToIdeal_def, mem_spvOfIdeal_ofValuation]
-  exact TauCeti.Valuation.characteristicSubgroupOfIdeal_restrictToIdeal_eq_top _ I hfg
+  exact Valuation.characteristicSubgroupOfIdeal_restrictToIdeal_eq_top _ I hfg
 
 /-- **The roadmap's `r_I : Spv A → Spv (A, I)`**, with the codomain the roadmap asks for. This is
 `restrictToIdeal` corestricted along the landing theorem, so a consumer receives a point of the
@@ -133,7 +133,7 @@ theorem restrictToIdeal_eq_self_of_mem_spvOfIdeal (v : Spv A) (I : Ideal A)
   -- with `cΓ_v(I)` everything, the restriction vanishes exactly where `v` does
   have hzero : ∀ a : A, v.valuation.restrictToIdeal I hfg a = 0 ↔ v.valuation a = 0 := by
     intro a
-    rw [TauCeti.Valuation.restrictToIdeal_eq_zero_iff]
+    rw [Valuation.restrictToIdeal_eq_zero_iff]
     refine ⟨?_, fun h ↦ Or.inl h⟩
     rintro (h | ⟨h0, hmem⟩)
     · exact h

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
@@ -41,7 +41,7 @@ public section
 
 namespace TauCeti.ValuationSpectrum
 
-open TauCeti TauCeti.Huber TauCeti.Valuation
+open TauCeti TauCeti.Huber Valuation
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
@@ -63,7 +63,7 @@ public section
 
 namespace TauCeti.ValuationSpectrum
 
-open TauCeti.Valuation
+open Valuation
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Comap.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Comap.lean
@@ -58,7 +58,7 @@ public section
 
 namespace TauCeti.ValuationSpectrum
 
-open TauCeti.Valuation
+open Valuation
 
 variable {A B C : Type*} [CommRing A] [TopologicalSpace A] [CommRing B] [TopologicalSpace B]
   [CommRing C] [TopologicalSpace C]

--- a/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Basic.lean
@@ -23,7 +23,7 @@ of points whose ideal-indexed characteristic subgroup is everything.
 
 Points of `Spv A` are *classes* of valuations, so a condition on valuations cuts out a subset
 only if it is class-invariant. That is Lemma 7.4's role, recorded as
-`TauCeti.Valuation.characteristicSubgroupOfIdeal_eq_top_congr_of_isEquiv`. No quotient
+`Valuation.characteristicSubgroupOfIdeal_eq_top_congr_of_isEquiv`. No quotient
 eliminator is needed: `ValuationSpectrum.valuation` picks a canonical representative of each
 point and `ofValuation_valuation` says the choice round-trips, so the set is defined directly
 by that representative and `mem_spvOfIdeal_ofValuation` transfers the test to any other.
@@ -66,7 +66,7 @@ public section
 
 namespace TauCeti.ValuationSpectrum
 
-open TauCeti.Valuation MonoidWithZeroHom
+open Valuation MonoidWithZeroHom
 
 variable {A : Type*} [CommRing A]
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Spectral.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/SpvOfIdeal/Spectral.lean
@@ -125,7 +125,7 @@ public section
 
 namespace TauCeti.ValuationSpectrum
 
-open Set Topology TopologicalSpace TauCeti TauCeti.Valuation MonoidWithZeroHom
+open Set Topology TopologicalSpace TauCeti Valuation MonoidWithZeroHom
 
 variable {A : Type*} [CommRing A]
 

--- a/TauCeti/RingTheory/Huber/Continuous/OfCofinal.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/OfCofinal.lean
@@ -67,7 +67,7 @@ public section
 
 namespace TauCeti.Huber.PairOfDefinition
 
-open TauCeti TauCeti.Valuation
+open TauCeti Valuation
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
   {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]

--- a/TauCeti/RingTheory/Valuation/CharacteristicGroup.lean
+++ b/TauCeti/RingTheory/Valuation/CharacteristicGroup.lean
@@ -39,24 +39,24 @@ formalised here.
 
 ## Main definitions
 
-* `TauCeti.Valuation.CofinalValue v a` : Powers of `v a` fall below every positive element
+* `Valuation.CofinalValue v a` : Powers of `v a` fall below every positive element
   of the value group of `v`.
-* `TauCeti.Valuation.characteristicGenerators v` and
-  `TauCeti.Valuation.characteristicSubgroup v` : The attained values `≥ 1` and the convex
+* `Valuation.characteristicGenerators v` and
+  `Valuation.characteristicSubgroup v` : The attained values `≥ 1` and the convex
   subgroup `cΓ_v` they generate.
-* `TauCeti.Valuation.HasFullCharacteristicGroup v` : Every positive element of the value
+* `Valuation.HasFullCharacteristicGroup v` : Every positive element of the value
   group of `v` is bounded by attained values.
 
 ## Main results
 
-* `TauCeti.Valuation.exists_pow_lt_of_forall_cofinalValue` : one exponent serves finitely many
+* `Valuation.exists_pow_lt_of_forall_cofinalValue` : one exponent serves finitely many
   cofinal values.
-* `TauCeti.Valuation.mem_characteristicSubgroup_iff` : Membership in `cΓ_v` is bounding by a
+* `Valuation.mem_characteristicSubgroup_iff` : Membership in `cΓ_v` is bounding by a
   single attained value `≥ 1`.
-* `TauCeti.Valuation.hasFullCharacteristicGroup_iff_characteristicSubgroup_eq_top` : The
+* `Valuation.hasFullCharacteristicGroup_iff_characteristicSubgroup_eq_top` : The
   elementwise fullness condition is exactly `cΓ_v = Γ_v`.
-* `TauCeti.Valuation.characteristicSubgroup_eq_comap_of_isEquiv` and
-  `TauCeti.Valuation.valueGroupOrderIso_mem_characteristicSubgroup_iff` : `cΓ_v` is invariant
+* `Valuation.characteristicSubgroup_eq_comap_of_isEquiv` and
+  `Valuation.valueGroupOrderIso_mem_characteristicSubgroup_iff` : `cΓ_v` is invariant
   under valuation equivalence, so it descends to points of the valuation spectrum.
 
 ## References
@@ -71,7 +71,7 @@ cluster), reformulated on the value group.
 
 public section
 
-namespace TauCeti.Valuation
+namespace Valuation
 
 open MonoidWithZeroHom
 
@@ -396,4 +396,4 @@ theorem characteristicSubgroup_eq_comap_of_isEquiv {v : Valuation A Γ₀}
     ((valueGroupOrderIso_mem_characteristicSubgroup_iff h).symm.trans
       TauCeti.ConvexSubgroup.mem_comap.symm)
 
-end TauCeti.Valuation
+end Valuation

--- a/TauCeti/RingTheory/Valuation/CharacteristicGroup.lean
+++ b/TauCeti/RingTheory/Valuation/CharacteristicGroup.lean
@@ -121,7 +121,7 @@ theorem CofinalValue.of_isEquiv {v : Valuation A Γ₀} {w : Valuation A Γ₀'}
   simpa using this
 
 /-- Cofinality is invariant under valuation equivalence. -/
-theorem _root_.Valuation.IsEquiv.cofinalValue_iff {v : Valuation A Γ₀}
+theorem IsEquiv.cofinalValue_iff {v : Valuation A Γ₀}
     {w : Valuation A Γ₀'} (h : v.IsEquiv w) {a : A} :
     CofinalValue v a ↔ CofinalValue w a :=
   ⟨fun hv ↦ hv.of_isEquiv h, fun hw ↦ hw.of_isEquiv h.symm⟩
@@ -181,7 +181,7 @@ theorem HasFullCharacteristicGroup.of_isEquiv {v : Valuation A Γ₀} {w : Valua
     simpa using this
 
 /-- The full-characteristic-group condition is invariant under valuation equivalence. -/
-theorem _root_.Valuation.IsEquiv.hasFullCharacteristicGroup_iff {v : Valuation A Γ₀}
+theorem IsEquiv.hasFullCharacteristicGroup_iff {v : Valuation A Γ₀}
     {w : Valuation A Γ₀'} (h : v.IsEquiv w) :
     HasFullCharacteristicGroup v ↔ HasFullCharacteristicGroup w :=
   ⟨fun hv ↦ hv.of_isEquiv h, fun hw ↦ hw.of_isEquiv h.symm⟩

--- a/TauCeti/RingTheory/Valuation/CofinalIdeal/Basic.lean
+++ b/TauCeti/RingTheory/Valuation/CofinalIdeal/Basic.lean
@@ -30,25 +30,25 @@ something derivable from cofinality.
 
 ## Main definitions
 
-* `TauCeti.Valuation.CofinalValueFor v H a` : The powers of `v a` fall below every member
+* `Valuation.CofinalValueFor v H a` : The powers of `v a` fall below every member
   of the subgroup `H` of the value group.
-* `TauCeti.Valuation.cofinalIdeal v hH` : Those elements, as an ideal.
+* `Valuation.cofinalIdeal v hH` : Those elements, as an ideal.
 
 ## Main results
-* `TauCeti.Valuation.cofinalValueFor_closure_singleton_of_le` : A value bounded by
+* `Valuation.cofinalValueFor_closure_singleton_of_le` : A value bounded by
   `h < 1` is cofinal for the convex subgroup `h` generates — below `1`, a larger value
   generates a smaller subgroup.
 
-* `TauCeti.Valuation.cofinalValueFor_iff_isCofinalElement` : For a non-vanishing value, the
+* `Valuation.cofinalValueFor_iff_isCofinalElement` : For a non-vanishing value, the
   valuation-side predicate agrees with the group-side `IsCofinalElement` on the value group.
   This is what lets Wedhorn Proposition 1.20 apply.
-* `TauCeti.Valuation.isRadical_cofinalIdeal` : The ideal is radical — the `rad(c) = c` half
+* `Valuation.isRadical_cofinalIdeal` : The ideal is radical — the `rad(c) = c` half
   of Lemma 7.1 — with `cofinalValueFor_pow_iff` the elementwise form behind it.
-* `TauCeti.Valuation.cofinalIdeal_ne_top` : It is proper, a corollary of the ring-level
-  `TauCeti.Valuation.not_cofinalValueFor_one`.
-* `TauCeti.Valuation.cofinalValueFor_top_iff` : At the whole value group the predicate is the
+* `Valuation.cofinalIdeal_ne_top` : It is proper, a corollary of the ring-level
+  `Valuation.not_cofinalValueFor_one`.
+* `Valuation.cofinalValueFor_top_iff` : At the whole value group the predicate is the
   ambient `CofinalValue`.
-* `TauCeti.Valuation.cofinalValueFor_neg_iff` : cofinality is invariant under negation, with
+* `Valuation.cofinalValueFor_neg_iff` : cofinality is invariant under negation, with
   `CofinalValueFor.sub` the resulting difference closure.
 
 ## Implementation notes
@@ -67,7 +67,7 @@ there.
 
 public section
 
-namespace TauCeti.Valuation
+namespace Valuation
 
 open MonoidWithZeroHom
 
@@ -308,4 +308,4 @@ theorem isRadical_cofinalIdeal {v : Valuation A Γ₀}
 
 end CommRing
 
-end TauCeti.Valuation
+end Valuation

--- a/TauCeti/RingTheory/Valuation/CofinalIdeal/Greatest.lean
+++ b/TauCeti/RingTheory/Valuation/CofinalIdeal/Greatest.lean
@@ -27,41 +27,41 @@ the two uses Wedhorn makes of it, and both appear here.
 
 ## Main definitions
 
-* `TauCeti.Valuation.IdealCofinalFor v H I` : every element of `I` has value cofinal for `H`.
-* `TauCeti.Valuation.IdealMeetsCharacteristicSubgroup v I` : `v(I)` meets `cΓ_v`, the
+* `Valuation.IdealCofinalFor v H I` : every element of `I` has value cofinal for `H`.
+* `Valuation.IdealMeetsCharacteristicSubgroup v I` : `v(I)` meets `cΓ_v`, the
   branch condition of Definition 7.3.
-* `TauCeti.Valuation.valueSet v I` : the nonzero values of `v` on `I`.
-* `TauCeti.Valuation.characteristicSubgroupOfIdeal` : **Definition 7.3**, `cΓ_v(I)`.
+* `Valuation.valueSet v I` : the nonzero values of `v` on `I`.
+* `Valuation.characteristicSubgroupOfIdeal` : **Definition 7.3**, `cΓ_v(I)`.
 
 ## Main results
-* `TauCeti.Valuation.idealMeetsCharacteristicSubgroup_iff` and
-  `TauCeti.Valuation.idealMeetsCharacteristicSubgroup_of_one_le` : the branch condition of
+* `Valuation.idealMeetsCharacteristicSubgroup_iff` and
+  `Valuation.idealMeetsCharacteristicSubgroup_of_one_le` : the branch condition of
   Definition 7.3 restated on `valueSet`, and the introduction rule discharging it from a
   value `≥ 1`.
 
-* `TauCeti.Valuation.idealCofinalFor_iff_forall_isCofinalElement` : the ideal condition is
+* `Valuation.idealCofinalFor_iff_forall_isCofinalElement` : the ideal condition is
   cofinality of each nonzero value as an element of the value group; vanishing values are
   excluded rather than constrained, since `0` is cofinal for every subgroup.
-* `TauCeti.Valuation.idealCofinalFor_of_span`,
-  `TauCeti.Valuation.le_closure_singleton_of_idealCofinalFor` and
-  `TauCeti.Valuation.le_of_idealCofinalFor_of_mem_valueSet` : the membership, maximality and
-  minimality halves of **Lemma 7.2**, with `TauCeti.Valuation.isLeast_of_idealCofinalFor` the
+* `Valuation.idealCofinalFor_of_span`,
+  `Valuation.le_closure_singleton_of_idealCofinalFor` and
+  `Valuation.le_of_idealCofinalFor_of_mem_valueSet` : the membership, maximality and
+  minimality halves of **Lemma 7.2**, with `Valuation.isLeast_of_idealCofinalFor` the
   least-element form of the last.
-* `TauCeti.Valuation.idealCofinalFor_radical_iff` : cofinality depends only on the radical.
-* `TauCeti.Valuation.isGreatestIdealCofinal_closure_singleton_of_span` : **Lemma 7.2's
+* `Valuation.idealCofinalFor_radical_iff` : cofinality depends only on the radical.
+* `Valuation.isGreatestIdealCofinal_closure_singleton_of_span` : **Lemma 7.2's
   greatest-cofinal conclusion** from a generating set, with
   `exists_isGreatestIdealCofinal_of_not_meets` its existence form, which is what Definition 7.3
   presupposes.
-* `TauCeti.Valuation.exists_mem_valueSet_mem_characteristicSubgroupOfIdeal` and
-  `TauCeti.Valuation.isLeast_characteristicSubgroupOfIdeal` : **Lemma 7.2's attainment and
+* `Valuation.exists_mem_valueSet_mem_characteristicSubgroupOfIdeal` and
+  `Valuation.isLeast_characteristicSubgroupOfIdeal` : **Lemma 7.2's attainment and
   minimality conclusions** for `cΓ_v(I)` — off the first branch and with `v` not identically zero
   on `I`, it contains a value of `I` and is the least convex subgroup that does.
-* `TauCeti.Valuation.characteristicSubgroup_le_characteristicSubgroupOfIdeal` : `cΓ_v(I)` always
+* `Valuation.characteristicSubgroup_le_characteristicSubgroupOfIdeal` : `cΓ_v(I)` always
   contains `cΓ_v`.
-* `TauCeti.Valuation.characteristicSubgroupOfIdeal_eq_top_iff` and
-  `TauCeti.Valuation.characteristicSubgroupOfIdeal_eq_top_iff_forall_span` : **Lemma 7.4**, in
+* `Valuation.characteristicSubgroupOfIdeal_eq_top_iff` and
+  `Valuation.characteristicSubgroupOfIdeal_eq_top_iff_forall_span` : **Lemma 7.4**, in
   the all-of-`I` and generating-set forms.
-* `TauCeti.Valuation.characteristicSubgroupOfIdeal_eq_top_congr_of_isEquiv` : that criterion is
+* `Valuation.characteristicSubgroupOfIdeal_eq_top_congr_of_isEquiv` : that criterion is
   an invariant of the valuation class, which is what lets `Spv (A, I)` be carved out of the
   valuation spectrum.
 
@@ -90,7 +90,7 @@ its `Valuation.CofinalValue` in `SpvAI.lean`.
 
 public section
 
-namespace TauCeti.Valuation
+namespace Valuation
 
 open MonoidWithZeroHom
 
@@ -628,4 +628,4 @@ theorem characteristicSubgroupOfIdeal_eq_top_congr_of_isEquiv {Γ₀' : Type*}
 
 end CommRing
 
-end TauCeti.Valuation
+end Valuation

--- a/TauCeti/RingTheory/Valuation/CofinalIdeal/Restrict.lean
+++ b/TauCeti/RingTheory/Valuation/CofinalIdeal/Restrict.lean
@@ -26,20 +26,20 @@ The point-level map on `Spv A` that Wedhorn's retraction `r_I` is built from liv
 
 ## Main definitions
 
-* `TauCeti.Valuation.RestrictedValues` : the value monoid the restriction lands in.
-* `TauCeti.Valuation.restrictToIdeal` : the restricted valuation `v|cΓ_v(I)`.
+* `Valuation.RestrictedValues` : the value monoid the restriction lands in.
+* `Valuation.restrictToIdeal` : the restricted valuation `v|cΓ_v(I)`.
 
 ## Main results
 
-* `TauCeti.Valuation.restrictToIdeal_apply_of_notMem`,
-  `TauCeti.Valuation.restrictToIdeal_apply_of_eq_zero` : the two vanishing branches.
-* `TauCeti.Valuation.restrictToIdeal_eq_zero_iff` : where the restriction vanishes, totally.
-* `TauCeti.Valuation.restrictToIdeal_le_iff` : how restricted values compare, totally.
-* `TauCeti.Valuation.restrictToIdeal_ne_zero_of_le` : the restriction keeps every value above a
+* `Valuation.restrictToIdeal_apply_of_notMem`,
+  `Valuation.restrictToIdeal_apply_of_eq_zero` : the two vanishing branches.
+* `Valuation.restrictToIdeal_eq_zero_iff` : where the restriction vanishes, totally.
+* `Valuation.restrictToIdeal_le_iff` : how restricted values compare, totally.
+* `Valuation.restrictToIdeal_ne_zero_of_le` : the restriction keeps every value above a
   kept value.
-* `TauCeti.Valuation.exists_mem_restrictToIdeal_ne_zero` : **Wedhorn Lemma 7.5(3)**, that the
+* `Valuation.exists_mem_restrictToIdeal_ne_zero` : **Wedhorn Lemma 7.5(3)**, that the
   restriction does not vanish identically on `I` unless `v` does.
-* `TauCeti.Valuation.restrictToIdeal_ne_zero_of_isAdmissible` : it does not kill a denominator
+* `Valuation.restrictToIdeal_ne_zero_of_isAdmissible` : it does not kill a denominator
   dominating an admissible numerator set.
 
 The *characterisation* lemmas — the vanishing branches, `restrictToIdeal_eq_zero_iff` and
@@ -72,7 +72,7 @@ is carried across by `ConvexSubgroup.comapUnitsWithZero`.
 
 public section
 
-namespace TauCeti.Valuation
+namespace Valuation
 
 open MonoidWithZeroHom TauCeti
 
@@ -328,7 +328,7 @@ private theorem characteristicSubgroup_restrictToIdeal_eq_top_of_meets (w : Valu
           (ValueGroup₀ (.ofClass w))ˣ) : ValueGroup₀ (.ofClass w)) :=
       WithZero.coe_unitsWithZeroEquiv_eq_units_val _
     rw [← hcoe, WithZero.coe_le_coe]
-    simp only [map_inv, InvMemClass.coe_inv]
+    simp only [InvMemClass.coe_inv]
     simpa using inv_le_inv_iff.mpr hginv
   · rw [← ValueGroup₀.embedding_strictMono.le_iff_le, Valuation.embedding_restrict, ← hu,
       coe_le_restrictToIdeal_iff, hga]
@@ -488,4 +488,4 @@ theorem restrictToIdeal_ne_zero_of_isAdmissible (v : Valuation A Γ₀) (I : Ide
         (Or.inl fun a ha ↦ cofinalValueFor_top_iff.mp (cofinalValueFor_of_eq_zero (hne a ha)))
     exact restrictToIdeal_ne_zero_of_mem v I hfg hu0 (htop ▸ ConvexSubgroup.mem_top) hRu
 
-end TauCeti.Valuation
+end Valuation

--- a/TauCeti/RingTheory/Valuation/CofinalIdeal/Restrict.lean
+++ b/TauCeti/RingTheory/Valuation/CofinalIdeal/Restrict.lean
@@ -177,7 +177,7 @@ theorem restrictToIdeal_apply_of_notMem (v : Valuation A Γ₀) (I : Ideal A)
     v.restrictToIdeal I hfg a = 0 :=
 by
   rw [restrictToIdeal_def v I hfg (mk0_restrict_mem_comapUnitsWithZero v I hfg)]
-  exact _root_.Valuation.restrictToConvex_apply_of_notMem _ _ _ _
+  exact restrictToConvex_apply_of_notMem _ _ _ _
     (fun hmem => hm ((mk0_restrict_mem_comapUnitsWithZero_iff v I hfg h0).mp hmem))
 
 /-- The restriction vanishes wherever `v` does. -/
@@ -187,7 +187,7 @@ theorem restrictToIdeal_apply_of_eq_zero (v : Valuation A Γ₀) (I : Ideal A)
     (h0 : (MonoidWithZeroHom.ofClass v) a = 0) : v.restrictToIdeal I hfg a = 0 :=
 by
   rw [restrictToIdeal_def v I hfg (mk0_restrict_mem_comapUnitsWithZero v I hfg)]
-  exact _root_.Valuation.restrictToConvex_apply_of_eq_zero _ _ _ (v.restrict_eq_zero_iff.mpr h0)
+  exact restrictToConvex_apply_of_eq_zero _ _ _ (v.restrict_eq_zero_iff.mpr h0)
 
 /-- **Where the restriction vanishes at a nonzero value**, stated through `cΓ_v(I)` itself.
 `restrictToIdeal_eq_zero_iff` is the total form, and is the `@[simp]` one: tagging this
@@ -199,7 +199,7 @@ theorem restrictToIdeal_eq_zero_iff_of_ne (v : Valuation A Γ₀) (I : Ideal A)
       valueGroup.mk (.ofClass v) 1 a (by simp) h0 ∉ characteristicSubgroupOfIdeal v I hfg :=
   by
   rw [restrictToIdeal_def v I hfg (mk0_restrict_mem_comapUnitsWithZero v I hfg)]
-  exact (_root_.Valuation.restrictToConvex_eq_zero_iff_of_ne _ _ _
+  exact (restrictToConvex_eq_zero_iff_of_ne _ _ _
       (fun h => h0 (v.restrict_eq_zero_iff.mp h))).trans
     (not_congr (mk0_restrict_mem_comapUnitsWithZero_iff v I hfg h0))
 
@@ -212,7 +212,7 @@ theorem restrictToIdeal_eq_zero_iff (v : Valuation A Γ₀) (I : Ideal A)
     v.restrictToIdeal I hfg a = 0 ↔ (MonoidWithZeroHom.ofClass v) a = 0 ∨
       ∃ h0 : (MonoidWithZeroHom.ofClass v) a ≠ 0,
         valueGroup.mk (.ofClass v) 1 a (by simp) h0 ∉ characteristicSubgroupOfIdeal v I hfg := by
-  rw [restrictToIdeal, _root_.Valuation.restrictToConvex_eq_zero_iff]
+  rw [restrictToIdeal, restrictToConvex_eq_zero_iff]
   constructor
   · rintro (hz | ⟨hr, hnm⟩)
     · exact Or.inl (v.restrict_eq_zero_iff.mp hz)
@@ -236,10 +236,10 @@ theorem restrictToIdeal_le_iff_of_mem (v : Valuation A Γ₀) (I : Ideal A)
     v.restrictToIdeal I hfg a ≤ v.restrictToIdeal I hfg b ↔ v a ≤ v b :=
 by
   rw [restrictToIdeal_def v I hfg (mk0_restrict_mem_comapUnitsWithZero v I hfg),
-    _root_.Valuation.restrictToConvex_le_iff_of_mem _ _ _ _ _
+    restrictToConvex_le_iff_of_mem _ _ _ _ _
       ((mk0_restrict_mem_comapUnitsWithZero_iff v I hfg h0a).mpr hma)
       ((mk0_restrict_mem_comapUnitsWithZero_iff v I hfg h0b).mpr hmb),
-    _root_.Valuation.restrict_le_iff]
+    restrict_le_iff]
 
 /-- **Comparison after restriction, totally**: a value discarded by the restriction is below
 everything, a kept value is below only kept values, and two kept values compare exactly as they
@@ -256,7 +256,7 @@ theorem restrictToIdeal_le_iff (v : Valuation A Γ₀) (I : Ideal A)
       v.restrictToIdeal I hfg a = 0 ∨ v.restrictToIdeal I hfg b ≠ 0 ∧ v a ≤ v b :=
 by
   rw [restrictToIdeal_def v I hfg (mk0_restrict_mem_comapUnitsWithZero v I hfg),
-    _root_.Valuation.restrictToConvex_le_iff, _root_.Valuation.restrict_le_iff]
+    restrictToConvex_le_iff, restrict_le_iff]
 
 /-- The companion of `restrictToIdeal_lt_coe_iff` with the member on the left. -/
 theorem coe_le_restrictToIdeal_iff (v : Valuation A Γ₀) (I : Ideal A)
@@ -265,7 +265,7 @@ theorem coe_le_restrictToIdeal_iff (v : Valuation A Γ₀) (I : Ideal A)
       (characteristicSubgroupOfIdeal v I hfg)).toSubgroup) :
     (u : RestrictedValues v I hfg) ≤ v.restrictToIdeal I hfg a ↔
       ((u : (ValueGroup₀ (.ofClass v))ˣ) : ValueGroup₀ (.ofClass v)) ≤ v.restrict a :=
-  _root_.Valuation.coe_le_restrictToConvex_iff _ _ _ a u
+  coe_le_restrictToConvex_iff _ _ _ a u
 
 /-- Comparing a restricted value against an abstract member of the transported `cΓ_v(I)`,
 back in the value monoid of `v`. This is the form a cofinality argument needs, where the
@@ -276,14 +276,14 @@ theorem restrictToIdeal_lt_coe_iff (v : Valuation A Γ₀) (I : Ideal A)
       (characteristicSubgroupOfIdeal v I hfg)).toSubgroup) :
     v.restrictToIdeal I hfg a < (u : RestrictedValues v I hfg) ↔
       v.restrict a < ((u : (ValueGroup₀ (.ofClass v))ˣ) : ValueGroup₀ (.ofClass v)) :=
-  _root_.Valuation.restrictToConvex_lt_coe_iff _ _ _ a u
+  restrictToConvex_lt_coe_iff _ _ _ a u
 
 /-- A value at least `1` stays at least `1`: `cΓ_v(I)` keeps every attained value `≥ 1`. -/
 theorem one_le_restrictToIdeal (v : Valuation A Γ₀) (I : Ideal A)
     (hfg : ∃ J : Ideal A, J.FG ∧ I.radical = J.radical) {a : A} (h1 : 1 ≤ v.restrict a) :
     1 ≤ v.restrictToIdeal I hfg a := by
   rw [restrictToIdeal_def v I hfg (mk0_restrict_mem_comapUnitsWithZero v I hfg)]
-  exact _root_.Valuation.one_le_restrictToConvex _ _ _ h1
+  exact one_le_restrictToConvex _ _ _ h1
 
 /-- The **meets** branch of `characteristicSubgroupOfIdeal_restrictToIdeal_eq_top`. When `I`
 meets `cΓ_v`, Wedhorn's

--- a/TauCeti/RingTheory/Valuation/Continuous/Basic.lean
+++ b/TauCeti/RingTheory/Valuation/Continuous/Basic.lean
@@ -145,7 +145,7 @@ theorem isContinuous_of_forall_isOpen_lt {v : Valuation A Γ₀}
 same pairs of elements, so the sets `{a ; v a < v b}` cutting out continuity are not merely
 matched up but literally the same sets. This is what lets continuity be imposed on a point of
 the valuation spectrum. -/
-theorem _root_.Valuation.IsEquiv.isContinuous_iff {v : Valuation A Γ₀} {w : Valuation A Γ₀'}
+theorem IsEquiv.isContinuous_iff {v : Valuation A Γ₀} {w : Valuation A Γ₀'}
     (h : v.IsEquiv w) : v.IsContinuous ↔ w.IsContinuous :=
   forall_congr' fun _ ↦ iff_of_eq (congrArg IsOpen (Set.ext fun _ ↦ h.lt_iff_lt))
 

--- a/TauCeti/RingTheory/Valuation/Continuous/Basic.lean
+++ b/TauCeti/RingTheory/Valuation/Continuous/Basic.lean
@@ -57,28 +57,28 @@ sets are *literally equal* for equivalent valuations, which is
 
 ## Main definitions
 
-* `TauCeti.Valuation.IsContinuous` : continuity of a valuation, in attained-value form. It
+* `Valuation.IsContinuous` : continuity of a valuation, in attained-value form. It
   recovers **Definition 7.7** under `[ContinuousConstSMul Aᵐᵒᵖ A]`, via `isOpen_lt_div`.
 
 ## Main results
 
 * `Valuation.IsEquiv.isContinuous_iff` : continuity depends only on the equivalence class, so it
   descends to the valuation spectrum.
-* `TauCeti.Valuation.IsContinuous.isOpen_lt_div` and
-  `TauCeti.Valuation.isContinuous_iff_forall_isOpen_lt_div` : the defining sets for an arbitrary
+* `Valuation.IsContinuous.isOpen_lt_div` and
+  `Valuation.isContinuous_iff_forall_isOpen_lt_div` : the defining sets for an arbitrary
   element `v b / v c` of the value group — Wedhorn's quantifier in full, as an elimination rule
   and as an equivalence.
-* `TauCeti.Valuation.isContinuous_of_continuous` : the easy half of Remark 7.8(1), needing no
+* `Valuation.isContinuous_of_continuous` : the easy half of Remark 7.8(1), needing no
   hypothesis on `A` beyond its topology.
-* `TauCeti.Valuation.isContinuous_iff_continuous` : **Remark 7.8(1)**, that once the attained
+* `Valuation.isContinuous_iff_continuous` : **Remark 7.8(1)**, that once the attained
   ratios are coinitial in `Γ₀` — in particular on a codomain no larger than `Γ_v ∪ {0}` —
   continuity is ordinary continuity into `WithZeroTopology`.
-* `TauCeti.Valuation.IsContinuous.isOpen_le_div` : **Remark 7.8(3)**, the non-strict sets are
+* `Valuation.IsContinuous.isOpen_le_div` : **Remark 7.8(3)**, the non-strict sets are
   open too, again over the whole value group; `IsContinuous.isOpen_le` is its attained-value
   case.
-* `TauCeti.Valuation.isContinuous_of_discreteTopology` : **Remark 7.8(2)**, every valuation on
+* `Valuation.isContinuous_of_discreteTopology` : **Remark 7.8(2)**, every valuation on
   a discrete ring is continuous.
-* `TauCeti.Valuation.IsContinuous.comap` : **Remark 7.9**, continuity is inherited along a
+* `Valuation.IsContinuous.comap` : **Remark 7.9**, continuity is inherited along a
   continuous ring homomorphism.
 
 ## References
@@ -101,9 +101,9 @@ attained values instead makes `Valuation.IsEquiv.isContinuous_iff` immediate.
 
 public section
 
-namespace TauCeti.Valuation
+namespace Valuation
 
-open Set Topology TauCeti
+open Set Topology
 
 variable {A : Type*} [Ring A] [TopologicalSpace A]
   {Γ₀ : Type*} [LinearOrderedCommMonoidWithZero Γ₀]
@@ -263,4 +263,4 @@ theorem isContinuous_iff_continuous [SeparatelyContinuousAdd A] [ContinuousConst
 
 end ValueGroup
 
-end TauCeti.Valuation
+end Valuation

--- a/TauCeti/RingTheory/Valuation/Continuous/TopologicallyNilpotent.lean
+++ b/TauCeti/RingTheory/Valuation/Continuous/TopologicallyNilpotent.lean
@@ -53,10 +53,10 @@ the first.
 
 ## Main results
 
-* `TauCeti.Valuation.exists_pow_lt_of_isTopologicallyNilpotent`
-* `TauCeti.Valuation.IsContinuous.lt_one_of_isTopologicallyNilpotent`
-* `TauCeti.Valuation.IsContinuous.cofinalValue_of_isTopologicallyNilpotent`
-* `TauCeti.Valuation.HasFullCharacteristicGroup.cofinalValue_of_isTopologicallyNilpotent` :
+* `Valuation.exists_pow_lt_of_isTopologicallyNilpotent`
+* `Valuation.IsContinuous.lt_one_of_isTopologicallyNilpotent`
+* `Valuation.IsContinuous.cofinalValue_of_isTopologicallyNilpotent`
+* `Valuation.HasFullCharacteristicGroup.cofinalValue_of_isTopologicallyNilpotent` :
   cofinality again, with continuity replaced by a full characteristic group plus the open unit
   ball being a neighbourhood of `0` — the `Γ_v = cΓ_v` branch of Theorem 7.10's converse.
 
@@ -73,7 +73,7 @@ the first.
 
 public section
 
-namespace TauCeti.Valuation
+namespace Valuation
 
 open MonoidWithZeroHom TauCeti
 
@@ -168,4 +168,4 @@ theorem HasFullCharacteristicGroup.cofinalValue_of_isTopologicallyNilpotent
     simpa only [map_pow, map_inv₀, _root_.Valuation.embedding_restrict] using hgoal
   exact ⟨n, hemb.trans_le htle⟩
 
-end TauCeti.Valuation
+end Valuation

--- a/TauCeti/RingTheory/Valuation/Continuous/TopologicallyNilpotent.lean
+++ b/TauCeti/RingTheory/Valuation/Continuous/TopologicallyNilpotent.lean
@@ -165,7 +165,7 @@ theorem HasFullCharacteristicGroup.cofinalValue_of_isTopologicallyNilpotent
   obtain ⟨n, hgoal⟩ := exists_pow_lt_of_isTopologicallyNilpotent hmem hx
   have hemb : v.restrict x ^ n < (v.restrict t)⁻¹ := by
     refine MonoidWithZeroHom.ValueGroup₀.embedding_strictMono.lt_iff_lt.mp ?_
-    simpa only [map_pow, map_inv₀, _root_.Valuation.embedding_restrict] using hgoal
+    simpa only [map_pow, map_inv₀, embedding_restrict] using hgoal
   exact ⟨n, hemb.trans_le htle⟩
 
 end Valuation

--- a/TauCeti/RingTheory/Valuation/Trivial.lean
+++ b/TauCeti/RingTheory/Valuation/Trivial.lean
@@ -18,13 +18,13 @@ the support map of the valuation spectrum.
 
 ## Main definitions
 
-* `TauCeti.Valuation.trivialValuation 𝔭` : The trivial valuation attached to a prime
+* `Valuation.trivialValuation 𝔭` : The trivial valuation attached to a prime
   ideal `𝔭`, with values in any linearly ordered commutative monoid with zero `Γ₀`
   (the valuation-spectrum section specializes it to `WithZero (Multiplicative ℤ)`).
 
 ## Main results
 
-* `TauCeti.Valuation.trivialValuation_eq_zero_iff` : The trivial valuation vanishes exactly
+* `Valuation.trivialValuation_eq_zero_iff` : The trivial valuation vanishes exactly
   on `𝔭`.
 
 ## References
@@ -34,7 +34,7 @@ the support map of the valuation spectrum.
 
 public section
 
-namespace TauCeti.Valuation
+namespace Valuation
 
 variable {A : Type*} [CommRing A] {Γ₀ : Type*} [LinearOrderedCommMonoidWithZero Γ₀]
 
@@ -68,4 +68,4 @@ lemma trivialValuation_eq_one_iff [Nontrivial Γ₀] {𝔭 : Ideal A} [𝔭.IsPr
   rw [trivialValuation_apply]
   split <;> simp_all
 
-end TauCeti.Valuation
+end Valuation

--- a/TauCeti/RingTheory/Valuation/ValueGroupTransport.lean
+++ b/TauCeti/RingTheory/Valuation/ValueGroupTransport.lean
@@ -49,14 +49,14 @@ Mathlib's `IsEquiv.orderMonoidIso` is an isomorphism of the value monoids *with 
 `ValueGroup₀ f = WithZero ↥(valueGroup f)`, so this is exactly the inverse of Mathlib's
 `OrderMonoidIso.withZero`, which identifies order isomorphisms of two groups with those of
 the groups with zero adjoined. -/
-noncomputable def _root_.Valuation.IsEquiv.valueGroupOrderIso {v : Valuation A Γ₀}
+noncomputable def IsEquiv.valueGroupOrderIso {v : Valuation A Γ₀}
     {w : Valuation A Γ₀'} (h : v.IsEquiv w) :
     valueGroup (.ofClass v) ≃*o valueGroup (.ofClass w) :=
   OrderMonoidIso.withZero.symm h.orderMonoidIso
 
 /-- The induced value-group isomorphism agrees with `orderMonoidIso` under the coercion. -/
 @[simp]
-theorem _root_.Valuation.IsEquiv.valueGroupOrderIso_coe {v : Valuation A Γ₀}
+theorem IsEquiv.valueGroupOrderIso_coe {v : Valuation A Γ₀}
     {w : Valuation A Γ₀'} (h : v.IsEquiv w) (γ : valueGroup (.ofClass v)) :
     ((h.valueGroupOrderIso γ : valueGroup (.ofClass w)) : ValueGroup₀ (.ofClass w))
       = h.orderMonoidIso (γ : ValueGroup₀ (.ofClass v)) :=
@@ -64,7 +64,7 @@ theorem _root_.Valuation.IsEquiv.valueGroupOrderIso_coe {v : Valuation A Γ₀}
 
 /-- Transport along the inverse equivalence is the inverse transport. Mirrors Mathlib's
 `Valuation.IsEquiv.orderMonoidIso_symm`. -/
-theorem _root_.Valuation.IsEquiv.valueGroupOrderIso_symm {v : Valuation A Γ₀}
+theorem IsEquiv.valueGroupOrderIso_symm {v : Valuation A Γ₀}
     {w : Valuation A Γ₀'} (h : v.IsEquiv w) (h' : w.IsEquiv v) :
     h.valueGroupOrderIso.symm = h'.valueGroupOrderIso :=
   (rfl)
@@ -72,7 +72,7 @@ theorem _root_.Valuation.IsEquiv.valueGroupOrderIso_symm {v : Valuation A Γ₀}
 /-- Transport along a valuation's equivalence with itself is the identity. Mirrors Mathlib's
 `Valuation.IsEquiv.orderMonoidIso_eq_refl`. -/
 @[simp]
-theorem _root_.Valuation.IsEquiv.valueGroupOrderIso_eq_refl {v : Valuation A Γ₀}
+theorem IsEquiv.valueGroupOrderIso_eq_refl {v : Valuation A Γ₀}
     (h : v.IsEquiv v) : h.valueGroupOrderIso = .refl _ := by
   ext γ
   simp [Valuation.IsEquiv.valueGroupOrderIso]
@@ -90,7 +90,7 @@ private theorem withZero_symm_trans {G H K : Type*} [CommGroup G] [PartialOrder 
 /-- Transport along a composite equivalence is the composite transport. Mirrors Mathlib's
 `Valuation.IsEquiv.orderMonoidIso_trans`. -/
 @[simp]
-theorem _root_.Valuation.IsEquiv.valueGroupOrderIso_trans {Γ₀'' : Type*}
+theorem IsEquiv.valueGroupOrderIso_trans {Γ₀'' : Type*}
     [LinearOrderedCommGroupWithZero Γ₀''] {v : Valuation A Γ₀} {w : Valuation A Γ₀'}
     {u : Valuation A Γ₀''} (h : v.IsEquiv w) (h' : w.IsEquiv u) :
     h.valueGroupOrderIso.trans h'.valueGroupOrderIso = (h.trans h').valueGroupOrderIso := by

--- a/TauCeti/RingTheory/Valuation/ValueGroupTransport.lean
+++ b/TauCeti/RingTheory/Valuation/ValueGroupTransport.lean
@@ -37,7 +37,7 @@ order isomorphisms of those groups with a zero adjoined.
 
 public section
 
-namespace TauCeti.Valuation
+namespace Valuation
 
 open MonoidWithZeroHom
 
@@ -97,4 +97,4 @@ theorem _root_.Valuation.IsEquiv.valueGroupOrderIso_trans {Γ₀'' : Type*}
   simp only [Valuation.IsEquiv.valueGroupOrderIso]
   rw [withZero_symm_trans, Valuation.IsEquiv.orderMonoidIso_trans]
 
-end TauCeti.Valuation
+end Valuation


### PR DESCRIPTION
This PR moves the declarations extending Mathlib's `Valuation` out of the recreated `TauCeti.Valuation` namespace, so receiver notation such as `v.CofinalValue a`, `v.IsContinuous`, and `v.restrictToIdeal I hfg` elaborates. It updates downstream references and module documentation, removes one wrapper-dependent `open`, and drops a `map_inv` simp argument whose unqualified name became captured by `Valuation.map_inv` after the move.

This is the `Valuation` namespace-migration slice of #3547. The 113 explicitly named declarations in the moved blocks were checked against the pinned Mathlib environment with no collisions. Locally verified with the full `lake build` (8,212 jobs), the dot-notation namespace lint (41 ratchetable entries removed), and direct receiver-notation elaboration checks. The stale entries remain only in the human-owned lint baseline and should be pruned with the enforcement workstream.

Roadmap: AdicSpaces

:robot: Prepared with OpenAI Codex