### PR TITLE
feat(Huber): identify A⟨T⟩ as a submodule over itself

### DIFF
--- a/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
@@ -33,6 +33,8 @@ where the convergent/restricted power series ring is (5.6.1) in §5.6.
   nonzero coefficients suffice.
 * `isRestricted_pi_iff`: restrictedness of a series with coefficients in a product is
   componentwise.
+* `restrictedMvPowerSeriesSubringLinearEquiv`: at `M = A` the subring and the submodule of
+  restricted series are `A`-linearly isomorphic.
 
 ## Provenance
 
@@ -56,10 +58,13 @@ were near-identical `tendsto_nhds`/`mem_cofinite` arguments and are now special 
 coefficient binders — `[Zero]` and a topology, where the original asked for a semiring.
 
 **Original here.** `isRestricted_monomial`, `isRestricted_of_hasFiniteSupport`,
-`IsRestricted.smul`, `restrictedMvPowerSeriesSubmodule`, `mem_restrictedMvPowerSeriesSubmodule`
-and `isRestricted_pi_iff`. The last has no AINTLIB counterpart: the source states restrictedness
-only for a single coefficient module, and never for a product. Its content is Mathlib's
-`tendsto_pi_nhds`, so what is original here is the statement, not the argument.
+`IsRestricted.smul`, `restrictedMvPowerSeriesSubmodule`, `mem_restrictedMvPowerSeriesSubmodule`,
+`isRestricted_pi_iff`, and `restrictedMvPowerSeriesSubringLinearEquiv` with its two coercion
+lemmas. Neither of the last two has an AINTLIB counterpart. `isRestricted_pi_iff` has none because
+the source states restrictedness only for a single coefficient module and never for a product; its
+content is Mathlib's `tendsto_pi_nhds`, so what is original in it is the statement rather than the
+argument. `restrictedMvPowerSeriesSubringLinearEquiv` has none because the source never introduces
+the submodule at all, so the subring is the only object it has to identify.
 
 The name `isRestricted_iff` needs care: the port introduced it for the `coeff`-form unfolding
 lemma, which is now `isRestricted_iff_coeff`. The statement the name carries here — unfolding
@@ -454,5 +459,44 @@ theorem mem_restrictedMvPowerSeriesSubmodule {k : ℕ} {A M : Type*} [Semiring A
     [TopologicalSpace M] [Module A M] [ContinuousAdd M] [ContinuousConstSMul A M]
     {f : MvPowerSeries (Fin k) M} :
     f ∈ restrictedMvPowerSeriesSubmodule k A M ↔ IsRestricted f := (Iff.rfl)
+
+/-- **`A⟨T₁, …, Tₖ⟩` as a submodule over itself**: at `M = A` the subring and the submodule cut
+out the same series, so they are `A`-linearly isomorphic.
+
+They are different structures over one carrier — `restrictedMvPowerSeriesSubring` is a `Subring`
+carrying an `Algebra A` instance, `restrictedMvPowerSeriesSubmodule` is a `Submodule A` — so the
+identification is not a coercion. It is what lets a statement about `M⟨T⟩` at `M = A` meet the
+tensor-product API, which produces the subring. -/
+noncomputable def restrictedMvPowerSeriesSubringLinearEquiv (k : ℕ) (A : Type*) [CommRing A]
+    [TopologicalSpace A] [NonarchimedeanRing A] :
+    restrictedMvPowerSeriesSubring k A ≃ₗ[A] restrictedMvPowerSeriesSubmodule k A A where
+  toFun f := ⟨f.1, mem_restrictedMvPowerSeriesSubmodule.mpr
+    (mem_restrictedMvPowerSeriesSubring.mp f.2)⟩
+  invFun g := ⟨g.1, mem_restrictedMvPowerSeriesSubring.mpr
+    (mem_restrictedMvPowerSeriesSubmodule.mp g.2)⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+  -- The subring's scalar action is `Algebra.smul_def`, the submodule's is pointwise; they agree
+  -- on the underlying series but not syntactically, so this one field is not `rfl`.
+  map_smul' a x := Subtype.ext <| by
+    simp only [Algebra.smul_def, Subring.coe_mul, RingHom.id_apply,
+      coe_algebraMap_restrictedMvPowerSeriesSubring, SetLike.val_smul]
+
+/-- `restrictedMvPowerSeriesSubringLinearEquiv` is the identity on the underlying series. Its body
+is not exposed, so this is how a consumer computes with it. -/
+@[simp]
+theorem coe_restrictedMvPowerSeriesSubringLinearEquiv {k : ℕ} {A : Type*} [CommRing A]
+    [TopologicalSpace A] [NonarchimedeanRing A] (f : restrictedMvPowerSeriesSubring k A) :
+    ((restrictedMvPowerSeriesSubringLinearEquiv k A f : restrictedMvPowerSeriesSubmodule k A A) :
+      MvPowerSeries (Fin k) A) = (f : MvPowerSeries (Fin k) A) := (rfl)
+
+/-- Its inverse is likewise the identity on the underlying series. -/
+@[simp]
+theorem coe_restrictedMvPowerSeriesSubringLinearEquiv_symm {k : ℕ} {A : Type*} [CommRing A]
+    [TopologicalSpace A] [NonarchimedeanRing A] (g : restrictedMvPowerSeriesSubmodule k A A) :
+    (((restrictedMvPowerSeriesSubringLinearEquiv k A).symm g :
+      restrictedMvPowerSeriesSubring k A) : MvPowerSeries (Fin k) A) =
+      (g : MvPowerSeries (Fin k) A) := (rfl)
 
 end TauCeti.Huber


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"restricted-subring-submodule-bridge"}-->

