### PR TITLE
feat: build W^{1,p}_0(Ω) and prove the Poincaré inequality on it

### DIFF
--- a/TauCeti/Analysis/Calculus/Gradient.lean
+++ b/TauCeti/Analysis/Calculus/Gradient.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Gradient.Basic
+-- Private: the derivative sum and scalar rules are used only inside the proofs below.
+import Mathlib.Analysis.Calculus.FDeriv.Add
+
+/-!
+# The gradient is an isometric linear image of the Fréchet derivative
+
+Mathlib defines `gradient f x`, written `∇ f x`, as the Riesz representative
+`(InnerProductSpace.toDual 𝕜 F).symm (fderiv 𝕜 f x)` of the Fréchet derivative of a scalar
+function on an inner product space, and develops its differential calculus. This file records the
+three consequences of the defining formula that come from `toDual` being a *conjugate-linear
+isometric equivalence*: the gradient has the same norm as the derivative, it is additive, and it
+is conjugate-homogeneous.
+
+These are exactly what is needed to see a family of gradients as a linear, norm-preserving image
+of the corresponding family of derivatives — for instance to know that `φ ↦ ∇ φ` is linear on
+test functions and that `‖∇ φ‖` may be estimated by any theorem about `‖Dφ‖`.
+
+## Main declarations
+
+* `TauCeti.norm_gradient`: `‖∇ f x‖ = ‖fderiv 𝕜 f x‖`.
+* `TauCeti.gradient_add`: additivity of the gradient at a point of differentiability.
+* `TauCeti.gradient_const_smul`: `∇ (c • f) x = conj c • ∇ f x`.
+-/
+
+public section
+
+namespace TauCeti
+
+open InnerProductSpace
+
+open scoped ComplexConjugate Gradient
+
+variable {𝕜 F : Type*} [RCLike 𝕜] [NormedAddCommGroup F] [InnerProductSpace 𝕜 F]
+  [CompleteSpace F] {f g : F → 𝕜} {x : F}
+
+/-- The gradient has the same norm as the Fréchet derivative it represents: `toDual` is an
+isometry. -/
+theorem norm_gradient (f : F → 𝕜) (x : F) : ‖∇ f x‖ = ‖fderiv 𝕜 f x‖ :=
+  (toDual 𝕜 F).symm.norm_map _
+
+/-- The gradient is additive wherever both summands are differentiable. -/
+theorem gradient_add (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+    ∇ (f + g) x = ∇ f x + ∇ g x := by
+  refine ext_inner_right 𝕜 fun y => ?_
+  rw [inner_add_left, inner_gradient_left, inner_gradient_left, inner_gradient_left,
+    fderiv_add hf hg]
+  rfl
+
+/-- The gradient is conjugate-homogeneous: `toDual` is conjugate-linear, so scaling the function
+by `c` scales the gradient by `conj c`. Over `ℝ` the conjugation is the identity. -/
+theorem gradient_const_smul (hf : DifferentiableAt 𝕜 f x) (c : 𝕜) :
+    ∇ (c • f) x = conj c • ∇ f x := by
+  refine ext_inner_right 𝕜 fun y => ?_
+  rw [inner_smul_left, inner_gradient_left, inner_gradient_left, RingHomCompTriple.comp_apply,
+    RingHom.id_apply, fderiv_const_smul hf c]
+  simp
+
+end TauCeti

--- a/TauCeti/Analysis/Calculus/Gradient.lean
+++ b/TauCeti/Analysis/Calculus/Gradient.lean
@@ -10,7 +10,7 @@ public import Mathlib.Analysis.Calculus.Gradient.Basic
 import Mathlib.Analysis.Calculus.FDeriv.Add
 
 /-!
-# The gradient is an isometric linear image of the Fréchet derivative
+# The gradient is an isometric conjugate-linear image of the Fréchet derivative
 
 Mathlib defines `gradient f x`, written `∇ f x`, as the Riesz representative
 `(InnerProductSpace.toDual 𝕜 F).symm (fderiv 𝕜 f x)` of the Fréchet derivative of a scalar
@@ -19,13 +19,14 @@ three consequences of the defining formula that come from `toDual` being a *conj
 isometric equivalence*: the gradient has the same norm as the derivative, it is additive, and it
 is conjugate-homogeneous.
 
-These are exactly what is needed to see a family of gradients as a linear, norm-preserving image
-of the corresponding family of derivatives — for instance to know that `φ ↦ ∇ φ` is linear on
-test functions and that `‖∇ φ‖` may be estimated by any theorem about `‖Dφ‖`.
+These are exactly what is needed to see a family of gradients as a conjugate-linear,
+norm-preserving image of the corresponding family of derivatives. Over `ℝ` it is linear; for
+instance, `φ ↦ ∇ φ` is linear on real-valued test functions, and `‖∇ φ‖` may be estimated by any
+theorem about `‖Dφ‖`.
 
 ## Main declarations
 
-* `TauCeti.norm_gradient`: `‖∇ f x‖ = ‖fderiv 𝕜 f x‖`.
+* `TauCeti.norm_gradient_eq_norm_fderiv`: `‖∇ f x‖ = ‖fderiv 𝕜 f x‖`.
 * `TauCeti.gradient_add`: additivity of the gradient at a point of differentiability.
 * `TauCeti.gradient_const_smul`: `∇ (c • f) x = conj c • ∇ f x`.
 -/
@@ -43,24 +44,21 @@ variable {𝕜 F : Type*} [RCLike 𝕜] [NormedAddCommGroup F] [InnerProductSpac
 
 /-- The gradient has the same norm as the Fréchet derivative it represents: `toDual` is an
 isometry. -/
-theorem norm_gradient (f : F → 𝕜) (x : F) : ‖∇ f x‖ = ‖fderiv 𝕜 f x‖ :=
+theorem norm_gradient_eq_norm_fderiv (f : F → 𝕜) (x : F) : ‖∇ f x‖ = ‖fderiv 𝕜 f x‖ :=
   (toDual 𝕜 F).symm.norm_map _
 
 /-- The gradient is additive wherever both summands are differentiable. -/
 theorem gradient_add (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
     ∇ (f + g) x = ∇ f x + ∇ g x := by
-  refine ext_inner_right 𝕜 fun y => ?_
-  rw [inner_add_left, inner_gradient_left, inner_gradient_left, inner_gradient_left,
-    fderiv_add hf hg]
-  rfl
+  apply (toDual 𝕜 F).injective
+  simp only [toDual_gradient, map_add, fderiv_add hf hg]
 
 /-- The gradient is conjugate-homogeneous: `toDual` is conjugate-linear, so scaling the function
 by `c` scales the gradient by `conj c`. Over `ℝ` the conjugation is the identity. -/
-theorem gradient_const_smul (hf : DifferentiableAt 𝕜 f x) (c : 𝕜) :
+theorem gradient_const_smul (c : 𝕜) :
     ∇ (c • f) x = conj c • ∇ f x := by
-  refine ext_inner_right 𝕜 fun y => ?_
-  rw [inner_smul_left, inner_gradient_left, inner_gradient_left, RingHomCompTriple.comp_apply,
-    RingHom.id_apply, fderiv_const_smul hf c]
-  simp
+  apply (toDual 𝕜 F).injective
+  simp only [toDual_gradient, map_smulₛₗ, RingHomCompTriple.comp_apply, RingHom.id_apply,
+    fderiv_const_smul_field, Pi.smul_apply]
 
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -310,28 +310,36 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab (hu : ContDiff ℝ 1 u)
         rw [lintegral_eq_lintegral_slabChart hmf]
 
 omit [CompleteSpace F] in
-/-- **The Poincaré inequality on a ball.** A `C¹` function on `ℝ^{n+1}` supported in the ball of
-radius `R` about the origin satisfies `‖u‖_p ≤ 2R ‖Du‖_p` for every `1 ≤ p < ∞`.
+/-- Membership in a Euclidean ball bounds every coordinate by the corresponding slab. -/
+theorem apply_mem_Icc_of_mem_ball {c x : EuclideanSpace ℝ (Fin (n + 1))} {R : ℝ}
+    (hx : x ∈ Metric.ball c R) (i : Fin (n + 1)) : x i ∈ Icc (c i - R) (c i + R) := by
+  have hnorm : ‖x - c‖ < R := by simpa only [Metric.mem_ball, dist_eq_norm] using hx
+  have hi := (PiLp.norm_apply_le (x - c) i).trans hnorm.le
+  rw [Real.norm_eq_abs, WithLp.ofLp_sub, Pi.sub_apply, abs_le] at hi
+  constructor <;> linarith
 
-This is the shape the estimate takes on a bounded domain: any `Ω ⊆ Metric.ball 0 R` sits inside
-a slab of width `2R`, so the constant may be taken to be twice the radius. It is not the optimal
+omit [CompleteSpace F] in
+/-- **The Poincaré inequality on a ball.** A `C¹` function on `ℝ^{n+1}` supported in a ball of
+radius `R` satisfies `‖u‖_p ≤ 2R ‖Du‖_p` for every `1 ≤ p < ∞`.
+
+This is the shape the estimate takes on a bounded domain: any `Ω ⊆ Metric.ball c R` sits inside a
+slab of width `2R`, so the constant may be taken to be twice the radius. It is not the optimal
 constant — for the ball the sharp one is smaller — but it is explicit and depends on nothing but
 `R`, as the roadmap asks. -/
-theorem eLpNorm_le_eLpNorm_fderiv_of_support_subset_ball {R : ℝ} (hu : ContDiff ℝ 1 u)
-    (hsupp : Function.support u ⊆ Metric.ball 0 R) {p : ℝ≥0∞} (hp : 1 ≤ p) (hp' : p ≠ ∞) :
+theorem eLpNorm_le_eLpNorm_fderiv_of_support_subset_ball
+    {c : EuclideanSpace ℝ (Fin (n + 1))} {R : ℝ} (hu : ContDiff ℝ 1 u)
+    (hsupp : Function.support u ⊆ Metric.ball c R) {p : ℝ≥0∞} (hp : 1 ≤ p) (hp' : p ≠ ∞) :
     eLpNorm u p volume ≤ ENNReal.ofReal (2 * R) * eLpNorm (fderiv ℝ u) p volume := by
   rcases le_or_gt R 0 with hR | hR
   · rw [Metric.ball_eq_empty.2 hR, subset_empty_iff, Function.support_eq_empty_iff] at hsupp
     simp [hsupp]
-  have hslab : ∀ x ∈ Function.support u, x (0 : Fin (n + 1)) ∈ Icc (-R) R := by
-    intro x hx
-    have hx' : ‖x‖ < R := by simpa using hsupp hx
-    have := (PiLp.norm_apply_le x (0 : Fin (n + 1))).trans hx'.le
-    rw [Real.norm_eq_abs, abs_le] at this
-    exact this
-  have hwidth : R - -R = 2 * R := by ring
+  have hslab : ∀ x ∈ Function.support u,
+      x (0 : Fin (n + 1)) ∈ Icc (c 0 - R) (c 0 + R) :=
+    fun x hx => apply_mem_Icc_of_mem_ball (hsupp hx) 0
+  have hwidth : (c 0 + R) - (c 0 - R) = 2 * R := by ring
   simpa [hwidth] using
-    eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab hu (by linarith : (-R : ℝ) ≤ R) hslab hp hp'
+    eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab hu
+      (by linarith : c 0 - R ≤ c 0 + R) hslab hp hp'
 
 end Slab
 

--- a/TauCeti/Analysis/Sobolev/Poincare/W1p0.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/W1p0.lean
@@ -23,7 +23,7 @@ Poincaré--Wirtinger is not proved here.
 The estimate for a single test function is
 `TauCeti.eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab`. The set
 `{u | ‖u‖_p ≤ C ‖∇u‖_p}` is closed and contains every test-function jet, so
-`TauCeti.mem_of_mem_w1p0Submodule` passes the estimate to their closure.
+`TauCeti.w1p0Submodule_subset_of_isClosed` passes the estimate to their closure.
 
 The slab hypothesis is load-bearing: no such inequality holds on the whole space, by
 `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`. So is the boundary condition: the
@@ -106,17 +106,8 @@ theorem W1p.norm_value_le_mul_norm_gradient_of_subset_slab (hp : p ≠ ∞) {i :
   have hclosed : IsClosed {v : W1p volume Omega p |
       ‖W1p.value v‖ ≤ (b - a) * ‖W1p.gradient v‖} := by
     simpa only [W1p.valueL_apply, W1p.gradientL_apply] using hclosedL
-  apply mem_of_mem_w1p0Submodule hclosed _ hu
-  intro phi
+  refine w1p0Submodule_subset_of_isClosed hclosed (fun phi => ?_) hu
   simpa using norm_testFunctionLp_le_of_subset_slab hp hab hOmega phi
-
-omit [Fact (1 ≤ p)] in
-private theorem eLpNorm_restrict_eq_zero_of_coe_eq_empty
-    {F : Type*} [NormedAddCommGroup F]
-    (hempty : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) = ∅)
-    (f : EuclideanSpace ℝ (Fin (n + 1)) → F) :
-    eLpNorm f p (volume.restrict (Omega : Set (EuclideanSpace ℝ (Fin (n + 1))))) = 0 := by
-  rw [hempty, Measure.restrict_empty, eLpNorm_measure_zero]
 
 /-- **The Poincaré inequality on `W^{1,p}_0(Ω)` for a bounded domain.** If `1 ≤ p < ∞` and
 `Ω ⊆ ℝ^{n+1}` is contained in a ball of radius `R`, then
@@ -132,9 +123,13 @@ theorem W1p.norm_value_le_mul_norm_gradient_of_subset_ball
   · have hball : Metric.ball c R = ∅ := Metric.ball_eq_empty.2 hR
     have hempty : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) = ∅ :=
       subset_empty_iff.1 (hball ▸ hOmega)
-    rw [Lp.norm_def, Lp.norm_def,
-      eLpNorm_restrict_eq_zero_of_coe_eq_empty hempty,
-      eLpNorm_restrict_eq_zero_of_coe_eq_empty hempty]
+    -- `Ω` is empty, so the measure is zero, its almost-everywhere filter is `⊥`, and every
+    -- `Lᵖ` class over it is `0`; both sides of the inequality vanish.
+    have hbot : ae (volume.restrict (Omega : Set (EuclideanSpace ℝ (Fin (n + 1))))) = ⊥ :=
+      ae_eq_bot.2 (by rw [hempty, Measure.restrict_empty])
+    have hvalue : W1p.value u = 0 := Lp.ext (by rw [hbot]; exact Filter.eventually_bot)
+    have hgradient : W1p.gradient u = 0 := Lp.ext (by rw [hbot]; exact Filter.eventually_bot)
+    rw [hvalue, hgradient]
     simp
   have hslab : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))),
       x (0 : Fin (n + 1)) ∈ Icc (c 0 - R) (c 0 + R) :=

--- a/TauCeti/Analysis/Sobolev/Poincare/W1p0.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/W1p0.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.Poincare.Slab
+public import TauCeti.Analysis.Sobolev.W1p.Zero
+public import Mathlib.MeasureTheory.Constructions.Pi
+
+/-!
+# The Poincaré inequality on `W^{1,p}_0(Ω)`
+
+This file proves the **Poincaré inequality** on `W^{1,p}_0(Ω)`: for `1 ≤ p < ∞` and a domain
+`Ω ⊆ ℝ^{n+1}` trapped between two parallel hyperplanes at distance `b - a`,
+
+`‖u‖_p ≤ (b - a) ‖∇u‖_p` for every `u ∈ W^{1,p}_0(Ω)`.
+
+This is the `W^{1,p}_0` half of Lane A.5 of `TauCetiRoadmap/PDE/README.md`;
+Poincaré--Wirtinger is not proved here.
+
+The estimate for a single test function is
+`TauCeti.eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab`. The set
+`{u | ‖u‖_p ≤ C ‖∇u‖_p}` is closed and contains every test-function jet, so
+`TauCeti.mem_of_mem_w1p0Submodule` passes the estimate to their closure.
+
+The slab hypothesis is load-bearing: no such inequality holds on the whole space, by
+`TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`. So is the boundary condition: the
+constant function `1` on a nonempty bounded open `Ω` lies in `W^{1,p}(Ω)` with zero gradient.
+
+## Main declarations
+
+* `TauCeti.W1p.norm_value_le_mul_norm_gradient_of_subset_slab`: Poincaré on a slab-contained
+  domain.
+* `TauCeti.W1p.norm_value_le_mul_norm_gradient_of_subset_ball`: the bounded-ball corollary.
+
+## References
+
+The `W^{1,p}_0` half of Lane A.5 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans,
+*Partial Differential Equations*, Sections 5.2 and 5.6.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open MeasureTheory Set TopologicalSpace
+open scoped Distributions ENNReal Gradient InnerProductSpace
+
+variable {n : ℕ} {Omega : Opens (EuclideanSpace ℝ (Fin (n + 1)))} {p : ENNReal} [Fact (1 ≤ p)]
+
+omit [Fact (1 ≤ p)] in
+/-- The `Lᵖ` norm of a test function on `Ω` is computed by the ambient Lebesgue measure: the
+function vanishes outside `Ω`, so restricting the measure changes nothing. -/
+private theorem norm_testFunctionLp_eq (phi : 𝓓(Omega, ℝ)) :
+    ‖testFunctionLp (mu := volume) p phi‖ = (eLpNorm (phi : _ → ℝ) p volume).toReal := by
+  rw [norm_testFunctionLp,
+    eLpNorm_restrict_eq_of_support_subset ((subset_tsupport _).trans phi.tsupport_subset)]
+
+omit [Fact (1 ≤ p)] in
+/-- The `Lᵖ` norm of the gradient of a test function on `Ω`, computed by the ambient Lebesgue
+measure and expressed through the Fréchet derivative. -/
+private theorem norm_gradientTestFunctionLp_eq (phi : 𝓓(Omega, ℝ)) :
+    ‖gradientTestFunctionLp (mu := volume) p phi‖ =
+      (eLpNorm (fderiv ℝ (phi : _ → ℝ)) p volume).toReal := by
+  rw [norm_gradientTestFunctionLp,
+    eLpNorm_restrict_eq_of_support_subset (support_gradient_testFunction_subset phi),
+    eLpNorm_congr_norm_ae
+      (ae_of_all _ fun x => norm_gradient_eq_norm_fderiv (𝕜 := ℝ) (phi : _ → ℝ) x)]
+
+/-- The Poincaré inequality for a single test function whose domain lies in a slab. -/
+private theorem norm_testFunctionLp_le_of_subset_slab (hp : p ≠ ∞) {i : Fin (n + 1)} {a b : ℝ}
+    (hab : a ≤ b)
+    (hOmega : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))), x i ∈ Icc a b)
+    (phi : 𝓓(Omega, ℝ)) :
+    ‖testFunctionLp (mu := volume) p phi‖ ≤
+      (b - a) * ‖gradientTestFunctionLp (mu := volume) p phi‖ := by
+  have hfinite : eLpNorm (fderiv ℝ (phi : _ → ℝ)) p volume ≠ ∞ :=
+    ((phi.contDiff.continuous_fderiv (by simp)).memLp_of_hasCompactSupport
+      (phi.hasCompactSupport.fderiv ℝ)).2.ne
+  have hslab := eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab (i := i)
+    (phi.contDiff.of_le (by simp)) hab
+    (fun x hx => hOmega x (phi.tsupport_subset (subset_tsupport _ hx))) Fact.out hp
+  rw [norm_testFunctionLp_eq, norm_gradientTestFunctionLp_eq,
+    ← ENNReal.toReal_ofReal (sub_nonneg.2 hab), ← ENNReal.toReal_mul]
+  exact ENNReal.toReal_mono (ENNReal.mul_ne_top (by finiteness) hfinite) hslab
+
+/-- **The Poincaré inequality on `W^{1,p}_0(Ω)`.** If `1 ≤ p < ∞` and the domain
+`Ω ⊆ ℝ^{n+1}` is trapped between the hyperplanes `xᵢ = a` and `xᵢ = b`, then every
+`u ∈ W^{1,p}_0(Ω)` satisfies `‖u‖_p ≤ (b - a) ‖∇u‖_p`.
+
+Only the width of the slab enters, so `Ω` need not be bounded; boundedness in one direction is
+enough. -/
+theorem W1p.norm_value_le_mul_norm_gradient_of_subset_slab (hp : p ≠ ∞) {i : Fin (n + 1)}
+    {a b : ℝ} (hab : a ≤ b)
+    (hOmega : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))), x i ∈ Icc a b)
+    {u : W1p volume Omega p} (hu : u ∈ w1p0Submodule volume Omega p) :
+    ‖W1p.value u‖ ≤ (b - a) * ‖W1p.gradient u‖ := by
+  have hclosedL : IsClosed {v : W1p volume Omega p |
+      ‖W1p.valueL v‖ ≤ (b - a) * ‖W1p.gradientL v‖} :=
+    isClosed_le (W1p.valueL (mu := volume) (Omega := Omega) (p := p)).continuous.norm
+      ((W1p.gradientL (mu := volume) (Omega := Omega) (p := p)).continuous.norm.const_mul _)
+  have hclosed : IsClosed {v : W1p volume Omega p |
+      ‖W1p.value v‖ ≤ (b - a) * ‖W1p.gradient v‖} := by
+    simpa only [W1p.valueL_apply, W1p.gradientL_apply] using hclosedL
+  apply mem_of_mem_w1p0Submodule hclosed _ hu
+  intro phi
+  simpa using norm_testFunctionLp_le_of_subset_slab hp hab hOmega phi
+
+omit [Fact (1 ≤ p)] in
+private theorem eLpNorm_restrict_eq_zero_of_coe_eq_empty
+    {F : Type*} [NormedAddCommGroup F]
+    (hempty : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) = ∅)
+    (f : EuclideanSpace ℝ (Fin (n + 1)) → F) :
+    eLpNorm f p (volume.restrict (Omega : Set (EuclideanSpace ℝ (Fin (n + 1))))) = 0 := by
+  rw [hempty, Measure.restrict_empty, eLpNorm_measure_zero]
+
+/-- **The Poincaré inequality on `W^{1,p}_0(Ω)` for a bounded domain.** If `1 ≤ p < ∞` and
+`Ω ⊆ ℝ^{n+1}` is contained in a ball of radius `R`, then
+`‖u‖_p ≤ 2R ‖∇u‖_p` for every `u ∈ W^{1,p}_0(Ω)`.
+
+The constant `2R` is not sharp, but it is explicit and independent of the centre. -/
+theorem W1p.norm_value_le_mul_norm_gradient_of_subset_ball
+    {c : EuclideanSpace ℝ (Fin (n + 1))} (hp : p ≠ ∞) {R : ℝ}
+    (hOmega : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) ⊆ Metric.ball c R)
+    {u : W1p volume Omega p} (hu : u ∈ w1p0Submodule volume Omega p) :
+    ‖W1p.value u‖ ≤ 2 * R * ‖W1p.gradient u‖ := by
+  rcases le_or_gt R 0 with hR | hR
+  · have hball : Metric.ball c R = ∅ := Metric.ball_eq_empty.2 hR
+    have hempty : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) = ∅ :=
+      subset_empty_iff.1 (hball ▸ hOmega)
+    rw [Lp.norm_def, Lp.norm_def,
+      eLpNorm_restrict_eq_zero_of_coe_eq_empty hempty,
+      eLpNorm_restrict_eq_zero_of_coe_eq_empty hempty]
+    simp
+  have hslab : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))),
+      x (0 : Fin (n + 1)) ∈ Icc (c 0 - R) (c 0 + R) :=
+    fun x hx => apply_mem_Icc_of_mem_ball (hOmega hx) 0
+  have hwidth : (c 0 + R) - (c 0 - R) = 2 * R := by ring
+  simpa only [hwidth] using W1p.norm_value_le_mul_norm_gradient_of_subset_slab hp
+    (by linarith : c 0 - R ≤ c 0 + R) hslab hu
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/Poincare/W1p0.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/W1p0.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Analysis.Sobolev.Poincare.Slab
 public import TauCeti.Analysis.Sobolev.W1p.Zero
