### PR TITLE
feat: the unit sphere is simply connected above rank two

### DIFF
--- a/TauCeti/AlgebraicTopology/SemilocallySimplyConnected/Basic.lean
+++ b/TauCeti/AlgebraicTopology/SemilocallySimplyConnected/Basic.lean
@@ -9,8 +9,7 @@ public import Mathlib.AlgebraicTopology.FundamentalGroupoid.InducedMaps
 public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
 public import Mathlib.Topology.Homotopy.LocallyContractible
 public import Mathlib.Topology.Homotopy.Product
--- Private: `Path.codRestrict`, `Path.map_codRestrict`, and
--- `Path.Homotopic.map_nullhomotopic_of_nullhomotopic` are used only in private proofs below,
+-- Private: `Path.Homotopic.refl_of_forall_mem_of_nullhomotopic` is used only in a proof below,
 -- so this import is not re-exported.
 import TauCeti.Topology.Homotopy.Path
 
@@ -132,13 +131,7 @@ theorem SemilocallySimplyConnectedSpace.of_locallyContractibleSpace
     have hnj : j.Nullhomotopic :=
       hnull.comp_right (⟨Subtype.val, continuous_subtype_val⟩ : C((Set.univ : Set X), X))
     refine ⟨V, hV, fun γ hγ => ?_⟩
-    -- Restrict the loop `γ` to the subspace `V` via `codRestrict`; pushing it forward along the
-    -- null-homotopic inclusion `j` recovers `γ` (`Path.map_codRestrict`), so `γ` is null-homotopic
-    -- in `X`.
-    let xV : V := ⟨x, mem_of_mem_nhds hV⟩
-    have hmap :=
-      Path.Homotopic.map_nullhomotopic_of_nullhomotopic hnj (γ.codRestrict hγ : Path xV xV)
-    rwa [Path.map_codRestrict] at hmap
+    exact Path.Homotopic.refl_of_forall_mem_of_nullhomotopic hnj γ hγ
 
 /-- A simply connected space is semilocally simply connected: the whole space already witnesses
 the condition, since every loop is null-homotopic. -/

