### PR TITLE
feat(HeckeSlash): the diagonal coset representative, and the upper-triangular sum augmented by it

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -141,12 +141,15 @@ noncomputable def upperTriRep (b : Fin p) : GL (Fin 2) ℚ :=
     (↑(upperTriRep p b) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 :=
   upperTriGL_apply_eq_zero_of_lt (fun i ↦ by fin_cases i <;> simp [b.pos]) _ (by decide)
 
-/-- **The remaining coset representative** `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`.
+/-- **The diagonal representative** `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`.
 
-For `p ∤ N` the double coset of `diag(1, p)` has `p + 1` left cosets, not `p`: the `p`
-upper-triangular ones `upperTriRep p b` and this one. It is diagonal, hence upper triangular,
-so it satisfies the same `(1, 0) = 0` hypothesis that mathlib's `IsBoundedAtImInfty.slash`
-asks for — the whole `p + 1`-term sum stays inside that machinery. -/
+For a **prime** `p ∤ N` the double coset of `diag(1, p)` has `p + 1` left cosets: the `p`
+upper-triangular ones `upperTriRep p b` and this one. That count is primality-specific — at a
+composite `p` the triangular decomposition has `∑_{d ∣ p} d` representatives, seven at `p = 4` —
+so nothing here claims a coset decomposition for general `p`.
+
+It is diagonal, hence upper triangular, so it satisfies the same `(1, 0) = 0` hypothesis that
+mathlib's `IsBoundedAtImInfty.slash` asks for, for every `p`. -/
 noncomputable def diagRep : GL (Fin 2) ℚ :=
   natDiagGL 2 ![p, 1]
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -161,16 +161,23 @@ noncomputable def diagRep : GL (Fin 2) ℚ :=
   fin_cases i <;> fin_cases j <;> simp [diagRep, natDiagGL_coe 2 ![p, 1] ha]
 
 /-- **The remaining representative is upper triangular too** — being diagonal, its `(1, 0)`
-entry vanishes, which is the hypothesis `IsBoundedAtImInfty.slash` asks for. -/
-@[simp] lemma diagRep_apply_one_zero (hp : 0 < p) :
-    (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 := by
-  simp [coe_diagRep p hp]
+entry vanishes, which is the hypothesis `IsBoundedAtImInfty.slash` asks for.
 
-/-- The remaining representative has positive determinant: `det !![p, 0; 0, 1] = p > 0`. -/
-lemma det_diagRep_pos (hp : 0 < p) :
-    0 < (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ).det := by
-  have ha : ∀ i : Fin 2, 0 < ![p, 1] i := fun i ↦ by fin_cases i <;> simp [hp]
-  simpa [diagRep] using natDiagGL_det_pos 2 ![p, 1] ha
+Unconditional in `p`: at `p = 0` the positivity condition fails and `natDiagGL` takes its junk
+value `1`, whose off-diagonal entries also vanish. -/
+@[simp] lemma diagRep_apply_one_zero :
+    (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 := by
+  by_cases hp : 0 < p
+  · simp [coe_diagRep p hp]
+  · have ha : ¬ ∀ i : Fin 2, 0 < ![p, 1] i := fun h ↦ hp (by simpa using h 0)
+    simp [diagRep, natDiagGL_of_not_pos 2 ha]
+
+/-- The remaining representative has positive determinant. Unconditional in `p`: this is the
+`posDetInt` membership `natDiagGL_mem_posDetInt`, which already covers the junk branch, rather
+than a fresh derivation from `natDiagGL_det_pos`. -/
+lemma det_diagRep_pos :
+    0 < (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ).det :=
+  ((mem_posDetInt_iff 2).mp (natDiagGL_mem_posDetInt 2 ![p, 1])).2
 
 /-- The representatives have positive determinant: `det !![1, b; 0, p] = p > 0`. -/
 lemma det_upperTriRep_pos (b : Fin p) :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.NumberTheory.HeckeRing.GLn.CosetDecomposition
 
 /-!
-# The upper-triangular entry assignments at `n = 2`
+# The `T_p` coset representatives at `n = 2`
 
 `GLn/CosetDecomposition.lean` indexes the upper-triangular coset representatives by the bounded
 entry assignments `UpperTriEntries n a`, a dependent function on the ordered index pairs
@@ -21,6 +21,10 @@ It is the adapter between the general-`n` decomposition and the classical `T_p` 
 which sums over `b` directly: a sum over `UpperTriEntries 2 ![1, p]` transfers along this
 equivalence rather than being restated.
 
+Alongside the upper-triangular family this file records the remaining representative,
+`diagRep p = !![p, 0; 0, 1]`, so that both families and the two facts every slash argument needs
+of them — upper-triangularity and positive determinant — sit together.
+
 Nothing here involves a level or a congruence subgroup; the level-`N` membership statements for
 these representatives are in `GL2/UpperTriangularDelta0.lean`.
 
@@ -30,6 +34,7 @@ these representatives are in `GL2/UpperTriangularDelta0.lean`.
 * `HeckeRing.GL2.upperTriEntriesEquiv`: `UpperTriEntries 2 a ≃ Fin (a 1 / a 0)`, for an
   arbitrary tuple `a`.
 * `HeckeRing.GL2.upperTriEntriesEquivFin`: its specialisation `UpperTriEntries 2 ![1, p] ≃ Fin p`.
+* `HeckeRing.GL2.diagRep`: the diagonal representative `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`.
 
 ## Main results
 
@@ -47,6 +52,12 @@ these representatives are in `GL2/UpperTriangularDelta0.lean`.
 * `HeckeRing.GL2.det_upperTriRep_pos`: they have determinant `p > 0`, which is what lets scalars
   pass through a slash by them without the `σ` twist.
 
+* `HeckeRing.GL2.coe_diagRep`: the entrywise description of the diagonal representative, for
+  `0 < p`.
+* `HeckeRing.GL2.diagRep_apply_one_zero` and `det_diagRep_pos`: it too is upper triangular and
+  has positive determinant — both unconditionally in `p`, since `natDiagGL`'s junk value is the
+  identity.
+
 ## Provenance
 
 No code is ported: the equivalence is a fact about this repository's own `UpperTriEntries`. The
@@ -55,7 +66,14 @@ No code is ported: the equivalence is a fact about this repository's own `UpperT
 `2baa76f742bdb4fb8ee323fabba41203bd390e08`, whose `heckeT_p_ut` sums over `b ∈ Finset.range p`
 and whose `T_p_upper p _ b = !![1, b; 0, p]` is `upperTriGL` at `n = 2`, `a = ![1, p]`. This file
 exists so that such a sum transfers onto the existing general-`n` decomposition instead of
-restating the index.
+restating the index. `diagRep` is the same file's `T_p_lower` (line 52), the diagonal
+representative `[[p, 0], [0, 1]]`, restated here as `natDiagGL 2 ![p, 1]` rather than as a fresh
+matrix literal.
+
+## References
+
+* [DS] Diamond–Shurman, *A first course in modular forms*, Proposition 5.2.1 — the `p + 1` left
+  cosets of the double coset of `diag(1, p)` over `Γ₀(N)`, the decomposition `diagRep` completes.
 -/
 
 public section
@@ -141,12 +159,39 @@ noncomputable def upperTriRep (b : Fin p) : GL (Fin 2) ℚ :=
     (↑(upperTriRep p b) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 :=
   upperTriGL_apply_eq_zero_of_lt (fun i ↦ by fin_cases i <;> simp [b.pos]) _ (by decide)
 
-/-- **The diagonal representative** `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`.
+/-- The representatives have positive determinant: `det !![1, b; 0, p] = p > 0`. -/
+lemma det_upperTriRep_pos (b : Fin p) :
+    0 < (↑(upperTriRep p b) : Matrix (Fin 2) (Fin 2) ℚ).det := by
+  have hpos : ∀ i : Fin 2, 0 < ![1, p] i := fun i ↦ by fin_cases i <;> simp [b.pos]
+  have hdiag : (0 : ℚ) < (↑(natDiagGL 2 ![1, p]) : Matrix (Fin 2) (Fin 2) ℚ).det :=
+    natDiagGL_det_pos 2 ![1, p] hpos
+  have hunit := RingHom.map_det (Int.castRingHom ℚ)
+    (unitriMat ((upperTriEntriesEquivFin p).symm b))
+  rw [det_unitriMat] at hunit
+  have hunit' : ((unitriMat ((upperTriEntriesEquivFin p).symm b)).map
+      (Int.cast : ℤ → ℚ)).det = 1 := by simpa using hunit.symm
+  rw [upperTriRep, upperTriGL_def, Units.val_mul, Matrix.det_mul]
+  simpa [hunit'] using hdiag
 
-For a **prime** `p ∤ N` the double coset of `diag(1, p)` has `p + 1` left cosets: the `p`
-upper-triangular ones `upperTriRep p b` and this one. That count is primality-specific — at a
-composite `p` the triangular decomposition has `∑_{d ∣ p} d` representatives, seven at `p = 4` —
-so nothing here claims a coset decomposition for general `p`.
+/-- **The diagonal representative** `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`. That entrywise
+description needs `0 < p`, which is why `coe_diagRep` carries the hypothesis: at `p = 0` the
+positivity condition fails and `natDiagGL` returns its junk value `1` (`natDiagGL_of_not_pos`).
+
+For a **prime** `p ∤ N`, over `Γ₀(N)` and with trivial character, the double coset of `diag(1, p)`
+has `p + 1` left cosets: the `p` upper-triangular ones `upperTriRep p b` and this one. Both
+qualifiers are load-bearing. With nebentypus `χ` the last term acquires a factor `χ(p)`, and over
+`Γ₁(N)` the untwisted matrix is not a coset representative at all — it is one only up to a `Γ₀(N)`
+twist, which is exactly what supplies the `χ(p)` in the recurrence.
+
+The count is primality-specific too, and `∑_{d ∣ p} d` counts the wrong thing to compare against
+`p + 1`: it counts *all* determinant-`p` classes, seven at `p = 4`, spread over more than one
+double coset. The double coset of `diag(1, 4)` alone has six left cosets; the seventh class is the
+scalar `2 • 1`, which lies in the double coset of `diag(2, 2)`. Six or seven, both exceed the five
+terms available at `p = 4`, so nothing here claims a coset decomposition for general `p`.
+
+Over `ℝ` this same matrix is `TauCeti.scaleGL p` (`ModularForms/Degeneracy.lean`), where slashing
+by it is the level-raising operator `V_p`; the analytic facts about it — `denom_scaleGL`,
+`coe_scaleGL_smul` — are proved there and are not restated here.
 
 It is diagonal, hence upper triangular, so it satisfies the same `(1, 0) = 0` hypothesis that
 mathlib's `IsBoundedAtImInfty.slash` asks for, for every `p`. -/
@@ -178,20 +223,6 @@ than a fresh derivation from `natDiagGL_det_pos`. -/
 lemma det_diagRep_pos :
     0 < (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ).det :=
   ((mem_posDetInt_iff 2).mp (natDiagGL_mem_posDetInt 2 ![p, 1])).2
-
-/-- The representatives have positive determinant: `det !![1, b; 0, p] = p > 0`. -/
-lemma det_upperTriRep_pos (b : Fin p) :
-    0 < (↑(upperTriRep p b) : Matrix (Fin 2) (Fin 2) ℚ).det := by
-  have hpos : ∀ i : Fin 2, 0 < ![1, p] i := fun i ↦ by fin_cases i <;> simp [b.pos]
-  have hdiag : (0 : ℚ) < (↑(natDiagGL 2 ![1, p]) : Matrix (Fin 2) (Fin 2) ℚ).det :=
-    natDiagGL_det_pos 2 ![1, p] hpos
-  have hunit := RingHom.map_det (Int.castRingHom ℚ)
-    (unitriMat ((upperTriEntriesEquivFin p).symm b))
-  rw [det_unitriMat] at hunit
-  have hunit' : ((unitriMat ((upperTriEntriesEquivFin p).symm b)).map
-      (Int.cast : ℤ → ℚ)).det = 1 := by simpa using hunit.symm
-  rw [upperTriRep, upperTriGL_def, Units.val_mul, Matrix.det_mul]
-  simpa [hunit'] using hdiag
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -22,7 +22,7 @@ which sums over `b` directly: a sum over `UpperTriEntries 2 ![1, p]` transfers a
 equivalence rather than being restated.
 
 Alongside the upper-triangular family this file records the remaining representative,
-`diagRep p = !![p, 0; 0, 1]`, so that both families and the two facts every slash argument needs
+`scaleRep p = !![p, 0; 0, 1]`, so that both families and the two facts every slash argument needs
 of them — upper-triangularity and positive determinant — sit together.
 
 Nothing here involves a level or a congruence subgroup; the level-`N` membership statements for
@@ -34,7 +34,9 @@ these representatives are in `GL2/UpperTriangularDelta0.lean`.
 * `HeckeRing.GL2.upperTriEntriesEquiv`: `UpperTriEntries 2 a ≃ Fin (a 1 / a 0)`, for an
   arbitrary tuple `a`.
 * `HeckeRing.GL2.upperTriEntriesEquivFin`: its specialisation `UpperTriEntries 2 ![1, p] ≃ Fin p`.
-* `HeckeRing.GL2.diagRep`: the diagonal representative `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`.
+* `HeckeRing.GL2.scaleRep`: the scaling representative `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`
+  — named for `TauCeti.scaleGL`, its image over `ℝ`. "Diagonal" alone would not pin it down:
+  `upperTriRep p 0` is `!![1, 0; 0, p]`, diagonal with the entries the other way round.
 
 ## Main results
 
@@ -52,9 +54,10 @@ these representatives are in `GL2/UpperTriangularDelta0.lean`.
 * `HeckeRing.GL2.det_upperTriRep_pos`: they have determinant `p > 0`, which is what lets scalars
   pass through a slash by them without the `σ` twist.
 
-* `HeckeRing.GL2.coe_diagRep`: the entrywise description of the diagonal representative, for
-  `0 < p`.
-* `HeckeRing.GL2.diagRep_apply_one_zero` and `det_diagRep_pos`: it too is upper triangular and
+* `HeckeRing.GL2.scaleRep_def` and `HeckeRing.GL2.scaleRep_zero`: the defining equation and the
+  junk branch, the route into the `natDiagGL` API.
+* `HeckeRing.GL2.coe_scaleRep`: its entrywise description, for `0 < p`.
+* `HeckeRing.GL2.scaleRep_apply_one_zero` and `det_scaleRep_pos`: it too is upper triangular and
   has positive determinant — both unconditionally in `p`, since `natDiagGL`'s junk value is the
   identity.
 
@@ -66,14 +69,14 @@ No code is ported: the equivalence is a fact about this repository's own `UpperT
 `2baa76f742bdb4fb8ee323fabba41203bd390e08`, whose `heckeT_p_ut` sums over `b ∈ Finset.range p`
 and whose `T_p_upper p _ b = !![1, b; 0, p]` is `upperTriGL` at `n = 2`, `a = ![1, p]`. This file
 exists so that such a sum transfers onto the existing general-`n` decomposition instead of
-restating the index. `diagRep` is the same file's `T_p_lower` (line 52), the diagonal
+restating the index. `scaleRep` is the same file's `T_p_lower` (line 52), the diagonal
 representative `[[p, 0], [0, 1]]`, restated here as `natDiagGL 2 ![p, 1]` rather than as a fresh
 matrix literal.
 
 ## References
 
 * [DS] Diamond–Shurman, *A first course in modular forms*, Proposition 5.2.1 — the `p + 1` left
-  cosets of the double coset of `diag(1, p)` over `Γ₀(N)`, the decomposition `diagRep` completes.
+  cosets of the double coset of `diag(1, p)` over `Γ₀(N)`, the decomposition `scaleRep` completes.
 -/
 
 public section
@@ -173,8 +176,8 @@ lemma det_upperTriRep_pos (b : Fin p) :
   rw [upperTriRep, upperTriGL_def, Units.val_mul, Matrix.det_mul]
   simpa [hunit'] using hdiag
 
-/-- **The diagonal representative** `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`. That entrywise
-description needs `0 < p`, which is why `coe_diagRep` carries the hypothesis: at `p = 0` the
+/-- **The scaling representative** `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`. That entrywise
+description needs `0 < p`, which is why `coe_scaleRep` carries the hypothesis: at `p = 0` the
 positivity condition fails and `natDiagGL` returns its junk value `1` (`natDiagGL_of_not_pos`).
 
 For a **prime** `p ∤ N`, over `Γ₀(N)` and with trivial character, the double coset of `diag(1, p)`
@@ -183,45 +186,48 @@ qualifiers are load-bearing. With nebentypus `χ` the last term acquires a facto
 `Γ₁(N)` the untwisted matrix is not a coset representative at all — it is one only up to a `Γ₀(N)`
 twist, which is exactly what supplies the `χ(p)` in the recurrence.
 
-The count is primality-specific too, and `∑_{d ∣ p} d` counts the wrong thing to compare against
-`p + 1`: it counts *all* determinant-`p` classes, seven at `p = 4`, spread over more than one
-double coset. The double coset of `diag(1, 4)` alone has six left cosets; the seventh class is the
-scalar `2 • 1`, which lies in the double coset of `diag(2, 2)`. Six or seven, both exceed the five
-terms available at `p = 4`, so nothing here claims a coset decomposition for general `p`.
+The `p + 1` count is specific to prime `p`; this definition is well formed for every `p` and
+claims no coset decomposition in general.
 
-Over `ℝ` this same matrix is `TauCeti.scaleGL p` (`ModularForms/Degeneracy.lean`), where slashing
-by it is the level-raising operator `V_p`; the analytic facts about it — `denom_scaleGL`,
-`coe_scaleGL_smul` — are proved there and are not restated here.
+Over `ℝ` the same matrix is `TauCeti.scaleGL p` (`ModularForms/Degeneracy.lean`), where slashing
+by it is, up to the scalar `p ^ (k - 1)`, the level-raising operator `V_p`. No declaration yet
+connects the two, so `denom_scaleGL` and `coe_scaleGL_smul` are *not* reachable from this name;
+the bridge belongs with the first consumer that needs the analytic facts.
 
 It is diagonal, hence upper triangular, so it satisfies the same `(1, 0) = 0` hypothesis that
 mathlib's `IsBoundedAtImInfty.slash` asks for, for every `p`. -/
-noncomputable def diagRep : GL (Fin 2) ℚ :=
+noncomputable def scaleRep : GL (Fin 2) ℚ :=
   natDiagGL 2 ![p, 1]
 
-/-- The matrix of `diagRep p` is `!![p, 0; 0, 1]`. -/
-@[simp] lemma coe_diagRep (hp : 0 < p) :
-    (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ) = !![(p : ℚ), 0; 0, 1] := by
+/-- The defining equation. The body is not exported, so this is what routes `scaleRep` into the
+`natDiagGL` API — `natDiagGL_det`, and the `Δ₀(N)` membership `natDiagGL_mem_Delta0_of_coprime`
+that the coprime branch needs. -/
+lemma scaleRep_def : scaleRep p = natDiagGL 2 ![p, 1] := (rfl)
+
+/-- The junk branch: at `p = 0` the positivity condition fails and `natDiagGL` returns `1`. -/
+@[simp] lemma scaleRep_zero : scaleRep 0 = 1 := by
+  have ha : ¬ ∀ i : Fin 2, 0 < ![0, 1] i := fun h ↦ absurd (h 0) (by simp)
+  rw [scaleRep_def, natDiagGL_of_not_pos 2 ha]
+
+/-- The matrix of `scaleRep p` is `!![p, 0; 0, 1]`, for `0 < p`. -/
+@[simp] lemma coe_scaleRep (hp : 0 < p) :
+    (↑(scaleRep p) : Matrix (Fin 2) (Fin 2) ℚ) = !![(p : ℚ), 0; 0, 1] := by
   have ha : ∀ i : Fin 2, 0 < ![p, 1] i := fun i ↦ by fin_cases i <;> simp [hp]
   ext i j
-  fin_cases i <;> fin_cases j <;> simp [diagRep, natDiagGL_coe 2 ![p, 1] ha]
+  fin_cases i <;> fin_cases j <;> simp [scaleRep, natDiagGL_coe 2 ![p, 1] ha]
 
-/-- **The remaining representative is upper triangular too** — being diagonal, its `(1, 0)`
-entry vanishes, which is the hypothesis `IsBoundedAtImInfty.slash` asks for.
-
-Unconditional in `p`: at `p = 0` the positivity condition fails and `natDiagGL` takes its junk
-value `1`, whose off-diagonal entries also vanish. -/
-@[simp] lemma diagRep_apply_one_zero :
-    (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 := by
+/-- **The remaining representative is upper triangular too**: its `(1, 0)` entry vanishes, which
+is the hypothesis `IsBoundedAtImInfty.slash` asks for. For every `p`, `p = 0` included. -/
+@[simp] lemma scaleRep_apply_one_zero :
+    (↑(scaleRep p) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 := by
   by_cases hp : 0 < p
-  · simp [coe_diagRep p hp]
+  · simp [coe_scaleRep p hp]
   · have ha : ¬ ∀ i : Fin 2, 0 < ![p, 1] i := fun h ↦ hp (by simpa using h 0)
-    simp [diagRep, natDiagGL_of_not_pos 2 ha]
+    simp [scaleRep, natDiagGL_of_not_pos 2 ha]
 
-/-- The remaining representative has positive determinant. Unconditional in `p`: this is the
-`posDetInt` membership `natDiagGL_mem_posDetInt`, which already covers the junk branch, rather
-than a fresh derivation from `natDiagGL_det_pos`. -/
-lemma det_diagRep_pos :
-    0 < (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ).det :=
+/-- `det (scaleRep p) > 0`, for every `p` — including `p = 0`, where `scaleRep 0 = 1`. -/
+lemma det_scaleRep_pos :
+    0 < (↑(scaleRep p) : Matrix (Fin 2) (Fin 2) ℚ).det :=
   ((mem_posDetInt_iff 2).mp (natDiagGL_mem_posDetInt 2 ![p, 1])).2
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -141,6 +141,34 @@ noncomputable def upperTriRep (b : Fin p) : GL (Fin 2) ℚ :=
     (↑(upperTriRep p b) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 :=
   upperTriGL_apply_eq_zero_of_lt (fun i ↦ by fin_cases i <;> simp [b.pos]) _ (by decide)
 
+/-- **The remaining coset representative** `!![p, 0; 0, 1]`, as `natDiagGL 2 ![p, 1]`.
+
+For `p ∤ N` the double coset of `diag(1, p)` has `p + 1` left cosets, not `p`: the `p`
+upper-triangular ones `upperTriRep p b` and this one. It is diagonal, hence upper triangular,
+so it satisfies the same `(1, 0) = 0` hypothesis that mathlib's `IsBoundedAtImInfty.slash`
+asks for — the whole `p + 1`-term sum stays inside that machinery. -/
+noncomputable def diagRep : GL (Fin 2) ℚ :=
+  natDiagGL 2 ![p, 1]
+
+/-- The matrix of `diagRep p` is `!![p, 0; 0, 1]`. -/
+@[simp] lemma coe_diagRep (hp : 0 < p) :
+    (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ) = !![(p : ℚ), 0; 0, 1] := by
+  have ha : ∀ i : Fin 2, 0 < ![p, 1] i := fun i ↦ by fin_cases i <;> simp [hp]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [diagRep, natDiagGL_coe 2 ![p, 1] ha]
+
+/-- **The remaining representative is upper triangular too** — being diagonal, its `(1, 0)`
+entry vanishes, which is the hypothesis `IsBoundedAtImInfty.slash` asks for. -/
+@[simp] lemma diagRep_apply_one_zero (hp : 0 < p) :
+    (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 := by
+  simp [coe_diagRep p hp]
+
+/-- The remaining representative has positive determinant: `det !![p, 0; 0, 1] = p > 0`. -/
+lemma det_diagRep_pos (hp : 0 < p) :
+    0 < (↑(diagRep p) : Matrix (Fin 2) (Fin 2) ℚ).det := by
+  have ha : ∀ i : Fin 2, 0 < ![p, 1] i := fun i ↦ by fin_cases i <;> simp [hp]
+  simpa [diagRep] using natDiagGL_det_pos 2 ![p, 1] ha
+
 /-- The representatives have positive determinant: `det !![1, b; 0, p] = p > 0`. -/
 lemma det_upperTriRep_pos (b : Fin p) :
     0 < (↑(upperTriRep p b) : Matrix (Fin 2) (Fin 2) ℚ).det := by

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
@@ -132,11 +132,11 @@ lemma heckeSlashUpperTriAddDiag_apply (f : ℍ → ℂ) (τ : ℍ) :
       (∑ b : Fin p, (f ∣[k] upperTriRep p b) τ) + (f ∣[k] diagRep p) τ := by
   rw [heckeSlashUpperTriAddDiag_def, Pi.add_apply, heckeSlashUpperTri_apply]
 
-/-- The full sum sends the zero function to zero. -/
+/-- The augmented sum sends the zero function to zero. -/
 @[simp] lemma heckeSlashUpperTriAddDiag_zero : heckeSlashUpperTriAddDiag k p 0 = 0 := by
   rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_zero, SlashAction.zero_slash, add_zero]
 
-/-- The full sum is additive in `f`, since each slash is. -/
+/-- The augmented sum is additive in `f`, since each slash is. -/
 @[simp] lemma heckeSlashUpperTriAddDiag_add (f g : ℍ → ℂ) :
     heckeSlashUpperTriAddDiag k p (f + g) =
       heckeSlashUpperTriAddDiag k p f + heckeSlashUpperTriAddDiag k p g := by
@@ -146,13 +146,14 @@ lemma heckeSlashUpperTriAddDiag_apply (f : ℍ → ℂ) (τ : ℍ) :
 
 /-- **Scalars pass through the augmented sum.** With `heckeSlashUpperTriAddDiag_add` and
 `heckeSlashUpperTriAddDiag_zero` this is the `ℂ`-linearity of
-`f ↦ heckeSlashUpperTriAddDiag k p f`. The positivity hypothesis is what
-`ModularForm.rat_smul_slash_of_det_pos` needs for the extra representative. -/
+`f ↦ heckeSlashUpperTriAddDiag k p f`. Unconditional in `p`, matching
+`heckeSlashUpperTri_smul`: `det_diagRep_pos` needs no positivity, since `natDiagGL`'s junk
+value is the identity. -/
 @[simp] lemma heckeSlashUpperTriAddDiag_smul {α : Type*} [DistribSMul α ℂ]
-    [IsScalarTower α ℂ ℂ] (hp : 0 < p)
+    [IsScalarTower α ℂ ℂ]
     (c : α) (f : ℍ → ℂ) :
       heckeSlashUpperTriAddDiag k p (c • f) = c • heckeSlashUpperTriAddDiag k p f := by
   rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_smul,
-    smul_add, ModularForm.rat_smul_slash_of_det_pos k (det_diagRep_pos p hp) f c]
+    smul_add, ModularForm.rat_smul_slash_of_det_pos k (det_diagRep_pos p) f c]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
@@ -12,9 +12,10 @@ public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 # The upper-triangular part of the Hecke operator
 
 The classical `T_p` is a sum of slashes by the representatives `!![1, b; 0, p]` for `b < p`,
-together with one further term when `p ∤ N`. This file defines that first sum, `heckeSlashUpperTri`,
-and records that `f ↦ heckeSlashUpperTri k p f` is `ℂ`-linear: it preserves zero, addition and
-scalar multiplication. (Linearity in `f` only; this is not yet bundled as a `LinearMap`.)
+together with one further term when `p ∤ N`. This file defines both: the triangular sum
+`heckeSlashUpperTri`, and the augmented sum `heckeSlashUpperTriAddDiag` adjoining the diagonal
+representative. For each it records `ℂ`-linearity in `f`: zero, addition and scalar multiplication
+are preserved. (Linearity in `f` only; neither is yet bundled as a `LinearMap`.)
 
 Why these representatives: mathlib's `IsBoundedAtImInfty.slash` requires `g 1 0 = 0`, so it
 applies when `g` is upper triangular. (Sufficient, not necessary — the zero function stays
@@ -28,8 +29,8 @@ the entrywise description of the representatives is not restated.
 
 * `HeckeRing.GL2.heckeSlashUpperTri`: the sum `∑ b < p, f ∣[k] !![1, b; 0, p]`.
 * `HeckeRing.GL2.heckeSlashUpperTriAddDiag`: that sum together with the diagonal representative
-  `!![p, 0; 0, 1]`. For **prime** `p ∤ N` this is the whole `T_p` coset sum; that identification
-  is primality-specific and is not proved here.
+  `!![p, 0; 0, 1]`. For **prime** `p ∤ N`, over `Γ₀(N)` and with trivial character, this is the
+  whole `T_p` coset sum; the identification needs both qualifiers and is not proved here.
 
 ## Main results
 
@@ -38,8 +39,8 @@ the entrywise description of the representatives is not restated.
   its sum.
 * `HeckeRing.GL2.heckeSlashUpperTri_zero`, `heckeSlashUpperTri_add`,
   `heckeSlashUpperTri_smul`: linearity in `f`.
-* `HeckeRing.GL2.heckeSlashUpperTriAddDiag_def`, `…_eq_sum_add`, `…_apply`, and
-  `…_zero` / `_add` / `_smul`: the same interface for the augmented sum.
+* `HeckeRing.GL2.heckeSlashUpperTriAddDiag_def`, `…_apply`, and `…_zero` / `_add` / `_smul`: the
+  same interface for the augmented sum.
 The representatives themselves, and their upper-triangularity and positive determinant, live in
 `HeckeRing/GL2/CosetDecomposition.lean`; this file is only the slash sum built from them.
 
@@ -52,10 +53,21 @@ The shape is AINTLIB's `heckeT_p_ut`
 representatives — `T_p_upper p _ b` is `upperTriGL` at `n = 2`, `a = ![1, p]` — so AINTLIB's
 `T_p_upper` is not reproduced.
 
+`heckeSlashUpperTriAddDiag` follows the same project's `heckeT_p_fun` (`HeckeT_p.lean`, lines
+110-115), which adjoins a diagonal term to `heckeT_p_ut`, and its prime-`T_p` dispatch
+`heckeT_p_all` (`HeckeT_n.lean`, lines 434-437). One deliberate difference, and it is why the
+docstrings below qualify the `T_p` claim: AINTLIB's extra term is
+`(⇑(diamondOp k ⟨p⟩ f)) ∣[k] T_p_lower p`, carrying the diamond operator, where the term here is
+the untwisted `f ∣[k] diagRep p`. The two agree exactly when the nebentypus is trivial. The
+twisted form needs `diamondOp`, which this file does not import.
+
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
   §3.4.
+* [DS] Diamond–Shurman, *A first course in modular forms*, Proposition 5.2.1 — the `p + 1`
+  representatives of the `T_p` coset decomposition for `p ∤ N`, the source AINTLIB's
+  `heckeT_p_fun` cites for the same statement.
 -/
 
 public section
@@ -106,11 +118,18 @@ scalar generality matches `ModularForm.rat_smul_slash_of_det_pos`. -/
 `heckeSlashUpperTri` plus `f ∣[k] diagRep p`.
 
 ⚠ This is **not** claimed to be the full `T_p` coset sum. It is that only for **prime** `p ∤ N`,
-where the double coset of `diag(1, p)` has exactly `p + 1` left cosets; at a composite `p` the
-triangular decomposition has `∑_{d ∣ p} d` representatives — seven at `p = 4` against the five
-terms here — so the identification is primality-specific and is not proved in this file. The
-definition itself is well formed for every `p`, which is why no `Nat.Prime` hypothesis is
-imposed on it.
+over `Γ₀(N)` and with trivial character, where the double coset of `diag(1, p)` has exactly
+`p + 1` left cosets. Both qualifiers are load-bearing: with nebentypus `χ` the diagonal term is
+`χ(p) • f ∣[k] diagRep p`, and over `Γ₁(N)` the untwisted matrix is not a coset representative at
+all. AINTLIB's `heckeT_p_fun` carries precisely that twist — its extra term is
+`(⟨p⟩ f) ∣[k] T_p_lower p`.
+
+The count is primality-specific too, and `∑_{d ∣ p} d` is not the number to compare with `p + 1`:
+it counts *all* determinant-`p` classes, seven at `p = 4`, spread over more than one double coset.
+The double coset of `diag(1, 4)` alone has six left cosets, the seventh class being the scalar
+`2 • 1`, which lies in the double coset of `diag(2, 2)`. Six or seven, both exceed the five terms
+available here, so the identification is not proved in this file. The definition itself is well
+formed for every `p`, which is why no `Nat.Prime` hypothesis is imposed on it.
 
 Every representative summed here is upper triangular — `diagRep` is diagonal — so
 `IsBoundedAtImInfty.slash` applies to each term exactly as it does to `heckeSlashUpperTri`. -/
@@ -120,11 +139,6 @@ noncomputable def heckeSlashUpperTriAddDiag (f : ℍ → ℂ) : ℍ → ℂ :=
 /-- The defining equation of `heckeSlashUpperTriAddDiag`, in terms of the partial sum. -/
 lemma heckeSlashUpperTriAddDiag_def (f : ℍ → ℂ) :
     heckeSlashUpperTriAddDiag k p f = heckeSlashUpperTri k p f + f ∣[k] diagRep p := (rfl)
-
-/-- `heckeSlashUpperTriAddDiag` written out over all `p + 1` representatives. -/
-lemma heckeSlashUpperTriAddDiag_eq_sum_add (f : ℍ → ℂ) :
-    heckeSlashUpperTriAddDiag k p f = (∑ b : Fin p, f ∣[k] upperTriRep p b) + f ∣[k] diagRep p := by
-  rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_def]
 
 /-- The pointwise form, for consumers working at a point of `ℍ`. -/
 lemma heckeSlashUpperTriAddDiag_apply (f : ℍ → ℂ) (τ : ℍ) :

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
@@ -27,8 +27,9 @@ the entrywise description of the representatives is not restated.
 ## Main definitions
 
 * `HeckeRing.GL2.heckeSlashUpperTri`: the sum `∑ b < p, f ∣[k] !![1, b; 0, p]`.
-* `HeckeRing.GL2.heckeSlashFull`: that sum together with the one further representative
-  `!![p, 0; 0, 1]` — the whole `T_p` sum in the `p ∤ N` case.
+* `HeckeRing.GL2.heckeSlashUpperTriAddDiag`: that sum together with the diagonal representative
+  `!![p, 0; 0, 1]`. For **prime** `p ∤ N` this is the whole `T_p` coset sum; that identification
+  is primality-specific and is not proved here.
 
 ## Main results
 
@@ -37,8 +38,8 @@ the entrywise description of the representatives is not restated.
   its sum.
 * `HeckeRing.GL2.heckeSlashUpperTri_zero`, `heckeSlashUpperTri_add`,
   `heckeSlashUpperTri_smul`: linearity in `f`.
-* `HeckeRing.GL2.heckeSlashFull_def`, `heckeSlashFull_eq_sum_add`, `heckeSlashFull_apply`,
-  and `heckeSlashFull_zero` / `_add` / `_smul`: the same interface for the full sum.
+* `HeckeRing.GL2.heckeSlashUpperTriAddDiag_def`, `…_eq_sum_add`, `…_apply`, and
+  `…_zero` / `_add` / `_smul`: the same interface for the augmented sum.
 The representatives themselves, and their upper-triangularity and positive determinant, live in
 `HeckeRing/GL2/CosetDecomposition.lean`; this file is only the slash sum built from them.
 
@@ -101,47 +102,57 @@ scalar generality matches `ModularForm.rat_smul_slash_of_det_pos`. -/
   exact Finset.sum_congr rfl fun b _ ↦
     ModularForm.rat_smul_slash_of_det_pos k (det_upperTriRep_pos p b) f c
 
-/-- **The full `T_p` sum for `p ∤ N`**: the `p` upper-triangular terms together with the one
-further representative `!![p, 0; 0, 1]`.
+/-- **The upper-triangular sum together with the diagonal term**: the `p` terms of
+`heckeSlashUpperTri` plus `f ∣[k] diagRep p`.
 
-`heckeSlashUpperTri` is the whole operator only when `p ∣ N`. For `p ∤ N` the double coset of
-`diag(1, p)` has `p + 1` left cosets, and this is the sum over all of them. Every representative
-here is upper triangular — `diagRep` is diagonal — so `IsBoundedAtImInfty.slash` applies to each
-term exactly as it does to `heckeSlashUpperTri`. -/
-noncomputable def heckeSlashFull (f : ℍ → ℂ) : ℍ → ℂ :=
+⚠ This is **not** claimed to be the full `T_p` coset sum. It is that only for **prime** `p ∤ N`,
+where the double coset of `diag(1, p)` has exactly `p + 1` left cosets; at a composite `p` the
+triangular decomposition has `∑_{d ∣ p} d` representatives — seven at `p = 4` against the five
+terms here — so the identification is primality-specific and is not proved in this file. The
+definition itself is well formed for every `p`, which is why no `Nat.Prime` hypothesis is
+imposed on it.
+
+Every representative summed here is upper triangular — `diagRep` is diagonal — so
+`IsBoundedAtImInfty.slash` applies to each term exactly as it does to `heckeSlashUpperTri`. -/
+noncomputable def heckeSlashUpperTriAddDiag (f : ℍ → ℂ) : ℍ → ℂ :=
   heckeSlashUpperTri k p f + f ∣[k] diagRep p
 
-/-- The defining equation of `heckeSlashFull`, in terms of the partial sum. -/
-lemma heckeSlashFull_def (f : ℍ → ℂ) :
-    heckeSlashFull k p f = heckeSlashUpperTri k p f + f ∣[k] diagRep p := (rfl)
+/-- The defining equation of `heckeSlashUpperTriAddDiag`, in terms of the partial sum. -/
+lemma heckeSlashUpperTriAddDiag_def (f : ℍ → ℂ) :
+    heckeSlashUpperTriAddDiag k p f = heckeSlashUpperTri k p f + f ∣[k] diagRep p := (rfl)
 
-/-- `heckeSlashFull` written out over all `p + 1` representatives. -/
-lemma heckeSlashFull_eq_sum_add (f : ℍ → ℂ) :
-    heckeSlashFull k p f = (∑ b : Fin p, f ∣[k] upperTriRep p b) + f ∣[k] diagRep p := by
-  rw [heckeSlashFull_def, heckeSlashUpperTri_def]
+/-- `heckeSlashUpperTriAddDiag` written out over all `p + 1` representatives. -/
+lemma heckeSlashUpperTriAddDiag_eq_sum_add (f : ℍ → ℂ) :
+    heckeSlashUpperTriAddDiag k p f = (∑ b : Fin p, f ∣[k] upperTriRep p b) + f ∣[k] diagRep p := by
+  rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_def]
 
 /-- The pointwise form, for consumers working at a point of `ℍ`. -/
-lemma heckeSlashFull_apply (f : ℍ → ℂ) (τ : ℍ) :
-    heckeSlashFull k p f τ = (∑ b : Fin p, (f ∣[k] upperTriRep p b) τ) + (f ∣[k] diagRep p) τ := by
-  rw [heckeSlashFull_def, Pi.add_apply, heckeSlashUpperTri_apply]
+lemma heckeSlashUpperTriAddDiag_apply (f : ℍ → ℂ) (τ : ℍ) :
+    heckeSlashUpperTriAddDiag k p f τ =
+      (∑ b : Fin p, (f ∣[k] upperTriRep p b) τ) + (f ∣[k] diagRep p) τ := by
+  rw [heckeSlashUpperTriAddDiag_def, Pi.add_apply, heckeSlashUpperTri_apply]
 
 /-- The full sum sends the zero function to zero. -/
-@[simp] lemma heckeSlashFull_zero : heckeSlashFull k p 0 = 0 := by
-  rw [heckeSlashFull_def, heckeSlashUpperTri_zero, SlashAction.zero_slash, add_zero]
+@[simp] lemma heckeSlashUpperTriAddDiag_zero : heckeSlashUpperTriAddDiag k p 0 = 0 := by
+  rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_zero, SlashAction.zero_slash, add_zero]
 
 /-- The full sum is additive in `f`, since each slash is. -/
-@[simp] lemma heckeSlashFull_add (f g : ℍ → ℂ) :
-    heckeSlashFull k p (f + g) = heckeSlashFull k p f + heckeSlashFull k p g := by
-  rw [heckeSlashFull_def, heckeSlashFull_def, heckeSlashFull_def, heckeSlashUpperTri_add,
-    SlashAction.add_slash]
+@[simp] lemma heckeSlashUpperTriAddDiag_add (f g : ℍ → ℂ) :
+    heckeSlashUpperTriAddDiag k p (f + g) =
+      heckeSlashUpperTriAddDiag k p f + heckeSlashUpperTriAddDiag k p g := by
+  rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTriAddDiag_def,
+    heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_add, SlashAction.add_slash]
   ring
 
-/-- **Scalars pass through the full sum.** With `heckeSlashFull_add` and `heckeSlashFull_zero`
-this is the `ℂ`-linearity of `f ↦ heckeSlashFull k p f`. The positivity hypothesis is what
+/-- **Scalars pass through the augmented sum.** With `heckeSlashUpperTriAddDiag_add` and
+`heckeSlashUpperTriAddDiag_zero` this is the `ℂ`-linearity of
+`f ↦ heckeSlashUpperTriAddDiag k p f`. The positivity hypothesis is what
 `ModularForm.rat_smul_slash_of_det_pos` needs for the extra representative. -/
-@[simp] lemma heckeSlashFull_smul {α : Type*} [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ] (hp : 0 < p)
-    (c : α) (f : ℍ → ℂ) : heckeSlashFull k p (c • f) = c • heckeSlashFull k p f := by
-  rw [heckeSlashFull_def, heckeSlashFull_def, heckeSlashUpperTri_smul, smul_add,
-    ModularForm.rat_smul_slash_of_det_pos k (det_diagRep_pos p hp) f c]
+@[simp] lemma heckeSlashUpperTriAddDiag_smul {α : Type*} [DistribSMul α ℂ]
+    [IsScalarTower α ℂ ℂ] (hp : 0 < p)
+    (c : α) (f : ℍ → ℂ) :
+      heckeSlashUpperTriAddDiag k p (c • f) = c • heckeSlashUpperTriAddDiag k p f := by
+  rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_smul,
+    smul_add, ModularForm.rat_smul_slash_of_det_pos k (det_diagRep_pos p hp) f c]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
@@ -27,6 +27,8 @@ the entrywise description of the representatives is not restated.
 ## Main definitions
 
 * `HeckeRing.GL2.heckeSlashUpperTri`: the sum `∑ b < p, f ∣[k] !![1, b; 0, p]`.
+* `HeckeRing.GL2.heckeSlashFull`: that sum together with the one further representative
+  `!![p, 0; 0, 1]` — the whole `T_p` sum in the `p ∤ N` case.
 
 ## Main results
 
@@ -35,6 +37,8 @@ the entrywise description of the representatives is not restated.
   its sum.
 * `HeckeRing.GL2.heckeSlashUpperTri_zero`, `heckeSlashUpperTri_add`,
   `heckeSlashUpperTri_smul`: linearity in `f`.
+* `HeckeRing.GL2.heckeSlashFull_def`, `heckeSlashFull_eq_sum_add`, `heckeSlashFull_apply`,
+  and `heckeSlashFull_zero` / `_add` / `_smul`: the same interface for the full sum.
 The representatives themselves, and their upper-triangularity and positive determinant, live in
 `HeckeRing/GL2/CosetDecomposition.lean`; this file is only the slash sum built from them.
 
@@ -96,5 +100,48 @@ scalar generality matches `ModularForm.rat_smul_slash_of_det_pos`. -/
   rw [heckeSlashUpperTri_def, heckeSlashUpperTri_def, Finset.smul_sum]
   exact Finset.sum_congr rfl fun b _ ↦
     ModularForm.rat_smul_slash_of_det_pos k (det_upperTriRep_pos p b) f c
+
+/-- **The full `T_p` sum for `p ∤ N`**: the `p` upper-triangular terms together with the one
+further representative `!![p, 0; 0, 1]`.
+
+`heckeSlashUpperTri` is the whole operator only when `p ∣ N`. For `p ∤ N` the double coset of
+`diag(1, p)` has `p + 1` left cosets, and this is the sum over all of them. Every representative
+here is upper triangular — `diagRep` is diagonal — so `IsBoundedAtImInfty.slash` applies to each
+term exactly as it does to `heckeSlashUpperTri`. -/
+noncomputable def heckeSlashFull (f : ℍ → ℂ) : ℍ → ℂ :=
+  heckeSlashUpperTri k p f + f ∣[k] diagRep p
+
+/-- The defining equation of `heckeSlashFull`, in terms of the partial sum. -/
+lemma heckeSlashFull_def (f : ℍ → ℂ) :
+    heckeSlashFull k p f = heckeSlashUpperTri k p f + f ∣[k] diagRep p := (rfl)
+
+/-- `heckeSlashFull` written out over all `p + 1` representatives. -/
+lemma heckeSlashFull_eq_sum_add (f : ℍ → ℂ) :
+    heckeSlashFull k p f = (∑ b : Fin p, f ∣[k] upperTriRep p b) + f ∣[k] diagRep p := by
+  rw [heckeSlashFull_def, heckeSlashUpperTri_def]
+
+/-- The pointwise form, for consumers working at a point of `ℍ`. -/
+lemma heckeSlashFull_apply (f : ℍ → ℂ) (τ : ℍ) :
+    heckeSlashFull k p f τ = (∑ b : Fin p, (f ∣[k] upperTriRep p b) τ) + (f ∣[k] diagRep p) τ := by
+  rw [heckeSlashFull_def, Pi.add_apply, heckeSlashUpperTri_apply]
+
+/-- The full sum sends the zero function to zero. -/
+@[simp] lemma heckeSlashFull_zero : heckeSlashFull k p 0 = 0 := by
+  rw [heckeSlashFull_def, heckeSlashUpperTri_zero, SlashAction.zero_slash, add_zero]
+
+/-- The full sum is additive in `f`, since each slash is. -/
+@[simp] lemma heckeSlashFull_add (f g : ℍ → ℂ) :
+    heckeSlashFull k p (f + g) = heckeSlashFull k p f + heckeSlashFull k p g := by
+  rw [heckeSlashFull_def, heckeSlashFull_def, heckeSlashFull_def, heckeSlashUpperTri_add,
+    SlashAction.add_slash]
+  ring
+
+/-- **Scalars pass through the full sum.** With `heckeSlashFull_add` and `heckeSlashFull_zero`
+this is the `ℂ`-linearity of `f ↦ heckeSlashFull k p f`. The positivity hypothesis is what
+`ModularForm.rat_smul_slash_of_det_pos` needs for the extra representative. -/
+@[simp] lemma heckeSlashFull_smul {α : Type*} [DistribSMul α ℂ] [IsScalarTower α ℂ ℂ] (hp : 0 < p)
+    (c : α) (f : ℍ → ℂ) : heckeSlashFull k p (c • f) = c • heckeSlashFull k p f := by
+  rw [heckeSlashFull_def, heckeSlashFull_def, heckeSlashUpperTri_smul, smul_add,
+    ModularForm.rat_smul_slash_of_det_pos k (det_diagRep_pos p hp) f c]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
@@ -13,7 +13,7 @@ public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 
 The classical `T_p` is a sum of slashes by the representatives `!![1, b; 0, p]` for `b < p`,
 together with one further term when `p ∤ N`. This file defines both: the triangular sum
-`heckeSlashUpperTri`, and the augmented sum `heckeSlashUpperTriAddDiag` adjoining the diagonal
+`heckeSlashUpperTri`, and the augmented sum `heckeSlashUpperTriAddScale` adjoining the diagonal
 representative. For each it records `ℂ`-linearity in `f`: zero, addition and scalar multiplication
 are preserved. (Linearity in `f` only; neither is yet bundled as a `LinearMap`.)
 
@@ -28,7 +28,7 @@ the entrywise description of the representatives is not restated.
 ## Main definitions
 
 * `HeckeRing.GL2.heckeSlashUpperTri`: the sum `∑ b < p, f ∣[k] !![1, b; 0, p]`.
-* `HeckeRing.GL2.heckeSlashUpperTriAddDiag`: that sum together with the diagonal representative
+* `HeckeRing.GL2.heckeSlashUpperTriAddScale`: that sum together with the scaling representative
   `!![p, 0; 0, 1]`. For **prime** `p ∤ N`, over `Γ₀(N)` and with trivial character, this is the
   whole `T_p` coset sum; the identification needs both qualifiers and is not proved here.
 
@@ -39,7 +39,7 @@ the entrywise description of the representatives is not restated.
   its sum.
 * `HeckeRing.GL2.heckeSlashUpperTri_zero`, `heckeSlashUpperTri_add`,
   `heckeSlashUpperTri_smul`: linearity in `f`.
-* `HeckeRing.GL2.heckeSlashUpperTriAddDiag_def`, `…_apply`, and `…_zero` / `_add` / `_smul`: the
+* `HeckeRing.GL2.heckeSlashUpperTriAddScale_def`, `…_apply`, and `…_zero` / `_add` / `_smul`: the
   same interface for the augmented sum.
 The representatives themselves, and their upper-triangularity and positive determinant, live in
 `HeckeRing/GL2/CosetDecomposition.lean`; this file is only the slash sum built from them.
@@ -53,12 +53,12 @@ The shape is AINTLIB's `heckeT_p_ut`
 representatives — `T_p_upper p _ b` is `upperTriGL` at `n = 2`, `a = ![1, p]` — so AINTLIB's
 `T_p_upper` is not reproduced.
 
-`heckeSlashUpperTriAddDiag` follows the same project's `heckeT_p_fun` (`HeckeT_p.lean`, lines
+`heckeSlashUpperTriAddScale` follows the same project's `heckeT_p_fun` (`HeckeT_p.lean`, lines
 110-115), which adjoins a diagonal term to `heckeT_p_ut`, and its prime-`T_p` dispatch
 `heckeT_p_all` (`HeckeT_n.lean`, lines 434-437). One deliberate difference, and it is why the
 docstrings below qualify the `T_p` claim: AINTLIB's extra term is
 `(⇑(diamondOp k ⟨p⟩ f)) ∣[k] T_p_lower p`, carrying the diamond operator, where the term here is
