### PR TITLE
feat: count the dimensions in the root-space decomposition

### DIFF
--- a/TauCeti/Algebra/Lie/Submodule/Finrank.lean
+++ b/TauCeti/Algebra/Lie/Submodule/Finrank.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Submodule
+public import Mathlib.LinearAlgebra.Dimension.Finrank
+
+/-!
+# The dimension of a Lie submodule
+
+A Lie submodule and its carrier submodule have the same underlying type, so they have the same
+dimension. This file states that definitional equality once, as the bridge that dimension counts
+over Lie submodules pass through: the linear-algebra lemmas about dimensions of direct sums are
+stated for `Submodule`, while the Lie-theoretic dimension lemmas are stated for `LieSubmodule`.
+
+## Main results
+
+* `TauCeti.finrank_toSubmodule`: a Lie submodule has the dimension of its carrier submodule.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+
+variable {R L M : Type*} [CommRing R] [LieRing L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M]
+
+/-- The type underlying a Lie submodule is the type underlying its carrier submodule, so the two
+have the same dimension. -/
+theorem finrank_toSubmodule (N : LieSubmodule R L M) :
+    finrank R N.toSubmodule = finrank R N :=
+  rfl
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Submodule/Finrank.lean
+++ b/TauCeti/Algebra/Lie/Submodule/Finrank.lean
@@ -12,13 +12,16 @@ public import Mathlib.LinearAlgebra.Dimension.Finrank
 # The dimension of a Lie submodule
 
 A Lie submodule and its carrier submodule have the same underlying type, so they have the same
-dimension. This file states that definitional equality once, as the bridge that dimension counts
-over Lie submodules pass through: the linear-algebra lemmas about dimensions of direct sums are
-stated for `Submodule`, while the Lie-theoretic dimension lemmas are stated for `LieSubmodule`.
+dimension; the same holds for a Lie subalgebra and the Lie submodule it becomes over itself. This
+file states those definitional equalities once, as the bridges that dimension counts over Lie
+submodules pass through: the linear-algebra lemmas about dimensions of direct sums are stated for
+`Submodule`, while the Lie-theoretic dimension lemmas are stated for `LieSubmodule`.
 
 ## Main results
 
 * `TauCeti.finrank_toSubmodule`: a Lie submodule has the dimension of its carrier submodule.
+* `TauCeti.finrank_toLieSubmodule`: a Lie subalgebra has the dimension of the Lie submodule it
+  determines over itself.
 -/
 
 public section
@@ -32,8 +35,18 @@ variable [AddCommGroup M] [Module R M] [LieRingModule L M]
 
 /-- The type underlying a Lie submodule is the type underlying its carrier submodule, so the two
 have the same dimension. -/
+@[simp]
 theorem finrank_toSubmodule (N : LieSubmodule R L M) :
     finrank R N.toSubmodule = finrank R N :=
