### PR TITLE
feat: package semisimple affine group schemes

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
@@ -118,6 +118,10 @@ instance (k : Type u) [Field k] :
         (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
           (CommHopfAlgCat.{u} (AlgebraicClosure k))))).IsClosedUnderIsomorphisms)
 
+/-- The category of semisimple finite-type commutative Hopf algebras over a field. -/
+abbrev SemisimpleCommHopfAlgCat (k : Type u) [Field k] :=
+  (semisimpleCommHopfAlgProperty k).FullSubcategory
+
 namespace semisimpleCommHopfAlgProperty
 
 variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}

--- a/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Semisimple/Basic.lean
@@ -30,6 +30,8 @@ algebraic closure of the ground field via the counit.
 
 * `TauCeti.semisimpleCommHopfAlgProperty`: semisimplicity for finite-type commutative Hopf
   algebras over a field.
+* `TauCeti.SemisimpleCommHopfAlgCat`: the full subcategory of semisimple coordinate Hopf
+  algebras.
 * `TauCeti.semisimpleCommHopfAlgProperty.eq_augmentation`: every connected normal smooth
   solvable closed subgroup of a semisimple group's geometric fibre is trivial.
 * `TauCeti.semisimpleCommHopfAlgProperty.geometricFiberCounitBialgEquiv`: a semisimple group

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -125,9 +125,10 @@ theorem geometricallyConnected_iff_geometricallyConnected_coordinate
   let eG :
       (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅ G.obj :=
     (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso (E.counitIso.app G)
-  change geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k) G.obj ↔
-    (geometricallyConnectedCommHopfAlgProperty k).op H₀
   calc
+    GeometricallyConnected G.obj.obj.X.hom ↔
+        geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k) G.obj :=
+      (geometricallyConnectedAffineGroupSchemeProperty_iff (CommRingCat.of k) G.obj).symm
     _ ↔ geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)
         ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
       ((geometricallyConnectedAffineGroupSchemeProperty
@@ -138,10 +139,15 @@ theorem geometricallyConnected_iff_geometricallyConnected_coordinate
       (geometricallyConnectedAffineGroupSchemeProperty
         (CommRingCat.of k)).prop_iff_of_iso eSpec
     _ ↔ (geometricallyConnectedCommHopfAlgProperty k).op H₀ := by
-      change ((geometricallyConnectedAffineGroupSchemeProperty
-        (CommRingCat.of k)).inverseImage
-          (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor) H₀ ↔ _
-      rw [geometricallyConnectedAffineGroupSchemeProperty_inverseImage]
+      exact Iff.of_eq <| congrArg
+        (fun P : ObjectProperty (CommHopfAlgCat.{u} k)ᵒᵖ ↦ P H₀)
+        (geometricallyConnectedAffineGroupSchemeProperty_inverseImage k)
+    _ ↔ geometricallyConnectedCommHopfAlgProperty k
+        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
+          G).unop.obj := by
+      rw [ObjectProperty.op_iff]
+      simp only [H₀, H, E, Functor.op_obj,
+        FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj]
 
 /-- The structural morphism of a Hopf spectrum is geometrically connected exactly when, after
 every extension `K / k` of the base field, every idempotent of `H ⊗[k] K` is zero or one. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.AlgebraicGeometry.Geometrically.Connected
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
 
 /-!
 # Geometric connectedness of affine group schemes
@@ -17,8 +17,12 @@ scheme-theoretic `GeometricallyConnected` predicate on its Hopf spectrum.
 
 ## Main declarations
 
+* `TauCeti.geometricallyConnectedAffineGroupSchemeProperty`: geometric connectedness of the
+  structural morphism as an object property on affine group schemes.
 * `TauCeti.geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec`: compatibility
   of the coordinate-ring and scheme-theoretic predicates.
+* `TauCeti.geometricallyConnected_iff_geometricallyConnected_coordinate`: geometric
+  connectedness of a finite-type affine group scheme in terms of its coordinate algebra.
 * `TauCeti.geometricallyConnected_hopfSpec_iff_idempotent_eq_zero_or_one`: the idempotent
   characterization of geometric connectedness for a Hopf spectrum.
 
@@ -41,6 +45,32 @@ open AlgebraicGeometry
 
 universe u
 
+private instance geometricallyConnected_respectsIso :
+    MorphismProperty.RespectsIso @GeometricallyConnected :=
+  MorphismProperty.IsStableUnderBaseChange.respectsIso
+
+/-- The object property on affine group schemes selecting those whose structural morphism is
+geometrically connected. -/
+def geometricallyConnectedAffineGroupSchemeProperty (S : CommRingCat.{u}) :
+    ObjectProperty (AffineGroupSchemeCat S) :=
+  fun G => GeometricallyConnected G.obj.X.hom
+
+/-- Membership in the geometrically connected affine-group-scheme object property. -/
+@[simp]
+lemma geometricallyConnectedAffineGroupSchemeProperty_iff (S : CommRingCat.{u})
+    (G : AffineGroupSchemeCat S) :
+    geometricallyConnectedAffineGroupSchemeProperty S G ↔
+      GeometricallyConnected G.obj.X.hom :=
+  Iff.rfl
+
+/-- Geometric connectedness of the structural morphism is invariant under isomorphism of affine
+group schemes. -/
+instance (S : CommRingCat.{u}) :
+    (geometricallyConnectedAffineGroupSchemeProperty S).IsClosedUnderIsomorphisms where
+  of_iso e hG :=
+    (MorphismProperty.over_iso_iff (@GeometricallyConnected)
+      ((Grp.forget _).mapIso ((affineGroupSchemeProperty S).ι.mapIso e))).mp hG
+
 /-- **Geometric connectedness agrees across the affine-group-scheme and coordinate-ring
 models.** The structural morphism of a Hopf spectrum is geometrically connected if and only if
 its coordinate algebra is geometrically connected after every field extension. -/
@@ -49,9 +79,6 @@ theorem geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec
     geometricallyConnectedCommHopfAlgProperty k H ↔
       GeometricallyConnected
         (((hopfSpec (CommRingCat.of k)).obj (Opposite.op H)).X.hom) := by
-  -- This witness is not a global instance, but `cancel_left_of_respectsIso` needs it below.
-  let : MorphismProperty.RespectsIso @GeometricallyConnected :=
-    MorphismProperty.IsStableUnderBaseChange.respectsIso
   rw [geometricallyConnectedCommHopfAlgProperty_iff, hopfSpec_obj_X_hom]
   rw [MorphismProperty.cancel_left_of_respectsIso
     (P := @GeometricallyConnected) (eqToHom (hopfSpec_obj_X_left k H))]
@@ -62,6 +89,59 @@ theorem geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec
     exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mpr (h K)
   · intro h K _ _
     exact (pullbackSpecIso k H K).hom.homeomorph.connectedSpace_iff.mp (h K)
+
+/-- Under the affine Hopf/group-scheme anti-equivalence, the inverse image of geometric
+connectedness on affine group schemes is geometric connectedness of coordinate Hopf algebras. -/
+theorem geometricallyConnectedAffineGroupSchemeProperty_inverseImage
+    (k : Type u) [Field k] :
+    (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)).inverseImage
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor =
+      (geometricallyConnectedCommHopfAlgProperty k).op := by
+  apply objectProperty_inverseImage_commHopfAlgCatOpEquiv
+  intro H
+  exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H).symm
+
+/-- A finite-type affine group scheme has geometrically connected structural morphism exactly
+when its coordinate algebra supplied by the affine anti-equivalence is geometrically connected. -/
+theorem geometricallyConnected_iff_geometricallyConnected_coordinate
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
+    GeometricallyConnected G.obj.obj.X.hom ↔
+      geometricallyConnectedCommHopfAlgProperty k
+        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
+          G).unop.obj := by
+  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
+  let H := E.inverse.obj G
+  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+    (CommHopfAlgCat.{u} k)).op.obj H
+  let eSpec :
+      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of k)).functor.obj H₀ :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H ≪≫
+        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+          (CommRingCat.of k)).app H₀).symm)
+  let eG :
+      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅ G.obj :=
+    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso (E.counitIso.app G)
+  change geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k) G.obj ↔
+    (geometricallyConnectedCommHopfAlgProperty k).op H₀
+  calc
+    _ ↔ geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)
+        ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
+      ((geometricallyConnectedAffineGroupSchemeProperty
+        (CommRingCat.of k)).prop_iff_of_iso eG).symm
+    _ ↔ geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)
+        ((commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of k)).functor.obj H₀) :=
+      (geometricallyConnectedAffineGroupSchemeProperty
+        (CommRingCat.of k)).prop_iff_of_iso eSpec
+    _ ↔ (geometricallyConnectedCommHopfAlgProperty k).op H₀ := by
+      change ((geometricallyConnectedAffineGroupSchemeProperty
+        (CommRingCat.of k)).inverseImage
+          (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor) H₀ ↔ _
+      rw [geometricallyConnectedAffineGroupSchemeProperty_inverseImage]
 
 /-- The structural morphism of a Hopf spectrum is geometrically connected exactly when, after
 every extension `K / k` of the base field, every idempotent of `H ⊗[k] K` is zero or one. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Connected.lean
@@ -110,44 +110,10 @@ theorem geometricallyConnected_iff_geometricallyConnected_coordinate
       geometricallyConnectedCommHopfAlgProperty k
         ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
           G).unop.obj := by
