### PR TITLE
feat: identify the tensor power of an endomorphism algebra

### DIFF
--- a/TauCeti/LinearAlgebra/PiTensorProduct/Hom.lean
+++ b/TauCeti/LinearAlgebra/PiTensorProduct/Hom.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
+public import Mathlib.LinearAlgebra.Matrix.ToLin
+public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
+
+/-!
+# The tensor product of hom modules is the hom module of the tensor products
+
+Mathlib's `PiTensorProduct.piTensorHomMap` is the canonical comparison map
+
+`⨂ᵢ (Mᵢ →ₗ Nᵢ) → (⨂ᵢ Mᵢ →ₗ ⨂ᵢ Nᵢ)`,  `⨂ᵢ fᵢ ↦ ⨂ᵢ mᵢ ↦ ⨂ᵢ fᵢ mᵢ`,
+
+defined for arbitrary families of modules over a commutative semiring. This file proves that it is
+**bijective** as soon as the index type is finite and every `Mᵢ` and every `Nᵢ` is finite free, and
+packages the result as the linear equivalence `PiTensorProduct.piTensorHomEquiv`.
+
+The proof is the basis computation. If `bᵢ` is a basis of `Mᵢ` indexed by `κᵢ` and `cᵢ` a basis of
+`Nᵢ` indexed by `νᵢ`, then `Module.Basis.linearMap` gives the matrix-unit basis of `Mᵢ →ₗ Nᵢ`
+indexed by `νᵢ × κᵢ`, and `Module.Basis.piTensorProduct` turns a family of bases into a basis of a
+tensor product. The comparison map carries the tensor of the matrix-unit bases to the matrix-unit
+basis of `⨂ᵢ Mᵢ →ₗ ⨂ᵢ Nᵢ` built from the two tensored bases, along the regrouping
+`(∀ i, νᵢ × κᵢ) ≃ (∀ i, νᵢ) × (∀ i, κᵢ)`; a linear map taking a basis bijectively to a basis is an
+isomorphism. Finiteness of the index type and of each basis is what gives the two sides matching
+bases at all, and it is used nowhere else.
+
+Taking `Nᵢ = Mᵢ` this identifies `End (⨂ᵢ Mᵢ)` with `⨂ᵢ End Mᵢ`, compatibly with composition
+(`PiTensorProduct.piTensorHomEquiv_tprod_comp_tprod`). That identification is the shape in which the
+commutant computations of Schur-Weyl duality are run: the endomorphisms of a tensor power commuting
+with the permutations of the factors are the invariants of the permutation action on the tensor
+power of the endomorphism algebra.
+
+## Main definitions
+
+* `PiTensorProduct.piTensorHomEquiv`: the comparison map as a linear equivalence, for a finite
+  index type and finite free modules.
+
+## Main results
+
+* `PiTensorProduct.piTensorHomMap_bijective_of_basis`: bijectivity of the comparison map from a
+  family of finite bases, the engine of the file.
+* `PiTensorProduct.piTensorHomMap_bijective`: bijectivity in the finite free formulation.
+* `PiTensorProduct.piTensorHomEquiv_tprod_comp_tprod`: the equivalence turns the factorwise
+  composition of two pure tensors of endomorphisms into the composition of their images.
+
+## References
+
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 8, "The double centralizer (image-level)". The commutant of the symmetric-group image in
+  `End (V^{⊗n})` is computed by transporting it through this isomorphism to the invariants of the
+  permutation action on `(End V)^{⊗n}`; the invariants are supplied by
+  `TauCeti/RepresentationTheory/Symmetric/TensorAction/Invariants.lean`, which names this
+  isomorphism as the comparison it is missing.
+* W. Fulton and J. Harris, *Representation Theory: A First Course*, Appendix B.1.
+-/
+
+public section
+
+open Module
+
+open scoped TensorProduct
+
+namespace PiTensorProduct
+
+universe uι uR uM uN uκ uν
+
+variable {ι : Type uι} {R : Type uR} {M : ι → Type uM} {N : ι → Type uN}
+  [CommSemiring R] [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
+  [∀ i, AddCommMonoid (N i)] [∀ i, Module R (N i)]
+
+section Bijective
+
+variable {κ : ι → Type uκ} {ν : ι → Type uν}
+
+/-- Regrouping a family of pairs as a pair of families. This is the reindexing along which the
+comparison map matches the matrix-unit basis of `⨂ᵢ (Mᵢ →ₗ Nᵢ)` with that of
+`⨂ᵢ Mᵢ →ₗ ⨂ᵢ Nᵢ`. -/
+private def piProdEquiv : (∀ i, ν i × κ i) ≃ (∀ i, ν i) × (∀ i, κ i) where
+  toFun p := (fun i => (p i).1, fun i => (p i).2)
+  invFun q i := (q.1 i, q.2 i)
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+variable [Finite ι] [∀ i, Finite (κ i)] [∀ i, Finite (ν i)]
+
+/-- **The comparison map is bijective**, given a finite basis of every `Mᵢ` and of every `Nᵢ`.
+
+The tensor of the matrix-unit bases of the `Mᵢ →ₗ Nᵢ` is carried to the matrix-unit basis of
+`⨂ᵢ Mᵢ →ₗ ⨂ᵢ Nᵢ`, up to the regrouping `(∀ i, νᵢ × κᵢ) ≃ (∀ i, νᵢ) × (∀ i, κᵢ)`. -/
+theorem piTensorHomMap_bijective_of_basis (b : ∀ i, Basis (κ i) R (M i))
+    (c : ∀ i, Basis (ν i) R (N i)) :
+    Function.Bijective (piTensorHomMap (R := R) (s := M) (t := N)) := by
+  classical
+  have : Fintype ι := Fintype.ofFinite ι
+  have : ∀ i, Fintype (κ i) := fun i => Fintype.ofFinite (κ i)
+  have : ∀ i, Fintype (ν i) := fun i => Fintype.ofFinite (ν i)
+  set B := Basis.piTensorProduct fun i => (b i).linearMap (c i) with hBdef
+  set C := (Basis.piTensorProduct b).linearMap (Basis.piTensorProduct c) with hCdef
+  -- The comparison map agrees with the basis-indexed equivalence on the basis `B`.
+  have hkey : (piTensorHomMap (R := R) (s := M) (t := N)) =
+      (B.equiv C piProdEquiv).toLinearMap := by
+    refine B.ext fun p => ?_
+    refine (Basis.piTensorProduct b).ext fun q => ?_
+    -- Both sides send `⨂ᵢ bᵢ (qᵢ)` to `⨂ᵢ cᵢ (pᵢ).1` when `q` matches the source indices of `p`,
+    -- and to zero otherwise. The matrix-unit lemma has to fire before the tensored bases are
+    -- unfolded, since it matches on a basis vector of the source.
+    rw [LinearEquiv.coe_coe, Basis.equiv_apply, hCdef, Basis.linearMap_apply_apply, hBdef]
+    simp only [Basis.piTensorProduct_apply, piTensorHomMap_tprod_tprod,
+      Basis.linearMap_apply_apply, piProdEquiv, Equiv.coe_fn_mk]
+    by_cases hpq : (fun i => (p i).2) = q
+    · subst hpq
+      simp
+    · rw [ite_eq_right hpq]
+      obtain ⟨i₀, hi₀⟩ := Function.ne_iff.mp hpq
+      refine (tprod R).map_coord_zero i₀ ?_
+      simp [hi₀]
+  rw [hkey]
+  exact (B.equiv C piProdEquiv).bijective
+
+end Bijective
+
+section Free
+
+variable [Finite ι] [∀ i, Module.Free R (M i)] [∀ i, Module.Finite R (M i)]
+  [∀ i, Module.Free R (N i)] [∀ i, Module.Finite R (N i)]
+
+/-- **The comparison map `⨂ᵢ (Mᵢ →ₗ Nᵢ) → (⨂ᵢ Mᵢ →ₗ ⨂ᵢ Nᵢ)` is bijective** over a finite index
+type when every `Mᵢ` and every `Nᵢ` is finite free. -/
+theorem piTensorHomMap_bijective :
+    Function.Bijective (piTensorHomMap (R := R) (s := M) (t := N)) :=
+  piTensorHomMap_bijective_of_basis (fun i => Module.Free.chooseBasis R (M i))
+    fun i => Module.Free.chooseBasis R (N i)
+
+variable (R M N) in
+/-- **The tensor product of the hom modules is the hom module of the tensor products.** The
+underlying map is `PiTensorProduct.piTensorHomMap`, so this is a statement about a canonical map
+and not about a choice of bases, even though the proof makes one. -/
+noncomputable def piTensorHomEquiv :
+    (⨂[R] i, M i →ₗ[R] N i) ≃ₗ[R] ((⨂[R] i, M i) →ₗ[R] ⨂[R] i, N i) :=
+  LinearEquiv.ofBijective piTensorHomMap piTensorHomMap_bijective
+
+/-- The equivalence acts as the comparison map it is built from. -/
+theorem piTensorHomEquiv_apply (x : ⨂[R] i, M i →ₗ[R] N i) :
+    piTensorHomEquiv R M N x = piTensorHomMap x :=
+  (rfl)
+
+/-- The equivalence and the comparison map have the same underlying function. -/
+theorem coe_piTensorHomEquiv :
+    ⇑(piTensorHomEquiv R M N) = ⇑(piTensorHomMap (R := R) (s := M) (t := N)) :=
+  (rfl)
+
+/-- On a pure tensor of linear maps the equivalence is `PiTensorProduct.map`. -/
+@[simp]
+theorem piTensorHomEquiv_tprod (f : ∀ i, M i →ₗ[R] N i) :
+    piTensorHomEquiv R M N (tprod R f) = map f := by
+  rw [piTensorHomEquiv_apply, piTensorHomMap_tprod_eq_map]
+
+/-- The inverse of the equivalence takes the factorwise map back to the pure tensor. -/
+@[simp]
+theorem piTensorHomEquiv_symm_map (f : ∀ i, M i →ₗ[R] N i) :
+    (piTensorHomEquiv R M N).symm (map f) = tprod R f :=
+  (LinearEquiv.symm_apply_eq _).mpr (piTensorHomEquiv_tprod f).symm
+
+end Free
+
+section End
+
+variable [Finite ι] [∀ i, Module.Free R (M i)] [∀ i, Module.Finite R (M i)]
+
+/-- **The equivalence is multiplicative on pure tensors of endomorphisms**: composing factorwise
+and then comparing is comparing and then composing. This is what makes the identification usable
+on the subalgebras of `End (⨂ᵢ Mᵢ)` that Schur-Weyl duality is about. -/
+theorem piTensorHomEquiv_tprod_comp_tprod (f g : ∀ i, M i →ₗ[R] M i) :
+    piTensorHomEquiv R M M (tprod R fun i => f i ∘ₗ g i) =
+      piTensorHomEquiv R M M (tprod R f) ∘ₗ piTensorHomEquiv R M M (tprod R g) := by
+  simp [map_comp]
+
+end End
+
+end PiTensorProduct

--- a/TauCeti/LinearAlgebra/PiTensorProduct/Hom.lean
+++ b/TauCeti/LinearAlgebra/PiTensorProduct/Hom.lean
@@ -144,7 +144,11 @@ noncomputable def piTensorHomEquiv :
     (⨂[R] i, M i →ₗ[R] N i) ≃ₗ[R] ((⨂[R] i, M i) →ₗ[R] ⨂[R] i, N i) :=
   LinearEquiv.ofBijective piTensorHomMap piTensorHomMap_bijective
 
-/-- The equivalence acts as the comparison map it is built from. -/
+/-- The equivalence acts as the comparison map it is built from. The priority is low so that the
+more specific `PiTensorProduct.piTensorHomEquiv_tprod` still reaches its own normal form
+`PiTensorProduct.map` on a pure tensor, which this rule would otherwise strand at
+`PiTensorProduct.piTensorHomMap`. -/
+@[simp low]
 theorem piTensorHomEquiv_apply (x : ⨂[R] i, M i →ₗ[R] N i) :
     piTensorHomEquiv R M N x = piTensorHomMap x :=
   (rfl)

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/Centralizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/Centralizer.lean
@@ -57,9 +57,18 @@ namespace PiTensorProduct
 
 universe u v w
 
+section Semiring
+
 variable {R : Type u} {M : Type v} {ι : Type w}
-variable [CommRing R] [AddCommGroup M] [Module R M] [Finite ι]
-  [Module.Free R M] [Module.Finite R M]
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
+
+/-- Permuting the factors is invertible: the operators of the permutation representation compose to
+the identity along inverse permutations. -/
+private theorem reindexRepresentation_mul_inv (σ : Equiv.Perm ι) :
+    reindexRepresentation R M ι σ * reindexRepresentation R M ι σ⁻¹ = 1 := by
+  rw [← map_mul, mul_inv_cancel, map_one]
+
+variable [Finite ι] [Module.Free R M] [Module.Finite R M]
 
 /-- **The comparison isomorphism carries a permuted pure tensor to the conjugated map.** This is
 the pure-tensor case of `PiTensorProduct.piTensorHomEquiv_reindexRepresentation_mul`, and is
@@ -93,14 +102,13 @@ theorem piTensorHomEquiv_reindexRepresentation_mul (σ : Equiv.Perm ι)
   | add x y hx hy =>
     rw [map_add, LinearEquiv.map_add, LinearEquiv.map_add, add_mul, mul_add, hx, hy]
 
-omit [Finite ι] [Module.Free R M] [Module.Finite R M] in
-/-- Permuting the factors is invertible: the operators of the permutation representation compose to
-the identity along inverse permutations. -/
-private theorem reindexRepresentation_mul_inv (σ : Equiv.Perm ι) :
-    reindexRepresentation R M ι σ * reindexRepresentation R M ι σ⁻¹ = 1 := by
-  rw [← map_mul, mul_inv_cancel, map_one]
+end Semiring
 
-variable [Fintype ι]
+section Ring
+
+variable {R : Type u} {M : Type v} {ι : Type w}
+variable [CommRing R] [AddCommGroup M] [Module R M] [Fintype ι]
+  [Module.Free R M] [Module.Finite R M]
 
 /-- **The commutant of the permutation action on a tensor power is the span of the diagonal
 operators.** For a finite free module `M` and `(#ι)!` invertible in `R`, an endomorphism of
@@ -137,6 +145,8 @@ theorem mem_span_range_map_const_iff_forall_commute (h : IsUnit ((Fintype.card �
     have hcancel := congrArg (· * reindexRepresentation R M ι σ⁻¹) (hkey.trans hcomm.symm)
     simp only [mul_assoc, reindexRepresentation_mul_inv, mul_one] at hcancel
     exact hcancel
+
+end Ring
 
 end PiTensorProduct
 

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/Centralizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/Centralizer.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.PiTensorProduct.Hom
+public import TauCeti.RepresentationTheory.Symmetric.TensorAction.Invariants
+
+/-!
+# The commutant of the permutation action on a tensor power
+
+The symmetric group of `ι` acts on `⨂[R] (_ : ι), M` by permuting the tensor factors, and every
+**diagonal** endomorphism `f^{⊗ι} = PiTensorProduct.map (fun _ ↦ f)` commutes with that action
+(`PiTensorProduct.commute_reindexRepresentation_map`). This file proves the converse when `M` is
+finite free and `(#ι)!` is invertible in `R`: an endomorphism of the tensor power commuting with
+all the factor permutations is an `R`-linear combination of diagonal ones.
+
+That is one half of the double centralizer of Schur-Weyl duality, at the level of image
+subalgebras: the commutant of the image of `R[S_ι]` in `End (M^{⊗ι})` is the span of the diagonal
+operators, through which the general linear group acts.
+
+The proof runs the computation on the other side of the comparison isomorphism
+`PiTensorProduct.piTensorHomEquiv`, which identifies `End (M^{⊗ι})` with `(End M)^{⊗ι}`. Under that
+identification conjugation by a factor permutation on `End (M^{⊗ι})` becomes the permutation action
+on `(End M)^{⊗ι}`, so a commuting endomorphism is an invariant tensor; and the invariants of a
+permutation action are the span of the pure powers
+(`PiTensorProduct.invariants_reindexRepresentation`), which are exactly the diagonal operators.
+Both hypotheses are used once: freeness and finiteness make the comparison map an isomorphism, and
+the invertibility of `(#ι)!` is what averaging over the symmetric group needs.
+
+## Main results
+
+* `PiTensorProduct.piTensorHomEquiv_reindexRepresentation_mul`: the comparison isomorphism
+  intertwines the permutation action on `(End M)^{⊗ι}` with conjugation by the factor permutations
+  on `End (M^{⊗ι})`.
+* `PiTensorProduct.mem_span_range_map_const_iff_forall_commute`: **the commutant of the permutation
+  action is the span of the diagonal operators.**
+* `TauCeti.mem_span_range_map_const_iff_forall_commute_permTensorAction`: the same statement in the
+  Schur-Weyl setting `M = Rⁿ`, `ι = Fin d`, where the invertibility hypothesis reads `d !`.
+
+## References
+
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 8, "The double centralizer (image-level)", whose first half asks for exactly the commutant
+  of the symmetric-group image inside `End (V^{⊗n})`. The other half, that the commutant of the
+  diagonal operators is the symmetric-group image, is not proved here.
+* W. Fulton and J. Harris, *Representation Theory: A First Course*, Lecture 6 and Appendix B.1.
+-/
+
+public section
+
+open scoped Nat TensorProduct
+
+namespace PiTensorProduct
+
+universe u v w
+
+variable {R : Type u} {M : Type v} {ι : Type w}
+variable [CommRing R] [AddCommGroup M] [Module R M] [Finite ι]
+  [Module.Free R M] [Module.Finite R M]
+
+/-- **The comparison isomorphism carries a permuted pure tensor to the conjugated map.** This is
+the pure-tensor case of `PiTensorProduct.piTensorHomEquiv_reindexRepresentation_mul`, and is
+Mathlib's compatibility of `PiTensorProduct.map` with `PiTensorProduct.reindex`. -/
+theorem piTensorHomEquiv_reindexRepresentation_tprod_mul (σ : Equiv.Perm ι)
+    (f : ι → (M →ₗ[R] M)) :
+    piTensorHomEquiv R (fun _ : ι => M) (fun _ : ι => M)
+          (reindexRepresentation R (M →ₗ[R] M) ι σ (tprod R f)) *
+        reindexRepresentation R M ι σ =
+      reindexRepresentation R M ι σ *
+        piTensorHomEquiv R (fun _ : ι => M) (fun _ : ι => M) (tprod R f) := by
+  rw [reindexRepresentation_apply, LinearEquiv.coe_toLinearMap, reindex_tprod,
+    piTensorHomEquiv_tprod, piTensorHomEquiv_tprod, reindexRepresentation_apply,
+    Module.End.mul_eq_comp, Module.End.mul_eq_comp]
+  exact map_comp_reindex_eq f σ
+
+/-- **The comparison isomorphism intertwines the two actions.** Permuting the factors of a tensor
+of endomorphisms is conjugating the corresponding endomorphism of the tensor power by the
+permutation of the factors. -/
+theorem piTensorHomEquiv_reindexRepresentation_mul (σ : Equiv.Perm ι)
+    (x : ⨂[R] _ : ι, M →ₗ[R] M) :
+    piTensorHomEquiv R (fun _ : ι => M) (fun _ : ι => M)
+          (reindexRepresentation R (M →ₗ[R] M) ι σ x) *
+        reindexRepresentation R M ι σ =
+      reindexRepresentation R M ι σ *
+        piTensorHomEquiv R (fun _ : ι => M) (fun _ : ι => M) x := by
+  induction x using PiTensorProduct.induction_on with
+  | smul_tprod r f =>
+    rw [map_smul, LinearEquiv.map_smul, LinearEquiv.map_smul, smul_mul_assoc, mul_smul_comm,
+      piTensorHomEquiv_reindexRepresentation_tprod_mul]
+  | add x y hx hy =>
+    rw [map_add, LinearEquiv.map_add, LinearEquiv.map_add, add_mul, mul_add, hx, hy]
+
+omit [Finite ι] [Module.Free R M] [Module.Finite R M] in
+/-- Permuting the factors is invertible: the operators of the permutation representation compose to
+the identity along inverse permutations. -/
+private theorem reindexRepresentation_mul_inv (σ : Equiv.Perm ι) :
+    reindexRepresentation R M ι σ * reindexRepresentation R M ι σ⁻¹ = 1 := by
+  rw [← map_mul, mul_inv_cancel, map_one]
+
+variable [Fintype ι]
+
+/-- **The commutant of the permutation action on a tensor power is the span of the diagonal
+operators.** For a finite free module `M` and `(#ι)!` invertible in `R`, an endomorphism of
+`⨂[R] (_ : ι), M` commutes with every permutation of the tensor factors exactly when it is an
+`R`-linear combination of the operators `f^{⊗ι}` applying one endomorphism `f` in every factor.
+
+One direction is `PiTensorProduct.commute_reindexRepresentation_map`; the substance is the other,
+which says that the diagonal operators already exhaust the commutant. -/
+theorem mem_span_range_map_const_iff_forall_commute (h : IsUnit ((Fintype.card ι)! : R))
+    (T : (⨂[R] _ : ι, M) →ₗ[R] ⨂[R] _ : ι, M) :
+    T ∈ Submodule.span R (Set.range fun f : M →ₗ[R] M => map fun _ : ι => f) ↔
+      ∀ σ : Equiv.Perm ι, Commute T (reindexRepresentation R M ι σ) := by
+  -- The diagonal operators are the images of the pure powers of endomorphisms.
+  have hdiag : (fun f : M →ₗ[R] M => map fun _ : ι => f) =
+      ⇑(piTensorHomEquiv R (fun _ : ι => M) (fun _ : ι => M)).toLinearMap ∘
+        fun f : M →ₗ[R] M => ⨂ₜ[R] (_ : ι), f := by
+    funext f
+    simp
+  -- So their span is the image of the invariants under the comparison map.
+  have hspan : Submodule.span R (Set.range fun f : M →ₗ[R] M => map fun _ : ι => f) =
+      Submodule.map (piTensorHomEquiv R (fun _ : ι => M) (fun _ : ι => M)).toLinearMap
+        (reindexRepresentation R (M →ₗ[R] M) ι).invariants := by
+    rw [invariants_reindexRepresentation h, Submodule.map_span, ← Set.range_comp, hdiag]
+  rw [hspan, Submodule.mem_map_equiv, Representation.mem_invariants]
+  refine forall_congr' fun σ => ?_
+  -- Being fixed by `σ` is, after comparison, commuting with the permutation of the factors.
+  have hkey := piTensorHomEquiv_reindexRepresentation_mul σ
+    ((piTensorHomEquiv R (fun _ : ι => M) (fun _ : ι => M)).symm T)
+  rw [LinearEquiv.apply_symm_apply] at hkey
+  refine ⟨fun hfix => ?_, fun hcomm => ?_⟩
+  · rw [Commute, SemiconjBy, ← hkey, hfix, LinearEquiv.apply_symm_apply]
+  · refine (piTensorHomEquiv R (fun _ : ι => M) (fun _ : ι => M)).injective ?_
+    rw [LinearEquiv.apply_symm_apply]
+    have hcancel := congrArg (· * reindexRepresentation R M ι σ⁻¹) (hkey.trans hcomm.symm)
+    simp only [mul_assoc, reindexRepresentation_mul_inv, mul_one] at hcancel
+    exact hcancel
+
+end PiTensorProduct
+
+namespace TauCeti
+
+open PiTensorProduct
+
+variable {R : Type*} {n d : ℕ} [CommRing R]
+
+/-- **The commutant of the symmetric group on `(Rⁿ)^{⊗d}`**, the Schur-Weyl reading of
+`PiTensorProduct.mem_span_range_map_const_iff_forall_commute`: when `d !` is invertible in `R`, the
+endomorphisms of `(Rⁿ)^{⊗d}` commuting with the permutations of the tensor factors are exactly the
+`R`-linear combinations of the diagonal operators `f^{⊗d}`, through which the general linear group
+acts. -/
+theorem mem_span_range_map_const_iff_forall_commute_permTensorAction (h : IsUnit (d ! : R))
+    (T : (⨂[R] _ : Fin d, Fin n → R) →ₗ[R] ⨂[R] _ : Fin d, Fin n → R) :
+    T ∈ Submodule.span R
+        (Set.range fun f : (Fin n → R) →ₗ[R] (Fin n → R) => map fun _ : Fin d => f) ↔
+      ∀ σ : Equiv.Perm (Fin d), Commute T (permTensorAction R n d σ) := by
+  rw [permTensorAction_def]
+  exact mem_span_range_map_const_iff_forall_commute (by rwa [Fintype.card_fin]) T
+
+end TauCeti


### PR DESCRIPTION
This PR proves that Mathlib's comparison map `PiTensorProduct.piTensorHomMap`, `⨂ᵢ (Mᵢ →ₗ Nᵢ) → (⨂ᵢ Mᵢ →ₗ ⨂ᵢ Nᵢ)`, is bijective as soon as the index type is finite and every `Mᵢ` and `Nᵢ` is finite free, packages it as the linear equivalence `PiTensorProduct.piTensorHomEquiv`, and uses the constant-family case — the identification of `End (M^{⊗ι})` with `(End M)^{⊗ι}` — to compute the commutant of the permutation action on a tensor power: for `M` finite free and `(#ι)!` invertible in `R`, an endomorphism of `⨂[R] (_ : ι), M` commutes with every permutation of the tensor factors exactly when it is an `R`-linear combination of the diagonal operators `f^{⊗ι} = PiTensorProduct.map (fun _ ↦ f)`. That is the first half of the target "The double centralizer (image-level)" in Layer 8 of `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, which asks for the commutant of the symmetric-group image inside `End (V^{⊗n})`; the reverse inclusion, that the commutant of the diagonal operators is the symmetric-group image, is not proved here.

The comparison isomorphism is the brick the existing `TauCeti/RepresentationTheory/Symmetric/TensorAction/Invariants.lean` names but does not supply: its header says that for finite `ι` and finite free `V` "the canonical map `(End V)^{⊗ι} → End (V^{⊗ι})` is an isomorphism", and its main theorem `PiTensorProduct.invariants_reindexRepresentation` computes exactly the invariants that the commutant corresponds to under that isomorphism. Bijectivity is proved by the basis computation: `Module.Basis.linearMap` gives the matrix-unit basis of each `Mᵢ →ₗ Nᵢ`, `Module.Basis.piTensorProduct` tensors a family of bases, and the comparison map carries one matrix-unit basis to the other along the regrouping `(∀ i, νᵢ × κᵢ) ≃ (∀ i, νᵢ) × (∀ i, κᵢ)`. The commutant statement then follows by transporting the permutation action through the isomorphism, where conjugation by a factor permutation becomes the permutation action on `(End M)^{⊗ι}`; the transport is Mathlib's `PiTensorProduct.map_comp_reindex_eq` on pure tensors, spread over the tensor power by linearity. Both new files are new; nothing was vendored from Mathlib. The Schur-Weyl reading `TauCeti.mem_span_range_map_const_iff_forall_commute_permTensorAction`, for `M = Rⁿ` and `ι = Fin d` with `d !` invertible, is stated against the existing `TauCeti.permTensorAction`.

Files added: `TauCeti/LinearAlgebra/PiTensorProduct/Hom.lean` (185 lines) and `TauCeti/RepresentationTheory/Symmetric/TensorAction/Centralizer.lean` (162 lines). `lake build`, `lake exe axioms`, `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` and `scripts/lint-env.sh` are all green locally, with no new environment-linter violations.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"pitensorhomequiv"}-->

🤖 Prepared with Claude Code

