### PR TITLE
feat: build the derivation Lie algebra of a non-associative algebra

### DIFF
--- a/TauCeti/Algebra/Lie/Derivation.lean
+++ b/TauCeti/Algebra/Lie/Derivation.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Algebra.Lie.Derivation.Basic
 public import Mathlib.Algebra.Lie.NonUnitalNonAssocAlgebra
-public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.Derivation.Lie
 
 /-!
@@ -18,8 +17,8 @@ A **derivation** of an algebra `A` is a linear map `D` obeying the Leibniz rule
 commutative or unital, and the derivations of any algebra are closed under the commutator
 `⁅D, E⁆ = D ∘ E - E ∘ D`, so they always form a Lie algebra `Der A`.  Mathlib has this construction
 twice over, but only in special cases: `Derivation R A M` needs `A` commutative and associative, and
-`LieDerivation R L M` needs the multiplication to be a Lie bracket.  The exceptional Lie algebras
-are derivation algebras of algebras of neither kind -- `G₂ = Der 𝕆` for the octonions
+`LieDerivation R L M` needs the multiplication to be a Lie bracket.  Two of the exceptional Lie
+algebras are derivation algebras of algebras of neither kind -- `G₂ = Der 𝕆` for the octonions
 (`TauCeti.Octonion`) and `F₄ = Der H₃(𝕆)` for the Albert algebra -- so this file builds `Der A` for
 an arbitrary non-unital non-associative algebra, and records that both Mathlib constructions are
 instances of it.
@@ -33,16 +32,17 @@ instances of it.
 
 ## Main results
 
-* `TauCeti.derivationLieAlgebra.apply_mul` and `TauCeti.derivationLieAlgebra.lie_mul`: the Leibniz
-  rule, as an identity of linear maps and in the notation of the Lie action of `Der A` on `A`; and
-  `TauCeti.derivationLieAlgebra.apply_one`: a derivation of a unital algebra kills the unit, and
-  `TauCeti.derivationLieAlgebra.apply_mul_eq_zero`: its constants are closed under multiplication.
+* `TauCeti.derivationLieAlgebra.apply_mul_eq_add`: the Leibniz rule;
+  `TauCeti.derivationLieAlgebra.apply_one_eq_zero`: a derivation of a unital algebra kills the
+  unit; and `TauCeti.derivationLieAlgebra.apply_mul_eq_zero`: its constants are closed under
+  multiplication.
 * `TauCeti.ad_mem_derivationLieAlgebra_commutatorRing`: the adjoint action of a Lie algebra is by
   derivations -- the Jacobi identity in Leibniz form.
-* `TauCeti.derivationLieEquiv`: for a commutative associative algebra, `Der A` is Mathlib's
-  `Derivation R A A` with its Lie structure.
-* `TauCeti.commutatorRingDerivationLieEquiv`: for a Lie algebra `L`, the derivations of the
-  underlying non-associative algebra `CommutatorRing L` are Mathlib's `LieDerivation R L L`.
+* `TauCeti.derivationEquivDerivationLieAlgebra`: for a commutative associative algebra, `Der A` is
+  Mathlib's `Derivation R A A` with its Lie structure.
+* `TauCeti.derivationLieAlgebraCommutatorRingEquivLieDerivation`: for a Lie algebra `L`, the
+  derivations of the underlying non-associative algebra `CommutatorRing L` are Mathlib's
+  `LieDerivation R L L`.
 
 ## Implementation notes
 
@@ -62,8 +62,9 @@ line in order to *state* facts about `Module.End R A` as a Lie algebra, but not 
 `↥(derivationLieAlgebra R A)`, whose own Lie structure is carried by the subalgebra.
 
 The simp-normal form of the action of a derivation is the application `(D : Module.End R A) x` of
-the underlying linear map, into which `TauCeti.derivationLieAlgebra.lie_apply` rewrites the Lie
-bracket `⁅D, x⁆`.
+the underlying linear map: Mathlib's `LieSubalgebra.coe_bracket_of_module` and
+`Module.End.lie_apply` already rewrite the Lie bracket `⁅D, x⁆` into it, so no lemma of this file
+needs to say so.
 
 ## References
 
@@ -115,28 +116,15 @@ theorem mem_derivationLieAlgebra {D : Module.End R A} :
 
 namespace derivationLieAlgebra
 
-/-- The Lie action of `Der A` on `A`, inherited from `Module.End R A`, is the application of the
-underlying linear map. -/
-@[simp]
-theorem lie_apply (D : derivationLieAlgebra R A) (x : A) : ⁅D, x⁆ = (D : Module.End R A) x :=
-  rfl
-
 /-- **The Leibniz rule**: a derivation differentiates each factor of a product. -/
-theorem apply_mul (D : derivationLieAlgebra R A) (x y : A) :
+@[simp]
+theorem apply_mul_eq_add (D : derivationLieAlgebra R A) (x y : A) :
     (D : Module.End R A) (x * y)
       = (D : Module.End R A) x * y + x * (D : Module.End R A) y :=
   D.2 x y
 
-/-- **The Leibniz rule, read as a compatibility of the Lie action of `Der A` with the
-multiplication of `A`.**  This is `TauCeti.derivationLieAlgebra.apply_mul` written in the notation
-of the `Der A`-module `A`, and is the sense in which that module is one whose bracket acts by
-derivations; it is stated separately because `TauCeti.derivationLieAlgebra.lie_apply` normalises
-the bracket away, so `simp` never produces this shape on its own. -/
-theorem lie_mul (D : derivationLieAlgebra R A) (x y : A) :
-    ⁅D, x * y⁆ = ⁅D, x⁆ * y + x * ⁅D, y⁆ :=
-  D.2 x y
-
 /-- The commutator of two derivations, evaluated. -/
+@[simp]
 theorem bracket_apply (D E : derivationLieAlgebra R A) (x : A) :
     (⁅D, E⁆ : Module.End R A) x
       = (D : Module.End R A) ((E : Module.End R A) x)
@@ -149,7 +137,7 @@ subalgebra of `A`. -/
 theorem apply_mul_eq_zero {D : derivationLieAlgebra R A} {x y : A}
     (hx : (D : Module.End R A) x = 0) (hy : (D : Module.End R A) y = 0) :
     (D : Module.End R A) (x * y) = 0 := by
-  rw [apply_mul, hx, hy, zero_mul, mul_zero, add_zero]
+  rw [apply_mul_eq_add, hx, hy, zero_mul, mul_zero, add_zero]
 
 /-- A derivation is determined by its values. -/
 @[ext]
@@ -169,12 +157,9 @@ variable {R : Type u} {A : Type v} [CommRing R] [NonAssocRing A] [Module R A]
 /-- **A derivation of a unital algebra kills the unit**: `1 = 1 * 1` forces `D 1 = D 1 + D 1`.
 Only unitality is used, not associativity. -/
 @[simp]
-theorem derivationLieAlgebra.apply_one (D : derivationLieAlgebra R A) :
+theorem derivationLieAlgebra.apply_one_eq_zero (D : derivationLieAlgebra R A) :
     (D : Module.End R A) 1 = 0 := by
-  have h := derivationLieAlgebra.apply_mul D 1 1
-  rw [mul_one, mul_one, one_mul] at h
-  nth_rewrite 1 [← add_zero ((D : Module.End R A) 1)] at h
-  exact (add_left_cancel h).symm
+  simpa using derivationLieAlgebra.apply_mul_eq_add D 1 1
 
 end Unital
 
