### PR TITLE
feat: prove non-simply-laced root data are reduced

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
@@ -369,6 +369,19 @@ private lemma pairing_typeBSimplyConnectedRootDatum (k l : Fin (2 * n ^ 2)) :
       (typeBSimplyConnectedRootDatum n).root k ⬝ᵥ (typeBSimplyConnectedRootDatum n).coroot l :=
   (rfl)
 
+/-- Every Cartan integer between roots of the pinned type `B` datum has absolute value at most
+two. -/
+theorem abs_pairing_typeBSimplyConnectedRootDatum_le_two (k l : Fin (2 * n ^ 2)) :
+    |(typeBSimplyConnectedRootDatum n).pairing k l| ≤ 2 := by
+  rw [pairing_typeBSimplyConnectedRootDatum, root_typeBSimplyConnectedRootDatum,
+    coroot_typeBSimplyConnectedRootDatum, rootIdx_def, corootIdx_def]
+  exact abs_rootOfPair_dotProduct_corootOfPair_le_two
+    (u := ((typeBEnum n).symm k).1)
+    (v := shift ((typeBEnum n).symm k).1 ((typeBEnum n).symm k).2)
+    (p := ((typeBEnum n).symm l).1)
+    (q := shift ((typeBEnum n).symm l).1 ((typeBEnum n).symm l).2)
+    (isPair_shift _ _) (isPair_shift _ _)
+
 /-- The roots of the pinned type `Bₙ` datum are exactly the roots constructed from admissible
 unordered pairs of signed basis vectors. -/
 theorem mem_range_root_typeBSimplyConnectedRootDatum_iff {x : Fin n → ℤ} :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Model.lean
@@ -505,6 +505,50 @@ lemma rootOfPair_dotProduct_corootOfPair {u v : Fin (2 * n)} (h : IsPair u v) :
     rw [rootOfPair_of_ne huv, add_dotProduct]
     omega
 
+/-- Cartan integers between roots in the classical type `B` model have absolute value at most
+two. -/
+lemma abs_rootOfPair_dotProduct_corootOfPair_le_two {u v p q : Fin (2 * n)}
+    (huv : IsPair u v) (hpq : IsPair p q) :
+    |rootOfPair u v ⬝ᵥ corootOfPair p q| ≤ 2 := by
+  have atom_le_two (z : Fin (2 * n)) : |signedWeight z ⬝ᵥ corootOfPair p q| ≤ 2 := by
+    have hval := two_mul_dotProduct_corootOfPair z p q
+    rw [signedWeight_dotProduct_signedCoweight,
+      signedWeight_dotProduct_signedCoweight] at hval
+    rw [abs_le]
+    constructor <;> split_ifs at hval <;> omega
+  rcases eq_or_ne u v with rfl | huv_ne
+  · simpa only [rootOfPair_self] using atom_le_two u
+  rcases eq_or_ne p q with rfl | hpq_ne
+  · have haxis : axis u ≠ axis v := huv.resolve_left huv_ne
+    have huv_opp : u ≠ opp v := ne_of_axis_ne (by simpa using haxis)
+    have hvu : v ≠ u := ne_of_axis_ne haxis.symm
+    have hvu_opp : v ≠ opp u := ne_of_axis_ne (by simpa using haxis.symm)
+    rw [rootOfPair_of_ne huv_ne, corootOfPair_self, add_dotProduct,
+      signedWeight_dotProduct_signedCoweight,
+      signedWeight_dotProduct_signedCoweight, abs_le]
+    constructor <;> split_ifs <;> simp_all
+  · have atom_le_one (z : Fin (2 * n)) : |signedWeight z ⬝ᵥ corootOfPair p q| ≤ 1 := by
+      have haxis : axis p ≠ axis q := hpq.resolve_left hpq_ne
+      have hpq_opp : p ≠ opp q := ne_of_axis_ne (by simpa using haxis)
+      have hqp : q ≠ p := ne_of_axis_ne haxis.symm
+      have hqp_opp : q ≠ opp p := ne_of_axis_ne (by simpa using haxis.symm)
+      have hoppp_oppq : opp p ≠ opp q := by
+        intro h
+        exact hpq_ne (by simpa using congrArg opp h)
+      have hval := two_mul_dotProduct_corootOfPair z p q
+      rw [signedWeight_dotProduct_signedCoweight,
+        signedWeight_dotProduct_signedCoweight] at hval
+      rw [abs_le]
+      constructor <;> split_ifs at hval <;> subst_vars <;> simp_all
+    rw [rootOfPair_of_ne huv_ne, add_dotProduct]
+    have hu := atom_le_one u
+    have hv := atom_le_one v
+    calc
+      |signedWeight u ⬝ᵥ corootOfPair p q + signedWeight v ⬝ᵥ corootOfPair p q| ≤
+          |signedWeight u ⬝ᵥ corootOfPair p q| +
+            |signedWeight v ⬝ᵥ corootOfPair p q| := abs_add_le _ _
+      _ ≤ 2 := by omega
+
 /-! ## The reflection in a root -/
 
 /-- The signed permutation of the basis vectors realising the reflection in the root named by the

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
@@ -370,6 +370,14 @@ private lemma pairing_typeCSimplyConnectedRootDatum (k l : Fin (2 * n ^ 2)) :
       (typeCSimplyConnectedRootDatum n).root k ⬝ᵥ (typeCSimplyConnectedRootDatum n).coroot l :=
   rfl
 
