### PR TITLE
feat(EllipticCurve): the omega family of division polynomials

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Invariant.lean
@@ -54,11 +54,12 @@ identities listed below.
 
 ## What is deliberately not here
 
-`WeierstrassCurve.ω` itself and its API — `ω_spec`, `two_mul_ω`, `ψc`, `ψc_spec`, `ω_zero`,
-`ω_one`, `ψc_neg`, `map_ω`, `ω_neg` — are **not** in this file: `ω` is defined through
-`reducedInvarDenom` and `complEDS₂Aux`, so it belongs above the reduced-invariant layer rather
-than beside these identities. Every input `ω_spec` consumes now exists by name — the source's
-chain `redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS` has landed in full as
+`WeierstrassCurve.ω` itself and its API — `ω_spec`, `ω_def`, `two_mul_ω`, `ψc`, `ψc_def`,
+`ψ_mul_ψc`, `ω_zero`, `ω_one`, `ψc_neg`, `map_ψc`, `map_ω`, `ω_neg` — are **not** in this file;
+they live in `DivisionPolynomial/Omega.lean`. `ω` is defined through `reducedInvarDenom` and
+`complEDS₂Aux`, so it belongs above the reduced-invariant layer rather than beside these
+identities. Every input `ω_spec` consumes exists by name — the source's chain
+`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS` has landed in full as
 `reducedInvarNum_eq_reducedInvarDenom_mul` (`EllipticDivisibilitySequence/ReducedInvariant.lean`)
 ← `IsEllipticNet.invarNum_normEDS_one_mul_eq_invarDenom_mul` ← `invarNum_mul_invarDenom` ←
 `isEllipticNet_normEDS`. Nothing in this file depends on any of it.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/NormEDS.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/NormEDS.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.NormEDS
+
+/-!
+# The division polynomial `ψ` as a normalised EDS
+
+Mathlib defines `WeierstrassCurve.ψ` as `normEDS` at the curve's division-polynomial parameters,
+but keeps the body unexposed, so no importing module can see the identification by unfolding.
+This file states it, at the level of functions, and draws the one consequence that needs nothing
+else: the `ψ` family is an elliptic sequence.
+
+These two facts depend only on Mathlib's `DivisionPolynomial/Basic.lean` and this repository's
+`EllipticDivisibilitySequence/NormEDS.lean`, so they sit at exactly that level — below both the
+`ω` development (`DivisionPolynomial/Omega.lean`, whose `ω_spec` rewrites through the function
+form) and the universal-curve transports (`DivisionPolynomial/Universal.lean`, whose elliptic
+sequence statement over `Universal.Field` factors through the same identification).
+
+## Main results
+
+* `WeierstrassCurve.ψ_eq_normEDS`: `W.ψ = normEDS W.ψ₂ (C W.Ψ₃) (C W.preΨ₄)`, as functions.
+* `WeierstrassCurve.isEllipticSequence_ψ`: the `ψ` family is an elliptic sequence.
+
+## Provenance
+
+`isEllipticSequence_ψ` is ported from J. Xu and D. K. Angdinata's
+`LutzNagell/DivisionPolynomialOmega.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`,
+Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declaration `isEllSequence_ψ`,
+renamed to match Mathlib's predicate name; its consumers are the scalar-multiplication
+development's addition formulas. That file's header reads
+`Authors: Junyan Xu, David Kurniadi Angdinata`; following this repository's convention for
+adapted material the upstream authorship is credited here rather than in the copyright header.
+`ψ_eq_normEDS` has no source counterpart: the source unfolds `ψ` where it needs this, which the
+module system rejects across file boundaries, so the identification is a named `rfl` here.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-- The `ψ` family is `normEDS` at the curve's division-polynomial parameters, stated at the
+level of functions for rewriting under function-valued arguments such as
+`IsEllipticNet.invarDenom`, where the per-application equation cannot fire. -/
+theorem ψ_eq_normEDS : W.ψ = normEDS W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) := rfl
+
+/-- The `ψ` family of division polynomials is an elliptic sequence. -/
+theorem isEllipticSequence_ψ : IsEllipticSequence W.ψ :=
+  isEllipticSequence_normEDS _ _ _
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -6,22 +6,25 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Invariant
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.NormEDS
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
 public import TauCeti.NumberTheory.EllipticDivisibilitySequence.ReducedInvariant
 
 /-!
 # The omega family of division polynomials
 
-`ω n` is the bivariate polynomial giving the second (Jacobian) coordinate of scalar
-multiplication by `n` on a Weierstrass curve, completing the `(φ, ψ)` pair of Mathlib's
-division-polynomial API. This file defines `ω` and the 2-complement `ψc` of `ψ`, and proves
-the identity that pins `ω` down,
+`ω n` is the bivariate polynomial that the scalar-multiplication development identifies as the
+second (Jacobian) coordinate of multiplication by `n` on a Weierstrass curve — that
+identification is proved there, not here. This file supplies the polynomial itself, completing
+the `(φ, ψ)` pair of Mathlib's division-polynomial API: it defines `ω` and the 2-complement
+`ψc` of `ψ`, and proves the defining identity
 
 `2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`,
 
-together with the value lemmas `ω_zero` and `ω_one`, the parity rules `ω_neg` and `ψc_neg`,
-the complement identity `ψ n * ψc n = ψ (2n)`, naturality in the coefficient ring, and the
-ellipticity of the `ψ` family itself.
+which pins down `2 ω n` in general and `ω` itself wherever `2` is a nonzerodivisor — the
+equation lemma `ω_def` is the unconditional handle. Alongside: the value lemmas `ω_zero` and
+`ω_one`, the parity rules `ω_neg` and `ψc_neg`, the complement identity `ψ n * ψc n = ψ (2n)`,
+and naturality in the coefficient ring for both families.
 
 ## Main definitions
 
@@ -31,10 +34,13 @@ ellipticity of the `ψ` family itself.
 ## Main results
 
 * `WeierstrassCurve.ω_spec`: `2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`.
+* `WeierstrassCurve.ω_def`: the defining formula, as an equation lemma — the unexposed body's
+  handle for consumers, and the only one that determines `ω` where `2` is a zero divisor.
 * `WeierstrassCurve.ψ_mul_ψc`: `ψ n * ψc n = ψ (2n)`.
 * `WeierstrassCurve.ω_neg`: `ω (-n) = ω n + a₁ φ n ψ n + a₃ (ψ n)³`, proved over the
   universal curve — where `2` is a nonzerodivisor — and specialised.