-  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
-  let H := E.inverse.obj G
-  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-    (CommHopfAlgCat.{u} k)).op.obj H
-  let eSpec :
-      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat
-          (CommRingCat.of k)).functor.obj H₀ :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
-      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H ≪≫
-        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-          (CommRingCat.of k)).app H₀).symm)
-  let eG :
-      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅ G.obj :=
-    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso (E.counitIso.app G)
-  calc
-    GeometricallyConnected G.obj.obj.X.hom ↔
-        geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k) G.obj :=
-      (geometricallyConnectedAffineGroupSchemeProperty_iff (CommRingCat.of k) G.obj).symm
-    _ ↔ geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)
-        ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
-      ((geometricallyConnectedAffineGroupSchemeProperty
-        (CommRingCat.of k)).prop_iff_of_iso eG).symm
-    _ ↔ geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k)
-        ((commHopfAlgCatOpEquivAffineGroupSchemeCat
-          (CommRingCat.of k)).functor.obj H₀) :=
-      (geometricallyConnectedAffineGroupSchemeProperty
-        (CommRingCat.of k)).prop_iff_of_iso eSpec
-    _ ↔ (geometricallyConnectedCommHopfAlgProperty k).op H₀ := by
-      exact Iff.of_eq <| congrArg
-        (fun P : ObjectProperty (CommHopfAlgCat.{u} k)ᵒᵖ ↦ P H₀)
-        (geometricallyConnectedAffineGroupSchemeProperty_inverseImage k)
-    _ ↔ geometricallyConnectedCommHopfAlgProperty k
-        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
-          G).unop.obj := by
-      rw [ObjectProperty.op_iff]
-      simp only [H₀, H, E, Functor.op_obj,
-        FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj]
+  exact finiteType_objectProperty_iff_coordinate k
+    (geometricallyConnectedAffineGroupSchemeProperty (CommRingCat.of k))
+    (geometricallyConnectedCommHopfAlgProperty k)
+    (geometricallyConnectedAffineGroupSchemeProperty_inverseImage k) G
 
 /-- The structural morphism of a Hopf spectrum is geometrically connected exactly when, after
 every extension `K / k` of the base field, every idempotent of `H ⊗[k] K` is zero or one. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.lean
@@ -30,7 +30,16 @@ namespace TauCeti
 
 open CategoryTheory AlgebraicGeometry Opposite
 
