### PR TITLE
feat: prove continuous homotopy invariance of winding number

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
@@ -47,16 +47,20 @@ open Set
 
 namespace TauCeti.Contour
 
+/-- The extension of a constant path is the constant function on `ℝ`, hence piecewise `C¹`. -/
+private theorem isPiecewiseC1On_refl_extend (x : ℂ) :
+    IsPiecewiseC1On (Path.refl x).extend 0 1 := by
+  simpa only [Path.refl_extend, ContinuousMap.coe_const] using
+    IsPiecewiseC1On.of_contDiffOn (γ := Function.const ℝ x) contDiff_const.contDiffOn
+
 /-- A piecewise-`C¹` loop continuously homotopic to its constant path through points avoiding `w`
 has winding number zero about `w`. -/
 theorem windingNumber_eq_zero_of_pathHomotopy_refl {x w : ℂ} {p : Path x x}
     (hp : IsPiecewiseC1On p.extend 0 1) (φ : p.Homotopy (Path.refl x))
     (havoid : ∀ st : I × I, φ st ≠ w) :
     windingNumber p.extend 0 1 w = 0 := by
-  have hrefl : IsPiecewiseC1On (Path.refl x).extend 0 1 := by
-    rw [Path.refl_extend]
-    change IsPiecewiseC1On (fun _ : ℝ => x) 0 1
-    exact IsPiecewiseC1On.of_contDiffOn (contDiff_const.contDiffOn)
+  have hrefl : IsPiecewiseC1On (Path.refl x).extend 0 1 :=
+    isPiecewiseC1On_refl_extend x
   rw [windingNumber_eq_of_pathHomotopy φ hp hrefl havoid]
   rw [Path.refl_extend]
   exact windingNumber_const x 0 1 w
@@ -69,10 +73,8 @@ This is one direction only: a null-homologous loop need not be null-homotopic. -
 theorem isNullHomologous_of_pathHomotopy_refl {x : ℂ} {p : Path x x} {Ω : Set ℂ}
     (hp : IsPiecewiseC1On p.extend 0 1) (φ : p.Homotopy (Path.refl x))
     (hφΩ : ∀ st : I × I, φ st ∈ Ω) : IsNullHomologous p.extend 0 1 Ω := by
