### PR TITLE
fix: install elan from a pinned, checksummed release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,11 +460,15 @@ jobs:
           fi
           # elan comes from a pinned leanprover/elan release verified by SHA-256, not from
           # whatever the installer URL serves at the moment of the request. The next step hands
-          # LAKE_CACHE_KEY to a `lake` this elan selected, so an unpinned installer would be the
-          # one input to this job that the repository does not fix, and it would move the
-          # toolchain check above rather than close it. The named Lean release itself remains a
-          # project-wide assumption about leanprover's release channel, shared with every other
-          # job here. scripts/test_elan_pin.py keeps the copies of the pin honest.
+          # LAKE_CACHE_KEY to a `lake` this elan selected, so an installer nothing here fixes
+          # would have moved the toolchain check above rather than closed it: constrain the
+          # toolchain NAME but not the elan that resolves it, and the choice just relocates.
+          # What this does not do is fix the bytes of the Lean release elan then downloads.
+          # `lean-toolchain` pins that release's name, not its contents, and elan offers no hook
+          # to verify the archive, so leanprover's release channel stays in this job's trust
+          # base exactly as it is in every other job here. See issue #3725 for why that is worth
+          # raising upstream rather than working around locally.
+          # scripts/test_elan_pin.py keeps the copies of the pin honest.
           curl -sSL -H "Accept: application/octet-stream" \
             "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
           echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,8 +466,10 @@ jobs:
           # What this does not do is fix the bytes of the Lean release elan then downloads.
           # `lean-toolchain` pins that release's name, not its contents, and elan offers no hook
           # to verify the archive, so leanprover's release channel stays in this job's trust
-          # base exactly as it is in every other job here. See issue #3725 for why that is worth
-          # raising upstream rather than working around locally.
+          # base exactly as it is in every other job here. Closing that would mean fetching and
+          # unpacking the release ourselves, or a verification hook from upstream; see
+          # https://github.com/TauCetiProject/TauCeti/issues/3725 for why the latter is the
+          # better bargain.
           # scripts/test_elan_pin.py keeps the copies of the pin honest.
           curl -sSL -H "Accept: application/octet-stream" \
             "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           python3 scripts/test_structure_nudge.py
           python3 scripts/test_workflow_pins.py
           python3 scripts/test_landrun_pin.py
+          python3 scripts/test_elan_pin.py
           PYTHONPATH=scripts python3 scripts/test_claims_access.py
           python3 scripts/test_lint_dot_notation.py
 
@@ -76,7 +77,7 @@ jobs:
           fi
 
       # Restore only Mathlib's compressed, content-addressed `.ltar` download store. This is
-      # deliberately separate from lean-action's multi-gigabyte `./.lake` cache below: `lake exe
+      # deliberately narrower than a cache of the whole multi-gigabyte `./.lake` tree: `lake exe
       # cache get` remains authoritative, locally selects and unpacks the linked hashes, and
       # downloads anything this best-effort snapshot does not contain. The exact key makes a
       # repeated pin cheap; the same-toolchain prefix lets a new Mathlib pin reuse unchanged
@@ -89,20 +90,29 @@ jobs:
         with:
           project-dir: .
 
-      # Use lean-action for toolchain setup, but keep the fetch as an explicit step so a failed
-      # normal fetch can be retried with `get!`, which force-downloads and unpacks every linked
-      # file instead of trusting a possibly malformed restored `.ltar`.
-      - name: Set up Lean
-        uses: leanprover/lean-action@v1
-        with:
-          auto-config: false
-          build: false
-          test: false
-          lint: false
-          use-mathlib-cache: false
-          # Keep lean-action's broad GitHub cache off. It archives the whole `./.lake` tree;
-          # the narrow restore/save steps here cache only Mathlib's compressed `.ltar` files.
-          use-github-cache: false
+      # Install elan from a pinned leanprover/elan release, verified by SHA-256, then install the
+      # toolchain `lean-toolchain` names. This replaces leanprover/lean-action, which resolved
+      # from a floating major tag and installed elan by piping an unpinned installer to `sh`; with
+      # its build, test, lint and cache inputs all off, toolchain setup was all it did here. The
+      # Mathlib fetch stays an explicit step below so a failed normal fetch can be retried with
+      # `get!`, which force-downloads and unpacks every linked file instead of trusting a possibly
+      # malformed restored `.ltar`. scripts/test_elan_pin.py keeps the copies of the pin honest.
+      - name: Install elan (pinned + checksum) and the toolchain
+        env:
+          ELAN_SHA256: df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2
+          ELAN_VER: v4.2.3
+        run: |
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
+          echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -
+          tar -xzf elan.tar.gz elan-init
+          ./elan-init -y --default-toolchain none
+          rm -f elan.tar.gz elan-init
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.elan/bin:$PATH"
+          elan toolchain install "$(cat lean-toolchain)"
+          lean --version
+          lake --version
 
       - name: Fetch Mathlib oleans, retrying with a forced full refetch
         run: |
