### PR TITLE
refactor: give the Clifford algebra API its canonical namespace

### DIFF
--- a/TauCeti/Algebra/Lie/SkewAdjoint.lean
+++ b/TauCeti/Algebra/Lie/SkewAdjoint.lean
@@ -38,7 +38,7 @@ symmetric, so `ad` maps `L` into the skew-adjoint endomorphisms of the polar for
 is Killing-semisimple and `2` is invertible
 the form is moreover nondegenerate, which is the hypothesis under which the skew-adjoint
 endomorphisms are the quadratic elements of the Clifford algebra `Cliff(L, κ)`
-(`TauCeti.CliffordAlgebra.soEquivQuadratic`). Composing the two is the adjoint quadratic lift
+(`CliffordAlgebra.soEquivQuadratic`). Composing the two is the adjoint quadratic lift
 `L → Cliff(L, κ)` whose left-regular action is the subject of Kostant's isotypy theorem; that
 composite is not built here.
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/Basic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/PBW/Basic.lean
@@ -28,7 +28,7 @@ comparison with `SymmetricAlgebra R L` is the next PBW stage and is not asserted
 Nothing in the construction is special to the enveloping algebra: `pbwFiltration` and
 `pbwFiltrationPrevious` are `TauCeti.Algebra.wordFiltration` and
 `TauCeti.Algebra.wordFiltrationPrevious` of `TauCeti/Algebra/WordFiltration.lean`, specialized to
-`UniversalEnvelopingAlgebra.ι R`, exactly as `TauCeti.CliffordAlgebra.filtration` is that same
+`UniversalEnvelopingAlgebra.ι R`, exactly as `CliffordAlgebra.filtration` is that same
 construction for `CliffordAlgebra.ι`. What is special to `U(L)` is the exhaustivity, which comes
 from the tensor-algebra presentation.
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -54,14 +54,11 @@ synthesizable.
 
 public section
 
-open CliffordAlgebra
 open scoped DirectSum
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -25,21 +25,21 @@ Its graded-algebra packaging adapts the pattern in Mathlib's
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.filtrationAssociatedGraded Q`: the direct sum
+* `CliffordAlgebra.filtrationAssociatedGraded Q`: the direct sum
   `⨁ k, FiltrationGradedPiece Q k` of the homogeneous pieces.
-* `TauCeti.CliffordAlgebra.filtrationGradedMul`: the product of two homogeneous pieces, induced by
+* `CliffordAlgebra.filtrationGradedMul`: the product of two homogeneous pieces, induced by
   Clifford multiplication through `filtration_mul`.
-* `TauCeti.CliffordAlgebra.filtrationGradedOne` and
-  `TauCeti.CliffordAlgebra.filtrationGradedAlgebraMap₀`: the degree-zero unit and the degree-zero
+* `CliffordAlgebra.filtrationGradedOne` and
+  `CliffordAlgebra.filtrationGradedAlgebraMap₀`: the degree-zero unit and the degree-zero
   image of a scalar.
 
 ## Main results
 
 * The graded structure instances assembling those pieces:
-  `TauCeti.CliffordAlgebra.filtrationGradedGOne`, `filtrationGradedGMul`,
+  `CliffordAlgebra.filtrationGradedGOne`, `filtrationGradedGMul`,
   `filtrationGradedGMonoid`, `filtrationGradedGRing`, `filtrationGradedGSemiring` and
   `filtrationGradedGAlgebra`, culminating in
-  `TauCeti.CliffordAlgebra.filtrationAssociatedGradedRing`, the ring structure on the direct sum.
+  `CliffordAlgebra.filtrationAssociatedGradedRing`, the ring structure on the direct sum.
 
 ## Implementation notes
 
@@ -59,9 +59,9 @@ open scoped DirectSum
 
 universe u v
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
@@ -476,5 +476,3 @@ noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
   infer_instance
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -21,13 +21,10 @@ linear equivalence with the exterior algebra.
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -25,7 +25,9 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
@@ -191,4 +193,4 @@ theorem exists_eq_algebraMap_of_mem_even_of_commute
   intro v
   rw [involute_eq_of_mem_even hx_even, (hx_comm v).eq]
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -28,26 +28,26 @@ Layer 9 CAR worked instance.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.bivector`: the half-normalized commutator of two Clifford
+* `CliffordAlgebra.bivector`: the half-normalized commutator of two Clifford
   generators.
-* `TauCeti.CliffordAlgebra.bivectorAlternating`: the corresponding alternating map.
-* `TauCeti.CliffordAlgebra.bivectorExterior`: the induced linear map from the second
+* `CliffordAlgebra.bivectorAlternating`: the corresponding alternating map.
+* `CliffordAlgebra.bivectorExterior`: the induced linear map from the second
   exterior power.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.bivector_lie_ι`: its commutator action on a generator is the
+* `CliffordAlgebra.bivector_lie_ι`: its commutator action on a generator is the
   infinitesimal rotation determined by `QuadraticMap.polar`.
-* `TauCeti.CliffordAlgebra.bivectorExterior_apply_ιMulti`: the exterior-square map on a
+* `CliffordAlgebra.bivectorExterior_apply_ιMulti`: the exterior-square map on a
   decomposable bivector.
-* `TauCeti.CliffordAlgebra.equivExterior_bivector`,
-  `TauCeti.CliffordAlgebra.equivExterior_bivectorExterior`, and
-  `TauCeti.CliffordAlgebra.bivectorExterior_injective`: the exterior model sends
+* `CliffordAlgebra.equivExterior_bivector`,
+  `CliffordAlgebra.equivExterior_bivectorExterior`, and
+  `CliffordAlgebra.bivectorExterior_injective`: the exterior model sends
   bivectors to exterior products, so the exterior-square map is injective.
-* `TauCeti.CliffordAlgebra.bivector_mem_evenOdd_zero` and
-  `TauCeti.CliffordAlgebra.bivector_mem_filtration_two`: it is even and has filtration
+* `CliffordAlgebra.bivector_mem_evenOdd_zero` and
+  `CliffordAlgebra.bivector_mem_filtration_two`: it is even and has filtration
   degree at most two.
-* `TauCeti.CliffordAlgebra.bivectorExterior_range_le_of_bivector_mem`: the
+* `CliffordAlgebra.bivectorExterior_range_le_of_bivector_mem`: the
   exterior-square map lands in any submodule containing the Clifford bivectors.
 
 ## References
@@ -62,9 +62,9 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 section CommRing
 
@@ -251,5 +251,3 @@ theorem bivector_lie_ι (a b x : M) :
 end CommRing
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -58,13 +58,10 @@ Layer 9 CAR worked instance.
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 section CommRing
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -46,8 +46,6 @@ open scoped Matrix TensorProduct
 
 namespace CliffordAlgebra
 
-open TauCeti
-
 variable {M : Type*} [AddCommGroup M] [Module ℝ M]
 variable (Q : QuadraticForm ℝ M)
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -18,11 +18,11 @@ import Mathlib.LinearAlgebra.Matrix.Unique
 This file proves the `(1, 1)` periodicity step for Clifford algebras: adding one positive and one
 negative generator is equivalent to tensoring with two-by-two real matrices. It also derives the
 signature-switch recurrence `Cliff(p + 2, q) ≅ Cliff(q, p) ⊗ M₂(ℝ)` from
-`TauCeti.CliffordAlgebra.signSwitchEquiv`.
+`CliffordAlgebra.signSwitchEquiv`.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.hyperbolicEquivTensor`: adjoining a hyperbolic plane to an arbitrary
+* `CliffordAlgebra.hyperbolicEquivTensor`: adjoining a hyperbolic plane to an arbitrary
   real quadratic module tensors its Clifford algebra with `M₂(ℝ)`;
 * `TauCeti.realCliffordBottEquiv`: the corresponding equivalence for the standard signature forms;
 * `TauCeti.realCliffordBottIterEquiv`: the iterated standard-signature equivalence, with matrix
@@ -44,7 +44,9 @@ public section
 open Module QuadraticMap
 open scoped Matrix TensorProduct
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 variable {M : Type*} [AddCommGroup M] [Module ℝ M]
 variable (Q : QuadraticForm ℝ M)
@@ -422,7 +424,7 @@ theorem hyperbolicEquivTensor_symm_apply_ι_hyperbolic
   rw [AlgEquiv.apply_symm_apply, hyperbolicEquivTensor_ι]
   simp
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra
 
 namespace TauCeti
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -40,7 +40,7 @@ M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra QuadraticMap
+open QuadraticMap
 
 universe u v
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CartanDieudonne.lean
@@ -23,11 +23,11 @@ element lies in the range of `pinToOrthogonal`.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.lipschitzToOrthogonal_surjective`: the Lipschitz action is onto for a
+* `CliffordAlgebra.lipschitzToOrthogonal_surjective`: the Lipschitz action is onto for a
   finite-dimensional nondegenerate quadratic space.
-* `TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton`: a
+* `CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton`: a
   Pin-range correction extends a fixed subspace by one orthogonal anisotropic vector.
-* `TauCeti.CliffordAlgebra.pinToOrthogonal_surjective`: over a separably closed field of
+* `CliffordAlgebra.pinToOrthogonal_surjective`: over a separably closed field of
   characteristic other than two, the Pin action is surjective on a finite-dimensional
   nondegenerate quadratic space.
 
@@ -42,11 +42,11 @@ public section
 
 open CliffordAlgebra QuadraticMap
 
-namespace TauCeti
-
 universe u v
 
 namespace CliffordAlgebra
+
+open TauCeti
 
 variable {K : Type u} {V : Type v} [Field K]
   [AddCommGroup V] [Module K V] (Q : QuadraticForm K V)
@@ -115,4 +115,3 @@ theorem pinToOrthogonal_surjective
 
 end IsSepClosed
 end CliffordAlgebra
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -20,12 +20,12 @@ spin representations roadmap. It does not construct that orthogonal Lie equivale
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.bivectorExteriorEquivQuadraticLieSubalgebra`: the exterior
+* `CliffordAlgebra.bivectorExteriorEquivQuadraticLieSubalgebra`: the exterior
   square is linearly equivalent to the quadratic Lie subalgebra.
