### PR TITLE
refactor(Moebius): restate the evaluation lemmas in natural-cast form

### DIFF
--- a/TauCeti/Data/ZMod/FinEquiv.lean
+++ b/TauCeti/Data/ZMod/FinEquiv.lean
@@ -30,10 +30,8 @@ open Fin.CommRing in
 /-- **Applying `ZMod.finEquiv` is the natural cast.** `ZMod.finEquiv n j` is the image of `j.val`
 under `Nat.cast`.
 
-This is not definitional: the cast `((j : ℕ) : ZMod n)` reduces the natural `j.val` modulo `n`
-again, and it is `Fin.cast_val_eq_self` that says doing so returns `j`. Mathlib states no
-evaluation rule for `finEquiv`, so this is the lemma a `Fin n`-indexed statement rewrites
-through. -/
+Mathlib defines `finEquiv` and states no evaluation rule for it in either direction, so this is
+the lemma a `Fin n`-indexed statement rewrites through to reach `ZMod n`. -/
 @[simp]
 lemma finEquiv_apply {n : ℕ} [NeZero n] (j : Fin n) :
     (ZMod.finEquiv n) j = ((j : ℕ) : ZMod n) := by

--- a/TauCeti/Data/ZMod/FinEquiv.lean
+++ b/TauCeti/Data/ZMod/FinEquiv.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.ZMod.Basic
+
+/-!
+# Applying `ZMod.finEquiv`
+
+Mathlib defines `ZMod.finEquiv : Fin n ≃+* ZMod n` for `[NeZero n]` and states nothing about
+applying it. This file states the two evaluation rules as `@[simp]` lemmas, so that an argument
+indexed by `Fin n` rewrites into `ZMod n` arithmetic instead of being unfolded at each use.
+
+## Main results
+
+* `ZMod.finEquiv_apply`: `ZMod.finEquiv n j` is the natural cast of `j.val`.
+* `ZMod.finEquiv_symm_apply_val`: it is `(ZMod.finEquiv n).symm` that produces the canonical `Fin n`
+  representative of an element of `ZMod n`, and that representative's coerced natural value is
+  the element's `val`.
+-/
+
+public section
+
+namespace ZMod
+
+open Fin.CommRing in
+/-- **Applying `ZMod.finEquiv` is the natural cast.** `ZMod.finEquiv n j` is the image of `j.val`
+under `Nat.cast`.
+
+This is not definitional: the cast `((j : ℕ) : ZMod n)` reduces the natural `j.val` modulo `n`
+again, and it is `Fin.cast_val_eq_self` that says doing so returns `j`. The proof goes through
+stated lemmas rather than defeq — `Fin.cast_val_eq_self` to put `j` in natural-cast form, then
+`map_natCast` for the ring hom — so it does not depend on `finEquiv` being defined by cases on
+`n`. `Fin.instCommRing` is scoped (`Mathlib/Data/ZMod/Defs.lean`), hence the `open`. Mathlib
+states no evaluation rule for `finEquiv`, so this is the lemma a `Fin n`-indexed statement
+rewrites through. -/
+@[simp]
+lemma finEquiv_apply {n : ℕ} [NeZero n] (j : Fin n) :
+    (ZMod.finEquiv n) j = ((j : ℕ) : ZMod n) := by
+  conv_lhs => rw [← Fin.cast_val_eq_self j]
+  exact map_natCast (ZMod.finEquiv n) j.val
+
+/-- **The canonical `Fin n` representative of `z : ZMod n` has natural value `z.val`.** The
+representative is produced by `(ZMod.finEquiv n).symm`, not by `finEquiv` itself, which maps the
+other way. This is the companion of `finEquiv_apply`, and the form needed to index by `Fin n` an
+element obtained by solving in `ZMod n`. -/
+@[simp]
+lemma finEquiv_symm_apply_val {n : ℕ} [NeZero n] (z : ZMod n) :
+    (((ZMod.finEquiv n).symm z : Fin n) : ℕ) = z.val := by
+  -- Through the stated rules rather than the `ZMod (k+1) = Fin (k+1)` reduction: rewrite `z` as
+  -- `finEquiv` of its representative, then evaluate with `finEquiv_apply`.
+  conv_rhs => rw [← (ZMod.finEquiv n).apply_symm_apply z, finEquiv_apply]
+  exact (ZMod.val_natCast_of_lt ((ZMod.finEquiv n).symm z).isLt).symm
+
+end ZMod

