### PR TITLE
feat: representations of a quiver are modules over its path algebra

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/UpperTriangular.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/UpperTriangular.lean
@@ -68,70 +68,49 @@ section ToMatrix
 
 variable (k : Type w) [CommSemiring k]
 
-/-- The linear map sending a path to the matrix unit in the row of its target and the column of
-its source. -/
-private noncomputable def toMatrixLinear :
-    pathAlgebra k (Kronecker A) →ₗ[k] Matrix (Fin 2) (Fin 2) k :=
-  (pathAlgebraBasis k (Kronecker A)).constr k fun x =>
-    Matrix.single (vertexEquiv x.2.1) (vertexEquiv x.1) 1
+/-- The matrix unit a path goes to: the one in the row of its target and the column of its
+source. -/
+private def toMatrixUnit (x : Quiver.TotalPath (Kronecker A)) : Matrix (Fin 2) (Fin 2) k :=
+  Matrix.single (vertexEquiv x.2.1) (vertexEquiv x.1) 1
 
-private theorem toMatrixLinear_single (x : Quiver.TotalPath (Kronecker A)) (c : k) :
-    toMatrixLinear k (PathAlgebra.single x c)
-      = Matrix.single (vertexEquiv x.2.1) (vertexEquiv x.1) c := by
-  have hb : pathAlgebraBasis k (Kronecker A) x = PathAlgebra.ofPath x :=
-    congrFun (coe_pathAlgebraBasis k (Kronecker A)) x
-  have hx : (PathAlgebra.single x c : pathAlgebra k (Kronecker A))
-      = c • pathAlgebraBasis k (Kronecker A) x := by
-    rw [hb, PathAlgebra.ofPath_eq_single, PathAlgebra.smul_single, mul_one]
-  rw [hx, map_smul, toMatrixLinear, Module.Basis.constr_basis, Matrix.smul_single, smul_eq_mul,
-    mul_one]
+/-- Concatenation of paths becomes multiplication of matrix units, the column of the first being
+the row of the second. -/
+private theorem toMatrixUnit_mul_toMatrixUnit_of_comp {a b c : Kronecker A} (p : Path a b)
+    (q : Path c a) :
+    toMatrixUnit k ⟨a, b, p⟩ * toMatrixUnit k ⟨c, a, q⟩ = toMatrixUnit k ⟨c, b, q.comp p⟩ := by
+  rw [toMatrixUnit, toMatrixUnit, toMatrixUnit, Matrix.single_mul_single_same, one_mul]
 
-/-- The two vertex idempotents go to the two diagonal matrix units, which sum to the identity
-matrix. -/
-private theorem toMatrixLinear_one :
-    toMatrixLinear k (1 : pathAlgebra k (Kronecker A)) = 1 := by
-  rw [PathAlgebra.one_def, sum_univ, map_add, PathAlgebra.vertexIdempotent_eq_single,
-    PathAlgebra.vertexIdempotent_eq_single, toMatrixLinear_single, toMatrixLinear_single,
-    ← Matrix.sum_single_one, Fin.sum_univ_two]
-  simp [add_comm]
+/-- Two paths that do not meet go to matrix units whose product vanishes, since `vertexEquiv` is
+injective. -/
+private theorem toMatrixUnit_mul_toMatrixUnit_of_not_composable
+    {x y : Quiver.TotalPath (Kronecker A)} (h : y.2.1 ≠ x.1) :
+    toMatrixUnit k x * toMatrixUnit k y = 0 := by
+  have hne : vertexEquiv x.1 ≠ vertexEquiv y.2.1 := fun hc => h (vertexEquiv.injective hc).symm
+  rw [toMatrixUnit, toMatrixUnit, Matrix.single_mul_single_of_ne (h := hne)]
 
-/-- Concatenation of paths becomes multiplication of matrix units: two paths meet exactly when the
-column of the first matrix unit is the row of the second, since `vertexEquiv` is injective. -/
-private theorem toMatrixLinear_mul (f g : pathAlgebra k (Kronecker A)) :
-    toMatrixLinear k (f * g) = toMatrixLinear k f * toMatrixLinear k g := by
-  induction f using PathAlgebra.induction_linear with
-  | zero => simp
-  | add f₁ f₂ ih₁ ih₂ => simp [add_mul, ih₁, ih₂]
-  | single x r =>
-    induction g using PathAlgebra.induction_linear with
-    | zero => simp
-    | add g₁ g₂ ih₁ ih₂ => simp [mul_add, ih₁, ih₂]
-    | single y s =>
-      by_cases h : y.2.1 = x.1
-      · obtain ⟨x₁, x₂, p⟩ := x
-        obtain ⟨y₁, y₂, q⟩ := y
-        subst h
-        rw [PathAlgebra.single_mul_single_of_comp, toMatrixLinear_single, toMatrixLinear_single,
-          toMatrixLinear_single, Matrix.single_mul_single_same]
-      · have hne : vertexEquiv x.1 ≠ vertexEquiv y.2.1 :=
-          fun hc => h (vertexEquiv.injective hc).symm
-        rw [PathAlgebra.single_mul_single_of_not_composable h, map_zero, toMatrixLinear_single,
-          toMatrixLinear_single, Matrix.single_mul_single_of_ne (h := hne)]
+/-- The two trivial paths go to the two diagonal matrix units, which sum to the identity matrix.
+The enumeration is left arbitrary, as `TauCeti.PathAlgebra.liftAlgHom` asks for this over any one:
+`TauCeti.Quiver.Kronecker.vertexEquiv` transports the sum to the one over `Fin 2`. -/
+private theorem sum_toMatrixUnit_nil (fq : Fintype (Kronecker A)) :
+    ∑ v ∈ @Finset.univ (Kronecker A) fq,
+        toMatrixUnit k (⟨v, v, Path.nil⟩ : Quiver.TotalPath (Kronecker A)) = 1 :=
+  (Fintype.sum_equiv vertexEquiv _ (fun i => Matrix.single i i (1 : k)) fun _ => rfl).trans
+    Matrix.sum_single_one
 
 /-- The path algebra of the generalized Kronecker quiver as `2 × 2` matrices: a path goes to the
-matrix unit in the row of its target and the column of its source. -/
+matrix unit in the row of its target and the column of its source. This is the universal property
+`TauCeti.PathAlgebra.liftAlgHom` applied to `toMatrixUnit`. -/
 private noncomputable def toMatrixAlgHom :
     pathAlgebra k (Kronecker A) →ₐ[k] Matrix (Fin 2) (Fin 2) k :=
-  AlgHom.ofLinearMap (toMatrixLinear k) (toMatrixLinear_one k) (toMatrixLinear_mul k)
-
-private theorem toMatrixAlgHom_toLinearMap :
-    (toMatrixAlgHom (A := A) k).toLinearMap = toMatrixLinear k := by
-  rw [toMatrixAlgHom, AlgHom.toLinearMap_ofLinearMap]
+  PathAlgebra.liftAlgHom k (toMatrixUnit k) (toMatrixUnit_mul_toMatrixUnit_of_comp k)
+    (toMatrixUnit_mul_toMatrixUnit_of_not_composable k)
+    (by intro fq; exact sum_toMatrixUnit_nil k fq)
 
 private theorem toMatrixAlgHom_single (x : Quiver.TotalPath (Kronecker A)) (c : k) :
     toMatrixAlgHom k (PathAlgebra.single x c)
       = Matrix.single (vertexEquiv x.2.1) (vertexEquiv x.1) c := by
-  rw [← AlgHom.toLinearMap_apply, toMatrixAlgHom_toLinearMap, toMatrixLinear_single]
+  rw [toMatrixAlgHom, PathAlgebra.liftAlgHom_single, toMatrixUnit, Matrix.smul_single,
+    smul_eq_mul, mul_one]
 
 end ToMatrix
 

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/UpperTriangular.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/UpperTriangular.lean
@@ -89,8 +89,9 @@ private theorem toMatrixUnit_mul_toMatrixUnit_of_not_composable
   rw [toMatrixUnit, toMatrixUnit, Matrix.single_mul_single_of_ne (h := hne)]
 
 /-- The two trivial paths go to the two diagonal matrix units, which sum to the identity matrix.
-The enumeration is left arbitrary, as `TauCeti.PathAlgebra.liftAlgHom` asks for this over any one:
-`TauCeti.Quiver.Kronecker.vertexEquiv` transports the sum to the one over `Fin 2`. -/
+The enumeration is left an argument, so that the sum can be taken over the one
+`TauCeti.PathAlgebra.liftAlgHom` asks for it over: `TauCeti.Quiver.Kronecker.vertexEquiv` transports
+the sum to the one over `Fin 2` whichever it is. -/
 private theorem sum_toMatrixUnit_nil (fq : Fintype (Kronecker A)) :
     ∑ v ∈ @Finset.univ (Kronecker A) fq,
         toMatrixUnit k (⟨v, v, Path.nil⟩ : Quiver.TotalPath (Kronecker A)) = 1 :=
@@ -104,7 +105,7 @@ private noncomputable def toMatrixAlgHom :
     pathAlgebra k (Kronecker A) →ₐ[k] Matrix (Fin 2) (Fin 2) k :=
   PathAlgebra.liftAlgHom k (toMatrixUnit k) (toMatrixUnit_mul_toMatrixUnit_of_comp k)
     (toMatrixUnit_mul_toMatrixUnit_of_not_composable k)
-    (by intro fq; exact sum_toMatrixUnit_nil k fq)
+    (sum_toMatrixUnit_nil k (Fintype.ofFinite _))
 
 private theorem toMatrixAlgHom_single (x : Quiver.TotalPath (Kronecker A)) (c : k) :
     toMatrixAlgHom k (PathAlgebra.single x c)

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -37,6 +37,9 @@ idempotents `e`, so left multiplication by `α` carries the `i`-component of a l
   `1 = ∑ᵥ eᵥ` exist.
 * `TauCeti.PathAlgebra.vertexIdempotent`: the idempotent `eᵥ` given by the trivial path at `v`.
 * `TauCeti.pathAlgebraBasis`: the paths of `Q` as a `k`-basis of `kQ`.
+* `TauCeti.PathAlgebra.liftAlgHom`: **the universal property of the path algebra**, extending an
+  assignment of elements of a `k`-algebra to the basis paths to an algebra homomorphism out of
+  `kQ`.
 
 ## Main results
 
@@ -684,6 +687,89 @@ theorem vertexIdempotent_mul_mul_vertexIdempotent (v : Q)
         zero_mul, Finsupp.single_eq_of_ne' hne, single_zero]
 
 end Basis
+
+/-! ### The universal property -/
+
+namespace PathAlgebra
+
+section Lift
+
+variable (k : Type w) {Q : Type u} {B : Type*} [CommSemiring k] [Quiver.{v} Q]
+  [Semiring B] [Algebra k B] (F : Quiver.TotalPath Q → B)
+
+/-- The `k`-linear map extending an assignment of algebra elements to the basis paths. Private:
+only its algebra-homomorphism upgrade `TauCeti.PathAlgebra.liftAlgHom` is public. -/
+private noncomputable def liftLinear : pathAlgebra k Q →ₗ[k] B :=
+  (pathAlgebraBasis k Q).constr k F
+
+private theorem liftLinear_ofPath (x : Quiver.TotalPath Q) : liftLinear k F (ofPath x) = F x := by
+  have h := (pathAlgebraBasis k Q).constr_basis k F x
+  rwa [coe_pathAlgebraBasis] at h
+
+private theorem liftLinear_single (x : Quiver.TotalPath Q) (c : k) :
+    liftLinear k F (single x c) = c • F x := by
+  have hx : (single x c : pathAlgebra k Q) = c • ofPath x := by
+    rw [ofPath_eq_single, smul_single, mul_one]
+  rw [hx, map_smul, liftLinear_ofPath]
+
+variable (hcomp : ∀ {a b c : Q} (p : _root_.Quiver.Path a b) (q : _root_.Quiver.Path c a),
+    F ⟨a, b, p⟩ * F ⟨c, a, q⟩ = F ⟨c, b, q.comp p⟩)
+  (hzero : ∀ {x y : Quiver.TotalPath Q}, y.2.1 ≠ x.1 → F x * F y = 0)
+
+include hcomp hzero in
+private theorem liftLinear_mul (f g : pathAlgebra k Q) :
+    liftLinear k F (f * g) = liftLinear k F f * liftLinear k F g := by
+  induction f using PathAlgebra.induction_linear with
+  | zero => simp
+  | add f₁ f₂ h₁ h₂ => rw [add_mul, map_add, map_add, h₁, h₂, add_mul]
+  | single x c =>
+    induction g using PathAlgebra.induction_linear with
+    | zero => simp
+    | add g₁ g₂ h₁ h₂ => rw [mul_add, map_add, map_add, h₁, h₂, mul_add]
+    | single y d =>
+      obtain ⟨a, b, p⟩ := x
+      obtain ⟨c', a', q⟩ := y
+      by_cases hy : a' = a
+      · subst hy
+        rw [single_mul_single_of_comp, liftLinear_single, liftLinear_single, liftLinear_single,
+          smul_mul_smul_comm, hcomp]
+      · rw [single_mul_single_of_not_composable hy, map_zero, liftLinear_single, liftLinear_single,
+          smul_mul_smul_comm, hzero hy, smul_zero]
+
+variable [Finite Q]
+  (hone : ∀ [Fintype Q], ∑ v : Q, F ⟨v, v, _root_.Quiver.Path.nil⟩ = 1)
+
+include hone in
+private theorem liftLinear_one : liftLinear k F (1 : pathAlgebra k Q) = 1 := by
+  let _ := Fintype.ofFinite Q
+  rw [one_def, map_sum]
+  simp only [vertexIdempotent_eq_single, liftLinear_single, one_smul]
+  exact hone
+
+include hcomp hzero hone in
+/-- **The universal property of the path algebra**: an assignment `F` of elements of a `k`-algebra
+`B` to the basis paths extends to a `k`-algebra homomorphism `kQ →ₐ[k] B` as soon as it turns the
+three defining products of `kQ` into products in `B` — composable paths concatenate (`hcomp`,
+later factor first, as `TauCeti.PathAlgebra.single_mul_single_of_comp` multiplies them), paths that
+do not meet annihilate one another (`hzero`), and the trivial paths give a decomposition of the
+unit (`hone`), as `TauCeti.PathAlgebra.one_def` says of the vertex idempotents. -/
+noncomputable def liftAlgHom : pathAlgebra k Q →ₐ[k] B :=
+  AlgHom.ofLinearMap (liftLinear k F) (liftLinear_one k F hone) (liftLinear_mul k F hcomp hzero)
+
+/-- **The lift extends the assignment**: a basis path goes to the element it was assigned. -/
+@[simp]
+theorem liftAlgHom_ofPath (x : Quiver.TotalPath Q) :
+    liftAlgHom k F hcomp hzero hone (ofPath x) = F x :=
+  liftLinear_ofPath k F x
+
+/-- The lift is `k`-linear, so a scaled basis path scales the element it was assigned. -/
+theorem liftAlgHom_single (x : Quiver.TotalPath Q) (c : k) :
+    liftAlgHom k F hcomp hzero hone (single x c) = c • F x :=
+  liftLinear_single k F x c
+
+end Lift
+
+end PathAlgebra
 
 section DivisionRing
 

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -736,8 +736,10 @@ private theorem liftLinear_mul (f g : pathAlgebra k Q) :
       · rw [single_mul_single_of_not_composable hy, map_zero, liftLinear_single, liftLinear_single,
           smul_mul_smul_comm, hzero hy, smul_zero]
 
+-- The enumeration is the one the unit is built from, `Fintype.ofFinite Q`; a caller holding the
+-- sum over some other `Fintype Q` transports it along `Subsingleton.elim`, as `one_def` does.
 variable [Finite Q]
-  (hone : ∀ [Fintype Q], ∑ v : Q, F ⟨v, v, _root_.Quiver.Path.nil⟩ = 1)
+  (hone : letI := Fintype.ofFinite Q; ∑ v : Q, F ⟨v, v, _root_.Quiver.Path.nil⟩ = 1)
 
 include hone in
 private theorem liftLinear_one : liftLinear k F (1 : pathAlgebra k Q) = 1 := by

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -39,7 +39,7 @@ idempotents `e`, so left multiplication by `α` carries the `i`-component of a l
 * `TauCeti.pathAlgebraBasis`: the paths of `Q` as a `k`-basis of `kQ`.
 * `TauCeti.PathAlgebra.liftAlgHom`: **the universal property of the path algebra**, extending an
   assignment of elements of a `k`-algebra to the basis paths to an algebra homomorphism out of
-  `kQ`.
+  `kQ`, the only one doing so by `TauCeti.PathAlgebra.liftAlgHom_unique`.
 
 ## Main results
 
@@ -763,9 +763,17 @@ theorem liftAlgHom_ofPath (x : Quiver.TotalPath Q) :
   liftLinear_ofPath k F x
 
 /-- The lift is `k`-linear, so a scaled basis path scales the element it was assigned. -/
+@[simp]
 theorem liftAlgHom_single (x : Quiver.TotalPath Q) (c : k) :
     liftAlgHom k F hcomp hzero hone (single x c) = c • F x :=
   liftLinear_single k F x c
