### PR TITLE
feat: induce an exact structure on an extension-closed subcategory

### DIFF
--- a/TauCeti/CategoryTheory/Exact/BaseChange.lean
+++ b/TauCeti/CategoryTheory/Exact/BaseChange.lean
@@ -34,7 +34,8 @@ extension-closed subcategories inherit axiom E1.
 
 * `TauCeti.ExactStructure.conflation_cobaseChange` and
   `TauCeti.ExactStructure.conflation_baseChange`: base and cobase change of a conflation along an
-  admissible morphism is a conflation.
+  arbitrary morphism is a conflation; the inflation or deflation in the original conflation is
+  the admissible morphism being pushed out or pulled back.
 * `TauCeti.ExactStructure.conflation_comp_of_isPushout` and
   `TauCeti.ExactStructure.conflation_comp_of_isPullback`: the cokernel of a composite of
   inflations, and the kernel of a composite of deflations, computed as a pushout resp. pullback.
@@ -64,7 +65,7 @@ variable (S : ShortComplex C) {X' Q : C} {u : S.X₁ ⟶ X'} {v : S.X₂ ⟶ Q} 
 
 /-- The morphism `Q ⟶ S.X₃` out of a cobase change of `S.f` along `u`, induced by `S.g` on the
 one summand and by `0` on the other. -/
-@[expose] noncomputable def cobaseChangeπ (sq : IsPushout S.f u v w) : Q ⟶ S.X₃ :=
+noncomputable def cobaseChangeπ (sq : IsPushout S.f u v w) : Q ⟶ S.X₃ :=
   sq.desc S.g 0 (by simp [S.zero])
 
 @[reassoc (attr := simp)]
@@ -77,16 +78,21 @@ theorem inr_cobaseChangeπ (sq : IsPushout S.f u v w) : w ≫ cobaseChangeπ S s
 
 /-- The cobase change of a short complex `S` along `u : S.X₁ ⟶ X'`: the short complex
 `X' ⟶ Q ⟶ S.X₃` attached to a pushout square of `S.f` along `u`. -/
-@[expose] noncomputable def cobaseChange (sq : IsPushout S.f u v w) : ShortComplex C :=
+noncomputable def cobaseChange (sq : IsPushout S.f u v w) : ShortComplex C :=
   ShortComplex.mk w (cobaseChangeπ S sq) (by simp)
 
-@[simp] theorem cobaseChange_X₁ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₁ = X' := rfl
-@[simp] theorem cobaseChange_X₂ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₂ = Q := rfl
-@[simp] theorem cobaseChange_X₃ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₃ = S.X₃ := rfl
-@[simp] theorem cobaseChange_f (sq : IsPushout S.f u v w) : (cobaseChange S sq).f = w := rfl
+/-- The defining equation for `cobaseChange`. -/
+theorem cobaseChange_def (sq : IsPushout S.f u v w) :
+    cobaseChange S sq = ShortComplex.mk w (cobaseChangeπ S sq) (by simp) := (rfl)
+
+@[simp] theorem cobaseChange_X₁ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₁ = X' := (rfl)
+@[simp] theorem cobaseChange_X₂ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₂ = Q := (rfl)
+@[simp] theorem cobaseChange_X₃ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₃ = S.X₃ := (rfl)
+@[simp] theorem cobaseChange_f (sq : IsPushout S.f u v w) : HEq (cobaseChange S sq).f w :=
+  (HEq.rfl)
 
 @[simp] theorem cobaseChange_g (sq : IsPushout S.f u v w) :
-    (cobaseChange S sq).g = cobaseChangeπ S sq := rfl
+    HEq (cobaseChange S sq).g (cobaseChangeπ S sq) := (HEq.rfl)
 
 end CobaseChange
 
@@ -96,7 +102,7 @@ variable (S : ShortComplex C) {Z' Q : C} {u : Z' ⟶ S.X₃} {v : Q ⟶ S.X₂} 
 
 /-- The morphism `S.X₁ ⟶ Q` into a base change of `S.g` along `u`, induced by `S.f` on the one
 factor and by `0` on the other. -/
-@[expose] noncomputable def baseChangeι (sq : IsPullback v w S.g u) : S.X₁ ⟶ Q :=
+noncomputable def baseChangeι (sq : IsPullback v w S.g u) : S.X₁ ⟶ Q :=
   sq.lift S.f 0 (by simp [S.zero])
 
 @[reassoc (attr := simp)]
@@ -109,16 +115,21 @@ theorem baseChangeι_snd (sq : IsPullback v w S.g u) : baseChangeι S sq ≫ w =
 
 /-- The base change of a short complex `S` along `u : Z' ⟶ S.X₃`: the short complex
 `S.X₁ ⟶ Q ⟶ Z'` attached to a pullback square of `S.g` along `u`. -/
-@[expose] noncomputable def baseChange (sq : IsPullback v w S.g u) : ShortComplex C :=
+noncomputable def baseChange (sq : IsPullback v w S.g u) : ShortComplex C :=
   ShortComplex.mk (baseChangeι S sq) w (by simp)
 
-@[simp] theorem baseChange_X₁ (sq : IsPullback v w S.g u) : (baseChange S sq).X₁ = S.X₁ := rfl
-@[simp] theorem baseChange_X₂ (sq : IsPullback v w S.g u) : (baseChange S sq).X₂ = Q := rfl
-@[simp] theorem baseChange_X₃ (sq : IsPullback v w S.g u) : (baseChange S sq).X₃ = Z' := rfl
-@[simp] theorem baseChange_g (sq : IsPullback v w S.g u) : (baseChange S sq).g = w := rfl
+/-- The defining equation for `baseChange`. -/
+theorem baseChange_def (sq : IsPullback v w S.g u) :
+    baseChange S sq = ShortComplex.mk (baseChangeι S sq) w (by simp) := (rfl)
+
+@[simp] theorem baseChange_X₁ (sq : IsPullback v w S.g u) : (baseChange S sq).X₁ = S.X₁ := (rfl)
+@[simp] theorem baseChange_X₂ (sq : IsPullback v w S.g u) : (baseChange S sq).X₂ = Q := (rfl)
+@[simp] theorem baseChange_X₃ (sq : IsPullback v w S.g u) : (baseChange S sq).X₃ = Z' := (rfl)
+@[simp] theorem baseChange_g (sq : IsPullback v w S.g u) : HEq (baseChange S sq).g w :=
+  (HEq.rfl)
 
 @[simp] theorem baseChange_f (sq : IsPullback v w S.g u) :
-    (baseChange S sq).f = baseChangeι S sq := rfl
+    HEq (baseChange S sq).f (baseChangeι S sq) := (HEq.rfl)
 
 end BaseChange
 

