### PR TITLE
refactor(Valuation): name the two order-sign facts equivalence gives

### DIFF
--- a/TauCeti/RingTheory/Valuation/Discrete/Order.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Order.lean
@@ -219,7 +219,7 @@ identifies the valuation subrings, and membership of the subring is exactly nonn
 additive order.
 
 Only equivalence is needed; neither valuation has to be surjective. -/
-private theorem ord_nonneg_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
+theorem ord_nonneg_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
     (f : F) : 0 ≤ ord v f ↔ 0 ≤ ord w f := by
   rw [← mem_valuationSubring_iff_ord_nonneg v, ← mem_valuationSubring_iff_ord_nonneg w]
   exact h.le_one_iff_le_one
@@ -228,7 +228,7 @@ private theorem ord_nonneg_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (
 analogue of `Valuation.IsEquiv.eq_zero`, and says the two valuations have the same units.
 
 Only equivalence is needed; neither valuation has to be surjective. -/
-private theorem ord_eq_zero_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
+theorem ord_eq_zero_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
     (f : F) : ord v f = 0 ↔ ord w f = 0 := by
   -- Nonnegativity at `f` and at `f⁻¹` together pin the order to zero, and `ord_inv` turns the
   -- second into nonpositivity at `f`.

--- a/TauCeti/RingTheory/Valuation/Discrete/Order.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Order.lean
@@ -214,22 +214,34 @@ theorem valuationSubring_ne_top_of_surjective (v : _root_.Valuation F ℤᵐ⁰)
   rw [mem_valuationSubring_iff_ord_nonneg v, ord_inv, ht] at ht'
   omega
 
+/-- **Equivalent valuations agree on which elements have nonnegative order.** Equivalence
+identifies the valuation subrings, and membership of the subring is exactly nonnegativity of the
+additive order.
+
+Only equivalence is needed; neither valuation has to be surjective. -/
+private theorem ord_nonneg_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
+    (f : F) : 0 ≤ ord v f ↔ 0 ≤ ord w f := by
+  rw [← mem_valuationSubring_iff_ord_nonneg v, ← mem_valuationSubring_iff_ord_nonneg w]
+  exact h.le_one_iff_le_one
+
+/-- **Equivalent valuations agree on which elements have order zero.** This is the additive-order
+analogue of `Valuation.IsEquiv.eq_zero`, and says the two valuations have the same units.
+
+Only equivalence is needed; neither valuation has to be surjective. -/
+private theorem ord_eq_zero_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
+    (f : F) : ord v f = 0 ↔ ord w f = 0 := by
+  -- Nonnegativity at `f` and at `f⁻¹` together pin the order to zero, and `ord_inv` turns the
+  -- second into nonpositivity at `f`.
+  have hf := ord_nonneg_iff_of_isEquiv h f
+  have hinv := ord_nonneg_iff_of_isEquiv h f⁻¹
+  rw [ord_inv, ord_inv] at hinv
+  omega
+
 /-- Two equivalent normalized `ℤᵐ⁰`-valuations are equal. -/
 theorem eq_of_isEquiv_of_surjective {v w : _root_.Valuation F ℤᵐ⁰}
     (hv : Function.Surjective v) (hw : Function.Surjective w) (h : v.IsEquiv w) : v = w := by
-  -- Equivalence identifies the valuation rings, so it preserves the sign and vanishing
-  -- of the associated additive orders.
-  have hmem : ∀ f : F, 0 ≤ ord v f ↔ 0 ≤ ord w f := fun f => by
-    rw [← mem_valuationSubring_iff_ord_nonneg v, ← mem_valuationSubring_iff_ord_nonneg w]
-    exact h.le_one_iff_le_one
-  have hle : ∀ f : F, ord v f ≤ 0 ↔ ord w f ≤ 0 := fun f => by
-    have h' := hmem f⁻¹
-    rw [ord_inv, ord_inv] at h'
-    omega
-  have hzero : ∀ f : F, ord v f = 0 ↔ ord w f = 0 := fun f => by
-    have h₁ := hmem f
-    have h₂ := hle f
-    omega
+  have hmem := ord_nonneg_iff_of_isEquiv h
+  have hzero := ord_eq_zero_iff_of_isEquiv h
   -- Choose order-one elements for both normalized valuations and compare their orders.
   obtain ⟨t, ht⟩ := ord_surjective v hv 1
   obtain ⟨s, hs⟩ := ord_surjective w hw 1

--- a/TauCeti/RingTheory/Valuation/Discrete/Order.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Order.lean
@@ -219,29 +219,32 @@ identifies the valuation subrings, and membership of the subring is exactly nonn
 additive order.
 
 Only equivalence is needed; neither valuation has to be surjective. -/
-theorem ord_nonneg_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
+theorem IsEquiv.ord_nonneg_iff {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
     (f : F) : 0 ≤ ord v f ↔ 0 ≤ ord w f := by
-  rw [← mem_valuationSubring_iff_ord_nonneg v, ← mem_valuationSubring_iff_ord_nonneg w]
+  rw [← mem_valuationSubring_iff_ord_nonneg v, ← mem_valuationSubring_iff_ord_nonneg w,
+    _root_.Valuation.mem_valuationSubring_iff, _root_.Valuation.mem_valuationSubring_iff]
   exact h.le_one_iff_le_one
 
 /-- **Equivalent valuations agree on which elements have order zero.** This is the additive-order
-analogue of `Valuation.IsEquiv.eq_zero`, and says the two valuations have the same units.
+analogue of `Valuation.IsEquiv.eq_one_iff_eq_one`: away from `0`, order zero says the valuation is
+`1`, so the two valuations have the same units. The junk value `ord v 0 = 0` is absorbed on both
+sides.
 
 Only equivalence is needed; neither valuation has to be surjective. -/
-theorem ord_eq_zero_iff_of_isEquiv {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
+theorem IsEquiv.ord_eq_zero_iff {v w : _root_.Valuation F ℤᵐ⁰} (h : v.IsEquiv w)
     (f : F) : ord v f = 0 ↔ ord w f = 0 := by
   -- Nonnegativity at `f` and at `f⁻¹` together pin the order to zero, and `ord_inv` turns the
   -- second into nonpositivity at `f`.
-  have hf := ord_nonneg_iff_of_isEquiv h f
-  have hinv := ord_nonneg_iff_of_isEquiv h f⁻¹
+  have hf := h.ord_nonneg_iff f
+  have hinv := h.ord_nonneg_iff f⁻¹
   rw [ord_inv, ord_inv] at hinv
   omega
 
 /-- Two equivalent normalized `ℤᵐ⁰`-valuations are equal. -/
 theorem eq_of_isEquiv_of_surjective {v w : _root_.Valuation F ℤᵐ⁰}
     (hv : Function.Surjective v) (hw : Function.Surjective w) (h : v.IsEquiv w) : v = w := by
-  have hmem := ord_nonneg_iff_of_isEquiv h
-  have hzero := ord_eq_zero_iff_of_isEquiv h
+  have hmem := h.ord_nonneg_iff
+  have hzero := h.ord_eq_zero_iff
   -- Choose order-one elements for both normalized valuations and compare their orders.
   obtain ⟨t, ht⟩ := ord_surjective v hv 1
   obtain ⟨s, hs⟩ := ord_surjective w hw 1


### PR DESCRIPTION
`eq_of_isEquiv_of_surjective` opened with an 11-line block deriving, from the equivalence alone,
how the two valuations' additive orders compare. Those are two statements worth naming, and both
are used repeatedly further down rather than once.

## The extractions

* **`Valuation.IsEquiv.ord_nonneg_iff`** — equivalent valuations agree on which elements have
  nonnegative order. Equivalence identifies the valuation subrings, and subring membership *is*
  nonnegativity of the order.
* **`Valuation.IsEquiv.ord_eq_zero_iff`** — they agree on which elements have order zero;
  equivalently, they have the same units. This is the additive-order analogue of Mathlib's
  `Valuation.IsEquiv.eq_one_iff_eq_one`.

Neither is a one-use wrapper: after the rewrite the parent uses the first twice and the second
four times, and the first is also what the second is proved from.

**Both are public**, and deliberately so: they characterise how the public `ord` behaves under
valuation equivalence, and the surrounding `ord` API (`ord_mul`, `ord_inv`, `ord_zpow`, `ord_div`,
`mem_valuationSubring_iff_ord_nonneg`) is already consumed outside this file. They sit in the
`Valuation.IsEquiv` namespace so that `h.ord_nonneg_iff` works, matching Mathlib's convention for
two-sided transfers along an equivalence; `_of_isEquiv` is this repo's suffix for *one*-directional
transfer.

## Minimal hypotheses

Each takes only `h : v.IsEquiv w`. The parent additionally carries surjectivity of both
valuations — `hv`, `hw` — and neither helper needs it, so neither takes it. The old intermediate
step `hle` (nonpositivity, obtained from nonnegativity at `f⁻¹` via `ord_inv`) is now internal to
the second helper instead of a third fact threaded through the parent.

## Not a Mathlib duplication

`ord` is defined in this very file, so no upstream lemma can be phrased in terms of it. Mathlib's
`Valuation.IsEquiv` API carries `eq_zero`, `eq_iff`, `le_one_iff_le_one`, `eq_one_iff_eq_one` and
so on at the level of the valuation itself. Note which one is the counterpart: `eq_zero` is
`v₁ r = 0 ↔ v₂ r = 0`, which over a field says `r = 0`; order zero corresponds instead to `v f = 1`,
so `ord_eq_zero_iff` mirrors `eq_one_iff_eq_one`, with the junk value `ord v 0 = 0` absorbed on
both sides.

## Result

| | before | after |
|---|---|---|
| `eq_of_isEquiv_of_surjective` | 48 | **37** |
| `Valuation.IsEquiv.ord_nonneg_iff` | — | 3 |
| `Valuation.IsEquiv.ord_eq_zero_iff` | — | 6 |

The parent leaves the 40–50 band. No statement of any existing declaration changed.

Gates run on `0303785b`: `lake build` (8496 jobs), `lake exe axioms` (58106 declarations),
`lake exe module-system` (2720 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`, 64 grandfathered;
docstring scan 4595/4595).

Roadmap: AdicSpaces
