### PR TITLE
feat: construct the Coxeter functor of a quiver

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Admissible.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Admissible.lean
@@ -32,6 +32,8 @@ for every finite acyclic quiver.
   forwards, whose entries carry no loop and emit no arrow off the list, is sink-admissible, with
   `TauCeti.Quiver.isSinkAdmissible_of_pairwise_of_forall_mem` the case of a list of all the
   vertices, where the last hypothesis — that no arrow leaves the list — is automatic.
+* `TauCeti.Quiver.IsSinkAdmissible.isEmpty_hom_self`: no vertex of a repetition-free
+  sink-admissible list carries a loop.
 
 ## References
 
@@ -172,6 +174,21 @@ theorem isSinkAdmissible_of_pairwise_of_forall_mem (q : _root_.Quiver.{v} V) {l 
     (hp : l.Pairwise fun x y ↦ IsEmpty (@_root_.Quiver.Hom V q x y)) :
     IsSinkAdmissible q l :=
   isSinkAdmissible_of_pairwise q hnd (fun x _ ↦ hloop x) hp fun _ _ b hb ↦ absurd (hall b) hb
+
+/-! ### Loops along a sink-admissible ordering -/
+
+/-- **No vertex of a repetition-free sink-admissible list carries a loop.** At its own stage the
+vertex is a sink of the reflected quiver, so it carries no loop there; and reflecting along a
+repetition-free prefix leaves the loops at any vertex alone
+(`TauCeti.Quiver.hom_reflectList`), because both ends of a loop lie on the same side of the
+prefix. This is the looplessness hypothesis under which the composite of the simple reflections
+along the list preserves the Tits form. -/
+theorem IsSinkAdmissible.isEmpty_hom_self {q : _root_.Quiver.{v} V} {l : List V} (hnd : l.Nodup)
+    (hl : IsSinkAdmissible q l) {i : V} (hi : i ∈ l) :
+    IsEmpty (@_root_.Quiver.Hom V q i i) := by
+  obtain ⟨t, u, rfl⟩ := List.append_of_mem hi
+  rw [← hom_reflectList q (List.Nodup.of_append_left hnd) (a := i) (b := i) Iff.rfl]
+  exact @IsSink.isEmpty_hom_self V (reflectList q t) i (hl t u i rfl)
 
 /-! ### Existence for a finite acyclic quiver -/
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
@@ -9,7 +9,6 @@ public import TauCeti.RepresentationTheory.Quiver.Reflection.Admissible
 public import TauCeti.RepresentationTheory.Quiver.Reflection.Coxeter
 public import TauCeti.RepresentationTheory.Quiver.Reflection.EulerForm
 public import TauCeti.RepresentationTheory.Quiver.Reflection.FullyFaithful
-public import TauCeti.RepresentationTheory.Quiver.Reflection.Iterate
 
 /-!
 # The Coxeter functor
@@ -160,15 +159,18 @@ theorem isZero_reflectionFunctorList_obj :
 
 /-! ### The action on an indecomposable representation -/
 
-/-- **A composite of reflection functors on an indecomposable representation.** Either no stage
-meets the vertex simple at its own sink -- and then the composite is again indecomposable, its
-dimension vector the corresponding product of simple reflections applied to the dimension vector
-of `M` -- or some stage does, and the composite is the zero representation.
+/-- **A composite of reflection functors on an indecomposable representation.** Either the
+composite is again indecomposable, and then its dimension vector is the corresponding product of
+simple reflections applied to the dimension vector of `M`, or the composite is the zero
+representation.
 
-Both cases occur: for example, the vertex simple `Sᵢ` at the first entry is annihilated by
-`TauCeti.isZero_reflectRep`. The simple reflections on the right are those of the *original*
-quiver, by `TauCeti.vertexPreReflectionList_reflectAt`, even though the successive stages act on
-successively reflected quivers. -/
+The proof runs the dichotomy `TauCeti.incomingSum_surjective_or_forall_subsingleton` at each
+stage: a stage meeting the vertex simple at its own sink annihilates the representation
+(`TauCeti.isZero_reflectRep`), which is what lands in the second branch, while every other stage
+preserves indecomposability and reflects the dimension vector. Both branches occur -- the vertex
+simple at the first entry falls into the second. The simple reflections on the right are those of
+the *original* quiver, by `TauCeti.vertexPreReflectionList_reflectAt`, even though the successive
+stages act on successively reflected quivers. -/
 theorem indecomposable_and_dimVector_reflectionFunctorList_or_isZero [DecidableEq V] :
     ∀ (l : List V) (q : _root_.Quiver.{w} V)
       (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
@@ -293,17 +295,6 @@ noncomputable def coxeterFunctor (k : Type u) {V : Type v} [fld : Field k] [fV :
     @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld q :=
   transportCodomain (Quiver.reflectList_eq_self q hnd hall) (reflectionFunctorList k l q hq hl)
 
-private theorem coxeterFunctor_def_aux (q : _root_.Quiver.{w} V)
-    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
-    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l) :
-    coxeterFunctor.{u, v, w, x} k q hq hnd hall hl =
-      Eq.mp (congrArg (fun r : _root_.Quiver.{w} V ↦
-        @QuiverRep.{u, v, w, max v w x} k V fld q ⥤
-          @QuiverRep.{u, v, w, max v w x} k V fld r)
-        (Quiver.reflectList_eq_self q hnd hall)) (reflectionFunctorList k l q hq hl) := by
-  change transportCodomain _ _ = _
-  exact transportCodomain_eq_eqMp _ _
-
 /-- The Coxeter functor is the reflection-functor composite transported along the equality between
 the iteratively reflected quiver and the original quiver. -/
 theorem coxeterFunctor_def (q : _root_.Quiver.{w} V)
@@ -314,7 +305,8 @@ theorem coxeterFunctor_def (q : _root_.Quiver.{w} V)
         @QuiverRep.{u, v, w, max v w x} k V fld q ⥤
           @QuiverRep.{u, v, w, max v w x} k V fld r)
         (Quiver.reflectList_eq_self q hnd hall)) (reflectionFunctorList k l q hq hl) :=
