### PR TITLE
Move homotopy group declarations to canonical namespaces

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/HigherHomotopy.lean
@@ -19,7 +19,7 @@ homotopy groups of a circle in dimensions at least two are trivial.
 The only calculation needed in the total space is elementary: any two generalized loops in a
 real topological vector space are homotopic relative to the cube boundary, so all homotopy
 groups of such a space are subsingletons
-(`TauCeti.HomotopyGroup.subsingleton_of_topologicalVectorSpace`). Applying the covering-map
+(`HomotopyGroup.subsingleton_of_topologicalVectorSpace`). Applying the covering-map
 isomorphism for `ℝ → AddCircle p` gives the circle calculation.
 
 This proves Stage 4, item 11 of the Tau Ceti universal-covers roadmap

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Covering.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Covering.lean
@@ -39,11 +39,11 @@ cover".
 
 ## Main declarations
 
-* `TauCeti.GenLoop.map_homotopic_iff`: postcomposition with a covering map reflects (and
+* `GenLoop.map_homotopic_iff`: postcomposition with a covering map reflects (and
   preserves) homotopy of generalized loops.
-* `TauCeti.GenLoop.map_surjective`: in dimension `≥ 2`, every generalized loop in the base
+* `GenLoop.map_surjective`: in dimension `≥ 2`, every generalized loop in the base
   lifts to a generalized loop in the total space based at a prescribed point of the fibre.
-* `TauCeti.HomotopyGroup.map_injective`, `TauCeti.HomotopyGroup.map_surjective`: the induced
+* `HomotopyGroup.map_injective`, `HomotopyGroup.map_surjective`: the induced
   map on homotopy classes.
 * `TauCeti.IsCoveringMap.homotopyGroupMulEquiv`: the isomorphism
   `HomotopyGroup N E e ≃* HomotopyGroup N X (p e)` for `[Nontrivial N]`.
@@ -59,8 +59,6 @@ covering-space API in `Mathlib.Topology.Homotopy.Lifting` and
 
 public section
 
-namespace TauCeti
-
 open scoped unitInterval Topology Topology.Homotopy
 
 variable {N X E : Type*} [TopologicalSpace X] [TopologicalSpace E] {p : E → X} {e : E}
@@ -71,7 +69,7 @@ namespace GenLoop
 generalized loops in the total space: two generalized loops based at `e` are homotopic
 relative to the cube boundary if and only if their postcompositions with `p` are.
 
-The reverse implication is `TauCeti.GenLoop.map_homotopic` and needs no hypothesis on `p`;
+The reverse implication is `GenLoop.map_homotopic` and needs no hypothesis on `p`;
 the forward implication lifts the homotopy, using that both generalized loops take the value
 `e` at the corner `0` of the cube. -/
 @[simp]
@@ -79,9 +77,9 @@ theorem map_homotopic_iff [Nonempty N] (hp : IsCoveringMap p) {F G : Ω^ N E e} 
     _root_.GenLoop.Homotopic (map ⟨p, hp.continuous⟩ rfl F) (map ⟨p, hp.continuous⟩ rfl G) ↔
       _root_.GenLoop.Homotopic F G :=
   (hp.homotopicRel_iff_comp (f₀ := (F : C(I^N, E))) (f₁ := (G : C(I^N, E)))
-    ⟨0, zero_mem_cubeBoundary,
-      (_root_.GenLoop.boundary F 0 zero_mem_cubeBoundary).trans
-        (_root_.GenLoop.boundary G 0 zero_mem_cubeBoundary).symm⟩).symm
+    ⟨0, TauCeti.zero_mem_cubeBoundary,
+      (_root_.GenLoop.boundary F 0 TauCeti.zero_mem_cubeBoundary).trans
+        (_root_.GenLoop.boundary G 0 TauCeti.zero_mem_cubeBoundary).symm⟩).symm
 
 /-- Every generalized loop in the base of a covering map lifts, in dimensions `≥ 2`, to a
 generalized loop in the total space based at any prescribed point `e` of the fibre.
