### PR TITLE
feat: identify affine group scheme images

### DIFF
--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+public import TauCeti.AlgebraicGeometry.SchemeTheoreticImage
 
 /-!
 # Scheme-theoretic images of affine group morphisms
@@ -56,33 +57,6 @@ namespace TauCeti
 open AlgebraicGeometry
 
 universe u
-
-variable {R S : CommRingCat.{u}}
-
-/-- The ideal defining the scheme-theoretic image of a spectrum map is the kernel of the
-corresponding ring homomorphism. -/
-@[simp]
-theorem specTargetImageIdeal_specMap (f : R ⟶ S) :
-    specTargetImageIdeal (Spec.map f) = RingHom.ker f.hom := by
-  rw [specTargetImageIdeal]
-  rw [Adjunction.homEquiv_symm_apply]
-  -- The image ideal is phrased through the `Γ ⊣ Spec` adjunction. Normalize its recovered
-  -- coordinate map to the explicit global-sections map before using naturality of `ΓSpecIso`.
-  change RingHom.ker (((Scheme.ΓSpecIso R).inv ≫ (Spec.map f).appTop).hom) = _
-  rw [← Scheme.ΓSpecIso_inv_naturality]
-  ext x
-  rw [RingHom.mem_ker, RingHom.mem_ker]
-  change (Scheme.ΓSpecIso S).inv.hom (f.hom x) = 0 ↔ f.hom x = 0
-  constructor
-  · intro hx
-    calc
-      f.hom x = (Scheme.ΓSpecIso S).hom.hom
-          ((Scheme.ΓSpecIso S).inv.hom (f.hom x)) :=
-        (Iso.inv_hom_id_apply (Scheme.ΓSpecIso S) (f.hom x)).symm
-      _ = (Scheme.ΓSpecIso S).hom.hom 0 := congrArg _ hx
-      _ = 0 := map_zero _
-  · intro hx
-    rw [hx, map_zero]
 
 namespace CommHopfAlgCat
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean
@@ -57,6 +57,33 @@ open AlgebraicGeometry
 
 universe u
 
+variable {R S : CommRingCat.{u}}
+
+/-- The ideal defining the scheme-theoretic image of a spectrum map is the kernel of the
+corresponding ring homomorphism. -/
+@[simp]
+theorem specTargetImageIdeal_specMap (f : R ⟶ S) :
+    specTargetImageIdeal (Spec.map f) = RingHom.ker f.hom := by
+  rw [specTargetImageIdeal]
+  rw [Adjunction.homEquiv_symm_apply]
+  -- The image ideal is phrased through the `Γ ⊣ Spec` adjunction. Normalize its recovered
+  -- coordinate map to the explicit global-sections map before using naturality of `ΓSpecIso`.
+  change RingHom.ker (((Scheme.ΓSpecIso R).inv ≫ (Spec.map f).appTop).hom) = _
+  rw [← Scheme.ΓSpecIso_inv_naturality]
+  ext x
+  rw [RingHom.mem_ker, RingHom.mem_ker]
+  change (Scheme.ΓSpecIso S).inv.hom (f.hom x) = 0 ↔ f.hom x = 0
+  constructor
+  · intro hx
+    calc
+      f.hom x = (Scheme.ΓSpecIso S).hom.hom
+          ((Scheme.ΓSpecIso S).inv.hom (f.hom x)) :=
+        (Iso.inv_hom_id_apply (Scheme.ΓSpecIso S) (f.hom x)).symm
+      _ = (Scheme.ΓSpecIso S).hom.hom 0 := congrArg _ hx
+      _ = 0 := map_zero _
+  · intro hx
+    rw [hx, map_zero]
+
 namespace CommHopfAlgCat
 
 variable {k : Type u} [Field k]
@@ -71,42 +98,25 @@ theorem hopfSpec_map_left_comp_eqToHom (f : H ⟶ K) :
         Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)) :=
   rfl
 
-/-- The ideal defining the scheme-theoretic image of the spectrum map of a Hopf-algebra morphism
-is the ordinary ring kernel of that morphism. -/
-theorem specTargetImageIdeal_specMap (f : H ⟶ K) :
+private theorem specTargetImageIdeal_specMap_hopf (f : H ⟶ K) :
     specTargetImageIdeal
         (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) =
       (HopfIdeal.ker f.hom).toIdeal := by
