### PR TITLE
feat: the upper-triangular Hecke operator at a level divisible by p

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -43,7 +43,7 @@ infrastructure independent of the diamond operators.
 * `CongruenceSubgroup.Gamma1_le_Gamma1_of_dvd`, `CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd`,
   `CongruenceSubgroup.Gamma_le_Gamma_of_dvd`: all three families are antitone in the level,
   `Γ(N) ≤ Γ(M)` whenever `M ∣ N`.
-* `CongruenceSubgroup.mem_Gamma1_iff_mem_Gamma0`: `Γ₁(N)` is cut out inside `Γ₀(N)` by the
+* `CongruenceSubgroup.mem_Gamma1_iff`: `Γ₁(N)` is cut out inside `Γ₀(N)` by the
   single congruence `d ≡ 1`.
 * `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0`: a `Γ₀(N)` matrix has
   unit upper-left entry modulo `N`.
@@ -123,7 +123,7 @@ lies in `Γ₀(N)` and its lower-right entry is `1` modulo `N`; the congruence `
 `CongruenceSubgroup.Gamma1_mem` also asks for is then forced by the determinant. This is the
 form in which membership is checked whenever a construction produces a `Γ₀(N)` matrix and
 controls only its lower-right entry. -/
-theorem mem_Gamma1_iff_mem_Gamma0 {γ : SL(2, ℤ)} :
+theorem mem_Gamma1_iff {γ : SL(2, ℤ)} :
     γ ∈ Gamma1 N ↔ γ ∈ Gamma0 N ∧ ((γ 1 1 : ℤ) : ZMod N) = 1 :=
   ⟨fun h ↦ ⟨Gamma1_in_Gamma0 N h, (Gamma1_mem N γ).mp h |>.2.1⟩,
     fun ⟨h₀, h₁⟩ ↦ (Gamma1_mem N γ).mpr ((Gamma1_to_Gamma0_mem ⟨γ, h₀⟩).mp h₁)⟩
@@ -143,8 +143,8 @@ level**: the determinant identity `ad - bc = 1` with the `bc` term killed by `M 
 theorem intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 {M N : ℕ} (hMN : M ∣ N)
     {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) :
     ((γ 0 0 : ℤ) : ZMod M) * ((γ 1 1 : ℤ) : ZMod M) = 1 := by
-  have h := congrArg (Int.cast : ℤ → ZMod M)
-    (show γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 from Matrix.det_fin_two γ.1 ▸ γ.2)
+  have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := Matrix.det_fin_two γ.1 ▸ γ.2
+  have h := congrArg (Int.cast : ℤ → ZMod M) hdet
   push_cast at h
   rw [intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hMN hγ] at h
   linear_combination h

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -47,9 +47,8 @@ infrastructure independent of the diamond operators.
   single congruence `d ≡ 1`.
 * `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0`: a `Γ₀(N)` matrix has
   unit upper-left entry modulo `N`.
-* `CongruenceSubgroup.intCast_apply_one_zero_eq_zero_of_mem_Gamma0` and
-  `CongruenceSubgroup.intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0`: modulo its
-  level, a `Γ₀(N)` matrix has vanishing lower-left entry and mutually inverse diagonal entries.
+* `CongruenceSubgroup.intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0`: modulo its
+  level, a `Γ₀(N)` matrix has mutually inverse diagonal entries.
 * `CongruenceSubgroup.Gamma0_normalizes_Gamma1` and
   `CongruenceSubgroup.Gamma0_le_normalizer_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
 * `CongruenceSubgroup.Gamma1_map_le_Gamma0_map`: the inclusion `Γ₁(N) ≤ Γ₀(N)` after mapping to
@@ -127,11 +126,6 @@ theorem mem_Gamma1_iff {γ : SL(2, ℤ)} :
   ⟨fun h ↦ ⟨Gamma1_in_Gamma0 N h, (Gamma1_mem N γ).mp h |>.2.1⟩,
     fun ⟨h₀, h₁⟩ ↦ (Gamma1_mem N γ).mpr ((Gamma1_to_Gamma0_mem ⟨γ, h₀⟩).mp h₁)⟩
 
-/-- **The lower-left entry of a `Γ₀(M)` matrix vanishes modulo `M`**: `c ≡ 0 (mod M)`. -/
-theorem intCast_apply_one_zero_eq_zero_of_mem_Gamma0 {M : ℕ} {γ : SL(2, ℤ)}
-    (hγ : γ ∈ Gamma0 M) : ((γ 1 0 : ℤ) : ZMod M) = 0 :=
-  Gamma0_mem.mp hγ
-
 /-- **The diagonal entries of a `Γ₀(M)` matrix are mutually inverse modulo `M`**: the determinant
 identity `ad - bc = 1` with the `bc` term killed by `M ∣ c`. It refines
 `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0` by naming the inverse. -/
@@ -141,7 +135,7 @@ theorem intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 {M : ℕ}
   have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := Matrix.det_fin_two γ.1 ▸ γ.2
   have h := congrArg (Int.cast : ℤ → ZMod M) hdet
   push_cast at h
-  rw [intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hγ] at h
+  rw [Gamma0_mem.mp hγ] at h
   linear_combination h
 
 /-- The upper-left entry of a `Γ₀(N)` matrix is a unit modulo `N`: the determinant is one

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -48,9 +48,8 @@ infrastructure independent of the diamond operators.
 * `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0`: a `Γ₀(N)` matrix has
   unit upper-left entry modulo `N`.
 * `CongruenceSubgroup.intCast_apply_one_zero_eq_zero_of_mem_Gamma0` and
-  `CongruenceSubgroup.intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0`: modulo any
-  divisor of the level, a `Γ₀(N)` matrix has vanishing lower-left entry and mutually inverse
-  diagonal entries.
+  `CongruenceSubgroup.intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0`: modulo its
+  level, a `Γ₀(N)` matrix has vanishing lower-left entry and mutually inverse diagonal entries.
 * `CongruenceSubgroup.Gamma0_normalizes_Gamma1` and
   `CongruenceSubgroup.Gamma0_le_normalizer_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
 * `CongruenceSubgroup.Gamma1_map_le_Gamma0_map`: the inclusion `Γ₁(N) ≤ Γ₀(N)` after mapping to
@@ -128,25 +127,21 @@ theorem mem_Gamma1_iff {γ : SL(2, ℤ)} :
   ⟨fun h ↦ ⟨Gamma1_in_Gamma0 N h, (Gamma1_mem N γ).mp h |>.2.1⟩,
     fun ⟨h₀, h₁⟩ ↦ (Gamma1_mem N γ).mpr ((Gamma1_to_Gamma0_mem ⟨γ, h₀⟩).mp h₁)⟩
 
-/-- **The lower-left entry vanishes modulo any divisor of the level**: for `γ ∈ Γ₀(N)` and
-`M ∣ N`, `c ≡ 0 (mod M)`. This is `CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd` read on the
-entry rather than on the group. -/
-theorem intCast_apply_one_zero_eq_zero_of_mem_Gamma0 {M N : ℕ} (hMN : M ∣ N) {γ : SL(2, ℤ)}
-    (hγ : γ ∈ Gamma0 N) : ((γ 1 0 : ℤ) : ZMod M) = 0 := by
-  rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
-  exact (Int.natCast_dvd_natCast.mpr hMN).trans
-    ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp hγ))
+/-- **The lower-left entry of a `Γ₀(M)` matrix vanishes modulo `M`**: `c ≡ 0 (mod M)`. -/
+theorem intCast_apply_one_zero_eq_zero_of_mem_Gamma0 {M : ℕ} {γ : SL(2, ℤ)}
+    (hγ : γ ∈ Gamma0 M) : ((γ 1 0 : ℤ) : ZMod M) = 0 :=
+  Gamma0_mem.mp hγ
 
-/-- **The diagonal entries of a `Γ₀(N)` matrix are mutually inverse modulo any divisor of the
-level**: the determinant identity `ad - bc = 1` with the `bc` term killed by `M ∣ c`. It refines
+/-- **The diagonal entries of a `Γ₀(M)` matrix are mutually inverse modulo `M`**: the determinant
+identity `ad - bc = 1` with the `bc` term killed by `M ∣ c`. It refines
 `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0` by naming the inverse. -/
-theorem intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 {M N : ℕ} (hMN : M ∣ N)
-    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) :
+theorem intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 {M : ℕ}
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 M) :
     ((γ 0 0 : ℤ) : ZMod M) * ((γ 1 1 : ℤ) : ZMod M) = 1 := by
   have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := Matrix.det_fin_two γ.1 ▸ γ.2
   have h := congrArg (Int.cast : ℤ → ZMod M) hdet
   push_cast at h
