### PR TITLE
feat: construct Galois invariants of group algebras

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Descent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Descent.lean
@@ -42,7 +42,7 @@ finite-rank free lattice, `D(M)` is a split torus.
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Corollary 12.24.
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Appendix A.64.
 
 This is the automorphism-action step used for semilinear descent in Layer 4, "Tori: split and
 non-split", of the ReductiveGroups roadmap. Taking invariants and identifying their scalar
@@ -190,6 +190,46 @@ theorem groupAlgebraTensorActionSemilinearEquiv_tmul
       groupAlgebraAction rho sigma x ⊗ₜ[L] groupAlgebraAction rho sigma y := by
   rw [groupAlgebraTensorActionSemilinearEquiv, TensorProduct.congr_tmul]
   simp only [groupAlgebraActionSemilinearEquiv_apply]
+
+/-- The tensor-square action is semilinear over the coefficient field. -/
+@[simp]
+theorem groupAlgebraTensorActionSemilinearEquiv_smul
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) (sigma : L ≃ₐ[k] L)
+    (a : L)
+    (t : MonoidAlgebra L (Multiplicative M) ⊗[L]
+      MonoidAlgebra L (Multiplicative M)) :
+    groupAlgebraTensorActionSemilinearEquiv rho sigma (a • t) =
+      sigma a • groupAlgebraTensorActionSemilinearEquiv rho sigma t :=
+  (groupAlgebraTensorActionSemilinearEquiv rho sigma).map_smulₛₗ a t
+
+/-- The tensor-square action preserves the multiplicative identity. -/
+@[simp]
+theorem groupAlgebraTensorActionSemilinearEquiv_map_one
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) (sigma : L ≃ₐ[k] L) :
+    groupAlgebraTensorActionSemilinearEquiv rho sigma 1 = 1 := by
+  rw [Algebra.TensorProduct.one_def,
+    groupAlgebraTensorActionSemilinearEquiv_tmul]
+  simp
+
+/-- The tensor-square action preserves multiplication. -/
+@[simp]
+theorem groupAlgebraTensorActionSemilinearEquiv_map_mul
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) (sigma : L ≃ₐ[k] L)
+    (x y : MonoidAlgebra L (Multiplicative M) ⊗[L]
+      MonoidAlgebra L (Multiplicative M)) :
+    groupAlgebraTensorActionSemilinearEquiv rho sigma (x * y) =
+      groupAlgebraTensorActionSemilinearEquiv rho sigma x *
+        groupAlgebraTensorActionSemilinearEquiv rho sigma y := by
+  induction x using TensorProduct.induction_on with
+  | zero => rw [zero_mul, map_zero, zero_mul]
+  | tmul x₁ x₂ =>
+      induction y using TensorProduct.induction_on with
+      | zero => rw [mul_zero, map_zero, mul_zero]
+      | tmul y₁ y₂ =>
+          simp only [Algebra.TensorProduct.tmul_mul_tmul,
+            groupAlgebraTensorActionSemilinearEquiv_tmul, map_mul]
+      | add y₁ y₂ hy₁ hy₂ => simp only [mul_add, map_add, hy₁, hy₂]
+  | add x₁ x₂ hx₁ hx₂ => simp only [add_mul, map_add, hx₁, hx₂]
 
 /-- The tensor-square action of the identity automorphism is the identity. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Invariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Invariants.lean
@@ -6,7 +6,7 @@ Authors: Codex
 module
 
 public import Mathlib.FieldTheory.Galois.Infinite
-public import TauCeti.Algebra.AlgebraicGroup.GroupAlgebra.GaloisDescent
+public import TauCeti.Algebra.AlgebraicGroup.GroupAlgebra.Galois.Descent
 public import TauCeti.Algebra.HopfAlgebra.Antipode
 
 /-!
@@ -18,7 +18,7 @@ representation of `Gal(L/k)`. The simultaneous action on coefficients and expone
 that the Hopf operations preserve the corresponding descent data.
 
 The counit of an invariant element is fixed by every automorphism of `L/k`, hence belongs to `k`.
-The antipode preserves the invariant subalgebra. Comultiplication lands in the fixed submodule of
+The antipode preserves the invariant subalgebra. Comultiplication lands in the fixed subalgebra of
 the tensor square for the diagonal semilinear action. The latter is deliberately not identified
 here with the tensor square of the invariant subalgebra: that identification is the faithfully
 flat scalar-extension theorem needed in the next descent step.
@@ -35,7 +35,7 @@ flat scalar-extension theorem needed in the next descent step.
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Corollary 12.24.
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Appendix A.64.
 
 This is the invariant-algebra step in Layer 4, "Tori: split and non-split", of the
 ReductiveGroups roadmap. It follows the semilinear group-algebra action and precedes the theorem
