### PR TITLE
feat: the weight spaces of the diagonal torus of GL n

### DIFF
--- a/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
+++ b/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
@@ -25,9 +25,17 @@ in a weight basis of an admissible lattice, and `TauCeti.basisDiagonal_apply_of_
 the statement that it acts on a weight vector by the corresponding character — which is what makes
 the conjugation formula against a root subgroup come out.
 
+Fixing the weight instead of the point turns a character into a homomorphism
+`TauCeti.weightChar` on the points of the torus, which is the form in which a weight indexes a
+joint eigenspace. Whether that indexing is faithful depends on the coefficients: over `𝔽₂` the
+torus has a single point, so every weight gives the trivial character, while over a field of
+characteristic zero distinct weights stay distinct (`TauCeti.weightChar_injective`).
+
 ## Main definitions
 
 * `TauCeti.torusCharacter`: the value at `s : κ → Rˣ` of the character `μ : κ → ℤ` of `𝔾ₘ^κ`.
+* `TauCeti.weightChar`: that character with the weight fixed, as a homomorphism on the points of
+  the torus.
 * `TauCeti.weylReflectTorusPoint`: the multiplicative reflection of split-torus points dual to a
   reflection of their character lattice.
 * `TauCeti.basisDiagonal`: the automorphism scaling each basis vector by a prescribed unit.
@@ -41,6 +49,8 @@ the conjugation formula against a root subgroup come out.
 * `TauCeti.basisWeightTorus_apply_of_repr_eq_zero`: the special case for a weight vector.
 * `TauCeti.torusCharacter_weylReflectTorusPoint`: evaluation at a reflected point agrees with
   evaluation of the reflected character.
+* `TauCeti.weightChar_injective`: over a field of characteristic zero, distinct weights give
+  distinct characters of the torus.
 
 ## References
 
@@ -202,6 +212,79 @@ theorem map_torusCharacter {S : Type*} [CommRing S] (φ : R →+* S) (s : κ →
     Units.map (φ : R →* S) (torusCharacter s μ) =
       torusCharacter (fun j => Units.map (φ : R →* S) (s j)) μ := by
   simp [torusCharacter, map_prod, map_zpow]
+
+/-! ## A character as a homomorphism of torus points -/
+
+section WeightChar
+
+variable (R)
+
+/-- The character `μ` of the split torus `𝔾ₘ^κ` read as a homomorphism `(κ → Rˣ) →* Rˣ`: the
+value `TauCeti.torusCharacter s μ` with the weight `μ` fixed and the point `s` varying. This is the
+form in which a weight indexes a joint eigenspace of the torus. -/
+def weightChar (μ : κ → ℤ) : (κ → Rˣ) →* Rˣ where
+  toFun s := torusCharacter s μ
+  map_one' := torusCharacter_one μ
+  map_mul' s t := torusCharacter_mul s t μ
+
+/-- A weight character evaluates as the split-torus character of its weight, with the arguments in
+the order the weight-space API uses. Every arithmetic property of `TauCeti.weightChar` reduces
+through this to the `TauCeti.torusCharacter` lemmas. -/
+theorem weightChar_apply (μ : κ → ℤ) (s : κ → Rˣ) : weightChar R μ s = torusCharacter s μ :=
+  (rfl)
+
+/-- The trivial weight gives the trivial character. -/
+@[simp]
+theorem weightChar_zero : weightChar R (0 : κ → ℤ) = 1 :=
+  MonoidHom.ext fun s ↦ torusCharacter_zero s
+
+/-- Weights add as characters multiply. -/
+theorem weightChar_add (μ ν : κ → ℤ) :
+    weightChar R (μ + ν) = weightChar R μ * weightChar R ν :=
+  MonoidHom.ext fun s ↦ torusCharacter_add s μ ν
+
+/-- The character of `Pi.single c 1` is the `c`-th coordinate: this is the weight carried by the
+`c`-th basis vector of a weight basis. -/
+@[simp]
+theorem weightChar_single [DecidableEq κ] (c : κ) (s : κ → Rˣ) :
+    weightChar R (Pi.single c 1) s = s c := by
+  rw [weightChar_apply, torusCharacter_def,
+    prod_eq_single c (fun j _ hj ↦ by simp [Pi.single_eq_of_ne hj])
+      (fun h ↦ absurd (mem_univ c) h),
+    Pi.single_eq_same, zpow_one]
+
+/-- The character of a constant weight is a power of the product of the coordinates. -/
+theorem weightChar_const (z : ℤ) (s : κ → Rˣ) :
+    weightChar R (fun _ ↦ z) s = (∏ j, s j) ^ z := by
+  rw [weightChar_apply, torusCharacter_def, prod_zpow]
+
+end WeightChar
+
+/-! ## Separating weights -/
+
+/-- In a field of characteristic zero the integer powers of `2` are pairwise distinct, so `2` is a
+unit of infinite order. This is the one arithmetic input to `TauCeti.weightChar_injective`. -/
+private theorem eq_of_two_zpow_eq (K : Type*) [Field K] [CharZero K] {a b : ℤ}
+    (hab : (2 : K) ^ a = (2 : K) ^ b) : a = b := by
+  have hcast : ∀ m : ℤ, (2 : K) ^ m = (((2 : ℚ) ^ m : ℚ) : K) := by
+    intro m
+    rw [Rat.cast_zpow]
+    norm_num
+  rw [hcast a, hcast b] at hab
+  exact (zpow_right_inj₀ (by norm_num) (by norm_num)).mp (Rat.cast_injective hab)
+
+/-- **Distinct weights give distinct characters of the split torus**, over a field of
+characteristic zero. Some hypothesis on the coefficients is needed: over `𝔽₂` the torus `𝔾ₘ^κ` has
+a single point and every weight gives the trivial character. -/
+theorem weightChar_injective {K : Type*} [Field K] [CharZero K] :
+    Function.Injective (weightChar K (κ := κ)) := by
+  classical
+  intro μ ν h
+  funext c
+  refine eq_of_two_zpow_eq K ?_
+  have hval := congrArg
+    (fun χ : (κ → Kˣ) →* Kˣ ↦ ((χ (Pi.mulSingle c (Units.mk0 (2 : K) two_ne_zero)) : Kˣ) : K)) h
+  simpa [weightChar_apply] using hval
 
 end TorusCharacter
 

--- a/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
+++ b/TauCeti/LinearAlgebra/Basis/DiagonalTorus.lean
@@ -5,6 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+-- The finiteness of the roots of `X ^ n - 1`, used only in the proof of `weightChar_injective`.
+import Mathlib.Algebra.Polynomial.Roots
+-- `CharZero.infinite`, which specialises `weightChar_injective` to characteristic zero.
+public import Mathlib.Algebra.CharZero.Infinite
 public import Mathlib.Algebra.Module.Equiv.Basic
 public import Mathlib.LinearAlgebra.Basis.SMul
 public import Mathlib.LinearAlgebra.Matrix.Basis
@@ -28,8 +32,8 @@ the conjugation formula against a root subgroup come out.
 Fixing the weight instead of the point turns a character into a homomorphism
 `TauCeti.weightChar` on the points of the torus, which is the form in which a weight indexes a
 joint eigenspace. Whether that indexing is faithful depends on the coefficients: over `𝔽₂` the
-torus has a single point, so every weight gives the trivial character, while over a field of
-characteristic zero distinct weights stay distinct (`TauCeti.weightChar_injective`).
+torus has a single point, so every weight gives the trivial character, while over an infinite
+field distinct weights stay distinct (`TauCeti.weightChar_injective`).
 
 ## Main definitions
 
@@ -49,8 +53,8 @@ characteristic zero distinct weights stay distinct (`TauCeti.weightChar_injectiv
 * `TauCeti.basisWeightTorus_apply_of_repr_eq_zero`: the special case for a weight vector.
 * `TauCeti.torusCharacter_weylReflectTorusPoint`: evaluation at a reflected point agrees with
   evaluation of the reflected character.
