### PR TITLE
feat: make collar coordinates a manifold

### DIFF
--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Chart.lean
@@ -42,13 +42,9 @@ shrinking it to a product neighbourhood `V × [0, 1)` is not proved here.
 
 This serves the collar-neighbourhood target in Layer 1 of the GeometricTopology roadmap
 (`TauCetiRoadmap/GeometricTopology/README.md`), after `Boundary.Collar.Basic`'s standard-model
-calculation. Two steps remain, neither proved here.
-
-* That the collar charts have `C^k` transitions, so `M` is also a manifold for the product model
-  `(𝓡 n).prod (𝓡∂ 1)` via `collarChartedSpace`. The two lemmas above bring this within reach —
-  they are about single charts against the half-space model, not about the transitions — but no
-  `HasGroupoid` or `IsManifold` instance for `collarChartedSpace` exists yet.
-* The global statement, that a whole neighbourhood of `I.boundary M` is diffeomorphic to
+calculation. `Boundary.Collar.Manifold` uses the two smoothness lemmas above to prove that these
+charts have `C^k` transitions. The remaining global statement is that a whole neighbourhood of
+`I.boundary M` is diffeomorphic to
   `I.boundary M × [0, 1)`. The two textbook routes differ in what they need. Lee Thm 9.25 goes
   through the Boundary Flowout Theorem, gluing an inward-pointing vector field and flowing it,
   which needs flows from boundary points; Mathlib's integral curves are still restricted to
@@ -216,8 +212,8 @@ the one-dimensional half-space.
 
 It is `ChartedSpace.comp` applied to `EuclideanHalfSpace.collarModelChartedSpace`, rather than an
 atlas written out by hand, so that `chartAt_comp`, the `extChartAt` composition lemmas and
-`HasGroupoid.comp` all apply to it — `HasGroupoid.comp` is the route to the `C^k` transitions that
-would make `M` a manifold for the product model, which is not proved yet.
+`HasGroupoid.comp` all apply to it. Its `C^k` manifold structure is proved in
+`Boundary.Collar.Manifold`.
 
 `n` and `M` are explicit so that `letI := collarChartedSpace n M` determines both; there is no
 expected type at a `letI` to solve them from.

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Manifold.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Manifold.lean
@@ -48,6 +48,42 @@ open scoped Manifold ContDiff
 
 namespace TauCeti
 
