### PR TITLE
feat: define semisimple affine groups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Radical/Basic.lean
@@ -13,12 +13,13 @@ public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 
 /-!
-# Geometric radical-triviality properties
+# Geometric normal-subgroup-freeness properties
 
 This file packages the common construction behind the reductive and semisimple predicates. Given
 an isomorphism-invariant property `P` of finite-type commutative Hopf algebras over an algebraic
-closure, `geometricRadicalFreeCommHopfAlgProperty k P` says that the ambient group is smooth and
-geometrically connected and that every connected normal closed subgroup satisfying `P` is trivial.
+closure, `geometricNormalSubgroupFreeCommHopfAlgProperty k P` says that the ambient group is
+smooth and geometrically connected and that every connected normal closed subgroup satisfying
+`P` is trivial.
 
 The construction is invariant under isomorphism. Its shared API also shows that, when the whole
 geometric fibre satisfies `P`, its zero Hopf ideal is the augmentation ideal and its coordinate
@@ -26,11 +27,12 @@ algebra is bialgebra-equivalent to the algebraic closure via the counit.
 
 ## Main declarations
 
-* `TauCeti.geometricRadicalFreeCommHopfAlgProperty`: the generic radical-triviality property.
-* `TauCeti.geometricRadicalFreeCommHopfAlgProperty.eq_augmentation`: candidate normal subgroups
-  are trivial.
-* `TauCeti.geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv`: a geometric
-  fibre satisfying the candidate property is trivial.
+* `TauCeti.geometricNormalSubgroupFreeCommHopfAlgProperty`: the generic normal-subgroup-freeness
+  property.
+* `TauCeti.geometricNormalSubgroupFreeCommHopfAlgProperty.eq_augmentation`: candidate normal
+  subgroups are trivial.
+* `TauCeti.geometricNormalSubgroupFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv`: a
+  geometric fibre satisfying the candidate property is trivial.
 
 This is shared infrastructure for the reductive and semisimple definitions in Layer 6,
 "Reductive and semisimple groups", of the ReductiveGroups roadmap.
@@ -51,7 +53,7 @@ connected normal geometric subgroups satisfying `P` are all trivial.
 
 The candidate property `P` is imposed on the coordinate Hopf algebra of the subgroup, represented
 contravariantly as a quotient by a normal Hopf ideal. -/
-def geometricRadicalFreeCommHopfAlgProperty (k : Type u) [Field k]
+def geometricNormalSubgroupFreeCommHopfAlgProperty (k : Type u) [Field k]
     (P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))) :
     ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
   fun H ↦
@@ -68,12 +70,12 @@ def geometricRadicalFreeCommHopfAlgProperty (k : Type u) [Field k]
             I = HopfIdeal.augmentation (AlgebraicClosure k)
               (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
 
-/-- Membership in the generic geometric radical-triviality property. -/
+/-- Membership in the generic geometric normal-subgroup-freeness property. -/
 @[simp]
-theorem geometricRadicalFreeCommHopfAlgProperty_iff (k : Type u) [Field k]
+theorem geometricNormalSubgroupFreeCommHopfAlgProperty_iff (k : Type u) [Field k]
     (P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)))
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    geometricRadicalFreeCommHopfAlgProperty k P H ↔
+    geometricNormalSubgroupFreeCommHopfAlgProperty k P H ↔
       Algebra.Smooth k H ∧
         geometricallyConnectedCommHopfAlgProperty k H.obj ∧
           ∀ I : HopfIdeal (AlgebraicClosure k)
@@ -88,12 +90,12 @@ theorem geometricRadicalFreeCommHopfAlgProperty_iff (k : Type u) [Field k]
                 (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
   Iff.rfl
 
-/-- Geometric radical-triviality is invariant under isomorphism when the candidate subgroup
+/-- Geometric normal-subgroup-freeness is invariant under isomorphism when the candidate subgroup
 property is invariant under isomorphism. -/
 instance (k : Type u) [Field k]
     (P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)))
     [P.IsClosedUnderIsomorphisms] :
-    (geometricRadicalFreeCommHopfAlgProperty k P).IsClosedUnderIsomorphisms where
+    (geometricNormalSubgroupFreeCommHopfAlgProperty k P).IsClosedUnderIsomorphisms where
   of_iso {H K} e hH := by
     let e₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
       (CommHopfAlgCat.{u} k)).mapIso e
@@ -133,24 +135,24 @@ instance (k : Type u) [Field k]
       HopfIdeal.comap_augmentation]
     exact hJ
 
-namespace geometricRadicalFreeCommHopfAlgProperty
+namespace geometricNormalSubgroupFreeCommHopfAlgProperty
 
 variable {k : Type u} [Field k]
   {P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))}
   {H : FiniteTypeCommHopfAlgCat.{u, u} k}
 
-/-- A group satisfying a geometric radical-triviality property is smooth. -/
-theorem smooth (hH : geometricRadicalFreeCommHopfAlgProperty k P H) :
+/-- A group satisfying a geometric normal-subgroup-freeness property is smooth. -/
+theorem smooth (hH : geometricNormalSubgroupFreeCommHopfAlgProperty k P H) :
     Algebra.Smooth k H :=
   hH.1
 
-/-- A group satisfying a geometric radical-triviality property is geometrically connected. -/
-theorem geometricallyConnected (hH : geometricRadicalFreeCommHopfAlgProperty k P H) :
+/-- A group satisfying a geometric normal-subgroup-freeness property is geometrically connected. -/
+theorem geometricallyConnected (hH : geometricNormalSubgroupFreeCommHopfAlgProperty k P H) :
     geometricallyConnectedCommHopfAlgProperty k H.obj :=
   hH.2.1
 
 /-- Every connected normal closed subgroup of the geometric fibre satisfying `P` is trivial. -/