-* `TauCeti.CliffordAlgebra.bivectorLieRing` and
-  `TauCeti.CliffordAlgebra.bivectorLieAlgebra`: the Lie structures transported to the
+* `CliffordAlgebra.bivectorLieRing` and
+  `CliffordAlgebra.bivectorLieAlgebra`: the Lie structures transported to the
   exterior square.
-* `TauCeti.CliffordAlgebra.bivectorLieEquiv`: the transported Lie equivalence with the
+* `CliffordAlgebra.bivectorLieEquiv`: the transported Lie equivalence with the
   quadratic Lie subalgebra.
 
 ## References
@@ -40,9 +40,9 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
@@ -125,5 +125,3 @@ theorem bivectorLieEquiv_symm_apply (x : quadraticLieSubalgebra Q) :
   exact LinearEquiv.lieEquiv_symm_apply _ x
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/CliffordExteriorSquare.lean
@@ -36,13 +36,10 @@ spin representations roadmap. It does not construct that orthogonal Lie equivale
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -48,7 +48,6 @@ grading and live with it.
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Contraction.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Grading
--- Private: `TauCeti.CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero` and
--- `TauCeti.CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one` are used only inside a proof.
+-- Private: `CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero` and
+-- `CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one` are used only inside a proof.
 import TauCeti.LinearAlgebra.CliffordAlgebra.Grading
 
 /-!
@@ -31,14 +31,14 @@ map, so `evenOdd Q (i + 1)` and `evenOdd Q (i - 1)` are the same submodule; the 
 names the first.
 
 The parity statement is proved by induction over the grading; its base case is read off by
-`TauCeti.CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero` and
-`TauCeti.CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one`, which are general facts about the
+`CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero` and
+`CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one`, which are general facts about the
 grading and live with it.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.contractLeft_mem_evenOdd`: **contraction shifts the parity**.
-* `TauCeti.CliffordAlgebra.involute_contractLeft`: `involute (d ⌋ x) = -(d ⌋ involute x)`.
+* `CliffordAlgebra.contractLeft_mem_evenOdd`: **contraction shifts the parity**.
+* `CliffordAlgebra.involute_contractLeft`: `involute (d ⌋ x) = -(d ⌋ involute x)`.
 
 ## References
 
@@ -52,7 +52,7 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   {Q : QuadraticForm R M}
@@ -104,4 +104,4 @@ theorem contractLeft_mem_evenOdd (d : Module.Dual R M) {i : ZMod 2} {x : Cliffor
     rw [add_comm]
     exact SetLike.mul_mem_graded (ι_mem_evenOdd_one Q m₁) h₁
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
@@ -92,7 +92,7 @@ separate milestone.
 
 public section
 
-open Module CliffordAlgebra
+open Module
 
 universe u v w
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
@@ -23,7 +23,7 @@ underlying module of `CliffordAlgebra Q` is as free, and as large, as the exteri
 
 This file records that. Over a commutative ring in which `2` is invertible, `CliffordAlgebra Q` is a
 free `R`-module whenever `M` is, with an explicit basis
-`TauCeti.CliffordAlgebra.basis Q b : Basis (Finset I) R (CliffordAlgebra Q)` attached to a basis `b`
+`CliffordAlgebra.basis Q b : Basis (Finset I) R (CliffordAlgebra Q)` attached to a basis `b`
 of `M` indexed by a linearly ordered `I`, and it is finite of rank `2 ^ finrank R M` whenever `M` is
 finite free. The `2 ^ n` is `∑ₖ (n choose k)` (`finrank_eq_sum_choose`), the count that a
 degree-graded argument would produce one exterior power at a time; here it is the count of subsets
@@ -59,27 +59,27 @@ separate milestone.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.basis`: the basis of `CliffordAlgebra Q` indexed by the finite subsets of
+* `CliffordAlgebra.basis`: the basis of `CliffordAlgebra Q` indexed by the finite subsets of
   the index set of a basis of `M`, over a ring in which `2` is invertible.
-* `TauCeti.CliffordAlgebra.mulRightιEquiv`: right multiplication by a vector whose norm is a unit,
+* `CliffordAlgebra.mulRightιEquiv`: right multiplication by a vector whose norm is a unit,
   as a linear automorphism of the Clifford algebra, and
-  `TauCeti.CliffordAlgebra.evenOddEquivAddOne`, the isomorphism between consecutive halves of the
+  `CliffordAlgebra.evenOddEquivAddOne`, the isomorphism between consecutive halves of the
   `ℤ/2`-grading that it restricts to.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.rank_eq_rank_exteriorAlgebra` and
-  `TauCeti.CliffordAlgebra.finrank_eq_finrank_exteriorAlgebra`: the rank of `CliffordAlgebra Q`
+* `CliffordAlgebra.rank_eq_rank_exteriorAlgebra` and
+  `CliffordAlgebra.finrank_eq_finrank_exteriorAlgebra`: the rank of `CliffordAlgebra Q`
   is the rank of `ExteriorAlgebra R M`. The right-hand sides do not mention `Q`, so this is the
   statement that the size of a Clifford algebra does not depend on the quadratic form.
-* `TauCeti.CliffordAlgebra.instFree` and `TauCeti.CliffordAlgebra.instFinite`: the Clifford algebra
+* `CliffordAlgebra.instFree` and `CliffordAlgebra.instFinite`: the Clifford algebra
   of a free module is free, and of a finite free module is finite.
-* `TauCeti.CliffordAlgebra.finrank_eq_two_pow`: `finrank R (CliffordAlgebra Q) = 2 ^ finrank R M`,
-  with `TauCeti.CliffordAlgebra.finrank_eq_sum_choose` the same count as a sum of binomial
+* `CliffordAlgebra.finrank_eq_two_pow`: `finrank R (CliffordAlgebra Q) = 2 ^ finrank R M`,
+  with `CliffordAlgebra.finrank_eq_sum_choose` the same count as a sum of binomial
   coefficients.
-* `TauCeti.CliffordAlgebra.map_evenOdd_mulRightιEquiv`: multiplying by a vector whose norm is a
+* `CliffordAlgebra.map_evenOdd_mulRightιEquiv`: multiplying by a vector whose norm is a
   unit exchanges the two halves of the `ℤ/2`-grading.
-* `TauCeti.CliffordAlgebra.finrank_evenOdd` and `TauCeti.CliffordAlgebra.finrank_even`: over a
+* `CliffordAlgebra.finrank_evenOdd` and `CliffordAlgebra.finrank_even`: over a
   field in which `2` is invertible, each half of the grading, and in particular the even
   subalgebra, has dimension `2 ^ (finrank K V - 1)`.
 
@@ -96,9 +96,9 @@ open Module CliffordAlgebra
 
 universe u v w
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 section CommRing
 
@@ -286,5 +286,3 @@ theorem finrank_even [Invertible (2 : K)] [Module.Finite K V] (hv : Q v ≠ 0) :
 end Field
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -22,9 +22,9 @@ The generic change-of-form transport belongs in `TauCeti.LinearAlgebra.CliffordA
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.exteriorPower_succ_disjoint_zero_form_filtration`: degree `k + 1` is
+* `CliffordAlgebra.exteriorPower_succ_disjoint_zero_form_filtration`: degree `k + 1` is
   disjoint from the lower zero-form filtration.
-* `TauCeti.CliffordAlgebra.zeroFormFiltrationQuotientEquivExteriorPower`: the successive
+* `CliffordAlgebra.zeroFormFiltrationQuotientEquivExteriorPower`: the successive
   zero-form filtration quotient is the degree `k + 1` exterior power.
 
 ## References
@@ -40,9 +40,9 @@ open scoped DirectSum
 
 universe u v
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
@@ -126,5 +126,3 @@ theorem zeroFormFiltrationQuotientEquivExteriorPower_apply (k : ℕ)
     LinearEquiv.apply_symm_apply]
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -35,14 +35,11 @@ The generic change-of-form transport belongs in `TauCeti.LinearAlgebra.CliffordA
 
 public section
 
-open CliffordAlgebra
 open scoped DirectSum
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -96,13 +96,10 @@ supremum over the `i` of a fixed parity.
 
 public section
 
-open CliffordAlgebra
 
 universe u v w
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -21,7 +21,7 @@ the number of generators, so parity descends to the quotient. It does *not* pres
 generators, so there is no `ℕ`-grading; what survives is an increasing **filtration** by the number
 of generators needed to write an element.
 
-This file builds that filtration. `TauCeti.CliffordAlgebra.filtration Q k` is the `R`-submodule
+This file builds that filtration. `CliffordAlgebra.filtration Q k` is the `R`-submodule
 spanned by the products `ι Q v₁ * ⋯ * ι Q vₙ` with `n ≤ k`, the empty product `1` included, so that
 `filtration Q 0` is the module of scalars and `filtration Q 1` adjoins the generators. It is
 increasing, multiplicative (`filtration Q i * filtration Q j = filtration Q (i + j)`), exhausts the
@@ -36,55 +36,55 @@ carries the same construction as its PBW filtration.
 
 Following the roadmap, the filtration is *not* the submodule power `LinearMap.range (ι Q) ^ k`:
 powers of a submodule of a noncommutative algebra collect the products of *exactly* `k` generators.