-the untwisted `f ∣[k] diagRep p`. The two agree exactly when the nebentypus is trivial. The
+the untwisted `f ∣[k] scaleRep p`. The two agree exactly when the nebentypus is trivial. The
 twisted form needs `diamondOp`, which this file does not import.
 
 ## References
@@ -115,59 +115,54 @@ scalar generality matches `ModularForm.rat_smul_slash_of_det_pos`. -/
     ModularForm.rat_smul_slash_of_det_pos k (det_upperTriRep_pos p b) f c
 
 /-- **The upper-triangular sum together with the diagonal term**: the `p` terms of
-`heckeSlashUpperTri` plus `f ∣[k] diagRep p`.
+`heckeSlashUpperTri` plus `f ∣[k] scaleRep p`.
 
 ⚠ This is **not** claimed to be the full `T_p` coset sum. It is that only for **prime** `p ∤ N`,
 over `Γ₀(N)` and with trivial character, where the double coset of `diag(1, p)` has exactly
 `p + 1` left cosets. Both qualifiers are load-bearing: with nebentypus `χ` the diagonal term is
-`χ(p) • f ∣[k] diagRep p`, and over `Γ₁(N)` the untwisted matrix is not a coset representative at
+`χ(p) • f ∣[k] scaleRep p`, and over `Γ₁(N)` the untwisted matrix is not a coset representative at
 all. AINTLIB's `heckeT_p_fun` carries precisely that twist — its extra term is
 `(⟨p⟩ f) ∣[k] T_p_lower p`.
 
