### PR TITLE
feat: prove simply-laced root data are reduced

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/Reduced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Reduced.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.RootSystem.Reduced
+
+/-!
+# A symmetry criterion for reduced root pairings
+
+A finite root pairing over a characteristic-zero domain is reduced as soon as its pairing is
+symmetric on roots and coroots. Indeed, two linearly dependent roots have Coxeter weight four.
+Symmetry makes this weight the square of one pairing value, so that value is `2` or `-2`; the
+root-pairing axioms then identify the two roots up to sign.
+
+This criterion is useful for root data presented in dual coordinate bases. Their roots and
+coroots need not be equal as coordinate vectors, while the pairing can still visibly be the
+symmetric form of a simply-laced Cartan matrix.
+
+## Main result
+
+* `RootPairing.isReduced_of_pairing_comm`: a finite root pairing with symmetric pairings is
+  reduced.
+-/
+
+public section
+
+open Module
+
+namespace RootPairing
+
+variable {ι R M N : Type*} [CommRing R] [CharZero R] [IsDomain R]
+  [AddCommGroup M] [Module R M] [Module.IsTorsionFree R M]
+  [AddCommGroup N] [Module R N] (P : RootPairing ι R M N)
+
+/-- A finite root pairing whose root--coroot pairing is symmetric is reduced. -/
+theorem isReduced_of_pairing_comm [Finite ι]
+    (hcomm : ∀ i j, P.pairing i j = P.pairing j i) : P.IsReduced := by
+  constructor
+  intro i j hdependent
+  have hweight : P.coxeterWeight i j = 4 :=
+    (P.coxeterWeight_eq_four_iff_not_linearIndependent).2 hdependent
+  have hsquare : P.pairing i j * P.pairing i j = 4 := by
+    simpa only [coxeterWeight, hcomm i j] using hweight
+  have hfactor : (P.pairing i j - 2) * (P.pairing i j + 2) = 0 := by
+    calc
+      (P.pairing i j - 2) * (P.pairing i j + 2) =
+          P.pairing i j * P.pairing i j - 4 := by ring
+      _ = 0 := by rw [hsquare, sub_self]
+  rcases mul_eq_zero.mp hfactor with htwo | hnegTwo
+  · left
+    have hij : P.pairing i j = 2 := sub_eq_zero.mp htwo
+    have hji : P.pairing j i = 2 := (hcomm i j).symm.trans hij
+    exact congrArg P.root ((P.pairing_two_two_iff i j).mp ⟨hij, hji⟩)
+  · right
+    have hij : P.pairing i j = -2 := eq_neg_of_add_eq_zero_left hnegTwo
+    have hji : P.pairing j i = -2 := (hcomm i j).symm.trans hij
+    exact (P.pairing_neg_two_neg_two_iff i j).mp ⟨hij, hji⟩
+
+end RootPairing

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -286,6 +286,7 @@ private def typeAPairEquiv (n : ℕ) : TypeAIndex n ≃ Fin n × Fin (n + 1) whe
 private def typeAIndexEquiv (n : ℕ) : TypeAIndex n ≃ Fin (n * (n + 1)) :=
   (typeAPairEquiv n).trans finProdFinEquiv
 
+/-- Reflection in the root indexed by `k`, transported to the pinned enumeration. -/
 private def typeAReflectionPerm (n : ℕ) (k : Fin (n * (n + 1))) :
     Fin (n * (n + 1)) ≃ Fin (n * (n + 1)) :=
   ((typeAIndexEquiv n).symm.trans
@@ -353,15 +354,10 @@ theorem pairing_typeASimplyConnectedRootDatum_comm (k l : Fin (n * (n + 1))) :
     root_typeASimplyConnectedRootDatum, root_typeASimplyConnectedRootDatum,
     coroot_typeASimplyConnectedRootDatum, coroot_typeASimplyConnectedRootDatum,
     typeAPairing, typeAPairing]