-* `TauCeti.weightChar_injective`: over a field of characteristic zero, distinct weights give
-  distinct characters of the torus.
+* `TauCeti.weightChar_injective`: over an infinite field, distinct weights give distinct
+  characters of the torus.
 
 ## References
 
@@ -262,29 +266,41 @@ end WeightChar
 
 /-! ## Separating weights -/
 
-/-- In a field of characteristic zero the integer powers of `2` are pairwise distinct, so `2` is a
-unit of infinite order. This is the one arithmetic input to `TauCeti.weightChar_injective`. -/
-private theorem eq_of_two_zpow_eq (K : Type*) [Field K] [CharZero K] {a b : ℤ}
-    (hab : (2 : K) ^ a = (2 : K) ^ b) : a = b := by
-  have hcast : ∀ m : ℤ, (2 : K) ^ m = (((2 : ℚ) ^ m : ℚ) : K) := by
-    intro m
-    rw [Rat.cast_zpow]
-    norm_num
-  rw [hcast a, hcast b] at hab
-  exact (zpow_right_inj₀ (by norm_num) (by norm_num)).mp (Rat.cast_injective hab)
+/-- In an infinite field no nonzero exponent kills every unit: the units killed by `d` are roots
+of `X ^ |d| - 1`, hence finitely many, while the nonzero elements are infinite in number. This is
+the one arithmetic input to `TauCeti.weightChar_injective`. No single unit need have infinite
+order — over the algebraic closure of `𝔽ₚ` none does — so the exponent has to be beaten by a unit
+depending on it. -/
+private theorem exists_zpow_ne_one (K : Type*) [Field K] [Infinite K] {d : ℤ} (hd : d ≠ 0) :
+    ∃ u : Kˣ, u ^ d ≠ 1 := by
+  by_contra hcon
+  push Not at hcon
+  have hpos : 0 < d.natAbs := Int.natAbs_pos.mpr hd
+  have hsub : (Set.univ : Set K) ⊆ insert 0 ↑(Polynomial.nthRootsFinset d.natAbs (1 : K)) := by
+    intro x _
+    rcases eq_or_ne x 0 with rfl | hx
+    · exact Set.mem_insert _ _
+    · have hu : Units.mk0 x hx ^ d.natAbs = 1 := pow_natAbs_eq_one.mpr (hcon _)
+      exact Set.mem_insert_of_mem _ (by
+        simpa [Polynomial.mem_nthRootsFinset hpos] using congrArg Units.val hu)
+  exact Set.infinite_univ
+    (((Polynomial.nthRootsFinset d.natAbs (1 : K)).finite_toSet.insert 0).subset hsub)
 
-/-- **Distinct weights give distinct characters of the split torus**, over a field of
-characteristic zero. Some hypothesis on the coefficients is needed: over `𝔽₂` the torus `𝔾ₘ^κ` has
-a single point and every weight gives the trivial character. -/
-theorem weightChar_injective {K : Type*} [Field K] [CharZero K] :
+/-- **Distinct weights give distinct characters of the split torus**, over an infinite field. Some
+hypothesis on the coefficients is needed: over `𝔽₂` the torus `𝔾ₘ^κ` has a single point and every
+weight gives the trivial character. A field of characteristic zero is infinite
+(`CharZero.infinite`), so that case is a specialisation. -/
+theorem weightChar_injective {K : Type*} [Field K] [Infinite K] :
     Function.Injective (weightChar K (κ := κ)) := by
   classical
   intro μ ν h
   funext c
