### PR TITLE
feat(EllipticCurve): the universal psic and omega at the cusp, and the omega transport

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -168,12 +168,12 @@ lemma evalEval_ω : (W.ω n).evalEval x y = polyEval W x y (curve.ω n) := by
 lemma polyEval_cusp_ψc : polyEval (cusp ℤ) 1 1 (curve.ψc n) = 2 := by
   rw [ψc_def, map_complEDS₂, ← evalEval_ψ₂, ← evalEval_Ψ₃, ← evalEval_preΨ₄, cusp_ψ₂,
     cusp_Ψ₃, cusp_preΨ₄]
-  simp [evalEval, complEDS₂_two_three_two]
+  simp [evalEval]
 
-/-- **On the cusp curve at `(1, 1)`, `ω n` evaluates to `1`.** The cusp evaluation of
-`two_mul_ω`, with every other term known: `ψc` gives `2`, `φ` gives `1`, and the cusp's
-`a₁` and `a₃` vanish, so twice the value is `2`. -/
+/-- **On the cusp curve at `(1, 1)`, `ω n` evaluates to `1`.** -/
 lemma polyEval_cusp_ω : polyEval (cusp ℤ) 1 1 (curve.ω n) = 1 := by
+  -- Evaluate `two_mul_ω` at the cusp: `ψc` gives `2`, `φ` gives `1`, the cusp's `a₁` and `a₃`
+  -- vanish, so twice the value is `2`.
   have h := congr(polyEval (cusp ℤ) 1 1 $(two_mul_ω curve n))
   rw [map_mul (polyEval (cusp ℤ) 1 1), map_sub (polyEval (cusp ℤ) 1 1),
     map_sub (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -24,12 +24,14 @@ Each proof is the same two steps: unfold `polyEval` into a `map` followed by `ev
 ## Main results
 
 * `WeierstrassCurve.Universal.evalEval_ψ₂`, `.evalEval_Ψ₃`, `.evalEval_preΨ₄`, `.evalEval_ψ`,
-  `.evalEval_φ`: the polynomials `ψ₂`, `Ψ₃`, `ψₙ` and `φₙ` of `W` at `(x, y)`, together with the
-  auxiliary `preΨ₄`, are the universal ones evaluated through `Universal.polyEval`.
+  `.evalEval_φ`, `.evalEval_ω`, `.evalEval_ψc`: the polynomials `ψ₂`, `Ψ₃`, `ψₙ`, `φₙ`, `ωₙ` and
+  the complement `ψc n` of `W` at `(x, y)`, together with the auxiliary `preΨ₄`, are the
+  universal ones evaluated through `Universal.polyEval`.
 * `WeierstrassCurve.Universal.isEllipticSequence_polyToField_ψ`: the universal `ψ` family, taken
   into `Universal.Field`, is an elliptic sequence.
-* `WeierstrassCurve.Universal.polyEval_cusp_ψ`, `.polyEval_cusp_φ`: specialised to the cusp curve
-  at `(1, 1)`, `ψₙ` evaluates to `n` itself and the numerator `φₙ` to `1`.
+* `WeierstrassCurve.Universal.polyEval_cusp_ψ`, `.polyEval_cusp_φ`, `.polyEval_cusp_ψc`,
+  `.polyEval_cusp_ω`: specialised to the cusp curve at `(1, 1)`, `ψₙ` evaluates to `n` itself,
+  the numerator `φₙ` to `1`, the complement `ψc n` to `2`, and `ωₙ` to `1`.
 
 ## Implementation notes
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Cusp
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Omega
-public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
 
 /-!
 # Division polynomials of the universal curve
@@ -163,6 +162,10 @@ lemma polyEval_cusp_φ : polyEval (cusp ℤ) 1 1 (curve.φ n) = 1 := by
 /-- The `ω`-division polynomial of `W` at `(x, y)` is the universal one under `polyEval`. -/
 lemma evalEval_ω : (W.ω n).evalEval x y = polyEval W x y (curve.ω n) := by
   simp_rw [polyEval_apply, ← map_ω, map_specialize]
+
+/-- The complement `ψc n` of `W` at `(x, y)` is the universal one under `polyEval`. -/
+lemma evalEval_ψc : (W.ψc n).evalEval x y = polyEval W x y (curve.ψc n) := by
+  simp_rw [polyEval_apply, ← map_ψc, map_specialize]
 
 /-- **On the cusp curve at `(1, 1)`, the complement `ψc n` evaluates to `2`.** -/
 lemma polyEval_cusp_ψc : polyEval (cusp ℤ) 1 1 (curve.ψc n) = 2 := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Cusp
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Omega
 
@@ -178,9 +177,7 @@ lemma polyEval_cusp_ω : polyEval (cusp ℤ) 1 1 (curve.ω n) = 1 := by
   -- Evaluate `two_mul_ω` at the cusp: `ψc` gives `2`, `φ` gives `1`, the cusp's `a₁` and `a₃`
   -- vanish, so twice the value is `2`.
   have h := congr(polyEval (cusp ℤ) 1 1 $(two_mul_ω curve n))
-  rw [map_mul (polyEval (cusp ℤ) 1 1), map_sub (polyEval (cusp ℤ) 1 1),
-    map_sub (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),
-    map_mul (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),
+  simp only [map_mul (polyEval (cusp ℤ) 1 1), map_sub (polyEval (cusp ℤ) 1 1),
     map_pow (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψc, polyEval_cusp_ψ, polyEval_cusp_φ] at h
   simpa [polyEval_apply, evalEval] using h
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Cusp
-public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.NormEDS
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Omega
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Universal
 
 /-!
@@ -55,20 +55,21 @@ first-order, and the same for `map_mul` and `map_pow`. That leaves the arithmeti
 `polyEval (cusp ℤ) 1 1 (C X) * n ^ 2 - (n + 1) * (n - 1) = 1`, which `ring` closes once `C X`
 evaluates to `1`.
 
-The remaining companions — `polyEval_cusp_ψc`, `polyEval_cusp_ω` and the transport `evalEval_ω`
-— are **not** here, and no longer for want of prerequisites: `ψc`, `ω`, `two_mul_ω` and `map_ω`
-all live in `DivisionPolynomial/Omega.lean`, downstream of the reduced-invariant identity this
-passage used to track. They are the cusp-value slice's own topic: stating them here would add an
-`Omega.lean` import for three lemmas that ship together with that development, so they arrive
-with it instead.
+The remaining two companions, `polyEval_cusp_ψc` and `polyEval_cusp_ω`, together with the sixth
+transport `evalEval_ω`, needed `ψc`, `two_mul_ω` and `map_ω` — the `ω` API this passage once
+recorded as not yet here. `DivisionPolynomial/Omega.lean` now supplies all three, on top of
+`reducedInvarNum_eq_reducedInvarDenom_mul`, so they are below: `evalEval_ω` closes the transport
+family, `polyEval_cusp_ψc` reads the complement off `complEDS₂_two_three_two`, and
+`polyEval_cusp_ω` divides the cusp evaluation of `two_mul_ω` by two.
 
 ## Provenance
 
 Adapted from `LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0),
 at `dev/modular-curves @ 9fec8eba7652` — the revision `TauCetiRoadmap/EllipticCurves/README.md`
 pins for the NagellLutz project. Declarations `Universal.evalEval_ψ₂`, `evalEval_Ψ₃`,
-`evalEval_preΨ₄`, `evalEval_ψ` and `evalEval_φ`; the sixth, `evalEval_ω`, is excluded for the
-reason above. `isEllipticSequence_polyToField_ψ` adapts that same file's `isEllSequence_ψᵤ`.
+`evalEval_preΨ₄`, `evalEval_ψ`, `evalEval_φ` and (added with the `ω` port, read at
+`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`) `evalEval_ω`.
+`isEllipticSequence_polyToField_ψ` adapts that same file's `isEllSequence_ψᵤ`.
 That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`; following this
 repository's convention for adapted material the upstream authorship is credited here rather than
 in the copyright header.
@@ -80,7 +81,10 @@ qualifying, because this file opens `Universal` rather than `WeierstrassCurve` a
 redundant here, since #3364's general `normEDS_two_three_two_eq_intCast` is `@[simp]` and reaches
 the same normal form first. And `polyEval_cusp_φ`'s proof is restructured for the reason given
 above: the source's unfold of `polyEval` is unavailable, so each `map_*` names its ring hom.
-The source's `polyEval_cusp_ψc` and `polyEval_cusp_ω` are excluded.
+The source's `polyEval_cusp_ψc` and `polyEval_cusp_ω` are adapted below (read at
+`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), with the same two mechanical changes as
+their siblings — qualified names, ring-hom-named `map_*` rewrites in place of unfolding
+`polyEval` — plus `ψc_def` in place of unfolding `ψc`, whose body is likewise unexposed.
 
 The `evalEval_*` statements are the source's unchanged. Docstrings are added here, and the
 source's shared `variable {m n : ℤ}` is narrowed to `n`: of those five only `evalEval_ψ` and