-public import Mathlib.MeasureTheory.Constructions.Pi
 
 /-!
 # The Poincaré inequality on `W^{1,p}_0(Ω)`

--- a/TauCeti/Analysis/Sobolev/TestFunctionLp.lean
+++ b/TauCeti/Analysis/Sobolev/TestFunctionLp.lean
@@ -139,25 +139,4 @@ theorem gradientTestFunctionLp_smul (q : ENNReal) (c : ℝ) (phi : 𝓓(Omega, �
 
 end Gradient
 
-section WeakGradient
-
-variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
-  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
-  {Omega : Opens E}
-
-/-- **A test function is weakly differentiable**, with weak derivative the continuous linear
-functional represented by its gradient. -/
-theorem hasWeakFDerivOn_testFunction (phi : 𝓓(Omega, ℝ)) :
-    HasWeakFDerivOn mu Omega (phi : E → ℝ) fun x => innerSL ℝ (∇ (phi : E → ℝ) x) := by
-  have hcoe : (fun x => innerSL ℝ (∇ (phi : E → ℝ) x)) = fderiv ℝ (phi : E → ℝ) := by
-    funext x
-    ext y
-    simp [inner_gradient_left (𝕜 := ℝ) (f := (phi : E → ℝ)) (x := x) (y := y)]
-  rw [hcoe]
-  refine hasWeakFDerivOn_of_differentiableOn ?_ ?_ fun x _ => differentiable_testFunction phi x
-  · exact phi.continuous.locallyIntegrable.locallyIntegrableOn _
-  · exact (phi.contDiff.continuous_fderiv (by simp)).locallyIntegrable.locallyIntegrableOn _
-
-end WeakGradient
-
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/TestFunctionLp.lean
+++ b/TauCeti/Analysis/Sobolev/TestFunctionLp.lean
@@ -14,6 +14,10 @@ public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 This file provides the generic bridge from compactly supported test functions on an open set to
 `Lp` classes. A test function belongs to every `Lᵖ` space for any measure finite on compact sets.
 The construction is used by the closed-graph presentations of weak Sobolev spaces.
+
+The bridge is linear: `TauCeti.testFunctionLp_add` and `TauCeti.testFunctionLp_smul` record that
+passing to the `Lᵖ` class commutes with the vector space structure of the test functions, which is
+what makes the image of `C_c^∞(Ω)` in an `Lᵖ`-based function space a subspace.
 -/
 
 public section
@@ -41,5 +45,27 @@ def testFunctionLp (q : ENNReal) (phi : 𝓓(Omega, ℝ)) : Lp ℝ q (mu.restric
 theorem testFunctionLp_apply_ae (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
     ∀ᵐ x ∂mu.restrict Omega, testFunctionLp (mu := mu) q phi x = phi x :=
   (memLp_testFunction (mu := mu) q phi).coeFn_toLp
+
+@[simp]
+theorem testFunctionLp_add (q : ENNReal) (phi psi : 𝓓(Omega, ℝ)) :
+    testFunctionLp (mu := mu) q (phi + psi) =
+      testFunctionLp (mu := mu) q phi + testFunctionLp (mu := mu) q psi := by
+  apply Lp.ext
+  filter_upwards [testFunctionLp_apply_ae (mu := mu) q (phi + psi),
+    testFunctionLp_apply_ae (mu := mu) q phi, testFunctionLp_apply_ae (mu := mu) q psi,
+    Lp.coeFn_add (testFunctionLp (mu := mu) q phi) (testFunctionLp (mu := mu) q psi)]
+    with x hsum hphi hpsi hadd
+  rw [hsum, hadd, Pi.add_apply, hphi, hpsi]
+  simp
+
+@[simp]
+theorem testFunctionLp_smul (q : ENNReal) (c : ℝ) (phi : 𝓓(Omega, ℝ)) :
+    testFunctionLp (mu := mu) q (c • phi) = c • testFunctionLp (mu := mu) q phi := by
+  apply Lp.ext
+  filter_upwards [testFunctionLp_apply_ae (mu := mu) q (c • phi),
+    testFunctionLp_apply_ae (mu := mu) q phi,
+    Lp.coeFn_smul c (testFunctionLp (mu := mu) q phi)] with x hsmul hphi hc
+  rw [hsmul, hc, Pi.smul_apply, hphi]
+  simp
 
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/TestFunctionLp.lean
+++ b/TauCeti/Analysis/Sobolev/TestFunctionLp.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Analysis.Calculus.Gradient
 public import TauCeti.Analysis.Sobolev.WeakDeriv
 public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 
@@ -16,8 +17,9 @@ This file provides the generic bridge from compactly supported test functions on
 The construction is used by the closed-graph presentations of weak Sobolev spaces.
 
 The bridge is linear: `TauCeti.testFunctionLp_add` and `TauCeti.testFunctionLp_smul` record that
-passing to the `Lᵖ` class commutes with the vector space structure of the test functions, which is
-what makes the image of `C_c^∞(Ω)` in an `Lᵖ`-based function space a subspace.
+passing to the `Lᵖ` class commutes with the vector space structure of the test functions. For an
+inner product space, `TauCeti.gradientTestFunctionLp` provides the parallel construction for the
+gradient. These facts make the image of `C_c^∞(Ω)` in an `Lᵖ`-based function space a subspace.
 -/
 
 public section
@@ -26,8 +28,8 @@ noncomputable section
 
 namespace TauCeti
 
-open MeasureTheory TopologicalSpace
-open scoped ContDiff Distributions ENNReal
+open MeasureTheory Set TopologicalSpace
+open scoped ContDiff Distributions ENNReal Gradient InnerProductSpace
 
 variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [NormedSpace ℝ E]
   [OpensMeasurableSpace E] {mu : Measure E} [IsFiniteMeasureOnCompacts mu] {Omega : Opens E}
@@ -46,26 +48,116 @@ theorem testFunctionLp_apply_ae (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
     ∀ᵐ x ∂mu.restrict Omega, testFunctionLp (mu := mu) q phi x = phi x :=
   (memLp_testFunction (mu := mu) q phi).coeFn_toLp
 
+/-- The norm of a test function's `Lᵖ` class is its `eLpNorm`, converted to `ℝ`. -/
+theorem norm_testFunctionLp (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
+    ‖testFunctionLp (mu := mu) q phi‖ =
+      (eLpNorm (phi : E → ℝ) q (mu.restrict Omega)).toReal :=
+  Lp.norm_toLp _ _
+
 @[simp]
 theorem testFunctionLp_add (q : ENNReal) (phi psi : 𝓓(Omega, ℝ)) :
     testFunctionLp (mu := mu) q (phi + psi) =
       testFunctionLp (mu := mu) q phi + testFunctionLp (mu := mu) q psi := by
-  apply Lp.ext
-  filter_upwards [testFunctionLp_apply_ae (mu := mu) q (phi + psi),
-    testFunctionLp_apply_ae (mu := mu) q phi, testFunctionLp_apply_ae (mu := mu) q psi,
-    Lp.coeFn_add (testFunctionLp (mu := mu) q phi) (testFunctionLp (mu := mu) q psi)]
-    with x hsum hphi hpsi hadd
-  rw [hsum, hadd, Pi.add_apply, hphi, hpsi]
-  simp
+  rw [testFunctionLp, testFunctionLp, testFunctionLp, ← MemLp.toLp_add]
+  apply MemLp.toLp_congr
+  exact ae_of_all _ fun x => congrFun (FunLike.coe_add phi psi) x
 
 @[simp]
 theorem testFunctionLp_smul (q : ENNReal) (c : ℝ) (phi : 𝓓(Omega, ℝ)) :
     testFunctionLp (mu := mu) q (c • phi) = c • testFunctionLp (mu := mu) q phi := by
-  apply Lp.ext
-  filter_upwards [testFunctionLp_apply_ae (mu := mu) q (c • phi),
-    testFunctionLp_apply_ae (mu := mu) q phi,
-    Lp.coeFn_smul c (testFunctionLp (mu := mu) q phi)] with x hsmul hphi hc
-  rw [hsmul, hc, Pi.smul_apply, hphi]
-  simp
+  rw [testFunctionLp, testFunctionLp, ← MemLp.toLp_const_smul]
+  apply MemLp.toLp_congr
+  exact ae_of_all _ fun x => congrFun (FunLike.coe_smul c phi) x
+
+section Gradient
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteSpace E]
+  {Omega : Opens E}
+
+/-! ### The gradient of a test function -/
+
+/-- The gradient of a test function is continuous. -/
+@[fun_prop]
+theorem continuous_gradient_testFunction (phi : 𝓓(Omega, ℝ)) :
+    Continuous fun x => ∇ (phi : E → ℝ) x :=
+  (InnerProductSpace.toDual ℝ E).symm.continuous.comp
+    (phi.contDiff.continuous_fderiv (by simp))
+
+/-- The gradient of a test function has compact support. -/
+theorem hasCompactSupport_gradient_testFunction (phi : 𝓓(Omega, ℝ)) :
+    HasCompactSupport fun x => ∇ (phi : E → ℝ) x :=
+  (phi.hasCompactSupport.fderiv ℝ).comp_left (map_zero _)
+
+/-- The gradient of a test function on `Ω` vanishes outside `Ω`. -/
+theorem support_gradient_testFunction_subset (phi : 𝓓(Omega, ℝ)) :
+    Function.support (fun x => ∇ (phi : E → ℝ) x) ⊆ (Omega : Set E) :=
+  (Function.support_comp_subset (map_zero (InnerProductSpace.toDual ℝ E).symm) _).trans <|
+    (subset_tsupport _).trans <| (tsupport_fderiv_subset ℝ).trans phi.tsupport_subset
+
+variable [MeasurableSpace E] [OpensMeasurableSpace E] {mu : Measure E}
+  [IsFiniteMeasureOnCompacts mu]
+
+/-- The gradient of a test function on `Ω` is continuous with compact support, so it lies in every
+`Lᵠ(Ω)`. -/
+theorem memLp_gradient_testFunction (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
+    MemLp (fun x => ∇ (phi : E → ℝ) x) q (mu.restrict Omega) :=
+  (continuous_gradient_testFunction phi).memLp_of_hasCompactSupport
+    (hasCompactSupport_gradient_testFunction phi)
+
+/-- The gradient of a test function on `Ω`, as an element of `Lᵠ(Ω, E)`. -/
+def gradientTestFunctionLp (q : ENNReal) (phi : 𝓓(Omega, ℝ)) : Lp E q (mu.restrict Omega) :=
+  (memLp_gradient_testFunction (mu := mu) q phi).toLp _
+
+@[simp]
+theorem gradientTestFunctionLp_apply_ae (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
+    ∀ᵐ x ∂mu.restrict Omega, gradientTestFunctionLp (mu := mu) q phi x = ∇ (phi : E → ℝ) x :=
+  (memLp_gradient_testFunction (mu := mu) q phi).coeFn_toLp
+
+/-- The norm of a test function gradient's `Lᵖ` class is its `eLpNorm`, converted to `ℝ`. -/
+theorem norm_gradientTestFunctionLp (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
+    ‖gradientTestFunctionLp (mu := mu) q phi‖ =
+      (eLpNorm (fun x => ∇ (phi : E → ℝ) x) q (mu.restrict Omega)).toReal :=
+  Lp.norm_toLp _ _
+
+@[simp]
+theorem gradientTestFunctionLp_add (q : ENNReal) (phi psi : 𝓓(Omega, ℝ)) :
+    gradientTestFunctionLp (mu := mu) q (phi + psi) =
+      gradientTestFunctionLp (mu := mu) q phi + gradientTestFunctionLp (mu := mu) q psi := by
+  rw [gradientTestFunctionLp, gradientTestFunctionLp, gradientTestFunctionLp,
+    ← MemLp.toLp_add]
+  apply MemLp.toLp_congr
+  exact ae_of_all _ fun x => gradient_add (differentiable_testFunction phi x)
+    (differentiable_testFunction psi x)
+
+@[simp]
+theorem gradientTestFunctionLp_smul (q : ENNReal) (c : ℝ) (phi : 𝓓(Omega, ℝ)) :
+    gradientTestFunctionLp (mu := mu) q (c • phi) =
+      c • gradientTestFunctionLp (mu := mu) q phi := by
+  rw [gradientTestFunctionLp, gradientTestFunctionLp, ← MemLp.toLp_const_smul]
+  apply MemLp.toLp_congr
+  exact ae_of_all _ fun x => by simpa using gradient_const_smul (f := (phi : E → ℝ)) (x := x) c
+
+end Gradient
+
+section WeakGradient
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
+  {Omega : Opens E}
+
+/-- **A test function is weakly differentiable**, with weak derivative the continuous linear
+functional represented by its gradient. -/
+theorem hasWeakFDerivOn_testFunction (phi : 𝓓(Omega, ℝ)) :
+    HasWeakFDerivOn mu Omega (phi : E → ℝ) fun x => innerSL ℝ (∇ (phi : E → ℝ) x) := by
+  have hcoe : (fun x => innerSL ℝ (∇ (phi : E → ℝ) x)) = fderiv ℝ (phi : E → ℝ) := by
+    funext x
+    ext y
+    simp [inner_gradient_left (𝕜 := ℝ) (f := (phi : E → ℝ)) (x := x) (y := y)]
+  rw [hcoe]
+  refine hasWeakFDerivOn_of_differentiableOn ?_ ?_ fun x _ => differentiable_testFunction phi x
+  · exact phi.continuous.locallyIntegrable.locallyIntegrableOn _
+  · exact (phi.contDiff.continuous_fderiv (by simp)).locallyIntegrable.locallyIntegrableOn _
+
+end WeakGradient
 
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/TestFunctionLp.lean
+++ b/TauCeti/Analysis/Sobolev/TestFunctionLp.lean
@@ -126,8 +126,8 @@ theorem gradientTestFunctionLp_add (q : ENNReal) (phi psi : 𝓓(Omega, ℝ)) :
   rw [gradientTestFunctionLp, gradientTestFunctionLp, gradientTestFunctionLp,
     ← MemLp.toLp_add]
   apply MemLp.toLp_congr
-  exact ae_of_all _ fun x => gradient_add (differentiable_testFunction phi x)
-    (differentiable_testFunction psi x)
+  exact ae_of_all _ fun x => gradient_add ((phi.contDiff.differentiable (by simp)) x)
+    ((psi.contDiff.differentiable (by simp)) x)
 
 @[simp]
 theorem gradientTestFunctionLp_smul (q : ENNReal) (c : ℝ) (phi : 𝓓(Omega, ℝ)) :

--- a/TauCeti/Analysis/Sobolev/W1p/Basic.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Basic.lean
@@ -47,8 +47,8 @@ boundary regularity of `Ω` is used.
 * `TauCeti.W1p`: the corresponding complete normed space.
 * `TauCeti.mem_w1pSubmodule_iff_hasWeakFDerivOn`: membership is exactly weak
   differentiability of the value component with the recorded gradient.
-* `TauCeti.W1p.continuous_value` and `TauCeti.W1p.continuous_gradient`: the two components depend
-  continuously, and linearly, on the Sobolev function.
+* `TauCeti.W1p.valueL` and `TauCeti.W1p.gradientL`: the two components as continuous linear
+  projections from the Sobolev space.
 
 ## References
 
@@ -369,45 +369,6 @@ def W1p.gradient (u : W1p mu Omega p) : Lp E p (mu.restrict Omega) :=
 omit [FiniteDimensional ℝ E] in
 @[simp]
 theorem W1p.gradientL_apply (u : W1p mu Omega p) : W1p.gradientL u = W1p.gradient u := (rfl)
-
-omit [FiniteDimensional ℝ E] in
-/-- The value component of a Sobolev function depends continuously on it: it is the underlying
-map of the continuous linear projection `TauCeti.W1p.valueL`. -/
-theorem W1p.continuous_value :
-    Continuous (W1p.value (mu := mu) (Omega := Omega) (p := p)) :=
-  (W1p.valueL (mu := mu) (Omega := Omega) (p := p)).continuous.congr fun u => W1p.valueL_apply u
-
-omit [FiniteDimensional ℝ E] in
-/-- The weak gradient of a Sobolev function depends continuously on it: it is the underlying map
-of the continuous linear projection `TauCeti.W1p.gradientL`. -/
-theorem W1p.continuous_gradient :
-    Continuous (W1p.gradient (mu := mu) (Omega := Omega) (p := p)) :=
-  (W1p.gradientL (mu := mu) (Omega := Omega) (p := p)).continuous.congr fun u =>
-    W1p.gradientL_apply u
-
-omit [FiniteDimensional ℝ E] in
-@[simp]
-theorem W1p.value_add (u v : W1p mu Omega p) :
-    W1p.value (u + v) = W1p.value u + W1p.value v := by
-  simp only [← W1p.valueL_apply, map_add]
-
-omit [FiniteDimensional ℝ E] in
-@[simp]
-theorem W1p.value_smul (c : ℝ) (u : W1p mu Omega p) :
-    W1p.value (c • u) = c • W1p.value u := by
-  simp only [← W1p.valueL_apply, map_smul]
-
-omit [FiniteDimensional ℝ E] in
-@[simp]
-theorem W1p.gradient_add (u v : W1p mu Omega p) :
-    W1p.gradient (u + v) = W1p.gradient u + W1p.gradient v := by
-  simp only [← W1p.gradientL_apply, map_add]
-
-omit [FiniteDimensional ℝ E] in
-@[simp]
-theorem W1p.gradient_smul (c : ℝ) (u : W1p mu Omega p) :
-    W1p.gradient (c • u) = c • W1p.gradient u := by
-  simp only [← W1p.gradientL_apply, map_smul]
 
 omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure]
     [Fact (1 <= p)] in

--- a/TauCeti/Analysis/Sobolev/W1p/Basic.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Basic.lean
@@ -47,6 +47,8 @@ boundary regularity of `Ω` is used.
 * `TauCeti.W1p`: the corresponding complete normed space.
 * `TauCeti.mem_w1pSubmodule_iff_hasWeakFDerivOn`: membership is exactly weak
   differentiability of the value component with the recorded gradient.
+* `TauCeti.W1p.continuous_value` and `TauCeti.W1p.continuous_gradient`: the two components depend
+  continuously, and linearly, on the Sobolev function.
 
 ## References
 
@@ -367,6 +369,45 @@ def W1p.gradient (u : W1p mu Omega p) : Lp E p (mu.restrict Omega) :=
 omit [FiniteDimensional ℝ E] in
 @[simp]
 theorem W1p.gradientL_apply (u : W1p mu Omega p) : W1p.gradientL u = W1p.gradient u := (rfl)
+
+omit [FiniteDimensional ℝ E] in
+/-- The value component of a Sobolev function depends continuously on it: it is the underlying
+map of the continuous linear projection `TauCeti.W1p.valueL`. -/
+theorem W1p.continuous_value :
+    Continuous (W1p.value (mu := mu) (Omega := Omega) (p := p)) :=
+  (W1p.valueL (mu := mu) (Omega := Omega) (p := p)).continuous.congr fun u => W1p.valueL_apply u
+
+omit [FiniteDimensional ℝ E] in
+/-- The weak gradient of a Sobolev function depends continuously on it: it is the underlying map
+of the continuous linear projection `TauCeti.W1p.gradientL`. -/
+theorem W1p.continuous_gradient :
+    Continuous (W1p.gradient (mu := mu) (Omega := Omega) (p := p)) :=
+  (W1p.gradientL (mu := mu) (Omega := Omega) (p := p)).continuous.congr fun u =>
+    W1p.gradientL_apply u
+
+omit [FiniteDimensional ℝ E] in
+@[simp]
+theorem W1p.value_add (u v : W1p mu Omega p) :
+    W1p.value (u + v) = W1p.value u + W1p.value v := by
+  simp only [← W1p.valueL_apply, map_add]
+
+omit [FiniteDimensional ℝ E] in
+@[simp]
+theorem W1p.value_smul (c : ℝ) (u : W1p mu Omega p) :
+    W1p.value (c • u) = c • W1p.value u := by
+  simp only [← W1p.valueL_apply, map_smul]
+
+omit [FiniteDimensional ℝ E] in
+@[simp]
+theorem W1p.gradient_add (u v : W1p mu Omega p) :
+    W1p.gradient (u + v) = W1p.gradient u + W1p.gradient v := by
+  simp only [← W1p.gradientL_apply, map_add]
+
+omit [FiniteDimensional ℝ E] in
+@[simp]
+theorem W1p.gradient_smul (c : ℝ) (u : W1p mu Omega p) :
+    W1p.gradient (c • u) = c • W1p.gradient u := by
+  simp only [← W1p.gradientL_apply, map_smul]
 
 omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure]
     [Fact (1 <= p)] in

--- a/TauCeti/Analysis/Sobolev/W1p/Zero.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Zero.lean
@@ -35,11 +35,13 @@ subspace under a suitable geometric hypothesis but not on all of `W^{1,p}(Ω)`.
 
 ## Main declarations
 
-* `TauCeti.W1p.ofTestFunctionₗ`: the linear embedding `C_c^∞(Ω) → W^{1,p}(Ω)`.
+* `TauCeti.W1p.ofTestFunctionₗ` and `TauCeti.W1p.ofTestFunctionₗ_injective`: the linear embedding
+  `C_c^∞(Ω) → W^{1,p}(Ω)`, and its injectivity.
 * `TauCeti.w1p0Submodule` and `TauCeti.W1p0`: the space `W^{1,p}_0(Ω)`, complete for the graph
   norm.
-* `TauCeti.mem_of_mem_w1p0Submodule`: extend a closed property from test-function jets to
-  `W^{1,p}_0(Ω)`.
+* `TauCeti.w1p0Submodule_subset_of_isClosed`: a closed set containing every test-function jet
+  contains `W^{1,p}_0(Ω)`, which is how a property is extended from test functions to the whole
+  space.
 
 ## References
 
@@ -66,7 +68,7 @@ omit [Fact (1 ≤ p)] in
 private theorem hasWeakFDerivOn_testFunctionLp (phi : 𝓓(Omega, ℝ)) :
     HasWeakFDerivOn mu Omega (testFunctionLp (mu := mu) p phi)
       fun x => innerSL ℝ (gradientTestFunctionLp (mu := mu) p phi x) := by
-  refine ((hasWeakFDerivOn_testFunction (mu := mu) phi).congr_ae ?_).congr_ae_deriv ?_
+  refine ((hasWeakFDerivOn_testFunction (μ := mu) phi).congr_ae ?_).congr_ae_deriv ?_
   · filter_upwards [testFunctionLp_apply_ae (mu := mu) p phi] with x hx using hx.symm
   · filter_upwards [gradientTestFunctionLp_apply_ae (mu := mu) p phi] with x hx
     rw [hx]
@@ -101,6 +103,31 @@ theorem W1p.gradient_ofTestFunctionₗ (phi : 𝓓(Omega, ℝ)) :
     W1p.gradient (W1p.ofTestFunctionₗ mu Omega p phi) = gradientTestFunctionLp p phi :=
   W1p.gradient_mk _ _ _
 
+/-- The embedding of the test functions is **injective**: two test functions with the same jet
+agree almost everywhere on `Ω`, hence everywhere, being continuous, supported in `Ω`, and measured
+by a Haar measure, which is positive on nonempty open sets. So `W^{1,p}(Ω)` really does contain a
+copy of `C_c^∞(Ω)`, not just a quotient of it. -/
+theorem W1p.ofTestFunctionₗ_injective :
+    Function.Injective (W1p.ofTestFunctionₗ mu Omega p) := by
+  intro phi psi h
+  have hLp : testFunctionLp (mu := mu) p phi = testFunctionLp (mu := mu) p psi := by
+    simpa using congrArg W1p.value h
+  have hae : (phi : E → ℝ) =ᵐ[mu.restrict Omega] (psi : E → ℝ) := by
+    filter_upwards [testFunctionLp_apply_ae (mu := mu) p phi,
+      testFunctionLp_apply_ae (mu := mu) p psi] with x hx hy
+    rw [← hx, ← hy, hLp]
+  have hsubset : {x | (phi : E → ℝ) x ≠ psi x} ⊆ (Omega : Set E) := by
+    intro x hx
+    by_contra hxO
+    exact hx (by rw [image_eq_zero_of_notMem_tsupport fun hc => hxO (phi.tsupport_subset hc),
+      image_eq_zero_of_notMem_tsupport fun hc => hxO (psi.tsupport_subset hc)])
+  have hzero : mu {x | (phi : E → ℝ) x ≠ psi x} = 0 := by
+    have := ae_iff.1 hae
+    rwa [Measure.restrict_apply' Omega.isOpen.measurableSet,
+      Set.inter_eq_self_of_subset_left hsubset] at this
+  have hempty := (isOpen_ne_fun phi.continuous psi.continuous).measure_eq_zero_iff mu |>.1 hzero
+  exact TestFunction.ext fun x => not_not.1 fun hx => Set.eq_empty_iff_forall_notMem.1 hempty x hx
+
 /-! ### The space `W^{1,p}_0(Ω)` -/
 
 /-- **The closed subspace `W^{1,p}_0(Ω)` of `W^{1,p}(Ω)`**: the closure of the test functions
@@ -121,14 +148,13 @@ theorem W1p.ofTestFunctionₗ_mem_w1p0Submodule (phi : 𝓓(Omega, ℝ)) :
     W1p.ofTestFunctionₗ mu Omega p phi ∈ w1p0Submodule mu Omega p :=
   Submodule.mem_closure_iff.2 (Submodule.le_topologicalClosure _ ⟨phi, rfl⟩)
 
-/-- A closed property that holds for every test-function jet holds throughout `W^{1,p}_0(Ω)`. -/
-theorem mem_of_mem_w1p0Submodule {s : Set (W1p mu Omega p)} (hs : IsClosed s)
-    (h : ∀ phi, W1p.ofTestFunctionₗ mu Omega p phi ∈ s) {u : W1p mu Omega p}
-    (hu : u ∈ w1p0Submodule mu Omega p) : u ∈ s := by
-  have hu' : u ∈ closure (Set.range (W1p.ofTestFunctionₗ mu Omega p)) := by
-    rw [← coe_w1p0Submodule]
-    exact hu
-  exact closure_minimal (by rintro _ ⟨phi, rfl⟩; exact h phi) hs hu'
+/-- **Minimality of the closure**: a closed set containing every test-function jet contains all
+of `W^{1,p}_0(Ω)`. -/
+theorem w1p0Submodule_subset_of_isClosed {s : Set (W1p mu Omega p)} (hs : IsClosed s)
+    (h : ∀ phi, W1p.ofTestFunctionₗ mu Omega p phi ∈ s) :
+    (w1p0Submodule mu Omega p : Set (W1p mu Omega p)) ⊆ s := by
+  rw [coe_w1p0Submodule]
+  exact closure_minimal (by rintro _ ⟨phi, rfl⟩; exact h phi) hs
 
 /-- **The Sobolev space `W^{1,p}_0(Ω)`**, the closure of `C_c^∞(Ω)` in `W^{1,p}(Ω)`. -/
 abbrev W1p0 (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)

--- a/TauCeti/Analysis/Sobolev/W1p/Zero.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Zero.lean
@@ -1,0 +1,357 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Calculus.Gradient
+public import TauCeti.Analysis.Sobolev.W1p.Basic
+-- The slab inequality is consumed inside the Poincaré proofs below; its module is imported
+-- publicly because it also carries the Lebesgue measure of `EuclideanSpace ℝ (Fin (n + 1))`,
+-- which the Poincaré statements mention.
+public import TauCeti.Analysis.Sobolev.Poincare.Slab
+public import Mathlib.MeasureTheory.Constructions.Pi
+
+/-!
+# The Sobolev space `W^{1,p}_0(Ω)` and its Poincaré inequality
+
+This file builds `W^{1,p}_0(Ω)`, the closure of the test functions `C_c^∞(Ω)` inside the weak
+Sobolev space `W^{1,p}(Ω)` of `TauCeti/Analysis/Sobolev/W1p/Basic.lean`, and proves the
+**Poincaré inequality** on it: for a domain `Ω ⊆ ℝ^{n+1}` trapped between two parallel
+hyperplanes at distance `b - a`,
+
+`‖u‖_p ≤ (b - a) ‖∇u‖_p` for every `u ∈ W^{1,p}_0(Ω)`.
+
+This is Lane A, items 2 and 5, of `TauCetiRoadmap/PDE/README.md`.
+
+## Test functions as Sobolev functions
+
+The embedding `C_c^∞(Ω) → W^{1,p}(Ω)` sends `φ` to the value-gradient jet `(φ, ∇φ)`, where `∇`
+is Mathlib's `gradient`, the Riesz representative of the Fréchet derivative. Two things have to be
+checked, and both are easy for a test function: the jet is `Lᵖ`, because `φ` and `∇φ` are
+continuous with compact support; and the weak-derivative identity holds, because `∇φ` represents
+the *classical* derivative, which is a weak derivative by
+`TauCeti.hasWeakFDerivOn_of_differentiableOn`. The embedding is linear
+(`TauCeti.W1p.ofTestFunctionLM`), which is what makes its range a subspace — and that is essential
+below, since the Poincaré inequality is preserved by limits but *not* by sums.
+
+## Why the closure, and why not all of `W^{1,p}(Ω)`
+
+`W^{1,p}_0(Ω)` is defined as `TauCeti.w1p0Submodule`, the topological closure of that range. It is
+the Sobolev-space stand-in for the homogeneous Dirichlet boundary condition `u|_{∂Ω} = 0`: no
+boundary regularity of `Ω` is assumed, and no trace operator is needed to state it. The
+distinction from `W^{1,p}(Ω)` is real and is exactly what the Poincaré inequality sees — the
+constant function `1` on a bounded `Ω` lies in `W^{1,p}(Ω)` and has vanishing gradient, so it
+cannot satisfy any inequality `‖u‖_p ≤ C ‖∇u‖_p`.
+
+## The Poincaré inequality
+
+The estimate for a *single* test function is Mathlib-free classical calculus and is already
+available as `TauCeti.eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab`. What this file adds is
+the passage to the closure. The two steps are:
+
+* the set `{u | ‖u‖_p ≤ C ‖∇u‖_p}` is **closed**, because both components of a Sobolev function
+  depend continuously on it; and
+* it **contains the range** of the test-function embedding, by the slab inequality together with
+  `‖∇φ‖ = ‖Dφ‖` (`TauCeti.norm_gradient`) and the fact that restricting the measure to `Ω`
+  does not change the `Lᵖ` norm of a function supported in `Ω`.
+
+Since the range is a *subspace*, its closure is `W^{1,p}_0(Ω)` and `closure_minimal` finishes.
+The set above is closed but is *not* a subspace — `‖u + v‖_p ≤ C‖∇u‖_p + C‖∇v‖_p` says nothing
+about `‖∇(u + v)‖_p` — which is why linearity of the embedding is load-bearing rather than
+cosmetic: the estimate must already hold on the whole span of the test functions, and that span
+is the range only because the embedding is linear.
+
+The hypothesis is that `Ω` lies in a slab, i.e. is bounded *in one direction*; boundedness of `Ω`
+is not needed, and some such hypothesis is: no inequality of this shape holds on the whole space,
+by `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`.
+
+## Main declarations
+
+* `TauCeti.gradientTestFunctionLp`: the gradient of a test function as an `Lᵖ` class, with its
+  additivity and homogeneity.
+* `TauCeti.hasWeakFDerivOn_testFunction`: a test function is weakly differentiable, with weak
+  derivative its gradient.
+* `TauCeti.W1p.ofTestFunctionLM`: the linear embedding `C_c^∞(Ω) → W^{1,p}(Ω)`.
+* `TauCeti.w1p0Submodule` and `TauCeti.W1p0`: the space `W^{1,p}_0(Ω)`, complete for the graph
+  norm.
+* `TauCeti.norm_value_le_of_mem_w1p0Submodule_of_subset_slab` and
+  `TauCeti.norm_value_le_of_mem_w1p0Submodule_of_subset_ball`: the Poincaré inequality.
+
+## References
+
+Lane A.2 and A.5 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans, *Partial Differential
+Equations*, Sections 5.2 and 5.6.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open MeasureTheory Set TopologicalSpace
+open scoped Distributions ENNReal Gradient InnerProductSpace
+
+section Calculus
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteSpace E]
+  {Omega : Opens E}
+
+/-! ### The gradient of a test function -/
+
+omit [CompleteSpace E] in
+/-- A test function is differentiable. -/
+theorem differentiableAt_testFunction (phi : 𝓓(Omega, ℝ)) (x : E) :
+    DifferentiableAt ℝ (phi : E → ℝ) x :=
+  (phi.contDiff.differentiable (by simp)).differentiableAt
+
+/-- The gradient of a test function is continuous. -/
+theorem continuous_gradient_testFunction (phi : 𝓓(Omega, ℝ)) :
+    Continuous fun x => ∇ (phi : E → ℝ) x :=
+  (InnerProductSpace.toDual ℝ E).symm.continuous.comp
+    (phi.contDiff.continuous_fderiv (by simp))
+
+/-- The gradient of a test function has compact support. -/
+theorem hasCompactSupport_gradient_testFunction (phi : 𝓓(Omega, ℝ)) :
+    HasCompactSupport fun x => ∇ (phi : E → ℝ) x :=
+  (phi.hasCompactSupport.fderiv ℝ).comp_left (map_zero _)
+
+/-- The gradient of a test function on `Ω` vanishes outside `Ω`. -/
+theorem support_gradient_testFunction_subset (phi : 𝓓(Omega, ℝ)) :
+    Function.support (fun x => ∇ (phi : E → ℝ) x) ⊆ (Omega : Set E) :=
+  (Function.support_comp_subset (map_zero (InnerProductSpace.toDual ℝ E).symm) _).trans <|
+    (subset_tsupport _).trans <| (tsupport_fderiv_subset ℝ).trans phi.tsupport_subset
+
+end Calculus
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
+  {Omega : Opens E} {p : ENNReal} [Fact (1 ≤ p)]
+
+/-! ### The gradient of a test function in `Lᵖ` -/
+
+/-- The gradient of a test function on `Ω` is continuous with compact support, so it lies in every
+`Lᵠ(Ω)`. -/
+theorem memLp_gradient_testFunction (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
+    MemLp (fun x => ∇ (phi : E → ℝ) x) q (mu.restrict Omega) :=
+  (continuous_gradient_testFunction phi).memLp_of_hasCompactSupport
+    (hasCompactSupport_gradient_testFunction phi)
+
+/-- The gradient of a test function on `Ω`, as an element of `Lᵠ(Ω, E)`. -/
+def gradientTestFunctionLp (q : ENNReal) (phi : 𝓓(Omega, ℝ)) : Lp E q (mu.restrict Omega) :=
+  (memLp_gradient_testFunction (mu := mu) q phi).toLp _
+
+@[simp]
+theorem gradientTestFunctionLp_apply_ae (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
+    ∀ᵐ x ∂mu.restrict Omega, gradientTestFunctionLp (mu := mu) q phi x = ∇ (phi : E → ℝ) x :=
+  (memLp_gradient_testFunction (mu := mu) q phi).coeFn_toLp
+
+@[simp]
+theorem gradientTestFunctionLp_add (q : ENNReal) (phi psi : 𝓓(Omega, ℝ)) :
+    gradientTestFunctionLp (mu := mu) q (phi + psi) =
+      gradientTestFunctionLp (mu := mu) q phi + gradientTestFunctionLp (mu := mu) q psi := by
+  apply Lp.ext
+  filter_upwards [gradientTestFunctionLp_apply_ae (mu := mu) q (phi + psi),
+    gradientTestFunctionLp_apply_ae (mu := mu) q phi,
+    gradientTestFunctionLp_apply_ae (mu := mu) q psi,
+    Lp.coeFn_add (gradientTestFunctionLp (mu := mu) q phi)
+      (gradientTestFunctionLp (mu := mu) q psi)] with x hsum hphi hpsi hadd
+  rw [hsum, hadd, Pi.add_apply, hphi, hpsi,
+    show ((phi + psi : 𝓓(Omega, ℝ)) : E → ℝ) = (phi : E → ℝ) + (psi : E → ℝ) from rfl,
+    gradient_add (differentiableAt_testFunction phi x) (differentiableAt_testFunction psi x)]
+
+@[simp]
+theorem gradientTestFunctionLp_smul (q : ENNReal) (c : ℝ) (phi : 𝓓(Omega, ℝ)) :
+    gradientTestFunctionLp (mu := mu) q (c • phi) =
+      c • gradientTestFunctionLp (mu := mu) q phi := by
+  apply Lp.ext
+  filter_upwards [gradientTestFunctionLp_apply_ae (mu := mu) q (c • phi),
+    gradientTestFunctionLp_apply_ae (mu := mu) q phi,
+    Lp.coeFn_smul c (gradientTestFunctionLp (mu := mu) q phi)] with x hsmul hphi hc
+  rw [hsmul, hc, Pi.smul_apply, hphi,
+    show ((c • phi : 𝓓(Omega, ℝ)) : E → ℝ) = c • (phi : E → ℝ) from rfl,
+    gradient_const_smul (differentiableAt_testFunction phi x) c]
+  simp
+
+/-! ### Test functions as Sobolev functions -/
+
+/-- **A test function is weakly differentiable**, with weak derivative the continuous linear
+functional represented by its gradient. This is the classical derivative, which is a weak one
+because the test function is smooth and everything in sight is locally integrable. -/
+theorem hasWeakFDerivOn_testFunction (phi : 𝓓(Omega, ℝ)) :
+    HasWeakFDerivOn mu Omega (phi : E → ℝ) fun x => innerSL ℝ (∇ (phi : E → ℝ) x) := by
+  have hcoe : (fun x => innerSL ℝ (∇ (phi : E → ℝ) x)) = fderiv ℝ (phi : E → ℝ) := by
+    funext x
+    ext y
+    simp [inner_gradient_left (𝕜 := ℝ) (f := (phi : E → ℝ)) (x := x) (y := y)]
+  rw [hcoe]
+  refine hasWeakFDerivOn_of_differentiableOn ?_ ?_ fun x _ => differentiableAt_testFunction phi x
+  · exact phi.continuous.locallyIntegrable.locallyIntegrableOn _
+  · exact (phi.contDiff.continuous_fderiv (by simp)).locallyIntegrable.locallyIntegrableOn _
+
+omit [Fact (1 ≤ p)] in
+private theorem hasWeakFDerivOn_testFunctionLp (phi : 𝓓(Omega, ℝ)) :
+    HasWeakFDerivOn mu Omega (testFunctionLp (mu := mu) p phi)
+      fun x => innerSL ℝ (gradientTestFunctionLp (mu := mu) p phi x) := by
+  refine ((hasWeakFDerivOn_testFunction (mu := mu) phi).congr_ae ?_).congr_ae_deriv ?_
+  · filter_upwards [testFunctionLp_apply_ae (mu := mu) p phi] with x hx using hx.symm
+  · filter_upwards [gradientTestFunctionLp_apply_ae (mu := mu) p phi] with x hx
+    rw [hx]
+
+/-- **The test functions inside `W^{1,p}(Ω)`**: the linear embedding sending `φ ∈ C_c^∞(Ω)` to the
+value-gradient jet `(φ, ∇φ)`. Linearity is what makes the range a subspace, hence its closure
+`TauCeti.w1p0Submodule` a subspace too. -/
+def W1p.ofTestFunctionLM (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
+    [Fact (1 ≤ p)] : 𝓓(Omega, ℝ) →ₗ[ℝ] W1p mu Omega p where
+  toFun phi := W1p.mk (testFunctionLp p phi) (gradientTestFunctionLp p phi)
+    (hasWeakFDerivOn_testFunctionLp phi)
+  map_add' phi psi := by
+    refine W1p.ext ?_ ?_ <;> simp [W1p.value_add, W1p.gradient_add]
+  map_smul' c phi := by
+    refine W1p.ext ?_ ?_ <;> simp [W1p.value_smul, W1p.gradient_smul]
+
+@[simp]
+theorem W1p.value_ofTestFunctionLM (phi : 𝓓(Omega, ℝ)) :
+    W1p.value (W1p.ofTestFunctionLM mu Omega p phi) = testFunctionLp p phi :=
+  W1p.value_mk _ _ _
+
+@[simp]
+theorem W1p.gradient_ofTestFunctionLM (phi : 𝓓(Omega, ℝ)) :
+    W1p.gradient (W1p.ofTestFunctionLM mu Omega p phi) = gradientTestFunctionLp p phi :=
+  W1p.gradient_mk _ _ _
+
+/-! ### The space `W^{1,p}_0(Ω)` -/
+
+/-- **The closed subspace `W^{1,p}_0(Ω)` of `W^{1,p}(Ω)`**: the closure of the test functions
+`C_c^∞(Ω)`, the Sobolev formulation of the homogeneous Dirichlet boundary condition. No
+regularity, and no boundedness, of `Ω` is assumed. -/
+def w1p0Submodule (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
+    [Fact (1 ≤ p)] : ClosedSubmodule ℝ (W1p mu Omega p) :=
+  (LinearMap.range (W1p.ofTestFunctionLM mu Omega p)).closure
+
+/-- `W^{1,p}_0(Ω)` is the closure of the set of test-function jets. -/
+theorem coe_w1p0Submodule :
+    (w1p0Submodule mu Omega p : Set (W1p mu Omega p)) =
+      closure (Set.range (W1p.ofTestFunctionLM mu Omega p)) := by
+  rw [w1p0Submodule, Submodule.coe_closure, LinearMap.coe_range]
+
+/-- A test function, viewed in `W^{1,p}(Ω)`, lies in `W^{1,p}_0(Ω)`. -/
+theorem W1p.ofTestFunctionLM_mem_w1p0Submodule (phi : 𝓓(Omega, ℝ)) :
+    W1p.ofTestFunctionLM mu Omega p phi ∈ w1p0Submodule mu Omega p :=
+  Submodule.mem_closure_iff.2 (Submodule.le_topologicalClosure _ ⟨phi, rfl⟩)
+
+/-- **The Sobolev space `W^{1,p}_0(Ω)`**, the closure of `C_c^∞(Ω)` in `W^{1,p}(Ω)`. -/
+abbrev W1p0 (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
+    [Fact (1 ≤ p)] := (w1p0Submodule mu Omega p).toSubmodule
+
+/-- `W^{1,p}_0(Ω)` is complete: it is a closed subspace of the complete space `W^{1,p}(Ω)`. -/
+instance : CompleteSpace (W1p0 mu Omega p) :=
+  (w1p0Submodule mu Omega p).isClosed.completeSpace_coe
+
+/-! ### The Poincaré inequality -/
+
+section Poincare
+
+variable {n : ℕ} {Omega : Opens (EuclideanSpace ℝ (Fin (n + 1)))} {p : ENNReal} [Fact (1 ≤ p)]
+
+omit [Fact (1 ≤ p)] in
+/-- The `Lᵖ` norm of a test function on `Ω` is computed by the ambient Lebesgue measure: the
+function vanishes outside `Ω`, so restricting the measure changes nothing. -/
+private theorem norm_testFunctionLp_eq (phi : 𝓓(Omega, ℝ)) :
+    ‖testFunctionLp (mu := volume) p phi‖ = (eLpNorm (phi : _ → ℝ) p volume).toReal := by
+  rw [Lp.norm_def, eLpNorm_congr_ae (testFunctionLp_apply_ae (mu := volume) p phi),
+    eLpNorm_restrict_eq_of_support_subset ((subset_tsupport _).trans phi.tsupport_subset)]
+
+omit [Fact (1 ≤ p)] in
+/-- The `Lᵖ` norm of the gradient of a test function on `Ω`, computed by the ambient Lebesgue
+measure and expressed through the Fréchet derivative. -/
+private theorem norm_gradientTestFunctionLp_eq (phi : 𝓓(Omega, ℝ)) :
+    ‖gradientTestFunctionLp (mu := volume) p phi‖ =
+      (eLpNorm (fderiv ℝ (phi : _ → ℝ)) p volume).toReal := by
+  rw [Lp.norm_def, eLpNorm_congr_ae (gradientTestFunctionLp_apply_ae (mu := volume) p phi),
+    eLpNorm_restrict_eq_of_support_subset (support_gradient_testFunction_subset phi),
+    eLpNorm_congr_norm_ae (ae_of_all _ fun x => norm_gradient (𝕜 := ℝ) (phi : _ → ℝ) x)]
+
+/-- **The Poincaré inequality for a single test function** whose domain lies in a slab: the shape
+in which `TauCeti.eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab` is consumed below. -/
+private theorem norm_testFunctionLp_le_of_subset_slab (hp : p ≠ ∞) {i : Fin (n + 1)} {a b : ℝ}
+    (hab : a ≤ b)
+    (hOmega : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))), x i ∈ Icc a b)
+    (phi : 𝓓(Omega, ℝ)) :
+    ‖testFunctionLp (mu := volume) p phi‖ ≤
+      (b - a) * ‖gradientTestFunctionLp (mu := volume) p phi‖ := by
+  have hfinite : eLpNorm (fderiv ℝ (phi : _ → ℝ)) p volume ≠ ∞ :=
+    ((phi.contDiff.continuous_fderiv (by simp)).memLp_of_hasCompactSupport
+      (phi.hasCompactSupport.fderiv ℝ)).2.ne
+  have hslab := eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab (i := i)
+    (phi.contDiff.of_le (by simp)) hab
+    (fun x hx => hOmega x (phi.tsupport_subset (subset_tsupport _ hx))) Fact.out hp
+  rw [norm_testFunctionLp_eq, norm_gradientTestFunctionLp_eq,
+    ← ENNReal.toReal_ofReal (sub_nonneg.2 hab), ← ENNReal.toReal_mul]
+  exact ENNReal.toReal_mono (by finiteness) hslab
+
+/-- **The Poincaré inequality on `W^{1,p}_0(Ω)`.** If the domain `Ω ⊆ ℝ^{n+1}` is trapped between
+the hyperplanes `xᵢ = a` and `xᵢ = b`, then every `u ∈ W^{1,p}_0(Ω)` satisfies
+`‖u‖_p ≤ (b - a) ‖∇u‖_p`.
+
+Only the width of the slab enters, so `Ω` need not be bounded — bounded in one direction is
+enough. Some such hypothesis is required: the inequality fails outright on the whole space, by
+`TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`. So is the boundary condition: the
+constant function `1` on a bounded `Ω` lies in `W^{1,p}(Ω)` with zero gradient. -/
+theorem norm_value_le_of_mem_w1p0Submodule_of_subset_slab (hp : p ≠ ∞) {i : Fin (n + 1)}
+    {a b : ℝ} (hab : a ≤ b)
+    (hOmega : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))), x i ∈ Icc a b)
+    {u : W1p volume Omega p} (hu : u ∈ w1p0Submodule volume Omega p) :
+    ‖W1p.value u‖ ≤ (b - a) * ‖W1p.gradient u‖ := by
+  have hclosed : IsClosed {v : W1p volume Omega p |
+      ‖W1p.value v‖ ≤ (b - a) * ‖W1p.gradient v‖} :=
+    isClosed_le W1p.continuous_value.norm (W1p.continuous_gradient.norm.const_mul _)
+  have hsub : (w1p0Submodule volume Omega p : Set (W1p volume Omega p)) ⊆
+      {v : W1p volume Omega p | ‖W1p.value v‖ ≤ (b - a) * ‖W1p.gradient v‖} := by
+    rw [coe_w1p0Submodule]
+    refine closure_minimal ?_ hclosed
+    rintro _ ⟨phi, rfl⟩
+    simpa using norm_testFunctionLp_le_of_subset_slab hp hab hOmega phi
+  exact hsub hu
+
+/-- **The Poincaré inequality on `W^{1,p}_0(Ω)` for a bounded domain**: if `Ω ⊆ ℝ^{n+1}` is
+contained in the ball of radius `R` about the origin, then `‖u‖_p ≤ 2R ‖∇u‖_p` for every
+`u ∈ W^{1,p}_0(Ω)`.
+
+The constant `2R` is not sharp — for the ball itself the optimal constant is smaller — but it is
+explicit and depends only on `R`, as the roadmap asks. -/
+theorem norm_value_le_of_mem_w1p0Submodule_of_subset_ball (hp : p ≠ ∞) {R : ℝ}
+    (hOmega : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) ⊆ Metric.ball 0 R)
+    {u : W1p volume Omega p} (hu : u ∈ w1p0Submodule volume Omega p) :
+    ‖W1p.value u‖ ≤ 2 * R * ‖W1p.gradient u‖ := by
+  rcases le_or_gt R 0 with hR | hR
+  · -- The domain is empty, so the restricted measure is zero and both sides vanish.
+    have hball : Metric.ball (0 : EuclideanSpace ℝ (Fin (n + 1))) R = ∅ :=
+      Metric.ball_eq_empty.2 hR
+    have hempty : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) = ∅ :=
+      subset_empty_iff.1 (hball ▸ hOmega)
+    have hzeroR : ∀ f : EuclideanSpace ℝ (Fin (n + 1)) → ℝ,
+        eLpNorm f p (volume.restrict (Omega : Set (EuclideanSpace ℝ (Fin (n + 1))))) = 0 := by
+      intro f
+      rw [hempty, Measure.restrict_empty, eLpNorm_measure_zero]
+    have hzeroE : ∀ f : EuclideanSpace ℝ (Fin (n + 1)) → EuclideanSpace ℝ (Fin (n + 1)),
+        eLpNorm f p (volume.restrict (Omega : Set (EuclideanSpace ℝ (Fin (n + 1))))) = 0 := by
+      intro f
+      rw [hempty, Measure.restrict_empty, eLpNorm_measure_zero]
+    rw [Lp.norm_def, Lp.norm_def, hzeroR, hzeroE]
+    simp
+  have hslab : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))),
+      x (0 : Fin (n + 1)) ∈ Icc (-R) R := by
+    intro x hx
+    have hnorm : ‖x‖ < R := by simpa using hOmega hx
+    have := (PiLp.norm_apply_le x (0 : Fin (n + 1))).trans hnorm.le
+    rwa [Real.norm_eq_abs, abs_le] at this
+  have hwidth : R - -R = 2 * R := by ring
+  simpa [hwidth] using
+    norm_value_le_of_mem_w1p0Submodule_of_subset_slab hp (by linarith : (-R : ℝ) ≤ R) hslab hu
+
+end Poincare
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/Zero.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Zero.lean
@@ -5,25 +5,15 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.Calculus.Gradient
 public import TauCeti.Analysis.Sobolev.W1p.Basic