@@ -425,9 +435,11 @@ jobs:
                       check(json.loads(line), lineno)
           PY
 
-      - name: Install elan and the pinned toolchain
+      - name: Install elan (pinned + checksum) and the pinned toolchain
         id: toolchain
         env:
+          ELAN_SHA256: df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2
+          ELAN_VER: v4.2.3
           REPORTED: ${{ needs.build.outputs.reported-toolchain }}
         run: |
           TOOLCHAIN="$(cat lean-toolchain)"
@@ -446,13 +458,19 @@ jobs:
             echo "::error::the build job built with '$REPORTED' but lean-toolchain pins '$TOOLCHAIN'"
             exit 1
           fi
-          # elan's installer is fetched unpinned, exactly as pr-build.yml and lean-action fetch
-          # it, so elan's distribution and the named Lean release are in this job's trust base
-          # the same way they are in every other job here. That is a project-wide assumption
-          # about leanprover's release channel, not one this split introduces: the build job
-          # installs elan the same way and runs the same toolchain over the whole library.
-          curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
-          chmod +x elan-init.sh && ./elan-init.sh -y --default-toolchain none
+          # elan comes from a pinned leanprover/elan release verified by SHA-256, not from
+          # whatever the installer URL serves at the moment of the request. The next step hands
+          # LAKE_CACHE_KEY to a `lake` this elan selected, so an unpinned installer would be the
+          # one input to this job that the repository does not fix, and it would move the
+          # toolchain check above rather than close it. The named Lean release itself remains a
+          # project-wide assumption about leanprover's release channel, shared with every other
+          # job here. scripts/test_elan_pin.py keeps the copies of the pin honest.
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
+          echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -
+          tar -xzf elan.tar.gz elan-init
+          ./elan-init -y --default-toolchain none
+          rm -f elan.tar.gz elan-init
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
           "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN"
           printf 'name=%s\n' "$TOOLCHAIN" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -130,10 +130,20 @@ jobs:
             echo "::error::landrun not enforcing (run=$ok write=$wr shm=$shm net=$net); refusing to run code under it"; exit 1
           fi
 
-      - name: Install elan
+      # Pinned by SHA-256 like landrun above. Both sides of this job's comparison install elan
+      # the same way, so an installer substituted under the workflow is exactly the failure the
+      # from-source rebuild could not detect. scripts/test_elan_pin.py keeps the copies honest.
+      - name: Install elan (pinned + checksum)
+        env:
+          ELAN_SHA256: df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2
+          ELAN_VER: v4.2.3
         run: |
-          curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
-          chmod +x elan-init.sh && ./elan-init.sh -y --default-toolchain none
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
+          echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -
+          tar -xzf elan.tar.gz elan-init
+          ./elan-init -y --default-toolchain none
+          rm -f elan.tar.gz elan-init
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       # One restore serves both workspaces: same commit, so same manifest and toolchain, and the

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -148,11 +148,20 @@ jobs:
             --out-dir web/static_files \
           || echo "::warning::PR statistics generation failed; keeping the committed fallback assets"
 
-      - name: Install elan
+      # Pinned leanprover/elan release, verified by SHA-256, rather than whatever the installer
+      # URL serves at the moment of the request; this elan chooses the toolchain that builds the
+      # documentation this job deploys. scripts/test_elan_pin.py keeps the copies of the pin honest.
+      - name: Install elan (pinned + checksum)
+        env:
+          ELAN_SHA256: df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2
+          ELAN_VER: v4.2.3
         run: |
