### PR TITLE
feat: the valence formula weighted by the elliptic orders

### DIFF
--- a/TauCeti/NumberTheory/Modular/Orbits.lean
+++ b/TauCeti/NumberTheory/Modular/Orbits.lean
@@ -35,6 +35,7 @@ half-arc.
   when it is `i`.
 * `TauCeti.ModularGroup.orbit_mk_eq_ρ_iff`: a point of `𝒟` lies in the orbit of `ρ` exactly
   when it is `ρ` or `ρ + 1`.
+* `TauCeti.ModularGroup.orbit_mk_I_ne_orbit_mk_ρ`: the two elliptic orbits are distinct.
 * `TauCeti.ModularGroup.orbit_mk_injOn_fd_left`: the orbit map is injective on `𝒟` minus the
   right vertical edge and the right half-arc.
 
@@ -220,6 +221,11 @@ lemma orbit_mk_eq_ρ_iff {p : ℍ} (hp : p ∈ 𝒟) :
   · rintro (rfl | rfl)
     · rfl
     · simpa using orbit_mk_int_vadd 1 ρ
+
+/-- **The two elliptic orbits are distinct.** -/
+theorem orbit_mk_I_ne_orbit_mk_ρ :
+    (Quotient.mk'' I : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) ≠ Quotient.mk'' ρ :=
+  fun h ↦ I_ne_ρ ((orbit_mk_eq_I_iff _root_.ModularGroup.ρ_mem_fd).mp h.symm).symm
 
 /-- The orbit map is injective on the part of `𝒟` left of the boundary identifications: the
 points with `re < 1/2` which, if on the unit circle, have `re < 0`. `T` moves the right

--- a/TauCeti/NumberTheory/Modular/Stabilizer.lean
+++ b/TauCeti/NumberTheory/Modular/Stabilizer.lean
@@ -56,7 +56,6 @@ literally the `q` with `q ≠ ⟦i⟧` and `q ≠ ⟦ρ⟧`.
   `TauCeti.ModularGroup.ellipticOrder_ρ`, `TauCeti.ModularGroup.ellipticOrder_eq_one_iff`,
   `TauCeti.ModularGroup.ellipticOrder_pos` and
   `TauCeti.ModularGroup.cardStabilizerOnOrbit_eq_two_mul_ellipticOrder`.
-* `TauCeti.ModularGroup.orbit_mk_I_ne_orbit_mk_ρ`: the two elliptic orbits are distinct.
 
 ## References
 
@@ -254,7 +253,6 @@ noncomputable def ellipticOrder (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ)
 
 /-- Evaluating `ellipticOrder` on the orbit of `z` recovers the `PSL(2, ℤ)`-stabiliser order
 at `z`. -/
-@[simp]
 theorem ellipticOrder_mk (z : ℍ) :
     ellipticOrder (Quotient.mk'' z : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) =
       Nat.card (stabilizer PSL(2, ℤ) z) := by
