### PR TITLE
feat: integral and even overlattices via isotropic subgroups

### DIFF
--- a/TauCeti/Algebra/AddCircle.lean
+++ b/TauCeti/Algebra/AddCircle.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Operations
+public import Mathlib.Topology.Instances.AddCircle.Defs
+
+/-!
+# Integrality in the rational circle group
+
+A rational number reduces to zero in `ℚ/ℤ`, realized as `AddCircle (1 : ℚ)`, exactly when it
+lies in `(1 : Submodule ℤ ℚ)`, the copy of `ℤ` inside `ℚ`. This bridges the two spellings of
+integrality used by the discriminant-form theory: vanishing in the circle group and membership
+in the unit `ℤ`-submodule.
+
+## Main declarations
+
+* `AddCircle.coe_eq_zero_iff_mem_one`: vanishing in `AddCircle (1 : ℚ)` is membership in
+  `(1 : Submodule ℤ ℚ)`.
+-/
+
+public section
+
+namespace AddCircle
+
+/-- A rational number reduces to zero in `ℚ/ℤ` exactly when it is an integer. -/
+theorem coe_eq_zero_iff_mem_one (q : ℚ) :
+    (q : AddCircle (1 : ℚ)) = 0 ↔ q ∈ (1 : Submodule ℤ ℚ) := by
+  constructor
+  · intro h
+    obtain ⟨n, hn⟩ := (coe_eq_zero_iff (1 : ℚ)).mp h
+    exact Submodule.mem_one.mpr ⟨n, by simpa using hn⟩
+  · intro h
+    obtain ⟨n, hn⟩ := Submodule.mem_one.mp h
+    exact (coe_eq_zero_iff (1 : ℚ)).mpr ⟨n, by simpa using hn⟩
+
+end AddCircle

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
@@ -588,6 +588,11 @@ theorem isIsotropicElem_prod (B : FiniteBilinearModule) (x : A) (y : B) :
 /-- A subgroup is bilinearly isotropic when the pairing vanishes on the subgroup square. -/
 def IsIsotropic (H : AddSubgroup A) : Prop := ∀ x ∈ H, ∀ y ∈ H, A.pairing x y = 0
 
+/-- Bilinear isotropy of a subgroup, unfolded to its defining property. -/
+theorem isIsotropic_def {H : AddSubgroup A} :
+    A.IsIsotropic H ↔ ∀ x ∈ H, ∀ y ∈ H, A.pairing x y = 0 :=
+  Iff.rfl
+
 /-- An element belonging to an isotropic subgroup is isotropic. -/
 theorem isIsotropicElem_of_mem_isIsotropic {H : AddSubgroup A} (hH : A.IsIsotropic H) {x : A}
     (hx : x ∈ H) : A.IsIsotropicElem x :=

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -257,6 +257,11 @@ theorem isIsotropicElem_prod (B : FiniteQuadraticModule) (x : A) (y : B) :
 /-- A subgroup is quadratically isotropic when the quadratic map vanishes on it. -/
 def IsIsotropic (H : AddSubgroup A) : Prop := ∀ x ∈ H, A.quadratic x = 0
 
+/-- Quadratic isotropy of a subgroup, unfolded to its defining property. -/
+theorem isIsotropic_def {H : AddSubgroup A} :
+    A.IsIsotropic H ↔ ∀ x ∈ H, A.quadratic x = 0 :=
+  Iff.rfl
+
 /-- A quadratic isometry transports quadratic isotropy of a subgroup. -/
 @[simp]
 theorem Isometry.isIsotropic_map_iff {B : FiniteQuadraticModule} (f : Isometry A B)

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Quotient.Bilinear
+public import TauCeti.Algebra.AddCircle
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Basic
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Group
 