--- a/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Normalize
+public import Mathlib.Topology.Homotopy.Contractible
+public import TauCeti.Topology.Homotopy.Path
+
+/-!
+# The punctured unit sphere
+
+Removing a point `p` from the unit sphere of a real normed space leaves a set that can be swept
+onto the antipode `-p`: for `x ≠ p` on the sphere the straight segment from `x` to `-p` never
+meets the origin, so normalising it gives a contraction of the punctured sphere inside the
+sphere. Consequently the inclusion of the punctured sphere into the sphere is null-homotopic, and
+a loop on the sphere that misses even a single point is null-homotopic.
+
+This is the easy half of the computation of `π₁(Sⁿ)`: the work left over is to homotope an
+arbitrary loop off a point, which is done in
+`TauCeti.AlgebraicTopology.Sphere.SimplyConnected`.
+
+## Main declarations
+
+* `TauCeti.sub_smul_ne_zero_of_norm_eq_one`: the segment from `x` to the antipode of `p` avoids
+  the origin, for distinct points `x`, `p` of the unit sphere.
+* `TauCeti.nullhomotopic_inclusion_sphere_compl`: the inclusion of the sphere minus a point into
+  the sphere is null-homotopic.
+* `TauCeti.homotopic_refl_of_notMem_range`: a loop on the unit sphere omitting a point of the
+  sphere is null-homotopic.
+
+## References
+
+This serves the `π₁(RPⁿ)` line of `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13,
+whose only missing input is the simple connectivity of the covering sphere. The contraction of a
+punctured sphere onto the antipode of the puncture is the standard one, as in Hatcher,
+*Algebraic Topology*, Section 1.1. No Mathlib code is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open Metric NormedSpace
+open scoped unitInterval
+
+namespace TauCeti
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- For distinct points `x` and `p` of the unit sphere, the segment running from `x` to the
+antipode `-p` misses the origin: a vanishing convex combination would force the two coefficients
+to agree, hence `x = p`. -/
+theorem sub_smul_ne_zero_of_norm_eq_one {x p : E} (hx : ‖x‖ = 1) (hp : ‖p‖ = 1) (hxp : x ≠ p)
+    {u : ℝ} (hu₀ : 0 ≤ u) (hu₁ : u ≤ 1) : (1 - u) • x - u • p ≠ 0 := by
+  intro h
+  have h' : (1 - u) • x = u • p := by rwa [sub_eq_zero] at h
+  have hcoeff : 1 - u = u := by
+    have hnorm := congrArg norm h'
+    rw [norm_smul, norm_smul, hx, hp, mul_one, mul_one, Real.norm_eq_abs, Real.norm_eq_abs,
+      abs_of_nonneg (by linarith), abs_of_nonneg hu₀] at hnorm
+    exact hnorm
+  have hu : u = 1 / 2 := by linarith
+  refine hxp ?_
+  have h2 : (2 : ℝ) • ((1 - u) • x) = (2 : ℝ) • (u • p) := by rw [h']
+  rw [smul_smul, smul_smul, hu] at h2
+  norm_num at h2
+  exact h2
+
+/-- **The inclusion of the punctured unit sphere into the unit sphere is null-homotopic.**
+Radial projection of the segment towards `-p` sweeps every point other than `p` to the
+antipode `-p`. -/
+theorem nullhomotopic_inclusion_sphere_compl (p : sphere (0 : E) 1) :
+    (ContinuousMap.mk (Subtype.val : ({p}ᶜ : Set (sphere (0 : E) 1)) → sphere (0 : E) 1)
+      continuous_subtype_val).Nullhomotopic := by
+  have hp : ‖(p : E)‖ = 1 := mem_sphere_zero_iff_norm.mp p.2
+  set g : I × ({p}ᶜ : Set (sphere (0 : E) 1)) → E := fun z =>
+    (1 - (z.1 : ℝ)) • ((z.2 : sphere (0 : E) 1) : E) - (z.1 : ℝ) • (p : E) with hg
+  have hgcont : Continuous g := by
+    have h1 : Continuous fun z : I × ({p}ᶜ : Set (sphere (0 : E) 1)) =>
+        ((z.2 : sphere (0 : E) 1) : E) :=
+      continuous_subtype_val.comp (continuous_subtype_val.comp continuous_snd)
+    have h2 : Continuous fun z : I × ({p}ᶜ : Set (sphere (0 : E) 1)) => ((z.1 : ℝ)) :=
+      continuous_subtype_val.comp continuous_fst
+    exact ((continuous_const.sub h2).smul h1).sub (h2.smul continuous_const)
+  have hgne : ∀ z, g z ≠ 0 := by
+    rintro ⟨u, q⟩
+    refine sub_smul_ne_zero_of_norm_eq_one
+      (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2) hp ?_ u.2.1 u.2.2
+    intro hq
+    exact q.2 (Set.mem_singleton_iff.mpr (Subtype.ext hq))
+  refine ⟨⟨-(p : E), by simp⟩, ⟨?_⟩⟩
+  exact
+    { toFun := fun z => ⟨normalize (g z), mem_sphere_zero_iff_norm.mpr (norm_normalize (hgne z))⟩
+      continuous_toFun := by
+        refine Continuous.subtype_mk ?_ _
+        change Continuous fun z => ‖g z‖⁻¹ • g z
+        exact ((continuous_norm.comp hgcont).inv₀
+          (fun z => norm_ne_zero_iff.mpr (hgne z))).smul hgcont
+      map_zero_left := fun q => by
+        refine Subtype.ext ?_
+        change NormedSpace.normalize (g (0, q)) = ((q : sphere (0 : E) 1) : E)
+        have hgq : g (0, q) = ((q : sphere (0 : E) 1) : E) := by simp [hg]
+        rw [hgq]
+        exact normalize_eq_self_of_norm_eq_one
+          (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2)
+      map_one_left := fun q => by
+        refine Subtype.ext ?_
+        change NormedSpace.normalize (g (1, q)) = -(p : E)
+        have hgq : g (1, q) = -(p : E) := by simp [hg]
+        rw [hgq, normalize_neg, normalize_eq_self_of_norm_eq_one hp] }
+
+/-- **A loop on the unit sphere that omits a point of the sphere is null-homotopic.** The loop
+runs in the punctured sphere, whose inclusion into the sphere is null-homotopic. -/
+theorem homotopic_refl_of_notMem_range {x : sphere (0 : E) 1} (γ : Path x x)
+    {p : sphere (0 : E) 1} (hp : p ∉ Set.range γ) : γ.Homotopic (Path.refl x) := by
+  have hmem : ∀ t, γ t ∈ ({p}ᶜ : Set (sphere (0 : E) 1)) := fun t hmem =>
+    hp ⟨t, (Set.mem_singleton_iff.mp hmem).symm ▸ rfl⟩
+  have hx : x ∈ ({p}ᶜ : Set (sphere (0 : E) 1)) := γ.source ▸ hmem 0
+  have key := Path.Homotopic.map_nullhomotopic_of_nullhomotopic
+    (nullhomotopic_inclusion_sphere_compl p)
+    (Path.codRestrict (x := ⟨x, hx⟩) (y := ⟨x, hx⟩) γ hmem)
+  rwa [Path.map_codRestrict (x := ⟨x, hx⟩) (y := ⟨x, hx⟩) γ hmem] at key
+
+end TauCeti
+
+end

--- a/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
@@ -24,12 +24,15 @@ arbitrary loop off a point, which is done in
 
 ## Main declarations
 
-* `TauCeti.sub_smul_ne_zero_of_norm_eq_one`: the segment from `x` to the antipode of `p` avoids
-  the origin, for distinct points `x`, `p` of the unit sphere.
-* `TauCeti.nullhomotopic_inclusion_sphere_compl`: the inclusion of the sphere minus a point into
+* `TauCeti.normalizeToSphere`: radial projection of a continuous nowhere-zero map to the unit
+  sphere.
+* `TauCeti.Path.homotopic_of_normalize_segment_ne_zero`: radial projection of a straight-line
+  homotopy between sphere loops.
+* `TauCeti.contractibleSpace_sphere_compl_singleton`: the sphere minus one point is contractible.
+* `TauCeti.nullhomotopic_inclusion_sphere_compl_singleton`: the inclusion of the sphere minus a
+  point into the sphere is null-homotopic.
+* `TauCeti.homotopic_refl_of_notMem_range_sphere`: a loop on the unit sphere omitting a point of
   the sphere is null-homotopic.
-* `TauCeti.homotopic_refl_of_notMem_range`: a loop on the unit sphere omitting a point of the
-  sphere is null-homotopic.
 
 ## References
 
@@ -50,79 +53,182 @@ namespace TauCeti
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-/-- For distinct points `x` and `p` of the unit sphere, the segment running from `x` to the
-antipode `-p` misses the origin: a vanishing convex combination would force the two coefficients
-to agree, hence `x = p`. -/
-theorem sub_smul_ne_zero_of_norm_eq_one {x p : E} (hx : ‖x‖ = 1) (hp : ‖p‖ = 1) (hxp : x ≠ p)
-    {u : ℝ} (hu₀ : 0 ≤ u) (hu₁ : u ≤ 1) : (1 - u) • x - u • p ≠ 0 := by
+/-- Radial projection sends a continuous nowhere-zero map into a real normed space continuously
+to its unit sphere. -/
+@[expose] noncomputable def normalizeToSphere {Y : Type*} [TopologicalSpace Y] (f : Y → E)
+    (hf : Continuous f) (h0 : ∀ y, f y ≠ 0) : C(Y, sphere (0 : E) 1) where
+  toFun y := ⟨normalize (f y), mem_sphere_zero_iff_norm.mpr (norm_normalize (h0 y))⟩
+  continuous_toFun := by
+    refine Continuous.subtype_mk ?_ _
+    -- `normalize` is definitionally inverse-norm scalar multiplication; exposing that formula
+    -- lets the standard continuity combinators apply.
+    change Continuous fun y => ‖f y‖⁻¹ • f y
+    exact ((continuous_norm.comp hf).inv₀
+      (fun y => norm_ne_zero_iff.mpr (h0 y))).smul hf
+
+/-- The underlying vector of `normalizeToSphere f hf h0 y` is the normalization of `f y`. -/
+@[simp]
+theorem normalizeToSphere_apply {Y : Type*} [TopologicalSpace Y] (f : Y → E)
+    (hf : Continuous f) (h0 : ∀ y, f y ≠ 0) (y : Y) :
+    ((normalizeToSphere f hf h0 y : sphere (0 : E) 1) : E) = normalize (f y) := rfl
+
+private theorem smul_sub_smul_ne_zero_of_ne {x p : E} (hx : ‖x‖ = 1) (hp : ‖p‖ = 1)
+    (hxp : x ≠ p) (u : ℝ) : (1 - u) • x - u • p ≠ 0 := by
   intro h
   have h' : (1 - u) • x = u • p := by rwa [sub_eq_zero] at h
-  have hcoeff : 1 - u = u := by
+  have habs : |1 - u| = |u| := by
     have hnorm := congrArg norm h'
-    rw [norm_smul, norm_smul, hx, hp, mul_one, mul_one, Real.norm_eq_abs, Real.norm_eq_abs,
-      abs_of_nonneg (by linarith), abs_of_nonneg hu₀] at hnorm
+    rw [norm_smul, norm_smul, hx, hp, mul_one, mul_one, Real.norm_eq_abs, Real.norm_eq_abs] at hnorm
     exact hnorm
-  have hu : u = 1 / 2 := by linarith
+  have hu : u = 1 / 2 := by
+    have hsquare := congrArg (fun r : ℝ => r ^ 2) habs
+    simp only [sq_abs] at hsquare
+    nlinarith
   refine hxp ?_
   have h2 : (2 : ℝ) • ((1 - u) • x) = (2 : ℝ) • (u • p) := by rw [h']
   rw [smul_smul, smul_smul, hu] at h2
   norm_num at h2
   exact h2
 
-/-- **The inclusion of the punctured unit sphere into the unit sphere is null-homotopic.**
-Radial projection of the segment towards `-p` sweeps every point other than `p` to the
-antipode `-p`. -/
-theorem nullhomotopic_inclusion_sphere_compl (p : sphere (0 : E) 1) :
+private noncomputable def normalizeSegmentToSphere {Y : Type*} [TopologicalSpace Y]
+    (f g : Y → E) (hf : Continuous f) (hg : Continuous g)
+    (h0 : ∀ z : I × Y, (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2 ≠ 0) :
+    C(I × Y, sphere (0 : E) 1) := by
+  have hu : Continuous fun z : I × Y => ((z.1 : ℝ)) :=
+    continuous_subtype_val.comp continuous_fst
+  exact normalizeToSphere
+    (fun z => (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2)
+    (((continuous_const.sub hu).smul (hf.comp continuous_snd)).add
+      (hu.smul (hg.comp continuous_snd))) h0
+
+/-- A loop in the unit sphere is homotopic to the radial projection of a continuous comparison
+loop when every point of their pointwise straight-line homotopy avoids the origin. -/
+theorem Path.homotopic_of_normalize_segment_ne_zero {x : sphere (0 : E) 1} (γ γ' : Path x x)
+    (f : I → E) (hf : Continuous f)
+    (hγ' : ∀ t, ((γ' t : sphere (0 : E) 1) : E) = normalize (f t))
+    (hf_zero : f 0 = (x : E)) (hf_one : f 1 = (x : E))
+    (h : ∀ z : I × I,
+      (1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E) +
+        (z.1 : ℝ) • f z.2 ≠ 0) : γ.Homotopic γ' := by
+  let K := normalizeSegmentToSphere
+    (fun t => ((γ t : sphere (0 : E) 1) : E)) f
+    (continuous_subtype_val.comp γ.continuous) hf h
+  have hxnorm : ‖((x : sphere (0 : E) 1) : E)‖ = 1 := mem_sphere_zero_iff_norm.mp x.2
+  refine Path.homotopic_of_continuous_square K K.continuous ?_ ?_ ?_ ?_
+  · intro s
+    apply Subtype.ext
+    simpa [K, normalizeSegmentToSphere, normalizeToSphere] using
+      normalize_eq_self_of_norm_eq_one (mem_sphere_zero_iff_norm.mp (γ s).2)
+  · intro s
+    apply Subtype.ext
+    simpa [K, normalizeSegmentToSphere, normalizeToSphere] using (hγ' s).symm
+  · intro u
+    apply Subtype.ext
+    simpa [K, normalizeSegmentToSphere, normalizeToSphere, γ.source, hf_zero, ← add_smul] using
+      normalize_eq_self_of_norm_eq_one hxnorm
+  · intro u
+    apply Subtype.ext
+    simpa [K, normalizeSegmentToSphere, normalizeToSphere, γ.target, hf_one, ← add_smul] using
+      normalize_eq_self_of_norm_eq_one hxnorm
+
+private theorem normalize_smul_sub_smul_ne_of_ne {x p : E} (hx : ‖x‖ = 1) (hp : ‖p‖ = 1)
+    (hxp : x ≠ p) (u : I) : normalize ((1 - (u : ℝ)) • x - (u : ℝ) • p) ≠ p := by
+  let v := (1 - (u : ℝ)) • x - (u : ℝ) • p
+  have hv0 : v ≠ 0 := smul_sub_smul_ne_zero_of_ne hx hp hxp u
+  have hvnorm : 0 < ‖v‖ := norm_pos_iff.mpr hv0
+  intro hvp
+  have hscale : ‖v‖ • p = v := by
+    rw [← hvp]
+    exact norm_smul_normalize v
+  have heq : (‖v‖ + (u : ℝ)) • p = (1 - (u : ℝ)) • x := by
+    rw [add_smul, hscale]
+    simp only [v]
+    abel
+  have hleft : 0 < ‖v‖ + (u : ℝ) := add_pos_of_pos_of_nonneg hvnorm u.2.1
+  have hright : 0 ≤ 1 - (u : ℝ) := sub_nonneg.mpr u.2.2
+  have hcoeff := congrArg norm heq
+  rw [norm_smul, norm_smul, hp, hx, mul_one, mul_one, Real.norm_eq_abs, Real.norm_eq_abs,
+    abs_of_pos hleft, abs_of_nonneg hright] at hcoeff
+  have hright' : 0 < 1 - (u : ℝ) := hcoeff ▸ hleft
+  rw [hcoeff] at heq
+  have hinv := congrArg (fun y : E => (1 - (u : ℝ))⁻¹ • y) heq
+  simp only [smul_smul, inv_mul_cancel₀ hright'.ne', one_smul] at hinv
+  exact hxp hinv.symm
+
+/-- **The unit sphere minus one point is contractible.** Radial projection of the segment towards
+the antipode of the deleted point gives a contraction that stays inside the punctured sphere. -/
+theorem contractibleSpace_sphere_compl_singleton (p : sphere (0 : E) 1) :
+    ContractibleSpace ({p}ᶜ : Set (sphere (0 : E) 1)) := by
+  refine (contractible_iff_id_nullhomotopic _).mpr ?_
+  have hp : ‖(p : E)‖ = 1 := mem_sphere_zero_iff_norm.mp p.2
+  let inclusion : ({p}ᶜ : Set (sphere (0 : E) 1)) → E := fun q =>
+    ((q : sphere (0 : E) 1) : E)
+  have hinclusion : Continuous inclusion := continuous_subtype_val.comp continuous_subtype_val
+  have hsegment : ∀ z : I × ({p}ᶜ : Set (sphere (0 : E) 1)),
+      (1 - (z.1 : ℝ)) • inclusion z.2 + (z.1 : ℝ) • (-(p : E)) ≠ 0 := by
+    rintro ⟨u, q⟩
+    simpa only [inclusion, smul_neg, sub_eq_add_neg] using smul_sub_smul_ne_zero_of_ne
+      (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2) hp
+      (fun hq => q.2 (Set.mem_singleton_iff.mpr (Subtype.ext hq))) u
+  let G := normalizeSegmentToSphere inclusion (fun _ => -(p : E))
+    hinclusion continuous_const hsegment
+  have hGne : ∀ z, G z ≠ p := by
+    rintro ⟨u, q⟩ hG
+    exact normalize_smul_sub_smul_ne_of_ne
+      (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2) hp
+      (fun hq => q.2 (Set.mem_singleton_iff.mpr (Subtype.ext hq))) u
+      (by simpa [G, normalizeSegmentToSphere, normalizeToSphere, inclusion, smul_neg,
+        sub_eq_add_neg] using congrArg Subtype.val hG)
+  let antipode : sphere (0 : E) 1 := ⟨-(p : E), by simp⟩
+  have hneg : antipode ≠ p := by
+    intro h
+    have hval : -(p : E) = (p : E) := by
+      simpa only [antipode] using congrArg Subtype.val h
+    have htwo : (2 : ℝ) • (p : E) = 0 := by
+      calc
+        (2 : ℝ) • (p : E) = (p : E) + (p : E) := two_smul ℝ (p : E)
+        _ = -(p : E) + (p : E) := congrArg (fun y : E => y + (p : E)) hval.symm
+        _ = 0 := neg_add_cancel (p : E)
+    have hpzero : (p : E) = 0 := (smul_eq_zero.mp htwo).resolve_left (by norm_num)
+    rw [hpzero, norm_zero] at hp
+    norm_num at hp
+  refine ⟨⟨antipode, by simpa only [Set.mem_compl_iff, Set.mem_singleton_iff]⟩, ⟨?_⟩⟩
+  exact
+    { toFun := fun z => ⟨G z,
+        by simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using hGne z⟩
+      continuous_toFun := G.continuous.subtype_mk fun z => by
+        simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using hGne z
+      map_zero_left := fun q => by
+        have hraw : ((G (0, q) : sphere (0 : E) 1) : E) =
+            ((q : sphere (0 : E) 1) : E) := by
+          simpa [G, normalizeSegmentToSphere, normalizeToSphere, inclusion] using
+            normalize_eq_self_of_norm_eq_one
+              (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2)
+        exact Subtype.ext (Subtype.ext hraw)
+      map_one_left := fun q => by
+        have hraw : ((G (1, q) : sphere (0 : E) 1) : E) = -(p : E) := by
+          simpa [G, normalizeSegmentToSphere, normalizeToSphere, inclusion, normalize_neg] using
+            congrArg Neg.neg (normalize_eq_self_of_norm_eq_one hp)
+        exact Subtype.ext (Subtype.ext hraw) }
+
+/-- **The inclusion of the unit sphere minus one point into the sphere is null-homotopic.** -/
+theorem nullhomotopic_inclusion_sphere_compl_singleton (p : sphere (0 : E) 1) :
     (ContinuousMap.mk (Subtype.val : ({p}ᶜ : Set (sphere (0 : E) 1)) → sphere (0 : E) 1)
       continuous_subtype_val).Nullhomotopic := by
-  have hp : ‖(p : E)‖ = 1 := mem_sphere_zero_iff_norm.mp p.2
-  set g : I × ({p}ᶜ : Set (sphere (0 : E) 1)) → E := fun z =>
-    (1 - (z.1 : ℝ)) • ((z.2 : sphere (0 : E) 1) : E) - (z.1 : ℝ) • (p : E) with hg
-  have hgcont : Continuous g := by
-    have h1 : Continuous fun z : I × ({p}ᶜ : Set (sphere (0 : E) 1)) =>
-        ((z.2 : sphere (0 : E) 1) : E) :=
-      continuous_subtype_val.comp (continuous_subtype_val.comp continuous_snd)
-    have h2 : Continuous fun z : I × ({p}ᶜ : Set (sphere (0 : E) 1)) => ((z.1 : ℝ)) :=
-      continuous_subtype_val.comp continuous_fst
-    exact ((continuous_const.sub h2).smul h1).sub (h2.smul continuous_const)
-  have hgne : ∀ z, g z ≠ 0 := by
-    rintro ⟨u, q⟩
-    refine sub_smul_ne_zero_of_norm_eq_one
-      (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2) hp ?_ u.2.1 u.2.2
-    intro hq
-    exact q.2 (Set.mem_singleton_iff.mpr (Subtype.ext hq))
-  refine ⟨⟨-(p : E), by simp⟩, ⟨?_⟩⟩
-  exact
-    { toFun := fun z => ⟨normalize (g z), mem_sphere_zero_iff_norm.mpr (norm_normalize (hgne z))⟩
-      continuous_toFun := by
-        refine Continuous.subtype_mk ?_ _
-        change Continuous fun z => ‖g z‖⁻¹ • g z
-        exact ((continuous_norm.comp hgcont).inv₀
-          (fun z => norm_ne_zero_iff.mpr (hgne z))).smul hgcont
-      map_zero_left := fun q => by
-        refine Subtype.ext ?_
-        change NormedSpace.normalize (g (0, q)) = ((q : sphere (0 : E) 1) : E)
-        have hgq : g (0, q) = ((q : sphere (0 : E) 1) : E) := by simp [hg]
-        rw [hgq]
-        exact normalize_eq_self_of_norm_eq_one
-          (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2)
-      map_one_left := fun q => by
-        refine Subtype.ext ?_
-        change NormedSpace.normalize (g (1, q)) = -(p : E)
-        have hgq : g (1, q) = -(p : E) := by simp [hg]
-        rw [hgq, normalize_neg, normalize_eq_self_of_norm_eq_one hp] }
+  let _ : ContractibleSpace ({p}ᶜ : Set (sphere (0 : E) 1)) :=
+    contractibleSpace_sphere_compl_singleton p
+  simpa using (id_nullhomotopic ({p}ᶜ : Set (sphere (0 : E) 1))).comp_right
+    (ContinuousMap.mk (Subtype.val : ({p}ᶜ : Set (sphere (0 : E) 1)) → sphere (0 : E) 1)
+      continuous_subtype_val)
 
 /-- **A loop on the unit sphere that omits a point of the sphere is null-homotopic.** The loop
 runs in the punctured sphere, whose inclusion into the sphere is null-homotopic. -/
-theorem homotopic_refl_of_notMem_range {x : sphere (0 : E) 1} (γ : Path x x)
+theorem homotopic_refl_of_notMem_range_sphere {x : sphere (0 : E) 1} (γ : Path x x)
     {p : sphere (0 : E) 1} (hp : p ∉ Set.range γ) : γ.Homotopic (Path.refl x) := by
   have hmem : ∀ t, γ t ∈ ({p}ᶜ : Set (sphere (0 : E) 1)) := fun t hmem =>
     hp ⟨t, (Set.mem_singleton_iff.mp hmem).symm ▸ rfl⟩
-  have hx : x ∈ ({p}ᶜ : Set (sphere (0 : E) 1)) := γ.source ▸ hmem 0
-  have key := Path.Homotopic.map_nullhomotopic_of_nullhomotopic
-    (nullhomotopic_inclusion_sphere_compl p)
-    (Path.codRestrict (x := ⟨x, hx⟩) (y := ⟨x, hx⟩) γ hmem)
-  rwa [Path.map_codRestrict (x := ⟨x, hx⟩) (y := ⟨x, hx⟩) γ hmem] at key
+  exact Path.Homotopic.refl_of_forall_mem_of_nullhomotopic
+    (nullhomotopic_inclusion_sphere_compl_singleton p) γ hmem
 
 end TauCeti
 

--- a/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
@@ -26,7 +26,7 @@ arbitrary loop off a point, which is done in
 
 * `TauCeti.normalizeToSphere`: radial projection of a continuous nowhere-zero map to the unit
   sphere.
-* `TauCeti.Path.homotopic_of_normalize_segment_ne_zero`: radial projection of a straight-line
+* `Path.homotopic_of_normalize_segment_ne_zero`: radial projection of a straight-line
   homotopy between sphere loops.
 * `TauCeti.contractibleSpace_sphere_compl_singleton`: the sphere minus one point is contractible.
 * `TauCeti.nullhomotopic_inclusion_sphere_compl_singleton`: the inclusion of the sphere minus a
@@ -103,7 +103,7 @@ private noncomputable def normalizeSegmentToSphere {Y : Type*} [TopologicalSpace
 
 /-- A loop in the unit sphere is homotopic to the radial projection of a continuous comparison
 loop when every point of their pointwise straight-line homotopy avoids the origin. -/
-theorem Path.homotopic_of_normalize_segment_ne_zero {x : sphere (0 : E) 1} (γ γ' : Path x x)
+theorem _root_.Path.homotopic_of_normalize_segment_ne_zero {x : sphere (0 : E) 1} (γ γ' : Path x x)
     (f : I → E) (hf : Continuous f)
     (hγ' : ∀ t, ((γ' t : sphere (0 : E) 1) : E) = normalize (f t))
     (hf_zero : f 0 = (x : E)) (hf_one : f 1 = (x : E))

--- a/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Homotopy.Contractible
 public import TauCeti.Analysis.Normed.Module.Normalize
 public import TauCeti.Topology.Homotopy.Path
 -- Private: these supply the affine homotopy and the antipode inequality used in proofs below.
@@ -27,7 +26,7 @@ arbitrary loop off a point, which is done in
 
 ## Main declarations
 
-* `TauCeti.homotopic_of_normalize_segment_ne_zero`: radial projection of a straight-line
+* `TauCeti.homotopic_of_segment_ne_zero`: radial projection of a straight-line
   homotopy between sphere paths.
 * `TauCeti.contractibleSpace_sphere_compl_singleton`: the sphere minus one point is contractible.
 * `TauCeti.nullhomotopic_inclusion_sphere_compl_singleton`: the inclusion of the sphere minus a
@@ -125,7 +124,7 @@ end Segment
 /-- A path in the unit sphere is homotopic to the radial projection of a continuous comparison
 map when every point of their pointwise straight-line homotopy avoids the origin and the comparison
 map itself takes the source and target values at the two endpoints. -/
-theorem homotopic_of_normalize_segment_ne_zero {a b : sphere (0 : E) 1} (γ γ' : Path a b)
+theorem homotopic_of_segment_ne_zero {a b : sphere (0 : E) 1} (γ γ' : Path a b)
     (f : I → E) (hf : Continuous f)
     (hγ' : ∀ t, ((γ' t : sphere (0 : E) 1) : E) = normalize (f t))
     (hf_zero : f 0 = (a : E)) (hf_one : f 1 = (b : E))

--- a/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
@@ -82,10 +82,8 @@ private noncomputable def normalizeSegmentToSphere {Y : Type*} [TopologicalSpace
     (ContinuousMap.Homotopy.affine F G).continuous fun z => by
       have hline : (ContinuousMap.Homotopy.affine F G) z =
           (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2 := by
-        rw [ContinuousMap.Homotopy.affine_apply, AffineMap.lineMap_apply]
-        change (z.1 : ℝ) • (g z.2 - f z.2) + f z.2 = _
-        rw [smul_sub, sub_smul, one_smul]
-        abel
+        rw [ContinuousMap.Homotopy.affine_apply, AffineMap.lineMap_apply_module]
+        rfl
       rw [hline]
       exact h0 z
 
@@ -100,11 +98,8 @@ private theorem coe_normalizeSegmentToSphere_apply (u : I) (y : Y) :
     ((normalizeSegmentToSphere f g hf hg h0 (u, y) : sphere (0 : E) 1) : E) =
       normalize ((1 - (u : ℝ)) • f y + (u : ℝ) • g y) := by
   rw [normalizeSegmentToSphere, coe_normalizeToSphere_apply,
-    ContinuousMap.Homotopy.affine_apply, AffineMap.lineMap_apply]
-  congr 1
-  change (u : ℝ) • (g y - f y) + f y = _
-  rw [smul_sub, sub_smul, one_smul]
-  abel
+    ContinuousMap.Homotopy.affine_apply, AffineMap.lineMap_apply_module]
+  rfl
 
 /-- The segment homotopy starts at the radial projection of `f`. -/
 private theorem coe_normalizeSegmentToSphere_zero_left (y : Y) :

--- a/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
@@ -5,9 +5,12 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Normed.Module.Normalize
 public import Mathlib.Topology.Homotopy.Contractible
+public import TauCeti.Analysis.Normed.Module.Normalize
 public import TauCeti.Topology.Homotopy.Path
+-- Private: these supply the affine homotopy and the antipode inequality used in proofs below.
+import Mathlib.Analysis.Normed.Module.Ball.Action
+import Mathlib.Topology.Homotopy.Affine
 
 /-!
 # The punctured unit sphere
@@ -24,14 +27,12 @@ arbitrary loop off a point, which is done in
 
 ## Main declarations
 
-* `TauCeti.normalizeToSphere`: radial projection of a continuous nowhere-zero map to the unit
-  sphere.
-* `Path.homotopic_of_normalize_segment_ne_zero`: radial projection of a straight-line
-  homotopy between sphere loops.
+* `TauCeti.homotopic_of_normalize_segment_ne_zero`: radial projection of a straight-line
+  homotopy between sphere paths.
 * `TauCeti.contractibleSpace_sphere_compl_singleton`: the sphere minus one point is contractible.
 * `TauCeti.nullhomotopic_inclusion_sphere_compl_singleton`: the inclusion of the sphere minus a
   point into the sphere is null-homotopic.
-* `TauCeti.homotopic_refl_of_notMem_range_sphere`: a loop on the unit sphere omitting a point of
+* `TauCeti.homotopic_refl_of_notMem_range`: a loop on the unit sphere omitting a point of
   the sphere is null-homotopic.
 
 ## References
@@ -53,33 +54,12 @@ namespace TauCeti
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-/-- Radial projection sends a continuous nowhere-zero map into a real normed space continuously
-to its unit sphere. -/
-@[expose] noncomputable def normalizeToSphere {Y : Type*} [TopologicalSpace Y] (f : Y → E)
-    (hf : Continuous f) (h0 : ∀ y, f y ≠ 0) : C(Y, sphere (0 : E) 1) where
-  toFun y := ⟨normalize (f y), mem_sphere_zero_iff_norm.mpr (norm_normalize (h0 y))⟩
-  continuous_toFun := by
-    refine Continuous.subtype_mk ?_ _
-    -- `normalize` is definitionally inverse-norm scalar multiplication; exposing that formula
-    -- lets the standard continuity combinators apply.
-    change Continuous fun y => ‖f y‖⁻¹ • f y
-    exact ((continuous_norm.comp hf).inv₀
-      (fun y => norm_ne_zero_iff.mpr (h0 y))).smul hf
-
-/-- The underlying vector of `normalizeToSphere f hf h0 y` is the normalization of `f y`. -/
-@[simp]
-theorem normalizeToSphere_apply {Y : Type*} [TopologicalSpace Y] (f : Y → E)
-    (hf : Continuous f) (h0 : ∀ y, f y ≠ 0) (y : Y) :
-    ((normalizeToSphere f hf h0 y : sphere (0 : E) 1) : E) = normalize (f y) := rfl
-
 private theorem smul_sub_smul_ne_zero_of_ne {x p : E} (hx : ‖x‖ = 1) (hp : ‖p‖ = 1)
     (hxp : x ≠ p) (u : ℝ) : (1 - u) • x - u • p ≠ 0 := by
   intro h
   have h' : (1 - u) • x = u • p := by rwa [sub_eq_zero] at h
   have habs : |1 - u| = |u| := by
-    have hnorm := congrArg norm h'
-    rw [norm_smul, norm_smul, hx, hp, mul_one, mul_one, Real.norm_eq_abs, Real.norm_eq_abs] at hnorm
-    exact hnorm
+    simpa [norm_smul, hx, hp, Real.norm_eq_abs] using congrArg norm h'
   have hu : u = 1 / 2 := by
     have hsquare := congrArg (fun r : ℝ => r ^ 2) habs
     simp only [sq_abs] at hsquare
@@ -96,11 +76,18 @@ private noncomputable def normalizeSegmentToSphere {Y : Type*} [TopologicalSpace
     (f g : Y → E) (hf : Continuous f) (hg : Continuous g)
     (h0 : ∀ z : I × Y, (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2 ≠ 0) :
     C(I × Y, sphere (0 : E) 1) :=
-  normalizeToSphere
-    (fun z => (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2)
-    (((continuous_const.sub (continuous_subtype_val.comp continuous_fst)).smul
-        (hf.comp continuous_snd)).add
-      ((continuous_subtype_val.comp continuous_fst).smul (hg.comp continuous_snd))) h0
+  let F : C(Y, E) := ⟨f, hf⟩
+  let G : C(Y, E) := ⟨g, hg⟩
+  normalizeToSphere (ContinuousMap.Homotopy.affine F G)
+    (ContinuousMap.Homotopy.affine F G).continuous fun z => by
+      have hline : (ContinuousMap.Homotopy.affine F G) z =
+          (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2 := by
+        rw [ContinuousMap.Homotopy.affine_apply, AffineMap.lineMap_apply]
+        change (z.1 : ℝ) • (g z.2 - f z.2) + f z.2 = _
+        rw [smul_sub, sub_smul, one_smul]
+        abel
+      rw [hline]
+      exact h0 z
 
 section Segment
 
@@ -109,59 +96,66 @@ variable {Y : Type*} [TopologicalSpace Y] {f g : Y → E} {hf : Continuous f} {h
 
 /-- The underlying vector of the segment homotopy at `(u, y)` is the normalization of the point
 of the segment from `f y` to `g y` at time `u`. -/
-private theorem normalizeSegmentToSphere_apply (u : I) (y : Y) :
+private theorem coe_normalizeSegmentToSphere_apply (u : I) (y : Y) :
     ((normalizeSegmentToSphere f g hf hg h0 (u, y) : sphere (0 : E) 1) : E) =
-      normalize ((1 - (u : ℝ)) • f y + (u : ℝ) • g y) :=
-  normalizeToSphere_apply _ _ _ (u, y)
+      normalize ((1 - (u : ℝ)) • f y + (u : ℝ) • g y) := by
+  rw [normalizeSegmentToSphere, coe_normalizeToSphere_apply,
+    ContinuousMap.Homotopy.affine_apply, AffineMap.lineMap_apply]
+  congr 1
+  change (u : ℝ) • (g y - f y) + f y = _
+  rw [smul_sub, sub_smul, one_smul]
+  abel
 
 /-- The segment homotopy starts at the radial projection of `f`. -/
-private theorem normalizeSegmentToSphere_zero_left (y : Y) :
+private theorem coe_normalizeSegmentToSphere_zero_left (y : Y) :
     ((normalizeSegmentToSphere f g hf hg h0 (0, y) : sphere (0 : E) 1) : E) = normalize (f y) := by
-  rw [normalizeSegmentToSphere_apply]
+  rw [coe_normalizeSegmentToSphere_apply]
   simp
 
 /-- The segment homotopy ends at the radial projection of `g`. -/
-private theorem normalizeSegmentToSphere_one_left (y : Y) :
+private theorem coe_normalizeSegmentToSphere_one_left (y : Y) :
     ((normalizeSegmentToSphere f g hf hg h0 (1, y) : sphere (0 : E) 1) : E) = normalize (g y) := by
-  rw [normalizeSegmentToSphere_apply]
+  rw [coe_normalizeSegmentToSphere_apply]
   simp
 
 /-- Where `f` and `g` agree at a unit vector the segment homotopy stays at that vector. -/
-private theorem normalizeSegmentToSphere_apply_of_eq {y : Y} {v : E} (hfy : f y = v)
+private theorem coe_normalizeSegmentToSphere_apply_of_eq {y : Y} {v : E} (hfy : f y = v)
     (hgy : g y = v) (hv : ‖v‖ = 1) (u : I) :
     ((normalizeSegmentToSphere f g hf hg h0 (u, y) : sphere (0 : E) 1) : E) = v := by
-  rw [normalizeSegmentToSphere_apply, hfy, hgy, ← add_smul]
+  rw [coe_normalizeSegmentToSphere_apply, hfy, hgy, ← add_smul]
   simpa using normalize_eq_self_of_norm_eq_one hv
 
 end Segment
 
-/-- A loop in the unit sphere is homotopic to the radial projection of a continuous comparison
-loop when every point of their pointwise straight-line homotopy avoids the origin. -/
-theorem _root_.Path.homotopic_of_normalize_segment_ne_zero {x : sphere (0 : E) 1} (γ γ' : Path x x)
+/-- A path in the unit sphere is homotopic to the radial projection of a continuous comparison
+map when every point of their pointwise straight-line homotopy avoids the origin and the comparison
+map itself takes the source and target values at the two endpoints. -/
+theorem homotopic_of_normalize_segment_ne_zero {a b : sphere (0 : E) 1} (γ γ' : Path a b)
     (f : I → E) (hf : Continuous f)
     (hγ' : ∀ t, ((γ' t : sphere (0 : E) 1) : E) = normalize (f t))
-    (hf_zero : f 0 = (x : E)) (hf_one : f 1 = (x : E))
+    (hf_zero : f 0 = (a : E)) (hf_one : f 1 = (b : E))
     (h : ∀ z : I × I,
       (1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E) +
         (z.1 : ℝ) • f z.2 ≠ 0) : γ.Homotopic γ' := by
-  have hxnorm : ‖((x : sphere (0 : E) 1) : E)‖ = 1 := mem_sphere_zero_iff_norm.mp x.2
+  have hanorm : ‖((a : sphere (0 : E) 1) : E)‖ = 1 := mem_sphere_zero_iff_norm.mp a.2
+  have hbnorm : ‖((b : sphere (0 : E) 1) : E)‖ = 1 := mem_sphere_zero_iff_norm.mp b.2
   refine Path.homotopic_of_continuous_square
     (normalizeSegmentToSphere (fun t => ((γ t : sphere (0 : E) 1) : E)) f
       (continuous_subtype_val.comp γ.continuous) hf h)
     (ContinuousMap.continuous _) ?_ ?_ ?_ ?_
   · intro s
     refine Subtype.ext ?_
-    rw [normalizeSegmentToSphere_zero_left]
+    rw [coe_normalizeSegmentToSphere_zero_left]
     exact normalize_eq_self_of_norm_eq_one (mem_sphere_zero_iff_norm.mp (γ s).2)
   · intro s
     refine Subtype.ext ?_
-    rw [normalizeSegmentToSphere_one_left]
+    rw [coe_normalizeSegmentToSphere_one_left]
     exact (hγ' s).symm
   · intro u
-    refine Subtype.ext (normalizeSegmentToSphere_apply_of_eq (y := (0 : I)) ?_ hf_zero hxnorm u)
+    refine Subtype.ext (coe_normalizeSegmentToSphere_apply_of_eq (y := (0 : I)) ?_ hf_zero hanorm u)
     exact congrArg Subtype.val γ.source
   · intro u
-    refine Subtype.ext (normalizeSegmentToSphere_apply_of_eq (y := (1 : I)) ?_ hf_one hxnorm u)
+    refine Subtype.ext (coe_normalizeSegmentToSphere_apply_of_eq (y := (1 : I)) ?_ hf_one hbnorm u)
     exact congrArg Subtype.val γ.target
 
 private theorem normalize_smul_sub_smul_ne_of_ne {x p : E} (hx : ‖x‖ = 1) (hp : ‖p‖ = 1)
@@ -179,9 +173,9 @@ private theorem normalize_smul_sub_smul_ne_of_ne {x p : E} (hx : ‖x‖ = 1) (h
     abel
   have hleft : 0 < ‖v‖ + (u : ℝ) := add_pos_of_pos_of_nonneg hvnorm u.2.1
   have hright : 0 ≤ 1 - (u : ℝ) := sub_nonneg.mpr u.2.2
-  have hcoeff := congrArg norm heq
-  rw [norm_smul, norm_smul, hp, hx, mul_one, mul_one, Real.norm_eq_abs, Real.norm_eq_abs,
-    abs_of_pos hleft, abs_of_nonneg hright] at hcoeff
+  have hcoeff : ‖v‖ + (u : ℝ) = 1 - (u : ℝ) := by
+    simpa [norm_smul, hp, hx, Real.norm_eq_abs, abs_of_pos hleft, abs_of_nonneg hright] using
+      congrArg norm heq
   have hright' : 0 < 1 - (u : ℝ) := hcoeff ▸ hleft
   rw [hcoeff] at heq
   have hinv := congrArg (fun y : E => (1 - (u : ℝ))⁻¹ • y) heq
@@ -212,27 +206,15 @@ theorem contractibleSpace_sphere_compl_singleton (p : sphere (0 : E) 1) :
             normalize ((1 - (u : ℝ)) • ((q : sphere (0 : E) 1) : E) - (u : ℝ) • (p : E)) :=
     ⟨normalizeSegmentToSphere inclusion (fun _ => -(p : E)) hinclusion continuous_const hsegment,
       ContinuousMap.continuous _,
-      fun u q => by rw [normalizeSegmentToSphere_apply, smul_neg, ← sub_eq_add_neg]⟩
+      fun u q => by rw [coe_normalizeSegmentToSphere_apply, smul_neg, ← sub_eq_add_neg]⟩
   have hGne : ∀ z, G z ≠ p := by
     rintro ⟨u, q⟩ hG
     refine normalize_smul_sub_smul_ne_of_ne
       (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2) hp
       (fun hq => q.2 (Set.mem_singleton_iff.mpr (Subtype.ext hq))) u ?_
     rw [← hGval u q, hG]
-  let antipode : sphere (0 : E) 1 := ⟨-(p : E), by simp⟩
-  have hneg : antipode ≠ p := by
-    intro h
-    have hval : -(p : E) = (p : E) := by
-      simpa only [antipode] using congrArg Subtype.val h
-    have htwo : (2 : ℝ) • (p : E) = 0 := by
-      calc
-        (2 : ℝ) • (p : E) = (p : E) + (p : E) := two_smul ℝ (p : E)
-        _ = -(p : E) + (p : E) := congrArg (fun y : E => y + (p : E)) hval.symm
-        _ = 0 := neg_add_cancel (p : E)
-    have hpzero : (p : E) = 0 := (smul_eq_zero.mp htwo).resolve_left (by norm_num)
-    rw [hpzero, norm_zero] at hp
-    norm_num at hp
-  refine ⟨⟨antipode, by simpa only [Set.mem_compl_iff, Set.mem_singleton_iff]⟩, ⟨?_⟩⟩
+  have hneg : -p ≠ p := (ne_neg_of_mem_unit_sphere ℝ p).symm
+  refine ⟨⟨-p, by simpa only [Set.mem_compl_iff, Set.mem_singleton_iff]⟩, ⟨?_⟩⟩
   exact
     { toFun := fun z => ⟨G z,
         by simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using hGne z⟩
@@ -249,7 +231,7 @@ theorem contractibleSpace_sphere_compl_singleton (p : sphere (0 : E) 1) :
         have hraw : ((G (1, q) : sphere (0 : E) 1) : E) = -(p : E) := by
           rw [hGval]
           simpa [normalize_neg] using congrArg Neg.neg (normalize_eq_self_of_norm_eq_one hp)
-        exact Subtype.ext (Subtype.ext hraw) }
+        exact Subtype.ext (Subtype.ext (hraw.trans (coe_neg_sphere p).symm)) }
 
 /-- **The inclusion of the unit sphere minus one point into the sphere is null-homotopic.** -/
 theorem nullhomotopic_inclusion_sphere_compl_singleton (p : sphere (0 : E) 1) :
@@ -263,7 +245,7 @@ theorem nullhomotopic_inclusion_sphere_compl_singleton (p : sphere (0 : E) 1) :
 
 /-- **A loop on the unit sphere that omits a point of the sphere is null-homotopic.** The loop
 runs in the punctured sphere, whose inclusion into the sphere is null-homotopic. -/
-theorem homotopic_refl_of_notMem_range_sphere {x : sphere (0 : E) 1} (γ : Path x x)
+theorem homotopic_refl_of_notMem_range {x : sphere (0 : E) 1} (γ : Path x x)
     {p : sphere (0 : E) 1} (hp : p ∉ Set.range γ) : γ.Homotopic (Path.refl x) := by
   have hmem : ∀ t, γ t ∈ ({p}ᶜ : Set (sphere (0 : E) 1)) := fun t hmem =>
     hp ⟨t, (Set.mem_singleton_iff.mp hmem).symm ▸ rfl⟩

--- a/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/Puncture.lean
@@ -90,16 +90,50 @@ private theorem smul_sub_smul_ne_zero_of_ne {x p : E} (hx : ‖x‖ = 1) (hp : �
   norm_num at h2
   exact h2
 
+/-- Radial projection of the straight-line homotopy from `f` to `g`, available whenever that
+segment never meets the origin. -/
 private noncomputable def normalizeSegmentToSphere {Y : Type*} [TopologicalSpace Y]
     (f g : Y → E) (hf : Continuous f) (hg : Continuous g)
     (h0 : ∀ z : I × Y, (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2 ≠ 0) :
-    C(I × Y, sphere (0 : E) 1) := by
-  have hu : Continuous fun z : I × Y => ((z.1 : ℝ)) :=
-    continuous_subtype_val.comp continuous_fst
-  exact normalizeToSphere
+    C(I × Y, sphere (0 : E) 1) :=
+  normalizeToSphere
     (fun z => (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2)
-    (((continuous_const.sub hu).smul (hf.comp continuous_snd)).add
-      (hu.smul (hg.comp continuous_snd))) h0
+    (((continuous_const.sub (continuous_subtype_val.comp continuous_fst)).smul
+        (hf.comp continuous_snd)).add
+      ((continuous_subtype_val.comp continuous_fst).smul (hg.comp continuous_snd))) h0
+
+section Segment
+
+variable {Y : Type*} [TopologicalSpace Y] {f g : Y → E} {hf : Continuous f} {hg : Continuous g}
+  {h0 : ∀ z : I × Y, (1 - (z.1 : ℝ)) • f z.2 + (z.1 : ℝ) • g z.2 ≠ 0}
+
+/-- The underlying vector of the segment homotopy at `(u, y)` is the normalization of the point
+of the segment from `f y` to `g y` at time `u`. -/
+private theorem normalizeSegmentToSphere_apply (u : I) (y : Y) :
+    ((normalizeSegmentToSphere f g hf hg h0 (u, y) : sphere (0 : E) 1) : E) =
+      normalize ((1 - (u : ℝ)) • f y + (u : ℝ) • g y) :=
+  normalizeToSphere_apply _ _ _ (u, y)
+
+/-- The segment homotopy starts at the radial projection of `f`. -/
+private theorem normalizeSegmentToSphere_zero_left (y : Y) :
+    ((normalizeSegmentToSphere f g hf hg h0 (0, y) : sphere (0 : E) 1) : E) = normalize (f y) := by
+  rw [normalizeSegmentToSphere_apply]
+  simp
+
+/-- The segment homotopy ends at the radial projection of `g`. -/
+private theorem normalizeSegmentToSphere_one_left (y : Y) :
+    ((normalizeSegmentToSphere f g hf hg h0 (1, y) : sphere (0 : E) 1) : E) = normalize (g y) := by
+  rw [normalizeSegmentToSphere_apply]
+  simp
+
+/-- Where `f` and `g` agree at a unit vector the segment homotopy stays at that vector. -/
+private theorem normalizeSegmentToSphere_apply_of_eq {y : Y} {v : E} (hfy : f y = v)
+    (hgy : g y = v) (hv : ‖v‖ = 1) (u : I) :
+    ((normalizeSegmentToSphere f g hf hg h0 (u, y) : sphere (0 : E) 1) : E) = v := by
+  rw [normalizeSegmentToSphere_apply, hfy, hgy, ← add_smul]
+  simpa using normalize_eq_self_of_norm_eq_one hv
+
+end Segment
 
 /-- A loop in the unit sphere is homotopic to the radial projection of a continuous comparison
 loop when every point of their pointwise straight-line homotopy avoids the origin. -/
@@ -110,26 +144,25 @@ theorem _root_.Path.homotopic_of_normalize_segment_ne_zero {x : sphere (0 : E) 1
     (h : ∀ z : I × I,
       (1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E) +
         (z.1 : ℝ) • f z.2 ≠ 0) : γ.Homotopic γ' := by
-  let K := normalizeSegmentToSphere
-    (fun t => ((γ t : sphere (0 : E) 1) : E)) f
-    (continuous_subtype_val.comp γ.continuous) hf h
   have hxnorm : ‖((x : sphere (0 : E) 1) : E)‖ = 1 := mem_sphere_zero_iff_norm.mp x.2
-  refine Path.homotopic_of_continuous_square K K.continuous ?_ ?_ ?_ ?_
+  refine Path.homotopic_of_continuous_square
+    (normalizeSegmentToSphere (fun t => ((γ t : sphere (0 : E) 1) : E)) f
+      (continuous_subtype_val.comp γ.continuous) hf h)
+    (ContinuousMap.continuous _) ?_ ?_ ?_ ?_
   · intro s
-    apply Subtype.ext
-    simpa [K, normalizeSegmentToSphere, normalizeToSphere] using
-      normalize_eq_self_of_norm_eq_one (mem_sphere_zero_iff_norm.mp (γ s).2)
+    refine Subtype.ext ?_
+    rw [normalizeSegmentToSphere_zero_left]
+    exact normalize_eq_self_of_norm_eq_one (mem_sphere_zero_iff_norm.mp (γ s).2)
   · intro s
-    apply Subtype.ext
-    simpa [K, normalizeSegmentToSphere, normalizeToSphere] using (hγ' s).symm
+    refine Subtype.ext ?_
+    rw [normalizeSegmentToSphere_one_left]
+    exact (hγ' s).symm
   · intro u
-    apply Subtype.ext
-    simpa [K, normalizeSegmentToSphere, normalizeToSphere, γ.source, hf_zero, ← add_smul] using
-      normalize_eq_self_of_norm_eq_one hxnorm
+    refine Subtype.ext (normalizeSegmentToSphere_apply_of_eq (y := (0 : I)) ?_ hf_zero hxnorm u)
+    exact congrArg Subtype.val γ.source
   · intro u
-    apply Subtype.ext
-    simpa [K, normalizeSegmentToSphere, normalizeToSphere, γ.target, hf_one, ← add_smul] using
-      normalize_eq_self_of_norm_eq_one hxnorm
+    refine Subtype.ext (normalizeSegmentToSphere_apply_of_eq (y := (1 : I)) ?_ hf_one hxnorm u)
+    exact congrArg Subtype.val γ.target
 
 private theorem normalize_smul_sub_smul_ne_of_ne {x p : E} (hx : ‖x‖ = 1) (hp : ‖p‖ = 1)
     (hxp : x ≠ p) (u : I) : normalize ((1 - (u : ℝ)) • x - (u : ℝ) • p) ≠ p := by
@@ -170,15 +203,22 @@ theorem contractibleSpace_sphere_compl_singleton (p : sphere (0 : E) 1) :
     simpa only [inclusion, smul_neg, sub_eq_add_neg] using smul_sub_smul_ne_zero_of_ne
       (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2) hp
       (fun hq => q.2 (Set.mem_singleton_iff.mpr (Subtype.ext hq))) u
-  let G := normalizeSegmentToSphere inclusion (fun _ => -(p : E))
-    hinclusion continuous_const hsegment
+  -- The contraction, presented by the value of its underlying vector so that no later step has
+  -- to unfold `normalizeSegmentToSphere`.
+  obtain ⟨G, hGcont, hGval⟩ :
+      ∃ G : I × ({p}ᶜ : Set (sphere (0 : E) 1)) → sphere (0 : E) 1, Continuous G ∧
+        ∀ (u : I) (q : ({p}ᶜ : Set (sphere (0 : E) 1))),
+          ((G (u, q) : sphere (0 : E) 1) : E) =
+            normalize ((1 - (u : ℝ)) • ((q : sphere (0 : E) 1) : E) - (u : ℝ) • (p : E)) :=
+    ⟨normalizeSegmentToSphere inclusion (fun _ => -(p : E)) hinclusion continuous_const hsegment,
+      ContinuousMap.continuous _,
+      fun u q => by rw [normalizeSegmentToSphere_apply, smul_neg, ← sub_eq_add_neg]⟩
   have hGne : ∀ z, G z ≠ p := by
     rintro ⟨u, q⟩ hG
-    exact normalize_smul_sub_smul_ne_of_ne
+    refine normalize_smul_sub_smul_ne_of_ne
       (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2) hp
-      (fun hq => q.2 (Set.mem_singleton_iff.mpr (Subtype.ext hq))) u
-      (by simpa [G, normalizeSegmentToSphere, normalizeToSphere, inclusion, smul_neg,
-        sub_eq_add_neg] using congrArg Subtype.val hG)
+      (fun hq => q.2 (Set.mem_singleton_iff.mpr (Subtype.ext hq))) u ?_
+    rw [← hGval u q, hG]
   let antipode : sphere (0 : E) 1 := ⟨-(p : E), by simp⟩
   have hneg : antipode ≠ p := by
     intro h
@@ -196,19 +236,19 @@ theorem contractibleSpace_sphere_compl_singleton (p : sphere (0 : E) 1) :
   exact
     { toFun := fun z => ⟨G z,
         by simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using hGne z⟩
-      continuous_toFun := G.continuous.subtype_mk fun z => by
+      continuous_toFun := hGcont.subtype_mk fun z => by
         simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using hGne z
       map_zero_left := fun q => by
         have hraw : ((G (0, q) : sphere (0 : E) 1) : E) =
             ((q : sphere (0 : E) 1) : E) := by
-          simpa [G, normalizeSegmentToSphere, normalizeToSphere, inclusion] using
-            normalize_eq_self_of_norm_eq_one
-              (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2)
+          rw [hGval]
+          simpa using normalize_eq_self_of_norm_eq_one
+            (mem_sphere_zero_iff_norm.mp (q : sphere (0 : E) 1).2)
         exact Subtype.ext (Subtype.ext hraw)
       map_one_left := fun q => by
         have hraw : ((G (1, q) : sphere (0 : E) 1) : E) = -(p : E) := by
-          simpa [G, normalizeSegmentToSphere, normalizeToSphere, inclusion, normalize_neg] using
-            congrArg Neg.neg (normalize_eq_self_of_norm_eq_one hp)
+          rw [hGval]
+          simpa [normalize_neg] using congrArg Neg.neg (normalize_eq_self_of_norm_eq_one hp)
         exact Subtype.ext (Subtype.ext hraw) }
 
 /-- **The inclusion of the unit sphere minus one point into the sphere is null-homotopic.** -/

--- a/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
@@ -196,12 +196,11 @@ private theorem sum_hatFunction_eq_one (N : ℕ) (t : I) :
     have hrestrict := Finset.sum_subset hsubset hzero
     have hhatm : hatFunction N m t = 1 - (r - m) := by
       unfold hatFunction
-      rw [show (N : ℝ) * (t : ℝ) - (m : ℝ) = r - m by rw [hr],
+      rw [← hr,
         abs_of_nonneg (by simpa [hr, hm] using h1), max_eq_right (by linarith [h2])]
     have hhatnext : hatFunction N (m + 1) t = r - m := by
       unfold hatFunction
-      rw [show (N : ℝ) * (t : ℝ) - ((m + 1 : ℕ) : ℝ) = r - (m + 1) by
-        push_cast; rw [hr]]
+      rw [← hr, Nat.cast_add, Nat.cast_one]
       rw [abs_of_nonpos (by simpa [hr, hm] using h2.le), max_eq_right (by linarith [h1])]
       ring
     rw [← hrestrict]

--- a/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Module.Submodule.Union
-public import Mathlib.Analysis.InnerProductSpace.EuclideanDist
+public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.Analysis.Normed.Module.Connected
 public import Mathlib.LinearAlgebra.Dimension.Constructions
 public import TauCeti.AlgebraicTopology.Sphere.Puncture
@@ -33,14 +33,14 @@ the sphere. And `Λ k t ≠ 0` also forces `k` to be `⌊N t⌋` or `⌊N t⌋ +
 span of two of the nodes. A finite family of proper subspaces of `E` cannot cover `E`
 (`Submodule.exists_forall_notMem_of_forall_ne_top`), and the spans of two vectors are proper
 exactly because the rank exceeds two, so the projected loop omits a point of the sphere. Loops
