### PR TITLE
chore: normalize copyright Authors lines (part 3/4)

### DIFF
--- a/TauCeti/MeasureTheory/Group/CountableAction.lean
+++ b/TauCeti/MeasureTheory/Group/CountableAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Group/FundamentalDomain.lean
+++ b/TauCeti/MeasureTheory/Group/FundamentalDomain.lean
@@ -2,12 +2,6 @@
 Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Birkbeck
-
-## References
-
-* The AINTLIB `LeanModularForms` project,
-  <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>
-  (`Modularforms/PeterssonLevelN.lean`)
 -/
 module
 
@@ -37,9 +31,9 @@ union.
   `g₂ • D` of an `H`-fundamental domain are a.e. disjoint whenever `g₁ ≠ g₂` and
   `g₁⁻¹ * g₂ ∈ H` (needing only quasi-measure-preservation of the one translation).
 
-Ported from the AINTLIB `LeanModularForms` project
-(`LeanModularForms/Modularforms/PeterssonLevelN.lean`, measure-theory section), as a
-prerequisite for fundamental domains of congruence subgroups.
+Ported from the [AINTLIB `LeanModularForms` project](https://github.com/CBirkbeck/AINTLIB),
+`LeanModularForms/Modularforms/PeterssonLevelN.lean` (measure-theory section), as a prerequisite
+for fundamental domains of congruence subgroups.
 -/
 
 public section

--- a/TauCeti/MeasureTheory/Group/FundamentalDomain.lean
+++ b/TauCeti/MeasureTheory/Group/FundamentalDomain.lean
@@ -31,9 +31,10 @@ union.
   `g₂ • D` of an `H`-fundamental domain are a.e. disjoint whenever `g₁ ≠ g₂` and
   `g₁⁻¹ * g₂ ∈ H` (needing only quasi-measure-preservation of the one translation).
 
-Ported from the [AINTLIB `LeanModularForms` project](https://github.com/CBirkbeck/AINTLIB),
-`LeanModularForms/Modularforms/PeterssonLevelN.lean` (measure-theory section), as a prerequisite
-for fundamental domains of congruence subgroups.
+Ported from the
+[AINTLIB `LeanModularForms` project](https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms),
+`projects/LeanModularForms/Modularforms/PeterssonLevelN.lean` (measure-theory section), as a
+prerequisite for fundamental domains of congruence subgroups.
 -/
 
 public section

--- a/TauCeti/MeasureTheory/Group/Inversion.lean
+++ b/TauCeti/MeasureTheory/Group/Inversion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/Dilation.lean
+++ b/TauCeti/MeasureTheory/Integral/Dilation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/ENNRealProd.lean
+++ b/TauCeti/MeasureTheory/Integral/ENNRealProd.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/ExpDecay.lean
+++ b/TauCeti/MeasureTheory/Integral/ExpDecay.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/OddSymmetric.lean
+++ b/TauCeti/MeasureTheory/Integral/OddSymmetric.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/Pi.lean
+++ b/TauCeti/MeasureTheory/Integral/Pi.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/PiSystem.lean
+++ b/TauCeti/MeasureTheory/Integral/PiSystem.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Integral/Prod.lean
+++ b/TauCeti/MeasureTheory/Integral/Prod.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/TauCeti/MeasureTheory/Measure/FiniteMeasure.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/GiryMonad.lean
+++ b/TauCeti/MeasureTheory/Measure/GiryMonad.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/LowerSemicontinuousLintegral.lean
+++ b/TauCeti/MeasureTheory/Measure/LowerSemicontinuousLintegral.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/MixtureInjective.lean
+++ b/TauCeti/MeasureTheory/Measure/MixtureInjective.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/PiWithDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/PiWithDensity.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/Prokhorov.lean
+++ b/TauCeti/MeasureTheory/Measure/Prokhorov.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/Measure/ZeroOne.lean
+++ b/TauCeti/MeasureTheory/Measure/ZeroOne.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/OptimalTransport/Chain.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Chain.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Tau Ceti Project. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/OptimalTransport/Chain.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Chain.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Tau Ceti Project. All rights reserved.
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: The Tau Ceti contributors
 -/

--- a/TauCeti/MeasureTheory/OptimalTransport/Finite/TransportMatrix.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Finite/TransportMatrix.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/OptimalTransport/Gluing.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Gluing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Replacement.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/MultiMarginal/Replacement.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ArithmeticFunction/TwistedDivisorSum.lean
+++ b/TauCeti/NumberTheory/ArithmeticFunction/TwistedDivisorSum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ClassGroup/Equiv.lean
+++ b/TauCeti/NumberTheory/ClassGroup/Equiv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/DedekindDomain/RamificationInertia.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/RamificationInertia.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/DedekindDomain/RelNorm.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/RelNorm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/ClassNumber/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/ClassNumber/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/Discriminant/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/Discriminant/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/HermiteCount/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/HermiteCount/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/IdealCount/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/IdealCount/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/Regulator.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/Regulator.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/SimpleGenerators.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/SimpleGenerators.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/TraceForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/UnitSquares/Basic.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/UnitSquares/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EffectiveBounds/WorkedExamples.lean
+++ b/TauCeti/NumberTheory/EffectiveBounds/WorkedExamples.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Descent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Elementary.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Ext.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Ext.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant/Basic.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Invariant/NormEDS.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Recurrence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/SignEquivariance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Six.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Six.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Transfer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Universal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/GeometryOfNumbers/Doubling.lean
+++ b/TauCeti/NumberTheory/GeometryOfNumbers/Doubling.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/GeometryOfNumbers/RankTwoDoubling.lean
+++ b/TauCeti/NumberTheory/GeometryOfNumbers/RankTwoDoubling.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/LegendreSymbol/Frobenius.lean
+++ b/TauCeti/NumberTheory/LegendreSymbol/Frobenius.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/LegendreSymbol/SquareClass.lean
+++ b/TauCeti/NumberTheory/LegendreSymbol/SquareClass.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Modular/Orbits.lean
+++ b/TauCeti/NumberTheory/Modular/Orbits.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/BoundedAtCusp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Cusps/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Cusps/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Cusps/Rat/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Cusps/Rat/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/GaloisProd.lean
+++ b/TauCeti/NumberTheory/ModularForms/GaloisProd.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Infty.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Infty.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Assembly.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Assembly.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/BoundaryPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/BoundaryPairing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Bridge.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Bridge.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Corner.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Ceiling/Corner.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CuspCircle.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CuspCircle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/DerivBound.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/DerivBound.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisionSeparation.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ExcisionSeparation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/LogDerivPV.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/LogDerivPV.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/OnCurveCapture.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/OnCurveCapture.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/PieceLog.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/PieceLog.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/SingularSets.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/SingularSets.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Arc.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Vertical.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/NonCorner/Vertical.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Geometry.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Geometry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/AddOne/Value.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Geometry.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Geometry.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding/Rho/Value.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ZeroBox.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ZeroBox.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Norm/Trace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OfVanishing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Order/OrbitReduction.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/OrbitReduction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Parity.lean
+++ b/TauCeti/NumberTheory/ModularForms/Parity.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 TauCeti contributors. All rights reserved.
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: The Tau Ceti contributors
 -/

--- a/TauCeti/NumberTheory/ModularForms/Parity.lean
+++ b/TauCeti/NumberTheory/ModularForms/Parity.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 TauCeti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Orthogonal.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Orthogonal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Unitary.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/Order.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/STransform.lean
+++ b/TauCeti/NumberTheory/ModularForms/STransform.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/SturmBound.lean
+++ b/TauCeti/NumberTheory/ModularForms/SturmBound.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/TrivialNebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/TrivialNebentypus.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 TauCeti contributors. All rights reserved.
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: The Tau Ceti contributors
 -/

--- a/TauCeti/NumberTheory/ModularForms/TrivialNebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/TrivialNebentypus.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 TauCeti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/ModularForms/WithCenter.lean
+++ b/TauCeti/NumberTheory/ModularForms/WithCenter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CMField/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CMField/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CMField/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CMField/GaloisGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Discriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Discriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/GaloisGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/GaloisGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Quadratic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Quadratic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Ramification.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/Ramification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CoprimeSquarefree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Frobenius.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Frobenius.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Examples.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Examples.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Factorization.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Factorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/OfSquarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/OfSquarefree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Galois/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Galois/Exponent.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois/Exponent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Galois/Group.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois/Group.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Galois/Relative.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois/Relative.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/GenusField.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GenusField.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Legendre/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Legendre/EvenPrimeDiscriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminant/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminant/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminant/Examples.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminant/Examples.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminants.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/RelativeDegree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/RelativeDegree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Examples.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Examples.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/RelativeDegree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/RelativeDegree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Examples/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Examples/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Examples/Lists.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Examples/Lists.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Field.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Field.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/GaloisGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Independence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Independence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/RelativeDegree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/RelativeDegree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Splitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Splitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/SubfieldLattice.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/SubfieldLattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/GaloisGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/RadicandSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/RadicandSplitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Radicands.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Radicands.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Subfield/Count.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Subfield/Count.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Subfield/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Subfield/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Subfield/Lattice.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Subfield/Lattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/Discriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/Discriminant.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/Ramification.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/Ramification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/Subfield.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/Subfield.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/RelativeDegree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/RelativeDegree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass/Independence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass/Independence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass/Rational.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass/Rational.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Classification.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Classification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Count.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Count.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Degree.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Lattice.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Lattice.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/ClassGroupElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/NumberField/ClassGroupElementaryTwoQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Discriminant/OfIntegralBasis.lean
+++ b/TauCeti/NumberTheory/NumberField/Discriminant/OfIntegralBasis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Frobenius.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/NumberField/InfinitePlace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/IntegralSqrt.lean
+++ b/TauCeti/NumberTheory/NumberField/IntegralSqrt.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Internal/PrimeDivisibility.lean
+++ b/TauCeti/NumberTheory/NumberField/Internal/PrimeDivisibility.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Internal/QuadraticIntegralBasis.lean
+++ b/TauCeti/NumberTheory/NumberField/Internal/QuadraticIntegralBasis.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup/ElementaryTwoQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup/Finite.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup/Finite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup/TotallyComplex.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup/TotallyComplex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/ClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/ClassGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/InfinitePlace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/TotalRamification.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/TotalRamification.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/SignApproximation.lean
+++ b/TauCeti/NumberTheory/NumberField/SignApproximation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/SplitsCompletely.lean
+++ b/TauCeti/NumberTheory/NumberField/SplitsCompletely.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Units/Dirichlet.lean
+++ b/TauCeti/NumberTheory/NumberField/Units/Dirichlet.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Units/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/NumberField/Units/ElementaryTwoQuotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Units/Signature/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Units/Signature/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/NumberField/Units/Signature/Surjective.lean
+++ b/TauCeti/NumberTheory/NumberField/Units/Signature/Surjective.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/RamificationInertia/Galois.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/Galois.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/NumberTheory/RamificationInertia/Splitting.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/Splitting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
+++ b/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti.lean
+++ b/TauCeti/Probability/DeFinetti.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/CommonEnding.lean
+++ b/TauCeti/Probability/DeFinetti/CommonEnding.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/CondExpConvergence.lean
+++ b/TauCeti/Probability/DeFinetti/CondExpConvergence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ConditionalCommonEnding.lean
+++ b/TauCeti/Probability/DeFinetti/ConditionalCommonEnding.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/Correspondence.lean
+++ b/TauCeti/Probability/DeFinetti/Correspondence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/CountableIndex.lean
+++ b/TauCeti/Probability/DeFinetti/CountableIndex.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Basic.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/BlockCylinder.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Coord.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Coord.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/EmpiricalMeasure.lean
+++ b/TauCeti/Probability/DeFinetti/EmpiricalMeasure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/FutureFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/FutureFactorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/Mixture.lean
+++ b/TauCeti/Probability/DeFinetti/Mixture.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/PrefixDeletion.lean
+++ b/TauCeti/Probability/DeFinetti/PrefixDeletion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/Representation.lean
+++ b/TauCeti/Probability/DeFinetti/Representation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/TailFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/TailFactorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/Theorem.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/BlockFactorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/CylinderMass.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/CylinderMass.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/Decoupling.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/InvariantConditionalLaw.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/InvariantConditionalLaw.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaKoopman/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/Theorem.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaL2/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/BlockFactorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaL2/ConditionallyIID.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/ConditionallyIID.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaL2/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/Theorem.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/DeFinetti/ViaL2/WindowProduct.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/WindowProduct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Distributions/Gaussian/Basic.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Basis.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Basis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/MemLp.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/MemLp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Parseval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Basis.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Basis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Pi/Parseval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Distributions/Gaussian/Pi.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Pi.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Distributions/Gaussian/PolynomialMemLp.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/PolynomialMemLp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 


### PR DESCRIPTION
This PR normalizes copyright blocks and `Authors:` lines in the third of four disjoint source batches required before enabling the header linter in CI.

Roadmap: none

:robot: Prepared with OpenAI Codex