-  have hite (a b : Fin (n + 1)) :
-      (if a = b then (1 : ℤ) else 0) = if b = a then 1 else 0 := by
-    rcases eq_or_ne a b with rfl | hab
-    · rfl
-    · rw [ite_eq_right hab, ite_eq_right hab.symm]
-  rw [hite ((typeAIndexEquiv n).symm l).val.1 ((typeAIndexEquiv n).symm k).val.1,
-    hite ((typeAIndexEquiv n).symm l).val.1 ((typeAIndexEquiv n).symm k).val.2,
-    hite ((typeAIndexEquiv n).symm l).val.2 ((typeAIndexEquiv n).symm k).val.1,
-    hite ((typeAIndexEquiv n).symm l).val.2 ((typeAIndexEquiv n).symm k).val.2]
+  rw [ite_eq_comm ((typeAIndexEquiv n).symm l).val.1 ((typeAIndexEquiv n).symm k).val.1,
+    ite_eq_comm ((typeAIndexEquiv n).symm l).val.1 ((typeAIndexEquiv n).symm k).val.2,
+    ite_eq_comm ((typeAIndexEquiv n).symm l).val.2 ((typeAIndexEquiv n).symm k).val.1,
+    ite_eq_comm ((typeAIndexEquiv n).symm l).val.2 ((typeAIndexEquiv n).symm k).val.2]
   ring
 
 /-- The `i`-th simple root of type `Aₙ` sits at root index `i`, the Bourbaki node `i + 1`. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -345,6 +345,25 @@ private lemma pairing_typeASimplyConnectedRootDatum (k l : Fin (n * (n + 1))) :
       (typeASimplyConnectedRootDatum n).root k ⬝ᵥ (typeASimplyConnectedRootDatum n).coroot l :=
   rfl
 
+/-- The root--coroot pairing of the pinned type `A` datum is symmetric. -/
+theorem pairing_typeASimplyConnectedRootDatum_comm (k l : Fin (n * (n + 1))) :
+    (typeASimplyConnectedRootDatum n).pairing k l =
+      (typeASimplyConnectedRootDatum n).pairing l k := by
+  rw [pairing_typeASimplyConnectedRootDatum, pairing_typeASimplyConnectedRootDatum,
+    root_typeASimplyConnectedRootDatum, root_typeASimplyConnectedRootDatum,
+    coroot_typeASimplyConnectedRootDatum, coroot_typeASimplyConnectedRootDatum,
+    typeAPairing, typeAPairing]
+  have hite (a b : Fin (n + 1)) :
+      (if a = b then (1 : ℤ) else 0) = if b = a then 1 else 0 := by
+    rcases eq_or_ne a b with rfl | hab
+    · rfl
+    · rw [ite_eq_right hab, ite_eq_right hab.symm]
+  rw [hite ((typeAIndexEquiv n).symm l).val.1 ((typeAIndexEquiv n).symm k).val.1,
+    hite ((typeAIndexEquiv n).symm l).val.1 ((typeAIndexEquiv n).symm k).val.2,
+    hite ((typeAIndexEquiv n).symm l).val.2 ((typeAIndexEquiv n).symm k).val.1,
+    hite ((typeAIndexEquiv n).symm l).val.2 ((typeAIndexEquiv n).symm k).val.2]
+  ring
+
 /-- The `i`-th simple root of type `Aₙ` sits at root index `i`, the Bourbaki node `i + 1`. -/
 def typeASimpleIndex (n : ℕ) (i : Fin n) : Fin (n * (n + 1)) :=
   ⟨i, lt_of_lt_of_le i.isLt (Nat.le_mul_of_pos_right n n.succ_pos)⟩

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/D.lean
@@ -333,6 +333,16 @@ private lemma pairing_typeDSimplyConnectedRootDatum (hn : 4 ≤ n)
         (typeDSimplyConnectedRootDatum n hn).coroot l :=
   rfl
 
