### PR TITLE
feat: base change the pinned root data to the rationals

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BaseChange.lean
@@ -179,7 +179,7 @@ def rootPairingBaseChange : RootPairing ι S (κ → S) (κ → S) where
     (rootPairingBaseChange S P hP).reflectionPerm = P.reflectionPerm :=
   (rfl)
 
-theorem toLinearMap_rootPairingBaseChange (x y : κ → S) :
+@[simp] theorem toLinearMap_rootPairingBaseChange (x y : κ → S) :
     (rootPairingBaseChange S P hP).toLinearMap x y = x ⬝ᵥ y :=
   (rfl)
 

--- a/TauCeti/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BaseChange.lean
@@ -18,8 +18,9 @@ public section
 An integral root datum carries its roots and coroots on the standard lattices `κ → ℤ`, paired by
 the dot product. The constructions which build a Lie algebra out of a root system — Serre's
 presentation, and Geck's construction — instead want a root system over a field of characteristic
-zero. This file moves such a pairing along a ring homomorphism, applying the structure map entrywise
-to every root and coroot and keeping the same reflection permutation.
+zero. This file moves such a pairing along an injective algebra map, expressed by
+`[FaithfulSMul R S]`, applying the structure map entrywise to every root and coroot and keeping the
+same reflection permutation.
 
 Only the target pairing is chosen here: it is again the dot product, which is perfect on `κ → S` for
 every commutative ring `S` by `TauCeti.dotProductBilin_isPerfPair`. So the construction asks the
@@ -34,7 +35,8 @@ base ring rather than transported.
 
 ## Main definitions
 
-* `TauCeti.rootPairingBaseChange`: the base change of a dot-product root pairing along `R → S`.
+* `TauCeti.rootPairingBaseChange`: the base change of a dot-product root pairing along an injective
+  algebra map `R → S`, expressed by `[FaithfulSMul R S]`.
 * `TauCeti.rootPairingBaseChangeBase`: the base of the base change attached to a base of the
   original pairing, supported on the same indices.
 
@@ -134,7 +136,8 @@ variable [FaithfulSMul R S]
 
 /-- **Base change of a root pairing on the standard lattices.** The roots and coroots of
 `P : RootPairing ι R (κ → R) (κ → R)`, whose pairing is the dot product, are pushed entrywise
-along `algebraMap R S` and paired again by the dot product on `κ → S`. -/
+along the injective map `algebraMap R S`, with injectivity supplied by `[FaithfulSMul R S]`, and
+paired again by the dot product on `κ → S`. -/
 def rootPairingBaseChange : RootPairing ι S (κ → S) (κ → S) where
   toLinearMap := dotProductBilin S S
   root := ⟨fun i => Pi.algebraMap κ R S (P.root i),
@@ -209,7 +212,7 @@ instance isCrystallographic_rootPairingBaseChange [P.IsCrystallographic] :
 
 /-- The integral pairing of a crystallographic root pairing is unchanged by base change into a
 ring of characteristic zero. Hence so is the Cartan matrix of any base. -/
