### PR TITLE
docs(EDS): correct the call-site count and fold the duplicated mechanism

### DIFF
--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/Complement.lean
@@ -65,8 +65,9 @@ reindexing `normEDS_mul_complEDS_div` (`:1350`) is ported here too, under its so
 That reverses an earlier decision recorded in this file, and the reason is worth keeping: the
 reindexing was left out because what consumers took from it was the divisibility, stated directly
 here as `normEDS_dvd_normEDS_mul` and `isDvdSequence_normEDS`, so it had no call site. It has
-eight now: the reduced-invariant cancellation in `ReducedInvariant.lean` reindexes one or two
-complements through it in each of its six residue branches. The source file's
+nine now: the reduced-invariant cancellation in `ReducedInvariant.lean` reindexes one or two
+complements through it in each of its six residue branches — once each for the residues `0`, `1`
+and `5`, twice each for `2`, `3` and `4`. The source file's
 header reads `Authors: David Kurniadi Angdinata`; following this repository's convention for
 adapted material the upstream authorship is credited here rather than in the copyright header.
 
@@ -171,12 +172,11 @@ theorem isDvdSequence_normEDS (b c d : R) : IsDvdSequence (normEDS b c d) := by
 
 /-- **The complement at a divisor.** When `k ∣ n`, the `k`-complement at index `n / k` multiplies
 `normEDS b c d k` back up to `normEDS b c d n`. This is the divisor-indexed form of
-`normEDS_mul_complEDS` (`Complement.lean`), which is stated at `n * k`; `Int.ediv_mul_cancel` is
+`normEDS_mul_complEDS`, which is stated at `n * k`; `Int.ediv_mul_cancel` is
 what converts between the two. Unconditional, like the identity it rests on.
 
-Its consumers are the six residue branches of
-`IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`, each of which reindexes one
-complement this way. -/
+Its one consumer is `IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul`; the module
+docstring records how often each of its residue branches goes through this. -/
 theorem normEDS_mul_complEDS_div (k n : ℤ) (hn : k ∣ n) :
     normEDS b c d k * complEDS b c d k (n / k) = normEDS b c d n := by
   rw [normEDS_mul_complEDS, Int.ediv_mul_cancel hn]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ReducedInvariant.lean
@@ -62,12 +62,13 @@ commutative ring.
 
 The denominator side reads `invarDenom (normEDS b c d) 1 m = W (m + 1) * W m * W (m - 1)`, and
 which of the three factors gives up `b = W 2` and `c = W 3` depends on `m` modulo `6` — hence the
-six-way split. Each branch reindexes a complement by `normEDS_mul_complEDS` (`Complement.lean`),
-`W k * complEDS b c d k n = W (n * k)`, taking `n = m / k` and turning `(m / k) * k` back into `m`
-with `Int.ediv_mul_cancel` on the divisibility that `m % 6 = r` supplies. The residues `0`, `1`
-and `5` go through the `6`-complement and rewrite `W 6` as `(W 5 - d ^ 2) * b * c`
-(`WeierstrassCurve.normEDS_six`, `Six.lean`); the residues `2`, `3` and `4` split the work between
-a `2`-complement and a `3`-complement.
+six-way split. Each branch reindexes one or two complements by `normEDS_mul_complEDS_div`
+(`Complement.lean`), `W k * complEDS b c d k (n / k) = W n`, which this development adds beside the
+identity it is derived from — `normEDS_mul_complEDS`, stated at `W (n * k)` — and which absorbs the
+`Int.ediv_mul_cancel` step on the divisibility that `m % 6 = r` supplies. The residues `0`, `1` and
+`5` go through the `6`-complement once each and rewrite `W 6` as `(W 5 - d ^ 2) * b * c`
+(`WeierstrassCurve.normEDS_six`, `Six.lean`); the residues `2`, `3` and `4` each split the work
+between a `2`-complement and a `3`-complement.
 
 Note that `b, c ≠ 0` over a domain would **not** by itself make `normEDS b c d 6` a
 nonzerodivisor — that needs `normEDS b c d 5 - d ^ 2 ≠ 0` as well — which is why the
@@ -76,13 +77,6 @@ statement hypothesis-free.
 
 The numerator needs none of this because its cancellation is an identity between polynomial
 expressions, proved by `ring` from the complement recurrences rather than through a division.