+/-- The root--coroot pairing of the pinned type `D` datum is symmetric. -/
+theorem pairing_typeDSimplyConnectedRootDatum_comm (hn : 4 ≤ n)
+    (k l : Fin (2 * n * (n - 1))) :
+    (typeDSimplyConnectedRootDatum n hn).pairing k l =
+      (typeDSimplyConnectedRootDatum n hn).pairing l k := by
+  rw [pairing_typeDSimplyConnectedRootDatum, pairing_typeDSimplyConnectedRootDatum,
+    root_eq_typeDWeight, root_eq_typeDWeight, coroot_eq_typeDSimpleRootCoordinates,
+    coroot_eq_typeDSimpleRootCoordinates, typeDWeight_dotProduct_coordinates,
+    typeDWeight_dotProduct_coordinates, dotProduct_comm]
+
 /-- **The simple roots are the rows of the Cartan matrix.** In the fundamental-weight basis the
 `i`-th simple root of the pinned type `Dₙ` datum is the `i`-th row of `CartanMatrix.D n`, which is
 what pins the character lattice as the weight lattice. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Reduced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Reduced.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Reduced
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Assembly
+
+/-!
+# Reducedness of the simply-laced pinned root data
+
+The pinned simply connected root data of types `A`, `D`, `E₆`, `E₇`, and `E₈` are reduced. Their
+character and cocharacter lattices use different preferred bases, so reducedness is not obtained
+by identifying each root with its coroot. Instead, their coordinate constructions all exhibit a
+symmetric root--coroot pairing. `RootPairing.isReduced_of_pairing_comm` then rules out nontrivial
+multiples among their roots.
+
+These instances supply the reducedness hypothesis needed to apply Mathlib's Geck construction to
+the rational scalar extensions of the pinned data. The non-simply-laced types require a separate
+argument because their root--coroot pairings are not symmetric.
+
+## Main results
+
+* Reducedness results for `DynkinType.typeASimplyConnectedRootDatum`,
+  `typeDSimplyConnectedRootDatum`, `e6SimplyConnectedRootDatum`,
+  `e7SimplyConnectedRootDatum`, and `e8SimplyConnectedRootDatum`.
+* `DynkinType.isReduced_simplyConnectedRootDatum_of_isSimplyLaced`: the uniform reducedness
+  theorem for every valid simply-laced Dynkin type.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plates I, IV--VII.
+* M. Geck, *On the construction of semisimple Lie algebras and Chevalley groups*.
+-/
+
+public section
+
+namespace TauCeti.DynkinType
+
+/-- The pinned simply connected root datum of type `A` is reduced. -/
+theorem isReduced_typeASimplyConnectedRootDatum (n : ℕ) :
+    (typeASimplyConnectedRootDatum n).IsReduced :=
+  RootPairing.isReduced_of_pairing_comm _ pairing_typeASimplyConnectedRootDatum_comm
+
+/-- The pinned simply connected root datum of type `D` is reduced. -/
+theorem isReduced_typeDSimplyConnectedRootDatum (n : ℕ) (hn : 4 ≤ n) :
+    (typeDSimplyConnectedRootDatum n hn).IsReduced :=
+  RootPairing.isReduced_of_pairing_comm _ (pairing_typeDSimplyConnectedRootDatum_comm hn)
+
+/-- The pinned simply connected root datum of type `E₆` is reduced. -/
+instance instIsReducedE6SimplyConnectedRootDatum : e6SimplyConnectedRootDatum.IsReduced :=
+  RootPairing.isReduced_of_pairing_comm _ fun i j => by
+    simpa only [e6SimplyConnectedRootDatum_pairing] using e6Root_dotProduct_e6Coroot_comm i j
+
+/-- The pinned simply connected root datum of type `E₇` is reduced. -/
+instance instIsReducedE7SimplyConnectedRootDatum : e7SimplyConnectedRootDatum.IsReduced :=
+  RootPairing.isReduced_of_pairing_comm _ fun i j => by
+    simpa only [e7SimplyConnectedRootDatum_pairing] using e7Root_dotProduct_e7Coroot_comm i j
+
+/-- The pinned simply connected root datum of type `E₈` is reduced. -/
+instance instIsReducedE8SimplyConnectedRootDatum : e8SimplyConnectedRootDatum.IsReduced :=
+  RootPairing.isReduced_of_pairing_comm _ fun i j => by
+    simpa only [e8SimplyConnectedRootDatum_pairing] using e8Root_dotProduct_e8Coroot_comm i j
+
+attribute [local instance] instIsReducedE6SimplyConnectedRootDatum
+  instIsReducedE7SimplyConnectedRootDatum instIsReducedE8SimplyConnectedRootDatum
+
+/-- The pinned simply connected root datum of every valid simply-laced Dynkin type is reduced. -/
+theorem isReduced_simplyConnectedRootDatum_of_isSimplyLaced (t : DynkinType) (ht : t.Valid)
+    (hs : t.IsSimplyLaced) : (t.simplyConnectedRootDatum ht).IsReduced := by
+  cases t with
+  | A n =>
+      rw [simplyConnectedRootDatum_A]
+      exact isReduced_typeASimplyConnectedRootDatum n
+  | B n => simp at hs
+  | C n => simp at hs
+  | D n =>
+      rw [simplyConnectedRootDatum_D]
+      exact isReduced_typeDSimplyConnectedRootDatum n (valid_D.mp ht)
+  | E6 =>
+      rw [simplyConnectedRootDatum_E6]
+      exact instIsReducedE6SimplyConnectedRootDatum
+  | E7 =>
+      rw [simplyConnectedRootDatum_E7]
+      exact instIsReducedE7SimplyConnectedRootDatum
+  | E8 =>
+      rw [simplyConnectedRootDatum_E8]
+      exact instIsReducedE8SimplyConnectedRootDatum
+  | F4 => simp at hs
+  | G2 => simp at hs
+
+end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Reduced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Reduced.lean
@@ -40,12 +40,12 @@ public section
 namespace TauCeti.DynkinType
 
 /-- The pinned simply connected root datum of type `A` is reduced. -/
