### PR TITLE
feat: define Markov exchangeability and place it in the symmetry lattice

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/TransitionCount.lean
+++ b/TauCeti/Combinatorics/Enumerative/TransitionCount.lean
@@ -103,27 +103,27 @@ theorem occCount_comp_succ_add_zero [DecidableEq α] {n : ℕ} (w : Fin (n + 1) 
   rfl
 
 /-- Summing the transitions out of `a` counts the positions carrying `a` other than the last one.
-The index set `S` only has to exhaust the letters actually used by `w`. -/
+The index set `S` only has to contain the successors of transitions in `w`. -/
 theorem sum_transitionCount_right {n : ℕ} (w : Fin (n + 1) → α) {S : Finset α}
-    (hS : ∀ i, w i ∈ S) (a : α) :
+    (hS : ∀ i : Fin n, w i.succ ∈ S) (a : α) :
     ∑ b ∈ S, transitionCount w a b = occCount (w ∘ Fin.castSucc) a := by
   classical
   rw [occCount_eq_card_filter,
     card_eq_sum_card_fiberwise (f := fun i : Fin n => w i.succ) (t := S)
-      fun i _ => hS i.succ]
+      fun i _ => hS i]
   refine sum_congr rfl fun b _ => ?_
   rw [transitionCount_eq_card_filter, filter_filter]
   rfl
 
 /-- Summing the transitions into `a` counts the positions carrying `a` other than the first one.
-The index set `S` only has to exhaust the letters actually used by `w`. -/
+The index set `S` only has to contain the predecessors of transitions in `w`. -/
 theorem sum_transitionCount_left {n : ℕ} (w : Fin (n + 1) → α) {S : Finset α}
-    (hS : ∀ i, w i ∈ S) (b : α) :
+    (hS : ∀ i : Fin n, w i.castSucc ∈ S) (b : α) :
     ∑ a ∈ S, transitionCount w a b = occCount (w ∘ Fin.succ) b := by
   classical
   rw [occCount_eq_card_filter,
     card_eq_sum_card_fiberwise (f := fun i : Fin n => w i.castSucc) (t := S)
-      fun i _ => hS i.castSucc]
+      fun i _ => hS i]
   refine sum_congr rfl fun a _ => ?_
   rw [transitionCount_eq_card_filter, filter_filter]
   exact congrArg _ (filter_congr fun i _ => by simp [and_comm])
@@ -137,10 +137,12 @@ theorem occCount_eq_of_transitionCount_eq {n : ℕ} {u v : Fin (n + 1) → α} (
   have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
   have hSv : ∀ i, v i ∈ S := fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))
   have hout : occCount (u ∘ Fin.castSucc) a = occCount (v ∘ Fin.castSucc) a := by
-    rw [← sum_transitionCount_right u hSu a, ← sum_transitionCount_right v hSv a]
+    rw [← sum_transitionCount_right u (fun i => hSu i.succ) a,
+      ← sum_transitionCount_right v (fun i => hSv i.succ) a]
     exact sum_congr rfl fun b _ => h a b
   have hin : occCount (u ∘ Fin.succ) a = occCount (v ∘ Fin.succ) a := by
-    rw [← sum_transitionCount_left u hSu a, ← sum_transitionCount_left v hSv a]
+    rw [← sum_transitionCount_left u (fun i => hSu i.castSucc) a,
+      ← sum_transitionCount_left v (fun i => hSv i.castSucc) a]
     exact sum_congr rfl fun c _ => h c a
   have hu_last := occCount_comp_castSucc_add_last u a
   have hu_zero := occCount_comp_succ_add_zero u a
@@ -171,15 +173,16 @@ theorem exists_perm_comp_of_transitionCount_eq {n : ℕ} {u v : Fin (n + 1) → 
   exists_perm_comp_of_occCount_eq (occCount_eq_of_transitionCount_eq h0 h)
 
 /-- **A product of transition weights along a word is a function of its transition counts.** The
-index set `S` only has to exhaust the letters actually used by `w`. -/
+index set `S` only has to contain both endpoints of every transition in `w`. -/
 theorem prod_transitionCount {M : Type*} [CommMonoid M] {n : ℕ} (w : Fin (n + 1) → α)
-    {S : Finset α} (hS : ∀ i, w i ∈ S) (p : α → α → M) :
+    {S : Finset α} (hS : ∀ i : Fin n, w i.castSucc ∈ S ∧ w i.succ ∈ S)
+    (p : α → α → M) :
     ∏ i : Fin n, p (w i.castSucc) (w i.succ) =
       ∏ ab ∈ S ×ˢ S, p ab.1 ab.2 ^ transitionCount w ab.1 ab.2 := by
   classical
   rw [← prod_fiberwise_of_maps_to (s := (univ : Finset (Fin n))) (t := S ×ˢ S)
       (g := fun i : Fin n => (w i.castSucc, w i.succ))
-      (fun i _ => mem_product.2 ⟨hS _, hS _⟩) fun i => p (w i.castSucc) (w i.succ)]
+      (fun i _ => mem_product.2 (hS i)) fun i => p (w i.castSucc) (w i.succ)]
   refine prod_congr rfl fun ab _ => ?_
   have hval : ∀ i ∈ filter (fun i : Fin n => (w i.castSucc, w i.succ) = ab) univ,
       p (w i.castSucc) (w i.succ) = p ab.1 ab.2 := fun i hi => by

