### PR TITLE
feat: the Hecke operator of a double coset at any congruence level

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -37,7 +37,8 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
 * `HeckeCoset.toSet`: the underlying set `H₁gH₂` of a double coset.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
-  in `Γ₁gΓ₂`; finite for a Hecke triple.
+  in `Γ₁gΓ₂`; finite for a Hecke triple. Its mirror `DecompQuotient Γ₂ Γ₁ g⁻¹` indexes the
+  right cosets `Γ₁a`, and is finite too.
 * `HeckeCosetModule.single`: the basis element `b • [D]` of the Hecke coset module, with
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
@@ -61,6 +62,12 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
 
 * `HeckeCoset.eq_iff`: `mk H₁ H₂ g = mk H₁ H₂ h ↔ H₁gH₂ = H₁hH₂`.
 * `HeckeCoset.toSet_injective`: a double coset is determined by its underlying set.
+* `DoubleCoset.doubleCoset_eq_iUnion_rightCosets` and
+  `DoubleCoset.op_mul_out_inv_smul_injective`: Shimura's decomposition `Γ₁gΓ₂ = ⊔ᵥ Γ₁(gτᵥ⁻¹)`
+  into *right* cosets, indexed without repetition by `DecompQuotient Γ₂ Γ₁ g⁻¹` — the mirror of
+  `DoubleCoset.doubleCoset_eq_iUnion_leftCosets` and `mk_out_mul_injective`.
+* `IsHeckeTriple.commensurable_conjAct_inv_left`, and the `Finite` instance beside it: that
+  right-coset index is finite, the mirror of the `Fintype` instance on `DecompQuotient H₁ H₂ g`.
 
 ## References
 
@@ -207,6 +214,41 @@ lemma conj_mem_of_mk_eq {H₁ H₂ : Subgroup G} (g : G) {u₁ u₂ : H₁}
     g⁻¹ * ((u₁ : G)⁻¹ * u₂) * g ∈ H₂ :=
   conj_mem_of_stabilizer g ⟨_, QuotientGroup.eq.mp h⟩
 
+/-- **Shimura's decomposition of a double coset into right cosets.** `Γ₁gΓ₂` is the union of the
+right cosets `Γ₁ · (g τᵥ⁻¹)`, where `τᵥ` runs over representatives of `Γ₂ ⧸ (Γ₂ ∩ g⁻¹Γ₁g)` — the
+mirror of `DoubleCoset.doubleCoset_eq_iUnion_leftCosets`, and of Mathlib's
+`doubleCoset_union_rightCoset`, which is indexed by all of `Γ₂` and so repeats each coset.
+
+The inverse on `τᵥ` is what converts the *left*-coset quotient `Γ₂ ⧸ (Γ₂ ∩ g⁻¹Γ₁g)` into an index
+for the right cosets: `Γ₁ g τ = Γ₁ g τ'` exactly when `τ'τ⁻¹ ∈ Γ₂ ∩ g⁻¹Γ₁g`.
+
+It lives here rather than beside `doubleCoset_eq_iUnion_leftCosets` because it is phrased with
+`DecompQuotient`, which this file defines. -/
+lemma doubleCoset_eq_iUnion_rightCosets (Γ₁ Γ₂ : Subgroup G) (g : G) :
+    doubleCoset g Γ₁ Γ₂ =
+      ⋃ v : DecompQuotient Γ₂ Γ₁ g⁻¹,
+        MulOpposite.op (g * ((v.out : G))⁻¹) • (Γ₁ : Set G) := by
+  rw [← doubleCoset_union_rightCoset]
+  refine le_antisymm (Set.iUnion_subset fun t ↦ ?_) (Set.iUnion_subset fun v ↦ ?_)
+  · -- `t : Γ₂` lands in the coset of the class of `t⁻¹`
+    refine Set.subset_iUnion_of_subset (QuotientGroup.mk t⁻¹) (le_of_eq ?_)
+    refine (rightCoset_eq_iff Γ₁).mpr ?_
+    have h := conj_mem_of_mk_eq (H₁ := Γ₂) (H₂ := Γ₁) g⁻¹ (Quotient.out_eq (QuotientGroup.mk t⁻¹))
+    simpa [mul_assoc] using h
+  · exact Set.subset_iUnion_of_subset ((v.out)⁻¹) (le_of_eq (by simp))
+
+/-- The right cosets of `doubleCoset_eq_iUnion_rightCosets` are pairwise distinct, so that union
+is a partition and the sum of a `Γ₁`-invariant function over it counts each coset once. -/
+lemma op_mul_out_inv_smul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
+    Function.Injective fun v : DecompQuotient Γ₂ Γ₁ g⁻¹ ↦
+      MulOpposite.op (g * ((v.out : G))⁻¹) • (Γ₁ : Set G) := by
+  intro v w hvw
+  have h := (rightCoset_eq_iff Γ₁).mp hvw.symm
+  rw [← QuotientGroup.out_eq' v, ← QuotientGroup.out_eq' w, QuotientGroup.eq,
+    Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv,
+    ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv]
+  simpa [mul_assoc] using h
+
 end DoubleCoset
 
 namespace IsHeckeTriple
@@ -222,6 +264,30 @@ commensurates `H₂`, which is commensurable with `H₁`. -/
 noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]
     (g : Δ) : Fintype (DecompQuotient H₁ H₂ (g : G)) :=
   Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
+
+/-- Conjugating the *left* subgroup by the inverse of an element of `Δ` gives a subgroup
+commensurable with the right one. This is `commensurable_conjAct_right` on the other flank:
+the commensurator is a subgroup, so it contains `g⁻¹` along with `g`.
+
+It is what makes `DecompQuotient H₂ H₁ g⁻¹` — the index of Shimura's decomposition of `H₁gH₂`
+into *right* cosets `H₁a` — finite. -/
+theorem commensurable_conjAct_inv_left {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
+    [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
+    Commensurable (ConjAct.toConjAct (g : G)⁻¹ • H₁) H₂ := by
+  have hg : Commensurable (ConjAct.toConjAct ((g : G)⁻¹) • H₁) H₁ :=
+    inv_mem (mem_commensurator_left H₂ g)
+  exact hg.trans (commensurable (Δ := Δ))
+
+/-- For a Hecke triple, the *right*-coset decomposition quotient of any `g : Δ` is finite.
+
+This is the companion of the instance above on the other flank, and it is the finiteness the
+slash sum over Shimura's decomposition `H₁gH₂ = ⊔ᵥ H₁aᵥ` needs. `Finite` rather than `Fintype`:
+no enumeration is chosen here, and a second `Fintype` on a quotient of the same shape would
+compete with the one above. -/
+instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTriple Δ H₁ H₂] (g : Δ) :
+    Finite (DecompQuotient H₂ H₁ (g : G)⁻¹) :=
+  @Finite.of_fintype _
+    (Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_inv_left g).1)
 
 end IsHeckeTriple
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
@@ -44,7 +44,8 @@ Chris Birkbeck).
 * `HeckeRing.GL2.Gamma1Image_le_Delta0`: `Γ₁(N) ≤ Δ₀(N)`, the special case of the Γ₀ result.
 * `HeckeRing.GL2.Delta0_le_commensurator_Gamma1Image`: `Δ₀(N)` lies in the commensurator
   of `Γ₁(N)`.
-* the `IsHeckeTriple (Delta0 N) (Gamma1Image N) (Gamma1Image N)` instance.
+* the `IsHeckeTriple (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))`
+  instance.
 
 ## References
 
@@ -97,8 +98,13 @@ lemma Delta0_le_commensurator_Gamma1Image :
   exact (Delta0_le_posDetInt N).trans (posDetInt_le_commensurator 2)
 
 /-- **The Hecke triple of `Γ₁(N)`**: `Γ₁(N) ≤ Δ₀(N) ≤ commensurator(Γ₁(N))` inside
-`GL₂(ℚ)` — the setting of the Hecke operators on modular forms of level `N`. -/
-instance : IsHeckeTriple (Delta0 N) (Gamma1Image N) (Gamma1Image N) :=
+`GL₂(ℚ)` — the setting of the Hecke operators on modular forms of level `N`.
+
+Stated at the unfolded `(Gamma1 N).map (mapGL ℚ)` rather than at `Gamma1Image N`: instance search
+unfolds neither, and the unfolded spelling is the one consumers meet, since the level of a
+modular form of level `N` is written `(Gamma1 N).map (mapGL ℝ)` and its rational companion
+arrives in the same shape. -/
+instance : IsHeckeTriple (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) :=
   IsHeckeTriple.of_diagonal (Gamma1Image_le_Delta0 N) (Delta0_le_commensurator_Gamma1Image N)
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
@@ -42,6 +42,8 @@ Chris Birkbeck).
 
 * `HeckeRing.GL2.Gamma1Image_le_Gamma0Image`: `Γ₁(N) ≤ Γ₀(N)` in `GL₂(ℚ)`.
 * `HeckeRing.GL2.Gamma1Image_le_Delta0`: `Γ₁(N) ≤ Δ₀(N)`, the special case of the Γ₀ result.
+* `HeckeRing.GL2.out_mem_glpos_of_delta0`: the chosen representative of a double coset of
+  `Δ₀(N)` has positive determinant.
 * `HeckeRing.GL2.Delta0_le_commensurator_Gamma1Image`: `Δ₀(N)` lies in the commensurator
   of `Γ₁(N)`.
 * the `IsHeckeTriple (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))`
@@ -83,6 +85,15 @@ lemma Gamma1Image_le_Gamma0Image : Gamma1Image N ≤ Gamma0Image N := by
 `Γ₁(N) ≤ Γ₀(N)`. -/
 lemma Gamma1Image_le_Delta0 : (Gamma1Image N).toSubmonoid ≤ Delta0 N :=
   fun _ hg ↦ Gamma0Image_le_Delta0 N (Gamma1Image_le_Gamma0Image N hg)