-universe u
+universe u v
+
+/-- Pulling an isomorphism-invariant object property forward and then backward along an
+equivalence recovers the original property. -/
+theorem objectProperty_inverseImage_equivalence_inverse
+    {C : Type u} {D : Type v} [Category C] [Category D]
+    (P : ObjectProperty C) [P.IsClosedUnderIsomorphisms] (e : C ≌ D) :
+    (P.inverseImage e.inverse).inverseImage e.functor = P := by
+  ext X
+  exact (P.prop_iff_of_iso (e.unitIso.app X)).symm
 
 /-- `Spec` as an anti-equivalence from commutative `S`-Hopf algebras onto affine group
 schemes over `Spec S`. The underlying functor is Mathlib's `AlgebraicGeometry.hopfSpec`,

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/FiniteType.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/FiniteType.lean
@@ -40,6 +40,8 @@ reductive-groups roadmap, while the dictionary records that the two predicates c
   anti-equivalence.
 * `TauCeti.finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso`:
   after both inclusions, the forward functor is Mathlib's `AlgebraicGeometry.hopfSpec`.
+* `TauCeti.finiteType_objectProperty_iff_coordinate`: transport of an isomorphism-invariant
+  object property through the finite-type anti-equivalence.
 
 ## References
 
@@ -193,5 +195,52 @@ noncomputable def
         (CommHopfAlgCat.{u} R)).op
       (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
         (CommRingCat.of R))
+
+/-- An isomorphism-invariant property of affine group schemes can be tested on the coordinate
+Hopf algebra of a finite-type affine group scheme whenever the unrestricted anti-equivalence
+identifies it with a coordinate-side property. -/
+theorem finiteType_objectProperty_iff_coordinate
+    (R : Type u) [CommRing R]
+    (P : ObjectProperty (AffineGroupSchemeCat (CommRingCat.of R)))
+    [P.IsClosedUnderIsomorphisms]
+    (Q : ObjectProperty (CommHopfAlgCat.{u} R))
+    (hPQ : P.inverseImage
+      (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of R)).functor = Q.op)
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of R)) :
+    P G.obj ↔
+      Q ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat R).inverse.obj
+        G).unop.obj := by
+  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat R
+  let H := E.inverse.obj G
+  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} R)
+    (CommHopfAlgCat.{u} R)).op.obj H
+  let eSpec :
+      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.obj (E.functor.obj H) ≅
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of R)).functor.obj H₀ :=
+    (affineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
+      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso R).app
+          H ≪≫
+        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+          (CommRingCat.of R)).app H₀).symm)
+  let eG :
+      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.obj (E.functor.obj H) ≅
+        G.obj :=
+    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.mapIso (E.counitIso.app G)
+  calc
+    P G.obj ↔ P
+        ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.obj (E.functor.obj H)) :=
+      (P.prop_iff_of_iso eG).symm
+    _ ↔ P ((commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of R)).functor.obj H₀) :=
+      P.prop_iff_of_iso eSpec
+    _ ↔ Q.op H₀ := by
+      exact Iff.of_eq <| congrArg
+        (fun T : ObjectProperty (CommHopfAlgCat.{u} R)ᵒᵖ ↦ T H₀) hPQ
+    _ ↔ Q ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat R).inverse.obj
+        G).unop.obj := by
+      rw [ObjectProperty.op_iff]
+      simp only [H₀, H, E, Functor.op_obj,
+        FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj]
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
@@ -216,7 +216,14 @@ private noncomputable def
       (forget₂ (SemisimpleCommHopfAlgCat.{u} k)
           (FiniteTypeCommHopfAlgCat.{u, u} k)).op ⋙
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor :=
-  Iso.refl _
+  Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft
+      (ObjectProperty.opEquivalence (semisimpleCommHopfAlgProperty k)).symm.functor
+      ((semisimpleAffineGroupSchemeProperty k).liftCompιIso _ _) ≪≫
+    (Functor.associator _ _ _).symm ≪≫
+    Functor.isoWhiskerRight
+      ((semisimpleCommHopfAlgProperty k).op.liftCompιIso _ _)
+      (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor
 
 /-- The forward semisimple anti-equivalence, followed by the inclusions into finite-type affine
 group schemes and affine group schemes, is Mathlib's `hopfSpec` after forgetting semisimplicity

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
@@ -141,7 +141,10 @@ noncomputable def semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat
       (semisimpleAffineGroupSchemeProperty_inverseImage k)
 
 /-- The forward semisimple anti-equivalence followed by the inclusions into finite-type affine
-group schemes is the finite-type anti-equivalence after forgetting semisimplicity. -/
+group schemes is definitionally the finite-type anti-equivalence after forgetting semisimplicity.
+
+This private isomorphism isolates the representation boundary of `opEquivalence`, `trans`, and
+`congrFullSubcategory` from the public `Spec` compatibility isomorphism below. -/
 private noncomputable def
     semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCatFunctorCompιIso
     (k : Type u) [Field k] :

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Semisimple.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
 
 /-!
@@ -20,8 +19,11 @@ its geometric fibre is trivial. The resulting full subcategory is anti-equivalen
 finite-type commutative Hopf algebras.
 
 The formulation uses the universal property of a trivial geometric radical. It does not assume
-that a maximal solvable normal subgroup has already been constructed, and it does not silently
-exclude nonsmooth subgroup schemes from the ambient affine-group-scheme category.
+that a maximal solvable normal subgroup has already been constructed. Its triviality requirement
+ranges over connected normal smooth solvable subgroup schemes; nonsmooth subgroup schemes are not
+constrained, while the ambient finite-type affine-group-scheme category still includes nonsmooth
+objects. Bundled semisimple objects carry smooth and geometrically connected structural-morphism
+instances.
 
 ## Main declarations
 
@@ -29,8 +31,13 @@ exclude nonsmooth subgroup schemes from the ambient affine-group-scheme category
   schemes over a field.
 * `TauCeti.semisimpleAffineGroupSchemeProperty_iff`: its coordinate-ring characterization.
 * `TauCeti.SemisimpleAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.smooth_of_semisimpleAffineGroupSchemeProperty` and
+  `TauCeti.geometricallyConnected_of_semisimpleAffineGroupSchemeProperty`: the scheme-side
+  smoothness and geometric-connectedness eliminators.
 * `TauCeti.semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat`: the restricted affine
   Hopf/group-scheme anti-equivalence.
+* `TauCeti.semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat.functorCompιIso`: its
+  computation isomorphism after forgetting to affine group schemes.
 
 ## References
 
@@ -61,45 +68,16 @@ def semisimpleAffineGroupSchemeProperty (k : Type u) [Field k] :
   (semisimpleCommHopfAlgProperty k).op.inverseImage
     (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse
 
-/-- A finite-type affine group scheme is semisimple exactly when its coordinate Hopf algebra is
-smooth and geometrically connected and every connected normal smooth solvable closed subgroup of
-its geometric fibre is trivial. -/
+/-- A finite-type affine group scheme is semisimple exactly when its coordinate Hopf algebra
+satisfies `semisimpleCommHopfAlgProperty`. -/
 @[simp]
 theorem semisimpleAffineGroupSchemeProperty_iff
     (k : Type u) [Field k]
     (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
     semisimpleAffineGroupSchemeProperty k G ↔
-      Algebra.Smooth k
-          ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop ∧
-        geometricallyConnectedCommHopfAlgProperty k
-          ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
-            G).unop.obj ∧
-        ∀ I : HopfIdeal (AlgebraicClosure k)
-            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
-              ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
-                G).unop),
-          I.IsNormal →
-            geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.quotient
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
-                  ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
-                    G).unop) I).obj →
-            Algebra.Smooth (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.quotient
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
-                  ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
-                    G).unop) I) →
-            geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.quotient
-                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
-                  ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
-                    G).unop) I).obj →
-            I = HopfIdeal.augmentation (AlgebraicClosure k)
-              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
-                ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
-                  G).unop) :=
-  semisimpleCommHopfAlgProperty_iff k
-    ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop
+      semisimpleCommHopfAlgProperty k
+        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop :=
+  Iff.rfl
 
 /-- Semisimplicity of finite-type affine group schemes is invariant under isomorphism. -/
 instance (k : Type u) [Field k] :