--- a/TauCeti/Data/ZMod/FinEquiv.lean
+++ b/TauCeti/Data/ZMod/FinEquiv.lean
@@ -31,15 +31,16 @@ open Fin.CommRing in
 under `Nat.cast`.
 
 This is not definitional: the cast `((j : ℕ) : ZMod n)` reduces the natural `j.val` modulo `n`
-again, and it is `Fin.cast_val_eq_self` that says doing so returns `j`. The proof goes through
-stated lemmas rather than defeq — `Fin.cast_val_eq_self` to put `j` in natural-cast form, then
-`map_natCast` for the ring hom — so it does not depend on `finEquiv` being defined by cases on
-`n`. `Fin.instCommRing` is scoped (`Mathlib/Data/ZMod/Defs.lean`), hence the `open`. Mathlib
-states no evaluation rule for `finEquiv`, so this is the lemma a `Fin n`-indexed statement
-rewrites through. -/
+again, and it is `Fin.cast_val_eq_self` that says doing so returns `j`. Mathlib states no
+evaluation rule for `finEquiv`, so this is the lemma a `Fin n`-indexed statement rewrites
+through. -/
 @[simp]
 lemma finEquiv_apply {n : ℕ} [NeZero n] (j : Fin n) :
     (ZMod.finEquiv n) j = ((j : ℕ) : ZMod n) := by
+  -- Through stated lemmas rather than defeq: `Fin.cast_val_eq_self` puts `j` in natural-cast
+  -- form, then `map_natCast` moves the cast across the ring hom. So the proof does not depend on
+  -- `finEquiv` being defined by cases on `n`. `Fin.instCommRing` is scoped
+  -- (`Mathlib/Data/ZMod/Defs.lean`), hence the `open Fin.CommRing in` above.
   conv_lhs => rw [← Fin.cast_val_eq_self j]
   exact map_natCast (ZMod.finEquiv n) j.val
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/MoebiusZMod.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/MoebiusZMod.lean
@@ -185,20 +185,18 @@ to (`moebiusGL_smul_some` off the pole, `moebiusGL_smul_infty` at it, with
 `OnePoint.smul_some_eq_infty_iff` deciding which).
 
 The cast is part of the statement rather than something a caller reintroduces, so both evaluation
-lemmas rewrite with it directly.
-
-The proof puts both sides into `ZMod.finEquiv` form before appealing to `simp`. An explicit
-`simp only` chain would be preferable, but the goal after `Equiv.permCongr_apply` carries
-`(ZMod.finEquiv p).symm.symm` — `moebiusFin` is built from `(ZMod.finEquiv p).toEquiv.symm`, so
-that double symm is on the `Equiv`, not the `RingEquiv` — and neither `Equiv.symm_symm` nor
-`RingEquiv.symm_symm` discharges it inside `simp only`. Until a lemma set is found that closes
-it, the `rw`-then-`simp` route stays. -/
+lemmas rewrite with it directly. -/
 private lemma natCast_moebiusFin (M : Matrix (Fin 2) (Fin 2) ℤ)
     (h : ((M.det : ℤ) : ZMod p) ≠ 0) (b : Fin p) :
     ((moebiusFin M h b : ℕ) : ZMod p) =
       Equiv.removeNone (MulAction.toPerm
         (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (det_map_ne_zero M h)) :
           Equiv.Perm (OnePoint (ZMod p))) (((b : ℕ) : ZMod p)) := by
