### PR TITLE
feat: define mixtures of Markov chains and prove they are Markov exchangeable

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/TransitionCount.lean
+++ b/TauCeti/Combinatorics/Enumerative/TransitionCount.lean
@@ -47,8 +47,8 @@ transition counts of a path are the sufficient statistic: see
   other.
 * `TauCeti.prod_transitionCount`: a product of transition weights along a word depends on the word
   only through its transition counts.
-* `TauCeti.prod_transitionCount_congr`: the resulting comparison of two words with equal transition
-  counts.
+* `TauCeti.prod_eq_of_transitionCount_eq`: the resulting comparison of two words with equal
+  transition counts.
 
 ## References
 
@@ -130,14 +130,23 @@ theorem sum_transitionCount_left {n : ℕ} (w : Fin (n + 1) → α) {S : Finset 
   rw [transitionCount_eq_card_filter, filter_filter]
   exact congrArg _ (filter_congr fun i _ => by simp [and_comm])
 
+/-- Implementation helper: two words over a common alphabet take all their values in one common
+`Finset`, namely the union of their images. This supplies the index set that
+`sum_transitionCount_left`, `sum_transitionCount_right`, and `prod_transitionCount` ask for when
+two words are compared. -/
+private theorem exists_finset_forall_mem {N : ℕ} (u v : Fin N → α) :
+    ∃ S : Finset α, (∀ i, u i ∈ S) ∧ ∀ i, v i ∈ S := by
+  classical
+  exact ⟨image u univ ∪ image v univ,
+    fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i)),
+    fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))⟩
+
 /-- **The transition counts and the first letter determine the occurrence counts.** -/
 theorem occCount_eq_of_transitionCount_eq {n : ℕ} {u v : Fin (n + 1) → α} (h0 : u 0 = v 0)
     (h : ∀ a b, transitionCount u a b = transitionCount v a b) (a : α) :
     occCount u a = occCount v a := by
   classical
-  set S : Finset α := image u univ ∪ image v univ
-  have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
-  have hSv : ∀ i, v i ∈ S := fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))
+  obtain ⟨S, hSu, hSv⟩ := exists_finset_forall_mem u v
   have hout : occCount (u ∘ Fin.castSucc) a = occCount (v ∘ Fin.castSucc) a := by
     rw [← sum_transitionCount_right u (fun i => hSu i.succ) a,
       ← sum_transitionCount_right v (fun i => hSv i.succ) a]
@@ -197,13 +206,10 @@ theorem prod_transitionCount {M : Type*} [CommMonoid M] {n : ℕ} (w : Fin (n + 
 /-- **Words with the same transition counts have the same product of transition weights.** This is
 `prod_transitionCount` with the index set eliminated: the two words are compared through the common
 `Finset` of letters they use. -/
-theorem prod_transitionCount_congr {M : Type*} [CommMonoid M] {n : ℕ} {u v : Fin (n + 1) → α}
+theorem prod_eq_of_transitionCount_eq {M : Type*} [CommMonoid M] {n : ℕ} {u v : Fin (n + 1) → α}
     (h : ∀ a b, transitionCount u a b = transitionCount v a b) (p : α → α → M) :
     ∏ i : Fin n, p (u i.castSucc) (u i.succ) = ∏ i : Fin n, p (v i.castSucc) (v i.succ) := by
-  classical
-  set S : Finset α := image u univ ∪ image v univ
-  have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
-  have hSv : ∀ i, v i ∈ S := fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))
+  obtain ⟨S, hSu, hSv⟩ := exists_finset_forall_mem u v
   rw [prod_transitionCount u (fun i : Fin n => ⟨hSu i.castSucc, hSu i.succ⟩) p,
     prod_transitionCount v (fun i : Fin n => ⟨hSv i.castSucc, hSv i.succ⟩) p]
   exact prod_congr rfl fun ab _ => by rw [h ab.1 ab.2]

--- a/TauCeti/Combinatorics/Enumerative/TransitionCount.lean
+++ b/TauCeti/Combinatorics/Enumerative/TransitionCount.lean
@@ -47,6 +47,8 @@ transition counts of a path are the sufficient statistic: see
   other.
 * `TauCeti.prod_transitionCount`: a product of transition weights along a word depends on the word
   only through its transition counts.
+* `TauCeti.prod_transitionCount_congr`: the resulting comparison of two words with equal transition
+  counts.
 
 ## References
 
@@ -191,6 +193,20 @@ theorem prod_transitionCount {M : Type*} [CommMonoid M] {n : ℕ} (w : Fin (n + 
       filter (fun i : Fin n => w i.castSucc = ab.1 ∧ w i.succ = ab.2) univ :=
     filter_congr fun i _ => by simp [Prod.ext_iff]
   rw [prod_congr rfl hval, prod_const, transitionCount_eq_card_filter, hset]
+
+/-- **Words with the same transition counts have the same product of transition weights.** This is
+`prod_transitionCount` with the index set eliminated: the two words are compared through the common
+`Finset` of letters they use. -/
+theorem prod_transitionCount_congr {M : Type*} [CommMonoid M] {n : ℕ} {u v : Fin (n + 1) → α}
+    (h : ∀ a b, transitionCount u a b = transitionCount v a b) (p : α → α → M) :
+    ∏ i : Fin n, p (u i.castSucc) (u i.succ) = ∏ i : Fin n, p (v i.castSucc) (v i.succ) := by
+  classical
+  set S : Finset α := image u univ ∪ image v univ
+  have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
+  have hSv : ∀ i, v i ∈ S := fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))
+  rw [prod_transitionCount u (fun i : Fin n => ⟨hSu i.castSucc, hSu i.succ⟩) p,
+    prod_transitionCount v (fun i : Fin n => ⟨hSv i.castSucc, hSv i.succ⟩) p]
+  exact prod_congr rfl fun ab _ => by rw [h ab.1 ab.2]
 
 end TauCeti
 

--- a/TauCeti/Probability/Exchangeability.lean
+++ b/TauCeti/Probability/Exchangeability.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Probability.Exchangeability.Map
 public import TauCeti.Probability.Exchangeability.MarkovExchangeable
+public import TauCeti.Probability.Exchangeability.MixedMarkovChain
 public import TauCeti.Probability.Exchangeability.Family
 public import TauCeti.Probability.Exchangeability.MixedIID.Map
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Implications
@@ -28,8 +29,9 @@ This module declares nothing of its own; it is a curated re-export.
 * the finite-dimensional laws `blockLaw`, `prefixLaw`, `pathLaw`, and finite-marginal uniqueness;
 * the symmetry predicates `ExchangeableAt`, `Exchangeable`, `FullyExchangeable`, `Contractable`,
   `MarkovExchangeable`, and the index-generic `ExchangeableFamily`;
-* the representation predicates `MixedIIDWith`, `MixedIID`, `ConditionallyIIDWith`,
-  `ConditionallyIID`, with their constructors, accessors, and simp-normal forms;
+* the representation predicates `MixedIIDWith`, `MixedIID`, `MixedMarkovChainWith`,
+  `MixedMarkovChain`, `ConditionallyIIDWith`, `ConditionallyIID`, with their constructors,
+  accessors, and simp-normal forms;
 * the implications between them, including the symmetry consequences of each and the projection
   from the conditional predicate to the mixture one;
 * reindexing along injections, and closure under measurable coordinate maps;