-* `WeierstrassCurve.isEllipticSequence_ψ`: the `ψ` family is an elliptic sequence.
+* `WeierstrassCurve.map_ψc`, `.map_ω`, `.baseChange_ψc`, `.baseChange_ω`: naturality in the
+  coefficient ring, in both the ring-hom and the algebra-tower form of the `ψ`/`φ` siblings.
 
 ## Provenance
 
@@ -42,14 +48,24 @@ Ported from J. Xu and D. K. Angdinata's `LutzNagell/DivisionPolynomialOmega.lean
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
 `1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `ψc`, `ω`, `ω_spec`, `two_mul_ω`,
 `ψc_spec` (here `ψ_mul_ψc`, naming its left-hand side), `ω_zero`, `ω_one`, `ψc_neg`,
-`map_ω`, `universal_ω_neg`, `ω_neg` and `isEllSequence_ψ` (here `isEllipticSequence_ψ`,
-matching Mathlib's predicate name). That file's header reads
+`map_ω`, `universal_ω_neg` and `ω_neg`. That file's header reads
 `Authors: Junyan Xu, David Kurniadi Angdinata`; following this repository's convention for
 adapted material the upstream authorship is credited here rather than in the copyright
 header. The invariant-polynomial half of that source file is already in
 `DivisionPolynomial/Invariant.lean`; this file is the `ω` half, unblocked by
 `reducedInvarNum_eq_reducedInvarDenom_mul` (`ReducedInvariant.lean`), the port of the
-source's `redInvar_normEDS`.
+source's `redInvar_normEDS`. Its `isEllSequence_ψ` is ported separately, in
+`DivisionPolynomial/NormEDS.lean`, which needs none of the reduced-invariant theory.
+
+The specification realised here and the well-definedness argument behind `ω_neg` are both
+stated in the module docstring of pinned Mathlib's
+`Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean` (D. K. Angdinata):
+`ωₙ := (ψ₂ₙ / ψₙ - ψₙ(a₁φₙ + a₃ψₙ²)) / 2`, with `2` dividing that difference in the
+characteristic-zero universal ring and `ωₙ` its image under the universal morphism. This file
+discharges that docstring's `TODO: the bivariate polynomials ωₙ`. The remaining declarations
+with no source counterpart are the equation lemmas `ψc_def` and `ω_def` (the module system
+keeps both bodies unexposed, so each needs a named handle), `map_ψc`, and the two
+`baseChange_*` forms, which follow Mathlib's sibling `baseChange_ψ`/`baseChange_φ`.
 -/
 
 open Polynomial
@@ -65,18 +81,9 @@ noncomputable section
 
 open Affine (polynomial polynomialX polynomialY negPolynomial)
 
-/-- The `ψ` family is `normEDS` at the curve's division-polynomial parameters, stated at the
-level of functions for rewriting under function-valued arguments such as
-`IsEllipticNet.invarDenom`, where the per-application equation cannot fire. -/
-theorem ψ_eq_normEDS : W.ψ = normEDS W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) := rfl
-
-/-- The `ψ` family of division polynomials is an elliptic sequence. -/
-theorem isEllipticSequence_ψ : IsEllipticSequence W.ψ :=
-  isEllipticSequence_normEDS _ _ _
-
 /-- The complement of `ψ n` in `ψ (2n)`: the parameter-level `complEDS₂` at the curve's
 division-polynomial parameters. `ψ_mul_ψc` below is the identity it is named for. -/
-def ψc : ℤ → R[X][Y] := complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄)
+protected def ψc : ℤ → R[X][Y] := complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄)
 
 /-- The defining formula for `ψc`, at the level of functions. The definition body is not
 exposed, so this equation lemma is how a consumer in another module computes with it. -/
@@ -89,6 +96,16 @@ protected def ω (n : ℤ) : R[X][Y] :=
     ((CC W.a₁ * polynomialY W - polynomialX W) * C W.Ψ₃
       + 4 * polynomial W * (2 * polynomial W + C W.Ψ₂Sq))
   - complEDS₂Aux W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n + negPolynomial W * W.ψ n ^ 3
+
+/-- The defining formula for `ω`. The definition body is not exposed, so this equation lemma is
+how a consumer in another module computes with it: `ω_spec` fixes only `2 * W.ω n`, which
+determines nothing where `2` is a zero divisor. Deliberately not `@[simp]`, for `ψc_def`'s
+reason. -/
+theorem ω_def (n : ℤ) : W.ω n =
+    reducedInvarDenom W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n *
+      ((CC W.a₁ * polynomialY W - polynomialX W) * C W.Ψ₃
+        + 4 * polynomial W * (2 * polynomial W + C W.Ψ₂Sq))
+    - complEDS₂Aux W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n + negPolynomial W * W.ψ n ^ 3 := (rfl)
 
 /-- **The defining identity of `ω`**:
 `2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`. -/
@@ -113,22 +130,16 @@ theorem two_mul_ω (n : ℤ) :
 theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n) :=
   normEDS_mul_complEDS₂ _ _ _ _
 
-/-- `ω` at `0` is `1`. -/
+/-- `ω` at `0` is `1`: the reduced denominator and `ψ 0` both vanish, and the auxiliary term
+contributes its value `-1`. -/
 @[simp] theorem ω_zero : W.ω 0 = 1 := by
-  simp only [WeierstrassCurve.ω, EuclideanDomain.zero_mod,
-    reducedInvarDenom_of_emod_six_eq_zero, EuclideanDomain.zero_div, complEDS_zero, mul_zero,
-    zero_add, normEDS_one, mul_one, zero_sub, Int.reduceNeg, normEDS_neg, zero_mul,
-    complEDS₂Aux_def, preNormEDS_neg, preNormEDS_two, preNormEDS_one, one_pow, Even.zero,
-    ↓reduceIte, sub_neg_eq_add, ψ_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow,
-    add_zero]
+  rw [ω_def, reducedInvarDenom_zero, complEDS₂Aux_zero, ψ_zero]
+  ring
 
-/-- `ω` at `1` is `Y`, matching `ψ 1 = 1` and `φ 1 = X`. -/
+/-- `ω` at `1` is `Y`, matching `ψ 1 = 1` and `φ 1 = X`: the reduced denominator vanishes, the
+auxiliary term contributes `-ψ₂ = -polynomialY`, and `polynomialY + negPolynomial = Y`. -/
 @[simp] theorem ω_one : W.ω 1 = Y := by
-  simp only [WeierstrassCurve.ω, ψ₂, Int.reduceMod, reducedInvarDenom_of_emod_six_eq_one,
-    sub_self, EuclideanDomain.zero_div, complEDS_zero, mul_zero, Int.reduceAdd, normEDS_two,
-    zero_mul, normEDS_one, mul_one, complEDS₂Aux_def, Int.reduceSub, preNormEDS_neg,
-    preNormEDS_one, preNormEDS_two, one_pow, Int.not_even_one, ↓reduceIte, zero_sub,
-    ← Affine.Y_sub_polynomialY, ψ_one]
+  rw [ω_def, reducedInvarDenom_one, complEDS₂Aux_one, ψ_one, ψ₂, ← Affine.Y_sub_polynomialY]
   ring1
 
 /-- `ψc` is an even family. -/
@@ -165,13 +176,33 @@ private theorem universal_ω_neg (n : ℤ) :
   ring1
 
 open Universal in
-/-- The parity rule for `ω`. -/
+/-- The parity rule for `ω`, `@[simp]` like its `ψ`/`φ`/`ψc` counterparts: without it the
+negative index has no elimination route at all. -/
+@[simp]
 theorem ω_neg (n : ℤ) :
     W.ω (-n) = W.ω n + CC W.a₁ * W.φ n * W.ψ n + CC W.a₃ * W.ψ n ^ 3 := by
   rw [← W.map_specialize, map_ω, universal_ω_neg, map_φ, map_ω, map_ψ]
   simp
 
 end Map
+
+section BaseChange
+
+variable {S : Type*} [CommRing S] [Algebra R S] {A : Type*} [CommRing A] [Algebra R A]
+  [Algebra S A] [IsScalarTower R S A] {B : Type*} [CommRing B] [Algebra R B] [Algebra S B]
+  [IsScalarTower R S B] (f : A →ₐ[S] B)
+
+/-- `ψc` commutes with base change across an algebra homomorphism, in the form of Mathlib's
+`baseChange_ψ`. -/
+lemma baseChange_ψc (n : ℤ) : (W⁄B).ψc n = ((W⁄A).ψc n).map (mapRingHom f) := by
+  rw [← map_ψc, map_baseChange]
+
+/-- `ω` commutes with base change across an algebra homomorphism, in the form of Mathlib's
+`baseChange_φ`. -/
+lemma baseChange_ω (n : ℤ) : (W⁄B).ω n = ((W⁄A).ω n).map (mapRingHom f) := by
+  rw [← map_ω, map_baseChange]
+
+end BaseChange
 
 end
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Invariant
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
+public import TauCeti.NumberTheory.EllipticDivisibilitySequence.ReducedInvariant
+
+/-!
+# The omega family of division polynomials
+
+`ω n` is the bivariate polynomial giving the second (Jacobian) coordinate of scalar
+multiplication by `n` on a Weierstrass curve, completing the `(φ, ψ)` pair of Mathlib's
+division-polynomial API. This file defines `ω` and the 2-complement `ψc` of `ψ`, and proves
+the identity that pins `ω` down,
+
+`2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`,
+
+together with the value lemmas `ω_zero` and `ω_one`, the parity rules `ω_neg` and `ψc_neg`,
+the complement identity `ψ n * ψc n = ψ (2n)`, naturality in the coefficient ring, and the
+ellipticity of the `ψ` family itself.
+
+## Main definitions
+
+* `WeierstrassCurve.ψc`: the complement of `ψ n` in `ψ (2n)`.
+* `WeierstrassCurve.ω`: the `ω` family of division polynomials.
+
+## Main results
+
+* `WeierstrassCurve.ω_spec`: `2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`.
+* `WeierstrassCurve.ψ_mul_ψc`: `ψ n * ψc n = ψ (2n)`.
+* `WeierstrassCurve.ω_neg`: `ω (-n) = ω n + a₁ φ n ψ n + a₃ (ψ n)³`, proved over the
+  universal curve — where `2` is a nonzerodivisor — and specialised.
+* `WeierstrassCurve.isEllipticSequence_ψ`: the `ψ` family is an elliptic sequence.
+
+## Provenance
+
+Ported from J. Xu and D. K. Angdinata's `LutzNagell/DivisionPolynomialOmega.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main` at
+`1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), declarations `ψc`, `ω`, `ω_spec`, `two_mul_ω`,
+`ψc_spec` (here `ψ_mul_ψc`, naming its left-hand side), `ω_zero`, `ω_one`, `ψc_neg`,
+`map_ω`, `universal_ω_neg`, `ω_neg` and `isEllSequence_ψ` (here `isEllipticSequence_ψ`,
+matching Mathlib's predicate name). That file's header reads
+`Authors: Junyan Xu, David Kurniadi Angdinata`; following this repository's convention for
+adapted material the upstream authorship is credited here rather than in the copyright
+header. The invariant-polynomial half of that source file is already in
+`DivisionPolynomial/Invariant.lean`; this file is the `ω` half, unblocked by
+`reducedInvarNum_eq_reducedInvarDenom_mul` (`ReducedInvariant.lean`), the port of the
+source's `redInvar_normEDS`.
+-/
+
+open Polynomial
+open scoped Polynomial.Bivariate
+
+namespace WeierstrassCurve
+
+variable {R : Type*} {S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve R)
+
+public section
+
+noncomputable section
+
+open Affine (polynomial polynomialX polynomialY negPolynomial)
+
+/-- The `ψ` family is `normEDS` at the curve's division-polynomial parameters, stated at the
+level of functions so that both applied and unapplied occurrences of `ψ` rewrite. -/
+theorem ψ_eq_normEDS : W.ψ = normEDS W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) := rfl
+
+/-- The `ψ` family of division polynomials is an elliptic sequence: it is `normEDS` at the
+curve's parameters, and a normalised EDS is an elliptic sequence. -/
+theorem isEllipticSequence_ψ : IsEllipticSequence W.ψ := by
+  rw [ψ_eq_normEDS]
+  exact isEllipticSequence_normEDS _ _ _
+
+/-- The complement of `ψ n` in `ψ (2n)`: the parameter-level `complEDS₂` at the curve's
+division-polynomial parameters. `ψ_mul_ψc` below is the identity it is named for. -/
+def ψc : ℤ → R[X][Y] := complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄)
+
+/-- The `ω` family of division polynomials: `ω n` gives the second coordinate in Jacobian
+coordinates of scalar multiplication by `n`. -/
+protected def ω (n : ℤ) : R[X][Y] :=
+  reducedInvarDenom W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n *
+    ((CC W.a₁ * polynomialY W - polynomialX W) * C W.Ψ₃
+      + 4 * polynomial W * (2 * polynomial W + C W.Ψ₂Sq))
+  - complEDS₂Aux W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n + negPolynomial W * W.ψ n ^ 3
+
+/-- **The defining identity of `ω`**:
+`2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`. -/
+theorem ω_spec (n : ℤ) :
+    2 * W.ω n + CC W.a₁ * W.φ n * W.ψ n + CC W.a₃ * W.ψ n ^ 3 = W.ψc n := by
+  rw [ψc, complEDS₂_eq_reducedInvarNum_sub, reducedInvarNum_eq_reducedInvarDenom_mul,
+    preΨ₄_add_ψ₂_pow_four, mul_assoc (C _), φ_mul_ψ, ψ_eq_normEDS,
+    IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul, WeierstrassCurve.ω,
+    ← ψ_eq_normEDS, invar_def, b₂, b₄, ψ₂, polynomialY, polynomialX, negPolynomial]
+  simp only [map_ofNat, C_add, C_mul, C_pow]
+  ring
+
+theorem two_mul_ω (n : ℤ) :
+    2 * W.ω n = W.ψc n - CC W.a₁ * W.φ n * W.ψ n - CC W.a₃ * W.ψ n ^ 3 := by
+  rw [← ω_spec]; abel
+
+/-- `ψ n * ψc n = ψ (2n)`: the complement identity `ψc` is named for. -/
+theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n) :=
+  normEDS_mul_complEDS₂ _ _ _ _
+
+@[simp] theorem ω_zero : W.ω 0 = 1 := by simp [WeierstrassCurve.ω, complEDS₂Aux_def]
+
+@[simp] theorem ω_one : W.ω 1 = Y := by
+  simp [WeierstrassCurve.ω, ψ₂, complEDS₂Aux_def, ← Affine.Y_sub_polynomialY]
+  ring
+
+@[simp] theorem ψc_neg (n : ℤ) : W.ψc (-n) = W.ψc n := by simp [ψc]
+
+end
+
+section Map
+
+open Affine in
+@[simp]
+theorem map_ω (f : R →+* S) (n : ℤ) : (W.map f).ω n = (W.ω n).map (mapRingHom f) := by
+  simp_rw [WeierstrassCurve.ω, ← coe_mapRingHom, map_add, map_sub, map_mul,
+    map_reducedInvarDenom, map_complEDS₂Aux, map_polynomial, map_polynomialX, map_polynomialY,
+    map_negPolynomial, map_ψ₂, map_Ψ₃, map_preΨ₄, map_Ψ₂Sq, map_ψ]
+  simp
+
+open Universal in
+/-- `ω_neg` over the universal curve, where the coefficient ring is a domain and `2` is a
+nonzerodivisor, so the identity may be doubled and read off `two_mul_ω`. -/
+private theorem universal_ω_neg (n : ℤ) :
+    curve.ω (-n) = curve.ω n + CC curve.a₁ * curve.φ n * curve.ψ n
+      + CC curve.a₃ * curve.ψ n ^ 3 := by
+  rw [← mul_cancel_left_mem_nonZeroDivisors
+    (mem_nonZeroDivisors_of_ne_zero (two_ne_zero (α := Universal.Poly)))]
+  simp_rw [left_distrib, two_mul_ω, ψc_neg, ψ_neg, φ_neg]
+  ring
+
+open Universal in
+/-- The parity rule for `ω`, specialised from the universal curve. -/
+theorem ω_neg (n : ℤ) :
+    W.ω (-n) = W.ω n + CC W.a₁ * W.φ n * W.ψ n + CC W.a₃ * W.ψ n ^ 3 := by
+  rw [← W.map_specialize, map_ω, universal_ω_neg, map_φ, map_ω, map_ψ]
+  simp
+
+end Map
+
+end
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -79,6 +79,10 @@ theorem isEllipticSequence_ψ : IsEllipticSequence W.ψ := by
 division-polynomial parameters. `ψ_mul_ψc` below is the identity it is named for. -/
 def ψc : ℤ → R[X][Y] := complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄)
 
