### PR TITLE
feat: define central points and central closed subgroup schemes

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -1,0 +1,288 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.Coalgebra.Convolution
+
+/-!
+# Central points of an affine group scheme
+
+Let `H` be a commutative bialgebra over `R`, so that `A ↦ (H →ₐ[R] A)` is the functor of points
+of the affine monoid scheme `Spec H`, a group functor when `H` is a Hopf algebra. A point
+`g : H →ₐ[R] A` is **central** when its image in `G(B)` commutes with *every* `B`-point of `G`,
+for every `A`-algebra `B`, and not merely with the points over `A` itself.
+
+Quantifying over all value algebras is what makes the notion correct: an element of the abstract
+group `G(A)` may commute with everything in `G(A)` without commuting with the points of `G` over
+larger algebras, so the naive condition does not describe a subgroup scheme. The same functorial
+formulation is used for the kernel of a central isogeny in
+`TauCeti.GroupScheme.HasCentralKernel`.
+
+The main result is that a single test algebra decides the question:
+`TauCeti.HopfAlgebra.isCentralPoint_iff_commute_includeRight` says that `g` is central exactly
+when its image in `G(A ⊗[R] H)` commutes with the tautological point `h ↦ 1 ⊗ₜ h`. Every other
+value algebra is a specialization of that universal one, because an algebra map out of
+`A ⊗[R] H` is exactly a pair consisting of an `A`-algebra and a point.
+
+Specialized to the tautological point of `G` over `H` itself, the criterion says that `G` is a
+commutative group functor exactly when `H` is cocommutative
+(`TauCeti.HopfAlgebra.isCentralPoint_id_iff_isCocomm`).
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.IsCentralPoint`: centrality of a point of the functor of points.
+* `TauCeti.HopfAlgebra.centre`: the central points as a subgroup of the group of points.
+
+## Main results
+
+* `TauCeti.HopfAlgebra.isCentralPoint_iff_commute_includeRight`: **one test algebra suffices**.
+* `TauCeti.HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm`: the two tensor-factor
+  points of `H` commute exactly when `H` is cocommutative.
+* `TauCeti.HopfAlgebra.convMul_includeRight_includeLeft`: the convolution product of the two
+  tensor-factor points in the reversed order is the flipped comultiplication.
+* `TauCeti.HopfAlgebra.isCentralPoint_id_iff_isCocomm`: the tautological point is central exactly
+  when `H` is cocommutative.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §1.k and §2.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+This is a prerequisite for the centre `Z(G)` in Layer 6, "Reductive and semisimple groups", of
+`TauCetiRoadmap/ReductiveGroups/README.md`.
+-/
+
+public section
+
+open TensorProduct WithConv
+
+namespace TauCeti
+
+namespace HopfAlgebra
+
+universe u v
+
+section Definition
+
+variable {R : Type u} {H : Type v} {A : Type v}
+variable [CommRing R] [Ring H] [_root_.Bialgebra R H] [CommRing A] [Algebra R A]
+
+/-- A point `g` of `Spec H` with values in `A` is **central** when, for every `R`-algebra map
+`φ : A →ₐ[R] B` into a commutative `R`-algebra, the point `φ ∘ g` commutes with every `B`-point
+of `Spec H`.
+
+Commuting with the points over `A` alone is a strictly weaker condition and does not describe a
+subgroup scheme; this is why the value algebra is quantified over. Restricting the quantifier to
+`Type v` loses nothing: `TauCeti.HopfAlgebra.isCentralPoint_iff_commute_includeRight` shows that
+the single value algebra `A ⊗[R] H` already decides centrality. -/
+def IsCentralPoint (g : WithConv (H →ₐ[R] A)) : Prop :=
+  ∀ ⦃B : Type v⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) (h : WithConv (H →ₐ[R] B)),
+    Commute (AlgHom.mapValue φ g) h
+
+/-- Centrality, restated as the defining condition. -/
+theorem isCentralPoint_def (g : WithConv (H →ₐ[R] A)) :
+    IsCentralPoint g ↔
+      ∀ ⦃B : Type v⦄ [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) (h : WithConv (H →ₐ[R] B)),
+        Commute (AlgHom.mapValue φ g) h :=
+  Iff.rfl
+
+/-- A central point commutes with every point over its own value algebra. -/
+theorem IsCentralPoint.commute {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPoint g)
+    (h : WithConv (H →ₐ[R] A)) : Commute g h := by
+  simpa using hg (AlgHom.id R A) h
+
+/-- Centrality is preserved by change of value algebra. -/
+theorem IsCentralPoint.mapValue {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPoint g)
+    {B : Type v} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B) :
+    IsCentralPoint (AlgHom.mapValue φ g) := by
+  intro C _ _ ψ h
+  rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp]
+  exact hg (ψ.comp φ) h
+
+/-- The identity point is central. -/
+theorem isCentralPoint_one : IsCentralPoint (1 : WithConv (H →ₐ[R] A)) := by
+  intro B _ _ φ h
+  rw [map_one]
+  exact Commute.one_left h
+
+/-- A product of central points is central. -/
+theorem IsCentralPoint.mul {g g' : WithConv (H →ₐ[R] A)} (hg : IsCentralPoint g)
+    (hg' : IsCentralPoint g') : IsCentralPoint (g * g') := by
+  intro B _ _ φ h
+  rw [map_mul]
+  exact (hg φ h).mul_left (hg' φ h)
+
+/-- Over a cocommutative bialgebra every point is central, the group functor being commutative. -/
+theorem isCentralPoint_of_isCocomm [_root_.Coalgebra.IsCocomm R H]
+    (g : WithConv (H →ₐ[R] A)) : IsCentralPoint g :=
+  fun _ _ _ _ h ↦ Commute.all _ h
+
+end Definition
+
+section Group
+
+variable {R : Type u} {H : Type v} {A : Type v}
+variable [CommRing R] [Ring H] [_root_.HopfAlgebra R H] [CommRing A] [Algebra R A]
+
+/-- The inverse of a central point is central. -/
+theorem IsCentralPoint.inv {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPoint g) :
+    IsCentralPoint g⁻¹ := by
+  intro B _ _ φ h
+  rw [map_inv]
+  exact (hg φ h).inv_left
+
+variable (R H A) in
+/-- The **centre** of the functor of points, as a subgroup of the group of `A`-points.
+
+Its elements are the points that stay central after every change of value algebra, so the
+construction is natural in `A` (`TauCeti.HopfAlgebra.mapValue_mem_centre`). It is contained in,
+and in general strictly smaller than, the abstract centre of the group `G(A)`. -/
+@[expose] noncomputable def centre : Subgroup (WithConv (H →ₐ[R] A)) where
+  carrier := {g | IsCentralPoint g}
+  mul_mem' hg hg' := IsCentralPoint.mul hg hg'
+  one_mem' := isCentralPoint_one
+  inv_mem' hg := IsCentralPoint.inv hg
+
+@[simp]
+theorem mem_centre {g : WithConv (H →ₐ[R] A)} : g ∈ centre R H A ↔ IsCentralPoint g :=
+  Iff.rfl
+
+/-- The centre of the functor of points is contained in the abstract centre of the group of
+`A`-points. The inclusion is generally strict: an abstractly central point need not stay central
+over larger value algebras. -/
+theorem centre_le_center : centre R H A ≤ Subgroup.center (WithConv (H →ₐ[R] A)) :=
+  fun _ hg ↦ Subgroup.mem_center_iff.mpr fun h ↦ ((mem_centre.mp hg).commute h).symm
+
+/-- The centre is natural in the value algebra. -/
+theorem mapValue_mem_centre {B : Type v} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
+    {g : WithConv (H →ₐ[R] A)} (hg : g ∈ centre R H A) :
+    AlgHom.mapValue φ g ∈ centre R H B :=
+  (mem_centre.mp hg).mapValue φ
+
+end Group
+
+section Universal
+
+variable {R : Type u} {H : Type v} {A : Type v}
+variable [CommRing R] [CommRing H] [_root_.Bialgebra R H] [CommRing A] [Algebra R A]
+
+/-- **A single value algebra decides centrality.** A point `g` of `Spec H` over `A` is central
+exactly when its image over `A ⊗[R] H` commutes with the tautological point `h ↦ 1 ⊗ₜ h`.
+
+Every pair consisting of an `A`-algebra `B` and a `B`-point of `Spec H` is the same thing as an
+algebra map `A ⊗[R] H →ₐ[R] B`, and the convolution product is functorial in the value algebra,
+so the universal case implies all the others. -/
+theorem isCentralPoint_iff_commute_includeRight (g : WithConv (H →ₐ[R] A)) :
+    IsCentralPoint g ↔
+      Commute
+        (AlgHom.mapValue
+          (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := A) (B := H)) g)
+        (toConv (Algebra.TensorProduct.includeRight (R := R) (A := A) (B := H))) := by
+  refine ⟨fun hg ↦ hg _ _, fun hg B _ _ φ h ↦ ?_⟩
+  have key := hg.map (AlgHom.mapValue (H := H) (Algebra.TensorProduct.productMap φ h.ofConv))
+  have h₁ : AlgHom.mapValue (H := H) (Algebra.TensorProduct.productMap φ h.ofConv)
+      (AlgHom.mapValue
+        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := A) (B := H)) g) =
+      AlgHom.mapValue φ g := by
+    rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp, Algebra.TensorProduct.productMap_left]
+  have h₂ : AlgHom.mapValue (H := H) (Algebra.TensorProduct.productMap φ h.ofConv)
+      (toConv (Algebra.TensorProduct.includeRight (R := R) (A := A) (B := H))) = h := by
+    rw [AlgHom.mapValue_apply, ofConv_toConv, Algebra.TensorProduct.productMap_right, toConv_ofConv]
+  rwa [h₁, h₂] at key
+
+end Universal
+
+section Cocommutative
+
+variable {R : Type u} {H : Type v}
+variable [CommRing R] [CommRing H] [_root_.Bialgebra R H]
+
+private theorem coe_algebraTensorProductComm (y : H ⊗[R] H) :
+    (Algebra.TensorProduct.comm R H H) y = _root_.TensorProduct.comm R H H y := rfl
+
+private theorem comm_toAlgHom_comp_includeLeft :
+    (Algebra.TensorProduct.comm R H H).toAlgHom.comp
+        (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) =
+      Algebra.TensorProduct.includeRight := by
+  ext x
+  simp
+
+private theorem comm_toAlgHom_comp_includeRight :
+    (Algebra.TensorProduct.comm R H H).toAlgHom.comp
+        (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
+      Algebra.TensorProduct.includeLeft := by
+  ext x
+  simp
+
+/-- The convolution product of the two tensor-factor points of `H` is the comultiplication.
+This is `TauCeti.Bialgebra.comulPoint_eq_include_mul` with the bialgebra inclusions replaced by
+their underlying algebra maps. -/
+theorem convMul_includeLeft_includeRight :
+    toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
+        toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
+      toConv (_root_.Bialgebra.comulAlgHom R H) := by
+  simpa using (Bialgebra.comulPoint_eq_include_mul (R := R) (H := H)).symm
+
+/-- The convolution product of the two tensor-factor points, taken in the other order, is the
+comultiplication followed by the flip of the tensor factors. -/
+theorem convMul_includeRight_includeLeft :
+    toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) *
+        toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) =
+      toConv ((Algebra.TensorProduct.comm R H H).toAlgHom.comp
+        (_root_.Bialgebra.comulAlgHom R H)) := by
+  have key := map_mul (AlgHom.mapValue (H := H) (Algebra.TensorProduct.comm R H H).toAlgHom)
+    (toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))
+    (toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)))
+  rw [convMul_includeLeft_includeRight] at key
+  rw [AlgHom.mapValue_apply, AlgHom.mapValue_apply, AlgHom.mapValue_apply, ofConv_toConv,
+    ofConv_toConv, ofConv_toConv, comm_toAlgHom_comp_includeLeft,
+    comm_toAlgHom_comp_includeRight] at key
+  exact key.symm
+
+variable (R H) in
+/-- **The two tensor-factor points of `H` commute exactly when `H` is cocommutative.** The two
+convolution products are the comultiplication and its flip, so their equality is precisely
+cocommutativity. -/
+theorem commute_includeLeft_includeRight_iff_isCocomm :
+    Commute (toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))
+        (toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H))) ↔
+      _root_.Coalgebra.IsCocomm R H := by
+  rw [commute_iff_eq, convMul_includeLeft_includeRight, convMul_includeRight_includeLeft]
+  constructor
+  · intro h
+    refine ⟨LinearMap.ext fun x ↦ ?_⟩
+    have hx := congrArg (fun f ↦ f.ofConv x) h
+    simpa [coe_algebraTensorProductComm] using hx.symm
+  · intro _
+    refine congrArg toConv (AlgHom.ext fun x ↦ ?_)
+    simp [coe_algebraTensorProductComm]
+
+end Cocommutative
+
+section Tautological
+
+variable {R : Type u} {H : Type v}
+variable [CommRing R] [CommRing H] [_root_.Bialgebra R H]
+
+variable (R H) in
+/-- **The tautological point is central exactly when `H` is cocommutative**, that is, exactly
+when the group functor of `Spec H` is commutative. -/
+theorem isCentralPoint_id_iff_isCocomm :
+    IsCentralPoint (toConv (AlgHom.id R H)) ↔ _root_.Coalgebra.IsCocomm R H := by
+  have h : AlgHom.mapValue (H := H)
+      (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H))
+        (toConv (AlgHom.id R H)) =
+      toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) := by
+    rw [AlgHom.mapValue_apply, ofConv_toConv, AlgHom.comp_id]
+  rw [isCentralPoint_iff_commute_includeRight, h,
+    commute_includeLeft_includeRight_iff_isCocomm]
+
+end Tautological
+
+end HopfAlgebra
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -35,7 +35,7 @@ commutative group functor exactly when `H` is cocommutative
 ## Main declarations
 
 * `TauCeti.HopfAlgebra.IsCentralPoint`: centrality of a point of the functor of points.
-* `TauCeti.HopfAlgebra.centre`: the central points as a subgroup of the group of points.
+* `TauCeti.HopfAlgebra.center`: the central points as a subgroup of the group of points.
 
 ## Main results
 
@@ -52,7 +52,7 @@ commutative group functor exactly when `H` is cocommutative
 * J. S. Milne, *Algebraic Groups* (2017), §1.k and §2.
 * W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
 
-This is a prerequisite for the centre `Z(G)` in Layer 6, "Reductive and semisimple groups", of
+This is a prerequisite for the center `Z(G)` in Layer 6, "Reductive and semisimple groups", of
 `TauCetiRoadmap/ReductiveGroups/README.md`.
 -/
 
@@ -136,32 +136,32 @@ theorem IsCentralPoint.inv {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPoint g
   exact (hg φ h).inv_left
 
 variable (R H A) in
-/-- The **centre** of the functor of points, as a subgroup of the group of `A`-points.
+/-- The **center** of the functor of points, as a subgroup of the group of `A`-points.
 
 Its elements are the points that stay central after every change of value algebra, so the
-construction is natural in `A` (`TauCeti.HopfAlgebra.mapValue_mem_centre`). It is contained in,
-and in general strictly smaller than, the abstract centre of the group `G(A)`. -/
-@[expose] noncomputable def centre : Subgroup (WithConv (H →ₐ[R] A)) where
+construction is natural in `A` (`TauCeti.HopfAlgebra.mapValue_mem_center`). It is contained in,
+and in general strictly smaller than, the abstract center of the group `G(A)`. -/
+noncomputable def center : Subgroup (WithConv (H →ₐ[R] A)) where
   carrier := {g | IsCentralPoint g}
   mul_mem' hg hg' := IsCentralPoint.mul hg hg'
   one_mem' := isCentralPoint_one
   inv_mem' hg := IsCentralPoint.inv hg
 
 @[simp]
-theorem mem_centre {g : WithConv (H →ₐ[R] A)} : g ∈ centre R H A ↔ IsCentralPoint g :=
+theorem mem_center {g : WithConv (H →ₐ[R] A)} : g ∈ center R H A ↔ IsCentralPoint g :=
   Iff.rfl
 
-/-- The centre of the functor of points is contained in the abstract centre of the group of
+/-- The center of the functor of points is contained in the abstract center of the group of
 `A`-points. The inclusion is generally strict: an abstractly central point need not stay central
 over larger value algebras. -/
-theorem centre_le_center : centre R H A ≤ Subgroup.center (WithConv (H →ₐ[R] A)) :=
-  fun _ hg ↦ Subgroup.mem_center_iff.mpr fun h ↦ ((mem_centre.mp hg).commute h).symm
+theorem center_le_center : center R H A ≤ Subgroup.center (WithConv (H →ₐ[R] A)) :=
+  fun _ hg ↦ Subgroup.mem_center_iff.mpr fun h ↦ ((mem_center.mp hg).commute h).symm
 
-/-- The centre is natural in the value algebra. -/
-theorem mapValue_mem_centre {B : Type v} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
-    {g : WithConv (H →ₐ[R] A)} (hg : g ∈ centre R H A) :
-    AlgHom.mapValue φ g ∈ centre R H B :=
-  (mem_centre.mp hg).mapValue φ
+/-- The center is natural in the value algebra. -/
+theorem mapValue_mem_center {B : Type v} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)
+    {g : WithConv (H →ₐ[R] A)} (hg : g ∈ center R H A) :
+    AlgHom.mapValue φ g ∈ center R H B :=
+  (mem_center.mp hg).mapValue φ
 
 end Group
 
@@ -228,11 +228,11 @@ theorem convMul_includeRight_includeLeft :
   have key := map_mul (AlgHom.mapValue (H := H) (Algebra.TensorProduct.comm R H H).toAlgHom)
     (toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))
     (toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)))
-  rw [show
-    toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
-        toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
-      toConv (_root_.Bialgebra.comulAlgHom R H) by
-        simpa using (Bialgebra.comulPoint_eq_include_mul (R := R) (H := H)).symm] at key
+  simp only [← Bialgebra.TensorProduct.includeLeft_toAlgHom,
+    ← Bialgebra.TensorProduct.includeRight_toAlgHom] at key
+  rw [← Bialgebra.comulPoint_eq_include_mul] at key
+  simp only [Bialgebra.TensorProduct.includeLeft_toAlgHom,
+    Bialgebra.TensorProduct.includeRight_toAlgHom] at key
   rw [AlgHom.mapValue_apply, AlgHom.mapValue_apply, AlgHom.mapValue_apply, ofConv_toConv,
     ofConv_toConv, ofConv_toConv, comm_toAlgHom_comp_includeLeft,
     comm_toAlgHom_comp_includeRight] at key
@@ -246,12 +246,12 @@ theorem commute_includeLeft_includeRight_iff_isCocomm :
     Commute (toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))
         (toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H))) ↔
       _root_.Coalgebra.IsCocomm R H := by
-  rw [commute_iff_eq, show
-    toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
-        toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
-      toConv (_root_.Bialgebra.comulAlgHom R H) by
-        simpa using (Bialgebra.comulPoint_eq_include_mul (R := R) (H := H)).symm,
-    convMul_includeRight_includeLeft]
+  simp only [← Bialgebra.TensorProduct.includeLeft_toAlgHom,
+    ← Bialgebra.TensorProduct.includeRight_toAlgHom]
+  rw [commute_iff_eq, ← Bialgebra.comulPoint_eq_include_mul]
+  simp only [Bialgebra.TensorProduct.includeLeft_toAlgHom,
+    Bialgebra.TensorProduct.includeRight_toAlgHom]
+  rw [convMul_includeRight_includeLeft]
   constructor
   · intro h
     refine ⟨LinearMap.ext fun x ↦ ?_⟩

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -218,15 +218,6 @@ private theorem comm_toAlgHom_comp_includeRight :
   ext x
   simp
 
-/-- The convolution product of the two tensor-factor points of `H` is the comultiplication.
-This is `TauCeti.Bialgebra.comulPoint_eq_include_mul` with the bialgebra inclusions replaced by
-their underlying algebra maps. -/
-theorem convMul_includeLeft_includeRight :
-    toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
-        toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
-      toConv (_root_.Bialgebra.comulAlgHom R H) := by
-  simpa using (Bialgebra.comulPoint_eq_include_mul (R := R) (H := H)).symm
-
 /-- The convolution product of the two tensor-factor points, taken in the other order, is the
 comultiplication followed by the flip of the tensor factors. -/
 theorem convMul_includeRight_includeLeft :
@@ -237,7 +228,11 @@ theorem convMul_includeRight_includeLeft :
   have key := map_mul (AlgHom.mapValue (H := H) (Algebra.TensorProduct.comm R H H).toAlgHom)
     (toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))
     (toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)))
-  rw [convMul_includeLeft_includeRight] at key
+  rw [show
+    toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
+        toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
+      toConv (_root_.Bialgebra.comulAlgHom R H) by
+        simpa using (Bialgebra.comulPoint_eq_include_mul (R := R) (H := H)).symm] at key
   rw [AlgHom.mapValue_apply, AlgHom.mapValue_apply, AlgHom.mapValue_apply, ofConv_toConv,
     ofConv_toConv, ofConv_toConv, comm_toAlgHom_comp_includeLeft,
     comm_toAlgHom_comp_includeRight] at key
@@ -251,7 +246,12 @@ theorem commute_includeLeft_includeRight_iff_isCocomm :
     Commute (toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))
         (toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H))) ↔
       _root_.Coalgebra.IsCocomm R H := by
-  rw [commute_iff_eq, convMul_includeLeft_includeRight, convMul_includeRight_includeLeft]
+  rw [commute_iff_eq, show
+    toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
+        toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) =
+      toConv (_root_.Bialgebra.comulAlgHom R H) by
+        simpa using (Bialgebra.comulPoint_eq_include_mul (R := R) (H := H)).symm,
+    convMul_includeRight_includeLeft]
   constructor
   · intro h
     refine ⟨LinearMap.ext fun x ↦ ?_⟩

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -79,13 +79,6 @@ def IsCentral (I : HopfIdeal R H) : Prop :=
   ∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
       Algebra.TensorProduct.includeRight x ∈ leftTensorIdeal (R := R) (H := H) I.toIdeal
 
-/-- Centrality, restated as the defining ideal-membership condition. -/
-theorem isCentral_def (I : HopfIdeal R H) :
-    I.IsCentral ↔
-      ∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
-        Algebra.TensorProduct.includeRight x ∈ leftTensorIdeal (R := R) (H := H) I.toIdeal :=
-  Iff.rfl
-
 /-- Centrality passes to larger Hopf ideals, which cut out smaller closed subgroups. -/
 theorem IsCentral.mono {I J : HopfIdeal R H} (hI : I.IsCentral) (hIJ : I ≤ J) : J.IsCentral :=
   fun x ↦ leftTensorIdeal_mono R H (toIdeal_le_toIdeal.mpr hIJ) (hI x)
@@ -101,7 +94,7 @@ The zero Hopf ideal cuts out all of `Spec H`, so its centrality says that conjug
 which for the convolution group of points is commutativity. -/
 theorem isCentral_bot_iff_isCocomm :
     (⊥ : HopfIdeal R H).IsCentral ↔ _root_.Coalgebra.IsCocomm R H := by
-  rw [isCentral_def, ← HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm R H,
+  rw [IsCentral, ← HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm R H,
     commute_iff_eq]
   have hzero : leftTensorIdeal (R := R) (H := H) (⊥ : HopfIdeal R H).toIdeal = ⊥ := by
     rw [bot_toIdeal, leftTensorIdeal_def, Ideal.map_bot]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -96,15 +96,6 @@ theorem isCentral_iSup_of_isCentral {ι : Sort*} {I : ι → HopfIdeal R H} {j :
     (hj : (I j).IsCentral) : (⨆ i, I i).IsCentral :=
   hj.mono (le_sSup (Set.mem_range_self j))
 
-/-- The coordinate morphism of conjugation, as a point, written with the underlying algebra maps
-of the two tensor-factor inclusions. -/
-private theorem toConv_conjugationAlgHom' :
-    toConv (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) =
-      toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
-          toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) *
-        (toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))⁻¹ := by
-  simpa using HopfAlgebra.toConv_conjugationAlgHom (R := R) (H := H)
-
 /-- **The whole group is central exactly when its coordinate Hopf algebra is cocommutative.**
 The zero Hopf ideal cuts out all of `Spec H`, so its centrality says that conjugation is trivial,
 which for the convolution group of points is commutativity. -/
@@ -125,13 +116,20 @@ theorem isCentral_bot_iff_isCocomm :
     rw [he]
     simp
   rw [hiff]
+  have hconj :
+      toConv (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) =
+        toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
+            toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) *
+          (toConv
+            (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))⁻¹ := by
+    simpa using HopfAlgebra.toConv_conjugationAlgHom (R := R) (H := H)
   constructor
   · intro he
     refine mul_inv_eq_iff_eq_mul.mp ?_
-    rw [← toConv_conjugationAlgHom', he]
+    rw [← hconj, he]
   · intro hc
     exact WithConv.toConv_injective
-      ((toConv_conjugationAlgHom').trans (mul_inv_eq_iff_eq_mul.mpr hc))
+      (hconj.trans (mul_inv_eq_iff_eq_mul.mpr hc))
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -79,6 +79,13 @@ def IsCentral (I : HopfIdeal R H) : Prop :=
   ∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
       Algebra.TensorProduct.includeRight x ∈ leftTensorIdeal (R := R) (H := H) I.toIdeal
 
+/-- Centrality, restated as the defining ideal-membership condition. -/
+theorem isCentral_def (I : HopfIdeal R H) :
+    I.IsCentral ↔
+      ∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
+        Algebra.TensorProduct.includeRight x ∈ leftTensorIdeal (R := R) (H := H) I.toIdeal :=
+  Iff.rfl
+
 /-- Centrality passes to larger Hopf ideals, which cut out smaller closed subgroups. -/
 theorem IsCentral.mono {I J : HopfIdeal R H} (hI : I.IsCentral) (hIJ : I ≤ J) : J.IsCentral :=
   fun x ↦ leftTensorIdeal_mono R H (toIdeal_le_toIdeal.mpr hIJ) (hI x)
@@ -94,7 +101,7 @@ The zero Hopf ideal cuts out all of `Spec H`, so its centrality says that conjug
 which for the convolution group of points is commutativity. -/
 theorem isCentral_bot_iff_isCocomm :
     (⊥ : HopfIdeal R H).IsCentral ↔ _root_.Coalgebra.IsCocomm R H := by
-  rw [IsCentral, ← HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm R H,
+  rw [isCentral_def, ← HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm R H,
     commute_iff_eq]
   have hzero : leftTensorIdeal (R := R) (H := H) (⊥ : HopfIdeal R H).toIdeal = ⊥ := by
     rw [bot_toIdeal, leftTensorIdeal_def, Ideal.map_bot]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.CentralPoint
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+
+/-!
+# Central closed subgroup schemes
+
+A closed subgroup of the affine group scheme `Spec H` is cut out by a Hopf ideal `I`, and it is
+**central** when conjugating by its points does nothing. This file states that condition on `I`,
+in the same coordinate style as normality: the coordinate morphism of conjugation agrees with the
+second projection modulo `I ⊗ H`, the ideal of `V(I) × G`.
+
+The condition is proved equivalent to the functorial one, that every point of `V(I)` is a central
+point of `G` in the sense of `TauCeti.HopfAlgebra.IsCentralPoint`. As for normality, one value
+algebra suffices to detect it, namely `(H ⧸ I) ⊗[R] H`, which carries the tautological point of
+the subgroup together with the tautological point of the ambient group.
+
+Two immediate consequences record that the notion behaves as expected. A central Hopf ideal is
+normal, and the zero Hopf ideal — the one cutting out the whole group — is central exactly when
+`H` is cocommutative, that is, exactly when `G` is commutative.
+
+Centrality is *upward* closed in the lattice of Hopf ideals, since a larger Hopf ideal cuts out a
+smaller closed subgroup. It is not closed downwards, so this file does not construct a smallest
+central Hopf ideal; the centre `Z(G)` as a closed subgroup scheme needs the extra work of
+producing a Hopf ideal from the cocommutativity defect of `H`.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsCentral`: centrality of a Hopf ideal, that is, of the closed subgroup
+  scheme it cuts out.
+
+## Main results
+
+* `TauCeti.CommHopfAlgCat.isCentral_iff_forall_isCentralPoint`: **a Hopf ideal is central exactly
+  when the points it cuts out are central points over every value algebra.**
+* `TauCeti.HopfIdeal.IsCentral.isNormal`: a central Hopf ideal is normal.
+* `TauCeti.HopfIdeal.isCentral_bot_iff_isCocomm`: the whole group is central exactly when the
+  coordinate Hopf algebra is cocommutative.
+* `TauCeti.CommHopfAlgCat.isCentral_augmentation`: the trivial subgroup is central.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §1.k and §2.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+The coordinate condition is the conjugation-triviality criterion for a central closed subgroup,
+and mirrors the normality criterion of `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal`. This is
+a prerequisite for the centre `Z(G)` in Layer 6, "Reductive and semisimple groups", of
+`TauCetiRoadmap/ReductiveGroups/README.md`.
+-/
+
+public section
+
+open TensorProduct WithConv
+
+namespace TauCeti
+
+universe u v
+
+namespace HopfIdeal
+
+variable {R : Type u} {H : Type v}
+variable [CommRing R] [CommRing H] [_root_.HopfAlgebra R H]
+
+/-- A Hopf ideal is **central** when the coordinate morphism of conjugation agrees with the
+inclusion of the acted-on variable modulo `I ⊗ H`.
+
+The first tensor factor of `TauCeti.HopfAlgebra.conjugationAlgHom` is the conjugating variable,
+so the left tensor ideal is the ideal of `V(I) × G`: the condition says that conjugating an
+arbitrary point of `G` by a point of the closed subgroup `V(I)` leaves it unchanged. -/
+def IsCentral (I : HopfIdeal R H) : Prop :=
+  ∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
+      Algebra.TensorProduct.includeRight x ∈ leftTensorIdeal (R := R) (H := H) I.toIdeal
+
+/-- Centrality restated as the defining ideal membership. -/
+theorem isCentral_def (I : HopfIdeal R H) :
+    I.IsCentral ↔
+      ∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
+        Algebra.TensorProduct.includeRight x ∈ leftTensorIdeal (R := R) (H := H) I.toIdeal :=
+  Iff.rfl
+
+/-- Centrality passes to larger Hopf ideals, which cut out smaller closed subgroups. -/
+theorem IsCentral.mono {I J : HopfIdeal R H} (hI : I.IsCentral) (hIJ : I ≤ J) : J.IsCentral :=
+  fun x ↦ leftTensorIdeal_mono R H (toIdeal_le_toIdeal.mpr hIJ) (hI x)
+
+/-- A supremum of Hopf ideals is central as soon as one of them is; the closed subgroup it cuts
+out is contained in the central one. -/
+theorem isCentral_iSup_of_isCentral {ι : Sort*} {I : ι → HopfIdeal R H} {j : ι}
+    (hj : (I j).IsCentral) : (⨆ i, I i).IsCentral :=
+  hj.mono (le_sSup (Set.mem_range_self j))
+
+/-- The coordinate morphism of conjugation, as a point, written with the underlying algebra maps
+of the two tensor-factor inclusions. -/
+private theorem toConv_conjugationAlgHom' :
+    toConv (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) =
+      toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)) *
+          toConv (Algebra.TensorProduct.includeRight (R := R) (A := H) (B := H)) *
+        (toConv (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := H) (B := H)))⁻¹ := by
+  simpa using HopfAlgebra.toConv_conjugationAlgHom (R := R) (H := H)
+
+/-- **The whole group is central exactly when its coordinate Hopf algebra is cocommutative.**
+The zero Hopf ideal cuts out all of `Spec H`, so its centrality says that conjugation is trivial,
+which for the convolution group of points is commutativity. -/
+theorem isCentral_bot_iff_isCocomm :
+    (⊥ : HopfIdeal R H).IsCentral ↔ _root_.Coalgebra.IsCocomm R H := by
+  rw [isCentral_def, ← HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm R H,
+    commute_iff_eq]
+  have hzero : leftTensorIdeal (R := R) (H := H) (⊥ : HopfIdeal R H).toIdeal = ⊥ := by
+    rw [bot_toIdeal, leftTensorIdeal_def, Ideal.map_bot]
+  have hiff : (∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
+        Algebra.TensorProduct.includeRight x ∈
+          leftTensorIdeal (R := R) (H := H) (⊥ : HopfIdeal R H).toIdeal) ↔
+      HopfAlgebra.conjugationAlgHom (R := R) (H := H) =
+        Algebra.TensorProduct.includeRight := by
+    rw [hzero]
+    refine ⟨fun hx ↦ AlgHom.ext fun x ↦ sub_eq_zero.mp (Ideal.mem_bot.mp (hx x)),
+      fun he x ↦ ?_⟩
+    rw [he]
+    simp
+  rw [hiff]
+  constructor
+  · intro he
+    refine mul_inv_eq_iff_eq_mul.mp ?_
+    rw [← toConv_conjugationAlgHom', he]
+  · intro hc
+    exact WithConv.toConv_injective
+      ((toConv_conjugationAlgHom').trans (mul_inv_eq_iff_eq_mul.mpr hc))
+
+end HopfIdeal
+
+namespace CommHopfAlgCat
+
+open CategoryTheory
+
+variable {R : Type u} [CommRing R]
+
+/-- Every point cut out by a central Hopf ideal is a central point of the ambient group, over
+every value algebra. -/
+theorem isCentralPoint_of_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (hI : I.IsCentral) (A : CommAlgCat.{v} R)
+    {g : HopfAlgebra.points (R := R) (H := H) A} (hg : g ∈ quotientPointsSubgroup H I A) :
+    HopfAlgebra.IsCentralPoint g := by
+  rw [HopfAlgebra.isCentralPoint_def]
+  intro B _ _ φ h
+  set g' : WithConv (↥H →ₐ[R] B) := AlgHom.mapValue φ g with hg'
+  have hker : HopfIdeal.leftTensorIdeal (R := R) (H := ↥H) I.toIdeal ≤
+      RingHom.ker (Algebra.TensorProduct.productMap g'.ofConv h.ofConv).toRingHom := by
+    rw [HopfIdeal.leftTensorIdeal_le_iff]
+    intro y hy
+    rw [Ideal.mem_comap, RingHom.mem_ker]
+    have hzero : g.ofConv y = 0 :=
+      (mem_quotientPointsSubgroup_iff H I A g).mp hg y (HopfIdeal.mem_toIdeal.mp hy)
+    simp [hg', hzero]
+  have hconj : ∀ x : ↥H, (g' * h * g'⁻¹).ofConv x = h.ofConv x := by
+    intro x
+    have heval := AlgHom.congr_fun
+      (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := ↥H) g' h) x
+    have hsub : Algebra.TensorProduct.productMap g'.ofConv h.ofConv
+        (HopfAlgebra.conjugationAlgHom (R := R) (H := ↥H) x -
+          Algebra.TensorProduct.includeRight x) = 0 :=
+      RingHom.mem_ker.mp (hker (hI x))
+    rw [map_sub, sub_eq_zero] at hsub
+    rw [← heval, AlgHom.comp_apply, hsub, Algebra.TensorProduct.includeRight_apply,
+      Algebra.TensorProduct.productMap_right_apply]
+  have : g' * h * g'⁻¹ = h :=
+    WithConv.ofConv_injective (AlgHom.ext hconj)
+  exact (commute_iff_eq _ _).mpr (mul_inv_eq_iff_eq_mul.mp this)
+
+/-- If the points cut out by a Hopf ideal are central over the value algebra `(H ⧸ I) ⊗ H`, the
+Hopf ideal is central. That single test algebra suffices: it carries the tautological point of
+the closed subgroup together with the tautological point of the ambient group. -/
+private theorem isCentral_of_isCentralPoint (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H)
+    (hcentral : ∀ g ∈ quotientPointsSubgroup H I
+        (CommAlgCat.of R (TensorProduct R (↥H ⧸ I.toIdeal) ↥H)),
+      HopfAlgebra.IsCentralPoint g) :
+    I.IsCentral := by
+  intro x
+  set Q := ↥H ⧸ I.toIdeal
+  set A : CommAlgCat.{v} R := CommAlgCat.of R (TensorProduct R Q ↥H)
+  set g : HopfAlgebra.points (R := R) (H := ↥H) A :=
+    quotientPointsHom H I A (toConv (Algebra.TensorProduct.includeLeft
+      (R := R) (S := R) (A := Q) (B := ↥H)))
+  set h : HopfAlgebra.points (R := R) (H := ↥H) A :=
+    toConv (Algebra.TensorProduct.includeRight (R := R) (A := Q) (B := ↥H)) with hhdef
+  have hgmem : g ∈ quotientPointsSubgroup H I A :=
+    quotientPointsHom_mem_quotientPointsSubgroup H I A _
+  have hcomm : g * h * g⁻¹ = h := by
+    have hgh := ((hcentral g hgmem).commute h).eq
+    rw [hgh, mul_assoc, mul_inv_cancel, mul_one]
+  have hgof : g.ofConv =
+      (Algebra.TensorProduct.includeLeft (R := R) (S := R) (A := Q) (B := ↥H)).comp
+        (Ideal.Quotient.mkₐ R I.toIdeal) :=
+    AlgHom.ext fun y ↦ quotientPointsHom_apply_apply H I A _ y
+  have hhof : h.ofConv =
+      (Algebra.TensorProduct.includeRight (R := R) (A := Q) (B := ↥H)) := by
+    rw [hhdef, ofConv_toConv]
+  have hproduct : Algebra.TensorProduct.productMap g.ofConv h.ofConv =
+      Algebra.TensorProduct.map (Ideal.Quotient.mkₐ R I.toIdeal) (AlgHom.id R ↥H) := by
+    rw [hgof, hhof]
+    refine Algebra.TensorProduct.ext ?_ ?_
+    · exact (Algebra.TensorProduct.productMap_left _ _).trans
+        (Algebra.TensorProduct.map_comp_includeLeft _ _).symm
+    · exact (Algebra.TensorProduct.productMap_right _ _).trans
+        (((Algebra.TensorProduct.map_comp_includeRight _ _).trans (AlgHom.comp_id _)).symm)
+  have heval := AlgHom.congr_fun
+    (HopfAlgebra.productMap_comp_conjugationAlgHom (R := R) (H := ↥H) g h) x
+  have hmem : HopfAlgebra.conjugationAlgHom (R := R) (H := ↥H) x -
+      Algebra.TensorProduct.includeRight x ∈
+      RingHom.ker (Algebra.TensorProduct.map (Ideal.Quotient.mkₐ R I.toIdeal)
+        (AlgHom.id R ↥H)) := by
+    rw [← hproduct, RingHom.mem_ker, map_sub, sub_eq_zero,
+      Algebra.TensorProduct.includeRight_apply,
+      Algebra.TensorProduct.productMap_right_apply, ← AlgHom.comp_apply, heval, hcomm]
+  rwa [HopfIdeal.ker_tensorProduct_map_quotient_id I.toIdeal] at hmem
+
+/-- **A Hopf ideal is central exactly when it cuts out central points over every value
+algebra.** -/
+theorem isCentral_iff_forall_isCentralPoint (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) :
+    I.IsCentral ↔
+      ∀ (A : CommAlgCat.{v} R), ∀ g ∈ quotientPointsSubgroup H I A,
+        HopfAlgebra.IsCentralPoint g :=
+  ⟨fun hI A _ hg ↦ isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hg,
+    fun hcentral ↦ isCentral_of_isCentralPoint H I (hcentral _)⟩
+
+/-- The points cut out by a central Hopf ideal lie in the centre of the functor of points. -/
+theorem quotientPointsSubgroup_le_centre (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (hI : I.IsCentral) (A : CommAlgCat.{v} R) :
+    quotientPointsSubgroup H I A ≤ HopfAlgebra.centre R ↥H ↥A :=
+  fun _ hg ↦ isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hg
+
+/-- A point killing the augmentation ideal is the identity point: the trivial subgroup has only
+the identity over every value algebra. -/
+theorem eq_one_of_mem_quotientPointsSubgroup_augmentation (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{v} R) {g : HopfAlgebra.points (R := R) (H := H) A}
+    (hg : g ∈ quotientPointsSubgroup H (HopfIdeal.augmentation R ↥H) A) : g = 1 := by
+  refine WithConv.ofConv_injective (AlgHom.ext fun x ↦ ?_)
+  have hx : x - algebraMap R ↥H (Coalgebra.counit (R := R) x) ∈
+      HopfIdeal.augmentation R ↥H := by
+    rw [HopfIdeal.mem_augmentation]
+    simp
+  have hzero := (mem_quotientPointsSubgroup_iff H _ A g).mp hg _ hx
+  rw [map_sub, sub_eq_zero] at hzero
+  rw [hzero, AlgHom.commutes]
+  exact (AlgHom.convOne_apply x).symm
+
+/-- **The trivial subgroup is central.** -/
+theorem isCentral_augmentation (H : _root_.CommHopfAlgCat.{v} R) :
+    (HopfIdeal.augmentation R ↥H).IsCentral := by
+  rw [isCentral_iff_forall_isCentralPoint]
+  intro A g hg
+  rw [eq_one_of_mem_quotientPointsSubgroup_augmentation H A hg]
+  exact HopfAlgebra.isCentralPoint_one
+
+end CommHopfAlgCat
+
+namespace HopfIdeal
+
+variable {R : Type u} [CommRing R]
+
+/-- **A central Hopf ideal is normal.** Its points commute with every point of the ambient group
+over the same value algebra, so they form a normal subgroup there, and normality of a Hopf ideal
+is detected pointwise. -/
+theorem IsCentral.isNormal {H : _root_.CommHopfAlgCat.{v} R} {I : HopfIdeal R H}
+    (hI : I.IsCentral) : I.IsNormal := by
+  rw [CommHopfAlgCat.isNormal_iff_quotientPointsSubgroup_normal]
+  intro A
+  refine ⟨fun n hn g ↦ ?_⟩
+  have hcom :=
+    (CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hn).commute g
+  have : g * n * g⁻¹ = n := by
+    rw [← hcom.eq, mul_assoc, mul_inv_cancel, mul_one]
+  rwa [this]
+
+end HopfIdeal
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -28,7 +28,7 @@ normal, and the zero Hopf ideal — the one cutting out the whole group — is c
 
 Centrality is *upward* closed in the lattice of Hopf ideals, since a larger Hopf ideal cuts out a
 smaller closed subgroup. It is not closed downwards, so this file does not construct a smallest
-central Hopf ideal; the centre `Z(G)` as a closed subgroup scheme needs the extra work of
+central Hopf ideal; the center `Z(G)` as a closed subgroup scheme needs the extra work of
 producing a Hopf ideal from the cocommutativity defect of `H`.
 
 ## Main declarations
@@ -52,7 +52,7 @@ producing a Hopf ideal from the cocommutativity defect of `H`.
 
 The coordinate condition is the conjugation-triviality criterion for a central closed subgroup,
 and mirrors the normality criterion of `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal`. This is
-a prerequisite for the centre `Z(G)` in Layer 6, "Reductive and semisimple groups", of
+a prerequisite for the center `Z(G)` in Layer 6, "Reductive and semisimple groups", of
 `TauCetiRoadmap/ReductiveGroups/README.md`.
 -/
 
@@ -79,13 +79,6 @@ def IsCentral (I : HopfIdeal R H) : Prop :=
   ∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
       Algebra.TensorProduct.includeRight x ∈ leftTensorIdeal (R := R) (H := H) I.toIdeal
 
-/-- Centrality restated as the defining ideal membership. -/
-theorem isCentral_def (I : HopfIdeal R H) :
-    I.IsCentral ↔
-      ∀ x : H, HopfAlgebra.conjugationAlgHom (R := R) (H := H) x -
-        Algebra.TensorProduct.includeRight x ∈ leftTensorIdeal (R := R) (H := H) I.toIdeal :=
-  Iff.rfl
-
 /-- Centrality passes to larger Hopf ideals, which cut out smaller closed subgroups. -/
 theorem IsCentral.mono {I J : HopfIdeal R H} (hI : I.IsCentral) (hIJ : I ≤ J) : J.IsCentral :=
   fun x ↦ leftTensorIdeal_mono R H (toIdeal_le_toIdeal.mpr hIJ) (hI x)
@@ -101,7 +94,7 @@ The zero Hopf ideal cuts out all of `Spec H`, so its centrality says that conjug
 which for the convolution group of points is commutativity. -/
 theorem isCentral_bot_iff_isCocomm :
     (⊥ : HopfIdeal R H).IsCentral ↔ _root_.Coalgebra.IsCocomm R H := by
-  rw [isCentral_def, ← HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm R H,
+  rw [IsCentral, ← HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm R H,
     commute_iff_eq]
   have hzero : leftTensorIdeal (R := R) (H := H) (⊥ : HopfIdeal R H).toIdeal = ⊥ := by
     rw [bot_toIdeal, leftTensorIdeal_def, Ideal.map_bot]
@@ -229,11 +222,12 @@ theorem isCentral_iff_forall_isCentralPoint (H : _root_.CommHopfAlgCat.{v} R)
   ⟨fun hI A _ hg ↦ isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hg,
     fun hcentral ↦ isCentral_of_isCentralPoint H I (hcentral _)⟩
 
-/-- The points cut out by a central Hopf ideal lie in the centre of the functor of points. -/
-theorem quotientPointsSubgroup_le_centre (H : _root_.CommHopfAlgCat.{v} R)
+/-- The points cut out by a central Hopf ideal lie in the center of the functor of points. -/
+theorem quotientPointsSubgroup_le_center (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (hI : I.IsCentral) (A : CommAlgCat.{v} R) :
-    quotientPointsSubgroup H I A ≤ HopfAlgebra.centre R ↥H ↥A :=
-  fun _ hg ↦ isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hg
+    quotientPointsSubgroup H I A ≤ HopfAlgebra.center R ↥H ↥A :=
+  fun _ hg ↦ HopfAlgebra.mem_center.mpr
+    (isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hg)
 
 /-- A point killing the augmentation ideal is the identity point: the trivial subgroup has only
 the identity over every value algebra. -/

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean
@@ -234,6 +234,19 @@ theorem ker_tensorProduct_map_id_quotient (I : Ideal H) :
   rw [rightTensorIdeal_def]
   rfl
 
+/-- The kernel of tensoring the quotient map on the left is the left tensor ideal. -/
+theorem ker_tensorProduct_map_quotient_id (I : Ideal H) :
+    RingHom.ker (Algebra.TensorProduct.map (Ideal.Quotient.mkₐ R I) (AlgHom.id R H)) =
+      leftTensorIdeal (R := R) (H := H) I := by
+  rw [Algebra.TensorProduct.rTensor_ker (C := H) (Ideal.Quotient.mkₐ R I)
+    (Ideal.Quotient.mkₐ_surjective R I)]
+  rw [← RingHom.ker_coe_toRingHom (Ideal.Quotient.mkₐ R I),
+    Ideal.Quotient.mkₐ_ker R I]
+  -- `rTensor_ker` uses the algebra-hom coercion for `includeLeft`, while
+  -- `leftTensorIdeal` uses its `toRingHom`; after unfolding they are definitionally equal.
+  rw [leftTensorIdeal_def]
+  rfl
+
 end HopfIdeal
 
 end TensorIdealQuotient


### PR DESCRIPTION
This PR defines centrality for the points of an affine group scheme and for its closed subgroup schemes, and proves the two notions agree. A point `g ∈ G(A)` is central when its image in `G(B)` commutes with every `B`-point of `G`, for every `A`-algebra `B`; the roadmap's own warning against reading a group-scheme condition off the points over one algebra applies here, since an element of the abstract group `G(A)` can commute with all of `G(A)` and still fail to be central. `TauCeti.HopfAlgebra.isCentralPoint_iff_commute_includeRight` shows the quantifier is harmless: the single value algebra `A ⊗[R] H` decides the question, because an algebra map out of `A ⊗[R] H` is exactly a pair consisting of an `A`-algebra and a point of `G` over it. Central points form a subgroup `TauCeti.HopfAlgebra.center R H A` of `G(A)`, natural in `A` and contained in — generally strictly — the abstract centre of `G(A)`. Specialized to the tautological point of `G` over `H` itself, the criterion says that `G` is commutative exactly when `H` is cocommutative, which is proved by identifying the two convolution products of the tensor-factor points with the comultiplication and its flip.

On the coordinate side, `TauCeti.HopfIdeal.IsCentral` says that the conjugation morphism `H →ₐ[R] H ⊗[R] H` agrees with the inclusion of the acted-on variable modulo `I ⊗ H`, the ideal of `V(I) × G`; this is the exact analogue of the merged normality criterion `TauCeti.HopfIdeal.IsNormal` and is proved equivalent to the functorial condition in `TauCeti.CommHopfAlgCat.isCentral_iff_forall_isCentralPoint`, with the single test algebra `(H ⧸ I) ⊗[R] H` carrying the tautological point of the subgroup alongside the tautological point of the ambient group. Three consequences record that the notion behaves: a central Hopf ideal is normal, the zero Hopf ideal is central exactly when `H` is cocommutative, and the augmentation ideal — the trivial subgroup — is always central. Centrality is upward closed in the lattice of Hopf ideals, since a larger Hopf ideal cuts out a smaller closed subgroup.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 6, milestone "Reductive and semisimple groups", which asks to "Develop the radical `R(G)`, the centre `Z(G)`, the derived group `G_der`, **central isogenies**, and the simply connected and adjoint forms". This is the most effective unclaimed current step on that milestone: the merged `TauCeti.GroupScheme.HasCentralKernel` states in its own module docstring that its functorial definition "is equivalent, by Yoneda, to factorization of the kernel through the scheme-theoretic centre once that closed subgroup has been constructed", and no such notion existed; meanwhile the open Layer 6 work occupies distinct pieces — #3712 and #3757 package reductive and semisimple group schemes, #3548 packages linear reductivity, and #3677 builds the derived subgroup — and each of those PR bodies lists the centre as still outstanding. After this PR the milestone still needs the centre `Z(G)` itself as a closed subgroup scheme, which requires producing a Hopf ideal from the cocommutativity defect of `H` (centrality is not closed downwards in the Hopf-ideal lattice, so no smallest central Hopf ideal is available for free), together with the radical, the structural properties of the derived group, and the simply connected and adjoint forms.

New modules: `TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean` (288 lines) and `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean` (285 lines). `TauCeti/Algebra/HopfAlgebra/HopfIdeal/Basic.lean` grows by 14 lines with `ker_tensorProduct_map_quotient_id`, the left-hand companion of the existing `ker_tensorProduct_map_id_quotient`, placed beside it. No declaration is renamed, moved or deleted. The construction reuses Tau Ceti's conjugation coordinate morphism, Hopf-ideal tensor ideals and quotient-points API, and the identification of comultiplication with the convolution product of the tensor inclusions, together with Mathlib's convolution monoids, `Algebra.TensorProduct.productMap` and `rTensor_ker`. No Mathlib infrastructure is vendored. The mathematics follows J. S. Milne, *Algebraic Groups* (2017), §1.k and §2, and W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2, as credited in both module docstrings.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"central-closed-subgroup-scheme"}-->

🤖 Prepared with Claude Code

