### PR TITLE
refactor: give the derivation API dot notation

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Tangent.lean
@@ -216,7 +216,7 @@ theorem tangent_bracket_eq_zero
       (CounitAlgebra R (SymmetricAlgebra R M) B)) : ⁅d, e⁆ = 0 := by
   apply derivation_ext
   intro x
-  rw [TauCeti.Derivation.bracket_apply, SymmetricAlgebra.comul_ι]
+  rw [Derivation.bracket_apply, SymmetricAlgebra.comul_ι]
   simp
 
 end Lie

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel/Tangent.lean
@@ -104,7 +104,7 @@ theorem derivationComp_eq_zero_iff_vanishes_kernelHopfIdeal (f : H ⟶ K)
   constructor
   · intro hcomp x hx
     rw [kernelHopfIdeal_toIdeal, Ideal.map] at hx
-    apply TauCeti.Derivation.apply_eq_zero_of_mem_span d (x := x) (S := f.hom ''
+    apply Derivation.apply_eq_zero_of_mem_span d (x := x) (S := f.hom ''
       ((HopfIdeal.augmentation R H).toIdeal : Set H)) _ _ hx
     · rintro _ ⟨y, hy, rfl⟩
       have hyε : Coalgebra.counit (R := R) y = 0 :=

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
@@ -230,7 +230,7 @@ theorem mem_lieSubalgebra_iff_of_toIdeal_eq_span (I : HopfIdeal R H) {S : Set H}
     rw [hI]
     exact Ideal.subset_span hx
   · intro hd x hx
-    apply TauCeti.Derivation.apply_eq_zero_of_mem_span d (hd := hd) (hx := hI ▸ hx)
+    apply Derivation.apply_eq_zero_of_mem_span d (hd := hd) (hx := hI ▸ hx)
     intro y hy
     apply I.counit_eq_zero
     apply HopfIdeal.mem_toIdeal.mp

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Tangent.lean
@@ -176,7 +176,7 @@ theorem tangentLinearEquiv_symm_apply_T (b : B) :
 @[simp]
 theorem tangent_bracket_eq_zero (d e : Derivation R H C) : ⁅d, e⁆ = 0 := by
   apply derivation_ext
-  rw [TauCeti.Derivation.bracket_apply, LaurentPolynomial.comul_T]
+  rw [Derivation.bracket_apply, LaurentPolynomial.comul_T]
   simp [mul_comm]
 
 end

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
@@ -30,10 +30,10 @@ computation appears; inverses come from the group of points.
 
 ## Main declarations
 
-* `TauCeti.Derivation.adDerivation`: the conjugate of a tangent vector by a point.
-* `TauCeti.Derivation.toConv_coe_adDerivation`: that conjugate as the convolution product
+* `Derivation.adDerivation`: the conjugate of a tangent vector by a point.
+* `Derivation.toConv_coe_adDerivation`: that conjugate as the convolution product
   `g ⋆ d ⋆ g⁻¹`, the form the algebraic manipulations use.
-* `TauCeti.Derivation.adRepresentation`: the adjoint action, as a representation of
+* `Derivation.adRepresentation`: the adjoint action, as a representation of
   the convolution group of points on the tangent space.
 
 Compatibility of the action with the Lie bracket needs the Lie structure and so lives in
@@ -52,11 +52,9 @@ finite-projectivity hypothesis on the conormal module and is not attempted here.
 
 public section
 
-namespace TauCeti
-
 namespace Derivation
 
-open _root_.Coalgebra WithConv TensorProduct
+open TauCeti _root_.Coalgebra WithConv TensorProduct
 
 variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
   [CommSemiring B] [Algebra R B]
@@ -211,5 +209,3 @@ lemma adRepresentation_apply (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra 
   rfl
 
 end Derivation
-
-end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -42,7 +42,7 @@ An algebra homomorphism between coefficient algebras transports these synonyms v
 `Bialgebra.CounitAlgebra.mapAlgHom`; `Bialgebra.CounitAlgebra.map` records that this
 transport is linear for the actions induced by the counit.
 
-The general generator criterion `TauCeti.Derivation.apply_eq_zero_of_mem_span` says that a
+The general generator criterion `Derivation.apply_eq_zero_of_mem_span` says that a
 counit-valued derivation vanishing on counit-zero generators vanishes on their ideal span.
 
 ## The exterior convolution product
@@ -63,9 +63,9 @@ consequence of these three identities.
 
 public section
 
-namespace TauCeti
-
 open TauCeti.Bialgebra _root_.Bialgebra _root_.Coalgebra WithConv
+
+namespace TauCeti
 
 section BialgebraPoint
 
@@ -240,12 +240,16 @@ lemma algEquivSelf_derivation_smul_apply
 
 end DerivationCoefficients
 
+end TauCeti
+
 section DerivationSpan
 
 variable {R H B : Type*} [CommSemiring R] [CommSemiring H] [Bialgebra R H]
   [CommSemiring B] [Algebra R B]
 
 namespace Derivation
+
+open TauCeti
 
 /-- The ideal on which both the counit and a counit-valued derivation vanish. -/
 private def vanishingIdeal
@@ -280,6 +284,8 @@ theorem apply_eq_zero_of_mem_span
 end Derivation
 
 end DerivationSpan
+
+namespace TauCeti
 
 section CounitAlgebraMap
 
@@ -723,6 +729,8 @@ lemma tangentKer_smul_apply_snd
 
 end Hopf
 
+end TauCeti
+
 section DerivationLeibniz
 
 open WithConv TensorProduct
@@ -735,7 +743,7 @@ variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
 
 namespace Derivation
 
-open TauCeti.LinearMap
+open TauCeti TauCeti.LinearMap
 
 /-- The Leibniz rule in convolution form: composing a counit-valued derivation with
 the multiplication of `A` is the exterior product against the convolution unit, on
@@ -758,5 +766,3 @@ lemma toConv_coe_comp_mul'
 end Derivation
 
 end DerivationLeibniz
-
-end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Cotangent.lean
@@ -159,7 +159,7 @@ private noncomputable def ofCotangentLinearMap
       (f.comp (Bialgebra.cotangentMap R A)))
     fun a b => by
       simp only [LinearMap.comp_apply]
-      rw [Bialgebra.cotangentMap_mul, map_add, LinearMap.map_smul, LinearMap.map_smul]
+      rw [Bialgebra.cotangentMap_mul, map_add, _root_.map_smul, _root_.map_smul]
       apply (Bialgebra.CounitAlgebra.algEquivSelf R A B).injective
       simp only [AlgEquiv.toLinearMap_apply]
       rw [AlgEquiv.apply_symm_apply, map_add, algEquivSelf_smul,

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Cotangent.lean
@@ -28,9 +28,9 @@ finite module (ReductiveGroups roadmap, Layer 2).
 * `TauCeti.Bialgebra.CotangentSpace`: the augmentation ideal modulo its square.
 * `TauCeti.Bialgebra.cotangentMap`: the universal first-order displacement from
   the identity.
-* `TauCeti.Derivation.cotangentLinearEquiv`: the duality between the cotangent
+* `Derivation.cotangentLinearEquiv`: the duality between the cotangent
   space and counit-valued derivations.
-* `TauCeti.Derivation.tangentScalarExtensionEquiv`: scalar extension of the
+* `Derivation.tangentScalarExtensionEquiv`: scalar extension of the
   cotangent dual when the cotangent space is finite projective.
 
 ## References
@@ -129,7 +129,11 @@ lemma cotangentMap_mul (a b : A) :
 
 end Bialgebra
 
+end TauCeti
+
 namespace Derivation
+
+open TauCeti _root_.Coalgebra TensorProduct
 
 variable {R A B : Type*} [CommRing R] [CommRing A] [Bialgebra R A]
   [CommRing B] [Algebra R B]
@@ -155,7 +159,7 @@ private noncomputable def ofCotangentLinearMap
       (f.comp (Bialgebra.cotangentMap R A)))
     fun a b => by
       simp only [LinearMap.comp_apply]
-      rw [Bialgebra.cotangentMap_mul, map_add, map_smul, map_smul]
+      rw [Bialgebra.cotangentMap_mul, map_add, LinearMap.map_smul, LinearMap.map_smul]
       apply (Bialgebra.CounitAlgebra.algEquivSelf R A B).injective
       simp only [AlgEquiv.toLinearMap_apply]
       rw [AlgEquiv.apply_symm_apply, map_add, algEquivSelf_smul,
@@ -236,7 +240,7 @@ private noncomputable def cotangentLinearEquivBase :
     ext a
     apply (Bialgebra.CounitAlgebra.algEquivSelf R A B).injective
     simp only [algEquivSelf_ofCotangentLinearMap_apply, LinearMap.smul_apply,
-      RingHom.id_apply, Derivation.smul_apply, map_smul]
+      RingHom.id_apply, Derivation.smul_apply, _root_.map_smul]
 
 private lemma cotangentLinearEquivBase_apply
     (f : Bialgebra.CotangentSpace R A →ₗ[R] B) :
@@ -394,5 +398,3 @@ lemma tangentScalarExtensionEquiv_tmul_apply
     tangentScalarExtensionEquivBase_tmul_apply]
 
 end Derivation
