### PR TITLE
feat: prove multiply-laced root subgroup relations

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/MultiplyLacedRelations.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/MultiplyLacedRelations.lean
@@ -10,8 +10,8 @@ public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Cheva
 /-!
 # Multiply-laced Chevalley relations for represented Kostant root subgroups
 
-For roots `α` and `β` in types `B`, `C`, or `F₄`, the positive part of their rank-two root
-string can contain both `α + β` and `2α + β`. The corresponding Kostant root subgroups satisfy
+For roots `α` and `β` whose positive rank-two root string contains both `α + β` and `2α + β`,
+this file proves, under the displayed bracket and nilpotence hypotheses, the conditional relation
 
 ```text
 ⁅x_α(t), x_β(u)⁆ = x_{α+β}(c t u) x_{2α+β}(d t² u).
@@ -89,14 +89,17 @@ theorem commutatorElement_kostantRootSubgroupPoints_of_lie_lie_eq
         kostantRootSubgroupPoints e h ρ M hM j hj g⁆ =
       kostantRootSubgroupPoints e h ρ M hM k hk p *
         kostantRootSubgroupPoints e h ρ M hM l hl q := by
-  rw [commutatorElement_def,
+  have hconj :=
     kostantRootSubgroupPoints_conj_of_lie_lie_eq e h ρ M hM hij hiij hil hjk hkl
-      hi hj hk hl f g p q hp hq]
+      hi hj hk hl f g p q hp hq
+  change MulAut.conj (kostantRootSubgroupPoints e h ρ M hM i hi f)
+      (kostantRootSubgroupPoints e h ρ M hM j hj g) = _ at hconj
+  rw [conj_eq_commutatorElement_mul] at hconj
   have hcomm :=
     (commute_kostantRootSubgroupPoints e h ρ M hM hjk hj hk g p).mul_right
       (commute_kostantRootSubgroupPoints e h ρ M hM hjl hj hl g q)
-  conv_lhs => lhs; rw [mul_assoc]
-  rw [hcomm.eq, mul_assoc, mul_inv_cancel, mul_one]
+  rw [mul_assoc, hcomm.eq] at hconj
+  exact mul_right_cancel hconj
 
 /-- The multiply-laced Chevalley commutator relation with the two output points written out at
 parameters `c t u` and `d t² u`. -/

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/MultiplyLacedRelations.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/MultiplyLacedRelations.lean
@@ -92,8 +92,7 @@ theorem commutatorElement_kostantRootSubgroupPoints_of_lie_lie_eq
   have hconj :=
     kostantRootSubgroupPoints_conj_of_lie_lie_eq e h ρ M hM hij hiij hil hjk hkl
       hi hj hk hl f g p q hp hq
-  change MulAut.conj (kostantRootSubgroupPoints e h ρ M hM i hi f)
-      (kostantRootSubgroupPoints e h ρ M hM j hj g) = _ at hconj
+  rw [← MulAut.conj_apply] at hconj
   rw [conj_eq_commutatorElement_mul] at hconj
   have hcomm :=
     (commute_kostantRootSubgroupPoints e h ρ M hM hjk hj hk g p).mul_right

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/MultiplyLacedRelations.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/MultiplyLacedRelations.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.ChevalleyRelations
+
+/-!
+# Multiply-laced Chevalley relations for represented Kostant root subgroups
+
+For roots `α` and `β` in types `B`, `C`, or `F₄`, the positive part of their rank-two root
+string can contain both `α + β` and `2α + β`. The corresponding Kostant root subgroups satisfy
+
+```text
+⁅x_α(t), x_β(u)⁆ = x_{α+β}(c t u) x_{2α+β}(d t² u).
+```
+
+`Commutator.lean` proves the underlying multiplication and conjugation identities for the
+divided-power actions. This file derives the canonical element-commutator form and transports it
+through an arbitrary finite integral basis to the represented general linear group. The
+scheme-valued form is in `RootSubgroup/Scheme/MultiplyLacedRelations.lean`.
+
+The extra hypothesis that the `β` root vector commutes with the `2α + β` root vector is exactly
+what removes the conjugated `β` factor from the element commutator. It holds for the indicated root
+string because `2α + 2β` is not a root.
+
+## Main declarations
+
+* `TauCeti.UniversalEnvelopingAlgebra.
+  commutatorElement_kostantRootSubgroupPoints_of_lie_lie_eq`: the multiply-laced relation for
+  divided-power root-subgroup actions.
+* `TauCeti.UniversalEnvelopingAlgebra.
+  commutatorElement_kostantRootSubgroupMatrix_of_lie_lie_eq`: the same relation in an arbitrary
+  finite integral basis.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, Theorem 5.2.2.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Sections 26--27.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+open TensorProduct WithConv
+open scoped commutatorElement
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe u v w
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {I : Type w} {κ : Type*}
+variable {V : Type v} [AddCommGroup V] [Module ℚ V]
+
+variable (e : I → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+
+-- Match tensor products to the `ℤ`-algebra structure used by scalar extension.
+attribute [local instance high] Algebra.toModule
+
+variable {A : Type*} [CommRing A]
+
+/-- **The multiply-laced Chevalley commutator relation for Kostant root-subgroup actions.**
+Suppose the distinguished root vectors form the chain `β`, `α + β`, `2α + β`, with the
+first and second iterated brackets scaled by `c` and `2 * d`. If `p` and `q` have parameters
+`c t u` and `d t² u`, then `⁅xᵢ(t), xⱼ(u)⁆ = xₖ(p) xₗ(q)`. -/
+theorem commutatorElement_kostantRootSubgroupPoints_of_lie_lie_eq
+    {i j k l : I} {c d : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hiij : ⁅e i, ⁅e i, e j⁆⁆ = (2 * d) • e l)
+    (hil : ⁅e i, e l⁆ = 0) (hjk : ⁅e j, e k⁆ = 0) (hjl : ⁅e j, e l⁆ = 0)
+    (hkl : ⁅e k, e l⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (hl : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e l))))
+    (f g p q : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A))
+    (hp : Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) p) =
+      (c : A) * (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) *
+        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g)))
+    (hq : Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) q) =
+      (d : A) * (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) ^ 2 *
+        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))) :
+    ⁅kostantRootSubgroupPoints e h ρ M hM i hi f,
+        kostantRootSubgroupPoints e h ρ M hM j hj g⁆ =
+      kostantRootSubgroupPoints e h ρ M hM k hk p *
+        kostantRootSubgroupPoints e h ρ M hM l hl q := by
+  rw [commutatorElement_def,
+    kostantRootSubgroupPoints_conj_of_lie_lie_eq e h ρ M hM hij hiij hil hjk hkl
+      hi hj hk hl f g p q hp hq]
+  have hcomm :=
+    (commute_kostantRootSubgroupPoints e h ρ M hM hjk hj hk g p).mul_right
+      (commute_kostantRootSubgroupPoints e h ρ M hM hjl hj hl g q)
+  conv_lhs => lhs; rw [mul_assoc]
+  rw [hcomm.eq, mul_assoc, mul_inv_cancel, mul_one]
+
+/-- The multiply-laced Chevalley commutator relation with the two output points written out at
+parameters `c t u` and `d t² u`. -/
+theorem commutatorElement_kostantRootSubgroupPoints_of_lie_lie_eq'
+    {i j k l : I} {c d : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hiij : ⁅e i, ⁅e i, e j⁆⁆ = (2 * d) • e l)
+    (hil : ⁅e i, e l⁆ = 0) (hjk : ⁅e j, e k⁆ = 0) (hjl : ⁅e j, e l⁆ = 0)
+    (hkl : ⁅e k, e l⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (hl : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e l))))
+    (f g : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    ⁅kostantRootSubgroupPoints e h ρ M hM i hi f,
+        kostantRootSubgroupPoints e h ρ M hM j hj g⁆ =
+      kostantRootSubgroupPoints e h ρ M hM k hk
+          ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+            (Multiplicative.ofAdd ((c : A) *
+              (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) *
+                Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))))) *
+        kostantRootSubgroupPoints e h ρ M hM l hl
+          ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+            (Multiplicative.ofAdd ((d : A) *
+              (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) ^ 2 *
+                Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))))) :=
+  commutatorElement_kostantRootSubgroupPoints_of_lie_lie_eq e h ρ M hM
+    hij hiij hil hjk hjl hkl hi hj hk hl f g _ _
+      (congrArg Multiplicative.toAdd
+        ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).apply_symm_apply _))
+      (congrArg Multiplicative.toAdd
+        ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).apply_symm_apply _))
+
+section Matrices
+
+variable {η : Type*} [Fintype η] [DecidableEq η] (b : Module.Basis η ℤ M)
+
+/-- **The multiply-laced Chevalley commutator relation in an integral basis.** The matrix
+commutator of the first two represented root subgroups is the product of the next two root
+subgroups, at parameters `c t u` and `d t² u`. -/
+theorem commutatorElement_kostantRootSubgroupMatrix_of_lie_lie_eq
+    {i j k l : I} {c d : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hiij : ⁅e i, ⁅e i, e j⁆⁆ = (2 * d) • e l)
+    (hil : ⁅e i, e l⁆ = 0) (hjk : ⁅e j, e k⁆ = 0) (hjl : ⁅e j, e l⁆ = 0)
+    (hkl : ⁅e k, e l⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (hl : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e l))))
+    (f g p q : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A))
+    (hp : Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) p) =
+      (c : A) * (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) *
+        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g)))
+    (hq : Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) q) =
+      (d : A) * (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) ^ 2 *
+        Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))) :
+    ⁅kostantRootSubgroupMatrix e h ρ M hM i hi b f,
+        kostantRootSubgroupMatrix e h ρ M hM j hj b g⁆ =
+      kostantRootSubgroupMatrix e h ρ M hM k hk b p *
+        kostantRootSubgroupMatrix e h ρ M hM l hl b q := by
+  rw [kostantRootSubgroupMatrix_def, kostantRootSubgroupMatrix_def,
+    kostantRootSubgroupMatrix_def, kostantRootSubgroupMatrix_def]
+  simpa only [MonoidHom.comp_apply, map_commutatorElement, map_mul] using
+    congrArg (Units.map (LinearMap.toMatrixAlgEquiv (b.baseChange A)).toMonoidHom)
+      (commutatorElement_kostantRootSubgroupPoints_of_lie_lie_eq e h ρ M hM
+        hij hiij hil hjk hjl hkl hi hj hk hl f g p q hp hq)
+
+/-- The multiply-laced matrix commutator relation with both output points written out. -/
+theorem commutatorElement_kostantRootSubgroupMatrix_of_lie_lie_eq'
+    {i j k l : I} {c d : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hiij : ⁅e i, ⁅e i, e j⁆⁆ = (2 * d) • e l)
+    (hil : ⁅e i, e l⁆ = 0) (hjk : ⁅e j, e k⁆ = 0) (hjl : ⁅e j, e l⁆ = 0)
+    (hkl : ⁅e k, e l⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (hl : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e l))))
+    (f g : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    ⁅kostantRootSubgroupMatrix e h ρ M hM i hi b f,
+        kostantRootSubgroupMatrix e h ρ M hM j hj b g⁆ =
+      kostantRootSubgroupMatrix e h ρ M hM k hk b
+          ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+            (Multiplicative.ofAdd ((c : A) *
+              (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) *
+                Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))))) *
+        kostantRootSubgroupMatrix e h ρ M hM l hl b
+          ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+            (Multiplicative.ofAdd ((d : A) *
+              (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) f) ^ 2 *
+                Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A) g))))) :=
+  commutatorElement_kostantRootSubgroupMatrix_of_lie_lie_eq e h ρ M hM b
+    hij hiij hil hjk hjl hkl hi hj hk hl f g _ _
+      (congrArg Multiplicative.toAdd
+        ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).apply_symm_apply _))
+      (congrArg Multiplicative.toAdd
+        ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).apply_symm_apply _))
+
+end Matrices
+
+end TauCeti.UniversalEnvelopingAlgebra

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/MultiplyLacedRelations.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/MultiplyLacedRelations.lean
@@ -11,9 +11,9 @@ public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Schem
 /-!
 # Multiply-laced Chevalley relations for Kostant root-subgroup scheme morphisms
 
-This file proves the `B`, `C`, and `F₄` Chevalley commutator relation on scheme-valued points of
-the represented root-subgroup morphisms `xᵢ : 𝔾ₐ → GLₙ`. For the root string
-`β`, `α + β`, `2α + β`, the relation is
+This file transports a conditional multiply-laced Chevalley commutator relation to scheme-valued
+points of the represented root-subgroup morphisms `xᵢ : 𝔾ₐ → GLₙ`. Under the stated bracket and
+nilpotence hypotheses for the chain `β`, `α + β`, `2α + β`, the relation is
 
 ```text
 ⁅x_α(t), x_β(u)⁆ = x_{α+β}(c t u) x_{2α+β}(d t² u).

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/MultiplyLacedRelations.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/MultiplyLacedRelations.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.MultiplyLacedRelations
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.Basic
+
+/-!
+# Multiply-laced Chevalley relations for Kostant root-subgroup scheme morphisms
+
+This file proves the `B`, `C`, and `F₄` Chevalley commutator relation on scheme-valued points of
+the represented root-subgroup morphisms `xᵢ : 𝔾ₐ → GLₙ`. For the root string
+`β`, `α + β`, `2α + β`, the relation is
+
+```text
+⁅x_α(t), x_β(u)⁆ = x_{α+β}(c t u) x_{2α+β}(d t² u).
+```
+
+It transports the matrix relation from `RootSubgroup/MultiplyLacedRelations.lean` through the
+point-comparison theorem for the actual affine group-scheme morphisms. Thus the equation is stated
+at the same interface used by the generated Chevalley--Demazure carrier.
+
+## Main declarations
+
+* `TauCeti.UniversalEnvelopingAlgebra.
+  commutatorElement_schemePointsMulEquiv_kostantRootSubgroup_of_lie_lie_eq`: the multiply-laced
+  relation for scheme-valued points.
+* `TauCeti.UniversalEnvelopingAlgebra.
+  commutatorElement_schemePointsMulEquiv_kostantRootSubgroup_of_lie_lie_eq'`: the same relation
+  with both output points written out.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, Theorem 5.2.2.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Sections 26--27.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory TensorProduct WithConv
+open scoped CategoryTheory.MonObj commutatorElement
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+universe u w
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {I : Type w} {κ : Type*}
+variable {V : Type} [AddCommGroup V] [Module ℚ V]
+
+variable (e : I → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+
+-- Match tensor products to the `ℤ`-algebra structure used by scalar extension.
+attribute [local instance high] Algebra.toModule
+
+variable {n : ℕ} (b : Module.Basis (Fin n) ℤ M)
+variable (A : Type) [CommRing A]
+
+/-- **The multiply-laced Chevalley commutator relation on scheme-valued points.** Suppose the
+distinguished root vectors form the chain `β`, `α + β`, `2α + β`, and let `r` and `s` carry
+parameters `c t u` and `d t² u`. Then the commutator of the represented `i`- and `j`-root values
+is the product of the represented `k`- and `l`-root values. -/
+theorem commutatorElement_schemePointsMulEquiv_kostantRootSubgroup_of_lie_lie_eq
+    {i j k l : I} {c d : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hiij : ⁅e i, ⁅e i, e j⁆⁆ = (2 * d) • e l)
+    (hil : ⁅e i, e l⁆ = 0) (hjk : ⁅e j, e k⁆ = 0) (hjl : ⁅e j, e l⁆ = 0)
+    (hkl : ⁅e k, e l⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (hl : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e l))))
+    (p q r s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (AdditiveGroup.groupScheme ℤ).X)
+    (hr : Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A r) =
+      (c : A) * (Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A p) *
+        Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A q)))
+    (hs : Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A s) =
+      (d : A) * (Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A p) ^ 2 *
+        Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A q))) :
+    ⁅GeneralLinear.schemePointsMulEquiv n A
+        (p ≫ (kostantRootSubgroup e h ρ M hM i hi b).hom.hom),
+      GeneralLinear.schemePointsMulEquiv n A
+        (q ≫ (kostantRootSubgroup e h ρ M hM j hj b).hom.hom)⁆ =
+      GeneralLinear.schemePointsMulEquiv n A
+          (r ≫ (kostantRootSubgroup e h ρ M hM k hk b).hom.hom) *
+        GeneralLinear.schemePointsMulEquiv n A
+          (s ≫ (kostantRootSubgroup e h ρ M hM l hl b).hom.hom) := by
+  rw [schemePointsMulEquiv_kostantRootSubgroup,
+    schemePointsMulEquiv_kostantRootSubgroup,
+    schemePointsMulEquiv_kostantRootSubgroup,
+    schemePointsMulEquiv_kostantRootSubgroup]
+  apply commutatorElement_kostantRootSubgroupMatrix_of_lie_lie_eq
+    e h ρ M hM b hij hiij hil hjk hjl hkl hi hj hk hl
+  · simpa only [AdditiveGroup.schemePointsMulEquiv_apply] using hr
+  · simpa only [AdditiveGroup.schemePointsMulEquiv_apply] using hs
+
+/-- The multiply-laced Chevalley commutator relation on scheme-valued points with both output
+points written out at parameters `c t u` and `d t² u`. -/
+theorem commutatorElement_schemePointsMulEquiv_kostantRootSubgroup_of_lie_lie_eq'
+    {i j k l : I} {c d : ℤ}
+    (hij : ⁅e i, e j⁆ = c • e k) (hiij : ⁅e i, ⁅e i, e j⁆⁆ = (2 * d) • e l)
+    (hil : ⁅e i, e l⁆ = 0) (hjk : ⁅e j, e k⁆ = 0) (hjl : ⁅e j, e l⁆ = 0)
+    (hkl : ⁅e k, e l⁆ = 0)
+    (hi : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+    (hj : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e j))))
+    (hk : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e k))))
+    (hl : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e l))))
+    (p q : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (AdditiveGroup.groupScheme ℤ).X) :
+    ⁅GeneralLinear.schemePointsMulEquiv n A
+        (p ≫ (kostantRootSubgroup e h ρ M hM i hi b).hom.hom),
+      GeneralLinear.schemePointsMulEquiv n A
+        (q ≫ (kostantRootSubgroup e h ρ M hM j hj b).hom.hom)⁆ =
+      GeneralLinear.schemePointsMulEquiv n A
+          ((AdditiveGroup.schemePointsMulEquiv A).symm
+              (Multiplicative.ofAdd ((c : A) *
+                (Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A p) *
+                  Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A q)))) ≫
+            (kostantRootSubgroup e h ρ M hM k hk b).hom.hom) *
+        GeneralLinear.schemePointsMulEquiv n A
+          ((AdditiveGroup.schemePointsMulEquiv A).symm
+              (Multiplicative.ofAdd ((d : A) *
+                (Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A p) ^ 2 *
+                  Multiplicative.toAdd (AdditiveGroup.schemePointsMulEquiv A q)))) ≫
+            (kostantRootSubgroup e h ρ M hM l hl b).hom.hom) :=
+  commutatorElement_schemePointsMulEquiv_kostantRootSubgroup_of_lie_lie_eq
+    e h ρ M hM b A hij hiij hil hjk hjl hkl hi hj hk hl p q _ _
+      (congrArg Multiplicative.toAdd
+        ((AdditiveGroup.schemePointsMulEquiv A).apply_symm_apply _))
+      (congrArg Multiplicative.toAdd
+        ((AdditiveGroup.schemePointsMulEquiv A).apply_symm_apply _))
+
+end TauCeti.UniversalEnvelopingAlgebra