--- The slab inequality is consumed inside the Poincaré proofs below; its module is imported
--- publicly because it also carries the Lebesgue measure of `EuclideanSpace ℝ (Fin (n + 1))`,
--- which the Poincaré statements mention.
-public import TauCeti.Analysis.Sobolev.Poincare.Slab
-public import Mathlib.MeasureTheory.Constructions.Pi
 
 /-!
-# The Sobolev space `W^{1,p}_0(Ω)` and its Poincaré inequality
+# The Sobolev space `W^{1,p}_0(Ω)`
 
 This file builds `W^{1,p}_0(Ω)`, the closure of the test functions `C_c^∞(Ω)` inside the weak
-Sobolev space `W^{1,p}(Ω)` of `TauCeti/Analysis/Sobolev/W1p/Basic.lean`, and proves the
-**Poincaré inequality** on it: for a domain `Ω ⊆ ℝ^{n+1}` trapped between two parallel
-hyperplanes at distance `b - a`,
-
-`‖u‖_p ≤ (b - a) ‖∇u‖_p` for every `u ∈ W^{1,p}_0(Ω)`.
-
-This is Lane A, items 2 and 5, of `TauCetiRoadmap/PDE/README.md`.
+Sobolev space `W^{1,p}(Ω)` of `TauCeti/Analysis/Sobolev/W1p/Basic.lean`. This is the
+`C_c^∞(Ω)`-closure half of Lane A.2 of `TauCetiRoadmap/PDE/README.md`; Meyers--Serrin density is
+not proved here.
 
 ## Test functions as Sobolev functions
 