--- a/TauCeti/Combinatorics/Enumerative/TransitionCount.lean
+++ b/TauCeti/Combinatorics/Enumerative/TransitionCount.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.Data.Fintype.EquivFin
+public import Mathlib.SetTheory.Cardinal.Finite
+public import Mathlib.Logic.Equiv.Basic
+
+/-!
+# Occurrence and transition counts of a finite word
+
+A word `w : Fin N → α` over an arbitrary alphabet `α` has two elementary statistics: the
+**occurrence count** `occCount w a`, the number of positions carrying the letter `a`, and — for a
+word of length `n + 1` — the **transition count** `transitionCount w a b`, the number of positions
+at which the letter `a` is immediately followed by the letter `b`.
+
+The main result is that a word of positive length is determined up to rearrangement by its first
+letter together with its transition counts:
+
+`exists_perm_comp_of_transitionCount_eq`.
+
+The mechanism is a conservation law. Summing `transitionCount w a ·` recovers the number of
+positions other than the last carrying `a`, and summing `transitionCount w · a` recovers the number
+of positions other than the first carrying `a`; comparing the two expressions for `occCount w a`
+pins the last letter once the first letter is known, and then pins every occurrence count. Equal
+occurrence counts glue the fibrewise bijections into a permutation of the positions.
+
+This is the combinatorial heart of Markov exchangeability (Diaconis–Freedman), where the
+transition counts of a path are the sufficient statistic: see
+`TauCeti/Probability/Exchangeability/MarkovExchangeable.lean`.
+
+## Main definitions
+
+* `TauCeti.occCount`: the number of positions of a word carrying a given letter.
+* `TauCeti.transitionCount`: the number of positions of a word at which a given ordered pair of
+  letters occurs consecutively.
+
+## Main results
+
+* `TauCeti.occCount_eq_of_transitionCount_eq`: equal first letters and equal transition counts
+  force equal occurrence counts.
+* `TauCeti.exists_perm_comp_of_transitionCount_eq`: two such words are rearrangements of each
+  other.
+* `TauCeti.prod_transitionCount`: a product of transition weights along a word depends on the word
+  only through its transition counts.
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115–130.
+-/
+
+public section
+
+noncomputable section
+
+open Finset
+
+namespace TauCeti
+
+variable {α : Type*}
+
+/-- The number of positions of the word `w` carrying the letter `a`. -/
+def occCount {N : ℕ} (w : Fin N → α) (a : α) : ℕ :=
+  Nat.card {i : Fin N // w i = a}
+
+/-- The number of positions `i` of the word `w` at which the letter `a` is immediately followed by
+the letter `b`. -/
+def transitionCount {n : ℕ} (w : Fin (n + 1) → α) (a b : α) : ℕ :=
+  Nat.card {i : Fin n // w i.castSucc = a ∧ w i.succ = b}
+
+/-- The occurrence count as the cardinality of a `Finset` of positions. -/
+theorem occCount_eq_card_filter [DecidableEq α] {N : ℕ} (w : Fin N → α) (a : α) :
+    occCount w a = #{i : Fin N | w i = a} := by
+  rw [occCount, Nat.card_eq_fintype_card, Fintype.card_subtype]
+
+/-- The transition count as the cardinality of a `Finset` of positions. -/
+theorem transitionCount_eq_card_filter [DecidableEq α] {n : ℕ} (w : Fin (n + 1) → α) (a b : α) :
+    transitionCount w a b = #{i : Fin n | w i.castSucc = a ∧ w i.succ = b} := by
+  rw [transitionCount, Nat.card_eq_fintype_card, Fintype.card_subtype]
+
+/-- The occurrence count as a sum of indicators over the positions. -/
+theorem occCount_eq_sum [DecidableEq α] {N : ℕ} (w : Fin N → α) (a : α) :
+    occCount w a = ∑ i : Fin N, if w i = a then 1 else 0 := by
+  rw [occCount_eq_card_filter, card_filter]
+
+/-- Splitting off the last position: the occurrences of `a` in a word are those in its initial
+segment together with a possible occurrence at the last position. -/
+theorem occCount_comp_castSucc_add_last [DecidableEq α] {n : ℕ} (w : Fin (n + 1) → α) (a : α) :
+    occCount (w ∘ Fin.castSucc) a + (if w (Fin.last n) = a then 1 else 0) = occCount w a := by
+  rw [occCount_eq_sum, occCount_eq_sum, Fin.sum_univ_castSucc]
+  rfl
+
+/-- Splitting off the first position: the occurrences of `a` in a word are those in its final
+segment together with a possible occurrence at the first position. -/
+theorem occCount_comp_succ_add_zero [DecidableEq α] {n : ℕ} (w : Fin (n + 1) → α) (a : α) :
+    occCount (w ∘ Fin.succ) a + (if w 0 = a then 1 else 0) = occCount w a := by
+  rw [occCount_eq_sum, occCount_eq_sum, Fin.sum_univ_succ, Nat.add_comm]
+  rfl
+
+/-- Summing the transitions out of `a` counts the positions carrying `a` other than the last one.
+The index set `S` only has to exhaust the letters actually used by `w`. -/
+theorem sum_transitionCount_right {n : ℕ} (w : Fin (n + 1) → α) {S : Finset α}
+    (hS : ∀ i, w i ∈ S) (a : α) :
+    ∑ b ∈ S, transitionCount w a b = occCount (w ∘ Fin.castSucc) a := by
+  classical
+  rw [occCount_eq_card_filter,
+    card_eq_sum_card_fiberwise (f := fun i : Fin n => w i.succ) (t := S)
+      fun i _ => hS i.succ]
+  refine sum_congr rfl fun b _ => ?_
+  rw [transitionCount_eq_card_filter, filter_filter]
+  rfl
+
+/-- Summing the transitions into `a` counts the positions carrying `a` other than the first one.
+The index set `S` only has to exhaust the letters actually used by `w`. -/
+theorem sum_transitionCount_left {n : ℕ} (w : Fin (n + 1) → α) {S : Finset α}
+    (hS : ∀ i, w i ∈ S) (b : α) :
+    ∑ a ∈ S, transitionCount w a b = occCount (w ∘ Fin.succ) b := by
+  classical
+  rw [occCount_eq_card_filter,
+    card_eq_sum_card_fiberwise (f := fun i : Fin n => w i.castSucc) (t := S)
+      fun i _ => hS i.castSucc]
+  refine sum_congr rfl fun a _ => ?_
+  rw [transitionCount_eq_card_filter, filter_filter]
+  exact congrArg _ (filter_congr fun i _ => by simp [and_comm])
+
+/-- **The transition counts and the first letter determine the occurrence counts.** -/
+theorem occCount_eq_of_transitionCount_eq {n : ℕ} {u v : Fin (n + 1) → α} (h0 : u 0 = v 0)
+    (h : ∀ a b, transitionCount u a b = transitionCount v a b) (a : α) :
+    occCount u a = occCount v a := by
+  classical
+  set S : Finset α := image u univ ∪ image v univ
+  have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
+  have hSv : ∀ i, v i ∈ S := fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))
+  have hout : occCount (u ∘ Fin.castSucc) a = occCount (v ∘ Fin.castSucc) a := by
+    rw [← sum_transitionCount_right u hSu a, ← sum_transitionCount_right v hSv a]
+    exact sum_congr rfl fun b _ => h a b
+  have hin : occCount (u ∘ Fin.succ) a = occCount (v ∘ Fin.succ) a := by
+    rw [← sum_transitionCount_left u hSu a, ← sum_transitionCount_left v hSv a]
+    exact sum_congr rfl fun c _ => h c a
+  have hu_last := occCount_comp_castSucc_add_last u a
+  have hu_zero := occCount_comp_succ_add_zero u a
+  have hv_last := occCount_comp_castSucc_add_last v a
+  have hv_zero := occCount_comp_succ_add_zero v a
+  rw [h0] at hu_zero
+  omega
+
+/-- Two words with the same occurrence counts are rearrangements of each other. -/
+theorem exists_perm_comp_of_occCount_eq {N : ℕ} {u v : Fin N → α}
+    (h : ∀ a, occCount u a = occCount v a) :
+    ∃ σ : Equiv.Perm (Fin N), v ∘ σ = u := by
+  classical
+  refine ⟨Equiv.ofFiberEquiv (f := u) (g := v) fun c =>
+    Fintype.equivOfCardEq (by
+      rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card]
+      exact h c), ?_⟩
+  funext i
+  exact Equiv.ofFiberEquiv_map _ i
+
+/-- **Words with the same first letter and the same transition counts are rearrangements of each
+other.** This is the elementary fact underlying Markov exchangeability: the transition counts of a
+path, together with its starting point, are a sufficient statistic finer than the occurrence
+counts, so any symmetry expressed through them is implied by exchangeability. -/
+theorem exists_perm_comp_of_transitionCount_eq {n : ℕ} {u v : Fin (n + 1) → α} (h0 : u 0 = v 0)
+    (h : ∀ a b, transitionCount u a b = transitionCount v a b) :
+    ∃ σ : Equiv.Perm (Fin (n + 1)), v ∘ σ = u :=
+  exists_perm_comp_of_occCount_eq (occCount_eq_of_transitionCount_eq h0 h)
+
+/-- **A product of transition weights along a word is a function of its transition counts.** The
+index set `S` only has to exhaust the letters actually used by `w`. -/
+theorem prod_transitionCount {M : Type*} [CommMonoid M] {n : ℕ} (w : Fin (n + 1) → α)
+    {S : Finset α} (hS : ∀ i, w i ∈ S) (p : α → α → M) :
+    ∏ i : Fin n, p (w i.castSucc) (w i.succ) =
+      ∏ ab ∈ S ×ˢ S, p ab.1 ab.2 ^ transitionCount w ab.1 ab.2 := by
+  classical
+  rw [← prod_fiberwise_of_maps_to (s := (univ : Finset (Fin n))) (t := S ×ˢ S)
+      (g := fun i : Fin n => (w i.castSucc, w i.succ))
+      (fun i _ => mem_product.2 ⟨hS _, hS _⟩) fun i => p (w i.castSucc) (w i.succ)]
+  refine prod_congr rfl fun ab _ => ?_
+  have hval : ∀ i ∈ filter (fun i : Fin n => (w i.castSucc, w i.succ) = ab) univ,
+      p (w i.castSucc) (w i.succ) = p ab.1 ab.2 := fun i hi => by
+    rw [← (mem_filter.1 hi).2]
+  have hset : filter (fun i : Fin n => (w i.castSucc, w i.succ) = ab) univ =
+      filter (fun i : Fin n => w i.castSucc = ab.1 ∧ w i.succ = ab.2) univ :=
+    filter_congr fun i _ => by simp [Prod.ext_iff]
+  rw [prod_congr rfl hval, prod_const, transitionCount_eq_card_filter, hset]
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/Exchangeability.lean
+++ b/TauCeti/Probability/Exchangeability.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Exchangeability.Map
+public import TauCeti.Probability.Exchangeability.MarkovExchangeable
 public import TauCeti.Probability.Exchangeability.Family
 public import TauCeti.Probability.Exchangeability.MixedIID.Map
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Implications
@@ -26,7 +27,7 @@ This module declares nothing of its own; it is a curated re-export.
 
 * the finite-dimensional laws `blockLaw`, `prefixLaw`, `pathLaw`, and finite-marginal uniqueness;
 * the symmetry predicates `ExchangeableAt`, `Exchangeable`, `FullyExchangeable`, `Contractable`,
