### PR TITLE
feat: add piecewise smooth Riemannian paths

### DIFF
--- a/TauCeti/Geometry/Manifold/PiecewisePath.lean
+++ b/TauCeti/Geometry/Manifold/PiecewisePath.lean
@@ -22,6 +22,8 @@ bundled paths carrying irrelevant partition data.
 
 ## Main results
 
+* `TauCeti.Manifold.IsPiecewiseContMDiffOn.exists_partition`: extract a witnessing strict
+  partition and the piecewise regularity facts.
 * `TauCeti.Manifold.IsPiecewiseContMDiffOn.continuousOn`: piecewise `C^n` regularity implies
   continuity on the whole interval.
 
@@ -58,7 +60,7 @@ zero-piece witness.
 
 The partition is existential data because it witnesses a property of `γ`; it is not part of the
 identity of a path. In particular, refining a partition does not create a different object. -/
-@[expose] def IsPiecewiseContMDiffOn (I : ModelWithCorners ℝ E H) (n : ℕ∞ω)
+def IsPiecewiseContMDiffOn (I : ModelWithCorners ℝ E H) (n : ℕ∞ω)
     (γ : ℝ → M) (a b : ℝ) : Prop :=
   ∃ (k : ℕ) (τ : Fin (k + 2) → ℝ),
     τ 0 = a ∧
@@ -66,6 +68,18 @@ identity of a path. In particular, refining a partition does not create a differ
       (∀ i : Fin (k + 1), τ i.castSucc < τ i.succ) ∧
       ∀ i : Fin (k + 1),
         ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc (τ i.castSucc) (τ i.succ))
+
+/-- Extract a strict partition witnessing piecewise `C^n` regularity, together with the
+`C^n` restriction on each closed piece. -/
+theorem IsPiecewiseContMDiffOn.exists_partition (h : IsPiecewiseContMDiffOn I n γ a b) :
+    ∃ (k : ℕ) (τ : Fin (k + 2) → ℝ),
+      τ 0 = a ∧
+        τ (Fin.last (k + 1)) = b ∧
+        (∀ i : Fin (k + 1), τ i.castSucc < τ i.succ) ∧
+        ∀ i : Fin (k + 1),
+          ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ
+            (Icc (τ i.castSucc) (τ i.succ)) :=
+  h
 
 /-- The endpoints of a piecewise smooth path are strictly ordered. -/
 theorem IsPiecewiseContMDiffOn.lt (h : IsPiecewiseContMDiffOn I n γ a b) : a < b := by

