### PR TITLE
docs(Isogeny): record that instTorsionFreeB is deliberately absent

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Basic.lean
@@ -105,6 +105,22 @@ a fixed extension with the algebra structures supplied as instance arguments, wh
 takes the pullback-induced structure locally and assumes no separability. None of the declarations
 below is a transcription of a source declaration.
 
+**`instTorsionFreeB` is unported but not missing, and should stay unported.** Its content is
+available from the two embeddings below composed with Mathlib's
+`Module.isTorsionFree_iff_algebraMap_injective`: a consumer holding the corestricted algebra
+structures writes
+
+```
+Module.isTorsionFree_iff_algebraMap_injective.mpr φ.toIntermediateRing_injective
+Module.isTorsionFree_iff_algebraMap_injective.mpr φ.pullbackToIntermediateRing_injective
+```
+
+for the source and target sides. Named `isTorsionFree_intermediateRing` lemmas of exactly that shape
+were written and then **deleted in review**, as one-step wrappers of that `iff` with no in-repo
+consumer: a `theorem` carrying an explicit pointwise hypothesis can never be selected by instance
+search, so it saves a caller nothing over the one-liner. Read "not ported" as "deliberately
+absent, content reachable in one step" rather than as a gap to be filled.
+
 ## References
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.


### PR DESCRIPTION
The provenance note in `IntermediateRing/Basic.lean` said only that `instFractionRingB` and
`instTorsionFreeB` are "not ported". Read literally that describes a **gap**, and it invites exactly
the change it should prevent.

Named `Isogeny.isTorsionFree_intermediateRing_source`/`_target` lemmas were written on the branch
that added the coordinate-ring embeddings and **deleted there in review**: the `reuse` rubric found
them to be one-step wrappers of Mathlib's `Module.isTorsionFree_iff_algebraMap_injective` with no
in-repo consumer, and it was right — a `theorem` carrying an explicit pointwise hypothesis can never
be selected by instance search, so it saves a caller nothing over the one-liner.

The note now records three things the old wording left out:

* the torsion-free content is **reachable in one step** from the two embeddings already in this file,
* the one-liner a consumer actually writes, for each of the source and target sides,
* that the absence is **deliberate**, so "not ported" reads as "content reachable in one step"
  rather than as work to be done.

Documentation only — no declaration, statement, proof or import changes.

## Why this is worth a PR

This is not hypothetical tidying. Working the isogeny lane today I read "not ported", concluded the
instances were missing, and wrote the file — 123 lines, both instances — before finding the earlier
branch's own description of why it had been removed. Deleted unbuilt. Those two lemmas have now been
proposed three times; the note is the only place a fourth attempt would be caught, and as written it
pointed the wrong way.

## Gates

`lake build` green across `Basic`, `Dedekind`, `Finite` and `IntegrallyClosed` (2567 jobs);
`scripts/lint-style.sh` clean; `lean_diagnostic_messages` empty; no line over 100 codepoints.

## Review status

**Opened without a scoreboard.** Both codex credentials on this machine are over quota until
2026-08-20 04:30, verified by a real single-rubric run rather than a token probe. A dead provider
does not surface as an error — the run reports `verdict=PARSE_FAILED cost=$0.0000` while the
scoreboard reads *changes requested* — so posting one would make a fake blocking verdict the
canonical record, since `merge_from_scoreboard.py` takes the newest scoreboard by `updated_at` with
no access bar. Same reasoning as #3406, #3392, #3361 and #3405.

Note also that `review.yml` is currently `disabled_manually`, so no automated review fires on this
PR; `pr-build` is active and will build it. A full-rubric board on subscription codex follows after
the reset if it is still unreviewed.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"intermediatering-torsionfree-note"}-->

Provenance: documents a decision already recorded on this repository's own branch history; the
upstream fact is `instTorsionFreeB` of `projects/HasseWeil/HasseWeil/Curves/NormConormIntegralClosure.lean`
in `github.com/CBirkbeck/AINTLIB` @ `2baa76f742bdb4fb8ee323fabba41203bd390e08` (Apache-2.0, by Chris
Birkbeck), which remains deliberately unported. No source material is transcribed.