+/-- The defining formula for `ψc`, at the level of functions. The definition body is not
+exposed, so this equation lemma is how a consumer in another module computes with it. -/
+theorem ψc_def : W.ψc = complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) := (rfl)
+
 /-- The `ω` family of division polynomials: `ω n` gives the second coordinate in Jacobian
 coordinates of scalar multiplication by `n`. -/
 protected def ω (n : ℤ) : R[X][Y] :=

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -89,6 +89,12 @@ protected def ψc : ℤ → R[X][Y] := complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.pre�
 exposed, so this equation lemma is how a consumer in another module computes with it. -/
 theorem ψc_def : W.ψc = complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) := (rfl)
 
+/-- `ψc` at `0` is `2`. -/
+@[simp] theorem ψc_zero : W.ψc 0 = 2 := by rw [ψc_def, complEDS₂_zero]
+
+/-- `ψc` at `1` is `ψ₂`, matching `ψ 1 * ψc 1 = ψ 2`. -/
+@[simp] theorem ψc_one : W.ψc 1 = W.ψ₂ := by rw [ψc_def, complEDS₂_one]
+
 /-- The `ω` family of division polynomials: `ω n` gives the second coordinate in Jacobian
 coordinates of scalar multiplication by `n`. -/
 protected def ω (n : ℤ) : R[X][Y] :=