-  rw [HopfIdeal.ker_toIdeal]
-  rw [specTargetImageIdeal]
-  rw [Adjunction.homEquiv_symm_apply]
-  -- The image ideal is phrased through the `Γ ⊣ Spec` adjunction. Normalize its recovered
-  -- coordinate map to the explicit global-sections map before using naturality of `ΓSpecIso`.
-  change RingHom.ker (((Scheme.ΓSpecIso (CommRingCat.of H)).inv ≫
-    (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))).appTop).hom) = _
-  rw [← Scheme.ΓSpecIso_inv_naturality]
+  rw [specTargetImageIdeal_specMap, HopfIdeal.ker_toIdeal]
   ext x
-  rw [RingHom.mem_ker, RingHom.mem_ker]
-  change (Scheme.ΓSpecIso (CommRingCat.of K)).inv.hom (f.hom x) = 0 ↔ f.hom x = 0
-  constructor
-  · intro hx
-    calc
-      f.hom x = (Scheme.ΓSpecIso (CommRingCat.of K)).hom.hom
-          ((Scheme.ΓSpecIso (CommRingCat.of K)).inv.hom (f.hom x)) :=
-        (Iso.inv_hom_id_apply (Scheme.ΓSpecIso (CommRingCat.of K)) (f.hom x)).symm
-      _ = (Scheme.ΓSpecIso (CommRingCat.of K)).hom.hom 0 := congrArg _ hx
-      _ = 0 := map_zero _
-  · intro hx
-    rw [hx, map_zero]
+  rfl
 
 /-- The ideal defining the scheme-theoretic image of a morphism of Hopf spectra is the kernel
 Hopf ideal's underlying ideal. -/
 theorem specTargetImageIdeal_hopfSpec_map (f : H ⟶ K) :
     specTargetImageIdeal ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left =
       (HopfIdeal.ker f.hom).toIdeal := by
+  -- `hopfSpec_map_left_comp_eqToHom` is the propositional comparison available to clients.
+  -- It cannot rewrite here: the codomain of the map is an index of `specTargetImageIdeal`, so
+  -- the comparison is heterogeneous until the definitional `hopfSpec` wrapper is exposed.
   change specTargetImageIdeal
     (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) = _
-  exact specTargetImageIdeal_specMap f
+  exact specTargetImageIdeal_specMap_hopf f
 
 /-- The coordinate ring of the scheme-theoretic image is canonically isomorphic to the Hopf
 image, the quotient by the kernel Hopf ideal. -/