-  refine eq_of_two_zpow_eq K ?_
-  have hval := congrArg
-    (fun χ : (κ → Kˣ) →* Kˣ ↦ ((χ (Pi.mulSingle c (Units.mk0 (2 : K) two_ne_zero)) : Kˣ) : K)) h
-  simpa [weightChar_apply] using hval
+  by_contra hne
+  obtain ⟨u, hu⟩ := exists_zpow_ne_one K (sub_ne_zero.mpr hne)
+  refine hu ?_
+  have hval := congrArg (fun χ : (κ → Kˣ) →* Kˣ ↦ χ (Pi.mulSingle c u)) h
+  simp only [weightChar_apply, torusCharacter_mulSingle] at hval
+  rw [zpow_sub, hval, mul_inv_cancel]
 
 end TorusCharacter
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
@@ -1,0 +1,310 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- The diagonal torus `TauCeti.diagGL`, the standard representation and its action at a diagonal
+-- matrix; this module also re-exports `Mathlib.RepresentationTheory.Character`, hence
+-- `Representation`.
+public import TauCeti.RepresentationTheory.ClassicalGroups.Torus
+-- The determinant powers, the worked one-dimensional example at the end of the file.
+public import TauCeti.RepresentationTheory.ClassicalGroups.Determinant
+-- The simultaneous eigenspaces of a commuting family of endomorphisms and their independence.
+public import Mathlib.LinearAlgebra.Eigenspace.Pi
+
+/-!
+# Weights of the diagonal torus of the general linear group
+
+A vector `w` of a representation `ρ` of `GL n k` has **weight** `l : Fin n → ℤ` when every
+invertible diagonal matrix `diagGL t` scales it by `∏ i, tᵢ ^ lᵢ`. The vectors of weight `l` form
+the **weight space** `TauCeti.weightSpace ρ l`, and this file builds that space, the characters
+`TauCeti.weightChar` of the diagonal torus cutting it out, and the two facts that make weights a
+decomposition rather than a labelling: the weight spaces are independent, and the standard
+representation is the internal direct sum of its weight spaces, which are its coordinate lines.
+
+The weight space is an intersection of eigenspaces, one for each point of the torus, so
+independence is the independence of the simultaneous eigenspaces of a commuting family of
+endomorphisms — Mathlib's `Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo` —
+transported along the injection `l ↦ TauCeti.weightChar k l`. That injection is where the
+coefficients enter: over `𝔽₂` the torus is trivial (`TauCeti.diagonalTorus_eq_bot`), every `l`
+gives the same character, and the whole module is a weight space for every weight at once, so
+nothing is independent. What rules this out is a unit of infinite order, and in a field of
+characteristic zero `2` is one; that is the standing hypothesis of every statement below that
+separates weights.
+
+The definitions themselves need only a commutative ring, and are stated there.
+
+## Main definitions
+
+* `TauCeti.weightChar`: the character `t ↦ ∏ i, tᵢ ^ lᵢ` of the diagonal torus attached to
+  `l : Fin n → ℤ`, as a homomorphism of the coordinatewise units.
+* `TauCeti.weightSpace`: the space of vectors on which the diagonal torus acts through
+  `TauCeti.weightChar`.
+
+## Main results
+
+* `TauCeti.weightChar_injective`: over a field of characteristic zero, distinct weights give
+  distinct characters of the torus.
+* `TauCeti.iSupIndep_weightSpace`: **the weight spaces of a representation of `GL n k` are
+  independent**, over a field of characteristic zero.
+* `TauCeti.weightSpace_stdRep_single` and `TauCeti.weightSpace_stdRep_eq_bot`: the weight spaces of
+  the standard representation are exactly its coordinate lines, the line `k ∙ eᵢ` carrying the
+  weight `Pi.single i 1` and every other weight space vanishing.
+* `TauCeti.isInternal_weightSpace_stdRep`: **the standard representation is the internal direct sum
+  of its weight spaces.**
+* `TauCeti.weightSpace_detPowerRep`: `det ^ m` is a single weight space, of weight the constant
+  sequence `m`.
+
+## Implementation notes
+
+The weight space is indexed by `l : Fin n → ℤ`, not by a character of the torus, because that is
+the index the highest-weight theory of the roadmap runs on; `TauCeti.weightChar` is the translation
+between the two, and `TauCeti.weightChar_injective` says the translation is faithful.
+
+The intersection defining `TauCeti.weightSpace` runs over `t : Fin n → kˣ` rather than over
+`TauCeti.diagonalTorus k n` itself: `TauCeti.diagGL` is onto the torus
+(`TauCeti.mem_diagonalTorus_iff_exists_diagGL`), so the two conditions agree, and the
+coordinatewise form is the one every computation below uses.
+
+Weight spaces are intersections of honest eigenspaces, not of generalised ones. Independence is
+inherited from the generalised statement, which is the form Mathlib proves; nothing below needs
+the generalised spaces themselves, since a torus element acts on a weight vector by an honest
+scalar.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 3, "The maximal torus and weight spaces".
+* W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), Lecture 15.
+-/
+
+public section
+
+open Matrix
+
+universe u v
+
+namespace TauCeti
+
+section CommRing
+
+variable (k : Type u) [CommRing k] {n : ℕ}
+
+/-! ## The characters of the diagonal torus -/
+
+/-- The character `t ↦ ∏ i, tᵢ ^ lᵢ` of the diagonal torus of `GL n k` attached to an integer
+sequence `l`. The weight space of `l` is cut out by it. -/
+def weightChar (l : Fin n → ℤ) : (Fin n → kˣ) →* kˣ where
+  toFun t := ∏ i, t i ^ l i
+  map_one' := by simp
+  map_mul' s t := by simp [mul_zpow, Finset.prod_mul_distrib]
+
+/-- The value of a weight character, unfolding the definition. -/
+theorem weightChar_apply (l : Fin n → ℤ) (t : Fin n → kˣ) :
+    weightChar k l t = ∏ i, t i ^ l i :=
+  (rfl)
+
+@[simp]
+theorem weightChar_zero : weightChar k (0 : Fin n → ℤ) = 1 :=
+  MonoidHom.ext fun t ↦ by simp [weightChar_apply]
+
+/-- Weights add as characters multiply. -/
+theorem weightChar_add (l m : Fin n → ℤ) :
+    weightChar k (l + m) = weightChar k l * weightChar k m :=
+  MonoidHom.ext fun t ↦ by
+    simp only [weightChar_apply, MonoidHom.mul_apply, Pi.add_apply, zpow_add]
+    rw [Finset.prod_mul_distrib]
+
+/-- The character of `Pi.single i 1` is the `i`-th coordinate: this is the weight carried by the
+`i`-th standard basis vector. -/
+@[simp]
+theorem weightChar_single (i : Fin n) (t : Fin n → kˣ) :
+    weightChar k (Pi.single i 1) t = t i := by
+  classical
+  rw [weightChar_apply,
+    Finset.prod_eq_single i (fun j _ hj ↦ by simp [Pi.single_eq_of_ne hj])
+      (fun h ↦ absurd (Finset.mem_univ i) h),
+    Pi.single_eq_same, zpow_one]
+
+/-- The character of a constant sequence is a power of the determinant of the torus element. -/
+theorem weightChar_const (m : ℤ) (t : Fin n → kˣ) :
+    weightChar k (fun _ ↦ m) t = (∏ i, t i) ^ m := by
+  rw [weightChar_apply, Finset.prod_zpow]
+
+/-- Evaluating a weight character at a torus element supported in one coordinate reads off the
+corresponding entry of the weight. This is how a weight is recovered from its character. -/
+theorem weightChar_update_one (l : Fin n → ℤ) (i : Fin n) (u : kˣ) :
+    weightChar k l (Function.update 1 i u) = u ^ l i := by
+  classical
+  rw [weightChar_apply,
+    Finset.prod_eq_single i (fun j _ hj ↦ by simp [Function.update_of_ne hj])
+      (fun h ↦ absurd (Finset.mem_univ i) h),
+    Function.update_self]
+
+/-! ## The weight spaces of a representation -/
+
+variable {k}
+variable {W : Type v} [AddCommGroup W] [Module k W]
+
+/-- The **weight space** of weight `l : Fin n → ℤ`: the vectors that every invertible diagonal
+matrix `diagGL t` scales by `∏ i, tᵢ ^ lᵢ`. -/
+def weightSpace (ρ : Representation k (GL (Fin n) k) W) (l : Fin n → ℤ) : Submodule k W :=
+  ⨅ t : Fin n → kˣ, Module.End.eigenspace (ρ (diagGL t)) ((weightChar k l t : kˣ) : k)
+
+/-- Membership in a weight space is the eigen-relation at every point of the torus. -/
+theorem mem_weightSpace_iff (ρ : Representation k (GL (Fin n) k) W) (l : Fin n → ℤ) (w : W) :
+    w ∈ weightSpace ρ l ↔
+      ∀ t : Fin n → kˣ, ρ (diagGL t) w = ((weightChar k l t : kˣ) : k) • w := by
+  simp [weightSpace]
+
+/-- A weight vector is an eigenvector for each individual point of the torus. -/
+theorem weightSpace_le_eigenspace (ρ : Representation k (GL (Fin n) k) W) (l : Fin n → ℤ)
+    (t : Fin n → kˣ) :
+    weightSpace ρ l ≤ Module.End.eigenspace (ρ (diagGL t)) ((weightChar k l t : kˣ) : k) :=
+  iInf_le _ t
+
+/-- The action of a torus element on a weight vector. -/
+theorem apply_of_mem_weightSpace {ρ : Representation k (GL (Fin n) k) W} {l : Fin n → ℤ} {w : W}
+    (hw : w ∈ weightSpace ρ l) (t : Fin n → kˣ) :
+    ρ (diagGL t) w = ((weightChar k l t : kˣ) : k) • w :=
+  (mem_weightSpace_iff ρ l w).mp hw t
+
+/-- The torus points act on a representation by commuting endomorphisms, the diagonal matrices
+forming a commutative subgroup. -/
+theorem commute_apply_diagGL (ρ : Representation k (GL (Fin n) k) W) (s t : Fin n → kˣ) :
+    Commute (ρ (diagGL s)) (ρ (diagGL t)) :=
+  ((Commute.all s t).map diagGL).map ρ
+
+/-! ## The standard representation and the determinant powers -/
+
+/-- The `i`-th standard basis vector has weight `Pi.single i 1`: a diagonal matrix scales it by its
+`i`-th entry. -/
+theorem basisFun_mem_weightSpace_stdRep (i : Fin n) :
+    Pi.basisFun k (Fin n) i ∈ weightSpace (stdRep k n) (Pi.single i 1) := by
+  rw [mem_weightSpace_iff]
+  intro t
+  rw [stdRep_diagGL_apply_basisFun, weightChar_single]
+
+/-- The coordinate line `k ∙ eᵢ` consists of vectors of weight `Pi.single i 1`. -/
+theorem span_basisFun_le_weightSpace_stdRep (i : Fin n) :
+    Submodule.span k {Pi.basisFun k (Fin n) i} ≤ weightSpace (stdRep k n) (Pi.single i 1) := by
+  rw [Submodule.span_le, Set.singleton_subset_iff]
+  exact basisFun_mem_weightSpace_stdRep i
+
+/-- The weight spaces of the standard representation span it, being its coordinate lines. -/
+theorem iSup_weightSpace_stdRep :
+    ⨆ l : Fin n → ℤ, weightSpace (stdRep k n) l = ⊤ := by
+  refine top_le_iff.mp ?_
+  rw [← (Pi.basisFun k (Fin n)).span_eq, Submodule.span_le]
+  rintro _ ⟨i, rfl⟩
+  exact le_iSup (fun l : Fin n → ℤ ↦ weightSpace (stdRep k n) l) (Pi.single i 1)
+    (basisFun_mem_weightSpace_stdRep i)
+
+/-- **`det ^ m` is a single weight space**, of weight the constant sequence `m`: a diagonal matrix
+acts on it by the `m`-th power of the product of its entries. -/
+theorem weightSpace_detPowerRep (m : ℤ) :
+    weightSpace (detPowerRep k n m) (fun _ ↦ m) = ⊤ := by
+  refine top_le_iff.mp fun x _ ↦ ?_
+  rw [mem_weightSpace_iff]
+  intro t
+  rw [detPowerRep_apply, weightChar_const, smul_eq_mul, det_diagGL]
+
+end CommRing
+
+/-- In a field of characteristic zero the integer powers of `2` are pairwise distinct, so `2` is a
+unit of infinite order. This is the one arithmetic input to `TauCeti.weightChar_injective`. -/
+private theorem eq_of_two_zpow_eq (k : Type u) [Field k] [CharZero k] {a b : ℤ}
+    (hab : (2 : k) ^ a = (2 : k) ^ b) : a = b := by
+  have hcast : ∀ m : ℤ, (2 : k) ^ m = (((2 : ℚ) ^ m : ℚ) : k) := by
+    intro m
+    rw [Rat.cast_zpow]
+    norm_num
+  rw [hcast a, hcast b] at hab
+  exact (zpow_right_inj₀ (by norm_num) (by norm_num)).mp (Rat.cast_injective hab)
+
+section Field
+
+variable {k : Type u} [Field k] [CharZero k] {n : ℕ}
+
+/-! ## Separating weights over a field of characteristic zero -/
+
+/-- **Distinct weights give distinct characters of the torus.** Characteristic zero is what makes
+this true: over `𝔽₂` the torus is trivial and every weight gives the trivial character. -/
+theorem weightChar_injective : Function.Injective (weightChar k (n := n)) := by
+  intro l l' h
+  funext i
+  refine eq_of_two_zpow_eq k ?_
+  have hval := congrArg
+    (fun χ : (Fin n → kˣ) →* kˣ ↦
+      ((χ (Function.update 1 i (Units.mk0 (2 : k) two_ne_zero)) : kˣ) : k)) h
+  simpa [weightChar_update_one] using hval
+
+variable {W : Type v} [AddCommGroup W] [Module k W]
+
+/-- **The weight spaces of a representation of `GL n k` are independent.** Over a field of
+characteristic zero the weight is recoverable from its character, so the weight spaces are a
+subfamily of the simultaneous eigenspaces of the commuting family `t ↦ ρ (diagGL t)`, and those are
+independent. -/
+theorem iSupIndep_weightSpace (ρ : Representation k (GL (Fin n) k) W) :
+    iSupIndep fun l : Fin n → ℤ ↦ weightSpace ρ l := by
+  classical
+  have hgen := Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo
+    (fun t : Fin n → kˣ ↦ ρ (diagGL t))
+    (fun s t φ ↦ Module.End.mapsTo_maxGenEigenspace_of_comm (commute_apply_diagGL ρ t s) φ)
+  have hinj : Function.Injective
+      (fun (l : Fin n → ℤ) (t : Fin n → kˣ) ↦ ((weightChar k l t : kˣ) : k)) := by
+    intro l l' h
+    refine weightChar_injective (k := k) (MonoidHom.ext fun t ↦ ?_)
+    exact Units.ext (congrFun h t)
+  refine (hgen.comp hinj).mono fun l ↦ le_iInf fun t ↦ ?_
+  exact (weightSpace_le_eigenspace ρ l t).trans Module.End.eigenspace_le_maxGenEigenspace
+
+/-! ## The weight-space decomposition of the standard representation -/
+
+/-- **A nonzero coordinate pins the weight.** If a vector of weight `l` in the standard
+representation has a nonzero `j`-th coordinate then `l = Pi.single j 1`. -/
+theorem eq_single_of_mem_weightSpace_stdRep {l : Fin n → ℤ} {w : Fin n → k}
+    (hw : w ∈ weightSpace (stdRep k n) l) {j : Fin n} (hj : w j ≠ 0) :
+    l = Pi.single j 1 := by
+  refine weightChar_injective (k := k) (MonoidHom.ext fun t ↦ ?_)
+  have h := congrFun (apply_of_mem_weightSpace hw t) j
+  rw [stdRep_diagGL_apply, Pi.smul_apply, smul_eq_mul] at h
+  rw [weightChar_single]
+  exact Units.ext (mul_right_cancel₀ hj h).symm
+
+/-- Off the weights `Pi.single i 1` the standard representation has no weight vectors. -/
+theorem weightSpace_stdRep_eq_bot {l : Fin n → ℤ} (hl : ∀ i : Fin n, l ≠ Pi.single i 1) :
+    weightSpace (stdRep k n) l = ⊥ := by
+  refine (Submodule.eq_bot_iff _).mpr fun w hw ↦ funext fun j ↦ ?_
+  by_contra hj
+  exact hl j (eq_single_of_mem_weightSpace_stdRep hw hj)
+
+/-- **The weight spaces of the standard representation are its coordinate lines.** -/
+theorem weightSpace_stdRep_single (i : Fin n) :
+    weightSpace (stdRep k n) (Pi.single i 1) = Submodule.span k {Pi.basisFun k (Fin n) i} := by
+  refine le_antisymm (fun w hw ↦ ?_) (span_basisFun_le_weightSpace_stdRep i)
+  rw [Submodule.mem_span_singleton]
+  refine ⟨w i, funext fun j ↦ ?_⟩
+  by_cases hji : j = i
+  · subst hji
+    simp
+  · have hzero : w j = 0 := by
+      by_contra hj
+      have hsingle := eq_single_of_mem_weightSpace_stdRep hw hj
+      have hone : (Pi.single i 1 : Fin n → ℤ) j = 1 := by rw [hsingle, Pi.single_eq_same]
+      rw [Pi.single_eq_of_ne hji] at hone
+      exact one_ne_zero hone.symm
+    simp [hzero, Pi.basisFun_apply, hji]
+
+/-- **The standard representation is the internal direct sum of its weight spaces**: the
+weight-space decomposition in its smallest instance. -/
+theorem isInternal_weightSpace_stdRep :
+    DirectSum.IsInternal fun l : Fin n → ℤ ↦ weightSpace (stdRep k n) l :=
+  (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mpr
+    ⟨iSupIndep_weightSpace _, iSup_weightSpace_stdRep⟩
+
+end Field
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
@@ -35,7 +35,7 @@ where the coefficients enter: over `𝔽₂` the torus is trivial
 (`TauCeti.diagonalTorus_eq_bot`), every `l` gives the same character, and the whole module is a
 weight space for every weight at once, so nothing is independent. Rather than fix the coefficients,
 every statement below that separates weights takes `Function.Injective (weightChar k)` as a
-hypothesis, and `TauCeti.weightChar_injective` discharges it over a field of characteristic zero.
+hypothesis, and `TauCeti.weightChar_injective` discharges it over an infinite field.
 
 The definitions themselves need only a commutative ring, and are stated there.
 
@@ -159,7 +159,7 @@ end CommRing
 /-! ## The weight spaces of the standard representation
 
 Here the coefficients must separate weights, in the sense that `l ↦ weightChar k l` is injective;
-`TauCeti.weightChar_injective` supplies that over a field of characteristic zero. -/
+`TauCeti.weightChar_injective` supplies that over an infinite field. -/
 
 section Domain
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
@@ -11,8 +11,10 @@ module
 public import TauCeti.RepresentationTheory.ClassicalGroups.Torus
 -- The determinant powers, the worked one-dimensional example at the end of the file.
 public import TauCeti.RepresentationTheory.ClassicalGroups.Determinant
--- The simultaneous eigenspaces of a commuting family of endomorphisms and their independence.
-public import Mathlib.LinearAlgebra.Eigenspace.Pi
+-- The characters `TauCeti.torusCharacter` of a split torus, which the weight characters package.
+public import TauCeti.LinearAlgebra.Basis.DiagonalTorus
+-- The independence of the joint eigenspaces of a representation, indexed by characters.
+public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Basic
 
 /-!
 # Weights of the diagonal torus of the general linear group
@@ -25,8 +27,8 @@ decomposition rather than a labelling: the weight spaces are independent, and th
 representation is the internal direct sum of its weight spaces, which are its coordinate lines.
 
 The weight space is an intersection of eigenspaces, one for each point of the torus, so
-independence is the independence of the simultaneous eigenspaces of a commuting family of
-endomorphisms — Mathlib's `Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo` —
+independence is the independence of the joint eigenspaces of a representation indexed by
+characters — `TauCeti.iSupIndep_iInf_eigenspace_unitHom` —
 transported along the injection `l ↦ TauCeti.weightChar k l`. That injection is where the
 coefficients enter: over `𝔽₂` the torus is trivial (`TauCeti.diagonalTorus_eq_bot`), every `l`
 gives the same character, and the whole module is a weight space for every weight at once, so
@@ -64,15 +66,19 @@ The weight space is indexed by `l : Fin n → ℤ`, not by a character of the to
 the index the highest-weight theory of the roadmap runs on; `TauCeti.weightChar` is the translation
 between the two, and `TauCeti.weightChar_injective` says the translation is faithful.
 
+`TauCeti.weightChar` only repackages the split-torus character `TauCeti.torusCharacter`, which is
+the same product `∏ i, tᵢ ^ lᵢ` read as a function of the weight; the point of the repackaging is
+that a *fixed* weight gives a homomorphism in the torus point, which is the form the joint
+eigenspaces are indexed by. All arithmetic of the characters comes from the `torusCharacter`
+lemmas.
+
 The intersection defining `TauCeti.weightSpace` runs over `t : Fin n → kˣ` rather than over
 `TauCeti.diagonalTorus k n` itself: `TauCeti.diagGL` is onto the torus
 (`TauCeti.mem_diagonalTorus_iff_exists_diagGL`), so the two conditions agree, and the
 coordinatewise form is the one every computation below uses.
 
-Weight spaces are intersections of honest eigenspaces, not of generalised ones. Independence is
-inherited from the generalised statement, which is the form Mathlib proves; nothing below needs
-the generalised spaces themselves, since a torus element acts on a weight vector by an honest
-scalar.
+Weight spaces are intersections of honest eigenspaces, not of generalised ones: a torus element
+acts on a weight vector by an honest scalar, and independence is available in that form already.
 
 ## References
 
@@ -96,27 +102,28 @@ variable (k : Type u) [CommRing k] {n : ℕ}
 /-! ## The characters of the diagonal torus -/
 
 /-- The character `t ↦ ∏ i, tᵢ ^ lᵢ` of the diagonal torus of `GL n k` attached to an integer
-sequence `l`. The weight space of `l` is cut out by it. -/
+sequence `l`: the split-torus character `TauCeti.torusCharacter` of `l`, read as a homomorphism in
+the torus point. The weight space of `l` is cut out by it. -/
 def weightChar (l : Fin n → ℤ) : (Fin n → kˣ) →* kˣ where
-  toFun t := ∏ i, t i ^ l i
-  map_one' := by simp
-  map_mul' s t := by simp [mul_zpow, Finset.prod_mul_distrib]
+  toFun t := torusCharacter t l
+  map_one' := torusCharacter_one l
+  map_mul' s t := torusCharacter_mul s t l
 
-/-- The value of a weight character, unfolding the definition. -/
+/-- A weight character is the split-torus character of its weight, with the arguments in the order
+the weight-space API uses. Every arithmetic property of `TauCeti.weightChar` reduces through this
+to the `TauCeti.torusCharacter` lemmas. -/
 theorem weightChar_apply (l : Fin n → ℤ) (t : Fin n → kˣ) :
-    weightChar k l t = ∏ i, t i ^ l i :=
+    weightChar k l t = torusCharacter t l :=
   (rfl)
 
 @[simp]
 theorem weightChar_zero : weightChar k (0 : Fin n → ℤ) = 1 :=
-  MonoidHom.ext fun t ↦ by simp [weightChar_apply]
+  MonoidHom.ext fun t ↦ torusCharacter_zero t
 
 /-- Weights add as characters multiply. -/
 theorem weightChar_add (l m : Fin n → ℤ) :
     weightChar k (l + m) = weightChar k l * weightChar k m :=
-  MonoidHom.ext fun t ↦ by
-    simp only [weightChar_apply, MonoidHom.mul_apply, Pi.add_apply, zpow_add]
-    rw [Finset.prod_mul_distrib]
+  MonoidHom.ext fun t ↦ torusCharacter_add t l m
 
 /-- The character of `Pi.single i 1` is the `i`-th coordinate: this is the weight carried by the
 `i`-th standard basis vector. -/
@@ -124,7 +131,7 @@ theorem weightChar_add (l m : Fin n → ℤ) :
 theorem weightChar_single (i : Fin n) (t : Fin n → kˣ) :
     weightChar k (Pi.single i 1) t = t i := by
   classical
-  rw [weightChar_apply,
+  rw [weightChar_apply, torusCharacter_def,
     Finset.prod_eq_single i (fun j _ hj ↦ by simp [Pi.single_eq_of_ne hj])
       (fun h ↦ absurd (Finset.mem_univ i) h),
     Pi.single_eq_same, zpow_one]
@@ -132,17 +139,7 @@ theorem weightChar_single (i : Fin n) (t : Fin n → kˣ) :
 /-- The character of a constant sequence is a power of the determinant of the torus element. -/
 theorem weightChar_const (m : ℤ) (t : Fin n → kˣ) :
     weightChar k (fun _ ↦ m) t = (∏ i, t i) ^ m := by
-  rw [weightChar_apply, Finset.prod_zpow]
-
-/-- Evaluating a weight character at a torus element supported in one coordinate reads off the
-corresponding entry of the weight. This is how a weight is recovered from its character. -/
-theorem weightChar_update_one (l : Fin n → ℤ) (i : Fin n) (u : kˣ) :
-    weightChar k l (Function.update 1 i u) = u ^ l i := by
-  classical
-  rw [weightChar_apply,
-    Finset.prod_eq_single i (fun j _ hj ↦ by simp [Function.update_of_ne hj])
-      (fun h ↦ absurd (Finset.mem_univ i) h),
-    Function.update_self]
+  rw [weightChar_apply, torusCharacter_def, Finset.prod_zpow]
 
 /-! ## The weight spaces of a representation -/
 
@@ -171,12 +168,6 @@ theorem apply_of_mem_weightSpace {ρ : Representation k (GL (Fin n) k) W} {l : F
     (hw : w ∈ weightSpace ρ l) (t : Fin n → kˣ) :
     ρ (diagGL t) w = ((weightChar k l t : kˣ) : k) • w :=
   (mem_weightSpace_iff ρ l w).mp hw t
-
-/-- The torus points act on a representation by commuting endomorphisms, the diagonal matrices
-forming a commutative subgroup. -/
-theorem commute_apply_diagGL (ρ : Representation k (GL (Fin n) k) W) (s t : Fin n → kˣ) :
-    Commute (ρ (diagGL s)) (ρ (diagGL t)) :=
-  ((Commute.all s t).map diagGL).map ρ
 
 /-! ## The standard representation and the determinant powers -/
 
@@ -241,28 +232,19 @@ theorem weightChar_injective : Function.Injective (weightChar k (n := n)) := by
   refine eq_of_two_zpow_eq k ?_
   have hval := congrArg
     (fun χ : (Fin n → kˣ) →* kˣ ↦
-      ((χ (Function.update 1 i (Units.mk0 (2 : k) two_ne_zero)) : kˣ) : k)) h
-  simpa [weightChar_update_one] using hval
+      ((χ (Pi.mulSingle i (Units.mk0 (2 : k) two_ne_zero)) : kˣ) : k)) h
+  simpa [weightChar_apply] using hval
 
 variable {W : Type v} [AddCommGroup W] [Module k W]
 
-/-- **The weight spaces of a representation of `GL n k` are independent.** Over a field of
-characteristic zero the weight is recoverable from its character, so the weight spaces are a
-subfamily of the simultaneous eigenspaces of the commuting family `t ↦ ρ (diagGL t)`, and those are
-independent. -/
+/-- **The weight spaces of a representation of `GL n k` are independent.** The weight spaces are
+the joint eigenspaces of the representation `t ↦ ρ (diagGL t)` of the torus indexed by the
+characters `weightChar k l`, and those are independent; over a field of characteristic zero the
+weight is recoverable from its character, so indexing by weights keeps them distinct. -/
 theorem iSupIndep_weightSpace (ρ : Representation k (GL (Fin n) k) W) :
-    iSupIndep fun l : Fin n → ℤ ↦ weightSpace ρ l := by
-  classical
-  have hgen := Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo
-    (fun t : Fin n → kˣ ↦ ρ (diagGL t))
-    (fun s t φ ↦ Module.End.mapsTo_maxGenEigenspace_of_comm (commute_apply_diagGL ρ t s) φ)
-  have hinj : Function.Injective
-      (fun (l : Fin n → ℤ) (t : Fin n → kˣ) ↦ ((weightChar k l t : kˣ) : k)) := by
-    intro l l' h
-    refine weightChar_injective (k := k) (MonoidHom.ext fun t ↦ ?_)
-    exact Units.ext (congrFun h t)
-  refine (hgen.comp hinj).mono fun l ↦ le_iInf fun t ↦ ?_
-  exact (weightSpace_le_eigenspace ρ l t).trans Module.End.eigenspace_le_maxGenEigenspace
+    iSupIndep fun l : Fin n → ℤ ↦ weightSpace ρ l :=
+  (iSupIndep_iInf_eigenspace_unitHom
+      (ρ := (ρ : GL (Fin n) k →* Module.End k W).comp diagGL)).comp weightChar_injective
 
 /-! ## The weight-space decomposition of the standard representation -/
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
@@ -54,8 +54,9 @@ The definitions themselves need only a commutative ring, and are stated there.
   weight `Pi.single i 1` and every other weight space vanishing.
 * `TauCeti.isInternal_weightSpace_stdRep`: **the standard representation is the internal direct sum
   of its weight spaces.**
-* `TauCeti.weightSpace_detPowerRep`: `det ^ m` is a single weight space, of weight the constant
-  sequence `m`.
+* `TauCeti.weightSpace_detPowerRep`: all of `det ^ m` has the constant weight `m`, that is, its
+  weight space at the constant sequence `m` is `⊤`. Over a general commutative ring this says
+  nothing about the other weight spaces — over `𝔽₂` all of them are `⊤` as well.
 
 ## Implementation notes
 
@@ -202,8 +203,10 @@ theorem iSup_weightSpace_stdRep :
   exact le_iSup (fun l : Fin n → ℤ ↦ weightSpace (stdRep k n) l) (Pi.single i 1)
     (basisFun_mem_weightSpace_stdRep i)
 
-/-- **`det ^ m` is a single weight space**, of weight the constant sequence `m`: a diagonal matrix
-acts on it by the `m`-th power of the product of its entries. -/
+/-- **All of `det ^ m` has weight the constant sequence `m`**: a diagonal matrix acts on it by the
+`m`-th power of the product of its entries. Over a commutative ring this leaves the other weight
+spaces of `det ^ m` unconstrained — over `𝔽₂` the torus is trivial, so every one of them is `⊤`
+too. -/
 theorem weightSpace_detPowerRep (m : ℤ) :
     weightSpace (detPowerRep k n m) (fun _ ↦ m) = ⊤ := by
   refine top_le_iff.mp fun x _ ↦ ?_

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean
@@ -11,7 +11,7 @@ module
 public import TauCeti.RepresentationTheory.ClassicalGroups.Torus
 -- The determinant powers, the worked one-dimensional example at the end of the file.
 public import TauCeti.RepresentationTheory.ClassicalGroups.Determinant
--- The characters `TauCeti.torusCharacter` of a split torus, which the weight characters package.
+-- The characters `TauCeti.weightChar` of a split torus, and their injectivity in weight.
 public import TauCeti.LinearAlgebra.Basis.DiagonalTorus
 -- The independence of the joint eigenspaces of a representation, indexed by characters.
 public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Basic
@@ -21,36 +21,33 @@ public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Basic
 
 A vector `w` of a representation `ρ` of `GL n k` has **weight** `l : Fin n → ℤ` when every
 invertible diagonal matrix `diagGL t` scales it by `∏ i, tᵢ ^ lᵢ`. The vectors of weight `l` form
-the **weight space** `TauCeti.weightSpace ρ l`, and this file builds that space, the characters
-`TauCeti.weightChar` of the diagonal torus cutting it out, and the two facts that make weights a
-decomposition rather than a labelling: the weight spaces are independent, and the standard
-representation is the internal direct sum of its weight spaces, which are its coordinate lines.
+the **weight space** `TauCeti.weightSpace ρ l`, and this file builds that space and the two facts
+that make weights a decomposition rather than a labelling: the weight spaces are independent, and
+the standard representation is the internal direct sum of its weight spaces, which are its
+coordinate lines.
 
-The weight space is an intersection of eigenspaces, one for each point of the torus, so
-independence is the independence of the joint eigenspaces of a representation indexed by
-characters — `TauCeti.iSupIndep_iInf_eigenspace_unitHom` —
-transported along the injection `l ↦ TauCeti.weightChar k l`. That injection is where the
-coefficients enter: over `𝔽₂` the torus is trivial (`TauCeti.diagonalTorus_eq_bot`), every `l`
-gives the same character, and the whole module is a weight space for every weight at once, so
-nothing is independent. What rules this out is a unit of infinite order, and in a field of
-characteristic zero `2` is one; that is the standing hypothesis of every statement below that
-separates weights.
+The scalar `∏ i, tᵢ ^ lᵢ` is the split-torus character `TauCeti.weightChar k l`, built in
+`TauCeti.LinearAlgebra.Basis.DiagonalTorus`. The weight space is an intersection of eigenspaces,
+one for each point of the torus, so independence is the independence of the joint eigenspaces of a
+representation indexed by characters — `TauCeti.iSupIndep_iInf_eigenspace_unitHom` — transported
+along `l ↦ TauCeti.weightChar k l`. That transport needs the map to be injective, and that is
+where the coefficients enter: over `𝔽₂` the torus is trivial
+(`TauCeti.diagonalTorus_eq_bot`), every `l` gives the same character, and the whole module is a
+weight space for every weight at once, so nothing is independent. Rather than fix the coefficients,
+every statement below that separates weights takes `Function.Injective (weightChar k)` as a
+hypothesis, and `TauCeti.weightChar_injective` discharges it over a field of characteristic zero.
 
 The definitions themselves need only a commutative ring, and are stated there.
 
 ## Main definitions
 
-* `TauCeti.weightChar`: the character `t ↦ ∏ i, tᵢ ^ lᵢ` of the diagonal torus attached to
-  `l : Fin n → ℤ`, as a homomorphism of the coordinatewise units.
 * `TauCeti.weightSpace`: the space of vectors on which the diagonal torus acts through
   `TauCeti.weightChar`.
 
 ## Main results
 
-* `TauCeti.weightChar_injective`: over a field of characteristic zero, distinct weights give
-  distinct characters of the torus.
 * `TauCeti.iSupIndep_weightSpace`: **the weight spaces of a representation of `GL n k` are
-  independent**, over a field of characteristic zero.
+  independent**, as soon as distinct weights give distinct characters.
 * `TauCeti.weightSpace_stdRep_single` and `TauCeti.weightSpace_stdRep_eq_bot`: the weight spaces of
   the standard representation are exactly its coordinate lines, the line `k ∙ eᵢ` carrying the
   weight `Pi.single i 1` and every other weight space vanishing.
@@ -64,13 +61,7 @@ The definitions themselves need only a commutative ring, and are stated there.
 
 The weight space is indexed by `l : Fin n → ℤ`, not by a character of the torus, because that is
 the index the highest-weight theory of the roadmap runs on; `TauCeti.weightChar` is the translation
-between the two, and `TauCeti.weightChar_injective` says the translation is faithful.
-
-`TauCeti.weightChar` only repackages the split-torus character `TauCeti.torusCharacter`, which is
-the same product `∏ i, tᵢ ^ lᵢ` read as a function of the weight; the point of the repackaging is
-that a *fixed* weight gives a homomorphism in the torus point, which is the form the joint
-eigenspaces are indexed by. All arithmetic of the characters comes from the `torusCharacter`
-lemmas.
+between the two, and the separation hypothesis says the translation is faithful.
 
 The intersection defining `TauCeti.weightSpace` runs over `t : Fin n → kˣ` rather than over
 `TauCeti.diagonalTorus k n` itself: `TauCeti.diagGL` is onto the torus
@@ -97,54 +88,10 @@ namespace TauCeti
 
 section CommRing
 
-variable (k : Type u) [CommRing k] {n : ℕ}
-
-/-! ## The characters of the diagonal torus -/
-
-/-- The character `t ↦ ∏ i, tᵢ ^ lᵢ` of the diagonal torus of `GL n k` attached to an integer
-sequence `l`: the split-torus character `TauCeti.torusCharacter` of `l`, read as a homomorphism in
-the torus point. The weight space of `l` is cut out by it. -/
-def weightChar (l : Fin n → ℤ) : (Fin n → kˣ) →* kˣ where
-  toFun t := torusCharacter t l
-  map_one' := torusCharacter_one l
-  map_mul' s t := torusCharacter_mul s t l
-
-/-- A weight character is the split-torus character of its weight, with the arguments in the order
-the weight-space API uses. Every arithmetic property of `TauCeti.weightChar` reduces through this
-to the `TauCeti.torusCharacter` lemmas. -/
-theorem weightChar_apply (l : Fin n → ℤ) (t : Fin n → kˣ) :
-    weightChar k l t = torusCharacter t l :=
-  (rfl)
-
-@[simp]
-theorem weightChar_zero : weightChar k (0 : Fin n → ℤ) = 1 :=
-  MonoidHom.ext fun t ↦ torusCharacter_zero t
-
-/-- Weights add as characters multiply. -/
-theorem weightChar_add (l m : Fin n → ℤ) :
-    weightChar k (l + m) = weightChar k l * weightChar k m :=
-  MonoidHom.ext fun t ↦ torusCharacter_add t l m
-
-/-- The character of `Pi.single i 1` is the `i`-th coordinate: this is the weight carried by the
-`i`-th standard basis vector. -/
-@[simp]
-theorem weightChar_single (i : Fin n) (t : Fin n → kˣ) :
-    weightChar k (Pi.single i 1) t = t i := by
-  classical
-  rw [weightChar_apply, torusCharacter_def,
-    Finset.prod_eq_single i (fun j _ hj ↦ by simp [Pi.single_eq_of_ne hj])
-      (fun h ↦ absurd (Finset.mem_univ i) h),
-    Pi.single_eq_same, zpow_one]
-
-/-- The character of a constant sequence is a power of the determinant of the torus element. -/
-theorem weightChar_const (m : ℤ) (t : Fin n → kˣ) :
-    weightChar k (fun _ ↦ m) t = (∏ i, t i) ^ m := by
-  rw [weightChar_apply, torusCharacter_def, Finset.prod_zpow]
+variable {k : Type u} [CommRing k] {n : ℕ}
+variable {W : Type v} [AddCommGroup W] [Module k W]
 
 /-! ## The weight spaces of a representation -/
-
-variable {k}
-variable {W : Type v} [AddCommGroup W] [Module k W]
 
 /-- The **weight space** of weight `l : Fin n → ℤ`: the vectors that every invertible diagonal
 matrix `diagGL t` scales by `∏ i, tᵢ ^ lᵢ`. -/
@@ -152,6 +99,7 @@ def weightSpace (ρ : Representation k (GL (Fin n) k) W) (l : Fin n → ℤ) : S
   ⨅ t : Fin n → kˣ, Module.End.eigenspace (ρ (diagGL t)) ((weightChar k l t : kˣ) : k)
 
 /-- Membership in a weight space is the eigen-relation at every point of the torus. -/
+@[simp]
 theorem mem_weightSpace_iff (ρ : Representation k (GL (Fin n) k) W) (l : Fin n → ℤ) (w : W) :
     w ∈ weightSpace ρ l ↔
       ∀ t : Fin n → kˣ, ρ (diagGL t) w = ((weightChar k l t : kˣ) : k) • w := by
@@ -198,6 +146,7 @@ theorem iSup_weightSpace_stdRep :
 `m`-th power of the product of its entries. Over a commutative ring this leaves the other weight
 spaces of `det ^ m` unconstrained — over `𝔽₂` the torus is trivial, so every one of them is `⊤`
 too. -/
+@[simp]
 theorem weightSpace_detPowerRep (m : ℤ) :
     weightSpace (detPowerRep k n m) (fun _ ↦ m) = ⊤ := by
   refine top_le_iff.mp fun x _ ↦ ?_
@@ -207,67 +156,38 @@ theorem weightSpace_detPowerRep (m : ℤ) :
 
 end CommRing
 
-/-- In a field of characteristic zero the integer powers of `2` are pairwise distinct, so `2` is a
-unit of infinite order. This is the one arithmetic input to `TauCeti.weightChar_injective`. -/
-private theorem eq_of_two_zpow_eq (k : Type u) [Field k] [CharZero k] {a b : ℤ}
-    (hab : (2 : k) ^ a = (2 : k) ^ b) : a = b := by
-  have hcast : ∀ m : ℤ, (2 : k) ^ m = (((2 : ℚ) ^ m : ℚ) : k) := by
-    intro m
-    rw [Rat.cast_zpow]
-    norm_num
-  rw [hcast a, hcast b] at hab
-  exact (zpow_right_inj₀ (by norm_num) (by norm_num)).mp (Rat.cast_injective hab)
+/-! ## The weight spaces of the standard representation
 
-section Field
+Here the coefficients must separate weights, in the sense that `l ↦ weightChar k l` is injective;
+`TauCeti.weightChar_injective` supplies that over a field of characteristic zero. -/
 
-variable {k : Type u} [Field k] [CharZero k] {n : ℕ}
+section Domain
 
-/-! ## Separating weights over a field of characteristic zero -/
-
-/-- **Distinct weights give distinct characters of the torus.** Characteristic zero is what makes
-this true: over `𝔽₂` the torus is trivial and every weight gives the trivial character. -/
-theorem weightChar_injective : Function.Injective (weightChar k (n := n)) := by
-  intro l l' h
-  funext i
-  refine eq_of_two_zpow_eq k ?_
-  have hval := congrArg
-    (fun χ : (Fin n → kˣ) →* kˣ ↦
-      ((χ (Pi.mulSingle i (Units.mk0 (2 : k) two_ne_zero)) : kˣ) : k)) h
-  simpa [weightChar_apply] using hval
-
-variable {W : Type v} [AddCommGroup W] [Module k W]
-
-/-- **The weight spaces of a representation of `GL n k` are independent.** The weight spaces are
-the joint eigenspaces of the representation `t ↦ ρ (diagGL t)` of the torus indexed by the
-characters `weightChar k l`, and those are independent; over a field of characteristic zero the
-weight is recoverable from its character, so indexing by weights keeps them distinct. -/
-theorem iSupIndep_weightSpace (ρ : Representation k (GL (Fin n) k) W) :
-    iSupIndep fun l : Fin n → ℤ ↦ weightSpace ρ l :=
-  (iSupIndep_iInf_eigenspace_unitHom
-      (ρ := (ρ : GL (Fin n) k →* Module.End k W).comp diagGL)).comp weightChar_injective
-
-/-! ## The weight-space decomposition of the standard representation -/
+variable {k : Type u} [CommRing k] [IsDomain k] {n : ℕ}
 
 /-- **A nonzero coordinate pins the weight.** If a vector of weight `l` in the standard
 representation has a nonzero `j`-th coordinate then `l = Pi.single j 1`. -/
-theorem eq_single_of_mem_weightSpace_stdRep {l : Fin n → ℤ} {w : Fin n → k}
+theorem eq_single_of_mem_weightSpace_stdRep
+    (hchar : Function.Injective (weightChar k (κ := Fin n))) {l : Fin n → ℤ} {w : Fin n → k}
     (hw : w ∈ weightSpace (stdRep k n) l) {j : Fin n} (hj : w j ≠ 0) :
     l = Pi.single j 1 := by
-  refine weightChar_injective (k := k) (MonoidHom.ext fun t ↦ ?_)
+  refine hchar (MonoidHom.ext fun t ↦ ?_)
   have h := congrFun (apply_of_mem_weightSpace hw t) j
   rw [stdRep_diagGL_apply, Pi.smul_apply, smul_eq_mul] at h
   rw [weightChar_single]
   exact Units.ext (mul_right_cancel₀ hj h).symm
 
 /-- Off the weights `Pi.single i 1` the standard representation has no weight vectors. -/
-theorem weightSpace_stdRep_eq_bot {l : Fin n → ℤ} (hl : ∀ i : Fin n, l ≠ Pi.single i 1) :
+theorem weightSpace_stdRep_eq_bot (hchar : Function.Injective (weightChar k (κ := Fin n)))
+    {l : Fin n → ℤ} (hl : ∀ i : Fin n, l ≠ Pi.single i 1) :
     weightSpace (stdRep k n) l = ⊥ := by
   refine (Submodule.eq_bot_iff _).mpr fun w hw ↦ funext fun j ↦ ?_
   by_contra hj
-  exact hl j (eq_single_of_mem_weightSpace_stdRep hw hj)
+  exact hl j (eq_single_of_mem_weightSpace_stdRep hchar hw hj)
 
 /-- **The weight spaces of the standard representation are its coordinate lines.** -/
-theorem weightSpace_stdRep_single (i : Fin n) :
+theorem weightSpace_stdRep_single (hchar : Function.Injective (weightChar k (κ := Fin n)))
+    (i : Fin n) :
     weightSpace (stdRep k n) (Pi.single i 1) = Submodule.span k {Pi.basisFun k (Fin n) i} := by
   refine le_antisymm (fun w hw ↦ ?_) (span_basisFun_le_weightSpace_stdRep i)
   rw [Submodule.mem_span_singleton]
@@ -277,18 +197,36 @@ theorem weightSpace_stdRep_single (i : Fin n) :
     simp
   · have hzero : w j = 0 := by
       by_contra hj
-      have hsingle := eq_single_of_mem_weightSpace_stdRep hw hj
+      have hsingle := eq_single_of_mem_weightSpace_stdRep hchar hw hj
       have hone : (Pi.single i 1 : Fin n → ℤ) j = 1 := by rw [hsingle, Pi.single_eq_same]
       rw [Pi.single_eq_of_ne hji] at hone
       exact one_ne_zero hone.symm
     simp [hzero, Pi.basisFun_apply, hji]
 
+end Domain
+
+section Field
+
+variable {k : Type u} [Field k] {n : ℕ}
+variable {W : Type v} [AddCommGroup W] [Module k W]
+
+/-- **The weight spaces of a representation of `GL n k` are independent**, as soon as distinct
+weights give distinct characters of the torus. The weight spaces are the joint eigenspaces of the
+representation `t ↦ ρ (diagGL t)` of the torus indexed by the characters `weightChar k l`, and
+those are independent; the hypothesis makes the weight recoverable from its character, so indexing
+by weights keeps them distinct. -/
+theorem iSupIndep_weightSpace (hchar : Function.Injective (weightChar k (κ := Fin n)))
+    (ρ : Representation k (GL (Fin n) k) W) :
+    iSupIndep fun l : Fin n → ℤ ↦ weightSpace ρ l :=
+  (iSupIndep_iInf_eigenspace_unitHom
+      (ρ := (ρ : GL (Fin n) k →* Module.End k W).comp diagGL)).comp hchar
+
 /-- **The standard representation is the internal direct sum of its weight spaces**: the
 weight-space decomposition in its smallest instance. -/
-theorem isInternal_weightSpace_stdRep :
+theorem isInternal_weightSpace_stdRep (hchar : Function.Injective (weightChar k (κ := Fin n))) :
     DirectSum.IsInternal fun l : Fin n → ℤ ↦ weightSpace (stdRep k n) l :=
   (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mpr
-    ⟨iSupIndep_weightSpace _, iSup_weightSpace_stdRep⟩
+    ⟨iSupIndep_weightSpace hchar _, iSup_weightSpace_stdRep⟩
 
 end Field
 


### PR DESCRIPTION
This PR builds the weight spaces of the diagonal torus of `GL n k`, the first item of Layer 3 of the classical-groups roadmap ("The maximal torus and weight spaces" in `TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md`, whose `Suggested.lean` pins `weightSpace`). `TauCeti.weightChar k l` is the split-torus character `TauCeti.torusCharacter` of `l : Fin n → ℤ` — the product `t ↦ ∏ i, tᵢ ^ lᵢ` — repackaged as a `MonoidHom` in the torus point, with its additivity in `l`, its value on `Pi.single i 1` and on a constant sequence, and the evaluation at a torus element supported in one coordinate that recovers `l` from the character. `TauCeti.weightSpace ρ l` is then the intersection over the torus of the eigenspaces of `ρ (diagGL t)` for the eigenvalue `weightChar k l t`, with the membership criterion and the eigenspace bound. Both are stated over a commutative ring, so they apply verbatim to the `ℂ` the roadmap pins.

The content that makes weights a decomposition rather than a labelling needs the coefficients to separate characters, and the file makes that dependence explicit: over `𝔽₂` the diagonal torus is trivial (`TauCeti.diagonalTorus_eq_bot`), every weight gives the same character, and no independence can hold. Over an infinite field no nonzero exponent kills every unit — the units it kills are roots of `X ^ n - 1`, hence finitely many — so `TauCeti.weightChar_injective` holds (characteristic zero is the specialisation through `CharZero.infinite`), and `TauCeti.iSupIndep_weightSpace` follows by transporting TauCeti's `iSupIndep_iInf_eigenspace_unitHom` for the torus representation `t ↦ ρ (diagGL t)` along that injection. Specialising, `TauCeti.weightSpace_stdRep_single` and `TauCeti.weightSpace_stdRep_eq_bot` identify the weight spaces of the standard representation as exactly its coordinate lines — the line `k ∙ eᵢ` carrying the weight `Pi.single i 1`, every other weight space vanishing — and `TauCeti.isInternal_weightSpace_stdRep` assembles independence and spanning into the weight-space decomposition of `stdRep` as an internal direct sum. `TauCeti.weightSpace_detPowerRep` records that all of `det ^ m` carries the constant weight `m` (over a commutative ring this fixes only that weight space, not the others), which is the twist the rational (as opposed to polynomial) weights are built from.

One new file, `TauCeti/RepresentationTheory/ClassicalGroups/Weight.lean` (295 lines); no existing declaration is renamed, moved or deleted, and no Mathlib infrastructure is vendored. `lake build`, `lake exe axioms` (allowlist only), `lake exe module-system`, `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` and `scripts/lint-env.sh` all pass locally.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"weightspace"}-->

🤖 Prepared with Claude Code


