### PR TITLE
feat(Huber): the neighbourhood filtration transfers to a finer denominator

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -509,12 +509,10 @@ comparison map `Aᵤ → A_w` carries `locIdealImage P U u V n` into `locIdealIm
 the same index `n` — passing to a multiple of the denominator costs no depth.
 
 This is the filtration companion of `awayLift_mem_locSubring`, which carries `D` itself. The two
-together are what a comparison of nested presentations needs: the topologies on both sides are
-defined by these filtrations, so continuity of the comparison map is exactly this statement.
-
-The generators of `Jⁿ` are images of `Iⁿ`, which the comparison map sends to the corresponding
-generators on the finer side; the `smul` case is where `awayLift_mem_locSubring` enters, placing
-the scalar in the finer `D` so that `locIdealImage_mul_locSubring_subset` applies. -/
+together are what a comparison of nested presentations needs. Since both topologies have these
+filtrations as a neighbourhood basis of zero, the same-index inclusion **implies** continuity of
+the comparison map; it is strictly stronger than continuity, which would allow the index to
+grow. -/
 theorem awayLift_mem_locIdealImage (P : PairOfDefinition A) (U : Finset A) (u : A)
     (V : Type*) [CommRing V] [Algebra A V] [IsLocalization.Away u V]
     (Tw : Finset A) (w : A) (W : Type*) [CommRing W] [Algebra A W] [IsLocalization.Away w W]

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Basic.lean
@@ -41,6 +41,9 @@ universal property in `LocalizationTopology.UniversalProperty`, the completion `
 * `hasDenominatorPower_of_idealOfDefinition_le_span`: numerators containing a subset of `A₀`
   whose span contains `I` supply the standing denominator-power hypothesis for every denominator.
 * `isHuberRing_locTopology`: `Aₛ` under `locTopology` is a Huber ring.
+* `awayLift_mem_locSubring` and `awayLift_mem_locIdealImage`: passing to a multiple `w = u * r`
+  of the denominator carries `D` and its neighbourhood filtration forward, the latter at the same
+  index — which is what makes the comparison map of two nested presentations continuous.
 * `isBounded_image_algebraMap_of_isBounded` and `isPowerBounded_algebraMap_of_isPowerBounded`:
   bounded sets have bounded image, so power-orbits transfer and each power-bounded *element*
   stays power-bounded. The `locSubring` route reaches only a ring of definition, whose
@@ -53,10 +56,11 @@ This is a port of AINTLIB's `LocalizationTopology.lean`, at commit `d9f2fbbb`.
 `locIdealImage_mul_algebraMap_subset`, `isBounded_image_algebraMap_of_isBounded` and
 `isPowerBounded_algebraMap_of_isPowerBounded` are later additions, following the skeleton at
 `LocalizationTopology.lean:690-753` of commit `37bbdaeb9`. `awayLift_mem_locSubring`,
-`divBy_mul_mem_locSubring` and `hasDenominatorPower_mul` are **also later additions, and have no
-AINTLIB analogue at all** — commit `37bbdaeb9` carries no transfer of `D`-membership along a
-comparison map and no combination of the denominator hypothesis for a product denominator; they are
-new work for the nested-presentation comparison of Wedhorn §8.2. The main changes
+`awayLift_mem_locIdealImage`, `divBy_mul_mem_locSubring` and `hasDenominatorPower_mul` are **also
+later additions, and have no AINTLIB analogue at all** — commit `37bbdaeb9` carries no transfer of
+`D`-membership or of its neighbourhood filtration along a comparison map, and no combination of the
+denominator hypothesis for a product denominator; they are new work for the nested-presentation
+comparison of Wedhorn §8.2. The main changes
 are: adapted `PairOfDefinition` field names to TauCeti conventions (`A₀`→`ringOfDefinition`,
 `I`→`ideal`, etc.); uses characteristic lemmas instead of destructuring definitions; removed
 unused hypotheses to satisfy `#lint` checks; stated over an arbitrary localisation `S` away from
