### PR TITLE
refactor(Torus): name the split-torus coordinate-ring isomorphism

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Characterization.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Characterization.lean
@@ -57,6 +57,19 @@ private theorem exists_mulEquiv_finsupp_int
     b.repr.toAddEquiv.trans (Finsupp.domCongr eι)
   exact ⟨_, ⟨AddEquiv.toMultiplicative e⟩⟩
 
+/-- **A finitely generated torsion-free commutative group has the coordinate ring of a split
+torus.** For such a `G` there is a rank `n` and an isomorphism of diagonalizable coordinate rings
+between the character group of `ULift (Fin n)` and `G`. -/
+private theorem exists_iso_coordinateRing_characterGroup (K : Type u) [Field K]
+    (G : FGCommGrpCat.{u}) [IsMulTorsionFree G] :
+    ∃ n : ℕ, Nonempty (DiagonalizableGroup.coordinateRing K
+        (SplitTorus.characterGroup (ULift.{u} (Fin n))) ≅
+      DiagonalizableGroup.coordinateRing K G) := by
+  obtain ⟨n, ⟨e⟩⟩ := exists_mulEquiv_finsupp_int G
+  exact ⟨n, ⟨ObjectProperty.isoMk _ <| _root_.CommHopfAlgCat.isoMk
+    (MonoidAlgebra.domCongrBialgEquiv K K
+      ((AddEquiv.toMultiplicative (Finsupp.domCongr Equiv.ulift)).trans e.symm))⟩⟩
+
 namespace torusCommHopfAlgProperty
 
 /-- **A finite-type commutative Hopf algebra over a field is a torus if and only if it is a