@@ -185,37 +170,48 @@ variable {R : Type u} {A : Type v} {B : Type w} [CommRing R]
   [NonUnitalNonAssocRing A] [Module R A] [SMulCommClass R A A] [IsScalarTower R A A]
   [NonUnitalNonAssocRing B] [Module R B] [SMulCommClass R B B] [IsScalarTower R B B]
 
+omit [SMulCommClass R A A] [IsScalarTower R A A] [SMulCommClass R B B] [IsScalarTower R B B] in
+/-- **The inverse of a multiplicative linear equivalence is multiplicative.**  The hypothesis is an
+unbundled multiplicativity condition on a `LinearEquiv` because Mathlib has no equivalence class for
+non-unital non-associative algebras; `he` says exactly that `e` is an algebra map, and no unitality
+is used. -/
+theorem symm_map_mul (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y) (u v : B) :
+    e.symm (u * v) = e.symm u * e.symm v :=
+  e.injective (by simp [he])
+
+/-- **Conjugation by a multiplicative linear equivalence carries derivations to derivations.** -/
+theorem lieConj_mem_derivationLieAlgebra {e : A ≃ₗ[R] B}
+    (he : ∀ x y : A, e (x * y) = e x * e y) {D : Module.End R A}
+    (hD : D ∈ derivationLieAlgebra R A) : e.lieConj D ∈ derivationLieAlgebra R B :=
+  mem_derivationLieAlgebra.mpr fun x y => by
+    simp only [LinearEquiv.lieConj_apply, LinearEquiv.conj_apply_apply, symm_map_mul e he,
+      mem_derivationLieAlgebra.mp hD, map_add, he, LinearEquiv.apply_symm_apply]
+
 /-- **Derivation algebras are transported along isomorphisms of algebras.**  A multiplicative
 `R`-linear equivalence `e : A ≃ₗ[R] B` conjugates derivations of `A` to derivations of `B`, and the
-resulting map is an isomorphism of Lie algebras.  This is the tool that identifies a concretely
-built `Der A` with an abstractly presented Lie algebra.
-
-The hypothesis is an unbundled multiplicativity condition on a `LinearEquiv` because Mathlib has no
-equivalence class for non-unital non-associative algebras; `he` says exactly that `e` is an algebra
-map, and no unitality is used. -/
+resulting map is an isomorphism of Lie algebras.  This is the tool that transports `Der` between two
+models of the same algebra -- two constructions of the split octonions, say. -/
 def derivationLieAlgebraCongr (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y) :
-    derivationLieAlgebra R A ≃ₗ⁅R⁆ derivationLieAlgebra R B where
-  toFun D := ⟨(e : A →ₗ[R] B) ∘ₗ (D : Module.End R A) ∘ₗ (e.symm : B →ₗ[R] A), fun x y => by
-    have hsymm : e.symm (x * y) = e.symm x * e.symm y :=
-      e.injective (by rw [he, e.apply_symm_apply, e.apply_symm_apply, e.apply_symm_apply])
-    simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe, hsymm,
-      D.2 (e.symm x) (e.symm y), map_add, he, e.apply_symm_apply]⟩
-  invFun D := ⟨(e.symm : B →ₗ[R] A) ∘ₗ (D : Module.End R B) ∘ₗ (e : A →ₗ[R] B), fun x y => by
-    have hsymm : ∀ u v : B, e.symm (u * v) = e.symm u * e.symm v := fun u v =>
-      e.injective (by rw [he, e.apply_symm_apply, e.apply_symm_apply, e.apply_symm_apply])
-    simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe, he,
-      D.2 (e x) (e y), map_add, hsymm, e.symm_apply_apply]⟩
-  map_add' _ _ := by ext x; simp
-  map_smul' _ _ := by ext x; simp
-  map_lie' := by intro D E; ext x; simp
-  left_inv _ := by ext x; simp
-  right_inv _ := by ext x; simp
+    derivationLieAlgebra R A ≃ₗ⁅R⁆ derivationLieAlgebra R B := by
+  apply LieEquiv.ofSubalgebras _ _ e.lieConj
+  refine SetLike.ext fun D => ⟨?_, fun hD => ?_⟩
+  · rintro ⟨E, hE, rfl⟩
+    exact lieConj_mem_derivationLieAlgebra he hE
+  · exact ⟨e.lieConj.symm D, lieConj_mem_derivationLieAlgebra (symm_map_mul e he) hD,
+      e.lieConj.apply_symm_apply D⟩
 
 @[simp]
 theorem derivationLieAlgebraCongr_apply (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y)
     (D : derivationLieAlgebra R A) (x : B) :
     (derivationLieAlgebraCongr e he D : Module.End R B) x
       = e ((D : Module.End R A) (e.symm x)) :=
+  (rfl)
+
+@[simp]
+theorem derivationLieAlgebraCongr_symm_apply (e : A ≃ₗ[R] B)
+    (he : ∀ x y : A, e (x * y) = e x * e y) (D : derivationLieAlgebra R B) (x : A) :
+    ((derivationLieAlgebraCongr e he).symm D : Module.End R A) x
+      = e.symm ((D : Module.End R B) (e x)) :=
   (rfl)
 
 end Congr
@@ -228,7 +224,7 @@ variable {R : Type u} {A : Type v} [CommRing R] [CommRing A] [Algebra R A]
 Leibniz rules `D (x * y) = D x * y + x * D y` and `D (x * y) = x • D y + y • D x` say the same
 thing, and both Lie structures are the commutator of `Module.End R A`, so the identity on
 underlying linear maps is an isomorphism of Lie algebras. -/
-def derivationLieEquiv : Derivation R A A ≃ₗ⁅R⁆ derivationLieAlgebra R A where
+def derivationEquivDerivationLieAlgebra : Derivation R A A ≃ₗ⁅R⁆ derivationLieAlgebra R A where
   toFun D := ⟨(D : A →ₗ[R] A), fun x y => by
     simp only [Derivation.coeFn_coe, Derivation.leibniz, smul_eq_mul]
     ring⟩
@@ -243,13 +239,13 @@ def derivationLieEquiv : Derivation R A A ≃ₗ⁅R⁆ derivationLieAlgebra R A
   right_inv _ := rfl
 
 @[simp]
-theorem derivationLieEquiv_apply (D : Derivation R A A) (x : A) :
-    (derivationLieEquiv D : Module.End R A) x = D x :=
+theorem derivationEquivDerivationLieAlgebra_apply (D : Derivation R A A) (x : A) :
+    (derivationEquivDerivationLieAlgebra D : Module.End R A) x = D x :=
   (rfl)
 
 @[simp]
-theorem derivationLieEquiv_symm_apply (D : derivationLieAlgebra R A) (x : A) :
-    derivationLieEquiv.symm D x = (D : Module.End R A) x :=
+theorem derivationEquivDerivationLieAlgebra_symm_apply (D : derivationLieAlgebra R A) (x : A) :
+    derivationEquivDerivationLieAlgebra.symm D x = (D : Module.End R A) x :=
   (rfl)
 
 end Commutative
@@ -258,47 +254,44 @@ section Lie
 
 variable {R : Type u} {L : Type v} [CommRing R] [LieRing L] [LieAlgebra R L]
 