--- a/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
@@ -158,7 +158,7 @@ theorem markovExchangeable_of_prefixLaw_singleton_eq [Countable α] [MeasurableS
     MarkovExchangeable μ X := by
   refine MarkovExchangeable.intro hX ?_
   intro n u v h0 hcount
-  rw [h n u, h n v, h0, prod_transitionCount_congr hcount p]
+  rw [h n u, h n v, h0, prod_eq_of_transitionCount_eq hcount p]
 
 /-- **The process-level and path-law formulations of Markov exchangeability agree.** -/
 theorem markovExchangeable_pathLaw_iff [Countable α] [MeasurableSingletonClass α]

--- a/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
+++ b/TauCeti/Probability/Exchangeability/MarkovExchangeable.lean
@@ -63,7 +63,7 @@ public section
 
 noncomputable section
 
-open Finset MeasureTheory
+open MeasureTheory
 open scoped ENNReal
 
 namespace TauCeti
@@ -156,16 +156,9 @@ theorem markovExchangeable_of_prefixLaw_singleton_eq [Countable α] [MeasurableS
     (h : ∀ (n : ℕ) (w : Fin (n + 1) → α),
       prefixLaw μ X (n + 1) {w} = p₀ (w 0) * ∏ i : Fin n, p (w i.castSucc) (w i.succ)) :
     MarkovExchangeable μ X := by
-  classical
   refine MarkovExchangeable.intro hX ?_
   intro n u v h0 hcount
-  set S : Finset α := image u univ ∪ image v univ
-  have hSu : ∀ i, u i ∈ S := fun i => mem_union_left _ (mem_image_of_mem u (mem_univ i))
-  have hSv : ∀ i, v i ∈ S := fun i => mem_union_right _ (mem_image_of_mem v (mem_univ i))
-  rw [h n u, h n v, h0,
-    prod_transitionCount u (fun i : Fin n => ⟨hSu i.castSucc, hSu i.succ⟩) p,
-    prod_transitionCount v (fun i : Fin n => ⟨hSv i.castSucc, hSv i.succ⟩) p]
-  exact congrArg _ (prod_congr rfl fun ab _ => by rw [hcount ab.1 ab.2])
+  rw [h n u, h n v, h0, prod_transitionCount_congr hcount p]
 
 /-- **The process-level and path-law formulations of Markov exchangeability agree.** -/
 theorem markovExchangeable_pathLaw_iff [Countable α] [MeasurableSingletonClass α]

--- a/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
+++ b/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
@@ -1,0 +1,296 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.MarkovExchangeable
+public import TauCeti.Probability.Exchangeability.MixedIID.Basic
+
+/-!
+# Mixtures of Markov chains
+
+A process `X : ℕ → Ω → α` on a countable state space is a **mixture of Markov chains** when its
+finite path probabilities are an average of Markov-chain path probabilities: there is a random
+initial law `ν : Ω → ProbabilityMeasure α` and a random transition matrix
+`κ : Ω → α → ProbabilityMeasure α` with
+
+```text
+prefixLaw μ X (n + 1) {w} = ∫⁻ ω, ν ω {w 0} * ∏ i, κ ω (w i.castSucc) {w i.succ} ∂μ
+```
+
+for every finite path `w`. `MixedMarkovChainWith μ X ν κ` names the pair of witnesses, and
+`MixedMarkovChain μ X` is the existential wrapper. The naming and the witness/existential split
+follow `MixedIIDWith` / `MixedIID`, which this notion contains: an i.i.d. mixture is the mixture of
+Markov chains whose rows do not depend on the current state
+(`MixedIIDWith.mixedMarkovChainWith`).
+
+⚠ Like `MixedIIDWith`, this is a property of the **unconditional** finite path laws only. It says
+nothing about the joint law of `(ν, κ, X)`, so it is not a conditional-independence statement, and
+the witnesses are not asserted to be unique. The conditional strengthening — conditionally on
+`(ν, κ)` the process is a Markov chain with that initial law and that transition matrix — is the
+analogue of `ConditionallyIIDWith` and is deliberately not what is defined here.
+
+This is the class in the conclusion of the Diaconis–Freedman representation theorem: a recurrent
+Markov exchangeable process is a mixture of Markov chains. This file supplies the class together
+with the **easy direction** of that theorem, `MixedMarkovChainWith.markovExchangeable`: every
+mixture of Markov chains is Markov exchangeable. The mechanism is the one that makes transition
+counts the sufficient statistic of a Markov chain — a product of transition weights along a path
+depends on the path only through its transition counts
+(`TauCeti.prod_transitionCount_congr`) — applied inside the mixing integral, where it holds
+pointwise in the mixing variable.
+
+The class is strictly larger than the mixed i.i.d. one: the deterministic 3-cycle of
+`TauCeti/Probability/Exchangeability/ThreeCycle.lean` is a Markov chain, hence a mixture of Markov
+chains (`threeCycle_mixedMarkovChain`), but is not exchangeable and so not mixed i.i.d.
+
+## Main definitions
+
+* `TauCeti.Probability.MixedMarkovChainWith`: the mixture identity with named witnesses.
+* `TauCeti.Probability.MixedMarkovChain`: its existential wrapper.
+
+## Main results
+
+* `TauCeti.Probability.MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow`: the
+  transition counts of a path are a sufficient statistic for its probability.
+* `TauCeti.Probability.MixedMarkovChainWith.markovExchangeable`: a mixture of Markov chains is
+  Markov exchangeable — the easy direction of Diaconis–Freedman.
+* `TauCeti.Probability.mixedMarkovChainWith_const`: a single Markov chain is the degenerate
+  mixture.
+* `TauCeti.Probability.MixedIIDWith.mixedMarkovChainWith`: a mixed i.i.d. process is a mixture of
+  Markov chains with state-independent rows.
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115–130.
+* Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, "Markov exchangeability".
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable rather than
+Markov exchangeable sequences.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **A mixture of Markov chains** with a specified random initial law `ν` and random transition
+matrix `κ`: the probability of a finite path is the `μ`-average of the Markov-chain probability
+built from `ν ω` and `κ ω`. The countability and measurable-singleton conjuncts restrict this
+singleton-mass formulation to discrete state spaces, matching `MarkovExchangeable`, where it is
+non-vacuous and determines the finite path laws. -/
+def MixedMarkovChainWith (μ : Measure Ω) (X : ℕ → Ω → α)
+    (ν : Ω → ProbabilityMeasure α) (κ : Ω → α → ProbabilityMeasure α) : Prop :=
+  Countable α ∧ MeasurableSingletonClass α ∧ (∀ i, AEMeasurable (X i) μ) ∧
+    Measurable ν ∧ (∀ a, Measurable fun ω => κ ω a) ∧
+      ∀ (n : ℕ) (w : Fin (n + 1) → α),
+        prefixLaw μ X (n + 1) {w} =
+          ∫⁻ ω, (ν ω : Measure α) {w 0} *
+            ∏ i : Fin n, (κ ω (w i.castSucc) : Measure α) {w i.succ} ∂μ
+
+/-- Constructor from discrete-state instances, coordinatewise a.e. measurability, measurability of
+the two witnesses, and the mixture identity for finite paths. -/
+theorem MixedMarkovChainWith.intro [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    {κ : Ω → α → ProbabilityMeasure α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (hν : Measurable ν) (hκ : ∀ a, Measurable fun ω => κ ω a)
+    (h : ∀ (n : ℕ) (w : Fin (n + 1) → α),
+      prefixLaw μ X (n + 1) {w} =
+        ∫⁻ ω, (ν ω : Measure α) {w 0} *
+          ∏ i : Fin n, (κ ω (w i.castSucc) : Measure α) {w i.succ} ∂μ) :
+    MixedMarkovChainWith μ X ν κ :=
+  ⟨inferInstance, inferInstance, hX, hν, hκ, h⟩
+
+/-- The state space of a mixture of Markov chains is countable. -/
+theorem MixedMarkovChainWith.countable {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) : Countable α :=
+  h.1
+
+/-- Singletons in the state space of a mixture of Markov chains are measurable. -/
+theorem MixedMarkovChainWith.measurableSingletonClass {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) : MeasurableSingletonClass α :=
+  h.2.1
+
+/-- Every coordinate of a mixture of Markov chains is a.e. measurable. -/
+theorem MixedMarkovChainWith.aemeasurable {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) (i : ℕ) : AEMeasurable (X i) μ :=
+  h.2.2.1 i
+
+/-- The random initial law of a mixture of Markov chains is measurable. -/
+@[grind →]
+theorem MixedMarkovChainWith.measurable_initialLaw {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) : Measurable ν :=
+  h.2.2.2.1
+
+/-- Each row of the random transition matrix of a mixture of Markov chains is measurable. -/
+theorem MixedMarkovChainWith.measurable_transitionMatrix {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) (a : α) : Measurable fun ω => κ ω a :=
+  h.2.2.2.2.1 a
+
+/-- The defining mixture identity: the probability of a finite path is the average of its
+Markov-chain probabilities. -/
+@[grind =>]
+theorem MixedMarkovChainWith.prefixLaw_singleton {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) (n : ℕ) (w : Fin (n + 1) → α) :
+    prefixLaw μ X (n + 1) {w} =
+      ∫⁻ ω, (ν ω : Measure α) {w 0} *
+        ∏ i : Fin n, (κ ω (w i.castSucc) : Measure α) {w i.succ} ∂μ :=
+  h.2.2.2.2.2 n w
+
+/-- Simp normal form for `MixedMarkovChainWith`. -/
+@[simp]
+theorem mixedMarkovChainWith_iff [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    {κ : Ω → α → ProbabilityMeasure α} :
+    MixedMarkovChainWith μ X ν κ ↔
+      (∀ i, AEMeasurable (X i) μ) ∧ Measurable ν ∧ (∀ a, Measurable fun ω => κ ω a) ∧
+        ∀ (n : ℕ) (w : Fin (n + 1) → α),
+          prefixLaw μ X (n + 1) {w} =
+            ∫⁻ ω, (ν ω : Measure α) {w 0} *
+              ∏ i : Fin n, (κ ω (w i.castSucc) : Measure α) {w i.succ} ∂μ :=
+  ⟨fun h => ⟨h.aemeasurable, h.measurable_initialLaw, h.measurable_transitionMatrix,
+      h.prefixLaw_singleton⟩,
+    fun h => MixedMarkovChainWith.intro h.1 h.2.1 h.2.2.1 h.2.2.2⟩
+
+/-- **A mixture of Markov chains**: existence of a random initial law and a random transition
+matrix representing the finite path laws. -/
+def MixedMarkovChain (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∃ (ν : Ω → ProbabilityMeasure α) (κ : Ω → α → ProbabilityMeasure α),
+    MixedMarkovChainWith μ X ν κ
+
+/-- Constructor from a named pair of witnesses. -/
+theorem MixedMarkovChain.of_witnesses {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) : MixedMarkovChain μ X :=
+  ⟨ν, κ, h⟩
+
+/-- A mixture of Markov chains has a random initial law and a random transition matrix. -/
+theorem MixedMarkovChain.exists_witnesses {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MixedMarkovChain μ X) :
+    ∃ (ν : Ω → ProbabilityMeasure α) (κ : Ω → α → ProbabilityMeasure α),
+      MixedMarkovChainWith μ X ν κ :=
+  h
+
+/-- Simp normal form for the existential wrapper `MixedMarkovChain`. -/
+@[simp]
+theorem mixedMarkovChain_iff {μ : Measure Ω} {X : ℕ → Ω → α} :
+    MixedMarkovChain μ X ↔
+      ∃ (ν : Ω → ProbabilityMeasure α) (κ : Ω → α → ProbabilityMeasure α),
+        MixedMarkovChainWith μ X ν κ :=
+  Iff.rfl
+
+/-- The state space of a mixture of Markov chains is countable. -/
+theorem MixedMarkovChain.countable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MixedMarkovChain μ X) : Countable α := by
+  obtain ⟨_, _, h⟩ := h
+  exact h.countable
+
+/-- Singletons in the state space of a mixture of Markov chains are measurable. -/
+theorem MixedMarkovChain.measurableSingletonClass {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MixedMarkovChain μ X) : MeasurableSingletonClass α := by
+  obtain ⟨_, _, h⟩ := h
+  exact h.measurableSingletonClass
+
+/-- Every coordinate of a mixture of Markov chains is a.e. measurable. -/
+theorem MixedMarkovChain.aemeasurable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MixedMarkovChain μ X) (i : ℕ) : AEMeasurable (X i) μ := by
+  obtain ⟨_, _, h⟩ := h
+  exact h.aemeasurable i
+
+/-- **The transition counts of a path are a sufficient statistic for its probability.** Rewriting
+the mixture identity through `TauCeti.prod_transitionCount` replaces the product along the path by
+a product of powers indexed by the transition counts; the index set `S` only has to contain the
+letters of the path. -/
+theorem MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow {μ : Measure Ω}
+    {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) {n : ℕ} (w : Fin (n + 1) → α) {S : Finset α}
+    (hS : ∀ i, w i ∈ S) :
+    prefixLaw μ X (n + 1) {w} =
+      ∫⁻ ω, (ν ω : Measure α) {w 0} *
+        ∏ ab ∈ S ×ˢ S, (κ ω ab.1 : Measure α) {ab.2} ^ transitionCount w ab.1 ab.2 ∂μ := by
+  rw [h.prefixLaw_singleton n w]
+  refine lintegral_congr fun ω => ?_
+  rw [prod_transitionCount w (fun i : Fin n => ⟨hS i.castSucc, hS i.succ⟩)
+    fun a b => (κ ω a : Measure α) {b}]
+
+/-- **A mixture of Markov chains is Markov exchangeable.** This is the easy direction of the
+Diaconis–Freedman representation theorem. Two paths with a common start and common transition
+counts have equal Markov-chain probabilities for *every* value of the mixing variable, because a
+product of transition weights depends on the path only through its transition counts; averaging
+preserves the equality. -/
+theorem MixedMarkovChainWith.markovExchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
+    (h : MixedMarkovChainWith μ X ν κ) : MarkovExchangeable μ X := by
+  have := h.countable
+  have := h.measurableSingletonClass
+  refine MarkovExchangeable.intro h.aemeasurable ?_
+  intro n u v h0 hcount
+  rw [h.prefixLaw_singleton n u, h.prefixLaw_singleton n v]
+  refine lintegral_congr fun ω => ?_
+  rw [h0, prod_transitionCount_congr hcount fun a b => (κ ω a : Measure α) {b}]
+
+/-- **A mixture of Markov chains is Markov exchangeable**, existential form. -/
+theorem MixedMarkovChain.markovExchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : MixedMarkovChain μ X) : MarkovExchangeable μ X := by
+  obtain ⟨_, _, h⟩ := h
+  exact h.markovExchangeable
+
+/-- **A Markov chain is the degenerate mixture of Markov chains.** The hypothesis is the defining
+product form of the finite-dimensional laws of a Markov chain with initial law `p₀` and transition
+matrix `p`; the witnesses are the constant random objects. -/
+theorem mixedMarkovChainWith_const [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} [IsProbabilityMeasure μ] {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (p₀ : ProbabilityMeasure α) (p : α → ProbabilityMeasure α)
+    (h : ∀ (n : ℕ) (w : Fin (n + 1) → α),
+      prefixLaw μ X (n + 1) {w} =
+        (p₀ : Measure α) {w 0} * ∏ i : Fin n, (p (w i.castSucc) : Measure α) {w i.succ}) :
+    MixedMarkovChainWith μ X (fun _ => p₀) fun _ => p :=
+  MixedMarkovChainWith.intro hX measurable_const (fun _ => measurable_const) fun n w => by
+    rw [h n w, lintegral_const, measure_univ, mul_one]
+
+/-- **A mixed i.i.d. process is a mixture of Markov chains** whose rows do not depend on the
+current state: drawing the next coordinate from the mixing representative, whatever the present
+one, reproduces the mixed i.i.d. finite-dimensional laws. This places `MixedIID` below
+`MixedMarkovChain` in the symmetry lattice, refining `Exchangeable.markovExchangeable` at the level
+of the representations. -/
+theorem MixedIIDWith.mixedMarkovChainWith [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (h : MixedIIDWith μ X ν) (hX : ∀ i, AEMeasurable (X i) μ) :
+    MixedMarkovChainWith μ X ν fun ω _ => ν ω := by
+  refine MixedMarkovChainWith.intro hX h.measurable_mixingRepresentative
+    (fun _ => h.measurable_mixingRepresentative) fun n w => ?_
+  have hk : Function.Injective fun i : Fin (n + 1) => i.val := fun i j hij => Fin.ext hij
+  rw [prefixLaw_def, ← Set.univ_pi_singleton w,
+    h.blockLaw_univ_pi _ hk (fun i => {w i}) fun i => measurableSet_singleton (w i)]
+  exact lintegral_congr fun ω => Fin.prod_univ_succ fun i => (ν ω : Measure α) {w i}
+
+/-- **A mixed i.i.d. process is a mixture of Markov chains**, existential form. -/
+theorem MixedIID.mixedMarkovChain [Countable α] [MeasurableSingletonClass α]
+    {μ : Measure Ω} {X : ℕ → Ω → α} (h : MixedIID μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
+    MixedMarkovChain μ X := by
+  obtain ⟨ν, hν⟩ := h.exists_mixingRepresentative
+  exact MixedMarkovChain.of_witnesses (hν.mixedMarkovChainWith hX)
+
+end Probability
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
+++ b/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
@@ -22,9 +22,9 @@ prefixLaw μ X (n + 1) {w} = ∫⁻ ω, ν ω {w 0} * ∏ i, κ ω (w i.castSucc
 
 for every finite path `w`. `MixedMarkovChainWith μ X ν κ` names the pair of witnesses, and
 `MixedMarkovChain μ X` is the existential wrapper. The naming and the witness/existential split
-follow `MixedIIDWith` / `MixedIID`, which this notion contains: an i.i.d. mixture is the mixture of
-Markov chains whose rows do not depend on the current state
-(`MixedIIDWith.mixedMarkovChainWith`).
+follow `MixedIIDWith` / `MixedIID`. Among coordinatewise a.e.-measurable processes, this notion
+contains mixed i.i.d. processes: an i.i.d. mixture is the mixture of Markov chains whose rows do not
+depend on the current state (`MixedIIDWith.mixedMarkovChainWith`).
 
 ⚠ Like `MixedIIDWith`, this is a property of the **unconditional** finite path laws only. It says
 nothing about the joint law of `(ν, κ, X)`, so it is not a conditional-independence statement, and
@@ -35,15 +35,16 @@ analogue of `ConditionallyIIDWith` and is deliberately not what is defined here.
 This is the class in the conclusion of the Diaconis–Freedman representation theorem: a recurrent
 Markov exchangeable process is a mixture of Markov chains. This file supplies the class together
 with the **easy direction** of that theorem, `MixedMarkovChainWith.markovExchangeable`: every
-mixture of Markov chains is Markov exchangeable. The mechanism is the one that makes transition
-counts the sufficient statistic of a Markov chain — a product of transition weights along a path
-depends on the path only through its transition counts
+mixture of Markov chains is Markov exchangeable. The mechanism is the one that makes the initial
+state together with the transition counts sufficient for a Markov-chain path probability — the
+transition-product factor depends on the path only through its transition counts
 (`TauCeti.prod_transitionCount_congr`) — applied inside the mixing integral, where it holds
 pointwise in the mixing variable.
 
-The class is strictly larger than the mixed i.i.d. one: the deterministic 3-cycle of
-`TauCeti/Probability/Exchangeability/ThreeCycle.lean` is a Markov chain, hence a mixture of Markov
-chains (`threeCycle_mixedMarkovChain`), but is not exchangeable and so not mixed i.i.d.
+Among coordinatewise a.e.-measurable processes, the class is strictly larger than the mixed i.i.d.
+one: the deterministic 3-cycle of `TauCeti/Probability/Exchangeability/ThreeCycle.lean` is a
+Markov chain, hence a mixture of Markov chains (`threeCycle_mixedMarkovChain`), but is not
+exchangeable and so not mixed i.i.d.
 
 ## Main definitions
 
@@ -53,13 +54,13 @@ chains (`threeCycle_mixedMarkovChain`), but is not exchangeable and so not mixed
 ## Main results
 
 * `TauCeti.Probability.MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow`: the
-  transition counts of a path are a sufficient statistic for its probability.
+  initial state and transition counts of a path are sufficient for its probability.
 * `TauCeti.Probability.MixedMarkovChainWith.markovExchangeable`: a mixture of Markov chains is
   Markov exchangeable — the easy direction of Diaconis–Freedman.
 * `TauCeti.Probability.mixedMarkovChainWith_const`: a single Markov chain is the degenerate
   mixture.
-* `TauCeti.Probability.MixedIIDWith.mixedMarkovChainWith`: a mixed i.i.d. process is a mixture of
-  Markov chains with state-independent rows.
+* `TauCeti.Probability.MixedIIDWith.mixedMarkovChainWith`: a coordinatewise a.e.-measurable mixed
+  i.i.d. process is a mixture of Markov chains with state-independent rows.
 
 ## References
 
@@ -213,10 +214,10 @@ theorem MixedMarkovChain.aemeasurable {μ : Measure Ω} {X : ℕ → Ω → α}
   obtain ⟨_, _, h⟩ := h
   exact h.aemeasurable i
 
-/-- **The transition counts of a path are a sufficient statistic for its probability.** Rewriting
-the mixture identity through `TauCeti.prod_transitionCount` replaces the product along the path by
-a product of powers indexed by the transition counts; the index set `S` only has to contain the
-letters of the path. -/
+/-- **The initial state together with the transition counts of a path is sufficient for its
+probability.** Rewriting the mixture identity through `TauCeti.prod_transitionCount` replaces the
+transition-product factor by a product of powers indexed by the transition counts; the index set
+`S` only has to contain the letters of the path. -/
 theorem MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow {μ : Measure Ω}
     {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
     (h : MixedMarkovChainWith μ X ν κ) {n : ℕ} (w : Fin (n + 1) → α) {S : Finset α}
@@ -264,11 +265,12 @@ theorem mixedMarkovChainWith_const [Countable α] [MeasurableSingletonClass α]
   MixedMarkovChainWith.intro hX measurable_const (fun _ => measurable_const) fun n w => by
     rw [h n w, lintegral_const, measure_univ, mul_one]
 
-/-- **A mixed i.i.d. process is a mixture of Markov chains** whose rows do not depend on the
-current state: drawing the next coordinate from the mixing representative, whatever the present
-one, reproduces the mixed i.i.d. finite-dimensional laws. This places `MixedIID` below
-`MixedMarkovChain` in the symmetry lattice, refining `Exchangeable.markovExchangeable` at the level
-of the representations. -/
+/-- **A coordinatewise a.e.-measurable mixed i.i.d. process is a mixture of Markov chains** whose
+rows do not depend on the current state: drawing the next coordinate from the mixing
+representative, whatever the present one, reproduces the mixed i.i.d. finite-dimensional laws.
+Thus, among coordinatewise a.e.-measurable processes, this places `MixedIID` below
+`MixedMarkovChain` in the symmetry lattice, refining `Exchangeable.markovExchangeable` at the
+level of the representations. -/
 theorem MixedIIDWith.mixedMarkovChainWith [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
     (h : MixedIIDWith μ X ν) (hX : ∀ i, AEMeasurable (X i) μ) :
@@ -280,7 +282,8 @@ theorem MixedIIDWith.mixedMarkovChainWith [Countable α] [MeasurableSingletonCla
     h.blockLaw_univ_pi _ hk (fun i => {w i}) fun i => measurableSet_singleton (w i)]
   exact lintegral_congr fun ω => Fin.prod_univ_succ fun i => (ν ω : Measure α) {w i}
 
-/-- **A mixed i.i.d. process is a mixture of Markov chains**, existential form. -/
+/-- **A coordinatewise a.e.-measurable mixed i.i.d. process is a mixture of Markov chains**,
+existential form. -/
 theorem MixedIID.mixedMarkovChain [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} (h : MixedIID μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
     MixedMarkovChain μ X := by

--- a/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
+++ b/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
@@ -12,8 +12,8 @@ public import TauCeti.Probability.Exchangeability.MixedIID.Basic
 # Mixtures of Markov chains
 
 A process `X : ℕ → Ω → α` on a countable state space is a **mixture of Markov chains** when its
-finite-path `μ`-masses are averages of Markov-chain path masses: there is a random
-initial law `ν : Ω → ProbabilityMeasure α` and a random transition matrix
+finite-path `μ`-masses are integrals of Markov-chain path masses against `μ`: there is a measurable
+initial-law witness `ν : Ω → ProbabilityMeasure α` and a measurable transition-matrix witness
 `κ : Ω → α → ProbabilityMeasure α` with
 
 ```text
@@ -84,13 +84,13 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- **A mixture of Markov chains** with a specified random initial law `ν` and random transition
-matrix `κ`: the `μ`-mass of a finite path is the `μ`-average of its Markov-chain path mass
-built from `ν ω` and `κ ω`. The countability and measurable-singleton conjuncts restrict this
-singleton-mass formulation to discrete state spaces, matching `MarkovExchangeable`, where it is
-non-vacuous and determines the finite path laws. Bundled alongside, as in `MarkovExchangeable`, are
-the regularity conjuncts the mixture identity is stated against: the process is coordinatewise a.e.
-measurable, and both witnesses are measurable (`ν`, and each row `ω ↦ κ ω a`). -/
+/-- **A mixture of Markov chains** with specified mixing witnesses `ν` and `κ`: the `μ`-mass of a
+finite path is the integral against `μ` of its Markov-chain path mass built from `ν ω` and `κ ω`.
+The countability and measurable-singleton conjuncts restrict this singleton-mass formulation to
+discrete state spaces, matching `MarkovExchangeable`, where it is non-vacuous and determines the
+finite path laws. Bundled alongside, as in `MarkovExchangeable`, are the regularity conjuncts the
+mixture identity is stated against: the process is coordinatewise a.e. measurable, and both
+witnesses are measurable (`ν`, and each row `ω ↦ κ ω a`). -/
 def MixedMarkovChainWith (μ : Measure Ω) (X : ℕ → Ω → α)
     (ν : Ω → ProbabilityMeasure α) (κ : Ω → α → ProbabilityMeasure α) : Prop :=
   Countable α ∧ MeasurableSingletonClass α ∧ (∀ i, AEMeasurable (X i) μ) ∧
@@ -131,21 +131,21 @@ theorem MixedMarkovChainWith.aemeasurable {μ : Measure Ω} {X : ℕ → Ω → 
     (h : MixedMarkovChainWith μ X ν κ) (i : ℕ) : AEMeasurable (X i) μ :=
   h.2.2.1 i
 
-/-- The random initial law of a mixture of Markov chains is measurable. -/
+/-- The initial-law witness of a mixture of Markov chains is measurable. -/
 @[grind →]
 theorem MixedMarkovChainWith.measurable_initialLaw {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
     (h : MixedMarkovChainWith μ X ν κ) : Measurable ν :=
   h.2.2.2.1
 
-/-- Each row of the random transition matrix of a mixture of Markov chains is measurable. -/
+/-- Each row of the transition-matrix witness of a mixture of Markov chains is measurable. -/
 theorem MixedMarkovChainWith.measurable_transitionMatrix {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
     (h : MixedMarkovChainWith μ X ν κ) (a : α) : Measurable fun ω => κ ω a :=
   h.2.2.2.2.1 a
 
-/-- The defining mixture identity: the `μ`-mass of a finite path is the `μ`-average of its
-Markov-chain path masses. -/
+/-- The defining mixture identity: the `μ`-mass of a finite path is the integral of its
+Markov-chain path masses against `μ`. -/
 @[grind =>]
 theorem MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
@@ -170,8 +170,8 @@ theorem mixedMarkovChainWith_iff [Countable α] [MeasurableSingletonClass α]
       h.prefixLaw_singleton_eq_lintegral⟩,
     fun h => MixedMarkovChainWith.intro h.1 h.2.1 h.2.2.1 h.2.2.2⟩
 
-/-- **A mixture of Markov chains**: existence of a random initial law and a random transition
-matrix representing the finite path laws. -/
+/-- **A mixture of Markov chains**: existence of initial-law and transition-matrix witnesses
+representing the finite path laws by integration against `μ`. -/
 def MixedMarkovChain (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∃ (ν : Ω → ProbabilityMeasure α) (κ : Ω → α → ProbabilityMeasure α),
     MixedMarkovChainWith μ X ν κ
@@ -182,7 +182,7 @@ theorem MixedMarkovChain.of_witnesses {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : MixedMarkovChainWith μ X ν κ) : MixedMarkovChain μ X :=
   ⟨ν, κ, h⟩
 
-/-- A mixture of Markov chains has a random initial law and a random transition matrix. -/
+/-- A mixture of Markov chains has initial-law and transition-matrix witnesses. -/
 theorem MixedMarkovChain.exists_witnesses {μ : Measure Ω} {X : ℕ → Ω → α}
     (h : MixedMarkovChain μ X) :
     ∃ (ν : Ω → ProbabilityMeasure α) (κ : Ω → α → ProbabilityMeasure α),
@@ -234,8 +234,8 @@ theorem MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow {μ : Mea
 /-- **A mixture of Markov chains is Markov exchangeable.** This is the easy direction of the
 Diaconis–Freedman representation theorem. Two paths with a common start and common transition
 counts have equal Markov-chain probabilities for *every* value of the mixing variable, because a
-product of transition weights depends on the path only through its transition counts; averaging
-preserves the equality. -/
+product of transition weights depends on the path only through its transition counts; integration
+against `μ` preserves the equality. -/
 theorem MixedMarkovChainWith.markovExchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
     (h : MixedMarkovChainWith μ X ν κ) : MarkovExchangeable μ X := by
@@ -255,7 +255,7 @@ theorem MixedMarkovChain.markovExchangeable {μ : Measure Ω} {X : ℕ → Ω �
 
 /-- **A Markov chain is the degenerate mixture of Markov chains.** The hypothesis is the defining
 product form of the finite-dimensional laws of a Markov chain with initial law `p₀` and transition
-matrix `p`; the witnesses are the constant random objects. -/
+matrix `p`; the mixing witnesses are constant. -/
 theorem mixedMarkovChainWith_const_of_prefixLaw_singleton_eq
     [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} [IsProbabilityMeasure μ] {X : ℕ → Ω → α}

--- a/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
+++ b/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
@@ -12,7 +12,7 @@ public import TauCeti.Probability.Exchangeability.MixedIID.Basic
 # Mixtures of Markov chains
 
 A process `X : ℕ → Ω → α` on a countable state space is a **mixture of Markov chains** when its
-finite path probabilities are an average of Markov-chain path probabilities: there is a random
+finite-path `μ`-masses are averages of Markov-chain path masses: there is a random
 initial law `ν : Ω → ProbabilityMeasure α` and a random transition matrix
 `κ : Ω → α → ProbabilityMeasure α` with
 
@@ -36,7 +36,7 @@ This is the class in the conclusion of the Diaconis–Freedman representation th
 Markov exchangeable process is a mixture of Markov chains. This file supplies the class together
 with the **easy direction** of that theorem, `MixedMarkovChainWith.markovExchangeable`: every
 mixture of Markov chains is Markov exchangeable. The mechanism is the one that makes the initial
-state together with the transition counts sufficient for a Markov-chain path probability — the
+state together with the transition counts sufficient for a Markov-chain path mass — the
 transition-product factor depends on the path only through its transition counts
 (`TauCeti.prod_transitionCount_congr`) — applied inside the mixing integral, where it holds
 pointwise in the mixing variable.
@@ -54,7 +54,7 @@ exchangeable and so not mixed i.i.d.
 ## Main results
 
 * `TauCeti.Probability.MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow`: the
-  initial state and transition counts of a path are sufficient for its probability.
+  initial state and transition counts of a path are sufficient for its `μ`-mass.
 * `TauCeti.Probability.MixedMarkovChainWith.markovExchangeable`: a mixture of Markov chains is
   Markov exchangeable — the easy direction of Diaconis–Freedman.
 * `TauCeti.Probability.mixedMarkovChainWith_const`: a single Markov chain is the degenerate
@@ -86,7 +86,7 @@ namespace Probability
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 /-- **A mixture of Markov chains** with a specified random initial law `ν` and random transition
-matrix `κ`: the probability of a finite path is the `μ`-average of the Markov-chain probability
+matrix `κ`: the `μ`-mass of a finite path is the `μ`-average of its Markov-chain path mass
 built from `ν ω` and `κ ω`. The countability and measurable-singleton conjuncts restrict this
 singleton-mass formulation to discrete state spaces, matching `MarkovExchangeable`, where it is
 non-vacuous and determines the finite path laws. -/
@@ -143,8 +143,8 @@ theorem MixedMarkovChainWith.measurable_transitionMatrix {μ : Measure Ω} {X : 
     (h : MixedMarkovChainWith μ X ν κ) (a : α) : Measurable fun ω => κ ω a :=
   h.2.2.2.2.1 a
 
-/-- The defining mixture identity: the probability of a finite path is the average of its
-Markov-chain probabilities. -/
+/-- The defining mixture identity: the `μ`-mass of a finite path is the `μ`-average of its
+Markov-chain path masses. -/
 @[grind =>]
 theorem MixedMarkovChainWith.prefixLaw_singleton {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
@@ -215,7 +215,7 @@ theorem MixedMarkovChain.aemeasurable {μ : Measure Ω} {X : ℕ → Ω → α}
   exact h.aemeasurable i
 
 /-- **The initial state together with the transition counts of a path is sufficient for its
-probability.** Rewriting the mixture identity through `TauCeti.prod_transitionCount` replaces the
+`μ`-mass.** Rewriting the mixture identity through `TauCeti.prod_transitionCount` replaces the
 transition-product factor by a product of powers indexed by the transition counts; the index set
 `S` only has to contain the letters of the path. -/
 theorem MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow {μ : Measure Ω}

--- a/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
+++ b/TauCeti/Probability/Exchangeability/MixedMarkovChain.lean
@@ -22,9 +22,9 @@ prefixLaw μ X (n + 1) {w} = ∫⁻ ω, ν ω {w 0} * ∏ i, κ ω (w i.castSucc
 
 for every finite path `w`. `MixedMarkovChainWith μ X ν κ` names the pair of witnesses, and
 `MixedMarkovChain μ X` is the existential wrapper. The naming and the witness/existential split
-follow `MixedIIDWith` / `MixedIID`. Among coordinatewise a.e.-measurable processes, this notion
-contains mixed i.i.d. processes: an i.i.d. mixture is the mixture of Markov chains whose rows do not
-depend on the current state (`MixedIIDWith.mixedMarkovChainWith`).
+follow `MixedIIDWith` / `MixedIID`. This notion contains mixed i.i.d. processes: an i.i.d. mixture
+is the mixture of Markov chains whose rows do not depend on the current state
+(`MixedIIDWith.mixedMarkovChainWith`).
 
 ⚠ Like `MixedIIDWith`, this is a property of the **unconditional** finite path laws only. It says
 nothing about the joint law of `(ν, κ, X)`, so it is not a conditional-independence statement, and
@@ -38,13 +38,12 @@ with the **easy direction** of that theorem, `MixedMarkovChainWith.markovExchang
 mixture of Markov chains is Markov exchangeable. The mechanism is the one that makes the initial
 state together with the transition counts sufficient for a Markov-chain path mass — the
 transition-product factor depends on the path only through its transition counts
-(`TauCeti.prod_transitionCount_congr`) — applied inside the mixing integral, where it holds
+(`TauCeti.prod_eq_of_transitionCount_eq`) — applied inside the mixing integral, where it holds
 pointwise in the mixing variable.
 
-Among coordinatewise a.e.-measurable processes, the class is strictly larger than the mixed i.i.d.
-one: the deterministic 3-cycle of `TauCeti/Probability/Exchangeability/ThreeCycle.lean` is a
-Markov chain, hence a mixture of Markov chains (`threeCycle_mixedMarkovChain`), but is not
-exchangeable and so not mixed i.i.d.
+The class is strictly larger than the mixed i.i.d. one: the deterministic 3-cycle of
+`TauCeti/Probability/Exchangeability/ThreeCycle.lean` is a Markov chain, hence a mixture of Markov
+chains (`threeCycle_mixedMarkovChain`), but is not exchangeable and so not mixed i.i.d.
 
 ## Main definitions
 
@@ -57,10 +56,10 @@ exchangeable and so not mixed i.i.d.
   initial state and transition counts of a path are sufficient for its `μ`-mass.
 * `TauCeti.Probability.MixedMarkovChainWith.markovExchangeable`: a mixture of Markov chains is
   Markov exchangeable — the easy direction of Diaconis–Freedman.
-* `TauCeti.Probability.mixedMarkovChainWith_const`: a single Markov chain is the degenerate
-  mixture.
-* `TauCeti.Probability.MixedIIDWith.mixedMarkovChainWith`: a coordinatewise a.e.-measurable mixed
-  i.i.d. process is a mixture of Markov chains with state-independent rows.
+* `TauCeti.Probability.mixedMarkovChainWith_const_of_prefixLaw_singleton_eq`: a single Markov chain
+  is the degenerate mixture.
+* `TauCeti.Probability.MixedIIDWith.mixedMarkovChainWith`: a mixed i.i.d. process is a mixture of
+  Markov chains with state-independent rows.
 
 ## References
 
@@ -89,7 +88,9 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 matrix `κ`: the `μ`-mass of a finite path is the `μ`-average of its Markov-chain path mass
 built from `ν ω` and `κ ω`. The countability and measurable-singleton conjuncts restrict this
 singleton-mass formulation to discrete state spaces, matching `MarkovExchangeable`, where it is
-non-vacuous and determines the finite path laws. -/
+non-vacuous and determines the finite path laws. Bundled alongside, as in `MarkovExchangeable`, are
+the regularity conjuncts the mixture identity is stated against: the process is coordinatewise a.e.
+measurable, and both witnesses are measurable (`ν`, and each row `ω ↦ κ ω a`). -/
 def MixedMarkovChainWith (μ : Measure Ω) (X : ℕ → Ω → α)
     (ν : Ω → ProbabilityMeasure α) (κ : Ω → α → ProbabilityMeasure α) : Prop :=
   Countable α ∧ MeasurableSingletonClass α ∧ (∀ i, AEMeasurable (X i) μ) ∧
@@ -146,7 +147,7 @@ theorem MixedMarkovChainWith.measurable_transitionMatrix {μ : Measure Ω} {X : 
 /-- The defining mixture identity: the `μ`-mass of a finite path is the `μ`-average of its
 Markov-chain path masses. -/
 @[grind =>]
-theorem MixedMarkovChainWith.prefixLaw_singleton {μ : Measure Ω} {X : ℕ → Ω → α}
+theorem MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral {μ : Measure Ω} {X : ℕ → Ω → α}
     {ν : Ω → ProbabilityMeasure α} {κ : Ω → α → ProbabilityMeasure α}
     (h : MixedMarkovChainWith μ X ν κ) (n : ℕ) (w : Fin (n + 1) → α) :
     prefixLaw μ X (n + 1) {w} =
@@ -166,7 +167,7 @@ theorem mixedMarkovChainWith_iff [Countable α] [MeasurableSingletonClass α]
             ∫⁻ ω, (ν ω : Measure α) {w 0} *
               ∏ i : Fin n, (κ ω (w i.castSucc) : Measure α) {w i.succ} ∂μ :=
   ⟨fun h => ⟨h.aemeasurable, h.measurable_initialLaw, h.measurable_transitionMatrix,
-      h.prefixLaw_singleton⟩,
+      h.prefixLaw_singleton_eq_lintegral⟩,
     fun h => MixedMarkovChainWith.intro h.1 h.2.1 h.2.2.1 h.2.2.2⟩
 
 /-- **A mixture of Markov chains**: existence of a random initial law and a random transition
@@ -225,7 +226,7 @@ theorem MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow {μ : Mea
     prefixLaw μ X (n + 1) {w} =
       ∫⁻ ω, (ν ω : Measure α) {w 0} *
         ∏ ab ∈ S ×ˢ S, (κ ω ab.1 : Measure α) {ab.2} ^ transitionCount w ab.1 ab.2 ∂μ := by
-  rw [h.prefixLaw_singleton n w]
+  rw [h.prefixLaw_singleton_eq_lintegral n w]
   refine lintegral_congr fun ω => ?_
   rw [prod_transitionCount w (fun i : Fin n => ⟨hS i.castSucc, hS i.succ⟩)
     fun a b => (κ ω a : Measure α) {b}]
@@ -242,9 +243,9 @@ theorem MixedMarkovChainWith.markovExchangeable {μ : Measure Ω} {X : ℕ → �
   have := h.measurableSingletonClass
   refine MarkovExchangeable.intro h.aemeasurable ?_
   intro n u v h0 hcount
-  rw [h.prefixLaw_singleton n u, h.prefixLaw_singleton n v]
+  rw [h.prefixLaw_singleton_eq_lintegral n u, h.prefixLaw_singleton_eq_lintegral n v]
   refine lintegral_congr fun ω => ?_
-  rw [h0, prod_transitionCount_congr hcount fun a b => (κ ω a : Measure α) {b}]
+  rw [h0, prod_eq_of_transitionCount_eq hcount fun a b => (κ ω a : Measure α) {b}]
 
 /-- **A mixture of Markov chains is Markov exchangeable**, existential form. -/
 theorem MixedMarkovChain.markovExchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -255,7 +256,8 @@ theorem MixedMarkovChain.markovExchangeable {μ : Measure Ω} {X : ℕ → Ω �
 /-- **A Markov chain is the degenerate mixture of Markov chains.** The hypothesis is the defining
 product form of the finite-dimensional laws of a Markov chain with initial law `p₀` and transition
 matrix `p`; the witnesses are the constant random objects. -/
-theorem mixedMarkovChainWith_const [Countable α] [MeasurableSingletonClass α]
+theorem mixedMarkovChainWith_const_of_prefixLaw_singleton_eq
+    [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} [IsProbabilityMeasure μ] {X : ℕ → Ω → α}
     (hX : ∀ i, AEMeasurable (X i) μ) (p₀ : ProbabilityMeasure α) (p : α → ProbabilityMeasure α)
     (h : ∀ (n : ℕ) (w : Fin (n + 1) → α),
@@ -265,30 +267,48 @@ theorem mixedMarkovChainWith_const [Countable α] [MeasurableSingletonClass α]
   MixedMarkovChainWith.intro hX measurable_const (fun _ => measurable_const) fun n w => by
     rw [h n w, lintegral_const, measure_univ, mul_one]
 
-/-- **A coordinatewise a.e.-measurable mixed i.i.d. process is a mixture of Markov chains** whose
-rows do not depend on the current state: drawing the next coordinate from the mixing
-representative, whatever the present one, reproduces the mixed i.i.d. finite-dimensional laws.
-Thus, among coordinatewise a.e.-measurable processes, this places `MixedIID` below
+/-- **A mixed i.i.d. process is a mixture of Markov chains** whose rows do not depend on the
+current state: drawing the next coordinate from the mixing representative, whatever the present
+one, reproduces the mixed i.i.d. finite-dimensional laws. Thus this places `MixedIID` below
 `MixedMarkovChain` in the symmetry lattice, refining `Exchangeable.markovExchangeable` at the
 level of the representations. -/
 theorem MixedIIDWith.mixedMarkovChainWith [Countable α] [MeasurableSingletonClass α]
     {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
-    (h : MixedIIDWith μ X ν) (hX : ∀ i, AEMeasurable (X i) μ) :
-    MixedMarkovChainWith μ X ν fun ω _ => ν ω := by
+    (h : MixedIIDWith μ X ν) : MixedMarkovChainWith μ X ν fun ω _ => ν ω := by
+  -- The mixture identity already forces coordinatewise a.e. measurability, by the argument of
+  -- `MixedIIDWith.aemeasurable_of_const`: a one-coordinate block law is a mixture of probability
+  -- measures, hence carries the total mass of `μ`, whereas `Measure.map` along a
+  -- non-a.e.-measurable function is `0`.
+  have hX : ∀ i, AEMeasurable (X i) μ := by
+    rcases eq_or_ne μ 0 with rfl | hμ
+    · exact fun _ => aemeasurable_zero_measure
+    intro i
+    have hblock := h.blockLaw_eq_mixture (fun _ : Fin 1 => i) fun a b _ => Subsingleton.elim a b
+    rw [blockLaw_def] at hblock
+    have hmass : (μ.bind fun ω => (ProbabilityMeasure.pi fun _ : Fin 1 => ν ω).toMeasure)
+        Set.univ = μ Set.univ := by
+      rw [Measure.bind_apply MeasurableSet.univ
+        (TauCeti.MeasureTheory.aemeasurable_probabilityMeasure_pi_const_toMeasure ν
+          h.measurable_mixingRepresentative.aemeasurable)]
+      simp
+    have hne : (μ.map fun ω (_ : Fin 1) => X i ω) ≠ 0 := by
+      rw [hblock]
+      intro hzero
+      rw [hzero] at hmass
+      exact Measure.measure_univ_ne_zero.2 hμ hmass.symm
+    exact (measurable_pi_apply 0).comp_aemeasurable (AEMeasurable.of_map_ne_zero hne)
   refine MixedMarkovChainWith.intro hX h.measurable_mixingRepresentative
     (fun _ => h.measurable_mixingRepresentative) fun n w => ?_
-  have hk : Function.Injective fun i : Fin (n + 1) => i.val := fun i j hij => Fin.ext hij
   rw [prefixLaw_def, ← Set.univ_pi_singleton w,
-    h.blockLaw_univ_pi _ hk (fun i => {w i}) fun i => measurableSet_singleton (w i)]
+    h.blockLaw_univ_pi (fun i : Fin (n + 1) => i.val) Fin.val_injective (fun i => {w i})
+      fun i => measurableSet_singleton (w i)]
   exact lintegral_congr fun ω => Fin.prod_univ_succ fun i => (ν ω : Measure α) {w i}
 
-/-- **A coordinatewise a.e.-measurable mixed i.i.d. process is a mixture of Markov chains**,
-existential form. -/
+/-- **A mixed i.i.d. process is a mixture of Markov chains**, existential form. -/
 theorem MixedIID.mixedMarkovChain [Countable α] [MeasurableSingletonClass α]
-    {μ : Measure Ω} {X : ℕ → Ω → α} (h : MixedIID μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
-    MixedMarkovChain μ X := by
+    {μ : Measure Ω} {X : ℕ → Ω → α} (h : MixedIID μ X) : MixedMarkovChain μ X := by
   obtain ⟨ν, hν⟩ := h.exists_mixingRepresentative
-  exact MixedMarkovChain.of_witnesses (hν.mixedMarkovChainWith hX)
+  exact MixedMarkovChain.of_witnesses hν.mixedMarkovChainWith
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/ThreeCycle.lean
+++ b/TauCeti/Probability/Exchangeability/ThreeCycle.lean
@@ -35,8 +35,8 @@ path of `ω + 1`, and the uniform law is translation invariant.
 It is a deterministic Markov chain, hence a mixture of Markov chains
 (`threeCycle_mixedMarkovChain`) and so Markov exchangeable (`threeCycle_markovExchangeable`); since
 it is not exchangeable, this is also the example showing that `Exchangeable` is strictly stronger
-than `MarkovExchangeable`, and — through `threeCycle_not_mixedIID` — that `MixedIID` is strictly
-stronger than `MixedMarkovChain`.
+than `MarkovExchangeable`, and — through `threeCycle_not_mixedIID` — that, among coordinatewise
+a.e.-measurable processes, `MixedIID` is strictly stronger than `MixedMarkovChain`.
 
 It is, however, neither exchangeable (`threeCycle_not_exchangeable`) nor contractable
 (`threeCycle_not_contractable`): the pair `(X₀, X₁) = (ω, ω + 1)` lands in
@@ -258,9 +258,9 @@ theorem threeCycle_mixedMarkovChainWith :
       exact congrArg _ (Finset.prod_congr rfl fun i _ =>
         (threeCycleStep_singleton (w i.castSucc) (w i.succ)).symm)
 
-/-- **The 3-cycle is a mixture of Markov chains.** With `threeCycle_not_mixedIID`, this separates
-`MixedMarkovChain` from `MixedIID`: mixing over Markov chains is strictly more general than mixing
-over i.i.d. laws. -/
+/-- **The 3-cycle is a mixture of Markov chains.** With `threeCycle_not_mixedIID`, this shows that,
+among coordinatewise a.e.-measurable processes, mixing over Markov chains is strictly more general
+than mixing over i.i.d. laws. -/
 theorem threeCycle_mixedMarkovChain : MixedMarkovChain threeCycleMeasure threeCycle :=
   MixedMarkovChain.of_witnesses threeCycle_mixedMarkovChainWith
 

--- a/TauCeti/Probability/Exchangeability/ThreeCycle.lean
+++ b/TauCeti/Probability/Exchangeability/ThreeCycle.lean
@@ -228,6 +228,8 @@ theorem threeCycleInitial_toMeasure :
     (threeCycleInitial : Measure (ZMod 3)) = threeCycleMeasure := by
   simp only [threeCycleInitial, ProbabilityMeasure.coe_mk]
 
+-- Not `@[simp]`: `threeCycleInitial_toMeasure` already simplifies this lemma's left-hand side, so
+-- the `simpNF` linter rejects the tag.
 /-- The bundled initial law gives mass `3⁻¹` to each singleton. -/
 theorem threeCycleInitial_singleton (a : ZMod 3) :
     (threeCycleInitial : Measure (ZMod 3)) {a} = 3⁻¹ := by
@@ -246,6 +248,8 @@ theorem threeCycleStep_toMeasure (a : ZMod 3) :
     (threeCycleStep a : Measure (ZMod 3)) = Measure.dirac (a + 1) := by
   simp only [threeCycleStep, diracProba, ProbabilityMeasure.coe_mk]
 
+-- Not `@[simp]`: `threeCycleStep_toMeasure` already simplifies this lemma's left-hand side, so the
+-- `simpNF` linter rejects the tag.
 /-- The deterministic step gives mass one to the successor state and mass zero to every other
 state. -/
 theorem threeCycleStep_singleton (a b : ZMod 3) :

--- a/TauCeti/Probability/Exchangeability/ThreeCycle.lean
+++ b/TauCeti/Probability/Exchangeability/ThreeCycle.lean
@@ -6,11 +6,13 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Exchangeability.Contractability
-public import TauCeti.Probability.Exchangeability.MarkovExchangeable
+public import TauCeti.Probability.Exchangeability.MixedMarkovChain
 public import TauCeti.Probability.Exchangeability.PathSpace.Shift
 public import Mathlib.MeasureTheory.Group.Measure
 public import Mathlib.Probability.UniformOn
 public import Mathlib.Data.ZMod.Basic
+-- Non-public: used only inside proofs — a mixed i.i.d. process is exchangeable.
+import TauCeti.Probability.Exchangeability.MixedIID.Implications
 
 /-!
 # A stationary process that is not exchangeable: the deterministic 3-cycle
@@ -30,9 +32,11 @@ its path law is invariant under the one-sided shift
 (`threeCycle_measurePreserving_shift`), because shifting the sample path of `ω` gives the sample
 path of `ω + 1`, and the uniform law is translation invariant.
 
-It is a deterministic Markov chain, hence Markov exchangeable
-(`threeCycle_markovExchangeable`); since it is not exchangeable, this is also the example showing
-that `Exchangeable` is strictly stronger than `MarkovExchangeable`.
+It is a deterministic Markov chain, hence a mixture of Markov chains
+(`threeCycle_mixedMarkovChain`) and so Markov exchangeable (`threeCycle_markovExchangeable`); since
+it is not exchangeable, this is also the example showing that `Exchangeable` is strictly stronger
+than `MarkovExchangeable`, and — through `threeCycle_not_mixedIID` — that `MixedIID` is strictly
+stronger than `MixedMarkovChain`.
 
 It is, however, neither exchangeable (`threeCycle_not_exchangeable`) nor contractable
 (`threeCycle_not_contractable`): the pair `(X₀, X₁) = (ω, ω + 1)` lands in
@@ -75,6 +79,10 @@ and stays scoped to this example, rather than leaking to the general `uniformOn 
 @[simp]
 theorem threeCycleMeasure_def : threeCycleMeasure = uniformOn Set.univ :=
   rfl
+
+/-- The stationary law of the 3-cycle is a probability measure. -/
+instance : IsProbabilityMeasure threeCycleMeasure :=
+  isProbabilityMeasure_uniformOn Set.finite_univ Set.univ_nonempty
 
 /-- The uniform law on `ZMod 3` is invariant under right addition, supplying the translation
 invariance used in the shift-stationarity proof. -/
@@ -215,6 +223,51 @@ theorem threeCycle_markovExchangeable : MarkovExchangeable threeCycleMeasure thr
   markovExchangeable_of_prefixLaw_singleton_eq (fun _ => Measurable.of_discrete.aemeasurable)
     (fun _ => 3⁻¹)
     (fun a b => if b = a + 1 then 1 else 0) threeCycle_prefixLaw_singleton
+
+/-- The uniform initial law of the 3-cycle, bundled as a probability measure. -/
+def threeCycleInitial : ProbabilityMeasure (ZMod 3) :=
+  ⟨threeCycleMeasure, inferInstance⟩
+
+/-- The bundled initial law gives mass `3⁻¹` to each singleton. -/
+theorem threeCycleInitial_singleton (a : ZMod 3) :
+    (threeCycleInitial : Measure (ZMod 3)) {a} = 3⁻¹ :=
+  threeCycleMeasure_singleton a
+
+/-- The deterministic transition matrix of the 3-cycle, sending the state `a` to the point mass at
+its successor `a + 1`. -/
+def threeCycleStep (a : ZMod 3) : ProbabilityMeasure (ZMod 3) :=
+  ⟨Measure.dirac (a + 1), inferInstance⟩
+
+/-- The deterministic step gives mass one to the successor state and mass zero to every other
+state. -/
+theorem threeCycleStep_singleton (a b : ZMod 3) :
+    (threeCycleStep a : Measure (ZMod 3)) {b} = if b = a + 1 then 1 else 0 := by
+  have h : (threeCycleStep a : Measure (ZMod 3)) = Measure.dirac (a + 1) := rfl
+  rw [h, Measure.dirac_apply]
+  simp [Set.indicator_apply, eq_comm]
+
+/-- **The 3-cycle is a mixture of Markov chains, with named witnesses** — degenerately, being a
+single Markov chain: the uniform initial law and the deterministic successor step reproduce its
+finite path laws. -/
+theorem threeCycle_mixedMarkovChainWith :
+    MixedMarkovChainWith threeCycleMeasure threeCycle (fun _ => threeCycleInitial)
+      fun _ => threeCycleStep :=
+  mixedMarkovChainWith_const
+    (fun _ => Measurable.of_discrete.aemeasurable) threeCycleInitial threeCycleStep fun n w => by
+      rw [threeCycle_prefixLaw_singleton n w, threeCycleInitial_singleton]
+      exact congrArg _ (Finset.prod_congr rfl fun i _ =>
+        (threeCycleStep_singleton (w i.castSucc) (w i.succ)).symm)
+
+/-- **The 3-cycle is a mixture of Markov chains.** With `threeCycle_not_mixedIID`, this separates
+`MixedMarkovChain` from `MixedIID`: mixing over Markov chains is strictly more general than mixing
+over i.i.d. laws. -/
+theorem threeCycle_mixedMarkovChain : MixedMarkovChain threeCycleMeasure threeCycle :=
+  MixedMarkovChain.of_witnesses threeCycle_mixedMarkovChainWith
+
+/-- **The 3-cycle is not mixed i.i.d.**, since a mixed i.i.d. process is exchangeable and the
+3-cycle is not. -/
+theorem threeCycle_not_mixedIID : ¬ MixedIID threeCycleMeasure threeCycle :=
+  fun h => threeCycle_not_exchangeable h.exchangeable
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/ThreeCycle.lean
+++ b/TauCeti/Probability/Exchangeability/ThreeCycle.lean
@@ -9,6 +9,7 @@ public import TauCeti.Probability.Exchangeability.Contractability
 public import TauCeti.Probability.Exchangeability.MixedMarkovChain
 public import TauCeti.Probability.Exchangeability.PathSpace.Shift
 public import Mathlib.MeasureTheory.Group.Measure
+public import Mathlib.MeasureTheory.Measure.DiracProba
 public import Mathlib.Probability.UniformOn
 public import Mathlib.Data.ZMod.Basic
 -- Non-public: used only inside proofs — a mixed i.i.d. process is exchangeable.
@@ -35,8 +36,8 @@ path of `ω + 1`, and the uniform law is translation invariant.
 It is a deterministic Markov chain, hence a mixture of Markov chains
 (`threeCycle_mixedMarkovChain`) and so Markov exchangeable (`threeCycle_markovExchangeable`); since
 it is not exchangeable, this is also the example showing that `Exchangeable` is strictly stronger
-than `MarkovExchangeable`, and — through `threeCycle_not_mixedIID` — that, among coordinatewise
-a.e.-measurable processes, `MixedIID` is strictly stronger than `MixedMarkovChain`.
+than `MarkovExchangeable`, and — through `threeCycle_not_mixedIID` — that `MixedIID` is strictly
+stronger than `MixedMarkovChain`.
 
 It is, however, neither exchangeable (`threeCycle_not_exchangeable`) nor contractable
 (`threeCycle_not_contractable`): the pair `(X₀, X₁) = (ω, ω + 1)` lands in
@@ -44,10 +45,11 @@ It is, however, neither exchangeable (`threeCycle_not_exchangeable`) nor contrac
 instead — produces a different two-dimensional law. This separates stationarity and
 shift-invariance from the symmetry notions, as the roadmap example asks.
 
-The example uses only the Layer 0 API (`Exchangeable`, `Contractable`, `pathLaw`, `blockLaw`,
-`shift`) together with Mathlib's translation invariance of the counting measure on a group
-(`MeasureTheory.map_add_right_eq_self`); it needs no material from
-`cameronfreer/exchangeability`.
+The example uses the Layer 0 API (`Exchangeable`, `Contractable`, `pathLaw`, `blockLaw`, `shift`)
+together with the Layer 8 `MarkovExchangeable` / `MixedMarkovChain` interface and `MixedIID`, and
+Mathlib's translation invariance of the counting measure on a group
+(`MeasureTheory.map_add_right_eq_self`) and its `MeasureTheory.diracProba`; it needs no material
+from `cameronfreer/exchangeability`.
 -/
 
 public section
@@ -216,34 +218,39 @@ theorem threeCycle_prefixLaw_singleton (n : ℕ) (w : Fin (n + 1) → ZMod 3) :
       ring
     rw [hmap, hset, measure_empty, hprod, mul_zero]
 
-/-- **The 3-cycle is Markov exchangeable.** It is a deterministic Markov chain, so its finite path
-probabilities factor through the transition counts. With `threeCycle_not_exchangeable`, this
-separates `MarkovExchangeable` from `Exchangeable`. -/
-theorem threeCycle_markovExchangeable : MarkovExchangeable threeCycleMeasure threeCycle :=
-  markovExchangeable_of_prefixLaw_singleton_eq (fun _ => Measurable.of_discrete.aemeasurable)
-    (fun _ => 3⁻¹)
-    (fun a b => if b = a + 1 then 1 else 0) threeCycle_prefixLaw_singleton
-
 /-- The uniform initial law of the 3-cycle, bundled as a probability measure. -/
 def threeCycleInitial : ProbabilityMeasure (ZMod 3) :=
   ⟨threeCycleMeasure, inferInstance⟩
 
+/-- The measure underlying the bundled initial law is `threeCycleMeasure`. -/
+@[simp]
+theorem threeCycleInitial_toMeasure :
+    (threeCycleInitial : Measure (ZMod 3)) = threeCycleMeasure := by
+  simp only [threeCycleInitial, ProbabilityMeasure.coe_mk]
+
 /-- The bundled initial law gives mass `3⁻¹` to each singleton. -/
 theorem threeCycleInitial_singleton (a : ZMod 3) :
-    (threeCycleInitial : Measure (ZMod 3)) {a} = 3⁻¹ :=
-  threeCycleMeasure_singleton a
+    (threeCycleInitial : Measure (ZMod 3)) {a} = 3⁻¹ := by
+  rw [threeCycleInitial_toMeasure]
+  exact threeCycleMeasure_singleton a
 
 /-- The deterministic transition matrix of the 3-cycle, sending the state `a` to the point mass at
 its successor `a + 1`. -/
 def threeCycleStep (a : ZMod 3) : ProbabilityMeasure (ZMod 3) :=
-  ⟨Measure.dirac (a + 1), inferInstance⟩
+  diracProba (a + 1)
+
+/-- The measure underlying the bundled deterministic step is the Dirac mass at the successor
+state. -/
+@[simp]
+theorem threeCycleStep_toMeasure (a : ZMod 3) :
+    (threeCycleStep a : Measure (ZMod 3)) = Measure.dirac (a + 1) := by
+  simp only [threeCycleStep, diracProba, ProbabilityMeasure.coe_mk]
 
 /-- The deterministic step gives mass one to the successor state and mass zero to every other
 state. -/
 theorem threeCycleStep_singleton (a b : ZMod 3) :
     (threeCycleStep a : Measure (ZMod 3)) {b} = if b = a + 1 then 1 else 0 := by
-  have h : (threeCycleStep a : Measure (ZMod 3)) = Measure.dirac (a + 1) := rfl
-  rw [h, Measure.dirac_apply]
+  rw [threeCycleStep_toMeasure, Measure.dirac_apply]
   simp [Set.indicator_apply, eq_comm]
 
 /-- **The 3-cycle is a mixture of Markov chains, with named witnesses** — degenerately, being a
@@ -252,17 +259,22 @@ finite path laws. -/
 theorem threeCycle_mixedMarkovChainWith :
     MixedMarkovChainWith threeCycleMeasure threeCycle (fun _ => threeCycleInitial)
       fun _ => threeCycleStep :=
-  mixedMarkovChainWith_const
+  mixedMarkovChainWith_const_of_prefixLaw_singleton_eq
     (fun _ => Measurable.of_discrete.aemeasurable) threeCycleInitial threeCycleStep fun n w => by
       rw [threeCycle_prefixLaw_singleton n w, threeCycleInitial_singleton]
       exact congrArg _ (Finset.prod_congr rfl fun i _ =>
         (threeCycleStep_singleton (w i.castSucc) (w i.succ)).symm)
 
-/-- **The 3-cycle is a mixture of Markov chains.** With `threeCycle_not_mixedIID`, this shows that,
-among coordinatewise a.e.-measurable processes, mixing over Markov chains is strictly more general
-than mixing over i.i.d. laws. -/
+/-- **The 3-cycle is a mixture of Markov chains.** With `threeCycle_not_mixedIID`, this shows that
+mixing over Markov chains is strictly more general than mixing over i.i.d. laws. -/
 theorem threeCycle_mixedMarkovChain : MixedMarkovChain threeCycleMeasure threeCycle :=
   MixedMarkovChain.of_witnesses threeCycle_mixedMarkovChainWith
+
+/-- **The 3-cycle is Markov exchangeable**, being a mixture of Markov chains: its finite path
+probabilities factor through the starting state and the transition counts. With
+`threeCycle_not_exchangeable`, this separates `MarkovExchangeable` from `Exchangeable`. -/
+theorem threeCycle_markovExchangeable : MarkovExchangeable threeCycleMeasure threeCycle :=
+  threeCycle_mixedMarkovChainWith.markovExchangeable
 
 /-- **The 3-cycle is not mixed i.i.d.**, since a mixed i.i.d. process is exchangeable and the
 3-cycle is not. -/


### PR DESCRIPTION
This PR defines mixtures of Markov chains and proves the easy direction of the Diaconis–Freedman representation theorem: every mixture of Markov chains is Markov exchangeable. `MarkovExchangeable` landed one day ago (TauCetiProject/TauCeti#3701) with the two elementary sources of the symmetry — an exchangeable process, and a single Markov chain — but the class that the representation theorem produces was not expressible, so neither the theorem's statement nor its easy half could be written down. `MixedMarkovChainWith μ X ν κ` supplies it: a random initial law `ν : Ω → ProbabilityMeasure α` and a random transition matrix `κ : Ω → α → ProbabilityMeasure α` with `prefixLaw μ X (n + 1) {w} = ∫⁻ ω, ν ω {w 0} * ∏ i, κ ω (w i.castSucc) {w i.succ} ∂μ` for every finite path `w`, and `MixedMarkovChain` is the existential wrapper. The witness/existential split, the bundled discrete-state conjuncts, and the accessor names follow `MixedIIDWith` / `MixedIID` and `MarkovExchangeable`; as there, the predicate constrains only the unconditional finite path laws, and the module docstring says so and names the conditional strengthening it deliberately is not.

The mathematics is `MixedMarkovChainWith.markovExchangeable`. Two paths with a common start and common transition counts have equal Markov-chain probabilities for every value of the mixing variable, because a product of transition weights along a path depends on the path only through its transition counts; averaging over the mixing variable preserves the equality. That pointwise fact is factored out of the existing `markovExchangeable_of_prefixLaw_singleton_eq` proof as `TauCeti.prod_transitionCount_congr`, a general statement about words over an arbitrary alphabet, and the old proof is shortened to a single rewrite through it. `MixedMarkovChainWith.prefixLaw_singleton_eq_lintegral_prod_pow` records the same mechanism positively: inside the mixing integral, the path probability is the initial mass times a product of transition weights raised to the transition counts, so the counts are a sufficient statistic.

Two arrows place the new class in the symmetry lattice. `mixedMarkovChainWith_const` is the degenerate mixture, so a single Markov chain is one. `MixedIIDWith.mixedMarkovChainWith` shows a mixed i.i.d. process is a mixture of Markov chains whose rows do not depend on the current state, which refines `Exchangeable.markovExchangeable` from the level of the symmetries to the level of the representations. That inclusion is strict, and the 3-cycle example file now proves it: `threeCycle_mixedMarkovChain` (through the named witnesses `threeCycleInitial` and `threeCycleStep`) against `threeCycle_not_mixedIID`, so mixing over Markov chains is genuinely more general than mixing over i.i.d. laws.

Milestone: Layer 8 of `TauCetiRoadmap/Exchangeability/README.md`, the "Markov exchangeability" bullet, whose target is the Diaconis–Freedman theorem that a recurrent Markov exchangeable process is a mixture of Markov chains. What remains after this PR is that hard converse: recurrence, the exchangeability of the successor sequence at each state, and the de Finetti application that produces the directing initial law and transition matrix.

Files: `TauCeti/Probability/Exchangeability/MixedMarkovChain.lean` (296 lines, new); `TauCeti/Combinatorics/Enumerative/TransitionCount.lean`, `TauCeti/Probability/Exchangeability/MarkovExchangeable.lean`, `TauCeti/Probability/Exchangeability/ThreeCycle.lean`, and the `TauCeti/Probability/Exchangeability.lean` facade (edited). No Mathlib source is vendored, and no material is adapted from `cameronfreer/exchangeability`, which treats exchangeable rather than Markov exchangeable sequences.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"mixedmarkovchainwith"}-->

🤖 Prepared with Claude Code