+/-- On the product model space, extending its self-chart by the model map reduces to the model map
+itself, in both the forward and inverse directions. -/
+private lemma collarModel_coordinateChange_eq_extChartAt {n : ℕ}
+    (f : ModelProd (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace 1) →
+      ModelProd (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace 1))
+    (x y : ModelProd (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace 1)) :
+    (((𝓡 n).prod (𝓡∂ 1)) ∘ f ∘ ((𝓡 n).prod (𝓡∂ 1)).symm) =
+      (extChartAt ((𝓡 n).prod (𝓡∂ 1)) y ∘ f ∘
+        (extChartAt ((𝓡 n).prod (𝓡∂ 1)) x).symm) := rfl
+
+private lemma modelProd_exists_fiber {E : Type*}
+    (p : E × EuclideanSpace ℝ (Fin 1)) :
+    (∃ y : ModelProd E (EuclideanHalfSpace 1), y.1 = p.1 ∧ y.2.1 = p.2) ↔
+      ∃ y : EuclideanHalfSpace 1, y.1 = p.2 := by
+  constructor
+  · rintro ⟨y, -, hy⟩
+    exact ⟨y.2, hy⟩
+  · rintro ⟨y, hy⟩
+    exact ⟨(p.1, y), rfl, hy⟩
+
+private lemma collarTransition_coordinateDomain_iff {n : ℕ} {M : Type*} [TopologicalSpace M]
+    (e e' : OpenPartialHomeomorph M (EuclideanHalfSpace (n + 1)))
+    (p : EuclideanSpace ℝ (Fin n) × EuclideanSpace ℝ (Fin 1)) :
+    ((EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
+              (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e.target ∧
+            (collarChart e).symm
+              (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e'.source) ∧
+          ∃ y : ModelProd (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace 1),
+            y.1 = p.1 ∧ y.2.1 = p.2) ↔
+        (∃ y : EuclideanHalfSpace 1, y.1 = p.2) ∧
+          EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
+            (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e.target ∧
+          e.symm (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
+            (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2)) ∈ e'.source := by
+  simp only [collarChart_symm_apply, modelProd_exists_fiber, and_comm]
+
 variable {n : ℕ} {k : WithTop ℕ∞} {M : Type*} [TopologicalSpace M]
   [ChartedSpace (EuclideanHalfSpace (n + 1)) M]
 
@@ -87,7 +123,7 @@ theorem isManifold_collarChartedSpace [IsManifold (𝓡∂ (n + 1)) k M] :
             (I := modelWithCornersEuclideanHalfSpace (n + 1)) (n := k) he))
   rw [contMDiffOn_iff] at hφ
   convert hφ.2 (0, 0) (0, 0) using 1
-  · rfl
+  · exact collarModel_coordinateChange_eq_extChartAt φ (0, 0) (0, 0)
   · ext p
     have hprod : Prod.map id (modelWithCornersEuclideanHalfSpace 1).symm p =
         (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) := rfl
@@ -97,27 +133,7 @@ theorem isManifold_collarChartedSpace [IsManifold (𝓡∂ (n + 1)) k M] :
           e.symm (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
               (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2)) ∈ e'.source := by
       rw [collarChart_symm_apply]
-    have hnormalized :
-        ((EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
-                (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e.target ∧
-              (collarChart e).symm
-                (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e'.source) ∧
-            ∃ y : ModelProd (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace 1),
-              y.1 = p.1 ∧ y.2.1 = p.2) ↔
-          (∃ y : EuclideanHalfSpace 1, y.1 = p.2) ∧
-            EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
-              (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e.target ∧
-            e.symm (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
-              (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2)) ∈ e'.source := by
-      constructor
-      · rintro ⟨⟨htarget, hsource⟩, ⟨y, -, hy⟩⟩
-        refine ⟨⟨y.2, hy⟩, htarget, ?_⟩
-        rw [collarChart_symm_apply] at hsource
-        exact hsource
-      · rintro ⟨⟨y, hy⟩, htarget, hsource⟩
-        refine ⟨⟨htarget, ?_⟩, ⟨(p.1, y), rfl, hy⟩⟩
-        rw [collarChart_symm_apply]
-        exact hsource
-    simpa [φ, chartAt_self_eq, Prod.ext_iff, hprod, hsource] using hnormalized
+    simpa [φ, chartAt_self_eq, Prod.ext_iff, hprod, hsource] using
+      collarTransition_coordinateDomain_iff e e' p
 
 end TauCeti

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Manifold.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Manifold.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.Boundary.Collar.Chart
+
+/-!
+# The manifold structure of collar coordinates
+
+The collar charts of `Boundary.Collar.Chart` express a manifold modeled on the Euclidean
+half-space in tangential and inward-normal coordinates. This file proves that those charts have
+`C^k` transition maps. Consequently, the charted space `TauCeti.collarChartedSpace n M` is a
+manifold modeled on `(𝓡 n).prod (𝓡∂ 1)` whenever the original half-space charted space is a
+`C^k` manifold.
+
+This is the local product-manifold step in Layer 1's collar-neighbourhood target of the
+GeometricTopology roadmap (`TauCetiRoadmap/GeometricTopology/README.md`). It is deliberately not
+the global collar theorem: a collar chart still has an arbitrary open target in the product model,
+not a target of the form `V × [0, ε)`. The global step must shrink and patch these local product
+coordinates along the entire boundary.
+
+For ambient atlas charts `e` and `e'`, their collar transition is the composite of the smooth
+inverse of `collarChart e` with the smooth map `collarChart e'`. The only bookkeeping left after
+this composition is translating manifold smoothness on the product model to the coordinate form
+used by `isManifold_of_contDiffOn`.
+
+## Main result
+
+* `TauCeti.isManifold_collarChartedSpace`: the collar charted space is a `C^k` manifold over the
+  product model.
+
+## References
+
+* M. Hirsch, *Differential Topology*, Springer GTM 33 (1976), Theorem 6.1.
+* J. Lee, *Introduction to Smooth Manifolds*, Springer GTM 218, 2nd ed. (2013), Theorem 9.25.
+-/
+
+public section
+
+noncomputable section
+
+open Function Set Topology
+
+open scoped Manifold ContDiff
+
+namespace TauCeti
+
+variable {n : ℕ} {k : WithTop ℕ∞} {M : Type*} [TopologicalSpace M]
+  [ChartedSpace (EuclideanHalfSpace (n + 1)) M]
+
+/-- The collar charts make a `C^k` manifold atlas for the product model
+`(𝓡 n).prod (𝓡∂ 1)`. This is the given half-space manifold structure expressed in tangential and
+inward-normal coordinates.
+
+The charted-space argument is explicit in the conclusion because `M` already has its original
+half-space charted-space instance. A consumer can install the result locally with
+`letI := collarChartedSpace n M` followed by `letI := isManifold_collarChartedSpace`. -/
+theorem isManifold_collarChartedSpace [IsManifold (𝓡∂ (n + 1)) k M] :
+    @IsManifold ℝ _ _ _ _ _ _ ((𝓡 n).prod (𝓡∂ 1)) k M _
+      (collarChartedSpace n M) := by
+  let collar : ChartedSpace
+      (ModelProd (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace 1)) M :=
+    collarChartedSpace n M
+  refine @isManifold_of_contDiffOn ℝ _ _ _ _ _ _
+    ((modelWithCornersSelf ℝ (EuclideanSpace ℝ (Fin n))).prod
+      (modelWithCornersEuclideanHalfSpace 1)) k M _ collar ?_
+  rintro _ _ he he'
+  rw [collarChartedSpace_atlas] at he he'
+  obtain ⟨e, he, rfl⟩ := he
+  obtain ⟨e', he', rfl⟩ := he'
+  let φ := (collarChart e).symm ≫ₕ collarChart e'
+  have hφ : ContMDiffOn
+      ((modelWithCornersSelf ℝ (EuclideanSpace ℝ (Fin n))).prod
+        (modelWithCornersEuclideanHalfSpace 1))
+      ((modelWithCornersSelf ℝ (EuclideanSpace ℝ (Fin n))).prod
+        (modelWithCornersEuclideanHalfSpace 1)) k φ φ.source := by
+    simpa only [φ, OpenPartialHomeomorph.coe_trans, OpenPartialHomeomorph.trans_source,
+      OpenPartialHomeomorph.symm_source, collarChart_source, Function.comp_apply] using
+      (contMDiffOn_collarChart
+        (IsManifold.subset_maximalAtlas
+          (I := modelWithCornersEuclideanHalfSpace (n + 1)) (n := k) he')).comp'
+        (contMDiffOn_collarChart_symm
+          (IsManifold.subset_maximalAtlas
+            (I := modelWithCornersEuclideanHalfSpace (n + 1)) (n := k) he))
+  rw [contMDiffOn_iff] at hφ
+  convert hφ.2 (0, 0) (0, 0) using 1
+  · rfl
+  · ext p
+    have hprod : Prod.map id (modelWithCornersEuclideanHalfSpace 1).symm p =
+        (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) := rfl
+    have hsource :
+        (collarChart e).symm
+              (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e'.source ↔
+          e.symm (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
+              (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2)) ∈ e'.source := by
+      rw [collarChart_symm_apply]
+    have hnormalized :
+        ((EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
+                (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e.target ∧
+              (collarChart e).symm
+                (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e'.source) ∧
+            ∃ y : ModelProd (EuclideanSpace ℝ (Fin n)) (EuclideanHalfSpace 1),
+              y.1 = p.1 ∧ y.2.1 = p.2) ↔
+          (∃ y : EuclideanHalfSpace 1, y.1 = p.2) ∧
+            EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
+              (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2) ∈ e.target ∧
+            e.symm (EuclideanHalfSpace.collarDiffeomorph (k := ⊤) n
+              (p.1, (modelWithCornersEuclideanHalfSpace 1).symm p.2)) ∈ e'.source := by
+      constructor
+      · rintro ⟨⟨htarget, hsource⟩, ⟨y, -, hy⟩⟩
+        refine ⟨⟨y.2, hy⟩, htarget, ?_⟩
+        rw [collarChart_symm_apply] at hsource
+        exact hsource
+      · rintro ⟨⟨y, hy⟩, htarget, hsource⟩
+        refine ⟨⟨htarget, ?_⟩, ⟨(p.1, y), rfl, hy⟩⟩
+        rw [collarChart_symm_apply]
+        exact hsource
+    simpa [φ, chartAt_self_eq, Prod.ext_iff, hprod, hsource] using hnormalized
+
+end TauCeti


### PR DESCRIPTION
This PR equips the collar-coordinate atlas of a Euclidean half-space manifold with a `C^k` manifold structure over `(𝓡 n).prod (𝓡∂ 1)`. Compose the already-proved smooth inverse of each collar chart with the next smooth collar chart, then identify the product-model coordinate domain required by `isManifold_of_contDiffOn`. Keep the alternate `ChartedSpace` explicit so it does not compete with the original half-space instance.

This advances the `GeometricTopology/README.md` Layer 1 milestone **Collar neighbourhoods**, specifically the local product-manifold transition step handed off by the existing collar-chart development. It is the most effective current critical-path step because the boundary manifold and smooth collar charts are already merged, and this closes their exact handoff before global patching. After this PR, the milestone still needs the global collar theorem producing a neighbourhood diffeomorphic to `∂M × [0, 1)` by shrinking and patching these local product coordinates.

Add the 123-line `TauCeti/Geometry/Manifold/Boundary/Collar/Manifold.lean` module and update the adjacent chart documentation to identify the remaining global step. The proof reuses Mathlib's `isManifold_of_contDiffOn`, `ContMDiffOn.comp'`, and product model/chart API together with Tau Ceti's existing smoothness theorems for `collarChart` and its inverse. No Mathlib infrastructure or external formalization is vendored; the module documentation records the Hirsch and Lee collar-theorem references used by the roadmap.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"collar-charted-space-is-manifold"}-->

🤖 Prepared with Codex