-  coxeterFunctor_def_aux q hq hnd hall hl
+  transportCodomain_eq_eqMp (Quiver.reflectList_eq_self q hnd hall)
+    (reflectionFunctorList k l q hq hl)
 
 /-- Transporting the reflection-functor composite back to the original quiver does not change its
 dimension vector after coercion to integers. -/

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
@@ -1,0 +1,384 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Reflection.Admissible
+public import TauCeti.RepresentationTheory.Quiver.Reflection.Coxeter
+public import TauCeti.RepresentationTheory.Quiver.Reflection.EulerForm
+public import TauCeti.RepresentationTheory.Quiver.Reflection.FullyFaithful
+public import TauCeti.RepresentationTheory.Quiver.Reflection.Iterate
+
+/-!
+# The Coxeter functor
+
+Reflecting a quiver at a sink reverses the arrows there, and the Bernstein-Gelfand-Ponomarev
+reflection functor `C⁺ᵢ` carries its representations to representations of the reflected quiver
+(`TauCeti.reflectionFunctor`). Reflecting at the successive entries of a **sink-admissible** list
+-- each entry a sink of the quiver its predecessors produce -- composes those functors, and along
+a sink-admissible **ordering**, a repetition-free list of *all* the vertices, the quiver comes
+back to itself (`TauCeti.Quiver.reflectList_eq_self`). The resulting endofunctor is the **Coxeter
+functor** of this file, `TauCeti.coxeterFunctor`, and on dimension vectors it realizes the Coxeter
+transformation `TauCeti.vertexPreReflectionList` of the ordering.
+
+Both halves of the Layer 4 identity `dim (C⁺ M) = c · dim M` are proved here for an
+indecomposable representation with finite-dimensional vertex spaces, as a dichotomy: either no
+stage of the composite meets the vertex simple at its own sink -- and then the composite is
+indecomposable and its dimension vector is the predicted one -- or some stage does, and the
+composite is the zero representation. The dichotomy is what the statement needs: reflection at a
+sink `i` annihilates `Sᵢ` (`TauCeti.isZero_reflectRep`) instead of reflecting its dimension
+vector, and an indecomposable representation admits no other exception
+(`TauCeti.incomingSum_surjective_or_forall_subsingleton`).
+
+## Main definitions
+
+* `TauCeti.reflectionFunctorList`: the composite of the reflection functors along a
+  sink-admissible list, from the representations of `q` to those of
+  `TauCeti.Quiver.reflectList q l`.
+* `TauCeti.coxeterFunctor`: the Coxeter functor `C⁺` of a sink-admissible ordering, an
+  endofunctor of the representations of `q`.
+
+## Main results
+
+* `TauCeti.reflectionFunctorList_nil` and `TauCeti.reflectionFunctorList_cons`: the composite is
+  the identity on the empty list and peels off one reflection functor at a time.
+* `TauCeti.isZero_reflectionFunctorList_obj` and `TauCeti.isZero_coxeterFunctor_obj`: the zero
+  representation is carried to the zero representation.
+* `TauCeti.vertexPreReflectionList_reflectAt`: reflecting the quiver structure changes no simple
+  reflection on dimension vectors, so the successive stages of the composite -- which act on
+  successively reflected quivers -- realize the simple reflections of the *original* quiver.
+* `TauCeti.indecomposable_and_dimVector_reflectionFunctorList_or_isZero` and
+  `TauCeti.indecomposable_and_dimVector_coxeterFunctor_or_isZero`: the dichotomy above, for a
+  general sink-admissible list and for the Coxeter functor.
+* `TauCeti.titsForm_dimVector_coxeterFunctor_obj`: the Coxeter functor preserves the Tits form of
+  the dimension vector of an indecomposable representation it does not annihilate.
+
+## Implementation notes
+
+The quiver structure is carried as an *explicit argument* rather than as an instance, because the
+recursion changes it: the vertex type is fixed and the arrows are reversed, so the recursion is on
+the `Quiver` structure `TauCeti.Quiver.reflectAt`, not on a type synonym like
+`TauCeti.Quiver.Reflect`, whose iteration would change the type at each step and so leave the
+range of structural recursion. `TauCeti.Quiver.fintypeHomReflectAt` carries arrow-finiteness along
+with it.
+
+A consequence is that two `Quiver` structures on one vertex type occur in the same statement, and
+the one in scope as a local instance is not always the intended one. Every statement below
+therefore supplies the structure explicitly to `TauCeti.dimVector`, `TauCeti.titsForm` and
+`TauCeti.vertexPreReflectionList`; vanishing is stated as `CategoryTheory.Limits.IsZero` of the
+representation rather than vertexwise, since the vertexwise form would need the structure supplied
+to `CategoryTheory.Functor.obj` as well.
+
+The Coxeter functor is the composite transported along `TauCeti.Quiver.reflectList_eq_self`, an
+equality of `Quiver` structures; the private `transportCodomain` names that transport and the
+three lemmas after it are its whole interface.
+
+The sink-admissible ordering is an argument of `TauCeti.coxeterFunctor` rather than something
+chosen from `TauCeti.Quiver.IsAcyclic.exists_isSinkAdmissible`: the Coxeter transformation the
+functor realizes depends on the ordering, so a consumer that needs to name it must be able to name
+the ordering too.
+
+## References
+
+This implements the “Coxeter functor” target of Layer 4 of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, the engine of that
+roadmap's Layer 5 reflection induction. See Bernstein--Gelfand--Ponomarev, *Coxeter functors and
+Gabriel's theorem*, and Assem--Simson--Skowroński, *Elements of the Representation Theory of
+Associative Algebras* I, VII.5.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+open _root_.TauCeti.Quiver
+
+universe u v w x
+
+namespace Quiver
+
+variable {V : Type v}
+
+/-- The arrows of a reflected quiver structure are finite in number when those of the given one
+are: they are the arrows of `TauCeti.Quiver.reflectHom`. -/
+@[instance_reducible]
+noncomputable def fintypeHomReflectAt (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) (i a b : V) :
+    Fintype (@_root_.Quiver.Hom V (reflectAt q i) a b) :=
+  @instFintypeReflectHom V q hq i a b
+
+end Quiver
+
+/-! ### The composite of the reflection functors along a sink-admissible list -/
+
+/-- **The composite of the reflection functors along a sink-admissible list.** Each entry of the
+list is a sink of the quiver its predecessors produce, so the reflection functors at the
+successive entries compose; the result carries the representations of `q` to those of
+`TauCeti.Quiver.reflectList q l`.
+
+The quiver structure is an explicit argument rather than an instance because it is what the
+recursion moves: the vertex type stays fixed while the arrows are reversed. -/
+@[expose]
+noncomputable def reflectionFunctorList (k : Type u) {V : Type v} [fld : Field k] [fV : Fintype V] :
+    ∀ (l : List V) (q : _root_.Quiver.{w} V)
+      (_hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)),
+      Quiver.IsSinkAdmissible q l →
+      (@QuiverRep.{u, v, w, max v w x} k V fld q ⥤
+        @QuiverRep.{u, v, w, max v w x} k V fld (Quiver.reflectList q l))
+  | [], _, _, _ => 𝟭 _
+  | i :: l, q, hq, hl => by
+      letI := q
+      letI := hq
+      exact reflectionFunctor i (Quiver.isSinkAdmissible_cons.mp hl).1 ⋙
+        reflectionFunctorList k l (Quiver.reflectAt q i) (Quiver.fintypeHomReflectAt q hq i)
+          (Quiver.isSinkAdmissible_cons.mp hl).2
+
+variable {k : Type u} {V : Type v} [fld : Field k] [fV : Fintype V]
+
+@[simp]
+theorem reflectionFunctorList_nil (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
+    (hl : Quiver.IsSinkAdmissible q []) :
+    reflectionFunctorList.{u, v, w, x} k [] q hq hl = 𝟭 _ :=
+  rfl
+
+@[simp]
+theorem reflectionFunctorList_cons (i : V) (l : List V) (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
+    (hl : Quiver.IsSinkAdmissible q (i :: l)) :
+    reflectionFunctorList.{u, v, w, x} k (i :: l) q hq hl
+      = @reflectionFunctor k V fld q fV hq i (Quiver.isSinkAdmissible_cons.mp hl).1 ⋙
+        reflectionFunctorList k l (Quiver.reflectAt q i) (Quiver.fintypeHomReflectAt q hq i)
+          (Quiver.isSinkAdmissible_cons.mp hl).2 :=
+  rfl
+
+/-- **A composite of reflections annihilates the zero representation.** Only the vanishing of the
+vertex spaces is used at each stage, through `TauCeti.isZero_reflectRep`. -/
+theorem isZero_reflectionFunctorList_obj :
+    ∀ (l : List V) (q : _root_.Quiver.{w} V)
+      (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
+      (hl : Quiver.IsSinkAdmissible q l) (M : @QuiverRep.{u, v, w, max v w x} k V fld q),
+      Limits.IsZero M → Limits.IsZero ((reflectionFunctorList k l q hq hl).obj M)
+  | [], q, hq, hl, M, hM => by
+      rw [reflectionFunctorList_nil]
+      exact hM
+  | i :: l, q, hq, hl, M, hM => by
+      let : _root_.Quiver.{w} V := q
+      let : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b) := hq
+      rw [reflectionFunctorList_cons]
+      refine isZero_reflectionFunctorList_obj l (Quiver.reflectAt q i)
+        (Quiver.fintypeHomReflectAt q hq i) (Quiver.isSinkAdmissible_cons.mp hl).2
+        ((reflectionFunctor i (Quiver.isSinkAdmissible_cons.mp hl).1).obj M) ?_
+      rw [reflectionFunctor_obj]
+      exact isZero_reflectRep M (Quiver.isSinkAdmissible_cons.mp hl).1 fun a _ ↦
+        ModuleCat.subsingleton_of_isZero ((Functor.isZero_iff M).mp hM a)
+
+/-! ### The simple reflections do not see the orientation -/
+
+/-- Reflecting the quiver structure at a vertex changes no simple reflection on dimension
+vectors: these are built from the polarized Tits form, which depends only on the underlying graph.
+This is `TauCeti.vertexPreReflection_reflect_apply` read on the iterating form
+`TauCeti.Quiver.reflectAt`. -/
+theorem vertexPreReflection_reflectAt [DecidableEq V] (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) (i j : V) :
+    @vertexPreReflection V (Quiver.reflectAt q i) fV (Quiver.fintypeHomReflectAt q hq i) _ j
+      = @vertexPreReflection V q fV hq _ j := by
+  let : _root_.Quiver.{w} V := q
+  let : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b) := hq
+  refine LinearMap.ext fun d ↦ funext fun t ↦ ?_
+  exact vertexPreReflection_reflect_apply (V := V) i j d t
+
+/-- The composite of the simple reflections along a word is unchanged by reflecting the quiver
+structure at a vertex, by `TauCeti.vertexPreReflection_reflectAt` at each letter. This is what
+lets the Coxeter transformation of the original quiver be read off a composite of reflection
+functors, whose successive stages act on the dimension vectors of successively reflected
+quivers. -/
+theorem vertexPreReflectionList_reflectAt [DecidableEq V] (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) (i : V) (l : List V) :
+    @vertexPreReflectionList V (Quiver.reflectAt q i) fV (Quiver.fintypeHomReflectAt q hq i) _ l
+      = @vertexPreReflectionList V q fV hq _ l := by
+  induction l with
+  | nil => rw [vertexPreReflectionList_nil, vertexPreReflectionList_nil]
+  | cons j l ih =>
+    rw [vertexPreReflectionList_cons, vertexPreReflectionList_cons, ih,
+      vertexPreReflection_reflectAt]
+
+/-! ### The action on an indecomposable representation -/
+
+/-- **A composite of reflection functors on an indecomposable representation.** Either no stage
+meets the vertex simple at its own sink -- and then the composite is again indecomposable, its
+dimension vector the corresponding product of simple reflections applied to the dimension vector
+of `M` -- or some stage does, and the composite is the zero representation.
+
+The dichotomy is genuine and both cases occur: the second is exactly the vertex simple `Sᵢ` at the
+first entry, which `TauCeti.isZero_reflectRep` annihilates. The simple reflections on the right are
+those of the *original* quiver, by `TauCeti.vertexPreReflectionList_reflectAt`, even though the
+successive stages act on successively reflected quivers. -/
+theorem indecomposable_and_dimVector_reflectionFunctorList_or_isZero [DecidableEq V] :
+    ∀ (l : List V) (q : _root_.Quiver.{w} V)
+      (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
+      (hl : Quiver.IsSinkAdmissible q l) (M : @QuiverRep.{u, v, w, max v w x} k V fld q),
+      Indecomposable M → (∀ a : V, FiniteDimensional k (M.obj a)) →
+      (Indecomposable ((reflectionFunctorList k l q hq hl).obj M) ∧
+            (fun j : V ↦ (@dimVector k V fld (Quiver.reflectList q l)
+                ((reflectionFunctorList k l q hq hl).obj M) j : ℤ))
+              = @vertexPreReflectionList V q fV hq _ l fun j ↦ (@dimVector k V fld q M j : ℤ))
+        ∨ Limits.IsZero ((reflectionFunctorList k l q hq hl).obj M)
+  | [], q, hq, hl, M, hM, _ => by
+      rw [reflectionFunctorList_nil, vertexPreReflectionList_nil]
+      exact Or.inl ⟨hM, rfl⟩
+  | i :: l, q, hq, hl, M, hM, hfd => by
+      let : _root_.Quiver.{w} V := q
+      let : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b) := hq
+      obtain ⟨hi, hl'⟩ := Quiver.isSinkAdmissible_cons.mp hl
+      have key : (reflectionFunctorList.{u, v, w, x} k (i :: l) q hq hl).obj M
+          = (reflectionFunctorList k l (Quiver.reflectAt q i)
+              (Quiver.fintypeHomReflectAt q hq i) hl').obj (reflectRep M hi) := by
+        rw [reflectionFunctorList_cons]
+        exact congrArg _ (reflectionFunctor_obj i hi M)
+      rw [key]
+      rcases incomingSum_surjective_or_forall_subsingleton hi hM with hs | hsub
+      · have hRdim : (fun j : V ↦
+              (@dimVector k V fld (Quiver.reflectAt q i) (reflectRep M hi) j : ℤ))
+            = @vertexPreReflection V q fV hq _ i fun j ↦ (@dimVector k V fld q M j : ℤ) :=
+          dimVector_reflectRep M hi (fun e ↦ hfd e.1) hs
+        rcases indecomposable_and_dimVector_reflectionFunctorList_or_isZero l
+            (Quiver.reflectAt q i) (Quiver.fintypeHomReflectAt q hq i) hl' (reflectRep M hi)
+            (indecomposable_reflectRep hi hM hs)
+            (finiteDimensional_reflectRep_obj M hi hfd) with ⟨h1, h2⟩ | h
+        · refine Or.inl ⟨h1, ?_⟩
+          calc (fun j : V ↦ (@dimVector k V fld (Quiver.reflectList q (i :: l))
+                ((reflectionFunctorList k l (Quiver.reflectAt q i)
+                  (Quiver.fintypeHomReflectAt q hq i) hl').obj (reflectRep M hi)) j : ℤ))
+              = @vertexPreReflectionList V (Quiver.reflectAt q i) fV
+                  (Quiver.fintypeHomReflectAt q hq i) _ l
+                  (fun j : V ↦
+                    (@dimVector k V fld (Quiver.reflectAt q i) (reflectRep M hi) j : ℤ)) := h2
+            _ = @vertexPreReflectionList V q fV hq _ l
+                  (@vertexPreReflection V q fV hq _ i
+                    fun j ↦ (@dimVector k V fld q M j : ℤ)) := by
+                  rw [vertexPreReflectionList_reflectAt, hRdim]
+            _ = @vertexPreReflectionList V q fV hq _ (i :: l)
+                  fun j ↦ (@dimVector k V fld q M j : ℤ) :=
+                  (vertexPreReflectionList_apply_cons V i l _).symm
+        · exact Or.inr h
+      · exact Or.inr (isZero_reflectionFunctorList_obj l (Quiver.reflectAt q i)
+          (Quiver.fintypeHomReflectAt q hq i) hl' (reflectRep M hi)
+          (isZero_reflectRep M hi hsub))
+
+/-! ### The Coxeter functor -/
+
+/-- A functor into the representations of the quiver structure `r`, read as a functor into the
+representations of `q` along an equality `r = q`. It is only used to bring the composite of the
+reflection functors along a sink-admissible *ordering* back to its own quiver, where
+`TauCeti.Quiver.reflectList_eq_self` supplies the equality; the three lemmas below are its whole
+interface, and each is the transport applied to a reflexive equality. -/
+private noncomputable def transportCodomain {q r : _root_.Quiver.{w} V} (h : r = q)
+    (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r) :
+    @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld q :=
+  h ▸ F
+
+omit fV in
+private theorem indecomposable_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h : r = q)
+    (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
+    Indecomposable ((transportCodomain h F).obj M) ↔ Indecomposable (F.obj M) := by
+  subst h
+  exact Iff.rfl
+
+omit fV in
+private theorem isZero_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h : r = q)
+    (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
+    Limits.IsZero ((transportCodomain h F).obj M) ↔ Limits.IsZero (F.obj M) := by
+  subst h
+  exact Iff.rfl
+
+omit fV in
+private theorem dimVector_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h : r = q)
+    (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
+    @dimVector k V fld q ((transportCodomain h F).obj M) = @dimVector k V fld r (F.obj M) := by
+  subst h
+  rfl
+
+/-- **The Coxeter functor** `C⁺`: the composite of the Bernstein-Gelfand-Ponomarev reflection
+functors at the successive vertices of a sink-admissible *ordering* of the vertices -- a
+sink-admissible list that repeats no vertex and contains every one of them. Reflecting once at
+every vertex restores the quiver structure (`TauCeti.Quiver.reflectList_eq_self`), so unlike a
+general composite of reflection functors this is an *endo*functor of the representations of `q`.
+
+Every finite acyclic quiver has such an ordering, by
+`TauCeti.Quiver.IsAcyclic.exists_isSinkAdmissible`; the ordering is an argument rather than a
+choice, since the Coxeter transformation it realizes on dimension vectors,
+`TauCeti.vertexPreReflectionList`, depends on it. -/
+noncomputable def coxeterFunctor (k : Type u) {V : Type v} [fld : Field k] [fV : Fintype V]
+    (q : _root_.Quiver.{w} V) (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
+    {l : List V} (hnd : l.Nodup) (hall : ∀ v : V, v ∈ l)
+    (hl : Quiver.IsSinkAdmissible q l) :
+    @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld q :=
+  transportCodomain (Quiver.reflectList_eq_self q hnd hall) (reflectionFunctorList k l q hq hl)
+
+/-- **The Coxeter functor annihilates the zero representation.** -/
+theorem isZero_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
+    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) (hM : Limits.IsZero M) :
+    Limits.IsZero ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) :=
+  (isZero_transportCodomain_obj _ _ M).mpr (isZero_reflectionFunctorList_obj l q hq hl M hM)
+
+/-- **The Coxeter functor on an indecomposable representation.** Either it is again
+indecomposable, with dimension vector the Coxeter transformation
+`TauCeti.vertexPreReflectionList` of the ordering applied to the dimension vector of `M`, or it is
+the zero representation -- which happens exactly when some stage of the composite meets the vertex
+simple at its own sink. This is the Layer 4 statement `dim (C⁺ M) = c · dim M` for the Coxeter
+element `c`, with the boundary case named. -/
+theorem indecomposable_and_dimVector_coxeterFunctor_or_isZero [DecidableEq V]
+    (q : _root_.Quiver.{w} V) (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
+    {l : List V} (hnd : l.Nodup) (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) (hM : Indecomposable M)
+    (hfd : ∀ a : V, FiniteDimensional k (M.obj a)) :
+    (Indecomposable ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) ∧
+          (fun j : V ↦
+              (@dimVector k V fld q ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) j : ℤ))
+            = @vertexPreReflectionList V q fV hq _ l fun j ↦ (@dimVector k V fld q M j : ℤ))
+      ∨ Limits.IsZero ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) := by
+  rcases indecomposable_and_dimVector_reflectionFunctorList_or_isZero l q hq hl M hM hfd with
+    ⟨h1, h2⟩ | h
+  · refine Or.inl ⟨(indecomposable_transportCodomain_obj _ _ M).mpr h1, ?_⟩
+    rw [show (fun j : V ↦
+        (@dimVector k V fld q ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) j : ℤ))
+      = (fun j : V ↦ (@dimVector k V fld (Quiver.reflectList q l)
+          ((reflectionFunctorList k l q hq hl).obj M) j : ℤ)) from
+      congrArg (fun c : V → ℕ ↦ fun j : V ↦ (c j : ℤ))
+        (dimVector_transportCodomain_obj _ _ M)]
+    exact h2
+  · exact Or.inr ((isZero_transportCodomain_obj _ _ M).mpr h)
+
+/-- **The Coxeter functor preserves the Tits form of the dimension vector.** The Tits form is
+unchanged by a simple reflection at a loopless vertex, hence by the whole Coxeter transformation
+(`TauCeti.titsForm_vertexPreReflectionList`), and no vertex of a repetition-free sink-admissible
+list carries a loop (`TauCeti.Quiver.IsSinkAdmissible.isEmpty_hom_self`). So on an indecomposable
+representation the Coxeter functor either annihilates it or leaves the Tits form of its dimension
+vector alone: the invariant along which the Layer 5 reflection induction descends. -/
+theorem titsForm_dimVector_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
+    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) (hM : Indecomposable M)
+    (hfd : ∀ a : V, FiniteDimensional k (M.obj a))
+    (hne : ¬ Limits.IsZero ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M)) :
+    @titsForm V q fV hq (fun j : V ↦
+        (@dimVector k V fld q ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) j : ℤ))
+      = @titsForm V q fV hq fun j : V ↦ (@dimVector k V fld q M j : ℤ) := by
+  classical
+  rcases indecomposable_and_dimVector_coxeterFunctor_or_isZero q hq hnd hall hl M hM hfd with
+    ⟨-, h2⟩ | h
+  · rw [h2]
+    exact @titsForm_vertexPreReflectionList V q fV hq _ l
+      (fun i hi ↦ hl.isEmpty_hom_self hnd hi) _
+  · exact absurd h hne
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
@@ -269,15 +269,6 @@ private theorem dimVector_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h :
   subst h
   rfl
 
