### PR TITLE
feat(Spa): a containment of rational subsets yields a refining presentation

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -70,12 +70,14 @@ layer deferred above.
   relatively open in the subspace `spa A⁺`.
 * `TauCeti.ValuationSpectrum.rationalSubset_inter` : the intersection identity above — the
   set-level half of Remark 7.30(5).
-* `TauCeti.ValuationSpectrum.rationalSubset_eq_inter_of_subset` : a contained rational subset is
-  its own intersection with the larger one, hence re-presentable with the larger denominator as a
+* `TauCeti.ValuationSpectrum.rationalSubset_eq_mul_insert_of_subset` : a contained rational subset
+  is re-presented by the product pair, whose denominator has the containing denominator as a
   factor — the re-presentation step of Wedhorn §8.2.
 * `TauCeti.ValuationSpectrum.exists_refinement_of_subset` : that re-presentation packaged as the
-  *refinement* data a restriction map needs — from `R(T'/s') ⊆ R(T/s)`, a presentation
-  `R(T''/(s · r))` of the smaller subset with `t · r ∈ T''` for every `t ∈ T`.
+  two *set-level* refinement inputs — from `R(T'/s') ⊆ R(T/s)`, a presentation `R(T''/(s · r))` of
+  the smaller subset with `t · r ∈ T''` for every `t ∈ T`. Constructing a restriction map needs one
+  further, algebraic input beyond these, the standing `HasDenominatorPower` hypothesis for the
+  finer pair, which this file does not supply.
 * `TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top` : a finite set
   generating the unit ideal gives a standard rational cover, the forward implication of
   Corollary 7.53.
