### PR TITLE
feat: represent the component group quotient

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Basic.lean
@@ -93,7 +93,8 @@ noncomputable abbrev componentGroupFppfSheaf (H : FiniteTypeCommHopfAlgCat.{u, u
     (isNormal_identityComponentHopfIdeal H)
 
 /-- The canonical morphism from the fppf sheaf of points of `H` to its component group sheaf. -/
-noncomputable def componentGroupFppfProjection (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+@[expose] noncomputable def componentGroupFppfProjection
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     CommHopfAlgCat.pointsFppfGroupObject H.obj ⟶ componentGroupFppfSheaf H :=
   CommHopfAlgCat.fppfQuotientProjection H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Basic.lean
@@ -93,12 +93,20 @@ noncomputable abbrev componentGroupFppfSheaf (H : FiniteTypeCommHopfAlgCat.{u, u
     (isNormal_identityComponentHopfIdeal H)
 
 /-- The canonical morphism from the fppf sheaf of points of `H` to its component group sheaf. -/
-@[expose] noncomputable def componentGroupFppfProjection
+noncomputable def componentGroupFppfProjection
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     CommHopfAlgCat.pointsFppfGroupObject H.obj ⟶ componentGroupFppfSheaf H :=
   CommHopfAlgCat.fppfQuotientProjection H.obj
     (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
     (isNormal_identityComponentHopfIdeal H)
+
+/-- The component-group projection is the fppf quotient projection by the identity component. -/
+theorem componentGroupFppfProjection_def (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupFppfProjection H =
+      CommHopfAlgCat.fppfQuotientProjection H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) := by
+  rw [componentGroupFppfProjection.eq_1]
 
 /-- The projection to the component group is an epimorphism of group objects in fppf sheaves. -/
 instance instEpiComponentGroupFppfProjection (H : FiniteTypeCommHopfAlgCat.{u, u} k) :

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -600,14 +600,7 @@ private theorem pointwiseQuotientPresheafGrpProjection_comp_componentIso_hom
         (Functor.whiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
           (CommHopfAlgCat.mapPointsFunctor (componentCoordinateHom H)))
         GrpCat.uliftFunctor.{u + 1, u}) := by
-    rw [show (CommHopfAlgCat.groupFunctorGrpIso (Functor.isoWhiskerRight
-      (Functor.isoWhiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
-        (componentPointwiseQuotientNatIso H))
-      GrpCat.uliftFunctor.{u + 1, u})).hom =
-        CommHopfAlgCat.groupFunctorGrpMap (Functor.whiskerRight
-          (Functor.whiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
-            (componentPointwiseQuotientNatIso H).hom)
-          GrpCat.uliftFunctor.{u + 1, u}) from rfl,
+    rw [CommHopfAlgCat.groupFunctorGrpIso_hom,
       groupFunctorGrpMap_comp]
     congr 1
     simpa only [Functor.whiskerLeft_comp, Functor.whiskerRight_comp,
@@ -638,6 +631,28 @@ noncomputable def componentCoordinateFppfGroupObjectHom
         (CommHopfAlgCat.of k (ConstantGroup.coordinateRing k
           (ConnectedComponents (PrimeSpectrum H))))).symm
 
+private theorem componentGroupFppfProjection_comp_iso_hom_def
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupFppfProjection H ≫ (componentGroupFppfGroupObjectIso H).hom =
+      let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
+      let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
+      eqToHom (CommHopfAlgCat.pointsFppfGroupObject.eq_1 H.obj) ≫
+        (F.mapGrp.map
+          (CommHopfAlgCat.pointwiseQuotientPresheafGrpProjection H.obj
+            (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+            (isNormal_identityComponentHopfIdeal H)) ≫
+          (F.mapGrp.mapIso (componentPointwiseQuotientPresheafGrpIso H)).hom) ≫
+        eqToHom (CommHopfAlgCat.pointsFppfGroupObject.eq_1
+          (CommHopfAlgCat.of k (ConstantGroup.coordinateRing k
+            (ConnectedComponents (PrimeSpectrum H))))).symm := by
+  let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
+  let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
+  unfold componentGroupFppfProjection
+  rw [fppfQuotientProjection_eq]
+  unfold componentGroupFppfGroupObjectIso
+  dsimp
+  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+
 /-- The representability isomorphism carries the component-group quotient projection to the
 sheafification of the component-coordinate morphism on points. -/
 @[simp]
@@ -647,20 +662,22 @@ theorem componentGroupFppfProjection_comp_componentGroupFppfGroupObjectIso_hom
       componentCoordinateFppfGroupObjectHom H := by
   let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
   let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
-  unfold componentGroupFppfProjection
-  rw [fppfQuotientProjection_eq]
-  unfold componentGroupFppfGroupObjectIso componentCoordinateFppfGroupObjectHom
+  rw [componentGroupFppfProjection_comp_iso_hom_def]
+  unfold componentCoordinateFppfGroupObjectHom
   dsimp
-  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl,
-    Category.id_comp]
-  change F.mapGrp.map
+  have hcore : F.mapGrp.map
         (CommHopfAlgCat.pointwiseQuotientPresheafGrpProjection H.obj
           (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
           (isNormal_identityComponentHopfIdeal H)) ≫
-      (F.mapGrp.mapIso (componentPointwiseQuotientPresheafGrpIso H)).hom =
-    F.mapGrp.map (componentCoordinatePresheafGrpHom H)
-  rw [Functor.mapIso_hom, ← F.mapGrp.map_comp,
-    pointwiseQuotientPresheafGrpProjection_comp_componentIso_hom]
+      F.mapGrp.map (componentPointwiseQuotientPresheafGrpIso H).hom =
+      F.mapGrp.map (componentCoordinatePresheafGrpHom H) := by
+    rw [← F.mapGrp.map_comp,
+      pointwiseQuotientPresheafGrpProjection_comp_componentIso_hom]
+  simpa only [Category.assoc] using congrArg (fun f ↦
+    eqToHom (CommHopfAlgCat.pointsFppfGroupObject.eq_1 H.obj) ≫ f ≫
+      eqToHom (CommHopfAlgCat.pointsFppfGroupObject.eq_1
+        (CommHopfAlgCat.of k (ConstantGroup.coordinateRing k
+          (ConnectedComponents (PrimeSpectrum H))))).symm) hcore
 
 /-- The underlying fppf sheaf of the component-group quotient is represented by the finite
 constant group scheme on the connected components of the prime spectrum. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -33,8 +33,9 @@ the desired representability.
   surjective on points over every test algebra.
 * `TauCeti.FiniteTypeCommHopfAlgCat.componentPointwiseQuotientMulEquiv`: the pointwise quotient by
   the identity component is the constant component group.
-* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfSheafIso`: the fppf component-group quotient
-  is represented by the finite constant group scheme.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfGroupObjectIso`: the fppf component-group
+  quotient is represented by the finite constant group scheme, compatibly with its group
+  structure.
 
 ## References
 
@@ -165,6 +166,8 @@ private theorem componentPointLiftAlgHom_comp_componentCoordinateMap
     exact h
   simp_rw [hrepresentative]
   have hq : q.ofConv x = qFun (ConstantGroup.functionAlgEquiv k C x) := by
+    -- `qFun` inserts the inverse of `functionAlgEquiv`; unfold that local wrapper once so the
+    -- public inverse law of the algebra equivalence can rewrite the argument.
     change q.ofConv x = q.ofConv
       ((ConstantGroup.functionAlgEquiv k C).symm (ConstantGroup.functionAlgEquiv k C x))
     rw [AlgEquiv.symm_apply_apply]
@@ -210,6 +213,8 @@ theorem componentPointsHom_surjective
   apply ofConv_injective
   ext x
   rw [componentPointsHom_apply, ofConv_toConv, AlgHom.comp_apply]
+  -- The point and Hopf-morphism wrappers both have `AlgHom` as their stable application API;
+  -- expose those definitionally equal maps before using `componentCoordinateHom_apply`.
   change componentPointLiftAlgHom H A q ((componentCoordinateHom H).hom x) = q.ofConv x
   rw [componentCoordinateHom_apply]
   exact AlgHom.congr_fun (componentPointLiftAlgHom_comp_componentCoordinateMap H A q) x
@@ -220,6 +225,9 @@ private theorem quotientPointsSubgroup_identityComponent_eq_componentPointsHom_k
         (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A =
       (componentPointsHom H A).ker := by
   ext g
+  -- Membership in the bundled kernel unfolds to equality with the convolution identity, while
+  -- `componentPointsHom_apply` exposes its underlying algebra map. Restate that wrapper boundary
+  -- once so the two public kernel lemmas below apply.
   change g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
       (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A ↔
     toConv (g.ofConv.comp (componentCoordinateHom H).hom.toAlgHom) = 1
@@ -280,6 +288,8 @@ theorem componentPointwiseQuotientMulEquiv_mk
       (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
       (isNormal_identityComponentHopfIdeal H) A
   rw [CommHopfAlgCat.pointwiseQuotientMk_apply]
+  -- `pointwiseQuotientMk_apply` exposes the raw `QuotientGroup.mk`; display that definitional
+  -- quotient carrier so the two first-isomorphism-theorem application lemmas can rewrite.
   change componentPointwiseQuotientMulEquiv H A
       (QuotientGroup.mk g) = componentPointsHom H A g
   rw [componentPointwiseQuotientMulEquiv, MulEquiv.trans_apply,
@@ -287,6 +297,7 @@ theorem componentPointwiseQuotientMulEquiv_mk
     TauCeti.QuotientGroup.quotientKerEquivOfSurjective_apply_mk]
 
 /-- The component morphism on points commutes with extension of the value algebra. -/
+@[simp]
 theorem mapPoints_componentPointsHom
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) {A B : CommAlgCat.{u} k} (f : A ⟶ B)
     (g : HopfAlgebra.points (R := k) (H := H) A) :
@@ -329,6 +340,9 @@ noncomputable def componentPointwiseQuotientNatIso
       obtain ⟨g, rfl⟩ := CommHopfAlgCat.pointwiseQuotientMk_surjective H.obj
         (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
         (isNormal_identityComponentHopfIdeal H) A q
+      -- The categorical composites evaluate through their `.hom` fields, definitionally giving
+      -- the displayed quotient and points maps. Expose that application boundary before using
+      -- the public naturality lemmas for those maps.
       change componentPointwiseQuotientMulEquiv H B
           (CommHopfAlgCat.mapPointwiseQuotient H.obj
             (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
@@ -356,6 +370,8 @@ noncomputable def componentPointwiseQuotientNatIso
               (H := ConstantGroup.coordinateRing k
                 (ConnectedComponents (PrimeSpectrum H))) f ≫
             eqToHom (HopfAlgebra.pointsFunctor_obj B).symm := by
+      -- Both `eqToHom`s transport along the defining object equalities of `pointsFunctor`; after
+      -- those stable transports are displayed, naturality is definitionally the same map.
       rfl
     simpa only [Iso.trans_hom, eqToIso.hom,
       CommHopfAlgCat.pointwiseQuotientFunctor_map,
@@ -367,6 +383,28 @@ noncomputable def componentPointwiseQuotientNatIso
         eqToHom (HopfAlgebra.pointsFunctor_obj B).symm) hbare
 
 /-- Before sheafification, the pointwise component quotient and the constant component group are
+isomorphic as group objects in type-valued presheaves on the affine fppf site. -/
+noncomputable def componentPointwiseQuotientPresheafGrpIso
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.pointwiseQuotientPresheafGrp H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) ≅
+      CommHopfAlgCat.pointsPresheafGrp
+        (CommHopfAlgCat.of k
+          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))) := by
+  let e := Functor.isoWhiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
+    (componentPointwiseQuotientNatIso H)
+  let e' := Functor.isoWhiskerRight e GrpCat.uliftFunctor.{u + 1, u}
+  exact eqToIso (CommHopfAlgCat.pointwiseQuotientPresheafGrp_eq H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+      (isNormal_identityComponentHopfIdeal H)) ≪≫
+    CommHopfAlgCat.groupFunctorGrpIso e' ≪≫
+      eqToIso (CommHopfAlgCat.pointsPresheafGrp_eq
+        (CommHopfAlgCat.of k
+          (ConstantGroup.coordinateRing k
+            (ConnectedComponents (PrimeSpectrum H))))).symm
+
+/-- Before sheafification, the pointwise component quotient and the constant component group are
 isomorphic as type-valued presheaves on the affine fppf site. -/
 noncomputable def componentPointwiseQuotientPresheafIso
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
@@ -375,15 +413,27 @@ noncomputable def componentPointwiseQuotientPresheafIso
         (isNormal_identityComponentHopfIdeal H)).X ≅
       (CommHopfAlgCat.pointsPresheafGrp
         (CommHopfAlgCat.of k
-          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))))).X := by
-  let e := Functor.isoWhiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
-    (componentPointwiseQuotientNatIso H)
-  let e' := Functor.isoWhiskerRight e GrpCat.uliftFunctor.{u + 1, u}
-  exact eqToIso (CommHopfAlgCat.pointwiseQuotientPresheafGrp_X_eq H.obj
+          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))))).X :=
+  (Grp.forget _).mapIso (componentPointwiseQuotientPresheafGrpIso H)
+
+/-- The fppf component-group quotient is represented by the finite constant group scheme,
+compatibly with multiplication, the unit, and inversion. -/
+noncomputable def componentGroupFppfGroupObjectIso
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupFppfSheaf H ≅
+      CommHopfAlgCat.pointsFppfGroupObject
+        (CommHopfAlgCat.of k
+          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))) := by
+  let _ : (presheafToSheaf
+      (CommAlgCat.fppfTopology k) (Type (u + 1))).Monoidal :=
+    Functor.Monoidal.ofChosenFiniteProducts _
+  exact eqToIso (CommHopfAlgCat.fppfQuotientSheaf_eq H.obj
       (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
       (isNormal_identityComponentHopfIdeal H)) ≪≫
-    Functor.isoWhiskerRight e' (forget GrpCat.{u + 1}) ≪≫
-      eqToIso (CommHopfAlgCat.pointsPresheafGrp_X_eq
+    (presheafToSheaf
+      (CommAlgCat.fppfTopology k) (Type (u + 1))).mapGrp.mapIso
+        (componentPointwiseQuotientPresheafGrpIso H) ≪≫
+      eqToIso (CommHopfAlgCat.pointsFppfGroupObject_eq
         (CommHopfAlgCat.of k
           (ConstantGroup.coordinateRing k
             (ConnectedComponents (PrimeSpectrum H))))).symm
@@ -395,19 +445,7 @@ noncomputable def componentGroupFppfSheafIso
     (componentGroupFppfSheaf H).X ≅
       (CommHopfAlgCat.pointsFppfGroupObject
         (CommHopfAlgCat.of k
-          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))))).X := by
-  let _ : (presheafToSheaf
-      (CommAlgCat.fppfTopology k) (Type (u + 1))).Monoidal :=
-    Functor.Monoidal.ofChosenFiniteProducts _
-  exact eqToIso (CommHopfAlgCat.fppfQuotientSheaf_X_eq H.obj
-      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-      (isNormal_identityComponentHopfIdeal H)) ≪≫
-    (presheafToSheaf
-      (CommAlgCat.fppfTopology k) (Type (u + 1))).mapIso
-        (componentPointwiseQuotientPresheafIso H) ≪≫
-    eqToIso (CommHopfAlgCat.pointsFppfGroupObject_X_eq
-      (CommHopfAlgCat.of k
-        (ConstantGroup.coordinateRing k
-          (ConnectedComponents (PrimeSpectrum H))))).symm
+          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))))).X :=
+  (Grp.forget _).mapIso (componentGroupFppfGroupObjectIso H)
 
 end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -166,10 +166,7 @@ private theorem componentPointLiftAlgHom_comp_componentCoordinateMap
     exact h
   simp_rw [hrepresentative]
   have hq : q.ofConv x = qFun (ConstantGroup.functionAlgEquiv k C x) := by
