### PR TITLE
feat: extend projective families on sequences

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProjectiveLimit.lean
+++ b/TauCeti/MeasureTheory/Measure/ProjectiveLimit.lean
@@ -50,20 +50,35 @@ private def prefixSuccEquiv (n : ℕ) :
   (MeasurableEquiv.prodCongr (MeasurableEquiv.refl _) (MeasurableEquiv.piSingleton n)).trans
     (MeasurableEquiv.IicProdIoc n.le_succ)
 
+private theorem prefixSuccEquiv_apply (n : ℕ) (x : (∀ i : Iic n, X i) × X (n + 1)) :
+    prefixSuccEquiv n x =
+      IicProdIoc n (n + 1) (x.1, MeasurableEquiv.piSingleton n x.2) := by
+  rw [prefixSuccEquiv, MeasurableEquiv.coe_trans, Function.comp_apply,
+    MeasurableEquiv.coe_IicProdIoc]
+  exact congrArg (IicProdIoc n (n + 1)) (congrFun (Equiv.prodCongr_apply _ _) x)
+
 private theorem prefixSuccEquiv_symm_apply (n : ℕ) (x : ∀ i : Iic (n + 1), X i) :
     (prefixSuccEquiv n).symm x =
       (frestrictLe₂ n.le_succ x, x ⟨n + 1, Finset.mem_Iic.mpr le_rfl⟩) := by
-  change (MeasurableEquiv.prodCongr (MeasurableEquiv.refl _)
-      (MeasurableEquiv.piSingleton n)).symm
-      ((MeasurableEquiv.IicProdIoc (X := X) n.le_succ).symm x) = _
-  rw [congrFun (MeasurableEquiv.coe_IicProdIoc_symm (X := X) n.le_succ) x]
-  rfl
+  rw [MeasurableEquiv.symm_apply_eq, prefixSuccEquiv_apply]
+  ext i
+  by_cases hi : i.1 ≤ n
+  · simp [IicProdIoc, hi]
+  · have hi_eq : i = ⟨n + 1, Finset.mem_Iic.mpr le_rfl⟩ := Subtype.ext <|
+      le_antisymm (Finset.mem_Iic.mp i.2) (Nat.succ_le_of_lt (Nat.lt_of_not_ge hi))
+    subst i
+    simp [IicProdIoc, MeasurableEquiv.piSingleton]
 
 private theorem prefixSuccEquiv_apply_pair (n : ℕ) (x : ∀ n, X n) :
     prefixSuccEquiv n (frestrictLe n x, x (n + 1)) = frestrictLe (n + 1) x := by
-  apply (prefixSuccEquiv n).symm.injective
-  rw [(prefixSuccEquiv n).symm_apply_apply, prefixSuccEquiv_symm_apply]
-  rfl
+  rw [prefixSuccEquiv_apply]
+  ext i
+  by_cases hi : i.1 ≤ n
+  · simp [IicProdIoc, hi]
+  · have hi_eq : i = ⟨n + 1, Finset.mem_Iic.mpr le_rfl⟩ := Subtype.ext <|
+      le_antisymm (Finset.mem_Iic.mp i.2) (Nat.succ_le_of_lt (Nat.lt_of_not_ge hi))
+    subst i
+    simp [IicProdIoc, MeasurableEquiv.piSingleton]
 
 /-- The law of a prefix and its next coordinate, obtained from the next prescribed prefix law. -/
 private def successorLaw (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) (n : ℕ) :

--- a/TauCeti/MeasureTheory/Measure/ProjectiveLimit.lean
+++ b/TauCeti/MeasureTheory/Measure/ProjectiveLimit.lean
@@ -10,10 +10,11 @@ public import Mathlib.Probability.Kernel.IonescuTulcea.Traj
 /-!
 # Projective limits on countable products
 
-This file proves existence in the countable standard-Borel case of Kolmogorov's extension theorem.
-Mathlib defines projective measure families and proves uniqueness of their projective limits, while
-its Ionescu--Tulcea construction produces a path law from a sequence of transition kernels. Here a
-coherent family of finite-prefix laws is disintegrated to obtain those kernels.
+This file proves a countable version of Kolmogorov's extension theorem when every positive-indexed
+coordinate is standard Borel. Mathlib defines projective measure families and proves uniqueness of
+their projective limits, while its Ionescu--Tulcea construction produces a path law from a sequence
+of transition kernels. Here a coherent family of finite-prefix laws is disintegrated to obtain
+those kernels.
 
 ## Main result
 