--- a/TauCeti/Geometry/Manifold/PiecewisePath.lean
+++ b/TauCeti/Geometry/Manifold/PiecewisePath.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Geometry.Manifold.ContMDiff.Basic
+
+/-!
+# Piecewise smooth paths in a manifold
+
+This file defines piecewise `C^n` regularity for a path on a compact real interval using a finite
+strict partition. The predicate retains the partition only existentially. Thus two proofs using
+different partitions are proofs of the same property of the underlying path, rather than distinct
+bundled paths carrying irrelevant partition data.
+
+## Main definitions
+
+* `TauCeti.Manifold.IsPiecewiseContMDiffOn`: a path is `C^n` on the pieces of some finite strict
+  partition of `[a, b]`.
+
+## Main results
+
+* `TauCeti.Manifold.IsPiecewiseContMDiffOn.continuousOn`: piecewise `C^n` regularity implies
+  continuity on the whole interval.
+
+This is the metric-independent finite-partition regularity API used in Layer 0 of the Hopf--Rinow
+roadmap.
+
+## References
+
+* M. P. do Carmo, *Riemannian Geometry*, Chapter 1, Definition 2.9 and Chapter 7, Section 2.
+-/
+
+public section
+
+open Set
+open scoped ContDiff Manifold
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+universe u
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H]
+  {I : ModelWithCorners ℝ E H}
+  {M : Type u} [TopologicalSpace M] [ChartedSpace H M]
+  {n : ℕ∞ω} {γ : ℝ → M} {a b : ℝ}
+
+/-- A path is piecewise `C^n` on `[a, b]` if there is a nonempty finite strict partition from
+`a` to `b` such that the path is `C^n` on every closed piece. The partition has `k + 1` pieces
+and `k + 2` vertices, so the definition includes the one-piece case but excludes a vacuous
+zero-piece witness.
+
+The partition is existential data because it witnesses a property of `γ`; it is not part of the
+identity of a path. In particular, refining a partition does not create a different object. -/
+@[expose] def IsPiecewiseContMDiffOn (I : ModelWithCorners ℝ E H) (n : ℕ∞ω)
+    (γ : ℝ → M) (a b : ℝ) : Prop :=
+  ∃ (k : ℕ) (τ : Fin (k + 2) → ℝ),
+    τ 0 = a ∧
+      τ (Fin.last (k + 1)) = b ∧
+      (∀ i : Fin (k + 1), τ i.castSucc < τ i.succ) ∧
+      ∀ i : Fin (k + 1),
+        ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc (τ i.castSucc) (τ i.succ))
+
+/-- The endpoints of a piecewise smooth path are strictly ordered. -/
+theorem IsPiecewiseContMDiffOn.lt (h : IsPiecewiseContMDiffOn I n γ a b) : a < b := by
+  obtain ⟨k, τ, rfl, rfl, hτ, -⟩ := h
+  exact (Fin.strictMono_iff_lt_succ.mpr hτ) Fin.last_pos'
+
+/-- A `C^n` path on a nondegenerate interval is piecewise `C^n`, witnessed by the partition
+consisting only of its two endpoints. -/
+theorem IsPiecewiseContMDiffOn.of_contMDiffOn (hab : a < b)
+    (hγ : ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc a b)) :
+    IsPiecewiseContMDiffOn I n γ a b := by
+  let τ : Fin 2 → ℝ := ![a, b]
+  refine ⟨0, τ, ?_, ?_, ?_, ?_⟩
+  · simp [τ]
+  · simp [τ]
+  · intro i
+    fin_cases i
+    simpa [τ] using hab
+  · intro i
+    fin_cases i
+    simpa [τ] using hγ
+
+/-- Restricting the requested differentiability order preserves piecewise smoothness. -/
+theorem IsPiecewiseContMDiffOn.of_le {m : ℕ∞ω} (h : IsPiecewiseContMDiffOn I n γ a b)
+    (hmn : m ≤ n) : IsPiecewiseContMDiffOn I m γ a b := by
+  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h
+  exact ⟨k, τ, hτa, hτb, hτ, fun i ↦ (hγ i).of_le hmn⟩
+
+/-- Continuity glues across a finite ordered partition. This is the induction underlying
+`IsPiecewiseContMDiffOn.continuousOn`. -/
+private theorem continuousOn_Icc_of_partition
+    {r : ℕ} (τ : Fin (r + 1) → ℝ)
+    (hτ : ∀ i : Fin r, τ i.castSucc ≤ τ i.succ)
+    (hγ : ∀ i : Fin r, ContinuousOn γ (Icc (τ i.castSucc) (τ i.succ))) :
+    ContinuousOn γ (Icc (τ 0) (τ (Fin.last r))) := by
+  induction r with
+  | zero => simp
+  | succ r ih =>
+      have hτmono : Monotone τ := Fin.monotone_iff_le_succ.mpr hτ
+      have hfirst : τ 0 ≤ τ (Fin.last r).castSucc := hτmono (Fin.zero_le _)
+      rw [← Fin.succ_last r]
+      rw [← Icc_union_Icc_eq_Icc
+        hfirst (hτ (Fin.last r))]
+      rw [continuousOn_union_iff_of_isClosed isClosed_Icc isClosed_Icc]
+      refine ⟨ih (fun i ↦ τ i.castSucc) (fun i ↦ ?_) (fun i ↦ ?_), ?_⟩
+      · simpa only [Fin.succ_castSucc] using hτ i.castSucc
+      · simpa only [Fin.succ_castSucc] using hγ i.castSucc
+      · simpa using hγ (Fin.last r)
+
+/-- Piecewise `C^n` regularity implies continuity on the whole interval. -/
+theorem IsPiecewiseContMDiffOn.continuousOn (h : IsPiecewiseContMDiffOn I n γ a b) :
+    ContinuousOn γ (Icc a b) := by
+  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h
+  rw [← hτa, ← hτb]
+  exact continuousOn_Icc_of_partition τ (fun i ↦ (hτ i).le)
+    (fun i ↦ (hγ i).continuousOn)
+
+end TauCeti.Manifold

