### PR TITLE
feat: the long exact cohomology sequence of a short exact sequence of sheaves of modules

### DIFF
--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Exactness.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Exactness.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf.Abelian
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf.Colimits
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf.Limits
+public import Mathlib.Algebra.Homology.ShortComplex.ShortExact
+
+/-!
+# Forgetting the module structure of a sheaf of modules is exact
+
+Let `R` be a sheaf of rings on a site `(C, J)`. Mathlib's `SheafOfModules.toSheaf R` sends a
+sheaf of `R`-modules to its underlying abelian sheaf, and knows that this functor preserves and
+reflects finite limits. This file supplies the missing half: it preserves finite colimits as
+well, hence carries short exact sequences of sheaves of modules to short exact sequences of
+abelian sheaves.
+
+## Main declarations
+
+* `TauCeti.SheafOfModules.preservesFiniteColimits_toSheaf`: `SheafOfModules.toSheaf` preserves
+  finite colimits;
+* `TauCeti.SheafOfModules.shortExact_map_toSheaf`: a short exact sequence of sheaves of modules
+  stays short exact after forgetting the module structures.
+
+The proof is a transfer along the sheafification of presheaves of modules. That functor is a
+left adjoint whose counit is an isomorphism, and composing it with `SheafOfModules.toSheaf`
+gives `PresheafOfModules.toPresheaf ⋙ presheafToSheaf`, which preserves finite colimits because
+colimits of presheaves of modules are computed sectionwise and `presheafToSheaf` is a left
+adjoint.
+
+Exactness of `SheafOfModules.toSheaf` is what makes the cohomology of a sheaf of modules, which
+is defined through the underlying abelian sheaf, fit into a long exact sequence; see
+`TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean`. It is therefore Layer B
+infrastructure for `TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is vendored:
+the ingredients are Mathlib's `PresheafOfModules.sheafificationAdjunction`,
+`PresheafOfModules.sheafificationCompToSheaf` and `ShortComplex.ShortExact.map_of_exact`.
+-/
+
+public section
+
+open CategoryTheory Limits
+
+universe v v' u u'
+
+noncomputable section
+
+variable {C : Type u'} [Category.{v'} C] {J : GrothendieckTopology C} {R : Sheaf J RingCat.{u}}
+  [HasSheafify J AddCommGrpCat.{v}] [J.WEqualsLocallyBijective AddCommGrpCat.{v}]
+
+namespace TauCeti
+
+namespace SheafOfModules
+
+open _root_.SheafOfModules
+
+instance preservesFiniteColimits_toSheaf :
+    PreservesFiniteColimits (toSheaf.{v} R) := by
+  constructor
+  intro D _ _
+  have hLF : PreservesColimitsOfShape D
+      (PresheafOfModules.sheafification.{v} (𝟙 R.obj) ⋙ toSheaf.{v} R) :=
+    preservesColimitsOfShape_of_natIso
+      (PresheafOfModules.sheafificationCompToSheaf.{v} (𝟙 R.obj)).symm
+  constructor
+  intro K
+  -- The counit isomorphism exhibits every diagram of sheaves of modules as the sheafification
+  -- of a diagram of presheaves of modules, on which both `L` and `L ⋙ toSheaf R` preserve
+  -- colimits.
+  set L := PresheafOfModules.sheafification.{v} (𝟙 R.obj)
+  set G := forget.{v} R ⋙ PresheafOfModules.restrictScalars (𝟙 R.obj)
+  have e : (K ⋙ G) ⋙ L ≅ K :=
+    Functor.isoWhiskerLeft K
+        (asIso (PresheafOfModules.sheafificationAdjunction.{v} (𝟙 R.obj)).counit) ≪≫
+      K.rightUnitor
+  have h₁ := isColimitOfPreserves L (colimit.isColimit (K ⋙ G))
+  have h₂ := isColimitOfPreserves (L ⋙ toSheaf.{v} R) (colimit.isColimit (K ⋙ G))
+  have := preservesColimit_of_preserves_colimit_cocone (F := toSheaf.{v} R) h₁ h₂
+  exact preservesColimit_of_iso_diagram _ e
+
+/-- Forgetting the module structures of a short exact sequence of sheaves of modules leaves a
+short exact sequence of abelian sheaves. -/
+theorem shortExact_map_toSheaf {S : ShortComplex (_root_.SheafOfModules.{v} R)}
+    (hS : S.ShortExact) : (S.map (toSheaf.{v} R)).ShortExact :=
+  hS.map_of_exact _
+
+end SheafOfModules
+
+end TauCeti
+
+end

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -83,7 +83,6 @@ def cohomologyZeroEquiv (M : X.Modules) :
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
 
 /-- The degree-zero cohomology equivalence is natural in the coefficient sheaf. -/
-@[simp]
 lemma cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N) (x : Cohomology M 0) :
     cohomologyZeroEquiv N ((cohomologyFunctor X 0).map f x) =
       f.app ⊤ (cohomologyZeroEquiv M x) :=

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -77,6 +77,7 @@ instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
 Naturality in the coefficient sheaf follows from `CategoryTheory.Sheaf.H.equiv₀_naturality`
 and `CategoryTheory.Sheaf.H.equiv₀_symm_naturality`, applied to `isTerminalTop` and the
 underlying sheaf morphism. -/
+@[expose]
 def cohomologyZeroEquiv (M : X.Modules) :
     Cohomology M 0 ≃+ Γ(M, ⊤) :=
   CategoryTheory.Sheaf.H.equiv₀

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -77,11 +77,18 @@ instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
 Naturality in the coefficient sheaf follows from `CategoryTheory.Sheaf.H.equiv₀_naturality`
 and `CategoryTheory.Sheaf.H.equiv₀_symm_naturality`, applied to `isTerminalTop` and the
 underlying sheaf morphism. -/
-@[expose]
 def cohomologyZeroEquiv (M : X.Modules) :
     Cohomology M 0 ≃+ Γ(M, ⊤) :=
   CategoryTheory.Sheaf.H.equiv₀
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
+
+/-- The degree-zero cohomology equivalence is natural in the coefficient sheaf. -/
+@[simp]
+lemma cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N) (x : Cohomology M 0) :
+    cohomologyZeroEquiv N ((cohomologyFunctor X 0).map f x) =
+      f.app ⊤ (cohomologyZeroEquiv M x) :=
+  (CategoryTheory.Sheaf.H.equiv₀_naturality isTerminalTop
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x).symm
 
 section Opens
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
@@ -63,7 +63,6 @@ namespace Scheme.Modules
 variable {X : Scheme.{u}}
 
 /-- A morphism of sheaves of modules on a scheme, as a map on degree-`n` cohomology. -/
-@[expose]
 def cohomologyMap {M N : X.Modules} (f : M ⟶ N) (n : ℕ) :
     Cohomology M n →+ Cohomology N n :=
   CategoryTheory.Sheaf.H.map ((toSheaf X).map f) n
@@ -71,7 +70,9 @@ def cohomologyMap {M N : X.Modules} (f : M ⟶ N) (n : ℕ) :
 @[simp]
 lemma cohomologyFunctor_map {M N : X.Modules} (f : M ⟶ N) (n : ℕ) :
     (cohomologyFunctor X n).map f = AddCommGrpCat.ofHom (cohomologyMap f n) :=
-  rfl
+  by
+    rw [cohomologyMap.eq_def]
+    rfl
 
 /-- Under the identification of degree-zero cohomology with global sections, the map induced on
 cohomology by a morphism of sheaves of modules is the map induced on global sections. -/
@@ -98,7 +99,6 @@ include hS
 
 /-- The connecting map `Hⁿ⁰(X, M₃) →+ Hⁿ¹(X, M₁)` of the long exact cohomology sequence of a
 short exact sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` of sheaves of modules. -/