+  -- Both sides go into `ZMod.finEquiv` form before `simp`. An explicit `simp only` chain would
+  -- be preferable, but after `Equiv.permCongr_apply` the goal carries `(ZMod.finEquiv p).symm.symm`
+  -- — `moebiusFin` is built from `(ZMod.finEquiv p).toEquiv.symm`, so that double symm is on the
+  -- `Equiv`, not the `RingEquiv` — and neither `Equiv.symm_symm` nor `RingEquiv.symm_symm`
+  -- discharges it inside `simp only`. Until a lemma set closes it, this route stays.
   rw [← ZMod.finEquiv_apply, ← ZMod.finEquiv_apply]
   simp [moebiusFin, Equiv.permCongr_apply]
 /-- **The reindexing off the pole.** Where the denominator does not vanish, the index goes to the

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/MoebiusZMod.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/MoebiusZMod.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Field.ZMod
 public import Mathlib.Logic.Equiv.Option
 public import Mathlib.Topology.Compactification.OnePoint.ProjectiveLine
+public import TauCeti.Data.ZMod.FinEquiv
 public import TauCeti.Topology.Compactification.OnePoint.ProjectiveLine
 
 /-!
@@ -54,13 +55,18 @@ notion.
 The pole criterion itself is `OnePoint.smul_some_eq_infty_iff`, which this file adds to Mathlib's
 action API in `TauCeti/Topology/Compactification/OnePoint/ProjectiveLine.lean`; the two value
 lemmas come straight from Mathlib's `smul_some_eq_ite` / `smul_infty_eq_ite`.
-* `TauCeti.finEquiv_moebiusFin_apply_of_ne_zero` and
-  `TauCeti.finEquiv_moebiusFin_apply_of_eq_zero`: the two evaluation branches on `Fin p`, read
-  back through `ZMod.finEquiv` — the affine quotient where the denominator does not vanish, and
-  the image of `∞` at the single index where it does.
-These two are the elimination API for `moebiusFin`: its body is sealed across the module
-boundary, so `unfold` is not available to a consumer, and the equation they are proved from is
-private scaffold rather than public surface.
+* `TauCeti.natCast_moebiusFin_of_ne_zero` and `TauCeti.natCast_moebiusFin_of_eq_zero`: the two
+  evaluation branches, read in `ZMod p` through the natural cast of the index — the affine
+  quotient where the denominator does not vanish, and the image of `∞` at the single index where
+  it does.
+
+Uniqueness of the pole is not stated here. That exactly one residue solves `c * i + a = 0` in
+`ZMod n` for a unit `c` mentions no matrix, so it belongs with the generic `ZMod` arithmetic
+rather than in this file; a Möbius consumer instantiates it at `a := M 0 0` and `c := M 1 0`,
+and wrapping that instantiation in a matrix-level restatement would add no content.
+The two evaluation lemmas above are the elimination API for `moebiusFin`: its body is sealed
+across the module boundary, so `unfold` is not available to a consumer, and the equation they are
+proved from is private scaffold rather than public surface.
 
 Injectivity is not stated separately: `moebiusFin` is an `Equiv`, so consumers use
 `Equiv.injective`.