+/-- Every Cartan integer between roots of the pinned type `C` datum has absolute value at most
+two. -/
+theorem abs_pairing_typeCSimplyConnectedRootDatum_le_two (k l : Fin (2 * n ^ 2)) :
+    |(typeCSimplyConnectedRootDatum n).pairing k l| ≤ 2 := by
+  rw [pairing_typeCSimplyConnectedRootDatum, root_typeCSimplyConnectedRootDatum,
+    coroot_typeCSimplyConnectedRootDatum]
+  exact abs_pairRoot_dotProduct_pairCoroot_le_two (typeCSnd_ne_signedNeg_typeCFst _)
+
 /-! ## The root and the coroot at an arbitrary index
 
 Away from the simple indices, a root of the datum is named by encoding a root index with

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
@@ -286,6 +286,32 @@ lemma pairRoot_dotProduct_pairCoroot_self {p q : Signed n} (h : q ≠ signedNeg 
       signedWeight_dotProduct_eq_zero hpq.symm h]
     ring
 
+/-- Cartan integers between roots in the classical type `C` model have absolute value at most
+two. -/
+lemma abs_pairRoot_dotProduct_pairCoroot_le_two {x y p q : Signed n}
+    (hpq : q ≠ signedNeg p) :
+    |pairRoot x y ⬝ᵥ pairCoroot p q| ≤ 2 := by
+  have atom_le_one (z : Signed n) : |signedWeight z ⬝ᵥ pairCoroot p q| ≤ 1 := by
+    rcases eq_or_ne p q with rfl | hpq_ne
+    · rw [pairCoroot_self, signedWeight_dotProduct_signedCoweight, abs_le]
+      constructor <;> split_ifs <;> omega
+    · rw [pairCoroot_of_ne hpq_ne, dotProduct_add,
+        signedWeight_dotProduct_signedCoweight,
+        signedWeight_dotProduct_signedCoweight, abs_le]
+      have hp_ne_neg_q : p ≠ signedNeg q := ne_signedNeg_of_ne_signedNeg hpq
+      have hnegp_ne_negq : signedNeg p ≠ signedNeg q := by
+        intro h
+        exact hpq_ne (by simpa using congrArg signedNeg h)
+      constructor <;> split_ifs <;> simp_all
+  rw [pairRoot, add_dotProduct]
+  have hx := atom_le_one x
+  have hy := atom_le_one y
+  calc
+    |signedWeight x ⬝ᵥ pairCoroot p q + signedWeight y ⬝ᵥ pairCoroot p q| ≤
+        |signedWeight x ⬝ᵥ pairCoroot p q| + |signedWeight y ⬝ᵥ pairCoroot p q| :=
+      abs_add_le _ _
+    _ ≤ 2 := by omega
+
 /-- A signed basis vector pairs to at least `1` with the coroot of `p + q` exactly when it is `p` or
 `q`. This is the recognition principle behind injectivity of the roots and coroots. -/
 lemma one_le_dotProduct_pairCoroot_iff {p q : Signed n} (h : q ≠ signedNeg p)

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/F4.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/F4.lean
@@ -302,6 +302,13 @@ noncomputable def f4SimplyConnectedRootDatum :
   rw [← RootPairing.root_coroot_eq_pairing]
   simp
 