-  and the index-generic `ExchangeableFamily`;
+  `MarkovExchangeable`, and the index-generic `ExchangeableFamily`;
 * the representation predicates `MixedIIDWith`, `MixedIID`, `ConditionallyIIDWith`,
   `ConditionallyIID`, with their constructors, accessors, and simp-normal forms;
 * the implications between them, including the symmetry consequences of each and the projection

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -220,6 +220,13 @@ theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
     Function.comp_def]
   rfl
 
+/-- The prefix laws of a path law are the prefix laws of the process. -/
+theorem prefixLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α} (hX : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) : prefixLaw (pathLaw μ X) (fun n (x : ℕ → α) => x n) n = prefixLaw μ X n := by
+  rw [prefixLaw_def, blockLaw_def,
+    ← map_prefixProj_pathLaw μ (aemeasurable_pi_lambda (fun ω => fun i => X i ω) hX) n]
+  rfl
+
 /-- A coordinatewise measurable map sends block laws to block laws. -/
 theorem map_blockLaw (μ : Measure Ω) {X : ι → Ω → α} {m : ℕ} (k : Fin m → ι)
     {f : α → β} [MeasurableSpace β] (hf : Measurable f)
@@ -311,6 +318,28 @@ theorem ExchangeableAt.permute {μ : Measure Ω} {X : ℕ → Ω → α} {n : �
     (h : ExchangeableAt μ X n) (σ : Equiv.Perm (Fin n)) :
     blockLaw μ X (fun i : Fin n => (σ i).val) = prefixLaw μ X n :=
   h σ
+
+/-- Under finite exchangeability at `n`, rearranging a path leaves its probability unchanged. -/
+theorem ExchangeableAt.prefixLaw_singleton_comp [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α} {n : ℕ} (h : ExchangeableAt μ X n)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) (w : Fin n → α)
+    (σ : Equiv.Perm (Fin n)) :
+    prefixLaw μ X n {w ∘ σ} = prefixLaw μ X n {w} := by
+  have hmeas : Measurable fun x : Fin n → α => fun i => x (σ⁻¹ i) :=
+    measurable_pi_lambda _ fun i => measurable_pi_apply (σ⁻¹ i)
+  have hmap : (prefixLaw μ X n).map (fun x : Fin n → α => fun i => x (σ⁻¹ i)) =
+      prefixLaw μ X n := by
+    conv_lhs => rw [prefixLaw_def]
+    rw [map_blockLaw_reindex μ (fun i : Fin n => i.val) (fun i => σ⁻¹ i) hX]
+    exact h σ⁻¹
+  conv_rhs => rw [← hmap]
+  rw [Measure.map_apply hmeas (measurableSet_singleton w)]
+  congr 1
+  ext x
+  simp only [Set.mem_preimage, Set.mem_singleton_iff, funext_iff, Function.comp_apply]
+  refine ⟨fun hx j => ?_, fun hx i => ?_⟩
+  · simpa using hx (σ⁻¹ j)
+  · simpa using hx (σ i)
 
 theorem FullyExchangeable.permute {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : FullyExchangeable μ X) (π : Equiv.Perm ℕ) :

--- a/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
@@ -72,26 +72,28 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- **Markov exchangeability**, Diaconis and Freedman's partial exchangeability: two finite paths
-with the same starting state and the same transition counts are equally likely. The countability
-and measurable-singleton conjuncts restrict this singleton-mass formulation to discrete state
-spaces, where it is non-vacuous and determines the finite-path laws. -/
+/-- **Markov exchangeability**, Diaconis and Freedman's partial exchangeability: a measurable
+process has equally likely finite paths whenever they have the same starting state and the same
+transition counts. The countability and measurable-singleton conjuncts restrict this
+singleton-mass formulation to discrete state spaces, where it is non-vacuous and determines the
+finite-path laws. -/
 def MarkovExchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
-  Countable α ∧ MeasurableSingletonClass α ∧
+  Countable α ∧ MeasurableSingletonClass α ∧ (∀ i, AEMeasurable (X i) μ) ∧
     ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
       (∀ a b, transitionCount u a b = transitionCount v a b) →
         prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v}
 