@@ -118,29 +96,8 @@ theorem smooth_of_semisimpleAffineGroupSchemeProperty
     (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
     (hG : semisimpleAffineGroupSchemeProperty k G) :
     Smooth G.obj.obj.X.hom := by
-  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
-  let H := E.inverse.obj G
-  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-    (CommHopfAlgCat.{u} k)).op.obj H
-  have hH : (smoothCommHopfAlgProperty k).op H₀ :=
-    (smoothCommHopfAlgProperty_iff H₀.unop).mpr
-      ((semisimpleAffineGroupSchemeProperty_iff k G).mp hG |>.1)
-  rw [← smoothAffineGroupSchemeProperty_inverseImage k] at hH
-  let eSpec :
-      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat
-          (CommRingCat.of k)).functor.obj H₀ :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
-      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H ≪≫
-        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-          (CommRingCat.of k)).app H₀).symm)
-  have hEF : smoothAffineGroupSchemeProperty (CommRingCat.of k)
-      ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
-    (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso eSpec.symm hH
-  exact (smoothAffineGroupSchemeProperty_iff (CommRingCat.of k) G.obj).mp <|
-    (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso
-      ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso
-        (E.counitIso.app G)) hEF
+  exact (smooth_iff_algebraSmooth_coordinate k G).mpr
+    ((semisimpleAffineGroupSchemeProperty_iff k G).mp hG).smooth
 
 /-- Objects of `SemisimpleAffineGroupSchemeCat k` have smooth structural morphism. -/
 instance (k : Type u) [Field k] (G : SemisimpleAffineGroupSchemeCat k) :
@@ -154,31 +111,8 @@ theorem geometricallyConnected_of_semisimpleAffineGroupSchemeProperty
     (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
     (hG : semisimpleAffineGroupSchemeProperty k G) :
     GeometricallyConnected G.obj.obj.X.hom := by
-  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
-  let H := E.inverse.obj G
-  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-    (CommHopfAlgCat.{u} k)).op.obj H
-  let P : ObjectProperty (Grp (Over (Spec (CommRingCat.of k)))) :=
-    fun X ↦ GeometricallyConnected X.X.hom
-  let _ : MorphismProperty.RespectsIso @GeometricallyConnected :=
-    MorphismProperty.IsStableUnderBaseChange.respectsIso
-  let _ : P.IsClosedUnderIsomorphisms :=
-    { of_iso := fun {X Y} e hX ↦
-        (MorphismProperty.over_iso_iff (@GeometricallyConnected)
-          ((Grp.forget _).mapIso e)).mp hX }
-  let X : Grp (Over (Spec (CommRingCat.of k))) :=
-    ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
-      (affineGroupSchemeProperty (CommRingCat.of k)).ι).obj (E.functor.obj H)
-  let eSpec : X ≅ (hopfSpec (CommRingCat.of k)).obj H₀ :=
-    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H
-  let eG : X ≅ G.obj.obj :=
-    ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
-      (affineGroupSchemeProperty (CommRingCat.of k)).ι).mapIso (E.counitIso.app G)
-  have hH : geometricallyConnectedCommHopfAlgProperty k H₀.unop :=
-    (semisimpleAffineGroupSchemeProperty_iff k G).mp hG |>.2.1
-  have hSpec : P ((hopfSpec (CommRingCat.of k)).obj H₀) :=
-    (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H₀.unop).mp hH
-  exact P.prop_of_iso eG (P.prop_of_iso eSpec.symm hSpec)
+  exact (geometricallyConnected_iff_geometricallyConnected_coordinate k G).mpr
+    ((semisimpleAffineGroupSchemeProperty_iff k G).mp hG).geometricallyConnected
 
 /-- Objects of `SemisimpleAffineGroupSchemeCat k` have geometrically connected structural
 morphism. -/
@@ -193,9 +127,9 @@ theorem semisimpleAffineGroupSchemeProperty_inverseImage
     (semisimpleAffineGroupSchemeProperty k).inverseImage
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
       (semisimpleCommHopfAlgProperty k).op := by
-  ext H
-  exact ((semisimpleCommHopfAlgProperty k).op.prop_iff_of_iso
-    ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).unitIso.app H)).symm
+  exact objectProperty_inverseImage_equivalence_inverse
+    (semisimpleCommHopfAlgProperty k).op
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k)
 
 /-- `Spec` restricts to an anti-equivalence from semisimple finite-type commutative Hopf algebras
 to semisimple affine group schemes. -/