-theorem pairingIn_rootPairingBaseChange [CharZero S] [P.IsCrystallographic] (i j : ι) :
+@[simp] theorem pairingIn_rootPairingBaseChange [CharZero S] [P.IsCrystallographic] (i j : ι) :
     (rootPairingBaseChange S P hP).pairingIn ℤ i j = P.pairingIn ℤ i j := by
   refine algebraMap_injective ℤ S ?_
   rw [RootPairing.algebraMap_pairingIn, pairing_rootPairingBaseChange,
@@ -287,7 +290,7 @@ def supportEquivRootPairingBaseChangeBase :
   (rfl)
 
 /-- Base change does not change the Cartan matrix of a base. -/
-theorem cartanMatrix_rootPairingBaseChangeBase [CharZero S] [P.IsCrystallographic]
+@[simp] theorem cartanMatrix_rootPairingBaseChangeBase [CharZero S] [P.IsCrystallographic]
     (i j : (rootPairingBaseChangeBase S P hP b).support) :
     (rootPairingBaseChangeBase S P hP b).cartanMatrix i j =
       b.cartanMatrix (supportEquivRootPairingBaseChangeBase S P hP b i)

--- a/TauCeti/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BaseChange.lean
@@ -1,0 +1,299 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.LinearIndependent.BaseChange
+public import Mathlib.LinearAlgebra.RootSystem.CartanMatrix
+public import Mathlib.LinearAlgebra.RootSystem.Reduced
+public import TauCeti.LinearAlgebra.Matrix.Dual
+
+public section
+
+/-!
+# Base change of a root pairing carried by the standard lattices
+
+An integral root datum carries its roots and coroots on the standard lattices `κ → ℤ`, paired by
+the dot product. The constructions which build a Lie algebra out of a root system — Serre's
+presentation, and Geck's construction — instead want a root system over a field of characteristic
+zero. This file moves such a pairing along a ring homomorphism, applying the structure map entrywise
+to every root and coroot and keeping the same reflection permutation.
+
+Only the target pairing is chosen here: it is again the dot product, which is perfect on `κ → S` for
+every commutative ring `S` by `TauCeti.dotProductBilin_isPerfPair`. So the construction asks the
+source pairing to be the dot product too, and every axiom of `RootPairing` then transports along
+`Pi.algebraMap`, entrywise application of `algebraMap R S`.
+
+The properties a downstream Lie-theoretic consumer needs are transported separately, each under its
+own hypotheses: being crystallographic, being reduced, spanning, and carrying a base with a
+prescribed Cartan matrix. Irreducibility is deliberately absent, because it is *false* over `ℤ`:
+the sublattice `2 • (κ → ℤ)` is invariant under every reflection. It has to be proved over the new
+base ring rather than transported.
+
+## Main definitions
+
+* `TauCeti.rootPairingBaseChange`: the base change of a dot-product root pairing along `R → S`.
+* `TauCeti.rootPairingBaseChangeBase`: the base of the base change attached to a base of the
+  original pairing, supported on the same indices.
+
+## Main results
+
+* `TauCeti.isCrystallographic_rootPairingBaseChange`: base change preserves being crystallographic.
+* `TauCeti.isReduced_rootPairingBaseChange`: base change preserves being reduced.
+* `TauCeti.span_range_root_rootPairingBaseChange_eq_top` and
+  `TauCeti.span_range_coroot_rootPairingBaseChange_eq_top`: a spanning family of roots or coroots
+  stays spanning.
+* `TauCeti.pairingIn_rootPairingBaseChange`: the integral pairings, hence the Cartan matrix of a
+  base, are unchanged.
+
+## References
+
+The construction is the standard passage from a root datum over `ℤ` to the root system over `ℚ`
+that it determines; see N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Ch. VI, §1. It
+supplies the root-system input of the Chevalley basis in Layer 9,
+"pinned Chevalley--Demazure group schemes over `ℤ`", of `TauCetiRoadmap/ReductiveGroups/README.md`.
+-/
+
+namespace TauCeti
+
+open Function Matrix Set
+open FaithfulSMul (algebraMap_injective)
+open Submodule (span)
+
+/-! ## Entrywise base change of the standard lattice -/
+
+section Entrywise
+
+variable {κ R : Type*} (S : Type*) [CommRing R] [CommRing S] [Algebra R S]
+
+/-- Entrywise base change of the standard lattice reads off entrywise. -/
+theorem piAlgebraMap_apply (x : κ → R) (j : κ) :
+    Pi.algebraMap κ R S x j = algebraMap R S (x j) :=
+  rfl
+
+private theorem injective_piAlgebraMap [FaithfulSMul R S] :
+    Injective (Pi.algebraMap κ R S) := fun _ _ h =>
+  funext fun j => algebraMap_injective R S (congrFun h j)
+
+/-- Entrywise base change carries the additive closure of a family into the additive closure of the
+base-changed family. -/
+theorem mem_closure_image_piAlgebraMap {ι : Type*} {g : ι → (κ → R)} {s : Set ι} {x : κ → R}
+    (hx : x ∈ AddSubmonoid.closure (g '' s)) :
+    Pi.algebraMap κ R S x ∈
+      AddSubmonoid.closure ((fun i => Pi.algebraMap κ R S (g i)) '' s) := by
+  have himage : (fun i => Pi.algebraMap κ R S (g i)) '' s =
+      (Pi.algebraMap κ R S : (κ → R) →ₗ[R] (κ → S)) '' (g '' s) := by
+    rw [← image_comp]
+    rfl
+  rw [himage, ← AddMonoidHom.map_mclosure]
+  exact AddSubmonoid.mem_map_of_mem _ hx
+
+/-- A family of vectors spanning the standard lattice still spans after entrywise base change. -/
+theorem span_range_piAlgebraMap_eq_top [Finite κ] {ι : Type*} {v : ι → (κ → R)}
+    (hv : span R (range v) = ⊤) :
+    span S (range fun i => Pi.algebraMap κ R S (v i)) = ⊤ := by
+  classical
+  have _i : Fintype κ := Fintype.ofFinite κ
+  set W : Submodule S (κ → S) := span S (range fun i => Pi.algebraMap κ R S (v i))
+  have hmem : ∀ x : κ → R, Pi.algebraMap κ R S x ∈ W := by
+    intro x
+    have hsub : span R (range v) ≤ (W.restrictScalars R).comap (Pi.algebraMap κ R S) := by
+      rw [Submodule.span_le]
+      rintro - ⟨i, rfl⟩
+      exact Submodule.subset_span (mem_range_self i)
+    exact hsub (hv ▸ Submodule.mem_top)
+  have hsingle : ∀ j : κ, Pi.single j (1 : S) ∈ W := by
+    intro j
+    have hj : Pi.algebraMap κ R S (Pi.single j (1 : R)) = Pi.single j (1 : S) := by
+      funext k
+      rw [piAlgebraMap_apply]
+      rcases eq_or_ne k j with rfl | hk
+      · simp
+      · simp [Pi.single_eq_of_ne hk]
+    exact hj ▸ hmem (Pi.single j (1 : R))
+  refine top_le_iff.mp fun x _ => ?_
+  rw [← Module.Basis.sum_repr (Pi.basisFun S κ) x]
+  exact Submodule.sum_mem _ fun j _ => Submodule.smul_mem _ _ (by simpa using hsingle j)
+
+end Entrywise
+
+/-! ## The base-changed pairing -/
+
+section Defs
+
+variable {ι κ R : Type*} (S : Type*) [Fintype κ] [CommRing R] [CommRing S] [Algebra R S]
+  (P : RootPairing ι R (κ → R) (κ → R)) (hP : ∀ x y, P.toLinearMap x y = x ⬝ᵥ y)
+
+private theorem dotProduct_piAlgebraMap (x y : κ → R) :
+    Pi.algebraMap κ R S x ⬝ᵥ Pi.algebraMap κ R S y = algebraMap R S (x ⬝ᵥ y) := by
+  simp [dotProduct, piAlgebraMap_apply, map_sum]
+
+variable [FaithfulSMul R S]
+
+/-- **Base change of a root pairing on the standard lattices.** The roots and coroots of
+`P : RootPairing ι R (κ → R) (κ → R)`, whose pairing is the dot product, are pushed entrywise
+along `algebraMap R S` and paired again by the dot product on `κ → S`. -/
+def rootPairingBaseChange : RootPairing ι S (κ → S) (κ → S) where
+  toLinearMap := dotProductBilin S S
+  root := ⟨fun i => Pi.algebraMap κ R S (P.root i),
+    (injective_piAlgebraMap S).comp P.root.injective⟩
+  coroot := ⟨fun i => Pi.algebraMap κ R S (P.coroot i),
+    (injective_piAlgebraMap S).comp P.coroot.injective⟩
+  root_coroot_two i := by
+    have h : Pi.algebraMap κ R S (P.root i) ⬝ᵥ Pi.algebraMap κ R S (P.coroot i) = (2 : S) := by
+      rw [dotProduct_piAlgebraMap, ← hP, P.root_coroot_two i, map_ofNat]
+    exact h
+  reflectionPerm := P.reflectionPerm
+  reflectionPerm_root i j := by
+    have h := congrArg (Pi.algebraMap κ R S) (P.reflectionPerm_root i j)
+    rw [map_sub, map_smul, hP] at h
+    have key : Pi.algebraMap κ R S (P.root j) -
+        (Pi.algebraMap κ R S (P.root j) ⬝ᵥ Pi.algebraMap κ R S (P.coroot i)) •
+          Pi.algebraMap κ R S (P.root i) =
+        Pi.algebraMap κ R S (P.root (P.reflectionPerm i j)) := by
+      rw [dotProduct_piAlgebraMap, algebraMap_smul]
+      exact h
+    exact key
+  reflectionPerm_coroot i j := by
+    have h := congrArg (Pi.algebraMap κ R S) (P.reflectionPerm_coroot i j)
+    rw [map_sub, map_smul, hP] at h
+    have key : Pi.algebraMap κ R S (P.coroot j) -
+        (Pi.algebraMap κ R S (P.root i) ⬝ᵥ Pi.algebraMap κ R S (P.coroot j)) •
+          Pi.algebraMap κ R S (P.coroot i) =
+        Pi.algebraMap κ R S (P.coroot (P.reflectionPerm i j)) := by
+      rw [dotProduct_piAlgebraMap, algebraMap_smul]
+      exact h
+    exact key
+
+@[simp] theorem root_rootPairingBaseChange (i : ι) :
+    (rootPairingBaseChange S P hP).root i = Pi.algebraMap κ R S (P.root i) :=
+  (rfl)
+
+@[simp] theorem coroot_rootPairingBaseChange (i : ι) :
+    (rootPairingBaseChange S P hP).coroot i = Pi.algebraMap κ R S (P.coroot i) :=
+  (rfl)
+
+@[simp] theorem reflectionPerm_rootPairingBaseChange :
+    (rootPairingBaseChange S P hP).reflectionPerm = P.reflectionPerm :=
+  (rfl)
+
+theorem toLinearMap_rootPairingBaseChange (x y : κ → S) :
+    (rootPairingBaseChange S P hP).toLinearMap x y = x ⬝ᵥ y :=
+  (rfl)
+
+@[simp] theorem pairing_rootPairingBaseChange (i j : ι) :
+    (rootPairingBaseChange S P hP).pairing i j = algebraMap R S (P.pairing i j) := by
+  rw [← RootPairing.root_coroot_eq_pairing, ← RootPairing.root_coroot_eq_pairing,
+    root_rootPairingBaseChange, coroot_rootPairingBaseChange, toLinearMap_rootPairingBaseChange,
+    dotProduct_piAlgebraMap, hP]
+
+end Defs
+
+/-! ## Transport of the axioms a Lie-theoretic consumer needs -/
+
+section Transport
+
+variable {ι κ R : Type*} (S : Type*) [Fintype κ] [CommRing R] [CommRing S] [Algebra R S]
+  (P : RootPairing ι R (κ → R) (κ → R)) (hP : ∀ x y, P.toLinearMap x y = x ⬝ᵥ y) [FaithfulSMul R S]
+
+/-- Base change preserves being crystallographic: a pairing which was an integer stays that same
+integer in the new base ring. -/
+instance isCrystallographic_rootPairingBaseChange [P.IsCrystallographic] :
+    (rootPairingBaseChange S P hP).IsCrystallographic where
+  exists_value i j := by
+    refine ⟨P.pairingIn ℤ i j, ?_⟩
+    rw [pairing_rootPairingBaseChange, ← P.algebraMap_pairingIn ℤ i j]
+    simp [algebraMap_int_eq]
+
+/-- The integral pairing of a crystallographic root pairing is unchanged by base change into a
+ring of characteristic zero. Hence so is the Cartan matrix of any base. -/
+theorem pairingIn_rootPairingBaseChange [CharZero S] [P.IsCrystallographic] (i j : ι) :
+    (rootPairingBaseChange S P hP).pairingIn ℤ i j = P.pairingIn ℤ i j := by
+  refine algebraMap_injective ℤ S ?_
+  rw [RootPairing.algebraMap_pairingIn, pairing_rootPairingBaseChange,
+    ← P.algebraMap_pairingIn ℤ i j]
+  simp [algebraMap_int_eq]
+
+/-- Base change along an injective map into a domain preserves being reduced. -/
+theorem isReduced_rootPairingBaseChange [IsDomain S] [P.IsReduced] :
+    (rootPairingBaseChange S P hP).IsReduced where
+  eq_or_eq_neg i j h := by
+    have hv : (fun k => algebraMap R S ∘ ![P.root i, P.root j] k) =
+        ![(rootPairingBaseChange S P hP).root i, (rootPairingBaseChange S P hP).root j] := by
+      funext k
+      fin_cases k <;> rfl
+    replace h : ¬ LinearIndependent R ![P.root i, P.root j] := by
+      rw [← linearIndependent_algebraMap_comp_iff (S := S), hv]
+      exact h
+    rcases RootPairing.IsReduced.eq_or_eq_neg (P := P) i j h with h | h
+    · exact Or.inl <| by rw [root_rootPairingBaseChange, root_rootPairingBaseChange, h]
+    · exact Or.inr <| by rw [root_rootPairingBaseChange, root_rootPairingBaseChange, h, map_neg]
+
+/-- Base change preserves spanning by the roots. -/
+theorem span_range_root_rootPairingBaseChange_eq_top (h : span R (range P.root) = ⊤) :
+    span S (range (rootPairingBaseChange S P hP).root) = ⊤ :=
+  span_range_piAlgebraMap_eq_top S h
+
+/-- Base change preserves spanning by the coroots. -/
+theorem span_range_coroot_rootPairingBaseChange_eq_top (h : span R (range P.coroot) = ⊤) :
+    span S (range (rootPairingBaseChange S P hP).coroot) = ⊤ :=
+  span_range_piAlgebraMap_eq_top S h
+
+end Transport
+
+/-! ## Bases -/
+
+section Base
+
+variable {ι κ R : Type*} (S : Type*) [Fintype κ] [CommRing R] [CommRing S] [Algebra R S]
+  (P : RootPairing ι R (κ → R) (κ → R)) (hP : ∀ x y, P.toLinearMap x y = x ⬝ᵥ y)
+  [FaithfulSMul R S] [IsDomain S] (b : P.Base)
+
+/-- **The base change of a base.** A base of `P` is a base of the base-changed pairing, supported
+on the same indices. Linear independence survives because `S` is a domain in which `R` embeds. -/
+def rootPairingBaseChangeBase : (rootPairingBaseChange S P hP).Base where
+  support := b.support
+  linearIndepOn_root :=
+    linearIndependent_algebraMap_comp_iff (S := S) |>.mpr b.linearIndepOn_root
+  linearIndepOn_coroot :=
+    linearIndependent_algebraMap_comp_iff (S := S) |>.mpr b.linearIndepOn_coroot
+  root_mem_or_neg_mem i := by
+    rcases b.root_mem_or_neg_mem i with h | h
+    · exact Or.inl <| mem_closure_image_piAlgebraMap S h
+    · refine Or.inr ?_
+      have hmem := mem_closure_image_piAlgebraMap (S := S) (g := P.root) (s := b.support) h
+      rwa [map_neg] at hmem
+  coroot_mem_or_neg_mem i := by
+    rcases b.coroot_mem_or_neg_mem i with h | h
+    · exact Or.inl <| mem_closure_image_piAlgebraMap S h
+    · refine Or.inr ?_
+      have hmem := mem_closure_image_piAlgebraMap (S := S) (g := P.coroot) (s := b.support) h
+      rwa [map_neg] at hmem
+
+@[simp] theorem support_rootPairingBaseChangeBase :
+    (rootPairingBaseChangeBase S P hP b).support = b.support :=
+  (rfl)
+
+/-- The supports of a base and of its base change name the same indices. -/
+def supportEquivRootPairingBaseChangeBase :
+    (rootPairingBaseChangeBase S P hP b).support ≃ b.support :=
+  Equiv.subtypeEquivRight fun i => by rw [support_rootPairingBaseChangeBase]
+
+@[simp] theorem coe_supportEquivRootPairingBaseChangeBase
+    (i : (rootPairingBaseChangeBase S P hP b).support) :
+    (supportEquivRootPairingBaseChangeBase S P hP b i : ι) = i :=
+  (rfl)
+
+/-- Base change does not change the Cartan matrix of a base. -/
+theorem cartanMatrix_rootPairingBaseChangeBase [CharZero S] [P.IsCrystallographic]
+    (i j : (rootPairingBaseChangeBase S P hP b).support) :
+    (rootPairingBaseChangeBase S P hP b).cartanMatrix i j =
+      b.cartanMatrix (supportEquivRootPairingBaseChangeBase S P hP b i)
+        (supportEquivRootPairingBaseChangeBase S P hP b j) :=
+  pairingIn_rootPairingBaseChange S P hP i j
+
+end Base
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -332,6 +332,10 @@ def typeASimplyConnectedRootDatum (n : ℕ) :
   reflectionPerm_root := typeAReflectionPerm_root
   reflectionPerm_coroot := typeAReflectionPerm_coroot
 
+/-- The pinned pairing of type `Aₙ` is the dot product of the two lattices. -/
+@[simp] theorem toLinearMap_typeASimplyConnectedRootDatum (x y : Fin n → ℤ) :
+    (typeASimplyConnectedRootDatum n).toLinearMap x y = x ⬝ᵥ y := (rfl)
+
 private lemma root_typeASimplyConnectedRootDatum (k : Fin (n * (n + 1))) :
     (typeASimplyConnectedRootDatum n).root k = typeAPairRoot ((typeAIndexEquiv n).symm k) :=
   rfl

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
@@ -45,6 +45,9 @@ make this explicit data available without requiring downstream users to unfold t
   lattice.
 * `TauCeti.DynkinType.root_simpleIndex`, `coroot_simpleIndex`, and
   `mem_support_simplyConnectedBase`: the entrywise pinning of the simple roots and base.
+* `TauCeti.DynkinType.card_support_simplyConnectedBase`: the pinned base has `t.rank` elements.
+* `TauCeti.DynkinType.toLinearMap_simplyConnectedRootDatum`: the pinned pairing is the dot
+  product, uniformly in the type.
 
 ## References
 
@@ -385,6 +388,63 @@ private theorem simpleIndex_G2 (ht : G2.Valid) (i : Fin 2) :
     rw [g2SimplyConnectedBase_support]
     simp only [Finset.mem_insert, Finset.mem_singleton]
     omega
+
+/-- The pinned base has one simple root per Bourbaki node. -/
+theorem card_support_simplyConnectedBase (t : DynkinType) (ht : t.Valid) :
+    (t.simplyConnectedBase ht).support.card = t.rank := by
+  classical
+  refine (Finset.card_bij (fun (i : Fin t.rank) _ => t.simpleIndex ht i) (fun i _ => ?_)
+    (fun i _ j _ hij => ?_) fun k hk => ?_).symm.trans (Finset.card_fin t.rank)
+  · rw [mem_support_simplyConnectedBase, simpleIndex_val]
+    exact i.isLt
+  · exact Fin.ext (by simpa using congrArg Fin.val hij)
+  · rw [mem_support_simplyConnectedBase] at hk
+    exact ⟨⟨k, hk⟩, Finset.mem_univ _, Fin.ext (simpleIndex_val t ht ⟨k, hk⟩).symm⟩
+
+/-- **The pinned pairing is the dot product** of the fundamental-weight and simple-coroot
+coordinates, uniformly in the Dynkin type. -/
+theorem toLinearMap_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid)
+    (x y : Fin t.rank → ℤ) :
+    (t.simplyConnectedRootDatum ht).toLinearMap x y = x ⬝ᵥ y := by
+  -- As with the entrywise pinning above, each branch only rewrites the dispatcher into its family
+  -- datum and applies that family's own pairing equation.
+  cases t with
+  | A n =>
+    change Fin n → ℤ at x y
+    rw [simplyConnectedRootDatum_A]
+    exact toLinearMap_typeASimplyConnectedRootDatum x y
+  | B n =>
+    change Fin n → ℤ at x y
+    rw [simplyConnectedRootDatum_B]
+    exact toLinearMap_typeBSimplyConnectedRootDatum x y
+  | C n =>
+    change Fin n → ℤ at x y
+    rw [simplyConnectedRootDatum_C]
+    exact toLinearMap_typeCSimplyConnectedRootDatum x y
+  | D n =>
+    change Fin n → ℤ at x y
+    rw [simplyConnectedRootDatum_D]
+    exact toLinearMap_typeDSimplyConnectedRootDatum (valid_D.mp ht) x y
+  | E6 =>
+    change Fin 6 → ℤ at x y
+    rw [simplyConnectedRootDatum_E6]
+    exact e6SimplyConnectedRootDatum_toLinearMap x y
+  | E7 =>
+    change Fin 7 → ℤ at x y
+    rw [simplyConnectedRootDatum_E7]
+    exact e7SimplyConnectedRootDatum_toLinearMap_apply x y
+  | E8 =>
+    change Fin 8 → ℤ at x y
+    rw [simplyConnectedRootDatum_E8]
+    exact e8SimplyConnectedRootDatum_toLinearMap_apply x y
+  | F4 =>
+    change Fin 4 → ℤ at x y
+    rw [simplyConnectedRootDatum_F4]
+    exact f4SimplyConnectedRootDatum_toLinearMap_apply_apply x y
+  | G2 =>
+    change Fin 2 → ℤ at x y
+    rw [simplyConnectedRootDatum_G2]
+    exact g2SimplyConnectedRootDatum_toLinearMap x y
 
 /-! ## Uniform acceptance theorems -/
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
@@ -406,43 +406,36 @@ coordinates, uniformly in the Dynkin type. -/
 theorem toLinearMap_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid)
     (x y : Fin t.rank → ℤ) :
     (t.simplyConnectedRootDatum ht).toLinearMap x y = x ⬝ᵥ y := by
