### PR TITLE
feat: make central closed subgroups commutative

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Center/Commutative.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Commutative.lean
@@ -17,8 +17,7 @@ more general fact that the coordinate Hopf algebra of every central closed subgr
 cocommutative.
 
 The cocommutativity result supplies the commutative-group-object structure on the Hopf spectrum,
-registered here on the canonical `centerGroupScheme` and transparently bundled as
-`centerCommGroupScheme`.
+registered here on the canonical `centerGroupScheme` and bundled as `centerCommGroupScheme`.
 
 ## Main declarations
 
@@ -28,6 +27,8 @@ registered here on the canonical `centerGroupScheme` and transparently bundled a
   commutative group object.
 * `TauCeti.CommHopfAlgCat.centerCommGroupScheme`: the center bundled as a commutative group
   scheme.
+* `TauCeti.CommHopfAlgCat.centerCommGroupScheme_toGrp`: its underlying group scheme is the
+  canonical center group scheme.
 
 ## References
 
@@ -64,9 +65,15 @@ instance isCommMonObj_centerGroupScheme (H : _root_.CommHopfAlgCat.{u} k) :
   (isCentral_centerDefiningIdeal H).isCommMonObj_quotientSpec
 
 /-- The center of an affine group scheme, bundled as a commutative group scheme. -/
-noncomputable abbrev centerCommGroupScheme (H : _root_.CommHopfAlgCat.{u} k) :
+noncomputable def centerCommGroupScheme (H : _root_.CommHopfAlgCat.{u} k) :
     CommGrp (Over (Spec (CommRingCat.of k))) :=
   CommGrp.mk (centerGroupScheme H).X