@@ -268,36 +266,29 @@ theorem cardStabilizerOnOrbit_eq_two_mul_ellipticOrder
     (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
     TauCeti.cardStabilizerOnOrbit q = 2 * ellipticOrder q := by
   induction q using Quotient.inductionOn' with
-  | _ z => simpa using card_stabilizer_eq_two_mul_card_stabilizer_psl z
-
--- Neither of the two elliptic values below is `@[simp]`, for the reason recorded above for the
--- stabiliser counts: `ellipticOrder_mk` together with `MulAction.mem_stabilizer_iff` rewrites the
--- left-hand side into a `Nat.card` of a subtype, so it is not in simp-normal form.
+  | _ z => simpa only [TauCeti.cardStabilizerOnOrbit_mk, ellipticOrder_mk] using
+      card_stabilizer_eq_two_mul_card_stabilizer_psl z
 
 /-- **`e_i = 2`.** -/
+@[simp]
 theorem ellipticOrder_I :
     ellipticOrder (Quotient.mk'' I : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = 2 := by
   rw [ellipticOrder_mk, card_stabilizer_psl_I]
 
 /-- **`e_ρ = 3`.** -/
+@[simp]
 theorem ellipticOrder_ρ :
     ellipticOrder (Quotient.mk'' ρ : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = 3 := by
   rw [ellipticOrder_mk, card_stabilizer_psl_ρ]
 
 /-- **`e_P = 1` off the two elliptic orbits**: away from them `PSL(2, ℤ)` acts freely. -/
-theorem ellipticOrder_eq_one {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ}
+theorem ellipticOrder_eq_one_of_orbit_ne_I_of_orbit_ne_ρ
+    {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ}
     (hI : q ≠ Quotient.mk'' I) (hρ : q ≠ Quotient.mk'' ρ) : ellipticOrder q = 1 := by
   induction q using Quotient.inductionOn' with
-  | _ z => exact card_stabilizer_psl_eq_one_of_orbit_ne_I_of_orbit_ne_ρ z hI hρ
-
-/-- **The two elliptic orbits are distinct**: their elliptic orders `2` and `3` differ. -/
-theorem orbit_mk_I_ne_orbit_mk_ρ :
-    (Quotient.mk'' I : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) ≠ Quotient.mk'' ρ := by
-  intro h
-  have h2 : ellipticOrder (Quotient.mk'' I : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = 2 :=
-    ellipticOrder_I
-  rw [h, ellipticOrder_ρ] at h2
-  omega
+  | _ z =>
+    rw [ellipticOrder_mk]
+    exact card_stabilizer_psl_eq_one_of_orbit_ne_I_of_orbit_ne_ρ z hI hρ
 
 /-- **The elliptic order is positive**, so the weight `1 / e_P` is defined and nonzero. -/
 theorem ellipticOrder_pos (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : 0 < ellipticOrder q := by
@@ -305,12 +296,13 @@ theorem ellipticOrder_pos (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : 0 <
   · rw [hI, ellipticOrder_I]; omega
   by_cases hρ : q = Quotient.mk'' ρ
   · rw [hρ, ellipticOrder_ρ]; omega
-  · rw [ellipticOrder_eq_one hI hρ]; omega
+  · rw [ellipticOrder_eq_one_of_orbit_ne_I_of_orbit_ne_ρ hI hρ]; omega
 
-/-- **Exactly two orbits are elliptic**: `e_P = 1` characterises the non-elliptic orbits. -/
+/-- **`e_P = 1` characterises the non-elliptic orbits.** -/
 theorem ellipticOrder_eq_one_iff {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ} :
     ellipticOrder q = 1 ↔ q ≠ Quotient.mk'' I ∧ q ≠ Quotient.mk'' ρ := by
-  refine ⟨fun h ↦ ⟨fun hI ↦ ?_, fun hρ ↦ ?_⟩, fun h ↦ ellipticOrder_eq_one h.1 h.2⟩
+  refine ⟨fun h ↦ ⟨fun hI ↦ ?_, fun hρ ↦ ?_⟩,
+    fun h ↦ ellipticOrder_eq_one_of_orbit_ne_I_of_orbit_ne_ρ h.1 h.2⟩
   · rw [hI, ellipticOrder_I] at h; omega
   · rw [hρ, ellipticOrder_ρ] at h; omega
 

--- a/TauCeti/NumberTheory/Modular/Stabilizer.lean
+++ b/TauCeti/NumberTheory/Modular/Stabilizer.lean
@@ -53,8 +53,8 @@ literally the `q` with `q ≠ ⟦i⟧` and `q ≠ ⟦ρ⟧`.
   elliptic orders `e_i = 2`, `e_ρ = 3` and `e_P = 1`.
 * `TauCeti.ModularGroup.ellipticOrder`: those orders assembled into a single function `e_P` on
   the orbit space, with `TauCeti.ModularGroup.ellipticOrder_I`,
-  `TauCeti.ModularGroup.ellipticOrder_ρ`, `TauCeti.ModularGroup.ellipticOrder_eq_one_iff`,
-  `TauCeti.ModularGroup.ellipticOrder_pos` and
+  `TauCeti.ModularGroup.ellipticOrder_ρ`, `TauCeti.ModularGroup.ellipticOrder_pos`,
+  `TauCeti.ModularGroup.ellipticOrder_le_three` and
   `TauCeti.ModularGroup.cardStabilizerOnOrbit_eq_two_mul_ellipticOrder`.
 
 ## References
@@ -292,19 +292,23 @@ theorem ellipticOrder_eq_one_of_orbit_ne_I_of_orbit_ne_ρ
 
 /-- **The elliptic order is positive**, so the weight `1 / e_P` is defined and nonzero. -/
 theorem ellipticOrder_pos (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : 0 < ellipticOrder q := by
-  by_cases hI : q = Quotient.mk'' I
-  · rw [hI, ellipticOrder_I]; omega
-  by_cases hρ : q = Quotient.mk'' ρ
-  · rw [hρ, ellipticOrder_ρ]; omega
-  · rw [ellipticOrder_eq_one_of_orbit_ne_I_of_orbit_ne_ρ hI hρ]; omega
+  induction q using Quotient.inductionOn' with
+  | _ z =>
+    have h := card_stabilizer_eq_two_mul_card_stabilizer_psl z
+    have : 0 < Nat.card (stabilizer SL(2, ℤ) z) := Nat.card_pos
+    rw [ellipticOrder_mk]
+    omega
 
-/-- **`e_P = 1` characterises the non-elliptic orbits.** -/
-theorem ellipticOrder_eq_one_iff {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ} :
-    ellipticOrder q = 1 ↔ q ≠ Quotient.mk'' I ∧ q ≠ Quotient.mk'' ρ := by
-  refine ⟨fun h ↦ ⟨fun hI ↦ ?_, fun hρ ↦ ?_⟩,
-    fun h ↦ ellipticOrder_eq_one_of_orbit_ne_I_of_orbit_ne_ρ h.1 h.2⟩
-  · rw [hI, ellipticOrder_I] at h; omega
-  · rw [hρ, ellipticOrder_ρ] at h; omega
+/-- **Every elliptic order is at most `3`.** -/
+theorem ellipticOrder_le_three (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
+    ellipticOrder q ≤ 3 := by
+  by_cases hI : q = Quotient.mk'' I
+  · rw [hI, ellipticOrder_I]
+    omega
+  by_cases hρ : q = Quotient.mk'' ρ
+  · rw [hρ, ellipticOrder_ρ]
+  · rw [ellipticOrder_eq_one_of_orbit_ne_I_of_orbit_ne_ρ hI hρ]
+    omega
 
 end ModularGroup
 

--- a/TauCeti/NumberTheory/Modular/Stabilizer.lean
+++ b/TauCeti/NumberTheory/Modular/Stabilizer.lean
@@ -51,6 +51,12 @@ literally the `q` with `q ≠ ⟦i⟧` and `q ≠ ⟦ρ⟧`.
 * `TauCeti.ModularGroup.card_stabilizer_psl_I`, `TauCeti.ModularGroup.card_stabilizer_psl_ρ` and
   `TauCeti.ModularGroup.card_stabilizer_psl_eq_one_of_orbit_ne_I_of_orbit_ne_ρ`: the resulting
   elliptic orders `e_i = 2`, `e_ρ = 3` and `e_P = 1`.
+* `TauCeti.ModularGroup.ellipticOrder`: those orders assembled into a single function `e_P` on
+  the orbit space, with `TauCeti.ModularGroup.ellipticOrder_I`,
+  `TauCeti.ModularGroup.ellipticOrder_ρ`, `TauCeti.ModularGroup.ellipticOrder_eq_one_iff`,
+  `TauCeti.ModularGroup.ellipticOrder_pos` and
+  `TauCeti.ModularGroup.cardStabilizerOnOrbit_eq_two_mul_ellipticOrder`.
+* `TauCeti.ModularGroup.orbit_mk_I_ne_orbit_mk_ρ`: the two elliptic orbits are distinct.
 
 ## References
 
@@ -226,6 +232,87 @@ theorem card_stabilizer_psl_eq_one_of_orbit_ne_I_of_orbit_ne_ρ (z : ℍ)
   have h := card_stabilizer_eq_two_mul_card_stabilizer_psl z
   rw [card_stabilizer_eq_two_of_orbit_ne_I_of_orbit_ne_ρ z hI hρ] at h
   omega
+
+/-! ### The elliptic order of an orbit -/
+
+/-- **The elliptic order `e_P` of an `SL(2, ℤ)`-orbit of `ℍ`**: the order of the stabiliser, in
+`PSL(2, ℤ)`, of any point of the orbit. It is `2` on the orbit of `i`, `3` on the orbit of `ρ`
+and `1` everywhere else, and the valence formula weights an orbit by its reciprocal `1 / e_P`.
+
+The index type is the `SL(2, ℤ)`-orbit space, because that is the one the order divisor
+`TauCeti.ModularForm.orderOfVanishingOnOrbit` is defined on, while the count is taken in
+`PSL(2, ℤ)`, which is the group acting effectively. So this is not an instance of the generic
+`TauCeti.cardStabilizerOnOrbit`, whose quotient and whose group are the same; the two are
+related by `cardStabilizerOnOrbit_eq_two_mul_ellipticOrder`. -/
+noncomputable def ellipticOrder (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : ℕ :=
+  Quotient.liftOn' q (fun z ↦ Nat.card (stabilizer PSL(2, ℤ) z)) fun a b h ↦ by
+    -- the `SL(2, ℤ)`-orders agree along the orbit, and each is twice the `PSL(2, ℤ)` one
+    have ha := card_stabilizer_eq_two_mul_card_stabilizer_psl a
+    have hb := card_stabilizer_eq_two_mul_card_stabilizer_psl b
+    have hab := TauCeti.card_stabilizer_of_orbitRel h
+    omega
+
+/-- Evaluating `ellipticOrder` on the orbit of `z` recovers the `PSL(2, ℤ)`-stabiliser order
+at `z`. -/
+@[simp]
+theorem ellipticOrder_mk (z : ℍ) :
+    ellipticOrder (Quotient.mk'' z : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) =
+      Nat.card (stabilizer PSL(2, ℤ) z) := by
+  unfold ellipticOrder
+  rfl
+
+/-- **The matrix stabiliser order is twice the elliptic order**, orbitwise: the centre `±1` acts
+trivially. This is `card_stabilizer_eq_two_mul_card_stabilizer_psl` read on the orbit space, and
+it is what relates `ellipticOrder` to the generic `TauCeti.cardStabilizerOnOrbit`. -/
+theorem cardStabilizerOnOrbit_eq_two_mul_ellipticOrder
+    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
+    TauCeti.cardStabilizerOnOrbit q = 2 * ellipticOrder q := by
+  induction q using Quotient.inductionOn' with
+  | _ z => simpa using card_stabilizer_eq_two_mul_card_stabilizer_psl z
+
+-- Neither of the two elliptic values below is `@[simp]`, for the reason recorded above for the
+-- stabiliser counts: `ellipticOrder_mk` together with `MulAction.mem_stabilizer_iff` rewrites the
+-- left-hand side into a `Nat.card` of a subtype, so it is not in simp-normal form.
+
+/-- **`e_i = 2`.** -/
+theorem ellipticOrder_I :
+    ellipticOrder (Quotient.mk'' I : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = 2 := by
+  rw [ellipticOrder_mk, card_stabilizer_psl_I]
+
+/-- **`e_ρ = 3`.** -/
+theorem ellipticOrder_ρ :
+    ellipticOrder (Quotient.mk'' ρ : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = 3 := by
+  rw [ellipticOrder_mk, card_stabilizer_psl_ρ]
+
+/-- **`e_P = 1` off the two elliptic orbits**: away from them `PSL(2, ℤ)` acts freely. -/
+theorem ellipticOrder_eq_one {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ}
+    (hI : q ≠ Quotient.mk'' I) (hρ : q ≠ Quotient.mk'' ρ) : ellipticOrder q = 1 := by
+  induction q using Quotient.inductionOn' with
+  | _ z => exact card_stabilizer_psl_eq_one_of_orbit_ne_I_of_orbit_ne_ρ z hI hρ
+
+/-- **The two elliptic orbits are distinct**: their elliptic orders `2` and `3` differ. -/
+theorem orbit_mk_I_ne_orbit_mk_ρ :
+    (Quotient.mk'' I : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) ≠ Quotient.mk'' ρ := by
+  intro h
+  have h2 : ellipticOrder (Quotient.mk'' I : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) = 2 :=
+    ellipticOrder_I
+  rw [h, ellipticOrder_ρ] at h2
+  omega
+
+/-- **The elliptic order is positive**, so the weight `1 / e_P` is defined and nonzero. -/
+theorem ellipticOrder_pos (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : 0 < ellipticOrder q := by
+  by_cases hI : q = Quotient.mk'' I
+  · rw [hI, ellipticOrder_I]; omega
+  by_cases hρ : q = Quotient.mk'' ρ
+  · rw [hρ, ellipticOrder_ρ]; omega
+  · rw [ellipticOrder_eq_one hI hρ]; omega
+
+/-- **Exactly two orbits are elliptic**: `e_P = 1` characterises the non-elliptic orbits. -/
+theorem ellipticOrder_eq_one_iff {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ} :
+    ellipticOrder q = 1 ↔ q ≠ Quotient.mk'' I ∧ q ≠ Quotient.mk'' ρ := by
+  refine ⟨fun h ↦ ⟨fun hI ↦ ?_, fun hρ ↦ ?_⟩, fun h ↦ ellipticOrder_eq_one h.1 h.2⟩
+  · rw [hI, ellipticOrder_I] at h; omega
+  · rw [hρ, ellipticOrder_ρ] at h; omega
 
 end ModularGroup
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
@@ -49,14 +49,12 @@ in the uniform form is there a single weight per orbit to redistribute.
 ## Main declarations
 
 * `valence_formula` (in `TauCeti.ModularForm`): the valence formula.
-* `TauCeti.ModularForm.weightedOrderOfVanishingOnOrbit`: the summand `ord_P f / e_P` of its
-  uniform form.
 * `TauCeti.ModularForm.valence_formula_weighted`: the uniform form.
-* `TauCeti.ModularForm.twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder`: the resulting
-  bound
+* `TauCeti.ModularForm.twelve_mul_orderOfVanishingOnOrbit_le_weight_mul_ellipticOrder`: the
+  resulting bound
   `12 · ord_P f ≤ k · e_P` on a single orbit, and
   `TauCeti.ModularForm.orderOfVanishingOnOrbit_eq_zero_of_weight_mul_ellipticOrder_lt_twelve`,
-  the nonvanishing it forces when `k · e_P < 12`.
+  the vanishing-order-zero conclusion it forces when `k · e_P < 12`.
 
 ## References
 
@@ -107,48 +105,6 @@ variable {F : Type*} [FunLike F ℍ ℂ] {k : ℤ}
 
 /-! ### The uniform form, weighted by the elliptic orders -/
 
-/-- **Splitting the uniform divisor sum at the two elliptic orbits.** Away from them the weight
-is `1`, so the sum over all orbits is the non-elliptic sum of `valence_formula` plus the two
-weighted elliptic terms. -/
-lemma finsum_weightedOrderOfVanishingOnOrbit_eq [ModularFormClass F 𝒮ℒ k] (f : F) :
-    (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ,
-      weightedOrderOfVanishingOnOrbit f q) =
-      ((∑ᶠ q : NonEllipticOrbit, orderOfVanishingOnOrbit f q.val : ℤ) : ℚ)
-        + (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2
-        + (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
-  classical
-  set S : Set (MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :=
-    {Quotient.mk'' UpperHalfPlane.I, Quotient.mk'' ρ} with hSdef
-  have hmem : ∀ q, q ∈ Sᶜ ↔ (q ≠ Quotient.mk'' UpperHalfPlane.I ∧ q ≠ Quotient.mk'' ρ) := by
-    intro q
-    simp [hSdef, not_or]
-  -- the two-element part contributes the weighted elliptic terms
-  have hpair : (∑ᶠ q ∈ S, weightedOrderOfVanishingOnOrbit f q) =
-      (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2
-        + (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
-    rw [hSdef, finsum_mem_pair ModularGroup.orbit_mk_I_ne_orbit_mk_ρ,
-      weightedOrderOfVanishingOnOrbit_I, weightedOrderOfVanishingOnOrbit_ρ]
-  -- the complement is the non-elliptic orbit type, on which the weight is trivial
-  have hcompl : (∑ᶠ q ∈ Sᶜ, weightedOrderOfVanishingOnOrbit f q) =
-      ((∑ᶠ q : NonEllipticOrbit, orderOfVanishingOnOrbit f q.val : ℤ) : ℚ) := by
-    have hcast := AddMonoidHom.map_finsum_of_injective (Int.castAddHom ℚ) Int.cast_injective
-      fun q : NonEllipticOrbit ↦ orderOfVanishingOnOrbit f q.val
-    have hval : (∑ᶠ q ∈ Sᶜ, weightedOrderOfVanishingOnOrbit f q) =
-        ∑ᶠ q ∈ Sᶜ, ((orderOfVanishingOnOrbit f q : ℤ) : ℚ) :=
-      finsum_mem_congr rfl fun q hq ↦
-        weightedOrderOfVanishingOnOrbit_of_orbit_ne_I_of_orbit_ne_ρ f
-          ((hmem q).1 hq).1 ((hmem q).1 hq).2
-    rw [hval, ← finsum_set_coe_eq_finsum_mem,
-      ← finsum_comp_equiv (Equiv.subtypeEquivRight fun q ↦ (hmem q).symm)
-        (f := fun q : (Sᶜ : Set _) ↦ ((orderOfVanishingOnOrbit f q.val : ℤ) : ℚ))]
-    simpa using hcast.symm
-  have hsplit := finsum_mem_add_sdiff' (f := weightedOrderOfVanishingOnOrbit f)
-    (Set.subset_univ S)
-    ((hasFiniteSupport_weightedOrderOfVanishingOnOrbit f).inter_of_right Set.univ)
-  rw [finsum_mem_univ, ← Set.compl_eq_univ_sdiff, hpair, hcompl] at hsplit
-  rw [← hsplit]
-  ring
-
 /-- **The valence formula, uniformly over the orbit space.** For a nonzero weight-`k` modular
 form on `SL₂(ℤ)`, weighting each orbit by the reciprocal of its elliptic order,
 
@@ -162,7 +118,7 @@ theorem valence_formula_weighted [ModularFormClass F 𝒮ℒ k] (f : F) (hf : (�
     (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ, weightedOrderOfVanishingOnOrbit f q)
       + (qExpansionOrderAtCusp 1 ⇑f : ℚ) = (k : ℚ) / 12 := by
   have key := valence_formula f hf
-  rw [finsum_weightedOrderOfVanishingOnOrbit_eq f]
+  rw [finsum_weightedOrderOfVanishingOnOrbit_eq_finsum_nonElliptic_add_elliptic f]
   refine Rat.cast_injective (α := ℂ) ?_
   push_cast
   linear_combination key
@@ -171,7 +127,7 @@ theorem valence_formula_weighted [ModularFormClass F 𝒮ℒ k] (f : F) (hf : (�
 
 /-- **The mass at one orbit is bounded by the total mass**: every other term of the uniform
 valence formula is nonnegative, so `12 · ord_P f ≤ k · e_P` for a nonzero form. -/
-theorem twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder
+theorem twelve_mul_orderOfVanishingOnOrbit_le_weight_mul_ellipticOrder
     [ModularFormClass F 𝒮ℒ k] (f : F)
     (hf : (⇑f : ℍ → ℂ) ≠ 0) (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
     12 * orderOfVanishingOnOrbit f q ≤ k * ModularGroup.ellipticOrder q := by
@@ -183,21 +139,26 @@ theorem twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder
   have he : (0 : ℚ) < (ModularGroup.ellipticOrder q : ℚ) := by
     exact_mod_cast ModularGroup.ellipticOrder_pos q
   have hle : weightedOrderOfVanishingOnOrbit f q ≤ (k : ℚ) / 12 := by linarith
-  rw [weightedOrderOfVanishingOnOrbit_def, div_le_div_iff₀ he (by norm_num)] at hle
+  have hle' := mul_le_mul_of_nonneg_left hle he.le
+  rw [ellipticOrder_mul_weightedOrderOfVanishingOnOrbit] at hle'
   have : (12 : ℚ) * (orderOfVanishingOnOrbit f q : ℚ) ≤
-      (k : ℚ) * (ModularGroup.ellipticOrder q : ℚ) := by linarith
+      (k : ℚ) * (ModularGroup.ellipticOrder q : ℚ) := by nlinarith
   exact_mod_cast this
 
-/-- **A small enough weighted degree forces nonvanishing at an orbit**: if `k · e_P < 12`, a
-zero at `P` would make the single-orbit bound impossible. -/
+/-- **A small enough weighted degree forces vanishing order zero at an orbit.** If `f` is
+nonzero, this says that `f` does not vanish there; the statement also covers the zero form under
+the convention that its vanishing order is zero. -/
 theorem orderOfVanishingOnOrbit_eq_zero_of_weight_mul_ellipticOrder_lt_twelve
-    [ModularFormClass F 𝒮ℒ k] (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0)
+    [ModularFormClass F 𝒮ℒ k] (f : F)
     {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ}
     (hk : k * ModularGroup.ellipticOrder q < 12) :
     orderOfVanishingOnOrbit f q = 0 := by
-  have hbound := twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder f hf q
-  have := orderOfVanishingOnOrbit_nonneg f q
-  omega
+  rcases eq_or_ne (⇑f : ℍ → ℂ) 0 with hf | hf
+  · induction q using Quotient.inductionOn' with
+    | _ p => simp [hf]
+  · have hbound := twelve_mul_orderOfVanishingOnOrbit_le_weight_mul_ellipticOrder f hf q
+    have := orderOfVanishingOnOrbit_nonneg f q
+    omega
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.NumberTheory.Modular.Stabilizer
 public import TauCeti.NumberTheory.ModularForms.Order.AtCusp
 public import TauCeti.NumberTheory.ModularForms.Order.OrbitReduction
 import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.ValencePV
@@ -26,9 +27,37 @@ the sum over the canonical left representatives and then as the three point-sum 
 strict interior, left vertical edge, left half-arc — which are literally the families of the
 contour identity.
 
+## The uniform form, and why it is the one general level needs
+
+Singling out `i` and `ρ` is an artefact of level one, where those are the only two elliptic
+points. The intrinsic statement weights *every* orbit by the reciprocal `1 / e_P` of its
+elliptic order — the order of its `PSL(2, ℤ)`-stabiliser, `TauCeti.ModularGroup.ellipticOrder` —
+and then reads
+
+`∑_{P ∈ SL₂(ℤ) \ ℍ} (1 / e_P) · ord_P f + ord_∞ f = k / 12`,
+
+with the `1/2` and the `1/3` produced by `e_i = 2` and `e_ρ = 3` and every other weight equal
+to `1`. That is `valence_formula_weighted` below, stated over `ℚ` because the weights are
+rational and the two sides are; the level-one shape above is the special case obtained by
+splitting off the two orbits at which `e_P ≠ 1`.
+
+The uniform shape is what the general-level formula of the Tau Ceti ModularForms roadmap's
+Layer 1 milestone **"General level — by the coset norm"** consumes: there the level-one formula
+is applied to the norm `∏_{γ ∈ Γ \ SL₂(ℤ)} f ∣[k] γ`, and each level-one weight `1 / e_P` is
+redistributed over the `Γ`-orbits inside the `SL₂(ℤ)`-orbit of `P` by a stabiliser count. Only
+in the uniform form is there a single weight per orbit to redistribute.
+
 ## Main declarations
 
 * `valence_formula` (in `TauCeti.ModularForm`): the valence formula.
+* `TauCeti.ModularForm.weightedOrderOnOrbit`: the summand `ord_P f / e_P` of its uniform form.
+* `TauCeti.ModularForm.valence_formula_weighted`: the uniform form.
+* `TauCeti.ModularForm.twelve_mul_orderOfVanishingOnOrbit_le`: the resulting bound
+  `12 · ord_P f ≤ k · e_P` on a single orbit, and
+  `TauCeti.ModularForm.orderOfVanishingOnOrbit_eq_zero_of_weight_lt_twelve`, the vanishing it
+  forces off the elliptic orbits in weight `k < 12`.
+* `TauCeti.ModularForm.twelve_mul_qExpansionOrderAtCusp_le`: the companion bound
+  `12 · ord_∞ f ≤ k` at the cusp.
 
 ## References
 
@@ -36,6 +65,8 @@ The statement shape follows AINTLIB's `valence_formula_textbook_orbit_finsum`
 ([github.com/CBirkbeck/AINTLIB](https://github.com/CBirkbeck/AINTLIB), commit `2baa76f742`,
 Apache 2.0, `projects/LeanModularForms/LeanModularForms/ForMathlib/ValenceFormula.lean`),
 with its `h_core` hypothesis discharged by the contour development rather than assumed.
+The uniform form is the one displayed in the roadmap, and in Diamond–Shurman, *A First Course
+in Modular Forms*, §3.1.
 -/
 
 public section
@@ -72,6 +103,160 @@ theorem valence_formula {F : Type*} [FunLike F ℍ ℂ] {k : ℤ} [ModularFormCl
     (fun p hpfd hord ↦ mem_fdZeros.mpr ⟨hpfd, hord⟩)
   push_cast at hsplit key ⊢
   linear_combination hsplit + key
+
+/-! ### The uniform form, weighted by the elliptic orders -/
+
+variable {F : Type*} [FunLike F ℍ ℂ] {k : ℤ}
+
+/-- **The elliptic-weighted vanishing order of `f` on an orbit**: `ord_P f / e_P`, the summand
+of the valence formula in its uniform form `∑_P (1 / e_P) · ord_P f + ord_∞ f = k / 12`. The
+weight is `1` on all but the two elliptic orbits, where it is `1/2` and `1/3`. -/
+noncomputable def weightedOrderOnOrbit [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
+    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ :=
+  (orderOfVanishingOnOrbit f q : ℚ) / (ModularGroup.ellipticOrder q : ℚ)
+
+/-- Off the two elliptic orbits the weight is `1`, so the summand is the plain order. -/
+lemma weightedOrderOnOrbit_of_ne [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
+    {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ} (hI : q ≠ Quotient.mk'' UpperHalfPlane.I)
+    (hρ : q ≠ Quotient.mk'' ρ) :
+    weightedOrderOnOrbit f q = (orderOfVanishingOnOrbit f q : ℚ) := by
+  rw [weightedOrderOnOrbit, ModularGroup.ellipticOrder_eq_one hI hρ]
+  norm_num
+
+/-- At the orbit of `i` the weight is `1/2`, from `e_i = 2`. -/
+lemma weightedOrderOnOrbit_I [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
+    weightedOrderOnOrbit f (Quotient.mk'' UpperHalfPlane.I) =
+      (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2 := by
+  rw [weightedOrderOnOrbit, ModularGroup.ellipticOrder_I, orderOfVanishingOnOrbit_mk]
+  norm_num
+
+/-- At the orbit of `ρ` the weight is `1/3`, from `e_ρ = 3`. -/
+lemma weightedOrderOnOrbit_ρ [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
+    weightedOrderOnOrbit f (Quotient.mk'' ρ) = (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
+  rw [weightedOrderOnOrbit, ModularGroup.ellipticOrder_ρ, orderOfVanishingOnOrbit_mk]
+  norm_num
+
+/-- Every summand of the uniform valence formula is nonnegative: a modular form is holomorphic
+and the weights are positive. -/
+lemma weightedOrderOnOrbit_nonneg [ModularFormClass F 𝒮ℒ k] (f : F)
+    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : 0 ≤ weightedOrderOnOrbit f q := by
+  refine div_nonneg ?_ (by positivity)
+  exact_mod_cast orderOfVanishingOnOrbit_nonneg f q
+
+/-- Only finitely many orbits contribute to the uniform valence formula: the weight cannot
+create support where the order has none. -/
+lemma hasFiniteSupport_weightedOrderOnOrbit [ModularFormClass F 𝒮ℒ k] (f : F) :
+    Function.HasFiniteSupport (weightedOrderOnOrbit f) := by
+  refine (hasFiniteSupport_orderOfVanishingOnOrbit f).subset fun q hq ↦ ?_
+  simp only [Function.mem_support, ne_eq] at hq ⊢
+  exact fun h ↦ hq (by rw [weightedOrderOnOrbit, h]; simp)
+
+/-- **Splitting the uniform divisor sum at the two elliptic orbits.** Away from them the weight
+is `1`, so the sum over all orbits is the non-elliptic sum of `valence_formula` plus the two
+weighted elliptic terms. -/
+lemma finsum_weightedOrderOnOrbit_eq [ModularFormClass F 𝒮ℒ k] (f : F) :
+    (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ, weightedOrderOnOrbit f q) =
+      ((∑ᶠ q : NonEllipticOrbit, orderOfVanishingOnOrbit f q.val : ℤ) : ℚ)
+        + (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2
+        + (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
+  classical
+  set S : Set (MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :=
+    {Quotient.mk'' UpperHalfPlane.I, Quotient.mk'' ρ} with hSdef
+  have hmem : ∀ q, q ∈ Sᶜ ↔ (q ≠ Quotient.mk'' UpperHalfPlane.I ∧ q ≠ Quotient.mk'' ρ) := by
+    intro q
+    simp [hSdef, not_or]
+  -- the two-element part contributes the weighted elliptic terms
+  have hpair : (∑ᶠ q ∈ S, weightedOrderOnOrbit f q) =
+      (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2
+        + (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
+    rw [hSdef, finsum_mem_pair ModularGroup.orbit_mk_I_ne_orbit_mk_ρ, weightedOrderOnOrbit_I,
+      weightedOrderOnOrbit_ρ]
+  -- the complement is the non-elliptic orbit type, on which the weight is trivial
+  have hcompl : (∑ᶠ q ∈ Sᶜ, weightedOrderOnOrbit f q) =
+      ((∑ᶠ q : NonEllipticOrbit, orderOfVanishingOnOrbit f q.val : ℤ) : ℚ) := by
+    have hcast := AddMonoidHom.map_finsum_of_injective (Int.castAddHom ℚ) Int.cast_injective
+      fun q : NonEllipticOrbit ↦ orderOfVanishingOnOrbit f q.val
+    have hval : (∑ᶠ q ∈ Sᶜ, weightedOrderOnOrbit f q) =
+        ∑ᶠ q ∈ Sᶜ, ((orderOfVanishingOnOrbit f q : ℤ) : ℚ) :=
+      finsum_mem_congr rfl fun q hq ↦
+        weightedOrderOnOrbit_of_ne f ((hmem q).1 hq).1 ((hmem q).1 hq).2
+    rw [hval, ← finsum_set_coe_eq_finsum_mem,
+      ← finsum_comp_equiv (Equiv.subtypeEquivRight fun q ↦ (hmem q).symm)
+        (f := fun q : (Sᶜ : Set _) ↦ ((orderOfVanishingOnOrbit f q.val : ℤ) : ℚ))]
+    simpa using hcast.symm
+  have hsplit := finsum_mem_add_sdiff' (f := weightedOrderOnOrbit f) (Set.subset_univ S)
+    ((hasFiniteSupport_weightedOrderOnOrbit f).inter_of_right Set.univ)
+  rw [finsum_mem_univ, ← Set.compl_eq_univ_sdiff, hpair, hcompl] at hsplit
+  rw [← hsplit]
+  ring
+
+/-- **The valence formula, uniformly over the orbit space.** For a nonzero weight-`k` modular
+form on `SL₂(ℤ)`, weighting each orbit by the reciprocal of its elliptic order,
+
+`∑_{P ∈ SL₂(ℤ) \ ℍ} (1 / e_P) · ord_P f + ord_∞ f = k / 12`.
+
+This is `valence_formula` with the two exceptional orbits absorbed into the general weight:
+`e_i = 2` and `e_ρ = 3` restore the `1/2` and the `1/3`, and `e_P = 1` elsewhere makes every
+other orbit count once. It is the form the general-level formula redistributes along the norm
+map, where a single weight per orbit is what a stabiliser count can split. -/
+theorem valence_formula_weighted [ModularFormClass F 𝒮ℒ k] (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ, weightedOrderOnOrbit f q)
+      + (qExpansionOrderAtCusp 1 ⇑f : ℚ) = (k : ℚ) / 12 := by
+  have key := valence_formula f hf
+  rw [finsum_weightedOrderOnOrbit_eq f]
+  refine Rat.cast_injective (α := ℂ) ?_
+  push_cast
+  linear_combination key
+
+/-! ### Consequences for a single orbit -/
+
+/-- **The mass at one orbit is bounded by the total mass**: every other term of the uniform
+valence formula is nonnegative, so `12 · ord_P f ≤ k · e_P` for a nonzero form. -/
+theorem twelve_mul_orderOfVanishingOnOrbit_le [ModularFormClass F 𝒮ℒ k] (f : F)
+    (hf : (⇑f : ℍ → ℂ) ≠ 0) (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
+    12 * orderOfVanishingOnOrbit f q ≤ k * ModularGroup.ellipticOrder q := by
+  have hsingle := single_le_finsum q (hasFiniteSupport_weightedOrderOnOrbit f)
+    (weightedOrderOnOrbit_nonneg f)
+  have hcusp : (0 : ℚ) ≤ (qExpansionOrderAtCusp 1 ⇑f : ℚ) := by
+    exact_mod_cast qExpansionOrderAtCusp_nonneg 1 ⇑f
+  have htotal := valence_formula_weighted f hf
+  have he : (0 : ℚ) < (ModularGroup.ellipticOrder q : ℚ) := by
+    exact_mod_cast ModularGroup.ellipticOrder_pos q
+  have hle : weightedOrderOnOrbit f q ≤ (k : ℚ) / 12 := by linarith
+  rw [weightedOrderOnOrbit, div_le_div_iff₀ he (by norm_num)] at hle
+  have : (12 : ℚ) * (orderOfVanishingOnOrbit f q : ℚ) ≤
+      (k : ℚ) * (ModularGroup.ellipticOrder q : ℚ) := by linarith
+  exact_mod_cast this
+
+/-- The same bound read at a point of `ℍ` rather than at its orbit. -/
+theorem twelve_mul_orderOfVanishingAt_le [ModularFormClass F 𝒮ℒ k] (f : F)
+    (hf : (⇑f : ℍ → ℂ) ≠ 0) (p : ℍ) :
+    12 * orderOfVanishingAt ⇑f p ≤ k * ModularGroup.ellipticOrder (Quotient.mk'' p) := by
+  simpa using twelve_mul_orderOfVanishingOnOrbit_le f hf (Quotient.mk'' p)
+
+/-- **The level-one cusp bound in exact form**: `12 · ord_∞ f ≤ k` for a nonzero form, because
+the interior mass it competes with is nonnegative. This is the order-side sharpening of
+Mathlib's `ModularForm.sturm_bound_levelOne`, which compares two forms rather than bounding one
+form's cusp order. -/
+theorem twelve_mul_qExpansionOrderAtCusp_le [ModularFormClass F 𝒮ℒ k] (f : F)
+    (hf : (⇑f : ℍ → ℂ) ≠ 0) : 12 * qExpansionOrderAtCusp 1 ⇑f ≤ k := by
+  have hinterior : (0 : ℚ) ≤
+      ∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ, weightedOrderOnOrbit f q :=
+    finsum_nonneg (weightedOrderOnOrbit_nonneg f)
+  have htotal := valence_formula_weighted f hf
+  have : (12 : ℚ) * (qExpansionOrderAtCusp 1 ⇑f : ℚ) ≤ (k : ℚ) := by linarith
+  exact_mod_cast this
+
+/-- **A nonzero form of weight `k < 12` cannot vanish off the elliptic orbits**: there the
+weight is `1`, so a single zero would already carry mass `1 > k / 12`. -/
+theorem orderOfVanishingOnOrbit_eq_zero_of_weight_lt_twelve [ModularFormClass F 𝒮ℒ k] (f : F)
+    (hf : (⇑f : ℍ → ℂ) ≠ 0) (hk : k < 12) {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ}
+    (hI : q ≠ Quotient.mk'' UpperHalfPlane.I) (hρ : q ≠ Quotient.mk'' ρ) :
+    orderOfVanishingOnOrbit f q = 0 := by
+  have hbound := twelve_mul_orderOfVanishingOnOrbit_le f hf q
+  rw [ModularGroup.ellipticOrder_eq_one hI hρ] at hbound
+  have := orderOfVanishingOnOrbit_nonneg f q
+  omega
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.Modular.Stabilizer
 public import TauCeti.NumberTheory.ModularForms.Order.AtCusp
 public import TauCeti.NumberTheory.ModularForms.Order.OrbitReduction
 import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.ValencePV
@@ -50,14 +49,14 @@ in the uniform form is there a single weight per orbit to redistribute.
 ## Main declarations
 
 * `valence_formula` (in `TauCeti.ModularForm`): the valence formula.
-* `TauCeti.ModularForm.weightedOrderOnOrbit`: the summand `ord_P f / e_P` of its uniform form.
+* `TauCeti.ModularForm.weightedOrderOfVanishingOnOrbit`: the summand `ord_P f / e_P` of its
+  uniform form.
 * `TauCeti.ModularForm.valence_formula_weighted`: the uniform form.
-* `TauCeti.ModularForm.twelve_mul_orderOfVanishingOnOrbit_le`: the resulting bound
+* `TauCeti.ModularForm.twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder`: the resulting
+  bound
   `12 · ord_P f ≤ k · e_P` on a single orbit, and
-  `TauCeti.ModularForm.orderOfVanishingOnOrbit_eq_zero_of_weight_lt_twelve`, the vanishing it
-  forces off the elliptic orbits in weight `k < 12`.
-* `TauCeti.ModularForm.twelve_mul_qExpansionOrderAtCusp_le`: the companion bound
-  `12 · ord_∞ f ≤ k` at the cusp.
+  `TauCeti.ModularForm.orderOfVanishingOnOrbit_eq_zero_of_weight_mul_ellipticOrder_lt_twelve`,
+  the vanishing it forces when `k · e_P < 12`.
 
 ## References
 
@@ -65,8 +64,8 @@ The statement shape follows AINTLIB's `valence_formula_textbook_orbit_finsum`
 ([github.com/CBirkbeck/AINTLIB](https://github.com/CBirkbeck/AINTLIB), commit `2baa76f742`,
 Apache 2.0, `projects/LeanModularForms/LeanModularForms/ForMathlib/ValenceFormula.lean`),
 with its `h_core` hypothesis discharged by the contour development rather than assumed.
-The uniform form is the one displayed in the roadmap, and in Diamond–Shurman, *A First Course
-in Modular Forms*, §3.1.
+The uniform form is the one displayed in the roadmap and follows the divisor-of-automorphic-forms
+development in Diamond–Shurman, *A First Course in Modular Forms*, §§3.5–3.6.
 -/
 
 public section
@@ -104,58 +103,16 @@ theorem valence_formula {F : Type*} [FunLike F ℍ ℂ] {k : ℤ} [ModularFormCl
   push_cast at hsplit key ⊢
   linear_combination hsplit + key
 
-/-! ### The uniform form, weighted by the elliptic orders -/
-
 variable {F : Type*} [FunLike F ℍ ℂ] {k : ℤ}
 
-/-- **The elliptic-weighted vanishing order of `f` on an orbit**: `ord_P f / e_P`, the summand
-of the valence formula in its uniform form `∑_P (1 / e_P) · ord_P f + ord_∞ f = k / 12`. The
-weight is `1` on all but the two elliptic orbits, where it is `1/2` and `1/3`. -/
-noncomputable def weightedOrderOnOrbit [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
-    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ :=
-  (orderOfVanishingOnOrbit f q : ℚ) / (ModularGroup.ellipticOrder q : ℚ)
-
-/-- Off the two elliptic orbits the weight is `1`, so the summand is the plain order. -/
-lemma weightedOrderOnOrbit_of_ne [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
-    {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ} (hI : q ≠ Quotient.mk'' UpperHalfPlane.I)
-    (hρ : q ≠ Quotient.mk'' ρ) :
-    weightedOrderOnOrbit f q = (orderOfVanishingOnOrbit f q : ℚ) := by
-  rw [weightedOrderOnOrbit, ModularGroup.ellipticOrder_eq_one hI hρ]
-  norm_num
-
-/-- At the orbit of `i` the weight is `1/2`, from `e_i = 2`. -/
-lemma weightedOrderOnOrbit_I [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
-    weightedOrderOnOrbit f (Quotient.mk'' UpperHalfPlane.I) =
-      (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2 := by
-  rw [weightedOrderOnOrbit, ModularGroup.ellipticOrder_I, orderOfVanishingOnOrbit_mk]
-  norm_num
-
-/-- At the orbit of `ρ` the weight is `1/3`, from `e_ρ = 3`. -/
-lemma weightedOrderOnOrbit_ρ [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
-    weightedOrderOnOrbit f (Quotient.mk'' ρ) = (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
-  rw [weightedOrderOnOrbit, ModularGroup.ellipticOrder_ρ, orderOfVanishingOnOrbit_mk]
-  norm_num
-
-/-- Every summand of the uniform valence formula is nonnegative: a modular form is holomorphic
-and the weights are positive. -/
-lemma weightedOrderOnOrbit_nonneg [ModularFormClass F 𝒮ℒ k] (f : F)
-    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : 0 ≤ weightedOrderOnOrbit f q := by
-  refine div_nonneg ?_ (by positivity)
-  exact_mod_cast orderOfVanishingOnOrbit_nonneg f q
-
-/-- Only finitely many orbits contribute to the uniform valence formula: the weight cannot
-create support where the order has none. -/
-lemma hasFiniteSupport_weightedOrderOnOrbit [ModularFormClass F 𝒮ℒ k] (f : F) :
-    Function.HasFiniteSupport (weightedOrderOnOrbit f) := by
-  refine (hasFiniteSupport_orderOfVanishingOnOrbit f).subset fun q hq ↦ ?_
-  simp only [Function.mem_support, ne_eq] at hq ⊢
-  exact fun h ↦ hq (by rw [weightedOrderOnOrbit, h]; simp)
+/-! ### The uniform form, weighted by the elliptic orders -/
 
 /-- **Splitting the uniform divisor sum at the two elliptic orbits.** Away from them the weight
 is `1`, so the sum over all orbits is the non-elliptic sum of `valence_formula` plus the two
 weighted elliptic terms. -/
-lemma finsum_weightedOrderOnOrbit_eq [ModularFormClass F 𝒮ℒ k] (f : F) :
-    (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ, weightedOrderOnOrbit f q) =
+lemma finsum_weightedOrderOfVanishingOnOrbit_eq [ModularFormClass F 𝒮ℒ k] (f : F) :
+    (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ,
+      weightedOrderOfVanishingOnOrbit f q) =
       ((∑ᶠ q : NonEllipticOrbit, orderOfVanishingOnOrbit f q.val : ℤ) : ℚ)
         + (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2
         + (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
@@ -166,26 +123,28 @@ lemma finsum_weightedOrderOnOrbit_eq [ModularFormClass F 𝒮ℒ k] (f : F) :
     intro q
     simp [hSdef, not_or]
   -- the two-element part contributes the weighted elliptic terms
-  have hpair : (∑ᶠ q ∈ S, weightedOrderOnOrbit f q) =
+  have hpair : (∑ᶠ q ∈ S, weightedOrderOfVanishingOnOrbit f q) =
       (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2
         + (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
-    rw [hSdef, finsum_mem_pair ModularGroup.orbit_mk_I_ne_orbit_mk_ρ, weightedOrderOnOrbit_I,
-      weightedOrderOnOrbit_ρ]
+    rw [hSdef, finsum_mem_pair ModularGroup.orbit_mk_I_ne_orbit_mk_ρ,
+      weightedOrderOfVanishingOnOrbit_I, weightedOrderOfVanishingOnOrbit_ρ]
   -- the complement is the non-elliptic orbit type, on which the weight is trivial
-  have hcompl : (∑ᶠ q ∈ Sᶜ, weightedOrderOnOrbit f q) =
+  have hcompl : (∑ᶠ q ∈ Sᶜ, weightedOrderOfVanishingOnOrbit f q) =
       ((∑ᶠ q : NonEllipticOrbit, orderOfVanishingOnOrbit f q.val : ℤ) : ℚ) := by
     have hcast := AddMonoidHom.map_finsum_of_injective (Int.castAddHom ℚ) Int.cast_injective
       fun q : NonEllipticOrbit ↦ orderOfVanishingOnOrbit f q.val
-    have hval : (∑ᶠ q ∈ Sᶜ, weightedOrderOnOrbit f q) =
+    have hval : (∑ᶠ q ∈ Sᶜ, weightedOrderOfVanishingOnOrbit f q) =
         ∑ᶠ q ∈ Sᶜ, ((orderOfVanishingOnOrbit f q : ℤ) : ℚ) :=
       finsum_mem_congr rfl fun q hq ↦
-        weightedOrderOnOrbit_of_ne f ((hmem q).1 hq).1 ((hmem q).1 hq).2
+        weightedOrderOfVanishingOnOrbit_of_orbit_ne_I_of_orbit_ne_ρ f
+          ((hmem q).1 hq).1 ((hmem q).1 hq).2
     rw [hval, ← finsum_set_coe_eq_finsum_mem,
       ← finsum_comp_equiv (Equiv.subtypeEquivRight fun q ↦ (hmem q).symm)
         (f := fun q : (Sᶜ : Set _) ↦ ((orderOfVanishingOnOrbit f q.val : ℤ) : ℚ))]
     simpa using hcast.symm
-  have hsplit := finsum_mem_add_sdiff' (f := weightedOrderOnOrbit f) (Set.subset_univ S)
-    ((hasFiniteSupport_weightedOrderOnOrbit f).inter_of_right Set.univ)
+  have hsplit := finsum_mem_add_sdiff' (f := weightedOrderOfVanishingOnOrbit f)
+    (Set.subset_univ S)
+    ((hasFiniteSupport_weightedOrderOfVanishingOnOrbit f).inter_of_right Set.univ)
   rw [finsum_mem_univ, ← Set.compl_eq_univ_sdiff, hpair, hcompl] at hsplit
   rw [← hsplit]
   ring
@@ -200,10 +159,10 @@ This is `valence_formula` with the two exceptional orbits absorbed into the gene
 other orbit count once. It is the form the general-level formula redistributes along the norm
 map, where a single weight per orbit is what a stabiliser count can split. -/
 theorem valence_formula_weighted [ModularFormClass F 𝒮ℒ k] (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
-    (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ, weightedOrderOnOrbit f q)
+    (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ, weightedOrderOfVanishingOnOrbit f q)
       + (qExpansionOrderAtCusp 1 ⇑f : ℚ) = (k : ℚ) / 12 := by
   have key := valence_formula f hf
-  rw [finsum_weightedOrderOnOrbit_eq f]
+  rw [finsum_weightedOrderOfVanishingOnOrbit_eq f]
   refine Rat.cast_injective (α := ℂ) ?_
   push_cast
   linear_combination key
@@ -212,49 +171,31 @@ theorem valence_formula_weighted [ModularFormClass F 𝒮ℒ k] (f : F) (hf : (�
 
 /-- **The mass at one orbit is bounded by the total mass**: every other term of the uniform
 valence formula is nonnegative, so `12 · ord_P f ≤ k · e_P` for a nonzero form. -/
-theorem twelve_mul_orderOfVanishingOnOrbit_le [ModularFormClass F 𝒮ℒ k] (f : F)
+theorem twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder
+    [ModularFormClass F 𝒮ℒ k] (f : F)
     (hf : (⇑f : ℍ → ℂ) ≠ 0) (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
     12 * orderOfVanishingOnOrbit f q ≤ k * ModularGroup.ellipticOrder q := by
-  have hsingle := single_le_finsum q (hasFiniteSupport_weightedOrderOnOrbit f)
-    (weightedOrderOnOrbit_nonneg f)
+  have hsingle := single_le_finsum q (hasFiniteSupport_weightedOrderOfVanishingOnOrbit f)
+    (weightedOrderOfVanishingOnOrbit_nonneg f)
   have hcusp : (0 : ℚ) ≤ (qExpansionOrderAtCusp 1 ⇑f : ℚ) := by
     exact_mod_cast qExpansionOrderAtCusp_nonneg 1 ⇑f
   have htotal := valence_formula_weighted f hf
   have he : (0 : ℚ) < (ModularGroup.ellipticOrder q : ℚ) := by
     exact_mod_cast ModularGroup.ellipticOrder_pos q
-  have hle : weightedOrderOnOrbit f q ≤ (k : ℚ) / 12 := by linarith
-  rw [weightedOrderOnOrbit, div_le_div_iff₀ he (by norm_num)] at hle
+  have hle : weightedOrderOfVanishingOnOrbit f q ≤ (k : ℚ) / 12 := by linarith
+  rw [weightedOrderOfVanishingOnOrbit_def, div_le_div_iff₀ he (by norm_num)] at hle
   have : (12 : ℚ) * (orderOfVanishingOnOrbit f q : ℚ) ≤
       (k : ℚ) * (ModularGroup.ellipticOrder q : ℚ) := by linarith
   exact_mod_cast this
 
-/-- The same bound read at a point of `ℍ` rather than at its orbit. -/
-theorem twelve_mul_orderOfVanishingAt_le [ModularFormClass F 𝒮ℒ k] (f : F)
-    (hf : (⇑f : ℍ → ℂ) ≠ 0) (p : ℍ) :
-    12 * orderOfVanishingAt ⇑f p ≤ k * ModularGroup.ellipticOrder (Quotient.mk'' p) := by
-  simpa using twelve_mul_orderOfVanishingOnOrbit_le f hf (Quotient.mk'' p)
-
-/-- **The level-one cusp bound in exact form**: `12 · ord_∞ f ≤ k` for a nonzero form, because
-the interior mass it competes with is nonnegative. This is the order-side sharpening of
-Mathlib's `ModularForm.sturm_bound_levelOne`, which compares two forms rather than bounding one
-form's cusp order. -/
-theorem twelve_mul_qExpansionOrderAtCusp_le [ModularFormClass F 𝒮ℒ k] (f : F)
-    (hf : (⇑f : ℍ → ℂ) ≠ 0) : 12 * qExpansionOrderAtCusp 1 ⇑f ≤ k := by
-  have hinterior : (0 : ℚ) ≤
-      ∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ, weightedOrderOnOrbit f q :=
-    finsum_nonneg (weightedOrderOnOrbit_nonneg f)
-  have htotal := valence_formula_weighted f hf
-  have : (12 : ℚ) * (qExpansionOrderAtCusp 1 ⇑f : ℚ) ≤ (k : ℚ) := by linarith
-  exact_mod_cast this
-
-/-- **A nonzero form of weight `k < 12` cannot vanish off the elliptic orbits**: there the
-weight is `1`, so a single zero would already carry mass `1 > k / 12`. -/
-theorem orderOfVanishingOnOrbit_eq_zero_of_weight_lt_twelve [ModularFormClass F 𝒮ℒ k] (f : F)
-    (hf : (⇑f : ℍ → ℂ) ≠ 0) (hk : k < 12) {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ}
-    (hI : q ≠ Quotient.mk'' UpperHalfPlane.I) (hρ : q ≠ Quotient.mk'' ρ) :
+/-- **A small enough weighted degree forces vanishing at an orbit**: if `k · e_P < 12`, a
+zero at `P` would make the single-orbit bound impossible. -/
+theorem orderOfVanishingOnOrbit_eq_zero_of_weight_mul_ellipticOrder_lt_twelve
+    [ModularFormClass F 𝒮ℒ k] (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0)
+    {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ}
+    (hk : k * ModularGroup.ellipticOrder q < 12) :
     orderOfVanishingOnOrbit f q = 0 := by
-  have hbound := twelve_mul_orderOfVanishingOnOrbit_le f hf q
-  rw [ModularGroup.ellipticOrder_eq_one hI hρ] at hbound
+  have hbound := twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder f hf q
   have := orderOfVanishingOnOrbit_nonneg f q
   omega
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/ValenceFormula.lean
@@ -56,7 +56,7 @@ in the uniform form is there a single weight per orbit to redistribute.
   bound
   `12 · ord_P f ≤ k · e_P` on a single orbit, and
   `TauCeti.ModularForm.orderOfVanishingOnOrbit_eq_zero_of_weight_mul_ellipticOrder_lt_twelve`,
-  the vanishing it forces when `k · e_P < 12`.
+  the nonvanishing it forces when `k · e_P < 12`.
 
 ## References
 
@@ -188,7 +188,7 @@ theorem twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder
       (k : ℚ) * (ModularGroup.ellipticOrder q : ℚ) := by linarith
   exact_mod_cast this
 
-/-- **A small enough weighted degree forces vanishing at an orbit**: if `k · e_P < 12`, a
+/-- **A small enough weighted degree forces nonvanishing at an orbit**: if `k · e_P < 12`, a
 zero at `P` would make the single-orbit bound impossible. -/
 theorem orderOfVanishingOnOrbit_eq_zero_of_weight_mul_ellipticOrder_lt_twelve
     [ModularFormClass F 𝒮ℒ k] (f : F) (hf : (⇑f : ℍ → ℂ) ≠ 0)

--- a/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.BigOperators.Finprod
 public import Mathlib.NumberTheory.Modular
+public import TauCeti.NumberTheory.Modular.Stabilizer
 public import TauCeti.NumberTheory.ModularForms.Order.OfVanishing
 
 import Mathlib.Algebra.FiniteSupport.Basic
@@ -29,6 +30,8 @@ empty. The generic orbit facts it rides live in `TauCeti.NumberTheory.Modular.Or
 * `TauCeti.ModularForm.orderOfVanishingOnOrbit_nonneg`: the order on an orbit is nonnegative.
 * `TauCeti.ModularForm.hasFiniteSupport_orderOfVanishingOnOrbit`: finite support on orbits, the
   zero form having empty support.
+* `TauCeti.ModularForm.weightedOrderOfVanishingOnOrbit`: the elliptic-weighted order
+  `ord_P f / e_P`, together with its values and finite-support properties.
 * `TauCeti.ModularForm.sum_orderOfVanishingAt_eq_finsum_orbit`: a divisor sum over an arbitrary
   index set, reindexed over the orbits its points represent, given that the index-to-orbit
   composite is injective.
@@ -92,6 +95,72 @@ lemma hasFiniteSupport_orderOfVanishingOnOrbit [ModularFormClass F 𝒮ℒ k] (f
   -- the `rfl` pattern rewrites `q` to `⟦p⟧`, after which `orderOfVanishingOnOrbit_mk` fires
   (finite_zeros_in_fd (f := f)).of_surjOn Quotient.mk'' fun q hq ↦
     (ModularGroup.exists_rep_mem_fd q).imp fun p ⟨rfl, hfd⟩ ↦ ⟨⟨hfd, by simpa using hq⟩, rfl⟩
+
+/-! ### The elliptic-weighted order -/
+
+/-- **The elliptic-weighted vanishing order of `f` on an orbit**: `ord_P f / e_P`, the summand
+of the valence formula in its uniform form `∑_P (1 / e_P) · ord_P f + ord_∞ f = k / 12`. The
+weight is `1` on all but the two elliptic orbits, where it is `1/2` and `1/3`. -/
+@[expose]
+noncomputable def weightedOrderOfVanishingOnOrbit [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
+    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ :=
+  (orderOfVanishingOnOrbit f q : ℚ) / (ModularGroup.ellipticOrder q : ℚ)
+
+/-- The defining equation for the elliptic-weighted vanishing order. -/
+lemma weightedOrderOfVanishingOnOrbit_def [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
+    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
+    weightedOrderOfVanishingOnOrbit f q =
+      (orderOfVanishingOnOrbit f q : ℚ) / (ModularGroup.ellipticOrder q : ℚ) :=
+  rfl
+
+/-- Evaluating the weighted order on the orbit of `p` recovers the pointwise order divided by
+the elliptic order of that orbit. -/
+lemma weightedOrderOfVanishingOnOrbit_mk [SlashInvariantFormClass F 𝒮ℒ k] (f : F) (p : ℍ) :
+    weightedOrderOfVanishingOnOrbit f (Quotient.mk'' p) =
+      (orderOfVanishingAt ⇑f p : ℚ) /
+        (ModularGroup.ellipticOrder (Quotient.mk'' p) : ℚ) := by
+  rw [weightedOrderOfVanishingOnOrbit_def, orderOfVanishingOnOrbit_mk]
+
+/-- Off the two elliptic orbits the weight is `1`, so the summand is the plain order. -/
+lemma weightedOrderOfVanishingOnOrbit_of_orbit_ne_I_of_orbit_ne_ρ
+    [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
+    {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ} (hI : q ≠ Quotient.mk'' UpperHalfPlane.I)
+    (hρ : q ≠ Quotient.mk'' ρ) :
+    weightedOrderOfVanishingOnOrbit f q = (orderOfVanishingOnOrbit f q : ℚ) := by
+  rw [weightedOrderOfVanishingOnOrbit_def,
+    ModularGroup.ellipticOrder_eq_one_of_orbit_ne_I_of_orbit_ne_ρ hI hρ]
+  norm_num
+
+/-- At the orbit of `i` the weight is `1/2`, from `e_i = 2`. -/
+lemma weightedOrderOfVanishingOnOrbit_I [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
+    weightedOrderOfVanishingOnOrbit f (Quotient.mk'' UpperHalfPlane.I) =
+      (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2 := by
+  rw [weightedOrderOfVanishingOnOrbit_mk, ModularGroup.ellipticOrder_I]
+  norm_num
+
+/-- At the orbit of `ρ` the weight is `1/3`, from `e_ρ = 3`. -/
+lemma weightedOrderOfVanishingOnOrbit_ρ [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
+    weightedOrderOfVanishingOnOrbit f (Quotient.mk'' ρ) =
+      (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
+  rw [weightedOrderOfVanishingOnOrbit_mk, ModularGroup.ellipticOrder_ρ]
+  norm_num
+
+/-- Every elliptic-weighted order is nonnegative: a modular form is holomorphic and the
+weights are positive. -/
+lemma weightedOrderOfVanishingOnOrbit_nonneg [ModularFormClass F 𝒮ℒ k] (f : F)
+    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
+    0 ≤ weightedOrderOfVanishingOnOrbit f q := by
+  rw [weightedOrderOfVanishingOnOrbit_def]
+  refine div_nonneg ?_ (by positivity)
+  exact_mod_cast orderOfVanishingOnOrbit_nonneg f q
+
+/-- Only finitely many orbits have nonzero elliptic-weighted order: the weight cannot create
+support where the order has none. -/
+lemma hasFiniteSupport_weightedOrderOfVanishingOnOrbit [ModularFormClass F 𝒮ℒ k] (f : F) :
+    Function.HasFiniteSupport (weightedOrderOfVanishingOnOrbit f) := by
+  refine (hasFiniteSupport_orderOfVanishingOnOrbit f).subset fun q hq ↦ ?_
+  simp only [Function.mem_support, ne_eq] at hq ⊢
+  exact fun h ↦ hq (by rw [weightedOrderOfVanishingOnOrbit_def, h]; simp)
 
 /-- A divisor sum reindexed over the orbits its points represent. The index set is arbitrary,
 mapped into `ℍ` by `p`.

--- a/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
@@ -26,6 +26,7 @@ empty. The generic orbit facts it rides live in `TauCeti.NumberTheory.Modular.Or
 
 * `TauCeti.ModularForm.orderOfVanishingOnOrbit`: the order descended to
   `MulAction.orbitRel.Quotient SL(2, ℤ) ℍ`.
+* `TauCeti.ModularForm.orderOfVanishingOnOrbit_nonneg`: the order on an orbit is nonnegative.
 * `TauCeti.ModularForm.hasFiniteSupport_orderOfVanishingOnOrbit`: finite support on orbits, the
   zero form having empty support.
 * `TauCeti.ModularForm.sum_orderOfVanishingAt_eq_finsum_orbit`: a divisor sum over an arbitrary
@@ -77,6 +78,13 @@ lemma orderOfVanishingOnOrbit_mk [SlashInvariantFormClass F 𝒮ℒ k] (p : ℍ)
     orderOfVanishingOnOrbit f (Quotient.mk'' p) = orderOfVanishingAt f p := by
   unfold orderOfVanishingOnOrbit
   rfl
+
+/-- The vanishing order on an orbit is nonnegative: a modular form is holomorphic, so it has no
+poles. -/
+lemma orderOfVanishingOnOrbit_nonneg [ModularFormClass F 𝒮ℒ k] (f : F)
+    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : 0 ≤ orderOfVanishingOnOrbit f q := by
+  induction q using Quotient.inductionOn' with
+  | _ p => simpa using orderOfVanishingAt_nonneg (ModularFormClass.holo f) p
 
 /-- Only finitely many orbits of a level-one form carry nonzero order. -/
 lemma hasFiniteSupport_orderOfVanishingOnOrbit [ModularFormClass F 𝒮ℒ k] (f : F) :

--- a/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
@@ -32,6 +32,8 @@ empty. The generic orbit facts it rides live in `TauCeti.NumberTheory.Modular.Or
   zero form having empty support.
 * `TauCeti.ModularForm.weightedOrderOfVanishingOnOrbit`: the elliptic-weighted order
   `ord_P f / e_P`, together with its values and finite-support properties.
+* `TauCeti.ModularForm.finsum_weightedOrderOfVanishingOnOrbit_eq_finsum_nonElliptic_add_elliptic`:
+  the uniform weighted sum split into its non-elliptic and two elliptic parts.
 * `TauCeti.ModularForm.sum_orderOfVanishingAt_eq_finsum_orbit`: a divisor sum over an arbitrary
   index set, reindexed over the orbits its points represent, given that the index-to-orbit
   composite is injective.
@@ -49,6 +51,8 @@ empty. The generic orbit facts it rides live in `TauCeti.NumberTheory.Modular.Or
 
 * [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
   development this file ports onto the current Mathlib pin.
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Chapter 3 — the elliptic-weighted divisor summand; new here, not part of the AINTLIB port above.
 -/
 
 public noncomputable section
@@ -114,6 +118,7 @@ lemma weightedOrderOfVanishingOnOrbit_def [SlashInvariantFormClass F 𝒮ℒ k] 
 
 /-- Evaluating the weighted order on the orbit of `p` recovers the pointwise order divided by
 the elliptic order of that orbit. -/
+@[simp]
 lemma weightedOrderOfVanishingOnOrbit_mk [SlashInvariantFormClass F 𝒮ℒ k] (f : F) (p : ℍ) :
     weightedOrderOfVanishingOnOrbit f (Quotient.mk'' p) =
       (orderOfVanishingAt ⇑f p : ℚ) /
@@ -121,7 +126,7 @@ lemma weightedOrderOfVanishingOnOrbit_mk [SlashInvariantFormClass F 𝒮ℒ k] (
   rw [weightedOrderOfVanishingOnOrbit_def, orderOfVanishingOnOrbit_mk]
 
 /-- Off the two elliptic orbits the weight is `1`, so the summand is the plain order. -/
-lemma weightedOrderOfVanishingOnOrbit_of_orbit_ne_I_of_orbit_ne_ρ
+lemma weightedOrderOfVanishingOnOrbit_eq_orderOfVanishingOnOrbit_of_orbit_ne_I_of_orbit_ne_ρ
     [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
     {q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ} (hI : q ≠ Quotient.mk'' UpperHalfPlane.I)
     (hρ : q ≠ Quotient.mk'' ρ) :
@@ -131,7 +136,6 @@ lemma weightedOrderOfVanishingOnOrbit_of_orbit_ne_I_of_orbit_ne_ρ
   norm_num
 
 /-- At the orbit of `i` the weight is `1/2`, from `e_i = 2`. -/
-@[simp]
 lemma weightedOrderOfVanishingOnOrbit_I [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
     weightedOrderOfVanishingOnOrbit f (Quotient.mk'' UpperHalfPlane.I) =
       (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2 := by
@@ -139,12 +143,20 @@ lemma weightedOrderOfVanishingOnOrbit_I [SlashInvariantFormClass F 𝒮ℒ k] (f
   norm_num
 
 /-- At the orbit of `ρ` the weight is `1/3`, from `e_ρ = 3`. -/
-@[simp]
 lemma weightedOrderOfVanishingOnOrbit_ρ [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
     weightedOrderOfVanishingOnOrbit f (Quotient.mk'' ρ) =
       (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
   rw [weightedOrderOfVanishingOnOrbit_mk, ModularGroup.ellipticOrder_ρ]
   norm_num
+
+/-- Multiplying the weighted order by the elliptic order recovers the plain vanishing order. -/
+lemma ellipticOrder_mul_weightedOrderOfVanishingOnOrbit
+    [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
+    (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
+    (ModularGroup.ellipticOrder q : ℚ) * weightedOrderOfVanishingOnOrbit f q =
+      (orderOfVanishingOnOrbit f q : ℚ) := by
+  rw [weightedOrderOfVanishingOnOrbit_def]
+  exact mul_div_cancel₀ _ (by exact_mod_cast (ModularGroup.ellipticOrder_pos q).ne')
 
 /-- Every elliptic-weighted order is nonnegative: a modular form is holomorphic and the
 weights are positive. -/
@@ -260,6 +272,48 @@ lemma hasFiniteSupport_orderOfVanishingOnOrbit_nonElliptic [ModularFormClass F �
     Function.HasFiniteSupport fun q : NonEllipticOrbit ↦ orderOfVanishingOnOrbit f q.val :=
   Function.HasFiniteSupport.fun_comp_of_injective Subtype.val_injective
     (hasFiniteSupport_orderOfVanishingOnOrbit f)
+
+/-- **Splitting the uniform divisor sum at the two elliptic orbits.** Away from them the weight
+is `1`, so the sum over all orbits is the non-elliptic sum plus the two weighted elliptic terms. -/
+lemma finsum_weightedOrderOfVanishingOnOrbit_eq_finsum_nonElliptic_add_elliptic
+    [ModularFormClass F 𝒮ℒ k] (f : F) :
+    (∑ᶠ q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ,
+      weightedOrderOfVanishingOnOrbit f q) =
+      ((∑ᶠ q : NonEllipticOrbit, orderOfVanishingOnOrbit f q.val : ℤ) : ℚ)
+        + (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2
+        + (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
+  classical
+  set S : Set (MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :=
+    {Quotient.mk'' UpperHalfPlane.I, Quotient.mk'' ρ} with hSdef
+  have hmem : ∀ q, q ∈ Sᶜ ↔ (q ≠ Quotient.mk'' UpperHalfPlane.I ∧ q ≠ Quotient.mk'' ρ) := by
+    intro q
+    simp [hSdef, not_or]
+  -- the two-element part contributes the weighted elliptic terms
+  have hpair : (∑ᶠ q ∈ S, weightedOrderOfVanishingOnOrbit f q) =
+      (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2
+        + (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by
+    rw [hSdef, finsum_mem_pair ModularGroup.orbit_mk_I_ne_orbit_mk_ρ,
+      weightedOrderOfVanishingOnOrbit_I, weightedOrderOfVanishingOnOrbit_ρ]
+  -- the complement is the non-elliptic orbit type, on which the weight is trivial
+  have hcompl : (∑ᶠ q ∈ Sᶜ, weightedOrderOfVanishingOnOrbit f q) =
+      ((∑ᶠ q : NonEllipticOrbit, orderOfVanishingOnOrbit f q.val : ℤ) : ℚ) := by
+    have hcast := AddMonoidHom.map_finsum_of_injective (Int.castAddHom ℚ) Int.cast_injective
+      fun q : NonEllipticOrbit ↦ orderOfVanishingOnOrbit f q.val
+    have hval : (∑ᶠ q ∈ Sᶜ, weightedOrderOfVanishingOnOrbit f q) =
+        ∑ᶠ q ∈ Sᶜ, ((orderOfVanishingOnOrbit f q : ℤ) : ℚ) :=
+      finsum_mem_congr rfl fun q hq ↦
+        weightedOrderOfVanishingOnOrbit_eq_orderOfVanishingOnOrbit_of_orbit_ne_I_of_orbit_ne_ρ
+          f ((hmem q).1 hq).1 ((hmem q).1 hq).2
+    rw [hval, ← finsum_set_coe_eq_finsum_mem,
+      ← finsum_comp_equiv (Equiv.subtypeEquivRight fun q ↦ (hmem q).symm)
+        (f := fun q : (Sᶜ : Set _) ↦ ((orderOfVanishingOnOrbit f q.val : ℤ) : ℚ))]
+    simpa using hcast.symm
+  have hsplit := finsum_mem_add_sdiff' (f := weightedOrderOfVanishingOnOrbit f)
+    (Set.subset_univ S)
+    ((hasFiniteSupport_weightedOrderOfVanishingOnOrbit f).inter_of_right Set.univ)
+  rw [finsum_mem_univ, ← Set.compl_eq_univ_sdiff, hpair, hcompl] at hsplit
+  rw [← hsplit]
+  ring
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/Orbits.lean
@@ -101,7 +101,6 @@ lemma hasFiniteSupport_orderOfVanishingOnOrbit [ModularFormClass F 𝒮ℒ k] (f
 /-- **The elliptic-weighted vanishing order of `f` on an orbit**: `ord_P f / e_P`, the summand
 of the valence formula in its uniform form `∑_P (1 / e_P) · ord_P f + ord_∞ f = k / 12`. The
 weight is `1` on all but the two elliptic orbits, where it is `1/2` and `1/3`. -/
-@[expose]
 noncomputable def weightedOrderOfVanishingOnOrbit [SlashInvariantFormClass F 𝒮ℒ k] (f : F)
     (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) : ℚ :=
   (orderOfVanishingOnOrbit f q : ℚ) / (ModularGroup.ellipticOrder q : ℚ)
@@ -111,7 +110,7 @@ lemma weightedOrderOfVanishingOnOrbit_def [SlashInvariantFormClass F 𝒮ℒ k] 
     (q : MulAction.orbitRel.Quotient SL(2, ℤ) ℍ) :
     weightedOrderOfVanishingOnOrbit f q =
       (orderOfVanishingOnOrbit f q : ℚ) / (ModularGroup.ellipticOrder q : ℚ) :=
-  rfl
+  (rfl)
 
 /-- Evaluating the weighted order on the orbit of `p` recovers the pointwise order divided by
 the elliptic order of that orbit. -/
@@ -132,6 +131,7 @@ lemma weightedOrderOfVanishingOnOrbit_of_orbit_ne_I_of_orbit_ne_ρ
   norm_num
 
 /-- At the orbit of `i` the weight is `1/2`, from `e_i = 2`. -/
+@[simp]
 lemma weightedOrderOfVanishingOnOrbit_I [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
     weightedOrderOfVanishingOnOrbit f (Quotient.mk'' UpperHalfPlane.I) =
       (orderOfVanishingAt ⇑f UpperHalfPlane.I : ℚ) / 2 := by
@@ -139,6 +139,7 @@ lemma weightedOrderOfVanishingOnOrbit_I [SlashInvariantFormClass F 𝒮ℒ k] (f
   norm_num
 
 /-- At the orbit of `ρ` the weight is `1/3`, from `e_ρ = 3`. -/
+@[simp]
 lemma weightedOrderOfVanishingOnOrbit_ρ [SlashInvariantFormClass F 𝒮ℒ k] (f : F) :
     weightedOrderOfVanishingOnOrbit f (Quotient.mk'' ρ) =
       (orderOfVanishingAt ⇑f ρ : ℚ) / 3 := by


### PR DESCRIPTION
This PR restates the level-one valence formula uniformly over the orbit space, weighting every `SL(2, ℤ)`-orbit of `ℍ` by the reciprocal `1 / e_P` of its elliptic order. It proves

`∑_{P ∈ SL₂(ℤ) \ ℍ} (1 / e_P) · ord_P f + ord_∞ f = k / 12`

for a nonzero weight-`k` form. This is exactly the equivalent formulation displayed in `TauCetiRoadmap/ModularForms/README.md`, Layer 1, and supplies the single orbitwise weight needed by the milestone **General level — by the coset norm**.

`TauCeti.ModularGroup.ellipticOrder` descends the `PSL(2, ℤ)` stabilizer order to the `SL(2, ℤ)` orbit space. Its API records `e_i = 2`, `e_ρ = 3`, `e_P = 1` away from those two orbits, positivity, and the relation to the generic orbit-stabilizer count. The distinctness of the two elliptic orbits is placed with the orbit API.

`TauCeti.ModularForm.weightedOrderOfVanishingOnOrbit f q = ord_q(f) / e_q` is placed beside `orderOfVanishingOnOrbit`, with an exposed defining equation, a point-evaluation lemma, the three orbit cases, nonnegativity, and finite support. `valence_formula_weighted` splits its finsum at the two elliptic orbits and derives the uniform statement from the existing `valence_formula`.

The single-orbit consequence is `twelve_mul_orderOfVanishingOnOrbit_le_mul_ellipticOrder`, namely `12 · ord_P f ≤ k · e_P`. Its low-weight corollary is stated in the general form `k · e_P < 12 → ord_P f = 0`. The duplicate point-level restatement and the duplicate level-one cusp/Sturm bound are intentionally omitted; Mathlib already provides `ModularForm.sturm_bound_levelOne` for the latter.

The level-one statement shape follows the cited AINTLIB valence-formula development. The uniform divisor formulation follows the Tau Ceti roadmap and the divisor-of-automorphic-forms development in Diamond–Shurman, *A First Course in Modular Forms*, §§3.5–3.6.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula-elliptic-order"}-->

🤖 Prepared with Claude Code and Codex