-  -- As with the entrywise pinning above, each branch only rewrites the dispatcher into its family
-  -- datum and applies that family's own pairing equation.
+  -- Unlike the entrywise pinning above, no index is retained in a dependent motive here: the case
+  -- split refines `t.rank` on a constructor, so `x` and `y` already have the family's index type.
+  -- Each branch therefore just rewrites the dispatcher into its family datum and applies that
+  -- family's own pairing equation.
   cases t with
   | A n =>
-    change Fin n → ℤ at x y
     rw [simplyConnectedRootDatum_A]
     exact toLinearMap_typeASimplyConnectedRootDatum x y
   | B n =>
-    change Fin n → ℤ at x y
     rw [simplyConnectedRootDatum_B]
     exact toLinearMap_typeBSimplyConnectedRootDatum x y
   | C n =>
-    change Fin n → ℤ at x y
     rw [simplyConnectedRootDatum_C]
     exact toLinearMap_typeCSimplyConnectedRootDatum x y
   | D n =>
-    change Fin n → ℤ at x y
     rw [simplyConnectedRootDatum_D]
     exact toLinearMap_typeDSimplyConnectedRootDatum (valid_D.mp ht) x y
   | E6 =>
-    change Fin 6 → ℤ at x y
     rw [simplyConnectedRootDatum_E6]
     exact e6SimplyConnectedRootDatum_toLinearMap x y
   | E7 =>