-The relation between the two is `TauCeti.CliffordAlgebra.filtration_eq_iSup_pow`, which writes
+The relation between the two is `CliffordAlgebra.filtration_eq_iSup_pow`, which writes
 `filtration Q k` as the supremum of those powers over `i ≤ k`; this is the sense in which the
 filtration is the "at most `k`" companion of Mathlib's `evenOdd`, whose definition is the analogous
 supremum over the `i` of a fixed parity.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.filtration Q k`: the span of the products of at most `k` generators.
-* `TauCeti.CliffordAlgebra.FiltrationGradedPiece Q k`: the degree-`k` successive quotient.
+* `CliffordAlgebra.filtration Q k`: the span of the products of at most `k` generators.
+* `CliffordAlgebra.FiltrationGradedPiece Q k`: the degree-`k` successive quotient.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.prod_map_ι_mem_filtration` and
-  `TauCeti.CliffordAlgebra.filtration_le_iff`: the products of at most `k` generators lie in the
+* `CliffordAlgebra.prod_map_ι_mem_filtration` and
+  `CliffordAlgebra.filtration_le_iff`: the products of at most `k` generators lie in the
   `k`-th step and generate it, which is how memberships and bounds are proved.
-* `TauCeti.CliffordAlgebra.filtration_eq_pow`: the defining equation, as the `k`-th power of the
+* `CliffordAlgebra.filtration_eq_pow`: the defining equation, as the `k`-th power of the
   scalars together with `LinearMap.range (ι Q)`.
-* `TauCeti.CliffordAlgebra.filtration_zero` and
-  `TauCeti.CliffordAlgebra.filtration_one` compute the first two steps, as the scalars and the
+* `CliffordAlgebra.filtration_zero` and
+  `CliffordAlgebra.filtration_one` compute the first two steps, as the scalars and the
   scalars together with `LinearMap.range (ι Q)`.
-* `TauCeti.CliffordAlgebra.filtration_mul`: the filtration is multiplicative, and in fact exactly
+* `CliffordAlgebra.filtration_mul`: the filtration is multiplicative, and in fact exactly
   so: `filtration Q i * filtration Q j = filtration Q (i + j)`. This is the statement that makes
   the associated graded object an algebra, and it is the prerequisite the roadmap asks for before
-  anything downstream; `TauCeti.CliffordAlgebra.filtration_pow` is its iterate and
-  `TauCeti.CliffordAlgebra.mul_mem_filtration` its elementwise form.
-* `TauCeti.CliffordAlgebra.filtration_succ_eq_sup`: the recursion for the successor step.
-* `TauCeti.CliffordAlgebra.filtration_eq_iSup_pow`: the comparison with the submodule powers of
+  anything downstream; `CliffordAlgebra.filtration_pow` is its iterate and
+  `CliffordAlgebra.mul_mem_filtration` its elementwise form.
+* `CliffordAlgebra.filtration_succ_eq_sup`: the recursion for the successor step.
+* `CliffordAlgebra.filtration_eq_iSup_pow`: the comparison with the submodule powers of
   `LinearMap.range (ι Q)`.
-* `TauCeti.CliffordAlgebra.filtrationLeadingTerm` and
-  `TauCeti.CliffordAlgebra.filtrationLeadingTerm_surjective`: the exterior-power leading-term map
+* `CliffordAlgebra.filtrationLeadingTerm` and
+  `CliffordAlgebra.filtrationLeadingTerm_surjective`: the exterior-power leading-term map
   onto each successive filtration quotient. It is surjective over any `CommRing`; when `2` is
-  invertible `TauCeti.CliffordAlgebra.filtrationGradedEquiv_comp_filtrationLeadingTerm` identifies
+  invertible `CliffordAlgebra.filtrationGradedEquiv_comp_filtrationLeadingTerm` identifies
   it with the inverse of the graded equivalence.
-* `TauCeti.CliffordAlgebra.iSup_filtration_eq_top`: the filtration is exhaustive.
-* `TauCeti.CliffordAlgebra.involute_mem_filtration`,
-  `TauCeti.CliffordAlgebra.reverse_mem_filtration` and
-  `TauCeti.CliffordAlgebra.map_mem_filtration`: the filtration is preserved by the grade
+* `CliffordAlgebra.iSup_filtration_eq_top`: the filtration is exhaustive.
+* `CliffordAlgebra.involute_mem_filtration`,
+  `CliffordAlgebra.reverse_mem_filtration` and
+  `CliffordAlgebra.map_mem_filtration`: the filtration is preserved by the grade
   involution, by reversal, and by an isometry of quadratic forms.
-* `TauCeti.CliffordAlgebra.contractLeft_mem_filtration_succ` and
-  `TauCeti.CliffordAlgebra.contractLeft_mem_filtration`,
-  `TauCeti.CliffordAlgebra.changeForm_mem_filtration`, and
-  `TauCeti.CliffordAlgebra.changeFormEquiv_map_filtration` and
-  `TauCeti.CliffordAlgebra.changeForm_mem_filtration_iff`: contraction and change of
+* `CliffordAlgebra.contractLeft_mem_filtration_succ` and
+  `CliffordAlgebra.contractLeft_mem_filtration`,
+  `CliffordAlgebra.changeForm_mem_filtration`, and
+  `CliffordAlgebra.changeFormEquiv_map_filtration` and
+  `CliffordAlgebra.changeForm_mem_filtration_iff`: contraction and change of
   quadratic form respect the filtration, contraction lowers every positive step by one, and the
   change-form equivalence transports every step exactly.
-* `TauCeti.CliffordAlgebra.changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration`: change of form
+* `CliffordAlgebra.changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration`: change of form
   has identity symbol, that is, it moves a word of generators only by terms two filtration degrees
   lower.
-* `TauCeti.CliffordAlgebra.fg_filtration`: each step is a finitely generated module when `M` is.
+* `CliffordAlgebra.fg_filtration`: each step is a finitely generated module when `M` is.
 
 ## References
 
@@ -100,9 +100,9 @@ open CliffordAlgebra
 
 universe u v w
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
@@ -648,5 +648,3 @@ theorem fg_filtration [Module.Finite R M] (k : ℕ) : (filtration Q k).FG := by
     exact ih.sup (hι.pow _)
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
@@ -24,20 +24,20 @@ construct the total associated-graded algebra or prove multiplication compatibil
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.equivExteriorFiltration`: `equivExterior` restricted to one filtration
+* `CliffordAlgebra.equivExteriorFiltration`: `equivExterior` restricted to one filtration
   step.
-* `TauCeti.CliffordAlgebra.filtrationGradedEquiv`: the corresponding degree-quotient equivalence
+* `CliffordAlgebra.filtrationGradedEquiv`: the corresponding degree-quotient equivalence
   with the exterior power.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.equivExterior_mem_zero_form_filtration` and
-  `TauCeti.CliffordAlgebra.equivExterior_symm_mem_filtration`: `equivExterior` and its inverse
+* `CliffordAlgebra.equivExterior_mem_zero_form_filtration` and
+  `CliffordAlgebra.equivExterior_symm_mem_filtration`: `equivExterior` and its inverse
   carry each Clifford filtration step to the corresponding zero-form step and back.
-* `TauCeti.CliffordAlgebra.filtrationGradedEquiv_comp_filtrationLeadingTerm`: the graded
+* `CliffordAlgebra.filtrationGradedEquiv_comp_filtrationLeadingTerm`: the graded
   equivalence inverts `Filtration.lean`'s leading-term map, so the two independent routes to the
   degree quotient are the same map, with
-  `TauCeti.CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm` the map-level form.
+  `CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm` the map-level form.
 
 ## References
 
@@ -59,9 +59,9 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M) [Invertible (2 : R)]
@@ -196,5 +196,3 @@ theorem filtrationLeadingTerm_eq_filtrationGradedEquiv_symm (k : ℕ) :
     (filtrationGradedEquiv_comp_filtrationLeadingTerm Q k)
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/FiltrationGradedEquiv.lean
@@ -55,13 +55,10 @@ construct the total associated-graded algebra or prove multiplication compatibil
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M) [Invertible (2 : R)]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -19,9 +19,9 @@ here once and shared.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero`: in the even base case the
+* `CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero`: in the even base case the
   element is a scalar.
-* `TauCeti.CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one`: in the odd base case it is a vector.
+* `CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one`: in the odd base case it is a vector.
 -/
 
 public section
@@ -30,7 +30,7 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   {Q : QuadraticForm R M}
@@ -48,4 +48,4 @@ theorem exists_ι_of_mem_range_ι_pow_one {v : CliffordAlgebra Q}
     (hv : v ∈ LinearMap.range (ι Q) ^ (1 : ZMod 2).val) : ∃ a, ι Q a = v := by
   simpa [ZMod.val_one] using hv
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Grading.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Grading.lean
@@ -26,7 +26,6 @@ here once and shared.
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
@@ -20,10 +20,10 @@ norm: the Clifford norm descends modulo squares through the kernel of that actio
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.lipschitzNorm`: the unit-valued Clifford norm.
-* `TauCeti.CliffordAlgebra.self_mul_star_eq_algebraMap_lipschitzNorm`: its second
+* `CliffordAlgebra.lipschitzNorm`: the unit-valued Clifford norm.
+* `CliffordAlgebra.self_mul_star_eq_algebraMap_lipschitzNorm`: its second
   characteristic Clifford-product equation.
-* `TauCeti.CliffordAlgebra.lipschitzNorm_unitι`: its value on a generating vector.
+* `CliffordAlgebra.lipschitzNorm_unitι`: its value on a generating vector.
 
 ## References
 