@@ -130,14 +136,13 @@ theorem two_mul_ω (n : ℤ) :
 theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n) :=
   normEDS_mul_complEDS₂ _ _ _ _
 
-/-- `ω` at `0` is `1`: the reduced denominator and `ψ 0` both vanish, and the auxiliary term
-contributes its value `-1`. -/
+/-- `ω` at `0` is `1`, matching `ψ 0 = 0` and `φ 0 = 1`. -/
 @[simp] theorem ω_zero : W.ω 0 = 1 := by
   rw [ω_def, reducedInvarDenom_zero, complEDS₂Aux_zero, ψ_zero]
   ring
 
-/-- `ω` at `1` is `Y`, matching `ψ 1 = 1` and `φ 1 = X`: the reduced denominator vanishes, the
-auxiliary term contributes `-ψ₂ = -polynomialY`, and `polynomialY + negPolynomial = Y`. -/
+/-- `ω` at `1` is `Y`, matching `ψ 1 = 1` and `φ 1 = X`: the point `1 • (X, Y)` is `(X, Y)`
+itself. -/
 @[simp] theorem ω_one : W.ω 1 = Y := by
   rw [ω_def, reducedInvarDenom_one, complEDS₂Aux_one, ψ_one, ψ₂, ← Affine.Y_sub_polynomialY]
   ring1

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -101,6 +101,7 @@ theorem ω_spec (n : ℤ) :
   simp only [map_ofNat, C_add, C_mul, C_pow]
   ring1
 
