### PR TITLE
feat: a place finite on an affine model is one of its height one primes

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/AffineModel.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Valuation.Integral
+public import TauCeti.FieldTheory.FunctionField.Place.Basic
+public import TauCeti.RingTheory.DedekindDomain.AdicValuation
+
+/-!
+# Affine models: a place finite on a Dedekind subring is one of its height one primes
+
+An *affine model* of `F / k` is a Dedekind `k`-subalgebra `R` of `F` whose fraction field is `F`;
+the standard example is the integral closure `R_x` of `k[x]` in `F` for a transcendental `x`. This
+file proves that the places of `F / k` whose valuation ring contains `R` are exactly the height
+one primes of `R`, in the strong sense that the valuation of such a place *equals* — not merely
+is equivalent to — the normalized `𝔭`-adic valuation of a unique height one prime `𝔭` of `R`.
+The prime in question is the centre `{r : R | ord_P r > 0}` of the place on `R`, so the
+valuation ring of the place is the localization of `R` there.
+
+This is the "places ↔ height one primes" half of the affine-model dictionary that reduces divisor
+theory on the finite chart of a model to Mathlib's factorization calculus for fractional ideals.
+Which places are finite on `R_x` is settled by the two order-of-`x` criteria below: `k[x]` lies in
+the valuation ring of `P` exactly when `x` has no pole at `P`, and the valuation ring, being
+integrally closed, then swallows everything integral over `k[x]`.
+
+## Main results
+
+* `TauCeti.Place.mem_integers_of_isIntegral`: the valuation ring of a place is integrally closed,
+  so it contains everything integral over a subring it contains.
+* `TauCeti.Place.adjoin_le_integers_iff`: `k[x] ⊆ 𝒪_P` exactly when `x ∈ 𝒪_P`.
+* `TauCeti.Place.center`: the height one prime of an affine model below a place finite on it,
+  with `TauCeti.Place.valuation_center` identifying the adic valuation of that prime with the
+  valuation of the place, and `TauCeti.Place.center_injective` showing that a place finite on a
+  model is determined by its centre.
+* `TauCeti.Place.existsUnique_valuation_eq`: the uniqueness statement, and
+  `TauCeti.Place.integers_eq_valuationSubringAtPrime`: the valuation ring of the place is the
+  localization of the model at the centre.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Sections I.1 and III.2.
+-/
+
+@[expose] public section
+
+open IsDedekindDomain
+
+namespace TauCeti
+
+namespace Place
+
+universe u v w
+
+variable {k : Type u} {F : Type v} [Field k] [Field F] [Algebra k F] (P : Place k F)
+
+section Integers
+
+/-- The valuation ring of a place is integrally closed in `F`: an element of `F` integral over a
+`k`-algebra whose image lies in `𝒪_P` lies in `𝒪_P`. -/
+theorem mem_integers_of_isIntegral {R : Type w} [CommRing R] [Algebra R F]
+    (hR : ∀ r : R, algebraMap R F r ∈ P.integers) {y : F} (hy : IsIntegral R y) :
+    y ∈ P.integers := by
+  have hR' : ∀ r : R, algebraMap R F r ∈ P.valuation.valuationSubring :=
+    fun r ↦ P.mem_integers_iff.mp (hR r)
+  let : Algebra R P.valuation.valuationSubring := ((algebraMap R F).codRestrict _ hR').toAlgebra
+  have : IsScalarTower R P.valuation.valuationSubring F := .of_algebraMap_eq fun _ ↦ rfl
+  exact P.mem_integers_iff.mpr
+    ((Valuation.valuationSubring.integers P.valuation).isIntegral_iff_v_le_one.mp hy.tower_top)
+
+/-- The polynomial ring `k[x]` lies in the valuation ring of `P` as soon as `x` does: the
+valuation ring is a `k`-subalgebra of `F`. -/
+theorem mem_integers_of_mem_adjoin {x : F} (hx : x ∈ P.integers) {y : F}
+    (hy : y ∈ Algebra.adjoin k ({x} : Set F)) : y ∈ P.integers :=
+  Algebra.adjoin_le (S := Subalgebra.mk P.integers.toSubring.toSubsemiring
+    P.algebraMap_mem_integers) (by simpa using hx) hy
+
+/-- **`k[x]` lies in the valuation ring of `P` exactly when `x` has no pole at `P`**: the
+criterion selecting the places on the finite chart of `x`. Its additive form is obtained from
+`TauCeti.Place.mem_integers_iff_ord_nonneg`. -/
+theorem adjoin_le_integers_iff {x : F} :
+    (∀ y ∈ Algebra.adjoin k ({x} : Set F), y ∈ P.integers) ↔ x ∈ P.integers :=
+  ⟨fun h ↦ h x (Algebra.self_mem_adjoin_singleton k x),
+    fun hx _ hy ↦ P.mem_integers_of_mem_adjoin hx hy⟩
+
+/-- Every element of `F` integral over `k[x]` lies in the valuation ring of `P`, as soon as `x`
+has no pole at `P`. This is what makes the integral closure of `k[x]` in `F` — the affine model
+attached to `x` — an object of the finite chart of `P`. -/
+theorem mem_integers_of_isIntegral_adjoin {x : F} (hx : x ∈ P.integers) {y : F}
+    (hy : IsIntegral (Algebra.adjoin k ({x} : Set F)) y) : y ∈ P.integers :=
+  P.mem_integers_of_isIntegral (fun r ↦ P.mem_integers_of_mem_adjoin hx r.2) hy
+
+end Integers
+
+section AffineModel
+
+variable {R : Type w} [CommRing R] [IsDedekindDomain R] [Algebra R F] [IsFractionRing R F]
+  (hR : ∀ r : R, algebraMap R F r ∈ P.integers)
+
+include hR
+
+/-- The **centre** on an affine model `R` of a place `P` finite on `R`: the height one prime of
+`R` consisting of the elements with a zero at `P`. -/
+def center : HeightOneSpectrum R :=
+  P.valuation.heightOneSpectrum R P.valuation_surjective fun r ↦ P.mem_integers_iff.mp (hR r)
+
+@[simp]
+theorem mem_center_asIdeal {r : R} :
+    r ∈ (P.center hR).asIdeal ↔ P.valuation (algebraMap R F r) < 1 := Iff.rfl
+
+/-- The additive form of `TauCeti.Place.mem_center_asIdeal`: the centre of `P` on `R` consists of
+the elements of `R` with a zero at `P`. The hypothesis `r ≠ 0` guards the junk value
+`ord_P 0 = 0`. -/
+theorem mem_center_asIdeal_iff_ord_pos {r : R} (hr : r ≠ 0) :
+    r ∈ (P.center hR).asIdeal ↔ 0 < P.ord (algebraMap R F r) := by
+  have hr' : algebraMap R F r ≠ 0 := (map_ne_zero_iff _ (IsFractionRing.injective R F)).mpr hr
+  rw [mem_center_asIdeal, P.valuation_eq_exp_neg_ord hr', ← WithZero.exp_zero (M := ℤ),
+    WithZero.exp_lt_exp]
+  omega
+
+/-- **The valuation of a place finite on an affine model is the adic valuation of its centre.**
+This is the exact, not merely up-to-equivalence, form of the correspondence between places and
+height one primes. -/
+@[simp]
+theorem valuation_center : (P.center hR).valuation F = P.valuation :=
+  Valuation.valuation_heightOneSpectrum _ _
+
+/-- A height one prime whose adic valuation is that of `P` is the centre of `P`. -/
+theorem eq_center {𝔭 : HeightOneSpectrum R} (h : 𝔭.valuation F = P.valuation) :
+    𝔭 = P.center hR :=
+  Valuation.eq_heightOneSpectrum _ _ h
+
+/-- **A place of `F / k` whose valuation ring contains an affine model `R` is the adic place of a
+unique height one prime of `R`** (Stichtenoth, Section III.2). -/
+theorem existsUnique_valuation_eq :
+    ∃! 𝔭 : HeightOneSpectrum R, 𝔭.valuation F = P.valuation :=
+  Valuation.existsUnique_heightOneSpectrum_valuation_eq R P.valuation_surjective
+    fun r ↦ P.mem_integers_iff.mp (hR r)
+
+/-- The valuation ring of a place finite on an affine model is the localization of the model at
+the centre of the place. -/
+theorem integers_eq_valuationSubringAtPrime :
+    HeightOneSpectrum.valuationSubringAtPrime F (P.center hR) = P.integers := by
+  rw [HeightOneSpectrum.valuationSubringAtPrime_eq_valuationSubring, P.valuation_center hR]
+  exact SetLike.ext fun _ ↦ P.mem_integers_iff.symm
+
+/-- Distinct places finite on an affine model have distinct centres: a place is recovered from its
+centre. -/
+theorem center_injective {Q : Place k F} (hQ : ∀ r : R, algebraMap R F r ∈ Q.integers)
+    (h : P.center hR = Q.center hQ) : P = Q :=
+  Place.ext (by rw [← P.valuation_center hR, ← Q.valuation_center hQ, h])
+
+omit hR in
+/-- A place at which `x` has no pole is the adic place of a unique height one prime of any affine
+model integral over `k[x]`: the finite chart of `x` is covered by the height one primes of the
+model. -/
+theorem existsUnique_valuation_eq_of_isIntegral_adjoin {x : F} (hx : x ∈ P.integers)
+    (hint : ∀ r : R, IsIntegral (Algebra.adjoin k ({x} : Set F)) (algebraMap R F r)) :
+    ∃! 𝔭 : HeightOneSpectrum R, 𝔭.valuation F = P.valuation :=
+  P.existsUnique_valuation_eq fun r ↦ P.mem_integers_of_isIntegral_adjoin hx (hint r)
+
+end AffineModel
+
+end Place
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/AffineModel.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel.lean
@@ -41,12 +41,6 @@ integrally closed, then swallows everything integral over `k[x]`.
   `TauCeti.Place.valuationSubringAtPrime_eq_integers`: the valuation ring of the place is the
   localization of the model at the centre.
 
-## Implementation notes
-
-`TauCeti.Place.center` is `@[expose]`d, and it is the only definition here that is: its
-characterization lemma `TauCeti.Place.mem_center_asIdeal` holds by `rfl`, and the proof term of an
-exported theorem may unfold only exposed definitions.
-
 ## References
 
 * H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
@@ -112,13 +106,22 @@ include hR
 
 /-- The **centre** on an affine model `R` of a place `P` finite on `R`: the height one prime of
 `R` consisting of the elements with a zero at `P`. -/
-@[expose]
 def center : HeightOneSpectrum R :=
   P.valuation.heightOneSpectrum R P.valuation_surjective fun r ↦ P.mem_integers_iff.mp (hR r)
 
+/-- **The valuation of a place finite on an affine model is the adic valuation of its centre.**
+This is the exact, not merely up-to-equivalence, form of the correspondence between places and
+height one primes. -/
+@[simp]
+theorem valuation_center : (P.center hR).valuation F = P.valuation :=
+  Valuation.valuation_heightOneSpectrum _ _
+
+/-- The centre of `P` on `R` consists of the elements of `R` at which the valuation of `P` is
+`< 1`. -/
 @[simp]
 theorem mem_center_asIdeal {r : R} :
-    r ∈ (P.center hR).asIdeal ↔ P.valuation (algebraMap R F r) < 1 := Iff.rfl
+    r ∈ (P.center hR).asIdeal ↔ P.valuation (algebraMap R F r) < 1 := by
+  rw [← HeightOneSpectrum.valuation_lt_one_iff_mem (K := F), P.valuation_center hR]
 
 /-- The additive form of `TauCeti.Place.mem_center_asIdeal`: the centre of `P` on `R` consists of
 the elements of `R` with a zero at `P`. The hypothesis `r ≠ 0` guards the junk value
@@ -129,13 +132,6 @@ theorem mem_center_asIdeal_iff_ord_pos {r : R} (hr : r ≠ 0) :
   rw [mem_center_asIdeal, P.valuation_eq_exp_neg_ord hr', ← WithZero.exp_zero (M := ℤ),
     WithZero.exp_lt_exp]
   omega
-
-/-- **The valuation of a place finite on an affine model is the adic valuation of its centre.**
-This is the exact, not merely up-to-equivalence, form of the correspondence between places and
-height one primes. -/
-@[simp]
-theorem valuation_center : (P.center hR).valuation F = P.valuation :=
-  Valuation.valuation_heightOneSpectrum _ _
 
 /-- A height one prime whose adic valuation is that of `P` is the centre of `P`. -/
 theorem eq_center {𝔭 : HeightOneSpectrum R} (h : 𝔭.valuation F = P.valuation) :

--- a/TauCeti/FieldTheory/FunctionField/AffineModel.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel.lean
@@ -14,13 +14,15 @@ public import TauCeti.RingTheory.DedekindDomain.AdicValuation
 
 An *affine model* of `F / k` is a Dedekind `k`-subalgebra `R` of `F` whose fraction field is `F`;
 the standard example is the integral closure `R_x` of `k[x]` in `F` for a transcendental `x`. This
-file proves that the places of `F / k` whose valuation ring contains `R` are exactly the height
-one primes of `R`, in the strong sense that the valuation of such a place *equals* — not merely
-is equivalent to — the normalized `𝔭`-adic valuation of a unique height one prime `𝔭` of `R`.
-The prime in question is the centre `{r : R | ord_P r > 0}` of the place on `R`, so the
-valuation ring of the place is the localization of `R` there.
+file proves the forward direction of the places ↔ height one primes correspondence: a place of
+`F / k` whose valuation ring contains `R` is the adic place of a *unique* height one prime `𝔭` of
+`R`, in the strong sense that the valuation of the place *equals* — not merely is equivalent to —
+the normalized `𝔭`-adic valuation. The prime in question is the centre `{r : R | ord_P r > 0}` of
+the place on `R`, so the valuation ring of the place is the localization of `R` there. The converse
+— that every height one prime of `R` arises this way, which upgrades this injection into a
+bijection — is not proved here; it belongs to the module constructing a place from a prime.
 
-This is the "places ↔ height one primes" half of the affine-model dictionary that reduces divisor
+This is the "places → height one primes" half of the affine-model dictionary that reduces divisor
 theory on the finite chart of a model to Mathlib's factorization calculus for fractional ideals.
 Which places are finite on `R_x` is settled by the two order-of-`x` criteria below: `k[x]` lies in
 the valuation ring of `P` exactly when `x` has no pole at `P`, and the valuation ring, being
@@ -36,8 +38,14 @@ integrally closed, then swallows everything integral over `k[x]`.
   valuation of the place, and `TauCeti.Place.center_injective` showing that a place finite on a
   model is determined by its centre.
 * `TauCeti.Place.existsUnique_valuation_eq`: the uniqueness statement, and
-  `TauCeti.Place.integers_eq_valuationSubringAtPrime`: the valuation ring of the place is the
+  `TauCeti.Place.valuationSubringAtPrime_eq_integers`: the valuation ring of the place is the
   localization of the model at the centre.
+
+## Implementation notes
+
+`TauCeti.Place.center` is `@[expose]`d, and it is the only definition here that is: its
+characterization lemma `TauCeti.Place.mem_center_asIdeal` holds by `rfl`, and the proof term of an
+exported theorem may unfold only exposed definitions.
 
 ## References
 
@@ -45,7 +53,7 @@ integrally closed, then swallows everything integral over `k[x]`.
   Sections I.1 and III.2.
 -/
 
-@[expose] public section
+public section
 
 open IsDedekindDomain
 
@@ -104,6 +112,7 @@ include hR
 
 /-- The **centre** on an affine model `R` of a place `P` finite on `R`: the height one prime of
 `R` consisting of the elements with a zero at `P`. -/
+@[expose]
 def center : HeightOneSpectrum R :=
   P.valuation.heightOneSpectrum R P.valuation_surjective fun r ↦ P.mem_integers_iff.mp (hR r)
 
@@ -142,7 +151,7 @@ theorem existsUnique_valuation_eq :
 
 /-- The valuation ring of a place finite on an affine model is the localization of the model at
 the centre of the place. -/
-theorem integers_eq_valuationSubringAtPrime :
+theorem valuationSubringAtPrime_eq_integers :
     HeightOneSpectrum.valuationSubringAtPrime F (P.center hR) = P.integers := by
   rw [HeightOneSpectrum.valuationSubringAtPrime_eq_valuationSubring, P.valuation_center hR]
   exact SetLike.ext fun _ ↦ P.mem_integers_iff.symm

--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
@@ -76,7 +76,6 @@ theorem mem_integers_of_isIntegral {R : Type w} [CommRing R] [Algebra R F]
 /-- **`k[x]` lies in the valuation ring of `P` exactly when `x` has no pole at `P`**: the
 criterion selecting the places on the finite chart of `x`. Its additive form is obtained from
 `TauCeti.Place.mem_integers_iff_ord_nonneg`. -/
-@[simp]
 theorem adjoin_le_integers_iff {x : F} :
     (∀ y ∈ Algebra.adjoin k ({x} : Set F), y ∈ P.integers) ↔ x ∈ P.integers :=
   ⟨fun h ↦ h x (Algebra.self_mem_adjoin_singleton k x), fun hx _ hy ↦

--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
@@ -102,14 +102,14 @@ include hR
 /-- The **centre** on an affine model `R` of a place `P` finite on `R`: the height one prime of
 `R` consisting of the elements with a zero at `P`. -/
 def center : HeightOneSpectrum R :=
-  P.valuation.heightOneSpectrum R P.valuation_surjective fun r ↦ P.mem_integers_iff.mp (hR r)
+  P.valuation.heightOneSpectrum R fun r ↦ P.mem_integers_iff.mp (hR r)
 
 /-- **The valuation of a place finite on an affine model is the adic valuation of its centre.**
 This is the exact, not merely up-to-equivalence, form of the correspondence between places and
 height one primes. -/
 @[simp]
 theorem valuation_center : (P.center hR).valuation F = P.valuation :=
-  Valuation.valuation_heightOneSpectrum _ _
+  Valuation.valuation_heightOneSpectrum P.valuation_surjective _
 
 /-- The centre of `P` on `R` consists of the elements of `R` at which the valuation of `P` is
 `< 1`. -/
@@ -131,7 +131,7 @@ theorem mem_center_asIdeal_iff_ord_pos {r : R} (hr : r ≠ 0) :
 /-- A height one prime whose adic valuation is that of `P` is the centre of `P`. -/
 theorem eq_center {𝔭 : HeightOneSpectrum R} (h : 𝔭.valuation F = P.valuation) :
     𝔭 = P.center hR :=
-  Valuation.eq_heightOneSpectrum _ _ h
+  Valuation.eq_heightOneSpectrum P.valuation_surjective _ h
 
 /-- **A place of `F / k` whose valuation ring contains an affine model `R` is the adic place of a
 unique height one prime of `R`** (Stichtenoth, Section III.2). -/

--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
@@ -73,27 +73,23 @@ theorem mem_integers_of_isIntegral {R : Type w} [CommRing R] [Algebra R F]
   exact P.mem_integers_iff.mpr
     ((Valuation.valuationSubring.integers P.valuation).isIntegral_iff_v_le_one.mp hy.tower_top)
 
-/-- The polynomial ring `k[x]` lies in the valuation ring of `P` as soon as `x` does: the
-valuation ring is a `k`-subalgebra of `F`. -/
-theorem mem_integers_of_mem_adjoin {x : F} (hx : x ∈ P.integers) {y : F}
-    (hy : y ∈ Algebra.adjoin k ({x} : Set F)) : y ∈ P.integers :=
-  Algebra.adjoin_le (S := Subalgebra.mk P.integers.toSubring.toSubsemiring
-    P.algebraMap_mem_integers) (by simpa using hx) hy
-
 /-- **`k[x]` lies in the valuation ring of `P` exactly when `x` has no pole at `P`**: the
 criterion selecting the places on the finite chart of `x`. Its additive form is obtained from
 `TauCeti.Place.mem_integers_iff_ord_nonneg`. -/
+@[simp]
 theorem adjoin_le_integers_iff {x : F} :
     (∀ y ∈ Algebra.adjoin k ({x} : Set F), y ∈ P.integers) ↔ x ∈ P.integers :=
-  ⟨fun h ↦ h x (Algebra.self_mem_adjoin_singleton k x),
-    fun hx _ hy ↦ P.mem_integers_of_mem_adjoin hx hy⟩
+  ⟨fun h ↦ h x (Algebra.self_mem_adjoin_singleton k x), fun hx _ hy ↦
+    Algebra.adjoin_le (S := Subalgebra.mk P.integers.toSubring.toSubsemiring
+      P.algebraMap_mem_integers) (Set.singleton_subset_iff.mpr (by simpa using hx)) hy⟩
 
 /-- Every element of `F` integral over `k[x]` lies in the valuation ring of `P`, as soon as `x`
 has no pole at `P`. This is what makes the integral closure of `k[x]` in `F` — the affine model
 attached to `x` — an object of the finite chart of `P`. -/
 theorem mem_integers_of_isIntegral_adjoin {x : F} (hx : x ∈ P.integers) {y : F}
     (hy : IsIntegral (Algebra.adjoin k ({x} : Set F)) y) : y ∈ P.integers :=
-  P.mem_integers_of_isIntegral (fun r ↦ P.mem_integers_of_mem_adjoin hx r.2) hy
+  P.mem_integers_of_isIntegral
+    (fun r ↦ P.adjoin_le_integers_iff.mpr hx r.1 r.2) hy
 
 end Integers
 

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
@@ -41,6 +41,11 @@ Mathlib's `IsDedekindDomain.HeightOneSpectrum.exists_primeCompl_mul_eq_or_mul_eq
 arbitrary element of `K` as a fraction with denominator outside `𝔭`, in one of the two possible
 directions.
 
+Bundling the centre as a height one prime needs `w` to be nontrivial, and nothing more; the
+normalization theorems need the stronger `Function.Surjective w`, from which the nontriviality
+instance is installed on the spot through `Valuation.isNontrivial_of_surjective`, so that
+surjectivity is their only valuation hypothesis.
+
 `Valuation.centerIdeal` and `Valuation.heightOneSpectrum` keep their bodies unexposed; the
 characterization lemmas `Valuation.mem_centerIdeal` and `Valuation.asIdeal_heightOneSpectrum` are
 the interface. The latter's definitional proof is parenthesized (`(rfl)`) so that it is not inferred
@@ -57,6 +62,14 @@ namespace Valuation
 
 variable {R : Type*} [CommRing R] {K : Type*} [Field K] [Algebra R K]
   {w : _root_.Valuation K ℤᵐ⁰}
+
+/-- A valuation onto `ℤᵐ⁰` that is surjective is nontrivial: some element has value
+`exp (-1) ≠ 1`. -/
+theorem isNontrivial_of_surjective (hw : Function.Surjective w) : w.IsNontrivial := by
+  obtain ⟨x, hx⟩ := hw (WithZero.exp (-1))
+  refine (isNontrivial_iff_exists_lt_one w).mpr ⟨x, ?_, ?_⟩
+  · exact w.ne_zero_iff.mp (by simp [hx])
+  · simpa [hx] using WithZero.exp_lt_exp.mpr (by norm_num : (-1 : ℤ) < 0)
 
 section CenterIdeal
 
@@ -175,25 +188,30 @@ theorem asIdeal_heightOneSpectrum [w.IsNontrivial]
 /-- **The adic valuation of the centre of `w` on `R` is `w` itself**: a normalized valuation of the
 fraction field of a Dedekind domain whose valuation ring contains that domain is adic. -/
 @[simp]
-theorem valuation_heightOneSpectrum [w.IsNontrivial] (hw : Function.Surjective w)
+theorem valuation_heightOneSpectrum (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
+    haveI := isNontrivial_of_surjective hw
     (heightOneSpectrum R w hR).valuation K = w :=
+  haveI := isNontrivial_of_surjective hw
   eq_valuation_of_forall_mem_asIdeal_iff hw hR fun _ ↦ by
     rw [asIdeal_heightOneSpectrum, mem_centerIdeal]
 
 /-- A height one prime whose adic valuation is `w` is the centre of `w`. -/
-theorem eq_heightOneSpectrum {𝔮 : HeightOneSpectrum R} [w.IsNontrivial]
+theorem eq_heightOneSpectrum {𝔮 : HeightOneSpectrum R}
     (hw : Function.Surjective w) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1)
-    (h : 𝔮.valuation K = w) : 𝔮 = heightOneSpectrum R w hR :=
+    (h : 𝔮.valuation K = w) :
+    haveI := isNontrivial_of_surjective hw
+    𝔮 = heightOneSpectrum R w hR :=
   HeightOneSpectrum.eq_of_valuation_isEquiv_valuation (K := K)
     (by rw [h, valuation_heightOneSpectrum hw hR])
 
 variable (R) in
 /-- **A normalized valuation of the fraction field of a Dedekind domain `R` whose valuation ring
 contains `R` is the adic valuation of a unique height one prime of `R`.** -/
-theorem existsUnique_heightOneSpectrum_valuation_eq [w.IsNontrivial]
+theorem existsUnique_heightOneSpectrum_valuation_eq
     (hw : Function.Surjective w) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
     ∃! 𝔭 : HeightOneSpectrum R, 𝔭.valuation K = w :=
+  haveI := isNontrivial_of_surjective hw
   ⟨heightOneSpectrum R w hR, valuation_heightOneSpectrum hw hR,
     fun _ h ↦ eq_heightOneSpectrum hw hR h⟩
 

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
@@ -43,8 +43,8 @@ directions.
 
 `Valuation.centerIdeal` and `Valuation.heightOneSpectrum` keep their bodies unexposed; the
 characterization lemmas `Valuation.mem_centerIdeal` and `Valuation.asIdeal_heightOneSpectrum` are
-the interface, and their proofs are parenthesized (`(rfl)`, `(Iff.rfl)`) so that they are not
-inferred to be `@[defeq]`, which would require the bodies to be exposed.
+the interface. The latter's definitional proof is parenthesized (`(rfl)`) so that it is not inferred
+to be `@[defeq]`, which would require the body to be exposed.
 -/
 
 public section
@@ -66,56 +66,34 @@ of elements of `R` of positive valuation. It is prime (`Valuation.isPrime_center
 nonzero as soon as `w` is nontrivial and `K` is the fraction field of `R`
 (`Valuation.centerIdeal_ne_bot`). -/
 def centerIdeal (w : _root_.Valuation K ℤᵐ⁰) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
-    Ideal R where
-  carrier := {r : R | w (algebraMap R K r) < 1}
-  zero_mem' := by simp
-  add_mem' {a b} ha hb := by
-    have h : w (algebraMap R K (a + b)) ≤ max (w (algebraMap R K a)) (w (algebraMap R K b)) := by
-      rw [map_add]
-      exact w.map_add _ _
-    exact lt_of_le_of_lt h (max_lt ha hb)
-  smul_mem' c x hx := by
-    have h : w (algebraMap R K (c • x)) = w (algebraMap R K c) * w (algebraMap R K x) := by
-      rw [smul_eq_mul, map_mul, w.map_mul]
-    calc w (algebraMap R K (c • x)) ≤ 1 * w (algebraMap R K x) := h ▸ mul_le_mul_left (hR c) _
-      _ < 1 := by simpa using hx
+    Ideal R :=
+  (IsLocalRing.maximalIdeal w.valuationSubring).comap
+    ((algebraMap R K).codRestrict w.valuationSubring fun r ↦
+      (w.mem_valuationSubring_iff _).mpr (hR r))
 
+/-- An element belongs to the centre ideal exactly when its valuation is strictly below `1`. -/
 @[simp]
 theorem mem_centerIdeal {r : R} {hR : ∀ r : R, w (algebraMap R K r) ≤ 1} :
-    r ∈ centerIdeal R w hR ↔ w (algebraMap R K r) < 1 := (Iff.rfl)
+    r ∈ centerIdeal R w hR ↔ w (algebraMap R K r) < 1 := by
+  rw [centerIdeal, Ideal.mem_comap, w.mem_maximalIdeal_iff]
+  rfl
 
 /-- Off its centre, a valuation bounded by `1` on `R` takes the value `1`. -/
 theorem eq_one_of_notMem_centerIdeal {r : R} (hR : ∀ r : R, w (algebraMap R K r) ≤ 1)
     (hr : r ∉ centerIdeal R w hR) : w (algebraMap R K r) = 1 :=
   le_antisymm (hR r) (not_lt.mp (mt mem_centerIdeal.mpr hr))
 
-/-- The centre of a valuation bounded by `1` on `R` is a prime ideal of `R`: off the centre the
-valuation takes the value `1`, so a product of two elements off the centre again has value `1`. -/
+/-- The centre of a valuation bounded by `1` on `R` is a prime ideal of `R`. -/
 theorem isPrime_centerIdeal (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
-    (centerIdeal R w hR).IsPrime := by
-  refine Ideal.isPrime_iff.mpr ⟨fun h ↦ ?_, fun {a b} hab ↦ ?_⟩
-  · have h1 : w (algebraMap R K (1 : R)) < 1 := mem_centerIdeal.mp (h ▸ Submodule.mem_top)
-    simp at h1
-  · by_contra hc
-    rw [not_or] at hc
-    have h : w (algebraMap R K (a * b)) = 1 := by
-      rw [map_mul, w.map_mul, eq_one_of_notMem_centerIdeal hR hc.1,
-        eq_one_of_notMem_centerIdeal hR hc.2, one_mul]
-    exact absurd (h ▸ mem_centerIdeal.mp hab) (lt_irrefl 1)
+    (centerIdeal R w hR).IsPrime :=
+  (IsLocalRing.maximalIdeal w.valuationSubring).comap_isPrime _
 
-/-- The centre of a surjective valuation of the fraction field `K` of `R` is a nonzero ideal of
-`R`: an element of `K` of value `exp (-1)` is a fraction `a / b` whose numerator `a` is a nonzero
+/-- The centre of a nontrivial valuation of the fraction field `K` of `R` is a nonzero ideal of
+`R`: an element of `K` of value below `1` is a fraction `a / b` whose numerator `a` is a nonzero
 element of the centre. -/
-theorem centerIdeal_ne_bot [IsDomain R] [IsFractionRing R K] (hw : Function.Surjective w)
+theorem centerIdeal_ne_bot [IsDomain R] [IsFractionRing R K] [w.IsNontrivial]
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : centerIdeal R w hR ≠ ⊥ := by
-  obtain ⟨y, hy⟩ := hw (WithZero.exp (-1 : ℤ))
-  have hy0 : y ≠ 0 := by
-    rintro rfl
-    rw [map_zero] at hy
-    exact WithZero.exp_ne_zero hy.symm
-  have hy1 : w y < 1 := by
-    rw [hy, ← WithZero.exp_zero (M := ℤ), WithZero.exp_lt_exp]
-    omega
+  obtain ⟨y, hy0, hy1⟩ := Valuation.IsNontrivial.exists_lt_one (v := w)
   obtain ⟨ab, hab⟩ := IsLocalization.surj (nonZeroDivisors R) y
   have hb : algebraMap R K (ab.2 : R) ≠ 0 :=
     IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors ab.2.2
@@ -182,11 +160,21 @@ variable (R) in
 centred. Its adic valuation is `w` itself (`Valuation.valuation_heightOneSpectrum`), and it is the
 only height one prime with that property (`Valuation.eq_heightOneSpectrum`). -/
 def heightOneSpectrum (w : _root_.Valuation K ℤᵐ⁰) (hw : Function.Surjective w)
-    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : HeightOneSpectrum R where
-  asIdeal := centerIdeal R w hR
-  isPrime := isPrime_centerIdeal hR
-  ne_bot := centerIdeal_ne_bot hw hR
+    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : HeightOneSpectrum R := by
+  letI : w.IsNontrivial := Valuation.isNontrivial_iff_exists_lt_one w |>.mpr <| by
+    obtain ⟨y, hy⟩ := hw (WithZero.exp (-1 : ℤ))
+    refine ⟨y, ?_, ?_⟩
+    · rintro rfl
+      rw [map_zero] at hy
+      exact WithZero.exp_ne_zero hy.symm
+    · rw [hy, ← WithZero.exp_zero (M := ℤ), WithZero.exp_lt_exp]
+      omega
+  exact
+    { asIdeal := centerIdeal R w hR
+      isPrime := isPrime_centerIdeal hR
+      ne_bot := centerIdeal_ne_bot hR }
 
+/-- The underlying ideal of `heightOneSpectrum` is the centre ideal. -/
 @[simp]
 theorem asIdeal_heightOneSpectrum (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
@@ -41,10 +41,10 @@ Mathlib's `IsDedekindDomain.HeightOneSpectrum.exists_primeCompl_mul_eq_or_mul_eq
 arbitrary element of `K` as a fraction with denominator outside `𝔭`, in one of the two possible
 directions.
 
-`Valuation.centerIdeal` and `Valuation.heightOneSpectrum` are `@[expose]`d, and only they are:
-their characterization lemmas `Valuation.mem_centerIdeal` and
-`Valuation.asIdeal_heightOneSpectrum` hold by `rfl`, and the proof term of an exported theorem may
-unfold only exposed definitions.
+`Valuation.centerIdeal` and `Valuation.heightOneSpectrum` keep their bodies unexposed; the
+characterization lemmas `Valuation.mem_centerIdeal` and `Valuation.asIdeal_heightOneSpectrum` are
+the interface, and their proofs are parenthesized (`(rfl)`, `(Iff.rfl)`) so that they are not
+inferred to be `@[defeq]`, which would require the bodies to be exposed.
 -/
 
 public section
@@ -62,10 +62,9 @@ section CenterIdeal
 
 variable (R) in
 /-- The **centre** on `R` of a valuation `w` of `K` whose valuation ring contains `R`: the ideal
-of elements of `R` of positive valuation. It is prime (`Valuation.centerIdeal_isPrime`), and it is
+of elements of `R` of positive valuation. It is prime (`Valuation.isPrime_centerIdeal`), and it is
 nonzero as soon as `w` is nontrivial and `K` is the fraction field of `R`
 (`Valuation.centerIdeal_ne_bot`). -/
-@[expose]
 def centerIdeal (w : _root_.Valuation K ℤᵐ⁰) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
     Ideal R where
   carrier := {r : R | w (algebraMap R K r) < 1}
@@ -83,7 +82,7 @@ def centerIdeal (w : _root_.Valuation K ℤᵐ⁰) (hR : ∀ r : R, w (algebraMa
 
 @[simp]
 theorem mem_centerIdeal {r : R} {hR : ∀ r : R, w (algebraMap R K r) ≤ 1} :
-    r ∈ centerIdeal R w hR ↔ w (algebraMap R K r) < 1 := Iff.rfl
+    r ∈ centerIdeal R w hR ↔ w (algebraMap R K r) < 1 := (Iff.rfl)
 
 /-- Off its centre, a valuation bounded by `1` on `R` takes the value `1`. -/
 theorem eq_one_of_notMem_centerIdeal {r : R} (hR : ∀ r : R, w (algebraMap R K r) ≤ 1)
@@ -92,7 +91,7 @@ theorem eq_one_of_notMem_centerIdeal {r : R} (hR : ∀ r : R, w (algebraMap R K 
 
 /-- The centre of a valuation bounded by `1` on `R` is a prime ideal of `R`: off the centre the
 valuation takes the value `1`, so a product of two elements off the centre again has value `1`. -/
-theorem centerIdeal_isPrime (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
+theorem isPrime_centerIdeal (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
     (centerIdeal R w hR).IsPrime := by
   refine Ideal.isPrime_iff.mpr ⟨fun h ↦ ?_, fun {a b} hab ↦ ?_⟩
   · have h1 : w (algebraMap R K (1 : R)) < 1 := mem_centerIdeal.mp (h ▸ Submodule.mem_top)
@@ -182,17 +181,16 @@ variable (R) in
 /-- The height one prime of `R` at which a normalized valuation of `K` bounded by `1` on `R` is
 centred. Its adic valuation is `w` itself (`Valuation.valuation_heightOneSpectrum`), and it is the
 only height one prime with that property (`Valuation.eq_heightOneSpectrum`). -/
-@[expose]
 def heightOneSpectrum (w : _root_.Valuation K ℤᵐ⁰) (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : HeightOneSpectrum R where
   asIdeal := centerIdeal R w hR
-  isPrime := centerIdeal_isPrime hR
+  isPrime := isPrime_centerIdeal hR
   ne_bot := centerIdeal_ne_bot hw hR
 
 @[simp]
 theorem asIdeal_heightOneSpectrum (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
-    (heightOneSpectrum R w hw hR).asIdeal = centerIdeal R w hR := rfl
+    (heightOneSpectrum R w hw hR).asIdeal = centerIdeal R w hR := (rfl)
 
 /-- **The adic valuation of the centre of `w` on `R` is `w` itself**: a normalized valuation of the
 fraction field of a Dedekind domain whose valuation ring contains that domain is adic. -/
@@ -200,7 +198,8 @@ fraction field of a Dedekind domain whose valuation ring contains that domain is
 theorem valuation_heightOneSpectrum (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
     (heightOneSpectrum R w hw hR).valuation K = w :=
-  eq_valuation_of_forall_mem_asIdeal_iff hw hR fun _ ↦ Iff.rfl
+  eq_valuation_of_forall_mem_asIdeal_iff hw hR fun _ ↦ by
+    rw [asIdeal_heightOneSpectrum, mem_centerIdeal]
 
 /-- A height one prime whose adic valuation is `w` is the centre of `w`. -/
 theorem eq_heightOneSpectrum {𝔮 : HeightOneSpectrum R} (hw : Function.Surjective w)

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
@@ -40,9 +40,14 @@ valuations are bounded by `1` on `R` and are `< 1` on the same elements of `R`, 
 Mathlib's `IsDedekindDomain.HeightOneSpectrum.exists_primeCompl_mul_eq_or_mul_eq`, which writes an
 arbitrary element of `K` as a fraction with denominator outside `𝔭`, in one of the two possible
 directions.
+
+`Valuation.centerIdeal` and `Valuation.heightOneSpectrum` are `@[expose]`d, and only they are:
+their characterization lemmas `Valuation.mem_centerIdeal` and
+`Valuation.asIdeal_heightOneSpectrum` hold by `rfl`, and the proof term of an exported theorem may
+unfold only exposed definitions.
 -/
 
-@[expose] public section
+public section
 
 open scoped WithZero
 
@@ -60,6 +65,7 @@ variable (R) in
 of elements of `R` of positive valuation. It is prime (`Valuation.centerIdeal_isPrime`), and it is
 nonzero as soon as `w` is nontrivial and `K` is the fraction field of `R`
 (`Valuation.centerIdeal_ne_bot`). -/
+@[expose]
 def centerIdeal (w : _root_.Valuation K ℤᵐ⁰) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
     Ideal R where
   carrier := {r : R | w (algebraMap R K r) < 1}
@@ -84,6 +90,8 @@ theorem eq_one_of_notMem_centerIdeal {r : R} (hR : ∀ r : R, w (algebraMap R K 
     (hr : r ∉ centerIdeal R w hR) : w (algebraMap R K r) = 1 :=
   le_antisymm (hR r) (not_lt.mp (mt mem_centerIdeal.mpr hr))
 
+/-- The centre of a valuation bounded by `1` on `R` is a prime ideal of `R`: off the centre the
+valuation takes the value `1`, so a product of two elements off the centre again has value `1`. -/
 theorem centerIdeal_isPrime (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
     (centerIdeal R w hR).IsPrime := by
   refine Ideal.isPrime_iff.mpr ⟨fun h ↦ ?_, fun {a b} hab ↦ ?_⟩
@@ -96,6 +104,9 @@ theorem centerIdeal_isPrime (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
         eq_one_of_notMem_centerIdeal hR hc.2, one_mul]
     exact absurd (h ▸ mem_centerIdeal.mp hab) (lt_irrefl 1)
 
+/-- The centre of a surjective valuation of the fraction field `K` of `R` is a nonzero ideal of
+`R`: an element of `K` of value `exp (-1)` is a fraction `a / b` whose numerator `a` is a nonzero
+element of the centre. -/
 theorem centerIdeal_ne_bot [IsDomain R] [IsFractionRing R K] (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : centerIdeal R w hR ≠ ⊥ := by
   obtain ⟨y, hy⟩ := hw (WithZero.exp (-1 : ℤ))
@@ -104,8 +115,8 @@ theorem centerIdeal_ne_bot [IsDomain R] [IsFractionRing R K] (hw : Function.Surj
     rw [map_zero] at hy
     exact WithZero.exp_ne_zero hy.symm
   have hy1 : w y < 1 := by
-    rw [hy]
-    simpa using WithZero.exp_lt_exp.mpr (show (-1 : ℤ) < 0 by norm_num)
+    rw [hy, ← WithZero.exp_zero (M := ℤ), WithZero.exp_lt_exp]
+    omega
   obtain ⟨ab, hab⟩ := IsLocalization.surj (nonZeroDivisors R) y
   have hb : algebraMap R K (ab.2 : R) ≠ 0 :=
     IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors ab.2.2
@@ -171,6 +182,7 @@ variable (R) in
 /-- The height one prime of `R` at which a normalized valuation of `K` bounded by `1` on `R` is
 centred. Its adic valuation is `w` itself (`Valuation.valuation_heightOneSpectrum`), and it is the
 only height one prime with that property (`Valuation.eq_heightOneSpectrum`). -/
+@[expose]
 def heightOneSpectrum (w : _root_.Valuation K ℤᵐ⁰) (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : HeightOneSpectrum R where
   asIdeal := centerIdeal R w hR
@@ -184,6 +196,7 @@ theorem asIdeal_heightOneSpectrum (hw : Function.Surjective w)
 
 /-- **The adic valuation of the centre of `w` on `R` is `w` itself**: a normalized valuation of the
 fraction field of a Dedekind domain whose valuation ring contains that domain is adic. -/
+@[simp]
 theorem valuation_heightOneSpectrum (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
     (heightOneSpectrum R w hw hR).valuation K = w :=

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
@@ -156,53 +156,45 @@ theorem eq_valuation_of_forall_mem_asIdeal_iff {𝔭 : HeightOneSpectrum R}
     rw [key _ (𝔭.valuation_le_one n) hd, key _ (hR n) ((hone (d : R)).mp hd), hone n]
 
 variable (R) in
-/-- The height one prime of `R` at which a normalized valuation of `K` bounded by `1` on `R` is
-centred. Its adic valuation is `w` itself (`Valuation.valuation_heightOneSpectrum`), and it is the
-only height one prime with that property (`Valuation.eq_heightOneSpectrum`). -/
-def heightOneSpectrum (w : _root_.Valuation K ℤᵐ⁰) (hw : Function.Surjective w)
-    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : HeightOneSpectrum R := by
-  letI : w.IsNontrivial := Valuation.isNontrivial_iff_exists_lt_one w |>.mpr <| by
-    obtain ⟨y, hy⟩ := hw (WithZero.exp (-1 : ℤ))
-    refine ⟨y, ?_, ?_⟩
-    · rintro rfl
-      rw [map_zero] at hy
-      exact WithZero.exp_ne_zero hy.symm
-    · rw [hy, ← WithZero.exp_zero (M := ℤ), WithZero.exp_lt_exp]
-      omega
-  exact
-    { asIdeal := centerIdeal R w hR
-      isPrime := isPrime_centerIdeal hR
-      ne_bot := centerIdeal_ne_bot hR }
+/-- The height one prime of `R` at which a nontrivial valuation of `K` bounded by `1` on `R` is
+centred. Once `w` is moreover normalized, its adic valuation is `w` itself
+(`Valuation.valuation_heightOneSpectrum`) and it is the only height one prime with that property
+(`Valuation.eq_heightOneSpectrum`). -/
+def heightOneSpectrum (w : _root_.Valuation K ℤᵐ⁰) [w.IsNontrivial]
+    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : HeightOneSpectrum R where
+  asIdeal := centerIdeal R w hR
+  isPrime := isPrime_centerIdeal hR
+  ne_bot := centerIdeal_ne_bot hR
 
 /-- The underlying ideal of `heightOneSpectrum` is the centre ideal. -/
 @[simp]
-theorem asIdeal_heightOneSpectrum (hw : Function.Surjective w)
+theorem asIdeal_heightOneSpectrum [w.IsNontrivial]
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
-    (heightOneSpectrum R w hw hR).asIdeal = centerIdeal R w hR := (rfl)
+    (heightOneSpectrum R w hR).asIdeal = centerIdeal R w hR := (rfl)
 
 /-- **The adic valuation of the centre of `w` on `R` is `w` itself**: a normalized valuation of the
 fraction field of a Dedekind domain whose valuation ring contains that domain is adic. -/
 @[simp]
-theorem valuation_heightOneSpectrum (hw : Function.Surjective w)
+theorem valuation_heightOneSpectrum [w.IsNontrivial] (hw : Function.Surjective w)
     (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
-    (heightOneSpectrum R w hw hR).valuation K = w :=
+    (heightOneSpectrum R w hR).valuation K = w :=
   eq_valuation_of_forall_mem_asIdeal_iff hw hR fun _ ↦ by
     rw [asIdeal_heightOneSpectrum, mem_centerIdeal]
 
 /-- A height one prime whose adic valuation is `w` is the centre of `w`. -/
-theorem eq_heightOneSpectrum {𝔮 : HeightOneSpectrum R} (hw : Function.Surjective w)
-    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) (h : 𝔮.valuation K = w) :
-    𝔮 = heightOneSpectrum R w hw hR :=
+theorem eq_heightOneSpectrum {𝔮 : HeightOneSpectrum R} [w.IsNontrivial]
+    (hw : Function.Surjective w) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1)
+    (h : 𝔮.valuation K = w) : 𝔮 = heightOneSpectrum R w hR :=
   HeightOneSpectrum.eq_of_valuation_isEquiv_valuation (K := K)
     (by rw [h, valuation_heightOneSpectrum hw hR])
 
 variable (R) in
 /-- **A normalized valuation of the fraction field of a Dedekind domain `R` whose valuation ring
 contains `R` is the adic valuation of a unique height one prime of `R`.** -/
-theorem existsUnique_heightOneSpectrum_valuation_eq (hw : Function.Surjective w)
-    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
+theorem existsUnique_heightOneSpectrum_valuation_eq [w.IsNontrivial]
+    (hw : Function.Surjective w) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
     ∃! 𝔭 : HeightOneSpectrum R, 𝔭.valuation K = w :=
-  ⟨heightOneSpectrum R w hw hR, valuation_heightOneSpectrum hw hR,
+  ⟨heightOneSpectrum R w hR, valuation_heightOneSpectrum hw hR,
     fun _ h ↦ eq_heightOneSpectrum hw hR h⟩
 
 end Comparison

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.AdicValuation
+public import TauCeti.RingTheory.Valuation.Discrete.Order
+
+/-!
+# Normalized valuations of the fraction field of a Dedekind domain are adic
+
+Mathlib attaches to every height one prime `𝔭` of a Dedekind domain `R` a normalized
+`ℤᵐ⁰`-valued valuation `𝔭.valuation K` of the fraction field `K`, and shows that distinct primes
+give inequivalent valuations. This file proves the converse: a normalized valuation of `K` whose
+valuation ring contains `R` *is* `𝔭.valuation K` for a unique height one prime `𝔭` of `R`, namely
+the centre of the valuation on `R`.
+
+## Main definitions
+
+* `Valuation.centerIdeal`: the centre `{r : R | w r < 1}` on `R` of a valuation `w` of `K` whose
+  valuation ring contains `R`.
+* `Valuation.heightOneSpectrum`: that centre, bundled as a height one prime of `R`.
+
+## Main results
+
+* `Valuation.eq_valuation_of_forall_mem_asIdeal_iff`: a normalized valuation bounded by `1` on `R`
+  and of positive value exactly on a height one prime `𝔭` is the adic valuation of `𝔭`.
+* `Valuation.valuation_heightOneSpectrum`: the adic valuation of the centre of `w` on `R` is `w`.
+* `Valuation.existsUnique_heightOneSpectrum_valuation_eq`: the centre is the only height one prime
+  whose adic valuation is `w`.
+
+## Implementation notes
+
+The comparison goes through `Valuation.isEquiv_iff_val_le_one` and the normalization lemma
+`Valuation.eq_of_isEquiv_of_surjective`: both valuations are surjective onto `ℤᵐ⁰`, so it is
+enough to see that they have the same valuation ring. That in turn uses only that the two
+valuations are bounded by `1` on `R` and are `< 1` on the same elements of `R`, together with
+Mathlib's `IsDedekindDomain.HeightOneSpectrum.exists_primeCompl_mul_eq_or_mul_eq`, which writes an
+arbitrary element of `K` as a fraction with denominator outside `𝔭`, in one of the two possible
+directions.
+-/
+
+@[expose] public section
+
+open scoped WithZero
+
+open IsDedekindDomain
+
+namespace Valuation
+
+variable {R : Type*} [CommRing R] {K : Type*} [Field K] [Algebra R K]
+  {w : _root_.Valuation K ℤᵐ⁰}
+
+section CenterIdeal
+
+variable (R) in
+/-- The **centre** on `R` of a valuation `w` of `K` whose valuation ring contains `R`: the ideal
+of elements of `R` of positive valuation. It is prime (`Valuation.centerIdeal_isPrime`), and it is
+nonzero as soon as `w` is nontrivial and `K` is the fraction field of `R`
+(`Valuation.centerIdeal_ne_bot`). -/
+def centerIdeal (w : _root_.Valuation K ℤᵐ⁰) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
+    Ideal R where
+  carrier := {r : R | w (algebraMap R K r) < 1}
+  zero_mem' := by simp
+  add_mem' {a b} ha hb := by
+    have h : w (algebraMap R K (a + b)) ≤ max (w (algebraMap R K a)) (w (algebraMap R K b)) := by
+      rw [map_add]
+      exact w.map_add _ _
+    exact lt_of_le_of_lt h (max_lt ha hb)
+  smul_mem' c x hx := by
+    have h : w (algebraMap R K (c • x)) = w (algebraMap R K c) * w (algebraMap R K x) := by
+      rw [smul_eq_mul, map_mul, w.map_mul]
+    calc w (algebraMap R K (c • x)) ≤ 1 * w (algebraMap R K x) := h ▸ mul_le_mul_left (hR c) _
+      _ < 1 := by simpa using hx
+
+@[simp]
+theorem mem_centerIdeal {r : R} {hR : ∀ r : R, w (algebraMap R K r) ≤ 1} :
+    r ∈ centerIdeal R w hR ↔ w (algebraMap R K r) < 1 := Iff.rfl
+
+/-- Off its centre, a valuation bounded by `1` on `R` takes the value `1`. -/
+theorem eq_one_of_notMem_centerIdeal {r : R} (hR : ∀ r : R, w (algebraMap R K r) ≤ 1)
+    (hr : r ∉ centerIdeal R w hR) : w (algebraMap R K r) = 1 :=
+  le_antisymm (hR r) (not_lt.mp (mt mem_centerIdeal.mpr hr))
+
+theorem centerIdeal_isPrime (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
+    (centerIdeal R w hR).IsPrime := by
+  refine Ideal.isPrime_iff.mpr ⟨fun h ↦ ?_, fun {a b} hab ↦ ?_⟩
+  · have h1 : w (algebraMap R K (1 : R)) < 1 := mem_centerIdeal.mp (h ▸ Submodule.mem_top)
+    simp at h1
+  · by_contra hc
+    rw [not_or] at hc
+    have h : w (algebraMap R K (a * b)) = 1 := by
+      rw [map_mul, w.map_mul, eq_one_of_notMem_centerIdeal hR hc.1,
+        eq_one_of_notMem_centerIdeal hR hc.2, one_mul]
+    exact absurd (h ▸ mem_centerIdeal.mp hab) (lt_irrefl 1)
+
+theorem centerIdeal_ne_bot [IsDomain R] [IsFractionRing R K] (hw : Function.Surjective w)
+    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : centerIdeal R w hR ≠ ⊥ := by
+  obtain ⟨y, hy⟩ := hw (WithZero.exp (-1 : ℤ))
+  have hy0 : y ≠ 0 := by
+    rintro rfl
+    rw [map_zero] at hy
+    exact WithZero.exp_ne_zero hy.symm
+  have hy1 : w y < 1 := by
+    rw [hy]
+    simpa using WithZero.exp_lt_exp.mpr (show (-1 : ℤ) < 0 by norm_num)
+  obtain ⟨ab, hab⟩ := IsLocalization.surj (nonZeroDivisors R) y
+  have hb : algebraMap R K (ab.2 : R) ≠ 0 :=
+    IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors ab.2.2
+  have ha0 : ab.1 ≠ 0 := by
+    intro h
+    rw [h, map_zero] at hab
+    exact (mul_eq_zero.mp hab).elim hy0 hb
+  have hmem : ab.1 ∈ centerIdeal R w hR := by
+    rw [mem_centerIdeal]
+    calc w (algebraMap R K ab.1) = w (y * algebraMap R K (ab.2 : R)) := by rw [hab]
+      _ = w y * w (algebraMap R K (ab.2 : R)) := w.map_mul _ _
+      _ ≤ w y * 1 := mul_le_mul_right (hR ab.2) _
+      _ < 1 := by simpa using hy1
+  exact fun h ↦ ha0 (by simpa [h] using hmem)
+
+end CenterIdeal
+
+section Comparison
+
+variable [IsDedekindDomain R] [IsFractionRing R K]
+
+/-- **A normalized valuation of the fraction field of a Dedekind domain `R` that is bounded by `1`
+on `R` and of positive value exactly at a height one prime `𝔭` is the adic valuation of `𝔭`.** -/
+theorem eq_valuation_of_forall_mem_asIdeal_iff {𝔭 : HeightOneSpectrum R}
+    (hw : Function.Surjective w) (hR : ∀ r : R, w (algebraMap R K r) ≤ 1)
+    (h𝔭 : ∀ r : R, r ∈ 𝔭.asIdeal ↔ w (algebraMap R K r) < 1) :
+    𝔭.valuation K = w := by
+  -- On `R` both valuations are bounded by `1` and are `< 1` on the members of `𝔭`, so they take
+  -- the value `1` on exactly the same elements of `R`.
+  have hone : ∀ r : R, 𝔭.valuation K (algebraMap R K r) = 1 ↔ w (algebraMap R K r) = 1 := by
+    intro r
+    rw [𝔭.valuation_eq_one_iff_notMem, h𝔭 r]
+    exact ⟨fun h ↦ le_antisymm (hR r) (not_lt.mp h), fun h ↦ by simp [h]⟩
+  refine eq_of_isEquiv_of_surjective (𝔭.valuation_surjective K) hw
+    (isEquiv_iff_val_le_one.mpr fun {x} ↦ ?_)
+  obtain ⟨n, d, hnd | hnd⟩ := 𝔭.exists_primeCompl_mul_eq_or_mul_eq x
+  · -- `x = n / d` with `d` outside `𝔭`: both valuations of `x` are those of `n`, hence `≤ 1`.
+    have hd : 𝔭.valuation K (algebraMap R K (d : R)) = 1 :=
+      𝔭.valuation_eq_one_iff_notMem.mpr d.2
+    have h₁ : 𝔭.valuation K x = 𝔭.valuation K (algebraMap R K n) := by
+      rw [← hnd, map_mul, hd, mul_one]
+    have h₂ : w x = w (algebraMap R K n) := by
+      rw [← hnd, w.map_mul, (hone (d : R)).mp hd, mul_one]
+    exact iff_of_true (h₁ ▸ 𝔭.valuation_le_one n) (h₂ ▸ hR n)
+  · -- `x = d / n` with `d` outside `𝔭`: either valuation of `x` is `≤ 1` exactly when the
+    -- corresponding valuation of `n` equals `1`.
+    have key : ∀ v : _root_.Valuation K ℤᵐ⁰, v (algebraMap R K n) ≤ 1 →
+        v (algebraMap R K (d : R)) = 1 → (v x ≤ 1 ↔ v (algebraMap R K n) = 1) := by
+      intro v hvn hvd
+      have hx : v x * v (algebraMap R K n) = 1 := by rw [← v.map_mul, hnd, hvd]
+      refine ⟨fun hle ↦ ?_, fun hn ↦ le_of_eq (by rwa [hn, mul_one] at hx)⟩
+      by_contra hne
+      have hlt : v x * v (algebraMap R K n) < 1 :=
+        calc v x * v (algebraMap R K n) ≤ 1 * v (algebraMap R K n) := mul_le_mul_left hle _
+          _ = v (algebraMap R K n) := one_mul _
+          _ < 1 := lt_of_le_of_ne hvn hne
+      exact absurd hx hlt.ne
+    have hd : 𝔭.valuation K (algebraMap R K (d : R)) = 1 :=
+      𝔭.valuation_eq_one_iff_notMem.mpr d.2
+    rw [key _ (𝔭.valuation_le_one n) hd, key _ (hR n) ((hone (d : R)).mp hd), hone n]
+
+variable (R) in
+/-- The height one prime of `R` at which a normalized valuation of `K` bounded by `1` on `R` is
+centred. Its adic valuation is `w` itself (`Valuation.valuation_heightOneSpectrum`), and it is the
+only height one prime with that property (`Valuation.eq_heightOneSpectrum`). -/
+def heightOneSpectrum (w : _root_.Valuation K ℤᵐ⁰) (hw : Function.Surjective w)
+    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) : HeightOneSpectrum R where
+  asIdeal := centerIdeal R w hR
+  isPrime := centerIdeal_isPrime hR
+  ne_bot := centerIdeal_ne_bot hw hR
+
+@[simp]
+theorem asIdeal_heightOneSpectrum (hw : Function.Surjective w)
+    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
+    (heightOneSpectrum R w hw hR).asIdeal = centerIdeal R w hR := rfl
+
+/-- **The adic valuation of the centre of `w` on `R` is `w` itself**: a normalized valuation of the
+fraction field of a Dedekind domain whose valuation ring contains that domain is adic. -/
+theorem valuation_heightOneSpectrum (hw : Function.Surjective w)
+    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
+    (heightOneSpectrum R w hw hR).valuation K = w :=
+  eq_valuation_of_forall_mem_asIdeal_iff hw hR fun _ ↦ Iff.rfl
+
+/-- A height one prime whose adic valuation is `w` is the centre of `w`. -/
+theorem eq_heightOneSpectrum {𝔮 : HeightOneSpectrum R} (hw : Function.Surjective w)
+    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) (h : 𝔮.valuation K = w) :
+    𝔮 = heightOneSpectrum R w hw hR :=
+  HeightOneSpectrum.eq_of_valuation_isEquiv_valuation (K := K)
+    (by rw [h, valuation_heightOneSpectrum hw hR])
+
+variable (R) in
+/-- **A normalized valuation of the fraction field of a Dedekind domain `R` whose valuation ring
+contains `R` is the adic valuation of a unique height one prime of `R`.** -/
+theorem existsUnique_heightOneSpectrum_valuation_eq (hw : Function.Surjective w)
+    (hR : ∀ r : R, w (algebraMap R K r) ≤ 1) :
+    ∃! 𝔭 : HeightOneSpectrum R, 𝔭.valuation K = w :=
+  ⟨heightOneSpectrum R w hw hR, valuation_heightOneSpectrum hw hR,
+    fun _ h ↦ eq_heightOneSpectrum hw hR h⟩
+
+end Comparison
+
+end Valuation


### PR DESCRIPTION
This PR proves the forward half of the AlgebraicCurves roadmap's Layer-2 milestone "**Places ↔ height one primes, as a proved chain**": a place `P` of `F / k` whose valuation ring contains a Dedekind subring `R` with fraction field `F` — an *affine model* — is the adic place of a unique height one prime of `R`, and the identification is an equality of normalized valuations, not merely an equivalence. The milestone's wording is "Contract the maximal ideal of `𝒪_P` to a nonzero height one prime `𝔭_P` of `R_x`, prove the local-ring equivalence `(R_x)_{𝔭_P} ≃+* 𝒪_P`, and prove that its normalized adic valuation is exactly `P.valuation`", together with the entry criterion "For a place `P`, first prove `ord_P(x) ≥ 0 ↔ k[x] ⊆ 𝒪_P`; integrality then gives `R_x ⊆ 𝒪_P`"; all three are proved here, the local-ring statement in the sharper form `valuationSubringAtPrime F 𝔭_P = 𝒪_P` (an equality of subrings of `F`, so no transport along an isomorphism is ever needed). Layer 2 needs Layer 0 only and, per the roadmap's ordering section, runs in parallel with Layer 1; Layer 0 already supplies the `Place` structure with its DVR and order-function API (#3661), the intrinsic function-field predicate (#3705), the constant field (#3771), and the degree of a place (#3820).

`TauCeti/RingTheory/DedekindDomain/AdicValuation.lean` (210 lines) does the ring-theoretic work at its natural generality, with no field of constants and no function field in sight. Mathlib attaches to a height one prime `𝔭` of a Dedekind domain `R` a normalized `ℤᵐ⁰`-valued valuation of the fraction field `K` and proves that distinct primes give inequivalent valuations; this file proves the converse. Given a surjective `w : Valuation K ℤᵐ⁰` with `w r ≤ 1` for every `r : R`, its centre `{r : R | w r < 1}` is an ideal (it is closed under addition by the ultrametric inequality and absorbs `R` because `w ≤ 1` there), it is prime (off the centre `w` takes the value `1`, and `1 · 1 ≠ w` of a member), and it is nonzero (an element of value `exp (-1)` is a fraction `a / b` with `w a < 1` and `a ≠ 0`). That the adic valuation of the centre is `w` on the nose is `Valuation.valuation_heightOneSpectrum`, proved through the criterion `Valuation.eq_valuation_of_forall_mem_asIdeal_iff`: two normalized valuations with the same valuation ring are equal, and to compare the valuation rings it is enough to know that both valuations are `≤ 1` on `R` and `< 1` on the same elements of `R`, because Mathlib's `IsDedekindDomain.HeightOneSpectrum.exists_primeCompl_mul_eq_or_mul_eq` writes an arbitrary `x : K` as `n / d` or as `d / n` with `d` outside `𝔭` — in the first case both valuations of `x` are those of `n`, in the second each is `≤ 1` exactly when the corresponding valuation of `n` is `1`. Uniqueness is Mathlib's `eq_of_valuation_isEquiv_valuation`.

`TauCeti/FieldTheory/FunctionField/AffineModel.lean` (169 lines) is the place-vocabulary layer. `Place.mem_integers_of_isIntegral` records that `𝒪_P` is integrally closed in `F`, `Place.adjoin_le_integers_iff` is the criterion `k[x] ⊆ 𝒪_P ↔ x ∈ 𝒪_P` (its additive form `0 ≤ ord_P x` is the existing `mem_integers_iff_ord_nonneg`), and the two combine into `Place.mem_integers_of_isIntegral_adjoin`: a place at which `x` has no pole is finite on every ring integral over `k[x]`. `Place.center` is then the height one prime of an affine model below such a place, with `Place.valuation_center`, `Place.eq_center`, `Place.existsUnique_valuation_eq`, `Place.valuationSubringAtPrime_eq_integers`, and `Place.center_injective` — a place finite on a model is determined by its centre. No function-field hypothesis is used anywhere: the statements hold for an arbitrary field extension `F / k` carrying a place, which is how Stichtenoth's Section III.2 discussion of subrings and integral closures is set up.

What remains in Layer 2 after this PR is the converse direction — building a place from a height one prime, which open PR #3879 supplies in `Place/Adic.lean`, so that the two compose into the bijection `{P : Place k F | ord_P x ≥ 0} ≃ HeightOneSpectrum R_x` — together with the finite-normalization theorem that makes `R_x` Dedekind in the inseparable case, and the two-chart compatibility for `x⁻¹`. This PR deliberately builds neither: the converse is in flight, and the normalization theorem is a separate topic, so `R` is taken here as a Dedekind subring by hypothesis, which is exactly the form a consumer instantiates. The complementary case that open PR #3892 explicitly left out for Weierstrass function fields — "every such valuation is the adic valuation of a height one prime of the coordinate ring" — is the general theorem proved here.

The mathematics follows Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Sections I.1 and III.2, cited per declaration. No Mathlib infrastructure is vendored and no code from external formalizations of this material — in particular none from `vaca22/riemann-roch-function-fields` — is copied or adapted; the localization input `exists_primeCompl_mul_eq_or_mul_eq`, the valuation subring at a prime, `eq_of_valuation_isEquiv_valuation` and `valuation_surjective` are Mathlib's, and `Valuation.Integers.isIntegral_iff_v_le_one` (Kenny Lau, Yakov Pechersky) is consumed rather than reproved.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"places-height-one-primes"}-->

🤖 Prepared with Claude Code

