### PR TITLE
chore: make main pass the newly enforced source style lint

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/BaseChange.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/BaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Congr.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Congr.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/Congr.lean
+++ b/TauCeti/Probability/Exchangeability/Congr.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/Probability/Exchangeability/MixedIID/Congr.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Congr.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/PairOfDefinition.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/PairOfDefinition.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 
@@ -15,7 +16,7 @@ For a Huber ring `A` with pair of definition `(A₀, I)`, the ring `A⟨X₁,…
 restricted power series is again a Huber ring, with pair of definition
 
 ```text
-(A₀⟨X⟩_T, I⟨X⟩_T),    Iⁿ⟨X⟩_T = {f ; coeff ν f ∈ Tν · Iⁿ for every ν}.
+(A₀⟨X⟩_T, I⟨X⟩_T),    Iⁿ⟨X⟩_T = {f; coeff ν f ∈ Tν · Iⁿ for every ν}.
 ```
 
 The content is the identification of the neighbourhood subgroups with the powers of one finitely
@@ -132,7 +133,7 @@ variable [NonarchimedeanRing A] {T : Fin k → Set A}
 
 /-- **The level of each coefficient.** For a series all of whose coefficients meet the `Iⁿ` bound
 there is a function `m` such that the coefficient at `ν` meets the sharper bound at level
-`n + m ν`, and such that every sublevel set `{ν ; m ν < M}` is finite.
+`n + m ν`, and such that every sublevel set `{ν; m ν < M}` is finite.
 
 This is the choice the reverse inclusion of
 `TauCeti.Huber.PairOfDefinition.weightedIdeal_one_pow` runs on: decomposing each coefficient at

--- a/TauCeti/RingTheory/Subring/Basic.lean
+++ b/TauCeti/RingTheory/Subring/Basic.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 

--- a/TauCeti/RingTheory/Subring/RationalBaseChange.lean
+++ b/TauCeti/RingTheory/Subring/RationalBaseChange.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
 -/
 module
 


### PR DESCRIPTION
This PR makes `main` pass the source style lint that #3560 turned on.

Enforcement landed while eight files were in flight without a conforming copyright header, so they
carry no `Authors:` line and the header check rejects them. Each gains
`Authors: The Tau Ceti contributors`, matching the normalization in #3556, #3617, #3618 and #3619.
Three of the eight are mine, from #3636.

`WeightedRestrictedSeries/PairOfDefinition.lean` additionally has two set-builder comprehensions
written `{f ; …}` in doc comments, which the lint reads as a space before a semicolon; both lose the
space.

With these, `scripts/lint-style.sh` exits clean: all 2526 source files have conforming headers and
no style errors remain.

Roadmap: none

🤖 Prepared with Claude Code