+/-- Every Cartan integer between roots of the pinned type `F₄` datum has absolute value at most
+two. -/
+theorem abs_pairing_f4SimplyConnectedRootDatum_le_two (i j : Fin 48) :
+    |f4SimplyConnectedRootDatum.pairing i j| ≤ 2 := by
+  simp only [f4SimplyConnectedRootDatum_pairing]
+  decide +revert
+
 /-- Reflection in the root of index `i` permutes the root indices of the pinned `F4` datum by the
 explicit table `f4ReflectionIndex i`. -/
 @[simp] lemma f4SimplyConnectedRootDatum_reflectionPerm (i j : Fin 48) :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/G2.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/G2.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.RootSystem.DynkinType
 public import TauCeti.LinearAlgebra.RootSystem.Positive
+public import Mathlib.LinearAlgebra.RootSystem.Reduced
 
 public section
 
@@ -40,6 +41,7 @@ also make the reflection-stability axioms of `RootPairing` decidable finite calc
   `g2SimplyConnectedRootDatum_pairing` the lemmas that expose them.
 * Its `RootPairing.IsRootSystem` instance records that the roots and the coroots span their
   lattices; coroot spanning is the simply connected condition.
+* Its `RootPairing.IsReduced` instance rules out nontrivial scalar multiples among the roots.
 * `TauCeti.DynkinType.g2SimplyConnectedBase` is its Bourbaki-numbered base.
 * `TauCeti.DynkinType.g2SimplyConnectedRootDatum_pairing_eq_cartanMatrix_G2` pins that numbering
   entrywise: on the two base indices the Cartan integers are the Bourbaki matrix `!![2, -1; -3, 2]`.
@@ -160,6 +162,23 @@ fundamental-weight and simple-coroot bases being dual to one another. -/
 tabulated root and coroot coordinates. -/
 @[simp] lemma g2SimplyConnectedRootDatum_pairing (i j : Fin 12) :
     g2SimplyConnectedRootDatum.pairing i j = g2Root i ⬝ᵥ g2Coroot j := (rfl)
+
+/-- The pinned simply connected root datum of type `G₂` is reduced. -/
+instance instIsReducedG2SimplyConnectedRootDatum : g2SimplyConnectedRootDatum.IsReduced := by
+  constructor
+  intro i j hdependent
+  have hproduct :
+      g2SimplyConnectedRootDatum.pairing i j * g2SimplyConnectedRootDatum.pairing j i = 4 := by
+    simpa only [RootPairing.coxeterWeight] using
+      (g2SimplyConnectedRootDatum.coxeterWeight_eq_four_iff_not_linearIndependent.mpr hdependent)
+  have htable : ∀ i j : Fin 12,
+      (g2Root i ⬝ᵥ g2Coroot j) * (g2Root j ⬝ᵥ g2Coroot i) = 4 →
+        g2Root i = g2Root j ∨ g2Root i = -g2Root j := by
+    decide
+  have hproduct' :
+      (g2Root i ⬝ᵥ g2Coroot j) * (g2Root j ⬝ᵥ g2Coroot i) = 4 := by
+    simpa only [g2SimplyConnectedRootDatum_pairing] using hproduct
+  simpa only [g2SimplyConnectedRootDatum_root] using htable i j hproduct'
 
 private lemma span_g2Root_eq_top : span ℤ (range g2Root) = ⊤ := by
   apply top_unique

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/NonSimplyLaced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/NonSimplyLaced.lean
@@ -25,8 +25,8 @@ Mathlib's Geck construction to the rational scalar extensions of the pinned data
 
 ## Main results
 