@@ -119,19 +119,29 @@ private noncomputable def groupAlgebraInvariantsCounitToBot
     ((Bialgebra.counitAlgHom L
       (MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
         (groupAlgebraInvariants rho).val
-  exact
-  { toFun := fun x ↦ ⟨f x, by
+  have hmem : ∀ x, f x ∈ (⊥ : IntermediateField k L) := fun x ↦ by
       rw [InfiniteGalois.mem_bot_iff_fixed]
       intro sigma
       simp only [f, AlgHom.comp_apply, AlgHom.restrictScalars_apply,
         Subalgebra.val_apply, Bialgebra.counitAlgHom_apply]
       rw [← counit_groupAlgebraAction rho sigma,
-        (mem_groupAlgebraInvariants_iff rho x).mp x.property sigma]⟩
+        (mem_groupAlgebraInvariants_iff rho x).mp x.property sigma]
+  exact
+  { toFun := fun x ↦ ⟨f x, hmem x⟩
     map_one' := Subtype.ext f.map_one
     map_mul' x y := Subtype.ext (f.map_mul x y)
     map_zero' := Subtype.ext f.map_zero
     map_add' x y := Subtype.ext (f.map_add x y)
     commutes' r := Subtype.ext (f.commutes r) }
+
+/-- The restricted-codomain counit agrees with the ordinary group-algebra counit in `L`. -/
+@[simp]
+private theorem coe_groupAlgebraInvariantsCounitToBot_apply
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    (groupAlgebraInvariantsCounitToBot rho x : L) =
+      Coalgebra.counit (R := L) (x : MonoidAlgebra L (Multiplicative M)) :=
+  rfl
 
 /-- The counit of the descended invariant algebra. Invariance forces the original `L`-valued
 counit to lie in the image of `k`, and Galois fixed-field descent identifies that image with `k`.
@@ -159,7 +169,8 @@ theorem algebraMap_groupAlgebraInvariantsCounit
           ((IntermediateField.botEquiv k L) y) : (⊥ : IntermediateField k L)) : L) :=
       (IntermediateField.coe_algebraMap_apply (S := (⊥ : IntermediateField k L)) _).symm
     _ = (y : L) := h
-    _ = Coalgebra.counit (R := L) (x : MonoidAlgebra L (Multiplicative M)) := rfl
+    _ = Coalgebra.counit (R := L) (x : MonoidAlgebra L (Multiplicative M)) :=
+      coe_groupAlgebraInvariantsCounitToBot_apply rho x
 
 end Galois
 
@@ -247,10 +258,10 @@ theorem groupAlgebraInvariantsAntipode_symm
   apply (groupAlgebraInvariantsAntipode rho).injective
   rw [AlgEquiv.apply_symm_apply, groupAlgebraInvariantsAntipode_apply_apply]
 
-/-- The fixed `k`-submodule of the tensor square for the diagonal semilinear Galois action. -/
+/-- The fixed `k`-subalgebra of the tensor square for the diagonal semilinear Galois action. -/
 noncomputable def groupAlgebraTensorInvariants
     (rho : Representation ℤ (L ≃ₐ[k] L) M) :
-    Submodule k
+    Subalgebra k
       (MonoidAlgebra L (Multiplicative M) ⊗[L]
         MonoidAlgebra L (Multiplicative M)) := by
   let T := MonoidAlgebra L (Multiplicative M) ⊗[L]
@@ -263,18 +274,27 @@ noncomputable def groupAlgebraTensorInvariants
       mul_smul := groupAlgebraTensorActionSemilinearEquiv_mul rho
       smul_zero := fun sigma ↦ map_zero (groupAlgebraTensorActionSemilinearEquiv rho sigma)
       smul_add := fun sigma ↦ map_add (groupAlgebraTensorActionSemilinearEquiv rho sigma) }
-  exact
-  { FixedPoints.addSubgroup (L ≃ₐ[k] L) T with
-    smul_mem' := fun r x hx sigma ↦ by
-      have hsigma := hx sigma
-      change groupAlgebraTensorActionSemilinearEquiv rho sigma x = x at hsigma
-      change groupAlgebraTensorActionSemilinearEquiv rho sigma (r • x) = r • x
-      rw [← IsScalarTower.algebraMap_smul L r x,
-        (groupAlgebraTensorActionSemilinearEquiv rho sigma).map_smulₛₗ]
-      change sigma (algebraMap k L r) •
-          groupAlgebraTensorActionSemilinearEquiv rho sigma x =
-        algebraMap k L r • x
-      rw [sigma.commutes, hsigma, IsScalarTower.algebraMap_smul L r x] }
+  have action_apply (sigma : L ≃ₐ[k] L) (t : T) :
+      sigma • t = groupAlgebraTensorActionSemilinearEquiv rho sigma t := rfl
+  let fixedSubmodule : Submodule k T :=
+    { FixedPoints.addSubgroup (L ≃ₐ[k] L) T with
+      smul_mem' := fun r x hx sigma ↦ by
+        have hsigma : groupAlgebraTensorActionSemilinearEquiv rho sigma x = x := hx sigma
+        rw [action_apply, ← IsScalarTower.algebraMap_smul L r x,
+          groupAlgebraTensorActionSemilinearEquiv_smul, sigma.commutes, hsigma,
+          IsScalarTower.algebraMap_smul L r x] }
+  exact fixedSubmodule.toSubalgebra
+    (fun sigma ↦ by
+      rw [action_apply]
+      exact groupAlgebraTensorActionSemilinearEquiv_map_one rho sigma)
+    (fun x y hx hy sigma ↦ by
+      have hx' : groupAlgebraTensorActionSemilinearEquiv rho sigma x = x := by
+        rw [← action_apply]
+        exact hx sigma
+      have hy' : groupAlgebraTensorActionSemilinearEquiv rho sigma y = y := by
+        rw [← action_apply]
+        exact hy sigma
+      rw [action_apply, groupAlgebraTensorActionSemilinearEquiv_map_mul, hx', hy'])
 
 /-- Membership among invariant tensors means being fixed by the diagonal action. -/
 @[simp]
@@ -297,42 +317,18 @@ private theorem comul_mem_groupAlgebraTensorInvariants
   rw [← comul_groupAlgebraAction rho sigma,
     (mem_groupAlgebraInvariants_iff rho x).mp x.property sigma]
 
-/-- The linear map underlying comultiplication into invariant tensors. -/
-private noncomputable def groupAlgebraInvariantsComulLinearMap
-    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
-    groupAlgebraInvariants rho →ₗ[k] groupAlgebraTensorInvariants rho :=
-  ((((Coalgebra.comul (R := L)
-      (A := MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
-        (groupAlgebraInvariants rho).val.toLinearMap).codRestrict
-          (groupAlgebraTensorInvariants rho) fun x ↦
-            comul_mem_groupAlgebraTensorInvariants rho x)
-
-private theorem coe_groupAlgebraInvariantsComulLinearMap_apply
-    (rho : Representation ℤ (L ≃ₐ[k] L) M)
-    (x : groupAlgebraInvariants rho) :
-    (groupAlgebraInvariantsComulLinearMap rho x :
-        MonoidAlgebra L (Multiplicative M) ⊗[L]
-          MonoidAlgebra L (Multiplicative M)) =
-      Coalgebra.comul (R := L) (x : MonoidAlgebra L (Multiplicative M)) := by
-  have h := LinearMap.congr_fun
-    (LinearMap.subtype_comp_codRestrict
-      (f := ((Coalgebra.comul (R := L)
-        (A := MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
-          (groupAlgebraInvariants rho).val.toLinearMap)
-      (groupAlgebraTensorInvariants rho) fun x ↦
-        comul_mem_groupAlgebraTensorInvariants rho x) x
-  simpa only [groupAlgebraInvariantsComulLinearMap, LinearMap.comp_apply,
-    LinearMap.restrictScalars_apply, Submodule.subtype_apply, AlgHom.toLinearMap_apply,
-    Subalgebra.val_apply] using h
-
 /-- Comultiplication from invariant elements to tensors invariant under the diagonal action.
 
 Identifying the codomain with the tensor square of `groupAlgebraInvariants rho` is the subsequent
 faithfully flat descent step. -/
 noncomputable def groupAlgebraInvariantsComul
     (rho : Representation ℤ (L ≃ₐ[k] L) M) :
-    groupAlgebraInvariants rho →ₗ[k] groupAlgebraTensorInvariants rho :=
-  groupAlgebraInvariantsComulLinearMap rho
+    groupAlgebraInvariants rho →ₐ[k] groupAlgebraTensorInvariants rho :=
+  ((((Bialgebra.comulAlgHom L
+      (MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+        (groupAlgebraInvariants rho).val).codRestrict
+          (groupAlgebraTensorInvariants rho) fun x ↦
+            comul_mem_groupAlgebraTensorInvariants rho x)
 
 /-- The restricted comultiplication acts by the ordinary group-algebra comultiplication. -/
 @[simp]
@@ -344,6 +340,15 @@ theorem groupAlgebraInvariantsComul_apply
           MonoidAlgebra L (Multiplicative M)) =
       Coalgebra.comul (R := L) (x : MonoidAlgebra L (Multiplicative M)) :=
   by
-    exact coe_groupAlgebraInvariantsComulLinearMap_apply rho x
+    have h := AlgHom.congr_fun
+      (AlgHom.val_comp_codRestrict
+        (((Bialgebra.comulAlgHom L
+          (MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+            (groupAlgebraInvariants rho).val)
+        (groupAlgebraTensorInvariants rho) fun x ↦
+          comul_mem_groupAlgebraTensorInvariants rho x) x
+    simpa only [groupAlgebraInvariantsComul, AlgHom.comp_apply,
+      AlgHom.restrictScalars_apply, Subalgebra.val_apply,
+      Bialgebra.comulAlgHom_apply] using h
 
 end TauCeti.GaloisDescent

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Invariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Invariants.lean
@@ -266,35 +266,23 @@ noncomputable def groupAlgebraTensorInvariants
         MonoidAlgebra L (Multiplicative M)) := by
   let T := MonoidAlgebra L (Multiplicative M) ⊗[L]
     MonoidAlgebra L (Multiplicative M)
-  letI : SMul (L ≃ₐ[k] L) T :=
-    ⟨fun sigma t ↦ groupAlgebraTensorActionSemilinearEquiv rho sigma t⟩
-  letI : DistribMulAction (L ≃ₐ[k] L) T :=
+  letI : MulSemiringAction (L ≃ₐ[k] L) T :=
     { smul := fun sigma t ↦ groupAlgebraTensorActionSemilinearEquiv rho sigma t
       one_smul := groupAlgebraTensorActionSemilinearEquiv_one rho
       mul_smul := groupAlgebraTensorActionSemilinearEquiv_mul rho
       smul_zero := fun sigma ↦ map_zero (groupAlgebraTensorActionSemilinearEquiv rho sigma)
-      smul_add := fun sigma ↦ map_add (groupAlgebraTensorActionSemilinearEquiv rho sigma) }
+      smul_add := fun sigma ↦ map_add (groupAlgebraTensorActionSemilinearEquiv rho sigma)
+      smul_one := groupAlgebraTensorActionSemilinearEquiv_map_one rho
+      smul_mul := groupAlgebraTensorActionSemilinearEquiv_map_mul rho }
   have action_apply (sigma : L ≃ₐ[k] L) (t : T) :
       sigma • t = groupAlgebraTensorActionSemilinearEquiv rho sigma t := rfl
-  let fixedSubmodule : Submodule k T :=
-    { FixedPoints.addSubgroup (L ≃ₐ[k] L) T with
-      smul_mem' := fun r x hx sigma ↦ by
-        have hsigma : groupAlgebraTensorActionSemilinearEquiv rho sigma x = x := hx sigma
-        rw [action_apply, ← IsScalarTower.algebraMap_smul L r x,
-          groupAlgebraTensorActionSemilinearEquiv_smul, sigma.commutes, hsigma,
-          IsScalarTower.algebraMap_smul L r x] }
-  exact fixedSubmodule.toSubalgebra
-    (fun sigma ↦ by
-      rw [action_apply]
-      exact groupAlgebraTensorActionSemilinearEquiv_map_one rho sigma)
-    (fun x y hx hy sigma ↦ by
-      have hx' : groupAlgebraTensorActionSemilinearEquiv rho sigma x = x := by
-        rw [← action_apply]
-        exact hx sigma
-      have hy' : groupAlgebraTensorActionSemilinearEquiv rho sigma y = y := by
-        rw [← action_apply]
-        exact hy sigma
-      rw [action_apply, groupAlgebraTensorActionSemilinearEquiv_map_mul, hx', hy'])
+  letI : SMulCommClass (L ≃ₐ[k] L) k T :=
+    ⟨fun sigma r t ↦ by
+      rw [action_apply, ← IsScalarTower.algebraMap_smul L r t,
+        groupAlgebraTensorActionSemilinearEquiv_smul, sigma.commutes,
+        IsScalarTower.algebraMap_smul L r
+          (groupAlgebraTensorActionSemilinearEquiv rho sigma t), action_apply]⟩
+  exact FixedPoints.subalgebra k T (L ≃ₐ[k] L)
 
 /-- Membership among invariant tensors means being fixed by the diagonal action. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/GaloisInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/GaloisInvariants.lean
@@ -1,0 +1,275 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.FieldTheory.Galois.Infinite
+public import TauCeti.Algebra.AlgebraicGroup.GroupAlgebra.GaloisDescent
+public import TauCeti.Algebra.HopfAlgebra.Antipode
+
+/-!
+# Galois invariants of a group algebra
+
+Let `L/k` be a Galois extension and let `M` be an abelian group carrying an integral
+representation of `Gal(L/k)`. The simultaneous action on coefficients and exponents of
+`L[Multiplicative M]` has a fixed `k`-subalgebra. This file constructs that subalgebra and proves
+that the Hopf operations preserve the corresponding descent data.
+
+The counit of an invariant element is fixed by every automorphism of `L/k`, hence belongs to `k`.
+The antipode preserves the invariant subalgebra. Comultiplication lands in the fixed submodule of
+the tensor square for the diagonal semilinear action. The latter is deliberately not identified
+here with the tensor square of the invariant subalgebra: that identification is the faithfully
+flat scalar-extension theorem needed in the next descent step.
+
+## Main declarations
+
+* `TauCeti.GaloisDescent.groupAlgebraInvariants`: the fixed `k`-subalgebra of the split group
+  algebra.
+* `TauCeti.GaloisDescent.groupAlgebraInvariantsCounit`: its counit with values in `k`.
+* `TauCeti.GaloisDescent.groupAlgebraInvariantsAntipode`: the antipode restricted to invariants.
+* `TauCeti.GaloisDescent.groupAlgebraTensorInvariants`: fixed tensors for the diagonal action.
+* `TauCeti.GaloisDescent.groupAlgebraInvariantsComul`: comultiplication from invariant elements to
+  invariant tensors.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Corollary 12.24.
+
+This is the invariant-algebra step in Layer 4, "Tori: split and non-split", of the
+ReductiveGroups roadmap. It follows the semilinear group-algebra action and precedes the theorem
+identifying scalar extension of the invariant algebra with the original split coordinate algebra.
+-/
+
+public section
+
+open scoped TensorProduct TauCeti.GaloisDescent
+
+namespace TauCeti.GaloisDescent
+
+universe u
+
+variable {k L M : Type u} [Field k] [Field L] [Algebra k L]
+variable [AddCommGroup M]
+
+/-- The fixed `k`-subalgebra of `L[Multiplicative M]` for the simultaneous action on
+coefficients and exponents. -/
+noncomputable def groupAlgebraInvariants
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    Subalgebra k (MonoidAlgebra L (Multiplicative M)) where
+  carrier := {x | ∀ sigma, groupAlgebraAction rho sigma x = x}
+  zero_mem' sigma := map_zero _
+  one_mem' sigma := map_one _
+  add_mem' {x y} hx hy sigma := by rw [map_add, hx sigma, hy sigma]
+  mul_mem' {x y} hx hy sigma := by rw [map_mul, hx sigma, hy sigma]
+  algebraMap_mem' r sigma := (groupAlgebraAction rho sigma).commutes r
+
+/-- Membership in the invariant subalgebra means being fixed by every automorphism of `L/k`. -/
+@[simp]
+theorem mem_groupAlgebraInvariants_iff
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : MonoidAlgebra L (Multiplicative M)) :
+    x ∈ groupAlgebraInvariants rho ↔
+      ∀ sigma, groupAlgebraAction rho sigma x = x :=
+  Iff.rfl
+
+/-- Coefficientwise characterization of the invariant group algebra. The coefficient at `m`
+after applying `sigma` is read at the inverse translate of `m`. -/
+theorem mem_groupAlgebraInvariants_iff_coeff
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : MonoidAlgebra L (Multiplicative M)) :
+    x ∈ groupAlgebraInvariants rho ↔
+      ∀ (sigma : L ≃ₐ[k] L) (m : Multiplicative M),
+        sigma (x.coeff (Multiplicative.ofAdd (rho sigma⁻¹ m.toAdd))) = x.coeff m := by
+  rw [mem_groupAlgebraInvariants_iff]
+  constructor
+  · intro hx sigma m
+    have h := congrArg (fun y : MonoidAlgebra L (Multiplicative M) ↦ y.coeff m) (hx sigma)
+    simpa only [coeff_groupAlgebraAction] using h
+  · intro hx sigma
+    ext m
+    simpa only [coeff_groupAlgebraAction] using hx sigma m
+
+/-- A monomial is invariant if its coefficient and exponent are fixed by every Galois
+automorphism. -/
+theorem single_mem_groupAlgebraInvariants
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (m : Multiplicative M) (a : L)
+    (hm : ∀ sigma : L ≃ₐ[k] L, rho sigma m.toAdd = m.toAdd)
+    (ha : ∀ sigma : L ≃ₐ[k] L, sigma a = a) :
+    MonoidAlgebra.single m a ∈ groupAlgebraInvariants rho := by
+  rw [mem_groupAlgebraInvariants_iff]
+  intro sigma
+  rw [groupAlgebraAction_single, hm sigma, ofAdd_toAdd, ha sigma]
+
+section Galois
+
+variable [IsGalois k L]
+
+/-- The original `L`-valued counit, restricted to invariant elements and with its codomain
+restricted to the copy of `k` inside `L`. -/
+private noncomputable def groupAlgebraInvariantsCounitToBot
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    groupAlgebraInvariants rho →ₐ[k] (⊥ : IntermediateField k L) := by
+  let f : groupAlgebraInvariants rho →ₐ[k] L :=
+    ((Bialgebra.counitAlgHom L
+      (MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+        (groupAlgebraInvariants rho).val
+  exact
+  { toFun := fun x ↦ ⟨f x, by
+      rw [InfiniteGalois.mem_bot_iff_fixed]
+      intro sigma
+      change sigma (Coalgebra.counit (R := L)
+        (x : MonoidAlgebra L (Multiplicative M))) =
+          Coalgebra.counit (R := L) (x : MonoidAlgebra L (Multiplicative M))
+      rw [← counit_groupAlgebraAction rho sigma, x.property sigma]⟩
+    map_one' := Subtype.ext f.map_one
+    map_mul' x y := Subtype.ext (f.map_mul x y)
+    map_zero' := Subtype.ext f.map_zero
+    map_add' x y := Subtype.ext (f.map_add x y)
+    commutes' r := Subtype.ext (f.commutes r) }
+
+/-- The counit of the descended invariant algebra. Invariance forces the original `L`-valued
+counit to lie in the image of `k`, and Galois fixed-field descent identifies that image with `k`.
+-/
+noncomputable def groupAlgebraInvariantsCounit
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    groupAlgebraInvariants rho →ₐ[k] k :=
+  (IntermediateField.botEquiv k L).toAlgHom.comp
+    (groupAlgebraInvariantsCounitToBot rho)
+
+/-- Extending the descended counit value back to `L` recovers the ordinary group-algebra
+counit. -/
+@[simp]
+theorem algebraMap_groupAlgebraInvariantsCounit
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    algebraMap k L (groupAlgebraInvariantsCounit rho x) =
+      Coalgebra.counit (R := L) (x : MonoidAlgebra L (Multiplicative M)) := by
+  let y := groupAlgebraInvariantsCounitToBot rho x
+  have h := congrArg Subtype.val ((IntermediateField.botEquiv k L).symm_apply_apply y)
+  change algebraMap k L ((IntermediateField.botEquiv k L) y) = _
+  rw [← IntermediateField.coe_algebraMap_apply (S := (⊥ : IntermediateField k L))]
+  exact h
+
+end Galois
+
+/-- The antipode preserves the invariant group algebra. -/
+private theorem antipode_mem_groupAlgebraInvariants
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    HopfAlgebra.antipode L (x : MonoidAlgebra L (Multiplicative M)) ∈
+      groupAlgebraInvariants rho := by
+  rw [mem_groupAlgebraInvariants_iff]
+  intro sigma
+  rw [← antipode_groupAlgebraAction rho sigma, x.property sigma]
+
+/-- The group-algebra antipode restricted to the Galois-invariant subalgebra. -/
+noncomputable def groupAlgebraInvariantsAntipode
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    groupAlgebraInvariants rho ≃ₐ[k] groupAlgebraInvariants rho := by
+  let f : groupAlgebraInvariants rho →ₐ[k] groupAlgebraInvariants rho :=
+    ((((HopfAlgebra.antipodeAlgHom L
+        (MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+          (groupAlgebraInvariants rho).val).codRestrict
+            (groupAlgebraInvariants rho) fun x ↦ antipode_mem_groupAlgebraInvariants rho x)
+  exact AlgEquiv.ofAlgHom f f
+    (AlgHom.ext fun x ↦ Subtype.ext <| HopfAlgebra.antipode_antipode
+      (R := L) (A := MonoidAlgebra L (Multiplicative M)) x)
+    (AlgHom.ext fun x ↦ Subtype.ext <| HopfAlgebra.antipode_antipode
+      (R := L) (A := MonoidAlgebra L (Multiplicative M)) x)
+
+/-- The restricted antipode acts by the ordinary group-algebra antipode. -/
+@[simp]
+theorem groupAlgebraInvariantsAntipode_apply
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    (groupAlgebraInvariantsAntipode rho x : MonoidAlgebra L (Multiplicative M)) =
+      HopfAlgebra.antipode L (x : MonoidAlgebra L (Multiplicative M)) :=
+  by
+    rw [groupAlgebraInvariantsAntipode]
+    rfl
+
+/-- The antipode on the invariant algebra is involutive. -/
+@[simp]
+theorem groupAlgebraInvariantsAntipode_apply_apply
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    groupAlgebraInvariantsAntipode rho (groupAlgebraInvariantsAntipode rho x) = x := by
+  apply Subtype.ext
+  simp
+
+/-- The restricted antipode equivalence is its own inverse. -/
+@[simp]
+theorem groupAlgebraInvariantsAntipode_symm
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    (groupAlgebraInvariantsAntipode rho).symm = groupAlgebraInvariantsAntipode rho := by
+  apply AlgEquiv.ext
+  intro x
+  apply (groupAlgebraInvariantsAntipode rho).injective
+  rw [AlgEquiv.apply_symm_apply, groupAlgebraInvariantsAntipode_apply_apply]
+
+/-- The fixed `k`-submodule of the tensor square for the diagonal semilinear Galois action. -/
+noncomputable def groupAlgebraTensorInvariants
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    Submodule k
+      (MonoidAlgebra L (Multiplicative M) ⊗[L]
+        MonoidAlgebra L (Multiplicative M)) where
+  carrier := {t | ∀ sigma, groupAlgebraTensorActionSemilinearEquiv rho sigma t = t}
+  zero_mem' sigma := map_zero _
+  add_mem' {x y} hx hy sigma := by rw [map_add, hx sigma, hy sigma]
+  smul_mem' r x hx sigma := by
+    rw [← IsScalarTower.algebraMap_smul L r x,
+      (groupAlgebraTensorActionSemilinearEquiv rho sigma).map_smulₛₗ]
+    change sigma (algebraMap k L r) •
+        groupAlgebraTensorActionSemilinearEquiv rho sigma x =
+      algebraMap k L r • x
+    rw [sigma.commutes, hx sigma, IsScalarTower.algebraMap_smul L r x]
+
+/-- Membership among invariant tensors means being fixed by the diagonal action. -/
+@[simp]
+theorem mem_groupAlgebraTensorInvariants_iff
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (t : MonoidAlgebra L (Multiplicative M) ⊗[L]
+      MonoidAlgebra L (Multiplicative M)) :
+    t ∈ groupAlgebraTensorInvariants rho ↔
+      ∀ sigma, groupAlgebraTensorActionSemilinearEquiv rho sigma t = t :=
+  Iff.rfl
+
+/-- Comultiplication sends an invariant element to a tensor fixed by the diagonal action. -/
+private theorem comul_mem_groupAlgebraTensorInvariants
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    Coalgebra.comul (R := L) (x : MonoidAlgebra L (Multiplicative M)) ∈
+      groupAlgebraTensorInvariants rho := by
+  rw [mem_groupAlgebraTensorInvariants_iff]
+  intro sigma
+  rw [← comul_groupAlgebraAction rho sigma, x.property sigma]
+
+/-- Comultiplication from invariant elements to tensors invariant under the diagonal action.
+
+Identifying the codomain with the tensor square of `groupAlgebraInvariants rho` is the subsequent
+faithfully flat descent step. -/
+noncomputable def groupAlgebraInvariantsComul
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    groupAlgebraInvariants rho →ₗ[k] groupAlgebraTensorInvariants rho :=
+  ((((Coalgebra.comul (R := L) (A := MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+      (groupAlgebraInvariants rho).val.toLinearMap).codRestrict
+        (groupAlgebraTensorInvariants rho) fun x ↦
+          comul_mem_groupAlgebraTensorInvariants rho x)
+
+/-- The restricted comultiplication acts by the ordinary group-algebra comultiplication. -/
+@[simp]
+theorem groupAlgebraInvariantsComul_apply
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    (groupAlgebraInvariantsComul rho x :
+        MonoidAlgebra L (Multiplicative M) ⊗[L]
+          MonoidAlgebra L (Multiplicative M)) =
+      Coalgebra.comul (R := L) (x : MonoidAlgebra L (Multiplicative M)) :=
+  by
+    rw [groupAlgebraInvariantsComul]
+    rfl
+
+end TauCeti.GaloisDescent

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/GaloisInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/GaloisInvariants.lean
@@ -48,9 +48,10 @@ open scoped TensorProduct TauCeti.GaloisDescent
 
 namespace TauCeti.GaloisDescent
 
-universe u
+universe u_k u_L u_M
 
-variable {k L M : Type u} [Field k] [Field L] [Algebra k L]
+variable {k : Type u_k} {L : Type u_L} {M : Type u_M}
+variable [Field k] [Field L] [Algebra k L]
 variable [AddCommGroup M]
 
 /-- The fixed `k`-subalgebra of `L[Multiplicative M]` for the simultaneous action on
@@ -120,9 +121,8 @@ private noncomputable def groupAlgebraInvariantsCounitToBot
   { toFun := fun x ↦ ⟨f x, by
       rw [InfiniteGalois.mem_bot_iff_fixed]
       intro sigma
-      change sigma (Coalgebra.counit (R := L)
-        (x : MonoidAlgebra L (Multiplicative M))) =
-          Coalgebra.counit (R := L) (x : MonoidAlgebra L (Multiplicative M))
+      simp only [f, AlgHom.comp_apply, AlgHom.restrictScalars_apply,
+        Subalgebra.val_apply, Bialgebra.counitAlgHom_apply]
       rw [← counit_groupAlgebraAction rho sigma, x.property sigma]⟩
     map_one' := Subtype.ext f.map_one
     map_mul' x y := Subtype.ext (f.map_mul x y)
@@ -149,9 +149,14 @@ theorem algebraMap_groupAlgebraInvariantsCounit
       Coalgebra.counit (R := L) (x : MonoidAlgebra L (Multiplicative M)) := by
   let y := groupAlgebraInvariantsCounitToBot rho x
   have h := congrArg Subtype.val ((IntermediateField.botEquiv k L).symm_apply_apply y)
-  change algebraMap k L ((IntermediateField.botEquiv k L) y) = _
-  rw [← IntermediateField.coe_algebraMap_apply (S := (⊥ : IntermediateField k L))]
-  exact h
+  rw [groupAlgebraInvariantsCounit, AlgHom.comp_apply]
+  calc
+    algebraMap k L ((IntermediateField.botEquiv k L) y) =
+        ((algebraMap k (⊥ : IntermediateField k L)
+          ((IntermediateField.botEquiv k L) y) : (⊥ : IntermediateField k L)) : L) :=
+      (IntermediateField.coe_algebraMap_apply (S := (⊥ : IntermediateField k L)) _).symm
+    _ = (y : L) := h
+    _ = Coalgebra.counit (R := L) (x : MonoidAlgebra L (Multiplicative M)) := rfl
 
 end Galois
 
@@ -165,20 +170,48 @@ private theorem antipode_mem_groupAlgebraInvariants
   intro sigma
   rw [← antipode_groupAlgebraAction rho sigma, x.property sigma]
 
+/-- The algebra homomorphism underlying the restricted antipode. -/
+private noncomputable def groupAlgebraInvariantsAntipodeHom
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    groupAlgebraInvariants rho →ₐ[k] groupAlgebraInvariants rho :=
+  ((((HopfAlgebra.antipodeAlgHom L
+      (MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+        (groupAlgebraInvariants rho).val).codRestrict
+          (groupAlgebraInvariants rho) fun x ↦ antipode_mem_groupAlgebraInvariants rho x)
+
+private theorem coe_groupAlgebraInvariantsAntipodeHom_apply
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    (groupAlgebraInvariantsAntipodeHom rho x : MonoidAlgebra L (Multiplicative M)) =
+      HopfAlgebra.antipode L (x : MonoidAlgebra L (Multiplicative M)) := by
+  have h := AlgHom.congr_fun
+    (AlgHom.val_comp_codRestrict
+      (((HopfAlgebra.antipodeAlgHom L
+        (MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+          (groupAlgebraInvariants rho).val)
+      (groupAlgebraInvariants rho) fun x ↦ antipode_mem_groupAlgebraInvariants rho x) x
+  simpa only [groupAlgebraInvariantsAntipodeHom, AlgHom.comp_apply,
+    AlgHom.restrictScalars_apply, Subalgebra.val_apply,
+    HopfAlgebra.antipodeAlgHom_apply] using h
+
 /-- The group-algebra antipode restricted to the Galois-invariant subalgebra. -/
 noncomputable def groupAlgebraInvariantsAntipode
     (rho : Representation ℤ (L ≃ₐ[k] L) M) :
     groupAlgebraInvariants rho ≃ₐ[k] groupAlgebraInvariants rho := by
-  let f : groupAlgebraInvariants rho →ₐ[k] groupAlgebraInvariants rho :=
-    ((((HopfAlgebra.antipodeAlgHom L
-        (MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
-          (groupAlgebraInvariants rho).val).codRestrict
-            (groupAlgebraInvariants rho) fun x ↦ antipode_mem_groupAlgebraInvariants rho x)
-  exact AlgEquiv.ofAlgHom f f
-    (AlgHom.ext fun x ↦ Subtype.ext <| HopfAlgebra.antipode_antipode
-      (R := L) (A := MonoidAlgebra L (Multiplicative M)) x)
-    (AlgHom.ext fun x ↦ Subtype.ext <| HopfAlgebra.antipode_antipode
-      (R := L) (A := MonoidAlgebra L (Multiplicative M)) x)
+  exact AlgEquiv.ofAlgHom (groupAlgebraInvariantsAntipodeHom rho)
+    (groupAlgebraInvariantsAntipodeHom rho)
+    (AlgHom.ext fun x ↦ by
+      rw [AlgHom.comp_apply, AlgHom.id_apply]
+      apply Subtype.ext
+      rw [coe_groupAlgebraInvariantsAntipodeHom_apply,
+        coe_groupAlgebraInvariantsAntipodeHom_apply,
+        HopfAlgebra.antipode_antipode])
+    (AlgHom.ext fun x ↦ by
+      rw [AlgHom.comp_apply, AlgHom.id_apply]
+      apply Subtype.ext
+      rw [coe_groupAlgebraInvariantsAntipodeHom_apply,
+        coe_groupAlgebraInvariantsAntipodeHom_apply,
+        HopfAlgebra.antipode_antipode])
 
 /-- The restricted antipode acts by the ordinary group-algebra antipode. -/
 @[simp]
@@ -188,8 +221,8 @@ theorem groupAlgebraInvariantsAntipode_apply
     (groupAlgebraInvariantsAntipode rho x : MonoidAlgebra L (Multiplicative M)) =
       HopfAlgebra.antipode L (x : MonoidAlgebra L (Multiplicative M)) :=
   by
-    rw [groupAlgebraInvariantsAntipode]
-    rfl
+    simpa only [groupAlgebraInvariantsAntipode, AlgEquiv.ofAlgHom_apply] using
+      coe_groupAlgebraInvariantsAntipodeHom_apply rho x
 
 /-- The antipode on the invariant algebra is involutive. -/
 @[simp]
@@ -247,6 +280,34 @@ private theorem comul_mem_groupAlgebraTensorInvariants
   intro sigma
   rw [← comul_groupAlgebraAction rho sigma, x.property sigma]
 
+/-- The linear map underlying comultiplication into invariant tensors. -/
+private noncomputable def groupAlgebraInvariantsComulLinearMap
+    (rho : Representation ℤ (L ≃ₐ[k] L) M) :
+    groupAlgebraInvariants rho →ₗ[k] groupAlgebraTensorInvariants rho :=
+  ((((Coalgebra.comul (R := L)
+      (A := MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+        (groupAlgebraInvariants rho).val.toLinearMap).codRestrict
+          (groupAlgebraTensorInvariants rho) fun x ↦
+            comul_mem_groupAlgebraTensorInvariants rho x)
+
+private theorem coe_groupAlgebraInvariantsComulLinearMap_apply
+    (rho : Representation ℤ (L ≃ₐ[k] L) M)
+    (x : groupAlgebraInvariants rho) :
+    (groupAlgebraInvariantsComulLinearMap rho x :
+        MonoidAlgebra L (Multiplicative M) ⊗[L]
+          MonoidAlgebra L (Multiplicative M)) =
+      Coalgebra.comul (R := L) (x : MonoidAlgebra L (Multiplicative M)) := by
+  have h := LinearMap.congr_fun
+    (LinearMap.subtype_comp_codRestrict
+      (f := ((Coalgebra.comul (R := L)
+        (A := MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
+          (groupAlgebraInvariants rho).val.toLinearMap)
+      (groupAlgebraTensorInvariants rho) fun x ↦
+        comul_mem_groupAlgebraTensorInvariants rho x) x
+  simpa only [groupAlgebraInvariantsComulLinearMap, LinearMap.comp_apply,
+    LinearMap.restrictScalars_apply, Submodule.subtype_apply, AlgHom.toLinearMap_apply,
+    Subalgebra.val_apply] using h
+
 /-- Comultiplication from invariant elements to tensors invariant under the diagonal action.
 
 Identifying the codomain with the tensor square of `groupAlgebraInvariants rho` is the subsequent
@@ -254,10 +315,7 @@ faithfully flat descent step. -/
 noncomputable def groupAlgebraInvariantsComul
     (rho : Representation ℤ (L ≃ₐ[k] L) M) :
     groupAlgebraInvariants rho →ₗ[k] groupAlgebraTensorInvariants rho :=
-  ((((Coalgebra.comul (R := L) (A := MonoidAlgebra L (Multiplicative M))).restrictScalars k).comp
-      (groupAlgebraInvariants rho).val.toLinearMap).codRestrict
-        (groupAlgebraTensorInvariants rho) fun x ↦
-          comul_mem_groupAlgebraTensorInvariants rho x)
+  groupAlgebraInvariantsComulLinearMap rho
 
 /-- The restricted comultiplication acts by the ordinary group-algebra comultiplication. -/
 @[simp]
@@ -269,7 +327,6 @@ theorem groupAlgebraInvariantsComul_apply
           MonoidAlgebra L (Multiplicative M)) =
       Coalgebra.comul (R := L) (x : MonoidAlgebra L (Multiplicative M)) :=
   by
-    rw [groupAlgebraInvariantsComul]
-    rfl
+    exact coe_groupAlgebraInvariantsComulLinearMap_apply rho x
 
 end TauCeti.GaloisDescent

--- a/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/GaloisInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/GaloisInvariants.lean
@@ -58,13 +58,15 @@ variable [AddCommGroup M]
 coefficients and exponents. -/
 noncomputable def groupAlgebraInvariants
     (rho : Representation ℤ (L ≃ₐ[k] L) M) :
-    Subalgebra k (MonoidAlgebra L (Multiplicative M)) where
-  carrier := {x | ∀ sigma, groupAlgebraAction rho sigma x = x}
-  zero_mem' sigma := map_zero _
-  one_mem' sigma := map_one _
-  add_mem' {x y} hx hy sigma := by rw [map_add, hx sigma, hy sigma]
-  mul_mem' {x y} hx hy sigma := by rw [map_mul, hx sigma, hy sigma]
-  algebraMap_mem' r sigma := (groupAlgebraAction rho sigma).commutes r
+    Subalgebra k (MonoidAlgebra L (Multiplicative M)) := by
+  letI : SMul (L ≃ₐ[k] L) (MonoidAlgebra L (Multiplicative M)) :=
+    ⟨fun sigma x ↦ groupAlgebraAction rho sigma x⟩
+  letI : MulSemiringAction (L ≃ₐ[k] L) (MonoidAlgebra L (Multiplicative M)) :=
+    MulSemiringAction.compHom _ (groupAlgebraAction rho)
+  letI : SMulCommClass (L ≃ₐ[k] L) k (MonoidAlgebra L (Multiplicative M)) :=
+    ⟨fun sigma r x ↦ by
+      exact map_smul (groupAlgebraAction rho sigma) r x⟩
+  exact FixedPoints.subalgebra k (MonoidAlgebra L (Multiplicative M)) (L ≃ₐ[k] L)
 
 /-- Membership in the invariant subalgebra means being fixed by every automorphism of `L/k`. -/
 @[simp]
@@ -123,7 +125,8 @@ private noncomputable def groupAlgebraInvariantsCounitToBot
       intro sigma
       simp only [f, AlgHom.comp_apply, AlgHom.restrictScalars_apply,
         Subalgebra.val_apply, Bialgebra.counitAlgHom_apply]
-      rw [← counit_groupAlgebraAction rho sigma, x.property sigma]⟩
+      rw [← counit_groupAlgebraAction rho sigma,
+        (mem_groupAlgebraInvariants_iff rho x).mp x.property sigma]⟩
     map_one' := Subtype.ext f.map_one
     map_mul' x y := Subtype.ext (f.map_mul x y)
     map_zero' := Subtype.ext f.map_zero
@@ -168,7 +171,8 @@ private theorem antipode_mem_groupAlgebraInvariants
       groupAlgebraInvariants rho := by
   rw [mem_groupAlgebraInvariants_iff]
   intro sigma
-  rw [← antipode_groupAlgebraAction rho sigma, x.property sigma]
+  rw [← antipode_groupAlgebraAction rho sigma,
+    (mem_groupAlgebraInvariants_iff rho x).mp x.property sigma]
 
 /-- The algebra homomorphism underlying the restricted antipode. -/
 private noncomputable def groupAlgebraInvariantsAntipodeHom
@@ -248,17 +252,29 @@ noncomputable def groupAlgebraTensorInvariants
     (rho : Representation ℤ (L ≃ₐ[k] L) M) :
     Submodule k
       (MonoidAlgebra L (Multiplicative M) ⊗[L]
-        MonoidAlgebra L (Multiplicative M)) where
-  carrier := {t | ∀ sigma, groupAlgebraTensorActionSemilinearEquiv rho sigma t = t}
-  zero_mem' sigma := map_zero _
-  add_mem' {x y} hx hy sigma := by rw [map_add, hx sigma, hy sigma]
-  smul_mem' r x hx sigma := by
-    rw [← IsScalarTower.algebraMap_smul L r x,
-      (groupAlgebraTensorActionSemilinearEquiv rho sigma).map_smulₛₗ]
-    change sigma (algebraMap k L r) •
-        groupAlgebraTensorActionSemilinearEquiv rho sigma x =
-      algebraMap k L r • x
-    rw [sigma.commutes, hx sigma, IsScalarTower.algebraMap_smul L r x]
+        MonoidAlgebra L (Multiplicative M)) := by
+  let T := MonoidAlgebra L (Multiplicative M) ⊗[L]
+    MonoidAlgebra L (Multiplicative M)
+  letI : SMul (L ≃ₐ[k] L) T :=
+    ⟨fun sigma t ↦ groupAlgebraTensorActionSemilinearEquiv rho sigma t⟩
+  letI : DistribMulAction (L ≃ₐ[k] L) T :=
+    { smul := fun sigma t ↦ groupAlgebraTensorActionSemilinearEquiv rho sigma t
+      one_smul := groupAlgebraTensorActionSemilinearEquiv_one rho
+      mul_smul := groupAlgebraTensorActionSemilinearEquiv_mul rho
+      smul_zero := fun sigma ↦ map_zero (groupAlgebraTensorActionSemilinearEquiv rho sigma)
+      smul_add := fun sigma ↦ map_add (groupAlgebraTensorActionSemilinearEquiv rho sigma) }
+  exact
+  { FixedPoints.addSubgroup (L ≃ₐ[k] L) T with
+    smul_mem' := fun r x hx sigma ↦ by
+      have hsigma := hx sigma
+      change groupAlgebraTensorActionSemilinearEquiv rho sigma x = x at hsigma
+      change groupAlgebraTensorActionSemilinearEquiv rho sigma (r • x) = r • x
+      rw [← IsScalarTower.algebraMap_smul L r x,
+        (groupAlgebraTensorActionSemilinearEquiv rho sigma).map_smulₛₗ]
+      change sigma (algebraMap k L r) •
+          groupAlgebraTensorActionSemilinearEquiv rho sigma x =
+        algebraMap k L r • x
+      rw [sigma.commutes, hsigma, IsScalarTower.algebraMap_smul L r x] }
 
 /-- Membership among invariant tensors means being fixed by the diagonal action. -/
 @[simp]
@@ -278,7 +294,8 @@ private theorem comul_mem_groupAlgebraTensorInvariants
       groupAlgebraTensorInvariants rho := by
   rw [mem_groupAlgebraTensorInvariants_iff]
   intro sigma
-  rw [← comul_groupAlgebraAction rho sigma, x.property sigma]
+  rw [← comul_groupAlgebraAction rho sigma,
+    (mem_groupAlgebraInvariants_iff rho x).mp x.property sigma]
 
 /-- The linear map underlying comultiplication into invariant tensors. -/
 private noncomputable def groupAlgebraInvariantsComulLinearMap


### PR DESCRIPTION
This PR constructs the Galois-invariant coordinate algebra of a split diagonalizable group and records the Hopf operations at the descent-data level. Define `GaloisDescent.groupAlgebraInvariants` as the fixed `k`-subalgebra of `L[Multiplicative M]` for the simultaneous coefficient-and-exponent action, characterize membership coefficientwise, descend the counit to `k` for an arbitrary Galois extension, restrict the antipode as an involutive algebra equivalence, and send comultiplication into the fixed submodule of the tensor square under the diagonal action.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 milestone “Tori: split and non-split,” specifically the construction of non-split tori through Galois descent of the split coordinate algebra. This is the most effective current step because `TauCeti.GaloisDescent.groupAlgebraAction` already supplies the semilinear coefficient-and-exponent action and explicitly names taking invariants as its next step, while no open PR constructs that fixed algebra. After this PR, the milestone still needs the faithfully flat comparison `L ⊗[k] groupAlgebraInvariants ρ ≃ₐ[L] L[Multiplicative M]`, the induced Hopf structure obtained by identifying invariant tensors with the tensor square of the invariant algebra, and the resulting construction and classification of non-split tori from finite free continuous Galois lattices.

Add `TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/GaloisInvariants.lean` (275 lines). The construction follows J. S. Milne, *Algebraic Groups* (2017), Theorem 12.23 and Corollary 12.24, as credited in the module documentation. It reuses Mathlib’s `InfiniteGalois.mem_bot_iff_fixed`, `IntermediateField.botEquiv`, subalgebra and submodule APIs, and Tau Ceti’s existing semilinear group-algebra and tensor actions. No Mathlib infrastructure or external formalization is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"group-algebra-galois-invariants"}-->

🤖 Prepared with Codex