**Roadmap target.** `TauCetiRoadmap/AdicSpaces/README.md`, Layer 4.1 step 1 — Wedhorn Remark 8.29,
`M ⊗_A A⟨X⟩ ≅ M⟨X⟩`. The finitely generated case reduces to `M` finite free, and this supplies a
piece that case needs and does not have.

## The gap

At `M = A` the two objects cut out the same series but are **different structures over one
carrier**:

| | type | cut out by |
|---|---|---|
| `restrictedMvPowerSeriesSubring k A` | `Subring (MvPowerSeries (Fin k) A)`, carrying `Algebra A` | explicit carrier `{f | IsRestricted f}` |
| `restrictedMvPowerSeriesSubmodule k A A` | `Submodule A (MvPowerSeries (Fin k) A)` | `Filter.zeroAtFilterSubmodule` |

So there is no coercion between them, and the identification has to be a linear equivalence.

**Why it is needed rather than merely tidy.** In the finite free case the source side comes from
Mathlib — `TensorProduct.comm` then `TensorProduct.piScalarRight A A ↥A⟨T⟩ (Fin n)` gives
`(Fin n → A) ⊗[A] A⟨T⟩ ≃ₗ (Fin n → A⟨T⟩)`, landing in the **subring**. The comparison map
`restrictedMvPowerSeriesBaseChange` lands in the **submodule**. Without this bridge the two sides
of the base case are not even the same type.

## The one non-`rfl` field

`map_smul'`. The subring's scalar action is `Algebra.smul_def` — multiplication by
`algebraMap A _ a` — while the submodule's is pointwise. They agree on the underlying series but
not syntactically, so that field goes through

```lean
simp only [Algebra.smul_def, Subring.coe_mul, RingHom.id_apply,
  coe_algebraMap_restrictedMvPowerSeriesSubring, SetLike.val_smul]
```

Everything else is `rfl`. Both coercion lemmas are supplied, since the body is not exposed.

## Checked

* Mathlib has no bridge that applies: `Subalgebra.toSubmodule` wants a `Subalgebra`, and this is a
  `Subring` carrying an `Algebra` instance — the same reason `restrictedMvPowerSeriesSubringVal`
  exists rather than `Subalgebra.val`.
* Verified absent from `origin/main` before writing.
* Both module-docstring lists updated in the same edit as the declarations — **Main definitions
  and the Provenance ledger**. #3624 drew a `documentation` finding for updating only the first;
  this file has two lists and both are exhaustive.

## Gates

Build 8221 jobs; `axioms` 52814 declarations, allowlist only; `module-system` 2489 modules;
`LINT-ENV: PASS`. Branch off current `main`, pin unmoved.