-@[expose]
 def cohomologyδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     Cohomology S.X₃ n₀ →+ Cohomology S.X₁ n₁ :=
   TauCeti.CategoryTheory.Sheaf.H.δ (shortExact_map_toSheaf hS) n₀ n₁ h

--- a/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.Cohomology.Basic
+public import TauCeti.AlgebraicGeometry.Modules.Sheaf
+public import TauCeti.CategoryTheory.Sites.SheafCohomology.LongExactSequence
+
+/-!
+# The long exact cohomology sequence of a short exact sequence of sheaves of modules
+
+`TauCeti/AlgebraicGeometry/Cohomology/Basic.lean` defines the cohomology `Hⁿ(X, M)` of a sheaf
+of modules on a scheme. This file adds the long exact sequence attached to a short exact
+sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` of `𝒪_X`-modules,
+
+`0 ⟶ H⁰(X, M₁) ⟶ H⁰(X, M₂) ⟶ H⁰(X, M₃) ⟶ H¹(X, M₁) ⟶ H¹(X, M₂) ⟶ ⋯`
+
+together with its consequences for global sections. Where
+`TauCeti/AlgebraicGeometry/Cohomology/MayerVietoris.lean` varies the open subset, this file
+varies the coefficients.
+
+## Main declarations
+
+* `Scheme.Modules.cohomologyMap`, a morphism of sheaves of modules as a map on cohomology;
+* `Scheme.Modules.cohomologyδ`, the connecting map `Hⁿ⁰(X, M₃) ⟶ Hⁿ¹(X, M₁)`, together with the
+  three exactness statements `Scheme.Modules.exact_cohomologyMap_cohomologyMap`,
+  `Scheme.Modules.exact_cohomologyMap_cohomologyδ` and
+  `Scheme.Modules.exact_cohomologyδ_cohomologyMap`;
+* `Scheme.Modules.injective_cohomologyMap`, the injectivity in degree zero at which the sequence
+  starts, and `Scheme.Modules.surjective_cohomologyMap`, the surjectivity it gives when the next
+  cohomology group of `M₁` vanishes;
+* `Scheme.Modules.subsingleton_cohomology_X₂`, `Scheme.Modules.subsingleton_cohomology_X₃` and
+  `Scheme.Modules.subsingleton_cohomology_X₁`, the vanishing consequences;
+* `Scheme.Modules.exact_sections` and `Scheme.Modules.injective_sections`: global sections are
+  left exact, and `Scheme.Modules.surjective_sections`: they are exact on the right as soon as
+  `H¹(X, M₁)` vanishes. This last statement is the form in which the sequence is normally used.
+
+Additivity of the Euler characteristic, and with it Riemann-Roch, rest on this sequence, so it
+is Layer B infrastructure for `TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is
+vendored: the sequence itself is
+`TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean`, exactness of forgetting
+the module structures is `TauCeti/AlgebraicGeometry/Modules/Sheaf.lean`, and the comparison of
+degree-zero cohomology with global sections is `Scheme.Modules.cohomologyZeroEquiv`.
+-/
+
+public section
+
+open CategoryTheory Limits TopologicalSpace AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+namespace Scheme.Modules
+
+variable {X : Scheme.{u}}
+
+/-- A morphism of sheaves of modules on a scheme, as a map on degree-`n` cohomology. -/
+@[expose]
+def cohomologyMap {M N : X.Modules} (f : M ⟶ N) (n : ℕ) :
+    Cohomology M n →+ Cohomology N n :=
+  CategoryTheory.Sheaf.H.map ((toSheaf X).map f) n
+
+@[simp]
+lemma cohomologyFunctor_map {M N : X.Modules} (f : M ⟶ N) (n : ℕ) :
+    (cohomologyFunctor X n).map f = AddCommGrpCat.ofHom (cohomologyMap f n) :=
+  rfl
+
+/-- Under the identification of degree-zero cohomology with global sections, the map induced on
+cohomology by a morphism of sheaves of modules is the map induced on global sections. -/
+lemma cohomologyZeroEquiv_cohomologyMap {M N : X.Modules} (f : M ⟶ N) (x : Cohomology M 0) :
+    cohomologyZeroEquiv N (cohomologyMap f 0 x) = f.app ⊤ (cohomologyZeroEquiv M x) :=
+  (CategoryTheory.Sheaf.H.equiv₀_naturality isTerminalTop ((toSheaf X).map f) x).symm
+
+private lemma sections_ladder {M N : X.Modules} (f : M ⟶ N) :
+    (f.app ⊤).hom.comp (cohomologyZeroEquiv M) =
+      (cohomologyZeroEquiv N : Cohomology N 0 →+ Γ(N, ⊤)).comp (cohomologyMap f 0) := by
+  ext x
+  exact (cohomologyZeroEquiv_cohomologyMap f x).symm
+
+variable {S : ShortComplex X.Modules} (hS : S.ShortExact)
+
+include hS
+
+/-- The connecting map `Hⁿ⁰(X, M₃) →+ Hⁿ¹(X, M₁)` of the long exact cohomology sequence of a
+short exact sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` of sheaves of modules. -/
+@[expose]
+def cohomologyδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    Cohomology S.X₃ n₀ →+ Cohomology S.X₁ n₁ :=
+  TauCeti.CategoryTheory.Sheaf.H.δ (shortExact_map_toSheaf hS) n₀ n₁ h
+
+/-- The long exact cohomology sequence is exact at `Hⁿ(X, M₂)`. -/
+theorem exact_cohomologyMap_cohomologyMap (n : ℕ) :
+    Function.Exact (cohomologyMap S.f n) (cohomologyMap S.g n) :=
+  TauCeti.CategoryTheory.Sheaf.H.exact_map_map (shortExact_map_toSheaf hS) n
+
+/-- The long exact cohomology sequence is exact at `Hⁿ⁰(X, M₃)`. -/
+theorem exact_cohomologyMap_cohomologyδ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    Function.Exact (cohomologyMap S.g n₀) (cohomologyδ hS n₀ n₁ h) :=
+  TauCeti.CategoryTheory.Sheaf.H.exact_map_δ (shortExact_map_toSheaf hS) n₀ n₁ h
+
+/-- The long exact cohomology sequence is exact at `Hⁿ¹(X, M₁)`. -/
+theorem exact_cohomologyδ_cohomologyMap (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    Function.Exact (cohomologyδ hS n₀ n₁ h) (cohomologyMap S.f n₁) :=
+  TauCeti.CategoryTheory.Sheaf.H.exact_δ_map (shortExact_map_toSheaf hS) n₀ n₁ h
+
+/-- The long exact cohomology sequence starts with an injection. -/
+theorem injective_cohomologyMap : Function.Injective (cohomologyMap S.f 0) := by
+  intro x y hxy
+  exact TauCeti.CategoryTheory.Sheaf.H.injective_map_f (shortExact_map_toSheaf hS) hxy
+
+/-- If `Hⁿ¹(X, M₁)` vanishes, then `Hⁿ⁰(X, M₂) →+ Hⁿ⁰(X, M₃)` is surjective. -/
+theorem surjective_cohomologyMap (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (h₁ : Subsingleton (Cohomology S.X₁ n₁)) :
+    Function.Surjective (cohomologyMap S.g n₀) :=
+  TauCeti.CategoryTheory.Sheaf.H.surjective_map_g (shortExact_map_toSheaf hS) n₀ n₁ h h₁
+
+/-- If `Hⁿ(X, M₁)` and `Hⁿ(X, M₃)` vanish, then so does `Hⁿ(X, M₂)`. -/
+theorem subsingleton_cohomology_X₂ (n : ℕ) (h₁ : Subsingleton (Cohomology S.X₁ n))
+    (h₃ : Subsingleton (Cohomology S.X₃ n)) : Subsingleton (Cohomology S.X₂ n) :=
+  TauCeti.CategoryTheory.Sheaf.H.subsingleton_X₂ (shortExact_map_toSheaf hS) n h₁ h₃
+
+/-- If `Hⁿ⁰(X, M₂)` and `Hⁿ¹(X, M₁)` vanish, then so does `Hⁿ⁰(X, M₃)`. -/
+theorem subsingleton_cohomology_X₃ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (h₂ : Subsingleton (Cohomology S.X₂ n₀)) (h₁ : Subsingleton (Cohomology S.X₁ n₁)) :
+    Subsingleton (Cohomology S.X₃ n₀) :=
+  TauCeti.CategoryTheory.Sheaf.H.subsingleton_X₃ (shortExact_map_toSheaf hS) n₀ n₁ h h₂ h₁
+
+/-- If `Hⁿ⁰(X, M₃)` and `Hⁿ¹(X, M₂)` vanish, then so does `Hⁿ¹(X, M₁)`. -/
+theorem subsingleton_cohomology_X₁ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (h₃ : Subsingleton (Cohomology S.X₃ n₀)) (h₂ : Subsingleton (Cohomology S.X₂ n₁)) :
+    Subsingleton (Cohomology S.X₁ n₁) :=
+  TauCeti.CategoryTheory.Sheaf.H.subsingleton_X₁ (shortExact_map_toSheaf hS) n₀ n₁ h h₃ h₂
+
+/-- Global sections are left exact: the sections of `M₁` are exactly the sections of `M₂` that
+die in `M₃`. -/
+theorem exact_sections : Function.Exact ⇑(S.f.app ⊤) ⇑(S.g.app ⊤) :=
+  Function.Exact.of_ladder_addEquiv_of_exact (cohomologyZeroEquiv S.X₁)
+    (cohomologyZeroEquiv S.X₂) (cohomologyZeroEquiv S.X₃) (sections_ladder S.f)
+    (sections_ladder S.g) (exact_cohomologyMap_cohomologyMap hS 0)
+
+/-- Global sections are left exact: a monomorphism of sheaves of modules is injective on global
+sections. -/
+theorem injective_sections : Function.Injective ⇑(S.f.app ⊤) := by
+  intro a b hab
+  apply (cohomologyZeroEquiv S.X₁).symm.injective
+  apply injective_cohomologyMap hS
+  apply (cohomologyZeroEquiv S.X₂).injective
+  rw [cohomologyZeroEquiv_cohomologyMap, cohomologyZeroEquiv_cohomologyMap,
+    AddEquiv.apply_symm_apply, AddEquiv.apply_symm_apply, hab]
+
+/-- If `H¹(X, M₁)` vanishes, then every global section of `M₃` lifts to a global section of `M₂`.
+This is the form in which the long exact sequence is normally used. -/
+theorem surjective_sections (h₁ : Subsingleton (Cohomology S.X₁ 1)) :
+    Function.Surjective ⇑(S.g.app ⊤) := by
+  intro y
+  obtain ⟨x, hx⟩ := surjective_cohomologyMap hS 0 1 rfl h₁ ((cohomologyZeroEquiv S.X₃).symm y)
+  refine ⟨cohomologyZeroEquiv S.X₂ x, ?_⟩
+  rw [← cohomologyZeroEquiv_cohomologyMap, hx, AddEquiv.apply_symm_apply]
+
+end Scheme.Modules
+
+end
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
@@ -29,13 +29,13 @@ varies the coefficients.
   three exactness statements `Scheme.Modules.exact_cohomologyMap_cohomologyMap`,
   `Scheme.Modules.exact_cohomologyMap_cohomologyδ` and
   `Scheme.Modules.exact_cohomologyδ_cohomologyMap`;
-* `Scheme.Modules.injective_cohomologyMap`, the injectivity in degree zero at which the sequence
-  starts, and `Scheme.Modules.surjective_cohomologyMap`, the surjectivity it gives when the next
+* `Scheme.Modules.cohomologyMap_injective`, the injectivity in degree zero at which the sequence
+  starts, and `Scheme.Modules.cohomologyMap_surjective`, the surjectivity it gives when the next
   cohomology group of `M₁` vanishes;
 * `Scheme.Modules.subsingleton_cohomology_X₂`, `Scheme.Modules.subsingleton_cohomology_X₃` and
   `Scheme.Modules.subsingleton_cohomology_X₁`, the vanishing consequences;
-* `Scheme.Modules.exact_sections` and `Scheme.Modules.injective_sections`: global sections are
-  left exact, and `Scheme.Modules.surjective_sections`: they are exact on the right as soon as
+* `Scheme.Modules.exact_sections` and `Scheme.Modules.sections_injective`: global sections are
+  left exact, and `Scheme.Modules.sections_surjective`: they are exact on the right as soon as
   `H¹(X, M₁)` vanishes. This last statement is the form in which the sequence is normally used.
 
 Additivity of the Euler characteristic, and with it Riemann-Roch, rest on this sequence, so it
@@ -75,9 +75,16 @@ lemma cohomologyFunctor_map {M N : X.Modules} (f : M ⟶ N) (n : ℕ) :
 
 /-- Under the identification of degree-zero cohomology with global sections, the map induced on
 cohomology by a morphism of sheaves of modules is the map induced on global sections. -/
+@[simp]
 lemma cohomologyZeroEquiv_cohomologyMap {M N : X.Modules} (f : M ⟶ N) (x : Cohomology M 0) :
     cohomologyZeroEquiv N (cohomologyMap f 0 x) = f.app ⊤ (cohomologyZeroEquiv M x) :=
-  (CategoryTheory.Sheaf.H.equiv₀_naturality isTerminalTop ((toSheaf X).map f) x).symm
+  by
+    have hx : (cohomologyFunctor X 0).map f x = cohomologyMap f 0 x := by
+      exact congrArg
+        (fun g : (cohomologyFunctor X 0).obj M ⟶ (cohomologyFunctor X 0).obj N ↦ g x)
+        (cohomologyFunctor_map f 0)
+    rw [← hx]
+    exact cohomologyZeroEquiv_naturality f x
 
 private lemma sections_ladder {M N : X.Modules} (f : M ⟶ N) :
     (f.app ⊤).hom.comp (cohomologyZeroEquiv M) =
@@ -111,16 +118,17 @@ theorem exact_cohomologyδ_cohomologyMap (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     Function.Exact (cohomologyδ hS n₀ n₁ h) (cohomologyMap S.f n₁) :=
   TauCeti.CategoryTheory.Sheaf.H.exact_δ_map (shortExact_map_toSheaf hS) n₀ n₁ h
 
-/-- The long exact cohomology sequence starts with an injection. -/
-theorem injective_cohomologyMap : Function.Injective (cohomologyMap S.f 0) := by
-  intro x y hxy
-  exact TauCeti.CategoryTheory.Sheaf.H.injective_map_f (shortExact_map_toSheaf hS) hxy
+omit hS in
+/-- A monomorphism of sheaves of modules is injective on cohomology in degree zero. -/
+theorem cohomologyMap_injective {M N : X.Modules} (f : M ⟶ N) [Mono f] :
+    Function.Injective (cohomologyMap f 0) :=
+  TauCeti.CategoryTheory.Sheaf.H.map_injective ((toSheaf X).map f)
 
 /-- If `Hⁿ¹(X, M₁)` vanishes, then `Hⁿ⁰(X, M₂) →+ Hⁿ⁰(X, M₃)` is surjective. -/
-theorem surjective_cohomologyMap (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+theorem cohomologyMap_surjective (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     (h₁ : Subsingleton (Cohomology S.X₁ n₁)) :
     Function.Surjective (cohomologyMap S.g n₀) :=
-  TauCeti.CategoryTheory.Sheaf.H.surjective_map_g (shortExact_map_toSheaf hS) n₀ n₁ h h₁
+  TauCeti.CategoryTheory.Sheaf.H.map_g_surjective (shortExact_map_toSheaf hS) n₀ n₁ h h₁
 
 /-- If `Hⁿ(X, M₁)` and `Hⁿ(X, M₃)` vanish, then so does `Hⁿ(X, M₂)`. -/
 theorem subsingleton_cohomology_X₂ (n : ℕ) (h₁ : Subsingleton (Cohomology S.X₁ n))
@@ -146,22 +154,25 @@ theorem exact_sections : Function.Exact ⇑(S.f.app ⊤) ⇑(S.g.app ⊤) :=
     (cohomologyZeroEquiv S.X₂) (cohomologyZeroEquiv S.X₃) (sections_ladder S.f)
     (sections_ladder S.g) (exact_cohomologyMap_cohomologyMap hS 0)
 
+omit hS in
 /-- Global sections are left exact: a monomorphism of sheaves of modules is injective on global
 sections. -/
-theorem injective_sections : Function.Injective ⇑(S.f.app ⊤) := by
+theorem sections_injective {M N : X.Modules} (f : M ⟶ N) [Mono f] :
+    Function.Injective ⇑(f.app ⊤) := by
   intro a b hab
-  apply (cohomologyZeroEquiv S.X₁).symm.injective
-  apply injective_cohomologyMap hS
-  apply (cohomologyZeroEquiv S.X₂).injective
+  apply (cohomologyZeroEquiv M).symm.injective
+  apply cohomologyMap_injective f
+  apply (cohomologyZeroEquiv N).injective
   rw [cohomologyZeroEquiv_cohomologyMap, cohomologyZeroEquiv_cohomologyMap,
     AddEquiv.apply_symm_apply, AddEquiv.apply_symm_apply, hab]
 
 /-- If `H¹(X, M₁)` vanishes, then every global section of `M₃` lifts to a global section of `M₂`.
 This is the form in which the long exact sequence is normally used. -/
-theorem surjective_sections (h₁ : Subsingleton (Cohomology S.X₁ 1)) :
+theorem sections_surjective (h₁ : Subsingleton (Cohomology S.X₁ 1)) :
     Function.Surjective ⇑(S.g.app ⊤) := by
   intro y
-  obtain ⟨x, hx⟩ := surjective_cohomologyMap hS 0 1 rfl h₁ ((cohomologyZeroEquiv S.X₃).symm y)
+  obtain ⟨x, hx⟩ := cohomologyMap_surjective hS 0 1 rfl h₁
+    ((cohomologyZeroEquiv S.X₃).symm y)
   refine ⟨cohomologyZeroEquiv S.X₂ x, ?_⟩
   rw [← cohomologyZeroEquiv_cohomologyMap, hx, AddEquiv.apply_symm_apply]
 

--- a/TauCeti/AlgebraicGeometry/Modules/Sheaf.lean
+++ b/TauCeti/AlgebraicGeometry/Modules/Sheaf.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Exactness
 public import Mathlib.AlgebraicGeometry.Modules.Sheaf
-public import Mathlib.Topology.Sheaves.Abelian
 
 /-!
 # The underlying abelian sheaf of a sheaf of modules on a scheme

--- a/TauCeti/AlgebraicGeometry/Modules/Sheaf.lean
+++ b/TauCeti/AlgebraicGeometry/Modules/Sheaf.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Exactness
+public import Mathlib.AlgebraicGeometry.Modules.Sheaf
+public import Mathlib.Topology.Sheaves.Abelian
+
+/-!
+# The underlying abelian sheaf of a sheaf of modules on a scheme
+
+Mathlib packages the forgetful functors out of the category `X.Modules` of `𝒪_X`-modules on a
+scheme that land in presheaves: `AlgebraicGeometry.Scheme.Modules.toPresheafOfModules` and
+`AlgebraicGeometry.Scheme.Modules.toPresheaf`. This file adds the one that lands in abelian
+sheaves, and records that it is exact.
+
+## Main declarations
+
+* `TauCeti.AlgebraicGeometry.Scheme.Modules.toSheaf`, the functor sending an `𝒪_X`-module to its
+  underlying sheaf of abelian groups, with instances saying that it is additive and preserves
+  finite limits and finite colimits;
+* `TauCeti.AlgebraicGeometry.Scheme.Modules.shortExact_map_toSheaf`: a short exact sequence of
+  `𝒪_X`-modules stays short exact after forgetting the module structures.
+
+`TauCeti/AlgebraicGeometry/Cohomology/Basic.lean` defines the cohomology of an `𝒪_X`-module as
+the sheaf cohomology of its underlying abelian sheaf, so this exactness is what puts that
+cohomology into a long exact sequence; it is Layer B infrastructure for
+`TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is vendored: the functor is
+Mathlib's `SheafOfModules.toSheaf` for the sheaf of rings `X.ringCatSheaf`, and its exactness is
+`TauCeti/Algebra/Category/ModuleCat/Sheaf/Exactness.lean`.
+-/
+
+public section
+
+open CategoryTheory Limits AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+namespace Scheme.Modules
+
+variable (X : Scheme.{u})
+
+/-- The forgetful functor from `𝒪_X`-modules to sheaves of abelian groups on `X`.
+
+This is `SheafOfModules.toSheaf` for the sheaf of rings `X.ringCatSheaf`, packaged so that the
+source is the category `X.Modules`; compare `AlgebraicGeometry.Scheme.Modules.toPresheaf`. -/
+@[expose]
+def toSheaf : X.Modules ⥤ Sheaf (Opens.grothendieckTopology X) AddCommGrpCat.{u} :=
+  _root_.SheafOfModules.toSheaf X.ringCatSheaf
+
+instance : (toSheaf X).Additive :=
+  inferInstanceAs (_root_.SheafOfModules.toSheaf X.ringCatSheaf).Additive
+
+instance : PreservesFiniteLimits (toSheaf X) :=
+  inferInstanceAs (PreservesFiniteLimits (_root_.SheafOfModules.toSheaf X.ringCatSheaf))
+
+instance : PreservesFiniteColimits (toSheaf X) :=
+  inferInstanceAs (PreservesFiniteColimits (_root_.SheafOfModules.toSheaf X.ringCatSheaf))
+
+variable {X}
+
+/-- Forgetting the module structures of a short exact sequence of `𝒪_X`-modules leaves a short
+exact sequence of sheaves of abelian groups. -/
+theorem shortExact_map_toSheaf {S : ShortComplex X.Modules} (hS : S.ShortExact) :
+    (S.map (toSheaf X)).ShortExact :=
+  hS.map_of_exact _
+
+end Scheme.Modules
+
+end
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean
@@ -27,9 +27,9 @@ each of the three consecutive pairs.
 * `TauCeti.CategoryTheory.Sheaf.H.δ`, the connecting map `Hⁿ⁰(F₃) →+ Hⁿ¹(F₁)`;
 * `TauCeti.CategoryTheory.Sheaf.H.exact_map_map`, `H.exact_map_δ` and `H.exact_δ_map`, the
   exactness of the sequence at `Hⁿ(F₂)`, at `Hⁿ⁰(F₃)` and at `Hⁿ¹(F₁)`;
