### PR TITLE
feat: the field Frobenius of a Lie-type index and its fixed field

### DIFF
--- a/TauCeti/Algebra/CharP/FrobeniusFixed.lean
+++ b/TauCeti/Algebra/CharP/FrobeniusFixed.lean
@@ -37,7 +37,8 @@ and the subfield ones about an arbitrary field of exponential characteristic `p`
 * `TauCeti.mem_frobeniusFixedSubring`: membership is the equation `a ^ p ^ n = a`.
 * `TauCeti.mem_frobeniusFixedSubring_mul_iff_iterate_eq`: at exponent `m * k`, membership is being
   fixed by the `k`-th iterate of the `p ^ m`-power Frobenius.
-* `TauCeti.frobeniusFixedSubring_zero`: the zeroth iterate fixes everything.
+* `TauCeti.frobeniusFixedSubring_zero` and `TauCeti.frobeniusFixedSubfield_zero`: the zeroth
+  iterate fixes everything.
 * `TauCeti.frobeniusFixedSubring_le_of_dvd` and `TauCeti.frobeniusFixedSubfield_le_of_dvd`: the
   fixed subrings and subfields grow along divisibility of the exponent, the inclusion
   `𝔽_{p ^ m} ⊆ 𝔽_{p ^ k}` in the motivating case.
@@ -157,6 +158,12 @@ variable (K p n)
 @[simp]
 theorem toSubring_frobeniusFixedSubfield :
     (frobeniusFixedSubfield K p n).toSubring = frobeniusFixedSubring K p n := (rfl)
+
+/-- The zeroth Frobenius iterate is the identity, so it fixes every element. -/
+@[simp]
+theorem frobeniusFixedSubfield_zero : frobeniusFixedSubfield K p 0 = ⊤ := by
+  ext a
+  simp
 
 variable {K p n}
 

--- a/TauCeti/Algebra/CharP/FrobeniusFixed.lean
+++ b/TauCeti/Algebra/CharP/FrobeniusFixed.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.CharP.Algebra
 public import Mathlib.Algebra.CharP.Frobenius
+public import Mathlib.Algebra.Field.Subfield.Basic
 public import Mathlib.Algebra.Ring.Subring.Basic
 
 /-!
@@ -15,7 +16,8 @@ public import Mathlib.Algebra.Ring.Subring.Basic
 Let `A` be a commutative ring of exponential characteristic `p` and let `q = p ^ n`. The elements
 of `A` satisfying `a ^ q = a` are the equalizer of the ring homomorphism `iterateFrobenius A p n`
 and the identity, hence a subring: this file names it `TauCeti.frobeniusFixedSubring` and records
-its elementary properties.
+its elementary properties. Over a field the equalizer is closed under inverses as well, giving
+`TauCeti.frobeniusFixedSubfield`.
 
 For `p` prime, `0 < n` and `A` an algebraic closure of `ZMod p` this subring is the field of `q`
 elements sitting inside `A`, which is why the construction is the ring-theoretic half of "the fixed
@@ -27,13 +29,15 @@ Mathlib's `iterateFrobenius` supplies every proof.
 ## Main definitions
 
 * `TauCeti.frobeniusFixedSubring`: the subring of elements fixed by the `p ^ n`-power Frobenius.
+* `TauCeti.frobeniusFixedSubfield`: the same elements of a field, as a subfield.
 
 ## Main results
 
 * `TauCeti.mem_frobeniusFixedSubring`: membership is the equation `a ^ p ^ n = a`.
 * `TauCeti.frobeniusFixedSubring_zero`: the zeroth iterate fixes everything.
-* `TauCeti.frobeniusFixedSubring_le_of_dvd`: the fixed subrings grow along divisibility of the
-  exponent, the inclusion `𝔽_{p ^ m} ⊆ 𝔽_{p ^ k}` in the motivating case.
+* `TauCeti.frobeniusFixedSubring_le_of_dvd` and `TauCeti.frobeniusFixedSubfield_le_of_dvd`: the
+  fixed subrings and subfields grow along divisibility of the exponent, the inclusion
+  `𝔽_{p ^ m} ⊆ 𝔽_{p ^ k}` in the motivating case.
 * `TauCeti.map_le_frobeniusFixedSubring`: a ring homomorphism carries fixed elements to fixed
   elements.
 
@@ -47,6 +51,8 @@ field endomorphism is the `q`-power Frobenius.
 public section
 
 namespace TauCeti
+
+section Ring
 
 variable (A : Type*) [CommRing A] (p n : ℕ) [ExpChar A p]
 
@@ -112,5 +118,48 @@ theorem map_le_frobeniusFixedSubring (φ : A →+* B) :
 theorem map_mem_frobeniusFixedSubring (φ : A →+* B) {a : A}
     (ha : a ∈ frobeniusFixedSubring A p n) : φ a ∈ frobeniusFixedSubring B p n :=
   map_le_frobeniusFixedSubring φ ⟨a, ha, rfl⟩
+
+end Ring
+
+section Field
+
+variable (K : Type*) [Field K] (p n : ℕ) [ExpChar K p]
+
+/-- The subfield of elements of a field `K` fixed by the `p ^ n`-power Frobenius, that is, the
+solutions of `a ^ p ^ n = a`. It is the equalizer of `iterateFrobenius K p n` with the identity,
+taken as a subfield: over a field the equalizer is closed under inverses, since
+`(a⁻¹) ^ p ^ n = (a ^ p ^ n)⁻¹`.
+
+As with the subring, nothing about finiteness is asserted at this level of generality: at `n = 0`,
+or in characteristic zero, it is the whole of `K`. -/
+def frobeniusFixedSubfield : Subfield K :=
+  (iterateFrobenius K p n).eqLocusField (RingHom.id K)
+
+variable {K p n}
+
+/-- Membership in the Frobenius-fixed subfield is the equation `a ^ p ^ n = a`. -/
+@[simp]
+theorem mem_frobeniusFixedSubfield {a : K} :
+    a ∈ frobeniusFixedSubfield K p n ↔ a ^ p ^ n = a := Iff.rfl
+
+variable (K p n)
+
+/-- The Frobenius-fixed subfield has the Frobenius-fixed subring as its underlying subring. -/
+@[simp]
+theorem toSubring_frobeniusFixedSubfield :
+    (frobeniusFixedSubfield K p n).toSubring = frobeniusFixedSubring K p n := (rfl)
+
+variable {K p n}
+
+/-- Fixed subfields grow along divisibility of the exponent, the subfield form of
+`frobeniusFixedSubring_le_of_dvd`: in the motivating case this is the inclusion
+`𝔽_{p ^ m} ⊆ 𝔽_{p ^ k}` of subfields of an algebraic closure. -/
+theorem frobeniusFixedSubfield_le_of_dvd {m k : ℕ} (h : m ∣ k) :
+    frobeniusFixedSubfield K p m ≤ frobeniusFixedSubfield K p k := fun _ ha =>
+  mem_frobeniusFixedSubfield.mpr (mem_frobeniusFixedSubring.mp
+    (frobeniusFixedSubring_le_of_dvd h (mem_frobeniusFixedSubring.mpr
+      (mem_frobeniusFixedSubfield.mp ha))))
+
+end Field
 
 end TauCeti

--- a/TauCeti/Algebra/CharP/FrobeniusFixed.lean
+++ b/TauCeti/Algebra/CharP/FrobeniusFixed.lean
@@ -11,7 +11,7 @@ public import Mathlib.Algebra.Field.Subfield.Basic
 public import Mathlib.Algebra.Ring.Subring.Basic
 
 /-!
-# The subring fixed by an iterated Frobenius
+# The subring and subfield fixed by an iterated Frobenius
 
 Let `A` be a commutative ring of exponential characteristic `p` and let `q = p ^ n`. The elements
 of `A` satisfying `a ^ q = a` are the equalizer of the ring homomorphism `iterateFrobenius A p n`
@@ -23,8 +23,9 @@ For `p` prime, `0 < n` and `A` an algebraic closure of `ZMod p` this subring is 
 elements sitting inside `A`, which is why the construction is the ring-theoretic half of "the fixed
 points of the `q`-power Frobenius are the `𝔽_q`-points"; at `n = 0` it is instead the whole of `A`,
 since `q = 1`. Nothing about finiteness or about the field of `q` elements is proved here: the
-statements below are about an arbitrary commutative ring of exponential characteristic `p`, and
-Mathlib's `iterateFrobenius` supplies every proof.
+subring statements below are about an arbitrary commutative ring of exponential characteristic `p`
+and the subfield ones about an arbitrary field of exponential characteristic `p`, and Mathlib's
+`iterateFrobenius` supplies every proof.
 
 ## Main definitions
 
@@ -34,6 +35,8 @@ Mathlib's `iterateFrobenius` supplies every proof.
 ## Main results
 
 * `TauCeti.mem_frobeniusFixedSubring`: membership is the equation `a ^ p ^ n = a`.
+* `TauCeti.mem_frobeniusFixedSubring_mul_iff_iterate_eq`: at exponent `m * k`, membership is being
+  fixed by the `k`-th iterate of the `p ^ m`-power Frobenius.
 * `TauCeti.frobeniusFixedSubring_zero`: the zeroth iterate fixes everything.
 * `TauCeti.frobeniusFixedSubring_le_of_dvd` and `TauCeti.frobeniusFixedSubfield_le_of_dvd`: the
   fixed subrings and subfields grow along divisibility of the exponent, the inclusion
@@ -80,6 +83,13 @@ variable {A p n}
 theorem mem_frobeniusFixedSubring {a : A} :
     a ∈ frobeniusFixedSubring A p n ↔ a ^ p ^ n = a := Iff.rfl
 
+/-- At an exponent `m * k`, being fixed by the `p ^ (m * k)`-power Frobenius is being fixed by the
+`k`-th iterate of the `p ^ m`-power one, since that iterate *is* the `p ^ (m * k)`-power
+Frobenius. -/
+theorem mem_frobeniusFixedSubring_mul_iff_iterate_eq {m k : ℕ} {a : A} :
+    a ∈ frobeniusFixedSubring A p (m * k) ↔ (iterateFrobenius A p m)^[k] a = a := by
+  rw [mem_frobeniusFixedSubring, ← iterateFrobenius_def, iterateFrobenius_mul_apply]
+
 variable (A p n)
 
 /-- The zeroth Frobenius iterate is the identity, so it fixes every element. -/
@@ -99,9 +109,8 @@ theorem frobeniusFixedSubring_le_of_dvd {m k : ℕ} (h : m ∣ k) :
   intro a ha
   -- membership is `RingHom.eqLocus` membership by definition, so it *is* the equation
   -- `iterateFrobenius A p m a = a`; Mathlib's `RingHom.mem_eqLocus` is the bridge.
