### PR TITLE
refactor(Nilpotent): publish the base-change vanishing lemma and stop re-deriving it

### DIFF
--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -299,12 +299,11 @@ private theorem baseChange_mul_integralDividedPower
 
 This is the truncation fact every finite expansion of `baseChangeExp` needs: it is what makes the
 terms outside the truncation bound drop out. -/
-theorem baseChange_integralDividedPower_eq_zero_of_le
-    (x : A) (M : S)
-    (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
-    {k n : ℕ} (hk : x ^ k = 0) (hkn : k ≤ n) :
-    (integralDividedPower x M n (hM n)).baseChange R = 0 := by
-  rw [integralDividedPower_eq_zero_of_le x M n (hM n) hk hkn, LinearMap.baseChange_zero]
+theorem baseChange_integralDividedPower_eq_zero_of_le (x : A) (M : S) {n : ℕ}
+    (hn : ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
+    {k : ℕ} (hk : x ^ k = 0) (hkn : k ≤ n) :
+    (integralDividedPower x M n hn).baseChange R = 0 := by
+  rw [integralDividedPower_eq_zero_of_le x M n hn hk hkn, LinearMap.baseChange_zero]
 
 /-- The base-changed exponential expanded over any truncation bound `k` satisfying `x ^ k = 0`. -/
 theorem baseChangeExp_of_pow_eq_zero (x : A) (M : S)
@@ -318,7 +317,7 @@ theorem baseChangeExp_of_pow_eq_zero (x : A) (M : S)
   rw [mem_range] at hn hnot
   have hn_ge : nilpotencyClass x ≤ n := not_lt.1 hnot
   have hpow : x ^ nilpotencyClass x = 0 := pow_nilpotencyClass ⟨k, hk⟩
-  rw [baseChange_integralDividedPower_eq_zero_of_le x M hM hpow hn_ge, smul_zero]
+  rw [baseChange_integralDividedPower_eq_zero_of_le x M (hM n) hpow hn_ge, smul_zero]
 
 /-- The base-changed exponential acts on a pure tensor by the divided-power formula over any
 truncation bound `k` satisfying `x ^ k = 0`. -/
@@ -412,7 +411,7 @@ theorem baseChangeExp_add (x : A) (M : S)
   symm
   apply sum_pow_smul_mul_sum_pow_smul (fun n => (integralDividedPower x M n (hM n)).baseChange R)
   · intro n hn
-    exact baseChange_integralDividedPower_eq_zero_of_le x M hM
+    exact baseChange_integralDividedPower_eq_zero_of_le x M (hM n)
       (pow_nilpotencyClass hx) hn
   · exact baseChange_mul_integralDividedPower x M hM
 

--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -36,6 +36,8 @@ characteristic.
 * `TauCeti.integralDividedPower`: a divided-power operator restricted to an invariant additive
   subgroup.
 * `TauCeti.mul_integralDividedPower`: multiplication formula for restricted divided powers.
+* `TauCeti.baseChange_integralDividedPower_eq_zero_of_le`: a restricted divided power
+  vanishes on base change above the nilpotency index.
 * `TauCeti.baseChangeExp`: the finite divided-power exponential on `R ⊗[ℤ] M` for an element of `A`.
 * `TauCeti.map_baseChangeExp`: naturality of the exponential under a map of parameter rings.
 * `TauCeti.baseChangeExp_add`: its one-parameter group law.
@@ -292,7 +294,12 @@ private theorem baseChange_mul_integralDividedPower
   rw [← LinearMap.baseChange_mul, mul_integralDividedPower]
   exact map_nsmul (Module.End.baseChangeHom ℤ R M) _ _
 
-private theorem baseChange_integralDividedPower_eq_zero_of_le
+/-- **A restricted divided power vanishes on base change above the nilpotency index.** If
+`x ^ k = 0` and `k ≤ n`, the base change of `integralDividedPower x M n` is the zero map.
+
+This is the truncation fact every finite expansion of `baseChangeExp` needs: it is what makes the
+terms outside the truncation bound drop out. -/
+theorem baseChange_integralDividedPower_eq_zero_of_le
     (x : A) (M : S)
     (hM : ∀ n, ∀ v ∈ M, Associative.dividedPower n x • v ∈ M)
     {k n : ℕ} (hk : x ^ k = 0) (hkn : k ≤ n) :

--- a/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
+++ b/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
@@ -253,15 +253,12 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq
     simp only [map_mul, map_sum] at h
     exact h
   · -- Outside the truncation the reordered triple has a vanishing factor.
-    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 := by
-      intro q hq
-      rw [integralDividedPower_eq_zero_of_le x M q (hMx q) hkx hq, LinearMap.baseChange_zero]
-    have hvy : ∀ p, ky ≤ p → (integralDividedPower y M p (hMy p)).baseChange R = 0 := by
-      intro p hp
-      rw [integralDividedPower_eq_zero_of_le y M p (hMy p) hky hp, LinearMap.baseChange_zero]
-    have hvz : ∀ k, kz ≤ k → (integralDividedPower z M k (hMz k)).baseChange R = 0 := by
-      intro k hk
-      rw [integralDividedPower_eq_zero_of_le z M k (hMz k) hkz hk, LinearMap.baseChange_zero]
+    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 :=
+      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M hMx hkx hq
+    have hvy : ∀ p, ky ≤ p → (integralDividedPower y M p (hMy p)).baseChange R = 0 :=
+      fun p hp => baseChange_integralDividedPower_eq_zero_of_le y M hMy hky hp
+    have hvz : ∀ k, kz ≤ k → (integralDividedPower z M k (hMz k)).baseChange R = 0 :=
+      fun k hk => baseChange_integralDividedPower_eq_zero_of_le z M hMz hkz hk
     rintro p k q (hpk | hqk)
     · rcases le_or_gt ky p with hp | hp
       · rw [hvy p hp, zero_mul, zero_mul]

--- a/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
+++ b/TauCeti/RingTheory/Nilpotent/ChevalleyCommutator.lean
@@ -254,11 +254,11 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq
     exact h
   · -- Outside the truncation the reordered triple has a vanishing factor.
     have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 :=
-      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M hMx hkx hq
+      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M (hMx q) hkx hq
     have hvy : ∀ p, ky ≤ p → (integralDividedPower y M p (hMy p)).baseChange R = 0 :=
-      fun p hp => baseChange_integralDividedPower_eq_zero_of_le y M hMy hky hp
+      fun p hp => baseChange_integralDividedPower_eq_zero_of_le y M (hMy p) hky hp
     have hvz : ∀ k, kz ≤ k → (integralDividedPower z M k (hMz k)).baseChange R = 0 :=
-      fun k hk => baseChange_integralDividedPower_eq_zero_of_le z M hMz hkz hk
+      fun k hk => baseChange_integralDividedPower_eq_zero_of_le z M (hMz k) hkz hk
     rintro p k q (hpk | hqk)
     · rcases le_or_gt ky p with hp | hp
       · rw [hvy p hp, zero_mul, zero_mul]

--- a/TauCeti/RingTheory/Nilpotent/RootString/Basic.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/Basic.lean
@@ -249,13 +249,13 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq_two_nsmul
     exact h
   · -- Outside the truncation the reordered quadruple has a vanishing factor.
     have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 :=
-      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M hMx hkx hq
+      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M (hMx q) hkx hq
     have hvy : ∀ a, ky ≤ a → (integralDividedPower y M a (hMy a)).baseChange R = 0 :=
-      fun a ha => baseChange_integralDividedPower_eq_zero_of_le y M hMy hky ha
+      fun a ha => baseChange_integralDividedPower_eq_zero_of_le y M (hMy a) hky ha
     have hvz : ∀ b, kz ≤ b → (integralDividedPower z M b (hMz b)).baseChange R = 0 :=
-      fun b hb => baseChange_integralDividedPower_eq_zero_of_le z M hMz hkz hb
+      fun b hb => baseChange_integralDividedPower_eq_zero_of_le z M (hMz b) hkz hb
     have hvw : ∀ c, kw ≤ c → (integralDividedPower w M c (hMw c)).baseChange R = 0 :=
-      fun c hc => baseChange_integralDividedPower_eq_zero_of_le w M hMw hkw hc
+      fun c hc => baseChange_integralDividedPower_eq_zero_of_le w M (hMw c) hkw hc
     rintro a b c q (habc | hqbc)
     · rcases le_or_gt ky a with ha | ha
       · rw [hvy a ha, zero_mul, zero_mul, zero_mul]

--- a/TauCeti/RingTheory/Nilpotent/RootString/Basic.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/Basic.lean
@@ -248,18 +248,14 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq_two_nsmul
     simp only [map_mul, map_sum] at h
     exact h
   · -- Outside the truncation the reordered quadruple has a vanishing factor.
-    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 := by
-      intro q hq
-      rw [integralDividedPower_eq_zero_of_le x M q (hMx q) hkx hq, LinearMap.baseChange_zero]
-    have hvy : ∀ a, ky ≤ a → (integralDividedPower y M a (hMy a)).baseChange R = 0 := by
-      intro a ha
-      rw [integralDividedPower_eq_zero_of_le y M a (hMy a) hky ha, LinearMap.baseChange_zero]
-    have hvz : ∀ b, kz ≤ b → (integralDividedPower z M b (hMz b)).baseChange R = 0 := by
-      intro b hb
-      rw [integralDividedPower_eq_zero_of_le z M b (hMz b) hkz hb, LinearMap.baseChange_zero]
-    have hvw : ∀ c, kw ≤ c → (integralDividedPower w M c (hMw c)).baseChange R = 0 := by
-      intro c hc
-      rw [integralDividedPower_eq_zero_of_le w M c (hMw c) hkw hc, LinearMap.baseChange_zero]
+    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 :=
+      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M hMx hkx hq
+    have hvy : ∀ a, ky ≤ a → (integralDividedPower y M a (hMy a)).baseChange R = 0 :=
+      fun a ha => baseChange_integralDividedPower_eq_zero_of_le y M hMy hky ha
+    have hvz : ∀ b, kz ≤ b → (integralDividedPower z M b (hMz b)).baseChange R = 0 :=
+      fun b hb => baseChange_integralDividedPower_eq_zero_of_le z M hMz hkz hb
+    have hvw : ∀ c, kw ≤ c → (integralDividedPower w M c (hMw c)).baseChange R = 0 :=
+      fun c hc => baseChange_integralDividedPower_eq_zero_of_le w M hMw hkw hc
     rintro a b c q (habc | hqbc)
     · rcases le_or_gt ky a with ha | ha
       · rw [hvy a ha, zero_mul, zero_mul, zero_mul]

--- a/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
@@ -289,17 +289,17 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul
     exact h
   · -- Outside the truncation the reordered sextuple has a vanishing factor.
     have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 :=
-      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M hMx hkx hq
+      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M (hMx q) hkx hq
     have hvy : ∀ a, ky ≤ a → (integralDividedPower y M a (hMy a)).baseChange R = 0 :=
-      fun a ha => baseChange_integralDividedPower_eq_zero_of_le y M hMy hky ha
+      fun a ha => baseChange_integralDividedPower_eq_zero_of_le y M (hMy a) hky ha
     have hvz : ∀ b, kz ≤ b → (integralDividedPower z M b (hMz b)).baseChange R = 0 :=
-      fun b hb => baseChange_integralDividedPower_eq_zero_of_le z M hMz hkz hb
+      fun b hb => baseChange_integralDividedPower_eq_zero_of_le z M (hMz b) hkz hb
     have hvw : ∀ c, kw ≤ c → (integralDividedPower w M c (hMw c)).baseChange R = 0 :=
-      fun c hc => baseChange_integralDividedPower_eq_zero_of_le w M hMw hkw hc
+      fun c hc => baseChange_integralDividedPower_eq_zero_of_le w M (hMw c) hkw hc
     have hvv : ∀ d, kv ≤ d → (integralDividedPower v M d (hMv d)).baseChange R = 0 :=
-      fun d hd => baseChange_integralDividedPower_eq_zero_of_le v M hMv hkv hd
+      fun d hd => baseChange_integralDividedPower_eq_zero_of_le v M (hMv d) hkv hd
     have hvs' : ∀ e, ks ≤ e → (integralDividedPower s M e (hMs e)).baseChange R = 0 :=
-      fun e he => baseChange_integralDividedPower_eq_zero_of_le s M hMs hks he
+      fun e he => baseChange_integralDividedPower_eq_zero_of_le s M (hMs e) hks he
     rintro a b c d e q (habc | hqbc)
     · rcases le_or_gt ky a with ha | ha
       · simp [hvy a ha]

--- a/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
+++ b/TauCeti/RingTheory/Nilpotent/RootString/G2.lean
@@ -288,24 +288,18 @@ theorem baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul
     simp only [map_mul, map_sum] at h
     exact h
   · -- Outside the truncation the reordered sextuple has a vanishing factor.
-    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 := by
-      intro q hq
-      rw [integralDividedPower_eq_zero_of_le x M q (hMx q) hkx hq, LinearMap.baseChange_zero]
-    have hvy : ∀ a, ky ≤ a → (integralDividedPower y M a (hMy a)).baseChange R = 0 := by
-      intro a ha
-      rw [integralDividedPower_eq_zero_of_le y M a (hMy a) hky ha, LinearMap.baseChange_zero]
-    have hvz : ∀ b, kz ≤ b → (integralDividedPower z M b (hMz b)).baseChange R = 0 := by
-      intro b hb
-      rw [integralDividedPower_eq_zero_of_le z M b (hMz b) hkz hb, LinearMap.baseChange_zero]
-    have hvw : ∀ c, kw ≤ c → (integralDividedPower w M c (hMw c)).baseChange R = 0 := by
-      intro c hc
-      rw [integralDividedPower_eq_zero_of_le w M c (hMw c) hkw hc, LinearMap.baseChange_zero]
-    have hvv : ∀ d, kv ≤ d → (integralDividedPower v M d (hMv d)).baseChange R = 0 := by
-      intro d hd
-      rw [integralDividedPower_eq_zero_of_le v M d (hMv d) hkv hd, LinearMap.baseChange_zero]
-    have hvs' : ∀ e, ks ≤ e → (integralDividedPower s M e (hMs e)).baseChange R = 0 := by
-      intro e he
-      rw [integralDividedPower_eq_zero_of_le s M e (hMs e) hks he, LinearMap.baseChange_zero]
+    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 :=
+      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M hMx hkx hq
+    have hvy : ∀ a, ky ≤ a → (integralDividedPower y M a (hMy a)).baseChange R = 0 :=
+      fun a ha => baseChange_integralDividedPower_eq_zero_of_le y M hMy hky ha
+    have hvz : ∀ b, kz ≤ b → (integralDividedPower z M b (hMz b)).baseChange R = 0 :=
+      fun b hb => baseChange_integralDividedPower_eq_zero_of_le z M hMz hkz hb
+    have hvw : ∀ c, kw ≤ c → (integralDividedPower w M c (hMw c)).baseChange R = 0 :=
+      fun c hc => baseChange_integralDividedPower_eq_zero_of_le w M hMw hkw hc
+    have hvv : ∀ d, kv ≤ d → (integralDividedPower v M d (hMv d)).baseChange R = 0 :=
+      fun d hd => baseChange_integralDividedPower_eq_zero_of_le v M hMv hkv hd
+    have hvs' : ∀ e, ks ≤ e → (integralDividedPower s M e (hMs e)).baseChange R = 0 :=
+      fun e he => baseChange_integralDividedPower_eq_zero_of_le s M hMs hks he
     rintro a b c d e q (habc | hqbc)
     · rcases le_or_gt ky a with ha | ha
       · simp [hvy a ha]


### PR DESCRIPTION
`baseChange_integralDividedPower_eq_zero_of_le` **already existed** in `BaseChangeAction.lean`,
where it is used three times. But it was declared `private`, so every downstream file re-derived
its two-line body inline instead of importing it.

## The duplication

Thirteen copies, across three files:

| file | sites |
|---|---|
| `RingTheory/Nilpotent/ChevalleyCommutator.lean` | 3 |
| `RingTheory/Nilpotent/RootString/Basic.lean` | 4 |
| `RingTheory/Nilpotent/RootString/G2.lean` | 6 |

each of the form

```lean
    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 := by
      intro q hq
      rw [integralDividedPower_eq_zero_of_le x M q (hMx q) hkx hq, LinearMap.baseChange_zero]
```

That `rw` **is** the lemma's own body, instantiated at a different element of the root chain. Each
site now delegates:

```lean
    have hvx : ∀ q, kx ≤ q → (integralDividedPower x M q (hMx q)).baseChange R = 0 :=
      fun q hq => baseChange_integralDividedPower_eq_zero_of_le x M hMx hkx hq
```

The lemma is now public, carries a docstring, and is listed among the module's main results —
which is what it should have been, given `BaseChangeAction.lean` itself already treats it as a
named step three times over.

## Review round 1: the published hypothesis was too strong

`generality` caught something the de-duplication itself hid. The lemma is about a single degree
`n`, but it carried the whole-family hypothesis `hM : ∀ n, ∀ v ∈ M, dividedPower n x • v ∈ M` and
used only `hM n`. Harmless while it was private; publishing it made the surplus hypothesis part of
the API, so a caller holding invariance only at degree `n` could not use it.

I verified the convention rather than taking it on trust: the lemma's own dependency
`integralDividedPower_eq_zero_of_le` takes the per-degree `hn`, as do `integralDividedPower_zero`
and the file's other single-degree lemmas; `∀ n` is reserved for `baseChangeExp` and friends, which
genuinely quantify over the family.

It now takes `hn` per degree with `n` implicit, and all **15** call sites pass `(hM n)` — they all
had the family in scope, so nothing else changed. (The finding said 16; its own line list has 15,
and the build agrees.)

This is the minimal-hypothesis check I owe at extraction time and skipped here: publishing an
existing private lemma is still an extraction, and its hypotheses still need re-deriving.

## Scope

No new declaration, no statement changed, no proof restructured: one existing declaration is
exposed and thirteen re-derivations of it are removed. The one remaining occurrence of the raw
`rw` is the lemma's own body, where it belongs.

## Result

| | before | after |
|---|---|---|
| `baseChangeExp_mul_baseChangeExp_of_commutator_eq_two_nsmul` | 49 | 45 |
| `baseChangeExp_mul_baseChangeExp_of_commutator_eq_three_nsmul` | 70 | 64 |

Net `-6` lines overall (the published lemma gains a docstring and an index entry, which is why the
saving is smaller than the 13 lines removed).

Counting note: my first `grep -c integralDividedPower_eq_zero_of_le` over-counted, because that
string is also a substring of the wrapper's own name `baseChange_integralDividedPower_eq_zero_of_le`.
The 3/4/6 split above is from matching the inline `rw … LinearMap.baseChange_zero` pattern
specifically, and the rewrite script asserts that zero instances of it survive outside the lemma.

Gates re-run on `efa21db1`: `lake build` (8432 jobs), `lake exe axioms` (57168 declarations),
`lake exe module-system` (2670 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`, 64 grandfathered;
docstring scan 4489/4489 documented).

Roadmap: ReductiveGroups