@@ -114,7 +124,8 @@ noncomputable def specTargetImageIsoImage (f : H ⟶ K) :
     specTargetImage (Spec.map
       (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) ≅
       CommRingCat.of (H ⧸ (HopfIdeal.ker f.hom).toIdeal) :=
-  (Ideal.quotientEquivAlgOfEq ℤ (specTargetImageIdeal_specMap f)).toRingEquiv
+  (Ideal.quotientEquivAlgOfEq ℤ
+    (specTargetImageIdeal_specMap_hopf f)).toRingEquiv
     |>.toCommRingCatIso
 
 /-- The coordinate-ring isomorphism sends the class of an element to the same class in the Hopf
@@ -125,7 +136,8 @@ theorem specTargetImageIsoImage_hom_mk (f : H ⟶ K) (x : H) :
         (Ideal.Quotient.mk (specTargetImageIdeal
           (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) x) =
       Ideal.Quotient.mk (HopfIdeal.ker f.hom).toIdeal x := by
-  exact Ideal.quotientEquivAlgOfEq_mk ℤ (specTargetImageIdeal_specMap f) x
+  exact Ideal.quotientEquivAlgOfEq_mk ℤ
+    (specTargetImageIdeal_specMap_hopf f) x
 
 /-- The inverse coordinate-ring isomorphism also sends the class of an element to the same
 class, now regarded in the scheme-theoretic image quotient. -/
@@ -135,12 +147,8 @@ theorem specTargetImageIsoImage_inv_mk (f : H ⟶ K) (x : H) :
         (Ideal.Quotient.mk (HopfIdeal.ker f.hom).toIdeal x) =
       Ideal.Quotient.mk (specTargetImageIdeal
         (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) x := by
-  rw [specTargetImageIsoImage]
-  change (Ideal.quotientEquivAlgOfEq ℤ
-      (specTargetImageIdeal_specMap f)).symm
-        (Ideal.Quotient.mk (HopfIdeal.ker f.hom).toIdeal x) = _
-  rw [Ideal.quotientEquivAlgOfEq_symm,
-    Ideal.quotientEquivAlgOfEq_mk]
+  rw [← specTargetImageIsoImage_hom_mk f x]
+  exact Iso.hom_inv_id_apply (specTargetImageIsoImage f) _
 
 /-- The Hopf spectrum of the quotient-by-kernel image is canonically the scheme-theoretic image
 of the represented affine-group morphism. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean
@@ -1,0 +1,246 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+
+/-!
+# Scheme-theoretic images of affine group morphisms
+
+For a morphism `f : H ⟶ K` of commutative Hopf algebras over a field, the represented affine
+group morphism runs from `Spec K` to `Spec H`. Its coordinate image is the quotient
+
+```text
+H ⟶ H / ker(f) ⟶ K.
+```
+
+This file identifies `Spec (H / ker(f))` with Mathlib's scheme-theoretic image of
+`Spec K ⟶ Spec H`. The isomorphism carries both maps in the Hopf image factorization to the
+canonical closed immersion and source factor of the scheme-theoretic image. Thus the existing
+coordinate construction can be used as an actual closed subgroup scheme, rather than merely as
+an analogous quotient.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.specTargetImageIdeal_hopfSpec_map`: the scheme-theoretic image ideal is
+  the kernel Hopf ideal's underlying ideal.
+* `TauCeti.CommHopfAlgCat.specTargetImageIsoImage`: the scheme-theoretic image coordinate ring is
+  the quotient-by-kernel Hopf image.
+* `TauCeti.CommHopfAlgCat.hopfSpecImageSchemeIso`: the corresponding isomorphism of schemes.
+* `TauCeti.CommHopfAlgCat.hopfSpecImageSchemeIso_hom_comp_specTargetImageRingHom` and
+  `TauCeti.CommHopfAlgCat.hopfSpec_imageι_comp_hopfSpecImageSchemeIso_hom`: compatibility with
+  the two image factorizations.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §5.a.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §§15--16.
+* `Mathlib.AlgebraicGeometry.AffineScheme`: `specTargetImageIdeal`, `specTargetImage`, and their
+  canonical factorization.
+
+This is the scheme-side image compatibility required by Layer 3, "Subgroups, quotients,
+components", of the ReductiveGroups roadmap. It is also the image infrastructure used when
+constructing generated normal subgroups such as the unipotent radical and derived subgroup.
+-/
+
+public section
+
+open CategoryTheory Opposite
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u
+
+namespace CommHopfAlgCat
+
+variable {k : Type u} [Field k]
+variable {H K : _root_.CommHopfAlgCat.{u} k}
+
+/-- After identifying the source and target Hopf spectra with ordinary spectra, the underlying
+scheme map of `hopfSpec.map f.op` is `Spec.map f`. -/
+theorem hopfSpec_map_left_comp_eqToHom (f : H ⟶ K) :
+    ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ≫
+        eqToHom (hopfSpec_obj_X_left k H) =
+      eqToHom (hopfSpec_obj_X_left k K) ≫
+        Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) :=
+  rfl
+
+/-- The ideal defining the scheme-theoretic image of the spectrum map of a Hopf-algebra morphism
+is the ordinary ring kernel of that morphism. -/
+theorem specTargetImageIdeal_specMap (f : H ⟶ K) :
+    specTargetImageIdeal (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) =
+      (HopfIdeal.ker f.hom).toIdeal := by
+  rw [HopfIdeal.ker_toIdeal]
+  rw [specTargetImageIdeal]
+  rw [Adjunction.homEquiv_symm_apply]
+  -- The image ideal is phrased through the `Γ ⊣ Spec` adjunction. Normalize its recovered
+  -- coordinate map to the explicit global-sections map before using naturality of `ΓSpecIso`.
+  change RingHom.ker (((Scheme.ΓSpecIso (CommRingCat.of H)).inv ≫
+    (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)).appTop).hom) = _
+  rw [← Scheme.ΓSpecIso_inv_naturality]
+  ext x
+  rw [RingHom.mem_ker, RingHom.mem_ker]
+  change (Scheme.ΓSpecIso (CommRingCat.of K)).inv.hom (f.hom x) = 0 ↔ f.hom x = 0
+  constructor
+  · intro hx
+    calc
+      f.hom x = (Scheme.ΓSpecIso (CommRingCat.of K)).hom.hom
+          ((Scheme.ΓSpecIso (CommRingCat.of K)).inv.hom (f.hom x)) :=
+        (Iso.inv_hom_id_apply (Scheme.ΓSpecIso (CommRingCat.of K)) (f.hom x)).symm
+      _ = (Scheme.ΓSpecIso (CommRingCat.of K)).hom.hom 0 := congrArg _ hx
+      _ = 0 := map_zero _
+  · intro hx
+    rw [hx, map_zero]
+
+/-- The ideal defining the scheme-theoretic image of a morphism of Hopf spectra is the kernel
+Hopf ideal's underlying ideal. -/
+theorem specTargetImageIdeal_hopfSpec_map (f : H ⟶ K) :
+    specTargetImageIdeal ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left =
+      (HopfIdeal.ker f.hom).toIdeal := by
+  change specTargetImageIdeal (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) = _
+  exact specTargetImageIdeal_specMap f
+
+/-- The coordinate ring of the scheme-theoretic image is canonically isomorphic to the Hopf
+image, the quotient by the kernel Hopf ideal. -/
+noncomputable def specTargetImageIsoImage (f : H ⟶ K) :
+    specTargetImage (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ≅
+      CommRingCat.of (image f) :=
+  (Ideal.quotientEquivAlgOfEq ℤ (specTargetImageIdeal_specMap f)).toRingEquiv
+    |>.toCommRingCatIso
+
+/-- The coordinate-ring isomorphism sends the class of an element to the same class in the Hopf
+image quotient. -/
+@[simp]
+theorem specTargetImageIsoImage_hom_mk (f : H ⟶ K) (x : H) :
+    (specTargetImageIsoImage f).hom
+        (Ideal.Quotient.mk (specTargetImageIdeal
+          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) x) =
+      Ideal.Quotient.mk (HopfIdeal.ker f.hom).toIdeal x := by
+  exact Ideal.quotientEquivAlgOfEq_mk ℤ (specTargetImageIdeal_specMap f) x
+
+/-- The inverse coordinate-ring isomorphism also sends the class of an element to the same
+class, now regarded in the scheme-theoretic image quotient. -/
+@[simp]
+theorem specTargetImageIsoImage_inv_mk (f : H ⟶ K) (x : H) :
+    (specTargetImageIsoImage f).inv
+        (Ideal.Quotient.mk (HopfIdeal.ker f.hom).toIdeal x) =
+      Ideal.Quotient.mk (specTargetImageIdeal
+        (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) x := by
+  rw [specTargetImageIsoImage]
+  change (Ideal.quotientEquivAlgOfEq ℤ
+      (specTargetImageIdeal_specMap f)).symm
+        (Ideal.Quotient.mk (HopfIdeal.ker f.hom).toIdeal x) = _
+  rw [Ideal.quotientEquivAlgOfEq_symm,
+    Ideal.quotientEquivAlgOfEq_mk]
+
+/-- The Hopf spectrum of the quotient-by-kernel image is canonically the scheme-theoretic image
+of the represented affine-group morphism. -/
+noncomputable def hopfSpecImageSchemeIso (f : H ⟶ K) :
+    ((hopfSpec (CommRingCat.of k)).obj (op (image f))).X.left ≅
+      Spec (specTargetImage
+        (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) :=
+  eqToIso (hopfSpec_obj_X_left k (image f)) ≪≫
+    Scheme.Spec.mapIso (specTargetImageIsoImage f).op
+
+/-- Under the image isomorphism, the Hopf-spectrum map induced by the quotient morphism is the
+closed immersion of the scheme-theoretic image into the target. -/
+theorem hopfSpecImageSchemeIso_hom_comp_specTargetImageRingHom (f : H ⟶ K) :
+    (hopfSpecImageSchemeIso f).hom ≫
+        Spec.map (specTargetImageRingHom
+          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) =
+      ((hopfSpec (CommRingCat.of k)).map (mkImage f).op).hom.hom.left ≫
+        eqToHom (hopfSpec_obj_X_left k H) := by
+  rw [hopfSpecImageSchemeIso]
+  -- `hopfSpec` and ordinary `Spec` have propositionally identified underlying schemes. Move once
+  -- across that boundary so the remainder is a calculation with explicit spectrum maps.
+  change (eqToHom (hopfSpec_obj_X_left k (image f)) ≫
+      (Scheme.Spec.mapIso (specTargetImageIsoImage f).op).hom) ≫
+        Spec.map (specTargetImageRingHom
+          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) =
+      eqToHom (hopfSpec_obj_X_left k (image f)) ≫
+        Spec.map (CommRingCat.ofHom (mkImage f).hom.toAlgHom.toRingHom)
+  have hcoord : specTargetImageRingHom
+        (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ≫
+      (specTargetImageIsoImage f).hom =
+        CommRingCat.ofHom (mkImage f).hom.toAlgHom.toRingHom := by
+    ext x
+    rw [CommRingCat.comp_apply]
+    exact (specTargetImageIsoImage_hom_mk f x).trans (mkImage_apply f x).symm
+  have h : (Scheme.Spec.mapIso (specTargetImageIsoImage f).op).hom ≫
+        Spec.map (specTargetImageRingHom
+          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) =
+      Spec.map (CommRingCat.ofHom (mkImage f).hom.toAlgHom.toRingHom) := by
+    calc
+      (Scheme.Spec.mapIso (specTargetImageIsoImage f).op).hom ≫
+          Spec.map (specTargetImageRingHom
+            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) =
+        Spec.map ((specTargetImageIsoImage f).hom) ≫
+          Spec.map (specTargetImageRingHom
+            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) := rfl
+      _ = Spec.map (specTargetImageRingHom
+            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ≫
+          (specTargetImageIsoImage f).hom) := (Spec.map_comp _ _).symm
+      _ = Spec.map (CommRingCat.ofHom (mkImage f).hom.toAlgHom.toRingHom) :=
+        congrArg Spec.map hcoord
+  simpa only [Category.assoc] using
+    congrArg (fun g ↦ eqToHom (hopfSpec_obj_X_left k (image f)) ≫ g) h
+
+/-- Under the image isomorphism, the injective Hopf-algebra factor represents Mathlib's canonical
+factor from the source to its scheme-theoretic image. -/
+theorem hopfSpec_imageι_comp_hopfSpecImageSchemeIso_hom (f : H ⟶ K) :
+    ((hopfSpec (CommRingCat.of k)).map (imageι f).op).hom.hom.left ≫
+        (hopfSpecImageSchemeIso f).hom =
+      eqToHom (hopfSpec_obj_X_left k K) ≫
+        specTargetImageFactorization
+          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) := by
+  let j := Spec.map (specTargetImageRingHom
+    (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)))
+  let _ : IsClosedImmersion j := IsClosedImmersion.spec_of_surjective _
+    (specTargetImageRingHom_surjective
+      (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)))
+  have hgroup :
+      (hopfSpec (CommRingCat.of k)).map (imageι f).op ≫
+          (hopfSpec (CommRingCat.of k)).map (mkImage f).op =
+        (hopfSpec (CommRingCat.of k)).map f.op := by
+    rw [← Functor.map_comp]
+    rw [← op_comp, mkImage_comp_imageι]
+  have hscheme := congrArg
+    (fun g ↦ g.hom.hom.left) hgroup
+  have hscheme' :
+      ((hopfSpec (CommRingCat.of k)).map (imageι f).op).hom.hom.left ≫
+          ((hopfSpec (CommRingCat.of k)).map (mkImage f).op).hom.hom.left =
+        ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left := by
+    simpa only [Grp.comp', Mon.comp_hom', Over.comp_left] using hscheme
+  rw [← cancel_mono j]
+  rw [Category.assoc, hopfSpecImageSchemeIso_hom_comp_specTargetImageRingHom]
+  calc
+    ((hopfSpec (CommRingCat.of k)).map (imageι f).op).hom.hom.left ≫
+          (((hopfSpec (CommRingCat.of k)).map (mkImage f).op).hom.hom.left ≫
+            eqToHom (hopfSpec_obj_X_left k H)) =
+        (((hopfSpec (CommRingCat.of k)).map (imageι f).op).hom.hom.left ≫
+          ((hopfSpec (CommRingCat.of k)).map (mkImage f).op).hom.hom.left) ≫
+            eqToHom (hopfSpec_obj_X_left k H) := Category.assoc _ _ _ |>.symm
+    _ = ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ≫
+          eqToHom (hopfSpec_obj_X_left k H) := congrArg (· ≫
+            eqToHom (hopfSpec_obj_X_left k H)) hscheme'
+    _ = eqToHom (hopfSpec_obj_X_left k K) ≫
+          Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) :=
+      hopfSpec_map_left_comp_eqToHom f
+    _ = eqToHom (hopfSpec_obj_X_left k K) ≫
+          (specTargetImageFactorization
+            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ≫ j) := by
+      rw [specTargetImageFactorization_comp]
+    _ = (eqToHom (hopfSpec_obj_X_left k K) ≫
+          specTargetImageFactorization
+            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) ≫ j :=
+      Category.assoc _ _ _ |>.symm
+
+end CommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean
@@ -68,13 +68,14 @@ theorem hopfSpec_map_left_comp_eqToHom (f : H ⟶ K) :
     ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left ≫
         eqToHom (hopfSpec_obj_X_left k H) =
       eqToHom (hopfSpec_obj_X_left k K) ≫
-        Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) :=
+        Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)) :=
   rfl
 
 /-- The ideal defining the scheme-theoretic image of the spectrum map of a Hopf-algebra morphism
 is the ordinary ring kernel of that morphism. -/
 theorem specTargetImageIdeal_specMap (f : H ⟶ K) :
-    specTargetImageIdeal (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) =
+    specTargetImageIdeal
+        (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) =
       (HopfIdeal.ker f.hom).toIdeal := by
   rw [HopfIdeal.ker_toIdeal]
   rw [specTargetImageIdeal]
@@ -82,7 +83,7 @@ theorem specTargetImageIdeal_specMap (f : H ⟶ K) :
   -- The image ideal is phrased through the `Γ ⊣ Spec` adjunction. Normalize its recovered
   -- coordinate map to the explicit global-sections map before using naturality of `ΓSpecIso`.
   change RingHom.ker (((Scheme.ΓSpecIso (CommRingCat.of H)).inv ≫
-    (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)).appTop).hom) = _
+    (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))).appTop).hom) = _
   rw [← Scheme.ΓSpecIso_inv_naturality]
   ext x
   rw [RingHom.mem_ker, RingHom.mem_ker]
@@ -103,14 +104,16 @@ Hopf ideal's underlying ideal. -/
 theorem specTargetImageIdeal_hopfSpec_map (f : H ⟶ K) :
     specTargetImageIdeal ((hopfSpec (CommRingCat.of k)).map f.op).hom.hom.left =
       (HopfIdeal.ker f.hom).toIdeal := by
-  change specTargetImageIdeal (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) = _
+  change specTargetImageIdeal
+    (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) = _
   exact specTargetImageIdeal_specMap f
 
 /-- The coordinate ring of the scheme-theoretic image is canonically isomorphic to the Hopf
 image, the quotient by the kernel Hopf ideal. -/
 noncomputable def specTargetImageIsoImage (f : H ⟶ K) :
-    specTargetImage (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ≅
-      CommRingCat.of (image f) :=
+    specTargetImage (Spec.map
+      (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) ≅
+      CommRingCat.of (H ⧸ (HopfIdeal.ker f.hom).toIdeal) :=
   (Ideal.quotientEquivAlgOfEq ℤ (specTargetImageIdeal_specMap f)).toRingEquiv
     |>.toCommRingCatIso
 
@@ -120,7 +123,7 @@ image quotient. -/
 theorem specTargetImageIsoImage_hom_mk (f : H ⟶ K) (x : H) :
     (specTargetImageIsoImage f).hom
         (Ideal.Quotient.mk (specTargetImageIdeal
-          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) x) =
+          (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) x) =
       Ideal.Quotient.mk (HopfIdeal.ker f.hom).toIdeal x := by
   exact Ideal.quotientEquivAlgOfEq_mk ℤ (specTargetImageIdeal_specMap f) x
 
@@ -131,7 +134,7 @@ theorem specTargetImageIsoImage_inv_mk (f : H ⟶ K) (x : H) :
     (specTargetImageIsoImage f).inv
         (Ideal.Quotient.mk (HopfIdeal.ker f.hom).toIdeal x) =
       Ideal.Quotient.mk (specTargetImageIdeal
-        (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) x := by
+        (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) x := by
   rw [specTargetImageIsoImage]
   change (Ideal.quotientEquivAlgOfEq ℤ
       (specTargetImageIdeal_specMap f)).symm
@@ -144,7 +147,7 @@ of the represented affine-group morphism. -/
 noncomputable def hopfSpecImageSchemeIso (f : H ⟶ K) :
     ((hopfSpec (CommRingCat.of k)).obj (op (image f))).X.left ≅
       Spec (specTargetImage
-        (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) :=
+        (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) :=
   eqToIso (hopfSpec_obj_X_left k (image f)) ≪≫
     Scheme.Spec.mapIso (specTargetImageIsoImage f).op
 
@@ -153,7 +156,7 @@ closed immersion of the scheme-theoretic image into the target. -/
 theorem hopfSpecImageSchemeIso_hom_comp_specTargetImageRingHom (f : H ⟶ K) :
     (hopfSpecImageSchemeIso f).hom ≫
         Spec.map (specTargetImageRingHom
-          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) =
+          (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) =
       ((hopfSpec (CommRingCat.of k)).map (mkImage f).op).hom.hom.left ≫
         eqToHom (hopfSpec_obj_X_left k H) := by
   rw [hopfSpecImageSchemeIso]
@@ -162,11 +165,11 @@ theorem hopfSpecImageSchemeIso_hom_comp_specTargetImageRingHom (f : H ⟶ K) :
   change (eqToHom (hopfSpec_obj_X_left k (image f)) ≫
       (Scheme.Spec.mapIso (specTargetImageIsoImage f).op).hom) ≫
         Spec.map (specTargetImageRingHom
-          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) =
+          (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) =
       eqToHom (hopfSpec_obj_X_left k (image f)) ≫
         Spec.map (CommRingCat.ofHom (mkImage f).hom.toAlgHom.toRingHom)
   have hcoord : specTargetImageRingHom
-        (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ≫
+        (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) ≫
       (specTargetImageIsoImage f).hom =
         CommRingCat.ofHom (mkImage f).hom.toAlgHom.toRingHom := by
     ext x
@@ -174,17 +177,17 @@ theorem hopfSpecImageSchemeIso_hom_comp_specTargetImageRingHom (f : H ⟶ K) :
     exact (specTargetImageIsoImage_hom_mk f x).trans (mkImage_apply f x).symm
   have h : (Scheme.Spec.mapIso (specTargetImageIsoImage f).op).hom ≫
         Spec.map (specTargetImageRingHom
-          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) =
+          (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) =
       Spec.map (CommRingCat.ofHom (mkImage f).hom.toAlgHom.toRingHom) := by
     calc
       (Scheme.Spec.mapIso (specTargetImageIsoImage f).op).hom ≫
           Spec.map (specTargetImageRingHom
-            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) =
+            (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) =
         Spec.map ((specTargetImageIsoImage f).hom) ≫
           Spec.map (specTargetImageRingHom
-            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) := rfl
+            (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) := rfl
       _ = Spec.map (specTargetImageRingHom
-            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ≫
+            (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) ≫
           (specTargetImageIsoImage f).hom) := (Spec.map_comp _ _).symm
       _ = Spec.map (CommRingCat.ofHom (mkImage f).hom.toAlgHom.toRingHom) :=
         congrArg Spec.map hcoord
@@ -198,12 +201,12 @@ theorem hopfSpec_imageι_comp_hopfSpecImageSchemeIso_hom (f : H ⟶ K) :
         (hopfSpecImageSchemeIso f).hom =
       eqToHom (hopfSpec_obj_X_left k K) ≫
         specTargetImageFactorization
-          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) := by
+          (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) := by
   let j := Spec.map (specTargetImageRingHom
-    (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)))
+    (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))))
   let _ : IsClosedImmersion j := IsClosedImmersion.spec_of_surjective _
     (specTargetImageRingHom_surjective
-      (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)))
+      (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))))
   have hgroup :
       (hopfSpec (CommRingCat.of k)).map (imageι f).op ≫
           (hopfSpec (CommRingCat.of k)).map (mkImage f).op =
@@ -230,15 +233,15 @@ theorem hopfSpec_imageι_comp_hopfSpecImageSchemeIso_hom (f : H ⟶ K) :
           eqToHom (hopfSpec_obj_X_left k H) := congrArg (· ≫
             eqToHom (hopfSpec_obj_X_left k H)) hscheme'
     _ = eqToHom (hopfSpec_obj_X_left k K) ≫
-          Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) :=
+          Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)) :=
       hopfSpec_map_left_comp_eqToHom f
     _ = eqToHom (hopfSpec_obj_X_left k K) ≫
           (specTargetImageFactorization
-            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom)) ≫ j) := by
+            (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K))) ≫ j) := by
       rw [specTargetImageFactorization_comp]
     _ = (eqToHom (hopfSpec_obj_X_left k K) ≫
           specTargetImageFactorization
-            (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))) ≫ j :=
+            (Spec.map (CommRingCat.ofHom ((f.hom : H →ₐ[k] K) : H →+* K)))) ≫ j :=
       Category.assoc _ _ _ |>.symm
 
 end CommHopfAlgCat

--- a/TauCeti/AlgebraicGeometry/SchemeTheoreticImage.lean
+++ b/TauCeti/AlgebraicGeometry/SchemeTheoreticImage.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.AffineScheme
+
+/-!
+# Scheme-theoretic images
+
+This file contains general results about Mathlib's scheme-theoretic image construction.
+
+## Main declarations
+
+* `TauCeti.specTargetImageIdeal_specMap`: the ideal defining the image of a spectrum map is the
+  kernel of the corresponding ring homomorphism.
+-/
+
+public section
+
+open CategoryTheory Opposite
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u
+
+variable {R S : CommRingCat.{u}}
+
+/-- The ideal defining the scheme-theoretic image of a spectrum map is the kernel of the
+corresponding ring homomorphism. -/
+@[simp]
+theorem specTargetImageIdeal_specMap (f : R ⟶ S) :
+    specTargetImageIdeal (Spec.map f) = RingHom.ker f.hom := by
+  rw [specTargetImageIdeal]
+  rw [Adjunction.homEquiv_symm_apply]
+  -- The image ideal is phrased through the `Γ ⊣ Spec` adjunction. Normalize its recovered
+  -- coordinate map to the explicit global-sections map before using naturality of `ΓSpecIso`.
+  change RingHom.ker (((Scheme.ΓSpecIso R).inv ≫ (Spec.map f).appTop).hom) = _
+  rw [← Scheme.ΓSpecIso_inv_naturality]
+  ext x
+  rw [RingHom.mem_ker, RingHom.mem_ker]
+  exact (Scheme.ΓSpecIso S).symm.commRingCatIsoToRingEquiv.map_eq_zero_iff
+
+end TauCeti


### PR DESCRIPTION
This PR identifies the quotient-by-kernel Hopf image with Mathlib's scheme-theoretic image of the represented affine-group morphism, and carries both maps of the Hopf factorization to the canonical image factorization. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3 milestone "Subgroups, quotients, components," specifically the image infrastructure needed to treat coordinate Hopf quotients as actual closed subgroup schemes.

This is the most effective current step because the coordinate factorization `H ⟶ H / ker(f) ⟶ K` is already on `main`, but its module explicitly leaves geometric compatibility unproved; the new bridge makes that construction available to the roadmap's generated normal-subgroup, derived-subgroup, and radical paths without depending on any open PR. After this PR, Layer 3 still needs the remaining representability results for normal fppf quotients and the descent statements for identity components and component groups, while the image-compatibility step itself is complete.

Add `TauCeti/AlgebraicGeometry/AffineGroupScheme/Image.lean` (246 lines). Prove that `specTargetImageIdeal` is the underlying ideal of `HopfIdeal.ker`, identify the two quotient coordinate rings with computation lemmas in both directions, construct `hopfSpecImageSchemeIso`, and prove compatibility with both the closed immersion `Spec(H / ker f) ⟶ Spec H` and the source factor `Spec K ⟶ Spec(H / ker f)`.

No Mathlib infrastructure is vendored. The implementation reuses Mathlib's `specTargetImageIdeal`, `specTargetImage`, `specTargetImageFactorization`, the `Γ ⊣ Spec` adjunction, and spectrum functoriality, together with Tau Ceti's existing Hopf image factorization. The mathematical organization follows Milne, *Algebraic Groups* (2017), §5.a, and Waterhouse, *Introduction to Affine Group Schemes*, §§15--16, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-image-scheme-theoretic-image"}-->

🤖 Prepared with Codex
