### PR TITLE
feat: characterize unipotence by upper-unitriangular embeddings

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.UpperUnitriangular
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule.Flag.Induction
+import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Naturality
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.ClosedSubgroup
+import TauCeti.Algebra.AlgebraicGroup.UpperUnitriangular.Unipotent
+import TauCeti.Algebra.Coalgebra.Comodule.PointAction
+import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Kolchin
+
+/-!
+# Embedding unipotent affine groups in upper-unitriangular groups
+
+Let `H` be a reduced finite-type commutative Hopf algebra over an algebraically closed field `k`.
+If every `k`-valued point of `H` is unipotent, Kolchin's common fixed vector theorem gives a
+nonzero fixed vector in every nonzero finite-dimensional `H`-comodule. Point separation promotes
+the pointwise fixed-vector equation to the comodule equation `v ↦ v ⊗ 1`. Induction on dimension
+then produces a basis in which the coefficient matrix is upper unitriangular.
+
+Applying this to a faithful finite-dimensional subcomodule of the regular comodule gives a closed
+immersion of the represented affine group into some upper-unitriangular group `U_n`. The geometric
+unipotence property implies the required hypothesis on `k`-points by extension to the chosen
+algebraic closure.
+
+Reducedness is explicit in this file because it is exactly the hypothesis used by point
+separation. A future smooth-implies-geometrically-reduced theorem will discharge it for the
+roadmap's smooth formulation.
+
+## Main declarations
+
+* `TauCeti.Comodule.hasNonzeroFixedVector_of_forall_isUnipotentPoint`: Kolchin's theorem promoted
+  from point actions to a comodule fixed vector.
+* `TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperUnitriangular_of_forall_isUnipotentPoint`:
+  every finite-dimensional comodule has an upper-unitriangular basis.
+* `TauCeti.Comodule.exists_isClosedImmersion_upperUnitriangular_of_forall_isUnipotentPoint`:
+  the represented affine group embeds as a closed subgroup of some `U_n`.
+* `TauCeti.Comodule.exists_isClosedImmersion_upperUnitriangular_of_geometricallyUnipotentPoints`:
+  the same conclusion from the roadmap's geometric-point predicate.
+* `TauCeti.Comodule.geometricallyUnipotentPoints_iff_exists_isClosedImmersion_upperUnitriangular`:
+  the upper-unitriangular embedding characterization.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+
+This closes the Kolchin and faithful-embedding step of Layer 5, "Unipotent groups", of the
+ReductiveGroups roadmap for reduced groups over an algebraically closed field.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+open AlgebraicGeometry WithConv
+
+universe u
+
+noncomputable section
+
+variable {k H M : Type u}
+variable [Field k] [IsAlgClosed k] [CommRing H] [HopfAlgebra k H]
+variable [Algebra.FiniteType k H] [IsReduced H]
+variable [AddCommGroup M] [Module k M] [Comodule k H M]
+
+/-- If every point of a reduced finite-type commutative Hopf algebra over an algebraically closed
+field is unipotent, then every nonzero finite-dimensional comodule has a nonzero fixed vector. -/
+theorem hasNonzeroFixedVector_of_forall_isUnipotentPoint
+    [FiniteDimensional k M] [Nontrivial M]
+    (hH : ∀ g : WithConv (H →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g) :
+    HasNonzeroFixedVector k H M := by
+  obtain ⟨w, hw, hfixed⟩ :=
+    _root_.Representation.exists_common_fixed_vector_of_isUnipotent
+      (pointsRepresentation (A := k) M) fun g ↦ by
+        rw [pointsRepresentation_apply]
+        exact (HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one g).mp
+          (hH g) (FGComoduleCat.of (R := k) (C := H) M)
+  let e := TensorProduct.lid k M
+  let v := e w
+  rw [hasNonzeroFixedVector_iff]
+  refine ⟨v, fun hv ↦ hw (e.injective hv), ?_⟩
+  rw [coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (K := k)]
+  intro g
+  have haction := hfixed g
+  rw [pointsRepresentation_apply] at haction
+  rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap]
+  have hv : (1 : k) ⊗ₜ[k] v = w := by
+    exact e.symm_apply_apply w
+  simpa only [hv] using haction
+
+/-- If all points are unipotent, every finite-dimensional comodule has a basis with upper
+unitriangular coefficient matrix. -/
+theorem exists_basis_coefficientMatrix_isUpperUnitriangular_of_forall_isUnipotentPoint
+    [FiniteDimensional k M]
+    (hH : ∀ g : WithConv (H →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g) :
+    ∃ (n : ℕ) (b : _root_.Module.Basis (Fin n) k M),
+      (coefficientMatrix (C := H) b).IsUpperUnitriangular :=
+  exists_basis_coefficientMatrix_isUpperUnitriangular_of_fixed_vectors fun V _ _ _ _ _ ↦
+    hasNonzeroFixedVector_of_forall_isUnipotentPoint (M := V) hH
+
+/-- A reduced finite-type affine group over an algebraically closed field whose points are all
+unipotent embeds as a closed subgroup of an upper-unitriangular group. The witness includes the
+faithful comodule and its upper-unitriangular basis. -/
+theorem exists_isClosedImmersion_upperUnitriangular_of_forall_isUnipotentPoint
+    (hH : ∀ g : WithConv (H →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g) :
+    ∃ (M : Subcomodule k H H) (n : ℕ) (b : _root_.Module.Basis (Fin n) k M)
+      (hb : (coefficientMatrix (C := H) b).IsUpperUnitriangular),
+      IsClosedImmersion
+        (upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb).hom.hom.left := by
+  obtain ⟨M, n, b, hb⟩ := exists_isClosedImmersion_coordinateGroupSchemeHom (k := k) (H := H)
+  let _ : AddCommGroup M := _root_.Module.addCommMonoidToAddCommGroup k
+  let _ : _root_.Module.Finite k M := _root_.Module.Finite.of_basis b
+  have hfaithful : IsFaithful (k := k) (H := H) (V := M) :=
+    (isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom b).mpr hb
+  obtain ⟨m, b', hb'⟩ :=
+    exists_basis_coefficientMatrix_isUpperUnitriangular_of_forall_isUnipotentPoint
+      (M := M) hH
+  exact ⟨M, m, b', hb',
+    (isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff_isFaithful b' hb').mpr
+      hfaithful⟩
+
+/-- Geometric unipotence implies that the represented reduced affine group embeds as a closed
+subgroup of an upper-unitriangular group. -/
+theorem exists_isClosedImmersion_upperUnitriangular_of_geometricallyUnipotentPoints
+    (hH : geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H)) :
+    ∃ (M : Subcomodule k H H) (n : ℕ) (b : _root_.Module.Basis (Fin n) k M)
+      (hb : (coefficientMatrix (C := H) b).IsUpperUnitriangular),
+      IsClosedImmersion
+        (upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb).hom.hom.left := by
+  apply exists_isClosedImmersion_upperUnitriangular_of_forall_isUnipotentPoint
+  intro g
+  let φ : k →ₐ[k] AlgebraicClosure k := _root_.Algebra.ofId k (AlgebraicClosure k)
+  have hgeom := (geometricallyUnipotentPointsCommHopfAlgProperty_iff k
+    (CommHopfAlgCat.of k H)).mp hH
+  exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
+    (hgeom (AlgHom.mapValue (H := H) φ g))
+
+/-- A reduced finite-type affine group over an algebraically closed field has only unipotent
+points if and only if it admits a faithful upper-unitriangular representation, equivalently a
+closed immersion into some `U_n`. -/
+theorem geometricallyUnipotentPoints_iff_exists_isClosedImmersion_upperUnitriangular :
+    geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H) ↔
+      ∃ (M : Subcomodule k H H) (n : ℕ) (b : _root_.Module.Basis (Fin n) k M)
+        (hb : (coefficientMatrix (C := H) b).IsUpperUnitriangular),
+        IsClosedImmersion
+          (upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb).hom.hom.left := by
+  constructor
+  · exact exists_isClosedImmersion_upperUnitriangular_of_geometricallyUnipotentPoints
+  · rintro ⟨M, n, b, hb, hclosed⟩
+    apply geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective k
+      (CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom (H := H) b hb))
+    · exact (isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff b hb).mp hclosed
+    · exact UpperUnitriangular.geometricallyUnipotentPointsCommHopfAlgProperty_coordinateHopfAlgebra
+        n k
+
+end
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
@@ -219,11 +219,13 @@ theorem of_isClosedImmersion_upperUnitriangularGroupScheme
         (eqToIso (UpperUnitriangular.groupScheme_def k (Fin n))))).isIso_hom
   let φ : (CommHopfAlgCat.of k (UpperUnitriangular.coordinateHopfAlgebra k (Fin n))) ⟶
       (CommHopfAlgCat.of k H) := (hF.preimage (f ≫ e)).unop
