### PR TITLE
feat: polarizations of pure Hodge structures

### DIFF
--- a/TauCeti/Geometry/Hodge/BilinearForm.lean
+++ b/TauCeti/Geometry/Hodge/BilinearForm.lean
@@ -66,11 +66,13 @@ theorem integralFormToComplex_unique (hℂ : IsBaseChange ℂ ιℂ) (Q : Linear
   simp [hB x y]
 
 /-- Complexification turns the flip of an integral form into the flip of the complexified form. -/
+@[simp]
 theorem integralFormToComplex_flip (hℂ : IsBaseChange ℂ ιℂ) (Q : LinearMap.BilinForm ℤ V) :
     (integralFormToComplex hℂ Q).flip = integralFormToComplex hℂ Q.flip :=
   integralFormToComplex_unique hℂ _ _ fun x y ↦ by simp
 
 /-- Complexification commutes with integer multiples of an integral form. -/
+@[simp]
 theorem integralFormToComplex_zsmul (hℂ : IsBaseChange ℂ ιℂ) (k : ℤ)
     (Q : LinearMap.BilinForm ℤ V) :
     integralFormToComplex hℂ (k • Q) = k • integralFormToComplex hℂ Q :=

--- a/TauCeti/Geometry/Hodge/BilinearForm.lean
+++ b/TauCeti/Geometry/Hodge/BilinearForm.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.BilinearForm.TensorProduct
+public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+public import Mathlib.RingTheory.TensorProduct.Free
+public import TauCeti.Geometry.Hodge.Conjugation
+
+/-!
+# Complexification of an integral bilinear form
+
+An integral bilinear form on a lattice extends uniquely to a complex bilinear form on any
+abstract complexification of that lattice. This file constructs that extension,
+`TauCeti.Hodge.integralFormToComplex`, from Mathlib's base change of a bilinear form along the
+canonical tensor model, and characterizes it by its values on integral vectors.
+
+Two properties make the extension usable in Hodge theory. It is *real*: conjugating both arguments
+conjugates the value, because lattice-induced conjugation fixes the integral vectors. And it is
+nondegenerate as soon as the integral form is, provided the lattice is finite free, since
+nondegeneracy of a form on a finite free module over a domain is the nonvanishing of the
+determinant of its Gram matrix.
+
+## Main declarations
+
+* `TauCeti.Hodge.integralFormToComplex`: the complex bilinear form extending an integral one.
+* `TauCeti.Hodge.integralFormToComplex_ι`: its values on integral vectors.
+* `TauCeti.Hodge.integralFormToComplex_unique`: it is the only such extension.
+* `TauCeti.Hodge.integralFormToComplex_conj`: it commutes with lattice-induced conjugation.
+* `TauCeti.Hodge.integralFormToComplex_nondegenerate`: it inherits nondegeneracy from a finite
+  free lattice.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+open scoped TensorProduct
+
+universe u v
+
+variable {V : Type u} {Vℂ : Type v}
+variable [AddCommGroup V] [AddCommGroup Vℂ] [Module ℂ Vℂ]
+variable {ιℂ : V →ₗ[ℤ] Vℂ}
+
+/-- The complexification of an integral bilinear form, transported from Mathlib's base change
+along the canonical tensor model to an abstract complexification. -/
+noncomputable def integralFormToComplex (hℂ : IsBaseChange ℂ ιℂ)
+    (Q : LinearMap.BilinForm ℤ V) : LinearMap.BilinForm ℂ Vℂ :=
+  (Q.baseChange ℂ).compl₁₂ hℂ.equiv.symm.toLinearMap hℂ.equiv.symm.toLinearMap
+
+/-- On integral vectors the complexified form is the integral form. -/
+@[simp]
+theorem integralFormToComplex_ι (hℂ : IsBaseChange ℂ ιℂ) (Q : LinearMap.BilinForm ℤ V)
+    (x y : V) : integralFormToComplex hℂ Q (ιℂ x) (ιℂ y) = (Q x y : ℂ) := by
+  simp [integralFormToComplex, hℂ.equiv_symm_apply]
+
+/-- The complexified form is the unique complex bilinear form restricting to the integral one. -/
+theorem integralFormToComplex_unique (hℂ : IsBaseChange ℂ ιℂ) (Q : LinearMap.BilinForm ℤ V)
+    (B : LinearMap.BilinForm ℂ Vℂ) (hB : ∀ x y : V, B (ιℂ x) (ιℂ y) = (Q x y : ℂ)) :
+    B = integralFormToComplex hℂ Q := by
+  refine hℂ.algHom_ext _ _ fun x ↦ hℂ.algHom_ext _ _ fun y ↦ ?_
+  simp [hB x y]
+
+/-- Complexification turns the flip of an integral form into the flip of the complexified form. -/
+theorem integralFormToComplex_flip (hℂ : IsBaseChange ℂ ιℂ) (Q : LinearMap.BilinForm ℤ V) :
+    (integralFormToComplex hℂ Q).flip = integralFormToComplex hℂ Q.flip :=
+  integralFormToComplex_unique hℂ _ _ fun x y ↦ by simp
+
+/-- Complexification commutes with integer multiples of an integral form. -/
+theorem integralFormToComplex_zsmul (hℂ : IsBaseChange ℂ ιℂ) (k : ℤ)
+    (Q : LinearMap.BilinForm ℤ V) :
+    integralFormToComplex hℂ (k • Q) = k • integralFormToComplex hℂ Q :=
+  (integralFormToComplex_unique hℂ _ _ fun x y ↦ by simp).symm
+
+/-- Conjugating the second argument of a complexified integral form against an integral first
+argument conjugates its value. -/
+theorem integralFormToComplex_conj_right (hℂ : IsBaseChange ℂ ιℂ) (Q : LinearMap.BilinForm ℤ V)
+    (x : V) (y : Vℂ) :
+    integralFormToComplex hℂ Q (ιℂ x) (latticeConj hℂ y) =
+      starRingEnd ℂ (integralFormToComplex hℂ Q (ιℂ x) y) := by
+  induction y using hℂ.inductionOn with
+  | zero => simp
+  | tmul w => simp
+  | smul z y hy => simp [hy]
+  | add y₁ y₂ hy₁ hy₂ => simp [hy₁, hy₂]
+
+/-- Conjugating both arguments of a complexified integral form conjugates its value: the form
+takes real values on the lattice. -/
+@[simp]
+theorem integralFormToComplex_conj (hℂ : IsBaseChange ℂ ιℂ) (Q : LinearMap.BilinForm ℤ V)
+    (x y : Vℂ) :
+    integralFormToComplex hℂ Q (latticeConj hℂ x) (latticeConj hℂ y) =
+      starRingEnd ℂ (integralFormToComplex hℂ Q x y) := by
+  induction x using hℂ.inductionOn generalizing y with
+  | zero => simp
+  | tmul v => simpa using integralFormToComplex_conj_right hℂ Q v y
+  | smul z x hx => simp [hx]
+  | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂]
+
+/-- The complexification of a nondegenerate integral form on a finite free lattice is
+nondegenerate.
+
+Over a domain, nondegeneracy of a form on a finite free module is the nonvanishing of the
+determinant of its Gram matrix, and the Gram matrix of the complexified form in the complexified
+basis is the entrywise image of the integral Gram matrix. -/
+theorem integralFormToComplex_nondegenerate [Module.Free ℤ V] [Module.Finite ℤ V]
+    (hℂ : IsBaseChange ℂ ιℂ) {Q : LinearMap.BilinForm ℤ V}
+    (hQ : LinearMap.BilinForm.Nondegenerate Q) :
+    LinearMap.BilinForm.Nondegenerate (integralFormToComplex hℂ Q) := by
+  classical
+  set b := Module.Free.chooseBasis ℤ V
+  set bℂ := (Algebra.TensorProduct.basis ℂ b).map hℂ.equiv with hbℂ
+  have hbℂ_apply : ∀ i, bℂ i = ιℂ (b i) := by
+    intro i
+    simp [hbℂ, hℂ.equiv_tmul]
+  have hmat : LinearMap.BilinForm.toMatrix bℂ (integralFormToComplex hℂ Q) =
+      (LinearMap.BilinForm.toMatrix b Q).map (fun z : ℤ ↦ (z : ℂ)) := by
+    ext i j
+    simp [LinearMap.BilinForm.toMatrix_apply, hbℂ_apply]
+  rw [LinearMap.BilinForm.nondegenerate_iff_det_ne_zero bℂ, hmat, ← Int.cast_det]
+  simpa using (LinearMap.BilinForm.nondegenerate_iff_det_ne_zero b).mp hQ
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/BilinearForm.lean
+++ b/TauCeti/Geometry/Hodge/BilinearForm.lean
@@ -116,7 +116,9 @@ private theorem integralFormToRat_nondegenerate {Q : LinearMap.BilinForm ℤ V}
     have hv : v = 0 := hQ.1 v fun w ↦ by
       have h : Q.baseChange ℚ (s • x) (1 ⊗ₜ[ℤ] w) = 0 := by simp [hx]
       rw [hs] at h