@@ -34,7 +34,9 @@ public section
 
 open CliffordAlgebra QuadraticMap
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 universe u v
 
@@ -213,4 +215,4 @@ theorem lipschitzNorm_pinToLipschitz (Q : QuadraticForm R V) (p : pinGroup Q) :
   simpa only [coe_pinToLipschitz_apply, Units.val_one, map_one] using
     pinGroup.coe_star_mul_self p
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Lipschitz/Norm.lean
@@ -32,11 +32,9 @@ See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra QuadraticMap
+open QuadraticMap
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 universe u v
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
@@ -22,7 +22,7 @@ This completes the associated-graded-algebra part of Layer 0 in the
 
 ## Main definition
 
-* `TauCeti.CliffordAlgebra.filtrationAssociatedGradedEquivExterior`: the algebra equivalence from
+* `CliffordAlgebra.filtrationAssociatedGradedEquivExterior`: the algebra equivalence from
   the associated graded of the Clifford filtration to the exterior algebra.
 
 ## References
@@ -38,7 +38,9 @@ open scoped DirectSum
 
 universe u v
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M) [Invertible (2 : R)]
@@ -350,4 +352,4 @@ theorem filtrationAssociatedGradedEquivExterior_symm_apply_coe_succ (n : ℕ)
         ((filtrationGradedEquiv Q n).symm x) := by
   exact filtrationAssociatedGradedEquivExterior_symm_apply_coe Q (n + 1) x
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/PBW.lean
@@ -33,14 +33,11 @@ This completes the associated-graded-algebra part of Layer 0 in the
 
 public section
 
-open CliffordAlgebra
 open scoped DirectSum
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M) [Invertible (2 : R)]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Action.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Action.lean
@@ -70,7 +70,7 @@ Spinors* (1954), Chapter II.
 
 public section
 
-open CliffordAlgebra QuadraticMap
+open QuadraticMap
 
 universe u v
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Action.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Action.lean
@@ -23,36 +23,36 @@ space preserves the form, nor that it is a group homomorphism. This file supplie
 Form-preservation is proved along the generation of `lipschitzGroup Q` by vectors: a vector of
 invertible norm acts by `TauCeti.QuadraticMap.reflection`, which is orthogonal, and the orthogonal
 group is a subgroup, so every Lipschitz element acts orthogonally. That identification of the
-generators is `TauCeti.CliffordAlgebra.lipschitzVectorAction_unitι`, and it is the statement an
+generators is `CliffordAlgebra.lipschitzVectorAction_unitι`, and it is the statement an
 eventual Cartan-Dieudonné theorem turns into surjectivity of the double cover.
 
-`TauCeti.CliffordAlgebra.spinToOrthogonal` already describes the spin group acting by *plain*
+`CliffordAlgebra.spinToOrthogonal` already describes the spin group acting by *plain*
 conjugation. That is not a second action: an element of the spin group is even, so `involute` fixes
-it, and `TauCeti.CliffordAlgebra.pinToOrthogonal_spinToPin` records that the two agree there.
+it, and `CliffordAlgebra.pinToOrthogonal_spinToPin` records that the two agree there.
 Twisted conjugation is the one that extends to the odd part.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.unitι Q v`: a vector of invertible norm, as a unit of the Clifford
+* `CliffordAlgebra.unitι Q v`: a vector of invertible norm, as a unit of the Clifford
   algebra and hence a generator of the Lipschitz group.
-* `TauCeti.CliffordAlgebra.lipschitzVectorAction Q x`: the automorphism of the quadratic space
+* `CliffordAlgebra.lipschitzVectorAction Q x`: the automorphism of the quadratic space
   induced by twisted conjugation by a Lipschitz element.
-* `TauCeti.CliffordAlgebra.lipschitzToOrthogonal Q` and
-  `TauCeti.CliffordAlgebra.pinToOrthogonal Q`: the resulting homomorphisms to `O(Q)`, along the
-  inclusions `TauCeti.CliffordAlgebra.pinToLipschitz` and `TauCeti.CliffordAlgebra.spinToPin`.
+* `CliffordAlgebra.lipschitzToOrthogonal Q` and
+  `CliffordAlgebra.pinToOrthogonal Q`: the resulting homomorphisms to `O(Q)`, along the
+  inclusions `CliffordAlgebra.pinToLipschitz` and `CliffordAlgebra.spinToPin`.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.lipschitzVectorAction_unitι`: **a vector acts by the reflection in its
+* `CliffordAlgebra.lipschitzVectorAction_unitι`: **a vector acts by the reflection in its
   orthogonal hyperplane.** This is the identification of the generators referred to above.
-* `TauCeti.CliffordAlgebra.lipschitzVectorAction_map_app`: twisted conjugation by a Lipschitz
+* `CliffordAlgebra.lipschitzVectorAction_map_app`: twisted conjugation by a Lipschitz
   element preserves the quadratic form.
-* `TauCeti.CliffordAlgebra.ι_mem_pinGroup`: a vector `v` with `Q v = -1` lies in the Pin group, and
-  `TauCeti.CliffordAlgebra.pinToOrthogonal_ι_apply` computes the reflection it induces. The sign is
+* `CliffordAlgebra.ι_mem_pinGroup`: a vector `v` with `Q v = -1` lies in the Pin group, and
+  `CliffordAlgebra.pinToOrthogonal_ι_apply` computes the reflection it induces. The sign is
   forced by Mathlib's conventions: `star` is the reversal composed with the grade involution, so
   `star (ι Q v) = -ι Q v` and the unitarity condition defining `pinGroup Q` reads `-Q v = 1` on a
   vector.
-* `TauCeti.CliffordAlgebra.pinToOrthogonal_spinToPin`: on the spin group, twisted conjugation is
+* `CliffordAlgebra.pinToOrthogonal_spinToPin`: on the spin group, twisted conjugation is
   plain conjugation.
 
 Surjectivity of `pinToOrthogonal Q` (Cartan-Dieudonné) and the computation of its kernel as `{±1}`
@@ -72,11 +72,11 @@ public section
 
 open CliffordAlgebra QuadraticMap
 
-namespace TauCeti
-
 universe u v
 
 namespace CliffordAlgebra
+
+open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M)
@@ -143,7 +143,7 @@ theorem ι_mem_pinGroup {v : M} (hv : Q v = -1) : ι Q v ∈ pinGroup Q := by
 /-! ### The induced map on the quadratic space
 
 Twisted conjugation by a Lipschitz element carries vectors to vectors, so it descends to the
-quadratic space through the vector part `TauCeti.CliffordAlgebra.ιInv`. The unbundled form
+quadratic space through the vector part `CliffordAlgebra.ιInv`. The unbundled form
 `vectorMap` below is a plain linear endomorphism, defined for every unit but meaningful only for
 Lipschitz ones; the bundled automorphism is `lipschitzVectorAction`. -/
 
@@ -374,8 +374,8 @@ theorem coe_spinToPin_apply (x : spinGroup Q) :
   rfl
 
 /-- **On the spin group, twisted conjugation is plain conjugation.** A spin element is even, so the
-grade involution fixes it, and `TauCeti.CliffordAlgebra.spinToOrthogonal` is the restriction of
-`TauCeti.CliffordAlgebra.pinToOrthogonal` along the inclusion of the spin group. -/
+grade involution fixes it, and `CliffordAlgebra.spinToOrthogonal` is the restriction of
+`CliffordAlgebra.pinToOrthogonal` along the inclusion of the spin group. -/
 @[simp]
 theorem pinToOrthogonal_spinToPin (x : spinGroup Q) :
     pinToOrthogonal Q (spinToPin Q x) = spinToOrthogonal Q x := by
@@ -384,5 +384,3 @@ theorem pinToOrthogonal_spinToPin (x : spinGroup Q) :
     coe_spinToOrthogonal_apply, ι_spinVectorAction_apply]
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
@@ -39,7 +39,6 @@ from `TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover`.
 
 public section
 
-open CliffordAlgebra
 
 namespace CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/DoubleCover.lean
@@ -19,15 +19,15 @@ separably closed field.
 
 ## Main definitions and results
 
-* `TauCeti.CliffordAlgebra.pinDoubleCoverOfSurjective` packages any surjective Pin action as a
+* `CliffordAlgebra.pinDoubleCoverOfSurjective` packages any surjective Pin action as a
   group extension.
-* `TauCeti.CliffordAlgebra.pinDoubleCover` packages
+* `CliffordAlgebra.pinDoubleCover` packages
   `1 → ZMod 2 → Pin(Q) → O(Q) → 1` as a group extension.
-* `TauCeti.CliffordAlgebra.pinDoubleCoverOfSurjective_inl_ofAdd_one` and
-  `TauCeti.CliffordAlgebra.pinDoubleCoverOfSurjective_rightHom` characterize the generic
+* `CliffordAlgebra.pinDoubleCoverOfSurjective_inl_ofAdd_one` and
+  `CliffordAlgebra.pinDoubleCoverOfSurjective_rightHom` characterize the generic
   extension.
-* `TauCeti.CliffordAlgebra.pinDoubleCover_inl_ofAdd_one` and
-  `TauCeti.CliffordAlgebra.pinDoubleCover_rightHom` characterize the separably closed case.
+* `CliffordAlgebra.pinDoubleCover_inl_ofAdd_one` and
+  `CliffordAlgebra.pinDoubleCover_rightHom` characterize the separably closed case.
 
 ## References
 
@@ -41,7 +41,9 @@ public section
 
 open CliffordAlgebra
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 universe u v
 
