### PR TITLE
feat: compute the rational Dixon table for D4

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Data.ZMod.ValMinAbs
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.CentralCharacterCount
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.Dihedral
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Dihedral
+
+/-!
+# The rational Dixon computation for the dihedral group of order eight
+
+This file runs the rational stage of the Dixon--Schneider character-table algorithm for
+`DihedralGroup 4`.  The class data are numbered by `TauCeti.dihedralClassData 4`, whose class sizes
+are `[1, 1, 2, 2, 2]`.  Reducing modulo the certified good prime `5`, the simultaneous eigenvector
+search returns exactly the reductions of the five rows displayed in
+`TauCeti.dihedralGroupFourCentralCharacterTable`.
+
+Completeness is not established by evaluating the exponentially sized search.  Each displayed row
+is verified against the structure constants, while
+`TauCeti.ClassData.card_centralCharacterSearch_of_isGoodDixonPrime` proves that the search has only
+five elements.  Equality follows from those two facts.  The entries lie strictly between
+`-5 / 2` and `5 / 2`, so `ZMod.valMinAbs` reconstructs the displayed integral rows without any
+cyclotomic ambiguity.  Dividing by the class sizes and multiplying by the degrees gives the usual
+character table of the dihedral group of order eight.
+
+## Main definitions
+
+* `TauCeti.dihedralGroupFourCentralCharacterTable`: the five integral central-character rows.
+* `TauCeti.dihedralGroupFourModularCentralRows`: their reductions modulo `5`.
+* `TauCeti.dihedralGroupFourCharacterTable`: the resulting ordinary integral character table.
+
+## Main results
+
+* `TauCeti.dihedralGroupFour_centralCharacterSearch`: the modular search returns exactly the five
+  displayed reductions.
+* `TauCeti.dihedralGroupFour_valMinAbs_centralCharacterTable`: signed least representatives lift
+  every modular entry back to the displayed integer.
+* `TauCeti.dihedralGroupFour_degree_mul_centralCharacterTable`: the division-free conversion from
+  the central-character table to the ordinary character table.
+
+## References
+
+This closes the `D₄ = DihedralGroup 4` part of “Rational tables (first executable milestone)” in
+Layer 6 of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md).
+
+* J. D. Dixon, *High speed computation of group characters*, Numerische Mathematik 10 (1967),
+  446--450.
+* G. Schneider, *Dixon's character table algorithm revisited*, J. Symbolic Comput. 9 (1990),
+  601--606.
+-/
+
+public section
+
+namespace TauCeti
+
+open Matrix
+
+local instance : Fact (Nat.Prime 5) := ⟨by decide⟩
+
+/-- The numbered conjugacy classes of the dihedral group of order eight. -/
+abbrev DihedralGroupFourClassIndex := Fin (dihedralClassData 4).numClasses
+
+/-- **The integral central-character table of the dihedral group of order eight.** Columns follow
+the numbering of `TauCeti.dihedralClassData 4`: identity, central rotation, one reflection class,
+the rotations of order four, and the other reflection class. -/
+@[expose] def dihedralGroupFourCentralCharacterTable :
+    Matrix DihedralGroupFourClassIndex DihedralGroupFourClassIndex ℤ :=
+  !![1,  1,  2,  2,  2;
+     1,  1,  2, -2, -2;
+     1,  1, -2,  2, -2;
+     1,  1, -2, -2,  2;
+     1, -1,  0,  0,  0]
+
+/-- The five displayed central-character rows reduced modulo the certified Dixon prime `5`. -/
+@[expose] def dihedralGroupFourModularCentralRows :
+    Finset (DihedralGroupFourClassIndex → ZMod 5) :=
+  Finset.univ.image fun i j => (dihedralGroupFourCentralCharacterTable i j : ZMod 5)
+
+/-- Every displayed integral row is a simultaneous eigenrow of the integral class-multiplication
+matrices.  In particular, the modular verification below is the reduction of an honest
+characteristic-zero central character, rather than an eigenrow created by reduction. -/
+theorem dihedralGroupFour_isIntegralEigenrow (i : DihedralGroupFourClassIndex) :
+    (dihedralClassData 4).IsModularEigenrow
+      (fun j => dihedralGroupFourCentralCharacterTable i j) := by
+  rw [(dihedralClassData 4).isModularEigenrow_iff]
+  fin_cases i <;> decide
+
+/-- Reindexing a displayed integral row by the actual conjugacy classes gives a class-algebra
+eigenrow. -/
+theorem dihedralGroupFour_isClassEigenrow (i : DihedralGroupFourClassIndex) :
+    IsClassEigenrow ((dihedralClassData 4).reindexModularRow
+      fun j => dihedralGroupFourCentralCharacterTable i j) :=
+  ((dihedralClassData 4).isModularEigenrow_iff_isClassEigenrow _).mp
+    (dihedralGroupFour_isIntegralEigenrow i)
+
+/-- Every displayed reduction is normalized at the identity class and is a simultaneous eigenrow
+of the reduced class-multiplication matrices. -/
+theorem dihedralGroupFour_isModularEigenrow (i : DihedralGroupFourClassIndex) :
+    (dihedralClassData 4).IsModularEigenrow
+      (fun j => (dihedralGroupFourCentralCharacterTable i j : ZMod 5)) := by
+  rw [(dihedralClassData 4).isModularEigenrow_iff]
+  fin_cases i <;> decide
+
+/-- The explicit set of modular rows has five elements. -/
+@[simp]
+theorem card_dihedralGroupFourModularCentralRows :
+    dihedralGroupFourModularCentralRows.card = 5 := by
+  decide
+
+/-- **The executable modular central-character search for `DihedralGroup 4` returns precisely the
+five reductions in `TauCeti.dihedralGroupFourCentralCharacterTable`.** -/
+theorem dihedralGroupFour_centralCharacterSearch :
+    (dihedralClassData 4).centralCharacterSearch (F := ZMod 5) =
+      dihedralGroupFourModularCentralRows := by
+  symm
+  apply Finset.eq_of_subset_of_card_le
+  · rw [dihedralGroupFourModularCentralRows, Finset.image_subset_iff]
+    intro i _
+    rw [(dihedralClassData 4).mem_centralCharacterSearch]
+    exact ⟨by fin_cases i <;> decide, dihedralGroupFour_isModularEigenrow i⟩
+  · rw [(dihedralClassData 4).card_centralCharacterSearch_of_isGoodDixonPrime
+      isGoodDixonPrime_dihedralGroup_four_five,
+      card_dihedralGroupFourModularCentralRows,
+      numClasses_dihedralClassData_four]
+
+/-- **Signed least representatives modulo `5` recover every entry of the integral
+central-character table.** This is the rational lifting step of the Dixon computation. -/
+@[simp]
+theorem dihedralGroupFour_valMinAbs_centralCharacterTable
+    (i j : DihedralGroupFourClassIndex) :
+    ((dihedralGroupFourCentralCharacterTable i j : ZMod 5)).valMinAbs =
+      dihedralGroupFourCentralCharacterTable i j := by
+  apply ZMod.valMinAbs_intCast_of_two_mul_natAbs_lt
+  fin_cases i <;> fin_cases j <;> decide
+
+/-- The signed integral rows obtained by applying `ZMod.valMinAbs` to the output of the modular
+search. -/
+@[expose] def dihedralGroupFourLiftedCentralRows :
+    Finset (DihedralGroupFourClassIndex → ℤ) :=
+  ((dihedralClassData 4).centralCharacterSearch (F := ZMod 5)).image
+    fun a j => (a j).valMinAbs
+
+/-- **The rational lift of the modular search is exactly the displayed integral central-character
+table, up to the irrelevant order of its rows.** -/
+theorem dihedralGroupFour_liftedCentralRows :
+    dihedralGroupFourLiftedCentralRows =
+      Finset.univ.image fun i => dihedralGroupFourCentralCharacterTable i := by
+  rw [dihedralGroupFourLiftedCentralRows, dihedralGroupFour_centralCharacterSearch,
+    dihedralGroupFourModularCentralRows, Finset.image_image]
+  apply Finset.image_congr
+  intro i _
+  funext j
+  exact dihedralGroupFour_valMinAbs_centralCharacterTable i j
+
+/-- The degrees attached to the five central-character rows. -/
+@[expose] def dihedralGroupFourCharacterDegrees : DihedralGroupFourClassIndex → ℕ :=
+  ![1, 1, 1, 1, 2]
+
+/-- The class sizes in the numbering used by the rational computation. -/
+@[expose] def dihedralGroupFourClassSizes : DihedralGroupFourClassIndex → ℕ :=
+  ![1, 1, 2, 2, 2]
+
+/-- The displayed class sizes agree with the class data computed from the group. -/
+@[simp]
+theorem dihedralGroupFour_card_classFinset (i : DihedralGroupFourClassIndex) :
+    ((dihedralClassData 4).classFinset i).card = dihedralGroupFourClassSizes i := by
+  fin_cases i <;> decide
+
+/-- **The integral character table produced by the rational Dixon computation for the dihedral
+group of order eight.** The columns use the same class numbering as
+`TauCeti.dihedralGroupFourCentralCharacterTable`. -/
+@[expose] def dihedralGroupFourCharacterTable :
+    Matrix DihedralGroupFourClassIndex DihedralGroupFourClassIndex ℤ :=
+  !![1,  1,  1,  1,  1;
+     1,  1,  1, -1, -1;
+     1,  1, -1,  1, -1;
+     1,  1, -1, -1,  1;
+     2, -2,  0,  0,  0]
+
+/-- **Division-free conversion from central characters to ordinary characters.** For every row
+`i` and numbered conjugacy class `j`,
+`degree i * omega i j = |K_j| * chi i j`. -/
+theorem dihedralGroupFour_degree_mul_centralCharacterTable
+    (i j : DihedralGroupFourClassIndex) :
+    (dihedralGroupFourCharacterDegrees i : ℤ) *
+        dihedralGroupFourCentralCharacterTable i j =
+      ((dihedralClassData 4).classFinset j).card * dihedralGroupFourCharacterTable i j := by
+  fin_cases i <;> fin_cases j <;> decide
+
+/-- The displayed degrees are positive and divide the order of `DihedralGroup 4`. -/
+theorem dihedralGroupFour_characterDegrees_pos_dvd (i : DihedralGroupFourClassIndex) :
+    0 < dihedralGroupFourCharacterDegrees i ∧
+      dihedralGroupFourCharacterDegrees i ∣ Nat.card (DihedralGroup 4) := by
+  rw [DihedralGroup.nat_card]
+  fin_cases i <;> decide
+
+/-- The squares of the displayed degrees sum to the group order. -/
+theorem dihedralGroupFour_sum_characterDegrees_sq :
+    ∑ i, dihedralGroupFourCharacterDegrees i ^ 2 = Nat.card (DihedralGroup 4) := by
+  rw [DihedralGroup.nat_card]
+  decide
+
+/-- The displayed ordinary character rows satisfy the class-size weighted orthogonality
+relations. -/
+theorem dihedralGroupFour_characterTable_orthogonal (i j : DihedralGroupFourClassIndex) :
+    ∑ k, ((dihedralClassData 4).classFinset k).card *
+        dihedralGroupFourCharacterTable i k * dihedralGroupFourCharacterTable j k =
+      if i = j then Nat.card (DihedralGroup 4) else 0 := by
+  simp_rw [dihedralGroupFour_card_classFinset]
+  rw [DihedralGroup.nat_card]
+  fin_cases i <;> fin_cases j <;> decide
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/DihedralFour.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/DihedralFour.lean
@@ -152,8 +152,16 @@ central-character table.** This is the rational lifting step of the Dixon comput
 @[simp]
 theorem dihedralGroupFour_valMinAbs_centralCharacterTable
     (i j : DihedralGroupFourClassIndex) :