@@ -24,7 +25,8 @@ coherent family of finite-prefix laws is disintegrated to obtain those kernels.
 
 This is the existence bridge between Mathlib's `MeasureTheory.IsProjectiveMeasureFamily` API and
 its Ionescu--Tulcea theorem. The construction follows the standard proof of Kolmogorov extension
-for countable products by successive disintegration.
+for countable products by successive disintegration, as prescribed by the
+`TauCetiRoadmap/OptimalTransport/README.md` Layer 0, item 4 target.
 -/
 
 public section
@@ -71,13 +73,13 @@ private theorem fst_successorLaw (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i))
 
 /-- The transition kernel obtained by disintegrating the next prescribed prefix law over the
 current prefix. -/
-private def projectiveKernel [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)]
+private def projectiveKernel [∀ n, StandardBorelSpace (X (n + 1))] [∀ n, Nonempty (X n)]
     (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)] (n : ℕ) :
     Kernel (∀ i : Iic n, X i) (X (n + 1)) :=
   (successorLaw P n).condKernel
 
 private instance projectiveKernel.instIsMarkovKernel
-    [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)]
+    [∀ n, StandardBorelSpace (X (n + 1))] [∀ n, Nonempty (X n)]
     (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)] (n : ℕ) :
     IsMarkovKernel (projectiveKernel P n) := by
   rw [projectiveKernel]
@@ -95,20 +97,20 @@ private instance initialLaw.instIsProbabilityMeasure
 
 /-- The Ionescu--Tulcea path law built by successively disintegrating prescribed prefix laws. -/
 private def prefixLimit (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i))
-    [∀ n, IsProbabilityMeasure (P n)] [∀ n, StandardBorelSpace (X n)]
+    [∀ n, IsProbabilityMeasure (P n)] [∀ n, StandardBorelSpace (X (n + 1))]
     [∀ n, Nonempty (X n)] : Measure (∀ n, X n) :=
   Kernel.trajMeasure (initialLaw P) (projectiveKernel P)
 
 private instance prefixLimit.instIsProbabilityMeasure
     (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)]
-    [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)] :
+    [∀ n, StandardBorelSpace (X (n + 1))] [∀ n, Nonempty (X n)] :
     IsProbabilityMeasure (prefixLimit P) := by
   rw [prefixLimit]
   infer_instance
 
 private theorem map_frestrictLe_zero_prefixLimit
     (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)]
-    [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)] :
+    [∀ n, StandardBorelSpace (X (n + 1))] [∀ n, Nonempty (X n)] :
     (prefixLimit P).map (frestrictLe 0) = P 0 := by
   let e : (∀ i : Iic 0, X i) ≃ᵐ X 0 := MeasurableEquiv.piUnique _
   have hprefix : (prefixLimit P).map (frestrictLe 0) = (initialLaw P).map e.symm := by
@@ -123,7 +125,7 @@ private theorem map_frestrictLe_zero_prefixLimit
 
 private theorem map_frestrictLe_succ_prefixLimit
     (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)]
-    [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)]
+    [∀ n, StandardBorelSpace (X (n + 1))] [∀ n, Nonempty (X n)]
     (hP : ∀ n, (P (n + 1)).map (frestrictLe₂ n.le_succ) = P n) {n : ℕ}
     (hn : (prefixLimit P).map (frestrictLe n) = P n) :
     (prefixLimit P).map (frestrictLe (n + 1)) = P (n + 1) := by
@@ -154,13 +156,14 @@ private theorem map_frestrictLe_succ_prefixLimit
 
 /-- **Countable projective-family extension for coherent prefixes.** A coherent family of
 probability laws on the prefixes `∀ i : Iic n, X i` of a dependent sequence of standard Borel
-spaces is realized by a probability law on the whole sequence.
+spaces, except that the zeroth coordinate need only be measurable, is realized by a probability
+law on the whole sequence.
 
 The result is stated directly in terms of prefix laws because this is the interface consumed by
 countable gluing constructions. Together with Mathlib's
 `MeasureTheory.isProjectiveMeasureFamily_inducedFamily` and
 `MeasureTheory.isProjectiveLimit_nat_iff`, it gives the usual `Finset ℕ` formulation. -/