-/-- **The Leibniz rule in `CommutatorRing L`**, spelled with the bracket.  Regarding a Lie algebra
-as a non-associative algebra with `x * y = ⁅x, y⁆` turns the defining condition of
-`derivationLieAlgebra` into `D ⁅x, y⁆ = ⁅D x, y⁆ + ⁅x, D y⁆`. -/
-theorem mem_derivationLieAlgebra_commutatorRing {D : Module.End R L} :
-    D ∈ derivationLieAlgebra R (CommutatorRing L) ↔
-      ∀ x y : L, D ⁅x, y⁆ = ⁅D x, y⁆ + ⁅x, D y⁆ :=
-  Iff.rfl
-
-/-- The two spellings of the Leibniz rule on a Lie algebra agree: the symmetric form
-`⁅D x, y⁆ + ⁅x, D y⁆` that `derivationLieAlgebra` inherits from the multiplication, and the form
-`⁅x, D y⁆ - ⁅y, D x⁆` that `LieDerivation` is stated with because a Lie algebra carries no right
-action.  They differ by skew symmetry alone. -/
-theorem leibniz_add_iff_leibniz_sub {D : Module.End R L} :
+/-- The two spellings of the Leibniz rule on a Lie ring agree: the symmetric form
+`⁅D x, y⁆ + ⁅x, D y⁆` that `derivationLieAlgebra` inherits from the multiplication of
+`CommutatorRing L`, and the form `⁅x, D y⁆ - ⁅y, D x⁆` that `LieDerivation` is stated with because a
+Lie algebra carries no right action.  They differ by skew symmetry alone, so neither linearity of
+`D` nor the base ring plays any part. -/
+theorem leibniz_add_iff_leibniz_sub {D : L → L} :
     (∀ x y : L, D ⁅x, y⁆ = ⁅D x, y⁆ + ⁅x, D y⁆) ↔
       ∀ x y : L, D ⁅x, y⁆ = ⁅x, D y⁆ - ⁅y, D x⁆ := by
   have key : ∀ x y : L, ⁅D x, y⁆ = -⁅y, D x⁆ := fun x y => (lie_skew (D x) y).symm
   constructor <;> intro h x y <;> rw [h x y, key x y] <;> abel
 
-/-- Membership in `Der (CommutatorRing L)` is exactly the defining condition of a
-`LieDerivation R L L`. -/
-theorem mem_derivationLieAlgebra_commutatorRing_iff {D : Module.End R L} :
+/-- **Membership in `Der (CommutatorRing L)` is exactly the defining condition of a
+`LieDerivation R L L`.**  Regarding a Lie algebra as a non-associative algebra with `x * y = ⁅x, y⁆`
+turns the defining condition of `derivationLieAlgebra` into `D ⁅x, y⁆ = ⁅D x, y⁆ + ⁅x, D y⁆`, which
+`TauCeti.leibniz_add_iff_leibniz_sub` rewrites into the skew form. -/
+theorem mem_derivationLieAlgebra_commutatorRing_iff_apply_lie_eq_sub {D : Module.End R L} :
     D ∈ derivationLieAlgebra R (CommutatorRing L) ↔
       ∀ x y : L, D ⁅x, y⁆ = ⁅x, D y⁆ - ⁅y, D x⁆ :=
-  mem_derivationLieAlgebra_commutatorRing.trans leibniz_add_iff_leibniz_sub
+  mem_derivationLieAlgebra.trans leibniz_add_iff_leibniz_sub
 
 /-- **The adjoint action is by derivations**: `ad x` lies in `Der (CommutatorRing L)`, which is
 exactly the Jacobi identity in Leibniz form.  This is the inner-derivation half of
-`TauCeti.commutatorRingDerivationLieEquiv`. -/
+`TauCeti.derivationLieAlgebraCommutatorRingEquivLieDerivation`. -/
 theorem ad_mem_derivationLieAlgebra_commutatorRing (x : L) :
     LieAlgebra.ad R L x ∈ derivationLieAlgebra R (CommutatorRing L) :=
-  mem_derivationLieAlgebra_commutatorRing.mpr fun y z => leibniz_lie x y z
+  mem_derivationLieAlgebra.mpr fun (y z : L) => leibniz_lie x y z
 
 /-- **Mathlib's `LieDerivation R L L` is `Der (CommutatorRing L)`.**  For the non-associative
 algebra underlying a Lie algebra the two Leibniz rules agree by
-`TauCeti.leibniz_add_iff_leibniz_sub`, and both Lie structures are the commutator of the
-endomorphism ring, so the identity on underlying linear maps is an isomorphism of Lie algebras. -/
-def commutatorRingDerivationLieEquiv :
+`TauCeti.mem_derivationLieAlgebra_commutatorRing_iff_apply_lie_eq_sub`, and both Lie structures are
+the commutator of the endomorphism ring, so the identity on underlying linear maps is an isomorphism
+of Lie algebras. -/
+def derivationLieAlgebraCommutatorRingEquivLieDerivation :
     derivationLieAlgebra R (CommutatorRing L) ≃ₗ⁅R⁆ LieDerivation R L L where
-  toFun D := ⟨D.1, mem_derivationLieAlgebra_commutatorRing_iff.mp D.2⟩
+  toFun D := ⟨D.1, mem_derivationLieAlgebra_commutatorRing_iff_apply_lie_eq_sub.mp D.2⟩
   invFun D := ⟨(D : L →ₗ[R] L),
-    mem_derivationLieAlgebra_commutatorRing_iff.mpr fun x y => D.apply_lie_eq_sub x y⟩
+    mem_derivationLieAlgebra_commutatorRing_iff_apply_lie_eq_sub.mpr fun x y =>
+      D.apply_lie_eq_sub x y⟩
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
   map_lie' := rfl
@@ -306,9 +299,15 @@ def commutatorRingDerivationLieEquiv :
   right_inv _ := rfl
 
 @[simp]
-theorem commutatorRingDerivationLieEquiv_apply
+theorem derivationLieAlgebraCommutatorRingEquivLieDerivation_apply
     (D : derivationLieAlgebra R (CommutatorRing L)) (x : L) :
-    commutatorRingDerivationLieEquiv D x = D.1 x :=
+    derivationLieAlgebraCommutatorRingEquivLieDerivation D x = D.1 x :=
+  (rfl)
+
+@[simp]
+theorem derivationLieAlgebraCommutatorRingEquivLieDerivation_symm_apply
+    (D : LieDerivation R L L) (x : L) :
+    (derivationLieAlgebraCommutatorRingEquivLieDerivation.symm D).1 x = D x :=
   (rfl)
 
 end Lie

