### PR TITLE
feat: asphericity and Eilenberg-Mac Lane spaces along covering maps

### DIFF
--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Covering.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Covering.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Group.Equiv.Opposite
+public import Mathlib.Algebra.Group.Subgroup.Ker
+public import TauCeti.AlgebraicTopology.EilenbergMacLane.Basic
+public import TauCeti.Topology.Homotopy.Covering
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Covering
+
+/-!
+# Asphericity and covering spaces
+
+A covering map `p : E → X` is an isomorphism on homotopy groups in every dimension at least
+two, so the higher homotopy of a cover and of its base are the same. Asphericity is therefore
+inherited in both directions along a covering map, the only extra input being
+path-connectedness of whichever space is not already known to be path-connected.
+
+This file records that transfer and the two `K(G, 1)` recognition principles it yields.
+
+* Downwards: the base of a *surjective* covering map with aspherical total space is aspherical.
+  Combined with the identification of the fundamental group of the base of a simply connected
+  quotient covering map, a group acting freely and properly discontinuously on a simply
+  connected space whose higher homotopy vanishes has an orbit space of type `K(G, 1)`.
+  This is the standard way `K(G, 1)` spaces are produced.
+* Upwards: a path-connected covering space of an aspherical space is aspherical. Its
+  fundamental group is the subgroup of `π₁` of the base recovered by `p`, because a covering
+  map is injective on fundamental groups, so a path-connected cover of a `K(G, 1)` is a
+  `K(H, 1)` for that subgroup `H`.
+
+Taking the total space simply connected in the upwards direction says that the universal cover
+of an aspherical space is weakly contractible: all of its homotopy groups vanish, including
+`π₁`, which is where simple connectedness enters. Nothing here asserts that such a cover is
+contractible; that is a genuinely stronger statement, requiring a Whitehead-type theorem which
+this development does not have.
+
+The `ᵐᵒᵖ` in Mathlib's `IsQuotientCoveringMap.fundamentalGroupEquiv` is invisible in the
+`K(G, 1)` statement below: being a `K(G, 1)` is invariant under `MulEquiv.inv'`, the
+isomorphism `G ≃* Gᵐᵒᵖ` sending `g` to `op g⁻¹`.
+
+This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13, "`K(G, 1)`
+spaces", by supplying the covering-space recognition principle for them; the concrete circle
+and torus examples were proved directly.
+
+## Main declarations
+
+* `IsCoveringMap.subsingleton_homotopyGroup_iff`: a cover and its base have the same
+  higher homotopy groups.
+* `IsCoveringMap.isAspherical`: **the base of a surjective covering map with aspherical
+  total space is aspherical**.
+* `IsCoveringMap.isAspherical_totalSpace`: **a path-connected covering space of an
+  aspherical space is aspherical**.
+* `IsCoveringMap.subsingleton_homotopyGroup_of_isAspherical`: **the simply connected
+  cover of an aspherical space is weakly contractible**.
+* `IsCoveringMap.isEilenbergMacLaneSpaceOne_totalSpace`: a path-connected cover of a
+  `K(G, 1)` is a `K(H, 1)` for the subgroup `H` it recovers.
+* `IsQuotientCoveringMap.isEilenbergMacLaneSpaceOne`: **the orbit space of a free,
+  properly discontinuous action of `G` on a simply connected space with vanishing higher
+  homotopy is a `K(G, 1)`**.
+
+## References
+
+The isomorphism on higher homotopy groups is
+`TauCeti.IsCoveringMap.homotopyGroupPiMulEquiv`; the injectivity of a covering map on
+fundamental groups is `TauCeti.IsCoveringMap.mapOfEq_injective`. The identification of the
+fundamental group of the base of a simply connected quotient covering map with the opposite
+of the acting group is Junyan Xu's `IsQuotientCoveringMap.fundamentalGroupEquiv` in
+`Mathlib/Topology/Homotopy/Lifting.lean`. Compare Proposition 4.1 and Section 1.B of
+[hatcher02]; no external formalization is copied or adapted here.
+-/
+
+public section
+
+open TauCeti
+open scoped Topology Topology.Homotopy
+
+variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X} {e : E} {x : X}
+
+namespace IsCoveringMap
+
+/-- A covering map identifies the homotopy groups of its total space in dimensions at least two
+with those of its base, so one is trivial exactly when the other is. -/
+theorem subsingleton_homotopyGroup_iff (hp : IsCoveringMap p) (he : p e = x) (n : ℕ) :
+    Subsingleton (π_ (n + 2) E e) ↔ Subsingleton (π_ (n + 2) X x) := by
+  subst he
+  exact (TauCeti.IsCoveringMap.homotopyGroupPiMulEquiv hp e n).toEquiv.subsingleton_congr
+
+/-- **The base of a surjective covering map with aspherical total space is aspherical.** -/
+theorem isAspherical (hp : IsCoveringMap p) (hp' : Function.Surjective p)
+    (he : p e = x) (h : IsAspherical E e) : IsAspherical X x := by
+  have := h.pathConnectedSpace
+  exact IsAspherical.mk (hp'.pathConnectedSpace hp.continuous)
+    fun n ↦ (hp.subsingleton_homotopyGroup_iff he n).mp (h.subsingleton_homotopyGroup n)
+
+/-- **A path-connected covering space of an aspherical space is aspherical.** -/
+theorem isAspherical_totalSpace (hp : IsCoveringMap p) [PathConnectedSpace E]
+    (he : p e = x) (h : IsAspherical X x) : IsAspherical E e :=
+  IsAspherical.mk inferInstance
+    fun n ↦ (hp.subsingleton_homotopyGroup_iff he n).mpr (h.subsingleton_homotopyGroup n)
+
+/-- **The simply connected cover of an aspherical space is weakly contractible**: every one of
+its homotopy groups in a positive dimension is trivial.
+
+In dimension one this is simple connectedness of the cover; in the higher dimensions it is the
+asphericity of the base transported along the covering map. -/
+theorem subsingleton_homotopyGroup_of_isAspherical (hp : IsCoveringMap p)
+    [SimplyConnectedSpace E] (he : p e = x) (h : IsAspherical X x) (n : ℕ) :
+    Subsingleton (π_ (n + 1) E e) := by
+  cases n with
+  | zero => exact HomotopyGroup.pi1EquivFundamentalGroup.subsingleton_congr.mpr inferInstance
+  | succ m =>
+    exact (hp.subsingleton_homotopyGroup_iff he m).mpr (h.subsingleton_homotopyGroup m)
+
+/-- A base covered by a path-connected space whose higher homotopy groups all vanish is
+aspherical. This is the recognition principle behind `K(G, 1)` spaces: the hypothesis is on the
+cover, and no homotopy group of the base has to be computed directly. -/
+theorem isAspherical_of_subsingleton_homotopyGroup (hp : IsCoveringMap p)
+    (hp' : Function.Surjective p) [PathConnectedSpace E] (he : p e = x)
+    (h : ∀ n : ℕ, Subsingleton (π_ (n + 2) E e)) : IsAspherical X x :=
+  hp.isAspherical hp' he (IsAspherical.mk inferInstance h)
+
+/-- **A path-connected covering space of a `K(G, 1)` is a `K(H, 1)`**, for `H` the subgroup of
+the fundamental group of the base that the cover recovers.
+
+The fundamental-group witness is `MulEquiv.ofInjective` applied to the injectivity of `p` on
+fundamental groups; the recovered subgroup is by definition the range of that map. -/
+theorem isEilenbergMacLaneSpaceOne_totalSpace (hp : IsCoveringMap p)
+    [PathConnectedSpace E] (he : p e = x) (h : IsAspherical X x) :
+    IsEilenbergMacLaneSpaceOne
+      (FundamentalGroup.mapOfEq (⟨p, hp.continuous⟩ : C(E, X)) he).range E e :=
+  IsEilenbergMacLaneSpaceOne.mk (hp.isAspherical_totalSpace he h)
+    ⟨MonoidHom.ofInjective (TauCeti.IsCoveringMap.mapOfEq_injective hp he)⟩
+
+end IsCoveringMap
+
+namespace IsQuotientCoveringMap
+
+variable {G : Type*} [Group G] [MulAction G E] {f : E → X}
+
+/-- **The orbit space of a free, properly discontinuous action of `G` on a simply connected
+space all of whose higher homotopy groups vanish is a `K(G, 1)`.**
+
+The hypotheses are packaged as a quotient covering map, which is exactly freeness together
+with the local disjointness making the orbit map a covering. The fundamental group of the
+orbit space is the opposite group `Gᵐᵒᵖ`, which is isomorphic to `G` by `MulEquiv.inv'`. -/
+theorem isEilenbergMacLaneSpaceOne (hf : IsQuotientCoveringMap f G)
+    [SimplyConnectedSpace E] (he : f e = x)
+    (h : ∀ n : ℕ, Subsingleton (π_ (n + 2) E e)) :
+    IsEilenbergMacLaneSpaceOne G X x :=
+  IsEilenbergMacLaneSpaceOne.mk
+    (hf.isCoveringMap.isAspherical_of_subsingleton_homotopyGroup hf.surjective he h)
+    ⟨(hf.fundamentalGroupEquiv (⟨e, he⟩ : f ⁻¹' {x})).trans (MulEquiv.inv' G).symm⟩
+
+end IsQuotientCoveringMap
+
+end

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Covering.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Covering.lean
@@ -125,7 +125,7 @@ theorem isAspherical_of_subsingleton_homotopyGroup (hp : IsCoveringMap p)
 /-- **A path-connected covering space of a `K(G, 1)` is a `K(H, 1)`**, for `H` the subgroup of
 the fundamental group of the base that the cover recovers.
 
-The fundamental-group witness is `MulEquiv.ofInjective` applied to the injectivity of `p` on
+The fundamental-group witness is `MonoidHom.ofInjective` applied to the injectivity of `p` on
 fundamental groups; the recovered subgroup is by definition the range of that map. -/
 theorem isEilenbergMacLaneSpaceOne_totalSpace (hp : IsCoveringMap p)
     [PathConnectedSpace E] (he : p e = x) (h : IsAspherical X x) :

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/TopologicalVectorSpace.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/TopologicalVectorSpace.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Convex.Contractible
+public import TauCeti.AlgebraicTopology.EilenbergMacLane.Covering
+public import TauCeti.Topology.Homotopy.HomotopyGroup.TopologicalVectorSpace
+
+/-!
+# Quotients of a real topological vector space are Eilenberg--Mac Lane spaces
+
+A real topological vector space is contractible, hence simply connected, and all of its
+homotopy groups vanish. Feeding this into
+`IsQuotientCoveringMap.isEilenbergMacLaneSpaceOne` gives the classical source of
+`K(G, 1)` spaces: whenever a group `G` acts on a real topological vector space so that the
+orbit map is a quotient covering map — freely, with the orbits locally separated — the orbit
+space is a `K(G, 1)`.
+
+The two inputs are Mathlib's `RealTopologicalVectorSpace.contractibleSpace` and
+`TauCeti.HomotopyGroup.subsingleton_of_topologicalVectorSpace`; both are instances, so the
+statement carries no hypothesis beyond the quotient covering map itself.
+
+This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13, "`K(G, 1)`
+spaces". The circle and torus were already known to be `K(ℤ, 1)` and `K(ℤᵏ, 1)` by direct
+computation of their homotopy groups; this states the underlying general principle.
+
+## Main declarations
+
+* `IsQuotientCoveringMap.isEilenbergMacLaneSpaceOne_realTopologicalVectorSpace`:
+  **the orbit space of a free, properly discontinuous action of `G` on a real topological
+  vector space is a `K(G, 1)`**.
+-/
+
+public section
+
+open TauCeti
+open scoped Topology Topology.Homotopy
+
+namespace IsQuotientCoveringMap
+
+variable {V X G : Type*} [AddCommGroup V] [Module ℝ V] [TopologicalSpace V]
+  [IsTopologicalAddGroup V] [ContinuousSMul ℝ V] [TopologicalSpace X] [Group G] [MulAction G V]
+  {f : V → X} {v : V} {x : X}
+
+/-- **The orbit space of a free, properly discontinuous action of `G` on a real topological
+vector space is a `K(G, 1)`.**
+
+The hypothesis is exactly that the orbit map `f` is a quotient covering map for `G`; the
+asphericity and the identification of the fundamental group with `G` are then automatic. -/
+theorem isEilenbergMacLaneSpaceOne_realTopologicalVectorSpace
+    (hf : IsQuotientCoveringMap f G) (hv : f v = x) :
+    IsEilenbergMacLaneSpaceOne G X x :=
+  hf.isEilenbergMacLaneSpaceOne hv fun _ ↦ inferInstance
+
+end IsQuotientCoveringMap
+
+end

--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -170,7 +170,6 @@ def basepointLift (x₀ : X) : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} 
       exact BasedPath.endpoint_ofPath _)⟩
 
 /-- The endpoint projection sends the constant-path point to the basepoint. -/
-@[simp]
 theorem proj_basepointLift (x₀ : X) : proj (basepointLift x₀ : UniversalCover x₀) = x₀ :=
   (basepointLift x₀).2
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -169,7 +169,10 @@ def basepointLift (x₀ : X) : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} 
       rw [proj_ofBasedPath]
       exact BasedPath.endpoint_ofPath _)⟩
 
