### PR TITLE
feat: Landau's theorem for Dirichlet series with nonnegative coefficients

### DIFF
--- a/TauCeti/NumberTheory/LSeries/Landau.lean
+++ b/TauCeti/NumberTheory/LSeries/Landau.lean
@@ -1,0 +1,361 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Complex.TaylorSeries
+public import Mathlib.Analysis.SpecialFunctions.Exponential
+public import Mathlib.NumberTheory.LSeries.Dirichlet
+public import Mathlib.NumberTheory.LSeries.Positivity
+public import TauCeti.NumberTheory.LSeries.EntireExtension
+
+/-!
+# Landau's theorem on Dirichlet series with nonnegative coefficients
+
+A Dirichlet series whose coefficients are nonnegative real numbers is singular at the real point
+of its abscissa of absolute convergence. Writing `σ` for that abscissa, no function analytic on a
+disc around `σ` can agree with `LSeries a` immediately to the right of `σ`: the series would then
+already converge to the left of `σ`.
+
+The obstruction is recorded by `TauCeti.LSeries.HasAnalyticExtensionAt a σ`, the existence of such
+a disc and such a function; `TauCeti.LSeries.hasAnalyticExtensionAt_of_abscissaOfAbsConv_lt` shows
+the predicate is not vacuous, since strictly inside the half-plane of convergence the L-series is
+its own analytic continuation.
+
+## Main results
+
+* `TauCeti.LSeries.landau`: **Landau's theorem**. If `0 ≤ a` and
+  `LSeries.abscissaOfAbsConv a = (σ : EReal)`, then `¬ HasAnalyticExtensionAt a σ`. The equality
+  hypothesis is what makes `σ` the *actual* boundary and records its finiteness; convergence
+  throughout `Re s > σ` alone would not suffice.
+* `TauCeti.LSeries.abscissaOfAbsConv_le_of_differentiableOn`: the half-plane form. A nonnegative
+  Dirichlet series with finite abscissa converges as far to the left as it continues analytically.
+* `TauCeti.LSeries.abscissaOfAbsConv_eq_bot_of_differentiable`: the entire form, which is what a
+  nonvanishing argument applies once a positive combination of L-series has been shown entire.
+* `TauCeti.LSeries.abscissaOfAbsConv_eq_bot_of_hasEntireExtension`: the same conclusion phrased
+  through the repository's `LSeries.HasEntireExtension` predicate.
+* `TauCeti.LSeries.not_hasAnalyticExtensionAt_one`: the coefficient sequence of the Riemann zeta
+  function is singular at `s = 1`.
+
+## Implementation notes
+
+Mathlib's `LSeriesSummable` is equivalent to absolute summability of the Dirichlet terms, since
+`summable_norm_iff` holds in `ℂ`; consequently `LSeriesSummable.abscissaOfAbsConv_le` already
+identifies the ordinary and the absolute abscissa, and no separate lemma is needed here for
+nonnegative coefficients.
+
+The proof follows the classical argument. Suppose `F` is analytic on a disc around `σ` and agrees
+with `LSeries a` to its right. Patching `F` with `LSeries a` produces a function `G` analytic on a
+disc of radius slightly larger than `1` around `σ + 1`, and the Taylor coefficients of `G` at
+`σ + 1` are, up to sign, the numbers `∑ a n (log n) ^ k / n ^ (σ + 1) ≥ 0`
+(`LSeries.iteratedDeriv_alternating`). Evaluating the Taylor series at a real point `x < σ` of
+that disc and exchanging the two nonnegative summations exhibits `∑ a n / n ^ x` as a convergent
+series, contradicting `abscissaOfAbsConv a = σ`.
+
+## References
+
+* H. Davenport, *Multiplicative Number Theory*, §11.
+* G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter II.1,
+  Theorem 10.
+-/
+
+public section
+
+namespace TauCeti.LSeries
+
+open Complex Filter Metric
+open scoped ComplexOrder
+
+variable {a : ℕ → ℂ}
+
+/-- Iterating `LSeries.logMul` multiplies the Dirichlet term by a power of `Real.log n`. -/
+lemma term_logMul_iterate (f : ℕ → ℂ) (s : ℂ) (k n : ℕ) :
+    LSeries.term (LSeries.logMul^[k] f) s n = (Real.log n : ℂ) ^ k * LSeries.term f s n := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have h1 : LSeries.term (LSeries.logMul (LSeries.logMul^[k] f)) s n
+        = (Real.log n : ℂ) * LSeries.term (LSeries.logMul^[k] f) s n := by
+      rcases eq_or_ne n 0 with rfl | hn
+      · simp
+      · rw [LSeries.term_of_ne_zero hn, LSeries.term_of_ne_zero hn, LSeries.logMul,
+          Complex.natCast_log, mul_div_assoc]
+    rw [Function.iterate_succ_apply', h1, ih, pow_succ]
+    ring
+
+/-- The `k`-th iterated derivative of an L-series, with its alternating sign removed, is the
+L-series of `log ^ k * a`. -/
+lemma LSeries_logMul_iterate_eq {x : ℝ} (hx : LSeries.abscissaOfAbsConv a < x) (k : ℕ) :
+    LSeries (LSeries.logMul^[k] a) (x : ℂ)
+      = (-1 : ℂ) ^ k * iteratedDeriv k (LSeries a) (x : ℂ) := by
+  rw [LSeries_iteratedDeriv k (by simpa using hx), ← mul_assoc, ← pow_add,
+    Even.neg_one_pow ⟨k, rfl⟩, one_mul]
+
+/-- For nonnegative coefficients the L-series of `log ^ k * a` is a nonnegative real number
+throughout the half-plane of absolute convergence. -/
+lemma LSeries_logMul_iterate_nonneg (ha : 0 ≤ a) {x : ℝ}
+    (hx : LSeries.abscissaOfAbsConv a < x) (k : ℕ) :
+    0 ≤ LSeries (LSeries.logMul^[k] a) (x : ℂ) :=
+  (LSeries_logMul_iterate_eq hx k).symm ▸ LSeries.iteratedDeriv_alternating ha hx k
+
+/-- The real part of a Dirichlet term of a nonnegative coefficient sequence at a real point. -/
+lemma re_term_of_ne_zero (ha : 0 ≤ a) (x : ℝ) {n : ℕ} (hn : n ≠ 0) :
+    (LSeries.term a (x : ℂ) n).re = (a n).re / (n : ℝ) ^ x := by
+  have hA : a n = ((a n).re : ℂ) :=
+    Complex.eq_re_of_ofReal_le (by rw [Complex.ofReal_zero]; exact ha n)
+  have hcast : (n : ℂ) ^ (x : ℂ) = (((n : ℝ) ^ x : ℝ) : ℂ) := by
+    rw [← Complex.ofReal_natCast, ← Complex.ofReal_cpow (Nat.cast_nonneg n)]
+  rw [LSeries.term_of_ne_zero hn, hA, hcast, ← Complex.ofReal_div, Complex.ofReal_re,
+    Complex.ofReal_re]
+
+/-- The real part of a Dirichlet term of a nonnegative coefficient sequence is nonnegative. -/
+lemma re_term_nonneg (ha : 0 ≤ a) (x : ℝ) (n : ℕ) : 0 ≤ (LSeries.term a (x : ℂ) n).re := by
+  simpa using (Complex.le_def.mp (LSeries.term_nonneg (ha n) x)).1
+
+/-- For nonnegative coefficients and `x` in the half-plane of absolute convergence, the real
+series `∑ (log n) ^ k * a n / n ^ x` converges to the real part of the L-series of
+`log ^ k * a`. -/
+lemma hasSum_logPow_mul_re_term (ha : 0 ≤ a) {x : ℝ}
+    (hx : LSeries.abscissaOfAbsConv a < x) (k : ℕ) :
+    HasSum (fun n : ℕ ↦ Real.log n ^ k * (LSeries.term a (x : ℂ) n).re)
+      (LSeries (LSeries.logMul^[k] a) (x : ℂ)).re := by
+  have hsum : LSeriesSummable (LSeries.logMul^[k] a) (x : ℂ) :=
+    LSeriesSummable_of_abscissaOfAbsConv_lt_re (by
+      simpa [LSeries.absicssaOfAbsConv_logPowMul] using hx)
+  have h : HasSum (LSeries.term (LSeries.logMul^[k] a) (x : ℂ))
+      (LSeries (LSeries.logMul^[k] a) (x : ℂ)) := hsum.hasSum
+  refine (Complex.hasSum_re h).congr_fun fun n ↦ ?_
+  rw [term_logMul_iterate]
+  have hre : (LSeries.term a (x : ℂ) n) = ((LSeries.term a (x : ℂ) n).re : ℂ) :=
+    Complex.eq_re_of_ofReal_le (by
+      rw [Complex.ofReal_zero]; exact LSeries.term_nonneg (ha n) x)
+  rw [hre, ← Complex.ofReal_pow, ← Complex.ofReal_mul]
+  exact (Complex.ofReal_re _).symm
+
+/-- `HasAnalyticExtensionAt a σ` says that the L-series of `a` continues analytically across the
+real point `σ`: some function differentiable on a disc around `σ` agrees with `LSeries a` on the
+part of that disc lying in the half-plane `Re s > σ`. -/
+def HasAnalyticExtensionAt (a : ℕ → ℂ) (σ : ℝ) : Prop :=
+  ∃ r : ℝ, 0 < r ∧ ∃ F : ℂ → ℂ, DifferentiableOn ℂ F (ball (σ : ℂ) r) ∧
+    ∀ s ∈ ball (σ : ℂ) r, σ < s.re → F s = LSeries a s
+
+/-- Above the abscissa of absolute convergence the L-series continues across every real point:
+it is already analytic there. -/
+lemma hasAnalyticExtensionAt_of_abscissaOfAbsConv_lt {σ : ℝ}
+    (h : LSeries.abscissaOfAbsConv a < σ) : HasAnalyticExtensionAt a σ := by
+  obtain ⟨σ', h₁, h₂⟩ := EReal.exists_between_coe_real h
+  have h₂' : σ' < σ := mod_cast h₂
+  refine ⟨σ - σ', by linarith, LSeries a, ?_, fun _ _ _ ↦ rfl⟩
+  refine (LSeries_differentiableOn a).mono fun s hs ↦ ?_
+  have key : |s.re - σ| ≤ dist s ((σ : ℝ) : ℂ) := by
+    rw [dist_eq_norm]
+    simpa using Complex.abs_re_le_norm (s - ((σ : ℝ) : ℂ))
+  rw [mem_ball] at hs
+  have hσ' : σ' < s.re := by
+    have := (abs_lt.mp (key.trans_lt hs)).1
+    linarith
+  exact Set.mem_ofPred.mpr (h₁.trans_le (by exact_mod_cast hσ'.le))
+
+/-- **Landau's theorem.** If `a` has nonnegative values and its abscissa of absolute convergence
+is the real number `σ`, then `LSeries a` has no analytic continuation across `σ`. -/
+theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (σ : EReal)) :
+    ¬ HasAnalyticExtensionAt a σ := by
+  rintro ⟨r, hr, F, hF, hFeq⟩
+  set δ : ℝ := min (r ^ 2 / 4) 1 with hδdef
+  have hδpos : 0 < δ := lt_min (by positivity) one_pos
+  have hδ1 : δ ≤ 1 := min_le_right _ _
+  have hδr : 3 * δ < r ^ 2 := by
+    have h4 : δ ≤ r ^ 2 / 4 := min_le_left _ _
+    nlinarith
+  set c : ℝ := σ + 1 with hcdef
+  set U : Set ℂ := {s : ℂ | σ < s.re} with hUdef
+  have hUopen : IsOpen U := isOpen_lt continuous_const Complex.continuous_re
+  have habs_lt : ∀ {s : ℂ}, σ < s.re → LSeries.abscissaOfAbsConv a < s.re := by
+    intro s hs
+    rw [habs]
+    exact_mod_cast hs
+  set G : ℂ → ℂ := fun s ↦ if σ < s.re then LSeries a s else F s with hGdef
+  have hGU : Set.EqOn G (LSeries a) U := fun s hs ↦ ite_eq_left hs
+  have hGF : Set.EqOn G F (ball ((σ : ℝ) : ℂ) r) := by
+    intro s hs
+    by_cases h : σ < s.re
+    · simp only [hGdef]
+      rw [ite_eq_left h]
+      exact (hFeq s hs h).symm
+    · simp only [hGdef]
+      exact ite_eq_right h
+  -- every point of the disc of radius `1 + δ` around `c` lies in the half-plane or in the
+  -- given disc around `σ`
+  have hsub : ∀ s ∈ ball ((c : ℝ) : ℂ) (1 + δ), σ < s.re ∨ s ∈ ball ((σ : ℝ) : ℂ) r := by
+    intro s hs
+    by_cases h : σ < s.re
+    · exact Or.inl h
+    replace h := not_lt.mp h
+    refine Or.inr ?_
+    rw [mem_ball, Complex.dist_eq_re_im, Real.sqrt_lt' hr]
+    rw [mem_ball, Complex.dist_eq_re_im, Real.sqrt_lt' (by linarith)] at hs
+    simp only [Complex.ofReal_re, Complex.ofReal_im, hcdef] at hs ⊢
+    nlinarith [sq_nonneg (s.im - 0), sq_nonneg (s.re - σ)]
+  have hGdiff : ∀ s ∈ ball ((c : ℝ) : ℂ) (1 + δ), DifferentiableAt ℂ G s := by
+    intro s hs
+    rcases hsub s hs with h | h
+    · have hev : G =ᶠ[nhds s] LSeries a :=
+        Filter.eventuallyEq_of_mem (hUopen.mem_nhds h) hGU
+      exact hev.differentiableAt_iff.mpr (LSeries_hasDerivAt (habs_lt h)).differentiableAt
+    · have hev : G =ᶠ[nhds s] F := Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds h) hGF
+      exact hev.differentiableAt_iff.mpr (hF.differentiableAt (isOpen_ball.mem_nhds h))
+  -- Taylor expansion of `G` at `c`, evaluated at the real point `x = σ - δ / 2`
+  set y : ℝ := 1 + δ / 2 with hydef
+  set x : ℝ := c - y with hxdef
+  have hy0 : 0 < y := by rw [hydef]; linarith
+  have hxσ : x < σ := by rw [hxdef, hydef, hcdef]; linarith
+  have habsc : LSeries.abscissaOfAbsConv a < c := by
+    rw [habs]
+    exact_mod_cast (by rw [hcdef]; linarith : σ < c)
+  have hxball : ((x : ℝ) : ℂ) ∈ ball ((c : ℝ) : ℂ) (1 + δ) := by
+    rw [mem_ball, Complex.isometry_ofReal.dist_eq, Real.dist_eq, hxdef,
+      show c - y - c = -y by ring, abs_neg, abs_of_pos hy0, hydef]
+    linarith
+  have hGdiffOn : DifferentiableOn ℂ G (ball ((c : ℝ) : ℂ) (1 + δ)) :=
+    fun s hs ↦ (hGdiff s hs).differentiableWithinAt
+  have htaylor := Complex.hasSum_taylorSeries_on_ball hGdiffOn hxball
+  have hcU : ((c : ℝ) : ℂ) ∈ U := by
+    simp only [hUdef, Set.mem_ofPred_eq, Complex.ofReal_re, hcdef]
+    linarith
+  have hterm : ∀ k : ℕ, (Nat.factorial k : ℂ)⁻¹ • (((x : ℝ) : ℂ) - ((c : ℝ) : ℂ)) ^ k •
+      iteratedDeriv k G ((c : ℝ) : ℂ)
+      = ((y ^ k / Nat.factorial k *
+          (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re : ℝ) : ℂ) := by
+    intro k
+    have hd : iteratedDeriv k G ((c : ℝ) : ℂ) = iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ) :=
+      hGU.iteratedDeriv_of_isOpen hUopen k hcU
+    have hTk : LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)
+        = (((LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re : ℝ) : ℂ) :=
+      Complex.eq_re_of_ofReal_le (by
+        rw [Complex.ofReal_zero]; exact LSeries_logMul_iterate_nonneg ha habsc k)
+    have hzc : ((x : ℝ) : ℂ) - ((c : ℝ) : ℂ) = -((y : ℝ) : ℂ) := by
+      rw [hxdef]; push_cast; ring
+    have e1 : (-((y : ℝ) : ℂ)) ^ k * iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ)
+        = ((y : ℝ) : ℂ) ^ k * ((-1 : ℂ) ^ k * iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ)) := by
+      rw [neg_pow]; ring
+    rw [hd, hzc, smul_eq_mul, smul_eq_mul, e1, ← LSeries_logMul_iterate_eq habsc k]
+    nth_rewrite 1 [hTk]
+    push_cast
+    ring
+  -- the majorant series over `k` converges
+  have hsummable_k : Summable (fun k : ℕ ↦ y ^ k / Nat.factorial k *
+      (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re) :=
+    Complex.summable_ofReal.mp (htaylor.congr_fun fun k ↦ (hterm k).symm).summable
+  -- expand each Dirichlet term at `x` as a series in `k`
+  have hexp : ∀ n : ℕ, HasSum (fun k : ℕ ↦ y ^ k / Nat.factorial k *
+      (Real.log n ^ k * (LSeries.term a ((c : ℝ) : ℂ) n).re))
+      ((LSeries.term a ((x : ℝ) : ℂ) n).re) := by
+    intro n
+    have h1 : HasSum (fun k : ℕ ↦ (y * Real.log n) ^ k / Nat.factorial k)
+        (Real.exp (y * Real.log n)) := by
+      rw [Real.exp_eq_exp_ℝ]
+      exact NormedSpace.expSeries_div_hasSum_exp _
+    have h2 := h1.mul_right ((LSeries.term a ((c : ℝ) : ℂ) n).re)
+    have heq : Real.exp (y * Real.log n) * (LSeries.term a ((c : ℝ) : ℂ) n).re
+        = (LSeries.term a ((x : ℝ) : ℂ) n).re := by
+      rcases eq_or_ne n 0 with rfl | hn
+      · simp
+      · have hn0 : (0 : ℝ) < n := by positivity
+        have hyexp : Real.exp (y * Real.log n) = (n : ℝ) ^ y := by
+          rw [Real.rpow_def_of_pos hn0, mul_comm]
+        have hc : (n : ℝ) ^ c = (n : ℝ) ^ x * (n : ℝ) ^ y := by
+          rw [← Real.rpow_add hn0, hxdef]
+          norm_num
+        rw [re_term_of_ne_zero ha c hn, re_term_of_ne_zero ha x hn, hyexp, hc]
+        field_simp
+    rw [← heq]
+    refine h2.congr_fun fun k ↦ ?_
+    rw [mul_pow]
+    ring
+  -- hence the L-series converges absolutely at `x < σ`
+  have hsum_x : Summable (fun n : ℕ ↦ (LSeries.term a ((x : ℝ) : ℂ) n).re) := by
+    refine summable_of_sum_le (c := ∑' k : ℕ, y ^ k / Nat.factorial k *
+      (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re)
+      (fun n ↦ re_term_nonneg ha x n) fun s ↦ ?_
+    refine hasSum_le (fun k ↦ ?_) (hasSum_sum fun n _ ↦ hexp n) hsummable_k.hasSum
+    rw [← Finset.mul_sum]
+    refine mul_le_mul_of_nonneg_left ?_
+      (div_nonneg (pow_nonneg hy0.le k) (Nat.cast_nonneg _))
+    exact sum_le_hasSum s
+      (fun n _ ↦ mul_nonneg (pow_nonneg (Real.log_natCast_nonneg n) k) (re_term_nonneg ha c n))
+      (hasSum_logPow_mul_re_term ha habsc k)
+  have hLS : LSeriesSummable a ((x : ℝ) : ℂ) :=
+    (Complex.summable_ofReal.mpr hsum_x).congr fun n ↦
+      (Complex.eq_re_of_ofReal_le (by
+        rw [Complex.ofReal_zero]; exact LSeries.term_nonneg (ha n) x)).symm
+  have hle := hLS.abscissaOfAbsConv_le
+  rw [habs, Complex.ofReal_re] at hle
+  exact absurd (show σ ≤ x from mod_cast hle) (by linarith)
+
+/-- **Landau's theorem, half-plane form.** A Dirichlet series with nonnegative coefficients and
+finite abscissa of absolute convergence converges as far to the left as it continues
+analytically: if some function differentiable on `Re s > σ₁` agrees with `LSeries a` on the
+half-plane of absolute convergence, then that abscissa is at most `σ₁`.
+
+This is the form consumed by nonvanishing arguments, where `F` is a quotient of L-functions known
+to be analytic on a half-plane, or on the complement of a pole that a positive combination has
+already cancelled. -/
+theorem abscissaOfAbsConv_le_of_differentiableOn (ha : 0 ≤ a)
+    (hfin : LSeries.abscissaOfAbsConv a ≠ ⊤) {σ₁ : ℝ} {F : ℂ → ℂ}
+    (hF : DifferentiableOn ℂ F {s : ℂ | σ₁ < s.re})
+    (hFeq : ∀ s : ℂ, LSeries.abscissaOfAbsConv a < s.re → F s = LSeries a s) :
+    LSeries.abscissaOfAbsConv a ≤ σ₁ := by
+  by_contra hcon
+  have hlt : (σ₁ : EReal) < LSeries.abscissaOfAbsConv a := not_le.mp hcon
+  have hbot : LSeries.abscissaOfAbsConv a ≠ ⊥ := fun h ↦ by simp [h] at hlt
+  set σ : ℝ := (LSeries.abscissaOfAbsConv a).toReal with hσdef
+  have habs : LSeries.abscissaOfAbsConv a = (σ : EReal) := (EReal.coe_toReal hfin hbot).symm
+  have hσ₁σ : σ₁ < σ := by rw [habs] at hlt; exact_mod_cast hlt
+  refine landau ha habs ⟨σ - σ₁, by linarith, F, ?_, fun s _ h ↦ hFeq s ?_⟩
+  · refine hF.mono fun s hs ↦ ?_
+    have key : |s.re - σ| ≤ dist s ((σ : ℝ) : ℂ) := by
+      rw [dist_eq_norm]
+      simpa using Complex.abs_re_le_norm (s - ((σ : ℝ) : ℂ))
+    rw [mem_ball] at hs
+    have := (abs_lt.mp (key.trans_lt hs)).1
+    exact Set.mem_ofPred.mpr (by linarith)
+  · rw [habs]
+    exact_mod_cast h
+
+/-- **Landau's theorem, entire form.** If `a` has nonnegative values, its abscissa of absolute
+convergence is finite, and `LSeries a` agrees on its half-plane of convergence with an entire
+function, then the L-series converges absolutely at every point of the plane.
+
+This is the shape used to rule out a hypothetical zero of an L-function: the zero would cancel a
+pole, making a product of L-series entire, and a nonnegative Dirichlet series that is entire must
+converge everywhere. -/
+theorem abscissaOfAbsConv_eq_bot_of_differentiable (ha : 0 ≤ a)
+    (hfin : LSeries.abscissaOfAbsConv a ≠ ⊤) {F : ℂ → ℂ} (hF : Differentiable ℂ F)
+    (hFeq : ∀ s : ℂ, LSeries.abscissaOfAbsConv a < s.re → F s = LSeries a s) :
+    LSeries.abscissaOfAbsConv a = ⊥ := by
+  have key : ∀ σ₁ : ℝ, LSeries.abscissaOfAbsConv a ≤ (σ₁ : EReal) := fun σ₁ ↦
+    abscissaOfAbsConv_le_of_differentiableOn ha hfin hF.differentiableOn hFeq
+  refine le_antisymm ?_ bot_le
+  by_contra hne
+  obtain ⟨r, -, hr⟩ := EReal.exists_between_coe_real (not_le.mp hne)
+  exact absurd (key r) (not_le.mpr hr)
+
+/-- A Dirichlet series with nonnegative coefficients that has an entire extension in the sense of
+`LSeries.HasEntireExtension` converges absolutely at every point of the plane. -/
+theorem abscissaOfAbsConv_eq_bot_of_hasEntireExtension (ha : 0 ≤ a)
+    (h : LSeries.HasEntireExtension a) : LSeries.abscissaOfAbsConv a = ⊥ := by
+  obtain ⟨F, hF, hFa⟩ := h.exists_extension
+  exact abscissaOfAbsConv_eq_bot_of_differentiable ha h.abscissa_lt_top.ne hF fun _ hs ↦ hFa hs
+
+/-- **The Dirichlet series of the Riemann zeta function is singular at `s = 1`.** The constant
+sequence `1` has nonnegative values and abscissa of absolute convergence `1`, so Landau's theorem
+applies: no function differentiable on a disc around `1` agrees with `LSeries 1` to the right
+of `1`. -/
+theorem not_hasAnalyticExtensionAt_one : ¬ HasAnalyticExtensionAt (1 : ℕ → ℂ) 1 :=
+  landau (fun _ ↦ zero_le_one) (by
+    rw [EReal.coe_one]
+    exact LSeries.abscissaOfAbsConv_one)
+
+end TauCeti.LSeries

--- a/TauCeti/NumberTheory/LSeries/Landau.lean
+++ b/TauCeti/NumberTheory/LSeries/Landau.lean
@@ -131,22 +131,6 @@ def HasAnalyticExtensionAt (a : ℕ → ℂ) (σ : ℝ) : Prop :=
   ∃ r : ℝ, 0 < r ∧ ∃ F : ℂ → ℂ, DifferentiableOn ℂ F (ball (σ : ℂ) r) ∧
     ∀ s ∈ ball (σ : ℂ) r, σ < s.re → F s = LSeries a s
 
-namespace HasAnalyticExtensionAt
-
-/-- Introduction lemma for an analytic extension across a real point. -/
-theorem of_differentiableOn {r : ℝ} (hr : 0 < r) {F : ℂ → ℂ}
-    (hF : DifferentiableOn ℂ F (ball ((σ : ℝ) : ℂ) r))
-    (hFa : ∀ s ∈ ball ((σ : ℝ) : ℂ) r, σ < s.re → F s = LSeries a s) :
-    HasAnalyticExtensionAt a σ :=
-  ⟨r, hr, F, hF, hFa⟩
-
-/-- Elimination lemma for an analytic extension across a real point. -/
-theorem exists_extension (h : HasAnalyticExtensionAt a σ) :
-    ∃ r : ℝ, 0 < r ∧ ∃ F : ℂ → ℂ, DifferentiableOn ℂ F (ball ((σ : ℝ) : ℂ) r) ∧
-      ∀ s ∈ ball ((σ : ℝ) : ℂ) r, σ < s.re → F s = LSeries a s := h
-
-end HasAnalyticExtensionAt
-
 private lemma sub_lt_re_of_mem_ball {σ r : ℝ} {s : ℂ}
     (hs : s ∈ ball ((σ : ℝ) : ℂ) r) : σ - r < s.re := by
   have key : |s.re - σ| ≤ dist s ((σ : ℝ) : ℂ) := by
@@ -162,7 +146,7 @@ lemma hasAnalyticExtensionAt_of_abscissaOfAbsConv_lt {σ : ℝ}
     (h : LSeries.abscissaOfAbsConv a < σ) : HasAnalyticExtensionAt a σ := by
   obtain ⟨σ', h₁, h₂⟩ := EReal.exists_between_coe_real h
   have h₂' : σ' < σ := mod_cast h₂
-  refine .of_differentiableOn (r := σ - σ') (by linarith) ?_ fun _ _ _ ↦ rfl
+  refine ⟨σ - σ', by linarith, LSeries a, ?_, fun _ _ _ ↦ rfl⟩
   refine (LSeries_differentiableOn a).mono fun s hs ↦ ?_
   have hσ' : σ' < s.re := by
     have := sub_lt_re_of_mem_ball hs
@@ -174,7 +158,7 @@ private lemma exists_differentiableOn_patch {σ : ℝ}
     ∃ δ : ℝ, 0 < δ ∧ ∃ G : ℂ → ℂ,
       DifferentiableOn ℂ G (ball (((σ + 1 : ℝ) : ℂ)) (1 + δ)) ∧
         Set.EqOn G (LSeries a) {s : ℂ | σ < s.re} := by
-  obtain ⟨r, hr, F, hF, hFeq⟩ := h.exists_extension
+  obtain ⟨r, hr, F, hF, hFeq⟩ := h
   set δ : ℝ := min (r ^ 2 / 4) 1 with hδdef
   have hδpos : 0 < δ := lt_min (by positivity) one_pos
   have hδ1 : δ ≤ 1 := min_le_right _ _
@@ -193,11 +177,8 @@ private lemma exists_differentiableOn_patch {σ : ℝ}
   have hGF : Set.EqOn G F (ball ((σ : ℝ) : ℂ) r) := by
     intro s hs
     by_cases hsσ : σ < s.re
-    · change (if σ < s.re then LSeries a s else F s) = F s
-      rw [ite_eq_left hsσ]
-      exact (hFeq s hs hsσ).symm
-    · change (if σ < s.re then LSeries a s else F s) = F s
-      exact ite_eq_right hsσ
+    · simpa [hGdef, hsσ] using (hFeq s hs hsσ).symm
+    · simp [hGdef, hsσ]
   have hsub : ∀ s ∈ ball (((σ + 1 : ℝ) : ℂ)) (1 + δ),
       σ < s.re ∨ s ∈ ball ((σ : ℝ) : ℂ) r := by
     intro s hs
@@ -360,8 +341,7 @@ theorem abscissaOfAbsConv_le_of_differentiableOn (ha : 0 ≤ a)
   set σ : ℝ := (LSeries.abscissaOfAbsConv a).toReal with hσdef
   have habs : LSeries.abscissaOfAbsConv a = (σ : EReal) := (EReal.coe_toReal hfin hbot).symm
   have hσ₁σ : σ₁ < σ := by rw [habs] at hlt; exact_mod_cast hlt
-  refine landau ha habs (HasAnalyticExtensionAt.of_differentiableOn
-    (a := a) (σ := σ) (F := F) (r := σ - σ₁) (by linarith) ?_ ?_)
+  refine landau ha habs ⟨σ - σ₁, by linarith, F, ?_, ?_⟩
   · refine hF.mono fun s hs ↦ ?_
     have := sub_lt_re_of_mem_ball hs
     exact Set.mem_ofPred.mpr (by linarith)

--- a/TauCeti/NumberTheory/LSeries/Landau.lean
+++ b/TauCeti/NumberTheory/LSeries/Landau.lean
@@ -5,10 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Complex.TaylorSeries
-public import Mathlib.Analysis.SpecialFunctions.Exponential
-public import Mathlib.NumberTheory.LSeries.Dirichlet
-public import Mathlib.NumberTheory.LSeries.Positivity
+import Mathlib.Analysis.Complex.TaylorSeries
+import Mathlib.Analysis.SpecialFunctions.Exponential
+import Mathlib.NumberTheory.LSeries.Positivity
+public import Mathlib.NumberTheory.LSeries.Deriv
 public import TauCeti.NumberTheory.LSeries.EntireExtension
 
 /-!
@@ -36,8 +36,6 @@ its own analytic continuation.
   nonvanishing argument applies once a positive combination of L-series has been shown entire.
 * `TauCeti.LSeries.abscissaOfAbsConv_eq_bot_of_hasEntireExtension`: the same conclusion phrased
   through the repository's `LSeries.HasEntireExtension` predicate.
-* `TauCeti.LSeries.not_hasAnalyticExtensionAt_one`: the coefficient sequence of the Riemann zeta
-  function is singular at `s = 1`.
 
 ## Implementation notes
 
@@ -87,18 +85,17 @@ lemma term_logMul_iterate (f : ℕ → ℂ) (s : ℂ) (k n : ℕ) :
 
 /-- The `k`-th iterated derivative of an L-series, with its alternating sign removed, is the
 L-series of `log ^ k * a`. -/
-lemma LSeries_logMul_iterate_eq {x : ℝ} (hx : LSeries.abscissaOfAbsConv a < x) (k : ℕ) :
-    LSeries (LSeries.logMul^[k] a) (x : ℂ)
-      = (-1 : ℂ) ^ k * iteratedDeriv k (LSeries a) (x : ℂ) := by
-  rw [LSeries_iteratedDeriv k (by simpa using hx), ← mul_assoc, ← pow_add,
-    Even.neg_one_pow ⟨k, rfl⟩, one_mul]
+lemma LSeries_logMul_iterate_eq {s : ℂ} (hs : LSeries.abscissaOfAbsConv a < s.re) (k : ℕ) :
+    LSeries (LSeries.logMul^[k] a) s = (-1 : ℂ) ^ k * iteratedDeriv k (LSeries a) s := by
+  rw [LSeries_iteratedDeriv k hs, ← mul_assoc, ← pow_add, Even.neg_one_pow ⟨k, rfl⟩, one_mul]
 
 /-- For nonnegative coefficients the L-series of `log ^ k * a` is a nonnegative real number
 throughout the half-plane of absolute convergence. -/
 lemma LSeries_logMul_iterate_nonneg (ha : 0 ≤ a) {x : ℝ}
     (hx : LSeries.abscissaOfAbsConv a < x) (k : ℕ) :
     0 ≤ LSeries (LSeries.logMul^[k] a) (x : ℂ) :=
-  (LSeries_logMul_iterate_eq hx k).symm ▸ LSeries.iteratedDeriv_alternating ha hx k
+  (LSeries_logMul_iterate_eq (s := (x : ℂ)) (by simpa using hx) k).symm ▸
+    LSeries.iteratedDeriv_alternating ha hx k
 
 /-- The real part of a Dirichlet term of a nonnegative coefficient sequence at a real point. -/
 lemma re_term_of_ne_zero (ha : 0 ≤ a) (x : ℝ) {n : ℕ} (hn : n ≠ 0) :
@@ -109,10 +106,6 @@ lemma re_term_of_ne_zero (ha : 0 ≤ a) (x : ℝ) {n : ℕ} (hn : n ≠ 0) :
     rw [← Complex.ofReal_natCast, ← Complex.ofReal_cpow (Nat.cast_nonneg n)]
   rw [LSeries.term_of_ne_zero hn, hA, hcast, ← Complex.ofReal_div, Complex.ofReal_re,
     Complex.ofReal_re]
-
-/-- The real part of a Dirichlet term of a nonnegative coefficient sequence is nonnegative. -/
-lemma re_term_nonneg (ha : 0 ≤ a) (x : ℝ) (n : ℕ) : 0 ≤ (LSeries.term a (x : ℂ) n).re := by
-  simpa using (Complex.le_def.mp (LSeries.term_nonneg (ha n) x)).1
 
 /-- For nonnegative coefficients and `x` in the half-plane of absolute convergence, the real
 series `∑ (log n) ^ k * a n / n ^ x` converges to the real part of the L-series of
@@ -214,9 +207,11 @@ theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (
   have habsc : LSeries.abscissaOfAbsConv a < c := by
     rw [habs]
     exact_mod_cast (by rw [hcdef]; linarith : σ < c)
+  have hxc : x - c = -y := by rw [hxdef]; ring
+  have habsc' : LSeries.abscissaOfAbsConv a < (((c : ℝ) : ℂ)).re := by simpa using habsc
   have hxball : ((x : ℝ) : ℂ) ∈ ball ((c : ℝ) : ℂ) (1 + δ) := by
-    rw [mem_ball, Complex.isometry_ofReal.dist_eq, Real.dist_eq, hxdef,
-      show c - y - c = -y by ring, abs_neg, abs_of_pos hy0, hydef]
+    rw [mem_ball, Complex.isometry_ofReal.dist_eq, Real.dist_eq, hxc, abs_neg,
+      abs_of_pos hy0, hydef]
     linarith
   have hGdiffOn : DifferentiableOn ℂ G (ball ((c : ℝ) : ℂ) (1 + δ)) :=
     fun s hs ↦ (hGdiff s hs).differentiableWithinAt
@@ -240,7 +235,7 @@ theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (
     have e1 : (-((y : ℝ) : ℂ)) ^ k * iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ)
         = ((y : ℝ) : ℂ) ^ k * ((-1 : ℂ) ^ k * iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ)) := by
       rw [neg_pow]; ring
-    rw [hd, hzc, smul_eq_mul, smul_eq_mul, e1, ← LSeries_logMul_iterate_eq habsc k]
+    rw [hd, hzc, smul_eq_mul, smul_eq_mul, e1, ← LSeries_logMul_iterate_eq habsc' k]
     nth_rewrite 1 [hTk]
     push_cast
     ring
@@ -278,13 +273,14 @@ theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (
   have hsum_x : Summable (fun n : ℕ ↦ (LSeries.term a ((x : ℝ) : ℂ) n).re) := by
     refine summable_of_sum_le (c := ∑' k : ℕ, y ^ k / Nat.factorial k *
       (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re)
-      (fun n ↦ re_term_nonneg ha x n) fun s ↦ ?_
+      (fun n ↦ by simpa using (Complex.le_def.mp (LSeries.term_nonneg (ha n) x)).1) fun s ↦ ?_
     refine hasSum_le (fun k ↦ ?_) (hasSum_sum fun n _ ↦ hexp n) hsummable_k.hasSum
     rw [← Finset.mul_sum]
     refine mul_le_mul_of_nonneg_left ?_
       (div_nonneg (pow_nonneg hy0.le k) (Nat.cast_nonneg _))
     exact sum_le_hasSum s
-      (fun n _ ↦ mul_nonneg (pow_nonneg (Real.log_natCast_nonneg n) k) (re_term_nonneg ha c n))
+      (fun n _ ↦ mul_nonneg (pow_nonneg (Real.log_natCast_nonneg n) k)
+        (by simpa using (Complex.le_def.mp (LSeries.term_nonneg (ha n) c)).1))
       (hasSum_logPow_mul_re_term ha habsc k)
   have hLS : LSeriesSummable a ((x : ℝ) : ℂ) :=
     (Complex.summable_ofReal.mpr hsum_x).congr fun n ↦
@@ -292,7 +288,8 @@ theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (
         rw [Complex.ofReal_zero]; exact LSeries.term_nonneg (ha n) x)).symm
   have hle := hLS.abscissaOfAbsConv_le
   rw [habs, Complex.ofReal_re] at hle
-  exact absurd (show σ ≤ x from mod_cast hle) (by linarith)
+  have hσx : σ ≤ x := mod_cast hle
+  linarith
 
 /-- **Landau's theorem, half-plane form.** A Dirichlet series with nonnegative coefficients and
 finite abscissa of absolute convergence converges as far to the left as it continues
@@ -348,14 +345,5 @@ theorem abscissaOfAbsConv_eq_bot_of_hasEntireExtension (ha : 0 ≤ a)
     (h : LSeries.HasEntireExtension a) : LSeries.abscissaOfAbsConv a = ⊥ := by
   obtain ⟨F, hF, hFa⟩ := h.exists_extension
   exact abscissaOfAbsConv_eq_bot_of_differentiable ha h.abscissa_lt_top.ne hF fun _ hs ↦ hFa hs
-
-/-- **The Dirichlet series of the Riemann zeta function is singular at `s = 1`.** The constant
-sequence `1` has nonnegative values and abscissa of absolute convergence `1`, so Landau's theorem
-applies: no function differentiable on a disc around `1` agrees with `LSeries 1` to the right
-of `1`. -/
-theorem not_hasAnalyticExtensionAt_one : ¬ HasAnalyticExtensionAt (1 : ℕ → ℂ) 1 :=
-  landau (fun _ ↦ zero_le_one) (by
-    rw [EReal.coe_one]
-    exact LSeries.abscissaOfAbsConv_one)
 
 end TauCeti.LSeries

--- a/TauCeti/NumberTheory/LSeries/Landau.lean
+++ b/TauCeti/NumberTheory/LSeries/Landau.lean
@@ -32,17 +32,16 @@ its own analytic continuation.
   throughout `Re s > σ` alone would not suffice.
 * `TauCeti.LSeries.abscissaOfAbsConv_le_of_differentiableOn`: the half-plane form. A nonnegative
   Dirichlet series with finite abscissa converges as far to the left as it continues analytically.
-* `TauCeti.LSeries.abscissaOfAbsConv_eq_bot_of_differentiable`: the entire form, which is what a
-  nonvanishing argument applies once a positive combination of L-series has been shown entire.
 * `TauCeti.LSeries.abscissaOfAbsConv_eq_bot_of_hasEntireExtension`: the same conclusion phrased
-  through the repository's `LSeries.HasEntireExtension` predicate.
+  through the repository's `LSeries.HasEntireExtension` predicate, which is what a nonvanishing
+  argument applies once a positive combination of L-series has been shown entire.
 
 ## Implementation notes
 
-Mathlib's `LSeriesSummable` is equivalent to absolute summability of the Dirichlet terms, since
-`summable_norm_iff` holds in `ℂ`; consequently `LSeriesSummable.abscissaOfAbsConv_le` already
-identifies the ordinary and the absolute abscissa, and no separate lemma is needed here for
-nonnegative coefficients.
+Mathlib formalizes only the abscissa of absolute convergence: `LSeriesSummable` is equivalent to
+absolute summability of the Dirichlet terms because `summable_norm_iff` holds in `ℂ`. It does not
+define the classical abscissa of conditional convergence, so the ordinary/absolute distinction
+does not arise in this development and no equality between those abscissae is proved here.
 
 The proof follows the classical argument. Suppose `F` is analytic on a disc around `σ` and agrees
 with `LSeries a` to its right. Patching `F` with `LSeries a` produces a function `G` analytic on a
@@ -54,9 +53,8 @@ series, contradicting `abscissaOfAbsConv a = σ`.
 
 ## References
 
-* H. Davenport, *Multiplicative Number Theory*, §11.
-* G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter II.1,
-  Theorem 10.
+* [G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*][tenenbaum1995],
+  Chapter II.1, Theorem 10.
 -/
 
 public section
@@ -68,8 +66,9 @@ open scoped ComplexOrder
 
 variable {a : ℕ → ℂ}
 
-/-- Iterating `LSeries.logMul` multiplies the Dirichlet term by a power of `Real.log n`. -/
-lemma term_logMul_iterate (f : ℕ → ℂ) (s : ℂ) (k n : ℕ) :
+/-- Applying Mathlib's `logPowMul` operation multiplies the Dirichlet term by a power of
+`Real.log n`. -/
+lemma term_logPowMul (f : ℕ → ℂ) (s : ℂ) (k n : ℕ) :
     LSeries.term (LSeries.logMul^[k] f) s n = (Real.log n : ℂ) ^ k * LSeries.term f s n := by
   induction k with
   | zero => simp
@@ -83,34 +82,27 @@ lemma term_logMul_iterate (f : ℕ → ℂ) (s : ℂ) (k n : ℕ) :
     rw [Function.iterate_succ_apply', h1, ih, pow_succ]
     ring
 
-/-- The `k`-th iterated derivative of an L-series, with its alternating sign removed, is the
-L-series of `log ^ k * a`. -/
-lemma LSeries_logMul_iterate_eq {s : ℂ} (hs : LSeries.abscissaOfAbsConv a < s.re) (k : ℕ) :
+private lemma logPowMul_eq_alternating {s : ℂ}
+    (hs : LSeries.abscissaOfAbsConv a < s.re) (k : ℕ) :
     LSeries (LSeries.logMul^[k] a) s = (-1 : ℂ) ^ k * iteratedDeriv k (LSeries a) s := by
   rw [LSeries_iteratedDeriv k hs, ← mul_assoc, ← pow_add, Even.neg_one_pow ⟨k, rfl⟩, one_mul]
 
-/-- For nonnegative coefficients the L-series of `log ^ k * a` is a nonnegative real number
-throughout the half-plane of absolute convergence. -/
-lemma LSeries_logMul_iterate_nonneg (ha : 0 ≤ a) {x : ℝ}
+private lemma logPowMul_nonneg (ha : 0 ≤ a) {x : ℝ}
     (hx : LSeries.abscissaOfAbsConv a < x) (k : ℕ) :
     0 ≤ LSeries (LSeries.logMul^[k] a) (x : ℂ) :=
-  (LSeries_logMul_iterate_eq (s := (x : ℂ)) (by simpa using hx) k).symm ▸
+  (logPowMul_eq_alternating (s := (x : ℂ)) (by simpa using hx) k).symm ▸
     LSeries.iteratedDeriv_alternating ha hx k
 
-/-- The real part of a Dirichlet term of a nonnegative coefficient sequence at a real point. -/
-lemma re_term_of_ne_zero (ha : 0 ≤ a) (x : ℝ) {n : ℕ} (hn : n ≠ 0) :
+/-- The real part of a Dirichlet term at a real point. -/
+lemma re_term_of_ne_zero (a : ℕ → ℂ) (x : ℝ) {n : ℕ} (hn : n ≠ 0) :
     (LSeries.term a (x : ℂ) n).re = (a n).re / (n : ℝ) ^ x := by
-  have hA : a n = ((a n).re : ℂ) :=
-    Complex.eq_re_of_ofReal_le (by rw [Complex.ofReal_zero]; exact ha n)
   have hcast : (n : ℂ) ^ (x : ℂ) = (((n : ℝ) ^ x : ℝ) : ℂ) := by
     rw [← Complex.ofReal_natCast, ← Complex.ofReal_cpow (Nat.cast_nonneg n)]
-  rw [LSeries.term_of_ne_zero hn, hA, hcast, ← Complex.ofReal_div, Complex.ofReal_re,
-    Complex.ofReal_re]
+  rw [LSeries.term_of_ne_zero hn, hcast, Complex.div_ofReal_re]
 
-/-- For nonnegative coefficients and `x` in the half-plane of absolute convergence, the real
-series `∑ (log n) ^ k * a n / n ^ x` converges to the real part of the L-series of
-`log ^ k * a`. -/
-lemma hasSum_logPow_mul_re_term (ha : 0 ≤ a) {x : ℝ}
+/-- At a real point `x` in the half-plane of absolute convergence, the real series obtained by
+taking real parts of the terms of `logPowMul` converges to the real part of its L-series. -/
+lemma hasSum_logPowMul_re_term {x : ℝ}
     (hx : LSeries.abscissaOfAbsConv a < x) (k : ℕ) :
     HasSum (fun n : ℕ ↦ Real.log n ^ k * (LSeries.term a (x : ℂ) n).re)
       (LSeries (LSeries.logMul^[k] a) (x : ℂ)).re := by
@@ -120,12 +112,17 @@ lemma hasSum_logPow_mul_re_term (ha : 0 ≤ a) {x : ℝ}
   have h : HasSum (LSeries.term (LSeries.logMul^[k] a) (x : ℂ))
       (LSeries (LSeries.logMul^[k] a) (x : ℂ)) := hsum.hasSum
   refine (Complex.hasSum_re h).congr_fun fun n ↦ ?_
-  rw [term_logMul_iterate]
-  have hre : (LSeries.term a (x : ℂ) n) = ((LSeries.term a (x : ℂ) n).re : ℂ) :=
-    Complex.eq_re_of_ofReal_le (by
-      rw [Complex.ofReal_zero]; exact LSeries.term_nonneg (ha n) x)
-  rw [hre, ← Complex.ofReal_pow, ← Complex.ofReal_mul]
-  exact (Complex.ofReal_re _).symm
+  rw [term_logPowMul, ← Complex.ofReal_pow, Complex.re_ofReal_mul]
+
+private lemma re_term_nonneg (ha : 0 ≤ a) (x : ℝ) (n : ℕ) :
+    0 ≤ (LSeries.term a (x : ℂ) n).re := by
+  simpa using (Complex.le_def.mp (LSeries.term_nonneg (ha n) x)).1
+
+private lemma term_eq_ofReal_re (ha : 0 ≤ a) (x : ℝ) (n : ℕ) :
+    LSeries.term a (x : ℂ) n = ((LSeries.term a (x : ℂ) n).re : ℂ) :=
+  Complex.eq_re_of_ofReal_le (by
+    rw [Complex.ofReal_zero]
+    exact LSeries.term_nonneg (ha n) x)
 
 /-- `HasAnalyticExtensionAt a σ` says that the L-series of `a` continues analytically across the
 real point `σ`: some function differentiable on a disc around `σ` agrees with `LSeries a` on the
@@ -134,72 +131,182 @@ def HasAnalyticExtensionAt (a : ℕ → ℂ) (σ : ℝ) : Prop :=
   ∃ r : ℝ, 0 < r ∧ ∃ F : ℂ → ℂ, DifferentiableOn ℂ F (ball (σ : ℂ) r) ∧
     ∀ s ∈ ball (σ : ℂ) r, σ < s.re → F s = LSeries a s
 
+namespace HasAnalyticExtensionAt
+
+/-- Introduction lemma for an analytic extension across a real point. -/
+theorem of_differentiableOn {r : ℝ} (hr : 0 < r) {F : ℂ → ℂ}
+    (hF : DifferentiableOn ℂ F (ball ((σ : ℝ) : ℂ) r))
+    (hFa : ∀ s ∈ ball ((σ : ℝ) : ℂ) r, σ < s.re → F s = LSeries a s) :
+    HasAnalyticExtensionAt a σ :=
+  ⟨r, hr, F, hF, hFa⟩
+
+/-- Elimination lemma for an analytic extension across a real point. -/
+theorem exists_extension (h : HasAnalyticExtensionAt a σ) :
+    ∃ r : ℝ, 0 < r ∧ ∃ F : ℂ → ℂ, DifferentiableOn ℂ F (ball ((σ : ℝ) : ℂ) r) ∧
+      ∀ s ∈ ball ((σ : ℝ) : ℂ) r, σ < s.re → F s = LSeries a s := h
+
+end HasAnalyticExtensionAt
+
+private lemma sub_lt_re_of_mem_ball {σ r : ℝ} {s : ℂ}
+    (hs : s ∈ ball ((σ : ℝ) : ℂ) r) : σ - r < s.re := by
+  have key : |s.re - σ| ≤ dist s ((σ : ℝ) : ℂ) := by
+    rw [dist_eq_norm]
+    simpa using Complex.abs_re_le_norm (s - ((σ : ℝ) : ℂ))
+  rw [mem_ball] at hs
+  have := (abs_lt.mp (key.trans_lt hs)).1
+  linarith
+
 /-- Above the abscissa of absolute convergence the L-series continues across every real point:
 it is already analytic there. -/
 lemma hasAnalyticExtensionAt_of_abscissaOfAbsConv_lt {σ : ℝ}
     (h : LSeries.abscissaOfAbsConv a < σ) : HasAnalyticExtensionAt a σ := by
   obtain ⟨σ', h₁, h₂⟩ := EReal.exists_between_coe_real h
   have h₂' : σ' < σ := mod_cast h₂
-  refine ⟨σ - σ', by linarith, LSeries a, ?_, fun _ _ _ ↦ rfl⟩
+  refine .of_differentiableOn (r := σ - σ') (by linarith) ?_ fun _ _ _ ↦ rfl
   refine (LSeries_differentiableOn a).mono fun s hs ↦ ?_
-  have key : |s.re - σ| ≤ dist s ((σ : ℝ) : ℂ) := by
-    rw [dist_eq_norm]
-    simpa using Complex.abs_re_le_norm (s - ((σ : ℝ) : ℂ))
-  rw [mem_ball] at hs
   have hσ' : σ' < s.re := by
-    have := (abs_lt.mp (key.trans_lt hs)).1
+    have := sub_lt_re_of_mem_ball hs
     linarith
   exact Set.mem_ofPred.mpr (h₁.trans_le (by exact_mod_cast hσ'.le))
 
-/-- **Landau's theorem.** If `a` has nonnegative values and its abscissa of absolute convergence
-is the real number `σ`, then `LSeries a` has no analytic continuation across `σ`. -/
-theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (σ : EReal)) :
-    ¬ HasAnalyticExtensionAt a σ := by
-  rintro ⟨r, hr, F, hF, hFeq⟩
+private lemma exists_differentiableOn_patch {σ : ℝ}
+    (habs : LSeries.abscissaOfAbsConv a = (σ : EReal)) (h : HasAnalyticExtensionAt a σ) :
+    ∃ δ : ℝ, 0 < δ ∧ ∃ G : ℂ → ℂ,
+      DifferentiableOn ℂ G (ball (((σ + 1 : ℝ) : ℂ)) (1 + δ)) ∧
+        Set.EqOn G (LSeries a) {s : ℂ | σ < s.re} := by
+  obtain ⟨r, hr, F, hF, hFeq⟩ := h.exists_extension
   set δ : ℝ := min (r ^ 2 / 4) 1 with hδdef
   have hδpos : 0 < δ := lt_min (by positivity) one_pos
   have hδ1 : δ ≤ 1 := min_le_right _ _
   have hδr : 3 * δ < r ^ 2 := by
     have h4 : δ ≤ r ^ 2 / 4 := min_le_left _ _
     nlinarith
-  set c : ℝ := σ + 1 with hcdef
-  set U : Set ℂ := {s : ℂ | σ < s.re} with hUdef
-  have hUopen : IsOpen U := isOpen_lt continuous_const Complex.continuous_re
+  have hUopen : IsOpen {s : ℂ | σ < s.re} :=
+    isOpen_lt continuous_const Complex.continuous_re
   have habs_lt : ∀ {s : ℂ}, σ < s.re → LSeries.abscissaOfAbsConv a < s.re := by
     intro s hs
     rw [habs]
     exact_mod_cast hs
   set G : ℂ → ℂ := fun s ↦ if σ < s.re then LSeries a s else F s with hGdef
-  have hGU : Set.EqOn G (LSeries a) U := fun s hs ↦ ite_eq_left hs
+  have hGU : Set.EqOn G (LSeries a) {s : ℂ | σ < s.re} := fun s hs ↦
+    ite_eq_left (Set.mem_ofPred.mp hs)
   have hGF : Set.EqOn G F (ball ((σ : ℝ) : ℂ) r) := by
     intro s hs
-    by_cases h : σ < s.re
-    · simp only [hGdef]
-      rw [ite_eq_left h]
-      exact (hFeq s hs h).symm
-    · simp only [hGdef]
-      exact ite_eq_right h
-  -- every point of the disc of radius `1 + δ` around `c` lies in the half-plane or in the
-  -- given disc around `σ`
-  have hsub : ∀ s ∈ ball ((c : ℝ) : ℂ) (1 + δ), σ < s.re ∨ s ∈ ball ((σ : ℝ) : ℂ) r := by
+    by_cases hsσ : σ < s.re
+    · change (if σ < s.re then LSeries a s else F s) = F s
+      rw [ite_eq_left hsσ]
+      exact (hFeq s hs hsσ).symm
+    · change (if σ < s.re then LSeries a s else F s) = F s
+      exact ite_eq_right hsσ
+  have hsub : ∀ s ∈ ball (((σ + 1 : ℝ) : ℂ)) (1 + δ),
+      σ < s.re ∨ s ∈ ball ((σ : ℝ) : ℂ) r := by
     intro s hs
-    by_cases h : σ < s.re
-    · exact Or.inl h
-    replace h := not_lt.mp h
+    by_cases hsσ : σ < s.re
+    · exact Or.inl hsσ
+    replace hsσ := not_lt.mp hsσ
     refine Or.inr ?_
     rw [mem_ball, Complex.dist_eq_re_im, Real.sqrt_lt' hr]
     rw [mem_ball, Complex.dist_eq_re_im, Real.sqrt_lt' (by linarith)] at hs
-    simp only [Complex.ofReal_re, Complex.ofReal_im, hcdef] at hs ⊢
+    simp only [Complex.ofReal_re, Complex.ofReal_im] at hs ⊢
     nlinarith [sq_nonneg (s.im - 0), sq_nonneg (s.re - σ)]
-  have hGdiff : ∀ s ∈ ball ((c : ℝ) : ℂ) (1 + δ), DifferentiableAt ℂ G s := by
-    intro s hs
-    rcases hsub s hs with h | h
-    · have hev : G =ᶠ[nhds s] LSeries a :=
-        Filter.eventuallyEq_of_mem (hUopen.mem_nhds h) hGU
-      exact hev.differentiableAt_iff.mpr (LSeries_hasDerivAt (habs_lt h)).differentiableAt
-    · have hev : G =ᶠ[nhds s] F := Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds h) hGF
-      exact hev.differentiableAt_iff.mpr (hF.differentiableAt (isOpen_ball.mem_nhds h))
-  -- Taylor expansion of `G` at `c`, evaluated at the real point `x = σ - δ / 2`
+  refine ⟨δ, hδpos, G, fun s hs ↦ ?_, hGU⟩
+  rcases hsub s hs with hsU | hsF
+  · have hev : G =ᶠ[nhds s] LSeries a := Filter.eventuallyEq_of_mem
+      (hUopen.mem_nhds (Set.mem_ofPred.mpr hsU)) hGU
+    exact (hev.differentiableAt_iff.mpr
+      (LSeries_hasDerivAt (habs_lt hsU)).differentiableAt).differentiableWithinAt
+  · have hev : G =ᶠ[nhds s] F :=
+      Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds hsF) hGF
+    exact (hev.differentiableAt_iff.mpr
+      (hF.differentiableAt (isOpen_ball.mem_nhds hsF))).differentiableWithinAt
+
+private lemma taylorSeries_term_eq (ha : 0 ≤ a) {σ c x y : ℝ} {G : ℂ → ℂ}
+    (hGU : Set.EqOn G (LSeries a) {s : ℂ | σ < s.re}) (hc : σ < c)
+    (hxc : x - c = -y) (habsc : LSeries.abscissaOfAbsConv a < c) (k : ℕ) :
+    (Nat.factorial k : ℂ)⁻¹ • (((x : ℝ) : ℂ) - ((c : ℝ) : ℂ)) ^ k •
+        iteratedDeriv k G ((c : ℝ) : ℂ) =
+      ((y ^ k / Nat.factorial k *
+        (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re : ℝ) : ℂ) := by
+  have hUopen : IsOpen {s : ℂ | σ < s.re} :=
+    isOpen_lt continuous_const Complex.continuous_re
+  have hcU : ((c : ℝ) : ℂ) ∈ {s : ℂ | σ < s.re} :=
+    Set.mem_ofPred.mpr (by simpa using hc)
+  have hd : iteratedDeriv k G ((c : ℝ) : ℂ) =
+      iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ) :=
+    hGU.iteratedDeriv_of_isOpen hUopen k hcU
+  have hTk : LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ) =
+      (((LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re : ℝ) : ℂ) :=
+    Complex.eq_re_of_ofReal_le (by
+      rw [Complex.ofReal_zero]
+      exact logPowMul_nonneg ha habsc k)
+  have hzc : ((x : ℝ) : ℂ) - ((c : ℝ) : ℂ) = -((y : ℝ) : ℂ) := by
+    exact_mod_cast hxc
+  have e1 : (-((y : ℝ) : ℂ)) ^ k * iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ) =
+      ((y : ℝ) : ℂ) ^ k * ((-1 : ℂ) ^ k *
+        iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ)) := by
+    rw [neg_pow]
+    ring
+  rw [hd, hzc, smul_eq_mul, smul_eq_mul, e1,
+    ← logPowMul_eq_alternating (by simpa using habsc) k]
+  nth_rewrite 1 [hTk]
+  push_cast
+  ring
+
+private lemma hasSum_pow_mul_re_term (a : ℕ → ℂ) (c y : ℝ) (n : ℕ) :
+    HasSum (fun k : ℕ ↦ y ^ k / Nat.factorial k *
+      (Real.log n ^ k * (LSeries.term a ((c : ℝ) : ℂ) n).re))
+      ((LSeries.term a (((c - y : ℝ) : ℂ)) n).re) := by
+  have h1 : HasSum (fun k : ℕ ↦ (y * Real.log n) ^ k / Nat.factorial k)
+      (Real.exp (y * Real.log n)) := by
+    rw [Real.exp_eq_exp_ℝ]
+    exact NormedSpace.expSeries_div_hasSum_exp _
+  have h2 := h1.mul_right ((LSeries.term a ((c : ℝ) : ℂ) n).re)
+  have heq : Real.exp (y * Real.log n) * (LSeries.term a ((c : ℝ) : ℂ) n).re =
+      (LSeries.term a (((c - y : ℝ) : ℂ)) n).re := by
+    rcases eq_or_ne n 0 with rfl | hn
+    · simp
+    · have hn0 : (0 : ℝ) < n := by positivity
+      have hyexp : Real.exp (y * Real.log n) = (n : ℝ) ^ y := by
+        rw [Real.rpow_def_of_pos hn0, mul_comm]
+      have hc : (n : ℝ) ^ c = (n : ℝ) ^ (c - y) * (n : ℝ) ^ y := by
+        rw [← Real.rpow_add hn0]
+        ring_nf
+      rw [re_term_of_ne_zero a c hn, re_term_of_ne_zero a (c - y) hn, hyexp, hc]
+      field_simp
+  rw [← heq]
+  refine h2.congr_fun fun k ↦ ?_
+  rw [mul_pow]
+  ring
+
+private lemma summable_re_term_of_summable_logPow (ha : 0 ≤ a) {c x y : ℝ}
+    (hx : x = c - y) (hy : 0 < y) (habsc : LSeries.abscissaOfAbsConv a < c)
+    (hsummable : Summable (fun k : ℕ ↦ y ^ k / Nat.factorial k *
+      (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re)) :
+    Summable (fun n : ℕ ↦ (LSeries.term a ((x : ℝ) : ℂ) n).re) := by
+  have hexp : ∀ n : ℕ, HasSum (fun k : ℕ ↦ y ^ k / Nat.factorial k *
+      (Real.log n ^ k * (LSeries.term a ((c : ℝ) : ℂ) n).re))
+      ((LSeries.term a ((x : ℝ) : ℂ) n).re) := by
+    intro n
+    simpa only [hx] using hasSum_pow_mul_re_term a c y n
+  refine summable_of_sum_le (c := ∑' k : ℕ, y ^ k / Nat.factorial k *
+    (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re)
+    (fun n ↦ re_term_nonneg ha x n) fun s ↦ ?_
+  refine hasSum_le (fun k ↦ ?_) (hasSum_sum fun n _ ↦ hexp n) hsummable.hasSum
+  rw [← Finset.mul_sum]
+  refine mul_le_mul_of_nonneg_left ?_
+    (div_nonneg (pow_nonneg hy.le k) (Nat.cast_nonneg _))
+  exact sum_le_hasSum s
+    (fun n _ ↦ mul_nonneg (pow_nonneg (Real.log_natCast_nonneg n) k)
+      (re_term_nonneg ha c n))
+    (hasSum_logPowMul_re_term habsc k)
+
+/-- **Landau's theorem.** If `a` has nonnegative values and its abscissa of absolute convergence
+is the real number `σ`, then `LSeries a` has no analytic continuation across `σ`. -/
+theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (σ : EReal)) :
+    ¬ HasAnalyticExtensionAt a σ := by
+  intro h
+  obtain ⟨δ, hδpos, G, hGdiffOn', hGU⟩ := exists_differentiableOn_patch habs h
+  set c : ℝ := σ + 1 with hcdef
   set y : ℝ := 1 + δ / 2 with hydef
   set x : ℝ := c - y with hxdef
   have hy0 : 0 < y := by rw [hydef]; linarith
@@ -208,84 +315,26 @@ theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (
     rw [habs]
     exact_mod_cast (by rw [hcdef]; linarith : σ < c)
   have hxc : x - c = -y := by rw [hxdef]; ring
-  have habsc' : LSeries.abscissaOfAbsConv a < (((c : ℝ) : ℂ)).re := by simpa using habsc
   have hxball : ((x : ℝ) : ℂ) ∈ ball ((c : ℝ) : ℂ) (1 + δ) := by
     rw [mem_ball, Complex.isometry_ofReal.dist_eq, Real.dist_eq, hxc, abs_neg,
       abs_of_pos hy0, hydef]
     linarith
-  have hGdiffOn : DifferentiableOn ℂ G (ball ((c : ℝ) : ℂ) (1 + δ)) :=
-    fun s hs ↦ (hGdiff s hs).differentiableWithinAt
+  have hGdiffOn : DifferentiableOn ℂ G (ball ((c : ℝ) : ℂ) (1 + δ)) := by
+    simpa only [hcdef] using hGdiffOn'
   have htaylor := Complex.hasSum_taylorSeries_on_ball hGdiffOn hxball
-  have hcU : ((c : ℝ) : ℂ) ∈ U := by
-    simp only [hUdef, Set.mem_ofPred_eq, Complex.ofReal_re, hcdef]
-    linarith
   have hterm : ∀ k : ℕ, (Nat.factorial k : ℂ)⁻¹ • (((x : ℝ) : ℂ) - ((c : ℝ) : ℂ)) ^ k •
       iteratedDeriv k G ((c : ℝ) : ℂ)
       = ((y ^ k / Nat.factorial k *
           (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re : ℝ) : ℂ) := by
-    intro k
-    have hd : iteratedDeriv k G ((c : ℝ) : ℂ) = iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ) :=
-      hGU.iteratedDeriv_of_isOpen hUopen k hcU
-    have hTk : LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)
-        = (((LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re : ℝ) : ℂ) :=
-      Complex.eq_re_of_ofReal_le (by
-        rw [Complex.ofReal_zero]; exact LSeries_logMul_iterate_nonneg ha habsc k)
-    have hzc : ((x : ℝ) : ℂ) - ((c : ℝ) : ℂ) = -((y : ℝ) : ℂ) := by
-      rw [hxdef]; push_cast; ring
-    have e1 : (-((y : ℝ) : ℂ)) ^ k * iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ)
-        = ((y : ℝ) : ℂ) ^ k * ((-1 : ℂ) ^ k * iteratedDeriv k (LSeries a) ((c : ℝ) : ℂ)) := by
-      rw [neg_pow]; ring
-    rw [hd, hzc, smul_eq_mul, smul_eq_mul, e1, ← LSeries_logMul_iterate_eq habsc' k]
-    nth_rewrite 1 [hTk]
-    push_cast
-    ring
-  -- the majorant series over `k` converges
+    exact fun k ↦ taylorSeries_term_eq ha hGU (by rw [hcdef]; linarith) hxc habsc k
   have hsummable_k : Summable (fun k : ℕ ↦ y ^ k / Nat.factorial k *
       (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re) :=
     Complex.summable_ofReal.mp (htaylor.congr_fun fun k ↦ (hterm k).symm).summable
-  -- expand each Dirichlet term at `x` as a series in `k`
-  have hexp : ∀ n : ℕ, HasSum (fun k : ℕ ↦ y ^ k / Nat.factorial k *
-      (Real.log n ^ k * (LSeries.term a ((c : ℝ) : ℂ) n).re))
-      ((LSeries.term a ((x : ℝ) : ℂ) n).re) := by
-    intro n
-    have h1 : HasSum (fun k : ℕ ↦ (y * Real.log n) ^ k / Nat.factorial k)
-        (Real.exp (y * Real.log n)) := by
-      rw [Real.exp_eq_exp_ℝ]
-      exact NormedSpace.expSeries_div_hasSum_exp _
-    have h2 := h1.mul_right ((LSeries.term a ((c : ℝ) : ℂ) n).re)
-    have heq : Real.exp (y * Real.log n) * (LSeries.term a ((c : ℝ) : ℂ) n).re
-        = (LSeries.term a ((x : ℝ) : ℂ) n).re := by
-      rcases eq_or_ne n 0 with rfl | hn
-      · simp
-      · have hn0 : (0 : ℝ) < n := by positivity
-        have hyexp : Real.exp (y * Real.log n) = (n : ℝ) ^ y := by
-          rw [Real.rpow_def_of_pos hn0, mul_comm]
-        have hc : (n : ℝ) ^ c = (n : ℝ) ^ x * (n : ℝ) ^ y := by
-          rw [← Real.rpow_add hn0, hxdef]
-          norm_num
-        rw [re_term_of_ne_zero ha c hn, re_term_of_ne_zero ha x hn, hyexp, hc]
-        field_simp
-    rw [← heq]
-    refine h2.congr_fun fun k ↦ ?_
-    rw [mul_pow]
-    ring
-  -- hence the L-series converges absolutely at `x < σ`
   have hsum_x : Summable (fun n : ℕ ↦ (LSeries.term a ((x : ℝ) : ℂ) n).re) := by
-    refine summable_of_sum_le (c := ∑' k : ℕ, y ^ k / Nat.factorial k *
-      (LSeries (LSeries.logMul^[k] a) ((c : ℝ) : ℂ)).re)
-      (fun n ↦ by simpa using (Complex.le_def.mp (LSeries.term_nonneg (ha n) x)).1) fun s ↦ ?_
-    refine hasSum_le (fun k ↦ ?_) (hasSum_sum fun n _ ↦ hexp n) hsummable_k.hasSum
-    rw [← Finset.mul_sum]
-    refine mul_le_mul_of_nonneg_left ?_
-      (div_nonneg (pow_nonneg hy0.le k) (Nat.cast_nonneg _))
-    exact sum_le_hasSum s
-      (fun n _ ↦ mul_nonneg (pow_nonneg (Real.log_natCast_nonneg n) k)
-        (by simpa using (Complex.le_def.mp (LSeries.term_nonneg (ha n) c)).1))
-      (hasSum_logPow_mul_re_term ha habsc k)
+    exact summable_re_term_of_summable_logPow ha hxdef hy0 habsc hsummable_k
   have hLS : LSeriesSummable a ((x : ℝ) : ℂ) :=
     (Complex.summable_ofReal.mpr hsum_x).congr fun n ↦
-      (Complex.eq_re_of_ofReal_le (by
-        rw [Complex.ofReal_zero]; exact LSeries.term_nonneg (ha n) x)).symm
+      (term_eq_ofReal_re ha x n).symm
   have hle := hLS.abscissaOfAbsConv_le
   rw [habs, Complex.ofReal_re] at hle
   have hσx : σ ≤ x := mod_cast hle
@@ -294,7 +343,8 @@ theorem landau (ha : 0 ≤ a) {σ : ℝ} (habs : LSeries.abscissaOfAbsConv a = (
 /-- **Landau's theorem, half-plane form.** A Dirichlet series with nonnegative coefficients and
 finite abscissa of absolute convergence converges as far to the left as it continues
 analytically: if some function differentiable on `Re s > σ₁` agrees with `LSeries a` on the
-half-plane of absolute convergence, then that abscissa is at most `σ₁`.
+part of the absolute-convergence half-plane where it is differentiable, then that abscissa is at
+most `σ₁`.
 
 This is the form consumed by nonvanishing arguments, where `F` is a quotient of L-functions known
 to be analytic on a half-plane, or on the complement of a pole that a positive combination has
@@ -302,7 +352,7 @@ already cancelled. -/
 theorem abscissaOfAbsConv_le_of_differentiableOn (ha : 0 ≤ a)
     (hfin : LSeries.abscissaOfAbsConv a ≠ ⊤) {σ₁ : ℝ} {F : ℂ → ℂ}
     (hF : DifferentiableOn ℂ F {s : ℂ | σ₁ < s.re})
-    (hFeq : ∀ s : ℂ, LSeries.abscissaOfAbsConv a < s.re → F s = LSeries a s) :
+    (hFeq : ∀ s : ℂ, σ₁ < s.re → LSeries.abscissaOfAbsConv a < s.re → F s = LSeries a s) :
     LSeries.abscissaOfAbsConv a ≤ σ₁ := by
   by_contra hcon
   have hlt : (σ₁ : EReal) < LSeries.abscissaOfAbsConv a := not_le.mp hcon
@@ -310,40 +360,27 @@ theorem abscissaOfAbsConv_le_of_differentiableOn (ha : 0 ≤ a)
   set σ : ℝ := (LSeries.abscissaOfAbsConv a).toReal with hσdef
   have habs : LSeries.abscissaOfAbsConv a = (σ : EReal) := (EReal.coe_toReal hfin hbot).symm
   have hσ₁σ : σ₁ < σ := by rw [habs] at hlt; exact_mod_cast hlt
-  refine landau ha habs ⟨σ - σ₁, by linarith, F, ?_, fun s _ h ↦ hFeq s ?_⟩
+  refine landau ha habs (HasAnalyticExtensionAt.of_differentiableOn
+    (a := a) (σ := σ) (F := F) (r := σ - σ₁) (by linarith) ?_ ?_)
   · refine hF.mono fun s hs ↦ ?_
-    have key : |s.re - σ| ≤ dist s ((σ : ℝ) : ℂ) := by
-      rw [dist_eq_norm]
-      simpa using Complex.abs_re_le_norm (s - ((σ : ℝ) : ℂ))
-    rw [mem_ball] at hs
-    have := (abs_lt.mp (key.trans_lt hs)).1
+    have := sub_lt_re_of_mem_ball hs
     exact Set.mem_ofPred.mpr (by linarith)
-  · rw [habs]
-    exact_mod_cast h
-
-/-- **Landau's theorem, entire form.** If `a` has nonnegative values, its abscissa of absolute
-convergence is finite, and `LSeries a` agrees on its half-plane of convergence with an entire
-function, then the L-series converges absolutely at every point of the plane.
-
-This is the shape used to rule out a hypothetical zero of an L-function: the zero would cancel a
-pole, making a product of L-series entire, and a nonnegative Dirichlet series that is entire must
-converge everywhere. -/
-theorem abscissaOfAbsConv_eq_bot_of_differentiable (ha : 0 ≤ a)
-    (hfin : LSeries.abscissaOfAbsConv a ≠ ⊤) {F : ℂ → ℂ} (hF : Differentiable ℂ F)
-    (hFeq : ∀ s : ℂ, LSeries.abscissaOfAbsConv a < s.re → F s = LSeries a s) :
-    LSeries.abscissaOfAbsConv a = ⊥ := by
-  have key : ∀ σ₁ : ℝ, LSeries.abscissaOfAbsConv a ≤ (σ₁ : EReal) := fun σ₁ ↦
-    abscissaOfAbsConv_le_of_differentiableOn ha hfin hF.differentiableOn hFeq
-  refine le_antisymm ?_ bot_le
-  by_contra hne
-  obtain ⟨r, -, hr⟩ := EReal.exists_between_coe_real (not_le.mp hne)
-  exact absurd (key r) (not_le.mpr hr)
+  · intro s _ hs
+    refine hFeq s (hσ₁σ.trans hs) ?_
+    rw [habs]
+    exact_mod_cast hs
 
 /-- A Dirichlet series with nonnegative coefficients that has an entire extension in the sense of
 `LSeries.HasEntireExtension` converges absolutely at every point of the plane. -/
 theorem abscissaOfAbsConv_eq_bot_of_hasEntireExtension (ha : 0 ≤ a)
     (h : LSeries.HasEntireExtension a) : LSeries.abscissaOfAbsConv a = ⊥ := by
   obtain ⟨F, hF, hFa⟩ := h.exists_extension
-  exact abscissaOfAbsConv_eq_bot_of_differentiable ha h.abscissa_lt_top.ne hF fun _ hs ↦ hFa hs
+  have key : ∀ σ₁ : ℝ, LSeries.abscissaOfAbsConv a ≤ (σ₁ : EReal) := fun σ₁ ↦
+    abscissaOfAbsConv_le_of_differentiableOn ha h.abscissa_lt_top.ne
+      hF.differentiableOn fun s _ hs ↦ hFa hs
+  refine le_antisymm ?_ bot_le
+  by_contra hne
+  obtain ⟨r, -, hr⟩ := EReal.exists_between_coe_real (not_le.mp hne)
+  exact absurd (key r) (not_le.mpr hr)
 
 end TauCeti.LSeries


### PR DESCRIPTION
This PR proves **Landau's theorem** for Dirichlet series with nonnegative coefficients: if `a : ℕ → ℂ` takes nonnegative real values and `LSeries.abscissaOfAbsConv a = (σ : EReal)` for a real `σ`, then no function differentiable on a disc around `σ` agrees with `LSeries a` immediately to the right of `σ`. It supplies `landau`, the sole export-contract declaration of Layer 8.1 of `TauCetiRoadmap/ArithmeticDirichletSeries/README.md` ("Landau's theorem"), whose contract row reads "singularity at the finite, actual abscissa for nonnegative coefficients", together with the two corollaries the layer asks for downstream. The milestone is Layer 8, "Landau-type positivity"; after this PR that milestone still needs item 8.2, the `3-4-1` trigonometric nonnegativity package as a finite nonnegative coefficient combination.

Layer 8 is the milestone chosen because it is the one node of this roadmap that is analytically independent of the rest: it consumes only Mathlib `LSeries` vocabulary, so it is unblocked while Layer 0 — the ideal carriers, on which Layers 1–7 and 10 all rest — is contested by three open pull requests (#3901, #3903, #3904). No open or merged PR touches Landau's theorem, and Mathlib does not have it: `Mathlib/NumberTheory/LSeries/Positivity.lean` stops at `LSeries.iteratedDeriv_alternating` and the positivity of an entire extension on the real axis, and the only "Landau" in Mathlib is the unrelated Mahler-measure inequality in `Mathlib/Analysis/Polynomial/MahlerMeasure.lean`.

The single new file is `TauCeti/NumberTheory/LSeries/Landau.lean` (349 lines). `TauCeti.LSeries.HasAnalyticExtensionAt a σ` records the obstruction: a disc around `σ` and a function differentiable on it agreeing with `LSeries a` on the part of the disc with `Re s > σ`. Only that intersection is constrained, which makes the hypothesis of `landau` as weak, and the theorem as strong, as possible. `hasAnalyticExtensionAt_of_abscissaOfAbsConv_lt` shows the predicate is not vacuous: strictly inside the half-plane of convergence the L-series is its own continuation. `landau` then proves `¬ HasAnalyticExtensionAt a σ` from `0 ≤ a` and the abscissa *equality*, which is what both makes `σ` the actual boundary and records its finiteness — mere convergence throughout `Re s > σ` would not do.

The proof is the classical one. Patching the hypothetical `F` with `LSeries a` across `Re s = σ` gives a function analytic on the disc of radius `1 + δ` around `σ + 1`, where `δ = min (r ^ 2 / 4) 1` is chosen so that a point of that disc with `Re s ≤ σ` still lies in the original disc of radius `r`. Its Taylor coefficients at `σ + 1` are, up to sign, the nonnegative numbers `∑ a n (log n) ^ k / n ^ (σ + 1)` — that is Mathlib's `LSeries.iteratedDeriv_alternating`, reached through `Complex.hasSum_taylorSeries_on_ball`. Evaluating at the real point `σ - δ / 2` of the disc and exchanging the two nonnegative summations with `summable_of_sum_le` exhibits `∑ a n / n ^ (σ - δ / 2)` as convergent, contradicting the abscissa equality.

Three corollaries follow. `abscissaOfAbsConv_le_of_differentiableOn` is the half-plane form: a nonnegative Dirichlet series with finite abscissa converges as far to the left as it continues analytically. `abscissaOfAbsConv_eq_bot_of_differentiable` is the entire form, and `abscissaOfAbsConv_eq_bot_of_hasEntireExtension` restates it through the repository's existing `LSeries.HasEntireExtension` predicate from `TauCeti/NumberTheory/LSeries/EntireExtension.lean`, whose definition already packages exactly the finiteness and agreement hypotheses needed. These are the shapes a nonvanishing argument applies once a positive combination of L-series has been shown entire, which is what Layer 8.2 and the `LFunctions` roadmap will supply.

The layer also asks to record the equality of the ordinary and the absolute abscissa for nonnegative coefficients. That is already Mathlib's: `LSeriesSummable` is defined by `Summable (LSeries.term f s)` and `summable_norm_iff` holds in `ℂ`, so `LSeriesSummable.abscissaOfAbsConv_le` bounds the *absolute* abscissa by the real part of any point of plain summability. Restating it here would duplicate Mathlib, so the module documentation names that declaration instead; the final step of `landau` uses it directly.

The file lives under `TauCeti/NumberTheory/LSeries/` next to `EntireExtension.lean`, mirroring `Mathlib/NumberTheory/LSeries/`, because nothing in it mentions ideals or number fields; the roadmap's suggested directory tracks its ideal-indexed layers, and code organization and roadmap scope do not coincide. Declarations live in `namespace TauCeti.LSeries`. No Mathlib infrastructure was vendored; the supporting lemmas `term_logMul_iterate`, `LSeries_logMul_iterate_eq`, `re_term_of_ne_zero` and `hasSum_logPow_mul_re_term` are new and are stated for reuse by later layers.

Roadmap: ArithmeticDirichletSeries

<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"landau"}-->

🤖 Prepared with Claude Code