@@ -216,14 +150,7 @@ private noncomputable def
       (forget₂ (SemisimpleCommHopfAlgCat.{u} k)
           (FiniteTypeCommHopfAlgCat.{u, u} k)).op ⋙
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor :=
-  Functor.associator _ _ _ ≪≫
-    Functor.isoWhiskerLeft
-      (ObjectProperty.opEquivalence (semisimpleCommHopfAlgProperty k)).symm.functor
-      ((semisimpleAffineGroupSchemeProperty k).liftCompιIso _ _) ≪≫
-    (Functor.associator _ _ _).symm ≪≫
-    Functor.isoWhiskerRight
-      ((semisimpleCommHopfAlgProperty k).op.liftCompιIso _ _)
-      (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor
+  Iso.refl _
 
 /-- The forward semisimple anti-equivalence, followed by the inclusions into finite-type affine
 group schemes and affine group schemes, is Mathlib's `hopfSpec` after forgetting semisimplicity

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Semisimple.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Semisimple.Basic
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
+
+/-!
+# Semisimple affine group schemes
+
+This file transports semisimplicity from finite-type commutative Hopf algebras to affine group
+schemes of finite type over a field. The coordinate-ring predicate says that the group is smooth
+and geometrically connected and that every connected normal smooth solvable closed subgroup of
+its geometric fibre is trivial. The resulting full subcategory is anti-equivalent to semisimple
+finite-type commutative Hopf algebras.
+
+The formulation uses the universal property of a trivial geometric radical. It does not assume
+that a maximal solvable normal subgroup has already been constructed, and it does not silently
+exclude nonsmooth subgroup schemes from the ambient affine-group-scheme category.
+
+## Main declarations
+
+* `TauCeti.semisimpleAffineGroupSchemeProperty`: semisimplicity for finite-type affine group
+  schemes over a field.
+* `TauCeti.semisimpleAffineGroupSchemeProperty_iff`: its coordinate-ring characterization.
+* `TauCeti.SemisimpleAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat`: the restricted affine
+  Hopf/group-scheme anti-equivalence.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§6.46 and 21.10.
+* T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
+
+The formal organization follows `TauCeti.AlgebraicGeometry.AffineGroupScheme.Unipotent`. This
+advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap by keeping
+the coordinate-Hopf and affine-group-scheme models synchronized. Construction of the geometric
+radical and identification of this predicate with its triviality remain downstream.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory AlgebraicGeometry Opposite
+
+universe u
+
+/-- The object property selecting semisimple affine group schemes of finite type over a field.
+
+The property is transported through the finite-type affine Hopf/group-scheme anti-equivalence.
+Thus its normal-subgroup condition is the coordinate-Hopf universal property used by
+`semisimpleCommHopfAlgProperty`, presented on the scheme side. -/
+def semisimpleAffineGroupSchemeProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :=
+  (semisimpleCommHopfAlgProperty k).op.inverseImage
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse
+
+/-- A finite-type affine group scheme is semisimple exactly when its coordinate Hopf algebra is
+smooth and geometrically connected and every connected normal smooth solvable closed subgroup of
+its geometric fibre is trivial. -/
+@[simp]
+theorem semisimpleAffineGroupSchemeProperty_iff
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
+    semisimpleAffineGroupSchemeProperty k G ↔
+      Algebra.Smooth k
+          ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop ∧
+        geometricallyConnectedCommHopfAlgProperty k
+          ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
+            G).unop.obj ∧
+        ∀ I : HopfIdeal (AlgebraicClosure k)
+            (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+              ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
+                G).unop),
+          I.IsNormal →
+            geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+                  ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
+                    G).unop) I).obj →
+            Algebra.Smooth (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+                  ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
+                    G).unop) I) →
+            geometricallySolvablePointsCommHopfAlgProperty (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.quotient
+                (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+                  ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
+                    G).unop) I).obj →
+            I = HopfIdeal.augmentation (AlgebraicClosure k)
+              (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+                ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj
+                  G).unop) :=
+  semisimpleCommHopfAlgProperty_iff k
+    ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop
+
+/-- Semisimplicity of finite-type affine group schemes is invariant under isomorphism. -/
+instance (k : Type u) [Field k] :
+    (semisimpleAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms := by
+  unfold semisimpleAffineGroupSchemeProperty
+  infer_instance
+
+/-- The category of semisimple affine group schemes of finite type over a field. -/
+abbrev SemisimpleAffineGroupSchemeCat (k : Type u) [Field k] :=
+  (semisimpleAffineGroupSchemeProperty k).FullSubcategory
+
+/-- A finite-type affine group scheme satisfying the semisimplicity property has smooth
+structural morphism. -/
+theorem smooth_of_semisimpleAffineGroupSchemeProperty
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
+    (hG : semisimpleAffineGroupSchemeProperty k G) :
+    Smooth G.obj.obj.X.hom := by
+  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
+  let H := E.inverse.obj G
+  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+    (CommHopfAlgCat.{u} k)).op.obj H
+  have hH : (smoothCommHopfAlgProperty k).op H₀ :=
+    (smoothCommHopfAlgProperty_iff H₀.unop).mpr
+      ((semisimpleAffineGroupSchemeProperty_iff k G).mp hG |>.1)
+  rw [← smoothAffineGroupSchemeProperty_inverseImage k] at hH
+  let eSpec :
+      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of k)).functor.obj H₀ :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H ≪≫
+        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+          (CommRingCat.of k)).app H₀).symm)
+  have hEF : smoothAffineGroupSchemeProperty (CommRingCat.of k)
+      ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
+    (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso eSpec.symm hH
+  exact (smoothAffineGroupSchemeProperty_iff (CommRingCat.of k) G.obj).mp <|
+    (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso
+      ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso
+        (E.counitIso.app G)) hEF
+
+/-- Objects of `SemisimpleAffineGroupSchemeCat k` have smooth structural morphism. -/
+instance (k : Type u) [Field k] (G : SemisimpleAffineGroupSchemeCat k) :
+    Smooth G.obj.obj.obj.X.hom :=
+  smooth_of_semisimpleAffineGroupSchemeProperty k G.obj G.property
+
+/-- A finite-type affine group scheme satisfying the semisimplicity property has geometrically
+connected structural morphism. -/
+theorem geometricallyConnected_of_semisimpleAffineGroupSchemeProperty
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
+    (hG : semisimpleAffineGroupSchemeProperty k G) :
+    GeometricallyConnected G.obj.obj.X.hom := by
+  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
+  let H := E.inverse.obj G
+  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+    (CommHopfAlgCat.{u} k)).op.obj H
+  let P : ObjectProperty (Grp (Over (Spec (CommRingCat.of k)))) :=
+    fun X ↦ GeometricallyConnected X.X.hom
+  let _ : MorphismProperty.RespectsIso @GeometricallyConnected :=
+    MorphismProperty.IsStableUnderBaseChange.respectsIso
+  let _ : P.IsClosedUnderIsomorphisms :=
+    { of_iso := fun {X Y} e hX ↦
+        (MorphismProperty.over_iso_iff (@GeometricallyConnected)
+          ((Grp.forget _).mapIso e)).mp hX }
+  let X : Grp (Over (Spec (CommRingCat.of k))) :=
+    ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+      (affineGroupSchemeProperty (CommRingCat.of k)).ι).obj (E.functor.obj H)
+  let eSpec : X ≅ (hopfSpec (CommRingCat.of k)).obj H₀ :=
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H
+  let eG : X ≅ G.obj.obj :=
+    ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+      (affineGroupSchemeProperty (CommRingCat.of k)).ι).mapIso (E.counitIso.app G)
+  have hH : geometricallyConnectedCommHopfAlgProperty k H₀.unop :=
+    (semisimpleAffineGroupSchemeProperty_iff k G).mp hG |>.2.1
+  have hSpec : P ((hopfSpec (CommRingCat.of k)).obj H₀) :=
+    (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H₀.unop).mp hH
+  exact P.prop_of_iso eG (P.prop_of_iso eSpec.symm hSpec)
+
+/-- Objects of `SemisimpleAffineGroupSchemeCat k` have geometrically connected structural
+morphism. -/
+instance (k : Type u) [Field k] (G : SemisimpleAffineGroupSchemeCat k) :
+    GeometricallyConnected G.obj.obj.obj.X.hom :=
+  geometricallyConnected_of_semisimpleAffineGroupSchemeProperty k G.obj G.property
+
+/-- Under the finite-type affine Hopf/group-scheme anti-equivalence, the inverse image of
+semisimplicity on group schemes is semisimplicity of coordinate Hopf algebras. -/
+theorem semisimpleAffineGroupSchemeProperty_inverseImage
+    (k : Type u) [Field k] :
+    (semisimpleAffineGroupSchemeProperty k).inverseImage
+        (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
+      (semisimpleCommHopfAlgProperty k).op := by
+  ext H
+  exact ((semisimpleCommHopfAlgProperty k).op.prop_iff_of_iso
+    ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).unitIso.app H)).symm
+
+/-- `Spec` restricts to an anti-equivalence from semisimple finite-type commutative Hopf algebras
+to semisimple affine group schemes. -/
+noncomputable def semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat
+    (k : Type u) [Field k] :
+    (SemisimpleCommHopfAlgCat.{u} k)ᵒᵖ ≌ SemisimpleAffineGroupSchemeCat k :=
+  (ObjectProperty.opEquivalence (semisimpleCommHopfAlgProperty k)).symm.trans <|
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).congrFullSubcategory
+      (semisimpleAffineGroupSchemeProperty_inverseImage k)
+
+/-- The forward semisimple anti-equivalence followed by the inclusions into finite-type affine
+group schemes is the finite-type anti-equivalence after forgetting semisimplicity. -/
+private noncomputable def
+    semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCatFunctorCompιIso
+    (k : Type u) [Field k] :
+    (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).functor ⋙
+        (semisimpleAffineGroupSchemeProperty k).ι ≅
+      (forget₂ (SemisimpleCommHopfAlgCat.{u} k)
+          (FiniteTypeCommHopfAlgCat.{u, u} k)).op ⋙
+        (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor :=
+  Iso.refl _
+
+/-- The forward semisimple anti-equivalence, followed by the inclusions into finite-type affine
+group schemes and affine group schemes, is Mathlib's `hopfSpec` after forgetting semisimplicity
+and finite type. This is the computation interface for the restricted equivalence. -/
+noncomputable def
+    semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat.functorCompιIso
+    (k : Type u) [Field k] :
+    (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).functor ⋙
+          (semisimpleAffineGroupSchemeProperty k).ι ⋙
+          (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
+      (forget₂ (SemisimpleCommHopfAlgCat.{u} k)
+          (FiniteTypeCommHopfAlgCat.{u, u} k)).op ⋙
+        (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
+  Functor.isoWhiskerRight
+      (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCatFunctorCompιIso k)
+      ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of k)).ι) ≪≫
+    Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft
+      (forget₂ (SemisimpleCommHopfAlgCat.{u} k)
+        (FiniteTypeCommHopfAlgCat.{u, u} k)).op
+      (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k)
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
@@ -135,39 +135,10 @@ theorem smooth_iff_algebraSmooth_coordinate
     Smooth G.obj.obj.X.hom ↔
       Algebra.Smooth k
         ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop := by
