### PR TITLE
ci: build, audit, lint and stage main under landrun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,14 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Pinned rather than ubuntu-latest, and to the image pr-build.yml uses: the sandboxed run
+    # below enforces a wall-clock per-module deadline, so main and the merge gate should not be
+    # judging the same modules on different hardware.
+    runs-on: ubuntu-24.04
+    # A bound on the whole job. The sandbox confines a process tree but does not end it, so a
+    # detached child can outlive the landrun call and keep writing to .lake; this caps what any
+    # resulting stall can cost. Normal runs are around 15 to 20 minutes.
+    timeout-minutes: 90
     # Read by publish-lake-cache below, the only job that ever holds the upload secret.
     # Neither output reveals the secret's value or whether it is set, and neither is trusted
     # there: `staged` only decides whether that job runs at all, and `reported-toolchain` is
@@ -30,6 +37,14 @@ jobs:
     outputs:
       staged: ${{ steps.stage.outputs.staged }}
       reported-toolchain: ${{ steps.stage.outputs.toolchain }}
+    env:
+      # Lake artifact-cache knobs, off by default. The "Configure the Lake artifact cache" step
+      # flips these on (and sets LAKE_CACHE_DIR) only when the public endpoints are installed as
+      # repo variables. Declared here so the landrun build's `--env` list always has a defined
+      # value to pass, exactly as in pr-build.yml.
+      LAKE_ARTIFACT_CACHE: ""
+      LAKE_RESTORE_ARTIFACTS: ""
+      LAKE_CACHE_DIR: ""
     steps:
       - uses: actions/checkout@v4
         with:
@@ -118,6 +133,40 @@ jobs:
             lake exe cache get!
           fi
 
