### PR TITLE
refactor(Lie): name the three exponential-transport steps of expAd conjugation

### DIFF
--- a/TauCeti/Algebra/Lie/InnerAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/InnerAutomorphism.lean
@@ -155,6 +155,49 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 
 variable {A : Type*} [Ring A] [Algebra ℚ A]
 
+/-- **The nilpotent exponential commutes with passage to the opposite ring.** Taking `exp` in
+`Aᵐᵒᵖ` and reading the result back in `A` gives `exp` in `A`.
+
+Mathlib's `IsNilpotent.exp` API carries `map_exp` for ring homomorphisms, but `MulOpposite.op` is
+an anti-homomorphism, so that lemma does not apply. -/
+private theorem unop_exp_op {x : A} (hx : IsNilpotent x) :
+    MulOpposite.unop (IsNilpotent.exp (MulOpposite.op x)) = IsNilpotent.exp x := by
+  obtain ⟨k, hk⟩ := hx
+  have hk_op : MulOpposite.op x ^ k = 0 := by
+    rw [← MulOpposite.op_pow, hk, MulOpposite.op_zero]
+  rw [IsNilpotent.exp_eq_sum hk, IsNilpotent.exp_eq_sum hk_op]
+  simp
+
+/-- **The exponential of left multiplication is left multiplication by the exponential.** -/
+private theorem exp_mulLeft_apply {x : A} (hx : IsNilpotent x) (a : A) :
+    IsNilpotent.exp (LinearMap.mulLeft ℚ x) a = IsNilpotent.exp x * a := by
+  have hmulLeft : (Algebra.lsmul ℚ ℚ A) x = LinearMap.mulLeft ℚ x := by
+    ext b
+    simp [Algebra.lsmul_apply, LinearMap.mulLeft_apply]
+  rw [← hmulLeft]
+  simpa [Algebra.smul_def] using
+    LinearMap.congr_fun (IsNilpotent.map_exp hx (Algebra.lsmul ℚ ℚ A)).symm a
+
+/-- **The exponential of right multiplication is right multiplication by the exponential.** -/
+private theorem exp_mulRight_apply {x : A} (hx : IsNilpotent x) (a : A) :
+    IsNilpotent.exp (LinearMap.mulRight ℚ x) a = a * IsNilpotent.exp x := by
+  -- Right multiplication on `A` is left multiplication over `Aᵐᵒᵖ`, so this is the mirror of
+  -- `exp_mulLeft_apply` transported by `unop_exp_op`.
+  have hxop : IsNilpotent (MulOpposite.op x) := hx.op
+  have hmulRight : (Algebra.lsmul ℚ ℚ A) (MulOpposite.op x) = LinearMap.mulRight ℚ x := by
+    ext b
+    rw [Algebra.lsmul_apply, op_smul_eq_mul, LinearMap.mulRight_apply]
+  calc
+    IsNilpotent.exp (LinearMap.mulRight ℚ x) a =
+        IsNilpotent.exp ((Algebra.lsmul ℚ ℚ A) (MulOpposite.op x)) a := by rw [hmulRight]
+    _ = (Algebra.lsmul ℚ ℚ A) (IsNilpotent.exp (MulOpposite.op x)) a :=
+      LinearMap.congr_fun (IsNilpotent.map_exp hxop (Algebra.lsmul ℚ ℚ A)).symm a
+    _ = (IsNilpotent.exp (MulOpposite.op x)) • a :=
+      Algebra.lsmul_apply (R := ℚ) (B := ℚ) (M := A) (IsNilpotent.exp (MulOpposite.op x)) a
+    _ = a * MulOpposite.unop (IsNilpotent.exp (MulOpposite.op x)) :=
+      MulOpposite.smul_eq_mul_unop _ _
+    _ = a * IsNilpotent.exp x := by rw [unop_exp_op hx]
+
 /-- In an associative `ℚ`-algebra, the inner automorphism `exp (ad x)` is conjugation by the
 nilpotent exponential `exp x`.
 
@@ -174,43 +217,10 @@ theorem expAd_apply_eq_exp_mul_exp_neg {x y : A} (hx : IsNilpotent x) :
       LinearMap.mulLeft ℚ x - LinearMap.mulRight ℚ x := rfl
   rw [had, sub_eq_add_neg, IsNilpotent.exp_add_of_commute
     ((LinearMap.commute_mulLeft_right x x).neg_right) hleft hright.neg]