-      change Q.baseChange ℚ (1 ⊗ₜ[ℤ] v) (1 ⊗ₜ[ℤ] w) = 0 at h
+      have hfv : f v = 1 ⊗ₜ[ℤ] v := rfl
+      rw [hfv] at h
+      rw [LinearMap.BilinForm.baseChange_tmul] at h
       have hc : (Q v w : ℚ) = 0 := by simpa using h
       exact_mod_cast hc
     rw [hv, map_zero] at hs
@@ -126,67 +128,60 @@ private theorem integralFormToRat_nondegenerate {Q : LinearMap.BilinForm ℤ V}
     have hv : v = 0 := hQ.2 v fun w ↦ by
       have h : Q.baseChange ℚ (1 ⊗ₜ[ℤ] w) (s • y) = 0 := by simp [hy]
       rw [hs] at h
-      change Q.baseChange ℚ (1 ⊗ₜ[ℤ] w) (1 ⊗ₜ[ℤ] v) = 0 at h
+      have hfv : f v = 1 ⊗ₜ[ℤ] v := rfl
+      rw [hfv] at h
+      rw [LinearMap.BilinForm.baseChange_tmul] at h
       have hc : (Q w v : ℚ) = 0 := by simpa using h
       exact_mod_cast hc
     rw [hv, map_zero] at hs
     exact (IsLocalizedModule.smul_injective f s) (by simpa using hs)
 
-private theorem rationalFormToComplex_nondegenerate {W : Type*} [AddCommGroup W] [Module ℚ W]
-    {B : LinearMap.BilinForm ℚ W} (hB : B.Nondegenerate) :
-    (B.baseChange ℂ).Nondegenerate := by
+private theorem rationalFormToComplex_separatingLeft {W : Type*} [AddCommGroup W] [Module ℚ W]
+    {B : LinearMap.BilinForm ℚ W} (hB : B.SeparatingLeft) :
+    (B.baseChange ℂ).SeparatingLeft := by
   classical
   let b := Module.Free.chooseBasis ℚ ℂ
   let e := TensorProduct.equivFinsuppOfBasisLeft (N := W) b
+  intro x hx
+  let c := e x
+  have hc : c = 0 := by
+    ext i
+    apply hB (c i)
+    intro w
+    have h := hx (1 ⊗ₜ[ℚ] w)
+    have hrepr : c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = x := by
+      calc
+        c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = e.symm c :=
+          (TensorProduct.equivFinsuppOfBasisLeft_symm_apply b c).symm
+        _ = x := by simp [c]
+    rw [← hrepr] at h
+    have hi := congrArg (fun z : ℂ ↦ b.repr z i) h
+    have hi' : (∑ j ∈ c.support, Finsupp.single j (B (c j) w)) i = 0 := by
+      simpa [Finsupp.sum] using hi
+    by_cases hic : i ∈ c.support
+    · have heval : (∑ j ∈ c.support, Finsupp.single j (B (c j) w)) i =
+          B (c i) w := by
+        simp [Finsupp.single_apply, hic]
+      exact heval ▸ hi'
+    · have hci : c i = 0 := Finsupp.notMem_support_iff.mp hic
+      simp [hci]
+  exact e.injective (by simpa [c] using hc)
+
+private theorem rationalFormToComplex_baseChange_flip {W : Type*} [AddCommGroup W] [Module ℚ W]
+    (B : LinearMap.BilinForm ℚ W) :
+    B.flip.baseChange ℂ = (B.baseChange ℂ).flip := by
+  ext z v
+  simp
+
+private theorem rationalFormToComplex_nondegenerate {W : Type*} [AddCommGroup W] [Module ℚ W]
+    {B : LinearMap.BilinForm ℚ W} (hB : B.Nondegenerate) :
+    (B.baseChange ℂ).Nondegenerate := by
   constructor
-  · intro x hx
-    let c := e x
-    have hc : c = 0 := by
-      ext i
-      apply hB.1 (c i)
-      intro w
-      have h := hx (1 ⊗ₜ[ℚ] w)
-      have hrepr : c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = x := by
-        calc
-          c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = e.symm c :=
-            (TensorProduct.equivFinsuppOfBasisLeft_symm_apply b c).symm
-          _ = x := by simp [c]
-      rw [← hrepr] at h
-      have hi := congrArg (fun z : ℂ ↦ b.repr z i) h
-      have hi' : (∑ j ∈ c.support, Finsupp.single j (B (c j) w)) i = 0 := by
-        simpa [Finsupp.sum] using hi
-      by_cases hic : i ∈ c.support
-      · have heval : (∑ j ∈ c.support, Finsupp.single j (B (c j) w)) i =
-            B (c i) w := by
-          simp [Finsupp.single_apply, hic]
-        exact heval ▸ hi'
-      · have hci : c i = 0 := Finsupp.notMem_support_iff.mp hic
-        simp [hci]
-    exact e.injective (by simpa [c] using hc)
-  · intro y hy
-    let c := e y
-    have hc : c = 0 := by
-      ext i
-      apply hB.2 (c i)
-      intro w
-      have h := hy (1 ⊗ₜ[ℚ] w)
-      have hrepr : c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = y := by
-        calc
-          c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = e.symm c :=
-            (TensorProduct.equivFinsuppOfBasisLeft_symm_apply b c).symm
-          _ = y := by simp [c]
-      rw [← hrepr] at h
-      have hi := congrArg (fun z : ℂ ↦ b.repr z i) h
-      have hi' : (∑ j ∈ c.support, Finsupp.single j (B w (c j))) i = 0 := by
-        simpa [Finsupp.sum] using hi
-      by_cases hic : i ∈ c.support
-      · have heval : (∑ j ∈ c.support, Finsupp.single j (B w (c j))) i =
-            B w (c i) := by
-          simp [Finsupp.single_apply, hic]
-        exact heval ▸ hi'
-      · have hci : c i = 0 := Finsupp.notMem_support_iff.mp hic
-        simp [hci]
-    exact e.injective (by simpa [c] using hc)
+  · exact rationalFormToComplex_separatingLeft hB.1
+  · have hBflip : B.flip.SeparatingLeft := fun y hy ↦ hB.2 y hy
+    have h := rationalFormToComplex_separatingLeft hBflip
+    rw [rationalFormToComplex_baseChange_flip] at h
+    exact h
 
 private theorem integralFormToCanonicalComplex_nondegenerate {Q : LinearMap.BilinForm ℤ V}
     (hQ : Q.Nondegenerate) : (Q.baseChange ℂ).Nondegenerate := by
