### PR TITLE
feat: audit Tau Ceti's Lean toolchain tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           python3 scripts/test_elan_pin.py
           PYTHONPATH=scripts python3 scripts/test_claims_access.py
           python3 scripts/test_lint_dot_notation.py
+          python3 scripts/test_toolchain_tags.py
 
       # The two-library split is build convenience, not a trust boundary.
       # This guard is what actually stops the AI-owned library from inheriting

--- a/.github/workflows/toolchain-tags.yml
+++ b/.github/workflows/toolchain-tags.yml
@@ -1,0 +1,66 @@
+name: Toolchain tag audit
+
+# Report, to Zulip (Tau Ceti > "Releases"), every Lean release that still has no Tau Ceti
+# tag, and how to give it one. `scripts/toolchain_tags.py` holds the policy and the repair
+# recipes; this workflow is only what runs it on a schedule.
+#
+# It never tags, builds, pushes or creates a branch. Every one of those is an act with a
+# permanent consequence, and they belong to release-tag.yml, dispatched by a person who
+# has read this report. What this does is make sure nobody has to remember to look.
+#
+# Like stuck-alerts.yml, the alerts are the signal and the run's own colour is not: a run
+# that checks and posts successfully is green with ten releases outstanding. Only a
+# persistent Zulip configuration break fails it, because then the channel carrying the
+# report is itself down.
+#
+# The audit is also printed to the log in full, so the run page is a usable report even
+# for someone who does not read the Zulip topic.
+
+on:
+  schedule:
+  # Daily, an hour after update.yml's 17:00 bump, so a stepping stone that merged during
+  # the day is reflected the same night. Offset off the hour, like the other schedules.
+  - cron: "10 18 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read   # checkout the script; the audit reads refs through the API
+
+concurrency:
+  group: toolchain-tags
+  # Never cancel mid-post: cancelling while it is reconciling the topic could leave it
+  # half-written. timeout-minutes bounds a hung run instead.
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    if: github.repository == 'TauCetiProject/TauCeti'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Full history, and this is not incidental: the audit derives each release's base
+      # from the (toolchain, mathlib pin) segments of main, so a truncated clone would
+      # silently shift every index and mis-derive every base. The tool refuses to run in a
+      # shallow clone rather than answer from partial history.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Print the audit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/toolchain_tags.py --audit
+
+      - name: Reconcile the outstanding releases against Zulip
+        # No continue-on-error: a broken Zulip integration must go red here too.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+          ZULIP_SITE: https://leanprover.zulipchat.com
+          ZULIP_CHANNEL: Tau Ceti
+          # Its own topic. stuck_alerts.py reconciles "Stuck PRs" by marker and edits the
+          # messages it recognises there, so an unrelated post would sit inside its
+          # bookkeeping; release-tag.yml reports its own failures to this same topic.
+          ZULIP_TOPIC: Releases
+        run: python3 scripts/toolchain_tags.py --alert

--- a/.github/workflows/toolchain-tags.yml
+++ b/.github/workflows/toolchain-tags.yml
@@ -25,6 +25,7 @@ on:
 
 permissions:
   contents: read   # checkout the script; the audit reads refs through the API
+  actions: read    # the audit reads release-tag.yml's run conclusions per target commit
 
 concurrency:
   group: toolchain-tags

--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -1,0 +1,91 @@
+# Toolchain tags
+
+Tau Ceti carries a plain `vX.Y.Z` tag for each Lean release, the way Mathlib does, so a
+downstream project on Lean `v4.33.0` can check out `v4.33.0` here and get a tree that
+builds against Mathlib's own `v4.33.0`.
+
+`scripts/toolchain_tags.py --audit` is the authority on what exists, what does not, and
+how to repair the difference. It prints the policy with its report, so nothing below is
+needed to act on a gap. This file records the reasoning that the report has no room for.
+
+## What a tag means
+
+For every Lean release `X` this repository's history can reach, the tag `vX` points at
+the **first** `main`-reachable commit whose `lean-toolchain` is exactly
+`leanprover/lean4:X` and whose Mathlib pin is at or after Mathlib's own `vX` tag commit
+`M`. The pin is, in order of preference:
+
+1. **exact**, `M` itself. The commit is either already on `main`, or is a single commit on
+   a `releases/vX` branch whose parent is a `main` commit and which changes only
+   `lake-manifest.json` and `lean-toolchain`.
+2. **inexact**, when no exact commit exists or the exact one will not compile: the first
+   `main` commit on toolchain `X`. The annotated tag message records how many Mathlib
+   commits past `M` the pin is.
+
+A tag is created only after a from-source build of that commit, with the Lake artifact
+cache off, passes the audits and lints that commit defines, and its oleans have been
+published to the Lake cache and read back. **Tags are never moved.** A tag that disagrees
+with the policy is a question for a human, and no tool here will delete or force one.
+
+### Why "first" rather than the richest commit
+
+For the exact rung it is forced. A run of commits sharing a pin at the tip of `main` is
+open-ended: `main` keeps appending to it until the next bump. Under "last" the tag would
+want to move every day and would never be idempotent. "First" is fixed the moment the run
+begins. The inexact rung follows the same rule so that `vX` means one thing, at the cost
+of some mathematics: `v4.31.0-rc1` lands on the repository's initial commit, because that
+is where `main`'s `v4.31.0-rc1` era starts.
+
+## What the cache guarantee covers, and what it cannot
+
+Tau Ceti publishes **its own** oleans. Mathlib's come from Mathlib's cache, fetched by
+`lake exe cache get`. So a tag guarantees that Tau Ceti's own library is cached for that
+commit, and inherits whatever Mathlib published for the pin.
+
+That matters for the releases Mathlib cut on its `stable` branch, `v4.29.1`, `v4.32.1` and
+`v4.32.2`. Mathlib gates cache publication on a push to `master`, and a toolchain bump
+invalidates every module hash, so `v4.32.0`'s cache does not carry over. **A consumer of
+those tags must compile Mathlib themselves, whatever we publish**, and the release
+workflow refuses to start such a build unless it is dispatched with
+`allow_mathlib_rebuild`. That is upstream's gap and it cannot be closed from here.
+
+## How the pieces fit
+
+| Piece | What it does |
+|---|---|
+| `scripts/toolchain_tags.py` | The policy. Audits, names the target commit for each release, materialises a release commit's two pin files, and reports gaps to Zulip. Never builds, pushes or tags. |
+| `.github/workflows/toolchain-tags.yml` | Runs the audit daily and reconciles the outstanding releases against Zulip. |
+| `scripts/check-release-commit.sh`, `scripts/release_commit.py` | The trust anchor. Decides whether a commit may be built unsandboxed and published. Deliberately independent of the constructor above, so a bug there cannot certify itself. |
+| `.github/workflows/release-tag.yml` | Builds one commit from source, publishes it, reads the publish back, and tags. Dispatched per release. |
+| `.github/workflows/release-backfill.yml` | Runs the above over the audit's worklist, one release at a time. |
+
+## Two things about the cache that are easy to get wrong
+
+**The scope carries a platform for older releases.** Lake leaves the platform out of a
+package's cache scope only when the lakefile declares `platformIndependent = true`. Tau
+Ceti declared it on 2026-07-27; every release older than that is scoped
+`<repo>/pt/x86_64-unknown-linux-gnu/tc/<toolchain>/<rev>` instead of
+`<repo>/tc/<toolchain>/<rev>`. The publish job passes `--platform` exactly when the target
+needs it, which is why the staging step in `release-tag.yml` reports platform dependence
+where `ci.yml`'s copy fails on it: `ci.yml` only ever builds `main`, where its absence
+would mean somebody had removed it.
+
+**The uploading Lake is not the target's Lake.** `lake cache put-staged` gained `--rev`
+and `--service` only in v4.34.0-rc1, so an older release's own Lake cannot be told which
+revision to publish under. The publish job installs a modern toolchain as the uploader and
+passes the target's toolchain as data through `--toolchain`.
+
+## Keeping `main` from stepping over a release
+
+Mathlib's `vX` tag sits on the commit that bumps its own `lean-toolchain` to `X`, so the
+window in which `main` could pin it is exactly one Mathlib toolchain era, and for a stable
+release that can be as little as fifteen hours. The daily bump takes the latest
+last-known-good commit and has already stepped clean over one release that way
+(`v4.33.0`). `update.yml` therefore pins a release tag as its own stepping stone before
+continuing, so the exact commit exists on `main` rather than having to be constructed
+afterwards.
+
+That mechanism cannot reach the `stable`-branch patch releases, and structurally so:
+`scripts/check-bump.sh` requires the Mathlib rev to be on the branch the lakefile
+nominates, so a bump pinning one could never merge. They are backfill-only by
+construction.