-    change Fin 7 → ℤ at x y
     rw [simplyConnectedRootDatum_E7]
     exact e7SimplyConnectedRootDatum_toLinearMap_apply x y
   | E8 =>
-    change Fin 8 → ℤ at x y
     rw [simplyConnectedRootDatum_E8]
     exact e8SimplyConnectedRootDatum_toLinearMap_apply x y
   | F4 =>
-    change Fin 4 → ℤ at x y
     rw [simplyConnectedRootDatum_F4]
     exact f4SimplyConnectedRootDatum_toLinearMap_apply_apply x y
   | G2 =>
-    change Fin 2 → ℤ at x y
     rw [simplyConnectedRootDatum_G2]
     exact g2SimplyConnectedRootDatum_toLinearMap x y
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
@@ -357,6 +357,10 @@ def typeCSimplyConnectedRootDatum (n : ℕ) :
     simpa using
       typeCCoroot_typeCReflectionIdx ((typeCIndexEquiv n).symm k) ((typeCIndexEquiv n).symm l)
 
+/-- The pinned pairing of type `Cₙ` is the dot product of the two lattices. -/
+@[simp] theorem toLinearMap_typeCSimplyConnectedRootDatum (x y : Fin n → ℤ) :
+    (typeCSimplyConnectedRootDatum n).toLinearMap x y = x ⬝ᵥ y := (rfl)
+
 private lemma root_typeCSimplyConnectedRootDatum (k : Fin (2 * n ^ 2)) :
     (typeCSimplyConnectedRootDatum n).root k = typeCRoot ((typeCIndexEquiv n).symm k) :=
   rfl

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Rational.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Rational.lean
@@ -16,8 +16,10 @@ public section
 `TauCeti.DynkinType.simplyConnectedRootDatum` pins one integral root datum per valid Dynkin type,
 on the lattices `Fin t.rank → ℤ`. The constructions which build a semisimple Lie algebra out of a
 root system want instead a root *system* over a field of characteristic zero: the roots must span
