### PR TITLE
feat: transport the candidate simple group of an endomorphism

### DIFF
--- a/TauCeti/Algebra/Group/Subgroup/Map.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Map.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Group.Subgroup.Ker
+public import Mathlib.GroupTheory.Solvable
 public import Mathlib.GroupTheory.Subgroup.Center
 
 /-!
@@ -14,7 +15,19 @@ public import Mathlib.GroupTheory.Subgroup.Center
 Mathlib's `MonoidHom.subgroupComap` sends the preimage `K.comap f` of a subgroup `K` to `K`.
 Mathlib records that this map is surjective when `f` is
 (`MonoidHom.subgroupComap_surjective_of_surjective`); this file records the companion fact for
-injectivity. It also records how surjective homomorphisms act on centres.
+injectivity. It also records how surjective homomorphisms act on centres and on derived subgroups.
+
+An isomorphism carrying a subgroup `A` onto a subgroup `B` restricts to an isomorphism `↥A ≃* ↥B`.
+That restriction is `TauCeti.Subgroup.congrOfMapEq`, and every subgroup a construction transports
+along an isomorphism — here the derived subgroup, elsewhere the fixed subgroup of an endomorphism —
+uses it rather than repeating the composition of `MulEquiv.subgroupMap` with
+`MulEquiv.subgroupCongr`.
+
+## Main definitions
+
+* `TauCeti.Subgroup.congrOfMapEq`: the isomorphism of subgroups restricted from an isomorphism of
+  groups carrying the one onto the other.
+* `TauCeti.commutatorCongr`: its instance for the derived subgroup.
 
 ## Main results
 
@@ -24,6 +37,8 @@ injectivity. It also records how surjective homomorphisms act on centres.
   elements.
 * `TauCeti.MonoidHom.center_le_ker`: the centre lies in the kernel of a surjection onto a
   centreless group.
+* `TauCeti.Subgroup.map_commutator_eq_commutator`: a surjective homomorphism carries the derived
+  subgroup onto the derived subgroup.
 -/
 
 public section
@@ -63,5 +78,87 @@ theorem MonoidHom.center_le_ker (f : G →* H) (hf : Function.Surjective f)
   have hfx := Subgroup.map_center_le f hf ⟨x, hx, rfl⟩
   rw [hH, Subgroup.mem_bot] at hfx
   exact hfx
