### PR TITLE
feat: the constant field of an algebraic function field

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/ConstantField.lean
+++ b/TauCeti/FieldTheory/FunctionField/ConstantField.lean
@@ -1,0 +1,189 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.AlgebraicClosure
+public import TauCeti.FieldTheory.FunctionField.Basic
+
+/-!
+# The constant field of an algebraic function field
+
+The *field of constants* of an algebraic function field `F / k` is the relative algebraic closure
+`algebraicClosure k F` of `k` in `F`: the elements of `F` that are algebraic over `k`. This file
+proves that it is a finite extension of `k`, records the dictionary for the hypothesis that it is
+no larger than `k` (the literature's "`k` is the full field of constants"), and shows that
+replacing `k` by the field of constants normalizes any function field to one whose field of
+constants is exact.
+
+## Main results
+
+* `TauCeti.IsFunctionField.finiteDimensional_of_isAlgebraic`: an intermediate extension of a
+  function field `F / k` which is algebraic over `k` is finite over `k`.
+* `TauCeti.IsFunctionField.finiteDimensional_algebraicClosure`: the field of constants of a
+  function field is finite over the base field.
+* `TauCeti.algebraicClosure_eq_bot_iff_isIntegrallyClosedIn`,
+  `TauCeti.isIntegrallyClosedIn_iff_forall_isAlgebraic`,
+  `TauCeti.isIntegrallyClosedIn_iff_finrank_algebraicClosure_eq_one`: the three faces of the
+  exactness hypothesis on the field of constants.
+* `TauCeti.IsFunctionField.algebraicClosure` and
+  `TauCeti.isIntegrallyClosedIn_algebraicClosure`: `F` is a function field over its field of
+  constants, and there the field of constants is exact; the two are packaged as
+  `TauCeti.IsFunctionField.exists_intermediateField_isIntegrallyClosedIn`.
+* `TauCeti.algebraicClosure_ratFunc`: `k` is the field of constants of `k(x)`.
+
+## References
+
+The statements follow Stichtenoth, *Algebraic Function Fields and Codes*, second edition:
+Corollary 1.1.16 for the finiteness of the field of constants, the standing hypothesis of
+Section 1.4 for its exactness, and Proposition 1.2.1(d) for the rational function field.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open IntermediateField Polynomial
+
+open scoped RatFunc
+
+universe u v
+
+variable {k : Type u} {F : Type v} [Field k] [Field F] [Algebra k F]
+
+/-! ### Finiteness of the field of constants -/
+
+namespace IsFunctionField
+
+/-- An intermediate extension of an algebraic function field `F / k` which is algebraic over `k`
+is a finite extension of `k`.
+
+This is Stichtenoth, Corollary 1.1.16; the proof transports the hypothesis to Mathlib's
+chosen-parameter formulation and reads off `FunctionField.finiteDimensional_of_constantExtension`,
+which compares `k(x)` with `E(x)`. -/
+theorem finiteDimensional_of_isAlgebraic (hF : IsFunctionField k F) (E : Type*) [Field E]
+    [Algebra k E] [Algebra E F] [IsScalarTower k E F] [Algebra.IsAlgebraic k E] :
+    FiniteDimensional k E := by
+  obtain ⟨x, hx⟩ := hF.exists_transcendental
+  let : Algebra k[X] F := (Polynomial.aeval x).toRingHom.toAlgebra
+  have : IsScalarTower k k[X] F := .of_algebraMap_eq fun c ↦ by
+    simp [RingHom.algebraMap_toAlgebra]
+  have : FaithfulSMul k[X] F :=
+    (faithfulSMul_iff_algebraMap_injective _ _).2 (transcendental_iff_injective.1 hx)
+  let : Algebra E[X] F := (Polynomial.aeval x (R := E)).toRingHom.toAlgebra
+  have : FaithfulSMul E[X] F :=
+    (faithfulSMul_iff_algebraMap_injective _ _).2
+      (transcendental_iff_injective.1 (hx.extendScalars (S := E)))
+  let : Algebra k[X] E[X] := Polynomial.algebra k E
+  have : IsScalarTower k[X] E[X] F := .of_algebraMap_eq fun p ↦
+    (Polynomial.aeval_map_algebraMap E x p).symm
+  have : FunctionField k F := isFunctionField_iff_functionField.1 hF
+  exact FunctionField.finiteDimensional_of_constantExtension F
+
+/-- The field of constants of an algebraic function field is a finite extension of the base
+field (Stichtenoth, Corollary 1.1.16). -/
+theorem finiteDimensional_algebraicClosure (hF : IsFunctionField k F) :
+    FiniteDimensional k (_root_.algebraicClosure k F) :=
+  hF.finiteDimensional_of_isAlgebraic _
+
+/-- Every element of an algebraic function field outside its field of constants is a rational
+parameter (Stichtenoth, Remark 1.1.2 read through the field of constants). -/
+theorem finiteDimensional_adjoin_of_notMem_algebraicClosure (hF : IsFunctionField k F) {y : F}
+    (hy : y ∉ _root_.algebraicClosure k F) : FiniteDimensional k⟮y⟯ F :=
+  hF.finiteDimensional_adjoin fun h ↦ hy (mem_algebraicClosure_iff.2 h)
+
+end IsFunctionField
+
+/-! ### Exactness of the field of constants -/
+
+/-- `k` is integrally closed in `F` exactly when no element of `F` outside `k` is algebraic over
+`k`, that is, when the field of constants of `F / k` is `k` itself. -/
+theorem algebraicClosure_eq_bot_iff_isIntegrallyClosedIn :
+    algebraicClosure k F = ⊥ ↔ IsIntegrallyClosedIn k F := by
+  rw [← IsIntegrallyClosedIn.integralClosure_eq_bot_iff F (algebraMap k F).injective,
+    ← algebraicClosure_toSubalgebra, ← IntermediateField.bot_toSubalgebra,
+    IntermediateField.toSubalgebra_inj]
+
+/-- The elementwise form of the exactness hypothesis on the field of constants: every element of
+`F` algebraic over `k` is already a constant. This is the field-extension reading of Mathlib's
+`isIntegrallyClosedIn_iff`, whose injectivity clause is automatic here. -/
+theorem isIntegrallyClosedIn_iff_forall_isAlgebraic :
+    IsIntegrallyClosedIn k F ↔ ∀ x : F, IsAlgebraic k x → ∃ c : k, algebraMap k F c = x := by
+  rw [← algebraicClosure_eq_bot_iff_isIntegrallyClosedIn, eq_bot_iff, SetLike.le_def]
+  simp [mem_algebraicClosure_iff, IntermediateField.mem_bot]
+
+/-- The exactness hypothesis on the field of constants, read off its degree. -/
+theorem isIntegrallyClosedIn_iff_finrank_algebraicClosure_eq_one :
+    IsIntegrallyClosedIn k F ↔ Module.finrank k (algebraicClosure k F) = 1 := by
+  rw [IntermediateField.finrank_eq_one_iff, algebraicClosure_eq_bot_iff_isIntegrallyClosedIn]
+
+/-- Exactness of the constant field passes to intermediate extensions: if no element of `F`
+outside `k` is algebraic over `k`, the same holds inside any field between `k` and `F`. This
+specializes Mathlib's `AlgHom.isIntegrallyClosedIn` to a tower of fields, where the required
+injectivity is automatic. -/
+theorem isIntegrallyClosedIn_of_tower (E : Type*) [Field E] [Algebra k E] [Algebra E F]
+    [IsScalarTower k E F] [IsIntegrallyClosedIn k F] : IsIntegrallyClosedIn k E :=
+  AlgHom.isIntegrallyClosedIn (IsScalarTower.toAlgHom k E F)
+    (FaithfulSMul.algebraMap_injective E F) inferInstance
+
+/-- The field of constants is exact in itself: nothing in `F` outside `algebraicClosure k F` is
+algebraic over `algebraicClosure k F`. -/
+instance isIntegrallyClosedIn_algebraicClosure :
+    IsIntegrallyClosedIn (algebraicClosure k F) F :=
+  algebraicClosure_eq_bot_iff_isIntegrallyClosedIn.1 (algebraicClosure.algebraicClosure_eq_bot k F)
+
+/-! ### The normalization device -/
+
+/-- An algebraic function field is a function field over its own field of constants, and by
+`TauCeti.isIntegrallyClosedIn_algebraicClosure` the field of constants is exact there.
+
+This is the device that lets a statement needing an exact field of constants be applied to an
+arbitrary function field. -/
+theorem IsFunctionField.algebraicClosure (hF : IsFunctionField k F) :
+    IsFunctionField (_root_.algebraicClosure k F) F := by
+  have : Algebra.EssFiniteType k F := hF.essFiniteType
+  have : Algebra.EssFiniteType (_root_.algebraicClosure k F) F :=
+    Algebra.EssFiniteType.of_comp k (_root_.algebraicClosure k F) F
+  rw [isFunctionField_iff_trdeg_eq_one]
+  have h := lift_trdeg_add_eq k (_root_.algebraicClosure k F) F
+  rw [trdeg_eq_zero_iff.2 inferInstance, hF.trdeg_eq_one] at h
+  simpa using h
+
+/-- The normalization device: every algebraic function field is, over a finite extension of its
+base field, an algebraic function field with an exact field of constants. Later layers, whose
+statements are stated under the exactness hypothesis, are applied to a general function field
+through this. -/
+theorem IsFunctionField.exists_intermediateField_isIntegrallyClosedIn (hF : IsFunctionField k F) :
+    ∃ k' : IntermediateField k F,
+      FiniteDimensional k k' ∧ IsFunctionField k' F ∧ IsIntegrallyClosedIn k' F :=
+  ⟨_root_.algebraicClosure k F, hF.finiteDimensional_algebraicClosure, hF.algebraicClosure,
+    inferInstance⟩
+
+/-! ### The rational function field -/
+
+/-- The field of constants of the rational function field `k(x)` is `k`
+(Stichtenoth, Proposition 1.2.1(d)). -/
+theorem algebraicClosure_ratFunc (K : Type*) [Field K] :
+    algebraicClosure K (RatFunc K) = ⊥ := by
+  refine eq_bot_iff.2 fun f hf ↦ ?_
+  rw [mem_algebraicClosure_iff] at hf
+  obtain ⟨p, rfl⟩ := IsIntegrallyClosed.isIntegral_iff.1
+    (hf.isIntegral.tower_top (A := K[X]))
+  have hp : IsAlgebraic K p :=
+    (isAlgebraic_algebraMap_iff (FaithfulSMul.algebraMap_injective K[X] (RatFunc K))).1 hf
+  have hdeg : p.natDegree = 0 := by
+    by_contra hne
+    exact p.transcendental hne
+      (mem_nonZeroDivisors_of_ne_zero (leadingCoeff_ne_zero.2 fun h ↦ hne (by simp [h]))) hp
+  rw [Polynomial.eq_C_of_natDegree_eq_zero hdeg, RatFunc.algebraMap_C]
+  exact IntermediateField.algebraMap_mem _ _
+
+/-- `k` is integrally closed in the rational function field `k(x)`. -/
+instance isIntegrallyClosedIn_ratFunc : IsIntegrallyClosedIn k (RatFunc k) :=
+  algebraicClosure_eq_bot_iff_isIntegrallyClosedIn.1 (algebraicClosure_ratFunc k)
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/ConstantField.lean
+++ b/TauCeti/FieldTheory/FunctionField/ConstantField.lean
@@ -60,11 +60,7 @@ variable {k : Type u} {F : Type v} [Field k] [Field F] [Algebra k F]
 namespace IsFunctionField
 
 /-- An intermediate extension of an algebraic function field `F / k` which is algebraic over `k`
-is a finite extension of `k`.
-
-This is Stichtenoth, Corollary 1.1.16; the proof transports the hypothesis to Mathlib's
-chosen-parameter formulation and reads off `FunctionField.finiteDimensional_of_constantExtension`,
-which compares `k(x)` with `E(x)`. -/
+is a finite extension of `k` (Stichtenoth, Corollary 1.1.16). -/
 theorem finiteDimensional_of_isAlgebraic (hF : IsFunctionField k F) (E : Type*) [Field E]
     [Algebra k E] [Algebra E F] [IsScalarTower k E F] [Algebra.IsAlgebraic k E] :
     FiniteDimensional k E := by

--- a/TauCeti/FieldTheory/FunctionField/ConstantField.lean
+++ b/TauCeti/FieldTheory/FunctionField/ConstantField.lean
@@ -90,12 +90,6 @@ theorem finiteDimensional_algebraicClosure (hF : IsFunctionField k F) :
     FiniteDimensional k (_root_.algebraicClosure k F) :=
   hF.finiteDimensional_of_isAlgebraic _
 
-/-- Every element of an algebraic function field outside its field of constants is a rational
-parameter (Stichtenoth, Remark 1.1.2 read through the field of constants). -/
-theorem finiteDimensional_adjoin_of_notMem_algebraicClosure (hF : IsFunctionField k F) {y : F}
-    (hy : y ∉ _root_.algebraicClosure k F) : FiniteDimensional k⟮y⟯ F :=
-  hF.finiteDimensional_adjoin fun h ↦ hy (mem_algebraicClosure_iff.2 h)
-
 end IsFunctionField
 
 /-! ### Exactness of the field of constants -/
@@ -120,15 +114,6 @@ theorem isIntegrallyClosedIn_iff_forall_isAlgebraic :
 theorem isIntegrallyClosedIn_iff_finrank_algebraicClosure_eq_one :
     IsIntegrallyClosedIn k F ↔ Module.finrank k (algebraicClosure k F) = 1 := by
   rw [IntermediateField.finrank_eq_one_iff, algebraicClosure_eq_bot_iff_isIntegrallyClosedIn]
-
-/-- Exactness of the constant field passes to intermediate extensions: if no element of `F`
-outside `k` is algebraic over `k`, the same holds inside any field between `k` and `F`. This
-specializes Mathlib's `AlgHom.isIntegrallyClosedIn` to a tower of fields, where the required
-injectivity is automatic. -/
-theorem isIntegrallyClosedIn_of_tower (E : Type*) [Field E] [Algebra k E] [Algebra E F]
-    [IsScalarTower k E F] [IsIntegrallyClosedIn k F] : IsIntegrallyClosedIn k E :=
-  AlgHom.isIntegrallyClosedIn (IsScalarTower.toAlgHom k E F)
-    (FaithfulSMul.algebraMap_injective E F) inferInstance
 
 /-- The field of constants is exact in itself: nothing in `F` outside `algebraicClosure k F` is
 algebraic over `algebraicClosure k F`. -/
@@ -170,16 +155,9 @@ theorem IsFunctionField.exists_intermediateField_isIntegrallyClosedIn (hF : IsFu
 theorem algebraicClosure_ratFunc (K : Type*) [Field K] :
     algebraicClosure K (RatFunc K) = ⊥ := by
   refine eq_bot_iff.2 fun f hf ↦ ?_
-  rw [mem_algebraicClosure_iff] at hf
-  obtain ⟨p, rfl⟩ := IsIntegrallyClosed.isIntegral_iff.1
-    (hf.isIntegral.tower_top (A := K[X]))
-  have hp : IsAlgebraic K p :=
-    (isAlgebraic_algebraMap_iff (FaithfulSMul.algebraMap_injective K[X] (RatFunc K))).1 hf
-  have hdeg : p.natDegree = 0 := by
-    by_contra hne
-    exact p.transcendental hne
-      (mem_nonZeroDivisors_of_ne_zero (leadingCoeff_ne_zero.2 fun h ↦ hne (by simp [h]))) hp
-  rw [Polynomial.eq_C_of_natDegree_eq_zero hdeg, RatFunc.algebraMap_C]
+  obtain ⟨c, rfl⟩ := not_not.1 fun h ↦
+    RatFunc.transcendental_of_ne_C f h (mem_algebraicClosure_iff.1 hf)
+  rw [← RatFunc.algebraMap_eq_C]
   exact IntermediateField.algebraMap_mem _ _
 
 /-- `k` is integrally closed in the rational function field `k(x)`. -/


### PR DESCRIPTION
This PR builds the theory of the field of constants of an algebraic function field `F / k`, taken as Mathlib's relative algebraic closure `algebraicClosure k F`. It proves Stichtenoth's Corollary 1.1.16 — every intermediate extension of `F / k` that is algebraic over `k` is finite over `k`, in particular the field of constants is — by installing the algebra instances that transport the repository's intrinsic `IsFunctionField` predicate to Mathlib's chosen-parameter formulation and then reading off `FunctionField.finiteDimensional_of_constantExtension`, exactly as the roadmap directs. It then records the three faces of the exactness hypothesis on the field of constants — `algebraicClosure k F = ⊥`, the pinned `IsIntegrallyClosedIn k F`, and the elementwise "every element of `F` algebraic over `k` is a constant", plus the degree reading `finrank k (algebraicClosure k F) = 1` — proves that the field of constants is exact in itself, and shows that `F` is again an algebraic function field over it. The last two combine into `IsFunctionField.exists_intermediateField_isIntegrallyClosedIn`: every function field is, over a finite extension of its base field inside it, a function field with an exact field of constants. This is the normalization device that later layers cite when they apply a statement carrying the exactness hypothesis to an arbitrary function field. Finally the theory is exercised on the base case: `k` is the field of constants of the rational function field `k(x)` (Stichtenoth, Proposition 1.2.1(d)), which is where the exactness hypothesis is first discharged rather than assumed.

The milestone served is the "constant field" bullet of Layer 0 of the AlgebraicCurves roadmap ("function fields, constant fields, and places"), which asks for `k̃ := algebraicClosure k F` consumed rather than rebuilt, its finiteness over `k` (Corollary 1.1.16, consuming `finiteDimensional_of_constantExtension`), `IsIntegrallyClosedIn k F` as pinned with the `∀`-algebraic and `algebraicClosure k F = ⊥` equivalences, and "`F/k̃` is a function field with exact constants — the normalization device every later layer cites". This PR supplies all four; it builds directly on the merged `TauCeti.IsFunctionField` predicate, whose parameter-independence, `EssFiniteType`, transcendence-degree and Mathlib-comparison lemmas are what the proofs run through. What remains in Layer 0 after this PR is the places half — the `Place` structure with its valuation ring, `ord_P`, and residue degrees, the existence theorem 1.1.19, and weak approximation — which is independent of this bullet and is being taken up separately; Layer 1's classification of the places of `k(x)` then follows.

No Mathlib infrastructure was vendored. The file consumes `algebraicClosure` and its `algebraicClosure.algebraicClosure_eq_bot`, `FunctionField.finiteDimensional_of_constantExtension`, `IsIntegrallyClosedIn.integralClosure_eq_bot_iff`, `AlgHom.isIntegrallyClosedIn`, `Transcendental.extendScalars`, `RatFunc.liftAlgebra` and `Polynomial.transcendental` as they stand at the pin.

New module: `TauCeti/FieldTheory/FunctionField/ConstantField.lean` (189 lines).

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"constant-field"}-->

🤖 Prepared with Claude Code