--- a/TauCeti/Geometry/Manifold/PiecewisePath.lean
+++ b/TauCeti/Geometry/Manifold/PiecewisePath.lean
@@ -24,6 +24,8 @@ bundled paths carrying irrelevant partition data.
 
 * `TauCeti.Manifold.IsPiecewiseContMDiffOn.exists_partition`: extract a witnessing strict
   partition and the piecewise regularity facts.
+* `TauCeti.Manifold.IsPiecewiseContMDiffOn.of_partition`: construct piecewise regularity from a
+  strict partition and regularity on each piece.
 * `TauCeti.Manifold.IsPiecewiseContMDiffOn.continuousOn`: piecewise `C^n` regularity implies
   continuity on the whole interval.
 
@@ -80,6 +82,16 @@ theorem IsPiecewiseContMDiffOn.exists_partition (h : IsPiecewiseContMDiffOn I n 
           ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ
             (Icc (τ i.castSucc) (τ i.succ)) :=
   h
+
+/-- A strict finite partition on whose pieces a path is `C^n` witnesses piecewise `C^n`
+regularity. -/
+theorem IsPiecewiseContMDiffOn.of_partition {k : ℕ} (τ : Fin (k + 2) → ℝ)
+    (hτa : τ 0 = a) (hτb : τ (Fin.last (k + 1)) = b)
+    (hτ : ∀ i : Fin (k + 1), τ i.castSucc < τ i.succ)
+    (hγ : ∀ i : Fin (k + 1),
+      ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc (τ i.castSucc) (τ i.succ))) :
+    IsPiecewiseContMDiffOn I n γ a b :=
+  ⟨k, τ, hτa, hτb, hτ, hγ⟩
 
 /-- The endpoints of a piecewise smooth path are strictly ordered. -/
 theorem IsPiecewiseContMDiffOn.lt (h : IsPiecewiseContMDiffOn I n γ a b) : a < b := by

--- a/TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean
@@ -6,29 +6,18 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Geometry.Manifold.Riemannian.PathELength
+public import TauCeti.Geometry.Manifold.PiecewisePath
 
 /-!
-# Piecewise smooth paths in a manifold
+# Piecewise smooth Riemannian paths
 
-This file defines piecewise `C^n` regularity for a path on a compact real interval using a finite
-strict partition. It also proves that the sum of `Manifold.pathELength` over any ordered partition
-is the length on the whole interval. Consequently the sum used to compute the length of a
-piecewise-`C¹` path is independent of its witnessing partition and, more generally, of every
-refinement.
-
-The predicate retains the partition only existentially. Thus two proofs using different
-partitions are proofs of the same property of the underlying path, rather than distinct bundled
-paths carrying irrelevant partition data.
-
-## Main definitions
-
-* `TauCeti.Manifold.IsPiecewiseContMDiffOn`: a path is `C^n` on the pieces of some finite strict
-  partition of `[a, b]`.
+This file extends the metric-independent piecewise smooth path API with Riemannian length results.
+It proves that the sum of `Manifold.pathELength` over any ordered partition is the length on the
+whole interval. Consequently the sum used to compute the length of a piecewise-`C¹` path is
+independent of its witnessing partition and, more generally, of every refinement.
 
 ## Main results
 
-* `TauCeti.Manifold.IsPiecewiseContMDiffOn.continuousOn`: piecewise `C^n` regularity implies
-  continuity on the whole interval.
 * `TauCeti.Manifold.sum_pathELength_eq`: summing `Manifold.pathELength` over an ordered partition
   gives the length on the whole interval.
 * `TauCeti.Manifold.sum_pathELength_eq_of_endpoints_eq`: two ordered partitions with the same