-omitting a point are null-homotopic by `TauCeti.homotopic_refl_of_notMem_range`.
+omitting a point are null-homotopic by `TauCeti.homotopic_refl_of_notMem_range_sphere`.
 
 Rank two is genuinely the boundary: the circle is not simply connected.
 
 ## Main declarations
 
-* `TauCeti.exists_homotopic_notMem_range`: every loop on the unit sphere is homotopic to a loop
-  that omits a point of the sphere.
+* `TauCeti.exists_homotopic_notMem_range_sphere`: every loop on the unit sphere is homotopic to a
+  loop that omits a point of the sphere.
 * `TauCeti.simplyConnectedSpace_sphere`: **the unit sphere of a real inner product space of rank
   greater than two is simply connected.**
 * `TauCeti.simplyConnectedSpace_euclideanSphere`: the case of `Sⁿ` for `2 ≤ n`.
@@ -160,7 +160,7 @@ private theorem nodeInterp_one (N : ℕ) (node : ℕ → E) : nodeInterp N node 
       rw [hatFunction_one_of_ne (Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)) hkN, zero_smul]
   · exact fun hc => absurd (Finset.mem_range.mpr (Nat.lt_succ_self N)) hc
 
-/-- The interpolation at `t` lies on the geodesic chord of the two nodes straddling `t`. -/
+/-- The interpolation at `t` lies in the span of the two nodes straddling `t`. -/
 private theorem nodeInterp_mem_span (N : ℕ) (node : ℕ → E) (t : I) :
     nodeInterp N node t ∈
       Submodule.span ℝ {node ⌊(N : ℝ) * (t : ℝ)⌋₊, node (⌊(N : ℝ) * (t : ℝ)⌋₊ + 1)} := by