-The count is primality-specific too, and `∑_{d ∣ p} d` is not the number to compare with `p + 1`:
-it counts *all* determinant-`p` classes, seven at `p = 4`, spread over more than one double coset.
-The double coset of `diag(1, 4)` alone has six left cosets, the seventh class being the scalar
-`2 • 1`, which lies in the double coset of `diag(2, 2)`. Six or seven, both exceed the five terms
-available here, so the identification is not proved in this file. The definition itself is well
-formed for every `p`, which is why no `Nat.Prime` hypothesis is imposed on it.
+The `p + 1` count is specific to prime `p`; this definition is well formed for every `p` and
+claims no coset decomposition in general, which is why no `Nat.Prime` hypothesis is imposed on
+it.
 
-Every representative summed here is upper triangular — `diagRep` is diagonal — so
+Every representative summed here is upper triangular — `scaleRep` is diagonal — so
 `IsBoundedAtImInfty.slash` applies to each term exactly as it does to `heckeSlashUpperTri`. -/
-noncomputable def heckeSlashUpperTriAddDiag (f : ℍ → ℂ) : ℍ → ℂ :=
-  heckeSlashUpperTri k p f + f ∣[k] diagRep p
+noncomputable def heckeSlashUpperTriAddScale (f : ℍ → ℂ) : ℍ → ℂ :=
+  heckeSlashUpperTri k p f + f ∣[k] scaleRep p
 