-  refine RingHom.mem_eqLocus.mpr ?_
-  rw [iterateFrobenius_mul_apply, Function.iterate_fixed (RingHom.mem_eqLocus.mp ha)]
-  rfl
+  exact mem_frobeniusFixedSubring_mul_iff_iterate_eq.mpr
+    (Function.iterate_fixed (RingHom.mem_eqLocus.mp ha) c)
 
 variable {B : Type*} [CommRing B] [ExpChar B p]
 
@@ -155,10 +164,10 @@ variable {K p n}
 `frobeniusFixedSubring_le_of_dvd`: in the motivating case this is the inclusion
 `𝔽_{p ^ m} ⊆ 𝔽_{p ^ k}` of subfields of an algebraic closure. -/
 theorem frobeniusFixedSubfield_le_of_dvd {m k : ℕ} (h : m ∣ k) :
-    frobeniusFixedSubfield K p m ≤ frobeniusFixedSubfield K p k := fun _ ha =>
-  mem_frobeniusFixedSubfield.mpr (mem_frobeniusFixedSubring.mp
-    (frobeniusFixedSubring_le_of_dvd h (mem_frobeniusFixedSubring.mpr
-      (mem_frobeniusFixedSubfield.mp ha))))
+    frobeniusFixedSubfield K p m ≤ frobeniusFixedSubfield K p k := by
+  rw [← SetLike.coe_subset_coe, ← Subfield.coe_toSubring, ← Subfield.coe_toSubring,
+    toSubring_frobeniusFixedSubfield, toSubring_frobeniusFixedSubfield, SetLike.coe_subset_coe]
+  exact frobeniusFixedSubring_le_of_dvd h
 
 end Field
 

--- a/TauCeti/FieldTheory/Finite/AlgClosedSubfield.lean
+++ b/TauCeti/FieldTheory/Finite/AlgClosedSubfield.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.Finite.GaloisField
+public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import TauCeti.Algebra.CharP.FrobeniusFixed
+
+/-!
+# The finite subfields of an algebraically closed field of positive characteristic
+
+`TauCeti.frobeniusFixedSubring A p n` is the subring of solutions of `a ^ p ^ n = a`, defined for an
+arbitrary commutative ring of exponential characteristic `p`. Over a field it is closed under
+inverses, so it is a subfield, `TauCeti.frobeniusFixedSubfield`; and when the field is
+algebraically closed and `n ≠ 0` it is the field of `q = p ^ n` elements sitting inside it.
+
+The counting is the standard one: `a ^ q = a` says exactly that `a` is a root of `X ^ q - X`, a
+polynomial whose derivative is `-1` and which therefore has no repeated roots, so over an
+algebraically closed field it has as many roots as its degree. Being closed under inverses is what
+turns the resulting `q`-element subring into a copy of `𝔽_q`, and a counting argument then shows it
+is the *only* subfield with `q` elements. In the other direction every element of an algebraic
+closure of `ZMod p` lies in one of these subfields, since it generates a finite extension of the
+prime field.
+
+## Main definitions
+
+* `TauCeti.frobeniusFixedSubfield`: the subfield of a field of exponential characteristic `p` fixed
+  by the `p ^ n`-power Frobenius.
+
+## Main results
+
+* `TauCeti.card_frobeniusFixedSubfield`: over an algebraically closed field and for `n ≠ 0` it has
+  exactly `p ^ n` elements.
+* `TauCeti.eq_frobeniusFixedSubfield_of_natCard`: it is the unique subfield with that many elements.
+* `TauCeti.nonempty_ringEquiv_galoisField`: it is therefore a copy of `GaloisField p n`.
+* `TauCeti.exists_mem_frobeniusFixedSubfield`: an algebraic closure of the prime field is the union
+  of these subfields.
+
+## References
+
+This is the field-theoretic half of "the fixed points of the `q`-power Frobenius are the
+`𝔽_q`-points", the ring-theoretic half being `TauCeti.frobeniusFixedSubring` itself. It is a
+prerequisite of the "points over an algebraically closed field, functorially in the field" target
+of Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, and of milestone L1 of
+`TauCetiRoadmap/CFSGStatement/README.md`, whose Steinberg maps start from the `q`-power Frobenius
+of an algebraic closure of `ZMod p`.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §26.
+* S. Lang, *Algebra*, 3rd ed., V.5.
+-/
+
+public section
+
+open Polynomial
+
+namespace TauCeti
+
+/-! ## The fixed subfield -/
+
+section Field
+
+variable (K : Type*) [Field K] (p n : ℕ) [ExpChar K p]
+
+/-- The subfield of elements of a field `K` fixed by the `p ^ n`-power Frobenius, that is, the
+solutions of `a ^ p ^ n = a`.
+
+This is `TauCeti.frobeniusFixedSubring` together with closure under inverses, which holds because
+`(a⁻¹) ^ p ^ n = (a ^ p ^ n)⁻¹`. As with the subring, nothing about finiteness is asserted at this
+level of generality: at `n = 0`, or in characteristic zero, it is the whole of `K`. -/
+@[expose]
+def frobeniusFixedSubfield : Subfield K where
+  __ := frobeniusFixedSubring K p n
+  inv_mem' a ha := by
+    simp only [Subring.mem_carrier, mem_frobeniusFixedSubring] at ha ⊢
+    rw [inv_pow, ha]
+
+variable {K p n}
+
+/-- Membership in the Frobenius-fixed subfield is the equation `a ^ p ^ n = a`. -/
+@[simp]
+theorem mem_frobeniusFixedSubfield {a : K} :
+    a ∈ frobeniusFixedSubfield K p n ↔ a ^ p ^ n = a := mem_frobeniusFixedSubring
+
+variable (K p n)
+
+/-- The Frobenius-fixed subfield has the Frobenius-fixed subring as its underlying subring. -/
+@[simp]
+theorem toSubring_frobeniusFixedSubfield :
+    (frobeniusFixedSubfield K p n).toSubring = frobeniusFixedSubring K p n := rfl
+
+end Field
+
+/-! ## Counting over an algebraically closed field -/
+
+section RootSet
+
+variable (K : Type*) [Field K] (p n : ℕ) [Fact p.Prime] [CharP K p]
+
+/-- Over any field of characteristic `p`, being fixed by the `p ^ n`-power Frobenius is being a
+root of `X ^ p ^ n - X`. That polynomial is separable of degree `p ^ n`, which is where the count
+below comes from. -/
+theorem coe_frobeniusFixedSubfield_eq_rootSet (hn : n ≠ 0) :
+    (frobeniusFixedSubfield K p n : Set K) = (X ^ p ^ n - X : K[X]).rootSet K := by
+  have hne : (X ^ p ^ n - X : K[X]) ≠ 0 :=
+    FiniteField.X_pow_card_pow_sub_X_ne_zero K hn (Fact.out (p := p.Prime)).one_lt
+  ext a
+  simp [Polynomial.mem_rootSet, hne, sub_eq_zero]
+
+/-- The equivalence used to count the Frobenius-fixed subfield: its elements are exactly the roots
+of `X ^ p ^ n - X`, a separable polynomial of degree `p ^ n`. -/
+def frobeniusFixedSubfieldEquivRootSet (hn : n ≠ 0) :
+    frobeniusFixedSubfield K p n ≃ (X ^ p ^ n - X : K[X]).rootSet K :=
+  Equiv.setCongr (coe_frobeniusFixedSubfield_eq_rootSet K p n hn)
+
+/-- The Frobenius-fixed subfield of a field of characteristic `p` is finite once `n ≠ 0`, being a
+set of roots of a nonzero polynomial. This is not an instance: at `n = 0` the subfield is the whole
+of `K`, which need not be finite. -/
+theorem finite_frobeniusFixedSubfield (hn : n ≠ 0) : Finite (frobeniusFixedSubfield K p n) :=
+  .of_equiv _ (frobeniusFixedSubfieldEquivRootSet K p n hn).symm
+
+end RootSet
+
+section IsAlgClosed
+
+variable (K : Type*) [Field K] [IsAlgClosed K] (p n : ℕ) [Fact p.Prime] [CharP K p]
+
+/-- **The field of `q` elements inside an algebraically closed field.** For `q = p ^ n` with
+`n ≠ 0`, the elements of an algebraically closed field of characteristic `p` fixed by the
+`q`-power Frobenius form a subfield with exactly `q` elements.
+
+The count is the number of roots of the separable polynomial `X ^ q - X`, which is its degree. -/
+theorem card_frobeniusFixedSubfield (hn : n ≠ 0) :
+    Nat.card (frobeniusFixedSubfield K p n) = p ^ n := by
+  have hsep : Separable (X ^ p ^ n - X : K[X]) :=
+    galois_poly_separable p (p ^ n) (dvd_pow_self p hn)
+  have hsplit : ((X ^ p ^ n - X : K[X]).map (algebraMap K K)).Splits :=
+    IsAlgClosed.splits_domain _
+  rw [Nat.card_congr (frobeniusFixedSubfieldEquivRootSet K p n hn), Nat.card_eq_fintype_card,
+    card_rootSet_eq_natDegree hsep hsplit,
+    FiniteField.X_pow_card_pow_sub_X_natDegree_eq K hn (Fact.out (p := p.Prime)).one_lt]
+
+/-- **Uniqueness of the subfield of `q` elements.** A finite subfield of an algebraically closed
+field of characteristic `p` with `p ^ n` elements is the subfield fixed by the `p ^ n`-power
+Frobenius.
+
+Every element of a finite field of cardinality `q` satisfies `a ^ q = a`, so such a subfield is
+contained in the fixed one; the two then agree because they have the same finite cardinality. -/
+theorem eq_frobeniusFixedSubfield_of_natCard {F : Subfield K} [Finite F]
+    (hn : n ≠ 0) (hF : Nat.card F = p ^ n) : F = frobeniusFixedSubfield K p n := by
+  have _ : Fintype F := Fintype.ofFinite F
+  have _ : Finite (frobeniusFixedSubfield K p n) := finite_frobeniusFixedSubfield K p n hn
+  rw [Nat.card_eq_fintype_card] at hF
+  have hsub : (F : Set K) ⊆ (frobeniusFixedSubfield K p n : Set K) := by
+    intro a ha
+    have hpow := FiniteField.pow_card (⟨a, ha⟩ : F)
+    rw [hF] at hpow
+    exact mem_frobeniusFixedSubfield.mpr (congrArg (Subtype.val : F → K) hpow)
+  have hcard : (frobeniusFixedSubfield K p n : Set K).ncard ≤ (F : Set K).ncard := by
+    have h₁ : (frobeniusFixedSubfield K p n : Set K).ncard = p ^ n := by
+      simp only [← Nat.card_coe_set_eq, SetLike.coe_sort_coe]
+      exact card_frobeniusFixedSubfield K p n hn
+    have h₂ : (F : Set K).ncard = p ^ n := by
+      simp only [← Nat.card_coe_set_eq, SetLike.coe_sort_coe]
+      rw [Nat.card_eq_fintype_card, hF]
+    rw [h₁, h₂]
+  exact SetLike.coe_injective
+    (Set.eq_of_subset_of_ncard_le hsub hcard (Set.toFinite _))
+
+/-- The Frobenius-fixed subfield of an algebraically closed field is a copy of Mathlib's
+`GaloisField p n`, the two being finite fields of the same cardinality. The isomorphism is not
+canonical, which is why only its existence is recorded. -/
+theorem nonempty_ringEquiv_galoisField (hn : n ≠ 0) :
+    Nonempty (frobeniusFixedSubfield K p n ≃+* GaloisField p n) := by
+  have _ : Finite (frobeniusFixedSubfield K p n) := finite_frobeniusFixedSubfield K p n hn
+  have _ : Fintype (frobeniusFixedSubfield K p n) := Fintype.ofFinite _
+  have _ : Fintype (GaloisField p n) := Fintype.ofFinite _
+  refine ⟨FiniteField.ringEquivOfCardEq ?_⟩
+  rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card,
+    card_frobeniusFixedSubfield K p n hn, GaloisField.card p n hn]
+
+end IsAlgClosed
+
+/-! ## Exhaustion over an algebraic prime field -/
+
+section Algebraic
+
+variable (K : Type*) [Field K] (p : ℕ) [Fact p.Prime] [CharP K p] [Algebra (ZMod p) K]
+  [Algebra.IsAlgebraic (ZMod p) K]
+
+/-- **An algebraic extension of `ZMod p` is the union of its Frobenius-fixed subfields.** Every
+element generates a finite extension of the prime field, and so is fixed by the `p ^ n`-power
+Frobenius for the degree `n` of that extension.
+
+Only algebraicity over the prime field is used, so the statement covers an algebraic closure of
+`ZMod p` without assuming algebraic closedness. -/
+theorem exists_mem_frobeniusFixedSubfield (x : K) :
+    ∃ n ≠ 0, x ∈ frobeniusFixedSubfield K p n := by
+  classical
+  set E := IntermediateField.adjoin (ZMod p) ({x} : Set K) with hE
+  have hx : x ∈ E := IntermediateField.mem_adjoin_simple_self (ZMod p) x
+  have _ : FiniteDimensional (ZMod p) E :=
+    IntermediateField.adjoin.finiteDimensional (Algebra.IsIntegral.isIntegral x)
+  have _ : Finite E := Module.finite_of_finite (ZMod p)
+  have _ : Fintype E := Fintype.ofFinite E
+  refine ⟨Module.finrank (ZMod p) E, ?_, ?_⟩
+  · exact (Module.finrank_pos (R := ZMod p) (M := E)).ne'
+  · have hcard : p ^ Module.finrank (ZMod p) E = Nat.card E :=
+      FiniteField.pow_finrank_eq_natCard p E
+    have hpow := FiniteField.pow_card (⟨x, hx⟩ : E)
+    rw [← Nat.card_eq_fintype_card, ← hcard] at hpow
+    exact mem_frobeniusFixedSubfield.mpr (congrArg (Subtype.val : E → K) hpow)
+
+end Algebraic
+
+end TauCeti