-  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
-  let H := E.inverse.obj G
-  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-    (CommHopfAlgCat.{u} k)).op.obj H
-  let eSpec :
-      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat
-          (CommRingCat.of k)).functor.obj H₀ :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
-      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H ≪≫
-        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-          (CommRingCat.of k)).app H₀).symm)
-  let eG :
-      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅ G.obj :=
-    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso (E.counitIso.app G)
-  calc
-    Smooth G.obj.obj.X.hom ↔ smoothAffineGroupSchemeProperty (CommRingCat.of k) G.obj :=
-      (smoothAffineGroupSchemeProperty_iff (CommRingCat.of k) G.obj).symm
-    _ ↔ smoothAffineGroupSchemeProperty (CommRingCat.of k)
-        ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
-      ((smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_iff_of_iso eG).symm
-    _ ↔ smoothAffineGroupSchemeProperty (CommRingCat.of k)
-        ((commHopfAlgCatOpEquivAffineGroupSchemeCat
-          (CommRingCat.of k)).functor.obj H₀) :=
-      (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_iff_of_iso eSpec
-    _ ↔ (smoothCommHopfAlgProperty k).op H₀ := by
-      exact Iff.of_eq <| congrArg
-        (fun P : ObjectProperty (CommHopfAlgCat.{u} k)ᵒᵖ ↦ P H₀)
-        (smoothAffineGroupSchemeProperty_inverseImage k)
-    _ ↔ Algebra.Smooth k
-        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop := by
-      rw [ObjectProperty.op_iff, smoothCommHopfAlgProperty_iff]
-      simp only [H₀, H, E, Functor.op_obj,
-        FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj]
+  rw [← smoothCommHopfAlgProperty_iff]
+  exact finiteType_objectProperty_iff_coordinate k
+    (smoothAffineGroupSchemeProperty (CommRingCat.of k))
+    (smoothCommHopfAlgProperty k)
+    (smoothAffineGroupSchemeProperty_inverseImage k) G
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
@@ -152,7 +152,7 @@ theorem smooth_iff_algebraSmooth_coordinate
     (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso (E.counitIso.app G)
   calc
     Smooth G.obj.obj.X.hom ↔ smoothAffineGroupSchemeProperty (CommRingCat.of k) G.obj :=
-      Iff.rfl
+      (smoothAffineGroupSchemeProperty_iff (CommRingCat.of k) G.obj).symm
     _ ↔ smoothAffineGroupSchemeProperty (CommRingCat.of k)
         ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
       ((smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_iff_of_iso eG).symm
@@ -161,13 +161,13 @@ theorem smooth_iff_algebraSmooth_coordinate
           (CommRingCat.of k)).functor.obj H₀) :=
       (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_iff_of_iso eSpec
     _ ↔ (smoothCommHopfAlgProperty k).op H₀ := by
-      change ((smoothAffineGroupSchemeProperty (CommRingCat.of k)).inverseImage
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor) H₀ ↔ _
-      rw [smoothAffineGroupSchemeProperty_inverseImage]
+      exact Iff.of_eq <| congrArg
+        (fun P : ObjectProperty (CommHopfAlgCat.{u} k)ᵒᵖ ↦ P H₀)
+        (smoothAffineGroupSchemeProperty_inverseImage k)
     _ ↔ Algebra.Smooth k
         ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop := by
       rw [ObjectProperty.op_iff, smoothCommHopfAlgProperty_iff]
-      change Algebra.Smooth k H.unop.obj ↔ Algebra.Smooth k H.unop.obj
-      rfl
+      simp only [H₀, H, E, Functor.op_obj,
+        FiniteTypeCommHopfAlgCat.forget₂_commHopfAlgCat_obj]
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
@@ -8,8 +8,7 @@ module
 public import Mathlib.AlgebraicGeometry.Morphisms.Smooth
 public import Mathlib.CategoryTheory.ObjectProperty.Opposite
 public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
 
 /-!
 # Smooth affine group schemes
@@ -31,6 +30,8 @@ base, such as `μₚ` and `αₚ`, remain in the ambient category.
   group schemes.
 * `TauCeti.algebraSmooth_iff_smooth_hopfSpec`: compatibility of the algebraic and
   scheme-theoretic smoothness conditions.
+* `TauCeti.smooth_iff_algebraSmooth_coordinate`: smoothness of a finite-type affine group
+  scheme in terms of the coordinate algebra supplied by the anti-equivalence.
 
 ## References
 
@@ -125,5 +126,48 @@ theorem smoothAffineGroupSchemeProperty_inverseImage
     apply (smoothAffineGroupSchemeProperty (CommRingCat.of R)).prop_of_iso e.symm
     exact (algebraSmooth_iff_smooth_hopfSpec R H.unop).mp
       ((smoothCommHopfAlgProperty_iff H.unop).mpr h)
+
+/-- A finite-type affine group scheme has smooth structural morphism exactly when its coordinate
+algebra supplied by the affine anti-equivalence is smooth. -/
+theorem smooth_iff_algebraSmooth_coordinate
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
+    Smooth G.obj.obj.X.hom ↔
+      Algebra.Smooth k
+        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop := by
+  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
+  let H := E.inverse.obj G
+  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+    (CommHopfAlgCat.{u} k)).op.obj H
+  let eSpec :
+      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of k)).functor.obj H₀ :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H ≪≫
+        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
+          (CommRingCat.of k)).app H₀).symm)
+  let eG :
+      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅ G.obj :=
+    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso (E.counitIso.app G)
+  calc
+    Smooth G.obj.obj.X.hom ↔ smoothAffineGroupSchemeProperty (CommRingCat.of k) G.obj :=
+      Iff.rfl
+    _ ↔ smoothAffineGroupSchemeProperty (CommRingCat.of k)
+        ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
+      ((smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_iff_of_iso eG).symm
+    _ ↔ smoothAffineGroupSchemeProperty (CommRingCat.of k)
+        ((commHopfAlgCatOpEquivAffineGroupSchemeCat
+          (CommRingCat.of k)).functor.obj H₀) :=
+      (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_iff_of_iso eSpec
+    _ ↔ (smoothCommHopfAlgProperty k).op H₀ := by
+      change ((smoothAffineGroupSchemeProperty (CommRingCat.of k)).inverseImage
+        (commHopfAlgCatOpEquivAffineGroupSchemeCat (CommRingCat.of k)).functor) H₀ ↔ _
+      rw [smoothAffineGroupSchemeProperty_inverseImage]
+    _ ↔ Algebra.Smooth k
+        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop := by
+      rw [ObjectProperty.op_iff, smoothCommHopfAlgProperty_iff]
+      change Algebra.Smooth k H.unop.obj ↔ Algebra.Smooth k H.unop.obj
+      rfl
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Smooth.lean
@@ -130,15 +130,15 @@ theorem smoothAffineGroupSchemeProperty_inverseImage
 /-- A finite-type affine group scheme has smooth structural morphism exactly when its coordinate
 algebra supplied by the affine anti-equivalence is smooth. -/
 theorem smooth_iff_algebraSmooth_coordinate
-    (k : Type u) [Field k]
-    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
+    (R : Type u) [CommRing R]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of R)) :
     Smooth G.obj.obj.X.hom ↔
