### PR TITLE
feat(Spa): every open cover of a rational subset has a finite rational refinement

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -45,6 +45,9 @@ the basis arguments uses it.
 * `TauCeti.ValuationSpectrum.isCompact_of_mem_spaRationalFamily`: every member of the family is
   quasi-compact. Each result also has an `_of_pairOfDefinition` form for use with a specified
   pair of definition.
+* `TauCeti.ValuationSpectrum.exists_finite_spaRationalFamily_refinement`: every open cover of a
+  member of the family admits a finite refinement by members of the family — the two results
+  above combined, and the form a sheaf criterion on this basis consumes.
 * `TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_isTateRing_of_isOpen`: over a Tate
   ring, if a finite set `T` generates an open ideal, then the standard rational subsets cover
   `spa Aplus` (Wedhorn Corollary 7.53 specialization).
@@ -253,6 +256,29 @@ theorem isCompact_of_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
     {U : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus) : IsCompact U :=
   (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim
     fun P ↦ isCompact_of_mem_spaRationalFamily_of_pairOfDefinition P hU
+
+/-! ### Finite rational refinements -/
+
+/-- **Every open cover of a rational subset admits a finite refinement by rational subsets.**
+This is the previous two results combined: being a basis shrinks each point's cover member to a
+rational neighbourhood, and quasi-compactness then keeps finitely many of them. It is the shape a
+sheaf criterion on the rational basis consumes, where the cover is arbitrary but the Čech complex
+must be built from the basis itself. -/
+theorem exists_finite_spaRationalFamily_refinement [IsHuberRing A] {Aplus : Subring A}
+    {U : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus) {ι : Type*}
+    (V : ι → Set (spa Aplus)) (hVopen : ∀ i, IsOpen (V i)) (hcover : U ⊆ ⋃ i, V i) :
+    ∃ 𝒲 ⊆ spaRationalFamily Aplus, 𝒲.Finite ∧ (∀ W ∈ 𝒲, ∃ i, W ⊆ V i) ∧ U ⊆ ⋃₀ 𝒲 := by
+  have hcov : U ⊆ ⋃ W ∈ {W ∈ spaRationalFamily Aplus | ∃ i, W ⊆ V i}, W := by
+    intro x hx
+    obtain ⟨i, hi⟩ := Set.mem_iUnion.mp (hcover hx)
+    obtain ⟨W, hWmem, hxW, hWV⟩ :=
+      (isTopologicalBasis_spaRationalFamily Aplus).exists_subset_of_mem_open hi (hVopen i)
+    exact Set.mem_biUnion ⟨hWmem, i, hWV⟩ hxW
+  obtain ⟨𝒲, h𝒲G, h𝒲fin, h𝒲cov⟩ :=
+    (isCompact_of_mem_spaRationalFamily hU).elim_finite_subcover_image
+      (fun W hW ↦ (isTopologicalBasis_spaRationalFamily Aplus).isOpen hW.1) hcov
+  exact ⟨𝒲, fun W hW ↦ (h𝒲G hW).1, h𝒲fin, fun W hW ↦ (h𝒲G hW).2,
+    by simpa [Set.sUnion_eq_biUnion] using h𝒲cov⟩
 
 /-! ### Standard rational covers -/
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basis.lean
@@ -264,7 +264,15 @@ theorem isCompact_of_mem_spaRationalFamily [IsHuberRing A] {Aplus : Subring A}
 This is the previous two results combined: being a basis shrinks each point's cover member to a
 rational neighbourhood, and quasi-compactness then keeps finitely many of them. It is the shape a
 sheaf criterion on the rational basis consumes, where the cover is arbitrary but the Čech complex
-must be built from the basis itself. -/
+must be built from the basis itself.
+
+The two-step argument follows AINTLIB's `exists_finite_rational_refinement_huber` and its Tate-only
+`exists_finite_rational_refinement` (branch `dev/adic-spaces`, commit `37bbdaeb`, Apache 2.0), in
+`projects/AdicSpaces/Adic spaces/RestrictedLimitSheaf.lean`. Two differences: quasi-compactness is a
+hypothesis there and is discharged here by `isCompact_of_mem_spaRationalFamily`; and the conclusion
+there is a `Finset` of a bundled index type over `RationalLocData`, whereas this states a finite
+subfamily of `spaRationalFamily` with the containment as a side condition, matching the vocabulary
+this file already uses. -/
 theorem exists_finite_spaRationalFamily_refinement [IsHuberRing A] {Aplus : Subring A}
     {U : Set (spa Aplus)} (hU : U ∈ spaRationalFamily Aplus) {ι : Type*}
     (V : ι → Set (spa Aplus)) (hVopen : ∀ i, IsOpen (V i)) (hcover : U ⊆ ⋃ i, V i) :


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"rational-cover-refinement"}-->