@@ -61,78 +50,6 @@ variable
   {I : ModelWithCorners ℝ E H}
   {M : Type u} [TopologicalSpace M] [ChartedSpace H M]
   {n : ℕ∞ω} {γ : ℝ → M} {a b : ℝ}
-
-/-- A path is piecewise `C^n` on `[a, b]` if there is a nonempty finite strict partition from
-`a` to `b` such that the path is `C^n` on every closed piece. The partition has `k + 1` pieces
-and `k + 2` vertices, so the definition includes the one-piece case but excludes a vacuous
-zero-piece witness.
-
-The partition is existential data because it witnesses a property of `γ`; it is not part of the
-identity of a path. In particular, refining a partition does not create a different object. -/
-def IsPiecewiseContMDiffOn (I : ModelWithCorners ℝ E H) (n : ℕ∞ω)
-    (γ : ℝ → M) (a b : ℝ) : Prop :=
-  ∃ (k : ℕ) (τ : Fin (k + 2) → ℝ),
-    τ 0 = a ∧
-      τ (Fin.last (k + 1)) = b ∧
-      (∀ i : Fin (k + 1), τ i.castSucc < τ i.succ) ∧
-      ∀ i : Fin (k + 1),
-        ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc (τ i.castSucc) (τ i.succ))
-
-/-- The endpoints of a piecewise smooth path are strictly ordered. -/
-theorem IsPiecewiseContMDiffOn.lt (h : IsPiecewiseContMDiffOn I n γ a b) : a < b := by
-  obtain ⟨k, τ, rfl, rfl, hτ, -⟩ := h
-  exact (Fin.strictMono_iff_lt_succ.mpr hτ) Fin.last_pos'
-
-/-- A `C^n` path on a nondegenerate interval is piecewise `C^n`, witnessed by the partition
-consisting only of its two endpoints. -/
-theorem IsPiecewiseContMDiffOn.of_contMDiffOn (hab : a < b)
-    (hγ : ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc a b)) :
-    IsPiecewiseContMDiffOn I n γ a b := by
-  let τ : Fin 2 → ℝ := ![a, b]
-  refine ⟨0, τ, ?_, ?_, ?_, ?_⟩
-  · simp [τ]
-  · simp [τ]
-  · intro i
-    fin_cases i
-    simpa [τ] using hab
-  · intro i
-    fin_cases i
-    simpa [τ] using hγ
-
-/-- Restricting the requested differentiability order preserves piecewise smoothness. -/
-theorem IsPiecewiseContMDiffOn.of_le {m : ℕ∞ω} (h : IsPiecewiseContMDiffOn I n γ a b)
-    (hmn : m ≤ n) : IsPiecewiseContMDiffOn I m γ a b := by
-  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h
-  exact ⟨k, τ, hτa, hτb, hτ, fun i ↦ (hγ i).of_le hmn⟩
-
-/-- Continuity glues across a finite ordered partition. This is the induction underlying
-`IsPiecewiseContMDiffOn.continuousOn`. -/
-private theorem continuousOn_Icc_of_partition
-    {r : ℕ} (τ : Fin (r + 1) → ℝ)
-    (hτ : ∀ i : Fin r, τ i.castSucc ≤ τ i.succ)
-    (hγ : ∀ i : Fin r, ContinuousOn γ (Icc (τ i.castSucc) (τ i.succ))) :
-    ContinuousOn γ (Icc (τ 0) (τ (Fin.last r))) := by
-  induction r with
-  | zero => simp
-  | succ r ih =>
-      have hτmono : Monotone τ := Fin.monotone_iff_le_succ.mpr hτ
-      have hfirst : τ 0 ≤ τ (Fin.last r).castSucc := hτmono (Fin.zero_le _)
-      rw [← Fin.succ_last r]
-      rw [← Icc_union_Icc_eq_Icc
-        hfirst (hτ (Fin.last r))]
-      rw [continuousOn_union_iff_of_isClosed isClosed_Icc isClosed_Icc]
-      refine ⟨ih (fun i ↦ τ i.castSucc) (fun i ↦ ?_) (fun i ↦ ?_), ?_⟩
-      · simpa only [Fin.succ_castSucc] using hτ i.castSucc
-      · simpa only [Fin.succ_castSucc] using hγ i.castSucc
-      · simpa using hγ (Fin.last r)
-
-/-- Piecewise `C^n` regularity implies continuity on the whole interval. -/
-theorem IsPiecewiseContMDiffOn.continuousOn (h : IsPiecewiseContMDiffOn I n γ a b) :
-    ContinuousOn γ (Icc a b) := by
-  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h
-  rw [← hτa, ← hτb]
-  exact continuousOn_Icc_of_partition τ (fun i ↦ (hτ i).le)
-    (fun i ↦ (hγ i).continuousOn)
 
 variable [∀ x : M, ENorm (TangentSpace I x)]
 