+
+/-- **The lift is the only one**: an algebra homomorphism out of `kQ` taking the value `F x` on
+each basis path is `TauCeti.PathAlgebra.liftAlgHom`, since the basis paths span. -/
+theorem liftAlgHom_unique (G : pathAlgebra k Q →ₐ[k] B) (hG : ∀ x, G (ofPath x) = F x) :
+    G = liftAlgHom k F hcomp hzero hone :=
+  AlgHom.toLinearMap_injective <| (pathAlgebraBasis k Q).ext fun x => by
+    simp only [AlgHom.toLinearMap_apply, coe_pathAlgebraBasis, hG, liftAlgHom_ofPath]
 
 end Lift
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
@@ -137,12 +137,17 @@ instance instModuleVertexSpace (v : Q) : Module k (vertexSpace k Q M v) :=
 noncomputable def mapₗ {a b : Q} (p : _root_.Quiver.Path a b) :
     vertexSpace k Q M a →ₗ[k] vertexSpace k Q M b := (M.map p).hom
 
+-- Not `@[simp]`: `TauCeti.QuiverRep.mapₗ` is the simp-normal form of a structure map here, since
+-- it is the retyping that lets the direct sum see the vertex spaces; rewriting with this would
+-- undo that everywhere and take `TauCeti.QuiverRep.smul_ofVertex` and
+-- `TauCeti.QuiverRep.pathMap_vertexComponentEquiv` out of simp normal form.
 /-- The retyped structure map is the structure map. -/
 theorem mapₗ_apply {a b : Q} (p : _root_.Quiver.Path a b) (z : vertexSpace k Q M a) :
     mapₗ k Q M p z = (M.map p) z := (rfl)
 
 /-- **The trivial path acts as the identity**, the element-level
 `TauCeti.QuiverRep.map_nil_apply` read as an equation of linear maps. -/
+@[simp]
 theorem mapₗ_nil (a : Q) : mapₗ k Q M (_root_.Quiver.Path.nil : _root_.Quiver.Path a a)
     = LinearMap.id := by
   refine LinearMap.ext fun z => ?_
@@ -193,12 +198,6 @@ theorem pathEnd_mul {a b c : Q} (p : _root_.Quiver.Path a b) (q : _root_.Quiver.
     mapₗ_comp k Q M q p]
   exact congrArg _ (congrArg _ (DirectSum.component.lof_self k a _))
 
-/-- The projection onto a summand kills every other summand. -/
-theorem component_lof_of_ne {i j : Q} (hij : j ≠ i) (b : vertexSpace k Q M j) :
-    DirectSum.component k Q (vertexSpace k Q M) i
-      (DirectSum.lof k Q (vertexSpace k Q M) j b) = 0 :=
-  (DirectSum.component.of k i j b).trans (dite_eq_right hij)
-
 /-- **Paths that do not meet annihilate one another**, because the second lands in a summand the
 first reads as zero. This is the other half of the multiplicativity of
 `TauCeti.QuiverRep.toEnd`. -/
@@ -207,7 +206,8 @@ theorem pathEnd_mul_eq_zero {x y : Quiver.TotalPath Q} (h : y.2.1 ≠ x.1) :
   refine LinearMap.ext fun z => ?_
   have key : DirectSum.component k Q (vertexSpace k Q M) x.1 (pathEnd k Q M y z) = 0 := by
     rw [pathEnd_apply]
-    exact component_lof_of_ne k Q M h _
+    -- the projection onto a summand kills every other summand
+    exact (DirectSum.component.of k x.1 y.2.1 _).trans (dite_eq_right h)
   rw [Module.End.mul_apply, pathEnd_apply, key, map_zero, map_zero, LinearMap.zero_apply]
 
 /-- **The trivial paths give the summand projections**, and those sum to the identity: this is what
@@ -227,6 +227,7 @@ noncomputable def toEndₗ :
   (pathAlgebraBasis k Q).constr k (pathEnd k Q M)
 
 /-- The action of a basis path is the endomorphism it was assigned. -/
+@[simp]
 theorem toEndₗ_ofPath (x : Quiver.TotalPath Q) :
     toEndₗ k Q M (ofPath x) = pathEnd k Q M x := by
   have h := (pathAlgebraBasis k Q).constr_basis k (pathEnd k Q M) x
@@ -235,8 +236,9 @@ theorem toEndₗ_ofPath (x : Quiver.TotalPath Q) :
 /-- The action of a scaled basis path scales its endomorphism. -/
 theorem toEndₗ_single (x : Quiver.TotalPath Q) (c : k) :
     toEndₗ k Q M (single x c) = c • pathEnd k Q M x := by
-  rw [show (single x c : pathAlgebra k Q) = c • ofPath x by
-    rw [ofPath_eq_single, smul_single, mul_one], map_smul, toEndₗ_ofPath]
+  have hx : (single x c : pathAlgebra k Q) = c • ofPath x := by
+    rw [ofPath_eq_single, smul_single, mul_one]
+  rw [hx, map_smul, toEndₗ_ofPath]
 
 /-- The action of a vertex idempotent is the endomorphism of the trivial path there, which by
 `TauCeti.QuiverRep.mapₗ_nil` is the projection onto that summand. -/