-theorem eq_augmentation (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+theorem eq_augmentation (hH : geometricNormalSubgroupFreeCommHopfAlgProperty k P H)
     (I : HopfIdeal (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
     (hI : I.IsNormal)
@@ -165,7 +167,7 @@ theorem eq_augmentation (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
 
 /-- If the whole geometric fibre satisfies `P`, its zero Hopf ideal is the augmentation ideal. -/
 theorem bot_eq_augmentation [P.IsClosedUnderIsomorphisms]
-    (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (hH : geometricNormalSubgroupFreeCommHopfAlgProperty k P H)
     (hP : P (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) :
     (⊥ : HopfIdeal (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) =
@@ -187,7 +189,7 @@ theorem bot_eq_augmentation [P.IsClosedUnderIsomorphisms]
 /-- If the whole geometric fibre satisfies `P`, its coordinate algebra is bialgebra-equivalent
 to the algebraic closure via the counit. -/
 noncomputable def geometricFiberCounitBialgEquiv [P.IsClosedUnderIsomorphisms]
-    (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (hH : geometricNormalSubgroupFreeCommHopfAlgProperty k P H)
     (hP : P (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) :
     FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
         ≃ₐc[AlgebraicClosure k] AlgebraicClosure k :=
@@ -197,7 +199,7 @@ noncomputable def geometricFiberCounitBialgEquiv [P.IsClosedUnderIsomorphisms]
 /-- The generic trivial-geometric-fibre equivalence is the counit. -/
 @[simp]
 theorem geometricFiberCounitBialgEquiv_apply [P.IsClosedUnderIsomorphisms]
-    (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (hH : geometricNormalSubgroupFreeCommHopfAlgProperty k P H)
     (hP : P (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
     (x : FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :
     hH.geometricFiberCounitBialgEquiv hP x =
@@ -209,7 +211,7 @@ theorem geometricFiberCounitBialgEquiv_apply [P.IsClosedUnderIsomorphisms]
 /-- The inverse of the generic trivial-geometric-fibre equivalence is the structure map. -/
 @[simp]
 theorem geometricFiberCounitBialgEquiv_symm_apply [P.IsClosedUnderIsomorphisms]
-    (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (hH : geometricNormalSubgroupFreeCommHopfAlgProperty k P H)
     (hP : P (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
     (r : AlgebraicClosure k) :
     (hH.geometricFiberCounitBialgEquiv hP).symm r =
@@ -218,7 +220,7 @@ theorem geometricFiberCounitBialgEquiv_symm_apply [P.IsClosedUnderIsomorphisms]
   rw [geometricFiberCounitBialgEquiv]
   exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_symm_apply _ _
 
-end geometricRadicalFreeCommHopfAlgProperty
+end geometricNormalSubgroupFreeCommHopfAlgProperty
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Radical/Basic.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+public import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+
+/-!
+# Geometric radical-triviality properties
+
+This file packages the common construction behind the reductive and semisimple predicates. Given
+an isomorphism-invariant property `P` of finite-type commutative Hopf algebras over an algebraic
+closure, `geometricRadicalFreeCommHopfAlgProperty k P` says that the ambient group is smooth and
+geometrically connected and that every connected normal closed subgroup satisfying `P` is trivial.
+
+The construction is invariant under isomorphism. Its shared API also shows that, when the whole
+geometric fibre satisfies `P`, its zero Hopf ideal is the augmentation ideal and its coordinate
+algebra is bialgebra-equivalent to the algebraic closure via the counit.
+
+## Main declarations
+
+* `TauCeti.geometricRadicalFreeCommHopfAlgProperty`: the generic radical-triviality property.
+* `TauCeti.geometricRadicalFreeCommHopfAlgProperty.eq_augmentation`: candidate normal subgroups
+  are trivial.
+* `TauCeti.geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv`: a geometric
+  fibre satisfying the candidate property is trivial.
+
+This is shared infrastructure for the reductive and semisimple definitions in Layer 6,
+"Reductive and semisimple groups", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+/-- The object property selecting smooth geometrically connected finite-type affine groups whose
+connected normal geometric subgroups satisfying `P` are all trivial.
+
+The candidate property `P` is imposed on the coordinate Hopf algebra of the subgroup, represented
+contravariantly as a quotient by a normal Hopf ideal. -/
+def geometricRadicalFreeCommHopfAlgProperty (k : Type u) [Field k]
+    (P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))) :
+    ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
+  fun H ↦
+    Algebra.Smooth k H ∧
+      geometricallyConnectedCommHopfAlgProperty k H.obj ∧
+        ∀ I : HopfIdeal (AlgebraicClosure k)
+            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H),
+          I.IsNormal →
+            geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
+            P (FiniteTypeCommHopfAlgCat.quotient
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
+            I = HopfIdeal.augmentation (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+
+/-- Membership in the generic geometric radical-triviality property. -/
+@[simp]
+theorem geometricRadicalFreeCommHopfAlgProperty_iff (k : Type u) [Field k]
+    (P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)))
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    geometricRadicalFreeCommHopfAlgProperty k P H ↔
+      Algebra.Smooth k H ∧
+        geometricallyConnectedCommHopfAlgProperty k H.obj ∧
+          ∀ I : HopfIdeal (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H),
+            I.IsNormal →
+              geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.quotient
+                  (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
+              P (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
+              I = HopfIdeal.augmentation (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  Iff.rfl
+
+/-- Geometric radical-triviality is invariant under isomorphism when the candidate subgroup
+property is invariant under isomorphism. -/
+instance (k : Type u) [Field k]
+    (P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)))
+    [P.IsClosedUnderIsomorphisms] :
+    (geometricRadicalFreeCommHopfAlgProperty k P).IsClosedUnderIsomorphisms where
+  of_iso {H K} e hH := by
+    let e₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+      (CommHopfAlgCat.{u} k)).mapIso e
+    let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+    let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
+    let ebar := (FiniteTypeCommHopfAlgCat.baseChangeFunctor
+      (K := AlgebraicClosure k)).mapIso e
+    let ebar₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso ebar
+    let f : Hbar →ₐc[AlgebraicClosure k] Kbar := ebar₀.hom.hom
+    have hfinjective : Function.Injective f :=
+      (ConcreteCategory.bijective_of_isIso ebar₀.hom).1
+    have hfsurjective : Function.Surjective f :=
+      (ConcreteCategory.bijective_of_isIso ebar₀.hom).2
+    refine ⟨(smoothCommHopfAlgProperty_iff K.obj).mp <|
+        (smoothCommHopfAlgProperty k).prop_of_iso e₀
+          ((smoothCommHopfAlgProperty_iff H.obj).mpr hH.1),
+      (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀ hH.2.1, ?_⟩
+    intro I hnormal hconnected hP
+    let J := I.comap f hfsurjective
+    have hnormalJ : J.IsNormal :=
+      hnormal.comap_of_bijective f hfinjective hfsurjective
+    let qIso : FiniteTypeCommHopfAlgCat.quotient Hbar J ≅
+        FiniteTypeCommHopfAlgCat.quotient Kbar I :=
+      FiniteTypeCommHopfAlgCat.quotientIsoOfIso ebar I
+    let qIso₀ := (forget₂
+      (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso qIso
+    have hconnectedJ : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj :=
+      (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+        qIso₀.symm hconnected
+    have hPJ : P (FiniteTypeCommHopfAlgCat.quotient Hbar J) :=
+      P.prop_of_iso qIso.symm hP
+    have hJ := hH.2.2 J hnormalJ hconnectedJ hPJ
+    rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hfsurjective,
+      HopfIdeal.comap_augmentation]
+    exact hJ
+
+namespace geometricRadicalFreeCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+  {P : ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))}
+  {H : FiniteTypeCommHopfAlgCat.{u, u} k}
+
+/-- A group satisfying a geometric radical-triviality property is smooth. -/
+theorem smooth (hH : geometricRadicalFreeCommHopfAlgProperty k P H) :
+    Algebra.Smooth k H :=
+  hH.1
+
+/-- A group satisfying a geometric radical-triviality property is geometrically connected. -/
+theorem geometricallyConnected (hH : geometricRadicalFreeCommHopfAlgProperty k P H) :
+    geometricallyConnectedCommHopfAlgProperty k H.obj :=
+  hH.2.1
+
+/-- Every connected normal closed subgroup of the geometric fibre satisfying `P` is trivial. -/
+theorem eq_augmentation (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (I : HopfIdeal (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
+    (hI : I.IsNormal)
+    (hconnected : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj)
+    (hP : P (FiniteTypeCommHopfAlgCat.quotient
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I)) :
+    I = HopfIdeal.augmentation (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  hH.2.2 I hI hconnected hP
+
+/-- If the whole geometric fibre satisfies `P`, its zero Hopf ideal is the augmentation ideal. -/
+theorem bot_eq_augmentation [P.IsClosedUnderIsomorphisms]
+    (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (hP : P (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) :
+    (⊥ : HopfIdeal (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) =
+        HopfIdeal.augmentation (AlgebraicClosure k)
+          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+  let qIso := FiniteTypeCommHopfAlgCat.quotientBotIso Hbar
+  let qIso₀ := (forget₂
+    (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+    (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso qIso
+  apply hH.eq_augmentation (I := (⊥ : HopfIdeal (AlgebraicClosure k) Hbar))
+  · exact HopfIdeal.isNormal_bot
+  · exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+      qIso₀.symm
+      (geometricallyConnectedCommHopfAlgProperty.baseChange k (AlgebraicClosure k) H.obj
+        hH.geometricallyConnected)
+  · exact P.prop_of_iso qIso.symm hP
+
+/-- If the whole geometric fibre satisfies `P`, its coordinate algebra is bialgebra-equivalent
+to the algebraic closure via the counit. -/
+noncomputable def geometricFiberCounitBialgEquiv [P.IsClosedUnderIsomorphisms]
+    (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (hP : P (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) :
+    FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+        ≃ₐc[AlgebraicClosure k] AlgebraicClosure k :=
+  HopfIdeal.counitBialgEquivOfAugmentationEqBot
+    (hH.bot_eq_augmentation hP).symm
+
+/-- The generic trivial-geometric-fibre equivalence is the counit. -/
+@[simp]
+theorem geometricFiberCounitBialgEquiv_apply [P.IsClosedUnderIsomorphisms]
+    (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (hP : P (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
+    (x : FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :
+    hH.geometricFiberCounitBialgEquiv hP x =
+      Bialgebra.counitBialgHom (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) x := by
+  rw [geometricFiberCounitBialgEquiv]
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_apply _ _
+
+/-- The inverse of the generic trivial-geometric-fibre equivalence is the structure map. -/
+@[simp]
+theorem geometricFiberCounitBialgEquiv_symm_apply [P.IsClosedUnderIsomorphisms]
+    (hH : geometricRadicalFreeCommHopfAlgProperty k P H)
+    (hP : P (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
+    (r : AlgebraicClosure k) :
+    (hH.geometricFiberCounitBialgEquiv hP).symm r =
+      algebraMap (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) r := by
+  rw [geometricFiberCounitBialgEquiv]
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_symm_apply _ _
+
+end geometricRadicalFreeCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -5,11 +5,8 @@ Authors: Codex
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
-public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal
+public import TauCeti.Algebra.AlgebraicGroup.Radical.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
-public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 
 /-!
 # Reductive affine groups
@@ -69,20 +66,8 @@ the identity subgroup. A Hopf ideal `I` cuts out that subgroup contravariantly, 
 `I` is the augmentation ideal, not the zero ideal. -/
 def reductiveCommHopfAlgProperty (k : Type u) [Field k] :
     ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
-  fun H ↦
-    Algebra.Smooth k H ∧
-      geometricallyConnectedCommHopfAlgProperty k H.obj ∧
-        ∀ I : HopfIdeal (AlgebraicClosure k)
-            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H),
-          I.IsNormal →
-            geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.quotient
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
-            smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.quotient
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
-            I = HopfIdeal.augmentation (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+  geometricRadicalFreeCommHopfAlgProperty k
+    (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k))
 
 /-- Reductivity means smoothness, geometric connectedness, and absence of nontrivial connected
 normal smooth unipotent closed subgroups after extension to an algebraic closure. -/
@@ -101,54 +86,16 @@ theorem reductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
               smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
                 (FiniteTypeCommHopfAlgCat.quotient
                   (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
-              I = HopfIdeal.augmentation (AlgebraicClosure k)
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
-  Iff.rfl
+            I = HopfIdeal.augmentation (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  geometricRadicalFreeCommHopfAlgProperty_iff k
+    (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)) H
 
 /-- Reductivity is invariant under isomorphisms of finite-type commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :
-    (reductiveCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
-  of_iso {H K} e hH := by
-    rw [reductiveCommHopfAlgProperty_iff] at hH ⊢
-    let e₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-      (CommHopfAlgCat.{u} k)).mapIso e
-    let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
-    let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
-    let ebar := (FiniteTypeCommHopfAlgCat.baseChangeFunctor
-      (K := AlgebraicClosure k)).mapIso e
-    let ebar₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
-      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso ebar
-    let f : Hbar →ₐc[AlgebraicClosure k] Kbar := ebar₀.hom.hom
-    have hfinjective : Function.Injective f :=
-      (ConcreteCategory.bijective_of_isIso ebar₀.hom).1
-    have hfsurjective : Function.Surjective f :=
-      (ConcreteCategory.bijective_of_isIso ebar₀.hom).2
-    refine ⟨(smoothCommHopfAlgProperty_iff K.obj).mp <|
-        (smoothCommHopfAlgProperty k).prop_of_iso e₀
-          ((smoothCommHopfAlgProperty_iff H.obj).mpr hH.1),
-      (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀ hH.2.1, ?_⟩
-    intro I hnormal hconnected hunipotent
-    let J := I.comap f hfsurjective
-    have hnormalJ : J.IsNormal :=
-      hnormal.comap_of_bijective f hfinjective hfsurjective
-    let qIso : FiniteTypeCommHopfAlgCat.quotient Hbar J ≅
-        FiniteTypeCommHopfAlgCat.quotient Kbar I :=
-      FiniteTypeCommHopfAlgCat.quotientIsoOfIso ebar I
-    let qIso₀ := (forget₂
-      (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
-      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso qIso
-    have hconnectedJ : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj :=
-      (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-        qIso₀.symm hconnected
-    have hunipotentJ : smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.quotient Hbar J) :=
-      (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-        qIso.symm hunipotent
-    have hJ := hH.2.2 J hnormalJ hconnectedJ hunipotentJ
-    rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hfsurjective,
-      HopfIdeal.comap_augmentation]
-    exact hJ
+    (reductiveCommHopfAlgProperty k).IsClosedUnderIsomorphisms :=
+  inferInstanceAs ((geometricRadicalFreeCommHopfAlgProperty k
+    (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k))).IsClosedUnderIsomorphisms)
 
 namespace reductiveCommHopfAlgProperty
 
@@ -156,12 +103,12 @@ variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
 
 /-- A reductive finite-type commutative Hopf algebra is smooth over its ground field. -/
 theorem smooth (hH : reductiveCommHopfAlgProperty k H) : Algebra.Smooth k H :=
-  hH.1
+  geometricRadicalFreeCommHopfAlgProperty.smooth hH
 
 /-- A reductive finite-type commutative Hopf algebra is geometrically connected. -/
 theorem geometricallyConnected (hH : reductiveCommHopfAlgProperty k H) :
     geometricallyConnectedCommHopfAlgProperty k H.obj :=
-  hH.2.1
+  geometricRadicalFreeCommHopfAlgProperty.geometricallyConnected hH
 
 /-- Every connected normal smooth unipotent closed subgroup of the geometric fibre of a
 reductive group is the identity subgroup. -/
@@ -177,7 +124,7 @@ theorem eq_augmentation (hH : reductiveCommHopfAlgProperty k H)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I)) :
     I = HopfIdeal.augmentation (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
-  hH.2.2 I hI hconnected hunipotent
+  geometricRadicalFreeCommHopfAlgProperty.eq_augmentation hH I hI hconnected hunipotent
 
 /-- If the geometric fibre of a reductive group has only unipotent geometric points, its zero
 Hopf ideal is the augmentation ideal. Equivalently, the whole geometric fibre is the identity
@@ -189,21 +136,11 @@ theorem bot_eq_augmentation (hH : reductiveCommHopfAlgProperty k H)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) =
         HopfIdeal.augmentation (AlgebraicClosure k)
           (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
-  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
-  apply hH.eq_augmentation (I := (⊥ : HopfIdeal (AlgebraicClosure k) Hbar))
-  · exact HopfIdeal.isNormal_bot
-  · exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
-        (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso
-          (FiniteTypeCommHopfAlgCat.quotientBotIso Hbar)).symm
-      (geometricallyConnectedCommHopfAlgProperty.baseChange k (AlgebraicClosure k) H.obj
-        hH.geometricallyConnected)
-  · apply (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-      (FiniteTypeCommHopfAlgCat.quotientBotIso Hbar).symm
-    rw [smoothUnipotentCommHopfAlgProperty_iff]
-    refine ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, ?_⟩
-    exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff
-      (AlgebraicClosure k) Hbar.obj).mp hunipotent
+  apply geometricRadicalFreeCommHopfAlgProperty.bot_eq_augmentation hH
+  rw [smoothUnipotentCommHopfAlgProperty_iff]
+  refine ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, ?_⟩
+  exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff (AlgebraicClosure k)
+    (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj).mp hunipotent
 
 /-- A reductive group whose geometric fibre has only unipotent geometric points has trivial
 geometric fibre: its coordinate Hopf algebra is bialgebra-equivalent to the algebraic closure of
@@ -214,8 +151,11 @@ noncomputable def geometricFiberCounitBialgEquiv
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
     FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H ≃ₐc[AlgebraicClosure k]
       AlgebraicClosure k :=
-  HopfIdeal.counitBialgEquivOfAugmentationEqBot
-    (hH.bot_eq_augmentation hunipotent).symm
+  geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv hH <| by
+    rw [smoothUnipotentCommHopfAlgProperty_iff]
+    refine ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, ?_⟩
+    exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj).mp hunipotent
 
 /-- The equivalence from the geometric fibre to the algebraic closure is its counit. -/
 @[simp]
@@ -228,7 +168,7 @@ theorem geometricFiberCounitBialgEquiv_apply
       Bialgebra.counitBialgHom (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) x := by
   rw [geometricFiberCounitBialgEquiv]
-  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_apply _ _
+  exact geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv_apply _ _ _
 
 /-- The inverse equivalence from the algebraic closure is the geometric fibre's structure map. -/
 @[simp]
@@ -241,7 +181,7 @@ theorem geometricFiberCounitBialgEquiv_symm_apply
       algebraMap (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) r := by
   rw [geometricFiberCounitBialgEquiv]
-  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_symm_apply _ _
+  exact geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv_symm_apply _ _ _
 
 end reductiveCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -66,7 +66,7 @@ the identity subgroup. A Hopf ideal `I` cuts out that subgroup contravariantly, 
 `I` is the augmentation ideal, not the zero ideal. -/
 def reductiveCommHopfAlgProperty (k : Type u) [Field k] :
     ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
-  geometricRadicalFreeCommHopfAlgProperty k
+  geometricNormalSubgroupFreeCommHopfAlgProperty k
     (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k))
 
 /-- Reductivity means smoothness, geometric connectedness, and absence of nontrivial connected
@@ -88,13 +88,13 @@ theorem reductiveCommHopfAlgProperty_iff (k : Type u) [Field k]
                   (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
             I = HopfIdeal.augmentation (AlgebraicClosure k)
               (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
-  geometricRadicalFreeCommHopfAlgProperty_iff k
+  geometricNormalSubgroupFreeCommHopfAlgProperty_iff k
     (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)) H
 
 /-- Reductivity is invariant under isomorphisms of finite-type commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :
     (reductiveCommHopfAlgProperty k).IsClosedUnderIsomorphisms :=
-  inferInstanceAs ((geometricRadicalFreeCommHopfAlgProperty k
+  inferInstanceAs ((geometricNormalSubgroupFreeCommHopfAlgProperty k
     (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k))).IsClosedUnderIsomorphisms)
 
 namespace reductiveCommHopfAlgProperty
@@ -103,12 +103,12 @@ variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
 
 /-- A reductive finite-type commutative Hopf algebra is smooth over its ground field. -/
 theorem smooth (hH : reductiveCommHopfAlgProperty k H) : Algebra.Smooth k H :=
-  geometricRadicalFreeCommHopfAlgProperty.smooth hH
+  geometricNormalSubgroupFreeCommHopfAlgProperty.smooth hH
 
 /-- A reductive finite-type commutative Hopf algebra is geometrically connected. -/
 theorem geometricallyConnected (hH : reductiveCommHopfAlgProperty k H) :
     geometricallyConnectedCommHopfAlgProperty k H.obj :=
-  geometricRadicalFreeCommHopfAlgProperty.geometricallyConnected hH
+  geometricNormalSubgroupFreeCommHopfAlgProperty.geometricallyConnected hH
 
 /-- Every connected normal smooth unipotent closed subgroup of the geometric fibre of a
 reductive group is the identity subgroup. -/
@@ -124,7 +124,7 @@ theorem eq_augmentation (hH : reductiveCommHopfAlgProperty k H)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I)) :
     I = HopfIdeal.augmentation (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
-  geometricRadicalFreeCommHopfAlgProperty.eq_augmentation hH I hI hconnected hunipotent
+  geometricNormalSubgroupFreeCommHopfAlgProperty.eq_augmentation hH I hI hconnected hunipotent
 
 /-- If the geometric fibre of a reductive group has only unipotent geometric points, its zero
 Hopf ideal is the augmentation ideal. Equivalently, the whole geometric fibre is the identity
@@ -136,7 +136,7 @@ theorem bot_eq_augmentation (hH : reductiveCommHopfAlgProperty k H)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) =
         HopfIdeal.augmentation (AlgebraicClosure k)
           (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
-  apply geometricRadicalFreeCommHopfAlgProperty.bot_eq_augmentation hH
+  apply geometricNormalSubgroupFreeCommHopfAlgProperty.bot_eq_augmentation hH
   rw [smoothUnipotentCommHopfAlgProperty_iff]
   refine ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, ?_⟩
   exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff (AlgebraicClosure k)
@@ -151,11 +151,8 @@ noncomputable def geometricFiberCounitBialgEquiv
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
     FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H ≃ₐc[AlgebraicClosure k]
       AlgebraicClosure k :=
-  geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv hH <| by
-    rw [smoothUnipotentCommHopfAlgProperty_iff]
-    refine ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, ?_⟩
-    exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj).mp hunipotent
+  HopfIdeal.counitBialgEquivOfAugmentationEqBot
+    (hH.bot_eq_augmentation hunipotent).symm
 
 /-- The equivalence from the geometric fibre to the algebraic closure is its counit. -/
 @[simp]
@@ -168,7 +165,7 @@ theorem geometricFiberCounitBialgEquiv_apply
       Bialgebra.counitBialgHom (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) x := by
   rw [geometricFiberCounitBialgEquiv]
-  exact geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv_apply _ _ _
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_apply _ _
 
 /-- The inverse equivalence from the algebraic closure is the geometric fibre's structure map. -/
 @[simp]
@@ -181,7 +178,7 @@ theorem geometricFiberCounitBialgEquiv_symm_apply
       algebraMap (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) r := by
   rw [geometricFiberCounitBialgEquiv]
-  exact geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv_symm_apply _ _ _
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_symm_apply _ _
 
 end reductiveCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
@@ -5,12 +5,8 @@ Authors: Codex
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
-public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal
+public import TauCeti.Algebra.AlgebraicGroup.Radical.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
-public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
-public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 
 /-!
 # Semisimple affine groups
@@ -44,6 +40,10 @@ algebraic closure of the ground field via the counit.
 * J. S. Milne, *Algebraic Groups* (2017), §§6.46 and 21.10.
 * T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
 
+The formal construction and proof structure were adapted from
+`TauCeti.Algebra.AlgebraicGroup.Reductive.Basic`; their common radical-triviality infrastructure
+is factored through `TauCeti.Algebra.AlgebraicGroup.Radical.Basic`.
+
 This is the semisimple-group definition target in Layer 6, "Reductive and semisimple groups", of
 the ReductiveGroups roadmap. It states triviality of the geometric radical through its defining
 universal property while the radical construction is still being developed.
@@ -67,23 +67,11 @@ the identity subgroup. A Hopf ideal `I` cuts out that subgroup contravariantly, 
 `I` is the augmentation ideal, not the zero ideal. -/
 def semisimpleCommHopfAlgProperty (k : Type u) [Field k] :
     ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
-  fun H ↦
-    Algebra.Smooth k H ∧
-      geometricallyConnectedCommHopfAlgProperty k H.obj ∧
-        ∀ I : HopfIdeal (AlgebraicClosure k)
-            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H),
-          I.IsNormal →
-            geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.quotient
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
-            Algebra.Smooth (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.quotient
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
-            geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.quotient
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
-            I = HopfIdeal.augmentation (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+  geometricRadicalFreeCommHopfAlgProperty k <|
+    ((smoothCommHopfAlgProperty (AlgebraicClosure k)) ⊓
+      geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).inverseImage
+        (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+          (CommHopfAlgCat.{u} (AlgebraicClosure k)))
 
 /-- Semisimplicity means smoothness, geometric connectedness, and absence of nontrivial connected
 normal smooth solvable closed subgroups after extension to an algebraic closure. -/
@@ -107,59 +95,28 @@ theorem semisimpleCommHopfAlgProperty_iff (k : Type u) [Field k]
                   (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
               I = HopfIdeal.augmentation (AlgebraicClosure k)
                 (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
-  Iff.rfl
+  by
+    rw [semisimpleCommHopfAlgProperty, geometricRadicalFreeCommHopfAlgProperty_iff]
+    simp only [ObjectProperty.prop_inverseImage_iff, ObjectProperty.prop_inf_iff,
+      FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj, smoothCommHopfAlgProperty_iff]
+    constructor
+    · rintro ⟨hsmooth, hconnected, htrivial⟩
+      refine ⟨hsmooth, hconnected, ?_⟩
+      intro I hnormal hsubConnected hsubSmooth hsubSolvable
+      exact htrivial I hnormal hsubConnected ⟨hsubSmooth, hsubSolvable⟩
+    · rintro ⟨hsmooth, hconnected, htrivial⟩
+      refine ⟨hsmooth, hconnected, ?_⟩
+      intro I hnormal hsubConnected hsub
+      exact htrivial I hnormal hsubConnected hsub.1 hsub.2
 
 /-- Semisimplicity is invariant under isomorphisms of finite-type commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :
-    (semisimpleCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
-  of_iso {H K} e hH := by
-    rw [semisimpleCommHopfAlgProperty_iff] at hH ⊢
-    let e₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-      (CommHopfAlgCat.{u} k)).mapIso e
-    let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
-    let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
-    let ebar := (FiniteTypeCommHopfAlgCat.baseChangeFunctor
-      (K := AlgebraicClosure k)).mapIso e
-    let ebar₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
-      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso ebar
-    let f : Hbar →ₐc[AlgebraicClosure k] Kbar := ebar₀.hom.hom
-    have hfinjective : Function.Injective f :=
-      (ConcreteCategory.bijective_of_isIso ebar₀.hom).1
-    have hfsurjective : Function.Surjective f :=
-      (ConcreteCategory.bijective_of_isIso ebar₀.hom).2
-    refine ⟨(smoothCommHopfAlgProperty_iff K.obj).mp <|
-        (smoothCommHopfAlgProperty k).prop_of_iso e₀
-          ((smoothCommHopfAlgProperty_iff H.obj).mpr hH.1),
-      (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀ hH.2.1, ?_⟩
-    intro I hnormal hconnected hsmooth hsolvable
-    let J := I.comap f hfsurjective
-    have hnormalJ : J.IsNormal :=
-      hnormal.comap_of_bijective f hfinjective hfsurjective
-    let qIso : FiniteTypeCommHopfAlgCat.quotient Hbar J ≅
-        FiniteTypeCommHopfAlgCat.quotient Kbar I :=
-      FiniteTypeCommHopfAlgCat.quotientIsoOfIso ebar I
-    let qIso₀ := (forget₂
-      (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
-      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso qIso
-    have hconnectedJ : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj :=
-      (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-        qIso₀.symm hconnected
-    have hsmoothJ : Algebra.Smooth (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.quotient Hbar J) :=
-      (smoothCommHopfAlgProperty_iff
-        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj).mp <|
-          (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso₀.symm <|
-            (smoothCommHopfAlgProperty_iff
-              (FiniteTypeCommHopfAlgCat.quotient Kbar I).obj).mpr hsmooth
-    have hsolvableJ : geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj :=
-      (geometricallySolvablePointsCommHopfAlgProperty
-        (AlgebraicClosure k)).prop_of_iso qIso₀.symm hsolvable
-    have hJ := hH.2.2 J hnormalJ hconnectedJ hsmoothJ hsolvableJ
-    rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hfsurjective,
-      HopfIdeal.comap_augmentation]
-    exact hJ
+    (semisimpleCommHopfAlgProperty k).IsClosedUnderIsomorphisms :=
+  inferInstanceAs ((geometricRadicalFreeCommHopfAlgProperty k
+    (((smoothCommHopfAlgProperty (AlgebraicClosure k)) ⊓
+      geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).inverseImage
+        (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+          (CommHopfAlgCat.{u} (AlgebraicClosure k))))).IsClosedUnderIsomorphisms)
 
 namespace semisimpleCommHopfAlgProperty
 
@@ -167,12 +124,12 @@ variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
 
 /-- A semisimple finite-type commutative Hopf algebra is smooth over its ground field. -/
 theorem smooth (hH : semisimpleCommHopfAlgProperty k H) : Algebra.Smooth k H :=
-  hH.1
+  geometricRadicalFreeCommHopfAlgProperty.smooth hH
 
 /-- A semisimple finite-type commutative Hopf algebra is geometrically connected. -/
 theorem geometricallyConnected (hH : semisimpleCommHopfAlgProperty k H) :
     geometricallyConnectedCommHopfAlgProperty k H.obj :=
-  hH.2.1
+  geometricRadicalFreeCommHopfAlgProperty.geometricallyConnected hH
 
 /-- Every connected normal smooth solvable closed subgroup of the geometric fibre of a
 semisimple group is the identity subgroup. -/
@@ -190,8 +147,11 @@ theorem eq_augmentation (hH : semisimpleCommHopfAlgProperty k H)
       (FiniteTypeCommHopfAlgCat.quotient
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj) :
     I = HopfIdeal.augmentation (AlgebraicClosure k)
-      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
-  hH.2.2 I hI hconnected hsmooth hsolvable
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
+  apply geometricRadicalFreeCommHopfAlgProperty.eq_augmentation hH I hI hconnected
+  rw [ObjectProperty.prop_inverseImage_iff, ObjectProperty.prop_inf_iff,
+    FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj, smoothCommHopfAlgProperty_iff]
+  exact ⟨hsmooth, hsolvable⟩
 
 /-- If the geometric fibre of a semisimple group has solvable geometric points, its zero Hopf
 ideal is the augmentation ideal. Equivalently, the whole geometric fibre is the identity
@@ -203,24 +163,10 @@ theorem bot_eq_augmentation (hH : semisimpleCommHopfAlgProperty k H)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) =
         HopfIdeal.augmentation (AlgebraicClosure k)
           (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
-  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
-  let qIso := FiniteTypeCommHopfAlgCat.quotientBotIso Hbar
-  let qIso₀ := (forget₂
-    (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
-    (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso qIso
-  apply hH.eq_augmentation (I := (⊥ : HopfIdeal (AlgebraicClosure k) Hbar))
-  · exact HopfIdeal.isNormal_bot
-  · exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-      qIso₀.symm
-      (geometricallyConnectedCommHopfAlgProperty.baseChange k (AlgebraicClosure k) H.obj
-        hH.geometricallyConnected)
-  · exact (smoothCommHopfAlgProperty_iff
-      (FiniteTypeCommHopfAlgCat.quotient Hbar ⊥).obj).mp <|
-        (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso₀.symm <|
-          (smoothCommHopfAlgProperty_iff Hbar.obj).mpr
-            (@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth)
-  · exact (geometricallySolvablePointsCommHopfAlgProperty
-      (AlgebraicClosure k)).prop_of_iso qIso₀.symm hsolvable
+  apply geometricRadicalFreeCommHopfAlgProperty.bot_eq_augmentation hH
+  rw [ObjectProperty.prop_inverseImage_iff, ObjectProperty.prop_inf_iff,
+    FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj, smoothCommHopfAlgProperty_iff]
+  exact ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, hsolvable⟩
 
 /-- A semisimple group with solvable geometric fibre has trivial geometric fibre: its coordinate
 Hopf algebra is bialgebra-equivalent to the algebraic closure of the ground field via the
@@ -231,8 +177,11 @@ noncomputable def geometricFiberCounitBialgEquiv
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
     FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
         ≃ₐc[AlgebraicClosure k] AlgebraicClosure k :=
-  HopfIdeal.counitBialgEquivOfAugmentationEqBot
-    (hH.bot_eq_augmentation hsolvable).symm
+  geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv hH <| by
+    rw [ObjectProperty.prop_inverseImage_iff, ObjectProperty.prop_inf_iff,
+      FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj, smoothCommHopfAlgProperty_iff]
+    exact
+      ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, hsolvable⟩
 
 /-- The equivalence from the geometric fibre to the algebraic closure is its counit. -/
 @[simp]
@@ -245,7 +194,7 @@ theorem geometricFiberCounitBialgEquiv_apply
       Bialgebra.counitBialgHom (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) x := by
   rw [geometricFiberCounitBialgEquiv]
-  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_apply _ _
+  exact geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv_apply _ _ _
 
 /-- The inverse equivalence from the algebraic closure is the geometric fibre's structure map. -/
 @[simp]
@@ -258,7 +207,7 @@ theorem geometricFiberCounitBialgEquiv_symm_apply
       algebraMap (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) r := by
   rw [geometricFiberCounitBialgEquiv]
-  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_symm_apply _ _
+  exact geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv_symm_apply _ _ _
 
 end semisimpleCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
@@ -1,0 +1,267 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+
+/-!
+# Semisimple affine groups
+
+A finite-type affine group over a field is semisimple when it is smooth and geometrically
+connected and, after extension to an algebraic closure, it has no nontrivial connected normal
+smooth solvable closed subgroup. In coordinate-Hopf-algebra terms, a closed subgroup of the
+geometric fibre is represented contravariantly by a Hopf-ideal quotient. The subgroup is trivial
+exactly when its defining Hopf ideal is the augmentation ideal.
+
+This formulation is equivalent to triviality of the geometric radical once that radical has been
+constructed, but makes the semisimple predicate available without choosing a maximal subgroup.
+Smoothness of the candidate subgroup is essential: in positive characteristic a semisimple group
+can have non-smooth connected central subgroup schemes.
+
+As a basic consequence, if the geometric fibre of a semisimple group is itself solvable, then it
+is trivial. The resulting bialgebra equivalence identifies its coordinate algebra with the
+algebraic closure of the ground field via the counit.
+
+## Main declarations
+
+* `TauCeti.semisimpleCommHopfAlgProperty`: semisimplicity for finite-type commutative Hopf
+  algebras over a field.
+* `TauCeti.semisimpleCommHopfAlgProperty.eq_augmentation`: every connected normal smooth
+  solvable closed subgroup of a semisimple group's geometric fibre is trivial.
+* `TauCeti.semisimpleCommHopfAlgProperty.geometricFiberCounitBialgEquiv`: a semisimple group
+  with solvable geometric fibre has trivial geometric fibre.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§6.46 and 21.10.
+* T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
+
+This is the semisimple-group definition target in Layer 6, "Reductive and semisimple groups", of
+the ReductiveGroups roadmap. It states triviality of the geometric radical through its defining
+universal property while the radical construction is still being developed.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+/-- The object property selecting semisimple finite-type commutative Hopf algebras over a field.
+
+The first two conjuncts express smoothness and geometric connectedness of the ambient group. The
+last says that every connected normal smooth closed subgroup with solvable geometric points is
+the identity subgroup. A Hopf ideal `I` cuts out that subgroup contravariantly, so identity means
+`I` is the augmentation ideal, not the zero ideal. -/
+def semisimpleCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
+  fun H ↦
+    Algebra.Smooth k H ∧
+      geometricallyConnectedCommHopfAlgProperty k H.obj ∧
+        ∀ I : HopfIdeal (AlgebraicClosure k)
+            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H),
+          I.IsNormal →
+            geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
+            Algebra.Smooth (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
+            geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
+            I = HopfIdeal.augmentation (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+
+/-- Semisimplicity means smoothness, geometric connectedness, and absence of nontrivial connected
+normal smooth solvable closed subgroups after extension to an algebraic closure. -/
+@[simp]
+theorem semisimpleCommHopfAlgProperty_iff (k : Type u) [Field k]
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    semisimpleCommHopfAlgProperty k H ↔
+      Algebra.Smooth k H ∧
+        geometricallyConnectedCommHopfAlgProperty k H.obj ∧
+          ∀ I : HopfIdeal (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H),
+            I.IsNormal →
+              geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.quotient
+                  (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
+              Algebra.Smooth (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.quotient
+                  (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) →
+              geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.quotient
+                  (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj →
+              I = HopfIdeal.augmentation (AlgebraicClosure k)
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  Iff.rfl
+
+/-- Semisimplicity is invariant under isomorphisms of finite-type commutative Hopf algebras. -/
+instance (k : Type u) [Field k] :
+    (semisimpleCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
+  of_iso {H K} e hH := by
+    rw [semisimpleCommHopfAlgProperty_iff] at hH ⊢
+    let e₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+      (CommHopfAlgCat.{u} k)).mapIso e
+    let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+    let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
+    let ebar := (FiniteTypeCommHopfAlgCat.baseChangeFunctor
+      (K := AlgebraicClosure k)).mapIso e
+    let ebar₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso ebar
+    let f : Hbar →ₐc[AlgebraicClosure k] Kbar := ebar₀.hom.hom
+    have hfinjective : Function.Injective f :=
+      (ConcreteCategory.bijective_of_isIso ebar₀.hom).1
+    have hfsurjective : Function.Surjective f :=
+      (ConcreteCategory.bijective_of_isIso ebar₀.hom).2
+    refine ⟨(smoothCommHopfAlgProperty_iff K.obj).mp <|
+        (smoothCommHopfAlgProperty k).prop_of_iso e₀
+          ((smoothCommHopfAlgProperty_iff H.obj).mpr hH.1),
+      (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀ hH.2.1, ?_⟩
+    intro I hnormal hconnected hsmooth hsolvable
+    let J := I.comap f hfsurjective
+    have hnormalJ : J.IsNormal :=
+      hnormal.comap_of_bijective f hfinjective hfsurjective
+    let qIso : FiniteTypeCommHopfAlgCat.quotient Hbar J ≅
+        FiniteTypeCommHopfAlgCat.quotient Kbar I :=
+      FiniteTypeCommHopfAlgCat.quotientIsoOfIso ebar I
+    let qIso₀ := (forget₂
+      (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+      (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso qIso
+    have hconnectedJ : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj :=
+      (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+        qIso₀.symm hconnected
+    have hsmoothJ : Algebra.Smooth (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient Hbar J) :=
+      (smoothCommHopfAlgProperty_iff
+        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj).mp <|
+          (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso₀.symm <|
+            (smoothCommHopfAlgProperty_iff
+              (FiniteTypeCommHopfAlgCat.quotient Kbar I).obj).mpr hsmooth
+    have hsolvableJ : geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient Hbar J).obj :=
+      (geometricallySolvablePointsCommHopfAlgProperty
+        (AlgebraicClosure k)).prop_of_iso qIso₀.symm hsolvable
+    have hJ := hH.2.2 J hnormalJ hconnectedJ hsmoothJ hsolvableJ
+    rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hfsurjective,
+      HopfIdeal.comap_augmentation]
+    exact hJ
+
+namespace semisimpleCommHopfAlgProperty
+
+variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
+
+/-- A semisimple finite-type commutative Hopf algebra is smooth over its ground field. -/
+theorem smooth (hH : semisimpleCommHopfAlgProperty k H) : Algebra.Smooth k H :=
+  hH.1
+
+/-- A semisimple finite-type commutative Hopf algebra is geometrically connected. -/
+theorem geometricallyConnected (hH : semisimpleCommHopfAlgProperty k H) :
+    geometricallyConnectedCommHopfAlgProperty k H.obj :=
+  hH.2.1
+
+/-- Every connected normal smooth solvable closed subgroup of the geometric fibre of a
+semisimple group is the identity subgroup. -/
+theorem eq_augmentation (hH : semisimpleCommHopfAlgProperty k H)
+    (I : HopfIdeal (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H))
+    (hI : I.IsNormal)
+    (hconnected : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj)
+    (hsmooth : Algebra.Smooth (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I))
+    (hsolvable : geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj) :
+    I = HopfIdeal.augmentation (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
+  hH.2.2 I hI hconnected hsmooth hsolvable
+
+/-- If the geometric fibre of a semisimple group has solvable geometric points, its zero Hopf
+ideal is the augmentation ideal. Equivalently, the whole geometric fibre is the identity
+subgroup. -/
+theorem bot_eq_augmentation (hH : semisimpleCommHopfAlgProperty k H)
+    (hsolvable : geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
+    (⊥ : HopfIdeal (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) =
+        HopfIdeal.augmentation (AlgebraicClosure k)
+          (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+  let qIso := FiniteTypeCommHopfAlgCat.quotientBotIso Hbar
+  let qIso₀ := (forget₂
+    (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+    (CommHopfAlgCat.{u} (AlgebraicClosure k))).mapIso qIso
+  apply hH.eq_augmentation (I := (⊥ : HopfIdeal (AlgebraicClosure k) Hbar))
+  · exact HopfIdeal.isNormal_bot
+  · exact (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
+      qIso₀.symm
+      (geometricallyConnectedCommHopfAlgProperty.baseChange k (AlgebraicClosure k) H.obj
+        hH.geometricallyConnected)
+  · exact (smoothCommHopfAlgProperty_iff
+      (FiniteTypeCommHopfAlgCat.quotient Hbar ⊥).obj).mp <|
+        (smoothCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso₀.symm <|
+          (smoothCommHopfAlgProperty_iff Hbar.obj).mpr
+            (@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth)
+  · exact (geometricallySolvablePointsCommHopfAlgProperty
+      (AlgebraicClosure k)).prop_of_iso qIso₀.symm hsolvable
+
+/-- A semisimple group with solvable geometric fibre has trivial geometric fibre: its coordinate
+Hopf algebra is bialgebra-equivalent to the algebraic closure of the ground field via the
+counit. -/
+noncomputable def geometricFiberCounitBialgEquiv
+    (hH : semisimpleCommHopfAlgProperty k H)
+    (hsolvable : geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
+    FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+        ≃ₐc[AlgebraicClosure k] AlgebraicClosure k :=
+  HopfIdeal.counitBialgEquivOfAugmentationEqBot
+    (hH.bot_eq_augmentation hsolvable).symm
+
+/-- The equivalence from the geometric fibre to the algebraic closure is its counit. -/
+@[simp]
+theorem geometricFiberCounitBialgEquiv_apply
+    (hH : semisimpleCommHopfAlgProperty k H)
+    (hsolvable : geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)
+    (x : FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :
+    hH.geometricFiberCounitBialgEquiv hsolvable x =
+      Bialgebra.counitBialgHom (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) x := by
+  rw [geometricFiberCounitBialgEquiv]
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_apply _ _
+
+/-- The inverse equivalence from the algebraic closure is the geometric fibre's structure map. -/
+@[simp]
+theorem geometricFiberCounitBialgEquiv_symm_apply
+    (hH : semisimpleCommHopfAlgProperty k H)
+    (hsolvable : geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj)
+    (r : AlgebraicClosure k) :
+    (hH.geometricFiberCounitBialgEquiv hsolvable).symm r =
+      algebraMap (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) r := by
+  rw [geometricFiberCounitBialgEquiv]
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_symm_apply _ _
+
+end semisimpleCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
@@ -41,8 +41,8 @@ algebraic closure of the ground field via the counit.
 * T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
 
 The formal construction and proof structure were adapted from
-`TauCeti.Algebra.AlgebraicGroup.Reductive.Basic`; their common radical-triviality infrastructure
-is factored through `TauCeti.Algebra.AlgebraicGroup.Radical.Basic`.
+`TauCeti.Algebra.AlgebraicGroup.Reductive.Basic`; their common normal-subgroup-freeness
+infrastructure is factored through `TauCeti.Algebra.AlgebraicGroup.Radical.Basic`.
 
 This is the semisimple-group definition target in Layer 6, "Reductive and semisimple groups", of
 the ReductiveGroups roadmap. It states triviality of the geometric radical through its defining
@@ -67,7 +67,7 @@ the identity subgroup. A Hopf ideal `I` cuts out that subgroup contravariantly, 
 `I` is the augmentation ideal, not the zero ideal. -/
 def semisimpleCommHopfAlgProperty (k : Type u) [Field k] :
     ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
-  geometricRadicalFreeCommHopfAlgProperty k <|
+  geometricNormalSubgroupFreeCommHopfAlgProperty k <|
     ((smoothCommHopfAlgProperty (AlgebraicClosure k)) ⊓
       geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).inverseImage
         (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
@@ -96,7 +96,7 @@ theorem semisimpleCommHopfAlgProperty_iff (k : Type u) [Field k]
               I = HopfIdeal.augmentation (AlgebraicClosure k)
                 (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) :=
   by
-    rw [semisimpleCommHopfAlgProperty, geometricRadicalFreeCommHopfAlgProperty_iff]
+    rw [semisimpleCommHopfAlgProperty, geometricNormalSubgroupFreeCommHopfAlgProperty_iff]
     simp only [ObjectProperty.prop_inverseImage_iff, ObjectProperty.prop_inf_iff,
       FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj, smoothCommHopfAlgProperty_iff]
     constructor
@@ -112,7 +112,7 @@ theorem semisimpleCommHopfAlgProperty_iff (k : Type u) [Field k]
 /-- Semisimplicity is invariant under isomorphisms of finite-type commutative Hopf algebras. -/
 instance (k : Type u) [Field k] :
     (semisimpleCommHopfAlgProperty k).IsClosedUnderIsomorphisms :=
-  inferInstanceAs ((geometricRadicalFreeCommHopfAlgProperty k
+  inferInstanceAs ((geometricNormalSubgroupFreeCommHopfAlgProperty k
     (((smoothCommHopfAlgProperty (AlgebraicClosure k)) ⊓
       geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)).inverseImage
         (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
@@ -124,12 +124,12 @@ variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
 
 /-- A semisimple finite-type commutative Hopf algebra is smooth over its ground field. -/
 theorem smooth (hH : semisimpleCommHopfAlgProperty k H) : Algebra.Smooth k H :=
-  geometricRadicalFreeCommHopfAlgProperty.smooth hH
+  geometricNormalSubgroupFreeCommHopfAlgProperty.smooth hH
 
 /-- A semisimple finite-type commutative Hopf algebra is geometrically connected. -/
 theorem geometricallyConnected (hH : semisimpleCommHopfAlgProperty k H) :
     geometricallyConnectedCommHopfAlgProperty k H.obj :=
-  geometricRadicalFreeCommHopfAlgProperty.geometricallyConnected hH
+  geometricNormalSubgroupFreeCommHopfAlgProperty.geometricallyConnected hH
 
 /-- Every connected normal smooth solvable closed subgroup of the geometric fibre of a
 semisimple group is the identity subgroup. -/
@@ -148,7 +148,7 @@ theorem eq_augmentation (hH : semisimpleCommHopfAlgProperty k H)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I).obj) :
     I = HopfIdeal.augmentation (AlgebraicClosure k)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
-  apply geometricRadicalFreeCommHopfAlgProperty.eq_augmentation hH I hI hconnected
+  apply geometricNormalSubgroupFreeCommHopfAlgProperty.eq_augmentation hH I hI hconnected
   rw [ObjectProperty.prop_inverseImage_iff, ObjectProperty.prop_inf_iff,
     FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj, smoothCommHopfAlgProperty_iff]
   exact ⟨hsmooth, hsolvable⟩
@@ -163,7 +163,7 @@ theorem bot_eq_augmentation (hH : semisimpleCommHopfAlgProperty k H)
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)) =
         HopfIdeal.augmentation (AlgebraicClosure k)
           (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
-  apply geometricRadicalFreeCommHopfAlgProperty.bot_eq_augmentation hH
+  apply geometricNormalSubgroupFreeCommHopfAlgProperty.bot_eq_augmentation hH
   rw [ObjectProperty.prop_inverseImage_iff, ObjectProperty.prop_inf_iff,
     FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj, smoothCommHopfAlgProperty_iff]
   exact ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, hsolvable⟩
@@ -177,11 +177,8 @@ noncomputable def geometricFiberCounitBialgEquiv
       (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj) :
     FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
         ≃ₐc[AlgebraicClosure k] AlgebraicClosure k :=
-  geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv hH <| by
-    rw [ObjectProperty.prop_inverseImage_iff, ObjectProperty.prop_inf_iff,
-      FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj, smoothCommHopfAlgProperty_iff]
-    exact
-      ⟨@Algebra.Smooth.baseChange k _ H (AlgebraicClosure k) _ _ _ _ hH.smooth, hsolvable⟩
+  HopfIdeal.counitBialgEquivOfAugmentationEqBot
+    (hH.bot_eq_augmentation hsolvable).symm
 
 /-- The equivalence from the geometric fibre to the algebraic closure is its counit. -/
 @[simp]
@@ -194,7 +191,7 @@ theorem geometricFiberCounitBialgEquiv_apply
       Bialgebra.counitBialgHom (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) x := by
   rw [geometricFiberCounitBialgEquiv]
-  exact geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv_apply _ _ _
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_apply _ _
 
 /-- The inverse equivalence from the algebraic closure is the geometric fibre's structure map. -/
 @[simp]
@@ -207,7 +204,7 @@ theorem geometricFiberCounitBialgEquiv_symm_apply
       algebraMap (AlgebraicClosure k)
         (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) r := by
   rw [geometricFiberCounitBialgEquiv]
-  exact geometricRadicalFreeCommHopfAlgProperty.geometricFiberCounitBialgEquiv_symm_apply _ _ _
+  exact HopfIdeal.counitBialgEquivOfAugmentationEqBot_symm_apply _ _
 
 end semisimpleCommHopfAlgProperty
 


### PR DESCRIPTION
This PR defines semisimple finite-type affine groups over a field as smooth, geometrically connected groups whose geometric fibre has no nontrivial connected normal smooth solvable closed subgroup. Express the condition on coordinate Hopf algebras through Hopf-ideal quotients, prove invariance under Hopf-algebra isomorphism, and show that a semisimple group with solvable geometric fibre is trivial via the counit bialgebra equivalence.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6 milestone “Reductive and semisimple groups,” specifically “Semisimple: radical `R(G)` (maximal connected normal solvable, geometric) trivial.” This is the most effective current step because the geometric solvability predicate, normal Hopf ideals, finite-type quotients, smoothness, connectedness, and base change are already on `main`, while the scheme-theoretic derived subgroup is independently in flight in #3677. The definition states the radical’s universal triviality property without choosing a maximal subgroup before that construction exists.

After this PR, the Layer 6 milestone still needs construction and maximality of the geometric radical, identification of this predicate with `R(G) = 1`, the centre and structural properties of the derived group, and the simply connected and adjoint forms.

Add `TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean` (267 lines). The public API provides the defining iff theorem, isomorphism invariance, smoothness and connectedness eliminators, the characteristic `eq_augmentation` theorem for candidate radical subgroups, and the solvable-fibre triviality equivalence. Smoothness is required of candidate subgroups so infinitesimal central subgroup schemes in positive characteristic do not incorrectly exclude semisimple groups.

The formulation follows J. S. Milne, *Algebraic Groups* (2017), §§6.46 and 21.10, and T. A. Springer, *Linear Algebraic Groups*, Chapter 8, as credited in the module documentation. It reuses Tau Ceti’s geometric connectedness and solvability object properties, Hopf-ideal normality and quotient equivalences, and Mathlib’s smooth base-change infrastructure; no Mathlib source is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"semisimplecommhopfalgproperty"}-->

🤖 Prepared with Codex