--- a/TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean
@@ -1,0 +1,208 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Geometry.Manifold.Riemannian.PathELength
+
+/-!
+# Piecewise smooth paths in a manifold
+
+This file defines piecewise `C^n` regularity for a path on a compact real interval using a finite
+strict partition. It also proves that the sum of `Manifold.pathELength` over any ordered partition
+is the length on the whole interval. Consequently the sum used to compute the length of a
+piecewise-`C¹` path is independent of its witnessing partition and, more generally, of every
+refinement.
+
+The predicate retains the partition only existentially. Thus two proofs using different
+partitions are proofs of the same property of the underlying path, rather than distinct bundled
+paths carrying irrelevant partition data.
+
+## Main definitions
+
+* `TauCeti.Manifold.IsPiecewiseContMDiffOn`: a path is `C^n` on the pieces of some finite strict
+  partition of `[a, b]`.
+
+## Main results
+
+* `TauCeti.Manifold.IsPiecewiseContMDiffOn.continuousOn`: piecewise `C^n` regularity implies
+  continuity on the whole interval.
+* `TauCeti.Manifold.sum_pathELength_eq`: summing `Manifold.pathELength` over an ordered partition
+  gives the length on the whole interval.
+* `TauCeti.Manifold.sum_pathELength_eq_of_endpoints_eq`: two ordered partitions with the same
+  endpoints compute the same length.
+* `TauCeti.Manifold.IsPiecewiseContMDiffOn.exists_partition_sum_pathELength_eq`: a piecewise
+  smooth path has a witnessing partition whose piece lengths sum to its `pathELength`.
+
+This is the finite-partition part of Layer 0 of the Hopf--Rinow roadmap. It uses Mathlib's
+`Manifold.pathELength_add`; no separate notion of Riemannian length is introduced.
+
+## References
+
+* M. P. do Carmo, *Riemannian Geometry*, Chapter 1, Definition 2.9 and Chapter 7, Section 2.
+-/
+
+public section
+
+open Set
+open scoped ContDiff Manifold
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+universe u
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H]
+  {I : ModelWithCorners ℝ E H}
+  {M : Type u} [TopologicalSpace M] [ChartedSpace H M]
+  {n : ℕ∞ω} {γ : ℝ → M} {a b : ℝ}
+
+/-- A path is piecewise `C^n` on `[a, b]` if there is a nonempty finite strict partition from
+`a` to `b` such that the path is `C^n` on every closed piece. The partition has `k + 1` pieces
+and `k + 2` vertices, so the definition includes the one-piece case but excludes a vacuous
+zero-piece witness.
+
+The partition is existential data because it witnesses a property of `γ`; it is not part of the
+identity of a path. In particular, refining a partition does not create a different object. -/
+def IsPiecewiseContMDiffOn (I : ModelWithCorners ℝ E H) (n : ℕ∞ω)
+    (γ : ℝ → M) (a b : ℝ) : Prop :=
+  ∃ (k : ℕ) (τ : Fin (k + 2) → ℝ),
+    τ 0 = a ∧
+      τ (Fin.last (k + 1)) = b ∧
+      (∀ i : Fin (k + 1), τ i.castSucc < τ i.succ) ∧
+      ∀ i : Fin (k + 1),
+        ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc (τ i.castSucc) (τ i.succ))
+
+/-- `IsPiecewiseContMDiffOn` unfolded to a finite strict partition and the regularity of every
+piece. -/
+theorem isPiecewiseContMDiffOn_iff :
+    IsPiecewiseContMDiffOn I n γ a b ↔
+      ∃ (k : ℕ) (τ : Fin (k + 2) → ℝ),
+        τ 0 = a ∧
+          τ (Fin.last (k + 1)) = b ∧
+          (∀ i : Fin (k + 1), τ i.castSucc < τ i.succ) ∧
+          ∀ i : Fin (k + 1),
+            ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ
+              (Icc (τ i.castSucc) (τ i.succ)) :=
+  Iff.rfl
+
+/-- The endpoints of a piecewise smooth path are strictly ordered. -/
+theorem IsPiecewiseContMDiffOn.lt (h : IsPiecewiseContMDiffOn I n γ a b) : a < b := by
+  obtain ⟨k, τ, rfl, rfl, hτ, -⟩ := h
+  exact (Fin.strictMono_iff_lt_succ.mpr hτ) Fin.last_pos'
+
+/-- A `C^n` path on a nondegenerate interval is piecewise `C^n`, witnessed by the partition
+consisting only of its two endpoints. -/
+theorem IsPiecewiseContMDiffOn.of_contMDiffOn (hab : a < b)
+    (hγ : ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc a b)) :
+    IsPiecewiseContMDiffOn I n γ a b := by
+  let τ : Fin 2 → ℝ := ![a, b]
+  refine ⟨0, τ, ?_, ?_, ?_, ?_⟩
+  · simp [τ]
+  · simp [τ]
+  · intro i
+    fin_cases i
+    simpa [τ] using hab
+  · intro i
+    fin_cases i
+    simpa [τ] using hγ
+
+/-- Restricting the requested differentiability order preserves piecewise smoothness. -/
+theorem IsPiecewiseContMDiffOn.of_le {m : ℕ∞ω} (h : IsPiecewiseContMDiffOn I n γ a b)
+    (hmn : m ≤ n) : IsPiecewiseContMDiffOn I m γ a b := by
+  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h
+  exact ⟨k, τ, hτa, hτb, hτ, fun i ↦ (hγ i).of_le hmn⟩
+
+/-- Continuity glues across a finite ordered partition. This is the induction underlying
+`IsPiecewiseContMDiffOn.continuousOn`. -/
+private theorem continuousOn_Icc_of_partition
+    {r : ℕ} (τ : Fin (r + 1) → ℝ)
+    (hτ : ∀ i : Fin r, τ i.castSucc ≤ τ i.succ)
+    (hγ : ∀ i : Fin r, ContinuousOn γ (Icc (τ i.castSucc) (τ i.succ))) :
+    ContinuousOn γ (Icc (τ 0) (τ (Fin.last r))) := by
+  induction r with
+  | zero => simp
+  | succ r ih =>
+      have hτmono : Monotone τ := Fin.monotone_iff_le_succ.mpr hτ
+      have hfirst : τ 0 ≤ τ (Fin.last r).castSucc := hτmono (Fin.zero_le _)
+      rw [← Fin.succ_last r]
+      rw [← Icc_union_Icc_eq_Icc
+        hfirst (hτ (Fin.last r))]
+      rw [continuousOn_union_iff_of_isClosed isClosed_Icc isClosed_Icc]
+      refine ⟨ih (fun i ↦ τ i.castSucc) (fun i ↦ ?_) (fun i ↦ ?_), ?_⟩
+      · simpa only [Fin.succ_castSucc] using hτ i.castSucc
+      · simpa only [Fin.succ_castSucc] using hγ i.castSucc
+      · simpa using hγ (Fin.last r)
+
+/-- Piecewise `C^n` regularity implies continuity on the whole interval. -/
+theorem IsPiecewiseContMDiffOn.continuousOn (h : IsPiecewiseContMDiffOn I n γ a b) :
+    ContinuousOn γ (Icc a b) := by
+  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h
+  rw [← hτa, ← hτb]
+  exact continuousOn_Icc_of_partition τ (fun i ↦ (hτ i).le)
+    (fun i ↦ (hγ i).continuousOn)
+
+variable [∀ x : M, ENorm (TangentSpace I x)]
+
+/-- **Path length is additive over every finite ordered partition.** The sum of the lengths of
+the restrictions to consecutive pieces is the length over the interval between the first and last
+partition points. No regularity hypothesis is needed: this is finite iteration of Mathlib's
+`Manifold.pathELength_add`. -/
+theorem sum_pathELength_eq {r : ℕ} (τ : Fin (r + 1) → ℝ)
+    (hτ : ∀ i : Fin r, τ i.castSucc ≤ τ i.succ) :
+    ∑ i : Fin r, Manifold.pathELength I γ (τ i.castSucc) (τ i.succ) =
+      Manifold.pathELength I γ (τ 0) (τ (Fin.last r)) := by
+  induction r with
+  | zero => simp
+  | succ r ih =>
+      rw [Fin.sum_univ_castSucc]
+      have hfirst :
+        (∑ i : Fin r,
+          Manifold.pathELength I γ (τ i.castSucc.castSucc) (τ i.castSucc.succ)) =
+            Manifold.pathELength I γ (τ 0) (τ (Fin.last r).castSucc) := by
+        simpa only [Fin.succ_castSucc, Fin.castSucc_zero] using
+          ih (fun i ↦ τ i.castSucc) (fun i ↦ by
+            simpa only [Fin.succ_castSucc] using hτ i.castSucc)
+      rw [hfirst]
+      have hτmono : Monotone τ := Fin.monotone_iff_le_succ.mpr hτ
+      have hzero : τ 0 ≤ τ (Fin.last r).castSucc := hτmono (Fin.zero_le _)
+      simpa only [Fin.succ_last] using
+        Manifold.pathELength_add (I := I) (γ := γ)
+          hzero (hτ (Fin.last r))
+
+/-- Ordered finite partitions with the same first and last points give the same sum of piece
+lengths. In particular, inserting any finite collection of refinement points leaves the computed
+length unchanged. -/
+theorem sum_pathELength_eq_of_endpoints_eq
+    {r s : ℕ} {τ : Fin (r + 1) → ℝ} {σ : Fin (s + 1) → ℝ}
+    (hτ : ∀ i : Fin r, τ i.castSucc ≤ τ i.succ)
+    (hσ : ∀ i : Fin s, σ i.castSucc ≤ σ i.succ)
+    (h₀ : τ 0 = σ 0) (h₁ : τ (Fin.last r) = σ (Fin.last s)) :
+    ∑ i : Fin r, Manifold.pathELength I γ (τ i.castSucc) (τ i.succ) =
+      ∑ i : Fin s, Manifold.pathELength I γ (σ i.castSucc) (σ i.succ) := by
+  rw [sum_pathELength_eq τ hτ, sum_pathELength_eq σ hσ, h₀, h₁]
+
+/-- A piecewise smooth path admits a strict partition on which it is smooth and whose sum of
+piece lengths is exactly its `Manifold.pathELength` on the full interval. This is the form used to
+iterate corner smoothing over a partition. -/
+theorem IsPiecewiseContMDiffOn.exists_partition_sum_pathELength_eq
+    (h : IsPiecewiseContMDiffOn I n γ a b) :
+    ∃ (k : ℕ) (τ : Fin (k + 2) → ℝ),
+      τ 0 = a ∧
+        τ (Fin.last (k + 1)) = b ∧
+        (∀ i : Fin (k + 1), τ i.castSucc < τ i.succ) ∧
+        (∀ i : Fin (k + 1),
+          ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ
+            (Icc (τ i.castSucc) (τ i.succ))) ∧
+        ∑ i : Fin (k + 1), Manifold.pathELength I γ (τ i.castSucc) (τ i.succ) =
+          Manifold.pathELength I γ a b := by
+  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h
+  refine ⟨k, τ, hτa, hτb, hτ, hγ, ?_⟩
+  rw [sum_pathELength_eq τ (fun i ↦ (hτ i).le), hτa, hτb]
+
+end TauCeti.Manifold