-* `DynkinType.isReduced_typeBSimplyConnectedRootDatum` and
-  `DynkinType.isReduced_typeCSimplyConnectedRootDatum`: reducedness in every rank.
+* `DynkinType.instIsReducedTypeBSimplyConnectedRootDatum` and
+  `DynkinType.instIsReducedTypeCSimplyConnectedRootDatum`: reducedness in every rank.
 * `DynkinType.instIsReducedF4SimplyConnectedRootDatum` and
   `DynkinType.instIsReducedG2SimplyConnectedRootDatum`: reducedness of the exceptional data.
 * `DynkinType.isReduced_simplyConnectedRootDatum_of_not_isSimplyLaced`: the uniform theorem for
@@ -74,13 +74,13 @@ end RootPairing
 namespace TauCeti.DynkinType
 
 /-- The pinned simply connected root datum of type `B` is reduced. -/
-instance isReduced_typeBSimplyConnectedRootDatum (n : ℕ) :
+instance instIsReducedTypeBSimplyConnectedRootDatum (n : ℕ) :
     (typeBSimplyConnectedRootDatum n).IsReduced :=
   RootPairing.isReduced_of_abs_pairing_le_two _
     abs_pairing_typeBSimplyConnectedRootDatum_le_two
 
 /-- The pinned simply connected root datum of type `C` is reduced. -/
-instance isReduced_typeCSimplyConnectedRootDatum (n : ℕ) :
+instance instIsReducedTypeCSimplyConnectedRootDatum (n : ℕ) :
     (typeCSimplyConnectedRootDatum n).IsReduced :=
   RootPairing.isReduced_of_abs_pairing_le_two _
     abs_pairing_typeCSimplyConnectedRootDatum_le_two
@@ -97,10 +97,10 @@ theorem isReduced_simplyConnectedRootDatum_of_not_isSimplyLaced (t : DynkinType)
   | A n => simp at hs
   | B n =>
       rw [simplyConnectedRootDatum_B]
-      exact isReduced_typeBSimplyConnectedRootDatum n
+      exact instIsReducedTypeBSimplyConnectedRootDatum n
   | C n =>
       rw [simplyConnectedRootDatum_C]