@@ -185,11 +185,23 @@ private theorem half_mul_sum_le_inner_nodeInterp {N : ℕ} {node : ℕ → E} {a
   · have := mul_le_mul_of_nonneg_left (h k hk).le (hatFunction_nonneg N k t)
     linarith
 
+private theorem span_pair_ne_top (h : 2 < Module.rank ℝ E) (a b : E) :
+    Submodule.span ℝ ({a, b} : Set E) ≠ ⊤ := by
+  intro hab
+  have hcard : Cardinal.mk ({a, b} : Set E) ≤ 2 :=
+    calc Cardinal.mk ({a, b} : Set E) ≤ Cardinal.mk ({b} : Set E) + 1 := Cardinal.mk_insert_le
+      _ = 2 := by rw [Cardinal.mk_singleton]; exact one_add_one_eq_two
+  have h2 : Module.rank ℝ ↥(Submodule.span ℝ ({a, b} : Set E)) ≤ 2 :=
+    (rank_span_le _).trans hcard
+  rw [hab, rank_top] at h2
+  exact absurd h2 (not_le.mpr h)
+
 /-- **Every loop on the unit sphere of a real inner product space of rank greater than two is
 homotopic to a loop that omits a point of the sphere.** The comparison loop is the radial
 projection of the piecewise linear interpolation of finitely many values of the loop, and the
 point it omits is obtained by avoiding the finitely many planes those values span. -/
-theorem exists_homotopic_notMem_range (h : 2 < Module.rank ℝ E) {x : sphere (0 : E) 1}
+theorem exists_homotopic_notMem_range_sphere (h : 2 < Module.rank ℝ E)
+    {x : sphere (0 : E) 1}
     (γ : Path x x) :
     ∃ γ' : Path x x, γ.Homotopic γ' ∧ ∃ p : sphere (0 : E) 1, p ∉ Set.range γ' := by
   have hγnorm : ∀ t, ‖((γ t : sphere (0 : E) 1) : E)‖ = 1 := fun t =>
@@ -266,24 +278,15 @@ theorem exists_homotopic_notMem_range (h : 2 < Module.rank ℝ E) {x : sphere (0
     simp only [nodeInterp_one, hnode, hnodeParamN, γ.target]
   -- The comparison loop.
   have hcontL : Continuous (nodeInterp N node) := continuous_nodeInterp N node
-  have hcontγ' : Continuous fun t : I =>
-      (⟨normalize (nodeInterp N node t),
-        mem_sphere_zero_iff_norm.mpr (norm_normalize (hLne t))⟩ : sphere (0 : E) 1) := by
-    refine Continuous.subtype_mk ?_ _
-    change Continuous fun t => ‖nodeInterp N node t‖⁻¹ • nodeInterp N node t
-    exact ((continuous_norm.comp hcontL).inv₀
-      (fun t => norm_ne_zero_iff.mpr (hLne t))).smul hcontL
+  let Lsphere := normalizeToSphere (nodeInterp N node) hcontL hLne
   have hx1 : ‖((x : sphere (0 : E) 1) : E)‖ = 1 := mem_sphere_zero_iff_norm.mp x.2
-  set γ' : Path x x :=
-    { toFun := fun t => ⟨normalize (nodeInterp N node t),
-        mem_sphere_zero_iff_norm.mpr (norm_normalize (hLne t))⟩
-      continuous_toFun := hcontγ'
+  let γ' : Path x x :=
+    { toFun := Lsphere
+      continuous_toFun := Lsphere.continuous
       source' := Subtype.ext (by
-        change normalize (nodeInterp N node 0) = ((x : sphere (0 : E) 1) : E)
-        rw [hL0, normalize_eq_self_of_norm_eq_one hx1])
+        rw [normalizeToSphere_apply, hL0, normalize_eq_self_of_norm_eq_one hx1])
       target' := Subtype.ext (by
-        change normalize (nodeInterp N node 1) = ((x : sphere (0 : E) 1) : E)
-        rw [hL1, normalize_eq_self_of_norm_eq_one hx1]) } with hγ'
+        rw [normalizeToSphere_apply, hL1, normalize_eq_self_of_norm_eq_one hx1]) }
   -- The straight-line homotopy between the loop and the comparison loop misses the origin.
   have hGne : ∀ z : I × I,
       (1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E) + (z.1 : ℝ) • nodeInterp N node z.2
@@ -304,61 +307,13 @@ theorem exists_homotopic_notMem_range (h : 2 < Module.rank ℝ E) {x : sphere (0
     rw [← hexp] at hpos
     simp only [hz, inner_zero_right] at hpos
     exact lt_irrefl 0 hpos
-  have hsquare : γ.Homotopic γ' := by
-    refine Path.homotopic_of_continuous_square
-      (fun z => ⟨normalize ((1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E)
-          + (z.1 : ℝ) • nodeInterp N node z.2),
-        mem_sphere_zero_iff_norm.mpr (norm_normalize (hGne z))⟩) ?_ ?_ ?_ ?_ ?_
-    · refine Continuous.subtype_mk ?_ _
-      have hg : Continuous fun z : I × I =>
-          (1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E)
-            + (z.1 : ℝ) • nodeInterp N node z.2 := by
-        have h1 : Continuous fun z : I × I => ((γ z.2 : sphere (0 : E) 1) : E) :=
-          hγcont.comp continuous_snd
-        have h2 : Continuous fun z : I × I => ((z.1 : ℝ)) :=
-          continuous_subtype_val.comp continuous_fst
-        exact ((continuous_const.sub h2).smul h1).add
-          (h2.smul (hcontL.comp continuous_snd))
-      change Continuous fun z => ‖_‖⁻¹ • _
-      exact ((continuous_norm.comp hg).inv₀ (fun z => norm_ne_zero_iff.mpr (hGne z))).smul hg
-    · intro s
-      refine Subtype.ext ?_
-      change normalize ((1 - ((0 : I) : ℝ)) • ((γ s : sphere (0 : E) 1) : E)
-        + ((0 : I) : ℝ) • nodeInterp N node s) = ((γ s : sphere (0 : E) 1) : E)
-      rw [Set.Icc.coe_zero]
-      simp only [sub_zero, one_smul, zero_smul, add_zero]
-      exact normalize_eq_self_of_norm_eq_one (hγnorm s)
-    · intro s
-      refine Subtype.ext ?_
-      change normalize ((1 - ((1 : I) : ℝ)) • ((γ s : sphere (0 : E) 1) : E)
-        + ((1 : I) : ℝ) • nodeInterp N node s) = normalize (nodeInterp N node s)
-      rw [Set.Icc.coe_one]
-      simp
-    · intro u
-      refine Subtype.ext ?_
-      change normalize ((1 - (u : ℝ)) • ((γ 0 : sphere (0 : E) 1) : E)
-        + (u : ℝ) • nodeInterp N node 0) = ((x : sphere (0 : E) 1) : E)
-      rw [hL0, γ.source, ← add_smul, sub_add_cancel, one_smul,
-        normalize_eq_self_of_norm_eq_one hx1]
-    · intro u
-      refine Subtype.ext ?_
-      change normalize ((1 - (u : ℝ)) • ((γ 1 : sphere (0 : E) 1) : E)
-        + (u : ℝ) • nodeInterp N node 1) = ((x : sphere (0 : E) 1) : E)
-      rw [hL1, γ.target, ← add_smul, sub_add_cancel, one_smul,
-        normalize_eq_self_of_norm_eq_one hx1]
+  have hsquare : γ.Homotopic γ' :=
+    Path.homotopic_of_normalize_segment_ne_zero γ γ' (nodeInterp N node) hcontL
+      (fun t => normalizeToSphere_apply (nodeInterp N node) hcontL hLne t) hL0 hL1 hGne
   -- The comparison loop lives in finitely many planes, which cannot cover `E`.
   have hVne : ∀ m : Fin (N + 1),
-      Submodule.span ℝ ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E) ≠ ⊤ := by
-    intro m hm
-    have hcard : Cardinal.mk ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E) ≤ 2 :=
-      calc Cardinal.mk ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E)
-          ≤ Cardinal.mk ({node ((m : ℕ) + 1)} : Set E) + 1 := Cardinal.mk_insert_le
-        _ = 2 := by rw [Cardinal.mk_singleton]; exact one_add_one_eq_two
-    have h2 : Module.rank ℝ
-        ↥(Submodule.span ℝ ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E)) ≤ 2 :=
-      (rank_span_le _).trans hcard
-    rw [hm, rank_top] at h2
-    exact absurd h2 (not_le.mpr h)
+      Submodule.span ℝ ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E) ≠ ⊤ := fun m =>
+    span_pair_ne_top h _ _
   obtain ⟨w, hw⟩ := Submodule.exists_forall_notMem_of_forall_ne_top
     (fun m : Fin (N + 1) => Submodule.span ℝ ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E)) hVne
   have hw0 : w ≠ 0 := fun h0 => hw ⟨0, Nat.succ_pos N⟩ (h0 ▸ Submodule.zero_mem _)
@@ -385,8 +340,8 @@ theorem simplyConnectedSpace_sphere (h : 2 < Module.rank ℝ E) :
     isPathConnected_iff_pathConnectedSpace.mp
       (isPathConnected_sphere (Cardinal.one_lt_two.trans h) 0 zero_le_one)
   refine simply_connected_iff_loops_nullhomotopic.mpr ⟨hpc, fun x γ => ?_⟩
-  obtain ⟨γ', hγγ', p, hp⟩ := exists_homotopic_notMem_range h γ
-  exact hγγ'.trans (homotopic_refl_of_notMem_range γ' hp)
+  obtain ⟨γ', hγγ', p, hp⟩ := exists_homotopic_notMem_range_sphere h γ
+  exact hγγ'.trans (homotopic_refl_of_notMem_range_sphere γ' hp)
 
 /-- **The `n`-sphere is simply connected for `2 ≤ n`.** -/
 theorem simplyConnectedSpace_euclideanSphere {n : ℕ} (hn : 2 ≤ n) :

--- a/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
@@ -14,7 +14,7 @@ public import TauCeti.AlgebraicTopology.Sphere.Puncture
 /-!
 # The unit sphere is simply connected above rank two
 
-The unit sphere of a real inner product space `E` with `2 < Module.rank ℝ E` is simply connected;
+The unit sphere of a real normed space `E` with `2 < Module.rank ℝ E` is simply connected;
 in particular `Sⁿ` is simply connected for `2 ≤ n`.
 
 The proof is the classical one, in the form that avoids any smoothing or simplicial
@@ -26,32 +26,38 @@ the radial projection to the sphere of
   `L t = ∑ k ≤ N, Λ k t • γ (k/N)`,   `Λ k t = max 0 (1 - |N * t - k|)`,
 
 the piecewise linear interpolation of the nodes through the hat functions of the subdivision.
-Two facts about `L` do all the work. Since `Λ k t ≠ 0` forces `|N * t - k| < 1`, hence
-`⟪γ t, γ (k/N)⟫ > 1/2`, the inner product `⟪γ t, L t⟫` is positive; so the straight-line homotopy
-from `γ t` to `L t` never meets the origin, and its radial projection is a homotopy of loops on
-the sphere. And `Λ k t ≠ 0` also forces `k` to be `⌊N t⌋` or `⌊N t⌋ + 1`, so `L t` lies in the
-span of two of the nodes. A finite family of proper subspaces of `E` cannot cover `E`
+Two facts about `L` do all the work. Since `Λ k t ≠ 0` forces `|N * t - k| < 1`, every
+contributing node is within distance one of `γ t`. The nonnegative hat functions sum to one, so
+`‖L t - γ t‖ < 1`; consequently the straight-line homotopy from `γ t` to `L t` never meets the
+origin, and its radial projection is a homotopy of loops on the sphere. Also `Λ k t ≠ 0` forces
+`k` to be `⌊N t⌋` or `⌊N t⌋ + 1`, so `L t` lies in the span of two of the nodes.
+A finite family of proper subspaces of `E` cannot cover `E`
 (`Submodule.exists_forall_notMem_of_forall_ne_top`), and the spans of two vectors are proper
 exactly because the rank exceeds two, so the projected loop omits a point of the sphere. Loops
-omitting a point are null-homotopic by `TauCeti.homotopic_refl_of_notMem_range_sphere`.
+omitting a point are null-homotopic by `TauCeti.homotopic_refl_of_notMem_range`.
 
 Rank two is genuinely the boundary: the circle is not simply connected.
 
 ## Main declarations
 
-* `TauCeti.exists_homotopic_notMem_range_sphere`: every loop on the unit sphere is homotopic to a
+* `TauCeti.exists_homotopic_notMem_range`: every loop on the unit sphere is homotopic to a
   loop that omits a point of the sphere.
-* `TauCeti.simplyConnectedSpace_sphere`: **the unit sphere of a real inner product space of rank
+* `TauCeti.simplyConnectedSpace_sphere`: **the unit sphere of a real normed space of rank
   greater than two is simply connected.**
-* `TauCeti.simplyConnectedSpace_euclideanSphere`: the case of `Sⁿ` for `2 ≤ n`.
+* `TauCeti.simplyConnectedSpace_sphere_euclideanSpace`: the case of `Sⁿ` for `2 ≤ n`.
 
 ## References
 
 This is the missing input to the `π₁(RPⁿ)` line of `TauCetiRoadmap/UniversalCovers/README.md`,
 Stage 4, item 13: `TauCeti.RealProjectiveSpace.fundamentalGroupMulEquiv` and its corollaries were
-stated against a simply connected covering sphere, and this file discharges that hypothesis. The
-argument is the classical one of Hatcher, *Algebraic Topology*, Proposition 1.14, with the
-subdivision realised by hat functions rather than by gluing. No Mathlib code is vendored.
+stated against a simply connected covering sphere, and this file discharges that hypothesis.
+Hatcher, *Algebraic Topology*, Corollary 1.15 gives the classical theorem; the hat-function
+interpolation and finite-span avoidance argument used here is this repository's own arrangement.
+
+Concurrent work by Joël Riou in [mathlib4#28246](https://github.com/leanprover-community/mathlib4/pull/28246)
+formalizes the same theorem upstream by a different route. This implementation is independent; if
+that pull request lands, a future Mathlib bump should replace this file's theorem with the upstream
+API. No Mathlib code is vendored.
 -/
 
 public section
@@ -59,22 +65,19 @@ public section
 noncomputable section
 
 open Metric NormedSpace
-open scoped unitInterval RealInnerProductSpace
+open scoped unitInterval
 
 namespace TauCeti
 
-variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
-
-/-- Two unit vectors at distance less than one have inner product greater than `1 / 2`. -/
-private theorem half_lt_inner {a b : E} (ha : ‖a‖ = 1) (hb : ‖b‖ = 1) (hab : ‖a - b‖ < 1) :
-    1 / 2 < ⟪a, b⟫ := by
-  have hsq : ‖a - b‖ ^ 2 = 2 - 2 * ⟪a, b⟫ := by
-    rw [norm_sub_sq_real, ha, hb]; ring
-  nlinarith [norm_nonneg (a - b)]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-- The `k`-th hat function of the subdivision of the unit interval into `N` equal parts: it
 peaks at `k / N` and vanishes outside `((k - 1)/N, (k + 1)/N)`. -/
 private def hatFunction (N k : ℕ) (t : I) : ℝ := max 0 (1 - |(N : ℝ) * (t : ℝ) - (k : ℝ)|)
+
+/-- The `k`-th subdivision node, clamped to the unit interval. -/
+private def nodeParam (N k : ℕ) : I :=
+  Set.projIcc (0 : ℝ) 1 zero_le_one ((k : ℝ) / (N : ℝ))
 
 /-- The piecewise linear interpolation of the nodes `node 0, …, node N` through the hat
 functions of the subdivision of the unit interval into `N` equal parts. -/
@@ -94,14 +97,40 @@ private theorem abs_lt_one_of_hatFunction_ne_zero {N k : ℕ} {t : I} (h : hatFu
   push Not at hc
   exact h (max_eq_left (by linarith))
 
+private theorem floor_bounds (N : ℕ) (t : I) :
+    (((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) ≤ (N : ℝ) * (t : ℝ)) ∧
+      (N : ℝ) * (t : ℝ) < ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) + 1 := by
+  have h0 : (0 : ℝ) ≤ (N : ℝ) * (t : ℝ) :=
+    mul_nonneg (Nat.cast_nonneg N) (unitInterval.nonneg t)
+  exact ⟨Nat.floor_le h0, Nat.lt_floor_add_one _⟩
+
+/-- A node with nonzero hat weight is less than one mesh width from the parameter. -/
+private theorem dist_nodeParam_lt_of_hatFunction_ne_zero {N k : ℕ} {t : I}
+    (hN : 0 < N) (h : hatFunction N k t ≠ 0) : dist t (nodeParam N k) < 1 / (N : ℝ) := by
+  have hNR : (0 : ℝ) < N := by exact_mod_cast hN
+  have habs := abs_lt_one_of_hatFunction_ne_zero h
+  have hdiff : |(t : ℝ) - (k : ℝ) / (N : ℝ)| < 1 / (N : ℝ) := by
+    have hrw : (t : ℝ) - (k : ℝ) / (N : ℝ) =
+        ((N : ℝ) * (t : ℝ) - (k : ℝ)) / (N : ℝ) := by
+      field_simp
+    rw [hrw, abs_div, abs_of_pos hNR]
+    exact (div_lt_div_iff_of_pos_right hNR).mpr habs
+  rw [Subtype.dist_eq, Real.dist_eq]
+  calc
+    |(t : ℝ) - (nodeParam N k : ℝ)| =
+        |(Set.projIcc (0 : ℝ) 1 zero_le_one (t : ℝ) : ℝ) -
+          (Set.projIcc (0 : ℝ) 1 zero_le_one ((k : ℝ) / (N : ℝ)) : ℝ)| := by
+            rw [Set.projIcc_val]
+            rfl
+    _ ≤ |(t : ℝ) - (k : ℝ) / (N : ℝ)| :=
+      Set.abs_projIcc_sub_projIcc zero_le_one
+    _ < 1 / (N : ℝ) := hdiff
+
 /-- The only hat functions that do not vanish at `t` are those of the two nodes straddling `t`. -/
 private theorem eq_floor_or_of_hatFunction_ne_zero {N k : ℕ} {t : I}
     (h : hatFunction N k t ≠ 0) :
     k = ⌊(N : ℝ) * (t : ℝ)⌋₊ ∨ k = ⌊(N : ℝ) * (t : ℝ)⌋₊ + 1 := by
-  have h0 : (0 : ℝ) ≤ (N : ℝ) * (t : ℝ) :=
-    mul_nonneg (Nat.cast_nonneg N) (unitInterval.nonneg t)
-  have h1 : ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) ≤ (N : ℝ) * (t : ℝ) := Nat.floor_le h0
-  have h2 : (N : ℝ) * (t : ℝ) < ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) + 1 := Nat.lt_floor_add_one _
+  obtain ⟨h1, h2⟩ := floor_bounds N t
   have habs := abs_lt.mp (abs_lt_one_of_hatFunction_ne_zero h)
   have hk1 : (k : ℝ) < ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) + 2 := by linarith [habs.1]
   have hk2 : ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) < (k : ℝ) + 1 := by linarith [habs.2]