--- a/TauCeti/FieldTheory/Finite/AlgClosedSubfield.lean
+++ b/TauCeti/FieldTheory/Finite/AlgClosedSubfield.lean
@@ -8,27 +8,22 @@ module
 public import Mathlib.FieldTheory.Finite.GaloisField
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
 public import TauCeti.Algebra.CharP.FrobeniusFixed
+public import TauCeti.FieldTheory.Finite.FrobeniusFixed
 
 /-!
 # The finite subfields of an algebraically closed field of positive characteristic
 
-`TauCeti.frobeniusFixedSubring A p n` is the subring of solutions of `a ^ p ^ n = a`, defined for an
-arbitrary commutative ring of exponential characteristic `p`. Over a field it is closed under
-inverses, so it is a subfield, `TauCeti.frobeniusFixedSubfield`; and when the field is
-algebraically closed and `n ≠ 0` it is the field of `q = p ^ n` elements sitting inside it.
+`TauCeti.frobeniusFixedSubfield K p n` is the subfield of solutions of `a ^ p ^ n = a`, defined for
+an arbitrary field of exponential characteristic `p`. When the field is algebraically closed and
+`n ≠ 0` it is the field of `q = p ^ n` elements sitting inside it.
 
 The counting is the standard one: `a ^ q = a` says exactly that `a` is a root of `X ^ q - X`, a
 polynomial whose derivative is `-1` and which therefore has no repeated roots, so over an
-algebraically closed field it has as many roots as its degree. Being closed under inverses is what
-turns the resulting `q`-element subring into a copy of `𝔽_q`, and a counting argument then shows it
-is the *only* subfield with `q` elements. In the other direction every element of an algebraic
-closure of `ZMod p` lies in one of these subfields, since it generates a finite extension of the
-prime field.
-
-## Main definitions
-
-* `TauCeti.frobeniusFixedSubfield`: the subfield of a field of exponential characteristic `p` fixed
-  by the `p ^ n`-power Frobenius.
+algebraically closed field it has as many roots as its degree. In any field of characteristic `p` a
+subfield with `q` elements is *the* Frobenius-fixed one, since being fixed by the `q`-power map
+characterises the elements of a finite subfield of order `q`. In the other direction every element
+of an algebraic closure of `ZMod p` lies in one of these subfields, since it generates a finite
+extension of the prime field.
 
 ## Main results
 
@@ -45,11 +40,11 @@ This is the field-theoretic half of "the fixed points of the `q`-power Frobenius
 `𝔽_q`-points", the ring-theoretic half being `TauCeti.frobeniusFixedSubring` itself. It is a
 prerequisite of the "points over an algebraically closed field, functorially in the field" target
 of Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, and of milestone L1 of
-`TauCetiRoadmap/CFSGStatement/README.md`, whose Steinberg maps start from the `q`-power Frobenius
-of an algebraic closure of `ZMod p`.
+`TauCetiRoadmap/CFSGStatement/README.md`, whose ordinary and graph-twisted Steinberg maps start
+from the `q`-power Frobenius of an algebraic closure of `ZMod p`.
 
-* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §26.
 * S. Lang, *Algebra*, 3rd ed., V.5.
+* R. Lidl and H. Niederreiter, *Finite Fields*, §2.1.
 -/
 
 public section
@@ -58,42 +53,7 @@ open Polynomial
 
 namespace TauCeti
 
-/-! ## The fixed subfield -/
-
-section Field
-
-variable (K : Type*) [Field K] (p n : ℕ) [ExpChar K p]
-
-/-- The subfield of elements of a field `K` fixed by the `p ^ n`-power Frobenius, that is, the
-solutions of `a ^ p ^ n = a`.
-
-This is `TauCeti.frobeniusFixedSubring` together with closure under inverses, which holds because
-`(a⁻¹) ^ p ^ n = (a ^ p ^ n)⁻¹`. As with the subring, nothing about finiteness is asserted at this
-level of generality: at `n = 0`, or in characteristic zero, it is the whole of `K`. -/
-@[expose]
-def frobeniusFixedSubfield : Subfield K where
-  __ := frobeniusFixedSubring K p n
-  inv_mem' a ha := by
-    simp only [Subring.mem_carrier, mem_frobeniusFixedSubring] at ha ⊢
-    rw [inv_pow, ha]
-
-variable {K p n}
-
-/-- Membership in the Frobenius-fixed subfield is the equation `a ^ p ^ n = a`. -/
-@[simp]
-theorem mem_frobeniusFixedSubfield {a : K} :
-    a ∈ frobeniusFixedSubfield K p n ↔ a ^ p ^ n = a := mem_frobeniusFixedSubring
-
-variable (K p n)
-
-/-- The Frobenius-fixed subfield has the Frobenius-fixed subring as its underlying subring. -/
-@[simp]
-theorem toSubring_frobeniusFixedSubfield :
-    (frobeniusFixedSubfield K p n).toSubring = frobeniusFixedSubring K p n := rfl
-
-end Field
-
-/-! ## Counting over an algebraically closed field -/
+/-! ## The root set of `X ^ q - X` -/
 
 section RootSet
 
@@ -110,8 +70,9 @@ theorem coe_frobeniusFixedSubfield_eq_rootSet (hn : n ≠ 0) :
   simp [Polynomial.mem_rootSet, hne, sub_eq_zero]
 
 /-- The equivalence used to count the Frobenius-fixed subfield: its elements are exactly the roots
-of `X ^ p ^ n - X`, a separable polynomial of degree `p ^ n`. -/
-def frobeniusFixedSubfieldEquivRootSet (hn : n ≠ 0) :
+of `X ^ p ^ n - X`, a separable polynomial of degree `p ^ n`. The public form of this is
+`coe_frobeniusFixedSubfield_eq_rootSet`. -/
+private def frobeniusFixedSubfieldEquivRootSet (hn : n ≠ 0) :
     frobeniusFixedSubfield K p n ≃ (X ^ p ^ n - X : K[X]).rootSet K :=
   Equiv.setCongr (coe_frobeniusFixedSubfield_eq_rootSet K p n hn)
 
@@ -120,6 +81,25 @@ set of roots of a nonzero polynomial. This is not an instance: at `n = 0` the su
 of `K`, which need not be finite. -/
 theorem finite_frobeniusFixedSubfield (hn : n ≠ 0) : Finite (frobeniusFixedSubfield K p n) :=
   .of_equiv _ (frobeniusFixedSubfieldEquivRootSet K p n hn).symm
+
+/-- **Uniqueness of the subfield of `q` elements.** A subfield with `p ^ n` elements of a field of
+characteristic `p` is the subfield fixed by the `p ^ n`-power Frobenius.
+
+An element of the ambient field satisfies `a ^ q = a` exactly when it lies in a subfield with `q`
+elements, by `TauCeti.FiniteField.pow_card_eq_self_iff_mem_range_algebraMap`; no counting, and no
+algebraic closedness, is involved. -/
+theorem eq_frobeniusFixedSubfield_of_natCard {F : Subfield K} (hF : Nat.card F = p ^ n) :
+    F = frobeniusFixedSubfield K p n := by
+  have hne : Nat.card F ≠ 0 := by
+    rw [hF]
+    exact pow_ne_zero n (Fact.out (p := p.Prime)).ne_zero
+  have _ : Finite F := Nat.finite_of_card_ne_zero hne
+  have _ : Fintype F := Fintype.ofFinite F
+  have hcard : Fintype.card F = p ^ n := by rw [← Nat.card_eq_fintype_card, hF]
+  refine SetLike.coe_injective (Set.ext fun a => ?_)
+  rw [SetLike.mem_coe, SetLike.mem_coe, mem_frobeniusFixedSubfield, ← hcard,
+    FiniteField.pow_card_eq_self_iff_mem_range_algebraMap]
+  exact ⟨fun ha => ⟨⟨a, ha⟩, rfl⟩, fun ⟨b, hb⟩ => hb ▸ b.2⟩
 
 end RootSet
 