@@ -108,7 +106,7 @@ theorem map_surjective [Nontrivial N] (hp : IsCoveringMap p) (f : Ω^ N X (p e))
       prop' := fun t a ha =>
         _root_.GenLoop.boundary f _ (Cube.insertAt_boundary i (Or.inr ha)) }
   let QRel : cE.HomotopyRel cE (Cube.boundary { j // j ≠ i }) :=
-    hp.liftHomotopyRel qRel ⟨0, zero_mem_cubeBoundary, rfl⟩
+    hp.liftHomotopyRel qRel ⟨0, TauCeti.zero_mem_cubeBoundary, rfl⟩
       (funext fun _ => rfl) (funext fun _ => rfl)
   let P : Ω (Ω^ { j // j ≠ i } E e) _root_.GenLoop.const :=
     { toContinuousMap :=
@@ -150,6 +148,8 @@ theorem map_surjective [Nontrivial N] (hp : IsCoveringMap p) :
   exact ⟨⟦F⟧, by rw [map_mk, hF]⟩
 
 end HomotopyGroup
+
+namespace TauCeti
 
 /-- **A covering map induces an isomorphism on homotopy groups in dimensions `≥ 2`.**
 

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homeomorph.lean
@@ -27,17 +27,15 @@ before proving that a covering map induces isomorphisms on `π_n` for `n ≥ 2`.
 
 ## Main declarations
 
-* `TauCeti.HomotopyGroup.homeomorphEquivOfEq`: `π_N(X, x) ≃ π_N(Y, y)` from `e : X ≃ₜ Y` with
+* `HomotopyGroup.homeomorphEquivOfEq`: `π_N(X, x) ≃ π_N(Y, y)` from `e : X ≃ₜ Y` with
   `e x = y`.
-* `TauCeti.HomotopyGroup.homeomorphEquiv`: `π_N(X, x) ≃ π_N(Y, e x)`.
-* `TauCeti.HomotopyGroup.homeomorphMulEquivOfEq`: the positive-dimensional group isomorphism
+* `HomotopyGroup.homeomorphEquiv`: `π_N(X, x) ≃ π_N(Y, e x)`.
+* `HomotopyGroup.homeomorphMulEquivOfEq`: the positive-dimensional group isomorphism
   `π_N(X, x) ≃* π_N(Y, y)`.
-* `TauCeti.HomotopyGroup.homeomorphMulEquiv`: `π_N(X, x) ≃* π_N(Y, e x)`.
+* `HomotopyGroup.homeomorphMulEquiv`: `π_N(X, x) ≃* π_N(Y, e x)`.
 -/
 
 public section
-
-namespace TauCeti
 
 namespace HomotopyGroup
 
@@ -127,5 +125,3 @@ theorem homeomorphMulEquiv_symm_apply [DecidableEq N] [Nonempty N] (e : X ≃ₜ
   rfl
 
 end HomotopyGroup
-
-end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Homotopy.lean
@@ -21,8 +21,6 @@ item 9 of the Tau Ceti universal-covers roadmap.
 
 public section
 
-namespace TauCeti
-
 open scoped unitInterval Topology Topology.Homotopy
 open Topology.Homotopy
 
@@ -72,5 +70,3 @@ theorem mapHom_eq_of_homotopicRel [DecidableEq N] [Nonempty N] {f g : C(X, Y)}
   MonoidHom.ext fun a ↦ congrFun (map_eq_of_homotopicRel hf hx H) a
 
 end HomotopyGroup
-
-end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Map.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Map.lean
@@ -23,8 +23,6 @@ roadmap, Stage 3 item 9, before proving that a covering map induces isomorphisms
 
 public section
 
-namespace TauCeti
-
 open scoped unitInterval Topology Topology.Homotopy
 open Topology.Homotopy
 
@@ -287,5 +285,3 @@ theorem map_one [DecidableEq N] [Nonempty N] (f : C(X, Y)) (hf : f x = y) :
   (mapHom f hf).map_one
 
 end HomotopyGroup
-
-end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/Product.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/Product.lean
@@ -26,17 +26,15 @@ homotopy groups of a torus.
 
 ## Main declarations
 
-* `TauCeti.HomotopyGroup.prodEquiv`: the homotopy group of a binary product is the product
+* `HomotopyGroup.prodEquiv`: the homotopy group of a binary product is the product
   of the homotopy groups.
-* `TauCeti.HomotopyGroup.piEquiv`: the homotopy group of an indexed product is the indexed
+* `HomotopyGroup.piEquiv`: the homotopy group of an indexed product is the indexed
   product of the homotopy groups.
-* `TauCeti.HomotopyGroup.prodMulEquiv`, `TauCeti.HomotopyGroup.piMulEquiv`: the
+* `HomotopyGroup.prodMulEquiv`, `HomotopyGroup.piMulEquiv`: the
   positive-dimensional multiplicative forms.
 -/
 
 public section
-
-namespace TauCeti
 
 open scoped unitInterval Topology Topology.Homotopy
 open Topology.Homotopy
@@ -319,5 +317,3 @@ theorem pi_mul [DecidableEq N] [Nonempty N] (a b : ∀ i, HomotopyGroup N (Z i) 
     (piMulEquiv (N := N) z).symm.map_mul a b
 
 end HomotopyGroup
-
-end TauCeti

--- a/TauCeti/Topology/Homotopy/HomotopyGroup/TopologicalVectorSpace.lean
+++ b/TauCeti/Topology/Homotopy/HomotopyGroup/TopologicalVectorSpace.lean
@@ -18,15 +18,13 @@ is a subsingleton.
 
 ## Main declarations
 
-* `TauCeti.GenLoop.homotopic_of_topologicalVectorSpace`: generalized loops in a real
+* `GenLoop.homotopic_of_topologicalVectorSpace`: generalized loops in a real
   topological vector space with the same basepoint are homotopic.
-* `TauCeti.HomotopyGroup.subsingleton_of_topologicalVectorSpace`: all homotopy groups of a
+* `HomotopyGroup.subsingleton_of_topologicalVectorSpace`: all homotopy groups of a
   real topological vector space are subsingletons.
 -/
 
 public section
-
-namespace TauCeti
 
 open scoped unitInterval Topology Topology.Homotopy
 
@@ -56,5 +54,3 @@ instance subsingleton_of_topologicalVectorSpace : Subsingleton (HomotopyGroup N 
   exact Quotient.sound (GenLoop.homotopic_of_topologicalVectorSpace f g)
 
 end HomotopyGroup
-
-end TauCeti


### PR DESCRIPTION
This PR moves the remaining generalized-loop and homotopy-group declarations out of the TauCeti wrappers and into the canonical GenLoop and HomotopyGroup namespaces. It covers all declarations in the six defining modules, updates the downstream doc reference, and leaves the separately sliceable TauCeti.IsCoveringMap namespace debt unchanged.

The collision audit found no existing canonical declarations, and the post-migration environment contains no stale TauCeti.GenLoop or TauCeti.HomotopyGroup constants. A full lake build (8,212 jobs), lint-env, lint-dot-notation, and git diff --check pass locally. The dot-notation lint reports 30 ratchetable baseline rows; the baseline is human-owned and should be regenerated separately after this source-only migration lands.

Closes the HomotopyGroup/GenLoop namespace slice of #3547.

Roadmap: none

🤖 Generated with [Codex](https://openai.com/codex/)