-omit fV in
-private theorem intCast_dimVector_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h : r = q)
-    (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r)
-    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
-    (fun j : V ↦ (@dimVector k V fld q ((transportCodomain h F).obj M) j : ℤ))
-      = fun j : V ↦ (@dimVector k V fld r (F.obj M) j : ℤ) :=
-  congrArg (fun c : V → ℕ ↦ fun j : V ↦ (c j : ℤ))
-    (dimVector_transportCodomain_obj h F M)
-
 /-- **The Coxeter functor** `C⁺`: the composite of the Bernstein-Gelfand-Ponomarev reflection
 functors at the successive vertices of a sink-admissible *ordering* of the vertices -- a
 sink-admissible list that repeats no vertex and contains every one of them. Reflecting once at
@@ -309,6 +300,17 @@ theorem coxeterFunctor_def (q : _root_.Quiver.{w} V)
     (reflectionFunctorList k l q hq hl)
 
 /-- Transporting the reflection-functor composite back to the original quiver does not change its
+dimension vector. -/
+theorem dimVector_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
+    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
+    @dimVector k V fld q ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) =
+      @dimVector k V fld (Quiver.reflectList q l)
+        ((reflectionFunctorList k l q hq hl).obj M) :=
+  dimVector_transportCodomain_obj _ _ M
+
+/-- Transporting the reflection-functor composite back to the original quiver does not change its
 dimension vector after coercion to integers. -/
 theorem intCast_dimVector_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
     (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
@@ -318,7 +320,8 @@ theorem intCast_dimVector_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
         (@dimVector k V fld q ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) j : ℤ))
       = fun j : V ↦ (@dimVector k V fld (Quiver.reflectList q l)
           ((reflectionFunctorList k l q hq hl).obj M) j : ℤ) :=
