### PR TITLE
feat: derive root-system irreducibility from Cartan type

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
@@ -95,7 +95,7 @@ private theorem adj_fork_D {n : ℕ} (hn : 4 ≤ n) (i : Fin n)
   omega
 
 /-- The diagram of the standard Cartan matrix of a valid Dynkin type is connected. Validity
-excludes precisely the disconnected or empty low-rank classical matrices. -/
+confines each family to its canonical rank range, which is nonempty and is what the proof uses. -/
 theorem connected_diagramGraph_cartanMatrix {t : DynkinType} (ht : t.Valid) :
     (diagramGraph t.cartanMatrix).Connected := by
   cases t with

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Diagram
+public import Mathlib.LinearAlgebra.RootSystem.Irreducible
+
+public section
+
+/-!
+# Irreducibility from a connected Dynkin diagram
+
+This file proves the converse to the standard implication from irreducibility of a root pairing to
+connectedness of its Dynkin diagram. Over a field of characteristic zero, a root system whose base
+has connected diagram is irreducible. It then checks that the standard Cartan
+matrix of every valid `DynkinType` has connected diagram and packages the result in the form used by
+root systems identified through `TauCeti.HasCartanType`.
+
+The argument follows the usual proof in Humphreys, *Introduction to Lie Algebras and Representation
+Theory*, §10. A nonzero reflection-invariant subspace contains a root, hence a simple root. Once
+it contains one simple root, connectedness and reflection invariance propagate membership along
+every edge of the Dynkin diagram, so the simple roots span the whole space inside the subspace.
+
+## Main results
+
+* `TauCeti.RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix`: a connected base
+  diagram makes a root system irreducible.
+* `TauCeti.DynkinType.connected_diagramGraph_cartanMatrix`: every valid standard Dynkin diagram is
+  connected.
+* `TauCeti.HasCartanType.isIrreducible`: a root system of valid Cartan type is irreducible.
+-/
+
+open Function Set
+open Module.End (invtSubmodule)
+
+namespace TauCeti
+
+namespace SimpleGraph
+
+/-- A graph on `Fin n` is preconnected if every nonzero vertex has an adjacent predecessor. -/
+private theorem preconnected_fin_of_exists_adj_lt {n : ℕ} {G : SimpleGraph (Fin n)}
+    (hn : 0 < n)
+    (h : ∀ i : Fin n, (i : ℕ) ≠ 0 → ∃ j : Fin n, (j : ℕ) < i ∧ G.Adj j i) :
+    G.Preconnected := by
+  let z : Fin n := ⟨0, hn⟩
+  have hreach (i : Fin n) : G.Reachable z i := by
+    induction hi : (i : ℕ) using Nat.strong_induction_on generalizing i with
+    | h k ih =>
+        rcases eq_or_ne k 0 with rfl | hk
+        · have hiz : i = z := Fin.ext (by simpa [z] using hi)
+          rw [hiz]
+        · obtain ⟨j, hji, hadj⟩ := h i (hi ▸ hk)
+          exact (ih (j : ℕ) (hi ▸ hji) j rfl).trans hadj.reachable
+  exact fun i j ↦ (hreach i).symm.trans (hreach j)
+
+end SimpleGraph
+
+namespace DynkinType
+
+private theorem adj_succ_A {n : ℕ} (i : Fin n) (hi : (i : ℕ) + 1 < n) :
+    (diagramGraph (CartanMatrix.A n)).Adj i ⟨(i : ℕ) + 1, hi⟩ := by
+  rw [diagramGraph_adj]
+  simp [CartanMatrix.A]
+  simp only [Fin.ext_iff]
+  omega
+
+private theorem adj_succ_B {n : ℕ} (i : Fin n) (hi : (i : ℕ) + 1 < n) :
+    (diagramGraph (CartanMatrix.B n)).Adj i ⟨(i : ℕ) + 1, hi⟩ := by
+  rw [diagramGraph_adj]
+  simp [CartanMatrix.B]
+  simp only [Fin.ext_iff]
+  omega
+
+private theorem adj_succ_C {n : ℕ} (i : Fin n) (hi : (i : ℕ) + 1 < n) :
+    (diagramGraph (CartanMatrix.C n)).Adj i ⟨(i : ℕ) + 1, hi⟩ := by
+  rw [diagramGraph_adj]
+  simp [CartanMatrix.C]
+  simp only [Fin.ext_iff]
+  omega
+
+private theorem adj_succ_D {n : ℕ} (hn : 4 ≤ n) (i : Fin n)
+    (hi : (i : ℕ) + 1 < n - 1) :
+    (diagramGraph (CartanMatrix.D n)).Adj i ⟨(i : ℕ) + 1, by omega⟩ := by
+  rw [diagramGraph_adj]
+  simp [CartanMatrix.D]
+  simp only [Fin.ext_iff]
+  omega
+
+private theorem adj_fork_D {n : ℕ} (hn : 4 ≤ n) (i : Fin n)
+    (hi : (i : ℕ) = n - 1) :
+    (diagramGraph (CartanMatrix.D n)).Adj ⟨n - 3, by omega⟩ i := by
+  rw [diagramGraph_adj]
+  simp [CartanMatrix.D]
+  simp only [Fin.ext_iff]
+  omega
+
+/-- The diagram of the standard Cartan matrix of a valid Dynkin type is connected. Validity
+excludes precisely the disconnected or empty low-rank classical matrices. -/
+theorem connected_diagramGraph_cartanMatrix {t : DynkinType} (ht : t.Valid) :
+    (diagramGraph t.cartanMatrix).Connected := by
+  cases t with
+  | A n =>
+      have hn := valid_A.mp ht
+      let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
+      have hconn : (diagramGraph (CartanMatrix.A n)).Connected := by
+        refine ⟨SimpleGraph.preconnected_fin_of_exists_adj_lt hn fun i hi ↦ ?_⟩
+        let j : Fin n := ⟨(i : ℕ) - 1, by omega⟩
+        have hji : (⟨(j : ℕ) + 1, by simp [j]; omega⟩ : Fin n) = i := by
+          apply Fin.ext
+          simp [j]
+          omega
+        exact ⟨j, by simp [j]; omega, hji ▸ adj_succ_A j (by simp [j]; omega)⟩
+      simpa only [rank_A, cartanMatrix_A] using hconn
+  | B n =>
+      have hn : 0 < n := by have := valid_B.mp ht; omega
+      let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
+      have hconn : (diagramGraph (CartanMatrix.B n)).Connected := by
+        refine ⟨SimpleGraph.preconnected_fin_of_exists_adj_lt hn fun i hi ↦ ?_⟩
+        let j : Fin n := ⟨(i : ℕ) - 1, by omega⟩
+        have hji : (⟨(j : ℕ) + 1, by simp [j]; omega⟩ : Fin n) = i := by
+          apply Fin.ext
+          simp [j]
+          omega
+        exact ⟨j, by simp [j]; omega, hji ▸ adj_succ_B j (by simp [j]; omega)⟩
+      simpa only [rank_B, cartanMatrix_B] using hconn
+  | C n =>
+      have hn : 0 < n := by have := valid_C.mp ht; omega
+      let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
+      have hconn : (diagramGraph (CartanMatrix.C n)).Connected := by
+        refine ⟨SimpleGraph.preconnected_fin_of_exists_adj_lt hn fun i hi ↦ ?_⟩
+        let j : Fin n := ⟨(i : ℕ) - 1, by omega⟩
+        have hji : (⟨(j : ℕ) + 1, by simp [j]; omega⟩ : Fin n) = i := by
+          apply Fin.ext
+          simp [j]
+          omega
+        exact ⟨j, by simp [j]; omega, hji ▸ adj_succ_C j (by simp [j]; omega)⟩
+      simpa only [rank_C, cartanMatrix_C] using hconn
+  | D n =>
+      have hn := valid_D.mp ht
+      let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp (by omega)
+      have hconn : (diagramGraph (CartanMatrix.D n)).Connected := by
+        refine ⟨SimpleGraph.preconnected_fin_of_exists_adj_lt (by omega) fun i hi ↦ ?_⟩
+        by_cases hlast : (i : ℕ) = n - 1
+        · let j : Fin n := ⟨n - 3, by omega⟩
+          have hji : j = ⟨n - 3, by omega⟩ := rfl
+          refine ⟨j, ?_, hji ▸ adj_fork_D hn i hlast⟩
+          change n - 3 < (i : ℕ)
+          omega
+        · let j : Fin n := ⟨(i : ℕ) - 1, by omega⟩
+          have hji : (⟨(j : ℕ) + 1, by simp [j]; omega⟩ : Fin n) = i := by
+            apply Fin.ext
+            simp [j]
+            omega
+          exact ⟨j, by simp [j]; omega, hji ▸ adj_succ_D hn j (by simp [j]; omega)⟩
+      simpa only [rank_D, cartanMatrix_D] using hconn
+  | E6 =>
+      have hconn : (diagramGraph CartanMatrix.E₆).Connected := by
+        rw [SimpleGraph.connected_iff_exists_forall_reachable]
+        refine ⟨(3 : Fin 6), fun i ↦ ?_⟩
+        have h32 : (diagramGraph CartanMatrix.E₆).Adj 3 2 := by decide
+        have h20 : (diagramGraph CartanMatrix.E₆).Adj 2 0 := by decide
+        have h31 : (diagramGraph CartanMatrix.E₆).Adj 3 1 := by decide
+        have h34 : (diagramGraph CartanMatrix.E₆).Adj 3 4 := by decide
+        have h45 : (diagramGraph CartanMatrix.E₆).Adj 4 5 := by decide
+        fin_cases i
+        · exact h32.reachable.trans h20.reachable
+        · exact h31.reachable
+        · exact h32.reachable
+        · exact .rfl
+        · exact h34.reachable
+        · exact h34.reachable.trans h45.reachable
+      simpa only [rank_E6, cartanMatrix_E6] using hconn
+  | E7 =>
+      have hconn : (diagramGraph CartanMatrix.E₇).Connected := by
+        rw [SimpleGraph.connected_iff_exists_forall_reachable]
+        refine ⟨(3 : Fin 7), fun i ↦ ?_⟩
+        have h32 : (diagramGraph CartanMatrix.E₇).Adj 3 2 := by decide
+        have h20 : (diagramGraph CartanMatrix.E₇).Adj 2 0 := by decide
+        have h31 : (diagramGraph CartanMatrix.E₇).Adj 3 1 := by decide
+        have h34 : (diagramGraph CartanMatrix.E₇).Adj 3 4 := by decide
+        have h45 : (diagramGraph CartanMatrix.E₇).Adj 4 5 := by decide
+        have h56 : (diagramGraph CartanMatrix.E₇).Adj 5 6 := by decide
+        fin_cases i
+        · exact h32.reachable.trans h20.reachable
+        · exact h31.reachable
+        · exact h32.reachable
+        · exact .rfl
+        · exact h34.reachable
+        · exact h34.reachable.trans h45.reachable
+        · exact (h34.reachable.trans h45.reachable).trans h56.reachable
+      simpa only [rank_E7, cartanMatrix_E7] using hconn
+  | E8 =>
+      have hconn : (diagramGraph CartanMatrix.E₈).Connected := by
+        rw [SimpleGraph.connected_iff_exists_forall_reachable]
+        refine ⟨(3 : Fin 8), fun i ↦ ?_⟩
+        have h32 : (diagramGraph CartanMatrix.E₈).Adj 3 2 := by decide
+        have h20 : (diagramGraph CartanMatrix.E₈).Adj 2 0 := by decide
+        have h31 : (diagramGraph CartanMatrix.E₈).Adj 3 1 := by decide
+        have h34 : (diagramGraph CartanMatrix.E₈).Adj 3 4 := by decide
+        have h45 : (diagramGraph CartanMatrix.E₈).Adj 4 5 := by decide
+        have h56 : (diagramGraph CartanMatrix.E₈).Adj 5 6 := by decide
+        have h67 : (diagramGraph CartanMatrix.E₈).Adj 6 7 := by decide
+        fin_cases i
+        · exact h32.reachable.trans h20.reachable
+        · exact h31.reachable
+        · exact h32.reachable
+        · exact .rfl
+        · exact h34.reachable
+        · exact h34.reachable.trans h45.reachable
+        · exact (h34.reachable.trans h45.reachable).trans h56.reachable
+        · exact ((h34.reachable.trans h45.reachable).trans h56.reachable).trans h67.reachable
+      simpa only [rank_E8, cartanMatrix_E8] using hconn
+  | F4 =>
+      have hconn : (diagramGraph CartanMatrix.F₄).Connected := by
+        rw [SimpleGraph.connected_iff_exists_forall_reachable]
+        refine ⟨(0 : Fin 4), fun i ↦ ?_⟩
+        have h01 : (diagramGraph CartanMatrix.F₄).Adj 0 1 := by decide
+        have h12 : (diagramGraph CartanMatrix.F₄).Adj 1 2 := by decide
+        have h23 : (diagramGraph CartanMatrix.F₄).Adj 2 3 := by decide
+        fin_cases i
+        · exact .rfl
+        · exact h01.reachable
+        · exact h01.reachable.trans h12.reachable
+        · exact (h01.reachable.trans h12.reachable).trans h23.reachable
+      simpa only [rank_F4, cartanMatrix_F4] using hconn
+  | G2 =>
+      have hconn : (diagramGraph (CartanMatrix.G₂.transpose)).Connected := by
+        rw [SimpleGraph.connected_iff_exists_forall_reachable]
+        refine ⟨(0 : Fin 2), fun i ↦ ?_⟩
+        have h01 : (diagramGraph (CartanMatrix.G₂.transpose)).Adj 0 1 := by decide
+        fin_cases i
+        · exact .rfl
+        · exact h01.reachable
+      simpa only [rank_G2, cartanMatrix_G2] using hconn
+
+end DynkinType
+
+namespace RootPairing
+
+variable {K M N ι : Type*} [Field K] [CharZero K] [AddCommGroup M] [Module K M]
+  [AddCommGroup N] [Module K N] {P : RootPairing ι K M N} [P.IsCrystallographic]
+
+/-- A root system with a connected Dynkin diagram is irreducible.
+
+Characteristic zero ensures that a nonzero integral Cartan entry stays nonzero in the field when
+membership propagates across an edge. It also supplies the standard `2 ≠ 0` hypothesis in
+Mathlib's invariant-submodule criterion for a reflection. -/
+theorem isIrreducible_of_connected_diagramGraph_cartanMatrix [P.IsRootSystem] (b : P.Base)
+    (hconn : (diagramGraph b.cartanMatrix).Connected) : P.IsIrreducible := by
+  let _ : Nontrivial M :=
+    ⟨⟨P.root hconn.nonempty.some, 0, P.ne_zero hconn.nonempty.some⟩⟩
+  apply RootPairing.IsIrreducible.mk' P
+  intro q hinv hq
+  have hsimple : ∃ i : b.support, P.root i ∈ q := by
+    by_contra! h
+    have hle : q ≤ ⨅ i : b.support, LinearMap.ker (P.coroot' i) := by
+      refine le_iInf fun i ↦ _root_.RootPairing.invtRootSubmodule.le_ker_coroot' ⟨q, ?_⟩ (h i)
+      exact P.mem_invtRootSubmodule_iff.mpr hinv
+    have : q ≤ ⊥ := by
+      intro x hx
+      apply P.toPerfPair.injective
+      apply LinearMap.ext
+      intro y
+      rw [map_zero, ← b.toCoweightBasis.sum_repr y, map_sum]
+      apply Finset.sum_eq_zero
+      intro i hi
+      have hz : (P.toPerfPair x) (b.toCoweightBasis i) = 0 := by
+        have hallker : ∀ j : b.support, x ∈ LinearMap.ker (P.coroot' j) := by
+          simpa using hle hx
+        simpa using LinearMap.mem_ker.mp (hallker i)
+      rw [map_smul, hz, smul_zero]
+    exact hq (eq_bot_iff.mpr this)
+  obtain ⟨i, hi⟩ := hsimple
+  have propagate {u v : b.support} (hadj : (diagramGraph b.cartanMatrix).Adj u v)
+      (hu : P.root u ∈ q) : P.root v ∈ q := by
+    have hrefl : P.reflection v (P.root u) ∈ q :=
+      (Module.End.mem_invtSubmodule _).mp (hinv v) hu
+    have hpair : P.pairing u v ≠ 0 := by
+      intro hp
+      exact (diagramGraph_adj.mp hadj).2.1
+        (b.cartanMatrix_apply_eq_zero_iff_pairing.mpr hp)
+    have hsmul : P.pairing u v • P.root v ∈ q := by
+      simpa only [P.reflection_apply_root, sub_sub_cancel] using q.sub_mem hu hrefl
+    exact (q.smul_mem_iff hpair).mp hsmul
+  have hall : ∀ j : b.support, P.root j ∈ q := by
+    intro j
+    obtain ⟨w⟩ := hconn.preconnected i j
+    let rec along {u v : b.support} (w : (diagramGraph b.cartanMatrix).Walk u v)
+        (hu : P.root u ∈ q) : P.root v ∈ q :=
+      match w with
+      | .nil => hu
+      | .cons hadj w => along w (propagate hadj hu)
+    exact along w hi
+  rw [eq_top_iff, ← b.toWeightBasis.span_eq]
+  refine Submodule.span_le.mpr ?_
+  rintro _ ⟨j, rfl⟩
+  rw [b.toWeightBasis_apply]
+  exact hall j
+
+end RootPairing
+
+namespace HasCartanType
+
+variable {K M N ι : Type*} [Field K] [CharZero K] [AddCommGroup M] [Module K M]
+  [AddCommGroup N] [Module K N] {P : RootPairing ι K M N} [P.IsCrystallographic]
+
+/-- A root system whose base has a valid standard Cartan type is irreducible. -/
+theorem isIrreducible [P.IsRootSystem] {b : P.Base} {t : DynkinType}
+    (h : HasCartanType P b t) (ht : t.Valid) :
+    P.IsIrreducible := by
+  obtain ⟨e, he⟩ := (hasCartanType_iff b t).mp h
+  let graphIso : diagramGraph b.cartanMatrix ≃g diagramGraph t.cartanMatrix := by
+    refine ⟨e, ?_⟩
+    intro i j
+    simp only [diagramGraph_adj, he]
+    constructor
+    · rintro ⟨hij, h₁, h₂⟩
+      exact ⟨fun h ↦ hij (congrArg e h), h₁, h₂⟩
+    · rintro ⟨hij, h₁, h₂⟩
+      exact ⟨fun h ↦ hij (e.injective h), h₁, h₂⟩
+  exact TauCeti.RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix (P := P) b
+    (graphIso.connected_iff.mpr (DynkinType.connected_diagramGraph_cartanMatrix ht))
+
+end HasCartanType
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Diagram
 public import Mathlib.LinearAlgebra.RootSystem.Irreducible
+import Mathlib.Combinatorics.SimpleGraph.Hasse
 
 public section
 
@@ -14,8 +15,8 @@ public section
 # Irreducibility from a connected Dynkin diagram
 
 This file proves the converse to the standard implication from irreducibility of a root pairing to
-connectedness of its Dynkin diagram. Over a field of characteristic zero, a root system whose base
-has connected diagram is irreducible. It then checks that the standard Cartan
+connectedness of its Dynkin diagram. Over a field of characteristic zero, a crystallographic root
+system whose base has connected diagram is irreducible. It then checks that the standard Cartan
 matrix of every valid `DynkinType` has connected diagram and packages the result in the form used by
 root systems identified through `TauCeti.HasCartanType`.
 
@@ -56,30 +57,26 @@ private theorem preconnected_fin_of_exists_adj_lt {n : ℕ} {G : SimpleGraph (Fi
           exact (ih (j : ℕ) (hi ▸ hji) j rfl).trans hadj.reachable
   exact fun i j ↦ (hreach i).symm.trans (hreach j)
 
+/-- A graph containing every successor edge contains the path graph. -/
+private theorem pathGraph_le_of_adj_succ {n : ℕ} {G : SimpleGraph (Fin n)}
+    (h : ∀ (i : Fin n) (hi : (i : ℕ) + 1 < n), G.Adj i ⟨(i : ℕ) + 1, hi⟩) :
+    _root_.SimpleGraph.pathGraph n ≤ G := by
+  intro i j hij
+  rw [_root_.SimpleGraph.pathGraph_adj] at hij
+  rcases hij with hij | hij
+  · have hj : (⟨(i : ℕ) + 1, by omega⟩ : Fin n) = j := Fin.ext hij
+    exact hj ▸ h i (by omega)
+  · have hi : (⟨(j : ℕ) + 1, by omega⟩ : Fin n) = i := Fin.ext hij
+    exact (hi ▸ h j (by omega)).symm
+
+/-- A graph containing the path graph on the same nonempty vertex set is connected. -/
+private theorem connected_of_pathGraph_le {n : ℕ} {G : SimpleGraph (Fin n)}
+    [Nonempty (Fin n)] (h : _root_.SimpleGraph.pathGraph n ≤ G) : G.Connected :=
+  ⟨(_root_.SimpleGraph.pathGraph_preconnected n).mono h⟩
+
 end SimpleGraph
 
 namespace DynkinType
-
-private theorem adj_succ_A {n : ℕ} (i : Fin n) (hi : (i : ℕ) + 1 < n) :
-    (diagramGraph (CartanMatrix.A n)).Adj i ⟨(i : ℕ) + 1, hi⟩ := by
-  rw [diagramGraph_adj]
-  simp [CartanMatrix.A]
-  simp only [Fin.ext_iff]
-  omega
-
-private theorem adj_succ_B {n : ℕ} (i : Fin n) (hi : (i : ℕ) + 1 < n) :
-    (diagramGraph (CartanMatrix.B n)).Adj i ⟨(i : ℕ) + 1, hi⟩ := by
-  rw [diagramGraph_adj]
-  simp [CartanMatrix.B]
-  simp only [Fin.ext_iff]
-  omega
-
-private theorem adj_succ_C {n : ℕ} (i : Fin n) (hi : (i : ℕ) + 1 < n) :
-    (diagramGraph (CartanMatrix.C n)).Adj i ⟨(i : ℕ) + 1, hi⟩ := by
-  rw [diagramGraph_adj]
-  simp [CartanMatrix.C]
-  simp only [Fin.ext_iff]
-  omega
 
 private theorem adj_succ_D {n : ℕ} (hn : 4 ≤ n) (i : Fin n)
     (hi : (i : ℕ) + 1 < n - 1) :
@@ -106,37 +103,37 @@ theorem connected_diagramGraph_cartanMatrix {t : DynkinType} (ht : t.Valid) :
       have hn := valid_A.mp ht
       let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
       have hconn : (diagramGraph (CartanMatrix.A n)).Connected := by
-        refine ⟨SimpleGraph.preconnected_fin_of_exists_adj_lt hn fun i hi ↦ ?_⟩
-        let j : Fin n := ⟨(i : ℕ) - 1, by omega⟩
-        have hji : (⟨(j : ℕ) + 1, by simp [j]; omega⟩ : Fin n) = i := by
-          apply Fin.ext
-          simp [j]
-          omega
-        exact ⟨j, by simp [j]; omega, hji ▸ adj_succ_A j (by simp [j]; omega)⟩
+        apply SimpleGraph.connected_of_pathGraph_le
+        apply SimpleGraph.pathGraph_le_of_adj_succ
+        intro i hi
+        rw [diagramGraph_adj]
+        simp [CartanMatrix.A]
+        simp only [Fin.ext_iff]
+        omega
       simpa only [rank_A, cartanMatrix_A] using hconn
   | B n =>
       have hn : 0 < n := by have := valid_B.mp ht; omega
       let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
       have hconn : (diagramGraph (CartanMatrix.B n)).Connected := by
-        refine ⟨SimpleGraph.preconnected_fin_of_exists_adj_lt hn fun i hi ↦ ?_⟩
-        let j : Fin n := ⟨(i : ℕ) - 1, by omega⟩
-        have hji : (⟨(j : ℕ) + 1, by simp [j]; omega⟩ : Fin n) = i := by
-          apply Fin.ext
-          simp [j]
-          omega
-        exact ⟨j, by simp [j]; omega, hji ▸ adj_succ_B j (by simp [j]; omega)⟩
+        apply SimpleGraph.connected_of_pathGraph_le
+        apply SimpleGraph.pathGraph_le_of_adj_succ
+        intro i hi
+        rw [diagramGraph_adj]
+        simp [CartanMatrix.B]
+        simp only [Fin.ext_iff]
+        omega
       simpa only [rank_B, cartanMatrix_B] using hconn
   | C n =>
       have hn : 0 < n := by have := valid_C.mp ht; omega
       let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
       have hconn : (diagramGraph (CartanMatrix.C n)).Connected := by
-        refine ⟨SimpleGraph.preconnected_fin_of_exists_adj_lt hn fun i hi ↦ ?_⟩
-        let j : Fin n := ⟨(i : ℕ) - 1, by omega⟩
-        have hji : (⟨(j : ℕ) + 1, by simp [j]; omega⟩ : Fin n) = i := by
-          apply Fin.ext
-          simp [j]
-          omega
-        exact ⟨j, by simp [j]; omega, hji ▸ adj_succ_C j (by simp [j]; omega)⟩
+        apply SimpleGraph.connected_of_pathGraph_le
+        apply SimpleGraph.pathGraph_le_of_adj_succ
+        intro i hi
+        rw [diagramGraph_adj]
+        simp [CartanMatrix.C]
+        simp only [Fin.ext_iff]
+        omega
       simpa only [rank_C, cartanMatrix_C] using hconn
   | D n =>
       have hn := valid_D.mp ht
@@ -147,7 +144,7 @@ theorem connected_diagramGraph_cartanMatrix {t : DynkinType} (ht : t.Valid) :
         · let j : Fin n := ⟨n - 3, by omega⟩
           have hji : j = ⟨n - 3, by omega⟩ := rfl
           refine ⟨j, ?_, hji ▸ adj_fork_D hn i hlast⟩
-          change n - 3 < (i : ℕ)
+          simp only [j]
           omega
         · let j : Fin n := ⟨(i : ℕ) - 1, by omega⟩
           have hji : (⟨(j : ℕ) + 1, by simp [j]; omega⟩ : Fin n) = i := by
@@ -215,25 +212,17 @@ theorem connected_diagramGraph_cartanMatrix {t : DynkinType} (ht : t.Valid) :
       simpa only [rank_E8, cartanMatrix_E8] using hconn
   | F4 =>
       have hconn : (diagramGraph CartanMatrix.F₄).Connected := by
-        rw [SimpleGraph.connected_iff_exists_forall_reachable]
-        refine ⟨(0 : Fin 4), fun i ↦ ?_⟩
-        have h01 : (diagramGraph CartanMatrix.F₄).Adj 0 1 := by decide
-        have h12 : (diagramGraph CartanMatrix.F₄).Adj 1 2 := by decide
-        have h23 : (diagramGraph CartanMatrix.F₄).Adj 2 3 := by decide
-        fin_cases i
-        · exact .rfl
-        · exact h01.reachable
-        · exact h01.reachable.trans h12.reachable
-        · exact (h01.reachable.trans h12.reachable).trans h23.reachable
+        apply SimpleGraph.connected_of_pathGraph_le
+        apply SimpleGraph.pathGraph_le_of_adj_succ
+        intro i hi
+        fin_cases i <;> decide +kernel +revert
       simpa only [rank_F4, cartanMatrix_F4] using hconn
   | G2 =>
       have hconn : (diagramGraph (CartanMatrix.G₂.transpose)).Connected := by
-        rw [SimpleGraph.connected_iff_exists_forall_reachable]
-        refine ⟨(0 : Fin 2), fun i ↦ ?_⟩
-        have h01 : (diagramGraph (CartanMatrix.G₂.transpose)).Adj 0 1 := by decide
-        fin_cases i
-        · exact .rfl
-        · exact h01.reachable
+        apply SimpleGraph.connected_of_pathGraph_le
+        apply SimpleGraph.pathGraph_le_of_adj_succ
+        intro i hi
+        fin_cases i <;> decide +kernel +revert
       simpa only [rank_G2, cartanMatrix_G2] using hconn
 
 end DynkinType
@@ -243,7 +232,7 @@ namespace RootPairing
 variable {K M N ι : Type*} [Field K] [CharZero K] [AddCommGroup M] [Module K M]
   [AddCommGroup N] [Module K N] {P : RootPairing ι K M N} [P.IsCrystallographic]
 
-/-- A root system with a connected Dynkin diagram is irreducible.
+/-- A crystallographic root system with a connected Dynkin diagram is irreducible.
 
 Characteristic zero ensures that a nonzero integral Cartan entry stays nonzero in the field when
 membership propagates across an edge. It also supplies the standard `2 ≠ 0` hypothesis in


### PR DESCRIPTION
This PR proves that a characteristic-zero crystallographic root system with connected Dynkin diagram is irreducible, verifies connectedness for every valid standard `DynkinType`, and packages the result as `HasCartanType.isIrreducible`. It advances the exact target in `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9 milestone “The Chevalley–Demazure construction”: construct the split semisimple Lie algebra with Chevalley basis attached to each pinned simply connected root datum before assembling its Kostant `ℤ`-form into a group scheme.

The preferred `CFSGStatement` roadmap has no viable unclaimed direct step on current `main`: I0 and the sporadic S0/S1 lane are complete, `classificationStatement_of_zero` is in flight in #3058, and L0 explicitly waits on ReductiveGroups Layer 9. This PR therefore follows that declared prerequisite. The dependency edge is CFSGStatement milestone L0, declaration `ValidLieTypeIndex.AmbientGroup` → ReductiveGroups Layer 9's explicit pinned Chevalley–Demazure group scheme → the Geck split semisimple Lie algebra for `DynkinType.simplyConnectedRootDatum`; Mathlib's Geck construction requires an irreducible reduced root system, and `HasCartanType.isIrreducible` supplies the irreducibility half for the rational root system being introduced in #3678.

Add `TauCeti/LinearAlgebra/RootSystem/FiniteType/Irreducible.lean` (329 lines). `RootPairing.isIrreducible_of_connected_diagramGraph_cartanMatrix` proves the general connected-diagram criterion over characteristic-zero fields; `DynkinType.connected_diagramGraph_cartanMatrix` verifies the standard classical and exceptional diagrams; and `HasCartanType.isIrreducible` transports the criterion along the pinned Cartan labelling. After this PR, the Layer 9 milestone still needs reducedness of the rational root systems, instantiation of Geck's construction and the Chevalley/Kostant data, then the assembled pinned scheme, base change, root subgroups, pinned isomorphism theorem, and special isogenies before CFSG L0–L3 can close.

The proof follows Humphreys, *Introduction to Lie Algebras and Representation Theory*, §10, as credited in the module documentation. It reuses Mathlib's `RootPairing.IsIrreducible.mk'`, invariant-submodule kernel criterion, base weight and coweight bases, and simple-graph reachability; no Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hascartantype-isirreducible"}-->

🤖 Prepared with Codex