-/-- The defining equation of `heckeSlashUpperTriAddDiag`, in terms of the partial sum. -/
-lemma heckeSlashUpperTriAddDiag_def (f : ℍ → ℂ) :
-    heckeSlashUpperTriAddDiag k p f = heckeSlashUpperTri k p f + f ∣[k] diagRep p := (rfl)
+/-- The defining equation of `heckeSlashUpperTriAddScale`, in terms of the partial sum. -/
+lemma heckeSlashUpperTriAddScale_def (f : ℍ → ℂ) :
+    heckeSlashUpperTriAddScale k p f = heckeSlashUpperTri k p f + f ∣[k] scaleRep p := (rfl)
 
 /-- The pointwise form, for consumers working at a point of `ℍ`. -/
-lemma heckeSlashUpperTriAddDiag_apply (f : ℍ → ℂ) (τ : ℍ) :
-    heckeSlashUpperTriAddDiag k p f τ =
-      (∑ b : Fin p, (f ∣[k] upperTriRep p b) τ) + (f ∣[k] diagRep p) τ := by
-  rw [heckeSlashUpperTriAddDiag_def, Pi.add_apply, heckeSlashUpperTri_apply]
+lemma heckeSlashUpperTriAddScale_apply (f : ℍ → ℂ) (τ : ℍ) :
+    heckeSlashUpperTriAddScale k p f τ =
+      (∑ b : Fin p, (f ∣[k] upperTriRep p b) τ) + (f ∣[k] scaleRep p) τ := by
+  rw [heckeSlashUpperTriAddScale_def, Pi.add_apply, heckeSlashUpperTri_apply]
 
 /-- The augmented sum sends the zero function to zero. -/