--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -144,6 +144,7 @@ SCHEDULERS = {
     "housekeeping.yml":      ("queue housekeeping",        7),
     "zulip-healthcheck.yml": ("zulip healthcheck",        15),
     "merge-sweep.yml":       ("merge sweep",               4),
+    "toolchain-tags.yml":    ("toolchain tag audit",      30),
 }
 # A PR carrying any of these labels is intentionally parked; never "stranded".
 HOLD_LABELS = {"keep", "hold", "wip", "human", "do-not-close", "blocked"}

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -1,0 +1,1137 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/toolchain_tags.py.
+
+Run with: python3 scripts/test_toolchain_tags.py
+
+No network. Upstream reads either go through a routed `core.gh_api` fake that rejects
+any path it does not recognise, so adding a request shape is a deliberate act, or
+through `FakeUpstream`, an offline model of the parts of mathlib's history this
+repository's releases actually depend on.
+
+The segment fixture below is the real (toolchain, pin) table of `main`, so base
+derivation is pinned to real commits rather than to a story about them.
+"""
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "pr_status"))
+os.environ.setdefault("ZULIP_TOPIC", "Releases")
+
+import core  # noqa: E402
+import toolchain_tags as tt  # noqa: E402
+
+# --- fixtures ----------------------------------------------------------------
+
+# The real segments of main, oldest first, as of the commit that introduced this test:
+# (first_index, last_index, toolchain, mathlib pin, first sha, last sha).
+REAL_SEGMENTS_RAW = [
+    (0, 120, "leanprover/lean4:v4.31.0-rc1",
+     "66748b489336a59ed4b4a4a612615c38de823e9a",
+     "818d32f10a29dbfdd0807ae88270cb3c48e8cff7", "d0660b2555379c5b09e6dbd829ace8d147d21f15"),
+    (121, 131, "leanprover/lean4:v4.31.0-rc2",
+     "0be66d77ba290828a5260d883ace636f56bce89a",
+     "41ede0449b69dc5f5353b5db34642d3d1c58aad9", "19912f44a51669ab5d9302c247757862694bbf9f"),
+    (132, 140, "leanprover/lean4:v4.31.0",
+     "fabf563a7c95a166b8d7b6efca11c8b4dc9d911f",
+     "d2da4153396c7a2d57f3d068d194fb91468cfa40", "57a2df6a6ccfd83ce9e3a05123a927e4cdd6a340"),
+    (141, 185, "leanprover/lean4:v4.31.0",
+     "5ac74759704aa69e70b00ea2a622efd06aba73df",
+     "154d23f2254b386c44a4ab415a027178f42cc822", "07f9e637e1c711da36ad37c6990bee790e6acdcc"),
+    (186, 210, "leanprover/lean4:v4.31.0",
+     "63b065c2a061e7286444690d8c427f79cd6d5b6d",
+     "20065580dabf242e5989c98b3ba9f74f05e65424", "b04120e2f4927bde9624602e84833cdc8b5661f9"),
+    (211, 239, "leanprover/lean4:v4.32.0-rc1",
+     "843d7890de006fe2cb1d2974f5bafcf1b0e3fad8",
+     "eb7d34820ada29e2cf84508aaf7ea095f1fc1a2b", "4178d1e340a824cbdee895cfcc087c48bd78cb24"),
+    (240, 272, "leanprover/lean4:v4.32.0-rc1",
+     "29af5245bafea7d69fdca69591450f60b916ed71",
+     "76e25d1820a2114f8101b3f3e68dec4b3dd6a0d3", "98d424abef6fa2ef970b03aa9bd5c5171baa71b3"),
+    (273, 324, "leanprover/lean4:v4.32.0-rc1",
+     "06e4a530c2ee8e5c0fc6ba40a38d4814102c8fa2",
+     "c856c23ccc33137dadb3c916caba885d324a009a", "324fc42e579082a715be52fcd6f58373046b7421"),
+    (325, 350, "leanprover/lean4:v4.32.0-rc1",
+     "a163fd2f6fb7408d4102dbb5faaca2b635ba1c0d",
+     "f4dabe1db623670ea3d36f8f8efd4aecfc5f29f3", "41877a33b24abce37ae068424f0300e7f280aa26"),
+    (351, 374, "leanprover/lean4:v4.32.0-rc1",
+     "9ca31d8b72cf8c317e49c301bfdbfbe91fc49136",
+     "54895e9dcd668aaddd9b90c0784b450614fa4c20", "19a60cf0f738af696f969328211571947e6eba83"),
+    (375, 404, "leanprover/lean4:v4.32.0-rc1",
+     "2929a789898c9465220a5e2361032eb9edc5c928",
+     "c484d4cf76ea5e2186672da58a5ced7acacdb6c8", "d23d61874d5edfd82dc684153a96717b4ed4244c"),
+    (405, 425, "leanprover/lean4:v4.32.0-rc1",
+     "571b8a8e54219b4d393f75f4b8653fac08197fcc",
+     "1d97fc27f45b10f9610386500b1cc09a5a3a1645", "3236707714564e353403c16ea827a369a732b2f7"),
+    (426, 449, "leanprover/lean4:v4.32.0-rc1",
+     "0f320b07b214a5ce015b3da2cac08946c4b5a506",
+     "5cbc6442b19f075a3328f0e1565541d1ca86ede1", "f917d544f12c4a451bf65bda58fb2642d1abad3b"),
+    (450, 471, "leanprover/lean4:v4.32.0-rc1",
+     "b3efe7e8a0863c414a6eb8b1fa19c429f95a81e2",
+     "addc160d052569c3ff4acfb94a23e8443ce33c7e", "12321b5724f4ad41d0b60a2005aceb2b865d6c2b"),
+    (472, 684, "leanprover/lean4:v4.32.0-rc1",
+     "95fdbd69e13b7e6b08d6b2ea72cbb6dd26d0d5f8",
+     "d6990f8839bfa9a14cf4efaa768e33aff54e770b", "af4783c9bac74a6263585ad4a336e37e01c7a7cf"),
+    (685, 745, "leanprover/lean4:v4.32.0-rc1",
+     "40b45a066a39ea5a58a2acf3cf85bf513fc0e241",
+     "526789fceccca92a2600c5029001715321af90a5", "9d2e430a17494cbf42ec5d80370bcace88cbc6a2"),
+    (746, 775, "leanprover/lean4:v4.32.0-rc1",
+     "613038575adbb25fe394846010a0507cfe643053",
+     "0cd116dae144aff57af0e35c7e105adec0e4060d", "7fb83c95461ca67d500c9c3d9e6f4647e49eb912"),
+    (776, 897, "leanprover/lean4:v4.32.0-rc1",
+     "faaff5e5590ad6b6878f66d30a33ded94cd97cf6",
+     "acacf9bf346483f038d378415bb7bcb02a4589cb", "52c215ad3f8d3c1bc2caa6af9bec5e4af4f78732"),
+    (898, 924, "leanprover/lean4:v4.32.0-rc1",
+     "f4e566ca02d995d16c590cdfe4dc051cc80f4624",
+     "944129962e0c0c4e8e3c9cf7d00b9e33f8ae9e97", "e289a0905f1b74d4f78143786234dfbec6d16798"),
+    (925, 1062, "leanprover/lean4:v4.32.0",
+     "81a5d257c8e410db227a6665ed08f64fea08e997",
+     "6b8622df38e6cc52533bb73a3e2e77bb86574888", "84923c7d744bd92afae030fcc0c5becdd77da292"),
+    (1063, 1129, "leanprover/lean4:v4.32.0",
+     "e0824fdc1cf95ea19518210636c74510a36acb05",
+     "d81139371df8832bf1fa8e68e4fff92d7a766609", "0f0af98470cc4b014fda8c2b29cb78e4fb3f4b7c"),
+    (1130, 1350, "leanprover/lean4:v4.32.0",
+     "28313485bc624fcd16dcb162dd2e2c3c813aa8fe",
+     "b3464d63d873cca333d169f591d2031cd1c2fdce", "278ce66c349a60e7f96489c26b6d611be277f921"),
+    (1351, 1363, "leanprover/lean4:v4.33.0-rc1",
+     "79d0395a1825a6264ad5d269e35e60537518955e",
+     "a98ea8771fe237edca2339dfcb6d1beb4b9a2320", "b5d0985aa2d40350b5d10eb409c1a7a02e6f7ed1"),
+    (1364, 1367, "leanprover/lean4:v4.33.0-rc1",
+     "2eb08ab8c9be0180ce78d703513eb713e25ddf53",
+     "4618747a4e995686fcd81da039e2fc82127606cf", "111c6ee0bbd2013f18e9c840a146c673525e3636"),
+    (1368, 1375, "leanprover/lean4:v4.33.0-rc1",
+     "d99d52c36bea862ef9499bfaef386d0bcba9ea48",
+     "3a26ae30cade3a1428fce79aa2ec888fe46eb761", "1a6d58475213e55619673a490b66e9b545e2fd07"),
+    (1376, 1376, "leanprover/lean4:v4.33.0-rc1",
+     "7c8ff804e2608c13c288de9a42c3a5771f124d58",
+     "7caffc64eb7398ed48d5f116b44261abc6d57b9c", "7caffc64eb7398ed48d5f116b44261abc6d57b9c"),
+    (1377, 1382, "leanprover/lean4:v4.33.0-rc1",
+     "d4519b399018129db0a28eda3488eddfed9f73c4",
+     "987faf52fdb4f604516b182db576fdedaf877df9", "123bbebb818b5b84d777b09ffea0a394e22d834d"),
+    (1383, 1386, "leanprover/lean4:v4.33.0-rc1",
+     "d0060d7bbba57d53450b2ebe84d015f5e926793a",
+     "be373fcd956bbf1f25c5e5713519865d789e6e90", "54e043e87b338d6d85108068fc0689e241d4cae5"),
+    (1387, 1520, "leanprover/lean4:v4.33.0-rc1",
+     "c7202db459de001e1f4dcbe9cc244a2be198010f",
+     "5cd952648bc879b32bcc0f95e64c1fd8f5e288d3", "aa153fdb48c093cd23415bf97aefb7082f86e085"),
+    (1521, 1597, "leanprover/lean4:v4.33.0-rc1",
+     "edc39bf7bcc706ba243ae824adaa60fff00416db",
+     "e51dd9b19fdd9f4afcf38f09ea787ec83ae7d49a", "01a0f5b2abdb3f9b4616d68b2b209b827ebf42d3"),
+    (1598, 1673, "leanprover/lean4:v4.33.0-rc1",
+     "30696563acb0596ab44d272bc5dfee96b2e72263",
+     "86328ec300dbdecd379c7cf97d27aaa01695e789", "5ff6ce0c8e66574aa23388f09831b2299996f625"),
+    (1674, 1815, "leanprover/lean4:v4.33.0-rc1",
+     "0f0a217d5d731dad8a22f3f7095634784d30ac14",
+     "f522aadb64b228210ad65c3874496280e77f0510", "0560c63d18a70ec1e0994275cf1f93a5f0315c32"),
+    (1816, 1910, "leanprover/lean4:v4.33.0-rc1",
+     "9c0c555bde5a8277cd36dc4dc6dfe2a5a77a2b11",
+     "9afa0a589055ab45857a36177244aca1623bdb20", "249ffa1308e00d2ac4f4f1072ee067881d18db74"),
+    (1911, 1920, "leanprover/lean4:v4.33.0-rc1",
+     "c0032752b47af314b015a7b411123fa4ac99bbaf",
+     "2a2040bfe38e57b1bd304908ac8d640962142ea2", "2e60ddbc2f666712b576cc592daaa4997a2a199e"),
+    (1921, 1943, "leanprover/lean4:v4.33.0-rc1",
+     "d586c71e87ddf1c4fef06a739cdd3b733fd8b64d",
+     "4058bf19b066a045eb774e0f1d63546580fe7324", "3752261a693d758346beb1c004bc967c11545728"),
+    (1944, 2096, "leanprover/lean4:v4.33.0-rc2",
+     "9fb10993c11c9e7abfa291e86fb499b6e1f4da82",
+     "f1d72f954880bb790cf4825443fe16e3d8aa8805", "e574654cbc5550e28d19c3712736ff2be6a755d2"),
+    (2097, 2203, "leanprover/lean4:v4.33.0-rc2",
+     "7492625a36d9f2fec11042adea9b7eaf9cc22846",
+     "21ebbf4e0a77405f75611c5778127b383eb43555", "26089eaea76fe52ce1e4c319e551ec0d603d05da"),
+    (2204, 2347, "leanprover/lean4:v4.33.0-rc2",
+     "f6dc05e369aa1c3b6a70f416c4b299cf26e9dd38",
+     "78d894d611fe8e66aa5bd29a18fd5eeb8132c4ed", "5a778f85832286c96700c52e7a561f339bd8ca5f"),
+    (2348, 2401, "leanprover/lean4:v4.33.0-rc2",
+     "39122a64484ce32b5fdb6f005e5c2da61773e225",
+     "a3d43cf02bb6dc6b7907ac427f1a1be5d3d67771", "afb1aacb3632d3236eee756ea1683290c07270a3"),
+    (2402, 2634, "leanprover/lean4:v4.34.0-rc1",
+     "de5ce8a9a66a4aa68a9bdbb35b63a06d34d9ca11",
+     "3e44c028b2ba2a681c40cbeefb5bded4d637120a", "86cc55d9192fc3f094f293ead6f2e7a153c79d17"),
+    (2635, 2719, "leanprover/lean4:v4.34.0-rc1",
+     "f5809ef6d5ca171b70db20940625e4f6f36ddee8",
+     "41599c661a98d677ea7e9629ff16b72494759e27", "1ecc92cce7e1360dfaf04140ca524ce4a7051ee8"),
+    (2720, 2856, "leanprover/lean4:v4.34.0-rc1",
+     "f4fd7f7e24a83af258ec9d80deb04648d3428d34",
+     "052dec58e5611c2a556cb145f330d541fd12ce89", "de88076c34867b21dd80a7b7232f948dea890c73"),
+    (2857, 2981, "leanprover/lean4:v4.34.0-rc1",
+     "77cbcbc65f9e26f6ede0a01b24c2cb909e11cc0d",
+     "69fd9f9afec87fa107c45b6d9c16972383d12f05", "e28afb19d468aabb12e10f6bc1d226e6cb5e3f97"),
+    (2982, 3134, "leanprover/lean4:v4.34.0-rc1",
+     "05ae0103f49b1ad1248f6039bbbad43d8aeb52a9",
+     "d07f2034e3bff0a6f946d1c590e46e2eca105df9", "ed81293743fa7eb4aaf412bc0cad3050f1d6b8b8"),
+    (3135, 3291, "leanprover/lean4:v4.34.0-rc1",
+     "5658ee5a7ce168cbe5d8c6bd1c25122c237bf84d",
+     "81a74c776bcc5ad72c5f357762b096e81dac4ef7", "c4d7989a116c565aa558fb82c318ad7c651bf2f4"),
+    (3292, 3304, "leanprover/lean4:v4.34.0-rc1",
+     "ae26804842dd341fb1c52e81d71f1a105ef4ca34",
+     "5d5361671ebca14fcf3be2c42c50d9693552f9c7", "f93736047d51931862e138b4c097099c8d1168a6"),
+]
+
+# mathlib's release tags over the same window, and the commits they point at.
+REAL_TAGS = {
+    "v4.31.0-rc1": "d568c8c09630de097a046763c17b9ea99f95f950",
+    "v4.31.0-rc2": "d90090f647cae4f4ad4da99c0ac8bab2ca8c34ab",
+    "v4.31.0": "fabf563a7c95a166b8d7b6efca11c8b4dc9d911f",
+    "v4.32.0-rc1": "360da6fa66c1273b76b6b2d8c5666fd5ac2e3b56",
+    "v4.32.0": "81a5d257c8e410db227a6665ed08f64fea08e997",
+    "v4.32.1": "520045ab14e26149ee970e2e617ca04b09bde5d6",
+    "v4.32.2": "905b95818eb32af7874a58b427f50c1711a5e96c",
+    "v4.33.0-rc1": "79d0395a1825a6264ad5d269e35e60537518955e",
+    "v4.33.0-rc2": "51e6992efd06126df61a496bebf8f49482a4e129",
+    "v4.33.0": "db584cd6d46c92f209a44c0f1c829460d327499d",
+    "v4.34.0-rc1": "de5ce8a9a66a4aa68a9bdbb35b63a06d34d9ca11",
+}
+
+# The two tags mathlib cut on its `stable` branch. They are not on master, and their
+# parent chain reaches master at the v4.32.0 tag commit.
+OFF_MASTER = {
+    "v4.32.2": "v4.32.1",
+    "v4.32.1": "v4.32.0",
+}
+
+# The bases the policy must derive, taken from the real history. These are the assertion
+# this whole file exists to protect.
+EXPECTED_BASES = {
+    "v4.31.0-rc2": "d0660b2555379c5b09e6dbd829ace8d147d21f15",
+    "v4.32.0-rc1": "b04120e2f4927bde9624602e84833cdc8b5661f9",
+    "v4.32.1": "84923c7d744bd92afae030fcc0c5becdd77da292",
+    "v4.32.2": "84923c7d744bd92afae030fcc0c5becdd77da292",
+    "v4.33.0-rc2": "3752261a693d758346beb1c004bc967c11545728",
+    "v4.33.0": "afb1aacb3632d3236eee756ea1683290c07270a3",
+}
+
+
+def segments():
+    return [{"first_index": a, "last_index": b, "toolchain": tc, "mathlib_rev": rev,
+             "first_sha": first, "last_sha": last}
+            for a, b, tc, rev, first, last in REAL_SEGMENTS_RAW]
+
+
+class FakeUpstream:
+    """An offline model of the upstream facts the policy consults.
+
+    Ancestry is modelled the way mathlib's master history actually behaves: the
+    toolchain is monotone along it, and a release tag is the FIRST commit carrying its
+    own toolchain, so a commit's position is (its toolchain, whether it is the tag).
+    The two `stable`-branch tags are off master and reach it through their parents,
+    exactly as the real ones do."""
+
+    def __init__(self, tags=None, repo_tags=None, branches=None, verify=None,
+                 bump_commits=None, pins=None):
+        self.tags = dict(tags or REAL_TAGS)
+        self.by_sha = {sha: name for name, sha in self.tags.items()}
+        self.repo_tags = dict(repo_tags or {})
+        self.branches = dict(branches or {})
+        self.verify = dict(verify or {})
+        self.pins = dict(pins or {})
+        self.bump_commits = (set(self.tags) if bump_commits is None else set(bump_commits))
+        self.calls = 0
+        self._toolchain_of = {}
+        for index, (_a, _b, toolchain, rev, _f, _l) in enumerate(REAL_SEGMENTS_RAW):
+            self._toolchain_of[rev] = (toolchain, index + 1)
+
+    # ----- ordering along master
+
+    def _order(self, sha):
+        name = self.by_sha.get(sha)
+        if name is not None:
+            return (tt.release_key(name), 0)
+        toolchain, index = self._toolchain_of[sha]
+        return (tt.release_key(tt.release_of_toolchain(toolchain)), index)
+
+    def _anchor(self, sha):
+        """Walk an off-master commit back to the master commit it descends from."""
+        name = self.by_sha.get(sha)
+        while name in OFF_MASTER:
+            name = OFF_MASTER[name]
+        return self.tags[name] if name in self.tags else sha
+
+    def on_master(self, sha):
+        self.calls += 1
+        return self.by_sha.get(sha) not in OFF_MASTER
+
+    def is_ancestor(self, ancestor, descendant):
+        self.calls += 1
+        if ancestor == descendant:
+            return True
+        if not self.on_master(descendant):
+            descendant = self._anchor(descendant)
+            if ancestor == descendant:
+                return True
+        return self._order(ancestor) < self._order(descendant)
+
+    def is_toolchain_bump_commit(self, sha):
+        self.calls += 1
+        return sha in {self.tags[n] for n in self.bump_commits if n in self.tags}
+
+    def toolchain_at(self, sha):
+        self.calls += 1
+        name = self.by_sha.get(sha)
+        if name:
+            return tt.toolchain_for(name)
+        return self._toolchain_of[sha][0]
+
+    def committed_at(self, sha):
+        self.calls += 1
+        return "2020-01-01T00:00:00Z"
+
+    def release_tags(self):
+        self.calls += 1
+        return dict(self.tags)
+
+    def tag_target(self, release):
+        self.calls += 1
+        return self.repo_tags.get(release)
+
+    def branch_head(self, branch):
+        # Keyed by the short name, as the real one is: `releases/` is a namespace, and
+        # `Upstream.release_branches` strips it when it indexes the matching-refs reply.
+        self.calls += 1
+        short = branch[len("releases/"):] if branch.startswith("releases/") else branch
+        return self.branches.get(short)
+
+    def verify_conclusion(self, sha):
+        self.calls += 1
+        return self.verify.get(sha)
+
+    def repo_pin_at(self, sha):
+        self.calls += 1
+        return self.pins[sha]
+
+    def manifest_at(self, sha):
+        self.calls += 1
+        return MATHLIB_MANIFEST
+
+    def ahead_by(self, base, head):
+        self.calls += 1
+        return 83 if base == self.tags.get("v4.31.0-rc1") else 1
+
+
+# A base manifest in Lake's exact layout, trimmed to three packages. The layout, not
+# the package count, is what the renderer has to reproduce.
+BASE_MANIFEST = '''{"version": "1.2.0",
+ "packagesDir": ".lake/packages",
+ "packages":
+ [{"url": "https://github.com/leanprover-community/mathlib4",
+   "type": "git",
+   "subDir": null,
+   "scope": "",
+   "rev": "1111111111111111111111111111111111111111",
+   "name": "mathlib",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "master",
+   "inherited": false,
+   "configFile": "lakefile.lean"},
+  {"url": "https://github.com/leanprover-community/batteries",
+   "type": "git",
+   "subDir": null,
+   "scope": "leanprover-community",
+   "rev": "2222222222222222222222222222222222222222",
+   "name": "batteries",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "main",
+   "inherited": true,
+   "configFile": "lakefile.toml"}],
+ "name": "TauCeti",
+ "lakeDir": ".lake",
+ "fixedToolchain": false}
+'''
+
+# mathlib's own manifest at the tag: note `inherited` false on its direct dependency,
+# a `version` newer than the base's, and its own root fields, none of which may leak.
+MATHLIB_MANIFEST = '''{"version": "1.3.0",
+ "packagesDir": ".lake/packages",
+ "packages":
+ [{"url": "https://github.com/leanprover-community/batteries",
+   "type": "git",
+   "subDir": null,
+   "scope": "leanprover-community",
+   "rev": "3333333333333333333333333333333333333333",
+   "name": "batteries",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "main",
+   "inherited": false,
+   "configFile": "lakefile.toml"},
+  {"url": "https://github.com/leanprover/lean4-cli",
+   "type": "git",
+   "subDir": null,
+   "scope": "leanprover",
+   "rev": "4444444444444444444444444444444444444444",
+   "name": "Cli",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "main",
+   "inherited": true,
+   "configFile": "lakefile.toml"}],
+ "name": "mathlib",
+ "lakeDir": ".lake",
+ "fixedToolchain": true}
+'''
+
+M33 = REAL_TAGS["v4.33.0"]
+
+
+class RoutedGh:
+    """A `core.gh_api` stand-in that answers a fixed set of path shapes and raises on
+    anything else, so a new request shape cannot appear unnoticed."""
+
+    def __init__(self, routes):
+        self.routes = routes
+        self.requests = []
+
+    def __call__(self, path, jq=None, paginate=False):
+        self.requests.append(path)
+        for prefix, value in self.routes.items():
+            if path.startswith(prefix):
+                return value
+        raise RuntimeError(f"unrouted gh api path: {path}")
+
+
+@contextlib.contextmanager
+def routed(routes):
+    fake = RoutedGh(routes)
+    original = core.gh_api
+    core.gh_api = fake
+    try:
+        yield fake
+    finally:
+        core.gh_api = original
+
+
+# --- version algebra ---------------------------------------------------------
+
+class VersionAlgebra(unittest.TestCase):
+    def test_accepts_releases_and_rcs(self):
+        self.assertEqual(tt.parse_release("v4.33.0")[:3], (4, 33, 0))
+        self.assertEqual(tt.parse_release("v4.33.0-rc2")[3], 2)
+
+    def test_rejects_non_releases(self):
+        # `v4.32.0-rc1-patch1` is a mathlib patch of its own tree at an unchanged
+        # toolchain, so it names no Lean release and `v4.32.0-rc1` is already taken.
+        for name in ("v2024", "v4.32.0-rc1-patch1", "nightly-2026-01-01", "", None):
+            self.assertIsNone(tt.parse_release(name), name)
+
+    def test_final_sorts_after_its_own_rcs(self):
+        order = ["v4.32.1", "v4.33.0-rc1", "v4.33.0-rc2", "v4.33.0", "v4.34.0-rc1"]
+        self.assertEqual(sorted(order, key=tt.release_key), order)
+        self.assertTrue(tt.release_lt("v4.33.0-rc2", "v4.33.0"))
+        self.assertFalse(tt.release_lt("v4.33.0", "v4.33.0-rc2"))
+
+    def test_toolchain_round_trip(self):
+        self.assertEqual(tt.toolchain_for("v4.33.0"), "leanprover/lean4:v4.33.0")
+        self.assertEqual(tt.release_of_toolchain("leanprover/lean4:v4.33.0"), "v4.33.0")
+        self.assertIsNone(tt.release_of_toolchain("leanprover/lean4-pr-releases:pr-1"))
+        self.assertIsNone(tt.release_of_toolchain("leanprover/lean4:nightly-2026-01-01"))
+
+
+# --- the segment walk --------------------------------------------------------
+
+class SegmentWalk(unittest.TestCase):
+    def walk(self, order, changed, pins):
+        return tt.segments_from(order, set(changed), lambda sha: pins[sha])
+
+    def test_fills_forward_across_untouched_commits(self):
+        pins = {"a": ("tc1", "p1"), "d": ("tc2", "p2")}
+        segs = self.walk(list("abcdef"), ["a", "d"], pins)
+        self.assertEqual([(s["first_index"], s["last_index"]) for s in segs], [(0, 2), (3, 5)])
+        self.assertEqual(segs[0]["last_sha"], "c")
+        self.assertEqual(segs[1]["first_sha"], "d")
+
+    def test_a_touch_that_changes_nothing_extends_the_segment(self):
+        # A commit can touch lake-manifest.json without moving the pin (a reformat, a
+        # revert-and-restore). Splitting there would invent a boundary that no pin move
+        # corresponds to, and every later index would shift.
+        pins = {"a": ("tc1", "p1"), "c": ("tc1", "p1")}
+        segs = self.walk(list("abcd"), ["a", "c"], pins)
+        self.assertEqual(len(segs), 1)
+        self.assertEqual(segs[0]["last_index"], 3)
+
+    def test_segments_are_contiguous_and_cover_everything(self):
+        segs = segments()
+        self.assertEqual(segs[0]["first_index"], 0)
+        for earlier, later in zip(segs, segs[1:]):
+            self.assertEqual(earlier["last_index"] + 1, later["first_index"])
+
+    def test_real_history_is_monotone(self):
+        tt.assert_monotone(segments())
+
+    def test_a_backward_toolchain_move_fails_closed(self):
+        # Base derivation binary-searches on monotonicity. If main ever moved backward
+        # the search would return a silently wrong base, so this must raise.
+        segs = segments()[:3]
+        segs[2] = dict(segs[2], toolchain="leanprover/lean4:v4.30.0")
+        with self.assertRaises(RuntimeError):
+            tt.assert_monotone(segs)
+
+
+# --- base derivation ---------------------------------------------------------
+
+class BaseDerivation(unittest.TestCase):
+    def test_every_constructed_release_gets_its_real_base(self):
+        up = FakeUpstream()
+        for release, expected in EXPECTED_BASES.items():
+            with self.subTest(release=release):
+                base, _rule = tt.resolve_base(segments(), release, REAL_TAGS[release], up)
+                self.assertIsNotNone(base, f"{release} derived no base")
+                self.assertEqual(base["last_sha"], expected)
+
+    def test_the_naive_toolchain_rule_gets_the_patch_releases_wrong(self):
+        # Documents why the exact-pin clause and the off-master walk exist. "The last
+        # segment whose toolchain is older than X" lands well past v4.32.1's real base,
+        # because v4.32.1 branches off the v4.32.0 TAG, not off the end of that era.
+        segs = segments()
+        naive = [s for s in segs
+                 if tt.release_lt(tt.release_of_toolchain(s["toolchain"]), "v4.32.1")][-1]
+        self.assertNotEqual(naive["last_sha"], EXPECTED_BASES["v4.32.1"])
+
+    def test_the_fast_path_and_a_real_ancestry_search_agree(self):
+        # The fast path rests on mathlib's habit of tagging the toolchain-bump commit.
+        # Turning the habit off must not change any answer, only the cost.
+        for release, expected in EXPECTED_BASES.items():
+            with self.subTest(release=release):
+                slow = FakeUpstream(bump_commits=set())
+                base, rule = tt.resolve_base(segments(), release, REAL_TAGS[release], slow)
+                self.assertEqual(rule, "ancestry-search")
+                self.assertEqual(base["last_sha"], expected)
+
+    def test_the_fast_path_is_cheaper(self):
+        fast, slow = FakeUpstream(), FakeUpstream(bump_commits=set())
+        tt.resolve_base(segments(), "v4.33.0", REAL_TAGS["v4.33.0"], fast)
+        tt.resolve_base(segments(), "v4.33.0", REAL_TAGS["v4.33.0"], slow)
+        self.assertLess(fast.calls, slow.calls)
+
+    def test_a_wrong_fast_path_is_caught_and_corrected(self):
+        # If mathlib ever reverts to tagging a commit that is NOT the toolchain bump,
+        # as it did for v4.24.0, the fast path's premise is false. The verification
+        # query must notice and fall back rather than return a wrong base.
+        class Liar(FakeUpstream):
+            def is_toolchain_bump_commit(self, sha):
+                return True  # claims the habit holds when it does not
+
+            def _order(self, sha):
+                # v4.33.0's tag now sits at the END of its own era, so every pin the
+                # fast path would accept on toolchain grounds is still an ancestor,
+                # except the era's own, which it wrongly rejects.
+                order = super()._order(sha)
+                if self.by_sha.get(sha) == "v4.33.0":
+                    return (order[0], 99)
+                return order
+
+        up = Liar()
+        base, _rule = tt.resolve_base(segments(), "v4.33.0", REAL_TAGS["v4.33.0"], up)
+        self.assertTrue(up.is_ancestor(base["mathlib_rev"], REAL_TAGS["v4.33.0"]))
+
+    def test_no_base_when_the_repository_starts_after_the_tag(self):
+        # v4.31.0-rc1's tag predates the first commit, which already pins past it.
+        base, _rule = tt.resolve_base(segments(), "v4.31.0-rc1", REAL_TAGS["v4.31.0-rc1"],
+                                      FakeUpstream())
+        self.assertIsNone(base)
+
+
+# --- classification ----------------------------------------------------------
+
+class Classification(unittest.TestCase):
+    def row(self, release, up=None):
+        up = up or FakeUpstream()
+        return tt.classify(release, REAL_TAGS[release], segments(), up)
+
+    def test_the_four_exact_runs_are_ready_at_the_first_commit_of_the_run(self):
+        expected = {
+            "v4.31.0": "d2da4153396c7a2d57f3d068d194fb91468cfa40",
+            "v4.32.0": "6b8622df38e6cc52533bb73a3e2e77bb86574888",
+            "v4.33.0-rc1": "a98ea8771fe237edca2339dfcb6d1beb4b9a2320",
+            "v4.34.0-rc1": "3e44c028b2ba2a681c40cbeefb5bded4d637120a",
+        }
+        for release, sha in expected.items():
+            with self.subTest(release=release):
+                row = self.row(release)
+                self.assertEqual(row["status"], "ready")
+                self.assertTrue(row["exact"])
+                self.assertEqual(row["target_sha"], sha)
+
+    def test_the_target_does_not_move_as_main_grows(self):
+        # The reason RUN_TAG_POLICY is "first". The v4.34.0-rc1 run is at the tip, so
+        # main keeps appending commits to it; under "last" the tag would want to move
+        # on every one of them and would never be idempotent.
+        before = self.row("v4.34.0-rc1")["target_sha"]
+        grown = segments()
+        grown[-1] = dict(grown[-1], last_index=grown[-1]["last_index"] + 500,
+                         last_sha="f" * 40)
+        after = tt.classify("v4.34.0-rc1", REAL_TAGS["v4.34.0-rc1"], grown, FakeUpstream())
+        self.assertEqual(before, after["target_sha"])
+
+    def test_the_policy_constant_is_what_selects_the_commit(self):
+        # Keeps RUN_TAG_POLICY load-bearing. It was documentation that nothing read
+        # once, which is how a stated policy and an actual one drift apart.
+        original = tt.RUN_TAG_POLICY
+        try:
+            first = self.row("v4.31.0")["target_sha"]
+            tt.RUN_TAG_POLICY = "last"
+            last = self.row("v4.31.0")["target_sha"]
+        finally:
+            tt.RUN_TAG_POLICY = original
+        self.assertNotEqual(first, last)
+        self.assertEqual(first, "d2da4153396c7a2d57f3d068d194fb91468cfa40")
+
+    def test_constructed_releases_need_a_branch_and_name_their_base(self):
+        for release, base in EXPECTED_BASES.items():
+            with self.subTest(release=release):
+                row = self.row(release)
+                self.assertEqual(row["status"], "needs-branch")
+                self.assertEqual(row["base_sha"], base)
+                self.assertIsNone(row["target_sha"])
+
+    def test_an_existing_release_branch_becomes_the_target(self):
+        head = "a" * 40
+        up = FakeUpstream(branches={"v4.33.0": head})
+        row = self.row("v4.33.0", up)
+        self.assertEqual(row["status"], "branch-ready")
+        self.assertEqual(row["target_sha"], head)
+        self.assertEqual(row["target_kind"], "release-branch")
+
+    def test_the_inexact_rung_is_used_only_when_no_base_exists(self):
+        row = self.row("v4.31.0-rc1")
+        self.assertEqual(row["status"], "ready")
+        self.assertFalse(row["exact"])
+        self.assertEqual(row["target_sha"], REAL_SEGMENTS_RAW[0][4])
+
+    def test_releases_predating_the_repository_are_out_of_scope_and_free(self):
+        up = FakeUpstream(tags=dict(REAL_TAGS, **{"v4.20.0": "b" * 40}))
+        row = tt.classify("v4.20.0", "b" * 40, segments(), up)
+        self.assertEqual(row["status"], "out-of-scope")
+        self.assertEqual(up.calls, 0, "an out-of-scope release must cost no API calls")
+
+    def test_a_green_release_build_makes_a_target_verified(self):
+        sha = "3e44c028b2ba2a681c40cbeefb5bded4d637120a"
+        row = self.row("v4.34.0-rc1", FakeUpstream(verify={sha: "success"}))
+        self.assertEqual(row["status"], "verified")
+
+    def test_a_red_release_build_blocks_without_claiming_it_cannot_be_built(self):
+        sha = "3e44c028b2ba2a681c40cbeefb5bded4d637120a"
+        row = self.row("v4.34.0-rc1", FakeUpstream(verify={sha: "failure"}))
+        self.assertEqual(row["status"], "blocked")
+        self.assertIn("not the same as", row["reason"])
+
+    def test_an_existing_tag_is_judged_by_its_own_pins(self):
+        sha = "3e44c028b2ba2a681c40cbeefb5bded4d637120a"
+        up = FakeUpstream(repo_tags={"v4.34.0-rc1": sha},
+                          pins={sha: ("leanprover/lean4:v4.34.0-rc1",
+                                      REAL_TAGS["v4.34.0-rc1"])})
+        self.assertEqual(self.row("v4.34.0-rc1", up)["status"], "tagged")
+
+    def test_a_tag_on_a_deleted_release_branch_stays_tagged(self):
+        # Judging a tag by re-deriving today's target would call this a mismatch the
+        # moment the release branch is deleted, which is a harmless piece of tidying.
+        sha = "c" * 40
+        up = FakeUpstream(repo_tags={"v4.33.0": sha},
+                          pins={sha: ("leanprover/lean4:v4.33.0", REAL_TAGS["v4.33.0"])})
+        self.assertEqual(self.row("v4.33.0", up)["status"], "tagged")
+
+    def test_an_inexact_tag_is_accepted_when_its_pin_descends_from_the_release(self):
+        sha = REAL_SEGMENTS_RAW[0][4]
+        up = FakeUpstream(repo_tags={"v4.31.0-rc1": sha},
+                          pins={sha: ("leanprover/lean4:v4.31.0-rc1",
+                                      REAL_SEGMENTS_RAW[0][3])})
+        row = self.row("v4.31.0-rc1", up)
+        self.assertEqual(row["status"], "tagged")
+        self.assertFalse(row["exact"])
+
+    def test_a_tag_on_the_wrong_toolchain_is_blocked_and_never_moved(self):
+        sha = "d" * 40
+        up = FakeUpstream(repo_tags={"v4.33.0": sha},
+                          pins={sha: ("leanprover/lean4:v4.34.0-rc1", REAL_TAGS["v4.33.0"])})
+        row = self.row("v4.33.0", up)
+        self.assertEqual(row["status"], "blocked")
+        recipe = tt.recipe_for(row) or ""
+        for forbidden in ("--force", "tag -d", " -f "):
+            self.assertNotIn(forbidden, recipe)
+
+
+# --- the release commit's two files ------------------------------------------
+
+class ManifestLayout(unittest.TestCase):
+    def test_round_trips_this_repository_s_own_manifest_byte_for_byte(self):
+        # The renderer reproduces Lake's layout from the bytes rather than from a
+        # guess, so if Lake ever changes it this fails instead of the tool emitting a
+        # whole-file diff on every release commit.
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        with open(os.path.join(root, "lake-manifest.json")) as handle:
+            text = handle.read()
+        self.assertEqual(tt.render_manifest(tt.parse_manifest(text)), text)
+
+    def test_round_trips_the_fixtures(self):
+        for text in (BASE_MANIFEST, MATHLIB_MANIFEST):
+            self.assertEqual(tt.render_manifest(tt.parse_manifest(text)), text)
+
+
+class DeriveManifest(unittest.TestCase):
+    def derived(self):
+        return tt.parse_manifest(tt.derive_manifest(BASE_MANIFEST, MATHLIB_MANIFEST, M33))
+
+    def test_mathlib_comes_first_and_only_its_rev_changes(self):
+        pkg = self.derived()["packages"][0]
+        base = tt.parse_manifest(BASE_MANIFEST)["packages"][0]
+        self.assertEqual(pkg["name"], "mathlib")
+        self.assertEqual(pkg["rev"], M33)
+        for key in ("url", "scope", "configFile", "inputRev", "inherited", "subDir"):
+            self.assertEqual(pkg[key], base[key], key)
+
+    def test_dependencies_are_mathlib_s_own_normalised_to_inherited(self):
+        out = self.derived()
+        deps = {p["name"]: p for p in out["packages"] if p["name"] != "mathlib"}
+        upstream = {p["name"]: p for p in tt.parse_manifest(MATHLIB_MANIFEST)["packages"]}
+        self.assertEqual(set(deps), set(upstream))
+        for name, pkg in deps.items():
+            self.assertTrue(pkg["inherited"], f"{name} is transitive from here")
+            for key in ("type", "url", "rev", "inputRev", "scope", "configFile"):
+                self.assertEqual(pkg[key], upstream[name][key], f"{name}.{key}")
+        self.assertEqual(list(deps["batteries"]), list(upstream["batteries"]),
+                         "normalising `inherited` must not reorder the keys")
+
+    def test_root_fields_are_ours_except_the_manifest_format_version(self):
+        out = self.derived()
+        base = tt.parse_manifest(BASE_MANIFEST)
+        self.assertEqual(out["name"], "TauCeti")
+        self.assertEqual(out["lakeDir"], base["lakeDir"])
+        self.assertEqual(out["fixedToolchain"], base["fixedToolchain"])
+        self.assertEqual(list(out), list(base), "root key order is preserved")
+        # `version` is Lake's manifest-format version, written by the Lake that ships
+        # with the target toolchain, so mathlib's copy at the tag is the current one.
+        self.assertEqual(out["version"], "1.3.0")
+
+    def test_it_satisfies_what_bump_guard_compares(self):
+        # check-bump.sh step 3 compares (type, normalised url, rev, inputRev) for every
+        # package except mathlib against mathlib's own manifest. Re-implemented here so
+        # the constructor cannot drift away from the guard that has to accept it.
+        def norm(url):
+            url = (url or "").rstrip("/")
+            return url[:-4] if url.endswith(".git") else url
+
+        def tup(pkg):
+            return (pkg.get("type"), norm(pkg.get("url")), pkg.get("rev"), pkg.get("inputRev"))
+
+        ours = {p["name"]: p for p in self.derived()["packages"] if p["name"] != "mathlib"}
+        theirs = {p["name"]: p for p in tt.parse_manifest(MATHLIB_MANIFEST)["packages"]}
+        self.assertEqual(set(ours), set(theirs))
+        for name in theirs:
+            self.assertEqual(tup(ours[name]), tup(theirs[name]), name)
+
+    def test_it_refuses_a_base_whose_nomination_is_not_master(self):
+        base = BASE_MANIFEST.replace('"inputRev": "master"', '"inputRev": "v4.33.0"', 1)
+        with self.assertRaises(ValueError):
+            tt.derive_manifest(base, MATHLIB_MANIFEST, M33)
+
+    def test_it_refuses_a_non_sha_rev_and_a_non_git_dependency(self):
+        with self.assertRaises(ValueError):
+            tt.derive_manifest(BASE_MANIFEST, MATHLIB_MANIFEST, "master")
+        upstream = MATHLIB_MANIFEST.replace('"type": "git"', '"type": "path"', 1)
+        with self.assertRaises(ValueError):
+            tt.derive_manifest(BASE_MANIFEST, upstream, M33)
+
+    def test_it_refuses_an_upstream_manifest_that_contains_mathlib(self):
+        upstream = MATHLIB_MANIFEST.replace('"name": "batteries"', '"name": "mathlib"', 1)
+        with self.assertRaises(ValueError):
+            tt.derive_manifest(BASE_MANIFEST, upstream, M33)
+
+
+class DeriveToolchain(unittest.TestCase):
+    def test_content_and_trailing_newline_convention(self):
+        # This repository's lean-toolchain has no trailing newline and mathlib's does.
+        # Matching mathlib would add a whitespace-only diff for nothing; bump-guard
+        # strips whitespace when it compares, so both are valid and the minimal diff wins.
+        self.assertEqual(tt.derive_toolchain("leanprover/lean4:v4.32.0", "v4.33.0"),
+                         "leanprover/lean4:v4.33.0")
+        self.assertEqual(tt.derive_toolchain("leanprover/lean4:v4.32.0\n", "v4.33.0"),
+                         "leanprover/lean4:v4.33.0\n")
+
+
+class WriteReleaseFiles(unittest.TestCase):
+    def test_writes_exactly_two_files_with_the_derived_content(self):
+        up = FakeUpstream()
+        base = EXPECTED_BASES["v4.33.0"]
+        with tempfile.TemporaryDirectory() as directory:
+            original = tt.blob_at
+            tt.blob_at = lambda sha, path: (BASE_MANIFEST if path.endswith(".json")
+                                            else "leanprover/lean4:v4.33.0-rc2")
+            try:
+                written = tt.write_release_files(directory, "v4.33.0", M33, base, up)
+            finally:
+                tt.blob_at = original
+            self.assertEqual(sorted(os.listdir(directory)),
+                             ["lake-manifest.json", "lean-toolchain"])
+            self.assertEqual(len(written), 2)
+            with open(os.path.join(directory, "lean-toolchain")) as handle:
+                self.assertEqual(handle.read(), "leanprover/lean4:v4.33.0")
+            with open(os.path.join(directory, "lake-manifest.json")) as handle:
+                manifest = tt.parse_manifest(handle.read())
+            self.assertEqual(manifest["packages"][0]["rev"], M33)
+
+    def test_it_refuses_a_tag_that_does_not_name_the_toolchain_it_claims(self):
+        class Mislabelled(FakeUpstream):
+            def toolchain_at(self, sha):
+                return "leanprover/lean4:v4.32.0"
+
+        with tempfile.TemporaryDirectory() as directory:
+            original = tt.blob_at
+            tt.blob_at = lambda sha, path: (BASE_MANIFEST if path.endswith(".json")
+                                            else "leanprover/lean4:v4.33.0-rc2")
+            try:
+                with self.assertRaises(RuntimeError):
+                    tt.write_release_files(directory, "v4.33.0", M33, "base", Mislabelled())
+            finally:
+                tt.blob_at = original
+
+
+# --- tag metadata ------------------------------------------------------------
+
+class TagMetadata(unittest.TestCase):
+    def row(self, release="v4.33.0", exact=True, distance=None):
+        return {"release": release, "toolchain": tt.toolchain_for(release),
+                "mathlib_rev": REAL_TAGS[release], "target_sha": "e" * 40,
+                "target_kind": "release-branch", "exact": exact, "distance": distance}
+
+    def test_round_trips_through_the_marker(self):
+        meta = tt.parse_tag_message(tt.tag_message(self.row()))
+        self.assertEqual(meta["release"], "v4.33.0")
+        self.assertEqual(meta["mathlib_rev"], REAL_TAGS["v4.33.0"])
+        self.assertTrue(meta["exact"])
+
+    def test_an_inexact_tag_records_its_distance_in_both_forms(self):
+        message = tt.tag_message(self.row("v4.31.0-rc1", exact=False, distance=83))
+        self.assertIn("no, 83 mathlib commits past the tag", message)
+        self.assertEqual(tt.parse_tag_message(message)["distance"], 83)
+
+    def test_a_marker_quoted_earlier_in_the_body_is_not_the_marker(self):
+        # Anchored to the end, as stuck_alerts does, so a message that discusses a
+        # marker cannot be read as carrying one.
+        real = tt.tag_message(self.row())
+        decoy = '<!--tauceti-toolchain-tag:v1 {"release": "v9.9.9"}-->\n\n' + real
+        self.assertEqual(tt.parse_tag_message(decoy)["release"], "v4.33.0")
+
+    def test_a_malformed_marker_is_no_marker(self):
+        self.assertIsNone(tt.parse_tag_message("nothing here"))
+        self.assertIsNone(tt.parse_tag_message("<!--tauceti-toolchain-tag:v1 {not json}-->"))
+
+
+# --- the stepping stone ------------------------------------------------------
+
+class SteppingStone(unittest.TestCase):
+    def segments_pinned_at(self, release, rev):
+        segs = segments()
+        segs[-1] = dict(segs[-1], toolchain=tt.toolchain_for(release), mathlib_rev=rev)
+        return segs
+
+    def test_it_names_the_release_the_bump_would_hop_over(self):
+        # main sits on v4.33.0-rc2 while the bump target has reached v4.34.0-rc1, so
+        # the next stone is v4.33.0: the release in between that main never pinned.
+        segs = self.segments_pinned_at("v4.33.0-rc2", REAL_TAGS["v4.33.0-rc2"])
+        up = FakeUpstream()
+        self.assertEqual(tt.next_stepping_stone(segs, up, REAL_TAGS["v4.34.0-rc1"]),
+                         REAL_TAGS["v4.33.0"])
+
+    def test_it_names_the_smallest_uncrossed_release_first(self):
+        segs = self.segments_pinned_at("v4.33.0-rc1", REAL_TAGS["v4.33.0-rc1"])
+        up = FakeUpstream()
+        self.assertEqual(tt.next_stepping_stone(segs, up, REAL_TAGS["v4.34.0-rc1"]),
+                         REAL_TAGS["v4.33.0-rc2"])
+
+    def test_nothing_to_do_when_the_target_is_where_main_already_is(self):
+        segs = self.segments_pinned_at("v4.34.0-rc1", REAL_TAGS["v4.34.0-rc1"])
+        self.assertIsNone(tt.next_stepping_stone(segs, FakeUpstream(),
+                                                 REAL_TAGS["v4.34.0-rc1"]))
+
+    def test_it_never_proposes_a_stable_branch_patch_release(self):
+        # bump-guard requires the new rev to be on the nominated branch, so a stone
+        # pinning v4.32.1 could never merge. Those are backfill-only by construction.
+        segs = self.segments_pinned_at("v4.32.0", REAL_TAGS["v4.32.0"])
+        stone = tt.next_stepping_stone(segs, FakeUpstream(), REAL_TAGS["v4.33.0"])
+        self.assertNotIn(stone, (REAL_TAGS["v4.32.1"], REAL_TAGS["v4.32.2"]))
+        self.assertEqual(stone, REAL_TAGS["v4.33.0-rc1"])
+
+
+# --- the report --------------------------------------------------------------
+
+class Report(unittest.TestCase):
+    def rows(self):
+        return tt.audit(segments(), FakeUpstream())
+
+    def test_the_policy_is_part_of_the_output(self):
+        text = tt.render_audit(self.rows())
+        for phrase in ("Tau Ceti toolchain tags", "exact", "inexact",
+                       "Tags are NEVER moved", "release-tag.yml"):
+            self.assertIn(phrase, text)
+
+    def test_out_of_scope_releases_are_collapsed_unless_asked_for(self):
+        # mathlib carries about ninety tags that predate this repository. Reading past
+        # them to reach the actionable rows is the whole cost of the report.
+        old = ["v4.20.0", "v4.21.0"]
+        up = FakeUpstream(tags=dict(REAL_TAGS, **{name: "b" * 40 for name in old}))
+        rows = tt.audit(segments(), up)
+
+        def row_names(text):
+            return {line.split()[0] for line in text.splitlines() if line.startswith("v4.")}
+
+        collapsed = tt.render_table(rows)
+        self.assertFalse(row_names(collapsed) & set(old))
+        self.assertIn("predate this repository", collapsed)
+        self.assertTrue(set(old) <= row_names(tt.render_table(rows, show_all=True)))
+
+    def test_every_actionable_release_gets_an_actionable_recipe(self):
+        for row in tt.actionable(self.rows()):
+            with self.subTest(release=row["release"]):
+                recipe = tt.recipe_for(row)
+                self.assertTrue(recipe, f"{row['release']} has no recipe")
+                if row["status"] == "needs-branch":
+                    self.assertIn(row["base_sha"], recipe)
+                    self.assertIn(row["branch"], recipe)
+                    self.assertIn("--write", recipe)
+                elif row["status"] != "blocked":
+                    self.assertIn(row["target_sha"], recipe)
+                    self.assertIn("gh workflow run release-tag.yml", recipe)
+
+    def test_no_recipe_ever_moves_or_deletes_a_tag(self):
+        # `gh workflow run -f field=value` is fine; what must never appear is anything
+        # that could move or remove a published tag.
+        text = tt.render_audit(self.rows())
+        for forbidden in ("--force", "tag -f", "tag -d", "push --delete", "update-ref -d"):
+            self.assertNotIn(forbidden, text)
+
+    def test_the_json_worklist_is_one_terminal_status_per_release(self):
+        rows = json.loads(tt.rows_to_json(self.rows()))
+        self.assertEqual(len(rows), len({r["release"] for r in rows}))
+        for row in rows:
+            self.assertIn(row["status"], tt.STATUSES)
+            for key in ("release", "toolchain", "mathlib_rev", "status", "exact"):
+                self.assertIn(key, row)
+
+    def test_the_audit_reaches_the_network_only_through_Upstream(self):
+        # `_distance` once called `gh api` directly, so every audit in this file was
+        # quietly doing real network round trips. Anything that bypasses `Upstream` is
+        # both untestable offline and invisible to the request budget.
+        with routed({}) as fake:
+            tt.audit(segments(), FakeUpstream())
+            self.assertEqual(fake.requests, [])
+
+    def test_the_report_reproduces_the_eleven_in_scope_releases(self):
+        rows = [r for r in self.rows() if r["status"] != "out-of-scope"]
+        self.assertEqual(len(rows), 11)
+        counts = {}
+        for row in rows:
+            counts[row["status"]] = counts.get(row["status"], 0) + 1
+        self.assertEqual(counts, {"ready": 5, "needs-branch": 6})
+        self.assertEqual([r["release"] for r in rows if not r["exact"]], ["v4.31.0-rc1"])
+
+
+# --- the request budget and the cache ----------------------------------------
+
+class RequestBudget(unittest.TestCase):
+    """The perf design, written as a test: reading a pin per commit rather than per
+    segment, or querying a tag per release rather than a namespace at a time, is the
+    regression that turns a seconds-long report into a minutes-long one."""
+
+    ROUTES = {
+        "repos/leanprover-community/mathlib4/git/matching-refs/tags/v":
+            "refs/tags/v4.33.0\t" + REAL_TAGS["v4.33.0"] + "\tcommit\n",
+        "repos/TauCetiProject/TauCeti/git/matching-refs/tags/v": "",
+        "repos/TauCetiProject/TauCeti/git/matching-refs/heads/releases/": "",
+        "repos/TauCetiProject/TauCeti/actions/workflows/": "",
+        "repos/leanprover-community/mathlib4/compare/": "ahead",
+        "repos/leanprover-community/mathlib4/git/commits/":
+            REAL_TAGS["v4.33.0-rc2"],
+        "repos/leanprover-community/mathlib4/contents/lean-toolchain":
+            "bGVhbnByb3Zlci9sZWFuNDp2NC4zMy4wCg==",
+    }
+
+    def test_a_whole_audit_stays_inside_its_budget(self):
+        with routed(self.ROUTES) as fake:
+            up = tt.Upstream(cache=tt.Cache(path=os.devnull))
+            tt.audit(segments(), up)
+            self.assertLess(len(fake.requests), 60,
+                            f"{len(fake.requests)} requests: something is querying per "
+                            "commit or per release where it should batch")
+
+    def test_the_tag_and_branch_namespaces_are_each_one_request(self):
+        with routed(self.ROUTES) as fake:
+            up = tt.Upstream(cache=tt.Cache(path=os.devnull))
+            tt.audit(segments(), up)
+            for prefix in ("repos/TauCetiProject/TauCeti/git/matching-refs/tags/v",
+                           "repos/TauCetiProject/TauCeti/git/matching-refs/heads/releases/"):
+                hits = [p for p in fake.requests if p.startswith(prefix)]
+                self.assertEqual(len(hits), 1, prefix)
+
+    def test_an_unrecognised_request_shape_is_a_failure(self):
+        with routed({}) as fake:
+            with self.assertRaises(RuntimeError):
+                tt.Upstream(cache=tt.Cache(path=os.devnull)).release_tags()
+            self.assertTrue(fake.requests)
+
+
+class CacheBehaviour(unittest.TestCase):
+    def test_round_trip_and_flush(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "sub", "cache.json")
+            cache = tt.Cache(path=path)
+            cache.put(("toolchain", "abc"), "leanprover/lean4:v4.33.0")
+            cache.flush()
+            self.assertEqual(tt.Cache(path=path).get(("toolchain", "abc")),
+                             "leanprover/lean4:v4.33.0")
+
+    def test_a_corrupt_or_unwritable_cache_is_ignored_rather_than_fatal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "cache.json")
+            with open(path, "w") as handle:
+                handle.write("{not json")
+            cache = tt.Cache(path=path)
+            self.assertIsNone(cache.get(("toolchain", "abc")))
+            cache.put(("toolchain", "abc"), "x")
+            cache.flush()  # must not raise
+
+    def test_immutable_facts_are_cached_and_a_moving_ref_is_not(self):
+        routes = dict(RequestBudget.ROUTES)
+        with routed(routes) as fake:
+            up = tt.Upstream(cache=tt.Cache(path=os.devnull))
+            up.toolchain_at("abc")
+            up.toolchain_at("abc")
+            contents = [p for p in fake.requests if "contents/lean-toolchain" in p]
+            self.assertEqual(len(contents), 1, "an immutable blob was fetched twice")
+            up.compare("abc", "master")
+            up.compare("abc", "master")
+            compares = [p for p in fake.requests if "/compare/" in p]
+            self.assertEqual(len(compares), 2, "a moving ref must not be cached")
+
+
+# --- Zulip -------------------------------------------------------------------
+
+class FakeZulip:
+    def __init__(self, messages=None, bot_id=7):
+        self.messages = list(messages or [])
+        self.bot_id = bot_id
+        self.sent = []
+        self.updated = []
+
+    def my_user_id(self):
+        return self.bot_id
+
+    def get_messages(self, narrow):
+        return self.messages
+
+    def send_message(self, content):
+        self.sent.append(content)
+        return len(self.sent)
+
+    def update_message(self, message_id, content):
+        self.updated.append((message_id, content))
+
+
+class Alerts(unittest.TestCase):
+    def alert(self, key="needs-branch/v4.33.0", title="t", body="b"):
+        return {"key": key, "title": title, "body": body}
+
+    def msg(self, alert, ident=1, sender=7, resolved=False):
+        content = (tt.resolved_content(alert["key"], alert["title"]) if resolved
+                   else tt.alert_content(alert))
+        return {"id": ident, "sender_id": sender, "content": content}
+
+    def test_a_new_alert_is_posted(self):
+        z = FakeZulip()
+        tt.reconcile(z, [self.alert()], set(), dry_run=False)
+        self.assertEqual(len(z.sent), 1)
+
+    def test_an_unchanged_alert_is_left_alone(self):
+        alert = self.alert()
+        z = FakeZulip([self.msg(alert)])
+        tt.reconcile(z, [alert], set(), dry_run=False)
+        self.assertEqual((z.sent, z.updated), ([], []))
+
+    def test_a_changed_alert_is_edited(self):
+        alert = self.alert()
+        z = FakeZulip([self.msg(alert)])
+        tt.reconcile(z, [self.alert(body="different")], set(), dry_run=False)
+        self.assertEqual(len(z.updated), 1)
+        self.assertEqual(z.sent, [])
+
+    def test_a_cleared_alert_is_edited_to_the_resolved_form(self):
+        alert = self.alert()
+        z = FakeZulip([self.msg(alert)])
+        tt.reconcile(z, [], set(), dry_run=False)
+        self.assertEqual(len(z.updated), 1)
+        self.assertTrue(z.updated[0][1].lstrip().startswith(tt.GREEN))
+
+    def test_a_recurrence_posts_afresh_rather_than_editing_a_buried_tick(self):
+        alert = self.alert()
+        z = FakeZulip([self.msg(alert, resolved=True)])
+        tt.reconcile(z, [alert], set(), dry_run=False)
+        self.assertEqual(len(z.sent), 1)
+        self.assertEqual(z.updated, [])
+
+    def test_a_failed_classification_resolves_nothing(self):
+        # Fail closed: a run that could not work out the state must never report that
+        # an outstanding release is now fine.
+        alert = self.alert()
+        z = FakeZulip([self.msg(alert)])
+        tt.reconcile(z, [], {"needs-branch"}, dry_run=False)
+        self.assertEqual(z.updated, [])
+
+    def test_dry_run_touches_nothing(self):
+        z = FakeZulip()
+        tt.reconcile(z, [self.alert()], set(), dry_run=True)
+        self.assertEqual((z.sent, z.updated), ([], []))
+
+    def test_only_outstanding_releases_alert(self):
+        rows = tt.audit(segments(), FakeUpstream())
+        keys = {a["key"] for a in tt.alerts_from(rows, FakeUpstream())}
+        self.assertTrue(keys)
+        self.assertFalse([k for k in keys if k.startswith(("tagged", "out-of-scope"))])
+
+    def test_a_release_inside_its_grace_period_does_not_alert_yet(self):
+        import datetime
+
+        class Fresh(FakeUpstream):
+            def committed_at(self, sha):
+                return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        rows = tt.audit(segments(), FakeUpstream())
+        self.assertEqual(tt.alerts_from(rows, Fresh()), [])
+
+
+# --- the command line --------------------------------------------------------
+
+class CommandLine(unittest.TestCase):
+    def test_the_modes_are_mutually_exclusive(self):
+        parser = tt.build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["--audit", "--alert"])
+
+    def test_write_requires_a_release(self):
+        parser = tt.build_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["--write"])
+
+    def test_audit_is_the_default_mode(self):
+        args = tt.build_parser().parse_args([])
+        self.assertFalse(args.alert)
+        self.assertIsNone(args.write)
+
+    def test_help_carries_the_policy_so_it_documents_itself(self):
+        self.assertIn("Tau Ceti toolchain tags", tt.build_parser().format_help())
+
+    def test_strict_reports_blocked_releases_through_the_exit_code(self):
+        args = tt.build_parser().parse_args(["--audit", "--strict", "--json"])
+        blocked = [dict(r, status="blocked") for r in tt.audit(segments(), FakeUpstream())[:1]]
+        original = tt.audit
+        tt.audit = lambda *a, **k: blocked
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(tt._run_audit(args, segments(), FakeUpstream()), 1)
+                tt.audit = lambda *a, **k: [dict(blocked[0], status="tagged")]
+                self.assertEqual(tt._run_audit(args, segments(), FakeUpstream()), 0)
+        finally:
+            tt.audit = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -222,13 +222,14 @@ class FakeUpstream:
     exactly as the real ones do."""
 
     def __init__(self, tags=None, repo_tags=None, branches=None, verify=None,
-                 bump_commits=None, pins=None):
+                 bump_commits=None, pins=None, shapes=None):
         self.tags = dict(tags or REAL_TAGS)
         self.by_sha = {sha: name for name, sha in self.tags.items()}
         self.repo_tags = dict(repo_tags or {})
         self.branches = dict(branches or {})
         self.verify = dict(verify or {})
         self.pins = dict(pins or {})