@@ -70,6 +76,14 @@ Injectivity is not stated separately: `moebiusFin` is an `Equiv`, so consumers u
 The statement being realised is AINTLIB's `moebiusFin` / `moebiusFin_injective`
 ([`LeanModularForms/HeckeRIngs/GL2/HeckeT_p.lean`](https://github.com/CBirkbeck/AINTLIB), commit
 `2baa76f742bdb4fb8ee323fabba41203bd390e08`, lines 124-242, Apache-2.0, Chris Birkbeck).
+
+The two pole lemmas AINTLIB also states are not here: being arithmetic in `ZMod p` with no matrix
+or determinant in sight, they belong with the generic `ZMod` arithmetic and are not part of this
+refactor.
+
+`ZMod.finEquiv_apply` and `ZMod.finEquiv_symm_apply_val` (in `TauCeti/Data/ZMod/FinEquiv.lean`)
+have no AINTLIB counterpart either: the source writes its reindexing directly in `ZMod p` and so
+never needs the `Fin`/`ZMod` bridge in either direction.
 
 **No code is transcribed.** The source builds the map by hand as an `if`-split on whether the
 denominator vanishes, and proves injectivity by a four-way case analysis resting on five
@@ -146,6 +160,14 @@ end Field
 
 variable {p : ℕ} [Fact p.Prime]
 
+/-- The mapped matrix is invertible when the cast determinant is nonzero. This is `Int.cast_det`
+read in the direction the `moebiusGL` argument needs; it is stated once because seven call sites
+below need it. -/
+private lemma det_map_ne_zero (M : Matrix (Fin 2) (Fin 2) ℤ)
+    (h : ((M.det : ℤ) : ZMod p) ≠ 0) :
+    (M.map (Int.cast : ℤ → ZMod p)).det ≠ 0 := by
+  rwa [Int.cast_det] at h
+
 /-- **The Möbius reindexing of `Fin p`.** Mathlib's action of `moebiusGL` on `OnePoint (ZMod p)`
 is a permutation; `Equiv.removeNone` deletes `∞` from it, patching the pole to the image of `∞`,
 and `Equiv.permCongr` along `ZMod.finEquiv` transports the result to `Fin p`. -/
@@ -153,54 +175,62 @@ noncomputable def moebiusFin (M : Matrix (Fin 2) (Fin 2) ℤ) (h : ((M.det : ℤ
     Equiv.Perm (Fin p) :=
   (ZMod.finEquiv p).toEquiv.symm.permCongr
     (Equiv.removeNone (MulAction.toPerm
-      (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (by rwa [Int.cast_det] at h)) :
+      (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (det_map_ne_zero M h)) :
         Equiv.Perm (OnePoint (ZMod p))))
 
-/-- **The reindexing at an index**, with the conjugation cancelled. `moebiusFin` is
-`Equiv.removeNone` of Mathlib's action, conjugated along `ZMod.finEquiv`; reading it this way
-strips the conjugation and leaves a statement the value lemmas above apply to directly
-(`moebiusGL_smul_some` off the pole, `moebiusGL_smul_infty` at it, with
+/-- **The reindexing at an index**, cast into `ZMod p` and with the conjugation cancelled.
+`moebiusFin` is `Equiv.removeNone` of Mathlib's action, conjugated along `ZMod.finEquiv`; stating
+it after the cast strips the conjugation and leaves exactly the shape the value lemmas above apply
+to (`moebiusGL_smul_some` off the pole, `moebiusGL_smul_infty` at it, with
 `OnePoint.smul_some_eq_infty_iff` deciding which).
 
-This is what a consumer uses: the body of `moebiusFin` is sealed across the module boundary, so
-`unfold` is not available to it. -/
-private lemma moebiusFin_apply (M : Matrix (Fin 2) (Fin 2) ℤ) (h : ((M.det : ℤ) : ZMod p) ≠ 0)
-    (b : Fin p) :
-    moebiusFin M h b = (ZMod.finEquiv p).symm
-      (Equiv.removeNone (MulAction.toPerm
-        (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (by rwa [Int.cast_det] at h)) :
-          Equiv.Perm (OnePoint (ZMod p))) ((ZMod.finEquiv p) b)) := by
+The cast is part of the statement rather than something a caller reintroduces, so both evaluation
+lemmas rewrite with it directly.
+
+The proof puts both sides into `ZMod.finEquiv` form before appealing to `simp`. An explicit
+`simp only` chain would be preferable, but the goal after `Equiv.permCongr_apply` carries
+`(ZMod.finEquiv p).symm.symm` — `moebiusFin` is built from `(ZMod.finEquiv p).toEquiv.symm`, so
+that double symm is on the `Equiv`, not the `RingEquiv` — and neither `Equiv.symm_symm` nor
+`RingEquiv.symm_symm` discharges it inside `simp only`. Until a lemma set is found that closes
+it, the `rw`-then-`simp` route stays. -/
+private lemma natCast_moebiusFin (M : Matrix (Fin 2) (Fin 2) ℤ)
+    (h : ((M.det : ℤ) : ZMod p) ≠ 0) (b : Fin p) :
+    ((moebiusFin M h b : ℕ) : ZMod p) =
+      Equiv.removeNone (MulAction.toPerm
+        (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (det_map_ne_zero M h)) :
+          Equiv.Perm (OnePoint (ZMod p))) (((b : ℕ) : ZMod p)) := by
+  rw [← ZMod.finEquiv_apply, ← ZMod.finEquiv_apply]
   simp [moebiusFin, Equiv.permCongr_apply]
 /-- **The reindexing off the pole.** Where the denominator does not vanish, the index goes to the
-affine Möbius value, read back through `ZMod.finEquiv`. -/
+affine Möbius value, read in `ZMod p` through the natural cast of its index. -/
 @[simp]
-lemma finEquiv_moebiusFin_apply_of_ne_zero (M : Matrix (Fin 2) (Fin 2) ℤ)
+lemma natCast_moebiusFin_of_ne_zero (M : Matrix (Fin 2) (Fin 2) ℤ)
     (h : ((M.det : ℤ) : ZMod p) ≠ 0) (b : Fin p)
-    (hb : ((M 1 0 : ℤ) : ZMod p) * (ZMod.finEquiv p b) + ((M 0 0 : ℤ) : ZMod p) ≠ 0) :
-    (ZMod.finEquiv p) (moebiusFin M h b) =
-      (((M 1 1 : ℤ) : ZMod p) * (ZMod.finEquiv p b) + ((M 0 1 : ℤ) : ZMod p)) /
-        (((M 1 0 : ℤ) : ZMod p) * (ZMod.finEquiv p b) + ((M 0 0 : ℤ) : ZMod p)) := by
+    (hb : ((M 1 0 : ℤ) : ZMod p) * ((b : ℕ) : ZMod p) + ((M 0 0 : ℤ) : ZMod p) ≠ 0) :
+    ((moebiusFin M h b : ℕ) : ZMod p) =
+      (((M 1 1 : ℤ) : ZMod p) * ((b : ℕ) : ZMod p) + ((M 0 1 : ℤ) : ZMod p)) /
+        (((M 1 0 : ℤ) : ZMod p) * ((b : ℕ) : ZMod p) + ((M 0 0 : ℤ) : ZMod p)) := by
   have hval : (MulAction.toPerm
-      (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (by rwa [Int.cast_det] at h)) :
-        Equiv.Perm (OnePoint (ZMod p))) ((ZMod.finEquiv p b : ZMod p) : OnePoint (ZMod p)) =
-      ((((M 1 1 : ℤ) : ZMod p) * (ZMod.finEquiv p b) + ((M 0 1 : ℤ) : ZMod p)) /
-        (((M 1 0 : ℤ) : ZMod p) * (ZMod.finEquiv p b) + ((M 0 0 : ℤ) : ZMod p)) :
+      (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (det_map_ne_zero M h)) :
+        Equiv.Perm (OnePoint (ZMod p))) ((((b : ℕ) : ZMod p) : ZMod p) : OnePoint (ZMod p)) =
+      ((((M 1 1 : ℤ) : ZMod p) * ((b : ℕ) : ZMod p) + ((M 0 1 : ℤ) : ZMod p)) /
+        (((M 1 0 : ℤ) : ZMod p) * ((b : ℕ) : ZMod p) + ((M 0 0 : ℤ) : ZMod p)) :
           ZMod p) := by
     simpa [Matrix.map_apply, hb] using
-      moebiusGL_smul_some (M.map (Int.cast : ℤ → ZMod p)) (by rwa [Int.cast_det] at h)
-        (ZMod.finEquiv p b)
+      moebiusGL_smul_some (M.map (Int.cast : ℤ → ZMod p)) (det_map_ne_zero M h)
+        ((b : ℕ) : ZMod p)
   have := Equiv.removeNone_some _ ⟨_, hval⟩
-  rw [moebiusFin_apply, RingEquiv.apply_symm_apply]
+  rw [natCast_moebiusFin]
   exact Option.some_inj.mp (this.trans hval)
 
 /-- **The reindexing at the pole.** At the single index where the denominator vanishes, the value
 is the image of `∞`. The denominator's leading entry cannot also vanish there: if it did the
 determinant would vanish mod `p`, so the quotient below is not a division by zero. -/
 @[simp]
-lemma finEquiv_moebiusFin_apply_of_eq_zero (M : Matrix (Fin 2) (Fin 2) ℤ)
+lemma natCast_moebiusFin_of_eq_zero (M : Matrix (Fin 2) (Fin 2) ℤ)
     (h : ((M.det : ℤ) : ZMod p) ≠ 0) (b : Fin p)
-    (hb : ((M 1 0 : ℤ) : ZMod p) * (ZMod.finEquiv p b) + ((M 0 0 : ℤ) : ZMod p) = 0) :
-    (ZMod.finEquiv p) (moebiusFin M h b) =
+    (hb : ((M 1 0 : ℤ) : ZMod p) * ((b : ℕ) : ZMod p) + ((M 0 0 : ℤ) : ZMod p) = 0) :
+    ((moebiusFin M h b : ℕ) : ZMod p) =
       ((M 1 1 : ℤ) : ZMod p) / ((M 1 0 : ℤ) : ZMod p) := by
   have h10 : ((M 1 0 : ℤ) : ZMod p) ≠ 0 := by
     intro hz
@@ -209,18 +239,18 @@ lemma finEquiv_moebiusFin_apply_of_eq_zero (M : Matrix (Fin 2) (Fin 2) ℤ)
     push_cast at h
     exact h (by rw [hb, hz]; ring)
   have hinf : (MulAction.toPerm
-      (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (by rwa [Int.cast_det] at h)) :
-        Equiv.Perm (OnePoint (ZMod p))) ((ZMod.finEquiv p b : ZMod p) : OnePoint (ZMod p)) =
+      (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (det_map_ne_zero M h)) :
+        Equiv.Perm (OnePoint (ZMod p))) ((((b : ℕ) : ZMod p) : ZMod p) : OnePoint (ZMod p)) =
       (∞ : OnePoint (ZMod p)) := by
     simp [Matrix.map_apply, hb]
   have hnone := Equiv.removeNone_none _ hinf
   have hval : (MulAction.toPerm
-      (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (by rwa [Int.cast_det] at h)) :
+      (moebiusGL (M.map (Int.cast : ℤ → ZMod p)) (det_map_ne_zero M h)) :
         Equiv.Perm (OnePoint (ZMod p))) (∞ : OnePoint (ZMod p)) =
       ((((M 1 1 : ℤ) : ZMod p) / ((M 1 0 : ℤ) : ZMod p) : ZMod p) : OnePoint (ZMod p)) := by
     simpa [Matrix.map_apply, h10] using
-      moebiusGL_smul_infty (M.map (Int.cast : ℤ → ZMod p)) (by rwa [Int.cast_det] at h)
-  rw [moebiusFin_apply, RingEquiv.apply_symm_apply]
+      moebiusGL_smul_infty (M.map (Int.cast : ℤ → ZMod p)) (det_map_ne_zero M h)
+  rw [natCast_moebiusFin]
   exact Option.some_inj.mp (hnone.trans hval)
 
 end TauCeti


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"moebius-natcast-restate"}-->

Split out of #3488 at the `scope` rubric's request: *"Ship the MoebiusZMod restatement and the
`det_map_ne_zero` extraction as their own PR (in scope a priori as a refactor, so it can land
immediately), leaving this PR as the new `ZMod` arithmetic plus its consumer."*

This is that PR. It changes no statement's mathematical content — it restates two merged public
lemmas in the normal form their consumers actually need, and removes seven copies of one tactic
proof.

## What changes

**`MoebiusZMod.lean`** — the two evaluation branches move from `finEquiv` form to natural-cast
form, which is the form a `Fin p`-indexed consumer holds:

| was (on `main`) | now |
| --- | --- |
| `finEquiv_moebiusFin_apply_of_ne_zero` | `natCast_moebiusFin_of_ne_zero` |
| `finEquiv_moebiusFin_apply_of_eq_zero` | `natCast_moebiusFin_of_eq_zero` |
| `private moebiusFin_apply` | `private natCast_moebiusFin` |

and a new `private det_map_ne_zero` replaces **seven** inline copies of
`(by rwa [Int.cast_det] at h)` (at `main`'s lines 175, 191, 205, 211, 233, 239, 243), with the
`MulAction.toPerm (moebiusGL …)` term that accompanied them restated six times rather than
inline.

**`TauCeti/Data/ZMod/FinEquiv.lean`** (new) — the two evaluation rules for Mathlib's
`ZMod.finEquiv`, which the restatement needs and which Mathlib does not provide:

```lean
@[simp] lemma ZMod.finEquiv_apply {n : ℕ} [NeZero n] (j : Fin n) :
    (ZMod.finEquiv n) j = ((j : ℕ) : ZMod n)

@[simp] lemma ZMod.finEquiv_symm_apply_val {n : ℕ} [NeZero n] (z : ZMod n) :
    (((ZMod.finEquiv n).symm z : Fin n) : ℕ) = z.val
```

Mathlib defines `finEquiv` (`Data/ZMod/Basic.lean:45`) and states nothing about applying it in
either direction. `main`'s `MoebiusZMod.lean` uses neither lemma — it cannot, they do not exist —
which is exactly why its statements are in `finEquiv` form.

`finEquiv_apply` is proved through stated lemmas rather than defeq (`Fin.cast_val_eq_self` then
`map_natCast`), so it does not depend on `finEquiv` being defined by cases on `n`.
`Fin.instCommRing` is scoped, hence the `open Fin.CommRing in`.

## Why `FinEquiv.lean` travels with the refactor rather than staying in #3488

The restatement is not expressible without it: converting a `finEquiv`-form statement to
natural-cast form *is* `finEquiv_apply`. Leaving it behind would leave a refactor that cannot
compile. #3488 retains `DvdAddMul.lean`, the `∃!` arithmetic, which is the part under discussion
there.

## Known follow-up, recorded rather than hidden

`natCast_moebiusFin`'s proof still opens with `rw [← ZMod.finEquiv_apply, ← ZMod.finEquiv_apply]`
before an unrestricted `simp`, i.e. it leaves simp-normal form and returns. The `proof-quality`
rubric on #3488 asked for an explicit `simp only` chain instead; the suggested chain does not
close, because after `Equiv.permCongr_apply` the goal carries `(ZMod.finEquiv p).symm.symm` —
`moebiusFin` is built from `(ZMod.finEquiv p).toEquiv.symm`, so that double symm is on the
`Equiv`, not the `RingEquiv` — and neither `Equiv.symm_symm` nor `RingEquiv.symm_symm` discharges
it inside `simp only`. The declaration docstring records this so the next reader does not repeat
the search.

## Provenance

`moebiusFin` and its evaluation lemmas are AINTLIB's
([`LeanModularForms/HeckeRIngs/GL2/HeckeT_p.lean`](https://github.com/CBirkbeck/AINTLIB), commit
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, lines 124-242, Apache-2.0, Chris Birkbeck) and were
merged previously; this PR only restates them. The two `finEquiv` rules have no AINTLIB
counterpart: the source writes its reindexing directly in `ZMod p` and never needs the
`Fin`/`ZMod` bridge in either direction.