+  have hmap : F.map φ.op = f ≫ e := by
+    -- `φ` stores the unopposite of the preimage, so remove the resulting `op_unop` wrapper.
+    simpa only [φ, Quiver.Hom.op_unop] using hF.map_preimage (f ≫ e)
   apply geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective k φ
   · apply (CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff
       (S := CommRingCat.of k) φ).mp
-    rw [show F.map φ.op = f ≫ e by
-      simpa only [φ, Quiver.Hom.op_unop] using hF.map_preimage (f ≫ e)]
+    rw [hmap]
     simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
     rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
     exact hclosed

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
@@ -41,8 +41,9 @@ roadmap's smooth formulation.
 * `iff_exists_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom` in the
   `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty` namespace: the upper-unitriangular
   embedding characterization.
-* `exists_isClosedImmersion_upperUnitriangularGroupScheme` in that namespace: the represented
-  affine group embeds as a closed subgroup of some `U_n`.
+* `iff_exists_isClosedImmersion_upperUnitriangularGroupScheme` in that namespace: the represented
+  affine group is geometrically unipotent exactly when it embeds as a closed subgroup of some
+  `U_n`.
 
 ## References
 
@@ -59,7 +60,7 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-open AlgebraicGeometry WithConv
+open AlgebraicGeometry CategoryTheory WithConv
 
 universe u
 