-/-- Constructor from discrete-state instances and invariance under paths with equal transition
-counts. -/
+/-- Constructor from discrete-state instances, coordinatewise a.e. measurability, and invariance
+under paths with equal transition counts. -/
 theorem MarkovExchangeable.intro [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ)
     (h : ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
       (∀ a b, transitionCount u a b = transitionCount v a b) →
         prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v}) :
     MarkovExchangeable μ X := by
   rw [MarkovExchangeable]
-  exact ⟨inferInstance, inferInstance, h⟩
+  exact ⟨inferInstance, inferInstance, hX, h⟩
 
 /-- The state space of a Markov exchangeable process is countable. -/
 theorem MarkovExchangeable.countable {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -105,6 +107,12 @@ theorem MarkovExchangeable.measurableSingletonClass {μ : Measure Ω} {X : ℕ �
   rw [MarkovExchangeable] at h
   exact h.2.1
 
+/-- Every coordinate of a Markov exchangeable process is a.e. measurable. -/
+theorem MarkovExchangeable.aemeasurable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MarkovExchangeable μ X) (i : ℕ) : AEMeasurable (X i) μ := by
+  rw [MarkovExchangeable] at h
+  exact h.2.2.1 i
+
 /-- Paths with the same starting state and transition counts have the same probability under a
 Markov exchangeable process. -/
 theorem MarkovExchangeable.prefixLaw_singleton_eq {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -112,17 +120,19 @@ theorem MarkovExchangeable.prefixLaw_singleton_eq {μ : Measure Ω} {X : ℕ →
     (hcount : ∀ a b, transitionCount u a b = transitionCount v a b) :
     prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v} := by
   rw [MarkovExchangeable] at h
-  exact h.2.2 n u v h0 hcount
+  exact h.2.2.2 n u v h0 hcount
 
 /-- Simp normal form for `MarkovExchangeable`. -/
 @[simp]
 theorem markovExchangeable_iff [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} :
     MarkovExchangeable μ X ↔
-      ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
-        (∀ a b, transitionCount u a b = transitionCount v a b) →
-          prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v} :=
-  ⟨fun h n u v => h.prefixLaw_singleton_eq n u v, MarkovExchangeable.intro⟩
+      (∀ i, AEMeasurable (X i) μ) ∧
+        ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
+          (∀ a b, transitionCount u a b = transitionCount v a b) →
+            prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v} :=
+  ⟨fun h => ⟨h.aemeasurable, fun n u v => h.prefixLaw_singleton_eq n u v⟩,
+    fun h => MarkovExchangeable.intro h.1 h.2⟩
 
 /-- Under finite exchangeability at `n`, rearranging a path leaves its probability unchanged. -/
 theorem ExchangeableAt.prefixLaw_singleton_comp [MeasurableSingletonClass α]