-          curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
-          chmod +x elan-init.sh
-          ./elan-init.sh -y --default-toolchain none
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
+          echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -
+          tar -xzf elan.tar.gz elan-init
+          ./elan-init -y --default-toolchain none
+          rm -f elan.tar.gz elan-init
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       # --- API documentation (doc-gen4), normally built every three hours ----------------

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -330,11 +330,23 @@ jobs:
             echo "::error::TauCeti/ may not use set_option (it can weaken maxHeartbeats, linters, maxRecDepth, ...); remove it"; exit 1
           fi
 
-      - name: Install elan (trusted)
+      # Take elan from a pinned leanprover/elan release verified by SHA-256, not from whatever
+      # the installer URL serves at the moment of the request. This elan chooses the `lake` the
+      # sandboxed build runs, and it is installed here, in the trusted phase, before landrun
+      # confines anything, so a substituted one would sit outside the sandbox by construction.
+      # Same idiom as the landrun pin below; scripts/test_elan_pin.py keeps the copies honest.
+      - name: Install elan (trusted, pinned + checksum)
         if: ${{ env.INFRA != '1' }}
+        env:
+          ELAN_SHA256: df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2
+          ELAN_VER: v4.2.3
         run: |
-          curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
-          chmod +x elan-init.sh && ./elan-init.sh -y --default-toolchain none
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
+          echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -
+          tar -xzf elan.tar.gz elan-init
+          ./elan-init -y --default-toolchain none
+          rm -f elan.tar.gz elan-init
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Install landrun (pinned + checksum) and self-test (fail closed)

--- a/.github/workflows/pr-profile.yml
+++ b/.github/workflows/pr-profile.yml
@@ -261,12 +261,21 @@ jobs:
           printf '[]\n' > "$RUNNER_TEMP/base-results.json"
           printf '[]\n' > "$RUNNER_TEMP/head-results.json"
 
-      - name: Install elan (trusted)
+      # Pinned leanprover/elan release, verified by SHA-256. Like landrun below it is installed
+      # in the trusted phase, before anything confines the PR's code, and it chooses the `lake`
+      # that later runs inside that confinement. scripts/test_elan_pin.py keeps the copies honest.
+      - name: Install elan (trusted, pinned + checksum)
         if: ${{ steps.manifest.outputs.count != '0' }}
+        env:
+          ELAN_SHA256: df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2
+          ELAN_VER: v4.2.3
         run: |
-          curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh
-          chmod +x elan-init.sh
-          ./elan-init.sh -y --default-toolchain none
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
+          echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -
+          tar -xzf elan.tar.gz elan-init
+          ./elan-init -y --default-toolchain none
+          rm -f elan.tar.gz elan-init
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Install landrun and prove confinement (trusted, fail closed)