-
-end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Dimension.lean
@@ -33,11 +33,11 @@ in Layer 2 of the ReductiveGroups roadmap.
 
 ## Main declarations
 
-* `TauCeti.Derivation.finrank_eq_finrank_cotangentSpace`: tangent and cotangent `finrank` values
+* `Derivation.finrank_eq_finrank_cotangentSpace`: tangent and cotangent `finrank` values
   agree.
-* `TauCeti.Derivation.instFiniteDimensionalDerivationCounitAlgebra`: tangent spaces with
+* `Derivation.instFiniteDimensionalDerivationCounitAlgebra`: tangent spaces with
   coefficient-field values are finite-dimensional when the augmentation cotangent space is.
-* `TauCeti.Derivation.finrank_tangent_baseChange`: tangent dimension is invariant under extension
+* `Derivation.finrank_tangent_baseChange`: tangent dimension is invariant under extension
   of the coefficient field.
 
 ## References
@@ -47,13 +47,13 @@ in Layer 2 of the ReductiveGroups roadmap.
 
 public section
 
-namespace TauCeti
-
 universe u v w
 
 open scoped TensorProduct
 
 namespace Derivation
+
+open TauCeti
 
 variable {k : Type u} [Field k]
 variable {H : Type v} [CommRing H] [Bialgebra k H]