@@ -110,4 +112,4 @@ theorem pinDoubleCover_rightHom [IsSepClosed K]
     (pinDoubleCover Q hQ).rightHom = pinToOrthogonal Q := by
   rw [pinDoubleCover_def, pinDoubleCoverOfSurjective_rightHom]
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Kernel.lean
@@ -17,11 +17,11 @@ classification.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerPinToOrthogonal`: the kernel is canonically
+* `CliffordAlgebra.zmodTwoMulEquivKerPinToOrthogonal`: the kernel is canonically
   equivalent to `Multiplicative (ZMod 2)`.
-* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerPinToOrthogonal_apply_ofAdd_one`: the chosen
+* `CliffordAlgebra.zmodTwoMulEquivKerPinToOrthogonal_apply_ofAdd_one`: the chosen
   generator maps to the scalar `-1` inside the Pin group.
-* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerPinToOrthogonal_symm_apply_negOne`: the inverse
+* `CliffordAlgebra.zmodTwoMulEquivKerPinToOrthogonal_symm_apply_negOne`: the inverse
   sends the scalar `-1` to the chosen generator.
 
 ## References
@@ -33,7 +33,9 @@ M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 universe u v
 
@@ -125,4 +127,4 @@ theorem zmodTwoMulEquivKerPinToOrthogonal_symm_apply_negOne [Nontrivial M]
   rw [MulEquiv.symm_apply_eq]
   exact (zmodTwoMulEquivKerPinToOrthogonal_apply_ofAdd_one Q hQ).symm
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Pin/Kernel.lean
@@ -35,8 +35,6 @@ public section
 
 namespace CliffordAlgebra
 
-open TauCeti
-
 universe u v
 
 variable {K : Type u} {M : Type v} [Field K] [AddCommGroup M] [Module K M]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -17,15 +17,15 @@ Clifford action makes the target Clifford module a module for the original Lie a
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.cliffordInducedRep`: the induced Lie representation on a Clifford
+* `CliffordAlgebra.cliffordInducedRep`: the induced Lie representation on a Clifford
   module.
-* `TauCeti.CliffordAlgebra.cliffordInducedRep_apply`: its defining equation.
-* `TauCeti.CliffordAlgebra.cliffordDerivationRep`: the induced representation on the Clifford
+* `CliffordAlgebra.cliffordInducedRep_apply`: its defining equation.
+* `CliffordAlgebra.cliffordDerivationRep`: the induced representation on the Clifford
   algebra by inner derivations.
-* `TauCeti.CliffordAlgebra.cliffordDerivationRep_apply`: its defining commutator equation.
-* `TauCeti.CliffordAlgebra.adjointCliffordHom`: the quadratic lift of the adjoint representation
+* `CliffordAlgebra.cliffordDerivationRep_apply`: its defining commutator equation.
+* `CliffordAlgebra.adjointCliffordHom`: the quadratic lift of the adjoint representation
   for a Killing-semisimple Lie algebra.
-* `TauCeti.CliffordAlgebra.adjointCliffordHom_lie_ι`: the lift acts on Clifford generators by the
+* `CliffordAlgebra.adjointCliffordHom_lie_ι`: the lift acts on Clifford generators by the
   original adjoint action.
 
 ## References
@@ -40,7 +40,9 @@ open CliffordAlgebra
 
 universe u v w x
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
@@ -118,4 +120,4 @@ theorem adjointCliffordHom_lie_ι (K : Type u) (L : Type v) [Field K]
     LieSubalgebra.coe_incl, LieEquiv.coe_toLieHom, soEquivQuadratic_lie_ι,
     _root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply]
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -36,13 +36,10 @@ Clifford action makes the target Clifford module a module for the original Lie a
 
 public section
 
-open CliffordAlgebra
 
 universe u v w x
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Subalgebra.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Subalgebra.lean
@@ -70,13 +70,10 @@ scope.
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Subalgebra.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Subalgebra.lean
@@ -15,16 +15,16 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.Bivector
 
 A Clifford algebra is an associative algebra, so its commutator makes it a Lie algebra. Inside it
 the **quadratic elements** — the span of the half-normalized commutators
-`TauCeti.CliffordAlgebra.bivector Q a b` of two generators — are closed under the bracket,
+`CliffordAlgebra.bivector Q a b` of two generators — are closed under the bracket,
 and this file equips them with the resulting `LieSubalgebra` structure.
 
 Closure is a two-line consequence of the action-normalization identity
-`TauCeti.CliffordAlgebra.bivector_lie_ι`, which says that a Clifford bivector brackets a
+`CliffordAlgebra.bivector_lie_ι`, which says that a Clifford bivector brackets a
 generator to the infinitesimal rotation `x ↦ polar Q b x • a - polar Q a x • b`. Because bracketing
 with a fixed element is a derivation for the associative product, the bracket of two Clifford
 bivectors is obtained by rotating each of the two generators of the second one in turn, so it is
 again a sum of two Clifford bivectors
-(`TauCeti.CliffordAlgebra.lie_bivector_bivector`).
+(`CliffordAlgebra.lie_bivector_bivector`).
 
 Nothing here needs the quadratic form to be nondegenerate, the module to be finite-dimensional, or
 the base to be a field: the statements hold over any commutative ring in which `2` is invertible.
@@ -32,7 +32,7 @@ The identification of this subalgebra with `𝔰𝔬(V, Q)` — Mathlib's
 `skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q)` — does need those hypotheses, and is not
 proved here; the bridging fact this file does supply is that a quadratic element brackets every
 generator back into the generators
-(`TauCeti.CliffordAlgebra.lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra`), which is what makes
+(`CliffordAlgebra.lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra`), which is what makes
 that comparison map exist at all.
 
 Following Mathlib's `Mathlib/Algebra/Lie/SkewAdjoint.lean`, the Lie ring structure on an
@@ -43,23 +43,23 @@ scope.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra`: the quadratic elements of `CliffordAlgebra Q`,
+* `CliffordAlgebra.quadraticLieSubalgebra`: the quadratic elements of `CliffordAlgebra Q`,
   as a Lie subalgebra under the commutator bracket.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.lie_bivector_bivector`: the bracket of two Clifford
+* `CliffordAlgebra.lie_bivector_bivector`: the bracket of two Clifford
   bivectors, as a sum of two Clifford bivectors.
-* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_le_of_bivector_mem`: the
+* `CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_le_of_bivector_mem`: the
   universal property of the underlying submodule, from which the containments below are read off.
-* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_evenOdd_zero`,
-  `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_even` and
-  `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_filtration_two`: the quadratic elements are
+* `CliffordAlgebra.quadraticLieSubalgebra_le_evenOdd_zero`,
+  `CliffordAlgebra.quadraticLieSubalgebra_le_even` and
+  `CliffordAlgebra.quadraticLieSubalgebra_le_filtration_two`: the quadratic elements are
   even and have filtration degree at most two.
-* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_eq_range` and
-  `TauCeti.CliffordAlgebra.mem_quadraticLieSubalgebra_iff`: they are exactly the image of
-  `⋀[R]^2 M` under `TauCeti.CliffordAlgebra.bivectorExterior`.
-* `TauCeti.CliffordAlgebra.lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra`: bracketing with a
+* `CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_eq_range` and
+  `CliffordAlgebra.mem_quadraticLieSubalgebra_iff`: they are exactly the image of
+  `⋀[R]^2 M` under `CliffordAlgebra.bivectorExterior`.
+* `CliffordAlgebra.lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra`: bracketing with a
   quadratic element preserves the generators.
 
 ## References
@@ -74,9 +74,9 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
@@ -139,7 +139,7 @@ private theorem lie_mem_span {x y : CliffordAlgebra Q}
 
 /-- **The quadratic elements of a Clifford algebra**, as a Lie subalgebra of `CliffordAlgebra Q`
 under the commutator bracket: the `R`-span of the Clifford bivectors
-`TauCeti.CliffordAlgebra.bivector Q a b`.
+`CliffordAlgebra.bivector Q a b`.
 
 Unlike a transported bracket on `⋀[R]^2 M`, this is a subobject of the Clifford algebra itself, so
 it needs no scoped instances beyond the local `LieRing.ofAssociativeRing` on an associative ring. -/
@@ -185,7 +185,7 @@ theorem quadraticLieSubalgebra_le_filtration_two :
 
 /-- **The quadratic elements are the image of the second exterior power.** This is the sense in
 which the Lie subalgebra realizes `⋀[R]^2 M` inside the Clifford algebra; the map itself is
-`TauCeti.CliffordAlgebra.bivectorExterior`. -/
+`CliffordAlgebra.bivectorExterior`. -/
 theorem quadraticLieSubalgebra_toSubmodule_eq_range :
     (quadraticLieSubalgebra Q).toSubmodule = LinearMap.range (bivectorExterior Q) :=
   le_antisymm
@@ -196,7 +196,7 @@ theorem quadraticLieSubalgebra_toSubmodule_eq_range :
 
 /-- **Membership in the quadratic elements**: an element of the Clifford algebra is quadratic
 exactly when it is in the image of `⋀[R]^2 M` under
-`TauCeti.CliffordAlgebra.bivectorExterior`. -/
+`CliffordAlgebra.bivectorExterior`. -/
 @[simp]
 theorem mem_quadraticLieSubalgebra_iff {x : CliffordAlgebra Q} :
     x ∈ quadraticLieSubalgebra Q ↔ x ∈ LinearMap.range (bivectorExterior Q) := by
@@ -221,5 +221,3 @@ theorem lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra {x : CliffordAlgebra Q
 end CommRing
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
@@ -20,8 +20,8 @@ canonical bivector action rather than from a basis-dependent inverse.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.soEquivQuadratic`: the quadratic realization Lie equivalence.
-* `TauCeti.CliffordAlgebra.soEquivQuadratic_lie_ι`: its defining generator-action equation.
+* `CliffordAlgebra.soEquivQuadratic`: the quadratic realization Lie equivalence.
+* `CliffordAlgebra.soEquivQuadratic_lie_ι`: its defining generator-action equation.
 
 ## References
 