@@ -69,17 +70,6 @@ private theorem dualCarrierFormModOne_apply (L : IntegralLattice V) (x y : L.dua
     L.dualCarrierFormModOne x y = (L.form x y : AddCircle (1 : ℚ)) :=
   (rfl)
 
-/-- A rational number reduces to zero in `ℚ/ℤ` exactly when it is an integer. -/
-theorem coe_eq_zero_iff_mem_one (q : ℚ) :
-    (q : AddCircle (1 : ℚ)) = 0 ↔ q ∈ (1 : Submodule ℤ ℚ) := by
-  constructor
-  · intro h
-    obtain ⟨n, hn⟩ := (AddCircle.coe_eq_zero_iff (1 : ℚ)).mp h
-    exact Submodule.mem_one.mpr ⟨n, by simpa using hn⟩
-  · intro h
-    obtain ⟨n, hn⟩ := Submodule.mem_one.mp h
-    exact (AddCircle.coe_eq_zero_iff (1 : ℚ)).mpr ⟨n, by simpa using hn⟩
-
 /-- The pairing modulo `ℤ` is symmetric, hence reflexive in the sense needed to descend a
 bilinear map through the same quotient in both variables. -/
 private theorem dualCarrierFormModOne_isRefl (L : IntegralLattice V) :
@@ -96,7 +86,7 @@ private theorem carrierInDual_le_ker_dualCarrierFormModOne (L : IntegralLattice 
   rw [LinearMap.mem_ker]
   ext y
   rw [LinearMap.zero_apply, dualCarrierFormModOne_apply]
-  apply (coe_eq_zero_iff_mem_one _).mpr
+  apply (AddCircle.coe_eq_zero_iff_mem_one _).mpr
   have hyx : L.form y x ∈ (1 : Submodule ℤ ℚ) :=
     y.2 x ((L.mem_carrierInDual_iff x).mp hx)
   rw [L.isSymm.eq]
@@ -114,6 +104,14 @@ theorem discriminantPairing_mk (L : IntegralLattice V) (x y : L.dualCarrier) :
     L.discriminantPairing (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
       (L.form x y : AddCircle (1 : ℚ)) :=
   (rfl)
+
+/-- The discriminant pairing of two representatives vanishes exactly when the ambient form
+pairs them integrally. -/
+theorem discriminantPairing_mk_eq_zero_iff (L : IntegralLattice V) (x y : L.dualCarrier) :
+    L.discriminantPairing (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) = 0 ↔
+      L.form x y ∈ (1 : Submodule ℤ ℚ) := by
+  rw [discriminantPairing_mk]
+  exact AddCircle.coe_eq_zero_iff_mem_one _
 
 /-- The discriminant pairing is symmetric. -/
 theorem discriminantPairing_comm (L : IntegralLattice V) (x y : L.DiscriminantGroup) :
@@ -156,7 +154,7 @@ private theorem injective_discriminantPairing (L : IntegralLattice V) [L.IsNonde
       have hzero : (L.form ((x - y : L.dualCarrier) : V) z : AddCircle (1 : ℚ)) = 0 := by
         rw [Submodule.coe_sub, map_sub, LinearMap.sub_apply, AddCircle.coe_sub, sub_eq_zero]
         exact hpair
-      exact (coe_eq_zero_iff_mem_one _).mp hzero
+      exact (AddCircle.coe_eq_zero_iff_mem_one _).mp hzero
 
 /-- The discriminant bilinear module of a nondegenerate integral lattice is nondegenerate. -/
 theorem isNondegenerate_discriminantBilinearModule (L : IntegralLattice V)

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
@@ -69,7 +69,8 @@ private theorem dualCarrierFormModOne_apply (L : IntegralLattice V) (x y : L.dua
     L.dualCarrierFormModOne x y = (L.form x y : AddCircle (1 : ℚ)) :=
   (rfl)
 
-private theorem coe_eq_zero_iff_mem_one (q : ℚ) :
+/-- A rational number reduces to zero in `ℚ/ℤ` exactly when it is an integer. -/
+theorem coe_eq_zero_iff_mem_one (q : ℚ) :
     (q : AddCircle (1 : ℚ)) = 0 ↔ q ∈ (1 : Submodule ℤ ℚ) := by
   constructor
   · intro h

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Quadratic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
+public import TauCeti.Algebra.AddCircle
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Bilinear
 public import TauCeti.LinearAlgebra.IntegralLattice.Even
@@ -86,11 +87,6 @@ private theorem dualCarrierHalfNormModOne_apply (L : IntegralLattice V)
       ((L.form x x / 2 : ℚ) : AddCircle (1 : ℚ)) :=
   rfl
 
-private theorem coe_rat_eq_zero_of_eq_int (q : ℚ) (z : ℤ) (hq : q = z) :
-    (q : AddCircle (1 : ℚ)) = 0 := by
-  subst q
-  exact (AddCircle.coe_eq_zero_iff (1 : ℚ)).mpr ⟨z, by simp⟩
-
 /-- For an even lattice, its original carrier lies in the radical of the half-norm modulo `Z` on
 the dual carrier.  This is the representative-independence condition for the discriminant
 quadratic map. -/
@@ -102,10 +98,10 @@ private theorem carrierInDual_le_radical_dualCarrierHalfNormModOne
   · rw [dualCarrierHalfNormModOne_apply]
     obtain ⟨z, hz⟩ := hL.exists_norm_eq_two_mul
       ⟨x, (L.mem_carrierInDual_iff x).mp hx⟩
-    apply coe_rat_eq_zero_of_eq_int _ z
+    refine (AddCircle.coe_eq_zero_iff_mem_one _).mpr (Submodule.mem_one.mpr ⟨z, ?_⟩)
     rw [L.norm_apply] at hz
-    rw [hz]
-    norm_num
+    rw [eq_intCast, hz]
+    ring
   · apply LinearMap.ext
     intro y
     rw [dualCarrierHalfNormModOne, QuadraticMap.polarBilin_apply_apply, LinearMap.zero_apply,
@@ -114,9 +110,9 @@ private theorem carrierInDual_le_radical_dualCarrierHalfNormModOne
     obtain ⟨z, hz⟩ := Submodule.mem_one.mp
       (y.2 x ((L.mem_carrierInDual_iff x).mp hx))
     rw [← AddCircle.coe_add]
-    apply coe_rat_eq_zero_of_eq_int _ z
+    refine (AddCircle.coe_eq_zero_iff_mem_one _).mpr (Submodule.mem_one.mpr ⟨z, ?_⟩)
     have hz' : L.form y x = (z : ℚ) := by simpa using hz.symm
-    rw [hz']
+    rw [eq_intCast, hz']
     ring
 
 /-- The discriminant quadratic map of an even integral lattice, in the half-norm convention.
@@ -136,6 +132,26 @@ theorem discriminantQuadraticMap_mk (L : IntegralLattice V) (hL : L.IsEven)
       ((L.form x x / 2 : ℚ) : AddCircle (1 : ℚ)) := by
   rw [discriminantQuadraticMap, QuadraticMap.lift_mk,
     dualCarrierHalfNormModOne_apply]
+
+/-- The discriminant quadratic value of a representative vanishes exactly when the ambient
+self-pairing is twice an integer. -/
+theorem discriminantQuadraticMap_mk_eq_zero_iff (L : IntegralLattice V) (hL : L.IsEven)
+    (x : L.dualCarrier) :
+    L.discriminantQuadraticMap hL (Submodule.Quotient.mk x) = 0 ↔
+      ∃ n : ℤ, L.form x x = ((2 * n : ℤ) : ℚ) := by
+  rw [discriminantQuadraticMap_mk, AddCircle.coe_eq_zero_iff_mem_one]
+  constructor
+  · intro h
+    obtain ⟨n, hn⟩ := Submodule.mem_one.mp h
+    rw [eq_intCast] at hn
+    refine ⟨n, ?_⟩
+    push_cast
+    linarith [hn]
+  · rintro ⟨n, hn⟩
+    refine Submodule.mem_one.mpr ⟨n, ?_⟩
+    rw [eq_intCast, hn]
+    push_cast
+    ring
 
 /-- The polar of the half-norm discriminant quadratic map is the discriminant pairing. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Basic.lean
@@ -29,7 +29,9 @@ intermediate carrier is also proved to be a full `ℤ`-lattice in the common rat
 when `L` is nondegenerate. The correspondence and its membership, inverse, and order lemmas do not
 require nondegeneracy; only this fullness result does.
 
-Integrality and evenness of an intermediate carrier are deliberately not assumed here.
+Integrality and evenness of an intermediate carrier are deliberately not assumed here; the
+restrictions of the correspondence they cut out live in
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Isotropic`.
 
 ## Main declarations
 
@@ -40,12 +42,6 @@ Integrality and evenness of an intermediate carrier are deliberately not assumed
   intermediate carrier in `A_L`.
 * `TauCeti.IntegralLattice.intermediateCarrierOfDiscriminantSubgroup`: the inverse-image carrier
   `L_H` attached to a subgroup `H` of `A_L`.
-
-## TODO
-
-Restrict this correspondence to the bilinear-isotropic subgroups of `A_L`, which cut out the
-integral intermediate carriers, and to the quadratic-isotropic subgroups, which cut out the even
-ones. Neither refinement is formalized yet.
 
 ## References
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Isotropic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Isotropic.lean
@@ -13,27 +13,32 @@ public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Basic
 
 Let `L` be an integral lattice. This file refines the intermediate-carrier correspondence of
 `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Basic` by the two properties an intermediate
-carrier `L ≤ M ≤ Lᵛ` can enjoy: `M` is *integral* when the rational form takes integer values on
-pairs of its vectors, and `M` is *even* when every self-pairing of its vectors is an even integer.
-Evenness implies integrality by polarization, mirroring the classical fact that even lattices are
-integral.
+carrier `L ≤ M ≤ Lᵛ` can enjoy: `M` is *integral* when it lies in its own dual submodule, so the
+rational form pairs its vectors integrally, and `M` is *even* when the norm of each of its
+vectors is twice an integer. Evenness implies integrality by polarization, mirroring the
+classical fact that even lattices are integral.
 
-The characteristic results locate both classes inside the discriminant group. A carrier `M` is
-integral exactly when the discriminant bilinear pairing vanishes on the subgroup `M / L` of
-`A_L = Lᵛ / L`, and, when `L` is even, `M` is even exactly when the discriminant quadratic map
-vanishes on `M / L`. Restricting the intermediate-carrier order isomorphism accordingly packages
-the two gluing correspondences: integral carriers correspond to bilinear-isotropic subgroups, and
-even carriers of an even lattice correspond to quadratic-isotropic subgroups.
+The characteristic results locate both classes inside the discriminant group, in two stages. For
+any integral lattice, `M` is integral exactly when the discriminant pairing vanishes on the
+subgroup `M / L` of `A_L = Lᵛ / L`, and, when `L` is even, `M` is even exactly when the
+discriminant quadratic map vanishes on `M / L`. When `L` is moreover nondegenerate — so that the
+discriminant group packages as a finite bilinear or quadratic module — these become isotropy of
+`M / L`, and restricting the intermediate-carrier order isomorphism accordingly packages the two
+gluing correspondences: integral carriers correspond to bilinear-isotropic subgroups, and even
+carriers of an even lattice correspond to quadratic-isotropic subgroups.
 
 ## Main declarations
 
 * `TauCeti.IntegralLattice.IntermediateCarrier.IsIntegral`: integrality of an intermediate
   carrier.
 * `TauCeti.IntegralLattice.IntermediateCarrier.IsEven`: evenness of an intermediate carrier.
-* `TauCeti.IntegralLattice.IntermediateCarrier.isIntegral_iff_isIsotropic_discriminantSubgroup`:
-  integral carriers are cut out by bilinear isotropy in the discriminant group.
-* `TauCeti.IntegralLattice.IntermediateCarrier.isEven_iff_isIsotropic_discriminantSubgroup`: even
-  carriers of an even lattice are cut out by quadratic isotropy in the discriminant group.
+* `TauCeti.IntegralLattice.IntermediateCarrier.isIntegral_iff_forall_discriminantPairing_eq_zero`:
+  integral carriers are cut out by vanishing of the discriminant pairing.
+* `TauCeti.IntegralLattice.IntermediateCarrier.isEven_iff_forall_discriminantQuadraticMap_eq_zero`:
+  even carriers of an even lattice are cut out by vanishing of the discriminant quadratic map.
+* `TauCeti.IntegralLattice.IntermediateCarrier.isIntegral_iff_isIsotropic_discriminantSubgroup`,
+  `TauCeti.IntegralLattice.IntermediateCarrier.isEven_iff_isIsotropic_discriminantSubgroup`: the
+  isotropy forms of the two criteria, for a nondegenerate lattice.
 * `TauCeti.IntegralLattice.integralIntermediateCarrierOrderIsoIsotropicSubgroup`: the restriction
   of the intermediate-carrier order isomorphism to integral carriers.
 * `TauCeti.IntegralLattice.evenIntermediateCarrierOrderIsoIsotropicSubgroup`: the restriction of
@@ -62,126 +67,172 @@ variable {V : Type u} [AddCommGroup V] [Module ℚ V] {L : IntegralLattice V}
 
 namespace IntermediateCarrier
 
-/-- An intermediate carrier is integral when the rational form pairs its vectors integrally. -/
+/-- An intermediate carrier is integral when it lies in its own dual submodule, the shape of
+`IntegralLattice.le_dual`. -/
 def IsIntegral (M : L.IntermediateCarrier) : Prop :=
-  ∀ x ∈ M.1, ∀ y ∈ M.1, L.form x y ∈ (1 : Submodule ℤ ℚ)
+  M.1 ≤ L.form.dualSubmodule M.1
 
-/-- Integrality of an intermediate carrier, unfolded to its defining property. -/
+/-- Integrality of an intermediate carrier, unfolded to elementwise integrality of the form. -/
 theorem isIntegral_def {M : L.IntermediateCarrier} :
     IsIntegral M ↔ ∀ x ∈ M.1, ∀ y ∈ M.1, L.form x y ∈ (1 : Submodule ℤ ℚ) :=
   Iff.rfl
 
-/-- An intermediate carrier is even when every self-pairing of its vectors is an even integer. -/
+/-- An intermediate carrier is even when every norm of its vectors is twice an integer, the
+normal form of `IntegralLattice.isEven_iff_forall_norm`. -/
 def IsEven (M : L.IntermediateCarrier) : Prop :=
-  ∀ x ∈ M.1, ∃ n : ℤ, L.form x x = ((2 * n : ℤ) : ℚ)
+  ∀ x ∈ M.1, ∃ n : ℤ, L.norm x = 2 * n
 
 /-- Evenness of an intermediate carrier, unfolded to its defining property. -/
 theorem isEven_def {M : L.IntermediateCarrier} :
-    IsEven M ↔ ∀ x ∈ M.1, ∃ n : ℤ, L.form x x = ((2 * n : ℤ) : ℚ) :=
+    IsEven M ↔ ∀ x ∈ M.1, ∃ n : ℤ, L.norm x = 2 * n :=
   Iff.rfl
 
 /-- The bottom intermediate carrier, the lattice itself, is integral. -/
+@[simp]
 theorem isIntegral_bot : IsIntegral (⊥ : L.IntermediateCarrier) := by
-  intro x hx y hy
-  rw [Set.Icc.coe_bot] at hx hy
-  exact L.le_dual hx y hy
+  simp only [IsIntegral, Set.Icc.coe_bot]
+  exact L.le_dual
 
 /-- The bottom intermediate carrier is even exactly when the lattice itself is even. -/
+@[simp]
 theorem isEven_bot_iff : IsEven (⊥ : L.IntermediateCarrier) ↔ L.IsEven := by
   rw [L.isEven_iff_forall_norm]
   constructor
   · intro h x
-    obtain ⟨n, hn⟩ := h (x : V) (by rw [Set.Icc.coe_bot]; exact x.2)
-    refine ⟨n, ?_⟩
-    rw [L.norm_apply, hn]
-    push_cast
-    ring
+    exact h x (by rw [Set.Icc.coe_bot]; exact x.2)
   · intro h x hx
     rw [Set.Icc.coe_bot] at hx
-    obtain ⟨n, hn⟩ := h ⟨x, hx⟩
-    rw [L.norm_apply] at hn
-    refine ⟨n, ?_⟩
-    push_cast
-    simpa using hn
+    exact h ⟨x, hx⟩
+
+/-- Integrality descends along containment of intermediate carriers. -/
+theorem IsIntegral.mono {M N : L.IntermediateCarrier} (hN : IsIntegral N) (h : M ≤ N) :
+    IsIntegral M := by
+  have h' : M.1 ≤ N.1 := Subtype.coe_le_coe.mpr h
+  rw [isIntegral_def] at hN ⊢
+  intro x hx y hy
+  exact hN x (h' hx) y (h' hy)
+
+/-- Evenness descends along containment of intermediate carriers. -/
+theorem IsEven.mono {M N : L.IntermediateCarrier} (hN : IsEven N) (h : M ≤ N) :
+    IsEven M := fun x hx ↦ hN x (Subtype.coe_le_coe.mpr h hx)
 
 /-- Evenness of an intermediate carrier implies its integrality, by polarization. -/
 theorem IsEven.isIntegral {M : L.IntermediateCarrier} (hM : IsEven M) : IsIntegral M := by
+  rw [isIntegral_def]
   intro x hx y hy
   obtain ⟨a, ha⟩ := hM (x + y) (M.1.add_mem hx hy)
   obtain ⟨b, hb⟩ := hM x hx
   obtain ⟨c, hc⟩ := hM y hy
-  have hexpand : L.form (x + y) (x + y) =
-      L.form x x + L.form x y + (L.form y x + L.form y y) := by
-    simp only [map_add, LinearMap.add_apply]
-    ring
-  have hyx : L.form y x = L.form x y := by simpa using L.isSymm.eq y x
+  have hadd := L.norm_add x y
   refine Submodule.mem_one.mpr ⟨a - b - c, ?_⟩
   rw [eq_intCast]
   push_cast at ha hb hc ⊢
-  linarith [hexpand, hyx, ha, hb, hc]
+  linarith [hadd, ha, hb, hc]
 
-variable [L.IsNondegenerate]
-
-/-- **Integrality is bilinear isotropy.** An intermediate carrier is integral exactly when the
-discriminant bilinear pairing vanishes on its subgroup of the discriminant group. -/
-theorem isIntegral_iff_isIsotropic_discriminantSubgroup (M : L.IntermediateCarrier) :
-    IsIntegral M ↔ L.discriminantBilinearModule.IsIsotropic (L.discriminantSubgroup M) := by
+/-- **Integrality is vanishing of the discriminant pairing.** An intermediate carrier is
+integral exactly when the discriminant pairing vanishes on its subgroup of the discriminant
+group. No nondegeneracy is required. -/
+theorem isIntegral_iff_forall_discriminantPairing_eq_zero (M : L.IntermediateCarrier) :
+    IsIntegral M ↔ ∀ x ∈ L.discriminantSubgroup M, ∀ y ∈ L.discriminantSubgroup M,
+      L.discriminantPairing x y = 0 := by
+  rw [isIntegral_def]
   constructor
-  · intro hM
-    refine L.discriminantBilinearModule.isIsotropic_def.mpr ?_
-    intro x hx y hy
+  · intro hM x hx y hy
     obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ x
     obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective _ y
-    rw [discriminantBilinearModule_pairing, discriminantPairing_mk]
-    exact (coe_eq_zero_iff_mem_one _).mpr
+    exact (L.discriminantPairing_mk_eq_zero_iff x y).mpr
       (hM x ((L.mk_mem_discriminantSubgroup_iff M x).mp hx) y
         ((L.mk_mem_discriminantSubgroup_iff M y).mp hy))
   · intro hH x hx y hy
     have hxd : x ∈ L.dualCarrier := M.2.2 hx
     have hyd : y ∈ L.dualCarrier := M.2.2 hy
-    have h0 := L.discriminantBilinearModule.isIsotropic_def.mp hH (Submodule.Quotient.mk ⟨x, hxd⟩)
-      ((L.mk_mem_discriminantSubgroup_iff M ⟨x, hxd⟩).mpr hx)
-      (Submodule.Quotient.mk ⟨y, hyd⟩)
-      ((L.mk_mem_discriminantSubgroup_iff M ⟨y, hyd⟩).mpr hy)
-    rw [discriminantBilinearModule_pairing, discriminantPairing_mk] at h0
-    exact (coe_eq_zero_iff_mem_one _).mp h0
+    exact (L.discriminantPairing_mk_eq_zero_iff ⟨x, hxd⟩ ⟨y, hyd⟩).mp
+      (hH _ ((L.mk_mem_discriminantSubgroup_iff M ⟨x, hxd⟩).mpr hx)
+        _ ((L.mk_mem_discriminantSubgroup_iff M ⟨y, hyd⟩).mpr hy))
 
-/-- **Evenness is quadratic isotropy.** For an even lattice, an intermediate carrier is even
-exactly when the discriminant quadratic map vanishes on its subgroup of the discriminant group. -/
-theorem isEven_iff_isIsotropic_discriminantSubgroup (hL : L.IsEven) (M : L.IntermediateCarrier) :
-    IsEven M ↔ (L.discriminantQuadraticModule hL).IsIsotropic (L.discriminantSubgroup M) := by
+/-- **Evenness is vanishing of the discriminant quadratic map.** For an even lattice, an
+intermediate carrier is even exactly when the discriminant quadratic map vanishes on its
+subgroup of the discriminant group. No nondegeneracy is required. -/
+theorem isEven_iff_forall_discriminantQuadraticMap_eq_zero (hL : L.IsEven)
+    (M : L.IntermediateCarrier) :
+    IsEven M ↔ ∀ x ∈ L.discriminantSubgroup M, L.discriminantQuadraticMap hL x = 0 := by
   constructor
-  · intro hM
-    refine (L.discriminantQuadraticModule hL).isIsotropic_def.mpr ?_
-    intro x hx
+  · intro hM x hx
     obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ x
-    rw [discriminantQuadraticModule_quadratic, discriminantQuadraticMap_mk]
     obtain ⟨n, hn⟩ := hM x ((L.mk_mem_discriminantSubgroup_iff M x).mp hx)
-    refine (coe_eq_zero_iff_mem_one _).mpr (Submodule.mem_one.mpr ⟨n, ?_⟩)
-    rw [eq_intCast, hn]
+    refine (L.discriminantQuadraticMap_mk_eq_zero_iff hL x).mpr ⟨n, ?_⟩
+    rw [← L.norm_apply, hn]
     push_cast
     ring
   · intro hH x hx
     have hxd : x ∈ L.dualCarrier := M.2.2 hx
-    have h0 := (L.discriminantQuadraticModule hL).isIsotropic_def.mp hH
-      (Submodule.Quotient.mk ⟨x, hxd⟩)
-      ((L.mk_mem_discriminantSubgroup_iff M ⟨x, hxd⟩).mpr hx)
-    rw [discriminantQuadraticModule_quadratic, discriminantQuadraticMap_mk] at h0
-    obtain ⟨n, hn⟩ := Submodule.mem_one.mp ((coe_eq_zero_iff_mem_one _).mp h0)
-    rw [eq_intCast] at hn
+    obtain ⟨n, hn⟩ := (L.discriminantQuadraticMap_mk_eq_zero_iff hL ⟨x, hxd⟩).mp
+      (hH _ ((L.mk_mem_discriminantSubgroup_iff M ⟨x, hxd⟩).mpr hx))
     refine ⟨n, ?_⟩
-    have hn' : (n : ℚ) = L.form x x / 2 := by simpa using hn
-    push_cast
-    linarith [hn']
+    rw [L.norm_apply]
+    simpa using hn
+
+variable [L.IsNondegenerate]
+
+/-- **Integrality is bilinear isotropy.** For a nondegenerate lattice, an intermediate carrier
+is integral exactly when its subgroup of the discriminant group is isotropic in the discriminant
+bilinear module. -/
+theorem isIntegral_iff_isIsotropic_discriminantSubgroup (M : L.IntermediateCarrier) :
+    IsIntegral M ↔ L.discriminantBilinearModule.IsIsotropic (L.discriminantSubgroup M) := by
+  rw [isIntegral_iff_forall_discriminantPairing_eq_zero]
+  constructor
+  · intro h
+    exact L.discriminantBilinearModule.isIsotropic_def.mpr fun x hx y hy ↦
+      (L.discriminantBilinearModule_pairing x y).trans (h x hx y hy)
+  · intro h x hx y hy
+    exact (L.discriminantBilinearModule_pairing x y).symm.trans
+      (L.discriminantBilinearModule.isIsotropic_def.mp h x hx y hy)
+
+/-- **Evenness is quadratic isotropy.** For an even nondegenerate lattice, an intermediate
+carrier is even exactly when its subgroup of the discriminant group is isotropic in the
+discriminant quadratic module. -/
+theorem isEven_iff_isIsotropic_discriminantSubgroup (hL : L.IsEven) (M : L.IntermediateCarrier) :
+    IsEven M ↔ (L.discriminantQuadraticModule hL).IsIsotropic (L.discriminantSubgroup M) := by
+  rw [isEven_iff_forall_discriminantQuadraticMap_eq_zero hL]
+  constructor
+  · intro h
+    exact (L.discriminantQuadraticModule hL).isIsotropic_def.mpr fun x hx ↦
+      (L.discriminantQuadraticModule_quadratic hL x).trans (h x hx)
+  · intro h x hx
+    exact (L.discriminantQuadraticModule_quadratic hL x).symm.trans
+      ((L.discriminantQuadraticModule hL).isIsotropic_def.mp h x hx)
 
 end IntermediateCarrier
 
 open IntermediateCarrier
 
-variable (L : IntegralLattice V) [L.IsNondegenerate]
+variable (L : IntegralLattice V)
+
+/-- Restrict the intermediate-carrier order isomorphism along a predicate characterization: a
+predicate on carriers matching a predicate on discriminant subgroups induces an order
+isomorphism of the corresponding subtypes. -/
+private def restrictOrderIso {p : L.IntermediateCarrier → Prop}
+    {q : AddSubgroup L.DiscriminantGroup → Prop}
+    (h : ∀ M, p M ↔ q (L.discriminantSubgroup M)) :
+    {M : L.IntermediateCarrier // p M} ≃o {H : AddSubgroup L.DiscriminantGroup // q H} where
+  toEquiv :=
+    { toFun := fun M ↦ ⟨L.discriminantSubgroup M.1, (h M.1).mp M.2⟩
+      invFun := fun H ↦ ⟨L.intermediateCarrierOfDiscriminantSubgroup H.1, (h _).mpr (by
+        rw [L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup]
+        exact H.2)⟩
+      left_inv := fun M ↦ Subtype.ext
+        (L.intermediateCarrierOfDiscriminantSubgroup_discriminantSubgroup M.1)
+      right_inv := fun H ↦ Subtype.ext
+        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H.1) }
+  map_rel_iff' {M N} := by
+    simp only [Equiv.coe_fn_mk, Subtype.mk_le_mk, L.discriminantSubgroup_le_iff]
+    exact Subtype.coe_le_coe
+
+variable [L.IsNondegenerate]
 
 /-- The inverse-image carrier of a subgroup is integral exactly when the subgroup is
 bilinear-isotropic. -/
+@[simp]
 theorem isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff
     (H : AddSubgroup L.DiscriminantGroup) :
     IsIntegral (L.intermediateCarrierOfDiscriminantSubgroup H) ↔
@@ -203,19 +254,8 @@ order isomorphism restricts to the integral carriers on one side and the bilinea
 subgroups of the discriminant group on the other. -/
 def integralIntermediateCarrierOrderIsoIsotropicSubgroup :
     {M : L.IntermediateCarrier // IsIntegral M} ≃o
-      {H : AddSubgroup L.DiscriminantGroup // L.discriminantBilinearModule.IsIsotropic H} where
-  toEquiv :=
-    { toFun := fun M ↦ ⟨L.discriminantSubgroup M.1,
-        (isIntegral_iff_isIsotropic_discriminantSubgroup M.1).mp M.2⟩
-      invFun := fun H ↦ ⟨L.intermediateCarrierOfDiscriminantSubgroup H.1,
-        (L.isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff H.1).mpr H.2⟩
-      left_inv := fun M ↦ Subtype.ext
-        (L.intermediateCarrierOfDiscriminantSubgroup_discriminantSubgroup M.1)
-      right_inv := fun H ↦ Subtype.ext
-        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H.1) }
-  map_rel_iff' {M N} := by
-    simp only [Equiv.coe_fn_mk, Subtype.mk_le_mk, L.discriminantSubgroup_le_iff]
-    exact Subtype.coe_le_coe
+      {H : AddSubgroup L.DiscriminantGroup // L.discriminantBilinearModule.IsIsotropic H} :=
+  L.restrictOrderIso fun M ↦ isIntegral_iff_isIsotropic_discriminantSubgroup M
 
 /-- The restricted integral-carrier order isomorphism acts by the discriminant-subgroup
 construction. -/
@@ -224,8 +264,8 @@ theorem integralIntermediateCarrierOrderIsoIsotropicSubgroup_apply_coe
     (M : {M : L.IntermediateCarrier // IsIntegral M}) :
     (L.integralIntermediateCarrierOrderIsoIsotropicSubgroup M :
       AddSubgroup L.DiscriminantGroup) = L.discriminantSubgroup M.1 := by
-  simp only [integralIntermediateCarrierOrderIsoIsotropicSubgroup, RelIso.coe_fn_mk,
-    Equiv.coe_fn_mk]
+  simp only [integralIntermediateCarrierOrderIsoIsotropicSubgroup, restrictOrderIso,
+    RelIso.coe_fn_mk, Equiv.coe_fn_mk]
 
 /-- The inverse of the restricted integral-carrier order isomorphism acts by the inverse-image
 construction. -/
@@ -234,8 +274,8 @@ theorem integralIntermediateCarrierOrderIsoIsotropicSubgroup_symm_apply_coe
     (H : {H : AddSubgroup L.DiscriminantGroup // L.discriminantBilinearModule.IsIsotropic H}) :
     (L.integralIntermediateCarrierOrderIsoIsotropicSubgroup.symm H : L.IntermediateCarrier) =
       L.intermediateCarrierOfDiscriminantSubgroup H.1 := by
-  simp only [integralIntermediateCarrierOrderIsoIsotropicSubgroup, OrderIso.symm_mk,
-    RelIso.coe_fn_mk, Equiv.coe_fn_symm_mk]
+  simp only [integralIntermediateCarrierOrderIsoIsotropicSubgroup, restrictOrderIso,
+    OrderIso.symm_mk, RelIso.coe_fn_mk, Equiv.coe_fn_symm_mk]
 
 /-- **Even overlattices correspond to quadratic-isotropic subgroups.** For an even lattice, the
 intermediate-carrier order isomorphism restricts to the even carriers on one side and the
@@ -243,19 +283,8 @@ quadratic-isotropic subgroups of the discriminant group on the other. -/
 def evenIntermediateCarrierOrderIsoIsotropicSubgroup (hL : L.IsEven) :
     {M : L.IntermediateCarrier // IntermediateCarrier.IsEven M} ≃o
       {H : AddSubgroup L.DiscriminantGroup //
-        (L.discriminantQuadraticModule hL).IsIsotropic H} where
-  toEquiv :=
-    { toFun := fun M ↦ ⟨L.discriminantSubgroup M.1,
-        (isEven_iff_isIsotropic_discriminantSubgroup hL M.1).mp M.2⟩
-      invFun := fun H ↦ ⟨L.intermediateCarrierOfDiscriminantSubgroup H.1,
-        (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H.1).mpr H.2⟩
-      left_inv := fun M ↦ Subtype.ext
-        (L.intermediateCarrierOfDiscriminantSubgroup_discriminantSubgroup M.1)
-      right_inv := fun H ↦ Subtype.ext
-        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H.1) }
-  map_rel_iff' {M N} := by
-    simp only [Equiv.coe_fn_mk, Subtype.mk_le_mk, L.discriminantSubgroup_le_iff]
-    exact Subtype.coe_le_coe
+        (L.discriminantQuadraticModule hL).IsIsotropic H} :=
+  L.restrictOrderIso fun M ↦ isEven_iff_isIsotropic_discriminantSubgroup hL M
 
 /-- The restricted even-carrier order isomorphism acts by the discriminant-subgroup
 construction. -/
@@ -264,8 +293,8 @@ theorem evenIntermediateCarrierOrderIsoIsotropicSubgroup_apply_coe (hL : L.IsEve
     (M : {M : L.IntermediateCarrier // IntermediateCarrier.IsEven M}) :
     (L.evenIntermediateCarrierOrderIsoIsotropicSubgroup hL M :
       AddSubgroup L.DiscriminantGroup) = L.discriminantSubgroup M.1 := by
-  simp only [evenIntermediateCarrierOrderIsoIsotropicSubgroup, RelIso.coe_fn_mk,
-    Equiv.coe_fn_mk]
+  simp only [evenIntermediateCarrierOrderIsoIsotropicSubgroup, restrictOrderIso,
+    RelIso.coe_fn_mk, Equiv.coe_fn_mk]
 
 /-- The inverse of the restricted even-carrier order isomorphism acts by the inverse-image
 construction. -/
@@ -275,8 +304,8 @@ theorem evenIntermediateCarrierOrderIsoIsotropicSubgroup_symm_apply_coe (hL : L.
       (L.discriminantQuadraticModule hL).IsIsotropic H}) :
     ((L.evenIntermediateCarrierOrderIsoIsotropicSubgroup hL).symm H : L.IntermediateCarrier) =
       L.intermediateCarrierOfDiscriminantSubgroup H.1 := by
-  simp only [evenIntermediateCarrierOrderIsoIsotropicSubgroup, OrderIso.symm_mk,
-    RelIso.coe_fn_mk, Equiv.coe_fn_symm_mk]
+  simp only [evenIntermediateCarrierOrderIsoIsotropicSubgroup, restrictOrderIso,
+    OrderIso.symm_mk, RelIso.coe_fn_mk, Equiv.coe_fn_symm_mk]
 
 end IntegralLattice
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Isotropic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Isotropic.lean
@@ -1,0 +1,283 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Quadratic
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Basic
+
+/-!
+# Integral and even overlattices via isotropic subgroups
+
+Let `L` be an integral lattice. This file refines the intermediate-carrier correspondence of
+`TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Basic` by the two properties an intermediate
+carrier `L ≤ M ≤ Lᵛ` can enjoy: `M` is *integral* when the rational form takes integer values on
+pairs of its vectors, and `M` is *even* when every self-pairing of its vectors is an even integer.
+Evenness implies integrality by polarization, mirroring the classical fact that even lattices are
+integral.
+
+The characteristic results locate both classes inside the discriminant group. A carrier `M` is
+integral exactly when the discriminant bilinear pairing vanishes on the subgroup `M / L` of
+`A_L = Lᵛ / L`, and, when `L` is even, `M` is even exactly when the discriminant quadratic map
+vanishes on `M / L`. Restricting the intermediate-carrier order isomorphism accordingly packages
+the two gluing correspondences: integral carriers correspond to bilinear-isotropic subgroups, and
+even carriers of an even lattice correspond to quadratic-isotropic subgroups.
+
+## Main declarations
+
+* `TauCeti.IntegralLattice.IntermediateCarrier.IsIntegral`: integrality of an intermediate
+  carrier.
+* `TauCeti.IntegralLattice.IntermediateCarrier.IsEven`: evenness of an intermediate carrier.
+* `TauCeti.IntegralLattice.IntermediateCarrier.isIntegral_iff_isIsotropic_discriminantSubgroup`:
+  integral carriers are cut out by bilinear isotropy in the discriminant group.
+* `TauCeti.IntegralLattice.IntermediateCarrier.isEven_iff_isIsotropic_discriminantSubgroup`: even
+  carriers of an even lattice are cut out by quadratic isotropy in the discriminant group.
+* `TauCeti.IntegralLattice.integralIntermediateCarrierOrderIsoIsotropicSubgroup`: the restriction
+  of the intermediate-carrier order isomorphism to integral carriers.
+* `TauCeti.IntegralLattice.evenIntermediateCarrierOrderIsoIsotropicSubgroup`: the restriction of
+  the intermediate-carrier order isomorphism to even carriers of an even lattice.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.4,
+  Proposition 1.4.1. The quadratic statement here is that proposition in the half-norm `ℚ/ℤ`
+  convention; the bilinear statement is its elementary intermediate-lattice analogue.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+* `TauCetiRoadmap/IntegralLattices/README.md`, Layer 4.
+* `TauCetiRoadmap/IntegralLattices/Suggested.lean` (`integralOverlatticeEquivIsotropicSubgroup`,
+  `evenOverlatticeEquivIsotropicSubgroup`).
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+namespace IntegralLattice
+
+variable {V : Type u} [AddCommGroup V] [Module ℚ V] {L : IntegralLattice V}
+
+namespace IntermediateCarrier
+
+/-- An intermediate carrier is integral when the rational form pairs its vectors integrally. -/
+def IsIntegral (M : L.IntermediateCarrier) : Prop :=
+  ∀ x ∈ M.1, ∀ y ∈ M.1, L.form x y ∈ (1 : Submodule ℤ ℚ)
+
+/-- Integrality of an intermediate carrier, unfolded to its defining property. -/
+theorem isIntegral_def {M : L.IntermediateCarrier} :
+    IsIntegral M ↔ ∀ x ∈ M.1, ∀ y ∈ M.1, L.form x y ∈ (1 : Submodule ℤ ℚ) :=
+  Iff.rfl
+
+/-- An intermediate carrier is even when every self-pairing of its vectors is an even integer. -/
+def IsEven (M : L.IntermediateCarrier) : Prop :=
+  ∀ x ∈ M.1, ∃ n : ℤ, L.form x x = ((2 * n : ℤ) : ℚ)
+
+/-- Evenness of an intermediate carrier, unfolded to its defining property. -/
+theorem isEven_def {M : L.IntermediateCarrier} :
+    IsEven M ↔ ∀ x ∈ M.1, ∃ n : ℤ, L.form x x = ((2 * n : ℤ) : ℚ) :=
+  Iff.rfl
+
+/-- The bottom intermediate carrier, the lattice itself, is integral. -/
+theorem isIntegral_bot : IsIntegral (⊥ : L.IntermediateCarrier) := by
+  intro x hx y hy
+  rw [Set.Icc.coe_bot] at hx hy
+  exact L.le_dual hx y hy
+
+/-- The bottom intermediate carrier is even exactly when the lattice itself is even. -/
+theorem isEven_bot_iff : IsEven (⊥ : L.IntermediateCarrier) ↔ L.IsEven := by
+  rw [L.isEven_iff_forall_norm]
+  constructor
+  · intro h x
+    obtain ⟨n, hn⟩ := h (x : V) (by rw [Set.Icc.coe_bot]; exact x.2)
+    refine ⟨n, ?_⟩
+    rw [L.norm_apply, hn]
+    push_cast
+    ring
+  · intro h x hx
+    rw [Set.Icc.coe_bot] at hx
+    obtain ⟨n, hn⟩ := h ⟨x, hx⟩
+    rw [L.norm_apply] at hn
+    refine ⟨n, ?_⟩
+    push_cast
+    simpa using hn
+
+/-- Evenness of an intermediate carrier implies its integrality, by polarization. -/
+theorem IsEven.isIntegral {M : L.IntermediateCarrier} (hM : IsEven M) : IsIntegral M := by
+  intro x hx y hy
+  obtain ⟨a, ha⟩ := hM (x + y) (M.1.add_mem hx hy)
+  obtain ⟨b, hb⟩ := hM x hx
+  obtain ⟨c, hc⟩ := hM y hy
+  have hexpand : L.form (x + y) (x + y) =
+      L.form x x + L.form x y + (L.form y x + L.form y y) := by
+    simp only [map_add, LinearMap.add_apply]
+    ring
+  have hyx : L.form y x = L.form x y := by simpa using L.isSymm.eq y x
+  refine Submodule.mem_one.mpr ⟨a - b - c, ?_⟩
+  rw [eq_intCast]
+  push_cast at ha hb hc ⊢
+  linarith [hexpand, hyx, ha, hb, hc]
+
+variable [L.IsNondegenerate]
+
+/-- **Integrality is bilinear isotropy.** An intermediate carrier is integral exactly when the
+discriminant bilinear pairing vanishes on its subgroup of the discriminant group. -/
+theorem isIntegral_iff_isIsotropic_discriminantSubgroup (M : L.IntermediateCarrier) :
+    IsIntegral M ↔ L.discriminantBilinearModule.IsIsotropic (L.discriminantSubgroup M) := by
+  constructor
+  · intro hM
+    refine L.discriminantBilinearModule.isIsotropic_def.mpr ?_
+    intro x hx y hy
+    obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ x
+    obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective _ y
+    rw [discriminantBilinearModule_pairing, discriminantPairing_mk]
+    exact (coe_eq_zero_iff_mem_one _).mpr
+      (hM x ((L.mk_mem_discriminantSubgroup_iff M x).mp hx) y
+        ((L.mk_mem_discriminantSubgroup_iff M y).mp hy))
+  · intro hH x hx y hy
+    have hxd : x ∈ L.dualCarrier := M.2.2 hx
+    have hyd : y ∈ L.dualCarrier := M.2.2 hy
+    have h0 := L.discriminantBilinearModule.isIsotropic_def.mp hH (Submodule.Quotient.mk ⟨x, hxd⟩)
+      ((L.mk_mem_discriminantSubgroup_iff M ⟨x, hxd⟩).mpr hx)
+      (Submodule.Quotient.mk ⟨y, hyd⟩)
+      ((L.mk_mem_discriminantSubgroup_iff M ⟨y, hyd⟩).mpr hy)
+    rw [discriminantBilinearModule_pairing, discriminantPairing_mk] at h0
+    exact (coe_eq_zero_iff_mem_one _).mp h0
+
+/-- **Evenness is quadratic isotropy.** For an even lattice, an intermediate carrier is even
+exactly when the discriminant quadratic map vanishes on its subgroup of the discriminant group. -/
+theorem isEven_iff_isIsotropic_discriminantSubgroup (hL : L.IsEven) (M : L.IntermediateCarrier) :
+    IsEven M ↔ (L.discriminantQuadraticModule hL).IsIsotropic (L.discriminantSubgroup M) := by
+  constructor
+  · intro hM
+    refine (L.discriminantQuadraticModule hL).isIsotropic_def.mpr ?_
+    intro x hx
+    obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective _ x
+    rw [discriminantQuadraticModule_quadratic, discriminantQuadraticMap_mk]
+    obtain ⟨n, hn⟩ := hM x ((L.mk_mem_discriminantSubgroup_iff M x).mp hx)
+    refine (coe_eq_zero_iff_mem_one _).mpr (Submodule.mem_one.mpr ⟨n, ?_⟩)
+    rw [eq_intCast, hn]
+    push_cast
+    ring
+  · intro hH x hx
+    have hxd : x ∈ L.dualCarrier := M.2.2 hx
+    have h0 := (L.discriminantQuadraticModule hL).isIsotropic_def.mp hH
+      (Submodule.Quotient.mk ⟨x, hxd⟩)
+      ((L.mk_mem_discriminantSubgroup_iff M ⟨x, hxd⟩).mpr hx)
+    rw [discriminantQuadraticModule_quadratic, discriminantQuadraticMap_mk] at h0
+    obtain ⟨n, hn⟩ := Submodule.mem_one.mp ((coe_eq_zero_iff_mem_one _).mp h0)
+    rw [eq_intCast] at hn
+    refine ⟨n, ?_⟩
+    have hn' : (n : ℚ) = L.form x x / 2 := by simpa using hn
+    push_cast
+    linarith [hn']
+
+end IntermediateCarrier
+
+open IntermediateCarrier
+
+variable (L : IntegralLattice V) [L.IsNondegenerate]
+
+/-- The inverse-image carrier of a subgroup is integral exactly when the subgroup is
+bilinear-isotropic. -/
+theorem isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff
+    (H : AddSubgroup L.DiscriminantGroup) :
+    IsIntegral (L.intermediateCarrierOfDiscriminantSubgroup H) ↔
+      L.discriminantBilinearModule.IsIsotropic H := by
+  rw [isIntegral_iff_isIsotropic_discriminantSubgroup,
+    L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup]
+
+/-- For an even lattice, the inverse-image carrier of a subgroup is even exactly when the
+subgroup is quadratic-isotropic. -/
+theorem isEven_intermediateCarrierOfDiscriminantSubgroup_iff (hL : L.IsEven)
+    (H : AddSubgroup L.DiscriminantGroup) :
+    IntermediateCarrier.IsEven (L.intermediateCarrierOfDiscriminantSubgroup H) ↔
+      (L.discriminantQuadraticModule hL).IsIsotropic H := by
+  rw [isEven_iff_isIsotropic_discriminantSubgroup hL,
+    L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup]
+
+/-- **Integral overlattices correspond to bilinear-isotropic subgroups.** The intermediate-carrier
+order isomorphism restricts to the integral carriers on one side and the bilinear-isotropic
+subgroups of the discriminant group on the other. -/
+def integralIntermediateCarrierOrderIsoIsotropicSubgroup :
+    {M : L.IntermediateCarrier // IsIntegral M} ≃o
+      {H : AddSubgroup L.DiscriminantGroup // L.discriminantBilinearModule.IsIsotropic H} where
+  toEquiv :=
+    { toFun := fun M ↦ ⟨L.discriminantSubgroup M.1,
+        (isIntegral_iff_isIsotropic_discriminantSubgroup M.1).mp M.2⟩
+      invFun := fun H ↦ ⟨L.intermediateCarrierOfDiscriminantSubgroup H.1,
+        (L.isIntegral_intermediateCarrierOfDiscriminantSubgroup_iff H.1).mpr H.2⟩
+      left_inv := fun M ↦ Subtype.ext
+        (L.intermediateCarrierOfDiscriminantSubgroup_discriminantSubgroup M.1)
+      right_inv := fun H ↦ Subtype.ext
+        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H.1) }
+  map_rel_iff' {M N} := by
+    simp only [Equiv.coe_fn_mk, Subtype.mk_le_mk, L.discriminantSubgroup_le_iff]
+    exact Subtype.coe_le_coe
+
+/-- The restricted integral-carrier order isomorphism acts by the discriminant-subgroup
+construction. -/
+@[simp]
+theorem integralIntermediateCarrierOrderIsoIsotropicSubgroup_apply_coe
+    (M : {M : L.IntermediateCarrier // IsIntegral M}) :
+    (L.integralIntermediateCarrierOrderIsoIsotropicSubgroup M :
+      AddSubgroup L.DiscriminantGroup) = L.discriminantSubgroup M.1 := by
+  simp only [integralIntermediateCarrierOrderIsoIsotropicSubgroup, RelIso.coe_fn_mk,
+    Equiv.coe_fn_mk]
+
+/-- The inverse of the restricted integral-carrier order isomorphism acts by the inverse-image
+construction. -/
+@[simp]
+theorem integralIntermediateCarrierOrderIsoIsotropicSubgroup_symm_apply_coe
+    (H : {H : AddSubgroup L.DiscriminantGroup // L.discriminantBilinearModule.IsIsotropic H}) :
+    (L.integralIntermediateCarrierOrderIsoIsotropicSubgroup.symm H : L.IntermediateCarrier) =
+      L.intermediateCarrierOfDiscriminantSubgroup H.1 := by
+  simp only [integralIntermediateCarrierOrderIsoIsotropicSubgroup, OrderIso.symm_mk,
+    RelIso.coe_fn_mk, Equiv.coe_fn_symm_mk]
+
+/-- **Even overlattices correspond to quadratic-isotropic subgroups.** For an even lattice, the
+intermediate-carrier order isomorphism restricts to the even carriers on one side and the
+quadratic-isotropic subgroups of the discriminant group on the other. -/
+def evenIntermediateCarrierOrderIsoIsotropicSubgroup (hL : L.IsEven) :
+    {M : L.IntermediateCarrier // IntermediateCarrier.IsEven M} ≃o
+      {H : AddSubgroup L.DiscriminantGroup //
+        (L.discriminantQuadraticModule hL).IsIsotropic H} where
+  toEquiv :=
+    { toFun := fun M ↦ ⟨L.discriminantSubgroup M.1,
+        (isEven_iff_isIsotropic_discriminantSubgroup hL M.1).mp M.2⟩
+      invFun := fun H ↦ ⟨L.intermediateCarrierOfDiscriminantSubgroup H.1,
+        (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H.1).mpr H.2⟩
+      left_inv := fun M ↦ Subtype.ext
+        (L.intermediateCarrierOfDiscriminantSubgroup_discriminantSubgroup M.1)
+      right_inv := fun H ↦ Subtype.ext
+        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H.1) }
+  map_rel_iff' {M N} := by
+    simp only [Equiv.coe_fn_mk, Subtype.mk_le_mk, L.discriminantSubgroup_le_iff]
+    exact Subtype.coe_le_coe
+
+/-- The restricted even-carrier order isomorphism acts by the discriminant-subgroup
+construction. -/
+@[simp]
+theorem evenIntermediateCarrierOrderIsoIsotropicSubgroup_apply_coe (hL : L.IsEven)
+    (M : {M : L.IntermediateCarrier // IntermediateCarrier.IsEven M}) :
+    (L.evenIntermediateCarrierOrderIsoIsotropicSubgroup hL M :
+      AddSubgroup L.DiscriminantGroup) = L.discriminantSubgroup M.1 := by
+  simp only [evenIntermediateCarrierOrderIsoIsotropicSubgroup, RelIso.coe_fn_mk,
+    Equiv.coe_fn_mk]
+
+/-- The inverse of the restricted even-carrier order isomorphism acts by the inverse-image
+construction. -/
+@[simp]
+theorem evenIntermediateCarrierOrderIsoIsotropicSubgroup_symm_apply_coe (hL : L.IsEven)
+    (H : {H : AddSubgroup L.DiscriminantGroup //
+      (L.discriminantQuadraticModule hL).IsIsotropic H}) :
+    ((L.evenIntermediateCarrierOrderIsoIsotropicSubgroup hL).symm H : L.IntermediateCarrier) =
+      L.intermediateCarrierOfDiscriminantSubgroup H.1 := by
+  simp only [evenIntermediateCarrierOrderIsoIsotropicSubgroup, OrderIso.symm_mk,
+    RelIso.coe_fn_mk, Equiv.coe_fn_symm_mk]
+
+end IntegralLattice
+
+end TauCeti


### PR DESCRIPTION
Refines the intermediate-carrier correspondence of `Overlattice/Basic.lean` by the two classical properties an intermediate carrier `L ≤ M ≤ Lᵛ` can have, discharging that file's TODO.

## What this adds

* `IntermediateCarrier.IsIntegral` and `IntermediateCarrier.IsEven`, following the signatures pinned in `TauCetiRoadmap/IntegralLattices/Suggested.lean`, together with `_def` unfolding lemmas, the values at `⊥` (`isIntegral_bot`, `isEven_bot_iff`), and `IsEven.isIntegral` (polarization).
* `isIntegral_iff_isIsotropic_discriminantSubgroup`: `M` is integral exactly when the discriminant bilinear pairing vanishes on `M / L ≤ A_L`.
* `isEven_iff_isIsotropic_discriminantSubgroup`: for `L` even, `M` is even exactly when the discriminant quadratic map vanishes on `M / L`.
* The inverse-image forms of both, and the two restricted order isomorphisms `integralIntermediateCarrierOrderIsoIsotropicSubgroup` and `evenIntermediateCarrierOrderIsoIsotropicSubgroup`, with `apply`/`symm_apply` simp lemmas.

## Roadmap target

`TauCetiRoadmap/IntegralLattices/README.md`, Layer 4, second bullet, verbatim: "Prove the two refinements without conflating them. Integral overlattices correspond exactly to subgroups on which the **bilinear** discriminant form vanishes on `H×H`. When `L` is even, even overlattices correspond exactly to subgroups on which the **quadratic** discriminant form vanishes. State both restrictions of the general intermediate-lattice correspondence." The two statements are kept separate as the roadmap requires; the quadratic one is Nikulin §1.4, Proposition 1.4.1 in the half-norm convention, and the bilinear one is recorded as its elementary intermediate-lattice analogue.

## Supporting changes in existing files

* `FiniteBilinearModule/Basic.lean`, `FiniteBilinearModule/Quadratic.lean`: `isIsotropic_def` unfolding lemmas for the two isotropy predicates. Both are plain `def`s, opaque across module boundaries, so downstream files need a bridging lemma to introduce or eliminate them; this follows the existing `isIsotropicElem_def` precedent.
* `Discriminant/Bilinear.lean`: `coe_eq_zero_iff_mem_one` promoted from `private` to a public lemma with a docstring, so this PR can reuse it instead of duplicating the proof.
* `Overlattice/Basic.lean`: the TODO is discharged, replaced by a pointer to the new file.

`lake build` and `lake exe axioms` are green (56135 declarations audited, allowlist only).

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"overlattice-isotropic-refinements"}-->