-@[simp] lemma heckeSlashUpperTriAddDiag_zero : heckeSlashUpperTriAddDiag k p 0 = 0 := by
-  rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_zero, SlashAction.zero_slash, add_zero]
+@[simp] lemma heckeSlashUpperTriAddScale_zero : heckeSlashUpperTriAddScale k p 0 = 0 := by
+  rw [heckeSlashUpperTriAddScale_def, heckeSlashUpperTri_zero, SlashAction.zero_slash, add_zero]
 
 /-- The augmented sum is additive in `f`, since each slash is. -/
-@[simp] lemma heckeSlashUpperTriAddDiag_add (f g : ℍ → ℂ) :
-    heckeSlashUpperTriAddDiag k p (f + g) =
-      heckeSlashUpperTriAddDiag k p f + heckeSlashUpperTriAddDiag k p g := by
-  rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTriAddDiag_def,
-    heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_add, SlashAction.add_slash]
+@[simp] lemma heckeSlashUpperTriAddScale_add (f g : ℍ → ℂ) :
+    heckeSlashUpperTriAddScale k p (f + g) =
+      heckeSlashUpperTriAddScale k p f + heckeSlashUpperTriAddScale k p g := by
+  rw [heckeSlashUpperTriAddScale_def, heckeSlashUpperTriAddScale_def,
+    heckeSlashUpperTriAddScale_def, heckeSlashUpperTri_add, SlashAction.add_slash]
   ring
 
