### PR TITLE
feat: the U-tower in the lattice homology of a negative-definite plumbing

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -245,6 +245,13 @@ theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
       P.characteristicCubeWeight k x S :=
   by simp [characteristicWeight_def]
 
+/-- The characteristic weight of a zero-dimensional cube is the point weight of its base
+point. -/
+theorem characteristicWeight_of_directions_eq_empty [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions = ∅) :
+    characteristicWeight P k C = P.characteristicWeight k C.base := by
+  rw [characteristicWeight_def, hC, PlumbingGraph.characteristicCubeWeight_empty]
+
 /-- The nonnegative `U`-exponent contributed by the raw lower cube obtained by erasing a direction.
 When the direction is present, this is the exponent of the lower face. -/
 noncomputable irreducible_def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -245,13 +245,6 @@ theorem characteristicWeight_mk [Fintype V] (P : PlumbingGraph V)
       P.characteristicCubeWeight k x S :=
   by simp [characteristicWeight_def]
 
-/-- The characteristic weight of a zero-dimensional cube is the point weight of its base
-point. -/
-theorem characteristicWeight_of_directions_eq_empty [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions = ∅) :
-    characteristicWeight P k C = P.characteristicWeight k C.base := by
-  rw [characteristicWeight_def, hC, PlumbingGraph.characteristicCubeWeight_empty]
-
 /-- The nonnegative `U`-exponent contributed by the raw lower cube obtained by erasing a direction.
 When the direction is present, this is the exponent of the lower face. -/
 noncomputable irreducible_def characteristicLowerFaceExponent [Fintype V] (P : PlumbingGraph V)

--- a/TauCeti/LowDimTopology/Plumbing/E8.lean
+++ b/TauCeti/LowDimTopology/Plumbing/E8.lean
@@ -9,6 +9,7 @@ import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Ring
 public import TauCeti.LowDimTopology.Plumbing.NegativeDefinite
+public import TauCeti.LowDimTopology.Plumbing.Tower
 
 /-!
 # The negative-definite E₈ plumbing
@@ -32,6 +33,8 @@ for checking later computations on this example.
 * `TauCeti.e8Plumbing_neg_intersectionForm`: the completed-square identity for the negative
   intersection form.
 * `TauCeti.e8Plumbing_isNegativeDefinite`: the `E₈` plumbing is negative definite.
+* `TauCeti.e8Plumbing_not_isZero_latticeHomology`: its characteristic-two lattice homology is
+  nonzero in every spin^c structure.
 
 ## References
 
@@ -204,5 +207,12 @@ theorem e8Plumbing_isNegativeDefinite : e8Plumbing.IsNegativeDefinite := by
       Finset.sum_nonneg fun i _ => e8SquareTerm_nonneg x i
     nlinarith
   exact hx (eq_zero_of_e8SquareTerm_sum_eq_zero x hR)
+
+/-- The characteristic-two lattice homology of the `E₈` plumbing is nonzero in every spin^c
+structure. This is the roadmap's concrete negative-definite plumbing, the one whose lattice
+homology computes the Heegaard Floer homology of the Poincaré homology sphere. -/
+theorem e8Plumbing_not_isZero_latticeHomology (k : e8Plumbing.characteristicVectors) :
+    ¬ CategoryTheory.Limits.IsZero (e8Plumbing.latticeHomology k) :=
+  e8Plumbing.not_isZero_latticeHomology e8Plumbing_isNegativeDefinite k
 
 end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -35,6 +35,8 @@ canonically isomorphic to its whole chain module.
 
 * `TauCeti.PlumbingGraph.latticeShortComplex`: the short complex with the lattice differential
   in both positions.
+* `TauCeti.PlumbingGraph.latticeShortComplex_exact_iff_range_eq_ker`: that short complex is exact
+  exactly when the boundaries of the lattice differential are all of its cycles.
 * `TauCeti.PlumbingGraph.latticeHomology`: its canonical `𝔽₂[U]`-module homology.
 * `TauCeti.PlumbingGraph.latticeHomologyIsoChainOfIsEmpty`: the homology of a zero-vertex
   plumbing is its full chain module.