-/-- The endpoint projection sends the constant-path point to the basepoint. -/
+/-- The endpoint projection sends the constant-path point to the basepoint.
+
+This remains an explicit rewrite lemma: `basepointLift_coe` already puts its left-hand side in
+simp-normal form, so the `simpNF` linter rejects a redundant `@[simp]` annotation here. -/
 theorem proj_basepointLift (x₀ : X) : proj (basepointLift x₀ : UniversalCover x₀) = x₀ :=
   (basepointLift x₀).2
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -36,7 +36,8 @@ The inverse-free computation rule is `inv_smul_mk`.
 
 * The `MulAction`, `FaithfulSMul`, `ContinuousConstSMul`, and `IsCancelSMul` instances for
   `FundamentalGroup X x₀` acting on `UniversalCover x₀`.
-* `TauCeti.UniversalCover.basepointLift`: the constant-path point over `x₀`.
+* `TauCeti.UniversalCover.basepointLift`: the constant-path point over `x₀`, lying over `x₀`
+  by `TauCeti.UniversalCover.proj_basepointLift`.
 * `TauCeti.UniversalCover.monodromy_basepointLift`: monodromy at that point is the
   fundamental-group action by the inverse loop class.
 * `TauCeti.UniversalCover.proj_eq_iff_mem_orbit`: the fibres of `proj` are precisely the