@@ -499,6 +503,41 @@ theorem locIdealImage_mul_locSubring_subset (P : PairOfDefinition A) (T : Finset
     rw [locIdealImage_zero, Subring.coe_toAddSubgroup]
   rw [h]
   exact locIdealImage_mul_subset_add P T s S n 0
+
+/-- **The neighbourhood filtration transfers to a finer denominator.** With `w = u * r`, the
+comparison map `Aᵤ → A_w` carries `locIdealImage P U u V n` into `locIdealImage P Tw w W n`, at
+the same index `n` — passing to a multiple of the denominator costs no depth.
+
+This is the filtration companion of `awayLift_mem_locSubring`, which carries `D` itself. The two
+together are what a comparison of nested presentations needs: the topologies on both sides are
+defined by these filtrations, so continuity of the comparison map is exactly this statement.
+
+The generators of `Jⁿ` are images of `Iⁿ`, which the comparison map sends to the corresponding
+generators on the finer side; the `smul` case is where `awayLift_mem_locSubring` enters, placing
+the scalar in the finer `D` so that `locIdealImage_mul_locSubring_subset` applies. -/
+theorem awayLift_mem_locIdealImage (P : PairOfDefinition A) (U : Finset A) (u : A)
+    (V : Type*) [CommRing V] [Algebra A V] [IsLocalization.Away u V]
+    (Tw : Finset A) (w : A) (W : Type*) [CommRing W] [Algebra A W] [IsLocalization.Away w W]
+    (r : A) (hw : w = u * r) (hgen : ∀ t ∈ U, t * r ∈ Tw) (n : ℕ)
+    {x : V} (hx : x ∈ locIdealImage P U u V n) :
+    IsLocalization.Away.lift u (IsLocalization.Away.isUnit_of_dvd w ⟨r, hw⟩) x
+      ∈ locIdealImage P Tw w W n := by
+  obtain ⟨d, hd, rfl⟩ := (mem_locIdealImage_iff P U u V n).mp hx
+  clear hx
+  rw [locIdeal_pow_eq_span] at hd
+  induction hd using Submodule.span_induction with
+  | mem z hz =>
+      obtain ⟨b, hb, rfl⟩ := hz
+      rw [toLocSubring_apply, IsLocalization.Away.lift_eq]
+      exact (mem_locIdealImage_iff P Tw w W n).mpr
+        ⟨toLocSubring P Tw w W b, toLocSubring_mem_locIdeal_pow P Tw w W hb,
+          toLocSubring_apply P Tw w W b⟩
+  | zero => simp
+  | add p q _ _ hp hq => simpa [map_add] using (locIdealImage P Tw w W n).add_mem hp hq
+  | smul e p _ hp =>
+      have he := awayLift_mem_locSubring P U u V Tw w W r hw hgen e.2
+      simpa [map_mul, mul_comm] using locIdealImage_mul_locSubring_subset P Tw w W n
+        (Set.mul_mem_mul hp he)
 
 /-- Multiplying `1/s` by an element of `Jᴺ` lands back in `D`, once `N` is large enough that
 `b/s ∈ D` for every `b ∈ Iᴺ`. -/


### PR DESCRIPTION
`awayLift_mem_locSubring` carries the candidate ring of definition `D` along the comparison map
`Aᵤ → A_w` of two nested presentations (`w = u * r`). This adds the missing companion for the
**neighbourhood filtration**:

```text
awayLift_mem_locIdealImage :
  x ∈ locIdealImage P U u V n →
    IsLocalization.Away.lift u ⋯ x ∈ locIdealImage P Tw w W n
```

at the **same index `n`** — passing to a multiple of the denominator costs no depth.

## Why this is the shape that is needed

Both localisation topologies have these filtrations as a neighbourhood basis of zero
(`hasBasis_nhds_zero_locTopology`), so this statement **implies** continuity of the comparison map
— and is strictly stronger than it, since continuity would allow the index to grow rather than be
preserved. The subring version alone gives neither: `locSubring` transfer says where elements
land, not how deep they land.

Layer 3.1 asks for the canonical isomorphism between the localisations of two presentations of the
same rational subset and for restriction maps satisfying the identity and composition laws; a
*topological* comparison needs the filtration statement, and it is the index-preservation that
makes the two inverse maps mutually continuous rather than merely mutually inverse.

The proof is span induction over `locIdeal_pow_eq_span`. The generators of `Jⁿ` are images of `Iⁿ`,
which the comparison map sends to the corresponding generators on the finer side; the `smul` case is
where `awayLift_mem_locSubring` enters, placing the scalar in the finer `D` so that the existing
`locIdealImage_mul_locSubring_subset` applies.

## Placement

`Basic.lean`, in the existing `### The neighborhood basis` section, immediately after
`locIdealImage_mul_locSubring_subset` — the last *public* structural fact about `locIdealImage`,
and the lemma this proof consumes — and before the private continuity machinery that follows. It
cannot join `awayLift_mem_locSubring` in `### Passing to a denominator that is a multiple`, because
`locIdealImage` is not defined until the later section.

Roadmap: AdicSpaces

Advances **Layer 3.1, rational localisation of a Huber pair**, whose target reads: "A rational
subset has many presentations. Construct the canonical isomorphism between the localisations
associated with two presentations of the same subset, prove compatibility for three presentations,
and construct restriction maps satisfying the identity and composition laws."
(`TauCetiRoadmap/AdicSpaces/README.md`, roadmap `25ca958`.) This supplies a prerequisite for that
target rather than completing it.

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"away-lift-loc-ideal-image"}-->

Provenance: no source — this has **no AINTLIB analogue**, like its sibling
`awayLift_mem_locSubring`. AINTLIB (`github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9`, Apache-2.0,
`projects/AdicSpaces/`) has a large `locNhd` API and 32 `locLift_*` declarations, but none
transfers `locNhd` along a comparison map of two presentations. The two nearest were read in
full and are different results: `locNhd_subset_preimage_of_lift_stabilizing`
(`TopologyComparison.lean`) is a Tate-quotient statement needing `IsTateRing`, `T2Space` and a
stabilising hypothesis; `algebraMap_image_mem_Jfull_pow_of_awayLift_image_in_locNhd`
(`PresheafTateStructure.lean`) is the *reverse* direction, and its own surrounding prose records
that route as abandoned — the `(Jfull D)^m` form is too strong, with a `ℚ_p` counterexample.

The module docstring's `## Main results` and `## Provenance` are updated in the same commit, the
latter adding this name to the list of declarations with no AINTLIB analogue.

