### PR TITLE
feat(Distributions): the cumulant generating function of the uniform law

### DIFF
--- a/TauCeti/Probability/Distributions/Uniform.lean
+++ b/TauCeti/Probability/Distributions/Uniform.lean
@@ -141,14 +141,17 @@ Mathlib's `MeasureTheory.pdf.uniformPDF` is `ℝ≥0∞`-valued; this is the rea
 `uniformPDF_eq_ofReal_uniformPDFReal` relates the two. -/
 def uniformPDFReal (a b x : ℝ) : ℝ := if x ∈ Set.Ioc a b then (b - a)⁻¹ else 0
 
+/-- Inside the interval the real-valued density is the reciprocal of its length. -/
 @[simp]
 theorem uniformPDFReal_of_mem {a b x : ℝ} (hx : x ∈ Set.Ioc a b) :
     uniformPDFReal a b x = (b - a)⁻¹ := by simp [uniformPDFReal, hx]
 
+/-- Outside the interval the real-valued density vanishes. -/
 @[simp]
 theorem uniformPDFReal_of_notMem {a b x : ℝ} (hx : x ∉ Set.Ioc a b) :
     uniformPDFReal a b x = 0 := by simp [uniformPDFReal, hx]
 
+/-- The real-valued uniform density is measurable. -/
 theorem measurable_uniformPDFReal {a b : ℝ} : Measurable (uniformPDFReal a b) := by
   unfold uniformPDFReal
   exact measurable_const.ite measurableSet_Ioc measurable_const
@@ -167,6 +170,7 @@ theorem uniformPDF_eq_ofReal_uniformPDFReal {a b : ℝ} (x : ℝ) :
   · rw [uniformPDFReal_of_notMem hx, ENNReal.ofReal_zero]
     simp [hx]
 
+/-- Mathlib's uniform density on `Set.Ioc a b`, against `volume`, is measurable. -/
 theorem measurable_uniformPDF_Ioc_volume {a b : ℝ} :
     Measurable fun x => pdf.uniformPDF (Set.Ioc a b) x volume := by
   unfold pdf.uniformPDF

--- a/TauCeti/Probability/Distributions/Uniform.lean
+++ b/TauCeti/Probability/Distributions/Uniform.lean
@@ -53,6 +53,10 @@ therefore takes `a < b` as a hypothesis rather than assuming it silently.
   endpoints;
 * `mgf_id_uniformMeasure_zero` and `mgf_id_uniformMeasure` — the moment generating function, split
   at the removable singularity `t = 0`;
+* `mgf_id_uniformMeasure_pos` — the mgf is strictly positive, which is what makes the cgf's
+  logarithm meaningful;
+* `cgf_id_uniformMeasure_zero` and `cgf_id_uniformMeasure` — the cumulant generating function, split
+  the same way;
 * `map_uniformMeasure_affine` — every uniform law is an affine image of the standard one.
 
 ## Implementation
@@ -66,8 +70,8 @@ side condition.
 ## References
 
 * Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 0, item 3. The remaining
-  targets of that item — the cumulant generating function, the characteristic function, and
-  parameter measurability — are not built here.
+  targets of that item — the characteristic function and parameter measurability — are not built
+  here.
 * N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Univariate Distributions*, vol. 2, 2nd ed.,
   Wiley (1995), ch. 26.
 -/
@@ -308,6 +312,43 @@ theorem mgf_id_uniformMeasure {a b t : ℝ} (hab : a < b) (ht : t ≠ 0) :
   simp only [id_eq]
   rw [hint, ENNReal.toReal_inv, ENNReal.toReal_ofReal hba.le, smul_eq_mul]
   field_simp