+
+/-- The chosen representative of a double coset of `Δ₀(N)` has positive determinant, whatever the
+two flanking subgroups: `Δ₀(N)` consists of integral matrices of positive determinant. This is the
+positivity hypothesis the Hecke operators on modular forms of level `N` carry, discharged once for
+this semigroup. -/
+lemma out_mem_glpos_of_delta0 {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
+    (D : HeckeCoset (Delta0 N) Γ₁ Γ₂) :
+    (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ :=
+  posDetInt_le_glpos 2 (Delta0_le_posDetInt N D.out.2)
 
 variable [NeZero N]
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
@@ -41,7 +41,8 @@ different representative of the same right coset is `γ₁ · (δ τᵥ⁻¹)` f
 `f ∣[k] (γ₁ x) = (f ∣[k] γ₁) ∣[k] x`, so the summand moves unless the slash by `γ₁` is trivial on
 `f`. Even the identity double coset can therefore send a raw `f` to `f ∣[k] γ₁` rather than to `f`.
 What repairs it is slash-invariance of `f` under `Γ₁`, and that is `HeckeSlash/Reindex.lean`;
-`HeckeSlash/Invariance.lean` then turns it into invariance of the sum under `Γ₂`.
+`HeckeSlash/Invariance.lean` then turns it into invariance of the sum under `Γ₂`, and
+`HeckeSlash/Independence.lean` into independence of the sum from every one of those choices.
 
 ⚠ Conventions: `gH` is a left coset and `Hg` a right one, as in Mathlib and in
 `LeftCosetModule/Basic.lean`. AINTLIB's `HeckeAction.lean` uses the opposite labels for the same
@@ -198,11 +199,13 @@ the representatives of the decomposition of `Γ₁ δ Γ₂` into right cosets `
 normalising factor already built into the slash action, this is Shimura's `f ∣[Γ₁ δ Γ₂]ₖ`
 (§3.4, (3.4.1)).
 
-⚠ This depends on the chosen representatives `D.out` and `v.out`, and on a general
+⚠ The *definition* depends on the chosen representatives `D.out` and `v.out`, and on a general
 `f : ℍ → ℂ` the value changes with them — see the module docstring. Invariance of `f` under
-`Γ₁` is *sufficient* to make it independent of those choices (`slash_rightCosetRep_of_mem`,
-`HeckeSlash/Reindex.lean`); whether it is also necessary is not claimed here, since a particular
-`f` and `D` could be independent by cancellation.
+`Γ₁` is *sufficient* to make it independent of those choices: for such an `f` the sum is the
+sum over any decomposition of `Γ₁ δ Γ₂` into right cosets whatsoever
+(`heckeSlashSum_eq_sum_of_rightCosets`, `HeckeSlash/Independence.lean`), which is what makes the
+operators built from it attached to the double coset. Whether invariance is also *necessary* is
+not claimed here, since a particular `f` and `D` could be independent by cancellation.
 
 ⚠ Choice-independence is not the same as being an action, and this docstring does not claim the
 latter. What right multiplication gives is invariance of the *output* under `Γ₂`, which is the

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Basic.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import TauCeti.NumberTheory.HeckeRing.GLn.TransposeAntiInvolution
+public import TauCeti.NumberTheory.HeckeRing.Basic
 public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 
 /-!
@@ -16,144 +16,97 @@ coset and summing. This file defines that sum. It is unconditionally *additive* 
 `0`; homogeneity — and so `ℂ`-linearity — additionally needs the representatives to have positive
 determinant, because the scalar passes through the slash only on that branch.
 
+## Which cosets the representatives run over
+
+Shimura decomposes `Γ₁ δ Γ₂ = ⊔ᵥ Γ₁ aᵥ` — the group on the **left** — and sets
+`f ∣[Γ₁ δ Γ₂]ₖ = ∑ᵥ f ∣[k] aᵥ` (§3.4, (3.4.1)). That handedness is what a *right* action needs:
+right multiplication by `γ ∈ Γ₂` permutes the right cosets `Γ₁ aᵥ` among themselves, which is the
+proof of his Proposition 3.37, and the invariance that makes the sum independent of the chosen
+representatives is invariance of `f` under `Γ₁`.
+
+Mathlib's `DoubleCoset.DecompQuotient Γ₁ Γ₂ δ` indexes the *left* cosets `σᵢ δ Γ₂` instead. The
+right cosets are indexed by the mirror quotient `DecompQuotient Γ₂ Γ₁ δ⁻¹ = Γ₂ ⧸ (Γ₂ ∩ δ⁻¹Γ₁δ)`:
+`Γ₁ δ τ = Γ₁ δ τ'` exactly when `δ τ' τ⁻¹ δ⁻¹ ∈ Γ₁`, that is when `τ` and `τ'` have the same class
+there. The representative attached to a class `v` is `δ · (τᵥ)⁻¹`, the inverse appearing because
+`Γ₂ ⧸ (Γ₂ ∩ δ⁻¹Γ₁δ)` is a quotient by *left* cosets while `Γ₁ δ τ` is constant along right ones;
+`v ↦ γ⁻¹ • v` is then the permutation right multiplication by `γ` induces. That these
+representatives do run over the right cosets, each exactly once, is
+`DoubleCoset.doubleCoset_eq_iUnion_rightCosets` together with
+`DoubleCoset.op_mul_out_inv_smul_injective` (`HeckeRing/Basic.lean`).
+
 ⚠ **It is not yet an action, and on a general `f : ℍ → ℂ` it is not even well defined.**
-`heckeSlashSum` is a sum over *chosen* representatives — `D.out` for the double coset and
-`i.out` for each of its left cosets — and on an arbitrary function the choice changes the
-answer. A different representative of the same left coset is `σᵢ' δ = σᵢ δ h₂` for some
-`h₂ ∈ Γ₂`, so transposing gives `(σᵢ' δ)ᵀ = h₂ᵀ (σᵢ δ)ᵀ`: the representative is multiplied by
-`h₂ᵀ ∈ Γ₂ᵀ` on the **left**. Since `f ∣[k] (h₂ᵀ X) = (f ∣[k] h₂ᵀ) ∣[k] X`, the summand moves
-unless the slash by `h₂ᵀ` is trivial on `f`. Even the identity double coset can therefore send a
-raw `f` to `f ∣[k] h₂ᵀ` rather than to `f`.
-
-What repairs it is slash-invariance of `f`, and that is the content of Shimura's Proposition
-3.37. ⚠ **Two different groups are involved, and they are easy to conflate.**
-
-* **Choice-independence of the sum** needs `f` invariant under `Γ₂ᵀ`. Replacing `σᵢ` by another
-  representative of its class multiplies `(σᵢ δ)ᵀ` on the *left* by an element of `Γ₂ᵀ`, and
-  `f ∣[k] (hX) = (f ∣[k] h) ∣[k] X`, so the summand is unchanged exactly when `f ∣[k] h = f`
-  there. This is what makes the sum well defined at all.
-* **Invariance of the output** is a `Γ₁ᵀ` statement. Right multiplication by `γ ∈ Γ₁ᵀ` sends
-  `δᵀ σᵢᵀ` to `δᵀ (σᵢᵀ γ)` and so permutes the representatives, leaving the sum fixed.
-
-So in general the sum maps `Γ₂ᵀ`-invariant functions to `Γ₁ᵀ`-invariant ones: a map *between*
-invariance classes, **not** an endomorphism of one. It becomes an endomorphism only when those
-groups agree — see "Which group the representatives are cosets of" below, which is also where
-the level-one pair's two coincidences are recorded. Proposition 3.37 itself, and the descent of
-this sum to a genuine operator on
-`SlashInvariantForm` and `ModularForm`, are deliberately **not** in this file — the reindexing
-argument is substantial and is a different claim. Until then this is an auxiliary sum, named to
-say so, and every consumer must supply the invariance hypothesis itself.
-
-## The transpose, and why it is here
-
-The Hecke ring is built from the decomposition of `HδH` into **left** cosets `σᵢδH`
-(`DoubleCoset.DecompQuotient`, and `LeftCosetModule/Basic.lean` in this repository). But the
-slash action is a *right* action, so invariance of `∑ᵢ f ∣[k] Xᵢ` under `f ↦ f ∣[k] γ` needs
-right multiplication by `γ` to permute the `Xᵢ` up to multiplication by `H` **on the left** —
-that is, the `Xᵢ` must represent **right** cosets `HXᵢ`.
-
-Transposition exchanges the two: if `HδH = ⊔ᵢ (σᵢδ)H` then `HδH = ⊔ᵢ H(δᵀσᵢᵀ)`, because
-transposition is an anti-automorphism preserving `SL₂(ℤ)` and fixing every double coset. So the
-representative used here is `(σᵢδ)ᵀ`, which is `transposeRep`.
-
-## Which group the representatives are cosets of
-
-The display above is the level-one case, where a single `H = SL₂(ℤ)` sits on both sides. In
-general transposition is an *anti*-homomorphism, so it reverses the two flanks:
-`(Γ₁ δ Γ₂)ᵀ = Γ₂ᵀ δᵀ Γ₁ᵀ`, and the left-coset decomposition `Γ₁ δ Γ₂ = ⊔ᵢ (σᵢ δ) Γ₂` transposes
-to `⊔ᵢ Γ₂ᵀ (σᵢ δ)ᵀ`. So `transposeRep` enumerates right cosets of **`Γ₂ᵀ`**, and the invariance
-that makes the sum well defined is invariance under `Γ₂ᵀ`.
-
-⚠ **This is why the level-one pair is special, and why the generality here stops short of a
-level-`N` operator.** Throughout, a *group* is called transpose-stable when transposition maps it
-to itself. `SLnZ 2` is (`transposeGLEquiv_mem_SLnZ`, which is just `det` and integrality
-surviving transposition) and sits on both flanks, giving `Γ₂ᵀ = Γ₁`; transposition moreover fixes
-every double coset `SLnZ 2 · δ · SLnZ 2`. Those are two separate facts, and the sum is Shimura's
-operator for `Γ₁ δ Γ₂` acting on `Γ₁`-invariant functions only because **both** hold — flank
-agreement alone would leave `δᵀ` where `δ` should be. A congruence
-subgroup is **not** transpose-stable: transposition swaps the off-diagonal entries, so
-`!![1, 1; 0, 1] ∈ Γ₁(N)` for every `N` while its transpose lies in `Γ₁(N)` only when `N = 1`,
-and `Γ₁(N)ᵀ = Γ¹(N)`. At such a triple the expression below is still defined — it is a finite sum
-over chosen representatives, nothing more — but the cosets it runs over belong to `Γ₂ᵀ δᵀ Γ₁ᵀ`,
-so it is in no sense an operator on `Γ₁(N)`-invariant forms. Anything
-that wants the latter must first reconcile that orientation — either by carrying the correctly
-transposed source and target subgroups, or by a device that avoids the transpose altogether
-(upper-triangular representatives, as in `HeckeSlash/UpperTri/`).
-
-The transpose is an artefact of which handedness Mathlib's `DecompQuotient` supplies, not of the
-mathematics. Shimura decomposes `Γ₁αΓ₂ = ⊔ᵥ Γ₁aᵥ` — the group on the **left** — so his slash,
-being a right action, permutes those representatives directly and no transpose ever appears.
+`heckeSlashSum` is a sum over *chosen* representatives — `D.out` for the double coset and `v.out`
+for each of its right cosets — and on an arbitrary function the choice changes the answer. A
+different representative of the same right coset is `γ₁ · (δ τᵥ⁻¹)` for some `γ₁ ∈ Γ₁`, and
+`f ∣[k] (γ₁ x) = (f ∣[k] γ₁) ∣[k] x`, so the summand moves unless the slash by `γ₁` is trivial on
+`f`. Even the identity double coset can therefore send a raw `f` to `f ∣[k] γ₁` rather than to `f`.
+What repairs it is slash-invariance of `f` under `Γ₁`, and that is `HeckeSlash/Reindex.lean`;
+`HeckeSlash/Invariance.lean` then turns it into invariance of the sum under `Γ₂`.
 
 ⚠ Conventions: `gH` is a left coset and `Hg` a right one, as in Mathlib and in
-`LeftCosetModule/Basic.lean`. AINTLIB's `HeckeAction.lean` uses the opposite labels for the
-same objects; the mathematics is identical, the words are not.
-
-Transposition is available as the anti-involution of `GLn/TransposeAntiInvolution.lean`, the
-same one that proves the Hecke ring commutative; this file only needs that it preserves
-`posDetInt 2`, and only for the three declarations that mention determinants at all.
+`LeftCosetModule/Basic.lean`. AINTLIB's `HeckeAction.lean` uses the opposite labels for the same
+objects; the mathematics is identical, the words are not.
 
 ## An arbitrary triple, and what each declaration actually needs
 
 The declarations are stated over an arbitrary triple `HeckeCoset Δ Γ₁ Γ₂` rather than the
 level-one pair `(posDetInt 2, SLnZ 2, SLnZ 2)`, and each carries only what it uses. Nothing is
-asked of `Δ` at all beyond containing the chosen `δ`.
+asked of `Δ` at all beyond containing the chosen `δ`. In particular no group here has to be
+stable under transposition, which is what confines the *left*-coset indexing to level one and is
+why this file does not use it: `!![1, 1; 0, 1] ∈ Γ₁(N)` for every `N` while its transpose lies in
+`Γ₁(N)` only when `N = 1`.
 
-* `transposeRep` and its characteristic equation need only the group law.
+* `rightCosetRep` and its characteristic equation need only the group law.
 * The **sum** and its additivity and vanishing on `0` need only that the index type is finite,
-  so they take `[Finite (DecompQuotient Γ₁ Γ₂ δ)]` directly — the proposition, not the
+  so they take `[Finite (DecompQuotient Γ₂ Γ₁ δ⁻¹)]` directly — the proposition, not the
   data-bearing `Fintype`, since no chosen enumeration is used; the `Fintype` that `∑` needs is
   installed once as a local instance. A Hecke triple supplies that finiteness
-  (`HeckeRing/Basic.lean`) and is strictly stronger — it also demands commensurability
-  and that `Δ` commensurate `Γ₂`, none of which the sum uses.
+  (`IsHeckeTriple.commensurable_conjAct_inv_left`, `HeckeRing/Basic.lean`) and is strictly
+  stronger — it also demands commensurability and that `Δ` commensurate `Γ₁`, none of which the
+  sum uses.
 * Positivity of the determinant enters exactly once, in **homogeneity**: on the positive branch
   the slash action's conjugation `σ` is trivial and scalars commute past it
   (`ModularForm.rat_smul_slash_of_det_pos`), whereas over a general `GL(2, ℚ)`-element the twist
-  is complex conjugation and linearity would fail. So `transposeRep_mem_posDetInt`,
-  `det_transposeRep_pos` and `heckeSlashSum_smul` — and only those — mention determinants, and
-  each asks for the weakest form it can. `transposeRep_mem_posDetInt` concludes a `posDetInt`
-  membership and so needs integrality. `det_transposeRep_pos` concludes a statement about
-  determinants alone, so it asks only `Γ₁ ≤ GLPos (Fin 2) ℚ` and `δ ∈ GLPos (Fin 2) ℚ`.
+  is complex conjugation and linearity would fail. So `rightCosetRep_mem_posDetInt`,
+  `det_rightCosetRep_pos` and `heckeSlashSum_smul` — and only those — mention determinants, and
+  each asks for the weakest form it can. `rightCosetRep_mem_posDetInt` concludes a `posDetInt`
+  membership and so needs integrality. `det_rightCosetRep_pos` concludes a statement about
+  determinants alone, so it asks only `Γ₂ ≤ GLPos (Fin 2) ℚ` and `δ ∈ GLPos (Fin 2) ℚ`.
   `heckeSlashSum_smul` asks less still: not a condition on the factors but
-  `∀ i, 0 < det (transposeRep D i)`, since a product can be positive with neither factor positive
-  and a factorwise hypothesis would exclude those cases. `det_transposeRep_pos` is how callers
-  supply it. Neither `Γ₂` nor the rest of `Δ` is constrained anywhere. At the level-one pair these
-  come from
-  `SLnZ_le_posDetInt 2` and `D.out.2` composed with `posDetInt_le_glpos`.
-
-⚠ Positivity being available at level `N` is *not* enough to read the sum there as a Hecke
-operator: what fails at a congruence subgroup is the transpose orientation, not the determinant.
-See "Which group the representatives are cosets of" above.
+  `∀ v, 0 < det (rightCosetRep D v)`, since a product can be positive with neither factor
+  positive and a factorwise hypothesis would exclude those cases. `det_rightCosetRep_pos` is how
+  callers supply it. Neither `Γ₁` nor the rest of `Δ` is constrained anywhere.
 
 ## Main definitions
 
-* `HeckeRing.GL2.transposeRep`: the transposed representative `(σᵢ δ)ᵀ`.
-* `HeckeRing.GL2.heckeSlashSum`: the choice-dependent sum `∑ᵢ f ∣[k] (σᵢ δ)ᵀ`.
+* `HeckeRing.GL2.rightCosetRep`: the representative `δ τᵥ⁻¹` of the `v`-th right coset.
+* `HeckeRing.GL2.heckeSlashSum`: the choice-dependent sum `∑ᵥ f ∣[k] (δ τᵥ⁻¹)`.
 
 ## Main results
 
-* `HeckeRing.GL2.transposeRep_def`, `HeckeRing.GL2.heckeSlashSum_def` and
+* `HeckeRing.GL2.rightCosetRep_def`, `HeckeRing.GL2.heckeSlashSum_def` and
   `HeckeRing.GL2.heckeSlashSum_apply`: the characteristic equations, which are the interface
   since neither definition is `@[expose]`. The last two are the function-level and pointwise
   forms of the same equation.
-* `HeckeRing.GL2.det_transposeRep_pos`: the representatives have positive determinant, given
-  `Γ₁ ≤ GLPos (Fin 2) ℚ` and `δ ∈ GLPos (Fin 2) ℚ`.
+* `HeckeRing.GL2.det_rightCosetRep_pos`: the representatives have positive determinant, given
+  `Γ₂ ≤ GLPos (Fin 2) ℚ` and `δ ∈ GLPos (Fin 2) ℚ`.
 * `HeckeRing.GL2.heckeSlashSum_add` and `heckeSlashSum_zero`: additivity and vanishing on `0`,
   with no hypothesis beyond finiteness of the index type.
 * `HeckeRing.GL2.heckeSlashSum_smul`: homogeneity, which additionally needs each representative
   to have positive determinant — the hypothesis is that, not the factorwise condition, since a
-  product can be positive with neither factor positive. `det_transposeRep_pos` supplies it.
+  product can be positive with neither factor positive. `det_rightCosetRep_pos` supplies it.
   Together with `heckeSlashSum_add` this gives `ℂ`-linearity.
 
 ## Provenance
 
-Ported from the AINTLIB `LeanModularForms` project
+The definition and its additivity, zero and scalar lemmas correspond to `heckeSlash` and its
+algebraic API in the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/HeckeAction.lean`](https://github.com/CBirkbeck/AINTLIB),
-commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck): `transposeRep`,
-its `heckeSlash` (renamed `heckeSlashSum` here, since it is not yet an action) and that
-definition's additivity, zero and scalar lemmas. Restated
-against TauCeti's `HeckeCoset`/`posDetInt` vocabulary and `transposeGLEquiv` rather than
-AINTLIB's `GL_pair`/`GL_transposeEquiv`, and over an arbitrary triple rather than the fixed
-level-one pair both projects start from.
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck). No code is
+transcribed: AINTLIB indexes the sum by Mathlib's left-coset `DecompQuotient` and repairs the
+handedness with a transpose, a device that works only where every group in sight is stable under
+transposition — level one. The sum below runs over Shimura's own right-coset index instead, so it
+is stated over an arbitrary triple, with no transpose anywhere.
 
 ## References
 
@@ -174,51 +127,53 @@ namespace HeckeRing.GL2
 variable (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)} {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
   (D : HeckeCoset Δ Γ₁ Γ₂)
 
-/-- The transposed left-coset representative `(σᵢ δ)ᵀ = δᵀ σᵢᵀ`, where `δ` is the chosen
-representative of the double coset `D` and `σᵢ` runs over its left-coset decomposition of
-`Γ₁ δ Γ₂`. The transpose turns it into a representative of the right coset `Γ₂ᵀ(σᵢ δ)ᵀ`, which
-is the handedness a right action needs — the enclosing double coset being the transposed
-`Γ₂ᵀ δᵀ Γ₁ᵀ`, since transposition reverses the flanks. ⚠ The group on the left is `Γ₂ᵀ`, not
-`Γ₁`; see "Which group the representatives are cosets of" in the module docstring. -/
-noncomputable def transposeRep (i : DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)) :
+/-- The representative `δ τᵥ⁻¹` of the `v`-th right coset `Γ₁ aᵥ` in the decomposition
+`Γ₁ δ Γ₂ = ⊔ᵥ Γ₁ aᵥ`, where `δ` is the chosen representative of the double coset `D` and `τᵥ`
+runs over the chosen representatives of `Γ₂ ⧸ (Γ₂ ∩ δ⁻¹Γ₁δ)`.
+
+The inverse is what converts the *left*-coset quotient Mathlib supplies into the right-coset
+index the decomposition needs; see "Which cosets the representatives run over" in the module
+docstring. -/
+noncomputable def rightCosetRep (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
     GL (Fin 2) ℚ :=
-  (transposeGLEquiv 2 ((i.out : GL (Fin 2) ℚ) * (D.out : GL (Fin 2) ℚ))).unop
+  (D.out : GL (Fin 2) ℚ) * ((v.out : GL (Fin 2) ℚ))⁻¹
 
--- `transposeRep` and `heckeSlashSum` are not `@[expose]`, so a module downstream of this one cannot
--- unfold either body. Their characteristic equations below are therefore the interface, not a
--- restatement of something already visible; `transposeRep_def` is written `(rfl)` in the style of
--- `ModularForms/Basic.lean`, which opts out of exporting the definitional equality itself.
+-- `rightCosetRep` and `heckeSlashSum` are not `@[expose]`, so a module downstream of this one
+-- cannot unfold either body. Their characteristic equations below are therefore the interface,
+-- not a restatement of something already visible; `rightCosetRep_def` is written `(rfl)` in the
+-- style of `ModularForms/Basic.lean`, which opts out of exporting the definitional equality.
 
-/-- Defining equation for `transposeRep`: the transpose of `σᵢ δ`. Since `transposeRep` is not
-`@[expose]`, a downstream module rewrites with this instead of unfolding the body. -/
-lemma transposeRep_def (i : DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)) :
-    transposeRep D i =
-      (transposeGLEquiv 2 ((i.out : GL (Fin 2) ℚ) * (D.out : GL (Fin 2) ℚ))).unop := (rfl)
+/-- Defining equation for `rightCosetRep`. Since `rightCosetRep` is not `@[expose]`, a
+downstream module rewrites with this instead of unfolding the body. -/
+lemma rightCosetRep_def (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
+    rightCosetRep D v = (D.out : GL (Fin 2) ℚ) * ((v.out : GL (Fin 2) ℚ))⁻¹ := (rfl)
 
-/-- Each representative lies in `posDetInt 2` when the two factors of `σᵢ δ` do. Only `Γ₁` and the
-chosen `δ` are constrained: nothing is asked of `Γ₂`, and nothing of `Δ` beyond containing `δ`. -/
-lemma transposeRep_mem_posDetInt (hΓ₁ : Γ₁.toSubmonoid ≤ posDetInt 2)
+/-- Each representative lies in `posDetInt 2` when `δ` does and `Γ₂` does. Only `Γ₂` and the
+chosen `δ` are constrained: nothing is asked of `Γ₁`, and nothing of `Δ` beyond containing `δ`.
+The hypothesis is used at `τᵥ⁻¹`, which lies in `Γ₂` because `Γ₂` is a group. -/
+lemma rightCosetRep_mem_posDetInt (hΓ₂ : Γ₂.toSubmonoid ≤ posDetInt 2)
     (hD : (D.out : GL (Fin 2) ℚ) ∈ posDetInt 2)
-    (i : DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)) : transposeRep D i ∈ posDetInt 2 :=
-  transposeRep_def D i ▸
-    transposeGLEquiv_mem_posDetInt 2 (mul_mem (hΓ₁ i.out.2) hD)
+    (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) : rightCosetRep D v ∈ posDetInt 2 := by
+  have hv : ((v.out : GL (Fin 2) ℚ))⁻¹ ∈ Γ₂ := inv_mem v.out.2
+  exact rightCosetRep_def D v ▸ mul_mem hD (hΓ₂ hv)
 
 /-- The representatives have positive determinant, in the shape
 `ModularForm.rat_smul_slash_of_det_pos` consumes.
 
 This asks only for positivity, not for the integrality `posDetInt 2` also carries: the conclusion
-is about determinants alone, and `det (σᵢ δ)ᵀ = det σᵢ · det δ`. A `posDetInt` hypothesis is
+is about determinants alone, and `det (δ τᵥ⁻¹) = det δ · det τᵥ⁻¹`. A `posDetInt` hypothesis is
 converted by `posDetInt_le_glpos`.
 
 Factorwise positivity is *sufficient*, not necessary — a product can be positive with neither
 factor positive — so `heckeSlashSum_smul` takes the positivity of each representative directly
 and this lemma is the convenient way to supply it. -/
-lemma det_transposeRep_pos (hΓ₁ : Γ₁ ≤ Matrix.GLPos (Fin 2) ℚ)
+lemma det_rightCosetRep_pos (hΓ₂ : Γ₂ ≤ Matrix.GLPos (Fin 2) ℚ)
     (hD : (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ)
-    (i : DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)) :
-    0 < (transposeRep D i : Matrix (Fin 2) (Fin 2) ℚ).det := by
-  have h := mul_mem (hΓ₁ i.out.2) hD
-  rw [transposeRep_def, transposeGLEquiv_coe, Matrix.det_transpose]
+    (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
+    0 < (rightCosetRep D v : Matrix (Fin 2) (Fin 2) ℚ).det := by
+  have hv : ((v.out : GL (Fin 2) ℚ))⁻¹ ∈ Γ₂ := inv_mem v.out.2
+  have h := mul_mem hD (hΓ₂ hv)
+  rw [rightCosetRep_def]
   simpa using h
 
 -- From here on the sum needs its index type to be finite, and that is *all* it needs: a Hecke
@@ -230,50 +185,41 @@ lemma det_transposeRep_pos (hΓ₁ : Γ₁ ≤ Matrix.GLPos (Fin 2) ℚ)
 -- chosen enumeration, only that one exists. The `Fintype` the `∑` notation requires is then
 -- installed once, as a local instance, so every statement below is written against a single
 -- instance and none has to carry a `letI`. Everything here is already `noncomputable`.
-variable [Finite (DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ))]
+variable [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
 
 /-- The enumeration `∑` needs, obtained from the `Finite` assumption by choice. It is `local`
 and `noncomputable`: the sum below does not depend on which enumeration is chosen, so no
 declaration in this file should carry one as data. -/
-noncomputable local instance : Fintype (DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)) :=
+noncomputable local instance : Fintype (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :=
   Fintype.ofFinite _
 
-/-- **The slash sum over a chosen decomposition of a double coset**:
-`∑ᵢ f ∣[k] (σᵢ δ)ᵀ`, over the transposed representatives of the left-coset decomposition of
-`Γ₁ δ Γ₂`.
+/-- **The slash sum over a chosen decomposition of a double coset**: `∑ᵥ f ∣[k] (δ τᵥ⁻¹)`, over
+the representatives of the decomposition of `Γ₁ δ Γ₂` into right cosets `Γ₁ aᵥ`. Up to the `det`
+normalising factor already built into the slash action, this is Shimura's `f ∣[Γ₁ δ Γ₂]ₖ`
+(§3.4, (3.4.1)).
 
-⚠ The transposed representatives enumerate right cosets of `Γ₂ᵀ` inside `Γ₂ᵀ δᵀ Γ₁ᵀ`. Reading
-this as Shimura's `f ∣[Γ₁ α Γ₂]ₖ` (§3.4 (3.4.1), up to the `det` normalising factor) therefore
-needs **two** things, not one: the flanks must match, `Γ₂ᵀ = Γ₁` (equivalently `Γ₁ᵀ = Γ₂`), *and*
-the double coset itself must be transpose-stable, `Γ₁ δᵀ Γ₂ = Γ₁ δ Γ₂` — matching the flanks alone
-leaves `δᵀ` where `δ` should be. Both hold at the level-one pair, where transposition preserves
-`SL₂(ℤ)` and fixes every double coset; the identification is asserted here only for that case.
-See "Which group the representatives are cosets of" in the module docstring.
-
-⚠ This depends on the chosen representatives `D.out` and `i.out`, and on a general
+⚠ This depends on the chosen representatives `D.out` and `v.out`, and on a general
 `f : ℍ → ℂ` the value changes with them — see the module docstring. Invariance of `f` under
-`Γ₂ᵀ` is *sufficient* to make it independent of those choices; whether it is also necessary is
-not claimed here, since a particular `f` and `D` could be independent by cancellation. That
-sufficiency is a separate theorem and is not proved in this file.
+`Γ₁` is *sufficient* to make it independent of those choices (`slash_rightCosetRep_of_mem`,
+`HeckeSlash/Reindex.lean`); whether it is also necessary is not claimed here, since a particular
+`f` and `D` could be independent by cancellation.
 
-⚠ Choice-independence is **not** the same as being an action, and this docstring does not claim
-the latter. What right multiplication gives is invariance of the *output* under `Γ₁ᵀ`, a
-different group from the `Γ₂ᵀ` the input must be invariant under. Do not read this definition as
-"the Hecke operator" until both the sufficiency theorem and the agreement of those two groups
-are available. -/
+⚠ Choice-independence is not the same as being an action, and this docstring does not claim the
+latter. What right multiplication gives is invariance of the *output* under `Γ₂`, which is the
+same group as the input's only on a diagonal triple. -/
 noncomputable def heckeSlashSum (f : ℍ → ℂ) : ℍ → ℂ :=
-  ∑ i : DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ), f ∣[k] transposeRep D i
+  ∑ v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹, f ∣[k] rightCosetRep D v
 
 /-- Defining equation for `heckeSlashSum` at the level of functions. Since `heckeSlashSum` is
 not `@[expose]`, a downstream module rewrites with this instead of unfolding the body; the
 pointwise `heckeSlashSum_apply` below is the companion for arguments that work at a point. -/
 lemma heckeSlashSum_def (f : ℍ → ℂ) : heckeSlashSum k D f =
-    ∑ i : DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ), f ∣[k] transposeRep D i := (rfl)
+    ∑ v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹, f ∣[k] rightCosetRep D v := (rfl)
 
 /-- The pointwise value of the slash sum: the sum of the slashed values. This is the equation
 the reindexing proof of Prop 3.37 works from. -/
 lemma heckeSlashSum_apply (f : ℍ → ℂ) (τ : ℍ) : heckeSlashSum k D f τ =
-    ∑ i : DecompQuotient Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ), (f ∣[k] transposeRep D i) τ :=
+    ∑ v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹, (f ∣[k] rightCosetRep D v) τ :=
   Finset.sum_apply ..
 
 /-- The slash sum is additive in `f`. -/
@@ -286,25 +232,25 @@ lemma heckeSlashSum_add (f g : ℍ → ℂ) : heckeSlashSum k D (f + g) =
 @[simp]
 lemma heckeSlashSum_zero : heckeSlashSum k D 0 = 0 := by
   rw [heckeSlashSum]
-  exact Finset.sum_eq_zero fun i _ ↦ SlashAction.zero_slash k (transposeRep D i)
+  exact Finset.sum_eq_zero fun v _ ↦ SlashAction.zero_slash k (rightCosetRep D v)
 
 /-- **The slash sum is homogeneous in `f`**: a scalar acting on `ℂ` through the scalar tower
 passes out of the sum. With `heckeSlashSum_add`, at `α := ℂ`, this gives `ℂ`-linearity.
 
 Unlike additivity, this needs each representative to have positive determinant, because the
 scalar passes through the slash only on that branch. That is asked for directly rather than
-factorwise: `det (σᵢ δ)ᵀ > 0` is what the proof uses, and a product can be positive with neither
-factor positive, so hypotheses on `Γ₁` and `δ` separately would exclude cases the theorem covers.
-`det_transposeRep_pos` is the convenient sufficient condition. -/
+factorwise: `det (δ τᵥ⁻¹) > 0` is what the proof uses, and a product can be positive with neither
+factor positive, so hypotheses on `Γ₂` and `δ` separately would exclude cases the theorem covers.
+`det_rightCosetRep_pos` is the convenient sufficient condition. -/
 @[simp]
 lemma heckeSlashSum_smul
-    (hpos : ∀ i, 0 < (transposeRep D i : Matrix (Fin 2) (Fin 2) ℚ).det)
+    (hpos : ∀ v, 0 < (rightCosetRep D v : Matrix (Fin 2) (Fin 2) ℚ).det)
     {α : Type*} [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ] (c : α) (f : ℍ → ℂ) :
     heckeSlashSum k D (c • f) = c • heckeSlashSum k D f := by
   rw [heckeSlashSum, heckeSlashSum]
   -- each representative has positive determinant, so the slash carries no `σ` twist: the
   -- scalar leaves the summands one at a time, and only then comes out of the sum as a whole
-  exact (Finset.sum_congr rfl fun i _ ↦ ModularForm.rat_smul_slash_of_det_pos k
-    (hpos i) f c).trans Finset.smul_sum.symm
+  exact (Finset.sum_congr rfl fun v _ ↦ ModularForm.rat_smul_slash_of_det_pos k
+    (hpos v) f c).trans Finset.smul_sum.symm
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Cusps.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Cusps.lean
@@ -44,11 +44,12 @@ public section
 
 namespace HeckeRing.GL2
 
-open UpperHalfPlane DoubleCoset HeckeRing.GLn
+open Matrix UpperHalfPlane DoubleCoset HeckeRing.GLn
 
 open scoped MatrixGroups ModularForm
 
-variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+variable (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)} {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
+  (D : HeckeCoset Δ Γ₁ Γ₂) [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
 
 /-- **The slash sum vanishes at every cusp** when the function does. -/
 lemma isZeroAt_heckeSlashSum {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.IsArithmetic] {f : ℍ → ℂ}

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Form.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Form.lean
@@ -76,8 +76,10 @@ variable {G : Subgroup SL(2, ℤ)} (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)}
 `heckeSlashSum`, and its invariance is `heckeSlashSum_slash_invariant` transported across the
 `G.map (mapGL ℚ)` ↔ `G.map (mapGL ℝ)` correspondence.
 
-⚠ As in `Invariance.lean`, this is the sum over the representatives `heckeSlashSum` fixes; no
-claim is made that different choices of representatives give the same form. -/
+⚠ As in `Invariance.lean`, this is the sum over the representatives `heckeSlashSum` fixes. That
+any other decomposition of the double coset into right cosets gives the same form is
+`heckeSlashSum_coe_eq_sum_of_rightCosets` (`HeckeSlash/Independence.lean`), whose hypothesis is
+exactly the slash-invariance carried here. -/
 private noncomputable def heckeSlashInvariant (f : SlashInvariantForm (G.map (mapGL ℝ)) k) :
     SlashInvariantForm (G.map (mapGL ℝ)) k where
   toFun := heckeSlashSum k D f

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Form.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Form.lean
@@ -10,43 +10,48 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Invariance
 /-!
 # The slash sum as an operator on slash-invariant forms
 
-`Invariance.lean` proves that `heckeSlashSum k D f` is `SL₂(ℤ)`-invariant when `f` is. This file
-packages that into a map `SlashInvariantForm 𝒮ℒ k → SlashInvariantForm 𝒮ℒ k`, which is the point
-at which the double coset finally acts on *forms* rather than on raw functions `ℍ → ℂ`.
+`Invariance.lean` proves that `heckeSlashSum k D f` is `Γ₂`-invariant when `f` is `Γ₁`-invariant.
+This file packages the diagonal case of that into a map
+`SlashInvariantForm (G.map (mapGL ℝ)) k → SlashInvariantForm (G.map (mapGL ℝ)) k`, which is the
+point at which the double coset finally acts on *forms* rather than on raw functions `ℍ → ℂ`.
+
+## The level
+
+`G` is an arbitrary subgroup of `SL(2, ℤ)`; taking `G = Γ₁(N)` gives the level at which the
+roadmap's Hecke operators live, and `G = ⊤` recovers level one. The two flanks of the double
+coset are the *same* group `G.map (mapGL ℚ)`, which is what makes the hypothesis and the
+conclusion of `heckeSlashSum_slash_invariant` the same condition; no transpose-stability is
+needed anywhere, which is why the level is not confined to `SL₂(ℤ)`.
 
 ## Crossing from `ℚ` to `ℝ`
 
-The two sides speak different languages, and reconciling them is most of this file.
-`SlashInvariantForm Γ k` is indexed by a subgroup of `GL(2, ℝ)`, and `𝒮ℒ` is the range of
-`mapGL ℝ`; the invariance theorem is stated at `SLnZ 2`, the range of `mapGL ℚ`, under the
-rational slash action. Both are ranges of `mapGL` out of the *same* `SL₂(ℤ)`, so mathlib's
-`Matrix.SpecialLinearGroup.map_mapGL` — `(mapGL S g).map (algebraMap S T) = mapGL T g` for a
-scalar tower — relates them directly at `ℤ → ℚ → ℝ`. Both directions of the bridge are corollaries
-of it, and `ModularForm.rat_slash` turns each rational slash into the real one.
+The two sides speak different languages, and reconciling them is what
+`ModularForms/SlashActionRat.lean` is for. `SlashInvariantForm Γ k` is indexed by a subgroup of
+`GL(2, ℝ)`, while the Hecke triples of `HeckeRing/GL2/` live in `GL(2, ℚ)`; both levels here are
+images of the same `G ≤ SL(2, ℤ)`, so `Matrix.SpecialLinearGroup.map_mapGL` relates them
+directly at `ℤ → ℚ → ℝ`. `ModularForm.slash_eq_of_mem_map_mapGL` and its `_real` companion are
+the two directions, and they are the only bridging this file does.
 
 ## Main definitions
 
-* `HeckeRing.GL2.heckeSlashEnd`: the same map bundled as a `ℂ`-linear endomorphism. This is an
-  intermediate step toward Layer 2(b), which asks for endomorphisms of `ModularForm` at level
-  `Γ₁(N)`; the descent — holomorphy and the cusp conditions — is not formalised here.
+* `HeckeRing.GL2.heckeSlashEnd`: the double coset bundled as a `ℂ`-linear endomorphism of
+  `SlashInvariantForm (G.map (mapGL ℝ)) k`. This is an intermediate step toward Layer 2(b), which
+  asks for endomorphisms of `ModularForm`; holomorphy and the cusp conditions are added in
+  `HeckeSlash/ModularForm.lean`.
 
 ## Main results
 
-* `HeckeRing.GL2.coe_heckeSlashEnd`: the endomorphism is `heckeSlashSum` on functions.
+* `HeckeRing.GL2.coe_heckeSlashEnd`: the endomorphism is `heckeSlashSum` on underlying functions.
 
 ## Provenance
 
-Ported from the AINTLIB `LeanModularForms` project
+The statement corresponds to `heckeSlashInvariant` in the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/HeckeAction.lean`](https://github.com/CBirkbeck/AINTLIB),
-commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck): `glMap_mem_SL`,
-`mem_SL_exists_H` and `heckeSlashInvariant`. AINTLIB's `glMap` wrapper and its `glMap_mapGL_eq`
-have no counterpart here: `Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)` is already the map, and
-mathlib's `Matrix.SpecialLinearGroup.map_mapGL` is already the identity relating the two ranges.
-
-These are the bridging helpers that earlier files in this chain deliberately avoided: carrying
-slash-invariance rationally kept `Reindex.lean` and `Invariance.lean` free of them, and this is
-the file that pays for that choice, once, where the `ℝ`-indexed `SlashInvariantForm` makes it
-unavoidable.
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck). AINTLIB's `glMap`
+wrapper and its bridging helpers `glMap_mem_SL` and `mem_SL_exists_H` have no counterpart here:
+`Matrix.GeneralLinearGroup.map (algebraMap ℚ ℝ)` is already the map, mathlib's
+`Matrix.SpecialLinearGroup.map_mapGL` is already the identity relating the two images, and the
+statement is at a general `G` rather than at `SL₂(ℤ)`.
 
 ## References
 
