### PR TITLE
feat: prove semisimple groups are reductive

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Semisimple/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Semisimple/Reductive.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Semisimple.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Solvable
+
+/-!
+# Semisimple affine groups are reductive
+
+Every smooth connected normal unipotent closed subgroup of a semisimple affine group has solvable
+geometric points. It is therefore trivial by semisimplicity, which is precisely the defining
+normal-subgroup condition for reductivity.
+
+## Main declaration
+
+* `TauCeti.semisimpleCommHopfAlgProperty.reductive`: every semisimple finite-type commutative Hopf
+  algebra is reductive.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Section 21.
+* T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
+
+This is a structural implication in Layer 6, "Reductive and semisimple groups", of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace semisimpleCommHopfAlgProperty
+
+variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
+
+/-- Every semisimple finite-type affine group over a field is reductive. -/
+theorem reductive (hH : semisimpleCommHopfAlgProperty k H) :
+    reductiveCommHopfAlgProperty k H := by
+  rw [reductiveCommHopfAlgProperty_iff]
+  refine ⟨hH.smooth, hH.geometricallyConnected, ?_⟩
+  intro I hnormal hconnected hunipotent
+  rw [smoothUnipotentCommHopfAlgProperty_iff] at hunipotent
+  apply hH.eq_augmentation I hnormal hconnected hunipotent.1
+  apply geometricallyUnipotentPointsCommHopfAlgProperty.geometricallySolvable
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+  exact hunipotent.2
+
+end semisimpleCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Solvable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Solvable.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Faithful
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+public import TauCeti.RepresentationTheory.Unipotent.Solvable
+
+/-!
+# Solvability of geometrically unipotent affine groups
+
+A finite-type affine group admits a faithful finite-dimensional comodule. If all its geometric
+points are unipotent, their induced operators on this comodule are unipotent. Kolchin's theorem
+then embeds the geometric point group in an upper-unitriangular matrix group, proving that it is
+solvable.
+
+## Main declaration
+
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.geometricallySolvable`: a
+  geometrically unipotent finite-type affine group has a solvable group of geometric points.
+
+## References
+
+* A. Borel, *Linear Algebraic Groups*, Proposition 4.8.
+* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+
+This completes the point-group solvability implication needed in Layer 5 of the ReductiveGroups
+roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace geometricallyUnipotentPointsCommHopfAlgProperty
+
+variable {k H : Type u} [Field k] [CommRing H] [HopfAlgebra k H]
+
+/-- A geometrically unipotent finite-type affine group has a solvable group of geometric points.
+
+No reducedness hypothesis is needed: faithfulness is used only to inject the abstract geometric
+point group into its linear action, while Kolchin's theorem simultaneously upper-unitriangularizes
+that action. -/
+theorem geometricallySolvable [Algebra.FiniteType k H]
+    (hH : geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.of k H)) :
+    geometricallySolvablePointsCommHopfAlgProperty k (CommHopfAlgCat.of k H) := by
+  have hpoints := (geometricallyUnipotentPointsCommHopfAlgProperty_iff k
+    (CommHopfAlgCat.of k H)).mp hH
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff]
+  let A := AlgebraicClosure k
+  obtain ⟨M, n, b, hb⟩ :=
+    Comodule.exists_isClosedImmersion_coordinateGroupSchemeHom (k := k) (H := H)
+  let _ : AddCommGroup M := Module.addCommMonoidToAddCommGroup k
+  let _ : Module.Finite k M := Module.Finite.of_basis b
+  have hfaithful : Comodule.IsFaithful (k := k) (H := H) (V := M) :=
+    (Comodule.isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom b).mpr hb
+  let rho : Representation A (WithConv (H →ₐ[k] A)) (A ⊗[k] M) :=
+    Comodule.pointsRepresentation (R := k) (H := H) (A := A) M
+  have hinjective : Function.Injective rho.asGroupHom := by
+    intro g h hgh
+    apply Comodule.pointsAction_injective_of_isFaithful hfaithful
+    have hrho : rho g = rho h := by
+      simpa only [Representation.asGroupHom_apply] using congrArg Units.val hgh
+    apply LinearEquiv.ext
+    intro x
+    have hlinear :
+        (Comodule.pointsAction M g : A ⊗[k] M →ₗ[A] A ⊗[k] M) =
+          (Comodule.pointsAction M h : A ⊗[k] M →ₗ[A] A ⊗[k] M) := by
+      rw [Comodule.pointsAction_toLinearMap, Comodule.pointsAction_toLinearMap]
+      simpa only [rho, Comodule.pointsRepresentation_apply] using hrho
+    exact LinearMap.congr_fun hlinear x
+  apply Representation.isSolvable_of_injective_of_isUnipotent rho hinjective
+  intro g
+  rw [Comodule.pointsRepresentation_apply]
+  exact (HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one g).mp
+    (hpoints g) (FGComoduleCat.of (R := k) (C := H) M)
+
+end geometricallyUnipotentPointsCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
@@ -1,0 +1,226 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Kolchin
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.UpperUnitriangular.Nilpotent
+import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.RingTheory.Nilpotent.Lemmas
+
+/-!
+# Solvability of faithful unipotent representations
+
+Kolchin's common fixed-vector theorem constructs a complete invariant flag for a
+finite-dimensional representation whose every operator is unipotent. Relative to a basis adapted
+to this flag, every representing matrix is upper unitriangular. Consequently a group admitting a
+faithful representation of this kind embeds in an upper-unitriangular matrix group and is
+solvable.
+
+## Main declarations
+
+* `TauCeti.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent`: simultaneous
+  upper-unitriangularization of a unipotent monoid representation.
+* `TauCeti.Representation.isSolvable_of_injective_of_isUnipotent`: a group with a faithful
+  finite-dimensional unipotent representation is solvable.
+
+## References
+
+* A. Borel, *Linear Algebraic Groups*, Proposition 4.8.
+* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+
+This supplies the Lie--Kolchin solvability step in Layer 5 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open Module
+
+namespace TauCeti.Representation
+
+universe u v w
+
+noncomputable section
+
+variable {K : Type u} {G : Type w} {V : Type v}
+variable [Field K] [AddCommGroup V] [Module K V]
+
+section Monoid
+
+variable [Monoid G]
+
+private def extensionBasis {m n : ℕ} (p : Submodule K V)
+    (bp : Basis (Fin m) K p) (bq : Basis (Fin n) K (V ⧸ p)) :
+    Basis (Fin (m + n)) K V :=
+  (bp.sumQuot bq).reindex finSumFinEquiv
+
+@[simp]
+private theorem extensionBasis_castAdd {m n : ℕ} (p : Submodule K V)
+    (bp : Basis (Fin m) K p) (bq : Basis (Fin n) K (V ⧸ p)) (i : Fin m) :
+    extensionBasis p bp bq (Fin.castAdd n i) = bp i := by
+  rw [extensionBasis, Basis.reindex_apply, finSumFinEquiv_symm_apply_castAdd,
+    Basis.sumQuot_inl]
+
+@[simp]
+private theorem extensionBasis_natAdd_mkQ {m n : ℕ} (p : Submodule K V)
+    (bp : Basis (Fin m) K p) (bq : Basis (Fin n) K (V ⧸ p)) (j : Fin n) :
+    p.mkQ (extensionBasis p bp bq (Fin.natAdd m j)) = bq j := by
+  rw [extensionBasis, Basis.reindex_apply, finSumFinEquiv_symm_apply_natAdd,
+    Submodule.mkQ_apply, Basis.sumQuot_inr]
+
+@[simp]
+private theorem extensionBasis_repr_castAdd {m n : ℕ} (p : Submodule K V)
+    (bp : Basis (Fin m) K p) (bq : Basis (Fin n) K (V ⧸ p)) (x : p) (i : Fin m) :
+    (extensionBasis p bp bq).repr x (Fin.castAdd n i) = bp.repr x i := by
+  rw [extensionBasis, Basis.repr_reindex_apply, finSumFinEquiv_symm_apply_castAdd,
+    Basis.sumQuot_repr_inl]
+
+@[simp]
+private theorem extensionBasis_repr_natAdd {m n : ℕ} (p : Submodule K V)
+    (bp : Basis (Fin m) K p) (bq : Basis (Fin n) K (V ⧸ p)) (x : V) (j : Fin n) :
+    (extensionBasis p bp bq).repr x (Fin.natAdd m j) = bq.repr (p.mkQ x) j := by
+  rw [extensionBasis, Basis.repr_reindex_apply, finSumFinEquiv_symm_apply_natAdd,
+    Basis.sumQuot_repr_inr]
+
+/-- A finite-dimensional monoid representation by unipotent operators has a basis in which all
+representing matrices are upper unitriangular. -/
+theorem exists_basis_isUpperUnitriangular_of_isUnipotent [FiniteDimensional K V]
+    (rho : Representation K G V) (hunipotent : ∀ g, IsNilpotent (rho g - 1)) :
+    ∃ (n : ℕ) (b : Basis (Fin n) K V),
+      ∀ g, (LinearMap.toMatrixAlgEquiv b (rho g)).IsUpperUnitriangular := by
+  generalize hdim : finrank K V = d
+  induction d using Nat.strong_induction_on generalizing V with
+  | h d ih =>
+      by_cases hV : Nontrivial V
+      · let _ : Nontrivial V := hV
+        obtain ⟨p, hpdim, hfixed⟩ :=
+          rho.exists_fixed_submodule_finrank_eq_one_of_isUnipotent hunipotent
+        have hp (g : G) : p ≤ p.comap (rho g) := by
+          intro x hx
+          change rho g x ∈ p
+          rw [hfixed g x hx]
+          exact hx
+        let q : Representation K G (V ⧸ p) := rho.quotient p hp
+        have q_apply (g : G) (x : V) : q g (p.mkQ x) = p.mkQ (rho g x) := by
+          simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
+        have hq (g : G) : IsNilpotent (q g - 1) := by
+          have hsub : p ≤ p.comap (rho g - 1) := by
+            intro x hx
+            change rho g x - x ∈ p
+            exact p.sub_mem (hp g hx) hx
+          have hnil := Module.End.IsNilpotent.mapQ hsub (hunipotent g)
+          have heq : q g - 1 = p.mapQ p (rho g - 1) hsub := by
+            ext x
+            simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
+          rw [heq]
+          exact hnil
+        have hqdim : finrank K (V ⧸ p) < d := by
+          have hsum := Module.finrank_quotient_add_finrank_le p
+          rw [hpdim, hdim] at hsum
+          omega
+        obtain ⟨n, bq, hbq⟩ := ih (finrank K (V ⧸ p)) hqdim q hq rfl
+        let bp : Basis (Fin 1) K p := finBasisOfFinrankEq K p hpdim
+        let b := extensionBasis p bp bq
+        refine ⟨1 + n, b, fun g ↦ ?_⟩
+        rw [Matrix.isUpperUnitriangular_def]
+        constructor
+        · intro i j hji
+          obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
+          obtain ⟨j, rfl⟩ := finSumFinEquiv.surjective j
+          cases i with
+          | inl i =>
+              cases j with
+              | inl j =>
+                  simp only [finSumFinEquiv_apply_left] at hji
+                  have := (Fin.strictMono_castAdd n).lt_iff_lt.mp hji
+                  omega
+              | inr j =>
+                  rw [finSumFinEquiv_apply_left, finSumFinEquiv_apply_right] at hji
+                  change 1 + j.val < i.val at hji
+                  omega
+          | inr i =>
+              cases j with
+              | inl j =>
+                  rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_left,
+                    LinearMap.toMatrixAlgEquiv_apply]
+                  have hmem : rho g (bp j : V) ∈ p := hp g (bp j).2
+                  rw [extensionBasis_castAdd,
+                    extensionBasis_repr_natAdd p bp bq (rho g (bp j : V)) i]
+                  simp only [Submodule.mkQ_apply,
+                    (Submodule.Quotient.mk_eq_zero p).mpr hmem, map_zero,
+                    Finsupp.zero_apply]
+              | inr j =>
+                  rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_right,
+                    LinearMap.toMatrixAlgEquiv_apply,
+                    extensionBasis_repr_natAdd]
+                  rw [← q_apply]
+                  rw [extensionBasis_natAdd_mkQ]
+                  simpa only [LinearMap.toMatrixAlgEquiv_apply] using
+                    (hbq g |>.isUpperTriangular
+                      ((Fin.strictMono_natAdd 1).lt_iff_lt.mp hji))
+        · intro i
+          obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
+          cases i with
+          | inl i =>
+              rw [finSumFinEquiv_apply_left, LinearMap.toMatrixAlgEquiv_apply,
+                extensionBasis_castAdd]
+              have hfix : rho g (bp i : V) = bp i := hfixed g (bp i) (bp i).2
+              rw [hfix, extensionBasis_repr_castAdd]
+              simp
+          | inr i =>
+              rw [finSumFinEquiv_apply_right, LinearMap.toMatrixAlgEquiv_apply,
+                extensionBasis_repr_natAdd]
+              rw [← q_apply]
+              rw [extensionBasis_natAdd_mkQ]
+              simpa only [LinearMap.toMatrixAlgEquiv_apply] using hbq g |>.apply_diag i
+      · let _ : Subsingleton V := not_nontrivial_iff_subsingleton.mp hV
+        have hzero : finrank K V = 0 := Module.finrank_zero_of_subsingleton
+        let b : Basis (Fin 0) K V := finBasisOfFinrankEq K V hzero
+        refine ⟨0, b, fun g ↦ ?_⟩
+        rw [Matrix.isUpperUnitriangular_def]
+        exact ⟨fun i ↦ Fin.elim0 i, fun i ↦ Fin.elim0 i⟩
+
+end Monoid
+
+variable [Group G]
+
+private def toUpperUnitriangularGroup {n : ℕ} (rho : Representation K G V)
+    (b : Basis (Fin n) K V)
+    (h : ∀ g, (LinearMap.toMatrixAlgEquiv b (rho g)).IsUpperUnitriangular) :
+    G →* TauCeti.upperUnitriangularGroup (Fin n) K := by
+  let f : G →* Matrix.GeneralLinearGroup (Fin n) K :=
+    (Units.map (LinearMap.toMatrixAlgEquiv b).toMonoidHom).comp rho.asGroupHom
+  exact
+    { toFun := fun g ↦ ⟨f g, by
+        apply TauCeti.UpperUnitriangularGroup.mem_iff.mpr
+        simp only [f, MonoidHom.comp_apply, Units.coe_map,
+          Representation.asGroupHom_apply]
+        rw [Matrix.isUpperUnitriangular_def]
+        refine ⟨?_, h g |>.apply_diag⟩
+        intro i j hji
+        apply (h g).isUpperTriangular
+        change j.val < i.val at hji ⊢
+        exact hji⟩
+      map_one' := Subtype.ext (map_one f)
+      map_mul' := fun g h ↦ Subtype.ext (map_mul f g h) }
+
+/-- A group admitting a faithful finite-dimensional representation by unipotent operators is
+solvable. -/
+theorem isSolvable_of_injective_of_isUnipotent [FiniteDimensional K V]
+    (rho : Representation K G V) (hinjective : Function.Injective rho.asGroupHom)
+    (hunipotent : ∀ g, IsNilpotent (rho g - 1)) : Group.IsSolvable G := by
+  obtain ⟨n, b, hb⟩ := exists_basis_isUpperUnitriangular_of_isUnipotent rho hunipotent
+  apply Group.isSolvable_of_isSolvable_injective
+    (f := toUpperUnitriangularGroup rho b hb)
+  intro g h hgh
+  apply hinjective
+  apply Units.ext
+  apply (LinearMap.toMatrixAlgEquiv b).injective
+  exact congrArg (fun x : TauCeti.upperUnitriangularGroup (Fin n) K ↦
+    ((x : Matrix.GeneralLinearGroup (Fin n) K) : Matrix (Fin n) (Fin n) K)) hgh
+
+end
+
+end TauCeti.Representation

--- a/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
@@ -101,6 +101,7 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
           rho.exists_fixed_submodule_finrank_eq_one_of_isUnipotent hunipotent
         have hp (g : G) : p ≤ p.comap (rho g) := by
           intro x hx
+          -- Membership in the comap unfolds to membership of the image in `p`.
           change rho g x ∈ p
           rw [hfixed g x hx]
           exact hx
@@ -110,6 +111,7 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
         have hq (g : G) : IsNilpotent (q g - 1) := by
           have hsub : p ≤ p.comap (rho g - 1) := by
             intro x hx
+            -- After unfolding the comap and subtraction of endomorphisms, this is invariance.
             change rho g x - x ∈ p
             exact p.sub_mem (hp g hx) hx
           have hnil := Module.End.IsNilpotent.mapQ hsub (hunipotent g)
@@ -128,6 +130,10 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
         refine ⟨1 + n, b, fun g ↦ ?_⟩
         rw [Matrix.isUpperUnitriangular_def]
         constructor
+        -- The extension basis lists the fixed line `p` before a lift of the quotient basis.
+        -- We check the four resulting matrix blocks: the first two index configurations are
+        -- impossible below the diagonal, the lower-left block vanishes by invariance of `p`,
+        -- and the lower-right block is upper triangular by the induction hypothesis on `V ⧸ p`.
         · intro i j hji
           obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
           obtain ⟨j, rfl⟩ := finSumFinEquiv.surjective j
@@ -135,16 +141,20 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
           | inl i =>
               cases j with
               | inl j =>
+                  -- The fixed-line block is `1 × 1`, so it has no entry below the diagonal.
                   simp only [finSumFinEquiv_apply_left] at hji
                   have := (Fin.strictMono_castAdd n).lt_iff_lt.mp hji
                   omega
               | inr j =>
+                  -- A quotient column follows every fixed-line row in the extension basis.
                   rw [finSumFinEquiv_apply_left, finSumFinEquiv_apply_right] at hji
+                  -- The order on `Fin (1 + n)` unfolds to the displayed inequality of values.
                   change 1 + j.val < i.val at hji
                   omega
           | inr i =>
               cases j with
               | inl j =>
+                  -- The lower-left block is zero because every operator preserves `p`.
                   rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_left,
                     LinearMap.toMatrixAlgEquiv_apply]
                   have hmem : rho g (bp j : V) ∈ p := hp g (bp j).2
@@ -154,6 +164,7 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
                     (Submodule.Quotient.mk_eq_zero p).mpr hmem, map_zero,
                     Finsupp.zero_apply]
               | inr j =>
+                  -- The lower-right block represents the induced action on `V ⧸ p`.
                   rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_right,
                     LinearMap.toMatrixAlgEquiv_apply,
                     extensionBasis_repr_natAdd]
@@ -162,6 +173,8 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
                   simpa only [LinearMap.toMatrixAlgEquiv_apply] using
                     (hbq g |>.isUpperTriangular
                       ((Fin.strictMono_natAdd 1).lt_iff_lt.mp hji))
+        -- On the diagonal, the fixed-line block is the identity by construction and the
+        -- quotient block has diagonal entries one by the induction hypothesis.
         · intro i
           obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
           cases i with
@@ -206,6 +219,7 @@ private def _root_.Representation.toUpperUnitriangularGroup {n : ℕ}
         refine ⟨?_, h g |>.apply_diag⟩
         intro i j hji
         apply (h g).isUpperTriangular
+        -- The inherited order on `Fin n` is definitionally the order on its values.
         change j.val < i.val at hji ⊢
         exact hji⟩
       map_one' := Subtype.ext (map_one f)

--- a/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
@@ -67,9 +67,9 @@ private theorem extensionBasis_castAdd {m n : ℕ} (p : Submodule K V)
 @[simp]
 private theorem extensionBasis_natAdd_mkQ {m n : ℕ} (p : Submodule K V)
     (bp : Basis (Fin m) K p) (bq : Basis (Fin n) K (V ⧸ p)) (j : Fin n) :
-    p.mkQ (extensionBasis p bp bq (Fin.natAdd m j)) = bq j := by
+    Submodule.Quotient.mk (extensionBasis p bp bq (Fin.natAdd m j)) = bq j := by
   rw [extensionBasis, Basis.reindex_apply, finSumFinEquiv_symm_apply_natAdd,
-    Submodule.mkQ_apply, Basis.sumQuot_inr]
+    Basis.sumQuot_inr]
 
 @[simp]
 private theorem extensionBasis_repr_castAdd {m n : ℕ} (p : Submodule K V)
@@ -158,7 +158,7 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
                     LinearMap.toMatrixAlgEquiv_apply,
                     extensionBasis_repr_natAdd]
                   rw [← q_apply]
-                  rw [extensionBasis_natAdd_mkQ]
+                  rw [Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
                   simpa only [LinearMap.toMatrixAlgEquiv_apply] using
                     (hbq g |>.isUpperTriangular
                       ((Fin.strictMono_natAdd 1).lt_iff_lt.mp hji))
@@ -175,7 +175,7 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
               rw [finSumFinEquiv_apply_right, LinearMap.toMatrixAlgEquiv_apply,
                 extensionBasis_repr_natAdd]
               rw [← q_apply]
-              rw [extensionBasis_natAdd_mkQ]
+              rw [Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
               simpa only [LinearMap.toMatrixAlgEquiv_apply] using hbq g |>.apply_diag i
       · let _ : Subsingleton V := not_nontrivial_iff_subsingleton.mp hV
         have hzero : finrank K V = 0 := Module.finrank_zero_of_subsingleton

--- a/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/Solvable.lean
@@ -21,9 +21,9 @@ solvable.
 
 ## Main declarations
 
-* `TauCeti.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent`: simultaneous
+* `Representation.exists_basis_isUpperUnitriangular_of_isUnipotent`: simultaneous
   upper-unitriangularization of a unipotent monoid representation.
-* `TauCeti.Representation.isSolvable_of_injective_of_isUnipotent`: a group with a faithful
+* `Representation.isSolvable_of_injective_of_isUnipotent`: a group with a faithful
   finite-dimensional unipotent representation is solvable.
 
 ## References
@@ -51,6 +51,7 @@ section Monoid
 
 variable [Monoid G]
 
+/-- Extend bases of a submodule and its quotient to a basis of the ambient module. -/
 private def extensionBasis {m n : ℕ} (p : Submodule K V)
     (bp : Basis (Fin m) K p) (bq : Basis (Fin n) K (V ⧸ p)) :
     Basis (Fin (m + n)) K V :=
@@ -86,7 +87,8 @@ private theorem extensionBasis_repr_natAdd {m n : ℕ} (p : Submodule K V)
 
 /-- A finite-dimensional monoid representation by unipotent operators has a basis in which all
 representing matrices are upper unitriangular. -/
-theorem exists_basis_isUpperUnitriangular_of_isUnipotent [FiniteDimensional K V]
+theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent
+    [FiniteDimensional K V]
     (rho : Representation K G V) (hunipotent : ∀ g, IsNilpotent (rho g - 1)) :
     ∃ (n : ℕ) (b : Basis (Fin n) K V),
       ∀ g, (LinearMap.toMatrixAlgEquiv b (rho g)).IsUpperUnitriangular := by
@@ -186,7 +188,10 @@ end Monoid
 
 variable [Group G]
 
-private def toUpperUnitriangularGroup {n : ℕ} (rho : Representation K G V)
+/-- Embed a representation into an upper-unitriangular group using a basis in which all of its
+operators are upper unitriangular. -/
+private def _root_.Representation.toUpperUnitriangularGroup {n : ℕ}
+    (rho : Representation K G V)
     (b : Basis (Fin n) K V)
     (h : ∀ g, (LinearMap.toMatrixAlgEquiv b (rho g)).IsUpperUnitriangular) :
     G →* TauCeti.upperUnitriangularGroup (Fin n) K := by
@@ -208,12 +213,14 @@ private def toUpperUnitriangularGroup {n : ℕ} (rho : Representation K G V)
 
 /-- A group admitting a faithful finite-dimensional representation by unipotent operators is
 solvable. -/
-theorem isSolvable_of_injective_of_isUnipotent [FiniteDimensional K V]
+theorem _root_.Representation.isSolvable_of_injective_of_isUnipotent
+    [FiniteDimensional K V]
     (rho : Representation K G V) (hinjective : Function.Injective rho.asGroupHom)
     (hunipotent : ∀ g, IsNilpotent (rho g - 1)) : Group.IsSolvable G := by
-  obtain ⟨n, b, hb⟩ := exists_basis_isUpperUnitriangular_of_isUnipotent rho hunipotent
+  obtain ⟨n, b, hb⟩ :=
+    _root_.Representation.exists_basis_isUpperUnitriangular_of_isUnipotent rho hunipotent
   apply Group.isSolvable_of_isSolvable_injective
-    (f := toUpperUnitriangularGroup rho b hb)
+    (f := _root_.Representation.toUpperUnitriangularGroup rho b hb)
   intro g h hgh
   apply hinjective
   apply Units.ext


### PR DESCRIPTION
This PR proves that every semisimple finite-type affine group is reductive. Construct a complete invariant flag for any finite-dimensional monoid representation whose operators are unipotent, embed a faithful such group action into an upper-unitriangular group, and apply the result to geometric points of a finite-type commutative Hopf algebra.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 6, “Reductive and semisimple groups”: relate the two existing definitions by showing that every connected normal smooth unipotent subgroup excluded by reductivity is solvable and therefore excluded by semisimplicity. Its immediate prerequisite is the same roadmap’s Layer 5 target “Lie–Kolchin; solvable groups,” consumed here by `geometricallyUnipotentPointsCommHopfAlgProperty.geometricallySolvable`.

After this PR, Layer 6 still requires the radical, centre, derived-group comparisons, central isogenies, and simply connected and adjoint forms described by the milestone.

Reuse Mathlib’s quotient representation, `Module.Basis.sumQuot`, nilpotence on quotient endomorphisms, and solvability-under-injective-hom infrastructure; no external formalization is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"semisimple-implies-reductive"}-->

🤖 Prepared with Codex