-theorem isReduced_typeASimplyConnectedRootDatum (n : ℕ) :
+instance isReduced_typeASimplyConnectedRootDatum (n : ℕ) :
     (typeASimplyConnectedRootDatum n).IsReduced :=
   RootPairing.isReduced_of_pairing_comm _ pairing_typeASimplyConnectedRootDatum_comm
 
 /-- The pinned simply connected root datum of type `D` is reduced. -/
-theorem isReduced_typeDSimplyConnectedRootDatum (n : ℕ) (hn : 4 ≤ n) :
+instance isReduced_typeDSimplyConnectedRootDatum (n : ℕ) (hn : 4 ≤ n) :
     (typeDSimplyConnectedRootDatum n hn).IsReduced :=
   RootPairing.isReduced_of_pairing_comm _ (pairing_typeDSimplyConnectedRootDatum_comm hn)
 
@@ -63,9 +63,6 @@ instance instIsReducedE7SimplyConnectedRootDatum : e7SimplyConnectedRootDatum.Is
 instance instIsReducedE8SimplyConnectedRootDatum : e8SimplyConnectedRootDatum.IsReduced :=
   RootPairing.isReduced_of_pairing_comm _ fun i j => by
     simpa only [e8SimplyConnectedRootDatum_pairing] using e8Root_dotProduct_e8Coroot_comm i j
-
-attribute [local instance] instIsReducedE6SimplyConnectedRootDatum
-  instIsReducedE7SimplyConnectedRootDatum instIsReducedE8SimplyConnectedRootDatum
 
 /-- The pinned simply connected root datum of every valid simply-laced Dynkin type is reduced. -/
 theorem isReduced_simplyConnectedRootDatum_of_isSimplyLaced (t : DynkinType) (ht : t.Valid)


### PR DESCRIPTION
This PR proves the five simply-laced pinned simply connected root data are reduced. Derive a reusable criterion saying that a finite root pairing over a characteristic-zero domain is reduced when its root--coroot pairing is symmetric: linear dependence forces Coxeter weight four, symmetry turns that into a square equation, and Mathlib's `pairing_two_two_iff` and `pairing_neg_two_neg_two_iff` identify the roots up to sign. Apply it to the explicit data of types `A`, `D`, `E₆`, `E₇`, and `E₈`, then expose the uniform theorem `DynkinType.isReduced_simplyConnectedRootDatum_of_isSimplyLaced`.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 9 milestone “The Chevalley–Demazure construction,” specifically the split semisimple Lie algebra and Chevalley-basis input attached to each pinned simply connected root datum. Mathlib's `RootPairing.GeckConstruction` requires a reduced, crystallographic, irreducible root system; the pinned integral data and their bases are on `main`, rational scalar extension is in flight in #3678, and irreducibility from connected Cartan type is independently in flight in #3684. This PR supplies the reducedness hypothesis for every simply-laced family without enumerating pairs of roots.

This is the most effective distinct current step because the scheme-side carrier, root relations, torus, base-change, and admissible-lattice fronts are already occupied, while no open PR proves reducedness and the concrete Geck construction cannot be instantiated without it. After this PR, this prerequisite still needs reducedness for the non-simply-laced data `B`, `C`, `F₄`, and `G₂`; Layer 9 then still needs the resulting concrete Chevalley/Kostant data assembled and identified with the pinned group scheme, pinning-compatible base change, the pinned isomorphism theorem, algebraically closed points, and the characteristic-two/three special isogenies.

The downstream dependency edge is `CFSGStatement` milestone L0, declarations `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup` ← ReductiveGroups Layer 9's explicitly constructed pinned Chevalley–Demazure group ← the Geck Lie algebra of `DynkinType.simplyConnectedRootDatum`; this PR discharges reducedness for the simply-laced branches of that construction.

Add `TauCeti/LinearAlgebra/RootSystem/Reduced.lean` (62 lines) for the general symmetry criterion and `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Reduced.lean` (94 lines) for the family instances and uniform theorem. Extend the type `A` and `D` datum modules by 29 lines with their symmetric-pairing lemmas. Reuse Mathlib's Coxeter-weight characterization of linear dependence and its pairing characterizations of equal and opposite roots; no Mathlib infrastructure or external formalization is vendored. The family constructions and reduced-root-system interpretation follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plates I and IV--VII, and Geck, *On the construction of semisimple Lie algebras and Chevalley groups*, as credited in the new module.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"simply-laced-pinned-root-data-isreduced"}-->

🤖 Prepared with Codex