+/-- `ω_spec` solved for `2 ω n`. -/
 theorem two_mul_ω (n : ℤ) :
     2 * W.ω n = W.ψc n - CC W.a₁ * W.φ n * W.ψ n - CC W.a₃ * W.ψ n ^ 3 := by
   rw [← ω_spec]; abel
@@ -109,6 +110,7 @@ theorem two_mul_ω (n : ℤ) :
 theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n) :=
   normEDS_mul_complEDS₂ _ _ _ _
 
+/-- `ω` at `0` is `1`. -/
 @[simp] theorem ω_zero : W.ω 0 = 1 := by
   simp only [WeierstrassCurve.ω, EuclideanDomain.zero_mod,
     reducedInvarDenom_of_emod_six_eq_zero, EuclideanDomain.zero_div, complEDS_zero, mul_zero,
@@ -117,6 +119,7 @@ theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n) :=
     ↓reduceIte, sub_neg_eq_add, ψ_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow,
     add_zero]
 
+/-- `ω` at `1` is `Y`, matching `ψ 1 = 1` and `φ 1 = X`. -/
 @[simp] theorem ω_one : W.ω 1 = Y := by
   simp only [WeierstrassCurve.ω, ψ₂, Int.reduceMod, reducedInvarDenom_of_emod_six_eq_one,
     sub_self, EuclideanDomain.zero_div, complEDS_zero, mul_zero, Int.reduceAdd, normEDS_two,
@@ -125,13 +128,21 @@ theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n) :=
     ← Affine.Y_sub_polynomialY, ψ_one]
   ring1
 
+/-- `ψc` is an even family. -/
 @[simp] theorem ψc_neg (n : ℤ) : W.ψc (-n) = W.ψc n := by simp only [ψc_def, complEDS₂_neg]
 
 end
 
 section Map
 
+/-- `ψc` is natural in the coefficient ring. -/
+@[simp]
+theorem map_ψc (f : R →+* S) (n : ℤ) : (W.map f).ψc n = (W.ψc n).map (mapRingHom f) := by
+  simp_rw [ψc_def, ← coe_mapRingHom, map_complEDS₂, map_ψ₂, map_Ψ₃, map_preΨ₄]
+  simp
+
 open Affine in
+/-- `ω` is natural in the coefficient ring. -/
 @[simp]
 theorem map_ω (f : R →+* S) (n : ℤ) : (W.map f).ω n = (W.ω n).map (mapRingHom f) := by
   simp_rw [WeierstrassCurve.ω, ← coe_mapRingHom, map_add, map_sub, map_mul,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -94,11 +94,14 @@ protected def ω (n : ℤ) : R[X][Y] :=
 `2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`. -/
 theorem ω_spec (n : ℤ) :
     2 * W.ω n + CC W.a₁ * W.φ n * W.ψ n + CC W.a₃ * W.ψ n ^ 3 = W.ψc n := by
+  -- The directed steps: reindex `ψc` through the reduced invariant, cancel, and open `ω`.
   rw [ψc_def, complEDS₂_eq_reducedInvarNum_sub, reducedInvarNum_eq_reducedInvarDenom_mul,
     preΨ₄_add_ψ₂_pow_four, mul_assoc (C _), φ_mul_ψ, ψ_eq_normEDS,
     IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul, WeierstrassCurve.ω,
-    ← ψ_eq_normEDS, invar_def, b₂, b₄, ψ₂, polynomialY, polynomialX, negPolynomial]
-  simp only [map_ofNat, C_add, C_mul, C_pow]
+    ← ψ_eq_normEDS]
+  -- The rest is undirected normalisation: unfold the curve constants and push `C` through.
+  simp only [invar_def, b₂, b₄, ψ₂, polynomialY, polynomialX, negPolynomial, map_ofNat, C_add,
+    C_mul, C_pow]
   ring1
 
 /-- `ω_spec` solved for `2 ω n`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -66,14 +66,13 @@ noncomputable section
 open Affine (polynomial polynomialX polynomialY negPolynomial)
 
 /-- The `ψ` family is `normEDS` at the curve's division-polynomial parameters, stated at the
-level of functions so that both applied and unapplied occurrences of `ψ` rewrite. -/
+level of functions for rewriting under function-valued arguments such as
+`IsEllipticNet.invarDenom`, where the per-application equation cannot fire. -/
 theorem ψ_eq_normEDS : W.ψ = normEDS W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) := rfl
 
-/-- The `ψ` family of division polynomials is an elliptic sequence: it is `normEDS` at the
-curve's parameters, and a normalised EDS is an elliptic sequence. -/
-theorem isEllipticSequence_ψ : IsEllipticSequence W.ψ := by
-  rw [ψ_eq_normEDS]
-  exact isEllipticSequence_normEDS _ _ _
+/-- The `ψ` family of division polynomials is an elliptic sequence. -/
+theorem isEllipticSequence_ψ : IsEllipticSequence W.ψ :=
+  isEllipticSequence_normEDS _ _ _
 
 /-- The complement of `ψ n` in `ψ (2n)`: the parameter-level `complEDS₂` at the curve's
 division-polynomial parameters. `ψ_mul_ψc` below is the identity it is named for. -/