@@ -200,6 +201,47 @@ theorem exists_isClosedImmersion_upperUnitriangularGroupScheme
   obtain ⟨M, n, b, hb, hclosed⟩ :=
     exists_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom hH
   exact ⟨n, upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb, hclosed⟩
+
+/-- A closed immersion of the represented affine group into an upper-unitriangular group makes it
+geometrically unipotent. -/
+theorem of_isClosedImmersion_upperUnitriangularGroupScheme
+    {n : ℕ}
+    (f : (hopfSpec (CommRingCat.of k)).obj (Opposite.op (CommHopfAlgCat.of k H)) ⟶
+      UpperUnitriangular.groupScheme k (Fin n))
+    (hclosed : IsClosedImmersion f.hom.hom.left) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H) := by
+  let F := hopfSpec (CommRingCat.of k)
+  let hF := hopfSpec.fullyFaithful (R := CommRingCat.of k)
+  let e := eqToHom (UpperUnitriangular.groupScheme_def k (Fin n))
+  let _ : IsIso e.hom.hom.left :=
+    ((Over.forget (Spec (CommRingCat.of k))).mapIso
+      ((Grp.forget (Over (Spec (CommRingCat.of k)))).mapIso
+        (eqToIso (UpperUnitriangular.groupScheme_def k (Fin n))))).isIso_hom
+  let φ : (CommHopfAlgCat.of k (UpperUnitriangular.coordinateHopfAlgebra k (Fin n))) ⟶
+      (CommHopfAlgCat.of k H) := (hF.preimage (f ≫ e)).unop
+  apply geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective k φ
+  · apply (CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff
+      (S := CommRingCat.of k) φ).mp
+    rw [show F.map φ.op = f ≫ e by
+      simpa only [φ, Quiver.Hom.op_unop] using hF.map_preimage (f ≫ e)]
+    simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
+    rw [MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion)]
+    exact hclosed
+  · exact UpperUnitriangular.geometricallyUnipotentPointsCommHopfAlgProperty_coordinateHopfAlgebra
+      n k
+
+/-- A reduced finite-type affine group over an algebraically closed field is geometrically
+unipotent if and only if it embeds as a closed subgroup of some upper-unitriangular group `U_n`. -/
+theorem iff_exists_isClosedImmersion_upperUnitriangularGroupScheme
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H] :
+    geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H) ↔
+      ∃ (n : ℕ)
+        (f : (hopfSpec (CommRingCat.of k)).obj (Opposite.op (CommHopfAlgCat.of k H)) ⟶
+          UpperUnitriangular.groupScheme k (Fin n)), IsClosedImmersion f.hom.hom.left := by
+  constructor
+  · exact exists_isClosedImmersion_upperUnitriangularGroupScheme
+  · rintro ⟨n, f, hclosed⟩
+    exact of_isClosedImmersion_upperUnitriangularGroupScheme f hclosed
 
 /-- A reduced finite-type affine group over an algebraically closed field has only unipotent
 points if and only if a finite-dimensional subcomodule of its regular comodule has an

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
@@ -34,16 +34,15 @@ roadmap's smooth formulation.
 
 ## Main declarations
 
