### PR TITLE
feat: add the derived affine group scheme

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Derived.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Derived.lean
@@ -31,7 +31,7 @@ the subgroup normal and makes the pointwise quotient commutative.
 * `TauCeti.CommHopfAlgCat.derivedGroupScheme`: the derived affine group scheme.
 * `TauCeti.CommHopfAlgCat.commutator_mem_derivedPointsSubgroup`: every pointwise commutator lies
   in the derived subgroup.
-* `TauCeti.CommHopfAlgCat.derivedDefiningIdeal_isNormal`: the derived subgroup is normal.
+* `TauCeti.CommHopfAlgCat.isNormal_derivedDefiningIdeal`: the derived subgroup is normal.
 * `TauCeti.CommHopfAlgCat.isMulCommutative_derivedPointQuotient`: the quotient by derived points is
   commutative.
 
@@ -76,7 +76,7 @@ theorem derivedDefiningIdeal_toIdeal_le_ker :
 /-- A Hopf ideal is contained in the derived defining ideal exactly when the commutator
 coordinate morphism kills it. This is the coordinate universal property of the derived
 subgroup. -/
-theorem le_derivedDefiningIdeal_iff (I : HopfIdeal R H) :
+@[simp] theorem le_derivedDefiningIdeal_iff (I : HopfIdeal R H) :
     I ≤ derivedDefiningIdeal (R := R) H ↔
       I.toIdeal ≤
         RingHom.ker (HopfAlgebra.commutatorAlgHom (R := R) (H := H)).toRingHom := by
@@ -129,7 +129,7 @@ theorem derivedPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
       (commutator_mem_derivedPointsSubgroup H A g n) hn
 
 /-- The Hopf ideal defining the derived subgroup is normal. -/
-theorem derivedDefiningIdeal_isNormal (H : _root_.CommHopfAlgCat.{v} R) :
+theorem isNormal_derivedDefiningIdeal (H : _root_.CommHopfAlgCat.{v} R) :
     (derivedDefiningIdeal (R := R) H).IsNormal := by
   rw [isNormal_iff_quotientPointsSubgroup_normal]
   exact derivedPointsSubgroup_normal H