-      exact isReduced_typeCSimplyConnectedRootDatum n
+      exact instIsReducedTypeCSimplyConnectedRootDatum n
   | D n => simp at hs
   | E6 => simp at hs
   | E7 => simp at hs

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/NonSimplyLaced.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/NonSimplyLaced.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.RootSystem.Reduced
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.Assembly
+
+/-!
+# Reducedness of the non-simply-laced pinned root data
+
+The pinned simply connected root data of types `B`, `C`, `F₄`, and `G₂` are reduced. For `B`,
+`C`, and `F₄`, the proof uses a criterion tailored to crystallographic root data over `ℤ`: if
+every Cartan integer has absolute value at most two, then two dependent roots have equal or
+opposite signs. Indeed, dependence forces the product of the two Cartan integers to be four, and
+the bound leaves only the pairs `(2, 2)` and `(-2, -2)`. Type `G₂` also has Cartan integers of
+absolute value three, so its small explicit coordinate table is checked directly instead.
+
+For the classical families, the bound follows uniformly from their signed-coordinate models. For
+`F₄`, it is checked against the explicit coordinate table that defines its root datum. These
+instances provide the remaining reducedness hypotheses needed to apply
+Mathlib's Geck construction to the rational scalar extensions of the pinned data.
+
+## Main results
+
+* `DynkinType.isReduced_typeBSimplyConnectedRootDatum` and
+  `DynkinType.isReduced_typeCSimplyConnectedRootDatum`: reducedness in every rank.
+* `DynkinType.instIsReducedF4SimplyConnectedRootDatum` and
+  `DynkinType.instIsReducedG2SimplyConnectedRootDatum`: reducedness of the exceptional data.
+* `DynkinType.isReduced_simplyConnectedRootDatum_of_not_isSimplyLaced`: the uniform theorem for
+  every valid non-simply-laced Dynkin type.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plates II, III, VIII, and IX.
+* M. Geck, *On the construction of semisimple Lie algebras and Chevalley groups*.
+-/
+
+public section
+
+open Module
+
+namespace RootPairing
+
+variable {M N : Type*} [AddCommGroup M] [Module ℤ M] [Module.IsTorsionFree ℤ M]
+  [AddCommGroup N] [Module ℤ N]
+
+/-- A finite integral root pairing is reduced when all its Cartan integers have absolute value at
+most two. -/
+private theorem isReduced_of_abs_pairing_le_two {i : Type*} [Finite i]
+    (P : RootPairing i ℤ M N) (hbound : ∀ a b, |P.pairing a b| ≤ 2) : P.IsReduced := by
+  constructor
+  intro a b hdependent
+  have hproduct : P.pairing a b * P.pairing b a = 4 := by
+    simpa only [coxeterWeight] using
+      (P.coxeterWeight_eq_four_iff_not_linearIndependent.mpr hdependent)
+  obtain ⟨hab_lower, hab_upper⟩ := abs_le.mp (hbound a b)
+  obtain ⟨hba_lower, hba_upper⟩ := abs_le.mp (hbound b a)
+  have hvalues :
+      (P.pairing a b = 2 ∧ P.pairing b a = 2) ∨
+        (P.pairing a b = -2 ∧ P.pairing b a = -2) := by
+    interval_cases hab : P.pairing a b <;>
+      interval_cases hba : P.pairing b a <;> omega
+  rcases hvalues with hpos | hneg
+  · left
+    exact congrArg P.root ((P.pairing_two_two_iff a b).mp hpos)
+  · right
+    exact (P.pairing_neg_two_neg_two_iff a b).mp hneg
+
+end RootPairing
+
+namespace TauCeti.DynkinType
+
+/-- The pinned simply connected root datum of type `B` is reduced. -/
+instance isReduced_typeBSimplyConnectedRootDatum (n : ℕ) :
+    (typeBSimplyConnectedRootDatum n).IsReduced :=
+  RootPairing.isReduced_of_abs_pairing_le_two _
+    abs_pairing_typeBSimplyConnectedRootDatum_le_two
+
+/-- The pinned simply connected root datum of type `C` is reduced. -/
+instance isReduced_typeCSimplyConnectedRootDatum (n : ℕ) :
+    (typeCSimplyConnectedRootDatum n).IsReduced :=
+  RootPairing.isReduced_of_abs_pairing_le_two _
+    abs_pairing_typeCSimplyConnectedRootDatum_le_two
+
+/-- The pinned simply connected root datum of type `F₄` is reduced. -/
+instance instIsReducedF4SimplyConnectedRootDatum : f4SimplyConnectedRootDatum.IsReduced :=
+  RootPairing.isReduced_of_abs_pairing_le_two _ abs_pairing_f4SimplyConnectedRootDatum_le_two
+
+/-- The pinned simply connected root datum of every valid non-simply-laced Dynkin type is
+reduced. -/
+theorem isReduced_simplyConnectedRootDatum_of_not_isSimplyLaced (t : DynkinType) (ht : t.Valid)
+    (hs : ¬ t.IsSimplyLaced) : (t.simplyConnectedRootDatum ht).IsReduced := by
+  cases t with
+  | A n => simp at hs
+  | B n =>
+      rw [simplyConnectedRootDatum_B]
+      exact isReduced_typeBSimplyConnectedRootDatum n
+  | C n =>
+      rw [simplyConnectedRootDatum_C]
+      exact isReduced_typeCSimplyConnectedRootDatum n
+  | D n => simp at hs
+  | E6 => simp at hs
+  | E7 => simp at hs
+  | E8 => simp at hs
+  | F4 =>
+      rw [simplyConnectedRootDatum_F4]
+      exact instIsReducedF4SimplyConnectedRootDatum
+  | G2 =>
+      rw [simplyConnectedRootDatum_G2]
+      exact instIsReducedG2SimplyConnectedRootDatum
+
+end TauCeti.DynkinType