-    ((dihedralGroupFourCentralCharacterTable i j : ZMod 5)).valMinAbs =
-      dihedralGroupFourCentralCharacterTable i j := by
+    (((!![1,  1,  2,  2,  2;
+          1,  1,  2, -2, -2;
+          1,  1, -2,  2, -2;
+          1,  1, -2, -2,  2;
+          1, -1,  0,  0,  0] i j : ℤ) : ZMod 5)).valMinAbs =
+      !![1,  1,  2,  2,  2;
+         1,  1,  2, -2, -2;
+         1,  1, -2,  2, -2;
+         1,  1, -2, -2,  2;
+         1, -1,  0,  0,  0] i j := by
   apply ZMod.valMinAbs_intCast_of_two_mul_natAbs_lt
   fin_cases i <;> fin_cases j <;> decide
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/DihedralFour.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/DihedralFour.lean
@@ -103,7 +103,8 @@ theorem mem_dihedralGroupFourModularCentralRows_iff
 /-- Every displayed integral row is a simultaneous eigenrow of the integral class-multiplication
 matrices.  In particular, the modular verification below is the reduction of an honest
 characteristic-zero central character, rather than an eigenrow created by reduction. -/
-theorem dihedralGroupFour_isIntegralEigenrow (i : DihedralGroupFourClassIndex) :
+theorem isModularEigenrow_dihedralGroupFourCentralCharacterTable_int
+    (i : DihedralGroupFourClassIndex) :
     (dihedralClassData 4).IsModularEigenrow
       (fun j => dihedralGroupFourCentralCharacterTable i j) := by
   rw [(dihedralClassData 4).isModularEigenrow_iff]