@@ -109,5 +109,3 @@ theorem finrank_tangent_baseChange
       (cotangentLinearEquiv (R := k) (A := H) (B := k)).finrank_eq
 
 end Derivation
-
-end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint/Basic.lean
@@ -11,7 +11,7 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
 /-!
 # The adjoint action respects the Lie bracket
 
-`TauCeti.Derivation.adDerivation` conjugates a tangent vector by a point of the Hopf algebra.
+`Derivation.adDerivation` conjugates a tangent vector by a point of the Hopf algebra.
 `Tangent.Adjoint` shows that this is an action by linear automorphisms; this file adds the
 one statement that needs the Lie structure of `Tangent.Lie.Basic`, namely that each `Ad g` is
 an automorphism of the Lie bracket rather than merely of the module.
@@ -21,16 +21,14 @@ the Lie-algebra structure.
 
 ## Main results
 
-* `TauCeti.Derivation.adDerivation_lie`: `Ad g ⁅d₁, d₂⁆ = ⁅Ad g d₁, Ad g d₂⁆`.
+* `Derivation.adDerivation_lie`: `Ad g ⁅d₁, d₂⁆ = ⁅Ad g d₁, Ad g d₂⁆`.
 -/
 
 public section
 
-namespace TauCeti
-
 namespace Derivation
 
-open _root_.Coalgebra WithConv TensorProduct
+open TauCeti _root_.Coalgebra WithConv TensorProduct
 
 -- Only the coefficient algebra `B` need be a ring: the bracket is a commutator, so the
 -- convolution algebra `A →ₗ[R] CounitAlgebra R A B` must admit subtraction, and it inherits that