@@ -95,12 +94,12 @@ protected def ω (n : ℤ) : R[X][Y] :=
 `2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`. -/
 theorem ω_spec (n : ℤ) :
     2 * W.ω n + CC W.a₁ * W.φ n * W.ψ n + CC W.a₃ * W.ψ n ^ 3 = W.ψc n := by
-  rw [ψc, complEDS₂_eq_reducedInvarNum_sub, reducedInvarNum_eq_reducedInvarDenom_mul,
+  rw [ψc_def, complEDS₂_eq_reducedInvarNum_sub, reducedInvarNum_eq_reducedInvarDenom_mul,
     preΨ₄_add_ψ₂_pow_four, mul_assoc (C _), φ_mul_ψ, ψ_eq_normEDS,
     IsEllipticNet.invarDenom_normEDS_one_eq_reducedInvarDenom_mul, WeierstrassCurve.ω,
     ← ψ_eq_normEDS, invar_def, b₂, b₄, ψ₂, polynomialY, polynomialX, negPolynomial]
   simp only [map_ofNat, C_add, C_mul, C_pow]
-  ring
+  ring1
 
 theorem two_mul_ω (n : ℤ) :
     2 * W.ω n = W.ψc n - CC W.a₁ * W.φ n * W.ψ n - CC W.a₃ * W.ψ n ^ 3 := by
@@ -110,13 +109,23 @@ theorem two_mul_ω (n : ℤ) :
 theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n) :=
   normEDS_mul_complEDS₂ _ _ _ _
 
-@[simp] theorem ω_zero : W.ω 0 = 1 := by simp [WeierstrassCurve.ω, complEDS₂Aux_def]
+@[simp] theorem ω_zero : W.ω 0 = 1 := by
+  simp only [WeierstrassCurve.ω, EuclideanDomain.zero_mod,
+    reducedInvarDenom_of_emod_six_eq_zero, EuclideanDomain.zero_div, complEDS_zero, mul_zero,
+    zero_add, normEDS_one, mul_one, zero_sub, Int.reduceNeg, normEDS_neg, zero_mul,
+    complEDS₂Aux_def, preNormEDS_neg, preNormEDS_two, preNormEDS_one, one_pow, Even.zero,
+    ↓reduceIte, sub_neg_eq_add, ψ_zero, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow,
+    add_zero]
 
 @[simp] theorem ω_one : W.ω 1 = Y := by
-  simp [WeierstrassCurve.ω, ψ₂, complEDS₂Aux_def, ← Affine.Y_sub_polynomialY]
-  ring
+  simp only [WeierstrassCurve.ω, ψ₂, Int.reduceMod, reducedInvarDenom_of_emod_six_eq_one,
+    sub_self, EuclideanDomain.zero_div, complEDS_zero, mul_zero, Int.reduceAdd, normEDS_two,
+    zero_mul, normEDS_one, mul_one, complEDS₂Aux_def, Int.reduceSub, preNormEDS_neg,
+    preNormEDS_one, preNormEDS_two, one_pow, Int.not_even_one, ↓reduceIte, zero_sub,
+    ← Affine.Y_sub_polynomialY, ψ_one]
+  ring1
 
-@[simp] theorem ψc_neg (n : ℤ) : W.ψc (-n) = W.ψc n := by simp [ψc]
+@[simp] theorem ψc_neg (n : ℤ) : W.ψc (-n) = W.ψc n := by simp only [ψc_def, complEDS₂_neg]
 
 end
 
