### PR TITLE
chore: normalize copyright Authors lines (part 2/4)

### DIFF
--- a/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Quadratic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/IntermediateField/Rescale.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Rescale.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/RatFunc/Frobenius.lean
+++ b/TauCeti/FieldTheory/RatFunc/Frobenius.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/SeparableDegree.lean
+++ b/TauCeti/FieldTheory/SeparableDegree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/SquareClassGroup.lean
+++ b/TauCeti/FieldTheory/SquareClassGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/FieldTheory/Trace.lean
+++ b/TauCeti/FieldTheory/Trace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Diffeomorphism/Action.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Action.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Diffeomorphism/Congr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Congr.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
+++ b/TauCeti/Geometry/Diffeomorphism/FixingSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Diffeomorphism/Group.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Group.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
+++ b/TauCeti/Geometry/Diffeomorphism/RelativeCongr.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Diffeomorphism/Sphere.lean
+++ b/TauCeti/Geometry/Diffeomorphism/Sphere.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Derivative.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Derivative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Integral.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Units.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp/Units.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Exponential/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Exponential/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Exponential/Formula.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Exponential/Formula.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Infinitesimal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Representation/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Representation/Differential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Representation/Differential.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Units/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Units/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Adjoint/Units/Exponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Units/Exponential.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Basic.lean
+++ b/TauCeti/Geometry/Lie/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/Basic.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/Circle.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Circle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/Classification.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/Derivative/Basic.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Derivative/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/Derivative/Log.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Derivative/Log.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 public import TauCeti.Geometry.Lie.Exponential.Derivative.Basic

--- a/TauCeti/Geometry/Lie/Exponential/Matrix/Compatibility.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Matrix/Compatibility.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/OneParameter.lean
+++ b/TauCeti/Geometry/Lie/Exponential/OneParameter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/Trotter.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Trotter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 public import TauCeti.Analysis.Calculus.RescaledDerivative

--- a/TauCeti/Geometry/Lie/Exponential/Units/Basic.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Units/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Exponential/Units/Compatibility.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Units/Compatibility.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Interior.lean
+++ b/TauCeti/Geometry/Lie/Interior.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Basic.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField/Commutation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/RightInvariantVectorField.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/Boundary/Basic.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/Boundary/Charts.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Charts.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Basic.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/Boundary/Model.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Model.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
 module
 
 public import Mathlib.Geometry.Manifold.Instances.Real