+        self.shapes = dict(shapes or {})
         self.bump_commits = (set(self.tags) if bump_commits is None else set(bump_commits))
         self.calls = 0
         self._toolchain_of = {}
@@ -298,6 +299,10 @@ class FakeUpstream:
     def verify_conclusion(self, sha):
         self.calls += 1
         return self.verify.get(sha)
+
+    def release_branch_shape(self, head):
+        self.calls += 1
+        return self.shapes.get(head, (True, None))
 
     def repo_pin_at(self, sha):
         self.calls += 1
@@ -605,6 +610,39 @@ class Classification(unittest.TestCase):
         self.assertEqual(row["status"], "branch-ready")
         self.assertEqual(row["target_sha"], head)
         self.assertEqual(row["target_kind"], "release-branch")
+
+    def test_a_release_branch_carrying_more_than_the_pins_is_not_a_target(self):
+        # Right pins, wrong shape. A commit that also changes source would otherwise be
+        # nominated as a permanent tag target; the release workflow would refuse it later,
+        # but the audit should not be pointing at it in the meantime.
+        head = "a" * 40
+        up = FakeUpstream(branches={"v4.33.0": head},
+                          pins={head: ("leanprover/lean4:v4.33.0", REAL_TAGS["v4.33.0"])},
+                          shapes={head: (False, "changes TauCeti/Foo.lean, which is outside "
+                                                "the two Lake pins")})
+        row = self.row("v4.33.0", up)
+        self.assertEqual(row["status"], "blocked")
+        self.assertIn("outside the two Lake pins", row["reason"])
+
+    def test_an_unreadable_release_branch_is_not_called_wrong(self):
+        # A blinking API is not a verdict, and must not produce advice to re-cut a branch
+        # that may be perfectly correct.
+        head = "a" * 40
+        up = FakeUpstream(branches={"v4.33.0": head})   # no pins recorded: repo_pin_at raises
+        row = self.row("v4.33.0", up)
+        self.assertEqual(row["status"], "blocked")
+        self.assertIn("could not be read", row["reason"])
+        self.assertNotIn("re-cut", row["reason"])
+
+    def test_a_tag_is_not_judged_against_a_branch_that_has_since_moved(self):
+        # A permanent tag compared with a mutable branch head would start reading as a
+        # mismatch the moment someone re-cut the branch onto another exact-pin commit.
+        tagged, moved = "b" * 40, "c" * 40
+        pins = {sha: ("leanprover/lean4:v4.33.0", REAL_TAGS["v4.33.0"])
+                for sha in (tagged, moved)}
+        up = FakeUpstream(branches={"v4.33.0": moved}, pins=pins,
+                          repo_tags={"v4.33.0": tagged})
+        self.assertEqual(self.row("v4.33.0", up)["status"], "tagged")
 
     def test_a_release_branch_pointing_anywhere_is_not_a_target(self):
         # Creating `releases/vX` at an arbitrary commit must not make that commit the

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -640,6 +640,18 @@ class Classification(unittest.TestCase):
         self.assertEqual(row["status"], "tagged")
         self.assertFalse(row["exact"])
 