+  rfl
+
+variable [LieAlgebra R L]
+
+/-- The type underlying a Lie subalgebra is the type underlying the Lie submodule it determines
+over itself, so the two have the same dimension. -/
+@[simp]
+theorem finrank_toLieSubmodule (K : LieSubalgebra R L) :
+    finrank R K.toLieSubmodule = finrank R K :=
   rfl
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
+++ b/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
@@ -90,12 +90,13 @@ theorem nonempty_weight [IsTriangularizable K L M] [Nontrivial M] : Nonempty (We
   by_contra! contra
   simpa only [iSup_of_empty, bot_ne_top] using iSup_genWeightSpace_eq_top' K L M
 
-open scoped Classical in
+/-! ### The generalized weight-space decomposition -/
+
 /-- **The generalized weight-space decomposition.** A finite-dimensional triangularizable module is
 the internal direct sum of its generalized weight spaces, indexed by all of its weights. This is
 Mathlib's `LieModule.iSupIndep_genWeightSpace'` and `LieModule.iSup_genWeightSpace_eq_top'`
 packaged as a `DirectSum.IsInternal`, which is the form the dimension counts consume. -/
-theorem isInternal_genWeightSpace [IsTriangularizable K L M] :
+theorem isInternal_genWeightSpace [IsTriangularizable K L M] [DecidableEq (Weight K L M)] :
     DirectSum.IsInternal fun χ : Weight K L M ↦ (genWeightSpace M (χ : L → K)).toSubmodule := by
   refine DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top ?_ ?_
   · rw [LieSubmodule.iSupIndep_toSubmodule]

--- a/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
+++ b/TauCeti/Algebra/Lie/Weights/Diagonalizable.lean
@@ -43,6 +43,9 @@ to honest.
 ## Main results
 
 * `TauCeti.nonempty_weight`: a nonzero finite-dimensional triangularizable module has a weight.
+* `TauCeti.isInternal_genWeightSpace`: a finite-dimensional triangularizable module is the internal
+  direct sum of its *generalized* weight spaces. This needs no diagonalizability and is the form
+  the dimension counts consume; the honest-weight-space refinement is below.
 * `TauCeti.isSemisimple_toEnd_coroot`: a coroot acts semisimply on a finite-dimensional module.
 * `TauCeti.isSemisimple_toEnd_cartan`: **every element of the Cartan subalgebra acts semisimply.**
 * `TauCeti.genWeightSpace_eq_weightSpace`: **the generalized weight spaces are honest weight
@@ -86,6 +89,19 @@ Mathlib performs this step inside the proof of
 theorem nonempty_weight [IsTriangularizable K L M] [Nontrivial M] : Nonempty (Weight K L M) := by
   by_contra! contra
   simpa only [iSup_of_empty, bot_ne_top] using iSup_genWeightSpace_eq_top' K L M
+
+open scoped Classical in
+/-- **The generalized weight-space decomposition.** A finite-dimensional triangularizable module is
+the internal direct sum of its generalized weight spaces, indexed by all of its weights. This is
+Mathlib's `LieModule.iSupIndep_genWeightSpace'` and `LieModule.iSup_genWeightSpace_eq_top'`
+packaged as a `DirectSum.IsInternal`, which is the form the dimension counts consume. -/
+theorem isInternal_genWeightSpace [IsTriangularizable K L M] :
+    DirectSum.IsInternal fun χ : Weight K L M ↦ (genWeightSpace M (χ : L → K)).toSubmodule := by
+  refine DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top ?_ ?_
+  · rw [LieSubmodule.iSupIndep_toSubmodule]
+    exact iSupIndep_genWeightSpace' K L M
+  · rw [← LieSubmodule.iSup_toSubmodule, iSup_genWeightSpace_eq_top' K L M]
+    simp
 
 end Triangularizable
 
@@ -188,10 +204,6 @@ Killing-semisimple Lie algebra is the internal direct sum of the simultaneous ei
 Cartan subalgebra, so `χ ↦ finrank (weightSpace M χ)` counts honest multiplicities. -/
 theorem isInternal_weightSpace :
     DirectSum.IsInternal fun χ : Weight K H M ↦ (weightSpace M (χ : H → K)).toSubmodule := by
-  refine DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top ?_ ?_
-  · rw [LieSubmodule.iSupIndep_toSubmodule]
-    simpa only [genWeightSpace_eq_weightSpace] using iSupIndep_genWeightSpace' K H M
-  · rw [← LieSubmodule.iSup_toSubmodule, iSup_weightSpace_eq_top K H M]
-    simp
+  simpa only [genWeightSpace_eq_weightSpace] using isInternal_genWeightSpace K H M
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/Weights/Dimension.lean
+++ b/TauCeti/Algebra/Lie/Weights/Dimension.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Weights.RootSystem
+public import Mathlib.LinearAlgebra.RootSystem.BaseExists
+public import TauCeti.LinearAlgebra.Dimension.DirectSum
+public import TauCeti.LinearAlgebra.RootSystem.Positive
+
+public section
+
+/-!
+# The dimension count of the root-space decomposition
+
+Let `L` be a finite-dimensional Lie algebra with non-degenerate Killing form over a field of
+characteristic zero, and let `H` be a splitting Cartan subalgebra. The root-space decomposition
+writes `L` as the internal direct sum of one root space for each weight of `H` on `L`; the zero
+weight contributes `H` itself, and every other root space is a line
+(`LieAlgebra.IsKilling.finrank_rootSpace_eq_one`). Counting dimensions there gives
+
+`dim L = dim H + #Δ`,
+
+and, after choosing a base of the root system, the parity identity
+
+`dim L = dim H + 2 · #Δ⁺`,
+
+because root negation exchanges the positive and the negative roots
+(`TauCeti.two_mul_ncard_posRoots`). Both identities are stated additively, with no truncated
+subtraction; the subtracted and added forms `dim L - dim H = 2 · #Δ⁺` and
+`dim L + dim H = 2 · (dim H + #Δ⁺)` are then recorded separately, so that a consumer forming the
+exponents `(dim L ± dim H) / 2` is dividing exactly.
+
+The `dim H` summand comes from the zero root space, which for a Cartan subalgebra is `H` itself
+(`LieAlgebra.zeroRootSubalgebra_eq_of_is_cartan`). `TauCeti.finrank_rootSpace_zero` records this at
+the level of dimensions, covering also the degenerate case `H = ⊥`, where the zero functional is
+not a weight at all and both sides vanish; that is why the sum below is split over `H.root` and its
+complement rather than by removing a named zero weight, which need not exist.
+
+## Main results
+
+* `TauCeti.isInternal_rootSpace`: `L` is the internal direct sum of the root spaces of `H`, indexed
+  by the weights of `H` on `L`.
+* `TauCeti.finrank_rootSpace_zero`: the zero root space has the dimension of `H`.
+* `TauCeti.finrank_eq_finrank_cartan_add_card_root`: **`dim L = dim H + #Δ`**, whence
+  `TauCeti.finrank_cartan_le`.
+* `TauCeti.card_root_eq_two_mul_ncard_posRoots`: `#Δ = 2 · #Δ⁺`, and `TauCeti.even_card_root` the
+  parity of `#Δ` it gives.
+* `TauCeti.finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots` and
+  `TauCeti.finrank_eq_finrank_cartan_add_two_mul_card_isPos`: **`dim L = dim H + 2 · #Δ⁺`**, with
+  the positive roots counted as a set and as a `Finset`.
+* `TauCeti.finrank_sub_finrank_cartan` and `TauCeti.finrank_add_finrank_cartan`: the two
+  combinations `dim L ∓ dim H` are twice something, so halving them is exact.
+
+## References
+
+This is the numerical shadow of the root-space decomposition of Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, *"`L = H ⊕ ⨁_{α ∈ roots} Lα` with
+`finrank_rootSpace_eq_one` making each `Lα` a line"*. It is also the parity half of the bookkeeping
+pin `finrank_eq_rank_add_two_mul_card_isPos` of Layer 9 of
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`, *"the parity identity
+`d = l + 2 · #Δ⁺`, stated additively so the exponents `(d ± l)/2` below are exact divisions"*. That
+pin states the identity with `LieAlgebra.rank ℂ L` in place of `dim H`; comparing Mathlib's
+`LieAlgebra.rank`, defined through the nilpotency degree of a generic element, with the dimension of
+a Cartan subalgebra is a separate statement and is not proved here.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Springer GTM 9 (1972),
+  §8.1 (the root-space decomposition) and §10.1 (the pairing of positive and negative roots).
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule Module
+
+section RootSpaceDecomposition
+
+variable {K L : Type*} [Field K] [LieRing L] [LieAlgebra K L] [FiniteDimensional K L]
+  (H : LieSubalgebra K L) [H.IsCartanSubalgebra]
+
+omit [FiniteDimensional K L] [H.IsCartanSubalgebra] in
+/-- Reading the dimension of a Lie submodule through its underlying submodule changes nothing.
+This is the bridge between `TauCeti.finrank_eq_sum_finrank_of_isInternal`, which sums over
+submodules, and Mathlib's root-space dimension lemmas, which are stated for the Lie submodule. -/
+private theorem finrank_toSubmodule (N : LieSubmodule K H L) :
+    finrank K N.toSubmodule = finrank K N :=
+  rfl
+
+/-- Membership in the `Finset` of roots of a Cartan subalgebra is nonvanishing of the weight. -/
+theorem mem_root_iff {α : Weight K H L} : α ∈ H.root ↔ α.IsNonZero := by
+  simp [LieSubalgebra.root]
+
+open scoped Classical in
+/-- **The root-space decomposition.** A finite-dimensional Lie algebra that is triangularizable
+over a Cartan subalgebra `H` is the internal direct sum of the root spaces of `H`, indexed by the
+weights of `H` on `L`: the roots, together with the zero weight whose root space is `H` itself. -/
+theorem isInternal_rootSpace [LieModule.IsTriangularizable K H L] :
+    DirectSum.IsInternal fun α : Weight K H L ↦ (rootSpace H (α : H → K)).toSubmodule := by
+  refine DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top ?_ ?_
+  · rw [LieSubmodule.iSupIndep_toSubmodule]
+    exact iSupIndep_genWeightSpace' K H L
+  · rw [← LieSubmodule.iSup_toSubmodule, iSup_genWeightSpace_eq_top' K H L]
+    simp
+
+/-- **The zero root space is the Cartan subalgebra**, at the level of dimensions. When the zero
+functional is not a weight of `H` on `L` both sides vanish, since then `H` itself is trivial. -/
+theorem finrank_rootSpace_zero : finrank K (rootSpace H (0 : H → K)) = finrank K H := by
+  have h : (rootSpace H (0 : H → K)).toSubmodule = H.toSubmodule := by
+    rw [← LieAlgebra.coe_zeroRootSubalgebra K L H, zeroRootSubalgebra_eq_of_is_cartan K L H]
+  exact congrArg (fun N : Submodule K L ↦ finrank K N) h
+
+end RootSpaceDecomposition
+
+section Killing
+
+variable {K L : Type*} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
+  [LieAlgebra.IsKilling K L] [FiniteDimensional K L]
+  (H : LieSubalgebra K L) [H.IsCartanSubalgebra] [LieModule.IsTriangularizable K H L]
+
+/-- The root spaces indexed by the *nonzero* weights are lines, so they contribute `#Δ` in
+total. -/
+private theorem sum_finrank_rootSpace_root :
+    ∑ α ∈ H.root, finrank K (rootSpace H (α : H → K)) = H.root.card := by
+  rw [Finset.sum_congr rfl fun α hα ↦
+    IsKilling.finrank_rootSpace_eq_one α ((mem_root_iff H).mp hα), Finset.sum_const, smul_eq_mul,
+    mul_one]
+
+omit [CharZero K] [LieAlgebra.IsKilling K L] [LieModule.IsTriangularizable K H L] in
+open scoped Classical in
+/-- The root spaces indexed by the weights that are *not* roots contribute `dim H` in total: there
+is at most one such weight, the zero one, and its root space is `H`. -/
+private theorem sum_finrank_rootSpace_compl_root :
+    ∑ α ∈ H.rootᶜ, finrank K (rootSpace H (α : H → K)) = finrank K H := by
+  by_cases h0 : rootSpace H (0 : H → K) = ⊥
+  · have hH : finrank K H = 0 := by
+      rw [← finrank_rootSpace_zero H, ← finrank_toSubmodule, h0, LieSubmodule.bot_toSubmodule]
+      simp
+    have hempty : (H.rootᶜ : Finset (Weight K H L)) = ∅ := by
+      refine Finset.eq_empty_of_forall_notMem fun α hα ↦ Weight.genWeightSpace_ne_bot L α ?_
+      rw [Finset.mem_compl, mem_root_iff, not_not] at hα
+      rw [show (α : H → K) = 0 from hα]
+      exact h0
+    rw [hempty, Finset.sum_empty, hH]
+  · have hsingle : (H.rootᶜ : Finset (Weight K H L)) = {⟨0, h0⟩} := by
+      ext α
+      rw [Finset.mem_compl, mem_root_iff, not_not, Finset.mem_singleton]
+      refine ⟨fun hα ↦ Weight.ext fun x ↦ ?_, ?_⟩
+      · rw [congr_fun (show (α : H → K) = 0 from hα) x]
+        rfl
+      · rintro rfl
+        rfl
+    rw [hsingle, Finset.sum_singleton]
+    exact finrank_rootSpace_zero H
+
+/-- **The dimension count of the root-space decomposition**: the dimension of a Lie algebra with
+non-degenerate Killing form is the dimension of a Cartan subalgebra plus the number of roots. -/
+theorem finrank_eq_finrank_cartan_add_card_root :
+    finrank K L = finrank K H + H.root.card := by
+  classical
+  rw [finrank_eq_sum_finrank_of_isInternal (isInternal_rootSpace H)]
+  simp only [finrank_toSubmodule]
+  rw [← Finset.sum_compl_add_sum H.root fun α : Weight K H L ↦
+      finrank K (rootSpace H (α : H → K)),
+    sum_finrank_rootSpace_compl_root H, sum_finrank_rootSpace_root H]
+
+/-- The dimension of a Cartan subalgebra is at most the dimension of the whole Lie algebra. -/
+theorem finrank_cartan_le : finrank K H ≤ finrank K L :=
+  finrank_eq_finrank_cartan_add_card_root H ▸ Nat.le_add_right _ _
+
+/-- **The number of roots is twice the number of positive roots** for any base, since root
+negation exchanges the positive and the negative roots. -/
+theorem card_root_eq_two_mul_ncard_posRoots (b : (IsKilling.rootSystem H).Base) :
+    H.root.card = 2 * (posRoots (IsKilling.rootSystem H) b).ncard := by
+  rw [two_mul_ncard_posRoots, Nat.card_eq_fintype_card, Fintype.card_coe]
+
+/-- **The parity identity `d = l + 2 · #Δ⁺`**: the dimension of a Lie algebra with non-degenerate
+Killing form is the dimension of a Cartan subalgebra plus twice the number of positive roots,
+for any base of its root system. -/
+theorem finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots
+    (b : (IsKilling.rootSystem H).Base) :
+    finrank K L = finrank K H + 2 * (posRoots (IsKilling.rootSystem H) b).ncard := by
+  rw [← card_root_eq_two_mul_ncard_posRoots H b]
+  exact finrank_eq_finrank_cartan_add_card_root H
+
+open scoped Classical in
+/-- **The parity identity `d = l + 2 · #Δ⁺`**, with the positive roots counted as a `Finset` of the
+root index type. -/
+theorem finrank_eq_finrank_cartan_add_two_mul_card_isPos
+    (b : (IsKilling.rootSystem H).Base) :
+    finrank K L
+      = finrank K H + 2 * (Finset.univ.filter fun i : H.root ↦ b.IsPos i).card := by
+  rw [finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b,
+    show posRoots (IsKilling.rootSystem H) b
+      = ↑(Finset.univ.filter fun i : H.root ↦ b.IsPos i) from Set.ext fun i ↦ by
+        simp [mem_posRoots],
+    Set.ncard_coe_finset]
+
+/-- The number of roots is even: root negation pairs them up. No base has to be supplied, since
+one always exists (`RootPairing.nonempty_base`). -/
+theorem even_card_root : Even H.root.card :=
+  let b := (IsKilling.rootSystem H).nonempty_base.some
+  ⟨(posRoots (IsKilling.rootSystem H) b).ncard, by
+    rw [card_root_eq_two_mul_ncard_posRoots H b, two_mul]⟩
+
+/-- **`dim L - dim H` is twice the number of positive roots**, so halving it is exact. -/
+theorem finrank_sub_finrank_cartan (b : (IsKilling.rootSystem H).Base) :
+    finrank K L - finrank K H = 2 * (posRoots (IsKilling.rootSystem H) b).ncard := by
+  have h := finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b
+  omega
+
+/-- **`dim L + dim H` is twice `dim H` plus the number of positive roots**, so halving it is
+exact. -/
+theorem finrank_add_finrank_cartan (b : (IsKilling.rootSystem H).Base) :
+    finrank K L + finrank K H
+      = 2 * (finrank K H + (posRoots (IsKilling.rootSystem H) b).ncard) := by
+  have h := finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b
+  omega
+
+end Killing
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Weights/Dimension.lean
+++ b/TauCeti/Algebra/Lie/Weights/Dimension.lean
@@ -31,29 +31,26 @@ and, after choosing a base of the root system, the parity identity
 
 because root negation exchanges the positive and the negative roots
 (`TauCeti.two_mul_ncard_posRoots`). Both identities are stated additively, with no truncated
-subtraction; the subtracted and added forms `dim L - dim H = 2 · #Δ⁺` and
-`dim L + dim H = 2 · (dim H + #Δ⁺)` are then recorded separately, so that a consumer forming the
-exponents `(dim L ± dim H) / 2` is dividing exactly.
+subtraction, so that a consumer forming the exponents `(dim L ± dim H) / 2` reads off an exact
+division.
 
 The `dim H` summand comes from the zero root space, which for a Cartan subalgebra is `H` itself
-(`LieAlgebra.rootSpace_zero_eq`). `TauCeti.finrank_rootSpace_zero` records this at
-the level of dimensions, covering also the degenerate case `H = ⊥`, where the zero functional is
+(`LieAlgebra.rootSpace_zero_eq`). `TauCeti.finrank_rootSpace_zero_eq_finrank_cartan` records this
+at the level of dimensions, covering also the degenerate case `H = ⊥`, where the zero functional is
 not a weight at all and both sides vanish; that is why the sum below is split over `H.root` and its
 complement rather than by removing a named zero weight, which need not exist.
 
 ## Main results
 
 * `TauCeti.isInternal_rootSpace`: `L` is the internal direct sum of the root spaces of `H`, indexed
-  by the weights of `H` on `L`.
-* `TauCeti.finrank_rootSpace_zero`: the zero root space has the dimension of `H`.
+  by the weights of `H` on `L`. Only nilpotency of `H` and triangularizability are needed here.
+* `TauCeti.finrank_rootSpace_zero_eq_finrank_cartan`: the zero root space has the dimension of `H`.
 * `TauCeti.finrank_eq_finrank_cartan_add_card_root`: **`dim L = dim H + #Δ`**.
 * `TauCeti.card_root_eq_two_mul_ncard_posRoots`: `#Δ = 2 · #Δ⁺`, and `TauCeti.even_card_root` the
   parity of `#Δ` it gives.
 * `TauCeti.finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots` and
   `TauCeti.finrank_eq_finrank_cartan_add_two_mul_card_isPos`: **`dim L = dim H + 2 · #Δ⁺`**, with
   the positive roots counted as a set and as a `Finset`.
-* `TauCeti.finrank_sub_finrank_cartan` and `TauCeti.finrank_add_finrank_cartan`: the two
-  combinations `dim L ∓ dim H` are twice something, so halving them is exact.
 
 ## References
 
@@ -80,30 +77,34 @@ open LieAlgebra LieModule Module
 section RootSpaceDecomposition
 
 variable {K L : Type*} [Field K] [LieRing L] [LieAlgebra K L] [FiniteDimensional K L]
-  (H : LieSubalgebra K L) [H.IsCartanSubalgebra]
+  (H : LieSubalgebra K L) [LieRing.IsNilpotent H]
 
-open scoped Classical in
 /-- **The root-space decomposition.** A finite-dimensional Lie algebra that is triangularizable
-over a Cartan subalgebra `H` is the internal direct sum of the root spaces of `H`, indexed by all
-the weights of `H` on `L`. The nonzero weights are the roots; the zero weight, when it is a weight
-at all, contributes `H` itself.
+over a nilpotent subalgebra `H` is the internal direct sum of the root spaces of `H`, indexed by
+all the weights of `H` on `L`. For a Cartan subalgebra the nonzero weights are the roots, and the
+zero weight, when it is a weight at all, contributes `H` itself.
 
 This is `TauCeti.isInternal_genWeightSpace` for the adjoint action of `H` on `L`, a root space
 being by definition the generalized weight space of that action. -/
-theorem isInternal_rootSpace [LieModule.IsTriangularizable K H L] :
+theorem isInternal_rootSpace [LieModule.IsTriangularizable K H L] [DecidableEq (Weight K H L)] :
     DirectSum.IsInternal fun α : Weight K H L ↦ (rootSpace H (α : H → K)).toSubmodule :=
   isInternal_genWeightSpace K H L
+
+end RootSpaceDecomposition
+
+section ZeroRootSpace
+
+variable {R L : Type*} [CommRing R] [LieRing L] [LieAlgebra R L] [IsNoetherian R L]
+  (H : LieSubalgebra R L) [H.IsCartanSubalgebra]
 
 /-- **The zero root space is the Cartan subalgebra**, at the level of dimensions. When the zero
 functional is not a weight of `H` on `L` both sides vanish, since then `H` itself is trivial. -/
 @[simp]
-theorem finrank_rootSpace_zero : finrank K (rootSpace H (0 : H → K)) = finrank K H := by
-  have h : (rootSpace H (0 : H → K)).toSubmodule = H.toSubmodule :=
-    (congrArg LieSubmodule.toSubmodule (LieAlgebra.rootSpace_zero_eq K L H)).trans
-      H.coe_toLieSubmodule
-  exact congrArg (fun N : Submodule K L ↦ finrank K N) h
+theorem finrank_rootSpace_zero_eq_finrank_cartan :
+    finrank R (rootSpace H (0 : H → R)) = finrank R H := by
+  rw [LieAlgebra.rootSpace_zero_eq R L H, finrank_toLieSubmodule]
 
-end RootSpaceDecomposition
+end ZeroRootSpace
 
 section Killing
 
@@ -128,7 +129,8 @@ private theorem sum_finrank_rootSpace_compl_root :
   have hmem : ∀ α : Weight K H L, α ∈ H.rootᶜ ↔ (α : H → K) = 0 := fun α ↦ by simp
   by_cases h0 : rootSpace H (0 : H → K) = ⊥
   · have hH : finrank K H = 0 := by
-      rw [← finrank_rootSpace_zero H, ← finrank_toSubmodule, h0, LieSubmodule.bot_toSubmodule]
+      rw [← finrank_rootSpace_zero_eq_finrank_cartan H, ← finrank_toSubmodule, h0,
+        LieSubmodule.bot_toSubmodule]
       simp
     have hempty : (H.rootᶜ : Finset (Weight K H L)) = ∅ := by
       refine Finset.eq_empty_of_forall_notMem fun α hα ↦ Weight.genWeightSpace_ne_bot L α ?_
@@ -137,17 +139,16 @@ private theorem sum_finrank_rootSpace_compl_root :
     rw [hempty, Finset.sum_empty, hH]
   · have hsingle : (H.rootᶜ : Finset (Weight K H L)) = {⟨0, h0⟩} := by
       ext α
-      rw [hmem α, Finset.mem_singleton]
-      refine ⟨fun hα ↦ Weight.ext fun x ↦ ?_, ?_⟩
-      · rw [congr_fun hα x]
-        rfl
-      · rintro rfl
-        rfl
+      rw [hmem α, Finset.mem_singleton, ← Weight.ext_iff']
+      simp
     rw [hsingle, Finset.sum_singleton]
-    exact finrank_rootSpace_zero H
+    exact finrank_rootSpace_zero_eq_finrank_cartan H
 
 /-- **The dimension count of the root-space decomposition**: the dimension of a Lie algebra with
-non-degenerate Killing form is the dimension of a Cartan subalgebra plus the number of roots. -/
+non-degenerate Killing form is the dimension of a splitting Cartan subalgebra plus the number of
+roots. The Cartan subalgebra has to be splitting — that is, `L` has to be triangularizable over it
+— or there are too few roots: over `ℝ`, the compact form `su(2)` has a non-degenerate Killing form
+and a one-dimensional Cartan subalgebra, but no root at all, and `dim L = 3`. -/
 theorem finrank_eq_finrank_cartan_add_card_root :
     finrank K L = finrank K H + H.root.card := by
   classical
@@ -164,19 +165,18 @@ theorem card_root_eq_two_mul_ncard_posRoots (b : (IsKilling.rootSystem H).Base) 
   rw [two_mul_ncard_posRoots, Nat.card_eq_fintype_card, Fintype.card_coe]
 
 /-- **The parity identity `d = l + 2 · #Δ⁺`**: the dimension of a Lie algebra with non-degenerate
-Killing form is the dimension of a Cartan subalgebra plus twice the number of positive roots,
-for any base of its root system. -/
+Killing form is the dimension of a splitting Cartan subalgebra plus twice the number of positive
+roots, for any base of its root system. -/
 theorem finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots
     (b : (IsKilling.rootSystem H).Base) :
     finrank K L = finrank K H + 2 * (posRoots (IsKilling.rootSystem H) b).ncard := by
   rw [← card_root_eq_two_mul_ncard_posRoots H b]
   exact finrank_eq_finrank_cartan_add_card_root H
 
-open scoped Classical in
 /-- **The parity identity `d = l + 2 · #Δ⁺`**, with the positive roots counted as a `Finset` of the
 root index type. -/
 theorem finrank_eq_finrank_cartan_add_two_mul_card_isPos
-    (b : (IsKilling.rootSystem H).Base) :
+    (b : (IsKilling.rootSystem H).Base) [DecidablePred b.IsPos] :
     finrank K L
       = finrank K H + 2 * (Finset.univ.filter fun i : H.root ↦ b.IsPos i).card := by
   rw [finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b,
@@ -189,20 +189,6 @@ theorem even_card_root : Even H.root.card :=
   let b := (IsKilling.rootSystem H).nonempty_base.some
   ⟨(posRoots (IsKilling.rootSystem H) b).ncard, by
     rw [card_root_eq_two_mul_ncard_posRoots H b, two_mul]⟩
-
-/-- **`dim L - dim H` is twice the number of positive roots**, so halving it is exact. -/
-theorem finrank_sub_finrank_cartan (b : (IsKilling.rootSystem H).Base) :
-    finrank K L - finrank K H = 2 * (posRoots (IsKilling.rootSystem H) b).ncard := by
-  have h := finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b
-  omega
-
-/-- **`dim L + dim H` is twice the sum of `dim H` and the number of positive roots**, so halving
-it is exact. -/
-theorem finrank_add_finrank_cartan (b : (IsKilling.rootSystem H).Base) :
-    finrank K L + finrank K H
-      = 2 * (finrank K H + (posRoots (IsKilling.rootSystem H) b).ncard) := by
-  have h := finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b
-  omega
 
 end Killing
 

--- a/TauCeti/Algebra/Lie/Weights/Dimension.lean
+++ b/TauCeti/Algebra/Lie/Weights/Dimension.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Algebra.Lie.Weights.RootSystem
 public import Mathlib.LinearAlgebra.RootSystem.BaseExists
+public import TauCeti.Algebra.Lie.Submodule.Finrank
+public import TauCeti.Algebra.Lie.Weights.Diagonalizable
 public import TauCeti.LinearAlgebra.Dimension.DirectSum
 public import TauCeti.LinearAlgebra.RootSystem.Positive
 
@@ -34,7 +36,7 @@ subtraction; the subtracted and added forms `dim L - dim H = 2 · #Δ⁺` and
 exponents `(dim L ± dim H) / 2` is dividing exactly.
 
 The `dim H` summand comes from the zero root space, which for a Cartan subalgebra is `H` itself
-(`LieAlgebra.zeroRootSubalgebra_eq_of_is_cartan`). `TauCeti.finrank_rootSpace_zero` records this at
+(`LieAlgebra.rootSpace_zero_eq`). `TauCeti.finrank_rootSpace_zero` records this at
 the level of dimensions, covering also the degenerate case `H = ⊥`, where the zero functional is
 not a weight at all and both sides vanish; that is why the sum below is split over `H.root` and its
 complement rather than by removing a named zero weight, which need not exist.
@@ -44,8 +46,7 @@ complement rather than by removing a named zero weight, which need not exist.
 * `TauCeti.isInternal_rootSpace`: `L` is the internal direct sum of the root spaces of `H`, indexed
   by the weights of `H` on `L`.
 * `TauCeti.finrank_rootSpace_zero`: the zero root space has the dimension of `H`.
-* `TauCeti.finrank_eq_finrank_cartan_add_card_root`: **`dim L = dim H + #Δ`**, whence
-  `TauCeti.finrank_cartan_le`.
+* `TauCeti.finrank_eq_finrank_cartan_add_card_root`: **`dim L = dim H + #Δ`**.
 * `TauCeti.card_root_eq_two_mul_ncard_posRoots`: `#Δ = 2 · #Δ⁺`, and `TauCeti.even_card_root` the
   parity of `#Δ` it gives.
 * `TauCeti.finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots` and
@@ -58,13 +59,15 @@ complement rather than by removing a named zero weight, which need not exist.
 
 This is the numerical shadow of the root-space decomposition of Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, *"`L = H ⊕ ⨁_{α ∈ roots} Lα` with
-`finrank_rootSpace_eq_one` making each `Lα` a line"*. It is also the parity half of the bookkeeping
-pin `finrank_eq_rank_add_two_mul_card_isPos` of Layer 9 of
-`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`, *"the parity identity
-`d = l + 2 · #Δ⁺`, stated additively so the exponents `(d ± l)/2` below are exact divisions"*. That
-pin states the identity with `LieAlgebra.rank ℂ L` in place of `dim H`; comparing Mathlib's
-`LieAlgebra.rank`, defined through the nilpotency degree of a generic element, with the dimension of
-a Cartan subalgebra is a separate statement and is not proved here.
+`finrank_rootSpace_eq_one` making each `Lα` a line"*.
+
+It is a prerequisite for, and **not** an instance of, the bookkeeping pin
+`finrank_eq_rank_add_two_mul_card_isPos` of Layer 9 of
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`: that pin states the parity
+identity with `LieAlgebra.rank ℂ L` where the count below gives `dim H`. Bridging the two is the
+separate Layer 9 target `rank_eq_finrank_cartan`, which compares Mathlib's `LieAlgebra.rank`,
+defined through the nilpotency degree of a generic element, with the dimension of a Cartan
+subalgebra; it is not proved here, and no declaration below claims that pin.
 
 * J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Springer GTM 9 (1972),
   §8.1 (the root-space decomposition) and §10.1 (the pairing of positive and negative roots).
@@ -79,33 +82,25 @@ section RootSpaceDecomposition
 variable {K L : Type*} [Field K] [LieRing L] [LieAlgebra K L] [FiniteDimensional K L]
   (H : LieSubalgebra K L) [H.IsCartanSubalgebra]
 
-omit [FiniteDimensional K L] [H.IsCartanSubalgebra] in
-/-- Reading the dimension of a Lie submodule through its underlying submodule changes nothing.
-This is the bridge between `TauCeti.finrank_eq_sum_finrank_of_isInternal`, which sums over
-submodules, and Mathlib's root-space dimension lemmas, which are stated for the Lie submodule. -/
-private theorem finrank_toSubmodule (N : LieSubmodule K H L) :
-    finrank K N.toSubmodule = finrank K N :=
-  rfl
-
 open scoped Classical in
 /-- **The root-space decomposition.** A finite-dimensional Lie algebra that is triangularizable
 over a Cartan subalgebra `H` is the internal direct sum of the root spaces of `H`, indexed by all
 the weights of `H` on `L`. The nonzero weights are the roots; the zero weight, when it is a weight
-at all, contributes `H` itself. -/
+at all, contributes `H` itself.
+
+This is `TauCeti.isInternal_genWeightSpace` for the adjoint action of `H` on `L`, a root space
+being by definition the generalized weight space of that action. -/
 theorem isInternal_rootSpace [LieModule.IsTriangularizable K H L] :
-    DirectSum.IsInternal fun α : Weight K H L ↦ (rootSpace H (α : H → K)).toSubmodule := by
-  refine DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top ?_ ?_
-  · rw [LieSubmodule.iSupIndep_toSubmodule]
-    exact iSupIndep_genWeightSpace' K H L
-  · rw [← LieSubmodule.iSup_toSubmodule, iSup_genWeightSpace_eq_top' K H L]
-    simp
+    DirectSum.IsInternal fun α : Weight K H L ↦ (rootSpace H (α : H → K)).toSubmodule :=
+  isInternal_genWeightSpace K H L
 
 /-- **The zero root space is the Cartan subalgebra**, at the level of dimensions. When the zero
 functional is not a weight of `H` on `L` both sides vanish, since then `H` itself is trivial. -/
 @[simp]
 theorem finrank_rootSpace_zero : finrank K (rootSpace H (0 : H → K)) = finrank K H := by
-  have h : (rootSpace H (0 : H → K)).toSubmodule = H.toSubmodule := by
-    rw [← LieAlgebra.coe_zeroRootSubalgebra K L H, zeroRootSubalgebra_eq_of_is_cartan K L H]
+  have h : (rootSpace H (0 : H → K)).toSubmodule = H.toSubmodule :=
+    (congrArg LieSubmodule.toSubmodule (LieAlgebra.rootSpace_zero_eq K L H)).trans
+      H.coe_toLieSubmodule
   exact congrArg (fun N : Submodule K L ↦ finrank K N) h
 
 end RootSpaceDecomposition
@@ -162,10 +157,6 @@ theorem finrank_eq_finrank_cartan_add_card_root :
       finrank K (rootSpace H (α : H → K)),
     sum_finrank_rootSpace_compl_root H, sum_finrank_rootSpace_root H]
 
-/-- The dimension of a Cartan subalgebra is at most the dimension of the whole Lie algebra. -/
-theorem finrank_cartan_le : finrank K H ≤ finrank K L :=
-  finrank_eq_finrank_cartan_add_card_root H ▸ Nat.le_add_right _ _
-
 /-- **The number of roots is twice the number of positive roots** for any base, since root
 negation exchanges the positive and the negative roots. -/
 theorem card_root_eq_two_mul_ncard_posRoots (b : (IsKilling.rootSystem H).Base) :
@@ -188,10 +179,9 @@ theorem finrank_eq_finrank_cartan_add_two_mul_card_isPos
     (b : (IsKilling.rootSystem H).Base) :
     finrank K L
       = finrank K H + 2 * (Finset.univ.filter fun i : H.root ↦ b.IsPos i).card := by
-  have hpos : posRoots (IsKilling.rootSystem H) b
-      = ↑(Finset.univ.filter fun i : H.root ↦ b.IsPos i) :=
-    Set.ext fun i ↦ by simp [mem_posRoots]
-  rw [finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b, hpos, Set.ncard_coe_finset]
+  rw [finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b,
+    ← card_posRootsFinset (IsKilling.rootSystem H) b,
+    posRootsFinset_eq_filter (IsKilling.rootSystem H) b]
 
 /-- The number of roots is even: root negation pairs them up. No base has to be supplied, since
 one always exists (`RootPairing.nonempty_base`). -/

--- a/TauCeti/Algebra/Lie/Weights/Dimension.lean
+++ b/TauCeti/Algebra/Lie/Weights/Dimension.lean
@@ -87,14 +87,11 @@ private theorem finrank_toSubmodule (N : LieSubmodule K H L) :
     finrank K N.toSubmodule = finrank K N :=
   rfl
 
-/-- Membership in the `Finset` of roots of a Cartan subalgebra is nonvanishing of the weight. -/
-theorem mem_root_iff {α : Weight K H L} : α ∈ H.root ↔ α.IsNonZero := by
-  simp [LieSubalgebra.root]
-
 open scoped Classical in
 /-- **The root-space decomposition.** A finite-dimensional Lie algebra that is triangularizable
-over a Cartan subalgebra `H` is the internal direct sum of the root spaces of `H`, indexed by the
-weights of `H` on `L`: the roots, together with the zero weight whose root space is `H` itself. -/
+over a Cartan subalgebra `H` is the internal direct sum of the root spaces of `H`, indexed by all
+the weights of `H` on `L`. The nonzero weights are the roots; the zero weight, when it is a weight
+at all, contributes `H` itself. -/
 theorem isInternal_rootSpace [LieModule.IsTriangularizable K H L] :
     DirectSum.IsInternal fun α : Weight K H L ↦ (rootSpace H (α : H → K)).toSubmodule := by
   refine DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top ?_ ?_
@@ -105,6 +102,7 @@ theorem isInternal_rootSpace [LieModule.IsTriangularizable K H L] :
 
 /-- **The zero root space is the Cartan subalgebra**, at the level of dimensions. When the zero
 functional is not a weight of `H` on `L` both sides vanish, since then `H` itself is trivial. -/
+@[simp]
 theorem finrank_rootSpace_zero : finrank K (rootSpace H (0 : H → K)) = finrank K H := by
   have h : (rootSpace H (0 : H → K)).toSubmodule = H.toSubmodule := by
     rw [← LieAlgebra.coe_zeroRootSubalgebra K L H, zeroRootSubalgebra_eq_of_is_cartan K L H]
@@ -123,8 +121,8 @@ total. -/
 private theorem sum_finrank_rootSpace_root :
     ∑ α ∈ H.root, finrank K (rootSpace H (α : H → K)) = H.root.card := by
   rw [Finset.sum_congr rfl fun α hα ↦
-    IsKilling.finrank_rootSpace_eq_one α ((mem_root_iff H).mp hα), Finset.sum_const, smul_eq_mul,
-    mul_one]
+    IsKilling.finrank_rootSpace_eq_one α (H.isNonZero_coe_root ⟨α, hα⟩), Finset.sum_const,
+    smul_eq_mul, mul_one]
 
 omit [CharZero K] [LieAlgebra.IsKilling K L] [LieModule.IsTriangularizable K H L] in
 open scoped Classical in
@@ -132,21 +130,21 @@ open scoped Classical in
 is at most one such weight, the zero one, and its root space is `H`. -/
 private theorem sum_finrank_rootSpace_compl_root :
     ∑ α ∈ H.rootᶜ, finrank K (rootSpace H (α : H → K)) = finrank K H := by
+  have hmem : ∀ α : Weight K H L, α ∈ H.rootᶜ ↔ (α : H → K) = 0 := fun α ↦ by simp
   by_cases h0 : rootSpace H (0 : H → K) = ⊥
   · have hH : finrank K H = 0 := by
       rw [← finrank_rootSpace_zero H, ← finrank_toSubmodule, h0, LieSubmodule.bot_toSubmodule]
       simp
     have hempty : (H.rootᶜ : Finset (Weight K H L)) = ∅ := by
       refine Finset.eq_empty_of_forall_notMem fun α hα ↦ Weight.genWeightSpace_ne_bot L α ?_
-      rw [Finset.mem_compl, mem_root_iff, not_not] at hα
-      rw [show (α : H → K) = 0 from hα]
+      rw [(hmem α).mp hα]
       exact h0
     rw [hempty, Finset.sum_empty, hH]
   · have hsingle : (H.rootᶜ : Finset (Weight K H L)) = {⟨0, h0⟩} := by
       ext α
-      rw [Finset.mem_compl, mem_root_iff, not_not, Finset.mem_singleton]
+      rw [hmem α, Finset.mem_singleton]
       refine ⟨fun hα ↦ Weight.ext fun x ↦ ?_, ?_⟩
-      · rw [congr_fun (show (α : H → K) = 0 from hα) x]
+      · rw [congr_fun hα x]
         rfl
       · rintro rfl
         rfl
@@ -190,11 +188,10 @@ theorem finrank_eq_finrank_cartan_add_two_mul_card_isPos
     (b : (IsKilling.rootSystem H).Base) :
     finrank K L
       = finrank K H + 2 * (Finset.univ.filter fun i : H.root ↦ b.IsPos i).card := by
-  rw [finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b,
-    show posRoots (IsKilling.rootSystem H) b
-      = ↑(Finset.univ.filter fun i : H.root ↦ b.IsPos i) from Set.ext fun i ↦ by
-        simp [mem_posRoots],
-    Set.ncard_coe_finset]
+  have hpos : posRoots (IsKilling.rootSystem H) b
+      = ↑(Finset.univ.filter fun i : H.root ↦ b.IsPos i) :=
+    Set.ext fun i ↦ by simp [mem_posRoots]
+  rw [finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b, hpos, Set.ncard_coe_finset]
 
 /-- The number of roots is even: root negation pairs them up. No base has to be supplied, since
 one always exists (`RootPairing.nonempty_base`). -/
@@ -209,8 +206,8 @@ theorem finrank_sub_finrank_cartan (b : (IsKilling.rootSystem H).Base) :
   have h := finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots H b
   omega
 
-/-- **`dim L + dim H` is twice `dim H` plus the number of positive roots**, so halving it is
-exact. -/
+/-- **`dim L + dim H` is twice the sum of `dim H` and the number of positive roots**, so halving
+it is exact. -/
 theorem finrank_add_finrank_cartan (b : (IsKilling.rootSystem H).Base) :
     finrank K L + finrank K H
       = 2 * (finrank K H + (posRoots (IsKilling.rootSystem H) b).ncard) := by

--- a/TauCeti/Algebra/Lie/Weights/WeylInvariance.lean
+++ b/TauCeti/Algebra/Lie/Weights/WeylInvariance.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 public import Mathlib.Algebra.Lie.Weights.Chain
 public import TauCeti.Algebra.Lie.Sl2.WeightMultiplicity
+public import TauCeti.Algebra.Lie.Submodule.Finrank
 public import TauCeti.Algebra.Lie.Weights.Diagonalizable
 public import TauCeti.Algebra.Lie.Weights.Integrality
 public import TauCeti.Algebra.Lie.Weights.Reflection
@@ -86,15 +87,6 @@ variable {K : Type u} {L : Type v} [Field K] [CharZero K] [IsAlgClosed K]
   {H : LieSubalgebra K L} [H.IsCartanSubalgebra]
   {M : Type w} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
   [FiniteDimensional K M]
-
-omit [CharZero K] [IsAlgClosed K] [IsKilling K L] [FiniteDimensional K L] [H.IsCartanSubalgebra]
-  [LieModule K L M] [FiniteDimensional K M] in
-/-- The type underlying a Lie submodule is the type underlying its carrier submodule, so the two
-have the same dimension. This states once the definitional equality that the dimension counts
-below pass through. -/
-private theorem finrank_toSubmodule (N : LieSubmodule K H M) :
-    finrank K N.toSubmodule = finrank K N :=
-  rfl
 
 omit [CharZero K] [IsAlgClosed K] [IsKilling K L] [FiniteDimensional K L]
   [H.IsCartanSubalgebra] in

--- a/TauCeti/LinearAlgebra/RootSystem/Positive.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Positive.lean
@@ -36,7 +36,9 @@ positive root is a nonnegative integer combination of the simple coroots.
 
 * `TauCeti.image_reflectionPerm_self_posRoots` says root negation exchanges the two sets.
 * `TauCeti.ncard_posRoots_eq_natCard_div_two` says that, for a finite root index type, exactly
-  half of the roots are positive.
+  half of the roots are positive, and `TauCeti.posRootsFinset_eq_filter`,
+  `TauCeti.card_posRootsFinset` read `TauCeti.posRootsFinset` as the filter of the positivity
+  predicate and its cardinality as the cardinality of `TauCeti.posRoots`.
 * `TauCeti.add_mem_posRoots` and `TauCeti.add_mem_negRoots` say each of the two sets is closed
   under those sums of its members that are again roots, and
   `TauCeti.reflectionPerm_self_notMem_posRoots`, `TauCeti.reflectionPerm_self_notMem_negRoots` say
@@ -162,6 +164,17 @@ lemma mem_posRootsFinset [Finite ι] (i : ι) : i ∈ posRootsFinset P b ↔ i �
 @[simp]
 lemma mem_negRootsFinset [Finite ι] (i : ι) : i ∈ negRootsFinset P b ↔ i ∈ negRoots P b :=
   (negRoots_finite P b).mem_toFinset
+
+/-- The finset of positive roots is the filter of the positivity predicate, which is the shape a
+consumer that counts positive roots by `Finset.filter` meets them in. -/
+lemma posRootsFinset_eq_filter [Fintype ι] [DecidablePred b.IsPos] :
+    posRootsFinset P b = Finset.univ.filter fun i ↦ b.IsPos i := by
+  ext i
+  simp
+
+/-- Counting the positive roots as a finset agrees with counting them as a set. -/
+lemma card_posRootsFinset [Finite ι] : (posRootsFinset P b).card = (posRoots P b).ncard :=
+  (Set.ncard_eq_toFinset_card _ (posRoots_finite P b)).symm
 
 /-- Every simple root is positive. -/
 lemma support_subset_posRoots : ↑b.support ⊆ posRoots P b := by


### PR DESCRIPTION
This PR counts the dimensions in the root-space decomposition of a semisimple Lie algebra. For a finite-dimensional `L` with non-degenerate Killing form over a field of characteristic zero and a splitting Cartan subalgebra `H`, it proves `dim L = dim H + #Δ` and, after a base of the root system is chosen, the parity identity `dim L = dim H + 2 · #Δ⁺`.

This is the numerical shadow of the root-space decomposition of Layer 1 of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md` — *"`L = H ⊕ ⨁_{α ∈ roots} Lα` with `finrank_rootSpace_eq_one` making each `Lα` a line"*, which is the target this PR advances. It is a **prerequisite for, and not an instance of**, the bookkeeping pin `finrank_eq_rank_add_two_mul_card_isPos` of Layer 9 of `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`: that pin writes `LieAlgebra.rank ℂ L` where this PR writes `dim H`, and bridging the two is the separate Layer 9 target `rank_eq_finrank_cartan`, comparing Mathlib's `LieAlgebra.rank` — defined through the nilpotency degree of a generic element — with the dimension of a Cartan subalgebra. That target is deliberately **not** proved here, so no declaration in this PR claims the pin; the identity is stated in the Cartan-dimension form that the decomposition actually produces, and the module docstring says so.

The new module is `TauCeti/Algebra/Lie/Weights/Dimension.lean` (195 lines). `TauCeti.isInternal_rootSpace` packages `L` as the internal direct sum of the root spaces of `H`, indexed by the weights of `H` on `L`; it is the adjoint-action case of `TauCeti.isInternal_genWeightSpace`, which this PR states once in `TauCeti/Algebra/Lie/Weights/Diagonalizable.lean` — hypothesised only on triangularizability, with no algebraic closure and no Killing hypothesis — and from which the existing honest-weight-space `TauCeti.isInternal_weightSpace` of that file is now also derived. `TauCeti.finrank_rootSpace_zero_eq_finrank_cartan` identifies the zero root space with `H` at the level of dimensions, through Mathlib's `LieAlgebra.rootSpace_zero_eq` and the new `TauCeti.finrank_toLieSubmodule`. The counting theorem is `TauCeti.finrank_eq_finrank_cartan_add_card_root`, and the two positive-root forms are `TauCeti.finrank_eq_finrank_cartan_add_two_mul_ncard_posRoots` (positive roots as a set) and `TauCeti.finrank_eq_finrank_cartan_add_two_mul_card_isPos` (as the `Finset.univ.filter b.IsPos` the Layer 9 pin's signature uses, reached through the new `TauCeti.posRootsFinset_eq_filter` and `TauCeti.card_posRootsFinset` of `TauCeti/LinearAlgebra/RootSystem/Positive.lean`). Both identities are stated additively, with no truncated subtraction, so a consumer forming the Kostant exponents `2^{(d ∓ l)/2}` gets the exact division by `omega` at the call site; `TauCeti.card_root_eq_two_mul_ncard_posRoots` and `TauCeti.even_card_root` round out the API.

Two pieces of shared infrastructure come with it. `TauCeti/Algebra/Lie/Submodule/Finrank.lean` states once that a Lie submodule has the dimension of its carrier submodule, and that a Lie subalgebra has the dimension of the Lie submodule it determines over itself; it replaces the private copies of that bridge that `TauCeti/Algebra/Lie/Weights/WeylInvariance.lean` and this module each carried. And `TauCeti.isInternal_genWeightSpace`, described above, replaces the two parallel decomposition proofs.

Nothing was vendored. The proof consumes Mathlib's `LieModule.iSupIndep_genWeightSpace'`, `LieModule.iSup_genWeightSpace_eq_top'`, `LieAlgebra.IsKilling.finrank_rootSpace_eq_one`, `LieAlgebra.rootSpace_zero_eq` and `RootPairing.nonempty_base`, together with two existing Tau Ceti results: `TauCeti.finrank_eq_sum_finrank_of_isInternal` for the dimension of an internal direct sum, and `TauCeti.two_mul_ncard_posRoots` for the pairing of positive and negative roots under root negation. The one delicate point is the degenerate case `H = ⊥`, where the zero functional is not a weight at all; that is why the sum is split over `H.root` and its complement instead of removing a named zero weight, and both sides of `TauCeti.finrank_rootSpace_zero` then vanish.

`lake build` (8459 jobs) and `lake exe axioms` are green (`audited 57576 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound]`), and `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` and `scripts/lint-env.sh` report no new violations.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"root-space-decomposition-dimension-count"}-->

🤖 Prepared with Claude Code