--- a/TauCeti/Geometry/Manifold/ContMDiff/Prod.lean
+++ b/TauCeti/Geometry/Manifold/ContMDiff/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/LocallyFlat/Basic.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/LocallyFlat/Smooth.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat/Smooth.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/Basic.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Basic.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Naturality.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Naturality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Prod.lean
+++ b/TauCeti/Geometry/Manifold/SmoothEmbedding/ContinuousAmbientIsotopy/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Manifold/TwoForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Sphere/Circle.lean
+++ b/TauCeti/Geometry/Sphere/Circle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Sphere/LinearIsometry.lean
+++ b/TauCeti/Geometry/Sphere/LinearIsometry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/AlmostComplex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/CompatibleMetric.lean
+++ b/TauCeti/Geometry/Symplectic/CompatibleMetric.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Complex/Line.lean
+++ b/TauCeti/Geometry/Symplectic/Complex/Line.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Complex/Module/Basic.lean
+++ b/TauCeti/Geometry/Symplectic/Complex/Module/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Complex/Module/Hom.lean
+++ b/TauCeti/Geometry/Symplectic/Complex/Module/Hom.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Cotangent/Basic.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Cotangent/Compatible.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/Compatible.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/ExistsCompatible.lean
+++ b/TauCeti/Geometry/Symplectic/ExistsCompatible.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Finrank.lean
+++ b/TauCeti/Geometry/Symplectic/Finrank.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Hermitian.lean
+++ b/TauCeti/Geometry/Symplectic/Hermitian.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Basic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Congruence.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Congruence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Conj.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Conj.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Energy/Basic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Energy/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Energy/Integral.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Energy/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Line.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Line.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/MapOps.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/MapOps.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Neg.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Neg.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Prod/Basic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Prod/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Prod/Map.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Prod/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Square.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Square.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Transport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Varying.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Varying.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Lagrangian/Basic.lean
+++ b/TauCeti/Geometry/Symplectic/Lagrangian/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Lagrangian/Constructions.lean
+++ b/TauCeti/Geometry/Symplectic/Lagrangian/Constructions.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Lagrangian/TotallyReal.lean
+++ b/TauCeti/Geometry/Symplectic/Lagrangian/TotallyReal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/AlmostComplex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Manifold/Energy.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/Energy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Manifold/JHolomorphic.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/JHolomorphic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
+++ b/TauCeti/Geometry/Symplectic/Manifold/TwoForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Prod/Basic.lean
+++ b/TauCeti/Geometry/Symplectic/Prod/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Prod/Metric.lean
+++ b/TauCeti/Geometry/Symplectic/Prod/Metric.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Rescale.lean
+++ b/TauCeti/Geometry/Symplectic/Rescale.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Restrict.lean
+++ b/TauCeti/Geometry/Symplectic/Restrict.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/StandardCompatible.lean
+++ b/TauCeti/Geometry/Symplectic/StandardCompatible.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
+++ b/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/TameMetric.lean
+++ b/TauCeti/Geometry/Symplectic/TameMetric.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/TotallyReal.lean
+++ b/TauCeti/Geometry/Symplectic/TotallyReal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/DerivedCentralQuotient.lean
+++ b/TauCeti/GroupTheory/DerivedCentralQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/DoubleCoset/Finite.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Finite.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/DoubleCoset/Identity.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Identity.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Orbits.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/Elementary.lean
+++ b/TauCeti/GroupTheory/Elementary.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/Finiteness.lean
+++ b/TauCeti/GroupTheory/Finiteness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/FixedPointCandidate.lean
+++ b/TauCeti/GroupTheory/FixedPointCandidate.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/FixedSubgroup.lean
+++ b/TauCeti/GroupTheory/FixedSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/GroupAction/Burnside.lean
+++ b/TauCeti/GroupTheory/GroupAction/Burnside.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/GroupExtension/Basic.lean
+++ b/TauCeti/GroupTheory/GroupExtension/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/GroupExtension/Cohomology.lean
+++ b/TauCeti/GroupTheory/GroupExtension/Cohomology.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/GroupExtension/FactorSetOfSection.lean
+++ b/TauCeti/GroupTheory/GroupExtension/FactorSetOfSection.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/GroupExtension/Of/FactorSet.lean
+++ b/TauCeti/GroupTheory/GroupExtension/Of/FactorSet.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/GroupExtension/Of/Surjective.lean
+++ b/TauCeti/GroupTheory/GroupExtension/Of/Surjective.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/Perm/CyclePower.lean
+++ b/TauCeti/GroupTheory/Perm/CyclePower.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/Perm/FiberSubgroup.lean
+++ b/TauCeti/GroupTheory/Perm/FiberSubgroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/Presentation/Coxeter.lean
+++ b/TauCeti/GroupTheory/Presentation/Coxeter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
+++ b/TauCeti/GroupTheory/Presentation/GroupPresentation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/Presentation/Relator.lean
+++ b/TauCeti/GroupTheory/Presentation/Relator.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/QuotientGroup/Basic.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/QuotientGroup/KerEquiv.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/KerEquiv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Closure.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Closure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/GraphTwisted.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/BabyMonster.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/BabyMonster.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/One.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/One.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Three.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Three.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Two.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Conway/Two.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyFour.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyThree.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyThree.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyTwo.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Fischer/TwentyTwo.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HaradaNorton.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HaradaNorton.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Held.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HigmanSims.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/HigmanSims.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Four.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Four.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/One.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/One.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Three.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Three.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Two.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Janko/Two.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Lyons.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Lyons.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyFour.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyFour.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyThree.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Mathieu/TwentyThree.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/McLaughlin.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/McLaughlin.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Monster.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Monster.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/ONan.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/ONan.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Presentation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Rudvalis.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Rudvalis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Suzuki.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Suzuki.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Thompson.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Sporadic/Thompson.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/SuzukiRee.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/Dihedral.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/GroupTheory/TrivialIntersection.lean
+++ b/TauCeti/GroupTheory/TrivialIntersection.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/BasicCycles.lean
+++ b/TauCeti/KnotTheory/Grid/BasicCycles.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/BlockedRectangle.lean
+++ b/TauCeti/KnotTheory/Grid/BlockedRectangle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/ChainCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/ChainCardinality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Commutation/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Commutation/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation/Components.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Commutation/Move.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation/Move.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Commutation/Relabeling.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation/Relabeling.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Commutation/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation/Rotation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Complex.lean
+++ b/TauCeti/KnotTheory/Grid/Complex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/CycleSymmetry.lean
+++ b/TauCeti/KnotTheory/Grid/CycleSymmetry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Cycles.lean
+++ b/TauCeti/KnotTheory/Grid/Cycles.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Diagram/Relabeling.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Relabeling.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Backtracking.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Backtracking.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Coefficient.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Coefficient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Intermediates.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Support.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Support.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Differential/Support/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Support/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Differential/Support/Cardinality.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Support/Cardinality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Differential/Symmetry.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Symmetry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Grading/Change.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Change.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Grading/Integer.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Integer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/Gradings.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Homology.lean
+++ b/TauCeti/KnotTheory/Grid/Homology.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/JFunction/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/JFunction/Count.lean
+++ b/TauCeti/KnotTheory/Grid/JFunction/Count.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Move.lean
+++ b/TauCeti/KnotTheory/Grid/Move.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Count.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Count.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Swap.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Swap.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Rotation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/SmallGrid/Differential.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGrid/Differential.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/SmallGrid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGrid/Gradings.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/SmallGrid/Homology.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGrid/Homology.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Stabilization/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Stabilization/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/StateCardinality.lean
+++ b/TauCeti/KnotTheory/Grid/StateCardinality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/TorusLink.lean
+++ b/TauCeti/KnotTheory/Grid/TorusLink.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/KnotTheory/Grid/Unknot.lean
+++ b/TauCeti/KnotTheory/Grid/Unknot.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/DehnSurgery/Slope.lean
+++ b/TauCeti/LowDimTopology/DehnSurgery/Slope.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/BlowUp.lean
+++ b/TauCeti/LowDimTopology/Plumbing/BlowUp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Bounded.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Bounded.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/ChainComplex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/ChainComplex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Characteristic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Conjugation.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Conjugation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Cardinality.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Cardinality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Face/Basic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Face/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Face/Exponent.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Face/Exponent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Sublevel.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Sublevel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/VertexWeight.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/VertexWeight.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Weight/Basic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Weight/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Weight/Recursion.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Weight/Recursion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/DiagonalDominance.lean
+++ b/TauCeti/LowDimTopology/Plumbing/DiagonalDominance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Differential.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Differential.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/E8.lean
+++ b/TauCeti/LowDimTopology/Plumbing/E8.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/EdgeBlowUp.lean
+++ b/TauCeti/LowDimTopology/Plumbing/EdgeBlowUp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Filtration/Basic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Filtration/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Filtration/Colimit.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Filtration/Colimit.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Grading.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Grading.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean
+++ b/TauCeti/LowDimTopology/Plumbing/IntersectionForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/NegativeDefinite.lean
+++ b/TauCeti/LowDimTopology/Plumbing/NegativeDefinite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Weight/Basic.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Weight/BlowUp.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight/BlowUp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Weight/Polarization.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight/Polarization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Weight/Sublevel.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight/Sublevel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/LowDimTopology/Plumbing/Weight/Translation.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight/Translation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean
+++ b/TauCeti/MeasureTheory/Function/AEStronglyMeasurable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/BoundedMemLp.lean
+++ b/TauCeti/MeasureTheory/Function/BoundedMemLp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
+++ b/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
+++ b/TauCeti/MeasureTheory/Function/ConditionalExpectation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/L2ToL1Convergence.lean
+++ b/TauCeti/MeasureTheory/Function/L2ToL1Convergence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/Lp/BilinearForm.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/BilinearForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/Lp/CastMeasure.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/CastMeasure.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/Lp/CompMeasurePreservingEquiv.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/CompMeasurePreservingEquiv.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Cadence
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/Lp/Dilation.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/Dilation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/PolynomialMemLp.lean
+++ b/TauCeti/MeasureTheory/Function/PolynomialMemLp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/ProductL1Convergence.lean
+++ b/TauCeti/MeasureTheory/Function/ProductL1Convergence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Function/WeightL2Isometry.lean
+++ b/TauCeti/MeasureTheory/Function/WeightL2Isometry.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Group/Conjugation.lean
+++ b/TauCeti/MeasureTheory/Group/Conjugation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 


### PR DESCRIPTION
This PR normalizes copyright blocks and `Authors:` lines in the second of four disjoint source batches required before enabling the header linter in CI.

Roadmap: none

:robot: Prepared with OpenAI Codex