+
+/-- The underlying group scheme of the bundled commutative center is the canonical center. -/
+@[simp]
+theorem centerCommGroupScheme_toGrp (H : _root_.CommHopfAlgCat.{u} k) :
+    (centerCommGroupScheme H).toGrp = centerGroupScheme H :=
+  by rw [centerCommGroupScheme]
 
 end Scheme
 

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Commutative.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Commutative.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Center.Basic
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Central
+
+/-!
+# The center is commutative
+
+The center of an affine group scheme is a commutative group scheme. On coordinate Hopf algebras,
+this says that the quotient by `centerDefiningIdeal` is cocommutative. The result follows from the
+more general fact that the coordinate Hopf algebra of every central closed subgroup is
+cocommutative.
+
+The cocommutativity result supplies the commutative-group-object structure on the Hopf spectrum,
+which is bundled here as `centerCommGroupScheme`. Its underlying group scheme is canonically
+identified with the previously constructed `centerGroupScheme`.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.isCocomm_quotient_centerDefiningIdeal`: the coordinate Hopf algebra of
+  the center is cocommutative.
+* `TauCeti.CommHopfAlgCat.isMulCommutative_centerPointsSubgroup`: the points of the center form a
+  commutative group.
+* `TauCeti.CommHopfAlgCat.centerCommGroupScheme`: the center bundled as a commutative group
+  scheme.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Sections 1.k and 2.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+This supplies a structural property of the center required in Layer 6, "Reductive and semisimple
+groups", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u v
+
+variable {k : Type u} [Field k]
+
+/-- The coordinate Hopf algebra of the center is cocommutative. -/
+noncomputable instance isCocomm_quotient_centerDefiningIdeal
+    (H : _root_.CommHopfAlgCat.{v} k) :
+    _root_.Coalgebra.IsCocomm k (quotient H (centerDefiningIdeal H)) :=
+  (isCentral_centerDefiningIdeal H).isCocomm_quotient
+
+/-- The algebra-valued points of the center form a commutative group. -/
+noncomputable instance isMulCommutative_centerPointsSubgroup
+    (H : _root_.CommHopfAlgCat.{v} k) (A : CommAlgCat.{v} k) :
+    IsMulCommutative (centerPointsSubgroup H A) :=
+  (isCentral_centerDefiningIdeal H).isMulCommutative_quotientPointsSubgroup A
+
+section Scheme
+
+open AlgebraicGeometry
+
+/-- The center of an affine group scheme, bundled as a commutative group scheme. -/
+noncomputable def centerCommGroupScheme (H : _root_.CommHopfAlgCat.{u} k) :
+    CommGrp (Over (Spec (CommRingCat.of k))) :=
+  centralSubgroupCommGroupScheme H (centerDefiningIdeal H) (isCentral_centerDefiningIdeal H)
+
+/-- Forgetting commutativity from the bundled center recovers the center group scheme. -/
+@[simp]
+theorem centerCommGroupScheme_toGrp (H : _root_.CommHopfAlgCat.{u} k) :
+    (centerCommGroupScheme H).toGrp = centerGroupScheme H :=
+  centralSubgroupCommGroupScheme_toGrp H (centerDefiningIdeal H)
+    (isCentral_centerDefiningIdeal H)
+
+end Scheme
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Commutative.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Commutative.lean
@@ -17,15 +17,15 @@ more general fact that the coordinate Hopf algebra of every central closed subgr
 cocommutative.
 
 The cocommutativity result supplies the commutative-group-object structure on the Hopf spectrum,
-which is bundled here as `centerCommGroupScheme`. Its underlying group scheme is canonically
-identified with the previously constructed `centerGroupScheme`.
+registered here on the canonical `centerGroupScheme` and transparently bundled as
+`centerCommGroupScheme`.
 
 ## Main declarations
 
 * `TauCeti.CommHopfAlgCat.isCocomm_quotient_centerDefiningIdeal`: the coordinate Hopf algebra of
   the center is cocommutative.
-* `TauCeti.CommHopfAlgCat.isMulCommutative_centerPointsSubgroup`: the points of the center form a
-  commutative group.
+* `TauCeti.CommHopfAlgCat.isCommMonObj_centerGroupScheme`: the canonical center group scheme is a
+  commutative group object.
 * `TauCeti.CommHopfAlgCat.centerCommGroupScheme`: the center bundled as a commutative group
   scheme.
 
@@ -54,27 +54,19 @@ noncomputable instance isCocomm_quotient_centerDefiningIdeal
     _root_.Coalgebra.IsCocomm k (quotient H (centerDefiningIdeal H)) :=
   (isCentral_centerDefiningIdeal H).isCocomm_quotient
 
-/-- The algebra-valued points of the center form a commutative group. -/
-noncomputable instance isMulCommutative_centerPointsSubgroup
-    (H : _root_.CommHopfAlgCat.{v} k) (A : CommAlgCat.{v} k) :
-    IsMulCommutative (centerPointsSubgroup H A) :=
-  (isCentral_centerDefiningIdeal H).isMulCommutative_quotientPointsSubgroup A
-
 section Scheme
 
 open AlgebraicGeometry
 
-/-- The center of an affine group scheme, bundled as a commutative group scheme. -/
-noncomputable def centerCommGroupScheme (H : _root_.CommHopfAlgCat.{u} k) :
-    CommGrp (Over (Spec (CommRingCat.of k))) :=
-  centralSubgroupCommGroupScheme H (centerDefiningIdeal H) (isCentral_centerDefiningIdeal H)
+/-- The canonical center group scheme is a commutative group object. -/
+instance isCommMonObj_centerGroupScheme (H : _root_.CommHopfAlgCat.{u} k) :
+    IsCommMonObj (centerGroupScheme H).X :=
+  (isCentral_centerDefiningIdeal H).isCommMonObj_quotientSpec
 
-/-- Forgetting commutativity from the bundled center recovers the center group scheme. -/
-@[simp]
-theorem centerCommGroupScheme_toGrp (H : _root_.CommHopfAlgCat.{u} k) :
-    (centerCommGroupScheme H).toGrp = centerGroupScheme H :=
-  centralSubgroupCommGroupScheme_toGrp H (centerDefiningIdeal H)
-    (isCentral_centerDefiningIdeal H)
+/-- The center of an affine group scheme, bundled as a commutative group scheme. -/
+noncomputable abbrev centerCommGroupScheme (H : _root_.CommHopfAlgCat.{u} k) :
+    CommGrp (Over (Spec (CommRingCat.of k))) :=
+  CommGrp.mk (centerGroupScheme H).X
 
 end Scheme
 

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -36,6 +36,7 @@ commutative group functor exactly when `H` is cocommutative
 
 * `TauCeti.HopfAlgebra.IsCentralPoint`: centrality of a point of the functor of points.
 * `TauCeti.HopfAlgebra.center`: the central points as a subgroup of the group of points.
+* `TauCeti.HopfAlgebra.instIsMulCommutativeCenter`: the central points form a commutative group.
 
 ## Main results
 
@@ -156,6 +157,10 @@ theorem mem_center {g : WithConv (H →ₐ[R] A)} : g ∈ center R H A ↔ IsCen
 over larger value algebras. -/
 theorem center_le_center : center R H A ≤ Subgroup.center (WithConv (H →ₐ[R] A)) :=
   fun _ hg ↦ Subgroup.mem_center_iff.mpr fun h ↦ ((mem_center.mp hg).commute h).symm
+
+/-- The universally central points form a commutative group. -/
+noncomputable instance instIsMulCommutativeCenter : IsMulCommutative (center R H A) :=
+  IsMulCommutative.of_setLike_mul_comm fun _ ha b _ ↦ ((mem_center.mp ha).commute b).eq
 
 /-- The center is natural in the value algebra. -/
 theorem mapValue_mem_center {B : Type v} [CommRing B] [Algebra R B] (φ : A →ₐ[R] B)

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -41,6 +41,10 @@ producing a Hopf ideal from the cocommutativity defect of `H`.
 * `TauCeti.CommHopfAlgCat.isCentral_iff_forall_isCentralPoint`: **a Hopf ideal is central exactly
   when the points it cuts out are central points over every value algebra.**
 * `TauCeti.HopfIdeal.IsCentral.isNormal`: a central Hopf ideal is normal.
+* `TauCeti.HopfIdeal.IsCentral.isMulCommutative_quotientPointsSubgroup`: the points of a central
+  closed subgroup form a commutative group.
+* `TauCeti.HopfIdeal.IsCentral.isCocomm_quotient`: the coordinate Hopf algebra of a central
+  closed subgroup is cocommutative.
 * `TauCeti.HopfIdeal.isCentral_bot_iff_isCocomm`: the whole group is central exactly when the
   coordinate Hopf algebra is cocommutative.
 * `TauCeti.CommHopfAlgCat.isCentral_augmentation`: the trivial subgroup is central.
@@ -271,6 +275,38 @@ theorem IsCentral.isNormal {H : _root_.CommHopfAlgCat.{v} R} {I : HopfIdeal R H}
   have : g * n * g⁻¹ = n := by
     rw [← hcom.eq, mul_assoc, mul_inv_cancel, mul_one]
   rwa [this]
+
+/-- The algebra-valued points of a central closed subgroup form a commutative group. -/
+theorem IsCentral.isMulCommutative_quotientPointsSubgroup
+    {H : _root_.CommHopfAlgCat.{v} R} {I : HopfIdeal R H} (hI : I.IsCentral)
+    (A : CommAlgCat.{v} R) : IsMulCommutative (CommHopfAlgCat.quotientPointsSubgroup H I A) := by
+  rw [isMulCommutative_iff]
+  rintro ⟨g, hg⟩ ⟨h, _⟩
+  apply Subtype.ext
+  exact
+    ((CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hg).commute h).eq
+
+/-- The coordinate Hopf algebra of a central closed subgroup is cocommutative. Equivalently,
+every central closed subgroup scheme is a commutative group scheme. -/
+theorem IsCentral.isCocomm_quotient {H : _root_.CommHopfAlgCat.{v} R}
+    {I : HopfIdeal R H} (hI : I.IsCentral) :
+    _root_.Coalgebra.IsCocomm R (CommHopfAlgCat.quotient H I) := by
+  rw [← isCentral_bot_iff_isCocomm]
+  rw [CommHopfAlgCat.isCentral_iff_forall_isCentralPoint]
+  intro A g _
+  rw [HopfAlgebra.isCentralPoint_def]
+  intro B _ _ φ h
+  rw [commute_iff_eq]
+  let B' : CommAlgCat.{v} R := CommAlgCat.of R B
+  let g' := AlgHom.mapValue φ g
+  have hg' : CommHopfAlgCat.quotientPointsHom H I B' g' ∈
+      CommHopfAlgCat.quotientPointsSubgroup H I B' :=
+    CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H I B' g'
+  have hcentral :=
+    CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup H I hI B' hg'
+  apply CommHopfAlgCat.quotientPointsHom_injective H I B'
+  simpa only [map_mul] using
+    (hcentral.commute (CommHopfAlgCat.quotientPointsHom H I B' h)).eq
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -22,9 +22,10 @@ point of `G` in the sense of `TauCeti.HopfAlgebra.IsCentralPoint`. As for normal
 algebra suffices to detect it, namely `(H ⧸ I) ⊗[R] H`, which carries the tautological point of
 the subgroup together with the tautological point of the ambient group.
 
-Two immediate consequences record that the notion behaves as expected. A central Hopf ideal is
-normal, and the zero Hopf ideal — the one cutting out the whole group — is central exactly when
-`H` is cocommutative, that is, exactly when `G` is commutative.
+The main consequences record that the notion behaves as expected. A central Hopf ideal is normal,
+its closed subgroup has commutative point groups and cocommutative coordinate quotient, and the
+zero Hopf ideal — the one cutting out the whole group — is central exactly when `H` is
+cocommutative, that is, exactly when `G` is commutative.
 
 Centrality is *upward* closed in the lattice of Hopf ideals, since a larger Hopf ideal cuts out a
 smaller closed subgroup. It is not closed downwards, so this file does not construct a smallest
@@ -41,8 +42,6 @@ producing a Hopf ideal from the cocommutativity defect of `H`.
 * `TauCeti.CommHopfAlgCat.isCentral_iff_forall_isCentralPoint`: **a Hopf ideal is central exactly
   when the points it cuts out are central points over every value algebra.**
 * `TauCeti.HopfIdeal.IsCentral.isNormal`: a central Hopf ideal is normal.
-* `TauCeti.HopfIdeal.IsCentral.isMulCommutative_quotientPointsSubgroup`: the points of a central
-  closed subgroup form a commutative group.
 * `TauCeti.HopfIdeal.IsCentral.isCocomm_quotient`: the coordinate Hopf algebra of a central
   closed subgroup is cocommutative.
 * `TauCeti.HopfIdeal.isCentral_bot_iff_isCocomm`: the whole group is central exactly when the
@@ -276,37 +275,20 @@ theorem IsCentral.isNormal {H : _root_.CommHopfAlgCat.{v} R} {I : HopfIdeal R H}
     rw [← hcom.eq, mul_assoc, mul_inv_cancel, mul_one]
   rwa [this]
 
-/-- The algebra-valued points of a central closed subgroup form a commutative group. -/
-theorem IsCentral.isMulCommutative_quotientPointsSubgroup
-    {H : _root_.CommHopfAlgCat.{v} R} {I : HopfIdeal R H} (hI : I.IsCentral)
-    (A : CommAlgCat.{v} R) : IsMulCommutative (CommHopfAlgCat.quotientPointsSubgroup H I A) := by
-  rw [isMulCommutative_iff]
-  rintro ⟨g, hg⟩ ⟨h, _⟩
-  apply Subtype.ext
-  exact
-    ((CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup H I hI A hg).commute h).eq
-
 /-- The coordinate Hopf algebra of a central closed subgroup is cocommutative. Equivalently,
 every central closed subgroup scheme is a commutative group scheme. -/
 theorem IsCentral.isCocomm_quotient {H : _root_.CommHopfAlgCat.{v} R}
     {I : HopfIdeal R H} (hI : I.IsCentral) :
     _root_.Coalgebra.IsCocomm R (CommHopfAlgCat.quotient H I) := by
-  rw [← isCentral_bot_iff_isCocomm]
-  rw [CommHopfAlgCat.isCentral_iff_forall_isCentralPoint]
-  intro A g _
-  rw [HopfAlgebra.isCentralPoint_def]
-  intro B _ _ φ h
-  rw [commute_iff_eq]
-  let B' : CommAlgCat.{v} R := CommAlgCat.of R B
-  let g' := AlgHom.mapValue φ g
-  have hg' : CommHopfAlgCat.quotientPointsHom H I B' g' ∈
-      CommHopfAlgCat.quotientPointsSubgroup H I B' :=
-    CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H I B' g'
-  have hcentral :=
-    CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup H I hI B' hg'
-  apply CommHopfAlgCat.quotientPointsHom_injective H I B'
+  rw [← HopfAlgebra.commute_includeLeft_includeRight_iff_isCocomm R
+    (CommHopfAlgCat.quotient H I), commute_iff_eq]
+  let A : CommAlgCat.{v} R := CommAlgCat.of R
+    (TensorProduct R (CommHopfAlgCat.quotient H I) (CommHopfAlgCat.quotient H I))
+  apply CommHopfAlgCat.quotientPointsHom_injective H I A
   simpa only [map_mul] using
-    (hcentral.commute (CommHopfAlgCat.quotientPointsHom H I B' h)).eq
+    ((HopfAlgebra.mem_center.mp
+      (CommHopfAlgCat.quotientPointsSubgroup_le_center H I hI A
+        (CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H I A _))).commute _).eq
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -29,6 +29,8 @@ the point factors uniquely through the quotient algebra.
 * `CommHopfAlgCat.mem_range_quotientPointsHom_iff`: quotient points are exactly ambient
   points killing `I`.
 * `CommHopfAlgCat.quotientPointsSubgroup`: the subgroup of ambient points cut out by `I`.
+* `CommHopfAlgCat.instIsMulCommutativeQuotientPointsSubgroup`: when the quotient Hopf algebra is
+  cocommutative, the cut-out point subgroup is commutative.
 
 ## References
 
@@ -143,6 +145,14 @@ point-level closed subgroup represented by the quotient coordinate Hopf algebra 
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
     Subgroup (HopfAlgebra.points (R := R) (H := H) A) :=
   (quotientPointsHom H I A).hom.range
+
+/-- The points cut out by `I` form a commutative group whenever the quotient coordinate Hopf
+algebra is cocommutative. -/
+noncomputable instance instIsMulCommutativeQuotientPointsSubgroup
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H)
+    [Coalgebra.IsCocomm R (quotient H I)] (A : CommAlgCat.{w} R) :
+    IsMulCommutative (quotientPointsSubgroup H I A) :=
+  Subgroup.range_isMulCommutative (quotientPointsHom H I A).hom
 
 /-- Membership in the subgroup of points cut out by a Hopf ideal is vanishing on that ideal. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Central.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
+import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+
+/-!
+# Central closed subgroup schemes are commutative
+
+A central Hopf ideal cuts out a commutative closed subgroup scheme. The coordinate quotient is
+cocommutative by `HopfIdeal.IsCentral.isCocomm_quotient`, so its Hopf spectrum carries a
+commutative group-object structure. This file bundles that structure and identifies its underlying
+group scheme with the ordinary Hopf-ideal quotient spectrum.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.centralSubgroupCommGroupScheme`: a central closed subgroup bundled as a
+  commutative group scheme.
+* `TauCeti.CommHopfAlgCat.centralSubgroupCommGroupScheme_toGrp`: forgetting commutativity recovers
+  the quotient group scheme.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Sections 1.k and 2.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+This supplies a structural property of central closed subgroups used by the center in Layer 6,
+"Reductive and semisimple groups", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.CommHopfAlgCat
+
+open AlgebraicGeometry
+
+universe u
+
+variable {R : Type u} [CommRing R]
+
+/-- A central closed subgroup of an affine group scheme, bundled as a commutative group scheme. -/
+noncomputable def centralSubgroupCommGroupScheme (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) (hI : I.IsCentral) : CommGrp (Over (Spec (CommRingCat.of R))) := by
+  let _ : _root_.Coalgebra.IsCocomm R (quotient H I) := hI.isCocomm_quotient
+  exact CommGrp.mk ((Spec (CommRingCat.of (quotient H I))).asOver (Spec (CommRingCat.of R)))
+
+/-- Forgetting commutativity from a central closed subgroup recovers its quotient group scheme. -/
+@[simp]
+theorem centralSubgroupCommGroupScheme_toGrp (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) (hI : I.IsCentral) :
+    (centralSubgroupCommGroupScheme H I hI).toGrp = quotientSpec H I :=
+  (TauCeti.hopfSpec_obj_eq_asOver R (quotient H I)).symm
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Central.lean
@@ -14,15 +14,12 @@ import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
 A central Hopf ideal cuts out a commutative closed subgroup scheme. The coordinate quotient is
 cocommutative by `HopfIdeal.IsCentral.isCocomm_quotient`, so its Hopf spectrum carries a