--- a/TauCeti/Algebra/Lie/Derivation.lean
+++ b/TauCeti/Algebra/Lie/Derivation.lean
@@ -1,0 +1,316 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Derivation.Basic
+public import Mathlib.Algebra.Lie.NonUnitalNonAssocAlgebra
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+public import Mathlib.RingTheory.Derivation.Lie
+
+/-!
+# The derivation Lie algebra of a non-associative algebra
+
+A **derivation** of an algebra `A` is a linear map `D` obeying the Leibniz rule
+`D (x * y) = D x * y + x * D y`.  Nothing in that rule asks the multiplication to be associative,
+commutative or unital, and the derivations of any algebra are closed under the commutator
+`⁅D, E⁆ = D ∘ E - E ∘ D`, so they always form a Lie algebra `Der A`.  Mathlib has this construction
+twice over, but only in special cases: `Derivation R A M` needs `A` commutative and associative, and
+`LieDerivation R L M` needs the multiplication to be a Lie bracket.  The exceptional Lie algebras
+are derivation algebras of algebras of neither kind -- `G₂ = Der 𝕆` for the octonions
+(`TauCeti.Octonion`) and `F₄ = Der H₃(𝕆)` for the Albert algebra -- so this file builds `Der A` for
+an arbitrary non-unital non-associative algebra, and records that both Mathlib constructions are
+instances of it.
+
+## Main definitions
+
+* `TauCeti.derivationLieAlgebra R A`: the derivations of `A`, as a Lie subalgebra of
+  `Module.End R A`.
+* `TauCeti.derivationLieAlgebraCongr`: an isomorphism of algebras induces an isomorphism of their
+  derivation Lie algebras, by conjugation.
+
+## Main results
+
+* `TauCeti.derivationLieAlgebra.apply_mul` and `TauCeti.derivationLieAlgebra.lie_mul`: the Leibniz
+  rule, as an identity of linear maps and in the notation of the Lie action of `Der A` on `A`; and
+  `TauCeti.derivationLieAlgebra.apply_one`: a derivation of a unital algebra kills the unit, and
+  `TauCeti.derivationLieAlgebra.apply_mul_eq_zero`: its constants are closed under multiplication.
+* `TauCeti.ad_mem_derivationLieAlgebra_commutatorRing`: the adjoint action of a Lie algebra is by
+  derivations -- the Jacobi identity in Leibniz form.
+* `TauCeti.derivationLieEquiv`: for a commutative associative algebra, `Der A` is Mathlib's
+  `Derivation R A A` with its Lie structure.
+* `TauCeti.commutatorRingDerivationLieEquiv`: for a Lie algebra `L`, the derivations of the
+  underlying non-associative algebra `CommutatorRing L` are Mathlib's `LieDerivation R L L`.
+
+## Implementation notes
+
+`Der A` is a *bundled Lie subalgebra* of `Module.End R A` rather than a fresh carrier type with
+hand-built instances: the `LieRing` and `LieAlgebra R` structures, the `Module R`-structure, the
+action of `Der A` on `A` as a Lie module, and the lattice API then all come from Mathlib's
+`LieSubalgebra`, and the only thing left to prove is that the commutator of two derivations is a
+derivation.  This is also why the base is a `CommRing` and `A` a `NonUnitalNonAssocRing`: a Lie ring
+is an additive *group*, so the semiring-level hypotheses under which the Leibniz rule still makes
+sense do not suffice to make `Der A` one.
+
+The Lie bracket of `Module.End R A` is the ring commutator, which Mathlib deliberately keeps out of
+the global instance set (`LieRing.ofAssociativeRing`) because it clashes with the module action; it
+is a local instance here, exactly as in `Mathlib/Algebra/Lie/OfAssociative.lean`.  A file consuming
+`derivationLieAlgebra` needs the same `attribute [local instance 100] LieRing.ofAssociativeRing`
+line in order to *state* facts about `Module.End R A` as a Lie algebra, but not in order to use
+`↥(derivationLieAlgebra R A)`, whose own Lie structure is carried by the subalgebra.
+
+The simp-normal form of the action of a derivation is the application `(D : Module.End R A) x` of
+the underlying linear map, into which `TauCeti.derivationLieAlgebra.lie_apply` rewrites the Lie
+bracket `⁅D, x⁆`.
+
+## References
+
+* [Highest-weight roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md),
+  Layer 8, whose `derivationLieAlgebra` this is: the derivation algebra through which the split
+  octonions and the Albert algebra produce `G₂` and `F₄`.
+* N. Jacobson, *Lie Algebras* (1962), Chapter I, §2, and Chapter VII.
+-/
+
+public section
+
+namespace TauCeti
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+universe u v w
+
+section Defs
+
+variable (R : Type u) (A : Type v) [CommRing R] [NonUnitalNonAssocRing A] [Module R A]
+  [SMulCommClass R A A] [IsScalarTower R A A]
+
+/-- **The derivation Lie algebra** `Der A` of a non-unital non-associative `R`-algebra `A`: the
+`R`-linear maps `D : A → A` satisfying the Leibniz rule `D (x * y) = D x * y + x * D y`, a Lie
+subalgebra of `Module.End R A` under the commutator bracket.
+
+The Leibniz rule is preserved by sums and by scalar multiples because the multiplication of `A` is
+`R`-bilinear, and by the commutator because the "second derivative" terms `D (E x) * y` and
+`x * D (E y)` that the composite `D ∘ E` contributes cancel against those of `E ∘ D`. -/
+def derivationLieAlgebra : LieSubalgebra R (Module.End R A) where
+  carrier := {D | ∀ x y : A, D (x * y) = D x * y + x * D y}
+  add_mem' hD hE x y := by
+    simp only [LinearMap.add_apply, hD x y, hE x y, add_mul, mul_add]
+    abel
+  zero_mem' x y := by simp
+  smul_mem' r _ hD x y := by
+    simp only [LinearMap.smul_apply, hD x y, smul_add, smul_mul_assoc, mul_smul_comm]
+  lie_mem' hD hE x y := by
+    simp only [Ring.lie_def, LinearMap.sub_apply, Module.End.mul_apply, hE x y, hD x y, map_add,
+      hD _ y, hD x _, hE _ y, hE x _, sub_mul, mul_sub]
+    abel
+
+variable {R A}
+
+@[simp]
+theorem mem_derivationLieAlgebra {D : Module.End R A} :
+    D ∈ derivationLieAlgebra R A ↔ ∀ x y : A, D (x * y) = D x * y + x * D y :=
+  Iff.rfl
+
+namespace derivationLieAlgebra
+
+/-- The Lie action of `Der A` on `A`, inherited from `Module.End R A`, is the application of the
+underlying linear map. -/
+@[simp]
+theorem lie_apply (D : derivationLieAlgebra R A) (x : A) : ⁅D, x⁆ = (D : Module.End R A) x :=
+  rfl
+
+/-- **The Leibniz rule**: a derivation differentiates each factor of a product. -/
+theorem apply_mul (D : derivationLieAlgebra R A) (x y : A) :
+    (D : Module.End R A) (x * y)
+      = (D : Module.End R A) x * y + x * (D : Module.End R A) y :=
+  D.2 x y
+
+/-- **The Leibniz rule, read as a compatibility of the Lie action of `Der A` with the
+multiplication of `A`.**  This is `TauCeti.derivationLieAlgebra.apply_mul` written in the notation
+of the `Der A`-module `A`, and is the sense in which that module is one whose bracket acts by
+derivations; it is stated separately because `TauCeti.derivationLieAlgebra.lie_apply` normalises
+the bracket away, so `simp` never produces this shape on its own. -/
+theorem lie_mul (D : derivationLieAlgebra R A) (x y : A) :
+    ⁅D, x * y⁆ = ⁅D, x⁆ * y + x * ⁅D, y⁆ :=
+  D.2 x y
+
+/-- The commutator of two derivations, evaluated. -/
+theorem bracket_apply (D E : derivationLieAlgebra R A) (x : A) :
+    (⁅D, E⁆ : Module.End R A) x
+      = (D : Module.End R A) ((E : Module.End R A) x)
+        - (E : Module.End R A) ((D : Module.End R A) x) :=
+  rfl
+
+/-- **The constants of a derivation are closed under multiplication**: if `D` kills `x` and `y`
+then it kills `x * y`.  Together with linearity this says that the kernel of a derivation is a
+subalgebra of `A`. -/
+theorem apply_mul_eq_zero {D : derivationLieAlgebra R A} {x y : A}
+    (hx : (D : Module.End R A) x = 0) (hy : (D : Module.End R A) y = 0) :
+    (D : Module.End R A) (x * y) = 0 := by
+  rw [apply_mul, hx, hy, zero_mul, mul_zero, add_zero]
+
+/-- A derivation is determined by its values. -/
+@[ext]
+theorem ext {D E : derivationLieAlgebra R A}
+    (h : ∀ x : A, (D : Module.End R A) x = (E : Module.End R A) x) : D = E :=
+  Subtype.ext (LinearMap.ext h)
+
+end derivationLieAlgebra
+
+end Defs
+
+section Unital
+
+variable {R : Type u} {A : Type v} [CommRing R] [NonAssocRing A] [Module R A]
+  [SMulCommClass R A A] [IsScalarTower R A A]
+
+/-- **A derivation of a unital algebra kills the unit**: `1 = 1 * 1` forces `D 1 = D 1 + D 1`.
+Only unitality is used, not associativity. -/
+@[simp]
+theorem derivationLieAlgebra.apply_one (D : derivationLieAlgebra R A) :
+    (D : Module.End R A) 1 = 0 := by
+  have h := derivationLieAlgebra.apply_mul D 1 1
+  rw [mul_one, mul_one, one_mul] at h
+  nth_rewrite 1 [← add_zero ((D : Module.End R A) 1)] at h
+  exact (add_left_cancel h).symm
+
+end Unital
+
+
+section Congr
+
+variable {R : Type u} {A : Type v} {B : Type w} [CommRing R]
+  [NonUnitalNonAssocRing A] [Module R A] [SMulCommClass R A A] [IsScalarTower R A A]
+  [NonUnitalNonAssocRing B] [Module R B] [SMulCommClass R B B] [IsScalarTower R B B]
+
+/-- **Derivation algebras are transported along isomorphisms of algebras.**  A multiplicative
+`R`-linear equivalence `e : A ≃ₗ[R] B` conjugates derivations of `A` to derivations of `B`, and the
+resulting map is an isomorphism of Lie algebras.  This is the tool that identifies a concretely
+built `Der A` with an abstractly presented Lie algebra.
+
+The hypothesis is an unbundled multiplicativity condition on a `LinearEquiv` because Mathlib has no
+equivalence class for non-unital non-associative algebras; `he` says exactly that `e` is an algebra
+map, and no unitality is used. -/
+def derivationLieAlgebraCongr (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y) :
+    derivationLieAlgebra R A ≃ₗ⁅R⁆ derivationLieAlgebra R B where
+  toFun D := ⟨(e : A →ₗ[R] B) ∘ₗ (D : Module.End R A) ∘ₗ (e.symm : B →ₗ[R] A), fun x y => by
+    have hsymm : e.symm (x * y) = e.symm x * e.symm y :=
+      e.injective (by rw [he, e.apply_symm_apply, e.apply_symm_apply, e.apply_symm_apply])
+    simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe, hsymm,
+      D.2 (e.symm x) (e.symm y), map_add, he, e.apply_symm_apply]⟩
+  invFun D := ⟨(e.symm : B →ₗ[R] A) ∘ₗ (D : Module.End R B) ∘ₗ (e : A →ₗ[R] B), fun x y => by
+    have hsymm : ∀ u v : B, e.symm (u * v) = e.symm u * e.symm v := fun u v =>
+      e.injective (by rw [he, e.apply_symm_apply, e.apply_symm_apply, e.apply_symm_apply])
+    simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe, he,
+      D.2 (e x) (e y), map_add, hsymm, e.symm_apply_apply]⟩
+  map_add' _ _ := by ext x; simp
+  map_smul' _ _ := by ext x; simp
+  map_lie' := by intro D E; ext x; simp
+  left_inv _ := by ext x; simp
+  right_inv _ := by ext x; simp
+
+@[simp]
+theorem derivationLieAlgebraCongr_apply (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y)
+    (D : derivationLieAlgebra R A) (x : B) :
+    (derivationLieAlgebraCongr e he D : Module.End R B) x
+      = e ((D : Module.End R A) (e.symm x)) :=
+  (rfl)
+
+end Congr
+
+section Commutative
+
+variable {R : Type u} {A : Type v} [CommRing R] [CommRing A] [Algebra R A]
+
+/-- **Mathlib's `Derivation R A A` is `Der A`.**  For a commutative associative algebra the two
+Leibniz rules `D (x * y) = D x * y + x * D y` and `D (x * y) = x • D y + y • D x` say the same
+thing, and both Lie structures are the commutator of `Module.End R A`, so the identity on
+underlying linear maps is an isomorphism of Lie algebras. -/
+def derivationLieEquiv : Derivation R A A ≃ₗ⁅R⁆ derivationLieAlgebra R A where
+  toFun D := ⟨(D : A →ₗ[R] A), fun x y => by
+    simp only [Derivation.coeFn_coe, Derivation.leibniz, smul_eq_mul]
+    ring⟩
+  invFun D := Derivation.mk' (D : Module.End R A) fun x y => by
+    rw [D.2 x y]
+    simp only [smul_eq_mul]
+    ring
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  map_lie' := rfl
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+@[simp]
+theorem derivationLieEquiv_apply (D : Derivation R A A) (x : A) :
+    (derivationLieEquiv D : Module.End R A) x = D x :=
+  (rfl)
+
+@[simp]
+theorem derivationLieEquiv_symm_apply (D : derivationLieAlgebra R A) (x : A) :
+    derivationLieEquiv.symm D x = (D : Module.End R A) x :=
+  (rfl)
+
+end Commutative
+
+section Lie
+
+variable {R : Type u} {L : Type v} [CommRing R] [LieRing L] [LieAlgebra R L]
+
+/-- **The Leibniz rule in `CommutatorRing L`**, spelled with the bracket.  Regarding a Lie algebra
+as a non-associative algebra with `x * y = ⁅x, y⁆` turns the defining condition of
+`derivationLieAlgebra` into `D ⁅x, y⁆ = ⁅D x, y⁆ + ⁅x, D y⁆`. -/
+theorem mem_derivationLieAlgebra_commutatorRing {D : Module.End R L} :
+    D ∈ derivationLieAlgebra R (CommutatorRing L) ↔
+      ∀ x y : L, D ⁅x, y⁆ = ⁅D x, y⁆ + ⁅x, D y⁆ :=
+  Iff.rfl
+
+/-- The two spellings of the Leibniz rule on a Lie algebra agree: the symmetric form
+`⁅D x, y⁆ + ⁅x, D y⁆` that `derivationLieAlgebra` inherits from the multiplication, and the form
+`⁅x, D y⁆ - ⁅y, D x⁆` that `LieDerivation` is stated with because a Lie algebra carries no right
+action.  They differ by skew symmetry alone. -/
+theorem leibniz_add_iff_leibniz_sub {D : Module.End R L} :
+    (∀ x y : L, D ⁅x, y⁆ = ⁅D x, y⁆ + ⁅x, D y⁆) ↔
+      ∀ x y : L, D ⁅x, y⁆ = ⁅x, D y⁆ - ⁅y, D x⁆ := by
+  have key : ∀ x y : L, ⁅D x, y⁆ = -⁅y, D x⁆ := fun x y => (lie_skew (D x) y).symm
+  constructor <;> intro h x y <;> rw [h x y, key x y] <;> abel
+
+/-- Membership in `Der (CommutatorRing L)` is exactly the defining condition of a
+`LieDerivation R L L`. -/
+theorem mem_derivationLieAlgebra_commutatorRing_iff {D : Module.End R L} :
+    D ∈ derivationLieAlgebra R (CommutatorRing L) ↔
+      ∀ x y : L, D ⁅x, y⁆ = ⁅x, D y⁆ - ⁅y, D x⁆ :=
+  mem_derivationLieAlgebra_commutatorRing.trans leibniz_add_iff_leibniz_sub
+
+/-- **The adjoint action is by derivations**: `ad x` lies in `Der (CommutatorRing L)`, which is
+exactly the Jacobi identity in Leibniz form.  This is the inner-derivation half of
+`TauCeti.commutatorRingDerivationLieEquiv`. -/
+theorem ad_mem_derivationLieAlgebra_commutatorRing (x : L) :
+    LieAlgebra.ad R L x ∈ derivationLieAlgebra R (CommutatorRing L) :=
+  mem_derivationLieAlgebra_commutatorRing.mpr fun y z => leibniz_lie x y z
+
+/-- **Mathlib's `LieDerivation R L L` is `Der (CommutatorRing L)`.**  For the non-associative
+algebra underlying a Lie algebra the two Leibniz rules agree by
+`TauCeti.leibniz_add_iff_leibniz_sub`, and both Lie structures are the commutator of the
+endomorphism ring, so the identity on underlying linear maps is an isomorphism of Lie algebras. -/
+def commutatorRingDerivationLieEquiv :
+    derivationLieAlgebra R (CommutatorRing L) ≃ₗ⁅R⁆ LieDerivation R L L where
+  toFun D := ⟨D.1, mem_derivationLieAlgebra_commutatorRing_iff.mp D.2⟩
+  invFun D := ⟨(D : L →ₗ[R] L),
+    mem_derivationLieAlgebra_commutatorRing_iff.mpr fun x y => D.apply_lie_eq_sub x y⟩
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  map_lie' := rfl
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+@[simp]
+theorem commutatorRingDerivationLieEquiv_apply
+    (D : derivationLieAlgebra R (CommutatorRing L)) (x : L) :
+    commutatorRingDerivationLieEquiv D x = D.1 x :=
+  (rfl)
+
+end Lie
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Derivation.lean
+++ b/TauCeti/Algebra/Lie/Derivation.lean
@@ -63,8 +63,22 @@ line in order to *state* facts about `Module.End R A` as a Lie algebra, but not 
 
 The simp-normal form of the action of a derivation is the application `(D : Module.End R A) x` of
 the underlying linear map: Mathlib's `LieSubalgebra.coe_bracket_of_module` and