--- a/scripts/test_elan_pin.py
+++ b/scripts/test_elan_pin.py
@@ -1,0 +1,111 @@
+"""Ensure every workflow that installs elan installs the same verified binary.
+
+Run with: python3 scripts/test_elan_pin.py
+
+elan chooses the `lake` and `lean` a job runs, so whoever controls the elan a workflow installs
+controls what that job executes. That matters most in ci.yml's `publish-lake-cache` job, which
+hands LAKE_CACHE_KEY to a `lake` the installer selected, and in pr-build.yml, where elan is
+installed in the trusted phase before landrun confines anything. So every workflow takes elan
+from a pinned leanprover/elan release verified by SHA-256, and none of them runs the installer
+served at https://elan.lean-lang.org/elan-init.sh, whose contents are whatever that host returns
+at the moment of the request.
+
+The pin is deliberately duplicated across workflows rather than shared through a composite
+action, for the same reason landrun's is: pr-build.yml sits on the merge queue's critical path
+and runs from the base definition under pull_request_target, so a shared action introduced by a
+pull request could not be exercised by that pull request's own build. This test is what stops
+the copies drifting.
+
+Every file in .github/workflows is checked, rather than a list of the ones that install elan
+today, so a workflow added later cannot quietly reintroduce the unpinned install.
+
+To bump the pin, change ELAN_VER and ELAN_SHA256 together in every workflow that declares them;
+the checksum is that of the release's elan-x86_64-unknown-linux-gnu.tar.gz asset.
+"""
+
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = ROOT / ".github/workflows"
+
+SHA = re.compile(r"^\s*ELAN_SHA256:\s*([0-9a-f]{64})\s*$", re.MULTILINE)
+VER = re.compile(r"^\s*ELAN_VER:\s*(v[0-9][0-9A-Za-z.\-]*)\s*$", re.MULTILINE)
+# The download must name the pinned version, or the pin would describe a release the workflow
+# does not actually fetch.
+DOWNLOAD = re.compile(
+    r'"https://github\.com/leanprover/elan/releases/download/\$\{ELAN_VER\}/'
+    r'elan-x86_64-unknown-linux-gnu\.tar\.gz" -o elan\.tar\.gz'
+)
+VERIFY = 'echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -'
+# Every way of getting an elan that this repository does not choose by checksum. lean-action
+# resolves from a floating tag and pipes the second of these to `sh`; naming it in prose is
+# fine, so only a `uses:` of it counts.
+UNPINNED = (
+    ("the installer served at elan.lean-lang.org", re.compile(r"elan\.lean-lang\.org")),
+    ("elan's master branch on raw.githubusercontent.com",
+     re.compile(r"raw\.githubusercontent\.com/leanprover/elan")),
+    ("leanprover/lean-action, which installs elan itself",
+     re.compile(r"uses:\s*leanprover/lean-action")),
+)
+
+
+def workflows():
+    return sorted(WORKFLOW_DIR.glob("*.yml"))
+
+
+def describe(values):
+    return "; ".join(f"{value} in {', '.join(sorted(names))}"
+                     for value, names in sorted(values.items()))
+
+
+class ElanPin(unittest.TestCase):
+    def test_workflows_exist(self):
+        # A glob that silently matched nothing would make every test below vacuous.
+        self.assertTrue(workflows(), f"no workflows found under {WORKFLOW_DIR}")
+
+    def test_every_installing_workflow_pins_the_same_elan(self):
+        vers, shas = {}, {}
+        for workflow in workflows():
+            text = workflow.read_text()
+            for ver in VER.findall(text):
+                vers.setdefault(ver, set()).add(workflow.name)
+            for sha in SHA.findall(text):
+                shas.setdefault(sha, set()).add(workflow.name)
+        self.assertTrue(vers, "no workflow pins an elan release")
+        self.assertEqual(len(vers), 1, "workflows disagree on the elan version: " + describe(vers))
+        self.assertEqual(len(shas), 1, "workflows disagree on the elan checksum: " + describe(shas))
+
+    def test_every_pin_is_downloaded_and_verified(self):
+        # A pin that is declared but never checked is not a pin, and one checksum cannot cover
+        # two downloads in the same file, so the three counts must agree step for step.
+        for workflow in workflows():
+            text = workflow.read_text()
+            pins = len(VER.findall(text))
+            if not pins:
+                continue
+            with self.subTest(workflow=workflow.name):
+                self.assertEqual(len(SHA.findall(text)), pins,
+                                 f"{workflow.name} declares {pins} elan pin(s) but does not "
+                                 "give each of them a checksum")
+                self.assertEqual(len(DOWNLOAD.findall(text)), pins,
+                                 f"{workflow.name} declares {pins} elan pin(s) but does not "
+                                 "download each of them from the pinned URL")
+                self.assertEqual(text.count(VERIFY), pins,
+                                 f"{workflow.name} declares {pins} elan pin(s) but does not "
+                                 "verify each download's checksum")
+
+    def test_no_workflow_installs_an_unverified_elan(self):
+        for workflow in workflows():
+            text = workflow.read_text()
+            for description, pattern in UNPINNED:
+                with self.subTest(workflow=workflow.name, source=description):
+                    self.assertIsNone(
+                        pattern.search(text),
+                        f"{workflow.name} takes elan from {description}; install it from a "
+                        "pinned leanprover/elan release verified by SHA-256 instead")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_elan_pin.py
+++ b/scripts/test_elan_pin.py
@@ -16,8 +16,16 @@ and runs from the base definition under pull_request_target, so a shared action 
 pull request could not be exercised by that pull request's own build. This test is what stops
 the copies drifting.
 