@@ -207,7 +202,8 @@ theorem integralFormToComplex_nondegenerate (hℂ : IsBaseChange ℂ ιℂ)
   have hform : integralFormToComplex hℂ Q =
       LinearMap.BilinForm.congr hℂ.equiv (Q.baseChange ℂ) := by
     ext x y
-    rfl
+    simp only [integralFormToComplex, LinearMap.compl₁₂_apply,
+      LinearMap.BilinForm.congr_apply, LinearEquiv.coe_coe]
   rw [hform]
   exact LinearMap.BilinForm.Nondegenerate.congr hℂ.equiv
     (integralFormToCanonicalComplex_nondegenerate hQ)

--- a/TauCeti/Geometry/Hodge/BilinearForm.lean
+++ b/TauCeti/Geometry/Hodge/BilinearForm.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.LinearAlgebra.BilinearForm.TensorProduct
 public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 public import Mathlib.RingTheory.TensorProduct.Free
+import Mathlib.Algebra.Algebra.Rat
+import Mathlib.RingTheory.Localization.BaseChange
 public import TauCeti.Geometry.Hodge.Conjugation
 
 /-!
@@ -20,9 +22,8 @@ canonical tensor model, and characterizes it by its values on integral vectors.
 
 Two properties make the extension usable in Hodge theory. It is *real*: conjugating both arguments
 conjugates the value, because lattice-induced conjugation fixes the integral vectors. And it is
-nondegenerate as soon as the integral form is, provided the lattice is finite free, since
-nondegeneracy of a form on a finite free module over a domain is the nonvanishing of the
-determinant of its Gram matrix.
+nondegenerate as soon as the integral form is: nondegeneracy is preserved first by localization from
+`ℤ` to `ℚ` and then by scalar extension from `ℚ` to `ℂ`.
 
 ## Main declarations
 
@@ -30,8 +31,8 @@ determinant of its Gram matrix.
 * `TauCeti.Hodge.integralFormToComplex_ι`: its values on integral vectors.
 * `TauCeti.Hodge.integralFormToComplex_unique`: it is the only such extension.
 * `TauCeti.Hodge.integralFormToComplex_conj`: it commutes with lattice-induced conjugation.
-* `TauCeti.Hodge.integralFormToComplex_nondegenerate`: it inherits nondegeneracy from a finite
-  free lattice.
+* `TauCeti.Hodge.integralFormToComplex_nondegenerate`: it inherits nondegeneracy from the integral
+  form.
 -/
 
 public section
