### PR TITLE
feat: package rational localisation comparisons

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
@@ -173,33 +173,6 @@ theorem completionLocObjHom_hom [IsTopologicalRing A]
   intro g hg
   rfl
 
-/-- Packaging the identity ring homomorphism gives the identity morphism.
-
-This is the special case of `completionLocObjHom_eq_id` where the compatibility hypothesis holds
-definitionally, so it is deliberately not a `simp` lemma: `simp` already closes it using the
-general statement. -/
-theorem completionLocObjHom_id [IsTopologicalRing A]
-    (P : PairOfDefinition A) (T : Finset A) (s : A)
-    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
-    (hden : HasDenominatorPower P T s S) :
-    letI := locUniformSpace P T s S hden
-    letI := isUniformAddGroup_locUniformSpace P T s S hden
-    letI := isTopologicalRing_locUniformSpace P T s S hden
-    completionLocObjHom P T s S hden T s S hden (RingHom.id _) continuous_id =
-      𝟙 (completionLocObj P T s S hden) := by
-  let _ := locUniformSpace P T s S hden
-  let _ := isUniformAddGroup_locUniformSpace P T s S hden
-  let _ := isTopologicalRing_locUniformSpace P T s S hden
-  apply InducedCategory.hom_ext
-  rw [completionLocObjHom_hom]
-  have hG : (⟨RingHom.id (UniformSpace.Completion S), continuous_id⟩ :
-      TopCommRingCat.of (UniformSpace.Completion S) ⟶
-        TopCommRingCat.of (UniformSpace.Completion S)) =
-      𝟙 (TopCommRingCat.of (UniformSpace.Completion S)) := by
-    rfl
-  rw [hG]
-  simp
-
 /-- Packaging a composite of continuous ring homomorphisms gives the categorical composite of
 their packaged morphisms. -/
 @[simp]