-the ambient space, which they never do over the simply connected character lattice, since that
-lattice is the weight lattice and the roots only span the root lattice inside it.
+the ambient space, which they do not in general over the simply connected character lattice, since
+that lattice is the weight lattice and the roots only span the root lattice inside it. The two
+lattices agree exactly when the Cartan matrix is unimodular, so integrally the roots do span for
+`E₈`, `F₄` and `G₂`, and fail to span for every other valid type.
 
 This file base-changes the pinned datum to `ℚ`, using `TauCeti.rootPairingBaseChange`, and proves
 that the result is a genuine root system: the roots span, because the `t.rank` simple roots are
@@ -56,7 +58,7 @@ root-system input of the Chevalley basis in Layer 9, "pinned Chevalley--Demazure
 
 namespace TauCeti.DynkinType
 
-open Set
+open _root_.Matrix Set
 open Submodule (span)
 
 noncomputable section
@@ -93,6 +95,11 @@ def rationalBase : (t.rationalRootSystem ht).Base :=
     (t.rationalRootSystem ht).reflectionPerm = (t.simplyConnectedRootDatum ht).reflectionPerm :=
   reflectionPerm_rootPairingBaseChange ..
 
+/-- The pairing of the rational system is the dot product of `Fin t.rank → ℚ` with itself. -/
+@[simp] theorem toLinearMap_rationalRootSystem (x y : Fin t.rank → ℚ) :
+    (t.rationalRootSystem ht).toLinearMap x y = x ⬝ᵥ y :=
+  toLinearMap_rootPairingBaseChange ..
+
 @[simp] theorem pairing_rationalRootSystem (i j : Fin t.numRoots) :
     (t.rationalRootSystem ht).pairing i j = ((t.simplyConnectedRootDatum ht).pairing i j : ℚ) := by
   rw [rationalRootSystem, pairing_rootPairingBaseChange]