-`Module.End.lie_apply` already rewrite the Lie bracket `⁅D, x⁆` into it, so no lemma of this file
-needs to say so.
+`Module.End.lie_apply` already rewrite the Lie bracket `⁅D, x⁆` into it, and those two lemmas
+together with `LieHom.lie_apply` likewise evaluate the commutator `⁅D, E⁆` of two derivations, so no
+lemma of this file needs to say so.
+
+The `_apply` and `_symm_apply` lemmas of `derivationEquivDerivationLieAlgebra` and
+`derivationLieAlgebraCommutatorRingEquivLieDerivation` are proved by `rfl`, and no rewriting lemma
+could replace it: those two equivalences are *defined* to be the identity on the underlying linear
+map, so the right-hand side of each lemma is literally the `toFun`/`invFun` field of the structure
+instance just above it.  Mathlib proves the same shape the same way (`LieEquiv.ofSubalgebras_apply`,
+`LinearEquiv.lieConj_apply`).  The point of stating them is precisely that no *consumer* then has to
+unfold the definition.  The parentheses in `(rfl)` are the module system's: the definitions' bodies
+are not `@[expose]`d, so a bare `rfl` -- whose proof term is exported -- fails with "not a
+definitional equality", while the parenthesised form elaborates inside this module, where the bodies
+are visible.  By contrast `derivationLieAlgebraCongr` is *not* the identity but a composite of
+`LieEquiv.ofSubalgebras` and `LinearEquiv.lieConj`, so its two lemmas are proved from those
+constructions' own `apply` lemmas rather than by unfolding.
 
 ## References
 