@@ -204,17 +206,17 @@ theorem rationalSubset_inter (Aplus : Subring A) (T₁ T₂ : Finset A) (s₁ s�
 /-! ### Re-presenting a contained rational subset -/
 
 open scoped Classical Pointwise in
-/-- **A contained rational subset is its own intersection with the larger one**, so
-`rationalSubset_inter` re-presents it with the larger denominator as a factor:
-`R(T'/s') = R((U T' ∪-augmented product)/(s · s'))` where the numerators are `U₁U₂` for
-`U₁ = insert s T` and `U₂ = insert s' T'`.
+/-- **A contained rational subset is re-presented by the product pair**, with numerators `U₁U₂` for
+`U₁ = insert s T` and `U₂ = insert s' T'` and denominator `s · s'`.
 
-This is the re-presentation step of Wedhorn §8.2. Its point is the *denominator*: on the right
-`s` divides `s · s'`, so in a localisation presented by the right-hand pair the element `s`
-is invertible by construction, which is what a map out of the coordinate ring of `R(T/s)`
-needs. Nothing here is a statement about coordinate rings — see
-`exists_refinement_of_subset` for the packaged form those consume. -/
-theorem rationalSubset_eq_inter_of_subset (Aplus : Subring A) (T T' : Finset A) (s s' : A)
+Its point is the *denominator*: on the right `s` divides `s · s'`, so in a localisation presented by
+the product pair the element `s` is invertible by construction. That is the re-presentation step of
+Wedhorn §8.2, and it is what a map out of the coordinate ring of `R(T/s)` needs.
+
+The proof is the observation that a contained set is its own intersection with the containing one,
+after which `rationalSubset_inter` computes that intersection. Nothing here is a statement about
+coordinate rings — see `exists_refinement_of_subset` for the packaged form those consume. -/
+theorem rationalSubset_eq_mul_insert_of_subset (Aplus : Subring A) (T T' : Finset A) (s s' : A)
     (h : rationalSubset Aplus T' s' ⊆ rationalSubset Aplus T s) :
     rationalSubset Aplus T' s'
       = rationalSubset Aplus (insert s T * insert s' T') (s * s') := by
@@ -225,11 +227,16 @@ open scoped Classical Pointwise in
 `R(T'/s') ⊆ R(T/s)` then `R(T'/s')` has a presentation `R(T''/(s · r))` whose denominator is a
 multiple of `s` and whose numerators contain `t · r` for every `t ∈ T`.
 
-Those two conditions are exactly the *refinement* hypotheses under which a restriction map
-`A⟨T/s⟩ → A⟨T''/(s · r)⟩` exists, so this is the set-level input to the structure presheaf's
-restriction maps: it converts a containment of subsets, which is what a presheaf on a basis is
-indexed by, into the algebraic data the universal property of `A⟨T/s⟩` consumes. The witness is
-the intersection presentation, with cofactor `r = s'`.
+Those are the two *set-level* refinement inputs a restriction map `A⟨T/s⟩ → A⟨T''/(s · r)⟩` is
+built from: the denominator condition makes `s` invertible in the finer coordinate ring, and the
+numerator condition makes each `t/s` one of its distinguished fractions. **They are not by
+themselves enough to construct that map.** A presentation also carries the standing hypothesis
+`HasDenominatorPower` for the finer pair, which is an algebraic obligation about the ideal of
+definition and is not supplied here — nothing in this file mentions coordinate rings at all.
+
+So the role of this theorem is to convert a containment of subsets, which is what a presheaf on a
+basis is indexed by, into the two conditions the universal property of `A⟨T/s⟩` asks about the
+fractions. The witness is the product presentation, with cofactor `r = s'`.
 
 It is stated as an existential rather than with the witness spelled out because a consumer needs
 only that *some* refining presentation exists; which one is an artefact of the proof. -/
@@ -237,7 +244,7 @@ theorem exists_refinement_of_subset (Aplus : Subring A) (T T' : Finset A) (s s' 
     (h : rationalSubset Aplus T' s' ⊆ rationalSubset Aplus T s) :
     ∃ (T'' : Finset A) (r : A), rationalSubset Aplus T' s' = rationalSubset Aplus T'' (s * r)
       ∧ ∀ t ∈ T, t * r ∈ T'' :=
-  ⟨insert s T * insert s' T', s', rationalSubset_eq_inter_of_subset Aplus T T' s s' h,
+  ⟨insert s T * insert s' T', s', rationalSubset_eq_mul_insert_of_subset Aplus T T' s s' h,
     fun _ ht ↦ Finset.mul_mem_mul (Finset.mem_insert_of_mem ht) (Finset.mem_insert_self s' T')⟩
 
 /-- Generalization of the pointwise forward implication of Wedhorn Corollary 7.53 (which assumes

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -70,6 +70,12 @@ layer deferred above.
   relatively open in the subspace `spa A⁺`.
 * `TauCeti.ValuationSpectrum.rationalSubset_inter` : the intersection identity above — the
   set-level half of Remark 7.30(5).
+* `TauCeti.ValuationSpectrum.rationalSubset_eq_inter_of_subset` : a contained rational subset is
+  its own intersection with the larger one, hence re-presentable with the larger denominator as a
+  factor — the re-presentation step of Wedhorn §8.2.
+* `TauCeti.ValuationSpectrum.exists_refinement_of_subset` : that re-presentation packaged as the
+  *refinement* data a restriction map needs — from `R(T'/s') ⊆ R(T/s)`, a presentation
+  `R(T''/(s · r))` of the smaller subset with `t · r ∈ T''` for every `t ∈ T`.
 * `TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top` : a finite set
   generating the unit ideal gives a standard rational cover, the forward implication of
   Corollary 7.53.
@@ -194,6 +200,45 @@ theorem rationalSubset_inter (Aplus : Subring A) (T₁ T₂ : Finset A) (s₁ s�
       = rationalSubset Aplus (insert s₁ T₁ * insert s₂ T₂) (s₁ * s₂) := by
   rw [rationalSubset_def, rationalSubset_def, rationalSubset_def, ← basicOpenFinset_inter]
   exact (Set.inter_inter_distrib_left _ _ _).symm
+
+/-! ### Re-presenting a contained rational subset -/
+
+open scoped Classical Pointwise in
+/-- **A contained rational subset is its own intersection with the larger one**, so
+`rationalSubset_inter` re-presents it with the larger denominator as a factor:
+`R(T'/s') = R((U T' ∪-augmented product)/(s · s'))` where the numerators are `U₁U₂` for
+`U₁ = insert s T` and `U₂ = insert s' T'`.
+
+This is the re-presentation step of Wedhorn §8.2. Its point is the *denominator*: on the right
+`s` divides `s · s'`, so in a localisation presented by the right-hand pair the element `s`
+is invertible by construction, which is what a map out of the coordinate ring of `R(T/s)`
+needs. Nothing here is a statement about coordinate rings — see
+`exists_refinement_of_subset` for the packaged form those consume. -/
+theorem rationalSubset_eq_inter_of_subset (Aplus : Subring A) (T T' : Finset A) (s s' : A)
+    (h : rationalSubset Aplus T' s' ⊆ rationalSubset Aplus T s) :
+    rationalSubset Aplus T' s'
+      = rationalSubset Aplus (insert s T * insert s' T') (s * s') := by
+  rw [← rationalSubset_inter, Set.inter_eq_right.mpr h]
+
+open scoped Classical Pointwise in
+/-- **A containment of rational subsets yields a refining presentation of the smaller one.** If
+`R(T'/s') ⊆ R(T/s)` then `R(T'/s')` has a presentation `R(T''/(s · r))` whose denominator is a
+multiple of `s` and whose numerators contain `t · r` for every `t ∈ T`.
+
+Those two conditions are exactly the *refinement* hypotheses under which a restriction map
+`A⟨T/s⟩ → A⟨T''/(s · r)⟩` exists, so this is the set-level input to the structure presheaf's
+restriction maps: it converts a containment of subsets, which is what a presheaf on a basis is
+indexed by, into the algebraic data the universal property of `A⟨T/s⟩` consumes. The witness is
+the intersection presentation, with cofactor `r = s'`.
+
+It is stated as an existential rather than with the witness spelled out because a consumer needs
+only that *some* refining presentation exists; which one is an artefact of the proof. -/
+theorem exists_refinement_of_subset (Aplus : Subring A) (T T' : Finset A) (s s' : A)
+    (h : rationalSubset Aplus T' s' ⊆ rationalSubset Aplus T s) :
+    ∃ (T'' : Finset A) (r : A), rationalSubset Aplus T' s' = rationalSubset Aplus T'' (s * r)
+      ∧ ∀ t ∈ T, t * r ∈ T'' :=
+  ⟨insert s T * insert s' T', s', rationalSubset_eq_inter_of_subset Aplus T T' s s' h,
+    fun _ ht ↦ Finset.mul_mem_mul (Finset.mem_insert_of_mem ht) (Finset.mem_insert_self s' T')⟩
 
 /-- Generalization of the pointwise forward implication of Wedhorn Corollary 7.53 (which assumes
 a complete Hausdorff affinoid ring): for an arbitrary commutative ring `A` and subring `A⁺`, if `T`

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -70,14 +70,12 @@ layer deferred above.
   relatively open in the subspace `spa A⁺`.
 * `TauCeti.ValuationSpectrum.rationalSubset_inter` : the intersection identity above — the
   set-level half of Remark 7.30(5).
-* `TauCeti.ValuationSpectrum.rationalSubset_eq_mul_insert_of_subset` : a contained rational subset
-  is re-presented by the product pair, whose denominator has the containing denominator as a
-  factor — the re-presentation step of Wedhorn §8.2.
-* `TauCeti.ValuationSpectrum.exists_refinement_of_subset` : that re-presentation packaged as the
-  two *set-level* refinement inputs — from `R(T'/s') ⊆ R(T/s)`, a presentation `R(T''/(s · r))` of
-  the smaller subset with `t · r ∈ T''` for every `t ∈ T`. Constructing a restriction map needs one
-  further, algebraic input beyond these, the standing `HasDenominatorPower` hypothesis for the
-  finer pair, which this file does not supply.
+* `TauCeti.ValuationSpectrum.exists_refinement_of_subset` : the re-presentation step of Wedhorn
+  §8.2 — from `R(T'/s') ⊆ R(T/s)`, a presentation `R(T''/(s · s'))` of the smaller subset whose
+  denominator has each original denominator as a factor and whose numerators contain `t · s'` for
+  `t ∈ T` and `t' · s` for `t' ∈ T'`. Constructing a restriction map needs one further, algebraic
+  input beyond these, the standing `HasDenominatorPower` hypothesis for the new pair, which this
+  file does not supply.
 * `TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top` : a finite set
   generating the unit ideal gives a standard rational cover, the forward implication of
   Corollary 7.53.
@@ -206,46 +204,32 @@ theorem rationalSubset_inter (Aplus : Subring A) (T₁ T₂ : Finset A) (s₁ s�
 /-! ### Re-presenting a contained rational subset -/
 
 open scoped Classical Pointwise in
-/-- **A contained rational subset is re-presented by the product pair**, with numerators `U₁U₂` for
-`U₁ = insert s T` and `U₂ = insert s' T'` and denominator `s · s'`.
+/-- **A containment of rational subsets yields a presentation of the smaller one over the product
+denominator.** If `R(T'/s') ⊆ R(T/s)` then `R(T'/s')` has a presentation `R(T''/(s · s'))` whose
+numerators contain `t · s'` for every `t ∈ T` and `t' · s` for every `t' ∈ T'`.
 
-Its point is the *denominator*: on the right `s` divides `s · s'`, so in a localisation presented by
-the product pair the element `s` is invertible by construction. That is the re-presentation step of
-Wedhorn §8.2, and it is what a map out of the coordinate ring of `R(T/s)` needs.
+The denominator is the point: it is divisible by `s`, so in a localisation presented by this pair
+`s` is invertible by construction, and each numerator condition makes the fractions of one of the
+two original presentations distinguished fractions of the new one. Those are the *set-level* inputs
+a restriction map `A⟨T/s⟩ → A⟨T''/(s · s')⟩` is built from, and this is the re-presentation step of
+Wedhorn §8.2.
 
-The proof is the observation that a contained set is its own intersection with the containing one,
-after which `rationalSubset_inter` computes that intersection. Nothing here is a statement about
-coordinate rings — see `exists_refinement_of_subset` for the packaged form those consume. -/
-theorem rationalSubset_eq_mul_insert_of_subset (Aplus : Subring A) (T T' : Finset A) (s s' : A)
-    (h : rationalSubset Aplus T' s' ⊆ rationalSubset Aplus T s) :
-    rationalSubset Aplus T' s'
-      = rationalSubset Aplus (insert s T * insert s' T') (s * s') := by
-  rw [← rationalSubset_inter, Set.inter_eq_right.mpr h]
+**They are not by themselves enough to construct that map.** A presentation also carries the
+standing hypothesis `HasDenominatorPower` for the new pair, an algebraic obligation about the ideal
+of definition that this file does not supply — nothing here mentions coordinate rings at all.
 
-open scoped Classical Pointwise in
-/-- **A containment of rational subsets yields a refining presentation of the smaller one.** If
-`R(T'/s') ⊆ R(T/s)` then `R(T'/s')` has a presentation `R(T''/(s · r))` whose denominator is a
-multiple of `s` and whose numerators contain `t · r` for every `t ∈ T`.
-
-Those are the two *set-level* refinement inputs a restriction map `A⟨T/s⟩ → A⟨T''/(s · r)⟩` is
-built from: the denominator condition makes `s` invertible in the finer coordinate ring, and the
-numerator condition makes each `t/s` one of its distinguished fractions. **They are not by
-themselves enough to construct that map.** A presentation also carries the standing hypothesis
-`HasDenominatorPower` for the finer pair, which is an algebraic obligation about the ideal of
-definition and is not supplied here — nothing in this file mentions coordinate rings at all.
-
-So the role of this theorem is to convert a containment of subsets, which is what a presheaf on a
-basis is indexed by, into the two conditions the universal property of `A⟨T/s⟩` asks about the
-fractions. The witness is the product presentation, with cofactor `r = s'`.
-
-It is stated as an existential rather than with the witness spelled out because a consumer needs
-only that *some* refining presentation exists; which one is an artefact of the proof. -/
+Both numerator conditions are given rather than only the one for `T`, because discharging that
+standing hypothesis for a product denominator needs the fractions of *each* factor; a consumer
+holding one alone could not use it. -/
 theorem exists_refinement_of_subset (Aplus : Subring A) (T T' : Finset A) (s s' : A)
     (h : rationalSubset Aplus T' s' ⊆ rationalSubset Aplus T s) :
-    ∃ (T'' : Finset A) (r : A), rationalSubset Aplus T' s' = rationalSubset Aplus T'' (s * r)
-      ∧ ∀ t ∈ T, t * r ∈ T'' :=
-  ⟨insert s T * insert s' T', s', rationalSubset_eq_mul_insert_of_subset Aplus T T' s s' h,
-    fun _ ht ↦ Finset.mul_mem_mul (Finset.mem_insert_of_mem ht) (Finset.mem_insert_self s' T')⟩
+    ∃ T'' : Finset A, rationalSubset Aplus T' s' = rationalSubset Aplus T'' (s * s')
+      ∧ (∀ t ∈ T, t * s' ∈ T'') ∧ ∀ t' ∈ T', t' * s ∈ T'' :=
+  ⟨insert s T * insert s' T', by rw [← rationalSubset_inter, Set.inter_eq_right.mpr h],
+    fun _ ht ↦ Finset.mul_mem_mul (Finset.mem_insert_of_mem ht) (Finset.mem_insert_self s' T'),
+    fun t' ht' ↦ by
+      rw [mul_comm t' s]
+      exact Finset.mul_mem_mul (Finset.mem_insert_self s T) (Finset.mem_insert_of_mem ht')⟩
 
 /-- Generalization of the pointwise forward implication of Wedhorn Corollary 7.53 (which assumes
 a complete Hausdorff affinoid ring): for an arbitrary commutative ring `A` and subring `A⁺`, if `T`


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"rational-refining-presentation"}-->

Part of TauCetiProject/TauCetiRoadmap#174

A presheaf on the rational basis of `Spa(A, A⁺)` is indexed by *containments of subsets*, but the
universal property of the coordinate ring `A⟨T/s⟩` is fed *algebraic data*: `s` invertible and each
`t/s` power-bounded. This PR supplies the set-level step that converts the first into the second.

The observation is that a contained rational subset is its own intersection with the larger one, so
`rationalSubset_inter` (already on `main`) re-presents it — and the re-presentation's denominator is
a **product**:

```text
R(T'/s') ⊆ R(T/s)  ⟹  R(T'/s') = R((U₁U₂)/(s · s')),   U₁ = insert s T,  U₂ = insert s' T'.
```

That denominator is the whole point. On the right `s` divides `s · s'`, so in a localisation
presented by the right-hand pair `s` is invertible **by construction** — no adic Nullstellensatz
required. And each `t · s'`, for `t ∈ T`, is among the numerators `U₁U₂`, so each `t/s` is a
*distinguished* fraction of the new presentation and therefore power-bounded for free.

This is the re-presentation step of Wedhorn §8.2.

## What is added

One declaration, in `TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean`, in a new
section placed immediately after `rationalSubset_inter`, the identity it consumes:

* `exists_refinement_of_subset` — from `R(T'/s') ⊆ R(T/s)`, a presentation `R(T''/(s · s'))` of the
  smaller subset, together with **both** numerator conditions: `t · s' ∈ T''` for every `t ∈ T` and
  `t' · s ∈ T''` for every `t' ∈ T'`. The witness is the product pair `insert s T * insert s' T'`.

Both numerator conditions are given, not just the one for `T`, because discharging the standing
`HasDenominatorPower` hypothesis for a *product* denominator needs the fractions of each factor —
one alone is unusable, so an existential returning only one would not serve its own stated purpose.

An earlier revision split this across two declarations, with the set equality named separately. The
`reuse` rubric was right that the separate name was a containment-specialised restatement of
`rationalSubset_inter` whose proof was one line, so it is inlined here. That also settled a genuine
contradiction on the same board, where `naming` wanted that declaration renamed while `reuse` wanted
it deleted — deleting satisfies both.

## Relationship to #3625 — not stacked

This PR branches off `origin/main` and touches one file, disjoint from #3625's two. The two halves
can merge in either order: this one is pure set-level `Spa` content with no Huber imports, and
#3625 is pure `RingTheory` content with no `Spa` imports. Joining them — the theorem that a
containment of rational subsets gives a restriction map — is the follow-up, and it additionally
needs `HasDenominatorPower` for the intersection presentation, which is a separate obligation
neither PR discharges.

## Provenance

Not a port. AINTLIB (`dev/adic-spaces`, `37bbdaeb`, `projects/AdicSpaces/Adic spaces/Presheaf.lean`)
does **not** re-present the contained subset: it goes from the containment straight to unitness by a
prime-ideal argument (`mem_prime_of_rational_subset`, then `Ideal.mem_radical_iff` to get that `s`
divides a power of `s'`), and then *assumes* power-boundedness as the class field
`HasLocLiftPowerBounded.locLift_divByS_isPowerBounded` — blocked on the adic Nullstellensatz
(Wedhorn Proposition 7.14), which it records as an open ticket. The re-presentation route taken here
is what makes power-boundedness free instead of assumed, so there was nothing at this granularity
to port.

## References

* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), §8.2, and Remark 7.30(5) for the
  intersection identity this builds on.
* [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
  commit `37bbdaeb`, Apache 2.0 — consulted, different route, nothing ported.