@@ -68,5 +66,3 @@ theorem adDerivation_lie (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A 
   exact DFunLike.congr_fun (congrArg ofConv key) a
 
 end Derivation
-
-end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint/Cotangent.lean
@@ -18,9 +18,9 @@ convolution conjugation, so it preserves the Lie bracket.
 
 ## Main declarations
 
-* `TauCeti.Derivation.adjointLieEquiv`: every algebra-valued point acts by Lie algebra
+* `Derivation.adjointLieEquiv`: every algebra-valued point acts by Lie algebra
   automorphisms on the scalar-extended tangent space.
-* `TauCeti.Derivation.adjointAction_bracket`: the established adjoint action preserves brackets.
+* `Derivation.adjointAction_bracket`: the established adjoint action preserves brackets.
 
 ## References
 
@@ -31,7 +31,9 @@ public section
 
 open scoped TensorProduct
 
-namespace TauCeti.Derivation
+namespace Derivation
+
+open TauCeti
 
 universe u v
 
@@ -113,4 +115,4 @@ theorem adjointLieEquiv_symm
   simpa only [mul_inv_cancel, adjointLieEquiv_one, LieEquiv.one_apply,
     LieEquiv.trans_apply] using h
 
-end TauCeti.Derivation
+end Derivation

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -34,8 +34,9 @@ need not satisfy the Leibniz rule, the obstruction being the value commutators
 
 ## Main declarations
 
-* the `Bracket`, `LieRing`, and `LieAlgebra R` instances on
-  `Derivation R A (Bialgebra.CounitAlgebra R A B)`;
+* `Derivation.instBracketCounitAlgebra`, `Derivation.instLieRingCounitAlgebra`, and
+  `Derivation.instLieAlgebraCounitAlgebra`: the `Bracket`, `LieRing`, and `LieAlgebra R` instances
+  on `Derivation R A (Bialgebra.CounitAlgebra R A B)`;
 * `Derivation.coe_bracket`, `Derivation.bracket_apply`: the bracket
   is the convolution commutator.
 
@@ -47,7 +48,9 @@ composition-commutator `LieRing (Derivation R A A)`, even at `B = A`: the two
 carrier types differ in their `Module A` instance argument — the coefficient action
 here is through the counit (`a • m = algebraMap R B (counit a) * m`,
 `Bialgebra.CounitAlgebra.algebraMap_apply`), not multiplication — so neither
-elaboration nor instance search can identify the types, and no diamond exists.
+elaboration nor instance search can identify the types, and no diamond exists. The
+`CounitAlgebra` suffix also distinguishes their declaration names from Mathlib's
+`Derivation.instBracket`, `Derivation.instLieRing`, and `Derivation.instLieAlgebra`.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -36,7 +36,7 @@ need not satisfy the Leibniz rule, the obstruction being the value commutators
 
 * the `Bracket`, `LieRing`, and `LieAlgebra R` instances on
   `Derivation R A (Bialgebra.CounitAlgebra R A B)`;
-* `TauCeti.Derivation.coe_bracket`, `TauCeti.Derivation.bracket_apply`: the bracket
+* `Derivation.coe_bracket`, `Derivation.bracket_apply`: the bracket
   is the convolution commutator.
 
 No antipode enters: everything is stated over a bialgebra. The ring (rather than
@@ -52,11 +52,9 @@ elaboration nor instance search can identify the types, and no diamond exists.
 
 public section
 
-namespace TauCeti
-
-open _root_.Coalgebra WithConv TensorProduct
-
 namespace Derivation
+
+open TauCeti _root_.Coalgebra WithConv TensorProduct
 
 section Bracket
 
@@ -116,7 +114,7 @@ private lemma convMul_ofConv_mul (d₁ d₂ : Derivation R A (Bialgebra.CounitAl
 
 /-- The Lie bracket of tangent vectors at the identity: the commutator of the
 convolution product. -/
-noncomputable instance instBracket :
+noncomputable instance instBracketCounitAlgebra :
     Bracket (Derivation R A (Bialgebra.CounitAlgebra R A B))
       (Derivation R A (Bialgebra.CounitAlgebra R A B)) :=
   ⟨fun d₁ d₂ =>
@@ -180,7 +178,7 @@ variable {R A B : Type*} [CommRing R] [CommRing A] [Bialgebra R A]
 
 /-- The tangent space at the identity is a Lie ring under the convolution
 commutator. -/
-noncomputable instance instLieRing :
+noncomputable instance instLieRingCounitAlgebra :
     LieRing (Derivation R A (Bialgebra.CounitAlgebra R A B)) where
   add_lie d₁ d₂ d₃ := Derivation.ext fun a => by
     let _ : LieRing (WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :=
@@ -218,7 +216,7 @@ noncomputable instance instLieRing :
         (toConv (↑d₃ : A →ₗ[R] Bialgebra.CounitAlgebra R A B)))) a
 
 /-- The tangent space at the identity is a Lie algebra over the base ring. -/
-noncomputable instance instLieAlgebra :
+noncomputable instance instLieAlgebraCounitAlgebra :
     LieAlgebra R (Derivation R A (Bialgebra.CounitAlgebra R A B)) where
   lie_smul r d₁ d₂ := Derivation.ext fun a => by
     let _ : LieRing (WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :=
@@ -243,5 +241,3 @@ noncomputable instance instLieAlgebraCoefficients :
 end Lie
 
 end Derivation
-
-end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Cotangent.lean
@@ -21,9 +21,9 @@ packages the comparison as a Lie equivalence.
 
 ## Main declarations
 
-* `TauCeti.Derivation.cotangentDualLieEquiv`: the cotangent dual is canonically the tangent Lie
+* `Derivation.cotangentDualLieEquiv`: the cotangent dual is canonically the tangent Lie
   algebra of counit-valued derivations.
-* `TauCeti.Derivation.tangentScalarExtensionLieEquiv`: scalar extension of the cotangent-dual
+* `Derivation.tangentScalarExtensionLieEquiv`: scalar extension of the cotangent-dual
   Lie algebra agrees with coefficient-valued tangent derivations.
 
 ## References
@@ -38,9 +38,9 @@ public section
 
 open scoped TensorProduct
 
-namespace TauCeti.Derivation
+namespace Derivation
 
-open _root_.Coalgebra TensorProduct WithConv
+open TauCeti _root_.Coalgebra TensorProduct WithConv
 
 universe u v
 
@@ -202,4 +202,4 @@ end ScalarExtension
 
 end Bialgebra
 
-end TauCeti.Derivation
+end Derivation

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Naturality.lean
@@ -13,23 +13,21 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Naturality
 
 Postcomposition along a homomorphism of coefficient rings preserves the convolution
 commutator bracket on counit-valued derivations. Thus the functorial linear map
-`TauCeti.Derivation.mapValue` upgrades to a Lie algebra homomorphism. This is the
+`Derivation.mapValue` upgrades to a Lie algebra homomorphism. This is the
 Lie-algebra layer of the natural adjoint action constructed in `Tangent.Naturality`.
 
 ## Main declarations
 
-* `TauCeti.Derivation.mapValue_lie`: postcomposition preserves the tangent bracket.
-* `TauCeti.Derivation.lieMapValue`: change of coefficients as a Lie algebra
+* `Derivation.mapValue_lie`: postcomposition preserves the tangent bracket.
+* `Derivation.lieMapValue`: change of coefficients as a Lie algebra
   homomorphism.
 -/
 
 public section
 
-namespace TauCeti
-
 namespace Derivation
 
-open _root_.Coalgebra
+open TauCeti _root_.Coalgebra
 
 variable {R A B C : Type*} [CommRing R] [CommRing A] [Bialgebra R A]
   [CommRing B] [Algebra R B] [CommRing C] [Algebra R C]
@@ -117,5 +115,3 @@ theorem lieMapValue_comp {D : Type*} [CommRing D] [Algebra R D]
     lieMapValue_toLinearMap, mapValue_comp]
 
 end Derivation
-
-end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Naturality.lean
@@ -28,8 +28,8 @@ Together, these statements make the valuewise representations in
 * `TauCeti.Bialgebra.CounitAlgebra.mapAlgHom`: the coefficient algebra map.
 * `TauCeti.Bialgebra.CounitAlgebra.map`: the same map, linear over the bialgebra
   through the counit actions.
-* `TauCeti.Derivation.mapValue`: postcomposition of counit-valued derivations.
-* `TauCeti.Derivation.mapValue_adDerivation`: the adjoint action commutes with
+* `Derivation.mapValue`: postcomposition of counit-valued derivations.
+* `Derivation.mapValue_adDerivation`: the adjoint action commutes with
   change of coefficient algebra.
 
 The Lie-bracket compatibility, which requires additive inverses, is in
@@ -42,11 +42,9 @@ The Lie-bracket compatibility, which requires additive inverses, is in
 
 public section
 
-namespace TauCeti
-
-open _root_.Coalgebra WithConv
-
 namespace Derivation
+
+open TauCeti _root_.Coalgebra WithConv
 
 variable {R A B C : Type*} [CommSemiring R] [CommSemiring A]
 
@@ -144,5 +142,3 @@ theorem mapValue_adDerivation (phi : B →ₐ[R] C)
 end Adjoint
 
 end Derivation
-
-end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Representation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Representation.lean
@@ -26,12 +26,12 @@ its corresponding comodule, and, after choosing a finite basis, the coordinate m
 
 ## Main declarations
 
-* `TauCeti.Derivation.mapValue_tangentScalarExtensionEquiv`: scalar extension of tangent vectors
+* `Derivation.mapValue_tangentScalarExtensionEquiv`: scalar extension of tangent vectors
   is natural in the coefficient algebra.
-* `TauCeti.Derivation.adjointPointRepresentation`: the adjoint action on the base Lie algebra as a
+* `Derivation.adjointPointRepresentation`: the adjoint action on the base Lie algebra as a
   natural point representation.
-* `TauCeti.Derivation.adjointComodule`: the corresponding right `H`-comodule.
-* `TauCeti.Derivation.adjointCoordinateBialgHom`: the coordinate morphism of the adjoint
+* `Derivation.adjointComodule`: the corresponding right `H`-comodule.
+* `Derivation.adjointCoordinateBialgHom`: the coordinate morphism of the adjoint
   representation in a finite basis.
 
 ## References
@@ -47,7 +47,9 @@ public section
 open CategoryTheory TensorProduct WithConv
 open scoped TensorProduct
 
-namespace TauCeti.Derivation
+namespace Derivation
+
+open TauCeti
 
 universe u v
 
@@ -342,4 +344,4 @@ theorem adjointCoordinateBialgHom_antipode_X {n : ℕ}
   unfold adjointCoordinateBialgHom
   exact Comodule.coordinateBialgHom_antipode_X b i j
 
-end TauCeti.Derivation
+end Derivation

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.lean
@@ -31,22 +31,22 @@ one, or that `G` is reductive. When `π` does exhibit a split maximal torus `T` 
 
 ## Main definitions
 
-* `TauCeti.Derivation.adjointWeightSpace`: the `α`-weight submodule `𝔤_α` of the Lie algebra of
+* `Derivation.adjointWeightSpace`: the `α`-weight submodule `𝔤_α` of the Lie algebra of
   `G` under a homomorphism from a diagonalizable group.
-* `TauCeti.Derivation.nontrivialAdjointWeights`: the nontrivial characters whose adjoint weight
+* `Derivation.nontrivialAdjointWeights`: the nontrivial characters whose adjoint weight
   submodule is nonzero.
 
 ## Main results
 
-* `TauCeti.Derivation.isInternal_adjointWeightSpace`: **the Lie algebra of `G` is the internal
+* `Derivation.isInternal_adjointWeightSpace`: **the Lie algebra of `G` is the internal
   direct sum of its weight submodules.**
-* `TauCeti.Derivation.sup_iSup_adjointWeightSpace_eq_top`: the trivial weight submodule together
+* `Derivation.sup_iSup_adjointWeightSpace_eq_top`: the trivial weight submodule together
   with the submodules indexed by `nontrivialAdjointWeights π` exhaust the Lie algebra.
-* `TauCeti.Derivation.finite_nontrivialAdjointWeights`: **the set of nontrivial adjoint weights is
+* `Derivation.finite_nontrivialAdjointWeights`: **the set of nontrivial adjoint weights is
   finite.**
-* `TauCeti.Derivation.endOfPoint_tmul_of_mem_adjointWeightSpace`: a point of `D(M)` acts on the
+* `Derivation.endOfPoint_tmul_of_mem_adjointWeightSpace`: a point of `D(M)` acts on the
   `α`-weight submodule by the value of `α` at that point.
-* `TauCeti.Derivation.lie_mem_adjointWeightSpace_mul`: the adjoint weight decomposition is a Lie
+* `Derivation.lie_mem_adjointWeightSpace_mul`: the adjoint weight decomposition is a Lie
   grading: `[𝔤_α, 𝔤_β] ⊆ 𝔤_{αβ}`.
 
 ## Roadmap
@@ -72,9 +72,9 @@ public section
 
 open scoped DirectSum TensorProduct
 
-namespace TauCeti
-
 namespace Derivation
+
+open TauCeti
 
 attribute [local instance] Classical.decEq
 attribute [local instance] adjointComodule
@@ -276,5 +276,3 @@ theorem lie_mem_adjointWeightSpace_mul {π : H →ₐc[R] MonoidAlgebra R M} {α
   exact hmapped
 
 end Derivation
-
-end TauCeti


### PR DESCRIPTION
This PR moves the tangent-space declarations extending Mathlib's `Derivation` out of the enclosing `TauCeti` namespace, so receiver notation such as `d.apply_eq_zero_of_mem_span` elaborates and the API lives in the canonical root namespace. It hoists or restores wrapper-scoped opens, updates downstream references, and qualifies two `map_smul` uses whose names became captured after the move.

The pre-move environment contained 100 `TauCeti.Derivation.*` constants. Collision checking against pinned Mathlib found three public instance-name conflicts (`instBracket`, `instLieRing`, and `instLieAlgebra`), which are distinct counit-valued structures and are renamed descriptively in this PR. Locally verified with the full `lake build` (8,212 jobs), the dot-notation namespace lint (29 ratchetable entries removed, zero new findings), and direct receiver-notation elaboration checks.

This is the `Derivation` namespace-migration slice of #3547.

Roadmap: ReductiveGroups

:robot: Prepared with OpenAI Codex