-  have hl := IsNilpotent.map_exp hx (Algebra.lsmul ℚ ℚ A)
-  have hxop : IsNilpotent (MulOpposite.op (-x)) := hx.neg.op
-  let rsmul : Aᵐᵒᵖ →ₐ[ℚ] Module.End ℚ A := Algebra.lsmul ℚ ℚ A
-  have hr := IsNilpotent.map_exp hxop rsmul
-  have hmulLeft : (Algebra.lsmul ℚ ℚ A) x = LinearMap.mulLeft ℚ x := by
-    ext a
-    simp [Algebra.lsmul_apply, LinearMap.mulLeft_apply]
-  have hmulRight : rsmul (MulOpposite.op (-x)) = LinearMap.mulRight ℚ (-x) := by
-    ext a
-    rw [Algebra.lsmul_apply, op_smul_eq_mul, LinearMap.mulRight_apply]
-  have hexpOp : MulOpposite.unop (IsNilpotent.exp (MulOpposite.op (-x))) =
-      IsNilpotent.exp (-x) := by
-    obtain ⟨k, hk⟩ := hx.neg
-    have hk_op : MulOpposite.op (-x) ^ k = 0 := by
-      rw [← MulOpposite.op_pow, hk, MulOpposite.op_zero]
-    rw [IsNilpotent.exp_eq_sum hk, IsNilpotent.exp_eq_sum hk_op]
-    simp
-  have hl' (a : A) : IsNilpotent.exp (LinearMap.mulLeft ℚ x) a =
-      IsNilpotent.exp x * a := by
-    rw [← hmulLeft]
-    simpa [Algebra.smul_def] using LinearMap.congr_fun hl.symm a
-  have hr' (a : A) : IsNilpotent.exp (LinearMap.mulRight ℚ (-x)) a =
-      a * IsNilpotent.exp (-x) := by
-    calc
-      IsNilpotent.exp (LinearMap.mulRight ℚ (-x)) a =
-          IsNilpotent.exp (rsmul (MulOpposite.op (-x))) a := by rw [hmulRight]
-      _ = rsmul (IsNilpotent.exp (MulOpposite.op (-x))) a :=
-        LinearMap.congr_fun hr.symm a
-      _ = (IsNilpotent.exp (MulOpposite.op (-x))) • a :=
-        Algebra.lsmul_apply (R := ℚ) (B := ℚ) (M := A) (IsNilpotent.exp (MulOpposite.op (-x))) a
-      _ = a * MulOpposite.unop (IsNilpotent.exp (MulOpposite.op (-x))) :=
-        MulOpposite.smul_eq_mul_unop _ _
-      _ = a * IsNilpotent.exp (-x) := by rw [hexpOp]
   have hnegRight : -(LinearMap.mulRight ℚ x) = LinearMap.mulRight ℚ (-x) := by
     ext a
     simp
-  rw [Module.End.mul_apply, hnegRight, hr', hl']
+  rw [Module.End.mul_apply, hnegRight, exp_mulRight_apply hx.neg, exp_mulLeft_apply hx]
   exact (mul_assoc _ _ _).symm
 
 private theorem exp_mul_exp_mul_exp_neg {x y : A} (hx : IsNilpotent x)

--- a/TauCeti/Algebra/Lie/InnerAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/InnerAutomorphism.lean
@@ -156,12 +156,11 @@ attribute [local instance 100] LieRing.ofAssociativeRing
 variable {A : Type*} [Ring A] [Algebra ℚ A]
 
 /-- **The nilpotent exponential commutes with passage to the opposite ring.** Taking `exp` in
-`Aᵐᵒᵖ` and reading the result back in `A` gives `exp` in `A`.
-
-Mathlib's `IsNilpotent.exp` API carries `map_exp` for ring homomorphisms, but `MulOpposite.op` is
-an anti-homomorphism, so that lemma does not apply. -/
+`Aᵐᵒᵖ` and reading the result back in `A` gives `exp` in `A`. -/
 private theorem unop_exp_op {x : A} (hx : IsNilpotent x) :
     MulOpposite.unop (IsNilpotent.exp (MulOpposite.op x)) = IsNilpotent.exp x := by
+  -- `map_exp` covers ring homomorphisms, but `MulOpposite.op` is an anti-homomorphism, so it does
+  -- not apply here; compare the two truncated sums directly instead.
   obtain ⟨k, hk⟩ := hx
   have hk_op : MulOpposite.op x ^ k = 0 := by
     rw [← MulOpposite.op_pow, hk, MulOpposite.op_zero]


### PR DESCRIPTION
`expAd_apply_eq_exp_mul_exp_neg` ran to a 48-line body, but only the first few lines were about
inner automorphisms. The remaining ~30 transported `IsNilpotent.exp` between `A`, its endomorphism
algebra, and its opposite ring — three statements in their own right.

## The extractions

* **`unop_exp_op`** — the nilpotent exponential commutes with passage to the opposite ring:
  `unop (exp (op x)) = exp x`.
* **`exp_mulLeft_apply`** — the exponential of left multiplication is left multiplication by the
  exponential: `exp (mulLeft ℚ x) a = exp x * a`.
* **`exp_mulRight_apply`** — the right-handed mirror, `exp (mulRight ℚ x) a = a * exp x`. This is
  where `unop_exp_op` earns its keep: right multiplication on `A` is left multiplication over
  `Aᵐᵒᵖ`, so the proof crosses to the opposite ring and must come back.

## Checked against Mathlib first

`Mathlib/RingTheory/Nilpotent/Exp.lean` carries `exp_eq_sum`, `exp_add_of_commute`, `map_exp`,
`exp_smul`, `commute_exp_left_of_commute` and friends — but grepping it for `MulOpposite`, `unop`,
`mulLeft` and `mulRight` returns **nothing**. So none of the three is a composition of located
lemmas.

`unop_exp_op` is the interesting case: one might expect `map_exp` to cover it, but `map_exp` is
stated for `RingHomClass`, and `MulOpposite.op` is an *anti*-homomorphism. The fact therefore has
to be proved from `exp_eq_sum` on both sides.

## Minimal hypotheses

Each helper is stated for an arbitrary nilpotent element, not for the `x` and `-x` this caller
happens to want — the caller passes `hx` and `hx.neg`. That was deliberate: re-deriving the
hypotheses at extraction time, rather than threading through what was in scope, is what keeps them
from being specialisations of one call site.

## Result

| | before | after |
|---|---|---|
| `expAd_apply_eq_exp_mul_exp_neg` | 48 | **15** |
| `unop_exp_op` | — | 5 |
| `exp_mulLeft_apply` | — | 6 |
| `exp_mulRight_apply` | — | 16 |

No statement of any existing declaration changed; the three helpers are `private`.

Gates run on `536b9812`: `lake build` (8441 jobs), `lake exe axioms` (57297 declarations),
`lake exe module-system` (2675 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`, 64 grandfathered;
docstring scan 4500/4500).

Roadmap: ReductiveGroups