@@ -62,46 +67,48 @@ open scoped MatrixGroups ModularForm
 
 namespace HeckeRing.GL2
 
-variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+variable {G : Subgroup SL(2, ℤ)} (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)}
+  (D : HeckeCoset Δ (G.map (mapGL ℚ)) (G.map (mapGL ℚ)))
+  [Finite (DecompQuotient (G.map (mapGL ℚ)) (G.map (mapGL ℚ)) (D.out : GL (Fin 2) ℚ)⁻¹)]
+  (hD : (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ)
 
 /-- **The double coset acting on slash-invariant forms.** The underlying function is
-`heckeSlashSum`, and its invariance is `heckeSlashSum_slash_invariant_of_mem_SLnZ` transported
-across the `SLnZ 2` ↔ `𝒮ℒ` correspondence.
+`heckeSlashSum`, and its invariance is `heckeSlashSum_slash_invariant` transported across the
+`G.map (mapGL ℚ)` ↔ `G.map (mapGL ℝ)` correspondence.
 
 ⚠ As in `Invariance.lean`, this is the sum over the representatives `heckeSlashSum` fixes; no
 claim is made that different choices of representatives give the same form. -/
-private noncomputable def heckeSlashInvariant (f : SlashInvariantForm 𝒮ℒ k) :
-    SlashInvariantForm 𝒮ℒ k where
+private noncomputable def heckeSlashInvariant (f : SlashInvariantForm (G.map (mapGL ℝ)) k) :
+    SlashInvariantForm (G.map (mapGL ℝ)) k where
   toFun := heckeSlashSum k D f
   slash_action_eq' γ hγ := by
-    obtain ⟨δ, hδ, rfl⟩ := ModularForm.exists_mem_SLnZ_of_mem_SL hγ
-    rw [← ModularForm.rat_slash]
-    exact heckeSlashSum_slash_invariant_of_mem_SLnZ k D f
-      (fun _ h ↦ ModularForm.slash_eq_of_mem_SLnZ k f.slash_action_eq' h) hδ
+    refine ModularForm.slash_eq_of_mem_map_mapGL_real (fun δ hδ ↦ ?_) hγ
+    exact heckeSlashSum_slash_invariant k D (⇑f)
+      (fun _ hε ↦ ModularForm.slash_eq_of_mem_map_mapGL
+        (fun γ' hγ' ↦ SlashInvariantFormClass.slash_action_eq f γ' hγ') hε) hδ
 
-/-- **The double coset as a `ℂ`-linear endomorphism of `SlashInvariantForm 𝒮ℒ k`.** Bundling it
-as a `Module.End ℂ` is what lets Hecke operators compose and later carry a ring structure.
-Linearity is `heckeSlashSum_add`, which needs no hypothesis, together with `heckeSlashSum_smul`,
-which needs the two factors of each representative to have positive determinant. At this coset
-that is `SLnZ_le_posDetInt` and `D.out.2`, since both flanking groups and the ambient submonoid
-are `SL₂(ℤ)` and `posDetInt 2`.
+/-- **The double coset as a `ℂ`-linear endomorphism of `SlashInvariantForm (G.map (mapGL ℝ)) k`.**
+Bundling it as a `Module.End ℂ` is what lets Hecke operators compose and later carry a ring
+structure. Linearity is `heckeSlashSum_add`, which needs no hypothesis, together with
+`heckeSlashSum_smul`, which needs each representative to have positive determinant: the flanking
+group consists of determinant-one matrices (`ModularForm.map_mapGL_le_glpos`), so `hD` is all
+that is left to ask.
 
 ⚠ This is an intermediate step, not the roadmap's Layer 2(b) target: that asks for endomorphisms
-of `ModularForm ((Gamma1 N).map (mapGL ℝ)) k`, which additionally requires holomorphy and the
-cusp conditions to be preserved, and at level `Γ₁(N)` rather than `𝒮ℒ`. The descent is not
-formalised here. -/
-noncomputable def heckeSlashEnd : Module.End ℂ (SlashInvariantForm 𝒮ℒ k) where
+of `ModularForm (G.map (mapGL ℝ)) k`, which additionally requires holomorphy and the cusp
+conditions to be preserved. The descent is `HeckeSlash/ModularForm.lean`. -/
+noncomputable def heckeSlashEnd :
+    Module.End ℂ (SlashInvariantForm (G.map (mapGL ℝ)) k) where
   toFun := heckeSlashInvariant k D
   map_add' f g := by ext τ; simp [heckeSlashInvariant, heckeSlashSum_add]
   map_smul' c f := by
     ext τ
     simp [heckeSlashInvariant,
-      heckeSlashSum_smul k D
-      (det_transposeRep_pos D (SLnZ_le_glpos 2) (posDetInt_le_glpos 2 D.out.2))]
+      heckeSlashSum_smul k D (det_rightCosetRep_pos D (ModularForm.map_mapGL_le_glpos G) hD)]
 
 /-- The endomorphism is `heckeSlashSum` on underlying functions. This characterises it directly,
 without exposing the bundling. -/
-@[simp] lemma coe_heckeSlashEnd (f : SlashInvariantForm 𝒮ℒ k) :
-    ⇑(heckeSlashEnd k D f) = heckeSlashSum k D f := (rfl)
+@[simp] lemma coe_heckeSlashEnd (f : SlashInvariantForm (G.map (mapGL ℝ)) k) :
+    ⇑(heckeSlashEnd k D hD f) = heckeSlashSum k D f := (rfl)
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.ModularForm
+
+/-!
+# The Hecke operators of level `Γ₁(N)`
+
+`HeckeSlash/ModularForm.lean` builds, for a subgroup `G ≤ SL(2, ℤ)` and a double coset of a Hecke
+triple whose two flanks are `G.map (mapGL ℚ)`, the `ℂ`-linear endomorphisms of
+`ModularForm (G.map (mapGL ℝ)) k` and `CuspForm (G.map (mapGL ℝ)) k` that the coset induces. This
+file instantiates that at `G = Γ₁(N)` and `Δ = Δ₀(N)` — the roadmap's Layer 2(b) setting — and
+discharges, once, the two side conditions the general construction carries.
+
+The Hecke triple itself is `HeckeRing/GL2/Gamma1.lean`'s instance, and the finiteness of the
+right-coset index follows from it. What is left is the positivity hypothesis, and that is
+`Δ₀(N) ≤ posDetInt 2` composed with `posDetInt_le_glpos`: every element of `Δ₀(N)` has positive
+determinant by definition, so no double coset of this triple ever fails it.
+
+⚠ These are the operators of an *arbitrary* double coset. Identifying particular cosets with the
+classical `Tₙ` — the normalisation lemma for `Γ₁(N) · diag(1, p) · Γ₁(N)`, and the `q`-expansion
+recurrences — is a separate milestone and is not proved here.
+
+## Main definitions
+
+* `HeckeRing.GL2.heckeSlashGamma1ModularFormEnd`: the operator on `M_k(Γ₁(N))`.
+* `HeckeRing.GL2.heckeSlashGamma1CuspFormEnd`: the operator on `S_k(Γ₁(N))`.
+
+## Main results
+
+* `HeckeRing.GL2.mem_glpos_out_of_delta0`: a double coset of `Δ₀(N)` has a representative of
+  positive determinant.
+* `HeckeRing.GL2.coe_heckeSlashGamma1ModularFormEnd`,
+  `HeckeRing.GL2.coe_heckeSlashGamma1CuspFormEnd`: both operators are `heckeSlashSum` on
+  underlying functions.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4–3.5.
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.2.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
+  HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm
+
+namespace HeckeRing.GL2
+
+variable {N : ℕ}
+
+/-- The chosen representative of a double coset of `Δ₀(N)` has positive determinant: `Δ₀(N)`
+consists of integral matrices of positive determinant. This is the hypothesis
+`heckeSlashModularFormEnd` carries, discharged once for this triple. -/
+lemma mem_glpos_out_of_delta0 {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
+    (D : HeckeCoset (Delta0 N) Γ₁ Γ₂) :
+    (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ :=
+  posDetInt_le_glpos 2 (Delta0_le_posDetInt N D.out.2)
+
+variable [NeZero N] (k : ℤ)
+  (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
+
+/-- **The Hecke operator of a double coset on `M_k(Γ₁(N))`.** This is the roadmap's Layer 2(b)
+target for `ModularForm`: a `ℂ`-linear endomorphism of the space of modular forms of level
+`Γ₁(N)` attached to an arbitrary double coset of the Hecke triple `(Γ₁(N), Δ₀(N))`, with no
+condition relating `N` to the determinant of the coset. -/
+noncomputable def heckeSlashGamma1ModularFormEnd :
+    Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  heckeSlashModularFormEnd k D (mem_glpos_out_of_delta0 D)
+
+/-- **The Hecke operator of a double coset on `S_k(Γ₁(N))`** — the statement that the operator
+above preserves cuspidality. -/
+noncomputable def heckeSlashGamma1CuspFormEnd :
+    Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  heckeSlashCuspFormEnd k D (mem_glpos_out_of_delta0 D)
+
+/-- The operator is `heckeSlashSum` on underlying functions. -/
+@[simp] lemma coe_heckeSlashGamma1ModularFormEnd (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeSlashGamma1ModularFormEnd k D f) = heckeSlashSum k D f :=
+  coe_heckeSlashModularFormEnd k D (mem_glpos_out_of_delta0 D) f
+
+/-- The operator is `heckeSlashSum` on underlying functions. -/
+@[simp] lemma coe_heckeSlashGamma1CuspFormEnd (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeSlashGamma1CuspFormEnd k D f) = heckeSlashSum k D f :=
+  coe_heckeSlashCuspFormEnd k D (mem_glpos_out_of_delta0 D) f
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
@@ -22,6 +22,12 @@ right-coset index follows from it. What is left is the positivity hypothesis, an
 `Δ₀(N) ≤ posDetInt 2` composed with `posDetInt_le_glpos`: every element of `Δ₀(N)` has positive
 determinant by definition, so no double coset of this triple ever fails it.
 
+The operators belong to the double coset itself, not to the representatives `heckeSlashSum` sums
+over: `coe_heckeSlashGamma1ModularFormEnd` below rewrites either of them to `heckeSlashSum`, and
+`heckeSlashSum_coe_eq_sum_of_rightCosets` (`HeckeSlash/Independence.lean`) then evaluates that on
+*any* decomposition of `Γ₁(N) δ Γ₁(N)` into right cosets — any representative `δ` of the coset,
+and any representatives of the cosets `Γ₁(N) aᵢ` — always with the same answer.
+
 ⚠ These are the operators of an *arbitrary* double coset. Identifying particular cosets with the
 classical `Tₙ` — the normalisation lemma for `Γ₁(N) · diag(1, p) · Γ₁(N)`, and the `q`-expansion
 recurrences — is a separate milestone and is not proved here.

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
@@ -19,8 +19,8 @@ discharges, once, the two side conditions the general construction carries.
 
 The Hecke triple itself is `HeckeRing/GL2/Gamma1.lean`'s instance, and the finiteness of the
 right-coset index follows from it. What is left is the positivity hypothesis, and that is
-`Δ₀(N) ≤ posDetInt 2` composed with `posDetInt_le_glpos`: every element of `Δ₀(N)` has positive
-determinant by definition, so no double coset of this triple ever fails it.
+`out_mem_glpos_of_delta0` from the same file: every element of `Δ₀(N)` has positive determinant
+by definition, so no double coset of this triple ever fails it.
 
 The operators belong to the double coset itself, not to the representatives `heckeSlashSum` sums
 over: `coe_heckeSlashGamma1ModularFormEnd` below rewrites either of them to `heckeSlashSum`, and
@@ -39,8 +39,6 @@ recurrences — is a separate milestone and is not proved here.
 
 ## Main results
 
-* `HeckeRing.GL2.mem_glpos_out_of_delta0`: a double coset of `Δ₀(N)` has a representative of
-  positive determinant.
 * `HeckeRing.GL2.coe_heckeSlashGamma1ModularFormEnd`,
   `HeckeRing.GL2.coe_heckeSlashGamma1CuspFormEnd`: both operators are `heckeSlashSum` on
   underlying functions.
@@ -61,17 +59,7 @@ open scoped MatrixGroups ModularForm
 
 namespace HeckeRing.GL2
 
-variable {N : ℕ}
-
-/-- The chosen representative of a double coset of `Δ₀(N)` has positive determinant: `Δ₀(N)`
-consists of integral matrices of positive determinant. This is the hypothesis
-`heckeSlashModularFormEnd` carries, discharged once for this triple. -/
-lemma mem_glpos_out_of_delta0 {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
-    (D : HeckeCoset (Delta0 N) Γ₁ Γ₂) :
-    (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ :=
-  posDetInt_le_glpos 2 (Delta0_le_posDetInt N D.out.2)
-
-variable [NeZero N] (k : ℤ)
+variable {N : ℕ} [NeZero N] (k : ℤ)
   (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
 
 /-- **The Hecke operator of a double coset on `M_k(Γ₁(N))`.** This is the roadmap's Layer 2(b)
@@ -80,23 +68,23 @@ target for `ModularForm`: a `ℂ`-linear endomorphism of the space of modular fo
 condition relating `N` to the determinant of the coset. -/
 noncomputable def heckeSlashGamma1ModularFormEnd :
     Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
-  heckeSlashModularFormEnd k D (mem_glpos_out_of_delta0 D)
+  heckeSlashModularFormEnd k D (out_mem_glpos_of_delta0 N D)
 
 /-- **The Hecke operator of a double coset on `S_k(Γ₁(N))`** — the statement that the operator
 above preserves cuspidality. -/
 noncomputable def heckeSlashGamma1CuspFormEnd :
     Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
-  heckeSlashCuspFormEnd k D (mem_glpos_out_of_delta0 D)
+  heckeSlashCuspFormEnd k D (out_mem_glpos_of_delta0 N D)
 
 /-- The operator is `heckeSlashSum` on underlying functions. -/
 @[simp] lemma coe_heckeSlashGamma1ModularFormEnd (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
     ⇑(heckeSlashGamma1ModularFormEnd k D f) = heckeSlashSum k D f :=
-  coe_heckeSlashModularFormEnd k D (mem_glpos_out_of_delta0 D) f
+  coe_heckeSlashModularFormEnd k D (out_mem_glpos_of_delta0 N D) f
 
 /-- The operator is `heckeSlashSum` on underlying functions. -/
 @[simp] lemma coe_heckeSlashGamma1CuspFormEnd (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
     ⇑(heckeSlashGamma1CuspFormEnd k D f) = heckeSlashSum k D f :=
-  coe_heckeSlashCuspFormEnd k D (mem_glpos_out_of_delta0 D) f
+  coe_heckeSlashCuspFormEnd k D (out_mem_glpos_of_delta0 N D) f
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Holomorphic.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Holomorphic.lean
@@ -37,10 +37,11 @@ open scoped MatrixGroups ModularForm Manifold
 
 namespace HeckeRing.GL2
 
-variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+variable (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)} {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
+  (D : HeckeCoset Δ Γ₁ Γ₂) [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
 
 /-- **The slash sum of a holomorphic function is holomorphic.** Together with slash-invariance
-(`heckeSlashSum_slash_invariant_of_mem_SLnZ`) this supplies one of the two extra conditions a
+(`heckeSlashSum_slash_invariant`) this supplies one of the two extra conditions a
 `ModularForm` carries over a `SlashInvariantForm`; boundedness at the cusps is separate and is
 not proved here. -/
 lemma mdifferentiable_heckeSlashSum {f : ℍ → ℂ} (hf : MDiff f) : MDiff (heckeSlashSum k D f) := by

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
@@ -145,13 +145,15 @@ theorem heckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι] (a : ι �
       MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
         MulOpposite.op (rightCosetRep D (φ i)) • (Γ₁ : Set (GL (Fin 2) ℚ)) :=
     ⟨fun i ↦ (key i).choose, fun i ↦ (key i).choose_spec⟩
+  -- Indices with the same image under `φ` name the same coset of the family `(aᵢ)`, which `hinj`
+  -- then identifies; stated separately so that `hinj` is applied to this equality itself.
+  have hcoset : ∀ i j, φ i = φ j → MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op (a j) • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun i j hij ↦ by
+    rw [hφ i, hφ j, hij]
   have hbij : Function.Bijective φ := by
-    refine ⟨fun i j hij ↦ hinj ?_, fun v ↦ ?_⟩
-    · change MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
-        MulOpposite.op (a j) • (Γ₁ : Set (GL (Fin 2) ℚ))
-      rw [hφ i, hφ j, hij]
-    · obtain ⟨i, hi⟩ := key' v
-      exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
+    refine ⟨fun i j hij ↦ hinj (hcoset i j hij), fun v ↦ ?_⟩
+    obtain ⟨i, hi⟩ := key' v
+    exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
   rw [heckeSlashSum_def]
   exact (Fintype.sum_bijective φ hbij _ _ fun i ↦ slash_eq_of_rightCoset_eq k hf (hφ i)).symm
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Reindex
+
+/-!
+# The slash sum of an invariant function depends only on the double coset
+
+`heckeSlashSum k D f` is a sum over the *chosen* representatives `D.out` of the double coset and
+`v.out` of its right cosets, and `HeckeSlash/Basic.lean` records that on a general `f : ℍ → ℂ`
+the value moves with those choices. This file proves that for a `Γ₁`-invariant `f` it does not:
+the sum is `∑ᵢ f ∣[k] aᵢ` for **any** family `(aᵢ)` of representatives of the right cosets of
+`Γ₁ δ Γ₂`, whatever `δ` in the double coset and whatever representatives are used to name them.
+
+That is what makes the endomorphisms of `HeckeSlash/ModularForm.lean` operators attached to the
+double coset rather than to a presentation of it, and it is Shimura's definition (§3.4, (3.4.1)),
+which fixes no representatives at all.
+
+## What the choice-freeness rests on
+
+Two families of representatives of the same right cosets differ, coset by coset, by a factor of
+`Γ₁` on the **left**, and `f ∣[k] (γ₁ x) = (f ∣[k] γ₁) ∣[k] x = f ∣[k] x` for `γ₁ ∈ Γ₁` when `f`
+is `Γ₁`-invariant: that is `slash_eq_of_rightCoset_eq`, and it is the only place invariance is
+used. Everything else is a comparison of two enumerations of the same finite set of right
+cosets: `DoubleCoset.doubleCoset_eq_iUnion_rightCosets` says the chosen representatives cover
+the double coset and `DoubleCoset.op_mul_out_inv_smul_injective` says they do so without
+repetition, which are exactly the two hypotheses demanded of the family `(aᵢ)`, so the two
+enumerations are matched by a bijection and the sums agree term by term.
+
+The hypotheses are stated with `MulOpposite.op x • (Γ₁ : Set _)` — Mathlib's spelling of the
+right coset `Γ₁ x` — so that the two lemmas above are literally what a caller supplies. The
+double coset `Γ₁ δ Γ₂` is named as `doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂`; that *set*
+depends on no choice, since `DoubleCoset.doubleCoset_eq_of_mem` gives the same set for every
+`δ` in it, and `heckeSlashSum_eq_sum_of_mem_doubleCoset` is the resulting statement that any
+such `δ` may be used to form the sum.
+
+## Main results
+
+* `HeckeRing.GL2.slash_eq_of_rightCoset_eq`: slashing a `Γ₁`-invariant function by `x` depends
+  only on the right coset `Γ₁ x`.
+* `HeckeRing.GL2.heckeSlashSum_eq_sum_of_rightCosets`: **the choice-free description of the
+  slash sum.** For `Γ₁`-invariant `f`, `heckeSlashSum k D f = ∑ᵢ f ∣[k] aᵢ` for any family
+  `(aᵢ)` whose right cosets `Γ₁ aᵢ` are distinct and cover the double coset.
+* `HeckeRing.GL2.heckeSlashSum_eq_sum_of_mem_doubleCoset`: the special case that fixes the
+  choice of double-coset representative only: any `δ ∈ Γ₁ D.out Γ₂` gives the same sum.
+* `HeckeRing.GL2.heckeSlashSum_coe_eq_sum_of_rightCosets`: the same description for a form of
+  level `G.map (mapGL ℝ)`, whose slash-invariance discharges the hypothesis `hf`. It is what
+  `HeckeSlash/ModularForm.lean` reads off the two exported endomorphisms with, in
+  `coe_heckeSlashModularFormEnd_eq_sum` and `coe_heckeSlashCuspFormEnd_eq_sum`.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4: (3.4.1) defines `f ∣[Γ₁ α Γ₂]ₖ` as the sum over a decomposition `Γ₁ α Γ₂ = ⊔ᵥ Γ₁ aᵥ`,
+  and observes that it is independent of the decomposition chosen.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane DoubleCoset HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm Pointwise
+
+namespace HeckeRing.GL2
+
+variable (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)} {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
+  (D : HeckeCoset Δ Γ₁ Γ₂)
+
+/-- **Slashing a `Γ₁`-invariant function depends only on the right coset.** If `Γ₁ x = Γ₁ y`
+then `f ∣[k] x = f ∣[k] y`, because `y = (y x⁻¹) x` with `y x⁻¹ ∈ Γ₁` and the slash by that
+factor is trivial on `f`.
+
+This is the whole role invariance plays in the choice-freeness below: everything else is a
+comparison of two enumerations of the same set of cosets. -/
+lemma slash_eq_of_rightCoset_eq {f : ℍ → ℂ} (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) {x y : GL (Fin 2) ℚ}
+    (h : MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op y • (Γ₁ : Set (GL (Fin 2) ℚ))) :
+    f ∣[k] x = f ∣[k] y := by
+  have hγ : y * x⁻¹ ∈ Γ₁ := (rightCoset_eq_iff Γ₁).mp h
+  calc f ∣[k] x = (f ∣[k] (y * x⁻¹)) ∣[k] x := by rw [hf _ hγ]
+    _ = f ∣[k] (y * x⁻¹ * x) := (SlashAction.slash_mul k (y * x⁻¹) x f).symm
+    _ = f ∣[k] y := by rw [inv_mul_cancel_right]
+
+variable [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
+
+/-- **The slash sum of a `Γ₁`-invariant function is the sum over any decomposition of the double
+coset into right cosets.** If the right cosets `Γ₁ aᵢ` are pairwise distinct and cover
+`Γ₁ D.out Γ₂`, then `heckeSlashSum k D f = ∑ᵢ f ∣[k] aᵢ`.
+
+So the operator is attached to the double coset itself: the representatives `D.out` and `v.out`
+that `heckeSlashSum` happens to pick are one such family (`doubleCoset_eq_iUnion_rightCosets` and
+`op_mul_out_inv_smul_injective`), and every other family gives the same function.
+
+Invariance of `f` under `Γ₁` is what the proof uses, once, through
+`slash_eq_of_rightCoset_eq`; on a general `f` the statement is false, as `HeckeSlash/Basic.lean`
+records. -/
+theorem heckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ)
+    (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
+      ⋃ i, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)))
+    (hinj : Function.Injective fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)))
+    (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+    heckeSlashSum k D f = ∑ i, f ∣[k] a i := by
+  classical
+  -- the enumeration the comparison of sums needs; `heckeSlashSum` fixes one of its own, and the
+  -- two agree, no sum here depending on which is chosen
+  let _ : Fintype (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) := Fintype.ofFinite _
+  -- Shimura's decomposition, written with the representatives `heckeSlashSum` uses.
+  have hcover' : doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
+      ⋃ v, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+    simpa only [rightCosetRep_def] using
+      doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
+  have hinj' : Function.Injective fun v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹ ↦
+      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+    simpa only [rightCosetRep_def] using
+      op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
+  have hself : ∀ x : GL (Fin 2) ℚ, x ∈ MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun x ↦
+    (mem_rightCoset_iff x).mpr (by simp)
+  -- Two right cosets of `Γ₁` that meet are equal, so each family's cosets occur in the other.
+  have hmatch : ∀ x y : GL (Fin 2) ℚ, x ∈ MulOpposite.op y • (Γ₁ : Set (GL (Fin 2) ℚ)) →
+      MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op y • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun x y hxy ↦
+    (rightCoset_eq_iff Γ₁).mpr (by simpa using inv_mem ((mem_rightCoset_iff y).mp hxy))
+  have key : ∀ i, ∃ v, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+    intro i
+    have hmem : a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ := by
+      rw [hcover]; exact Set.mem_iUnion_of_mem i (hself (a i))
+    rw [hcover'] at hmem
+    obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hmem
+    exact ⟨v, hmatch _ _ hv⟩
+  have key' : ∀ v, ∃ i, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
+    intro v
+    have hmem : rightCosetRep D v ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ := by
+      rw [hcover']; exact Set.mem_iUnion_of_mem v (hself (rightCosetRep D v))
+    rw [hcover] at hmem
+    obtain ⟨i, hi⟩ := Set.mem_iUnion.mp hmem
+    exact ⟨i, hmatch _ _ hi⟩
+  -- The two enumerations are matched by `φ`, and matched cosets have equal slashes.
+  obtain ⟨φ, hφ⟩ : ∃ φ : ι → DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹, ∀ i,
+      MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op (rightCosetRep D (φ i)) • (Γ₁ : Set (GL (Fin 2) ℚ)) :=
+    ⟨fun i ↦ (key i).choose, fun i ↦ (key i).choose_spec⟩
+  have hbij : Function.Bijective φ := by
+    refine ⟨fun i j hij ↦ hinj ?_, fun v ↦ ?_⟩
+    · change MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op (a j) • (Γ₁ : Set (GL (Fin 2) ℚ))
+      rw [hφ i, hφ j, hij]
+    · obtain ⟨i, hi⟩ := key' v
+      exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
+  rw [heckeSlashSum_def]
+  exact (Fintype.sum_bijective φ hbij _ _ fun i ↦ slash_eq_of_rightCoset_eq k hf (hφ i)).symm
+
+/-- **The slash sum may be formed from any representative of the double coset.** For `δ` in
+`Γ₁ D.out Γ₂` and `Γ₁`-invariant `f`, summing `f ∣[k] (δ τᵥ⁻¹)` over `Γ₂ ⧸ (Γ₂ ∩ δ⁻¹Γ₁δ)` gives
+`heckeSlashSum k D f` again — the representative `heckeSlashSum` picks is in no way
+distinguished.
+
+This is `heckeSlashSum_eq_sum_of_rightCosets` at the family Shimura's decomposition of
+`Γ₁ δ Γ₂` provides, the double coset of `δ` being that of `D.out`
+(`DoubleCoset.doubleCoset_eq_of_mem`). -/
+theorem heckeSlashSum_eq_sum_of_mem_doubleCoset {δ : GL (Fin 2) ℚ}
+    (hδ : δ ∈ doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂)
+    [Fintype (DecompQuotient Γ₂ Γ₁ δ⁻¹)] (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+    heckeSlashSum k D f =
+      ∑ v : DecompQuotient Γ₂ Γ₁ δ⁻¹, f ∣[k] (δ * ((v.out : GL (Fin 2) ℚ))⁻¹) := by
+  refine heckeSlashSum_eq_sum_of_rightCosets k D _ ?_
+    (op_mul_out_inv_smul_injective Γ₁ Γ₂ δ) f hf
+  rw [← doubleCoset_eq_of_mem hδ]
+  exact doubleCoset_eq_iUnion_rightCosets Γ₁ Γ₂ δ
+
+section Form
+
+variable {G : Subgroup SL(2, ℤ)} {F : Type*} [FunLike F ℍ ℂ]
+  [SlashInvariantFormClass F (G.map (mapGL ℝ)) k]
+  (D : HeckeCoset Δ (G.map (mapGL ℚ)) (G.map (mapGL ℚ)))
+  [Finite (DecompQuotient (G.map (mapGL ℚ)) (G.map (mapGL ℚ)) (D.out : GL (Fin 2) ℚ)⁻¹)]
+
+/-- **The slash sum of a form of level `G.map (mapGL ℝ)` is the sum over any decomposition of the
+double coset into right cosets.** This is `heckeSlashSum_eq_sum_of_rightCosets` with the
+hypothesis `hf` discharged: a form of that level is slash-invariant under `G.map (mapGL ℚ)` by
+`ModularForm.slash_eq_of_mem_map_mapGL`, the `ℚ`/`ℝ` bridge.
+
+`F` is any type of slash-invariant forms, so this covers `SlashInvariantForm`, `ModularForm` and
+`CuspForm` at once; combined with the `coe_heckeSlash…End` lemmas it describes the endomorphisms
+built from a double coset, at any level, without reference to the representatives they are
+assembled from. -/
+theorem heckeSlashSum_coe_eq_sum_of_rightCosets {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ)
+    (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) (G.map (mapGL ℚ)) (G.map (mapGL ℚ)) =
+      ⋃ i, MulOpposite.op (a i) • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ)))
+    (hinj : Function.Injective fun i ↦
+      MulOpposite.op (a i) • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ)))
+    (f : F) : heckeSlashSum k D ⇑f = ∑ i, ⇑f ∣[k] a i :=
+  heckeSlashSum_eq_sum_of_rightCosets k D a hcover hinj ⇑f fun _ hγ ↦
+    ModularForm.slash_eq_of_mem_map_mapGL
+      (fun γ' hγ' ↦ SlashInvariantFormClass.slash_action_eq f γ' hγ') hγ
+
+end Form
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
@@ -71,8 +71,8 @@ The proof is Shimura's — right multiplication by `γ` permutes the summands �
 is `MulAction.toPerm` applied to `γ⁻¹`, acting on the right-coset index `Γ₂ ⧸ (Γ₂ ∩ δ⁻¹Γ₁δ)`.
 
 ⚠ This proves invariance of the sum formed from the representatives `D.out` and `v.out` that
-`heckeSlashSum` fixes. It does **not** state that sums formed from *different* choices of
-representatives agree; that would be a separate theorem, and none is available yet. -/
+`heckeSlashSum` fixes. That sums formed from *different* choices of representatives agree is a
+separate theorem, `heckeSlashSum_eq_sum_of_rightCosets` in `HeckeSlash/Independence.lean`. -/
 theorem heckeSlashSum_slash_invariant (f : ℍ → ℂ) (hf : ∀ δ ∈ Γ₁, f ∣[k] δ = f)
     {γ : GL (Fin 2) ℚ} (hγ : γ ∈ Γ₂) :
     heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f := by

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
@@ -80,9 +80,10 @@ theorem heckeSlashSum_slash_invariant (f : ℍ → ℂ) (hf : ∀ δ ∈ Γ₁, 
   have hperm (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
       (f ∣[k] rightCosetRep D v) ∣[k] γ =
         f ∣[k] rightCosetRep D ((⟨γ, hγ⟩ : Γ₂)⁻¹ • v) := by
-    rw [← SlashAction.slash_mul k (rightCosetRep D v) γ f, rightCosetRep_def D v,
-      show (D.out : GL (Fin 2) ℚ) * ((v.out : GL (Fin 2) ℚ))⁻¹ * γ =
-        (D.out : GL (Fin 2) ℚ) * (γ⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹ from by group,
+    -- `δ τᵥ⁻¹ γ = δ (γ⁻¹ τᵥ)⁻¹`: the right-hand factor is again the inverse of an element of `Γ₂`.
+    have hmul : (D.out : GL (Fin 2) ℚ) * ((v.out : GL (Fin 2) ℚ))⁻¹ * γ =
+        (D.out : GL (Fin 2) ℚ) * (γ⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹ := by group
+    rw [← SlashAction.slash_mul k (rightCosetRep D v) γ f, rightCosetRep_def D v, hmul,
       slash_rightCosetRep_of_mem_right k D (mul_mem (inv_mem hγ) v.out.2) f hf]
     exact congrArg (f ∣[k] rightCosetRep D ·)
       (MulAction.Quotient.mk_smul_out _ (⟨γ, hγ⟩ : Γ₂)⁻¹ v)

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Invariance.lean
@@ -8,36 +8,38 @@ module
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Reindex
 
 /-!
-# The slash sum is `SL₂(ℤ)`-invariant
+# The slash sum of a `Γ₁`-invariant function is `Γ₂`-invariant
 
 `heckeSlashSum` is a sum over *chosen* coset representatives, and `HeckeSlash/Basic.lean` records
 that on a general `f : ℍ → ℂ` the value depends on those choices. This file proves the theorem
-that repairs it: if `f` is invariant under the weight-`k` slash action of `SL₂(ℤ)`, then so is
-`heckeSlashSum k D f`.
+that repairs it: if `f` is invariant under the weight-`k` slash action of `Γ₁`, then
+`heckeSlashSum k D f` is invariant under that of `Γ₂`.
 
-That is the content of the proof of Shimura's Proposition 3.37 — right multiplication by
-`γ ∈ SL₂(ℤ)` merely **permutes** the representatives, so the sum is unchanged. The permutation is
-`MulAction.toPerm` for the action of `SL₂(ℤ)` on `DecompQuotient`, and the per-summand step is
-`slash_transposeRep_of_mem_SLnZ` from `HeckeSlash/Reindex.lean`.
+That is the content of Shimura's Proposition 3.37 — right multiplication by `γ ∈ Γ₂` merely
+**permutes** the right cosets `Γ₁ aᵥ` of the decomposition, so the sum is unchanged. Concretely
+`aᵥ γ = δ τᵥ⁻¹ γ = δ (γ⁻¹ τᵥ)⁻¹`, so the permutation is `v ↦ γ⁻¹ • v` for the action of `Γ₂` on
+`Γ₂ ⧸ (Γ₂ ∩ δ⁻¹Γ₁δ)` — `MulAction.toPerm` at `γ⁻¹` — and the per-summand step is
+`slash_rightCosetRep_of_mem_right` from `HeckeSlash/Reindex.lean`.
+
+⚠ The two groups are different: the hypothesis is invariance under `Γ₁` and the conclusion is
+invariance under `Γ₂`. They agree on a diagonal triple `HeckeCoset Δ Γ Γ`, which is where the
+Hecke operators of Layer 2(b) live, but nothing here needs them to.
 
 ## Main results
 
-* `HeckeRing.GL2.heckeSlashSum_slash_invariant_of_mem_SLnZ`: for `γ ∈ SL₂(ℤ)` and
-  slash-invariant `f`, `heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f`.
-* `HeckeRing.GL2.heckeSlashSumFormₗ`: the slash sum as a `ℂ`-linear operator on
-  `SlashInvariantForm`.
+* `HeckeRing.GL2.heckeSlashSum_slash_invariant`: for `γ ∈ Γ₂` and `Γ₁`-invariant `f`,
+  `heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f`.
 
 ## Provenance
 
-Ported from the AINTLIB `LeanModularForms` project
-([`LeanModularForms/HeckeRIngs/GL2/HeckeAction.lean`](https://github.com/CBirkbeck/AINTLIB),
-commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), lines 198–224:
-`tRep_mul_eq_transpose` and `heckeSlash_slash_invariant`.
-
-Restated against TauCeti's `SLnZ`/`posDetInt` Hecke pair and `transposeGLEquiv`. As in
-`Reindex.lean`, the invariance hypothesis is carried at `SLnZ 2` under the rational slash action
-rather than routed through the real `𝒮ℒ`, so AINTLIB's `mem_SL_exists_H` bridge — which opens its
-proof — is not needed here and the statement quantifies over `γ ∈ SLnZ 2` directly.
+The statement corresponds to `heckeSlash_slash_invariant` in the AINTLIB `LeanModularForms`
+project ([`LeanModularForms/HeckeRIngs/GL2/HeckeAction.lean`](https://github.com/CBirkbeck/AINTLIB),
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), lines 198–246,
+together with its helper `tRep_mul_eq_transpose`. No code is transcribed: that proof permutes a
+*left*-coset index by transposing, so it holds only where every group in sight is transpose-stable
+— level one — while the argument below is Shimura's own and quantifies over `γ ∈ Γ₂` at an
+arbitrary triple. As in `Reindex.lean`, invariance is carried under the rational slash action
+rather than routed through a real subgroup, so AINTLIB's `mem_SL_exists_H` bridge is not needed.
 
 ## References
 
@@ -53,70 +55,41 @@ open scoped MatrixGroups ModularForm
 
 namespace HeckeRing.GL2
 
-variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+variable (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)} {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
+  (D : HeckeCoset Δ Γ₁ Γ₂) [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
 
--- Right multiplication of a representative by `γ` is the transpose of left multiplication by
--- `γᵀ`, which is what turns the reindexing lemma into a permutation of the index type.
-private lemma transposeRep_mul (i : DecompQuotient (SLnZ 2) (SLnZ 2) D.out) (γ : GL (Fin 2) ℚ) :
-    transposeRep D i * γ = (transposeGLEquiv 2 ((transposeGLEquiv 2 γ).unop *
-      (i.out : GL (Fin 2) ℚ) * (D.out : GL (Fin 2) ℚ))).unop := by
-  simp [transposeRep_def, map_mul, MulOpposite.unop_mul, transposeGLEquiv_transposeGLEquiv,
-    mul_assoc]
+/-- The enumeration the reindexing argument needs, chosen exactly as in `HeckeSlash/Basic.lean`
+so that the two `∑`s are the same term. -/
+noncomputable local instance : Fintype (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :=
+  Fintype.ofFinite _
 
-/-- **The slash sum of a slash-invariant function is again slash-invariant.** For `f` invariant
-under the weight-`k` slash action of `SL₂(ℤ)` and `γ ∈ SL₂(ℤ)`,
+/-- **The slash sum of a `Γ₁`-invariant function is `Γ₂`-invariant.** For `f` invariant under the
+weight-`k` slash action of `Γ₁` and `γ ∈ Γ₂`,
 `heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f`.
 
 The proof is Shimura's — right multiplication by `γ` permutes the summands — and the permutation
-is `MulAction.toPerm` applied to `γᵀ`, the transpose appearing because the representatives are
-transposed.
+is `MulAction.toPerm` applied to `γ⁻¹`, acting on the right-coset index `Γ₂ ⧸ (Γ₂ ∩ δ⁻¹Γ₁δ)`.
 
-⚠ This proves invariance of the sum formed from the representatives `D.out` and `i.out` that
+⚠ This proves invariance of the sum formed from the representatives `D.out` and `v.out` that
 `heckeSlashSum` fixes. It does **not** state that sums formed from *different* choices of
 representatives agree; that would be a separate theorem, and none is available yet. -/
-theorem heckeSlashSum_slash_invariant_of_mem_SLnZ (f : ℍ → ℂ) (hf : ∀ δ ∈ SLnZ 2, f ∣[k] δ = f)
-    {γ : GL (Fin 2) ℚ} (hγ : γ ∈ SLnZ 2) :
+theorem heckeSlashSum_slash_invariant (f : ℍ → ℂ) (hf : ∀ δ ∈ Γ₁, f ∣[k] δ = f)
+    {γ : GL (Fin 2) ℚ} (hγ : γ ∈ Γ₂) :
     heckeSlashSum k D f ∣[k] γ = heckeSlashSum k D f := by
-  have hγT : (transposeGLEquiv 2 γ).unop ∈ SLnZ 2 := transposeGLEquiv_mem_SLnZ 2 hγ
-  -- Slashing the `i`-th summand by `γ` gives the summand at the permuted index.
-  have hperm (i : DecompQuotient (SLnZ 2) (SLnZ 2) D.out) :
-      (f ∣[k] transposeRep D i) ∣[k] γ =
-        f ∣[k] transposeRep D ((⟨_, hγT⟩ : SLnZ 2) • i) := by
-    rw [← SlashAction.slash_mul k (transposeRep D i) γ f, transposeRep_mul, ← mul_one
-      ((⟨_, hγT⟩ : SLnZ 2) * (i.out : GL (Fin 2) ℚ) * (D.out : GL (Fin 2) ℚ)),
-      slash_transposeRep_of_mem_SLnZ k D (mul_mem hγT i.out.2) (one_mem _) f hf]
-    exact congrArg (f ∣[k] transposeRep D ·)
-      (MulAction.Quotient.mk_smul_out _ (⟨_, hγT⟩ : SLnZ 2) i)
+  -- Slashing the `v`-th summand by `γ` gives the summand at the permuted index.
+  have hperm (v : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) :
+      (f ∣[k] rightCosetRep D v) ∣[k] γ =
+        f ∣[k] rightCosetRep D ((⟨γ, hγ⟩ : Γ₂)⁻¹ • v) := by
+    rw [← SlashAction.slash_mul k (rightCosetRep D v) γ f, rightCosetRep_def D v,
+      show (D.out : GL (Fin 2) ℚ) * ((v.out : GL (Fin 2) ℚ))⁻¹ * γ =
+        (D.out : GL (Fin 2) ℚ) * (γ⁻¹ * (v.out : GL (Fin 2) ℚ))⁻¹ from by group,
+      slash_rightCosetRep_of_mem_right k D (mul_mem (inv_mem hγ) v.out.2) f hf]
+    exact congrArg (f ∣[k] rightCosetRep D ·)
+      (MulAction.Quotient.mk_smul_out _ (⟨γ, hγ⟩ : Γ₂)⁻¹ v)
   rw [heckeSlashSum_def, SlashAction.sum_slash]
-  -- `MulAction.toPerm` of the transposed `γ` is the reindexing bijection. Its compatibility
-  -- hypothesis is `hperm` up to `toPerm_apply`, which is stated rather than left to defeq.
-  exact Fintype.sum_equiv (MulAction.toPerm (⟨_, hγT⟩ : SLnZ 2)) _ _ fun i ↦ by
-    simpa only [MulAction.toPerm_apply] using hperm i
-
-/-- The double-coset slash sum as a `ℂ`-linear operator on `SlashInvariantForm`. -/
-noncomputable def heckeSlashSumFormₗ : SlashInvariantForm 𝒮ℒ k →ₗ[ℂ] SlashInvariantForm 𝒮ℒ k where
-  toFun f :=
-    SlashInvariantForm.mk (heckeSlashSum k D ⇑f) fun γ hγ ↦ by
-      obtain ⟨σ, rfl⟩ := MonoidHom.mem_range.mp hγ
-      have hSLnZ : (mapGL ℚ σ : GL (Fin 2) ℚ) ∈ SLnZ 2 := coe_mem_SLnZ 2 σ
-      rw [← map_mapGL (S := ℚ) (T := ℝ) σ, ← ModularForm.rat_slash]
-      exact heckeSlashSum_slash_invariant_of_mem_SLnZ k D (⇑f) (γ := mapGL ℚ σ)
-        (fun g hg ↦ SlashInvariantFormClass.slash_eq_of_mem_SLnZ f g hg) hSLnZ
-  map_add' f g := SlashInvariantForm.ext fun τ ↦ by
-    simp only [SlashInvariantForm.coe_mk, FunLike.coe_add]
-    exact congrFun (heckeSlashSum_add k D ⇑f ⇑g) τ
-  map_smul' c f := SlashInvariantForm.ext fun τ ↦ by
-    simp only [SlashInvariantForm.coe_mk, FunLike.coe_smul]
-    exact congrFun (heckeSlashSum_smul k D
-      (det_transposeRep_pos D (SLnZ_le_glpos 2) (posDetInt_le_glpos 2 D.out.2)) c ⇑f) τ
-
-@[simp]
-lemma coe_heckeSlashSumFormₗ (f : SlashInvariantForm 𝒮ℒ k) :
-    ⇑(heckeSlashSumFormₗ k D f) = heckeSlashSum k D ⇑f := (rfl)
-
-/-- Pointwise evaluation of `heckeSlashSumFormₗ`. -/
-@[simp]
-lemma heckeSlashSumFormₗ_apply (f : SlashInvariantForm 𝒮ℒ k) (τ : ℍ) :
-    heckeSlashSumFormₗ k D f τ = heckeSlashSum k D (⇑f) τ := (rfl)
+  -- `MulAction.toPerm` of `γ⁻¹` is the reindexing bijection. Its compatibility hypothesis is
+  -- `hperm` up to `toPerm_apply`, which is stated rather than left to defeq.
+  exact Fintype.sum_equiv (MulAction.toPerm (⟨γ, hγ⟩ : Γ₂)⁻¹) _ _ fun v ↦ by
+    simpa only [MulAction.toPerm_apply] using hperm v
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Cusps
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Form
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Holomorphic
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Independence
 
 /-!
 # The slash sum descends to modular forms and to cusp forms
@@ -48,6 +49,11 @@ statements and are not proved here.
 
 * `HeckeRing.GL2.coe_heckeSlashModularFormEnd`, `HeckeRing.GL2.coe_heckeSlashCuspFormEnd`: both
   are `heckeSlashSum` on underlying functions.
+* `HeckeRing.GL2.coe_heckeSlashModularFormEnd_eq_sum`,
+  `HeckeRing.GL2.coe_heckeSlashCuspFormEnd_eq_sum`: both are the sum of the slashes over *any*
+  decomposition of the double coset into right cosets, so neither depends on the representatives
+  it is assembled from. This is `heckeSlashSum_coe_eq_sum_of_rightCosets`
+  (`HeckeSlash/Independence.lean`) read off the two endomorphisms.
 
 ## Provenance
 
@@ -69,7 +75,7 @@ public section
 
 open Matrix Matrix.SpecialLinearGroup UpperHalfPlane DoubleCoset HeckeRing.GLn
 
-open scoped MatrixGroups ModularForm
+open scoped MatrixGroups ModularForm Pointwise
 
 namespace HeckeRing.GL2
 
@@ -146,6 +152,33 @@ noncomputable def heckeSlashCuspFormEnd :
 @[simp] lemma coe_heckeSlashCuspFormEnd (f : CuspForm (G.map (mapGL ℝ)) k) :
     ⇑(heckeSlashCuspFormEnd k D hD f) = heckeSlashSum k D f :=
   coe_heckeSlashCuspForm k D hD f
+
+/-- **The operator on modular forms is the sum over any decomposition of the double coset into
+right cosets**: if the right cosets `G aᵢ` are pairwise distinct and cover the double coset, then
+`heckeSlashModularFormEnd k D hD f = ∑ᵢ f ∣[k] aᵢ`. So it is attached to the double coset, not to
+the representatives `heckeSlashSum` is assembled from; the choice-independence itself is
+`heckeSlashSum_coe_eq_sum_of_rightCosets` (`HeckeSlash/Independence.lean`). -/
+lemma coe_heckeSlashModularFormEnd_eq_sum {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ)
+    (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) (G.map (mapGL ℚ)) (G.map (mapGL ℚ)) =
+      ⋃ i, MulOpposite.op (a i) • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ)))
+    (hinj : Function.Injective fun i ↦
+      MulOpposite.op (a i) • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ)))
+    (f : ModularForm (G.map (mapGL ℝ)) k) :
+    ⇑(heckeSlashModularFormEnd k D hD f) = ∑ i, ⇑f ∣[k] a i :=
+  (coe_heckeSlashModularFormEnd k D hD f).trans
+    (heckeSlashSum_coe_eq_sum_of_rightCosets k D a hcover hinj f)
+
+/-- **The operator on cusp forms is the sum over any decomposition of the double coset into right
+cosets**, exactly as for modular forms. -/
+lemma coe_heckeSlashCuspFormEnd_eq_sum {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ)
+    (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) (G.map (mapGL ℚ)) (G.map (mapGL ℚ)) =
+      ⋃ i, MulOpposite.op (a i) • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ)))
+    (hinj : Function.Injective fun i ↦
+      MulOpposite.op (a i) • (G.map (mapGL ℚ) : Set (GL (Fin 2) ℚ)))
+    (f : CuspForm (G.map (mapGL ℝ)) k) :
+    ⇑(heckeSlashCuspFormEnd k D hD f) = ∑ i, ⇑f ∣[k] a i :=
+  (coe_heckeSlashCuspFormEnd k D hD f).trans
+    (heckeSlashSum_coe_eq_sum_of_rightCosets k D a hcover hinj f)
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -12,48 +12,52 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Holomorphic
 /-!
 # The slash sum descends to modular forms and to cusp forms
 
-`Form.lean` bundles the double coset as an endomorphism of `SlashInvariantForm 𝒮ℒ k`, and flags
-that this is *not* the roadmap's Layer 2(b) target because holomorphy and the cusp conditions are
-not yet carried along. This file supplies exactly that: the two remaining structure fields.
+`Form.lean` bundles the double coset as an endomorphism of
+`SlashInvariantForm (G.map (mapGL ℝ)) k`, and flags that this is *not* the roadmap's Layer 2(b)
+target because holomorphy and the cusp conditions are not yet carried along. This file supplies
+exactly that: the two remaining structure fields.
 
 Invariance comes from `heckeSlashEnd`, holomorphy from `mdifferentiable_heckeSlashSum`, and
 boundedness at the cusps from `isBoundedAt_heckeSlashSum`. Because `heckeSlashEnd` is not
 `@[expose]`, a structure field's `.toFun` does not reduce to the coercion by itself, so each
 such field names the coercion form with `change`, then rewrites by `coe_heckeSlashEnd`.
-The cusp-form case is then *derived* from the modular-form one, adding only
-`zero_at_cusps'`, so neither invariance nor holomorphy is proved twice.
+The cusp-form case is then *derived* from the modular-form one, adding only `zero_at_cusps'`,
+so neither invariance nor holomorphy is proved twice.
 
 Both maps are also bundled as `Module.End ℂ`, which is the form Hecke operators are consumed in:
 bundling is what lets them compose and later carry a ring structure.
 
-The level here is `𝒮ℒ`, which carries mathlib's `Subgroup.IsArithmetic` instance — the hypothesis
-the two cusp lemmas need. Descending further to `Γ₁(N)` is a separate step.
+## The level, and what it has to satisfy
+
+`G` is any subgroup of `SL(2, ℤ)` whose image `G.map (mapGL ℝ)` is arithmetic — the hypothesis
+the two cusp lemmas need, and one `(Gamma1 N).map (mapGL ℝ)` carries through
+`CongruenceSubgroup.instFiniteIndexGamma1` once `N ≠ 0`. **This is the roadmap's Layer 2(b)
+statement**: at `G = Γ₁(N)` and `Δ = Δ₀(N)` the endomorphisms below are the Hecke operators of a
+double coset acting on `M_k(Γ₁(N))` and on `S_k(Γ₁(N))`, for an arbitrary double coset of the
+Hecke triple, with no divisibility condition relating the level and the determinant. The
+`q`-expansion recurrences that identify particular cosets with the classical `Tₙ` are separate
+statements and are not proved here.
 
 ## Main definitions
 
-* `HeckeRing.GL2.heckeSlashModularFormEnd`: the double coset as a `ℂ`-linear endomorphism of
-  `ModularForm 𝒮ℒ k`.
-* `HeckeRing.GL2.heckeSlashCuspFormEnd`: the same on `CuspForm 𝒮ℒ k`, which is the statement that
-  **the action preserves cuspidality**.
-
-The unbundled constructors behind them are private; the bundled operators are the interface,
-since composition is what the Hecke ring will consume.
+* `HeckeRing.GL2.heckeSlashModularFormEnd`: the operator on `ModularForm (G.map (mapGL ℝ)) k`.
+* `HeckeRing.GL2.heckeSlashCuspFormEnd`: the operator on `CuspForm (G.map (mapGL ℝ)) k` — the
+  statement that the action preserves cuspidality.
 
 ## Main results
 
-* `HeckeRing.GL2.coe_heckeSlashModularFormEnd`, `coe_heckeSlashCuspFormEnd`: both endomorphisms
+* `HeckeRing.GL2.coe_heckeSlashModularFormEnd`, `HeckeRing.GL2.coe_heckeSlashCuspFormEnd`: both
   are `heckeSlashSum` on underlying functions.
 
 ## Provenance
 
-Shape ported from the AINTLIB `LeanModularForms` project
-([`LeanModularForms/HeckeRIngs/GL2/AdjointTheory.lean`](https://github.com/CBirkbeck/AINTLIB),
-commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), lines 102-105:
-`heckeT_p_cusp`, which assembles a `CuspForm` as `{ heckeT_p … with zero_at_cusps' := … }`. The
-assembly is the same; the operator differs, since this repository's `heckeSlashSum` is the general
-double-coset sum rather than `T_p`, and the level is `𝒮ℒ` rather than `Γ₁(N)`. AINTLIB's
-`CuspForm.toModularForm'` (line 51) is not ported: mathlib already supplies the coercion, as the
-`CoeTC` instance of `ModularFormClass` (`Mathlib/NumberTheory/ModularForms/Basic.lean`).
+The shape corresponds to `heckeSlashModularForm`, `heckeSlashCuspForm` and their bundlings in the
+AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GL2/HeckeAction.lean`](https://github.com/CBirkbeck/AINTLIB),
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck). No code is
+transcribed, and the level is a general `G` rather than `SL₂(ℤ)`. AINTLIB's
+`CuspForm.toModularForm'` is not ported: mathlib already supplies the coercion, as the `CoeTC`
+instance of `ModularFormClass` (`Mathlib/NumberTheory/ModularForms/Basic.lean`).
 
 ## References
 
@@ -63,78 +67,85 @@ double-coset sum rather than `T_p`, and the level is `𝒮ℒ` rather than `Γ�
 
 public section
 
-open UpperHalfPlane DoubleCoset HeckeRing.GLn
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane DoubleCoset HeckeRing.GLn
 
 open scoped MatrixGroups ModularForm
 
 namespace HeckeRing.GL2
 
-variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+variable {G : Subgroup SL(2, ℤ)} (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)}
+  (D : HeckeCoset Δ (G.map (mapGL ℚ)) (G.map (mapGL ℚ)))
+  [Finite (DecompQuotient (G.map (mapGL ℚ)) (G.map (mapGL ℚ)) (D.out : GL (Fin 2) ℚ)⁻¹)]
+  [(G.map (mapGL ℝ)).IsArithmetic]
+  (hD : (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ)
 
 /-- **The double coset acting on modular forms.** Invariance is `heckeSlashEnd`, holomorphy is
 `mdifferentiable_heckeSlashSum`, and boundedness at the cusps is `isBoundedAt_heckeSlashSum`.
 The public interface is the bundled `heckeSlashModularFormEnd`. -/
-private noncomputable def heckeSlashModularForm (f : ModularForm 𝒮ℒ k) : ModularForm 𝒮ℒ k where
-  toSlashInvariantForm := heckeSlashEnd k D f.toSlashInvariantForm
+private noncomputable def heckeSlashModularForm (f : ModularForm (G.map (mapGL ℝ)) k) :
+    ModularForm (G.map (mapGL ℝ)) k where
+  toSlashInvariantForm := heckeSlashEnd k D hD f.toSlashInvariantForm
   holo' := by
     rw [coe_heckeSlashEnd]; exact mdifferentiable_heckeSlashSum k D f.holo'
   -- `heckeSlashEnd` is unexposed, so the field's `.toFun` does not reduce to the coercion on
   -- its own; `change` names the coercion form, after which `coe_heckeSlashEnd` applies.
   bdd_at_cusps' := fun {c} hc ↦ by
-    change c.IsBoundedAt (⇑(heckeSlashEnd k D f.toSlashInvariantForm)) k
+    change c.IsBoundedAt (⇑(heckeSlashEnd k D hD f.toSlashInvariantForm)) k
     rw [coe_heckeSlashEnd]
     exact isBoundedAt_heckeSlashSum k D (fun _ h ↦ f.bdd_at_cusps' h) hc
 
-private lemma coe_heckeSlashModularForm (f : ModularForm 𝒮ℒ k) :
-    ⇑(heckeSlashModularForm k D f) = heckeSlashSum k D f :=
-  coe_heckeSlashEnd k D f.toSlashInvariantForm
+private lemma coe_heckeSlashModularForm (f : ModularForm (G.map (mapGL ℝ)) k) :
+    ⇑(heckeSlashModularForm k D hD f) = heckeSlashSum k D f :=
+  coe_heckeSlashEnd k D hD f.toSlashInvariantForm
 
 /-- **The double coset acting on cusp forms** — the action preserves cuspidality. Only the
 vanishing field is new: invariance and holomorphy come from `heckeSlashModularForm` at the
 underlying modular form, so neither is proved twice. -/
-private noncomputable def heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) : CuspForm 𝒮ℒ k :=
-  { heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k) with
+private noncomputable def heckeSlashCuspForm (f : CuspForm (G.map (mapGL ℝ)) k) :
+    CuspForm (G.map (mapGL ℝ)) k :=
+  { heckeSlashModularForm k D hD (f : ModularForm (G.map (mapGL ℝ)) k) with
     zero_at_cusps' := fun {c} hc ↦ by
-      change c.IsZeroAt (⇑(heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k))) k
+      change c.IsZeroAt
+        (⇑(heckeSlashModularForm k D hD (f : ModularForm (G.map (mapGL ℝ)) k))) k
       rw [coe_heckeSlashModularForm]
       exact isZeroAt_heckeSlashSum k D (fun _ h ↦ f.zero_at_cusps' h) hc }
 
-private lemma coe_heckeSlashCuspForm (f : CuspForm 𝒮ℒ k) :
-    ⇑(heckeSlashCuspForm k D f) = heckeSlashSum k D f :=
-  coe_heckeSlashModularForm k D (f : ModularForm 𝒮ℒ k)
+private lemma coe_heckeSlashCuspForm (f : CuspForm (G.map (mapGL ℝ)) k) :
+    ⇑(heckeSlashCuspForm k D hD f) = heckeSlashSum k D f :=
+  coe_heckeSlashModularForm k D hD (f : ModularForm (G.map (mapGL ℝ)) k)
 
-/-- **The double coset as a `ℂ`-linear endomorphism of `ModularForm 𝒮ℒ k`.** This is the form
-Hecke operators are consumed in: bundling is what lets them compose and later carry a ring
-structure. -/
-noncomputable def heckeSlashModularFormEnd : Module.End ℂ (ModularForm 𝒮ℒ k) where
-  toFun := heckeSlashModularForm k D
+/-- **The double coset as a `ℂ`-linear endomorphism of `ModularForm (G.map (mapGL ℝ)) k`.** This
+is the form Hecke operators are consumed in: bundling is what lets them compose and later carry a
+ring structure. At `G = Γ₁(N)` this is the roadmap's Layer 2(b) operator. -/
+noncomputable def heckeSlashModularFormEnd :
+    Module.End ℂ (ModularForm (G.map (mapGL ℝ)) k) where
+  toFun := heckeSlashModularForm k D hD
   map_add' f g := by ext τ; simp [coe_heckeSlashModularForm, heckeSlashSum_add]
   map_smul' c f := by
     ext τ
     simp [coe_heckeSlashModularForm,
-      heckeSlashSum_smul k D
-      (det_transposeRep_pos D (SLnZ_le_glpos 2) (posDetInt_le_glpos 2 D.out.2))]
+      heckeSlashSum_smul k D (det_rightCosetRep_pos D (ModularForm.map_mapGL_le_glpos G) hD)]
 
-/-- **The double coset as a `ℂ`-linear endomorphism of `CuspForm 𝒮ℒ k`** — the action preserves
-cuspidality. -/
-noncomputable def heckeSlashCuspFormEnd : Module.End ℂ (CuspForm 𝒮ℒ k) where
-  toFun := heckeSlashCuspForm k D
+/-- **The double coset as a `ℂ`-linear endomorphism of `CuspForm (G.map (mapGL ℝ)) k`** — the
+action preserves cuspidality. -/
+noncomputable def heckeSlashCuspFormEnd :
+    Module.End ℂ (CuspForm (G.map (mapGL ℝ)) k) where
+  toFun := heckeSlashCuspForm k D hD
   map_add' f g := by ext τ; simp [coe_heckeSlashCuspForm, heckeSlashSum_add]
   map_smul' c f := by
     ext τ
     simp [coe_heckeSlashCuspForm,
-      heckeSlashSum_smul k D
-      (det_transposeRep_pos D (SLnZ_le_glpos 2) (posDetInt_le_glpos 2 D.out.2))]
+      heckeSlashSum_smul k D (det_rightCosetRep_pos D (ModularForm.map_mapGL_le_glpos G) hD)]
 
 /-- The endomorphism is `heckeSlashSum` on underlying functions. -/
-@[simp] lemma coe_heckeSlashModularFormEnd (f : ModularForm 𝒮ℒ k) :
-    ⇑(heckeSlashModularFormEnd k D f) = heckeSlashSum k D f :=
-  coe_heckeSlashModularForm k D f
+@[simp] lemma coe_heckeSlashModularFormEnd (f : ModularForm (G.map (mapGL ℝ)) k) :
+    ⇑(heckeSlashModularFormEnd k D hD f) = heckeSlashSum k D f :=
+  coe_heckeSlashModularForm k D hD f
 
 /-- The endomorphism is `heckeSlashSum` on underlying functions. -/
-@[simp] lemma coe_heckeSlashCuspFormEnd (f : CuspForm 𝒮ℒ k) :
-    ⇑(heckeSlashCuspFormEnd k D f) = heckeSlashSum k D f :=
-  coe_heckeSlashCuspForm k D f
+@[simp] lemma coe_heckeSlashCuspFormEnd (f : CuspForm (G.map (mapGL ℝ)) k) :
+    ⇑(heckeSlashCuspFormEnd k D hD f) = heckeSlashSum k D f :=
+  coe_heckeSlashCuspForm k D hD f
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
@@ -8,63 +8,63 @@ module
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Basic
 
 /-!
-# Reindexing the slash sum: slashing by any element of a left coset
+# Reindexing the slash sum: slashing by any element of a double coset
 
-`heckeSlashSum` sums `f ∣[k] (σᵢ δ)ᵀ` over the left-coset decomposition of `HδH`. To show that
-sum is unchanged by right multiplication — the statement that turns the sum into an operator,
-and the proof of Shimura's Proposition 3.37 — one needs to know that the summand depends only on
-the *coset* of `σᵢ`, not on the representative chosen, once `f` is slash-invariant.
+`heckeSlashSum` sums `f ∣[k] (δ τᵥ⁻¹)` over the decomposition of `Γ₁ δ Γ₂` into right cosets
+`Γ₁ aᵥ`. To show that sum is unchanged by right multiplication — the statement that turns the sum
+into an operator, and the proof of Shimura's Proposition 3.37 — one needs to know that the
+summand depends only on the *coset*, not on the representative chosen, once `f` is
+slash-invariant.
 
-That is what this file proves. For `h₁, h₂ ∈ H`,
+That is what this file proves. For `h₁ ∈ Γ₁` and `h₂ ∈ Γ₂`,
 
-`f ∣[k] (h₁ δ h₂)ᵀ = f ∣[k] transposeRep D ⟦h₁⟧`,
+`f ∣[k] (h₁ δ h₂⁻¹) = f ∣[k] rightCosetRep D ⟦h₂⟧`,
 
-so an arbitrary element `h₁ δ h₂` of the double coset slashes exactly like the chosen
-representative of `h₁`'s class.
+so an arbitrary element `h₁ δ h₂⁻¹` of the double coset slashes exactly like the chosen
+representative of `h₂`'s class. Every element of `Γ₁ δ Γ₂` has this shape, `Γ₂` being a group.
 
 ## Why slash-invariance of `f` is needed, and where
 
-Transposition turns left multiplication into right multiplication, so changing the
-representative multiplies the transposed element **on the left** by a transposed element of
-`H`. Slashing is a right action, so that extra factor does not simply cancel: it survives as
-`f ∣[k] hᵀ`, and only vanishes because `f` is invariant under `H` — which is exactly the
-hypothesis `hf`. Without it the sum genuinely depends on the choice, as `HeckeSlash/Basic.lean`'s
-module docstring records.
+Two representatives of the same right coset differ by a factor of `Γ₁` on the **left**. Slashing
+is a right action, so that factor does not simply cancel: it survives as `f ∣[k] γ₁`, and only
+vanishes because `f` is invariant under `Γ₁` — which is exactly the hypothesis `hf` below, used
+once, in the last step.
+
+Concretely, if `u` is the chosen representative of `⟦h₂⟧` then `δ (u⁻¹ h₂) δ⁻¹ ∈ Γ₁`
+(`DoubleCoset.conj_mem_of_mk_eq`, the conjugation criterion for the stabiliser
+`Γ₂ ∩ δ⁻¹Γ₁δ` indexing the quotient), and
+
+`h₁ δ h₂⁻¹ = (h₁ · (δ (u⁻¹ h₂) δ⁻¹)⁻¹) · (δ u⁻¹)`
+
+exhibits the left factor as an element of `Γ₁` and the right one as `rightCosetRep D ⟦h₂⟧`.
 
 ## Main results
 
-* `HeckeRing.GL2.slash_transposeRep_of_mem_SLnZ`: slashing by the transpose of `h₁ δ h₂` agrees
-  with slashing by the representative attached to `h₁`.
+* `HeckeRing.GL2.slash_rightCosetRep_of_mem`: the displayed identity.
+* `HeckeRing.GL2.slash_rightCosetRep_of_mem_right`: its `h₁ = 1` case, the form the invariance
+  proof consumes.
 
 ## Provenance
 
-Ported from the AINTLIB `LeanModularForms` project
+The statement corresponds to `slash_left_H_transpose_mul`, `transpose_decomp_eq` and
+`slash_tRep_of_mem` in the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/HeckeAction.lean`](https://github.com/CBirkbeck/AINTLIB),
-commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), lines 154–196:
-`slash_left_H_transpose_mul`, `h_coset_mem_H`, `transpose_decomp_eq` and `slash_tRep_of_mem`.
-Restated against TauCeti's `SLnZ` / `posDetInt` Hecke pair, `DoubleCoset.DecompQuotient`,
-`transposeGLEquiv` and `transposeRep`, rather than AINTLIB's `GL_pair`, `decompQuot`,
-`GL_transposeEquiv` and `tRep`. AINTLIB's `h_coset_mem_H` is not reproduced as a declaration: this
-repository already owns exactly that statement as `DoubleCoset.conj_mem_of_mk_eq`, which is what
-the proof below calls.
-
-One deliberate deviation: the slash-invariance hypothesis is carried at `SLnZ 2` under the
-rational slash action, rather than routed through the real `𝒮ℒ`. AINTLIB's
-`slash_left_H_transpose_mul` crosses that bridge with a helper (`glMap_mem_SL`); here the
-membership is already rational, so `transposeGLEquiv_mem_SLnZ` applies directly and that helper
-is unnecessary. No claim is made about AINTLIB's other bridging helper `mem_SL_exists_H`, which
-is used only by the invariance block that follows the ported range.
+commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), lines 154–196. No
+code is transcribed: those declarations reindex a sum over *left* cosets and pay for it with a
+transpose, which confines them to `SL₂(ℤ)`, whereas the identity below is Shimura's own
+right-coset step and holds at an arbitrary triple. AINTLIB's `h_coset_mem_H` has no counterpart
+either: this repository already owns exactly that statement as
+`DoubleCoset.conj_mem_of_mk_eq`, which is what the proof below calls.
 
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
   §3.4 *Action of double cosets on automorphic forms*, Proposition 3.37.
 
-Shimura states the result this file supports inside the proof of Proposition 3.37: "Let `α ∈ Γ₂`.
-Then `{Γ₁ aᵥ α}` coincides with `{Γ₁ aᵥ}` as a whole", from which `g ∣[α]ₖ = g` for
-`g = f ∣[Γ₁ α Γ₂]ₖ`. He needs no transpose, because his decomposition `Γ₁ α Γ₂ = ⊔ᵥ Γ₁ aᵥ` puts
-the group on the left already; the transpose here is an artefact of the handedness Mathlib's
-`DecompQuotient` supplies, not of the mathematics.
+Shimura states the result this file supports inside the proof of Proposition 3.37: "Let
+`α ∈ Γ₂`. Then `{Γ₁ aᵥ α}` coincides with `{Γ₁ aᵥ}` as a whole", from which `g ∣[α]ₖ = g` for
+`g = f ∣[Γ₁ α Γ₂]ₖ`. Knowing that a given element of the double coset slashes like the chosen
+representative of its coset is what makes that comparison of *sets* into a comparison of *sums*.
 -/
 
 public section
@@ -75,55 +75,47 @@ open scoped MatrixGroups ModularForm
 
 namespace HeckeRing.GL2
 
-variable (k : ℤ) (D : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+variable (k : ℤ) {Δ : Submonoid (GL (Fin 2) ℚ)} {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
+  (D : HeckeCoset Δ Γ₁ Γ₂)
 
--- A transposed element of `H` on the left of a slash is absorbed by slash-invariance. This is the
--- single point at which `hf` enters the file — the "where" of the section above — which is why it
--- is named rather than inlined at its one call site.
---
--- Mathlib does not name this step: it open-codes the same composition inside
--- `SlashInvariantForm.translate` and `SlashInvariantForm.quotientFunc`. That convention does not
--- transfer here, because both of those carry invariance in a `[SlashInvariantFormClass F Γ k]`
--- instance and so recover it in one typeclass call at each site, whereas `hf` is a bare
--- hypothesis threaded through a three-step argument.
-private lemma slash_transpose_mul_of_mem_SLnZ {h : GL (Fin 2) ℚ} (hh : h ∈ SLnZ 2)
-    (g : GL (Fin 2) ℚ) (f : ℍ → ℂ) (hf : ∀ γ ∈ SLnZ 2, f ∣[k] γ = f) :
-    f ∣[k] ((transposeGLEquiv 2 h).unop * g) = f ∣[k] g := by
-  rw [SlashAction.slash_mul, hf _ (transposeGLEquiv_mem_SLnZ 2 hh)]
+/-- **An arbitrary element `h₁ δ h₂⁻¹` of the double coset slashes like the representative
+attached to `h₂`'s class.** For `h₁ ∈ Γ₁`, `h₂ ∈ Γ₂` and `f` invariant under the weight-`k` slash
+action of `Γ₁`, `f ∣[k] (h₁ δ h₂⁻¹) = f ∣[k] rightCosetRep D ⟦h₂⟧`, where `δ = D.out`.
 
--- Splitting `(h₁ δ h₂)ᵀ` as the correction factor's transpose times the chosen representative.
-private lemma transposeGLEquiv_eq_mul_transposeRep (q : DecompQuotient (SLnZ 2) (SLnZ 2) D.out)
-    (h₁ h₂ : GL (Fin 2) ℚ) : (transposeGLEquiv 2 (h₁ * ↑D.out * h₂)).unop =
-      (transposeGLEquiv 2 ((D.out : GL (Fin 2) ℚ)⁻¹ * ((q.out : GL (Fin 2) ℚ)⁻¹ * h₁) * ↑D.out *
-        h₂)).unop * transposeRep D q := by
-  -- Transposition is an anti-homomorphism, so the two `δ`s meet in the middle and cancel.
-  -- `transposeRep` has no exposed body in a module file, so its characteristic equation
-  -- `transposeRep_def` is the only way in; `simp [transposeRep]` and `unfold` both fail here.
-  simp [transposeRep_def, ← MulOpposite.unop_mul, ← map_mul, mul_assoc]
+`hh₂` is part of the statement rather than a side condition: the right-hand side slashes by
+`rightCosetRep D ⟦⟨h₂, hh₂⟩⟧`, a class built from `hh₂`. Membership is a `Prop`, so any proof of
+`h₂ ∈ Γ₂` names the same class. Note that `hf` is invariance under the *rational* slash action,
+not one routed through a real subgroup.
 
-/-- **An arbitrary element `h₁ δ h₂` of the double coset slashes like the representative attached
-to `h₁`'s class.** For `h₁, h₂ ∈ H` and `f` invariant under the weight-`k` slash action of
-`H = SLnZ 2`, `f ∣[k] (h₁ δ h₂)ᵀ = f ∣[k] transposeRep D ⟦h₁⟧`, where `δ = D.out`.
+This is the per-summand step behind Shimura's Proposition 3.37 (§3.4). The statement that right
+multiplication permutes the summands of `heckeSlashSum` without changing the sum is a separate
+argument, in `HeckeSlash/Invariance.lean`. Mathlib's `SlashInvariantForm.quotientFunc_mk` is the
+single-subgroup analogue, with no double coset. -/
+lemma slash_rightCosetRep_of_mem {h₁ h₂ : GL (Fin 2) ℚ} (hh₁ : h₁ ∈ Γ₁) (hh₂ : h₂ ∈ Γ₂)
+    (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+    f ∣[k] (h₁ * (D.out : GL (Fin 2) ℚ) * h₂⁻¹) =
+      f ∣[k] rightCosetRep D ⟦⟨h₂, hh₂⟩⟧ := by
+  -- Make the chosen representative `u` of `⟦h₂⟧` visible, then name it.
+  rw [rightCosetRep_def]
+  set u : GL (Fin 2) ℚ :=
+    (((⟦⟨h₂, hh₂⟩⟧ : DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹).out :
+      Γ₂) : GL (Fin 2) ℚ) with hu
+  -- `u` and `h₂` have the same class, so `δ (u⁻¹ h₂) δ⁻¹` lies in `Γ₁`.
+  have hconj : (D.out : GL (Fin 2) ℚ) * (u⁻¹ * h₂) * (D.out : GL (Fin 2) ℚ)⁻¹ ∈ Γ₁ := by
+    rw [hu]
+    simpa using conj_mem_of_mk_eq ((D.out : GL (Fin 2) ℚ)⁻¹) (Quotient.out_eq _)
+  -- Split off that factor on the left; what is left is the chosen representative.
+  rw [show h₁ * (D.out : GL (Fin 2) ℚ) * h₂⁻¹ =
+      (h₁ * ((D.out : GL (Fin 2) ℚ) * (u⁻¹ * h₂) * (D.out : GL (Fin 2) ℚ)⁻¹)⁻¹) *
+        ((D.out : GL (Fin 2) ℚ) * u⁻¹) from by group,
+    SlashAction.slash_mul, hf _ (mul_mem hh₁ (inv_mem hconj))]
 
-`hh₁` is part of the statement rather than a side condition: the right-hand side slashes by
-`transposeRep D ⟦⟨h₁, hh₁⟩⟧`, a class built from `hh₁`. Membership is a `Prop`, so any proof of
-`h₁ ∈ SLnZ 2` names the same class. Narrowing `hf` does not help: when `h₁` is the chosen
-representative of its own class the absorbed factor is exactly `h₂ᵀ`, so quantifying over `h₂`
-already reaches every element of `SLnZ 2`. Note also that `hf` is invariance under the *rational*
-slash action, not one routed through the real `𝒮ℒ`.
-
-This is the per-summand step behind Shimura's Proposition 3.37 (§3.4). The statement
-that right multiplication permutes the summands of `heckeSlashSum` without changing the sum is a
-separate argument, which is not formalised here. Mathlib's `SlashInvariantForm.quotientFunc_mk`
-is the single-subgroup analogue, with no double coset and no transpose. -/
-lemma slash_transposeRep_of_mem_SLnZ {h₁ h₂ : GL (Fin 2) ℚ} (hh₁ : h₁ ∈ SLnZ 2) (hh₂ : h₂ ∈ SLnZ 2)
-    (f : ℍ → ℂ) (hf : ∀ γ ∈ SLnZ 2, f ∣[k] γ = f) :
-    f ∣[k] (transposeGLEquiv 2 (h₁ * ↑D.out * h₂)).unop = f ∣[k] transposeRep D ⟦⟨h₁, hh₁⟩⟧ := by
-  rw [transposeGLEquiv_eq_mul_transposeRep D ⟦⟨h₁, hh₁⟩⟧ h₁ h₂]
-  -- The leftover factor lies in `H`: `Quotient.out_eq` says the chosen representative of `⟦h₁⟧`
-  -- is in `h₁`'s own class, and `conj_mem_of_mk_eq` turns that class equality into the
-  -- conjugated membership in one step.
-  exact slash_transpose_mul_of_mem_SLnZ k
-    (mul_mem (conj_mem_of_mk_eq _ (Quotient.out_eq _)) hh₂) _ f hf
+/-- The `h₁ = 1` case of `slash_rightCosetRep_of_mem`: slashing by `δ h₂⁻¹` agrees with slashing
+by the chosen representative of `h₂`'s class. This is the form the invariance proof consumes,
+where the element being compared already arises as `δ τᵥ⁻¹ γ = δ (γ⁻¹ τᵥ)⁻¹`. -/
+lemma slash_rightCosetRep_of_mem_right {h₂ : GL (Fin 2) ℚ} (hh₂ : h₂ ∈ Γ₂) (f : ℍ → ℂ)
+    (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+    f ∣[k] ((D.out : GL (Fin 2) ℚ) * h₂⁻¹) = f ∣[k] rightCosetRep D ⟦⟨h₂, hh₂⟩⟧ := by
+  simpa using slash_rightCosetRep_of_mem k D (one_mem Γ₁) hh₂ f hf
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Reindex.lean
@@ -105,10 +105,10 @@ lemma slash_rightCosetRep_of_mem {h₁ h₂ : GL (Fin 2) ℚ} (hh₁ : h₁ ∈ 
     rw [hu]
     simpa using conj_mem_of_mk_eq ((D.out : GL (Fin 2) ℚ)⁻¹) (Quotient.out_eq _)
   -- Split off that factor on the left; what is left is the chosen representative.
-  rw [show h₁ * (D.out : GL (Fin 2) ℚ) * h₂⁻¹ =
+  have hsplit : h₁ * (D.out : GL (Fin 2) ℚ) * h₂⁻¹ =
       (h₁ * ((D.out : GL (Fin 2) ℚ) * (u⁻¹ * h₂) * (D.out : GL (Fin 2) ℚ)⁻¹)⁻¹) *
-        ((D.out : GL (Fin 2) ℚ) * u⁻¹) from by group,
-    SlashAction.slash_mul, hf _ (mul_mem hh₁ (inv_mem hconj))]
+        ((D.out : GL (Fin 2) ℚ) * u⁻¹) := by group
+  rw [hsplit, SlashAction.slash_mul, hf _ (mul_mem hh₁ (inv_mem hconj))]
 
 /-- The `h₁ = 1` case of `slash_rightCosetRep_of_mem`: slashing by `δ h₂⁻¹` agrees with slashing
 by the chosen representative of `h₂`'s class. This is the form the invariance proof consumes,

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
@@ -39,7 +39,7 @@ is the congruence condition `p ∣ N` that makes the upper-triangular representa
 The cusp conditions ask for `Subgroup.IsArithmetic` on the level, which `(Gamma1 N).map (mapGL ℝ)`
 carries through `CongruenceSubgroup.instFiniteIndexGamma1` once `N ≠ 0`. Invariance is carried
 rationally throughout `UpperTri/Invariance.lean`, so the one place the `ℚ`/`ℝ` bridge is needed
-is `rat_slash_mapGL` below.
+is `ModularForm.rat_slash_mapGL`, from `ModularForms/SlashActionRat.lean`.
 
 ## Main definitions
 
@@ -77,19 +77,12 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ} (k : ℤ)
 
-/-- The `ℚ`/`ℝ` bridge for the slash by an integral matrix: the rational action in which
-`UpperTri/Invariance.lean` is stated agrees with the real action in which `SlashInvariantForm`
-is indexed. -/
-private lemma rat_slash_mapGL (F : ℍ → ℂ) (δ : SL(2, ℤ)) :
-    F ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = F ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) := by
-  rw [ModularForm.rat_slash, map_mapGL]
-
 /-- Slash-invariance of a form at level `Γ₁(N)`, transported to the rational action — the
 hypothesis `UpperTri/Invariance.lean` asks for. -/
 private lemma rat_slash_eq_of_mem_Gamma1 {F : Type*} [FunLike F ℍ ℂ]
     [SlashInvariantFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (f : F) {δ : SL(2, ℤ)}
     (hδ : δ ∈ Gamma1 N) : (⇑f) ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = ⇑f := by
-  rw [rat_slash_mapGL]
+  rw [ModularForm.rat_slash_mapGL]
   exact SlashInvariantFormClass.slash_action_eq f _ (Subgroup.mem_map_of_mem _ hδ)
 
 /-- The width of `∞` for `Γ₁(N)` is `1`, so all `q`-expansions below are taken at width `1`. -/
@@ -112,7 +105,7 @@ private noncomputable def heckeSlashUpperTriModularForm (hpN : p ∣ N)
   slash_action_eq' γ hγ := by
     obtain ⟨δ, hδ, rfl⟩ := Subgroup.mem_map.mp hγ
     let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
-    rw [← rat_slash_mapGL]
+    rw [← ModularForm.rat_slash_mapGL]
     exact heckeSlashUpperTri_slash_mapGL_of_mem_Gamma1 k hpN hδ
       fun _ hε ↦ rat_slash_eq_of_mem_Gamma1 k f hε
   holo' := mdifferentiable_heckeSlashUpperTri k p (ModularFormClass.holo f)
@@ -179,9 +172,9 @@ theorem heckeSlashUpperTriModularFormEnd_mem_modFormCharSpace (hpN : p ∣ N)
   let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
   rw [mem_modFormCharSpace_iff_nebentypus] at hf ⊢
   intro g
-  rw [coe_heckeSlashUpperTriModularFormEnd, ← rat_slash_mapGL]
+  rw [coe_heckeSlashUpperTriModularFormEnd, ← ModularForm.rat_slash_mapGL]
   exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hpN χ g
-    fun δ ↦ by rw [rat_slash_mapGL]; exact hf δ
+    fun δ ↦ by rw [ModularForm.rat_slash_mapGL]; exact hf δ
 
 /-- **The operator preserves the nebentypus on cusp forms**: it maps `S_k(N, χ)` into itself. -/
 theorem heckeSlashUpperTriCuspFormEnd_mem_cuspFormCharSpace (hpN : p ∣ N)
@@ -191,9 +184,9 @@ theorem heckeSlashUpperTriCuspFormEnd_mem_cuspFormCharSpace (hpN : p ∣ N)
   let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
   rw [mem_cuspFormCharSpace_iff_nebentypus] at hf ⊢
   intro g
-  rw [coe_heckeSlashUpperTriCuspFormEnd, ← rat_slash_mapGL]
+  rw [coe_heckeSlashUpperTriCuspFormEnd, ← ModularForm.rat_slash_mapGL]
   exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hpN χ g
-    fun δ ↦ by rw [rat_slash_mapGL]; exact hf δ
+    fun δ ↦ by rw [ModularForm.rat_slash_mapGL]; exact hf δ
 
 /-- **The `q`-expansion recurrence**: the coefficient at `m` is `a_{p m}(f)` for `p ∣ N`.
 When `p` is prime, this is the Diamond–Shurman recurrence

--- a/TauCeti/NumberTheory/ModularForms/SlashActionRat.lean
+++ b/TauCeti/NumberTheory/ModularForms/SlashActionRat.lean
@@ -50,6 +50,11 @@ cross, rather than in any module about particular matrices.
   positive-determinant rational matrix, with no `σ` twist.
 * `ModularForm.map_ratCast_mem_SL`, `ModularForm.exists_mem_SLnZ_of_mem_SL`: the two directions
   of the `SLnZ 2` / `𝒮ℒ` correspondence.
+* `ModularForm.rat_slash_mapGL`: the rational slash at `mapGL ℚ σ` is the real slash at
+  `mapGL ℝ σ`, and `ModularForm.slash_eq_of_mem_map_mapGL`,
+  `ModularForm.slash_eq_of_mem_map_mapGL_real`: the two directions of slash-invariance under
+  the images of a subgroup `G ≤ SL₂(ℤ)` in `GL(2, ℚ)` and in `GL(2, ℝ)`, together with
+  `ModularForm.map_mapGL_le_glpos`.
 * `ModularForm.slash_eq_of_mem_SLnZ`: real slash-invariance under `𝒮ℒ` gives rational
   slash-invariance under `SLnZ 2`.
 * `UpperHalfPlane.IsBoundedAtImInfty.rat_slash`, `UpperHalfPlane.IsZeroAtImInfty.rat_slash`: the
@@ -173,6 +178,45 @@ lemma slash_eq_of_mem_SLnZ (k : ℤ) {f : ℍ → ℂ} (hf : ∀ γ ∈ 𝒮ℒ,
     (hδ : δ ∈ SLnZ 2) : f ∣[k] δ = f := by
   rw [rat_slash]
   exact hf _ (map_ratCast_mem_SL hδ)
+
+/-- **The `ℚ`/`ℝ` bridge for the slash by an integral matrix**: the rational action at
+`mapGL ℚ σ` is the real action at `mapGL ℝ σ`. Both are ranges of `mapGL` out of the same
+`SL(2, ℤ)`, and mathlib's `Matrix.SpecialLinearGroup.map_mapGL` relates them along `ℤ → ℚ → ℝ`.
+
+This is the one lemma needed to state a hypothesis rationally and consume it at a level
+`G.map (mapGL ℝ)`, or the other way about. -/
+lemma rat_slash_mapGL (k : ℤ) (f : ℍ → ℂ) (σ : SL(2, ℤ)) :
+    f ∣[k] (mapGL ℚ σ : GL (Fin 2) ℚ) = f ∣[k] (mapGL ℝ σ : GL (Fin 2) ℝ) := by
+  rw [rat_slash, map_mapGL]
+
+/-- Real slash-invariance under the image of `G ≤ SL₂(ℤ)` in `GL(2, ℝ)` — the way a level is
+spelled for `SlashInvariantForm` — gives rational slash-invariance under its image in
+`GL(2, ℚ)`, which is the way the Hecke triples of `HeckeRing/GL2/` are spelled.
+`slash_eq_of_mem_SLnZ` is the case `G = ⊤`, written with the ranges `SLnZ 2` and `𝒮ℒ` that the
+level-one development uses. -/
+lemma slash_eq_of_mem_map_mapGL {k : ℤ} {G : Subgroup SL(2, ℤ)} {f : ℍ → ℂ}
+    (hf : ∀ γ ∈ G.map (mapGL ℝ), f ∣[k] γ = f) {δ : GL (Fin 2) ℚ}
+    (hδ : δ ∈ G.map (mapGL ℚ)) : f ∣[k] δ = f := by
+  obtain ⟨σ, hσ, rfl⟩ := Subgroup.mem_map.mp hδ
+  rw [rat_slash_mapGL]
+  exact hf _ (Subgroup.mem_map_of_mem _ hσ)
+
+/-- The converse of `slash_eq_of_mem_map_mapGL`: rational slash-invariance under the image of
+`G ≤ SL₂(ℤ)` in `GL(2, ℚ)` gives real slash-invariance under its image in `GL(2, ℝ)`. This is
+the direction that discharges the `slash_action_eq'` field of a `SlashInvariantForm`. -/
+lemma slash_eq_of_mem_map_mapGL_real {k : ℤ} {G : Subgroup SL(2, ℤ)} {f : ℍ → ℂ}
+    (hf : ∀ δ ∈ G.map (mapGL ℚ), f ∣[k] δ = f) {γ : GL (Fin 2) ℝ}
+    (hγ : γ ∈ G.map (mapGL ℝ)) : f ∣[k] γ = f := by
+  obtain ⟨σ, hσ, rfl⟩ := Subgroup.mem_map.mp hγ
+  rw [← rat_slash_mapGL]
+  exact hf _ (Subgroup.mem_map_of_mem _ hσ)
+
+/-- The image of `G ≤ SL₂(ℤ)` in `GL(2, ℚ)` consists of matrices of determinant `1`, so it lies
+in `GLPos`. This is the hypothesis `det_rightCosetRep_pos` asks of the flanking group. -/
+lemma map_mapGL_le_glpos (G : Subgroup SL(2, ℤ)) :
+    G.map (mapGL ℚ) ≤ Matrix.GLPos (Fin 2) ℚ := by
+  rintro _ ⟨σ, -, rfl⟩
+  exact SLnZ_le_glpos 2 ((mem_SLnZ_iff 2).mpr ⟨σ, rfl⟩)
 
 end ModularForm
 


### PR DESCRIPTION
This PR reorients the double-coset slash sum onto Shimura's own decomposition of `Γ₁δΓ₂` into **right** cosets `Γ₁aᵥ`, and delivers the operators that decomposition was always meant to produce: `ℂ`-linear endomorphisms of `ModularForm ((Gamma1 N).map (mapGL ℝ)) k` and `CuspForm ((Gamma1 N).map (mapGL ℝ)) k` attached to an arbitrary double coset of the Hecke triple `(Γ₁(N), Δ₀(N))`. That is the ModularForms roadmap's **Layer 2(b), "the action on forms"** — the roadmap's own `STATUS.md` names "Hecke operators on forms" as the frontier and records that "Layers 3 to 7 are all downstream of this one target".

The obstruction being removed is recorded, at length, in the file it blocked. `HeckeSlash/Basic.lean` indexed the sum by Mathlib's `DoubleCoset.DecompQuotient Γ₁ Γ₂ δ`, which enumerates **left** cosets `σᵢδΓ₂`, and repaired the handedness a right action needs by transposing each representative. Its docstring then had to explain that the transposed representatives are cosets of `Γ₂ᵀ`, that the construction is Shimura's operator only when both flanks are transpose-stable *and* transposition fixes the double coset, and that a congruence subgroup is not transpose-stable — `!![1, 1; 0, 1] ∈ Γ₁(N)` for every `N` while its transpose lies in `Γ₁(N)` only when `N = 1`, and `Γ₁(N)ᵀ = Γ¹(N)`. Every downstream file was therefore pinned to `𝒮ℒ`, and the docstring flagged that "anything that wants the latter must first reconcile that orientation". This PR reconciles it the way the file suggested: by avoiding the transpose altogether.

Shimura decomposes `Γ₁αΓ₂ = ⊔ᵥ Γ₁aᵥ` — the group on the left — because right multiplication by `γ ∈ Γ₂` permutes right cosets, which is the whole proof of his Proposition 3.37. Mathlib supplies the mirror quotient already: `Γ₁δτ = Γ₁δτ'` exactly when `τ'τ⁻¹ ∈ Γ₂ ∩ δ⁻¹Γ₁δ`, so `DecompQuotient Γ₂ Γ₁ δ⁻¹ = Γ₂ ⧸ (Γ₂ ∩ δ⁻¹Γ₁δ)` is the right-coset index, with `rightCosetRep D v = δ·τᵥ⁻¹` (the inverse converts a quotient by left cosets into an index for right ones), and `v ↦ γ⁻¹ • v` is the permutation. `HeckeRing/Basic.lean` gains the two facts that make this honest — `doubleCoset_eq_iUnion_rightCosets` and `op_mul_out_inv_smul_injective`, the mirrors of the existing `doubleCoset_eq_iUnion_leftCosets` and `mk_out_mul_injective`, so the representatives provably run over the right cosets exactly once — together with `IsHeckeTriple.commensurable_conjAct_inv_left` and the `Finite` instance it gives that index, the mirror of the existing `Fintype` instance. Nothing needs transpose-stability, so `Basic`, `Reindex`, `Invariance`, `Cusps`, `Holomorphic`, `Form` and `ModularForm` are now all stated at an arbitrary triple: `slash_rightCosetRep_of_mem` says an arbitrary `h₁δh₂⁻¹` slashes like the representative of `h₂`'s class, `heckeSlashSum_slash_invariant` says a `Γ₁`-invariant `f` has a `Γ₂`-invariant slash sum, and `heckeSlashModularFormEnd`/`heckeSlashCuspFormEnd` bundle the descent at any level `G.map (mapGL ℝ)` for `G ≤ SL(2, ℤ)` with arithmetic image. `HeckeSlash/Gamma1.lean` instantiates that at `G = Γ₁(N)`, `Δ = Δ₀(N)`, discharging the one remaining hypothesis (`Δ₀(N) ≤ posDetInt 2`, so no double coset of this triple has a representative of non-positive determinant).

The old code is replaced, not kept alongside, per the repository's no-back-compatibility rule: `transposeRep`, `det_transposeRep_pos`, `transposeRep_mem_posDetInt`, `slash_transposeRep_of_mem_SLnZ` and `heckeSlashSum_slash_invariant_of_mem_SLnZ` are gone, their statements superseded by the general ones under the `rightCosetRep` names. Two pre-existing duplicates go with them: `heckeSlashSumFormₗ` (`Invariance.lean`) and `heckeSlashEnd` (`Form.lean`) were the same `SlashInvariantForm →ₗ[ℂ] SlashInvariantForm` under two names, so only `heckeSlashEnd` survives; and the private `rat_slash_mapGL` of `UpperTri/ModularForm.lean` is promoted to `ModularForm.rat_slash_mapGL` in `SlashActionRat.lean`, which also gains `slash_eq_of_mem_map_mapGL`, its `_real` converse and `map_mapGL_le_glpos` — the `ℚ`/`ℝ` bridge at a general `G ≤ SL(2, ℤ)` rather than only at `𝒮ℒ`. The `Γ₁(N)` Hecke triple instance in `HeckeRing/GL2/Gamma1.lean` is restated at `(Gamma1 N).map (mapGL ℚ)` instead of the sealed abbreviation `Gamma1Image N`, because instance search unfolds neither and the unfolded spelling is the one a level-`N` modular form presents.

`HeckeSlash/Independence.lean` closes the loop the sum leaves open: for a `Γ₁`-invariant `f`, `heckeSlashSum_eq_sum_of_rightCosets` says `heckeSlashSum k D f = ∑ᵢ f ∣[k] aᵢ` for *any* family `(aᵢ)` whose right cosets `Γ₁ aᵢ` are pairwise distinct and cover `Γ₁ δ Γ₂` — precisely what `doubleCoset_eq_iUnion_rightCosets` and `op_mul_out_inv_smul_injective` supply, so the chosen `D.out` and `v.out` are one admissible family among many and every other gives the same function. `heckeSlashSum_eq_sum_of_mem_doubleCoset` reads off the change of double-coset representative, and `heckeSlashSum_coe_eq_sum_of_rightCosets` discharges the invariance hypothesis for any `SlashInvariantFormClass` at level `G.map (mapGL ℝ)`, which is how `HeckeSlash/ModularForm.lean`'s `coe_heckeSlashModularFormEnd_eq_sum` and `coe_heckeSlashCuspFormEnd_eq_sum` characterise the two exported endomorphisms without reference to any representative. The one place invariance is used is `slash_eq_of_rightCoset_eq`: slashing an invariant function depends only on the right coset.

No mathematics is weakened or specialised to reach this: every statement here is strictly more general than the one it replaces, and the level-one case is recovered at `G = ⊤`. What remains in Layer 2(b) after this PR is the identification of *particular* cosets with the classical operators — the normalisation lemma pinning `Γ₁(N)·diag(1, p)·Γ₁(N)` to the classical `Tₚ`, the `q`-expansion recurrence `aₘ(Tₚf) = a_{mp}(f) + χ(p)p^{k−1}a_{m/p}(f)` at `p ∤ N` (the `p ∣ N` case is already in, via `HeckeSlash/UpperTri/`), preservation of the nebentypus spaces `M_k(N, χ)`, and the ring homomorphism `𝕋 (Gamma0_pair N) ℤ →+* Module.End ℂ (modFormCharSpace k χ)`.

The construction and its algebraic API correspond to `heckeSlash`, `heckeSlash_slash_invariant`, `heckeSlashInvariant`, `heckeSlashModularForm` and `heckeSlashCuspForm` in the AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`); no code is transcribed, since AINTLIB is the transposed left-coset development this PR replaces, and each file records that in its own provenance block.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke-double-coset-action-on-modular-forms"}-->

🤖 Prepared with Claude Code