-  intCast_dimVector_transportCodomain_obj _ _ M
+  congrArg (fun c : V → ℕ ↦ fun j : V ↦ (c j : ℤ))
+    (dimVector_coxeterFunctor_obj q hq hnd hall hl M)
 
 /-- **The Coxeter functor annihilates the zero representation.** -/
 theorem isZero_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
@@ -356,7 +359,8 @@ unchanged by a simple reflection at a loopless vertex, hence by the whole Coxete
 (`TauCeti.titsForm_vertexPreReflectionList`), and no vertex of a repetition-free sink-admissible
 list carries a loop (`TauCeti.Quiver.IsSinkAdmissible.isEmpty_hom_self`). So on an indecomposable
 representation the Coxeter functor either annihilates it or leaves the Tits form of its dimension
-vector alone: the invariant along which the Layer 5 reflection induction descends. -/
+vector alone. This preserved invariant is used by the Layer 5 reflection induction, whose descent
+measure is root height. -/
 theorem titsForm_dimVector_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
     (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
     (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
@@ -23,14 +23,13 @@ back to itself (`TauCeti.Quiver.reflectList_eq_self`). The resulting endofunctor
 functor** of this file, `TauCeti.coxeterFunctor`, and on dimension vectors it realizes the Coxeter
 transformation `TauCeti.vertexPreReflectionList` of the ordering.
 
-Both halves of the Layer 4 identity `dim (C⁺ M) = c · dim M` are proved here for an
-indecomposable representation with finite-dimensional vertex spaces, as a dichotomy: either no
-stage of the composite meets the vertex simple at its own sink -- and then the composite is
-indecomposable and its dimension vector is the predicted one -- or some stage does, and the
-composite is the zero representation. The dichotomy is what the statement needs: reflection at a
-sink `i` annihilates `Sᵢ` (`TauCeti.isZero_reflectRep`) instead of reflecting its dimension
-vector, and an indecomposable representation admits no other exception
-(`TauCeti.incomingSum_surjective_or_forall_subsingleton`).
+The Layer 4 identity `dim (C⁺ M) = c · dim M` is proved here for an indecomposable representation
+with finite-dimensional vertex spaces, with the zero representation as its alternative. The proof
+proceeds stagewise: away from the vertex simple at the current sink, reflection preserves
+indecomposability and transforms the dimension vector as predicted; at that vertex simple,
+reflection instead annihilates the representation (`TauCeti.isZero_reflectRep`). The corresponding
+dichotomy for indecomposables is supplied by
+`TauCeti.incomingSum_surjective_or_forall_subsingleton`.
 
 ## Main definitions
 
@@ -46,9 +45,6 @@ vector, and an indecomposable representation admits no other exception
   the identity on the empty list and peels off one reflection functor at a time.
 * `TauCeti.isZero_reflectionFunctorList_obj` and `TauCeti.isZero_coxeterFunctor_obj`: the zero
   representation is carried to the zero representation.
-* `TauCeti.vertexPreReflectionList_reflectAt`: reflecting the quiver structure changes no simple
-  reflection on dimension vectors, so the successive stages of the composite -- which act on
-  successively reflected quivers -- realize the simple reflections of the *original* quiver.
 * `TauCeti.indecomposable_and_dimVector_reflectionFunctorList_or_isZero` and
   `TauCeti.indecomposable_and_dimVector_coxeterFunctor_or_isZero`: the dichotomy above, for a
   general sink-admissible list and for the Coxeter functor.
@@ -72,8 +68,8 @@ representation rather than vertexwise, since the vertexwise form would need the 
 to `CategoryTheory.Functor.obj` as well.
 
 The Coxeter functor is the composite transported along `TauCeti.Quiver.reflectList_eq_self`, an
-equality of `Quiver` structures; the private `transportCodomain` names that transport and the
-three lemmas after it are its whole interface.
+equality of `Quiver` structures; `TauCeti.coxeterFunctor_def` exposes this characterization while
+the auxiliary transport construction remains private.
 
 The sink-admissible ordering is an argument of `TauCeti.coxeterFunctor` rather than something
 chosen from `TauCeti.Quiver.IsAcyclic.exists_isSinkAdmissible`: the Coxeter transformation the
@@ -107,7 +103,6 @@ successive entries compose; the result carries the representations of `q` to tho
 
 The quiver structure is an explicit argument rather than an instance because it is what the
 recursion moves: the vertex type stays fixed while the arrows are reversed. -/
-@[expose]
 noncomputable def reflectionFunctorList (k : Type u) {V : Type v} [fld : Field k] [fV : Fintype V] :
     ∀ (l : List V) (q : _root_.Quiver.{w} V)
       (_hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)),
@@ -128,8 +123,8 @@ variable {k : Type u} {V : Type v} [fld : Field k] [fV : Fintype V]
 theorem reflectionFunctorList_nil (q : _root_.Quiver.{w} V)
     (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
     (hl : Quiver.IsSinkAdmissible q []) :
-    reflectionFunctorList.{u, v, w, x} k [] q hq hl = 𝟭 _ :=
-  rfl
+    reflectionFunctorList.{u, v, w, x} k [] q hq hl = 𝟭 _ := by
+  rw [reflectionFunctorList]
 
 @[simp]
 theorem reflectionFunctorList_cons (i : V) (l : List V) (q : _root_.Quiver.{w} V)
@@ -138,8 +133,9 @@ theorem reflectionFunctorList_cons (i : V) (l : List V) (q : _root_.Quiver.{w} V
     reflectionFunctorList.{u, v, w, x} k (i :: l) q hq hl
       = @reflectionFunctor k V fld q fV hq i (Quiver.isSinkAdmissible_cons.mp hl).1 ⋙
         reflectionFunctorList k l (Quiver.reflectAt q i) (@instFintypeReflectHom V q hq i)
-          (Quiver.isSinkAdmissible_cons.mp hl).2 :=
-  rfl
+          (Quiver.isSinkAdmissible_cons.mp hl).2 := by
+  rw [reflectionFunctorList]
+  congr
 
 /-- **A composite of reflections annihilates the zero representation.** Only the vanishing of the
 vertex spaces is used at each stage, through `TauCeti.isZero_reflectRep`. -/
@@ -162,25 +158,6 @@ theorem isZero_reflectionFunctorList_obj :
       exact isZero_reflectRep M (Quiver.isSinkAdmissible_cons.mp hl).1 fun a _ ↦
         ModuleCat.subsingleton_of_isZero ((Functor.isZero_iff M).mp hM a)
 
-/-! ### The simple reflections do not see the orientation -/
-
-/-- The composite of the simple reflections along a word is unchanged by reflecting the quiver
-structure at a vertex, by `TauCeti.vertexPreReflection_reflect_apply` at each letter. This is what
-lets the Coxeter transformation of the original quiver be read off a composite of reflection
-functors, whose successive stages act on the dimension vectors of successively reflected
-quivers. -/
-theorem vertexPreReflectionList_reflectAt [DecidableEq V] (q : _root_.Quiver.{w} V)
-    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) (i : V) (l : List V) :
-    @vertexPreReflectionList V (Quiver.reflectAt q i) fV (@instFintypeReflectHom V q hq i) _ l
-      = @vertexPreReflectionList V q fV hq _ l := by
-  induction l with
-  | nil => rw [vertexPreReflectionList_nil, vertexPreReflectionList_nil]
-  | cons j l ih =>
-    rw [vertexPreReflectionList_cons, vertexPreReflectionList_cons, ih]
-    congr 1
-    refine LinearMap.ext fun d ↦ funext fun t ↦ ?_
-    exact vertexPreReflection_reflect_apply (V := V) i j d t
-
 /-! ### The action on an indecomposable representation -/
 
 /-- **A composite of reflection functors on an indecomposable representation.** Either no stage
@@ -188,10 +165,10 @@ meets the vertex simple at its own sink -- and then the composite is again indec
 dimension vector the corresponding product of simple reflections applied to the dimension vector
 of `M` -- or some stage does, and the composite is the zero representation.
 
-The dichotomy is genuine and both cases occur: the second is exactly the vertex simple `Sᵢ` at the
-first entry, which `TauCeti.isZero_reflectRep` annihilates. The simple reflections on the right are
-those of the *original* quiver, by `TauCeti.vertexPreReflectionList_reflectAt`, even though the
-successive stages act on successively reflected quivers. -/
+Both cases occur: for example, the vertex simple `Sᵢ` at the first entry is annihilated by
+`TauCeti.isZero_reflectRep`. The simple reflections on the right are those of the *original*
+quiver, by `TauCeti.vertexPreReflectionList_reflectAt`, even though the successive stages act on
+successively reflected quivers. -/
 theorem indecomposable_and_dimVector_reflectionFunctorList_or_isZero [DecidableEq V] :
     ∀ (l : List V) (q : _root_.Quiver.{w} V)
       (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
@@ -257,6 +234,16 @@ private noncomputable def transportCodomain {q r : _root_.Quiver.{w} V} (h : r =
   h ▸ F
 
 omit fV in
+private theorem transportCodomain_eq_eqMp {q r : _root_.Quiver.{w} V} (h : r = q)
+    (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r) :
+    transportCodomain h F =
+      Eq.mp (congrArg (fun s : _root_.Quiver.{w} V ↦
+        @QuiverRep.{u, v, w, max v w x} k V fld q ⥤
+          @QuiverRep.{u, v, w, max v w x} k V fld s) h) F := by
+  subst h
+  rfl
+
+omit fV in
 private theorem indecomposable_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h : r = q)
     (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r)
     (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
@@ -280,6 +267,15 @@ private theorem dimVector_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h :
   subst h
   rfl
 
+omit fV in
+private theorem intCast_dimVector_transportCodomain_obj {q r : _root_.Quiver.{w} V} (h : r = q)
+    (F : @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld r)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
+    (fun j : V ↦ (@dimVector k V fld q ((transportCodomain h F).obj M) j : ℤ))
+      = fun j : V ↦ (@dimVector k V fld r (F.obj M) j : ℤ) :=
+  congrArg (fun c : V → ℕ ↦ fun j : V ↦ (c j : ℤ))
+    (dimVector_transportCodomain_obj h F M)
+
 /-- **The Coxeter functor** `C⁺`: the composite of the Bernstein-Gelfand-Ponomarev reflection
 functors at the successive vertices of a sink-admissible *ordering* of the vertices -- a
 sink-admissible list that repeats no vertex and contains every one of them. Reflecting once at
@@ -297,6 +293,41 @@ noncomputable def coxeterFunctor (k : Type u) {V : Type v} [fld : Field k] [fV :
     @QuiverRep.{u, v, w, max v w x} k V fld q ⥤ @QuiverRep.{u, v, w, max v w x} k V fld q :=
   transportCodomain (Quiver.reflectList_eq_self q hnd hall) (reflectionFunctorList k l q hq hl)
 
+private theorem coxeterFunctor_def_aux (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
+    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l) :
+    coxeterFunctor.{u, v, w, x} k q hq hnd hall hl =
+      Eq.mp (congrArg (fun r : _root_.Quiver.{w} V ↦
+        @QuiverRep.{u, v, w, max v w x} k V fld q ⥤
+          @QuiverRep.{u, v, w, max v w x} k V fld r)
+        (Quiver.reflectList_eq_self q hnd hall)) (reflectionFunctorList k l q hq hl) := by
+  change transportCodomain _ _ = _
+  exact transportCodomain_eq_eqMp _ _
+
+/-- The Coxeter functor is the reflection-functor composite transported along the equality between
+the iteratively reflected quiver and the original quiver. -/
+theorem coxeterFunctor_def (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
+    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l) :
+    coxeterFunctor.{u, v, w, x} k q hq hnd hall hl =
+      Eq.mp (congrArg (fun r : _root_.Quiver.{w} V ↦
+        @QuiverRep.{u, v, w, max v w x} k V fld q ⥤
+          @QuiverRep.{u, v, w, max v w x} k V fld r)
+        (Quiver.reflectList_eq_self q hnd hall)) (reflectionFunctorList k l q hq hl) :=
+  coxeterFunctor_def_aux q hq hnd hall hl
+
+/-- Transporting the reflection-functor composite back to the original quiver does not change its
+dimension vector after coercion to integers. -/
+theorem intCast_dimVector_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
+    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
+    (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
+    (M : @QuiverRep.{u, v, w, max v w x} k V fld q) :
+    (fun j : V ↦
+        (@dimVector k V fld q ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) j : ℤ))
+      = fun j : V ↦ (@dimVector k V fld (Quiver.reflectList q l)
+          ((reflectionFunctorList k l q hq hl).obj M) j : ℤ) :=
+  intCast_dimVector_transportCodomain_obj _ _ M
+
 /-- **The Coxeter functor annihilates the zero representation.** -/
 theorem isZero_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
     (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) {l : List V} (hnd : l.Nodup)
@@ -308,9 +339,9 @@ theorem isZero_coxeterFunctor_obj (q : _root_.Quiver.{w} V)
 /-- **The Coxeter functor on an indecomposable representation.** Either it is again
 indecomposable, with dimension vector the Coxeter transformation
 `TauCeti.vertexPreReflectionList` of the ordering applied to the dimension vector of `M`, or it is
-the zero representation -- which happens exactly when some stage of the composite meets the vertex
-simple at its own sink. This is the Layer 4 statement `dim (C⁺ M) = c · dim M` for the Coxeter
-element `c`, with the boundary case named. -/
+the zero representation. The proof applies the reflection dichotomy successively, with a vertex
+simple at the current sink providing the annihilated case. This is the Layer 4 statement
+`dim (C⁺ M) = c · dim M` for the Coxeter element `c`, with the boundary case named. -/
 theorem indecomposable_and_dimVector_coxeterFunctor_or_isZero [DecidableEq V]
     (q : _root_.Quiver.{w} V) (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b))
     {l : List V} (hnd : l.Nodup) (hall : ∀ v : V, v ∈ l) (hl : Quiver.IsSinkAdmissible q l)
@@ -324,12 +355,7 @@ theorem indecomposable_and_dimVector_coxeterFunctor_or_isZero [DecidableEq V]
   rcases indecomposable_and_dimVector_reflectionFunctorList_or_isZero l q hq hl M hM hfd with
     ⟨h1, h2⟩ | h
   · refine Or.inl ⟨(indecomposable_transportCodomain_obj _ _ M).mpr h1, ?_⟩
-    rw [show (fun j : V ↦
-        (@dimVector k V fld q ((coxeterFunctor.{u, v, w, x} k q hq hnd hall hl).obj M) j : ℤ))
-      = (fun j : V ↦ (@dimVector k V fld (Quiver.reflectList q l)
-          ((reflectionFunctorList k l q hq hl).obj M) j : ℤ)) from
-      congrArg (fun c : V → ℕ ↦ fun j : V ↦ (c j : ℤ))
-        (dimVector_transportCodomain_obj _ _ M)]
+    rw [intCast_dimVector_coxeterFunctor_obj]
     exact h2
   · exact Or.inr ((isZero_transportCodomain_obj _ _ M).mpr h)
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Composite.lean
@@ -61,8 +61,8 @@ The quiver structure is carried as an *explicit argument* rather than as an inst
 recursion changes it: the vertex type is fixed and the arrows are reversed, so the recursion is on
 the `Quiver` structure `TauCeti.Quiver.reflectAt`, not on a type synonym like
 `TauCeti.Quiver.Reflect`, whose iteration would change the type at each step and so leave the
-range of structural recursion. `TauCeti.Quiver.fintypeHomReflectAt` carries arrow-finiteness along
-with it.
+range of structural recursion. The existing `TauCeti.Quiver.instFintypeReflectHom` carries
+arrow-finiteness along with it.
 
 A consequence is that two `Quiver` structures on one vertex type occur in the same statement, and
 the one in scope as a local instance is not always the intended one. Every statement below
@@ -98,20 +98,6 @@ open _root_.TauCeti.Quiver
 
 universe u v w x
 
-namespace Quiver
-
-variable {V : Type v}
-
-/-- The arrows of a reflected quiver structure are finite in number when those of the given one
-are: they are the arrows of `TauCeti.Quiver.reflectHom`. -/
-@[instance_reducible]
-noncomputable def fintypeHomReflectAt (q : _root_.Quiver.{w} V)
-    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) (i a b : V) :
-    Fintype (@_root_.Quiver.Hom V (reflectAt q i) a b) :=
-  @instFintypeReflectHom V q hq i a b
-
-end Quiver
-
 /-! ### The composite of the reflection functors along a sink-admissible list -/
 
 /-- **The composite of the reflection functors along a sink-admissible list.** Each entry of the
@@ -133,7 +119,7 @@ noncomputable def reflectionFunctorList (k : Type u) {V : Type v} [fld : Field k
       letI := q
       letI := hq
       exact reflectionFunctor i (Quiver.isSinkAdmissible_cons.mp hl).1 ⋙
-        reflectionFunctorList k l (Quiver.reflectAt q i) (Quiver.fintypeHomReflectAt q hq i)
+        reflectionFunctorList k l (Quiver.reflectAt q i) (@instFintypeReflectHom V q hq i)
           (Quiver.isSinkAdmissible_cons.mp hl).2
 
 variable {k : Type u} {V : Type v} [fld : Field k] [fV : Fintype V]
@@ -151,7 +137,7 @@ theorem reflectionFunctorList_cons (i : V) (l : List V) (q : _root_.Quiver.{w} V
     (hl : Quiver.IsSinkAdmissible q (i :: l)) :
     reflectionFunctorList.{u, v, w, x} k (i :: l) q hq hl
       = @reflectionFunctor k V fld q fV hq i (Quiver.isSinkAdmissible_cons.mp hl).1 ⋙
-        reflectionFunctorList k l (Quiver.reflectAt q i) (Quiver.fintypeHomReflectAt q hq i)
+        reflectionFunctorList k l (Quiver.reflectAt q i) (@instFintypeReflectHom V q hq i)
           (Quiver.isSinkAdmissible_cons.mp hl).2 :=
   rfl
 
@@ -170,7 +156,7 @@ theorem isZero_reflectionFunctorList_obj :
       let : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b) := hq
       rw [reflectionFunctorList_cons]
       refine isZero_reflectionFunctorList_obj l (Quiver.reflectAt q i)
-        (Quiver.fintypeHomReflectAt q hq i) (Quiver.isSinkAdmissible_cons.mp hl).2
+        (@instFintypeReflectHom V q hq i) (Quiver.isSinkAdmissible_cons.mp hl).2
         ((reflectionFunctor i (Quiver.isSinkAdmissible_cons.mp hl).1).obj M) ?_
       rw [reflectionFunctor_obj]
       exact isZero_reflectRep M (Quiver.isSinkAdmissible_cons.mp hl).1 fun a _ ↦
@@ -178,33 +164,22 @@ theorem isZero_reflectionFunctorList_obj :
 
 /-! ### The simple reflections do not see the orientation -/
 
-/-- Reflecting the quiver structure at a vertex changes no simple reflection on dimension
-vectors: these are built from the polarized Tits form, which depends only on the underlying graph.
-This is `TauCeti.vertexPreReflection_reflect_apply` read on the iterating form
-`TauCeti.Quiver.reflectAt`. -/
-theorem vertexPreReflection_reflectAt [DecidableEq V] (q : _root_.Quiver.{w} V)
-    (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) (i j : V) :
-    @vertexPreReflection V (Quiver.reflectAt q i) fV (Quiver.fintypeHomReflectAt q hq i) _ j
-      = @vertexPreReflection V q fV hq _ j := by
-  let : _root_.Quiver.{w} V := q
-  let : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b) := hq
-  refine LinearMap.ext fun d ↦ funext fun t ↦ ?_
-  exact vertexPreReflection_reflect_apply (V := V) i j d t
-
 /-- The composite of the simple reflections along a word is unchanged by reflecting the quiver
-structure at a vertex, by `TauCeti.vertexPreReflection_reflectAt` at each letter. This is what
+structure at a vertex, by `TauCeti.vertexPreReflection_reflect_apply` at each letter. This is what
 lets the Coxeter transformation of the original quiver be read off a composite of reflection
 functors, whose successive stages act on the dimension vectors of successively reflected
 quivers. -/
 theorem vertexPreReflectionList_reflectAt [DecidableEq V] (q : _root_.Quiver.{w} V)
     (hq : ∀ a b : V, Fintype (@_root_.Quiver.Hom V q a b)) (i : V) (l : List V) :
-    @vertexPreReflectionList V (Quiver.reflectAt q i) fV (Quiver.fintypeHomReflectAt q hq i) _ l
+    @vertexPreReflectionList V (Quiver.reflectAt q i) fV (@instFintypeReflectHom V q hq i) _ l
       = @vertexPreReflectionList V q fV hq _ l := by
   induction l with
   | nil => rw [vertexPreReflectionList_nil, vertexPreReflectionList_nil]
   | cons j l ih =>
-    rw [vertexPreReflectionList_cons, vertexPreReflectionList_cons, ih,
-      vertexPreReflection_reflectAt]
+    rw [vertexPreReflectionList_cons, vertexPreReflectionList_cons, ih]
+    congr 1
+    refine LinearMap.ext fun d ↦ funext fun t ↦ ?_
+    exact vertexPreReflection_reflect_apply (V := V) i j d t
 
 /-! ### The action on an indecomposable representation -/
 
@@ -236,7 +211,7 @@ theorem indecomposable_and_dimVector_reflectionFunctorList_or_isZero [DecidableE
       obtain ⟨hi, hl'⟩ := Quiver.isSinkAdmissible_cons.mp hl
       have key : (reflectionFunctorList.{u, v, w, x} k (i :: l) q hq hl).obj M
           = (reflectionFunctorList k l (Quiver.reflectAt q i)
-              (Quiver.fintypeHomReflectAt q hq i) hl').obj (reflectRep M hi) := by
+              (@instFintypeReflectHom V q hq i) hl').obj (reflectRep M hi) := by
         rw [reflectionFunctorList_cons]
         exact congrArg _ (reflectionFunctor_obj i hi M)
       rw [key]
@@ -246,15 +221,15 @@ theorem indecomposable_and_dimVector_reflectionFunctorList_or_isZero [DecidableE
             = @vertexPreReflection V q fV hq _ i fun j ↦ (@dimVector k V fld q M j : ℤ) :=
           dimVector_reflectRep M hi (fun e ↦ hfd e.1) hs
         rcases indecomposable_and_dimVector_reflectionFunctorList_or_isZero l
-            (Quiver.reflectAt q i) (Quiver.fintypeHomReflectAt q hq i) hl' (reflectRep M hi)
+            (Quiver.reflectAt q i) (@instFintypeReflectHom V q hq i) hl' (reflectRep M hi)
             (indecomposable_reflectRep hi hM hs)
             (finiteDimensional_reflectRep_obj M hi hfd) with ⟨h1, h2⟩ | h
         · refine Or.inl ⟨h1, ?_⟩
           calc (fun j : V ↦ (@dimVector k V fld (Quiver.reflectList q (i :: l))
                 ((reflectionFunctorList k l (Quiver.reflectAt q i)
-                  (Quiver.fintypeHomReflectAt q hq i) hl').obj (reflectRep M hi)) j : ℤ))
+                  (@instFintypeReflectHom V q hq i) hl').obj (reflectRep M hi)) j : ℤ))
               = @vertexPreReflectionList V (Quiver.reflectAt q i) fV
-                  (Quiver.fintypeHomReflectAt q hq i) _ l
+                  (@instFintypeReflectHom V q hq i) _ l
                   (fun j : V ↦
                     (@dimVector k V fld (Quiver.reflectAt q i) (reflectRep M hi) j : ℤ)) := h2
             _ = @vertexPreReflectionList V q fV hq _ l
@@ -266,7 +241,7 @@ theorem indecomposable_and_dimVector_reflectionFunctorList_or_isZero [DecidableE
                   (vertexPreReflectionList_apply_cons V i l _).symm
         · exact Or.inr h
       · exact Or.inr (isZero_reflectionFunctorList_obj l (Quiver.reflectAt q i)
-          (Quiver.fintypeHomReflectAt q hq i) hl' (reflectRep M hi)
+          (@instFintypeReflectHom V q hq i) hl' (reflectRep M hi)
           (isZero_reflectRep M hi hsub))
 
 /-! ### The Coxeter functor -/

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Coxeter.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Coxeter.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.Quiver.Reflection.DimensionVector
+public import TauCeti.RepresentationTheory.Quiver.Reflection.Iterate
+import TauCeti.RepresentationTheory.Quiver.Reflection.EulerForm
 
 /-!
 # The Coxeter transformation on the dimension vectors of a quiver
@@ -98,6 +100,21 @@ theorem vertexPreReflectionList_apply_cons (i : Q) (l : List Q) (d : Q → ℤ) 
     vertexPreReflectionList Q (i :: l) d
       = vertexPreReflectionList Q l (vertexPreReflection Q i d) := by
   rw [vertexPreReflectionList_cons, Module.End.mul_apply]
+
+omit [Quiver Q] [∀ a b : Q, Fintype (a ⟶ b)] in
+/-- The composite of the simple reflections along a word is unchanged by reflecting the quiver
+structure at a vertex. -/
+theorem vertexPreReflectionList_reflectAt (q : _root_.Quiver.{v} Q)
+    (hq : ∀ a b : Q, Fintype (@_root_.Quiver.Hom Q q a b)) (i : Q) (l : List Q) :
+    @vertexPreReflectionList Q (Quiver.reflectAt q i) _ (@Quiver.instFintypeReflectHom Q q hq i) _ l
+      = @vertexPreReflectionList Q q _ hq _ l := by
+  induction l with
+  | nil => rw [vertexPreReflectionList_nil, vertexPreReflectionList_nil]
+  | cons j l ih =>
+    rw [vertexPreReflectionList_cons, vertexPreReflectionList_cons, ih]
+    congr 1
+    refine LinearMap.ext fun d ↦ funext fun t ↦ ?_
+    exact vertexPreReflection_reflect_apply (V := Q) i j d t
 
 /-- Concatenating two words composes their reflection products, the first word acting first. -/
 theorem vertexPreReflectionList_append (l₁ l₂ : List Q) :

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Iterate.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Iterate.lean
@@ -34,6 +34,13 @@ the arrows of `Reflect V i`, by `TauCeti.Quiver.hom_reflectAt_eq_hom_reflect` �
   quiver structure, with `TauCeti.Quiver.hom_reflectList_of_forall_mem` the same statement on
   arrow types.
 
+## Implementation notes
+
+Both definitions are `@[expose]`d. A module that iterates the reflection of *representations*
+needs the reductions `reflectList q (i :: l) = reflectList (reflectAt q i) l` and
+`(a ⟶ b) = TauCeti.Quiver.reflectHom i a b` in `reflectAt q i` to hold definitionally, so that a
+recursive construction typechecks against the quiver structure its predecessor produced.
+
 ## References
 
 The lists along which this iteration is sink-admissible are studied in
@@ -63,7 +70,7 @@ namespace Quiver
 vertex type: `reflectAt q i` has the arrows of `q` with every arrow incident to `i` reversed.
 Unlike the type synonym `TauCeti.Quiver.Reflect`, this form iterates, which is what a sequence of
 reflections needs. -/
-@[instance_reducible]
+@[expose, instance_reducible]
 noncomputable def reflectAt (q : _root_.Quiver.{v} V) (i : V) : _root_.Quiver.{v} V :=
   ⟨@reflectHom V q i⟩
 
@@ -90,7 +97,7 @@ theorem reflectAt_reflectAt (q : _root_.Quiver.{v} V) (i : V) :
 /-! ### Reflecting along a list of vertices -/
 
 /-- Reflection at each vertex of a list in turn, starting from the head. -/
-@[instance_reducible]
+@[expose, instance_reducible]
 noncomputable def reflectList (q : _root_.Quiver.{v} V) (l : List V) : _root_.Quiver.{v} V :=
   l.foldl reflectAt q
 

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/Representation.lean
@@ -65,6 +65,11 @@ representation concentrated at `i` whose space at `i` is nontrivial, of which th
   at `i` with nontrivial space there, and `TauCeti.subsingleton_reflectRep_obj_self`: the reflected
   space at `i` vanishes under the same source-vanishing hypothesis. Together they describe the
   vertex simple `Sᵢ`, the boundary case of the previous result.
+* `TauCeti.forall_subsingleton_reflectRep_obj` and `TauCeti.isZero_reflectRep`: a representation
+  concentrated at the sink reflects to the zero representation, the same boundary case read at
+  every vertex and on the whole reflection.
+* `TauCeti.finiteDimensional_reflectRep_obj`: reflection preserves finite-dimensionality of the
+  vertex spaces.
 
 ## Implementation notes
 
@@ -742,6 +747,46 @@ theorem subsingleton_reflectRep_obj_self {i : Q} (hi : IsSink i)
   have hker : Subsingleton (LinearMap.ker (incomingSum M i)) :=
     ⟨fun a b ↦ Subtype.ext (hdom.elim _ _)⟩
   exact reflectRep_obj_self M hi ▸ hker
+
+/-- **Reflection annihilates a representation concentrated at the sink.** If every vertex space of
+`M` away from `i` vanishes, then the reflection is the zero representation: at `i` by
+`TauCeti.subsingleton_reflectRep_obj_self`, since no arrow into a sink is a loop, and away from
+`i` because the vertex space is unchanged there. This is the boundary case in which reflection
+does not act by the simple reflection on dimension vectors -- for an indecomposable
+representation it is the vertex simple `Sᵢ`, which `TauCeti.incomingSum_not_surjective`
+describes -- and it is what makes a composite of reflections vanish once one of its stages
+does. -/
+theorem forall_subsingleton_reflectRep_obj {i : Q} (hi : IsSink i)
+    (h : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) (j : Q) :
+    Subsingleton ((reflectRep M hi).obj j) := by
+  rcases eq_or_ne j i with rfl | hj
+  · exact subsingleton_reflectRep_obj_self M hi fun b e ↦ h b (hi.ne_of_hom e)
+  · rw [reflectRep_obj_of_ne M hi hj]
+    exact h j hj
+
+/-- **Reflection annihilates a representation concentrated at the sink**, read on the whole
+reflection: `TauCeti.forall_subsingleton_reflectRep_obj` says every vertex space of the reflection
+vanishes, and a representation with vanishing vertex spaces is a zero object. -/
+theorem isZero_reflectRep {i : Q} (hi : IsSink i)
+    (h : ∀ a : Q, a ≠ i → Subsingleton (M.obj a)) :
+    Limits.IsZero (reflectRep M hi) :=
+  (Functor.isZero_iff _).mpr fun j ↦
+    have := forall_subsingleton_reflectRep_obj M hi h j
+    ModuleCat.isZero_of_subsingleton _
+
+/-- **Reflection preserves finite-dimensionality.** The reflected space at the sink is a subspace
+of a finite product of vertex spaces of `M`, and away from the sink the vertex spaces are those of
+`M`. This is what carries the finite-dimensionality hypothesis of
+`TauCeti.dimVector_reflectRep` through a sequence of reflections. -/
+theorem finiteDimensional_reflectRep_obj {i : Q} (hi : IsSink i)
+    (h : ∀ a : Q, FiniteDimensional k (M.obj a)) (j : Q) :
+    FiniteDimensional k ((reflectRep M hi).obj j) := by
+  rcases eq_or_ne j i with rfl | hj
+  · have hpi : ∀ e : Σ b : Q, (b ⟶ j), FiniteDimensional k (M.obj e.1) := fun e ↦ h e.1
+    rw [reflectRep_obj_self M hi]
+    exact FiniteDimensional.finiteDimensional_submodule _
+  · rw [reflectRep_obj_of_ne M hi hj]
+    exact h j
 
 /-- If every source of an arrow into the sink vanishes, the reflected dimension at the sink is
 zero. -/


### PR DESCRIPTION
This PR constructs the Coxeter functor of a finite quiver: it composes the Bernstein-Gelfand-Ponomarev reflection functors along a sink-admissible list of vertices, and, along a sink-admissible *ordering* — a repetition-free list containing every vertex, whose reflections carry the quiver back to itself by `TauCeti.Quiver.reflectList_eq_self` — assembles them into an endofunctor `TauCeti.coxeterFunctor` of the representations. This is the "Coxeter functor" target of Layer 4 of `RepresentationTheory/QuiverRepresentations/README.md` (`coxeterFunctor` in that roadmap's `Suggested.lean`), the last Layer 4 item still open and the engine that the Layer 5 milestone — Gabriel's theorem, the bijection between indecomposables and positive roots — runs on. After this PR that milestone still needs the height-descent argument itself: that every indecomposable is carried to a vertex simple by an iterated Coxeter functor, and the resulting bijection with the positive roots.

`TauCeti.reflectionFunctorList` reflects at the successive entries of a sink-admissible list, landing in the representations of the iterated reflection `TauCeti.Quiver.reflectList q l`, with `reflectionFunctorList_nil` and `reflectionFunctorList_cons` as its computation rules. The quiver structure is carried as an explicit argument rather than as an instance because it is what the recursion moves — the vertex type is fixed and the arrows are reversed — so the recursion runs on the `Quiver` structure `TauCeti.Quiver.reflectAt` rather than on the type synonym `TauCeti.Quiver.Reflect`, whose iteration would change the type at every step and leave the range of structural recursion.

The mathematical content is a dichotomy for an indecomposable representation with finite-dimensional vertex spaces, `TauCeti.indecomposable_and_dimVector_reflectionFunctorList_or_isZero` and its Coxeter form `TauCeti.indecomposable_and_dimVector_coxeterFunctor_or_isZero`: either no stage of the composite meets the vertex simple at its own sink, and then the composite is again indecomposable and its dimension vector is `TauCeti.vertexPreReflectionList` of the list applied to the dimension vector of the input — the Layer 4 identity `dim (C⁺ M) = c · dim M` for the Coxeter element `c` — or some stage does, and the composite is the zero representation. The dichotomy is not a hedge: reflection at a sink `i` annihilates `Sᵢ` rather than reflecting its dimension vector, and by `TauCeti.incomingSum_surjective_or_forall_subsingleton` an indecomposable representation admits no other exception. `TauCeti.titsForm_dimVector_coxeterFunctor_obj` reads off the invariant the Layer 5 induction descends by: the Coxeter functor preserves the Tits form of the dimension vector of every indecomposable it does not annihilate.

Two facts about the simple reflections are needed to state that cleanly and are proved here: `TauCeti.vertexPreReflectionList_reflectAt`, that reflecting the quiver structure changes no simple reflection on dimension vectors (from the existing `TauCeti.vertexPreReflection_reflect_apply`), so that the successive stages — which act on successively reflected quivers — realize the simple reflections of the *original* quiver; and `TauCeti.Quiver.IsSinkAdmissible.isEmpty_hom_self`, that no vertex of a repetition-free sink-admissible list carries a loop, which is the looplessness hypothesis of `TauCeti.titsForm_vertexPreReflectionList`.

Three existing files are touched, each for a prerequisite of the above rather than for its own sake. `Reflection/Representation.lean` gains `TauCeti.forall_subsingleton_reflectRep_obj` and `TauCeti.isZero_reflectRep` (reflection at a sink annihilates a representation concentrated there, the boundary case that already had its vertex-at-the-sink half as `subsingleton_reflectRep_obj_self`) and `TauCeti.finiteDimensional_reflectRep_obj` (reflection preserves finite-dimensionality, which carries the hypothesis of `dimVector_reflectRep` through a sequence of reflections); both belong with `reflectRep`, not with the composite. `Reflection/Admissible.lean` gains the looplessness lemma above. `Reflection/Iterate.lean` marks `TauCeti.Quiver.reflectAt` and `TauCeti.Quiver.reflectList` `@[expose]`, which the recursion needs: `reflectList q (i :: l)` must reduce to `reflectList (reflectAt q i) l`, and the arrows of `reflectAt q i` to `TauCeti.Quiver.reflectHom`, definitionally, for the recursive construction to typecheck against the structure its predecessor produced. No Mathlib source was vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"coxeter-functor"}-->

🤖 Prepared with Claude Code