+
+/-! ## Restricting an isomorphism to a subgroup -/
+
+variable {K : Type*} [Group K]
+
+/-- The isomorphism of subgroups restricted from an isomorphism of groups carrying the one onto the
+other. -/
+def Subgroup.congrOfMapEq (e : G ≃* H) {A : Subgroup G} {B : Subgroup H}
+    (h : A.map (e : G →* H) = B) : ↥A ≃* ↥B :=
+  (e.subgroupMap A).trans (MulEquiv.subgroupCongr h)
+
+@[simp]
+theorem Subgroup.coe_congrOfMapEq_apply (e : G ≃* H) {A : Subgroup G} {B : Subgroup H}
+    (h : A.map (e : G →* H) = B) (x : ↥A) : (Subgroup.congrOfMapEq e h x : H) = e (x : G) := by
+  simp only [Subgroup.congrOfMapEq, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
+    MulEquiv.coe_subgroupMap_apply]
+
+@[simp]
+theorem Subgroup.coe_congrOfMapEq_symm_apply (e : G ≃* H) {A : Subgroup G} {B : Subgroup H}
+    (h : A.map (e : G →* H) = B) (y : ↥B) :
+    ((Subgroup.congrOfMapEq e h).symm y : G) = e.symm (y : H) := by
+  simp only [Subgroup.congrOfMapEq, MulEquiv.symm_trans_apply, MulEquiv.subgroupCongr_symm_apply,
+    MulEquiv.subgroupMap_symm_apply]
+
+@[simp]
+theorem Subgroup.congrOfMapEq_refl {A : Subgroup G}
+    (h : A.map (MulEquiv.refl G : G →* G) = A) :
+    Subgroup.congrOfMapEq (MulEquiv.refl G) h = MulEquiv.refl ↥A :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+@[simp]
+theorem Subgroup.congrOfMapEq_trans (e : G ≃* H) {A : Subgroup G} {B : Subgroup H}
+    (h : A.map (e : G →* H) = B) (f : H ≃* K) {C : Subgroup K}
+    (h' : B.map (f : H →* K) = C) :
+    (Subgroup.congrOfMapEq e h).trans (Subgroup.congrOfMapEq f h') =
+      Subgroup.congrOfMapEq (e.trans f)
+        (by rw [MulEquiv.coe_monoidHom_trans, ← _root_.Subgroup.map_map, h, h']) :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+-- Not `@[simp]`: with this in the simp set, `Subgroup.coe_congrOfMapEq_symm_apply` below is
+-- provable by `simp`, which the `simpNF` linter rejects.
+theorem Subgroup.congrOfMapEq_symm (e : G ≃* H) {A : Subgroup G} {B : Subgroup H}
+    (h : A.map (e : G →* H) = B) :
+    (Subgroup.congrOfMapEq e h).symm =
+      Subgroup.congrOfMapEq e.symm ((_root_.Subgroup.map_symm_eq_iff_map_eq A).mpr h) :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+/-! ## Transporting the derived subgroup -/
+
+/-- A surjective homomorphism carries the derived subgroup onto the derived subgroup. -/
+theorem Subgroup.map_commutator_eq_commutator {f : G →* H} (hf : Function.Surjective f) :
+    (commutator G).map f = commutator H := by
+  simpa using map_derivedSeries_eq hf 1
+
+/-- The isomorphism of derived subgroups restricted from an isomorphism of groups. -/
+def commutatorCongr (e : G ≃* H) : ↥(commutator G) ≃* ↥(commutator H) :=
+  Subgroup.congrOfMapEq e (Subgroup.map_commutator_eq_commutator e.surjective)
+
+@[simp]
+theorem coe_commutatorCongr_apply (e : G ≃* H) (x : ↥(commutator G)) :
+    (commutatorCongr e x : H) = e (x : G) :=
+  Subgroup.coe_congrOfMapEq_apply e _ x
+
+@[simp]
+theorem coe_commutatorCongr_symm_apply (e : G ≃* H) (y : ↥(commutator H)) :
+    ((commutatorCongr e).symm y : G) = e.symm (y : H) :=
+  Subgroup.coe_congrOfMapEq_symm_apply e _ y
+
+@[simp]
+theorem commutatorCongr_refl :
+    commutatorCongr (MulEquiv.refl G) = MulEquiv.refl ↥(commutator G) :=
+  Subgroup.congrOfMapEq_refl _
+
+@[simp]
+theorem commutatorCongr_trans (e : G ≃* H) (f : H ≃* K) :
+    (commutatorCongr e).trans (commutatorCongr f) = commutatorCongr (e.trans f) :=
+  Subgroup.congrOfMapEq_trans e _ f _
+
+-- Not `@[simp]`, for the reason given at `Subgroup.congrOfMapEq_symm`.
+theorem commutatorCongr_symm (e : G ≃* H) :
+    (commutatorCongr e).symm = commutatorCongr e.symm :=
+  Subgroup.congrOfMapEq_symm e _
 
 end TauCeti

--- a/TauCeti/GroupTheory/DerivedCentralQuotient.lean
+++ b/TauCeti/GroupTheory/DerivedCentralQuotient.lean
@@ -41,8 +41,8 @@ depends only on the isomorphism class of `G`.
 
 * `TauCeti.DerivedCentralQuotient`: the group `[G, G] / Z([G, G])`.
 * `TauCeti.DerivedCentralQuotient.lift`: the factorisation of a surjection onto a centreless group.
-* `TauCeti.commutatorCongr` and `TauCeti.DerivedCentralQuotient.congr`: transport of the derived
-  subgroup and of the derived central quotient along an isomorphism of groups.
+* `TauCeti.DerivedCentralQuotient.congr`: transport of the derived central quotient along an
+  isomorphism of groups, built from the transport `TauCeti.commutatorCongr` of the derived subgroup.
 
 ## Main results
 
@@ -87,46 +87,6 @@ theorem isPerfect_of_not_isMulCommutative [IsSimpleGroup G] (h : ¬ IsMulCommuta
   exact h (center_eq_top_iff.mp hb)
 
 end IsSimpleGroup
-
-/-! ## Transporting the derived subgroup -/
-
-variable {G' G'' : Type*} [Group G'] [Group G'']
-
-/-- An isomorphism of groups carries the derived subgroup onto the derived subgroup. -/
-theorem Subgroup.map_commutator_eq_commutator (ψ : G ≃* G') :
-    (commutator G).map (ψ : G →* G') = commutator G' := by
-  rw [map_commutator_eq, MonoidHom.range_eq_top_of_surjective _ ψ.surjective]
-  rfl
-
-/-- The isomorphism of derived subgroups induced by an isomorphism of groups. -/
-def commutatorCongr (ψ : G ≃* G') : ↥(commutator G) ≃* ↥(commutator G') :=
-  (ψ.subgroupMap (commutator G)).trans
-    (MulEquiv.subgroupCongr (Subgroup.map_commutator_eq_commutator ψ))
-
-@[simp]
-theorem coe_commutatorCongr_apply (ψ : G ≃* G') (x : ↥(commutator G)) :
-    (commutatorCongr ψ x : G') = ψ (x : G) := by
-  simp only [commutatorCongr, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
-    MulEquiv.coe_subgroupMap_apply]
-
-@[simp]
-theorem coe_commutatorCongr_symm_apply (ψ : G ≃* G') (y : ↥(commutator G')) :
-    ((commutatorCongr ψ).symm y : G) = ψ.symm (y : G') := by
-  simp only [commutatorCongr, MulEquiv.symm_trans_apply, MulEquiv.subgroupCongr_symm_apply,
-    MulEquiv.subgroupMap_symm_apply]
-
-@[simp]
-theorem commutatorCongr_refl :
-    commutatorCongr (MulEquiv.refl G) = MulEquiv.refl ↥(commutator G) :=
-  MulEquiv.ext fun _ => Subtype.ext (by simp)
-
-theorem commutatorCongr_trans (ψ : G ≃* G') (χ : G' ≃* G'') :
-    (commutatorCongr ψ).trans (commutatorCongr χ) = commutatorCongr (ψ.trans χ) :=
-  MulEquiv.ext fun _ => Subtype.ext (by simp)
-
-theorem commutatorCongr_symm (ψ : G ≃* G') :
-    (commutatorCongr ψ).symm = commutatorCongr ψ.symm :=
-  MulEquiv.ext fun _ => Subtype.ext (by simp)
 
 /-! ## The derived subgroup modulo its centre -/
 
@@ -244,6 +204,8 @@ theorem mulEquivSelf_mk [Group.IsPerfect ↥(commutator G)]
 
 /-! ### Transport along an isomorphism -/
 
+variable {G' G'' : Type*} [Group G'] [Group G'']
+
 /-- The derived central quotient transported along an isomorphism of groups.
 
 Both steps of the recipe are transported: the isomorphism restricts to the derived subgroups, and
@@ -264,17 +226,20 @@ theorem congr_refl :
     DerivedCentralQuotient.congr (MulEquiv.refl G) = MulEquiv.refl (DerivedCentralQuotient G) :=
   MulEquiv.ext fun x => QuotientGroup.induction_on x fun y => by simp
 
+@[simp]
 theorem congr_trans (ψ : G ≃* G') (χ : G' ≃* G'') :
     (DerivedCentralQuotient.congr ψ).trans (DerivedCentralQuotient.congr χ) =
       DerivedCentralQuotient.congr (ψ.trans χ) :=
   MulEquiv.ext fun x => QuotientGroup.induction_on x fun y => by
-    simp [← commutatorCongr_trans]
+    simp only [MulEquiv.trans_apply, congr_mk]
+    exact congrArg _ (Subtype.ext (by simp))
 
+@[simp]
 theorem congr_symm (ψ : G ≃* G') :
     (DerivedCentralQuotient.congr ψ).symm = DerivedCentralQuotient.congr ψ.symm :=
   MulEquiv.ext fun x => QuotientGroup.induction_on x fun y => by
-    apply (DerivedCentralQuotient.congr ψ).injective
-    simp [← commutatorCongr_symm]
+    simp only [DerivedCentralQuotient.congr, QuotientGroup.congr_symm, QuotientGroup.congr_mk,
+      commutatorCongr_symm]
 
 end DerivedCentralQuotient
 

--- a/TauCeti/GroupTheory/DerivedCentralQuotient.lean
+++ b/TauCeti/GroupTheory/DerivedCentralQuotient.lean
@@ -34,10 +34,21 @@ does nothing once it has succeeded: on a perfect group with trivial centre — i
 nonabelian simple group — it returns the group itself, and by Grün's lemma its output is centreless
 as soon as `[G, G]` is perfect, so a second application changes nothing.
 
+Two ways of comparing the output with another group are supplied, because the recipe names a group
+without describing it. Transport says that isomorphic groups have isomorphic derived central
+quotients, so the output depends only on the isomorphism class of `G`. Recognition says that a
+surjection from `[G, G]` onto a centreless group with central kernel *is* the derived central
+quotient; that is the shape in which the output is identified with a group given by some other
+construction, and it needs no description of `Z([G, G])`.
+
 ## Main definitions
 
 * `TauCeti.DerivedCentralQuotient`: the group `[G, G] / Z([G, G])`.
 * `TauCeti.DerivedCentralQuotient.lift`: the factorisation of a surjection onto a centreless group.
+* `TauCeti.DerivedCentralQuotient.mulEquivOfKerLeCenter`: the recognition isomorphism attached to a
+  surjection with central kernel onto a centreless group.
+* `TauCeti.commutatorCongr` and `TauCeti.DerivedCentralQuotient.congr`: transport of the derived
+  subgroup and of the derived central quotient along an isomorphism of groups.
 
 ## Main results
 
@@ -82,6 +93,46 @@ theorem isPerfect_of_not_isMulCommutative [IsSimpleGroup G] (h : ¬ IsMulCommuta
   exact h (center_eq_top_iff.mp hb)
 
 end IsSimpleGroup
+
+/-! ## Transporting the derived subgroup -/
+
+variable {G' G'' : Type*} [Group G'] [Group G'']
+
+/-- An isomorphism of groups carries the derived subgroup onto the derived subgroup. -/
+theorem Subgroup.map_commutator_eq_commutator (ψ : G ≃* G') :
+    (commutator G).map (ψ : G →* G') = commutator G' := by
+  rw [map_commutator_eq, MonoidHom.range_eq_top_of_surjective _ ψ.surjective]
+  rfl
+
+/-- The isomorphism of derived subgroups induced by an isomorphism of groups. -/
+def commutatorCongr (ψ : G ≃* G') : ↥(commutator G) ≃* ↥(commutator G') :=
+  (ψ.subgroupMap (commutator G)).trans
+    (MulEquiv.subgroupCongr (Subgroup.map_commutator_eq_commutator ψ))
+
+@[simp]
+theorem coe_commutatorCongr_apply (ψ : G ≃* G') (x : ↥(commutator G)) :
+    (commutatorCongr ψ x : G') = ψ (x : G) := by
+  simp only [commutatorCongr, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
+    MulEquiv.coe_subgroupMap_apply]
+
+@[simp]
+theorem coe_commutatorCongr_symm_apply (ψ : G ≃* G') (y : ↥(commutator G')) :
+    ((commutatorCongr ψ).symm y : G) = ψ.symm (y : G') := by
+  simp only [commutatorCongr, MulEquiv.symm_trans_apply, MulEquiv.subgroupCongr_symm_apply,
+    MulEquiv.subgroupMap_symm_apply]
+
+@[simp]
+theorem commutatorCongr_refl :
+    commutatorCongr (MulEquiv.refl G) = MulEquiv.refl ↥(commutator G) :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+theorem commutatorCongr_trans (ψ : G ≃* G') (χ : G' ≃* G'') :
+    (commutatorCongr ψ).trans (commutatorCongr χ) = commutatorCongr (ψ.trans χ) :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+theorem commutatorCongr_symm (ψ : G ≃* G') :
+    (commutatorCongr ψ).symm = commutatorCongr ψ.symm :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
 
 /-! ## The derived subgroup modulo its centre -/
 
@@ -137,6 +188,42 @@ theorem lift_surjective {K : Type*} [Group K] (f : ↥(commutator G) →* K)
     (hf : Function.Surjective f) (hK : center K = ⊥) : Function.Surjective (lift f hf hK) :=
   QuotientGroup.lift_surjective_of_surjective _ f hf
     (TauCeti.MonoidHom.center_le_ker f hf hK)
+
+/-- The kernel of a surjection from `[G, G]` onto a centreless group is exactly the centre as soon
+as it is central at all: the centre always lies in it, so the two hypotheses meet. -/
+theorem ker_eq_center {K : Type*} [Group K] (f : ↥(commutator G) →* K)
+    (hf : Function.Surjective f) (hK : center K = ⊥)
+    (hker : f.ker ≤ center ↥(commutator G)) : f.ker = center ↥(commutator G) :=
+  le_antisymm hker (TauCeti.MonoidHom.center_le_ker f hf hK)
+
+/-- **Recognition of the derived central quotient.** A surjection from `[G, G]` onto a centreless
+group with central kernel *is* the derived central quotient.
+
+This is the shape in which the output of the recipe is identified with a group produced by some
+other construction: exhibiting a surjection from `[H, H]` onto that group whose kernel is central
+suffices, and no description of `Z([H, H])` itself is needed. The centreless hypothesis on the
+target cannot be dropped, since the identity of `[G, G]` has trivial, hence central, kernel. -/
+noncomputable def mulEquivOfKerLeCenter {K : Type*} [Group K] (f : ↥(commutator G) →* K)
+    (hf : Function.Surjective f) (hK : center K = ⊥)
+    (hker : f.ker ≤ center ↥(commutator G)) : DerivedCentralQuotient G ≃* K :=
+  (QuotientGroup.quotientMulEquivOfEq (ker_eq_center f hf hK hker).symm).trans
+    (QuotientGroup.quotientKerEquivOfSurjective f hf)
+
+@[simp]
+theorem mulEquivOfKerLeCenter_mk {K : Type*} [Group K] (f : ↥(commutator G) →* K)
+    (hf : Function.Surjective f) (hK : center K = ⊥)
+    (hker : f.ker ≤ center ↥(commutator G)) (x : ↥(commutator G)) :
+    mulEquivOfKerLeCenter f hf hK hker (x : DerivedCentralQuotient G) = f x := by
+  simp only [mulEquivOfKerLeCenter, MulEquiv.trans_apply, QuotientGroup.quotientMulEquivOfEq_mk]
+  exact QuotientGroup.kerLift_mk ..
+
+/-- The recognition isomorphism is the factorisation of `f` through the quotient, so it is the
+unique homomorphism compatible with the quotient map. -/
+theorem toMonoidHom_mulEquivOfKerLeCenter {K : Type*} [Group K] (f : ↥(commutator G) →* K)
+    (hf : Function.Surjective f) (hK : center K = ⊥)
+    (hker : f.ker ≤ center ↥(commutator G)) :
+    (mulEquivOfKerLeCenter f hf hK hker : DerivedCentralQuotient G →* K) = lift f hf hK :=
+  lift_unique f hf hK _ fun x => mulEquivOfKerLeCenter_mk f hf hK hker x
 
 /-! ### The recipe on groups it has already succeeded on -/
 
@@ -196,6 +283,40 @@ theorem mulEquivSelf_mk [Group.IsPerfect ↥(commutator G)]
     mulEquivSelf (G := G) (x : DerivedCentralQuotient (DerivedCentralQuotient G)) =
       (x : DerivedCentralQuotient G) :=
   mulEquivOfCenterEqBot_mk center_eq_bot x
+
+/-! ### Transport along an isomorphism -/
+
+/-- The derived central quotient transported along an isomorphism of groups.
+
+Both steps of the recipe are transported: the isomorphism restricts to the derived subgroups, and
+that restriction carries the centre of the one onto the centre of the other. So the recipe depends
+only on the isomorphism class of `G`. -/
+def congr (ψ : G ≃* G') : DerivedCentralQuotient G ≃* DerivedCentralQuotient G' :=
+  QuotientGroup.congr _ _ (commutatorCongr ψ)
+    (TauCeti.Subgroup.map_center_eq_center (commutatorCongr ψ))
+
+@[simp]
+theorem congr_mk (ψ : G ≃* G') (x : ↥(commutator G)) :
+    DerivedCentralQuotient.congr ψ (x : DerivedCentralQuotient G) =
+      (commutatorCongr ψ x : DerivedCentralQuotient G') := by
+  simp only [DerivedCentralQuotient.congr, QuotientGroup.congr_mk]
+
+@[simp]
+theorem congr_refl :
+    DerivedCentralQuotient.congr (MulEquiv.refl G) = MulEquiv.refl (DerivedCentralQuotient G) :=
+  MulEquiv.ext fun x => QuotientGroup.induction_on x fun y => by simp
+
+theorem congr_trans (ψ : G ≃* G') (χ : G' ≃* G'') :
+    (DerivedCentralQuotient.congr ψ).trans (DerivedCentralQuotient.congr χ) =
+      DerivedCentralQuotient.congr (ψ.trans χ) :=
+  MulEquiv.ext fun x => QuotientGroup.induction_on x fun y => by
+    simp [← commutatorCongr_trans]
+
+theorem congr_symm (ψ : G ≃* G') :
+    (DerivedCentralQuotient.congr ψ).symm = DerivedCentralQuotient.congr ψ.symm :=
+  MulEquiv.ext fun x => QuotientGroup.induction_on x fun y => by
+    apply (DerivedCentralQuotient.congr ψ).injective
+    simp [← commutatorCongr_symm]
 
 end DerivedCentralQuotient
 

--- a/TauCeti/GroupTheory/DerivedCentralQuotient.lean
+++ b/TauCeti/GroupTheory/DerivedCentralQuotient.lean
@@ -34,19 +34,13 @@ does nothing once it has succeeded: on a perfect group with trivial centre — i
 nonabelian simple group — it returns the group itself, and by Grün's lemma its output is centreless
 as soon as `[G, G]` is perfect, so a second application changes nothing.
 
-Two ways of comparing the output with another group are supplied, because the recipe names a group
-without describing it. Transport says that isomorphic groups have isomorphic derived central
-quotients, so the output depends only on the isomorphism class of `G`. Recognition says that a
-surjection from `[G, G]` onto a centreless group with central kernel *is* the derived central
-quotient; that is the shape in which the output is identified with a group given by some other
-construction, and it needs no description of `Z([G, G])`.
+Transport says that isomorphic groups have isomorphic derived central quotients, so the output
+depends only on the isomorphism class of `G`.
 
 ## Main definitions
 
 * `TauCeti.DerivedCentralQuotient`: the group `[G, G] / Z([G, G])`.
 * `TauCeti.DerivedCentralQuotient.lift`: the factorisation of a surjection onto a centreless group.
-* `TauCeti.DerivedCentralQuotient.mulEquivOfKerLeCenter`: the recognition isomorphism attached to a
-  surjection with central kernel onto a centreless group.
 * `TauCeti.commutatorCongr` and `TauCeti.DerivedCentralQuotient.congr`: transport of the derived
   subgroup and of the derived central quotient along an isomorphism of groups.
 
@@ -188,42 +182,6 @@ theorem lift_surjective {K : Type*} [Group K] (f : ↥(commutator G) →* K)
     (hf : Function.Surjective f) (hK : center K = ⊥) : Function.Surjective (lift f hf hK) :=
   QuotientGroup.lift_surjective_of_surjective _ f hf
     (TauCeti.MonoidHom.center_le_ker f hf hK)
-
-/-- The kernel of a surjection from `[G, G]` onto a centreless group is exactly the centre as soon
-as it is central at all: the centre always lies in it, so the two hypotheses meet. -/
-theorem ker_eq_center {K : Type*} [Group K] (f : ↥(commutator G) →* K)
-    (hf : Function.Surjective f) (hK : center K = ⊥)
-    (hker : f.ker ≤ center ↥(commutator G)) : f.ker = center ↥(commutator G) :=
-  le_antisymm hker (TauCeti.MonoidHom.center_le_ker f hf hK)
-
-/-- **Recognition of the derived central quotient.** A surjection from `[G, G]` onto a centreless
-group with central kernel *is* the derived central quotient.
-
-This is the shape in which the output of the recipe is identified with a group produced by some
-other construction: exhibiting a surjection from `[H, H]` onto that group whose kernel is central
-suffices, and no description of `Z([H, H])` itself is needed. The centreless hypothesis on the
-target cannot be dropped, since the identity of `[G, G]` has trivial, hence central, kernel. -/
-noncomputable def mulEquivOfKerLeCenter {K : Type*} [Group K] (f : ↥(commutator G) →* K)
-    (hf : Function.Surjective f) (hK : center K = ⊥)
-    (hker : f.ker ≤ center ↥(commutator G)) : DerivedCentralQuotient G ≃* K :=
-  (QuotientGroup.quotientMulEquivOfEq (ker_eq_center f hf hK hker).symm).trans
-    (QuotientGroup.quotientKerEquivOfSurjective f hf)
-
-@[simp]
-theorem mulEquivOfKerLeCenter_mk {K : Type*} [Group K] (f : ↥(commutator G) →* K)
-    (hf : Function.Surjective f) (hK : center K = ⊥)
-    (hker : f.ker ≤ center ↥(commutator G)) (x : ↥(commutator G)) :
-    mulEquivOfKerLeCenter f hf hK hker (x : DerivedCentralQuotient G) = f x := by
-  simp only [mulEquivOfKerLeCenter, MulEquiv.trans_apply, QuotientGroup.quotientMulEquivOfEq_mk]
-  exact QuotientGroup.kerLift_mk ..
-
-/-- The recognition isomorphism is the factorisation of `f` through the quotient, so it is the
-unique homomorphism compatible with the quotient map. -/
-theorem toMonoidHom_mulEquivOfKerLeCenter {K : Type*} [Group K] (f : ↥(commutator G) →* K)
-    (hf : Function.Surjective f) (hK : center K = ⊥)
-    (hker : f.ker ≤ center ↥(commutator G)) :
-    (mulEquivOfKerLeCenter f hf hK hker : DerivedCentralQuotient G →* K) = lift f hf hK :=
-  lift_unique f hf hK _ fun x => mulEquivOfKerLeCenter_mk f hf hK hker x
 
 /-! ### The recipe on groups it has already succeeded on -/
 

--- a/TauCeti/GroupTheory/FixedPointCandidate.lean
+++ b/TauCeti/GroupTheory/FixedPointCandidate.lean
@@ -34,13 +34,6 @@ depends only on the isomorphism class of the *pair* `(G, F)`, which is what lets
 * `TauCeti.FixedPointCandidate`: the derived central quotient of a fixed subgroup.
 * `TauCeti.FixedPointCandidate.congr`: its transport along an isomorphism intertwining the two
   endomorphisms.
-* `TauCeti.FixedPointCandidate.congrEnd`: the same, with the endomorphism carried along by
-  conjugation rather than supplied.
-
-## Main results
-
-* `TauCeti.FixedPointCandidate.mulEquivId`: at the identity endomorphism the recipe returns the
-  derived central quotient of the whole group.
 
 ## References
 
@@ -94,38 +87,20 @@ theorem congr_refl (hψ : (MulEquiv.refl G : G →* G).comp F = F.comp (MulEquiv
     FixedPointCandidate.congr (MulEquiv.refl G) hψ = MulEquiv.refl (FixedPointCandidate F) := by
   rw [FixedPointCandidate.congr, fixedSubgroupCongr_refl, DerivedCentralQuotient.congr_refl]
 
+@[simp]
 theorem congr_trans (ψ : G ≃* G') (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G'))
     (χ : G' ≃* G'') (hχ : (χ : G' →* G'').comp F' = F''.comp (χ : G' →* G'')) :
     (FixedPointCandidate.congr ψ hψ).trans (FixedPointCandidate.congr χ hχ) =
-      FixedPointCandidate.congr (ψ.trans χ) (MulEquiv.trans_comp_eq_comp_trans hψ hχ) := by
+      FixedPointCandidate.congr (ψ.trans χ) (trans_comp_eq_comp_trans_of_comp_eq_comp hψ hχ) := by
   rw [FixedPointCandidate.congr, FixedPointCandidate.congr, FixedPointCandidate.congr,
     DerivedCentralQuotient.congr_trans, fixedSubgroupCongr_trans]
 
+@[simp]
 theorem congr_symm (ψ : G ≃* G') (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
     (FixedPointCandidate.congr ψ hψ).symm =
-      FixedPointCandidate.congr ψ.symm (MulEquiv.symm_comp_eq_comp_symm ψ hψ) := by
+      FixedPointCandidate.congr ψ.symm (symm_comp_eq_comp_symm_of_comp_eq_comp ψ hψ) := by
   rw [FixedPointCandidate.congr, FixedPointCandidate.congr, DerivedCentralQuotient.congr_symm,
     fixedSubgroupCongr_symm]
-
-/-- The candidate simple group transported along an isomorphism of the ambient group, with the
-endomorphism carried along by conjugation.
-
-This is the form a consumer replacing one realization of a pinned group by another uses: only the
-isomorphism of ambient groups has to be produced, and the Steinberg map on the other side is then
-determined. -/
-def congrEnd (ψ : G ≃* G') (F : G →* G) :
-    FixedPointCandidate F ≃* FixedPointCandidate (MulEquiv.endCongr ψ F) :=
-  FixedPointCandidate.congr ψ (MulEquiv.comp_eq_endCongr_comp ψ F)
-
-/-- At the identity endomorphism the recipe returns the derived central quotient of the whole
-group, since the identity fixes every point.
-
-This is the degenerate end of the construction, and the reason the two steps are composed in the
-stated order: no Steinberg endomorphism is involved, and what is left is exactly the
-derived-subgroup-modulo-its-centre step. -/
-def mulEquivId : FixedPointCandidate (MonoidHom.id G) ≃* DerivedCentralQuotient G :=
-  DerivedCentralQuotient.congr
-    ((MulEquiv.subgroupCongr (fixedSubgroup_eq_top_iff.mpr rfl)).trans Subgroup.topEquiv)
 
 end FixedPointCandidate
 

--- a/TauCeti/GroupTheory/FixedPointCandidate.lean
+++ b/TauCeti/GroupTheory/FixedPointCandidate.lean
@@ -23,9 +23,27 @@ algebraic group. Nothing here asserts that the result is finite or simple, and n
 involved: the composite is a carrier-independent prerequisite for the later family-by-family
 construction.
 
+Both steps of the recipe transport along an isomorphism, so the composite does too:
+`TauCeti.FixedPointCandidate.congr` turns an isomorphism `ψ : G ≃* G'` intertwining `F` with an
+endomorphism `F'` of `G'` into an isomorphism of the two candidates. The candidate therefore
+depends only on the isomorphism class of the *pair* `(G, F)`, which is what lets a construction of
+`(G, F)` be replaced by another realization of it without changing the group named. Comparison with
+a group produced by an unrelated construction is instead
+`TauCeti.DerivedCentralQuotient.mulEquivOfKerLeCenter`, which applies to the candidate verbatim
+because `FixedPointCandidate` is a derived central quotient.
+
 ## Main definitions
 
 * `TauCeti.FixedPointCandidate`: the derived central quotient of a fixed subgroup.
+* `TauCeti.FixedPointCandidate.congr`: its transport along an isomorphism intertwining the two
+  endomorphisms.
+* `TauCeti.FixedPointCandidate.congrEnd`: the same, with the endomorphism carried along by
+  conjugation rather than supplied.
+
+## Main results
+
+* `TauCeti.FixedPointCandidate.mulEquivId`: at the identity endomorphism the recipe returns the
+  derived central quotient of the whole group.
 
 ## References
 
@@ -51,5 +69,67 @@ parameters it can be trivial, nonsimple, a duplicate, or the separately indexed 
 these properties is asserted here. -/
 abbrev FixedPointCandidate (F : G →* G) : Type _ :=
   DerivedCentralQuotient ↥(fixedSubgroup F)
+
+namespace FixedPointCandidate
+
+variable {G' G'' : Type*} [Group G'] [Group G'']
+variable {F : G →* G} {F' : G' →* G'} {F'' : G'' →* G''}
+
+/-- The candidate simple group transported along an isomorphism intertwining the two
+endomorphisms.
+
+The isomorphism carries the fixed subgroup of the one onto the fixed subgroup of the other, and the
+derived central quotient of isomorphic groups are isomorphic, so the candidate depends only on the
+isomorphism class of the pair `(G, F)`. -/
+def congr (ψ : G ≃* G') (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
+    FixedPointCandidate F ≃* FixedPointCandidate F' :=
+  DerivedCentralQuotient.congr (fixedSubgroupCongr ψ hψ)
+
+@[simp]
+theorem congr_mk (ψ : G ≃* G') (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G'))
+    (x : ↥(commutator ↥(fixedSubgroup F))) :
+    FixedPointCandidate.congr ψ hψ (x : FixedPointCandidate F) =
+      (commutatorCongr (fixedSubgroupCongr ψ hψ) x : FixedPointCandidate F') := by
+  simp only [FixedPointCandidate.congr, DerivedCentralQuotient.congr_mk]
+
+@[simp]
+theorem congr_refl (hψ : (MulEquiv.refl G : G →* G).comp F = F.comp (MulEquiv.refl G : G →* G)) :
+    FixedPointCandidate.congr (MulEquiv.refl G) hψ = MulEquiv.refl (FixedPointCandidate F) := by
+  rw [FixedPointCandidate.congr, fixedSubgroupCongr_refl, DerivedCentralQuotient.congr_refl]
+
+theorem congr_trans (ψ : G ≃* G') (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G'))
+    (χ : G' ≃* G'') (hχ : (χ : G' →* G'').comp F' = F''.comp (χ : G' →* G'')) :
+    (FixedPointCandidate.congr ψ hψ).trans (FixedPointCandidate.congr χ hχ) =
+      FixedPointCandidate.congr (ψ.trans χ) (MulEquiv.trans_comp_eq_comp_trans hψ hχ) := by
+  rw [FixedPointCandidate.congr, FixedPointCandidate.congr, FixedPointCandidate.congr,
+    DerivedCentralQuotient.congr_trans, fixedSubgroupCongr_trans]
+
+theorem congr_symm (ψ : G ≃* G') (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
+    (FixedPointCandidate.congr ψ hψ).symm =
+      FixedPointCandidate.congr ψ.symm (MulEquiv.symm_comp_eq_comp_symm ψ hψ) := by
+  rw [FixedPointCandidate.congr, FixedPointCandidate.congr, DerivedCentralQuotient.congr_symm,
+    fixedSubgroupCongr_symm]
+
+/-- The candidate simple group transported along an isomorphism of the ambient group, with the
+endomorphism carried along by conjugation.
+
+This is the form a consumer replacing one realization of a pinned group by another uses: only the
+isomorphism of ambient groups has to be produced, and the Steinberg map on the other side is then
+determined. -/
+def congrEnd (ψ : G ≃* G') (F : G →* G) :
+    FixedPointCandidate F ≃* FixedPointCandidate (MulEquiv.endCongr ψ F) :=
+  FixedPointCandidate.congr ψ (MulEquiv.comp_eq_endCongr_comp ψ F)
+
+/-- At the identity endomorphism the recipe returns the derived central quotient of the whole
+group, since the identity fixes every point.
+
+This is the degenerate end of the construction, and the reason the two steps are composed in the
+stated order: no Steinberg endomorphism is involved, and what is left is exactly the
+derived-subgroup-modulo-its-centre step. -/
+def mulEquivId : FixedPointCandidate (MonoidHom.id G) ≃* DerivedCentralQuotient G :=
+  DerivedCentralQuotient.congr
+    ((MulEquiv.subgroupCongr (fixedSubgroup_eq_top_iff.mpr rfl)).trans Subgroup.topEquiv)
+
+end FixedPointCandidate
 
 end TauCeti

--- a/TauCeti/GroupTheory/FixedPointCandidate.lean
+++ b/TauCeti/GroupTheory/FixedPointCandidate.lean
@@ -27,10 +27,7 @@ Both steps of the recipe transport along an isomorphism, so the composite does t
 `TauCeti.FixedPointCandidate.congr` turns an isomorphism `ψ : G ≃* G'` intertwining `F` with an
 endomorphism `F'` of `G'` into an isomorphism of the two candidates. The candidate therefore
 depends only on the isomorphism class of the *pair* `(G, F)`, which is what lets a construction of
-`(G, F)` be replaced by another realization of it without changing the group named. Comparison with
-a group produced by an unrelated construction is instead
-`TauCeti.DerivedCentralQuotient.mulEquivOfKerLeCenter`, which applies to the candidate verbatim
-because `FixedPointCandidate` is a derived central quotient.
+`(G, F)` be replaced by another realization of it without changing the group named.
 
 ## Main definitions
 

--- a/TauCeti/GroupTheory/FixedSubgroup.lean
+++ b/TauCeti/GroupTheory/FixedSubgroup.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.Group.Subgroup.Map
 public import Mathlib.Algebra.Group.Equiv.Basic
 public import Mathlib.Algebra.Group.Subgroup.Ker
 
@@ -39,6 +40,9 @@ endomorphism of it, so it is available before any ambient group has been constru
   fixed by the one to the points fixed by the other.
 * `TauCeti.map_fixedSubgroup_eq`: an isomorphism intertwining them carries the one *onto* the other.
 * `TauCeti.fixedSubgroupCongr`: the resulting isomorphism of fixed subgroups.
+* `TauCeti.symm_comp_eq_comp_symm_of_comp_eq_comp` and
+  `TauCeti.trans_comp_eq_comp_trans_of_comp_eq_comp`: intertwining relations invert and compose,
+  which is what makes that isomorphism symmetric and transitive.
 
 ## References
 
@@ -51,7 +55,7 @@ public section
 
 namespace TauCeti
 
-open Subgroup
+open _root_.Subgroup
 
 variable {G : Type*} [Group G]
 
@@ -105,25 +109,22 @@ variable {F : G →* G} {F' : G' →* G'}
 
 The equation is not symmetric in `ψ` and `ψ.symm`, so this is what makes the transport of the fixed
 subgroup two-sided. -/
-theorem _root_.MulEquiv.symm_comp_eq_comp_symm (ψ : G ≃* G')
+theorem symm_comp_eq_comp_symm_of_comp_eq_comp (ψ : G ≃* G')
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
-    (ψ.symm : G' →* G).comp F' = F.comp (ψ.symm : G' →* G) := by
-  ext y
-  apply ψ.injective
-  simpa using (DFunLike.congr_fun hψ (ψ.symm y)).symm
+    (ψ.symm : G' →* G).comp F' = F.comp (ψ.symm : G' →* G) :=
+  have h : Function.Semiconj ψ F F' := fun x => DFunLike.congr_fun hψ x
+  MonoidHom.ext (h.inverse_left ψ.symm_apply_apply ψ.apply_symm_apply)
 
 variable {G'' : Type*} [Group G''] {F'' : G'' →* G''}
 
 /-- Intertwining relations compose. -/
-theorem _root_.MulEquiv.trans_comp_eq_comp_trans {ψ : G ≃* G'} {χ : G' ≃* G''}
+theorem trans_comp_eq_comp_trans_of_comp_eq_comp {ψ : G ≃* G'} {χ : G' ≃* G''}
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G'))
     (hχ : (χ : G' →* G'').comp F' = F''.comp (χ : G' →* G'')) :
-    ((ψ.trans χ : G ≃* G'') : G →* G'').comp F = F''.comp ((ψ.trans χ : G ≃* G'') : G →* G'') := by
-  ext x
-  have h₁ : ψ (F x) = F' (ψ x) := DFunLike.congr_fun hψ x
-  have h₂ : χ (F' (ψ x)) = F'' (χ (ψ x)) := DFunLike.congr_fun hχ (ψ x)
-  change χ (ψ (F x)) = F'' (χ (ψ x))
-  rw [h₁, h₂]
+    ((ψ.trans χ : G ≃* G'') : G →* G'').comp F = F''.comp ((ψ.trans χ : G ≃* G'') : G →* G'') :=
+  have h₁ : Function.Semiconj ψ F F' := fun x => DFunLike.congr_fun hψ x
+  have h₂ : Function.Semiconj χ F' F'' := fun x => DFunLike.congr_fun hχ x
+  MonoidHom.ext (h₁.trans h₂)
 
 /-- An isomorphism intertwining two endomorphisms carries the points fixed by the one *onto* the
 points fixed by the other. -/
@@ -132,7 +133,8 @@ theorem map_fixedSubgroup_eq (ψ : G ≃* G')
     (fixedSubgroup F).map (ψ : G →* G') = fixedSubgroup F' :=
   le_antisymm (map_fixedSubgroup_le _ hψ) fun y hy =>
     ⟨ψ.symm y,
-      map_fixedSubgroup_le (ψ.symm : G' →* G) (MulEquiv.symm_comp_eq_comp_symm ψ hψ) ⟨y, hy, rfl⟩,
+      map_fixedSubgroup_le (ψ.symm : G' →* G) (symm_comp_eq_comp_symm_of_comp_eq_comp ψ hψ)
+        ⟨y, hy, rfl⟩,
       ψ.apply_symm_apply y⟩
 
 /-- The isomorphism of fixed subgroups induced by an isomorphism intertwining the two
@@ -140,80 +142,39 @@ endomorphisms. -/
 def fixedSubgroupCongr (ψ : G ≃* G')
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
     ↥(fixedSubgroup F) ≃* ↥(fixedSubgroup F') :=
-  (ψ.subgroupMap (fixedSubgroup F)).trans (MulEquiv.subgroupCongr (map_fixedSubgroup_eq ψ hψ))
+  Subgroup.congrOfMapEq ψ (map_fixedSubgroup_eq ψ hψ)
 
 @[simp]
 theorem coe_fixedSubgroupCongr_apply (ψ : G ≃* G')
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) (x : ↥(fixedSubgroup F)) :
-    (fixedSubgroupCongr ψ hψ x : G') = ψ (x : G) := by
-  simp only [fixedSubgroupCongr, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
-    MulEquiv.coe_subgroupMap_apply]
+    (fixedSubgroupCongr ψ hψ x : G') = ψ (x : G) :=
+  Subgroup.coe_congrOfMapEq_apply ψ _ x
 
 @[simp]
 theorem coe_fixedSubgroupCongr_symm_apply (ψ : G ≃* G')
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) (y : ↥(fixedSubgroup F')) :
-    ((fixedSubgroupCongr ψ hψ).symm y : G) = ψ.symm (y : G') := by
-  simp only [fixedSubgroupCongr, MulEquiv.symm_trans_apply, MulEquiv.subgroupCongr_symm_apply,
-    MulEquiv.subgroupMap_symm_apply]
+    ((fixedSubgroupCongr ψ hψ).symm y : G) = ψ.symm (y : G') :=
+  Subgroup.coe_congrOfMapEq_symm_apply ψ _ y
 
 @[simp]
 theorem fixedSubgroupCongr_refl
     (hψ : (MulEquiv.refl G : G →* G).comp F = F.comp (MulEquiv.refl G : G →* G)) :
     fixedSubgroupCongr (MulEquiv.refl G) hψ = MulEquiv.refl ↥(fixedSubgroup F) :=
-  MulEquiv.ext fun _ => Subtype.ext (by simp)
+  Subgroup.congrOfMapEq_refl _
 
+@[simp]
 theorem fixedSubgroupCongr_trans (ψ : G ≃* G')
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) (χ : G' ≃* G'')
     (hχ : (χ : G' →* G'').comp F' = F''.comp (χ : G' →* G'')) :
     (fixedSubgroupCongr ψ hψ).trans (fixedSubgroupCongr χ hχ) =
-      fixedSubgroupCongr (ψ.trans χ) (MulEquiv.trans_comp_eq_comp_trans hψ hχ) :=
-  MulEquiv.ext fun _ => Subtype.ext (by simp)
+      fixedSubgroupCongr (ψ.trans χ) (trans_comp_eq_comp_trans_of_comp_eq_comp hψ hχ) :=
+  Subgroup.congrOfMapEq_trans _ _ _ _
 
+-- Not `@[simp]`, for the reason given at `TauCeti.Subgroup.congrOfMapEq_symm`.
 theorem fixedSubgroupCongr_symm (ψ : G ≃* G')
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
     (fixedSubgroupCongr ψ hψ).symm =
-      fixedSubgroupCongr ψ.symm (MulEquiv.symm_comp_eq_comp_symm ψ hψ) :=
-  MulEquiv.ext fun _ => Subtype.ext (by simp)
-
-/-! ### Transporting the endomorphism as well
-
-A consumer usually has an isomorphism `ψ : G ≃* G'` and an endomorphism of `G`, and no candidate
-`F'` in hand. Conjugating `F` by `ψ` supplies one, and it is the only choice: `ψ` intertwines `F`
-with `F'` exactly when `F'` is that conjugate. -/
-
-/-- The endomorphism of `G'` obtained by conjugating an endomorphism of `G` by an isomorphism. -/
-def _root_.MulEquiv.endCongr (ψ : G ≃* G') : (G →* G) ≃ (G' →* G') :=
-  (MulEquiv.monoidHomCongrLeftEquiv (N := G) ψ).trans (MulEquiv.monoidHomCongrRightEquiv ψ)
-
-@[simp]
-theorem _root_.MulEquiv.endCongr_apply (ψ : G ≃* G') (F : G →* G) (y : G') :
-    MulEquiv.endCongr ψ F y = ψ (F (ψ.symm y)) := by
-  simp only [MulEquiv.endCongr, Equiv.trans_apply, MulEquiv.monoidHomCongrLeftEquiv_apply,
-    MulEquiv.monoidHomCongrRightEquiv_apply, MonoidHom.coe_comp, Function.comp_apply,
-    MulEquiv.coe_toMonoidHom]
-
-/-- An isomorphism intertwines an endomorphism with its own conjugate. -/
-theorem _root_.MulEquiv.comp_eq_endCongr_comp (ψ : G ≃* G') (F : G →* G) :
-    (ψ : G →* G').comp F = (MulEquiv.endCongr ψ F).comp (ψ : G →* G') := by
-  ext x
-  simp
-
-/-- An isomorphism intertwines `F` with `F'` exactly when `F'` is the conjugate of `F`, so no
-generality is lost by conjugating. -/
-theorem _root_.MulEquiv.comp_eq_comp_iff_eq_endCongr (ψ : G ≃* G') :
-    (ψ : G →* G').comp F = F'.comp (ψ : G →* G') ↔ MulEquiv.endCongr ψ F = F' := by
-  refine ⟨fun h => MonoidHom.ext fun y => ?_, fun h => h ▸ MulEquiv.comp_eq_endCongr_comp ψ F⟩
-  simpa using DFunLike.congr_fun h (ψ.symm y)
-
-/-- The isomorphism of fixed subgroups induced by an isomorphism of the ambient group, with the
-endomorphism carried along by conjugation. -/
-def fixedSubgroupCongrEnd (ψ : G ≃* G') (F : G →* G) :
-    ↥(fixedSubgroup F) ≃* ↥(fixedSubgroup (MulEquiv.endCongr ψ F)) :=
-  fixedSubgroupCongr ψ (MulEquiv.comp_eq_endCongr_comp ψ F)
-
-@[simp]
-theorem coe_fixedSubgroupCongrEnd_apply (ψ : G ≃* G') (F : G →* G) (x : ↥(fixedSubgroup F)) :
-    (fixedSubgroupCongrEnd ψ F x : G') = ψ (x : G) :=
-  coe_fixedSubgroupCongr_apply _ _ x
+      fixedSubgroupCongr ψ.symm (symm_comp_eq_comp_symm_of_comp_eq_comp ψ hψ) :=
+  Subgroup.congrOfMapEq_symm _ _
 
 end TauCeti

--- a/TauCeti/GroupTheory/FixedSubgroup.lean
+++ b/TauCeti/GroupTheory/FixedSubgroup.lean
@@ -105,7 +105,7 @@ variable {F : G →* G} {F' : G' →* G'}
 
 The equation is not symmetric in `ψ` and `ψ.symm`, so this is what makes the transport of the fixed
 subgroup two-sided. -/
-theorem MulEquiv.symm_comp_eq_comp_symm (ψ : G ≃* G')
+theorem _root_.MulEquiv.symm_comp_eq_comp_symm (ψ : G ≃* G')
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
     (ψ.symm : G' →* G).comp F' = F.comp (ψ.symm : G' →* G) := by
   ext y
@@ -115,7 +115,7 @@ theorem MulEquiv.symm_comp_eq_comp_symm (ψ : G ≃* G')
 variable {G'' : Type*} [Group G''] {F'' : G'' →* G''}
 
 /-- Intertwining relations compose. -/
-theorem MulEquiv.trans_comp_eq_comp_trans {ψ : G ≃* G'} {χ : G' ≃* G''}
+theorem _root_.MulEquiv.trans_comp_eq_comp_trans {ψ : G ≃* G'} {χ : G' ≃* G''}
     (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G'))
     (hχ : (χ : G' →* G'').comp F' = F''.comp (χ : G' →* G'')) :
     ((ψ.trans χ : G ≃* G'') : G →* G'').comp F = F''.comp ((ψ.trans χ : G ≃* G'') : G →* G'') := by
@@ -182,25 +182,25 @@ A consumer usually has an isomorphism `ψ : G ≃* G'` and an endomorphism of `G
 with `F'` exactly when `F'` is that conjugate. -/
 
 /-- The endomorphism of `G'` obtained by conjugating an endomorphism of `G` by an isomorphism. -/
-def MulEquiv.endCongr (ψ : G ≃* G') : (G →* G) ≃ (G' →* G') :=
+def _root_.MulEquiv.endCongr (ψ : G ≃* G') : (G →* G) ≃ (G' →* G') :=
   (MulEquiv.monoidHomCongrLeftEquiv (N := G) ψ).trans (MulEquiv.monoidHomCongrRightEquiv ψ)
 
 @[simp]
-theorem MulEquiv.endCongr_apply (ψ : G ≃* G') (F : G →* G) (y : G') :
+theorem _root_.MulEquiv.endCongr_apply (ψ : G ≃* G') (F : G →* G) (y : G') :
     MulEquiv.endCongr ψ F y = ψ (F (ψ.symm y)) := by
   simp only [MulEquiv.endCongr, Equiv.trans_apply, MulEquiv.monoidHomCongrLeftEquiv_apply,
     MulEquiv.monoidHomCongrRightEquiv_apply, MonoidHom.coe_comp, Function.comp_apply,
     MulEquiv.coe_toMonoidHom]
 
 /-- An isomorphism intertwines an endomorphism with its own conjugate. -/
-theorem MulEquiv.comp_eq_endCongr_comp (ψ : G ≃* G') (F : G →* G) :
+theorem _root_.MulEquiv.comp_eq_endCongr_comp (ψ : G ≃* G') (F : G →* G) :
     (ψ : G →* G').comp F = (MulEquiv.endCongr ψ F).comp (ψ : G →* G') := by
   ext x
   simp
 
 /-- An isomorphism intertwines `F` with `F'` exactly when `F'` is the conjugate of `F`, so no
 generality is lost by conjugating. -/
-theorem MulEquiv.comp_eq_comp_iff_eq_endCongr (ψ : G ≃* G') :
+theorem _root_.MulEquiv.comp_eq_comp_iff_eq_endCongr (ψ : G ≃* G') :
     (ψ : G →* G').comp F = F'.comp (ψ : G →* G') ↔ MulEquiv.endCongr ψ F = F' := by
   refine ⟨fun h => MonoidHom.ext fun y => ?_, fun h => h ▸ MulEquiv.comp_eq_endCongr_comp ψ F⟩
   simpa using DFunLike.congr_fun h (ψ.symm y)

--- a/TauCeti/GroupTheory/FixedSubgroup.lean
+++ b/TauCeti/GroupTheory/FixedSubgroup.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.Group.Equiv.Basic
 public import Mathlib.Algebra.Group.Subgroup.Ker
 
 /-!
@@ -16,7 +17,14 @@ Let `F` be an endomorphism of a group `G`. This file studies the subgroup
 fixedSubgroup F = F.eqLocus (MonoidHom.id G)
 ```
 
-of points of `G` fixed by `F`: when it is everything and how it grows along the powers of `F`.
+of points of `G` fixed by `F`: when it is everything, how it grows along the powers of `F`, and how
+it transports along an isomorphism of the ambient group.
+
+An isomorphism `ψ : G ≃* G'` *intertwines* `F` with an endomorphism `F'` of `G'` when
+`ψ ∘ F = F' ∘ ψ`. Such a `ψ` carries `fixedSubgroup F` onto `fixedSubgroup F'`, so the pair
+`(G, F)` determines its fixed subgroup up to isomorphism and not merely up to inclusion. The
+one-sided statement for a homomorphism is `TauCeti.map_fixedSubgroup_le`; the two-sided statements
+are `TauCeti.map_fixedSubgroup_eq` and `TauCeti.fixedSubgroupCongr`.
 
 Nothing here is specific to any particular endomorphism: the material needs only a group and an
 endomorphism of it, so it is available before any ambient group has been constructed.
@@ -29,6 +37,8 @@ endomorphism of it, so it is available before any ambient group has been constru
   its powers.
 * `TauCeti.map_fixedSubgroup_le`: a homomorphism intertwining two endomorphisms carries the points
   fixed by the one to the points fixed by the other.
+* `TauCeti.map_fixedSubgroup_eq`: an isomorphism intertwining them carries the one *onto* the other.
+* `TauCeti.fixedSubgroupCongr`: the resulting isomorphism of fixed subgroups.
 
 ## References
 
@@ -86,5 +96,124 @@ theorem map_fixedSubgroup_le {F : G →* G} {F' : G' →* G'} (ψ : G →* G')
   rintro _ ⟨x, hx, rfl⟩
   rw [mem_fixedSubgroup, ← MonoidHom.comp_apply, ← hψ, MonoidHom.comp_apply,
     mem_fixedSubgroup.mp hx]
+
+/-! ### Transport along an isomorphism of the ambient group -/
+
+variable {F : G →* G} {F' : G' →* G'}
+
+/-- An isomorphism intertwining two endomorphisms has an inverse intertwining them the other way.
+
+The equation is not symmetric in `ψ` and `ψ.symm`, so this is what makes the transport of the fixed
+subgroup two-sided. -/
+theorem MulEquiv.symm_comp_eq_comp_symm (ψ : G ≃* G')
+    (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
+    (ψ.symm : G' →* G).comp F' = F.comp (ψ.symm : G' →* G) := by
+  ext y
+  apply ψ.injective
+  simpa using (DFunLike.congr_fun hψ (ψ.symm y)).symm
+
+variable {G'' : Type*} [Group G''] {F'' : G'' →* G''}
+
+/-- Intertwining relations compose. -/
+theorem MulEquiv.trans_comp_eq_comp_trans {ψ : G ≃* G'} {χ : G' ≃* G''}
+    (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G'))
+    (hχ : (χ : G' →* G'').comp F' = F''.comp (χ : G' →* G'')) :
+    ((ψ.trans χ : G ≃* G'') : G →* G'').comp F = F''.comp ((ψ.trans χ : G ≃* G'') : G →* G'') := by
+  ext x
+  have h₁ : ψ (F x) = F' (ψ x) := DFunLike.congr_fun hψ x
+  have h₂ : χ (F' (ψ x)) = F'' (χ (ψ x)) := DFunLike.congr_fun hχ (ψ x)
+  change χ (ψ (F x)) = F'' (χ (ψ x))
+  rw [h₁, h₂]
+
+/-- An isomorphism intertwining two endomorphisms carries the points fixed by the one *onto* the
+points fixed by the other. -/
+theorem map_fixedSubgroup_eq (ψ : G ≃* G')
+    (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
+    (fixedSubgroup F).map (ψ : G →* G') = fixedSubgroup F' :=
+  le_antisymm (map_fixedSubgroup_le _ hψ) fun y hy =>
+    ⟨ψ.symm y,
+      map_fixedSubgroup_le (ψ.symm : G' →* G) (MulEquiv.symm_comp_eq_comp_symm ψ hψ) ⟨y, hy, rfl⟩,
+      ψ.apply_symm_apply y⟩
+
+/-- The isomorphism of fixed subgroups induced by an isomorphism intertwining the two
+endomorphisms. -/
+def fixedSubgroupCongr (ψ : G ≃* G')
+    (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
+    ↥(fixedSubgroup F) ≃* ↥(fixedSubgroup F') :=
+  (ψ.subgroupMap (fixedSubgroup F)).trans (MulEquiv.subgroupCongr (map_fixedSubgroup_eq ψ hψ))
+
+@[simp]
+theorem coe_fixedSubgroupCongr_apply (ψ : G ≃* G')
+    (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) (x : ↥(fixedSubgroup F)) :
+    (fixedSubgroupCongr ψ hψ x : G') = ψ (x : G) := by
+  simp only [fixedSubgroupCongr, MulEquiv.trans_apply, MulEquiv.subgroupCongr_apply,
+    MulEquiv.coe_subgroupMap_apply]
+
+@[simp]
+theorem coe_fixedSubgroupCongr_symm_apply (ψ : G ≃* G')
+    (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) (y : ↥(fixedSubgroup F')) :
+    ((fixedSubgroupCongr ψ hψ).symm y : G) = ψ.symm (y : G') := by
+  simp only [fixedSubgroupCongr, MulEquiv.symm_trans_apply, MulEquiv.subgroupCongr_symm_apply,
+    MulEquiv.subgroupMap_symm_apply]
+
+@[simp]
+theorem fixedSubgroupCongr_refl
+    (hψ : (MulEquiv.refl G : G →* G).comp F = F.comp (MulEquiv.refl G : G →* G)) :
+    fixedSubgroupCongr (MulEquiv.refl G) hψ = MulEquiv.refl ↥(fixedSubgroup F) :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+theorem fixedSubgroupCongr_trans (ψ : G ≃* G')
+    (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) (χ : G' ≃* G'')
+    (hχ : (χ : G' →* G'').comp F' = F''.comp (χ : G' →* G'')) :
+    (fixedSubgroupCongr ψ hψ).trans (fixedSubgroupCongr χ hχ) =
+      fixedSubgroupCongr (ψ.trans χ) (MulEquiv.trans_comp_eq_comp_trans hψ hχ) :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+theorem fixedSubgroupCongr_symm (ψ : G ≃* G')
+    (hψ : (ψ : G →* G').comp F = F'.comp (ψ : G →* G')) :
+    (fixedSubgroupCongr ψ hψ).symm =
+      fixedSubgroupCongr ψ.symm (MulEquiv.symm_comp_eq_comp_symm ψ hψ) :=
+  MulEquiv.ext fun _ => Subtype.ext (by simp)
+
+/-! ### Transporting the endomorphism as well
+
+A consumer usually has an isomorphism `ψ : G ≃* G'` and an endomorphism of `G`, and no candidate
+`F'` in hand. Conjugating `F` by `ψ` supplies one, and it is the only choice: `ψ` intertwines `F`
+with `F'` exactly when `F'` is that conjugate. -/
+
+/-- The endomorphism of `G'` obtained by conjugating an endomorphism of `G` by an isomorphism. -/
+def MulEquiv.endCongr (ψ : G ≃* G') : (G →* G) ≃ (G' →* G') :=
+  (MulEquiv.monoidHomCongrLeftEquiv (N := G) ψ).trans (MulEquiv.monoidHomCongrRightEquiv ψ)
+
+@[simp]
+theorem MulEquiv.endCongr_apply (ψ : G ≃* G') (F : G →* G) (y : G') :
+    MulEquiv.endCongr ψ F y = ψ (F (ψ.symm y)) := by
+  simp only [MulEquiv.endCongr, Equiv.trans_apply, MulEquiv.monoidHomCongrLeftEquiv_apply,
+    MulEquiv.monoidHomCongrRightEquiv_apply, MonoidHom.coe_comp, Function.comp_apply,
+    MulEquiv.coe_toMonoidHom]
+
+/-- An isomorphism intertwines an endomorphism with its own conjugate. -/
+theorem MulEquiv.comp_eq_endCongr_comp (ψ : G ≃* G') (F : G →* G) :
+    (ψ : G →* G').comp F = (MulEquiv.endCongr ψ F).comp (ψ : G →* G') := by
+  ext x
+  simp
+
+/-- An isomorphism intertwines `F` with `F'` exactly when `F'` is the conjugate of `F`, so no
+generality is lost by conjugating. -/
+theorem MulEquiv.comp_eq_comp_iff_eq_endCongr (ψ : G ≃* G') :
+    (ψ : G →* G').comp F = F'.comp (ψ : G →* G') ↔ MulEquiv.endCongr ψ F = F' := by
+  refine ⟨fun h => MonoidHom.ext fun y => ?_, fun h => h ▸ MulEquiv.comp_eq_endCongr_comp ψ F⟩
+  simpa using DFunLike.congr_fun h (ψ.symm y)
+
+/-- The isomorphism of fixed subgroups induced by an isomorphism of the ambient group, with the
+endomorphism carried along by conjugation. -/
+def fixedSubgroupCongrEnd (ψ : G ≃* G') (F : G →* G) :
+    ↥(fixedSubgroup F) ≃* ↥(fixedSubgroup (MulEquiv.endCongr ψ F)) :=
+  fixedSubgroupCongr ψ (MulEquiv.comp_eq_endCongr_comp ψ F)
+
+@[simp]
+theorem coe_fixedSubgroupCongrEnd_apply (ψ : G ≃* G') (F : G →* G) (x : ↥(fixedSubgroup F)) :
+    (fixedSubgroupCongrEnd ψ F x : G') = ψ (x : G) :=
+  coe_fixedSubgroupCongr_apply _ _ x
 
 end TauCeti


### PR DESCRIPTION
This PR adds carrier-independent transport for the fixed-point candidate
`FixedPointCandidate F = [H, H] / Z([H, H])`, where `H = fixedSubgroup F`.

An isomorphism `ψ : G ≃* G'` intertwining `F` and `F'` transports each stage of the construction:

- `Subgroup.congrOfMapEq` restricts an isomorphism carrying one subgroup onto another to those
  subgroups, and carries the coercion, `refl`, `trans`, and `symm` laws once for all its users.
- `commutatorCongr` and `fixedSubgroupCongr` are its instances for the derived subgroup and for the
  fixed subgroup of an endomorphism, the latter resting on the two lemmas saying that intertwining
  relations invert and compose.
- `DerivedCentralQuotient.congr` and `FixedPointCandidate.congr` compose those equivalences.

The result is one comparison mechanism: the candidate depends only on the isomorphism class of the
pair `(G, F)`. This supplies reusable transport for the group recipe fixed by milestone `L3` of
`TauCetiRoadmap/CFSGStatement/README.md`, and for milestone `L4`, whose target is an isomorphism
between one of those candidates and Mathlib's `suzukiGroup`. No finiteness, simplicity,
recognition, order, or ambient-group construction is asserted.

The commutator image lemma is stated for any surjection and proved from Mathlib's
`map_derivedSeries_eq`; the intertwining lemmas are proved from `Function.Semiconj`. The changes
extend the existing carrier-independent modules beside the constructions they transport, and add no
new file.

Roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"CFSGStatement","id":"fixedpointcandidate-congr"}-->

🤖 Prepared with Claude Code and Codex