-theorem exists_map_frestrictLe_eq [∀ n, StandardBorelSpace (X n)]
+theorem exists_map_frestrictLe_eq [∀ n, StandardBorelSpace (X (n + 1))]
     (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)]
     (hP : ∀ n, (P (n + 1)).map (frestrictLe₂ n.le_succ) = P n) :
     ∃ μ : Measure (∀ n, X n), IsProbabilityMeasure μ ∧
@@ -173,13 +176,13 @@ theorem exists_map_frestrictLe_eq [∀ n, StandardBorelSpace (X n)]
   | zero => exact map_frestrictLe_zero_prefixLimit P
   | succ n hn => exact map_frestrictLe_succ_prefixLimit P hP hn
 
-/-- **Kolmogorov extension for a sequence of standard Borel spaces.** Every projective family of
-probability laws indexed by the finite subsets of `ℕ` has a projective limit, which is again a
-probability measure.
+/-- **Kolmogorov extension for a sequence with standard Borel positive coordinates.** Every
+projective family of probability laws indexed by the finite subsets of `ℕ` has a projective limit,
+which is again a probability measure.
 
 Mathlib already proves that this projective limit is unique; this theorem supplies existence by
 reducing to coherent prefixes and applying `TauCeti.Measure.exists_map_frestrictLe_eq`. -/
-theorem exists_isProjectiveLimit_nat [∀ n, StandardBorelSpace (X n)]
+theorem exists_isProjectiveLimit_nat [∀ n, StandardBorelSpace (X (n + 1))]
     (P : ∀ I : Finset ℕ, Measure (∀ i : I, X i)) [∀ I, IsProbabilityMeasure (P I)]
     (hP : IsProjectiveMeasureFamily P) :
     ∃ μ : Measure (∀ n, X n), IsProbabilityMeasure μ ∧ IsProjectiveLimit μ P := by

--- a/TauCeti/MeasureTheory/Measure/ProjectiveLimit.lean
+++ b/TauCeti/MeasureTheory/Measure/ProjectiveLimit.lean
@@ -50,6 +50,21 @@ private def prefixSuccEquiv (n : ℕ) :
   (MeasurableEquiv.prodCongr (MeasurableEquiv.refl _) (MeasurableEquiv.piSingleton n)).trans
     (MeasurableEquiv.IicProdIoc n.le_succ)
 
+private theorem prefixSuccEquiv_symm_apply (n : ℕ) (x : ∀ i : Iic (n + 1), X i) :
+    (prefixSuccEquiv n).symm x =
+      (frestrictLe₂ n.le_succ x, x ⟨n + 1, Finset.mem_Iic.mpr le_rfl⟩) := by
+  change (MeasurableEquiv.prodCongr (MeasurableEquiv.refl _)
+      (MeasurableEquiv.piSingleton n)).symm
+      ((MeasurableEquiv.IicProdIoc (X := X) n.le_succ).symm x) = _
+  rw [congrFun (MeasurableEquiv.coe_IicProdIoc_symm (X := X) n.le_succ) x]
+  rfl
+
+private theorem prefixSuccEquiv_apply_pair (n : ℕ) (x : ∀ n, X n) :
+    prefixSuccEquiv n (frestrictLe n x, x (n + 1)) = frestrictLe (n + 1) x := by
+  apply (prefixSuccEquiv n).symm.injective
+  rw [(prefixSuccEquiv n).symm_apply_apply, prefixSuccEquiv_symm_apply]
+  rfl
+
 /-- The law of a prefix and its next coordinate, obtained from the next prescribed prefix law. -/
 private def successorLaw (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) (n : ℕ) :
     Measure ((∀ i : Iic n, X i) × X (n + 1)) :=
@@ -67,8 +82,8 @@ private theorem fst_successorLaw (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i))
     MeasureTheory.Measure.map_map measurable_fst (prefixSuccEquiv n).symm.measurable]
   have hfun : (Prod.fst : ((∀ i : Iic n, X i) × X (n + 1)) → (∀ i : Iic n, X i)) ∘
       (prefixSuccEquiv n).symm = frestrictLe₂ n.le_succ := by
-    funext x i
-    rfl
+    funext x
+    exact congrArg Prod.fst (prefixSuccEquiv_symm_apply n x)
   rw [hfun, hP n]
 
 /-- The transition kernel obtained by disintegrating the next prescribed prefix law over the