Part of TauCetiProject/TauCetiRoadmap#174

Layer 3.5 ("Sheaf criteria on the rational basis") asks for five facts about the rational basis of
`X = Spa(A, A⁺)`. Two are already on `main`; this PR adds the third.

```text
theorem TauCeti.ValuationSpectrum.exists_finite_spaRationalFamily_refinement
    (hU : U ∈ spaRationalFamily Aplus) (V : ι → Set (spa Aplus))
    (hVopen : ∀ i, IsOpen (V i)) (hcover : U ⊆ ⋃ i, V i) :
    ∃ 𝒲 ⊆ spaRationalFamily Aplus, 𝒲.Finite ∧ (∀ W ∈ 𝒲, ∃ i, W ⊆ V i) ∧ U ⊆ ⋃₀ 𝒲
```

*Every open cover of a rational subset admits a finite refinement by rational subsets.*

## Why it is short

It is exactly the conjunction of the two bullets that landed before it:

* `isTopologicalBasis_spaRationalFamily` shrinks each point's cover member to a rational
  neighbourhood inside it;
* `isCompact_of_mem_spaRationalFamily` then keeps finitely many.

Fifteen lines, and both Mathlib primitives are reused rather than reproved
(`IsTopologicalBasis.exists_subset_of_mem_open`, `IsCompact.elim_finite_subcover_image`).

## Placement

`Spa/RationalSubset/Basis.lean`, immediately after the two results it combines, under a new
`### Finite rational refinements` header and before the Tate-only `### Standard rational covers`
section — this needs only `[IsHuberRing A]`. No new file, and the module docstring's Main-results
list gains the matching bullet.

## Acknowledged overlap with #3560

One other open PR touches this file: **#3560** ("ci: enforce source style lint across TauCeti"), a
repo-wide chore adding the `Authors:` copyright line. Its change here is `+1/-0` — that single header
line — and it adds **no declarations**, so there is no mathematical overlap with
`exists_finite_spaRationalFamily_refinement`. It also cannot conflict: `main` already carries that
line in this file (it landed via #3617), and this branch has it too after merging current `main`, so
both sides agree on the line. #3560 additionally modifies `.github/workflows/`, which is human-owned;
this PR does not touch those paths and nothing here should be taken as acting on that PR.

## Not in Mathlib

Mathlib's `Topology/Compactness/Bases.lean` has
`eq_finite_iUnion_of_isTopologicalBasis_of_isCompact_open` and its `sUnion`/`Finset` variant, which
express a compact **open** set as a finite union of basis elements. Neither refines a *given* cover
— the output basis elements bear no relation to any prescribed family — and neither applies to a
rational subset that is not assumed open. So the statement is absent; the pieces of the proof are
not.

## Provenance

AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache 2.0, branch `dev/adic-spaces` at `37bbdaeb9`) has
this result twice, in `projects/AdicSpaces/Adic spaces/RestrictedLimitSheaf.lean`:
`exists_finite_rational_refinement_huber` and a Tate-only `exists_finite_rational_refinement`. The
two-step argument is the same one and is theirs. Two deliberate differences:

* **Compactness is discharged, not assumed.** AINTLIB carries `hcomp : IsCompact (spaOpen D)` as a
  hypothesis; `isCompact_of_mem_spaRationalFamily` is on `main`, so the statement here is
  unconditional.
* **The conclusion is over subsets, not a bundled index.** AINTLIB returns a `Finset` of a bundled
  `RefinementIndex D U` (a rational presentation together with the cover index it sits inside), over
  its `RationalLocData`. TauCeti's vocabulary for this basis is the subset family
  `spaRationalFamily`, so the refinement is a finite subfamily of it and the containment
  `∃ i, W ⊆ V i` is a side condition; `choose` recovers the index map where a Čech construction
  wants it.

No proof text was copied.

## References

* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), §7.3 for the rational basis.
* [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
  commit `37bbdaeb`, Apache 2.0.