@@ -112,13 +141,71 @@ private theorem eq_floor_or_of_hatFunction_ne_zero {N k : ℕ} {t : I}
 /-- At `t` the hat function of the node `⌊N t⌋` is positive. -/
 private theorem hatFunction_floor_pos {N : ℕ} (t : I) :
     0 < hatFunction N ⌊(N : ℝ) * (t : ℝ)⌋₊ t := by
-  have h0 : (0 : ℝ) ≤ (N : ℝ) * (t : ℝ) :=
-    mul_nonneg (Nat.cast_nonneg N) (unitInterval.nonneg t)
-  have h1 : ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) ≤ (N : ℝ) * (t : ℝ) := Nat.floor_le h0
-  have h2 : (N : ℝ) * (t : ℝ) < ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) + 1 := Nat.lt_floor_add_one _
+  obtain ⟨h1, h2⟩ := floor_bounds N t
   have habs : |(N : ℝ) * (t : ℝ) - ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ)| < 1 := by
     rw [abs_lt]; constructor <;> linarith
   exact lt_max_of_lt_right (by linarith)
+
+/-- The hat weights form a partition of unity on the unit interval. -/
+private theorem sum_hatFunction_eq_one (N : ℕ) (t : I) :
+    ∑ k ∈ Finset.range (N + 1), hatFunction N k t = 1 := by
+  set r : ℝ := (N : ℝ) * (t : ℝ) with hr
+  set m : ℕ := ⌊(N : ℝ) * (t : ℝ)⌋₊ with hm
+  obtain ⟨h1, h2⟩ := floor_bounds N t
+  have hrle : r ≤ N := by
+    rw [hr]
+    exact mul_le_of_le_one_right (Nat.cast_nonneg N) (unitInterval.le_one t)
+  have hmle : m ≤ N := by
+    have : (m : ℝ) ≤ N := h1.trans hrle
+    exact_mod_cast this
+  by_cases hmN : m = N
+  · have hNr : (N : ℝ) ≤ r :=
+      calc
+        (N : ℝ) = (m : ℝ) := by rw [hmN]
+        _ = ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) := by rw [hm]
+        _ ≤ (N : ℝ) * (t : ℝ) := h1
+        _ = r := hr.symm
+    have hrN : r = N := le_antisymm hrle hNr
+    have hhatm : hatFunction N m t = 1 := by
+      unfold hatFunction
+      have harg : (N : ℝ) * (t : ℝ) - (m : ℝ) = 0 := by
+        rw [← hr, hrN, hmN]
+        simp
+      rw [harg]
+      norm_num
+    rw [Finset.sum_eq_single m]
+    · exact hhatm
+    · intro k hk hkm
+      by_contra hk0
+      rcases eq_floor_or_of_hatFunction_ne_zero hk0 with h | h
+      · exact hkm (by simpa [hm] using h)
+      · have hklt := Finset.mem_range.mp hk
+        omega
+    · exact fun hm => (hm (Finset.mem_range.mpr (Nat.lt_succ_of_le hmle))).elim
+  · have hm_lt : m < N := lt_of_le_of_ne hmle hmN
+    have hsubset : ({m, m + 1} : Finset ℕ) ⊆ Finset.range (N + 1) := by
+      intro k hk
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hk
+      rcases hk with rfl | rfl <;> exact Finset.mem_range.mpr (by omega)
+    have hzero : ∀ k ∈ Finset.range (N + 1), k ∉ ({m, m + 1} : Finset ℕ) →
+        hatFunction N k t = 0 := by
+      intro k _ hk
+      by_contra hk0
+      rcases eq_floor_or_of_hatFunction_ne_zero hk0 with h | h <;>
+        exact hk (by simp [hm, h])
+    have hrestrict := Finset.sum_subset hsubset hzero
+    have hhatm : hatFunction N m t = 1 - (r - m) := by
+      unfold hatFunction
+      rw [show (N : ℝ) * (t : ℝ) - (m : ℝ) = r - m by rw [hr],
+        abs_of_nonneg (by simpa [hr, hm] using h1), max_eq_right (by linarith [h2])]
+    have hhatnext : hatFunction N (m + 1) t = r - m := by
+      unfold hatFunction
+      rw [show (N : ℝ) * (t : ℝ) - ((m + 1 : ℕ) : ℝ) = r - (m + 1) by
+        push_cast; rw [hr]]
+      rw [abs_of_nonpos (by simpa [hr, hm] using h2.le), max_eq_right (by linarith [h1])]
+      ring
+    rw [← hrestrict]
+    simp [hhatm, hhatnext]
 
 private theorem hatFunction_zero_self (N : ℕ) : hatFunction N 0 (0 : I) = 1 := by
   simp [hatFunction]
@@ -172,18 +259,71 @@ private theorem nodeInterp_mem_span (N : ℕ) (node : ℕ → E) (t : I) :
     rcases eq_floor_or_of_hatFunction_ne_zero hk with h | h <;>
       exact h ▸ Submodule.subset_span (by simp)
 
-/-- If every node whose hat function is alive at `t` has inner product with `a` above `1/2`,
-then the inner product of `a` with the interpolation is at least half the total weight. -/
-private theorem half_mul_sum_le_inner_nodeInterp {N : ℕ} {node : ℕ → E} {a : E} (t : I)
-    (h : ∀ k, hatFunction N k t ≠ 0 → 1 / 2 < ⟪a, node k⟫) :
-    1 / 2 * ∑ k ∈ Finset.range (N + 1), hatFunction N k t ≤ ⟪a, nodeInterp N node t⟫ := by
-  rw [nodeInterp, inner_sum, Finset.mul_sum]
-  refine Finset.sum_le_sum fun k _ => ?_
-  rw [real_inner_smul_right]
-  rcases eq_or_ne (hatFunction N k t) 0 with hk | hk
-  · simp [hk]
-  · have := mul_le_mul_of_nonneg_left (h k hk).le (hatFunction_nonneg N k t)
-    linarith
+/-- If every node with nonzero weight is within distance one of `a`, then so is their
+hat-function interpolation. -/
+private theorem norm_nodeInterp_sub_lt_one {N : ℕ} {node : ℕ → E} {a : E} (t : I)
+    (h : ∀ k, hatFunction N k t ≠ 0 → ‖a - node k‖ < 1) :
+    ‖nodeInterp N node t - a‖ < 1 := by
+  have hsum := sum_hatFunction_eq_one N t
+  have hrearrange : nodeInterp N node t - a =
+      ∑ k ∈ Finset.range (N + 1), hatFunction N k t • (node k - a) := by
+    rw [nodeInterp]
+    calc
+      ∑ k ∈ Finset.range (N + 1), hatFunction N k t • node k - a =
+          ∑ k ∈ Finset.range (N + 1), hatFunction N k t • node k -
+            (∑ k ∈ Finset.range (N + 1), hatFunction N k t) • a := by rw [hsum, one_smul]
+      _ = ∑ k ∈ Finset.range (N + 1),
+          (hatFunction N k t • node k - hatFunction N k t • a) := by
+            rw [Finset.sum_sub_distrib, ← Finset.sum_smul]
+      _ = ∑ k ∈ Finset.range (N + 1), hatFunction N k t • (node k - a) := by
+            apply Finset.sum_congr rfl
+            intro k _
+            rw [smul_sub]
+  rw [hrearrange]
+  calc
+    ‖∑ k ∈ Finset.range (N + 1), hatFunction N k t • (node k - a)‖ ≤
+        ∑ k ∈ Finset.range (N + 1), ‖hatFunction N k t • (node k - a)‖ :=
+      norm_sum_le _ _
+    _ = ∑ k ∈ Finset.range (N + 1), hatFunction N k t * ‖node k - a‖ := by
+      apply Finset.sum_congr rfl
+      intro k _
+      rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg (hatFunction_nonneg N k t)]
+    _ < ∑ k ∈ Finset.range (N + 1), hatFunction N k t * 1 := by
+      apply Finset.sum_lt_sum
+      · intro k _
+        by_cases hk : hatFunction N k t = 0
+        · simp [hk]
+        · exact mul_le_mul_of_nonneg_left (by simpa [norm_sub_rev] using (h k hk).le)
+            (hatFunction_nonneg N k t)
+      · let m := ⌊(N : ℝ) * (t : ℝ)⌋₊
+        have hm : m ∈ Finset.range (N + 1) := by
+          rw [Finset.mem_range]
+          have hrle : (N : ℝ) * (t : ℝ) ≤ N :=
+            mul_le_of_le_one_right (Nat.cast_nonneg N) (unitInterval.le_one t)
+          have hmle : m ≤ N := by
+            have h0 : (0 : ℝ) ≤ (N : ℝ) * (t : ℝ) :=
+              mul_nonneg (Nat.cast_nonneg N) (unitInterval.nonneg t)
+            have : (m : ℝ) ≤ N := (Nat.floor_le h0).trans hrle
+            exact_mod_cast this
+          omega
+        refine ⟨m, hm, mul_lt_mul_of_pos_left ?_ (hatFunction_floor_pos t)⟩
+        simpa [norm_sub_rev] using h m (ne_of_gt (hatFunction_floor_pos t))
+    _ = 1 := by simpa using hsum
+
+/-- A segment from a unit vector to a point less than one away never meets the origin. -/
+private theorem segment_ne_zero_of_norm_sub_lt {a b : E} (ha : ‖a‖ = 1)
+    (hab : ‖b - a‖ < 1) (u : I) : (1 - (u : ℝ)) • a + (u : ℝ) • b ≠ 0 := by
+  intro hz
+  have hform : (1 - (u : ℝ)) • a + (u : ℝ) • b = a + (u : ℝ) • (b - a) := by
+    rw [sub_smul, one_smul, smul_sub]
+    abel
+  rw [hform] at hz
+  have heq : a = -((u : ℝ) • (b - a)) := eq_neg_of_add_eq_zero_left hz
+  have hnorm := congrArg norm heq
+  rw [ha, norm_neg, norm_smul, Real.norm_eq_abs, abs_of_nonneg (unitInterval.nonneg u)] at hnorm
+  have hle : (u : ℝ) * ‖b - a‖ ≤ ‖b - a‖ := by
+    exact mul_le_of_le_one_left (norm_nonneg _) (unitInterval.le_one u)
+  linarith
 
 private theorem span_pair_ne_top (h : 2 < Module.rank ℝ E) (a b : E) :
     Submodule.span ℝ ({a, b} : Set E) ≠ ⊤ := by
@@ -196,11 +336,11 @@ private theorem span_pair_ne_top (h : 2 < Module.rank ℝ E) (a b : E) :
   rw [hab, rank_top] at h2
   exact absurd h2 (not_le.mpr h)
 
-/-- **Every loop on the unit sphere of a real inner product space of rank greater than two is
+/-- **Every loop on the unit sphere of a real normed space of rank greater than two is
 homotopic to a loop that omits a point of the sphere.** The comparison loop is the radial
 projection of the piecewise linear interpolation of finitely many values of the loop, and the
 point it omits is obtained by avoiding the finitely many planes those values span. -/
-theorem exists_homotopic_notMem_range_sphere (h : 2 < Module.rank ℝ E)
+theorem exists_homotopic_notMem_range (h : 2 < Module.rank ℝ E)
     {x : sphere (0 : E) 1}
     (γ : Path x x) :
     ∃ γ' : Path x x, γ.Homotopic γ' ∧ ∃ p : sphere (0 : E) 1, p ∉ Set.range γ' := by
@@ -216,62 +356,31 @@ theorem exists_homotopic_notMem_range_sphere (h : 2 < Module.rank ℝ E)
   have hNR : (0 : ℝ) < (N : ℝ) := by positivity
   have hNδ : 1 / (N : ℝ) < δ := by rw [hNdef]; push_cast; exact hN₀
   -- The nodes of the subdivision, and the piecewise linear interpolation through them.
-  have hparam : ∀ k : ℕ, min 1 ((k : ℝ) / (N : ℝ)) ∈ I := fun k =>
-    ⟨le_min zero_le_one (by positivity), min_le_left _ _⟩
-  set nodeParam : ℕ → I := fun k => ⟨min 1 ((k : ℝ) / (N : ℝ)), hparam k⟩ with hnodeParam
-  set node : ℕ → E := fun k => ((γ (nodeParam k) : sphere (0 : E) 1) : E) with hnode
-  have hnodenorm : ∀ k, ‖node k‖ = 1 := fun k => hγnorm _
+  set node : ℕ → E := fun k => ((γ (nodeParam N k) : sphere (0 : E) 1) : E) with hnode
   have hfloor_le : ∀ t : I, ⌊(N : ℝ) * (t : ℝ)⌋₊ ≤ N := by
     intro t
     calc ⌊(N : ℝ) * (t : ℝ)⌋₊ ≤ ⌊(N : ℝ)⌋₊ :=
           Nat.floor_mono (mul_le_of_le_one_right hNR.le (unitInterval.le_one t))
       _ = N := Nat.floor_natCast N
-  -- Every node alive at `t` is close to `γ t`, hence at inner product above `1/2`.
+  -- Every node alive at `t` is close to `γ t`.
   have hclose : ∀ (t : I) (k : ℕ), hatFunction N k t ≠ 0 →
-      1 / 2 < ⟪((γ t : sphere (0 : E) 1) : E), node k⟫ := by
+      ‖((γ t : sphere (0 : E) 1) : E) - node k‖ < 1 := by
     intro t k hk
-    have habs := abs_lt_one_of_hatFunction_ne_zero hk
-    have hdiff : |(t : ℝ) - (k : ℝ) / (N : ℝ)| < 1 / (N : ℝ) := by
-      have hrw : (t : ℝ) - (k : ℝ) / (N : ℝ) = ((N : ℝ) * (t : ℝ) - (k : ℝ)) / (N : ℝ) := by
-        field_simp
-      rw [hrw, abs_div, abs_of_pos hNR]
-      gcongr
-    have hmin : |(t : ℝ) - min 1 ((k : ℝ) / (N : ℝ))| ≤ |(t : ℝ) - (k : ℝ) / (N : ℝ)| := by
-      rcases le_or_gt ((k : ℝ) / (N : ℝ)) 1 with hc | hc
-      · rw [min_eq_right hc]
-      · rw [min_eq_left hc.le]
-        have ht1 : (t : ℝ) ≤ 1 := unitInterval.le_one t
-        rw [abs_of_nonpos (by linarith), abs_of_nonpos (by linarith)]
-        linarith
-    have hdist : dist t (nodeParam k) < δ := by
-      rw [Subtype.dist_eq, Real.dist_eq]
-      calc |(t : ℝ) - ((nodeParam k : I) : ℝ)| = |(t : ℝ) - min 1 ((k : ℝ) / (N : ℝ))| := rfl
-        _ ≤ |(t : ℝ) - (k : ℝ) / (N : ℝ)| := hmin
-        _ < 1 / (N : ℝ) := hdiff
-        _ < δ := hNδ
-    have hlt : ‖((γ t : sphere (0 : E) 1) : E) - node k‖ < 1 := by
-      have := hδ' hdist
-      rwa [dist_eq_norm] at this
-    exact half_lt_inner (hγnorm t) (hnodenorm k) hlt
-  -- Hence the interpolation is never antipodal to, indeed never orthogonal to, the loop.
-  have hLinner : ∀ t : I, 0 < ⟪((γ t : sphere (0 : E) 1) : E), nodeInterp N node t⟫ := by
-    intro t
-    have hm : ⌊(N : ℝ) * (t : ℝ)⌋₊ ∈ Finset.range (N + 1) :=
-      Finset.mem_range.mpr (Nat.lt_succ_of_le (hfloor_le t))
-    have hpossum : 0 < ∑ k ∈ Finset.range (N + 1), hatFunction N k t :=
-      lt_of_lt_of_le (hatFunction_floor_pos t)
-        (Finset.single_le_sum (fun k _ => hatFunction_nonneg N k t) hm)
-    have := half_mul_sum_le_inner_nodeInterp (node := node) t (fun k hk => hclose t k hk)
-    linarith
+    have hdist := dist_nodeParam_lt_of_hatFunction_ne_zero (N := N) (Nat.succ_pos N₀) hk
+    have := hδ' (hdist.trans hNδ)
+    rwa [dist_eq_norm] at this
+  have hLclose : ∀ t : I,
+      ‖nodeInterp N node t - ((γ t : sphere (0 : E) 1) : E)‖ < 1 := fun t =>
+    norm_nodeInterp_sub_lt_one t (fun k hk => hclose t k hk)
   have hLne : ∀ t : I, nodeInterp N node t ≠ 0 := by
     intro t ht
-    have hpos := hLinner t
-    rw [ht, inner_zero_right] at hpos
-    exact lt_irrefl 0 hpos
+    have hlt := hLclose t
+    rw [ht, zero_sub, norm_neg, hγnorm t] at hlt
+    exact lt_irrefl 1 hlt
   -- The interpolation matches the loop at both ends of the interval.
-  have hnodeParam0 : nodeParam 0 = (0 : I) := Subtype.ext (by simp [hnodeParam])
-  have hnodeParamN : nodeParam N = (1 : I) :=
-    Subtype.ext (by simp [hnodeParam])
+  have hnodeParam0 : nodeParam N 0 = (0 : I) := Subtype.ext (by simp [nodeParam])
+  have hnodeParamN : nodeParam N N = (1 : I) :=
+    Subtype.ext (by simp [nodeParam])
   have hL0 : nodeInterp N node 0 = ((x : sphere (0 : E) 1) : E) := by
     simp only [nodeInterp_zero, hnode, hnodeParam0, γ.source]
   have hL1 : nodeInterp N node 1 = ((x : sphere (0 : E) 1) : E) := by
@@ -284,32 +393,18 @@ theorem exists_homotopic_notMem_range_sphere (h : 2 < Module.rank ℝ E)
     { toFun := Lsphere
       continuous_toFun := Lsphere.continuous
       source' := Subtype.ext (by
-        rw [normalizeToSphere_apply, hL0, normalize_eq_self_of_norm_eq_one hx1])
+        rw [coe_normalizeToSphere_apply, hL0, normalize_eq_self_of_norm_eq_one hx1])
       target' := Subtype.ext (by
-        rw [normalizeToSphere_apply, hL1, normalize_eq_self_of_norm_eq_one hx1]) }
+        rw [coe_normalizeToSphere_apply, hL1, normalize_eq_self_of_norm_eq_one hx1]) }
   -- The straight-line homotopy between the loop and the comparison loop misses the origin.
   have hGne : ∀ z : I × I,
       (1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E) + (z.1 : ℝ) • nodeInterp N node z.2
         ≠ 0 := by
-    rintro ⟨u, t⟩ hz
-    have hexp : ⟪((γ t : sphere (0 : E) 1) : E),
-        (1 - (u : ℝ)) • ((γ t : sphere (0 : E) 1) : E) + (u : ℝ) • nodeInterp N node t⟫
-          = (1 - (u : ℝ)) * 1
-            + (u : ℝ) * ⟪((γ t : sphere (0 : E) 1) : E), nodeInterp N node t⟫ := by
-      rw [inner_add_right, real_inner_smul_right, real_inner_smul_right,
-        real_inner_self_eq_norm_sq, hγnorm t]
-      norm_num
-    have hpos : 0 < (1 - (u : ℝ)) * 1
-        + (u : ℝ) * ⟪((γ t : sphere (0 : E) 1) : E), nodeInterp N node t⟫ := by
-      rcases (unitInterval.nonneg u).lt_or_eq with hu | hu
-      · nlinarith [mul_pos hu (hLinner t), unitInterval.le_one u]
-      · rw [← hu]; norm_num
-    rw [← hexp] at hpos
-    simp only [hz, inner_zero_right] at hpos
-    exact lt_irrefl 0 hpos
+    rintro ⟨u, t⟩
+    exact segment_ne_zero_of_norm_sub_lt (hγnorm t) (hLclose t) u
   have hsquare : γ.Homotopic γ' :=
-    Path.homotopic_of_normalize_segment_ne_zero γ γ' (nodeInterp N node) hcontL
-      (fun t => normalizeToSphere_apply (nodeInterp N node) hcontL hLne t) hL0 hL1 hGne
+    homotopic_of_normalize_segment_ne_zero γ γ' (nodeInterp N node) hcontL
+      (fun t => coe_normalizeToSphere_apply (nodeInterp N node) hcontL hLne t) hL0 hL1 hGne
   -- The comparison loop lives in finitely many planes, which cannot cover `E`.
   have hVne : ∀ m : Fin (N + 1),
       Submodule.span ℝ ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E) ≠ ⊤ := fun m =>