@@ -245,6 +218,8 @@ theorem completionLocObjHom_comp [IsTopologicalRing A]
       TopCommRingCat.of (UniformSpace.Completion S') := ⟨g, hg⟩
   let H : TopCommRingCat.of (UniformSpace.Completion S') ⟶
       TopCommRingCat.of (UniformSpace.Completion S'') := ⟨h, hh⟩
+  -- The public object equation is the only way to expose the transports surrounding `G` and `H`;
+  -- `completionLocObj` itself is deliberately not exposed.
   change eqToHom _ ≫ (G ≫ H) ≫ eqToHom _ =
     (eqToHom _ ≫ G ≫ eqToHom _) ≫ eqToHom _ ≫ H ≫ eqToHom _
   simp [Category.assoc]
@@ -278,6 +253,25 @@ theorem completionLocObjHom_eq_id [IsTopologicalRing A]
     exact hg_id
   rw [hG]
   simp
+
+/-- Packaging the identity ring homomorphism gives the identity morphism.
+
+This is the special case of `completionLocObjHom_eq_id` where the compatibility hypothesis holds
+definitionally, so it is deliberately not a `simp` lemma: `simp` already closes it using the
+general statement. -/
+theorem completionLocObjHom_id [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    completionLocObjHom P T s S hden T s S hden (RingHom.id _) continuous_id =
+      𝟙 (completionLocObj P T s S hden) := by
+  let _ := locUniformSpace P T s S hden
+  let _ := isUniformAddGroup_locUniformSpace P T s S hden
+  let _ := isTopologicalRing_locUniformSpace P T s S hden
+  exact completionLocObjHom_eq_id P T s S hden (RingHom.id _) continuous_id rfl
 
 /-- Comparison morphisms compatible with the structure maps from `A` compose categorically.
 This is the cocycle law for presentationwise objects in `CompleteSeparatedTopCommRingCat`. -/

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
@@ -4,21 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.RingTheory.Huber.LocalizationTopology.Completion
+public import TauCeti.RingTheory.Huber.LocalizationTopology.Presentation
 public import TauCeti.Topology.Category.TopCommRingCat.CompleteSeparated.Basic
 
 /-!
 # `A⟨T/s⟩` is a complete separated topological ring
 
-The adic structure presheaf (roadmap Layer 3.3) is to assign `A⟨T/s⟩` to the rational subset
+The adic structure presheaf (roadmap Layer 3.3) assigns `A⟨T/s⟩` to the rational subset
 `R(T/s)`, and its values are required to be *complete separated* topological rings (*Adic Spaces*,
-arXiv:1910.05934v1, §8.1–§8.2). This module supplies the codomain fact that assignment will need:
-it exhibits `A⟨T/s⟩` as an object of `CompleteSeparatedTopCommRingCat`.
+arXiv:1910.05934v1, §8.1–§8.2). This module supplies the categorical packaging that assignment
+needs: it exhibits `A⟨T/s⟩` as an object of `CompleteSeparatedTopCommRingCat`, lifts continuous
+comparison maps to morphisms, and packages mutually compatible comparisons as isomorphisms.
 
-No presheaf exists yet, and what is built here is not one of its values but a *presentationwise*
-object: it depends on the data `(T, s, S, hden)` presenting the localization, not only on the
-subset `R(T/s)`. Showing that different presentations of the same rational subset give isomorphic
-objects, and constructing the restriction maps, are both later work.
+No presheaf exists yet, and the objects here remain *presentationwise*: they depend on the data
+`(T, s, S, hden)` presenting the localisation, not only on the subset `R(T/s)`. The isomorphism
+constructed here is conditional on compatible comparison maps in both directions. Producing those
+maps from equality of rational subsets, and constructing restriction maps from containments, are
+separate steps.
 
 Nothing here is deep — `A⟨T/s⟩` is a separated completion, so it is complete and Hausdorff for its
 own uniformity, and `CompleteSeparatedTopCommRingCat.of` bundles exactly that. What the module
@@ -31,11 +33,18 @@ every use. The definition below carries it once.
 
 * `TauCeti.Huber.PairOfDefinition.completionLocObj` : `A⟨T/s⟩` as an object of
   `CompleteSeparatedTopCommRingCat`, presentationwise in `(T, s, S, hden)`.
+* `TauCeti.Huber.PairOfDefinition.completionLocObjHom` : a continuous comparison map as a
+  morphism between presentationwise objects.
+* `TauCeti.Huber.PairOfDefinition.completionLocObjIso` : compatible comparisons in both
+  directions as an isomorphism of complete separated topological rings.
 
 ## Main results
 
 * `TauCeti.Huber.PairOfDefinition.completionLocObj_obj` : the underlying `TopCommRingCat` of that
   object is `UniformSpace.Completion S` with the topology `locUniformSpace` induces.
+* `TauCeti.Huber.PairOfDefinition.completionLocObjHom_eq_id` and
+  `TauCeti.Huber.PairOfDefinition.completionLocObjHom_eq_comp` : identity and composition for
+  comparison morphisms compatible with the structure maps from `A`.
 
 ## Provenance
 
@@ -55,11 +64,13 @@ there was nothing at this granularity to port.
 
 namespace TauCeti.Huber
 
-open TauCeti.TopCommRingCat
+open CategoryTheory TauCeti.TopCommRingCat
 
 public section
 
-variable {A : Type*} [CommRing A] [TopologicalSpace A]
+universe u v
+
+variable {A : Type v} [CommRing A] [TopologicalSpace A]
 
 namespace PairOfDefinition
 
@@ -75,7 +86,7 @@ on `R(T/s)`, and the restriction maps are later work.
 `completionLocObj_obj` identifies the underlying object; the body is not exported, so that is how
 a consumer computes with it. -/
 noncomputable def completionLocObj [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A)
-    (s : A) (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (s : A) (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     (hden : HasDenominatorPower P T s S) : CompleteSeparatedTopCommRingCat :=
   letI := locUniformSpace P T s S hden
   letI := isUniformAddGroup_locUniformSpace P T s S hden
@@ -86,7 +97,7 @@ noncomputable def completionLocObj [IsTopologicalRing A] (P : PairOfDefinition A
 `Aₛ` for the uniformity `locUniformSpace`. -/
 @[simp]
 theorem completionLocObj_obj [IsTopologicalRing A] (P : PairOfDefinition A) (T : Finset A) (s : A)
-    (S : Type*) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
     (hden : HasDenominatorPower P T s S) :
     letI := locUniformSpace P T s S hden
     letI := isUniformAddGroup_locUniformSpace P T s S hden
@@ -96,6 +107,273 @@ theorem completionLocObj_obj [IsTopologicalRing A] (P : PairOfDefinition A) (T :
   let _ := isUniformAddGroup_locUniformSpace P T s S hden
   let _ := isTopologicalRing_locUniformSpace P T s S hden
   exact CompleteSeparatedTopCommRingCat.of_obj _
+
+/-! ### Comparison morphisms between presentationwise objects -/
+
+/-- A continuous ring homomorphism between two completed localisations, as a morphism between
+their presentationwise objects in `CompleteSeparatedTopCommRingCat`.
+
+No compatibility with the structure maps from `A` is required merely to form the morphism. That
+compatibility is used by `completionLocObjHom_eq_id`, `completionLocObjHom_eq_comp`, and
+`completionLocObjIso`. -/
+noncomputable def completionLocObjHom [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (T' : Finset A) (s' : A)
+    (S' : Type u) [CommRing S'] [Algebra A S'] [IsLocalization.Away s' S']
+    (hden' : HasDenominatorPower P T' s' S') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s' S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s' S' hden'
+    (g : UniformSpace.Completion S →+* UniformSpace.Completion S') → Continuous g →
+      (completionLocObj P T s S hden ⟶ completionLocObj P T' s' S' hden') := by
+  let _ := locUniformSpace P T s S hden
+  let _ := isUniformAddGroup_locUniformSpace P T s S hden
+  let _ := isTopologicalRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s' S' hden'
+  let _ := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+  let _ := isTopologicalRing_locUniformSpace P T' s' S' hden'
+  intro g hg
+  exact InducedCategory.homMk
+    (eqToHom (completionLocObj_obj P T s S hden) ≫
+      (⟨g, hg⟩ : TopCommRingCat.of (UniformSpace.Completion S) ⟶
+        TopCommRingCat.of (UniformSpace.Completion S')) ≫
+      eqToHom (completionLocObj_obj P T' s' S' hden').symm)
+
+/-- The underlying morphism of `completionLocObjHom` is the given ring homomorphism, transported
+across `completionLocObj_obj` at its source and target. -/
+@[simp]
+theorem completionLocObjHom_hom [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (T' : Finset A) (s' : A)
+    (S' : Type u) [CommRing S'] [Algebra A S'] [IsLocalization.Away s' S']
+    (hden' : HasDenominatorPower P T' s' S') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s' S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s' S' hden'
+    ∀ (g : UniformSpace.Completion S →+* UniformSpace.Completion S') (hg : Continuous g),
+      (completionLocObjHom P T s S hden T' s' S' hden' g hg).hom =
+        eqToHom (completionLocObj_obj P T s S hden) ≫
+          (⟨g, hg⟩ : TopCommRingCat.of (UniformSpace.Completion S) ⟶
+            TopCommRingCat.of (UniformSpace.Completion S')) ≫
+          eqToHom (completionLocObj_obj P T' s' S' hden').symm := by
+  intro g hg
+  rfl
+
+/-- A comparison endomorphism compatible with the structure map from `A` is the identity
+morphism of the presentationwise complete separated object. -/
+@[simp]
+theorem completionLocObjHom_eq_id [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    ∀ (g : UniformSpace.Completion S →+* UniformSpace.Completion S) (hg : Continuous g),
+      g.comp (toCompletionLoc P T s S hden) = toCompletionLoc P T s S hden →
+      completionLocObjHom P T s S hden T s S hden g hg =
+        𝟙 (completionLocObj P T s S hden) := by
+  let _ := locUniformSpace P T s S hden
+  let _ := isUniformAddGroup_locUniformSpace P T s S hden
+  let _ := isTopologicalRing_locUniformSpace P T s S hden
+  intro g hg hgc
+  have hg_id : g = RingHom.id (UniformSpace.Completion S) :=
+    eq_id_of_comp_toCompletionLoc_eq_self P T s S hden g hg hgc
+  apply InducedCategory.hom_ext
+  rw [completionLocObjHom_hom]
+  have hG : (⟨g, hg⟩ : TopCommRingCat.of (UniformSpace.Completion S) ⟶
+      TopCommRingCat.of (UniformSpace.Completion S)) =
+      𝟙 (TopCommRingCat.of (UniformSpace.Completion S)) := by
+    apply Subtype.ext
+    exact hg_id
+  rw [hG]
+  simp
+
+/-- Comparison morphisms compatible with the structure maps from `A` compose categorically.
+This is the cocycle law for presentationwise objects in `CompleteSeparatedTopCommRingCat`. -/
+theorem completionLocObjHom_eq_comp [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (T' : Finset A) (s' : A)
+    (S' : Type u) [CommRing S'] [Algebra A S'] [IsLocalization.Away s' S']
+    (hden' : HasDenominatorPower P T' s' S')
+    (T'' : Finset A) (s'' : A)
+    (S'' : Type u) [CommRing S''] [Algebra A S''] [IsLocalization.Away s'' S'']
+    (hden'' : HasDenominatorPower P T'' s'' S'') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s' S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s' S' hden'
+    letI := locUniformSpace P T'' s'' S'' hden''
+    letI := isUniformAddGroup_locUniformSpace P T'' s'' S'' hden''
+    letI := isTopologicalRing_locUniformSpace P T'' s'' S'' hden''
+    ∀ (g : UniformSpace.Completion S →+* UniformSpace.Completion S')
+      (h : UniformSpace.Completion S' →+* UniformSpace.Completion S'')
+      (k : UniformSpace.Completion S →+* UniformSpace.Completion S'')
+      (hg : Continuous g) (hh : Continuous h) (hk : Continuous k),
+      g.comp (toCompletionLoc P T s S hden) = toCompletionLoc P T' s' S' hden' →
+      h.comp (toCompletionLoc P T' s' S' hden') = toCompletionLoc P T'' s'' S'' hden'' →
+      k.comp (toCompletionLoc P T s S hden) = toCompletionLoc P T'' s'' S'' hden'' →
+      completionLocObjHom P T s S hden T'' s'' S'' hden'' k hk =
+        completionLocObjHom P T s S hden T' s' S' hden' g hg ≫
+          completionLocObjHom P T' s' S' hden' T'' s'' S'' hden'' h hh := by
+  let _ := locUniformSpace P T s S hden
+  let _ := isUniformAddGroup_locUniformSpace P T s S hden
+  let _ := isTopologicalRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s' S' hden'
+  let _ := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+  let _ := isTopologicalRing_locUniformSpace P T' s' S' hden'
+  let _ := locUniformSpace P T'' s'' S'' hden''
+  let _ := isUniformAddGroup_locUniformSpace P T'' s'' S'' hden''
+  let _ := isTopologicalRing_locUniformSpace P T'' s'' S'' hden''
+  intro g h k hg hh hk hgc hhc hkc
+  have hk_comp : k = h.comp g :=
+    eq_comp_of_comp_toCompletionLoc_eq_three P T s S hden T' s' S' hden'
+      T'' s'' S'' hden'' g h k hg hh hk hgc hhc hkc
+  apply InducedCategory.hom_ext
+  rw [completionLocObjHom_hom, ObjectProperty.FullSubcategory.comp_hom,
+    completionLocObjHom_hom, completionLocObjHom_hom]
+  let G : TopCommRingCat.of (UniformSpace.Completion S) ⟶
+      TopCommRingCat.of (UniformSpace.Completion S') := ⟨g, hg⟩
+  let H : TopCommRingCat.of (UniformSpace.Completion S') ⟶
+      TopCommRingCat.of (UniformSpace.Completion S'') := ⟨h, hh⟩
+  let K : TopCommRingCat.of (UniformSpace.Completion S) ⟶
+      TopCommRingCat.of (UniformSpace.Completion S'') := ⟨k, hk⟩
+  have hK : K = G ≫ H := by
+    apply Subtype.ext
+    exact hk_comp
+  -- The public object equation is the only way to expose the transports surrounding `G`, `H`,
+  -- and `K`; `completionLocObj` itself is deliberately not exposed.
+  change eqToHom _ ≫ K ≫ eqToHom _ =
+    (eqToHom _ ≫ G ≫ eqToHom _) ≫ eqToHom _ ≫ H ≫ eqToHom _
+  rw [hK]
+  simp [Category.assoc]
+
+/-! ### Isomorphisms between presentationwise objects -/
+
+/-- Compatible comparison maps in both directions give an isomorphism between the associated
+objects of `CompleteSeparatedTopCommRingCat`.
+
+This is the categorical form of `presentationRingEquiv`. As there, the construction is
+conditional: equality of rational subsets must separately supply the two comparison maps and
+their compatibility with the structure maps from `A`. -/
+noncomputable def completionLocObjIso [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (T' : Finset A) (s' : A)
+    (S' : Type u) [CommRing S'] [Algebra A S'] [IsLocalization.Away s' S']
+    (hden' : HasDenominatorPower P T' s' S') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s' S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s' S' hden'
+    ∀ (g : UniformSpace.Completion S →+* UniformSpace.Completion S')
+      (h : UniformSpace.Completion S' →+* UniformSpace.Completion S),
+      Continuous g → Continuous h →
+      g.comp (toCompletionLoc P T s S hden) = toCompletionLoc P T' s' S' hden' →
+      h.comp (toCompletionLoc P T' s' S' hden') = toCompletionLoc P T s S hden →
+      (completionLocObj P T s S hden ≅ completionLocObj P T' s' S' hden') := by
+  let _ := locUniformSpace P T s S hden
+  let _ := isUniformAddGroup_locUniformSpace P T s S hden
+  let _ := isTopologicalRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s' S' hden'
+  let _ := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+  let _ := isTopologicalRing_locUniformSpace P T' s' S' hden'
+  intro g h hg hh hgc hhc
+  refine
+    { hom := completionLocObjHom P T s S hden T' s' S' hden' g hg
+      inv := completionLocObjHom P T' s' S' hden' T s S hden h hh
+      hom_inv_id := ?_
+      inv_hom_id := ?_ }
+  · have hcomp : (h.comp g).comp (toCompletionLoc P T s S hden) =
+        toCompletionLoc P T s S hden := by
+      rw [RingHom.comp_assoc, hgc, hhc]
+    calc
+      completionLocObjHom P T s S hden T' s' S' hden' g hg ≫
+          completionLocObjHom P T' s' S' hden' T s S hden h hh =
+        completionLocObjHom P T s S hden T s S hden (h.comp g) (hh.comp hg) :=
+          (completionLocObjHom_eq_comp P T s S hden T' s' S' hden' T s S hden
+            g h (h.comp g) hg hh (hh.comp hg) hgc hhc hcomp).symm
+      _ = 𝟙 (completionLocObj P T s S hden) :=
+        completionLocObjHom_eq_id P T s S hden (h.comp g) (hh.comp hg) hcomp
+  · have hcomp : (g.comp h).comp (toCompletionLoc P T' s' S' hden') =
+        toCompletionLoc P T' s' S' hden' := by
+      rw [RingHom.comp_assoc, hhc, hgc]
+    calc
+      completionLocObjHom P T' s' S' hden' T s S hden h hh ≫
+          completionLocObjHom P T s S hden T' s' S' hden' g hg =
+        completionLocObjHom P T' s' S' hden' T' s' S' hden'
+          (g.comp h) (hg.comp hh) :=
+          (completionLocObjHom_eq_comp P T' s' S' hden' T s S hden T' s' S' hden'
+            h g (g.comp h) hh hg (hg.comp hh) hhc hgc hcomp).symm
+      _ = 𝟙 (completionLocObj P T' s' S' hden') :=
+        completionLocObjHom_eq_id P T' s' S' hden' (g.comp h) (hg.comp hh) hcomp
+
+/-- The forward morphism of `completionLocObjIso` is the packaged forward comparison map. -/
+@[simp]
+theorem completionLocObjIso_hom [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (T' : Finset A) (s' : A)
+    (S' : Type u) [CommRing S'] [Algebra A S'] [IsLocalization.Away s' S']
+    (hden' : HasDenominatorPower P T' s' S') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s' S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s' S' hden'
+    ∀ (g : UniformSpace.Completion S →+* UniformSpace.Completion S')
+      (h : UniformSpace.Completion S' →+* UniformSpace.Completion S)
+      (hg : Continuous g) (hh : Continuous h)
+      (hgc : g.comp (toCompletionLoc P T s S hden) = toCompletionLoc P T' s' S' hden')
+      (hhc : h.comp (toCompletionLoc P T' s' S' hden') = toCompletionLoc P T s S hden),
+      (completionLocObjIso P T s S hden T' s' S' hden' g h hg hh hgc hhc).hom =
+        completionLocObjHom P T s S hden T' s' S' hden' g hg := by
+  intro g h hg hh hgc hhc
+  rfl
+
+/-- The inverse morphism of `completionLocObjIso` is the packaged backward comparison map. -/
+@[simp]
+theorem completionLocObjIso_inv [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (T' : Finset A) (s' : A)
+    (S' : Type u) [CommRing S'] [Algebra A S'] [IsLocalization.Away s' S']
+    (hden' : HasDenominatorPower P T' s' S') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s' S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s' S' hden'
+    ∀ (g : UniformSpace.Completion S →+* UniformSpace.Completion S')
+      (h : UniformSpace.Completion S' →+* UniformSpace.Completion S)
+      (hg : Continuous g) (hh : Continuous h)
+      (hgc : g.comp (toCompletionLoc P T s S hden) = toCompletionLoc P T' s' S' hden')
+      (hhc : h.comp (toCompletionLoc P T' s' S' hden') = toCompletionLoc P T s S hden),
+      (completionLocObjIso P T s S hden T' s' S' hden' g h hg hh hgc hhc).inv =
+        completionLocObjHom P T' s' S' hden' T s S hden h hh := by
+  intro g h hg hh hgc hhc
+  rfl
 
 end PairOfDefinition
 

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
@@ -10,11 +10,12 @@ public import TauCeti.Topology.Category.TopCommRingCat.CompleteSeparated.Basic
 /-!
 # `A⟨T/s⟩` is a complete separated topological ring
 
-The adic structure presheaf (roadmap Layer 3.3) assigns `A⟨T/s⟩` to the rational subset
-`R(T/s)`, and its values are required to be *complete separated* topological rings (*Adic Spaces*,
-arXiv:1910.05934v1, §8.1–§8.2). This module supplies the categorical packaging that assignment
-needs: it exhibits `A⟨T/s⟩` as an object of `CompleteSeparatedTopCommRingCat`, lifts continuous
-comparison maps to morphisms, and packages mutually compatible comparisons as isomorphisms.
+The adic structure presheaf (roadmap Layer 3.3) is intended to assign `A⟨T/s⟩` to the rational
+subset `R(T/s)`, and its values are required to be *complete separated* topological rings
+(*Adic Spaces*, arXiv:1910.05934v1, §8.1–§8.2). This module supplies the categorical packaging
+that assignment needs: it exhibits `A⟨T/s⟩` as an object of `CompleteSeparatedTopCommRingCat`,
+lifts continuous comparison maps to morphisms, and packages mutually compatible comparisons as
+isomorphisms.
 
 No presheaf exists yet, and the objects here remain *presentationwise*: they depend on the data
 `(T, s, S, hden)` presenting the localisation, not only on the subset `R(T/s)`. The isomorphism
@@ -45,6 +46,9 @@ every use. The definition below carries it once.
 * `TauCeti.Huber.PairOfDefinition.completionLocObjHom_eq_id` and
   `TauCeti.Huber.PairOfDefinition.completionLocObjHom_eq_comp` : identity and composition for
   comparison morphisms compatible with the structure maps from `A`.
+* `TauCeti.Huber.PairOfDefinition.completionLocObjHom_id` and
+  `TauCeti.Huber.PairOfDefinition.completionLocObjHom_comp` : packaging preserves identity and
+  composition.
 
 ## Provenance
 
@@ -168,6 +172,79 @@ theorem completionLocObjHom_hom [IsTopologicalRing A]
           eqToHom (completionLocObj_obj P T' s' S' hden').symm := by
   intro g hg
   rfl
+
+/-- Packaging the identity ring homomorphism gives the identity morphism. -/
+@[simp]
+theorem completionLocObjHom_id [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S) :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    completionLocObjHom P T s S hden T s S hden (RingHom.id _) continuous_id =
+      𝟙 (completionLocObj P T s S hden) := by
+  let _ := locUniformSpace P T s S hden
+  let _ := isUniformAddGroup_locUniformSpace P T s S hden
+  let _ := isTopologicalRing_locUniformSpace P T s S hden
+  apply InducedCategory.hom_ext
+  rw [completionLocObjHom_hom]
+  have hG : (⟨RingHom.id (UniformSpace.Completion S), continuous_id⟩ :
+      TopCommRingCat.of (UniformSpace.Completion S) ⟶
+        TopCommRingCat.of (UniformSpace.Completion S)) =
+      𝟙 (TopCommRingCat.of (UniformSpace.Completion S)) := by
+    rfl
+  rw [hG]
+  simp
+
+/-- Packaging a composite of continuous ring homomorphisms gives the categorical composite of
+their packaged morphisms. -/
+@[simp]
+theorem completionLocObjHom_comp [IsTopologicalRing A]
+    (P : PairOfDefinition A) (T : Finset A) (s : A)
+    (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]
+    (hden : HasDenominatorPower P T s S)
+    (T' : Finset A) (s' : A)
+    (S' : Type u) [CommRing S'] [Algebra A S'] [IsLocalization.Away s' S']
+    (hden' : HasDenominatorPower P T' s' S')
+    (T'' : Finset A) (s'' : A)
+    (S'' : Type u) [CommRing S''] [Algebra A S''] [IsLocalization.Away s'' S'']
+    (hden'' : HasDenominatorPower P T'' s'' S'') :
+    letI := locUniformSpace P T s S hden
+    letI := isUniformAddGroup_locUniformSpace P T s S hden
+    letI := isTopologicalRing_locUniformSpace P T s S hden
+    letI := locUniformSpace P T' s' S' hden'
+    letI := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+    letI := isTopologicalRing_locUniformSpace P T' s' S' hden'
+    letI := locUniformSpace P T'' s'' S'' hden''
+    letI := isUniformAddGroup_locUniformSpace P T'' s'' S'' hden''
+    letI := isTopologicalRing_locUniformSpace P T'' s'' S'' hden''
+    ∀ (g : UniformSpace.Completion S →+* UniformSpace.Completion S')
+      (h : UniformSpace.Completion S' →+* UniformSpace.Completion S'')
+      (hg : Continuous g) (hh : Continuous h),
+      completionLocObjHom P T s S hden T'' s'' S'' hden'' (h.comp g) (hh.comp hg) =
+        completionLocObjHom P T s S hden T' s' S' hden' g hg ≫
+          completionLocObjHom P T' s' S' hden' T'' s'' S'' hden'' h hh := by
+  let _ := locUniformSpace P T s S hden
+  let _ := isUniformAddGroup_locUniformSpace P T s S hden
+  let _ := isTopologicalRing_locUniformSpace P T s S hden
+  let _ := locUniformSpace P T' s' S' hden'
+  let _ := isUniformAddGroup_locUniformSpace P T' s' S' hden'
+  let _ := isTopologicalRing_locUniformSpace P T' s' S' hden'
+  let _ := locUniformSpace P T'' s'' S'' hden''
+  let _ := isUniformAddGroup_locUniformSpace P T'' s'' S'' hden''
+  let _ := isTopologicalRing_locUniformSpace P T'' s'' S'' hden''
+  intro g h hg hh
+  apply InducedCategory.hom_ext
+  rw [completionLocObjHom_hom, ObjectProperty.FullSubcategory.comp_hom,
+    completionLocObjHom_hom, completionLocObjHom_hom]
+  let G : TopCommRingCat.of (UniformSpace.Completion S) ⟶
+      TopCommRingCat.of (UniformSpace.Completion S') := ⟨g, hg⟩
+  let H : TopCommRingCat.of (UniformSpace.Completion S') ⟶
+      TopCommRingCat.of (UniformSpace.Completion S'') := ⟨h, hh⟩
+  change eqToHom _ ≫ (G ≫ H) ≫ eqToHom _ =
+    (eqToHom _ ≫ G ≫ eqToHom _) ≫ eqToHom _ ≫ H ≫ eqToHom _
+  simp [Category.assoc]
 
 /-- A comparison endomorphism compatible with the structure map from `A` is the identity
 morphism of the presentationwise complete separated object. -/

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
@@ -173,8 +173,11 @@ theorem completionLocObjHom_hom [IsTopologicalRing A]
   intro g hg
   rfl
 
-/-- Packaging the identity ring homomorphism gives the identity morphism. -/
-@[simp]
+/-- Packaging the identity ring homomorphism gives the identity morphism.
+
+This is the special case of `completionLocObjHom_eq_id` where the compatibility hypothesis holds
+definitionally, so it is deliberately not a `simp` lemma: `simp` already closes it using the
+general statement. -/
 theorem completionLocObjHom_id [IsTopologicalRing A]
     (P : PairOfDefinition A) (T : Finset A) (s : A)
     (S : Type u) [CommRing S] [Algebra A S] [IsLocalization.Away s S]

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean
@@ -317,24 +317,9 @@ theorem completionLocObjHom_eq_comp [IsTopologicalRing A]
   have hk_comp : k = h.comp g :=
     eq_comp_of_comp_toCompletionLoc_eq_three P T s S hden T' s' S' hden'
       T'' s'' S'' hden'' g h k hg hh hk hgc hhc hkc
-  apply InducedCategory.hom_ext
-  rw [completionLocObjHom_hom, ObjectProperty.FullSubcategory.comp_hom,
-    completionLocObjHom_hom, completionLocObjHom_hom]
-  let G : TopCommRingCat.of (UniformSpace.Completion S) ⟶
-      TopCommRingCat.of (UniformSpace.Completion S') := ⟨g, hg⟩
-  let H : TopCommRingCat.of (UniformSpace.Completion S') ⟶
-      TopCommRingCat.of (UniformSpace.Completion S'') := ⟨h, hh⟩
-  let K : TopCommRingCat.of (UniformSpace.Completion S) ⟶
-      TopCommRingCat.of (UniformSpace.Completion S'') := ⟨k, hk⟩
-  have hK : K = G ≫ H := by
-    apply Subtype.ext
-    exact hk_comp
-  -- The public object equation is the only way to expose the transports surrounding `G`, `H`,
-  -- and `K`; `completionLocObj` itself is deliberately not exposed.
-  change eqToHom _ ≫ K ≫ eqToHom _ =
-    (eqToHom _ ≫ G ≫ eqToHom _) ≫ eqToHom _ ≫ H ≫ eqToHom _
-  rw [hK]
-  simp [Category.assoc]
+  subst k
+  exact completionLocObjHom_comp P T s S hden T' s' S' hden'
+    T'' s'' S'' hden'' g h hg hh
 
 /-! ### Isomorphisms between presentationwise objects -/
 


### PR DESCRIPTION
This PR lifts continuous comparison maps between completed rational localisations to morphisms of `CompleteSeparatedTopCommRingCat`, proves their identity and three-presentation cocycle laws, and packages compatible maps in both directions as a categorical isomorphism. It advances `AdicSpaces/README.md`, Layer 3.1 milestone “Rational localisation of a Huber pair,” specifically the target to construct the canonical isomorphism between localisations attached to two presentations and prove compatibility for three presentations; the resulting morphisms and coherence are in the exact codomain required by Layer 3.3’s rational-basis structure presheaf.

This is the most effective current step because `completionLocObj` and the ring-level uniqueness, inverse, and composition results are on `main`, while the independent ingredients that turn rational-subset containments into refined comparison maps are already in flight in #3625, #3629, and #3632. This PR supplies the missing categorical bridge without duplicating those branches or depending on unmerged declarations. After this PR, Layer 3.1 still needs those algebraic and set-level ingredients assembled to produce comparisons from equality or containment of rational subsets, and then the plus-ring and adic-spectrum identifications; Layer 3.3 still needs the resulting coherent assignment assembled into the rational-basis presheaf.

Modify `TauCeti/RingTheory/Huber/LocalizationTopology/CompleteSeparated.lean` by 290 additions and 12 deletions (382 lines total). The public API adds `completionLocObjHom`, its characteristic underlying-morphism equation, categorical identity and composition laws, and `completionLocObjIso` with simp-normalized hom and inverse projections. The implementation respects the hidden body of `completionLocObj` by transporting only through its public object equation.

No Mathlib infrastructure is vendored. The construction reuses Mathlib’s full-subcategory morphisms, `eqToHom`, and categorical composition, together with Tau Ceti’s existing completed-localisation extensionality and presentation-comparison theorems. The mathematical organization follows T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, §8.1–§8.2, as credited in the module documentation.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"rational-localisation-object-isomorphism"}-->

🤖 Prepared with Codex