-Every file in .github/workflows is checked, rather than a list of the ones that install elan
-today, so a workflow added later cannot quietly reintroduce the unpinned install.
+The checks below match the install as a single ordered block of adjacent lines, over a view of
+the file with comment lines removed, and then require that nothing else in the file names the
+archive or the installer. Counting the pieces separately would have let a commented-out or
+otherwise dead copy of the approved block pay for a live step that installed elan some other
+way. Both .yml and .yaml are scanned, since GitHub reads either, and every file in the directory
+is scanned rather than a fixed list, so a workflow added later cannot quietly reintroduce the
+unpinned install.
+
+What this cannot do is recognise an arbitrary new way to obtain an elan; no textual check can.
+It fixes the approved shape and closes the routes that were actually in use.
 
 To bump the pin, change ELAN_VER and ELAN_SHA256 together in every workflow that declares them;
 the checksum is that of the release's elan-x86_64-unknown-linux-gnu.tar.gz asset.
@@ -32,13 +40,23 @@ WORKFLOW_DIR = ROOT / ".github/workflows"
 
 SHA = re.compile(r"^\s*ELAN_SHA256:\s*([0-9a-f]{64})\s*$", re.MULTILINE)
 VER = re.compile(r"^\s*ELAN_VER:\s*(v[0-9][0-9A-Za-z.\-]*)\s*$", re.MULTILINE)