-* `TauCeti.Comodule.hasNonzeroFixedVector_of_forall_isUnipotentPoint`: Kolchin's theorem promoted
-  from point actions to a comodule fixed vector.
+* `TauCeti.Comodule.hasNonzeroFixedVector_of_forall_isNilpotent_endOfPoint_sub_one`: Kolchin's
+  theorem promoted from point actions to a comodule fixed vector.
 * `TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperUnitriangular_of_forall_isUnipotentPoint`:
   every finite-dimensional comodule has an upper-unitriangular basis.
-* `TauCeti.Comodule.exists_isClosedImmersion_upperUnitriangular_of_forall_isUnipotentPoint`:
-  the represented affine group embeds as a closed subgroup of some `U_n`.
-* `TauCeti.Comodule.exists_isClosedImmersion_upperUnitriangular_of_geometricallyUnipotentPoints`:
-  the same conclusion from the roadmap's geometric-point predicate.
-* `TauCeti.Comodule.geometricallyUnipotentPoints_iff_exists_isClosedImmersion_upperUnitriangular`:
-  the upper-unitriangular embedding characterization.
+* `iff_exists_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom` in the
+  `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty` namespace: the upper-unitriangular
+  embedding characterization.
+* `exists_isClosedImmersion_upperUnitriangularGroupScheme` in that namespace: the represented
+  affine group embeds as a closed subgroup of some `U_n`.
 
 ## References
 
@@ -58,7 +57,7 @@ public section
 
 open scoped TensorProduct
 
-namespace TauCeti.Comodule
+namespace TauCeti
 
 open AlgebraicGeometry WithConv
 
@@ -67,38 +66,53 @@ universe u
 noncomputable section
 
 variable {k H M : Type u}
-variable [Field k] [IsAlgClosed k] [CommRing H] [HopfAlgebra k H]
-variable [Algebra.FiniteType k H] [IsReduced H]
+variable [Field k] [CommRing H] [HopfAlgebra k H]
 variable [AddCommGroup M] [Module k M] [Comodule k H M]
 
