### PR TITLE
feat(Normed): the exterior of a ball is connected; the unbounded component is unique

### DIFF
--- a/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
@@ -23,11 +23,8 @@ components cannot both be outside `TauCeti.filledHull K`.
   real normed space of dimension at least two.
 * `TauCeti.connectedComponentIn_compl_eq_of_not_isBounded` — the unbounded connected component of
   the complement of a bounded set is unique.
-* `TauCeti.isClosed_filledHull` — the filled hull of a closed set is closed.
-* `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points of the
-  complement of a bounded set in different components, at least one lies in the filled hull.
-
-This is a prerequisite of the planar-separation step of the `ConformalMapping` roadmap (L5).
+* `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points in
+  different components, at least one lies in the filled hull.
 
 ## References
 
@@ -106,31 +103,18 @@ theorem connectedComponentIn_compl_eq_of_not_isBounded (h : 1 < Module.rank ℝ 
     (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
   rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
 
-omit [NormedSpace ℝ E] in
-/-- **The filled hull of a closed set is closed.** Its complement is the union of the unbounded
-connected components of `Kᶜ`, each of which is open. -/
-theorem isClosed_filledHull [LocallyConnectedSpace E] (hK : IsClosed K) :
-    IsClosed (filledHull K) := by
-  rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
-  intro x hx
-  rw [mem_compl_iff, mem_filledHull_iff] at hx
-  refine ⟨connectedComponentIn Kᶜ x, fun y hy => ?_, hK.isOpen_compl.connectedComponentIn, ?_⟩
-  · rw [mem_compl_iff, mem_filledHull_iff, ← connectedComponentIn_eq hy]
-    exact hx
-  · refine mem_connectedComponentIn fun hxK => hx ?_
-    rw [connectedComponentIn_eq_empty (notMem_compl_iff.mpr hxK)]
-    exact isBounded_empty
-
-/-- **Two points of the complement of a bounded set in different components are not both outside
+/-- **Two points in different components of the complement of a bounded set cannot both lie outside
 the filled hull.** -/
 theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
-    (hK : IsBounded K) (hy : y ∉ K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
+    (hK : IsBounded K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
     x ∈ filledHull K ∨ y ∈ filledHull K := by
-  by_contra hcon
-  push Not at hcon
-  rw [mem_filledHull_iff] at hcon
-  rw [mem_filledHull_iff] at hcon
-  exact hxy ((connectedComponentIn_compl_eq_of_not_isBounded h hK hcon.1 hcon.2).symm ▸
-    mem_connectedComponentIn (mem_compl hy))
+  by_cases hy : y ∈ K
+  · exact Or.inr (subset_filledHull hy)
+  · by_contra hcon
+    push Not at hcon
+    rw [mem_filledHull_iff] at hcon
+    rw [mem_filledHull_iff] at hcon
+    exact hxy ((connectedComponentIn_compl_eq_of_not_isBounded h hK hcon.1 hcon.2).symm ▸
+      mem_connectedComponentIn (mem_compl hy))
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Connected
+public import TauCeti.Topology.FilledHull
+
+/-!
+# The exterior of a ball is connected, and the unbounded component is unique
+
+In a real normed space of dimension at least two the complement of a closed ball is preconnected:
+it is the union, over the radii `M` exceeding the ball's, of the spheres of radius `M`, strung
+together along a single ray from the centre. Consequently the complement of a *bounded* set has at
+most one unbounded connected component — any two unbounded components reach the exterior of a ball
+containing the set, and that exterior lies in a single component — so two points of the complement
+that lie in different components cannot both be outside the filled hull
+`TauCeti.filledHull K` (`TauCeti/Topology/FilledHull.lean`).
+
+## Main results
+
+* `TauCeti.isPreconnected_compl_closedBall` — the exterior of a closed ball is preconnected in a
+  real normed space of dimension at least two.
+* `TauCeti.connectedComponentIn_compl_eq_of_not_isBounded` — the unbounded connected component of
+  the complement of a bounded set is unique.
+* `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points of the
+  complement of a bounded set in different components, at least one lies in the filled hull.
+
+## Roadmap role
+
+This is a prerequisite of the planar-separation step of layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md`: once the two sides of an image crosscut are known to
+lie in different components of the complement of the small Jordan curve through the crosscut, this
+file says one of them is inside that curve, in the vocabulary of `TauCeti.filledHull`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology Metric Set
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {K : Set E} {x y : E}
+
+/-- **The exterior of a closed ball is preconnected** in a real normed space of dimension at least
+two. The exterior is the union of the spheres of larger radius, each of which meets the ray
+`t ↦ x + t • u` (`‖u‖ = 1`) issuing from the centre, so all of them are strung together along that
+ray. -/
+theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r : ℝ) :
+    IsPreconnected (closedBall x r)ᶜ := by
+  rcases lt_or_ge r 0 with hr | hr
+  · rw [closedBall_eq_empty.mpr hr, compl_empty]
+    exact isPreconnected_univ
+  have : Nontrivial E := rank_pos_iff_nontrivial.mp (zero_lt_one.trans h)
+  obtain ⟨u, hu⟩ := exists_norm_eq E zero_le_one
+  -- the ray from the centre, beyond the ball
+  set L : Set E := (fun t : ℝ => x + t • u) '' Ioi r with hL
+  have hLc : IsPreconnected L :=
+    isPreconnected_Ioi.image _ (by fun_prop : Continuous fun t : ℝ => x + t • u).continuousOn
+  have hLmem : ∀ t, r < t → x + t • u ∈ L := fun t ht => ⟨t, ht, rfl⟩
+  have hnorm : ∀ t : ℝ, 0 ≤ t → ‖x + t • u - x‖ = t := by
+    intro t ht
+    rw [add_sub_cancel_left, norm_smul, hu, mul_one, Real.norm_eq_abs, abs_of_nonneg ht]
+  have hLsub : L ⊆ (closedBall x r)ᶜ := by
+    rintro _ ⟨t, ht, rfl⟩
+    rw [mem_compl_iff, mem_closedBall, dist_eq_norm, hnorm t (hr.trans ht.le), not_le]
+    exact ht
+  -- the exterior is the union of the outer spheres, each strung to the ray
+  have key : (closedBall x r)ᶜ = ⋃ M : Ioi r, (sphere x M ∪ L) := by
+    ext w
+    constructor
+    · intro hw
+      have hwM : r < ‖w - x‖ := by
+        rwa [mem_compl_iff, mem_closedBall, dist_eq_norm, not_le] at hw
+      exact mem_iUnion.mpr ⟨⟨‖w - x‖, hwM⟩, Or.inl (by rw [mem_sphere, dist_eq_norm])⟩
+    · intro hw
+      obtain ⟨⟨M, hM⟩, hwM⟩ := mem_iUnion.mp hw
+      rcases hwM with hwM | hwM
+      · rw [mem_sphere, dist_eq_norm] at hwM
+        rw [mem_compl_iff, mem_closedBall, dist_eq_norm, hwM, not_le]
+        exact hM
+      · exact hLsub hwM
+  rw [key]
+  refine isPreconnected_iUnion ⟨x + (r + 1) • u, ?_⟩ fun ⟨M, hM⟩ => ?_
+  · simp only [mem_iInter]
+    exact fun _ => Or.inr (hLmem _ (by linarith))
+  · refine IsPreconnected.union (x + M • u) ?_ (hLmem M hM) (isPreconnected_sphere h x M) hLc
+    rw [mem_sphere, dist_eq_norm, hnorm M (hr.trans hM.le)]
+
+/-- **The unbounded component of the complement of a bounded set is unique.** Two unbounded
+components both reach outside a closed ball containing the set, and the exterior of that ball is
+preconnected and disjoint from the set, so it lies in a single component. -/
+theorem connectedComponentIn_compl_eq_of_not_isBounded (h : 1 < Module.rank ℝ E)
+    (hK : IsBounded K) (hx : ¬ IsBounded (connectedComponentIn Kᶜ x))
+    (hy : ¬ IsBounded (connectedComponentIn Kᶜ y)) :
+    connectedComponentIn Kᶜ x = connectedComponentIn Kᶜ y := by
+  obtain ⟨R, hR⟩ := hK.subset_closedBall (0 : E)
+  have hext : (closedBall (0 : E) R)ᶜ ⊆ Kᶜ := compl_subset_compl.mpr hR
+  obtain ⟨x', hx'c, hx'R⟩ : ∃ x' ∈ connectedComponentIn Kᶜ x, x' ∈ (closedBall (0 : E) R)ᶜ := by
+    by_contra hcon
+    push Not at hcon
+    exact hx ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun z hz =>
+      notMem_compl_iff.mp (hcon z hz))
+  obtain ⟨y', hy'c, hy'R⟩ : ∃ y' ∈ connectedComponentIn Kᶜ y, y' ∈ (closedBall (0 : E) R)ᶜ := by
+    by_contra hcon
+    push Not at hcon
+    exact hy ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun z hz =>
+      notMem_compl_iff.mp (hcon z hz))
+  have h1 : y' ∈ connectedComponentIn Kᶜ x' :=
+    (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
+  rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
+
+/-- **Two points of the complement of a bounded set in different components are not both outside
+the filled hull.** If neither lay in `TauCeti.filledHull K`, both components would be unbounded,
+hence equal by `TauCeti.connectedComponentIn_compl_eq_of_not_isBounded`. -/
+theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
+    (hK : IsBounded K) (hy : y ∉ K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
+    x ∈ filledHull K ∨ y ∈ filledHull K := by
+  by_contra hcon
+  push Not at hcon
+  rw [mem_filledHull_iff] at hcon
+  rw [mem_filledHull_iff] at hcon
+  exact hxy ((connectedComponentIn_compl_eq_of_not_isBounded h hK hcon.1 hcon.2).symm ▸
+    mem_connectedComponentIn (mem_compl hy))
+
+end TauCeti

--- a/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
@@ -14,10 +14,8 @@ public import TauCeti.Topology.FilledHull
 In a real normed space of dimension at least two the complement of a closed ball is preconnected:
 it is the union, over the radii `M` exceeding the ball's, of the spheres of radius `M`, strung
 together along a single ray from the centre. Consequently the complement of a *bounded* set has at
-most one unbounded connected component — any two unbounded components reach the exterior of a ball
-containing the set, and that exterior lies in a single component — so two points of the complement
-that lie in different components cannot both be outside the filled hull
-`TauCeti.filledHull K` (`TauCeti/Topology/FilledHull.lean`).
+most one unbounded connected component, and two points of the complement that lie in different
+components cannot both be outside `TauCeti.filledHull K`.
 
 ## Main results
 
@@ -25,15 +23,15 @@ that lie in different components cannot both be outside the filled hull
   real normed space of dimension at least two.
 * `TauCeti.connectedComponentIn_compl_eq_of_not_isBounded` — the unbounded connected component of
   the complement of a bounded set is unique.
+* `TauCeti.isClosed_filledHull` — the filled hull of a closed set is closed.
 * `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points of the
   complement of a bounded set in different components, at least one lies in the filled hull.
 
-## Roadmap role
+This is a prerequisite of the planar-separation step of the `ConformalMapping` roadmap (L5).
 
-This is a prerequisite of the planar-separation step of layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md`: once the two sides of an image crosscut are known to
-lie in different components of the complement of the small Jordan curve through the crosscut, this
-file says one of them is inside that curve, in the vocabulary of `TauCeti.filledHull`.
+## References
+
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Springer, 1992.
 -/
 
 public section
@@ -45,9 +43,7 @@ open Bornology Metric Set
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {K : Set E} {x y : E}
 
 /-- **The exterior of a closed ball is preconnected** in a real normed space of dimension at least
-two. The exterior is the union of the spheres of larger radius, each of which meets the ray
-`t ↦ x + t • u` (`‖u‖ = 1`) issuing from the centre, so all of them are strung together along that
-ray. -/
+two. -/
 theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r : ℝ) :
     IsPreconnected (closedBall x r)ᶜ := by
   rcases lt_or_ge r 0 with hr | hr
@@ -89,9 +85,7 @@ theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r :
   · refine IsPreconnected.union (x + M • u) ?_ (hLmem M hM) (isPreconnected_sphere h x M) hLc
     rw [mem_sphere, dist_eq_norm, hnorm M (hr.trans hM.le)]
 
-/-- **The unbounded component of the complement of a bounded set is unique.** Two unbounded
-components both reach outside a closed ball containing the set, and the exterior of that ball is
-preconnected and disjoint from the set, so it lies in a single component. -/
+/-- **The unbounded component of the complement of a bounded set is unique.** -/
 theorem connectedComponentIn_compl_eq_of_not_isBounded (h : 1 < Module.rank ℝ E)
     (hK : IsBounded K) (hx : ¬ IsBounded (connectedComponentIn Kᶜ x))
     (hy : ¬ IsBounded (connectedComponentIn Kᶜ y)) :
@@ -112,9 +106,23 @@ theorem connectedComponentIn_compl_eq_of_not_isBounded (h : 1 < Module.rank ℝ 
     (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
   rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
 
+omit [NormedSpace ℝ E] in
+/-- **The filled hull of a closed set is closed.** Its complement is the union of the unbounded
+connected components of `Kᶜ`, each of which is open. -/
+theorem isClosed_filledHull [LocallyConnectedSpace E] (hK : IsClosed K) :
+    IsClosed (filledHull K) := by
+  rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
+  intro x hx
+  rw [mem_compl_iff, mem_filledHull_iff] at hx
+  refine ⟨connectedComponentIn Kᶜ x, fun y hy => ?_, hK.isOpen_compl.connectedComponentIn, ?_⟩
+  · rw [mem_compl_iff, mem_filledHull_iff, ← connectedComponentIn_eq hy]
+    exact hx
+  · refine mem_connectedComponentIn fun hxK => hx ?_
+    rw [connectedComponentIn_eq_empty (notMem_compl_iff.mpr hxK)]
+    exact isBounded_empty
+
 /-- **Two points of the complement of a bounded set in different components are not both outside
-the filled hull.** If neither lay in `TauCeti.filledHull K`, both components would be unbounded,
-hence equal by `TauCeti.connectedComponentIn_compl_eq_of_not_isBounded`. -/
+the filled hull.** -/
 theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
     (hK : IsBounded K) (hy : y ∉ K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
     x ∈ filledHull K ∨ y ∈ filledHull K := by

--- a/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
@@ -21,14 +21,12 @@ components cannot both be outside `TauCeti.filledHull K`.
 
 * `TauCeti.isPreconnected_compl_closedBall` — the exterior of a closed ball is preconnected in a
   real normed space of dimension at least two.
-* `TauCeti.connectedComponentIn_compl_eq_of_not_isBounded` — the unbounded connected component of
-  the complement of a bounded set is unique.
+* `TauCeti.connectedComponentIn_compl_eq_of_unbounded_component` — the unbounded connected
+  component of the complement of a bounded set is unique (dimension at least two).
 * `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points in
-  different components, at least one lies in the filled hull.
+  different components, at least one lies in the filled hull (dimension at least two).
 
-## References
-
-* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Springer, 1992.
+This is a prerequisite of the planar-separation step of the `ConformalMapping` roadmap (L5).
 -/
 
 public section
@@ -48,8 +46,7 @@ theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r :
     exact isPreconnected_univ
   have : Nontrivial E := rank_pos_iff_nontrivial.mp (zero_lt_one.trans h)
   obtain ⟨u, hu⟩ := exists_norm_eq E zero_le_one
-  -- the ray from the centre, beyond the ball
-  set L : Set E := (fun t : ℝ => x + t • u) '' Ioi r with hL
+  set L : Set E := (fun t : ℝ => x + t • u) '' Ioi r
   have hLc : IsPreconnected L :=
     isPreconnected_Ioi.image _ (by fun_prop : Continuous fun t : ℝ => x + t • u).continuousOn
   have hLmem : ∀ t, r < t → x + t • u ∈ L := fun t ht => ⟨t, ht, rfl⟩
@@ -60,7 +57,6 @@ theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r :
     rintro _ ⟨t, ht, rfl⟩
     rw [mem_compl_iff, mem_closedBall, dist_eq_norm, hnorm t (hr.trans ht.le), not_le]
     exact ht
-  -- the exterior is the union of the outer spheres, each strung to the ray
   have key : (closedBall x r)ᶜ = ⋃ M : Ioi r, (sphere x M ∪ L) := by
     ext w
     constructor
@@ -82,29 +78,28 @@ theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r :
   · refine IsPreconnected.union (x + M • u) ?_ (hLmem M hM) (isPreconnected_sphere h x M) hLc
     rw [mem_sphere, dist_eq_norm, hnorm M (hr.trans hM.le)]
 
-/-- **The unbounded component of the complement of a bounded set is unique.** -/
-theorem connectedComponentIn_compl_eq_of_not_isBounded (h : 1 < Module.rank ℝ E)
+/-- **The unbounded component of the complement of a bounded set is unique** in a real normed space
+of dimension at least two. -/
+theorem connectedComponentIn_compl_eq_of_unbounded_component (h : 1 < Module.rank ℝ E)
     (hK : IsBounded K) (hx : ¬ IsBounded (connectedComponentIn Kᶜ x))
     (hy : ¬ IsBounded (connectedComponentIn Kᶜ y)) :
     connectedComponentIn Kᶜ x = connectedComponentIn Kᶜ y := by
   obtain ⟨R, hR⟩ := hK.subset_closedBall (0 : E)
   have hext : (closedBall (0 : E) R)ᶜ ⊆ Kᶜ := compl_subset_compl.mpr hR
-  obtain ⟨x', hx'c, hx'R⟩ : ∃ x' ∈ connectedComponentIn Kᶜ x, x' ∈ (closedBall (0 : E) R)ᶜ := by
+  have hesc : ∀ z : E, ¬ IsBounded (connectedComponentIn Kᶜ z) →
+      ∃ z' ∈ connectedComponentIn Kᶜ z, z' ∈ (closedBall (0 : E) R)ᶜ := fun z hz => by
     by_contra hcon
     push Not at hcon
-    exact hx ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun z hz =>
-      notMem_compl_iff.mp (hcon z hz))
-  obtain ⟨y', hy'c, hy'R⟩ : ∃ y' ∈ connectedComponentIn Kᶜ y, y' ∈ (closedBall (0 : E) R)ᶜ := by
-    by_contra hcon
-    push Not at hcon
-    exact hy ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun z hz =>
-      notMem_compl_iff.mp (hcon z hz))
+    exact hz ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun w hw =>
+      notMem_compl_iff.mp (hcon w hw))
+  obtain ⟨x', hx'c, hx'R⟩ := hesc x hx
+  obtain ⟨y', hy'c, hy'R⟩ := hesc y hy
   have h1 : y' ∈ connectedComponentIn Kᶜ x' :=
     (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
   rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
 
 /-- **Two points in different components of the complement of a bounded set cannot both lie outside
-the filled hull.** -/
+the filled hull** in a real normed space of dimension at least two. -/
 theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
     (hK : IsBounded K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
     x ∈ filledHull K ∨ y ∈ filledHull K := by
@@ -112,9 +107,8 @@ theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 <
   · exact Or.inr (subset_filledHull hy)
   · by_contra hcon
     push Not at hcon
-    rw [mem_filledHull_iff] at hcon
-    rw [mem_filledHull_iff] at hcon
-    exact hxy ((connectedComponentIn_compl_eq_of_not_isBounded h hK hcon.1 hcon.2).symm ▸
+    simp only [mem_filledHull_iff] at hcon
+    exact hxy ((connectedComponentIn_compl_eq_of_unbounded_component h hK hcon.1 hcon.2).symm ▸
       mem_connectedComponentIn (mem_compl hy))
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
@@ -6,21 +6,25 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Normed.Module.Connected
+public import TauCeti.Topology.FilledHull
 
 /-!
-# The exterior of a closed ball is preconnected
+# The exterior of a ball is connected, and the unbounded component is unique
 
 In a real normed space of dimension at least two the complement of a closed ball is preconnected:
 it is the union, over the radii `M` exceeding the ball's, of the spheres of radius `M`, strung
-together along a single ray from the centre.
-
-The consequences for bounded sets — uniqueness of the unbounded component and the filled-hull
-alternative — are in `TauCeti/Analysis/Normed/Module/FilledHull.lean`.
+together along a single ray from the centre. Consequently the complement of a *bounded* set has at
+most one unbounded connected component, and two points of the complement that lie in different
+components cannot both be outside `TauCeti.filledHull K`.
 
 ## Main results
 
 * `TauCeti.isPreconnected_compl_closedBall` — the exterior of a closed ball is preconnected in a
   real normed space of dimension at least two.
+* `TauCeti.connectedComponentIn_compl_eq_of_unbounded_component` — the unbounded connected
+  component of the complement of a bounded set is unique (dimension at least two).
+* `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points in
+  different components, at least one lies in the filled hull (dimension at least two).
 
 This is a prerequisite of the planar-separation step of the `ConformalMapping` roadmap (L5).
 
@@ -35,7 +39,7 @@ namespace TauCeti
 
 open Bornology Metric Set
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {K : Set E} {x y : E}
 
 /-- **The exterior of a closed ball is preconnected** in a real normed space of dimension at least
 two. -/
@@ -75,5 +79,38 @@ theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r :
     exact fun _ => Or.inr (hLmem _ (by linarith))
   · refine IsPreconnected.union (x + M • u) ?_ (hLmem M hM) (isPreconnected_sphere h x M) hLc
     rw [mem_sphere, hdist M (hr.trans hM.le)]
+
+/-- **The unbounded component of the complement of a bounded set is unique** in a real normed space
+of dimension at least two. -/
+theorem connectedComponentIn_compl_eq_of_unbounded_component (h : 1 < Module.rank ℝ E)
+    (hK : IsBounded K) (hx : ¬ IsBounded (connectedComponentIn Kᶜ x))
+    (hy : ¬ IsBounded (connectedComponentIn Kᶜ y)) :
+    connectedComponentIn Kᶜ x = connectedComponentIn Kᶜ y := by
+  obtain ⟨R, hR⟩ := hK.subset_closedBall (0 : E)
+  have hext : (closedBall (0 : E) R)ᶜ ⊆ Kᶜ := compl_subset_compl.mpr hR
+  have hesc : ∀ z : E, ¬ IsBounded (connectedComponentIn Kᶜ z) →
+      ∃ z' ∈ connectedComponentIn Kᶜ z, z' ∈ (closedBall (0 : E) R)ᶜ := fun z hz => by
+    by_contra hcon
+    push Not at hcon
+    exact hz ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun w hw =>
+      notMem_compl_iff.mp (hcon w hw))
+  obtain ⟨x', hx'c, hx'R⟩ := hesc x hx
+  obtain ⟨y', hy'c, hy'R⟩ := hesc y hy
+  have h1 : y' ∈ connectedComponentIn Kᶜ x' :=
+    (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
+  rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
+
+/-- **Two points in different components of the complement of a bounded set cannot both lie outside
+the filled hull** in a real normed space of dimension at least two. -/
+theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
+    (hK : IsBounded K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
+    x ∈ filledHull K ∨ y ∈ filledHull K := by
+  by_cases hy : y ∈ K
+  · exact Or.inr (subset_filledHull hy)
+  · by_contra hcon
+    push Not at hcon
+    simp only [mem_filledHull_iff] at hcon
+    exact hxy ((connectedComponentIn_compl_eq_of_unbounded_component h hK hcon.1 hcon.2).symm ▸
+      mem_connectedComponentIn (mem_compl hy))
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
@@ -6,25 +6,21 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Normed.Module.Connected
-public import TauCeti.Topology.FilledHull
 
 /-!
-# The exterior of a ball is connected, and the unbounded component is unique
+# The exterior of a closed ball is preconnected
 
 In a real normed space of dimension at least two the complement of a closed ball is preconnected:
 it is the union, over the radii `M` exceeding the ball's, of the spheres of radius `M`, strung
-together along a single ray from the centre. Consequently the complement of a *bounded* set has at
-most one unbounded connected component, and two points of the complement that lie in different
-components cannot both be outside `TauCeti.filledHull K`.
+together along a single ray from the centre.
+
+The consequences for bounded sets — uniqueness of the unbounded component and the filled-hull
+alternative — are in `TauCeti/Analysis/Normed/Module/FilledHull.lean`.
 
 ## Main results
 
 * `TauCeti.isPreconnected_compl_closedBall` — the exterior of a closed ball is preconnected in a
   real normed space of dimension at least two.
-* `TauCeti.connectedComponentIn_compl_eq_of_unbounded_component` — the unbounded connected
-  component of the complement of a bounded set is unique (dimension at least two).
-* `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points in
-  different components, at least one lies in the filled hull (dimension at least two).
 
 This is a prerequisite of the planar-separation step of the `ConformalMapping` roadmap (L5).
 
@@ -39,7 +35,7 @@ namespace TauCeti
 
 open Bornology Metric Set
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {K : Set E} {x y : E}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-- **The exterior of a closed ball is preconnected** in a real normed space of dimension at least
 two. -/
@@ -79,38 +75,5 @@ theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r :
     exact fun _ => Or.inr (hLmem _ (by linarith))
   · refine IsPreconnected.union (x + M • u) ?_ (hLmem M hM) (isPreconnected_sphere h x M) hLc
     rw [mem_sphere, hdist M (hr.trans hM.le)]
-
-/-- **The unbounded component of the complement of a bounded set is unique** in a real normed space
-of dimension at least two. -/
-theorem connectedComponentIn_compl_eq_of_unbounded_component (h : 1 < Module.rank ℝ E)
-    (hK : IsBounded K) (hx : ¬ IsBounded (connectedComponentIn Kᶜ x))
-    (hy : ¬ IsBounded (connectedComponentIn Kᶜ y)) :
-    connectedComponentIn Kᶜ x = connectedComponentIn Kᶜ y := by
-  obtain ⟨R, hR⟩ := hK.subset_closedBall (0 : E)
-  have hext : (closedBall (0 : E) R)ᶜ ⊆ Kᶜ := compl_subset_compl.mpr hR
-  have hesc : ∀ z : E, ¬ IsBounded (connectedComponentIn Kᶜ z) →
-      ∃ z' ∈ connectedComponentIn Kᶜ z, z' ∈ (closedBall (0 : E) R)ᶜ := fun z hz => by
-    by_contra hcon
-    push Not at hcon
-    exact hz ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun w hw =>
-      notMem_compl_iff.mp (hcon w hw))
-  obtain ⟨x', hx'c, hx'R⟩ := hesc x hx
-  obtain ⟨y', hy'c, hy'R⟩ := hesc y hy
-  have h1 : y' ∈ connectedComponentIn Kᶜ x' :=
-    (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
-  rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
-
-/-- **Two points in different components of the complement of a bounded set cannot both lie outside
-the filled hull** in a real normed space of dimension at least two. -/
-theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
-    (hK : IsBounded K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
-    x ∈ filledHull K ∨ y ∈ filledHull K := by
-  by_cases hy : y ∈ K
-  · exact Or.inr (subset_filledHull hy)
-  · by_contra hcon
-    push Not at hcon
-    simp only [mem_filledHull_iff] at hcon
-    exact hxy ((connectedComponentIn_compl_eq_of_unbounded_component h hK hcon.1 hcon.2).symm ▸
-      mem_connectedComponentIn (mem_compl hy))
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
@@ -27,6 +27,10 @@ components cannot both be outside `TauCeti.filledHull K`.
   different components, at least one lies in the filled hull (dimension at least two).
 
 This is a prerequisite of the planar-separation step of the `ConformalMapping` roadmap (L5).
+
+## References
+
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Ch. 2.
 -/
 
 public section

--- a/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Exterior.lean
@@ -6,25 +6,21 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Normed.Module.Connected
-public import TauCeti.Topology.FilledHull
 
 /-!
-# The exterior of a ball is connected, and the unbounded component is unique
+# The exterior of a closed ball is preconnected
 
 In a real normed space of dimension at least two the complement of a closed ball is preconnected:
 it is the union, over the radii `M` exceeding the ball's, of the spheres of radius `M`, strung
-together along a single ray from the centre. Consequently the complement of a *bounded* set has at
-most one unbounded connected component, and two points of the complement that lie in different
-components cannot both be outside `TauCeti.filledHull K`.
+together along a single ray from the centre.
+
+The consequences for bounded sets — uniqueness of the unbounded component and the filled-hull
+alternative — are in `TauCeti/Analysis/Normed/Module/FilledHull.lean`.
 
 ## Main results
 
 * `TauCeti.isPreconnected_compl_closedBall` — the exterior of a closed ball is preconnected in a
   real normed space of dimension at least two.
-* `TauCeti.connectedComponentIn_compl_eq_of_unbounded_component` — the unbounded connected
-  component of the complement of a bounded set is unique (dimension at least two).
-* `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points in
-  different components, at least one lies in the filled hull (dimension at least two).
 
 This is a prerequisite of the planar-separation step of the `ConformalMapping` roadmap (L5).
 
@@ -39,7 +35,7 @@ namespace TauCeti
 
 open Bornology Metric Set
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {K : Set E} {x y : E}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-- **The exterior of a closed ball is preconnected** in a real normed space of dimension at least
 two. -/
@@ -54,65 +50,30 @@ theorem isPreconnected_compl_closedBall (h : 1 < Module.rank ℝ E) (x : E) (r :
   have hLc : IsPreconnected L :=
     isPreconnected_Ioi.image _ (by fun_prop : Continuous fun t : ℝ => x + t • u).continuousOn
   have hLmem : ∀ t, r < t → x + t • u ∈ L := fun t ht => ⟨t, ht, rfl⟩
-  have hnorm : ∀ t : ℝ, 0 ≤ t → ‖x + t • u - x‖ = t := by
+  have hdist : ∀ t : ℝ, 0 ≤ t → dist (x + t • u) x = t := by
     intro t ht
-    rw [add_sub_cancel_left, norm_smul, hu, mul_one, Real.norm_eq_abs, abs_of_nonneg ht]
+    simp [dist_eq_norm, norm_smul, hu, abs_of_nonneg ht]
+  have hmem : ∀ w, w ∈ (closedBall x r)ᶜ ↔ r < dist w x := by
+    simp [mem_closedBall, not_le]
   have hLsub : L ⊆ (closedBall x r)ᶜ := by
     rintro _ ⟨t, ht, rfl⟩
-    rw [mem_compl_iff, mem_closedBall, dist_eq_norm, hnorm t (hr.trans ht.le), not_le]
+    rw [hmem, hdist t (hr.trans ht.le)]
     exact ht
   have key : (closedBall x r)ᶜ = ⋃ M : Ioi r, (sphere x M ∪ L) := by
     ext w
     constructor
     · intro hw
-      have hwM : r < ‖w - x‖ := by
-        rwa [mem_compl_iff, mem_closedBall, dist_eq_norm, not_le] at hw
-      exact mem_iUnion.mpr ⟨⟨‖w - x‖, hwM⟩, Or.inl (by rw [mem_sphere, dist_eq_norm])⟩
+      exact mem_iUnion.mpr ⟨⟨dist w x, (hmem w).mp hw⟩, Or.inl (mem_sphere.mpr rfl)⟩
     · intro hw
       obtain ⟨⟨M, hM⟩, hwM⟩ := mem_iUnion.mp hw
       rcases hwM with hwM | hwM
-      · rw [mem_sphere, dist_eq_norm] at hwM
-        rw [mem_compl_iff, mem_closedBall, dist_eq_norm, hwM, not_le]
-        exact hM
+      · rw [hmem]; rw [mem_sphere, dist_comm] at hwM; rw [dist_comm, hwM]; exact hM
       · exact hLsub hwM
   rw [key]
   refine isPreconnected_iUnion ⟨x + (r + 1) • u, ?_⟩ fun ⟨M, hM⟩ => ?_
   · simp only [mem_iInter]
     exact fun _ => Or.inr (hLmem _ (by linarith))
   · refine IsPreconnected.union (x + M • u) ?_ (hLmem M hM) (isPreconnected_sphere h x M) hLc
-    rw [mem_sphere, dist_eq_norm, hnorm M (hr.trans hM.le)]
-
-/-- **The unbounded component of the complement of a bounded set is unique** in a real normed space
-of dimension at least two. -/
-theorem connectedComponentIn_compl_eq_of_unbounded_component (h : 1 < Module.rank ℝ E)
-    (hK : IsBounded K) (hx : ¬ IsBounded (connectedComponentIn Kᶜ x))
-    (hy : ¬ IsBounded (connectedComponentIn Kᶜ y)) :
-    connectedComponentIn Kᶜ x = connectedComponentIn Kᶜ y := by
-  obtain ⟨R, hR⟩ := hK.subset_closedBall (0 : E)
-  have hext : (closedBall (0 : E) R)ᶜ ⊆ Kᶜ := compl_subset_compl.mpr hR
-  have hesc : ∀ z : E, ¬ IsBounded (connectedComponentIn Kᶜ z) →
-      ∃ z' ∈ connectedComponentIn Kᶜ z, z' ∈ (closedBall (0 : E) R)ᶜ := fun z hz => by
-    by_contra hcon
-    push Not at hcon
-    exact hz ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun w hw =>
-      notMem_compl_iff.mp (hcon w hw))
-  obtain ⟨x', hx'c, hx'R⟩ := hesc x hx
-  obtain ⟨y', hy'c, hy'R⟩ := hesc y hy
-  have h1 : y' ∈ connectedComponentIn Kᶜ x' :=
-    (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
-  rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
-
-/-- **Two points in different components of the complement of a bounded set cannot both lie outside
-the filled hull** in a real normed space of dimension at least two. -/
-theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
-    (hK : IsBounded K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
-    x ∈ filledHull K ∨ y ∈ filledHull K := by
-  by_cases hy : y ∈ K
-  · exact Or.inr (subset_filledHull hy)
-  · by_contra hcon
-    push Not at hcon
-    simp only [mem_filledHull_iff] at hcon
-    exact hxy ((connectedComponentIn_compl_eq_of_unbounded_component h hK hcon.1 hcon.2).symm ▸
-      mem_connectedComponentIn (mem_compl hy))
+    rw [mem_sphere, hdist M (hr.trans hM.le)]
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Convex
 public import TauCeti.Topology.FilledHull
+public import TauCeti.Analysis.Normed.Module.Ball.Exterior
 import Mathlib.Analysis.LocallyConvex.Separation
 -- `NormedSpace.toLocallyConvexSpace`, needed to apply `geometric_hahn_banach_point_closed`.
 import Mathlib.Analysis.LocallyConvex.WithSeminorms
@@ -74,6 +75,10 @@ used, and the separation argument is the general Hahn–Banach one.
   functional is unbounded, and `TauCeti.isBounded_closedConvexHull`,
   `TauCeti.diam_closedConvexHull` — the closed forms of the two convex-hull facts the width
   argument runs on.
+* `TauCeti.connectedComponentIn_compl_eq_of_unbounded_component` — the unbounded connected
+  component of the complement of a bounded set is unique (dimension at least two).
+* `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points in
+  different components, at least one lies in the filled hull (dimension at least two).
 -/
 
 public section
@@ -205,5 +210,40 @@ preconnected, disjoint from `K`, and meets the filled hull of `K`, then it lies 
 theorem IsPreconnected.diam_le_diam_of_disjoint (hS : IsPreconnected S) (hSK : Disjoint S K)
     (hne : (S ∩ filledHull K).Nonempty) (hK : IsBounded K) : diam S ≤ diam K :=
   diam_le_diam_of_subset_filledHull hK (IsPreconnected.subset_filledHull hS hSK hne)
+
+variable {x y : E}
+
+/-- **The unbounded component of the complement of a bounded set is unique** in a real normed space
+of dimension at least two. -/
+theorem connectedComponentIn_compl_eq_of_unbounded_component (h : 1 < Module.rank ℝ E)
+    (hK : IsBounded K) (hx : ¬ IsBounded (connectedComponentIn Kᶜ x))
+    (hy : ¬ IsBounded (connectedComponentIn Kᶜ y)) :
+    connectedComponentIn Kᶜ x = connectedComponentIn Kᶜ y := by
+  obtain ⟨R, hR⟩ := hK.subset_closedBall (0 : E)
+  have hext : (closedBall (0 : E) R)ᶜ ⊆ Kᶜ := compl_subset_compl.mpr hR
+  have hesc : ∀ z : E, ¬ IsBounded (connectedComponentIn Kᶜ z) →
+      ∃ z' ∈ connectedComponentIn Kᶜ z, z' ∈ (closedBall (0 : E) R)ᶜ := fun z hz => by
+    by_contra hcon
+    push Not at hcon
+    exact hz ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun w hw =>
+      notMem_compl_iff.mp (hcon w hw))
+  obtain ⟨x', hx'c, hx'R⟩ := hesc x hx
+  obtain ⟨y', hy'c, hy'R⟩ := hesc y hy
+  have h1 : y' ∈ connectedComponentIn Kᶜ x' :=
+    (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
+  rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
+
+/-- **Two points in different components of the complement of a bounded set cannot both lie outside
+the filled hull** in a real normed space of dimension at least two. -/
+theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
+    (hK : IsBounded K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
+    x ∈ filledHull K ∨ y ∈ filledHull K := by
+  by_cases hy : y ∈ K
+  · exact Or.inr (subset_filledHull hy)
+  · by_contra hcon
+    push Not at hcon
+    simp only [mem_filledHull_iff] at hcon
+    exact hxy ((connectedComponentIn_compl_eq_of_unbounded_component h hK hcon.1 hcon.2).symm ▸
+      mem_connectedComponentIn (mem_compl hy))
 
 end TauCeti

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Convex
 public import TauCeti.Topology.FilledHull
-public import TauCeti.Analysis.Normed.Module.Ball.Exterior
 import Mathlib.Analysis.LocallyConvex.Separation
 -- `NormedSpace.toLocallyConvexSpace`, needed to apply `geometric_hahn_banach_point_closed`.
 import Mathlib.Analysis.LocallyConvex.WithSeminorms
@@ -75,10 +74,6 @@ used, and the separation argument is the general Hahn–Banach one.
   functional is unbounded, and `TauCeti.isBounded_closedConvexHull`,
   `TauCeti.diam_closedConvexHull` — the closed forms of the two convex-hull facts the width
   argument runs on.
-* `TauCeti.connectedComponentIn_compl_eq_of_unbounded_component` — the unbounded connected
-  component of the complement of a bounded set is unique (dimension at least two).
-* `TauCeti.mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — of two points in
-  different components, at least one lies in the filled hull (dimension at least two).
 -/
 
 public section
@@ -210,40 +205,5 @@ preconnected, disjoint from `K`, and meets the filled hull of `K`, then it lies 
 theorem IsPreconnected.diam_le_diam_of_disjoint (hS : IsPreconnected S) (hSK : Disjoint S K)
     (hne : (S ∩ filledHull K).Nonempty) (hK : IsBounded K) : diam S ≤ diam K :=
   diam_le_diam_of_subset_filledHull hK (IsPreconnected.subset_filledHull hS hSK hne)
-
-variable {x y : E}
-
-/-- **The unbounded component of the complement of a bounded set is unique** in a real normed space
-of dimension at least two. -/
-theorem connectedComponentIn_compl_eq_of_unbounded_component (h : 1 < Module.rank ℝ E)
-    (hK : IsBounded K) (hx : ¬ IsBounded (connectedComponentIn Kᶜ x))
-    (hy : ¬ IsBounded (connectedComponentIn Kᶜ y)) :
-    connectedComponentIn Kᶜ x = connectedComponentIn Kᶜ y := by
-  obtain ⟨R, hR⟩ := hK.subset_closedBall (0 : E)
-  have hext : (closedBall (0 : E) R)ᶜ ⊆ Kᶜ := compl_subset_compl.mpr hR
-  have hesc : ∀ z : E, ¬ IsBounded (connectedComponentIn Kᶜ z) →
-      ∃ z' ∈ connectedComponentIn Kᶜ z, z' ∈ (closedBall (0 : E) R)ᶜ := fun z hz => by
-    by_contra hcon
-    push Not at hcon
-    exact hz ((isBounded_closedBall (x := (0 : E)) (r := R)).subset fun w hw =>
-      notMem_compl_iff.mp (hcon w hw))
-  obtain ⟨x', hx'c, hx'R⟩ := hesc x hx
-  obtain ⟨y', hy'c, hy'R⟩ := hesc y hy
-  have h1 : y' ∈ connectedComponentIn Kᶜ x' :=
-    (isPreconnected_compl_closedBall h 0 R).subset_connectedComponentIn hx'R hext hy'R
-  rw [connectedComponentIn_eq hx'c, connectedComponentIn_eq h1, ← connectedComponentIn_eq hy'c]
-
-/-- **Two points in different components of the complement of a bounded set cannot both lie outside
-the filled hull** in a real normed space of dimension at least two. -/
-theorem mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn (h : 1 < Module.rank ℝ E)
-    (hK : IsBounded K) (hxy : y ∉ connectedComponentIn Kᶜ x) :
-    x ∈ filledHull K ∨ y ∈ filledHull K := by
-  by_cases hy : y ∈ K
-  · exact Or.inr (subset_filledHull hy)
-  · by_contra hcon
-    push Not at hcon
-    simp only [mem_filledHull_iff] at hcon
-    exact hxy ((connectedComponentIn_compl_eq_of_unbounded_component h hK hcon.1 hcon.2).symm ▸
-      mem_connectedComponentIn (mem_compl hy))
 
 end TauCeti

--- a/TauCeti/Topology/FilledHull.lean
+++ b/TauCeti/Topology/FilledHull.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Topology.Bornology.Basic
 public import Mathlib.Topology.Connected.Basic
 import TauCeti.Topology.Frontier
-public import Mathlib.Topology.Connected.LocallyConnected
 
 /-!
 # Filling in the bounded complementary components of a set
@@ -39,9 +38,8 @@ The negation of membership — that the component of a point in the complement o
 off the filled hull of the trace. Those statements are left as they stand: they are about the
 unbounded side, which needs no name, whereas everything here is about the filled side.
 
-The hull is *not* claimed to be connected or idempotent, neither of which holds without hypotheses
-on `K`. Closedness does hold when `K` is closed and the space is locally connected
-(`isClosed_filledHull`).
+The hull is deliberately *not* claimed to be closed, connected, or idempotent — none of which is
+needed downstream, and the first two of which fail without hypotheses on `K`.
 
 ## Roadmap role
 
@@ -68,7 +66,6 @@ separation, or any other regularity of `K`.
   filled hull lies in it.
 * `TauCeti.subset_filledHull_of_frontier_subset` — a bounded set whose frontier `K` swallows
   lies in the filled hull, with no connectivity asked of it.
-* `TauCeti.isClosed_filledHull` — the filled hull of a closed set is closed.
 -/
 
 public section
@@ -147,19 +144,5 @@ theorem subset_filledHull_of_frontier_subset (hSb : IsBounded S) (hfr : frontier
       isPreconnected_connectedComponentIn ⟨x, mem_connectedComponentIn hxKc, hxi⟩ ⟨y, hy, hyi⟩
     exact connectedComponentIn_subset _ _ hz (hfr (frontier_interior_subset hzf))
   exact mem_filledHull_iff.mpr (hSb.subset (hcomp.trans interior_subset))
-
-/-- **The filled hull of a closed set is closed.** Its complement is the union of the unbounded
-connected components of `Kᶜ`, each of which is open. -/
-theorem isClosed_filledHull [LocallyConnectedSpace E] (hK : IsClosed K) :
-    IsClosed (filledHull K) := by
-  rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
-  intro x hx
-  rw [mem_compl_iff, mem_filledHull_iff] at hx
-  refine ⟨connectedComponentIn Kᶜ x, fun y hy => ?_, hK.isOpen_compl.connectedComponentIn, ?_⟩
-  · rw [mem_compl_iff, mem_filledHull_iff, ← connectedComponentIn_eq hy]
-    exact hx
-  · refine mem_connectedComponentIn fun hxK => hx ?_
-    rw [connectedComponentIn_eq_empty (notMem_compl_iff.mpr hxK)]
-    exact isBounded_empty
 
 end TauCeti

--- a/TauCeti/Topology/FilledHull.lean
+++ b/TauCeti/Topology/FilledHull.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Topology.Bornology.Basic
 public import Mathlib.Topology.Connected.Basic
 import TauCeti.Topology.Frontier
+public import Mathlib.Topology.Connected.LocallyConnected
 
 /-!
 # Filling in the bounded complementary components of a set
@@ -38,8 +39,9 @@ The negation of membership — that the component of a point in the complement o
 off the filled hull of the trace. Those statements are left as they stand: they are about the
 unbounded side, which needs no name, whereas everything here is about the filled side.
 
-The hull is deliberately *not* claimed to be closed, connected, or idempotent — none of which is
-needed downstream, and the first two of which fail without hypotheses on `K`.
+The hull is *not* claimed to be connected or idempotent, neither of which holds without hypotheses
+on `K`. Closedness does hold when `K` is closed and the space is locally connected
+(`isClosed_filledHull`).
 
 ## Roadmap role
 
@@ -66,6 +68,7 @@ separation, or any other regularity of `K`.
   filled hull lies in it.
 * `TauCeti.subset_filledHull_of_frontier_subset` — a bounded set whose frontier `K` swallows
   lies in the filled hull, with no connectivity asked of it.
+* `TauCeti.isClosed_filledHull` — the filled hull of a closed set is closed.
 -/
 
 public section
@@ -144,5 +147,19 @@ theorem subset_filledHull_of_frontier_subset (hSb : IsBounded S) (hfr : frontier
       isPreconnected_connectedComponentIn ⟨x, mem_connectedComponentIn hxKc, hxi⟩ ⟨y, hy, hyi⟩
     exact connectedComponentIn_subset _ _ hz (hfr (frontier_interior_subset hzf))
   exact mem_filledHull_iff.mpr (hSb.subset (hcomp.trans interior_subset))
+
+/-- **The filled hull of a closed set is closed.** Its complement is the union of the unbounded
+connected components of `Kᶜ`, each of which is open. -/
+theorem isClosed_filledHull [LocallyConnectedSpace E] (hK : IsClosed K) :
+    IsClosed (filledHull K) := by
+  rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
+  intro x hx
+  rw [mem_compl_iff, mem_filledHull_iff] at hx
+  refine ⟨connectedComponentIn Kᶜ x, fun y hy => ?_, hK.isOpen_compl.connectedComponentIn, ?_⟩
+  · rw [mem_compl_iff, mem_filledHull_iff, ← connectedComponentIn_eq hy]
+    exact hx
+  · refine mem_connectedComponentIn fun hxK => hx ?_
+    rw [connectedComponentIn_eq_empty (notMem_compl_iff.mpr hxK)]
+    exact isBounded_empty
 
 end TauCeti


### PR DESCRIPTION
The complement of a closed ball in a real normed space of dimension at least two is preconnected, so the complement of a bounded set has at most one unbounded connected component. Two points of the complement in different components cannot both lie outside `TauCeti.filledHull K`.

This is a prerequisite of the planar-separation step of the ConformalMapping roadmap (L5): the uniqueness of the unbounded component feeds into the segment-crossing separation argument that distinguishes the two sides of a crosscut.

New file `TauCeti/Analysis/Normed/Module/Ball/Exterior.lean`:
- `isPreconnected_compl_closedBall` — the exterior of a closed ball is preconnected.

New declarations in `TauCeti/Analysis/Normed/Module/FilledHull.lean`:
- `connectedComponentIn_compl_eq_of_unbounded_component` — the unbounded component is unique.
- `mem_filledHull_or_mem_filledHull_of_notMem_connectedComponentIn` — points in different components cannot both lie outside the filled hull.

No sorry, no axiom, no native_decide. Proof generated with Claude Fable 5.

Roadmap: ConformalMapping