@@ -100,6 +102,19 @@ theorem latticeShortComplex_f (P : PlumbingGraph V) (k : P.characteristicVectors
 theorem latticeShortComplex_g (P : PlumbingGraph V) (k : P.characteristicVectors) :
     HEq (P.latticeShortComplex k).g
       (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
+
+/-- Exactness of the lattice short complex says exactly that the boundaries of the lattice
+differential are all of its cycles.
+
+This is the chain-level reading of the vanishing of lattice homology. It has to be stated here:
+the body of `latticeShortComplex` is not exposed, so a downstream file cannot see that its three
+objects and two maps are the plumbing-chain module and the lattice differential, and hence cannot
+apply `ShortComplex.moduleCat_exact_iff_range_eq_ker` to it. -/
+theorem latticeShortComplex_exact_iff_range_eq_ker (P : PlumbingGraph V)
+    (k : P.characteristicVectors) :
+    (P.latticeShortComplex k).Exact ↔
+      LinearMap.range (P.latticeDifferential k) = LinearMap.ker (P.latticeDifferential k) :=
+  ShortComplex.moduleCat_exact_iff_range_eq_ker _
 
 /-- The characteristic-two lattice homology module: the homology of the weighted
 plumbing-lattice short complex.

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -35,6 +35,8 @@ canonically isomorphic to its whole chain module.
 
 * `TauCeti.PlumbingGraph.latticeShortComplex`: the short complex with the lattice differential
   in both positions.
+* `TauCeti.PlumbingGraph.latticeShortComplex_exact_iff`: that short complex is exact exactly when
+  every cycle of the lattice differential is a boundary.
 * `TauCeti.PlumbingGraph.latticeHomology`: its canonical `𝔽₂[U]`-module homology.
 * `TauCeti.PlumbingGraph.latticeHomologyIsoChainOfIsEmpty`: the homology of a zero-vertex
   plumbing is its full chain module.
@@ -100,6 +102,22 @@ theorem latticeShortComplex_f (P : PlumbingGraph V) (k : P.characteristicVectors
 theorem latticeShortComplex_g (P : PlumbingGraph V) (k : P.characteristicVectors) :
     HEq (P.latticeShortComplex k).g
       (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
+
+/-- Exactness of the lattice short complex says exactly that every cycle of the lattice
+differential is a boundary. This is the concrete, chain-level reading of the vanishing of lattice
+homology. -/
+theorem latticeShortComplex_exact_iff (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    (P.latticeShortComplex k).Exact ↔
+      ∀ c : PlumbingChain V, P.latticeDifferential k c = 0 →
+        c ∈ LinearMap.range (P.latticeDifferential k) := by
+  rw [ShortComplex.moduleCat_exact_iff]
+  constructor
+  · intro hexact c hc
+    obtain ⟨b, hb⟩ := hexact c hc
+    exact ⟨b, hb⟩
+  · intro hcycle c hc
+    obtain ⟨b, hb⟩ := hcycle c hc
+    exact ⟨b, hb⟩
 
 /-- The characteristic-two lattice homology module: the homology of the weighted
 plumbing-lattice short complex.

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -38,6 +38,8 @@ canonically isomorphic to its whole chain module.
 * `TauCeti.PlumbingGraph.latticeShortComplex_exact_iff_range_eq_ker`: that short complex is exact
   exactly when the boundaries of the lattice differential are all of its cycles.
 * `TauCeti.PlumbingGraph.latticeHomology`: its canonical `𝔽₂[U]`-module homology.
+* `TauCeti.PlumbingGraph.latticeHomologyCycleMap`: the map taking a coefficient to the homology
+  class of its multiple of a fixed cycle.
 * `TauCeti.PlumbingGraph.latticeHomologyIsoChainOfIsEmpty`: the homology of a zero-vertex
   plumbing is its full chain module.
 * `TauCeti.PlumbingGraph.latticeHomologyIsoCoefficientOfIsEmpty`: that chain module has one
@@ -131,6 +133,55 @@ theorem latticeHomology_def (P : PlumbingGraph V) (k : P.characteristicVectors) 
     P.latticeHomology k = (P.latticeShortComplex k).homology := by
   unfold latticeHomology
   rfl
+
+/-- The linear map sending `a : 𝔽₂[U]` to the homology class of `a • c`, for a lattice
+cycle `c`. -/
+noncomputable def latticeHomologyCycleMap (P : PlumbingGraph V) (k : P.characteristicVectors)
+    (c : PlumbingChain V) (hc : P.latticeDifferential k c = 0) :
+    PlumbingCoefficient →ₗ[PlumbingCoefficient] P.latticeHomology k :=
+  let S := P.latticeShortComplex k
+  let z : LinearMap.ker S.g.hom := ⟨c, by
+    change P.latticeDifferential k c = 0
+    exact hc⟩
+  let q : S.moduleCatLeftHomologyData.H :=
+    (LinearMap.range S.moduleCatToCycles).mkQ z
+  S.moduleCatHomologyIso.inv.hom.comp
+    (LinearMap.toSpanSingleton PlumbingCoefficient S.moduleCatLeftHomologyData.H q)
+
+/-- A coefficient maps to zero under `latticeHomologyCycleMap` exactly when its multiple of the
+cycle is a boundary. -/
+theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (c : PlumbingChain V)
+    (hc : P.latticeDifferential k c = 0) (a : PlumbingCoefficient) :
+    P.latticeHomologyCycleMap k c hc a = 0 ↔
+      a • c ∈ LinearMap.range (P.latticeDifferential k) := by
+  let S := P.latticeShortComplex k
+  let z : LinearMap.ker S.g.hom := ⟨c, by
+    change P.latticeDifferential k c = 0
+    exact hc⟩
+  let q : S.moduleCatLeftHomologyData.H :=
+    (LinearMap.range S.moduleCatToCycles).mkQ z
+  change S.moduleCatHomologyIso.inv (a • q) = 0 ↔ _
+  constructor
+  · intro ha
+    have hq : a • q = 0 := by
+      have hz := S.moduleCatHomologyIso.inv_hom_id_apply (a • q)
+      rw [ha, map_zero] at hz
+      exact hz.symm
+    change (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0 at hq
+    rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero] at hq
+    obtain ⟨b, hb⟩ := hq
+    exact ⟨b, congrArg Subtype.val hb⟩
+  · rintro ⟨b, hb⟩
+    have hz : a • z ∈ LinearMap.range S.moduleCatToCycles := by
+      refine ⟨b, ?_⟩
+      apply Subtype.ext
+      exact hb
+    have hq : a • q = 0 := by
+      change (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0
+      rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero]
+      exact hz
+    exact (congrArg (fun x => S.moduleCatHomologyIso.inv x) hq).trans (map_zero _)
 
 /-- The characteristic-two lattice homology of a zero-vertex plumbing is canonically isomorphic
 to its whole plumbing-chain module. -/

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -35,8 +35,6 @@ canonically isomorphic to its whole chain module.
 
 * `TauCeti.PlumbingGraph.latticeShortComplex`: the short complex with the lattice differential
   in both positions.
-* `TauCeti.PlumbingGraph.latticeShortComplex_exact_iff`: that short complex is exact exactly when
-  every cycle of the lattice differential is a boundary.
 * `TauCeti.PlumbingGraph.latticeHomology`: its canonical `𝔽₂[U]`-module homology.
 * `TauCeti.PlumbingGraph.latticeHomologyIsoChainOfIsEmpty`: the homology of a zero-vertex
   plumbing is its full chain module.
@@ -102,22 +100,6 @@ theorem latticeShortComplex_f (P : PlumbingGraph V) (k : P.characteristicVectors
 theorem latticeShortComplex_g (P : PlumbingGraph V) (k : P.characteristicVectors) :
     HEq (P.latticeShortComplex k).g
       (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
-
-/-- Exactness of the lattice short complex says exactly that every cycle of the lattice
-differential is a boundary. This is the concrete, chain-level reading of the vanishing of lattice
-homology. -/
-theorem latticeShortComplex_exact_iff (P : PlumbingGraph V) (k : P.characteristicVectors) :
-    (P.latticeShortComplex k).Exact ↔
-      ∀ c : PlumbingChain V, P.latticeDifferential k c = 0 →
-        c ∈ LinearMap.range (P.latticeDifferential k) := by
-  rw [ShortComplex.moduleCat_exact_iff]
-  constructor
-  · intro hexact c hc
-    obtain ⟨b, hb⟩ := hexact c hc
-    exact ⟨b, hb⟩
-  · intro hcycle c hc
-    obtain ⟨b, hb⟩ := hcycle c hc
-    exact ⟨b, hb⟩
 
 /-- The characteristic-two lattice homology module: the homology of the weighted
 plumbing-lattice short complex.

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -150,6 +150,7 @@ noncomputable def latticeHomologyCycleMap (P : PlumbingGraph V) (k : P.character
 
 /-- A coefficient maps to zero under `latticeHomologyCycleMap` exactly when its multiple of the
 cycle is a boundary. -/
+@[simp]
 theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
     (k : P.characteristicVectors) (c : PlumbingChain V)
     (hc : P.latticeDifferential k c = 0) (a : PlumbingCoefficient) :

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -134,15 +134,17 @@ theorem latticeHomology_def (P : PlumbingGraph V) (k : P.characteristicVectors) 
   unfold latticeHomology
   rfl
 
+private theorem latticeShortComplex_g_hom_apply (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (c : PlumbingChain V) :
+    (P.latticeShortComplex k).g.hom c = P.latticeDifferential k c := rfl
+
 /-- The linear map sending `a : 𝔽₂[U]` to the homology class of `a • c`, for a lattice
 cycle `c`. -/
 noncomputable def latticeHomologyCycleMap (P : PlumbingGraph V) (k : P.characteristicVectors)
     (c : PlumbingChain V) (hc : P.latticeDifferential k c = 0) :
     PlumbingCoefficient →ₗ[PlumbingCoefficient] P.latticeHomology k :=
   let S := P.latticeShortComplex k
-  let z : LinearMap.ker S.g.hom := ⟨c, by
-    change P.latticeDifferential k c = 0
-    exact hc⟩
+  let z : LinearMap.ker S.g.hom := ⟨c, (P.latticeShortComplex_g_hom_apply k c).trans hc⟩
   let q : S.moduleCatLeftHomologyData.H :=
     (LinearMap.range S.moduleCatToCycles).mkQ z
   S.moduleCatHomologyIso.inv.hom.comp
@@ -157,11 +159,12 @@ theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
     P.latticeHomologyCycleMap k c hc a = 0 ↔
       a • c ∈ LinearMap.range (P.latticeDifferential k) := by
   let S := P.latticeShortComplex k
-  let z : LinearMap.ker S.g.hom := ⟨c, by
-    change P.latticeDifferential k c = 0
-    exact hc⟩
+  let z : LinearMap.ker S.g.hom := ⟨c, (P.latticeShortComplex_g_hom_apply k c).trans hc⟩
   let q : S.moduleCatLeftHomologyData.H :=
     (LinearMap.range S.moduleCatToCycles).mkQ z
+  -- `moduleCatHomologyIso` is Mathlib's interface from abstract homology to the explicit
+  -- kernel/range quotient. Unfolding the local cycle map here is necessary to use that interface;
+  -- rewriting across it instead fails because `latticeHomology` remains opaque to the rewriter.
   change S.moduleCatHomologyIso.inv (a • q) = 0 ↔ _
   constructor
   · intro ha
@@ -169,6 +172,8 @@ theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
       have hz := S.moduleCatHomologyIso.inv_hom_id_apply (a • q)
       rw [ha, map_zero] at hz
       exact hz.symm
+    -- The local `q` is definitionally the quotient projection of `z`; expose that single
+    -- application so `Submodule.Quotient.mk_eq_zero` can characterize its kernel.
     change (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0 at hq
     rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero] at hq
     obtain ⟨b, hb⟩ := hq
@@ -179,6 +184,7 @@ theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
       apply Subtype.ext
       exact hb
     have hq : a • q = 0 := by
+      -- As above, this is the concrete application rule for the quotient projection defining `q`.
       change (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0
       rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero]
       exact hz

--- a/TauCeti/LowDimTopology/Plumbing/Tower.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Tower.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.E8
+public import TauCeti.LowDimTopology.Plumbing.Grading
+public import TauCeti.LowDimTopology.Plumbing.Homology
+public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel
+
+/-!
+# The `U`-tower in characteristic-two lattice homology
+
+This file proves that the lattice homology of a negative-definite plumbing graph is nonzero, and
+locates a free `𝔽₂[U]`-tower inside it.
+
+The mechanism is an augmentation. Write `m` for the minimal value `sInfCharacteristicWeight` of
+the characteristic weight function `χ_k`, which a negative-definite plumbing attains. Send the
+zero-dimensional cube at a lattice point `x` to `U ^ (χ_k(x) - m)` and every cube of positive
+dimension to `0`. The resulting `𝔽₂[U]`-linear map kills the lattice differential: a cube of
+dimension at least two has all its codimension-one faces of positive dimension, and the two faces
+of an edge contribute `U ^ (w - m)` each, for the same edge weight `w`, hence cancel in
+characteristic two. So the augmentation vanishes on boundaries, while a lattice point of minimal
+weight is a cycle sent to `1`.
+
+Two consequences follow. First, lattice homology is not zero: the short complex of the lattice
+differential is not exact. Second, and more precisely, the class of a minimal-weight lattice point
+generates a *free* `𝔽₂[U]`-submodule: no nonzero multiple `U ^ j` of it is a boundary. That
+infinite `U`-tower is the structural feature that makes `m` the numerical `d`-invariant of the
+plumbed three-manifold, rather than one value among many.
+
+## Main definitions
+
+* `TauCeti.PlumbingGraph.latticeAugmentation`: the `𝔽₂[U]`-linear augmentation of the plumbing
+  chain module.
+
+## Main results
+
+* `TauCeti.PlumbingGraph.latticeAugmentation_comp_latticeDifferential`: the augmentation kills
+  boundaries.
+* `TauCeti.PlumbingGraph.exists_cycle_latticeAugmentation_eq_one`: a lattice point of minimal
+  characteristic weight is a cycle with augmentation `1`.
+* `TauCeti.PlumbingGraph.exists_cycle_forall_smul_notMem_range_latticeDifferential`: that cycle
+  spans a free `𝔽₂[U]`-submodule of the cycles modulo boundaries: the `U`-tower.
+* `TauCeti.PlumbingGraph.not_isZero_latticeHomology`: the lattice homology of a negative-definite
+  plumbing is nonzero.
+* `TauCeti.e8Plumbing_not_isZero_latticeHomology`: in particular the lattice homology of the `E₈`
+  plumbing is nonzero in every spin^c structure.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"),
+which asks for Némethi's lattice homology as a `ℤ[U]`-module together with computations of
+concrete negative-definite plumbings and `d`-invariant analogues. The `U`-tower and the role of
+`min χ_k` follow A. Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+namespace PlumbingGraph
+
+universe u
+
+variable {V : Type u} [DecidableEq V] [Fintype V]
+
+/-- The coefficient the lattice augmentation assigns to a plumbing cube: the power
+`U ^ (χ_k(x) - min χ_k)` on the zero-dimensional cube at the lattice point `x`, and `0` on every
+cube of positive dimension. -/
+noncomputable def latticeAugmentationCoefficient (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) : PlumbingCoefficient :=
+  if C.directions = ∅ then
+    Polynomial.X ^ (P.characteristicWeight k C.base - P.sInfCharacteristicWeight k).toNat
+  else 0
+
+/-- On a zero-dimensional cube the augmentation coefficient is the `U`-power measuring how far the
+base point sits above the minimal characteristic weight. -/
+theorem latticeAugmentationCoefficient_of_directions_eq_empty (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions = ∅) :
+    P.latticeAugmentationCoefficient k C =
+      Polynomial.X ^ (P.characteristicWeight k C.base - P.sInfCharacteristicWeight k).toNat := by
+  simp [latticeAugmentationCoefficient, hC]
+
+/-- On a cube of positive dimension the augmentation coefficient vanishes. -/
+theorem latticeAugmentationCoefficient_of_directions_ne_empty (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions ≠ ∅) :
+    P.latticeAugmentationCoefficient k C = 0 := by
+  simp [latticeAugmentationCoefficient, hC]
+
+/-- The `𝔽₂[U]`-linear augmentation of the plumbing chain module. -/
+noncomputable def latticeAugmentation (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    PlumbingChain V →ₗ[PlumbingCoefficient] PlumbingCoefficient :=
+  Finsupp.linearCombination PlumbingCoefficient (P.latticeAugmentationCoefficient k)
+
+/-- The augmentation of a single cube with coefficient `a` is `a` times the cube's augmentation
+coefficient. -/
+@[simp]
+theorem latticeAugmentation_single (P : PlumbingGraph V) (k : P.characteristicVectors)
+    (C : PlumbingCube V) (a : PlumbingCoefficient) :
+    P.latticeAugmentation k (Finsupp.single C a) = a * P.latticeAugmentationCoefficient k C := by
+  rw [latticeAugmentation, Finsupp.linearCombination_single, smul_eq_mul]
+
+/-- The augmentation vanishes on chains supported in positive cubical degree: it only sees
+lattice points. -/
+theorem latticeAugmentation_eq_zero_of_mem_degreePart (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {q : ℕ} (hq : q ≠ 0) {c : PlumbingChain V}
+    (hc : c ∈ PlumbingChain.degreePart V q) : P.latticeAugmentation k c = 0 := by
+  rw [latticeAugmentation, Finsupp.linearCombination_apply]
+  refine Finset.sum_eq_zero fun C hC => ?_
+  have hdim : C.dimension = q := (PlumbingChain.mem_degreePart V q c).mp hc C hC
+  have hne : C.directions ≠ ∅ := by
+    intro hempty
+    rw [PlumbingCube.dimension, hempty, Finset.card_empty] at hdim
+    exact hq hdim.symm
+  simp [P.latticeAugmentationCoefficient_of_directions_ne_empty k hne]
+
+/-- A zero-dimensional cube has no directions to differentiate along, so it is a cycle. -/
+theorem latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions = ∅) :
+    P.latticeDifferentialOnGenerator k C = 0 := by
+  rw [latticeDifferentialOnGenerator_def]
+  refine Finset.sum_eq_zero fun v _ => ?_
+  have : (v : V) ∈ (∅ : Finset V) := by rw [← hC]; exact v.property
+  exact absurd this (Finset.notMem_empty _)
+
+/-- The augmentation kills the differential of a single cube.
+
+A cube of dimension at least two has every codimension-one face of positive dimension, so all the
+augmentation coefficients occurring vanish. For an edge the two faces contribute the *same*
+`U`-power `U ^ (w - m)`, where `w` is the weight of the edge and `m` the minimal characteristic
+weight, because a face exponent is exactly the drop from `w` to the weight of that face. In
+characteristic two the two contributions cancel. -/
+theorem latticeAugmentation_latticeDifferentialOnGenerator (P : PlumbingGraph V)
+    (h : P.IsNegativeDefinite) (k : P.characteristicVectors) (C : PlumbingCube V) :
+    P.latticeAugmentation k (P.latticeDifferentialOnGenerator k C) = 0 := by
+  classical
+  rw [latticeDifferentialOnGenerator_def, map_sum]
+  refine Finset.sum_eq_zero fun v _ => ?_
+  rw [map_add, latticeAugmentation_single, latticeAugmentation_single]
+  by_cases herase : C.directions.erase v.val = ∅
+  · -- The cube is an edge: both faces are lattice points and their contributions agree.
+    have hlower : (C.lowerFace v.val v.property).directions = ∅ := by
+      rw [PlumbingCube.lowerFace_directions, herase]
+    have hupper : (C.upperFace v.val v.property).directions = ∅ := by
+      rw [PlumbingCube.upperFace_directions, herase]
+    rw [P.latticeAugmentationCoefficient_of_directions_eq_empty k hlower,
+      P.latticeAugmentationCoefficient_of_directions_eq_empty k hupper,
+      ← pow_add, ← pow_add]
+    have hlowerbase :
+        P.characteristicWeight k (C.lowerFace v.val v.property).base =
+          PlumbingCube.characteristicWeight P k (C.lowerFace v.val v.property) :=
+      (PlumbingCube.characteristicWeight_of_directions_eq_empty P k hlower).symm
+    have hupperbase :
+        P.characteristicWeight k (C.upperFace v.val v.property).base =
+          PlumbingCube.characteristicWeight P k (C.upperFace v.val v.property) :=
+      (PlumbingCube.characteristicWeight_of_directions_eq_empty P k hupper).symm
+    have hlowerexp :
+        (PlumbingCube.characteristicLowerFaceExponent P k C v.val : ℤ) =
+          PlumbingCube.characteristicWeight P k C -
+            PlumbingCube.characteristicWeight P k (C.lowerFace v.val v.property) := by
+      rw [PlumbingCube.characteristicLowerFaceExponent_natCast, PlumbingCube.lowerFace_def]
+    have hupperexp :
+        (PlumbingCube.characteristicUpperFaceExponent P k C v.property : ℤ) =
+          PlumbingCube.characteristicWeight P k C -
+            PlumbingCube.characteristicWeight P k (C.upperFace v.val v.property) :=
+      PlumbingCube.characteristicUpperFaceExponent_natCast P k C v.property
+    have hlowerle :
+        PlumbingCube.characteristicWeight P k (C.lowerFace v.val v.property) ≤
+          PlumbingCube.characteristicWeight P k C :=
+      PlumbingCube.characteristicWeight_lowerFace_le P k C v.property
+    have hupperle :
+        PlumbingCube.characteristicWeight P k (C.upperFace v.val v.property) ≤
+          PlumbingCube.characteristicWeight P k C :=
+      PlumbingCube.characteristicWeight_upperFace_le P k C v.property
+    have hlowermin :
+        P.sInfCharacteristicWeight k ≤
+          P.characteristicWeight k (C.lowerFace v.val v.property).base :=
+      P.sInfCharacteristicWeight_le h k _
+    have huppermin :
+        P.sInfCharacteristicWeight k ≤
+          P.characteristicWeight k (C.upperFace v.val v.property).base :=
+      P.sInfCharacteristicWeight_le h k _
+    have hexp :
+        PlumbingCube.characteristicLowerFaceExponent P k C v.val +
+            (P.characteristicWeight k (C.lowerFace v.val v.property).base -
+              P.sInfCharacteristicWeight k).toNat =
+          PlumbingCube.characteristicUpperFaceExponent P k C v.property +
+            (P.characteristicWeight k (C.upperFace v.val v.property).base -
+              P.sInfCharacteristicWeight k).toNat := by
+      rw [hlowerbase] at hlowermin ⊢
+      rw [hupperbase] at huppermin ⊢
+      omega
+    rw [hexp]
+    exact CharTwo.add_self_eq_zero (R := PlumbingCoefficient) _
+  · -- The cube has dimension at least two, so neither face is a lattice point.
+    have hlower : (C.lowerFace v.val v.property).directions ≠ ∅ := by
+      rw [PlumbingCube.lowerFace_directions]
+      exact herase
+    have hupper : (C.upperFace v.val v.property).directions ≠ ∅ := by
+      rw [PlumbingCube.upperFace_directions]
+      exact herase
+    rw [P.latticeAugmentationCoefficient_of_directions_ne_empty k hlower,
+      P.latticeAugmentationCoefficient_of_directions_ne_empty k hupper]
+    simp
+
+/-- The augmentation kills the lattice differential, so it descends to lattice homology. -/
+theorem latticeAugmentation_comp_latticeDifferential (P : PlumbingGraph V)
+    (h : P.IsNegativeDefinite) (k : P.characteristicVectors) :
+    (P.latticeAugmentation k).comp (P.latticeDifferential k) = 0 := by
+  classical
+  refine Finsupp.lhom_ext' fun C => LinearMap.ext_ring ?_
+  simp only [LinearMap.comp_apply, Finsupp.lsingle_apply, LinearMap.zero_apply]
+  rw [latticeDifferential_single, map_smul,
+    P.latticeAugmentation_latticeDifferentialOnGenerator h k C, smul_zero]
+
+/-- The augmentation vanishes on every boundary. -/
+theorem latticeAugmentation_eq_zero_of_mem_range (P : PlumbingGraph V)
+    (h : P.IsNegativeDefinite) (k : P.characteristicVectors) {c : PlumbingChain V}
+    (hc : c ∈ LinearMap.range (P.latticeDifferential k)) :
+    P.latticeAugmentation k c = 0 := by
+  obtain ⟨b, rfl⟩ := hc
+  exact congrFun (congrArg DFunLike.coe (P.latticeAugmentation_comp_latticeDifferential h k)) b
+
+/-- A lattice point of minimal characteristic weight gives a cycle whose augmentation is `1`. -/
+theorem exists_cycle_latticeAugmentation_eq_one (P : PlumbingGraph V)
+    (h : P.IsNegativeDefinite) (k : P.characteristicVectors) :
+    ∃ c : PlumbingChain V, P.latticeDifferential k c = 0 ∧ P.latticeAugmentation k c = 1 := by
+  obtain ⟨x, hx⟩ := P.exists_characteristicWeight_eq_sInfCharacteristicWeight h k
+  refine ⟨Finsupp.single ({ base := x, directions := ∅ } : PlumbingCube V) 1, ?_, ?_⟩
+  · rw [latticeDifferential_single,
+      P.latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty k rfl, smul_zero]
+  · rw [latticeAugmentation_single,
+      P.latticeAugmentationCoefficient_of_directions_eq_empty k rfl, hx]
+    simp
+
+/-- The `U`-tower: the class of a minimal-weight lattice point spans a free `𝔽₂[U]`-submodule of
+lattice homology, since no nonzero multiple of that cycle is a boundary. -/
+theorem exists_cycle_forall_smul_notMem_range_latticeDifferential (P : PlumbingGraph V)
+    (h : P.IsNegativeDefinite) (k : P.characteristicVectors) :
+    ∃ c : PlumbingChain V, P.latticeDifferential k c = 0 ∧
+      ∀ a : PlumbingCoefficient,
+        a • c ∈ LinearMap.range (P.latticeDifferential k) → a = 0 := by
+  obtain ⟨c, hcycle, hone⟩ := P.exists_cycle_latticeAugmentation_eq_one h k
+  refine ⟨c, hcycle, fun a ha => ?_⟩
+  have := P.latticeAugmentation_eq_zero_of_mem_range h k ha
+  rwa [map_smul, hone, smul_eq_mul, mul_one] at this
+
+/-! ### Nonvanishing of lattice homology -/
+
+/-- The lattice short complex of a negative-definite plumbing is not exact: the class of a
+minimal-weight lattice point is a cycle that is not a boundary. -/
+theorem not_exact_latticeShortComplex (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+    (k : P.characteristicVectors) : ¬ (P.latticeShortComplex k).Exact := by
+  obtain ⟨c, hcycle, hone⟩ := P.exists_cycle_latticeAugmentation_eq_one h k
+  rw [latticeShortComplex_exact_iff]
+  intro hexact
+  have hzero := P.latticeAugmentation_eq_zero_of_mem_range h k (hexact c hcycle)
+  rw [hone] at hzero
+  exact one_ne_zero hzero
+
+/-- The characteristic-two lattice homology of a negative-definite plumbing is nonzero.
+
+This is the first nonvanishing statement for the invariant: up to now the only computed lattice
+homology was that of the zero-vertex plumbing. -/
+theorem not_isZero_latticeHomology (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+    (k : P.characteristicVectors) : ¬ Limits.IsZero (P.latticeHomology k) := by
+  rw [latticeHomology_def, ← ShortComplex.exact_iff_isZero_homology]
+  exact P.not_exact_latticeShortComplex h k
+
+end PlumbingGraph
+
+/-- The characteristic-two lattice homology of the `E₈` plumbing is nonzero in every spin^c
+structure. This is the roadmap's concrete negative-definite plumbing, the one whose lattice
+homology computes the Heegaard Floer homology of the Poincaré homology sphere. -/
+theorem e8Plumbing_not_isZero_latticeHomology (k : e8Plumbing.characteristicVectors) :
+    ¬ CategoryTheory.Limits.IsZero (e8Plumbing.latticeHomology k) :=
+  e8Plumbing.not_isZero_latticeHomology e8Plumbing_isNegativeDefinite k
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/Tower.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Tower.lean
@@ -79,6 +79,7 @@ noncomputable def latticeAugmentationCoefficient (P : PlumbingGraph V)
 
 /-- On a zero-dimensional cube the augmentation coefficient is the `U`-power measuring how far the
 base point sits above the minimal characteristic weight. -/
+@[simp]
 theorem latticeAugmentationCoefficient_of_directions_eq_empty (P : PlumbingGraph V)
     (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions = ∅) :
     P.latticeAugmentationCoefficient k C =
@@ -86,6 +87,7 @@ theorem latticeAugmentationCoefficient_of_directions_eq_empty (P : PlumbingGraph
   simp [latticeAugmentationCoefficient, hC]
 
 /-- On a cube of positive dimension the augmentation coefficient vanishes. -/
+@[simp]
 theorem latticeAugmentationCoefficient_of_directions_ne_empty (P : PlumbingGraph V)
     (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions ≠ ∅) :
     P.latticeAugmentationCoefficient k C = 0 := by
@@ -119,6 +121,7 @@ theorem latticeAugmentation_eq_zero_of_mem_degreePart (P : PlumbingGraph V)
   simp [P.latticeAugmentationCoefficient_of_directions_ne_empty k hne]
 
 /-- A zero-dimensional cube has no directions to differentiate along, so it is a cycle. -/
+@[simp]
 theorem latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty (P : PlumbingGraph V)
     (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions = ∅) :
     P.latticeDifferentialOnGenerator k C = 0 := by

--- a/TauCeti/LowDimTopology/Plumbing/Tower.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Tower.lean
@@ -44,7 +44,9 @@ future work.
 * `TauCeti.PlumbingGraph.exists_cycle_latticeAugmentation_eq_one`: a lattice point of minimal
   characteristic weight is a cycle with augmentation `1`.
 * `TauCeti.PlumbingGraph.exists_cycle_eq_zero_of_smul_mem_range_latticeDifferential`: that cycle
-  spans a free `𝔽₂[U]`-submodule of the cycles modulo boundaries: the `U`-tower.
+  satisfies the chain-level nonboundary criterion for the `U`-tower.
+* `TauCeti.PlumbingGraph.exists_injective_latticeHomologyCycleMap`: the resulting map from
+  `𝔽₂[U]` into lattice homology is injective.
 * `TauCeti.PlumbingGraph.not_isZero_latticeHomology`: the lattice homology of a negative-definite
   plumbing is nonzero.
 
@@ -253,6 +255,28 @@ theorem exists_cycle_eq_zero_of_smul_mem_range_latticeDifferential (P : Plumbing
   refine ⟨c, hcycle, fun a ha => ?_⟩
   have := P.latticeAugmentation_eq_zero_of_mem_range h k ha
   rwa [map_smul, hone, smul_eq_mul, mul_one] at this
+
+/-- A cycle with augmentation `1` generates a free copy of `𝔽₂[U]` in lattice homology. -/
+theorem latticeHomologyCycleMap_injective (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
+    (k : P.characteristicVectors) (c : PlumbingChain V)
+    (hc : P.latticeDifferential k c = 0) (hone : P.latticeAugmentation k c = 1) :
+    Function.Injective (P.latticeHomologyCycleMap k c hc) := by
+  apply (injective_iff_map_eq_zero _).2
+  intro a ha
+  have hrange : a • c ∈ LinearMap.range (P.latticeDifferential k) :=
+    (P.latticeHomologyCycleMap_apply_eq_zero_iff k c hc a).mp ha
+  have hzero := P.latticeAugmentation_eq_zero_of_mem_range h k hrange
+  rwa [map_smul, hone, smul_eq_mul, mul_one] at hzero
+
+/-- The class of a minimal-weight lattice point embeds a free `𝔽₂[U]`-submodule into the
+lattice homology of a negative-definite plumbing. -/
+theorem exists_injective_latticeHomologyCycleMap (P : PlumbingGraph V)
+    (h : P.IsNegativeDefinite) (k : P.characteristicVectors) :
+    ∃ (c : PlumbingChain V) (hc : P.latticeDifferential k c = 0),
+      P.latticeAugmentation k c = 1 ∧
+        Function.Injective (P.latticeHomologyCycleMap k c hc) := by
+  obtain ⟨c, hc, hone⟩ := P.exists_cycle_latticeAugmentation_eq_one h k
+  exact ⟨c, hc, hone, P.latticeHomologyCycleMap_injective h k c hc hone⟩
 
 /-! ### Nonvanishing of lattice homology -/
 

--- a/TauCeti/LowDimTopology/Plumbing/Tower.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Tower.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LowDimTopology.Plumbing.E8
 public import TauCeti.LowDimTopology.Plumbing.Grading
 public import TauCeti.LowDimTopology.Plumbing.Homology
 public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel
@@ -42,12 +41,10 @@ plumbed three-manifold, rather than one value among many.
   boundaries.
 * `TauCeti.PlumbingGraph.exists_cycle_latticeAugmentation_eq_one`: a lattice point of minimal
   characteristic weight is a cycle with augmentation `1`.
-* `TauCeti.PlumbingGraph.exists_cycle_forall_smul_notMem_range_latticeDifferential`: that cycle
+* `TauCeti.PlumbingGraph.exists_cycle_eq_zero_of_smul_mem_range_latticeDifferential`: that cycle
   spans a free `𝔽₂[U]`-submodule of the cycles modulo boundaries: the `U`-tower.
 * `TauCeti.PlumbingGraph.not_isZero_latticeHomology`: the lattice homology of a negative-definite
   plumbing is nonzero.
-* `TauCeti.e8Plumbing_not_isZero_latticeHomology`: in particular the lattice homology of the `E₈`
-  plumbing is nonzero in every spin^c structure.
 
 ## References
 
@@ -153,12 +150,14 @@ theorem latticeAugmentation_latticeDifferentialOnGenerator (P : PlumbingGraph V)
       ← pow_add, ← pow_add]
     have hlowerbase :
         P.characteristicWeight k (C.lowerFace v.val v.property).base =
-          PlumbingCube.characteristicWeight P k (C.lowerFace v.val v.property) :=
-      (PlumbingCube.characteristicWeight_of_directions_eq_empty P k hlower).symm
+          PlumbingCube.characteristicWeight P k (C.lowerFace v.val v.property) := by
+      rw [PlumbingCube.characteristicWeight_def, hlower,
+        PlumbingGraph.characteristicCubeWeight_empty]
     have hupperbase :
         P.characteristicWeight k (C.upperFace v.val v.property).base =
-          PlumbingCube.characteristicWeight P k (C.upperFace v.val v.property) :=
-      (PlumbingCube.characteristicWeight_of_directions_eq_empty P k hupper).symm
+          PlumbingCube.characteristicWeight P k (C.upperFace v.val v.property) := by
+      rw [PlumbingCube.characteristicWeight_def, hupper,
+        PlumbingGraph.characteristicCubeWeight_empty]
     have hlowerexp :
         (PlumbingCube.characteristicLowerFaceExponent P k C v.val : ℤ) =
           PlumbingCube.characteristicWeight P k C -
@@ -240,7 +239,7 @@ theorem exists_cycle_latticeAugmentation_eq_one (P : PlumbingGraph V)
 
 /-- The `U`-tower: the class of a minimal-weight lattice point spans a free `𝔽₂[U]`-submodule of
 lattice homology, since no nonzero multiple of that cycle is a boundary. -/
-theorem exists_cycle_forall_smul_notMem_range_latticeDifferential (P : PlumbingGraph V)
+theorem exists_cycle_eq_zero_of_smul_mem_range_latticeDifferential (P : PlumbingGraph V)
     (h : P.IsNegativeDefinite) (k : P.characteristicVectors) :
     ∃ c : PlumbingChain V, P.latticeDifferential k c = 0 ∧
       ∀ a : PlumbingCoefficient,
@@ -257,9 +256,57 @@ minimal-weight lattice point is a cycle that is not a boundary. -/
 theorem not_exact_latticeShortComplex (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
     (k : P.characteristicVectors) : ¬ (P.latticeShortComplex k).Exact := by
   obtain ⟨c, hcycle, hone⟩ := P.exists_cycle_latticeAugmentation_eq_one h k
-  rw [latticeShortComplex_exact_iff]
+  rw [ShortComplex.moduleCat_exact_iff]
   intro hexact
-  have hzero := P.latticeAugmentation_eq_zero_of_mem_range h k (hexact c hcycle)
+  have hf : (P.latticeShortComplex k).f =
+      eqToHom (P.latticeShortComplex_X₁ k) ≫
+        ModuleCat.ofHom (P.latticeDifferential k) ≫
+          eqToHom (P.latticeShortComplex_X₂ k).symm :=
+    (conj_eqToHom_iff_heq _ _ (P.latticeShortComplex_X₁ k)
+      (P.latticeShortComplex_X₂ k)).mpr (P.latticeShortComplex_f k)
+  have hg : (P.latticeShortComplex k).g =
+      eqToHom (P.latticeShortComplex_X₂ k) ≫
+        ModuleCat.ofHom (P.latticeDifferential k) ≫
+          eqToHom (P.latticeShortComplex_X₃ k).symm :=
+    (conj_eqToHom_iff_heq _ _ (P.latticeShortComplex_X₂ k)
+      (P.latticeShortComplex_X₃ k)).mpr (P.latticeShortComplex_g k)
+  have hf_comp : (P.latticeShortComplex k).f ≫
+      (eqToIso (P.latticeShortComplex_X₂ k)).hom =
+        (eqToIso (P.latticeShortComplex_X₁ k)).hom ≫
+          ModuleCat.ofHom (P.latticeDifferential k) := by
+    rw [hf]
+    simp
+  have hg_comp : (eqToIso (P.latticeShortComplex_X₂ k)).inv ≫
+      (P.latticeShortComplex k).g =
+        ModuleCat.ofHom (P.latticeDifferential k) ≫
+          (eqToIso (P.latticeShortComplex_X₃ k)).inv := by
+    rw [hg]
+    simp
+  let c' : (P.latticeShortComplex k).X₂ :=
+    (eqToIso (P.latticeShortComplex_X₂ k)).inv c
+  have hcycle' : (P.latticeShortComplex k).g c' = 0 := by
+    change (((eqToIso (P.latticeShortComplex_X₂ k)).inv ≫
+      (P.latticeShortComplex k).g) c) = 0
+    rw [hg_comp, ConcreteCategory.comp_apply]
+    change (eqToIso (P.latticeShortComplex_X₃ k)).inv
+      (P.latticeDifferential k c) = 0
+    rw [hcycle, map_zero]
+  obtain ⟨b, hb⟩ := hexact c' hcycle'
+  let b' : PlumbingChain V := (eqToIso (P.latticeShortComplex_X₁ k)).hom b
+  have hb' : P.latticeDifferential k b' = c := by
+    have hb'' := congrArg (fun x => (eqToIso (P.latticeShortComplex_X₂ k)).hom x) hb
+    change (((P.latticeShortComplex k).f ≫
+      (eqToIso (P.latticeShortComplex_X₂ k)).hom) b) =
+        (eqToIso (P.latticeShortComplex_X₂ k)).hom c' at hb''
+    rw [hf_comp, ConcreteCategory.comp_apply] at hb''
+    change P.latticeDifferential k b' =
+      (eqToIso (P.latticeShortComplex_X₂ k)).hom c' at hb''
+    have hc' : (eqToIso (P.latticeShortComplex_X₂ k)).hom c' = c := by
+      change (((eqToIso (P.latticeShortComplex_X₂ k)).inv ≫
+        (eqToIso (P.latticeShortComplex_X₂ k)).hom) c) = c
+      simp
+    rwa [hc'] at hb''
+  have hzero := P.latticeAugmentation_eq_zero_of_mem_range h k ⟨b', hb'⟩
   rw [hone] at hzero
   exact one_ne_zero hzero
 
@@ -273,12 +320,5 @@ theorem not_isZero_latticeHomology (P : PlumbingGraph V) (h : P.IsNegativeDefini
   exact P.not_exact_latticeShortComplex h k
 
 end PlumbingGraph
-
-/-- The characteristic-two lattice homology of the `E₈` plumbing is nonzero in every spin^c
-structure. This is the roadmap's concrete negative-definite plumbing, the one whose lattice
-homology computes the Heegaard Floer homology of the Poincaré homology sphere. -/
-theorem e8Plumbing_not_isZero_latticeHomology (k : e8Plumbing.characteristicVectors) :
-    ¬ CategoryTheory.Limits.IsZero (e8Plumbing.latticeHomology k) :=
-  e8Plumbing.not_isZero_latticeHomology e8Plumbing_isNegativeDefinite k
 
 end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/Tower.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Tower.lean
@@ -26,9 +26,11 @@ weight is a cycle sent to `1`.
 
 Two consequences follow. First, lattice homology is not zero: the short complex of the lattice
 differential is not exact. Second, and more precisely, the class of a minimal-weight lattice point
-generates a *free* `𝔽₂[U]`-submodule: no nonzero multiple `U ^ j` of it is a boundary. That
-infinite `U`-tower is the structural feature that makes `m` the numerical `d`-invariant of the
-plumbed three-manifold, rather than one value among many.
+generates a *free* `𝔽₂[U]`-submodule: no nonzero multiple `U ^ j` of it is a boundary, an infinite
+`U`-tower. Nothing here locates that tower in a homological grading, so no `d`-invariant is
+identified; in Némethi's theory it is the graded bottom of such a tower that gives the
+`d`-invariant of the plumbed three-manifold, and a graded statement to that effect is left to
+future work.
 
 ## Main definitions
 
@@ -256,57 +258,10 @@ minimal-weight lattice point is a cycle that is not a boundary. -/
 theorem not_exact_latticeShortComplex (P : PlumbingGraph V) (h : P.IsNegativeDefinite)
     (k : P.characteristicVectors) : ¬ (P.latticeShortComplex k).Exact := by
   obtain ⟨c, hcycle, hone⟩ := P.exists_cycle_latticeAugmentation_eq_one h k
-  rw [ShortComplex.moduleCat_exact_iff]
+  rw [P.latticeShortComplex_exact_iff_range_eq_ker k]
   intro hexact
-  have hf : (P.latticeShortComplex k).f =
-      eqToHom (P.latticeShortComplex_X₁ k) ≫
-        ModuleCat.ofHom (P.latticeDifferential k) ≫
-          eqToHom (P.latticeShortComplex_X₂ k).symm :=
-    (conj_eqToHom_iff_heq _ _ (P.latticeShortComplex_X₁ k)
-      (P.latticeShortComplex_X₂ k)).mpr (P.latticeShortComplex_f k)
-  have hg : (P.latticeShortComplex k).g =
-      eqToHom (P.latticeShortComplex_X₂ k) ≫
-        ModuleCat.ofHom (P.latticeDifferential k) ≫
-          eqToHom (P.latticeShortComplex_X₃ k).symm :=
-    (conj_eqToHom_iff_heq _ _ (P.latticeShortComplex_X₂ k)
-      (P.latticeShortComplex_X₃ k)).mpr (P.latticeShortComplex_g k)
-  have hf_comp : (P.latticeShortComplex k).f ≫
-      (eqToIso (P.latticeShortComplex_X₂ k)).hom =
-        (eqToIso (P.latticeShortComplex_X₁ k)).hom ≫
-          ModuleCat.ofHom (P.latticeDifferential k) := by
-    rw [hf]
-    simp
-  have hg_comp : (eqToIso (P.latticeShortComplex_X₂ k)).inv ≫
-      (P.latticeShortComplex k).g =
-        ModuleCat.ofHom (P.latticeDifferential k) ≫
-          (eqToIso (P.latticeShortComplex_X₃ k)).inv := by
-    rw [hg]
-    simp
-  let c' : (P.latticeShortComplex k).X₂ :=
-    (eqToIso (P.latticeShortComplex_X₂ k)).inv c
-  have hcycle' : (P.latticeShortComplex k).g c' = 0 := by
-    change (((eqToIso (P.latticeShortComplex_X₂ k)).inv ≫
-      (P.latticeShortComplex k).g) c) = 0
-    rw [hg_comp, ConcreteCategory.comp_apply]
-    change (eqToIso (P.latticeShortComplex_X₃ k)).inv
-      (P.latticeDifferential k c) = 0
-    rw [hcycle, map_zero]
-  obtain ⟨b, hb⟩ := hexact c' hcycle'
-  let b' : PlumbingChain V := (eqToIso (P.latticeShortComplex_X₁ k)).hom b
-  have hb' : P.latticeDifferential k b' = c := by
-    have hb'' := congrArg (fun x => (eqToIso (P.latticeShortComplex_X₂ k)).hom x) hb
-    change (((P.latticeShortComplex k).f ≫
-      (eqToIso (P.latticeShortComplex_X₂ k)).hom) b) =
-        (eqToIso (P.latticeShortComplex_X₂ k)).hom c' at hb''
-    rw [hf_comp, ConcreteCategory.comp_apply] at hb''
-    change P.latticeDifferential k b' =
-      (eqToIso (P.latticeShortComplex_X₂ k)).hom c' at hb''
-    have hc' : (eqToIso (P.latticeShortComplex_X₂ k)).hom c' = c := by
-      change (((eqToIso (P.latticeShortComplex_X₂ k)).inv ≫
-        (eqToIso (P.latticeShortComplex_X₂ k)).hom) c) = c
-      simp
-    rwa [hc'] at hb''
-  have hzero := P.latticeAugmentation_eq_zero_of_mem_range h k ⟨b', hb'⟩
+  have hzero := P.latticeAugmentation_eq_zero_of_mem_range h k
+    (hexact ▸ LinearMap.mem_ker.mpr hcycle)
   rw [hone] at hzero
   exact one_ne_zero hzero
 


### PR DESCRIPTION
This PR proves that the characteristic-two lattice homology of a negative-definite plumbing graph is nonzero, and locates a free `𝔽₂[U]`-tower inside it, advancing `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"), whose milestone asks for "Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions; ... computations for Seifert-fibered examples; `d`-invariant analogues", with the acceptance criterion "`ℍ` of a concrete negative-definite plumbing (e.g. the `E₈`-plumbing / Poincaré sphere)". Everything Lane L had computed so far was the zero-vertex plumbing, where the differential is zero for size reasons; `latticeHomology` of a plumbing with vertices was not known to be nonzero, so no statement about it could yet be non-vacuous.

The mechanism is an augmentation. Write `m` for `sInfCharacteristicWeight`, the minimal value of the characteristic weight `χ_k`, which a negative-definite plumbing attains. `latticeAugmentationCoefficient` sends the zero-dimensional cube at a lattice point `x` to `U ^ (χ_k(x) - m)` and every cube of positive dimension to `0`, and `latticeAugmentation` is the resulting `𝔽₂[U]`-linear map on plumbing chains. It kills the lattice differential: a cube of dimension at least two has all its codimension-one faces of positive dimension, while for an edge the lower and upper faces contribute `U ^ (w - m)` each — the face exponent is exactly the drop from the edge weight `w` to the weight of that face, so the two exponents telescope to the same value — and in characteristic two they cancel. A lattice point of minimal weight is therefore a cycle whose augmentation is `1`, and `exists_cycle_eq_zero_of_smul_mem_range_latticeDifferential` records the consequence that no nonzero multiple `U ^ j` of that cycle is a boundary: the class spans a free `𝔽₂[U]`-submodule. That infinite `U`-tower, based at `m`, is the structure whose graded bottom gives the `d`-invariant of the plumbed three-manifold in Némethi's theory; no grading statement is proved here, so this PR identifies no `d`-invariant. `not_isZero_latticeHomology` is the categorical form, and `e8Plumbing_not_isZero_latticeHomology` specializes it to the roadmap's named example in every spin^c structure.

This was the most effective distinct next step because Lane L already had the graded chain complex, `∂² = 0`, negative-definiteness of `E₈`, the finiteness of the weight sublevel sets and the attained minimum `sInfCharacteristicWeight` on `main`, so the missing link between the numerical `d`-invariant input and the invariant itself was exactly a nonvanishing statement, and the augmentation supplies it with no new coefficient theory; the open CombinatorialHeegaardFloer pull requests concern the grid lane instead (marking regions, marking centres and gradings, and the unblocked grid differential). After this PR, Lane L still needs `ℤ[U]` coefficients with signs and Neumann-move invariance before `ℍ` of `E₈` can be matched against the literature rank by rank.

Add `TauCeti/LowDimTopology/Plumbing/Tower.lean`, the `E₈` specialization in `E8.lean`, and, in `Homology.lean`, `latticeShortComplex_exact_iff_range_eq_ker`, the chain-level reading of exactness of the lattice short complex: it has to be stated there because the body of `latticeShortComplex` is not exposed, so no downstream file can apply `ShortComplex.moduleCat_exact_iff_range_eq_ker` to it. Reuse Mathlib's `Finsupp.linearCombination`, `CharTwo.add_self_eq_zero`, `ShortComplex.moduleCat_exact_iff_range_eq_ker` and `ShortComplex.exact_iff_isZero_homology` together with Tau Ceti's existing cube, weight, sublevel and lattice-differential APIs; no Mathlib implementation or external formalization is vendored.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"lattice-homology-u-tower"}-->

🤖 Prepared with Claude Code

