### PR TITLE
feat(EllipticCurve): nonvanishing of the universal division polynomials

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -64,8 +64,9 @@ stated in the module docstring of pinned Mathlib's
 characteristic-zero universal ring and `ωₙ` its image under the universal morphism. This file
 discharges that docstring's `TODO: the bivariate polynomials ωₙ`. The remaining declarations
 with no source counterpart are the equation lemmas `ψc_def` and `ω_def` (the module system
-keeps both bodies unexposed, so each needs a named handle), `map_ψc`, and the two
-`baseChange_*` forms, which follow Mathlib's sibling `baseChange_ψ`/`baseChange_φ`.
+keeps both bodies unexposed, so each needs a named handle), the value lemmas `ψc_zero`,
+`ψc_one` and `ψc_two` (the `complEDS₂` values read at the curve's parameters), `map_ψc`, and
+the two `baseChange_*` forms, which follow Mathlib's sibling `baseChange_ψ`/`baseChange_φ`.
 -/
 
 open Polynomial
@@ -94,6 +95,9 @@ theorem ψc_def : W.ψc = complEDS₂ W.ψ₂ (C W.Ψ₃) (C W.preΨ₄) := (rfl
 
 /-- `ψc` at `1` is `ψ₂`, matching `ψ 1 * ψc 1 = ψ 2`. -/
 @[simp] theorem ψc_one : W.ψc 1 = W.ψ₂ := by rw [ψc_def, complEDS₂_one]
+
+/-- `ψc` at `2` is `preΨ₄`, matching `ψ 2 * ψc 2 = ψ 4`. -/
+@[simp] theorem ψc_two : W.ψc 2 = C W.preΨ₄ := by rw [ψc_def, complEDS₂_two]
 
 /-- The `ω` family of division polynomials: `ω n` gives the second coordinate in Jacobian
 coordinates of scalar multiplication by `n`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -61,11 +61,12 @@ first-order, and the same for `map_mul` and `map_pow`. That leaves the arithmeti
 evaluates to `1`.
 
 The remaining two companions, `polyEval_cusp_ψc` and `polyEval_cusp_ω`, together with the sixth
-transport `evalEval_ω`, needed `ψc`, `two_mul_ω` and `map_ω` — the `ω` API this passage once
-recorded as not yet here. `DivisionPolynomial/Omega.lean` now supplies all three, on top of
-`reducedInvarNum_eq_reducedInvarDenom_mul`, so they are below: `evalEval_ω` closes the transport
-family, `polyEval_cusp_ψc` reads the complement off `complEDS₂_two_three_two`, and
-`polyEval_cusp_ω` divides the cusp evaluation of `two_mul_ω` by two.
+and seventh transports `evalEval_ψc` and `evalEval_ω`, needed `ψc`, `two_mul_ω`, `map_ψc` and
+`map_ω` — the `ω` API this passage once recorded as not yet here. `DivisionPolynomial/Omega.lean`
+now supplies all four, on top of `reducedInvarNum_eq_reducedInvarDenom_mul`, so they are below:
+`evalEval_ψc` and `evalEval_ω` close the transport family, `polyEval_cusp_ψc` reads the
+complement off `complEDS₂_two_three_two`, and `polyEval_cusp_ω` divides the cusp evaluation of
+`two_mul_ω` by two.
 
 ## Provenance
 
@@ -73,7 +74,7 @@ Adapted from `LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`,
 at `dev/modular-curves @ 9fec8eba7652` — the revision `TauCetiRoadmap/EllipticCurves/README.md`
 pins for the NagellLutz project. Declarations `Universal.evalEval_ψ₂`, `evalEval_Ψ₃`,
 `evalEval_preΨ₄`, `evalEval_ψ`, `evalEval_φ` and (added with the `ω` port, read at
-`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`) `evalEval_ω`.
+`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`) `evalEval_ψc` and `evalEval_ω`.
 `isEllipticSequence_polyToField_ψ` adapts that same file's `isEllSequence_ψᵤ`.
 That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`; following this
 repository's convention for adapted material the upstream authorship is credited here rather than

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -35,7 +35,7 @@ Each proof is the same two steps: unfold `polyEval` into a `map` followed by `ev
 * `WeierstrassCurve.Universal.polyToField_ψ_ne_zero`, `.polyToField_φ_ne_zero`: in
   `Universal.Field`, `ψₙ` is nonzero for every `n ≠ 0` and `φₙ` for every `n` — the cusp
   evaluations above, read back through the retraction onto `ℤ`.
-* `WeierstrassCurve.Universal.polyToField_ψ₂Sq`: `Ψ₂Sq` is the square of `ψ 2` in the universal
+* `WeierstrassCurve.Universal.polyToField_Ψ₂Sq`: `Ψ₂Sq` is the square of `ψ 2` in the universal
   field, the Weierstrass relation being exactly what `Universal.Ring` quotients out.
 
 ## Implementation notes
@@ -102,7 +102,8 @@ of `ψ` with `normEDS` is the named `ψ_eq_normEDS` (`DivisionPolynomial/NormEDS
 
 The nonvanishing block adapts, at the same `main` revision, `ψᵤ_ne_zero` (`:141`, respelt
 `polyToField_ψ_ne_zero` with the abbreviation dropped as above), `polyToField_φ_ne_zero` (`:148`,
-source name kept) and `polyToField_ψ₂Sq` (`:154`, source name kept). One departure beyond the
+source name kept) and `polyToField_ψ₂Sq` (`:154`, here `polyToField_Ψ₂Sq`: the constant in its
+conclusion is `Ψ₂Sq`, capitalised). One departure beyond the
 `ψᵤ` respelling: the source rewrites through its `polyToField_polynomial`, which has no
 counterpart here — the vanishing of the Weierstrass polynomial is inlined as a `have` through
 `AdjoinRoot.mk_self`, the same step `Universal.lean`'s `equation_point` uses.
@@ -216,13 +217,12 @@ lemma polyToField_φ_ne_zero : polyToField (curve.φ n) ≠ 0 := fun h ↦ by
   rw [ringEval_mk, polyEval_cusp_φ, map_zero] at h
   exact one_ne_zero h
 
-/-- **`Ψ₂Sq` in the universal field is the square of `ψ 2`.** The `4 · polynomial` correction in
-`ψ₂_sq` is exactly the relation `Universal.Ring` quotients out, so it vanishes under
-`polyToField`. -/
-lemma polyToField_ψ₂Sq : polyToField (C curve.Ψ₂Sq) = polyToField (curve.ψ 2) ^ 2 := by
-  have hpoly : polyToField curve.toAffine.polynomial = 0 := by
-    rw [polyToField_apply, AdjoinRoot.mk_self, map_zero]
-  rw [← map_pow, ψ_two, ψ₂_sq, map_add, map_mul, hpoly, mul_zero, add_zero]
+/-- **`Ψ₂Sq` in the universal field is the square of `ψ 2`**: the coordinate-ring identity
+`mk_ψ₂_sq`, pushed into the field of fractions. -/
+lemma polyToField_Ψ₂Sq : polyToField (C curve.Ψ₂Sq) = polyToField (curve.ψ 2) ^ 2 := by
+  rw [ψ_two, polyToField_apply, polyToField_apply, ← map_pow]
+  exact (congrArg (algebraMap Universal.Ring Universal.Field)
+    (Affine.CoordinateRing.mk_ψ₂_sq curve)).symm
 
 end Universal
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -32,6 +32,11 @@ Each proof is the same two steps: unfold `polyEval` into a `map` followed by `ev
 * `WeierstrassCurve.Universal.polyEval_cusp_ψ`, `.polyEval_cusp_φ`, `.polyEval_cusp_ψc`,
   `.polyEval_cusp_ω`: specialised to the cusp curve at `(1, 1)`, `ψₙ` evaluates to `n` itself,
   the numerator `φₙ` to `1`, the complement `ψc n` to `2`, and `ωₙ` to `1`.
+* `WeierstrassCurve.Universal.polyToField_ψ_ne_zero`, `.polyToField_φ_ne_zero`: in
+  `Universal.Field`, `ψₙ` is nonzero for every `n ≠ 0` and `φₙ` for every `n` — the cusp
+  evaluations above, read back through the retraction onto `ℤ`.
+* `WeierstrassCurve.Universal.polyToField_ψ₂Sq`: `Ψ₂Sq` is the square of `ψ 2` in the universal
+  field, the Weierstrass relation being exactly what `Universal.Ring` quotients out.
 
 ## Implementation notes
 
@@ -94,6 +99,13 @@ an `abbrev ψᵤ` and its own `ψᵤ_eq_normEDS`; here the abbreviation is dropp
 of `ψ` with `normEDS` is the named `ψ_eq_normEDS` (`DivisionPolynomial/NormEDS.lean`), and a
 `have` transports it through `polyToField`, so the statement is spelled on
 `fun n ↦ polyToField (curve.ψ n)` directly.
+
+The nonvanishing block adapts, at the same `main` revision, `ψᵤ_ne_zero` (`:141`, respelt
+`polyToField_ψ_ne_zero` with the abbreviation dropped as above), `polyToField_φ_ne_zero` (`:148`,
+source name kept) and `polyToField_ψ₂Sq` (`:154`, source name kept). One departure beyond the
+`ψᵤ` respelling: the source rewrites through its `polyToField_polynomial`, which has no
+counterpart here — the vanishing of the Weierstrass polynomial is inlined as a `have` through
+`AdjoinRoot.mk_self`, the same step `Universal.lean`'s `equation_point` uses.
 -/
 
 public section
@@ -185,6 +197,32 @@ lemma polyEval_cusp_ω : polyEval (cusp ℤ) 1 1 (curve.ω n) = 1 := by
   -- The residual `a₁`/`a₃` terms sit under `CC`, whose body is unexposed and has no cusp value
   -- lemma, so no named rewrite can kill them; evaluating the wrappers is the one route left.
   simpa [polyEval_apply, evalEval] using h
+
+/-- **The universal `ψₙ` is nonzero in `Universal.Field` for every `n ≠ 0`.** Evaluating at the
+cusp curve's point `(1, 1)` retracts the universal coefficients onto `ℤ`, where `ψₙ` reads off as
+`n` itself (`polyEval_cusp_ψ`) — so `ψₙ = 0` would force `n = 0`. This is the nonvanishing the
+`n • (X, Y)` coordinate formulas divide by. -/
+lemma polyToField_ψ_ne_zero (h0 : n ≠ 0) : polyToField (curve.ψ n) ≠ 0 := fun h ↦ by
+  rw [polyToField_apply, map_eq_zero_iff _ (IsFractionRing.injective _ _)] at h
+  replace h := congr(ringEval (equation_cusp_one_one ℤ) $h)
+  rw [ringEval_mk, polyEval_cusp_ψ, map_zero] at h
+  exact h0 h
+
+/-- **The universal `φₙ` is nonzero in `Universal.Field`, for every `n`.** The same cusp
+retraction: at `(1, 1)` it evaluates to `1` (`polyEval_cusp_φ`). -/
+lemma polyToField_φ_ne_zero : polyToField (curve.φ n) ≠ 0 := fun h ↦ by
+  rw [polyToField_apply, map_eq_zero_iff _ (IsFractionRing.injective _ _)] at h
+  replace h := congr(ringEval (equation_cusp_one_one ℤ) $h)
+  rw [ringEval_mk, polyEval_cusp_φ, map_zero] at h
+  exact one_ne_zero h
+
+/-- **`Ψ₂Sq` in the universal field is the square of `ψ 2`.** The `4 · polynomial` correction in
+`ψ₂_sq` is exactly the relation `Universal.Ring` quotients out, so it vanishes under
+`polyToField`. -/
+lemma polyToField_ψ₂Sq : polyToField (C curve.Ψ₂Sq) = polyToField (curve.ψ 2) ^ 2 := by
+  have hpoly : polyToField curve.toAffine.polynomial = 0 := by
+    rw [polyToField_apply, AdjoinRoot.mk_self, map_zero]
+  rw [← map_pow, ψ_two, ψ₂_sq, map_add, map_mul, hpoly, mul_zero, add_zero]
 
 end Universal
 


### PR DESCRIPTION
> Based directly on `main` (the #3862 `ω` and #3863 cusp layers both merged); the diff is
> this PR's own increment: the nonvanishing block at the end of
> `DivisionPolynomial/Universal.lean` — three lemmas — plus their module-docstring entries,
> and two review-round additions on this PR's board: the `ψc_two` value lemma in
> `DivisionPolynomial/Omega.lean` (api-design), and the seven-transport inventory correction
> in `Universal.lean`'s implementation notes and provenance (documentation).

Nonvanishing of the universal division polynomials, by cusp retraction.

```lean
lemma polyToField_ψ_ne_zero (h0 : n ≠ 0) : polyToField (curve.ψ n) ≠ 0
lemma polyToField_φ_ne_zero : polyToField (curve.φ n) ≠ 0
lemma polyToField_ψ₂Sq : polyToField (C curve.Ψ₂Sq) = polyToField (curve.ψ 2) ^ 2
```

## What it closes

The `n • (X, Y)` coordinate formulas of the Nagell–Lutz route (`ZSMul`) are rational functions
with `ψₙ`-powers in their denominators; every slope and addition identity there divides by them.
These are those divisors' nonvanishing statements, in the universal field where the division
happens. The argument is the file's existing cusp machinery earning its keep once more:
evaluating at the cusp curve's rational point `(1, 1)` retracts `Universal.Field`'s coefficients
onto `ℤ` (`ringEval (equation_cusp_one_one ℤ)`), where `ψₙ` reads off as `n` itself and `φₙ` as
`1` — the `polyEval_cusp_*` values of #3863 and of merged `main`. `polyToField_ψ₂Sq` is the
companion identity the same formulas consume: `Ψ₂Sq` is the square of `ψ 2` once the Weierstrass
relation — exactly what `Universal.Ring` quotients out — vanishes.

## Reuse

`polyToField_ψ_ne_zero`, `polyToField_φ_ne_zero`, `polyToField_ψ₂Sq` return nothing on
`origin/main` in `TauCeti/` (positive control: `polyEval_cusp_ψ`, 8 occurrences in the one file
this PR touches). The statements are not spellable in pinned Mathlib: `polyToField`,
`Universal.Field` and the cusp-retraction layer are this repository's (`EllipticCurve/
Universal.lean`); Mathlib's division-polynomial files carry no universal-curve layer.

`net_ψᵤ` (source `:140`) is deliberately **not** ported: its one prospective consumer is the
slope development (`Z3`), and a consumer-less general lemma is exactly what the reuse rubric
rejects — it ships with its consumer.

## Gates

Targeted `lake build` of the module PASS (2022 jobs, full linter set, zero warnings — first
try, source-faithful proofs). Line lengths python-verified ≤ 100 codepoints. No new `@[simp]`
(nothing rewrites; two are `Ne` facts, and the `ψ₂Sq` identity is directional API). No
`sorry`/`set_option`. Full-library suite runs before any further push, as for the rest of the
stack.

## Review status

**Opened without a local pre-review, at the maintainer's instruction** (codex quota exhausted on
this machine until 2026-08-20 04:30; a dead-provider run renders as a fake "changes requested"
at `cost=$0.0000`, so nothing was posted). Review happens GitHub-side.

## Roadmap

New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
Nagell–Lutz**", whose stated route is the division-polynomial formula for `n • P`
(`README.md:1163`, the Layer-6 NagellLutz entry naming AINTLIB as the pinned source). These are
the nonvanishing prerequisites that formula's slope and addition identities divide by; they
advance that target and nothing else.

## Provenance

Ported from J. Xu and D. K. Angdinata's `LutzNagell/ZSMul.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`),
declarations `ψᵤ_ne_zero` (`:141`, respelt `polyToField_ψ_ne_zero` — this repository drops the
`ψᵤ` abbreviation), `polyToField_φ_ne_zero` (`:148`, source name kept) and `polyToField_ψ₂Sq`
(`:154`, source name kept). One departure beyond the respelling: the source rewrites through its
`polyToField_polynomial`, which has no counterpart here — the vanishing of the Weierstrass
polynomial is inlined as a `have` through `AdjoinRoot.mk_self`, the same step `equation_point`
uses. The module docstring records the same.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-psi-nonvanishing"}-->

🤖 Prepared with Claude Code (Claude Opus 5)

