### PR TITLE
ci: keep the GitHub token out of workspaces that elaborate TauCeti

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # This job elaborates every TauCeti module, and Lean runs code at elaboration time.
+          # Without this, checkout leaves an http.extraheader carrying GITHUB_TOKEN in the
+          # workspace .git/config for the whole job, within reach of that code. Nothing here
+          # needs it: no step calls the GitHub API or pushes, `lake exe cache get` talks to
+          # Mathlib's own server, scripts/lake-cache-get.sh does anonymous GETs, and
+          # `lake cache get` reads the local revision from .git without authenticating.
+          persist-credentials: false
           # Enough history for `lake cache get` to backtrack to a recently-published
           # ancestor commit (its `--max-revs`) when the tip itself has no mapping yet.
           # Harmless (just a slightly deeper fetch) when the cache is off.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -85,6 +85,15 @@ jobs:
       # series by walking every commit, so a shallow checkout would truncate the charts.
       - uses: actions/checkout@v4
         with:
+          # Same reasoning as ci.yml's build checkout, and it matters more here: this job
+          # elaborates TauCeti twice (the doc-gen4 build and the examples build), and the token
+          # this workflow grants carries `pages: write` and `id-token: write`, not just
+          # `contents: read`. Left in the workspace .git/config, it would be readable by code
+          # running at elaboration time, which could then publish to the project's Pages site.
+          # Nothing in this job authenticates to GitHub: the only git command is a clone of the
+          # public roadmap repository, the history this checkout fetches is used locally, and the
+          # branch update lives in the separate advance-docgen-ref job with its own GH_TOKEN.
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Clone the roadmap repository (full history, for its chart)


### PR DESCRIPTION
This PR stops the two jobs that compile TauCeti from leaving a GitHub token where the code they compile can read it.

`actions/checkout` writes an `http.extraheader` carrying `GITHUB_TOKEN` into the workspace `.git/config` unless told otherwise, and leaves it there for the life of the job. Both jobs go on to elaborate every TauCeti module, and Lean executes code at elaboration time: a `run_cmd` doing file IO is enough to read it, runs before any audit inspects the result, and emits no diagnostic. Only `set_option` is restricted at source level.

In `ci.yml`'s build job the token is scoped `contents: read` on a public repository, so what it grants is close to what anyone can read anonymously; the point is that it need not be reachable, and that the exposure would grow silently the day `permissions:` is widened for an unrelated reason. `pages.yml`'s `build-site` job is the sharper case, and is why this covers two workflows rather than one: it elaborates TauCeti twice, for the doc-gen4 build and again for the examples build, and the token it inherits carries `pages: write` and `id-token: write`. Reachable from elaboration, that is enough to publish arbitrary content to the project's Pages site.

Neither job authenticates to GitHub. In `ci.yml`: no step calls the API or pushes, `lake exe cache get` talks to Mathlib's own cache server, `scripts/lake-cache-get.sh` performs anonymous S3 GETs against the public read host, `restore-mathlib-ltars` and the artifact steps authenticate with the Actions runtime credential rather than this one, and `lake cache get` reads the current revision out of `.git` without authenticating. In `pages.yml`: the only git command in the job is a clone of the public roadmap repository, the history the checkout fetches is used locally, and the branch update lives in the separate `advance-docgen-ref` job with its own explicit `GH_TOKEN`. Both checkouts keep their fetch depth, which `actions/checkout` applies while fetching and before it drops the credential, so `lake cache get`'s `--max-revs` backtrack and the Pages history walk are unaffected.

This is a smaller thing than it sounds: it removes a credential from reach rather than closing an exploitable path, and it is not a sandbox. Code elaborated in these jobs still runs as the runner user. Sandboxing main's build is https://github.com/TauCetiProject/TauCeti/pull/3731; the underlying cause behind https://github.com/TauCetiProject/TauCeti/issues/3720 is the pair of them.

Roadmap: none

🤖 Prepared with Claude Code