@@ -33,56 +23,28 @@ checked, and both are easy for a test function: the jet is `Lᵖ`, because `φ` 
 continuous with compact support; and the weak-derivative identity holds, because `∇φ` represents
 the *classical* derivative, which is a weak derivative by
 `TauCeti.hasWeakFDerivOn_of_differentiableOn`. The embedding is linear
-(`TauCeti.W1p.ofTestFunctionLM`), which is what makes its range a subspace — and that is essential
-below, since the Poincaré inequality is preserved by limits but *not* by sums.
+(`TauCeti.W1p.ofTestFunctionₗ`), which is what makes its range a subspace.
 
 ## Why the closure, and why not all of `W^{1,p}(Ω)`
 
 `W^{1,p}_0(Ω)` is defined as `TauCeti.w1p0Submodule`, the topological closure of that range. It is
 the Sobolev-space stand-in for the homogeneous Dirichlet boundary condition `u|_{∂Ω} = 0`: no
 boundary regularity of `Ω` is assumed, and no trace operator is needed to state it. The
-distinction from `W^{1,p}(Ω)` is real and is exactly what the Poincaré inequality sees — the
-constant function `1` on a bounded `Ω` lies in `W^{1,p}(Ω)` and has vanishing gradient, so it
-cannot satisfy any inequality `‖u‖_p ≤ C ‖∇u‖_p`.
-
-## The Poincaré inequality
-
-The estimate for a *single* test function is Mathlib-free classical calculus and is already
-available as `TauCeti.eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab`. What this file adds is
-the passage to the closure. The two steps are:
-
-* the set `{u | ‖u‖_p ≤ C ‖∇u‖_p}` is **closed**, because both components of a Sobolev function
-  depend continuously on it; and
-* it **contains the range** of the test-function embedding, by the slab inequality together with
-  `‖∇φ‖ = ‖Dφ‖` (`TauCeti.norm_gradient`) and the fact that restricting the measure to `Ω`
-  does not change the `Lᵖ` norm of a function supported in `Ω`.
-
-Since the range is a *subspace*, its closure is `W^{1,p}_0(Ω)` and `closure_minimal` finishes.
-The set above is closed but is *not* a subspace — `‖u + v‖_p ≤ C‖∇u‖_p + C‖∇v‖_p` says nothing
-about `‖∇(u + v)‖_p` — which is why linearity of the embedding is load-bearing rather than
-cosmetic: the estimate must already hold on the whole span of the test functions, and that span
-is the range only because the embedding is linear.
-
-The hypothesis is that `Ω` lies in a slab, i.e. is bounded *in one direction*; boundedness of `Ω`
-is not needed, and some such hypothesis is: no inequality of this shape holds on the whole space,
-by `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`.
+distinction from `W^{1,p}(Ω)` is real: for example, the Poincaré inequality holds on this closed
+subspace under a suitable geometric hypothesis but not on all of `W^{1,p}(Ω)`.
 
 ## Main declarations
 