@@ -111,15 +112,17 @@ theorem dihedralGroupFour_isIntegralEigenrow (i : DihedralGroupFourClassIndex) :
 
 /-- Reindexing a displayed integral row by the actual conjugacy classes gives a class-algebra
 eigenrow. -/
-theorem dihedralGroupFour_isClassEigenrow (i : DihedralGroupFourClassIndex) :
+theorem isClassEigenrow_dihedralGroupFourCentralCharacterTable
+    (i : DihedralGroupFourClassIndex) :
     IsClassEigenrow ((dihedralClassData 4).reindexModularRow
       fun j => dihedralGroupFourCentralCharacterTable i j) :=
   ((dihedralClassData 4).isModularEigenrow_iff_isClassEigenrow _).mp
-    (dihedralGroupFour_isIntegralEigenrow i)
+    (isModularEigenrow_dihedralGroupFourCentralCharacterTable_int i)
 
 /-- Every displayed reduction is a simultaneous eigenrow of the reduced class-multiplication
 matrices. -/
-theorem dihedralGroupFour_isModularEigenrow (i : DihedralGroupFourClassIndex) :
+theorem isModularEigenrow_dihedralGroupFourCentralCharacterTable_zmod
+    (i : DihedralGroupFourClassIndex) :
     (dihedralClassData 4).IsModularEigenrow
       (fun j => (dihedralGroupFourCentralCharacterTable i j : ZMod 5)) := by
   rw [(dihedralClassData 4).isModularEigenrow_iff]