+    def test_a_tag_on_the_wrong_commit_of_an_exact_run_is_blocked(self):
+        # The policy word is "first". A tag placed on a later commit of the same run, or on
+        # main's tip, has the right toolchain and a pin at or after the release, so a check
+        # that asked only those questions would bless a permanent tag on the wrong commit.
+        wrong = REAL_SEGMENTS_RAW[-1][5]
+        up = FakeUpstream(repo_tags={"v4.34.0-rc1": wrong},
+                          pins={wrong: ("leanprover/lean4:v4.34.0-rc1",
+                                        REAL_SEGMENTS_RAW[-1][3])})
+        row = self.row("v4.34.0-rc1", up)
+        self.assertEqual(row["status"], "blocked")
+        self.assertIn("policy names", row["reason"])
+
     def test_a_tag_on_the_wrong_toolchain_is_blocked_and_never_moved(self):
         sha = "d" * 40
         up = FakeUpstream(repo_tags={"v4.33.0": sha},
@@ -1080,6 +1092,25 @@ class Alerts(unittest.TestCase):
         z = FakeZulip()
         tt.reconcile(z, [self.alert()], set(), dry_run=True)
         self.assertEqual((z.sent, z.updated), ([], []))
+
+    def test_the_alert_key_survives_a_change_of_status(self):
+        # needs-branch -> branch-ready is progress, not resolution. Keying on the status
+        # retired the old key, and the reconciler then edited the original message to a
+        # green tick for a release that was still untagged.
+        rows = tt.audit(segments(), FakeUpstream())
+        before = {a["key"] for a in tt.alerts_from(rows, FakeUpstream())}
+        moved = [dict(r, status="branch-ready", target_sha="a" * 40)
+                 if r["status"] == "needs-branch" else r for r in rows]
+        after = {a["key"] for a in tt.alerts_from(moved, FakeUpstream())}
+        self.assertEqual(before, after)
+
+    def test_a_built_but_untagged_release_still_alerts(self):
+        # `verified` is the state where the expensive part is done and only the one cheap
+        # irreversible step is missing. Silencing it let a release sit built and untagged
+        # for ever with the workflow green.
+        rows = [dict(r, status="verified") for r in tt.audit(segments(), FakeUpstream())
+                if r["status"] == "ready"][:1]
+        self.assertTrue(tt.alerts_from(rows, FakeUpstream()))
 
     def test_only_outstanding_releases_alert(self):
         rows = tt.audit(segments(), FakeUpstream())

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -634,6 +634,19 @@ class Classification(unittest.TestCase):
         self.assertIn("could not be read", row["reason"])
         self.assertNotIn("re-cut", row["reason"])
 
+    def test_a_tag_on_an_off_main_commit_of_the_wrong_shape_is_blocked(self):
+        # Declining to compare a release-branch tag with a branch that may have moved must
+        # not leave the tagged commit unchecked: an arbitrary off-main commit with the right
+        # two pins would otherwise read back as done, permanently.
+        tagged = "d" * 40
+        up = FakeUpstream(repo_tags={"v4.33.0": tagged},
+                          pins={tagged: ("leanprover/lean4:v4.33.0", REAL_TAGS["v4.33.0"])},
+                          shapes={tagged: (False, "changes TauCeti/Foo.lean, which is "
+                                                  "outside the two Lake pins")})
+        row = self.row("v4.33.0", up)
+        self.assertEqual(row["status"], "blocked")
+        self.assertIn("outside the two Lake pins", row["reason"])
+
     def test_a_tag_is_not_judged_against_a_branch_that_has_since_moved(self):
         # A permanent tag compared with a mutable branch head would start reading as a
         # mismatch the moment someone re-cut the branch onto another exact-pin commit.

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -301,6 +301,10 @@ class FakeUpstream:
 
     def repo_pin_at(self, sha):
         self.calls += 1
+        if sha not in self.pins:
+            # As the real one does when the API cannot read the commit. Returning something
+            # bland here would let a test pass without ever supplying the facts under test.
+            raise RuntimeError(f"no pins recorded for {sha}")
         return self.pins[sha]
 
     def manifest_at(self, sha):
@@ -459,6 +463,14 @@ class SegmentWalk(unittest.TestCase):
     def test_real_history_is_monotone(self):
         tt.assert_monotone(segments())
 
+    def test_an_unorderable_toolchain_fails_closed(self):
+        # The waiver for non-release toolchains was the one case the binary search cannot
+        # survive: the fast path's predicate goes false in the middle of the run.
+        segs = segments()[:3]
+        segs[1] = dict(segs[1], toolchain="leanprover/lean4:nightly-2026-01-01")
+        with self.assertRaises(RuntimeError):
+            tt.assert_monotone(segs)
+
     def test_a_backward_toolchain_move_fails_closed(self):
         # Base derivation binary-searches on monotonicity. If main ever moved backward
         # the search would return a silently wrong base, so this must raise.
@@ -587,11 +599,23 @@ class Classification(unittest.TestCase):
 
     def test_an_existing_release_branch_becomes_the_target(self):
         head = "a" * 40
-        up = FakeUpstream(branches={"v4.33.0": head})
+        up = FakeUpstream(branches={"v4.33.0": head},
+                          pins={head: ("leanprover/lean4:v4.33.0", REAL_TAGS["v4.33.0"])})
         row = self.row("v4.33.0", up)
         self.assertEqual(row["status"], "branch-ready")
         self.assertEqual(row["target_sha"], head)
         self.assertEqual(row["target_kind"], "release-branch")
+
+    def test_a_release_branch_pointing_anywhere_is_not_a_target(self):
+        # Creating `releases/vX` at an arbitrary commit must not make that commit the
+        # permanent tag target. The release workflow's own checker would refuse it later,
+        # but the audit should not be naming it in the meantime.
+        head = "a" * 40
+        up = FakeUpstream(branches={"v4.33.0": head},
+                          pins={head: ("leanprover/lean4:v4.33.0", "9" * 40)})
+        row = self.row("v4.33.0", up)
+        self.assertEqual(row["status"], "blocked")
+        self.assertIn("re-cut it", row["reason"])
 
     def test_the_inexact_rung_is_used_only_when_no_base_exists(self):
         row = self.row("v4.31.0-rc1")
@@ -939,6 +963,47 @@ class Report(unittest.TestCase):
 
 
 # --- the request budget and the cache ----------------------------------------
+
+class RefNamespaces(unittest.TestCase):
+    """The query prefix and the ref namespace are different things.
+
+    Querying `tags/v` and then stripping `refs/tags/v` keyed every tag without its leading
+    `v`, so every lookup missed and every existing tag was reported absent for ever. The
+    request-budget fake returned an empty tag namespace, which is precisely why no test
+    noticed."""
+
+    ROUTES = {
+        "repos/TauCetiProject/TauCeti/git/matching-refs/tags/v":
+            "refs/tags/v4.33.0\tdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tcommit\n"
+            "refs/tags/v4.34.0-rc1\tcafebabecafebabecafebabecafebabecafebabe\ttag\n",
+        "repos/TauCetiProject/TauCeti/git/matching-refs/heads/releases/":
+            "refs/heads/releases/v4.33.0\tfeedfacefeedfacefeedfacefeedfacefeedface\tcommit\n",
+        "repos/TauCetiProject/TauCeti/git/tags/":
+            "1111111111111111111111111111111111111111",
+    }
+
+    def test_a_lightweight_tag_is_found_under_its_own_name(self):
+        with routed(self.ROUTES):
+            up = tt.Upstream(cache=tt.Cache(path=os.devnull))
+            self.assertEqual(up.tag_target("v4.33.0"),
+                             "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+    def test_an_annotated_tag_is_peeled(self):
+        with routed(self.ROUTES):
+            up = tt.Upstream(cache=tt.Cache(path=os.devnull))
+            self.assertEqual(up.tag_target("v4.34.0-rc1"), "1" * 40)
+
+    def test_an_absent_tag_is_absent(self):
+        with routed(self.ROUTES):
+            up = tt.Upstream(cache=tt.Cache(path=os.devnull))
+            self.assertIsNone(up.tag_target("v4.31.0"))
+
+    def test_a_release_branch_is_found_under_its_short_name(self):
+        with routed(self.ROUTES):
+            up = tt.Upstream(cache=tt.Cache(path=os.devnull))
+            self.assertEqual(up.branch_head("releases/v4.33.0"),
+                             "feedfacefeedfacefeedfacefeedfacefeedface")
+
 
 class RequestBudget(unittest.TestCase):
     """The perf design, written as a test: reading a pin per commit rather than per

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -767,15 +767,24 @@ def _target_of(segments, release, mathlib_rev, up):
     return None, None, True, None, rule
 
 
-def _tag_is_valid(tag_sha, release, mathlib_rev, up):
+def _tag_is_valid(tag_sha, release, mathlib_rev, up, target=None, target_exact=True):
     """(ok, why-not, exact) for a tag that already exists.
 
-    Rung-aware: an exact tag pins the mathlib tag commit itself, an inexact one pins a
-    master descendant of it. Both must carry the release's own toolchain."""
+    Rung-aware, and it checks WHICH commit, not merely a plausible one. An earlier version
+    accepted any commit carrying the release's toolchain whose pin was at or after the
+    mathlib tag, which blessed a tag placed on the wrong commit of an exact run: the
+    policy's load-bearing word is "first", and a permanent tag on the wrong commit is
+    exactly the error this tool exists to prevent. So when policy can name a target, the
+    tag must be on it."""
     toolchain, pin = up.repo_pin_at(tag_sha)
     want = toolchain_for(release)
     if toolchain != want:
         return False, f"is on {toolchain or 'no toolchain'}, not {want}", True
+    if target and tag_sha != target:
+        return False, (f"is on {tag_sha[:8]}, but policy names {target[:8]}"), target_exact
+    if target_exact and pin != mathlib_rev:
+        return False, (f"pins mathlib {(pin or 'nothing')[:8]}, but an exact tag for "
+                       f"{release} pins {mathlib_rev[:8]}"), True
     if pin == mathlib_rev:
         return True, None, True
     if pin and up.is_ancestor(mathlib_rev, pin):
@@ -815,11 +824,12 @@ def classify(release, mathlib_rev, segments, up):
         # Judge an existing tag by the pins it actually carries, not by re-deriving
         # what policy would name today. Otherwise deleting a `releases/vX` branch
         # after tagging, which is harmless, would read as a tag mismatch.
-        ok, why, exact = _tag_is_valid(tag_sha, release, mathlib_rev, up)
+        ok, why, exact = _tag_is_valid(tag_sha, release, mathlib_rev, up,
+                                       target=target, target_exact=row["exact"])
         row["exact"] = exact
         if ok:
             row["status"] = "tagged"
-            row["target_sha"], row["target_kind"] = tag_sha, row["target_kind"]
+            row["target_sha"] = tag_sha
         else:
             row["status"] = "blocked"
             row["reason"] = (f"the tag at {tag_sha[:8]} {why}; a published tag is never "
@@ -1114,7 +1124,7 @@ def alerts_from(rows, up, now=None):
     now = now or datetime.datetime.now(datetime.timezone.utc)
     out = []
     for row in rows:
-        if row["status"] in ("tagged", "out-of-scope", "verified"):
+        if row["status"] in ("tagged", "out-of-scope"):
             continue
         if row["status"] != "blocked":
             try:
@@ -1126,7 +1136,11 @@ def alerts_from(rows, up, now=None):
                 continue
         title = f"{row['release']} has no toolchain tag ({row['status']})"
         body = zp.zulip_sanitize(recipe_for(row) or row["reason"] or "")
-        out.append({"key": f"{row['status']}/{row['release']}".lower(),
+        # Keyed on the RELEASE, not on its status. Keying on the status meant that an
+        # ordinary step forward, needs-branch to branch-ready, retired the old key and the
+        # reconciler edited the original message to a green tick for a release that was
+        # still untagged. The status belongs in the title, where it can change freely.
+        out.append({"key": f"toolchain-tag/{row['release']}".lower(),
                     "title": zp.zulip_sanitize(title), "body": body})
     return out
 
@@ -1262,7 +1276,7 @@ def _run_alert(args, segments, up):
         rows = audit(segments, up)
     except Exception as exc:  # fail closed: resolve nothing when the audit itself broke
         zp.log(f"audit failed (non-fatal): {exc}")
-        failed = set(STATUSES)
+        failed = {"toolchain-tag"}
     alerts = alerts_from(rows, up) if rows else []
     zp.log(f"{len(alerts)} outstanding release(s): {sorted(a['key'] for a in alerts)}")
 

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -868,6 +868,16 @@ def _tag_is_valid(tag_sha, release, mathlib_rev, up, target=None, target_exact=T
         # release branch is mutable: if it is later re-cut onto another exact-pin commit, a
         # correctly placed permanent tag would otherwise start reading as a mismatch.
         return False, (f"is on {tag_sha[:8]}, but policy names {target[:8]}"), target_exact
+    if target_kind != "main-commit":
+        # ...but declining to compare it with the branch must not leave the commit
+        # unchecked. Judge the tagged commit on its own shape, which is the property that
+        # made it taggable, rather than on a ref that has since moved.
+        shaped, why = up.release_branch_shape(tag_sha)
+        if shaped is None:
+            return False, f"is on {tag_sha[:8]}, whose shape could not be read ({why})", \
+                   target_exact
+        if not shaped:
+            return False, f"is on {tag_sha[:8]}, which {why}", target_exact
     if target_exact and pin != mathlib_rev:
         return False, (f"pins mathlib {(pin or 'nothing')[:8]}, but an exact tag for "
                        f"{release} pins {mathlib_rev[:8]}"), True

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -250,7 +250,12 @@ def assert_monotone(segments):
             continue
         ra, rb = release_of_toolchain(a), release_of_toolchain(b)
         if ra is None or rb is None:
-            continue  # a nightly or fork channel: unordered, not evidence of a move back
+            # Not "unordered, so ignore it". An unorderable toolchain makes the fast path's
+            # predicate false in the middle of the run, which is the non-monotone shape the
+            # binary search cannot survive, so it is the one case that must NOT be waived.
+            raise RuntimeError(
+                f"main's toolchain {a if ra is None else b!r} is not a Lean release, so the "
+                "segment order the base derivation binary-searches on is not defined")
         if release_lt(rb, ra):
             raise RuntimeError(
                 f"main's toolchain moved backward: {a} at {earlier['first_sha'][:8]} "
@@ -336,6 +341,7 @@ class Upstream:
         self.calls = 0
         self._repo_tags = None
         self._release_branches = None
+        self._verify_exists = None
 
     # ----- mathlib
 
@@ -461,16 +467,21 @@ class Upstream:
 
     # ----- this repository
 
-    def _matching_refs(self, prefix):
+    def _matching_refs(self, namespace, query=""):
         """{short name: (sha, object type)} for one `git/matching-refs` query.
 
-        One call for a whole namespace rather than one per release. Asking for eleven
-        tags individually is eleven round trips, and in a repository that has no tags
-        yet every one of them is a 404."""
+        One call for a whole namespace rather than one per release. Asking for eleven tags
+        individually is eleven round trips, and in a repository that has no tags yet every
+        one of them is a 404.
+
+        `namespace` is what gets stripped from the returned ref, `query` only narrows the
+        search. Conflating them is a real bug rather than a hypothetical: querying `tags/v`
+        and stripping `refs/tags/v` turned `refs/tags/v4.33.0` into the key `4.33.0`, while
+        every caller looks up `v4.33.0`, so every tag that existed was reported absent."""
         self.calls += 1
-        raw = _gh_optional(f"repos/{REPO}/git/matching-refs/{prefix}",
+        raw = _gh_optional(f"repos/{REPO}/git/matching-refs/{namespace}{query}",
                            jq='.[] | [.ref, .object.sha, .object.type] | @tsv') or ""
-        full = f"refs/{prefix}"
+        full = f"refs/{namespace}"
         out = {}
         for line in raw.splitlines():
             ref, sha, kind = line.split("\t")
@@ -479,7 +490,7 @@ class Upstream:
 
     def repo_tags(self):
         if self._repo_tags is None:
-            self._repo_tags = self._matching_refs("tags/v")
+            self._repo_tags = self._matching_refs("tags/", "v")
         return self._repo_tags
 
     def release_branches(self):
@@ -522,9 +533,24 @@ class Upstream:
         entry = self.release_branches().get(short)
         return entry[0] if entry else None
 
+    def verify_workflow_exists(self):
+        """Whether the release workflow is on the default branch at all.
+
+        Asked once, and separately, because the runs endpoint 404s both when the workflow
+        does not exist and when it exists but never ran on a commit. Reading those alike
+        made a missing release pipeline look like a pile of releases merely waiting to be
+        built."""
+        if self._verify_exists is None:
+            self.calls += 1
+            self._verify_exists = _gh_optional(
+                f"repos/{REPO}/actions/workflows/{VERIFY_WORKFLOW}") is not None
+        return self._verify_exists
+
     def verify_conclusion(self, sha):
-        """The newest conclusion of the release workflow on this commit, or None when
-        it has never run there. `None` means "not built yet", never "failed"."""
+        """The newest conclusion of the release workflow on this commit, or None when it
+        has never run there. `None` means "not built yet", never "failed"."""
+        if not self.verify_workflow_exists():
+            return None
         self.calls += 1
         raw = _gh_optional(
             f"repos/{REPO}/actions/workflows/{VERIFY_WORKFLOW}/runs"
@@ -616,20 +642,30 @@ def resolve_base(segments, release, mathlib_rev, up):
             return up.is_ancestor(usable[index]["mathlib_rev"], mathlib_rev)
 
     found = _last_true(len(usable), holds)
-    if found < 0:
-        return None, rule
-    base = usable[found]
-    # Verify the fast path's answer with one real ancestry query. The premise it rests
-    # on is an upstream habit rather than a contract, so the saving is worth one call
-    # but not the risk of trusting it unchecked.
-    if rule == "toolchain-fast-path" and not up.is_ancestor(base["mathlib_rev"], mathlib_rev):
+
+    def boundary_holds(index):
+        """Both sides of the answer, which is what makes it an answer.
+
+        Checking only that the chosen segment is an ancestor asks whether the base is
+        VALID, never whether it is the LAST valid one, and those come apart exactly when
+        the fast path's premise fails: if mathlib carried X, moved off it and came back,
+        earlier master commits also carry X and a later segment is a better base that the
+        toolchain comparison rejects. A too-early base means the release branch is cut from
+        a stale tree, permanently, so the successor must be checked too."""
+        if index >= 0 and not up.is_ancestor(usable[index]["mathlib_rev"], mathlib_rev):
+            return False
+        nxt = index + 1
+        if nxt < len(usable) and up.is_ancestor(usable[nxt]["mathlib_rev"], mathlib_rev):
+            return False
+        return True
+
+    if rule == "toolchain-fast-path" and not boundary_holds(found):
         rule = "ancestry-search"
         found = _last_true(len(usable), lambda i: up.is_ancestor(usable[i]["mathlib_rev"],
                                                                  mathlib_rev))
-        if found < 0:
-            return None, rule
-        base = usable[found]
-    return base, rule
+    if found < 0:
+        return None, rule
+    return usable[found], rule
 
 
 # --- the release commit's two files ------------------------------------------
@@ -750,7 +786,17 @@ def _target_of(segments, release, mathlib_rev, up):
     branch = RELEASE_BRANCH_FMT.format(release=release)
     head = up.branch_head(branch)
     if head:
-        return head, "release-branch", True, None, "release-branch"
+        # A branch in the right namespace is not evidence that its head is a release
+        # commit. Check the two facts that make it one before naming it as the target;
+        # scripts/check-release-commit.sh proves the rest (single parent, off a main
+        # ancestor, only the pin files changed) before anything is built from it.
+        try:
+            toolchain, pin = up.repo_pin_at(head)
+        except RuntimeError:
+            toolchain, pin = None, None
+        if toolchain == toolchain_for(release) and pin == mathlib_rev:
+            return head, "release-branch", True, None, "release-branch"
+        return None, "release-branch", True, None, "release-branch-invalid"
 
     base, rule = resolve_base(segments, release, mathlib_rev, up)
     if base is not None:
@@ -837,6 +883,12 @@ def classify(release, mathlib_rev, segments, up):
         return row
 
     if target is None:
+        if rule == "release-branch-invalid":
+            row["status"] = "blocked"
+            row["reason"] = (
+                f"{row['branch']} exists but its head does not pin mathlib {mathlib_rev[:8]} "
+                f"on {toolchain}; re-cut it from the base rather than tagging what is there")
+            return row
         if row["base_sha"]:
             # The base exists, so an exact release commit can be constructed; there is
             # simply no commit to name until someone does.
@@ -1017,8 +1069,13 @@ def recipe_for(row):
     return None
 
 
-def render_audit(rows, show_all=False):
+def render_audit(rows, show_all=False, verify_missing=False):
     parts = [POLICY_TEXT, "", render_table(rows, show_all), ""]
+    if verify_missing:
+        parts += [
+            f"NOTE: {VERIFY_WORKFLOW} is not on the default branch, so nothing can be built,",
+            "published or tagged yet and no release below can reach `verified`. The recipes",
+            "are correct but not yet runnable.", ""]
     recipes = [r for r in (recipe_for(row) for row in actionable(rows)) if r]
     if recipes:
         parts += ["Repairs", "-------", ""] + recipes
@@ -1246,7 +1303,7 @@ def _run_audit(args, segments, up):
     if args.json:
         print(rows_to_json(rows))
     else:
-        print(render_audit(rows, args.all))
+        print(render_audit(rows, args.all, not up.verify_workflow_exists()))
     if args.strict and any(r["status"] == "blocked" for r in rows):
         return 1
     return 0

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -1,0 +1,1346 @@
+#!/usr/bin/env python3
+"""Audit and materialise Tau Ceti's Lean toolchain tags (`v4.33.0`, `v4.33.0-rc2`, ...).
+
+Mathlib tags every Lean release, so a downstream project can check out mathlib at
+`v4.33.0` and get a tree that builds on Lean v4.33.0. This tool gives Tau Ceti the
+same thing, and audits which releases still lack one.
+
+## What a toolchain tag means
+
+For every Lean release `X` that Tau Ceti's history can reach, the tag `vX` points at
+the FIRST `main`-reachable commit whose `lean-toolchain` is exactly
+`leanprover/lean4:X` and whose mathlib pin is at or after mathlib's own `vX` tag
+commit `M`. The pin is, in order of preference:
+
+  1. exact -- `M` itself. The commit is either already on `main`, or is a single
+     commit on a `releases/vX` branch whose parent is a `main` commit and which
+     changes only `lake-manifest.json` and `lean-toolchain`.
+  2. inexact -- when no exact commit exists or the exact one will not compile, the
+     first `main` commit on toolchain `X`. The tag message records how many mathlib
+     commits past `M` the pin is.
+
+"First" is uniform across both rungs, and for the exact rung it is forced: a run of
+commits sharing a pin at the tip of `main` is open-ended, so "last" would want to
+move the tag every day, while "first" is immutable the moment the run begins.
+
+A tag is created only after a from-source build of that commit passes the audits and
+lints `main` runs and its oleans have been published. Tags are never moved: this tool
+never emits a recipe containing `-f`, `--force` or `tag -d`.
+
+## Usage
+
+    # the report, with repair instructions for every gap:
+    toolchain_tags.py --audit
+    toolchain_tags.py --audit --release v4.33.0
+    toolchain_tags.py --audit --json          # the canonical worklist
+    toolchain_tags.py --audit --strict        # exit 1 if any release is blocked
+
+    # what the daily bump should pin instead of the last-known-good commit:
+    toolchain_tags.py --next-stepping-stone
+
+    # materialise a release commit's two pin files into a worktree:
+    toolchain_tags.py --write v4.33.0 --dir .
+
+    # the annotated tag body, and the Zulip reconciler:
+    toolchain_tags.py --tag-message v4.33.0
+    toolchain_tags.py --alert [--dry-run]
+
+## Environment
+
+    GH_TOKEN / GITHUB_TOKEN   authenticates the `gh` CLI (all upstream reads)
+    GH_REPO                   this repository (default TauCetiProject/TauCeti)
+    MATHLIB_REPO              default leanprover-community/mathlib4
+    TOOLCHAIN_TAGS_CACHE      memo file for immutable upstream facts
+                              (default .git/tauceti/toolchain-tags-cache.json)
+    ZULIP_EMAIL, ZULIP_API_KEY, ZULIP_SITE, ZULIP_CHANNEL, ZULIP_TOPIC   for --alert
+
+Only python3's standard library and an authenticated `gh` CLI. Nothing here builds,
+tags or pushes: it names commits and prints instructions, and `.github/workflows/
+release-tag.yml` is what verifies, publishes and tags them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "pr_status"))
+import core  # noqa: E402
+import zulip as zp  # noqa: E402
+
+# --- policy constants --------------------------------------------------------
+
+MATHLIB = os.environ.get("MATHLIB_REPO", "leanprover-community/mathlib4")
+REPO = core.REPO
+
+# The two files a release commit may differ from its main base in, and nothing else.
+PIN_FILES = ("lake-manifest.json", "lean-toolchain")
+
+RELEASE_BRANCH_FMT = "releases/{release}"
+
+# WHICH commit of an exact-pin run carries the tag. "first", and this is not a
+# preference: a run at the tip of main is open-ended, because main keeps appending
+# commits that share the pin until the next bump. Under "last" the tag would want to
+# move every day and would never be idempotent. "first" is fixed the moment the run
+# begins. The same rule applies to the inexact rung, where it is a choice: one uniform
+# meaning for `vX` is worth more than the extra mathematics "last" would pick up.
+RUN_TAG_POLICY = "first"
+
+# How long automation gets to act on an actionable release before it is worth waking
+# a human over. Measured from the mathlib tag's own commit date.
+GRACE_HOURS = 48
+
+# The workflow whose run conclusion on a target commit is the durable record of
+# "this was built from source and published".
+VERIFY_WORKFLOW = "release-tag.yml"
+
+# `[^<>]` rather than `.`: a greedy `.*` would run from the FIRST marker's brace to
+# the LAST one's, so a body quoting a marker would make the real payload unparseable.
+# No payload this tool writes can contain an angle bracket, and `-->` contains one.
+_TAG_MARKER_RE = re.compile(r"<!--tauceti-toolchain-tag:v1 (\{[^<>]*\})-->\s*\Z", re.S)
+
+# --- version algebra (pure) --------------------------------------------------
+
+# `v4.32.0-rc1-patch1` and `v2024` are deliberately rejected: the first is a mathlib
+# patch of its own tree at an unchanged toolchain, not a Lean release, and `vX` is
+# already taken by the Lean release it belongs to.
+RELEASE_RE = re.compile(r"\Av(\d+)\.(\d+)\.(\d+)(?:-rc(\d+))?\Z")
+
+TOOLCHAIN_PREFIX = "leanprover/lean4:"
+
+
+def parse_release(name):
+    """(major, minor, patch, rc) for a Lean release name, else None.
+
+    A final release sorts AFTER every rc of the same version, so rc-lessness is
+    `inf` rather than 0. This is the same ordering `scripts/check-bump.sh` step 4
+    applies to the toolchain, and a test asserts the two agree."""
+    m = RELEASE_RE.match(name or "")
+    if not m:
+        return None
+    major, minor, patch, rc = m.groups()
+    return (int(major), int(minor), int(patch), int(rc) if rc is not None else math.inf)
+
+
+def is_release(name):
+    return parse_release(name) is not None
+
+
+def toolchain_for(release):
+    return TOOLCHAIN_PREFIX + release
+
+
+def release_of_toolchain(toolchain):
+    """The release a `leanprover/lean4:vX` pin names, or None for anything else
+    (a nightly, a fork channel, a local build)."""
+    tc = (toolchain or "").strip()
+    if not tc.startswith(TOOLCHAIN_PREFIX):
+        return None
+    name = tc[len(TOOLCHAIN_PREFIX):]
+    return name if is_release(name) else None
+
+
+def release_key(name):
+    """Sort key that puts unparseable names last rather than raising."""
+    return parse_release(name) or (math.inf, math.inf, math.inf, math.inf)
+
+
+def release_lt(a, b):
+    return release_key(a) < release_key(b)
+
+
+# --- Tau Ceti git ------------------------------------------------------------
+
+def git(*args, check=True):
+    """Run git in the repository this script lives in. Returns stdout, stripped."""
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    out = subprocess.run(("git", "-C", root) + args, capture_output=True, text=True)
+    if check and out.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {out.stderr.strip()}")
+    return out.stdout.strip()
+
+
+def assert_full_history():
+    """A shallow clone silently truncates the segment table, which would move every
+    index and mis-derive every base. Fail loudly instead."""
+    if git("rev-parse", "--is-shallow-repository") == "true":
+        raise RuntimeError(
+            "this is a shallow clone; toolchain_tags needs full history "
+            "(actions/checkout with fetch-depth: 0)")
+
+
+def main_ref():
+    """`origin/main` when it resolves, else `main`: CI checkouts have the remote ref,
+    a local clone on another branch may only have the local one."""
+    if git("rev-parse", "--verify", "--quiet", "origin/main", check=False):
+        return "origin/main"
+    return "main"
+
+
+def blob_at(sha, path):
+    out = git("show", f"{sha}:{path}", check=False)
+    return out or None
+
+
+def read_pin(sha):
+    """(toolchain, mathlib_rev) at a commit, from the two pin files."""
+    toolchain = (blob_at(sha, "lean-toolchain") or "").strip()
+    manifest = blob_at(sha, "lake-manifest.json")
+    rev = None
+    if manifest:
+        for pkg in json.loads(manifest).get("packages", []):
+            if pkg.get("name") == "mathlib":
+                rev = pkg.get("rev")
+    return toolchain, rev
+
+
+def segments_from(order, changed, read):
+    """Fill-forward the (toolchain, pin) state along `order`, reading only at index 0
+    and at commits in `changed`.
+
+    Reading every commit is what makes the naive version unusable: 3300 commits is
+    two `git show` calls each, and only 47 of them touch a pin file. A commit in
+    `changed` whose state is unchanged extends the current segment rather than
+    splitting it, so segment boundaries mean "the pin actually moved"."""
+    segments = []
+    state = None
+    for index, sha in enumerate(order):
+        if index == 0 or sha in changed:
+            new = read(sha)
+            if new != state:
+                state = new
+                segments.append({
+                    "first_index": index, "last_index": index,
+                    "first_sha": sha, "last_sha": sha,
+                    "toolchain": state[0], "mathlib_rev": state[1],
+                })
+                continue
+        if not segments:
+            raise RuntimeError("segment walk started without a pin state")
+        segments[-1]["last_index"] = index
+        segments[-1]["last_sha"] = sha
+    return segments
+
+
+def compute_segments(ref=None):
+    """The (toolchain, pin) segments of main, oldest first, along the first-parent
+    line. First-parent is the right notion of "states main passed through": a merged
+    PR's own commits are not states main was ever in."""
+    assert_full_history()
+    ref = ref or main_ref()
+    order = git("rev-list", "--first-parent", "--reverse", ref).split()
+    if not order:
+        raise RuntimeError(f"no commits on {ref}")
+    changed = set(git("rev-list", "--first-parent", ref, "--", *PIN_FILES).split())
+    return segments_from(order, changed, read_pin)
+
+
+def assert_monotone(segments):
+    """Segment toolchains never move backward. Base derivation binary-searches on the
+    assumption that main's pin advances monotonically; if that ever stops being true
+    the search would silently return a wrong base, so fail closed here instead."""
+    for earlier, later in zip(segments, segments[1:]):
+        a, b = earlier["toolchain"], later["toolchain"]
+        if a == b:
+            continue
+        ra, rb = release_of_toolchain(a), release_of_toolchain(b)
+        if ra is None or rb is None:
+            continue  # a nightly or fork channel: unordered, not evidence of a move back
+        if release_lt(rb, ra):
+            raise RuntimeError(
+                f"main's toolchain moved backward: {a} at {earlier['first_sha'][:8]} "
+                f"then {b} at {later['first_sha'][:8]}")
+
+
+# --- upstream facts, through the gh CLI --------------------------------------
+
+def _gh(path, jq=None, paginate=False):
+    return core.gh_api(path, jq=jq, paginate=paginate)
+
+
+def _gh_optional(path, jq=None):
+    """`_gh`, but None when the resource does not exist. A 404 is an answer here
+    (no such tag, no such branch); anything else is still an error, so an expired
+    token cannot be mistaken for an absent tag."""
+    try:
+        return _gh(path, jq=jq)
+    except RuntimeError as exc:
+        if "404" in str(exc):
+            return None
+        raise
+
+
+class Cache:
+    """A best-effort memo for IMMUTABLE upstream facts, keyed by a tuple.
+
+    Lives inside `.git/`, so it can never be committed and needs no ignore entry.
+    Every failure mode (missing, corrupt, unwritable) degrades to "no cache": this
+    is a latency optimisation and must never be able to break a run."""
+
+    def __init__(self, path=None):
+        self.path = path or os.environ.get("TOOLCHAIN_TAGS_CACHE") or self._default()
+        self.data = {}
+        self.dirty = False
+        try:
+            with open(self.path) as handle:
+                loaded = json.load(handle)
+            if isinstance(loaded, dict):
+                self.data = loaded
+        except Exception:
+            pass
+
+    @staticmethod
+    def _default():
+        try:
+            gitdir = git("rev-parse", "--absolute-git-dir")
+        except Exception:
+            return os.devnull
+        return os.path.join(gitdir, "tauceti", "toolchain-tags-cache.json")
+
+    @staticmethod
+    def _key(key):
+        return "\t".join(str(part) for part in key)
+
+    def get(self, key):
+        return self.data.get(self._key(key))
+
+    def put(self, key, value):
+        self.data[self._key(key)] = value
+        self.dirty = True
+
+    def flush(self):
+        if not self.dirty or self.path == os.devnull:
+            return
+        try:
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+            with open(self.path, "w") as handle:
+                json.dump(self.data, handle)
+        except Exception:
+            pass
+
+
+class Upstream:
+    """Every read of mathlib, and the few reads of this repository's refs.
+
+    Exactly seven request shapes, so the offline fake in the tests has a small
+    surface and can reject anything it does not recognise."""
+
+    def __init__(self, repo=MATHLIB, cache=None):
+        self.repo = repo
+        self.cache = cache if cache is not None else Cache()
+        self.calls = 0
+        self._repo_tags = None
+        self._release_branches = None
+
+    # ----- mathlib
+
+    def release_tags(self):
+        """{release name: tag object sha} for every mathlib tag that names a Lean
+        release. Mutable (new releases appear), so never cached."""
+        self.calls += 1
+        raw = _gh(f"repos/{self.repo}/git/matching-refs/tags/v",
+                  jq='.[] | [.ref, .object.sha, .object.type] | @tsv')
+        out = {}
+        for line in raw.splitlines():
+            ref, sha, kind = line.split("\t")
+            name = ref.rsplit("/", 1)[-1]
+            if not is_release(name):
+                continue
+            out[name] = self.peel(sha, kind)
+        return out
+
+    def peel(self, sha, kind):
+        """A tag ref can point at a tag object rather than a commit. mathlib's are
+        lightweight today, so this is defensive, but a heavyweight tag would
+        otherwise make every later lookup use the wrong sha."""
+        if kind != "tag":
+            return sha
+        cached = self.cache.get(("peel", sha))
+        if cached:
+            return cached
+        self.calls += 1
+        target = _gh(f"repos/{self.repo}/git/tags/{sha}", jq=".object.sha").strip()
+        self.cache.put(("peel", sha), target)
+        return target
+
+    def toolchain_at(self, sha):
+        cached = self.cache.get(("toolchain", sha))
+        if cached:
+            return cached
+        self.calls += 1
+        value = _gh(f"repos/{self.repo}/contents/lean-toolchain?ref={sha}",
+                    jq=".content").strip()
+        value = _b64(value).strip()
+        self.cache.put(("toolchain", sha), value)
+        return value
+
+    def manifest_at(self, sha):
+        cached = self.cache.get(("manifest", sha))
+        if cached:
+            return cached
+        self.calls += 1
+        value = _b64(_gh(f"repos/{self.repo}/contents/lake-manifest.json?ref={sha}",
+                         jq=".content").strip())
+        self.cache.put(("manifest", sha), value)
+        return value
+
+    def parents(self, sha):
+        cached = self.cache.get(("parents", sha))
+        if cached is not None:
+            return cached
+        self.calls += 1
+        raw = _gh(f"repos/{self.repo}/git/commits/{sha}", jq="[.parents[].sha] | @tsv")
+        value = raw.split()
+        self.cache.put(("parents", sha), value)
+        return value
+
+    def committed_at(self, sha):
+        cached = self.cache.get(("date", sha))
+        if cached:
+            return cached
+        self.calls += 1
+        value = _gh(f"repos/{self.repo}/git/commits/{sha}", jq=".committer.date").strip()
+        self.cache.put(("date", sha), value)
+        return value
+
+    def compare(self, base, head):
+        """`.status` of base...head: ahead, behind, identical or diverged. Between two
+        immutable SHAs the answer is immutable too, so it is cached; a symbolic head
+        such as `master` is not."""
+        immutable = _is_sha(base) and _is_sha(head)
+        if immutable:
+            cached = self.cache.get(("compare", base, head))
+            if cached:
+                return cached
+        self.calls += 1
+        value = _gh(f"repos/{self.repo}/compare/{base}...{head}", jq=".status").strip()
+        if immutable:
+            self.cache.put(("compare", base, head), value)
+        return value
+
+    def ahead_by(self, base, head):
+        """How many commits `head` is ahead of `base`. Immutable between two shas."""
+        cached = self.cache.get(("aheadby", base, head))
+        if cached is not None:
+            return cached
+        self.calls += 1
+        value = int(_gh(f"repos/{self.repo}/compare/{base}...{head}", jq=".ahead_by").strip())
+        self.cache.put(("aheadby", base, head), value)
+        return value
+
+    def is_ancestor(self, ancestor, descendant):
+        """Whether `ancestor` is an ancestor of, or equal to, `descendant`.
+
+        The same primitive, and the same reading of `.status`, that
+        `scripts/check-bump.sh` step 2 uses to decide a bump moved forward."""
+        if ancestor == descendant:
+            return True
+        return self.compare(ancestor, descendant) in ("ahead", "identical")
+
+    def on_master(self, sha):
+        return self.compare(sha, "master") in ("ahead", "identical")
+
+    def is_toolchain_bump_commit(self, sha):
+        """Whether `sha` is the first commit carrying its own toolchain, i.e. its
+        parent's toolchain differs.
+
+        Mathlib has tagged releases this way since v4.28.0, and that habit is what
+        lets ancestry be decided by comparing toolchains. It is a habit, not a
+        contract: `v4.24.0`, `v4.25.0` and `v4.27.0` sit on commits whose parent
+        already carried the same toolchain. So this is asserted per release, and the
+        caller falls back to real ancestry queries when it does not hold."""
+        parents = self.parents(sha)
+        if len(parents) != 1:
+            return False
+        return self.toolchain_at(sha) != self.toolchain_at(parents[0])
+
+    # ----- this repository
+
+    def _matching_refs(self, prefix):
+        """{short name: (sha, object type)} for one `git/matching-refs` query.
+
+        One call for a whole namespace rather than one per release. Asking for eleven
+        tags individually is eleven round trips, and in a repository that has no tags
+        yet every one of them is a 404."""
+        self.calls += 1
+        raw = _gh_optional(f"repos/{REPO}/git/matching-refs/{prefix}",
+                           jq='.[] | [.ref, .object.sha, .object.type] | @tsv') or ""
+        full = f"refs/{prefix}"
+        out = {}
+        for line in raw.splitlines():
+            ref, sha, kind = line.split("\t")
+            out[ref[len(full):] if ref.startswith(full) else ref] = (sha, kind)
+        return out
+
+    def repo_tags(self):
+        if self._repo_tags is None:
+            self._repo_tags = self._matching_refs("tags/v")
+        return self._repo_tags
+
+    def release_branches(self):
+        if self._release_branches is None:
+            self._release_branches = self._matching_refs("heads/releases/")
+        return self._release_branches
+
+    def tag_target(self, release):
+        """The commit a tag points at, peeled, or None when there is no such tag."""
+        entry = self.repo_tags().get(release)
+        if not entry:
+            return None
+        sha, kind = entry
+        if kind != "tag":
+            return sha
+        self.calls += 1
+        return _gh(f"repos/{REPO}/git/tags/{sha}", jq=".object.sha").strip()
+
+    def repo_pin_at(self, sha):
+        """(toolchain, mathlib rev) at a commit of THIS repository, read through the
+        API rather than git: a tag's target may be a release-branch commit that a
+        given checkout has never fetched. Immutable, so cached."""
+        cached = self.cache.get(("repopin", sha))
+        if cached:
+            return tuple(cached)
+        self.calls += 2
+        toolchain = _b64(_gh(f"repos/{REPO}/contents/lean-toolchain?ref={sha}",
+                             jq=".content").strip()).strip()
+        manifest = _b64(_gh(f"repos/{REPO}/contents/lake-manifest.json?ref={sha}",
+                            jq=".content").strip())
+        rev = None
+        for pkg in json.loads(manifest).get("packages", []):
+            if pkg.get("name") == "mathlib":
+                rev = pkg.get("rev")
+        self.cache.put(("repopin", sha), [toolchain, rev])
+        return toolchain, rev
+
+    def branch_head(self, branch):
+        short = branch[len("releases/"):] if branch.startswith("releases/") else branch
+        entry = self.release_branches().get(short)
+        return entry[0] if entry else None
+
+    def verify_conclusion(self, sha):
+        """The newest conclusion of the release workflow on this commit, or None when
+        it has never run there. `None` means "not built yet", never "failed"."""
+        self.calls += 1
+        raw = _gh_optional(
+            f"repos/{REPO}/actions/workflows/{VERIFY_WORKFLOW}/runs"
+            f"?head_sha={sha}&per_page=20",
+            jq='[.workflow_runs[] | select(.status == "completed") | .conclusion] | .[0] // ""')
+        return (raw or "").strip() or None
+
+
+def _b64(content):
+    import base64
+    return base64.b64decode(content).decode()
+
+
+def _is_sha(value):
+    return bool(re.fullmatch(r"[0-9a-f]{40}", value or ""))
+
+
+# --- base derivation ---------------------------------------------------------
+
+def find_exact_run(segments, toolchain, mathlib_rev):
+    """The segment pinning exactly (toolchain, mathlib_rev), or None.
+
+    At most one can exist: a segment is a maximal run of one state, and main's pin
+    only ever moves forward, so a state never recurs."""
+    for seg in segments:
+        if seg["toolchain"] == toolchain and seg["mathlib_rev"] == mathlib_rev:
+            return seg
+    return None
+
+
+def first_on_toolchain(segments, toolchain):
+    for seg in segments:
+        if seg["toolchain"] == toolchain:
+            return seg
+    return None
+
+
+def _last_true(count, predicate):
+    """Index of the last i < count with predicate(i), or -1.
+
+    Binary search, valid because the predicate is monotone: main's pin advances, so
+    once a pin has passed M every later pin has too."""
+    low, high, found = 0, count - 1, -1
+    while low <= high:
+        mid = (low + high) // 2
+        if predicate(mid):
+            found = mid
+            low = mid + 1
+        else:
+            high = mid - 1
+    return found
+
+
+def resolve_base(segments, release, mathlib_rev, up):
+    """(segment, rule) for the last main segment whose pin is an ancestor-or-equal of
+    the mathlib tag commit, or (None, rule) when the repository has no such commit.
+
+    `rule` is `toolchain-fast-path` or `ancestry-search`, and says which decision
+    procedure was used, so the audit can show its working."""
+    usable = [seg for seg in segments if seg["mathlib_rev"]]
+    if not usable:
+        return None, "none"
+
+    fast = False
+    try:
+        fast = up.on_master(mathlib_rev) and up.is_toolchain_bump_commit(mathlib_rev)
+    except RuntimeError:
+        fast = False
+
+    if fast:
+        # M is the first master commit carrying toolchain X, so for a pin p on master:
+        # toolchain(p) < X means p precedes M, toolchain(p) > X means p follows it, and
+        # toolchain(p) == X means p is M itself or a descendant. No API call per pin.
+        target = release
+        rule = "toolchain-fast-path"
+
+        def holds(index):
+            seg = usable[index]
+            name = release_of_toolchain(seg["toolchain"])
+            if name is None:
+                return False
+            if release_lt(name, target):
+                return True
+            return seg["mathlib_rev"] == mathlib_rev
+    else:
+        rule = "ancestry-search"
+
+        def holds(index):
+            return up.is_ancestor(usable[index]["mathlib_rev"], mathlib_rev)
+
+    found = _last_true(len(usable), holds)
+    if found < 0:
+        return None, rule
+    base = usable[found]
+    # Verify the fast path's answer with one real ancestry query. The premise it rests
+    # on is an upstream habit rather than a contract, so the saving is worth one call
+    # but not the risk of trusting it unchecked.
+    if rule == "toolchain-fast-path" and not up.is_ancestor(base["mathlib_rev"], mathlib_rev):
+        rule = "ancestry-search"
+        found = _last_true(len(usable), lambda i: up.is_ancestor(usable[i]["mathlib_rev"],
+                                                                 mathlib_rev))
+        if found < 0:
+            return None, rule
+        base = usable[found]
+    return base, rule
+
+
+# --- the release commit's two files ------------------------------------------
+
+def parse_manifest(text):
+    return json.loads(text)
+
+
+def render_manifest(obj):
+    """Lake's exact `lake-manifest.json` layout, so a derived manifest is a minimal
+    diff against the one Lake last wrote.
+
+    Reproduced from the bytes rather than guessed: root entries are separated by
+    `,\\n ` (one space), the packages array sits on its own line with the same one
+    space, package objects are separated by `,\\n  ` (two), and keys within a package
+    by `,\\n   ` (three, which aligns them under both `[{` and ` {`). A round-trip
+    test against the repository's own manifest is what keeps this honest."""
+    def scalar(value):
+        return json.dumps(value)
+
+    def package(pkg):
+        body = ",\n   ".join(f"{scalar(k)}: {scalar(v)}" for k, v in pkg.items())
+        return "{" + body + "}"
+
+    parts = []
+    for key, value in obj.items():
+        if key == "packages":
+            packages = ",\n  ".join(package(p) for p in value)
+            parts.append(f'{scalar(key)}:\n [{packages}]')
+        else:
+            parts.append(f"{scalar(key)}: {scalar(value)}")
+    return "{" + ",\n ".join(parts) + "}\n"
+
+
+def derive_manifest(base_manifest, mathlib_manifest, mathlib_rev):
+    """The manifest a release commit carries: this repository's own root fields, its
+    own mathlib entry repointed at `mathlib_rev`, and mathlib's entire dependency set
+    at that revision.
+
+    Every rule here mirrors a step of `scripts/check-bump.sh`, so the result passes
+    bump-guard by construction. Note that bump-guard compares the tuple
+    `(type, normalised url, rev, inputRev)` and not literally every field, which is
+    why `inherited` may be normalised below without contradicting it."""
+    base = parse_manifest(base_manifest)
+    upstream = parse_manifest(mathlib_manifest)
+
+    ours = [p for p in base.get("packages", []) if p.get("name") == "mathlib"]
+    if len(ours) != 1:
+        raise ValueError(f"expected exactly one mathlib package in the base, found {len(ours)}")
+    mathlib_pkg = dict(ours[0])
+    if mathlib_pkg.get("inputRev") != "master":
+        raise ValueError(
+            f"base pins mathlib at inputRev {mathlib_pkg.get('inputRev')!r}, not 'master'; "
+            "the nominated branch is human-owned and a release commit never changes it")
+    if not _is_sha(mathlib_rev):
+        raise ValueError(f"mathlib rev {mathlib_rev!r} is not a 40-hex commit sha")
+    mathlib_pkg["rev"] = mathlib_rev
+
+    deps = []
+    for pkg in upstream.get("packages", []):
+        if pkg.get("name") == "mathlib":
+            raise ValueError("mathlib's own manifest lists a package named mathlib")
+        if pkg.get("type") != "git":
+            raise ValueError(f"upstream package {pkg.get('name')!r} is not a git package")
+        if not _is_sha(pkg.get("rev")):
+            raise ValueError(f"upstream package {pkg.get('name')!r} has a non-sha rev")
+        # Every mathlib dependency is transitive from here, whatever mathlib itself
+        # recorded: mathlib marks its own direct deps `false`, and Lake writes `true`
+        # for all of ours. Assigning through dict() keeps the key in its original place.
+        deps.append(dict(pkg, inherited=True))
+
+    names = [p.get("name") for p in deps] + ["mathlib"]
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    if duplicates:
+        raise ValueError(f"duplicate package names in the derived manifest: {duplicates}")
+
+    out = {}
+    for key, value in base.items():
+        if key == "packages":
+            out["packages"] = [mathlib_pkg] + deps
+        elif key == "version":
+            # Lake's manifest-format version, written by the Lake that ships with the
+            # target toolchain, so mathlib's copy at M is the right one and the base's
+            # may be stale. Every other root field (name, lakeDir, packagesDir,
+            # fixedToolchain, and anything Lake adds later) is ours and is preserved.
+            out["version"] = upstream.get("version", value)
+        else:
+            out[key] = value
+    return render_manifest(out)
+
+
+def derive_toolchain(base_toolchain, release):
+    """`leanprover/lean4:vX`, keeping the base file's trailing-newline convention.
+    mathlib's file ends with one and this repository's does not; matching mathlib
+    byte for byte would add a gratuitous whitespace diff, and bump-guard strips
+    whitespace when it compares."""
+    text = toolchain_for(release)
+    return text + "\n" if (base_toolchain or "").endswith("\n") else text
+
+
+# --- classification ----------------------------------------------------------
+
+STATUSES = ("tagged", "verified", "ready", "branch-ready", "needs-branch", "blocked",
+            "out-of-scope")
+
+
+def _target_of(segments, release, mathlib_rev, up):
+    """(target_sha, kind, exact, base_segment, base_rule) for the commit that should
+    carry this release's tag, with target_sha None when none can be named yet.
+
+    `kind` is `main-commit` or `release-branch`. RUN_TAG_POLICY decides which commit
+    of an exact-pin run is chosen; see its comment for why it is not a free choice."""
+    toolchain = toolchain_for(release)
+    run = find_exact_run(segments, toolchain, mathlib_rev)
+    if run is not None:
+        return run[f"{RUN_TAG_POLICY}_sha"], "main-commit", True, None, "exact-on-main"
+
+    branch = RELEASE_BRANCH_FMT.format(release=release)
+    head = up.branch_head(branch)
+    if head:
+        return head, "release-branch", True, None, "release-branch"
+
+    base, rule = resolve_base(segments, release, mathlib_rev, up)
+    if base is not None:
+        return None, "release-branch", True, base, rule
+
+    # No forward base exists, so the exact pin is unreachable. Fall back to the
+    # inexact rung when main did traverse this toolchain; when it did not, nothing
+    # can be tagged, because mathlib's own oleans exist only for mathlib's commits
+    # at that toolchain and a pin elsewhere would not build.
+    era = first_on_toolchain(segments, toolchain)
+    if era is not None:
+        return (era[f"{RUN_TAG_POLICY}_sha"], "main-commit", False, None,
+                "inexact-first-on-toolchain")
+    return None, None, True, None, rule
+
+
+def _tag_is_valid(tag_sha, release, mathlib_rev, up):
+    """(ok, why-not, exact) for a tag that already exists.
+
+    Rung-aware: an exact tag pins the mathlib tag commit itself, an inexact one pins a
+    master descendant of it. Both must carry the release's own toolchain."""
+    toolchain, pin = up.repo_pin_at(tag_sha)
+    want = toolchain_for(release)
+    if toolchain != want:
+        return False, f"is on {toolchain or 'no toolchain'}, not {want}", True
+    if pin == mathlib_rev:
+        return True, None, True
+    if pin and up.is_ancestor(mathlib_rev, pin):
+        return True, None, False
+    return False, (f"pins mathlib {(pin or 'nothing')[:8]}, which is not the {release} tag "
+                   "commit nor a descendant of it"), False
+
+
+def classify(release, mathlib_rev, segments, up):
+    """One row of the audit. Exactly one terminal status per release."""
+    toolchain = toolchain_for(release)
+    row = {
+        "release": release, "toolchain": toolchain, "mathlib_rev": mathlib_rev,
+        "status": None, "reason": None, "target_sha": None, "target_kind": None,
+        "exact": True, "distance": None, "base_sha": None, "base_index": None,
+        "base_rule": None, "branch": RELEASE_BRANCH_FMT.format(release=release),
+        "verify": None, "tag_sha": None,
+    }
+
+    oldest = release_of_toolchain(segments[0]["toolchain"])
+    if oldest is not None and release_lt(release, oldest):
+        row["status"] = "out-of-scope"
+        row["reason"] = f"predates this repository, whose history starts on {oldest}"
+        return row
+
+    target, kind, exact, base, rule = _target_of(segments, release, mathlib_rev, up)
+    row.update(target_sha=target, target_kind=kind, exact=exact, base_rule=rule)
+    if base is not None:
+        row.update(base_sha=base["last_sha"], base_index=base["last_index"])
+
+    if not exact and target:
+        row["distance"] = _distance(segments, target, mathlib_rev, up)
+
+    tag_sha = up.tag_target(release)
+    row["tag_sha"] = tag_sha
+    if tag_sha:
+        # Judge an existing tag by the pins it actually carries, not by re-deriving
+        # what policy would name today. Otherwise deleting a `releases/vX` branch
+        # after tagging, which is harmless, would read as a tag mismatch.
+        ok, why, exact = _tag_is_valid(tag_sha, release, mathlib_rev, up)
+        row["exact"] = exact
+        if ok:
+            row["status"] = "tagged"
+            row["target_sha"], row["target_kind"] = tag_sha, row["target_kind"]
+        else:
+            row["status"] = "blocked"
+            row["reason"] = (f"the tag at {tag_sha[:8]} {why}; a published tag is never "
+                             "moved, so a human decides what to do")
+        return row
+
+    if target is None:
+        if row["base_sha"]:
+            # The base exists, so an exact release commit can be constructed; there is
+            # simply no commit to name until someone does.
+            row["status"] = "needs-branch"
+            return row
+        row["status"] = "blocked"
+        row["reason"] = (
+            "no main commit pins an ancestor of the mathlib tag, and main never ran on "
+            f"{toolchain}, so neither an exact nor an inexact commit exists")
+        return row
+
+    row["verify"] = up.verify_conclusion(target)
+    if row["verify"] == "success":
+        row["status"] = "verified"
+    elif row["verify"] in ("failure", "timed_out", "startup_failure"):
+        row["status"] = "blocked"
+        row["reason"] = (f"the release build on {target[:8]} concluded {row['verify']}; "
+                         "it needs a release build that passes, which is not the same as "
+                         "saying this release cannot be built")
+    elif row["target_kind"] == "release-branch" and row["target_sha"]:
+        row["status"] = "branch-ready"
+    elif row["target_kind"] == "release-branch":
+        row["status"] = "needs-branch"
+    else:
+        row["status"] = "ready"
+    return row
+
+
+def _distance(segments, target_sha, mathlib_rev, up):
+    """How many mathlib commits the target's pin sits past the release tag. Recorded
+    in an inexact tag's message, and checked against the graph rather than trusted."""
+    for seg in segments:
+        if seg["first_sha"] != target_sha:
+            continue
+        pin = seg["mathlib_rev"]
+        if not pin or pin == mathlib_rev:
+            return 0
+        try:
+            return up.ahead_by(mathlib_rev, pin)
+        except (RuntimeError, ValueError):
+            return None
+    return None
+
+
+def audit(segments, up, only=None):
+    """One row per mathlib release tag, newest last."""
+    assert_monotone(segments)
+    tags = up.release_tags()
+    rows = []
+    for release in sorted(tags, key=release_key):
+        if only and release != only:
+            continue
+        rows.append(classify(release, tags[release], segments, up))
+    return rows
+
+
+def actionable(rows):
+    return [r for r in rows if r["status"] in ("verified", "ready", "branch-ready",
+                                               "needs-branch", "blocked")]
+
+
+# --- rendering ---------------------------------------------------------------
+
+POLICY_TEXT = """\
+Tau Ceti toolchain tags
+=======================
+
+For every Lean release X that this repository's history can reach, the tag `vX`
+points at the FIRST main-reachable commit whose lean-toolchain is exactly
+`leanprover/lean4:X` and whose mathlib pin is at or after mathlib's own `vX` tag
+commit M. The pin is, in order of preference:
+
+  1. exact   -- M itself. The commit is either already on main, or is a single
+                commit on a `releases/vX` branch whose parent is a main commit and
+                which changes ONLY lake-manifest.json and lean-toolchain.
+  2. inexact -- when no exact commit exists or the exact one will not compile, the
+                first main commit on toolchain X. The tag message records how many
+                mathlib commits past M the pin is.
+
+A tag is created only after a from-source build of that commit passes the audits and
+lints main runs, and its oleans have been published to the Lake cache and read back.
+That build, publish and tag is `.github/workflows/release-tag.yml`; this tool never
+builds, pushes or tags anything itself.
+
+Tags are NEVER moved. If a tag exists but disagrees with the policy, that is a
+question for a human, and no instruction below will ever delete or force a tag.
+
+What the cache promise covers: this repository publishes its OWN oleans, and
+mathlib's come from mathlib's cache. Where mathlib published no cache for a release,
+which is the case for tags it cut on its `stable` branch, a consumer must compile
+mathlib whatever we do.
+"""
+
+_STATUS_BLURB = {
+    "tagged": "done",
+    "verified": "built and published; the tag is all that is missing",
+    "ready": "an exact commit exists on main and needs a release build",
+    "branch-ready": "the release branch exists and needs a release build",
+    "needs-branch": "the release commit has to be constructed first",
+    "blocked": "needs a human",
+    "out-of-scope": "predates this repository",
+}
+
+
+def render_table(rows, show_all=False):
+    head = f"{'release':14s} {'status':13s} {'pin':8s} {'target':9s} {'note'}"
+    lines = [head, "-" * max(len(head), 76)]
+    skipped = [r for r in rows if r["status"] == "out-of-scope"]
+    if skipped and not show_all:
+        span = (skipped[0]["release"] if len(skipped) == 1
+                else f"{skipped[0]['release']} to {skipped[-1]['release']}")
+        lines.append(f"({len(skipped)} release{'' if len(skipped) == 1 else 's'} "
+                     f"({span}) predate this repository; --all to list them)")
+        rows = [r for r in rows if r["status"] != "out-of-scope"]
+    for row in rows:
+        target = (row["target_sha"] or "")[:8] or "-"
+        pin = "exact" if row["exact"] else "inexact"
+        note = row["reason"] or _STATUS_BLURB.get(row["status"], "")
+        if row["status"] == "ready" and not row["exact"]:
+            note = "no exact commit is reachable; needs a release build on the inexact rung"
+        if row["status"] == "needs-branch" and row["base_sha"]:
+            note = f"base {row['base_sha'][:8]} (main #{row['base_index']})"
+        if not row["exact"] and row["distance"] is not None:
+            note = f"{note}; pin is {row['distance']} mathlib commits past the tag"
+        lines.append(f"{row['release']:14s} {row['status']:13s} {pin:8s} {target:9s} {note}")
+    return "\n".join(lines)
+
+
+def recipe_for(row):
+    """Literal, copy-pasteable repair instructions for one release. These are what an
+    agent acts on, so they name every sha in full and never abbreviate a command."""
+    release, status = row["release"], row["status"]
+    dispatch = (f"    gh workflow run release-tag.yml -f release={release} "
+                f"-f sha={row['target_sha']} -f exact={'true' if row['exact'] else 'false'}")
+    if status == "out-of-scope":
+        return None
+    if status == "tagged":
+        return None
+    if status == "verified":
+        return (f"{release} -- verified\n"
+                f"  {row['target_sha']} was built from source and published, but carries no\n"
+                f"  tag. Re-dispatch the release workflow; its tag job is idempotent and will\n"
+                f"  create the tag without rebuilding anything that already succeeded:\n"
+                f"{dispatch}\n")
+    if status in ("ready", "branch-ready"):
+        if row["target_kind"] != "main-commit":
+            where = f"the head of {row['branch']}, pinning mathlib's {release} tag"
+        elif row["exact"]:
+            where = "a commit on main pinning mathlib's tag exactly"
+        else:
+            where = "the first main commit on the release's toolchain"
+        extra = ""
+        if not row["exact"]:
+            extra = ("  No exact pin is reachable for this release, so this is the inexact\n"
+                     f"  rung, and the pin sits {row['distance']} mathlib commits past the tag.\n")
+        return (f"{release} -- {status}\n"
+                f"  {row['target_sha']} is {where}. It needs a from-source build, a cache\n"
+                f"  publish and a tag:\n{extra}{dispatch}\n")
+    if status == "needs-branch":
+        base = row["base_sha"]
+        return (f"{release} -- needs-branch\n"
+                f"  main never pinned mathlib's {release} tag ({row['mathlib_rev']}), so the\n"
+                f"  release commit has to be constructed. Its base is {base}\n"
+                f"  (main #{row['base_index']}), the last main commit whose pin is an ancestor\n"
+                f"  of the tag, so the pin only moves forward:\n\n"
+                f"    git fetch origin main\n"
+                f"    git checkout -b {row['branch']} {base}\n"
+                f"    python3 scripts/toolchain_tags.py --write {release} --dir .\n"
+                f"    git commit -am 'chore: release commit for Lean {release}'\n"
+                f"    git push origin {row['branch']}\n"
+                f"    python3 scripts/toolchain_tags.py --audit --release {release}"
+                f"   # expect: branch-ready\n\n"
+                f"  Then dispatch the release workflow on the branch head. The branch must\n"
+                f"  differ from its base in the two pin files and nothing else; a compile fix\n"
+                f"  belongs on main, after which re-cut the branch.\n")
+    if status == "blocked":
+        return (f"{release} -- blocked\n  {row['reason']}\n")
+    return None
+
+
+def render_audit(rows, show_all=False):
+    parts = [POLICY_TEXT, "", render_table(rows, show_all), ""]
+    recipes = [r for r in (recipe_for(row) for row in actionable(rows)) if r]
+    if recipes:
+        parts += ["Repairs", "-------", ""] + recipes
+    else:
+        parts += ["Every reachable release is tagged.", ""]
+    return "\n".join(parts)
+
+
+def rows_to_json(rows):
+    return json.dumps(rows, indent=2, sort_keys=True)
+
+
+def tag_message(row):
+    """The annotated tag body. The trailing marker carries the same facts in machine
+    form so a later audit can read back what was claimed at tagging time."""
+    exact = "yes" if row["exact"] else f"no, {row['distance']} mathlib commits past the tag"
+    meta = {
+        "schema": 1, "release": row["release"], "toolchain": row["toolchain"],
+        "mathlib_rev": row["mathlib_rev"], "mathlib_tag": row["release"],
+        "exact": bool(row["exact"]), "distance": row["distance"],
+        "kind": row["target_kind"], "commit": row["target_sha"],
+    }
+    return (
+        f"TauCeti {row['release']}\n\n"
+        f"Lean toolchain: {row['toolchain']}\n"
+        f"Mathlib:        {row['mathlib_rev']} ({MATHLIB} {row['release']})\n"
+        f"Commit:         {row['target_sha']} ({row['target_kind']})\n"
+        f"Exact pin:      {exact}\n\n"
+        f"Built from source with the Lake artifact cache disabled, audited and linted\n"
+        f"exactly as main is, and published to the Lake cache.\n\n"
+        f"<!--tauceti-toolchain-tag:v1 {json.dumps(meta, sort_keys=True)}-->\n")
+
+
+def parse_tag_message(message):
+    """The marker's payload, or None. Anchored to the end and strictly shaped, so
+    text quoting a marker earlier in the body cannot be read as the real one."""
+    match = _TAG_MARKER_RE.search(message or "")
+    if not match:
+        return None
+    try:
+        return json.loads(match.group(1))
+    except ValueError:
+        return None
+
+
+# --- Zulip ------------------------------------------------------------------
+#
+# The marker-and-reconcile idiom below is copied from scripts/pr_status/stuck_alerts.py
+# (`parse_marker` through `reconcile`), which is the source of truth for it. It is
+# copied rather than shared: that module is the emergency watchdog, and refactoring a
+# live detector to take a marker parameter for a new feature's convenience is the
+# wrong trade. Keep the two in step by hand if the idiom changes.
+
+KEY_RE = re.compile(r"[a-z0-9][a-z0-9._/-]*")
+MARKER_RE = re.compile(r"<!--toolchain-tag:v1 (" + KEY_RE.pattern + r")-->\s*\Z")
+RED = "\U0001f534"
+GREEN = "✅"
+
+
+def key_prefix(key):
+    return key.split("/", 1)[0]
+
+
+def parse_marker(content):
+    match = MARKER_RE.search(content or "")
+    return match.group(1) if match else None
+
+
+def alert_content(alert):
+    return (f"{RED} **{alert['title']}**\n\n{alert['body']}\n\n"
+            f"<!--toolchain-tag:v1 {alert['key']}-->")
+
+
+def resolved_content(key, title):
+    return (f"{GREEN} **{title}** — cleared\n\n_No longer outstanding as of the latest "
+            f"check._\n\n<!--toolchain-tag:v1 {key}-->")
+
+
+def newest_by_key(msgs, bot_id):
+    out = {}
+    for msg in msgs:
+        if msg["sender_id"] != bot_id:
+            continue
+        key = parse_marker(msg["content"])
+        if key is None:
+            continue
+        if key not in out or msg["id"] > out[key]["id"]:
+            out[key] = msg
+    return out
+
+
+def is_resolved(msg):
+    return msg["content"].lstrip().startswith(GREEN)
+
+
+def alerts_from(rows, up, now=None):
+    """One alert per release that needs attention.
+
+    Blocked releases alert immediately. The merely actionable ones wait out a grace
+    period measured from mathlib's own tag date, so the automation gets first crack at
+    a release before anyone is woken about it."""
+    import datetime
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    out = []
+    for row in rows:
+        if row["status"] in ("tagged", "out-of-scope", "verified"):
+            continue
+        if row["status"] != "blocked":
+            try:
+                cut = datetime.datetime.fromisoformat(
+                    up.committed_at(row["mathlib_rev"]).replace("Z", "+00:00"))
+            except Exception:
+                cut = None
+            if cut and (now - cut).total_seconds() < GRACE_HOURS * 3600:
+                continue
+        title = f"{row['release']} has no toolchain tag ({row['status']})"
+        body = zp.zulip_sanitize(recipe_for(row) or row["reason"] or "")
+        out.append({"key": f"{row['status']}/{row['release']}".lower(),
+                    "title": zp.zulip_sanitize(title), "body": body})
+    return out
+
+
+def reconcile(z, alerts, failed, dry_run):
+    bot_id = z.my_user_id()
+    msgs = z.get_messages([
+        {"operator": "channel", "operand": zp.CHANNEL},
+        {"operator": "topic", "operand": zp.TOPIC},
+    ])
+    existing = newest_by_key(msgs, bot_id)
+    active = {a["key"]: a for a in alerts}
+
+    for key, alert in active.items():
+        content = alert_content(alert)
+        msg = existing.get(key)
+        if msg is None or is_resolved(msg):
+            zp.log(f"POST alert {key}")
+            if not dry_run:
+                z.send_message(content)
+        elif msg["content"] != content:
+            zp.log(f"refresh alert {key}")
+            if not dry_run:
+                z.update_message(msg["id"], content)
+        else:
+            zp.log(f"ongoing alert {key} (unchanged)")
+
+    for key, msg in existing.items():
+        if key in active or is_resolved(msg):
+            continue
+        if key_prefix(key) in failed:
+            zp.log(f"classification for {key} failed this run; NOT resolving (fail closed)")
+            continue
+        zp.log(f"RESOLVED alert {key}")
+        if not dry_run:
+            z.update_message(msg["id"], resolved_content(key, key))
+
+
+# --- the other modes ---------------------------------------------------------
+
+def next_stepping_stone(segments, up, target=None):
+    """The mathlib rev the daily bump should pin instead of its last-known-good
+    commit, or None.
+
+    A release qualifies when main's pin has not reached its tag but the bump's target
+    has passed it, the tag is on master (a `stable`-branch patch release could never
+    satisfy bump-guard, so it is backfill-only by construction), and the move is
+    forward from main's current pin."""
+    current = segments[-1]
+    head = target or "master"
+    reached = release_of_toolchain(up.toolchain_at(head))
+    here = release_of_toolchain(current["toolchain"])
+    if reached is None or here is None:
+        return None
+    tags = up.release_tags()
+    for release in sorted(tags, key=release_key):
+        if not release_lt(here, release) or release_lt(reached, release):
+            continue
+        rev = tags[release]
+        if rev == current["mathlib_rev"]:
+            continue
+        if not up.on_master(rev):
+            continue
+        if not up.is_ancestor(current["mathlib_rev"], rev):
+            continue
+        return rev
+    return None
+
+
+def write_release_files(directory, release, mathlib_rev, base_sha, up):
+    """Materialise the two pin files of a release commit. Returns the paths written."""
+    base_manifest = blob_at(base_sha, "lake-manifest.json")
+    base_toolchain = blob_at(base_sha, "lean-toolchain")
+    if not base_manifest or not base_toolchain:
+        raise RuntimeError(f"{base_sha} is missing a pin file; is it fetched?")
+    manifest = derive_manifest(base_manifest, up.manifest_at(mathlib_rev), mathlib_rev)
+    toolchain = derive_toolchain(base_toolchain, release)
+    upstream_toolchain = up.toolchain_at(mathlib_rev).strip()
+    if upstream_toolchain != toolchain_for(release):
+        raise RuntimeError(
+            f"mathlib at {mathlib_rev[:8]} is on {upstream_toolchain}, not "
+            f"{toolchain_for(release)}; that tag does not name the release it claims to")
+    written = []
+    for name, text in (("lake-manifest.json", manifest), ("lean-toolchain", toolchain)):
+        path = os.path.join(directory, name)
+        with open(path, "w") as handle:
+            handle.write(text)
+        written.append(path)
+    return written
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def _row_for(release, segments, up):
+    tags = up.release_tags()
+    if release not in tags:
+        raise RuntimeError(f"{MATHLIB} has no release tag named {release}")
+    return classify(release, tags[release], segments, up)
+
+
+def _run_audit(args, segments, up):
+    rows = audit(segments, up, only=args.audit_release)
+    if args.json:
+        print(rows_to_json(rows))
+    else:
+        print(render_audit(rows, args.all))
+    if args.strict and any(r["status"] == "blocked" for r in rows):
+        return 1
+    return 0
+
+
+def _run_write(args, segments, up):
+    row = _row_for(args.write, segments, up)
+    base = args.base or row["base_sha"]
+    if not base:
+        print(f"no base commit for {args.write}: {row['reason'] or row['status']}",
+              file=sys.stderr)
+        return 1
+    if args.dry_run:
+        manifest = derive_manifest(blob_at(base, "lake-manifest.json"),
+                                   up.manifest_at(row["mathlib_rev"]), row["mathlib_rev"])
+        print(derive_toolchain(blob_at(base, "lean-toolchain"), args.write))
+        print(manifest, end="")
+        return 0
+    for path in write_release_files(args.dir, args.write, row["mathlib_rev"], base, up):
+        print(f"wrote {path}")
+    return 0
+
+
+def _run_alert(args, segments, up):
+    rows, failed = [], set()
+    try:
+        rows = audit(segments, up)
+    except Exception as exc:  # fail closed: resolve nothing when the audit itself broke
+        zp.log(f"audit failed (non-fatal): {exc}")
+        failed = set(STATUSES)
+    alerts = alerts_from(rows, up) if rows else []
+    zp.log(f"{len(alerts)} outstanding release(s): {sorted(a['key'] for a in alerts)}")
+
+    if args.dry_run:  # never touches Zulip, with or without credentials
+        for alert in alerts:
+            print("\n" + alert_content(alert))
+        return 0
+
+    email = (os.environ.get("ZULIP_EMAIL") or "").strip()
+    api_key = (os.environ.get("ZULIP_API_KEY") or "").strip()
+    site = (os.environ.get("ZULIP_SITE") or "https://leanprover.zulipchat.com").strip()
+    if not (email and api_key):
+        return zp.fail_config("ZULIP_EMAIL / ZULIP_API_KEY not set (no bot configured)")
+    z = zp.Zulip(email, api_key, site)
+    try:
+        zp.check(z)
+        reconcile(z, alerts, failed, args.dry_run)
+    except zp.ConfigError as exc:
+        return zp.fail_config(str(exc))
+    except Exception as exc:  # a transient Zulip hiccup is cosmetic and self-heals
+        zp.log(f"reconcile failed (non-fatal): {exc}")
+    return 0
+
+
+def build_parser():
+    ap = argparse.ArgumentParser(
+        description="Audit and materialise Tau Ceti's Lean toolchain tags.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=POLICY_TEXT)
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--audit", action="store_true",
+                      help="report every release and how to repair the gaps (default)")
+    mode.add_argument("--next-stepping-stone", action="store_true",
+                      help="print the mathlib rev the daily bump should pin first")
+    mode.add_argument("--write", metavar="vX",
+                      help="materialise a release commit's two pin files")
+    mode.add_argument("--tag-message", metavar="vX",
+                      help="print the annotated tag body for a release")
+    mode.add_argument("--alert", action="store_true",
+                      help="reconcile the outstanding releases against Zulip")
+    ap.add_argument("--release", dest="audit_release", metavar="vX",
+                    help="with --audit, report only this release")
+    ap.add_argument("--json", action="store_true", help="with --audit, the machine worklist")
+    ap.add_argument("--all", action="store_true",
+                    help="with --audit, list the releases that predate this repository too")
+    ap.add_argument("--strict", action="store_true",
+                    help="with --audit, exit 1 when any release is blocked")
+    ap.add_argument("--target", help="with --next-stepping-stone, the bump's target rev")
+    ap.add_argument("--dir", default=".", help="with --write, where to put the files")
+    ap.add_argument("--base", help="with --write, override the derived base commit")
+    ap.add_argument("--dry-run", action="store_true", help="print, do not write or post")
+    return ap
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    up = Upstream()
+    try:
+        segments = compute_segments()
+        if args.next_stepping_stone:
+            rev = next_stepping_stone(segments, up, args.target)
+            if rev:
+                print(rev)
+            return 0
+        if args.write:
+            return _run_write(args, segments, up)
+        if args.tag_message:
+            print(tag_message(_row_for(args.tag_message, segments, up)), end="")
+            return 0
+        if args.alert:
+            return _run_alert(args, segments, up)
+        return _run_audit(args, segments, up)
+    except RuntimeError as exc:
+        print(f"toolchain_tags: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        up.cache.flush()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -509,6 +509,35 @@ class Upstream:
         self.calls += 1
         return _gh(f"repos/{REPO}/git/tags/{sha}", jq=".object.sha").strip()
 
+    def release_branch_shape(self, head):
+        """(ok, why-not) for the structural half of a release commit.
+
+        Matching pins is not the whole shape: a commit that also carries source changes
+        would otherwise be nominated as a permanent tag target. This is the same property
+        `scripts/check-release-commit.sh` establishes before anything is built, checked here
+        too so the audit does not name a commit the release workflow will refuse. Kept to
+        one request: the compare endpoint answers both questions."""
+        self.calls += 1
+        try:
+            raw = _gh(f"repos/{REPO}/compare/main...{head}",
+                      jq='[(.status), (.ahead_by|tostring), '
+                         '([.files[]? | .filename + ":" + .status] | join(","))] | @tsv')
+        except RuntimeError as exc:
+            return None, f"could not compare it with main ({exc})"
+        status, ahead, files = (raw.strip().split("\t") + ["", "", ""])[:3]
+        if status not in ("ahead", "diverged"):
+            return False, f"compares {status!r} with main, so it is not one commit off it"
+        if ahead != "1":
+            return False, f"is {ahead} commits ahead of main; a release commit is exactly one"
+        changed = [f for f in files.split(",") if f]
+        if not changed or len(changed) > len(PIN_FILES):
+            return False, f"changes {len(changed)} files; a release commit changes only the pins"
+        for entry in changed:
+            name, _, state = entry.rpartition(":")
+            if name not in PIN_FILES or state != "modified":
+                return False, f"changes {name or entry!r}, which is outside the two Lake pins"
+        return True, None
+
     def repo_pin_at(self, sha):
         """(toolchain, mathlib rev) at a commit of THIS repository, read through the
         API rather than git: a tag's target may be a release-branch commit that a
@@ -792,11 +821,18 @@ def _target_of(segments, release, mathlib_rev, up):
         # ancestor, only the pin files changed) before anything is built from it.
         try:
             toolchain, pin = up.repo_pin_at(head)
-        except RuntimeError:
-            toolchain, pin = None, None
-        if toolchain == toolchain_for(release) and pin == mathlib_rev:
-            return head, "release-branch", True, None, "release-branch"
-        return None, "release-branch", True, None, "release-branch-invalid"
+        except RuntimeError as exc:
+            # Unreadable is not wrong. Telling someone to re-cut a branch because the API
+            # blinked is worse advice than saying the state could not be read.
+            return None, "release-branch", True, None, f"release-branch-unreadable:{exc}"
+        if toolchain != toolchain_for(release) or pin != mathlib_rev:
+            return None, "release-branch", True, None, "release-branch-invalid"
+        shaped, why = up.release_branch_shape(head)
+        if shaped is None:
+            return None, "release-branch", True, None, f"release-branch-unreadable:{why}"
+        if not shaped:
+            return None, "release-branch", True, None, f"release-branch-misshapen:{why}"
+        return head, "release-branch", True, None, "release-branch"
 
     base, rule = resolve_base(segments, release, mathlib_rev, up)
     if base is not None:
@@ -813,7 +849,8 @@ def _target_of(segments, release, mathlib_rev, up):
     return None, None, True, None, rule
 
 
-def _tag_is_valid(tag_sha, release, mathlib_rev, up, target=None, target_exact=True):
+def _tag_is_valid(tag_sha, release, mathlib_rev, up, target=None, target_exact=True,
+                  target_kind=None):
     """(ok, why-not, exact) for a tag that already exists.
 
     Rung-aware, and it checks WHICH commit, not merely a plausible one. An earlier version
@@ -826,7 +863,10 @@ def _tag_is_valid(tag_sha, release, mathlib_rev, up, target=None, target_exact=T
     want = toolchain_for(release)
     if toolchain != want:
         return False, f"is on {toolchain or 'no toolchain'}, not {want}", True
-    if target and tag_sha != target:
+    if target and target_kind == "main-commit" and tag_sha != target:
+        # Only for a main commit, whose identity policy fixes and nothing can move. A
+        # release branch is mutable: if it is later re-cut onto another exact-pin commit, a
+        # correctly placed permanent tag would otherwise start reading as a mismatch.
         return False, (f"is on {tag_sha[:8]}, but policy names {target[:8]}"), target_exact
     if target_exact and pin != mathlib_rev:
         return False, (f"pins mathlib {(pin or 'nothing')[:8]}, but an exact tag for "
@@ -871,7 +911,8 @@ def classify(release, mathlib_rev, segments, up):
         # what policy would name today. Otherwise deleting a `releases/vX` branch
         # after tagging, which is harmless, would read as a tag mismatch.
         ok, why, exact = _tag_is_valid(tag_sha, release, mathlib_rev, up,
-                                       target=target, target_exact=row["exact"])
+                                       target=target, target_exact=row["exact"],
+                                       target_kind=row["target_kind"])
         row["exact"] = exact
         if ok:
             row["status"] = "tagged"
@@ -883,6 +924,18 @@ def classify(release, mathlib_rev, segments, up):
         return row
 
     if target is None:
+        if rule.startswith("release-branch-unreadable"):
+            row["status"] = "blocked"
+            row["reason"] = (
+                f"{row['branch']} exists but its state could not be read "
+                f"({rule.split(':', 1)[-1]}); this is not a verdict on the branch")
+            return row
+        if rule.startswith("release-branch-misshapen"):
+            row["status"] = "blocked"
+            row["reason"] = (
+                f"{row['branch']} pins the right mathlib but {rule.split(':', 1)[-1]}; "
+                "re-cut it from the base rather than tagging what is there")
+            return row
         if rule == "release-branch-invalid":
             row["status"] = "blocked"
             row["reason"] = (


### PR DESCRIPTION
This PR adds `scripts/toolchain_tags.py`, the single source of the toolchain-tag policy, and reports the outstanding releases to Zulip once a day. Mathlib tags every Lean release, so a downstream project on Lean v4.33.0 can check out mathlib at `v4.33.0`; this is the machinery that lets Tau Ceti offer the same thing, and says which releases still lack a tag and exactly how to give them one.

The policy: for every Lean release X this repository's history can reach, `vX` points at the first main-reachable commit whose `lean-toolchain` is `leanprover/lean4:X` and whose mathlib pin is at or after mathlib's own `vX` tag commit, preferring a commit that pins that tag exactly and falling back to the first main commit on the toolchain when no exact one is reachable. "First" is not a preference for the exact rung but a requirement: a run of commits sharing a pin at the tip of main is open-ended, so "last" would want to move the tag every day and would never be idempotent.

Two things the implementation is careful about. Ancestry is checked rather than inferred: mathlib has tagged the toolchain-bump commit since v4.28.0, which makes ancestry decidable by comparing toolchains, but v4.24.0, v4.25.0 and v4.27.0 did not, so the tool asserts that premise per release and falls back to the compare API when it fails. And pins are read only at the 47 commits that touch them and filled forward, so the walk over 3305 first-parent commits takes 0.19s where a naive one timed out at two minutes; a test asserts the request budget so a stray per-commit call turns the build red.

The tool never builds, pushes, tags or creates a branch. It names commits and prints instructions, and `release-tag.yml`, which arrives in its own PR, is what acts on them. `docs/toolchain-tags.md` records the reasoning the report has no room for, including the honest limit of the cache promise: this repository publishes its own oleans and mathlib's come from mathlib, so for the two releases mathlib cut on its stable branch a consumer compiles mathlib whatever we do.

Roadmap: none

🤖 Prepared with Claude Code