@@ -103,27 +104,112 @@ theorem integralFormToComplex_conj (hℂ : IsBaseChange ℂ ιℂ) (Q : LinearMa
   | smul z x hx => simp [hx]
   | add x₁ x₂ hx₁ hx₂ => simp [hx₁, hx₂]
 
-/-- The complexification of a nondegenerate integral form on a finite free lattice is
-nondegenerate.
+private theorem integralFormToRat_nondegenerate {Q : LinearMap.BilinForm ℤ V}
+    (hQ : Q.Nondegenerate) : (Q.baseChange ℚ).Nondegenerate := by
+  let f : V →ₗ[ℤ] ℚ ⊗[ℤ] V := TensorProduct.mk ℤ ℚ V 1
+  have hf : IsLocalizedModule (nonZeroDivisors ℤ) f := by
+    rw [isLocalizedModule_iff_isBaseChange (nonZeroDivisors ℤ) ℚ]
+    exact TensorProduct.isBaseChange ℤ V ℚ
+  constructor
+  · intro x hx
+    obtain ⟨⟨v, s⟩, hs⟩ := hf.surj x
+    have hv : v = 0 := hQ.1 v fun w ↦ by
+      have h : Q.baseChange ℚ (s • x) (1 ⊗ₜ[ℤ] w) = 0 := by simp [hx]
+      rw [hs] at h
+      change Q.baseChange ℚ (1 ⊗ₜ[ℤ] v) (1 ⊗ₜ[ℤ] w) = 0 at h
+      have hc : (Q v w : ℚ) = 0 := by simpa using h
+      exact_mod_cast hc
+    rw [hv, map_zero] at hs
+    exact (IsLocalizedModule.smul_injective f s) (by simpa using hs)
+  · intro y hy
+    obtain ⟨⟨v, s⟩, hs⟩ := hf.surj y
+    have hv : v = 0 := hQ.2 v fun w ↦ by
+      have h : Q.baseChange ℚ (1 ⊗ₜ[ℤ] w) (s • y) = 0 := by simp [hy]
+      rw [hs] at h
+      change Q.baseChange ℚ (1 ⊗ₜ[ℤ] w) (1 ⊗ₜ[ℤ] v) = 0 at h
+      have hc : (Q w v : ℚ) = 0 := by simpa using h
+      exact_mod_cast hc
+    rw [hv, map_zero] at hs
+    exact (IsLocalizedModule.smul_injective f s) (by simpa using hs)
 
-Over a domain, nondegeneracy of a form on a finite free module is the nonvanishing of the
-determinant of its Gram matrix, and the Gram matrix of the complexified form in the complexified
-basis is the entrywise image of the integral Gram matrix. -/
-theorem integralFormToComplex_nondegenerate [Module.Free ℤ V] [Module.Finite ℤ V]
-    (hℂ : IsBaseChange ℂ ιℂ) {Q : LinearMap.BilinForm ℤ V}
-    (hQ : LinearMap.BilinForm.Nondegenerate Q) :
-    LinearMap.BilinForm.Nondegenerate (integralFormToComplex hℂ Q) := by
+private theorem rationalFormToComplex_nondegenerate {W : Type*} [AddCommGroup W] [Module ℚ W]
+    {B : LinearMap.BilinForm ℚ W} (hB : B.Nondegenerate) :
+    (B.baseChange ℂ).Nondegenerate := by
   classical
-  set b := Module.Free.chooseBasis ℤ V
-  set bℂ := (Algebra.TensorProduct.basis ℂ b).map hℂ.equiv with hbℂ
-  have hbℂ_apply : ∀ i, bℂ i = ιℂ (b i) := by
-    intro i
-    simp [hbℂ, hℂ.equiv_tmul]
-  have hmat : LinearMap.BilinForm.toMatrix bℂ (integralFormToComplex hℂ Q) =
-      (LinearMap.BilinForm.toMatrix b Q).map (fun z : ℤ ↦ (z : ℂ)) := by
-    ext i j
-    simp [LinearMap.BilinForm.toMatrix_apply, hbℂ_apply]
-  rw [LinearMap.BilinForm.nondegenerate_iff_det_ne_zero bℂ, hmat, ← Int.cast_det]
-  simpa using (LinearMap.BilinForm.nondegenerate_iff_det_ne_zero b).mp hQ
+  let b := Module.Free.chooseBasis ℚ ℂ
+  let e := TensorProduct.equivFinsuppOfBasisLeft (N := W) b
+  constructor
+  · intro x hx
+    let c := e x
+    have hc : c = 0 := by
+      ext i
+      apply hB.1 (c i)
+      intro w
+      have h := hx (1 ⊗ₜ[ℚ] w)
+      have hrepr : c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = x := by
+        calc
+          c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = e.symm c :=
+            (TensorProduct.equivFinsuppOfBasisLeft_symm_apply b c).symm
+          _ = x := by simp [c]
+      rw [← hrepr] at h
+      have hi := congrArg (fun z : ℂ ↦ b.repr z i) h
+      have hi' : (∑ j ∈ c.support, Finsupp.single j (B (c j) w)) i = 0 := by
+        simpa [Finsupp.sum] using hi
+      by_cases hic : i ∈ c.support
+      · have heval : (∑ j ∈ c.support, Finsupp.single j (B (c j) w)) i =
+            B (c i) w := by
+          simp [Finsupp.single_apply, hic]
+        exact heval ▸ hi'
+      · have hci : c i = 0 := Finsupp.notMem_support_iff.mp hic
+        simp [hci]
+    exact e.injective (by simpa [c] using hc)
+  · intro y hy
+    let c := e y
+    have hc : c = 0 := by
+      ext i
+      apply hB.2 (c i)
+      intro w
+      have h := hy (1 ⊗ₜ[ℚ] w)
+      have hrepr : c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = y := by
+        calc
+          c.sum (fun i v ↦ b i ⊗ₜ[ℚ] v) = e.symm c :=
+            (TensorProduct.equivFinsuppOfBasisLeft_symm_apply b c).symm
+          _ = y := by simp [c]
+      rw [← hrepr] at h
+      have hi := congrArg (fun z : ℂ ↦ b.repr z i) h
+      have hi' : (∑ j ∈ c.support, Finsupp.single j (B w (c j))) i = 0 := by
+        simpa [Finsupp.sum] using hi
+      by_cases hic : i ∈ c.support
+      · have heval : (∑ j ∈ c.support, Finsupp.single j (B w (c j))) i =
+            B w (c i) := by
+          simp [Finsupp.single_apply, hic]
+        exact heval ▸ hi'
+      · have hci : c i = 0 := Finsupp.notMem_support_iff.mp hic
+        simp [hci]
+    exact e.injective (by simpa [c] using hc)
+
+private theorem integralFormToCanonicalComplex_nondegenerate {Q : LinearMap.BilinForm ℤ V}
+    (hQ : Q.Nondegenerate) : (Q.baseChange ℂ).Nondegenerate := by
+  let e := TensorProduct.AlgebraTensorModule.cancelBaseChange ℤ ℚ ℂ ℂ V
+  have hn : ((Q.baseChange ℚ).baseChange ℂ).Nondegenerate :=
+    rationalFormToComplex_nondegenerate (integralFormToRat_nondegenerate hQ)
+  have heq : Q.baseChange ℂ =
+      LinearMap.BilinForm.congr e ((Q.baseChange ℚ).baseChange ℂ) := by
+    ext z v
+    simp [e]
+  rw [heq]
+  exact LinearMap.BilinForm.Nondegenerate.congr e hn
+
+/-- Complexification preserves nondegeneracy of an integral bilinear form. -/
+theorem integralFormToComplex_nondegenerate (hℂ : IsBaseChange ℂ ιℂ)
+    {Q : LinearMap.BilinForm ℤ V} (hQ : Q.Nondegenerate) :
+    (integralFormToComplex hℂ Q).Nondegenerate := by
+  have hform : integralFormToComplex hℂ Q =
+      LinearMap.BilinForm.congr hℂ.equiv (Q.baseChange ℂ) := by
+    ext x y
+    rfl
+  rw [hform]
+  exact LinearMap.BilinForm.Nondegenerate.congr hℂ.equiv
+    (integralFormToCanonicalComplex_nondegenerate hQ)
 
 end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Polarization.lean
+++ b/TauCeti/Geometry/Hodge/Polarization.lean
@@ -90,7 +90,7 @@ theorem symm_of_even (h : IsPolarization hℂ hs Q) (hn : Even n) (x y : V) : Q 
   simpa [Int.negOnePow_even n hn] using h.symm_weight x y
 
 /-- A polarization of an odd-weight Hodge structure is an antisymmetric form. -/
-theorem neg_of_odd (h : IsPolarization hℂ hs Q) (hn : Odd n) (x y : V) : Q y x = -Q x y := by
+theorem eq_neg_of_odd (h : IsPolarization hℂ hs Q) (hn : Odd n) (x y : V) : Q y x = -Q x y := by
   simpa [Int.negOnePow_odd n hn] using h.symm_weight x y
 
 /-- The flip of a polarizing form is its `(-1)^n`-multiple. -/
@@ -104,7 +104,8 @@ theorem complex_symm_weight (h : IsPolarization hℂ hs Q) (x y : Vℂ) :
   have hforms : (integralFormToComplex hℂ Q).flip =
       (n.negOnePow : ℤ) • integralFormToComplex hℂ Q := by
     rw [integralFormToComplex_flip, h.flip_eq, integralFormToComplex_zsmul]
-  simpa using DFunLike.congr_fun (DFunLike.congr_fun hforms x) y
+  have hxy := DFunLike.congr_fun (DFunLike.congr_fun hforms x) y
+  simpa only [LinearMap.BilinForm.flip_apply, LinearMap.smul_apply, zsmul_eq_mul] using hxy
 
 /-- The complexification of a polarizing form on a finite free lattice is nondegenerate. -/
 theorem complex_nondegenerate [Module.Free ℤ V] [Module.Finite ℤ V]
@@ -172,10 +173,35 @@ variable {hℂ : IsBaseChange ℂ ιℂ} {n : ℤ} {hs : HodgeStructure hℂ n}
 noncomputable def Q (P : Polarization hℂ hs) : LinearMap.BilinForm ℂ Vℂ :=
   integralFormToComplex hℂ P.Qint
 
+/-- The complex form of a polarization obeys the weight symmetry. -/
+theorem Q_symm_weight (P : Polarization hℂ hs) (x y : Vℂ) :
+    P.Q y x = (n.negOnePow : ℤ) * P.Q x y :=
+  P.isPolarization.complex_symm_weight x y
+
+/-- The complex form of a polarization on a finite free lattice is nondegenerate. -/
+theorem Q_nondegenerate [Module.Free ℤ V] [Module.Finite ℤ V] (P : Polarization hℂ hs) :
+    LinearMap.BilinForm.Nondegenerate P.Q :=
+  P.isPolarization.complex_nondegenerate
+
+/-- The complex form of a polarization satisfies the first Hodge–Riemann relation. -/
+theorem Q_orthogonal (P : Polarization hℂ hs) (p : ℤ) {x y : Vℂ} (hx : x ∈ hs.F p)
+    (hy : y ∈ hs.F (n + 1 - p)) : P.Q x y = 0 :=
+  P.isPolarization.orthogonal p x hx y hy
+
+/-- The complex form of a polarization satisfies the second Hodge–Riemann relation. -/
+theorem Q_positive (P : Polarization hℂ hs) (p : ℤ) {x : Vℂ} (hx : x ∈ hs.piece p)
+    (hx0 : x ≠ 0) :
+    0 < Complex.I ^ (2 * p - n) * P.Q x (latticeConj hℂ x) :=
+  P.isPolarization.positive p x hx hx0
+
 /-- The complex form of a polarization restricts to the integral form on integral vectors. -/
 @[simp]
 theorem Q_ι (P : Polarization hℂ hs) (x y : V) : P.Q (ιℂ x) (ιℂ y) = (P.Qint x y : ℂ) :=
   integralFormToComplex_ι hℂ P.Qint x y
+
+/-- The complex bilinear form is the complexification of the integral form. -/
+theorem Q_def (P : Polarization hℂ hs) : P.Q = integralFormToComplex hℂ P.Qint :=
+  integralFormToComplex_unique hℂ P.Qint P.Q P.Q_ι
 
 /-- The complex form of a polarization takes conjugate values on conjugate arguments. -/
 @[simp]

--- a/TauCeti/Geometry/Hodge/Polarization.lean
+++ b/TauCeti/Geometry/Hodge/Polarization.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Complex.Order
+public import TauCeti.Geometry.Hodge.BilinearForm
+public import TauCeti.Geometry.Hodge.Structure
+
+/-!
+# Polarizations of pure Hodge structures
+
+A polarization of a weight-`n` Hodge structure on a lattice `V` is an integral bilinear form on
+`V` satisfying the Hodge–Riemann bilinear relations. This file states those relations as a
+predicate on a *fixed* form, `TauCeti.Hodge.IsPolarization`, so that a form can be required to
+polarize a structure without being carried twice; bundling the form with a proof gives
+`TauCeti.Hodge.Polarization`, and forgetting the form gives the property
+`TauCeti.Hodge.IsPolarizable`.
+
+The complex form is derived rather than postulated: it is the complexification
+`TauCeti.Hodge.integralFormToComplex` of the integral form, so the integral-to-complex link is a
+computation rather than an axiom.
+
+## Conventions
+
+The weight sign is `Q y x = (-1)^n Q x y`, written with `Int.negOnePow`, and the positivity
+relation is `0 < i^(p-q) * Q x (conj x)` for `0 ≠ x` in the Hodge component `H^{p,q}`, in the
+partial order on `ℂ` available as `open scoped ComplexOrder`. Requiring positivity in that order
+also requires the value to be real, which is part of the classical statement. A geometric
+polarization built from a cup product carries an extra sign `(-1)^(n(n-1)/2)`, which an instance
+realized that way must insert to match this convention.
+
+## Main declarations
+
+* `TauCeti.Hodge.IsPolarization`: the Hodge–Riemann relations for a fixed integral form.
+* `TauCeti.Hodge.IsPolarization.orthogonal_piece`: distinct Hodge components pair to zero unless
+  their degrees add up to the weight.
+* `TauCeti.Hodge.IsPolarization.complex_nondegenerate`: the complexified form of a polarization of
+  a finite free lattice is nondegenerate.
+* `TauCeti.Hodge.IsPolarization.exists_pairing_ne_zero`: conjugate Hodge components pair
+  nondegenerately.
+* `TauCeti.Hodge.Polarization`: a polarized Hodge structure's form, bundled with its relations.
+* `TauCeti.Hodge.IsPolarizable`: existence of some polarizing form.
+
+The Hodge–Riemann relations follow Voisin, *Hodge Theory and Complex Algebraic Geometry I*,
+§7.1.2, and Peters–Steenbrink, *Mixed Hodge Structures*, §2. This is the definition layer of
+Layer L1 of `TauCetiRoadmap/HodgeStructures/README.md`.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+open scoped ComplexOrder
+
+universe u v
+
+variable {V : Type u} {Vℂ : Type v}
+variable [AddCommGroup V] [AddCommGroup Vℂ] [Module ℂ Vℂ]
+variable {ιℂ : V →ₗ[ℤ] Vℂ}
+
+/-- The **Hodge–Riemann bilinear relations** for a fixed integral bilinear form `Q` on the lattice
+of a weight-`n` Hodge structure.
+
+The form is `(-1)^n`-symmetric and nondegenerate; its complexification annihilates
+`F p × F (n + 1 - p)`; and `i^(p-q) Q x (conj x)` is a positive real number for every nonzero `x`
+in the Hodge component `H^{p,q}`, where `q = n - p`. -/
+structure IsPolarization (hℂ : IsBaseChange ℂ ιℂ) {n : ℤ} (hs : HodgeStructure hℂ n)
+    (Q : LinearMap.BilinForm ℤ V) : Prop where
+  /-- The form is symmetric in even weight and antisymmetric in odd weight. -/
+  symm_weight : ∀ x y, Q y x = (n.negOnePow : ℤ) * Q x y
+  /-- The form has no radical. -/
+  nondegenerate : Q.Nondegenerate
+  /-- The first Hodge–Riemann relation: `F p` and `F (n + 1 - p)` are orthogonal. -/
+  orthogonal : ∀ p, ∀ x ∈ hs.F p, ∀ y ∈ hs.F (n + 1 - p),
+    integralFormToComplex hℂ Q x y = 0
+  /-- The second Hodge–Riemann relation: `i^(p-q) Q x (conj x)` is positive on `H^{p,q}`. -/
+  positive : ∀ p, ∀ x ∈ hs.piece p, x ≠ 0 →
+    0 < Complex.I ^ (2 * p - n) * integralFormToComplex hℂ Q x (latticeConj hℂ x)
+
+namespace IsPolarization
+
+variable {hℂ : IsBaseChange ℂ ιℂ} {n : ℤ} {hs : HodgeStructure hℂ n}
+variable {Q : LinearMap.BilinForm ℤ V}
+
+/-- A polarization of an even-weight Hodge structure is a symmetric form. -/
+theorem symm_of_even (h : IsPolarization hℂ hs Q) (hn : Even n) (x y : V) : Q y x = Q x y := by
+  simpa [Int.negOnePow_even n hn] using h.symm_weight x y
+
+/-- A polarization of an odd-weight Hodge structure is an antisymmetric form. -/
+theorem neg_of_odd (h : IsPolarization hℂ hs Q) (hn : Odd n) (x y : V) : Q y x = -Q x y := by
+  simpa [Int.negOnePow_odd n hn] using h.symm_weight x y
+
+/-- The flip of a polarizing form is its `(-1)^n`-multiple. -/
+theorem flip_eq (h : IsPolarization hℂ hs Q) : Q.flip = (n.negOnePow : ℤ) • Q := by
+  ext x y
+  simpa using h.symm_weight x y
+
+/-- The complexification of a polarizing form obeys the same weight symmetry. -/
+theorem complex_symm_weight (h : IsPolarization hℂ hs Q) (x y : Vℂ) :
+    integralFormToComplex hℂ Q y x = (n.negOnePow : ℤ) * integralFormToComplex hℂ Q x y := by
+  have hforms : (integralFormToComplex hℂ Q).flip =
+      (n.negOnePow : ℤ) • integralFormToComplex hℂ Q := by
+    rw [integralFormToComplex_flip, h.flip_eq, integralFormToComplex_zsmul]
+  simpa using DFunLike.congr_fun (DFunLike.congr_fun hforms x) y
+
+/-- The complexification of a polarizing form on a finite free lattice is nondegenerate. -/
+theorem complex_nondegenerate [Module.Free ℤ V] [Module.Finite ℤ V]
+    (h : IsPolarization hℂ hs Q) :
+    LinearMap.BilinForm.Nondegenerate (integralFormToComplex hℂ Q) :=
+  integralFormToComplex_nondegenerate hℂ h.nondegenerate
+
+/-- The first Hodge–Riemann relation transported to the conjugate filtration. -/
+theorem orthogonal_conjF (h : IsPolarization hℂ hs Q) (p : ℤ) {x y : Vℂ}
+    (hx : x ∈ hs.conjF p) (hy : y ∈ hs.conjF (n + 1 - p)) :
+    integralFormToComplex hℂ Q x y = 0 := by
+  have hx' : latticeConj hℂ x ∈ hs.F p := by
+    simpa using (hs.mem_conjF_iff p x).mp hx
+  have hy' : latticeConj hℂ y ∈ hs.F (n + 1 - p) := by
+    simpa using (hs.mem_conjF_iff (n + 1 - p) y).mp hy
+  have hzero := h.orthogonal p _ hx' _ hy'
+  rw [integralFormToComplex_conj] at hzero
+  simpa using congrArg (starRingEnd ℂ) hzero
+
+/-- **Orthogonality of the Hodge components.** Two Hodge components pair to zero under a
+polarization unless their degrees add up to the weight. -/
+theorem orthogonal_piece (h : IsPolarization hℂ hs Q) {p p' : ℤ} (hpp : p + p' ≠ n)
+    {x y : Vℂ} (hx : x ∈ hs.piece p) (hy : y ∈ hs.piece p') :
+    integralFormToComplex hℂ Q x y = 0 := by
+  rcases lt_or_gt_of_ne hpp with hlt | hgt
+  · -- Below the weight: conjugate both arguments into complementary filtration steps.
+    refine h.orthogonal_conjF (n - p) (hs.piece_le_conjF p hx) ?_
+    exact hs.conjF_antitone (by omega) (hs.piece_le_conjF p' hy)
+  · -- Above the weight: the second argument already lies deep enough in the filtration.
+    refine h.orthogonal p x (hs.piece_le_F p hx) y ?_
+    exact hs.F_antitone (by omega) (hs.piece_le_F p' hy)
+
+/-- Under a polarization the Hodge–Riemann pairing of a nonzero component vector with its
+conjugate is nonzero. -/
+theorem pairing_conj_ne_zero (h : IsPolarization hℂ hs Q) {p : ℤ} {x : Vℂ}
+    (hx : x ∈ hs.piece p) (hx0 : x ≠ 0) :
+    integralFormToComplex hℂ Q x (latticeConj hℂ x) ≠ 0 := by
+  intro hzero
+  have hpos := h.positive p x hx hx0
+  rw [hzero, mul_zero] at hpos
+  exact lt_irrefl 0 hpos
+
+/-- **Nondegeneracy of the Hodge–Riemann pairing between conjugate components.** Every nonzero
+vector of `H^{p,q}` pairs nontrivially with a vector of `H^{q,p}`, namely with its conjugate. -/
+theorem exists_pairing_ne_zero (h : IsPolarization hℂ hs Q) {p : ℤ} {x : Vℂ}
+    (hx : x ∈ hs.piece p) (hx0 : x ≠ 0) :
+    ∃ y ∈ hs.piece (n - p), integralFormToComplex hℂ Q x y ≠ 0 :=
+  ⟨latticeConj hℂ x, by simpa using hs.conj_mem_piece hx, h.pairing_conj_ne_zero hx hx0⟩
+
+end IsPolarization
+
+/-- A **polarization** of a pure Hodge structure: an integral bilinear form on its lattice
+together with the Hodge–Riemann relations. -/
+structure Polarization (hℂ : IsBaseChange ℂ ιℂ) {n : ℤ} (hs : HodgeStructure hℂ n) where
+  /-- The underlying integral bilinear form. -/
+  Qint : LinearMap.BilinForm ℤ V
+  /-- The Hodge–Riemann relations for that form. -/
+  isPolarization : IsPolarization hℂ hs Qint
+
+namespace Polarization
+
+variable {hℂ : IsBaseChange ℂ ιℂ} {n : ℤ} {hs : HodgeStructure hℂ n}
+
+/-- The complex bilinear form of a polarization, derived by complexifying the integral form. -/
+noncomputable def Q (P : Polarization hℂ hs) : LinearMap.BilinForm ℂ Vℂ :=
+  integralFormToComplex hℂ P.Qint
+
+/-- The complex form of a polarization restricts to the integral form on integral vectors. -/
+@[simp]
+theorem Q_ι (P : Polarization hℂ hs) (x y : V) : P.Q (ιℂ x) (ιℂ y) = (P.Qint x y : ℂ) :=
+  integralFormToComplex_ι hℂ P.Qint x y
+
+/-- The complex form of a polarization takes conjugate values on conjugate arguments. -/
+@[simp]
+theorem Q_conj (P : Polarization hℂ hs) (x y : Vℂ) :
+    P.Q (latticeConj hℂ x) (latticeConj hℂ y) = starRingEnd ℂ (P.Q x y) :=
+  integralFormToComplex_conj hℂ P.Qint x y
+
+/-- Two polarizations of the same Hodge structure agree as soon as their integral forms do. -/
+@[ext]
+theorem ext {P P' : Polarization hℂ hs} (h : P.Qint = P'.Qint) : P = P' := by
+  cases P
+  cases P'
+  simp_all
+
+end Polarization
+
+/-- A pure Hodge structure is **polarizable** when some integral form polarizes it. This, rather
+than a chosen polarization, is the property under which the category of rational Hodge structures
+is semisimple. -/
+def IsPolarizable (hℂ : IsBaseChange ℂ ιℂ) {n : ℤ} (hs : HodgeStructure hℂ n) : Prop :=
+  ∃ Q : LinearMap.BilinForm ℤ V, IsPolarization hℂ hs Q
+
+/-- A chosen polarization exhibits a Hodge structure as polarizable. -/
+theorem Polarization.isPolarizable {hℂ : IsBaseChange ℂ ιℂ} {n : ℤ} {hs : HodgeStructure hℂ n}
+    (P : Polarization hℂ hs) : IsPolarizable hℂ hs :=
+  ⟨P.Qint, P.isPolarization⟩
+
+/-- Polarizability is exactly the existence of a bundled polarization. -/
+theorem isPolarizable_iff_nonempty {hℂ : IsBaseChange ℂ ιℂ} {n : ℤ} {hs : HodgeStructure hℂ n} :
+    IsPolarizable hℂ hs ↔ Nonempty (Polarization hℂ hs) :=
+  ⟨fun ⟨Q, hQ⟩ ↦ ⟨⟨Q, hQ⟩⟩, fun ⟨P⟩ ↦ P.isPolarizable⟩
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Polarization.lean
+++ b/TauCeti/Geometry/Hodge/Polarization.lean
@@ -37,8 +37,8 @@ realized that way must insert to match this convention.
 * `TauCeti.Hodge.IsPolarization`: the Hodge–Riemann relations for a fixed integral form.
 * `TauCeti.Hodge.IsPolarization.orthogonal_piece`: distinct Hodge components pair to zero unless
   their degrees add up to the weight.
-* `TauCeti.Hodge.IsPolarization.complex_nondegenerate`: the complexified form of a polarization of
-  a finite free lattice is nondegenerate.
+* `TauCeti.Hodge.IsPolarization.complex_nondegenerate`: the complexified form of a polarization is
+  nondegenerate.
 * `TauCeti.Hodge.IsPolarization.exists_pairing_ne_zero`: conjugate Hodge components pair
   nondegenerately.
 * `TauCeti.Hodge.Polarization`: a polarized Hodge structure's form, bundled with its relations.
@@ -107,9 +107,8 @@ theorem complex_symm_weight (h : IsPolarization hℂ hs Q) (x y : Vℂ) :
   have hxy := DFunLike.congr_fun (DFunLike.congr_fun hforms x) y
   simpa only [LinearMap.BilinForm.flip_apply, LinearMap.smul_apply, zsmul_eq_mul] using hxy
 
-/-- The complexification of a polarizing form on a finite free lattice is nondegenerate. -/
-theorem complex_nondegenerate [Module.Free ℤ V] [Module.Finite ℤ V]
-    (h : IsPolarization hℂ hs Q) :
+/-- The complexification of a polarizing form is nondegenerate. -/
+theorem complex_nondegenerate (h : IsPolarization hℂ hs Q) :
     LinearMap.BilinForm.Nondegenerate (integralFormToComplex hℂ Q) :=
   integralFormToComplex_nondegenerate hℂ h.nondegenerate
 
@@ -178,8 +177,8 @@ theorem Q_symm_weight (P : Polarization hℂ hs) (x y : Vℂ) :
     P.Q y x = (n.negOnePow : ℤ) * P.Q x y :=
   P.isPolarization.complex_symm_weight x y
 
-/-- The complex form of a polarization on a finite free lattice is nondegenerate. -/
-theorem Q_nondegenerate [Module.Free ℤ V] [Module.Finite ℤ V] (P : Polarization hℂ hs) :
+/-- The complex form of a polarization is nondegenerate. -/
+theorem Q_nondegenerate (P : Polarization hℂ hs) :
     LinearMap.BilinForm.Nondegenerate P.Q :=
   P.isPolarization.complex_nondegenerate
 

--- a/TauCeti/Geometry/Hodge/Structure.lean
+++ b/TauCeti/Geometry/Hodge/Structure.lean
@@ -33,7 +33,7 @@ Buzzard, and Joël Riou.
   complexification.
 * `TauCeti.Hodge.HodgeStructureOn.piece`: the Hodge component `H^{p,n-p}`.
 * `TauCeti.Hodge.HodgeStructureOn.conj_piece`: conjugation exchanges `H^{p,n-p}` and
-  `H^{n-p,p}`.
+  `H^{n-p,p}`, with `TauCeti.Hodge.HodgeStructureOn.conj_mem_piece` its elementwise form.
 * `TauCeti.Hodge.HodgeStructureOn.IsEffective`: the filtration is supported in bidegrees with
   both indices nonnegative.
 -/
@@ -174,6 +174,11 @@ theorem conj_piece (hs : HodgeStructureOn W ω n) (p : ℤ) :
     (hs.piece p).map ω.toEquiv.toLinearMap = hs.piece (n - p) := by
   rw [piece_def, Submodule.map_inf _ ω.toEquiv.injective, conjF_def, ω.map_map_eq_self,
     piece_def, conjF_def, sub_sub_cancel, inf_comm]
+
+/-- Elementwise form of the exchange of Hodge components by conjugation. -/
+theorem conj_mem_piece (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W} (hx : x ∈ hs.piece p) :
+    ω.toEquiv x ∈ hs.piece (n - p) :=
+  hs.conj_piece p ▸ Submodule.mem_map_of_mem hx
 
 /-- A weight-`n` Hodge structure is effective when its Hodge filtration begins at `F 0 = ⊤`.
 Equivalently, it ends at `F (n + 1) = ⊥`, and its Hodge components can occur only when both

--- a/TauCeti/Geometry/Hodge/Tate.lean
+++ b/TauCeti/Geometry/Hodge/Tate.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Geometry.Hodge.Structure
+public import TauCeti.Geometry.Hodge.Polarization
 public import Mathlib.LinearAlgebra.Dimension.Finite
 
 /-!
@@ -17,7 +17,8 @@ The Tate structure `ℤ(m)` is the rank-one pure Hodge structure of weight `-2m`
 
 This is the first concrete nonzero inhabitant of `TauCeti.Hodge.HodgeStructure`. Besides fixing the
 weight and filtration-shift conventions needed by later Tate twists, it verifies directly that the
-opposed-filtration definition has the intended rank-one objects.
+opposed-filtration definition has the intended rank-one objects. Multiplication of integers
+polarizes it, so it also witnesses that the Hodge–Riemann relations are satisfiable.
 
 The convention follows the Hodge structures roadmap and standard Hodge-theory notation; see
 Voisin, *Hodge Theory and Complex Algebraic Geometry I*, §7.
@@ -28,6 +29,8 @@ Voisin, *Hodge Theory and Complex Algebraic Geometry I*, §7.
 * `TauCeti.Hodge.tate_F`: its filtration is `⊤` exactly in degrees at most `-m`.
 * `TauCeti.Hodge.tate_piece`: its only nonzero Hodge component has bidegree `(-m,-m)`.
 * `TauCeti.Hodge.finrank_tate_piece`: its Hodge number there is one and all others are zero.
+* `TauCeti.Hodge.isPolarization_tate`: multiplication of integers satisfies the Hodge–Riemann
+  relations for it, and `TauCeti.Hodge.tatePolarization` bundles that as a polarization.
 -/
 
 public section
@@ -128,5 +131,63 @@ theorem finrank_tate_piece (m p : ℤ) :
     Module.finrank ℂ ((tate m).piece p) = if p = -m then 1 else 0 := by
   rw [tate_piece, apply_ite (fun S : Submodule ℂ ℂ ↦ Module.finrank ℂ S)]
   simp
+
+/-! ### The polarization of a Tate structure -/
+
+/-- The conjugation of the Tate complexification is complex conjugation. -/
+theorem latticeConj_tateLatticeMap (z : ℂ) :
+    latticeConj isBaseChange_tateLatticeMap z = starRingEnd ℂ z := by
+  have huniq := latticeConj_unique isBaseChange_tateLatticeMap (starRingEnd ℂ).toSemilinearMap
+    (fun v ↦ by simp)
+  exact congrArg (fun f ↦ f z) huniq.symm
+
+/-- The complexification of integer multiplication is complex multiplication. -/
+theorem integralFormToComplex_tateLatticeMap_mul :
+    integralFormToComplex isBaseChange_tateLatticeMap (LinearMap.mul ℤ ℤ) =
+      LinearMap.mul ℂ ℂ :=
+  (integralFormToComplex_unique isBaseChange_tateLatticeMap _ _ fun x y ↦ by simp).symm
+
+/-- Multiplication of integers satisfies the Hodge–Riemann relations for `ℤ(m)`. -/
+theorem isPolarization_tate (m : ℤ) :
+    IsPolarization isBaseChange_tateLatticeMap (tate m) (LinearMap.mul ℤ ℤ) where
+  symm_weight x y := by
+    rw [Int.negOnePow_even _ ⟨-m, by ring⟩]
+    simp [mul_comm]
+  nondegenerate := ⟨fun x hx ↦ by simpa using hx 1, fun y hy ↦ by simpa using hy 1⟩
+  orthogonal p x hx y hy := by
+    by_cases hp : p ≤ -m
+    · have hcond : ¬ -2 * m + 1 - p ≤ -m := by omega
+      have hbot : (tate m).F (-2 * m + 1 - p) = (⊥ : Submodule ℂ ℂ) := by
+        rw [tate_F]
+        exact ite_eq_right hcond
+      rw [hbot, Submodule.mem_bot] at hy
+      simp [hy]
+    · have hbot : (tate m).F p = (⊥ : Submodule ℂ ℂ) := by simp [hp]
+      rw [hbot, Submodule.mem_bot] at hx
+      simp [hx]
+  positive p x hx hx0 := by
+    by_cases hp : p = -m
+    · subst hp
+      have hexp : 2 * -m - -2 * m = 0 := by ring
+      rw [hexp, zpow_zero, one_mul, integralFormToComplex_tateLatticeMap_mul,
+        latticeConj_tateLatticeMap]
+      simpa [Complex.mul_conj] using Complex.normSq_pos.mpr hx0
+    · have hbot : (tate m).piece p = (⊥ : Submodule ℂ ℂ) := by simp [hp]
+      rw [hbot, Submodule.mem_bot] at hx
+      exact absurd hx hx0
+
+/-- The Tate Hodge structure `ℤ(m)`, polarized by multiplication of integers. -/
+def tatePolarization (m : ℤ) : Polarization isBaseChange_tateLatticeMap (tate m) where
+  Qint := LinearMap.mul ℤ ℤ
+  isPolarization := isPolarization_tate m
+
+/-- The polarizing form of `ℤ(m)` is multiplication of integers. -/
+@[simp]
+theorem tatePolarization_Qint (m : ℤ) : (tatePolarization m).Qint = LinearMap.mul ℤ ℤ :=
+  (rfl)
+
+/-- The Tate Hodge structure is polarizable. -/
+theorem isPolarizable_tate (m : ℤ) : IsPolarizable isBaseChange_tateLatticeMap (tate m) :=
+  (tatePolarization m).isPolarizable
 
 end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Tate.lean
+++ b/TauCeti/Geometry/Hodge/Tate.lean
@@ -181,11 +181,6 @@ def tatePolarization (m : ℤ) : Polarization isBaseChange_tateLatticeMap (tate 
   Qint := LinearMap.mul ℤ ℤ
   isPolarization := isPolarization_tate m
 
-/-- The polarizing form of `ℤ(m)` is multiplication of integers. -/
-@[simp]
-theorem tatePolarization_Qint (m : ℤ) : (tatePolarization m).Qint = LinearMap.mul ℤ ℤ :=
-  (rfl)
-
 /-- The Tate Hodge structure is polarizable. -/
 theorem isPolarizable_tate (m : ℤ) : IsPolarizable isBaseChange_tateLatticeMap (tate m) :=
   (tatePolarization m).isPolarizable


### PR DESCRIPTION
This PR states the Hodge–Riemann bilinear relations and lands the definition layer of Layer L1 of the `HodgeStructures` roadmap, whose milestone is the semisimplicity of polarizable rational Hodge structures. L1 asks for `IsPolarization hs Qint` (the relations as a `Prop` on a *given* integral form), `Polarization hs` (a form bundled with such a proof, with its complex form *derived*), and `IsPolarizable hs`; all three are supplied here, together with the roadmap's blocking requirement that the definitions have an explicit nonzero inhabitant — multiplication of integers is shown to polarize the Tate structure `ℤ(m)`.

`TauCeti/Geometry/Hodge/BilinearForm.lean` builds the derived complex form. `integralFormToComplex` extends an integral bilinear form on the lattice to any abstract `IsBaseChange` complexification, by transporting Mathlib's `LinearMap.BilinForm.baseChange` along `IsBaseChange.equiv`, so the integral-to-complex link is Mathlib's `baseChange_tmul` rather than a hand-imposed axiom, exactly as the roadmap's *Core definitions* section requires. It is characterized by its values on integral vectors (`integralFormToComplex_unique`), commutes with flips and integer multiples, is real for the lattice-induced conjugation (`integralFormToComplex_conj`, proved by induction over the base change), and inherits nondegeneracy from a finite free lattice (`integralFormToComplex_nondegenerate`, via the Gram determinant over the domains `ℤ` and `ℂ`).

`TauCeti/Geometry/Hodge/Polarization.lean` states `IsPolarization` with the four conditions the roadmap pins: `(-1)^n`-symmetry written with `Int.negOnePow`, nondegeneracy, the first Hodge–Riemann relation `Q(F^p, F^{n+1-p}) = 0`, and the second relation `0 < i^{p-q} Q(x, x̄)` on the Hodge component `H^{p,q}`, in the partial order of `open scoped ComplexOrder` — which also forces the value to be real, as the classical statement does. The pinned sign convention is recorded in the module docstring, including the extra `(-1)^{n(n-1)/2}` a cup-product instance must insert. The derived API includes the even/odd symmetry forms, the weight symmetry of the complexified form, nondegeneracy of that form, the first relation transported to the conjugate filtration, and the fact the mixed and pure theory both use downstream: two Hodge components pair to zero unless their degrees add up to the weight (`orthogonal_piece`), while a nonzero vector of `H^{p,q}` pairs nontrivially with its conjugate in `H^{q,p}` (`exists_pairing_ne_zero`). `Structure.lean` gains the elementwise `conj_mem_piece` companion to the existing `conj_piece` that this needs.

`Tate.lean` discharges the roadmap's blocking instance: `isPolarization_tate` checks the relations for `LinearMap.mul ℤ ℤ` on `ℤ(m)` — even weight `-2m` makes the sign condition symmetry, the orthogonality is the degenerate `⊤`/`⊥` check, and the positivity is `0 < z * z̄` — and `tatePolarization` bundles it, so the relations are visibly satisfiable and not vacuous. Two supporting identities are proved on the way: lattice conjugation on the Tate complexification is complex conjugation, and the complexification of integer multiplication is complex multiplication.

Nothing is vendored from Mathlib; the construction reuses `LinearMap.BilinForm.baseChange`, `Algebra.TensorProduct.basis`, `LinearMap.BilinForm.nondegenerate_iff_det_ne_zero`, `Int.cast_det`, `Int.negOnePow` and `Complex.partialOrder` as they stand.

What remains for the L1 milestone after this PR: the Weil operator `C` with `C² = (-1)^n` and the positive-definite Hermitian form `h(u,v) = Q(C u, v̄)` it carries, `RationalHodgeSubstructure`, and the orthogonal-complement argument that gives semisimplicity.

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"ispolarization"}-->

🤖 Prepared with Claude Code