-* `TauCeti.gradientTestFunctionLp`: the gradient of a test function as an `Lᵖ` class, with its
-  additivity and homogeneity.
-* `TauCeti.hasWeakFDerivOn_testFunction`: a test function is weakly differentiable, with weak
-  derivative its gradient.
-* `TauCeti.W1p.ofTestFunctionLM`: the linear embedding `C_c^∞(Ω) → W^{1,p}(Ω)`.
+* `TauCeti.W1p.ofTestFunctionₗ`: the linear embedding `C_c^∞(Ω) → W^{1,p}(Ω)`.
 * `TauCeti.w1p0Submodule` and `TauCeti.W1p0`: the space `W^{1,p}_0(Ω)`, complete for the graph
   norm.
-* `TauCeti.norm_value_le_of_mem_w1p0Submodule_of_subset_slab` and
-  `TauCeti.norm_value_le_of_mem_w1p0Submodule_of_subset_ball`: the Poincaré inequality.
+* `TauCeti.mem_of_mem_w1p0Submodule`: extend a closed property from test-function jets to
+  `W^{1,p}_0(Ω)`.
 
 ## References
 
-Lane A.2 and A.5 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans, *Partial Differential
-Equations*, Sections 5.2 and 5.6.
+The `C_c^∞(Ω)`-closure half of Lane A.2 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans,
+*Partial Differential Equations*, Section 5.2.
 -/
 
 public section