@@ -123,17 +137,10 @@ theorem apply_mul_eq_add (D : derivationLieAlgebra R A) (x y : A) :
       = (D : Module.End R A) x * y + x * (D : Module.End R A) y :=
   D.2 x y
 
-/-- The commutator of two derivations, evaluated. -/
-@[simp]
-theorem bracket_apply (D E : derivationLieAlgebra R A) (x : A) :
-    (⁅D, E⁆ : Module.End R A) x
-      = (D : Module.End R A) ((E : Module.End R A) x)
-        - (E : Module.End R A) ((D : Module.End R A) x) :=
-  rfl
-
 /-- **The constants of a derivation are closed under multiplication**: if `D` kills `x` and `y`
-then it kills `x * y`.  Together with linearity this says that the kernel of a derivation is a
-subalgebra of `A`. -/
+then it kills `x * y`.  Together with linearity this says that the kernel of a derivation is an
+`R`-submodule of `A` closed under multiplication -- a subalgebra where `A` is unital and
+associative enough for `Subalgebra` to be available. -/
 theorem apply_mul_eq_zero {D : derivationLieAlgebra R A} {x y : A}
     (hx : (D : Module.End R A) x = 0) (hy : (D : Module.End R A) y = 0) :
     (D : Module.End R A) (x * y) = 0 := by
@@ -192,27 +199,30 @@ theorem lieConj_mem_derivationLieAlgebra {e : A ≃ₗ[R] B}
 resulting map is an isomorphism of Lie algebras.  This is the tool that transports `Der` between two
 models of the same algebra -- two constructions of the split octonions, say. -/
 def derivationLieAlgebraCongr (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y) :
-    derivationLieAlgebra R A ≃ₗ⁅R⁆ derivationLieAlgebra R B := by
-  apply LieEquiv.ofSubalgebras _ _ e.lieConj
-  refine SetLike.ext fun D => ⟨?_, fun hD => ?_⟩
-  · rintro ⟨E, hE, rfl⟩
-    exact lieConj_mem_derivationLieAlgebra he hE
-  · exact ⟨e.lieConj.symm D, lieConj_mem_derivationLieAlgebra (symm_map_mul e he) hD,
-      e.lieConj.apply_symm_apply D⟩
+    derivationLieAlgebra R A ≃ₗ⁅R⁆ derivationLieAlgebra R B :=
+  LieEquiv.ofSubalgebras _ _ e.lieConj <| by
+    refine SetLike.ext fun D => ⟨?_, fun hD => ?_⟩
+    · rintro ⟨E, hE, rfl⟩
+      exact lieConj_mem_derivationLieAlgebra he hE
+    · exact ⟨e.lieConj.symm D, lieConj_mem_derivationLieAlgebra (symm_map_mul e he) hD,
+        e.lieConj.apply_symm_apply D⟩
 
 @[simp]
 theorem derivationLieAlgebraCongr_apply (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y)
     (D : derivationLieAlgebra R A) (x : B) :
     (derivationLieAlgebraCongr e he D : Module.End R B) x