-* `TauCeti.CategoryTheory.Sheaf.H.injective_map_f`, the injectivity of `H⁰(F₁) →+ H⁰(F₂)`, which
+* `TauCeti.CategoryTheory.Sheaf.H.map_injective`, the injectivity of `H⁰(F₁) →+ H⁰(F₂)`, which
   is where the sequence starts;
-* `TauCeti.CategoryTheory.Sheaf.H.surjective_map_g`, `H.subsingleton_X₂`, `H.subsingleton_X₃`
+* `TauCeti.CategoryTheory.Sheaf.H.map_g_surjective`, `H.subsingleton_X₂`, `H.subsingleton_X₃`
   and `H.subsingleton_X₁`, the vanishing consequences that the sequence is normally used for.
 
 The six-term form of the sequence as a `ComposableArrows` is already available: it is Mathlib's
@@ -93,17 +93,17 @@ theorem exact_δ_map (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
   have := Ext.covariant_sequence_exact₁' (constZ (J := J)) hS n₀ n₁ h
   rwa [ShortComplex.ab_exact_iff_function_exact] at this
 
-/-- The long exact cohomology sequence starts with an injection: a monomorphism of abelian
-sheaves is injective on global cohomology in degree zero. -/
-theorem injective_map_f : Function.Injective (_root_.CategoryTheory.Sheaf.H.map S.f 0) := by
-  have := hS.mono_f
+omit hS in
+/-- A monomorphism of abelian sheaves is injective on cohomology in degree zero. -/
+theorem map_injective {F G : Sheaf J AddCommGrpCat.{v}} (f : F ⟶ G) [Mono f] :
+    Function.Injective (_root_.CategoryTheory.Sheaf.H.map f 0) := by
   intro x y hxy
   apply (Ext.addEquiv₀ (C := Sheaf J AddCommGrpCat.{v})).injective
-  rw [← cancel_mono S.f, ← _root_.CategoryTheory.Sheaf.H.addEquiv₀_map,
+  rw [← cancel_mono f, ← _root_.CategoryTheory.Sheaf.H.addEquiv₀_map,
     ← _root_.CategoryTheory.Sheaf.H.addEquiv₀_map, hxy]
 
 /-- If `Hⁿ¹(F₁)` vanishes, then `Hⁿ⁰(F₂) →+ Hⁿ⁰(F₃)` is surjective. -/
-theorem surjective_map_g (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+theorem map_g_surjective (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     (h₁ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₁ n₁)) :
     Function.Surjective (_root_.CategoryTheory.Sheaf.H.map S.g n₀) := fun x ↦
   (exact_map_δ hS n₀ n₁ h x).1 (Subsingleton.elim _ _)
@@ -122,7 +122,7 @@ theorem subsingleton_X₃ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     (h₂ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₂ n₀))
     (h₁ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₁ n₁)) :
     Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₃ n₀) :=