@@ -167,6 +168,11 @@ def basepointLift (x₀ : X) : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} 
     Set.mem_singleton_iff.mpr (by
       rw [proj_ofBasedPath]
       exact BasedPath.endpoint_ofPath _)⟩
+
+/-- The endpoint projection sends the constant-path point to the basepoint. -/
+@[simp]
+theorem proj_basepointLift (x₀ : X) : proj (basepointLift x₀ : UniversalCover x₀) = x₀ :=
+  (basepointLift x₀).2
 
 /-- The underlying point of `basepointLift` is represented by the constant path. -/
 @[simp]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/EilenbergMacLane.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Group.Equiv.Opposite
 public import TauCeti.AlgebraicTopology.EilenbergMacLane.Covering
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
@@ -38,12 +37,8 @@ that stage are Eilenberg--Mac Lane spaces whenever the base is.
 
 ## Main declarations
 
-* `TauCeti.UniversalCover.subsingleton_homotopyGroup_iff`: the universal cover and its base
-  have the same homotopy groups in dimensions at least two.
 * `TauCeti.UniversalCover.isAspherical_iff`: **a space is aspherical exactly when the higher
   homotopy groups of its universal cover vanish**.
-* `TauCeti.UniversalCover.subsingleton_homotopyGroup_of_isAspherical`: **the universal cover
-  of an aspherical space is weakly contractible**.
 * `TauCeti.UniversalCover.isEilenbergMacLaneSpaceOne`: the resulting `K(G, 1)` recognition
   principle.
 * `TauCeti.UniversalCover.isAspherical_subgroupQuotient` and