--- a/TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean
@@ -105,7 +105,7 @@ theorem IsPiecewiseContMDiffOn.exists_partition_sum_pathELength_eq
             (Icc (τ i.castSucc) (τ i.succ))) ∧
         ∑ i : Fin (k + 1), Manifold.pathELength I γ (τ i.castSucc) (τ i.succ) =
           Manifold.pathELength I γ a b := by
-  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h
+  obtain ⟨k, τ, hτa, hτb, hτ, hγ⟩ := h.exists_partition
   refine ⟨k, τ, hτa, hτb, hτ, hγ, ?_⟩
   rw [sum_pathELength_eq τ (fun i ↦ (hτ i).le), hτa, hτb]
 

--- a/TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean
@@ -78,19 +78,6 @@ def IsPiecewiseContMDiffOn (I : ModelWithCorners ℝ E H) (n : ℕ∞ω)
       ∀ i : Fin (k + 1),
         ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ (Icc (τ i.castSucc) (τ i.succ))
 
-/-- `IsPiecewiseContMDiffOn` unfolded to a finite strict partition and the regularity of every
-piece. -/
-theorem isPiecewiseContMDiffOn_iff :
-    IsPiecewiseContMDiffOn I n γ a b ↔
-      ∃ (k : ℕ) (τ : Fin (k + 2) → ℝ),
-        τ 0 = a ∧
-          τ (Fin.last (k + 1)) = b ∧
-          (∀ i : Fin (k + 1), τ i.castSucc < τ i.succ) ∧
-          ∀ i : Fin (k + 1),
-            ContMDiffOn (modelWithCornersSelf ℝ ℝ) I n γ
-              (Icc (τ i.castSucc) (τ i.succ)) :=
-  Iff.rfl
-
 /-- The endpoints of a piecewise smooth path are strictly ordered. -/
 theorem IsPiecewiseContMDiffOn.lt (h : IsPiecewiseContMDiffOn I n γ a b) : a < b := by
   obtain ⟨k, τ, rfl, rfl, hτ, -⟩ := h