-      Algebra.Smooth k
-        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop := by
+      Algebra.Smooth R
+        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat R).inverse.obj G).unop := by
   rw [← smoothCommHopfAlgProperty_iff]
-  exact finiteType_objectProperty_iff_coordinate k
-    (smoothAffineGroupSchemeProperty (CommRingCat.of k))
-    (smoothCommHopfAlgProperty k)
-    (smoothAffineGroupSchemeProperty_inverseImage k) G
+  exact finiteType_objectProperty_iff_coordinate R
+    (smoothAffineGroupSchemeProperty (CommRingCat.of R))
+    (smoothCommHopfAlgProperty R)
+    (smoothAffineGroupSchemeProperty_inverseImage R) G
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Unipotent.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
 
 /-!
@@ -95,29 +94,8 @@ theorem smooth_of_smoothUnipotentAffineGroupSchemeProperty
     (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
     (hG : smoothUnipotentAffineGroupSchemeProperty k G) :
     Smooth G.obj.obj.X.hom := by
-  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
-  let H := E.inverse.obj G
-  let H₀ := (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
-    (CommHopfAlgCat.{u} k)).op.obj H
-  have hH : (smoothCommHopfAlgProperty k).op H₀ :=
-    (smoothCommHopfAlgProperty_iff H₀.unop).mpr
-      ((smoothUnipotentAffineGroupSchemeProperty_iff k G).mp hG |>.1)
-  rw [← smoothAffineGroupSchemeProperty_inverseImage k] at hH
-  let eSpec :
-      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H) ≅
-        (commHopfAlgCatOpEquivAffineGroupSchemeCat
-          (CommRingCat.of k)).functor.obj H₀ :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
-      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app H ≪≫
-        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-          (CommRingCat.of k)).app H₀).symm)
-  have hEF : smoothAffineGroupSchemeProperty (CommRingCat.of k)
-      ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj (E.functor.obj H)) :=
-    (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso eSpec.symm hH
-  exact (smoothAffineGroupSchemeProperty_iff (CommRingCat.of k) G.obj).mp <|
-    (smoothAffineGroupSchemeProperty (CommRingCat.of k)).prop_of_iso
-      ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.mapIso
-        (E.counitIso.app G)) hEF
+  exact (smooth_iff_algebraSmooth_coordinate k G).mpr
+    ((smoothUnipotentAffineGroupSchemeProperty_iff k G).mp hG).1
 
 /-- Objects of `SmoothUnipotentAffineGroupSchemeCat k` have smooth structural morphism. -/
 instance (k : Type u) [Field k] (G : SmoothUnipotentAffineGroupSchemeCat k) :