@@ -141,7 +144,8 @@ theorem dihedralGroupFour_centralCharacterSearch :
   · rw [dihedralGroupFourModularCentralRows, Finset.image_subset_iff]
     intro i _
     rw [(dihedralClassData 4).mem_centralCharacterSearch]
-    exact ⟨by fin_cases i <;> decide, dihedralGroupFour_isModularEigenrow i⟩
+    exact ⟨by fin_cases i <;> decide,
+      isModularEigenrow_dihedralGroupFourCentralCharacterTable_zmod i⟩
   · rw [(dihedralClassData 4).card_centralCharacterSearch_of_isGoodDixonPrime
       isGoodDixonPrime_dihedralGroup_four_five,
       card_dihedralGroupFourModularCentralRows,
@@ -236,7 +240,7 @@ theorem dihedralGroupFour_degree_mul_centralCharacterTable
   fin_cases i <;> fin_cases j <;> decide
 
 /-- The displayed degrees are positive and divide the order of `DihedralGroup 4`. -/
-theorem dihedralGroupFour_characterDegrees_pos_dvd (i : DihedralGroupFourClassIndex) :
+theorem dihedralGroupFour_characterDegrees_pos_and_dvd (i : DihedralGroupFourClassIndex) :
     0 < dihedralGroupFourCharacterDegrees i ∧
       dihedralGroupFourCharacterDegrees i ∣ Nat.card (DihedralGroup 4) := by
   rw [DihedralGroup.nat_card]

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/DihedralFour.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/DihedralFour.lean
@@ -152,20 +152,15 @@ theorem dihedralGroupFour_centralCharacterSearch :
       numClasses_dihedralClassData_four]
 
 /-- **Signed least representatives modulo `5` recover every entry of the integral
-central-character table.** This is the rational lifting step of the Dixon computation. -/
-@[simp]
+central-character table.** This is the rational lifting step of the Dixon computation.
+
+This is not a `simp` lemma: `dihedralGroupFourCentralCharacterTable_apply` already rewrites both
+sides to matrix literals, so the simplifier reaches the same conclusion on its own. -/
 theorem dihedralGroupFour_valMinAbs_centralCharacterTable
     (i j : DihedralGroupFourClassIndex) :