@@ -319,7 +414,9 @@ theorem exists_homotopic_notMem_range_sphere (h : 2 < Module.rank ℝ E)
   have hw0 : w ≠ 0 := fun h0 => hw ⟨0, Nat.succ_pos N⟩ (h0 ▸ Submodule.zero_mem _)
   refine ⟨γ', hsquare, ⟨normalize w, mem_sphere_zero_iff_norm.mpr (norm_normalize hw0)⟩, ?_⟩
   rintro ⟨t, ht⟩
-  have hteq : normalize (nodeInterp N node t) = normalize w := congrArg Subtype.val ht
+  have hteq : normalize (nodeInterp N node t) = normalize w :=
+    (coe_normalizeToSphere_apply (nodeInterp N node) hcontL hLne t).symm.trans
+      (congrArg Subtype.val ht)
   have hwmem : w ∈
       Submodule.span ℝ ({node ⌊(N : ℝ) * (t : ℝ)⌋₊, node (⌊(N : ℝ) * (t : ℝ)⌋₊ + 1)} : Set E) := by
     have hwrite : w = (‖w‖ * ‖nodeInterp N node t‖⁻¹) • nodeInterp N node t :=
@@ -331,7 +428,7 @@ theorem exists_homotopic_notMem_range_sphere (h : 2 < Module.rank ℝ E)
     exact Submodule.smul_mem _ _ (nodeInterp_mem_span N node t)
   exact hw ⟨⌊(N : ℝ) * (t : ℝ)⌋₊, Nat.lt_succ_of_le (hfloor_le t)⟩ hwmem
 
-/-- **The unit sphere of a real inner product space of rank greater than two is simply
+/-- **The unit sphere of a real normed space of rank greater than two is simply
 connected.** Every loop is homotopic to one omitting a point, and the punctured sphere contracts
 to the antipode of the omitted point. -/
 theorem simplyConnectedSpace_sphere (h : 2 < Module.rank ℝ E) :
@@ -340,11 +437,11 @@ theorem simplyConnectedSpace_sphere (h : 2 < Module.rank ℝ E) :
     isPathConnected_iff_pathConnectedSpace.mp
       (isPathConnected_sphere (Cardinal.one_lt_two.trans h) 0 zero_le_one)
   refine simply_connected_iff_loops_nullhomotopic.mpr ⟨hpc, fun x γ => ?_⟩
-  obtain ⟨γ', hγγ', p, hp⟩ := exists_homotopic_notMem_range_sphere h γ
-  exact hγγ'.trans (homotopic_refl_of_notMem_range_sphere γ' hp)
+  obtain ⟨γ', hγγ', p, hp⟩ := exists_homotopic_notMem_range h γ
+  exact hγγ'.trans (homotopic_refl_of_notMem_range γ' hp)
 
 /-- **The `n`-sphere is simply connected for `2 ≤ n`.** -/
-theorem simplyConnectedSpace_euclideanSphere {n : ℕ} (hn : 2 ≤ n) :
+theorem simplyConnectedSpace_sphere_euclideanSpace {n : ℕ} (hn : 2 ≤ n) :
     SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) := by
   refine simplyConnectedSpace_sphere ?_
   have hrank : Module.rank ℝ (EuclideanSpace ℝ (Fin (n + 1))) = ((n + 1 : ℕ) : Cardinal) := by

--- a/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
@@ -18,8 +18,9 @@ The unit sphere of a real normed space `E` with `2 < Module.rank ℝ E` is simpl
 in particular `Sⁿ` is simply connected for `2 ≤ n`.
 
 The proof is the classical one, in the form that avoids any smoothing or simplicial
-approximation. A loop `γ` is compared with the *piecewise geodesic* loop through the `N + 1`
-values `γ(k/N)`, where `N` is chosen so fine that `‖γ s - γ t‖ < 1` whenever `|s - t| ≤ 1/N`.
+approximation. A loop `γ` is compared with the radial projection of the piecewise-linear
+interpolation through the `N + 1` values `γ(k/N)`, where `N` is chosen so fine that
+`‖γ s - γ t‖ < 1` whenever `|s - t| ≤ 1/N`.
 That comparison loop is written as a single global formula rather than by gluing pieces: it is
 the radial projection to the sphere of
 

--- a/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
@@ -1,0 +1,402 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Module.Submodule.Union
+public import Mathlib.Analysis.InnerProductSpace.EuclideanDist
+public import Mathlib.Analysis.Normed.Module.Connected
+public import Mathlib.LinearAlgebra.Dimension.Constructions
+public import TauCeti.AlgebraicTopology.Sphere.Puncture
+
+/-!
+# The unit sphere is simply connected above rank two
+
+The unit sphere of a real inner product space `E` with `2 < Module.rank ℝ E` is simply connected;
+in particular `Sⁿ` is simply connected for `2 ≤ n`.
+
+The proof is the classical one, in the form that avoids any smoothing or simplicial
+approximation. A loop `γ` is compared with the *piecewise geodesic* loop through the `N + 1`
+values `γ(k/N)`, where `N` is chosen so fine that `‖γ s - γ t‖ < 1` whenever `|s - t| ≤ 1/N`.
+That comparison loop is written as a single global formula rather than by gluing pieces: it is
+the radial projection to the sphere of
+
+  `L t = ∑ k ≤ N, Λ k t • γ (k/N)`,   `Λ k t = max 0 (1 - |N * t - k|)`,
+
+the piecewise linear interpolation of the nodes through the hat functions of the subdivision.
+Two facts about `L` do all the work. Since `Λ k t ≠ 0` forces `|N * t - k| < 1`, hence
+`⟪γ t, γ (k/N)⟫ > 1/2`, the inner product `⟪γ t, L t⟫` is positive; so the straight-line homotopy
+from `γ t` to `L t` never meets the origin, and its radial projection is a homotopy of loops on
+the sphere. And `Λ k t ≠ 0` also forces `k` to be `⌊N t⌋` or `⌊N t⌋ + 1`, so `L t` lies in the
+span of two of the nodes. A finite family of proper subspaces of `E` cannot cover `E`
+(`Submodule.exists_forall_notMem_of_forall_ne_top`), and the spans of two vectors are proper
+exactly because the rank exceeds two, so the projected loop omits a point of the sphere. Loops
+omitting a point are null-homotopic by `TauCeti.homotopic_refl_of_notMem_range`.
+
+Rank two is genuinely the boundary: the circle is not simply connected.
+
+## Main declarations
+
+* `TauCeti.exists_homotopic_notMem_range`: every loop on the unit sphere is homotopic to a loop
+  that omits a point of the sphere.
+* `TauCeti.simplyConnectedSpace_sphere`: **the unit sphere of a real inner product space of rank
+  greater than two is simply connected.**
+* `TauCeti.simplyConnectedSpace_euclideanSphere`: the case of `Sⁿ` for `2 ≤ n`.
+
+## References
+
+This is the missing input to the `π₁(RPⁿ)` line of `TauCetiRoadmap/UniversalCovers/README.md`,
+Stage 4, item 13: `TauCeti.RealProjectiveSpace.fundamentalGroupMulEquiv` and its corollaries were
+stated against a simply connected covering sphere, and this file discharges that hypothesis. The
+argument is the classical one of Hatcher, *Algebraic Topology*, Proposition 1.14, with the
+subdivision realised by hat functions rather than by gluing. No Mathlib code is vendored.
+-/
+
+public section
+
+noncomputable section
+
+open Metric NormedSpace
+open scoped unitInterval RealInnerProductSpace
+
+namespace TauCeti
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- Two unit vectors at distance less than one have inner product greater than `1 / 2`. -/
+private theorem half_lt_inner {a b : E} (ha : ‖a‖ = 1) (hb : ‖b‖ = 1) (hab : ‖a - b‖ < 1) :
+    1 / 2 < ⟪a, b⟫ := by
+  have hsq : ‖a - b‖ ^ 2 = 2 - 2 * ⟪a, b⟫ := by
+    rw [norm_sub_sq_real, ha, hb]; ring
+  nlinarith [norm_nonneg (a - b)]
+
+/-- The `k`-th hat function of the subdivision of the unit interval into `N` equal parts: it
+peaks at `k / N` and vanishes outside `((k - 1)/N, (k + 1)/N)`. -/
+private def hatFunction (N k : ℕ) (t : I) : ℝ := max 0 (1 - |(N : ℝ) * (t : ℝ) - (k : ℝ)|)
+
+/-- The piecewise linear interpolation of the nodes `node 0, …, node N` through the hat
+functions of the subdivision of the unit interval into `N` equal parts. -/
+private def nodeInterp (N : ℕ) (node : ℕ → E) (t : I) : E :=
+  ∑ k ∈ Finset.range (N + 1), hatFunction N k t • node k
+
+private theorem hatFunction_nonneg (N k : ℕ) (t : I) : 0 ≤ hatFunction N k t := le_max_left _ _
+
+private theorem continuous_hatFunction (N k : ℕ) : Continuous (hatFunction N k) := by
+  unfold hatFunction
+  fun_prop
+
+/-- The hat function of the `k`-th node vanishes unless `N * t` is within `1` of `k`. -/
+private theorem abs_lt_one_of_hatFunction_ne_zero {N k : ℕ} {t : I} (h : hatFunction N k t ≠ 0) :
+    |(N : ℝ) * (t : ℝ) - (k : ℝ)| < 1 := by
+  by_contra hc
+  push Not at hc
+  exact h (max_eq_left (by linarith))
+
+/-- The only hat functions that do not vanish at `t` are those of the two nodes straddling `t`. -/
+private theorem eq_floor_or_of_hatFunction_ne_zero {N k : ℕ} {t : I}
+    (h : hatFunction N k t ≠ 0) :
+    k = ⌊(N : ℝ) * (t : ℝ)⌋₊ ∨ k = ⌊(N : ℝ) * (t : ℝ)⌋₊ + 1 := by
+  have h0 : (0 : ℝ) ≤ (N : ℝ) * (t : ℝ) :=
+    mul_nonneg (Nat.cast_nonneg N) (unitInterval.nonneg t)
+  have h1 : ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) ≤ (N : ℝ) * (t : ℝ) := Nat.floor_le h0
+  have h2 : (N : ℝ) * (t : ℝ) < ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) + 1 := Nat.lt_floor_add_one _
+  have habs := abs_lt.mp (abs_lt_one_of_hatFunction_ne_zero h)
+  have hk1 : (k : ℝ) < ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) + 2 := by linarith [habs.1]
+  have hk2 : ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) < (k : ℝ) + 1 := by linarith [habs.2]
+  have hk1' : k < ⌊(N : ℝ) * (t : ℝ)⌋₊ + 2 := by exact_mod_cast hk1
+  have hk2' : ⌊(N : ℝ) * (t : ℝ)⌋₊ < k + 1 := by exact_mod_cast hk2
+  omega
+
+/-- At `t` the hat function of the node `⌊N t⌋` is positive. -/
+private theorem hatFunction_floor_pos {N : ℕ} (t : I) :
+    0 < hatFunction N ⌊(N : ℝ) * (t : ℝ)⌋₊ t := by
+  have h0 : (0 : ℝ) ≤ (N : ℝ) * (t : ℝ) :=
+    mul_nonneg (Nat.cast_nonneg N) (unitInterval.nonneg t)
+  have h1 : ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) ≤ (N : ℝ) * (t : ℝ) := Nat.floor_le h0
+  have h2 : (N : ℝ) * (t : ℝ) < ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ) + 1 := Nat.lt_floor_add_one _
+  have habs : |(N : ℝ) * (t : ℝ) - ((⌊(N : ℝ) * (t : ℝ)⌋₊ : ℕ) : ℝ)| < 1 := by
+    rw [abs_lt]; constructor <;> linarith
+  exact lt_max_of_lt_right (by linarith)
+
+private theorem hatFunction_zero_self (N : ℕ) : hatFunction N 0 (0 : I) = 1 := by
+  simp [hatFunction]
+
+private theorem hatFunction_zero_of_ne (N : ℕ) {k : ℕ} (hk : k ≠ 0) :
+    hatFunction N k (0 : I) = 0 := by
+  have hk1 : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast Nat.one_le_iff_ne_zero.mpr hk
+  have habs : |(N : ℝ) * ((0 : I) : ℝ) - (k : ℝ)| = (k : ℝ) := by
+    rw [Set.Icc.coe_zero, mul_zero, zero_sub, abs_neg, abs_of_nonneg (Nat.cast_nonneg k)]
+  simp only [hatFunction, habs]
+  exact max_eq_left (by linarith)
+
+private theorem hatFunction_one_self (N : ℕ) : hatFunction N N (1 : I) = 1 := by
+  simp [hatFunction]
+
+private theorem hatFunction_one_of_ne {N k : ℕ} (hkN : k ≤ N) (hk : k ≠ N) :
+    hatFunction N k (1 : I) = 0 := by
+  have h1 : (k : ℝ) + 1 ≤ (N : ℝ) := by
+    exact_mod_cast Nat.succ_le_of_lt (lt_of_le_of_ne hkN hk)
+  have habs : |(N : ℝ) * ((1 : I) : ℝ) - (k : ℝ)| = (N : ℝ) - (k : ℝ) := by
+    rw [Set.Icc.coe_one, mul_one, abs_of_nonneg (by linarith)]
+  simp only [hatFunction, habs]
+  exact max_eq_left (by linarith)
+
+private theorem continuous_nodeInterp (N : ℕ) (node : ℕ → E) :
+    Continuous (nodeInterp N node) :=
+  continuous_finsetSum _ fun k _ => (continuous_hatFunction N k).smul continuous_const
+
+private theorem nodeInterp_zero (N : ℕ) (node : ℕ → E) : nodeInterp N node 0 = node 0 := by
+  rw [nodeInterp, Finset.sum_eq_single 0]
+  · rw [hatFunction_zero_self, one_smul]
+  · exact fun k _ hk => by rw [hatFunction_zero_of_ne N hk, zero_smul]
+  · exact fun hc => absurd (Finset.mem_range.mpr (Nat.succ_pos N)) hc
+
+private theorem nodeInterp_one (N : ℕ) (node : ℕ → E) : nodeInterp N node 1 = node N := by
+  rw [nodeInterp, Finset.sum_eq_single N]
+  · rw [hatFunction_one_self, one_smul]
+  · exact fun k hk hkN => by
+      rw [hatFunction_one_of_ne (Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)) hkN, zero_smul]
+  · exact fun hc => absurd (Finset.mem_range.mpr (Nat.lt_succ_self N)) hc
+
+/-- The interpolation at `t` lies on the geodesic chord of the two nodes straddling `t`. -/
+private theorem nodeInterp_mem_span (N : ℕ) (node : ℕ → E) (t : I) :
+    nodeInterp N node t ∈
+      Submodule.span ℝ {node ⌊(N : ℝ) * (t : ℝ)⌋₊, node (⌊(N : ℝ) * (t : ℝ)⌋₊ + 1)} := by
+  rw [nodeInterp]
+  refine Submodule.sum_mem _ fun k _ => ?_
+  by_cases hk : hatFunction N k t = 0
+  · simp [hk]
+  · refine Submodule.smul_mem _ _ ?_
+    rcases eq_floor_or_of_hatFunction_ne_zero hk with h | h <;>
+      exact h ▸ Submodule.subset_span (by simp)
+
+/-- If every node whose hat function is alive at `t` has inner product with `a` above `1/2`,
+then the inner product of `a` with the interpolation is at least half the total weight. -/
+private theorem half_mul_sum_le_inner_nodeInterp {N : ℕ} {node : ℕ → E} {a : E} (t : I)
+    (h : ∀ k, hatFunction N k t ≠ 0 → 1 / 2 < ⟪a, node k⟫) :
+    1 / 2 * ∑ k ∈ Finset.range (N + 1), hatFunction N k t ≤ ⟪a, nodeInterp N node t⟫ := by
+  rw [nodeInterp, inner_sum, Finset.mul_sum]
+  refine Finset.sum_le_sum fun k _ => ?_
+  rw [real_inner_smul_right]
+  rcases eq_or_ne (hatFunction N k t) 0 with hk | hk
+  · simp [hk]
+  · have := mul_le_mul_of_nonneg_left (h k hk).le (hatFunction_nonneg N k t)
+    linarith
+
+/-- **Every loop on the unit sphere of a real inner product space of rank greater than two is
+homotopic to a loop that omits a point of the sphere.** The comparison loop is the radial
+projection of the piecewise linear interpolation of finitely many values of the loop, and the
+point it omits is obtained by avoiding the finitely many planes those values span. -/
+theorem exists_homotopic_notMem_range (h : 2 < Module.rank ℝ E) {x : sphere (0 : E) 1}
+    (γ : Path x x) :
+    ∃ γ' : Path x x, γ.Homotopic γ' ∧ ∃ p : sphere (0 : E) 1, p ∉ Set.range γ' := by
+  have hγnorm : ∀ t, ‖((γ t : sphere (0 : E) 1) : E)‖ = 1 := fun t =>
+    mem_sphere_zero_iff_norm.mp (γ t).2
+  have hγcont : Continuous fun t : I => ((γ t : sphere (0 : E) 1) : E) :=
+    continuous_subtype_val.comp γ.continuous
+  -- Choose a subdivision so fine that the loop moves by less than `1` across each step.
+  obtain ⟨δ, hδ, hδ'⟩ := Metric.uniformContinuous_iff.mp
+    (CompactSpace.uniformContinuous_of_continuous hγcont) 1 one_pos
+  obtain ⟨N₀, hN₀⟩ := exists_nat_one_div_lt hδ
+  set N : ℕ := N₀ + 1 with hNdef
+  have hNR : (0 : ℝ) < (N : ℝ) := by positivity
+  have hNδ : 1 / (N : ℝ) < δ := by rw [hNdef]; push_cast; exact hN₀
+  -- The nodes of the subdivision, and the piecewise linear interpolation through them.
+  have hparam : ∀ k : ℕ, min 1 ((k : ℝ) / (N : ℝ)) ∈ I := fun k =>
+    ⟨le_min zero_le_one (by positivity), min_le_left _ _⟩
+  set nodeParam : ℕ → I := fun k => ⟨min 1 ((k : ℝ) / (N : ℝ)), hparam k⟩ with hnodeParam
+  set node : ℕ → E := fun k => ((γ (nodeParam k) : sphere (0 : E) 1) : E) with hnode
+  have hnodenorm : ∀ k, ‖node k‖ = 1 := fun k => hγnorm _
+  have hfloor_le : ∀ t : I, ⌊(N : ℝ) * (t : ℝ)⌋₊ ≤ N := by
+    intro t
+    calc ⌊(N : ℝ) * (t : ℝ)⌋₊ ≤ ⌊(N : ℝ)⌋₊ :=
+          Nat.floor_mono (mul_le_of_le_one_right hNR.le (unitInterval.le_one t))
+      _ = N := Nat.floor_natCast N
+  -- Every node alive at `t` is close to `γ t`, hence at inner product above `1/2`.
+  have hclose : ∀ (t : I) (k : ℕ), hatFunction N k t ≠ 0 →
+      1 / 2 < ⟪((γ t : sphere (0 : E) 1) : E), node k⟫ := by
+    intro t k hk
+    have habs := abs_lt_one_of_hatFunction_ne_zero hk
+    have hdiff : |(t : ℝ) - (k : ℝ) / (N : ℝ)| < 1 / (N : ℝ) := by
+      have hrw : (t : ℝ) - (k : ℝ) / (N : ℝ) = ((N : ℝ) * (t : ℝ) - (k : ℝ)) / (N : ℝ) := by
+        field_simp
+      rw [hrw, abs_div, abs_of_pos hNR]
+      gcongr
+    have hmin : |(t : ℝ) - min 1 ((k : ℝ) / (N : ℝ))| ≤ |(t : ℝ) - (k : ℝ) / (N : ℝ)| := by
+      rcases le_or_gt ((k : ℝ) / (N : ℝ)) 1 with hc | hc
+      · rw [min_eq_right hc]
+      · rw [min_eq_left hc.le]
+        have ht1 : (t : ℝ) ≤ 1 := unitInterval.le_one t
+        rw [abs_of_nonpos (by linarith), abs_of_nonpos (by linarith)]
+        linarith
+    have hdist : dist t (nodeParam k) < δ := by
+      rw [Subtype.dist_eq, Real.dist_eq]
+      calc |(t : ℝ) - ((nodeParam k : I) : ℝ)| = |(t : ℝ) - min 1 ((k : ℝ) / (N : ℝ))| := rfl
+        _ ≤ |(t : ℝ) - (k : ℝ) / (N : ℝ)| := hmin
+        _ < 1 / (N : ℝ) := hdiff
+        _ < δ := hNδ
+    have hlt : ‖((γ t : sphere (0 : E) 1) : E) - node k‖ < 1 := by
+      have := hδ' hdist
+      rwa [dist_eq_norm] at this
+    exact half_lt_inner (hγnorm t) (hnodenorm k) hlt
+  -- Hence the interpolation is never antipodal to, indeed never orthogonal to, the loop.
+  have hLinner : ∀ t : I, 0 < ⟪((γ t : sphere (0 : E) 1) : E), nodeInterp N node t⟫ := by
+    intro t
+    have hm : ⌊(N : ℝ) * (t : ℝ)⌋₊ ∈ Finset.range (N + 1) :=
+      Finset.mem_range.mpr (Nat.lt_succ_of_le (hfloor_le t))
+    have hpossum : 0 < ∑ k ∈ Finset.range (N + 1), hatFunction N k t :=
+      lt_of_lt_of_le (hatFunction_floor_pos t)
+        (Finset.single_le_sum (fun k _ => hatFunction_nonneg N k t) hm)
+    have := half_mul_sum_le_inner_nodeInterp (node := node) t (fun k hk => hclose t k hk)
+    linarith
+  have hLne : ∀ t : I, nodeInterp N node t ≠ 0 := by
+    intro t ht
+    have hpos := hLinner t
+    rw [ht, inner_zero_right] at hpos
+    exact lt_irrefl 0 hpos
+  -- The interpolation matches the loop at both ends of the interval.
+  have hnodeParam0 : nodeParam 0 = (0 : I) := Subtype.ext (by simp [hnodeParam])
+  have hnodeParamN : nodeParam N = (1 : I) :=
+    Subtype.ext (by simp [hnodeParam])
+  have hL0 : nodeInterp N node 0 = ((x : sphere (0 : E) 1) : E) := by
+    simp only [nodeInterp_zero, hnode, hnodeParam0, γ.source]
+  have hL1 : nodeInterp N node 1 = ((x : sphere (0 : E) 1) : E) := by
+    simp only [nodeInterp_one, hnode, hnodeParamN, γ.target]
+  -- The comparison loop.
+  have hcontL : Continuous (nodeInterp N node) := continuous_nodeInterp N node
+  have hcontγ' : Continuous fun t : I =>
+      (⟨normalize (nodeInterp N node t),
+        mem_sphere_zero_iff_norm.mpr (norm_normalize (hLne t))⟩ : sphere (0 : E) 1) := by
+    refine Continuous.subtype_mk ?_ _
+    change Continuous fun t => ‖nodeInterp N node t‖⁻¹ • nodeInterp N node t
+    exact ((continuous_norm.comp hcontL).inv₀
+      (fun t => norm_ne_zero_iff.mpr (hLne t))).smul hcontL
+  have hx1 : ‖((x : sphere (0 : E) 1) : E)‖ = 1 := mem_sphere_zero_iff_norm.mp x.2
+  set γ' : Path x x :=
+    { toFun := fun t => ⟨normalize (nodeInterp N node t),
+        mem_sphere_zero_iff_norm.mpr (norm_normalize (hLne t))⟩
+      continuous_toFun := hcontγ'
+      source' := Subtype.ext (by
+        change normalize (nodeInterp N node 0) = ((x : sphere (0 : E) 1) : E)
+        rw [hL0, normalize_eq_self_of_norm_eq_one hx1])
+      target' := Subtype.ext (by
+        change normalize (nodeInterp N node 1) = ((x : sphere (0 : E) 1) : E)
+        rw [hL1, normalize_eq_self_of_norm_eq_one hx1]) } with hγ'
+  -- The straight-line homotopy between the loop and the comparison loop misses the origin.
+  have hGne : ∀ z : I × I,
+      (1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E) + (z.1 : ℝ) • nodeInterp N node z.2
+        ≠ 0 := by
+    rintro ⟨u, t⟩ hz
+    have hexp : ⟪((γ t : sphere (0 : E) 1) : E),
+        (1 - (u : ℝ)) • ((γ t : sphere (0 : E) 1) : E) + (u : ℝ) • nodeInterp N node t⟫
+          = (1 - (u : ℝ)) * 1
+            + (u : ℝ) * ⟪((γ t : sphere (0 : E) 1) : E), nodeInterp N node t⟫ := by
+      rw [inner_add_right, real_inner_smul_right, real_inner_smul_right,
+        real_inner_self_eq_norm_sq, hγnorm t]
+      norm_num
+    have hpos : 0 < (1 - (u : ℝ)) * 1
+        + (u : ℝ) * ⟪((γ t : sphere (0 : E) 1) : E), nodeInterp N node t⟫ := by
+      rcases (unitInterval.nonneg u).lt_or_eq with hu | hu
+      · nlinarith [mul_pos hu (hLinner t), unitInterval.le_one u]
+      · rw [← hu]; norm_num
+    rw [← hexp] at hpos
+    simp only [hz, inner_zero_right] at hpos
+    exact lt_irrefl 0 hpos
+  have hsquare : γ.Homotopic γ' := by
+    refine Path.homotopic_of_continuous_square
+      (fun z => ⟨normalize ((1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E)
+          + (z.1 : ℝ) • nodeInterp N node z.2),
+        mem_sphere_zero_iff_norm.mpr (norm_normalize (hGne z))⟩) ?_ ?_ ?_ ?_ ?_
+    · refine Continuous.subtype_mk ?_ _
+      have hg : Continuous fun z : I × I =>
+          (1 - (z.1 : ℝ)) • ((γ z.2 : sphere (0 : E) 1) : E)
+            + (z.1 : ℝ) • nodeInterp N node z.2 := by
+        have h1 : Continuous fun z : I × I => ((γ z.2 : sphere (0 : E) 1) : E) :=
+          hγcont.comp continuous_snd
+        have h2 : Continuous fun z : I × I => ((z.1 : ℝ)) :=
+          continuous_subtype_val.comp continuous_fst
+        exact ((continuous_const.sub h2).smul h1).add
+          (h2.smul (hcontL.comp continuous_snd))
+      change Continuous fun z => ‖_‖⁻¹ • _
+      exact ((continuous_norm.comp hg).inv₀ (fun z => norm_ne_zero_iff.mpr (hGne z))).smul hg
+    · intro s
+      refine Subtype.ext ?_
+      change normalize ((1 - ((0 : I) : ℝ)) • ((γ s : sphere (0 : E) 1) : E)
+        + ((0 : I) : ℝ) • nodeInterp N node s) = ((γ s : sphere (0 : E) 1) : E)
+      rw [Set.Icc.coe_zero]
+      simp only [sub_zero, one_smul, zero_smul, add_zero]
+      exact normalize_eq_self_of_norm_eq_one (hγnorm s)
+    · intro s
+      refine Subtype.ext ?_
+      change normalize ((1 - ((1 : I) : ℝ)) • ((γ s : sphere (0 : E) 1) : E)
+        + ((1 : I) : ℝ) • nodeInterp N node s) = normalize (nodeInterp N node s)
+      rw [Set.Icc.coe_one]
+      simp
+    · intro u
+      refine Subtype.ext ?_
+      change normalize ((1 - (u : ℝ)) • ((γ 0 : sphere (0 : E) 1) : E)
+        + (u : ℝ) • nodeInterp N node 0) = ((x : sphere (0 : E) 1) : E)
+      rw [hL0, γ.source, ← add_smul, sub_add_cancel, one_smul,
+        normalize_eq_self_of_norm_eq_one hx1]
+    · intro u
+      refine Subtype.ext ?_
+      change normalize ((1 - (u : ℝ)) • ((γ 1 : sphere (0 : E) 1) : E)
+        + (u : ℝ) • nodeInterp N node 1) = ((x : sphere (0 : E) 1) : E)
+      rw [hL1, γ.target, ← add_smul, sub_add_cancel, one_smul,
+        normalize_eq_self_of_norm_eq_one hx1]
+  -- The comparison loop lives in finitely many planes, which cannot cover `E`.
+  have hVne : ∀ m : Fin (N + 1),
+      Submodule.span ℝ ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E) ≠ ⊤ := by
+    intro m hm
+    have hcard : Cardinal.mk ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E) ≤ 2 :=
+      calc Cardinal.mk ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E)
+          ≤ Cardinal.mk ({node ((m : ℕ) + 1)} : Set E) + 1 := Cardinal.mk_insert_le
+        _ = 2 := by rw [Cardinal.mk_singleton]; exact one_add_one_eq_two
+    have h2 : Module.rank ℝ
+        ↥(Submodule.span ℝ ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E)) ≤ 2 :=
+      (rank_span_le _).trans hcard
+    rw [hm, rank_top] at h2
+    exact absurd h2 (not_le.mpr h)
+  obtain ⟨w, hw⟩ := Submodule.exists_forall_notMem_of_forall_ne_top
+    (fun m : Fin (N + 1) => Submodule.span ℝ ({node (m : ℕ), node ((m : ℕ) + 1)} : Set E)) hVne
+  have hw0 : w ≠ 0 := fun h0 => hw ⟨0, Nat.succ_pos N⟩ (h0 ▸ Submodule.zero_mem _)
+  refine ⟨γ', hsquare, ⟨normalize w, mem_sphere_zero_iff_norm.mpr (norm_normalize hw0)⟩, ?_⟩
+  rintro ⟨t, ht⟩
+  have hteq : normalize (nodeInterp N node t) = normalize w := congrArg Subtype.val ht
+  have hwmem : w ∈
+      Submodule.span ℝ ({node ⌊(N : ℝ) * (t : ℝ)⌋₊, node (⌊(N : ℝ) * (t : ℝ)⌋₊ + 1)} : Set E) := by
+    have hwrite : w = (‖w‖ * ‖nodeInterp N node t‖⁻¹) • nodeInterp N node t :=
+      calc w = ‖w‖ • normalize w := (norm_smul_normalize w).symm
+        _ = ‖w‖ • normalize (nodeInterp N node t) := by rw [hteq]
+        _ = (‖w‖ * ‖nodeInterp N node t‖⁻¹) • nodeInterp N node t := by
+              rw [NormedSpace.normalize, smul_smul]
+    rw [hwrite]
+    exact Submodule.smul_mem _ _ (nodeInterp_mem_span N node t)
+  exact hw ⟨⌊(N : ℝ) * (t : ℝ)⌋₊, Nat.lt_succ_of_le (hfloor_le t)⟩ hwmem
+
+/-- **The unit sphere of a real inner product space of rank greater than two is simply
+connected.** Every loop is homotopic to one omitting a point, and the punctured sphere contracts
+to the antipode of the omitted point. -/
+theorem simplyConnectedSpace_sphere (h : 2 < Module.rank ℝ E) :
+    SimplyConnectedSpace (sphere (0 : E) 1) := by
+  have hpc : PathConnectedSpace (sphere (0 : E) 1) :=
+    isPathConnected_iff_pathConnectedSpace.mp
+      (isPathConnected_sphere (Cardinal.one_lt_two.trans h) 0 zero_le_one)
+  refine simply_connected_iff_loops_nullhomotopic.mpr ⟨hpc, fun x γ => ?_⟩
+  obtain ⟨γ', hγγ', p, hp⟩ := exists_homotopic_notMem_range h γ
+  exact hγγ'.trans (homotopic_refl_of_notMem_range γ' hp)
+
+/-- **The `n`-sphere is simply connected for `2 ≤ n`.** -/
+theorem simplyConnectedSpace_euclideanSphere {n : ℕ} (hn : 2 ≤ n) :
+    SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) := by
+  refine simplyConnectedSpace_sphere ?_
+  have hrank : Module.rank ℝ (EuclideanSpace ℝ (Fin (n + 1))) = ((n + 1 : ℕ) : Cardinal) := by
+    simp [← Module.finrank_eq_rank]
+  rw [hrank]
+  exact_mod_cast (by omega : 2 < n + 1)
+
+end TauCeti
+
+end

