### PR TITLE
fix: publish the Lake cache from a job that runs no project code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # Read by publish-lake-cache below, the only job that ever holds the upload secret.
-    # Neither output reveals the secret's value or whether it is set.
+    # Neither output reveals the secret's value or whether it is set, and neither is trusted
+    # there: `staged` only decides whether that job runs at all, and `reported-toolchain` is
+    # cross-checked against the pin that job reads for itself.
     outputs:
       staged: ${{ steps.stage.outputs.staged }}
-      toolchain: ${{ steps.stage.outputs.toolchain }}
+      reported-toolchain: ${{ steps.stage.outputs.toolchain }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -301,8 +303,9 @@ jobs:
             exit 1
           fi
           # `lake env` reports the workspace's own view of the toolchain, which is exactly the
-          # `Env.toolchain` Lake scopes an upload by. Empty would silently scope the upload
-          # with no toolchain at all, so fail rather than publish somewhere nothing reads.
+          # `Env.toolchain` Lake scopes an upload by. The publish job does not take this on
+          # faith: it reads lean-toolchain itself and fails if the two disagree. Reporting it
+          # anyway turns a disagreement into a loud failure instead of a silent wrong scope.
           TOOLCHAIN="$(lake env printenv ELAN_TOOLCHAIN || true)"
           if [ -z "$TOOLCHAIN" ]; then
             echo "::error::could not determine the Lean toolchain that scopes the cache upload"
@@ -325,12 +328,12 @@ jobs:
           # burns CPU on both ends and saves nothing.
           compression-level: 0
 
-  # The only job that ever holds LAKE_CACHE_KEY. It has no checkout, no Lake workspace and no
-  # dependencies, so no code from this repository, and none from Mathlib either, runs
-  # anywhere in it: `lake cache put-staged` is documented as not configuring the workspace and
-  # therefore not executing arbitrary user code. Everything it uploads arrives as an artifact
-  # from the build job, whose contents code that landed on main could have chosen, so the
-  # staged tree is checked before Lake is pointed at it.
+  # The only job that ever holds LAKE_CACHE_KEY. It checks out exactly one file and nothing
+  # else, and has no Lake workspace and no dependencies, so no code from this repository, and
+  # none from Mathlib either, runs anywhere in it: `lake cache put-staged` is documented as not
+  # configuring the workspace and therefore not executing arbitrary user code. Everything else
+  # it consumes arrives from the build job, whose every output code that landed on main could
+  # have chosen, so nothing from there is trusted without a check.
   publish-lake-cache:
     needs: build
     if: ${{ needs.build.outputs.staged == 'true' }}
@@ -339,6 +342,20 @@ jobs:
     # Actions runtime token, and nothing else here talks to the GitHub API.
     permissions: {}
     steps:
+      # Exactly one file, and deliberately not the one the build job reported. Which toolchain
+      # this job installs and runs decides which `lake` binary handles the key, so it must come
+      # from the repository rather than from a job that executed code which landed on main:
+      # that job can rewrite lean-toolchain on disk, or poison a later step through $GITHUB_ENV
+      # and $GITHUB_PATH, so anything it reports is attacker-chosen. lean-toolchain itself is a
+      # Lake pin: bump-guard only lets it move forward along leanprover/lean4 releases without a
+      # human, and the build job above already installed and ran whatever it names, so reading
+      # it here adds no trust that main's build did not already extend.
+      - name: Check out the toolchain pin, and nothing else
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: lean-toolchain
+          sparse-checkout-cone-mode: false
+
       - name: Download the staged oleans
         uses: actions/download-artifact@v4
         with:
@@ -398,14 +415,32 @@ jobs:
                       check(json.loads(line), lineno)
           PY
 
-      - name: Install elan (no checkout, so no project code)
+      - name: Install elan and the pinned toolchain
+        id: toolchain
         env:
-          TOOLCHAIN: ${{ needs.build.outputs.toolchain }}
+          REPORTED: ${{ needs.build.outputs.reported-toolchain }}
         run: |
+          TOOLCHAIN="$(cat lean-toolchain)"
+          # Refuse anything that is not a leanprover/lean4 release name. `elan toolchain
+          # install owner/repo:tag` fetches from that repository's releases, so an unconstrained
+          # name would choose which `lake` binary later handles the key. bump-guard enforces the
+          # same shape on the pin; this repeats it rather than relying on it.
+          case "$TOOLCHAIN" in
+            leanprover/lean4:[A-Za-z0-9]*) ;;
+            *) echo "::error::lean-toolchain names '$TOOLCHAIN', which is not a leanprover/lean4 release"; exit 1 ;;
+          esac
+          # The upload scope must be the toolchain the artifacts were actually built with. The
+          # pin is what the build job's elan resolved, so the two agree unless something moved
+          # underneath the build; say so rather than publish under a scope pr-build never reads.
+          if [ "$TOOLCHAIN" != "$REPORTED" ]; then
+            echo "::error::the build job built with '$REPORTED' but lean-toolchain pins '$TOOLCHAIN'"
+            exit 1
+          fi
           curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
           chmod +x elan-init.sh && ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
           "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN"