-/-- If every point of a reduced finite-type commutative Hopf algebra over an algebraically closed
-field is unipotent, then every nonzero finite-dimensional comodule has a nonzero fixed vector. -/
-theorem hasNonzeroFixedVector_of_forall_isUnipotentPoint
+namespace Comodule
+
+/-- If every point acts nilpotently minus the identity on a given comodule over a reduced
+finite-type commutative Hopf algebra over an algebraically closed field, then that comodule has a
+nonzero fixed vector. -/
+theorem hasNonzeroFixedVector_of_forall_isNilpotent_endOfPoint_sub_one
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H]
     [FiniteDimensional k M] [Nontrivial M]
-    (hH : ∀ g : WithConv (H →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g) :
+    (hM : ∀ g : WithConv (H →ₐ[k] k), IsNilpotent (endOfPoint M g.ofConv - 1)) :
     HasNonzeroFixedVector k H M := by
   obtain ⟨w, hw, hfixed⟩ :=
     _root_.Representation.exists_common_fixed_vector_of_isUnipotent
       (pointsRepresentation (A := k) M) fun g ↦ by
         rw [pointsRepresentation_apply]
-        exact (HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one g).mp
-          (hH g) (FGComoduleCat.of (R := k) (C := H) M)
+        exact hM g
   let e := TensorProduct.lid k M
   let v := e w
   rw [hasNonzeroFixedVector_iff]
-  refine ⟨v, fun hv ↦ hw (e.injective hv), ?_⟩
+  refine ⟨v, e.map_ne_zero_iff.mpr hw, ?_⟩
   rw [coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (K := k)]
   intro g
   have haction := hfixed g
   rw [pointsRepresentation_apply] at haction
   rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap]
   have hv : (1 : k) ⊗ₜ[k] v = w := by
-    exact e.symm_apply_apply w
+    exact (TensorProduct.lid_symm_apply (R := k) v).symm.trans (e.symm_apply_apply w)
   simpa only [hv] using haction
+
+/-- If every point of a reduced finite-type commutative Hopf algebra over an algebraically closed
+field is unipotent, then every nonzero finite-dimensional comodule has a nonzero fixed vector. -/
+theorem hasNonzeroFixedVector_of_forall_isUnipotentPoint
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H]
+    [FiniteDimensional k M] [Nontrivial M]
+    (hH : ∀ g : WithConv (H →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g) :
+    HasNonzeroFixedVector k H M := by
+  apply hasNonzeroFixedVector_of_forall_isNilpotent_endOfPoint_sub_one
+  intro g
+  exact (HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one g).mp
+    (hH g) (FGComoduleCat.of (R := k) (C := H) M)
 
 /-- If all points are unipotent, every finite-dimensional comodule has a basis with upper
 unitriangular coefficient matrix. -/
 theorem exists_basis_coefficientMatrix_isUpperUnitriangular_of_forall_isUnipotentPoint
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H]
     [FiniteDimensional k M]
     (hH : ∀ g : WithConv (H →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g) :
     ∃ (n : ℕ) (b : _root_.Module.Basis (Fin n) k M),
@@ -106,10 +120,13 @@ theorem exists_basis_coefficientMatrix_isUpperUnitriangular_of_forall_isUnipoten
   exists_basis_coefficientMatrix_isUpperUnitriangular_of_fixed_vectors fun V _ _ _ _ _ ↦
     hasNonzeroFixedVector_of_forall_isUnipotentPoint (M := V) hH
 
+namespace upperUnitriangularCoordinateGroupSchemeHom
+
 /-- A reduced finite-type affine group over an algebraically closed field whose points are all
 unipotent embeds as a closed subgroup of an upper-unitriangular group. The witness includes the
 faithful comodule and its upper-unitriangular basis. -/
-theorem exists_isClosedImmersion_upperUnitriangular_of_forall_isUnipotentPoint
+theorem exists_isClosedImmersion_of_forall_isUnipotentPoint
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H]
     (hH : ∀ g : WithConv (H →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g) :
     ∃ (M : Subcomodule k H H) (n : ℕ) (b : _root_.Module.Basis (Fin n) k M)
       (hb : (coefficientMatrix (C := H) b).IsUpperUnitriangular),
@@ -127,15 +144,18 @@ theorem exists_isClosedImmersion_upperUnitriangular_of_forall_isUnipotentPoint
     (isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff_isFaithful b' hb').mpr
       hfaithful⟩
 
-/-- Geometric unipotence implies that the represented reduced affine group embeds as a closed
-subgroup of an upper-unitriangular group. -/
-theorem exists_isClosedImmersion_upperUnitriangular_of_geometricallyUnipotentPoints
+end upperUnitriangularCoordinateGroupSchemeHom
+
+end Comodule
+
+namespace geometricallyUnipotentPointsCommHopfAlgProperty
+
+open Comodule Comodule.upperUnitriangularCoordinateGroupSchemeHom
+
+/-- Geometric unipotence implies that every point valued in the ground field is unipotent. -/
+theorem forall_isUnipotentPoint
     (hH : geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H)) :