@@ -141,33 +121,6 @@ theorem card_frobeniusFixedSubfield (hn : n ≠ 0) :
   rw [Nat.card_congr (frobeniusFixedSubfieldEquivRootSet K p n hn), Nat.card_eq_fintype_card,
     card_rootSet_eq_natDegree hsep hsplit,
     FiniteField.X_pow_card_pow_sub_X_natDegree_eq K hn (Fact.out (p := p.Prime)).one_lt]
-
-/-- **Uniqueness of the subfield of `q` elements.** A finite subfield of an algebraically closed
-field of characteristic `p` with `p ^ n` elements is the subfield fixed by the `p ^ n`-power
-Frobenius.
-
-Every element of a finite field of cardinality `q` satisfies `a ^ q = a`, so such a subfield is
-contained in the fixed one; the two then agree because they have the same finite cardinality. -/
-theorem eq_frobeniusFixedSubfield_of_natCard {F : Subfield K} [Finite F]
-    (hn : n ≠ 0) (hF : Nat.card F = p ^ n) : F = frobeniusFixedSubfield K p n := by
-  have _ : Fintype F := Fintype.ofFinite F
-  have _ : Finite (frobeniusFixedSubfield K p n) := finite_frobeniusFixedSubfield K p n hn
-  rw [Nat.card_eq_fintype_card] at hF
-  have hsub : (F : Set K) ⊆ (frobeniusFixedSubfield K p n : Set K) := by
-    intro a ha
-    have hpow := FiniteField.pow_card (⟨a, ha⟩ : F)
-    rw [hF] at hpow
-    exact mem_frobeniusFixedSubfield.mpr (congrArg (Subtype.val : F → K) hpow)
-  have hcard : (frobeniusFixedSubfield K p n : Set K).ncard ≤ (F : Set K).ncard := by
-    have h₁ : (frobeniusFixedSubfield K p n : Set K).ncard = p ^ n := by
-      simp only [← Nat.card_coe_set_eq, SetLike.coe_sort_coe]
-      exact card_frobeniusFixedSubfield K p n hn
-    have h₂ : (F : Set K).ncard = p ^ n := by
-      simp only [← Nat.card_coe_set_eq, SetLike.coe_sort_coe]
-      rw [Nat.card_eq_fintype_card, hF]
-    rw [h₁, h₂]
-  exact SetLike.coe_injective
-    (Set.eq_of_subset_of_ncard_le hsub hcard (Set.toFinite _))
 
 /-- The Frobenius-fixed subfield of an algebraically closed field is a copy of Mathlib's
 `GaloisField p n`, the two being finite fields of the same cardinality. The isomorphism is not
@@ -204,14 +157,11 @@ theorem exists_mem_frobeniusFixedSubfield (x : K) :
   have _ : FiniteDimensional (ZMod p) E :=
     IntermediateField.adjoin.finiteDimensional (Algebra.IsIntegral.isIntegral x)
   have _ : Finite E := Module.finite_of_finite (ZMod p)
-  have _ : Fintype E := Fintype.ofFinite E
-  refine ⟨Module.finrank (ZMod p) E, ?_, ?_⟩
-  · exact (Module.finrank_pos (R := ZMod p) (M := E)).ne'
-  · have hcard : p ^ Module.finrank (ZMod p) E = Nat.card E :=
-      FiniteField.pow_finrank_eq_natCard p E
-    have hpow := FiniteField.pow_card (⟨x, hx⟩ : E)
-    rw [← Nat.card_eq_fintype_card, ← hcard] at hpow
-    exact mem_frobeniusFixedSubfield.mpr (congrArg (Subtype.val : E → K) hpow)
+  refine ⟨Module.finrank (ZMod p) E, (Module.finrank_pos (R := ZMod p) (M := E)).ne', ?_⟩
+  have hcard : Nat.card E.toSubfield = p ^ Module.finrank (ZMod p) E :=
+    (FiniteField.pow_finrank_eq_natCard p E).symm
+  rw [← eq_frobeniusFixedSubfield_of_natCard K p _ hcard]
+  exact (E.mem_toSubfield x).mpr hx
 
 end Algebraic
 

--- a/TauCeti/FieldTheory/Finite/SepClosedSubfield.lean
+++ b/TauCeti/FieldTheory/Finite/SepClosedSubfield.lean
@@ -6,20 +6,20 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.Finite.GaloisField
-public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import Mathlib.FieldTheory.IsSepClosed
 public import TauCeti.Algebra.CharP.FrobeniusFixed
 public import TauCeti.FieldTheory.Finite.FrobeniusFixed
 
 /-!
-# The finite subfields of an algebraically closed field of positive characteristic
+# The finite subfields of a separably closed field of positive characteristic
 
 `TauCeti.frobeniusFixedSubfield K p n` is the subfield of solutions of `a ^ p ^ n = a`, defined for
-an arbitrary field of exponential characteristic `p`. When the field is algebraically closed and
+an arbitrary field of exponential characteristic `p`. When the field is separably closed and
 `n ≠ 0` it is the field of `q = p ^ n` elements sitting inside it.
 
 The counting is the standard one: `a ^ q = a` says exactly that `a` is a root of `X ^ q - X`, a
-polynomial whose derivative is `-1` and which therefore has no repeated roots, so over an
-algebraically closed field it has as many roots as its degree. In any field of characteristic `p` a
+polynomial whose derivative is `-1` and which therefore has no repeated roots, so over a separably
+closed field it splits and has as many roots as its degree. In any field of characteristic `p` a
 subfield with `q` elements is *the* Frobenius-fixed one, since being fixed by the `q`-power map
 characterises the elements of a finite subfield of order `q`. In the other direction every element
 of an algebraic closure of `ZMod p` lies in one of these subfields, since it generates a finite
@@ -27,10 +27,11 @@ extension of the prime field.
 
 ## Main results
 
-* `TauCeti.card_frobeniusFixedSubfield`: over an algebraically closed field and for `n ≠ 0` it has
+* `TauCeti.card_frobeniusFixedSubfield`: over a separably closed field and for `n ≠ 0` it has
   exactly `p ^ n` elements.
 * `TauCeti.eq_frobeniusFixedSubfield_of_natCard`: it is the unique subfield with that many elements.
-* `TauCeti.nonempty_ringEquiv_galoisField`: it is therefore a copy of `GaloisField p n`.
+* `TauCeti.nonempty_frobeniusFixedSubfield_ringEquiv_galoisField`: it is therefore a copy of
+  `GaloisField p n`.
 * `TauCeti.exists_mem_frobeniusFixedSubfield`: an algebraic closure of the prime field is the union
   of these subfields.
 
@@ -59,9 +60,10 @@ section RootSet
 
 variable (K : Type*) [Field K] (p n : ℕ) [Fact p.Prime] [CharP K p]
 
-/-- Over any field of characteristic `p`, being fixed by the `p ^ n`-power Frobenius is being a
-root of `X ^ p ^ n - X`. That polynomial is separable of degree `p ^ n`, which is where the count
-below comes from. -/
+/-- Over any field of characteristic `p` and for `n ≠ 0`, being fixed by the `p ^ n`-power
+Frobenius is being a root of `X ^ p ^ n - X`. That polynomial is then separable of degree `p ^ n`,
+which is where the count below comes from. At `n = 0` the two sides differ: the subfield is the
+whole of `K` while `X ^ 1 - X = 0` has empty root set. -/
 theorem coe_frobeniusFixedSubfield_eq_rootSet (hn : n ≠ 0) :
     (frobeniusFixedSubfield K p n : Set K) = (X ^ p ^ n - X : K[X]).rootSet K := by
   have hne : (X ^ p ^ n - X : K[X]) ≠ 0 :=
@@ -98,17 +100,17 @@ theorem eq_frobeniusFixedSubfield_of_natCard {F : Subfield K} (hF : Nat.card F =
   have hcard : Fintype.card F = p ^ n := by rw [← Nat.card_eq_fintype_card, hF]
   refine SetLike.coe_injective (Set.ext fun a => ?_)
   rw [SetLike.mem_coe, SetLike.mem_coe, mem_frobeniusFixedSubfield, ← hcard,
-    FiniteField.pow_card_eq_self_iff_mem_range_algebraMap]
-  exact ⟨fun ha => ⟨⟨a, ha⟩, rfl⟩, fun ⟨b, hb⟩ => hb ▸ b.2⟩
+    FiniteField.pow_card_eq_self_iff_mem_range_algebraMap, Subfield.algebraMap_ofSubfield,
+    Subfield.coe_subtype, Subtype.range_coe_subtype, Set.mem_ofPred_eq]
 
 end RootSet
 
-section IsAlgClosed
+section IsSepClosed
 
-variable (K : Type*) [Field K] [IsAlgClosed K] (p n : ℕ) [Fact p.Prime] [CharP K p]
+variable (K : Type*) [Field K] [IsSepClosed K] (p n : ℕ) [Fact p.Prime] [CharP K p]
 
-/-- **The field of `q` elements inside an algebraically closed field.** For `q = p ^ n` with
-`n ≠ 0`, the elements of an algebraically closed field of characteristic `p` fixed by the
+/-- **The field of `q` elements inside a separably closed field.** For `q = p ^ n` with
+`n ≠ 0`, the elements of a separably closed field of characteristic `p` fixed by the
 `q`-power Frobenius form a subfield with exactly `q` elements.
 
 The count is the number of roots of the separable polynomial `X ^ q - X`, which is its degree. -/
@@ -117,15 +119,15 @@ theorem card_frobeniusFixedSubfield (hn : n ≠ 0) :
   have hsep : Separable (X ^ p ^ n - X : K[X]) :=
     galois_poly_separable p (p ^ n) (dvd_pow_self p hn)
   have hsplit : ((X ^ p ^ n - X : K[X]).map (algebraMap K K)).Splits :=
-    IsAlgClosed.splits_domain _
+    IsSepClosed.splits_domain _ hsep
   rw [Nat.card_congr (frobeniusFixedSubfieldEquivRootSet K p n hn), Nat.card_eq_fintype_card,
     card_rootSet_eq_natDegree hsep hsplit,
     FiniteField.X_pow_card_pow_sub_X_natDegree_eq K hn (Fact.out (p := p.Prime)).one_lt]
 
-/-- The Frobenius-fixed subfield of an algebraically closed field is a copy of Mathlib's
+/-- The Frobenius-fixed subfield of a separably closed field is a copy of Mathlib's
 `GaloisField p n`, the two being finite fields of the same cardinality. The isomorphism is not
 canonical, which is why only its existence is recorded. -/