@@ -144,12 +159,7 @@ private theorem map_frestrictLe_succ_prefixLimit
   have hfun : frestrictLe (n + 1) =
       prefixSuccEquiv n ∘ fun x : (∀ n, X n) ↦ (frestrictLe n x, x (n + 1)) := by
     funext x
-    apply (prefixSuccEquiv n).symm.injective
-    simp only [Function.comp_apply]
-    rw [(prefixSuccEquiv n).symm_apply_apply]
-    apply Prod.ext
-    · rfl
-    · rfl
+    exact (prefixSuccEquiv_apply_pair n x).symm
   rw [hfun, ← MeasureTheory.Measure.map_map (prefixSuccEquiv n).measurable (by fun_prop),
     hpair, successorLaw]
   exact MeasurableEquiv.map_map_symm (prefixSuccEquiv n)

--- a/TauCeti/MeasureTheory/Measure/ProjectiveLimit.lean
+++ b/TauCeti/MeasureTheory/Measure/ProjectiveLimit.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Probability.Kernel.IonescuTulcea.Traj
+
+/-!
+# Projective limits on countable products
+
+This file proves existence in the countable standard-Borel case of Kolmogorov's extension theorem.
+Mathlib defines projective measure families and proves uniqueness of their projective limits, while
+its Ionescu--Tulcea construction produces a path law from a sequence of transition kernels. Here a
+coherent family of finite-prefix laws is disintegrated to obtain those kernels.
+
+## Main result
+
+* `TauCeti.Measure.exists_map_frestrictLe_eq` constructs a probability measure on a dependent
+  sequence whose finite-prefix laws are a prescribed coherent family.
+* `TauCeti.Measure.exists_isProjectiveLimit_nat` realizes a projective family indexed by finite
+  subsets of `ℕ`.
+
+This is the existence bridge between Mathlib's `MeasureTheory.IsProjectiveMeasureFamily` API and
+its Ionescu--Tulcea theorem. The construction follows the standard proof of Kolmogorov extension
+for countable products by successive disintegration.
+-/
+
+public section
+
+noncomputable section
+
+open Finset MeasureTheory Preorder ProbabilityTheory
+
+namespace TauCeti
+
+namespace Measure
+
+universe u
+
+variable {X : ℕ → Type u} [∀ n, MeasurableSpace (X n)]
+
+/-- Split a trajectory through time `n + 1` into its prefix through time `n` and its last
+coordinate. -/
+private def prefixSuccEquiv (n : ℕ) :
+    ((∀ i : Iic n, X i) × X (n + 1)) ≃ᵐ (∀ i : Iic (n + 1), X i) :=
+  (MeasurableEquiv.prodCongr (MeasurableEquiv.refl _) (MeasurableEquiv.piSingleton n)).trans
+    (MeasurableEquiv.IicProdIoc n.le_succ)
+
+/-- The law of a prefix and its next coordinate, obtained from the next prescribed prefix law. -/
+private def successorLaw (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) (n : ℕ) :
+    Measure ((∀ i : Iic n, X i) × X (n + 1)) :=
+  (P (n + 1)).map (prefixSuccEquiv n).symm
+
+private instance successorLaw.instIsProbabilityMeasure
+    (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)] (n : ℕ) :
+    IsProbabilityMeasure (successorLaw P n) :=
+  MeasureTheory.Measure.isProbabilityMeasure_map (prefixSuccEquiv n).symm.measurable.aemeasurable
+
+private theorem fst_successorLaw (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i))
+    (hP : ∀ n, (P (n + 1)).map (frestrictLe₂ n.le_succ) = P n) (n : ℕ) :
+    (successorLaw P n).fst = P n := by
+  rw [successorLaw, MeasureTheory.Measure.fst,
+    MeasureTheory.Measure.map_map measurable_fst (prefixSuccEquiv n).symm.measurable]
+  have hfun : (Prod.fst : ((∀ i : Iic n, X i) × X (n + 1)) → (∀ i : Iic n, X i)) ∘
+      (prefixSuccEquiv n).symm = frestrictLe₂ n.le_succ := by
+    funext x i
+    rfl
+  rw [hfun, hP n]
+
+/-- The transition kernel obtained by disintegrating the next prescribed prefix law over the
+current prefix. -/
+private def projectiveKernel [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)]
+    (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)] (n : ℕ) :
+    Kernel (∀ i : Iic n, X i) (X (n + 1)) :=
+  (successorLaw P n).condKernel
+
+private instance projectiveKernel.instIsMarkovKernel
+    [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)]
+    (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)] (n : ℕ) :
+    IsMarkovKernel (projectiveKernel P n) := by
+  rw [projectiveKernel]
+  infer_instance
+
+/-- The zeroth-coordinate law extracted from the first prescribed prefix law. -/
+private def initialLaw (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) : Measure (X 0) :=
+  (P 0).map (MeasurableEquiv.piUnique fun i : Iic 0 ↦ X i)
+
+private instance initialLaw.instIsProbabilityMeasure
+    (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)] :
+    IsProbabilityMeasure (initialLaw P) :=
+  MeasureTheory.Measure.isProbabilityMeasure_map
+    (MeasurableEquiv.piUnique fun i : Iic 0 ↦ X i).measurable.aemeasurable
+
+/-- The Ionescu--Tulcea path law built by successively disintegrating prescribed prefix laws. -/
+private def prefixLimit (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i))
+    [∀ n, IsProbabilityMeasure (P n)] [∀ n, StandardBorelSpace (X n)]
+    [∀ n, Nonempty (X n)] : Measure (∀ n, X n) :=
+  Kernel.trajMeasure (initialLaw P) (projectiveKernel P)
+
+private instance prefixLimit.instIsProbabilityMeasure
+    (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)]
+    [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)] :
+    IsProbabilityMeasure (prefixLimit P) := by
+  rw [prefixLimit]
+  infer_instance
+
+private theorem map_frestrictLe_zero_prefixLimit
+    (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)]
+    [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)] :
+    (prefixLimit P).map (frestrictLe 0) = P 0 := by
+  let e : (∀ i : Iic 0, X i) ≃ᵐ X 0 := MeasurableEquiv.piUnique _
+  have hprefix : (prefixLimit P).map (frestrictLe 0) = (initialLaw P).map e.symm := by
+    rw [prefixLimit, Kernel.trajMeasure, MeasureTheory.Measure.map_comp,
+      Kernel.traj_map_frestrictLe, Kernel.partialTraj_self, MeasureTheory.Measure.id_comp]
+    · rfl
+    · fun_prop
+  calc
+    (prefixLimit P).map (frestrictLe 0) = (initialLaw P).map e.symm := hprefix
+    _ = ((P 0).map e).map e.symm := rfl
+    _ = P 0 := MeasurableEquiv.map_map_symm e.symm
+
+private theorem map_frestrictLe_succ_prefixLimit
+    (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)]
+    [∀ n, StandardBorelSpace (X n)] [∀ n, Nonempty (X n)]
+    (hP : ∀ n, (P (n + 1)).map (frestrictLe₂ n.le_succ) = P n) {n : ℕ}
+    (hn : (prefixLimit P).map (frestrictLe n) = P n) :
+    (prefixLimit P).map (frestrictLe (n + 1)) = P (n + 1) := by
+  have hcomp : (prefixLimit P).map (frestrictLe n) ⊗ₘ projectiveKernel P n =
+      successorLaw P n := by
+    rw [hn, ← fst_successorLaw P hP n, projectiveKernel,
+      MeasureTheory.Measure.disintegrate]
+  have hpair : (prefixLimit P).map (fun x ↦ (frestrictLe n x, x (n + 1))) =
+      successorLaw P n := by
+    calc
+      _ = (prefixLimit P).map (frestrictLe n) ⊗ₘ projectiveKernel P n := by
+        simpa only [prefixLimit] using
+          (Kernel.map_frestrictLe_trajMeasure_compProd_eq_map_trajMeasure
+            (μ₀ := initialLaw P) (κ := projectiveKernel P) (a := n)).symm
+      _ = successorLaw P n := hcomp
+  have hfun : frestrictLe (n + 1) =
+      prefixSuccEquiv n ∘ fun x : (∀ n, X n) ↦ (frestrictLe n x, x (n + 1)) := by
+    funext x
+    apply (prefixSuccEquiv n).symm.injective
+    simp only [Function.comp_apply]
+    rw [(prefixSuccEquiv n).symm_apply_apply]
+    apply Prod.ext
+    · rfl
+    · rfl
+  rw [hfun, ← MeasureTheory.Measure.map_map (prefixSuccEquiv n).measurable (by fun_prop),
+    hpair, successorLaw]
+  exact MeasurableEquiv.map_map_symm (prefixSuccEquiv n)
+
+/-- **Countable projective-family extension for coherent prefixes.** A coherent family of
+probability laws on the prefixes `∀ i : Iic n, X i` of a dependent sequence of standard Borel
+spaces is realized by a probability law on the whole sequence.
+
+The result is stated directly in terms of prefix laws because this is the interface consumed by
+countable gluing constructions. Together with Mathlib's
+`MeasureTheory.isProjectiveMeasureFamily_inducedFamily` and
+`MeasureTheory.isProjectiveLimit_nat_iff`, it gives the usual `Finset ℕ` formulation. -/
+theorem exists_map_frestrictLe_eq [∀ n, StandardBorelSpace (X n)]
+    (P : ∀ n : ℕ, Measure (∀ i : Iic n, X i)) [∀ n, IsProbabilityMeasure (P n)]
+    (hP : ∀ n, (P (n + 1)).map (frestrictLe₂ n.le_succ) = P n) :
+    ∃ μ : Measure (∀ n, X n), IsProbabilityMeasure μ ∧
+      ∀ n, μ.map (frestrictLe n) = P n := by
+  let _ : ∀ n, Nonempty (X n) := fun n =>
+    (nonempty_of_isProbabilityMeasure (P n)).map fun x => x ⟨n, Finset.mem_Iic.mpr le_rfl⟩
+  refine ⟨prefixLimit P, inferInstance, ?_⟩
+  intro n
+  induction n with
+  | zero => exact map_frestrictLe_zero_prefixLimit P
+  | succ n hn => exact map_frestrictLe_succ_prefixLimit P hP hn
+
+/-- **Kolmogorov extension for a sequence of standard Borel spaces.** Every projective family of
+probability laws indexed by the finite subsets of `ℕ` has a projective limit, which is again a
+probability measure.
+
+Mathlib already proves that this projective limit is unique; this theorem supplies existence by
+reducing to coherent prefixes and applying `TauCeti.Measure.exists_map_frestrictLe_eq`. -/
+theorem exists_isProjectiveLimit_nat [∀ n, StandardBorelSpace (X n)]
+    (P : ∀ I : Finset ℕ, Measure (∀ i : I, X i)) [∀ I, IsProbabilityMeasure (P I)]
+    (hP : IsProjectiveMeasureFamily P) :
+    ∃ μ : Measure (∀ n, X n), IsProbabilityMeasure μ ∧ IsProjectiveLimit μ P := by
+  have hprefix : ∀ n, (P (Iic (n + 1))).map (frestrictLe₂ n.le_succ) = P (Iic n) :=
+    fun n => (hP (Iic (n + 1)) (Iic n) (Iic_subset_Iic.mpr n.le_succ)).symm
+  obtain ⟨μ, hμprob, hμ⟩ := exists_map_frestrictLe_eq (fun n => P (Iic n)) hprefix
+  exact ⟨μ, hμprob, (isProjectiveLimit_nat_iff hP μ).mpr hμ⟩
+
+end Measure
+
+end TauCeti