@@ -35,7 +35,9 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
@@ -172,4 +174,4 @@ theorem soEquivQuadratic_lie_ι (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
       CliffordAlgebra Q), ι Q x⁆ = _
   exact soToQuadraticLinearEquiv_lie_ι Q hQ f x
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
@@ -31,7 +31,6 @@ canonical bivector action rather than from a basis-dependent inverse.
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -155,7 +155,7 @@ below to be isomorphisms. -/
 @[simp]
 theorem finrank_cliffordAlgebra_realCliffordForm (p q : ℕ) :
     finrank ℝ (CliffordAlgebra (realCliffordForm p q)) = 2 ^ (p + q) := by
-  rw [TauCeti.CliffordAlgebra.finrank_eq_two_pow, Module.finrank_pi, Fintype.card_fin]
+  rw [CliffordAlgebra.finrank_eq_two_pow, Module.finrank_pi, Fintype.card_fin]
 
 private def realCliffordNegIndexEquiv (p q : ℕ) : Fin (p + q) ≃ Fin (q + p) :=
   finSumFinEquiv.symm |>.trans

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -35,7 +35,7 @@ See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra QuadraticMap
+open QuadraticMap
 
 universe u v
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -20,9 +20,9 @@ automatically.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.reflection_mem_range_pinToOrthogonal_of_isSquare`: a reflection lifts
+* `CliffordAlgebra.reflection_mem_range_pinToOrthogonal_of_isSquare`: a reflection lifts
   through the Pin action when its normalization scalar is a square.
-* `TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare`: a
+* `CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare`: a
   product of two reflections lifts through the Spin action when the product of its normalization
   scalars is a square. The version without the suffix is a separably closed-field corollary.
 
@@ -37,11 +37,11 @@ public section
 
 open CliffordAlgebra QuadraticMap
 
-namespace TauCeti
-
 universe u v
 
 namespace CliffordAlgebra
+
+open TauCeti
 
 section Square
 
@@ -230,4 +230,3 @@ theorem reflection_mul_reflection_mem_range_spinToOrthogonal
 end IsSepClosed
 
 end CliffordAlgebra
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SignSwitch.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SignSwitch.lean
@@ -16,9 +16,9 @@ negation. The construction is generic over a commutative ring.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.signSwitchEquiv`: the sign-switch algebra equivalence;
-* `TauCeti.CliffordAlgebra.signSwitchEquiv_ι`: its equation on generators;
-* `TauCeti.CliffordAlgebra.signSwitchEquiv_symm_apply_ι`: the inverse generator equation.
+* `CliffordAlgebra.signSwitchEquiv`: the sign-switch algebra equivalence;
+* `CliffordAlgebra.signSwitchEquiv_ι`: its equation on generators;
+* `CliffordAlgebra.signSwitchEquiv_symm_apply_ι`: the inverse generator equation.
 
 ## References
 
@@ -29,7 +29,7 @@ public section
 
 open Module QuadraticMap
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
 
 section SignSwitch
 
@@ -165,4 +165,4 @@ theorem signSwitchEquiv_symm_apply_ι (x : N × R) :
 
 end SignSwitch
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Action.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Action.lean
@@ -15,7 +15,7 @@ public import Mathlib.LinearAlgebra.CliffordAlgebra.SpinGroup
 
 Mathlib defines `spinGroup Q` inside `CliffordAlgebra Q` and proves that its conjugation action
 preserves the range of the generating map `CliffordAlgebra.ι Q`. This file transports that action
-through `TauCeti.CliffordAlgebra.ιRangeEquiv`, proves that it preserves `Q`, and packages the result
+through `CliffordAlgebra.ιRangeEquiv`, proves that it preserves `Q`, and packages the result
 as `spinToOrthogonal Q : spinGroup Q →* QuadraticMap.orthogonalGroup Q`.
 
 This is the representation underlying the double cover from the spin group to the special
@@ -24,9 +24,9 @@ Cartan--Dieudonné argument and are deliberately not asserted here.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.spinVectorAction Q x` is the linear automorphism induced by conjugation
+* `CliffordAlgebra.spinVectorAction Q x` is the linear automorphism induced by conjugation
   by the spin element `x`.
-* `TauCeti.CliffordAlgebra.spinToOrthogonal Q` is the resulting homomorphism into `O(Q)`.
+* `CliffordAlgebra.spinToOrthogonal Q` is the resulting homomorphism into `O(Q)`.
 
 ## References
 
@@ -39,11 +39,11 @@ public section
 
 open CliffordAlgebra
 
-namespace TauCeti
-
 universe u v
 
 namespace CliffordAlgebra
+
+open TauCeti
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M) [Invertible (2 : R)]
@@ -170,4 +170,3 @@ theorem coe_spinToOrthogonal_apply (x : spinGroup Q) (m : M) :
   rfl
 
 end CliffordAlgebra
-end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Action.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Action.lean
@@ -37,7 +37,6 @@ and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
@@ -39,7 +39,6 @@ M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra
 
 namespace CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/DoubleCover.lean
@@ -19,15 +19,15 @@ separably closed field.
 
 ## Main definitions and results
 
-* `TauCeti.CliffordAlgebra.spinDoubleCoverOfSurjective` packages any surjective Spin action as a
+* `CliffordAlgebra.spinDoubleCoverOfSurjective` packages any surjective Spin action as a
   group extension.
-* `TauCeti.CliffordAlgebra.spinDoubleCover` packages
+* `CliffordAlgebra.spinDoubleCover` packages
   `1 → ZMod 2 → Spin(Q) → SO(Q) → 1` as a group extension.
-* `TauCeti.CliffordAlgebra.spinDoubleCoverOfSurjective_inl_ofAdd_one` and
-  `TauCeti.CliffordAlgebra.spinDoubleCoverOfSurjective_rightHom` characterize the generic
+* `CliffordAlgebra.spinDoubleCoverOfSurjective_inl_ofAdd_one` and
+  `CliffordAlgebra.spinDoubleCoverOfSurjective_rightHom` characterize the generic
   extension.
-* `TauCeti.CliffordAlgebra.spinDoubleCover_inl_ofAdd_one` and
-  `TauCeti.CliffordAlgebra.spinDoubleCover_rightHom` characterize the separably closed case.
+* `CliffordAlgebra.spinDoubleCover_inl_ofAdd_one` and
+  `CliffordAlgebra.spinDoubleCover_rightHom` characterize the separably closed case.
 
 ## References
 
@@ -41,7 +41,9 @@ public section
 
 open CliffordAlgebra
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 universe u v
 
@@ -111,4 +113,4 @@ theorem spinDoubleCover_rightHom [IsSepClosed K]
     (spinDoubleCover Q hQ).rightHom = spinToSpecialOrthogonal Q := by
   rw [spinDoubleCover_def, spinDoubleCoverOfSurjective_rightHom]
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -19,15 +19,15 @@ contraction and the exterior-algebra basis. Unitarity then restricts the scalar 
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.mem_ker_spinToSpecialOrthogonal_iff`: a Spin element is in the kernel
+* `CliffordAlgebra.mem_ker_spinToSpecialOrthogonal_iff`: a Spin element is in the kernel
 exactly when it is `1` or the canonical scalar `-1`.
-* `TauCeti.CliffordAlgebra.card_ker_spinToSpecialOrthogonal`: the kernel of the Spin action on
+* `CliffordAlgebra.card_ker_spinToSpecialOrthogonal`: the kernel of the Spin action on
 the special orthogonal group has cardinality two.
-* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal`: the kernel is canonically
+* `CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal`: the kernel is canonically
   equivalent to `Multiplicative (ZMod 2)`.
-* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one`: the chosen
+* `CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal_apply_ofAdd_one`: the chosen
   generator maps to the scalar `-1`.
-* `TauCeti.CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal_symm_apply_negOne`: the inverse
+* `CliffordAlgebra.zmodTwoMulEquivKerSpinToSpecialOrthogonal_symm_apply_negOne`: the inverse
   sends the scalar `-1` to the chosen generator.
 
 ## References
@@ -41,7 +41,9 @@ public section
 
 open CliffordAlgebra
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 universe u v
 
@@ -213,9 +215,11 @@ end spinGroup
 
 end NegOne
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 section Kernel
 