-    (((!![1,  1,  2,  2,  2;
-          1,  1,  2, -2, -2;
-          1,  1, -2,  2, -2;
-          1,  1, -2, -2,  2;
-          1, -1,  0,  0,  0] i j : ℤ) : ZMod 5)).valMinAbs =
-      !![1,  1,  2,  2,  2;
-         1,  1,  2, -2, -2;
-         1,  1, -2,  2, -2;
-         1,  1, -2, -2,  2;
-         1, -1,  0,  0,  0] i j := by
+    ((dihedralGroupFourCentralCharacterTable i j : ZMod 5)).valMinAbs =
+      dihedralGroupFourCentralCharacterTable i j := by
+  rw [dihedralGroupFourCentralCharacterTable_apply]
   apply ZMod.valMinAbs_intCast_of_two_mul_natAbs_lt
   fin_cases i <;> fin_cases j <;> decide
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/DihedralFour.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/DihedralFour.lean
@@ -68,7 +68,7 @@ abbrev DihedralGroupFourClassIndex := Fin (dihedralClassData 4).numClasses
 /-- **The integral central-character table of the dihedral group of order eight.** Columns follow
 the numbering of `TauCeti.dihedralClassData 4`: identity, central rotation, one reflection class,
 the rotations of order four, and the other reflection class. -/
-@[expose] def dihedralGroupFourCentralCharacterTable :
+def dihedralGroupFourCentralCharacterTable :
     Matrix DihedralGroupFourClassIndex DihedralGroupFourClassIndex ℤ :=
   !![1,  1,  2,  2,  2;
      1,  1,  2, -2, -2;
@@ -76,10 +76,29 @@ the rotations of order four, and the other reflection class. -/
      1,  1, -2, -2,  2;
      1, -1,  0,  0,  0]
 
+/-- The entries of the integral central-character table. -/
+@[simp]
+theorem dihedralGroupFourCentralCharacterTable_apply (i j : DihedralGroupFourClassIndex) :
+    dihedralGroupFourCentralCharacterTable i j =
+      !![1,  1,  2,  2,  2;
+         1,  1,  2, -2, -2;
+         1,  1, -2,  2, -2;
+         1,  1, -2, -2,  2;
+         1, -1,  0,  0,  0] i j := by
+  rfl
+
 /-- The five displayed central-character rows reduced modulo the certified Dixon prime `5`. -/
-@[expose] def dihedralGroupFourModularCentralRows :
+def dihedralGroupFourModularCentralRows :
     Finset (DihedralGroupFourClassIndex → ZMod 5) :=
   Finset.univ.image fun i j => (dihedralGroupFourCentralCharacterTable i j : ZMod 5)
+
+/-- A modular row is displayed exactly when it is the reduction of a row of the integral table. -/
+@[simp]
+theorem mem_dihedralGroupFourModularCentralRows_iff
+    {a : DihedralGroupFourClassIndex → ZMod 5} :
+    a ∈ dihedralGroupFourModularCentralRows ↔
+      ∃ i, (fun j => (dihedralGroupFourCentralCharacterTable i j : ZMod 5)) = a := by
+  simp [dihedralGroupFourModularCentralRows]
 
 /-- Every displayed integral row is a simultaneous eigenrow of the integral class-multiplication
 matrices.  In particular, the modular verification below is the reduction of an honest
@@ -98,8 +117,8 @@ theorem dihedralGroupFour_isClassEigenrow (i : DihedralGroupFourClassIndex) :
   ((dihedralClassData 4).isModularEigenrow_iff_isClassEigenrow _).mp
     (dihedralGroupFour_isIntegralEigenrow i)
 
-/-- Every displayed reduction is normalized at the identity class and is a simultaneous eigenrow
-of the reduced class-multiplication matrices. -/
+/-- Every displayed reduction is a simultaneous eigenrow of the reduced class-multiplication
+matrices. -/
 theorem dihedralGroupFour_isModularEigenrow (i : DihedralGroupFourClassIndex) :
     (dihedralClassData 4).IsModularEigenrow
       (fun j => (dihedralGroupFourCentralCharacterTable i j : ZMod 5)) := by
@@ -140,7 +159,7 @@ theorem dihedralGroupFour_valMinAbs_centralCharacterTable
 
 /-- The signed integral rows obtained by applying `ZMod.valMinAbs` to the output of the modular
 search. -/
-@[expose] def dihedralGroupFourLiftedCentralRows :
+def dihedralGroupFourLiftedCentralRows :
     Finset (DihedralGroupFourClassIndex → ℤ) :=
   ((dihedralClassData 4).centralCharacterSearch (F := ZMod 5)).image
     fun a j => (a j).valMinAbs
@@ -157,30 +176,46 @@ theorem dihedralGroupFour_liftedCentralRows :
   funext j
   exact dihedralGroupFour_valMinAbs_centralCharacterTable i j
 