### PR DESCRIPTION
This PR adds the ℕ-indexed existence bridge required by the `OptimalTransport/README.md` milestone “Layer 0 — Raw couplings and gluing”, item 4: prove the arbitrary countable standard-Borel projective-family extension theorem over Mathlib's existing projective-family and Ionescu–Tulcea APIs. It realizes both coherent dependent prefix laws and projective probability families indexed by `Finset ℕ` as marginals of a probability law on the full dependent product.

The construction disintegrates each successor prefix law, feeds the resulting Markov kernels to `ProbabilityTheory.Kernel.trajMeasure`, proves the prescribed prefix marginals inductively, and uses `MeasureTheory.isProjectiveLimit_nat_iff` to recover every finite marginal. This is the most effective current step because the roadmap's countable chain-gluing theorem has landed, while this result removes the stronger finite-dimensional consistency obstruction needed for later compactness arguments.

After this PR, transporting the sequence theorem along an enumeration/equivalence remains to obtain the roadmap's arbitrary countable index-type statement.

This reuses Mathlib's `Measure.condKernel`, `Measure.disintegrate`, `Kernel.trajMeasure`, `IsProjectiveMeasureFamily`, and `isProjectiveLimit_nat_iff`; it vendors no upstream code.

Verification: `lake exe cache get`, `lake build`, and `lake exe axioms`.

Roadmap: OptimalTransport

<!--tauceti-target:v1 {"focus":"OptimalTransport","id":"nat-projective-family-extension"}-->

🤖 Prepared with Codex