### PR DESCRIPTION
This PR proves the multiply-laced Chevalley commutator relation through the represented affine group-scheme interface, advancing `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9 milestone “Root subgroup maps”: construct `x_α : 𝔾_a → G` together with the Chevalley commutator relations they satisfy. For a root string `β`, `α + β`, `2α + β`, it derives `⁅x_α(t), x_β(u)⁆ = x_{α+β}(c t u) x_{2α+β}(d t² u)` from the existing divided-power conjugation formula and transports it first to matrices in an arbitrary integral basis and then to scheme-valued points of the actual root-subgroup morphisms.

The preferred `CFSGStatement` roadmap has no viable direct unclaimed step on current `main`: I0 and S0/S1 are complete, `classificationStatement_of_zero` is in flight in #3058, and L0 explicitly depends on ReductiveGroups Layer 9. This is the most effective available prerequisite because the underlying `B/C/F₄` root-string multiplication relation and the point-to-matrix and scheme-point comparison maps are merged, but the canonical commutator equation at the represented scheme interface was still missing; the in-flight #3631 treats only the class-two relation, while #3584 and #3609 treat the distinct G₂ string.

The new point theorem states the additional vanishing bracket needed to commute the `β` factor past the `2α + β` factor instead of hiding it in the proof. Its matrix theorem uses `map_commutatorElement` and the existing coordinate representation, and its scheme theorem uses `schemePointsMulEquiv_kostantRootSubgroup`; no root-action formula is rederived. This follows Carter, *Simple Groups of Lie Type*, Theorem 5.2.2, Humphreys, *Introduction to Lie Algebras and Representation Theory*, §§26–27, and Jantzen, *Representations of Algebraic Groups*, II.1, as credited in both module docstrings. No Mathlib infrastructure or external formalization is vendored.

The dependency edge is `CFSGStatement` milestone L0, “pinned ambient groups”: `ValidLieTypeIndex.simpleRootSubgroup` and the eventual pinned Chevalley–Demazure carrier consume Layer 9’s root-subgroup maps and their Chevalley relations. After this PR, the Layer 9 root-subgroup milestone still needs the G₂ long-string relation transported through the represented scheme interface and the multiply-laced/G₂ relations descended into the generated carrier; Layer 9 as a whole still needs the pinned group-scheme assembly, pinning-compatible base change, the pinned isomorphism theorem, full algebraically closed points identification, and the characteristic-two/three special isogenies.

Add `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/MultiplyLacedRelations.lean` (198 lines) and `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/MultiplyLacedRelations.lean` (140 lines).

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"kostant-multiply-laced-scheme-relations"}-->

🤖 Prepared with Codex