-/-- **Scalars pass through the augmented sum.** With `heckeSlashUpperTriAddDiag_add` and
-`heckeSlashUpperTriAddDiag_zero` this is the `ℂ`-linearity of
-`f ↦ heckeSlashUpperTriAddDiag k p f`. Unconditional in `p`, matching
-`heckeSlashUpperTri_smul`: `det_diagRep_pos` needs no positivity, since `natDiagGL`'s junk
-value is the identity. -/
-@[simp] lemma heckeSlashUpperTriAddDiag_smul {α : Type*} [DistribSMul α ℂ]
+/-- **Scalars pass through the augmented sum**, for every `p`. With
+`heckeSlashUpperTriAddScale_add` and `heckeSlashUpperTriAddScale_zero` this is the `ℂ`-linearity
+of `f ↦ heckeSlashUpperTriAddScale k p f`. -/
+@[simp] lemma heckeSlashUpperTriAddScale_smul {α : Type*} [DistribSMul α ℂ]
     [IsScalarTower α ℂ ℂ]
     (c : α) (f : ℍ → ℂ) :
-      heckeSlashUpperTriAddDiag k p (c • f) = c • heckeSlashUpperTriAddDiag k p f := by
-  rw [heckeSlashUpperTriAddDiag_def, heckeSlashUpperTriAddDiag_def, heckeSlashUpperTri_smul,
-    smul_add, ModularForm.rat_smul_slash_of_det_pos k (det_diagRep_pos p) f c]
+      heckeSlashUpperTriAddScale k p (c • f) = c • heckeSlashUpperTriAddScale k p f := by
+  rw [heckeSlashUpperTriAddScale_def, heckeSlashUpperTriAddScale_def, heckeSlashUpperTri_smul,
+    smul_add, ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p) f c]
 
 end HeckeRing.GL2


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke-tp-coprime-sum"}-->