@@ -92,104 +54,13 @@ noncomputable section
 namespace TauCeti
 
 open MeasureTheory Set TopologicalSpace
-open scoped Distributions ENNReal Gradient InnerProductSpace
-
-section Calculus
-
-variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteSpace E]
-  {Omega : Opens E}
-
-/-! ### The gradient of a test function -/
-
-omit [CompleteSpace E] in
-/-- A test function is differentiable. -/
-theorem differentiableAt_testFunction (phi : 𝓓(Omega, ℝ)) (x : E) :
-    DifferentiableAt ℝ (phi : E → ℝ) x :=
-  (phi.contDiff.differentiable (by simp)).differentiableAt
-
-/-- The gradient of a test function is continuous. -/
-theorem continuous_gradient_testFunction (phi : 𝓓(Omega, ℝ)) :
-    Continuous fun x => ∇ (phi : E → ℝ) x :=
-  (InnerProductSpace.toDual ℝ E).symm.continuous.comp
-    (phi.contDiff.continuous_fderiv (by simp))
-
-/-- The gradient of a test function has compact support. -/
-theorem hasCompactSupport_gradient_testFunction (phi : 𝓓(Omega, ℝ)) :
-    HasCompactSupport fun x => ∇ (phi : E → ℝ) x :=
-  (phi.hasCompactSupport.fderiv ℝ).comp_left (map_zero _)
-
-/-- The gradient of a test function on `Ω` vanishes outside `Ω`. -/
-theorem support_gradient_testFunction_subset (phi : 𝓓(Omega, ℝ)) :
-    Function.support (fun x => ∇ (phi : E → ℝ) x) ⊆ (Omega : Set E) :=
-  (Function.support_comp_subset (map_zero (InnerProductSpace.toDual ℝ E).symm) _).trans <|
-    (subset_tsupport _).trans <| (tsupport_fderiv_subset ℝ).trans phi.tsupport_subset
-
-end Calculus
+open scoped Distributions ENNReal InnerProductSpace
 
 variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
   [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
   {Omega : Opens E} {p : ENNReal} [Fact (1 ≤ p)]
 
-/-! ### The gradient of a test function in `Lᵖ` -/
-
-/-- The gradient of a test function on `Ω` is continuous with compact support, so it lies in every
-`Lᵠ(Ω)`. -/
-theorem memLp_gradient_testFunction (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
-    MemLp (fun x => ∇ (phi : E → ℝ) x) q (mu.restrict Omega) :=
-  (continuous_gradient_testFunction phi).memLp_of_hasCompactSupport
-    (hasCompactSupport_gradient_testFunction phi)
-
-/-- The gradient of a test function on `Ω`, as an element of `Lᵠ(Ω, E)`. -/
-def gradientTestFunctionLp (q : ENNReal) (phi : 𝓓(Omega, ℝ)) : Lp E q (mu.restrict Omega) :=
-  (memLp_gradient_testFunction (mu := mu) q phi).toLp _
-
-@[simp]
-theorem gradientTestFunctionLp_apply_ae (q : ENNReal) (phi : 𝓓(Omega, ℝ)) :
-    ∀ᵐ x ∂mu.restrict Omega, gradientTestFunctionLp (mu := mu) q phi x = ∇ (phi : E → ℝ) x :=
-  (memLp_gradient_testFunction (mu := mu) q phi).coeFn_toLp
-
-@[simp]
-theorem gradientTestFunctionLp_add (q : ENNReal) (phi psi : 𝓓(Omega, ℝ)) :
-    gradientTestFunctionLp (mu := mu) q (phi + psi) =
-      gradientTestFunctionLp (mu := mu) q phi + gradientTestFunctionLp (mu := mu) q psi := by
-  apply Lp.ext
-  filter_upwards [gradientTestFunctionLp_apply_ae (mu := mu) q (phi + psi),
-    gradientTestFunctionLp_apply_ae (mu := mu) q phi,
-    gradientTestFunctionLp_apply_ae (mu := mu) q psi,
-    Lp.coeFn_add (gradientTestFunctionLp (mu := mu) q phi)
-      (gradientTestFunctionLp (mu := mu) q psi)] with x hsum hphi hpsi hadd
-  rw [hsum, hadd, Pi.add_apply, hphi, hpsi,
-    show ((phi + psi : 𝓓(Omega, ℝ)) : E → ℝ) = (phi : E → ℝ) + (psi : E → ℝ) from rfl,
-    gradient_add (differentiableAt_testFunction phi x) (differentiableAt_testFunction psi x)]
-
-@[simp]
-theorem gradientTestFunctionLp_smul (q : ENNReal) (c : ℝ) (phi : 𝓓(Omega, ℝ)) :
-    gradientTestFunctionLp (mu := mu) q (c • phi) =
-      c • gradientTestFunctionLp (mu := mu) q phi := by
-  apply Lp.ext
-  filter_upwards [gradientTestFunctionLp_apply_ae (mu := mu) q (c • phi),
-    gradientTestFunctionLp_apply_ae (mu := mu) q phi,
-    Lp.coeFn_smul c (gradientTestFunctionLp (mu := mu) q phi)] with x hsmul hphi hc
-  rw [hsmul, hc, Pi.smul_apply, hphi,
-    show ((c • phi : 𝓓(Omega, ℝ)) : E → ℝ) = c • (phi : E → ℝ) from rfl,
-    gradient_const_smul (differentiableAt_testFunction phi x) c]
-  simp
-
 /-! ### Test functions as Sobolev functions -/
-
-/-- **A test function is weakly differentiable**, with weak derivative the continuous linear
-functional represented by its gradient. This is the classical derivative, which is a weak one
-because the test function is smooth and everything in sight is locally integrable. -/
-theorem hasWeakFDerivOn_testFunction (phi : 𝓓(Omega, ℝ)) :
-    HasWeakFDerivOn mu Omega (phi : E → ℝ) fun x => innerSL ℝ (∇ (phi : E → ℝ) x) := by
-  have hcoe : (fun x => innerSL ℝ (∇ (phi : E → ℝ) x)) = fderiv ℝ (phi : E → ℝ) := by
-    funext x
-    ext y
-    simp [inner_gradient_left (𝕜 := ℝ) (f := (phi : E → ℝ)) (x := x) (y := y)]
-  rw [hcoe]
-  refine hasWeakFDerivOn_of_differentiableOn ?_ ?_ fun x _ => differentiableAt_testFunction phi x
-  · exact phi.continuous.locallyIntegrable.locallyIntegrableOn _
-  · exact (phi.contDiff.continuous_fderiv (by simp)).locallyIntegrable.locallyIntegrableOn _
 
 omit [Fact (1 ≤ p)] in
 private theorem hasWeakFDerivOn_testFunctionLp (phi : 𝓓(Omega, ℝ)) :
@@ -203,23 +74,33 @@ private theorem hasWeakFDerivOn_testFunctionLp (phi : 𝓓(Omega, ℝ)) :
 /-- **The test functions inside `W^{1,p}(Ω)`**: the linear embedding sending `φ ∈ C_c^∞(Ω)` to the
 value-gradient jet `(φ, ∇φ)`. Linearity is what makes the range a subspace, hence its closure
 `TauCeti.w1p0Submodule` a subspace too. -/
-def W1p.ofTestFunctionLM (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
+def W1p.ofTestFunctionₗ (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
     [Fact (1 ≤ p)] : 𝓓(Omega, ℝ) →ₗ[ℝ] W1p mu Omega p where
   toFun phi := W1p.mk (testFunctionLp p phi) (gradientTestFunctionLp p phi)
     (hasWeakFDerivOn_testFunctionLp phi)
   map_add' phi psi := by
-    refine W1p.ext ?_ ?_ <;> simp [W1p.value_add, W1p.gradient_add]
+    apply W1p.ext
+    · rw [W1p.value_mk, testFunctionLp_add, ← W1p.valueL_apply, map_add,
+        W1p.valueL_apply, W1p.value_mk, W1p.valueL_apply, W1p.value_mk]
+    · rw [W1p.gradient_mk, gradientTestFunctionLp_add, ← W1p.gradientL_apply, map_add,
+        W1p.gradientL_apply, W1p.gradient_mk, W1p.gradientL_apply, W1p.gradient_mk]
   map_smul' c phi := by
-    refine W1p.ext ?_ ?_ <;> simp [W1p.value_smul, W1p.gradient_smul]
+    apply W1p.ext
+    · rw [W1p.value_mk, testFunctionLp_smul, ← W1p.valueL_apply, map_smul,
+        W1p.valueL_apply, W1p.value_mk]
+      simp
+    · rw [W1p.gradient_mk, gradientTestFunctionLp_smul, ← W1p.gradientL_apply, map_smul,
+        W1p.gradientL_apply, W1p.gradient_mk]
+      simp
 
 @[simp]
-theorem W1p.value_ofTestFunctionLM (phi : 𝓓(Omega, ℝ)) :
-    W1p.value (W1p.ofTestFunctionLM mu Omega p phi) = testFunctionLp p phi :=
+theorem W1p.value_ofTestFunctionₗ (phi : 𝓓(Omega, ℝ)) :
+    W1p.value (W1p.ofTestFunctionₗ mu Omega p phi) = testFunctionLp p phi :=
   W1p.value_mk _ _ _
 
 @[simp]
-theorem W1p.gradient_ofTestFunctionLM (phi : 𝓓(Omega, ℝ)) :
-    W1p.gradient (W1p.ofTestFunctionLM mu Omega p phi) = gradientTestFunctionLp p phi :=
+theorem W1p.gradient_ofTestFunctionₗ (phi : 𝓓(Omega, ℝ)) :
+    W1p.gradient (W1p.ofTestFunctionₗ mu Omega p phi) = gradientTestFunctionLp p phi :=
   W1p.gradient_mk _ _ _
 
 /-! ### The space `W^{1,p}_0(Ω)` -/
@@ -229,18 +110,32 @@ theorem W1p.gradient_ofTestFunctionLM (phi : 𝓓(Omega, ℝ)) :
 regularity, and no boundedness, of `Ω` is assumed. -/
 def w1p0Submodule (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
     [Fact (1 ≤ p)] : ClosedSubmodule ℝ (W1p mu Omega p) :=
-  (LinearMap.range (W1p.ofTestFunctionLM mu Omega p)).closure
+  (LinearMap.range (W1p.ofTestFunctionₗ mu Omega p)).closure
 
 /-- `W^{1,p}_0(Ω)` is the closure of the set of test-function jets. -/
 theorem coe_w1p0Submodule :
     (w1p0Submodule mu Omega p : Set (W1p mu Omega p)) =
-      closure (Set.range (W1p.ofTestFunctionLM mu Omega p)) := by
+      closure (Set.range (W1p.ofTestFunctionₗ mu Omega p)) := by
   rw [w1p0Submodule, Submodule.coe_closure, LinearMap.coe_range]
 
+/-- `W^{1,p}_0(Ω)` is the closed-submodule closure of the range of the test-function embedding. -/
+theorem w1p0Submodule_def :
+    w1p0Submodule mu Omega p = (LinearMap.range (W1p.ofTestFunctionₗ mu Omega p)).closure := by
+  apply SetLike.coe_injective
+  rw [coe_w1p0Submodule, Submodule.coe_closure, LinearMap.coe_range]
+
 /-- A test function, viewed in `W^{1,p}(Ω)`, lies in `W^{1,p}_0(Ω)`. -/
-theorem W1p.ofTestFunctionLM_mem_w1p0Submodule (phi : 𝓓(Omega, ℝ)) :
-    W1p.ofTestFunctionLM mu Omega p phi ∈ w1p0Submodule mu Omega p :=
+theorem W1p.ofTestFunctionₗ_mem_w1p0Submodule (phi : 𝓓(Omega, ℝ)) :
+    W1p.ofTestFunctionₗ mu Omega p phi ∈ w1p0Submodule mu Omega p :=
   Submodule.mem_closure_iff.2 (Submodule.le_topologicalClosure _ ⟨phi, rfl⟩)
+
+/-- A closed property that holds for every test-function jet holds throughout `W^{1,p}_0(Ω)`. -/
+theorem mem_of_mem_w1p0Submodule {s : Set (W1p mu Omega p)} (hs : IsClosed s)
+    (h : ∀ phi, W1p.ofTestFunctionₗ mu Omega p phi ∈ s) {u : W1p mu Omega p}
+    (hu : u ∈ w1p0Submodule mu Omega p) : u ∈ s := by
+  change u ∈ (w1p0Submodule mu Omega p : Set (W1p mu Omega p)) at hu
+  rw [coe_w1p0Submodule] at hu
+  exact closure_minimal (by rintro _ ⟨phi, rfl⟩; exact h phi) hs hu
 
 /-- **The Sobolev space `W^{1,p}_0(Ω)`**, the closure of `C_c^∞(Ω)` in `W^{1,p}(Ω)`. -/
 abbrev W1p0 (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)
@@ -249,109 +144,5 @@ abbrev W1p0 (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNRea
 /-- `W^{1,p}_0(Ω)` is complete: it is a closed subspace of the complete space `W^{1,p}(Ω)`. -/
 instance : CompleteSpace (W1p0 mu Omega p) :=
   (w1p0Submodule mu Omega p).isClosed.completeSpace_coe
-
-/-! ### The Poincaré inequality -/
-
-section Poincare
-
-variable {n : ℕ} {Omega : Opens (EuclideanSpace ℝ (Fin (n + 1)))} {p : ENNReal} [Fact (1 ≤ p)]
-
-omit [Fact (1 ≤ p)] in
-/-- The `Lᵖ` norm of a test function on `Ω` is computed by the ambient Lebesgue measure: the
-function vanishes outside `Ω`, so restricting the measure changes nothing. -/
-private theorem norm_testFunctionLp_eq (phi : 𝓓(Omega, ℝ)) :
-    ‖testFunctionLp (mu := volume) p phi‖ = (eLpNorm (phi : _ → ℝ) p volume).toReal := by
-  rw [Lp.norm_def, eLpNorm_congr_ae (testFunctionLp_apply_ae (mu := volume) p phi),
-    eLpNorm_restrict_eq_of_support_subset ((subset_tsupport _).trans phi.tsupport_subset)]
-
-omit [Fact (1 ≤ p)] in
-/-- The `Lᵖ` norm of the gradient of a test function on `Ω`, computed by the ambient Lebesgue
-measure and expressed through the Fréchet derivative. -/
-private theorem norm_gradientTestFunctionLp_eq (phi : 𝓓(Omega, ℝ)) :
-    ‖gradientTestFunctionLp (mu := volume) p phi‖ =
-      (eLpNorm (fderiv ℝ (phi : _ → ℝ)) p volume).toReal := by
-  rw [Lp.norm_def, eLpNorm_congr_ae (gradientTestFunctionLp_apply_ae (mu := volume) p phi),
-    eLpNorm_restrict_eq_of_support_subset (support_gradient_testFunction_subset phi),
-    eLpNorm_congr_norm_ae (ae_of_all _ fun x => norm_gradient (𝕜 := ℝ) (phi : _ → ℝ) x)]
-
-/-- **The Poincaré inequality for a single test function** whose domain lies in a slab: the shape
-in which `TauCeti.eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab` is consumed below. -/
-private theorem norm_testFunctionLp_le_of_subset_slab (hp : p ≠ ∞) {i : Fin (n + 1)} {a b : ℝ}
-    (hab : a ≤ b)
-    (hOmega : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))), x i ∈ Icc a b)
-    (phi : 𝓓(Omega, ℝ)) :
-    ‖testFunctionLp (mu := volume) p phi‖ ≤
-      (b - a) * ‖gradientTestFunctionLp (mu := volume) p phi‖ := by
-  have hfinite : eLpNorm (fderiv ℝ (phi : _ → ℝ)) p volume ≠ ∞ :=
-    ((phi.contDiff.continuous_fderiv (by simp)).memLp_of_hasCompactSupport
-      (phi.hasCompactSupport.fderiv ℝ)).2.ne
-  have hslab := eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab (i := i)
-    (phi.contDiff.of_le (by simp)) hab
-    (fun x hx => hOmega x (phi.tsupport_subset (subset_tsupport _ hx))) Fact.out hp
-  rw [norm_testFunctionLp_eq, norm_gradientTestFunctionLp_eq,
-    ← ENNReal.toReal_ofReal (sub_nonneg.2 hab), ← ENNReal.toReal_mul]
-  exact ENNReal.toReal_mono (by finiteness) hslab
-
-/-- **The Poincaré inequality on `W^{1,p}_0(Ω)`.** If the domain `Ω ⊆ ℝ^{n+1}` is trapped between
-the hyperplanes `xᵢ = a` and `xᵢ = b`, then every `u ∈ W^{1,p}_0(Ω)` satisfies
-`‖u‖_p ≤ (b - a) ‖∇u‖_p`.
-
-Only the width of the slab enters, so `Ω` need not be bounded — bounded in one direction is
-enough. Some such hypothesis is required: the inequality fails outright on the whole space, by
-`TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`. So is the boundary condition: the
-constant function `1` on a bounded `Ω` lies in `W^{1,p}(Ω)` with zero gradient. -/
-theorem norm_value_le_of_mem_w1p0Submodule_of_subset_slab (hp : p ≠ ∞) {i : Fin (n + 1)}
-    {a b : ℝ} (hab : a ≤ b)
-    (hOmega : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))), x i ∈ Icc a b)
-    {u : W1p volume Omega p} (hu : u ∈ w1p0Submodule volume Omega p) :
-    ‖W1p.value u‖ ≤ (b - a) * ‖W1p.gradient u‖ := by
-  have hclosed : IsClosed {v : W1p volume Omega p |
-      ‖W1p.value v‖ ≤ (b - a) * ‖W1p.gradient v‖} :=
-    isClosed_le W1p.continuous_value.norm (W1p.continuous_gradient.norm.const_mul _)
-  have hsub : (w1p0Submodule volume Omega p : Set (W1p volume Omega p)) ⊆
-      {v : W1p volume Omega p | ‖W1p.value v‖ ≤ (b - a) * ‖W1p.gradient v‖} := by
-    rw [coe_w1p0Submodule]
-    refine closure_minimal ?_ hclosed
-    rintro _ ⟨phi, rfl⟩
-    simpa using norm_testFunctionLp_le_of_subset_slab hp hab hOmega phi
-  exact hsub hu
-
-/-- **The Poincaré inequality on `W^{1,p}_0(Ω)` for a bounded domain**: if `Ω ⊆ ℝ^{n+1}` is
-contained in the ball of radius `R` about the origin, then `‖u‖_p ≤ 2R ‖∇u‖_p` for every
-`u ∈ W^{1,p}_0(Ω)`.
-
-The constant `2R` is not sharp — for the ball itself the optimal constant is smaller — but it is
-explicit and depends only on `R`, as the roadmap asks. -/
-theorem norm_value_le_of_mem_w1p0Submodule_of_subset_ball (hp : p ≠ ∞) {R : ℝ}
-    (hOmega : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) ⊆ Metric.ball 0 R)
-    {u : W1p volume Omega p} (hu : u ∈ w1p0Submodule volume Omega p) :
-    ‖W1p.value u‖ ≤ 2 * R * ‖W1p.gradient u‖ := by
-  rcases le_or_gt R 0 with hR | hR
-  · -- The domain is empty, so the restricted measure is zero and both sides vanish.
-    have hball : Metric.ball (0 : EuclideanSpace ℝ (Fin (n + 1))) R = ∅ :=
-      Metric.ball_eq_empty.2 hR
-    have hempty : (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))) = ∅ :=
-      subset_empty_iff.1 (hball ▸ hOmega)
-    have hzeroR : ∀ f : EuclideanSpace ℝ (Fin (n + 1)) → ℝ,
-        eLpNorm f p (volume.restrict (Omega : Set (EuclideanSpace ℝ (Fin (n + 1))))) = 0 := by
-      intro f
-      rw [hempty, Measure.restrict_empty, eLpNorm_measure_zero]
-    have hzeroE : ∀ f : EuclideanSpace ℝ (Fin (n + 1)) → EuclideanSpace ℝ (Fin (n + 1)),
-        eLpNorm f p (volume.restrict (Omega : Set (EuclideanSpace ℝ (Fin (n + 1))))) = 0 := by
-      intro f
-      rw [hempty, Measure.restrict_empty, eLpNorm_measure_zero]
-    rw [Lp.norm_def, Lp.norm_def, hzeroR, hzeroE]
-    simp
-  have hslab : ∀ x ∈ (Omega : Set (EuclideanSpace ℝ (Fin (n + 1)))),
-      x (0 : Fin (n + 1)) ∈ Icc (-R) R := by
-    intro x hx
-    have hnorm : ‖x‖ < R := by simpa using hOmega hx
-    have := (PiLp.norm_apply_le x (0 : Fin (n + 1))).trans hnorm.le
-    rwa [Real.norm_eq_abs, abs_le] at this
-  have hwidth : R - -R = 2 * R := by ring
-  simpa [hwidth] using
-    norm_value_le_of_mem_w1p0Submodule_of_subset_slab hp (by linarith : (-R : ℝ) ≤ R) hslab hu
-
-end Poincare
 
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/Zero.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Zero.lean
@@ -81,17 +81,11 @@ def W1p.ofTestFunctionₗ (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens 
   toFun phi := W1p.mk (testFunctionLp p phi) (gradientTestFunctionLp p phi)
     (hasWeakFDerivOn_testFunctionLp phi)
   map_add' phi psi := by
-    apply W1p.ext
-    · rw [W1p.value_mk, testFunctionLp_add, ← W1p.valueL_apply, map_add]
-      simp
-    · rw [W1p.gradient_mk, gradientTestFunctionLp_add, ← W1p.gradientL_apply, map_add]
-      simp
+    apply W1p.ext <;>
+      simp only [← W1p.valueL_apply, ← W1p.gradientL_apply, map_add] <;> simp
   map_smul' c phi := by
-    apply W1p.ext
-    · rw [W1p.value_mk, testFunctionLp_smul, ← W1p.valueL_apply, map_smul]
-      simp
-    · rw [W1p.gradient_mk, gradientTestFunctionLp_smul, ← W1p.gradientL_apply, map_smul]
-      simp
+    apply W1p.ext <;>
+      simp only [← W1p.valueL_apply, ← W1p.gradientL_apply, map_smul] <;> simp
 
 @[simp]
 theorem W1p.value_ofTestFunctionₗ (phi : 𝓓(Omega, ℝ)) :

--- a/TauCeti/Analysis/Sobolev/W1p/Zero.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Zero.lean
@@ -80,17 +80,15 @@ def W1p.ofTestFunctionₗ (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens 
     (hasWeakFDerivOn_testFunctionLp phi)
   map_add' phi psi := by
     apply W1p.ext
-    · rw [W1p.value_mk, testFunctionLp_add, ← W1p.valueL_apply, map_add,
-        W1p.valueL_apply, W1p.value_mk, W1p.valueL_apply, W1p.value_mk]
-    · rw [W1p.gradient_mk, gradientTestFunctionLp_add, ← W1p.gradientL_apply, map_add,
-        W1p.gradientL_apply, W1p.gradient_mk, W1p.gradientL_apply, W1p.gradient_mk]
+    · rw [W1p.value_mk, testFunctionLp_add, ← W1p.valueL_apply, map_add]
+      simp
+    · rw [W1p.gradient_mk, gradientTestFunctionLp_add, ← W1p.gradientL_apply, map_add]
+      simp
   map_smul' c phi := by
     apply W1p.ext
-    · rw [W1p.value_mk, testFunctionLp_smul, ← W1p.valueL_apply, map_smul,
-        W1p.valueL_apply, W1p.value_mk]
+    · rw [W1p.value_mk, testFunctionLp_smul, ← W1p.valueL_apply, map_smul]
       simp
-    · rw [W1p.gradient_mk, gradientTestFunctionLp_smul, ← W1p.gradientL_apply, map_smul,
-        W1p.gradientL_apply, W1p.gradient_mk]
+    · rw [W1p.gradient_mk, gradientTestFunctionLp_smul, ← W1p.gradientL_apply, map_smul]
       simp
 
 @[simp]
@@ -118,12 +116,6 @@ theorem coe_w1p0Submodule :
       closure (Set.range (W1p.ofTestFunctionₗ mu Omega p)) := by
   rw [w1p0Submodule, Submodule.coe_closure, LinearMap.coe_range]
 
-/-- `W^{1,p}_0(Ω)` is the closed-submodule closure of the range of the test-function embedding. -/
-theorem w1p0Submodule_def :
-    w1p0Submodule mu Omega p = (LinearMap.range (W1p.ofTestFunctionₗ mu Omega p)).closure := by
-  apply SetLike.coe_injective
-  rw [coe_w1p0Submodule, Submodule.coe_closure, LinearMap.coe_range]
-
 /-- A test function, viewed in `W^{1,p}(Ω)`, lies in `W^{1,p}_0(Ω)`. -/
 theorem W1p.ofTestFunctionₗ_mem_w1p0Submodule (phi : 𝓓(Omega, ℝ)) :
     W1p.ofTestFunctionₗ mu Omega p phi ∈ w1p0Submodule mu Omega p :=
@@ -133,9 +125,10 @@ theorem W1p.ofTestFunctionₗ_mem_w1p0Submodule (phi : 𝓓(Omega, ℝ)) :
 theorem mem_of_mem_w1p0Submodule {s : Set (W1p mu Omega p)} (hs : IsClosed s)
     (h : ∀ phi, W1p.ofTestFunctionₗ mu Omega p phi ∈ s) {u : W1p mu Omega p}
     (hu : u ∈ w1p0Submodule mu Omega p) : u ∈ s := by
-  change u ∈ (w1p0Submodule mu Omega p : Set (W1p mu Omega p)) at hu
-  rw [coe_w1p0Submodule] at hu
-  exact closure_minimal (by rintro _ ⟨phi, rfl⟩; exact h phi) hs hu
+  have hu' : u ∈ closure (Set.range (W1p.ofTestFunctionₗ mu Omega p)) := by
+    rw [← coe_w1p0Submodule]
+    exact hu
+  exact closure_minimal (by rintro _ ⟨phi, rfl⟩; exact h phi) hs hu'
 
 /-- **The Sobolev space `W^{1,p}_0(Ω)`**, the closure of `C_c^∞(Ω)` in `W^{1,p}(Ω)`. -/
 abbrev W1p0 (mu : Measure E) [mu.IsAddHaarMeasure] (Omega : Opens E) (p : ENNReal)

--- a/TauCeti/Analysis/Sobolev/W2p.lean
+++ b/TauCeti/Analysis/Sobolev/W2p.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Sobolev.GraphStep
-public import TauCeti.Analysis.Sobolev.W1p
+public import TauCeti.Analysis.Sobolev.W1p.Basic
 
 /-!
 # Second-order weak Sobolev spaces

--- a/TauCeti/Analysis/Sobolev/WeakDeriv.lean
+++ b/TauCeti/Analysis/Sobolev/WeakDeriv.lean
@@ -156,11 +156,15 @@ variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-! ### Derivatives of test functions -/
 
+/-- A test function is differentiable. -/
+@[fun_prop]
+theorem differentiable_testFunction (φ : 𝓓(Ω, ℝ)) : Differentiable ℝ (φ : E → ℝ) :=
+  φ.contDiff.differentiable (by simp)
+
 /-- Outside its support, the directional derivative of a test function vanishes. -/
 theorem lineDeriv_eq_zero_of_notMem_tsupport (φ : 𝓓(Ω, ℝ)) {x : E}
     (hx : x ∉ tsupport (φ : E → ℝ)) (v : E) : lineDeriv ℝ (φ : E → ℝ) x v = 0 := by
-  have hd : DifferentiableAt ℝ (φ : E → ℝ) x :=
-    (φ.contDiff.differentiable (by simp)).differentiableAt
+  have hd : DifferentiableAt ℝ (φ : E → ℝ) x := differentiable_testFunction φ x
   rw [hd.lineDeriv_eq_fderiv, fderiv_of_notMem_tsupport ℝ hx]
   simp
 
@@ -515,7 +519,7 @@ theorem hasWeakLineDerivOn_of_hasLineDerivAt (hu : LocallyIntegrableOn u Ω μ)
     (hu' : LocallyIntegrableOn u' Ω μ) (h : ∀ x ∈ (Ω : Set E), HasLineDerivAt ℝ u (u' x) x v) :
     HasWeakLineDerivOn μ Ω u u' v := by
   refine ⟨‹CompleteSpace F›, hu, hu', fun φ => ?_⟩
-  have hφd : Differentiable ℝ (φ : E → ℝ) := φ.contDiff.differentiable (by simp)
+  have hφd := differentiable_testFunction φ
   have key := integral_bilinear_hasLineDerivAt_right_eq_neg_left_of_integrable
     (μ := μ) (f := u) (f' := u') (g := (φ : E → ℝ))
     (g' := fun x => lineDeriv ℝ (φ : E → ℝ) x v) (v := v)

--- a/TauCeti/Analysis/Sobolev/WeakDeriv.lean
+++ b/TauCeti/Analysis/Sobolev/WeakDeriv.lean
@@ -13,6 +13,9 @@ public import Mathlib.Analysis.Distribution.TestFunction
 -- uniqueness, so downstream importers pay for neither.
 import Mathlib.Analysis.Calculus.LineDeriv.IntegrationByParts
 import Mathlib.Analysis.Distribution.AEEqOfIntegralContDiff
+-- This import is public: `Gradient` supplies the `∇` of the weak derivative of a test function
+-- below, together with the Riesz correspondence `innerSL` in which that statement is phrased.
+public import Mathlib.Analysis.Calculus.Gradient.Basic
 
 /-!
 # Weak derivatives on an open set
@@ -137,6 +140,8 @@ weaken them for no gain.
   `TauCeti.hasWeakFDerivOn_of_differentiableOn`: classical derivatives that are locally integrable
   on `Ω` are weak derivatives.
 * `TauCeti.hasWeakLineDerivOn_const`: against a Haar measure, a constant has weak derivative `0`.
+* `TauCeti.hasWeakFDerivOn_testFunction`: a test function has weak derivative the linear
+  functional represented by its gradient.
 * `TauCeti.HasWeakLineDerivOn.ae_eq` and `TauCeti.HasWeakFDerivOn.ae_eq`: uniqueness almost
   everywhere on `Ω`.
 * `TauCeti.HasWeakLineDerivOn.ae_eq_lineDeriv` and `TauCeti.HasWeakFDerivOn.ae_eq_fderiv`: where
@@ -554,6 +559,34 @@ theorem hasWeakFDerivOn_of_differentiableOn (hu : LocallyIntegrableOn u Ω μ)
     fun x hx => (h x hx).hasFDerivAt.hasLineDerivAt v
 
 end Classical
+
+/-! ### Test functions are weakly differentiable
+
+A test function is the basic example: it is smooth, so its classical derivative is also a weak
+one. On an inner product space the derivative is recorded through its Riesz representative, the
+gradient, which is the form in which the Sobolev spaces consume it. -/
+
+section TestFunction
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {μ : Measure E} [μ.IsAddHaarMeasure] {Ω : Opens E}
+
+open scoped Gradient InnerProductSpace
+
+/-- **A test function is weakly differentiable**, with weak derivative the continuous linear
+functional represented by its gradient. -/
+theorem hasWeakFDerivOn_testFunction (φ : 𝓓(Ω, ℝ)) :
+    HasWeakFDerivOn μ Ω (φ : E → ℝ) fun x => innerSL ℝ (∇ (φ : E → ℝ) x) := by
+  have hcoe : (fun x => innerSL ℝ (∇ (φ : E → ℝ) x)) = fderiv ℝ (φ : E → ℝ) := by
+    funext x
+    ext y
+    simp [inner_gradient_left (𝕜 := ℝ) (f := (φ : E → ℝ)) (x := x) (y := y)]
+  rw [hcoe]
+  refine hasWeakFDerivOn_of_differentiableOn ?_ ?_ fun x _ => differentiable_testFunction φ x
+  · exact φ.continuous.locallyIntegrable.locallyIntegrableOn _
+  · exact (φ.contDiff.continuous_fderiv (by simp)).locallyIntegrable.locallyIntegrableOn _
+
+end TestFunction
 
 /-! ### Uniqueness -/
 

--- a/TauCeti/Analysis/Sobolev/WeakDeriv.lean
+++ b/TauCeti/Analysis/Sobolev/WeakDeriv.lean
@@ -161,15 +161,11 @@ variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-! ### Derivatives of test functions -/
 
-/-- A test function is differentiable. -/
-@[fun_prop]
-theorem differentiable_testFunction (φ : 𝓓(Ω, ℝ)) : Differentiable ℝ (φ : E → ℝ) :=
-  φ.contDiff.differentiable (by simp)
-
 /-- Outside its support, the directional derivative of a test function vanishes. -/
 theorem lineDeriv_eq_zero_of_notMem_tsupport (φ : 𝓓(Ω, ℝ)) {x : E}
     (hx : x ∉ tsupport (φ : E → ℝ)) (v : E) : lineDeriv ℝ (φ : E → ℝ) x v = 0 := by
-  have hd : DifferentiableAt ℝ (φ : E → ℝ) x := differentiable_testFunction φ x
+  have hd : DifferentiableAt ℝ (φ : E → ℝ) x :=
+    (φ.contDiff.differentiable (by simp)) x
   rw [hd.lineDeriv_eq_fderiv, fderiv_of_notMem_tsupport ℝ hx]
   simp
 
@@ -524,7 +520,7 @@ theorem hasWeakLineDerivOn_of_hasLineDerivAt (hu : LocallyIntegrableOn u Ω μ)
     (hu' : LocallyIntegrableOn u' Ω μ) (h : ∀ x ∈ (Ω : Set E), HasLineDerivAt ℝ u (u' x) x v) :
     HasWeakLineDerivOn μ Ω u u' v := by
   refine ⟨‹CompleteSpace F›, hu, hu', fun φ => ?_⟩
-  have hφd := differentiable_testFunction φ
+  have hφd := φ.contDiff.differentiable (by simp)
   have key := integral_bilinear_hasLineDerivAt_right_eq_neg_left_of_integrable
     (μ := μ) (f := u) (f' := u') (g := (φ : E → ℝ))
     (g' := fun x => lineDeriv ℝ (φ : E → ℝ) x v) (v := v)
@@ -582,7 +578,8 @@ theorem hasWeakFDerivOn_testFunction (φ : 𝓓(Ω, ℝ)) :
     ext y
     simp [inner_gradient_left (𝕜 := ℝ) (f := (φ : E → ℝ)) (x := x) (y := y)]
   rw [hcoe]
-  refine hasWeakFDerivOn_of_differentiableOn ?_ ?_ fun x _ => differentiable_testFunction φ x
+  refine hasWeakFDerivOn_of_differentiableOn ?_ ?_ fun x _ =>
+    (φ.contDiff.differentiable (by simp)) x
   · exact φ.continuous.locallyIntegrable.locallyIntegrableOn _
   · exact (φ.contDiff.continuous_fderiv (by simp)).locallyIntegrable.locallyIntegrableOn _
 


### PR DESCRIPTION
This PR builds `W^{1,p}_0(Ω)`, the closure of the test functions `C_c^∞(Ω)` inside the weak-derivative Sobolev space `W^{1,p}(Ω)`, and proves the **Poincaré inequality** on it: `‖u‖_p ≤ (b − a) ‖∇u‖_p` whenever `Ω ⊆ ℝ^{n+1}` is trapped between the hyperplanes `xᵢ = a` and `xᵢ = b`, together with the bounded-domain corollary `‖u‖_p ≤ 2R ‖∇u‖_p` for `Ω ⊆ Metric.ball 0 R`. It closes items 2 and 5 of Lane A of the PDE roadmap ("Density and `W^{k,p}_0`" — the `C_c^∞(Ω)`-closure half — and "**Poincaré** on `W^{1,p}_0(Ω)` (bounded `Ω`) … with explicit constant dependence"), which are the last inputs the milestone of Lane D.17, "Existence & uniqueness (coercive case)", is waiting on besides the integrated Gårding inequality: `TauCeti.PDE.garding_energyIntegrand_self_of_bounds` gives the pointwise bound `a(u,u) ≥ (λ/2)‖∇u‖² − (β²/2λ)|u|²`, and coercivity of the energy form on `H¹_0(Ω)` is exactly that bound integrated plus the Poincaré inequality proved here; `TauCeti.IsCoercive.solutionOfFunctional` then applies verbatim. What remains after this PR for that milestone is the integrated Gårding inequality on `W1p0 volume Ω 2` and the assembly of the two into `IsCoercive`.

The mathematical content is the passage from one test function to the closure. The estimate for a single test function is already available as `TauCeti.eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab`; what is new is that the set `{u | ‖u‖_p ≤ C‖∇u‖_p}` is closed (both components of a Sobolev function depend continuously on it) and contains the range of the test-function embedding, so `closure_minimal` transfers the bound to the whole of `W^{1,p}_0(Ω)`. That set is closed but is *not* a subspace, so the embedding `C_c^∞(Ω) → W^{1,p}(Ω)` has to be known linear before the closure is taken; that is why `TauCeti.W1p.ofTestFunctionLM` is built as a `LinearMap` and why `TauCeti.w1p0Submodule` is the closure of its range rather than of a bare set of generators. `Ω` is not assumed bounded, and no boundary regularity is used: only being bounded in one direction enters, and some such hypothesis is necessary by the existing `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`. Together those two discharge the roadmap's acceptance criterion "Poincaré is non-vacuous: the constant is finite on a concrete bounded `Ω` (e.g. a ball) and the inequality genuinely *fails* on `ℝⁿ`", in both directions.

New declarations. `TauCeti/Analysis/Sobolev/W1p/Zero.lean` (357 lines) carries the gradient of a test function as an `Lᵖ` class (`gradientTestFunctionLp`, with its additivity and homogeneity), `hasWeakFDerivOn_testFunction` (a test function is weakly differentiable with weak derivative its gradient, from `hasWeakFDerivOn_of_differentiableOn`), the linear embedding `W1p.ofTestFunctionLM`, the closed subspace `w1p0Submodule` with `W1p0` and its `CompleteSpace` instance, and the two Poincaré theorems. `TauCeti/Analysis/Calculus/Gradient.lean` (66 lines) records the three facts about Mathlib's `gradient` that follow from `InnerProductSpace.toDual` being a conjugate-linear isometric equivalence — `norm_gradient`, `gradient_add`, `gradient_const_smul` — none of which is in Mathlib (`Mathlib/Analysis/Calculus/Gradient/Basic.lean` has the differential calculus but no algebra). `TestFunctionLp.lean` gains `testFunctionLp_add` and `testFunctionLp_smul`, and `W1p/Basic.lean` gains `W1p.continuous_value`, `W1p.continuous_gradient` and the four linearity lemmas for the two components, all beside the definitions they are about.

Module move. Adding `W1p/Zero.lean` would have left two flat `W1p*.lean` siblings, so `W1p.lean` becomes `W1p/Basic.lean` in the same PR. Only imports and the module header change; no declaration is renamed.

| old module | new module |
| --- | --- |
| `TauCeti.Analysis.Sobolev.W1p` | `TauCeti.Analysis.Sobolev.W1p.Basic` |

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"w1p0"}-->

🤖 Prepared with Claude Code