-    -- `qFun` inserts the inverse of `functionAlgEquiv`; unfold that local wrapper once so the
-    -- public inverse law of the algebra equivalence can rewrite the argument.
-    change q.ofConv x = q.ofConv
-      ((ConstantGroup.functionAlgEquiv k C).symm (ConstantGroup.functionAlgEquiv k C x))
+    dsimp only [qFun, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply]
     rw [AlgEquiv.symm_apply_apply]
   rw [hq]
   change (∑ D, qFun (Pi.single D 1) * algebraMap k A

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -647,7 +647,7 @@ private theorem componentGroupFppfProjection_comp_iso_hom_def
             (ConnectedComponents (PrimeSpectrum H))))).symm := by
   let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
   let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
-  unfold componentGroupFppfProjection
+  rw [componentGroupFppfProjection_def]
   rw [fppfQuotientProjection_eq]
   unfold componentGroupFppfGroupObjectIso
   dsimp

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -380,7 +380,7 @@ noncomputable def componentPointwiseQuotientPresheafGrpIso
   let e := Functor.isoWhiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
     (componentPointwiseQuotientNatIso H)
   let e' := Functor.isoWhiskerRight e GrpCat.uliftFunctor.{u + 1, u}
-  exact eqToIso (CommHopfAlgCat.pointwiseQuotientPresheafGrp_eq H.obj
+  exact eqToIso (CommHopfAlgCat.pointwiseQuotientPresheafGrp_def H.obj
       (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
       (isNormal_identityComponentHopfIdeal H)) ≪≫
     CommHopfAlgCat.groupFunctorGrpIso e' ≪≫
@@ -412,7 +412,7 @@ noncomputable def componentGroupFppfGroupObjectIso
   let _ : (presheafToSheaf
       (CommAlgCat.fppfTopology k) (Type (u + 1))).Monoidal :=
     Functor.Monoidal.ofChosenFiniteProducts _
-  exact eqToIso (CommHopfAlgCat.fppfQuotientSheaf_eq H.obj
+  exact eqToIso (CommHopfAlgCat.fppfQuotientSheaf_def H.obj
       (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
       (isNormal_identityComponentHopfIdeal H)) ≪≫
     (presheafToSheaf

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -399,7 +399,7 @@ noncomputable def componentPointwiseQuotientPresheafGrpIso
       (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
       (isNormal_identityComponentHopfIdeal H)) ≪≫
     CommHopfAlgCat.groupFunctorGrpIso e' ≪≫
-      eqToIso (CommHopfAlgCat.pointsPresheafGrp_eq
+      eqToIso (CommHopfAlgCat.pointsPresheafGrp.eq_1
         (CommHopfAlgCat.of k
           (ConstantGroup.coordinateRing k
             (ConnectedComponents (PrimeSpectrum H))))).symm
@@ -433,7 +433,7 @@ noncomputable def componentGroupFppfGroupObjectIso
     (presheafToSheaf
       (CommAlgCat.fppfTopology k) (Type (u + 1))).mapGrp.mapIso
         (componentPointwiseQuotientPresheafGrpIso H) ≪≫
-      eqToIso (CommHopfAlgCat.pointsFppfGroupObject_eq
+      eqToIso (CommHopfAlgCat.pointsFppfGroupObject.eq_1
         (CommHopfAlgCat.of k
           (ConstantGroup.coordinateRing k
             (ConnectedComponents (PrimeSpectrum H))))).symm

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -168,9 +168,13 @@ private theorem componentPointLiftAlgHom_comp_componentCoordinateMap
   have hq : q.ofConv x = qFun (ConstantGroup.functionAlgEquiv k C x) := by
     dsimp only [qFun, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply]
     rw [AlgEquiv.symm_apply_apply]
-  rw [hq]
-  change (∑ D, qFun (Pi.single D 1) * algebraMap k A
-      (ConstantGroup.functionAlgEquiv k C x D)) = _
+  have hqFun_sum :
+      (∑ D, q.ofConv ((ConstantGroup.functionAlgEquiv k C).symm (Pi.single D 1)) *
+          algebraMap k A (ConstantGroup.functionAlgEquiv k C x D)) =
+        ∑ D, qFun (Pi.single D 1) *
+          algebraMap k A (ConstantGroup.functionAlgEquiv k C x D) := by
+    rfl
+  rw [hqFun_sum, hq]
   let f := ConstantGroup.functionAlgEquiv k C x
   calc
     (∑ D, qFun (Pi.single D 1) * algebraMap k A (f D)) =

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -185,6 +185,19 @@ private theorem componentPointLiftAlgHom_comp_componentCoordinateMap
     _ = qFun (∑ D, (f D) • Pi.single D 1) := by rw [map_sum]
     _ = qFun f := congrArg qFun (pi_eq_sum_univ' f).symm
 
+private theorem componentPointLiftAlgHom_componentCoordinateHom_apply
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points
+      (R := k)
+      (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) A)
+    (x : ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) :
+    (toConv (componentPointLiftAlgHom H A q)).ofConv
+        ((componentCoordinateHom H).hom.toAlgHom x) = q.ofConv x := by
+  simp only [BialgHom.coe_toAlgHom]
+  rw [componentCoordinateHom_apply]
+  simpa only [AlgHom.comp_apply] using
+    AlgHom.congr_fun (componentPointLiftAlgHom_comp_componentCoordinateMap H A q) x
+
 /-- The component-coordinate morphism on points over a commutative test algebra. -/
 noncomputable def componentPointsHom
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
@@ -212,12 +225,8 @@ theorem componentPointsHom_surjective
   refine ⟨toConv (componentPointLiftAlgHom H A q), ?_⟩
   apply ofConv_injective
   ext x
-  rw [componentPointsHom_apply, ofConv_toConv, AlgHom.comp_apply]
-  -- The point and Hopf-morphism wrappers both have `AlgHom` as their stable application API;
-  -- expose those definitionally equal maps before using `componentCoordinateHom_apply`.
-  change componentPointLiftAlgHom H A q ((componentCoordinateHom H).hom x) = q.ofConv x
-  rw [componentCoordinateHom_apply]
-  exact AlgHom.congr_fun (componentPointLiftAlgHom_comp_componentCoordinateMap H A q) x
+  rw [componentPointsHom_apply, ofConv_toConv, AlgHom.comp_apply,
+    componentPointLiftAlgHom_componentCoordinateHom_apply]
 
 private theorem quotientPointsSubgroup_identityComponent_eq_componentPointsHom_ker
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
@@ -225,13 +234,8 @@ private theorem quotientPointsSubgroup_identityComponent_eq_componentPointsHom_k
         (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A =
       (componentPointsHom H A).ker := by
   ext g
-  -- Membership in the bundled kernel unfolds to equality with the convolution identity, while
-  -- `componentPointsHom_apply` exposes its underlying algebra map. Restate that wrapper boundary
-  -- once so the two public kernel lemmas below apply.
-  change g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
-      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A ↔
-    toConv (g.ofConv.comp (componentCoordinateHom H).hom.toAlgHom) = 1
-  rw [CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff]
+  rw [MonoidHom.mem_ker, componentPointsHom_apply,
+    CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff]
   rw [kernelHopfIdeal_componentCoordinateHom]
 
 /-- The group structure on the pointwise quotient, exposed locally for the first isomorphism
@@ -288,11 +292,7 @@ theorem componentPointwiseQuotientMulEquiv_mk
       (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
       (isNormal_identityComponentHopfIdeal H) A
   rw [CommHopfAlgCat.pointwiseQuotientMk_apply]
-  -- `pointwiseQuotientMk_apply` exposes the raw `QuotientGroup.mk`; display that definitional
-  -- quotient carrier so the two first-isomorphism-theorem application lemmas can rewrite.
-  change componentPointwiseQuotientMulEquiv H A
-      (QuotientGroup.mk g) = componentPointsHom H A g
-  rw [componentPointwiseQuotientMulEquiv, MulEquiv.trans_apply,
+  rw [QuotientGroup.mk'_apply, componentPointwiseQuotientMulEquiv, MulEquiv.trans_apply,
     QuotientGroup.quotientMulEquivOfEq_mk,
     TauCeti.QuotientGroup.quotientKerEquivOfSurjective_apply_mk]
 
@@ -340,22 +340,8 @@ noncomputable def componentPointwiseQuotientNatIso
       obtain ⟨g, rfl⟩ := CommHopfAlgCat.pointwiseQuotientMk_surjective H.obj
         (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
         (isNormal_identityComponentHopfIdeal H) A q
-      -- The categorical composites evaluate through their `.hom` fields, definitionally giving
-      -- the displayed quotient and points maps. Expose that application boundary before using
-      -- the public naturality lemmas for those maps.
-      change componentPointwiseQuotientMulEquiv H B
-          (CommHopfAlgCat.mapPointwiseQuotient H.obj
-            (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-            (isNormal_identityComponentHopfIdeal H) f
-            (CommHopfAlgCat.pointwiseQuotientMk H.obj
-              (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-              (isNormal_identityComponentHopfIdeal H) A g)) =
-        HopfAlgebra.mapPoints
-          (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) f
-          (componentPointwiseQuotientMulEquiv H A
-            (CommHopfAlgCat.pointwiseQuotientMk H.obj
-              (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
-              (isNormal_identityComponentHopfIdeal H) A g))
+      simp only [GrpCat.hom_comp, MonoidHom.comp_apply, MulEquiv.toGrpIso_hom,
+        MulEquiv.toMonoidHom_eq_coe, ConcreteCategory.hom_ofHom, MonoidHom.coe_coe]
       rw [CommHopfAlgCat.mapPointwiseQuotient_mk,
         componentPointwiseQuotientMulEquiv_mk,
         componentPointwiseQuotientMulEquiv_mk,
@@ -370,9 +356,7 @@ noncomputable def componentPointwiseQuotientNatIso
               (H := ConstantGroup.coordinateRing k
                 (ConnectedComponents (PrimeSpectrum H))) f ≫
             eqToHom (HopfAlgebra.pointsFunctor_obj B).symm := by
-      -- Both `eqToHom`s transport along the defining object equalities of `pointsFunctor`; after
-      -- those stable transports are displayed, naturality is definitionally the same map.
-      rfl
+      exact HopfAlgebra.pointsFunctor_map_eqToHom f
     simpa only [Iso.trans_hom, eqToIso.hom,
       CommHopfAlgCat.pointwiseQuotientFunctor_map,
       Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp,

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -1,0 +1,413 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.Coordinate
+public import TauCeti.Algebra.AlgebraicGroup.ConstantGroup.Scheme
+public import TauCeti.Algebra.AlgebraicGroup.Fppf.Quotient.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel
+public import TauCeti.GroupTheory.QuotientGroup.KerEquiv
+import Mathlib.Algebra.BigOperators.Pi
+
+/-!
+# Representability of the component group
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over an algebraically closed
+field. This file identifies the fppf quotient `H / H⁰` with the fppf points sheaf of the finite
+constant group of connected components of `Spec H`.
+
+The key point is stronger than local surjectivity. Every point of the constant component group
+over a test algebra lifts to a point of `H`: its orthogonal idempotents split the test algebra into
+components, and on each component one uses a chosen rational point of the corresponding connected
+component of `Spec H`. The kernel calculation for the component coordinate morphism then identifies
+the pointwise quotient with the constant-group points. Sheafifying this natural isomorphism gives
+the desired representability.
+
+## Main declarations
+
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentPointsHom_surjective`: the component morphism is
+  surjective on points over every test algebra.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentPointwiseQuotientMulEquiv`: the pointwise quotient by
+  the identity component is the constant component group.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfSheafIso`: the fppf component-group quotient
+  is represented by the finite constant group scheme.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37 and Section 5.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Sections 6.7 and 14.
+
+This completes the algebraically closed-field representability step of Layer 3, "Identity
+component `G°` and component group `π₀(G)`", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory Opposite WithConv
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.FiniteTypeCommHopfAlgCat
+
+universe u v w
+
+variable {k : Type u} [Field k] [IsAlgClosed k]
+
+private noncomputable instance (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Fintype (ConnectedComponents (PrimeSpectrum H)) :=
+  Fintype.ofFinite _
+
+private noncomputable instance (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    DecidableEq (ConnectedComponents (PrimeSpectrum H)) :=
+  Classical.decEq _
+
+/-- A chosen rational point in each connected component of the spectrum. -/
+private noncomputable def componentRepresentative
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (C : ConnectedComponents (PrimeSpectrum H)) :
+    HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k) :=
+  Classical.choose (rationalComponentMap_surjective H C)
+
+@[simp]
+private theorem rationalComponentMap_componentRepresentative
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (C : ConnectedComponents (PrimeSpectrum H)) :
+    rationalComponentMap H (componentRepresentative H C) = C :=
+  Classical.choose_spec (rationalComponentMap_surjective H C)
+
+/-- The algebra map obtained by gluing the chosen component representatives along the
+orthogonal idempotents of a constant-group point. -/
+private noncomputable def componentPointLiftAlgHom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points
+      (R := k)
+      (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) A) :
+    H →ₐ[k] A := by
+  classical
+  let C := ConnectedComponents (PrimeSpectrum H)
+  let qFun : (C → k) →ₐ[k] A := q.ofConv.comp (ConstantGroup.functionAlgEquiv k C).symm.toAlgHom
+  let e : C → A := fun D ↦ qFun (Pi.single D 1)
+  have he : CompleteOrthogonalIdempotents e := by
+    exact (CompleteOrthogonalIdempotents.single (fun _ : C ↦ k)).map qFun.toRingHom
+  refine
+    { toFun := fun x ↦ ∑ D, e D * algebraMap k A ((componentRepresentative H D).ofConv x)
+      map_zero' := by simp
+      map_add' := fun x y ↦ by
+        simp only [map_add, mul_add, Finset.sum_add_distrib]
+      map_one' := by
+        simp only [map_one, mul_one, he.complete]
+      map_mul' := fun x y ↦ ?_
+      commutes' := fun a ↦ ?_ }
+  · rw [Finset.sum_mul_sum]
+    symm
+    apply Finset.sum_congr rfl
+    intro D _
+    rw [Finset.sum_eq_single D]
+    · rw [map_mul]
+      calc
+        e D * algebraMap k A ((componentRepresentative H D).ofConv x) *
+            (e D * algebraMap k A ((componentRepresentative H D).ofConv y)) =
+            (e D * e D) *
+              (algebraMap k A ((componentRepresentative H D).ofConv x) *
+                algebraMap k A ((componentRepresentative H D).ofConv y)) := by
+          ring
+        _ = e D * algebraMap k A
+            ((componentRepresentative H D).ofConv x *
+              (componentRepresentative H D).ofConv y) := by
+          rw [he.idem, map_mul]
+    · intro E _ hED
+      calc
+        e D * algebraMap k A ((componentRepresentative H D).ofConv x) *
+            (e E * algebraMap k A ((componentRepresentative H E).ofConv y)) =
+            (e D * e E) *
+              (algebraMap k A ((componentRepresentative H D).ofConv x) *
+                algebraMap k A ((componentRepresentative H E).ofConv y)) := by
+          ring
+        _ = 0 := by rw [he.ortho hED.symm, zero_mul]
+    · simp
+  · simp_rw [AlgHom.commutes]
+    rw [← Finset.sum_mul, he.complete, one_mul]
+    rw [Algebra.algebraMap_self_apply]
+
+private theorem componentPointLiftAlgHom_apply
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points
+      (R := k)
+      (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) A)
+    (x : H) :
+    componentPointLiftAlgHom H A q x =
+      ∑ D,
+        q.ofConv ((ConstantGroup.functionAlgEquiv k
+          (ConnectedComponents (PrimeSpectrum H))).symm (Pi.single D 1)) *
+          algebraMap k A ((componentRepresentative H D).ofConv x) := by
+  rfl
+
+private theorem componentPointLiftAlgHom_comp_componentCoordinateMap
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points
+      (R := k)
+      (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) A) :
+    (componentPointLiftAlgHom H A q).comp (componentCoordinateMap H) = q.ofConv := by
+  classical
+  let C := ConnectedComponents (PrimeSpectrum H)
+  let qFun : (C → k) →ₐ[k] A := q.ofConv.comp (ConstantGroup.functionAlgEquiv k C).symm.toAlgHom
+  ext x
+  rw [AlgHom.comp_apply, componentPointLiftAlgHom_apply]
+  have hrepresentative (D : C) :
+      (componentRepresentative H D).ofConv (componentCoordinateMap H x) =
+        ConstantGroup.functionAlgEquiv k C x D := by
+    have h := AlgHom.congr_fun
+      (eval_componentCoordinateMap H (componentRepresentative H D)) x
+    rw [rationalComponentMap_componentRepresentative, ConstantGroup.eval_apply] at h
+    exact h
+  simp_rw [hrepresentative]
+  have hq : q.ofConv x = qFun (ConstantGroup.functionAlgEquiv k C x) := by
+    change q.ofConv x = q.ofConv
+      ((ConstantGroup.functionAlgEquiv k C).symm (ConstantGroup.functionAlgEquiv k C x))
+    rw [AlgEquiv.symm_apply_apply]
+  rw [hq]
+  change (∑ D, qFun (Pi.single D 1) * algebraMap k A
+      (ConstantGroup.functionAlgEquiv k C x D)) = _
+  let f := ConstantGroup.functionAlgEquiv k C x
+  calc
+    (∑ D, qFun (Pi.single D 1) * algebraMap k A (f D)) =
+        ∑ D, qFun ((f D) • Pi.single D 1) := by
+      apply Finset.sum_congr rfl
+      intro D _
+      rw [map_smul, Algebra.smul_def]
+      ring
+    _ = qFun (∑ D, (f D) • Pi.single D 1) := by rw [map_sum]
+    _ = qFun f := congrArg qFun (pi_eq_sum_univ' f).symm
+
+/-- The component-coordinate morphism on points over a commutative test algebra. -/
+noncomputable def componentPointsHom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    HopfAlgebra.points (R := k) (H := H) A →*
+      HopfAlgebra.points
+        (R := k)
+        (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) A :=
+  AlgHom.mapDomain (componentCoordinateHom H).hom
+
+/-- The component morphism on points is precomposition with the component coordinate map. -/
+@[simp]
+theorem componentPointsHom_apply
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) A) :
+    componentPointsHom H A g =
+      toConv (g.ofConv.comp (componentCoordinateHom H).hom.toAlgHom) := by
+  exact AlgHom.mapDomain_apply (A := A) (componentCoordinateHom H).hom g
+
+/-- The component-coordinate morphism is surjective on points over every commutative test
+algebra. -/
+theorem componentPointsHom_surjective
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    Function.Surjective (componentPointsHom H A) := by
+  intro q
+  refine ⟨toConv (componentPointLiftAlgHom H A q), ?_⟩
+  apply ofConv_injective
+  ext x
+  rw [componentPointsHom_apply, ofConv_toConv, AlgHom.comp_apply]
+  change componentPointLiftAlgHom H A q ((componentCoordinateHom H).hom x) = q.ofConv x
+  rw [componentCoordinateHom_apply]
+  exact AlgHom.congr_fun (componentPointLiftAlgHom_comp_componentCoordinateMap H A q) x
+
+private theorem quotientPointsSubgroup_identityComponent_eq_componentPointsHom_ker
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    CommHopfAlgCat.quotientPointsSubgroup H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A =
+      (componentPointsHom H A).ker := by
+  ext g
+  change g ∈ CommHopfAlgCat.quotientPointsSubgroup H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A ↔
+    toConv (g.ofConv.comp (componentCoordinateHom H).hom.toAlgHom) = 1
+  rw [CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff]
+  rw [kernelHopfIdeal_componentCoordinateHom]
+
+/-- The group structure on the pointwise quotient, exposed locally for the first isomorphism
+theorem. -/
+noncomputable local instance componentPointwiseQuotientGroup
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    Group (CommHopfAlgCat.pointwiseQuotientGroup H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+      (isNormal_identityComponentHopfIdeal H) A) :=
+  (CommHopfAlgCat.pointwiseQuotientGroup H.obj
+    (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+    (isNormal_identityComponentHopfIdeal H) A).str
+
+/-- The pointwise quotient by the identity component is canonically the group of points of the
+finite constant component group. -/
+noncomputable def componentPointwiseQuotientMulEquiv
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    CommHopfAlgCat.pointwiseQuotientGroup H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) A ≃*
+      HopfAlgebra.points
+        (R := k)
+        (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) A := by
+  let I := HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)
+  let hI := isNormal_identityComponentHopfIdeal H
+  let N := CommHopfAlgCat.quotientPointsSubgroup H.obj I A
+  let phi := componentPointsHom H A
+  let hN : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal H.obj I hI A
+  let hker : phi.ker.Normal := phi.normal_ker
+  let _ : N.Normal := hN
+  let _ : phi.ker.Normal := hker
+  let _ : Group (HopfAlgebra.points (R := k) (H := H) A ⧸ phi.ker) :=
+    QuotientGroup.Quotient.group phi.ker
+  exact (@QuotientGroup.quotientMulEquivOfEq _ _ N phi.ker hN hker
+      (quotientPointsSubgroup_identityComponent_eq_componentPointsHom_ker H A)).trans
+    (QuotientGroup.quotientKerEquivOfSurjective
+      (componentPointsHom H A)
+      (componentPointsHom_surjective H A))
+
+/-- The pointwise component-group equivalence sends the class of an ambient point to its image
+under the component-coordinate morphism. -/
+@[simp]
+theorem componentPointwiseQuotientMulEquiv_mk
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k)
+    (g : HopfAlgebra.points (R := k) (H := H) A) :
+    componentPointwiseQuotientMulEquiv H A
+        (CommHopfAlgCat.pointwiseQuotientMk H.obj
+          (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+          (isNormal_identityComponentHopfIdeal H) A g) =
+      componentPointsHom H A g := by
+  let _ : (CommHopfAlgCat.quotientPointsSubgroup H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H)) A).Normal :=
+    CommHopfAlgCat.quotientPointsSubgroup_normal H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+      (isNormal_identityComponentHopfIdeal H) A
+  rw [CommHopfAlgCat.pointwiseQuotientMk_apply]
+  change componentPointwiseQuotientMulEquiv H A
+      (QuotientGroup.mk g) = componentPointsHom H A g
+  rw [componentPointwiseQuotientMulEquiv, MulEquiv.trans_apply,
+    QuotientGroup.quotientMulEquivOfEq_mk,
+    TauCeti.QuotientGroup.quotientKerEquivOfSurjective_apply_mk]
+
+/-- The component morphism on points commutes with extension of the value algebra. -/
+theorem mapPoints_componentPointsHom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) {A B : CommAlgCat.{u} k} (f : A ⟶ B)
+    (g : HopfAlgebra.points (R := k) (H := H) A) :
+    HopfAlgebra.mapPoints
+        (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) f
+        (componentPointsHom H A g) =
+      componentPointsHom H B (HopfAlgebra.mapPoints (H := H) f g) := by
+  exact DFunLike.congr_fun
+    (AlgHom.mapValue_mapDomain (componentCoordinateHom H).hom f.hom) g
+
+/-- The pointwise quotient functor by the identity component is naturally isomorphic to the
+functor of points of the finite constant component group. -/
+noncomputable def componentPointwiseQuotientNatIso
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.pointwiseQuotientFunctor H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) ≅
+      HopfAlgebra.pointsFunctor
+        (R := k)
+        (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) :=
+  NatIso.ofComponents (fun A ↦
+    eqToIso (CommHopfAlgCat.pointwiseQuotientFunctor_obj H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+      (isNormal_identityComponentHopfIdeal H) A) ≪≫
+        (componentPointwiseQuotientMulEquiv H A).toGrpIso ≪≫
+          eqToIso (HopfAlgebra.pointsFunctor_obj A).symm) <| by
+    intro A B f
+    have hbare :
+        CommHopfAlgCat.mapPointwiseQuotient H.obj
+            (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+            (isNormal_identityComponentHopfIdeal H) f ≫
+          (componentPointwiseQuotientMulEquiv H B).toGrpIso.hom =
+        (componentPointwiseQuotientMulEquiv H A).toGrpIso.hom ≫
+          HopfAlgebra.mapPoints
+            (H := ConstantGroup.coordinateRing k
+              (ConnectedComponents (PrimeSpectrum H))) f := by
+      apply GrpCat.hom_ext
+      apply MonoidHom.ext
+      intro q
+      obtain ⟨g, rfl⟩ := CommHopfAlgCat.pointwiseQuotientMk_surjective H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) A q
+      change componentPointwiseQuotientMulEquiv H B
+          (CommHopfAlgCat.mapPointwiseQuotient H.obj
+            (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+            (isNormal_identityComponentHopfIdeal H) f
+            (CommHopfAlgCat.pointwiseQuotientMk H.obj
+              (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+              (isNormal_identityComponentHopfIdeal H) A g)) =
+        HopfAlgebra.mapPoints
+          (H := ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) f
+          (componentPointwiseQuotientMulEquiv H A
+            (CommHopfAlgCat.pointwiseQuotientMk H.obj
+              (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+              (isNormal_identityComponentHopfIdeal H) A g))
+      rw [CommHopfAlgCat.mapPointwiseQuotient_mk,
+        componentPointwiseQuotientMulEquiv_mk,
+        componentPointwiseQuotientMulEquiv_mk,
+        mapPoints_componentPointsHom]
+    have hpoints :
+        eqToHom (HopfAlgebra.pointsFunctor_obj A).symm ≫
+            (HopfAlgebra.pointsFunctor
+              (R := k)
+              (H := ConstantGroup.coordinateRing k
+                (ConnectedComponents (PrimeSpectrum H)))).map f =
+          HopfAlgebra.mapPoints
+              (H := ConstantGroup.coordinateRing k
+                (ConnectedComponents (PrimeSpectrum H))) f ≫
+            eqToHom (HopfAlgebra.pointsFunctor_obj B).symm := by
+      rfl
+    simpa only [Iso.trans_hom, eqToIso.hom,
+      CommHopfAlgCat.pointwiseQuotientFunctor_map,
+      Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp,
+      Category.comp_id, hpoints] using congrArg (fun z ↦
+        eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj H.obj
+          (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+          (isNormal_identityComponentHopfIdeal H) A) ≫ z ≫
+        eqToHom (HopfAlgebra.pointsFunctor_obj B).symm) hbare
+
+/-- Before sheafification, the pointwise component quotient and the constant component group are
+isomorphic as type-valued presheaves on the affine fppf site. -/
+noncomputable def componentPointwiseQuotientPresheafIso
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (CommHopfAlgCat.pointwiseQuotientPresheafGrp H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H)).X ≅
+      (CommHopfAlgCat.pointsPresheafGrp
+        (CommHopfAlgCat.of k
+          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))))).X := by
+  let e := Functor.isoWhiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
+    (componentPointwiseQuotientNatIso H)
+  let e' := Functor.isoWhiskerRight e GrpCat.uliftFunctor.{u + 1, u}
+  exact eqToIso (CommHopfAlgCat.pointwiseQuotientPresheafGrp_X_eq H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+      (isNormal_identityComponentHopfIdeal H)) ≪≫
+    Functor.isoWhiskerRight e' (forget GrpCat.{u + 1}) ≪≫
+      eqToIso (CommHopfAlgCat.pointsPresheafGrp_X_eq
+        (CommHopfAlgCat.of k
+          (ConstantGroup.coordinateRing k
+            (ConnectedComponents (PrimeSpectrum H))))).symm
+
+/-- The underlying fppf sheaf of the component-group quotient is represented by the finite
+constant group scheme on the connected components of the prime spectrum. -/
+noncomputable def componentGroupFppfSheafIso
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (componentGroupFppfSheaf H).X ≅
+      (CommHopfAlgCat.pointsFppfGroupObject
+        (CommHopfAlgCat.of k
+          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))))).X := by
+  let _ : (presheafToSheaf
+      (CommAlgCat.fppfTopology k) (Type (u + 1))).Monoidal :=
+    Functor.Monoidal.ofChosenFiniteProducts _
+  exact eqToIso (CommHopfAlgCat.fppfQuotientSheaf_X_eq H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+      (isNormal_identityComponentHopfIdeal H)) ≪≫
+    (presheafToSheaf
+      (CommAlgCat.fppfTopology k) (Type (u + 1))).mapIso
+        (componentPointwiseQuotientPresheafIso H) ≪≫
+    eqToIso (CommHopfAlgCat.pointsFppfGroupObject_X_eq
+      (CommHopfAlgCat.of k
+        (ConstantGroup.coordinateRing k
+          (ConnectedComponents (PrimeSpectrum H))))).symm
+
+end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Representable.lean
@@ -36,6 +36,9 @@ the desired representability.
 * `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfGroupObjectIso`: the fppf component-group
   quotient is represented by the finite constant group scheme, compatibly with its group
   structure.
+* `componentGroupFppfProjection_comp_componentGroupFppfGroupObjectIso_hom`:
+  the representability isomorphism identifies the quotient projection with the sheafified
+  component-coordinate morphism.
 
 ## References
 
@@ -422,6 +425,242 @@ noncomputable def componentGroupFppfGroupObjectIso
         (CommHopfAlgCat.of k
           (ConstantGroup.coordinateRing k
             (ConnectedComponents (PrimeSpectrum H))))).symm
+
+private theorem eqToHom_hom_hom {C : Type w} [Category.{v} C]
+    [CartesianMonoidalCategory C] {X Y : Grp C} (h : X = Y) :
+    (eqToHom h : X ⟶ Y).hom.hom = eqToHom (congrArg (fun Z : Grp C ↦ Z.X) h) := by
+  subst h
+  rfl
+
+private theorem groupFunctorGrpMap_hom_hom {C : Type u} [Category.{v} C]
+    {F G : C ⥤ GrpCat.{u}} (α : F ⟶ G) :
+    (CommHopfAlgCat.groupFunctorGrpMap α).hom.hom =
+      Functor.whiskerRight α (forget GrpCat.{u}) := by
+  rfl
+
+private theorem groupFunctorGrpMap_comp {C : Type u} [Category.{v} C]
+    {F G K : C ⥤ GrpCat.{u}} (α : F ⟶ G) (β : G ⟶ K) :
+    CommHopfAlgCat.groupFunctorGrpMap α ≫
+        CommHopfAlgCat.groupFunctorGrpMap β =
+      CommHopfAlgCat.groupFunctorGrpMap (α ≫ β) := by
+  apply Grp.hom_ext
+  rw [Grp.comp_hom_hom, groupFunctorGrpMap_hom_hom, groupFunctorGrpMap_hom_hom,
+    groupFunctorGrpMap_hom_hom, Functor.whiskerRight_comp]
+  rfl
+
+private theorem pointwiseQuotientPresheafGrpProjection_eq
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.pointwiseQuotientPresheafGrpProjection H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) =
+      eqToHom (CommHopfAlgCat.pointsPresheafGrp.eq_1 H.obj) ≫
+        CommHopfAlgCat.groupFunctorGrpMap (Functor.whiskerRight
+          (CommHopfAlgCat.pointwiseQuotientPresheafProjection H.obj
+            (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+            (isNormal_identityComponentHopfIdeal H))
+          GrpCat.uliftFunctor.{u + 1, u}) ≫
+        eqToHom (CommHopfAlgCat.pointwiseQuotientPresheafGrp_def H.obj
+          (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+          (isNormal_identityComponentHopfIdeal H)).symm := by
+  apply Grp.hom_ext
+  rw [CommHopfAlgCat.pointwiseQuotientPresheafGrpProjection_hom_hom]
+  rw [Grp.comp_hom_hom, Grp.comp_hom_hom]
+  simp_rw [eqToHom_hom_hom, groupFunctorGrpMap_hom_hom]
+  rfl
+
+private theorem fppfQuotientProjection_eq
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.fppfQuotientProjection H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) =
+      let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
+      let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
+      eqToHom (CommHopfAlgCat.pointsFppfGroupObject.eq_1 H.obj) ≫
+        F.mapGrp.map
+            (CommHopfAlgCat.pointwiseQuotientPresheafGrpProjection H.obj
+              (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+              (isNormal_identityComponentHopfIdeal H)) ≫
+        eqToHom (CommHopfAlgCat.fppfQuotientSheaf_def H.obj
+          (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+          (isNormal_identityComponentHopfIdeal H)).symm := by
+  let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
+  let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
+  apply Grp.hom_ext
+  rw [CommHopfAlgCat.fppfQuotientProjection_hom]
+  rw [Grp.comp_hom_hom, Grp.comp_hom_hom]
+  simp_rw [eqToHom_hom_hom]
+  rfl
+
+private theorem componentPointwiseQuotientNatIso_hom_app
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    (componentPointwiseQuotientNatIso H).hom.app A =
+      eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) A) ≫
+        (componentPointwiseQuotientMulEquiv H A).toGrpIso.hom ≫
+          eqToHom (HopfAlgebra.pointsFunctor_obj A).symm := by
+  rw [componentPointwiseQuotientNatIso.eq_1]
+  rfl
+
+private theorem pointwiseQuotientProjection_app'
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    (CommHopfAlgCat.pointwiseQuotientProjection H.obj
+      (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+      (isNormal_identityComponentHopfIdeal H)).app A =
+        eqToHom (HopfAlgebra.pointsFunctor_obj (H := H) A) ≫
+          CommHopfAlgCat.pointwiseQuotientMk H.obj
+            (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+            (isNormal_identityComponentHopfIdeal H) A ≫
+          eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj H.obj
+            (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+            (isNormal_identityComponentHopfIdeal H) A).symm := by
+  rw [CommHopfAlgCat.pointwiseQuotientProjection_app]
+  rfl
+
+private theorem mapPointsFunctor_componentCoordinateHom_app
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) (A : CommAlgCat.{u} k) :
+    (CommHopfAlgCat.mapPointsFunctor (componentCoordinateHom H)).app A =
+      eqToHom (HopfAlgebra.pointsFunctor_obj (H := H) A) ≫
+        GrpCat.ofHom (componentPointsHom H A) ≫
+          eqToHom (HopfAlgebra.pointsFunctor_obj
+            (H := ConstantGroup.coordinateRing k
+              (ConnectedComponents (PrimeSpectrum H))) A).symm := by
+  rfl
+
+private theorem pointwiseQuotientProjection_comp_componentNatIso_hom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.pointwiseQuotientProjection H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) ≫
+      (componentPointwiseQuotientNatIso H).hom =
+        CommHopfAlgCat.mapPointsFunctor (componentCoordinateHom H) := by
+  apply NatTrans.ext
+  funext A
+  rw [NatTrans.comp_app, pointwiseQuotientProjection_app',
+    componentPointwiseQuotientNatIso_hom_app,
+    mapPointsFunctor_componentCoordinateHom_app]
+  have hbare :
+      CommHopfAlgCat.pointwiseQuotientMk H.obj
+          (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+          (isNormal_identityComponentHopfIdeal H) A ≫
+        (componentPointwiseQuotientMulEquiv H A).toGrpIso.hom =
+      GrpCat.ofHom (componentPointsHom H A) := by
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    exact componentPointwiseQuotientMulEquiv_mk H A g
+  simpa only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl,
+    Category.id_comp] using congrArg (fun z ↦
+      eqToHom (HopfAlgebra.pointsFunctor_obj (H := H) A) ≫ z ≫
+        eqToHom (HopfAlgebra.pointsFunctor_obj
+          (H := ConstantGroup.coordinateRing k
+            (ConnectedComponents (PrimeSpectrum H))) A).symm) hbare
+
+/-- The component-coordinate map on group-valued presheaves, including the canonical universe
+and presentation transports used by the points-presheaf API. -/
+private noncomputable def componentCoordinatePresheafGrpHom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.pointsPresheafGrp H.obj ⟶
+      CommHopfAlgCat.pointsPresheafGrp
+        (CommHopfAlgCat.of k
+          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))) :=
+  eqToHom (CommHopfAlgCat.pointsPresheafGrp.eq_1 H.obj) ≫
+    CommHopfAlgCat.groupFunctorGrpMap (Functor.whiskerRight
+      (Functor.whiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
+        (CommHopfAlgCat.mapPointsFunctor (componentCoordinateHom H)))
+      GrpCat.uliftFunctor.{u + 1, u}) ≫
+    eqToHom (CommHopfAlgCat.pointsPresheafGrp.eq_1
+      (CommHopfAlgCat.of k
+        (ConstantGroup.coordinateRing k
+          (ConnectedComponents (PrimeSpectrum H))))).symm
+
+private theorem pointwiseQuotientPresheafGrpProjection_comp_componentIso_hom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.pointwiseQuotientPresheafGrpProjection H.obj
+        (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+        (isNormal_identityComponentHopfIdeal H) ≫
+      (componentPointwiseQuotientPresheafGrpIso H).hom =
+        componentCoordinatePresheafGrpHom H := by
+  rw [pointwiseQuotientPresheafGrpProjection_eq]
+  unfold componentPointwiseQuotientPresheafGrpIso componentCoordinatePresheafGrpHom
+  dsimp
+  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl,
+    Category.id_comp]
+  have hcore :
+      CommHopfAlgCat.groupFunctorGrpMap (Functor.whiskerRight
+          (CommHopfAlgCat.pointwiseQuotientPresheafProjection H.obj
+            (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+            (isNormal_identityComponentHopfIdeal H))
+          GrpCat.uliftFunctor.{u + 1, u}) ≫
+        (CommHopfAlgCat.groupFunctorGrpIso (Functor.isoWhiskerRight
+          (Functor.isoWhiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
+            (componentPointwiseQuotientNatIso H))
+          GrpCat.uliftFunctor.{u + 1, u})).hom =
+      CommHopfAlgCat.groupFunctorGrpMap (Functor.whiskerRight
+        (Functor.whiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
+          (CommHopfAlgCat.mapPointsFunctor (componentCoordinateHom H)))
+        GrpCat.uliftFunctor.{u + 1, u}) := by
+    rw [show (CommHopfAlgCat.groupFunctorGrpIso (Functor.isoWhiskerRight
+      (Functor.isoWhiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
+        (componentPointwiseQuotientNatIso H))
+      GrpCat.uliftFunctor.{u + 1, u})).hom =
+        CommHopfAlgCat.groupFunctorGrpMap (Functor.whiskerRight
+          (Functor.whiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor
+            (componentPointwiseQuotientNatIso H).hom)
+          GrpCat.uliftFunctor.{u + 1, u}) from rfl,
+      groupFunctorGrpMap_comp]
+    congr 1
+    simpa only [Functor.whiskerLeft_comp, Functor.whiskerRight_comp,
+      Functor.isoWhiskerLeft_hom, Functor.isoWhiskerRight_hom] using congrArg
+        (fun f ↦ Functor.whiskerRight
+          (Functor.whiskerLeft (opOpEquivalence (CommAlgCat.{u} k)).functor f)
+          GrpCat.uliftFunctor.{u + 1, u})
+        (pointwiseQuotientProjection_comp_componentNatIso_hom H)
+  simpa only [Category.assoc] using congrArg (fun f ↦
+    eqToHom (CommHopfAlgCat.pointsPresheafGrp.eq_1 H.obj) ≫ f ≫
+      eqToHom (CommHopfAlgCat.pointsPresheafGrp.eq_1
+        (CommHopfAlgCat.of k (ConstantGroup.coordinateRing k
+          (ConnectedComponents (PrimeSpectrum H))))).symm) hcore
+
+/-- The component-coordinate morphism on fppf points, obtained by sheafifying precomposition with
+`componentCoordinateHom`. -/
+noncomputable def componentCoordinateFppfGroupObjectHom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    CommHopfAlgCat.pointsFppfGroupObject H.obj ⟶
+      CommHopfAlgCat.pointsFppfGroupObject
+        (CommHopfAlgCat.of k
+          (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))) := by
+  let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
+  let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
+  exact eqToHom (CommHopfAlgCat.pointsFppfGroupObject.eq_1 H.obj) ≫
+    F.mapGrp.map (componentCoordinatePresheafGrpHom H) ≫
+      eqToHom (CommHopfAlgCat.pointsFppfGroupObject.eq_1
+        (CommHopfAlgCat.of k (ConstantGroup.coordinateRing k
+          (ConnectedComponents (PrimeSpectrum H))))).symm
+
+/-- The representability isomorphism carries the component-group quotient projection to the
+sheafification of the component-coordinate morphism on points. -/
+@[simp]
+theorem componentGroupFppfProjection_comp_componentGroupFppfGroupObjectIso_hom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupFppfProjection H ≫ (componentGroupFppfGroupObjectIso H).hom =
+      componentCoordinateFppfGroupObjectHom H := by
+  let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
+  let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
+  unfold componentGroupFppfProjection
+  rw [fppfQuotientProjection_eq]
+  unfold componentGroupFppfGroupObjectIso componentCoordinateFppfGroupObjectHom
+  dsimp
+  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl,
+    Category.id_comp]
+  change F.mapGrp.map
+        (CommHopfAlgCat.pointwiseQuotientPresheafGrpProjection H.obj
+          (HopfAlgebra.identityComponentHopfIdeal (k := k) (H := H))
+          (isNormal_identityComponentHopfIdeal H)) ≫
+      (F.mapGrp.mapIso (componentPointwiseQuotientPresheafGrpIso H)).hom =
+    F.mapGrp.map (componentCoordinatePresheafGrpHom H)
+  rw [Functor.mapIso_hom, ← F.mapGrp.map_comp,
+    pointwiseQuotientPresheafGrpProjection_comp_componentIso_hom]
 
 /-- The underlying fppf sheaf of the component-group quotient is represented by the finite
 constant group scheme on the connected components of the prime spectrum. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
@@ -114,14 +114,6 @@ noncomputable def pointsPresheafGrp (H : _root_.CommHopfAlgCat.{u} R) :
   groupFunctorGrp
     (HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u})
 
-/-- Unfold the points-presheaf group object to the group object associated to its group-valued
-functor. -/
-theorem pointsPresheafGrp_eq (H : _root_.CommHopfAlgCat.{u} R) :
-    pointsPresheafGrp H =
-      groupFunctorGrp
-        (HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u}) := by
-  rw [pointsPresheafGrp.eq_1]
-
 /-- The fppf sheaf of points, regarded as a group object in type-valued sheaves.
 
 This form is canonically the sheafification of the group-valued points presheaf. Since that
@@ -133,15 +125,6 @@ noncomputable def pointsFppfGroupObject (H : _root_.CommHopfAlgCat.{u} R) :
     Functor.Monoidal.ofChosenFiniteProducts _
   exact (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).mapGrp.obj
     (pointsPresheafGrp H)
-
-/-- Unfold the fppf points group object to the image of its presheaf group object under
-sheafification. -/
-theorem pointsFppfGroupObject_eq (H : _root_.CommHopfAlgCat.{u} R) :
-    pointsFppfGroupObject H =
-      let F := presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))
-      let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
-      F.mapGrp.obj (pointsPresheafGrp H) := by
-  rw [pointsFppfGroupObject.eq_1]
 
 /-- The underlying sheaf of `pointsFppfGroupObject` is canonically the universe lift of the
 existing group-valued points sheaf `HopfAlgebra.pointsFppfSheaf`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
@@ -94,12 +94,33 @@ noncomputable def groupFunctorGrpMap {C : Type u} [Category.{v} C]
         (α.app X) (p.1 : F.obj X) * (α.app X) (p.2 : F.obj X)
       exact (α.app X).hom.map_mul p.1 p.2)
 
+/-- A natural isomorphism of group-valued functors induces an isomorphism of their associated
+group objects in type-valued functors. -/
+noncomputable def groupFunctorGrpIso {C : Type u} [Category.{v} C]
+    {F G : C ⥤ GrpCat.{u}} (e : F ≅ G) : groupFunctorGrp F ≅ groupFunctorGrp G where
+  hom := groupFunctorGrpMap e.hom
+  inv := groupFunctorGrpMap e.inv
+  hom_inv_id := by
+    ext X x
+    exact congrArg (fun f ↦ f x) (e.hom_inv_id_app X)
+  inv_hom_id := by
+    ext X x
+    exact congrArg (fun f ↦ f x) (e.inv_hom_id_app X)
+
 /-- The convolution-points presheaf as a group object in type-valued presheaves, with values
 lifted to the universe in which the affine-site sheafification lives. -/
 noncomputable def pointsPresheafGrp (H : _root_.CommHopfAlgCat.{u} R) :
     Grp (((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ Type (u + 1)) :=
   groupFunctorGrp
     (HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u})
+
+/-- Unfold the points-presheaf group object to the group object associated to its group-valued
+functor. -/
+theorem pointsPresheafGrp_eq (H : _root_.CommHopfAlgCat.{u} R) :
+    pointsPresheafGrp H =
+      groupFunctorGrp
+        (HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u}) := by
+  rw [pointsPresheafGrp.eq_1]
 
 /-- The fppf sheaf of points, regarded as a group object in type-valued sheaves.
 
@@ -112,6 +133,15 @@ noncomputable def pointsFppfGroupObject (H : _root_.CommHopfAlgCat.{u} R) :
     Functor.Monoidal.ofChosenFiniteProducts _
   exact (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).mapGrp.obj
     (pointsPresheafGrp H)
+
+/-- Unfold the fppf points group object to the image of its presheaf group object under
+sheafification. -/
+theorem pointsFppfGroupObject_eq (H : _root_.CommHopfAlgCat.{u} R) :
+    pointsFppfGroupObject H =
+      let F := presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))
+      let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
+      F.mapGrp.obj (pointsPresheafGrp H) := by
+  rw [pointsFppfGroupObject.eq_1]
 
 /-- The underlying sheaf of `pointsFppfGroupObject` is canonically the universe lift of the
 existing group-valued points sheaf `HopfAlgebra.pointsFppfSheaf`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
@@ -107,6 +107,14 @@ noncomputable def groupFunctorGrpIso {C : Type u} [Category.{v} C]
     ext X x
     exact congrArg (fun f ↦ f x) (e.inv_hom_id_app X)
 
+/-- The forward map of the group-object isomorphism induced by a natural isomorphism is the
+group-object map induced by its forward natural transformation. -/
+@[simp]
+theorem groupFunctorGrpIso_hom {C : Type u} [Category.{v} C]
+    {F G : C ⥤ GrpCat.{u}} (e : F ≅ G) :
+    (groupFunctorGrpIso e).hom = groupFunctorGrpMap e.hom := by
+  rw [groupFunctorGrpIso.eq_1]
+
 /-- The convolution-points presheaf as a group object in type-valued presheaves, with values
 lifted to the universe in which the affine-site sheafification lives. -/
 noncomputable def pointsPresheafGrp (H : _root_.CommHopfAlgCat.{u} R) :

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.lean
@@ -79,7 +79,7 @@ noncomputable def pointwiseQuotientPresheafGrp
 
 /-- Unfold the pointwise quotient presheaf group object to the group object associated to its
 group-valued functor. -/
-theorem pointwiseQuotientPresheafGrp_eq
+theorem pointwiseQuotientPresheafGrp_def
     (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) (hI : I.IsNormal) :
     pointwiseQuotientPresheafGrp H I hI =
       groupFunctorGrp
@@ -151,7 +151,7 @@ noncomputable def fppfQuotientSheaf (H : _root_.CommHopfAlgCat.{u} R)
 
 /-- Unfold the fppf quotient group object to the image of its pointwise presheaf group object
 under sheafification. -/
-theorem fppfQuotientSheaf_eq (H : _root_.CommHopfAlgCat.{u} R)
+theorem fppfQuotientSheaf_def (H : _root_.CommHopfAlgCat.{u} R)
     (I : HopfIdeal R H) (hI : I.IsNormal) :
     fppfQuotientSheaf H I hI =
       let F := presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.lean
@@ -77,6 +77,15 @@ noncomputable def pointwiseQuotientPresheafGrp
   groupFunctorGrp
     (pointwiseQuotientPresheaf H I hI ⋙ GrpCat.uliftFunctor.{u + 1, u})
 
+/-- Unfold the pointwise quotient presheaf group object to the group object associated to its
+group-valued functor. -/
+theorem pointwiseQuotientPresheafGrp_eq
+    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) (hI : I.IsNormal) :
+    pointwiseQuotientPresheafGrp H I hI =
+      groupFunctorGrp
+        (pointwiseQuotientPresheaf H I hI ⋙ GrpCat.uliftFunctor.{u + 1, u}) := by
+  rw [pointwiseQuotientPresheafGrp.eq_1]
+
 /-- The quotient projection as a morphism of group objects in type-valued presheaves. -/
 noncomputable def pointwiseQuotientPresheafGrpProjection
     (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) (hI : I.IsNormal) :
@@ -139,6 +148,16 @@ noncomputable def fppfQuotientSheaf (H : _root_.CommHopfAlgCat.{u} R)
     Functor.Monoidal.ofChosenFiniteProducts _
   exact (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).mapGrp.obj
     (pointwiseQuotientPresheafGrp H I hI)
+
+/-- Unfold the fppf quotient group object to the image of its pointwise presheaf group object
+under sheafification. -/
+theorem fppfQuotientSheaf_eq (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) (hI : I.IsNormal) :
+    fppfQuotientSheaf H I hI =
+      let F := presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))
+      let _ : F.Monoidal := Functor.Monoidal.ofChosenFiniteProducts F
+      F.mapGrp.obj (pointwiseQuotientPresheafGrp H I hI) := by
+  rw [fppfQuotientSheaf.eq_1]
 
 /-- The canonical morphism from the fppf sheaf of points of `G` to the fppf quotient sheaf
 `G / V(I)`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -115,6 +115,14 @@ lemma pointsFunctor_map {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     (pointsFunctor (H := H)).map φ = mapPoints (H := H) φ :=
   rfl
 
+/-- The map of `pointsFunctor`, transported along its concrete object presentations, is the
+corresponding map on points. -/
+lemma pointsFunctor_map_eqToHom {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    eqToHom (pointsFunctor_obj (H := H) A).symm ≫
+        (pointsFunctor (H := H)).map φ =
+      mapPoints (H := H) φ ≫ eqToHom (pointsFunctor_obj (H := H) B).symm :=
+  rfl
+
 /-- The pointwise value of the image of an `A`-point under `pointsFunctor.map φ`. -/
 @[simp]
 lemma pointsFunctor_map_apply_apply {A B : CommAlgCat.{w} R} (φ : A ⟶ B)


### PR DESCRIPTION
This PR identifies the fppf quotient by the identity component with the finite constant group of connected components over an algebraically closed field. It advances the exact ReductiveGroups Layer 3 milestone “Identity component `G°` and component group `π₀(G)`,” specifically the finite-étale component-group conclusion after geometric base change.

For every commutative test algebra, construct a global lift of a constant-component point by gluing chosen rational representatives along its complete family of orthogonal idempotents. Use the established kernel description for the component coordinate morphism and the first isomorphism theorem to obtain a natural multiplicative equivalence from the pointwise quotient. Sheafifying that natural equivalence yields `componentGroupFppfSheafIso`, exhibiting the quotient sheaf as the points sheaf of `ConstantGroup.groupScheme` on the finite set of connected components; the existing `isFinite_groupScheme` and `etale_groupScheme` instances supply finiteness and étaleness.

This is the most direct next step after the component coordinate morphism and finite constant group scheme infrastructure already on `main`: it turns those two prerequisites into the representability theorem needed by the milestone. After this PR, the milestone still needs geometric connectedness under base change and descent of the component group from an algebraic closure to perfect fields (or the roadmap’s suitable smoothness hypotheses).

The implementation reuses Mathlib’s `CompleteOrthogonalIdempotents`, functor/sheafification infrastructure, and quotient-group first isomorphism machinery, together with Tau Ceti’s component-coordinate kernel theorem. No Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"component-group-fppf-quotient-representable"}-->

🤖 Prepared with Codex