`heckeSlashUpperTri` sums over the `p` upper-triangular representatives `!![1, b; 0, p]`. That
is the whole operator only when `p ∣ N`. For a **prime** `p ∤ N`, over `Γ₀(N)` and with trivial
character, the double coset of `diag(1, p)` has `p + 1` left cosets, and the missing one is
`!![p, 0; 0, 1]`. This PR supplies that representative and the augmented sum.

```lean
noncomputable def scaleRep : GL (Fin 2) ℚ := natDiagGL 2 ![p, 1]

noncomputable def heckeSlashUpperTriAddScale (f : ℍ → ℂ) : ℍ → ℂ :=
  heckeSlashUpperTri k p f + f ∣[k] scaleRep p
```

## What is *not* claimed (correctness review, rounds 1-2)

The first revision called this `heckeSlashFull` and documented it as the full `T_p` sum. That
overclaimed in two independent ways, and the docstrings now record both.

**The group and the character.** The identification holds over `Γ₀(N)` with trivial nebentypus,
not in general. AINTLIB's own coprime `T_p` settles it: `heckeT_p_fun` (`HeckeT_p.lean:110-115`)
has extra term `(⟨p⟩ f) ∣[k] T_p_lower p`, carrying the diamond operator, where the term here is
the untwisted `f ∣[k] scaleRep p`. The two agree exactly when the nebentypus is trivial; over
`Γ₁(N)` the untwisted matrix is not a coset representative at all.