@@ -319,4 +323,4 @@ theorem zmodTwoMulEquivKerSpinToSpecialOrthogonal_symm_apply_negOne [Nontrivial 
 
 end Kernel
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Kernel.lean
@@ -39,8 +39,6 @@ M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra
-
 namespace CliffordAlgebra
 
 open TauCeti
@@ -218,8 +216,6 @@ end NegOne
 end CliffordAlgebra
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 section Kernel
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
@@ -18,11 +18,11 @@ remains canonical.
 
 ## Main definitions and results
 
-* `TauCeti.CliffordAlgebra.spinToSpecialOrthogonal` is the Spin action with codomain restricted to
+* `CliffordAlgebra.spinToSpecialOrthogonal` is the Spin action with codomain restricted to
   the special orthogonal group.
-* `TauCeti.CliffordAlgebra.ker_spinToSpecialOrthogonal` identifies its kernel with that of the
+* `CliffordAlgebra.ker_spinToSpecialOrthogonal` identifies its kernel with that of the
   orthogonal Spin action.
-* `TauCeti.CliffordAlgebra.coe_spinToSpecialOrthogonal_apply` identifies its underlying action
+* `CliffordAlgebra.coe_spinToSpecialOrthogonal_apply` identifies its underlying action
   with the Spin action on the quadratic module.
 
 ## References
@@ -36,7 +36,9 @@ public section
 
 open CliffordAlgebra QuadraticMap
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 universe u v
 
@@ -253,4 +255,4 @@ theorem coe_spinToSpecialOrthogonal_apply (Q : QuadraticForm R M) (x : spinGroup
   change (((spinToOrthogonal Q x : QuadraticMap.orthogonalGroup Q) : M ≃ₗ[R] M) m) = _
   rw [coe_spinToOrthogonal_apply]
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
@@ -34,7 +34,7 @@ M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra QuadraticMap
+open QuadraticMap
 
 namespace CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
@@ -22,9 +22,9 @@ Spin group.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.orthogonalSpinorNorm`: the square-class-valued spinor norm on `O(Q)`.
-* `TauCeti.CliffordAlgebra.spinorNorm`: its restriction to `SO(Q)`.
-* `TauCeti.CliffordAlgebra.range_spinToSpecialOrthogonal_eq_ker_spinorNorm`: the Spin image is
+* `CliffordAlgebra.orthogonalSpinorNorm`: the square-class-valued spinor norm on `O(Q)`.
+* `CliffordAlgebra.spinorNorm`: its restriction to `SO(Q)`.
+* `CliffordAlgebra.range_spinToSpecialOrthogonal_eq_ker_spinorNorm`: the Spin image is
   the kernel of the spinor norm.
 
 ## References
@@ -36,7 +36,9 @@ public section
 
 open CliffordAlgebra QuadraticMap
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 universe u v
 
@@ -315,4 +317,4 @@ theorem range_spinToSpecialOrthogonal_eq_ker_spinorNorm
     rw [coe_spinToOrthogonal_apply] at hv
     exact hv
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
@@ -34,7 +34,7 @@ See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra QuadraticMap
+open QuadraticMap
 
 namespace CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Surjectivity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Surjectivity.lean
@@ -32,7 +32,7 @@ M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 
 public section
 
-open CliffordAlgebra QuadraticMap
+open QuadraticMap
 
 namespace CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Surjectivity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Surjectivity.lean
@@ -16,11 +16,11 @@ the special orthogonal group.
 
 ## Main definitions and results
 
-* `TauCeti.CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_pinToOrthogonal_surjective`
+* `CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_pinToOrthogonal_surjective`
   restricts any surjective Pin action to a surjective Spin action on the special orthogonal group.
-* `TauCeti.CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_isSquare` proves its
+* `CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_isSquare` proves its
   surjectivity when every reflection normalization scalar is a square.
-* `TauCeti.CliffordAlgebra.spinToSpecialOrthogonal_surjective` specializes this to a
+* `CliffordAlgebra.spinToSpecialOrthogonal_surjective` specializes this to a
   separably closed field.
 
 ## References
@@ -34,7 +34,9 @@ public section
 
 open CliffordAlgebra QuadraticMap
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 universe u v
 
@@ -93,4 +95,4 @@ end Field
 
 end Surjectivity
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/StandardBivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/StandardBivector.lean
@@ -27,10 +27,10 @@ commutator action of Clifford bivectors, rather than by expanding a matrix commu
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.bivectorEquivSo`: the standard exterior-bivector Lie equivalence.
-* `TauCeti.CliffordAlgebra.bivectorEquivSo_apply_ιMulti`: its value on a decomposable bivector.
-* `TauCeti.CliffordAlgebra.bivectorEquivSo_symm_repr_apply`: the coefficients of its inverse.
-* `TauCeti.CliffordAlgebra.bivectorEquivSo_apply_ιMulti_mulVec`: its normalized action on a vector.
+* `CliffordAlgebra.bivectorEquivSo`: the standard exterior-bivector Lie equivalence.
+* `CliffordAlgebra.bivectorEquivSo_apply_ιMulti`: its value on a decomposable bivector.
+* `CliffordAlgebra.bivectorEquivSo_symm_repr_apply`: the coefficients of its inverse.
+* `CliffordAlgebra.bivectorEquivSo_apply_ιMulti_mulVec`: its normalized action on a vector.
 
 ## References
 
@@ -48,7 +48,9 @@ open CliffordAlgebra
 
 universe u
 
-namespace TauCeti.CliffordAlgebra
+namespace CliffordAlgebra
+
+open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
@@ -489,4 +491,4 @@ theorem bivectorEquivSo_apply_ιMulti_mulVec (u v x : Fin n → R) :
   rw [bivectorEquivSo_apply]
   exact standardBivectorToSoLinear_mulVec n R u v x
 
-end TauCeti.CliffordAlgebra
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/StandardBivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/StandardBivector.lean
@@ -43,14 +43,10 @@ public section
 open scoped Matrix
 
 open TauCeti
-open CliffordAlgebra
-
 
 universe u
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
@@ -73,13 +73,10 @@ the scalars and the vectors, the disjointness of the two pins that step down to 
 
 public section
 
-open CliffordAlgebra
 
 universe u v
 
 namespace CliffordAlgebra
-
-open TauCeti
 
 section CommRing
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Vectors.lean
@@ -30,7 +30,7 @@ transports the exterior-algebra statements along it, so all of them hold for an 
 quadratic form over a commutative ring in which `2` is invertible; no hypothesis on `Q` — no
 nondegeneracy, no finiteness, no freeness — is needed.
 
-The payoff is `TauCeti.CliffordAlgebra.ιRangeEquiv`, the linear equivalence `M ≃ₗ[R] range (ι Q)`.
+The payoff is `CliffordAlgebra.ιRangeEquiv`, the linear equivalence `M ≃ₗ[R] range (ι Q)`.
 It is what turns a statement about elements of `CliffordAlgebra Q` that happen to lie in
 `range (ι Q)` into a statement about vectors of `M`: Mathlib's twisted conjugation lemmas
 (`lipschitzGroup.conjAct_smul_range_ι`, `spinGroup.involute_act_ι_mem_range_ι`) say only that the
@@ -39,28 +39,28 @@ action to an honest linear automorphism of `M`. Landing in the orthogonal group 
 further step: a linear automorphism is not orthogonal for free, and that the transported action
 preserves `Q` has to be proved separately.
 
-Against the degree filtration `TauCeti.CliffordAlgebra.filtration`, whose first step is spanned by
+Against the degree filtration `CliffordAlgebra.filtration`, whose first step is spanned by
 the scalars and the vectors, the disjointness of the two pins that step down to `R ⊕ M`:
-`TauCeti.CliffordAlgebra.filtrationOneEquiv`.
+`CliffordAlgebra.filtrationOneEquiv`.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.ιInv`: the linear left inverse of `ι Q`, the *vector part* of an
+* `CliffordAlgebra.ιInv`: the linear left inverse of `ι Q`, the *vector part* of an
   element of the Clifford algebra.
-* `TauCeti.CliffordAlgebra.ιRangeEquiv`: the vector equivalence `M ≃ₗ[R] range (ι Q)`.
-* `TauCeti.CliffordAlgebra.scalarAddVector` and
-  `TauCeti.CliffordAlgebra.filtrationOneEquiv`: the map `(r, m) ↦ r + ι Q m` out of `R × M`, and
+* `CliffordAlgebra.ιRangeEquiv`: the vector equivalence `M ≃ₗ[R] range (ι Q)`.
+* `CliffordAlgebra.scalarAddVector` and
+  `CliffordAlgebra.filtrationOneEquiv`: the map `(r, m) ↦ r + ι Q m` out of `R × M`, and
   the equivalence with the first step of the degree filtration that it induces.
 
 ## Main results
 
-* `TauCeti.CliffordAlgebra.ι_injective`, `TauCeti.CliffordAlgebra.ι_inj` and
-  `TauCeti.CliffordAlgebra.ι_eq_zero_iff`: the generators are a faithful copy of `M`.
-* `TauCeti.CliffordAlgebra.ι_eq_algebraMap_iff`, `TauCeti.CliffordAlgebra.ι_ne_one` and
-  `TauCeti.CliffordAlgebra.ι_range_disjoint_one`: a vector is a scalar only when both vanish.
-* `TauCeti.CliffordAlgebra.mem_range_ι_iff`: membership of `range (ι Q)` is detected by the vector
+* `CliffordAlgebra.ι_injective`, `CliffordAlgebra.ι_inj` and
+  `CliffordAlgebra.ι_eq_zero_iff`: the generators are a faithful copy of `M`.
+* `CliffordAlgebra.ι_eq_algebraMap_iff`, `CliffordAlgebra.ι_ne_one` and
+  `CliffordAlgebra.ι_range_disjoint_one`: a vector is a scalar only when both vanish.
+* `CliffordAlgebra.mem_range_ι_iff`: membership of `range (ι Q)` is detected by the vector
   part.
-* `TauCeti.CliffordAlgebra.finrank_filtration_one`: the first step of the degree filtration has one
+* `CliffordAlgebra.finrank_filtration_one`: the first step of the degree filtration has one
   more dimension than `M`.
 
 ## References
@@ -77,9 +77,9 @@ open CliffordAlgebra
 
 universe u v
 
-namespace TauCeti
-
 namespace CliffordAlgebra
+
+open TauCeti
 
 section CommRing
 
@@ -156,9 +156,9 @@ theorem ι_ne_one [Nontrivial R] (m : M) : ι Q m ≠ 1 := by
   exact one_ne_zero ∘ And.right
 
 /-- **The vectors of a Clifford algebra are disjoint from its scalars.** Together with
-`TauCeti.CliffordAlgebra.filtration_one`, which writes the first step of the degree filtration as
+`CliffordAlgebra.filtration_one`, which writes the first step of the degree filtration as
 `1 ⊔ LinearMap.range (ι Q)`, this is what makes that step a direct sum of `R` and `M`; see
-`TauCeti.CliffordAlgebra.filtrationOneEquiv`. -/
+`CliffordAlgebra.filtrationOneEquiv`. -/
 theorem ι_range_disjoint_one :
     Disjoint (LinearMap.range (ι Q)) (1 : Submodule R (CliffordAlgebra Q)) := by
   rw [Submodule.disjoint_def]
@@ -207,7 +207,7 @@ theorem ιRangeEquiv_symm_apply (x : LinearMap.range (ι Q)) :
 /-! ### The first step of the degree filtration -/
 
 /-- The elements of degree at most one, as a map out of `R × M`: `(r, m) ↦ r + ι Q m`. It is
-injective with image `TauCeti.CliffordAlgebra.filtration Q 1`. -/
+injective with image `CliffordAlgebra.filtration Q 1`. -/
 def scalarAddVector : R × M →ₗ[R] CliffordAlgebra Q :=
   LinearMap.coprod (Algebra.linearMap R (CliffordAlgebra Q)) (ι Q)
 
@@ -223,7 +223,7 @@ theorem range_scalarAddVector : LinearMap.range (scalarAddVector Q) = filtration
   rw [scalarAddVector, LinearMap.range_coprod, ← Submodule.one_eq_range, ← filtration_one]
 
 /-- A scalar and a vector summing to zero both vanish, the scalars and the vectors being disjoint
-(`TauCeti.CliffordAlgebra.ι_range_disjoint_one`). -/
+(`CliffordAlgebra.ι_range_disjoint_one`). -/
 theorem scalarAddVector_injective : Function.Injective (scalarAddVector Q) := by
   have hd : Disjoint (LinearMap.range (Algebra.linearMap R (CliffordAlgebra Q)))
       (LinearMap.range (ι Q)) := by
@@ -234,8 +234,8 @@ theorem scalarAddVector_injective : Function.Injective (scalarAddVector Q) := by
     Submodule.prod_bot]
 
 /-- **The first step of the degree filtration is `R ⊕ M`.** The scalars and the vectors span it
-(`TauCeti.CliffordAlgebra.filtration_one`) and meet only in `0`
-(`TauCeti.CliffordAlgebra.ι_range_disjoint_one`), so together they parametrize it faithfully. -/
+(`CliffordAlgebra.filtration_one`) and meet only in `0`
+(`CliffordAlgebra.ι_range_disjoint_one`), so together they parametrize it faithfully. -/
 noncomputable def filtrationOneEquiv : (R × M) ≃ₗ[R] filtration Q 1 :=
   (LinearEquiv.ofInjective _ (scalarAddVector_injective Q)).trans
     (LinearEquiv.ofEq _ _ (range_scalarAddVector Q))
@@ -254,7 +254,7 @@ section Field
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
   (Q : QuadraticForm K V) [Invertible (2 : K)]
 
-/-- Counting dimensions in `TauCeti.CliffordAlgebra.filtrationOneEquiv`: the first step of the
+/-- Counting dimensions in `CliffordAlgebra.filtrationOneEquiv`: the first step of the
 degree filtration is one dimension bigger than the space of vectors. -/
 theorem finrank_filtration_one [FiniteDimensional K V] :
     Module.finrank K (filtration Q 1) = Module.finrank K V + 1 := by
@@ -264,5 +264,3 @@ theorem finrank_filtration_one [FiniteDimensional K V] :
 end Field
 
 end CliffordAlgebra
-
-end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/HalfSpin.lean
+++ b/TauCeti/RepresentationTheory/Spin/HalfSpin.lean
@@ -7,11 +7,11 @@ module
 
 public import Mathlib.RepresentationTheory.Subrepresentation
 public import TauCeti.RepresentationTheory.Spin.Representation
--- Private: `TauCeti.CliffordAlgebra.contractLeft_mem_evenOdd` is used only inside a proof, and
+-- Private: `CliffordAlgebra.contractLeft_mem_evenOdd` is used only inside a proof, and
 -- `CliffordAction` imports this module privately too, so it is not available transitively.
 import TauCeti.LinearAlgebra.CliffordAlgebra.Contraction
--- Private: `TauCeti.CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero` and
--- `TauCeti.CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one` are used only inside a proof.
+-- Private: `CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero` and
+-- `CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one` are used only inside a proof.
 import TauCeti.LinearAlgebra.CliffordAlgebra.Grading
 -- Private: `Subrepresentation.mem_toSubmodule`, `Subrepresentation.toSubmodule_bot` and
 -- `Subrepresentation.toSubmodule_top` are used only inside a proof.
@@ -47,7 +47,7 @@ The grading statement `TauCeti.spinAction_mem_evenOdd` is proved once, for an ar
 the acting Clifford element, and the half-spin invariance and the parity shift by odd elements are
 both read off it. Its two inputs are that exterior multiplication raises the exterior degree
 (Mathlib's `CliffordAlgebra.evenOdd_mul_le`) and that contraction lowers it
-(`TauCeti.CliffordAlgebra.contractLeft_mem_evenOdd`); the induction that propagates them from a
+(`CliffordAlgebra.contractLeft_mem_evenOdd`); the induction that propagates them from a
 single vector to a general Clifford element is Mathlib's `CliffordAlgebra.evenOdd_induction`.
 
 Nothing here needs a field, a nondegeneracy hypothesis, or a finite dimension: like
@@ -161,7 +161,7 @@ private theorem cliffordOperator_mem_evenOdd (hline : P.line = ⊥) (v : V) {j :
   · rw [P.wedge_apply, ← add_comm (1 : ZMod 2) j]
     exact SetLike.mul_mem_graded (ι_mem_evenOdd_one (0 : QuadraticForm K P.W) (x : P.W)) hs
   · rw [P.contract_apply]
-    exact TauCeti.CliffordAlgebra.contractLeft_mem_evenOdd _ hs
+    exact CliffordAlgebra.contractLeft_mem_evenOdd _ hs
 
 /-- **The Clifford action on the spinor module is graded** when the polarization has no line
 summand: a Clifford element of parity `i` shifts the exterior parity of a spinor by `i`. -/
@@ -175,9 +175,9 @@ theorem spinAction_mem_evenOdd (hline : P.line = ⊥) {i j : ZMod 2} {x : Cliffo
   | range_ι_pow v hv =>
     -- `i.val` is `0` or `1`, so `v` is a scalar or a vector.
     rcases (by decide : ∀ c : ZMod 2, c = 0 ∨ c = 1) i with rfl | rfl
-    · obtain ⟨r, rfl⟩ := TauCeti.CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero hv
+    · obtain ⟨r, rfl⟩ := CliffordAlgebra.exists_algebraMap_of_mem_range_ι_pow_zero hv
       simpa using Submodule.smul_mem _ r hs
-    · obtain ⟨a, rfl⟩ := TauCeti.CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one hv
+    · obtain ⟨a, rfl⟩ := CliffordAlgebra.exists_ι_of_mem_range_ι_pow_one hv
       rw [spinAction_ι, add_comm]
       exact cliffordOperator_mem_evenOdd P hline a hs
   | add x y hx hy ihx ihy => simpa only [map_add, LinearMap.add_apply] using add_mem ihx ihy

--- a/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/CliffordAction.lean
@@ -161,7 +161,7 @@ vanish — `ExteriorAlgebra.ι_sq_zero` for creation and
 it is the identity, by `CliffordAlgebra.involute_involute`, which is what makes the remainder
 coordinate contribute `Q z` rather than `0`. Parity anticommutes with each of the other two, by
 `CliffordAlgebra.involute_ι` through `map_mul` and by
-`TauCeti.CliffordAlgebra.involute_contractLeft`. The sixth term, the creation–annihilation
+`CliffordAlgebra.involute_contractLeft`. The sixth term, the creation–annihilation
 anticommutator, is the only one that sees the polarization and the only nonzero one among the
 three; it is recorded here. -/
 
@@ -211,7 +211,7 @@ theorem cliffordOperator_sq (v : V) :
     ← mul_assoc, ExteriorAlgebra.ι_sq_zero, zero_mul,
     CliffordAlgebra.contractLeft_ι_mul, CliffordAlgebra.contractLeft_contractLeft,
     map_mul, CliffordAlgebra.involute_ι, neg_mul,
-    TauCeti.CliffordAlgebra.involute_contractLeft,
+    CliffordAlgebra.involute_contractLeft,
     CliffordAlgebra.involute_involute, P.pairingEquiv_apply]
   module
 


### PR DESCRIPTION
This PR moves every declaration extending Mathlib's `CliffordAlgebra` from the recreated `TauCeti.CliffordAlgebra` namespace to the canonical root namespace. It updates downstream references, removes 13 enclosing `TauCeti` wrappers, restores the few wrapper-scoped opens still needed, and preserves the separate `TauCeti` real-signature API in `BottPeriodicity`.

The old lint baseline saw only 25 declarations in 11 files, but the complete environment audit found 327 exported `TauCeti.CliffordAlgebra.*` constants across 30 defining files. All 327 target names were checked against pinned Mathlib with no collisions. Locally verified with the full `lake build` (8,212 jobs), the dot-notation namespace lint (25 ratchetable entries removed, zero new findings), and direct root-namespace elaboration checks.

This is the `CliffordAlgebra` namespace-migration slice of #3547.

Roadmap: RepresentationTheory

:robot: Prepared with OpenAI Codex