--- a/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
+++ b/TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean
@@ -72,8 +72,7 @@ namespace TauCeti
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-/-- The `k`-th hat function of the subdivision of the unit interval into `N` equal parts: it
-peaks at `k / N` and vanishes outside `((k - 1)/N, (k + 1)/N)`. -/
+/-- The `k`-th hat-function formula for a subdivision into `N` equal parts. -/
 private def hatFunction (N k : ℕ) (t : I) : ℝ := max 0 (1 - |(N : ℝ) * (t : ℝ) - (k : ℝ)|)
 
 /-- The `k`-th subdivision node, clamped to the unit interval. -/
@@ -403,7 +402,7 @@ theorem exists_homotopic_notMem_range (h : 2 < Module.rank ℝ E)
     rintro ⟨u, t⟩
     exact segment_ne_zero_of_norm_sub_lt (hγnorm t) (hLclose t) u
   have hsquare : γ.Homotopic γ' :=
-    homotopic_of_normalize_segment_ne_zero γ γ' (nodeInterp N node) hcontL
+    homotopic_of_segment_ne_zero γ γ' (nodeInterp N node) hcontL
       (fun t => coe_normalizeToSphere_apply (nodeInterp N node) hcontL hLne t) hL0 hL1 hGne
   -- The comparison loop lives in finitely many planes, which cannot cover `E`.
   have hVne : ∀ m : Fin (N + 1),

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -726,24 +726,6 @@ private theorem continuous_uncurry_basedPath {α β : BasedPath x₀} (F : Path 
     continuous_subtype_val.comp F.continuous
   exact ContinuousMap.continuous_uncurry_of_continuous ⟨_, h1⟩
 
-/-- **A square with prescribed edges is a path homotopy.** A continuous map on `I × I` that
-restricts to `p` at `t = 0` and to `q` at `t = 1`, and is constant along each of the edges `s = 0`
-and `s = 1`, exhibits `p` and `q` as homotopic paths. -/
-private theorem homotopic_of_continuous_square {a b : X} {p q : Path a b} (K : I × I → X)
-    (hK_cont : Continuous K) (hK_zero : ∀ s, K (0, s) = p s) (hK_one : ∀ s, K (1, s) = q s)
-    (hK_left : ∀ t, K (t, 0) = a) (hK_right : ∀ t, K (t, 1) = b) : p.Homotopic q :=
-  ⟨{ toFun := K
-     continuous_toFun := hK_cont
-     map_zero_left := hK_zero
-     map_one_left := hK_one
-     prop' := by
-       intro t s hs
-       rcases hs with rfl | hs
-       · exact (hK_left t).trans p.source.symm
-       · rw [Set.mem_singleton_iff] at hs
-         subst hs
-         exact (hK_right t).trans p.target.symm }⟩
-
 private theorem joinedInSLSC_uFn_zero_left (s : I) :
     (joinedInSLSC_uFn (0, s) : ℝ) = max 0 (2 * (s : ℝ) - 1) := by
   simp [joinedInSLSC_uFn, joinedInSLSC_uReal]
@@ -846,7 +828,7 @@ public theorem toPath_homotopic_of_joinedIn_pathHomotopyTrivial
     rw [K_fn_apply, joinedInSLSC_uFn_one_right, joinedInSLSC_vFn_one_right, hF1_eq]; rfl
   -- The square deforms `α' ⬝ L` into `β ⬝ const`, and `L` is null-homotopic, so it collapses.
   exact (Path.Homotopic.trans_right_of_nullhomotopic hL_refl).symm.trans
-    ((homotopic_of_continuous_square K_fn hK_cont hK_zero hK_one hK_at_zero hK_at_one).trans
+    ((Path.homotopic_of_continuous_square K_fn hK_cont hK_zero hK_one hK_at_zero hK_at_one).trans
       (Path.Homotopic.trans_refl β.toPath))
 
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean
@@ -7,35 +7,31 @@ module
 
 public import Mathlib.Algebra.Group.Equiv.Opposite
 public import TauCeti.AlgebraicTopology.NotSimplyConnected
+public import TauCeti.AlgebraicTopology.Sphere.SimplyConnected
 public import TauCeti.AlgebraicTopology.UniversalCover.Deck.FundamentalGroup.Basic
 public import TauCeti.AlgebraicTopology.UniversalCover.RealProjective.Deck
 
 /-!
-# The fundamental group of real projective space from a simply connected sphere cover
+# The fundamental group of real projective space
 
-For `2 ≤ n`, assuming the covering unit sphere `Sⁿ` is simply connected (as developed
-upstream in Mathlib PR #28246), real projective `n`-space `RPⁿ` has fundamental group isomorphic
-to `ℤˣ` via the two-sheeted antipodal quotient `mk n`.
+For `2 ≤ n`, real projective `n`-space `RPⁿ` has fundamental group isomorphic to `ℤˣ` via the
+two-sheeted antipodal quotient `mk n`.
 
-The antipodal cover is a regular covering map with deck group `ℤˣ`.
-Under the assumption that the covering sphere is simply connected, the regular-cover comparison
-`TauCeti.Deck.IsRegular.fundamentalGroupEquiv` identifies the fundamental group of `RPⁿ` at any
-basepoint with the opposite of the deck group. Since `ℤˣ` is commutative, the opposite drops out,
-yielding
+The antipodal cover is a regular covering map with deck group `ℤˣ`, and the covering sphere `Sⁿ`
+is simply connected for `2 ≤ n` by `TauCeti.simplyConnectedSpace_euclideanSphere`. The
+regular-cover comparison `TauCeti.Deck.IsRegular.fundamentalGroupEquiv` therefore identifies the
+fundamental group of `RPⁿ` at any basepoint with the opposite of the deck group. Since `ℤˣ` is
+commutative, the opposite drops out, yielding
 
   `FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ`.
 
-As consequences, `RPⁿ` (for `2 ≤ n` and simply connected `Sⁿ`) has a fundamental group of order 2,
-a nontrivial fundamental group, is not simply connected, not contractible, and not homeomorphic to
-`ℝ`.
-
-The simple-connectivity instance for `Sⁿ`, which turns these conditional results into the usual
-unconditional computation, is being developed upstream in Mathlib PR #28246.
+As consequences, `RPⁿ` (for `2 ≤ n`) has a fundamental group of order 2, a nontrivial fundamental
+group, is not simply connected, not contractible, and not homeomorphic to `ℝ`.
 
 ## Main declarations
 
-* `TauCeti.RealProjectiveSpace.fundamentalGroupMulEquiv`: for `2 ≤ n` and a simply connected
-  covering sphere, `FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ` for any basepoint `x`
+* `TauCeti.RealProjectiveSpace.fundamentalGroupMulEquiv`: for `2 ≤ n`,
+  `FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ` for any basepoint `x`
   with a chosen lift `e`.
 * `TauCeti.RealProjectiveSpace.fundamentalGroupMulEquiv_apply_eq_iff`: characterization of the
   isomorphism on monodromy.
@@ -58,8 +54,9 @@ This is the deck-to-fundamental-group part of the `π₁(RPⁿ)` milestone in
 `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13. It consumes
 `TauCeti.RealProjectiveSpace.isQuotientCoveringMap_mk` and
 `TauCeti.RealProjectiveSpace.deckMulEquiv` from
-`TauCeti.AlgebraicTopology.UniversalCover.RealProjective.Deck`, and the regular-cover comparison
-of Stage 1. The equivalence construction and monodromy proof pattern are adapted from
+`TauCeti.AlgebraicTopology.UniversalCover.RealProjective.Deck`, the simple connectivity of the
+covering sphere from `TauCeti.AlgebraicTopology.Sphere.SimplyConnected`, and the regular-cover
+comparison of Stage 1. The equivalence construction and monodromy proof pattern are adapted from
 `TauCeti.AlgebraicTopology.UniversalCover.Circle.FundamentalGroup` for the antipodal cover.
 -/
 
@@ -75,13 +72,13 @@ noncomputable section
 
 variable (n : ℕ)
 
-/-- **The fundamental group of real projective space `RPⁿ` (for `2 ≤ n`) with a simply connected
-covering sphere is isomorphic to `ℤˣ`**, for any basepoint `x` with a chosen lift `e` in the sphere:
+/-- **The fundamental group of real projective space `RPⁿ` (for `2 ≤ n`) is isomorphic to `ℤˣ`**,
+for any basepoint `x` with a chosen lift `e` in the sphere:
 `FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ`. -/
 def fundamentalGroupMulEquiv (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)]
     {x : RealProjectiveSpace n} (e : (mk n) ⁻¹' {x}) :
     FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ :=
+  haveI := simplyConnectedSpace_euclideanSphere hn
   (Deck.IsRegular.fundamentalGroupEquiv (isRegular_mk n) (isCoveringMap_mk n) e).trans
     ((MulEquiv.op (deckMulEquiv n (by omega)).symm).trans
       (MulOpposite.opMulEquiv (M := ℤˣ)).symm)
@@ -91,12 +88,12 @@ class `γ` maps to `u : ℤˣ` exactly when its monodromy translate of the chose
 `u • (e : sphere _ 1)`. -/
 @[simp]
 lemma fundamentalGroupMulEquiv_apply_eq_iff (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)]
     {x : RealProjectiveSpace n} (e : (mk n) ⁻¹' {x})
     (γ : FundamentalGroup (RealProjectiveSpace n) x) (u : ℤˣ) :
     fundamentalGroupMulEquiv n hn e γ = u ↔
       ((isCoveringMap_mk n).monodromy γ e : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) =
         u • (e : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) := by
+  have := simplyConnectedSpace_euclideanSphere hn
   let F := Deck.IsRegular.fundamentalGroupEquiv (isRegular_mk n) (isCoveringMap_mk n) e
   let T := (MulEquiv.op (deckMulEquiv n (by omega)).symm).trans
     (MulOpposite.opMulEquiv (M := ℤˣ)).symm
@@ -119,7 +116,6 @@ lemma fundamentalGroupMulEquiv_apply_eq_iff (hn : 2 ≤ n)
 translates the chosen lift by `u`. -/
 @[simp]
 lemma monodromy_fundamentalGroupMulEquiv_symm (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)]
     {x : RealProjectiveSpace n} (e : (mk n) ⁻¹' {x}) (u : ℤˣ) :
     ((isCoveringMap_mk n).monodromy ((fundamentalGroupMulEquiv n hn e).symm u) e :
       sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) =
@@ -131,7 +127,6 @@ lemma monodromy_fundamentalGroupMulEquiv_symm (hn : 2 ≤ n)
 /-- A loop class maps to `1` under the fundamental group equivalence exactly when its monodromy
 fixes the chosen lift. -/
 lemma fundamentalGroupMulEquiv_eq_one_iff (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)]
     {x : RealProjectiveSpace n} (e : (mk n) ⁻¹' {x})
     (γ : FundamentalGroup (RealProjectiveSpace n) x) :
     fundamentalGroupMulEquiv n hn e γ = 1 ↔
@@ -143,54 +138,47 @@ lemma fundamentalGroupMulEquiv_eq_one_iff (hn : 2 ≤ n)
         (e : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) ↔
       (isCoveringMap_mk n).monodromy γ e = e))
 
-/-- **The fundamental group of real projective space `RPⁿ` (for `2 ≤ n`) with a simply connected
-covering sphere is isomorphic to `ℤˣ` for any basepoint `x`**:
-`FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ`. -/
+/-- **The fundamental group of real projective space `RPⁿ` (for `2 ≤ n`) is isomorphic to `ℤˣ`
+for any basepoint `x`**: `FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ`. -/
 def fundamentalGroupMulEquivAt (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)]
     (x : RealProjectiveSpace n) :
     FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ :=
   let h := mk_surjective n x
   fundamentalGroupMulEquiv n hn ⟨h.choose, Set.mem_singleton_iff.mpr h.choose_spec⟩
 
-/-- For `2 ≤ n` and a simply connected covering sphere, the fundamental group of `RPⁿ` has
+/-- For `2 ≤ n`, the fundamental group of `RPⁿ` has
 exactly two elements. -/
 theorem card_fundamentalGroup (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)]
     (x : RealProjectiveSpace n) :
     Nat.card (FundamentalGroup (RealProjectiveSpace n) x) = 2 := by
   rw [Nat.card_congr (fundamentalGroupMulEquivAt n hn x).toEquiv, Nat.card_eq_fintype_card,
     Fintype.card_units_int]
 
-/-- For `2 ≤ n` and a simply connected covering sphere, the fundamental group of `RPⁿ` is
+/-- For `2 ≤ n`, the fundamental group of `RPⁿ` is
 nontrivial. -/
 theorem nontrivial_fundamentalGroup (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)]
     (x : RealProjectiveSpace n) :
     Nontrivial (FundamentalGroup (RealProjectiveSpace n) x) := by
   have hunit : Nontrivial ℤˣ := ⟨(1 : ℤˣ), (-1 : ℤˣ), by decide⟩
   exact @Equiv.nontrivial _ _ (fundamentalGroupMulEquivAt n hn x).toEquiv hunit
 
-/-- For `2 ≤ n` and a simply connected covering sphere, real projective space `RPⁿ` is not
-simply connected. -/
+/-- For `2 ≤ n`, real projective space `RPⁿ` is not simply connected. -/
 theorem not_simplyConnectedSpace (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)] :
+ :
     ¬ SimplyConnectedSpace (RealProjectiveSpace n) := by
   let x : RealProjectiveSpace n := mk n (instNonemptySphere n).some
   have := nontrivial_fundamentalGroup n hn x
   exact not_simplyConnectedSpace_of_nontrivial_fundamentalGroup x
 
-/-- For `2 ≤ n` and a simply connected covering sphere, real projective space `RPⁿ` is not
-contractible. -/
+/-- For `2 ≤ n`, real projective space `RPⁿ` is not contractible. -/
 theorem not_contractibleSpace (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)] :
+ :
     ¬ ContractibleSpace (RealProjectiveSpace n) :=
   not_contractibleSpace_of_not_simplyConnectedSpace (not_simplyConnectedSpace n hn)
 
-/-- For `2 ≤ n` and a simply connected covering sphere, real projective space `RPⁿ` is not
-homeomorphic to `ℝ`. -/
+/-- For `2 ≤ n`, real projective space `RPⁿ` is not homeomorphic to `ℝ`. -/
 theorem isEmpty_homeomorph_real (hn : 2 ≤ n)
-    [SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)] :
+ :
     IsEmpty (RealProjectiveSpace n ≃ₜ ℝ) :=
   isEmpty_homeomorph_real_of_not_simplyConnectedSpace (not_simplyConnectedSpace n hn)
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean
@@ -18,7 +18,7 @@ For `2 ≤ n`, real projective `n`-space `RPⁿ` has fundamental group isomorphi
 two-sheeted antipodal quotient `mk n`.
 
 The antipodal cover is a regular covering map with deck group `ℤˣ`, and the covering sphere `Sⁿ`
-is simply connected for `2 ≤ n` by `TauCeti.simplyConnectedSpace_euclideanSphere`. The
+is simply connected for `2 ≤ n` by `TauCeti.simplyConnectedSpace_sphere_euclideanSpace`. The
 regular-cover comparison `TauCeti.Deck.IsRegular.fundamentalGroupEquiv` therefore identifies the
 fundamental group of `RPⁿ` at any basepoint with the opposite of the deck group. Since `ℤˣ` is
 commutative, the opposite drops out, yielding
@@ -78,7 +78,7 @@ for any basepoint `x` with a chosen lift `e` in the sphere:
 def fundamentalGroupMulEquiv (hn : 2 ≤ n)
     {x : RealProjectiveSpace n} (e : (mk n) ⁻¹' {x}) :
     FundamentalGroup (RealProjectiveSpace n) x ≃* ℤˣ :=
-  haveI := simplyConnectedSpace_euclideanSphere hn
+  haveI := simplyConnectedSpace_sphere_euclideanSpace hn
   (Deck.IsRegular.fundamentalGroupEquiv (isRegular_mk n) (isCoveringMap_mk n) e).trans
     ((MulEquiv.op (deckMulEquiv n (by omega)).symm).trans
       (MulOpposite.opMulEquiv (M := ℤˣ)).symm)
@@ -93,7 +93,7 @@ lemma fundamentalGroupMulEquiv_apply_eq_iff (hn : 2 ≤ n)
     fundamentalGroupMulEquiv n hn e γ = u ↔
       ((isCoveringMap_mk n).monodromy γ e : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) =
         u • (e : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) := by
-  have := simplyConnectedSpace_euclideanSphere hn
+  have := simplyConnectedSpace_sphere_euclideanSpace hn
   let F := Deck.IsRegular.fundamentalGroupEquiv (isRegular_mk n) (isCoveringMap_mk n) e
   let T := (MulEquiv.op (deckMulEquiv n (by omega)).symm).trans
     (MulOpposite.opMulEquiv (M := ℤˣ)).symm

--- a/TauCeti/Analysis/Normed/Module/Normalize.lean
+++ b/TauCeti/Analysis/Normed/Module/Normalize.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Normalize
+
+/-!
+# Radial projection to the unit sphere
+
+This file packages pointwise normalization of a continuous nowhere-zero map as a continuous map
+to the unit sphere.
+-/
+
+public section
+
+noncomputable section
+
+open Metric NormedSpace
+
+namespace TauCeti
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- Radial projection sends a continuous nowhere-zero map into a real normed space continuously
+to its unit sphere. -/
+noncomputable def normalizeToSphere {Y : Type*} [TopologicalSpace Y] (f : Y → E)
+    (hf : Continuous f) (h0 : ∀ y, f y ≠ 0) : C(Y, sphere (0 : E) 1) where
+  toFun y := ⟨normalize (f y), mem_sphere_zero_iff_norm.mpr (norm_normalize (h0 y))⟩
+  continuous_toFun := by
+    refine Continuous.subtype_mk ?_ _
+    simp only [NormedSpace.normalize]
+    exact ((continuous_norm.comp hf).inv₀
+      (fun y => norm_ne_zero_iff.mpr (h0 y))).smul hf
+
+/-- The underlying vector of `normalizeToSphere f hf h0 y` is the normalization of `f y`. -/
+@[simp]
+theorem coe_normalizeToSphere_apply {Y : Type*} [TopologicalSpace Y] (f : Y → E)
+    (hf : Continuous f) (h0 : ∀ y, f y ≠ 0) (y : Y) :
+    ((normalizeToSphere f hf h0 y : sphere (0 : E) 1) : E) = normalize (f y) :=
+  (rfl)
+
+end TauCeti
+
+end

--- a/TauCeti/Topology/Homotopy/Path.lean
+++ b/TauCeti/Topology/Homotopy/Path.lean
@@ -125,6 +125,24 @@ theorem exists_homotopy_forall_mem_of_isSimplyConnected {V : Set X} (hV : IsSimp
     (Path.map_codRestrict (x := ⟨a, haV⟩) (y := ⟨b, hbV⟩) q hq), fun t x => ?_⟩
   simp
 
+/-- **A square with prescribed edges is a path homotopy.** A continuous map on `I × I` that
+restricts to `p` at `t = 0` and to `q` at `t = 1`, and is constant along each of the edges `s = 0`
+and `s = 1`, exhibits `p` and `q` as homotopic paths. -/
+theorem homotopic_of_continuous_square {a b : X} {p q : Path a b} (K : I × I → X)
+    (hK_cont : Continuous K) (hK_zero : ∀ s, K (0, s) = p s) (hK_one : ∀ s, K (1, s) = q s)
+    (hK_left : ∀ t, K (t, 0) = a) (hK_right : ∀ t, K (t, 1) = b) : p.Homotopic q :=
+  ⟨{ toFun := K
+     continuous_toFun := hK_cont
+     map_zero_left := hK_zero
+     map_one_left := hK_one
+     prop' := by
+       intro t s hs
+       rcases hs with rfl | hs
+       · exact (hK_left t).trans p.source.symm
+       · rw [Set.mem_singleton_iff] at hs
+         subst hs
+         exact (hK_right t).trans p.target.symm }⟩
+
 end Path
 
 namespace Path

--- a/TauCeti/Topology/Homotopy/Path.lean
+++ b/TauCeti/Topology/Homotopy/Path.lean
@@ -27,9 +27,11 @@ ambient space whose intermediate paths all stay in `V`. Analytic continuation co
 `Analysis/Complex/Conformal/GlobalBranch.lean`.
 
 `Path.homotopic_of_continuous_square` is likewise adapted from Kim Morrison's
-[#38292](https://github.com/leanprover-community/mathlib4/pull/38292). It moved here from
-`AlgebraicTopology/UniversalCover/BasedPath.lean` and is used by
-`AlgebraicTopology/Sphere/SimplyConnected.lean`.
+[#38292](https://github.com/leanprover-community/mathlib4/pull/38292). It is used by
+`AlgebraicTopology/UniversalCover/BasedPath.lean`, where it previously lived privately, and by
+`AlgebraicTopology/Sphere/Puncture.lean`. The lemma
+`Path.Homotopic.refl_of_forall_mem_of_nullhomotopic` is not from #38292; it was factored out of
+`AlgebraicTopology/SemilocallySimplyConnected/Basic.lean`.
 -/
 
 public section

--- a/TauCeti/Topology/Homotopy/Path.lean
+++ b/TauCeti/Topology/Homotopy/Path.lean
@@ -25,6 +25,11 @@ Tau Ceti work in [#42](https://github.com/TauCetiProject/TauCeti/pull/42).
 `SimplyConnectedSpace.paths_homotopic`, applied in a subspace `↥V`, yields a homotopy in the
 ambient space whose intermediate paths all stay in `V`. Analytic continuation consumes it in
 `Analysis/Complex/Conformal/GlobalBranch.lean`.
+
+`Path.homotopic_of_continuous_square` is likewise adapted from Kim Morrison's
+[#38292](https://github.com/leanprover-community/mathlib4/pull/38292). It moved here from
+`AlgebraicTopology/UniversalCover/BasedPath.lean` and is used by
+`AlgebraicTopology/Sphere/SimplyConnected.lean`.
 -/
 
 public section
@@ -246,6 +251,16 @@ theorem map_nullhomotopic_of_nullhomotopic {Y : Type*} [TopologicalSpace Y] {f :
   rw [hconst] at key
   exact Path.Homotopic.trans_right_cancel
     ((key.trans (Path.Homotopic.trans_refl _)).trans (Path.Homotopic.refl_trans _).symm)
+
+/-- A loop that stays in a set whose inclusion is null-homotopic is itself null-homotopic in the
+ambient space. -/
+theorem refl_of_forall_mem_of_nullhomotopic {s : Set X}
+    (hs : (ContinuousMap.mk (Subtype.val : s → X) continuous_subtype_val).Nullhomotopic)
+    {x : X} (γ : Path x x) (hγ : ∀ t, γ t ∈ s) : γ.Homotopic (Path.refl x) := by
+  have hx : x ∈ s := γ.source ▸ hγ 0
+  have hmap := map_nullhomotopic_of_nullhomotopic hs
+    (γ.codRestrict (x := ⟨x, hx⟩) (y := ⟨x, hx⟩) hγ)
+  rwa [Path.map_codRestrict] at hmap
 
 namespace Quotient
 variable {x₀ x₁ : X}


### PR DESCRIPTION
This PR proves that the unit sphere of a real normed space `E` with `2 < Module.rank ℝ E` is simply connected, and specialises that to `Sⁿ` for `2 ≤ n`. It is the missing input to the `π₁(RPⁿ)` line of Stage 4, item 13 of `TauCetiRoadmap/UniversalCovers/README.md`: `TauCeti.RealProjectiveSpace.fundamentalGroupMulEquiv` and its corollaries were already on `main` but stated against a hypothesis `[SimplyConnectedSpace (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)]`, with a module docstring pointing at concurrent upstream Mathlib work. That hypothesis is discharged here, so `π₁(RPⁿ) ≃* ℤˣ` for `2 ≤ n`, its order-two corollary, and the non-contractibility statements become unconditional. This closes the roadmap's `π₁(RPⁿ)` line; the separate `K(G, 1)` line remains untouched.

The argument is the classical one, in the form that needs no smoothing and no simplicial approximation. A loop `γ` is compared with the piecewise linear loop through the `N + 1` values `γ (k/N)`, where uniform continuity supplies an `N` with `‖γ s - γ t‖ < 1` whenever `|s - t| ≤ 1/N`. The comparison loop is written as one global formula: the radial projection to the sphere of `L t = ∑ k ≤ N, Λ k t • γ (k/N)`, where `Λ k t = max 0 (1 - |N t - k|)` is the hat function of the `k`-th node. Since the nonnegative hat functions sum to one and every contributing node is within distance one of `γ t`, the interpolation satisfies `‖L t - γ t‖ < 1`; the entire straight segment from `γ t` to `L t` therefore avoids the origin, and radial projection gives the required homotopy. Also `Λ k t ≠ 0` forces `k ∈ {⌊N t⌋, ⌊N t⌋ + 1}`, so `L t` lies in the span of two nodes. Mathlib's `Submodule.exists_forall_notMem_of_forall_ne_top` produces a vector outside all `N + 1` of those spans — they are proper precisely because the rank exceeds two, via `rank_span_le` — and its radial projection is a point of the sphere that the comparison loop omits.

Omitting a point is then enough, by `TauCeti.homotopic_refl_of_notMem_range` in the companion file: for `x ≠ p` on the sphere the segment from `x` to `-p` misses the origin (a vanishing convex combination forces equal coefficients, hence `x = p`), so normalising it exhibits the inclusion of the punctured sphere into the sphere as null-homotopic, and a loop that misses `p` factors through the puncture. This route avoids stereographic projection and the `(ℝ ∙ v)ᵮ` machinery entirely and works throughout for real normed spaces, without an inner product.

Rank, not finite dimension, is the hypothesis: `2 < Module.rank ℝ E` is what makes a span of two vectors proper, it matches the shape of `isPathConnected_sphere (h : 1 < Module.rank ℝ E)` that supplies path connectedness, and it covers the infinite-dimensional case, where the statement is also true. Rank two is genuinely the boundary — the circle is not simply connected, as `TauCeti.Circle.not_simplyConnectedSpace` already records.

I checked the pinned Mathlib before writing: it has covering maps, homotopy lifting, `SimplyConnectedSpace`, `NormedSpace.normalize`, `isPathConnected_sphere` and the finite-union-of-proper-subspaces theorem, but no simple connectivity of any sphere, and `Mathlib/Geometry/Manifold/Instances/Sphere.lean` stops at the stereographic charts. Nothing is vendored from Mathlib. Two prerequisite extractions are folded in because the new sphere files directly reuse them. First, `Path.homotopic_of_continuous_square` — a continuous square with prescribed edges is a path homotopy — was private in `TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean`, where it is adapted from Kim Morrison's [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292); it moves to `TauCeti/Topology/Homotopy/Path.lean`, and `BasedPath.lean` continues to call it there. Second, `Path.Homotopic.refl_of_forall_mem_of_nullhomotopic` is factored from `TauCeti/AlgebraicTopology/SemilocallySimplyConnected/Basic.lean` into the same path-helper module and reused to close the punctured-sphere argument.

Files: `TauCeti/Analysis/Normed/Module/Normalize.lean` (new, 47 lines) packages radial projection at the analysis layer; `TauCeti/AlgebraicTopology/Sphere/Puncture.lean` (new, 257 lines) and `TauCeti/AlgebraicTopology/Sphere/SimplyConnected.lean` (new, 454 lines) contain the sphere argument; `TauCeti/Topology/Homotopy/Path.lean` (+35 lines), `TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean` (-19 lines), and `TauCeti/AlgebraicTopology/SemilocallySimplyConnected/Basic.lean` (+2/-9 lines) perform the two prerequisite extractions; `TauCeti/AlgebraicTopology/UniversalCover/RealProjective/FundamentalGroup/Basic.lean` drops the ten `[SimplyConnectedSpace (sphere …)]` binders and the now-false docstring claims about that hypothesis being open upstream.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"simplyconnectedspace-sphere"}-->

🤖 Prepared with Claude Code