@@ -155,6 +159,27 @@ lemma polyEval_cusp_φ : polyEval (cusp ℤ) 1 1 (curve.φ n) = 1 := by
     polyEval_cusp_ψ, polyEval_cusp_ψ]
   simp [polyEval_apply, evalEval]
   ring
+
+/-- The `ω`-division polynomial of `W` at `(x, y)` is the universal one under `polyEval`. -/
+lemma evalEval_ω : (W.ω n).evalEval x y = polyEval W x y (curve.ω n) := by
+  simp_rw [polyEval_apply, ← map_ω, map_specialize]
+
+/-- **On the cusp curve at `(1, 1)`, the complement `ψc n` evaluates to `2`.** -/
+lemma polyEval_cusp_ψc : polyEval (cusp ℤ) 1 1 (curve.ψc n) = 2 := by
+  rw [ψc_def, map_complEDS₂, ← evalEval_ψ₂, ← evalEval_Ψ₃, ← evalEval_preΨ₄, cusp_ψ₂,
+    cusp_Ψ₃, cusp_preΨ₄]
+  simp [evalEval, complEDS₂_two_three_two]
+
+/-- **On the cusp curve at `(1, 1)`, `ω n` evaluates to `1`.** The cusp evaluation of
+`two_mul_ω`, with every other term known: `ψc` gives `2`, `φ` gives `1`, and the cusp's
+`a₁` and `a₃` vanish, so twice the value is `2`. -/
+lemma polyEval_cusp_ω : polyEval (cusp ℤ) 1 1 (curve.ω n) = 1 := by
+  have h := congr(polyEval (cusp ℤ) 1 1 $(two_mul_ω curve n))
+  rw [map_mul (polyEval (cusp ℤ) 1 1), map_sub (polyEval (cusp ℤ) 1 1),
+    map_sub (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),
+    map_mul (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),
+    map_pow (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψc, polyEval_cusp_ψ, polyEval_cusp_φ] at h
+  simpa [polyEval_apply, evalEval] using h
 
 end Universal
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -85,8 +85,9 @@ their siblings — qualified names, ring-hom-named `map_*` rewrites in place of 
 `polyEval` — plus `ψc_def` in place of unfolding `ψc`, whose body is likewise unexposed.
 
 The `evalEval_*` statements are the source's unchanged. Docstrings are added here, and the
-source's shared `variable {m n : ℤ}` is narrowed to `n`: of those five only `evalEval_ψ` and
-`evalEval_φ` carry an index, and both use `n` alone. `isEllSequence_ψᵤ` is stated upstream through
+source's shared `variable {m n : ℤ}` is narrowed to `n`: of the seven transports only
+`evalEval_ψ`, `evalEval_φ`, `evalEval_ω` and `evalEval_ψc` carry an index, and all four use `n`
+alone. `isEllSequence_ψᵤ` is stated upstream through
 an `abbrev ψᵤ` and its own `ψᵤ_eq_normEDS`; here the abbreviation is dropped, the identification
 of `ψ` with `normEDS` is the named `ψ_eq_normEDS` (`DivisionPolynomial/NormEDS.lean`), and a
 `have` transports it through `polyToField`, so the statement is spelled on
@@ -175,10 +176,12 @@ lemma polyEval_cusp_ψc : polyEval (cusp ℤ) 1 1 (curve.ψc n) = 2 := by
 /-- **On the cusp curve at `(1, 1)`, `ω n` evaluates to `1`.** -/
 lemma polyEval_cusp_ω : polyEval (cusp ℤ) 1 1 (curve.ω n) = 1 := by
   -- Evaluate `two_mul_ω` at the cusp: `ψc` gives `2`, `φ` gives `1`, the cusp's `a₁` and `a₃`
-  -- vanish, so twice the value is `2`.
+  -- vanish, so `h` collapses to `2 * (the goal's left side) = 2` and the `2` cancels.
   have h := congr(polyEval (cusp ℤ) 1 1 $(two_mul_ω curve n))
   simp only [map_mul (polyEval (cusp ℤ) 1 1), map_sub (polyEval (cusp ℤ) 1 1),
     map_pow (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψc, polyEval_cusp_ψ, polyEval_cusp_φ] at h
+  -- The residual `a₁`/`a₃` terms sit under `CC`, whose body is unexposed and has no cusp value
+  -- lemma, so no named rewrite can kill them; evaluating the wrappers is the one route left.
   simpa [polyEval_apply, evalEval] using h
 
 end Universal

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -60,6 +60,9 @@ distinction where the identity is proved.
   in normal form and `simpNF` fails the build.
 * `universalNormEDS_ne_zero`: the universal sequence vanishes only at `0`, which is what the
   previous item buys.
+* `complEDS₂_two_three_two`: the 2-complement of the identity sequence is the constant `2` —
+  `complEDS₂ (2 : R) 3 2 n = 2` over any commutative ring, transported from the `ℤ` case along
+  `Int.castRingHom` exactly as `normEDS_two_three_two_eq_intCast`.
 
 The first consumer this unlocks is `IsEllipticNet.invarNum_mul_invarDenom`, which callers can
 apply to `isEllipticNet_normEDS` directly; it is deliberately not restated here as a

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -119,6 +119,13 @@ is `Descent.lean`'s `IsEllipticNet.of_rel`, fed the two recurrences in relator f
 is six lines rather than a file. The universal transport is the source's argument, with
 `normEDS_eq_aeval` in place of its inline rewriting.
 
+`complEDS₂_two_three_two` adapts that same file's `compl₂EDS_two_three_two` (`:1243`, at the
+`main` revision named above), restated over an arbitrary commutative ring — the source states
+only the `ℤ` case — and rerouted: the `ℤ` proof reads the value off Mathlib's `complEDS₂_mul_b`
+at the identity sequence, with no case split, where the source cancels `n` off
+`normEDS_mul_complEDS₂` behind an `n = 0` split; the general form transports along
+`Int.castRingHom`, exactly as `normEDS_two_three_two_eq_intCast` above.
+
 `universalNormEDS_ne_zero` adapts the same file's `universalNormEDS_ne_zero` (`:1251`) at the
 roadmap's NagellLutz pin `dev/modular-curves @ 9fec8eba7652`. One departure: the source proves it
 by `simp only [universalNormEDS, …]`, unfolding the definition. That does not port —

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -178,6 +178,17 @@ theorem normEDS_two_three_two_eq_id : normEDS (2 : ℤ) 3 2 = id := by
   · simp
   · simp
 
+/-- **The 2-complement of the identity sequence is the constant `2`**: for `normEDS 2 3 2`
+on `ℤ`, the complement of `n` in `2n`. At `n = 0` this is Mathlib's `complEDS₂_zero`; away
+from `0` it is read off `normEDS_mul_complEDS₂` by cancelling `n`. -/
+theorem complEDS₂_two_three_two (n : ℤ) : complEDS₂ (2 : ℤ) 3 2 n = 2 := by
+  obtain rfl | hn := eq_or_ne n 0
+  · exact complEDS₂_zero ..
+  · have h := normEDS_mul_complEDS₂ (2 : ℤ) 3 2 n
+    rw [normEDS_two_three_two_eq_id] at h
+    simp only [id] at h
+    exact mul_right_cancel₀ hn (by linarith)
+
 /-- **`normEDS 2 3 2` is the integer cast, over any commutative ring.** The identity on `ℤ`
 transported along the unique ring map out of it. -/
 @[simp]

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -191,7 +191,9 @@ private theorem complEDS₂_two_three_two_int (n : ℤ) : complEDS₂ (2 : ℤ) 
   have h := complEDS₂_mul_b (b := (2 : ℤ)) (c := 3) (d := 2) n
   rw [normEDS_two_three_two_eq_id] at h
   simp only [id_eq] at h
-  rw [show (n - 1) ^ 2 * (n + 2) - (n - 2) * (n + 1) ^ 2 = 4 by ring] at h
+  -- `omega` is linear, so the cubic right side must first collapse to the constant it equals.
+  have h4 : (n - 1) ^ 2 * (n + 2) - (n - 2) * (n + 1) ^ 2 = 4 := by ring
+  rw [h4] at h
   omega
 
 /-- **The 2-complement of `normEDS 2 3 2` is the constant `2`, over any commutative ring**:

--- a/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
+++ b/TauCeti/NumberTheory/EllipticDivisibilitySequence/NormEDS.lean
@@ -178,16 +178,23 @@ theorem normEDS_two_three_two_eq_id : normEDS (2 : ℤ) 3 2 = id := by
   · simp
   · simp
 
-/-- **The 2-complement of the identity sequence is the constant `2`**: for `normEDS 2 3 2`
-on `ℤ`, the complement of `n` in `2n`. At `n = 0` this is Mathlib's `complEDS₂_zero`; away
-from `0` it is read off `normEDS_mul_complEDS₂` by cancelling `n`. -/
-theorem complEDS₂_two_three_two (n : ℤ) : complEDS₂ (2 : ℤ) 3 2 n = 2 := by
-  obtain rfl | hn := eq_or_ne n 0
-  · exact complEDS₂_zero ..
-  · have h := normEDS_mul_complEDS₂ (2 : ℤ) 3 2 n
-    rw [normEDS_two_three_two_eq_id] at h
-    simp only [id] at h
-    exact mul_right_cancel₀ hn (by linarith)
+/-- The 2-complement of the identity sequence on `ℤ` is the constant `2`. -/
+private theorem complEDS₂_two_three_two_int (n : ℤ) : complEDS₂ (2 : ℤ) 3 2 n = 2 := by
+  -- Read off `complEDS₂_mul_b`, whose right side is `4` once `normEDS 2 3 2 = id`.
+  have h := complEDS₂_mul_b (b := (2 : ℤ)) (c := 3) (d := 2) n
+  rw [normEDS_two_three_two_eq_id] at h
+  simp only [id_eq] at h
+  rw [show (n - 1) ^ 2 * (n + 2) - (n - 2) * (n + 1) ^ 2 = 4 by ring] at h
+  omega
+
+/-- **The 2-complement of `normEDS 2 3 2` is the constant `2`, over any commutative ring**:
+the complement of `n` in `2n` for the integer-cast sequence. -/
+@[simp]
+theorem complEDS₂_two_three_two (R : Type*) [CommRing R] (n : ℤ) :
+    complEDS₂ (2 : R) 3 2 n = 2 := by
+  have h := map_complEDS₂ (f := Int.castRingHom R) (b := (2 : ℤ)) (c := 3) (d := 2) n
+  rw [complEDS₂_two_three_two_int] at h
+  simpa using h.symm
 
 /-- **`normEDS 2 3 2` is the integer cast, over any commutative ring.** The identity on `ℤ`
 transported along the unique ring map out of it. -/


### PR DESCRIPTION
> Based directly on `main` (the `ω` PR #3862 merged); the diff is this PR's own increment — the three lemmas + prose in `DivisionPolynomial/Universal.lean` and one value lemma in `EllipticDivisibilitySequence/NormEDS.lean`.

The universal `ψc` and `ω` at the cusp, and the sixth transport — the three declarations
`DivisionPolynomial/Universal.lean` recorded as "arriving with `ω`", now that it has.

```lean
lemma evalEval_ψc : (W.ψc n).evalEval x y = polyEval W x y (curve.ψc n)
lemma evalEval_ω  : (W.ω n).evalEval x y  = polyEval W x y (curve.ω n)
lemma polyEval_cusp_ψc : polyEval (cusp ℤ) 1 1 (curve.ψc n) = 2
lemma polyEval_cusp_ω  : polyEval (cusp ℤ) 1 1 (curve.ω n) = 1
```

with one new EDS value lemma they rest on, beside its `normEDS` sibling in `NormEDS.lean` and
in the same general form:

```lean
@[simp] theorem complEDS₂_two_three_two (R) [CommRing R] (n : ℤ) : complEDS₂ (2 : R) 3 2 n = 2
```

## Shape

`evalEval_ψc` and `evalEval_ω` close the transport family with exactly their siblings' one-line
proof (`polyEval_apply`, `← map_ψc`/`← map_ω`, `map_specialize`). `polyEval_cusp_ψc` pulls the
three parameters back through the `evalEval_*` transports to the cusp values `2, 3, 2` and the
goal closes from the simp set. `complEDS₂_two_three_two` is stated over any commutative ring,
transported from a private `ℤ` form along `Int.castRingHom` exactly as
`normEDS_two_three_two_eq_intCast`; the `ℤ` proof reads the value off `complEDS₂_mul_b` at the
identity sequence, with no case split. `polyEval_cusp_ω` evaluates `two_mul_ω` at the cusp,
where `ψc` gives `2`, `φ` gives `1`, and the cusp's `a₁`, `a₃` vanish. The two redundant direct
imports the `Omega` edge created are dropped, as is the direct Mathlib `DivisionPolynomial.Basic`
import that `Cusp.lean` publicly re-exports (review round), and both module-docstring passages
that recorded this material as pending are updated to say it arrived.

## Reuse

`complEDS₂_two_three_two`, `polyEval_cusp_ψc`, `polyEval_cusp_ω`, `evalEval_ω` return nothing
on `origin/main` in `TauCeti/` and nothing in pinned Mathlib (positive controls:
`normEDS_two_three_two_eq_id`, `polyEval_cusp_ψ`, `complEDS₂_zero` all found where expected).

## Gates

LSP zero-diagnostics on both files after the one build-caught fix (the `polyEval_cusp_ω`
finisher: the residual after `simp at h` is the `polyEval_apply` spelling of `h` itself, not
arithmetic — `simpa` closes it, `omega` cannot). `polyEval_cusp_ω`'s hom pushes name each
`map_*` lemma once in a `simp only` (review round; the two-stage shape is load-bearing — the
closing `simpa` switches spelling to `specialize`/`eval`, after which the cusp-value lemmas
cannot match). Proofs of 1–7 lines. One new `@[simp]`: `complEDS₂_two_three_two`, a value
lemma with no competing rewrite on its head — full-library `lint-env` (`simpNF` included)
passes with it. No `sorry`/`set_option`.

## Roadmap

New mathematics on the same target as its parent PR: `TauCetiRoadmap/EllipticCurves/README.md:821`
(Nagell–Lutz via division polynomials); these are the cusp normalisation facts `ZSMul`'s
specialisation arguments consume.

## Provenance

Adapted from J. Xu and D. K. Angdinata's `LutzNagell/ZSMul.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
declarations `evalEval_ω` (source `:105`), `polyEval_cusp_ψc` (`:122`), `polyEval_cusp_ω`
(`:126`), and `LutzNagell/EllipticDivisibilitySequence.lean`'s `compl₂EDS_two_three_two`
(`:1243`). Changes: the ring-hom-named `map_*` rewrites replace the source's `polyEval` unfold
(unexposed body, as for their landed siblings); `ψc_def` replaces the `ψc` unfold; the
`polyEval_cusp_ω` tail replaces the source's `simpa [cusp, polyEval, specialize, curve]` —
four unexposed definitions — with `simpa [polyEval_apply, evalEval]`. Authorship credited in
the module docstrings per convention.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-omega-cusp"}-->

🤖 Prepared with Claude Code (Claude Opus 5)