-  (surjective_map_g hS n₀ n₁ h h₁).subsingleton
+  (map_g_surjective hS n₀ n₁ h h₁).subsingleton
 
 /-- If `Hⁿ⁰(F₃)` and `Hⁿ¹(F₂)` vanish, then so does `Hⁿ¹(F₁)`. -/
 theorem subsingleton_X₁ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Homology.DerivedCategory.Ext.ExactSequences
+public import Mathlib.CategoryTheory.Sites.SheafCohomology.Basic
+
+/-!
+# The long exact cohomology sequence of a short exact sequence of abelian sheaves
+
+Mathlib defines the cohomology `CategoryTheory.Sheaf.H F n` of an abelian sheaf `F` on a site
+`(C, J)` as the `Ext`-group in degree `n` from the constant sheaf `ℤ` to `F`. A short exact
+sequence `0 ⟶ F₁ ⟶ F₂ ⟶ F₃ ⟶ 0` of abelian sheaves therefore has a long exact cohomology
+sequence
+
+`⋯ ⟶ Hⁿ⁰(F₁) ⟶ Hⁿ⁰(F₂) ⟶ Hⁿ⁰(F₃) ⟶ Hⁿ¹(F₁) ⟶ Hⁿ¹(F₂) ⟶ Hⁿ¹(F₃) ⟶ ⋯`
+
+whose connecting map is composition with the extension class of the sequence. This file records
+it, in the form in which it is used: a connecting homomorphism together with the exactness of
+each of the three consecutive pairs.
+
+## Main declarations
+
+* `TauCeti.CategoryTheory.Sheaf.H.δ`, the connecting map `Hⁿ⁰(F₃) →+ Hⁿ¹(F₁)`;
+* `TauCeti.CategoryTheory.Sheaf.H.exact_map_map`, `H.exact_map_δ` and `H.exact_δ_map`, the
+  exactness of the sequence at `Hⁿ(F₂)`, at `Hⁿ⁰(F₃)` and at `Hⁿ¹(F₁)`;
+* `TauCeti.CategoryTheory.Sheaf.H.injective_map_f`, the injectivity of `H⁰(F₁) →+ H⁰(F₂)`, which
+  is where the sequence starts;
+* `TauCeti.CategoryTheory.Sheaf.H.surjective_map_g`, `H.subsingleton_X₂`, `H.subsingleton_X₃`
+  and `H.subsingleton_X₁`, the vanishing consequences that the sequence is normally used for.
+
+The six-term form of the sequence as a `ComposableArrows` is already available: it is Mathlib's
+`CategoryTheory.Abelian.Ext.covariantSequence` for the constant sheaf `ℤ`, whose arrows are
+definitionally the maps used here.
+
+Sheaf cohomology on the small Zariski site of a scheme is the cohomology of a sheaf of modules,
+so this is Layer B infrastructure for `TauCetiRoadmap/JacobianChallenge/README.md`; see
+`TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean`. No formalization is vendored: the
+underlying long exact sequence is Mathlib's `CategoryTheory.Abelian.Ext.covariant_sequence_exact₁'`,
+`covariant_sequence_exact₂'` and `covariant_sequence_exact₃'`.
+-/
+
+public section
+
+open CategoryTheory Limits Abelian
+
+universe w v u
+
+namespace TauCeti
+
+namespace CategoryTheory
+
+namespace Sheaf
+
+variable {C : Type u} [Category.{v} C] {J : GrothendieckTopology C}
+  [HasSheafify J AddCommGrpCat.{v}] [HasExt.{w} (Sheaf J AddCommGrpCat.{v})]
+  {S : ShortComplex (Sheaf J AddCommGrpCat.{v})} (hS : S.ShortExact)
+
+/-- The constant sheaf `ℤ`, the object the cohomology of the site is corepresented by. -/
+private noncomputable abbrev constZ : Sheaf J AddCommGrpCat.{v} :=
+  (constantSheaf J AddCommGrpCat.{v}).obj (AddCommGrpCat.of (ULift.{v} ℤ))
+
+namespace H
+
+/-- The connecting map `Hⁿ⁰(F₃) →+ Hⁿ¹(F₁)` of the long exact cohomology sequence of a short
+exact sequence `0 ⟶ F₁ ⟶ F₂ ⟶ F₃ ⟶ 0` of abelian sheaves: composition with the extension class
+of the sequence. -/
+noncomputable def δ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    _root_.CategoryTheory.Sheaf.H S.X₃ n₀ →+ _root_.CategoryTheory.Sheaf.H S.X₁ n₁ :=
+  hS.extClass.postcomp _ h
+
+include hS
+
+/-- The long exact cohomology sequence is exact at `Hⁿ(F₂)`. -/
+theorem exact_map_map (n : ℕ) :
+    Function.Exact (_root_.CategoryTheory.Sheaf.H.map S.f n)
+      (_root_.CategoryTheory.Sheaf.H.map S.g n) := by
+  have := Ext.covariant_sequence_exact₂' (constZ (J := J)) hS n
+  rwa [ShortComplex.ab_exact_iff_function_exact] at this
+
+/-- The long exact cohomology sequence is exact at `Hⁿ⁰(F₃)`. -/
+theorem exact_map_δ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    Function.Exact (_root_.CategoryTheory.Sheaf.H.map S.g n₀) (δ hS n₀ n₁ h) := by
+  have := Ext.covariant_sequence_exact₃' (constZ (J := J)) hS n₀ n₁ h
+  rwa [ShortComplex.ab_exact_iff_function_exact] at this
+
+/-- The long exact cohomology sequence is exact at `Hⁿ¹(F₁)`. -/
+theorem exact_δ_map (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    Function.Exact (δ hS n₀ n₁ h) (_root_.CategoryTheory.Sheaf.H.map S.f n₁) := by
+  have := Ext.covariant_sequence_exact₁' (constZ (J := J)) hS n₀ n₁ h
+  rwa [ShortComplex.ab_exact_iff_function_exact] at this
+
+/-- The long exact cohomology sequence starts with an injection: a monomorphism of abelian
+sheaves is injective on global cohomology in degree zero. -/
+theorem injective_map_f : Function.Injective (_root_.CategoryTheory.Sheaf.H.map S.f 0) := by
+  have := hS.mono_f
+  intro x y hxy
+  apply (Ext.addEquiv₀ (C := Sheaf J AddCommGrpCat.{v})).injective
+  rw [← cancel_mono S.f, ← _root_.CategoryTheory.Sheaf.H.addEquiv₀_map,
+    ← _root_.CategoryTheory.Sheaf.H.addEquiv₀_map, hxy]
+
+/-- If `Hⁿ¹(F₁)` vanishes, then `Hⁿ⁰(F₂) →+ Hⁿ⁰(F₃)` is surjective. -/
+theorem surjective_map_g (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (h₁ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₁ n₁)) :
+    Function.Surjective (_root_.CategoryTheory.Sheaf.H.map S.g n₀) := fun x ↦
+  (exact_map_δ hS n₀ n₁ h x).1 (Subsingleton.elim _ _)
+
+/-- If `Hⁿ(F₁)` and `Hⁿ(F₃)` vanish, then so does `Hⁿ(F₂)`. -/
+theorem subsingleton_X₂ (n : ℕ) (h₁ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₁ n))
+    (h₃ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₃ n)) :
+    Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₂ n) := by
+  refine ⟨fun x y ↦ ?_⟩
+  obtain ⟨x₁, hx₁⟩ := (exact_map_map hS n x).1 (Subsingleton.elim _ _)
+  obtain ⟨y₁, hy₁⟩ := (exact_map_map hS n y).1 (Subsingleton.elim _ _)
+  rw [← hx₁, ← hy₁, Subsingleton.elim x₁ y₁]
+
+/-- If `Hⁿ⁰(F₂)` and `Hⁿ¹(F₁)` vanish, then so does `Hⁿ⁰(F₃)`. -/
+theorem subsingleton_X₃ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (h₂ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₂ n₀))
+    (h₁ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₁ n₁)) :
+    Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₃ n₀) :=
+  (surjective_map_g hS n₀ n₁ h h₁).subsingleton
+
+/-- If `Hⁿ⁰(F₃)` and `Hⁿ¹(F₂)` vanish, then so does `Hⁿ¹(F₁)`. -/
+theorem subsingleton_X₁ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (h₃ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₃ n₀))
+    (h₂ : Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₂ n₁)) :
+    Subsingleton (_root_.CategoryTheory.Sheaf.H S.X₁ n₁) := by
+  refine ⟨fun x y ↦ ?_⟩
+  obtain ⟨x₃, hx₃⟩ := (exact_δ_map hS n₀ n₁ h x).1 (Subsingleton.elim _ _)
+  obtain ⟨y₃, hy₃⟩ := (exact_δ_map hS n₀ n₁ h y).1 (Subsingleton.elim _ _)
+  rw [← hx₃, ← hy₃, Subsingleton.elim x₃ y₃]
+
+end H
+
+end Sheaf
+
+end CategoryTheory
+
+end TauCeti


### PR DESCRIPTION
This PR builds the long exact cohomology sequence attached to a short exact sequence of coefficients, which is the tool the whole of Layer B of `TauCetiRoadmap/JacobianChallenge/README.md` runs on. The milestone is Layer B, "**Coherent sheaves** and cohomology `Hⁱ(X, ℱ)`", whose next unmet piece after the Mayer-Vietoris sequence of an open cover (TauCeti#2719) is the complementary long exact sequence in the *coefficient* variable: for a short exact sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` of `𝒪_X`-modules,