@@ -131,18 +140,18 @@ theorem map_ω (f : R →+* S) (n : ℤ) : (W.map f).ω n = (W.ω n).map (mapRin
   simp
 
 open Universal in
-/-- `ω_neg` over the universal curve, where the coefficient ring is a domain and `2` is a
-nonzerodivisor, so the identity may be doubled and read off `two_mul_ω`. -/
+/-- `ω_neg` over the universal curve. -/
 private theorem universal_ω_neg (n : ℤ) :
     curve.ω (-n) = curve.ω n + CC curve.a₁ * curve.φ n * curve.ψ n
       + CC curve.a₃ * curve.ψ n ^ 3 := by
+  -- Double both sides — `2` is a nonzerodivisor here — and read the identity off `two_mul_ω`.
   rw [← mul_cancel_left_mem_nonZeroDivisors
     (mem_nonZeroDivisors_of_ne_zero (two_ne_zero (α := Universal.Poly)))]
   simp_rw [left_distrib, two_mul_ω, ψc_neg, ψ_neg, φ_neg]
-  ring
+  ring1
 
 open Universal in
-/-- The parity rule for `ω`, specialised from the universal curve. -/
+/-- The parity rule for `ω`. -/
 theorem ω_neg (n : ℤ) :
     W.ω (-n) = W.ω n + CC W.a₁ * W.φ n * W.ψ n + CC W.a₃ * W.ψ n ^ 3 := by
   rw [← W.map_specialize, map_ω, universal_ω_neg, map_φ, map_ω, map_ψ]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Cusp
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.NormEDS
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
-public import TauCeti.NumberTheory.EllipticDivisibilitySequence.NormEDS
 
 /-!
 # Division polynomials of the universal curve
@@ -55,19 +55,12 @@ first-order, and the same for `map_mul` and `map_pow`. That leaves the arithmeti
 `polyEval (cusp ℤ) 1 1 (C X) * n ^ 2 - (n + 1) * (n - 1) = 1`, which `ring` closes once `C X`
 evaluates to `1`.
 
-The remaining two companions, `polyEval_cusp_ψc` and `polyEval_cusp_ω`, need `ψc` and `two_mul_ω`,
-both part of the `ω` API that `DivisionPolynomial/Invariant.lean` records as not yet here. Those are
-ordinary missing prerequisites and arrive with `ω`.
-
-The companion transport for `ω` is **not** here. It cannot be: `WeierstrassCurve.ω` does not exist
-in this repository or in the pinned Mathlib, and neither does the `map_ω` such a proof would rewrite
-with. `DivisionPolynomial/Invariant.lean` lists both among what it deliberately leaves out, and
-records the chain still missing for them — the top of
-`redInvar_normEDS ← invar₂_normEDS ← invar_normEDS ← net_normEDS`, the source's names for it; the
-denominator itself has landed as `reducedInvarDenom`. The
-lower three links are `isEllipticNet_normEDS`, `invarNum_mul_invarDenom` and
-`IsEllipticNet.invarNum_normEDS_one_mul_eq_invarDenom_mul`, all present, so what remains is
-`redInvar_normEDS`. `evalEval_ω` belongs with that work rather than here.
+The remaining companions — `polyEval_cusp_ψc`, `polyEval_cusp_ω` and the transport `evalEval_ω`
+— are **not** here, and no longer for want of prerequisites: `ψc`, `ω`, `two_mul_ω` and `map_ω`
+all live in `DivisionPolynomial/Omega.lean`, downstream of the reduced-invariant identity this
+passage used to track. They are the cusp-value slice's own topic: stating them here would add an
+`Omega.lean` import for three lemmas that ship together with that development, so they arrive
+with it instead.
 
 ## Provenance
 
@@ -92,8 +85,10 @@ The source's `polyEval_cusp_ψc` and `polyEval_cusp_ω` are excluded.
 The `evalEval_*` statements are the source's unchanged. Docstrings are added here, and the
 source's shared `variable {m n : ℤ}` is narrowed to `n`: of those five only `evalEval_ψ` and
 `evalEval_φ` carry an index, and both use `n` alone. `isEllSequence_ψᵤ` is stated upstream through
-an `abbrev ψᵤ` and its own `ψᵤ_eq_normEDS`; here the abbreviation is dropped and that equation is
-inlined as a `have`, so the statement is spelled on `fun n ↦ polyToField (curve.ψ n)` directly.
+an `abbrev ψᵤ` and its own `ψᵤ_eq_normEDS`; here the abbreviation is dropped, the identification
+of `ψ` with `normEDS` is the named `ψ_eq_normEDS` (`DivisionPolynomial/NormEDS.lean`), and a
+`have` transports it through `polyToField`, so the statement is spelled on
+`fun n ↦ polyToField (curve.ψ n)` directly.
 -/
 
 public section
@@ -142,7 +137,7 @@ lemma isEllipticSequence_polyToField_ψ :
   have h : (fun n : ℤ ↦ polyToField (curve.ψ n))
       = normEDS (polyToField curve.ψ₂) (polyToField (Polynomial.C curve.Ψ₃))
           (polyToField (Polynomial.C curve.preΨ₄)) := by
-    funext n; rw [← _root_.map_normEDS]; rfl
+    funext n; rw [ψ_eq_normEDS, _root_.map_normEDS]
   rw [h]
   exact isEllipticSequence_normEDS _ _ _
 

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
@@ -38,8 +38,8 @@ the division polynomials.
   bookkeeping; the `b ^ 4` rescaling is untouched, being the same inside `complEDS₂Aux` as inside
   `normEDS`. This is the companion of Mathlib's `complEDS₂_mul_b`, and it is why the definition is
   stated with `preNormEDS` rather than `normEDS`.
-* `complEDS₂Aux_two`: the auxiliary term vanishes at `2`, since `preNormEDS _ _ _ 0`
-  does.
+* `complEDS₂Aux_zero`, `complEDS₂Aux_one`, `complEDS₂Aux_two`: the values at the base indices,
+  `-1`, `-b` and `0` — the last since `preNormEDS _ _ _ 0` vanishes.
 * `map_complEDS₂Aux`: it is natural in the coefficient ring.
 
 ## Implementation notes
@@ -91,6 +91,16 @@ have `simp` unfold `complEDS₂Aux` everywhere and defeat the point of naming th
 theorem complEDS₂Aux_def : complEDS₂Aux b c d m =
     preNormEDS (b ^ 4) c d (m - 2) * preNormEDS (b ^ 4) c d (m + 1) ^ 2 *
       if Even m then 1 else b := (rfl)
+
+/-- The auxiliary term at `0` is `-1`: its first factor is `preNormEDS _ _ _ (-2) = -1` and the
+other two are `1`. -/
+@[simp]
+theorem complEDS₂Aux_zero : complEDS₂Aux b c d 0 = -1 := by simp [complEDS₂Aux_def]
+
+/-- The auxiliary term at `1` is `-b`: its first factor is `preNormEDS _ _ _ (-1) = -1` and the
+index is odd, so the parity factor contributes the `b`. -/
+@[simp]
+theorem complEDS₂Aux_one : complEDS₂Aux b c d 1 = -b := by simp [complEDS₂Aux_def]
 
 /-- The auxiliary term vanishes at `2`: its first factor is `preNormEDS _ _ _ 0`. -/
 @[simp]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/ComplAux.lean
@@ -92,13 +92,11 @@ theorem complEDS₂Aux_def : complEDS₂Aux b c d m =
     preNormEDS (b ^ 4) c d (m - 2) * preNormEDS (b ^ 4) c d (m + 1) ^ 2 *
       if Even m then 1 else b := (rfl)
 
-/-- The auxiliary term at `0` is `-1`: its first factor is `preNormEDS _ _ _ (-2) = -1` and the
-other two are `1`. -/
+/-- The auxiliary term at `0` is `-1`. -/
 @[simp]
 theorem complEDS₂Aux_zero : complEDS₂Aux b c d 0 = -1 := by simp [complEDS₂Aux_def]
 
-/-- The auxiliary term at `1` is `-b`: its first factor is `preNormEDS _ _ _ (-1) = -1` and the
-index is odd, so the parity factor contributes the `b`. -/
+/-- The auxiliary term at `1` is `-b`. -/
 @[simp]
 theorem complEDS₂Aux_one : complEDS₂Aux b c d 1 = -b := by simp [complEDS₂Aux_def]
 


### PR DESCRIPTION
> **Based directly on `main`** — its former parents (#3845's original content and #3861) have
> merged, so the diff now shows only this PR's own increment: the new files
> `DivisionPolynomial/Omega.lean` and `DivisionPolynomial/NormEDS.lean`, the two
> `complEDS₂Aux` value lemmas in `ComplAux.lean`, and the docstring syncs in
> `DivisionPolynomial/Universal.lean` and `Invariant.lean`.

The `ω` family of division polynomials — the polynomial the scalar-multiplication development
identifies as the second Jacobian coordinate, completing Mathlib's `(φ, ψ)` pair.

```lean
protected def ψc : ℤ → R[X][Y] := complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄)
protected def ω (n : ℤ) : R[X][Y] := reducedInvarDenom W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) n * (…) - …

theorem ω_spec (n : ℤ) : 2 * W.ω n + CC W.a₁ * W.φ n * W.ψ n + CC W.a₃ * W.ψ n ^ 3 = W.ψc n
theorem ψ_mul_ψc (n : ℤ) : W.ψ n * W.ψc n = W.ψ (2 * n)
theorem ω_neg (n : ℤ) : W.ω (-n) = W.ω n + CC W.a₁ * W.φ n * W.ψ n + CC W.a₃ * W.ψ n ^ 3
```

plus the equation lemmas `ω_def` and `ψc_def` (both bodies are unexposed; `ω_spec` alone fixes
only `2 ω n`, which determines nothing where `2` is a zero divisor — `ω_def` is the
unconditional handle), `two_mul_ω`, `ω_zero`, `ω_one`, `ψc_neg`, `map_ψc`, `map_ω`, and the
algebra-tower forms `baseChange_ψc`/`baseChange_ω` in Mathlib's `baseChange_ψ` shape. The
generic bridge `ψ_eq_normEDS` and `isEllipticSequence_ψ` live in the small new
`DivisionPolynomial/NormEDS.lean` at exactly the Mathlib-`Basic` + EDS-`NormEDS` level, so both
this file and the earlier `DivisionPolynomial/Universal.lean` (which previously re-derived the
identification inline) consume them from below.

## What it closes

`DivisionPolynomial/Invariant.lean`'s module docstring has carried an inventory of "what is
deliberately not here": `ω` and its API, pending `redInvar_normEDS`. That identity landed as
`reducedInvarNum_eq_reducedInvarDenom_mul` (previous PR in this chain), and this file is the
inventory's payoff — every rewrite input of `ω_spec` now exists by name:
`complEDS₂_eq_reducedInvarNum_sub`, the reduced-invariant identity,
`preΨ₄_add_ψ₂_pow_four`, `φ_mul_ψ`, `invarDenom_normEDS_one_eq_reducedInvarDenom_mul`.

`ω_neg` cannot be proved over a general `CommRing` directly — it is read off `two_mul_ω` by
cancelling `2`. The proof therefore runs over the universal curve, where the coefficient ring
is a polynomial ring over `ℤ` and `2` is a nonzerodivisor, and specialises along
`map_specialize` — the same universal-specialisation route as
`Invariant/NormEDS.lean` and `ReducedInvariant.lean` one level down.

## Reuse

`WeierstrassCurve.ω`, `ψc`, `ω_spec` return nothing on `origin/main` in `TauCeti/` and nothing
in pinned Mathlib's `AlgebraicGeometry/EllipticCurve/` tree (positive control: `ψ₂`, `preΨ₄`,
`normEDS_mul_complEDS₂` all found where expected). `DivisionPolynomial/Invariant.lean` and
`DivisionPolynomial/Universal.lean` both record `ω` as absent-by-name in their module
docstrings — a documented-pending absence, now closed.

## Gates

Full-library `lake build` PASS with the whole stack, plus `lint-env` (`simpNF` included),
`axioms` (allowlist only), `module-system` and `lint-style`. Longest proof (`ω_spec`) is ten
directed rewrites, a closing `simp only` normalisation (the definitional unfolds live there,
per review), and `ring1` — 11 lines; `ω_zero`/`ω_one` are three-rewrite proofs through the
named values `reducedInvarDenom_zero`/`_one` and `complEDS₂Aux_zero`/`_one` (the latter pair
added beside `complEDS₂Aux_two`, per review); no `sorry`, no `set_option`, no `maxHeartbeats`.
New `@[simp]`: `ω_zero`, `ω_one`, `ψc_neg`, `ω_neg` (per the api-design round — its siblings
all normalise the negative index), `map_ψc`, `map_ω`, and the two `complEDS₂Aux` values —
value/naturality lemmas in the shape of their `φ`/`ψ` siblings; the equation lemmas `ψc_def`
and `ω_def` are deliberately untagged, so no rewrite competes with the value lemmas on the
same head.

## Review history

kbuzzard's seven-rubric round (board at `6f5d73fd7`) is applied in the `review:` commit at this
head: `ω_def` + `@[simp] ω_neg` + protected `ψc` + `baseChange_*` (api-design), the
`DivisionPolynomial/NormEDS.lean` relocation with `Universal.lean` consuming it (placement —
the reviewer's own new-file option; moving into `Universal.lean` itself would cycle with the
next PR's `Universal → Omega` import), the named-value `ω_zero`/`ω_one` proofs plus the
`complEDS₂Aux` value pair (proof-quality), the Mathlib-docstring credit whose `TODO` this file
discharges (attribution), and the docstring syncs in `Universal.lean`/`Invariant.lean`
(correctness/naming/documentation).

## Roadmap

New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
Nagell–Lutz**", whose route is the division-polynomial formula for `n • P`; `ω` is that
formula's `Y`-coordinate half, and `README.md:1163` (the Layer-6 NagellLutz entry) pins the
AINTLIB project this ports. The onward consumer is `ZSMul` (`zsmul_point_eq_smulX_smulY`),
whose universal layer is already partly in `DivisionPolynomial/Universal.lean`.

## Provenance

Ported from J. Xu and D. K. Angdinata's `LutzNagell/DivisionPolynomialOmega.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`)
— the `ω` half; the invariant half of that file is already in
`DivisionPolynomial/Invariant.lean`. Declarations `ψc`, `ω`, `ω_spec`, `two_mul_ω`, `ψc_spec`
(here `ψ_mul_ψc`, naming its left-hand side), `ω_zero`, `ω_one`, `ψc_neg`, `map_ω`,
`universal_ω_neg`, `ω_neg`, `isEllSequence_ψ` (here `isEllipticSequence_ψ`, Mathlib's predicate
name). The source file's header reads `Authors: Junyan Xu, David Kurniadi Angdinata`; per this
repository's convention the upstream authorship is credited in the module docstring rather
than the copyright header.

Departures, each forced by this repository's module system or linters: the source's
`rw […, ψ, …, ← ψ, …]` def-unfolds become `ψ_eq_normEDS` (protected `ψ`'s per-application
equation misses the unapplied occurrence) and `invar_def` (unexposed body); the local `C_simp`
macro is written out at its use site with the minimal list the `unusedSimpArgs` linter accepts;
`ψc_def` is added for downstream modules; and `two_ne_zero` is applied at `Universal.Poly`
rather than through the source's project-local `Universal.Poly.two_ne_zero`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-omega"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