-    ∃ (M : Subcomodule k H H) (n : ℕ) (b : _root_.Module.Basis (Fin n) k M)
-      (hb : (coefficientMatrix (C := H) b).IsUpperUnitriangular),
-      IsClosedImmersion
-        (upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb).hom.hom.left := by
-  apply exists_isClosedImmersion_upperUnitriangular_of_forall_isUnipotentPoint
+    ∀ g : WithConv (H →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g := by
   intro g
   let φ : k →ₐ[k] AlgebraicClosure k := _root_.Algebra.ofId k (AlgebraicClosure k)
   have hgeom := (geometricallyUnipotentPointsCommHopfAlgProperty_iff k
@@ -143,24 +163,63 @@ theorem exists_isClosedImmersion_upperUnitriangular_of_geometricallyUnipotentPoi
   exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
     (hgeom (AlgHom.mapValue (H := H) φ g))
 
+/-- A closed immersion given by an upper-unitriangular comodule makes the represented affine group
+geometrically unipotent. -/
+theorem of_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom
+    {n : ℕ} (b : _root_.Module.Basis (Fin n) k M)
+    (hb : (coefficientMatrix (C := H) b).IsUpperUnitriangular)
+    (hclosed : IsClosedImmersion
+      (upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb).hom.hom.left) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H) := by
+  apply geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective k
+    (CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom (H := H) b hb))
+  · exact (isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff b hb).mp hclosed
+  · exact UpperUnitriangular.geometricallyUnipotentPointsCommHopfAlgProperty_coordinateHopfAlgebra
+      n k
+
+/-- Geometric unipotence implies that the represented reduced affine group has a faithful
+upper-unitriangular coordinate morphism. -/
+theorem exists_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H]
+    (hH : geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H)) :
+    ∃ (M : Subcomodule k H H) (n : ℕ) (b : _root_.Module.Basis (Fin n) k M)
+      (hb : (coefficientMatrix (C := H) b).IsUpperUnitriangular),
+      IsClosedImmersion
+        (upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb).hom.hom.left := by
+  exact exists_isClosedImmersion_of_forall_isUnipotentPoint
+    (forall_isUnipotentPoint hH)
+
+/-- A geometrically unipotent reduced finite-type affine group over an algebraically closed field
+embeds as a closed subgroup of some upper-unitriangular group `U_n`. -/
+theorem exists_isClosedImmersion_upperUnitriangularGroupScheme
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H]
+    (hH : geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H)) :
+    ∃ (n : ℕ)
+      (f : (hopfSpec (CommRingCat.of k)).obj (Opposite.op (CommHopfAlgCat.of k H)) ⟶
+        UpperUnitriangular.groupScheme k (Fin n)), IsClosedImmersion f.hom.hom.left := by
+  obtain ⟨M, n, b, hb, hclosed⟩ :=
+    exists_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom hH
+  exact ⟨n, upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb, hclosed⟩
+
 /-- A reduced finite-type affine group over an algebraically closed field has only unipotent
