### PR TITLE
ci: restore TauCeti's oleans on main, and verify main from source nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           python3 scripts/pr_status/test_zulip.py
           python3 scripts/test_structure_nudge.py
           python3 scripts/test_workflow_pins.py
+          python3 scripts/test_landrun_pin.py
           PYTHONPATH=scripts python3 scripts/test_claims_access.py
           python3 scripts/test_lint_dot_notation.py
 
@@ -131,10 +132,18 @@ jobs:
 
       # Anonymous GETs from the PUBLIC read host, the same trusted, publisher-built data
       # pr-build restores. The shared script discards a partial fetch rather than keeping it;
-      # see its header. Reading main's own previous publication is not circular: artifacts are
-      # content-addressed by Lake input hash, so a restored module is byte-identical to what a
-      # fresh compile would produce, and every module this push actually changed misses the
-      # cache and is rebuilt here.
+      # see its header.
+      #
+      # What this does NOT establish: that a restored module matches what a compile of the
+      # checked-out source would produce. Lake keys artifacts by an input hash that is a single
+      # UInt64 and explicitly not cryptographic (Lake/Build/Trace.lean carries a TODO to replace
+      # it), so content addressing is a deduplication scheme here, not an integrity guarantee.
+      # Restoring on main also gives up main's former role as the one build that took nothing on
+      # faith. nightly-verify.yml reinstates it on a daily cadence: it rebuilds from source with the
+      # cache off and compares the resulting oleans byte for byte against a cache-restored build of
+      # the same commit. That is a detector, not an equivalent guarantee, and its own header spells
+      # out the exposure window it leaves. The two are a pair; do not enable this restore without
+      # that nightly running.
       - name: Fetch TauCeti's own oleans from the Lake cache
         if: ${{ env.TAUCETI_CACHE_ENABLED == '1' }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Enough history for `lake cache get` to backtrack to a recently-published
+          # ancestor commit (its `--max-revs`) when the tip itself has no mapping yet.
+          # Harmless (just a slightly deeper fetch) when the cache is off.
+          fetch-depth: 100
 
       - name: Infrastructure policy unit tests
         run: |
@@ -98,10 +103,56 @@ jobs:
             lake exe cache get!
           fi
 
+      # --- Lake artifact-cache restore (dormant until configured) --------------------
+      # Restore TauCeti's OWN oleans before building, exactly as pr-build.yml does. Without
+      # this, the post-merge run recompiled the whole library from scratch on every push,
+      # spending about 49 minutes to reproduce oleans the merge-queue build had produced
+      # minutes earlier. Because the publisher is serialized, that capped publication at
+      # roughly one snapshot an hour while several commits an hour were landing, and the
+      # permanently stale snapshot is what pushed merge-queue builds onto the roughly
+      # 55 minute cold-cache path.
+      # No-op until the LAKE_CACHE_*_PUBLIC repo variables are set, as on the consuming side.
+      - name: Configure the Lake artifact cache (no-op unless the public endpoints are set)
+        env:
+          PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          if [ -n "$PUBLIC_ARTIFACT_ENDPOINT" ] && [ -n "$PUBLIC_REVISION_ENDPOINT" ]; then
+            {
+              echo "LAKE_CACHE_DIR=$GITHUB_WORKSPACE/.lake/cache"
+              echo "LAKE_ARTIFACT_CACHE=true"
+              echo "LAKE_RESTORE_ARTIFACTS=true"
+              echo "TAUCETI_CACHE_ENABLED=1"
+            } >> "$GITHUB_ENV"
+            echo "::notice::Lake artifact cache enabled — restoring TauCeti's oleans and building incrementally"
+          else
+            echo "::notice::Lake artifact cache not configured — building TauCeti/ from scratch (set the LAKE_CACHE_*_PUBLIC repo variables to enable)"
+          fi
+
+      # Anonymous GETs from the PUBLIC read host, the same trusted, publisher-built data
+      # pr-build restores. The shared script discards a partial fetch rather than keeping it;
+      # see its header. Reading main's own previous publication is not circular: artifacts are
+      # content-addressed by Lake input hash, so a restored module is byte-identical to what a
+      # fresh compile would produce, and every module this push actually changed misses the
+      # cache and is rebuilt here.
+      - name: Fetch TauCeti's own oleans from the Lake cache
+        if: ${{ env.TAUCETI_CACHE_ENABLED == '1' }}
+        env:
+          # Passed under non-LAKE_ names so Lake never sees the deprecated endpoint
+          # environment variables; the script hands it the endpoints through a `--service` config.
+          PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: bash scripts/lake-cache-get.sh .
+
       # No aggregator check: the root TauCeti.lean is intentionally empty and imports nothing.
       # The build globs every TauCeti/ module directly, so nothing depends on a root that
       # re-exports the library.
       - name: Build
+        env:
+          # Restore only from the locally-populated $LAKE_CACHE_DIR the step above filled;
+          # never let the build itself reach a remote cache service. Same rule as the
+          # sandboxed build in pr-build.yml and as the publish step below.
+          LAKE_NO_CACHE: "true"
         run: lake build
 
       # Main is the sole publisher. PR and merge-group builds restore these trusted snapshots
@@ -130,6 +181,8 @@ jobs:
       # Quot.sound}, catching sorry/admit (sorryAx), native_decide (Lean.ofReduceBool),
       # and home-rolled axioms, including ones reaching in through imports.
       - name: Axiom audit (TauCeti/ uses only allowlisted axioms)
+        env:
+          LAKE_NO_CACHE: "true"
         run: lake exe axioms
 
       # Module-system audit. Inspects the built TauCeti `.olean`s and rejects any module that
@@ -137,6 +190,8 @@ jobs:
       # `ModuleData.isModule` flag from the compiled artifact, so it cannot be fooled by a
       # `module` appearing in a comment or string the way a textual grep could.
       - name: Module-system audit (every TauCeti/ file opts into `module`)
+        env:
+          LAKE_NO_CACHE: "true"
         run: lake exe module-system
 
       # Environment lint. Elaborates a generated driver importing every TauCeti/
@@ -151,6 +206,8 @@ jobs:
       # landrun sandbox in pr-build.yml (this lint executes the linted code); this
       # post-merge run is the health check on main, like the audits above.
       - name: Environment lint (default linters + docstring scan vs grandfathered baseline)
+        env:
+          LAKE_NO_CACHE: "true"
         run: bash scripts/lint-env.sh
 
       - name: Dot-notation namespace lint (Mathlib type namespaces stay at root)

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -1,0 +1,396 @@
+name: Nightly verification
+
+# Rebuild main from source with the Lake artifact cache switched off, and check that a clean
+# compile agrees byte for byte with what the cache serves.
+#
+# ci.yml used to be this check by accident: it recompiled the whole library on every push, so main
+# was an independent root of trust that never took a compiled artifact on faith. Restoring the cache
+# there (#3715) took the post-merge run from about 58 minutes to about 15 and lifted publication from
+# roughly one snapshot an hour to three or four, but it also retired that property. This workflow
+# reinstates it on a nightly cadence.
+#
+# What that cadence does and does not buy. It detects persistent corruption and gives every day a
+# commit with independently established provenance. It does NOT give every published revision its
+# own trusted provenance: a bad artifact landing just after a run can be consumed and republished
+# for a day, and if the affected module changes before the next run, no clean build ever judges the
+# revision that carried it. Closing that needs a promoted-snapshot scheme, where consumers read only
+# what a clean build has verified. That is a larger change; this is the cheap 90%.
+#
+# Two signals, deliberately not collapsed into one:
+#
+#   * The from-source build, audits and lints. The hard signal. It elaborates every module and means
+#     something whatever the cache did.
+#   * The byte comparison against a cache-restored build of the same commit. Advisory, because it
+#     assumes Lean output is reproducible for a fixed toolchain, source and platform. If the first
+#     runs show it is not, delete the comparison rather than let it cry wolf; the hard signal stands
+#     alone.
+#
+# Fail closed, not open. The comparison reports `inconclusive` and alerts whenever it could not
+# actually compare a cache-restored build against a clean one. The case that matters most, a cache
+# so broken that the restore falls back to building from source, would otherwise compare two clean
+# builds and report agreement: an unusable cache must never look like a verified one.
+#
+# The cache-restored build runs under landrun, because it imports the very artifacts it is meant to
+# be judging and importing Lean code executes its initializers. Only `reference` is mounted, with
+# `reference/.lake` writable; the clean build, its manifest and the comparator are outside the mount
+# set entirely. Both manifests are taken outside the sandbox, and the clean one is taken before the
+# reference workspace runs anything at all.
+
+on:
+  schedule:
+  - cron: "25 15 * * *"   # daily, offset from stuck-alerts (:50), merge-sweep (:40), housekeeping (:20)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-verify
+  # Never cancel mid-run: a partial verification tells us nothing, and killing a run after the
+  # from-source build but before the report wastes the expensive part.
+  cancel-in-progress: false
+
+jobs:
+  # No secrets reach this job. It builds and executes repository code, including a build restored
+  # from the public cache, so anything it can read is code-reachable. Reporting lives in a separate
+  # job for exactly that reason.
+  verify:
+    if: github.repository == 'TauCetiProject/TauCeti'
+    runs-on: ubuntu-latest
+    # The from-scratch build alone ran about 49 minutes as ci.yml's Build step before #3715, and the
+    # cache-restored build adds roughly 15. Generous headroom, but bounded; a run that hits this
+    # still reports, because the report job keys off the job result.
+    timeout-minutes: 240
+    outputs:
+      sha: ${{ steps.rev.outputs.sha }}
+      build: ${{ steps.fresh_build.outcome }}
+      audit: ${{ steps.fresh_audit.outcome }}
+      compare: ${{ steps.compare.outputs.status }}
+      detail: ${{ steps.compare.outputs.detail }}
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: fresh
+          # This job executes repository code and a cache-restored build; leaving the token in
+          # the workspace git config would put it within their reach.
+          persist-credentials: false
+          # Enough history for `lake cache get` to backtrack to a published ancestor in the
+          # reference workspace below.
+          fetch-depth: 100
+
+      - name: Resolve the commit under test
+        id: rev
+        run: |
+          set -euo pipefail
+          sha=$(git -C fresh rev-parse HEAD)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "verifying $sha"
+
+      # Pin the reference workspace to the SAME commit, by SHA rather than by branch: main advances
+      # several times an hour, and comparing two different trees would report everything as divergent.
+      - name: Check out the same commit for the reference build
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.rev.outputs.sha }}
+          path: reference
+          persist-credentials: false
+          fetch-depth: 100
+
+      # The cache-restored build below runs under landrun. See its step for why.
+      #
+      # The version and checksum are duplicated from pr-build.yml on purpose: that workflow is on
+      # the merge queue's critical path and runs from the BASE definition under
+      # pull_request_target, so a shared composite action introduced here would not be exercised
+      # by this PR's own build and a mistake in it would redden every PR. Drift is prevented by
+      # scripts/test_landrun_pin.py instead, which runs with the infrastructure policy tests.
+      - name: Install landrun (pinned + checksum) and self-test (fail closed)
+        env:
+          LANDRUN_SHA256: 645178e3239cd33760560834e50efea0864183a2a8a82faf199760dffee6dd71
+          LANDRUN_VER: v0.1.14
+        run: |
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/Zouuup/landrun/releases/download/${LANDRUN_VER}/landrun-linux-amd64" -o landrun
+          echo "${LANDRUN_SHA256}  landrun" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"; install -m 0755 landrun "$HOME/.local/bin/landrun"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          landrun --version || true
+          # Prove the sandbox enforces before trusting it with a cache-restored build: run works,
+          # out-of-tree write denied, /dev/shm write denied, network denied without the flag.
+          set +e
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo ok' >/dev/null 2>&1; ok=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo x > /etc/landrun-probe' >/dev/null 2>&1; wr=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo x > /dev/shm/landrun-probe' >/dev/null 2>&1; shm=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'curl -sS --max-time 8 https://example.com >/dev/null' >/dev/null 2>&1; net=$?
+          set -e
+          echo "self-test: run=$ok write=$wr shm=$shm net=$net (nonzero = denied for w/shm/net)"
+          if [ $ok -ne 0 ] || [ $wr -eq 0 ] || [ $shm -eq 0 ] || [ $net -eq 0 ]; then
+            echo "::error::landrun not enforcing (run=$ok write=$wr shm=$shm net=$net); refusing to run code under it"; exit 1
+          fi
+
+      - name: Install elan
+        run: |
+          curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
+          chmod +x elan-init.sh && ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      # One restore serves both workspaces: same commit, so same manifest and toolchain, and the
+      # action exports MATHLIB_CACHE_DIR for every later step. This holds Mathlib's artifacts only;
+      # TauCeti's own oleans are never in it, so it cannot pre-populate the from-source build.
+      - name: Restore Mathlib's compressed download cache
+        uses: ./fresh/.github/actions/restore-mathlib-ltars
+        with:
+          project-dir: fresh
+
+      - name: Fetch Mathlib oleans for both workspaces
+        run: |
+          set -euo pipefail
+          for dir in fresh reference; do
+            ( cd "$dir" && { lake exe cache get || lake exe cache get!; } )
+          done
+
+      # --- The hard signal: everything elaborated from source -------------------------------
+      # LAKE_RESTORE_ARTIFACTS=false and a workspace-local LAKE_CACHE_DIR that is never fetched into
+      # are what make this from scratch. LAKE_ARTIFACT_CACHE stays true only so the build packs its
+      # own outputs locally for the audits that follow; nothing is ever read from the network.
+      - name: Build main from source, with no cached artifacts
+        id: fresh_build
+        env:
+          LAKE_ARTIFACT_CACHE: "true"
+          LAKE_RESTORE_ARTIFACTS: "false"
+          LAKE_NO_CACHE: "true"
+          LAKE_CACHE_DIR: ${{ github.workspace }}/fresh/.lake/cache
+        run: ( cd fresh && lake build )
+
+      # Immediately after the clean build and before anything else runs here: the audits below
+      # build `scripts/Axioms.olean` and friends in this workspace only, which would read as
+      # divergence, and the cache-restored build later on shares this runner.
+      - name: Record what the clean build produced
+        run: python3 fresh/scripts/compare-build-outputs.py manifest fresh/.lake/build "$RUNNER_TEMP/clean-manifest.txt"
+
+      - name: Audit and lint the from-source build
+        id: fresh_audit
+        env:
+          LAKE_ARTIFACT_CACHE: "true"
+          LAKE_RESTORE_ARTIFACTS: "false"
+          LAKE_NO_CACHE: "true"
+          LAKE_CACHE_DIR: ${{ github.workspace }}/fresh/.lake/cache
+        run: |
+          set -euo pipefail
+          cd fresh
+          lake exe axioms
+          lake exe module-system
+          bash scripts/lint-env.sh
+          bash scripts/lint-style.sh
+
+      # --- The advisory signal: does the cache agree with a clean compile? -------------------
+      - name: Configure the Lake artifact cache for the reference build
+        id: refcfg
+        env:
+          PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          if [ -n "$PUBLIC_ARTIFACT_ENDPOINT" ] && [ -n "$PUBLIC_REVISION_ENDPOINT" ]; then
+            {
+              echo "LAKE_CACHE_DIR=$GITHUB_WORKSPACE/reference/.lake/cache"
+              echo "LAKE_ARTIFACT_CACHE=true"
+              echo "LAKE_RESTORE_ARTIFACTS=true"
+            } >> "$GITHUB_ENV"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Lake cache endpoints not configured — the comparison will report inconclusive"
+          fi
+
+      - name: Restore what the cache serves for this commit
+        id: restore
+        if: ${{ steps.refcfg.outputs.enabled == 'true' }}
+        continue-on-error: true
+        env:
+          PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: bash reference/scripts/lake-cache-get.sh reference
+
+      # The step above falls back to LAKE_ARTIFACT_CACHE=false when it cannot get a whole cache,
+      # which would leave the reference workspace building from source. Comparing that against the
+      # from-source build proves nothing while looking like agreement, so establish here whether a
+      # real restore happened and refuse to compare if it did not. GITHUB_ENV writes land in the
+      # next step, which is why this is a step of its own.
+      - name: Confirm the reference workspace really restored from the cache
+        id: restored
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.refcfg.outputs.enabled }}" != "true" ]; then
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            echo "why=the Lake cache endpoints are not configured" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.restore.outcome }}" != "success" ]; then
+            # `outcome` is the pre-continue-on-error result. Without this, a fetch that died
+            # after leaving a partial cache but before writing its fallback flags would look
+            # like a successful restore, and Lake rebuilding the gaps would look like agreement.
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            echo "why=the cache fetch did not complete successfully" >> "$GITHUB_OUTPUT"
+          elif [ "${LAKE_ARTIFACT_CACHE:-}" != "true" ] || [ "${LAKE_RESTORE_ARTIFACTS:-}" != "true" ]; then
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            echo "why=the cache fetch gave up and disabled artifact restoration" >> "$GITHUB_OUTPUT"
+          elif [ -z "$(find reference/.lake/cache -type f -print -quit 2>/dev/null)" ]; then
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            echo "why=the restored cache is empty" >> "$GITHUB_OUTPUT"
+          else
+            echo "restored=true" >> "$GITHUB_OUTPUT"
+            echo "why=" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Under landrun, because this build IMPORTS the artifacts it is meant to be judging, and
+      # importing Lean code executes its initializers (see scripts/lint-env.sh). Unsandboxed it
+      # could reach the clean build's outputs, the manifest recording them, or the comparator, and
+      # a poisoned artifact could arrange to be found identical to a clean one. The sandbox mounts
+      # only `reference` read-only with `reference/.lake` writable: `fresh` and $RUNNER_TEMP are
+      # not in the mount set at all, so the evidence is out of reach. Offline too, like pr-build's
+      # sandbox, so nothing here can fetch more than the restore step already placed on disk.
+      - name: Build the reference workspace from the cache, under landrun
+        id: reference_build
+        if: ${{ steps.restored.outputs.restored == 'true' }}
+        # A failure here is a finding, not an error: a poisoned or incomplete artifact looks exactly
+        # like this. It is turned into `inconclusive` below rather than swallowed.
+        continue-on-error: true
+        env:
+          LAKE_NO_CACHE: "true"
+        run: |
+          set -euo pipefail
+          mkdir -p reference/.lake/tmp
+          export PATH="$HOME/.local/bin:$HOME/.elan/bin:$PATH"
+          landrun --rox /usr --rox /etc \
+            --rw /dev/null --rox /dev/zero --rox /dev/urandom --rox /dev/random \
+            --rox "$HOME/.elan" \
+            --rox "$PWD/reference" --rw "$PWD/reference/.lake" \
+            --env PATH --env HOME --env CI \
+            --env LAKE_NO_CACHE --env LAKE_ARTIFACT_CACHE --env LAKE_RESTORE_ARTIFACTS --env LAKE_CACHE_DIR \
+            -- bash -euo pipefail -c 'cd reference && export TMPDIR="$PWD/.lake/tmp" && exec lake build'
+
+      # Outside the sandbox: the digests must be taken by code the build could not touch.
+      - name: Record what the cache-restored build produced
+        if: ${{ steps.reference_build.outcome == 'success' }}
+        run: python3 fresh/scripts/compare-build-outputs.py manifest reference/.lake/build "$RUNNER_TEMP/cached-manifest.txt"
+
+      # Always runs, and every path that could not actually compare a cache-restored build against a
+      # clean one reports `inconclusive`, which the report job treats as alert-worthy.
+      - name: Compare the two builds
+        id: compare
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.restored.outputs.restored }}" != "true" ]; then
+            {
+              echo "status=inconclusive"
+              echo "detail=nothing was compared: ${{ steps.restored.outputs.why }}"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ steps.reference_build.outcome }}" != "success" ]; then
+            {
+              echo "status=inconclusive"
+              echo "detail=the cache-restored build failed, which is itself what a poisoned or incomplete artifact looks like"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 fresh/scripts/compare-build-outputs.py compare \
+            "$RUNNER_TEMP/clean-manifest.txt" "$RUNNER_TEMP/cached-manifest.txt"
+
+  # Reporting is a separate job on a fresh runner with no checkout, so the Zulip credential never
+  # shares a machine with repository code, a cache-restored olean, or anything either could have
+  # written. It receives only the structured outputs above, and the Zulip client here is a dozen
+  # lines of standard library rather than an import from the tree being verified.
+  report:
+    needs: verify
+    # `always()` so a timed-out or cancelled verify still reports; without it the very failure this
+    # workflow exists to catch could pass in silence. Parenthesised because `&&` binds tighter
+    # than `||`.
+    # The repository guard matters here too: on a fork `verify` is skipped, and without it this
+    # job would fire on every schedule and fail for want of a Zulip secret it should not have.
+    if: ${{ always() && github.repository == 'TauCetiProject/TauCeti'
+            && (needs.verify.result != 'success' || needs.verify.outputs.compare != 'agree') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Post the divergence to Zulip
+        env:
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+          ZULIP_SITE: https://leanprover.zulipchat.com
+          ZULIP_CHANNEL: Tau Ceti
+          # A topic of its own, not "Stuck PRs": stuck_alerts.py reconciles that topic by marker and
+          # edits messages it recognises, so an unrelated post would sit inside its bookkeeping.
+          ZULIP_TOPIC: Nightly verification
+          RESULT: ${{ needs.verify.result }}
+          SHA: ${{ needs.verify.outputs.sha }}
+          BUILD: ${{ needs.verify.outputs.build }}
+          AUDIT: ${{ needs.verify.outputs.audit }}
+          COMPARE: ${{ needs.verify.outputs.compare }}
+          DETAIL: ${{ needs.verify.outputs.detail }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import base64
+          import json
+          import os
+          import sys
+          import urllib.parse
+          import urllib.request
+
+          sha = os.environ.get("SHA") or ""
+          where = (f"[`{sha[:8]}`](https://github.com/TauCetiProject/TauCeti/commit/{sha})"
+                   if sha else "an unresolved commit")
+          lines = [f"**Nightly verification did not come back clean** on {where}."]
+
+          # Deliberately does not claim the cached per-push CI passed for this SHA: main's CI
+          # coalesces intermediate commits, so this workflow's commit may never have had its own run.
+          if os.environ.get("RESULT") != "success":
+              if os.environ.get("BUILD") not in ("success", "", None):
+                  lines.append("The from-source build FAILED with the artifact cache disabled. "
+                               "Treat the published Lake cache as suspect until this is explained.")
+              elif os.environ.get("AUDIT") not in ("success", "", None):
+                  lines.append("main built from source, but an audit or lint FAILED there. "
+                               "Treat the published Lake cache as suspect until this is explained.")
+              else:
+                  lines.append(f"The verification job did not complete "
+                               f"(result: `{os.environ.get('RESULT')}`).")
+
+          compare = os.environ.get("COMPARE") or ""
+          detail = os.environ.get("DETAIL") or ""
+          if compare == "disagree":
+              lines.append(f"A clean compile and the cache-restored build of the same commit "
+                           f"produced DIFFERENT oleans: {detail}")
+          elif compare == "inconclusive":
+              lines.append(f"The comparison could not be made, which is not a pass: {detail}")
+          elif compare not in ("agree", ""):
+              lines.append(f"Unrecognised comparison status `{compare}`: {detail}")
+
+          lines.append(f"[Run log]({os.environ['RUN_URL']})")
+          content = "\n\n".join(lines)
+
+          email = (os.environ.get("ZULIP_EMAIL") or "").strip()
+          key = (os.environ.get("ZULIP_API_KEY") or "").strip()
+          site = (os.environ.get("ZULIP_SITE") or "").strip().rstrip("/")
+          if not (email and key and site):
+              print("::error::ZULIP_EMAIL / ZULIP_API_KEY not set; cannot report divergence")
+              sys.exit(1)
+
+          data = urllib.parse.urlencode({
+              "type": "stream",
+              "to": os.environ["ZULIP_CHANNEL"],
+              "topic": os.environ["ZULIP_TOPIC"],
+              "content": content,
+          }).encode()
+          req = urllib.request.Request(site + "/api/v1/messages", data=data, method="POST")
+          req.add_header("Authorization",
+                         "Basic " + base64.b64encode(f"{email}:{key}".encode()).decode())
+          req.add_header("Content-Type", "application/x-www-form-urlencoded")
+          # No retry: Zulip's send is not idempotent, and a duplicate emergency post is worse than
+          # a missed one when the run is red anyway.
+          with urllib.request.urlopen(req) as resp:
+              result = json.loads(resp.read().decode()).get("result")
+          print(f"posted to Zulip: {result}")
+          PY

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -459,141 +459,18 @@ jobs:
             echo "::notice::Lake artifact cache not configured — building TauCeti/ from scratch (set the LAKE_CACHE_*_PUBLIC repo variables to enable)"
           fi
 
-      # Anonymous GETs from the PUBLIC read host (a different host than the S3 API endpoint
-      # the trusted main upload uses). Looks up TauCeti's OWN root-package oleans for the
-      # base-branch revision — backtracking up to --max-revs ancestors — and unpacks them
-      # into the local Lake cache ($LAKE_CACHE_DIR). This is trusted, main-built data: no
-      # token is in reach and no PR code runs (lakefile.toml is declarative + base-trusted).
-      # Mathlib's oleans are NOT here; they come from `lake exe cache get` above.
-      #
-      # A TOTAL miss is non-fatal: the landrun build just recompiles from scratch, as when the
-      # cache is off. A PARTIAL fetch is a different matter. `lake cache get` continues past a
-      # failed download and exits nonzero (see `lake cache help get`), leaving input-to-output
-      # mappings whose artifacts never arrived. The landrun build below is offline and has no
-      # cache service configured, so it cannot fetch them: Lake logs a warning per affected
-      # module and correctly rebuilds it from source, but `lake build --iofail` is
-      # `--fail-level=info`, so those warnings fail a build in which every module compiled.
-      # Partial fetches are routine: they cost about a third of merge-group builds their cache.
-      # Fixed by https://github.com/leanprover/lean4/pull/14651, landing in v4.34.0-rc1;
-      # see https://github.com/TauCetiProject/TauCeti/issues/2062.
-      #
-      # Hence: retry from an EMPTY cache each time, then fall back to no cache at all. Retrying
-      # over the dirty cache a failed attempt left behind does not work: Lake skips any artifact
-      # already on disk, so the retry re-fetches only what is still MISSING and never revisits
-      # what the failed attempt got wrong. It then reports clean and the corruption survives
-      # into the build. Discarding between attempts is what makes a clean verdict mean the
-      # cache is whole; it is affordable because a failing attempt aborts in seconds and a full
-      # refetch is ~30s.
+      # Restore TauCeti's own root-package oleans from the public Lake cache. The fetch logic
+      # (retry-from-empty, then fall back to no cache at all) lives in the workflow-pinned
+      # trusted script so ci.yml's post-merge build can restore the very same way; see its
+      # header for why a partial fetch must be discarded rather than kept.
       - name: Fetch TauCeti's own oleans from the Lake cache (network, no token; no PR code)
         if: ${{ env.INFRA != '1' && env.TAUCETI_CACHE_ENABLED == '1' }}
         env:
           # Passed under non-LAKE_ names so Lake never sees the deprecated endpoint
-          # environment variables; we hand it the endpoints through a `--service` config.
+          # environment variables; the script hands it the endpoints through a `--service` config.
           PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
-        run: |
-          # Define the public read service in a Lake system config and select it with
-          # `--service` (the env-var form of endpoint config is deprecated). Anonymous
-          # GETs, so no key here.
-          CFG="$RUNNER_TEMP/lake-cache.toml"
-          cat > "$CFG" <<TOML
-          cache.defaultService = "tauceti-public"
-          [[cache.service]]
-          name = "tauceti-public"
-          kind = "s3"
-          artifactEndpoint = "$PUBLIC_ARTIFACT_ENDPOINT"
-          revisionEndpoint = "$PUBLIC_REVISION_ENDPOINT"
-          TOML
-          # `lake cache get` cannot be judged by exit status alone. Lake accumulates transfer
-          # failures into a local `didError` but then tests the stale `s.didError`
-          # (Lake/Config/Cache.lean, `if s.didError then failure`), so it can log
-          # "failed to download some artifacts" and still exit 0. An attempt therefore counts
-          # as clean only if it exits 0 AND logs no failure diagnostic.
-          # SIMPLIFY ON THE BUMP TO v4.34.0: that stale read is fixed by
-          # https://github.com/leanprover/lean4/pull/14651 ("fix: lake: gracefully handle curl
-          # and IO errors during transfer"), which missed v4.33.0-rc2 by hours and was not
-          # backported. From v4.34.0-rc1 on, drop FAIL_RE and trust `rc` alone.
-          # The purge below outlives that bump: it is for
-          # https://github.com/leanprover/lean4/issues/14670, still open.
-          # Discarding the cache must never fail the step. A plain `rm -rf` on a directory that
-          # Lake's stragglers are still writing into exits 1 with "Directory not empty", and under
-          # `set -e` that killed the whole build — worse than the partial cache it was clearing.
-          # Rename first (atomic, and unaffected by concurrent writes under the old path), then
-          # delete the renamed copy best-effort. What matters for correctness is only that the
-          # cache PATH is empty for the next attempt, not that the bytes are reclaimed promptly.
-          discard_cache() {
-            local d=base/.lake/cache
-            [ -e "$d" ] || return 0
-            if mv "$d" "$d.discard.$$" 2>/dev/null; then
-              rm -rf "$d.discard.$$" 2>/dev/null || true
-            else
-              rm -rf "$d" 2>/dev/null || true
-            fi
-            return 0
-          }
-          # `downloaded artifact hash mismatch` must be here. Lake handles a mismatch by deleting
-          # the artifact and setting `didError`, but the stale `didError` read below means the
-          # process can still exit 0, and the deletion leaves an input-to-output mapping whose
-          # artifact is gone. The offline build cannot refetch it, so that entry becomes a build
-          # failure rather than a rebuild. Treat it as unclean so the cache is refetched or dropped.
-          FAIL_RE='failed to download|output lookup failed|curl exited with code|downloaded artifact hash mismatch'
-          # A revision with no cached build at all is deterministic: retrying cannot change it,
-          # and there is nothing partial to discard.
-          MISS_RE='no outputs found'
-          # Six attempts, not three. Losing every attempt discards the whole cache and forces a
-          # ~22 minute full rebuild, which was happening on 4 of 18 sampled builds (the other 14
-          # took 2-3 minutes). The cause is lean4#14698: one unreadable artifact throws out of
-          # `computeFileHash`, which has no try/catch, so a single ENOENT aborts the entire fetch
-          # and discards every artifact already downloaded. Which artifact trips it varies between
-          # attempts, so re-fetching genuinely tends to succeed; at the observed per-attempt
-          # failure rate six attempts take whole-cache loss from roughly 22% to roughly 5%.
-          # Reduce this again once the fix (lean4#14651) reaches a released toolchain: it is on
-          # master only, and v4.33.0-rc2 was branched before it landed.
-          ATTEMPTS=6
-          clean=0
-          for attempt in $(seq 1 $ATTEMPTS); do
-            LOG="$RUNNER_TEMP/cache-get-$attempt.log"
-            rc=0
-            ( cd base && LAKE_CONFIG="$CFG" lake cache get --service tauceti-public \
-                --repo TauCetiProject/TauCeti ) > "$LOG" 2>&1 || rc=$?
-            cat "$LOG"
-            if [ "$rc" = 0 ] && ! grep -qE "$FAIL_RE" "$LOG"; then clean=1; break; fi
-            if grep -qE "$MISS_RE" "$LOG"; then break; fi
-            # `[ ... ] && sleep` would abort the step under `bash -e` on the last attempt,
-            # when the test is false and the whole list returns nonzero. Use a plain `if`.
-            if [ "$attempt" != "$ATTEMPTS" ]; then
-              echo "::notice::lake cache get attempt $attempt of $ATTEMPTS did not complete cleanly; discarding the partial cache and retrying"
-              # Sleep BEFORE discarding. A failed `lake cache get` returns as soon as one transfer
-              # errors, while its sibling curl/leantar processes are still writing into the cache
-              # dir; discarding at that instant races them. This is no longer a throttling backoff:
-              # the read endpoint serves these artifacts byte-identically under 48-way concurrency,
-              # so the failures are the Lake bug above rather than rate limiting, and a short fixed
-              # pause is enough to let the stragglers finish.
-              sleep 10
-              # Must precede the retry: see the step comment above. Without this, attempt N+1
-              # skips every artifact this attempt already wrote, including the broken ones, and
-              # a clean exit from it says nothing about the entries that made this attempt fail.
-              discard_cache
-            fi
-          done
-          if [ "$clean" != 1 ]; then
-            # Purge on ANY unclean outcome, not just a recognised download failure: an earlier
-            # attempt may have written mappings whose artifacts never arrived, and the last
-            # attempt's log alone does not witness that. A cache the offline build cannot fully
-            # resolve is worse than none, because each unresolvable entry becomes a build
-            # failure rather than a rebuild. Discarding it restores the no-cache path exactly.
-            echo "::warning::lake cache get did not complete cleanly; discarding the cache and building TauCeti/ from scratch"
-            discard_cache
-            # Empty is NOT off: Lake parses an empty LAKE_ARTIFACT_CACHE as "unspecified" and
-            # then defaults artifact-cache reads to true, and an empty LAKE_CACHE_DIR falls back
-            # to the workspace's own .lake/cache. Say false explicitly rather than relying on
-            # the directory above having just been deleted.
-            {
-              echo "LAKE_ARTIFACT_CACHE=false"
-              echo "LAKE_RESTORE_ARTIFACTS=false"
-              echo "LAKE_CACHE_DIR="
-            } >> "$GITHUB_ENV"
-          fi
+        run: bash gate/scripts/lake-cache-get.sh base
 
       - name: Prepare trusted read-only Lean watchdog toolchain
         if: ${{ env.INFRA != '1' }}

--- a/scripts/compare-build-outputs.py
+++ b/scripts/compare-build-outputs.py
@@ -1,0 +1,132 @@
+"""Snapshot and compare the compiled outputs of two builds of the same commit.
+
+Run with: python3 scripts/compare-build-outputs.py manifest BUILD_DIR OUT_FILE
+          python3 scripts/compare-build-outputs.py compare FRESH_MANIFEST REFERENCE_MANIFEST
+
+`manifest` records SHA-256 of every build artifact under BUILD_DIR. `compare` checks that two
+such manifests agree: every artifact must appear in both at the same relative path with the
+same digest. A difference means the cache handed a build something a clean compile of the same
+sources does not produce.
+
+The comparison is on SHA-256 of the file contents, deliberately not on Lake's own recorded
+output hashes. `Lake.Hash` is a single UInt64 and explicitly not cryptographic, so comparing
+Lake's hashes would inherit the very weakness this check exists to cover.
+
+Splitting snapshot from compare is what lets the caller hash the clean build BEFORE anything
+else runs on that machine. It also keeps the two sides symmetric: a manifest must be taken
+right after `lake build`, since later commands such as `lake exe axioms` add root-package
+outputs on one side only and would otherwise read as divergence.
+
+SUFFIXES is every artifact Lake produces for a module, not just `.olean`. A cache entry can
+differ in `Foo.olean.private` or in generated C while `Foo.olean` matches, and private and
+server oleans affect what later imports see.
+
+Statuses written to $GITHUB_OUTPUT as `status=`:
+
+  agree         every artifact matched
+  disagree      a path or a digest differed, in either direction
+  inconclusive  either manifest was empty, so there was nothing to compare
+
+`inconclusive` is a reportable outcome, not a pass. `compare` exits 0 in every case: the caller
+decides what to do, and the from-source build's own success must never depend on this script.
+"""
+
+import hashlib
+import os
+import sys
+
+SUFFIXES = (
+    ".olean", ".olean.private", ".olean.server",
+    ".ilean", ".ir", ".ir.sig", ".c", ".bc",
+)
+
+
+def manifest(root):
+    """Return {relative path: sha256} for every build artifact under `root`."""
+    out = {}
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            if not name.endswith(SUFFIXES):
+                continue
+            full = os.path.join(dirpath, name)
+            h = hashlib.sha256()
+            with open(full, "rb") as f:
+                for chunk in iter(lambda: f.read(1 << 20), b""):
+                    h.update(chunk)
+            out[os.path.relpath(full, root)] = h.hexdigest()
+    return out
+
+
+def read_manifest(path):
+    out = {}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            digest, _, rel = line.partition("  ")
+            out[rel] = digest
+    return out
+
+
+def do_manifest(build_dir, out_file):
+    entries = manifest(build_dir)
+    with open(out_file, "w", encoding="utf-8") as f:
+        for rel in sorted(entries):
+            f.write(f"{entries[rel]}  {rel}\n")
+    print(f"recorded {len(entries)} artifacts from {build_dir} into {out_file}")
+    return 0
+
+
+def do_compare(fresh_path, reference_path):
+    fresh, reference = read_manifest(fresh_path), read_manifest(reference_path)
+
+    only_fresh = sorted(set(fresh) - set(reference))
+    only_reference = sorted(set(reference) - set(fresh))
+    differing = sorted(k for k in set(fresh) & set(reference) if fresh[k] != reference[k])
+
+    print(f"clean-build artifacts:  {len(fresh)}")
+    print(f"cached-build artifacts: {len(reference)}")
+    print(f"only in clean:          {len(only_fresh)}")
+    print(f"only in cached:         {len(only_reference)}")
+    print(f"differing bytes:        {len(differing)}")
+
+    if not fresh or not reference:
+        status = "inconclusive"
+        detail = f"nothing to compare (clean {len(fresh)}, cached {len(reference)})"
+    elif only_fresh or only_reference or differing:
+        status = "disagree"
+        detail = (f"{len(differing)} differing, {len(only_fresh)} only in the clean build, "
+                  f"{len(only_reference)} only in the cached build")
+    else:
+        status = "agree"
+        detail = f"{len(fresh)} artifacts identical"
+
+    for label, items in (("differing", differing),
+                         ("only in the clean build", only_fresh),
+                         ("only in the cached build", only_reference)):
+        for path in items[:10]:
+            print(f"  {label}: {path}")
+        if len(items) > 10:
+            print(f"  ... and {len(items) - 10} more {label}")
+
+    print(f"status: {status} ({detail})")
+    step_output = os.environ.get("GITHUB_OUTPUT")
+    if step_output:
+        with open(step_output, "a", encoding="utf-8") as f:
+            f.write(f"status={status}\n")
+            f.write(f"detail={detail}\n")
+    return 0
+
+
+def main(argv):
+    if len(argv) == 4 and argv[1] == "manifest":
+        return do_manifest(argv[2], argv[3])
+    if len(argv) == 4 and argv[1] == "compare":
+        return do_compare(argv[2], argv[3])
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lake-cache-get.sh
+++ b/scripts/lake-cache-get.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# lake-cache-get.sh — restore TauCeti's OWN root-package oleans from the public Lake
+# artifact cache, factored out of .github/workflows/pr-build.yml so ci.yml can use the
+# same logic. Both callers want identical semantics: a clean whole cache, or none at all.
+#
+# Usage: bash scripts/lake-cache-get.sh <project-dir>
+#
+# Reads PUBLIC_ARTIFACT_ENDPOINT / PUBLIC_REVISION_ENDPOINT from the environment (the
+# LAKE_CACHE_*_PUBLIC repo variables). Expects LAKE_CACHE_DIR to be <project-dir>/.lake/cache.
+# On an unclean outcome it discards the cache and appends the LAKE_* disable lines to
+# $GITHUB_ENV, so the caller's build proceeds exactly as if the cache were switched off.
+#
+# Anonymous GETs from the PUBLIC read host (a different host than the S3 API endpoint the
+# trusted upload uses). Looks up the root-package oleans for the checkout's revision --
+# backtracking up to --max-revs ancestors, and unpacks them into $LAKE_CACHE_DIR. This is
+# trusted, publisher-built data: no token is in reach and no PR code runs (lakefile.toml is
+# declarative and base-trusted). Mathlib's oleans are NOT here; they come from
+# `lake exe cache get`.
+#
+# A TOTAL miss is non-fatal: the build just recompiles from scratch, as when the cache is off.
+# A PARTIAL fetch is a different matter. `lake cache get` continues past a failed download and
+# exits nonzero (see `lake cache help get`), leaving input-to-output mappings whose artifacts
+# never arrived. pr-build's sandboxed build is offline with no cache service configured, so it
+# cannot fetch them: Lake logs a warning per affected module and correctly rebuilds it from
+# source, but `lake build --iofail` is `--fail-level=info`, so those warnings fail a build in
+# which every module compiled. Partial fetches are routine: they cost about a third of
+# merge-group builds their cache. Fixed by https://github.com/leanprover/lean4/pull/14651,
+# landing in v4.34.0-rc1; see https://github.com/TauCetiProject/TauCeti/issues/2062.
+#
+# Hence: retry from an EMPTY cache each time, then fall back to no cache at all. Retrying over
+# the dirty cache a failed attempt left behind does not work: Lake skips any artifact already
+# on disk, so the retry re-fetches only what is still MISSING and never revisits what the failed
+# attempt got wrong. It then reports clean and the corruption survives into the build.
+# Discarding between attempts is what makes a clean verdict mean the cache is whole; it is
+# affordable because a failing attempt aborts in seconds and a full refetch is ~30s.
+set -euo pipefail
+
+PROJECT_DIR="${1:?usage: lake-cache-get.sh <project-dir>}"
+: "${PUBLIC_ARTIFACT_ENDPOINT:?PUBLIC_ARTIFACT_ENDPOINT is required}"
+: "${PUBLIC_REVISION_ENDPOINT:?PUBLIC_REVISION_ENDPOINT is required}"
+
+# Define the public read service in a Lake system config and select it with `--service`
+# (the env-var form of endpoint config is deprecated). Anonymous GETs, so no key here.
+CFG="${RUNNER_TEMP:-/tmp}/lake-cache.toml"
+cat > "$CFG" <<TOML
+cache.defaultService = "tauceti-public"
+[[cache.service]]
+name = "tauceti-public"
+kind = "s3"
+artifactEndpoint = "$PUBLIC_ARTIFACT_ENDPOINT"
+revisionEndpoint = "$PUBLIC_REVISION_ENDPOINT"
+TOML
+
+# Discarding the cache must never fail. A plain `rm -rf` on a directory that Lake's stragglers
+# are still writing into exits 1 with "Directory not empty", and under `set -e` that killed the
+# whole build, which is worse than the partial cache it was clearing. Rename first (atomic,
+# and unaffected by concurrent writes under the old path), then delete the renamed copy
+# best-effort. What matters for correctness is only that the cache PATH is empty for the next
+# attempt, not that the bytes are reclaimed promptly.
+discard_cache() {
+  local d="$PROJECT_DIR/.lake/cache"
+  [ -e "$d" ] || return 0
+  if mv "$d" "$d.discard.$$" 2>/dev/null; then
+    rm -rf "$d.discard.$$" 2>/dev/null || true
+  else
+    rm -rf "$d" 2>/dev/null || true
+  fi
+  return 0
+}
+
+# `lake cache get` cannot be judged by exit status alone. Lake accumulates transfer failures
+# into a local `didError` but then tests the stale `s.didError` (Lake/Config/Cache.lean,
+# `if s.didError then failure`), so it can log "failed to download some artifacts" and still
+# exit 0. An attempt therefore counts as clean only if it exits 0 AND logs no failure
+# diagnostic.
+# SIMPLIFY ON THE BUMP TO v4.34.0: that stale read is fixed by
+# https://github.com/leanprover/lean4/pull/14651 ("fix: lake: gracefully handle curl and IO
+# errors during transfer"), which missed v4.33.0-rc2 by hours and was not backported. From
+# v4.34.0-rc1 on, drop FAIL_RE and trust `rc` alone. The purge below outlives that bump: it is
+# for https://github.com/leanprover/lean4/issues/14670, still open.
+#
+# `downloaded artifact hash mismatch` must be here. Lake handles a mismatch by deleting the
+# artifact and setting `didError`, but the stale `didError` read means the process can still
+# exit 0, and the deletion leaves an input-to-output mapping whose artifact is gone. An offline
+# build cannot refetch it, so that entry becomes a build failure rather than a rebuild. Treat it
+# as unclean so the cache is refetched or dropped.
+FAIL_RE='failed to download|output lookup failed|curl exited with code|downloaded artifact hash mismatch'
+# A revision with no cached build at all is deterministic: retrying cannot change it, and there
+# is nothing partial to discard.
+MISS_RE='no outputs found'
+# Six attempts, not three. Losing every attempt discards the whole cache and forces a ~22 minute
+# full rebuild, which was happening on 4 of 18 sampled builds (the other 14 took 2-3 minutes).
+# The cause is lean4#14698: one unreadable artifact throws out of `computeFileHash`, which has
+# no try/catch, so a single ENOENT aborts the entire fetch and discards every artifact already
+# downloaded. Which artifact trips it varies between attempts, so re-fetching genuinely tends to
+# succeed; at the observed per-attempt failure rate six attempts take whole-cache loss from
+# roughly 22% to roughly 5%. Reduce this again once the fix (lean4#14651) reaches a released
+# toolchain: it is on master only, and v4.33.0-rc2 was branched before it landed.
+ATTEMPTS=6
+clean=0
+for attempt in $(seq 1 $ATTEMPTS); do
+  LOG="${RUNNER_TEMP:-/tmp}/cache-get-$attempt.log"
+  rc=0
+  ( cd "$PROJECT_DIR" && LAKE_CONFIG="$CFG" lake cache get --service tauceti-public \
+      --repo TauCetiProject/TauCeti ) > "$LOG" 2>&1 || rc=$?
+  cat "$LOG"
+  if [ "$rc" = 0 ] && ! grep -qE "$FAIL_RE" "$LOG"; then clean=1; break; fi
+  if grep -qE "$MISS_RE" "$LOG"; then break; fi
+  # `[ ... ] && sleep` would abort the script under `bash -e` on the last attempt, when the
+  # test is false and the whole list returns nonzero. Use a plain `if`.
+  if [ "$attempt" != "$ATTEMPTS" ]; then
+    echo "::notice::lake cache get attempt $attempt of $ATTEMPTS did not complete cleanly; discarding the partial cache and retrying"
+    # Sleep BEFORE discarding. A failed `lake cache get` returns as soon as one transfer errors,
+    # while its sibling curl/leantar processes are still writing into the cache dir; discarding
+    # at that instant races them. This is not a throttling backoff: the read endpoint serves
+    # these artifacts byte-identically under 48-way concurrency, so the failures are the Lake bug
+    # above rather than rate limiting, and a short fixed pause is enough to let the stragglers
+    # finish.
+    sleep 10
+    # Must precede the retry: see the header. Without this, attempt N+1 skips every artifact this
+    # attempt already wrote, including the broken ones, and a clean exit from it says nothing
+    # about the entries that made this attempt fail.
+    discard_cache
+  fi
+done
+
+if [ "$clean" != 1 ]; then
+  # Purge on ANY unclean outcome, not just a recognised download failure: an earlier attempt may
+  # have written mappings whose artifacts never arrived, and the last attempt's log alone does
+  # not witness that. A cache the build cannot fully resolve is worse than none, because each
+  # unresolvable entry becomes a build failure rather than a rebuild under `--iofail`.
+  # Discarding it restores the no-cache path exactly.
+  echo "::warning::lake cache get did not complete cleanly; discarding the cache and building TauCeti/ from scratch"
+  discard_cache
+  # Empty is NOT off: Lake parses an empty LAKE_ARTIFACT_CACHE as "unspecified" and then defaults
+  # artifact-cache reads to true, and an empty LAKE_CACHE_DIR falls back to the workspace's own
+  # .lake/cache. Say false explicitly rather than relying on the directory above having just been
+  # deleted.
+  {
+    echo "LAKE_ARTIFACT_CACHE=false"
+    echo "LAKE_RESTORE_ARTIFACTS=false"
+    echo "LAKE_CACHE_DIR="
+  } >> "${GITHUB_ENV:-/dev/null}"
+fi

--- a/scripts/test_landrun_pin.py
+++ b/scripts/test_landrun_pin.py
@@ -1,0 +1,53 @@
+"""Ensure every workflow that runs code under landrun trusts the same binary.
+
+Run with: python3 scripts/test_landrun_pin.py
+
+pr-build.yml sandboxes untrusted PR sources; nightly-verify.yml sandboxes a cache-restored
+build that imports the artifacts it is judging. Both pin the landrun release and its SHA-256,
+and both would be weakened by trusting a different binary than the other.
+
+The pin is deliberately duplicated rather than shared through a composite action: pr-build.yml
+sits on the merge queue's critical path and runs from the base definition under
+pull_request_target, so a shared action could not be exercised by the PR that introduced it.
+This test is what stops the copies drifting.
+"""
+
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOWS = (
+    ROOT / ".github/workflows/pr-build.yml",
+    ROOT / ".github/workflows/nightly-verify.yml",
+)
+SHA = re.compile(r"^\s*LANDRUN_SHA256:\s*([0-9a-f]{64})\s*$", re.MULTILINE)
+VER = re.compile(r"^\s*LANDRUN_VER:\s*(v[0-9][0-9A-Za-z.\-]*)\s*$", re.MULTILINE)
+
+
+class LandrunPin(unittest.TestCase):
+    def test_every_sandboxing_workflow_pins_the_same_landrun(self):
+        seen = {}
+        for workflow in WORKFLOWS:
+            text = workflow.read_text()
+            shas, vers = SHA.findall(text), VER.findall(text)
+            self.assertEqual(len(shas), 1, f"expected one LANDRUN_SHA256 in {workflow.name}")
+            self.assertEqual(len(vers), 1, f"expected one LANDRUN_VER in {workflow.name}")
+            seen[workflow.name] = (vers[0], shas[0])
+        distinct = set(seen.values())
+        self.assertEqual(
+            len(distinct), 1,
+            "workflows disagree on which landrun to trust: "
+            + ", ".join(f"{name} pins {ver} {sha}" for name, (ver, sha) in sorted(seen.items())),
+        )
+
+    def test_every_sandboxing_workflow_verifies_the_checksum(self):
+        # A pin that is downloaded but never checked is not a pin.
+        for workflow in WORKFLOWS:
+            with self.subTest(workflow=workflow.name):
+                self.assertIn('echo "${LANDRUN_SHA256}  landrun" | sha256sum -c -',
+                              workflow.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR makes the post-merge run on `main` restore TauCeti's own oleans from the Lake artifact cache before building, and adds a nightly workflow that rebuilds `main` from source with the cache switched off and reports any disagreement to Zulip. The two changes are a pair and should not be separated.

`ci.yml` is the cache publisher, but it never consumed the cache it publishes: its `Build` step was a plain `lake build`, and the `LAKE_ARTIFACT_CACHE` / `LAKE_RESTORE_ARTIFACTS` knobs appeared only in the publish step at the end. Over the eleven runs sampled on 2026-08-17/18 that build step took a median of 49 minutes, reproducing oleans a merge-queue `pr-build` had produced for the identical tree minutes earlier, and the whole job took a median of 58 minutes. Since #3029 serialized the publisher, that put a hard ceiling of roughly one published snapshot per hour against five to eight commits landing per hour, so the snapshot merge-group builds restore from was permanently about an hour stale. That is what puts them on the cold path: across the last thirty merge-group builds the sandboxed build step was bimodal, 7 to 9 minutes on a cache hit and 50 to 57 minutes on a miss, with eleven of the thirty paying the full rebuild.

Restoring on `main` should take that run from about 58 minutes to about 15 to 20, and with it the publication rate from one snapshot an hour to three or four.

That 49 minute rebuild was not only waste, though, and this is why the nightly comes with it. It made `main` the one build in the system that took no compiled artifact on faith. Removing it means nothing ever builds from source, so a wrong artifact in the bucket would persist and be re-published under every later `main` revision. Lake keys artifacts by an input hash that is a single `UInt64` and explicitly not cryptographic, with a standing upstream TODO to replace it, so content addressing deduplicates here rather than guaranteeing integrity.

`nightly-verify.yml` buys the property back on a nightly cadence instead of a per-push one. It resolves `main` to a SHA, checks that commit out twice, and produces two signals that are deliberately not collapsed into one. The hard signal is a from-scratch build of the first workspace with artifact restoration off, followed by the axiom audit, the module-system audit, the environment lint and the source style lint; it elaborates every module and means something whatever the cache did. The advisory signal restores the second workspace from the published cache and compares the two builds' Lake input-to-output mappings, since any input hash both know about must map to the same output. Either signal posts to Zulip, under its own topic so that `stuck_alerts.py`'s marker reconciliation in "Stuck PRs" is left alone. A red run alone would not do: nothing watches this workflow's colour.

The comparison rests on Lean's output being reproducible for a fixed toolchain, source and platform, which is not measured here. It is therefore advisory in the strict sense: it runs under `continue-on-error`, it never gates the hard signal, and the comparator exits zero whether or not the mappings agree. If the first runs show that oleans are not bit-reproducible, remove the comparison rather than let it cry wolf; the from-source build stands on its own.

The fetch logic moves to `scripts/lake-cache-get.sh` unchanged and both workflows now call it, so the two sides cannot drift. Its retry-from-empty behaviour matters as much on `main` as in `pr-build`: a partial `lake cache get` leaves mappings whose artifacts never arrived, and keeping one is worse than keeping none.

The `ci.yml` checkout deepens to `fetch-depth: 100` so `lake cache get` can backtrack to a published ancestor when the tip itself has no mapping yet, matching `pr-build`. `LAKE_NO_CACHE` is set on `Build` and on the three Lake invocations after it, so switching the artifact cache on cannot send any of them to a remote cache service; the `lake exe cache get` step that fetches Mathlib is deliberately left alone.

Two things this does not address, both pre-existing and both found while reviewing it. `main` builds unsandboxed, and its publish step puts `$HOME/.elan/bin` ahead of the system path before passing the upload secret through `sed`, which is #3720. And the 64-bit input hash is a weak binding between source and artifact for `pr-build` too, not only here; that needs an upstream fix.

Roadmap: none

🤖 Prepared with Claude Code