--- a/TauCeti/CategoryTheory/Exact/BaseChange.lean
+++ b/TauCeti/CategoryTheory/Exact/BaseChange.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.CategoryTheory.Exact.ExactStructure
+
+/-!
+# Conflations along admissible base change, and the Noether conflation
+
+Quillen's axiom E2 produces a pushout of an inflation along an arbitrary morphism and asserts
+only that the resulting morphism is again an inflation. This file identifies the *cokernel* of
+that inflation: cobase change of a conflation `X ⟶ Y ⟶ Z` along `u : X ⟶ X'` produces a
+conflation `X' ⟶ Q ⟶ Z` with the *same* third term. Dually, base change of a conflation along
+`u : Z' ⟶ Z` produces a conflation `X ⟶ Q ⟶ Z'` with the same first term.
+
+The second half of the file uses this to describe the conflations attached to a composite of two
+inflations. If `X ⟶ Y ⟶ Z` and `Y ⟶ W ⟶ V` are conflations, then the pushout `Q` of the
+inflation `Y ⟶ W` along the deflation `Y ⟶ Z` is at once the third term of a conflation
+`X ⟶ W ⟶ Q` and the second term of a conflation `Z ⟶ Q ⟶ V`. This is the exact-category form of
+Noether's second isomorphism theorem, `Q ≅ W/X` with `(W/X)/(Y/X) ≅ W/Y`, and it is what makes
+extension-closed subcategories inherit axiom E1.
+
+## Main definitions
+
+* `TauCeti.cobaseChange`: the conflation `X' ⟶ Q ⟶ Z` obtained from `S : X ⟶ Y ⟶ Z` and a
+  pushout square along `u : X ⟶ X'`.
+* `TauCeti.baseChange`: the conflation `X ⟶ Q ⟶ Z'` obtained from `S : X ⟶ Y ⟶ Z` and a pullback
+  square along `u : Z' ⟶ Z`.
+
+## Main results
+
+* `TauCeti.ExactStructure.conflation_cobaseChange` and
+  `TauCeti.ExactStructure.conflation_baseChange`: base and cobase change of a conflation along an
+  admissible morphism is a conflation.
+* `TauCeti.ExactStructure.conflation_comp_of_isPushout` and
+  `TauCeti.ExactStructure.conflation_comp_of_isPullback`: the cokernel of a composite of
+  inflations, and the kernel of a composite of deflations, computed as a pushout resp. pullback.
+* `TauCeti.ExactStructure.exists_conflation_comp`: the Noether package for a composite of two
+  inflations.
+
+## References
+
+* Theo Bühler, *Exact categories*, Expositiones Mathematicae **28** (2010), 1--69,
+  <https://arxiv.org/abs/0811.1480>. Proposition 2.12 identifies the cokernel along a cobase
+  change and Lemma 3.5 is the Noether isomorphism proved here.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+section CobaseChange
+
+variable (S : ShortComplex C) {X' Q : C} {u : S.X₁ ⟶ X'} {v : S.X₂ ⟶ Q} {w : X' ⟶ Q}
+
+/-- The morphism `Q ⟶ S.X₃` out of a cobase change of `S.f` along `u`, induced by `S.g` on the
+one summand and by `0` on the other. -/
+@[expose] noncomputable def cobaseChangeπ (sq : IsPushout S.f u v w) : Q ⟶ S.X₃ :=
+  sq.desc S.g 0 (by simp [S.zero])
+
+@[reassoc (attr := simp)]
+theorem inl_cobaseChangeπ (sq : IsPushout S.f u v w) : v ≫ cobaseChangeπ S sq = S.g :=
+  sq.inl_desc _ _ _
+
+@[reassoc (attr := simp)]
+theorem inr_cobaseChangeπ (sq : IsPushout S.f u v w) : w ≫ cobaseChangeπ S sq = 0 :=
+  sq.inr_desc _ _ _
+
+/-- The cobase change of a short complex `S` along `u : S.X₁ ⟶ X'`: the short complex
+`X' ⟶ Q ⟶ S.X₃` attached to a pushout square of `S.f` along `u`. -/
+@[expose] noncomputable def cobaseChange (sq : IsPushout S.f u v w) : ShortComplex C :=
+  ShortComplex.mk w (cobaseChangeπ S sq) (by simp)
+
+@[simp] theorem cobaseChange_X₁ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₁ = X' := rfl
+@[simp] theorem cobaseChange_X₂ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₂ = Q := rfl
+@[simp] theorem cobaseChange_X₃ (sq : IsPushout S.f u v w) : (cobaseChange S sq).X₃ = S.X₃ := rfl
+@[simp] theorem cobaseChange_f (sq : IsPushout S.f u v w) : (cobaseChange S sq).f = w := rfl
+
+@[simp] theorem cobaseChange_g (sq : IsPushout S.f u v w) :
+    (cobaseChange S sq).g = cobaseChangeπ S sq := rfl
+
+end CobaseChange
+
+section BaseChange
+
+variable (S : ShortComplex C) {Z' Q : C} {u : Z' ⟶ S.X₃} {v : Q ⟶ S.X₂} {w : Q ⟶ Z'}
+
+/-- The morphism `S.X₁ ⟶ Q` into a base change of `S.g` along `u`, induced by `S.f` on the one
+factor and by `0` on the other. -/
+@[expose] noncomputable def baseChangeι (sq : IsPullback v w S.g u) : S.X₁ ⟶ Q :=
+  sq.lift S.f 0 (by simp [S.zero])
+
+@[reassoc (attr := simp)]
+theorem baseChangeι_fst (sq : IsPullback v w S.g u) : baseChangeι S sq ≫ v = S.f :=
+  sq.lift_fst _ _ _
+
+@[reassoc (attr := simp)]
+theorem baseChangeι_snd (sq : IsPullback v w S.g u) : baseChangeι S sq ≫ w = 0 :=
+  sq.lift_snd _ _ _
+
+/-- The base change of a short complex `S` along `u : Z' ⟶ S.X₃`: the short complex
+`S.X₁ ⟶ Q ⟶ Z'` attached to a pullback square of `S.g` along `u`. -/
+@[expose] noncomputable def baseChange (sq : IsPullback v w S.g u) : ShortComplex C :=
+  ShortComplex.mk (baseChangeι S sq) w (by simp)
+
+@[simp] theorem baseChange_X₁ (sq : IsPullback v w S.g u) : (baseChange S sq).X₁ = S.X₁ := rfl
+@[simp] theorem baseChange_X₂ (sq : IsPullback v w S.g u) : (baseChange S sq).X₂ = Q := rfl
+@[simp] theorem baseChange_X₃ (sq : IsPullback v w S.g u) : (baseChange S sq).X₃ = Z' := rfl
+@[simp] theorem baseChange_g (sq : IsPullback v w S.g u) : (baseChange S sq).g = w := rfl
+
+@[simp] theorem baseChange_f (sq : IsPullback v w S.g u) :
+    (baseChange S sq).f = baseChangeι S sq := rfl
+
+end BaseChange
+
+namespace ExactStructure
+
+variable [HasZeroObject C] [HasBinaryBiproducts C] (E : ExactStructure C)
+
+/-- **Cobase change of a conflation is a conflation with the same cokernel.** The pushout of a
+conflation `X ⟶ Y ⟶ Z` along a morphism `u : X ⟶ X'` is a conflation `X' ⟶ Q ⟶ Z`.
+
+Axiom E2 alone gives only that `X' ⟶ Q` is an inflation; the content here is that its cokernel
+may be taken to be the original `Z`. -/
+theorem conflation_cobaseChange {S : ShortComplex C} (hS : E.Conflation S) {X' Q : C}
+    {u : S.X₁ ⟶ X'} {v : S.X₂ ⟶ Q} {w : X' ⟶ Q} (sq : IsPushout S.f u v w) :
+    E.Conflation (cobaseChange S sq) := by
+  have hpair : IsKernelCokernelPair S := E.isKernelCokernelPair S hS
+  have hw : E.IsInflation w :=
+    E.isStableUnderCobaseChange_inflations.of_isPushout sq.flip (E.isInflation_f hS)
+  have hepi : Epi (cobaseChangeπ S sq) := by
+    have := hpair.epi_g
+    have h : Epi (v ≫ cobaseChangeπ S sq) := by rw [inl_cobaseChangeπ]; assumption
+    exact epi_of_epi v (cobaseChangeπ S sq)
+  have key : ∀ (A : C) (k : Q ⟶ A), w ≫ k = 0 →
+      ∃ l : S.X₃ ⟶ A, cobaseChangeπ S sq ≫ l = k := fun A k hk => by
+    refine ⟨hpair.desc (v ≫ k) ?_, ?_⟩
+    · rw [← Category.assoc, sq.w, Category.assoc, hk, comp_zero]
+    · refine sq.hom_ext ?_ ?_
+      · rw [← Category.assoc, inl_cobaseChangeπ, hpair.g_desc]
+      · rw [← Category.assoc, inr_cobaseChangeπ, zero_comp, hk]
+  refine E.conflation_of_isColimit_of_isInflation ?_ hw
+  letI : Epi (cobaseChange S sq).g := hepi
+  exact CokernelCofork.IsColimit.ofπ' _ _ fun {A} k hk =>
+    ⟨(key A k hk).choose, (key A k hk).choose_spec⟩
+
+/-- **Base change of a conflation is a conflation with the same kernel.** The pullback of a
+conflation `X ⟶ Y ⟶ Z` along a morphism `u : Z' ⟶ Z` is a conflation `X ⟶ Q ⟶ Z'`. -/
+theorem conflation_baseChange {S : ShortComplex C} (hS : E.Conflation S) {Z' Q : C}
+    {u : Z' ⟶ S.X₃} {v : Q ⟶ S.X₂} {w : Q ⟶ Z'} (sq : IsPullback v w S.g u) :
+    E.Conflation (baseChange S sq) := by
+  have hpair : IsKernelCokernelPair S := E.isKernelCokernelPair S hS
+  have hw : E.IsDeflation w :=
+    E.isStableUnderBaseChange_deflations.of_isPullback sq (E.isDeflation_g hS)
+  have hmono : Mono (baseChangeι S sq) := by
+    have := hpair.mono_f
+    have h : Mono (baseChangeι S sq ≫ v) := by rw [baseChangeι_fst]; assumption
+    exact mono_of_mono (baseChangeι S sq) v
+  have key : ∀ (A : C) (k : A ⟶ Q), k ≫ w = 0 →
+      ∃ l : A ⟶ S.X₁, l ≫ baseChangeι S sq = k := fun A k hk => by
+    refine ⟨hpair.lift (k ≫ v) ?_, ?_⟩
+    · rw [Category.assoc, sq.w, ← Category.assoc, hk, zero_comp]
+    · refine sq.hom_ext ?_ ?_
+      · rw [Category.assoc, baseChangeι_fst, hpair.lift_f]
+      · rw [Category.assoc, baseChangeι_snd, comp_zero, hk]
+  refine E.conflation_of_isLimit_of_isDeflation ?_ hw
+  letI : Mono (baseChange S sq).f := hmono
+  exact KernelFork.IsLimit.ofι' _ _ fun {A} k hk =>
+    ⟨(key A k hk).choose, (key A k hk).choose_spec⟩
+
+/-- **The cokernel of a composite of inflations.** If `X ⟶ Y ⟶ Z` and `Y ⟶ W ⟶ V` are
+conflations, then the pushout `Q` of the inflation `Y ⟶ W` along the deflation `Y ⟶ Z` is a
+cokernel of the composite inflation `X ⟶ W`. -/
+theorem conflation_comp_of_isPushout {X Y Z W V Q : C} {i : X ⟶ Y} {p : Y ⟶ Z} {hip : i ≫ p = 0}
+    (h₁ : E.Conflation (ShortComplex.mk i p hip)) {j : Y ⟶ W} {v : W ⟶ V} {hjv : j ≫ v = 0}
+    (h₂ : E.Conflation (ShortComplex.mk j v hjv)) {c : W ⟶ Q} {α : Z ⟶ Q}
+    (sq : IsPushout j p c α) :
+    E.Conflation (ShortComplex.mk (i ≫ j) c
+      (by rw [Category.assoc, sq.w, ← Category.assoc, hip, zero_comp])) := by
+  have hpair₁ : IsKernelCokernelPair (ShortComplex.mk i p hip) := E.isKernelCokernelPair _ h₁
+  have hp : Epi p := hpair₁.epi_g
+  have hij : E.IsInflation (i ≫ j) :=
+    E.isInflation_comp i j (E.isInflation_f h₁) (E.isInflation_f h₂)
+  have hc : Epi c := ⟨fun {T} k l hkl => sq.hom_ext hkl (by
+    rw [← cancel_epi p, ← Category.assoc, ← Category.assoc, ← sq.w, Category.assoc,
+      Category.assoc, hkl])⟩
+  have key : ∀ (T : C) (t : W ⟶ T), (i ≫ j) ≫ t = 0 → ∃ s : Q ⟶ T, c ≫ s = t := fun T t ht => by
+    have hu : i ≫ j ≫ t = 0 := by rw [← Category.assoc]; exact ht
+    exact ⟨sq.desc t (hpair₁.desc (j ≫ t) hu) (hpair₁.g_desc (j ≫ t) hu).symm, by simp⟩
+  refine E.conflation_of_isColimit_of_isInflation ?_ hij
+  exact CokernelCofork.IsColimit.ofπ' _ _ fun {T} t ht =>
+    ⟨(key T t ht).choose, (key T t ht).choose_spec⟩
+
+/-- **The kernel of a composite of deflations.** If `X ⟶ Y ⟶ Z` and `V ⟶ W ⟶ Y` are conflations,
+then the pullback `Q` of the deflation `W ⟶ Y` along the inflation `X ⟶ Y` is a kernel of the
+composite deflation `W ⟶ Z`. -/
+theorem conflation_comp_of_isPullback {X Y Z W V Q : C} {i : X ⟶ Y} {p : Y ⟶ Z} {hip : i ≫ p = 0}
+    (h₁ : E.Conflation (ShortComplex.mk i p hip)) {v : V ⟶ W} {q : W ⟶ Y} {hvq : v ≫ q = 0}
+    (h₂ : E.Conflation (ShortComplex.mk v q hvq)) {c : Q ⟶ W} {α : Q ⟶ X}
+    (sq : IsPullback c α q i) :
+    E.Conflation (ShortComplex.mk c (q ≫ p)
+      (by rw [← Category.assoc, sq.w, Category.assoc, hip, comp_zero])) := by
+  have hpair₁ : IsKernelCokernelPair (ShortComplex.mk i p hip) := E.isKernelCokernelPair _ h₁
+  have hi : Mono i := hpair₁.mono_f
+  have hqp : E.IsDeflation (q ≫ p) :=
+    E.isDeflation_comp q p (E.isDeflation_g h₂) (E.isDeflation_g h₁)
+  have hc : Mono c := ⟨fun {T} k l hkl => sq.hom_ext hkl (by
+    rw [← cancel_mono i, Category.assoc, Category.assoc, ← sq.w, ← Category.assoc,
+      ← Category.assoc, hkl])⟩
+  have key : ∀ (T : C) (t : T ⟶ W), t ≫ q ≫ p = 0 → ∃ l : T ⟶ Q, l ≫ c = t := fun T t ht => by
+    have hu : (t ≫ q) ≫ p = 0 := by rw [Category.assoc]; exact ht
+    exact ⟨sq.lift t (hpair₁.lift (t ≫ q) hu) (hpair₁.lift_f (t ≫ q) hu).symm, by simp⟩
+  refine E.conflation_of_isLimit_of_isDeflation ?_ hqp
+  exact KernelFork.IsLimit.ofι' _ _ fun {T} t ht =>
+    ⟨(key T t ht).choose, (key T t ht).choose_spec⟩
+
+/-- **The Noether isomorphism for exact categories.** Given conflations `X ⟶ Y ⟶ Z` and
+`Y ⟶ W ⟶ V`, there is an object `Q` — the pushout of `Y ⟶ W` along `Y ⟶ Z` — which is at once
+the cokernel of the composite inflation `X ⟶ W` and an extension of `V` by `Z`.
+
+In the classical notation `Q ≅ W/X`, and the second conflation is
+`Y/X ⟶ W/X ⟶ W/Y`. This is Bühler's Lemma 3.5, and it is exactly what an extension-closed
+subcategory needs in order to inherit axiom E1. -/
+theorem exists_conflation_comp {X Y Z W V : C} {i : X ⟶ Y} {p : Y ⟶ Z} {hip : i ≫ p = 0}
+    (h₁ : E.Conflation (ShortComplex.mk i p hip)) {j : Y ⟶ W} {v : W ⟶ V} {hjv : j ≫ v = 0}
+    (h₂ : E.Conflation (ShortComplex.mk j v hjv)) :
+    ∃ (Q : C) (c : W ⟶ Q) (α : Z ⟶ Q) (β : Q ⟶ V) (hc : (i ≫ j) ≫ c = 0) (hβ : α ≫ β = 0),
+      E.Conflation (ShortComplex.mk (i ≫ j) c hc) ∧ E.Conflation (ShortComplex.mk α β hβ) ∧
+        j ≫ c = p ≫ α ∧ c ≫ β = v := by
+  have : HasPushout j p := E.hasPushouts_inflations.hasPushout p (E.isInflation_f h₂)
+  have sq : IsPushout j p (pushout.inl j p) (pushout.inr j p) := IsPushout.of_hasPushout j p
+  exact ⟨pushout j p, pushout.inl j p, pushout.inr j p,
+    cobaseChangeπ (ShortComplex.mk j v hjv) sq,
+    by rw [Category.assoc, sq.w, ← Category.assoc, hip, zero_comp],
+    inr_cobaseChangeπ (ShortComplex.mk j v hjv) sq,
+    E.conflation_comp_of_isPushout h₁ h₂ sq, E.conflation_cobaseChange h₂ sq, sq.w,
+    inl_cobaseChangeπ (ShortComplex.mk j v hjv) sq⟩
+
+/-- **The dual Noether isomorphism.** Given conflations `X ⟶ Y ⟶ Z` and `V ⟶ W ⟶ Y`, the
+pullback `Q` of `W ⟶ Y` along `X ⟶ Y` is at once the kernel of the composite deflation
+`W ⟶ Z` and an extension of `X` by `V`. -/
+theorem exists_conflation_comp' {X Y Z W V : C} {i : X ⟶ Y} {p : Y ⟶ Z} {hip : i ≫ p = 0}
+    (h₁ : E.Conflation (ShortComplex.mk i p hip)) {v : V ⟶ W} {q : W ⟶ Y} {hvq : v ≫ q = 0}
+    (h₂ : E.Conflation (ShortComplex.mk v q hvq)) :
+    ∃ (Q : C) (c : Q ⟶ W) (α : Q ⟶ X) (β : V ⟶ Q) (hc : c ≫ q ≫ p = 0) (hβ : β ≫ α = 0),
+      E.Conflation (ShortComplex.mk c (q ≫ p) hc) ∧ E.Conflation (ShortComplex.mk β α hβ) ∧
+        c ≫ q = α ≫ i ∧ β ≫ c = v := by
+  have : HasPullback q i := E.hasPullbacks_deflations.hasPullback i (E.isDeflation_g h₂)
+  have sq : IsPullback (pullback.fst q i) (pullback.snd q i) q i := IsPullback.of_hasPullback q i
+  exact ⟨pullback q i, pullback.fst q i, pullback.snd q i,
+    baseChangeι (ShortComplex.mk v q hvq) sq,
+    by rw [← Category.assoc, sq.w, Category.assoc, hip, comp_zero],
+    baseChangeι_snd (ShortComplex.mk v q hvq) sq,
+    E.conflation_comp_of_isPullback h₁ h₂ sq, E.conflation_baseChange h₂ sq, sq.w,
+    baseChangeι_fst (ShortComplex.mk v q hvq) sq⟩
+
+end ExactStructure
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Exact/BaseChange.lean
+++ b/TauCeti/CategoryTheory/Exact/BaseChange.lean
@@ -201,9 +201,8 @@ theorem conflation_comp_of_isPushout {X Y Z W V Q : C} {i : X ⟶ Y} {p : Y ⟶ 
   have hp : Epi p := hpair₁.epi_g
   have hij : E.IsInflation (i ≫ j) :=
     E.isInflation_comp i j (E.isInflation_f h₁) (E.isInflation_f h₂)
-  have hc : Epi c := ⟨fun {T} k l hkl => sq.hom_ext hkl (by
-    rw [← cancel_epi p, ← Category.assoc, ← Category.assoc, ← sq.w, Category.assoc,
-      Category.assoc, hkl])⟩
+  have hc : Epi c := ⟨fun {T} k l hkl => sq.hom_ext hkl <| (cancel_epi p).1 <| by
+    simp only [← reassoc_of% sq.w, hkl]⟩
   have key : ∀ (T : C) (t : W ⟶ T), (i ≫ j) ≫ t = 0 → ∃ s : Q ⟶ T, c ≫ s = t := fun T t ht => by
     have hu : i ≫ j ≫ t = 0 := by rw [← Category.assoc]; exact ht
     exact ⟨sq.desc t (hpair₁.desc (j ≫ t) hu) (hpair₁.g_desc (j ≫ t) hu).symm, by simp⟩
@@ -224,9 +223,8 @@ theorem conflation_comp_of_isPullback {X Y Z W V Q : C} {i : X ⟶ Y} {p : Y ⟶
   have hi : Mono i := hpair₁.mono_f
   have hqp : E.IsDeflation (q ≫ p) :=
     E.isDeflation_comp q p (E.isDeflation_g h₂) (E.isDeflation_g h₁)
-  have hc : Mono c := ⟨fun {T} k l hkl => sq.hom_ext hkl (by
-    rw [← cancel_mono i, Category.assoc, Category.assoc, ← sq.w, ← Category.assoc,
-      ← Category.assoc, hkl])⟩
+  have hc : Mono c := ⟨fun {T} k l hkl => sq.hom_ext hkl <| (cancel_mono i).1 <| by
+    simp only [Category.assoc, ← sq.w, reassoc_of% hkl]⟩
   have key : ∀ (T : C) (t : T ⟶ W), t ≫ q ≫ p = 0 → ∃ l : T ⟶ Q, l ≫ c = t := fun T t ht => by
     have hu : (t ≫ q) ≫ p = 0 := by rw [Category.assoc]; exact ht
     exact ⟨sq.lift t (hpair₁.lift (t ≫ q) hu) (hpair₁.lift_f (t ≫ q) hu).symm, by simp⟩

--- a/TauCeti/CategoryTheory/Exact/ExactStructure.lean
+++ b/TauCeti/CategoryTheory/Exact/ExactStructure.lean
@@ -150,41 +150,54 @@ theorem conflation_iff_of_iso (E : ConflationClass C) {S T : ShortComplex C} (e 
     E.Conflation S ↔ E.Conflation T :=
   E.Conflation.prop_iff_of_iso e
 
-/-- A kernel–cokernel pair whose first map is an inflation is a conflation: the conflation
-witnessing the inflation has the same cokernel, so the two short complexes are isomorphic. -/
-theorem conflation_of_isKernelCokernelPair_of_isInflation (E : ConflationClass C)
-    {S : ShortComplex C}
-    (hS : IsKernelCokernelPair S) (hf : E.IsInflation S.f) : E.Conflation S := by
+/-- A short complex whose first map is an inflation and whose second map is a cokernel of the
+first is a conflation: the conflation witnessing the inflation has the same cokernel, so the two
+short complexes are isomorphic.
+
+Only the cokernel half of `TauCeti.IsKernelCokernelPair` is needed, because the kernel half is
+then inherited from the witnessing conflation. -/
+theorem conflation_of_isColimit_of_isInflation (E : ConflationClass C) {S : ShortComplex C}
+    (hS : IsColimit (CokernelCofork.ofπ S.g S.zero)) (hf : E.IsInflation S.f) :
+    E.Conflation S := by
   obtain ⟨Z, q, hq, hT⟩ := (E.isInflation_iff _).mp hf
   let T := ShortComplex.mk S.f q hq
   have hT' : E.Conflation T := by simpa [T] using hT
   have hpairT : IsKernelCokernelPair T := E.isKernelCokernelPair T hT'
-  let e : Z ≅ S.X₃ :=
-    IsColimit.coconePointUniqueUpToIso hpairT.gIsCokernel hS.gIsCokernel
+  let e : Z ≅ S.X₃ := IsColimit.coconePointUniqueUpToIso hpairT.gIsCokernel hS
   have he : q ≫ e.hom = S.g :=
-    IsColimit.comp_coconePointUniqueUpToIso_hom hpairT.gIsCokernel hS.gIsCokernel
-      WalkingParallelPair.one
+    IsColimit.comp_coconePointUniqueUpToIso_hom hpairT.gIsCokernel hS WalkingParallelPair.one
   exact E.conflation_of_iso (S := T) (T := S)
     (ShortComplex.isoMk (Iso.refl _) (Iso.refl _) e
       (by simp [T]) (by simpa [T] using he.symm)) hT'
 
-/-- A kernel–cokernel pair whose second map is a deflation is a conflation: the conflation
-witnessing the deflation has the same kernel, so the two short complexes are isomorphic. -/
-theorem conflation_of_isKernelCokernelPair_of_isDeflation (E : ConflationClass C)
-    {S : ShortComplex C}
-    (hS : IsKernelCokernelPair S) (hg : E.IsDeflation S.g) : E.Conflation S := by
+/-- A short complex whose second map is a deflation and whose first map is a kernel of the second
+is a conflation: the conflation witnessing the deflation has the same kernel, so the two short
+complexes are isomorphic. -/
+theorem conflation_of_isLimit_of_isDeflation (E : ConflationClass C) {S : ShortComplex C}
+    (hS : IsLimit (KernelFork.ofι S.f S.zero)) (hg : E.IsDeflation S.g) :
+    E.Conflation S := by
   obtain ⟨X, i, hi, hT⟩ := (E.isDeflation_iff _).mp hg
   let T := ShortComplex.mk i S.g hi
   have hT' : E.Conflation T := by simpa [T] using hT
   have hpairT : IsKernelCokernelPair T := E.isKernelCokernelPair T hT'
-  let e : X ≅ S.X₁ :=
-    IsLimit.conePointUniqueUpToIso hpairT.fIsKernel hS.fIsKernel
+  let e : X ≅ S.X₁ := IsLimit.conePointUniqueUpToIso hpairT.fIsKernel hS
   have he : e.hom ≫ S.f = i :=
-    IsLimit.conePointUniqueUpToIso_hom_comp hpairT.fIsKernel hS.fIsKernel
-      WalkingParallelPair.zero
+    IsLimit.conePointUniqueUpToIso_hom_comp hpairT.fIsKernel hS WalkingParallelPair.zero
   exact E.conflation_of_iso (S := T) (T := S)
     (ShortComplex.isoMk e (Iso.refl _) (Iso.refl _)
       (by simpa [T] using he) (by simp [T])) hT'
+
+/-- A kernel–cokernel pair whose first map is an inflation is a conflation. -/
+theorem conflation_of_isKernelCokernelPair_of_isInflation (E : ConflationClass C)
+    {S : ShortComplex C}
+    (hS : IsKernelCokernelPair S) (hf : E.IsInflation S.f) : E.Conflation S :=
+  E.conflation_of_isColimit_of_isInflation hS.gIsCokernel hf
+
+/-- A kernel–cokernel pair whose second map is a deflation is a conflation. -/
+theorem conflation_of_isKernelCokernelPair_of_isDeflation (E : ConflationClass C)
+    {S : ShortComplex C}
+    (hS : IsKernelCokernelPair S) (hg : E.IsDeflation S.g) : E.Conflation S :=
+  E.conflation_of_isLimit_of_isDeflation hS.fIsKernel hg
 
 /-- Being an inflation is invariant under composing with isomorphisms on either side: the
 witnessing conflation transports along the isomorphism. -/

--- a/TauCeti/CategoryTheory/Exact/ExtensionClosed.lean
+++ b/TauCeti/CategoryTheory/Exact/ExtensionClosed.lean
@@ -131,7 +131,7 @@ variable (E : ExactStructure C) (P : ObjectProperty C)
 
 /-- The conflations induced on a full subcategory: the short complexes of the subcategory whose
 image in the ambient category is a conflation. -/
-def conflationClassFullSubcategory : ConflationClass P.FullSubcategory where
+private def conflationClassFullSubcategory : ConflationClass P.FullSubcategory where
   Conflation S := E.Conflation (S.map P.ι)
   isKernelCokernelPair _ hS := (E.isKernelCokernelPair _ hS).of_map P.ι
   isClosedUnderIsomorphisms :=
@@ -140,13 +140,13 @@ def conflationClassFullSubcategory : ConflationClass P.FullSubcategory where
 variable {E P}
 
 @[simp]
-theorem conflationClassFullSubcategory_conflation (S : ShortComplex P.FullSubcategory) :
+private theorem conflationClassFullSubcategory_conflation (S : ShortComplex P.FullSubcategory) :
     (E.conflationClassFullSubcategory P).Conflation S ↔ E.Conflation (S.map P.ι) :=
   Iff.rfl
 
 /-- A short complex of the subcategory admitting a splitting is a conflation of the induced
 class, because a splitting is carried to a splitting by the additive inclusion functor. -/
-theorem conflation_fullSubcategory_of_splitting {S : ShortComplex P.FullSubcategory}
+private theorem conflation_fullSubcategory_of_splitting {S : ShortComplex P.FullSubcategory}
     (s : S.Splitting) : (E.conflationClassFullSubcategory P).Conflation S :=
   E.conflation_of_splitting (s.map P.ι)
 
@@ -155,7 +155,7 @@ section ZeroObject
 variable [P.ContainsZero]
 
 /-- E0 for the induced class: identity morphisms are inflations. -/
-theorem isInflation_id_fullSubcategory (X : P.FullSubcategory) :
+private theorem isInflation_id_fullSubcategory (X : P.FullSubcategory) :
     (E.conflationClassFullSubcategory P).IsInflation (𝟙 X) :=
   (ConflationClass.isInflation_iff _ _).mpr ⟨0, 0, by simp,
     conflation_fullSubcategory_of_splitting
@@ -163,7 +163,7 @@ theorem isInflation_id_fullSubcategory (X : P.FullSubcategory) :
         inferInstance (isZero_zero _))⟩
 
 /-- E0op for the induced class: identity morphisms are deflations. -/
-theorem isDeflation_id_fullSubcategory (X : P.FullSubcategory) :
+private theorem isDeflation_id_fullSubcategory (X : P.FullSubcategory) :
     (E.conflationClassFullSubcategory P).IsDeflation (𝟙 X) :=
   (ConflationClass.isDeflation_iff _ _).mpr ⟨0, 0, by simp,
     conflation_fullSubcategory_of_splitting
@@ -176,7 +176,7 @@ end ZeroObject
 /-- E1 for the induced class: a composite of inflations is an inflation. This is where extension
 closure is needed — the cokernel of the composite is an extension of the two cokernels, by the
 Noether conflation `TauCeti.ExactStructure.exists_conflation_comp`. -/
-theorem isInflation_comp_fullSubcategory (hP : E.IsExtensionClosed P)
+private theorem isInflation_comp_fullSubcategory (hP : E.IsExtensionClosed P)
     {X Y W : P.FullSubcategory} (i : X ⟶ Y) (j : Y ⟶ W)
     (hi : (E.conflationClassFullSubcategory P).IsInflation i)
     (hj : (E.conflationClassFullSubcategory P).IsInflation j) :
@@ -190,7 +190,7 @@ theorem isInflation_comp_fullSubcategory (hP : E.IsExtensionClosed P)
   simpa using hc
 
 /-- E1op for the induced class: a composite of deflations is a deflation. -/
-theorem isDeflation_comp_fullSubcategory (hP : E.IsExtensionClosed P)
+private theorem isDeflation_comp_fullSubcategory (hP : E.IsExtensionClosed P)
     {W Y Z : P.FullSubcategory} (q : W ⟶ Y) (p : Y ⟶ Z)
     (hq : (E.conflationClassFullSubcategory P).IsDeflation q)
     (hp : (E.conflationClassFullSubcategory P).IsDeflation p) :
@@ -209,7 +209,8 @@ the subcategory, and the cobase-changed morphism is again an inflation.
 The pushout is computed in the ambient category; extension closure is what places it back in the
 subcategory, since by `TauCeti.ExactStructure.conflation_cobaseChange` it is an extension of the
 cokernel of the inflation by the target of the arbitrary morphism. -/
-theorem exists_isPushout_fullSubcategory (hP : E.IsExtensionClosed P) {X Y T : P.FullSubcategory}
+private theorem exists_isPushout_fullSubcategory (hP : E.IsExtensionClosed P)
+    {X Y T : P.FullSubcategory}
     {i : X ⟶ Y} (hi : (E.conflationClassFullSubcategory P).IsInflation i) (f : X ⟶ T) :
     ∃ (Q : P.FullSubcategory) (v : Y ⟶ Q) (w : T ⟶ Q),
       IsPushout i f v w ∧ (E.conflationClassFullSubcategory P).IsInflation w := by
@@ -220,6 +221,7 @@ theorem exists_isPushout_fullSubcategory (hP : E.IsExtensionClosed P) {X Y T : P
   have sqC : IsPushout (P.ι.map i) (P.ι.map f) (pushout.inl (P.ι.map i) (P.ι.map f))
       (pushout.inr (P.ι.map i) (P.ι.map f)) := IsPushout.of_hasPushout _ _
   have hconf := E.conflation_cobaseChange hS' sqC
+  rw [cobaseChange_def ((ShortComplex.mk i p hip).map P.ι) sqC] at hconf
   refine ⟨⟨_, hP.prop_X₂ hconf T.property Z.property⟩,
     ObjectProperty.homMk (pushout.inl _ _), ObjectProperty.homMk (pushout.inr _ _),
     IsPushout.of_map_of_faithful P.ι sqC, (ConflationClass.isInflation_iff _ _).mpr
@@ -229,7 +231,8 @@ theorem exists_isPushout_fullSubcategory (hP : E.IsExtensionClosed P) {X Y T : P
 
 /-- E2op for the induced class: a pullback of a deflation along an arbitrary morphism exists
 inside the subcategory, and the base-changed morphism is again a deflation. -/
-theorem exists_isPullback_fullSubcategory (hP : E.IsExtensionClosed P) {Y Z T : P.FullSubcategory}
+private theorem exists_isPullback_fullSubcategory (hP : E.IsExtensionClosed P)
+    {Y Z T : P.FullSubcategory}
     {p : Y ⟶ Z} (hp : (E.conflationClassFullSubcategory P).IsDeflation p) (f : T ⟶ Z) :
     ∃ (Q : P.FullSubcategory) (v : Q ⟶ Y) (w : Q ⟶ T),
       IsPullback v w p f ∧ (E.conflationClassFullSubcategory P).IsDeflation w := by
@@ -241,6 +244,7 @@ theorem exists_isPullback_fullSubcategory (hP : E.IsExtensionClosed P) {Y Z T : 
       (pullback.snd (P.ι.map p) (P.ι.map f)) (P.ι.map p) (P.ι.map f) :=
     IsPullback.of_hasPullback _ _
   have hconf := E.conflation_baseChange hS' sqC
+  rw [baseChange_def ((ShortComplex.mk i p hip).map P.ι) sqC] at hconf
   refine ⟨⟨_, hP.prop_X₂ hconf X.property T.property⟩,
     ObjectProperty.homMk (pullback.fst _ _), ObjectProperty.homMk (pullback.snd _ _),
     IsPullback.of_map_of_faithful P.ι sqC, (ConflationClass.isDeflation_iff _ _).mpr
@@ -288,6 +292,7 @@ variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts] (hP : E.IsExtensionClo
 
 /-- A short complex of the subcategory is a conflation of the induced exact structure exactly
 when its image in the ambient category is a conflation. -/
+@[simp]
 theorem fullSubcategory_conflation_iff (S : ShortComplex P.FullSubcategory) :
     (E.fullSubcategory P hP).Conflation S ↔ E.Conflation (S.map P.ι) :=
   Iff.rfl

--- a/TauCeti/CategoryTheory/Exact/ExtensionClosed.lean
+++ b/TauCeti/CategoryTheory/Exact/ExtensionClosed.lean
@@ -62,9 +62,6 @@ universe v u
 
 variable {C : Type u} [Category.{v} C] [Preadditive C]
 
-/-- The inclusion of a full subcategory of a preadditive category is an additive functor. -/
-instance (P : ObjectProperty C) : P.ι.Additive where
-
 variable [HasZeroObject C] [HasBinaryBiproducts C]
 
 /-- A full subcategory of an additive category closed under binary products has binary

--- a/TauCeti/CategoryTheory/Exact/ExtensionClosed.lean
+++ b/TauCeti/CategoryTheory/Exact/ExtensionClosed.lean
@@ -1,0 +1,308 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.CategoryTheory.Exact.Abelian
+public import TauCeti.CategoryTheory.Exact.BaseChange
+public import TauCeti.CategoryTheory.Exact.Functor
+public import Mathlib.CategoryTheory.ObjectProperty.Extensions
+public import Mathlib.CategoryTheory.ObjectProperty.FiniteProducts
+
+/-!
+# The exact structure induced on an extension-closed full subcategory
+
+Let `E` be a Quillen exact structure on an additive category `C` and let `P : ObjectProperty C`
+be closed under extensions: whenever `X ⟶ Y ⟶ Z` is an `E`-conflation with `P X` and `P Z`,
+also `P Y`. If moreover `P` holds for a zero object and is closed under binary products — the
+explicit form of "the full subcategory is additive" — then `P.FullSubcategory` carries an exact
+structure whose conflations are the conflations of `E` all of whose terms lie in `P`, and the
+inclusion functor both preserves and reflects conflations.
+
+This is the third of the three fundamental constructions of exact structures, after the split
+structure on an additive category and the canonical structure on an abelian category. It is what
+lets a subcategory such as the finitely generated projective modules, or the modules admitting a
+finite projective resolution, be treated as an exact category in its own right.
+
+## Main definitions
+
+* `TauCeti.ExactStructure.IsExtensionClosed`: closure of an object property under extensions in
+  a given exact structure.
+* `TauCeti.ExactStructure.fullSubcategory`: the induced exact structure.
+
+## Main results
+
+* `TauCeti.ExactStructure.IsExtensionClosed.prop_biprod`: extension closure implies closure under
+  binary biproducts, so additivity of the subcategory only has to be assumed for the zero object.
+* `TauCeti.ExactStructure.isExtensionClosed_split_iff` and
+  `TauCeti.ExactStructure.isExtensionClosed_abelian_iff`: for the split exact structure extension
+  closure is closure under binary biproducts, and for the canonical exact structure of an abelian
+  category it agrees with Mathlib's
+  `CategoryTheory.ObjectProperty.IsClosedUnderExtensions`.
+* `TauCeti.ExactStructure.isConflationExact_ι` and
+  `TauCeti.ExactStructure.reflectsConflations_ι`: the inclusion of the subcategory is
+  conflation-exact and reflects conflations.
+
+## References
+
+* Theo Bühler, *Exact categories*, Expositiones Mathematicae **28** (2010), 1--69,
+  <https://arxiv.org/abs/0811.1480>. Lemma 10.20 is the statement proved here; the proof of E1
+  uses the Noether conflation of `TauCeti/CategoryTheory/Exact/BaseChange.lean`.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits CategoryTheory.ObjectProperty ZeroObject
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+/-- The inclusion of a full subcategory of a preadditive category is an additive functor. -/
+instance (P : ObjectProperty C) : P.ι.Additive where
+
+variable [HasZeroObject C] [HasBinaryBiproducts C]
+
+/-- A full subcategory of an additive category closed under binary products has binary
+biproducts: in a preadditive category binary products already are biproducts. -/
+instance (P : ObjectProperty C) [P.IsClosedUnderBinaryProducts] :
+    HasBinaryBiproducts P.FullSubcategory :=
+  HasBinaryBiproducts.of_hasBinaryProducts
+
+namespace ExactStructure
+
+/-- An object property is **extension closed** for an exact structure `E` when the middle term of
+every `E`-conflation whose outer terms satisfy the property satisfies the property.
+
+For the canonical exact structure of an abelian category this is Mathlib's
+`CategoryTheory.ObjectProperty.IsClosedUnderExtensions`; see
+`TauCeti.ExactStructure.isExtensionClosed_abelian_iff`. -/
+structure IsExtensionClosed (E : ExactStructure C) (P : ObjectProperty C) : Prop where
+  /-- The middle term of a conflation with outer terms in `P` lies in `P`. -/
+  prop_X₂ {S : ShortComplex C} (hS : E.Conflation S) (h₁ : P S.X₁) (h₃ : P S.X₃) : P S.X₂
+
+namespace IsExtensionClosed
+
+variable {E : ExactStructure C} {P : ObjectProperty C}
+
+/-- An extension-closed property is closed under binary biproducts, because the biproduct short
+complex is a conflation of every exact structure. -/
+theorem prop_biprod (hP : E.IsExtensionClosed P) {X Y : C} (hX : P X) (hY : P Y) : P (X ⊞ Y) :=
+  hP.prop_X₂ (E.conflation_biprodShortComplex X Y) hX hY
+
+/-- A replete extension-closed property is closed under binary products. Together with
+`CategoryTheory.ObjectProperty.ContainsZero` this is exactly the additivity of the full
+subcategory, so no separate closure hypothesis on biproducts is needed. -/
+theorem isClosedUnderBinaryProducts (hP : E.IsExtensionClosed P) [P.IsClosedUnderIsomorphisms] :
+    P.IsClosedUnderBinaryProducts := by
+  refine IsClosedUnderLimitsOfShape.mk' ?_
+  rintro _ ⟨F, hF⟩
+  refine P.prop_of_iso ?_ (hP.prop_biprod (hF ⟨WalkingPair.left⟩) (hF ⟨WalkingPair.right⟩))
+  exact (biprod.isoProd _ _).trans (HasLimit.isoOfNatIso (diagramIsoPair F)).symm
+
+end IsExtensionClosed
+
+/-- For the split exact structure, extension closure is exactly closure under binary biproducts.
+This is the hypothesis under which a subcategory such as the finitely generated projective
+modules inherits the split structure. -/
+theorem isExtensionClosed_split_iff (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] :
+    (ExactStructure.split C).IsExtensionClosed P ↔ ∀ X Y : C, P X → P Y → P (X ⊞ Y) := by
+  refine ⟨fun hP X Y hX hY => hP.prop_biprod hX hY, fun h => ⟨fun {S} hS h₁ h₃ => ?_⟩⟩
+  obtain ⟨s⟩ := (ExactStructure.split_conflation S).mp hS
+  exact P.prop_of_iso s.isoBinaryBiproduct.symm (h _ _ h₁ h₃)
+
+/-- For the canonical exact structure of an abelian category, extension closure agrees with
+Mathlib's `CategoryTheory.ObjectProperty.IsClosedUnderExtensions`. -/
+theorem isExtensionClosed_abelian_iff {A : Type u} [Category.{v} A] [Abelian A]
+    (P : ObjectProperty A) :
+    (ExactStructure.abelian A).IsExtensionClosed P ↔ P.IsClosedUnderExtensions := by
+  constructor
+  · exact fun hP => ⟨fun hS h₁ h₃ => hP.prop_X₂ ((abelian_conflation _).mpr hS) h₁ h₃⟩
+  · exact fun _ => ⟨fun hS h₁ h₃ =>
+      P.prop_X₂_of_shortExact ((abelian_conflation _).mp hS) h₁ h₃⟩
+
+section FullSubcategory
+
+variable (E : ExactStructure C) (P : ObjectProperty C)
+
+/-- The conflations induced on a full subcategory: the short complexes of the subcategory whose
+image in the ambient category is a conflation. -/
+def conflationClassFullSubcategory : ConflationClass P.FullSubcategory where
+  Conflation S := E.Conflation (S.map P.ι)
+  isKernelCokernelPair _ hS := (E.isKernelCokernelPair _ hS).of_map P.ι
+  isClosedUnderIsomorphisms :=
+    ⟨fun e hS => E.conflation_of_iso (P.ι.mapShortComplex.mapIso e) hS⟩
+
+variable {E P}
+
+@[simp]
+theorem conflationClassFullSubcategory_conflation (S : ShortComplex P.FullSubcategory) :
+    (E.conflationClassFullSubcategory P).Conflation S ↔ E.Conflation (S.map P.ι) :=
+  Iff.rfl
+
+/-- A short complex of the subcategory admitting a splitting is a conflation of the induced
+class, because a splitting is carried to a splitting by the additive inclusion functor. -/
+theorem conflation_fullSubcategory_of_splitting {S : ShortComplex P.FullSubcategory}
+    (s : S.Splitting) : (E.conflationClassFullSubcategory P).Conflation S :=
+  E.conflation_of_splitting (s.map P.ι)
+
+section ZeroObject
+
+variable [P.ContainsZero]
+
+/-- E0 for the induced class: identity morphisms are inflations. -/
+theorem isInflation_id_fullSubcategory (X : P.FullSubcategory) :
+    (E.conflationClassFullSubcategory P).IsInflation (𝟙 X) :=
+  (ConflationClass.isInflation_iff _ _).mpr ⟨0, 0, by simp,
+    conflation_fullSubcategory_of_splitting
+      (ShortComplex.Splitting.ofIsIsoOfIsZero (S := ShortComplex.mk (𝟙 X) (0 : X ⟶ 0) (by simp))
+        inferInstance (isZero_zero _))⟩
+
+/-- E0op for the induced class: identity morphisms are deflations. -/
+theorem isDeflation_id_fullSubcategory (X : P.FullSubcategory) :
+    (E.conflationClassFullSubcategory P).IsDeflation (𝟙 X) :=
+  (ConflationClass.isDeflation_iff _ _).mpr ⟨0, 0, by simp,
+    conflation_fullSubcategory_of_splitting
+      (ShortComplex.Splitting.ofIsZeroOfIsIso
+        (S := ShortComplex.mk (0 : (0 : P.FullSubcategory) ⟶ X) (𝟙 X) (by simp))
+        (isZero_zero _) inferInstance)⟩
+
+end ZeroObject
+
+/-- E1 for the induced class: a composite of inflations is an inflation. This is where extension
+closure is needed — the cokernel of the composite is an extension of the two cokernels, by the
+Noether conflation `TauCeti.ExactStructure.exists_conflation_comp`. -/
+theorem isInflation_comp_fullSubcategory (hP : E.IsExtensionClosed P)
+    {X Y W : P.FullSubcategory} (i : X ⟶ Y) (j : Y ⟶ W)
+    (hi : (E.conflationClassFullSubcategory P).IsInflation i)
+    (hj : (E.conflationClassFullSubcategory P).IsInflation j) :
+    (E.conflationClassFullSubcategory P).IsInflation (i ≫ j) := by
+  obtain ⟨Z, p, hip, hS₁⟩ := (ConflationClass.isInflation_iff _ _).mp hi
+  obtain ⟨V, v, hjv, hS₂⟩ := (ConflationClass.isInflation_iff _ _).mp hj
+  obtain ⟨Q, c, α, β, hc, hβ, hQ₁, hQ₂, -, -⟩ := E.exists_conflation_comp hS₁ hS₂
+  refine (ConflationClass.isInflation_iff _ _).mpr
+    ⟨⟨Q, hP.prop_X₂ hQ₂ Z.property V.property⟩, ObjectProperty.homMk c, ?_, hQ₁⟩
+  apply ObjectProperty.hom_ext
+  simpa using hc
+
+/-- E1op for the induced class: a composite of deflations is a deflation. -/
+theorem isDeflation_comp_fullSubcategory (hP : E.IsExtensionClosed P)
+    {W Y Z : P.FullSubcategory} (q : W ⟶ Y) (p : Y ⟶ Z)
+    (hq : (E.conflationClassFullSubcategory P).IsDeflation q)
+    (hp : (E.conflationClassFullSubcategory P).IsDeflation p) :
+    (E.conflationClassFullSubcategory P).IsDeflation (q ≫ p) := by
+  obtain ⟨V, v, hvq, hS₂⟩ := (ConflationClass.isDeflation_iff _ _).mp hq
+  obtain ⟨X, i, hip, hS₁⟩ := (ConflationClass.isDeflation_iff _ _).mp hp
+  obtain ⟨Q, c, α, β, hc, hβ, hQ₁, hQ₂, -, -⟩ := E.exists_conflation_comp' hS₁ hS₂
+  refine (ConflationClass.isDeflation_iff _ _).mpr
+    ⟨⟨Q, hP.prop_X₂ hQ₂ V.property X.property⟩, ObjectProperty.homMk c, ?_, hQ₁⟩
+  apply ObjectProperty.hom_ext
+  simpa using hc
+
+/-- E2 for the induced class: a pushout of an inflation along an arbitrary morphism exists inside
+the subcategory, and the cobase-changed morphism is again an inflation.
+
+The pushout is computed in the ambient category; extension closure is what places it back in the
+subcategory, since by `TauCeti.ExactStructure.conflation_cobaseChange` it is an extension of the
+cokernel of the inflation by the target of the arbitrary morphism. -/
+theorem exists_isPushout_fullSubcategory (hP : E.IsExtensionClosed P) {X Y T : P.FullSubcategory}
+    {i : X ⟶ Y} (hi : (E.conflationClassFullSubcategory P).IsInflation i) (f : X ⟶ T) :
+    ∃ (Q : P.FullSubcategory) (v : Y ⟶ Q) (w : T ⟶ Q),
+      IsPushout i f v w ∧ (E.conflationClassFullSubcategory P).IsInflation w := by
+  obtain ⟨Z, p, hip, hS⟩ := (ConflationClass.isInflation_iff _ _).mp hi
+  have hS' : E.Conflation ((ShortComplex.mk i p hip).map P.ι) := hS
+  have : HasPushout (P.ι.map i) (P.ι.map f) :=
+    E.hasPushouts_inflations.hasPushout (P.ι.map f) (E.isInflation_f hS')
+  have sqC : IsPushout (P.ι.map i) (P.ι.map f) (pushout.inl (P.ι.map i) (P.ι.map f))
+      (pushout.inr (P.ι.map i) (P.ι.map f)) := IsPushout.of_hasPushout _ _
+  have hconf := E.conflation_cobaseChange hS' sqC
+  refine ⟨⟨_, hP.prop_X₂ hconf T.property Z.property⟩,
+    ObjectProperty.homMk (pushout.inl _ _), ObjectProperty.homMk (pushout.inr _ _),
+    IsPushout.of_map_of_faithful P.ι sqC, (ConflationClass.isInflation_iff _ _).mpr
+      ⟨Z, ObjectProperty.homMk (cobaseChangeπ ((ShortComplex.mk i p hip).map P.ι) sqC),
+        ?_, hconf⟩⟩
+  exact ObjectProperty.hom_ext _ (inr_cobaseChangeπ ((ShortComplex.mk i p hip).map P.ι) sqC)
+
+/-- E2op for the induced class: a pullback of a deflation along an arbitrary morphism exists
+inside the subcategory, and the base-changed morphism is again a deflation. -/
+theorem exists_isPullback_fullSubcategory (hP : E.IsExtensionClosed P) {Y Z T : P.FullSubcategory}
+    {p : Y ⟶ Z} (hp : (E.conflationClassFullSubcategory P).IsDeflation p) (f : T ⟶ Z) :
+    ∃ (Q : P.FullSubcategory) (v : Q ⟶ Y) (w : Q ⟶ T),
+      IsPullback v w p f ∧ (E.conflationClassFullSubcategory P).IsDeflation w := by
+  obtain ⟨X, i, hip, hS⟩ := (ConflationClass.isDeflation_iff _ _).mp hp
+  have hS' : E.Conflation ((ShortComplex.mk i p hip).map P.ι) := hS
+  have : HasPullback (P.ι.map p) (P.ι.map f) :=
+    E.hasPullbacks_deflations.hasPullback (P.ι.map f) (E.isDeflation_g hS')
+  have sqC : IsPullback (pullback.fst (P.ι.map p) (P.ι.map f))
+      (pullback.snd (P.ι.map p) (P.ι.map f)) (P.ι.map p) (P.ι.map f) :=
+    IsPullback.of_hasPullback _ _
+  have hconf := E.conflation_baseChange hS' sqC
+  refine ⟨⟨_, hP.prop_X₂ hconf X.property T.property⟩,
+    ObjectProperty.homMk (pullback.fst _ _), ObjectProperty.homMk (pullback.snd _ _),
+    IsPullback.of_map_of_faithful P.ι sqC, (ConflationClass.isDeflation_iff _ _).mpr
+      ⟨X, ObjectProperty.homMk (baseChangeι ((ShortComplex.mk i p hip).map P.ι) sqC),
+        ?_, hconf⟩⟩
+  exact ObjectProperty.hom_ext _ (baseChangeι_snd ((ShortComplex.mk i p hip).map P.ι) sqC)
+
+variable (P) in
+/-- **The exact structure induced on an extension-closed full subcategory.** Its conflations are
+the conflations of `E` all of whose terms lie in `P`.
+
+The subcategory is required to be additive in the explicit form of containing a zero object and
+being closed under binary products; by
+`TauCeti.ExactStructure.IsExtensionClosed.isClosedUnderBinaryProducts` the second condition is
+automatic for a replete extension-closed `P`. -/
+noncomputable def fullSubcategory [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
+    (hP : E.IsExtensionClosed P) : ExactStructure P.FullSubcategory where
+  toConflationClass := E.conflationClassFullSubcategory P
+  isInflation_id := isInflation_id_fullSubcategory
+  isDeflation_id := isDeflation_id_fullSubcategory
+  isInflation_comp := isInflation_comp_fullSubcategory hP
+  isDeflation_comp := isDeflation_comp_fullSubcategory hP
+  hasPushouts_inflations := by
+    refine ⟨fun {_ _ _ _} g hf => ?_⟩
+    obtain ⟨_, _, _, sq, -⟩ := exists_isPushout_fullSubcategory hP hf g
+    exact sq.hasPushout
+  isStableUnderCobaseChange_inflations := by
+    refine ⟨fun {_ _ _ _ _ g _ _} sq hf => ?_⟩
+    obtain ⟨_, _, w, sq₀, hw⟩ := exists_isPushout_fullSubcategory hP hf g
+    rw [← sq₀.inr_isoIsPushout_hom _ _ sq.flip]
+    exact ((E.conflationClassFullSubcategory P).inflations.cancel_right_of_respectsIso w
+      (sq₀.isoIsPushout _ _ sq.flip).hom).mpr hw
+  hasPullbacks_deflations := by
+    refine ⟨fun {_ _ _ _} g hf => ?_⟩
+    obtain ⟨_, _, _, sq, -⟩ := exists_isPullback_fullSubcategory hP hf g
+    exact sq.hasPullback
+  isStableUnderBaseChange_deflations := by
+    refine ⟨fun {_ _ _ _ f _ _ _} sq hg => ?_⟩
+    obtain ⟨_, _, w, sq₀, hw⟩ := exists_isPullback_fullSubcategory hP hg f
+    rw [← sq₀.isoIsPullback_inv_snd _ _ sq]
+    exact ((E.conflationClassFullSubcategory P).deflations.cancel_left_of_respectsIso
+      (sq₀.isoIsPullback _ _ sq).inv w).mpr hw
+
+variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts] (hP : E.IsExtensionClosed P)
+
+/-- A short complex of the subcategory is a conflation of the induced exact structure exactly
+when its image in the ambient category is a conflation. -/
+theorem fullSubcategory_conflation_iff (S : ShortComplex P.FullSubcategory) :
+    (E.fullSubcategory P hP).Conflation S ↔ E.Conflation (S.map P.ι) :=
+  Iff.rfl
+
+/-- The inclusion of an extension-closed full subcategory is conflation-exact. -/
+theorem isConflationExact_ι : (E.fullSubcategory P hP).IsConflationExact E P.ι where
+  map_conflation hS := hS
+
+/-- The inclusion of an extension-closed full subcategory reflects conflations: a short complex
+of the subcategory whose image is a conflation of `E` is a conflation of the induced structure. -/
+theorem reflectsConflations_ι : (E.fullSubcategory P hP).ReflectsConflations E P.ι where
+  reflects_conflation hS := hS
+
+end FullSubcategory
+
+end ExactStructure
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
+++ b/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
@@ -41,7 +41,8 @@ category with homology the notion coincides with Mathlib's
   class of kernel–cokernel pairs is closed under isomorphism of short complexes, as an exact
   structure requires.
 * `TauCeti.IsKernelCokernelPair.map`: a functor preserving the two relevant (co)limits carries
-  kernel–cokernel pairs to kernel–cokernel pairs.
+  kernel–cokernel pairs to kernel–cokernel pairs, and
+  `TauCeti.IsKernelCokernelPair.of_map`: a fully faithful functor reflects them.
 * `TauCeti.IsKernelCokernelPair.op`, `TauCeti.isKernelCokernelPair_op_iff` and
   `TauCeti.isKernelCokernelPair_unop_iff`: the notion is self-dual, which is what makes the
   Bühler axioms transport to the opposite category.
@@ -181,6 +182,33 @@ theorem map {D : Type u'} [Category.{v'} D] [HasZeroMorphisms D] (h : IsKernelCo
     (F : C ⥤ D) [F.PreservesZeroMorphisms] [PreservesLimit (parallelPair S.g 0) F]
     [PreservesColimit (parallelPair S.f 0) F] : IsKernelCokernelPair (S.map F) :=
   ⟨⟨KernelFork.mapIsLimit _ h.fIsKernel F⟩, ⟨CokernelCofork.mapIsColimit _ h.gIsCokernel F⟩⟩
+
+/-- A fully faithful functor preserving zero morphisms *reflects* kernel–cokernel pairs. This
+is what makes a full subcategory inherit the kernel–cokernel pairs of its ambient category: the
+universal properties only have to be tested against objects of the subcategory. -/
+theorem of_map {D : Type u'} [Category.{v'} D] [HasZeroMorphisms D] (F : C ⥤ D)
+    [F.PreservesZeroMorphisms] [F.Full] [F.Faithful] (h : IsKernelCokernelPair (S.map F)) :
+    IsKernelCokernelPair S := by
+  have hmono : Mono S.f := F.mono_of_mono_map h.mono_f
+  have hepi : Epi S.g := F.epi_of_epi_map h.epi_g
+  have key₁ : ∀ (A : C) (k : A ⟶ S.X₂), k ≫ S.g = 0 → ∃ l : A ⟶ S.X₁, l ≫ S.f = k := by
+    intro A k hk
+    have h' := congrArg F.map hk
+    simp only [F.map_comp, F.map_zero] at h'
+    obtain ⟨l, hl⟩ : ∃ l : F.obj A ⟶ F.obj S.X₁, l ≫ F.map S.f = F.map k :=
+      ⟨h.lift (F.map k) h', h.lift_f _ _⟩
+    exact ⟨F.preimage l, F.map_injective (by rw [F.map_comp, F.map_preimage]; exact hl)⟩
+  have key₂ : ∀ (A : C) (k : S.X₂ ⟶ A), S.f ≫ k = 0 → ∃ l : S.X₃ ⟶ A, S.g ≫ l = k := by
+    intro A k hk
+    have h' := congrArg F.map hk
+    simp only [F.map_comp, F.map_zero] at h'
+    obtain ⟨l, hl⟩ : ∃ l : F.obj S.X₃ ⟶ F.obj A, F.map S.g ≫ l = F.map k :=
+      ⟨h.desc (F.map k) h', h.g_desc _ _⟩
+    exact ⟨F.preimage l, F.map_injective (by rw [F.map_comp, F.map_preimage]; exact hl)⟩
+  exact ⟨⟨KernelFork.IsLimit.ofι' _ _ fun {A} k hk =>
+      ⟨(key₁ A k hk).choose, (key₁ A k hk).choose_spec⟩⟩,
+    ⟨CokernelCofork.IsColimit.ofπ' _ _ fun {A} k hk =>
+      ⟨(key₂ A k hk).choose, (key₂ A k hk).choose_spec⟩⟩⟩
 
 /-- A short complex whose first morphism is an isomorphism and whose last object is zero is a
 kernel–cokernel pair: an isomorphism is an inflation. -/

--- a/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
+++ b/TauCeti/CategoryTheory/Exact/KernelCokernelPair.lean
@@ -188,27 +188,9 @@ is what makes a full subcategory inherit the kernel–cokernel pairs of its ambi
 universal properties only have to be tested against objects of the subcategory. -/
 theorem of_map {D : Type u'} [Category.{v'} D] [HasZeroMorphisms D] (F : C ⥤ D)
     [F.PreservesZeroMorphisms] [F.Full] [F.Faithful] (h : IsKernelCokernelPair (S.map F)) :
-    IsKernelCokernelPair S := by
-  have hmono : Mono S.f := F.mono_of_mono_map h.mono_f
-  have hepi : Epi S.g := F.epi_of_epi_map h.epi_g
-  have key₁ : ∀ (A : C) (k : A ⟶ S.X₂), k ≫ S.g = 0 → ∃ l : A ⟶ S.X₁, l ≫ S.f = k := by
-    intro A k hk
-    have h' := congrArg F.map hk
-    simp only [F.map_comp, F.map_zero] at h'
-    obtain ⟨l, hl⟩ : ∃ l : F.obj A ⟶ F.obj S.X₁, l ≫ F.map S.f = F.map k :=
-      ⟨h.lift (F.map k) h', h.lift_f _ _⟩
-    exact ⟨F.preimage l, F.map_injective (by rw [F.map_comp, F.map_preimage]; exact hl)⟩
-  have key₂ : ∀ (A : C) (k : S.X₂ ⟶ A), S.f ≫ k = 0 → ∃ l : S.X₃ ⟶ A, S.g ≫ l = k := by
-    intro A k hk
-    have h' := congrArg F.map hk
-    simp only [F.map_comp, F.map_zero] at h'
-    obtain ⟨l, hl⟩ : ∃ l : F.obj S.X₃ ⟶ F.obj A, F.map S.g ≫ l = F.map k :=
-      ⟨h.desc (F.map k) h', h.g_desc _ _⟩
-    exact ⟨F.preimage l, F.map_injective (by rw [F.map_comp, F.map_preimage]; exact hl)⟩
-  exact ⟨⟨KernelFork.IsLimit.ofι' _ _ fun {A} k hk =>
-      ⟨(key₁ A k hk).choose, (key₁ A k hk).choose_spec⟩⟩,
-    ⟨CokernelCofork.IsColimit.ofπ' _ _ fun {A} k hk =>
-      ⟨(key₂ A k hk).choose, (key₂ A k hk).choose_spec⟩⟩⟩
+    IsKernelCokernelPair S :=
+  ⟨⟨isLimitOfReflects F ((isLimitMapConeForkEquiv' F S.zero).symm h.fIsKernel)⟩,
+    ⟨isColimitOfReflects F ((isColimitMapCoconeCoforkEquiv' F S.zero).symm h.gIsCokernel)⟩⟩
 
 /-- A short complex whose first morphism is an isomorphism and whose last object is zero is a
 kernel–cokernel pair: an isomorphism is an inflation. -/


### PR DESCRIPTION
This PR builds the third of Layer 0's three fundamental constructions of Quillen exact structures: the structure induced on a replete full additive extension-closed subcategory. For an exact structure `E` on an additive category `C` and an object property `P` that is closed under `E`-extensions, `TauCeti.ExactStructure.fullSubcategory` equips `P.FullSubcategory` with the exact structure whose conflations are exactly the `E`-conflations with all three terms in `P`, and `TauCeti.ExactStructure.isConflationExact_ι` and `TauCeti.ExactStructure.reflectsConflations_ι` prove that the inclusion functor preserves and reflects conflations.

The roadmap target is `TauCetiRoadmap/GrothendieckEulerForms/README.md`, Layer 0, milestone "The three fundamental constructions", specifically its third item — "the induced structure on a replete full **additive** extension-closed subcategory ... Prove that the last inclusion is conflation-exact and reflects conflations" — which follows Bühler, Lemma 10.20. The split and canonical abelian structures, the opposite structure, the biproduct calculus and the conflation-exact functors are already on `main`, and the three other open Layer 0 PRs (#3646 bicartesian squares, #3658 equivalence transfer, #3702 the category of conflations) each name this bullet as the one still outstanding. After this PR, Layer 0 is complete apart from those three in-flight items, and Layer 3's resolving subcategories and Layer 4's module and projective subcategories have the exact structure they are stated over.

Additivity of the subcategory is required in the explicit form the roadmap asks for: `CategoryTheory.ObjectProperty.ContainsZero` and `CategoryTheory.ObjectProperty.IsClosedUnderBinaryProducts`, both Mathlib classes, with `TauCeti.ExactStructure.IsExtensionClosed.prop_biprod` and `IsExtensionClosed.isClosedUnderBinaryProducts` proving that the second is automatic for a replete extension-closed property. Two comparison theorems pin the new predicate to what already exists: `isExtensionClosed_split_iff` says that for the split exact structure extension closure is closure under binary biproducts, and `isExtensionClosed_abelian_iff` identifies it, for the canonical structure of an abelian category, with Mathlib's `CategoryTheory.ObjectProperty.IsClosedUnderExtensions`.

Axiom E1 for the subcategory is the substantial point, and it needs the cokernel of a composite of inflations to be an extension of the two cokernels. `TauCeti/CategoryTheory/Exact/BaseChange.lean` supplies that: `conflation_cobaseChange` proves that the cobase change of a conflation `X ⟶ Y ⟶ Z` along `u : X ⟶ X'` is a conflation `X' ⟶ Q ⟶ Z` with the same third term — E2 by itself gives only that `X' ⟶ Q` is an inflation — `conflation_comp_of_isPushout` computes the cokernel of a composite of inflations as a pushout, and `exists_conflation_comp` packages the two as the exact-category Noether isomorphism (Bühler, Lemma 3.5). Each has its dual, proved directly rather than through the opposite structure. This is disjoint from the bicartesian statement of #3646, which produces the biproduct conflation `W ⟶ X ⊞ Y ⟶ Q` and the `BicartesianSq`, and neither file uses the other.

Two existing files are touched. `ExactStructure.lean` gains `ConflationClass.conflation_of_isColimit_of_isInflation` and its dual, which weaken `conflation_of_isKernelCokernelPair_of_isInflation` to require only the cokernel half of the kernel–cokernel pair; the two existing theorems become one-line corollaries of them, and both new files use the weaker form. `KernelCokernelPair.lean` gains `IsKernelCokernelPair.of_map`, the reflection statement dual to the existing `map`: a fully faithful functor preserving zero morphisms reflects kernel–cokernel pairs, which is what lets the subcategory inherit them. No declaration is renamed, deprecated or removed.

Nothing is vendored from Mathlib. The construction consumes Mathlib's `ObjectProperty.FullSubcategory` with its `Preadditive` and `ContainsZero`-derived `HasZeroObject` instances, `ObjectProperty.IsClosedUnderLimitsOfShape`, `IsClosedUnderExtensions`, `HasBinaryBiproducts.of_hasBinaryProducts`, `IsPushout`/`IsPullback` with `of_map_of_faithful` and `isoIsPushout`, `ShortComplex.Splitting` and its `map`, and the `MorphismProperty` pushout and cobase-change classes.

New files: `TauCeti/CategoryTheory/Exact/BaseChange.lean` (268 lines) and `TauCeti/CategoryTheory/Exact/ExtensionClosed.lean` (308 lines).

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"induced-exact-structure-extension-closed-subcategory"}-->

🤖 Prepared with Claude Code