-points if and only if it admits a faithful upper-unitriangular representation, equivalently a
-closed immersion into some `U_n`. -/
-theorem geometricallyUnipotentPoints_iff_exists_isClosedImmersion_upperUnitriangular :
+points if and only if a finite-dimensional subcomodule of its regular comodule has an
+upper-unitriangular basis whose coordinate morphism is a closed immersion into `U_n`. -/
+theorem iff_exists_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H] :
     geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H) ↔
       ∃ (M : Subcomodule k H H) (n : ℕ) (b : _root_.Module.Basis (Fin n) k M)
         (hb : (coefficientMatrix (C := H) b).IsUpperUnitriangular),
         IsClosedImmersion
           (upperUnitriangularCoordinateGroupSchemeHom (H := H) b hb).hom.hom.left := by
   constructor
-  · exact exists_isClosedImmersion_upperUnitriangular_of_geometricallyUnipotentPoints
+  · exact exists_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom
   · rintro ⟨M, n, b, hb, hclosed⟩
-    apply geometricallyUnipotentPointsCommHopfAlgProperty_of_surjective k
-      (CommHopfAlgCat.ofHom (upperUnitriangularCoordinateBialgHom (H := H) b hb))
-    · exact (isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom_iff b hb).mp hclosed
-    · exact UpperUnitriangular.geometricallyUnipotentPointsCommHopfAlgProperty_coordinateHopfAlgebra
-        n k
+    let _ : AddCommGroup M := _root_.Module.addCommMonoidToAddCommGroup k
+    exact of_isClosedImmersion_upperUnitriangularCoordinateGroupSchemeHom
+      (M := M) (H := H) b hb hclosed
+
+end geometricallyUnipotentPointsCommHopfAlgProperty
 
 end
 
-end TauCeti.Comodule
+end TauCeti


### PR DESCRIPTION
This PR proves the reduced algebraically closed coordinate case of the exact `ReductiveGroups/README.md` Layer 5 milestone **Unipotent groups**, which asks that a smooth connected group be unipotent exactly when it embeds in an upper-unitriangular group. It characterizes geometric-point unipotence of a reduced finite-type commutative Hopf algebra over an algebraically closed field by the existence of a faithful upper-unitriangular comodule, equivalently a closed immersion of its Hopf spectrum into some `U_n`.

The forward implication applies Kolchin's common fixed vector theorem to every finite-dimensional comodule, uses reduced finite-type point separation to promote pointwise fixed vectors to honest comodule fixed vectors, inducts on dimension to obtain an upper-unitriangular coefficient matrix, and applies the existing finite-subcoalgebra embedding theorem to choose the comodule faithfully. The converse reuses the existing unipotence of `U_n` and preservation under smooth closed subgroups. The main result is `Comodule.geometricallyUnipotentPoints_iff_exists_isClosedImmersion_upperUnitriangular`, with separate fixed-vector, basis, and embedding lemmas for downstream use.

After this PR, the Layer 5 embedding milestone still needs the smooth-implies-geometrically-reduced bridge to remove the explicit `IsReduced` hypothesis from the smooth formulation, and descent from the algebraically closed case to the intended perfect-field generality.

The proof follows J. C. Jantzen, *Representations of Algebraic Groups*, I.2, and T. A. Springer, *Linear Algebraic Groups*, §2.4, as credited in the module docstring. No Mathlib infrastructure was vendored. The new file is `TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean` (166 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"smooth-unipotent-upper-unitriangular-embedding"}-->

🤖 Prepared with Codex