```text
0 ⟶ H⁰(X, M₁) ⟶ H⁰(X, M₂) ⟶ H⁰(X, M₃) ⟶ H¹(X, M₁) ⟶ H¹(X, M₂) ⟶ ⋯
```

Additivity of the Euler characteristic — and with it `χ(L) = deg L + 1 − g`, the Riemann-Roch statement the layer is aiming at — is exactly the statement that this sequence exists and is exact; what remains after this PR, on the way to Riemann-Roch, is finite-dimensionality of the cohomology of a proper scheme over a field, without which `χ` cannot even be defined.

`TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean` states the sequence for an abelian sheaf on an arbitrary site, where `CategoryTheory.Sheaf.H` lives: the connecting map `H.δ` is composition with the extension class of the sequence, and `H.exact_map_map`, `H.exact_map_δ` and `H.exact_δ_map` are its exactness at the three consecutive spots, with `H.injective_map_f` the injectivity in degree zero at which it starts and `H.surjective_map_g` and the three `H.subsingleton_X…` lemmas the vanishing consequences it is used for. The six-term `ComposableArrows` presentation is not re-stated: it is already Mathlib's `CategoryTheory.Abelian.Ext.covariantSequence` for the constant sheaf `ℤ`, whose arrows are definitionally the maps used here, so this file only extracts the `Function.Exact` form and the connecting map.

