### PR TITLE
feat: transport centers across isomorphisms

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
@@ -199,14 +199,22 @@ theorem centerGroupSchemeIso_inv (e : H ≅ K) :
   rw [centerGroupSchemeIso]
   simp
 
+/-- The monoidal structure underlying the canonical braided structure on relative spectrum. -/
+noncomputable local instance centerAlgSpecMonoidal :
+    (AlgebraicGeometry.algSpec (CommRingCat.of k)).Monoidal :=
+  AlgebraicGeometry.braidedAlgSpec.toMonoidal
+
 /-- The isomorphism of centers commutes with their inclusions into the ambient affine group
 schemes. -/
 @[simp]
 theorem centerGroupSchemeIso_hom_comp_centerGroupSchemeι (e : H ≅ K) :
-    (centerGroupSchemeIso e).hom ≫ centerGroupSchemeι K =
+    (AlgebraicGeometry.algSpec (CommRingCat.of k)).mapGrp.map
+        ((commHopfAlgCatEquivCogrpCommAlgCat k).functor.map
+          (centerCoordinateMap e.symm)).unop ≫ centerGroupSchemeι K =
       centerGroupSchemeι H ≫
         (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map e.inv.op := by
-  rw [centerGroupSchemeIso_hom]
+  change (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map
+      (centerCoordinateMap e.symm).op ≫ centerGroupSchemeι K = _
   simp only [centerGroupSchemeι]
   rw [quotientSpecι_def, quotientSpecι_def,
     ← (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map_comp,

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Center.Basic
+
+/-!
+# Centers and isomorphisms of affine groups
+
+An isomorphism of commutative Hopf algebras carries the ideal defining the center to the ideal
+defining the center. Equivalently, the induced isomorphism of affine group schemes restricts to
+an isomorphism of their centers.
+
+The proof uses the universal property of `centerDefiningIdeal`: the pullback of a central Hopf
+ideal along a bialgebra equivalence is central, so minimality gives both inclusions. The resulting
+coordinate isomorphism is constructed with the general quotient-by-pullback isomorphism and is
+then transported through `hopfSpec`.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.comap_centerDefiningIdeal`: center ideals are preserved by
+  isomorphisms.
+* `TauCeti.CommHopfAlgCat.centerCoordinateMap`: restriction of an isomorphism to the coordinate
+  Hopf algebras of the centers.
+* `TauCeti.CommHopfAlgCat.centerCoordinateIso`: the resulting coordinate isomorphism.
+* `TauCeti.CommHopfAlgCat.centerGroupSchemeIso`: the corresponding isomorphism of center group
+  schemes.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §1.k and §2.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+This supplies the isomorphism invariance of the center `Z(G)` required by Layer 6, "Reductive and
+semisimple groups", of `TauCetiRoadmap/ReductiveGroups/README.md`. It makes the center canonical
+for the subsequent central-isogeny and adjoint-form constructions.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u
+
+variable {k : Type u} [Field k]
+variable {H K : _root_.CommHopfAlgCat.{u} k}
+
+/-- **An isomorphism of commutative Hopf algebras preserves the ideal defining the center.** -/
+@[simp]
+theorem comap_centerDefiningIdeal (e : H ≅ K) :
+    (centerDefiningIdeal K).comap e.hom.hom
+        (ConcreteCategory.bijective_of_isIso e.hom).2 = centerDefiningIdeal H := by
+  let he : Function.Bijective e.hom.hom := ConcreteCategory.bijective_of_isIso e.hom
+  let he' : Function.Bijective e.inv.hom := ConcreteCategory.bijective_of_isIso e.inv
+  have hforward : centerDefiningIdeal H ≤
+      (centerDefiningIdeal K).comap e.hom.hom he.2 := by
+    rw [centerDefiningIdeal_le_iff]
+    exact (isCentral_centerDefiningIdeal K).comap_of_bijective e.hom.hom he.1 he.2
+  have hbackward : centerDefiningIdeal K ≤
+      (centerDefiningIdeal H).comap e.inv.hom he'.2 := by
+    rw [centerDefiningIdeal_le_iff]
+    exact (isCentral_centerDefiningIdeal H).comap_of_bijective e.inv.hom he'.1 he'.2
+  apply le_antisymm
+  · intro x hx
+    have hxK : e.hom.hom x ∈ centerDefiningIdeal K := HopfIdeal.mem_comap.mp hx
+    have hxH : e.inv.hom (e.hom.hom x) ∈ centerDefiningIdeal H :=
+      HopfIdeal.mem_comap.mp (hbackward hxK)
+    simpa using hxH
+  · exact hforward
+
+/-- The coordinate morphism obtained by restricting an ambient isomorphism to the centers. -/
+noncomputable def centerCoordinateMap (e : H ≅ K) :
+    quotient H (centerDefiningIdeal H) ⟶ quotient K (centerDefiningIdeal K) :=
+  liftQuotient (centerDefiningIdeal H)
+    (e.hom ≫ mkQuotient K (centerDefiningIdeal K)) <| by
+      intro x hx
+      change (mkQuotient K (centerDefiningIdeal K)).hom (e.hom.hom x) = 0
+      rw [mkQuotient_eq_zero_iff]
+      apply HopfIdeal.mem_comap.mp
+      rwa [comap_centerDefiningIdeal e]
+
+/-- On quotient classes, restriction to the center applies the ambient isomorphism before taking
+the target quotient class. -/
+@[simp]
+theorem centerCoordinateMap_mk (e : H ≅ K) (x : H) :
+    (centerCoordinateMap e).hom
+        (Ideal.Quotient.mk (centerDefiningIdeal H).toIdeal x) =
+      Ideal.Quotient.mkₐ k (centerDefiningIdeal K).toIdeal (e.hom.hom x) := by
+  rw [← Ideal.Quotient.mkₐ_eq_mk (R₁ := k)]
+  rw [centerCoordinateMap, liftQuotient_mk, _root_.CommHopfAlgCat.comp_apply,
+    mkQuotient_apply]
+
+/-- Restriction to centers commutes with the two ambient quotient morphisms. -/
+@[simp]
+theorem mkQuotient_comp_centerCoordinateMap (e : H ≅ K) :
+    mkQuotient H (centerDefiningIdeal H) ≫ centerCoordinateMap e =
+      e.hom ≫ mkQuotient K (centerDefiningIdeal K) :=
+  mkQuotient_comp_liftQuotient _ _ _
+
+/-- The map on center coordinates induced by an identity is the identity. -/
+@[simp]
+theorem centerCoordinateMap_id (H : _root_.CommHopfAlgCat.{u} k) :
+    centerCoordinateMap (Iso.refl H) = 𝟙 (quotient H (centerDefiningIdeal H)) := by
+  ext q
+  obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal H).toIdeal q
+  simp only [Ideal.Quotient.mkₐ_eq_mk]
+  rw [centerCoordinateMap_mk]
+  rfl
+
+/-- Restriction to center coordinates is compatible with composition of isomorphisms. -/
+@[simp]
+theorem centerCoordinateMap_trans {L : _root_.CommHopfAlgCat.{u} k}
+    (e : H ≅ K) (f : K ≅ L) :
+    centerCoordinateMap (e ≪≫ f) = centerCoordinateMap e ≫ centerCoordinateMap f := by
+  ext q
+  obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal H).toIdeal q
+  simp only [Ideal.Quotient.mkₐ_eq_mk]
+  rw [centerCoordinateMap_mk, _root_.CommHopfAlgCat.comp_apply,
+    centerCoordinateMap_mk]
+  simp only [Ideal.Quotient.mkₐ_eq_mk]
+  rw [centerCoordinateMap_mk]
+  rfl
+
+/-- The isomorphism on coordinate Hopf algebras obtained by restricting an ambient isomorphism
+to the centers. -/
+noncomputable def centerCoordinateIso (e : H ≅ K) :
+    quotient H (centerDefiningIdeal H) ≅ quotient K (centerDefiningIdeal K) where
+  hom := centerCoordinateMap e
+  inv := centerCoordinateMap e.symm
+  hom_inv_id := by
+    ext q
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal H).toIdeal q
+    simp only [Ideal.Quotient.mkₐ_eq_mk]
+    rw [_root_.CommHopfAlgCat.comp_apply, centerCoordinateMap_mk]
+    simp only [Ideal.Quotient.mkₐ_eq_mk]
+    rw [centerCoordinateMap_mk]
+    simp
+  inv_hom_id := by
+    ext q
+    obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal K).toIdeal q
+    simp only [Ideal.Quotient.mkₐ_eq_mk]
+    rw [_root_.CommHopfAlgCat.comp_apply, centerCoordinateMap_mk]
+    simp only [Ideal.Quotient.mkₐ_eq_mk]
+    rw [centerCoordinateMap_mk]
+    simp
+
+/-- The coordinate isomorphism of centers sends the class of `x` to the class of its image under
+the ambient isomorphism. -/
+@[simp]
+theorem centerCoordinateIso_hom_mk (e : H ≅ K) (x : H) :
+    (centerCoordinateIso e).hom.hom
+        (Ideal.Quotient.mk (centerDefiningIdeal H).toIdeal x) =
+      Ideal.Quotient.mkₐ k (centerDefiningIdeal K).toIdeal (e.hom.hom x) := by
+  exact centerCoordinateMap_mk e x
+
+/-- An isomorphism of affine group schemes represented by commutative Hopf algebras restricts to
+an isomorphism of their center group schemes. -/
+noncomputable def centerGroupSchemeIso (e : H ≅ K) :
+    centerGroupScheme H ≅ centerGroupScheme K :=
+  ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).mapIso (centerCoordinateIso e).op).symm
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
@@ -78,13 +78,13 @@ theorem comap_centerDefiningIdeal (e : H ≅ K) :
 
 /-- The isomorphism on coordinate Hopf algebras obtained by restricting an ambient isomorphism
 to the centers. -/
-@[expose] noncomputable def centerCoordinateIso (e : H ≅ K) :
+noncomputable def centerCoordinateIso (e : H ≅ K) :
     quotient H (centerDefiningIdeal H) ≅ quotient K (centerDefiningIdeal K) :=
   eqToIso (congrArg (quotient H) (comap_centerDefiningIdeal e).symm) ≪≫
     quotientIsoOfIso e (centerDefiningIdeal K)
 
 /-- The coordinate morphism obtained by restricting an ambient isomorphism to the centers. -/
-@[expose] noncomputable def centerCoordinateMap (e : H ≅ K) :
+noncomputable def centerCoordinateMap (e : H ≅ K) :
     quotient H (centerDefiningIdeal H) ⟶ quotient K (centerDefiningIdeal K) :=
   (centerCoordinateIso e).hom
 
@@ -92,7 +92,7 @@ to the centers. -/
 @[simp]
 theorem centerCoordinateIso_hom (e : H ≅ K) :
     (centerCoordinateIso e).hom = centerCoordinateMap e :=
-  rfl
+  (rfl)
 
 /-- Restriction to centers commutes with the two ambient quotient morphisms. -/
 @[simp]
@@ -175,7 +175,7 @@ variable {H K : _root_.CommHopfAlgCat.{u} k}
 
 /-- An isomorphism of affine group schemes represented by commutative Hopf algebras restricts to
 an isomorphism of their center group schemes. -/
-@[expose] noncomputable def centerGroupSchemeIso (e : H ≅ K) :
+noncomputable def centerGroupSchemeIso (e : H ≅ K) :
     centerGroupScheme H ≅ centerGroupScheme K :=
   ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).mapIso (centerCoordinateIso e).op).symm
 
@@ -204,6 +204,15 @@ noncomputable local instance centerAlgSpecMonoidal :
     (AlgebraicGeometry.algSpec (CommRingCat.of k)).Monoidal :=
   AlgebraicGeometry.braidedAlgSpec.toMonoidal
 
+/-- Mapping a Hopf-algebra morphism through `algSpec.mapGrp` is the morphism obtained by mapping it
+through the composite functor `hopfSpec`. -/
+private theorem algSpec_mapGrp_map_eq_hopfSpec_map {A B : _root_.CommHopfAlgCat.{u} k}
+    (f : A ⟶ B) :
+    (AlgebraicGeometry.algSpec (CommRingCat.of k)).mapGrp.map
+        ((commHopfAlgCatEquivCogrpCommAlgCat k).functor.map f).unop =
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map f.op := by
+  simp only [Functor.comp_map, Functor.leftOp_map, Quiver.Hom.unop_op]
+
 /-- The isomorphism of centers commutes with their inclusions into the ambient affine group
 schemes. -/
 @[simp]
@@ -213,8 +222,7 @@ theorem centerGroupSchemeIso_hom_comp_centerGroupSchemeι (e : H ≅ K) :
           (centerCoordinateMap e.symm)).unop ≫ centerGroupSchemeι K =
       centerGroupSchemeι H ≫
         (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map e.inv.op := by
-  change (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map
-      (centerCoordinateMap e.symm).op ≫ centerGroupSchemeι K = _
+  rw [algSpec_mapGrp_map_eq_hopfSpec_map]
   simp only [centerGroupSchemeι]
   rw [quotientSpecι_def, quotientSpecι_def,
     ← (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map_comp,

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
@@ -206,10 +206,7 @@ theorem centerGroupSchemeIso_hom_comp_centerGroupSchemeι (e : H ≅ K) :
       centerGroupSchemeι H ≫
         (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map e.inv.op := by
   rw [centerGroupSchemeIso_hom]
-  change (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map
-      (centerCoordinateMap e.symm).op ≫ quotientSpecι K (centerDefiningIdeal K) =
-    quotientSpecι H (centerDefiningIdeal H) ≫
-      (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map e.inv.op
+  simp only [centerGroupSchemeι]
   rw [quotientSpecι_def, quotientSpecι_def,
     ← (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map_comp,
     ← (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map_comp,

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
@@ -16,8 +16,8 @@ an isomorphism of their centers.
 
 The proof uses the universal property of `centerDefiningIdeal`: the pullback of a central Hopf
 ideal along a bialgebra equivalence is central, so minimality gives both inclusions. The resulting
-coordinate isomorphism is constructed with the general quotient-by-pullback isomorphism and is
-then transported through `hopfSpec`.
+coordinate isomorphism transports the general quotient-by-pullback isomorphism along this ideal
+equality and is then carried through `hopfSpec`.
 
 ## Main declarations
 
@@ -45,10 +45,13 @@ open CategoryTheory
 
 namespace TauCeti.CommHopfAlgCat
 
-universe u
+universe u v
 
 variable {k : Type u} [Field k]
-variable {H K : _root_.CommHopfAlgCat.{u} k}
+
+section Coordinate
+
+variable {H K : _root_.CommHopfAlgCat.{v} k}
 
 /-- **An isomorphism of commutative Hopf algebras preserves the ideal defining the center.** -/
 @[simp]
@@ -73,16 +76,31 @@ theorem comap_centerDefiningIdeal (e : H ≅ K) :
     simpa using hxH
   · exact hforward
 
+/-- The isomorphism on coordinate Hopf algebras obtained by restricting an ambient isomorphism
+to the centers. -/
+@[expose] noncomputable def centerCoordinateIso (e : H ≅ K) :
+    quotient H (centerDefiningIdeal H) ≅ quotient K (centerDefiningIdeal K) :=
+  eqToIso (congrArg (quotient H) (comap_centerDefiningIdeal e).symm) ≪≫
+    quotientIsoOfIso e (centerDefiningIdeal K)
+
 /-- The coordinate morphism obtained by restricting an ambient isomorphism to the centers. -/
-noncomputable def centerCoordinateMap (e : H ≅ K) :
+@[expose] noncomputable def centerCoordinateMap (e : H ≅ K) :
     quotient H (centerDefiningIdeal H) ⟶ quotient K (centerDefiningIdeal K) :=
-  liftQuotient (centerDefiningIdeal H)
-    (e.hom ≫ mkQuotient K (centerDefiningIdeal K)) <| by
-      intro x hx
-      change (mkQuotient K (centerDefiningIdeal K)).hom (e.hom.hom x) = 0
-      rw [mkQuotient_eq_zero_iff]
-      apply HopfIdeal.mem_comap.mp
-      rwa [comap_centerDefiningIdeal e]
+  (centerCoordinateIso e).hom
+
+/-- The forward morphism of the coordinate isomorphism is the restricted coordinate map. -/
+@[simp]
+theorem centerCoordinateIso_hom (e : H ≅ K) :
+    (centerCoordinateIso e).hom = centerCoordinateMap e :=
+  rfl
+
+/-- Restriction to centers commutes with the two ambient quotient morphisms. -/
+@[simp]
+theorem mkQuotient_comp_centerCoordinateMap (e : H ≅ K) :
+    mkQuotient H (centerDefiningIdeal H) ≫ centerCoordinateMap e =
+      e.hom ≫ mkQuotient K (centerDefiningIdeal K) := by
+  rw [centerCoordinateMap, centerCoordinateIso]
+  simp
 
 /-- On quotient classes, restriction to the center applies the ambient isomorphism before taking
 the target quotient class. -/
@@ -91,77 +109,127 @@ theorem centerCoordinateMap_mk (e : H ≅ K) (x : H) :
     (centerCoordinateMap e).hom
         (Ideal.Quotient.mk (centerDefiningIdeal H).toIdeal x) =
       Ideal.Quotient.mkₐ k (centerDefiningIdeal K).toIdeal (e.hom.hom x) := by
-  rw [← Ideal.Quotient.mkₐ_eq_mk (R₁ := k)]
-  rw [centerCoordinateMap, liftQuotient_mk, _root_.CommHopfAlgCat.comp_apply,
-    mkQuotient_apply]
-
-/-- Restriction to centers commutes with the two ambient quotient morphisms. -/
-@[simp]
-theorem mkQuotient_comp_centerCoordinateMap (e : H ≅ K) :
-    mkQuotient H (centerDefiningIdeal H) ≫ centerCoordinateMap e =
-      e.hom ≫ mkQuotient K (centerDefiningIdeal K) :=
-  mkQuotient_comp_liftQuotient _ _ _
+  calc
+    (centerCoordinateMap e).hom
+        (Ideal.Quotient.mk (centerDefiningIdeal H).toIdeal x) =
+        (mkQuotient H (centerDefiningIdeal H) ≫ centerCoordinateMap e).hom x := by
+      rw [_root_.CommHopfAlgCat.comp_apply, mkQuotient_apply,
+        Ideal.Quotient.mkₐ_eq_mk]
+    _ = (e.hom ≫ mkQuotient K (centerDefiningIdeal K)).hom x :=
+      BialgHom.congr_fun
+        (congrArg _root_.CommHopfAlgCat.Hom.hom
+          (mkQuotient_comp_centerCoordinateMap e)) x
+    _ = Ideal.Quotient.mkₐ k (centerDefiningIdeal K).toIdeal (e.hom.hom x) := by
+      rw [_root_.CommHopfAlgCat.comp_apply, mkQuotient_apply]
 
 /-- The map on center coordinates induced by an identity is the identity. -/
 @[simp]
-theorem centerCoordinateMap_id (H : _root_.CommHopfAlgCat.{u} k) :
+theorem centerCoordinateMap_refl (H : _root_.CommHopfAlgCat.{v} k) :
     centerCoordinateMap (Iso.refl H) = 𝟙 (quotient H (centerDefiningIdeal H)) := by
-  ext q
-  obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal H).toIdeal q
-  simp only [Ideal.Quotient.mkₐ_eq_mk]
-  rw [centerCoordinateMap_mk]
-  rfl
+  let _ : Epi (mkQuotient H (centerDefiningIdeal H)) :=
+    ConcreteCategory.epi_of_surjective _
+      (Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal H).toIdeal)
+  rw [← cancel_epi (mkQuotient H (centerDefiningIdeal H))]
+  simp
 
 /-- Restriction to center coordinates is compatible with composition of isomorphisms. -/
 @[simp]
-theorem centerCoordinateMap_trans {L : _root_.CommHopfAlgCat.{u} k}
+theorem centerCoordinateMap_trans {L : _root_.CommHopfAlgCat.{v} k}
     (e : H ≅ K) (f : K ≅ L) :
     centerCoordinateMap (e ≪≫ f) = centerCoordinateMap e ≫ centerCoordinateMap f := by
-  ext q
-  obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal H).toIdeal q
-  simp only [Ideal.Quotient.mkₐ_eq_mk]
-  rw [centerCoordinateMap_mk, _root_.CommHopfAlgCat.comp_apply,
-    centerCoordinateMap_mk]
-  simp only [Ideal.Quotient.mkₐ_eq_mk]
-  rw [centerCoordinateMap_mk]
-  rfl
+  let _ : Epi (mkQuotient H (centerDefiningIdeal H)) :=
+    ConcreteCategory.epi_of_surjective _
+      (Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal H).toIdeal)
+  rw [← cancel_epi (mkQuotient H (centerDefiningIdeal H))]
+  calc
+    mkQuotient H (centerDefiningIdeal H) ≫ centerCoordinateMap (e ≪≫ f) =
+        (e ≪≫ f).hom ≫ mkQuotient L (centerDefiningIdeal L) :=
+      mkQuotient_comp_centerCoordinateMap (e ≪≫ f)
+    _ = e.hom ≫ (f.hom ≫ mkQuotient L (centerDefiningIdeal L)) := by
+      rw [Iso.trans_hom, Category.assoc]
+    _ = e.hom ≫ (mkQuotient K (centerDefiningIdeal K) ≫ centerCoordinateMap f) := by
+      rw [mkQuotient_comp_centerCoordinateMap]
+    _ = (e.hom ≫ mkQuotient K (centerDefiningIdeal K)) ≫ centerCoordinateMap f :=
+      (Category.assoc _ _ _).symm
+    _ = (mkQuotient H (centerDefiningIdeal H) ≫ centerCoordinateMap e) ≫
+        centerCoordinateMap f := by
+      rw [mkQuotient_comp_centerCoordinateMap]
+    _ = mkQuotient H (centerDefiningIdeal H) ≫
+        (centerCoordinateMap e ≫ centerCoordinateMap f) :=
+      Category.assoc _ _ _
 
-/-- The isomorphism on coordinate Hopf algebras obtained by restricting an ambient isomorphism
-to the centers. -/
-noncomputable def centerCoordinateIso (e : H ≅ K) :
-    quotient H (centerDefiningIdeal H) ≅ quotient K (centerDefiningIdeal K) where
-  hom := centerCoordinateMap e
-  inv := centerCoordinateMap e.symm
-  hom_inv_id := by
-    ext q
-    obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal H).toIdeal q
-    simp only [Ideal.Quotient.mkₐ_eq_mk]
-    rw [_root_.CommHopfAlgCat.comp_apply, centerCoordinateMap_mk]
-    simp only [Ideal.Quotient.mkₐ_eq_mk]
-    rw [centerCoordinateMap_mk]
-    simp
-  inv_hom_id := by
-    ext q
-    obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective k (centerDefiningIdeal K).toIdeal q
-    simp only [Ideal.Quotient.mkₐ_eq_mk]
-    rw [_root_.CommHopfAlgCat.comp_apply, centerCoordinateMap_mk]
-    simp only [Ideal.Quotient.mkₐ_eq_mk]
-    rw [centerCoordinateMap_mk]
-    simp
-
-/-- The coordinate isomorphism of centers sends the class of `x` to the class of its image under
-the ambient isomorphism. -/
+/-- The inverse morphism of the coordinate isomorphism is restriction along the inverse ambient
+isomorphism. -/
 @[simp]
-theorem centerCoordinateIso_hom_mk (e : H ≅ K) (x : H) :
-    (centerCoordinateIso e).hom.hom
-        (Ideal.Quotient.mk (centerDefiningIdeal H).toIdeal x) =
-      Ideal.Quotient.mkₐ k (centerDefiningIdeal K).toIdeal (e.hom.hom x) := by
-  exact centerCoordinateMap_mk e x
+theorem centerCoordinateIso_inv (e : H ≅ K) :
+    (centerCoordinateIso e).inv = centerCoordinateMap e.symm := by
+  rw [← cancel_mono (centerCoordinateIso e).hom]
+  rw [Iso.inv_hom_id, centerCoordinateIso_hom, ← centerCoordinateMap_trans,
+    Iso.symm_self_id, centerCoordinateMap_refl]
+
+end Coordinate
+
+section Scheme
+
+variable {H K : _root_.CommHopfAlgCat.{u} k}
 
 /-- An isomorphism of affine group schemes represented by commutative Hopf algebras restricts to
 an isomorphism of their center group schemes. -/
-noncomputable def centerGroupSchemeIso (e : H ≅ K) :
+@[expose] noncomputable def centerGroupSchemeIso (e : H ≅ K) :
     centerGroupScheme H ≅ centerGroupScheme K :=
   ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).mapIso (centerCoordinateIso e).op).symm
+
+/-- The forward center-scheme isomorphism is induced contravariantly by restriction along the
+inverse ambient isomorphism. -/
+@[simp]
+theorem centerGroupSchemeIso_hom (e : H ≅ K) :
+    (centerGroupSchemeIso e).hom =
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map
+        (centerCoordinateMap e.symm).op := by
+  rw [centerGroupSchemeIso]
+  simp
+
+/-- The inverse center-scheme isomorphism is induced contravariantly by restriction along the
+forward ambient isomorphism. -/
+@[simp]
+theorem centerGroupSchemeIso_inv (e : H ≅ K) :
+    (centerGroupSchemeIso e).inv =
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map
+        (centerCoordinateMap e).op := by
+  rw [centerGroupSchemeIso]
+  simp
+
+/-- The isomorphism of centers commutes with their inclusions into the ambient affine group
+schemes. -/
+theorem centerGroupSchemeIso_hom_comp_centerGroupSchemeι (e : H ≅ K) :
+    (centerGroupSchemeIso e).hom ≫ centerGroupSchemeι K =
+      centerGroupSchemeι H ≫
+        (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map e.inv.op := by
+  rw [centerGroupSchemeIso_hom]
+  change (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map
+      (centerCoordinateMap e.symm).op ≫ quotientSpecι K (centerDefiningIdeal K) =
+    quotientSpecι H (centerDefiningIdeal H) ≫
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map e.inv.op
+  rw [quotientSpecι_def, quotientSpecι_def,
+    ← (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map_comp,
+    ← (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).map_comp,
+    ← op_comp, ← op_comp, mkQuotient_comp_centerCoordinateMap, Iso.symm_hom]
+
+/-- The center-scheme isomorphism induced by the identity is the identity. -/
+@[simp]
+theorem centerGroupSchemeIso_refl (H : _root_.CommHopfAlgCat.{u} k) :
+    centerGroupSchemeIso (Iso.refl H) = Iso.refl (centerGroupScheme H) := by
+  apply Iso.ext
+  simp
+
+/-- Center-scheme isomorphisms induced by ambient isomorphisms respect composition. -/
+@[simp]
+theorem centerGroupSchemeIso_trans {L : _root_.CommHopfAlgCat.{u} k}
+    (e : H ≅ K) (f : K ≅ L) :
+    centerGroupSchemeIso (e ≪≫ f) = centerGroupSchemeIso e ≪≫ centerGroupSchemeIso f := by
+  apply Iso.ext
+  simp
+
+end Scheme
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Isomorphism.lean
@@ -201,6 +201,7 @@ theorem centerGroupSchemeIso_inv (e : H ≅ K) :
 
 /-- The isomorphism of centers commutes with their inclusions into the ambient affine group
 schemes. -/
+@[simp]
 theorem centerGroupSchemeIso_hom_comp_centerGroupSchemeι (e : H ≅ K) :
     (centerGroupSchemeIso e).hom ≫ centerGroupSchemeι K =
       centerGroupSchemeι H ≫

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
 public import TauCeti.Algebra.Coalgebra.Convolution
 
 /-!
@@ -103,6 +103,48 @@ theorem IsCentralPoint.mapValue {g : WithConv (H →ₐ[R] A)} (hg : IsCentralPo
   intro C _ _ ψ h
   rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp]
   exact hg (ψ.comp φ) h
+
+section CoordinateEquiv
+
+variable {K : Type v} [Ring K] [_root_.Bialgebra R K]
+
+/-- Precomposition by a bialgebra equivalence preserves and reflects universal centrality of
+points. This is invariance of the center of the functor of points under a change of coordinate
+Hopf algebra. -/
+theorem isCentralPoint_mapDomain_bialgEquiv_iff (e : H ≃ₐc[R] K)
+    (g : WithConv (K →ₐ[R] A)) :
+    IsCentralPoint (AlgHom.mapDomain (A := A) e.toBialgHom g) ↔ IsCentralPoint g := by
+  constructor
+  · intro hg B _ _ φ h
+    let E := AlgHom.mapDomainMulEquiv (A := B) e
+    have hc := hg φ (E h)
+    have hc' := hc.map E.symm.toMonoidHom
+    simp only [MulEquiv.coe_toMonoidHom] at hc'
+    have hnatural :
+        E (AlgHom.mapValue (H := K) φ g) =
+          AlgHom.mapValue (H := H) φ (AlgHom.mapDomain (A := A) e.toBialgHom g) :=
+      DFunLike.congr_fun (AlgHom.mapValue_mapDomain e.toBialgHom φ) g
+    have hleft :
+        E.symm (AlgHom.mapValue (H := H) φ
+          (AlgHom.mapDomain (A := A) e.toBialgHom g)) =
+            AlgHom.mapValue (H := K) φ g := by
+      rw [← hnatural]
+      exact E.symm_apply_apply _
+    rw [hleft, E.symm_apply_apply] at hc'
+    exact hc'
+  · intro hg B _ _ φ h
+    let E := AlgHom.mapDomainMulEquiv (A := B) e
+    have hc := hg φ (E.symm h)
+    have hc' := hc.map E.toMonoidHom
+    simp only [MulEquiv.coe_toMonoidHom] at hc'
+    have hnatural :
+        E (AlgHom.mapValue (H := K) φ g) =
+          AlgHom.mapValue (H := H) φ (AlgHom.mapDomain (A := A) e.toBialgHom g) :=
+      DFunLike.congr_fun (AlgHom.mapValue_mapDomain e.toBialgHom φ) g
+    rw [hnatural, E.apply_symm_apply] at hc'
+    exact hc'
+
+end CoordinateEquiv
 
 /-- The identity point is central. -/
 theorem isCentralPoint_one : IsCentralPoint (1 : WithConv (H →ₐ[R] A)) := by

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -136,9 +136,10 @@ theorem isCentralPoint_mapDomain_bialgEquiv_iff (e : H ≃ₐc[R] K)
   constructor
   · intro hg
     have htransport := hg.mapDomain_bialgEquiv e.symm
-    change IsCentralPoint ((AlgHom.mapDomainMulEquiv (A := A) e).symm
-      (AlgHom.mapDomainMulEquiv (A := A) e g)) at htransport
-    rw [(AlgHom.mapDomainMulEquiv (A := A) e).symm_apply_apply] at htransport
+    simp only [BialgEquiv.toBialgHom_eq_coe] at htransport
+    rw [← AlgHom.mapDomainMulEquiv_apply (A := A) e,
+      ← AlgHom.mapDomainMulEquiv_symm_apply (A := A) e,
+      (AlgHom.mapDomainMulEquiv (A := A) e).symm_apply_apply] at htransport
     exact htransport
   · exact fun hg ↦ hg.mapDomain_bialgEquiv e
 

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/CentralPoint.lean
@@ -47,6 +47,9 @@ commutative group functor exactly when `H` is cocommutative
   tensor-factor points in the reversed order is the flipped comultiplication.
 * `TauCeti.HopfAlgebra.isCentralPoint_id_iff_isCocomm`: the tautological point is central exactly
   when `H` is cocommutative.
+* `TauCeti.HopfAlgebra.IsCentralPoint.mapDomain_bialgEquiv` and
+  `TauCeti.HopfAlgebra.isCentralPoint_mapDomain_bialgEquiv_iff`: centrality is invariant under a
+  change of coordinate bialgebra by an equivalence.
 
 ## References
 
@@ -108,6 +111,22 @@ section CoordinateEquiv
 
 variable {K : Type v} [Ring K] [_root_.Bialgebra R K]
 
+/-- Precomposition by a bialgebra equivalence preserves universal centrality of points. -/
+theorem IsCentralPoint.mapDomain_bialgEquiv {g : WithConv (K →ₐ[R] A)}
+    (hg : IsCentralPoint g) (e : H ≃ₐc[R] K) :
+    IsCentralPoint (AlgHom.mapDomain (A := A) e.toBialgHom g) := by
+  intro B _ _ φ h
+  let E := AlgHom.mapDomainMulEquiv (A := B) e
+  have hc := hg φ (E.symm h)
+  have hc' := hc.map E.toMonoidHom
+  simp only [MulEquiv.coe_toMonoidHom] at hc'
+  have hnatural :
+      E (AlgHom.mapValue (H := K) φ g) =
+        AlgHom.mapValue (H := H) φ (AlgHom.mapDomain (A := A) e.toBialgHom g) :=
+    DFunLike.congr_fun (AlgHom.mapValue_mapDomain e.toBialgHom φ) g
+  rw [hnatural, E.apply_symm_apply] at hc'
+  exact hc'
+
 /-- Precomposition by a bialgebra equivalence preserves and reflects universal centrality of
 points. This is invariance of the center of the functor of points under a change of coordinate
 Hopf algebra. -/
@@ -115,34 +134,13 @@ theorem isCentralPoint_mapDomain_bialgEquiv_iff (e : H ≃ₐc[R] K)
     (g : WithConv (K →ₐ[R] A)) :
     IsCentralPoint (AlgHom.mapDomain (A := A) e.toBialgHom g) ↔ IsCentralPoint g := by
   constructor
-  · intro hg B _ _ φ h
-    let E := AlgHom.mapDomainMulEquiv (A := B) e
-    have hc := hg φ (E h)
-    have hc' := hc.map E.symm.toMonoidHom
-    simp only [MulEquiv.coe_toMonoidHom] at hc'
-    have hnatural :
-        E (AlgHom.mapValue (H := K) φ g) =
-          AlgHom.mapValue (H := H) φ (AlgHom.mapDomain (A := A) e.toBialgHom g) :=
-      DFunLike.congr_fun (AlgHom.mapValue_mapDomain e.toBialgHom φ) g
-    have hleft :
-        E.symm (AlgHom.mapValue (H := H) φ
-          (AlgHom.mapDomain (A := A) e.toBialgHom g)) =
-            AlgHom.mapValue (H := K) φ g := by
-      rw [← hnatural]
-      exact E.symm_apply_apply _
-    rw [hleft, E.symm_apply_apply] at hc'
-    exact hc'
-  · intro hg B _ _ φ h
-    let E := AlgHom.mapDomainMulEquiv (A := B) e
-    have hc := hg φ (E.symm h)
-    have hc' := hc.map E.toMonoidHom
-    simp only [MulEquiv.coe_toMonoidHom] at hc'
-    have hnatural :
-        E (AlgHom.mapValue (H := K) φ g) =
-          AlgHom.mapValue (H := H) φ (AlgHom.mapDomain (A := A) e.toBialgHom g) :=
-      DFunLike.congr_fun (AlgHom.mapValue_mapDomain e.toBialgHom φ) g
-    rw [hnatural, E.apply_symm_apply] at hc'
-    exact hc'
+  · intro hg
+    have htransport := hg.mapDomain_bialgEquiv e.symm
+    change IsCentralPoint ((AlgHom.mapDomainMulEquiv (A := A) e).symm
+      (AlgHom.mapDomainMulEquiv (A := A) e g)) at htransport
+    rw [(AlgHom.mapDomainMulEquiv (A := A) e).symm_apply_apply] at htransport
+    exact htransport
+  · exact fun hg ↦ hg.mapDomain_bialgEquiv e
 
 end CoordinateEquiv
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -22,10 +22,11 @@ point of `G` in the sense of `TauCeti.HopfAlgebra.IsCentralPoint`. As for normal
 algebra suffices to detect it, namely `(H ⧸ I) ⊗[R] H`, which carries the tautological point of
 the subgroup together with the tautological point of the ambient group.
 
-The main consequences record that the notion behaves as expected. A central Hopf ideal is normal,
-its closed subgroup has commutative point groups and cocommutative coordinate quotient, and the
-zero Hopf ideal — the one cutting out the whole group — is central exactly when `H` is
-cocommutative, that is, exactly when `G` is commutative.
+The main consequences record that the notion behaves as expected. Centrality is preserved by
+pullback along a bijective bialgebra morphism, a central Hopf ideal is normal, its closed subgroup
+has commutative point groups and cocommutative coordinate quotient, and the zero Hopf ideal — the
+one cutting out the whole group — is central exactly when `H` is cocommutative, that is, exactly
+when `G` is commutative.
 
 Centrality is *upward* closed in the lattice of Hopf ideals, since a larger Hopf ideal cuts out a
 smaller closed subgroup. It is not closed downwards, so this file does not construct a smallest
@@ -41,6 +42,8 @@ producing a Hopf ideal from the cocommutativity defect of `H`.
 
 * `TauCeti.CommHopfAlgCat.isCentral_iff_forall_isCentralPoint`: **a Hopf ideal is central exactly
   when the points it cuts out are central points over every value algebra.**
+* `TauCeti.HopfIdeal.IsCentral.comap_of_bijective`: centrality is preserved by pullback along a
+  bijective bialgebra morphism.
 * `TauCeti.HopfIdeal.IsCentral.isNormal`: a central Hopf ideal is normal.
 * `TauCeti.HopfIdeal.IsCentral.isCocomm_quotient`: the coordinate Hopf algebra of a central
   closed subgroup is cocommutative.
@@ -274,30 +277,19 @@ theorem IsCentral.comap_of_bijective {H K : Type v} [CommRing H] [CommRing K]
   intro A g hg
   let e := BialgEquiv.ofBijective f ⟨hinj, hsurj⟩
   let E := AlgHom.mapDomainMulEquiv (A := A) e
-  have hmem (q : HopfAlgebra.points (R := R) (H := K) A) :
-      E q ∈ CommHopfAlgCat.quotientPointsSubgroup
-          (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A ↔
-        q ∈ CommHopfAlgCat.quotientPointsSubgroup
-          (_root_.CommHopfAlgCat.of R K) I A := by
-    rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff,
-      CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
-    constructor
-    · intro hq y hy
-      obtain ⟨x, rfl⟩ := hsurj y
-      exact hq x (mem_comap.mpr hy)
-    · intro hq x hx
-      exact hq (f x) (mem_comap.mp hx)
+  have hmem := CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comap_iff
+    f hinj hsurj I A
   have hg' : E.symm g ∈ CommHopfAlgCat.quotientPointsSubgroup
       (_root_.CommHopfAlgCat.of R K) I A := by
-    rw [← hmem]
+    apply (hmem (E.symm g)).mp
+    change E (E.symm g) ∈ CommHopfAlgCat.quotientPointsSubgroup
+      (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A
     simpa using hg
   have hcentral := CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup
     (_root_.CommHopfAlgCat.of R K) I hI A hg'
-  have htransport :=
-    (HopfAlgebra.isCentralPoint_mapDomain_bialgEquiv_iff e (E.symm g)).mpr hcentral
-  have heq : AlgHom.mapDomain (A := A) e.toBialgHom (E.symm g) = g := by
-    exact E.apply_symm_apply g
-  rw [heq] at htransport
+  have htransport := hcentral.mapDomain_bialgEquiv e
+  change HopfAlgebra.IsCentralPoint (E (E.symm g)) at htransport
+  rw [E.apply_symm_apply] at htransport
   exact htransport
 
 /-- **A central Hopf ideal is normal.** Its points commute with every point of the ambient group

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -282,14 +282,13 @@ theorem IsCentral.comap_of_bijective {H K : Type v} [CommRing H] [CommRing K]
   have hg' : E.symm g ∈ CommHopfAlgCat.quotientPointsSubgroup
       (_root_.CommHopfAlgCat.of R K) I A := by
     apply (hmem (E.symm g)).mp
-    change E (E.symm g) ∈ CommHopfAlgCat.quotientPointsSubgroup
-      (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A
-    simpa using hg
+    rw [E.apply_symm_apply]
+    exact hg
   have hcentral := CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup
     (_root_.CommHopfAlgCat.of R K) I hI A hg'
   have htransport := hcentral.mapDomain_bialgEquiv e
-  change HopfAlgebra.IsCentralPoint (E (E.symm g)) at htransport
-  rw [E.apply_symm_apply] at htransport
+  simp only [BialgEquiv.toBialgHom_eq_coe] at htransport
+  rw [← AlgHom.mapDomainMulEquiv_apply e, E.apply_symm_apply] at htransport
   exact htransport
 
 /-- **A central Hopf ideal is normal.** Its points commute with every point of the ambient group

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Central.lean
@@ -262,6 +262,44 @@ namespace HopfIdeal
 
 variable {R : Type u} [CommRing R]
 
+/-- Pulling a central Hopf ideal back along a bijective bialgebra morphism preserves centrality.
+Contravariantly, an isomorphism of affine group schemes carries central closed subgroup schemes
+to central closed subgroup schemes. -/
+theorem IsCentral.comap_of_bijective {H K : Type v} [CommRing H] [CommRing K]
+    [HopfAlgebra R H] [HopfAlgebra R K] {I : HopfIdeal R K} (hI : I.IsCentral)
+    (f : H →ₐc[R] K) (hinj : Function.Injective f) (hsurj : Function.Surjective f) :
+    (I.comap f hsurj).IsCentral := by
+  apply (CommHopfAlgCat.isCentral_iff_forall_isCentralPoint
+    (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj)).mpr
+  intro A g hg
+  let e := BialgEquiv.ofBijective f ⟨hinj, hsurj⟩
+  let E := AlgHom.mapDomainMulEquiv (A := A) e
+  have hmem (q : HopfAlgebra.points (R := R) (H := K) A) :
+      E q ∈ CommHopfAlgCat.quotientPointsSubgroup
+          (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A ↔
+        q ∈ CommHopfAlgCat.quotientPointsSubgroup
+          (_root_.CommHopfAlgCat.of R K) I A := by
+    rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff,
+      CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
+    constructor
+    · intro hq y hy
+      obtain ⟨x, rfl⟩ := hsurj y
+      exact hq x (mem_comap.mpr hy)
+    · intro hq x hx
+      exact hq (f x) (mem_comap.mp hx)
+  have hg' : E.symm g ∈ CommHopfAlgCat.quotientPointsSubgroup
+      (_root_.CommHopfAlgCat.of R K) I A := by
+    rw [← hmem]
+    simpa using hg
+  have hcentral := CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup
+    (_root_.CommHopfAlgCat.of R K) I hI A hg'
+  have htransport :=
+    (HopfAlgebra.isCentralPoint_mapDomain_bialgEquiv_iff e (E.symm g)).mpr hcentral
+  have heq : AlgHom.mapDomain (A := A) e.toBialgHom (E.symm g) = g := by
+    exact E.apply_symm_apply g
+  rw [heq] at htransport
+  exact htransport
+
 /-- **A central Hopf ideal is normal.** Its points commute with every point of the ambient group
 over the same value algebra, so they form a normal subgroup there, and normality of a Hopf ideal
 is detected pointwise. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Basic.lean
@@ -40,6 +40,8 @@ cut out by `J`, namely its normal closure.
   bijective bialgebra morphism.
 * `TauCeti.CommHopfAlgCat.quotientPointsSubgroup_normal`: a normal Hopf ideal cuts out a normal
   subgroup on points over every commutative value algebra.
+* `TauCeti.CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comap_iff`: transport of
+  quotient-subgroup membership along a bialgebra equivalence.
 
 ## References
 
@@ -174,6 +176,24 @@ theorem quotientPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     simpa using hn y ((HopfIdeal.mem_toIdeal (I := I)).mp hy)
   exact RingHom.mem_ker.mp (hker (hI.conjugation_mem hx))
 
+/-- Precomposition by a bijective bialgebra morphism identifies the points cut out by a Hopf
+ideal with the points cut out by its pullback. -/
+theorem mapDomainMulEquiv_mem_quotientPointsSubgroup_comap_iff
+    {H K : Type v} [CommRing H] [CommRing K] [HopfAlgebra R H] [HopfAlgebra R K]
+    (f : H →ₐc[R] K) (hinj : Function.Injective f) (hsurj : Function.Surjective f)
+    (I : HopfIdeal R K) (A : CommAlgCat.{w} R)
+    (g : HopfAlgebra.points (R := R) (H := K) A) :
+    AlgHom.mapDomainMulEquiv (A := A) (BialgEquiv.ofBijective f ⟨hinj, hsurj⟩) g ∈
+        quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A ↔
+      g ∈ quotientPointsSubgroup (_root_.CommHopfAlgCat.of R K) I A := by
+  rw [mem_quotientPointsSubgroup_iff, mem_quotientPointsSubgroup_iff]
+  constructor
+  · intro hg y hy
+    obtain ⟨x, rfl⟩ := hsurj y
+    exact hg x (HopfIdeal.mem_comap.mpr hy)
+  · intro hg x hx
+    exact hg (f x) (HopfIdeal.mem_comap.mp hx)
+
 /-- If a Hopf ideal cuts out a normal subgroup over the value algebra `H ⊗ (H ⧸ I)`, then it is
 normal. That single test algebra suffices: it carries the two points whose conjugate detects
 membership in the ideal. -/
@@ -245,29 +265,23 @@ theorem IsNormal.comap_of_bijective {I : HopfIdeal R K} (hI : I.IsNormal) (f : H
   intro A
   let e := BialgEquiv.ofBijective f ⟨hinj, hsurj⟩
   let E := AlgHom.mapDomainMulEquiv (A := A) e
-  have hmem (g : HopfAlgebra.points (R := R) (H := K) A) :
-      E g ∈ CommHopfAlgCat.quotientPointsSubgroup
-          (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A ↔
-        g ∈ CommHopfAlgCat.quotientPointsSubgroup
-          (_root_.CommHopfAlgCat.of R K) I A := by
-    rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff,
-      CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
-    constructor
-    · intro hg y hy
-      obtain ⟨x, rfl⟩ := hsurj y
-      exact hg x (mem_comap.mpr hy)
-    · intro hg x hx
-      exact hg (f x) (mem_comap.mp hx)
+  have hmem := CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comap_iff
+    f hinj hsurj I A
   constructor
   intro n hn g
   have hn' : E.symm n ∈ CommHopfAlgCat.quotientPointsSubgroup
       (_root_.CommHopfAlgCat.of R K) I A := by
-    rw [← hmem]
+    apply (hmem (E.symm n)).mp
+    change E (E.symm n) ∈ CommHopfAlgCat.quotientPointsSubgroup
+      (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A
     simpa using hn
   have hconj := (CommHopfAlgCat.quotientPointsSubgroup_normal
     (_root_.CommHopfAlgCat.of R K) I hI A).conj_mem (E.symm n) hn' (E.symm g)
-  rw [← hmem] at hconj
-  simpa using hconj
+  have hconj' := (hmem _).mpr hconj
+  change E (E.symm g * E.symm n * (E.symm g)⁻¹) ∈
+    CommHopfAlgCat.quotientPointsSubgroup
+      (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A at hconj'
+  simpa using hconj'
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Basic.lean
@@ -40,8 +40,6 @@ cut out by `J`, namely its normal closure.
   bijective bialgebra morphism.
 * `TauCeti.CommHopfAlgCat.quotientPointsSubgroup_normal`: a normal Hopf ideal cuts out a normal
   subgroup on points over every commutative value algebra.
-* `TauCeti.CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comap_iff`: transport of
-  quotient-subgroup membership along a bialgebra equivalence.
 
 ## References
 
@@ -176,24 +174,6 @@ theorem quotientPointsSubgroup_normal (H : _root_.CommHopfAlgCat.{v} R)
     simpa using hn y ((HopfIdeal.mem_toIdeal (I := I)).mp hy)
   exact RingHom.mem_ker.mp (hker (hI.conjugation_mem hx))
 
-/-- Precomposition by a bijective bialgebra morphism identifies the points cut out by a Hopf
-ideal with the points cut out by its pullback. -/
-theorem mapDomainMulEquiv_mem_quotientPointsSubgroup_comap_iff
-    {H K : Type v} [CommRing H] [CommRing K] [HopfAlgebra R H] [HopfAlgebra R K]
-    (f : H →ₐc[R] K) (hinj : Function.Injective f) (hsurj : Function.Surjective f)
-    (I : HopfIdeal R K) (A : CommAlgCat.{w} R)
-    (g : HopfAlgebra.points (R := R) (H := K) A) :
-    AlgHom.mapDomainMulEquiv (A := A) (BialgEquiv.ofBijective f ⟨hinj, hsurj⟩) g ∈
-        quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A ↔
-      g ∈ quotientPointsSubgroup (_root_.CommHopfAlgCat.of R K) I A := by
-  rw [mem_quotientPointsSubgroup_iff, mem_quotientPointsSubgroup_iff]
-  constructor
-  · intro hg y hy
-    obtain ⟨x, rfl⟩ := hsurj y
-    exact hg x (HopfIdeal.mem_comap.mpr hy)
-  · intro hg x hx
-    exact hg (f x) (HopfIdeal.mem_comap.mp hx)
-
 /-- If a Hopf ideal cuts out a normal subgroup over the value algebra `H ⊗ (H ⧸ I)`, then it is
 normal. That single test algebra suffices: it carries the two points whose conjugate detects
 membership in the ideal. -/
@@ -272,16 +252,12 @@ theorem IsNormal.comap_of_bijective {I : HopfIdeal R K} (hI : I.IsNormal) (f : H
   have hn' : E.symm n ∈ CommHopfAlgCat.quotientPointsSubgroup
       (_root_.CommHopfAlgCat.of R K) I A := by
     apply (hmem (E.symm n)).mp
-    change E (E.symm n) ∈ CommHopfAlgCat.quotientPointsSubgroup
-      (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A
-    simpa using hn
+    rw [E.apply_symm_apply]
+    exact hn
   have hconj := (CommHopfAlgCat.quotientPointsSubgroup_normal
     (_root_.CommHopfAlgCat.of R K) I hI A).conj_mem (E.symm n) hn' (E.symm g)
   have hconj' := (hmem _).mpr hconj
-  change E (E.symm g * E.symm n * (E.symm g)⁻¹) ∈
-    CommHopfAlgCat.quotientPointsSubgroup
-      (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A at hconj'
-  simpa using hconj'
+  simpa only [E, e, map_mul, map_inv, MulEquiv.apply_symm_apply] using hconj'
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -31,6 +31,8 @@ the point factors uniquely through the quotient algebra.
 * `CommHopfAlgCat.quotientPointsSubgroup`: the subgroup of ambient points cut out by `I`.
 * `CommHopfAlgCat.instIsMulCommutativeQuotientPointsSubgroup`: when the quotient Hopf algebra is
   cocommutative, the cut-out point subgroup is commutative.
+* `CommHopfAlgCat.mapDomainMulEquiv_mem_quotientPointsSubgroup_comap_iff`: transport of
+  quotient-subgroup membership along a bialgebra equivalence.
 
 ## References
 
@@ -161,6 +163,24 @@ lemma mem_quotientPointsSubgroup_iff (H : _root_.CommHopfAlgCat.{v} R)
     (g : HopfAlgebra.points (R := R) (H := H) A) :
     g ∈ quotientPointsSubgroup H I A ↔ ∀ h : H, h ∈ I → g.ofConv h = 0 :=
   mem_range_quotientPointsHom_iff H I A g
+
+/-- Precomposition by a bijective bialgebra morphism identifies the points cut out by a Hopf
+ideal with the points cut out by its pullback. -/
+theorem mapDomainMulEquiv_mem_quotientPointsSubgroup_comap_iff
+    {H K : Type v} [CommRing H] [CommRing K] [HopfAlgebra R H] [HopfAlgebra R K]
+    (f : H →ₐc[R] K) (hinj : Function.Injective f) (hsurj : Function.Surjective f)
+    (I : HopfIdeal R K) (A : CommAlgCat.{w} R)
+    (g : HopfAlgebra.points (R := R) (H := K) A) :
+    AlgHom.mapDomainMulEquiv (A := A) (BialgEquiv.ofBijective f ⟨hinj, hsurj⟩) g ∈
+        quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) (I.comap f hsurj) A ↔
+      g ∈ quotientPointsSubgroup (_root_.CommHopfAlgCat.of R K) I A := by
+  rw [mem_quotientPointsSubgroup_iff, mem_quotientPointsSubgroup_iff]
+  constructor
+  · intro hg y hy
+    obtain ⟨x, rfl⟩ := hsurj y
+    exact hg x (HopfIdeal.mem_comap.mpr hy)
+  · intro hg x hx
+    exact hg (f x) (HopfIdeal.mem_comap.mp hx)
 
 /-- The included quotient point belongs to the subgroup cut out by the Hopf ideal. -/
 lemma quotientPointsHom_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)


### PR DESCRIPTION
This PR makes the center construction invariant under isomorphism of commutative Hopf algebras: preserve and reflect universal central points under a bialgebra equivalence, pull central Hopf ideals back along bijective bialgebra morphisms, identify the two center-defining ideals, and restrict the ambient isomorphism to both center coordinate algebras and center group schemes.

The exact roadmap target is the Layer 6 milestone in `TauCetiRoadmap/ReductiveGroups/README.md`: “Develop the radical, the centre `Z(G)`, the derived group `G_der`, central isogenies, and the simply connected and adjoint forms.” This is the next critical-path step because the center construction has landed, while central isogenies and adjoint forms require that construction to be canonical under isomorphism. After this PR, the center lane still needs functoriality under the suitable non-isomorphic homomorphisms used by central isogenies, and Layer 6 still needs the radical, derived group, central isogenies, and simply connected and adjoint forms.

The new `Center/Isomorphism.lean` module contains the 167-line public restriction API and its proofs. Supporting lemmas add isomorphism invariance of universal centrality to `Hopf/CentralPoint.lean` and bijective pullback of central Hopf ideals to `HopfIdeal/Central.lean`. The proofs use the existing quotient, point-subgroup, and `hopfSpec` infrastructure; no Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"center-isomorphism"}-->

🤖 Prepared with Codex
