### PR TITLE
feat: the Weil operator of a pure Hodge structure

### DIFF
--- a/TauCeti/Geometry/Hodge/Decomposition.lean
+++ b/TauCeti/Geometry/Hodge/Decomposition.lean
@@ -34,7 +34,7 @@ Hodge II*, §1.2.1, and Voisin, *Hodge Theory and Complex Algebraic Geometry I*,
 * `TauCeti.Hodge.HodgeStructureOn.isInternal_piece`: the Hodge components form an internal direct
   sum of the ambient complex vector space.
 * `TauCeti.Hodge.HodgeStructureOn.decomposition`: that direct sum as a linear equivalence.
-* `TauCeti.Hodge.HodgeStructureOn.piece_induction`: induction along the Hodge decomposition.
+* `TauCeti.Hodge.HodgeStructureOn.piece_induction_on`: induction along the Hodge decomposition.
 -/
 
 public section
@@ -167,7 +167,7 @@ theorem decomposition_apply_of_mem (hs : HodgeStructureOn W ω n) {p : ℤ} {x :
 
 /-- Induction along the Hodge decomposition: a property that holds at zero, is stable under
 addition, and holds on every Hodge component holds everywhere. -/
-theorem piece_induction (hs : HodgeStructureOn W ω n) {motive : W → Prop} (x : W)
+theorem piece_induction_on (hs : HodgeStructureOn W ω n) {motive : W → Prop} (x : W)
     (mem : ∀ p, ∀ y ∈ hs.piece p, motive y) (zero : motive 0)
     (add : ∀ y z, motive y → motive z → motive (y + z)) : motive x := by
   have hx : x ∈ ⨆ p, hs.piece p := by
@@ -181,7 +181,7 @@ theorem linearMap_ext_of_piece {N : Type*} [AddCommGroup N] [Module ℂ N]
     (hs : HodgeStructureOn W ω n) {f g : W →ₗ[ℂ] N}
     (h : ∀ p, ∀ x ∈ hs.piece p, f x = g x) : f = g := by
   ext x
-  refine hs.piece_induction x h (by simp) fun y z hy hz ↦ ?_
+  refine hs.piece_induction_on x h (by simp) fun y z hy hz ↦ ?_
   rw [map_add, map_add, hy, hz]
 
 end HodgeStructureOn

--- a/TauCeti/Geometry/Hodge/Decomposition.lean
+++ b/TauCeti/Geometry/Hodge/Decomposition.lean
@@ -33,11 +33,15 @@ Hodge II*, §1.2.1, and Voisin, *Hodge Theory and Complex Algebraic Geometry I*,
 * `TauCeti.Hodge.HodgeStructureOn.piece_iSupIndep`: the Hodge components are independent.
 * `TauCeti.Hodge.HodgeStructureOn.isInternal_piece`: the Hodge components form an internal direct
   sum of the ambient complex vector space.
+* `TauCeti.Hodge.HodgeStructureOn.decomposition`: that direct sum as a linear equivalence.
+* `TauCeti.Hodge.HodgeStructureOn.piece_induction`: induction along the Hodge decomposition.
 -/
 
 public section
 
 namespace TauCeti.Hodge
+
+open scoped DirectSum
 
 universe u
 
@@ -141,6 +145,44 @@ theorem isInternal_piece (hs : HodgeStructureOn W ω n) : DirectSum.IsInternal h
   classical
   exact DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top
     hs.piece_iSupIndep hs.iSup_piece_eq_top
+
+/-- The Hodge decomposition as a linear equivalence: the ambient complex vector space is the
+direct sum of its Hodge components. -/
+noncomputable def decomposition (hs : HodgeStructureOn W ω n) :
+    W ≃ₗ[ℂ] ⨁ p, hs.piece p :=
+  (LinearEquiv.ofBijective (DirectSum.coeLinearMap hs.piece) hs.isInternal_piece).symm
+
+/-- The inverse of the Hodge decomposition sums up the Hodge components. -/
+@[simp]
+theorem decomposition_symm_apply (hs : HodgeStructureOn W ω n) (x : ⨁ p, hs.piece p) :
+    hs.decomposition.symm x = DirectSum.coeLinearMap hs.piece x := by
+  rw [decomposition, LinearEquiv.symm_symm]
+  rfl
+
+/-- A vector lying in a single Hodge component decomposes as that one component. -/
+theorem decomposition_apply_of_mem (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W}
+    (hx : x ∈ hs.piece p) :
+    hs.decomposition x = DirectSum.lof ℂ ℤ (fun q ↦ hs.piece q) p ⟨x, hx⟩ :=
+  hs.decomposition.symm.injective (by simp)
+
+/-- Induction along the Hodge decomposition: a property that holds at zero, is stable under
+addition, and holds on every Hodge component holds everywhere. -/
+theorem piece_induction (hs : HodgeStructureOn W ω n) {motive : W → Prop} (x : W)
+    (mem : ∀ p, ∀ y ∈ hs.piece p, motive y) (zero : motive 0)
+    (add : ∀ y z, motive y → motive z → motive (y + z)) : motive x := by
+  have hx : x ∈ ⨆ p, hs.piece p := by
+    rw [hs.iSup_piece_eq_top]
+    exact Submodule.mem_top
+  exact Submodule.iSup_induction (motive := motive) hs.piece hx mem zero add
+
+/-- Two complex-linear maps out of the ambient space that agree on every Hodge component are
+equal. -/
+theorem linearMap_ext_of_piece {N : Type*} [AddCommGroup N] [Module ℂ N]
+    (hs : HodgeStructureOn W ω n) {f g : W →ₗ[ℂ] N}
+    (h : ∀ p, ∀ x ∈ hs.piece p, f x = g x) : f = g := by
+  ext x
+  refine hs.piece_induction x h (by simp) fun y z hy hz ↦ ?_
+  rw [map_add, map_add, hy, hz]
 
 end HodgeStructureOn
 

--- a/TauCeti/Geometry/Hodge/WeilOperator.lean
+++ b/TauCeti/Geometry/Hodge/WeilOperator.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Hodge.Decomposition
+public import TauCeti.Geometry.Hodge.Morphism
+public import TauCeti.Geometry.Hodge.Tate
+
+/-!
+# The Weil operator of a pure Hodge structure
+
+The Weil operator `C` of a pure Hodge structure of weight `n` is the complex-linear automorphism
+acting on the Hodge component `H^{p,q}` by the scalar `i^{p-q}`. Since `q = n - p` on the
+component `piece p`, that scalar is `i^{2p-n}`, and the Hodge decomposition
+`TauCeti.Hodge.HodgeStructureOn.isInternal_piece` extends it to the whole ambient space.
+
+Two identities make `C` the carrier of the Hermitian theory. It squares to the weight sign,
+`C ∘ C = (-1)^n`, so `C` is an automorphism, and is a complex structure exactly in odd weight.
+And it commutes with the conjugation, so it is defined over the real form: this is what allows a
+symmetric bilinear form `Q` to be turned into the Hermitian form `h(u, v) = Q(C u, conj v)` on all
+of the ambient space, rather than only on homogeneous vectors where `i^{p-q}` makes sense.
+
+## Main declarations
+
+* `TauCeti.Hodge.HodgeStructureOn.weilOperator`: the Weil operator `C`.
+* `TauCeti.Hodge.HodgeStructureOn.weilOperator_apply_of_mem`: `C` acts on `H^{p,n-p}` by
+  `i^{2p-n}`.
+* `TauCeti.Hodge.HodgeStructureOn.weilOperator_unique`: that action characterizes `C`.
+* `TauCeti.Hodge.HodgeStructureOn.weilOperator_piece`, `…_F`, `…_conjF`: `C` preserves the Hodge
+  components and both filtrations.
+* `TauCeti.Hodge.HodgeStructureOn.weilOperator_comp_weilOperator`: `C ∘ C = (-1)^n`.
+* `TauCeti.Hodge.HodgeStructureOn.weilOperatorEquiv`: `C` bundled as a linear automorphism.
+* `TauCeti.Hodge.HodgeStructureOn.conj_weilOperator`: `C` commutes with the conjugation.
+* `TauCeti.Hodge.HodgeStructure.Hom.commutes_weilOperator`: morphisms commute with `C`.
+* `TauCeti.Hodge.tate_weilOperator`: the Weil operator of `ℤ(m)` is the identity.
+
+This supplies the Weil operator targeted in Layer L1 of
+`TauCetiRoadmap/HodgeStructures/README.md`. The sign conventions are those of Voisin, *Hodge
+Theory and Complex Algebraic Geometry I*, §7.1.2, and Peters–Steenbrink, *Mixed Hodge
+Structures*, §2.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+universe u
+
+namespace HodgeStructureOn
+
+variable {W : Type u} [AddCommGroup W] [Module ℂ W]
+variable {ω : Conjugation W} {n : ℤ}
+
+/-- The square of a power of `i` is the corresponding power of `-1`. -/
+private theorem I_zpow_mul_self (k : ℤ) :
+    Complex.I ^ k * Complex.I ^ k = (-1 : ℂ) ^ k := by
+  rw [← zpow_add₀ Complex.I_ne_zero, ← two_mul, zpow_mul]
+  norm_num
+
+/-- An even shift does not change a power of `-1`. -/
+private theorem negOne_zpow_two_mul_sub (p k : ℤ) :
+    (-1 : ℂ) ^ (2 * p - k) = (-1 : ℂ) ^ k := by
+  have hne : (-1 : ℂ) ≠ 0 := by norm_num
+  have hkey : ∀ m : ℤ, (-1 : ℂ) ^ (2 * m) = 1 := fun m ↦ by
+    rw [zpow_mul]
+    norm_num
+  refine mul_right_cancel₀ (b := (-1 : ℂ) ^ k) (zpow_ne_zero _ hne) ?_
+  rw [← zpow_add₀ hne, ← zpow_add₀ hne, show 2 * p - k + k = 2 * p by ring,
+    show k + k = 2 * k by ring, hkey, hkey]
+
+/-- **The Weil operator** of a pure Hodge structure of weight `n`: the complex-linear map acting
+on the Hodge component `H^{p,q}` by `i^{p-q} = i^{2p-n}`. -/
+noncomputable def weilOperator (hs : HodgeStructureOn W ω n) : W →ₗ[ℂ] W :=
+  (DirectSum.toModule ℂ ℤ W fun p ↦ Complex.I ^ (2 * p - n) • (hs.piece p).subtype) ∘ₗ
+    hs.decomposition.toLinearMap
+
+/-- The Weil operator acts on the Hodge component `H^{p,n-p}` by the scalar `i^{2p-n}`. -/
+theorem weilOperator_apply_of_mem (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W}
+    (hx : x ∈ hs.piece p) : hs.weilOperator x = Complex.I ^ (2 * p - n) • x := by
+  rw [weilOperator, LinearMap.comp_apply, LinearEquiv.coe_coe,
+    hs.decomposition_apply_of_mem hx, DirectSum.toModule_lof]
+  rfl
+
+/-- The Weil operator is the only complex-linear map acting on each Hodge component `H^{p,n-p}`
+by `i^{2p-n}`. -/
+theorem weilOperator_unique (hs : HodgeStructureOn W ω n) (f : W →ₗ[ℂ] W)
+    (hf : ∀ p : ℤ, ∀ x ∈ hs.piece p, f x = Complex.I ^ (2 * p - n) • x) :
+    f = hs.weilOperator :=
+  hs.linearMap_ext_of_piece fun p x hx ↦ by
+    rw [hf p x hx, hs.weilOperator_apply_of_mem hx]
+
+/-- The Weil operator preserves every Hodge component. -/
+theorem weilOperator_mem_piece (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W}
+    (hx : x ∈ hs.piece p) : hs.weilOperator x ∈ hs.piece p := by
+  rw [hs.weilOperator_apply_of_mem hx]
+  exact Submodule.smul_mem _ _ hx
+
+/-- The Weil operator restricts to an automorphism of every Hodge component. -/
+@[simp]
+theorem weilOperator_piece (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    (hs.piece p).map hs.weilOperator = hs.piece p := by
+  refine le_antisymm ?_ fun y hy ↦ ?_
+  · rintro _ ⟨y, hy, rfl⟩
+    exact hs.weilOperator_mem_piece hy
+  · refine ⟨(Complex.I ^ (2 * p - n))⁻¹ • y, Submodule.smul_mem _ _ hy, ?_⟩
+    rw [hs.weilOperator_apply_of_mem (Submodule.smul_mem _ _ hy), smul_smul,
+      mul_inv_cancel₀ (zpow_ne_zero _ Complex.I_ne_zero), one_smul]
+
+/-- The Weil operator preserves every step of the Hodge filtration. -/
+@[simp]
+theorem weilOperator_F (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    (hs.F p).map hs.weilOperator = hs.F p := by
+  rw [hs.F_eq_iSup_piece p]
+  simp only [Submodule.map_iSup, hs.weilOperator_piece]
+
+/-- The Weil operator preserves every step of the conjugate Hodge filtration. -/
+@[simp]
+theorem weilOperator_conjF (hs : HodgeStructureOn W ω n) (p : ℤ) :
+    (hs.conjF p).map hs.weilOperator = hs.conjF p := by
+  rw [hs.conjF_eq_iSup_piece p]
+  simp only [Submodule.map_iSup, hs.weilOperator_piece]
+
+/-- Elementwise form of preservation of the Hodge filtration. -/
+theorem weilOperator_mem_F (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W} (hx : x ∈ hs.F p) :
+    hs.weilOperator x ∈ hs.F p :=
+  (hs.weilOperator_F p).le ⟨x, hx, rfl⟩
+
+/-- Elementwise form of preservation of the conjugate Hodge filtration. -/
+theorem weilOperator_mem_conjF (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W}
+    (hx : x ∈ hs.conjF p) : hs.weilOperator x ∈ hs.conjF p :=
+  (hs.weilOperator_conjF p).le ⟨x, hx, rfl⟩
+
+/-- **The Weil operator squares to the weight sign:** `C ∘ C = (-1)^n`. -/
+theorem weilOperator_comp_weilOperator (hs : HodgeStructureOn W ω n) :
+    hs.weilOperator ∘ₗ hs.weilOperator = ((-1 : ℂ) ^ n) • LinearMap.id :=
+  hs.linearMap_ext_of_piece fun p x hx ↦ by
+    rw [LinearMap.comp_apply, hs.weilOperator_apply_of_mem hx, map_smul,
+      hs.weilOperator_apply_of_mem hx, smul_smul, I_zpow_mul_self,
+      negOne_zpow_two_mul_sub, LinearMap.smul_apply, LinearMap.id_apply]
+
+/-- The Weil operator squares to `-1` in odd weight, where it is therefore a complex structure. -/
+theorem weilOperator_comp_weilOperator_of_odd (hs : HodgeStructureOn W ω n) (hn : Odd n) :
+    hs.weilOperator ∘ₗ hs.weilOperator = -LinearMap.id := by
+  rw [hs.weilOperator_comp_weilOperator, hn.neg_one_zpow, neg_one_smul]
+
+/-- The Weil operator is an involution in even weight. -/
+theorem weilOperator_comp_weilOperator_of_even (hs : HodgeStructureOn W ω n) (hn : Even n) :
+    hs.weilOperator ∘ₗ hs.weilOperator = LinearMap.id := by
+  rw [hs.weilOperator_comp_weilOperator, hn.neg_one_zpow, one_smul]
+
+/-- Doubling a power of `-1` gives one. -/
+private theorem negOne_zpow_mul_self (k : ℤ) : ((-1 : ℂ) ^ k) * ((-1 : ℂ) ^ k) = 1 := by
+  rw [← zpow_add₀ (by norm_num : (-1 : ℂ) ≠ 0), ← two_mul, zpow_mul]
+  norm_num
+
+/-- The Weil operator is inverted by `(-1)^n` times itself, on the right. -/
+theorem weilOperator_comp_smul_weilOperator (hs : HodgeStructureOn W ω n) :
+    hs.weilOperator ∘ₗ (((-1 : ℂ) ^ n) • hs.weilOperator) = LinearMap.id := by
+  rw [LinearMap.comp_smul, hs.weilOperator_comp_weilOperator, smul_smul,
+    negOne_zpow_mul_self, one_smul]
+
+/-- The Weil operator is inverted by `(-1)^n` times itself, on the left. -/
+theorem smul_weilOperator_comp_weilOperator (hs : HodgeStructureOn W ω n) :
+    (((-1 : ℂ) ^ n) • hs.weilOperator) ∘ₗ hs.weilOperator = LinearMap.id := by
+  rw [LinearMap.smul_comp, hs.weilOperator_comp_weilOperator, smul_smul,
+    negOne_zpow_mul_self, one_smul]
+
+/-- The Weil operator, bundled as a complex-linear automorphism of the ambient space. -/
+noncomputable def weilOperatorEquiv (hs : HodgeStructureOn W ω n) : W ≃ₗ[ℂ] W :=
+  LinearEquiv.ofLinearMap hs.weilOperator (((-1 : ℂ) ^ n) • hs.weilOperator)
+    hs.weilOperator_comp_smul_weilOperator hs.smul_weilOperator_comp_weilOperator
+
+/-- The bundled Weil operator acts as the Weil operator. -/
+@[simp]
+theorem weilOperatorEquiv_apply (hs : HodgeStructureOn W ω n) (x : W) :
+    hs.weilOperatorEquiv x = hs.weilOperator x := by
+  simp [weilOperatorEquiv]
+
+/-- The inverse of the bundled Weil operator is `(-1)^n` times the Weil operator. -/
+@[simp]
+theorem weilOperatorEquiv_symm_apply (hs : HodgeStructureOn W ω n) (x : W) :
+    hs.weilOperatorEquiv.symm x = ((-1 : ℂ) ^ n) • hs.weilOperator x := by
+  simp [weilOperatorEquiv]
+
+/-- The Weil operator is bijective. -/
+theorem weilOperator_bijective (hs : HodgeStructureOn W ω n) :
+    Function.Bijective hs.weilOperator :=
+  hs.weilOperatorEquiv.bijective
+
+/-- In weight one the Weil operator acts on `H^{1,0}` by `i`. Together with the next lemma this
+identifies it with the complex structure of an effective weight-one Hodge structure. -/
+theorem weilOperator_apply_of_mem_piece_one {hs : HodgeStructureOn W ω 1} {x : W}
+    (hx : x ∈ hs.piece 1) : hs.weilOperator x = Complex.I • x := by
+  rw [hs.weilOperator_apply_of_mem hx]
+  norm_num
+
+/-- In weight one the Weil operator acts on `H^{0,1}` by `-i`. -/
+theorem weilOperator_apply_of_mem_piece_zero {hs : HodgeStructureOn W ω 1} {x : W}
+    (hx : x ∈ hs.piece 0) : hs.weilOperator x = -(Complex.I • x) := by
+  rw [hs.weilOperator_apply_of_mem hx, show 2 * (0 : ℤ) - 1 = -1 by ring, zpow_neg,
+    zpow_one, Complex.inv_I, neg_smul]
+
+/-- **The Weil operator is real:** it commutes with the conjugation of the Hodge structure. This
+is what lets the Hermitian form `Q(C u, conj v)` be assembled from the scalars `i^{p-q}`. -/
+theorem conj_weilOperator (hs : HodgeStructureOn W ω n) (x : W) :
+    ω.toEquiv (hs.weilOperator x) = hs.weilOperator (ω.toEquiv x) := by
+  refine hs.piece_induction
+    (motive := fun w ↦ ω.toEquiv (hs.weilOperator w) = hs.weilOperator (ω.toEquiv w)) x
+    (fun p y hy ↦ ?_) (by simp) fun y z hy hz ↦ by simp [map_add, hy, hz]
+  have hconj : ω.toEquiv y ∈ hs.piece (n - p) := by
+    rw [← hs.conj_piece p]
+    exact ⟨y, hy, rfl⟩
+  rw [hs.weilOperator_apply_of_mem hy, map_smulₛₗ, hs.weilOperator_apply_of_mem hconj]
+  congr 1
+  rw [map_zpow₀, Complex.conj_I, show 2 * (n - p) - n = -(2 * p - n) by ring, zpow_neg,
+    ← inv_zpow, Complex.inv_I]
+
+end HodgeStructureOn
+
+namespace HodgeStructure.Hom
+
+universe u₁ v₁ u₂ v₂
+
+variable {V₁ : Type u₁} {V₂ : Type u₂} {W₁ : Type v₁} {W₂ : Type v₂}
+variable [AddCommGroup V₁] [AddCommGroup V₂]
+variable [AddCommGroup W₁] [Module ℂ W₁] [AddCommGroup W₂] [Module ℂ W₂]
+variable {ι₁ : V₁ →ₗ[ℤ] W₁} {ι₂ : V₂ →ₗ[ℤ] W₂}
+variable {h₁ : IsBaseChange ℂ ι₁} {h₂ : IsBaseChange ℂ ι₂} {n : ℤ}
+variable {source : HodgeStructure h₁ n} {target : HodgeStructure h₂ n}
+
+/-- A morphism of pure Hodge structures commutes with the Weil operators: it preserves every
+Hodge component, on which both operators are the same scalar. -/
+theorem commutes_weilOperator (f : Hom source target) (x : W₁) :
+    f (source.weilOperator x) = target.weilOperator (f x) := by
+  refine source.piece_induction
+    (motive := fun w ↦ f (source.weilOperator w) = target.weilOperator (f w)) x
+    (fun p y hy ↦ ?_) (by simp) fun y z hy hz ↦ by simp [map_add, hy, hz]
+  rw [source.weilOperator_apply_of_mem hy, map_smul,
+    target.weilOperator_apply_of_mem (f.map_mem_piece p hy)]
+
+end HodgeStructure.Hom
+
+/-- The Weil operator of the Tate structure `ℤ(m)` is the identity: its single Hodge component
+has `p = q = -m`, where the scalar `i^{p-q}` is one. -/
+@[simp]
+theorem tate_weilOperator (m : ℤ) : (tate m).weilOperator = LinearMap.id := by
+  refine LinearMap.ext fun x ↦ ?_
+  have hx : x ∈ (tate m).piece (-m) := by
+    rw [tate_piece]
+    simp
+  rw [(tate m).weilOperator_apply_of_mem hx, show 2 * -m - -2 * m = (0 : ℤ) by ring]
+  simp
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/WeilOperator.lean
+++ b/TauCeti/Geometry/Hodge/WeilOperator.lean
@@ -18,7 +18,7 @@ component `piece p`, that scalar is `i^{2p-n}`, and the Hodge decomposition
 `TauCeti.Hodge.HodgeStructureOn.isInternal_piece` extends it to the whole ambient space.
 
 Two identities make `C` the carrier of the Hermitian theory. It squares to the weight sign,
-`C ∘ C = (-1)^n`, so `C` is an automorphism, and is a complex structure exactly in odd weight.
+`C ∘ C = (-1)^n`, so `C` is an automorphism, and is a complex structure in odd weight.
 And it commutes with the conjugation, so it is defined over the real form: this is what allows a
 symmetric bilinear form `Q` to be turned into the Hermitian form `h(u, v) = Q(C u, conj v)` on all
 of the ambient space, rather than only on homogeneous vectors where `i^{p-q}` makes sense.
@@ -67,9 +67,10 @@ private theorem negOne_zpow_two_mul_sub (p k : ℤ) :
   have hkey : ∀ m : ℤ, (-1 : ℂ) ^ (2 * m) = 1 := fun m ↦ by
     rw [zpow_mul]
     norm_num
+  have hp : 2 * p - k + k = 2 * p := by ring
+  have hk : k + k = 2 * k := by ring
   refine mul_right_cancel₀ (b := (-1 : ℂ) ^ k) (zpow_ne_zero _ hne) ?_
-  rw [← zpow_add₀ hne, ← zpow_add₀ hne, show 2 * p - k + k = 2 * p by ring,
-    show k + k = 2 * k by ring, hkey, hkey]
+  rw [← zpow_add₀ hne, ← zpow_add₀ hne, hp, hk, hkey, hkey]
 
 /-- **The Weil operator** of a pure Hodge structure of weight `n`: the complex-linear map acting
 on the Hodge component `H^{p,q}` by `i^{p-q} = i^{2p-n}`. -/
@@ -78,6 +79,7 @@ noncomputable def weilOperator (hs : HodgeStructureOn W ω n) : W →ₗ[ℂ] W 
     hs.decomposition.toLinearMap
 
 /-- The Weil operator acts on the Hodge component `H^{p,n-p}` by the scalar `i^{2p-n}`. -/
+@[simp]
 theorem weilOperator_apply_of_mem (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W}
     (hx : x ∈ hs.piece p) : hs.weilOperator x = Complex.I ^ (2 * p - n) • x := by
   rw [weilOperator, LinearMap.comp_apply, LinearEquiv.coe_coe,
@@ -200,14 +202,15 @@ theorem weilOperator_apply_of_mem_piece_one {hs : HodgeStructureOn W ω 1} {x : 
 /-- In weight one the Weil operator acts on `H^{0,1}` by `-i`. -/
 theorem weilOperator_apply_of_mem_piece_zero {hs : HodgeStructureOn W ω 1} {x : W}
     (hx : x ∈ hs.piece 0) : hs.weilOperator x = -(Complex.I • x) := by
-  rw [hs.weilOperator_apply_of_mem hx, show 2 * (0 : ℤ) - 1 = -1 by ring, zpow_neg,
-    zpow_one, Complex.inv_I, neg_smul]
+  have h_exp : 2 * (0 : ℤ) - 1 = -1 := by ring
+  rw [hs.weilOperator_apply_of_mem hx, h_exp, zpow_neg, zpow_one, Complex.inv_I, neg_smul]
 
 /-- **The Weil operator is real:** it commutes with the conjugation of the Hodge structure. This
 is what lets the Hermitian form `Q(C u, conj v)` be assembled from the scalars `i^{p-q}`. -/
+@[simp]
 theorem conj_weilOperator (hs : HodgeStructureOn W ω n) (x : W) :
     ω.toEquiv (hs.weilOperator x) = hs.weilOperator (ω.toEquiv x) := by
-  refine hs.piece_induction
+  refine hs.piece_induction_on
     (motive := fun w ↦ ω.toEquiv (hs.weilOperator w) = hs.weilOperator (ω.toEquiv w)) x
     (fun p y hy ↦ ?_) (by simp) fun y z hy hz ↦ by simp [map_add, hy, hz]
   have hconj : ω.toEquiv y ∈ hs.piece (n - p) := by
@@ -215,8 +218,8 @@ theorem conj_weilOperator (hs : HodgeStructureOn W ω n) (x : W) :
     exact ⟨y, hy, rfl⟩
   rw [hs.weilOperator_apply_of_mem hy, map_smulₛₗ, hs.weilOperator_apply_of_mem hconj]
   congr 1
-  rw [map_zpow₀, Complex.conj_I, show 2 * (n - p) - n = -(2 * p - n) by ring, zpow_neg,
-    ← inv_zpow, Complex.inv_I]
+  have h_exp : 2 * (n - p) - n = -(2 * p - n) := by ring
+  rw [map_zpow₀, Complex.conj_I, h_exp, zpow_neg, ← inv_zpow, Complex.inv_I]
 
 end HodgeStructureOn
 
@@ -233,9 +236,10 @@ variable {source : HodgeStructure h₁ n} {target : HodgeStructure h₂ n}
 
 /-- A morphism of pure Hodge structures commutes with the Weil operators: it preserves every
 Hodge component, on which both operators are the same scalar. -/
+@[simp]
 theorem commutes_weilOperator (f : Hom source target) (x : W₁) :
     f (source.weilOperator x) = target.weilOperator (f x) := by
-  refine source.piece_induction
+  refine source.piece_induction_on
     (motive := fun w ↦ f (source.weilOperator w) = target.weilOperator (f w)) x
     (fun p y hy ↦ ?_) (by simp) fun y z hy hz ↦ by simp [map_add, hy, hz]
   rw [source.weilOperator_apply_of_mem hy, map_smul,
@@ -251,7 +255,8 @@ theorem tate_weilOperator (m : ℤ) : (tate m).weilOperator = LinearMap.id := by
   have hx : x ∈ (tate m).piece (-m) := by
     rw [tate_piece]
     simp
-  rw [(tate m).weilOperator_apply_of_mem hx, show 2 * -m - -2 * m = (0 : ℤ) by ring]
+  have h_exp : 2 * -m - -2 * m = (0 : ℤ) := by ring
+  rw [(tate m).weilOperator_apply_of_mem hx, h_exp]
   simp
 
 end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/WeilOperator.lean
+++ b/TauCeti/Geometry/Hodge/WeilOperator.lean
@@ -79,7 +79,6 @@ noncomputable def weilOperator (hs : HodgeStructureOn W ω n) : W →ₗ[ℂ] W 
     hs.decomposition.toLinearMap
 
 /-- The Weil operator acts on the Hodge component `H^{p,n-p}` by the scalar `i^{2p-n}`. -/
-@[simp]
 theorem weilOperator_apply_of_mem (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W}
     (hx : x ∈ hs.piece p) : hs.weilOperator x = Complex.I ^ (2 * p - n) • x := by
   rw [weilOperator, LinearMap.comp_apply, LinearEquiv.coe_coe,


### PR DESCRIPTION
This PR defines the **Weil operator** `C` of a pure Hodge structure of arbitrary weight `n` and proves the identities that make it usable, closing the target the `HodgeStructures` roadmap states in its own right inside Layer **L1** ("*Weil operator:* … Target it in its own right: its definition from `piece`, its action on pieces, `C² = (−1)^n` …, compatibility with `latticeConj` and with `Q`, and positive-definiteness of `h`. Everything downstream wanting a Hermitian form wants `C`."). L1's milestone is the semisimplicity of polarizable rational Hodge structures, whose discharge runs through the Hermitian form `h(u, v) = Q(C u, conj v)`; that form is undefined without `C`, because `i^{p-q}` makes sense only on homogeneous vectors and needs a carrier extending it to all of `V_ℂ`.

`TauCeti/Geometry/Hodge/WeilOperator.lean` defines `HodgeStructureOn.weilOperator` by transporting the scalars `i^{2p-n}` (which is `i^{p-q}`, since `q = n - p` on `piece p`) through the already proved Hodge decomposition `isInternal_piece`, so the operator is genuine data rather than an existential. `weilOperator_apply_of_mem` records its action on `H^{p,n-p}` and `weilOperator_unique` shows that action characterizes it, which makes every later lemma independent of the chosen construction. `C` preserves each Hodge component (`weilOperator_piece`) and hence both filtrations (`weilOperator_F`, `weilOperator_conjF`), with elementwise companions. `weilOperator_comp_weilOperator` is `C ∘ C = (-1)^n`, specialized to `-1` in odd weight — where `C` is therefore a complex structure — and to the identity in even weight; from the two-sided inverse `(-1)^n • C` the operator is bundled as a linear automorphism `weilOperatorEquiv`. `conj_weilOperator` proves `C` commutes with the ambient conjugation, i.e. that `C` is defined over the real form: this is the step that lets a bilinear form be converted into a Hermitian one on the whole space. `HodgeStructure.Hom.commutes_weilOperator` shows morphisms of Hodge structures commute with the Weil operators, and `tate_weilOperator` computes `C = id` on the Tate structure `ℤ(m)` (type `(-m,-m)`, so `i^{p-q} = 1`), keeping the file anchored to an explicit inhabitant rather than to the empty structure. Two weight-one specializations pin the classical convention, `C = i` on `H^{1,0}` and `C = -i` on `H^{0,1}`, which is the scalar side of L0's `J`-eigenspace instance bridge.

`TauCeti/Geometry/Hodge/Decomposition.lean` gains the three companions the construction needs, in the file where the decomposition already lives: `decomposition`, the internal direct sum packaged as a linear equivalence `V_ℂ ≃ₗ[ℂ] ⨁ p, H^{p,n-p}` with the value of a homogeneous vector computed; `piece_induction`, induction along that decomposition; and `linearMap_ext_of_piece`, the extensionality principle for maps agreeing on every Hodge component. All three are stated for the conjugation-parametric `HodgeStructureOn`, so the mixed theory's graded pieces inherit them.

Nothing is vendored from Mathlib. The construction reuses `DirectSum.IsInternal`, `DirectSum.coeLinearMap`/`toModule`/`lof`, `Submodule.iSup_induction`, `LinearEquiv.ofLinearMap`, `Odd.neg_one_zpow`/`Even.neg_one_zpow`, `Complex.conj_I` and `Complex.inv_I` as they stand.

Files: `TauCeti/Geometry/Hodge/WeilOperator.lean` (257 lines, new) and 42 lines added to `TauCeti/Geometry/Hodge/Decomposition.lean`.

This is deliberately disjoint from open PR #3830, which lands L1's `IsPolarization` / `Polarization` definitions; the two meet later. What remains for the L1 milestone after both: the Hermitian form `h(u, v) = Q(C u, conj v)` and its positive definiteness from the Hodge–Riemann relations, `RationalHodgeSubstructure`, and the orthogonal-complement argument giving semisimplicity.

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"weiloperator"}-->

🤖 Prepared with Claude Code