-  have hrefl : IsPiecewiseC1On (Path.refl x).extend 0 1 := by
-    rw [Path.refl_extend]
-    change IsPiecewiseC1On (fun _ : ℝ => x) 0 1
-    exact IsPiecewiseC1On.of_contDiffOn (contDiff_const.contDiffOn)
+  have hrefl : IsPiecewiseC1On (Path.refl x).extend 0 1 :=
+    isPiecewiseC1On_refl_extend x
   exact (isNullHomologous_iff_of_pathHomotopy φ hp hrefl hφΩ).2
     (by
       rw [Path.refl_extend]

--- a/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
@@ -12,20 +12,20 @@ import TauCeti.Analysis.Contour.HomologyCauchy
 /-!
 # Cauchy's theorem for null-homotopic contours
 
-A closed path that is smoothly homotopic to its constant path inside an open set is
+A closed piecewise-`C¹` path continuously homotopic to its constant path inside an open set is
 null-homologous there. Consequently, the homology form of Cauchy's theorem makes the contour
 integral of every holomorphic function vanish along such a path. This supplies the
 null-homotopic special case explicitly requested in Layer 3 of the Contour Integration roadmap.
 
-The homotopy is represented by Mathlib's `Path.Homotopy`, and the same `C²` regularity used by
-`windingNumber_eq_of_pathHomotopy` is retained. That regularity supplies a piecewise-`C¹` source
-path, matching the raw-curve interface expected by `homologyCauchyTheorem`.
+The homotopy is represented by Mathlib's `Path.Homotopy`; no differentiability of it is required.
+The source path itself is assumed piecewise `C¹`, matching the raw-curve interface expected by
+`homologyCauchyTheorem`.
 
 ## Main results
 
-* `windingNumber_eq_zero_of_pathHomotopy_refl` — a loop smoothly homotopic to its constant path
+* `windingNumber_eq_zero_of_pathHomotopy_refl` — a loop continuously homotopic to its constant path
   through a point-avoiding homotopy has winding number zero about that point.
-* `isNullHomologous_of_pathHomotopy_refl` — a loop smoothly contracted inside `Ω` is
+* `isNullHomologous_of_pathHomotopy_refl` — a loop continuously contracted inside `Ω` is
   null-homologous in `Ω`.
 * `cauchyTheorem_of_pathHomotopy_refl` — Cauchy's theorem for such a contractible contour.
 
@@ -47,46 +47,48 @@ open Set
 
 namespace TauCeti.Contour
 
-/-- A loop smoothly homotopic to its constant path through points avoiding `w` has winding number
-zero about `w`. -/
+/-- A piecewise-`C¹` loop continuously homotopic to its constant path through points avoiding `w`
+has winding number zero about `w`. -/
 theorem windingNumber_eq_zero_of_pathHomotopy_refl {x w : ℂ} {p : Path x x}
-    (φ : p.Homotopy (Path.refl x)) (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
-    (havoid : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ≠ w) :
+    (hp : IsPiecewiseC1On p.extend 0 1) (φ : p.Homotopy (Path.refl x))
+    (havoid : ∀ st : I × I, φ st ≠ w) :
     windingNumber p.extend 0 1 w = 0 := by
-  rw [windingNumber_eq_of_pathHomotopy φ hφsmooth havoid]
+  have hrefl : IsPiecewiseC1On (Path.refl x).extend 0 1 := by
+    rw [Path.refl_extend]
+    change IsPiecewiseC1On (fun _ : ℝ => x) 0 1
+    exact IsPiecewiseC1On.of_contDiffOn (contDiff_const.contDiffOn)
+  rw [windingNumber_eq_of_pathHomotopy φ hp hrefl havoid]
   rw [Path.refl_extend]
   exact windingNumber_const x 0 1 w
 
-/-- **Null-homotopic implies null-homologous.** If a loop admits a `C²` path homotopy to its
-constant path whose image lies in `Ω`, then its generalized winding number vanishes at every point
-outside `Ω`. Thus the loop is null-homologous in `Ω`.
+/-- **Null-homotopic implies null-homologous.** If a piecewise-`C¹` loop admits a continuous path
+homotopy to its constant path whose image lies in `Ω`, then its generalized winding number vanishes
+at every point outside `Ω`. Thus the loop is null-homologous in `Ω`.
 
 This is one direction only: a null-homologous loop need not be null-homotopic. -/
 theorem isNullHomologous_of_pathHomotopy_refl {x : ℂ} {p : Path x x} {Ω : Set ℂ}
-    (φ : p.Homotopy (Path.refl x)) (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
-    (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω) :
-    IsNullHomologous p.extend 0 1 Ω :=
-  (isNullHomologous_iff_of_pathHomotopy φ hφsmooth hφΩ).2
+    (hp : IsPiecewiseC1On p.extend 0 1) (φ : p.Homotopy (Path.refl x))
+    (hφΩ : ∀ st : I × I, φ st ∈ Ω) : IsNullHomologous p.extend 0 1 Ω := by
+  have hrefl : IsPiecewiseC1On (Path.refl x).extend 0 1 := by
+    rw [Path.refl_extend]
+    change IsPiecewiseC1On (fun _ : ℝ => x) 0 1
+    exact IsPiecewiseC1On.of_contDiffOn (contDiff_const.contDiffOn)
+  exact (isNullHomologous_iff_of_pathHomotopy φ hp hrefl hφΩ).2
     (by
       rw [Path.refl_extend]
       exact isNullHomologous_const x 0 1 Ω)
 
 /-- **Cauchy's theorem for a null-homotopic contour.** Let `p` be a piecewise-`C¹` loop admitting
-a `C²` path homotopy to its constant path inside an open set `Ω`. If `f` is holomorphic on `Ω`,
-then the contour integral of `f` along `p` vanishes.
+a continuous path homotopy to its constant path inside an open set `Ω`. If `f` is holomorphic on
+`Ω`, then the contour integral of `f` along `p` vanishes.
 
-The smooth homotopy supplies the piecewise-`C¹` regularity expected by
-`homologyCauchyTheorem`, as well as containment of the source path in `Ω` and its null-homology
-there. -/
+The path regularity is exactly what `homologyCauchyTheorem` expects; the homotopy supplies
+containment of the source path in `Ω` and its null-homology there. -/
 theorem cauchyTheorem_of_pathHomotopy_refl {f : ℂ → ℂ} {Ω : Set ℂ} (hΩ : IsOpen Ω)
-    {x : ℂ} (p : Path x x) (φ : p.Homotopy (Path.refl x)) (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
-    (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω) (hf : DifferentiableOn ℂ f Ω) :
+    {x : ℂ} (p : Path x x) (hp : IsPiecewiseC1On p.extend 0 1)
+    (φ : p.Homotopy (Path.refl x)) (hφΩ : ∀ st : I × I, φ st ∈ Ω)
+    (hf : DifferentiableOn ℂ f Ω) :
     ∫ t in (0 : ℝ)..1, deriv p.extend t • f (p.extend t) = 0 := by
-  have hp : IsPiecewiseC1On p.extend 0 1 := by
-    simpa using isPiecewiseC1On_eval_of_smoothPathHomotopy φ hφsmooth (0 : I)
   apply homologyCauchyTheorem hΩ p.extend 0 1 hp
   · intro t ht
     rw [uIcc_of_le zero_le_one] at ht
@@ -94,7 +96,7 @@ theorem cauchyTheorem_of_pathHomotopy_refl {f : ℂ → ℂ} {Ω : Set ℂ} (hΩ
     simpa using hφΩ ((0 : Set.Icc (0 : ℝ) 1), ⟨t, ht⟩)
   · simp only [Path.extend_zero, Path.extend_one]
   · exact hf
-  · exact isNullHomologous_of_pathHomotopy_refl φ hφsmooth hφΩ
+  · exact isNullHomologous_of_pathHomotopy_refl hp φ hφΩ
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
@@ -23,10 +23,10 @@ The source path itself is assumed piecewise `C¹`, matching the raw-curve interf
 
 ## Main results
 
-* `windingNumber_eq_zero_of_pathHomotopy_refl` — a loop continuously homotopic to its constant path
-  through a point-avoiding homotopy has winding number zero about that point.
-* `isNullHomologous_of_pathHomotopy_refl` — a loop continuously contracted inside `Ω` is
-  null-homologous in `Ω`.
+* `windingNumber_eq_zero_of_pathHomotopy_refl` — a piecewise-`C¹` loop continuously homotopic to
+  its constant path through a point-avoiding homotopy has winding number zero about that point.
+* `isNullHomologous_of_pathHomotopy_refl` — a piecewise-`C¹` loop continuously contracted inside
+  `Ω` is null-homologous in `Ω`.
 * `cauchyTheorem_of_pathHomotopy_refl` — Cauchy's theorem for such a contractible contour.
 
 ## Provenance

--- a/TauCeti/Analysis/Contour/Curve/Approximation.lean
+++ b/TauCeti/Analysis/Contour/Curve/Approximation.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Calculus.ContDiff.Basic
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Analysis.SpecialFunctions.Bernstein
+import Mathlib.Analysis.Calculus.ContDiff.Polynomial
+import Mathlib.Topology.ContinuousMap.Compact
+
+/-!
+# Smooth endpoint-preserving approximation of continuous complex curves
+
+Every continuous map from the unit interval to `ℂ` is uniformly approximated, to any positive
+tolerance, by a smooth curve on `ℝ` taking the same values at `0` and `1`. The approximants are
+Mathlib's Bernstein approximations, read as polynomial functions on all of `ℝ`, which is what makes
+their smoothness and their endpoint values immediate.
+
+## Main results
+
+* `TauCeti.Contour.exists_contDiff_eq_endpoints_dist_lt` — the endpoint-preserving smooth
+  approximation.
+
+This is the regularization step that lets the merely continuous intermediate paths of a path
+homotopy be compared with the piecewise-`C¹` winding number.
+
+## Provenance
+
+The construction and its uniform convergence are Mathlib's `bernsteinApproximation` and
+`bernsteinApproximation_uniform`; the polynomials themselves are Mathlib's `bernsteinPolynomial`.
+No formal source is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open scoped unitInterval
+
+namespace TauCeti.Contour
+
+/-- Mathlib's `n`-th Bernstein approximation of `f`, read as a polynomial function on all of `ℝ`.
+Keeping the polynomial off the unit interval makes its smoothness immediate, while
+`bernsteinCurve_apply` connects it to Mathlib's uniform approximation theorem. -/
+private def bernsteinCurve (n : ℕ) (f : C(I, ℂ)) (t : ℝ) : ℂ :=
+  ∑ k : Fin (n + 1), Polynomial.aeval t (bernsteinPolynomial ℝ n k) • f (bernstein.z k)
+
+private theorem bernsteinCurve_apply (n : ℕ) (f : C(I, ℂ)) (t : I) :
+    bernsteinCurve n f t = bernsteinApproximation n f t := by
+  simp [bernsteinCurve, bernsteinApproximation.apply, bernstein, Polynomial.coe_aeval_eq_eval]
+
+private theorem contDiff_bernsteinCurve (n : ℕ) (f : C(I, ℂ)) :
+    ContDiff ℝ ⊤ (bernsteinCurve n f) :=
+  ContDiff.sum fun _ _ => (Polynomial.contDiff_aeval _ _).smul_const _
+
+/-- **Endpoint-preserving smooth approximation of a continuous complex path.** Every continuous map
+from the unit interval to `ℂ` is uniformly approximated, to any positive tolerance, by a smooth
+curve on `ℝ` with the same values at `0` and `1`.
+
+The approximants are Mathlib's Bernstein approximations, read as polynomial functions on `ℝ`; a
+consumer needing only piecewise-`C¹` regularity gets it from `IsPiecewiseC1On.of_contDiffOn`. -/
+theorem exists_contDiff_eq_endpoints_dist_lt (f : C(I, ℂ)) {ε : ℝ} (hε : 0 < ε) :
+    ∃ γ : ℝ → ℂ, ContDiff ℝ ⊤ γ ∧ γ 0 = f 0 ∧ γ 1 = f 1 ∧ ∀ t : I, dist (γ t) (f t) < ε := by
+  obtain ⟨N, hN⟩ := Metric.tendsto_atTop.mp (bernsteinApproximation_uniform f) ε hε
+  let n := max N 1
+  have hnN : N ≤ n := Nat.le_max_left _ _
+  have hn : n ≠ 0 := Nat.ne_of_gt (lt_of_lt_of_le Nat.zero_lt_one (Nat.le_max_right _ _))
+  refine ⟨bernsteinCurve n f, contDiff_bernsteinCurve n f, ?_, ?_, ?_⟩
+  · exact (bernsteinCurve_apply n f 0).trans (bernsteinApproximation.apply_zero n f)
+  · exact (bernsteinCurve_apply n f 1).trans (bernsteinApproximation.apply_one hn f)
+  · intro t
+    rw [bernsteinCurve_apply]
+    exact (ContinuousMap.dist_apply_le_dist t).trans_lt (hN n hnN)
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Curve/Approximation.lean
+++ b/TauCeti/Analysis/Contour/Curve/Approximation.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.Calculus.ContDiff.Basic
 public import Mathlib.Analysis.Complex.Basic
-public import Mathlib.Analysis.SpecialFunctions.Bernstein
+import Mathlib.Analysis.SpecialFunctions.Bernstein
 import Mathlib.Analysis.Calculus.ContDiff.Polynomial
 import Mathlib.Topology.ContinuousMap.Compact
 

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -35,7 +35,7 @@ theorem.
   in a smooth homotopy.
 * `curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy` is the smooth Stokes step: a `C²` homotopy
   through `ℂ \ {w}` preserves the curve integral of the Cauchy-kernel `1`-form.
-* `exists_isPiecewiseC1On_dist_lt_of_continuousMap` gives endpoint-preserving smooth
+* `exists_isPiecewiseC1On_dist_lt_of_continuousMap` gives endpoint-preserving piecewise-`C¹`
   approximations of continuous complex paths.
 * `windingNumber_eq_of_pathHomotopy` proves the Layer 0 homotopy invariance result without any
   regularity hypothesis on the homotopy.
@@ -76,13 +76,15 @@ private theorem contDiff_bernsteinCurve (n : ℕ) (f : C(I, ℂ)) :
   unfold bernsteinCurve
   fun_prop
 
-/-- **Endpoint-preserving smooth approximation of a continuous complex path.** Every continuous
-map from the unit interval to `ℂ` is uniformly approximated, to any positive tolerance, by a
-globally smooth curve with the same values at `0` and `1`.
+/-- **Endpoint-preserving piecewise-`C¹` approximation of a continuous complex path.** Every
+continuous map from the unit interval to `ℂ` is uniformly approximated, to any positive
+tolerance, by a piecewise-`C¹` curve with the same values at `0` and `1`.
 
-The approximants are Mathlib's Bernstein approximations, interpreted as polynomials on `ℝ`.
-This is the regularization step used to compare the merely continuous intermediate paths of a
-path homotopy with Tau Ceti's piecewise-`C¹` winding number. -/
+The approximants are Mathlib's Bernstein approximations, interpreted as polynomials on `ℝ`, so
+they are in fact globally smooth; the conclusion records only the piecewise-`C¹` regularity that
+the winding number consumes. This is the regularization step used to compare the merely
+continuous intermediate paths of a path homotopy with Tau Ceti's piecewise-`C¹` winding
+number. -/
 theorem exists_isPiecewiseC1On_dist_lt_of_continuousMap (f : C(I, ℂ)) {ε : ℝ} (hε : 0 < ε) :
     ∃ γ : ℝ → ℂ, IsPiecewiseC1On γ 0 1 ∧ γ 0 = f 0 ∧ γ 1 = f 1 ∧
       ∀ t : I, dist (γ t) (f t) < ε := by
@@ -249,8 +251,9 @@ theorem windingNumber_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y} (φ : p.
       (div_pos hρ (by norm_num))
   have hγpw (k : Fin (N + 1)) : IsPiecewiseC1On (γ k) 0 1 := (hγ k).1
   have hγclose (k : Fin (N + 1)) (t : I) : dist (γ k t) (φ (bernstein.z k, t)) < ρ / 5 := by
-    change dist (γ k t) ((φ.eval (bernstein.z k)) t) < ρ / 5
-    simpa only [slice, Path.coe_toContinuousMap] using (hγ k).2.2.2 t
+    simpa only [slice, Path.coe_toContinuousMap, Path.Homotopy.eval_apply,
+      ContinuousMap.Homotopy.curry_apply, ContinuousMap.HomotopyWith.coe_toHomotopy] using
+      (hγ k).2.2.2 t
   have hγzero (k : Fin (N + 1)) : γ k 0 = x := by
     calc
       γ k 0 = slice k 0 := (hγ k).2.1

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -9,46 +9,36 @@ public import TauCeti.Analysis.Contour.PiecewiseC1On
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import Mathlib.MeasureTheory.Integral.CurveIntegral.Basic
 public import Mathlib.Topology.Homotopy.Path
+import TauCeti.Analysis.Contour.Curve.Approximation
 import TauCeti.Analysis.Contour.NullHomologous
 import TauCeti.Analysis.Contour.Winding.Proximity
-import Mathlib.Analysis.Calculus.Deriv.Inv
 import Mathlib.Analysis.SpecialFunctions.Bernstein
-import Mathlib.MeasureTheory.Integral.CurveIntegral.Poincare
 
 /-!
 # Homotopy invariance of the winding number
 
-The winding number of a piecewise-`C¹` path about `w` is invariant under an arbitrary continuous
-fixed-endpoint homotopy through `ℂ \ {w}`. The proof regularizes finitely many horizontal slices
-by Mathlib's endpoint-preserving Bernstein approximations, then chains the resulting smooth paths
-with proximity invariance of the winding number.
-
-The earlier smooth route remains available at the level where it has distinct content: a `C²`
-homotopy preserves the actual curve integral of the Cauchy-kernel `1`-form by Mathlib's Poincaré
-theorem.
+Two piecewise-`C¹` paths with the same endpoints, joined by an arbitrary continuous fixed-endpoint
+homotopy through `ℂ \ {w}`, have the same winding number about `w`. The proof regularizes finitely
+many horizontal slices of the homotopy by endpoint-preserving smooth approximations, then chains
+the resulting smooth paths with proximity invariance of the winding number.
 
 ## Main results
 
 * `windingNumber_eq_two_pi_I_inv_mul_curveIntegral` identifies Tau Ceti's raw-function winding
   number of a piecewise-`C¹` path with Mathlib's curve integral of the Cauchy-kernel `1`-form.
-* `isPiecewiseC1On_eval_of_smoothPathHomotopy` supplies piecewise-`C¹` regularity for every path
-  in a smooth homotopy.
-* `curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy` is the smooth Stokes step: a `C²` homotopy
-  through `ℂ \ {w}` preserves the curve integral of the Cauchy-kernel `1`-form.
-* `exists_isPiecewiseC1On_dist_lt_of_continuousMap` gives endpoint-preserving piecewise-`C¹`
-  approximations of continuous complex paths.
 * `windingNumber_eq_of_pathHomotopy` proves the Layer 0 homotopy invariance result without any
   regularity hypothesis on the homotopy.
+* `curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy` is its curve-integral form: such a homotopy
+  preserves the integral of the Cauchy-kernel `1`-form.
 * `isNullHomologous_iff_of_pathHomotopy` transfers null-homology across a homotopy in the ambient
   set.
 
 ## Provenance
 
-The continuous homotopy step reuses Mathlib's `bernsteinApproximation_uniform`; the independent
-smooth curve-integral statement reuses
-`ContinuousMap.Homotopy.curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt`. No formal source
-is vendored. Homotopy invariance of the classical winding number is standard complex analysis; see
-the references in the Contour Integration roadmap.
+The regularization step is `exists_contDiff_eq_endpoints_dist_lt`, which reuses Mathlib's
+`bernsteinApproximation_uniform`. No formal source is vendored. Homotopy invariance of the
+classical winding number is standard complex analysis; see the references in the Contour
+Integration roadmap.
 -/
 
 public section
@@ -59,71 +49,6 @@ open scoped unitInterval
 open MeasureTheory Set
 
 namespace TauCeti.Contour
-
-/-- The polynomial on `ℝ` underlying Mathlib's `n`-th Bernstein approximation of `f` on the
-unit interval. Keeping the polynomial formula on all of `ℝ` makes its contour regularity
-immediate, while `bernsteinCurve_apply` connects it to Mathlib's uniform approximation theorem. -/
-private def bernsteinCurve (n : ℕ) (f : C(I, ℂ)) (t : ℝ) : ℂ :=
-  ∑ k : Fin (n + 1),
-    ((n.choose k : ℝ) * t ^ (k : ℕ) * (1 - t) ^ (n - (k : ℕ))) • f (bernstein.z k)
-
-private theorem bernsteinCurve_apply (n : ℕ) (f : C(I, ℂ)) (t : I) :
-    bernsteinCurve n f t = bernsteinApproximation n f t := by
-  simp only [bernsteinCurve, bernsteinApproximation.apply, bernstein_apply]
-
-private theorem contDiff_bernsteinCurve (n : ℕ) (f : C(I, ℂ)) :
-    ContDiff ℝ ⊤ (bernsteinCurve n f) := by
-  unfold bernsteinCurve
-  fun_prop
-
-/-- **Endpoint-preserving piecewise-`C¹` approximation of a continuous complex path.** Every
-continuous map from the unit interval to `ℂ` is uniformly approximated, to any positive
-tolerance, by a piecewise-`C¹` curve with the same values at `0` and `1`.
-
-The approximants are Mathlib's Bernstein approximations, interpreted as polynomials on `ℝ`, so
-they are in fact globally smooth; the conclusion records only the piecewise-`C¹` regularity that
-the winding number consumes. This is the regularization step used to compare the merely
-continuous intermediate paths of a path homotopy with Tau Ceti's piecewise-`C¹` winding
-number. -/
-theorem exists_isPiecewiseC1On_dist_lt_of_continuousMap (f : C(I, ℂ)) {ε : ℝ} (hε : 0 < ε) :
-    ∃ γ : ℝ → ℂ, IsPiecewiseC1On γ 0 1 ∧ γ 0 = f 0 ∧ γ 1 = f 1 ∧
-      ∀ t : I, dist (γ t) (f t) < ε := by
-  obtain ⟨N, hN⟩ := Metric.tendsto_atTop.mp (bernsteinApproximation_uniform f) ε hε
-  let n := max N 1
-  have hnN : N ≤ n := Nat.le_max_left _ _
-  have hn : n ≠ 0 := Nat.ne_of_gt (lt_of_lt_of_le Nat.zero_lt_one (Nat.le_max_right _ _))
-  refine ⟨bernsteinCurve n f,
-    IsPiecewiseC1On.of_contDiffOn ((contDiff_bernsteinCurve n f).contDiffOn.of_le (by norm_num)),
-    ?_, ?_, ?_⟩
-  · exact (bernsteinCurve_apply n f 0).trans (bernsteinApproximation.apply_zero n f)
-  · exact (bernsteinCurve_apply n f 1).trans (bernsteinApproximation.apply_one hn f)
-  · intro t
-    rw [bernsteinCurve_apply]
-    exact (ContinuousMap.dist_apply_le_dist t).trans_lt (hN n hnN)
-
-private def indexForm (w : ℂ) : ℂ → ℂ →L[ℂ] ℂ :=
-  fun z => (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ
-
-private def indexFormDeriv (w z : ℂ) : ℂ →L[ℝ] (ℂ →L[ℂ] ℂ) :=
-  ((1 : ℂ →L[ℂ] ℂ).smulRight (-((z - w) ^ 2)⁻¹) |>.smulRight
-    (ContinuousLinearMap.id ℂ ℂ)).restrictScalars ℝ
-
-private theorem hasFDerivAt_indexForm {w z : ℂ} (hzw : z ≠ w) :
-    HasFDerivAt (indexForm w) (indexFormDeriv w z) z := by
-  have hscalar : HasDerivAt (fun y : ℂ => (y - w)⁻¹) (-((z - w) ^ 2)⁻¹) z := by
-    convert ((hasDerivAt_id z).sub_const w).inv (sub_ne_zero.mpr hzw) using 1
-    · rfl
-    · rfl
-    · rfl
-    · simp [div_eq_mul_inv]
-  exact (hscalar.hasFDerivAt.smul_const (ContinuousLinearMap.id ℂ ℂ)).restrictScalars ℝ
-
-private theorem indexFormDeriv_apply_comm (w z u v : ℂ) :
-    indexFormDeriv w z u v = indexFormDeriv w z v u := by
-  have happly (x y : ℂ) : indexFormDeriv w z x y = x * (-((z - w) ^ 2)⁻¹) * y := by
-    simp [indexFormDeriv, mul_assoc]
-  rw [happly, happly]
-  ring
 
 /-- For a piecewise-`C¹` path avoiding `w`, its winding number about `w` is the normalized curve
 integral of the closed `1`-form `z ↦ (z - w)⁻¹ dz`. This is the bridge from Tau Ceti's raw-function
@@ -144,61 +69,6 @@ theorem windingNumber_eq_two_pi_I_inv_mul_curveIntegral {x y w : ℂ} {p : Path 
     curveIntegral_eq_intervalIntegral_deriv]
   simp only [smul_apply, ContinuousLinearMap.id_apply, smul_eq_mul]
 
-/-- If the extension of a path homotopy is `C²` on the unit square, then every intermediate
-path, extended constantly from the unit interval to `ℝ`, is piecewise `C¹` on `[0, 1]`. -/
-theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x y : ℂ} {p q : Path x y} (φ : p.Homotopy q)
-    (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
-    (s : I) :
-    IsPiecewiseC1On (φ.eval s).extend 0 1 := by
-  apply IsPiecewiseC1On.of_contDiffOn
-  rw [Set.uIcc_of_le zero_le_one]
-  have hs : ContDiffOn ℝ 1
-      ((fun st : ℝ × ℝ ↦
-        Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) ∘
-        fun t : ℝ => ((s, t) : ℝ × ℝ)) (Set.Icc 0 1) :=
-    (hφsmooth.of_le (by norm_num)).comp (by fun_prop)
-      (fun t ht => by
-        simpa [Prod.le_def] using ⟨⟨s.2.1, ht.1⟩, ⟨s.2.2, ht.2⟩⟩)
-  exact hs.congr fun _ _ => by simp [Path.extend, Path.Homotopy.eval]
-
-/-- **A path homotopy avoiding `w` preserves the curve integral of the Cauchy kernel.** Paths with
-the same endpoints, joined by a `C²` homotopy through `ℂ \ {w}`, have equal integrals of the
-`1`-form `z ↦ (z - w)⁻¹ dz`. -/
-theorem curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y}
-    (φ : p.Homotopy q)
-    (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
-    (haway : ∀ z ∈ Set.range φ, z ≠ w) :
-    (∫ᶜ z in p, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ) =
-      ∫ᶜ z in q, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ := by
-  -- `indexForm w` is the private abbreviation for this integrand; fold it so the closedness and
-  -- derivative lemmas below, which are stated for it, apply.
-  change (∫ᶜ z in p, indexForm w z) = ∫ᶜ z in q, indexForm w z
-  have hrange : IsClosed (Set.range φ) :=
-    (isCompact_range φ.toHomotopy.continuous).isClosed
-  have hclosedForm : ∀ z ∈ Set.range φ,
-      HasFDerivWithinAt (indexForm w) (indexFormDeriv w z) (Set.range φ) z :=
-    fun z hz ↦ (hasFDerivAt_indexForm (haway z hz)).hasFDerivWithinAt
-  have hcontinuousForm : ContinuousOn (indexForm w) (closure (Set.range φ)) := by
-    rw [hrange.closure_eq]
-    exact fun z hz ↦ (hasFDerivAt_indexForm (haway z hz)).continuousAt.continuousWithinAt
-  have hboundary :=
-    φ.toHomotopy.curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt
-      (t := Set.range φ) (ω := indexForm w) (dω := indexFormDeriv w)
-      (fun s _ t _ ↦ Set.mem_range_self (s, t)) hclosedForm hcontinuousForm
-      (fun z _ u _ v _ ↦ indexFormDeriv_apply_comm w z u v) hφsmooth
-  have heval_zero :
-      φ.toHomotopy.evalAt 0 = (Path.refl x).cast p.source q.source := by
-    ext t
-    exact φ.source t
-  have heval_one :
-      φ.toHomotopy.evalAt 1 = (Path.refl y).cast p.target q.target := by
-    ext t
-    exact φ.target t
-  rw [heval_zero, heval_one] at hboundary
-  simpa only [curveIntegral_cast, curveIntegral_refl, add_zero] using hboundary
-
 /-- A continuous path homotopy avoiding `w` stays a uniformly positive distance from `w`, since
 its domain is the compact unit square. -/
 private theorem exists_pathHomotopy_dist_lower_bound {x y w : ℂ} {p q : Path x y}
@@ -214,7 +84,8 @@ private theorem exists_pathHomotopy_dist_lower_bound {x y w : ℂ} {p q : Path x
   simpa [dist_comm] using Metric.infDist_le_dist_of_mem (x := w) (Set.mem_range_self st)
 
 /-- Uniform continuity lets a path homotopy be divided into finitely many nearby horizontal
-slices. The stages use `bernstein.z`, the same uniform mesh used by the smooth approximants. -/
+slices. The stages are the equally spaced points `bernstein.z k` for a mesh size `N` supplied by
+uniform continuity; the degree of the approximants regularizing each slice is chosen separately. -/
 private theorem exists_nat_dist_pathHomotopy_stage_lt {x y : ℂ} {p q : Path x y}
     (φ : p.Homotopy q) {ε : ℝ} (hε : 0 < ε) :
     ∃ N : ℕ, N ≠ 0 ∧ ∀ k : Fin N, ∀ t : I,
@@ -231,9 +102,24 @@ private theorem exists_nat_dist_pathHomotopy_stage_lt {x y : ℂ} {p q : Path x 
   have hsub : (((k : ℕ) + 1 : ℕ) : ℝ) / N - ((k : ℕ) : ℝ) / N = 1 / N := by
     push_cast
     ring
-  simp only [bernstein.z, Subtype.dist_eq, Real.dist_eq, Fin.succ, Fin.castSucc, Fin.val_castAdd]
+  simp only [bernstein.z, Subtype.dist_eq, Real.dist_eq, Fin.val_succ, Fin.val_castSucc]
   rw [hsub, abs_of_pos (by positivity), max_eq_left (by positivity)]
   exact hmesh
+
+/-- The unit-interval form of the leash lemma used to chain the approximants below: two
+piecewise-`C¹` curves with common endpoints that stay within `c` of one another, one of which
+stays at distance at least `c` from `w`, have the same winding number about `w`. -/
+private theorem windingNumber_eq_of_dist_lt_of_le_dist {γ δ : ℝ → ℂ} {w : ℂ} {c : ℝ}
+    (hγ : IsPiecewiseC1On γ 0 1) (hδ : IsPiecewiseC1On δ 0 1) (h₀ : γ 0 = δ 0) (h₁ : γ 1 = δ 1)
+    (hclose : ∀ t : I, dist (γ t) (δ t) < c) (hfar : ∀ t : I, c ≤ dist (δ t) w) :
+    windingNumber γ 0 1 w = windingNumber δ 0 1 w := by
+  refine hδ.windingNumber_eq_of_dist_lt_dist_of_eq_endpoints hγ h₀.symm h₁.symm fun t ht => ?_
+  rw [Set.uIcc_of_le zero_le_one] at ht
+  have hcoe : ((⟨t, ht⟩ : I) : ℝ) = t := rfl
+  have hc := hclose ⟨t, ht⟩
+  have hf := hfar ⟨t, ht⟩
+  rw [hcoe] at hc hf
+  exact hc.trans_le hf
 
 /-- **Homotopy invariance of the winding number off the curve.** Two piecewise-`C¹` paths with the
 same endpoints, joined through `ℂ \ {w}` by an arbitrary continuous path homotopy, have the same
@@ -247,9 +133,9 @@ theorem windingNumber_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y} (φ : p.
     (0 : ℝ) < 5))
   let slice : Fin (N + 1) → C(I, ℂ) := fun k => (φ.eval (bernstein.z k)).toContinuousMap
   choose γ hγ using fun k : Fin (N + 1) =>
-    exists_isPiecewiseC1On_dist_lt_of_continuousMap (slice k) (ε := ρ / 5)
-      (div_pos hρ (by norm_num))
-  have hγpw (k : Fin (N + 1)) : IsPiecewiseC1On (γ k) 0 1 := (hγ k).1
+    exists_contDiff_eq_endpoints_dist_lt (slice k) (ε := ρ / 5) (div_pos hρ (by norm_num))
+  have hγpw (k : Fin (N + 1)) : IsPiecewiseC1On (γ k) 0 1 :=
+    IsPiecewiseC1On.of_contDiffOn ((hγ k).1.contDiffOn.of_le (by norm_num))
   have hγclose (k : Fin (N + 1)) (t : I) : dist (γ k t) (φ (bernstein.z k, t)) < ρ / 5 := by
     simpa only [slice, Path.coe_toContinuousMap, Path.Homotopy.eval_apply,
       ContinuousMap.Homotopy.curry_apply, ContinuousMap.HomotopyWith.coe_toHomotopy] using
@@ -268,71 +154,72 @@ theorem windingNumber_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y} (φ : p.
     have hclose := hγclose k t
     rw [dist_comm (φ (bernstein.z k, t)) (γ k t)] at htriangle
     linarith
-  -- Consecutive smooth approximants are close enough for the dog-on-a-leash lemma.
+  -- Consecutive approximants are close enough for the leash lemma.
   have hadjacent (k : Fin N) : windingNumber (γ k.succ) 0 1 w =
       windingNumber (γ k.castSucc) 0 1 w := by
-    apply (hγpw k.castSucc).windingNumber_eq_of_dist_lt_dist_of_eq_endpoints (hγpw k.succ)
-      ((hγzero k.castSucc).trans (hγzero k.succ).symm)
-      ((hγone k.castSucc).trans (hγone k.succ).symm)
-    intro t ht
-    let tI : I := ⟨t, by simpa [Set.uIcc_of_le zero_le_one] using ht⟩
-    have h₁ := hγclose k.succ tI
-    have h₂ := hstage k tI
-    have h₃ := hγclose k.castSucc tI
-    have hupper : dist (γ k.succ t) (γ k.castSucc t) < 3 * ρ / 5 := by
-      calc
+    refine windingNumber_eq_of_dist_lt_of_le_dist (c := 3 * ρ / 5) (hγpw k.succ) (hγpw k.castSucc)
+      ((hγzero k.succ).trans (hγzero k.castSucc).symm)
+      ((hγone k.succ).trans (hγone k.castSucc).symm) (fun t => ?_) (fun t => ?_)
+    · calc
         dist (γ k.succ t) (γ k.castSucc t) ≤
-            dist (γ k.succ t) (φ (bernstein.z k.succ, tI)) +
-              dist (φ (bernstein.z k.succ, tI)) (γ k.castSucc t) := dist_triangle _ _ _
-        _ ≤ dist (γ k.succ t) (φ (bernstein.z k.succ, tI)) +
-              (dist (φ (bernstein.z k.succ, tI)) (φ (bernstein.z k.castSucc, tI)) +
-                dist (φ (bernstein.z k.castSucc, tI)) (γ k.castSucc t)) := by
+            dist (γ k.succ t) (φ (bernstein.z k.succ, t)) +
+              dist (φ (bernstein.z k.succ, t)) (γ k.castSucc t) := dist_triangle _ _ _
+        _ ≤ dist (γ k.succ t) (φ (bernstein.z k.succ, t)) +
+              (dist (φ (bernstein.z k.succ, t)) (φ (bernstein.z k.castSucc, t)) +
+                dist (φ (bernstein.z k.castSucc, t)) (γ k.castSucc t)) := by
                   gcongr
                   exact dist_triangle _ _ _
-        _ < 3 * ρ / 5 := by rw [dist_comm (φ _ ) (γ k.castSucc t)]; linarith
-    exact hupper.trans (by linarith [hγdist k.castSucc tI])
+        _ < 3 * ρ / 5 := by
+              rw [dist_comm (φ (bernstein.z k.castSucc, t)) (γ k.castSucc t)]
+              linarith [hγclose k.succ t, hstage k t, hγclose k.castSucc t]
+    · linarith [hγdist k.castSucc t]
   -- Chain the finitely many approximants from homotopy time `0` to time `1`.
-  have hchain : ∀ k : ℕ, ∀ hk : k ≤ N,
-      windingNumber (γ ⟨k, Nat.lt_succ_iff.mpr hk⟩) 0 1 w = windingNumber (γ 0) 0 1 w := by
-    intro k
-    induction k with
-    | zero => intro _; rfl
-    | succ k ih =>
-      intro hk
-      have hkN : k < N := Nat.lt_of_succ_le hk
-      exact (hadjacent ⟨k, hkN⟩).trans (ih hkN.le)
-  have hchain_final : windingNumber (γ (Fin.last N)) 0 1 w = windingNumber (γ 0) 0 1 w := by
-    simpa only [Fin.last] using hchain N le_rfl
+  have hchain (k : Fin (N + 1)) : windingNumber (γ k) 0 1 w = windingNumber (γ 0) 0 1 w := by
+    induction k using Fin.induction with
+    | zero => rfl
+    | succ k ih => exact (hadjacent k).trans ih
   -- The first and last approximants are close to the original endpoint paths.
   have hstart : windingNumber (γ 0) 0 1 w = windingNumber p.extend 0 1 w := by
-    apply hp.windingNumber_eq_of_dist_lt_dist_of_eq_endpoints (hγpw 0)
+    have hp_apply (t : I) : p.extend t = φ (0, t) := by
+      rw [Path.extend_extends' p t]
+      simp
+    refine windingNumber_eq_of_dist_lt_of_le_dist (c := ρ / 5) (hγpw 0) hp
       (by rw [Path.extend_zero, hγzero]) (by rw [Path.extend_one, hγone])
-    intro t ht
-    let tI : I := ⟨t, by simpa [Set.uIcc_of_le zero_le_one] using ht⟩
-    have hp_apply : p.extend t = φ (0, tI) := by
-      calc
-        p.extend t = p tI := Path.extend_apply p tI.property
-        _ = φ (0, tI) := by simp
-    have hclose : dist (γ 0 t) (p.extend t) < ρ / 5 := by
-      rw [hp_apply]
-      simpa using hγclose 0 tI
-    exact hclose.trans (by rw [hp_apply]; linarith [hρle (0, tI)])
-  have hend : windingNumber q.extend 0 1 w = windingNumber (γ (Fin.last N)) 0 1 w := by
-    apply (hγpw (Fin.last N)).windingNumber_eq_of_dist_lt_dist_of_eq_endpoints hq
+      (fun t => ?_) (fun t => ?_)
+    · rw [hp_apply t]
+      simpa using hγclose 0 t
+    · rw [hp_apply t]
+      linarith [hρle (0, t)]
+  have hend : windingNumber (γ (Fin.last N)) 0 1 w = windingNumber q.extend 0 1 w := by
+    have hq_apply (t : I) : q.extend t = φ (1, t) := by
+      rw [Path.extend_extends' q t]
+      simp
+    have hz : bernstein.z (Fin.last N) = (1 : I) := bernstein.z_last hN
+    refine windingNumber_eq_of_dist_lt_of_le_dist (c := ρ / 5) (hγpw (Fin.last N)) hq
       (by rw [Path.extend_zero, hγzero]) (by rw [Path.extend_one, hγone])
-    intro t ht
-    let tI : I := ⟨t, by simpa [Set.uIcc_of_le zero_le_one] using ht⟩
-    have hq_apply : q.extend t = φ (1, tI) := by
-      calc
-        q.extend t = q tI := Path.extend_apply q tI.property
-        _ = φ (1, tI) := by simp
-    have hz : bernstein.z (Fin.last N) = 1 := bernstein.z_last hN
-    have hφz : φ (bernstein.z (Fin.last N), tI) = φ (1, tI) := by rw [hz]
-    have hclose : dist (q.extend t) (γ (Fin.last N) t) < ρ / 5 := by
-      rw [hq_apply, ← hφz, dist_comm]
-      exact hγclose (Fin.last N) tI
-    exact hclose.trans (by linarith [hγdist (Fin.last N) tI])
-  exact hstart.symm.trans (hchain_final.symm.trans hend.symm)
+      (fun t => ?_) (fun t => ?_)
+    · rw [hq_apply t]
+      simpa [hz] using hγclose (Fin.last N) t
+    · rw [hq_apply t]
+      linarith [hρle (1, t)]
+  exact hstart.symm.trans ((hchain (Fin.last N)).symm.trans hend)
+
+/-- **A path homotopy avoiding `w` preserves the curve integral of the Cauchy kernel.** Two
+piecewise-`C¹` paths with the same endpoints, joined by an arbitrary continuous homotopy through
+`ℂ \ {w}`, have equal integrals of the `1`-form `z ↦ (z - w)⁻¹ dz`. This is the curve-integral
+restatement of `windingNumber_eq_of_pathHomotopy`. -/
+theorem curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y}
+    (φ : p.Homotopy q) (hp : IsPiecewiseC1On p.extend 0 1) (hq : IsPiecewiseC1On q.extend 0 1)
+    (haway : ∀ z ∈ Set.range φ, z ≠ w) :
+    (∫ᶜ z in p, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ) =
+      ∫ᶜ z in q, (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ := by
+  have hne : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero two_ne_zero (Complex.ofReal_ne_zero.mpr Real.pi_ne_zero))
+      Complex.I_ne_zero
+  have hwind := windingNumber_eq_of_pathHomotopy φ hp hq fun st => haway _ ⟨st, rfl⟩
+  rw [windingNumber_eq_two_pi_I_inv_mul_curveIntegral hp (fun t ↦ haway _ ⟨(0, t), by simp⟩),
+    windingNumber_eq_two_pi_I_inv_mul_curveIntegral hq (fun t ↦ haway _ ⟨(1, t), by simp⟩)] at hwind
+  exact mul_left_cancel₀ (inv_ne_zero hne) hwind
 
 /-- Null-homology in `Ω` is invariant under an arbitrary continuous path homotopy whose image lies
 in `Ω`. The endpoint paths themselves are piecewise `C¹`; no regularity is assumed of the

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -10,16 +10,22 @@ public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import Mathlib.MeasureTheory.Integral.CurveIntegral.Basic
 public import Mathlib.Topology.Homotopy.Path
 import TauCeti.Analysis.Contour.NullHomologous
+import TauCeti.Analysis.Contour.Winding.Proximity
 import Mathlib.Analysis.Calculus.Deriv.Inv
+import Mathlib.Analysis.SpecialFunctions.Bernstein
 import Mathlib.MeasureTheory.Integral.CurveIntegral.Poincare
 
 /-!
 # Homotopy invariance of the winding number
 
-The winding number of a path about `w` is invariant under a twice continuously differentiable
-fixed-endpoint homotopy through `ℂ \ {w}`. The proof represents the Cauchy kernel as the closed
-complex-linear `1`-form `z ↦ (z - w)⁻¹ dz`, then applies Mathlib's Poincaré theorem for curve
-integrals on the compact image of the homotopy.
+The winding number of a piecewise-`C¹` path about `w` is invariant under an arbitrary continuous
+fixed-endpoint homotopy through `ℂ \ {w}`. The proof regularizes finitely many horizontal slices
+by Mathlib's endpoint-preserving Bernstein approximations, then chains the resulting smooth paths
+with proximity invariance of the winding number.
+
+The earlier smooth route remains available at the level where it has distinct content: a `C²`
+homotopy preserves the actual curve integral of the Cauchy-kernel `1`-form by Mathlib's Poincaré
+theorem.
 
 ## Main results
 
@@ -27,16 +33,20 @@ integrals on the compact image of the homotopy.
   number of a piecewise-`C¹` path with Mathlib's curve integral of the Cauchy-kernel `1`-form.
 * `isPiecewiseC1On_eval_of_smoothPathHomotopy` supplies piecewise-`C¹` regularity for every path
   in a smooth homotopy.
-* `curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy` is the Stokes step: a homotopy through
-  `ℂ \ {w}` preserves the curve integral of the Cauchy-kernel `1`-form.
-* `windingNumber_eq_of_pathHomotopy` proves the Layer 0 homotopy invariance result.
+* `curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy` is the smooth Stokes step: a `C²` homotopy
+  through `ℂ \ {w}` preserves the curve integral of the Cauchy-kernel `1`-form.
+* `exists_isPiecewiseC1On_dist_lt_of_continuousMap` gives endpoint-preserving smooth
+  approximations of continuous complex paths.
+* `windingNumber_eq_of_pathHomotopy` proves the Layer 0 homotopy invariance result without any
+  regularity hypothesis on the homotopy.
 * `isNullHomologous_iff_of_pathHomotopy` transfers null-homology across a homotopy in the ambient
   set.
 
 ## Provenance
 
-The homotopy step reuses Mathlib's
-`ContinuousMap.Homotopy.curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt`; no formal source
+The continuous homotopy step reuses Mathlib's `bernsteinApproximation_uniform`; the independent
+smooth curve-integral statement reuses
+`ContinuousMap.Homotopy.curveIntegral_add_curveIntegral_eq_of_hasFDerivWithinAt`. No formal source
 is vendored. Homotopy invariance of the classical winding number is standard complex analysis; see
 the references in the Contour Integration roadmap.
 -/
@@ -49,6 +59,45 @@ open scoped unitInterval
 open MeasureTheory Set
 
 namespace TauCeti.Contour
+
+/-- The polynomial on `ℝ` underlying Mathlib's `n`-th Bernstein approximation of `f` on the
+unit interval. Keeping the polynomial formula on all of `ℝ` makes its contour regularity
+immediate, while `bernsteinCurve_apply` connects it to Mathlib's uniform approximation theorem. -/
+private def bernsteinCurve (n : ℕ) (f : C(I, ℂ)) (t : ℝ) : ℂ :=
+  ∑ k : Fin (n + 1),
+    ((n.choose k : ℝ) * t ^ (k : ℕ) * (1 - t) ^ (n - (k : ℕ))) • f (bernstein.z k)
+
+private theorem bernsteinCurve_apply (n : ℕ) (f : C(I, ℂ)) (t : I) :
+    bernsteinCurve n f t = bernsteinApproximation n f t := by
+  simp only [bernsteinCurve, bernsteinApproximation.apply, bernstein_apply]
+
+private theorem contDiff_bernsteinCurve (n : ℕ) (f : C(I, ℂ)) :
+    ContDiff ℝ ⊤ (bernsteinCurve n f) := by
+  unfold bernsteinCurve
+  fun_prop
+
+/-- **Endpoint-preserving smooth approximation of a continuous complex path.** Every continuous
+map from the unit interval to `ℂ` is uniformly approximated, to any positive tolerance, by a
+globally smooth curve with the same values at `0` and `1`.
+
+The approximants are Mathlib's Bernstein approximations, interpreted as polynomials on `ℝ`.
+This is the regularization step used to compare the merely continuous intermediate paths of a
+path homotopy with Tau Ceti's piecewise-`C¹` winding number. -/
+theorem exists_isPiecewiseC1On_dist_lt_of_continuousMap (f : C(I, ℂ)) {ε : ℝ} (hε : 0 < ε) :
+    ∃ γ : ℝ → ℂ, IsPiecewiseC1On γ 0 1 ∧ γ 0 = f 0 ∧ γ 1 = f 1 ∧
+      ∀ t : I, dist (γ t) (f t) < ε := by
+  obtain ⟨N, hN⟩ := Metric.tendsto_atTop.mp (bernsteinApproximation_uniform f) ε hε
+  let n := max N 1
+  have hnN : N ≤ n := Nat.le_max_left _ _
+  have hn : n ≠ 0 := Nat.ne_of_gt (lt_of_lt_of_le Nat.zero_lt_one (Nat.le_max_right _ _))
+  refine ⟨bernsteinCurve n f,
+    IsPiecewiseC1On.of_contDiffOn ((contDiff_bernsteinCurve n f).contDiffOn.of_le (by norm_num)),
+    ?_, ?_, ?_⟩
+  · exact (bernsteinCurve_apply n f 0).trans (bernsteinApproximation.apply_zero n f)
+  · exact (bernsteinCurve_apply n f 1).trans (bernsteinApproximation.apply_one hn f)
+  · intro t
+    rw [bernsteinCurve_apply]
+    exact (ContinuousMap.dist_apply_le_dist t).trans_lt (hN n hnN)
 
 private def indexForm (w : ℂ) : ℂ → ℂ →L[ℂ] ℂ :=
   fun z => (z - w)⁻¹ • ContinuousLinearMap.id ℂ ℂ
@@ -148,45 +197,156 @@ theorem curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy {x y w : ℂ} {p q : Pa
   rw [heval_zero, heval_one] at hboundary
   simpa only [curveIntegral_cast, curveIntegral_refl, add_zero] using hboundary
 
-/-- **Homotopy invariance of the winding number off the curve.** Two paths with the same endpoints,
-joined through `ℂ \ {w}` by a path homotopy whose extension to the unit square is `C²`, have the
-same winding number about `w`. -/
-theorem windingNumber_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y} (φ : p.Homotopy q)
-    (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
-    (havoid : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ≠ w) :
-    windingNumber p.extend 0 1 w = windingNumber q.extend 0 1 w := by
-  have haway : ∀ z ∈ Set.range φ, z ≠ w := by
-    rintro _ ⟨st, rfl⟩
-    exact havoid st
-  have hcurve' := curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy φ hφsmooth haway
-  have hp : IsPiecewiseC1On p.extend 0 1 := by
-    simpa using isPiecewiseC1On_eval_of_smoothPathHomotopy φ hφsmooth (0 : I)
-  have hq : IsPiecewiseC1On q.extend 0 1 := by
-    simpa using isPiecewiseC1On_eval_of_smoothPathHomotopy φ hφsmooth (1 : I)
-  rw [windingNumber_eq_two_pi_I_inv_mul_curveIntegral
-      hp
-      (fun t ↦ haway _ ⟨(0, t), by simp⟩),
-    windingNumber_eq_two_pi_I_inv_mul_curveIntegral
-      hq
-      (fun t ↦ haway _ ⟨(1, t), by simp⟩),
-    hcurve']
+/-- A continuous path homotopy avoiding `w` stays a uniformly positive distance from `w`, since
+its domain is the compact unit square. -/
+private theorem exists_pathHomotopy_dist_lower_bound {x y w : ℂ} {p q : Path x y}
+    (φ : p.Homotopy q) (havoid : ∀ st : I × I, φ st ≠ w) :
+    ∃ ρ > 0, ∀ st : I × I, ρ ≤ dist (φ st) w := by
+  have hcompact : IsCompact (Set.range φ) := isCompact_range φ.toHomotopy.continuous
+  have hnonempty : (Set.range φ).Nonempty := Set.range_nonempty φ
+  have hw : w ∉ Set.range φ := by
+    rintro ⟨st, hst⟩
+    exact havoid st hst
+  refine ⟨Metric.infDist w (Set.range φ),
+    (hcompact.isClosed.notMem_iff_infDist_pos hnonempty).mp hw, fun st => ?_⟩
+  simpa [dist_comm] using Metric.infDist_le_dist_of_mem (x := w) (Set.mem_range_self st)
 
-/-- Null-homology in `Ω` is invariant under a `C²` path homotopy whose image lies in `Ω`. -/
+/-- Uniform continuity lets a path homotopy be divided into finitely many nearby horizontal
+slices. The stages use `bernstein.z`, the same uniform mesh used by the smooth approximants. -/
+private theorem exists_nat_dist_pathHomotopy_stage_lt {x y : ℂ} {p q : Path x y}
+    (φ : p.Homotopy q) {ε : ℝ} (hε : 0 < ε) :
+    ∃ N : ℕ, N ≠ 0 ∧ ∀ k : Fin N, ∀ t : I,
+      dist (φ (bernstein.z k.succ, t)) (φ (bernstein.z k.castSucc, t)) < ε := by
+  obtain ⟨δ, hδ, hclose⟩ := Metric.uniformContinuous_iff.mp
+    (CompactSpace.uniformContinuous_of_continuous φ.toHomotopy.continuous) ε hε
+  obtain ⟨N, hN⟩ := exists_nat_gt (1 / δ)
+  have hNpos : (0 : ℝ) < N := lt_of_le_of_lt (by positivity) hN
+  have hmesh : 1 / (N : ℝ) < δ := by
+    rw [div_lt_iff₀ hNpos]
+    simpa [mul_comm] using (div_lt_iff₀ hδ).mp hN
+  refine ⟨N, Nat.ne_of_gt (by exact_mod_cast hNpos), fun k t => hclose ?_⟩
+  simp only [Prod.dist_eq, dist_self]
+  have hsub : (((k : ℕ) + 1 : ℕ) : ℝ) / N - ((k : ℕ) : ℝ) / N = 1 / N := by
+    push_cast
+    ring
+  simp only [bernstein.z, Subtype.dist_eq, Real.dist_eq, Fin.succ, Fin.castSucc, Fin.val_castAdd]
+  rw [hsub, abs_of_pos (by positivity), max_eq_left (by positivity)]
+  exact hmesh
+
+/-- **Homotopy invariance of the winding number off the curve.** Two piecewise-`C¹` paths with the
+same endpoints, joined through `ℂ \ {w}` by an arbitrary continuous path homotopy, have the same
+winding number about `w`. No differentiability of the homotopy is required. -/
+theorem windingNumber_eq_of_pathHomotopy {x y w : ℂ} {p q : Path x y} (φ : p.Homotopy q)
+    (hp : IsPiecewiseC1On p.extend 0 1) (hq : IsPiecewiseC1On q.extend 0 1)
+    (havoid : ∀ st : I × I, φ st ≠ w) :
+    windingNumber p.extend 0 1 w = windingNumber q.extend 0 1 w := by
+  obtain ⟨ρ, hρ, hρle⟩ := exists_pathHomotopy_dist_lower_bound φ havoid
+  obtain ⟨N, hN, hstage⟩ := exists_nat_dist_pathHomotopy_stage_lt φ (div_pos hρ (by norm_num :
+    (0 : ℝ) < 5))
+  let slice : Fin (N + 1) → C(I, ℂ) := fun k => (φ.eval (bernstein.z k)).toContinuousMap
+  choose γ hγ using fun k : Fin (N + 1) =>
+    exists_isPiecewiseC1On_dist_lt_of_continuousMap (slice k) (ε := ρ / 5)
+      (div_pos hρ (by norm_num))
+  have hγpw (k : Fin (N + 1)) : IsPiecewiseC1On (γ k) 0 1 := (hγ k).1
+  have hγclose (k : Fin (N + 1)) (t : I) : dist (γ k t) (φ (bernstein.z k, t)) < ρ / 5 := by
+    change dist (γ k t) ((φ.eval (bernstein.z k)) t) < ρ / 5
+    simpa only [slice, Path.coe_toContinuousMap] using (hγ k).2.2.2 t
+  have hγzero (k : Fin (N + 1)) : γ k 0 = x := by
+    calc
+      γ k 0 = slice k 0 := (hγ k).2.1
+      _ = x := by simp [slice]
+  have hγone (k : Fin (N + 1)) : γ k 1 = y := by
+    calc
+      γ k 1 = slice k 1 := (hγ k).2.2.1
+      _ = y := by simp [slice]
+  have hγdist (k : Fin (N + 1)) (t : I) : 4 * ρ / 5 < dist (γ k t) w := by
+    have htriangle := dist_triangle (φ (bernstein.z k, t)) (γ k t) w
+    have hlower := hρle (bernstein.z k, t)
+    have hclose := hγclose k t
+    rw [dist_comm (φ (bernstein.z k, t)) (γ k t)] at htriangle
+    linarith
+  -- Consecutive smooth approximants are close enough for the dog-on-a-leash lemma.
+  have hadjacent (k : Fin N) : windingNumber (γ k.succ) 0 1 w =
+      windingNumber (γ k.castSucc) 0 1 w := by
+    apply (hγpw k.castSucc).windingNumber_eq_of_dist_lt_dist_of_eq_endpoints (hγpw k.succ)
+      ((hγzero k.castSucc).trans (hγzero k.succ).symm)
+      ((hγone k.castSucc).trans (hγone k.succ).symm)
+    intro t ht
+    let tI : I := ⟨t, by simpa [Set.uIcc_of_le zero_le_one] using ht⟩
+    have h₁ := hγclose k.succ tI
+    have h₂ := hstage k tI
+    have h₃ := hγclose k.castSucc tI
+    have hupper : dist (γ k.succ t) (γ k.castSucc t) < 3 * ρ / 5 := by
+      calc
+        dist (γ k.succ t) (γ k.castSucc t) ≤
+            dist (γ k.succ t) (φ (bernstein.z k.succ, tI)) +
+              dist (φ (bernstein.z k.succ, tI)) (γ k.castSucc t) := dist_triangle _ _ _
+        _ ≤ dist (γ k.succ t) (φ (bernstein.z k.succ, tI)) +
+              (dist (φ (bernstein.z k.succ, tI)) (φ (bernstein.z k.castSucc, tI)) +
+                dist (φ (bernstein.z k.castSucc, tI)) (γ k.castSucc t)) := by
+                  gcongr
+                  exact dist_triangle _ _ _
+        _ < 3 * ρ / 5 := by rw [dist_comm (φ _ ) (γ k.castSucc t)]; linarith
+    exact hupper.trans (by linarith [hγdist k.castSucc tI])
+  -- Chain the finitely many approximants from homotopy time `0` to time `1`.
+  have hchain : ∀ k : ℕ, ∀ hk : k ≤ N,
+      windingNumber (γ ⟨k, Nat.lt_succ_iff.mpr hk⟩) 0 1 w = windingNumber (γ 0) 0 1 w := by
+    intro k
+    induction k with
+    | zero => intro _; rfl
+    | succ k ih =>
+      intro hk
+      have hkN : k < N := Nat.lt_of_succ_le hk
+      exact (hadjacent ⟨k, hkN⟩).trans (ih hkN.le)
+  have hchain_final : windingNumber (γ (Fin.last N)) 0 1 w = windingNumber (γ 0) 0 1 w := by
+    simpa only [Fin.last] using hchain N le_rfl
+  -- The first and last approximants are close to the original endpoint paths.
+  have hstart : windingNumber (γ 0) 0 1 w = windingNumber p.extend 0 1 w := by
+    apply hp.windingNumber_eq_of_dist_lt_dist_of_eq_endpoints (hγpw 0)
+      (by rw [Path.extend_zero, hγzero]) (by rw [Path.extend_one, hγone])
+    intro t ht
+    let tI : I := ⟨t, by simpa [Set.uIcc_of_le zero_le_one] using ht⟩
+    have hp_apply : p.extend t = φ (0, tI) := by
+      calc
+        p.extend t = p tI := Path.extend_apply p tI.property
+        _ = φ (0, tI) := by simp
+    have hclose : dist (γ 0 t) (p.extend t) < ρ / 5 := by
+      rw [hp_apply]
+      simpa using hγclose 0 tI
+    exact hclose.trans (by rw [hp_apply]; linarith [hρle (0, tI)])
+  have hend : windingNumber q.extend 0 1 w = windingNumber (γ (Fin.last N)) 0 1 w := by
+    apply (hγpw (Fin.last N)).windingNumber_eq_of_dist_lt_dist_of_eq_endpoints hq
+      (by rw [Path.extend_zero, hγzero]) (by rw [Path.extend_one, hγone])
+    intro t ht
+    let tI : I := ⟨t, by simpa [Set.uIcc_of_le zero_le_one] using ht⟩
+    have hq_apply : q.extend t = φ (1, tI) := by
+      calc
+        q.extend t = q tI := Path.extend_apply q tI.property
+        _ = φ (1, tI) := by simp
+    have hz : bernstein.z (Fin.last N) = 1 := bernstein.z_last hN
+    have hφz : φ (bernstein.z (Fin.last N), tI) = φ (1, tI) := by rw [hz]
+    have hclose : dist (q.extend t) (γ (Fin.last N) t) < ρ / 5 := by
+      rw [hq_apply, ← hφz, dist_comm]
+      exact hγclose (Fin.last N) tI
+    exact hclose.trans (by linarith [hγdist (Fin.last N) tI])
+  exact hstart.symm.trans (hchain_final.symm.trans hend.symm)
+
+/-- Null-homology in `Ω` is invariant under an arbitrary continuous path homotopy whose image lies
+in `Ω`. The endpoint paths themselves are piecewise `C¹`; no regularity is assumed of the
+intermediate paths. -/
 theorem isNullHomologous_iff_of_pathHomotopy {x y : ℂ} {p q : Path x y} {Ω : Set ℂ}
     (φ : p.Homotopy q)
-    (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
-    (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω) :
+    (hp : IsPiecewiseC1On p.extend 0 1) (hq : IsPiecewiseC1On q.extend 0 1)
+    (hφΩ : ∀ st : I × I, φ st ∈ Ω) :
     IsNullHomologous p.extend 0 1 Ω ↔ IsNullHomologous q.extend 0 1 Ω := by
   constructor
   · intro h
     exact h.congr_windingNumber fun z hz ↦
-      (windingNumber_eq_of_pathHomotopy φ hφsmooth
+      (windingNumber_eq_of_pathHomotopy φ hp hq
         (fun st (hst : φ st = z) ↦ hz (hst ▸ hφΩ st))).symm
   · intro h
     exact h.congr_windingNumber fun z hz ↦
-      windingNumber_eq_of_pathHomotopy φ hφsmooth
+      windingNumber_eq_of_pathHomotopy φ hp hq
         (fun st (hst : φ st = z) ↦ hz (hst ▸ hφΩ st))
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/Winding/Proximity.lean
+++ b/TauCeti/Analysis/Contour/Winding/Proximity.lean
@@ -27,10 +27,8 @@ winding number about `0` therefore vanishes, because the closed left half-plane 
 connected subset of the complement of its image. Since the index integrands satisfy
 `σ' / σ = γ₁' / (γ₁ - w) - γ₀' / (γ₀ - w)` pointwise, that vanishing is the asserted equality.
 
-The Layer 0 item this serves is homotopy invariance of the winding number off the curve. What was
-already available (`Contour.windingNumber_eq_of_pathHomotopy`) needs a path homotopy whose
-extension to the square is `C²`; the results here need no regularity of the homotopy whatsoever.
-In particular `Contour.IsPiecewiseC1On.windingNumber_eq_of_notMem_segment` deduces invariance
+The Layer 0 item this serves is homotopy invariance of the winding number off the curve.
+`Contour.IsPiecewiseC1On.windingNumber_eq_of_notMem_segment` deduces invariance
 along the straight-line homotopy `s ↦ (1 - s) • γ₀ + s • γ₁` from the purely geometric hypothesis
 that the segment `[γ₀ t, γ₁ t]` misses `w` for every parameter `t`: the intermediate curves are
 piecewise `C¹` because that predicate is stable under affine combinations, and a compactness
@@ -43,6 +41,8 @@ estimate lets finitely many of them be chained together by the leash lemma.
   `dist (γ₁ t) (γ₀ t) < dist (γ₀ t) w` throughout, have equal winding numbers about `w`.
 * `Contour.IsPiecewiseC1On.windingNumber_eq_of_dist_lt_dist` — the same for closed piecewise-`C¹`
   curves, whose regularity supplies the raw hypotheses on its own.
+* `Contour.IsPiecewiseC1On.windingNumber_eq_of_dist_lt_dist_of_eq_endpoints` — the common-endpoint
+  version for paths that need not be closed.
 * `Contour.IsPiecewiseC1On.windingNumber_eq_of_notMem_segment` — invariance along the
   straight-line homotopy: if `w ∉ [γ₀ t, γ₁ t]` for every `t`, the winding numbers agree.
 
@@ -127,18 +127,16 @@ private theorem not_isBounded_connectedComponentIn_compl {S : Set ℂ} (hS : ∀
   rw [Complex.norm_real, Real.norm_eq_abs, abs_of_nonpos (by linarith), neg_neg] at hle
   linarith
 
-/-- **Proximity invariance of the winding number** (the "dog on a leash" lemma). Let `γ₀` and `γ₁`
-be closed curves on the oriented interval with endpoints `a`, `b`, each continuous on
-`Set.uIcc a b`, differentiable off a common countable set `P`, and with interval-integrable
-derivative. If at every parameter the two curves are closer to each other than `γ₀` is to `w`,
-then they have the same winding number about `w`.
+/-- Core comparison-quotient form of proximity invariance. The raw curves are regular enough to
+integrate, stay within leash distance, and have a closed comparison quotient. The public closed
+curve and common-endpoint forms below supply the last hypothesis.
 
 The comparison quotient `σ = (γ₁ - w) / (γ₀ - w)` is then a closed curve inside the open right
 half-plane, so `0` lies in an unbounded component of the complement of its image and
 `n_0(σ) = 0`; pointwise `σ' / σ = γ₁' / (γ₁ - w) - γ₀' / (γ₀ - w)`, so `n_0(σ)` is the difference
 of the two winding numbers. -/
-theorem windingNumber_eq_of_dist_lt_dist {P : Set ℝ} (hP : P.Countable)
-    (h₀closed : γ₀ a = γ₀ b) (h₁closed : γ₁ a = γ₁ b)
+private theorem windingNumber_eq_of_dist_lt_dist_aux {P : Set ℝ} (hP : P.Countable)
+    (hσclosed : compRatio γ₀ γ₁ w a = compRatio γ₀ γ₁ w b)
     (h₀cont : ContinuousOn γ₀ (uIcc a b)) (h₁cont : ContinuousOn γ₁ (uIcc a b))
     (h₀diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ₀ t)
     (h₁diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ₁ t)
@@ -158,8 +156,6 @@ theorem windingNumber_eq_of_dist_lt_dist {P : Set ℝ} (hP : P.Countable)
   -- Regularity of the comparison quotient.
   have hσcont : ContinuousOn (compRatio γ₀ γ₁ w) (uIcc a b) :=
     (h₁cont.sub continuousOn_const).div (h₀cont.sub continuousOn_const) h₀ne
-  have hσclosed : compRatio γ₀ γ₁ w a = compRatio γ₀ γ₁ w b := by
-    rw [compRatio_apply, compRatio_apply, h₀closed, h₁closed]
   have hσhas : ∀ t ∈ Ioo (min a b) (max a b) \ P, HasDerivAt (compRatio γ₀ γ₁ w)
       ((deriv γ₁ t * (γ₀ t - w) - (γ₁ t - w) * deriv γ₀ t) / (γ₀ t - w) ^ 2) t := by
     intro t ht
@@ -221,6 +217,24 @@ theorem windingNumber_eq_of_dist_lt_dist {P : Set ℝ} (hP : P.Countable)
       (fun t ht => sub_ne_zero.mp (h₀ne t ht)) hint₀] at hσzero
   exact sub_eq_zero.mp hσzero
 
+/-- **Proximity invariance of the winding number** (the "dog on a leash" lemma). Let `γ₀` and `γ₁`
+be closed curves on the oriented interval with endpoints `a`, `b`, each continuous on
+`Set.uIcc a b`, differentiable off a common countable set `P`, and with interval-integrable
+derivative. If at every parameter the two curves are closer to each other than `γ₀` is to `w`,
+then they have the same winding number about `w`. -/
+theorem windingNumber_eq_of_dist_lt_dist {P : Set ℝ} (hP : P.Countable)
+    (h₀closed : γ₀ a = γ₀ b) (h₁closed : γ₁ a = γ₁ b)
+    (h₀cont : ContinuousOn γ₀ (uIcc a b)) (h₁cont : ContinuousOn γ₁ (uIcc a b))
+    (h₀diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ₀ t)
+    (h₁diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ₁ t)
+    (h₀int : IntervalIntegrable (fun t => deriv γ₀ t) volume a b)
+    (h₁int : IntervalIntegrable (fun t => deriv γ₁ t) volume a b)
+    (hlt : ∀ t ∈ uIcc a b, dist (γ₁ t) (γ₀ t) < dist (γ₀ t) w) :
+    windingNumber γ₁ a b w = windingNumber γ₀ a b w := by
+  apply windingNumber_eq_of_dist_lt_dist_aux hP
+    (by rw [compRatio_apply, compRatio_apply, h₀closed, h₁closed])
+    h₀cont h₁cont h₀diff h₁diff h₀int h₁int hlt
+
 /-- **Proximity invariance for closed piecewise-`C¹` curves.** If two closed piecewise-`C¹` curves
 stay closer to each other than the first stays to `w`, they have the same winding number about `w`.
 Piecewise-`C¹` regularity supplies the continuity, differentiability and integrability hypotheses
@@ -236,6 +250,25 @@ theorem IsPiecewiseC1On.windingNumber_eq_of_dist_lt_dist (h₀ : IsPiecewiseC1On
     (fun t ht => hdiff₀ t ⟨ht.1, fun hmem => ht.2 (Or.inl hmem)⟩)
     (fun t ht => hdiff₁ t ⟨ht.1, fun hmem => ht.2 (Or.inr hmem)⟩)
     h₀.intervalIntegrable_deriv h₁.intervalIntegrable_deriv hlt
+
+/-- **Proximity invariance for paths with common endpoints.** If two piecewise-`C¹` paths agree at
+both endpoints and stay closer to each other than the first stays to `w`, then they have the same
+winding number about `w`. Unlike `IsPiecewiseC1On.windingNumber_eq_of_dist_lt_dist`, the paths need
+not be closed; their common endpoints make the comparison quotient a closed curve. -/
+theorem IsPiecewiseC1On.windingNumber_eq_of_dist_lt_dist_of_eq_endpoints
+    (h₀ : IsPiecewiseC1On γ₀ a b) (h₁ : IsPiecewiseC1On γ₁ a b)
+    (ha : γ₀ a = γ₁ a) (hb : γ₀ b = γ₁ b)
+    (hlt : ∀ t ∈ uIcc a b, dist (γ₁ t) (γ₀ t) < dist (γ₀ t) w) :
+    windingNumber γ₁ a b w = windingNumber γ₀ a b w := by
+  obtain ⟨P₀, hP₀, hdiff₀⟩ := h₀.exists_countable_differentiableAt
+  obtain ⟨P₁, hP₁, hdiff₁⟩ := h₁.exists_countable_differentiableAt
+  apply windingNumber_eq_of_dist_lt_dist_aux (hP₀.union hP₁) ?_ h₀.continuousOn h₁.continuousOn
+    (fun t ht => hdiff₀ t ⟨ht.1, fun hmem => ht.2 (Or.inl hmem)⟩)
+    (fun t ht => hdiff₁ t ⟨ht.1, fun hmem => ht.2 (Or.inr hmem)⟩)
+    h₀.intervalIntegrable_deriv h₁.intervalIntegrable_deriv hlt
+  have h₀a : γ₀ a - w ≠ 0 := sub_ne_zero.mpr (ne_of_dist_lt_dist (hlt a left_mem_uIcc))
+  have h₀b : γ₀ b - w ≠ 0 := sub_ne_zero.mpr (ne_of_dist_lt_dist (hlt b right_mem_uIcc))
+  rw [compRatio_apply, compRatio_apply, ← ha, ← hb, div_self h₀a, div_self h₀b]
 
 /-- The stage at time `s` of the straight-line homotopy `(1 - s) • γ₀ + s • γ₁`. -/
 private def lineHomotopy (γ₀ γ₁ : ℝ → ℂ) (s : ℝ) : ℝ → ℂ := fun t => (1 - s) • γ₀ t + s • γ₁ t


### PR DESCRIPTION
This PR proves the ContourIntegration Layer 0 target “homotopy invariance in ℂ ∖ C” for arbitrary continuous fixed-endpoint path homotopies. It regularizes finitely many homotopy slices with Mathlib’s endpoint-preserving Bernstein approximations and chains them with proximity invariance, so only the endpoint paths—not the homotopy—need piecewise-`C¹` regularity. It also propagates the stronger result to null-homology and the null-homotopic form of Cauchy’s theorem.

The designated milestone is Layer 0’s classical winding-number case. This is the next critical-path step because the preceding proximity-invariance PR left continuous homotopies as the final regularity gap. After this PR, the Layer 0 milestone is complete; remaining ContourIntegration work includes the Hungerbühler–Wasem Proposition 2.2 finite-crossing decomposition and the cycle-level generalized residue and argument-principle extensions.

The proof reuses Mathlib’s `bernsteinPolynomial`, `bernsteinApproximation`, `bernsteinApproximation_uniform`, and the endpoint formulas from `Mathlib.Analysis.SpecialFunctions.Bernstein`; no upstream implementation is vendored. The regularization step is factored out as `TauCeti/Analysis/Contour/Curve/Approximation.lean`, which depends on no winding-number theory.

The former `C²` Stokes route is now subsumed: `curveIntegral_inv_sub_smul_id_eq_of_pathHomotopy` is restated for an arbitrary continuous homotopy (with piecewise-`C¹` endpoint paths) and derived from the winding-number theorem via `windingNumber_eq_two_pi_I_inv_mul_curveIntegral`, so its Poincaré scaffolding (`indexForm`, `indexFormDeriv`, `hasFDerivAt_indexForm`, `indexFormDeriv_apply_comm`, `isPiecewiseC1On_eval_of_smoothPathHomotopy`) and the `Mathlib.MeasureTheory.Integral.CurveIntegral.Poincare` import are removed.

Roadmap: ContourIntegration

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"continuous-path-homotopy-invariance"}-->

🤖 Prepared with Codex