--- a/TauCeti/Algebra/AlgebraicGroup/Derived.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Derived.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Commutator
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
+
+/-!
+# The derived subgroup of an affine group scheme
+
+Let `H` be a commutative Hopf algebra, representing an affine group scheme `G`. The commutator
+morphism `G × G ⟶ G` need not be a group homomorphism, so its image is not directly represented by
+a quotient Hopf algebra. Instead, this file defines `derivedDefiningIdeal H` to be the largest
+Hopf ideal contained in the kernel of the commutator coordinate morphism
+
+```text
+H ⟶ H ⊗[R] H.
+```
+
+The quotient by this ideal represents the smallest closed subgroup scheme of `G` containing the
+commutator image. Every algebra-valued commutator belongs to its subgroup of points. This makes
+the subgroup normal and makes the pointwise quotient commutative.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.derivedDefiningIdeal`: the ideal cutting out the derived subgroup.
+* `TauCeti.CommHopfAlgCat.derivedGroupScheme`: the derived affine group scheme.
+* `TauCeti.CommHopfAlgCat.commutator_mem_derivedPointsSubgroup`: every pointwise commutator lies
+  in the derived subgroup.
+* `TauCeti.CommHopfAlgCat.derivedDefiningIdeal_isNormal`: the derived subgroup is normal.
+* `TauCeti.CommHopfAlgCat.isMulCommutative_derivedPointQuotient`: the quotient by derived points is
+  commutative.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §6d, especially Propositions 6.17 and 6.18.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 10.
+
+This supplies `G_der`, required in Layer 6 of the ReductiveGroups roadmap, and the
+scheme-theoretic derived subgroup left outstanding by the Layer 5 solvability development.
+-/
+
+public section
+
+open CategoryTheory WithConv
+open scoped commutatorElement
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u v w
+
+variable {R : Type u} [CommRing R]
+
+/-- The largest Hopf ideal contained in the kernel of the commutator coordinate morphism.
+
+Its quotient represents the smallest closed subgroup scheme containing the image of the
+commutator morphism. -/
+noncomputable def derivedDefiningIdeal (H : _root_.CommHopfAlgCat.{v} R) : HopfIdeal R H :=
+  sSup {I | I.toIdeal ≤
+    RingHom.ker (HopfAlgebra.commutatorAlgHom (R := R) (H := H)).toRingHom}
+
+/-- The derived defining ideal is killed by the commutator coordinate morphism. -/
+theorem derivedDefiningIdeal_toIdeal_le_ker (H : _root_.CommHopfAlgCat.{v} R) :
+    (derivedDefiningIdeal H).toIdeal ≤
+      RingHom.ker (HopfAlgebra.commutatorAlgHom (R := R) (H := H)).toRingHom := by
+  rw [derivedDefiningIdeal, HopfIdeal.sSup_toIdeal]
+  exact iSup_le fun I ↦ I.2
+
+/-- A Hopf ideal is contained in the derived defining ideal exactly when the commutator
+coordinate morphism kills it. This is the coordinate universal property of the derived
+subgroup. -/
+theorem le_derivedDefiningIdeal_iff (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) :
+    I ≤ derivedDefiningIdeal H ↔
+      I.toIdeal ≤
+        RingHom.ker (HopfAlgebra.commutatorAlgHom (R := R) (H := H)).toRingHom := by
+  constructor
+  · intro h
+    exact (HopfIdeal.toIdeal_le_toIdeal.mpr h).trans
+      (derivedDefiningIdeal_toIdeal_le_ker H)
+  · intro h
+    exact le_sSup h
+
+/-- The affine group scheme represented by the coordinate algebra of the derived subgroup. -/
+noncomputable abbrev derivedGroupScheme (H : _root_.CommHopfAlgCat.{u} R) :
+    Grp (Over (AlgebraicGeometry.Spec (CommRingCat.of R))) :=
+  quotientSpec H (derivedDefiningIdeal H)
+
+/-- The closed immersion of the derived group scheme into the ambient Hopf spectrum. -/
+noncomputable abbrev derivedGroupSchemeι (H : _root_.CommHopfAlgCat.{u} R) :
+    derivedGroupScheme H ⟶
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H) :=
+  quotientSpecι H (derivedDefiningIdeal H)
+
+/-- The inclusion of the derived group scheme is a closed immersion. -/
+instance isClosedImmersion_derivedGroupSchemeι (H : _root_.CommHopfAlgCat.{u} R) :
+    AlgebraicGeometry.IsClosedImmersion (derivedGroupSchemeι H).hom.hom.left :=
+  inferInstance
+
+/-- Every commutator of algebra-valued points lies in the derived subgroup. -/
+theorem commutator_mem_derivedPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{w} R) (g h : HopfAlgebra.points (R := R) (H := H) A) :
+    ⁅g, h⁆ ∈ quotientPointsSubgroup H (derivedDefiningIdeal H) A := by
+  rw [mem_quotientPointsSubgroup_iff]
+  intro x hx
+  rw [← HopfAlgebra.productMap_comp_commutatorAlgHom]
+  exact map_zero (Algebra.TensorProduct.productMap g.ofConv h.ofConv) ▸
+    congrArg (Algebra.TensorProduct.productMap g.ofConv h.ofConv)
+      (RingHom.mem_ker.mp
+        (derivedDefiningIdeal_toIdeal_le_ker H ((HopfIdeal.mem_toIdeal).mpr hx)))
+
+/-- The subgroup of algebra-valued points cut out by the derived ideal is normal. -/
+theorem derivedPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{w} R) :
+    (quotientPointsSubgroup H (derivedDefiningIdeal H) A).Normal := by
+  refine ⟨fun n hn g ↦ ?_⟩
+  simpa [commutatorElement_def, mul_assoc] using
+    (quotientPointsSubgroup H (derivedDefiningIdeal H) A).mul_mem
+      (commutator_mem_derivedPointsSubgroup H A g n) hn
+
+/-- The Hopf ideal defining the derived subgroup is normal. -/
+theorem derivedDefiningIdeal_isNormal (H : _root_.CommHopfAlgCat.{v} R) :
+    (derivedDefiningIdeal H).IsNormal := by
+  rw [isNormal_iff_quotientPointsSubgroup_normal]
+  exact derivedPointsSubgroup_normal H
+
+/-- The quotient of the point group by the derived subgroup is commutative. -/
+theorem isMulCommutative_derivedPointQuotient (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{w} R) :
+    let _ : (quotientPointsSubgroup H (derivedDefiningIdeal H) A).Normal :=
+      derivedPointsSubgroup_normal H A
+    IsMulCommutative
+      (HopfAlgebra.points (R := R) (H := H) A ⧸
+        quotientPointsSubgroup H (derivedDefiningIdeal H) A) := by
+  let _ : (quotientPointsSubgroup H (derivedDefiningIdeal H) A).Normal :=
+    derivedPointsSubgroup_normal H A
+  rw [Subgroup.Normal.quotient_commutative_iff_commutator_le, commutator_eq_closure,
+    Subgroup.closure_le]
+  rintro _ ⟨g, h, rfl⟩
+  exact commutator_mem_derivedPointsSubgroup H A g h
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Derived.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Derived.lean
@@ -53,19 +53,22 @@ namespace TauCeti.CommHopfAlgCat
 
 universe u v w
 
-variable {R : Type u} [CommRing R]
+section DefiningIdeal
+
+variable {R : Type u} [CommSemiring R]
+variable (H : Type v) [CommSemiring H] [_root_.HopfAlgebra R H]
 
 /-- The largest Hopf ideal contained in the kernel of the commutator coordinate morphism.
 
 Its quotient represents the smallest closed subgroup scheme containing the image of the
 commutator morphism. -/
-noncomputable def derivedDefiningIdeal (H : _root_.CommHopfAlgCat.{v} R) : HopfIdeal R H :=
+noncomputable def derivedDefiningIdeal : HopfIdeal R H :=
   sSup {I | I.toIdeal ≤
     RingHom.ker (HopfAlgebra.commutatorAlgHom (R := R) (H := H)).toRingHom}
 
 /-- The derived defining ideal is killed by the commutator coordinate morphism. -/
-theorem derivedDefiningIdeal_toIdeal_le_ker (H : _root_.CommHopfAlgCat.{v} R) :
-    (derivedDefiningIdeal H).toIdeal ≤
+theorem derivedDefiningIdeal_toIdeal_le_ker :
+    (derivedDefiningIdeal (R := R) H).toIdeal ≤
       RingHom.ker (HopfAlgebra.commutatorAlgHom (R := R) (H := H)).toRingHom := by
   rw [derivedDefiningIdeal, HopfIdeal.sSup_toIdeal]
   exact iSup_le fun I ↦ I.2
@@ -73,17 +76,20 @@ theorem derivedDefiningIdeal_toIdeal_le_ker (H : _root_.CommHopfAlgCat.{v} R) :
 /-- A Hopf ideal is contained in the derived defining ideal exactly when the commutator
 coordinate morphism kills it. This is the coordinate universal property of the derived
 subgroup. -/
-theorem le_derivedDefiningIdeal_iff (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) :
-    I ≤ derivedDefiningIdeal H ↔
+theorem le_derivedDefiningIdeal_iff (I : HopfIdeal R H) :
+    I ≤ derivedDefiningIdeal (R := R) H ↔
       I.toIdeal ≤
         RingHom.ker (HopfAlgebra.commutatorAlgHom (R := R) (H := H)).toRingHom := by
   constructor
   · intro h
     exact (HopfIdeal.toIdeal_le_toIdeal.mpr h).trans
-      (derivedDefiningIdeal_toIdeal_le_ker H)
+      (derivedDefiningIdeal_toIdeal_le_ker (R := R) H)
   · intro h
     exact le_sSup h
+
+end DefiningIdeal
+
+variable {R : Type u} [CommRing R]
 
 /-- The affine group scheme represented by the coordinate algebra of the derived subgroup. -/
 noncomputable abbrev derivedGroupScheme (H : _root_.CommHopfAlgCat.{u} R) :
@@ -104,39 +110,39 @@ instance isClosedImmersion_derivedGroupSchemeι (H : _root_.CommHopfAlgCat.{u} R
 /-- Every commutator of algebra-valued points lies in the derived subgroup. -/
 theorem commutator_mem_derivedPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
     (A : CommAlgCat.{w} R) (g h : HopfAlgebra.points (R := R) (H := H) A) :
-    ⁅g, h⁆ ∈ quotientPointsSubgroup H (derivedDefiningIdeal H) A := by
+    ⁅g, h⁆ ∈ quotientPointsSubgroup H (derivedDefiningIdeal (R := R) H) A := by
   rw [mem_quotientPointsSubgroup_iff]
   intro x hx
   rw [← HopfAlgebra.productMap_comp_commutatorAlgHom]
   exact map_zero (Algebra.TensorProduct.productMap g.ofConv h.ofConv) ▸
     congrArg (Algebra.TensorProduct.productMap g.ofConv h.ofConv)
       (RingHom.mem_ker.mp
-        (derivedDefiningIdeal_toIdeal_le_ker H ((HopfIdeal.mem_toIdeal).mpr hx)))
+        (derivedDefiningIdeal_toIdeal_le_ker (R := R) H ((HopfIdeal.mem_toIdeal).mpr hx)))
 
 /-- The subgroup of algebra-valued points cut out by the derived ideal is normal. -/
 theorem derivedPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     (A : CommAlgCat.{w} R) :
-    (quotientPointsSubgroup H (derivedDefiningIdeal H) A).Normal := by
+    (quotientPointsSubgroup H (derivedDefiningIdeal (R := R) H) A).Normal := by
   refine ⟨fun n hn g ↦ ?_⟩
   simpa [commutatorElement_def, mul_assoc] using
-    (quotientPointsSubgroup H (derivedDefiningIdeal H) A).mul_mem
+    (quotientPointsSubgroup H (derivedDefiningIdeal (R := R) H) A).mul_mem
       (commutator_mem_derivedPointsSubgroup H A g n) hn
 
 /-- The Hopf ideal defining the derived subgroup is normal. -/
 theorem derivedDefiningIdeal_isNormal (H : _root_.CommHopfAlgCat.{v} R) :
-    (derivedDefiningIdeal H).IsNormal := by
+    (derivedDefiningIdeal (R := R) H).IsNormal := by
   rw [isNormal_iff_quotientPointsSubgroup_normal]
   exact derivedPointsSubgroup_normal H
 
 /-- The quotient of the point group by the derived subgroup is commutative. -/
 theorem isMulCommutative_derivedPointQuotient (H : _root_.CommHopfAlgCat.{v} R)
     (A : CommAlgCat.{w} R) :
-    let _ : (quotientPointsSubgroup H (derivedDefiningIdeal H) A).Normal :=
+    let _ : (quotientPointsSubgroup H (derivedDefiningIdeal (R := R) H) A).Normal :=
       derivedPointsSubgroup_normal H A
     IsMulCommutative
       (HopfAlgebra.points (R := R) (H := H) A ⧸
-        quotientPointsSubgroup H (derivedDefiningIdeal H) A) := by
-  let _ : (quotientPointsSubgroup H (derivedDefiningIdeal H) A).Normal :=
+        quotientPointsSubgroup H (derivedDefiningIdeal (R := R) H) A) := by
+  let _ : (quotientPointsSubgroup H (derivedDefiningIdeal (R := R) H) A).Normal :=
     derivedPointsSubgroup_normal H A
   rw [Subgroup.Normal.quotient_commutative_iff_commutator_le, commutator_eq_closure,
     Subgroup.closure_le]

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Commutator.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Commutator.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Commutator.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Product
+public import TauCeti.Algebra.Coalgebra.Convolution
+
+/-!
+# The commutator morphism in Hopf-algebra coordinates
+
+For a commutative Hopf algebra `H` over a commutative semiring `R`, this file constructs the
+algebra morphism
+
+```text
+H ⟶ H ⊗[R] H
+```
+
+representing the group commutator `(g, h) ↦ g * h * g⁻¹ * h⁻¹`. If `i₁` and `i₂` are the
+two universal points with values in `H ⊗[R] H`, the morphism is the algebra map underlying the
+convolution point `i₁ * i₂ * i₁⁻¹ * i₂⁻¹`.
+
+The commutator is not generally a group homomorphism from the product, so this construction is an
+algebra morphism rather than a bialgebra morphism. Its kernel nevertheless determines the smallest
+closed subgroup scheme containing the image, constructed in
+`TauCeti.Algebra.AlgebraicGroup.Derived`.
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.commutatorAlgHom`: the coordinate algebra morphism of the commutator.
+* `TauCeti.HopfAlgebra.productMap_comp_commutatorAlgHom`: evaluation at two algebra-valued points.
+* `TauCeti.HopfAlgebra.comp_commutatorAlgHom`: evaluation against an arbitrary map from the tensor
+  square.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §6d.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 10.
+
+This is the coordinate prerequisite for the derived group `G_der` in Layer 6 of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open TensorProduct WithConv
+open scoped commutatorElement
+
+namespace TauCeti.HopfAlgebra
+
+universe u v w
+
+variable {R : Type u} {H : Type v} [CommSemiring R] [CommSemiring H]
+variable [_root_.HopfAlgebra R H]
+
+/-- The coordinate algebra morphism of the group commutator
+`(g, h) ↦ g * h * g⁻¹ * h⁻¹`.
+
+The two tensor factors are the two commutator variables, in that order. -/
+noncomputable def commutatorAlgHom : H →ₐ[R] H ⊗[R] H :=
+  (toConv (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := H)).toAlgHom *
+      toConv (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := H)).toAlgHom *
+      (toConv
+        (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := H)).toAlgHom)⁻¹ *
+      (toConv
+        (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := H)).toAlgHom)⁻¹).ofConv
+
+/-- The commutator coordinate morphism is the convolution commutator of the two universal
+tensor-factor points. -/
+theorem toConv_commutatorAlgHom :
+    toConv (commutatorAlgHom (R := R) (H := H)) =
+      toConv (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := H)).toAlgHom *
+        toConv (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := H)).toAlgHom *
+        (toConv
+          (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := H)).toAlgHom)⁻¹ *
+        (toConv
+          (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := H)).toAlgHom)⁻¹ := by
+  rw [commutatorAlgHom, toConv_ofConv]
+
+/-- Evaluating the commutator coordinate morphism at two algebra-valued points gives their
+group-theoretic commutator. -/
+@[simp]
+theorem productMap_comp_commutatorAlgHom
+    {A : Type w} [CommSemiring A] [Algebra R A]
+    (g h : WithConv (H →ₐ[R] A)) :
+    (Algebra.TensorProduct.productMap g.ofConv h.ofConv).comp
+      (commutatorAlgHom (R := R) (H := H)) =
+      (⁅g, h⁆).ofConv := by
+  have hmap :
+      AlgHom.mapValue (H := H) (Algebra.TensorProduct.productMap g.ofConv h.ofConv)
+          (toConv (commutatorAlgHom (R := R) (H := H))) = ⁅g, h⁆ := by
+    rw [toConv_commutatorAlgHom, map_mul, map_mul, map_mul, map_inv, map_inv]
+    simp only [AlgHom.mapValue_apply,
+      Bialgebra.TensorProduct.includeLeft_toAlgHom,
+      Bialgebra.TensorProduct.includeRight_toAlgHom,
+      Algebra.TensorProduct.productMap_left, Algebra.TensorProduct.productMap_right,
+      commutatorElement_def]
+  exact congrArg WithConv.ofConv hmap
+
+/-- Evaluation against an arbitrary algebra map out of the tensor square takes the commutator of
+its restrictions to the two tensor factors. -/
+theorem comp_commutatorAlgHom {A : Type w} [CommSemiring A] [Algebra R A]
+    (phi : H ⊗[R] H →ₐ[R] A) :
+    phi.comp (commutatorAlgHom (R := R) (H := H)) =
+      (⁅toConv (phi.comp Algebra.TensorProduct.includeLeft),
+        toConv (phi.comp Algebra.TensorProduct.includeRight)⁆).ofConv := by
+  calc
+    phi.comp (commutatorAlgHom (R := R) (H := H)) =
+        (Algebra.TensorProduct.productMap
+          (phi.comp Algebra.TensorProduct.includeLeft)
+          (phi.comp Algebra.TensorProduct.includeRight)).comp
+            (commutatorAlgHom (R := R) (H := H)) :=
+      congrArg (fun psi : H ⊗[R] H →ₐ[R] A ↦
+        psi.comp (commutatorAlgHom (R := R) (H := H)))
+        (AffineGroup.Product.productMap_restrict phi).symm
+    _ = _ := by
+      simpa only [ofConv_toConv] using
+        productMap_comp_commutatorAlgHom (R := R) (H := H)
+          (toConv (phi.comp Algebra.TensorProduct.includeLeft))
+          (toConv (phi.comp Algebra.TensorProduct.includeRight))
+
+/-- The commutator with the identity in the first variable is the identity point. -/
+@[simp]
+theorem productMap_one_id_comp_commutatorAlgHom :
+    (Algebra.TensorProduct.productMap
+        (1 : WithConv (H →ₐ[R] H)).ofConv (AlgHom.id R H)).comp
+      (commutatorAlgHom (R := R) (H := H)) =
+        (1 : WithConv (H →ₐ[R] H)).ofConv := by
+  simpa using productMap_comp_commutatorAlgHom (R := R) (H := H)
+    (1 : WithConv (H →ₐ[R] H)) (toConv (AlgHom.id R H))
+
+/-- The commutator with the identity in the second variable is the identity point. -/
+@[simp]
+theorem productMap_id_one_comp_commutatorAlgHom :
+    (Algebra.TensorProduct.productMap
+        (AlgHom.id R H) (1 : WithConv (H →ₐ[R] H)).ofConv).comp
+      (commutatorAlgHom (R := R) (H := H)) =
+        (1 : WithConv (H →ₐ[R] H)).ofConv := by
+  simpa using productMap_comp_commutatorAlgHom (R := R) (H := H)
+    (toConv (AlgHom.id R H)) (1 : WithConv (H →ₐ[R] H))
+
+end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Commutator.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Commutator.lean
@@ -122,24 +122,4 @@ theorem comp_commutatorAlgHom {A : Type w} [CommSemiring A] [Algebra R A]
           (toConv (phi.comp Algebra.TensorProduct.includeLeft))
           (toConv (phi.comp Algebra.TensorProduct.includeRight))
 