-  rw [intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hMN hγ] at h
+  rw [intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hγ] at h
   linear_combination h
 
 /-- The upper-left entry of a `Γ₀(N)` matrix is a unit modulo `N`: the determinant is one

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -43,8 +43,14 @@ infrastructure independent of the diamond operators.
 * `CongruenceSubgroup.Gamma1_le_Gamma1_of_dvd`, `CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd`,
   `CongruenceSubgroup.Gamma_le_Gamma_of_dvd`: all three families are antitone in the level,
   `Γ(N) ≤ Γ(M)` whenever `M ∣ N`.
+* `CongruenceSubgroup.mem_Gamma1_iff_mem_Gamma0`: `Γ₁(N)` is cut out inside `Γ₀(N)` by the
+  single congruence `d ≡ 1`.
 * `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0`: a `Γ₀(N)` matrix has
   unit upper-left entry modulo `N`.
+* `CongruenceSubgroup.intCast_apply_one_zero_eq_zero_of_mem_Gamma0` and
+  `CongruenceSubgroup.intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0`: modulo any
+  divisor of the level, a `Γ₀(N)` matrix has vanishing lower-left entry and mutually inverse
+  diagonal entries.
 * `CongruenceSubgroup.Gamma0_normalizes_Gamma1` and
   `CongruenceSubgroup.Gamma0_le_normalizer_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
 * `CongruenceSubgroup.Gamma1_map_le_Gamma0_map`: the inclusion `Γ₁(N) ≤ Γ₀(N)` after mapping to
@@ -111,6 +117,37 @@ theorem Gamma0_le_Gamma0_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma0 N ≤ Gamma0 
   intro A hA
   rw [Gamma0_mem] at hA ⊢
   simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA
+
+/-- **`Γ₁(N)` is the fibre of `Gamma0Map` over `1`.** A matrix lies in `Γ₁(N)` exactly when it
+lies in `Γ₀(N)` and its lower-right entry is `1` modulo `N`; the congruence `a ≡ 1` that
+`CongruenceSubgroup.Gamma1_mem` also asks for is then forced by the determinant. This is the
+form in which membership is checked whenever a construction produces a `Γ₀(N)` matrix and
+controls only its lower-right entry. -/
+theorem mem_Gamma1_iff_mem_Gamma0 {γ : SL(2, ℤ)} :
+    γ ∈ Gamma1 N ↔ γ ∈ Gamma0 N ∧ ((γ 1 1 : ℤ) : ZMod N) = 1 :=
+  ⟨fun h ↦ ⟨Gamma1_in_Gamma0 N h, (Gamma1_mem N γ).mp h |>.2.1⟩,
+    fun ⟨h₀, h₁⟩ ↦ (Gamma1_mem N γ).mpr ((Gamma1_to_Gamma0_mem ⟨γ, h₀⟩).mp h₁)⟩
+
+/-- **The lower-left entry vanishes modulo any divisor of the level**: for `γ ∈ Γ₀(N)` and
+`M ∣ N`, `c ≡ 0 (mod M)`. This is `CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd` read on the
+entry rather than on the group. -/
+theorem intCast_apply_one_zero_eq_zero_of_mem_Gamma0 {M N : ℕ} (hMN : M ∣ N) {γ : SL(2, ℤ)}
+    (hγ : γ ∈ Gamma0 N) : ((γ 1 0 : ℤ) : ZMod M) = 0 := by
+  rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
+  exact (Int.natCast_dvd_natCast.mpr hMN).trans
+    ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp hγ))
+
+/-- **The diagonal entries of a `Γ₀(N)` matrix are mutually inverse modulo any divisor of the
+level**: the determinant identity `ad - bc = 1` with the `bc` term killed by `M ∣ c`. It refines
+`CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0` by naming the inverse. -/
+theorem intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 {M N : ℕ} (hMN : M ∣ N)
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) :
+    ((γ 0 0 : ℤ) : ZMod M) * ((γ 1 1 : ℤ) : ZMod M) = 1 := by
+  have h := congrArg (Int.cast : ℤ → ZMod M)
+    (show γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 from Matrix.det_fin_two γ.1 ▸ γ.2)
+  push_cast at h
+  rw [intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hMN hγ] at h
+  linear_combination h
 
 /-- The upper-left entry of a `Γ₀(N)` matrix is a unit modulo `N`: the determinant is one
 and the lower-left entry vanishes modulo `N`, so `ad ≡ 1`. -/

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
@@ -47,7 +47,7 @@ alone is *not* invariant.
 
 ## Main definitions
 
-* `HeckeRing.GL2.upperTriShift`: the offset permutation `j ↦ d b + j d² mod p`.
+* `HeckeRing.GL2.upperTriShift`: the offset map `j ↦ d b + j d² mod p`.
 
 ## Main results
 
@@ -88,13 +88,12 @@ def upperTriShift (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) : Fin p :=
       = ((γ 1 1 * γ 0 1 + (j : ℕ) * (γ 1 1 * γ 1 1) : ℤ) : ZMod p) :=
   ZMod.natCast_rightInverse _
 
-/-- **The offset map is a bijection.** Under the stated hypotheses, `d` is the inverse of `a`
-modulo `p`, so the map gives the unique solution in `[0, p)` of `a j' ≡ b + j d (mod p)`.
+/-- **The offset map is a bijection.** For `γ ∈ Γ₀(p)`, `d` is the inverse of `a` modulo `p`,
+so the map gives the unique solution in `[0, p)` of `a j' ≡ b + j d (mod p)`.
 Two offsets with the same shift differ by an element killed by the unit `d²`. -/
-lemma upperTriShift_bijective [NeZero p] (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) :
+lemma upperTriShift_bijective [NeZero p] {γ : SL(2, ℤ)} (hγp : γ ∈ Gamma0 p) :
     Function.Bijective (upperTriShift p γ) := by
   refine Finite.injective_iff_bijective.mp fun j j' hjj ↦ ?_
-  have hγp : γ ∈ Gamma0 p := Gamma0_le_Gamma0_of_dvd hpN hγ
   have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hγp
   have h := congrArg (fun m : Fin p ↦ ((m : ℕ) : ZMod p)) hjj
   simp only [upperTriShift_natCast] at h