@@ -150,7 +160,7 @@ transition counts are rearrangements of each other, so exchangeability already e
 theorem Exchangeable.markovExchangeable [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} (h : Exchangeable μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
     MarkovExchangeable μ X := by
-  refine MarkovExchangeable.intro ?_
+  refine MarkovExchangeable.intro hX ?_
   intro n u v h0 hcount
   obtain ⟨σ, hσ⟩ := exists_perm_comp_of_transitionCount_eq h0 hcount
   rw [← hσ]
@@ -162,12 +172,13 @@ transition weights `p` along the path. Only the product form matters, not that `
 probability kernel. -/
 theorem markovExchangeable_of_prefixLaw_singleton_eq [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ)
     (p₀ : α → ℝ≥0∞) (p : α → α → ℝ≥0∞)
     (h : ∀ (n : ℕ) (w : Fin (n + 1) → α),
       prefixLaw μ X (n + 1) {w} = p₀ (w 0) * ∏ i : Fin n, p (w i.castSucc) (w i.succ)) :
     MarkovExchangeable μ X := by
   classical
-  refine MarkovExchangeable.intro ?_
+  refine MarkovExchangeable.intro hX ?_
   intro n u v h0 hcount
   set S : Finset α := image u univ ∪ image v univ
   have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
@@ -187,7 +198,17 @@ theorem markovExchangeable_pathLaw_iff [Countable α] [MeasurableSingletonClass 
     {μ : Measure Ω} {X : ℕ → Ω → α}
     (hX : ∀ i, AEMeasurable (X i) μ) :
     MarkovExchangeable (pathLaw μ X) (fun n (x : ℕ → α) => x n) ↔ MarkovExchangeable μ X := by
-  simp only [markovExchangeable_iff, prefixLaw_pathLaw hX]
+  constructor
+  · intro h
+    refine MarkovExchangeable.intro hX ?_
+    intro n u v h0 hcount
+    rw [← prefixLaw_pathLaw hX]
+    exact h.prefixLaw_singleton_eq n u v h0 hcount
+  · intro h
+    refine MarkovExchangeable.intro (fun i => (measurable_pi_apply i).aemeasurable) ?_
+    intro n u v h0 hcount
+    rw [prefixLaw_pathLaw hX]
+    exact h.prefixLaw_singleton_eq n u v h0 hcount
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
@@ -90,7 +90,7 @@ theorem markovExchangeable_iff {μ : Measure Ω} {X : ℕ → Ω → α} :
   Iff.rfl
 
 /-- Under finite exchangeability at `n`, rearranging a path leaves its probability unchanged. -/
-theorem ExchangeableAt.prefixLaw_singleton_comp [Countable α] [MeasurableSingletonClass α]
+theorem ExchangeableAt.prefixLaw_singleton_comp [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} {n : ℕ} (h : ExchangeableAt μ X n)
     (hX : ∀ i, AEMeasurable (X i) μ) (w : Fin n → α) (σ : Equiv.Perm (Fin n)) :
     prefixLaw μ X n {w ∘ σ} = prefixLaw μ X n {w} := by
@@ -112,7 +112,7 @@ theorem ExchangeableAt.prefixLaw_singleton_comp [Countable α] [MeasurableSingle
 
 /-- **An exchangeable process is Markov exchangeable.** Two paths with a common start and common
 transition counts are rearrangements of each other, so exchangeability already equates them. -/
-theorem Exchangeable.markovExchangeable [Countable α] [MeasurableSingletonClass α]
+theorem Exchangeable.markovExchangeable [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} (h : Exchangeable μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
     MarkovExchangeable μ X := by
   intro n u v h0 hcount

--- a/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
@@ -134,27 +134,6 @@ theorem markovExchangeable_iff [Countable α] [MeasurableSingletonClass α]
   ⟨fun h => ⟨h.aemeasurable, fun n u v => h.prefixLaw_singleton_eq n u v⟩,
     fun h => MarkovExchangeable.intro h.1 h.2⟩
 
-/-- Under finite exchangeability at `n`, rearranging a path leaves its probability unchanged. -/
-theorem ExchangeableAt.prefixLaw_singleton_comp [MeasurableSingletonClass α]
-    {μ : Measure Ω} {X : ℕ → Ω → α} {n : ℕ} (h : ExchangeableAt μ X n)
-    (hX : ∀ i, AEMeasurable (X i) μ) (w : Fin n → α) (σ : Equiv.Perm (Fin n)) :
-    prefixLaw μ X n {w ∘ σ} = prefixLaw μ X n {w} := by
-  have hmeas : Measurable fun x : Fin n → α => fun i => x (σ⁻¹ i) :=
-    measurable_pi_lambda _ fun i => measurable_pi_apply (σ⁻¹ i)
-  have hmap : (prefixLaw μ X n).map (fun x : Fin n → α => fun i => x (σ⁻¹ i)) =
-      prefixLaw μ X n := by
-    conv_lhs => rw [prefixLaw_def]
-    rw [map_blockLaw_reindex μ (fun i : Fin n => i.val) (fun i => σ⁻¹ i) fun j => hX j.val]
-    exact h σ⁻¹
-  conv_rhs => rw [← hmap]
-  rw [Measure.map_apply hmeas (measurableSet_singleton w)]
-  congr 1
-  ext x
-  simp only [Set.mem_preimage, Set.mem_singleton_iff, funext_iff, Function.comp_apply]
-  refine ⟨fun hx j => ?_, fun hx i => ?_⟩
-  · simpa using hx (σ⁻¹ j)
-  · simpa using hx (σ i)
-
 /-- **An exchangeable process is Markov exchangeable.** Two paths with a common start and common
 transition counts are rearrangements of each other, so exchangeability already equates them. -/
 theorem Exchangeable.markovExchangeable [Countable α] [MeasurableSingletonClass α]
@@ -164,7 +143,7 @@ theorem Exchangeable.markovExchangeable [Countable α] [MeasurableSingletonClass
   intro n u v h0 hcount
   obtain ⟨σ, hσ⟩ := exists_perm_comp_of_transitionCount_eq h0 hcount
   rw [← hσ]
-  exact (h (n + 1)).prefixLaw_singleton_comp hX v σ
+  exact (h (n + 1)).prefixLaw_singleton_comp (fun i => hX i.val) v σ
 
 /-- **A Markov chain is Markov exchangeable.** The hypothesis is the defining product form of the
 finite-dimensional laws of a Markov chain: an initial weight `p₀` at the starting state times the
@@ -183,15 +162,10 @@ theorem markovExchangeable_of_prefixLaw_singleton_eq [Countable α] [MeasurableS
   set S : Finset α := image u univ ∪ image v univ
   have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
   have hSv : ∀ i, v i ∈ S := fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))
-  rw [h n u, h n v, h0, prod_transitionCount u hSu p, prod_transitionCount v hSv p]
+  rw [h n u, h n v, h0,
+    prod_transitionCount u (fun i : Fin n => ⟨hSu i.castSucc, hSu i.succ⟩) p,
+    prod_transitionCount v (fun i : Fin n => ⟨hSv i.castSucc, hSv i.succ⟩) p]
   exact congrArg _ (prod_congr rfl fun ab _ => by rw [hcount ab.1 ab.2])
-
-/-- The prefix laws of a path law are the prefix laws of the process. -/
-theorem prefixLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α} (hX : ∀ i, AEMeasurable (X i) μ)
-    (n : ℕ) : prefixLaw (pathLaw μ X) (fun n (x : ℕ → α) => x n) n = prefixLaw μ X n := by
-  rw [prefixLaw_def, blockLaw_def,
-    ← map_prefixProj_pathLaw μ (aemeasurable_pi_lambda (fun ω => fun i => X i ω) hX) n]
-  rfl
 
 /-- **The process-level and path-law formulations of Markov exchangeability agree.** -/
 theorem markovExchangeable_pathLaw_iff [Countable α] [MeasurableSingletonClass α]

--- a/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
@@ -76,12 +76,43 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 with the same starting state and the same transition counts are equally likely. The countability
 and measurable-singleton conjuncts restrict this singleton-mass formulation to discrete state
 spaces, where it is non-vacuous and determines the finite-path laws. -/
-@[expose]
 def MarkovExchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   Countable α ∧ MeasurableSingletonClass α ∧
     ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
       (∀ a b, transitionCount u a b = transitionCount v a b) →
         prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v}
+
+/-- Constructor from discrete-state instances and invariance under paths with equal transition
+counts. -/
+theorem MarkovExchangeable.intro [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
+      (∀ a b, transitionCount u a b = transitionCount v a b) →
+        prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v}) :
+    MarkovExchangeable μ X := by
+  rw [MarkovExchangeable]
+  exact ⟨inferInstance, inferInstance, h⟩
+
+/-- The state space of a Markov exchangeable process is countable. -/
+theorem MarkovExchangeable.countable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MarkovExchangeable μ X) : Countable α := by
+  rw [MarkovExchangeable] at h
+  exact h.1
+
+/-- Singletons in the state space of a Markov exchangeable process are measurable. -/
+theorem MarkovExchangeable.measurableSingletonClass {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MarkovExchangeable μ X) : MeasurableSingletonClass α := by
+  rw [MarkovExchangeable] at h
+  exact h.2.1
+
+/-- Paths with the same starting state and transition counts have the same probability under a
+Markov exchangeable process. -/
+theorem MarkovExchangeable.prefixLaw_singleton_eq {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MarkovExchangeable μ X) (n : ℕ) (u v : Fin (n + 1) → α) (h0 : u 0 = v 0)
+    (hcount : ∀ a b, transitionCount u a b = transitionCount v a b) :
+    prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v} := by
+  rw [MarkovExchangeable] at h
+  exact h.2.2 n u v h0 hcount
 
 /-- Simp normal form for `MarkovExchangeable`. -/
 @[simp]
@@ -91,7 +122,7 @@ theorem markovExchangeable_iff [Countable α] [MeasurableSingletonClass α]
       ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
         (∀ a b, transitionCount u a b = transitionCount v a b) →
           prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v} :=
-  ⟨fun h => h.2.2, fun h => ⟨inferInstance, inferInstance, h⟩⟩
+  ⟨fun h n u v => h.prefixLaw_singleton_eq n u v, MarkovExchangeable.intro⟩
 
 /-- Under finite exchangeability at `n`, rearranging a path leaves its probability unchanged. -/
 theorem ExchangeableAt.prefixLaw_singleton_comp [MeasurableSingletonClass α]
@@ -119,7 +150,7 @@ transition counts are rearrangements of each other, so exchangeability already e
 theorem Exchangeable.markovExchangeable [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} (h : Exchangeable μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
     MarkovExchangeable μ X := by
-  refine ⟨inferInstance, inferInstance, ?_⟩
+  refine MarkovExchangeable.intro ?_
   intro n u v h0 hcount
   obtain ⟨σ, hσ⟩ := exists_perm_comp_of_transitionCount_eq h0 hcount
   rw [← hσ]
@@ -136,7 +167,7 @@ theorem markovExchangeable_of_prefixLaw_singleton_eq [Countable α] [MeasurableS
       prefixLaw μ X (n + 1) {w} = p₀ (w 0) * ∏ i : Fin n, p (w i.castSucc) (w i.succ)) :
     MarkovExchangeable μ X := by
   classical
-  refine ⟨inferInstance, inferInstance, ?_⟩
+  refine MarkovExchangeable.intro ?_
   intro n u v h0 hcount
   set S : Finset α := image u univ ∪ image v univ
   have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))

--- a/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.Enumerative.TransitionCount
+public import TauCeti.Probability.Exchangeability.Basic
+
+/-!
+# Markov exchangeability
+
+A process `X : ℕ → Ω → α` on a countable state space is **Markov exchangeable** — Diaconis and
+Freedman's *partial exchangeability* — when two finite paths that start at the same state and make
+the same number of transitions from each state to each state are equally likely:
+
+```text
+u 0 = v 0  →  transitionCount u = transitionCount v  →  prefixLaw μ X (n + 1) {u} =
+  prefixLaw μ X (n + 1) {v}
+```
+
+This is the symmetry that a Markov chain has and an exchangeable process has, and it is the
+hypothesis of the Diaconis–Freedman representation theorem, which says that a recurrent Markov
+exchangeable process is a mixture of Markov chains. This file sets up the notion and its two
+sources.
+
+Markov exchangeability is a genuine weakening of exchangeability. Exchangeability asks for
+invariance under *all* rearrangements of a finite path, whereas Markov exchangeability asks for it
+only between paths sharing a start and a transition-count matrix; the latter class of paths is
+strictly smaller, because a rearrangement generally destroys the transition counts. That the
+implication `Exchangeable → MarkovExchangeable` nevertheless holds is a conservation law for words:
+the transition counts and the first letter already determine the occurrence counts, hence the
+rearrangement class (`TauCeti.exists_perm_comp_of_transitionCount_eq`). That the implication is
+strict is witnessed by the deterministic 3-cycle, in
+`TauCeti/Probability/Exchangeability/ThreeCycle.lean`.
+
+## Main definitions
+
+* `TauCeti.Probability.MarkovExchangeable`: the symmetry above.
+
+## Main results
+
+* `TauCeti.Probability.Exchangeable.markovExchangeable`: an exchangeable process is Markov
+  exchangeable.
+* `TauCeti.Probability.markovExchangeable_of_prefixLaw_singleton_eq`: a process whose finite path
+  probabilities factor as an initial weight times a product of transition weights — a Markov chain
+  — is Markov exchangeable.
+* `TauCeti.Probability.markovExchangeable_pathLaw_iff`: the process-level and path-law
+  formulations agree.
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115–130.
+* Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, "Markov exchangeability".
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable rather than
+Markov exchangeable sequences.
+-/
+
+public section
+
+noncomputable section
+
+open Finset MeasureTheory
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **Markov exchangeability**, Diaconis and Freedman's partial exchangeability: two finite paths
+with the same starting state and the same transition counts are equally likely. -/
+@[expose]
+def MarkovExchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
+    (∀ a b, transitionCount u a b = transitionCount v a b) →
+      prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v}
+
+/-- Simp normal form for `MarkovExchangeable`. -/
+@[simp]
+theorem markovExchangeable_iff {μ : Measure Ω} {X : ℕ → Ω → α} :
+    MarkovExchangeable μ X ↔
+      ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
+        (∀ a b, transitionCount u a b = transitionCount v a b) →
+          prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v} :=
+  Iff.rfl
+
+/-- Under finite exchangeability at `n`, rearranging a path leaves its probability unchanged. -/
+theorem ExchangeableAt.prefixLaw_singleton_comp [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α} {n : ℕ} (h : ExchangeableAt μ X n)
+    (hX : ∀ i, AEMeasurable (X i) μ) (w : Fin n → α) (σ : Equiv.Perm (Fin n)) :
+    prefixLaw μ X n {w ∘ σ} = prefixLaw μ X n {w} := by
+  have hmeas : Measurable fun x : Fin n → α => fun i => x (σ⁻¹ i) :=
+    measurable_pi_lambda _ fun i => measurable_pi_apply (σ⁻¹ i)
+  have hmap : (prefixLaw μ X n).map (fun x : Fin n → α => fun i => x (σ⁻¹ i)) =
+      prefixLaw μ X n := by
+    conv_lhs => rw [prefixLaw_def]
+    rw [map_blockLaw_reindex μ (fun i : Fin n => i.val) (fun i => σ⁻¹ i) fun j => hX j.val]
+    exact h σ⁻¹
+  conv_rhs => rw [← hmap]
+  rw [Measure.map_apply hmeas (measurableSet_singleton w)]
+  congr 1
+  ext x
+  simp only [Set.mem_preimage, Set.mem_singleton_iff, funext_iff, Function.comp_apply]
+  refine ⟨fun hx j => ?_, fun hx i => ?_⟩
+  · simpa using hx (σ⁻¹ j)
+  · simpa using hx (σ i)
+
+/-- **An exchangeable process is Markov exchangeable.** Two paths with a common start and common
+transition counts are rearrangements of each other, so exchangeability already equates them. -/
+theorem Exchangeable.markovExchangeable [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α} (h : Exchangeable μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
+    MarkovExchangeable μ X := by
+  intro n u v h0 hcount
+  obtain ⟨σ, hσ⟩ := exists_perm_comp_of_transitionCount_eq h0 hcount
+  rw [← hσ]
+  exact (h (n + 1)).prefixLaw_singleton_comp hX v σ
+
+/-- **A Markov chain is Markov exchangeable.** The hypothesis is the defining product form of the
+finite-dimensional laws of a Markov chain: an initial weight `p₀` at the starting state times the
+transition weights `p` along the path. Only the product form matters, not that `p` is a
+probability kernel. -/
+theorem markovExchangeable_of_prefixLaw_singleton_eq {μ : Measure Ω} {X : ℕ → Ω → α}
+    (p₀ : α → ℝ≥0∞) (p : α → α → ℝ≥0∞)
+    (h : ∀ (n : ℕ) (w : Fin (n + 1) → α),
+      prefixLaw μ X (n + 1) {w} = p₀ (w 0) * ∏ i : Fin n, p (w i.castSucc) (w i.succ)) :
+    MarkovExchangeable μ X := by
+  classical
+  intro n u v h0 hcount
+  set S : Finset α := image u univ ∪ image v univ
+  have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
+  have hSv : ∀ i, v i ∈ S := fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))
+  rw [h n u, h n v, h0, prod_transitionCount u hSu p, prod_transitionCount v hSv p]
+  exact congrArg _ (prod_congr rfl fun ab _ => by rw [hcount ab.1 ab.2])
+
+/-- The prefix laws of a path law are the prefix laws of the process. -/
+theorem prefixLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α} (hX : ∀ i, AEMeasurable (X i) μ)
+    (n : ℕ) : prefixLaw (pathLaw μ X) (fun n (x : ℕ → α) => x n) n = prefixLaw μ X n := by
+  rw [prefixLaw_def, blockLaw_def,
+    ← map_prefixProj_pathLaw μ (aemeasurable_pi_lambda (fun ω => fun i => X i ω) hX) n]
+  rfl
+
+/-- **The process-level and path-law formulations of Markov exchangeability agree.** -/
+theorem markovExchangeable_pathLaw_iff {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) :
+    MarkovExchangeable (pathLaw μ X) (fun n (x : ℕ → α) => x n) ↔ MarkovExchangeable μ X := by
+  simp only [markovExchangeable_iff, prefixLaw_pathLaw hX]
+
+end Probability
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
@@ -73,21 +73,25 @@ namespace Probability
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 /-- **Markov exchangeability**, Diaconis and Freedman's partial exchangeability: two finite paths
-with the same starting state and the same transition counts are equally likely. -/
+with the same starting state and the same transition counts are equally likely. The countability
+and measurable-singleton conjuncts restrict this singleton-mass formulation to discrete state
+spaces, where it is non-vacuous and determines the finite-path laws. -/
 @[expose]
 def MarkovExchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
-  ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
-    (∀ a b, transitionCount u a b = transitionCount v a b) →
-      prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v}
+  Countable α ∧ MeasurableSingletonClass α ∧
+    ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
+      (∀ a b, transitionCount u a b = transitionCount v a b) →
+        prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v}
 
 /-- Simp normal form for `MarkovExchangeable`. -/
 @[simp]
-theorem markovExchangeable_iff {μ : Measure Ω} {X : ℕ → Ω → α} :
+theorem markovExchangeable_iff [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α} :
     MarkovExchangeable μ X ↔
       ∀ (n : ℕ) (u v : Fin (n + 1) → α), u 0 = v 0 →
         (∀ a b, transitionCount u a b = transitionCount v a b) →
           prefixLaw μ X (n + 1) {u} = prefixLaw μ X (n + 1) {v} :=
-  Iff.rfl
+  ⟨fun h => h.2.2, fun h => ⟨inferInstance, inferInstance, h⟩⟩
 
 /-- Under finite exchangeability at `n`, rearranging a path leaves its probability unchanged. -/
 theorem ExchangeableAt.prefixLaw_singleton_comp [MeasurableSingletonClass α]
@@ -112,9 +116,10 @@ theorem ExchangeableAt.prefixLaw_singleton_comp [MeasurableSingletonClass α]
 
 /-- **An exchangeable process is Markov exchangeable.** Two paths with a common start and common
 transition counts are rearrangements of each other, so exchangeability already equates them. -/
-theorem Exchangeable.markovExchangeable [MeasurableSingletonClass α]
+theorem Exchangeable.markovExchangeable [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} (h : Exchangeable μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
     MarkovExchangeable μ X := by
+  refine ⟨inferInstance, inferInstance, ?_⟩
   intro n u v h0 hcount
   obtain ⟨σ, hσ⟩ := exists_perm_comp_of_transitionCount_eq h0 hcount
   rw [← hσ]
@@ -124,12 +129,14 @@ theorem Exchangeable.markovExchangeable [MeasurableSingletonClass α]
 finite-dimensional laws of a Markov chain: an initial weight `p₀` at the starting state times the
 transition weights `p` along the path. Only the product form matters, not that `p` is a
 probability kernel. -/
-theorem markovExchangeable_of_prefixLaw_singleton_eq {μ : Measure Ω} {X : ℕ → Ω → α}
+theorem markovExchangeable_of_prefixLaw_singleton_eq [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α}
     (p₀ : α → ℝ≥0∞) (p : α → α → ℝ≥0∞)
     (h : ∀ (n : ℕ) (w : Fin (n + 1) → α),
       prefixLaw μ X (n + 1) {w} = p₀ (w 0) * ∏ i : Fin n, p (w i.castSucc) (w i.succ)) :
     MarkovExchangeable μ X := by
   classical
+  refine ⟨inferInstance, inferInstance, ?_⟩
   intro n u v h0 hcount
   set S : Finset α := image u univ ∪ image v univ
   have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
@@ -145,7 +152,8 @@ theorem prefixLaw_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α} (hX : ∀ i,
   rfl
 
 /-- **The process-level and path-law formulations of Markov exchangeability agree.** -/
-theorem markovExchangeable_pathLaw_iff {μ : Measure Ω} {X : ℕ → Ω → α}
+theorem markovExchangeable_pathLaw_iff [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α}
     (hX : ∀ i, AEMeasurable (X i) μ) :
     MarkovExchangeable (pathLaw μ X) (fun n (x : ℕ → α) => x n) ↔ MarkovExchangeable μ X := by
   simp only [markovExchangeable_iff, prefixLaw_pathLaw hX]

--- a/TauCeti/Probability/Exchangeability/ThreeCycle.lean
+++ b/TauCeti/Probability/Exchangeability/ThreeCycle.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability
+public import TauCeti.Probability.Exchangeability.MarkovExchangeable
 public import TauCeti.Probability.Exchangeability.PathSpace.Shift
 public import Mathlib.MeasureTheory.Group.Measure
 public import Mathlib.Probability.UniformOn
@@ -28,6 +29,10 @@ ProbabilityTheory.uniformOn Set.univ`, and the deterministic rotation process `t
 its path law is invariant under the one-sided shift
 (`threeCycle_measurePreserving_shift`), because shifting the sample path of `ω` gives the sample
 path of `ω + 1`, and the uniform law is translation invariant.
+
+It is a deterministic Markov chain, hence Markov exchangeable
+(`threeCycle_markovExchangeable`); since it is not exchangeable, this is also the example showing
+that `Exchangeable` is strictly stronger than `MarkovExchangeable`.
 
 It is, however, neither exchangeable (`threeCycle_not_exchangeable`) nor contractable
 (`threeCycle_not_contractable`): the pair `(X₀, X₁) = (ω, ω + 1)` lands in
@@ -157,6 +162,58 @@ exchangeability symmetry: the pair `(X₀, X₁) = (ω, ω + 1)` ranges over
 theorem threeCycle_not_exchangeable : ¬ Exchangeable threeCycleMeasure threeCycle := by
   intro hE
   exact threeCycle_not_contractable (hE.contractable (fun _ => Measurable.of_discrete.aemeasurable))
+
+/-- **The 3-cycle has the finite-dimensional laws of a Markov chain.** A path of length `n + 1` is
+possible only if every step advances the state by one, in which case it is determined by its
+starting state and carries the uniform mass `3⁻¹`. -/
+theorem threeCycle_prefixLaw_singleton (n : ℕ) (w : Fin (n + 1) → ZMod 3) :
+    prefixLaw threeCycleMeasure threeCycle (n + 1) {w} =
+      3⁻¹ * ∏ i : Fin n, (if w i.succ = w i.castSucc + 1 then 1 else 0 : ℝ≥0∞) := by
+  classical
+  have hmap : prefixLaw threeCycleMeasure threeCycle (n + 1) {w} =
+      threeCycleMeasure ((fun (ω : ZMod 3) (i : Fin (n + 1)) => threeCycle i.val ω) ⁻¹' {w}) := by
+    rw [prefixLaw_def, blockLaw_def,
+      Measure.map_apply Measurable.of_discrete MeasurableSet.of_discrete]
+  by_cases hstep : ∀ i : Fin n, w i.succ = w i.castSucc + 1
+  · have hprod : (∏ i : Fin n, (if w i.succ = w i.castSucc + 1 then 1 else 0 : ℝ≥0∞)) = 1 :=
+      Finset.prod_eq_one fun i _ => by simp [hstep i]
+    have hw : ∀ i : Fin (n + 1), w i = w 0 + (i.val : ZMod 3) := by
+      intro i
+      induction i using Fin.induction with
+      | zero => simp
+      | succ j ih =>
+        rw [hstep j, ih]
+        simp only [Fin.val_succ, Fin.val_castSucc]
+        push_cast
+        ring
+    have hset : (fun (ω : ZMod 3) (i : Fin (n + 1)) => threeCycle i.val ω) ⁻¹' {w} = {w 0} := by
+      ext ω
+      simp only [Set.mem_preimage, Set.mem_singleton_iff, funext_iff, threeCycle_apply]
+      refine ⟨fun h => by simpa using h 0, ?_⟩
+      rintro rfl i
+      exact (hw i).symm
+    rw [hmap, hset, threeCycleMeasure_singleton, hprod, mul_one]
+  · obtain ⟨i, hi⟩ := not_forall.mp hstep
+    have hprod : (∏ i : Fin n, (if w i.succ = w i.castSucc + 1 then 1 else 0 : ℝ≥0∞)) = 0 :=
+      Finset.prod_eq_zero (Finset.mem_univ i) (by simp [hi])
+    have hset : (fun (ω : ZMod 3) (i : Fin (n + 1)) => threeCycle i.val ω) ⁻¹' {w} = ∅ := by
+      ext ω
+      simp only [Set.mem_preimage, Set.mem_singleton_iff, funext_iff, threeCycle_apply,
+        Set.mem_empty_iff_false, iff_false]
+      intro h
+      refine hi ?_
+      rw [← h i.succ, ← h i.castSucc]
+      simp only [Fin.val_succ, Fin.val_castSucc]
+      push_cast
+      ring
+    rw [hmap, hset, measure_empty, hprod, mul_zero]
+
+/-- **The 3-cycle is Markov exchangeable.** It is a deterministic Markov chain, so its finite path
+probabilities factor through the transition counts. With `threeCycle_not_exchangeable`, this
+separates `MarkovExchangeable` from `Exchangeable`. -/
+theorem threeCycle_markovExchangeable : MarkovExchangeable threeCycleMeasure threeCycle :=
+  markovExchangeable_of_prefixLaw_singleton_eq (fun _ => 3⁻¹)
+    (fun a b => if b = a + 1 then 1 else 0) threeCycle_prefixLaw_singleton
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/ThreeCycle.lean
+++ b/TauCeti/Probability/Exchangeability/ThreeCycle.lean
@@ -212,7 +212,8 @@ theorem threeCycle_prefixLaw_singleton (n : ℕ) (w : Fin (n + 1) → ZMod 3) :
 probabilities factor through the transition counts. With `threeCycle_not_exchangeable`, this
 separates `MarkovExchangeable` from `Exchangeable`. -/
 theorem threeCycle_markovExchangeable : MarkovExchangeable threeCycleMeasure threeCycle :=
-  markovExchangeable_of_prefixLaw_singleton_eq (fun _ => 3⁻¹)
+  markovExchangeable_of_prefixLaw_singleton_eq (fun _ => Measurable.of_discrete.aemeasurable)
+    (fun _ => 3⁻¹)
     (fun a b => if b = a + 1 then 1 else 0) threeCycle_prefixLaw_singleton
 
 end Probability


### PR DESCRIPTION
This PR opens the **Markov exchangeability** entry of Layer 8 of the Exchangeability roadmap
("Build: ... Markov exchangeability"), the one Layer 8 build item on which nothing had landed
apart from the exchangeable-arrays tower. It defines `MarkovExchangeable` — Diaconis and
Freedman's partial exchangeability, the hypothesis of their de Finetti theorem for Markov chains
— and supplies both of its sources, so that the new predicate sits correctly in the symmetry
lattice from the start rather than being a name without content.

`TauCeti/Combinatorics/Enumerative/TransitionCount.lean` (new, 193 lines) carries the
combinatorial core, stated for words over an arbitrary alphabet with no probability in sight:
`occCount w a` counts the positions of `w` carrying the letter `a`, `transitionCount w a b` counts
the positions at which `a` is immediately followed by `b`, and `occCount_eq_of_transitionCount_eq`
is the conservation law — summing the transitions out of `a` counts the positions carrying `a`
other than the last, summing the transitions into `a` counts those other than the first, so once
the first letter is known the two expressions for `occCount w a` pin the last letter and then
every occurrence count. `exists_perm_comp_of_transitionCount_eq` glues the fibrewise bijections
into a permutation of the positions, and `prod_transitionCount` records that a product of
transition weights along a word depends on the word only through its transition counts.

`TauCeti/Probability/Exchangeability/MarkovExchangeable.lean` (new, 159 lines) defines
`MarkovExchangeable μ X` — paths of the same length that start at the same state and have the same
transition counts are equally likely — and proves `Exchangeable.markovExchangeable` (an
exchangeable process is Markov exchangeable, by the rearrangement lemma above),
`markovExchangeable_of_prefixLaw_singleton_eq` (a process whose finite path probabilities factor
as an initial weight times a product of transition weights — a Markov chain — is Markov
exchangeable), and `markovExchangeable_pathLaw_iff` (the process-level and path-law formulations
agree, as the roadmap's Layer 0 API warning asks of every symmetry notion here).

The implication `Exchangeable → MarkovExchangeable` is proved strict rather than asserted:
`TauCeti/Probability/Exchangeability/ThreeCycle.lean` gains `threeCycle_prefixLaw_singleton` and
`threeCycle_markovExchangeable`, so the deterministic 3-cycle already in the repository — which
`threeCycle_not_exchangeable` shows is not exchangeable — is exhibited as a Markov exchangeable
process, which also grounds the product-form hypothesis in an actual instance.
`TauCeti/Probability/Exchangeability.lean` re-exports the new predicate through the Layer 7
symmetry facade.

What remains for this milestone after this PR is the Diaconis–Freedman representation theorem
itself: a recurrent Markov exchangeable process is a mixture of Markov chains. That needs
recurrence of the state sequence and the excursion decomposition its proof runs on, neither of
which exists yet; the definition and the two implications landed here are what any statement of it
must be phrased against.

No Mathlib infrastructure was vendored, and no material is adapted from
`cameronfreer/exchangeability`, which treats exchangeable rather than Markov exchangeable
sequences.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"markovexchangeable"}-->

🤖 Prepared with Claude Code
