### PR TITLE
feat(Huber): a Huber ring is first countable at zero

### DIFF
--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -43,6 +43,9 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
   inducing map. This is what lets a ring of definition carry an ideal of definition that natively
   lives in a merely equivalent ring, which is what `TauCeti.Huber.PairOfDefinition` needs.
 * `TauCeti.Huber.IsHuberRing.toNonarchimedeanRing`: a Huber ring is nonarchimedean.
+* `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`: its neighbourhoods of zero are
+  countably generated. With the previous bullet these are exactly the two hypotheses Henkel's open
+  mapping theorem asks of the underlying group, so both are instances.
 * `TauCeti.Huber.IsHuberRing.quotient`: a quotient of a Huber ring is a Huber ring.
 * `TauCeti.Huber.PairOfDefinition.isBounded_ringOfDefinition`: a ring of definition is bounded,
   hence `A₀ ≤ A°` (`TauCeti.Huber.PairOfDefinition.le_powerBoundedSubring`). This is the
@@ -463,6 +466,20 @@ variable (A : Type*) [CommRing A] [TopologicalSpace A] [IsTopologicalRing A] [Is
 /-- Every Huber ring is nonarchimedean. This is what makes `A°` a subring. -/
 instance (priority := 100) IsHuberRing.toNonarchimedeanRing : NonarchimedeanRing A :=
   IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦ P.toNonarchimedeanRing
+
+/-- **The neighbourhoods of zero in a Huber ring are countably generated.** The images of the
+powers of an ideal of definition are a basis of `𝓝 0` indexed by `ℕ`
+(`TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero`), and a basis indexed by a countable type
+generates a countably generated filter.
+
+This is one of the two hypotheses Henkel's open mapping theorem asks of a topological group, the
+other being `TauCeti.Huber.IsHuberRing.toNonarchimedeanRing` above: nonarchimedean makes the open
+subgroups a basis at zero, and countable generation extracts an antitone *sequence* from that
+basis (`NonarchimedeanAddGroup.exists_antitone_basis_openAddSubgroup`). Being an instance is the
+point — it is what lets a Huber ring be handed to that theorem without the caller discharging
+anything. -/
+instance IsHuberRing.isCountablyGenerated_nhds_zero : (𝓝 (0 : A)).IsCountablyGenerated :=
+  IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦ P.hasBasis_nhds_zero.isCountablyGenerated
 
 /-- Wedhorn Corollary 6.4: the power-bounded subring of a Huber ring is open. -/
 theorem isOpen_powerBoundedSubring : IsOpen (powerBoundedSubring A : Set A) := by


### PR DESCRIPTION
Every Huber ring has a countably generated filter of neighbourhoods of zero — i.e. is first
countable at `0` — and this records it as an **instance**:

```text
instance IsHuberRing.isCountablyGenerated_nhds_zero : (𝓝 (0 : A)).IsCountablyGenerated
```

## Why this is worth an instance

`TauCeti.Huber.IsTateRing.isOpenMap` — Layer 0.6's open mapping theorem — is on `main` and has
**no consumers**. The reason is not that nothing wants it: it is that nothing in the repository can
discharge its hypotheses. `IsCountablyGenerated` appears in `TauCeti/` only ever as an *assumption*
(`Huber/OpenMapping.lean:102,104`, `Topology/Algebra/OpenMapping/Henkel.lean:60`,
`Topology/Algebra/Nonarchimedean/FirstCountable.lean:51`); **no declaration anywhere produces one**.

So the theorem cannot be applied to a Huber ring without the caller proving first countability by
hand, every time. This supplies it once, as an instance, which is the form that makes the
difference between a theorem that is stated and one that can be used.

## The proof

Two lines. `PairOfDefinition.hasBasis_nhds_zero` (`Huber/Basic.lean:332`, Wedhorn Proposition and
Definition 6.1) already gives a basis of `𝓝 0` **indexed by `ℕ`**, and a basis indexed by a
countable type generates a countably generated filter (`Filter.HasBasis.isCountablyGenerated`).
The only step is choosing a pair of definition, which `IsHuberRing.nonempty_pairOfDefinition.elim`
does — `IsCountablyGenerated` is a `Prop`, so eliminating into it is allowed and the instance does
not depend on the choice.

## Placement

`section HuberRing` of `Huber/Basic.lean`, immediately after `IsHuberRing.toNonarchimedeanRing`.
That is deliberate: those two instances are exactly the pair Henkel's theorem asks of the
underlying group — nonarchimedean makes the open subgroups a basis at zero, and countable
generation extracts an antitone *sequence* from that basis, which is what
`NonarchimedeanAddGroup.exists_antitone_basis_openAddSubgroup` needs. The section's variable block
`[IsHuberRing A]` is already the right one.

Roadmap: AdicSpaces

Advances **Layer 0.6, open mapping and strict morphisms**, which asks to "State Henkel's
hypotheses explicitly: the base ring has a zero sequence of units, and the modules are complete,
Hausdorff, and *first countable*". This is that first-countability hypothesis, supplied for Huber
rings in the form the theorem consumes. (`TauCetiRoadmap/AdicSpaces/README.md`, roadmap `2b8aa31`.)

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"huber-countably-generated-nhds-zero"}-->

Provenance: no source. AINTLIB (`github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9`, Apache-2.0,
`projects/AdicSpaces/`) states no countability or first-countability property of a Huber ring.
Absence on TauCeti `main` was checked two ways, because a name census alone would not settle it:
an untruncated grep for `IsCountablyGenerated` across `TauCeti/` (every hit is a hypothesis, none
a producer), and a **compiled negative control** — `infer_instance` for
`(𝓝 (0 : A)).IsCountablyGenerated` under `[IsHuberRing A]` fails to synthesize against unmodified
`main`, so no existing instance already covers it.
