### PR TITLE
feat: preserve diagonalizability under closed subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/ClosedSubgroup.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.EssentialImage
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.Bialgebra.GroupLike.Map
+
+/-!
+# Closed subgroups of diagonalizable affine groups
+
+A finite-type commutative Hopf algebra over a field is the coordinate algebra of a
+diagonalizable group exactly when its group-like elements span it. This condition passes to a
+Hopf quotient: the quotient morphism is surjective and sends every group-like element to a
+group-like element, so the images of the original spanning family span the quotient.
+
+Contravariantly, a Hopf ideal cuts out a closed subgroup of the represented affine group. Thus
+the main result is the coordinate-algebra form of the fact that every closed subgroup of a
+diagonalizable affine group is diagonalizable.
+
+## Main declarations
+
+* `TauCeti.DiagonalizableGroup.groupLikeSpannedProperty.of_surjective`: a surjective morphism of
+  finite-type commutative Hopf algebras preserves the diagonalizable coordinate property.
+* `TauCeti.DiagonalizableGroup.groupLikeSpannedProperty.quotient`: every Hopf quotient of a
+  diagonalizable coordinate algebra is again diagonalizable.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Theorem 12.9.
+
+This advances Layer 4, "Diagonalizable groups and groups of multiplicative type", of the
+ReductiveGroups roadmap. It also supplies the closed-subgroup classification used in Layer 6 to
+show that smooth unipotent closed subgroups of tori are trivial, on the way to proving that tori
+are reductive.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+namespace DiagonalizableGroup.groupLikeSpannedProperty
+
+variable (k : Type u) [Field k]
+
+/-- A surjective morphism of finite-type commutative Hopf algebras preserves spanning by
+group-like elements. Contravariantly, this is closure of diagonalizable affine groups under
+closed subgroups presented by a surjective coordinate morphism. -/
+theorem of_surjective (H K : FiniteTypeCommHopfAlgCat.{u, u} k) (f : H ⟶ K)
+    (hf : Function.Surjective (FiniteTypeCommHopfAlgCat.toBialgHom f))
+    (hH : DiagonalizableGroup.groupLikeSpannedProperty k H) :
+    DiagonalizableGroup.groupLikeSpannedProperty k K := by
+  rw [DiagonalizableGroup.groupLikeSpannedProperty_iff] at hH ⊢
+  exact GroupLike.groupLikeSetSpan_eq_top_of_surjective
+    (FiniteTypeCommHopfAlgCat.toBialgHom f) hf hH
+
+/-- Every Hopf quotient of a finite-type diagonalizable coordinate algebra is again a
+diagonalizable coordinate algebra. Contravariantly, every closed subgroup cut out by a Hopf ideal
+in a diagonalizable affine group is diagonalizable. -/
+theorem quotient (H : FiniteTypeCommHopfAlgCat.{u, u} k) (I : HopfIdeal k H)
+    (hH : DiagonalizableGroup.groupLikeSpannedProperty k H) :
+    DiagonalizableGroup.groupLikeSpannedProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I) := by
+  apply of_surjective k H (FiniteTypeCommHopfAlgCat.quotient H I)
+    (FiniteTypeCommHopfAlgCat.mkQuotient H I) _ hH
+  exact CommHopfAlgCat.mkQuotient_surjective H.obj I
+
+end DiagonalizableGroup.groupLikeSpannedProperty
+
+end TauCeti

--- a/TauCeti/Algebra/Bialgebra/GroupLike/Map.lean
+++ b/TauCeti/Algebra/Bialgebra/GroupLike/Map.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.RingTheory.Bialgebra.Equiv
 public import Mathlib.RingTheory.Bialgebra.GroupLike
 public import TauCeti.Algebra.Coalgebra.GroupLike.Map
+public import TauCeti.Algebra.Coalgebra.Subcoalgebra.GroupLike
 
 /-!
 # Functoriality of group-like elements
@@ -19,6 +20,8 @@ bialgebra equivalence induces a multiplicative equivalence of group-like element
 ## Main declarations
 
 * `TauCeti.GroupLike.map`: the homomorphism on group-like elements induced by a bialgebra map.
+* `TauCeti.GroupLike.groupLikeSetSpan_eq_top_of_surjective`: a surjective bialgebra map preserves
+  spanning by group-like elements.
 * `TauCeti.GroupLike.mapEquiv`: the equivalence induced by a bialgebra equivalence.
 -/
 
@@ -60,6 +63,36 @@ theorem map_comp {C : Type*} [Semiring C] [Bialgebra R C]
     map (g.comp f) = (map g).comp (map f) := by
   ext x
   rfl
+
+/-- A surjective bialgebra morphism preserves spanning by group-like elements. -/
+theorem groupLikeSetSpan_eq_top_of_surjective (f : A →ₐc[R] B)
+    (hf : Function.Surjective f)
+    (hA : Subcoalgebra.groupLikeSetSpan (R := R) (C := A) Set.univ = ⊤) :
+    Subcoalgebra.groupLikeSetSpan (R := R) (C := B) Set.univ = ⊤ := by
+  rw [Subcoalgebra.groupLikeSetSpan_eq_top_iff_span_eq_top] at hA ⊢
+  apply top_unique
+  intro b _
+  obtain ⟨a, rfl⟩ := hf b
+  have ha : a ∈ Submodule.span R
+      (Set.range (_root_.GroupLike.val (R := R) (A := A))) := by
+    rw [hA]
+    trivial
+  apply Submodule.span_induction (R := R) (M := A)
+      (s := Set.range (_root_.GroupLike.val (R := R) (A := A)))
+      (p := fun x _ ↦ f x ∈ Submodule.span R
+        (Set.range (_root_.GroupLike.val (R := R) (A := B))))
+      (x := a)
+  · intro x hx
+    obtain ⟨g, rfl⟩ := hx
+    exact Submodule.subset_span ⟨map f g, by simp⟩
+  · simp
+  · intro x y _ _ hx hy
+    rw [map_add]
+    exact Submodule.add_mem _ hx hy
+  · intro r x _ hx
+    rw [map_smul]
+    exact Submodule.smul_mem _ r hx
+  · exact ha
 
 /-- A bialgebra equivalence induces a multiplicative equivalence of group-like elements. -/
 def mapEquiv (e : A ≃ₐc[R] B) :


### PR DESCRIPTION
This PR establishes that closed subgroups of diagonalizable affine groups remain diagonalizable in the coordinate-Hopf-algebra model. It proves the general reusable fact that a surjective bialgebra morphism preserves spanning by group-like elements, then applies it to every finite-type Hopf quotient.

The exact roadmap target is `ReductiveGroups/README.md`, Layer 4, “Diagonalizable groups and groups of multiplicative type,” with the quotient theorem supplying the closed-subgroup classification needed by the Layer 6 “Reductive and semisimple groups” milestone to prove that tori are reductive. After this PR, it remains to use smoothness of a candidate unipotent subgroup to rule out the nonreduced diagonalizable cases and then apply semisimple–unipotent rigidity.

The proof works at the natural generality of bialgebras over a commutative semiring and uses the existing intrinsic characterization of diagonalizable coordinate algebras by their group-like span. The application stays in the finite-type commutative Hopf category used by the reductive predicate.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"closed-subgroups-diagonalizable"}-->

Targeted builds, the changed-declaration axiom audit, and the changed-module lint environment pass.

🤖 Prepared with Codex