-      = e ((D : Module.End R A) (e.symm x)) :=
-  (rfl)
+      = e ((D : Module.End R A) (e.symm x)) := by
+  simp only [derivationLieAlgebraCongr, LieEquiv.ofSubalgebras_apply, LinearEquiv.lieConj_apply,
+    LinearEquiv.conj_apply_apply]
 
 @[simp]
 theorem derivationLieAlgebraCongr_symm_apply (e : A ≃ₗ[R] B)
     (he : ∀ x y : A, e (x * y) = e x * e y) (D : derivationLieAlgebra R B) (x : A) :
     ((derivationLieAlgebraCongr e he).symm D : Module.End R A) x
-      = e.symm ((D : Module.End R B) (e x)) :=
-  (rfl)
+      = e.symm ((D : Module.End R B) (e x)) := by
+  simp only [derivationLieAlgebraCongr, LieEquiv.ofSubalgebras_symm_apply,
+    LinearEquiv.lieConj_symm, LinearEquiv.lieConj_apply, LinearEquiv.conj_apply_apply,
+    LinearEquiv.symm_symm]
 
 end Congr
 
@@ -238,6 +248,9 @@ def derivationEquivDerivationLieAlgebra : Derivation R A A ≃ₗ⁅R⁆ derivat
   left_inv _ := rfl
   right_inv _ := rfl
 
+-- `(rfl)` here and below is the whole content of the lemma: `derivationEquivDerivationLieAlgebra`
+-- keeps the underlying linear map, so the right-hand side *is* its `toFun`/`invFun` field.  See the
+-- implementation notes for why the parentheses are needed.
 @[simp]
 theorem derivationEquivDerivationLieAlgebra_apply (D : Derivation R A A) (x : A) :
     (derivationEquivDerivationLieAlgebra D : Module.End R A) x = D x :=
@@ -269,14 +282,14 @@ theorem leibniz_add_iff_leibniz_sub {D : L → L} :
 `LieDerivation R L L`.**  Regarding a Lie algebra as a non-associative algebra with `x * y = ⁅x, y⁆`
 turns the defining condition of `derivationLieAlgebra` into `D ⁅x, y⁆ = ⁅D x, y⁆ + ⁅x, D y⁆`, which
 `TauCeti.leibniz_add_iff_leibniz_sub` rewrites into the skew form. -/
+@[simp]
 theorem mem_derivationLieAlgebra_commutatorRing_iff_apply_lie_eq_sub {D : Module.End R L} :
     D ∈ derivationLieAlgebra R (CommutatorRing L) ↔
       ∀ x y : L, D ⁅x, y⁆ = ⁅x, D y⁆ - ⁅y, D x⁆ :=
   mem_derivationLieAlgebra.trans leibniz_add_iff_leibniz_sub
 
 /-- **The adjoint action is by derivations**: `ad x` lies in `Der (CommutatorRing L)`, which is
-exactly the Jacobi identity in Leibniz form.  This is the inner-derivation half of
-`TauCeti.derivationLieAlgebraCommutatorRingEquivLieDerivation`. -/
+exactly the Jacobi identity in Leibniz form. -/
 theorem ad_mem_derivationLieAlgebra_commutatorRing (x : L) :
     LieAlgebra.ad R L x ∈ derivationLieAlgebra R (CommutatorRing L) :=
   mem_derivationLieAlgebra.mpr fun (y z : L) => leibniz_lie x y z
@@ -298,6 +311,7 @@ def derivationLieAlgebraCommutatorRingEquivLieDerivation :
   left_inv _ := rfl
   right_inv _ := rfl
 
+-- As above, `(rfl)` is the whole content: this equivalence too keeps the underlying linear map.
 @[simp]
 theorem derivationLieAlgebraCommutatorRingEquivLieDerivation_apply
     (D : derivationLieAlgebra R (CommutatorRing L)) (x : L) :

--- a/TauCeti/Algebra/Lie/Derivation.lean
+++ b/TauCeti/Algebra/Lie/Derivation.lean
@@ -32,7 +32,7 @@ instances of it.
 
 ## Main results
 
-* `TauCeti.derivationLieAlgebra.apply_mul_eq_add`: the Leibniz rule;
+* `TauCeti.derivationLieAlgebra.leibniz`: the Leibniz rule;
   `TauCeti.derivationLieAlgebra.apply_one_eq_zero`: a derivation of a unital algebra kills the
   unit; and `TauCeti.derivationLieAlgebra.apply_mul_eq_zero`: its constants are closed under
   multiplication.
@@ -53,6 +53,10 @@ action of `Der A` on `A` as a Lie module, and the lattice API then all come from
 derivation.  This is also why the base is a `CommRing` and `A` a `NonUnitalNonAssocRing`: a Lie ring
 is an additive *group*, so the semiring-level hypotheses under which the Leibniz rule still makes
 sense do not suffice to make `Der A` one.
+
+The Leibniz rule is preserved by sums and by scalar multiples because the multiplication of `A` is
+`R`-bilinear, and by the commutator because the "second derivative" terms `D (E x) * y` and
+`x * D (E y)` that the composite `D ∘ E` contributes cancel against those of `E ∘ D`.
 
 The Lie bracket of `Module.End R A` is the ring commutator, which Mathlib deliberately keeps out of
 the global instance set (`LieRing.ofAssociativeRing`) because it clashes with the module action; it