+/-- A lifted row occurs exactly when it is a row of the displayed integral table. -/
+@[simp]
+theorem mem_dihedralGroupFourLiftedCentralRows_iff
+    {a : DihedralGroupFourClassIndex → ℤ} :
+    a ∈ dihedralGroupFourLiftedCentralRows ↔
+      ∃ i, dihedralGroupFourCentralCharacterTable i = a := by
+  rw [dihedralGroupFour_liftedCentralRows]
+  simp
+
 /-- The degrees attached to the five central-character rows. -/
-@[expose] def dihedralGroupFourCharacterDegrees : DihedralGroupFourClassIndex → ℕ :=
+def dihedralGroupFourCharacterDegrees : DihedralGroupFourClassIndex → ℕ :=
   ![1, 1, 1, 1, 2]
 
-/-- The class sizes in the numbering used by the rational computation. -/
-@[expose] def dihedralGroupFourClassSizes : DihedralGroupFourClassIndex → ℕ :=
-  ![1, 1, 2, 2, 2]
-
-/-- The displayed class sizes agree with the class data computed from the group. -/
+/-- The degrees attached to the central-character rows, entrywise. -/
 @[simp]
-theorem dihedralGroupFour_card_classFinset (i : DihedralGroupFourClassIndex) :
-    ((dihedralClassData 4).classFinset i).card = dihedralGroupFourClassSizes i := by
-  fin_cases i <;> decide
+theorem dihedralGroupFourCharacterDegrees_apply (i : DihedralGroupFourClassIndex) :
+    dihedralGroupFourCharacterDegrees i = ![1, 1, 1, 1, 2] i := by
+  rfl
 
 /-- **The integral character table produced by the rational Dixon computation for the dihedral
 group of order eight.** The columns use the same class numbering as
 `TauCeti.dihedralGroupFourCentralCharacterTable`. -/
-@[expose] def dihedralGroupFourCharacterTable :
+def dihedralGroupFourCharacterTable :
     Matrix DihedralGroupFourClassIndex DihedralGroupFourClassIndex ℤ :=
   !![1,  1,  1,  1,  1;
      1,  1,  1, -1, -1;
      1,  1, -1,  1, -1;
      1,  1, -1, -1,  1;
      2, -2,  0,  0,  0]
+
+/-- The entries of the ordinary integral character table. -/
+@[simp]
+theorem dihedralGroupFourCharacterTable_apply (i j : DihedralGroupFourClassIndex) :
+    dihedralGroupFourCharacterTable i j =
+      !![1,  1,  1,  1,  1;
+         1,  1,  1, -1, -1;
+         1,  1, -1,  1, -1;
+         1,  1, -1, -1,  1;
+         2, -2,  0,  0,  0] i j := by
+  rfl
 
 /-- **Division-free conversion from central characters to ordinary characters.** For every row
 `i` and numbered conjugacy class `j`,
@@ -211,7 +246,6 @@ theorem dihedralGroupFour_characterTable_orthogonal (i j : DihedralGroupFourClas
     ∑ k, ((dihedralClassData 4).classFinset k).card *
         dihedralGroupFourCharacterTable i k * dihedralGroupFourCharacterTable j k =
       if i = j then Nat.card (DihedralGroup 4) else 0 := by
-  simp_rw [dihedralGroupFour_card_classFinset]
   rw [DihedralGroup.nat_card]
   fin_cases i <;> fin_cases j <;> decide
 


### PR DESCRIPTION
This PR completes the `D₄ = DihedralGroup 4` target in Layer 6's “Rational tables (first executable milestone)”. It computes the exact five modular central-character rows at the certified good prime `5`, lifts them to integers with signed least representatives, and recovers the ordinary character table.

The new `Dixon/Rational` module proves that every displayed row satisfies the reduced structure-constant eigenvalue equations and uses `card_centralCharacterSearch_of_isGoodDixonPrime` to prove that these are all the search results, without evaluating the exponentially sized search. It then proves the `ZMod.valMinAbs` lift entrywise, verifies the integral class-algebra eigenrow equations, performs the division-free degree/class-size conversion, and checks degree positivity and divisibility, the degree-square sum, and weighted row orthogonality.

The exact roadmap target is `RepresentationTheory/CharacterTheory`, Layer 6, “Rational tables (first executable milestone)”, item `D₄ = DihedralGroup 4`.

After this PR, the milestone still needs the `C₂`, `S₃`, `Q₈`, and remaining order-at-most-16 p-group tables, while the general assembled pipeline still needs its roadmap-listed reconstruction bounds.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"dihedral-four-dixon-character-table"}-->

🤖 Prepared with Codex