-
-The divisor form is `normEDS_mul_complEDS_div`, which this development adds to `Complement.lean`
-beside the identity it reindexes. Each residue reduces `W k * complEDS b c d k (n / k)` to
-`W n` by `normEDS_mul_complEDS` — which is stated at `W (n * k)` — followed
-by `Int.ediv_mul_cancel` on the divisibility that `m % 6 = r` supplies. The factor
-`W 5 - d ^ 2` carried by the residues `0`, `1` and `5` is `W 6` with `b * c` removed, which is
-`WeierstrassCurve.normEDS_six` (`Six.lean`).
 
 The other half of the reduced-invariant theory — `redInvar_normEDS ← invar₂_normEDS ←
 invar_normEDS ← net_normEDS`, written in the source's names — is complete: `net_normEDS` is


### PR DESCRIPTION
Three prose corrections to the residue-split layer, so the documentation states what the proof
actually does.

- `Complement.lean` — the call-site inventory for `normEDS_mul_complEDS_div` said the consumer has
  **eight** call sites. It has **nine**: the cancellation
  `IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul` rewrites through it once each in
  the residue-`0`, -`1` and -`5` branches and twice each in -`2`, -`3` and -`4`. The count now
  carries that split, so a reader can check it against the proof instead of trusting it.
- `Complement.lean` — `normEDS_mul_complEDS_div`'s own docstring named the six *branch lemmas* as
  its consumers, "each of which reindexes one complement this way". Neither half was true: the
  branch lemmas never mention it, and three of the six branches reindex two complements. It is now
  a pointer to the single real consumer, with the count kept in one place. A self-referential
  `(Complement.lean)` pointer inside `Complement.lean` goes too.
- `ReducedInvariant.lean` — the reindexing mechanism was stated twice, and the surviving copy said
  each branch "reindexes a complement by `normEDS_mul_complEDS`". The proof calls only the divisor
  form: ten occurrences of `normEDS_mul_complEDS_div` and none of the bare identity. Folded into one
  paragraph that names the divisor form as what the branches rewrite by, with
  `normEDS_mul_complEDS` named as the identity it is derived from, and `Int.ediv_mul_cancel`
  described as absorbed by the divisor form rather than performed alongside it.

## What happened to the rename this PR opened with

This PR opened as the rename `reducedInvarDenom_of_emod_eq_*` → `reducedInvarDenom_of_emod_six_eq_*`
plus a first pass at the prose. **The rename is already on `main`**: #3861 was rebased onto this
branch before it merged, so it carried the rename in — `reducedInvarDenom_of_emod_six_eq_` occurs 17
times in `main` and the old spelling occurs nowhere. What remained outstanding was the round-2 prose
review, which is what the diff is now.

The branch was therefore **rebuilt on `main` as a single commit rather than rebased**, and that was
necessary rather than tidier. Its old head was based on the pre-#3861 tree, so replaying it would
have deleted #3861's contribution — `reducedInvarNum_eq_reducedInvarDenom_mul` and its section, the
`Invariant.NormEDS` import, the `map_reducedInvarNum` `simpNF` fix, and its provenance paragraph.
The rebase conflicts were git declining to do that quietly. Rebuilt on `main`, the diff can only
add.

Verified before pushing: #3861's identity is still present (10 references), and no changed line
matches `theorem`/`def`/`import`/`@[`/a tactic — the diff is prose only, so no declaration changes
in this PR.

## Gates

`lake build` green on both modules (1497 jobs) against `main`'s current Mathlib pin
`4fae4090fac7`; `lint-style` clean; no line over 100 codepoints. No new declarations, no `sorry`, no
`set_option`, no alias or deprecation.

## Review status

The round-2 board (6 rubrics, `request_changes`, at the old head `de5c94850`) is answered by exactly
these three changes — they were its two root causes: the wrong count, cited by all six rubrics, and
the duplicated inventories, cited by `reuse`, `api-design`, `correctness` and `documentation`. Both
were verified against the source rather than taken on report: I counted the consumer proof, and I
checked the source revision against `TauCetiRoadmap` at `origin/main`. Replies are in the
`documentation`, `attribution`, `reuse` and `api-design` threads.

The board is stale against this head and no fresh one accompanies this push: both codex credentials
on this machine are over quota (`~/.codex` resets ~03:30Z, `~/.codex2` not until 2026-09-14), and
the `Review` workflow is `disabled_manually`, so nothing re-reviews automatically.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"eds-factor-compl"}-->

Provenance: no ported material. The `normEDS_mul_complEDS_div` whose inventory this corrects was
ported by an earlier merged PR from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
`dev/modular-curves @ 9fec8eba7652`, `:1350`), which is what both `Complement.lean` and
`ReducedInvariant.lean` record and what `TauCetiRoadmap/EllipticCurves/README.md` pins for this
material.