@@ -69,13 +64,6 @@ namespace TauCeti.UniversalCover
 variable {X : Type*} [TopologicalSpace X] [LocallyPathConnectedSpace X] [PathConnectedSpace X]
   [SemilocallySimplyConnectedSpace X] (x₀ : X)
 
-/-- The universal cover and its base have the same homotopy groups in dimensions at least
-two, so one is trivial exactly when the other is. -/
-theorem subsingleton_homotopyGroup_iff (n : ℕ) :
-    Subsingleton (π_ (n + 2) (UniversalCover x₀) (basepointLift x₀ : UniversalCover x₀)) ↔
-      Subsingleton (π_ (n + 2) X x₀) :=
-  (isCoveringMap x₀).subsingleton_homotopyGroup_iff (proj_basepointLift x₀) n
-
 /-- **A space is aspherical exactly when the higher homotopy groups of its universal cover
 vanish.**
 
@@ -85,17 +73,11 @@ theorem isAspherical_iff :
     IsAspherical X x₀ ↔
       ∀ n : ℕ,
         Subsingleton (π_ (n + 2) (UniversalCover x₀) (basepointLift x₀ : UniversalCover x₀)) :=
-  ⟨fun h n ↦ (subsingleton_homotopyGroup_iff x₀ n).mpr (h.subsingleton_homotopyGroup n),
+  ⟨fun h n ↦ ((isCoveringMap x₀).subsingleton_homotopyGroup_iff
+      (proj_basepointLift x₀) n).mpr (h.subsingleton_homotopyGroup n),
     fun h ↦
       (isCoveringMap x₀).isAspherical_of_subsingleton_homotopyGroup proj_surjective
         (proj_basepointLift x₀) h⟩