-/-- The commutator with the identity in the first variable is the identity point. -/
-@[simp]
-theorem productMap_one_id_comp_commutatorAlgHom :
-    (Algebra.TensorProduct.productMap
-        (1 : WithConv (H →ₐ[R] H)).ofConv (AlgHom.id R H)).comp
-      (commutatorAlgHom (R := R) (H := H)) =
-        (1 : WithConv (H →ₐ[R] H)).ofConv := by
-  simpa using productMap_comp_commutatorAlgHom (R := R) (H := H)
-    (1 : WithConv (H →ₐ[R] H)) (toConv (AlgHom.id R H))
-
-/-- The commutator with the identity in the second variable is the identity point. -/
-@[simp]
-theorem productMap_id_one_comp_commutatorAlgHom :
-    (Algebra.TensorProduct.productMap
-        (AlgHom.id R H) (1 : WithConv (H →ₐ[R] H)).ofConv).comp
-      (commutatorAlgHom (R := R) (H := H)) =
-        (1 : WithConv (H →ₐ[R] H)).ofConv := by
-  simpa using productMap_comp_commutatorAlgHom (R := R) (H := H)
-    (toConv (AlgHom.id R H)) (1 : WithConv (H →ₐ[R] H))
-
 end TauCeti.HopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Commutator.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Commutator.lean