+          printf 'name=%s\n' "$TOOLCHAIN" >> "$GITHUB_OUTPUT"
 
       - name: Publish the staged oleans to the Lake cache
         env:
@@ -414,10 +449,10 @@ jobs:
           S3_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
           S3_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
           LAKE_CACHE_KEY_RAW: ${{ secrets.LAKE_CACHE_KEY }}
-          # There is no lean-toolchain file to read (there is no checkout), so name the
-          # toolchain the build job used. Lake takes ELAN_TOOLCHAIN as its `Env.toolchain`,
-          # which is also the string it scopes uploads by.
-          ELAN_TOOLCHAIN: ${{ needs.build.outputs.toolchain }}
+          # The pinned toolchain, read from the repository above. Lake takes ELAN_TOOLCHAIN as
+          # its `Env.toolchain`, which is also the string it scopes uploads by, and elan's `lake`
+          # shim takes it as which toolchain to run.
+          ELAN_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
           STAGING: ${{ runner.temp }}/lake-cache-staging
         run: |
           if [ -z "$LAKE_CACHE_KEY_RAW" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,13 +293,19 @@ jobs:
           lake cache stage .lake/outputs.jsonl "$RUNNER_TEMP/lake-cache-staging"
           # `lake cache put-staged` does not configure the workspace, which is precisely what
           # keeps project code out of the publish job, so it cannot derive the toolchain and
-          # platform halves of the upload scope. Hand it the toolchain explicitly, and check
-          # the platform assumption here, where the workspace does exist: `platformIndependent`
-          # is what makes Lake leave the platform out of the scope, which is what put-staged
-          # assumes by default. A silent mismatch would publish under a scope pr-build's
-          # `lake cache get --service ... --repo` never reads, i.e. a cache that is never hit.
+          # platform halves of the upload scope. The publish job supplies them from the pin
+          # instead, which is right only while the package config keeps the two assumptions
+          # below. Check them here, where the workspace does exist: `platformIndependent` is
+          # what makes Lake leave the platform out of the scope (put-staged's default), while
+          # `fixedToolchain` or `bootstrap` would make Lake leave the toolchain out of it (which
+          # put-staged is told to include). Either silent mismatch would publish under a scope
+          # pr-build's `lake cache get --service ... --repo` never reads, i.e. a cache never hit.
           if ! grep -Eq '^[[:space:]]*platformIndependent[[:space:]]*=[[:space:]]*true' lakefile.toml; then
             echo "::error::lakefile.toml no longer sets platformIndependent = true; publish-lake-cache must now pass --platform to lake cache put-staged"
+            exit 1
+          fi
+          if grep -Eq '^[[:space:]]*(fixedToolchain|bootstrap)[[:space:]]*=[[:space:]]*true' lakefile.toml; then
+            echo "::error::lakefile.toml now sets fixedToolchain or bootstrap; Lake drops the toolchain from the scope for such a package, so publish-lake-cache must stop passing --toolchain"
             exit 1
           fi
           # `lake env` reports the workspace's own view of the toolchain, which is exactly the
@@ -436,6 +442,11 @@ jobs:
             echo "::error::the build job built with '$REPORTED' but lean-toolchain pins '$TOOLCHAIN'"
             exit 1
           fi
+          # elan's installer is fetched unpinned, exactly as pr-build.yml and lean-action fetch
+          # it, so elan's distribution and the named Lean release are in this job's trust base
+          # the same way they are in every other job here. That is a project-wide assumption
+          # about leanprover's release channel, not one this split introduces: the build job
+          # installs elan the same way and runs the same toolchain over the whole library.
           curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
           chmod +x elan-init.sh && ./elan-init.sh -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,10 @@ jobs:
         id: stage
         if: ${{ steps.cachecfg.outputs.enabled == 'true' }}
         env:
+          # Restated at step level, and the same values the restore step sets job-wide when the
+          # public endpoints are configured, so staging works either way: with the restore on,
+          # the health-check build already packed these artifacts; with it off, the pack below
+          # is what puts them in the cache directory for `lake cache stage` to find.
           LAKE_ARTIFACT_CACHE: "true"
           LAKE_RESTORE_ARTIFACTS: "true"
           # Don't download during the packing build — we only want to PUT, not GET. (The

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Read by publish-lake-cache below, the only job that ever holds the upload secret.
+    # Neither output reveals the secret's value or whether it is set.
+    outputs:
+      staged: ${{ steps.stage.outputs.staged }}
+      toolchain: ${{ steps.stage.outputs.toolchain }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -233,26 +238,39 @@ jobs:
       # --- Lake artifact-cache publish (dormant until configured) ---------------------
       # Publish TauCeti's OWN oleans (root-package only) to the Lake cache, so pr-build can
       # fetch them and recompile only a PR's changed modules instead of the whole library.
-      # Runs only once the upload credential + S3 endpoints are installed; until then these
-      # two steps are skipped and main's health check is unchanged. Mathlib's oleans are
-      # never uploaded: `-o` records only root-package outputs, and Mathlib stays on
-      # `lake exe cache get`. See pr-build.yml for the consuming side.
-      - name: Configure the Lake cache upload (no-op unless secret + S3 endpoints are set)
+      # Mathlib's oleans are never uploaded: `-o` records only root-package outputs, and
+      # Mathlib stays on `lake exe cache get`. See pr-build.yml for the consuming side.
+      #
+      # The upload is split across two jobs, and the split is the security boundary rather
+      # than a convenience. THIS job runs `lake build` unsandboxed, as the runner user, on
+      # whatever landed on main, and Lean executes code at elaboration time: `run_cmd`,
+      # `initialize` and macro-time IO are all unrestricted, since the scope, import-boundary
+      # and set_option guards are textual scans. Such code can therefore rewrite
+      # `$HOME/.elan/bin/lake`, prepend a directory of its own to every later step's PATH
+      # through `$GITHUB_PATH`, or set LD_PRELOAD or BASH_ENV for every later step through
+      # `$GITHUB_ENV`. A secret given to any later step of this job is a secret given to code
+      # that landed on main, whatever that step does with it. So this job only stages the
+      # artifacts, and publish-lake-cache below, a fresh runner with no checkout, no
+      # workspace and no project code, is the only place the key exists.
+      - name: Configure the Lake cache staging (no-op unless the S3 endpoints are set)
         id: cachecfg
         env:
-          LAKE_CACHE_KEY_RAW: ${{ secrets.LAKE_CACHE_KEY }}
+          # The secret is deliberately not referenced anywhere in this job, not even to test
+          # whether it is set. The endpoints alone decide whether staging runs; the publish
+          # job skips with a notice if the key turns out to be missing.
           S3_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
           S3_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
         run: |
-          if [ -n "$LAKE_CACHE_KEY_RAW" ] && [ -n "$S3_ARTIFACT_ENDPOINT" ] && [ -n "$S3_REVISION_ENDPOINT" ]; then
+          if [ -n "$S3_ARTIFACT_ENDPOINT" ] && [ -n "$S3_REVISION_ENDPOINT" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Lake cache upload configured — publishing TauCeti's oleans"
+            echo "::notice::Lake cache upload configured; staging TauCeti's oleans"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Lake cache upload not configured — skipping (set the LAKE_CACHE_KEY secret and the LAKE_CACHE_ARTIFACT_ENDPOINT / LAKE_CACHE_REVISION_ENDPOINT repo variables to enable)"
+            echo "::notice::Lake cache upload not configured, skipping (set the LAKE_CACHE_ARTIFACT_ENDPOINT / LAKE_CACHE_REVISION_ENDPOINT repo variables and the LAKE_CACHE_KEY secret to enable)"
           fi
 
-      - name: Publish TauCeti's oleans to the Lake cache
+      - name: Stage TauCeti's oleans for the publish job
+        id: stage
         if: ${{ steps.cachecfg.outputs.enabled == 'true' }}
         env:
           LAKE_ARTIFACT_CACHE: "true"
@@ -261,17 +279,156 @@ jobs:
           # S3 host needs SigV4 even for reads, so an anonymous GET here would 403 anyway.)
           LAKE_NO_CACHE: "true"
           LAKE_CACHE_DIR: ${{ github.workspace }}/.lake/cache
+        run: |
+          # Pack the already-built oleans into the local Lake cache (no recompile, since the
+          # health-check build above left matching traces), emit the root-package
+          # input->output mappings, then copy exactly the artifacts those mappings name into
+          # a staging directory, alongside a copy of the mappings themselves. `lake cache
+          # stage` reads no credential and contacts no network.
+          lake build >/dev/null
+          lake build --no-build -o .lake/outputs.jsonl
+          echo "root-package mapping entries: $(wc -l < .lake/outputs.jsonl)"
+          lake cache stage .lake/outputs.jsonl "$RUNNER_TEMP/lake-cache-staging"
+          # `lake cache put-staged` does not configure the workspace, which is precisely what
+          # keeps project code out of the publish job, so it cannot derive the toolchain and
+          # platform halves of the upload scope. Hand it the toolchain explicitly, and check
+          # the platform assumption here, where the workspace does exist: `platformIndependent`
+          # is what makes Lake leave the platform out of the scope, which is what put-staged
+          # assumes by default. A silent mismatch would publish under a scope pr-build's
+          # `lake cache get --service ... --repo` never reads, i.e. a cache that is never hit.
+          if ! grep -Eq '^[[:space:]]*platformIndependent[[:space:]]*=[[:space:]]*true' lakefile.toml; then
+            echo "::error::lakefile.toml no longer sets platformIndependent = true; publish-lake-cache must now pass --platform to lake cache put-staged"
+            exit 1
+          fi
+          # `lake env` reports the workspace's own view of the toolchain, which is exactly the
+          # `Env.toolchain` Lake scopes an upload by. Empty would silently scope the upload
+          # with no toolchain at all, so fail rather than publish somewhere nothing reads.
+          TOOLCHAIN="$(lake env printenv ELAN_TOOLCHAIN || true)"
+          if [ -z "$TOOLCHAIN" ]; then
+            echo "::error::could not determine the Lean toolchain that scopes the cache upload"
+            exit 1
+          fi
+          printf 'toolchain=%s\n' "$TOOLCHAIN" >> "$GITHUB_OUTPUT"
+          echo "staged=true" >> "$GITHUB_OUTPUT"
+
+      - name: Hand the staged oleans to the publish job
+        if: ${{ steps.stage.outputs.staged == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: lake-cache-staging
+          path: ${{ runner.temp }}/lake-cache-staging
+          if-no-files-found: error
+          # Long enough to inspect a failed publish, short enough not to accumulate a
+          # 60 MB artifact per push to main.
+          retention-days: 1
+          # The staged files are already-compressed `.ltar` archives; recompressing them
+          # burns CPU on both ends and saves nothing.
+          compression-level: 0
+
+  # The only job that ever holds LAKE_CACHE_KEY. It has no checkout, no Lake workspace and no
+  # dependencies, so no code from this repository, and none from Mathlib either, runs
+  # anywhere in it: `lake cache put-staged` is documented as not configuring the workspace and
+  # therefore not executing arbitrary user code. Everything it uploads arrives as an artifact
+  # from the build job, whose contents code that landed on main could have chosen, so the
+  # staged tree is checked before Lake is pointed at it.
+  publish-lake-cache:
+    needs: build
+    if: ${{ needs.build.outputs.staged == 'true' }}
+    runs-on: ubuntu-latest
+    # No GITHUB_TOKEN scopes at all: downloading an artifact from the same run uses the
+    # Actions runtime token, and nothing else here talks to the GitHub API.
+    permissions: {}
+    steps:
+      - name: Download the staged oleans
+        uses: actions/download-artifact@v4
+        with:
+          name: lake-cache-staging
+          path: ${{ runner.temp }}/lake-cache-staging
+
+      - name: Check the staged tree before pointing Lake at it
+        env:
+          STAGING: ${{ runner.temp }}/lake-cache-staging
+        run: |
+          # `lake cache put-staged` uploads `<staging dir>/<name>` for every artifact the
+          # mappings file names, and it parses a name as "<hash>.<everything after the first
+          # dot>" without checking that the join stays inside the staging directory. The job
+          # that produced this tree ran code that landed on main, so both the names and the
+          # tree are attacker-chosen: a name such as `0.art/../../../proc/self/environ` would
+          # otherwise have Lake read this job's environment, the key included, and PUT it
+          # into a publicly readable bucket. Artifact names are flat `<hash>.<ext>` files, so
+          # require exactly that, and require the tree to be a flat directory of regular files
+          # so no name can resolve through a symlink either.
+          if find "$STAGING" -mindepth 2 -print -quit | grep -q .; then
+            echo "::error::the staged tree is nested; expected a flat directory of artifacts"
+            exit 1
+          fi
+          if find "$STAGING" -mindepth 1 ! -type f -print -quit | grep -q .; then
+            echo "::error::the staged tree holds an entry that is not a regular file"
+            exit 1
+          fi
+          python3 - "$STAGING/outputs.jsonl" <<'PY'
+          import json, re, sys
+
+          # A Lake artifact name: a content hash, then dot-separated extension components.
+          NAME = re.compile(r"\A[0-9A-Za-z]+(\.[0-9A-Za-z]+)*\Z")
+
+          def check(value, lineno):
+              """Reject any string that is not a plain artifact name.
+
+              Lake reads artifact descriptors out of arbitrarily nested JSON, so recurse
+              over everything and hold every string to the same shape rather than trying
+              to predict which positions become file names.
+              """
+              if isinstance(value, str):
+                  if not NAME.match(value):
+                      sys.exit(f"::error::{path} line {lineno}: {value!r} is not a plain artifact name")
+              elif isinstance(value, list):
+                  for item in value:
+                      check(item, lineno)
+              elif isinstance(value, dict):
+                  for key, item in value.items():
+                      check(key, lineno)
+                      check(item, lineno)
+
+          path = sys.argv[1]
+          with open(path, encoding="utf-8") as handle:
+              for lineno, line in enumerate(handle, start=1):
+                  # The first line carries the map's schema version, not an artifact name.
+                  if lineno > 1:
+                      check(json.loads(line), lineno)
+          PY
+
+      - name: Install elan (no checkout, so no project code)
+        env:
+          TOOLCHAIN: ${{ needs.build.outputs.toolchain }}
+        run: |
+          curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
+          chmod +x elan-init.sh && ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN"
+
+      - name: Publish the staged oleans to the Lake cache
+        env:
           # Passed under non-LAKE_ names so Lake never sees the deprecated endpoint
           # environment variables; we hand it the endpoints through a `--service` config.
           S3_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
           S3_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
           LAKE_CACHE_KEY_RAW: ${{ secrets.LAKE_CACHE_KEY }}
+          # There is no lean-toolchain file to read (there is no checkout), so name the
+          # toolchain the build job used. Lake takes ELAN_TOOLCHAIN as its `Env.toolchain`,
+          # which is also the string it scopes uploads by.
+          ELAN_TOOLCHAIN: ${{ needs.build.outputs.toolchain }}
+          STAGING: ${{ runner.temp }}/lake-cache-staging
         run: |
-          export PATH="$HOME/.elan/bin:$PATH"
-          # curl --user wants "<ACCESS_KEY_ID>:<SECRET>"; trim trailing whitespace and mask
-          # it so it never lands in the log. LAKE_CACHE_KEY (the upload secret) stays an
-          # env var; only the endpoints move to the --service config below.
-          KEY="$(printf %s "$LAKE_CACHE_KEY_RAW" | sed -e 's/[[:space:]]*$//')"
+          if [ -z "$LAKE_CACHE_KEY_RAW" ]; then
+            echo "::notice::the LAKE_CACHE_KEY secret is not set; the staged oleans were not published"
+            exit 0
+          fi
+          # curl --user wants "<ACCESS_KEY_ID>:<SECRET>"; trim trailing whitespace and mask it
+          # so it never lands in the log. The trim is bash parameter expansion rather than a
+          # pipe through `sed`, so no external program sits between the secret and Lake.
+          KEY="$LAKE_CACHE_KEY_RAW"
+          KEY="${KEY%"${KEY##*[![:space:]]}"}"
           echo "::add-mask::$KEY"; export LAKE_CACHE_KEY="$KEY"
           # Define the authenticated S3 service in a Lake system config and select it with
           # `--service` (the env-var form of endpoint config is deprecated).
@@ -285,13 +442,9 @@ jobs:
           revisionEndpoint = "$S3_REVISION_ENDPOINT"
           TOML
           export LAKE_CONFIG="$CFG"
-          # Pack the already-built oleans into the local Lake cache (no recompile — the
-          # health-check build above left matching traces), emit the root-package
-          # input->output mappings, then upload just those artifacts (SigV4 PUT to S3).
-          # `lake cache put` configures the workspace, so the revision (this main commit)
-          # and the toolchain/platform scope are detected automatically and match what
-          # pr-build's `lake cache get --service ... --repo` derives.
-          lake build >/dev/null
-          lake build --no-build -o .lake/outputs.jsonl
-          echo "root-package mapping entries: $(wc -l < .lake/outputs.jsonl)"
-          lake cache put .lake/outputs.jsonl --service tauceti-r2 --repo TauCetiProject/TauCeti
+          # `--rev` names the commit the build job built, since there is no working tree to
+          # detect it from. That option, `--toolchain`, and the deliberately absent
+          # `--platform` reproduce byte for byte the scope `lake cache put` derived from the
+          # workspace, and so the scope pr-build's `lake cache get --service ... --repo` reads.
+          lake cache put-staged "$STAGING" --service tauceti-r2 \
+            --repo TauCetiProject/TauCeti --rev "$GITHUB_SHA" --toolchain "$ELAN_TOOLCHAIN"

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -61,11 +61,52 @@ to sign them, so the read host must be public; only uploads use a key.
 | `LAKE_CACHE_REVISION_ENDPOINT_PUBLIC` | `https://cache.taucetiproject.org/revisions` | `pr-build.yml` read |
 | `LAKE_CACHE_ARTIFACT_ENDPOINT` | `https://d789bf36….r2.cloudflarestorage.com/tauceti-cache/artifacts` | `ci.yml` upload |
 | `LAKE_CACHE_REVISION_ENDPOINT` | `https://d789bf36….r2.cloudflarestorage.com/tauceti-cache/revisions` | `ci.yml` upload |
-| `LAKE_CACHE_KEY` (secret) | `<ACCESS_KEY_ID>:<SECRET>`, read-write | `ci.yml` upload only |
+| `LAKE_CACHE_KEY` (secret) | `<ACCESS_KEY_ID>:<SECRET>`, read-write | `ci.yml`, `publish-lake-cache` job only |
 
 Lake service names: `tauceti-public` for reads, `tauceti-r2` for uploads. Object keys are
 `artifacts/TauCetiProject/TauCeti/<hash>.art`, so the endpoint variables hold only the prefix and
 Lake appends the scope.
+
+## Why the upload is its own job
+
+`ci.yml` publishes in two jobs. `build` compiles main and *stages* the artifacts; the separate
+`publish-lake-cache` job holds `LAKE_CACHE_KEY` and uploads them. The split is a trust boundary,
+not a convenience.
+
+`build` runs `lake build` unsandboxed, as the runner user, on whatever landed on main, and Lean
+executes code at elaboration time. `run_cmd`, `initialize` and macro-time IO are all unrestricted:
+the scope, import-boundary and `set_option` guards are textual scans, and a file that writes
+during elaboration exits 0 with no diagnostic. Such code runs with the runner user's privileges,
+so it can rewrite `$HOME/.elan/bin/lake`, prepend a directory to every later step's `PATH` through
+`$GITHUB_PATH`, or set `LD_PRELOAD` or `BASH_ENV` for every later step through `$GITHUB_ENV`.
+Hardening the individual commands that touch the key does not help: any secret placed in a later
+step of that job is a secret placed in reach of code that landed on main. (This is not reachable
+from an unmerged PR, which compiles only under landrun in `pr-build.yml`, with writes confined to
+`base/.lake` and no secret in the sandbox's `--env` allowlist.)
+
+So `build` runs `lake cache stage`, which needs no credential and touches no network, and hands
+the staging directory to `publish-lake-cache` as a workflow artifact: about 60 MB, one flat
+directory of `.ltar` files plus the mappings. That job has no checkout, no Lake workspace and no
+dependencies, so no code from this repository or from Mathlib runs anywhere in it, and it takes no
+`GITHUB_TOKEN` scopes. `lake cache put-staged` is the command for exactly this: it does not
+configure the workspace and so does not execute arbitrary user code.
+
+Because it does not configure the workspace, `put-staged` cannot derive the toolchain and platform
+halves of the upload scope, so the job passes `--rev` and `--toolchain` explicitly and relies on
+the default of no platform. That reproduces the scope `lake cache put` derived, verified by
+comparing the revision URLs the two commands emit, which are identical:
+`revisions/TauCetiProject/TauCeti/tc/leanprover--lean4---<version>/<rev>.jsonl`. The platform is
+absent because `lakefile.toml` sets `platformIndependent = true`; the staging step fails loudly if
+that ever stops being true, since a silent mismatch would publish under a scope `pr-build` never
+reads.
+
+The staged tree arrives from a job that ran code that landed on main, so `publish-lake-cache`
+checks it before pointing Lake at it: the tree must be a flat directory of regular files, and
+every string in the mappings must be a plain `<hash>.<ext>` artifact name. Lake parses an artifact
+name as everything after the first dot and joins it to the staging directory without checking that
+the result stays inside, so an unchecked name like `0.art/../../../proc/self/environ` would
+otherwise have Lake read the publishing job's environment and `PUT` it into a publicly readable
+bucket.
 
 ## Why a custom domain
 

--- a/docs/cache-infrastructure.md
+++ b/docs/cache-infrastructure.md
@@ -86,10 +86,18 @@ from an unmerged PR, which compiles only under landrun in `pr-build.yml`, with w
 
 So `build` runs `lake cache stage`, which needs no credential and touches no network, and hands
 the staging directory to `publish-lake-cache` as a workflow artifact: about 60 MB, one flat
-directory of `.ltar` files plus the mappings. That job has no checkout, no Lake workspace and no
-dependencies, so no code from this repository or from Mathlib runs anywhere in it, and it takes no
-`GITHUB_TOKEN` scopes. `lake cache put-staged` is the command for exactly this: it does not
-configure the workspace and so does not execute arbitrary user code.
+directory of `.ltar` files plus the mappings. That job checks out exactly one file and has no Lake
+workspace and no dependencies, so no code from this repository or from Mathlib runs anywhere in
+it, and it takes no `GITHUB_TOKEN` scopes. `lake cache put-staged` is the command for exactly
+this: it does not configure the workspace and so does not execute arbitrary user code.
+
+Nothing the build job reports is trusted there. The one file `publish-lake-cache` checks out is
+`lean-toolchain`, because which toolchain it installs decides which `lake` binary handles the key,
+and `elan toolchain install owner/repo:tag` fetches from that repository's releases. Taking that
+name from the build job would hand the choice straight back to code that landed on `main`, which
+can rewrite `lean-toolchain` on disk or poison the reporting step through `$GITHUB_ENV`. The pin
+is read from the repository instead, its shape is re-checked against `leanprover/lean4:` releases,
+and it must equal what the build job reports it built with.
 
 Because it does not configure the workspace, `put-staged` cannot derive the toolchain and platform
 halves of the upload scope, so the job passes `--rev` and `--toolchain` explicitly and relies on


### PR DESCRIPTION
This PR moves `ci.yml`'s Lake cache upload into its own job, so the `LAKE_CACHE_KEY` secret is never present in a job that has executed code from `main`.

`ci.yml`'s `Build` step runs `lake build` unsandboxed, as the runner user, on whatever landed on `main`, and Lean executes code at elaboration time: `run_cmd`, `initialize` and macro-time IO are all unrestricted, since the scope, import-boundary and `set_option` guards are textual scans. Such code holds the runner user's privileges for the rest of the job, so hardening the individual commands that touch the key is not enough. Besides rewriting `$HOME/.elan/bin/lake` or planting a `sed` ahead of it on `PATH`, it can append to `$GITHUB_PATH` or `$GITHUB_ENV` and so set `PATH`, `LD_PRELOAD` or `BASH_ENV` for every later step of the job. Any secret placed in a later step of that job is a secret placed in reach of code that landed on `main`, whatever that step does with it.

The `build` job now runs `lake cache stage`, which needs no credential and contacts no network, and hands the staging directory to a new `publish-lake-cache` job as a workflow artifact (about 60 MB: one flat directory of `.ltar` files plus the mappings). That job checks out exactly one file, has no Lake workspace and no dependencies, so no code from this repository or from Mathlib runs anywhere in it, and it takes no `GITHUB_TOKEN` scopes. It uploads with `lake cache put-staged`, whose help page states that it does not configure the workspace and therefore does not execute arbitrary user code. The trailing-whitespace trim on the key is bash parameter expansion rather than a pipe through `sed`, so no external program sits between the secret and Lake.

Nothing the build job reports is trusted in the publish job. The one file it checks out is `lean-toolchain`, because which toolchain it installs decides which `lake` binary handles the key, and `elan toolchain install owner/repo:tag` fetches from that repository's releases: taking that name from the build job would hand the choice straight back to the code the split exists to contain. The pin is read from the repository instead, its shape is re-checked against `leanprover/lean4:` releases, and it must equal what the build job reports it built with. `lean-toolchain` is a Lake pin that `bump-guard` only lets move forward along `leanprover/lean4` releases without a human, and `main`'s build already installed and ran whatever it names, so reading it there extends no trust that the build did not already extend.

Because it does not configure the workspace, `put-staged` cannot derive the toolchain and platform halves of the upload scope, so the job passes `--rev` and `--toolchain` explicitly and relies on the default of no platform. That reproduces byte for byte the scope `lake cache put` derived, checked locally by comparing the revision URLs the two commands emit against a dead endpoint: both are `revisions/TauCetiProject/TauCeti/tc/leanprover--lean4---v4.34.0-rc1/<rev>.jsonl`, which is what `pr-build`'s `lake cache get --service ... --repo` reads. That equality holds only while the package config keeps two properties, so the staging step fails loudly if `lakefile.toml` stops setting `platformIndependent` (Lake would then put a platform in the scope) or starts setting `fixedToolchain` or `bootstrap` (Lake would then leave the toolchain out of it).

The staged tree arrives from the job that ran the landed code, so `publish-lake-cache` checks it before pointing Lake at it: the tree must be a flat directory of regular files, and every string in the mappings must be a plain `<hash>.<ext>` artifact name. Lake parses an artifact name as everything after the first dot and joins it to the staging directory without checking that the result stays inside, so an unchecked name like `0.art/../../../proc/self/environ` would otherwise have Lake read the publishing job's environment and `PUT` it into a publicly readable bucket. The check is exercised locally against a real 2563-entry staging tree and against traversal, absolute-path, symlink and nested-directory variants of it.

elan's installer is still fetched unpinned in the new job, exactly as `pr-build.yml` and `lean-action` fetch it elsewhere, so elan's distribution and the named Lean release stay in its trust base. That is a project-wide assumption about leanprover's release channel rather than one this split introduces, and pinning it is tracked separately in https://github.com/TauCetiProject/TauCeti/issues/3725.

The publish path stays dormant until the endpoints and the key are installed. The `build` job no longer references the secret at all, not even to test whether it is set, so staging depends on the two endpoint variables alone and the publish job skips with a notice if the key turns out to be missing.

Closes https://github.com/TauCetiProject/TauCeti/issues/3720

Roadmap: none

🤖 Prepared with Claude Code