-theorem nonempty_ringEquiv_galoisField (hn : n ≠ 0) :
+theorem nonempty_frobeniusFixedSubfield_ringEquiv_galoisField (hn : n ≠ 0) :
     Nonempty (frobeniusFixedSubfield K p n ≃+* GaloisField p n) := by
   have _ : Finite (frobeniusFixedSubfield K p n) := finite_frobeniusFixedSubfield K p n hn
   have _ : Fintype (frobeniusFixedSubfield K p n) := Fintype.ofFinite _
@@ -134,7 +136,7 @@ theorem nonempty_ringEquiv_galoisField (hn : n ≠ 0) :
   rw [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card,
     card_frobeniusFixedSubfield K p n hn, GaloisField.card p n hn]
 
-end IsAlgClosed
+end IsSepClosed
 
 /-! ## Exhaustion over an algebraic prime field -/
 
@@ -151,15 +153,15 @@ Only algebraicity over the prime field is used, so the statement covers an algeb
 `ZMod p` without assuming algebraic closedness. -/
 theorem exists_mem_frobeniusFixedSubfield (x : K) :
     ∃ n ≠ 0, x ∈ frobeniusFixedSubfield K p n := by
-  classical
-  set E := IntermediateField.adjoin (ZMod p) ({x} : Set K) with hE
+  set E := IntermediateField.adjoin (ZMod p) ({x} : Set K)
   have hx : x ∈ E := IntermediateField.mem_adjoin_simple_self (ZMod p) x
   have _ : FiniteDimensional (ZMod p) E :=
     IntermediateField.adjoin.finiteDimensional (Algebra.IsIntegral.isIntegral x)
   have _ : Finite E := Module.finite_of_finite (ZMod p)
   refine ⟨Module.finrank (ZMod p) E, (Module.finrank_pos (R := ZMod p) (M := E)).ne', ?_⟩
-  have hcard : Nat.card E.toSubfield = p ^ Module.finrank (ZMod p) E :=
-    (FiniteField.pow_finrank_eq_natCard p E).symm
+  have hcard : Nat.card E.toSubfield = p ^ Module.finrank (ZMod p) E := by
+    rw [Nat.card_congr (Equiv.subtypeEquivRight (E.mem_toSubfield ·))]
+    exact (FiniteField.pow_finrank_eq_natCard p E).symm
   rw [← eq_frobeniusFixedSubfield_of_natCard K p _ hcard]
   exact (E.mem_toSubfield x).mpr hx
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Frobenius.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Frobenius.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.FieldTheory.Finite.AlgClosedSubfield
+public import TauCeti.FieldTheory.Finite.SepClosedSubfield
 public import TauCeti.GroupTheory.SpecificGroups.CFSG.Closure
 
 /-!
@@ -44,7 +44,8 @@ branch, which is why it is defined for every valid index and not only for the un
   the corresponding powers of `q`.
 * `TauCeti.ValidLieTypeIndex.card_fixedField`: the fixed field has `q` elements.
 * `TauCeti.ValidLieTypeIndex.eq_fixedField_of_natCard`: it is the only subfield with `q` elements.
-* `TauCeti.ValidLieTypeIndex.nonempty_ringEquiv_galoisField`: it is a copy of `GaloisField p e`.
+* `TauCeti.ValidLieTypeIndex.nonempty_fixedField_ringEquiv_galoisField`: it is a copy of
+  `GaloisField p e`.
 * `TauCeti.ValidLieTypeIndex.mem_frobeniusFixedSubfield_iff_iterate_frobeniusEquiv_eq`: the `k`-th
   iterate fixes the subfield at exponent `e * k`, which for `k ≠ 0` is the field of `q ^ k`
   elements.
@@ -90,12 +91,20 @@ def frobeniusEquiv : d.Closure ≃+* d.Closure :=
 theorem frobeniusEquiv_apply (x : d.Closure) : d.frobeniusEquiv x = x ^ d.fieldOrder := by
   rw [frobeniusEquiv, iterateFrobeniusEquiv_def, ← d.fieldOrder_eq_characteristic_pow]
 
+/-- The Frobenius attached to an index is the `q`-power map. This is the form iteration and
+composition arguments use, `frobeniusEquiv_apply` being the pointwise one.
+
+This is not a `simp` lemma: `simp only [coe_frobeniusEquiv]` already proves
+`frobeniusEquiv_apply`, so annotating it would make that lemma a `simpNF` violation. -/
+theorem coe_frobeniusEquiv : ⇑d.frobeniusEquiv = (· ^ d.fieldOrder) :=
+  funext d.frobeniusEquiv_apply
+
 /-- Iterating the Frobenius attached to an index raises to the corresponding power of `q`. This is
 the form the graph-twisted branches use: their Steinberg map has an `r`-th power equal to the plain
 `Frob_{q ^ r}`, with `r` the order of the diagram automorphism. -/
 theorem iterate_frobeniusEquiv_apply (k : ℕ) (x : d.Closure) :
     (d.frobeniusEquiv : d.Closure → d.Closure)^[k] x = x ^ d.fieldOrder ^ k := by
-  rw [show ⇑d.frobeniusEquiv = (· ^ d.fieldOrder) from funext d.frobeniusEquiv_apply, pow_iterate]
+  rw [coe_frobeniusEquiv, pow_iterate]
 
 /-! ## The field of definition -/
 
@@ -148,9 +157,9 @@ theorem eq_fixedField_of_natCard {F : Subfield d.Closure}
     (by rw [hF, d.fieldOrder_eq_characteristic_pow])
 
 /-- The fixed field is a copy of Mathlib's `GaloisField`, non-canonically. -/
-theorem nonempty_ringEquiv_galoisField :
+theorem nonempty_fixedField_ringEquiv_galoisField :
     Nonempty (d.fixedField ≃+* GaloisField d.characteristic d.fieldExponent) :=
-  _root_.TauCeti.nonempty_ringEquiv_galoisField d.Closure d.characteristic d.fieldExponent
+  nonempty_frobeniusFixedSubfield_ringEquiv_galoisField d.Closure d.characteristic d.fieldExponent
     d.fieldExponent_pos.ne'
 
 variable {d}
@@ -162,8 +171,8 @@ group: the degree `r` extension of `𝔽_q`, with `r` the order of the diagram a
 theorem mem_frobeniusFixedSubfield_iff_iterate_frobeniusEquiv_eq {k : ℕ} {x : d.Closure} :
     x ∈ frobeniusFixedSubfield d.Closure d.characteristic (d.fieldExponent * k) ↔
       (d.frobeniusEquiv : d.Closure → d.Closure)^[k] x = x := by
-  rw [iterate_frobeniusEquiv_apply, mem_frobeniusFixedSubfield, pow_mul,
-    ← d.fieldOrder_eq_characteristic_pow]
+  rw [← Subfield.mem_toSubring, toSubring_frobeniusFixedSubfield,
+    mem_frobeniusFixedSubring_mul_iff_iterate_eq, frobeniusEquiv, coe_iterateFrobeniusEquiv]
 
 /-- **The closure is the union of the finite fields inside it.** Every element of the algebraic
 closure attached to a valid Lie-type index is fixed by some positive iterate of the Frobenius,

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Frobenius.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Frobenius.lean
@@ -11,41 +11,45 @@ public import TauCeti.GroupTheory.SpecificGroups.CFSG.Closure
 /-!
 # The field Frobenius of a Lie-type index
 
-Every Steinberg endomorphism in the CFSG list starts from the map `x ↦ x ^ q` on the algebraic
-closure of the prime field, where `q` is the Frobenius parameter recorded by the index. This file
-constructs that map, `TauCeti.ValidLieTypeIndex.frobenius`, and identifies the field it fixes.
+On the ordinary and graph-twisted branches of the CFSG list the Steinberg endomorphism starts from
+the map `x ↦ x ^ q` on the algebraic closure of the prime field, where `q` is the Frobenius
+parameter recorded by the index; on the Suzuki--Ree and Tits branches the Steinberg map is instead
+an odd power of a half-Frobenius, whose square is that same `x ↦ x ^ q`. Either way `𝔽_q` is the
+field of definition, so the map is worth having for every valid index. This file constructs it,
+`TauCeti.ValidLieTypeIndex.frobeniusEquiv`, and identifies the field it fixes.
 
 The construction is Mathlib's iterated Frobenius. Writing `q = p ^ e` with
 `TauCeti.LieTypeIndex.fieldExponent`, the map is the `e`-fold iterate of the `p`-power Frobenius of
 `TauCeti.ValidLieTypeIndex.Closure`, which is a ring *automorphism* because an algebraically closed
 field is perfect. Its fixed field is the copy of `𝔽_q` inside the closure: it has exactly `q`
-elements, it is the unique subfield with that many, and every element of the closure lies in the
-fixed field of some such map. So the ambient field of a group of Lie type is the union of the
-finite fields that its Frobenius powers cut out, and the field of definition attached to the index
-is the one cut out by `frobenius` itself.
+elements, it is the unique subfield with that many, and every element of the closure is fixed by
+some positive iterate. So the ambient field of a group of Lie type is the union of the finite
+fields that its Frobenius powers cut out, and the field of definition attached to the index is the
+one cut out by `frobeniusEquiv` itself.
 
-Nothing here concerns a group. The graph-twisted and Suzuki--Ree branches compose this map with a
-diagram automorphism or replace it by an odd power of a half-Frobenius, and both of those act on a
-group and not on the field; the field-level map is the same `x ↦ x ^ q` on every branch, which is
-why it is defined for every valid index and not only for the untwisted ones.
+Nothing here concerns a group. The graph-twisted branches compose this map with a diagram
+automorphism and the Suzuki--Ree branches replace it by an odd power of a half-Frobenius, and both
+of those act on a group and not on the field; the field-level map is the same `x ↦ x ^ q` on every
+branch, which is why it is defined for every valid index and not only for the untwisted ones.
 
 ## Main definitions
 
-* `TauCeti.ValidLieTypeIndex.frobenius`: the `q`-power Frobenius automorphism of the closure.
+* `TauCeti.ValidLieTypeIndex.frobeniusEquiv`: the `q`-power Frobenius automorphism of the closure.
 * `TauCeti.ValidLieTypeIndex.fixedField`: the subfield it fixes.
 
 ## Main results
 