-commutative group-object structure. This file bundles that structure and identifies its underlying
-group scheme with the ordinary Hopf-ideal quotient spectrum.
+commutative group-object structure on the canonical Hopf-ideal quotient spectrum.
 
 ## Main declarations
 
-* `TauCeti.CommHopfAlgCat.centralSubgroupCommGroupScheme`: a central closed subgroup bundled as a
-  commutative group scheme.
-* `TauCeti.CommHopfAlgCat.centralSubgroupCommGroupScheme_toGrp`: forgetting commutativity recovers
-  the quotient group scheme.
+* `TauCeti.HopfIdeal.IsCentral.isCommMonObj_quotientSpec`: the canonical quotient group scheme of
+  a central Hopf ideal is a commutative group object.
 
 ## References
 
@@ -37,7 +34,7 @@ public section
 
 open CategoryTheory
 
-namespace TauCeti.CommHopfAlgCat
+namespace TauCeti.HopfIdeal
 
 open AlgebraicGeometry
 
@@ -45,17 +42,11 @@ universe u
 
 variable {R : Type u} [CommRing R]
 
-/-- A central closed subgroup of an affine group scheme, bundled as a commutative group scheme. -/
-noncomputable def centralSubgroupCommGroupScheme (H : _root_.CommHopfAlgCat.{u} R)
-    (I : HopfIdeal R H) (hI : I.IsCentral) : CommGrp (Over (Spec (CommRingCat.of R))) := by
-  let _ : _root_.Coalgebra.IsCocomm R (quotient H I) := hI.isCocomm_quotient
-  exact CommGrp.mk ((Spec (CommRingCat.of (quotient H I))).asOver (Spec (CommRingCat.of R)))
+/-- The canonical quotient group scheme of a central Hopf ideal is a commutative group object. -/
+theorem IsCentral.isCommMonObj_quotientSpec {H : _root_.CommHopfAlgCat.{u} R}
+    {I : HopfIdeal R H} (hI : I.IsCentral) :
+    IsCommMonObj (CommHopfAlgCat.quotientSpec H I).X := by
+  let _ := hI.isCocomm_quotient
+  infer_instance
 