@@ -32,8 +32,6 @@ closed subgroup scheme containing the image, constructed in
 
 * `TauCeti.HopfAlgebra.commutatorAlgHom`: the coordinate algebra morphism of the commutator.
 * `TauCeti.HopfAlgebra.productMap_comp_commutatorAlgHom`: evaluation at two algebra-valued points.
-* `TauCeti.HopfAlgebra.comp_commutatorAlgHom`: evaluation against an arbitrary map from the tensor
-  square.
 
 ## References
 
@@ -98,28 +96,7 @@ theorem productMap_comp_commutatorAlgHom
       Bialgebra.TensorProduct.includeRight_toAlgHom,
       Algebra.TensorProduct.productMap_left, Algebra.TensorProduct.productMap_right,
       commutatorElement_def]
-  exact congrArg WithConv.ofConv hmap
-
-/-- Evaluation against an arbitrary algebra map out of the tensor square takes the commutator of
-its restrictions to the two tensor factors. -/
-theorem comp_commutatorAlgHom {A : Type w} [CommSemiring A] [Algebra R A]
-    (phi : H ⊗[R] H →ₐ[R] A) :
-    phi.comp (commutatorAlgHom (R := R) (H := H)) =
-      (⁅toConv (phi.comp Algebra.TensorProduct.includeLeft),
-        toConv (phi.comp Algebra.TensorProduct.includeRight)⁆).ofConv := by
-  calc
-    phi.comp (commutatorAlgHom (R := R) (H := H)) =
-        (Algebra.TensorProduct.productMap
-          (phi.comp Algebra.TensorProduct.includeLeft)
-          (phi.comp Algebra.TensorProduct.includeRight)).comp
-            (commutatorAlgHom (R := R) (H := H)) :=
-      congrArg (fun psi : H ⊗[R] H →ₐ[R] A ↦
-        psi.comp (commutatorAlgHom (R := R) (H := H)))
-        (AffineGroup.Product.productMap_restrict phi).symm
-    _ = _ := by
-      simpa only [ofConv_toConv] using
-        productMap_comp_commutatorAlgHom (R := R) (H := H)
-          (toConv (phi.comp Algebra.TensorProduct.includeLeft))
-          (toConv (phi.comp Algebra.TensorProduct.includeRight))
+  rw [AlgHom.mapValue_apply] at hmap
+  simpa only [ofConv_toConv] using congrArg WithConv.ofConv hmap
 
 end TauCeti.HopfAlgebra