-* `TauCeti.ValidLieTypeIndex.frobenius_apply` and
-  `TauCeti.ValidLieTypeIndex.iterate_frobenius_apply`: the Frobenius and its iterates raise to the
-  corresponding powers of `q`.
+* `TauCeti.ValidLieTypeIndex.frobeniusEquiv_apply` and
+  `TauCeti.ValidLieTypeIndex.iterate_frobeniusEquiv_apply`: the Frobenius and its iterates raise to
+  the corresponding powers of `q`.
 * `TauCeti.ValidLieTypeIndex.card_fixedField`: the fixed field has `q` elements.
 * `TauCeti.ValidLieTypeIndex.eq_fixedField_of_natCard`: it is the only subfield with `q` elements.
 * `TauCeti.ValidLieTypeIndex.nonempty_ringEquiv_galoisField`: it is a copy of `GaloisField p e`.
-* `TauCeti.ValidLieTypeIndex.mem_frobeniusFixedSubfield_iff_iterate_frobenius_eq`: the `k`-th
-  iterate fixes the field of `q ^ k` elements.
-* `TauCeti.ValidLieTypeIndex.exists_mem_frobeniusFixedSubfield`: the closure is the union of the
-  fixed fields of the iterated Frobenius maps.
+* `TauCeti.ValidLieTypeIndex.mem_frobeniusFixedSubfield_iff_iterate_frobeniusEquiv_eq`: the `k`-th
+  iterate fixes the subfield at exponent `e * k`, which for `k ≠ 0` is the field of `q ^ k`
+  elements.
+* `TauCeti.ValidLieTypeIndex.exists_iterate_frobeniusEquiv_eq`: every element of the closure is
+  fixed by some positive iterate.
 
 ## Roadmap
 
@@ -78,22 +82,20 @@ variable (d : ValidLieTypeIndex)
 
 It is the `fieldExponent`-fold iterate of the `p`-power Frobenius, and is an automorphism rather
 than merely an endomorphism because an algebraically closed field is perfect. -/
-def frobenius : d.Closure ≃+* d.Closure :=
+def frobeniusEquiv : d.Closure ≃+* d.Closure :=
   iterateFrobeniusEquiv d.Closure d.characteristic d.fieldExponent
 
 /-- The Frobenius attached to an index raises to the power recorded by the index. -/
 @[simp]
-theorem frobenius_apply (x : d.Closure) : d.frobenius x = x ^ d.fieldOrder := by
-  rw [frobenius, iterateFrobeniusEquiv_def, ← d.fieldOrder_eq_characteristic_pow]
+theorem frobeniusEquiv_apply (x : d.Closure) : d.frobeniusEquiv x = x ^ d.fieldOrder := by
+  rw [frobeniusEquiv, iterateFrobeniusEquiv_def, ← d.fieldOrder_eq_characteristic_pow]
 
 /-- Iterating the Frobenius attached to an index raises to the corresponding power of `q`. This is