@@ -187,7 +186,8 @@ theorem heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 (k : ℤ) [NeZero p] (hpN :
     rw [← SlashAction.slash_mul, hmul, SlashAction.slash_mul, hf γ' hγ' hdd,
       ModularForm.rat_smul_slash_of_det_pos k (det_upperTriRep_pos p _) f u]
   rw [Finset.sum_congr rfl fun j _ ↦ key j]
-  exact Fintype.sum_bijective (upperTriShift p γ) (upperTriShift_bijective hpN hγ)
+  exact Fintype.sum_bijective (upperTriShift p γ)
+    (upperTriShift_bijective (Gamma0_le_Gamma0_of_dvd hpN hγ))
     (fun j ↦ u • (f ∣[k] (upperTriRep p (upperTriShift p γ j) : GL (Fin 2) ℚ)))
     (fun j ↦ u • (f ∣[k] (upperTriRep p j : GL (Fin 2) ℚ))) fun _ ↦ rfl
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.Sum
+
+/-!
+# The upper-triangular Hecke sum is `Γ₀(N)`-equivariant when `p ∣ N`
+
+`UpperTri/Sum.lean` defines `heckeSlashUpperTri k p f = ∑_{b < p} f ∣[k] !![1, b; 0, p]`, and
+`UpperTri/Periodic.lean` shows it preserves invariance under the single matrix `T`. That is far
+short of an operator: to act on `M_k(Γ₁(N))` the sum has to preserve invariance under the whole
+group. This file proves that it does, **provided `p` divides the level** — the case in which the
+`p` representatives above are already a full left-coset decomposition of the double coset, so no
+further representative is needed.
+
+## The permutation
+
+Write `γ = !![a, b; c, d] ∈ Γ₀(N)`, so `N ∣ c` and hence `p ∣ c`. Then
+
+`!![1, j; 0, p] · γ = !![a + jc, b + jd; pc, pd]`,
+
+and one asks for a factorisation `γ' · !![1, j'; 0, p]` with `γ' ∈ Γ₀(N)`. Matching entries forces
+`γ' = !![a + jc, b'; pc, d - cj']` and `p b' = b + jd - (a + jc) j'`, so `j'` must solve
+`a j' ≡ b + jd (mod p)`. Because `p ∣ c`, the determinant identity `ad - bc = 1` reduces to
+`ad ≡ 1 (mod p)`: `a` is invertible modulo `p`, with inverse `d`, and the unique solution in
+`[0, p)` is
+
+`j' = d b + j d² mod p`,
+
+which is `upperTriShift p γ`. It is a bijection of `Fin p` because `d²` is again invertible
+modulo `p`. Slashing therefore permutes the summands, and the sum is unchanged up to the scalar
+by which `γ'` acts on `f`.
+
+Two facts make that scalar behave. The new lower-right entry is `d - c j' ≡ d (mod N)`, so `γ'`
+has the *same* `Gamma0Map` value as `γ`; and if `γ ∈ Γ₁(N)` then `γ' ∈ Γ₁(N)`. So the hypothesis
+on `f` is only ever used at matrices congruent to `γ` in the relevant sense, which is what lets
+the nebentypus version below carry a fixed character.
+
+⚠ `p ∣ N` is essential, not a convenience. At `p ∤ N` the double coset has one further left
+coset, represented by `!![p, 0; 0, 1]` up to a `Γ₀(N)` twist, and the sum over the upper-triangular
+representatives alone is *not* invariant.
+
+## Main definitions
+
+* `HeckeRing.GL2.upperTriShift`: the offset permutation `j ↦ d b + j d² mod p`.
+
+## Main results
+
+* `HeckeRing.GL2.upperTriShift_bijective`: it is a bijection of `Fin p`.
+* `HeckeRing.GL2.exists_mem_Gamma0_upperTriRep_mul`: the factorisation
+  `!![1, j; 0, p] · γ = γ' · !![1, j'; 0, p]` with `γ' ∈ Γ₀(N)` of the same `Gamma0Map` value.
+* `HeckeRing.GL2.heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0`: the equivariance, stated with an
+  arbitrary scalar so that both corollaries below are instances of it.
+* `HeckeRing.GL2.heckeSlashUpperTri_slash_mapGL_of_mem_Gamma1`: the sum of a `Γ₁(N)`-invariant
+  function is `Γ₁(N)`-invariant.
+* `HeckeRing.GL2.heckeSlashUpperTri_slash_mapGL_of_nebentypus`: the sum of a function with
+  nebentypus `χ` has nebentypus `χ`.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.2.
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.5.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane HeckeRing.GLn CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm
+
+namespace HeckeRing.GL2
+
+variable {N p : ℕ}
+
+/-- **The offset permutation attached to `γ ∈ Γ₀(N)`**, `j ↦ d b + j d² mod p`, where
+`γ = !![a, b; c, d]`. It is the unique solution in `[0, p)` of `a j' ≡ b + j d (mod p)`, written
+using the inverse `d` of `a` modulo `p` so that no inversion appears in the definition. -/
+def upperTriShift (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) : Fin p :=
+  ⟨((γ 1 1 * γ 0 1 + (j : ℕ) * (γ 1 1 * γ 1 1) : ℤ) : ZMod p).val, ZMod.val_lt _⟩
+
+/-- The defining congruence of `upperTriShift`, in `ZMod p`. -/
+lemma upperTriShift_intCast (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) :
+    (((upperTriShift p γ j : ℕ) : ℤ) : ZMod p)
+      = ((γ 1 1 * γ 0 1 + (j : ℕ) * (γ 1 1 * γ 1 1) : ℤ) : ZMod p) := by
+  rw [Int.cast_natCast]
+  exact ZMod.natCast_rightInverse _
+
+/-- **The offset permutation is a bijection.** Two offsets with the same shift differ by an
+element killed by `d²`, which is invertible modulo `p`. -/
+lemma upperTriShift_bijective [NeZero p] (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) :
+    Function.Bijective (upperTriShift p γ) := by
+  refine Finite.injective_iff_bijective.mp fun j j' hjj ↦ ?_
+  have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hpN hγ
+  have h := congrArg (fun m : Fin p ↦ (((m : ℕ) : ℤ) : ZMod p)) hjj
+  simp only [upperTriShift_intCast] at h
+  push_cast at h
+  have hud : IsUnit ((γ 1 1 : ℤ) : ZMod p) :=
+    IsUnit.of_mul_eq_one _ (show ((γ 1 1 : ℤ) : ZMod p) * ((γ 0 0 : ℤ) : ZMod p) = 1 by
+      linear_combination had)
+  have hcancel : ((j : ℕ) : ZMod p) = ((j' : ℕ) : ZMod p) :=
+    (hud.mul hud).mul_left_inj.mp (by linear_combination h)
+  exact Fin.val_injective (by
+    simpa [ZMod.val_natCast_of_lt j.isLt, ZMod.val_natCast_of_lt j'.isLt] using
+      congrArg ZMod.val hcancel)
+
+/-- The matrix identity behind the coset factorisation, with the four entries of the second
+factor given by hypothesis. Stated separately so that the computation runs on atoms: the
+entries of `γ` and `γ'` never have to be unfolded inside it. -/
+private lemma upperTriRep_mul_mapGL_eq {p : ℕ} (j j' : Fin p) (γ γ' : SL(2, ℤ))
+    (h00 : γ' 0 0 = γ 0 0 + (j : ℕ) * γ 1 0)
+    (h01 : (p : ℤ) * γ' 0 1
+      = γ 0 1 + (j : ℕ) * γ 1 1 - (γ 0 0 + (j : ℕ) * γ 1 0) * (j' : ℕ))
+    (h10 : γ' 1 0 = (p : ℤ) * γ 1 0)
+    (h11 : γ' 1 1 = γ 1 1 - γ 1 0 * (j' : ℕ)) :
+    upperTriRep p j * mapGL ℚ γ = mapGL ℚ γ' * upperTriRep p j' := by
+  have c00 := congrArg (Int.cast : ℤ → ℚ) h00
+  have c01 := congrArg (Int.cast : ℤ → ℚ) h01
+  have c10 := congrArg (Int.cast : ℤ → ℚ) h10
+  have c11 := congrArg (Int.cast : ℤ → ℚ) h11
+  push_cast at c00 c01 c10 c11
+  refine Units.ext (Matrix.ext fun r t ↦ ?_)
+  rw [Units.val_mul, Units.val_mul, Matrix.mul_apply, Matrix.mul_apply, Fin.sum_univ_two,
+    Fin.sum_univ_two, coe_upperTriRep, coe_upperTriRep, mapGL_coe_matrix, mapGL_coe_matrix]
+  fin_cases r <;> fin_cases t <;> simp only [Fin.zero_eta, Fin.mk_one, Fin.isValue,
+      Matrix.of_apply, Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_fin_one,
+      Matrix.cons_val_one, algebraMap_int_eq, Matrix.SpecialLinearGroup.map_apply_coe,
+      RingHom.mapMatrix_apply, Int.coe_castRingHom, Matrix.map_apply, one_mul, mul_one, mul_zero,
+      add_zero, zero_mul, zero_add] <;>
+    [linear_combination -c00; linear_combination -c01 - ((j' : ℕ) : ℚ) * c00;
+      linear_combination -c10; linear_combination -((j' : ℕ) : ℚ) * c10 - (p : ℚ) * c11]
+
+/-- **The coset factorisation.** For `p ∣ N` and `γ ∈ Γ₀(N)`, the product
+`!![1, j; 0, p] · γ` factors as `γ' · !![1, j'; 0, p]` with `γ' ∈ Γ₀(N)` and `j'` the shifted
+offset. The new lower-right entry is congruent to the old one modulo `N`, so `γ'` has the same
+`Gamma0Map` value as `γ`: this is what makes the equivariance below carry a fixed character. -/
+theorem exists_mem_Gamma0_upperTriRep_mul [NeZero p] (hpN : p ∣ N) {γ : SL(2, ℤ)}
+    (hγ : γ ∈ Gamma0 N) (j : Fin p) :
+    ∃ γ' : SL(2, ℤ), γ' ∈ Gamma0 N ∧ ((γ' 1 1 : ℤ) : ZMod N) = ((γ 1 1 : ℤ) : ZMod N) ∧
+      upperTriRep p j * mapGL ℚ γ = mapGL ℚ γ' * upperTriRep p (upperTriShift p γ j) := by
+  have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := Matrix.det_fin_two γ.1 ▸ γ.2
+  have hcN : ((γ 1 0 : ℤ) : ZMod N) = 0 := Gamma0_mem.mp hγ
+  have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hpN hγ
+  -- the entry `b'` is an integer: the congruence `a j' ≡ b + j d (mod p)` is exactly `p ∣ …`
+  have hdvd : (p : ℤ) ∣ γ 0 1 + (j : ℕ) * γ 1 1
+      - (γ 0 0 + (j : ℕ) * γ 1 0) * ((upperTriShift p γ j : ℕ) : ℤ) := by
+    rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
+    push_cast
+    rw [← Int.cast_natCast ((upperTriShift p γ j : ℕ)), upperTriShift_intCast,
+      intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hpN hγ]
+    push_cast
+    linear_combination (-((γ 0 1 : ℤ) : ZMod p)
+      - ((j : ℕ) : ZMod p) * ((γ 1 1 : ℤ) : ZMod p)) * had
+  obtain ⟨b', hb'⟩ := hdvd
+  have hdet' : (!![γ 0 0 + (j : ℕ) * γ 1 0, b';
+      (p : ℤ) * γ 1 0, γ 1 1 - γ 1 0 * ((upperTriShift p γ j : ℕ) : ℤ)]).det = 1 := by
+    rw [Matrix.det_fin_two_of]
+    linear_combination hdet + (γ 1 0 : ℤ) * hb'
+  refine ⟨⟨_, hdet'⟩, Gamma0_mem.mpr ?_, ?_,
+    upperTriRep_mul_mapGL_eq _ _ _ _ rfl hb'.symm rfl rfl⟩
+  · change (((p : ℤ) * γ 1 0 : ℤ) : ZMod N) = 0
+    rw [Int.cast_mul, hcN, mul_zero]
+  · change (((γ 1 1 - γ 1 0 * ((upperTriShift p γ j : ℕ) : ℤ) : ℤ)) : ZMod N) = _
+    push_cast
+    rw [hcN]
+    ring
+
+/-- **The upper-triangular sum is `Γ₀(N)`-equivariant at `p ∣ N`.** The hypothesis is imposed
+only at matrices of `Γ₀(N)` with the same lower-right entry modulo `N` as `γ`, which is all the
+factorisation ever produces; the scalar `u` is left free so that the two corollaries below —
+`Γ₁(N)`-invariance and nebentypus transport — are both instances. -/
+theorem heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 (k : ℤ) [NeZero N] (hpN : p ∣ N)
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) {f : ℍ → ℂ} {u : ℂ}
+    (hf : ∀ δ ∈ Gamma0 N, ((δ 1 1 : ℤ) : ZMod N) = ((γ 1 1 : ℤ) : ZMod N) →
+      f ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = u • f) :
+    heckeSlashUpperTri k p f ∣[k] (mapGL ℚ γ : GL (Fin 2) ℚ)
+      = u • heckeSlashUpperTri k p f := by
+  have : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
+  rw [heckeSlashUpperTri_def, SlashAction.sum_slash, Finset.smul_sum]
+  have key : ∀ j : Fin p,
+      (f ∣[k] (upperTriRep p j : GL (Fin 2) ℚ)) ∣[k] (mapGL ℚ γ : GL (Fin 2) ℚ)
+        = u • (f ∣[k] (upperTriRep p (upperTriShift p γ j) : GL (Fin 2) ℚ)) := fun j ↦ by
+    obtain ⟨γ', hγ', hdd, hmul⟩ := exists_mem_Gamma0_upperTriRep_mul hpN hγ j
+    rw [← SlashAction.slash_mul, hmul, SlashAction.slash_mul, hf γ' hγ' hdd,
+      ModularForm.rat_smul_slash_of_det_pos k (det_upperTriRep_pos p _) f u]
+  rw [Finset.sum_congr rfl fun j _ ↦ key j]
+  exact Fintype.sum_bijective (upperTriShift p γ) (upperTriShift_bijective hpN hγ)
+    (fun j ↦ u • (f ∣[k] (upperTriRep p (upperTriShift p γ j) : GL (Fin 2) ℚ)))
+    (fun j ↦ u • (f ∣[k] (upperTriRep p j : GL (Fin 2) ℚ))) fun _ ↦ rfl
+
+/-- **The upper-triangular sum preserves `Γ₁(N)`-invariance at `p ∣ N`** — the invariance that
+turns it into an operator on `M_k(Γ₁(N))`. -/
+theorem heckeSlashUpperTri_slash_mapGL_of_mem_Gamma1 (k : ℤ) [NeZero N] (hpN : p ∣ N)
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma1 N) {f : ℍ → ℂ}
+    (hf : ∀ δ ∈ Gamma1 N, f ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = f) :
+    heckeSlashUpperTri k p f ∣[k] (mapGL ℚ γ : GL (Fin 2) ℚ) = heckeSlashUpperTri k p f := by
+  have h11 : ((γ 1 1 : ℤ) : ZMod N) = 1 := (mem_Gamma1_iff_mem_Gamma0.mp hγ).2
+  have h := heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 (u := 1) k hpN
+    (Gamma1_in_Gamma0 N hγ) (f := f) fun δ hδ hd ↦ by
+      rw [hf δ (mem_Gamma1_iff_mem_Gamma0.mpr ⟨hδ, hd.trans h11⟩), one_smul]
+  rwa [one_smul] at h
+
+/-- **The upper-triangular sum preserves the nebentypus at `p ∣ N`**: if `f` transforms under
+`Γ₀(N)` by the character `χ`, so does `heckeSlashUpperTri k p f`. This is the function-level
+statement behind the fact that the operator preserves `M_k(N, χ)`. -/
+theorem heckeSlashUpperTri_slash_mapGL_of_nebentypus (k : ℤ) [NeZero N] (hpN : p ∣ N)
+    (χ : (ZMod N)ˣ →* ℂˣ) (γ : ↥(Gamma0 N)) {f : ℍ → ℂ}
+    (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℚ (δ : SL(2, ℤ)) : GL (Fin 2) ℚ)
+      = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :
+    heckeSlashUpperTri k p f ∣[k] (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)
+      = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) • heckeSlashUpperTri k p f :=
+  heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 k hpN γ.2 fun δ hδ hd ↦ by
+    rw [hf ⟨δ, hδ⟩,
+      show ((Gamma0Map N).toHomUnits ⟨δ, hδ⟩) = (Gamma0Map N).toHomUnits γ from Units.ext hd]
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
@@ -94,7 +94,8 @@ Two offsets with the same shift differ by an element killed by the unit `d²`. -
 lemma upperTriShift_bijective [NeZero p] (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) :
     Function.Bijective (upperTriShift p γ) := by
   refine Finite.injective_iff_bijective.mp fun j j' hjj ↦ ?_
-  have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hpN hγ
+  have hγp : γ ∈ Gamma0 p := Gamma0_le_Gamma0_of_dvd hpN hγ
+  have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hγp
   have h := congrArg (fun m : Fin p ↦ ((m : ℕ) : ZMod p)) hjj
   simp only [upperTriShift_natCast] at h
   push_cast at h
@@ -142,13 +143,14 @@ theorem exists_mem_Gamma0_upperTriRep_mul [NeZero p] (hpN : p ∣ N) {γ : SL(2,
       upperTriRep p j * mapGL ℚ γ = mapGL ℚ γ' * upperTriRep p (upperTriShift p γ j) := by
   have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := Matrix.det_fin_two γ.1 ▸ γ.2
   have hcN : ((γ 1 0 : ℤ) : ZMod N) = 0 := Gamma0_mem.mp hγ
-  have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hpN hγ
+  have hγp : γ ∈ Gamma0 p := Gamma0_le_Gamma0_of_dvd hpN hγ
+  have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hγp
   -- the entry `b'` is an integer: the congruence `a j' ≡ b + j d (mod p)` is exactly `p ∣ …`
   have hdvd : (p : ℤ) ∣ γ 0 1 + (j : ℕ) * γ 1 1
       - (γ 0 0 + (j : ℕ) * γ 1 0) * ((upperTriShift p γ j : ℕ) : ℤ) := by
     rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
     push_cast
-    rw [upperTriShift_natCast, intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hpN hγ]
+    rw [upperTriShift_natCast, intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hγp]
     push_cast
     linear_combination (-((γ 0 1 : ℤ) : ZMod p)
       - ((j : ℕ) : ZMod p) * ((γ 1 1 : ℤ) : ZMod p)) * had
@@ -209,10 +211,11 @@ theorem heckeSlashUpperTri_slash_mapGL_of_nebentypus (k : ℤ) [NeZero p] (hpN :
     (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℚ (δ : SL(2, ℤ)) : GL (Fin 2) ℚ)
       = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :
     heckeSlashUpperTri k p f ∣[k] (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)
-      = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) • heckeSlashUpperTri k p f :=
-  heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 k hpN γ.2 fun δ hδ hd ↦ by
-    rw [hf ⟨δ, hδ⟩,
-      show ((Gamma0Map N).toHomUnits ⟨δ, hδ⟩) = (Gamma0Map N).toHomUnits γ from Units.ext hd]
+      = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) • heckeSlashUpperTri k p f := by
+  apply heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 k hpN γ.2
+  intro δ hδ hd
+  have hmap : (Gamma0Map N).toHomUnits ⟨δ, hδ⟩ = (Gamma0Map N).toHomUnits γ := Units.ext hd
+  rw [hf ⟨δ, hδ⟩, hmap]
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
@@ -15,8 +15,7 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.Sum
 `UpperTri/Periodic.lean` shows it preserves invariance under the single matrix `T`. That is far
 short of an operator: to act on `M_k(Γ₁(N))` the sum has to preserve invariance under the whole
 group. This file proves that it does, **provided `p` divides the level** — the case in which the
-`p` representatives above are already a full left-coset decomposition of the double coset, so no
-further representative is needed.
+factorisation below closes on the `p` upper-triangular representatives.
 
 ## The permutation
 
@@ -41,9 +40,10 @@ has the *same* `Gamma0Map` value as `γ`; and if `γ ∈ Γ₁(N)` then `γ' ∈
 on `f` is only ever used at matrices congruent to `γ` in the relevant sense, which is what lets
 the nebentypus version below carry a fixed character.
 
-⚠ `p ∣ N` is essential, not a convenience. At `p ∤ N` the double coset has one further left
-coset, represented by `!![p, 0; 0, 1]` up to a `Γ₀(N)` twist, and the sum over the upper-triangular
-representatives alone is *not* invariant.
+⚠ `p ∣ N` is essential to the equivariance proved here, not a convenience. When `p` is prime and
+`p ∤ N`, the classical double coset has one further left coset, represented by
+`!![p, 0; 0, 1]` up to a `Γ₀(N)` twist, and the sum over the upper-triangular representatives
+alone is *not* invariant.
 
 ## Main definitions
 
@@ -78,21 +78,20 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ}
 
-/-- **The offset permutation attached to `γ ∈ Γ₀(N)`**, `j ↦ d b + j d² mod p`, where
-`γ = !![a, b; c, d]`. It is the unique solution in `[0, p)` of `a j' ≡ b + j d (mod p)`, written
-using the inverse `d` of `a` modulo `p` so that no inversion appears in the definition. -/
+/-- **The offset map**, `j ↦ d b + j d² mod p`, where `γ = !![a, b; c, d]`. -/
 def upperTriShift (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) : Fin p :=
   ⟨((γ 1 1 * γ 0 1 + (j : ℕ) * (γ 1 1 * γ 1 1) : ℤ) : ZMod p).val, ZMod.val_lt _⟩
 
 /-- The defining congruence of `upperTriShift`, in `ZMod p`. -/
-lemma upperTriShift_intCast (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) :
+@[simp] lemma upperTriShift_intCast (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) :
     (((upperTriShift p γ j : ℕ) : ℤ) : ZMod p)
       = ((γ 1 1 * γ 0 1 + (j : ℕ) * (γ 1 1 * γ 1 1) : ℤ) : ZMod p) := by
   rw [Int.cast_natCast]
   exact ZMod.natCast_rightInverse _
 
-/-- **The offset permutation is a bijection.** Two offsets with the same shift differ by an
-element killed by `d²`, which is invertible modulo `p`. -/
+/-- **The offset map is a bijection.** Under the stated hypotheses, `d` is the inverse of `a`
+modulo `p`, so the map gives the unique solution in `[0, p)` of `a j' ≡ b + j d (mod p)`.
+Two offsets with the same shift differ by an element killed by the unit `d²`. -/
 lemma upperTriShift_bijective [NeZero p] (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) :
     Function.Bijective (upperTriShift p γ) := by
   refine Finite.injective_iff_bijective.mp fun j j' hjj ↦ ?_
@@ -101,8 +100,7 @@ lemma upperTriShift_bijective [NeZero p] (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ 
   simp only [upperTriShift_intCast] at h
   push_cast at h
   have hud : IsUnit ((γ 1 1 : ℤ) : ZMod p) :=
-    IsUnit.of_mul_eq_one _ (show ((γ 1 1 : ℤ) : ZMod p) * ((γ 0 0 : ℤ) : ZMod p) = 1 by
-      linear_combination had)
+    IsUnit.of_mul_eq_one _ (by simpa [mul_comm] using had)
   have hcancel : ((j : ℕ) : ZMod p) = ((j' : ℕ) : ZMod p) :=
     (hud.mul hud).mul_left_inj.mp (by linear_combination h)
   exact Fin.val_injective (by
@@ -163,6 +161,7 @@ theorem exists_mem_Gamma0_upperTriRep_mul [NeZero p] (hpN : p ∣ N) {γ : SL(2,
     linear_combination hdet + (γ 1 0 : ℤ) * hb'
   refine ⟨⟨_, hdet'⟩, Gamma0_mem.mpr ?_, ?_,
     upperTriRep_mul_mapGL_eq _ _ _ _ rfl hb'.symm rfl rfl⟩
+  -- Unfold the two relevant projections of the explicitly displayed `SL(2, ℤ)` witness.
   · change (((p : ℤ) * γ 1 0 : ℤ) : ZMod N) = 0
     rw [Int.cast_mul, hcN, mul_zero]
   · change (((γ 1 1 - γ 1 0 * ((upperTriShift p γ j : ℕ) : ℤ) : ℤ)) : ZMod N) = _
@@ -174,13 +173,12 @@ theorem exists_mem_Gamma0_upperTriRep_mul [NeZero p] (hpN : p ∣ N) {γ : SL(2,
 only at matrices of `Γ₀(N)` with the same lower-right entry modulo `N` as `γ`, which is all the
 factorisation ever produces; the scalar `u` is left free so that the two corollaries below —
 `Γ₁(N)`-invariance and nebentypus transport — are both instances. -/
-theorem heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 (k : ℤ) [NeZero N] (hpN : p ∣ N)
+theorem heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 (k : ℤ) [NeZero p] (hpN : p ∣ N)
     {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 N) {f : ℍ → ℂ} {u : ℂ}
     (hf : ∀ δ ∈ Gamma0 N, ((δ 1 1 : ℤ) : ZMod N) = ((γ 1 1 : ℤ) : ZMod N) →
       f ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = u • f) :
     heckeSlashUpperTri k p f ∣[k] (mapGL ℚ γ : GL (Fin 2) ℚ)
       = u • heckeSlashUpperTri k p f := by
-  have : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
   rw [heckeSlashUpperTri_def, SlashAction.sum_slash, Finset.smul_sum]
   have key : ∀ j : Fin p,
       (f ∣[k] (upperTriRep p j : GL (Fin 2) ℚ)) ∣[k] (mapGL ℚ γ : GL (Fin 2) ℚ)
@@ -195,20 +193,20 @@ theorem heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 (k : ℤ) [NeZero N] (hpN :
 
 /-- **The upper-triangular sum preserves `Γ₁(N)`-invariance at `p ∣ N`** — the invariance that
 turns it into an operator on `M_k(Γ₁(N))`. -/
-theorem heckeSlashUpperTri_slash_mapGL_of_mem_Gamma1 (k : ℤ) [NeZero N] (hpN : p ∣ N)
+theorem heckeSlashUpperTri_slash_mapGL_of_mem_Gamma1 (k : ℤ) [NeZero p] (hpN : p ∣ N)
     {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma1 N) {f : ℍ → ℂ}
     (hf : ∀ δ ∈ Gamma1 N, f ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = f) :
     heckeSlashUpperTri k p f ∣[k] (mapGL ℚ γ : GL (Fin 2) ℚ) = heckeSlashUpperTri k p f := by
-  have h11 : ((γ 1 1 : ℤ) : ZMod N) = 1 := (mem_Gamma1_iff_mem_Gamma0.mp hγ).2
+  have h11 : ((γ 1 1 : ℤ) : ZMod N) = 1 := (mem_Gamma1_iff.mp hγ).2
   have h := heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0 (u := 1) k hpN
     (Gamma1_in_Gamma0 N hγ) (f := f) fun δ hδ hd ↦ by
-      rw [hf δ (mem_Gamma1_iff_mem_Gamma0.mpr ⟨hδ, hd.trans h11⟩), one_smul]
+      rw [hf δ (mem_Gamma1_iff.mpr ⟨hδ, hd.trans h11⟩), one_smul]
   rwa [one_smul] at h
 
 /-- **The upper-triangular sum preserves the nebentypus at `p ∣ N`**: if `f` transforms under
 `Γ₀(N)` by the character `χ`, so does `heckeSlashUpperTri k p f`. This is the function-level
 statement behind the fact that the operator preserves `M_k(N, χ)`. -/
-theorem heckeSlashUpperTri_slash_mapGL_of_nebentypus (k : ℤ) [NeZero N] (hpN : p ∣ N)
+theorem heckeSlashUpperTri_slash_mapGL_of_nebentypus (k : ℤ) [NeZero p] (hpN : p ∣ N)
     (χ : (ZMod N)ˣ →* ℂˣ) (γ : ↥(Gamma0 N)) {f : ℍ → ℂ}
     (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℚ (δ : SL(2, ℤ)) : GL (Fin 2) ℚ)
       = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
@@ -83,11 +83,10 @@ def upperTriShift (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) : Fin p :=
   ⟨((γ 1 1 * γ 0 1 + (j : ℕ) * (γ 1 1 * γ 1 1) : ℤ) : ZMod p).val, ZMod.val_lt _⟩
 
 /-- The defining congruence of `upperTriShift`, in `ZMod p`. -/
-@[simp] lemma upperTriShift_intCast (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) :
-    (((upperTriShift p γ j : ℕ) : ℤ) : ZMod p)
-      = ((γ 1 1 * γ 0 1 + (j : ℕ) * (γ 1 1 * γ 1 1) : ℤ) : ZMod p) := by
-  rw [Int.cast_natCast]
-  exact ZMod.natCast_rightInverse _
+@[simp] lemma upperTriShift_natCast (p : ℕ) [NeZero p] (γ : SL(2, ℤ)) (j : Fin p) :
+    ((upperTriShift p γ j : ℕ) : ZMod p)
+      = ((γ 1 1 * γ 0 1 + (j : ℕ) * (γ 1 1 * γ 1 1) : ℤ) : ZMod p) :=
+  ZMod.natCast_rightInverse _
 
 /-- **The offset map is a bijection.** Under the stated hypotheses, `d` is the inverse of `a`
 modulo `p`, so the map gives the unique solution in `[0, p)` of `a j' ≡ b + j d (mod p)`.
@@ -96,8 +95,8 @@ lemma upperTriShift_bijective [NeZero p] (hpN : p ∣ N) {γ : SL(2, ℤ)} (hγ 
     Function.Bijective (upperTriShift p γ) := by
   refine Finite.injective_iff_bijective.mp fun j j' hjj ↦ ?_
   have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hpN hγ
-  have h := congrArg (fun m : Fin p ↦ (((m : ℕ) : ℤ) : ZMod p)) hjj
-  simp only [upperTriShift_intCast] at h
+  have h := congrArg (fun m : Fin p ↦ ((m : ℕ) : ZMod p)) hjj
+  simp only [upperTriShift_natCast] at h
   push_cast at h
   have hud : IsUnit ((γ 1 1 : ℤ) : ZMod p) :=
     IsUnit.of_mul_eq_one _ (by simpa [mul_comm] using had)
@@ -149,8 +148,7 @@ theorem exists_mem_Gamma0_upperTriRep_mul [NeZero p] (hpN : p ∣ N) {γ : SL(2,
       - (γ 0 0 + (j : ℕ) * γ 1 0) * ((upperTriShift p γ j : ℕ) : ℤ) := by
     rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
     push_cast
-    rw [← Int.cast_natCast ((upperTriShift p γ j : ℕ)), upperTriShift_intCast,
-      intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hpN hγ]
+    rw [upperTriShift_natCast, intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hpN hγ]
     push_cast
     linear_combination (-((γ 0 1 : ℤ) : ZMod p)
       - ((j : ℕ) : ZMod p) * ((γ 1 1 : ℤ) : ZMod p)) * had

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
@@ -150,7 +150,7 @@ theorem exists_mem_Gamma0_upperTriRep_mul [NeZero p] (hpN : p ∣ N) {γ : SL(2,
       - (γ 0 0 + (j : ℕ) * γ 1 0) * ((upperTriShift p γ j : ℕ) : ℤ) := by
     rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
     push_cast
-    rw [upperTriShift_natCast, intCast_apply_one_zero_eq_zero_of_mem_Gamma0 hγp]
+    rw [upperTriShift_natCast, Gamma0_mem.mp hγp]
     push_cast
     linear_combination (-((γ 0 1 : ℤ) : ZMod p)
       - ((j : ℕ) : ZMod p) * ((γ 1 1 : ℤ) : ZMod p)) * had

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
@@ -22,10 +22,11 @@ and of `CuspForm ((Gamma1 N).map (mapGL ℝ)) k`, and records the two facts that
 it preserves each nebentypus space `M_k(N, χ)`, `S_k(N, χ)`, and on `q`-expansions it is
 `aₘ ↦ a_{p m}`.
 
-This is Layer 2(b) of the ModularForms roadmap at a level divisible by `p`. The classical `Tₚ`
-for `p ∤ N` needs one further coset representative and is not built here; at `p ∣ N` the classical
-`Tₚ` *is* this operator, which is why the recurrence below carries no `χ(p) p^{k-1}` term.
-Following Miyake, Diamond–Shurman and Shimura, no separate `Uₚ` is introduced.
+This is Layer 2(b) of the ModularForms roadmap at a level divisible by `p`. When `p` is prime,
+the classical `Tₚ` for `p ∤ N` needs one further coset representative and is not built here;
+at `p ∣ N` the classical `Tₚ` *is* this operator, which is why the corresponding prime Hecke
+recurrence carries no `χ(p) p^{k-1}` term. Following Miyake, Diamond–Shurman and Shimura, no
+separate `Uₚ` is introduced.
 
 ## Where the level enters
 
@@ -56,7 +57,8 @@ is `rat_slash_mapGL` below.
   `HeckeRing.GL2.heckeSlashUpperTriCuspFormEnd_mem_cuspFormCharSpace`: **the operator preserves
   the nebentypus**.
 * `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriModularFormEnd`,
-  `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriCuspFormEnd`: `aₘ(Tₚ f) = a_{p m}(f)`.
+  `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriCuspFormEnd`: the coefficient at `m` is the
+  coefficient of the original form at `p m`.
 
 ## References
 
@@ -109,6 +111,7 @@ private noncomputable def heckeSlashUpperTriModularForm (hpN : p ∣ N)
   toFun := heckeSlashUpperTri k p f
   slash_action_eq' γ hγ := by
     obtain ⟨δ, hδ, rfl⟩ := Subgroup.mem_map.mp hγ
+    let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
     rw [← rat_slash_mapGL]
     exact heckeSlashUpperTri_slash_mapGL_of_mem_Gamma1 k hpN hδ
       fun _ hε ↦ rat_slash_eq_of_mem_Gamma1 k f hε
@@ -127,6 +130,7 @@ private noncomputable def heckeSlashUpperTriCuspForm (hpN : p ∣ N)
     (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) : CuspForm ((Gamma1 N).map (mapGL ℝ)) k :=
   { heckeSlashUpperTriModularForm k hpN (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) with
     zero_at_cusps' := fun {c} hc ↦ by
+      -- Reduce the cusp-form structure literal to its bundled modular-form field.
       change c.IsZeroAt
         (⇑(heckeSlashUpperTriModularForm k hpN (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k))) k
       rw [coe_heckeSlashUpperTriModularForm]
@@ -172,6 +176,7 @@ theorem heckeSlashUpperTriModularFormEnd_mem_modFormCharSpace (hpN : p ∣ N)
     (χ : (ZMod N)ˣ →* ℂˣ) {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k}
     (hf : f ∈ modFormCharSpace k χ) :
     heckeSlashUpperTriModularFormEnd k hpN f ∈ modFormCharSpace k χ := by
+  let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
   rw [mem_modFormCharSpace_iff_nebentypus] at hf ⊢
   intro g
   rw [coe_heckeSlashUpperTriModularFormEnd, ← rat_slash_mapGL]
@@ -183,15 +188,17 @@ theorem heckeSlashUpperTriCuspFormEnd_mem_cuspFormCharSpace (hpN : p ∣ N)
     (χ : (ZMod N)ˣ →* ℂˣ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
     (hf : f ∈ cuspFormCharSpace k χ) :
     heckeSlashUpperTriCuspFormEnd k hpN f ∈ cuspFormCharSpace k χ := by
+  let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
   rw [mem_cuspFormCharSpace_iff_nebentypus] at hf ⊢
   intro g
   rw [coe_heckeSlashUpperTriCuspFormEnd, ← rat_slash_mapGL]
   exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hpN χ g
     fun δ ↦ by rw [rat_slash_mapGL]; exact hf δ
 
-/-- **The `q`-expansion recurrence**: `aₘ(Tₚ f) = a_{p m}(f)` for `p ∣ N`. This is the
-Diamond–Shurman recurrence `aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k-1} a_{m/p}(f)` in the case that
-makes the second term vanish, `χ(p) = 0`. -/
+/-- **The `q`-expansion recurrence**: the coefficient at `m` is `a_{p m}(f)` for `p ∣ N`.
+When `p` is prime, this is the Diamond–Shurman recurrence
+`aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k-1} a_{m/p}(f)` in the case that makes the second term vanish,
+`χ(p) = 0`. -/
 theorem qExpansion_coeff_heckeSlashUpperTriModularFormEnd (hpN : p ∣ N)
     (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
     (qExpansion 1 (heckeSlashUpperTriModularFormEnd k hpN f)).coeff m
@@ -200,7 +207,8 @@ theorem qExpansion_coeff_heckeSlashUpperTriModularFormEnd (hpN : p ∣ N)
   exact qExpansion_coeff_heckeSlashUpperTri' k p one_mem_strictPeriods_Gamma1
     (Nat.pos_of_ne_zero fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))) f m
 
-/-- **The `q`-expansion recurrence on cusp forms**: `aₘ(Tₚ f) = a_{p m}(f)` for `p ∣ N`. -/
+/-- **The `q`-expansion recurrence on cusp forms**: the coefficient at `m` is `a_{p m}(f)` for
+`p ∣ N`. -/
 theorem qExpansion_coeff_heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N)
     (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
     (qExpansion 1 (heckeSlashUpperTriCuspFormEnd k hpN f)).coeff m

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.DiamondOperators
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.Cusps
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.Invariance
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.QExpansion
+
+/-!
+# The upper-triangular Hecke operator on `M_k(Γ₁(N))` and `S_k(Γ₁(N))`
+
+The four analytic inputs for `heckeSlashUpperTri` are in place — holomorphy
+(`UpperTri/Holomorphic.lean`), boundedness and vanishing at every cusp (`UpperTri/Cusps.lean`),
+the `q`-expansion (`UpperTri/QExpansion.lean`) — and `UpperTri/Invariance.lean` supplies the
+missing algebraic one: at `p ∣ N` the sum preserves `Γ₁(N)`-invariance. This file assembles them
+into the operator itself, a `ℂ`-linear endomorphism of `ModularForm ((Gamma1 N).map (mapGL ℝ)) k`
+and of `CuspForm ((Gamma1 N).map (mapGL ℝ)) k`, and records the two facts that make it usable:
+it preserves each nebentypus space `M_k(N, χ)`, `S_k(N, χ)`, and on `q`-expansions it is
+`aₘ ↦ a_{p m}`.
+
+This is Layer 2(b) of the ModularForms roadmap at a level divisible by `p`. The classical `Tₚ`
+for `p ∤ N` needs one further coset representative and is not built here; at `p ∣ N` the classical
+`Tₚ` *is* this operator, which is why the recurrence below carries no `χ(p) p^{k-1}` term.
+Following Miyake, Diamond–Shurman and Shimura, no separate `Uₚ` is introduced.
+
+## Where the level enters
+
+`HeckeSlash/ModularForm.lean` already descends the *general double-coset* sum to forms, but only
+at level `𝒮ℒ`, where invariance is Shimura's Proposition 3.37 and no congruence condition is
+involved. Neither file implies the other: that one has an arbitrary double coset and the full
+modular group, this one has a fixed family of representatives and a congruence subgroup, and it
+is the congruence condition `p ∣ N` that makes the upper-triangular representatives suffice.
+
+The cusp conditions ask for `Subgroup.IsArithmetic` on the level, which `(Gamma1 N).map (mapGL ℝ)`
+carries through `CongruenceSubgroup.instFiniteIndexGamma1` once `N ≠ 0`. Invariance is carried
+rationally throughout `UpperTri/Invariance.lean`, so the one place the `ℚ`/`ℝ` bridge is needed
+is `rat_slash_mapGL` below.
+
+## Main definitions
+
+* `HeckeRing.GL2.heckeSlashUpperTriModularFormEnd`: the operator on `M_k(Γ₁(N))`, bundled as a
+  `Module.End ℂ`.
+* `HeckeRing.GL2.heckeSlashUpperTriCuspFormEnd`: the operator on `S_k(Γ₁(N))` — the statement
+  that it preserves cuspidality.
+
+## Main results
+
+* `HeckeRing.GL2.coe_heckeSlashUpperTriModularFormEnd`,
+  `HeckeRing.GL2.coe_heckeSlashUpperTriCuspFormEnd`: both are `heckeSlashUpperTri` on underlying
+  functions.
+* `HeckeRing.GL2.heckeSlashUpperTriModularFormEnd_mem_modFormCharSpace`,
+  `HeckeRing.GL2.heckeSlashUpperTriCuspFormEnd_mem_cuspFormCharSpace`: **the operator preserves
+  the nebentypus**.
+* `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriModularFormEnd`,
+  `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriCuspFormEnd`: `aₘ(Tₚ f) = a_{p m}(f)`.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.2–5.3.
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.5.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm Manifold
+
+namespace HeckeRing.GL2
+
+variable {N p : ℕ} (k : ℤ)
+
+/-- The `ℚ`/`ℝ` bridge for the slash by an integral matrix: the rational action in which
+`UpperTri/Invariance.lean` is stated agrees with the real action in which `SlashInvariantForm`
+is indexed. -/
+private lemma rat_slash_mapGL (F : ℍ → ℂ) (δ : SL(2, ℤ)) :
+    F ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = F ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) := by
+  rw [ModularForm.rat_slash, map_mapGL]
+
+/-- Slash-invariance of a form at level `Γ₁(N)`, transported to the rational action — the
+hypothesis `UpperTri/Invariance.lean` asks for. -/
+private lemma rat_slash_eq_of_mem_Gamma1 {F : Type*} [FunLike F ℍ ℂ]
+    [SlashInvariantFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (f : F) {δ : SL(2, ℤ)}
+    (hδ : δ ∈ Gamma1 N) : (⇑f) ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = ⇑f := by
+  rw [rat_slash_mapGL]
+  exact SlashInvariantFormClass.slash_action_eq f _ (Subgroup.mem_map_of_mem _ hδ)
+
+/-- The width of `∞` for `Γ₁(N)` is `1`, so all `q`-expansions below are taken at width `1`. -/
+private lemma one_mem_strictPeriods_Gamma1 :
+    (1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods := by
+  rw [strictPeriods_Gamma1]
+  exact AddSubgroup.mem_zmultiples 1
+
+variable [NeZero N]
+
+/-- **The upper-triangular sum acting on modular forms of level `Γ₁(N)`**, for `p ∣ N`.
+Invariance is `heckeSlashUpperTri_slash_mapGL_of_mem_Gamma1`, holomorphy is
+`mdifferentiable_heckeSlashUpperTri`, and boundedness at the cusps is
+`isBoundedAt_heckeSlashUpperTri`. The public interface is the bundled
+`heckeSlashUpperTriModularFormEnd`. -/
+private noncomputable def heckeSlashUpperTriModularForm (hpN : p ∣ N)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ModularForm ((Gamma1 N).map (mapGL ℝ)) k where
+  toFun := heckeSlashUpperTri k p f
+  slash_action_eq' γ hγ := by
+    obtain ⟨δ, hδ, rfl⟩ := Subgroup.mem_map.mp hγ
+    rw [← rat_slash_mapGL]
+    exact heckeSlashUpperTri_slash_mapGL_of_mem_Gamma1 k hpN hδ
+      fun _ hε ↦ rat_slash_eq_of_mem_Gamma1 k f hε
+  holo' := mdifferentiable_heckeSlashUpperTri k p (ModularFormClass.holo f)
+  bdd_at_cusps' hc :=
+    isBoundedAt_heckeSlashUpperTri k p (fun _ h ↦ ModularFormClass.bdd_at_cusps f h) hc
+
+private lemma coe_heckeSlashUpperTriModularForm (hpN : p ∣ N)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeSlashUpperTriModularForm k hpN f) = heckeSlashUpperTri k p f := (rfl)
+
+/-- **The upper-triangular sum acting on cusp forms of level `Γ₁(N)`** — the statement that the
+action preserves cuspidality. Only the vanishing field is new: invariance and holomorphy come
+from the underlying modular form, so neither is proved twice. -/
+private noncomputable def heckeSlashUpperTriCuspForm (hpN : p ∣ N)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) : CuspForm ((Gamma1 N).map (mapGL ℝ)) k :=
+  { heckeSlashUpperTriModularForm k hpN (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) with
+    zero_at_cusps' := fun {c} hc ↦ by
+      change c.IsZeroAt
+        (⇑(heckeSlashUpperTriModularForm k hpN (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k))) k
+      rw [coe_heckeSlashUpperTriModularForm]
+      exact isZeroAt_heckeSlashUpperTri k p (fun _ h ↦ CuspFormClass.zero_at_cusps f h) hc }
+
+private lemma coe_heckeSlashUpperTriCuspForm (hpN : p ∣ N)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeSlashUpperTriCuspForm k hpN f) = heckeSlashUpperTri k p f := (rfl)
+
+/-- **The upper-triangular Hecke operator on `M_k(Γ₁(N))`**, for `p ∣ N`, as a `ℂ`-linear
+endomorphism. Bundling is what lets Hecke operators compose and later carry a ring structure. -/
+noncomputable def heckeSlashUpperTriModularFormEnd (hpN : p ∣ N) :
+    Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) where
+  toFun := heckeSlashUpperTriModularForm k hpN
+  map_add' f g := by
+    ext τ; simp [coe_heckeSlashUpperTriModularForm, heckeSlashUpperTri_add]
+  map_smul' c f := by
+    ext τ; simp [coe_heckeSlashUpperTriModularForm, heckeSlashUpperTri_smul]
+
+/-- **The upper-triangular Hecke operator on `S_k(Γ₁(N))`**, for `p ∣ N`. -/
+noncomputable def heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N) :
+    Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) where
+  toFun := heckeSlashUpperTriCuspForm k hpN
+  map_add' f g := by
+    ext τ; simp [coe_heckeSlashUpperTriCuspForm, heckeSlashUpperTri_add]
+  map_smul' c f := by
+    ext τ; simp [coe_heckeSlashUpperTriCuspForm, heckeSlashUpperTri_smul]
+
+/-- The operator is `heckeSlashUpperTri` on underlying functions. -/
+@[simp] lemma coe_heckeSlashUpperTriModularFormEnd (hpN : p ∣ N)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeSlashUpperTriModularFormEnd k hpN f) = heckeSlashUpperTri k p f := (rfl)
+
+/-- The operator is `heckeSlashUpperTri` on underlying functions. -/
+@[simp] lemma coe_heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeSlashUpperTriCuspFormEnd k hpN f) = heckeSlashUpperTri k p f := (rfl)
+
+/-- **The operator preserves the nebentypus**: it maps `M_k(N, χ)` into itself. Not an
+assumption but a theorem: the factorisation of `UpperTri/Invariance.lean` replaces a `Γ₀(N)`
+matrix by one with the same lower-right entry modulo `N`, so the character value is unchanged. -/
+theorem heckeSlashUpperTriModularFormEnd_mem_modFormCharSpace (hpN : p ∣ N)
+    (χ : (ZMod N)ˣ →* ℂˣ) {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ modFormCharSpace k χ) :
+    heckeSlashUpperTriModularFormEnd k hpN f ∈ modFormCharSpace k χ := by
+  rw [mem_modFormCharSpace_iff_nebentypus] at hf ⊢
+  intro g
+  rw [coe_heckeSlashUpperTriModularFormEnd, ← rat_slash_mapGL]
+  exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hpN χ g
+    fun δ ↦ by rw [rat_slash_mapGL]; exact hf δ
+
+/-- **The operator preserves the nebentypus on cusp forms**: it maps `S_k(N, χ)` into itself. -/
+theorem heckeSlashUpperTriCuspFormEnd_mem_cuspFormCharSpace (hpN : p ∣ N)
+    (χ : (ZMod N)ˣ →* ℂˣ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ cuspFormCharSpace k χ) :
+    heckeSlashUpperTriCuspFormEnd k hpN f ∈ cuspFormCharSpace k χ := by
+  rw [mem_cuspFormCharSpace_iff_nebentypus] at hf ⊢
+  intro g
+  rw [coe_heckeSlashUpperTriCuspFormEnd, ← rat_slash_mapGL]
+  exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hpN χ g
+    fun δ ↦ by rw [rat_slash_mapGL]; exact hf δ
+
+/-- **The `q`-expansion recurrence**: `aₘ(Tₚ f) = a_{p m}(f)` for `p ∣ N`. This is the
+Diamond–Shurman recurrence `aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k-1} a_{m/p}(f)` in the case that
+makes the second term vanish, `χ(p) = 0`. -/
+theorem qExpansion_coeff_heckeSlashUpperTriModularFormEnd (hpN : p ∣ N)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
+    (qExpansion 1 (heckeSlashUpperTriModularFormEnd k hpN f)).coeff m
+      = (qExpansion 1 f).coeff (p * m) := by
+  rw [coe_heckeSlashUpperTriModularFormEnd]
+  exact qExpansion_coeff_heckeSlashUpperTri' k p one_mem_strictPeriods_Gamma1
+    (Nat.pos_of_ne_zero fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))) f m
+
+/-- **The `q`-expansion recurrence on cusp forms**: `aₘ(Tₚ f) = a_{p m}(f)` for `p ∣ N`. -/
+theorem qExpansion_coeff_heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
+    (qExpansion 1 (heckeSlashUpperTriCuspFormEnd k hpN f)).coeff m
+      = (qExpansion 1 f).coeff (p * m) := by
+  rw [coe_heckeSlashUpperTriCuspFormEnd]
+  exact qExpansion_coeff_heckeSlashUpperTri' k p one_mem_strictPeriods_Gamma1
+    (Nat.pos_of_ne_zero fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))) f m
+
+end HeckeRing.GL2
+
+end


### PR DESCRIPTION
This PR builds the first Hecke operator acting on modular forms at congruence level: for `p ∣ N` it descends the upper-triangular slash sum `heckeSlashUpperTri k p f = ∑_{b < p} f ∣[k] !![1, b; 0, p]` to `ℂ`-linear endomorphisms of `ModularForm ((Gamma1 N).map (mapGL ℝ)) k` and `CuspForm ((Gamma1 N).map (mapGL ℝ)) k`, proves that they preserve the nebentypus spaces `M_k(N, χ)` and `S_k(N, χ)`, and records the `q`-expansion recurrence `aₘ(Tₚ f) = a_{p m}(f)`. It serves the ModularForms roadmap's Layer 2(b) milestone, "**The action on forms**" — `Tₙ`, `Tₚ` as `ℂ`-linear endomorphisms preserving `M_k(N, χ)` and `S_k(N, χ)` with their explicit `q`-expansion recurrences — which the roadmap's frontier names as the one target that Layers 3 to 7 all wait on. What remains after this PR for that milestone is the `p ∤ N` case, whose double coset needs the further representative `!![p, 0; 0, 1]` and contributes the second term `χ(p) p^{k-1} a_{m/p}(f)`, and then the multiplicative extension to general `n` with the ring homomorphism from the abstract Hecke ring.

Everything analytic about this sum already existed: holomorphy (`UpperTri/Holomorphic.lean`), boundedness and vanishing at every cusp (`UpperTri/Cusps.lean`), and the coefficient formula (`UpperTri/QExpansion.lean`, TauCeti#3744). The missing input was algebraic, and it is what `UpperTri/Invariance.lean` supplies. Writing `γ = !![a, b; c, d] ∈ Γ₀(N)`, so that `p ∣ c`, the product `!![1, j; 0, p] · γ` factors as `γ' · !![1, j'; 0, p]` with `γ' = !![a + jc, b'; pc, d - cj'] ∈ Γ₀(N)` and `p b' = b + jd - (a + jc) j'`. Solvability forces `a j' ≡ b + jd (mod p)`, which is where `p ∣ N` is used twice over: it makes `p ∣ c`, hence `ad ≡ 1 (mod p)`, so `a` is invertible modulo `p` with inverse `d`, and the unique offset in `[0, p)` is `j' = d b + j d² mod p` — `upperTriShift`, a bijection of `Fin p` because `d²` is again invertible. Slashing by `γ` therefore permutes the summands. Two bookkeeping facts make the scalar behave: the new lower-right entry is `d - c j' ≡ d (mod N)`, so `γ'` has the same `Gamma0Map` value as `γ`; and `Γ₁(N)` is exactly the fibre of `Gamma0Map` over `1`. The equivariance is consequently proved once with a free scalar, `heckeSlashUpperTri_slash_mapGL_of_mem_Gamma0`, and both `Γ₁(N)`-invariance and nebentypus transport are instances of it. At `p ∤ N` the statement is false as it stands — the double coset has one further left coset — and the module docstring says so.

Naming follows the roadmap's convention rather than the modern literature: no `Uₚ` is introduced as an independent operator. The declarations are named after the slash sum they descend (`heckeSlashUpperTriModularFormEnd`, `heckeSlashUpperTriCuspFormEnd`), so that when the classical `Tₚ` is built for all `p` it can be *proved* equal to this operator at `p ∣ N` rather than competing with a second name for it. This is also why the recurrence here carries no `χ(p) p^{k-1}` term: that is the Diamond–Shurman recurrence in the case `χ(p) = 0`.

`HeckeSlash/ModularForm.lean` already descends the *general* double-coset sum to forms, but only at level `𝒮ℒ`, where invariance is Shimura's Proposition 3.37 and no congruence condition appears; neither file implies the other, and the new module docstring explains the difference. Three lemmas that are congruence-subgroup arithmetic rather than Hecke theory are placed in `TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean` beside `isUnit_intCast_apply_zero_zero_of_mem_Gamma0`: `mem_Gamma1_iff_mem_Gamma0`, and the two divisor-level entry facts `intCast_apply_one_zero_eq_zero_of_mem_Gamma0` and `intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0`.

Files added: `TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean` (223 lines) and `TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean` (214 lines); 37 lines added to `CongruenceSubgroups.lean`. No Mathlib infrastructure was vendored, and no code was transcribed from AINTLIB: the factorisation and its bijection are derived here against this repository's `upperTriRep` family, and AINTLIB's corresponding `Γ₁(N)` invariance step is not reproduced.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"upper-triangular-hecke-sum-gamma1-invariance"}-->

🤖 Prepared with Claude Code