Getting from there to `𝒪_X`-modules needs one genuinely missing fact, since `Scheme.Modules.Cohomology` is defined through the underlying abelian sheaf. Mathlib knows that `SheafOfModules.toSheaf` preserves and reflects finite limits, but nothing about colimits. `TauCeti/Algebra/Category/ModuleCat/Sheaf/Exactness.lean` supplies the other half: the functor preserves finite colimits, hence is exact. The proof transfers along the sheafification of presheaves of modules, whose counit is an isomorphism, so every diagram of sheaves of modules is the sheafification of a diagram of presheaves of modules; composed with `SheafOfModules.toSheaf`, sheafification is `PresheafOfModules.toPresheaf ⋙ presheafToSheaf`, and both of those preserve finite colimits. `TauCeti/AlgebraicGeometry/Modules/Sheaf.lean` then packages the functor with source the category `X.Modules` — the analogue of Mathlib's `AlgebraicGeometry.Scheme.Modules.toPresheaf`, and the form in which `ShortComplex.map` applies to a short complex of `𝒪_X`-modules.

`TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean` is the payoff: `cohomologyMap`, `cohomologyδ` and the three exactness statements for `Hⁿ(X, M)`, the vanishing consequences, and the global-sections corollaries obtained through `Scheme.Modules.cohomologyZeroEquiv` — global sections are left exact (`exact_sections`, `injective_sections`), and `surjective_sections` says every global section of `M₃` lifts to `M₂` as soon as `H¹(X, M₁)` vanishes, which is the shape in which the sequence gets used on a curve. The one change to an existing file marks `Scheme.Modules.cohomologyZeroEquiv` `@[expose]`, without which its defining equation is invisible across the module boundary and the comparison with global sections cannot be proved.

No formalization is vendored. The long exact sequence rests on Mathlib's `CategoryTheory.Abelian.Ext.covariant_sequence_exact₁'`, `covariant_sequence_exact₂'` and `covariant_sequence_exact₃'`; the exactness transfer uses `PresheafOfModules.sheafificationAdjunction`, `PresheafOfModules.sheafificationCompToSheaf` and `ShortComplex.ShortExact.map_of_exact`; the global-sections comparison uses `CategoryTheory.Sheaf.H.equiv₀_naturality` and `Function.Exact.of_ladder_addEquiv_of_exact`.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"long-exact-sequence-in-sheaf-cohomology"}-->

🤖 Prepared with Claude Code