@@ -291,6 +293,7 @@ noncomputable def toEnd : pathAlgebra k Q →ₐ[k] Module.End k (DirectSum Q (v
     fun c x => (toEndₗ k Q M).map_smul c x
 
 /-- The algebra map acts by the linear map it was built from. -/
+@[simp]
 theorem toEnd_apply (f : pathAlgebra k Q) : toEnd k Q M f = toEndₗ k Q M f := (rfl)
 
 /-- The module over the path algebra carried by a representation of `Q`. -/
@@ -300,9 +303,14 @@ def asModule : Type max v t := DirectSum Q (vertexSpace k Q M)
 instance : AddCommGroup (asModule k Q M) :=
   inferInstanceAs (AddCommGroup (DirectSum Q (vertexSpace k Q M)))
 
+/-- **The defining `kQ`-action**: the path algebra acts on `⨁ᵥ Mᵥ` through the algebra map
+`TauCeti.QuiverRep.toEnd` into its `k`-linear endomorphisms. -/
 noncomputable instance : Module (pathAlgebra k Q) (asModule k Q M) :=
   Module.compHom (DirectSum Q (vertexSpace k Q M)) (toEnd k Q M).toRingHom
 
+/-- The `k`-action, by restriction of scalars along `algebraMap k (kQ)` — deliberately *not* the
+direct sum's own `k`-action, though `TauCeti.QuiverRep.smul_asModule_k` says the two agree; see the
+implementation notes. -/
 noncomputable instance : Module k (asModule k Q M) :=
   Module.restrictScalars k (pathAlgebra k Q) (asModule k Q M)
 
@@ -311,7 +319,8 @@ two are compatible by construction. -/
 instance : IsScalarTower k (pathAlgebra k Q) (asModule k Q M) :=
   IsScalarTower.restrictScalars k (pathAlgebra k Q) (asModule k Q M)
 
-/-- The underlying direct sum of an element. -/
+/-- The additive equivalence identifying `TauCeti.QuiverRep.asModule` with the direct sum `⨁ᵥ Mᵥ`
+underlying it. -/
 @[expose]
 def asModuleEquiv : asModule k Q M ≃+ DirectSum Q (vertexSpace k Q M) := AddEquiv.refl _
 
@@ -336,6 +345,7 @@ noncomputable def asModuleLinearEquiv :
   { asModuleEquiv k Q M with map_smul' := smul_asModule_k k Q M }
 
 /-- The `k`-linear identification with the underlying direct sum is the additive one. -/
+@[simp]
 theorem asModuleLinearEquiv_apply (x : asModule k Q M) :
     asModuleLinearEquiv k Q M x = asModuleEquiv k Q M x := (rfl)
 
@@ -349,10 +359,12 @@ noncomputable def toVertex (v : Q) : asModule k Q M →ₗ[k] vertexSpace k Q M 
     (asModuleLinearEquiv k Q M).toLinearMap
 
 /-- The inclusion of a vertex space is the inclusion of the corresponding summand. -/
+@[simp]
 theorem asModuleEquiv_ofVertex (v : Q) (z : vertexSpace k Q M v) :
     asModuleEquiv k Q M (ofVertex k Q M v z) = DirectSum.lof k Q (vertexSpace k Q M) v z := (rfl)
 
 /-- The projection onto a vertex space undoes its inclusion. -/
+@[simp]
 theorem toVertex_ofVertex (v : Q) (z : vertexSpace k Q M v) :
     toVertex k Q M v (ofVertex k Q M v z) = z :=
   DirectSum.component.lof_self k v z
@@ -374,6 +386,7 @@ theorem smul_ofVertex {a b : Q} (p : _root_.Quiver.Path a b) (z : vertexSpace k 
 
 /-- **The vertex idempotent acts as the projection onto its summand**, the fact from which the
 vertex component of `TauCeti.QuiverRep.asModule` is read off. -/
+@[simp]
 theorem vertexIdempotent_smul (v : Q) (x : asModule k Q M) :
     (vertexIdempotent k v : pathAlgebra k Q) • x = ofVertex k Q M v (toVertex k Q M v x) := by
   apply (asModuleEquiv k Q M).injective
@@ -400,11 +413,13 @@ noncomputable def vertexComponentEquiv (v : Q) :
 
 /-- The identification of a vertex space with a vertex component is the inclusion of the
 summand. -/
+@[simp]
 theorem coe_vertexComponentEquiv (v : Q) (z : vertexSpace k Q M v) :
     (vertexComponentEquiv k Q M v z : asModule k Q M) = ofVertex k Q M v z := (rfl)
 
 /-- **The identification is natural in the path**: the action of a path on the vertex components of
 `TauCeti.QuiverRep.asModule` is the structure map of the representation. -/
+@[simp]
 theorem pathMap_vertexComponentEquiv {a b : Q} (p : _root_.Quiver.Path a b)
     (z : vertexSpace k Q M a) :
     pathMap k (asModule k Q M) p (vertexComponentEquiv k Q M a z)
@@ -427,6 +442,11 @@ noncomputable def asModuleIso : quiverRepOfModule k Q (asModule k Q M) ≅ M :=
       change Q at a
       change Q at b
       refine ModuleCat.hom_ext (LinearMap.ext fun x => ?_)
+      -- both sides of the naturality square are `ModuleCat.ofHom` of a composite of a structure
+      -- map with a `LinearEquiv.toModuleIso`, and the bundling is definitional: no rewrite lemma
+      -- states the elementwise form, because `ModuleCat.hom_comp` and
+      -- `LinearEquiv.toModuleIso_symm_hom` fire only on the unapplied morphisms, leaving the
+      -- coercions to unfold anyway. `change` names the elementwise goal in one step.
       change (vertexComponentEquiv k Q M b).symm (pathMap k (asModule k Q M) p x)
         = mapₗ k Q M p ((vertexComponentEquiv k Q M a).symm x)
       rw [LinearEquiv.symm_apply_eq, ← pathMap_vertexComponentEquiv]

--- a/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
@@ -26,39 +26,46 @@ The carrier is the direct sum `⨁ᵥ Mᵥ` of the vertex spaces.  A basis path 
 on it by the endomorphism `TauCeti.QuiverRep.pathEnd` that reads off the `a`-component, applies the
 structure map `M.map p`, and puts the result in the `b`-component; two such endomorphisms compose
 to the endomorphism of the concatenated path when the paths meet
-(`TauCeti.QuiverRep.pathEnd_mul`) and to zero when they do not
-(`TauCeti.QuiverRep.pathEnd_mul_eq_zero`), while the trivial paths give the component projections,
-which sum to the identity (`TauCeti.QuiverRep.sum_pathEnd_nil`).  Extending linearly along the path
-basis `TauCeti.pathAlgebraBasis` therefore gives an algebra homomorphism
+(`TauCeti.QuiverRep.pathEnd_mul_pathEnd_of_comp`) and to zero when they do not
+(`TauCeti.QuiverRep.pathEnd_mul_pathEnd_of_not_composable`), while the trivial paths give the
+component projections, which sum to the identity (`TauCeti.QuiverRep.sum_pathEnd_nil`).  Those are
+exactly the three hypotheses of the universal property `TauCeti.PathAlgebra.liftAlgHom`, so the
+assignment extends to an algebra homomorphism
 `TauCeti.QuiverRep.toEnd : kQ →ₐ[k] End_k (⨁ᵥ Mᵥ)`, and `TauCeti.QuiverRep.asModule` is `⨁ᵥ Mᵥ`
 with the module structure it induces.
 
 With that in hand the vertex idempotent `eᵥ` acts as the composite of the projection to `Mᵥ` and
 the inclusion back (`TauCeti.QuiverRep.vertexIdempotent_smul`), so the vertex component
 `eᵥ · asModule` is exactly the image of `Mᵥ` (`TauCeti.QuiverRep.vertexComponent_asModule`) and the
-inclusion is a `k`-linear isomorphism onto it.  Those isomorphisms are natural in the path, because
-a path acts on the image of `Mₐ` through `M.map p` (`TauCeti.QuiverRep.smul_ofVertex`), which is
-the natural isomorphism `TauCeti.QuiverRep.asModuleIso`.
+inclusion is a `k`-linear isomorphism onto it, `TauCeti.QuiverRep.vertexComponentEquiv`.  Those
+isomorphisms are natural in the path, because a path acts on the image of `Mₐ` through `M.map p`
+(`TauCeti.QuiverRep.smul_ofVertex`, whence
+`TauCeti.QuiverRep.pathMap_vertexComponentEquiv`); assembling them with
+`CategoryTheory.NatIso.ofComponents` gives the natural isomorphism
+`TauCeti.QuiverRep.asModuleIso`.
 
 ## Main definitions
 
-* `TauCeti.QuiverRep.vertexSpace`: the vector space a representation assigns to a vertex, as a bare
-  type indexed by the vertices, with `TauCeti.QuiverRep.mapₗ` the structure maps between those.
-* `TauCeti.QuiverRep.pathEnd`: the endomorphism of `⨁ᵥ Mᵥ` by which a basis path of `kQ` acts.
-* `TauCeti.QuiverRep.toEndₗ` and `TauCeti.QuiverRep.toEnd`: that action extended along the path
-  basis, first linearly and then as a `k`-algebra homomorphism into `End_k (⨁ᵥ Mᵥ)`.
+* `TauCeti.QuiverRep.pathEnd`: the endomorphism of `⨁ᵥ Mᵥ` by which a basis path of `kQ` acts, and
+  `TauCeti.QuiverRep.toEnd`: that action extended along the path basis as a `k`-algebra
+  homomorphism into `End_k (⨁ᵥ Mᵥ)`.
 * `TauCeti.QuiverRep.asModule`: **the `kQ`-module carried by a representation of `Q`**, the direct
   sum `⨁ᵥ Mᵥ` with the action of `TauCeti.QuiverRep.toEnd`.
 * `TauCeti.QuiverRep.ofVertex` and `TauCeti.QuiverRep.toVertex`: the inclusion of a vertex space
   into that module and the projection onto it.
 * `TauCeti.quiverRepEquivalence`: **representations of a quiver are modules over its path
-  algebra.**
+  algebra**, with `TauCeti.quiverRepEquivalenceFunctorObjIso` identifying the module it sends a
+  representation to with `TauCeti.QuiverRep.asModule`.
 
 ## Main results
 
-* `TauCeti.QuiverRep.vertexIdempotent_smul`: the vertex idempotent `eᵥ` acts on `asModule` as the
-  projection onto the summand `Mᵥ`, whence `TauCeti.QuiverRep.vertexComponent_asModule`: the vertex
-  component of `asModule` at `v` is the image of `Mᵥ`.
+* `TauCeti.QuiverRep.smul_ofPath`: a basis path acts on `asModule` by reading off the component at
+  its source, applying the structure map and putting the result in the component at its target;
+  the two cases used below are `TauCeti.QuiverRep.smul_ofVertex` and
+  `TauCeti.QuiverRep.vertexIdempotent_smul`, the latter saying that the vertex idempotent `eᵥ` acts
+  as the projection onto the summand `Mᵥ`, whence
+  `TauCeti.QuiverRep.vertexComponent_asModule`: the vertex component of `asModule` at `v` is the
+  image of `Mᵥ`.
 * `TauCeti.QuiverRep.vertexComponentEquiv`: the vertex space `Mᵥ` is that vertex component, and
   `TauCeti.QuiverRep.pathMap_vertexComponentEquiv`: the identification is natural in the path.
 * `TauCeti.QuiverRep.asModuleIso`: **the representation carried by `asModule M` is `M`**, so
@@ -68,14 +75,13 @@ the natural isomorphism `TauCeti.QuiverRep.asModuleIso`.
 
 ## Implementation notes
 
-The vertex spaces are named as a family `TauCeti.QuiverRep.vertexSpace` rather than used as
-`M.obj v` directly.  A representation is a functor out of `CategoryTheory.Paths Q`, whose objects
-are vertices only after unfolding the semireducible `CategoryTheory.Paths`; instance search does
-not see through that when it is asked for the *family* `∀ v : Q, AddCommMonoid (M.obj v)` that a
-direct sum indexed by the vertices needs, although it succeeds at each individual vertex.  Naming
-the family and giving it its two instances by `inferInstanceAs` is what makes `DirectSum Q` usable
-here at all.  For the same reason the naturality square of `TauCeti.QuiverRep.asModuleIso` opens
-with `change Q at a`, restating its quantified objects as vertices.
+The vertex spaces are used through the family `TauCeti.QuiverRep.vertexSpace` of
+`TauCeti.RepresentationTheory.Quiver.Representation.Basic` rather than as `M.obj v` directly,
+because instance search does not see the objects of `CategoryTheory.Paths Q` as vertices when it is
+asked for the *family* of instances that a direct sum indexed by the vertices needs; that file's
+implementation notes say more.  For the same reason the naturality square of
+`TauCeti.QuiverRep.asModuleIso` opens with `change Q at a`, restating its quantified objects as
+vertices.
 
 The `k`-module structure on `TauCeti.QuiverRep.asModule` is deliberately **not** the one the direct
 sum already carries: it is `Module.restrictScalars k (pathAlgebra k Q)`, restriction of scalars
@@ -83,17 +89,18 @@ along `algebraMap`.  That is exactly the structure `ModuleCat.moduleOfAlgebraMod
 object of `ModuleCat (kQ)`, which is the one `TauCeti.quiverRepFunctor` uses; taking the direct
 sum's own structure instead would give a second, only propositionally equal, `Module k` instance
 and the essential-surjectivity isomorphism would not typecheck against the functor.  The two agree
-by `TauCeti.QuiverRep.smul_asModule_k`, which is what upgrades the underlying additive equivalence
-`TauCeti.QuiverRep.asModuleEquiv` to the `k`-linear `TauCeti.QuiverRep.asModuleLinearEquiv`.
+by `TauCeti.QuiverRep.asModuleAddEquiv_smul`, which is what upgrades the underlying additive
+equivalence `TauCeti.QuiverRep.asModuleAddEquiv` to the `k`-linear
+`TauCeti.QuiverRep.asModuleEquiv`.
 
 `DecidableEq Q` is needed to write down the summand inclusions `DirectSum.lof`, so it is carried
 through the construction; the essential-surjectivity instance is a `Prop` and discharges it with
 `classical`, so neither it nor `TauCeti.quiverRepEquivalence` asks for it.
 
-The universes are the reason the equivalence is stated for representations valued in
-`ModuleCat.{max v t} k` for a vertex type in `Type v`: the direct sum of a `Type v`-indexed family
-of `Type t`-modules lands in `Type (max v t)`, so a representation is carried by a module in that
-universe and no smaller one.  For the usual case of a vertex type and vector spaces in the same
+The equivalence is stated for representations valued in `ModuleCat.{max v t} k` for a vertex type
+in `Type v` because that is where the carrier built here lands: the direct sum used is indexed by
+`Q : Type v` and its summands lie in `Type t`, so `⨁ᵥ Mᵥ : Type (max v t)`, and no reindexing to a
+smaller universe is performed.  For the usual case of a vertex type and vector spaces in the same
 universe this is no restriction.
 
 ## References
@@ -103,6 +110,11 @@ This is the essential-surjectivity half of `quiverRepEquivalence`, Layer 1 of
 equivalence "sending a module `M` to the representation `v ↦ eᵥ M`, with an arrow acting by left
 multiplication, and inverting through the idempotent decomposition `M = ⨁ᵥ eᵥ M`"; the fully
 faithful half is `TauCeti.quiverRepFunctorFullyFaithful`.
+
+The plan of the file follows Mathlib's group-algebra analogue: the type synonym carrying a module
+structure through `Module.compHom`, the equivalence with the underlying type and the shape of the
+final `≌ ModuleCat (algebra)` statement are those of `Representation.asModule`,
+`Representation.asModuleEquiv` and `Rep.equivalenceModuleMonoidAlgebra` for `k[G]`.
 
 See I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
 Algebras, Vol. 1*, Ch. III, or R. Schiffler, *Quiver Representations*, Ch. 5.
@@ -117,53 +129,6 @@ open CategoryTheory PathAlgebra
 universe u v w t
 
 namespace QuiverRep
-
-section Vertex
-
-variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q]
-variable (M : QuiverRep.{u, v, w, t} k Q)
-
-/-- The vertex space, as a bare type indexed by the vertices. -/
-@[expose]
-def vertexSpace (v : Q) : Type t := M.obj v
-
-instance instAddCommGroupVertexSpace (v : Q) : AddCommGroup (vertexSpace k Q M v) :=
-  inferInstanceAs (AddCommGroup (M.obj v))
-
-instance instModuleVertexSpace (v : Q) : Module k (vertexSpace k Q M v) :=
-  inferInstanceAs (Module k (M.obj v))
-
-/-- The structure map of a representation along a path, retyped between vertex spaces. -/
-noncomputable def mapₗ {a b : Q} (p : _root_.Quiver.Path a b) :
-    vertexSpace k Q M a →ₗ[k] vertexSpace k Q M b := (M.map p).hom
-
--- Not `@[simp]`: `TauCeti.QuiverRep.mapₗ` is the simp-normal form of a structure map here, since
--- it is the retyping that lets the direct sum see the vertex spaces; rewriting with this would
--- undo that everywhere and take `TauCeti.QuiverRep.smul_ofVertex` and
--- `TauCeti.QuiverRep.pathMap_vertexComponentEquiv` out of simp normal form.
-/-- The retyped structure map is the structure map. -/
-theorem mapₗ_apply {a b : Q} (p : _root_.Quiver.Path a b) (z : vertexSpace k Q M a) :
-    mapₗ k Q M p z = (M.map p) z := (rfl)
-
-/-- **The trivial path acts as the identity**, the element-level
-`TauCeti.QuiverRep.map_nil_apply` read as an equation of linear maps. -/
-@[simp]
-theorem mapₗ_nil (a : Q) : mapₗ k Q M (_root_.Quiver.Path.nil : _root_.Quiver.Path a a)
-    = LinearMap.id := by
-  refine LinearMap.ext fun z => ?_
-  rw [mapₗ_apply, LinearMap.id_apply]
-  exact QuiverRep.map_nil_apply M a z
-
-/-- **Concatenation of paths composes the structure maps**, the functoriality of a representation
-read on the retyped maps. -/
-theorem mapₗ_comp {a b c : Q} (p : _root_.Quiver.Path a b) (q : _root_.Quiver.Path b c) :
-    mapₗ k Q M (p.comp q) = (mapₗ k Q M q).comp (mapₗ k Q M p) := by
-  refine LinearMap.ext fun z => ?_
-  have h : M.map (p.comp q) = M.map p ≫ M.map q := M.map_comp p q
-  rw [mapₗ_apply, h]
-  rfl
-
-end Vertex
 
 section Basic
 
@@ -191,7 +156,8 @@ theorem pathEnd_mk_apply {a b : Q} (p : _root_.Quiver.Path a b)
 
 /-- **Composable paths compose**: the endomorphisms of two paths that meet multiply to the
 endomorphism of their concatenation, later factor first, as the path algebra multiplies them. -/
-theorem pathEnd_mul {a b c : Q} (p : _root_.Quiver.Path a b) (q : _root_.Quiver.Path c a) :
+theorem pathEnd_mul_pathEnd_of_comp {a b c : Q} (p : _root_.Quiver.Path a b)
+    (q : _root_.Quiver.Path c a) :
     pathEnd k Q M ⟨a, b, p⟩ * pathEnd k Q M ⟨c, a, q⟩ = pathEnd k Q M ⟨c, b, q.comp p⟩ := by
   refine LinearMap.ext fun z => ?_
   rw [Module.End.mul_apply, pathEnd_mk_apply, pathEnd_mk_apply, pathEnd_mk_apply,
@@ -201,7 +167,7 @@ theorem pathEnd_mul {a b c : Q} (p : _root_.Quiver.Path a b) (q : _root_.Quiver.
 /-- **Paths that do not meet annihilate one another**, because the second lands in a summand the
 first reads as zero. This is the other half of the multiplicativity of
 `TauCeti.QuiverRep.toEnd`. -/
-theorem pathEnd_mul_eq_zero {x y : Quiver.TotalPath Q} (h : y.2.1 ≠ x.1) :
+theorem pathEnd_mul_pathEnd_of_not_composable {x y : Quiver.TotalPath Q} (h : y.2.1 ≠ x.1) :
     pathEnd k Q M x * pathEnd k Q M y = 0 := by
   refine LinearMap.ext fun z => ?_
   have key : DirectSum.component k Q (vertexSpace k Q M) x.1 (pathEnd k Q M y z) = 0 := by
@@ -221,52 +187,6 @@ theorem sum_pathEnd_nil [Fintype Q] :
     ← DirectSum.apply_eq_component, Module.End.one_apply, DirectSum.lof_eq_of]
   exact DirectSum.sum_univ_of z
 
-/-- The action of the path algebra on `⨁ᵥ Mᵥ`, as a linear map. -/
-noncomputable def toEndₗ :
-    pathAlgebra k Q →ₗ[k] Module.End k (DirectSum Q (vertexSpace k Q M)) :=
-  (pathAlgebraBasis k Q).constr k (pathEnd k Q M)
-
-/-- The action of a basis path is the endomorphism it was assigned. -/
-@[simp]
-theorem toEndₗ_ofPath (x : Quiver.TotalPath Q) :
-    toEndₗ k Q M (ofPath x) = pathEnd k Q M x := by
-  have h := (pathAlgebraBasis k Q).constr_basis k (pathEnd k Q M) x
-  rwa [coe_pathAlgebraBasis] at h
-
-/-- The action of a scaled basis path scales its endomorphism. -/
-theorem toEndₗ_single (x : Quiver.TotalPath Q) (c : k) :
-    toEndₗ k Q M (single x c) = c • pathEnd k Q M x := by
-  have hx : (single x c : pathAlgebra k Q) = c • ofPath x := by
-    rw [ofPath_eq_single, smul_single, mul_one]
-  rw [hx, map_smul, toEndₗ_ofPath]
-
-/-- The action of a vertex idempotent is the endomorphism of the trivial path there, which by
-`TauCeti.QuiverRep.mapₗ_nil` is the projection onto that summand. -/
-theorem toEndₗ_vertexIdempotent (v : Q) :
-    toEndₗ k Q M (vertexIdempotent k v) = pathEnd k Q M ⟨v, v, _root_.Quiver.Path.nil⟩ := by
-  rw [vertexIdempotent_eq_single, toEndₗ_single, one_smul]
-
-/-- **The action is multiplicative**, by `TauCeti.QuiverRep.pathEnd_mul` on composable basis paths
-and `TauCeti.QuiverRep.pathEnd_mul_eq_zero` on the rest. -/
-theorem toEndₗ_mul (f g : pathAlgebra k Q) :
-    toEndₗ k Q M (f * g) = toEndₗ k Q M f * toEndₗ k Q M g := by
-  induction f using PathAlgebra.induction_linear with
-  | zero => simp
-  | add f₁ f₂ h₁ h₂ => rw [add_mul, map_add, map_add, h₁, h₂, add_mul]
-  | single x c =>
-    induction g using PathAlgebra.induction_linear with
-    | zero => simp
-    | add g₁ g₂ h₁ h₂ => rw [mul_add, map_add, map_add, h₁, h₂, mul_add]
-    | single y d =>
-      obtain ⟨a, b, p⟩ := x
-      obtain ⟨c', a', q⟩ := y
-      by_cases hy : a' = a
-      · subst hy
-        rw [single_mul_single_of_comp, toEndₗ_single, toEndₗ_single, toEndₗ_single,
-          smul_mul_smul_comm, pathEnd_mul]
-      · rw [single_mul_single_of_not_composable hy, map_zero, toEndₗ_single, toEndₗ_single,
-          smul_mul_smul_comm, pathEnd_mul_eq_zero k Q M hy, smul_zero]
-
 end Basic
 
 section Algebra
@@ -274,29 +194,37 @@ section Algebra
 variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q] [Finite Q] [DecidableEq Q]
 variable (M : QuiverRep.{u, v, w, t} k Q)
 
-/-- **The action is unital**: the unit of the path algebra is the sum of the vertex idempotents,
-whose endomorphisms are the summand projections. -/
-theorem toEndₗ_one : toEndₗ k Q M 1 = 1 := by
-  let _ := Fintype.ofFinite Q
-  rw [one_def, map_sum]
-  simp only [toEndₗ_vertexIdempotent]
-  exact sum_pathEnd_nil k Q M
-
-/-- The action of the path algebra on `⨁ᵥ Mᵥ`, as an algebra map. -/
+/-- **The action of the path algebra on `⨁ᵥ Mᵥ`**: the universal property
+`TauCeti.PathAlgebra.liftAlgHom` applied to `TauCeti.QuiverRep.pathEnd`, whose three hypotheses are
+the two composition laws and the completeness of the summand projections proved above. -/
 noncomputable def toEnd : pathAlgebra k Q →ₐ[k] Module.End k (DirectSum Q (vertexSpace k Q M)) :=
-  AlgHom.mk'
-    { toFun := toEndₗ k Q M
-      map_one' := toEndₗ_one k Q M
-      map_mul' := toEndₗ_mul k Q M
-      map_zero' := map_zero _
-      map_add' := fun f g => map_add _ f g }
-    fun c x => (toEndₗ k Q M).map_smul c x
+  PathAlgebra.liftAlgHom k (pathEnd k Q M) (pathEnd_mul_pathEnd_of_comp k Q M)
+    (pathEnd_mul_pathEnd_of_not_composable k Q M) (by intro _; exact sum_pathEnd_nil k Q M)
 
-/-- The algebra map acts by the linear map it was built from. -/
+/-- The action of a basis path is the endomorphism it was assigned. -/
 @[simp]
-theorem toEnd_apply (f : pathAlgebra k Q) : toEnd k Q M f = toEndₗ k Q M f := (rfl)
+theorem toEnd_ofPath (x : Quiver.TotalPath Q) : toEnd k Q M (ofPath x) = pathEnd k Q M x := by
+  rw [toEnd, PathAlgebra.liftAlgHom_ofPath]
 
-/-- The module over the path algebra carried by a representation of `Q`. -/
+/-- The action of a scaled basis path scales its endomorphism. -/
+theorem toEnd_single (x : Quiver.TotalPath Q) (c : k) :
+    toEnd k Q M (single x c) = c • pathEnd k Q M x := by
+  rw [toEnd, PathAlgebra.liftAlgHom_single]
+
+/-- The action of a vertex idempotent is the endomorphism of the trivial path there, which by
+`TauCeti.QuiverRep.mapₗ_nil` is the projection onto that summand. -/
+theorem toEnd_vertexIdempotent (v : Q) :
+    toEnd k Q M (vertexIdempotent k v) = pathEnd k Q M ⟨v, v, _root_.Quiver.Path.nil⟩ := by
+  rw [vertexIdempotent_eq_single, toEnd_single, one_smul]
+
+/-- The module over the path algebra carried by a representation of `Q`.
+
+`@[expose]` is load-bearing rather than a leak: the `Module (pathAlgebra k Q)` instance below is
+`Module.compHom` on the underlying direct sum, and the naturality square of
+`TauCeti.QuiverRep.asModuleIso` is stated on elements of it, neither of which elaborates against
+this type until the body is unfolded.  Consumers should still go through
+`TauCeti.QuiverRep.asModuleEquiv`, since the direct sum's own `k`-action is only propositionally
+the one carried here. -/
 @[expose]
 def asModule : Type max v t := DirectSum Q (vertexSpace k Q M)
 
@@ -309,8 +237,8 @@ noncomputable instance : Module (pathAlgebra k Q) (asModule k Q M) :=
   Module.compHom (DirectSum Q (vertexSpace k Q M)) (toEnd k Q M).toRingHom
 
 /-- The `k`-action, by restriction of scalars along `algebraMap k (kQ)` — deliberately *not* the
-direct sum's own `k`-action, though `TauCeti.QuiverRep.smul_asModule_k` says the two agree; see the
-implementation notes. -/
+direct sum's own `k`-action, though `TauCeti.QuiverRep.asModuleAddEquiv_smul` says the two agree;
+see the implementation notes. -/
 noncomputable instance : Module k (asModule k Q M) :=
   Module.restrictScalars k (pathAlgebra k Q) (asModule k Q M)
 
@@ -320,48 +248,63 @@ instance : IsScalarTower k (pathAlgebra k Q) (asModule k Q M) :=
   IsScalarTower.restrictScalars k (pathAlgebra k Q) (asModule k Q M)
 
 /-- The additive equivalence identifying `TauCeti.QuiverRep.asModule` with the direct sum `⨁ᵥ Mᵥ`
-underlying it. -/
+underlying it.  Its `k`-linear upgrade, once the two `k`-actions have been reconciled, is
+`TauCeti.QuiverRep.asModuleEquiv`.
+
+`@[expose]` is load-bearing for the same reason as on `TauCeti.QuiverRep.asModule`: this is the
+identity map, and the goals that reconcile the two `k`-actions
+(`TauCeti.QuiverRep.asModuleAddEquiv_smul`) and compute the action of a path
+(`TauCeti.QuiverRep.smul_ofPath`) close only once that is unfolded. -/
 @[expose]
-def asModuleEquiv : asModule k Q M ≃+ DirectSum Q (vertexSpace k Q M) := AddEquiv.refl _
+def asModuleAddEquiv : asModule k Q M ≃+ DirectSum Q (vertexSpace k Q M) := AddEquiv.refl _
 
 /-- The defining action on `TauCeti.QuiverRep.asModule`: an element of the path algebra acts
 through `TauCeti.QuiverRep.toEnd`. -/
 theorem smul_asModule_def (f : pathAlgebra k Q) (x : asModule k Q M) :
-    f • x = toEnd k Q M f (asModuleEquiv k Q M x) := (rfl)
+    f • x = toEnd k Q M f (asModuleAddEquiv k Q M x) := (rfl)
 
 /-- **The two `k`-actions agree**: the restriction of scalars along `algebraMap k (kQ)` that
 `TauCeti.QuiverRep.asModule` carries is the direct sum's own `k`-action, because
 `TauCeti.QuiverRep.toEnd` is a `k`-algebra map. This is what makes
-`TauCeti.QuiverRep.asModuleLinearEquiv` `k`-linear. -/
-theorem smul_asModule_k (r : k) (x : asModule k Q M) :
-    asModuleEquiv k Q M (r • x) = r • asModuleEquiv k Q M x := by
-  change asModuleEquiv k Q M ((algebraMap k (pathAlgebra k Q) r) • x) = _
-  rw [smul_asModule_def, AlgHom.commutes, Algebra.algebraMap_eq_smul_one]
+`TauCeti.QuiverRep.asModuleEquiv` `k`-linear. -/
+theorem asModuleAddEquiv_smul (r : k) (x : asModule k Q M) :
+    asModuleAddEquiv k Q M (r • x) = r • asModuleAddEquiv k Q M x := by
+  rw [← algebraMap_smul (pathAlgebra k Q) r x, smul_asModule_def, AlgHom.commutes,
+    Algebra.algebraMap_eq_smul_one, LinearMap.smul_apply, Module.End.one_apply]
+  -- what is left is the outer `TauCeti.QuiverRep.asModuleAddEquiv`, which is `AddEquiv.refl`
   rfl
 
-/-- The underlying direct sum of the module carried by a representation, `k`-linearly. -/
-noncomputable def asModuleLinearEquiv :
-    asModule k Q M ≃ₗ[k] DirectSum Q (vertexSpace k Q M) :=
-  { asModuleEquiv k Q M with map_smul' := smul_asModule_k k Q M }
+/-- **The module carried by a representation is its direct sum of vertex spaces**, `k`-linearly. -/
+noncomputable def asModuleEquiv : asModule k Q M ≃ₗ[k] DirectSum Q (vertexSpace k Q M) :=
+  { asModuleAddEquiv k Q M with map_smul' := asModuleAddEquiv_smul k Q M }
 
 /-- The `k`-linear identification with the underlying direct sum is the additive one. -/
 @[simp]
-theorem asModuleLinearEquiv_apply (x : asModule k Q M) :
-    asModuleLinearEquiv k Q M x = asModuleEquiv k Q M x := (rfl)
+theorem asModuleEquiv_apply (x : asModule k Q M) :
+    asModuleEquiv k Q M x = asModuleAddEquiv k Q M x := (rfl)
 
 /-- The inclusion of a vertex space into the module carried by a representation. -/
 noncomputable def ofVertex (v : Q) : vertexSpace k Q M v →ₗ[k] asModule k Q M :=
-  (asModuleLinearEquiv k Q M).symm.toLinearMap.comp (DirectSum.lof k Q (vertexSpace k Q M) v)
+  (asModuleEquiv k Q M).symm.toLinearMap.comp (DirectSum.lof k Q (vertexSpace k Q M) v)
 
 /-- The projection of the module carried by a representation onto a vertex space. -/
 noncomputable def toVertex (v : Q) : asModule k Q M →ₗ[k] vertexSpace k Q M v :=
-  (DirectSum.component k Q (vertexSpace k Q M) v).comp
-    (asModuleLinearEquiv k Q M).toLinearMap
+  (DirectSum.component k Q (vertexSpace k Q M) v).comp (asModuleEquiv k Q M).toLinearMap
 
 /-- The inclusion of a vertex space is the inclusion of the corresponding summand. -/
 @[simp]
-theorem asModuleEquiv_ofVertex (v : Q) (z : vertexSpace k Q M v) :
-    asModuleEquiv k Q M (ofVertex k Q M v z) = DirectSum.lof k Q (vertexSpace k Q M) v z := (rfl)
+theorem asModuleAddEquiv_ofVertex (v : Q) (z : vertexSpace k Q M v) :
+    asModuleAddEquiv k Q M (ofVertex k Q M v z)
+      = DirectSum.lof k Q (vertexSpace k Q M) v z := (rfl)
+
+-- Not `@[simp]`: this is the counterpart of `TauCeti.QuiverRep.asModuleAddEquiv_ofVertex`, stated
+-- so that the projection can be computed, but rewriting with it would take
+-- `TauCeti.QuiverRep.toVertex` out of the simp-normal form that
+-- `TauCeti.QuiverRep.toVertex_ofVertex` and `TauCeti.QuiverRep.vertexIdempotent_smul` fix.
+/-- The projection onto a vertex space reads off the corresponding component. -/
+theorem toVertex_apply (v : Q) (x : asModule k Q M) :
+    toVertex k Q M v x
+      = DirectSum.component k Q (vertexSpace k Q M) v (asModuleAddEquiv k Q M x) := (rfl)
 
 /-- The projection onto a vertex space undoes its inclusion. -/
 @[simp]
@@ -369,30 +312,60 @@ theorem toVertex_ofVertex (v : Q) (z : vertexSpace k Q M v) :
     toVertex k Q M v (ofVertex k Q M v z) = z :=
   DirectSum.component.lof_self k v z
 
+/-- **The summands are independent**: the projection onto a vertex space kills the image of every
+other one. -/
+@[simp]
+theorem toVertex_ofVertex_of_ne {u v : Q} (h : u ≠ v) (z : vertexSpace k Q M v) :
+    toVertex k Q M u (ofVertex k Q M v z) = 0 := by
+  rw [toVertex_apply, asModuleAddEquiv_ofVertex, DirectSum.component.of k u v z]
+  exact dite_eq_right (Ne.symm h)
+
+/-- **The summands exhaust the module**: every element of `TauCeti.QuiverRep.asModule` is the sum
+of the images of its vertex components. -/
+theorem sum_ofVertex_toVertex [Fintype Q] (x : asModule k Q M) :
+    ∑ v : Q, ofVertex k Q M v (toVertex k Q M v x) = x := by
+  apply (asModuleAddEquiv k Q M).injective
+  rw [map_sum]
+  simp only [asModuleAddEquiv_ofVertex, toVertex_apply, ← DirectSum.apply_eq_component,
+    DirectSum.lof_eq_of]
+  exact DirectSum.sum_univ_of _
+
 /-- The inclusion of a vertex space is injective. -/
 theorem ofVertex_injective (v : Q) : Function.Injective (ofVertex k Q M v) :=
   Function.LeftInverse.injective (toVertex_ofVertex k Q M v)
 
+-- Not `@[simp]`: the specialized `TauCeti.QuiverRep.smul_ofVertex` and
+-- `TauCeti.QuiverRep.vertexIdempotent_smul` are the simp-normal forms of the action, this one
+-- being stated on an arbitrary element and so introducing `TauCeti.QuiverRep.toVertex` where they
+-- do not.
+/-- **A basis path acts by transporting the component at its source**: it reads off that
+component, applies the structure map, and puts the result in the component at its target. This is
+`TauCeti.QuiverRep.pathEnd` read on `TauCeti.QuiverRep.asModule`. -/
+theorem smul_ofPath {a b : Q} (p : _root_.Quiver.Path a b) (x : asModule k Q M) :
+    (ofPath ⟨a, b, p⟩ : pathAlgebra k Q) • x
+      = ofVertex k Q M b (mapₗ k Q M p (toVertex k Q M a x)) := by
+  apply (asModuleAddEquiv k Q M).injective
+  rw [smul_asModule_def, toEnd_ofPath, pathEnd_mk_apply, asModuleAddEquiv_ofVertex, toVertex_apply]
+  -- what is left is the outer `TauCeti.QuiverRep.asModuleAddEquiv`, which is `AddEquiv.refl`
+  rfl
+
 /-- **A path acts on the image of its source through the structure map**: this is the naturality
 that makes `TauCeti.QuiverRep.asModuleIso` a morphism of representations. -/
+@[simp]
 theorem smul_ofVertex {a b : Q} (p : _root_.Quiver.Path a b) (z : vertexSpace k Q M a) :
     (ofPath ⟨a, b, p⟩ : pathAlgebra k Q) • ofVertex k Q M a z
       = ofVertex k Q M b (mapₗ k Q M p z) := by
-  apply (asModuleEquiv k Q M).injective
-  rw [smul_asModule_def, toEnd_apply, toEndₗ_ofPath, pathEnd_mk_apply, asModuleEquiv_ofVertex,
-    asModuleEquiv_ofVertex]
-  exact congrArg (fun y => DirectSum.lof k Q (vertexSpace k Q M) b (mapₗ k Q M p y))
-    (DirectSum.component.lof_self k a z)
+  rw [smul_ofPath, toVertex_ofVertex]
 
 /-- **The vertex idempotent acts as the projection onto its summand**, the fact from which the
 vertex component of `TauCeti.QuiverRep.asModule` is read off. -/
 @[simp]
 theorem vertexIdempotent_smul (v : Q) (x : asModule k Q M) :
     (vertexIdempotent k v : pathAlgebra k Q) • x = ofVertex k Q M v (toVertex k Q M v x) := by
-  apply (asModuleEquiv k Q M).injective
-  rw [smul_asModule_def, toEnd_apply, toEndₗ_vertexIdempotent, pathEnd_mk_apply,
-    asModuleEquiv_ofVertex, mapₗ_nil]
-  rfl
+  have h : (vertexIdempotent k v : pathAlgebra k Q)
+      = ofPath ⟨v, v, _root_.Quiver.Path.nil⟩ := by
+    rw [vertexIdempotent_eq_single, ofPath_eq_single]
+  rw [h, smul_ofPath, mapₗ_nil, LinearMap.id_coe, id_eq]
 
 /-- **The vertex component is the image of the vertex space**: the piece of
 `TauCeti.QuiverRep.asModule` that the vertex idempotent fixes is the summand `Mᵥ`. -/
@@ -485,6 +458,17 @@ the module-to-representation functor of
 `TauCeti.RepresentationTheory.Quiver.Representation.OfModule`, turned around. -/
 theorem _root_.TauCeti.quiverRepEquivalence_inverse :
     (quiverRepEquivalence.{u, v, w, t} k Q).inverse = quiverRepFunctor k Q := (rfl)
+
+/-- **The forward direction of `TauCeti.quiverRepEquivalence` is
+`TauCeti.QuiverRep.asModule`.** The functor of the equivalence is `CategoryTheory.Functor.inv`, so
+on objects it is a choice of preimage; this identifies that choice with the module built here,
+which is what a consumer transporting a representation across the equivalence needs. -/
+noncomputable def _root_.TauCeti.quiverRepEquivalenceFunctorObjIso [DecidableEq Q]
+    (M : QuiverRep.{u, v, w, max v t} k Q) :
+    (quiverRepEquivalence.{u, v, w, t} k Q).functor.obj M
+      ≅ ModuleCat.of (pathAlgebra k Q) (asModule k Q M) :=
+  (quiverRepFunctorFullyFaithful k Q).preimageIso
+    ((quiverRepFunctor.{u, v, w, max v t} k Q).objObjPreimageIso M ≪≫ (asModuleIso k Q M).symm)
 
 end Equivalence
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.RepresentationTheory.Quiver.Representation.OfModule
 public import Mathlib.Algebra.DirectSum.Module
+public import Mathlib.Algebra.Module.Shrink
 
 /-!
 # The module over the path algebra carried by a representation of a quiver
@@ -42,7 +43,10 @@ isomorphisms are natural in the path, because a path acts on the image of `Mₐ`
 (`TauCeti.QuiverRep.smul_ofVertex`, whence
 `TauCeti.QuiverRep.pathMap_vertexComponentEquiv`); assembling them with
 `CategoryTheory.NatIso.ofComponents` gives the natural isomorphism
-`TauCeti.QuiverRep.asModuleIso`.
+`TauCeti.QuiverRep.asModuleIso`.  Transported to the model
+`TauCeti.QuiverRep.asModuleShrink` of the carrier in the universe of the representation itself,
+that isomorphism becomes `TauCeti.QuiverRep.asModuleShrinkIso`, the essential surjectivity of
+`TauCeti.quiverRepFunctor`.
 
 ## Main definitions
 
@@ -53,6 +57,8 @@ isomorphisms are natural in the path, because a path acts on the image of `Mₐ`
   sum `⨁ᵥ Mᵥ` with the action of `TauCeti.QuiverRep.toEnd`.
 * `TauCeti.QuiverRep.ofVertex` and `TauCeti.QuiverRep.toVertex`: the inclusion of a vertex space
   into that module and the projection onto it.
+* `TauCeti.QuiverRep.asModuleShrink`: the model of that module in the universe of the
+  representation, `TauCeti.QuiverRep.asModuleShrinkEquiv` identifying the two.
 * `TauCeti.quiverRepEquivalence`: **representations of a quiver are modules over its path
   algebra**, with `TauCeti.quiverRepEquivalenceFunctorObjIso` identifying the module it sends a
   representation to with `TauCeti.QuiverRep.asModule`.
@@ -68,7 +74,8 @@ isomorphisms are natural in the path, because a path acts on the image of `Mₐ`
   image of `Mᵥ`.
 * `TauCeti.QuiverRep.vertexComponentEquiv`: the vertex space `Mᵥ` is that vertex component, and
   `TauCeti.QuiverRep.pathMap_vertexComponentEquiv`: the identification is natural in the path.
-* `TauCeti.QuiverRep.asModuleIso`: **the representation carried by `asModule M` is `M`**, so
+* `TauCeti.QuiverRep.asModuleIso`: **the representation carried by `asModule M` is `M`**, whence
+  `TauCeti.QuiverRep.asModuleShrinkIso` says the same of the small model, so
   `TauCeti.quiverRepFunctor` is essentially surjective, and being fully faithful already it is an
   equivalence.  `TauCeti.QuiverRep.dimVector_asModule` records that the dimension vector is
   unchanged.
@@ -79,29 +86,34 @@ The vertex spaces are used through the family `TauCeti.QuiverRep.vertexSpace` of
 `TauCeti.RepresentationTheory.Quiver.Representation.Basic` rather than as `M.obj v` directly,
 because instance search does not see the objects of `CategoryTheory.Paths Q` as vertices when it is
 asked for the *family* of instances that a direct sum indexed by the vertices needs; that file's
-implementation notes say more.  For the same reason the naturality square of
-`TauCeti.QuiverRep.asModuleIso` opens with `change Q at a`, restating its quantified objects as
-vertices.
+implementation notes say more.  For the same reason the naturality squares of
+`TauCeti.QuiverRep.asModuleIso` and `TauCeti.QuiverRep.asModuleShrinkIso` open with
+`change Q at a`, restating their quantified objects as vertices.
 
 The `k`-module structure on `TauCeti.QuiverRep.asModule` is deliberately **not** the one the direct
 sum already carries: it is `Module.restrictScalars k (pathAlgebra k Q)`, restriction of scalars
 along `algebraMap`.  That is exactly the structure `ModuleCat.moduleOfAlgebraModule` puts on an
 object of `ModuleCat (kQ)`, which is the one `TauCeti.quiverRepFunctor` uses; taking the direct
 sum's own structure instead would give a second, only propositionally equal, `Module k` instance
-and the essential-surjectivity isomorphism would not typecheck against the functor.  The two agree
-by `TauCeti.QuiverRep.asModuleAddEquiv_smul`, which is what upgrades the underlying additive
-equivalence `TauCeti.QuiverRep.asModuleAddEquiv` to the `k`-linear
-`TauCeti.QuiverRep.asModuleEquiv`.
+and the essential-surjectivity isomorphism would not typecheck against the functor.  That the two
+agree is what makes the identification `TauCeti.QuiverRep.asModuleEquiv` with the direct sum
+`k`-linear; the identity additive equivalence it upgrades is private, `asModuleEquiv` being the
+identification consumers use.
 
 `DecidableEq Q` is needed to write down the summand inclusions `DirectSum.lof`, so it is carried
 through the construction; the essential-surjectivity instance is a `Prop` and discharges it with
 `classical`, so neither it nor `TauCeti.quiverRepEquivalence` asks for it.
 
-The equivalence is stated for representations valued in `ModuleCat.{max v t} k` for a vertex type
-in `Type v` because that is where the carrier built here lands: the direct sum used is indexed by
-`Q : Type v` and its summands lie in `Type t`, so `⨁ᵥ Mᵥ : Type (max v t)`, and no reindexing to a
-smaller universe is performed.  For the usual case of a vertex type and vector spaces in the same
-universe this is no restriction.
+The concrete carrier is indexed by `Q : Type v` with summands in `Type t`, so
+`⨁ᵥ Mᵥ : Type (max v t)`: `TauCeti.QuiverRep.asModule` lands in a larger universe than the
+representation it is built from whenever the vertex type does.  `TauCeti.quiverRepEquivalence` is
+nevertheless stated at an arbitrary representation universe `t`, because over a finite vertex set
+that direct sum is a finite product of the vertex spaces and so has a model in `Type t`
+(`TauCeti.QuiverRep.small_asModule`); the model `TauCeti.QuiverRep.asModuleShrink` of it, whose
+vertex components are those of `asModule` because `TauCeti.QuiverRep.asModuleShrinkEquiv` is
+`kQ`-linear, is what witnesses essential surjectivity there.  The concrete direct-sum API is kept
+at `max v t`, and `TauCeti.quiverRepEquivalenceFunctorObjIso` identifies the forward direction with
+`asModule` itself at that universe.
 
 ## References
 
@@ -207,6 +219,7 @@ theorem toEnd_ofPath (x : Quiver.TotalPath Q) : toEnd k Q M (ofPath x) = pathEnd
   rw [toEnd, PathAlgebra.liftAlgHom_ofPath]
 
 /-- The action of a scaled basis path scales its endomorphism. -/
+@[simp]
 theorem toEnd_single (x : Quiver.TotalPath Q) (c : k) :
     toEnd k Q M (single x c) = c • pathEnd k Q M x := by
   rw [toEnd, PathAlgebra.liftAlgHom_single]
@@ -237,8 +250,8 @@ noncomputable instance : Module (pathAlgebra k Q) (asModule k Q M) :=
   Module.compHom (DirectSum Q (vertexSpace k Q M)) (toEnd k Q M).toRingHom
 
 /-- The `k`-action, by restriction of scalars along `algebraMap k (kQ)` — deliberately *not* the
-direct sum's own `k`-action, though `TauCeti.QuiverRep.asModuleAddEquiv_smul` says the two agree;
-see the implementation notes. -/
+direct sum's own `k`-action, though the two agree, which is what makes
+`TauCeti.QuiverRep.asModuleEquiv` `k`-linear; see the implementation notes. -/
 noncomputable instance : Module k (asModule k Q M) :=
   Module.restrictScalars k (pathAlgebra k Q) (asModule k Q M)
 
@@ -247,41 +260,36 @@ two are compatible by construction. -/
 instance : IsScalarTower k (pathAlgebra k Q) (asModule k Q M) :=
   IsScalarTower.restrictScalars k (pathAlgebra k Q) (asModule k Q M)
 
-/-- The additive equivalence identifying `TauCeti.QuiverRep.asModule` with the direct sum `⨁ᵥ Mᵥ`
-underlying it.  Its `k`-linear upgrade, once the two `k`-actions have been reconciled, is
-`TauCeti.QuiverRep.asModuleEquiv`.
+/-- The identity additive equivalence between `TauCeti.QuiverRep.asModule` and the direct sum
+`⨁ᵥ Mᵥ` underlying it.  It is private, being only the step at which the two `k`-actions are
+reconciled: the public identification is its `k`-linear upgrade
+`TauCeti.QuiverRep.asModuleEquiv`. -/
+private def asModuleAddEquiv : asModule k Q M ≃+ DirectSum Q (vertexSpace k Q M) := AddEquiv.refl _
 
-`@[expose]` is load-bearing for the same reason as on `TauCeti.QuiverRep.asModule`: this is the
-identity map, and the goals that reconcile the two `k`-actions
-(`TauCeti.QuiverRep.asModuleAddEquiv_smul`) and compute the action of a path
-(`TauCeti.QuiverRep.smul_ofPath`) close only once that is unfolded. -/
-@[expose]
-def asModuleAddEquiv : asModule k Q M ≃+ DirectSum Q (vertexSpace k Q M) := AddEquiv.refl _
-
-/-- The defining action on `TauCeti.QuiverRep.asModule`: an element of the path algebra acts
-through `TauCeti.QuiverRep.toEnd`. -/
-theorem smul_asModule_def (f : pathAlgebra k Q) (x : asModule k Q M) :
-    f • x = toEnd k Q M f (asModuleAddEquiv k Q M x) := (rfl)
+/-- The defining action, read through the identity additive equivalence; the public form is
+`TauCeti.QuiverRep.smul_asModule_def`. -/
+private theorem asModuleAddEquiv_smul_pathAlgebra (f : pathAlgebra k Q) (x : asModule k Q M) :
+    asModuleAddEquiv k Q M (f • x) = toEnd k Q M f (asModuleAddEquiv k Q M x) := (rfl)
 
 /-- **The two `k`-actions agree**: the restriction of scalars along `algebraMap k (kQ)` that
 `TauCeti.QuiverRep.asModule` carries is the direct sum's own `k`-action, because
 `TauCeti.QuiverRep.toEnd` is a `k`-algebra map. This is what makes
 `TauCeti.QuiverRep.asModuleEquiv` `k`-linear. -/
-theorem asModuleAddEquiv_smul (r : k) (x : asModule k Q M) :
+private theorem asModuleAddEquiv_smul (r : k) (x : asModule k Q M) :
     asModuleAddEquiv k Q M (r • x) = r • asModuleAddEquiv k Q M x := by
-  rw [← algebraMap_smul (pathAlgebra k Q) r x, smul_asModule_def, AlgHom.commutes,
+  rw [← algebraMap_smul (pathAlgebra k Q) r x, asModuleAddEquiv_smul_pathAlgebra, AlgHom.commutes,
     Algebra.algebraMap_eq_smul_one, LinearMap.smul_apply, Module.End.one_apply]
-  -- what is left is the outer `TauCeti.QuiverRep.asModuleAddEquiv`, which is `AddEquiv.refl`
-  rfl
 
-/-- **The module carried by a representation is its direct sum of vertex spaces**, `k`-linearly. -/
+/-- **The module carried by a representation is its direct sum of vertex spaces**, `k`-linearly.
+This is the identification consumers should go through, the `k`-action on
+`TauCeti.QuiverRep.asModule` being only propositionally the direct sum's own. -/
 noncomputable def asModuleEquiv : asModule k Q M ≃ₗ[k] DirectSum Q (vertexSpace k Q M) :=
   { asModuleAddEquiv k Q M with map_smul' := asModuleAddEquiv_smul k Q M }
 
-/-- The `k`-linear identification with the underlying direct sum is the additive one. -/
-@[simp]
-theorem asModuleEquiv_apply (x : asModule k Q M) :
-    asModuleEquiv k Q M x = asModuleAddEquiv k Q M x := (rfl)
+/-- The defining action on `TauCeti.QuiverRep.asModule`: an element of the path algebra acts
+through `TauCeti.QuiverRep.toEnd`. -/
+theorem smul_asModule_def (f : pathAlgebra k Q) (x : asModule k Q M) :
+    f • x = toEnd k Q M f (asModuleEquiv k Q M x) := (rfl)
 
 /-- The inclusion of a vertex space into the module carried by a representation. -/
 noncomputable def ofVertex (v : Q) : vertexSpace k Q M v →ₗ[k] asModule k Q M :=
@@ -293,18 +301,18 @@ noncomputable def toVertex (v : Q) : asModule k Q M →ₗ[k] vertexSpace k Q M 
 
 /-- The inclusion of a vertex space is the inclusion of the corresponding summand. -/
 @[simp]
-theorem asModuleAddEquiv_ofVertex (v : Q) (z : vertexSpace k Q M v) :
-    asModuleAddEquiv k Q M (ofVertex k Q M v z)
+theorem asModuleEquiv_ofVertex (v : Q) (z : vertexSpace k Q M v) :
+    asModuleEquiv k Q M (ofVertex k Q M v z)
       = DirectSum.lof k Q (vertexSpace k Q M) v z := (rfl)
 
--- Not `@[simp]`: this is the counterpart of `TauCeti.QuiverRep.asModuleAddEquiv_ofVertex`, stated
+-- Not `@[simp]`: this is the counterpart of `TauCeti.QuiverRep.asModuleEquiv_ofVertex`, stated
 -- so that the projection can be computed, but rewriting with it would take
 -- `TauCeti.QuiverRep.toVertex` out of the simp-normal form that
 -- `TauCeti.QuiverRep.toVertex_ofVertex` and `TauCeti.QuiverRep.vertexIdempotent_smul` fix.
 /-- The projection onto a vertex space reads off the corresponding component. -/
 theorem toVertex_apply (v : Q) (x : asModule k Q M) :
     toVertex k Q M v x
-      = DirectSum.component k Q (vertexSpace k Q M) v (asModuleAddEquiv k Q M x) := (rfl)
+      = DirectSum.component k Q (vertexSpace k Q M) v (asModuleEquiv k Q M x) := (rfl)
 
 /-- The projection onto a vertex space undoes its inclusion. -/
 @[simp]
@@ -317,16 +325,16 @@ other one. -/
 @[simp]
 theorem toVertex_ofVertex_of_ne {u v : Q} (h : u ≠ v) (z : vertexSpace k Q M v) :
     toVertex k Q M u (ofVertex k Q M v z) = 0 := by
-  rw [toVertex_apply, asModuleAddEquiv_ofVertex, DirectSum.component.of k u v z]
+  rw [toVertex_apply, asModuleEquiv_ofVertex, DirectSum.component.of k u v z]
   exact dite_eq_right (Ne.symm h)
 
 /-- **The summands exhaust the module**: every element of `TauCeti.QuiverRep.asModule` is the sum
 of the images of its vertex components. -/
 theorem sum_ofVertex_toVertex [Fintype Q] (x : asModule k Q M) :
     ∑ v : Q, ofVertex k Q M v (toVertex k Q M v x) = x := by
-  apply (asModuleAddEquiv k Q M).injective
+  apply (asModuleEquiv k Q M).injective
   rw [map_sum]
-  simp only [asModuleAddEquiv_ofVertex, toVertex_apply, ← DirectSum.apply_eq_component,
+  simp only [asModuleEquiv_ofVertex, toVertex_apply, ← DirectSum.apply_eq_component,
     DirectSum.lof_eq_of]
   exact DirectSum.sum_univ_of _
 
@@ -344,9 +352,9 @@ component, applies the structure map, and puts the result in the component at it
 theorem smul_ofPath {a b : Q} (p : _root_.Quiver.Path a b) (x : asModule k Q M) :
     (ofPath ⟨a, b, p⟩ : pathAlgebra k Q) • x
       = ofVertex k Q M b (mapₗ k Q M p (toVertex k Q M a x)) := by
-  apply (asModuleAddEquiv k Q M).injective
-  rw [smul_asModule_def, toEnd_ofPath, pathEnd_mk_apply, asModuleAddEquiv_ofVertex, toVertex_apply]
-  -- what is left is the outer `TauCeti.QuiverRep.asModuleAddEquiv`, which is `AddEquiv.refl`
+  apply (asModuleEquiv k Q M).injective
+  rw [smul_asModule_def, toEnd_ofPath, pathEnd_mk_apply, asModuleEquiv_ofVertex, toVertex_apply]
+  -- what is left is the outer `TauCeti.QuiverRep.asModuleEquiv`, which is the identity map
   rfl
 
 /-- **A path acts on the image of its source through the structure map**: this is the naturality
@@ -400,6 +408,16 @@ theorem pathMap_vertexComponentEquiv {a b : Q} (p : _root_.Quiver.Path a b)
   apply Subtype.ext
   rw [coe_pathMap_apply, coe_vertexComponentEquiv, coe_vertexComponentEquiv, smul_ofVertex]
 
+/-- `TauCeti.QuiverRep.pathMap_vertexComponentEquiv` read backwards through the identification:
+this is the elementwise naturality square of the isomorphisms below, in the form in which the
+vertex component, rather than the vertex space, carries the element. -/
+private theorem vertexComponentEquiv_symm_pathMap {a b : Q} (p : _root_.Quiver.Path a b)
+    (y : vertexComponent k (asModule k Q M) a) :
+    (vertexComponentEquiv k Q M b).symm (pathMap k (asModule k Q M) p y)
+      = mapₗ k Q M p ((vertexComponentEquiv k Q M a).symm y) := by
+  rw [LinearEquiv.symm_apply_eq, ← pathMap_vertexComponentEquiv]
+  exact congrArg _ ((vertexComponentEquiv k Q M a).apply_symm_apply y).symm
+
 end Algebra
 
 section EssSurj
@@ -414,16 +432,11 @@ noncomputable def asModuleIso : quiverRepOfModule k Q (asModule k Q M) ≅ M :=
     (fun {a b} p => by
       change Q at a
       change Q at b
-      refine ModuleCat.hom_ext (LinearMap.ext fun x => ?_)
       -- both sides of the naturality square are `ModuleCat.ofHom` of a composite of a structure
-      -- map with a `LinearEquiv.toModuleIso`, and the bundling is definitional: no rewrite lemma
-      -- states the elementwise form, because `ModuleCat.hom_comp` and
-      -- `LinearEquiv.toModuleIso_symm_hom` fire only on the unapplied morphisms, leaving the
-      -- coercions to unfold anyway. `change` names the elementwise goal in one step.
-      change (vertexComponentEquiv k Q M b).symm (pathMap k (asModule k Q M) p x)
-        = mapₗ k Q M p ((vertexComponentEquiv k Q M a).symm x)
-      rw [LinearEquiv.symm_apply_eq, ← pathMap_vertexComponentEquiv]
-      exact congrArg _ ((vertexComponentEquiv k Q M a).apply_symm_apply x).symm)
+      -- map with a `LinearEquiv.toModuleIso`, and the bundling is definitional, so the square is
+      -- the elementwise `TauCeti.QuiverRep.vertexComponentEquiv_symm_pathMap`
+      exact ModuleCat.hom_ext
+        (LinearMap.ext fun x => vertexComponentEquiv_symm_pathMap k Q M p x))
 
 /-- **The dimension vector is unchanged** by passing to the module a representation carries and
 back. -/
@@ -433,25 +446,121 @@ theorem dimVector_asModule :
 
 end EssSurj
 
+section Shrink
+
+-- the two instances of `Mathlib.Algebra.Category.ModuleCat.Algebra` that give the underlying type
+-- of an object of `ModuleCat (pathAlgebra k Q)` its `k`-structure are scoped
+open scoped ModuleCat
+
+variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q] [Finite Q] [DecidableEq Q]
+variable (M : QuiverRep.{u, v, w, t} k Q)
+
+/-- **The module carried by a representation is no larger than the representation**: over a finite
+vertex set the direct sum `⨁ᵥ Mᵥ` is a finite product of the vertex spaces, so it has a model in
+their universe even though it is indexed by a vertex type that may live in a larger one. -/
+instance small_asModule : Small.{t} (asModule k Q M) := by
+  classical
+  have : Fintype Q := Fintype.ofFinite Q
+  have : Small.{t} Q := small_map (Finite.equivFin Q)
+  exact small_map (α := asModule k Q M) (DFinsupp.equivFunOnFintype (β := vertexSpace k Q M))
+
+/-- **The module carried by a representation, in the universe of the representation**: a model of
+`TauCeti.QuiverRep.asModule` in `Type t`, as an object of `ModuleCat (kQ)`.  It is bundled as an
+object rather than as a type so that its `k`-structure is the restriction of scalars that
+`ModuleCat.moduleOfAlgebraModule` puts on it, and not the one `Shrink` transports; that is the
+structure `TauCeti.quiverRepFunctor` reads it with. -/
+noncomputable def asModuleShrink : ModuleCat.{t} (pathAlgebra k Q) :=
+  ModuleCat.of (pathAlgebra k Q) (Shrink.{t} (asModule k Q M))
+
+/-- **The small model is the module carried by the representation**, `kQ`-linearly. -/
+noncomputable def asModuleShrinkEquiv :
+    (asModuleShrink k Q M : Type t) ≃ₗ[pathAlgebra k Q] asModule k Q M :=
+  Shrink.linearEquiv (pathAlgebra k Q) (asModule k Q M)
+
+/-- The vertex components of the small model are those of `TauCeti.QuiverRep.asModule`, the
+restriction of `TauCeti.QuiverRep.asModuleShrinkEquiv` to them. -/
+private noncomputable def vertexComponentShrinkEquiv (a : Q) :
+    vertexComponent k (asModuleShrink k Q M : Type t) a
+      ≃ₗ[k] vertexComponent k (asModule k Q M) a :=
+  LinearEquiv.ofLinearMap (vertexComponentMap k (asModuleShrinkEquiv k Q M).toLinearMap a)
+    (vertexComponentMap k (asModuleShrinkEquiv k Q M).symm.toLinearMap a)
+    (by
+      rw [← vertexComponentMap_comp]
+      simp only [LinearEquiv.comp_coe, LinearEquiv.symm_trans_self, LinearEquiv.refl_toLinearMap,
+        vertexComponentMap_id])
+    (by
+      rw [← vertexComponentMap_comp]
+      simp only [LinearEquiv.comp_coe, LinearEquiv.self_trans_symm, LinearEquiv.refl_toLinearMap,
+        vertexComponentMap_id])
+
+/-- The vertex space of the representation is the vertex component of the small model: this is
+`TauCeti.QuiverRep.vertexComponentEquiv` transported along
+`TauCeti.QuiverRep.asModuleShrinkEquiv`. -/
+private noncomputable def vertexShrinkEquiv (a : Q) :
+    vertexComponent k (asModuleShrink k Q M : Type t) a ≃ₗ[k] vertexSpace k Q M a :=
+  (vertexComponentShrinkEquiv k Q M a).trans (vertexComponentEquiv k Q M a).symm
+
+private theorem vertexShrinkEquiv_apply (a : Q)
+    (x : vertexComponent k (asModuleShrink k Q M : Type t) a) :
+    vertexShrinkEquiv k Q M a x
+      = (vertexComponentEquiv k Q M a).symm (vertexComponentShrinkEquiv k Q M a x) := (rfl)
+
+/-- The restriction of a `kQ`-linear map to the vertex components commutes with the action of a
+path, so the vertex components of the small model carry a path the same way. -/
+private theorem vertexComponentShrinkEquiv_pathMap {a b : Q} (p : _root_.Quiver.Path a b)
+    (x : vertexComponent k (asModuleShrink k Q M : Type t) a) :
+    vertexComponentShrinkEquiv k Q M b (pathMap k (asModuleShrink k Q M : Type t) p x)
+      = pathMap k (asModule k Q M) p (vertexComponentShrinkEquiv k Q M a x) :=
+  LinearMap.congr_fun
+    (vertexComponentMap_comp_pathMap k (asModuleShrinkEquiv k Q M).toLinearMap p) x
+
+/-- **The identification is natural in the path**, the naturality square of the isomorphism
+below. -/
+private theorem vertexShrinkEquiv_pathMap {a b : Q} (p : _root_.Quiver.Path a b)
+    (x : vertexComponent k (asModuleShrink k Q M : Type t) a) :
+    vertexShrinkEquiv k Q M b (pathMap k (asModuleShrink k Q M : Type t) p x)
+      = mapₗ k Q M p (vertexShrinkEquiv k Q M a x) := by
+  rw [vertexShrinkEquiv_apply, vertexShrinkEquiv_apply, vertexComponentShrinkEquiv_pathMap,
+    vertexComponentEquiv_symm_pathMap]
+
+/-- **Essential surjectivity in the universe of the representation**: the representation carried by
+the small model of the module carried by `M` is `M` again.  This is
+`TauCeti.QuiverRep.asModuleIso` transported along `TauCeti.QuiverRep.asModuleShrinkEquiv`, and it is
+what makes `TauCeti.quiverRepEquivalence` an equivalence at an arbitrary representation
+universe. -/
+noncomputable def asModuleShrinkIso :
+    quiverRepOfModule k Q (asModuleShrink k Q M : Type t) ≅ M :=
+  NatIso.ofComponents (fun a => (vertexShrinkEquiv k Q M a).toModuleIso)
+    (fun {a b} p => by
+      change Q at a
+      change Q at b
+      -- as for `TauCeti.QuiverRep.asModuleIso`, the bundling of both sides of the square is
+      -- definitional, so the square is the elementwise
+      -- `TauCeti.QuiverRep.vertexShrinkEquiv_pathMap`
+      exact ModuleCat.hom_ext (LinearMap.ext fun x => vertexShrinkEquiv_pathMap k Q M p x))
+
+end Shrink
+
 section Equivalence
 
 variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q] [Finite Q]
 
 /-- **The module-to-representation functor is essentially surjective**: every representation is
-carried by the `kQ`-module `TauCeti.QuiverRep.asModule` built from it. -/
-instance : (quiverRepFunctor.{u, v, w, max v t} k Q).EssSurj where
+carried by the `kQ`-module `TauCeti.QuiverRep.asModule` built from it, read in the universe of the
+representation through `TauCeti.QuiverRep.asModuleShrink`. -/
+instance : (quiverRepFunctor.{u, v, w, t} k Q).EssSurj where
   mem_essImage M := by
     classical
-    exact ⟨ModuleCat.of (pathAlgebra k Q) (asModule k Q M), ⟨asModuleIso k Q M⟩⟩
+    exact ⟨asModuleShrink k Q M, ⟨asModuleShrinkIso k Q M⟩⟩
 
 /-- **The module-to-representation functor is an equivalence**: it is fully faithful by
 `TauCeti.quiverRepFunctorFullyFaithful` and essentially surjective by the instance above. -/
-instance : (quiverRepFunctor.{u, v, w, max v t} k Q).IsEquivalence where
+instance : (quiverRepFunctor.{u, v, w, t} k Q).IsEquivalence where
 
 /-- **Representations of a quiver are modules over its path algebra.** -/
 noncomputable def _root_.TauCeti.quiverRepEquivalence :
-    QuiverRep.{u, v, w, max v t} k Q ≌ ModuleCat.{max v t} (pathAlgebra k Q) :=
-  (quiverRepFunctor.{u, v, w, max v t} k Q).asEquivalence.symm
+    QuiverRep.{u, v, w, t} k Q ≌ ModuleCat.{t} (pathAlgebra k Q) :=
+  (quiverRepFunctor.{u, v, w, t} k Q).asEquivalence.symm
 
 /-- The inverse of `TauCeti.quiverRepEquivalence` is `TauCeti.quiverRepFunctor`: the equivalence is
 the module-to-representation functor of
@@ -462,10 +571,12 @@ theorem _root_.TauCeti.quiverRepEquivalence_inverse :
 /-- **The forward direction of `TauCeti.quiverRepEquivalence` is
 `TauCeti.QuiverRep.asModule`.** The functor of the equivalence is `CategoryTheory.Functor.inv`, so
 on objects it is a choice of preimage; this identifies that choice with the module built here,
-which is what a consumer transporting a representation across the equivalence needs. -/
+which is what a consumer transporting a representation across the equivalence needs.  It is stated
+at the universe `max v t` where the direct sum `⨁ᵥ Mᵥ` lives; for a representation valued in a
+smaller universe the preimage is the model `TauCeti.QuiverRep.asModuleShrink` of that sum. -/
 noncomputable def _root_.TauCeti.quiverRepEquivalenceFunctorObjIso [DecidableEq Q]
     (M : QuiverRep.{u, v, w, max v t} k Q) :
-    (quiverRepEquivalence.{u, v, w, t} k Q).functor.obj M
+    (quiverRepEquivalence.{u, v, w, max v t} k Q).functor.obj M
       ≅ ModuleCat.of (pathAlgebra k Q) (asModule k Q M) :=
   (quiverRepFunctorFullyFaithful k Q).preimageIso
     ((quiverRepFunctor.{u, v, w, max v t} k Q).objObjPreimageIso M ≪≫ (asModuleIso k Q M).symm)

--- a/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
@@ -1,0 +1,473 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Representation.OfModule
+public import Mathlib.Algebra.DirectSum.Module
+
+/-!
+# The module over the path algebra carried by a representation of a quiver
+
+`TauCeti.RepresentationTheory.Quiver.Representation.OfModule` turns a left module over the path
+algebra `kQ` of a finite quiver into a representation of `Q`, and proves that functor **fully
+faithful**.  This file supplies the other half: the `kQ`-module `TauCeti.QuiverRep.asModule`
+carried by a representation, the identification of its vertex components with the vertex spaces of
+the representation one started from, and hence the **essential surjectivity** that completes the
+equivalence
+
+`TauCeti.quiverRepEquivalence : QuiverRep k Q ≌ ModuleCat (pathAlgebra k Q)`.
+
+## The construction
+
+The carrier is the direct sum `⨁ᵥ Mᵥ` of the vertex spaces.  A basis path `p : a ⟶ b` of `kQ` acts
+on it by the endomorphism `TauCeti.QuiverRep.pathEnd` that reads off the `a`-component, applies the
+structure map `M.map p`, and puts the result in the `b`-component; two such endomorphisms compose
+to the endomorphism of the concatenated path when the paths meet
+(`TauCeti.QuiverRep.pathEnd_mul`) and to zero when they do not
+(`TauCeti.QuiverRep.pathEnd_mul_eq_zero`), while the trivial paths give the component projections,
+which sum to the identity (`TauCeti.QuiverRep.sum_pathEnd_nil`).  Extending linearly along the path
+basis `TauCeti.pathAlgebraBasis` therefore gives an algebra homomorphism
+`TauCeti.QuiverRep.toEnd : kQ →ₐ[k] End_k (⨁ᵥ Mᵥ)`, and `TauCeti.QuiverRep.asModule` is `⨁ᵥ Mᵥ`
+with the module structure it induces.
+
+With that in hand the vertex idempotent `eᵥ` acts as the composite of the projection to `Mᵥ` and
+the inclusion back (`TauCeti.QuiverRep.vertexIdempotent_smul`), so the vertex component
+`eᵥ · asModule` is exactly the image of `Mᵥ` (`TauCeti.QuiverRep.vertexComponent_asModule`) and the
+inclusion is a `k`-linear isomorphism onto it.  Those isomorphisms are natural in the path, because
+a path acts on the image of `Mₐ` through `M.map p` (`TauCeti.QuiverRep.smul_ofVertex`), which is
+the natural isomorphism `TauCeti.QuiverRep.asModuleIso`.
+
+## Main definitions
+
+* `TauCeti.QuiverRep.vertexSpace`: the vector space a representation assigns to a vertex, as a bare
+  type indexed by the vertices, with `TauCeti.QuiverRep.mapₗ` the structure maps between those.
+* `TauCeti.QuiverRep.pathEnd`: the endomorphism of `⨁ᵥ Mᵥ` by which a basis path of `kQ` acts.
+* `TauCeti.QuiverRep.toEndₗ` and `TauCeti.QuiverRep.toEnd`: that action extended along the path
+  basis, first linearly and then as a `k`-algebra homomorphism into `End_k (⨁ᵥ Mᵥ)`.
+* `TauCeti.QuiverRep.asModule`: **the `kQ`-module carried by a representation of `Q`**, the direct
+  sum `⨁ᵥ Mᵥ` with the action of `TauCeti.QuiverRep.toEnd`.
+* `TauCeti.QuiverRep.ofVertex` and `TauCeti.QuiverRep.toVertex`: the inclusion of a vertex space
+  into that module and the projection onto it.
+* `TauCeti.quiverRepEquivalence`: **representations of a quiver are modules over its path
+  algebra.**
+
+## Main results
+
+* `TauCeti.QuiverRep.vertexIdempotent_smul`: the vertex idempotent `eᵥ` acts on `asModule` as the
+  projection onto the summand `Mᵥ`, whence `TauCeti.QuiverRep.vertexComponent_asModule`: the vertex
+  component of `asModule` at `v` is the image of `Mᵥ`.
+* `TauCeti.QuiverRep.vertexComponentEquiv`: the vertex space `Mᵥ` is that vertex component, and
+  `TauCeti.QuiverRep.pathMap_vertexComponentEquiv`: the identification is natural in the path.
+* `TauCeti.QuiverRep.asModuleIso`: **the representation carried by `asModule M` is `M`**, so
+  `TauCeti.quiverRepFunctor` is essentially surjective, and being fully faithful already it is an
+  equivalence.  `TauCeti.QuiverRep.dimVector_asModule` records that the dimension vector is
+  unchanged.
+
+## Implementation notes
+
+The vertex spaces are named as a family `TauCeti.QuiverRep.vertexSpace` rather than used as
+`M.obj v` directly.  A representation is a functor out of `CategoryTheory.Paths Q`, whose objects
+are vertices only after unfolding the semireducible `CategoryTheory.Paths`; instance search does
+not see through that when it is asked for the *family* `∀ v : Q, AddCommMonoid (M.obj v)` that a
+direct sum indexed by the vertices needs, although it succeeds at each individual vertex.  Naming
+the family and giving it its two instances by `inferInstanceAs` is what makes `DirectSum Q` usable
+here at all.  For the same reason the naturality square of `TauCeti.QuiverRep.asModuleIso` opens
+with `change Q at a`, restating its quantified objects as vertices.
+
+The `k`-module structure on `TauCeti.QuiverRep.asModule` is deliberately **not** the one the direct
+sum already carries: it is `Module.restrictScalars k (pathAlgebra k Q)`, restriction of scalars
+along `algebraMap`.  That is exactly the structure `ModuleCat.moduleOfAlgebraModule` puts on an
+object of `ModuleCat (kQ)`, which is the one `TauCeti.quiverRepFunctor` uses; taking the direct
+sum's own structure instead would give a second, only propositionally equal, `Module k` instance
+and the essential-surjectivity isomorphism would not typecheck against the functor.  The two agree
+by `TauCeti.QuiverRep.smul_asModule_k`, which is what upgrades the underlying additive equivalence
+`TauCeti.QuiverRep.asModuleEquiv` to the `k`-linear `TauCeti.QuiverRep.asModuleLinearEquiv`.
+
+`DecidableEq Q` is needed to write down the summand inclusions `DirectSum.lof`, so it is carried
+through the construction; the essential-surjectivity instance is a `Prop` and discharges it with
+`classical`, so neither it nor `TauCeti.quiverRepEquivalence` asks for it.
+
+The universes are the reason the equivalence is stated for representations valued in
+`ModuleCat.{max v t} k` for a vertex type in `Type v`: the direct sum of a `Type v`-indexed family
+of `Type t`-modules lands in `Type (max v t)`, so a representation is carried by a module in that
+universe and no smaller one.  For the usual case of a vertex type and vector spaces in the same
+universe this is no restriction.
+
+## References
+
+This is the essential-surjectivity half of `quiverRepEquivalence`, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, which asks for the
+equivalence "sending a module `M` to the representation `v ↦ eᵥ M`, with an arrow acting by left
+multiplication, and inverting through the idempotent decomposition `M = ⨁ᵥ eᵥ M`"; the fully
+faithful half is `TauCeti.quiverRepFunctorFullyFaithful`.
+
+See I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+Algebras, Vol. 1*, Ch. III, or R. Schiffler, *Quiver Representations*, Ch. 5.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory PathAlgebra
+
+universe u v w t
+
+namespace QuiverRep
+
+section Vertex
+
+variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q]
+variable (M : QuiverRep.{u, v, w, t} k Q)
+
+/-- The vertex space, as a bare type indexed by the vertices. -/
+@[expose]
+def vertexSpace (v : Q) : Type t := M.obj v
+
+instance instAddCommGroupVertexSpace (v : Q) : AddCommGroup (vertexSpace k Q M v) :=
+  inferInstanceAs (AddCommGroup (M.obj v))
+
+instance instModuleVertexSpace (v : Q) : Module k (vertexSpace k Q M v) :=
+  inferInstanceAs (Module k (M.obj v))
+
+/-- The structure map of a representation along a path, retyped between vertex spaces. -/
+noncomputable def mapₗ {a b : Q} (p : _root_.Quiver.Path a b) :
+    vertexSpace k Q M a →ₗ[k] vertexSpace k Q M b := (M.map p).hom
+
+/-- The retyped structure map is the structure map. -/
+theorem mapₗ_apply {a b : Q} (p : _root_.Quiver.Path a b) (z : vertexSpace k Q M a) :
+    mapₗ k Q M p z = (M.map p) z := (rfl)
+
+/-- **The trivial path acts as the identity**, the element-level
+`TauCeti.QuiverRep.map_nil_apply` read as an equation of linear maps. -/
+theorem mapₗ_nil (a : Q) : mapₗ k Q M (_root_.Quiver.Path.nil : _root_.Quiver.Path a a)
+    = LinearMap.id := by
+  refine LinearMap.ext fun z => ?_
+  rw [mapₗ_apply, LinearMap.id_apply]
+  exact QuiverRep.map_nil_apply M a z
+
+/-- **Concatenation of paths composes the structure maps**, the functoriality of a representation
+read on the retyped maps. -/
+theorem mapₗ_comp {a b c : Q} (p : _root_.Quiver.Path a b) (q : _root_.Quiver.Path b c) :
+    mapₗ k Q M (p.comp q) = (mapₗ k Q M q).comp (mapₗ k Q M p) := by
+  refine LinearMap.ext fun z => ?_
+  have h : M.map (p.comp q) = M.map p ≫ M.map q := M.map_comp p q
+  rw [mapₗ_apply, h]
+  rfl
+
+end Vertex
+
+section Basic
+
+variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q] [DecidableEq Q]
+variable (M : QuiverRep.{u, v, w, t} k Q)
+
+/-- The endomorphism of `⨁ᵥ Mᵥ` by which a path acts. -/
+noncomputable def pathEnd (x : Quiver.TotalPath Q) :
+    Module.End k (DirectSum Q (vertexSpace k Q M)) :=
+  (DirectSum.lof k Q (vertexSpace k Q M) x.2.1).comp
+    ((mapₗ k Q M x.2.2).comp (DirectSum.component k Q (vertexSpace k Q M) x.1))
+
+/-- The endomorphism of a path reads off the component at its source, applies the structure map,
+and puts the result in the component at its target. -/
+theorem pathEnd_apply (x : Quiver.TotalPath Q) (z : DirectSum Q (vertexSpace k Q M)) :
+    pathEnd k Q M x z = DirectSum.lof k Q (vertexSpace k Q M) x.2.1
+      (mapₗ k Q M x.2.2 (DirectSum.component k Q (vertexSpace k Q M) x.1 z)) := (rfl)
+
+/-- `TauCeti.QuiverRep.pathEnd_apply` on a path given by its source, target and underlying path,
+the form in which the endpoints are available for rewriting. -/
+theorem pathEnd_mk_apply {a b : Q} (p : _root_.Quiver.Path a b)
+    (z : DirectSum Q (vertexSpace k Q M)) :
+    pathEnd k Q M ⟨a, b, p⟩ z = DirectSum.lof k Q (vertexSpace k Q M) b
+      (mapₗ k Q M p (DirectSum.component k Q (vertexSpace k Q M) a z)) := (rfl)
+
+/-- **Composable paths compose**: the endomorphisms of two paths that meet multiply to the
+endomorphism of their concatenation, later factor first, as the path algebra multiplies them. -/
+theorem pathEnd_mul {a b c : Q} (p : _root_.Quiver.Path a b) (q : _root_.Quiver.Path c a) :
+    pathEnd k Q M ⟨a, b, p⟩ * pathEnd k Q M ⟨c, a, q⟩ = pathEnd k Q M ⟨c, b, q.comp p⟩ := by
+  refine LinearMap.ext fun z => ?_
+  rw [Module.End.mul_apply, pathEnd_mk_apply, pathEnd_mk_apply, pathEnd_mk_apply,
+    mapₗ_comp k Q M q p]
+  exact congrArg _ (congrArg _ (DirectSum.component.lof_self k a _))
+
+/-- The projection onto a summand kills every other summand. -/
+theorem component_lof_of_ne {i j : Q} (hij : j ≠ i) (b : vertexSpace k Q M j) :
+    DirectSum.component k Q (vertexSpace k Q M) i
+      (DirectSum.lof k Q (vertexSpace k Q M) j b) = 0 :=
+  (DirectSum.component.of k i j b).trans (dite_eq_right hij)
+
+/-- **Paths that do not meet annihilate one another**, because the second lands in a summand the
+first reads as zero. This is the other half of the multiplicativity of
+`TauCeti.QuiverRep.toEnd`. -/
+theorem pathEnd_mul_eq_zero {x y : Quiver.TotalPath Q} (h : y.2.1 ≠ x.1) :
+    pathEnd k Q M x * pathEnd k Q M y = 0 := by
+  refine LinearMap.ext fun z => ?_
+  have key : DirectSum.component k Q (vertexSpace k Q M) x.1 (pathEnd k Q M y z) = 0 := by
+    rw [pathEnd_apply]
+    exact component_lof_of_ne k Q M h _
+  rw [Module.End.mul_apply, pathEnd_apply, key, map_zero, map_zero, LinearMap.zero_apply]
+
+/-- **The trivial paths give the summand projections**, and those sum to the identity: this is what
+makes `TauCeti.QuiverRep.toEnd` unital, the unit of the path algebra being the sum of the vertex
+idempotents. -/
+theorem sum_pathEnd_nil [Fintype Q] :
+    ∑ v : Q, pathEnd k Q M ⟨v, v, _root_.Quiver.Path.nil⟩ = 1 := by
+  refine LinearMap.ext fun z => ?_
+  rw [LinearMap.sum_apply]
+  simp only [pathEnd_apply, mapₗ_nil, LinearMap.id_coe, id_eq,
+    ← DirectSum.apply_eq_component, Module.End.one_apply, DirectSum.lof_eq_of]
+  exact DirectSum.sum_univ_of z
+
+/-- The action of the path algebra on `⨁ᵥ Mᵥ`, as a linear map. -/
+noncomputable def toEndₗ :
+    pathAlgebra k Q →ₗ[k] Module.End k (DirectSum Q (vertexSpace k Q M)) :=
+  (pathAlgebraBasis k Q).constr k (pathEnd k Q M)
+
+/-- The action of a basis path is the endomorphism it was assigned. -/
+theorem toEndₗ_ofPath (x : Quiver.TotalPath Q) :
+    toEndₗ k Q M (ofPath x) = pathEnd k Q M x := by
+  have h := (pathAlgebraBasis k Q).constr_basis k (pathEnd k Q M) x
+  rwa [coe_pathAlgebraBasis] at h
+
+/-- The action of a scaled basis path scales its endomorphism. -/
+theorem toEndₗ_single (x : Quiver.TotalPath Q) (c : k) :
+    toEndₗ k Q M (single x c) = c • pathEnd k Q M x := by
+  rw [show (single x c : pathAlgebra k Q) = c • ofPath x by
+    rw [ofPath_eq_single, smul_single, mul_one], map_smul, toEndₗ_ofPath]
+
+/-- The action of a vertex idempotent is the endomorphism of the trivial path there, which by
+`TauCeti.QuiverRep.mapₗ_nil` is the projection onto that summand. -/
+theorem toEndₗ_vertexIdempotent (v : Q) :
+    toEndₗ k Q M (vertexIdempotent k v) = pathEnd k Q M ⟨v, v, _root_.Quiver.Path.nil⟩ := by
+  rw [vertexIdempotent_eq_single, toEndₗ_single, one_smul]
+
+/-- **The action is multiplicative**, by `TauCeti.QuiverRep.pathEnd_mul` on composable basis paths
+and `TauCeti.QuiverRep.pathEnd_mul_eq_zero` on the rest. -/
+theorem toEndₗ_mul (f g : pathAlgebra k Q) :
+    toEndₗ k Q M (f * g) = toEndₗ k Q M f * toEndₗ k Q M g := by
+  induction f using PathAlgebra.induction_linear with
+  | zero => simp
+  | add f₁ f₂ h₁ h₂ => rw [add_mul, map_add, map_add, h₁, h₂, add_mul]
+  | single x c =>
+    induction g using PathAlgebra.induction_linear with
+    | zero => simp
+    | add g₁ g₂ h₁ h₂ => rw [mul_add, map_add, map_add, h₁, h₂, mul_add]
+    | single y d =>
+      obtain ⟨a, b, p⟩ := x
+      obtain ⟨c', a', q⟩ := y
+      by_cases hy : a' = a
+      · subst hy
+        rw [single_mul_single_of_comp, toEndₗ_single, toEndₗ_single, toEndₗ_single,
+          smul_mul_smul_comm, pathEnd_mul]
+      · rw [single_mul_single_of_not_composable hy, map_zero, toEndₗ_single, toEndₗ_single,
+          smul_mul_smul_comm, pathEnd_mul_eq_zero k Q M hy, smul_zero]
+
+end Basic
+
+section Algebra
+
+variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q] [Finite Q] [DecidableEq Q]
+variable (M : QuiverRep.{u, v, w, t} k Q)
+
+/-- **The action is unital**: the unit of the path algebra is the sum of the vertex idempotents,
+whose endomorphisms are the summand projections. -/
+theorem toEndₗ_one : toEndₗ k Q M 1 = 1 := by
+  let _ := Fintype.ofFinite Q
+  rw [one_def, map_sum]
+  simp only [toEndₗ_vertexIdempotent]
+  exact sum_pathEnd_nil k Q M
+
+/-- The action of the path algebra on `⨁ᵥ Mᵥ`, as an algebra map. -/
+noncomputable def toEnd : pathAlgebra k Q →ₐ[k] Module.End k (DirectSum Q (vertexSpace k Q M)) :=
+  AlgHom.mk'
+    { toFun := toEndₗ k Q M
+      map_one' := toEndₗ_one k Q M
+      map_mul' := toEndₗ_mul k Q M
+      map_zero' := map_zero _
+      map_add' := fun f g => map_add _ f g }
+    fun c x => (toEndₗ k Q M).map_smul c x
+
+/-- The algebra map acts by the linear map it was built from. -/
+theorem toEnd_apply (f : pathAlgebra k Q) : toEnd k Q M f = toEndₗ k Q M f := (rfl)
+
+/-- The module over the path algebra carried by a representation of `Q`. -/
+@[expose]
+def asModule : Type max v t := DirectSum Q (vertexSpace k Q M)
+
+instance : AddCommGroup (asModule k Q M) :=
+  inferInstanceAs (AddCommGroup (DirectSum Q (vertexSpace k Q M)))
+
+noncomputable instance : Module (pathAlgebra k Q) (asModule k Q M) :=
+  Module.compHom (DirectSum Q (vertexSpace k Q M)) (toEnd k Q M).toRingHom
+
+noncomputable instance : Module k (asModule k Q M) :=
+  Module.restrictScalars k (pathAlgebra k Q) (asModule k Q M)
+
+/-- The `k`-action on `TauCeti.QuiverRep.asModule` is the restriction of the `kQ`-action, so the
+two are compatible by construction. -/
+instance : IsScalarTower k (pathAlgebra k Q) (asModule k Q M) :=
+  IsScalarTower.restrictScalars k (pathAlgebra k Q) (asModule k Q M)
+
+/-- The underlying direct sum of an element. -/
+@[expose]
+def asModuleEquiv : asModule k Q M ≃+ DirectSum Q (vertexSpace k Q M) := AddEquiv.refl _
+
+/-- The defining action on `TauCeti.QuiverRep.asModule`: an element of the path algebra acts
+through `TauCeti.QuiverRep.toEnd`. -/
+theorem smul_asModule_def (f : pathAlgebra k Q) (x : asModule k Q M) :
+    f • x = toEnd k Q M f (asModuleEquiv k Q M x) := (rfl)
+
+/-- **The two `k`-actions agree**: the restriction of scalars along `algebraMap k (kQ)` that
+`TauCeti.QuiverRep.asModule` carries is the direct sum's own `k`-action, because
+`TauCeti.QuiverRep.toEnd` is a `k`-algebra map. This is what makes
+`TauCeti.QuiverRep.asModuleLinearEquiv` `k`-linear. -/
+theorem smul_asModule_k (r : k) (x : asModule k Q M) :
+    asModuleEquiv k Q M (r • x) = r • asModuleEquiv k Q M x := by
+  change asModuleEquiv k Q M ((algebraMap k (pathAlgebra k Q) r) • x) = _
+  rw [smul_asModule_def, AlgHom.commutes, Algebra.algebraMap_eq_smul_one]
+  rfl
+
+/-- The underlying direct sum of the module carried by a representation, `k`-linearly. -/
+noncomputable def asModuleLinearEquiv :
+    asModule k Q M ≃ₗ[k] DirectSum Q (vertexSpace k Q M) :=
+  { asModuleEquiv k Q M with map_smul' := smul_asModule_k k Q M }
+
+/-- The `k`-linear identification with the underlying direct sum is the additive one. -/
+theorem asModuleLinearEquiv_apply (x : asModule k Q M) :
+    asModuleLinearEquiv k Q M x = asModuleEquiv k Q M x := (rfl)
+
+/-- The inclusion of a vertex space into the module carried by a representation. -/
+noncomputable def ofVertex (v : Q) : vertexSpace k Q M v →ₗ[k] asModule k Q M :=
+  (asModuleLinearEquiv k Q M).symm.toLinearMap.comp (DirectSum.lof k Q (vertexSpace k Q M) v)
+
+/-- The projection of the module carried by a representation onto a vertex space. -/
+noncomputable def toVertex (v : Q) : asModule k Q M →ₗ[k] vertexSpace k Q M v :=
+  (DirectSum.component k Q (vertexSpace k Q M) v).comp
+    (asModuleLinearEquiv k Q M).toLinearMap
+
+/-- The inclusion of a vertex space is the inclusion of the corresponding summand. -/
+theorem asModuleEquiv_ofVertex (v : Q) (z : vertexSpace k Q M v) :
+    asModuleEquiv k Q M (ofVertex k Q M v z) = DirectSum.lof k Q (vertexSpace k Q M) v z := (rfl)
+
+/-- The projection onto a vertex space undoes its inclusion. -/
+theorem toVertex_ofVertex (v : Q) (z : vertexSpace k Q M v) :
+    toVertex k Q M v (ofVertex k Q M v z) = z :=
+  DirectSum.component.lof_self k v z
+
+/-- The inclusion of a vertex space is injective. -/
+theorem ofVertex_injective (v : Q) : Function.Injective (ofVertex k Q M v) :=
+  Function.LeftInverse.injective (toVertex_ofVertex k Q M v)
+
+/-- **A path acts on the image of its source through the structure map**: this is the naturality
+that makes `TauCeti.QuiverRep.asModuleIso` a morphism of representations. -/
+theorem smul_ofVertex {a b : Q} (p : _root_.Quiver.Path a b) (z : vertexSpace k Q M a) :
+    (ofPath ⟨a, b, p⟩ : pathAlgebra k Q) • ofVertex k Q M a z
+      = ofVertex k Q M b (mapₗ k Q M p z) := by
+  apply (asModuleEquiv k Q M).injective
+  rw [smul_asModule_def, toEnd_apply, toEndₗ_ofPath, pathEnd_mk_apply, asModuleEquiv_ofVertex,
+    asModuleEquiv_ofVertex]
+  exact congrArg (fun y => DirectSum.lof k Q (vertexSpace k Q M) b (mapₗ k Q M p y))
+    (DirectSum.component.lof_self k a z)
+
+/-- **The vertex idempotent acts as the projection onto its summand**, the fact from which the
+vertex component of `TauCeti.QuiverRep.asModule` is read off. -/
+theorem vertexIdempotent_smul (v : Q) (x : asModule k Q M) :
+    (vertexIdempotent k v : pathAlgebra k Q) • x = ofVertex k Q M v (toVertex k Q M v x) := by
+  apply (asModuleEquiv k Q M).injective
+  rw [smul_asModule_def, toEnd_apply, toEndₗ_vertexIdempotent, pathEnd_mk_apply,
+    asModuleEquiv_ofVertex, mapₗ_nil]
+  rfl
+
+/-- **The vertex component is the image of the vertex space**: the piece of
+`TauCeti.QuiverRep.asModule` that the vertex idempotent fixes is the summand `Mᵥ`. -/
+theorem vertexComponent_asModule (v : Q) :
+    vertexComponent k (asModule k Q M) v = LinearMap.range (ofVertex k Q M v) := by
+  ext x
+  rw [mem_vertexComponent_iff_smul_eq_self, vertexIdempotent_smul, LinearMap.mem_range]
+  constructor
+  · exact fun h => ⟨toVertex k Q M v x, h⟩
+  · rintro ⟨z, rfl⟩
+    rw [toVertex_ofVertex]
+
+/-- The vertex space of a representation is the vertex component of the module it carries. -/
+noncomputable def vertexComponentEquiv (v : Q) :
+    vertexSpace k Q M v ≃ₗ[k] vertexComponent k (asModule k Q M) v :=
+  (LinearEquiv.ofInjective _ (ofVertex_injective k Q M v)).trans
+    (LinearEquiv.ofEq _ _ (vertexComponent_asModule k Q M v).symm)
+
+/-- The identification of a vertex space with a vertex component is the inclusion of the
+summand. -/
+theorem coe_vertexComponentEquiv (v : Q) (z : vertexSpace k Q M v) :
+    (vertexComponentEquiv k Q M v z : asModule k Q M) = ofVertex k Q M v z := (rfl)
+
+/-- **The identification is natural in the path**: the action of a path on the vertex components of
+`TauCeti.QuiverRep.asModule` is the structure map of the representation. -/
+theorem pathMap_vertexComponentEquiv {a b : Q} (p : _root_.Quiver.Path a b)
+    (z : vertexSpace k Q M a) :
+    pathMap k (asModule k Q M) p (vertexComponentEquiv k Q M a z)
+      = vertexComponentEquiv k Q M b (mapₗ k Q M p z) := by
+  apply Subtype.ext
+  rw [coe_pathMap_apply, coe_vertexComponentEquiv, coe_vertexComponentEquiv, smul_ofVertex]
+
+end Algebra
+
+section EssSurj
+
+variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q] [Finite Q] [DecidableEq Q]
+variable (M : QuiverRep.{u, v, w, max v t} k Q)
+
+/-- **Essential surjectivity, as an isomorphism**: the representation carried by the module
+carried by `M` is `M` again. -/
+noncomputable def asModuleIso : quiverRepOfModule k Q (asModule k Q M) ≅ M :=
+  NatIso.ofComponents (fun a => (vertexComponentEquiv k Q M a).toModuleIso.symm)
+    (fun {a b} p => by
+      change Q at a
+      change Q at b
+      refine ModuleCat.hom_ext (LinearMap.ext fun x => ?_)
+      change (vertexComponentEquiv k Q M b).symm (pathMap k (asModule k Q M) p x)
+        = mapₗ k Q M p ((vertexComponentEquiv k Q M a).symm x)
+      rw [LinearEquiv.symm_apply_eq, ← pathMap_vertexComponentEquiv]
+      exact congrArg _ ((vertexComponentEquiv k Q M a).apply_symm_apply x).symm)
+
+/-- **The dimension vector is unchanged** by passing to the module a representation carries and
+back. -/
+theorem dimVector_asModule :
+    dimVector (quiverRepOfModule k Q (asModule k Q M)) = dimVector M :=
+  dimVector_eq_of_iso (asModuleIso k Q M)
+
+end EssSurj
+
+section Equivalence
+
+variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q] [Finite Q]
+
+/-- **The module-to-representation functor is essentially surjective**: every representation is
+carried by the `kQ`-module `TauCeti.QuiverRep.asModule` built from it. -/
+instance : (quiverRepFunctor.{u, v, w, max v t} k Q).EssSurj where
+  mem_essImage M := by
+    classical
+    exact ⟨ModuleCat.of (pathAlgebra k Q) (asModule k Q M), ⟨asModuleIso k Q M⟩⟩
+
+/-- **The module-to-representation functor is an equivalence**: it is fully faithful by
+`TauCeti.quiverRepFunctorFullyFaithful` and essentially surjective by the instance above. -/
+instance : (quiverRepFunctor.{u, v, w, max v t} k Q).IsEquivalence where
+
+/-- **Representations of a quiver are modules over its path algebra.** -/
+noncomputable def _root_.TauCeti.quiverRepEquivalence :
+    QuiverRep.{u, v, w, max v t} k Q ≌ ModuleCat.{max v t} (pathAlgebra k Q) :=
+  (quiverRepFunctor.{u, v, w, max v t} k Q).asEquivalence.symm
+
+/-- The inverse of `TauCeti.quiverRepEquivalence` is `TauCeti.quiverRepFunctor`: the equivalence is
+the module-to-representation functor of
+`TauCeti.RepresentationTheory.Quiver.Representation.OfModule`, turned around. -/
+theorem _root_.TauCeti.quiverRepEquivalence_inverse :
+    (quiverRepEquivalence.{u, v, w, t} k Q).inverse = quiverRepFunctor k Q := (rfl)
+
+end Equivalence
+
+end QuiverRep
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
@@ -211,7 +211,8 @@ variable (M : QuiverRep.{u, v, w, t} k Q)
 the two composition laws and the completeness of the summand projections proved above. -/
 noncomputable def toEnd : pathAlgebra k Q →ₐ[k] Module.End k (DirectSum Q (vertexSpace k Q M)) :=
   PathAlgebra.liftAlgHom k (pathEnd k Q M) (pathEnd_mul_pathEnd_of_comp k Q M)
-    (pathEnd_mul_pathEnd_of_not_composable k Q M) (by intro _; exact sum_pathEnd_nil k Q M)
+    (pathEnd_mul_pathEnd_of_not_composable k Q M)
+    (letI := Fintype.ofFinite Q; sum_pathEnd_nil k Q M)
 
 /-- The action of a basis path is the endomorphism it was assigned. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/AsModule.lean
@@ -60,8 +60,10 @@ that isomorphism becomes `TauCeti.QuiverRep.asModuleShrinkIso`, the essential su
 * `TauCeti.QuiverRep.asModuleShrink`: the model of that module in the universe of the
   representation, `TauCeti.QuiverRep.asModuleShrinkEquiv` identifying the two.
 * `TauCeti.quiverRepEquivalence`: **representations of a quiver are modules over its path
-  algebra**, with `TauCeti.quiverRepEquivalenceFunctorObjIso` identifying the module it sends a
-  representation to with `TauCeti.QuiverRep.asModule`.
+  algebra**, with `TauCeti.quiverRepEquivalenceFunctorObjShrinkIso` identifying the module it sends
+  a representation to with `TauCeti.QuiverRep.asModuleShrink`, and
+  `TauCeti.quiverRepEquivalenceFunctorObjIso` identifying it with `TauCeti.QuiverRep.asModule`
+  itself in the universe where the direct sum lives.
 
 ## Main results
 
@@ -111,8 +113,10 @@ nevertheless stated at an arbitrary representation universe `t`, because over a 
 that direct sum is a finite product of the vertex spaces and so has a model in `Type t`
 (`TauCeti.QuiverRep.small_asModule`); the model `TauCeti.QuiverRep.asModuleShrink` of it, whose
 vertex components are those of `asModule` because `TauCeti.QuiverRep.asModuleShrinkEquiv` is
-`kQ`-linear, is what witnesses essential surjectivity there.  The concrete direct-sum API is kept
-at `max v t`, and `TauCeti.quiverRepEquivalenceFunctorObjIso` identifies the forward direction with
+`kQ`-linear, is what witnesses essential surjectivity there; `TauCeti.quiverRepEquivalence`'s
+forward direction is identified with that model by
+`TauCeti.quiverRepEquivalenceFunctorObjShrinkIso`.  The concrete direct-sum API is kept at
+`max v t`, and `TauCeti.quiverRepEquivalenceFunctorObjIso` identifies the forward direction with
 `asModule` itself at that universe.
 
 ## References
@@ -570,11 +574,23 @@ theorem _root_.TauCeti.quiverRepEquivalence_inverse :
     (quiverRepEquivalence.{u, v, w, t} k Q).inverse = quiverRepFunctor k Q := (rfl)
 
 /-- **The forward direction of `TauCeti.quiverRepEquivalence` is
-`TauCeti.QuiverRep.asModule`.** The functor of the equivalence is `CategoryTheory.Functor.inv`, so
-on objects it is a choice of preimage; this identifies that choice with the module built here,
-which is what a consumer transporting a representation across the equivalence needs.  It is stated
-at the universe `max v t` where the direct sum `⨁ᵥ Mᵥ` lives; for a representation valued in a
-smaller universe the preimage is the model `TauCeti.QuiverRep.asModuleShrink` of that sum. -/
+`TauCeti.QuiverRep.asModuleShrink`.** The functor of the equivalence is
+`CategoryTheory.Functor.inv`, so on objects it is a choice of preimage; this identifies that choice
+with the model of `TauCeti.QuiverRep.asModule` built here, at the arbitrary representation universe
+`t` the equivalence is stated at, which is what a consumer transporting a representation across it
+needs.  For a representation valued in the universe `max v t` where the direct sum `⨁ᵥ Mᵥ` itself
+lives, `TauCeti.quiverRepEquivalenceFunctorObjIso` identifies the preimage with that sum
+directly. -/
+noncomputable def _root_.TauCeti.quiverRepEquivalenceFunctorObjShrinkIso [DecidableEq Q]
+    (M : QuiverRep.{u, v, w, t} k Q) :
+    (quiverRepEquivalence.{u, v, w, t} k Q).functor.obj M ≅ asModuleShrink k Q M :=
+  (quiverRepFunctorFullyFaithful k Q).preimageIso
+    ((quiverRepFunctor.{u, v, w, t} k Q).objObjPreimageIso M ≪≫ (asModuleShrinkIso k Q M).symm)
+
+/-- **The forward direction of `TauCeti.quiverRepEquivalence` is
+`TauCeti.QuiverRep.asModule`**, at the universe `max v t` where the direct sum `⨁ᵥ Mᵥ` lives: the
+concrete form of `TauCeti.quiverRepEquivalenceFunctorObjShrinkIso`, identifying the chosen preimage
+with the direct sum itself rather than with a model of it. -/
 noncomputable def _root_.TauCeti.quiverRepEquivalenceFunctorObjIso [DecidableEq Q]
     (M : QuiverRep.{u, v, w, max v t} k Q) :
     (quiverRepEquivalence.{u, v, w, max v t} k Q).functor.obj M

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
@@ -16,9 +16,21 @@ to every arrow, compatibly with path composition. This is precisely a functor fr
 path category to its category of modules.
 
 This file introduces the standard abbreviation, and the one structural fact that the trivial path
-acts as the identity. The equivalence with modules over the path algebra is
-`TauCeti.quiverRepEquivalence`, built in
+acts as the identity. It also names the vertex spaces of a representation as a family
+`TauCeti.QuiverRep.vertexSpace` indexed by the vertices, with `TauCeti.QuiverRep.mapₗ` the
+structure maps between them; that is what a construction indexed by the vertices — a direct sum, a
+product — needs, since instance search does not see the objects of `CategoryTheory.Paths Q` as
+vertices when it is asked for a *family* of instances over `Q` (see the implementation notes). The
+equivalence with modules over the path algebra is `TauCeti.quiverRepEquivalence`, built in
 `TauCeti.RepresentationTheory.Quiver.Representation.AsModule`.
+
+## Implementation notes
+
+A representation is a functor out of `CategoryTheory.Paths Q`, whose objects are vertices only
+after unfolding the semireducible `CategoryTheory.Paths`. Instance search does not see through
+that when it is asked for the *family* `∀ v : Q, AddCommMonoid (M.obj v)`, although it succeeds at
+each individual vertex; naming the family as `TauCeti.QuiverRep.vertexSpace` and giving it its two
+instances by `inferInstanceAs` is what makes such a family usable.
 
 ## References
 
@@ -32,7 +44,7 @@ namespace TauCeti
 
 open CategoryTheory
 
-universe u v w
+universe u v w t
 
 /-- The category of representations of a quiver `Q` over a field `k`. -/
 abbrev QuiverRep (k : Type u) (Q : Type v) [Field k] [Quiver Q] :=
@@ -64,5 +76,61 @@ theorem QuiverRep.map_nil_apply {k : Type u} {Q : Type v} [Field k] [Quiver.{w} 
     M.map (Quiver.Path.nil : Quiver.Path a a) x = x := by
   rw [QuiverRep.map_nil]
   rfl
+
+namespace QuiverRep
+
+section Vertex
+
+variable (k : Type u) (Q : Type v) [Field k] [Quiver.{w} Q]
+variable (M : QuiverRep.{u, v, w, t} k Q)
+
+/-- The vertex space, as a bare type indexed by the vertices. -/
+@[expose]
+def vertexSpace (v : Q) : Type t := M.obj v
+
+instance instAddCommGroupVertexSpace (v : Q) : AddCommGroup (vertexSpace k Q M v) :=
+  inferInstanceAs (AddCommGroup (M.obj v))
+
+instance instModuleVertexSpace (v : Q) : Module k (vertexSpace k Q M v) :=
+  inferInstanceAs (Module k (M.obj v))
+
+/-- The structure map of a representation along a path, retyped between vertex spaces.
+
+`@[expose]` is load-bearing rather than a leak: a goal about a vertex-indexed construction that has
+been unfolded to the underlying `ModuleCat` morphisms — as the naturality square of
+`TauCeti.QuiverRep.asModuleIso` is — only matches this once the body is visible. -/
+@[expose]
+noncomputable def mapₗ {a b : Q} (p : Quiver.Path a b) :
+    vertexSpace k Q M a →ₗ[k] vertexSpace k Q M b := (M.map p).hom
+
+-- Not `@[simp]`: `TauCeti.QuiverRep.mapₗ` is the simp-normal form of a structure map, since it is
+-- the retyping that lets a vertex-indexed construction see the vertex spaces; rewriting with this
+-- would undo that everywhere.
+/-- The retyped structure map is the structure map. -/
+theorem mapₗ_apply {a b : Q} (p : Quiver.Path a b) (z : vertexSpace k Q M a) :
+    mapₗ k Q M p z = (M.map p) z := (rfl)
+
+/-- **The trivial path acts as the identity**, the element-level
+`TauCeti.QuiverRep.map_nil_apply` read as an equation of linear maps. -/
+@[simp]
+theorem mapₗ_nil (a : Q) : mapₗ k Q M (Quiver.Path.nil : Quiver.Path a a) = LinearMap.id := by
+  refine LinearMap.ext fun z => ?_
+  rw [mapₗ_apply, LinearMap.id_apply]
+  exact QuiverRep.map_nil_apply M a z
+
+/-- **Concatenation of paths composes the structure maps**, the functoriality of a representation
+read on the retyped maps. -/
+theorem mapₗ_comp {a b c : Q} (p : Quiver.Path a b) (q : Quiver.Path b c) :
+    mapₗ k Q M (p.comp q) = (mapₗ k Q M q).comp (mapₗ k Q M p) := by
+  refine LinearMap.ext fun z => ?_
+  have h : M.map (p.comp q) = M.map p ≫ M.map q := M.map_comp p q
+  rw [mapₗ_apply, h, LinearMap.comp_apply, mapₗ_apply, mapₗ_apply]
+  -- `rw` cannot use this: its motive retypes the vertex `a` as an object of
+  -- `CategoryTheory.Paths Q`, which `M.obj` does not accept, so the rewrite is applied by hand
+  exact ModuleCat.comp_apply (M.map p) (M.map q) z
+
+end Vertex
+
+end QuiverRep
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Basic.lean
@@ -16,8 +16,9 @@ to every arrow, compatibly with path composition. This is precisely a functor fr
 path category to its category of modules.
 
 This file introduces the standard abbreviation, and the one structural fact that the trivial path
-acts as the identity. The equivalence with modules over the path algebra is planned for separate
-development.
+acts as the identity. The equivalence with modules over the path algebra is
+`TauCeti.quiverRepEquivalence`, built in
+`TauCeti.RepresentationTheory.Quiver.Representation.AsModule`.
 
 ## References
 

--- a/TauCeti/RepresentationTheory/Quiver/Representation/OfModule.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/OfModule.lean
@@ -103,7 +103,9 @@ This is the fully faithful half of `quiverRepEquivalence`, Layer 1 of
 equivalence "sending a module `M` to the representation `v ↦ eᵥ M`, with an arrow acting by left
 multiplication, and inverting through the idempotent decomposition `M = ⨁ᵥ eᵥ M`". Full
 faithfulness is proved here; the essential surjectivity that completes the equivalence — a
-`kQ`-module structure on `⨁ᵥ Mᵥ` for a given representation — is not, and is the remaining half.
+`kQ`-module structure on `⨁ᵥ Mᵥ` for a given representation — is
+`TauCeti.RepresentationTheory.Quiver.Representation.AsModule`, where the two halves are assembled
+into `TauCeti.quiverRepEquivalence`.
 
 The equivalence itself is classical; see Assem--Simson--Skowroński, *Elements of the Representation
 Theory of Associative Algebras I*, Ch. III, or Schiffler, *Quiver Representations*, Ch. 5.
@@ -449,7 +451,8 @@ theorem quiverRepFunctor_map {M N : ModuleCat.{t} (pathAlgebra k Q)} (f : M ⟶ 
 /-- **The functor from `kQ`-modules to representations of `Q` is fully faithful**: this is
 `TauCeti.quiverRepHomOfModule_bijective`, with `TauCeti.moduleHomOfQuiverRepHom` as the explicit
 preimage. It is one half of the roadmap's `quiverRepEquivalence`; the other half is essential
-surjectivity. -/
+surjectivity, proved in
+`TauCeti.RepresentationTheory.Quiver.Representation.AsModule`. -/
 noncomputable def quiverRepFunctorFullyFaithful :
     (quiverRepFunctor.{u, v, w, t} k Q).FullyFaithful where
   preimage {_ _} φ := ModuleCat.ofHom (moduleHomOfQuiverRepHom k Q φ)


### PR DESCRIPTION
This PR builds the module over the path algebra `kQ` carried by a representation of a finite quiver `Q`, and uses it to complete the equivalence between representations of `Q` and left `kQ`-modules. The carrier is the direct sum of the vertex spaces; a basis path `p : a ⟶ b` acts by reading off the `a`-component, applying the structure map `M.map p`, and putting the result in the `b`-component. Composable paths compose (`pathEnd_mul_pathEnd_of_comp`), paths that do not meet annihilate one another (`pathEnd_mul_pathEnd_of_not_composable`), and the trivial paths give the summand projections, which sum to the identity (`sum_pathEnd_nil`) — exactly the three hypotheses of the universal property `PathAlgebra.liftAlgHom`, so the assignment extends to a `k`-algebra map `toEnd : kQ →ₐ[k] End_k (⨁ᵥ Mᵥ)` and with it `QuiverRep.asModule`. The vertex idempotent `eᵥ` then acts as the projection onto the summand `Mᵥ` (`vertexIdempotent_smul`), so the vertex component of `asModule` at `v` is exactly the image of `Mᵥ` (`vertexComponent_asModule`), naturally in the path (`pathMap_vertexComponentEquiv`); that natural isomorphism `asModuleIso` is the essential surjectivity of `TauCeti.quiverRepFunctor`, which was already fully faithful, and the two halves assemble into `TauCeti.quiverRepEquivalence`, whose forward direction is identified with `asModule` by `TauCeti.quiverRepEquivalenceFunctorObjIso`.

This advances Layer 1 of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` ("Layer 1: representations of a quiver as `kQ`-modules", the bullet *"Representations are modules"*), whose pinned signature is `quiverRepEquivalence : QuiverRep k Q ≌ ModuleCat (pathAlgebra k Q)` in that roadmap's `Suggested.lean`. `TauCeti/RepresentationTheory/Quiver/Representation/OfModule.lean` already named the missing half in its own docstring — *"the essential surjectivity that completes the equivalence — a `kQ`-module structure on `⨁ᵥ Mᵥ` for a given representation — is not, and is the remaining half"* — and this is that half; the two stale docstrings that said so, in `OfModule.lean` and `Representation/Basic.lean`, are updated to point at the new module.

Two supporting refactors ride along, both extractions of code that already existed rather than new mathematics. `PathAlgebra.liftAlgHom` in `PathAlgebra/Basic.lean` is the universal property of `kQ` — extend along the path basis, given `hcomp`, `hzero` and `hone` — factored out of the five-step block that this file and the private `toMatrixAlgHom` of `Kronecker/UpperTriangular.lean` had each written separately; both now call it. And the vertex-space family `QuiverRep.vertexSpace` with its structure maps `QuiverRep.mapₗ`, which depends on nothing later than `Representation/Basic.lean`, is stated there rather than at the end of the path-algebra stack.

Two design points are worth flagging. The `k`-module structure on `QuiverRep.asModule` is deliberately `Module.restrictScalars k (pathAlgebra k Q)`, not the direct sum's own `k`-action: that is the structure `ModuleCat.moduleOfAlgebraModule` puts on an object of `ModuleCat (kQ)`, which is the one `quiverRepFunctor` uses, and taking the direct sum's own structure would give a second, only propositionally equal, `Module k` instance against which the essential-surjectivity isomorphism would not typecheck. That the two agree is what upgrades the (private) identity additive equivalence to the `k`-linear `asModuleEquiv`, the identification consumers go through. Separately, the vertex spaces are named as a family rather than used as `M.obj v` directly, because instance search does not see through the semireducible `CategoryTheory.Paths` when asked for the *family* `∀ v : Q, AddCommMonoid (M.obj v)` that a direct sum indexed by the vertices needs, although it succeeds at each individual vertex.

The concrete carrier is indexed by `Q : Type v` with summands in `Type t`, so `⨁ᵥ Mᵥ : Type (max v t)`: it lands in a larger universe than the representation whenever the vertex type does. The equivalence is nevertheless stated at an arbitrary representation universe, `QuiverRep.{u, v, w, t} k Q ≌ ModuleCat.{t} (pathAlgebra k Q)` — the shape of the pinned signature — because over a finite vertex set that direct sum is a finite product of the vertex spaces and so is `t`-small (`QuiverRep.small_asModule`); `QuiverRep.asModuleShrink` is the model of it in `Type t`, bundled as an object of `ModuleCat (kQ)` so that its `k`-structure is the restriction of scalars the functor reads it with, `QuiverRep.asModuleShrinkEquiv` identifies the two `kQ`-linearly, and `QuiverRep.asModuleShrinkIso` transports `asModuleIso` along it. The concrete direct-sum API stays at `max v t`, where `quiverRepEquivalenceFunctorObjIso` identifies the forward direction with `asModule` itself. `DecidableEq Q` is needed to write the summand inclusions and is carried through the construction; the essential-surjectivity instance is a `Prop` and discharges it with `classical`, so neither it nor `quiverRepEquivalence` asks for it. No Mathlib infrastructure was vendored: the construction consumes `DirectSum`, `Module.compHom`/`Module.restrictScalars`, `Module.Basis.constr`, `Shrink`/`Shrink.linearEquiv` and `CategoryTheory.Functor.asEquivalence` as they stand.

`lake build`, `lake exe axioms`, `scripts/lint-style.sh` and `scripts/lint-env.sh` are green.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"quiverrepequivalence"}-->

🤖 Prepared with Claude Code