-# The download must name the pinned version, or the pin would describe a release the workflow
-# does not actually fetch.
-DOWNLOAD = re.compile(
-    r'"https://github\.com/leanprover/elan/releases/download/\$\{ELAN_VER\}/'
-    r'elan-x86_64-unknown-linux-gnu\.tar\.gz" -o elan\.tar\.gz'
+# The approved install, as adjacent lines: fetch the pinned release, refuse it unless it hashes
+# to the pin, and only then unpack and run the installer it contains. The download must name
+# ${ELAN_VER} and the check ${ELAN_SHA256}, or the declared pin would describe a release the
+# workflow does not actually fetch, or a checksum it does not actually compare against.
+INSTALL = re.compile(
+    r'^[ \t]*curl -sSL -H "Accept: application/octet-stream" \\\n'
+    r'[ \t]*"https://github\.com/leanprover/elan/releases/download/\$\{ELAN_VER\}/'
+    r'elan-x86_64-unknown-linux-gnu\.tar\.gz" -o elan\.tar\.gz\n'
+    r'[ \t]*echo "\$\{ELAN_SHA256\}  elan\.tar\.gz" \| sha256sum -c -\n'
+    r'[ \t]*tar -xzf elan\.tar\.gz elan-init\n'
+    r'[ \t]*\./elan-init -y --default-toolchain none\n'
+    r'[ \t]*rm -f elan\.tar\.gz elan-init\n',
+    re.MULTILINE,
 )
-VERIFY = 'echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -'
+# The names the approved block introduces. Once its matches are removed, no mention of either
+# may remain: a second step touching them is installing elan some way this test has not vetted.
+NAMES = re.compile(r"elan-init|elan\.tar\.gz")
 # Every way of getting an elan that this repository does not choose by checksum. lean-action
 # resolves from a floating tag and pipes the second of these to `sh`; naming it in prose is
 # fine, so only a `uses:` of it counts.
@@ -52,7 +70,13 @@ UNPINNED = (
 
 
 def workflows():
-    return sorted(WORKFLOW_DIR.glob("*.yml"))
+    return sorted(set(WORKFLOW_DIR.glob("*.yml")) | set(WORKFLOW_DIR.glob("*.yaml")))
+
+
+def code(workflow):
+    """The workflow with whole-line comments dropped, so only lines that run are matched."""
+    return "".join(line for line in workflow.read_text().splitlines(keepends=True)
+                   if not line.lstrip().startswith("#"))
 
 
 def describe(values):
@@ -68,7 +92,7 @@ class ElanPin(unittest.TestCase):
     def test_every_installing_workflow_pins_the_same_elan(self):
         vers, shas = {}, {}
         for workflow in workflows():
-            text = workflow.read_text()
+            text = code(workflow)
             for ver in VER.findall(text):
                 vers.setdefault(ver, set()).add(workflow.name)
             for sha in SHA.findall(text):
@@ -77,11 +101,11 @@ class ElanPin(unittest.TestCase):
         self.assertEqual(len(vers), 1, "workflows disagree on the elan version: " + describe(vers))
         self.assertEqual(len(shas), 1, "workflows disagree on the elan checksum: " + describe(shas))
 
-    def test_every_pin_is_downloaded_and_verified(self):
+    def test_every_pin_belongs_to_a_verified_install(self):
         # A pin that is declared but never checked is not a pin, and one checksum cannot cover
         # two downloads in the same file, so the three counts must agree step for step.
         for workflow in workflows():
-            text = workflow.read_text()
+            text = code(workflow)
             pins = len(VER.findall(text))
             if not pins:
                 continue
@@ -89,16 +113,23 @@ class ElanPin(unittest.TestCase):
                 self.assertEqual(len(SHA.findall(text)), pins,
                                  f"{workflow.name} declares {pins} elan pin(s) but does not "
                                  "give each of them a checksum")
-                self.assertEqual(len(DOWNLOAD.findall(text)), pins,
+                self.assertEqual(len(INSTALL.findall(text)), pins,
                                  f"{workflow.name} declares {pins} elan pin(s) but does not "
-                                 "download each of them from the pinned URL")
-                self.assertEqual(text.count(VERIFY), pins,
-                                 f"{workflow.name} declares {pins} elan pin(s) but does not "
-                                 "verify each download's checksum")
+                                 "download, verify and run each of them as one block")
+
+    def test_nothing_else_touches_the_installer(self):
+        for workflow in workflows():
+            leftover = NAMES.search(INSTALL.sub("", code(workflow)))
+            with self.subTest(workflow=workflow.name):
+                self.assertIsNone(
+                    leftover,
+                    f"{workflow.name} names {leftover.group(0) if leftover else ''} outside the "
+                    "verified install block; elan may only come from the pinned, checksummed "
+                    "release")
 
     def test_no_workflow_installs_an_unverified_elan(self):
         for workflow in workflows():
-            text = workflow.read_text()
+            text = code(workflow)
             for description, pattern in UNPINNED:
                 with self.subTest(workflow=workflow.name, source=description):
                     self.assertIsNone(


### PR DESCRIPTION
This PR takes elan from a pinned `leanprover/elan` release verified by SHA-256, in place of
running whatever `https://elan.lean-lang.org/elan-init.sh` serves at the moment of the request.
All five workflows that install elan fetch `elan-x86_64-unknown-linux-gnu.tar.gz` for the pinned
tag, check it against `sha256sum -c -` before extracting, and run the resulting `elan-init` —
exactly the idiom `pr-build.yml` already uses for landrun. The pin matters most in
`publish-lake-cache`, which hands `LAKE_CACHE_KEY` to a `lake` the installer selected, and in
`pr-build.yml` and `pr-profile.yml`, where elan is installed during the trusted phase before
landrun confines anything.

`ci.yml`'s build job set up its toolchain through `leanprover/lean-action@v1`, which resolves
from a floating major tag and installs elan by piping `elan-init.sh` from elan's `master` branch
to `sh`. With its build, test, lint and cache inputs all off, toolchain setup was the only thing
that action did here, so the job now installs the pinned elan and the toolchain
`lean-toolchain` names directly. That closes the second unpinned path and keeps the explicit
Mathlib fetch step, whose retry with `get!` is why the fetch was separated from the action in
the first place.

`scripts/test_elan_pin.py` matches the install as one ordered block of adjacent lines, over a
view of each workflow with comment lines removed, and then requires that nothing else in the
file names the archive or the installer; counting the declaration, the download and the checksum
separately would have let a dead copy of the approved block pay for a live step that installed
elan some other way. It reads both `.yml` and `.yaml`, and every file in the directory rather
than a fixed list, so a workflow added later cannot quietly reintroduce the old install.
Bumping the pin means changing `ELAN_VER` and `ELAN_SHA256` together in every workflow that
declares them; the test says so when they disagree.

What this does not do is fix the bytes of the Lean release elan then downloads. `lean-toolchain`
pins that release's name, not its contents, and elan offers no hook to verify the archive, so
leanprover's release channel stays in every job's trust base. The comment in `publish-lake-cache`
now says that rather than implying the job's inputs are fully fixed.

Closes https://github.com/TauCetiProject/TauCeti/issues/3725

Roadmap: none

🤖 Prepared with Claude Code