### PR TITLE
chore: normalize copyright Authors lines (part 4/4)

### DIFF
--- a/TauCeti/Probability/Ergodic/BirkhoffLp.lean
+++ b/TauCeti/Probability/Ergodic/BirkhoffLp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Ergodic/InvariantSigma.lean
+++ b/TauCeti/Probability/Ergodic/InvariantSigma.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Adapted from Cameron Freer's `cameronfreer/exchangeability`.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
+++ b/TauCeti/Probability/Ergodic/KoopmanMarkov.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Ergodic/MeanErgodic.lean
+++ b/TauCeti/Probability/Ergodic/MeanErgodic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability.lean
+++ b/TauCeti/Probability/Exchangeability.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/AdjacentTranspositions.lean
+++ b/TauCeti/Probability/Exchangeability/AdjacentTranspositions.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/CondExp.lean
+++ b/TauCeti/Probability/Exchangeability/CondExp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/CoinFlips.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/CoinFlips.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Const.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Const.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/EmpiricalMeasure.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/EmpiricalMeasure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Implications.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Implications.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Map.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Map.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Moments.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Moments.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/PathDisintegration.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/PathDisintegration.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/StrongLaw.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/StrongLaw.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/Cylinder.lean
+++ b/TauCeti/Probability/Exchangeability/Cylinder.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
+++ b/TauCeti/Probability/Exchangeability/ExchangeableAtMonotone.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteMarginals.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/FullyExchangeable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/IID.lean
+++ b/TauCeti/Probability/Exchangeability/IID.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/JointPathLaw.lean
+++ b/TauCeti/Probability/Exchangeability/JointPathLaw.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/L2/BlockAverages.lean
+++ b/TauCeti/Probability/Exchangeability/L2/BlockAverages.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
+++ b/TauCeti/Probability/Exchangeability/L2/BoundedObservable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/L2/Cesaro/Convergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Cesaro/Convergence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/L2/Cesaro/ToCondExp.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Cesaro/ToCondExp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/L2/Covariance.lean
+++ b/TauCeti/Probability/Exchangeability/L2/Covariance.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/L2/LongTailAverages.lean
+++ b/TauCeti/Probability/Exchangeability/L2/LongTailAverages.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/L2/TailMeasurability.lean
+++ b/TauCeti/Probability/Exchangeability/L2/TailMeasurability.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/Map.lean
+++ b/TauCeti/Probability/Exchangeability/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/MixedIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/MixedIID/Const.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Const.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/MixedIID/Implications.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Implications.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/MixedIID/Map.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ContractableLaw.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/Ergodic.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/Ergodic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/Sigma.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/Sigma.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/TailStrict.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/TailStrict.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/ToContractable.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Exchangeable/ToContractable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Invariant/BlockTransport.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Invariant/BlockTransport.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Invariant/Tail.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Invariant/Tail.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Bridge.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Bridge.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/ZeroOne.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/ZeroOne.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/ProcessShift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Shift.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Shift.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/PermutationExtension.lean
+++ b/TauCeti/Probability/Exchangeability/PermutationExtension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/SamplingWithoutReplacement.lean
+++ b/TauCeti/Probability/Exchangeability/SamplingWithoutReplacement.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/Stationary.lean
+++ b/TauCeti/Probability/Exchangeability/Stationary.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ThreeCycle.lean
+++ b/TauCeti/Probability/Exchangeability/ThreeCycle.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Kernel/Composition/MeasureCompProd.lean
+++ b/TauCeti/Probability/Kernel/Composition/MeasureCompProd.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Kernel/ProbabilityMeasure.lean
+++ b/TauCeti/Probability/Kernel/ProbabilityMeasure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Martingale/AntitoneLimit.lean
+++ b/TauCeti/Probability/Martingale/AntitoneLimit.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Martingale/Convergence.lean
+++ b/TauCeti/Probability/Martingale/Convergence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Martingale/Crossings/Bounds.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Bounds.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Martingale/Crossings/Pathwise.lean
+++ b/TauCeti/Probability/Martingale/Crossings/Pathwise.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
+++ b/TauCeti/Probability/Martingale/Crossings/TimeReversal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
+++ b/TauCeti/Probability/Martingale/LevyDownwardEventuallyConst.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Martingale/Reverse.lean
+++ b/TauCeti/Probability/Martingale/Reverse.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Moments/CompactDeterminacy.lean
+++ b/TauCeti/Probability/Moments/CompactDeterminacy.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Moments/Determinacy.lean
+++ b/TauCeti/Probability/Moments/Determinacy.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Moments/LaplaceDeterminacy.lean
+++ b/TauCeti/Probability/Moments/LaplaceDeterminacy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Moments/VanishingMoments.lean
+++ b/TauCeti/Probability/Moments/VanishingMoments.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Process/BlockAverage.lean
+++ b/TauCeti/Probability/Process/BlockAverage.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Process/DisjointWindow.lean
+++ b/TauCeti/Probability/Process/DisjointWindow.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Process/EmpiricalMeasure.lean
+++ b/TauCeti/Probability/Process/EmpiricalMeasure.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Process/Tail/Basic.lean
+++ b/TauCeti/Probability/Process/Tail/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Process/Tail/ReverseFiltration.lean
+++ b/TauCeti/Probability/Process/Tail/ReverseFiltration.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/StrongLaw.lean
+++ b/TauCeti/Probability/StrongLaw.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/UniformSampling.lean
+++ b/TauCeti/Probability/UniformSampling.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Adjoin/Unit.lean
+++ b/TauCeti/RingTheory/Adjoin/Unit.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/AdjoinRoot.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Binomial.lean
+++ b/TauCeti/RingTheory/Binomial.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/CentralIdempotent.lean
+++ b/TauCeti/RingTheory/CentralIdempotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/ClassGroup/Basic.lean
+++ b/TauCeti/RingTheory/ClassGroup/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/ClassGroup/HeightOneSpectrum.lean
+++ b/TauCeti/RingTheory/ClassGroup/HeightOneSpectrum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/ClassGroup/RelNorm.lean
+++ b/TauCeti/RingTheory/ClassGroup/RelNorm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Cyclotomic/Basic.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Cyclotomic/Lift.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Lift.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/Factorization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Factorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
+++ b/TauCeti/RingTheory/DedekindDomain/RamificationLocus.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/SInteger/Basic.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SInteger/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/SInteger/ClassGroup.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SInteger/ClassGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/SInteger/Factorization.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SInteger/Factorization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/SInteger/Spectrum.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SInteger/Spectrum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/SInteger/Unit.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SInteger/Unit.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DedekindDomain/SelmerGroup.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SelmerGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Derivation/DualNumber.lean
+++ b/TauCeti/RingTheory/Derivation/DualNumber.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DividedPowers/Associative.lean
+++ b/TauCeti/RingTheory/DividedPowers/Associative.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DividedPowers/Basis.lean
+++ b/TauCeti/RingTheory/DividedPowers/Basis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DividedPowers/Commutation.lean
+++ b/TauCeti/RingTheory/DividedPowers/Commutation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
+++ b/TauCeti/RingTheory/DividedPowers/NormalOrdering.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex, Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/DividedPowers/RootString/Basic.lean
+++ b/TauCeti/RingTheory/DividedPowers/RootString/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/FiniteType/PointSeparation.lean
+++ b/TauCeti/RingTheory/FiniteType/PointSeparation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/HahnSeries/Inverse.lean
+++ b/TauCeti/RingTheory/HahnSeries/Inverse.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/Bounded.lean
+++ b/TauCeti/RingTheory/Huber/Bounded.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/Completion.lean
+++ b/TauCeti/RingTheory/Huber/Completion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/LaurentSeries.lean
+++ b/TauCeti/RingTheory/Huber/LaurentSeries.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Completion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Plus.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Plus.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/UniversalProperty.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/UniversalProperty.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/OpenIdeal.lean
+++ b/TauCeti/RingTheory/Huber/OpenIdeal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/OpenMapping.lean
+++ b/TauCeti/RingTheory/Huber/OpenMapping.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/Padic/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/Padic/Field.lean
+++ b/TauCeti/RingTheory/Huber/Padic/Field.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/Pair.lean
+++ b/TauCeti/RingTheory/Huber/Pair.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/PowerBounded.lean
+++ b/TauCeti/RingTheory/Huber/PowerBounded.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/Restricted/BaseChange.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/RingOfDefinition.lean
+++ b/TauCeti/RingTheory/Huber/RingOfDefinition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Completion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Continuous.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Hom.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Hom.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Map.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/Mul.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedEval/UniversalProperty.lean
+++ b/TauCeti/RingTheory/Huber/WeightedEval/UniversalProperty.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
+++ b/TauCeti/RingTheory/Huber/ZeroSequenceOfUnits.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Ideal/Cotangent/Basic.lean
+++ b/TauCeti/RingTheory/Ideal/Cotangent/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Ideal/Cotangent/Localization.lean
+++ b/TauCeti/RingTheory/Ideal/Cotangent/Localization.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Ideal/LiesOver.lean
+++ b/TauCeti/RingTheory/Ideal/LiesOver.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Idempotents/Connected/Component.lean
+++ b/TauCeti/RingTheory/Idempotents/Connected/Component.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Idempotents/Connected/Spectrum.lean
+++ b/TauCeti/RingTheory/Idempotents/Connected/Spectrum.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Idempotents/LinearIndependent.lean
+++ b/TauCeti/RingTheory/Idempotents/LinearIndependent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Idempotents/Module.lean
+++ b/TauCeti/RingTheory/Idempotents/Module.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Jacobson/FiniteDimensional.lean
+++ b/TauCeti/RingTheory/Jacobson/FiniteDimensional.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Jacobson/Module.lean
+++ b/TauCeti/RingTheory/Jacobson/Module.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Jacobson/MulOpposite.lean
+++ b/TauCeti/RingTheory/Jacobson/MulOpposite.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Kaehler/MapSemilinear.lean
+++ b/TauCeti/RingTheory/Kaehler/MapSemilinear.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/KrullSchmidt/Existence.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Existence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/KrullSchmidt/Indecomposable.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Indecomposable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/KrullSchmidt/Uniqueness.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Uniqueness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/LocalRing/Basic.lean
+++ b/TauCeti/RingTheory/LocalRing/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Localization/Completion.lean
+++ b/TauCeti/RingTheory/Localization/Completion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Localization/DenIdeal.lean
+++ b/TauCeti/RingTheory/Localization/DenIdeal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/MvPolynomial/Symmetric/Complete.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Symmetric/Complete.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Basic.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Branching.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Branching.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Complete.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Complete.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Elementary.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Elementary.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
+++ b/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Nilpotent/Exp.lean
+++ b/TauCeti/RingTheory/Nilpotent/Exp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Nilpotent/RootString/Basic.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/Basic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Norm/Quadratic.lean
+++ b/TauCeti/RingTheory/Norm/Quadratic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Polynomial/BinomialBasis.lean
+++ b/TauCeti/RingTheory/Polynomial/BinomialBasis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
+++ b/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Polynomial/Cyclotomic/Computable.lean
+++ b/TauCeti/RingTheory/Polynomial/Cyclotomic/Computable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Polynomial/Hermite/Real.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Real.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Polynomial/Pochhammer.lean
+++ b/TauCeti/RingTheory/Polynomial/Pochhammer.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Codex
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
+++ b/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/PowerSeries/Order.lean
+++ b/TauCeti/RingTheory/PowerSeries/Order.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/PrimitiveIdempotent.lean
+++ b/TauCeti/RingTheory/PrimitiveIdempotent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/BasicAlgebra.lean
+++ b/TauCeti/RingTheory/Semisimple/BasicAlgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/BlockCount.lean
+++ b/TauCeti/RingTheory/Semisimple/BlockCount.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/CenterDimension.lean
+++ b/TauCeti/RingTheory/Semisimple/CenterDimension.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/CentralCharacter.lean
+++ b/TauCeti/RingTheory/Semisimple/CentralCharacter.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/DimensionCount.lean
+++ b/TauCeti/RingTheory/Semisimple/DimensionCount.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean
+++ b/TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/EndAlgebra.lean
+++ b/TauCeti/RingTheory/Semisimple/EndAlgebra.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/IsotypicEnd.lean
+++ b/TauCeti/RingTheory/Semisimple/IsotypicEnd.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/MatrixDivisionRing.lean
+++ b/TauCeti/RingTheory/Semisimple/MatrixDivisionRing.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/Multiplicity.lean
+++ b/TauCeti/RingTheory/Semisimple/Multiplicity.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/NilpotentIdeal.lean
+++ b/TauCeti/RingTheory/Semisimple/NilpotentIdeal.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/RegularIsotypicComponent.lean
+++ b/TauCeti/RingTheory/Semisimple/RegularIsotypicComponent.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/Schur.lean
+++ b/TauCeti/RingTheory/Semisimple/Schur.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/SimpleArtinian.lean
+++ b/TauCeti/RingTheory/Semisimple/SimpleArtinian.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/Wedderburn/Blocks.lean
+++ b/TauCeti/RingTheory/Semisimple/Wedderburn/Blocks.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/Wedderburn/Presentation.lean
+++ b/TauCeti/RingTheory/Semisimple/Wedderburn/Presentation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Semisimple/Wedderburn/Uniqueness.lean
+++ b/TauCeti/RingTheory/Semisimple/Wedderburn/Uniqueness.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/SimpleModule/Basic.lean
+++ b/TauCeti/RingTheory/SimpleModule/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/ZMod/Torsion.lean
+++ b/TauCeti/RingTheory/ZMod/Torsion.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/ConstMulAction.lean
+++ b/TauCeti/Topology/Algebra/ConstMulAction.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/Group/Pointwise.lean
+++ b/TauCeti/Topology/Algebra/Group/Pointwise.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/Homeomorph/Action.lean
+++ b/TauCeti/Topology/Algebra/Homeomorph/Action.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/Homeomorph/Congr.lean
+++ b/TauCeti/Topology/Algebra/Homeomorph/Congr.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/Module/BilinearForm.lean
+++ b/TauCeti/Topology/Algebra/Module/BilinearForm.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Absorption.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Absorption.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Completion.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Completion.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/Nonarchimedean/FirstCountable.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/FirstCountable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/OpenMapping/Basic.lean
+++ b/TauCeti/Topology/Algebra/OpenMapping/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/OpenMapping/Complete.lean
+++ b/TauCeti/Topology/Algebra/OpenMapping/Complete.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/OpenMapping/Henkel.lean
+++ b/TauCeti/Topology/Algebra/OpenMapping/Henkel.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/OpenMapping/Sequence.lean
+++ b/TauCeti/Topology/Algebra/OpenMapping/Sequence.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/UnitaryGroup.lean
+++ b/TauCeti/Topology/Algebra/UnitaryGroup.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
+++ b/TauCeti/Topology/Algebra/ZeroSequenceOfUnits.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/ConnectedComponents.lean
+++ b/TauCeti/Topology/ConnectedComponents.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Covering/Category.lean
+++ b/TauCeti/Topology/Covering/Category.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Covering/Monodromy/Basic.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Covering/Monodromy/Connected.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Connected.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Covering/Monodromy/Full.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Full.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Covering/Quotient.lean
+++ b/TauCeti/Topology/Covering/Quotient.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/DiscreteSeparation.lean
+++ b/TauCeti/Topology/DiscreteSeparation.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Basic.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Complement.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopic/Naturality.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopic/Naturality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/AmbientIsotopyConj.lean
+++ b/TauCeti/Topology/Homotopy/AmbientIsotopyConj.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/Covering.lean
+++ b/TauCeti/Topology/Homotopy/Covering.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/Cube.lean
+++ b/TauCeti/Topology/Homotopy/Cube.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Covering.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Covering.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Map.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Map.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Product.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Product.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/TopologicalVectorSpace.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/TopologicalVectorSpace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Comp.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Prod.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/Monodromy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/Monodromy/Full.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/Full.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/LocallyConstant/Preconnected.lean
+++ b/TauCeti/Topology/LocallyConstant/Preconnected.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean
+++ b/TauCeti/Topology/NoetherianSpace/ConnectedComponents.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Semicontinuity/Approximation.lean
+++ b/TauCeti/Topology/Semicontinuity/Approximation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Sheaves/EtaleSpace.lean
+++ b/TauCeti/Topology/Sheaves/EtaleSpace.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Sym.lean
+++ b/TauCeti/Topology/Sym.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Topology/Triangulable.lean
+++ b/TauCeti/Topology/Triangulable.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 


### PR DESCRIPTION
This PR normalizes copyright blocks and `Authors:` lines in the fourth of four disjoint source batches required before enabling the header linter in CI.

Roadmap: none

:robot: Prepared with OpenAI Codex