-
-/-- **The universal cover of an aspherical space is weakly contractible**: all of its homotopy
-groups in positive dimensions are trivial. Dimension one is simple connectedness of the
-universal cover, and the higher dimensions are the asphericity of the base. -/
-theorem subsingleton_homotopyGroup_of_isAspherical (h : IsAspherical X x₀) (n : ℕ) :
-    Subsingleton (π_ (n + 1) (UniversalCover x₀) (basepointLift x₀ : UniversalCover x₀)) :=
-  (isCoveringMap x₀).subsingleton_homotopyGroup_of_isAspherical (proj_basepointLift x₀) h n
 
 /-- **A space whose universal cover has vanishing higher homotopy groups is a `K(G, 1)`**, for
 any group `G` isomorphic to its fundamental group. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/EilenbergMacLane.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Group.Equiv.Opposite
+public import TauCeti.AlgebraicTopology.EilenbergMacLane.Covering
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.RecoveredSubgroup
+
+/-!
+# Aspherical spaces through the universal cover and its subgroup quotients
+
+Under the standing hypotheses of this development — `X` path-connected, locally
+path-connected and semilocally simply connected — every homotopy group of `X` in a dimension
+at least two is a homotopy group of the universal cover. Asphericity of `X` is therefore a
+property of the universal cover alone: `X` is aspherical exactly when the higher homotopy
+groups of `UniversalCover x₀` vanish. Since the universal cover is simply connected, that
+condition says precisely that it is weakly contractible.
+
+This turns the Galois correspondence of Stage 2 into a statement about Eilenberg--Mac Lane
+spaces. Every subgroup `H ≤ π₁(X, x₀)` is realised by the connected cover
+`UniversalCover x₀ / H`, whose fundamental group is `Hᵐᵒᵖ`, hence `H`; when `X` is a
+`K(G, 1)` that cover is aspherical too, so it is a `K(H, 1)`. In particular every subgroup of
+the fundamental group of a `K(G, 1)` is itself the fundamental group of a `K(H, 1)`, realised
+on the nose as a covering space of `X`.
+
+The general covering-space input is
+`IsCoveringMap.isAspherical_totalSpace`; the only work here is to supply the
+universal cover and the covers attached to subgroups as instances of it, with their
+distinguished basepoints.
+
+This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13, "`K(G, 1)`
+spaces", by tying that item to the Stage 2 classification: the covers produced by item 7 of
+that stage are Eilenberg--Mac Lane spaces whenever the base is.
+
+## Main declarations
+
+* `TauCeti.UniversalCover.subsingleton_homotopyGroup_iff`: the universal cover and its base
+  have the same homotopy groups in dimensions at least two.
+* `TauCeti.UniversalCover.isAspherical_iff`: **a space is aspherical exactly when the higher
+  homotopy groups of its universal cover vanish**.
+* `TauCeti.UniversalCover.subsingleton_homotopyGroup_of_isAspherical`: **the universal cover
+  of an aspherical space is weakly contractible**.
+* `TauCeti.UniversalCover.isEilenbergMacLaneSpaceOne`: the resulting `K(G, 1)` recognition
+  principle.
+* `TauCeti.UniversalCover.isAspherical_subgroupQuotient` and
+  `TauCeti.UniversalCover.isEilenbergMacLaneSpaceOne_subgroupQuotient`: **the cover attached
+  to `H ≤ π₁(X, x₀)` over a `K(G, 1)` is a `K(H, 1)`**.
+
+## References
+
+The cover attached to a subgroup and its fundamental group come from
+`TauCeti.AlgebraicTopology.UniversalCover.Classification.Existence` and
+`…Classification.RecoveredSubgroup`, which adapt Kim Morrison's universal-cover construction
+in [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292) and use
+Junyan Xu's quotient-covering API in `Mathlib/Topology/Homotopy/Lifting.lean`. Compare
+Section 1.B of [hatcher02]; no external formalization is copied or adapted here.
+-/
+
+public section
+
+open scoped Topology Topology.Homotopy
+
+namespace TauCeti.UniversalCover
+
+variable {X : Type*} [TopologicalSpace X] [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X] (x₀ : X)
+
+/-- The universal cover and its base have the same homotopy groups in dimensions at least
+two, so one is trivial exactly when the other is. -/
+theorem subsingleton_homotopyGroup_iff (n : ℕ) :
+    Subsingleton (π_ (n + 2) (UniversalCover x₀) (basepointLift x₀ : UniversalCover x₀)) ↔
+      Subsingleton (π_ (n + 2) X x₀) :=
+  (isCoveringMap x₀).subsingleton_homotopyGroup_iff (proj_basepointLift x₀) n
+
+/-- **A space is aspherical exactly when the higher homotopy groups of its universal cover
+vanish.**
+
+Together with simple connectedness of the universal cover, the right-hand side says that the
+universal cover is weakly contractible. -/
+theorem isAspherical_iff :
+    IsAspherical X x₀ ↔
+      ∀ n : ℕ,
+        Subsingleton (π_ (n + 2) (UniversalCover x₀) (basepointLift x₀ : UniversalCover x₀)) :=
+  ⟨fun h n ↦ (subsingleton_homotopyGroup_iff x₀ n).mpr (h.subsingleton_homotopyGroup n),
+    fun h ↦
+      (isCoveringMap x₀).isAspherical_of_subsingleton_homotopyGroup proj_surjective
+        (proj_basepointLift x₀) h⟩
+
+/-- **The universal cover of an aspherical space is weakly contractible**: all of its homotopy
+groups in positive dimensions are trivial. Dimension one is simple connectedness of the
+universal cover, and the higher dimensions are the asphericity of the base. -/
+theorem subsingleton_homotopyGroup_of_isAspherical (h : IsAspherical X x₀) (n : ℕ) :
+    Subsingleton (π_ (n + 1) (UniversalCover x₀) (basepointLift x₀ : UniversalCover x₀)) :=
+  (isCoveringMap x₀).subsingleton_homotopyGroup_of_isAspherical (proj_basepointLift x₀) h n
+
+/-- **A space whose universal cover has vanishing higher homotopy groups is a `K(G, 1)`**, for
+any group `G` isomorphic to its fundamental group. -/
+theorem isEilenbergMacLaneSpaceOne {G : Type*} [Group G] (e : FundamentalGroup X x₀ ≃* G)
+    (h : ∀ n : ℕ,
+      Subsingleton (π_ (n + 2) (UniversalCover x₀) (basepointLift x₀ : UniversalCover x₀))) :
+    IsEilenbergMacLaneSpaceOne G X x₀ :=
+  IsEilenbergMacLaneSpaceOne.mk ((isAspherical_iff x₀).mpr h) ⟨e⟩
+
+variable (H : Subgroup (FundamentalGroup X x₀))
+
+/-- The cover of an aspherical space attached to a subgroup of its fundamental group is
+aspherical. -/
+theorem isAspherical_subgroupQuotient (h : IsAspherical X x₀) :
+    IsAspherical (SubgroupQuotient x₀ H) (SubgroupQuotient.basepoint x₀ H) :=
+  (isCoveringMap_subgroupQuotientProj x₀ H).isAspherical_totalSpace
+    (subgroupQuotientProj_basepoint x₀ H) h
+
+/-- **The cover attached to `H ≤ π₁(X, x₀)` over a `K(G, 1)` is a `K(H, 1)`.**
+
+So every subgroup of the fundamental group of an aspherical space is realised, on the nose, as
+the fundamental group of an aspherical covering space of it. The `ᵐᵒᵖ` recorded by
+`TauCeti.UniversalCover.SubgroupQuotient.fundamentalGroupEquiv` disappears along
+`MulEquiv.inv'`. -/
+theorem isEilenbergMacLaneSpaceOne_subgroupQuotient (h : IsAspherical X x₀) :
+    IsEilenbergMacLaneSpaceOne H (SubgroupQuotient x₀ H) (SubgroupQuotient.basepoint x₀ H) :=
+  IsEilenbergMacLaneSpaceOne.mk (isAspherical_subgroupQuotient x₀ H h)
+    ⟨(SubgroupQuotient.fundamentalGroupEquiv x₀ H).trans (MulEquiv.inv' H).symm⟩
+
+end TauCeti.UniversalCover
+
+end

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/EilenbergMacLane.lean
@@ -21,10 +21,10 @@ condition says precisely that it is weakly contractible.
 
 This turns the Galois correspondence of Stage 2 into a statement about Eilenberg--Mac Lane
 spaces. Every subgroup `H ≤ π₁(X, x₀)` is realised by the connected cover
-`UniversalCover x₀ / H`, whose fundamental group is `Hᵐᵒᵖ`, hence `H`; when `X` is a
+`UniversalCover x₀ / H`, whose fundamental group is `Hᵐᵒᵖ`, hence isomorphic to `H`; when `X` is a
 `K(G, 1)` that cover is aspherical too, so it is a `K(H, 1)`. In particular every subgroup of
-the fundamental group of a `K(G, 1)` is itself the fundamental group of a `K(H, 1)`, realised
-on the nose as a covering space of `X`.
+the fundamental group of a `K(G, 1)` is isomorphic to the fundamental group of a `K(H, 1)`
+realised as a covering space of `X`.
 
 The general covering-space input is
 `IsCoveringMap.isAspherical_totalSpace`; the only work here is to supply the
@@ -98,8 +98,8 @@ theorem isAspherical_subgroupQuotient (h : IsAspherical X x₀) :
 
 /-- **The cover attached to `H ≤ π₁(X, x₀)` over a `K(G, 1)` is a `K(H, 1)`.**
 
-So every subgroup of the fundamental group of an aspherical space is realised, on the nose, as
-the fundamental group of an aspherical covering space of it. The `ᵐᵒᵖ` recorded by
+So every subgroup of the fundamental group of an aspherical space is isomorphic to the
+fundamental group of an aspherical covering space of it. The `ᵐᵒᵖ` recorded by
 `TauCeti.UniversalCover.SubgroupQuotient.fundamentalGroupEquiv` disappears along
 `MulEquiv.inv'`. -/
 theorem isEilenbergMacLaneSpaceOne_subgroupQuotient (h : IsAspherical X x₀) :


### PR DESCRIPTION
This PR transfers asphericity along covering maps and turns that transfer into the two standard recognition principles for Eilenberg--Mac Lane spaces of type `K(G, 1)`. A covering map is an isomorphism on homotopy groups in every dimension at least two, so the higher homotopy of a cover and of its base coincide; the base of a surjective covering map with aspherical total space is aspherical (`IsCoveringMap.isAspherical`), and a path-connected covering space of an aspherical space is aspherical (`IsCoveringMap.isAspherical_totalSpace`). Downwards this gives `IsQuotientCoveringMap.isEilenbergMacLaneSpaceOne`: the orbit space of a free, properly discontinuous action of `G` on a simply connected space whose higher homotopy groups all vanish is a `K(G, 1)`, specialised to a real topological vector space in `IsQuotientCoveringMap.isEilenbergMacLaneSpaceOne_realTopologicalVectorSpace`, where both hypotheses on the acted-on space are instances. Upwards it gives `IsCoveringMap.isEilenbergMacLaneSpaceOne_totalSpace`: a path-connected cover of a `K(G, 1)` is a `K(H, 1)` for the subgroup `H` of `π₁` that it recovers, the fundamental-group witness being `MonoidHom.ofInjective` applied to injectivity of `p` on `π₁`. Taking the total space simply connected gives `IsCoveringMap.subsingleton_homotopyGroup_of_isAspherical`: the universal cover of an aspherical space is weakly contractible, `π₁` included.

Against the universal cover built here, this yields `TauCeti.UniversalCover.isAspherical_iff` — a space is aspherical exactly when the higher homotopy groups of `UniversalCover x₀` vanish — together with the resulting `K(G, 1)` recognition principle `TauCeti.UniversalCover.isEilenbergMacLaneSpaceOne`. Combined with the Stage 2 classification it gives `TauCeti.UniversalCover.isEilenbergMacLaneSpaceOne_subgroupQuotient`: for `H ≤ π₁(X, x₀)` and an aspherical `X`, the connected cover `UniversalCover x₀ / H` is a `K(H, 1)`. So every subgroup of the fundamental group of a `K(G, 1)` is realised, up to isomorphism, as the fundamental group of an aspherical covering space of it — which is what makes the Galois correspondence usable for producing new `K(G, 1)` spaces from old ones. The `ᵐᵒᵖ` recorded by `IsQuotientCoveringMap.fundamentalGroupEquiv` and by `SubgroupQuotient.fundamentalGroupEquiv` disappears along Mathlib's `MulEquiv.inv'`.

The target is `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13, "`π_n(Tᵏ)`, `π₁(RPⁿ)`, `K(G, 1)` spaces", and specifically its `K(G, 1)` clause: `TauCeti.IsAspherical` and `TauCeti.IsEilenbergMacLaneSpaceOne` were on `main` with the invariance and product API, and circles and tori were shown to be `K(ℤ, 1)` and `K(ℤᵏ, 1)` by direct computation of their homotopy groups, but nothing recognised a `K(G, 1)` from a covering space, which is how the class is normally produced and how it interacts with the rest of this roadmap. After this PR the remaining pieces of item 13 are `π₁(RPⁿ)`, which is in flight, and concrete new `K(G, 1)` examples; nothing else here is claimed to close.

Files: `TauCeti/AlgebraicTopology/EilenbergMacLane/Covering.lean` (new, the general covering transfer and both recognition principles), `TauCeti/AlgebraicTopology/EilenbergMacLane/TopologicalVectorSpace.lean` (new, the real-topological-vector-space specialisation), and `TauCeti/AlgebraicTopology/UniversalCover/Classification/EilenbergMacLane.lean` (new, the universal cover and its subgroup quotients). `TauCeti/AlgebraicTopology/UniversalCover/Action.lean` gains the one-line projection lemma `proj_basepointLift`, which belongs beside the definition of `basepointLift` it is about.

No Mathlib infrastructure is vendored. The consumed inputs are Junyan Xu's `IsQuotientCoveringMap.fundamentalGroupEquiv` in `Mathlib/Topology/Homotopy/Lifting.lean`, Mathlib's `RealTopologicalVectorSpace.contractibleSpace`, `SimplyConnectedSpace.ofContractible` and `MulEquiv.inv'`, and, from this repository, `TauCeti.IsCoveringMap.homotopyGroupPiMulEquiv`, `TauCeti.IsCoveringMap.mapOfEq_injective`, `TauCeti.HomotopyGroup.subsingleton_of_topologicalVectorSpace` and the Stage 2 subgroup-cover API. Compare Proposition 4.1 and Section 1.B of Hatcher, *Algebraic Topology*.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"covers-of-aspherical-spaces"}-->

🤖 Prepared with Claude Code