-the form the graph-twisted branches use: their Steinberg map has a `d`-th power equal to the plain
-`Frob_{q ^ d}`, with `d` the order of the diagram automorphism. -/
-theorem iterate_frobenius_apply (k : ℕ) (x : d.Closure) :
-    (d.frobenius : d.Closure → d.Closure)^[k] x = x ^ d.fieldOrder ^ k := by
-  induction k with
-  | zero => simp
-  | succ k ih => rw [Function.iterate_succ_apply', ih, frobenius_apply, ← pow_mul, ← pow_succ]
+the form the graph-twisted branches use: their Steinberg map has an `r`-th power equal to the plain
+`Frob_{q ^ r}`, with `r` the order of the diagram automorphism. -/
+theorem iterate_frobeniusEquiv_apply (k : ℕ) (x : d.Closure) :
+    (d.frobeniusEquiv : d.Closure → d.Closure)^[k] x = x ^ d.fieldOrder ^ k := by
+  rw [show ⇑d.frobeniusEquiv = (· ^ d.fieldOrder) from funext d.frobeniusEquiv_apply, pow_iterate]
 
 /-! ## The field of definition -/
 
@@ -101,6 +103,10 @@ theorem iterate_frobenius_apply (k : ℕ) (x : d.Closure) :
 index: the copy of `𝔽_q` inside the closure, with `q = d.fieldOrder`. -/
 def fixedField : Subfield d.Closure :=
   frobeniusFixedSubfield d.Closure d.characteristic d.fieldExponent
+
+/-- The fixed field is the Frobenius-fixed subfield at the exponent recorded by the index. -/
+theorem fixedField_def :
+    d.fixedField = frobeniusFixedSubfield d.Closure d.characteristic d.fieldExponent := (rfl)
 
 variable {d}
 
@@ -111,9 +117,9 @@ theorem mem_fixedField {x : d.Closure} : x ∈ d.fixedField ↔ x ^ d.fieldOrder
 
 /-- The fixed field is the fixed-point set of the Frobenius, which is what makes it the field of
 definition of the group cut out by that Frobenius. -/
-theorem mem_fixedField_iff_frobenius_eq {x : d.Closure} :
-    x ∈ d.fixedField ↔ d.frobenius x = x := by
-  rw [mem_fixedField, frobenius_apply]
+theorem mem_fixedField_iff_frobeniusEquiv_eq {x : d.Closure} :
+    x ∈ d.fixedField ↔ d.frobeniusEquiv x = x := by
+  rw [mem_fixedField, frobeniusEquiv_apply]
 
 variable (d)
 
@@ -124,7 +130,10 @@ instance : Finite d.fixedField :=
     d.fieldExponent_pos.ne'
 
 /-- **The field of definition has `q` elements.** The subfield of the algebraic closure fixed by
-the Frobenius attached to a valid Lie-type index has exactly `d.fieldOrder` elements. -/
+the Frobenius attached to a valid Lie-type index has exactly `d.fieldOrder` elements.
+
+This is not a `simp` lemma: `mem_fixedField` already rewrites the membership under the coercion,
+so the left-hand side is not in `simp`-normal form. -/
 theorem card_fixedField : Nat.card d.fixedField = d.fieldOrder := by
   rw [fixedField,
     card_frobeniusFixedSubfield d.Closure d.characteristic d.fieldExponent
@@ -133,10 +142,10 @@ theorem card_fixedField : Nat.card d.fixedField = d.fieldOrder := by
 
 /-- The fixed field is the unique subfield of the closure with `d.fieldOrder` elements, so the
 index determines it without reference to the Frobenius that cut it out. -/
-theorem eq_fixedField_of_natCard {F : Subfield d.Closure} [Finite F]
+theorem eq_fixedField_of_natCard {F : Subfield d.Closure}
     (hF : Nat.card F = d.fieldOrder) : F = d.fixedField :=
   eq_frobeniusFixedSubfield_of_natCard d.Closure d.characteristic d.fieldExponent
-    d.fieldExponent_pos.ne' (by rw [hF, d.fieldOrder_eq_characteristic_pow])
+    (by rw [hF, d.fieldOrder_eq_characteristic_pow])
 
 /-- The fixed field is a copy of Mathlib's `GaloisField`, non-canonically. -/
 theorem nonempty_ringEquiv_galoisField :
@@ -144,28 +153,30 @@ theorem nonempty_ringEquiv_galoisField :
   _root_.TauCeti.nonempty_ringEquiv_galoisField d.Closure d.characteristic d.fieldExponent
     d.fieldExponent_pos.ne'
 
+variable {d}
+
+/-- The elements fixed by the `k`-th iterate of the Frobenius are the fixed subfield at exponent
+`fieldExponent * k`, which for `k ≠ 0` is by `card_frobeniusFixedSubfield` the field of `q ^ k`
+elements. This identifies the field of definition of a graph-twisted family's ambient untwisted
+group: the degree `r` extension of `𝔽_q`, with `r` the order of the diagram automorphism. -/
+theorem mem_frobeniusFixedSubfield_iff_iterate_frobeniusEquiv_eq {k : ℕ} {x : d.Closure} :
+    x ∈ frobeniusFixedSubfield d.Closure d.characteristic (d.fieldExponent * k) ↔
+      (d.frobeniusEquiv : d.Closure → d.Closure)^[k] x = x := by
+  rw [iterate_frobeniusEquiv_apply, mem_frobeniusFixedSubfield, pow_mul,
+    ← d.fieldOrder_eq_characteristic_pow]
+
 /-- **The closure is the union of the finite fields inside it.** Every element of the algebraic
-closure attached to a valid Lie-type index is fixed by some positive iterate of the `p`-power
-Frobenius, hence lies in a finite subfield.
+closure attached to a valid Lie-type index is fixed by some positive iterate of the Frobenius,
+hence lies in a finite subfield of the closure.
 
 Together with `card_fixedField` this places the field of definition of the index inside an
 exhaustive tower of finite subfields, and it is why the closure, though itself infinite, carries no
 element that is not algebraic over a field of definition. -/
-theorem exists_mem_frobeniusFixedSubfield (x : d.Closure) :
-    ∃ n ≠ 0, x ∈ frobeniusFixedSubfield d.Closure d.characteristic n :=
-  _root_.TauCeti.exists_mem_frobeniusFixedSubfield d.Closure d.characteristic x
-
-variable {d}
-
-/-- The elements fixed by the `k`-th iterate of the Frobenius are the fixed subfield at exponent
-`fieldExponent * k`, which by `card_frobeniusFixedSubfield` is the field of `q ^ k` elements. This
-identifies the field of definition of a graph-twisted family's ambient untwisted group: the degree
-`d` extension of `𝔽_q`, with `d` the order of the diagram automorphism. -/
-theorem mem_frobeniusFixedSubfield_iff_iterate_frobenius_eq {k : ℕ} {x : d.Closure} :
-    x ∈ frobeniusFixedSubfield d.Closure d.characteristic (d.fieldExponent * k) ↔
-      (d.frobenius : d.Closure → d.Closure)^[k] x = x := by
-  rw [iterate_frobenius_apply, mem_frobeniusFixedSubfield, pow_mul,
-    ← d.fieldOrder_eq_characteristic_pow]
+theorem exists_iterate_frobeniusEquiv_eq (x : d.Closure) :
+    ∃ k ≠ 0, (d.frobeniusEquiv : d.Closure → d.Closure)^[k] x = x := by
+  obtain ⟨n, hn, hx⟩ := exists_mem_frobeniusFixedSubfield d.Closure d.characteristic x
+  exact ⟨n, hn, mem_frobeniusFixedSubfield_iff_iterate_frobeniusEquiv_eq.mp
+    (frobeniusFixedSubfield_le_of_dvd (dvd_mul_left n d.fieldExponent) hx)⟩
 
 end
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Frobenius.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Frobenius.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.Finite.AlgClosedSubfield
+public import TauCeti.GroupTheory.SpecificGroups.CFSG.Closure
+
+/-!
+# The field Frobenius of a Lie-type index
+
+Every Steinberg endomorphism in the CFSG list starts from the map `x ↦ x ^ q` on the algebraic
+closure of the prime field, where `q` is the Frobenius parameter recorded by the index. This file
+constructs that map, `TauCeti.ValidLieTypeIndex.frobenius`, and identifies the field it fixes.
+
+The construction is Mathlib's iterated Frobenius. Writing `q = p ^ e` with
+`TauCeti.LieTypeIndex.fieldExponent`, the map is the `e`-fold iterate of the `p`-power Frobenius of
+`TauCeti.ValidLieTypeIndex.Closure`, which is a ring *automorphism* because an algebraically closed
+field is perfect. Its fixed field is the copy of `𝔽_q` inside the closure: it has exactly `q`
+elements, it is the unique subfield with that many, and every element of the closure lies in the
+fixed field of some such map. So the ambient field of a group of Lie type is the union of the
+finite fields that its Frobenius powers cut out, and the field of definition attached to the index
+is the one cut out by `frobenius` itself.
+
+Nothing here concerns a group. The graph-twisted and Suzuki--Ree branches compose this map with a
+diagram automorphism or replace it by an odd power of a half-Frobenius, and both of those act on a
+group and not on the field; the field-level map is the same `x ↦ x ^ q` on every branch, which is
+why it is defined for every valid index and not only for the untwisted ones.
+
+## Main definitions
+
+* `TauCeti.ValidLieTypeIndex.frobenius`: the `q`-power Frobenius automorphism of the closure.
+* `TauCeti.ValidLieTypeIndex.fixedField`: the subfield it fixes.
+
+## Main results
+
+* `TauCeti.ValidLieTypeIndex.frobenius_apply` and
+  `TauCeti.ValidLieTypeIndex.iterate_frobenius_apply`: the Frobenius and its iterates raise to the
+  corresponding powers of `q`.
+* `TauCeti.ValidLieTypeIndex.card_fixedField`: the fixed field has `q` elements.
+* `TauCeti.ValidLieTypeIndex.eq_fixedField_of_natCard`: it is the only subfield with `q` elements.
+* `TauCeti.ValidLieTypeIndex.nonempty_ringEquiv_galoisField`: it is a copy of `GaloisField p e`.
+* `TauCeti.ValidLieTypeIndex.mem_frobeniusFixedSubfield_iff_iterate_frobenius_eq`: the `k`-th
+  iterate fixes the field of `q ^ k` elements.
+* `TauCeti.ValidLieTypeIndex.exists_mem_frobeniusFixedSubfield`: the closure is the union of the
+  fixed fields of the iterated Frobenius maps.
+
+## Roadmap
+
+This is the field-level half of `Frob_q` in milestone L1 of
+`TauCetiRoadmap/CFSGStatement/README.md`, which sets "`Frob_q` the endomorphism induced on points
+by `x ↦ x ^ d.fieldOrder` on the algebraic closure". The endomorphism of points that L1 asks for
+is induced by this map once milestone L0 supplies the ambient pinned group, which waits on Layer 9
+of `TauCetiRoadmap/ReductiveGroups/README.md`; the map being induced from is this one. The
+`fieldExponent` data it uses belongs to the numbered conventions of milestone I0.
+
+## References
+
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
+* D. Gorenstein, R. Lyons, and R. Solomon, *The Classification of the Finite Simple Groups*,
+  Number 3, §2.
+-/
+
+public section
+
+namespace TauCeti.ValidLieTypeIndex
+
+noncomputable section
+
+variable (d : ValidLieTypeIndex)
+
+/-! ## The Frobenius automorphism -/
+
+/-- The `q`-power Frobenius of the algebraic closure attached to a valid Lie-type index, where
+`q = d.fieldOrder`.
+
+It is the `fieldExponent`-fold iterate of the `p`-power Frobenius, and is an automorphism rather
+than merely an endomorphism because an algebraically closed field is perfect. -/
+def frobenius : d.Closure ≃+* d.Closure :=
+  iterateFrobeniusEquiv d.Closure d.characteristic d.fieldExponent
+
+/-- The Frobenius attached to an index raises to the power recorded by the index. -/
+@[simp]
+theorem frobenius_apply (x : d.Closure) : d.frobenius x = x ^ d.fieldOrder := by
+  rw [frobenius, iterateFrobeniusEquiv_def, ← d.fieldOrder_eq_characteristic_pow]
+
+/-- Iterating the Frobenius attached to an index raises to the corresponding power of `q`. This is
+the form the graph-twisted branches use: their Steinberg map has a `d`-th power equal to the plain
+`Frob_{q ^ d}`, with `d` the order of the diagram automorphism. -/
+theorem iterate_frobenius_apply (k : ℕ) (x : d.Closure) :
+    (d.frobenius : d.Closure → d.Closure)^[k] x = x ^ d.fieldOrder ^ k := by
+  induction k with
+  | zero => simp
+  | succ k ih => rw [Function.iterate_succ_apply', ih, frobenius_apply, ← pow_mul, ← pow_succ]
+
+/-! ## The field of definition -/
+
+/-- The subfield of the algebraic closure fixed by the Frobenius attached to a valid Lie-type
+index: the copy of `𝔽_q` inside the closure, with `q = d.fieldOrder`. -/
+def fixedField : Subfield d.Closure :=
+  frobeniusFixedSubfield d.Closure d.characteristic d.fieldExponent
+
+variable {d}
+
+/-- Membership in the fixed field is the equation `x ^ q = x`. -/
+@[simp]
+theorem mem_fixedField {x : d.Closure} : x ∈ d.fixedField ↔ x ^ d.fieldOrder = x := by
+  rw [fixedField, mem_frobeniusFixedSubfield, d.fieldOrder_eq_characteristic_pow]
+
+/-- The fixed field is the fixed-point set of the Frobenius, which is what makes it the field of
+definition of the group cut out by that Frobenius. -/
+theorem mem_fixedField_iff_frobenius_eq {x : d.Closure} :
+    x ∈ d.fixedField ↔ d.frobenius x = x := by
+  rw [mem_fixedField, frobenius_apply]
+
+variable (d)
+
+/-- The fixed field is finite. The exponent is positive on every branch of the index, so unlike the
+general statement this needs no side condition. -/
+instance : Finite d.fixedField :=
+  finite_frobeniusFixedSubfield d.Closure d.characteristic d.fieldExponent
+    d.fieldExponent_pos.ne'
+
+/-- **The field of definition has `q` elements.** The subfield of the algebraic closure fixed by
+the Frobenius attached to a valid Lie-type index has exactly `d.fieldOrder` elements. -/
+theorem card_fixedField : Nat.card d.fixedField = d.fieldOrder := by
+  rw [fixedField,
+    card_frobeniusFixedSubfield d.Closure d.characteristic d.fieldExponent
+      d.fieldExponent_pos.ne',
+    ← d.fieldOrder_eq_characteristic_pow]
+
+/-- The fixed field is the unique subfield of the closure with `d.fieldOrder` elements, so the
+index determines it without reference to the Frobenius that cut it out. -/
+theorem eq_fixedField_of_natCard {F : Subfield d.Closure} [Finite F]
+    (hF : Nat.card F = d.fieldOrder) : F = d.fixedField :=
+  eq_frobeniusFixedSubfield_of_natCard d.Closure d.characteristic d.fieldExponent
+    d.fieldExponent_pos.ne' (by rw [hF, d.fieldOrder_eq_characteristic_pow])
+
+/-- The fixed field is a copy of Mathlib's `GaloisField`, non-canonically. -/
+theorem nonempty_ringEquiv_galoisField :
+    Nonempty (d.fixedField ≃+* GaloisField d.characteristic d.fieldExponent) :=
+  _root_.TauCeti.nonempty_ringEquiv_galoisField d.Closure d.characteristic d.fieldExponent
+    d.fieldExponent_pos.ne'
+
+/-- **The closure is the union of the finite fields inside it.** Every element of the algebraic
+closure attached to a valid Lie-type index is fixed by some positive iterate of the `p`-power
+Frobenius, hence lies in a finite subfield.
+
+Together with `card_fixedField` this places the field of definition of the index inside an
+exhaustive tower of finite subfields, and it is why the closure, though itself infinite, carries no
+element that is not algebraic over a field of definition. -/
+theorem exists_mem_frobeniusFixedSubfield (x : d.Closure) :
+    ∃ n ≠ 0, x ∈ frobeniusFixedSubfield d.Closure d.characteristic n :=
+  _root_.TauCeti.exists_mem_frobeniusFixedSubfield d.Closure d.characteristic x
+
+variable {d}
+
+/-- The elements fixed by the `k`-th iterate of the Frobenius are the fixed subfield at exponent
+`fieldExponent * k`, which by `card_frobeniusFixedSubfield` is the field of `q ^ k` elements. This
+identifies the field of definition of a graph-twisted family's ambient untwisted group: the degree
+`d` extension of `𝔽_q`, with `d` the order of the diagram automorphism. -/
+theorem mem_frobeniusFixedSubfield_iff_iterate_frobenius_eq {k : ℕ} {x : d.Closure} :
+    x ∈ frobeniusFixedSubfield d.Closure d.characteristic (d.fieldExponent * k) ↔
+      (d.frobenius : d.Closure → d.Closure)^[k] x = x := by
+  rw [iterate_frobenius_apply, mem_frobeniusFixedSubfield, pow_mul,
+    ← d.fieldOrder_eq_characteristic_pow]
+
+end
+
+end TauCeti.ValidLieTypeIndex

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
@@ -80,11 +80,8 @@ theorem ext (q r : PrimePower) (hp : q.p = r.p) (he : q.exponent = r.exponent) :
 /-- The cardinality represented by a prime-power parameter. -/
 def card (q : PrimePower) : ℕ := q.p ^ q.exponent
 
-@[simp] lemma card_mk (p exponent : ℕ) (hp : p.Prime) (he : 0 < exponent) :
-    card ⟨p, exponent, hp, he⟩ = p ^ exponent := (rfl)
-
 /-- The stored cardinality is the stored base raised to the stored exponent. -/
-lemma card_eq_pow (q : PrimePower) : q.card = q.p ^ q.exponent := by cases q; simp
+@[simp] lemma card_eq_pow (q : PrimePower) : q.card = q.p ^ q.exponent := (rfl)
 
 /-- The cardinality stored by a prime-power parameter is a prime power in Mathlib's sense. -/
 lemma isPrimePow_card (q : PrimePower) : IsPrimePow q.card :=

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
@@ -83,6 +83,9 @@ def card (q : PrimePower) : ℕ := q.p ^ q.exponent
 @[simp] lemma card_mk (p exponent : ℕ) (hp : p.Prime) (he : 0 < exponent) :
     card ⟨p, exponent, hp, he⟩ = p ^ exponent := (rfl)
 
+/-- The stored cardinality is the stored base raised to the stored exponent. -/
+lemma card_eq_pow (q : PrimePower) : q.card = q.p ^ q.exponent := by cases q; simp
+
 /-- The cardinality stored by a prime-power parameter is a prime power in Mathlib's sense. -/
 lemma isPrimePow_card (q : PrimePower) : IsPrimePow q.card :=
   q.prime_p.isPrimePow.pow (Nat.ne_of_gt q.exponent_pos)
@@ -404,6 +407,82 @@ def fieldOrder : LieTypeIndex → ℕ
 
 @[simp] theorem fieldOrder_tits : tits.fieldOrder = 2 := by simp only [fieldOrder]
 
+/-- The exponent writing the Frobenius parameter `q` as a power of the characteristic. It is the
+stored exponent of the prime power on the ordinary and graph-twisted branches, and the odd number
+`2 * m + 1` on the Suzuki--Ree branches, whose field order is `p ^ (2 * m + 1)`.
+
+This is not a second numeric parameter: `fieldOrder_eq_characteristic_pow` recovers `fieldOrder`
+from it, and it exists because the `q`-power Frobenius of a field of characteristic `p` is the
+`fieldExponent`-fold iterate of the `p`-power Frobenius. -/
+def fieldExponent : LieTypeIndex → ℕ
+  | .A _ q | .twistedA _ q | .B _ q | .C _ q | .D _ q | .twistedD _ q
+  | .E6 q | .E7 q | .E8 q | .F4 q | .G2 q | .twistedE6 q | .trialityD4 q => q.exponent
+  | .suzuki m | .reeF4 m | .reeG2 m => 2 * m + 1
+  | .tits => 1
+
+@[simp] theorem fieldExponent_A (n : ℕ) (q : PrimePower) : (A n q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_twistedA (n : ℕ) (q : PrimePower) :
+    (twistedA n q).fieldExponent = q.exponent := by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_B (n : ℕ) (q : PrimePower) : (B n q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_C (n : ℕ) (q : PrimePower) : (C n q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_D (n : ℕ) (q : PrimePower) : (D n q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_twistedD (n : ℕ) (q : PrimePower) :
+    (twistedD n q).fieldExponent = q.exponent := by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_E6 (q : PrimePower) : (E6 q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_E7 (q : PrimePower) : (E7 q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_E8 (q : PrimePower) : (E8 q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_F4 (q : PrimePower) : (F4 q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_G2 (q : PrimePower) : (G2 q).fieldExponent = q.exponent :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_twistedE6 (q : PrimePower) :
+    (twistedE6 q).fieldExponent = q.exponent := by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_trialityD4 (q : PrimePower) :
+    (trialityD4 q).fieldExponent = q.exponent := by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_suzuki (m : ℕ) : (suzuki m).fieldExponent = 2 * m + 1 :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_reeF4 (m : ℕ) : (reeF4 m).fieldExponent = 2 * m + 1 :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_reeG2 (m : ℕ) : (reeG2 m).fieldExponent = 2 * m + 1 :=
+  by simp only [fieldExponent]
+
+@[simp] theorem fieldExponent_tits : tits.fieldExponent = 1 := by simp only [fieldExponent]
+
+/-- The Frobenius parameter is the recorded power of the characteristic. -/
+theorem fieldOrder_eq_characteristic_pow (d : LieTypeIndex) :
+    d.fieldOrder = d.characteristic ^ d.fieldExponent := by
+  cases d <;>
+    simp only [fieldOrder, characteristic, fieldExponent, PrimePower.card_eq_pow, pow_one]
+
+/-- The exponent writing the Frobenius parameter as a power of the characteristic is positive, so
+the Frobenius parameter is never `1`. -/
+theorem fieldExponent_pos (d : LieTypeIndex) : 0 < d.fieldExponent := by
+  cases d <;>
+    simp only [fieldExponent] <;>
+    first | exact PrimePower.exponent_pos _ | positivity
+
 end LieTypeIndex
 
 /-- A Lie-type index satisfying its rank, field, and preferred-representative conditions. Later
@@ -450,6 +529,18 @@ instance (d : ValidLieTypeIndex) : Fact d.characteristic.Prime := ⟨d.character
 
 /-- The total Frobenius-parameter map, restricted along the valid-index coercion. -/
 abbrev fieldOrder (d : ValidLieTypeIndex) : ℕ := d.1.fieldOrder
+
+/-- The total field-exponent map, restricted along the valid-index coercion. -/
+abbrev fieldExponent (d : ValidLieTypeIndex) : ℕ := d.1.fieldExponent
+
+/-- The Frobenius parameter of a valid index is the recorded power of its characteristic. -/
+theorem fieldOrder_eq_characteristic_pow (d : ValidLieTypeIndex) :
+    d.fieldOrder = d.characteristic ^ d.fieldExponent :=
+  d.1.fieldOrder_eq_characteristic_pow
+
+/-- The field exponent of a valid index is positive. -/
+theorem fieldExponent_pos (d : ValidLieTypeIndex) : 0 < d.fieldExponent :=
+  d.1.fieldExponent_pos
 
 end ValidLieTypeIndex
 

--- a/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/CFSG/Index.lean
@@ -81,7 +81,7 @@ theorem ext (q r : PrimePower) (hp : q.p = r.p) (he : q.exponent = r.exponent) :
 def card (q : PrimePower) : ℕ := q.p ^ q.exponent
 
 /-- The stored cardinality is the stored base raised to the stored exponent. -/
-@[simp] lemma card_eq_pow (q : PrimePower) : q.card = q.p ^ q.exponent := (rfl)
+@[simp] lemma card_def (q : PrimePower) : q.card = q.p ^ q.exponent := (rfl)
 
 /-- The cardinality stored by a prime-power parameter is a prime power in Mathlib's sense. -/
 lemma isPrimePow_card (q : PrimePower) : IsPrimePow q.card :=
@@ -405,8 +405,9 @@ def fieldOrder : LieTypeIndex → ℕ
 @[simp] theorem fieldOrder_tits : tits.fieldOrder = 2 := by simp only [fieldOrder]
 
 /-- The exponent writing the Frobenius parameter `q` as a power of the characteristic. It is the
-stored exponent of the prime power on the ordinary and graph-twisted branches, and the odd number
-`2 * m + 1` on the Suzuki--Ree branches, whose field order is `p ^ (2 * m + 1)`.
+stored exponent of the prime power on the ordinary and graph-twisted branches, the odd number
+`2 * m + 1` on the Suzuki--Ree branches, whose field order is `p ^ (2 * m + 1)`, and `1` on the
+Tits branch, whose field order is the characteristic `2` itself.
 
 This is not a second numeric parameter: `fieldOrder_eq_characteristic_pow` recovers `fieldOrder`
 from it, and it exists because the `q`-power Frobenius of a field of characteristic `p` is the
@@ -471,7 +472,7 @@ def fieldExponent : LieTypeIndex → ℕ
 theorem fieldOrder_eq_characteristic_pow (d : LieTypeIndex) :
     d.fieldOrder = d.characteristic ^ d.fieldExponent := by
   cases d <;>
-    simp only [fieldOrder, characteristic, fieldExponent, PrimePower.card_eq_pow, pow_one]
+    simp only [fieldOrder, characteristic, fieldExponent, PrimePower.card_def, pow_one]
 
 /-- The exponent writing the Frobenius parameter as a power of the characteristic is positive, so
 the Frobenius parameter is never `1`. -/


### PR DESCRIPTION
This PR constructs the `q`-power Frobenius of the algebraic closure attached to a valid Lie-type index and identifies the subfield it fixes as the field of `q` elements. `TauCeti.ValidLieTypeIndex.frobeniusEquiv` is the `fieldExponent`-fold iterate of the `p`-power Frobenius of `ValidLieTypeIndex.Closure`, a ring automorphism because an algebraically closed field is perfect, and `frobeniusEquiv_apply` unfolds it to `x ↦ x ^ d.fieldOrder`. Its fixed subfield has exactly `d.fieldOrder` elements, is the unique subfield of the closure with that many, and is a copy of Mathlib's `GaloisField`; the `k`-th iterate fixes the field of `q ^ k` elements, and every element of the closure is fixed by some positive iterate, so the closure is the union of the finite fields inside it.

The milestone is `L1` of `CFSGStatement/README.md`, "ordinary and graph Steinberg maps", which sets "let `Frob_q` be the endomorphism induced on points by `x ↦ x ^ d.fieldOrder` on the algebraic closure": this is the map that endomorphism is induced from, stated at the field level where it needs nothing from milestone `L0`. What remains for `L1` after this PR is `L0` itself, the pinned Chevalley--Demazure ambient group whose points `Frob_q` acts on, which waits on Layer 9 of the reductive-groups roadmap.

The general half is `TauCeti/FieldTheory/Finite/SepClosedSubfield.lean` (170 lines), together with the `frobeniusFixedSubfield` additions to `TauCeti/Algebra/CharP/FrobeniusFixed.lean`. That file's existing `TauCeti.frobeniusFixedSubring` — a subring of an arbitrary commutative ring of exponential characteristic `p`, whose module docstring records that "nothing about finiteness or about the field of `q` elements is proved here" — gains its subfield form `TauCeti.frobeniusFixedSubfield` over a field, and the new file closes exactly that gap: over a separably closed field and for `n ≠ 0` the fixed subfield is the root set of the separable polynomial `X ^ p ^ n - X`, so it has `p ^ n` elements (`card_frobeniusFixedSubfield`); a finite subfield of that cardinality is contained in it and therefore equal to it (`eq_frobeniusFixedSubfield_of_natCard`); and an algebraic extension of `ZMod p` is the union of these subfields, since each element generates a finite extension of the prime field (`exists_mem_frobeniusFixedSubfield`).

The index-level half is `TauCeti/GroupTheory/SpecificGroups/CFSG/Frobenius.lean` (192 lines), together with `LieTypeIndex.fieldExponent` and its branch equations added to `CFSG/Index.lean`. The exponent is the numeric datum that writes `fieldOrder` as a power of `characteristic` — `q.exponent` on the ordinary and graph-twisted branches, `2 * m + 1` on the Suzuki--Ree ones, `1` for Tits — and `fieldOrder_eq_characteristic_pow` recovers `fieldOrder` from it, so it is not a second parameter. It belongs with the numbered conventions of milestone `I0`, beside `characteristic` and `fieldOrder`, and exists because the `q`-power Frobenius of a field of characteristic `p` is an iterate of the `p`-power one. `fieldExponent_pos` holds on every branch, which is why finiteness of the fixed field is an instance here and a hypothesis-carrying theorem in the general file. `PrimePower.card_def` is the missing unbundled form of the deleted `card_mk`.

Nothing here concerns a group. The field-level map is the same `x ↦ x ^ q` on every branch, including the graph-twisted and Suzuki--Ree ones, whose extra structure acts on a group and not on the field; no finiteness, simplicity, or order statement about any group of Lie type is involved, and no ambient group is constructed. Nothing is vendored from Mathlib.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"validlietypeindex-frobenius"}-->

🤖 Prepared with Claude Code