@@ -84,34 +97,18 @@ theorem iff_multiplicativeType_and_geometricallyConnected_and_geometricallyReduc
         (DiagonalizableGroup.coordinateRing (AlgebraicClosure k) G).obj :=
       (geometricallyReducedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso i'.symm
         (geometricallyReducedCommHopfAlgProperty.baseChange (AlgebraicClosure k) hreduced)
-    let coordinateRingObjIso :
-        _root_.CommHopfAlgCat.of (AlgebraicClosure k)
-            (MonoidAlgebra (AlgebraicClosure k) G) ≅
-          (DiagonalizableGroup.coordinateRing (AlgebraicClosure k) G).obj :=
-      Iso.refl _
-    have hconnectedMonoid :=
-      (geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-        coordinateRingObjIso hconnected'
-    have hreducedMonoid :=
-      (geometricallyReducedCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso
-        coordinateRingObjIso hreduced'
+    -- The coordinate ring of a diagonalizable group *is* the group algebra, so the two properties
+    -- transfer to it without an intervening isomorphism.
     let _ : ConnectedSpace
         (PrimeSpectrum (MonoidAlgebra (AlgebraicClosure k) G)) :=
-      hconnectedMonoid.connectedSpace (AlgebraicClosure k)
+      hconnected'.connectedSpace (AlgebraicClosure k)
         (_root_.CommHopfAlgCat.of (AlgebraicClosure k)
           (MonoidAlgebra (AlgebraicClosure k) G))
-    let _ : IsReduced (MonoidAlgebra (AlgebraicClosure k) G) := hreducedMonoid.isReduced
+    let _ : IsReduced (MonoidAlgebra (AlgebraicClosure k) G) := hreduced'.isReduced
     let _ : IsMulTorsionFree G :=
       isMulTorsionFree_of_isReduced_monoidAlgebra_of_connectedSpace
         (AlgebraicClosure k) G
-    obtain ⟨n, ⟨e⟩⟩ := exists_mulEquiv_finsupp_int G
-    let e' : SplitTorus.characterGroup (ULift.{u} (Fin n)) ≃* G :=
-      (AddEquiv.toMultiplicative (Finsupp.domCongr Equiv.ulift)).trans e.symm
-    let j : DiagonalizableGroup.coordinateRing (AlgebraicClosure k)
-          (SplitTorus.characterGroup (ULift.{u} (Fin n))) ≅
-        DiagonalizableGroup.coordinateRing (AlgebraicClosure k) G :=
-      ObjectProperty.isoMk _ <| _root_.CommHopfAlgCat.isoMk
-        (MonoidAlgebra.domCongrBialgEquiv (AlgebraicClosure k) (AlgebraicClosure k) e')
+    obtain ⟨n, ⟨j⟩⟩ := exists_iso_coordinateRing_characterGroup (AlgebraicClosure k) G
     rw [torusCommHopfAlgProperty_iff]
     exact ⟨n, ⟨j ≪≫ i⟩⟩
 

--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Characterization.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Characterization.lean
@@ -60,7 +60,7 @@ private theorem exists_mulEquiv_finsupp_int
 /-- **A finitely generated torsion-free commutative group has the coordinate ring of a split
 torus.** For such a `G` there is a rank `n` and an isomorphism of diagonalizable coordinate rings
 between the character group of `ULift (Fin n)` and `G`. -/
-private theorem exists_iso_coordinateRing_characterGroup (K : Type u) [Field K]
+private theorem exists_iso_coordinateRing_characterGroup (K : Type u) [CommRing K]
     (G : FGCommGrpCat.{u}) [IsMulTorsionFree G] :
     ∃ n : ℕ, Nonempty (DiagonalizableGroup.coordinateRing K
         (SplitTorus.characterGroup (ULift.{u} (Fin n))) ≅


### PR DESCRIPTION
`iff_multiplicativeType_and_geometricallyConnected_and_geometricallyReduced` ran to 47 lines. Two
changes bring it to 31, and neither touches a statement.

## The extraction

* **`exists_iso_coordinateRing_characterGroup`** — a finitely generated torsion-free commutative
  group has, for some rank `n`, an isomorphism of diagonalizable coordinate rings with the
  character group of `ULift (Fin n)`.

This is the last step of the backward direction, and it needs none of the Hopf-property machinery
around it: just the group, torsion-freeness, and a commutative ring of coefficients. It takes the parent's
`let`s `e'` and `j` with it.

## A transport across the identity

The parent also built

```lean
let coordinateRingObjIso :
    CommHopfAlgCat.of (AlgebraicClosure k) (MonoidAlgebra (AlgebraicClosure k) G) ≅
      (DiagonalizableGroup.coordinateRing (AlgebraicClosure k) G).obj :=
  Iso.refl _
```

and pushed both geometric properties across it. That isomorphism is `Iso.refl _` — the coordinate
ring of a diagonalizable group *is* the group algebra — so `hconnected'` and `hreduced'` already
have the right type and the two `prop_of_iso` calls were bookkeeping. Removing them drops
`hconnectedMonoid` and `hreducedMonoid` as well.

## Minimal hypotheses

The helper takes `(K : Type u) [CommRing K]` and `(G : FGCommGrpCat.{u}) [IsMulTorsionFree G]`.
The parent supplies an `AlgebraicClosure k`, but no field structure is used: `coordinateRing` is
declared over `[CommRing R]` and `MonoidAlgebra.domCongrBialgEquiv` over `[CommSemiring R]`.
`CommRing` is the floor and not a stopping point chosen by hand — at `[CommSemiring K]` the
statement stops elaborating, because `coordinateRing` cannot be formed.

Note `G` is an object of `FGCommGrpCat`, not a bare `Type u`; stating it with `[CommGroup G]
[Group.FG G]` over a type does not typecheck against `DiagonalizableGroup.coordinateRing`.

## Result

| | before | after |
|---|---|---|
| `iff_multiplicativeType_and_geometricallyConnected_and_geometricallyReduced` | 47 | **31** |
| `exists_iso_coordinateRing_characterGroup` | — | 4 |

The parent leaves the 40–50 band. The helper is `private`; no existing statement changed.

Gates run on `1b6f4872`: `lake build` (8534 jobs), `lake exe axioms` (59089 declarations),
`lake exe module-system` (2751 modules), `scripts/lint-env.sh` (`LINT-ENV: PASS`, 64
grandfathered, 0 new).

Roadmap: ReductiveGroups