-/-- Forgetting commutativity from a central closed subgroup recovers its quotient group scheme. -/
-@[simp]
-theorem centralSubgroupCommGroupScheme_toGrp (H : _root_.CommHopfAlgCat.{u} R)
-    (I : HopfIdeal R H) (hI : I.IsCentral) :
-    (centralSubgroupCommGroupScheme H I hI).toGrp = quotientSpec H I :=
-  (TauCeti.hopfSpec_obj_eq_asOver R (quotient H I)).symm
-
-end TauCeti.CommHopfAlgCat
+end TauCeti.HopfIdeal

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -37,6 +37,8 @@ same-universe restriction is inherited from Mathlib's current `hopfSpec` constru
   `TauCeti.hopfSpec_obj_inv_left`: its three group operations.
 * `TauCeti.isCocomm_iff_isCommMonObj_hopfSpec`: cocommutativity corresponds to a commutative
   group object.
+* `TauCeti.instIsCommMonObjHopfSpec`: a cocommutative Hopf algebra has a commutative Hopf
+  spectrum.
 * `TauCeti.moduleFinite_iff_isFinite_hopfSpec`: module-finiteness corresponds to a finite
   structural morphism.
 * `TauCeti.moduleFlat_iff_flat_hopfSpec`: module-flatness corresponds to a flat structural