**The count.** The composite-`p` counterexample originally read `∑_{d ∣ 4} d = 7` as the size of
the `diag(1, 4)` double coset. It is not: seven counts *all* determinant-4 classes, spread over
more than one double coset, and the `diag(1, 4)` coset alone has `ψ(4) = 6` — the seventh class
is the scalar `2 • 1`, which lies in the `diag(2, 2)` coset. Six or seven, both still exceed the
five terms available at `p = 4`, so the conclusion is unchanged; only the attribution of the
number is corrected.

The declaration is renamed to say what it is — the upper-triangular sum plus the diagonal term —
and the identification with the full coset sum **is not proved here**.

No `Nat.Prime p` hypothesis is imposed on the definition: its body never uses one, so requiring
it would be an unused argument. The identification is a theorem to be stated later, not a
hypothesis to be carried now.

## Why this is the gap, and why now

`UpperTri/Sum.lean`'s own module docstring already named it: *"The classical `T_p` is a sum of
slashes by the representatives `!![1, b; 0, p]` for `b < p`, **together with one further term
when `p ∤ N`**. This file defines that first sum."* The second term is added here, beside the
first.

On current `main` the extra coset existed **only in prose** —
`UpperTri/Invariance.lean:45`, `UpperTri/QExpansion.lean:37` and `:201` all describe
`!![p, 0; 0, 1]` without any declaration for it — and
`git grep Coprime origin/main -- TauCeti/NumberTheory/ModularForms/HeckeSlash/` returns nothing.
Every `hpN` under `UpperTri/` is `p ∣ N`.

## The point of `scaleRep_apply_one_zero`

The extra representative is *diagonal*, so its `(1, 0)` entry vanishes too. That is exactly the
hypothesis mathlib's `IsBoundedAtImInfty.slash (hg : g 1 0 = 0)` asks for, so the `p + 1`-term
sum stays inside the machinery the `p ∣ N` case already uses. No appeal to the
abstract `transposeRep` double-coset route is needed.

## API

`scaleRep` joins `upperTriRep` in `HeckeRing/GL2/CosetDecomposition.lean` with the same three
facts it has — `coe_scaleRep`, `scaleRep_apply_one_zero`, `det_scaleRep_pos` — plus `scaleRep_def`
and `@[simp] scaleRep_zero`, which characterise both branches of `natDiagGL` and are what route
the name into the `natDiagGL` API.

**Renamed in round 2 on the `naming` rubric.** It was `diagRep`, but "the diagonal representative"
does not pin the matrix down: `upperTriRep p 0` is `!![1, 0; 0, p]`, diagonal with the entries the
other way round. `scaleRep` names it after `TauCeti.scaleGL`, its image over `ℝ`, and matches the
sibling `upperTriRep`; the dependent sum family renamed with it.

`heckeSlashUpperTriAddScale` carries the same interface as `heckeSlashUpperTri`, and exactly the
same size: `_def`, `_apply`, and linearity in `f` (`_zero`, `_add`, `_smul`). All are
unconditional in `p`. Two changes came out of review: the round-1 `0 < p` hypotheses were dropped
once `natDiagGL`'s junk value (`1`, of positive determinant) was used instead of re-deriving from
`natDiagGL_det_pos`, and `_eq_sum_add` was removed as `_def` composed with the already-public
`heckeSlashUpperTri_def`, both `rfl`.

## Not a duplicate

Main's `heckeSlashSum` (`HeckeSlash/Basic.lean:264`) is also a Hecke sum, but it is the abstract
double-coset sum over `transposeRep` — a different object, and its own docstring declines to call
it "the Hecke operator" pending two further theorems. Swept all 80 open PRs — unfiltered by author, branch
prefix or title — by filename and by added-declaration grep: nothing else touches
`CosetDecomposition.lean` or `UpperTri/Sum.lean`, and nothing else declares
`heckeSlashUpperTriAddScale` or `scaleRep`.

## Roadmap

`TauCetiRoadmap/ModularForms/README.md` Layer 2 — `:405` lists `heckeT_n` as a target with its
AINTLIB source named inline at `:402-403`; `:409` gives the coefficient identity for the `p ∤ N`
case; `:414` says to keep the `Nat.Coprime n N` hypotheses. This is the representative-level
prerequisite for that branch: `heckeT_p_all` (AINTLIB `HeckeT_n.lean:434`) is
`if Coprime p N then heckeT_p else heckeT_p_divN`, and main already has the `p ∣ N` half
(`heckeSlashUpperTriModularFormEnd`) and the diamond operator (`diamondOpNat`,
`DiamondOperators.lean:353`) but not the coprime half.

## Provenance

The `p + 1` representative set is Diamond–Shurman §5.2. The organising shape follows AINTLIB
([`LeanModularForms/HeckeRIngs/GL2/HeckeT_n.lean`](https://github.com/CBirkbeck/AINTLIB), commit
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck), whose `heckeT_p_all`
(lines 434-441) splits on `Nat.Coprime p N` between the coprime `heckeT_p` and the
upper-triangular-only `heckeT_p_divN` (lines 375-433). The construction here differs: it is a
function-level slash sum built on this repository's `natDiagGL` / `upperTriGL` families rather
than the source's own representative machinery, and no operator on `ModularForm` is bundled yet.

Both citations now live **in the code**, which is what the `attribution` rubric asked for:
`Sum.lean`'s Provenance names `heckeT_p_fun` and `heckeT_p_all` with their line spans and states
the diamond-twist difference, its References list gains Diamond–Shurman Prop. 5.2.1, and
`CosetDecomposition.lean` credits `T_p_lower` (`HeckeT_p.lean:52`) as the source of `scaleRep` and
carries the same Diamond–Shurman citation.