+      # Ahead of the sandboxed build, not after it. `lake exe cache clean` configures the
+      # workspace, and configuring elaborates each dependency's Lake config; at least one of
+      # those is a lakefile.lean living under .lake/packages, which the sandboxed build can
+      # write. Running it afterwards would elaborate whatever was left there, outside the
+      # sandbox. Nothing between here and the build needs the pruned store.
+      #
+      # Main is the sole publisher. PR and merge-group builds restore these trusted snapshots
+      # but never save, so candidate code cannot populate a cache consumed by later builds.
+      # GitHub cache keys are immutable; an exact restore needs no redundant save, while a
+      # prefix restore is extended with the newly downloaded hashes under the exact current key.
+      # Pruning is essential: without it, every prefix restore would carry all old pins forward
+      # and each immutable snapshot would grow monotonically. If pruning itself breaks, leave main
+      # green but skip publication rather than saving an unbounded snapshot.
+      - name: Prune Mathlib's download cache to the current pin
+        id: mathlib_ltar_prune
+        if: ${{ steps.mathlib_ltar_restore.outputs.cache-hit != 'true' }}
+        continue-on-error: true
+        run: lake exe cache clean
+
+      - name: Save Mathlib's compressed download cache
+        if: ${{ steps.mathlib_ltar_restore.outputs.cache-hit != 'true' && steps.mathlib_ltar_prune.outcome == 'success' }}
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.mathlib_ltar_restore.outputs.cache-dir }}/*.ltar
+          key: ${{ steps.mathlib_ltar_restore.outputs.cache-primary-key }}
+
+      # Also ahead of the build, matching pr-build.yml: this lint derives Mathlib's namespaces
+      # from .lake/packages/mathlib, which the sandboxed build can write. Run afterwards, an
+      # elaborating module could edit those sources so the lint stops recognising the
+      # namespace that would have caught it.
+      - name: Dot-notation namespace lint (Mathlib type namespaces stay at root)
+        run: python3 scripts/lint-dot-notation.py
+
       # --- Lake artifact-cache restore (dormant until configured) --------------------
       # Restore TauCeti's OWN oleans before building, exactly as pr-build.yml does. Without
       # this, the post-merge run recompiled the whole library from scratch on every push,
@@ -167,82 +216,144 @@ jobs:
           PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
         run: bash scripts/lake-cache-get.sh .
 
+      # Everything above this point either runs no repository code or is a textual check. From
+      # here the job elaborates TauCeti, and Lean executes code at elaboration time, so the rest
+      # of the checking goes inside landrun.
+      #
+      # One caveat inherited from pr-build.yml, so that "offline" below is read for what it is:
+      # landrun's network rules come from Landlock's TCP bind/connect rights, so they deny classic
+      # TCP, which is what the self-test probes, but not UDP. Confinement of the FILESYSTEM is the
+      # property this step relies on, and that is enforced.
+      #
+      # The version and checksum are duplicated from pr-build.yml and nightly-verify.yml on
+      # purpose, with scripts/test_landrun_pin.py keeping the copies honest. pr-build.yml sits on
+      # the merge queue's critical path and runs from the BASE definition under
+      # pull_request_target, so a shared composite action could not be exercised by the PR that
+      # introduced it, and a mistake in one would redden every PR build.
+      - name: Install landrun (pinned + checksum) and self-test (fail closed)
+        env:
+          LANDRUN_SHA256: 645178e3239cd33760560834e50efea0864183a2a8a82faf199760dffee6dd71
+          LANDRUN_VER: v0.1.14
+        run: |
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/Zouuup/landrun/releases/download/${LANDRUN_VER}/landrun-linux-amd64" -o landrun
+          echo "${LANDRUN_SHA256}  landrun" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"; install -m 0755 landrun "$HOME/.local/bin/landrun"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          landrun --version || true
+          # Prove the sandbox enforces before trusting it: run works, out-of-tree write denied,
+          # /dev/shm write denied, network denied without the flag.
+          set +e
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo ok' >/dev/null 2>&1; ok=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo x > /etc/landrun-probe' >/dev/null 2>&1; wr=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'echo x > /dev/shm/landrun-probe' >/dev/null 2>&1; shm=$?
+          landrun --rox /usr --rox /etc --rw /dev/null -- bash -c 'curl -sS --max-time 8 https://example.com >/dev/null' >/dev/null 2>&1; net=$?
+          set -e
+          echo "self-test: run=$ok write=$wr shm=$shm net=$net (nonzero = denied for w/shm/net)"
+          if [ $ok -ne 0 ] || [ $wr -eq 0 ] || [ $shm -eq 0 ] || [ $net -eq 0 ]; then
+            echo "::error::landrun not enforcing (run=$ok write=$wr shm=$shm net=$net); refusing to run code under it"; exit 1
+          fi
+
+      # The same trusted read-only wrapper pr-build.yml uses: it routes every compiler process
+      # through a wall-clock watchdog, so one pathological module cannot burn the job's whole
+      # budget. sandbox-build.sh requires it.
+      - name: Prepare trusted read-only Lean watchdog toolchain
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.elan/bin:$PATH"
+          real_lean=$(elan which lean)
+          watchdog="$RUNNER_TEMP/lean-watchdog-toolchain"
+          bash scripts/perf/prepare-watchdog-toolchain.sh "$watchdog" "$real_lean"
+          echo "WATCHDOG_TOOLCHAIN=$watchdog" >> "$GITHUB_ENV"
+
       # No aggregator check: the root TauCeti.lean is intentionally empty and imports nothing.
       # The build globs every TauCeti/ module directly, so nothing depends on a root that
       # re-exports the library.
-      - name: Build
+      #
+      # The build, both audits and both elaborating lints now come from scripts/sandbox-build.sh,
+      # the very script pr-build.yml runs for PR sources, under the same sandbox: offline, writes
+      # confined to .lake, and $GITHUB_ENV, $GITHUB_PATH, $HOME and $RUNNER_TEMP all outside the
+      # mount set, so nothing elaborated here can steer a later step of this job. That is what the
+      # staging step below relies on to be worth trusting at all.
+      #
+      # Sharing the script also makes main and the merge gate enforce identically, which brings
+      # `--iofail` (fail on any info-level diagnostic) and the watchdog deadline to main. For a
+      # TauCeti-only commit that changes nothing: it arrived through a merge-group pr-build which
+      # already applied both to the same tree, on the same runner image. A human-merged
+      # infrastructure commit skips the queue, so it is the one case where this could newly go
+      # red, which is the correct direction for a check to be wrong in.
+      # The dependency Lake configs, recorded before anything elaborates. $RUNNER_TEMP is
+      # outside every sandbox here, so what lands in it cannot be rewritten from inside one.
+      - name: Record the dependency Lake configs
+        run: |
+          set -euo pipefail
+          bash scripts/hash-dep-configs.sh > "$RUNNER_TEMP/dep-configs.before"
+          echo "recorded $(wc -l < "$RUNNER_TEMP/dep-configs.before") dependency config files"
+
+      - name: Build, audit and lint under landrun, offline
         env:
-          # Restore only from the locally-populated $LAKE_CACHE_DIR the step above filled;
-          # never let the build itself reach a remote cache service. Same rule as the
-          # sandboxed build in pr-build.yml and as the publish step below.
+          # Restore only from the locally-populated $LAKE_CACHE_DIR the fetch step filled; never
+          # let the build itself reach a remote cache service. The sandbox is offline regardless.
           LAKE_NO_CACHE: "true"
-        run: lake build
+        run: |
+          set -euo pipefail
+          # Created out here: landrun errors on a mount path that does not exist, and the
+          # sandbox cannot create its own writable roots.
+          mkdir -p .lake/tmp
+          export PATH="$HOME/.local/bin:$HOME/.elan/bin:$PATH"
+          # `.lake` is granted as a whole, deliberately, and after trying not to. Keeping
+          # `.lake/packages` read-only would protect the dependencies' Lake configs, which
+          # configuring the workspace elaborates. It is not achievable: Lake writes a `.hash`
+          # sidecar next to every traced input, and those are scattered through the package
+          # sources rather than confined to build directories. A dry run failed on
+          # `.lake/packages/proofwidgets/widget/package-lock.json.hash`. Carving a read-only hole
+          # inside a `--rw` does not work either: Landlock unions permissions, so a nested
+          # `--rox` grants nothing back, verified against the pinned binary in both orderings.
+          #
+          # What stands in its place is an ordering invariant, stated precisely because the loose
+          # version is false: every workspace-configuring `lake` invocation AFTER untrusted
+          # elaboration begins is sandboxed. Three run unrestricted before it, and only before it,
+          # against the checked-out root config and freshly fetched pinned dependencies:
+          # `lake exe cache get`, `lake exe cache clean`, and the `lake cache get` inside
+          # scripts/lake-cache-get.sh. The dependency-config tripwire after the build is a canary
+          # for crude edits, not an integrity boundary, and cannot license adding a fourth.
+          landrun --rox /usr --rox /etc \
+            --rw /dev/null --rox /dev/zero --rox /dev/urandom --rox /dev/random \
+            --rox "$HOME/.elan" --rox "$WATCHDOG_TOOLCHAIN" \
+            --rox "$PWD" \
+            --rw "$PWD/.lake" \
+            --env PATH --env HOME --env CI \
+            --env LAKE_NO_CACHE --env LAKE_ARTIFACT_CACHE --env LAKE_RESTORE_ARTIFACTS --env LAKE_CACHE_DIR \
+            --env WATCHDOG_TOOLCHAIN \
+            -- bash -euxo pipefail -c 'exec bash scripts/sandbox-build.sh'
 
-      # Main is the sole publisher. PR and merge-group builds restore these trusted snapshots
-      # but never save, so candidate code cannot populate a cache consumed by later builds.
-      # GitHub cache keys are immutable; an exact restore needs no redundant save, while a
-      # prefix restore is extended with the newly downloaded hashes under the exact current key.
-      # Pruning is essential: without it, every prefix restore would carry all old pins forward
-      # and each immutable snapshot would grow monotonically. If pruning itself breaks, leave main
-      # green but skip publication rather than saving an unbounded snapshot.
-      - name: Prune Mathlib's download cache to the current pin
-        id: mathlib_ltar_prune
-        if: ${{ steps.mathlib_ltar_restore.outputs.cache-hit != 'true' }}
-        continue-on-error: true
-        run: lake exe cache clean
 
-      - name: Save Mathlib's compressed download cache
-        if: ${{ steps.mathlib_ltar_restore.outputs.cache-hit != 'true' && steps.mathlib_ltar_prune.outcome == 'success' }}
-        continue-on-error: true
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ steps.mathlib_ltar_restore.outputs.cache-dir }}/*.ltar
-          key: ${{ steps.mathlib_ltar_restore.outputs.cache-primary-key }}
-
-      # Axiom audit (replaces the old textual no-sorry grep). Inspects the built
-      # TauCeti environment and rejects any axiom outside {propext, Classical.choice,
-      # Quot.sound}, catching sorry/admit (sorryAx), native_decide (Lean.ofReduceBool),
-      # and home-rolled axioms, including ones reaching in through imports.
-      - name: Axiom audit (TauCeti/ uses only allowlisted axioms)
-        env:
-          LAKE_NO_CACHE: "true"
-        run: lake exe axioms
-
-      # Module-system audit. Inspects the built TauCeti `.olean`s and rejects any module that
-      # did not opt into the Lean module system (a leading `module`). It reads each module's
-      # `ModuleData.isModule` flag from the compiled artifact, so it cannot be fooled by a
-      # `module` appearing in a comment or string the way a textual grep could.
-      - name: Module-system audit (every TauCeti/ file opts into `module`)
-        env:
-          LAKE_NO_CACHE: "true"
-        run: lake exe module-system
-
-      # Environment lint. Elaborates a generated driver importing every TauCeti/
-      # module and runs Mathlib's default `#lint` set minus docBlame (simpNF,
-      # checkType, synTaut, ...) plus a module-system-reliable docstring scan (the
-      # docBlame linter is blind across module boundaries; see the script header),
-      # comparing linter-qualified violations against the grandfathered baseline in
-      # scripts/lint-baseline.txt: new violations fail, fixed baseline entries print
-      # a ratchet reminder. `@[nolint <linter>]` applications must be accounted for
-      # in scripts/lint-nolints-allowlist.txt, per (linter, declaration) pair.
-      # PR-time enforcement runs inside the
-      # landrun sandbox in pr-build.yml (this lint executes the linted code); this
-      # post-merge run is the health check on main, like the audits above.
-      - name: Environment lint (default linters + docstring scan vs grandfathered baseline)
-        env:
-          LAKE_NO_CACHE: "true"
-        run: bash scripts/lint-env.sh
-
-      - name: Dot-notation namespace lint (Mathlib type namespaces stay at root)
-        run: python3 scripts/lint-dot-notation.py
-
-      # Source style lint. The wrapper validates one complete TauCeti/** source list, applies
-      # Mathlib's copyright/Authors checks directly (the empty TauCeti.lean root is exempt), and
-      # generates an import-all module under .lake/ for lint-style's text-based checks. This is
-      # deliberately narrower than the command header linter's unrelated import and module-doc
-      # checks; the empty root makes that command linter skip every library module at this pin.
-      - name: Source style lint (copyright headers + text linters)
-        run: bash scripts/lint-style.sh
+      # The axiom audit, the module-system audit, the environment lint and the source style lint
+      # all moved into the sandboxed run above: each of them elaborates or executes TauCeti code,
+      # so each belongs inside landrun rather than beside it. scripts/sandbox-build.sh is where
+      # they live now, and it is the same file pr-build.yml runs, so main and the merge gate
+      # cannot drift on which checks a commit has to pass.
+      #
+      # This one stays outside on purpose: it is a textual scan of the sources that neither
+      # elaborates nor executes them, exactly as in pr-build.yml.
+      # A tripwire, not an integrity boundary, and worth naming as such. `.lake` has to be
+      # writable for Lake to trace at all, so an elaborating module can reach the dependency
+      # configs. This catches a crude persistent edit to one of the config files the manifest
+      # names. It does NOT catch a poisoned cached `lakefile.olean`, a helper `.lean` imported by
+      # a lakefile, or a modify-run-restore sequence, and it says nothing about what a detached
+      # child does after it runs. It exists so that a future unsandboxed `lake` added to this job
+      # fails noisily rather than inheriting the problem in silence; it is not permission to add
+      # one. It runs again after staging for the same reason.
+      - name: Check the dependency Lake configs were not modified
+        run: |
+          set -euo pipefail
+          bash scripts/hash-dep-configs.sh > "$RUNNER_TEMP/dep-configs.after"
+          if ! diff -u "$RUNNER_TEMP/dep-configs.before" "$RUNNER_TEMP/dep-configs.after"; then
+            echo "::error::a dependency's Lake config changed during the sandboxed build; configuring the workspace elaborates these, so treat this as code trying to leave the sandbox"
+            exit 1
+          fi
+          echo "dependency Lake configs unchanged"
 
       # --- Lake artifact-cache publish (dormant until configured) ---------------------
       # Publish TauCeti's OWN oleans (root-package only) to the Lake cache, so pr-build can
@@ -251,16 +362,17 @@ jobs:
       # Mathlib stays on `lake exe cache get`. See pr-build.yml for the consuming side.
       #
       # The upload is split across two jobs, and the split is the security boundary rather
-      # than a convenience. THIS job runs `lake build` unsandboxed, as the runner user, on
-      # whatever landed on main, and Lean executes code at elaboration time: `run_cmd`,
-      # `initialize` and macro-time IO are all unrestricted, since the scope, import-boundary
-      # and set_option guards are textual scans. Such code can therefore rewrite
-      # `$HOME/.elan/bin/lake`, prepend a directory of its own to every later step's PATH
-      # through `$GITHUB_PATH`, or set LD_PRELOAD or BASH_ENV for every later step through
-      # `$GITHUB_ENV`. A secret given to any later step of this job is a secret given to code
-      # that landed on main, whatever that step does with it. So this job only stages the
-      # artifacts, and publish-lake-cache below, a fresh runner with no checkout, no
-      # workspace and no project code, is the only place the key exists.
+      # than a convenience. THIS job elaborates whatever landed on main, and Lean executes code
+      # at elaboration time: `run_cmd`, `initialize` and macro-time IO are all unrestricted,
+      # since the scope, import-boundary and set_option guards are textual scans. That
+      # elaboration is now confined to landrun, so it can no longer rewrite `$HOME/.elan/bin/lake`
+      # or reach `$GITHUB_PATH` and `$GITHUB_ENV` to set PATH, LD_PRELOAD or BASH_ENV for later
+      # steps. It can still write all of `.lake`, and landrun confines a process tree rather than
+      # ending it, so a detached child may keep writing there after the sandbox returns. The
+      # staged tree is therefore hostile input on both sides of the job boundary, and a secret
+      # given to any later step of this job would still be a secret handed to code that landed on
+      # main. So this job only stages the artifacts, and publish-lake-cache below, a fresh runner
+      # with no checkout, no workspace and no project code, is the only place the key exists.
       - name: Configure the Lake cache staging (no-op unless the S3 endpoints are set)
         id: cachecfg
         env:
@@ -278,39 +390,62 @@ jobs:
             echo "::notice::Lake cache upload not configured, skipping (set the LAKE_CACHE_ARTIFACT_ENDPOINT / LAKE_CACHE_REVISION_ENDPOINT repo variables and the LAKE_CACHE_KEY secret to enable)"
           fi
 
-      - name: Stage TauCeti's oleans for the publish job
-        id: stage
+      # Inside landrun, like the build, and for the same reason: every `lake` invocation
+      # configures the workspace, and configuring elaborates each dependency's Lake config. At
+      # least one of those is a lakefile.lean under .lake/packages, which the sandboxed build can
+      # write. Packing outside the sandbox would hand whatever was left there to an unrestricted
+      # runner with $GITHUB_ENV, $GITHUB_PATH, $RUNNER_TEMP and the network in reach, which would
+      # give back everything sandboxing the build just bought. The staged tree therefore lands
+      # under .lake and is read out by the trusted step below.
+      - name: Stage TauCeti's oleans under landrun, offline
         if: ${{ steps.cachecfg.outputs.enabled == 'true' }}
         env:
           # Restated at step level, and the same values the restore step sets job-wide when the
           # public endpoints are configured, so staging works either way: with the restore on,
-          # the health-check build already packed these artifacts; with it off, the pack below
-          # is what puts them in the cache directory for `lake cache stage` to find.
+          # the build already packed these artifacts; with it off, the pack inside is what puts
+          # them in the cache directory for `lake cache stage` to find.
           LAKE_ARTIFACT_CACHE: "true"
           LAKE_RESTORE_ARTIFACTS: "true"
-          # Don't download during the packing build — we only want to PUT, not GET. (The
-          # S3 host needs SigV4 even for reads, so an anonymous GET here would 403 anyway.)
+          # Only PUT later, never GET here. (The S3 host needs SigV4 even for reads, so an
+          # anonymous GET would 403 anyway.) The sandbox is offline regardless.
           LAKE_NO_CACHE: "true"
           LAKE_CACHE_DIR: ${{ github.workspace }}/.lake/cache
         run: |
-          # Pack the already-built oleans into the local Lake cache (no recompile, since the
-          # health-check build above left matching traces), emit the root-package
-          # input->output mappings, then copy exactly the artifacts those mappings name into
-          # a staging directory, alongside a copy of the mappings themselves. `lake cache
-          # stage` reads no credential and contacts no network.
-          lake build >/dev/null
-          lake build --no-build -o .lake/outputs.jsonl
-          echo "root-package mapping entries: $(wc -l < .lake/outputs.jsonl)"
-          lake cache stage .lake/outputs.jsonl "$RUNNER_TEMP/lake-cache-staging"
+          set -euo pipefail
+          rm -rf .lake/staging && mkdir -p .lake/staging
+          export PATH="$HOME/.local/bin:$HOME/.elan/bin:$PATH"
+          # Same narrowing as the build, plus one writable directory of its own for the staged
+          # tree, so nothing here needs `.lake` as a whole either.
+          landrun --rox /usr --rox /etc \
+            --rw /dev/null --rox /dev/zero --rox /dev/urandom --rox /dev/random \
+            --rox "$HOME/.elan" --rox "$WATCHDOG_TOOLCHAIN" \
+            --rox "$PWD" \
+            --rw "$PWD/.lake" \
+            --env PATH --env HOME --env CI \
+            --env LAKE_NO_CACHE --env LAKE_ARTIFACT_CACHE --env LAKE_RESTORE_ARTIFACTS --env LAKE_CACHE_DIR \
+            --env WATCHDOG_TOOLCHAIN \
+            -- bash -euxo pipefail -c 'exec bash scripts/stage-lake-cache.sh'
+
+      # Trusted, and touches no `lake`. lakefile.toml sits outside the sandbox's writable mount,
+      # so these two checks read what the repository actually says. Everything from .lake is
+      # attacker-choosable and is treated that way: the tree itself is validated by
+      # publish-lake-cache before Lake sees it, and the toolchain string is pattern-checked here
+      # before it can reach $GITHUB_OUTPUT, since a newline in it would let staged code inject
+      # further step outputs.
+      - name: Read the staged tree and report it to the publish job
+        id: stage
+        if: ${{ steps.cachecfg.outputs.enabled == 'true' }}
+        run: |
+          set -euo pipefail
           # `lake cache put-staged` does not configure the workspace, which is precisely what
           # keeps project code out of the publish job, so it cannot derive the toolchain and
           # platform halves of the upload scope. The publish job supplies them from the pin
           # instead, which is right only while the package config keeps the two assumptions
-          # below. Check them here, where the workspace does exist: `platformIndependent` is
-          # what makes Lake leave the platform out of the scope (put-staged's default), while
-          # `fixedToolchain` or `bootstrap` would make Lake leave the toolchain out of it (which
-          # put-staged is told to include). Either silent mismatch would publish under a scope
-          # pr-build's `lake cache get --service ... --repo` never reads, i.e. a cache never hit.
+          # below. `platformIndependent` is what makes Lake leave the platform out of the scope
+          # (put-staged's default), while `fixedToolchain` or `bootstrap` would make Lake leave
+          # the toolchain out of it (which put-staged is told to include). Either silent mismatch
+          # would publish under a scope pr-build's `lake cache get --service ... --repo` never
+          # reads, i.e. a cache never hit.
           if ! grep -Eq '^[[:space:]]*platformIndependent[[:space:]]*=[[:space:]]*true' lakefile.toml; then
             echo "::error::lakefile.toml no longer sets platformIndependent = true; publish-lake-cache must now pass --platform to lake cache put-staged"
             exit 1
@@ -319,24 +454,58 @@ jobs:
             echo "::error::lakefile.toml now sets fixedToolchain or bootstrap; Lake drops the toolchain from the scope for such a package, so publish-lake-cache must stop passing --toolchain"
             exit 1
           fi
-          # `lake env` reports the workspace's own view of the toolchain, which is exactly the
-          # `Env.toolchain` Lake scopes an upload by. The publish job does not take this on
-          # faith: it reads lean-toolchain itself and fails if the two disagree. Reporting it
-          # anyway turns a disagreement into a loud failure instead of a silent wrong scope.
-          TOOLCHAIN="$(lake env printenv ELAN_TOOLCHAIN || true)"
-          if [ -z "$TOOLCHAIN" ]; then
-            echo "::error::could not determine the Lean toolchain that scopes the cache upload"
+          # The staged tree comes out of the sandbox, so it is hostile input here and not only
+          # in publish-lake-cache. Validate shape and size BEFORE anything follows a path in it:
+          # a FIFO or a device left in place of a file would otherwise block a read for the rest
+          # of the job, and a symlink would be followed out of the tree.
+          STAGING=.lake/staging/cache-staging
+          if find "$STAGING" -mindepth 2 -print -quit | grep -q .; then
+            echo "::error::the staged tree is nested; expected a flat directory of artifacts"
+            exit 1
+          fi
+          if find "$STAGING" -mindepth 1 ! -type f -print -quit | grep -q .; then
+            echo "::error::the staged tree holds an entry that is not a regular file"
+            exit 1
+          fi
+          entries=$(find "$STAGING" -mindepth 1 -type f | wc -l)
+          bytes=$(du -sb "$STAGING" | cut -f1)
+          echo "staged $entries files, $bytes bytes"
+          # Roughly thirty times the observed normal output, so this bounds a runaway without
+          # tripping on ordinary growth.
+          if [ "$entries" -gt 50000 ] || [ "$bytes" -gt 2147483648 ]; then
+            echo "::error::the staged tree is implausibly large ($entries files, $bytes bytes)"
+            exit 1
+          fi
+          if [ ! -s "$STAGING/outputs.jsonl" ]; then
+            echo "::error::the sandboxed staging step produced no mappings"
+            exit 1
+          fi
+          # Read defensively before reading at all: this path is attacker-choosable, so a FIFO
+          # or a device node here would make an ordinary `head` block until the job timeout, and a
+          # symlink would be followed out of the tree. Require a small regular file, then take the
+          # first line of a bounded read. The publish job still cross-checks the value against the
+          # lean-toolchain pin it reads for itself; this is about what may enter $GITHUB_OUTPUT.
+          TC=.lake/staging/toolchain.txt
+          if [ -L "$TC" ] || [ ! -f "$TC" ] || [ "$(stat -c %s "$TC")" -gt 4096 ]; then
+            echo "::error::the staged toolchain file is missing, not a regular file, or too large"
+            exit 1
+          fi
+          TOOLCHAIN="$(head -c 200 "$TC" | head -n 1)"
+          if ! printf '%s' "$TOOLCHAIN" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._:+/-]{0,99}$'; then
+            echo "::error::the staged toolchain string is missing or not a plain toolchain name"
             exit 1
           fi
           printf 'toolchain=%s\n' "$TOOLCHAIN" >> "$GITHUB_OUTPUT"
           echo "staged=true" >> "$GITHUB_OUTPUT"
+
 
       - name: Hand the staged oleans to the publish job
         if: ${{ steps.stage.outputs.staged == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: lake-cache-staging
-          path: ${{ runner.temp }}/lake-cache-staging
+          # Under .lake, because the sandboxed staging step could not write anywhere else.
+          path: .lake/staging/cache-staging
           if-no-files-found: error
           # Long enough to inspect a failed publish, short enough not to accumulate a
           # 60 MB artifact per push to main.

--- a/scripts/hash-dep-configs.sh
+++ b/scripts/hash-dep-configs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# hash-dep-configs.sh — checksum the Lake config of every dependency, for the tripwire in ci.yml.
+#
+# The filenames come from lake-manifest.json's `configFile` for each package rather than a
+# `lakefile.*` glob, so a dependency naming its config something else is still covered. The
+# manifest itself is checked too: rewriting it to point at a different config would otherwise move
+# the tripwire rather than trip it. It is a repository file, outside the sandbox's writable mount.
+#
+# This is a canary for crude persistent edits. It cannot see a poisoned compiled config, a helper
+# imported by a lakefile, or a modify-run-restore sequence. ci.yml says so where it is used.
+#
+# Prints "<sha256>  <path>" per existing file, sorted by path. Paths that do not exist are skipped
+# rather than failing: a dependency's lakefile.olean is absent until something compiles it, and
+# their appearance or disappearance is itself a difference the caller's diff will show.
+set -euo pipefail
+
+configs() {
+  python3 - <<'PY'
+import json
+
+manifest = json.load(open("lake-manifest.json"))
+for pkg in manifest.get("packages", []):
+    name = pkg.get("name")
+    if not name:
+        continue
+    # `configFile` is optional; Lake's own default applies when it is absent.
+    config = pkg.get("configFile") or "lakefile.toml"
+    print(f".lake/packages/{name}/{config}")
+    # The compiled form, which Lake elaborates in preference to the source when it is current.
+    print(f".lake/packages/{name}/.lake/lakefile.olean")
+PY
+}
+
+{
+  sha256sum lake-manifest.json
+  # A plain `if`, never `[ -e "$rel" ] && sha256sum "$rel"`. Under `set -e` a loop takes the exit
+  # status of its final iteration, so the `&&` form aborts the whole script whenever the last path
+  # happens not to exist, which is precisely what an uncompiled lakefile.olean does.
+  while IFS= read -r rel; do
+    if [ -e "$rel" ]; then
+      sha256sum "$rel"
+    fi
+  done < <(configs)
+} | sort -k2

--- a/scripts/sandbox-build.sh
+++ b/scripts/sandbox-build.sh
@@ -14,7 +14,9 @@
 # so this script cannot be swapped out to escape the sandbox, even though it elaborates
 # the PR's (untrusted) TauCeti/ code, which is the whole reason it runs under landrun.
 #
-# cwd on entry is the trusted `base` checkout, with the PR's TauCeti/ already overlaid.
+# cwd on entry is the workspace to check. pr-build.yml runs this in the trusted `base` checkout
+# with the PR's TauCeti/ overlaid; ci.yml runs it in main's own checkout after a merge. Every path
+# below is relative to that cwd, so nothing here depends on which caller it is.
 set -euxo pipefail
 
 export TMPDIR="$PWD/.lake/tmp"

--- a/scripts/stage-lake-cache.sh
+++ b/scripts/stage-lake-cache.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# stage-lake-cache.sh — pack main's freshly built oleans and lay them out for the publish job.
+#
+# Runs INSIDE landrun, for the same reason the build does. Every `lake` invocation configures
+# the workspace, and configuring elaborates each dependency's Lake config; at least one of them
+# is a `lakefile.lean`, living under `.lake/packages`, which the sandboxed build can write. A
+# `lake` run outside the sandbox would therefore elaborate whatever was left there, as the
+# unrestricted runner user with $GITHUB_ENV, $GITHUB_PATH, $RUNNER_TEMP and the network in
+# reach. Nothing in this file may move back out of the sandbox for that reason alone.
+#
+# Everything it produces lands under `.lake/staging`, the one writable directory this call is
+# given beyond the build's own, and
+# is therefore attacker-choosable: publish-lake-cache validates the staged tree before pointing
+# Lake at it, and cross-checks the toolchain below against the `lean-toolchain` pin it reads for
+# itself. Neither is a formality.
+#
+# cwd on entry is the workspace root. ci.yml is the only caller.
+set -euxo pipefail
+
+export TMPDIR="$PWD/.lake/tmp"
+
+# Same watchdog wrapper the build used. Not for safety here, but so Lake sees the identical
+# compiler and its traces still match: a different LEAN would make the packing build below
+# recompile the library rather than pack it.
+test -n "${WATCHDOG_TOOLCHAIN:-}"
+test -x "$WATCHDOG_TOOLCHAIN/bin/lean"
+export LAKE_OVERRIDE_LEAN=true
+export LEAN="$WATCHDOG_TOOLCHAIN/bin/lean"
+
+# Pack the already-built oleans into the local Lake cache. No recompile: the build left matching
+# traces. Then emit the root-package input-to-output mappings and copy exactly the artifacts
+# those mappings name into a staging directory beside them. `lake cache stage` reads no
+# credential and contacts no network.
+lake build >/dev/null
+lake build --no-build -o .lake/staging/outputs.jsonl
+echo "root-package mapping entries: $(wc -l < .lake/staging/outputs.jsonl)"
+lake cache stage .lake/staging/outputs.jsonl .lake/staging/cache-staging
+
+# `lake env` reports the workspace's own view of the toolchain, which is exactly the
+# `Env.toolchain` Lake scopes an upload by. Recording it lets publish-lake-cache turn a
+# disagreement with the `lean-toolchain` pin into a loud failure instead of a silently wrong
+# upload scope. It reads this as untrusted input, which is the point: a wrong value fails that
+# job rather than steering it.
+lake env printenv ELAN_TOOLCHAIN > .lake/staging/toolchain.txt

--- a/scripts/test_landrun_pin.py
+++ b/scripts/test_landrun_pin.py
@@ -2,14 +2,20 @@
 
 Run with: python3 scripts/test_landrun_pin.py
 
-pr-build.yml sandboxes untrusted PR sources; nightly-verify.yml sandboxes a cache-restored
-build that imports the artifacts it is judging. Both pin the landrun release and its SHA-256,
-and both would be weakened by trusting a different binary than the other.
+Four workflows sandbox with landrun: pr-build.yml around untrusted PR sources, ci.yml around
+main's own build and its cache staging, nightly-verify.yml around a cache-restored build that
+imports the artifacts it is judging, and pr-profile.yml around its measurements. Each pins a
+landrun release and its SHA-256, and each would be weakened by trusting a different binary than
+the others.
 
 The pin is deliberately duplicated rather than shared through a composite action: pr-build.yml
 sits on the merge queue's critical path and runs from the base definition under
-pull_request_target, so a shared action could not be exercised by the PR that introduced it.
-This test is what stops the copies drifting.
+pull_request_target, so a shared action could not be exercised by the PR that introduced it and a
+mistake in it would redden every PR build. This test is what stops the copies drifting.
+
+The set of workflows is DISCOVERED rather than listed, so a fifth one cannot be added without
+being covered, and the canary below keeps the four we know about from dropping out of the set
+unnoticed. A workflow counts as sandboxing if `landrun` appears in it outside a comment.
 """
 
 import pathlib
@@ -17,36 +23,55 @@ import re
 import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
-WORKFLOWS = (
-    ROOT / ".github/workflows/pr-build.yml",
-    ROOT / ".github/workflows/nightly-verify.yml",
-)
+WORKFLOW_DIR = ROOT / ".github/workflows"
+
+# Any `landrun` token on a line that is not a comment. Deliberately broad and fail-closed:
+# matching only commands at the start of a line would let `exec landrun`, `( landrun ... )`,
+# `if landrun ...` or a variable-prefixed invocation add a fifth sandboxing workflow that this
+# test silently did not cover. A false positive costs a pin declaration; a false negative costs
+# the guarantee.
+INVOKES = re.compile(r"^(?!\s*#).*\blandrun\b", re.MULTILINE)
 SHA = re.compile(r"^\s*LANDRUN_SHA256:\s*([0-9a-f]{64})\s*$", re.MULTILINE)
 VER = re.compile(r"^\s*LANDRUN_VER:\s*(v[0-9][0-9A-Za-z.\-]*)\s*$", re.MULTILINE)
+VERIFIES = 'echo "${LANDRUN_SHA256}  landrun" | sha256sum -c -'
+
+
+def sandboxing_workflows():
+    return sorted(
+        (w for w in WORKFLOW_DIR.glob("*.yml") if INVOKES.search(w.read_text())),
+        key=lambda w: w.name,
+    )
 
 
 class LandrunPin(unittest.TestCase):
+    def test_the_discovery_finds_the_workflows_we_know_about(self):
+        # A canary: if landrun sandboxing is removed from one of these, or the invocation is
+        # reworded past the pattern above, the rest of this file would silently stop checking it.
+        found = {w.name for w in sandboxing_workflows()}
+        self.assertLessEqual(
+            {"pr-build.yml", "ci.yml", "nightly-verify.yml", "pr-profile.yml"}, found,
+            f"a workflow that used to run landrun no longer appears to; found {sorted(found)}",
+        )
+
     def test_every_sandboxing_workflow_pins_the_same_landrun(self):
         seen = {}
-        for workflow in WORKFLOWS:
+        for workflow in sandboxing_workflows():
             text = workflow.read_text()
             shas, vers = SHA.findall(text), VER.findall(text)
             self.assertEqual(len(shas), 1, f"expected one LANDRUN_SHA256 in {workflow.name}")
             self.assertEqual(len(vers), 1, f"expected one LANDRUN_VER in {workflow.name}")
             seen[workflow.name] = (vers[0], shas[0])
-        distinct = set(seen.values())
         self.assertEqual(
-            len(distinct), 1,
+            len(set(seen.values())), 1,
             "workflows disagree on which landrun to trust: "
             + ", ".join(f"{name} pins {ver} {sha}" for name, (ver, sha) in sorted(seen.items())),
         )
 
     def test_every_sandboxing_workflow_verifies_the_checksum(self):
         # A pin that is downloaded but never checked is not a pin.
-        for workflow in WORKFLOWS:
+        for workflow in sandboxing_workflows():
             with self.subTest(workflow=workflow.name):
-                self.assertIn('echo "${LANDRUN_SHA256}  landrun" | sha256sum -c -',
-                              workflow.read_text())
+                self.assertIn(VERIFIES, workflow.read_text())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR runs main's build, both audits, both elaborating lints and the cache staging inside the landrun sandbox, and moves everything that reads or configures the Lake workspace ahead of them.

Until now `ci.yml` elaborated every TauCeti module unsandboxed. Lean executes code at elaboration time and the repository restricts only `set_option` at source level, so `run_cmd`, `initialize` and macro-time IO are all available to whatever landed on main: a `run_cmd` doing `IO.FS.writeFile` writes its file, exits 0, and emits no diagnostic, so `--iofail` passes it. That code could write anywhere on the runner, reach the network, and append to `$GITHUB_ENV` and `$GITHUB_PATH` to steer the steps that follow it. https://github.com/TauCetiProject/TauCeti/pull/3722 removed the valuable target by moving the upload credential into a job that runs no project code; this removes the capability.

Sandboxing the build alone is not enough, which is the shape of the change. landrun must give the build write access to `.lake`, and that includes `.lake/packages`, where the dependencies keep their Lake configs. Every `lake` invocation configures the workspace, and configuring elaborates those configs. So a `lake` run after the sandbox would elaborate whatever the sandboxed build chose to leave there, as the unrestricted runner user with `$GITHUB_ENV`, `$GITHUB_PATH`, `$RUNNER_TEMP` and the network in reach. Every such invocation therefore moves to one side or the other:

- `lake exe cache clean` and the `.ltar` save move **before** the build, where the tree is still the repository's. Nothing between there and the build needs the pruned store.
- The dot-notation lint moves before it too, matching `pr-build.yml`. It derives Mathlib's namespaces from `.lake/packages/mathlib`; run afterwards, an elaborating module could edit those sources so the lint stops recognising the namespace that would have caught it.
- The staging sequence moves **inside**, as `scripts/stage-lake-cache.sh`, writing under `.lake/staging`. What remains outside runs no `lake` at all: it greps `lakefile.toml`, which is outside the writable mount, and reads the staged tree.

Making `.lake/packages` read-only would have been the stronger fix, and it is not available. Two dry runs established why. Denying `.lake` and granting only `build`, `cache` and `tmp` fails across every dependency with `failed to cache artifact: permission denied`; adding one `--rw` per dependency build directory still fails, on `.lake/packages/proofwidgets/widget/package-lock.json.hash`. Lake writes a `.hash` sidecar next to every traced input, and those are scattered through the package sources rather than confined to build directories, so the set to exempt is open-ended and would move under us on any bump. Carving is independently impossible: Landlock unions permissions, so a `--rox` nested inside a `--rw` grants nothing back, verified against the pinned binary in both orderings.

So this settles for detection where prevention was not available. A trusted step records `sha256sum` of every dependency `lakefile.*` into `$RUNNER_TEMP`, which is outside every sandbox here, before anything elaborates, and re-checks it afterwards. Nothing in this job would run a doctored config, because every `lake` here is sandboxed; the check is what stops a step added later inheriting the problem silently.

Everything crossing back out of the sandbox is treated as chosen by whatever was elaborated. `publish-lake-cache` already validates the staged tree before pointing Lake at it. The toolchain string is now pattern-checked before it can reach `$GITHUB_OUTPUT`, because that file is `key=value` lines and a newline in the value would let staged code inject further step outputs; the publish job still cross-checks it against the `lean-toolchain` pin it reads for itself.

Sharing `scripts/sandbox-build.sh` with `pr-build.yml` means main and the merge gate can no longer drift on which checks a commit must pass, and brings `--iofail` and the per-module watchdog deadline to main. For a TauCeti-only commit that changes nothing, since it arrived through a merge-group `pr-build` that already applied both to the same tree; the runner image is pinned to `ubuntu-24.04` to match, because the watchdog deadline is wall-clock. A human-merged infrastructure commit skips the queue, so it is the one case where this could newly go red, which is the correct direction for a check to be wrong in.

`ci.yml` only runs on push to main, so none of this is exercised by this PR's own build. It was validated instead on a scratch branch carrying the same workflow with its trigger repointed, its own concurrency group, and `publish-lake-cache` disabled so it could not reach the bucket. The passing run built, audited and linted inside the sandbox (`lint-env` over 2569 modules, `lint-style`, both audits), recorded and re-verified 11 dependency configs, staged 2571 mappings and uploaded them, in 13 minutes.

Two things this does not claim. `lake exe cache get` stays unsandboxed with network, as in `pr-build.yml`, since it runs Mathlib's own `cache` executable under the project's track-master policy, so "main's build is sandboxed" is true of TauCeti's code rather than of every process in the job. And landrun's network rules come from Landlock's TCP rights, so "offline" denies classic TCP, which the self-test probes, but not UDP; filesystem confinement is the property this change rests on.

The landrun pin is duplicated rather than shared through a composite action, because `pr-build.yml` is on the merge queue's critical path and runs from the base definition under `pull_request_target`, so an action introduced here could not be exercised by this PR and a mistake in it would redden every PR build. `scripts/test_landrun_pin.py` now discovers the sandboxing workflows instead of listing them, so a fifth cannot be added without being covered; it caught that `pr-profile.yml` was already pinning landrun independently.

Roadmap: none

🤖 Prepared with Claude Code