### PR DESCRIPTION
This PR proves that the pinned simply connected root data of types `B`, `C`, `F₄`, and `G₂` are reduced, completing the non-simply-laced reducedness input to the concrete Geck Lie-algebra construction. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9 milestone “The Chevalley–Demazure construction,” specifically the split semisimple Lie algebra and Chevalley-basis input attached to each pinned simply connected root datum.

The preferred `CFSGStatement` roadmap has no viable unclaimed direct step on current `main`: I0 and S0/S1 are complete, `classificationStatement_of_zero` is in flight in #3058, and L0 explicitly depends on ReductiveGroups Layer 9. This is the most effective distinct prerequisite because rational scalar extension is in flight in #3678, irreducibility is in flight in #3684, and #3689 proves reducedness only for the simply-laced types while explicitly leaving `B`, `C`, `F₄`, and `G₂`; no other open PR covers those four families.

For `B` and `C`, add uniform signed-coordinate proofs that every Cartan integer has absolute value at most two. Check the same bound against the explicit `F₄` table, then use the finite-root-pairing identity that dependent roots have Coxeter weight four: the bound leaves only `(2, 2)` and `(-2, -2)`, which Mathlib's `pairing_two_two_iff` and `pairing_neg_two_neg_two_iff` identify with equal and opposite roots. Since `G₂` genuinely has Cartan integers of absolute value three, check its twelve-root table directly rather than applying a false uniform bound. The aggregate theorem `DynkinType.isReduced_simplyConnectedRootDatum_of_not_isSimplyLaced` exposes the result for every valid non-simply-laced Dynkin type.

After this PR, the Layer 9 milestone still needs the in-flight rational root-system, irreducibility, simply-laced reducedness, and numbering work to merge, then the normalized Chevalley/Kostant data must be assembled and identified with the pinned group scheme, with pinning-compatible base change, the pinned isomorphism theorem, algebraically closed points, and the characteristic-two/three special isogenies.

Add `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/NonSimplyLaced.lean` (115 lines) and extend the six owning family model/datum modules by 117 lines. The implementation consumes Mathlib's `RootPairing.coxeterWeight_eq_four_iff_not_linearIndependent`, `pairing_two_two_iff`, and `pairing_neg_two_neg_two_iff`; no Mathlib infrastructure or external Lean formalization is vendored. The coordinate models and reduced-root-system interpretation follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4–6*, Plates II, III, VIII, and IX, and Geck, *On the construction of semisimple Lie algebras and Chevalley groups*, as credited in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

Dependency edge: `CFSGStatement` milestone L0 declarations `ValidLieTypeIndex.AmbientGroup` and `ValidLieTypeIndex.simpleRootSubgroup` consume the explicit pinned Chevalley–Demazure group of ReductiveGroups Layer 9; that construction consumes Mathlib's Geck Lie algebra for the rational scalar extension of `DynkinType.simplyConnectedRootDatum`, which requires the reducedness instances supplied here for the four non-simply-laced families.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"non-simply-laced-pinned-root-data-isreduced"}-->

🤖 Prepared with Codex