@@ -131,9 +109,9 @@ theorem smoothUnipotentAffineGroupSchemeProperty_inverseImage
     (smoothUnipotentAffineGroupSchemeProperty k).inverseImage
         (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
       (smoothUnipotentCommHopfAlgProperty k).op := by
-  ext H
-  exact ((smoothUnipotentCommHopfAlgProperty k).op.prop_iff_of_iso
-    ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).unitIso.app H)).symm
+  exact objectProperty_inverseImage_equivalence_inverse
+    (smoothUnipotentCommHopfAlgProperty k).op
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k)
 
 /-- `Spec` restricts to an anti-equivalence from smooth unipotent finite-type commutative Hopf
 algebras to smooth unipotent affine group schemes. -/


### PR DESCRIPTION
This PR transports semisimplicity from finite-type commutative Hopf algebras to affine group schemes, packages the corresponding full subcategories, and restricts the established `Spec` anti-equivalence to them. It also proves that every bundled semisimple affine group scheme has smooth and geometrically connected structural morphism, so scheme-side consumers do not need to unpack the coordinate object.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 6 milestone “Reductive and semisimple groups,” specifically “Semisimple: radical `R(G)` (maximal connected normal solvable, geometric) trivial,” together with the roadmap-wide requirement to keep the Hopf-algebra and group-scheme views synchronized by explicit equivalences. The merged coordinate predicate already expresses triviality through the radical’s universal property; this PR supplies its missing scheme-side model. This is the most effective distinct current step because reductive scheme packaging is in flight in #3712 and the derived subgroup is in flight in #3677, while no open or merged work supplies the parallel semisimple scheme interface needed to state their eventual structural comparison.

After this PR, the Layer 6 milestone still needs construction and maximality of the geometric radical, identification of the transported predicate with `R(G) = 1`, the centre and structural properties of the derived group, central isogenies, and the simply connected and adjoint forms.

Add `TauCeti.SemisimpleCommHopfAlgCat`, then add `TauCeti.semisimpleAffineGroupSchemeProperty`, its complete coordinate-ring characterization, `TauCeti.SemisimpleAffineGroupSchemeCat`, smoothness and geometric-connectedness eliminators and instances, and `TauCeti.semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat` with its public `hopfSpec` computation isomorphism. The new module is 245 lines; the coordinate module grows by 4 lines.

The formal organization follows `TauCeti.AlgebraicGeometry.AffineGroupScheme.Unipotent` and reuses Tau Ceti’s finite-type affine Hopf/group-scheme anti-equivalence, coordinate/scheme smoothness and connectedness comparisons, and Mathlib’s object-property and morphism-property transport infrastructure. No Mathlib source is vendored. The mathematical formulation follows J. S. Milne, *Algebraic Groups* (2017), §§6.46 and 21.10, and T. A. Springer, *Linear Algebraic Groups*, Chapter 8, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"semisimple-affine-group-schemes"}-->

🤖 Prepared with Codex