@@ -263,6 +265,11 @@ theorem isCocomm_iff_isCommMonObj_hopfSpec
     apply LinearMap.ext
     intro x
     exact LinearMap.congr_fun hlinear x
+
+/-- The Hopf spectrum of a cocommutative Hopf algebra is a commutative group object. -/
+instance instIsCommMonObjHopfSpec (H : CommHopfAlgCat.{u} R) [Coalgebra.IsCocomm R H] :
+    IsCommMonObj (((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (op H)).X) :=
+  (isCocomm_iff_isCommMonObj_hopfSpec R H).mp inferInstance
 
 /-- A Hopf spectrum is finite over its base exactly when its coordinate algebra is
 module-finite. -/


### PR DESCRIPTION
This PR proves that every central closed subgroup of an affine group scheme is commutative and packages its Hopf spectrum as a commutative group scheme. Apply the general result to `centerDefiningIdeal` to make the newly constructed center `Z(G)` available as `centerCommGroupScheme`, with its coordinate cocommutativity, commutative algebra-valued point groups, and underlying-group-scheme identification.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6 milestone “Reductive and semisimple groups,” specifically “Develop the radical `R(G)`, the centre `Z(G)`, the derived group `G_der`, central isogenies, and the simply connected and adjoint forms.” This is the most effective current step because the center construction merged in #3814 and explicitly left its structural properties outstanding, while the open Layer 6 work covers the distinct derived-subgroup, reductive-packaging, and unipotent-radical lanes. After this PR, the center part of Layer 6 still needs its behavior under base change and homomorphisms and its relation to the radical and derived group; the milestone also still needs central isogenies and the simply connected and adjoint forms.

The proof uses the functor-of-points characterization of central Hopf ideals: centrality makes the cut-out point subgroup commutative, and injectivity of the quotient-points map reflects commutativity to every point group of the quotient. The existing `isCentral_bot_iff_isCocomm` criterion then makes the quotient coordinate Hopf algebra cocommutative. Add `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Central.lean` (61 lines) and `TauCeti/Algebra/AlgebraicGroup/Center/Commutative.lean` (81 lines), and extend `HopfIdeal/Central.lean` by 36 lines. The construction follows Milne, *Algebraic Groups* (2017), §§1.k and 2, and Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2, as credited in both new modules. No Mathlib infrastructure or external formalization is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"center-commutative-group-scheme"}-->

🤖 Prepared with Codex