### PR DESCRIPTION
This PR constructs the scheme-theoretic derived subgroup of an affine group scheme as the smallest closed subgroup containing the commutator morphism. Define the coordinate morphism `H ⟶ H ⊗[R] H` from the convolution commutator of the two universal tensor-factor points, prove its evaluation formula on every commutative value algebra, and take the largest Hopf ideal contained in its kernel. The resulting quotient Hopf algebra represents `G_der`; every pointwise commutator lands in it, so its defining ideal is normal and the pointwise quotient is commutative.

The exact roadmap targets are `ReductiveGroups/README.md`, Layer 5, milestone “Lie–Kolchin; solvable groups,” whose merged solvability foundation explicitly leaves the scheme-theoretic derived subgroup outstanding, and Layer 6, milestone “Reductive and semisimple groups,” which requires development of the derived group `G_der`. This is the most effective independent step on that path because the commutative-Hopf-algebra/affine-group-scheme equivalence, Hopf-ideal quotients, closed-subgroup schemes, conjugation coordinates, and pointwise normality criterion are all on `main`, while the current open ReductiveGroups work concerns the distinct Chevalley, base-change, and component-group lanes. After this PR, the Layer 6 milestone still needs the derived subgroup’s base-change and structural properties together with the radical, centre, central isogenies, and simply-connected and adjoint forms.

Add `TauCeti/Algebra/AlgebraicGroup/Hopf/Commutator.lean` (145 lines) and `TauCeti/Algebra/AlgebraicGroup/Derived.lean` (146 lines). The construction reuses Mathlib’s convolution group and commutator/quotient-group API and Tau Ceti’s existing tensor-product points, Hopf-ideal lattice, quotient-spectrum, and normality APIs; no Mathlib infrastructure or external formalization is vendored. The mathematics follows J. S. Milne, *Algebraic Groups* (2017), §6d, especially Propositions 6.17 and 6.18, and W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 10, as credited in both module docstrings.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"derived-subgroup-scheme"}-->

🤖 Prepared with Codex