### PR DESCRIPTION
This PR defines finite-partition piecewise `C^n` regularity for manifold paths and proves that the sum of `Manifold.pathELength` over the pieces is independent of the witnessing partition. It keeps the partition existential, proves that piecewise smooth paths are continuous on the whole interval, supplies the one-piece constructor and order-restriction API, and exposes the strict partition together with the exact length-sum identity needed by the smoothing construction.

The exact roadmap target is `HopfRinow/README.md`, Layer 0, milestone “Corner smoothing and the piecewise-`C¹` comparison,” specifically “define a piecewise-`C¹` path by a finite partition and compute its length as the sum of Mathlib `pathELength`s on the pieces” and “prove independence under refinement.” This is the most effective current step because distance finiteness and binary corner smoothing are already covered by open PRs #3653 and #3656, while the finite-partition API that turns binary smoothing into the roadmap’s full piecewise-`C¹` comparison was unclaimed and absent from `main`. After this PR, the milestone still needs iteration of binary corner smoothing over the supplied partition and the resulting equality between the piecewise-`C¹` and Mathlib `C¹` infima; Layer 0 separately retains regular reparametrization, lower semicontinuity, and open-submanifold restriction.

Add `TauCeti/Geometry/Manifold/Riemannian/PiecewisePath.lean` (208 lines). The core finite induction proves the stronger statement that any two ordered partitions with equal endpoints have equal sums, so refinement independence is immediate without introducing a second Riemannian length definition or carrying refinement data in path identity.

No Mathlib infrastructure or external formalization is vendored. The implementation consumes Mathlib’s `Manifold.pathELength_add`, finite-tuple monotonicity, and closed-set continuity gluing directly. The mathematical convention follows do Carmo, *Riemannian Geometry*, Chapter 1, Definition 2.9 and Chapter 7, Section 2, as credited in the module documentation.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"piecewise-c1-path-refinement"}-->

🤖 Prepared with Codex