+
+/-! ### The cumulant generating function
+
+The cgf is the real logarithm of the mgf, so it is only meaningful once the mgf is known to be
+strictly positive. That positivity is proved here rather than assumed: `mgf_id_uniformMeasure_pos`
+follows from `mgf_pos`, whose integrability hypothesis is exactly what
+`integrableExpSet_id_uniformMeasure` supplies. -/
+
+/-- Every exponential moment of the uniform law is integrable, read off the exponential-moment
+set. -/
+theorem integrable_exp_mul_id_uniformMeasure {a b t : ℝ} :
+    Integrable (fun x => Real.exp (t * x)) (uniformMeasure a b) := by
+  have h : t ∈ integrableExpSet id (uniformMeasure a b) := by
+    rw [integrableExpSet_id_uniformMeasure]
+    exact Set.mem_univ t
+  simpa [integrableExpSet, id_eq] using h
+
+/-- **The moment generating function of the uniform law is strictly positive.**
+
+This is what makes the cgf's logarithm meaningful; it is not a side remark. -/
+theorem mgf_id_uniformMeasure_pos {a b : ℝ} (hab : a < b) (t : ℝ) :
+    0 < mgf id (uniformMeasure a b) t := by
+  have := isProbabilityMeasure_uniformMeasure hab
+  exact mgf_pos integrable_exp_mul_id_uniformMeasure
+
+/-- The cumulant generating function of the uniform law at `0` is `0`. -/
+theorem cgf_id_uniformMeasure_zero {a b : ℝ} (hab : a < b) :
+    cgf id (uniformMeasure a b) 0 = 0 := by
+  rw [cgf, mgf_id_uniformMeasure_zero hab, Real.log_one]
+
+/-- **The cumulant generating function of the uniform law**, away from the removable singularity.
+
+The argument of the logarithm is positive by `mgf_id_uniformMeasure_pos`. -/
+theorem cgf_id_uniformMeasure {a b t : ℝ} (hab : a < b) (ht : t ≠ 0) :
+    cgf id (uniformMeasure a b) t =
+      Real.log ((Real.exp (t * b) - Real.exp (t * a)) / ((b - a) * t)) := by
+  rw [cgf, mgf_id_uniformMeasure hab ht]
 
 /-! ### Affine transport
 


### PR DESCRIPTION
Continues Layer 0 item 3, picking up after the mgf landed in #3640.

## Positivity is the content, not a footnote

`cgf X μ t` is `Real.log (mgf X μ t)`, so writing the cgf as a logarithm says nothing useful unless
the argument is known positive. That is proved here rather than assumed:

```lean
theorem mgf_id_uniformMeasure_pos (hab : a < b) (t : ℝ) : 0 < mgf id (uniformMeasure a b) t
```

via Mathlib's `mgf_pos`, whose integrability hypothesis is **exactly** what
`integrableExpSet_id_uniformMeasure` already supplies — so the earlier PR pays for this one, and no
bound is re-derived. `integrable_exp_mul_id_uniformMeasure` reads that integrability off the
exponential-moment set.

## Split at the singularity, as before

| | |
|---|---|
| `cgf_id_uniformMeasure_zero` | `cgf id (uniformMeasure a b) 0 = 0` |
| `cgf_id_uniformMeasure` | `log ((exp (t*b) - exp (t*a)) / ((b - a) * t))`, for `t ≠ 0` |

Same treatment as the mgf: the quotient's removable singularity at `t = 0` is handled by giving the
value directly rather than pushing a proof through it.

## Also: four pre-existing docstrings

A sweep found four public declarations in `Uniform.lean` without docstrings —
`uniformPDFReal_of_mem`, `uniformPDFReal_of_notMem`, `measurable_uniformPDFReal`,
`measurable_uniformPDF_Ioc_volume`. They predate this PR but are now documented; the file has none
undocumented.

## Scope

Remaining in item 3 after this: the characteristic function (again splitting `t = 0`, with the
complex calculation kept clear of the real mgf proof) and parameter measurability. The PR completing
those should carry the `Closes` for #242.

Advances TauCetiProject/TauCetiRoadmap#242 — deliberately not closing it.

Roadmap: StandardDistributions

Authorized by `TauCetiRoadmap/StandardDistributions/README.md`, Layer 0, item 3, which names the cgf
as the real logarithm of the positive mgf.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