@@ -120,7 +127,9 @@ theorem span_range_coroot_rationalRootSystem_eq_top :
 
 /-- The simple roots of the rational system are `t.rank` linearly independent vectors in a space of
 dimension `t.rank`, so the roots span the rational character space. This is the statement which
-fails over `ℤ`: there the roots span only the root lattice inside the weight lattice. -/
+fails integrally outside the unimodular types `E₈`, `F₄` and `G₂`: over `ℤ` the roots span only the
+root lattice, which is a proper sublattice of the weight lattice whenever the Cartan matrix has
+determinant other than `1`. -/
 theorem span_range_root_rationalRootSystem_eq_top :
     span ℚ (range (t.rationalRootSystem ht).root) = ⊤ := by
   have hli : LinearIndependent ℚ fun i : ((t.rationalBase ht).support : Finset _) =>

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Rational.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Rational.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.BaseChange
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Assembly
+
+public section
+
+/-!
+# The rational root system of a Dynkin type
+
+`TauCeti.DynkinType.simplyConnectedRootDatum` pins one integral root datum per valid Dynkin type,
+on the lattices `Fin t.rank → ℤ`. The constructions which build a semisimple Lie algebra out of a
+root system want instead a root *system* over a field of characteristic zero: the roots must span
+the ambient space, which they never do over the simply connected character lattice, since that
+lattice is the weight lattice and the roots only span the root lattice inside it.
+
+This file base-changes the pinned datum to `ℚ`, using `TauCeti.rootPairingBaseChange`, and proves
+that the result is a genuine root system: the roots span, because the `t.rank` simple roots are
+linearly independent in a space of dimension `t.rank`, and the coroots span, because they already
+did over `ℤ`. The pinned base and the Bourbaki-numbered Cartan matrix survive the base change
+unchanged, so the rational system realizes the same Dynkin type as the datum it comes from.
+
+What is *not* proved here is that the rational system is reduced and irreducible. Both are
+properties of the explicit root tables rather than of the base change: irreducibility is false over
+`ℤ`, so it cannot be transported at all, and reducedness has not been established for the pinned
+tables. They are the two remaining hypotheses of Geck's construction
+`RootPairing.GeckConstruction.lieAlgebra`, which is what turns this root system into the split
+semisimple Lie algebra whose Chevalley basis a Chevalley--Demazure group scheme is built from.
+
+## Main definitions
+
+* `TauCeti.DynkinType.rationalRootSystem`: the pinned datum of a valid Dynkin type, base-changed
+  to `ℚ`.
+* `TauCeti.DynkinType.rationalBase`: its Bourbaki-numbered base.
+
+## Main results
+
+* `TauCeti.DynkinType.instIsRootSystemRationalRootSystem`: the roots and coroots span.
+* `TauCeti.DynkinType.hasCartanType_rationalRootSystem`: the rational system realizes its own
+  Dynkin type against the pinned numbering.
+* `TauCeti.DynkinType.pairingIn_rationalRootSystem`: its Cartan integers are those of the datum.
+
+## References
+
+The passage from a root datum over `ℤ` to the root system over `ℚ` it determines is standard; see
+N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Ch. VI, §1. This supplies the
+root-system input of the Chevalley basis in Layer 9, "pinned Chevalley--Demazure group schemes over
+`ℤ`", of `TauCetiRoadmap/ReductiveGroups/README.md`, whose consumer is milestone L0 of the
+`CFSGStatement` roadmap.
+-/
+
+namespace TauCeti.DynkinType
+
+open Set
+open Submodule (span)
+
+noncomputable section
+
+variable (t : DynkinType) (ht : t.Valid)
+
+/-! ## The base change to `ℚ` -/
+
+/-- **The rational root system of a valid Dynkin type**: the pinned simply connected root datum
+with its roots and coroots read in `Fin t.rank → ℚ`. The pairing is again the dot product, and the
+reflection permutation is unchanged. -/
+def rationalRootSystem :
+    RootPairing (Fin t.numRoots) ℚ (Fin t.rank → ℚ) (Fin t.rank → ℚ) :=
+  rootPairingBaseChange ℚ (t.simplyConnectedRootDatum ht)
+    (toLinearMap_simplyConnectedRootDatum t ht)
+
+/-- The Bourbaki-numbered base of `TauCeti.DynkinType.rationalRootSystem`, supported on the same
+first `t.rank` root indices as the base of the integral datum. -/
+def rationalBase : (t.rationalRootSystem ht).Base :=
+  rootPairingBaseChangeBase ℚ (t.simplyConnectedRootDatum ht)
+    (toLinearMap_simplyConnectedRootDatum t ht) (t.simplyConnectedBase ht)
+
+@[simp] theorem root_rationalRootSystem (i : Fin t.numRoots) (k : Fin t.rank) :
+    (t.rationalRootSystem ht).root i k = ((t.simplyConnectedRootDatum ht).root i k : ℚ) := by
+  rw [rationalRootSystem, root_rootPairingBaseChange, piAlgebraMap_apply]
+  simp
+
+@[simp] theorem coroot_rationalRootSystem (i : Fin t.numRoots) (k : Fin t.rank) :
+    (t.rationalRootSystem ht).coroot i k = ((t.simplyConnectedRootDatum ht).coroot i k : ℚ) := by
+  rw [rationalRootSystem, coroot_rootPairingBaseChange, piAlgebraMap_apply]
+  simp
+
+@[simp] theorem reflectionPerm_rationalRootSystem :
+    (t.rationalRootSystem ht).reflectionPerm = (t.simplyConnectedRootDatum ht).reflectionPerm :=
+  reflectionPerm_rootPairingBaseChange ..
+
+@[simp] theorem pairing_rationalRootSystem (i j : Fin t.numRoots) :
+    (t.rationalRootSystem ht).pairing i j = ((t.simplyConnectedRootDatum ht).pairing i j : ℚ) := by
+  rw [rationalRootSystem, pairing_rootPairingBaseChange]
+  simp
+
+@[simp] theorem support_rationalBase :
+    (t.rationalBase ht).support = (t.simplyConnectedBase ht).support :=
+  support_rootPairingBaseChangeBase ..
+
+instance instIsCrystallographicRationalRootSystem : (t.rationalRootSystem ht).IsCrystallographic :=
+  isCrystallographic_rootPairingBaseChange ..
+
+/-- The Cartan integers of the rational system are those of the integral datum. -/
+@[simp] theorem pairingIn_rationalRootSystem (i j : Fin t.numRoots) :
+    (t.rationalRootSystem ht).pairingIn ℤ i j = (t.simplyConnectedRootDatum ht).pairingIn ℤ i j :=
+  pairingIn_rootPairingBaseChange ..
+
+/-! ## The rational system is a root system -/
+
+/-- The coroots of the rational system span the rational cocharacter space, because the coroots of
+the simply connected datum already span the cocharacter lattice. -/
+theorem span_range_coroot_rationalRootSystem_eq_top :
+    span ℚ (range (t.rationalRootSystem ht).coroot) = ⊤ :=
+  span_range_coroot_rootPairingBaseChange_eq_top ℚ _ _ (span_coroot_simplyConnectedRootDatum t ht)
+
+/-- The simple roots of the rational system are `t.rank` linearly independent vectors in a space of
+dimension `t.rank`, so the roots span the rational character space. This is the statement which
+fails over `ℤ`: there the roots span only the root lattice inside the weight lattice. -/
+theorem span_range_root_rationalRootSystem_eq_top :
+    span ℚ (range (t.rationalRootSystem ht).root) = ⊤ := by
+  have hli : LinearIndependent ℚ fun i : ((t.rationalBase ht).support : Finset _) =>
+      (t.rationalRootSystem ht).root i := (t.rationalBase ht).linearIndepOn_root
+  have hcard : Fintype.card ((t.rationalBase ht).support : Finset _) =
+      Module.finrank ℚ (Fin t.rank → ℚ) := by
+    rw [Fintype.card_coe, Module.finrank_fin_fun, support_rationalBase]
+    exact card_support_simplyConnectedBase t ht
+  refine top_le_iff.mp ?_
+  rw [← hli.span_eq_top_of_card_eq_finrank' hcard]
+  exact Submodule.span_mono (by rintro - ⟨i, rfl⟩; exact mem_range_self (i : Fin t.numRoots))
+
+instance instIsRootSystemRationalRootSystem : (t.rationalRootSystem ht).IsRootSystem where
+  span_root_eq_top := span_range_root_rationalRootSystem_eq_top t ht
+  span_coroot_eq_top := span_range_coroot_rationalRootSystem_eq_top t ht
+
+/-! ## Acceptance: the rational system realizes its own Dynkin type -/
+
+/-- **The rational system has Cartan type `t`.** The base change leaves both the support of the
+pinned base and every Cartan integer alone, so the relabelling exhibited by the integral datum
+still works. -/
+theorem hasCartanType_rationalRootSystem :
+    HasCartanType (t.rationalRootSystem ht) (t.rationalBase ht) t := by
+  obtain ⟨e, he⟩ := (hasCartanType_iff _ _).1 (hasCartanType_simplyConnectedRootDatum t ht)
+  refine (hasCartanType_iff _ _).2 ⟨(supportEquivRootPairingBaseChangeBase ℚ _ _ _).trans e,
+    fun i j => ?_⟩
+  exact (cartanMatrix_rootPairingBaseChangeBase ℚ _ _ _ i j).trans (he _ _)
+
+end
+
+end TauCeti.DynkinType


### PR DESCRIPTION
This PR base-changes a root pairing carried by the standard dot-product lattices along a ring homomorphism, and instantiates the construction at `ℤ → ℚ` to produce the rational root system of every valid Dynkin type. `TauCeti.rootPairingBaseChange` pushes the roots and coroots of a pairing on `κ → R` entrywise along `algebraMap R S`, keeps the reflection permutation, and pairs the images by the dot product on `κ → S`, which is perfect over any commutative ring. Each property a Lie-theoretic consumer needs is then transported separately and under its own hypotheses: being crystallographic, being reduced (over an injective map into a domain, via Mathlib's `linearIndependent_algebraMap_comp_iff`), spanning by roots or by coroots, and carrying a base — `TauCeti.rootPairingBaseChangeBase` — supported on the same indices with an unchanged Cartan matrix. Irreducibility is deliberately absent and the module says why: it is *false* over `ℤ`, since `2 • (κ → ℤ)` is invariant under every reflection, so it cannot be transported at all.

`TauCeti.DynkinType.rationalRootSystem t ht` is that base change applied to `DynkinType.simplyConnectedRootDatum t ht`, with `rationalBase` its Bourbaki-numbered base. It carries `IsCrystallographic` and, crucially, `IsRootSystem`: the coroots span because they already spanned the cocharacter lattice over `ℤ`, and the roots span because the `t.rank` simple roots are linearly independent in a space of dimension `t.rank`. The second half is exactly what fails over the integral datum outside the unimodular types `E₈`, `F₄` and `G₂`: its character lattice is the weight lattice while its roots span only the root lattice — which is why the simply connected data deliberately carry no `IsRootSystem` instance and why base change, not a further integral theorem, is the step needed here. `hasCartanType_rationalRootSystem` closes the loop: the rational system realizes the same Dynkin type against the same Bourbaki numbering, and `pairingIn_rationalRootSystem` records that its Cartan integers are those of the datum.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, "pinned Chevalley--Demazure group schemes over `ℤ`", milestone "**The Chevalley--Demazure construction.** For each root datum, an explicitly constructed split reductive group scheme over `ℤ` realizing it, via a Chevalley basis and the Kostant `ℤ`-form. Constructed, not asserted to exist." That milestone starts from a split semisimple Lie algebra with a Chevalley basis attached to each root datum, and nothing on `main` connects `DynkinType.simplyConnectedRootDatum` to a Lie algebra at all. Mathlib's `RootPairing.GeckConstruction.lieAlgebra` and `GeckConstruction.basis` are the construction that does so, and they take a root pairing over a *field* of characteristic zero which is reduced, crystallographic, irreducible and a root system. The pinned data are over `ℤ`, so the first missing link is the passage to `ℚ`; this PR supplies it, along with two of the four hypotheses. It is the most effective current step because the Kostant/scheme half of Layer 9 is heavily occupied — root-subgroup relations, the torus, the Borel, the generated carrier, base change of Hopf ideals and the points comparison are all in flight — while every one of those files takes its Lie algebra, its integral lattice and its weight basis as hypotheses that no explicit root datum yet discharges.

Consumer roadmap: CFSGStatement

The dependency edge is `CFSGStatement` milestone L0, "pinned ambient groups": `ValidLieTypeIndex.AmbientGroup` consumes the explicitly constructed pinned Chevalley--Demazure group scheme of ReductiveGroups Layer 9, which in turn consumes the Chevalley basis of the split semisimple Lie algebra of `DynkinType.simplyConnectedRootDatum`. `CFSGStatement`'s own remaining lane is blocked on that Layer 9 input: `I0` and the sporadic lane are complete, `A0` waits on `L3`, and `L0` waits on Layer 9 in full.

After this PR, the Lie-algebra input still needs the rational system to be proved reduced and irreducible — both are properties of the explicit per-type root tables rather than of the base change, and neither transports — after which Geck's construction gives the Lie algebra with its distinguished basis, and Layer 9 still needs the Chevalley system and Kostant lattice instantiated at that Lie algebra per root datum, the assembled pinned scheme, pinning-compatible base change, the pinned isomorphism theorem, the algebraically closed points, and the characteristic 2/3 special isogenies.

Two small public lemmas are added where they belong, in the type `A` and type `C` datum files, recording that their pinned pairing is the dot product; the other seven families already had that lemma. `Assembly.lean` gains the two uniform facts the dispatcher needed: `toLinearMap_simplyConnectedRootDatum` and `card_support_simplyConnectedBase`. The implementation reuses Mathlib's `Pi.algebraMap`, `linearIndependent_algebraMap_comp_iff`, `AddMonoidHom.map_mclosure`, `LinearIndependent.span_eq_top_of_card_eq_finrank'`, and Tau Ceti's `dotProductBilin_isPerfPair` and pinned-datum acceptance theorems; no Mathlib infrastructure or external formalization is vendored. Add `TauCeti/LinearAlgebra/RootSystem/BaseChange.lean` (299 lines) and `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Rational.lean` (154 lines), plus 68 lines across the three existing files.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"dynkintype-rationalrootsystem"}-->

🤖 Prepared with Claude Code