@@ -103,11 +107,7 @@ variable (R : Type u) (A : Type v) [CommRing R] [NonUnitalNonAssocRing A] [Modul
 
 /-- **The derivation Lie algebra** `Der A` of a non-unital non-associative `R`-algebra `A`: the
 `R`-linear maps `D : A → A` satisfying the Leibniz rule `D (x * y) = D x * y + x * D y`, a Lie
-subalgebra of `Module.End R A` under the commutator bracket.
-
-The Leibniz rule is preserved by sums and by scalar multiples because the multiplication of `A` is
-`R`-bilinear, and by the commutator because the "second derivative" terms `D (E x) * y` and
-`x * D (E y)` that the composite `D ∘ E` contributes cancel against those of `E ∘ D`. -/
+subalgebra of `Module.End R A` under the commutator bracket. -/
 def derivationLieAlgebra : LieSubalgebra R (Module.End R A) where
   carrier := {D | ∀ x y : A, D (x * y) = D x * y + x * D y}
   add_mem' hD hE x y := by
@@ -132,7 +132,7 @@ namespace derivationLieAlgebra
 
 /-- **The Leibniz rule**: a derivation differentiates each factor of a product. -/
 @[simp]
-theorem apply_mul_eq_add (D : derivationLieAlgebra R A) (x y : A) :
+theorem leibniz (D : derivationLieAlgebra R A) (x y : A) :
     (D : Module.End R A) (x * y)
       = (D : Module.End R A) x * y + x * (D : Module.End R A) y :=
   D.2 x y
@@ -144,7 +144,7 @@ associative enough for `Subalgebra` to be available. -/
 theorem apply_mul_eq_zero {D : derivationLieAlgebra R A} {x y : A}
     (hx : (D : Module.End R A) x = 0) (hy : (D : Module.End R A) y = 0) :
     (D : Module.End R A) (x * y) = 0 := by
-  rw [apply_mul_eq_add, hx, hy, zero_mul, mul_zero, add_zero]
+  rw [leibniz, hx, hy, zero_mul, mul_zero, add_zero]
 
 /-- A derivation is determined by its values. -/
 @[ext]
@@ -166,7 +166,7 @@ Only unitality is used, not associativity. -/
 @[simp]
 theorem derivationLieAlgebra.apply_one_eq_zero (D : derivationLieAlgebra R A) :
     (D : Module.End R A) 1 = 0 := by
-  simpa using derivationLieAlgebra.apply_mul_eq_add D 1 1
+  simpa using derivationLieAlgebra.leibniz D 1 1
 
 end Unital
 
@@ -181,8 +181,8 @@ omit [SMulCommClass R A A] [IsScalarTower R A A] [SMulCommClass R B B] [IsScalar
 /-- **The inverse of a multiplicative linear equivalence is multiplicative.**  The hypothesis is an
 unbundled multiplicativity condition on a `LinearEquiv` because Mathlib has no equivalence class for
 non-unital non-associative algebras; `he` says exactly that `e` is an algebra map, and no unitality
-is used. -/
-theorem symm_map_mul (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y) (u v : B) :
+is used.  This is an implementation detail of `derivationLieAlgebraCongr`, and so is private. -/
+private theorem symm_map_mul (e : A ≃ₗ[R] B) (he : ∀ x y : A, e (x * y) = e x * e y) (u v : B) :
     e.symm (u * v) = e.symm u * e.symm v :=
   e.injective (by simp [he])
 

--- a/TauCeti/Algebra/Octonion.lean
+++ b/TauCeti/Algebra/Octonion.lean
@@ -62,8 +62,10 @@ which ranks are well behaved, and each asks for it as `StrongRankCondition` and 
 * `TauCeti.Octonion.mul_self`: every octonion satisfies its rank-two equation
   `x * x = trace x • x - norm x • 1`.
 * `TauCeti.Octonion.finrank_imaginary`: the imaginary octonions, the trace-zero subspace, are
-  `7`-dimensional. Identifying them with the fundamental representation of `G₂ = Der 𝕆` waits on
-  the derivation algebra, which is not built here.
+  `7`-dimensional. The derivation algebra `Der 𝕆` is `TauCeti.derivationLieAlgebra R (Octonion R)`
+  (`TauCeti/Algebra/Lie/Derivation.lean`); identifying the imaginary octonions with the fundamental
+  representation of `G₂ = Der 𝕆` still waits on the count `finrank (Der 𝕆) = 14` and the
+  isomorphism with `LieAlgebra.g₂`, neither of which is proved here.
 
 ## Implementation notes
 
@@ -86,7 +88,8 @@ through.
 
 The norm is left as a bare map `Octonion R → R`, as the roadmap pins it. Packaging it as a
 `QuadraticForm R (Octonion R)` — its polarization is the trace form `x, y ↦ trace (x * conj y)` —
-is deferred, together with the derivation algebra `Der 𝕆`.
+is deferred.  The derivation algebra `Der 𝕆` is not deferred: it is
+`TauCeti.derivationLieAlgebra R (Octonion R)`, built in `TauCeti/Algebra/Lie/Derivation.lean`.
 
 ## References
 
@@ -523,7 +526,9 @@ example :
 
 /-- **The imaginary octonions**, the trace-zero subspace of `𝕆`. It is `7`-dimensional
 (`TauCeti.Octonion.finrank_imaginary`); identifying it with the fundamental representation of
-`G₂ = Der 𝕆` waits on the derivation algebra, which is not built here. -/
+`G₂ = Der 𝕆` -- where `Der 𝕆` is `TauCeti.derivationLieAlgebra R (Octonion R)` -- waits on the
+count `finrank (Der 𝕆) = 14` and the isomorphism with `LieAlgebra.g₂`, neither of which is proved
+here. -/
 def imaginary (R : Type*) [CommRing R] : Submodule R (Octonion R) := LinearMap.ker trace
 
 @[simp] theorem mem_imaginary {x : Octonion R} : x ∈ imaginary R ↔ trace x = 0 :=


### PR DESCRIPTION
This PR builds `TauCeti.derivationLieAlgebra R A`, the Lie algebra `Der A` of derivations of a non-unital non-associative `R`-algebra `A`, realised as a Lie subalgebra of `Module.End R A` under the commutator bracket. It is the `derivationLieAlgebra` target of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md` Layer 8 ("the exceptional Lie algebras, explicitly"), pinned in that roadmap's `Suggested.lean` as `def derivationLieAlgebra (A : Type u) [...] : Type u` together with its `LieRing` and `LieAlgebra K` instances. Layer 8 is the roadmap's declared independent lane — its `## Ordering` paragraph says the split-octonion and split-Albert track "can be built from scratch at any time (they need no prior layer)" — and this is the missing brick between the octonions and `G₂`: `TauCeti/Algebra/Octonion.lean` already ends by recording that identifying the imaginary octonions with the fundamental representation of `G₂ = Der 𝕆` "waits on the derivation algebra, which is not built here".

Mathlib has derivations twice over but never in this generality: `Derivation R A M` requires `A` commutative and associative, and `LieDerivation R L M` requires the multiplication to be a Lie bracket. Neither covers the octonions (non-associative) or the Albert algebra (commutative but non-associative). Rather than hand-build a carrier type, the definition is a bundled `LieSubalgebra R (Module.End R A)`, so the `LieRing`, `LieAlgebra R` and `Module R` structures, the Lie action of `Der A` on `A`, and the lattice API are all Mathlib's, and the only thing proved is that the commutator of two derivations is a derivation. The pinned signature is followed except that `A` carries `NonUnitalNonAssocRing` rather than `NonUnitalNonAssocSemiring`: a Lie ring is an additive group, so the semiring-level hypothesis cannot support the `LieRing` instance the same roadmap entry asks for. The base ring is relaxed from the section's `[Field K] [CharZero K]` blanket to a `CommRing`, which is all the construction uses.

Both Mathlib constructions are then exhibited as instances of this one, so the file consumes them rather than duplicating them: `TauCeti.derivationLieEquiv` is a Lie algebra isomorphism `Derivation R A A ≃ₗ⁅R⁆ Der A` for a commutative associative `A`, and `TauCeti.commutatorRingDerivationLieEquiv` is one `Der (CommutatorRing L) ≃ₗ⁅R⁆ LieDerivation R L L`, resting on `TauCeti.leibniz_add_iff_leibniz_sub`, which reconciles the symmetric Leibniz rule with the `⁅x, D y⁆ - ⁅y, D x⁆` form `LieDerivation` uses. Alongside these sit the Leibniz rule in both linear-map and Lie-action form, the fact that a derivation of a unital algebra kills the unit and that its constants are closed under multiplication, the Jacobi identity as the statement that `ad x` is a derivation of `CommutatorRing L`, and `TauCeti.derivationLieAlgebraCongr`, which conjugates `Der A` to `Der B` along a multiplicative linear equivalence — the tool that will identify a concretely built `Der 𝕆` with an abstractly presented `G₂`. No Mathlib source was vendored.

One new file, `TauCeti/Algebra/Lie/Derivation.lean` (316 lines). `lake build --iofail`, `lake exe axioms` (allowlist only), `lake exe module-system`, `scripts/lint-env.sh` and `scripts/lint-dot-notation.py` all pass locally.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"derivationliealgebra"}-->

🤖 Prepared with Claude Code
