### PR TITLE
feat: characterize central kernels in Hopf coordinates

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -43,8 +43,6 @@ coordinate algebra.
   test scheme.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain`: the comparison is
   contravariantly natural in the coordinate bialgebra.
-* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapPointsFunctor`: the Hopf-category form of
-  coordinate naturality for the relative comparison.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation`: Mathlib's spectrum-points equivalence with
   its target transported across a named presentation.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation_apply_left`: the underlying spectrum map of
@@ -55,8 +53,6 @@ coordinate algebra.
   transport across a named presentation.
 * `TauCeti.CommHopfAlgCat.mapMulEquiv_mapDomain`: a coordinate bialgebra morphism
   becomes postcomposition by the induced relative spectrum morphism `Spec K ⟶ Spec H`.
-* `TauCeti.CommHopfAlgCat.mapMulEquiv_mapPointsFunctor`: the Hopf-category form of affine
-  coordinate naturality, phrased through `mapPointsFunctor` and `hopfSpec`.
 * `TauCeti.CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain`: contravariance for arbitrary
   named point equivalences characterized by their underlying spectrum maps.
 * `TauCeti.CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf`: the natural comparison between
@@ -103,17 +99,6 @@ theorem mapMulEquiv_mapDomain
   simp only [mapMulEquiv_left, OverClass.asOverHom_left, AlgHom.mapDomain_apply]
   erw [← Spec.map_comp]
   rfl
-
-/-- The Hopf-category form of contravariant naturality for Mathlib's spectrum-points
-equivalence. This packages the underlying bialgebra statement through `mapPointsFunctor` and
-the `hopfSpec` functor. -/
-theorem mapMulEquiv_mapPointsFunctor
-    {H K : _root_.CommHopfAlgCat.{u} R} (A : CommAlgCat.{u} R) (φ : H ⟶ K)
-    (p : HopfAlgebra.points (R := R) (H := K) A) :
-    AlgebraicGeometry.Spec.mapMulEquiv ((mapPointsFunctor φ).app A p) =
-      AlgebraicGeometry.Spec.mapMulEquiv p ≫
-        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom :=
-  mapMulEquiv_mapDomain A φ.hom p
 
 /-! ### Points of affine spectra on arbitrary test schemes -/
 
@@ -309,18 +294,6 @@ theorem schemePointsAlgΓMulEquiv_mapDomain
       rw [Category.assoc]
       congr 1
       exact (mapMulEquiv_mapDomain _ f (eK g)).symm
-
-/-- The Hopf-category form of coordinate naturality for the relative global-sections
-comparison. This packages the underlying bialgebra statement through `mapPointsFunctor` and
-the `hopfSpec` functor. -/
-theorem schemePointsAlgΓMulEquiv_mapPointsFunctor
-    {H K : _root_.CommHopfAlgCat.{u} R} (T : Over (Spec (CommRingCat.of R))) (φ : H ⟶ K)
-    (g : T ⟶ ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) :
-    schemePointsAlgΓMulEquiv H T
-        (g ≫ ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom) =
-      (mapPointsFunctor φ).app ((algΓ (CommRingCat.of R)).obj T).unop
-        (schemePointsAlgΓMulEquiv K T g) :=
-  schemePointsAlgΓMulEquiv_mapDomain T φ.hom g
 
 /-! ### Points on affine test schemes -/
 

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -170,14 +170,23 @@ private theorem schemePointsAlgΓEquiv_symm_apply
       (Opposite.op (CommAlgCat.of R H))) (CommAlgCat.ofHom p.ofConv).op = _
   rw [Adjunction.homEquiv_unit]
 
+private theorem mapMulEquiv_eq_algSpec_map
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (A : Type u) [CommRing A] [Algebra R A]
+    (p : WithConv (H →ₐ[R] A)) :
+    AlgebraicGeometry.Spec.mapMulEquiv p =
+      (algSpec (CommRingCat.of R)).map (CommAlgCat.ofHom p.ofConv).op := by
+  apply Over.OverMorphism.ext
+  rw [mapMulEquiv_left, algSpec_map_left]
+  rfl
+
 private theorem algΓPointSchemePoint_eq_symm
     (H : Type u) [CommRing H] [Bialgebra R H]
     (T : Over (Spec (CommRingCat.of R)))
     (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
     algΓPointSchemePoint H T p = (schemePointsAlgΓEquiv H T).symm p := by
   rw [schemePointsAlgΓEquiv_symm_apply]
-  -- `algSpec.map` and `Spec.mapMulEquiv` present the same relative spectrum map.
-  rfl
+  exact congrArg (algΓUnitToSpec T ≫ ·) (mapMulEquiv_eq_algSpec_map H _ p)
 
 private theorem algΓPointSchemePoint_mul
     (H : Type u) [CommRing H] [Bialgebra R H]

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -10,7 +10,7 @@ public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 
 /-!
-# Scheme-valued points of affine bialgebra spectra
+# Scheme-valued points of affine Hopf-algebra spectra
 
 For a commutative ring `R` and a same-universe commutative bialgebra `H`, this file identifies
 the convolution monoid of `H`-points with morphisms over `Spec R` into `Spec H`. It treats both
@@ -26,8 +26,10 @@ made, so the resulting monoid of points need not be commutative. The target
 The affine equivalence and its multiplicativity are Mathlib's
 `AlgebraicGeometry.Spec.mapMulEquiv`. The comparison for arbitrary test schemes upgrades
 Mathlib's `AlgebraicGeometry.algΓAlgSpecAdjunction` to a multiplicative equivalence. This file
-also provides transport across named scheme presentations and proves covariance in the value
-algebra and contravariance in the coordinate bialgebra.
+proves this comparison at bialgebra/monoid generality. It additionally records the Hopf-algebra
+case: transport across named `Grp`-presentations and the points-presheaf isomorphism for
+`CommHopfAlgCat`, together with covariance in the value algebra and contravariance in the
+coordinate algebra.
 
 ## Main declarations
 
@@ -35,10 +37,10 @@ algebra and contravariance in the coordinate bialgebra.
   an affine bialgebra spectrum are convolution points valued in its relative global sections.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_symm_apply`: the inverse comparison is the
   adjunction unit followed by the spectrum map of the convolution point.
-* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_precomp`: the comparison is natural in the
-  test scheme.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain`: the comparison is
   contravariantly natural in the coordinate bialgebra.
+* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapPointsFunctor`: the Hopf-category form of
+  coordinate naturality for the relative comparison.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation`: Mathlib's spectrum-points equivalence with
   its target transported across a named presentation.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation_apply_left`: the underlying spectrum map of
@@ -48,7 +50,9 @@ algebra and contravariance in the coordinate bialgebra.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation_mapValue`: the same covariance after
   transport across a named presentation.
 * `TauCeti.CommHopfAlgCat.mapMulEquiv_mapDomain`: a coordinate bialgebra morphism
-  becomes postcomposition by its contravariant `hopfSpec` image.
+  becomes postcomposition by the induced relative spectrum morphism `Spec K ⟶ Spec H`.
+* `TauCeti.CommHopfAlgCat.mapMulEquiv_mapPointsFunctor`: the Hopf-category form of affine
+  coordinate naturality, phrased through `mapPointsFunctor` and `hopfSpec`.
 * `TauCeti.CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain`: contravariance for arbitrary
   named point equivalences characterized by their underlying spectrum maps.
 * `TauCeti.CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf`: the natural comparison between
@@ -79,7 +83,41 @@ lemma mapMulEquiv_left
       Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) :=
   rfl
 
+/-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
+bialgebra. Precomposing a `K`-point by `f : H →ₐc[R] K` corresponds on spectra to
+postcomposing by the induced morphism `Spec K ⟶ Spec H`. -/
+theorem mapMulEquiv_mapDomain
+    {H K : Type u} [CommRing H] [CommRing K] [Bialgebra R H] [Bialgebra R K]
+    (A : CommAlgCat.{u} R) (f : H →ₐc[R] K)
+    (p : WithConv (K →ₐ[R] A)) :
+    AlgebraicGeometry.Spec.mapMulEquiv (AlgHom.mapDomain f p) =
+      AlgebraicGeometry.Spec.mapMulEquiv p ≫
+        (Spec.map (CommRingCat.ofHom f.toAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of R)) := by
+  apply Over.OverMorphism.ext
+  erw [Over.comp_left]
+  simp only [mapMulEquiv_left, OverClass.asOverHom_left, AlgHom.mapDomain_apply]
+  erw [← Spec.map_comp]
+  rfl
+
+/-- The Hopf-category form of contravariant naturality for Mathlib's spectrum-points
+equivalence. This packages the underlying bialgebra statement through `mapPointsFunctor` and
+the `hopfSpec` functor. -/
+theorem mapMulEquiv_mapPointsFunctor
+    {H K : _root_.CommHopfAlgCat.{u} R} (A : CommAlgCat.{u} R) (φ : H ⟶ K)
+    (p : HopfAlgebra.points (R := R) (H := K) A) :
+    AlgebraicGeometry.Spec.mapMulEquiv ((mapPointsFunctor φ).app A p) =
+      AlgebraicGeometry.Spec.mapMulEquiv p ≫
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom :=
+  mapMulEquiv_mapDomain A φ.hom p
+
 /-! ### Points of affine spectra on arbitrary test schemes -/
+
+private theorem algSpec_obj_eq_spec
+    (H : Type u) [CommRing H] [Algebra R H] :
+    (algSpec (CommRingCat.of R)).obj (Opposite.op (CommAlgCat.of R H)) =
+      (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R)) :=
+  rfl
 
 /-- The relative `Γ-Spec` adjunction as an equivalence between scheme-valued points and
 convolution points, before recording multiplicativity. -/
@@ -90,11 +128,10 @@ private noncomputable def schemePointsAlgΓEquiv
       WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) := by
   let e₀ := (algΓAlgSpecAdjunction (CommRingCat.of R)).homEquiv T
     (Opposite.op (CommAlgCat.of R H))
-  exact e₀.symm.trans
-    { toFun := fun f ↦ toConv f.unop.hom
-      invFun := fun f ↦ (CommAlgCat.ofHom f.ofConv).op
-      left_inv := by intro f; rfl
-      right_inv := by intro f; rfl }
+  exact (Equiv.cast (congrArg (fun X ↦ T ⟶ X) (algSpec_obj_eq_spec H).symm)).trans
+    (e₀.symm.trans
+      ((opEquiv ((algΓ (CommRingCat.of R)).obj T) (Opposite.op (CommAlgCat.of R H))).trans
+        (HopfAlgebra.pointsHomEquiv H ((algΓ (CommRingCat.of R)).obj T).unop)))
 
 /-- A private elaboration bridge between the adjunction's composite-functor target and the
 definitionally equal relative-spectrum presentation. Keeping this bridge opaque prevents
@@ -120,10 +157,11 @@ private theorem schemePointsAlgΓEquiv_symm_apply
     (schemePointsAlgΓEquiv H T).symm p =
       (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫
         (algSpec (CommRingCat.of R)).map (CommAlgCat.ofHom p.ofConv).op := by
-  -- `schemePointsAlgΓEquiv` only adds the opposite-category and `WithConv` wrappers to the
-  -- adjunction equivalence; removing those wrappers exposes Mathlib's characterization lemma.
+  rw [schemePointsAlgΓEquiv, Equiv.symm_trans_apply, Equiv.symm_trans_apply,
+    Equiv.symm_trans_apply,
+    HopfAlgebra.pointsHomEquiv_symm_apply]
   change ((algΓAlgSpecAdjunction (CommRingCat.of R)).homEquiv T
-    (Opposite.op (CommAlgCat.of R H))) (CommAlgCat.ofHom p.ofConv).op = _
+      (Opposite.op (CommAlgCat.of R H))) (CommAlgCat.ofHom p.ofConv).op = _
   rw [Adjunction.homEquiv_unit]
 
 private theorem algΓPointSchemePoint_eq_symm
@@ -186,41 +224,11 @@ theorem schemePointsAlgΓMulEquiv_symm_apply
     (T : Over (Spec (CommRingCat.of R)))
     (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
     (schemePointsAlgΓMulEquiv H T).symm p =
-      (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫
-        (algSpec (CommRingCat.of R)).map (CommAlgCat.ofHom p.ofConv).op :=
-  schemePointsAlgΓEquiv_symm_apply H T p
-
-/-- The global-sections comparison is natural in the test scheme. Precomposing a `T`-valued
-point by `φ : S ⟶ T` postcomposes its algebra point with the induced map `Γ(T) ⟶ Γ(S)`. -/
-theorem schemePointsAlgΓMulEquiv_precomp
-    (H : Type u) [CommRing H] [Bialgebra R H]
-    {S T : Over (Spec (CommRingCat.of R))} (φ : S ⟶ T)
-    (g : T ⟶ (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :
-    schemePointsAlgΓMulEquiv H S (φ ≫ g) =
-      AlgHom.mapValue ((algΓ (CommRingCat.of R)).map φ).unop.hom
-        (schemePointsAlgΓMulEquiv H T g) := by
-  -- Unfolding only the opposite-category and `WithConv` wrappers reduces this to the public
-  -- left-naturality theorem for the adjunction's hom-set equivalence.
-  change (toConv _) = AlgHom.mapValue ((algΓ (CommRingCat.of R)).map φ).unop.hom (toConv _)
-  rw [AlgHom.mapValue_apply]
-  congr 1
-
-/-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
-bialgebra. Precomposing a `K`-point by `f : H →ₐc[R] K` corresponds on spectra to
-postcomposing by the induced morphism `Spec K ⟶ Spec H`. -/
-theorem mapMulEquiv_mapDomain
-    {H K : Type u} [CommRing H] [CommRing K] [Bialgebra R H] [Bialgebra R K]
-    (A : CommAlgCat.{u} R) (f : H →ₐc[R] K)
-    (p : WithConv (K →ₐ[R] A)) :
-    AlgebraicGeometry.Spec.mapMulEquiv (AlgHom.mapDomain f p) =
-      AlgebraicGeometry.Spec.mapMulEquiv p ≫
-        (Spec.map (CommRingCat.ofHom f.toAlgHom.toRingHom)).asOver
-          (Spec (CommRingCat.of R)) := by
-  apply Over.OverMorphism.ext
-  erw [Over.comp_left]
-  simp only [mapMulEquiv_left, OverClass.asOverHom_left, AlgHom.mapDomain_apply]
-  erw [← Spec.map_comp]
-  rfl
+      ((algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T :
+          T ⟶ (Spec (CommRingCat.of ((algΓ (CommRingCat.of R)).obj T).unop)).asOver
+            (Spec (CommRingCat.of R))) ≫
+        AlgebraicGeometry.Spec.mapMulEquiv p :=
+  schemePointsAlgΓMulEquiv_symm_apply_spec H T p
 
 /-- The global-sections comparison is contravariantly natural in the coordinate bialgebra.
 Postcomposing a scheme-valued point with `Spec f` is precomposition of its algebra point by `f`.
@@ -251,36 +259,19 @@ theorem schemePointsAlgΓMulEquiv_mapDomain
       congr 1
       exact (mapMulEquiv_mapDomain _ f (eK g)).symm
 
-/-- On an affine test scheme, the relative `Γ-Spec` comparison agrees with Mathlib's
-`Spec.mapMulEquiv` after mapping a point along the adjunction counit. -/
-theorem schemePointsAlgΓMulEquiv_symm_mapValue_counit
-    (H A : Type u) [CommRing H] [CommRing A] [Bialgebra R H] [Algebra R A]
-    (p : WithConv (H →ₐ[R] A)) :
-    (schemePointsAlgΓMulEquiv H
-      ((algSpec (CommRingCat.of R)).obj (Opposite.op (CommAlgCat.of R A)))).symm
-        (AlgHom.mapValue
-          ((algΓAlgSpecAdjunction (CommRingCat.of R)).counit.app
-            (Opposite.op (CommAlgCat.of R A))).unop.hom p) =
-      AlgebraicGeometry.Spec.mapMulEquiv p := by
-  rw [schemePointsAlgΓMulEquiv_symm_apply]
-  -- The adjunction triangle identity is stated using `algSpec.map`, whereas
-  -- `Spec.mapMulEquiv` uses the definitionally equal relative-spectrum presentation.
-  change (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app
-      ((algSpec (CommRingCat.of R)).obj (Opposite.op (CommAlgCat.of R A))) ≫
-    (algSpec (CommRingCat.of R)).map
-      ((algΓAlgSpecAdjunction (CommRingCat.of R)).counit.app
-        (Opposite.op (CommAlgCat.of R A)) ≫ (CommAlgCat.ofHom p.ofConv).op) = _
-  rw [Functor.map_comp, ← Category.assoc,
-    (algΓAlgSpecAdjunction (CommRingCat.of R)).right_triangle_components]
-  rfl
+/-- The Hopf-category form of coordinate naturality for the relative global-sections
+comparison. This packages the underlying bialgebra statement through `mapPointsFunctor` and
+the `hopfSpec` functor. -/
+theorem schemePointsAlgΓMulEquiv_mapPointsFunctor
+    {H K : _root_.CommHopfAlgCat.{u} R} (T : Over (Spec (CommRingCat.of R))) (φ : H ⟶ K)
+    (g : T ⟶ ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) :
+    schemePointsAlgΓMulEquiv H T
+        (g ≫ ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom) =
+      (mapPointsFunctor φ).app ((algΓ (CommRingCat.of R)).obj T).unop
+        (schemePointsAlgΓMulEquiv K T g) :=
+  schemePointsAlgΓMulEquiv_mapDomain T φ.hom g
 
 /-! ### Points on affine test schemes -/
-
-private lemma hopfSpec_map_left
-    {H K : _root_.CommHopfAlgCat.{u} R} (φ : H ⟶ K) :
-    ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom.left =
-      Spec.map (CommRingCat.ofHom φ.hom.toAlgHom.toRingHom) :=
-  rfl
 
 /-- Mathlib's spectrum-points equivalence with its target transported to an equal named scheme
 over `Spec R`.

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -39,6 +39,8 @@ coordinate algebra.
   relative global sections and then the adjunction counit.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_symm_apply`: the inverse comparison is the
   adjunction unit followed by the spectrum map of the convolution point.
+* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_precomp`: the comparison is natural in the
+  test scheme.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain`: the comparison is
   contravariantly natural in the coordinate bialgebra.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapPointsFunctor`: the Hopf-category form of
@@ -254,6 +256,7 @@ private theorem schemePointsAlgΓMulEquiv_symm_apply_spec
 
 /-- The inverse relative `Γ-Spec` comparison is the adjunction unit followed by the affine
 spectrum point represented by `p`. -/
+@[simp]
 theorem schemePointsAlgΓMulEquiv_symm_apply
     (H : Type u) [CommRing H] [Bialgebra R H]
     (T : Over (Spec (CommRingCat.of R)))
@@ -264,6 +267,19 @@ theorem schemePointsAlgΓMulEquiv_symm_apply
             (Spec (CommRingCat.of R))) ≫
         AlgebraicGeometry.Spec.mapMulEquiv p :=
   schemePointsAlgΓMulEquiv_symm_apply_spec H T p
+
+/-- The global-sections comparison is natural in the test scheme. Precomposing a `T`-valued
+point by `φ : S ⟶ T` postcomposes its algebra point with the induced map `Γ(T) ⟶ Γ(S)`. -/
+theorem schemePointsAlgΓMulEquiv_precomp
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    {S T : Over (Spec (CommRingCat.of R))} (φ : S ⟶ T)
+    (g : T ⟶ (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :
+    schemePointsAlgΓMulEquiv H S (φ ≫ g) =
+      AlgHom.mapValue ((algΓ (CommRingCat.of R)).map φ).unop.hom
+        (schemePointsAlgΓMulEquiv H T g) := by
+  rw [schemePointsAlgΓMulEquiv_apply, schemePointsAlgΓMulEquiv_apply,
+    AlgHom.mapValue_apply]
+  congr 1
 
 /-- The global-sections comparison is contravariantly natural in the coordinate bialgebra.
 Postcomposing a scheme-valued point with `Spec f` is precomposition of its algebra point by `f`.

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -237,6 +237,8 @@ theorem schemePointsAlgΓMulEquiv_apply
       WithConv.toConv (((algΓ (CommRingCat.of R)).map g ≫
         (algΓAlgSpecAdjunction (CommRingCat.of R)).counit.app
           (Opposite.op (CommAlgCat.of R H))).unop.hom) := by
+  -- `schemePointsAlgΓMulEquiv` is a structure update of `schemePointsAlgΓEquiv` that only
+  -- supplies `map_mul'`; expose their definitionally identical forward maps for simplification.
   change schemePointsAlgΓEquiv H T g = _
   unfold schemePointsAlgΓEquiv
   simp only [Equiv.trans_apply, HopfAlgebra.pointsHomEquiv_apply,

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -35,6 +35,8 @@ coordinate algebra.
 
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv`: maps from an arbitrary relative scheme to
   an affine bialgebra spectrum are convolution points valued in its relative global sections.
+* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_apply`: the forward comparison applies
+  relative global sections and then the adjunction counit.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_symm_apply`: the inverse comparison is the
   adjunction unit followed by the spectrum map of the convolution point.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain`: the comparison is
@@ -160,6 +162,10 @@ private theorem schemePointsAlgΓEquiv_symm_apply
   rw [schemePointsAlgΓEquiv, Equiv.symm_trans_apply, Equiv.symm_trans_apply,
     Equiv.symm_trans_apply,
     HopfAlgebra.pointsHomEquiv_symm_apply]
+  -- The remaining `Equiv.cast` transports the relative-spectrum presentation, while
+  -- `opEquiv` reverses the bundled algebra morphism. These wrappers are definitionally the
+  -- displayed adjunction hom-equivalence application; there is no morphism-level rewrite for
+  -- the cast through the three composed equivalences.
   change ((algΓAlgSpecAdjunction (CommRingCat.of R)).homEquiv T
       (Opposite.op (CommAlgCat.of R H))) (CommAlgCat.ofHom p.ofConv).op = _
   rw [Adjunction.homEquiv_unit]
@@ -209,6 +215,24 @@ noncomputable def schemePointsAlgΓMulEquiv
         _ = (schemePointsAlgΓEquiv H T).symm
             (schemePointsAlgΓEquiv H T g * schemePointsAlgΓEquiv H T h) :=
           algΓPointSchemePoint_eq_symm H T _ }
+
+/-- The forward relative `Γ-Spec` comparison applies relative global sections to the scheme
+point and composes with the adjunction counit, then regards the resulting algebra morphism as a
+convolution point. -/
+@[simp]
+theorem schemePointsAlgΓMulEquiv_apply
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R)))
+    (g : T ⟶ (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :
+    schemePointsAlgΓMulEquiv H T g =
+      WithConv.toConv (((algΓ (CommRingCat.of R)).map g ≫
+        (algΓAlgSpecAdjunction (CommRingCat.of R)).counit.app
+          (Opposite.op (CommAlgCat.of R H))).unop.hom) := by
+  change schemePointsAlgΓEquiv H T g = _
+  unfold schemePointsAlgΓEquiv
+  simp only [Equiv.trans_apply, HopfAlgebra.pointsHomEquiv_apply,
+    Adjunction.homEquiv_counit]
+  rfl
 
 private theorem schemePointsAlgΓMulEquiv_symm_apply_spec
     (H : Type u) [CommRing H] [Bialgebra R H]

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -10,26 +10,33 @@ public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 
 /-!
-# Scheme-valued points of affine Hopf spectra
+# Scheme-valued points of affine bialgebra spectra
 
-For a commutative ring `R`, a same-universe commutative Hopf algebra `H`, and a
-same-universe commutative `R`-algebra `A`, this file identifies the convolution group
-`WithConv (H →ₐ[R] A)` with the group of morphisms over `Spec R` from `Spec A` into
-`Spec H`.
+For a commutative ring `R` and a same-universe commutative bialgebra `H`, this file identifies
+the convolution monoid of `H`-points with morphisms over `Spec R` into `Spec H`. It treats both
+affine test schemes `Spec A` and arbitrary schemes `T`, whose points are valued in the relative
+global sections of `T` through the relative `Γ-Spec` adjunction.
 
-The group law on the scheme side is the pointwise group law induced by the group object
-represented by `H`; the source `Spec A` need not itself be a group object. No
-cocommutativity assumption is made, so the resulting group of points need not be
-commutative. The target `(Spec H).asOver (Spec R)` below is definitionally the underlying
-object of `(AlgebraicGeometry.hopfSpec R).obj (Opposite.op H)`.
+The monoid law on the scheme side is the pointwise law induced by the monoid object represented
+by `H`; the source `Spec A` need not itself be a monoid object. No cocommutativity assumption is
+made, so the resulting monoid of points need not be commutative. The target
+`(Spec H).asOver (Spec R)` below is definitionally the underlying object of
+`(AlgebraicGeometry.bialgSpec R).obj (Opposite.op (CommBialgCat.of R H))`.
 
-The equivalence and its multiplicativity are Mathlib's
-`AlgebraicGeometry.Spec.mapMulEquiv`. This file provides its transport across named scheme
-presentations and proves its covariance in the value algebra and contravariance in the coordinate
-Hopf algebra.
+The affine equivalence and its multiplicativity are Mathlib's
+`AlgebraicGeometry.Spec.mapMulEquiv`. The comparison for arbitrary test schemes upgrades
+Mathlib's `AlgebraicGeometry.algΓAlgSpecAdjunction` to a multiplicative equivalence. This file
+also provides transport across named scheme presentations and proves covariance in the value
+algebra and contravariance in the coordinate bialgebra.
 
 ## Main declarations
 
+* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv`: maps from an arbitrary relative scheme to
+  an affine bialgebra spectrum are convolution points valued in its relative global sections.
+* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_symm_apply`: the inverse comparison is the
+  adjunction unit followed by the spectrum map of the convolution point.
+* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain`: the comparison is
+  contravariantly natural in the coordinate bialgebra.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation`: Mathlib's spectrum-points equivalence with
   its target transported across a named presentation.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation_apply_left`: the underlying spectrum map of
@@ -38,7 +45,7 @@ Hopf algebra.
   precomposition by the corresponding spectrum morphism.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation_mapValue`: the same covariance after
   transport across a named presentation.
-* `TauCeti.CommHopfAlgCat.mapMulEquiv_mapDomain`: a coordinate Hopf morphism
+* `TauCeti.CommHopfAlgCat.mapMulEquiv_mapDomain`: a coordinate bialgebra morphism
   becomes postcomposition by its contravariant `hopfSpec` image.
 * `TauCeti.CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain`: contravariance for arbitrary
   named point equivalences characterized by their underlying spectrum maps.
@@ -69,6 +76,172 @@ lemma mapMulEquiv_left
     (AlgebraicGeometry.Spec.mapMulEquiv f).left =
       Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) :=
   rfl
+
+/-! ### Points of affine spectra on arbitrary test schemes -/
+
+/-- The relative `Γ-Spec` adjunction as an equivalence between scheme-valued points and
+convolution points, before recording multiplicativity. -/
+private noncomputable def schemePointsAlgΓEquiv
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R))) :
+    (T ⟶ (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) ≃
+      WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) := by
+  let e₀ := (algΓAlgSpecAdjunction (CommRingCat.of R)).homEquiv T
+    (Opposite.op (CommAlgCat.of R H))
+  exact e₀.symm.trans
+    { toFun := fun f ↦ toConv f.unop.hom
+      invFun := fun f ↦ (CommAlgCat.ofHom f.ofConv).op
+      left_inv := by intro f; rfl
+      right_inv := by intro f; rfl }
+
+/-- The adjunction unit, with its target presented as the relative spectrum of global sections. -/
+noncomputable def algΓUnitToSpec (T : Over (Spec (CommRingCat.of R))) :
+    T ⟶ (Spec (CommRingCat.of ((algΓ (CommRingCat.of R)).obj T).unop)).asOver
+      (Spec (CommRingCat.of R)) :=
+  (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T
+
+/-- A convolution point over the global sections of `T`, regarded as a `T`-valued point through
+the relative spectrum presentation. -/
+private noncomputable def algΓPointSchemePoint
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R)))
+    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    T ⟶ (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R)) :=
+  algΓUnitToSpec T ≫ AlgebraicGeometry.Spec.mapMulEquiv p
+
+private theorem schemePointsAlgΓEquiv_symm_apply
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R)))
+    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    (schemePointsAlgΓEquiv H T).symm p =
+      (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫
+        (algSpec (CommRingCat.of R)).map (CommAlgCat.ofHom p.ofConv).op := by
+  change ((algΓAlgSpecAdjunction (CommRingCat.of R)).homEquiv T
+    (Opposite.op (CommAlgCat.of R H))) (CommAlgCat.ofHom p.ofConv).op = _
+  rw [Adjunction.homEquiv_unit]
+
+private theorem algΓPointSchemePoint_eq_symm
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R)))
+    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    algΓPointSchemePoint H T p = (schemePointsAlgΓEquiv H T).symm p := by
+  rw [schemePointsAlgΓEquiv_symm_apply]
+  -- `algSpec.map` and `Spec.mapMulEquiv` present the same relative spectrum map.
+  rfl
+
+private theorem algΓPointSchemePoint_mul
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R)))
+    (p q : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    algΓPointSchemePoint H T (p * q) =
+      algΓPointSchemePoint H T p * algΓPointSchemePoint H T q := by
+  unfold algΓPointSchemePoint
+  rw [map_mul, MonObj.comp_mul]
+
+/-- Maps from an arbitrary scheme `T` over `Spec R` to the affine monoid scheme represented by
+`H` are the convolution monoid of `H`-points valued in the relative global sections of `T`.
+
+Unlike `AlgebraicGeometry.Spec.mapMulEquiv`, the test scheme here need not be affine. The
+equivalence is the relative `Γ-Spec` adjunction, with its target given the convolution product.
+-/
+noncomputable def schemePointsAlgΓMulEquiv
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R))) :
+    (T ⟶ (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) ≃*
+      WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) :=
+  { schemePointsAlgΓEquiv H T with
+    map_mul' := by
+      intro g h
+      apply (schemePointsAlgΓEquiv H T).symm.injective
+      calc
+        _ = g * h := (schemePointsAlgΓEquiv H T).symm_apply_apply (g * h)
+        _ = algΓPointSchemePoint H T (schemePointsAlgΓEquiv H T g) *
+            algΓPointSchemePoint H T (schemePointsAlgΓEquiv H T h) := by
+          rw [algΓPointSchemePoint_eq_symm, algΓPointSchemePoint_eq_symm,
+            Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+        _ = algΓPointSchemePoint H T
+            (schemePointsAlgΓEquiv H T g * schemePointsAlgΓEquiv H T h) :=
+          (algΓPointSchemePoint_mul H T _ _).symm
+        _ = (schemePointsAlgΓEquiv H T).symm
+            (schemePointsAlgΓEquiv H T g * schemePointsAlgΓEquiv H T h) :=
+          algΓPointSchemePoint_eq_symm H T _ }
+
+/-- The inverse relative `Γ-Spec` comparison is the adjunction unit followed by the affine
+spectrum point represented by `p`. -/
+theorem schemePointsAlgΓMulEquiv_symm_apply
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R)))
+    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    (schemePointsAlgΓMulEquiv H T).symm p =
+      algΓUnitToSpec T ≫ AlgebraicGeometry.Spec.mapMulEquiv p :=
+  (algΓPointSchemePoint_eq_symm H T p).symm
+
+/-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
+bialgebra. Precomposing a `K`-point by `f : H →ₐc[R] K` corresponds on spectra to
+postcomposing by the induced morphism `Spec K ⟶ Spec H`. -/
+theorem mapMulEquiv_mapDomain
+    {H K : Type u} [CommRing H] [CommRing K] [Bialgebra R H] [Bialgebra R K]
+    (A : CommAlgCat.{u} R) (f : H →ₐc[R] K)
+    (p : WithConv (K →ₐ[R] A)) :
+    AlgebraicGeometry.Spec.mapMulEquiv (AlgHom.mapDomain f p) =
+      AlgebraicGeometry.Spec.mapMulEquiv p ≫
+        (Spec.map (CommRingCat.ofHom f.toAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of R)) := by
+  apply Over.OverMorphism.ext
+  erw [Over.comp_left]
+  simp only [mapMulEquiv_left, OverClass.asOverHom_left, AlgHom.mapDomain_apply]
+  erw [← Spec.map_comp]
+  rfl
+
+/-- The global-sections comparison is contravariantly natural in the coordinate bialgebra.
+Postcomposing a scheme-valued point with `Spec f` is precomposition of its algebra point by `f`.
+-/
+theorem schemePointsAlgΓMulEquiv_mapDomain
+    {H K : Type u} [CommRing H] [CommRing K] [Bialgebra R H] [Bialgebra R K]
+    (T : Over (Spec (CommRingCat.of R))) (f : H →ₐc[R] K)
+    (g : T ⟶ (Spec (CommRingCat.of K)).asOver (Spec (CommRingCat.of R))) :
+    schemePointsAlgΓMulEquiv H T
+        (g ≫ (Spec.map (CommRingCat.ofHom f.toAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of R))) =
+      AlgHom.mapDomain f (schemePointsAlgΓMulEquiv K T g) := by
+  let eH := schemePointsAlgΓMulEquiv H T
+  let eK := schemePointsAlgΓMulEquiv K T
+  apply eH.symm.injective
+  calc
+    eH.symm (eH (g ≫ (Spec.map (CommRingCat.ofHom f.toAlgHom.toRingHom)).asOver
+        (Spec (CommRingCat.of R)))) =
+        g ≫ (Spec.map (CommRingCat.ofHom f.toAlgHom.toRingHom)).asOver
+          (Spec (CommRingCat.of R)) := eH.symm_apply_apply _
+    _ = eH.symm (AlgHom.mapDomain f (eK g)) := by
+      conv_lhs => rw [← eK.symm_apply_apply g]
+      dsimp only [eH, eK]
+      rw [schemePointsAlgΓMulEquiv_symm_apply, schemePointsAlgΓMulEquiv_symm_apply]
+      rw [Category.assoc]
+      congr 1
+      exact (mapMulEquiv_mapDomain _ f (eK g)).symm
+
+/-- On an affine test scheme, the relative `Γ-Spec` comparison agrees with Mathlib's
+`Spec.mapMulEquiv` after mapping a point along the adjunction counit. -/
+theorem schemePointsAlgΓMulEquiv_symm_mapValue_counit
+    (H A : Type u) [CommRing H] [CommRing A] [Bialgebra R H] [Algebra R A]
+    (p : WithConv (H →ₐ[R] A)) :
+    (schemePointsAlgΓMulEquiv H
+      ((algSpec (CommRingCat.of R)).obj (Opposite.op (CommAlgCat.of R A)))).symm
+        (AlgHom.mapValue
+          ((algΓAlgSpecAdjunction (CommRingCat.of R)).counit.app
+            (Opposite.op (CommAlgCat.of R A))).unop.hom p) =
+      AlgebraicGeometry.Spec.mapMulEquiv p := by
+  rw [schemePointsAlgΓMulEquiv_symm_apply]
+  change (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app
+      ((algSpec (CommRingCat.of R)).obj (Opposite.op (CommAlgCat.of R A))) ≫
+    (algSpec (CommRingCat.of R)).map
+      ((algΓAlgSpecAdjunction (CommRingCat.of R)).counit.app
+        (Opposite.op (CommAlgCat.of R A)) ≫ (CommAlgCat.ofHom p.ofConv).op) = _
+  rw [Functor.map_comp, ← Category.assoc,
+    (algΓAlgSpecAdjunction (CommRingCat.of R)).right_triangle_components]
+  rfl
+
+/-! ### Points on affine test schemes -/
 
 private lemma hopfSpec_map_left
     {H K : _root_.CommHopfAlgCat.{u} R} (φ : H ⟶ K) :
@@ -172,22 +345,6 @@ theorem mapMulEquivOfPresentation_mapValue
     simp only [Over.comp_left, OverClass.asOverHom_left, mapMulEquiv_left] at hmapLeft
     exact hmapLeft
   simpa only [q] using hq
-
-/-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
-Hopf algebra. Precomposing a `K`-point by `φ : H ⟶ K` corresponds on spectra to
-postcomposing by the group-scheme morphism `Spec K ⟶ Spec H` induced by `hopfSpec`. -/
-theorem mapMulEquiv_mapDomain
-    {H K : _root_.CommHopfAlgCat.{u} R} (A : CommAlgCat.{u} R)
-    (φ : H ⟶ K) (p : HopfAlgebra.points (R := R) (H := K) A) :
-    AlgebraicGeometry.Spec.mapMulEquiv ((mapPointsFunctor φ).app A p) =
-      AlgebraicGeometry.Spec.mapMulEquiv p ≫
-        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom := by
-  rw [mapPointsFunctor_app_apply]
-  apply Over.OverMorphism.ext
-  erw [Over.comp_left]
-  simp only [mapMulEquiv_left, hopfSpec_map_left]
-  erw [← Spec.map_comp]
-  rfl
 
 private lemma transportedHopfSpecMap_left
     {H K : _root_.CommHopfAlgCat.{u} R}

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -35,6 +35,8 @@ algebra and contravariance in the coordinate bialgebra.
   an affine bialgebra spectrum are convolution points valued in its relative global sections.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_symm_apply`: the inverse comparison is the
   adjunction unit followed by the spectrum map of the convolution point.
+* `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_precomp`: the comparison is natural in the
+  test scheme.
 * `TauCeti.CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain`: the comparison is
   contravariantly natural in the coordinate bialgebra.
 * `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation`: Mathlib's spectrum-points equivalence with
@@ -94,8 +96,10 @@ private noncomputable def schemePointsAlgΓEquiv
       left_inv := by intro f; rfl
       right_inv := by intro f; rfl }
 
-/-- The adjunction unit, with its target presented as the relative spectrum of global sections. -/
-noncomputable def algΓUnitToSpec (T : Over (Spec (CommRingCat.of R))) :
+/-- A private elaboration bridge between the adjunction's composite-functor target and the
+definitionally equal relative-spectrum presentation. Keeping this bridge opaque prevents
+category-rewriting tactics from losing the latter presentation at `implicit` transparency. -/
+private noncomputable def algΓUnitToSpec (T : Over (Spec (CommRingCat.of R))) :
     T ⟶ (Spec (CommRingCat.of ((algΓ (CommRingCat.of R)).obj T).unop)).asOver
       (Spec (CommRingCat.of R)) :=
   (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T
@@ -116,6 +120,8 @@ private theorem schemePointsAlgΓEquiv_symm_apply
     (schemePointsAlgΓEquiv H T).symm p =
       (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫
         (algSpec (CommRingCat.of R)).map (CommAlgCat.ofHom p.ofConv).op := by
+  -- `schemePointsAlgΓEquiv` only adds the opposite-category and `WithConv` wrappers to the
+  -- adjunction equivalence; removing those wrappers exposes Mathlib's characterization lemma.
   change ((algΓAlgSpecAdjunction (CommRingCat.of R)).homEquiv T
     (Opposite.op (CommAlgCat.of R H))) (CommAlgCat.ofHom p.ofConv).op = _
   rw [Adjunction.homEquiv_unit]
@@ -166,6 +172,13 @@ noncomputable def schemePointsAlgΓMulEquiv
             (schemePointsAlgΓEquiv H T g * schemePointsAlgΓEquiv H T h) :=
           algΓPointSchemePoint_eq_symm H T _ }
 
+private theorem schemePointsAlgΓMulEquiv_symm_apply_spec
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    (T : Over (Spec (CommRingCat.of R)))
+    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    (schemePointsAlgΓMulEquiv H T).symm p = algΓPointSchemePoint H T p :=
+  (algΓPointSchemePoint_eq_symm H T p).symm
+
 /-- The inverse relative `Γ-Spec` comparison is the adjunction unit followed by the affine
 spectrum point represented by `p`. -/
 theorem schemePointsAlgΓMulEquiv_symm_apply
@@ -173,8 +186,24 @@ theorem schemePointsAlgΓMulEquiv_symm_apply
     (T : Over (Spec (CommRingCat.of R)))
     (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
     (schemePointsAlgΓMulEquiv H T).symm p =
-      algΓUnitToSpec T ≫ AlgebraicGeometry.Spec.mapMulEquiv p :=
-  (algΓPointSchemePoint_eq_symm H T p).symm
+      (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫
+        (algSpec (CommRingCat.of R)).map (CommAlgCat.ofHom p.ofConv).op :=
+  schemePointsAlgΓEquiv_symm_apply H T p
+
+/-- The global-sections comparison is natural in the test scheme. Precomposing a `T`-valued
+point by `φ : S ⟶ T` postcomposes its algebra point with the induced map `Γ(T) ⟶ Γ(S)`. -/
+theorem schemePointsAlgΓMulEquiv_precomp
+    (H : Type u) [CommRing H] [Bialgebra R H]
+    {S T : Over (Spec (CommRingCat.of R))} (φ : S ⟶ T)
+    (g : T ⟶ (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :
+    schemePointsAlgΓMulEquiv H S (φ ≫ g) =
+      AlgHom.mapValue ((algΓ (CommRingCat.of R)).map φ).unop.hom
+        (schemePointsAlgΓMulEquiv H T g) := by
+  -- Unfolding only the opposite-category and `WithConv` wrappers reduces this to the public
+  -- left-naturality theorem for the adjunction's hom-set equivalence.
+  change (toConv _) = AlgHom.mapValue ((algΓ (CommRingCat.of R)).map φ).unop.hom (toConv _)
+  rw [AlgHom.mapValue_apply]
+  congr 1
 
 /-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
 bialgebra. Precomposing a `K`-point by `f : H →ₐc[R] K` corresponds on spectra to
@@ -215,7 +244,9 @@ theorem schemePointsAlgΓMulEquiv_mapDomain
     _ = eH.symm (AlgHom.mapDomain f (eK g)) := by
       conv_lhs => rw [← eK.symm_apply_apply g]
       dsimp only [eH, eK]
-      rw [schemePointsAlgΓMulEquiv_symm_apply, schemePointsAlgΓMulEquiv_symm_apply]
+      rw [schemePointsAlgΓMulEquiv_symm_apply_spec,
+        schemePointsAlgΓMulEquiv_symm_apply_spec]
+      unfold algΓPointSchemePoint
       rw [Category.assoc]
       congr 1
       exact (mapMulEquiv_mapDomain _ f (eK g)).symm
@@ -232,6 +263,8 @@ theorem schemePointsAlgΓMulEquiv_symm_mapValue_counit
             (Opposite.op (CommAlgCat.of R A))).unop.hom p) =
       AlgebraicGeometry.Spec.mapMulEquiv p := by
   rw [schemePointsAlgΓMulEquiv_symm_apply]
+  -- The adjunction triangle identity is stated using `algSpec.map`, whereas
+  -- `Spec.mapMulEquiv` uses the definitionally equal relative-spectrum presentation.
   change (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app
       ((algSpec (CommRingCat.of R)).obj (Opposite.op (CommAlgCat.of R A))) ≫
     (algSpec (CommRingCat.of R)).map

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
@@ -284,7 +284,7 @@ theorem groupSchemePointsMulEquiv_groupSchemeMap {G H : FGCommGrpCat.{u}} (f : G
   have hpcomp := congrArg
     (fun q => q ≫ hopfSpecMapAsOver (R := R) f) hp.symm
   have hnat := (CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R A)
-    (coordinateMap R f).hom
+    (coordinateMap R f).hom.hom
     (AlgebraicGeometry.Spec.mapMulEquiv.symm
       (p ≫ (groupSchemeIsoSpec (R := R) H).hom))).symm
   exact hcomp.trans (hpcomp.trans hnat)

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
@@ -283,8 +283,8 @@ theorem groupSchemePointsMulEquiv_groupSchemeMap {G H : FGCommGrpCat.{u}} (f : G
     (p ≫ (groupSchemeIsoSpec (R := R) H).hom)
   have hpcomp := congrArg
     (fun q => q ≫ hopfSpecMapAsOver (R := R) f) hp.symm
-  have hnat := (CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R A)
-    (coordinateMap R f).hom.hom
+  have hnat := (CommHopfAlgCat.mapMulEquiv_mapPointsFunctor (CommAlgCat.of R A)
+    (coordinateMap R f).hom
     (AlgebraicGeometry.Spec.mapMulEquiv.symm
       (p ≫ (groupSchemeIsoSpec (R := R) H).hom))).symm
   exact hcomp.trans (hpcomp.trans hnat)

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Points.lean
@@ -283,8 +283,8 @@ theorem groupSchemePointsMulEquiv_groupSchemeMap {G H : FGCommGrpCat.{u}} (f : G
     (p ≫ (groupSchemeIsoSpec (R := R) H).hom)
   have hpcomp := congrArg
     (fun q => q ≫ hopfSpecMapAsOver (R := R) f) hp.symm
-  have hnat := (CommHopfAlgCat.mapMulEquiv_mapPointsFunctor (CommAlgCat.of R A)
-    (coordinateMap R f).hom
+  have hnat := (CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R A)
+    (coordinateMap R f).hom.hom
     (AlgebraicGeometry.Spec.mapMulEquiv.symm
       (p ≫ (groupSchemeIsoSpec (R := R) H).hom))).symm
   exact hcomp.trans (hpcomp.trans hnat)

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
@@ -302,8 +302,14 @@ private lemma groupSchemePointsMulEquiv_comp_diagonalTorus
             (SplitTorus.characterGroup (ULift.{u} (Fin N))) p)) := by
   let q := DiagonalizableGroup.groupSchemePointsMulEquiv (R := R) (A := A)
     (SplitTorus.characterGroup (ULift.{u} (Fin N))) p
-  have hmap := CommHopfAlgCat.mapMulEquiv_mapPointsFunctor (CommAlgCat.of R A)
-    (diagonalTorusCoordinateMap (R := R) (N := N)) q
+  have hmap : AlgebraicGeometry.Spec.mapMulEquiv
+      ((CommHopfAlgCat.mapPointsFunctor
+        (diagonalTorusCoordinateMap (R := R) (N := N))).app (CommAlgCat.of R A) q) =
+      AlgebraicGeometry.Spec.mapMulEquiv q ≫
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+          (diagonalTorusCoordinateMap (R := R) (N := N)).op).hom.hom :=
+    CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R A)
+      (diagonalTorusCoordinateMap (R := R) (N := N)).hom q
   rw [mapPointsFunctor_diagonalTorusCoordinateMap_app] at hmap
   apply Over.OverMorphism.ext
   rw [groupSchemePointMulEquiv_apply_left, Over.comp_left]

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
@@ -303,7 +303,13 @@ private lemma groupSchemePointsMulEquiv_comp_diagonalTorus
   let q := DiagonalizableGroup.groupSchemePointsMulEquiv (R := R) (A := A)
     (SplitTorus.characterGroup (ULift.{u} (Fin N))) p
   have hmap := CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R A)
-    (diagonalTorusCoordinateMap (R := R) (N := N)) q
+    (diagonalTorusCoordinateMap (R := R) (N := N)).hom q
+  change AlgebraicGeometry.Spec.mapMulEquiv
+      ((CommHopfAlgCat.mapPointsFunctor
+        (diagonalTorusCoordinateMap (R := R) (N := N))).app (CommAlgCat.of R A) q) =
+    AlgebraicGeometry.Spec.mapMulEquiv q ≫
+      ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+        (diagonalTorusCoordinateMap (R := R) (N := N)).op).hom.hom at hmap
   rw [mapPointsFunctor_diagonalTorusCoordinateMap_app] at hmap
   apply Over.OverMorphism.ext
   rw [groupSchemePointMulEquiv_apply_left, Over.comp_left]

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
@@ -304,6 +304,8 @@ private lemma groupSchemePointsMulEquiv_comp_diagonalTorus
     (SplitTorus.characterGroup (ULift.{u} (Fin N))) p
   have hmap := CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R A)
     (diagonalTorusCoordinateMap (R := R) (N := N)).hom q
+  -- `mapMulEquiv_mapDomain` states the spectrum morphism through its underlying bialgebra map;
+  -- the Hopf-spectrum functor packages that same map in definitionally equal category wrappers.
   change AlgebraicGeometry.Spec.mapMulEquiv
       ((CommHopfAlgCat.mapPointsFunctor
         (diagonalTorusCoordinateMap (R := R) (N := N))).app (CommAlgCat.of R A) q) =

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus.lean
@@ -302,16 +302,8 @@ private lemma groupSchemePointsMulEquiv_comp_diagonalTorus
             (SplitTorus.characterGroup (ULift.{u} (Fin N))) p)) := by
   let q := DiagonalizableGroup.groupSchemePointsMulEquiv (R := R) (A := A)
     (SplitTorus.characterGroup (ULift.{u} (Fin N))) p
-  have hmap := CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R A)
-    (diagonalTorusCoordinateMap (R := R) (N := N)).hom q
-  -- `mapMulEquiv_mapDomain` states the spectrum morphism through its underlying bialgebra map;
-  -- the Hopf-spectrum functor packages that same map in definitionally equal category wrappers.
-  change AlgebraicGeometry.Spec.mapMulEquiv
-      ((CommHopfAlgCat.mapPointsFunctor
-        (diagonalTorusCoordinateMap (R := R) (N := N))).app (CommAlgCat.of R A) q) =
-    AlgebraicGeometry.Spec.mapMulEquiv q ≫
-      ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
-        (diagonalTorusCoordinateMap (R := R) (N := N)).op).hom.hom at hmap
+  have hmap := CommHopfAlgCat.mapMulEquiv_mapPointsFunctor (CommAlgCat.of R A)
+    (diagonalTorusCoordinateMap (R := R) (N := N)) q
   rw [mapPointsFunctor_diagonalTorusCoordinateMap_app] at hmap
   apply Over.OverMorphism.ext
   rw [groupSchemePointMulEquiv_apply_left, Over.comp_left]

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Torus.lean
@@ -171,8 +171,7 @@ private theorem groupSchemePoint_comp_weightTorusRepresentation
     (R := ℤ) (A := A) (SplitTorus.characterGroup κ) p
   let f := CommHopfAlgCat.ofHom (DiagonalizableGroup.diagonalCoordinateMap bL
     (fun x => SplitTorus.weightCharacter (wt x)))
-  have hmap := CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of ℤ A) f q
-  rw [CommHopfAlgCat.mapPointsFunctor_app_apply] at hmap
+  have hmap := CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of ℤ A) f.hom q
   apply Over.OverMorphism.ext
   rw [GeneralLinear.groupSchemePointMulEquiv_apply_left, Over.comp_left,
     weightTorusRepresentation_def, DiagonalizableGroup.diagonalGroupSchemeHom_def]

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Torus.lean
@@ -171,7 +171,7 @@ private theorem groupSchemePoint_comp_weightTorusRepresentation
     (R := ℤ) (A := A) (SplitTorus.characterGroup κ) p
   let f := CommHopfAlgCat.ofHom (DiagonalizableGroup.diagonalCoordinateMap bL
     (fun x => SplitTorus.weightCharacter (wt x)))
-  have hmap := CommHopfAlgCat.mapMulEquiv_mapPointsFunctor (CommAlgCat.of ℤ A) f q
+  have hmap := CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of ℤ A) f.hom q
   apply Over.OverMorphism.ext
   rw [GeneralLinear.groupSchemePointMulEquiv_apply_left, Over.comp_left,
     weightTorusRepresentation_def, DiagonalizableGroup.diagonalGroupSchemeHom_def]

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Torus.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/Torus.lean
@@ -171,7 +171,7 @@ private theorem groupSchemePoint_comp_weightTorusRepresentation
     (R := ℤ) (A := A) (SplitTorus.characterGroup κ) p
   let f := CommHopfAlgCat.ofHom (DiagonalizableGroup.diagonalCoordinateMap bL
     (fun x => SplitTorus.weightCharacter (wt x)))
-  have hmap := CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of ℤ A) f.hom q
+  have hmap := CommHopfAlgCat.mapMulEquiv_mapPointsFunctor (CommAlgCat.of ℤ A) f q
   apply Over.OverMorphism.ext
   rw [GeneralLinear.groupSchemePointMulEquiv_apply_left, Over.comp_left,
     weightTorusRepresentation_def, DiagonalizableGroup.diagonalGroupSchemeHom_def]

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
@@ -56,17 +56,6 @@ universe u
 
 variable {R : Type u} [CommRing R]
 
-/-- The map on scheme-valued points of an affine Hopf-spectrum morphism becomes precomposition
-by its coordinate Hopf morphism on relative global sections. -/
-theorem schemePointsAlgΓMulEquiv_pointMap
-    {H K : CommHopfAlgCat.{u} R} (T : Over (Spec (CommRingCat.of R))) (f : H ⟶ K)
-    (g : T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) :
-    CommHopfAlgCat.schemePointsAlgΓMulEquiv H T
-        (pointMap ((hopfSpec (CommRingCat.of R)).map f.op) T g) =
-      AlgHom.mapDomain f.hom (CommHopfAlgCat.schemePointsAlgΓMulEquiv K T g) := by
-  rw [pointMap_apply]
-  exact CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapPointsFunctor T f g
-
 /-- If the represented kernel Hopf ideal is central, then the induced affine group-scheme
 morphism has central kernel on points valued in every scheme over the base. -/
 theorem hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal
@@ -88,7 +77,8 @@ theorem hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal
       AlgHom.mapDomain f.hom (eK g) =
           eH (pointMap ((hopfSpec (CommRingCat.of R)).map f.op) T g) := by
         dsimp only [eH, eK]
-        exact (schemePointsAlgΓMulEquiv_pointMap T f g).symm
+        rw [pointMap_apply]
+        exact (CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain T f.hom g).symm
       _ = eH 1 := congrArg eH (MonoidHom.mem_ker.mp hg)
       _ = 1 := map_one eH
   rw [AlgHom.mapDomain_apply, ← CommHopfAlgCat.mapPointsFunctor_app_apply] at hmap
@@ -132,7 +122,8 @@ theorem isCentral_kernelHopfIdeal_of_hasCentralKernel_hopfSpec_map
   have hnat : eK gB ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom =
       eH ((CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB) := by
     dsimp only [eH, eK]
-    exact (CommHopfAlgCat.mapMulEquiv_mapPointsFunctor (CommAlgCat.of R B) f gB).symm
+    rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
+    exact (CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R B) f.hom gB).symm
   have hsg : eK gB ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom = 1 := by
     calc
       _ = eH ((CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB) := hnat

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
@@ -1,0 +1,307 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Naturality
+public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Basic
+
+/-!
+# Coordinate criterion for central kernels
+
+A morphism `f : H ⟶ K` of commutative Hopf algebras induces contravariantly a morphism
+`Spec K ⟶ Spec H` of affine group schemes. This file identifies the two existing notions of a
+central kernel for that morphism:
+
+* `GroupScheme.HasCentralKernel` tests the kernel on points valued in every scheme over the base;
+* `HopfIdeal.IsCentral` says that the represented kernel Hopf ideal is central.
+
+The bridge must account for nonaffine test schemes in `HasCentralKernel`. For an arbitrary test
+scheme `T`, the relative `Γ-Spec` adjunction identifies its maps to `Spec H` with algebra maps
+from `H` to the relative global sections of `T`. The first main construction upgrades that
+adjunction equivalence to a multiplicative equivalence, so the group law on all scheme-valued
+points is convolution on global sections. Naturality in `H` then identifies the kernel of the
+scheme-valued point map with the points cut out by `kernelHopfIdeal f`.
+
+## Main declarations
+
+* `TauCeti.GroupScheme.schemePointsAlgΓMulEquiv`: maps from an arbitrary relative scheme to an
+  affine Hopf spectrum are convolution points valued in its relative global sections.
+* `TauCeti.GroupScheme.schemePointsAlgΓMulEquiv_mapDomain`: this comparison is contravariantly
+  natural in the coordinate Hopf algebra.
+* `TauCeti.GroupScheme.hasCentralKernel_hopfSpec_map_iff`: the induced affine group-scheme morphism
+  has central kernel exactly when its kernel Hopf ideal is central.
+* `TauCeti.GroupScheme.isCentralIsogeny_hopfSpec_map_iff`: the resulting coordinate criterion
+  for a central isogeny.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§1.k, 2, and 18.a.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapters 2 and 10.
+
+The relative global-sections comparison uses Mathlib's `algΓAlgSpecAdjunction`; on affine test
+schemes it specializes to Mathlib's `AlgebraicGeometry.Spec.mapMulEquiv`. This synchronizes the
+Hopf-algebra and group-scheme formulations of central isogenies required in Layer 6 of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.GroupScheme
+
+open AlgebraicGeometry
+
+universe u
+
+variable {R : Type u} [CommRing R]
+
+/-- The relative `Γ-Spec` adjunction as an equivalence between scheme-valued points and
+convolution points, before recording multiplicativity. -/
+private noncomputable def schemePointsAlgΓEquiv
+    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R))) :
+    (T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) ≃
+      WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) := by
+  let e₀ := (algΓAlgSpecAdjunction (CommRingCat.of R)).homEquiv T
+    (Opposite.op (CommAlgCat.of R H))
+  exact e₀.symm.trans
+    { toFun := fun f ↦ toConv f.unop.hom
+      invFun := fun f ↦ (CommAlgCat.ofHom f.ofConv).op
+      left_inv := by intro f; rfl
+      right_inv := by intro f; rfl }
+
+/-- The adjunction unit, with its target presented as the relative spectrum of global sections. -/
+private noncomputable def algΓUnitToSpec (T : Over (Spec (CommRingCat.of R))) :
+    T ⟶ (Spec (CommRingCat.of ((algΓ (CommRingCat.of R)).obj T).unop)).asOver
+      (Spec (CommRingCat.of R)) :=
+  (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫ eqToHom (by rfl)
+
+/-- A convolution point over the global sections of `T`, regarded as a `T`-valued point through
+the relative spectrum presentation. -/
+private noncomputable def algΓPointSchemePoint
+    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R)))
+    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X :=
+  algΓUnitToSpec T ≫
+    CommHopfAlgCat.mapMulEquivOfPresentation H _ rfl p
+
+private theorem algΓPointSchemePoint_eq_symm
+    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R)))
+    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    algΓPointSchemePoint H T p = (schemePointsAlgΓEquiv H T).symm p := by
+  rw [show (schemePointsAlgΓEquiv H T).symm p =
+      (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫
+        (algSpec (CommRingCat.of R)).map (CommAlgCat.ofHom p.ofConv).op by rfl]
+  unfold algΓPointSchemePoint algΓUnitToSpec
+  apply Over.OverMorphism.ext
+  simp only [Over.comp_left, Category.assoc]
+  rw [CommHopfAlgCat.mapMulEquivOfPresentation_apply_left H _ rfl rfl]
+  rfl
+
+private theorem algΓPointSchemePoint_mul
+    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R)))
+    (p q : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    algΓPointSchemePoint H T (p * q) =
+      algΓPointSchemePoint H T p * algΓPointSchemePoint H T q := by
+  unfold algΓPointSchemePoint
+  rw [map_mul, MonObj.comp_mul]
+
+/-- Maps from an arbitrary scheme `T` over `Spec R` to the affine group scheme represented by
+`H` are the convolution group of `H`-points valued in the relative global sections of `T`.
+
+Unlike `AlgebraicGeometry.Spec.mapMulEquiv`, the test scheme here need not be affine. The
+equivalence is the relative `Γ-Spec` adjunction, with its target given the convolution group law.
+-/
+noncomputable def schemePointsAlgΓMulEquiv
+    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R))) :
+    (T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) ≃*
+      WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) :=
+  { schemePointsAlgΓEquiv H T with
+    map_mul' := by
+      intro g h
+      apply (schemePointsAlgΓEquiv H T).symm.injective
+      calc
+        _ = g * h := (schemePointsAlgΓEquiv H T).symm_apply_apply (g * h)
+        _ = algΓPointSchemePoint H T (schemePointsAlgΓEquiv H T g) *
+            algΓPointSchemePoint H T (schemePointsAlgΓEquiv H T h) := by
+          rw [algΓPointSchemePoint_eq_symm, algΓPointSchemePoint_eq_symm,
+            Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+        _ = algΓPointSchemePoint H T
+            (schemePointsAlgΓEquiv H T g * schemePointsAlgΓEquiv H T h) :=
+          (algΓPointSchemePoint_mul H T _ _).symm
+        _ = (schemePointsAlgΓEquiv H T).symm
+            (schemePointsAlgΓEquiv H T g * schemePointsAlgΓEquiv H T h) :=
+          algΓPointSchemePoint_eq_symm H T _ }
+
+private theorem schemePointsAlgΓMulEquiv_symm_apply
+    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R)))
+    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
+    (schemePointsAlgΓMulEquiv H T).symm p = algΓPointSchemePoint H T p :=
+  (algΓPointSchemePoint_eq_symm H T p).symm
+
+/-- The global-sections comparison is contravariantly natural in the coordinate Hopf algebra.
+Postcomposing a scheme-valued point with `Spec f` is precomposition of its algebra point by `f`.
+-/
+theorem schemePointsAlgΓMulEquiv_mapDomain
+    {H K : CommHopfAlgCat.{u} R} (T : Over (Spec (CommRingCat.of R))) (f : H ⟶ K)
+    (g : T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) :
+    schemePointsAlgΓMulEquiv H T
+        (g ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom) =
+      AlgHom.mapDomain f.hom (schemePointsAlgΓMulEquiv K T g) := by
+  let A : CommAlgCat R := ((algΓ (CommRingCat.of R)).obj T).unop
+  let eH := schemePointsAlgΓMulEquiv H T
+  let eK := schemePointsAlgΓMulEquiv K T
+  apply eH.symm.injective
+  calc
+    eH.symm (eH (g ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom)) =
+        g ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom := eH.symm_apply_apply _
+    _ = eH.symm (AlgHom.mapDomain f.hom (eK g)) := by
+      rw [← eK.symm_apply_apply g]
+      rw [eK.apply_symm_apply]
+      rw [schemePointsAlgΓMulEquiv_symm_apply, schemePointsAlgΓMulEquiv_symm_apply]
+      unfold algΓPointSchemePoint
+      rw [Category.assoc]
+      congr 1
+      simpa only [A, eqToHom_refl, Category.comp_id, Category.id_comp,
+        CommHopfAlgCat.mapPointsFunctor_app_apply, AlgHom.mapDomain_apply] using
+        (CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain (R := R) A
+          (hG := rfl) (hH' := rfl)
+          (CommHopfAlgCat.mapMulEquivOfPresentation H A rfl)
+          (CommHopfAlgCat.mapMulEquivOfPresentation K A rfl)
+          (fun p ↦ CommHopfAlgCat.mapMulEquivOfPresentation_apply_left H A rfl rfl p)
+          (fun p ↦ CommHopfAlgCat.mapMulEquivOfPresentation_apply_left K A rfl rfl p)
+          f (eK g))
+
+/-- The map on scheme-valued points of an affine Hopf-spectrum morphism becomes precomposition
+by its coordinate Hopf morphism on relative global sections. -/
+theorem schemePointsAlgΓMulEquiv_pointMap
+    {H K : CommHopfAlgCat.{u} R} (T : Over (Spec (CommRingCat.of R))) (f : H ⟶ K)
+    (g : T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) :
+    schemePointsAlgΓMulEquiv H T
+        (pointMap ((hopfSpec (CommRingCat.of R)).map f.op) T g) =
+      AlgHom.mapDomain f.hom (schemePointsAlgΓMulEquiv K T g) := by
+  rw [pointMap_apply]
+  exact schemePointsAlgΓMulEquiv_mapDomain T f g
+
+/-- If the represented kernel Hopf ideal is central, then the induced affine group-scheme
+morphism has central kernel on points valued in every scheme over the base. -/
+theorem hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal
+    {H K : CommHopfAlgCat.{u} R} (f : H ⟶ K) (hf : (CommHopfAlgCat.kernelHopfIdeal f).IsCentral) :
+    HasCentralKernel ((hopfSpec (CommRingCat.of R)).map f.op) := by
+  rw [hasCentralKernel_iff_pointMap_ker_le_center]
+  intro T g hg
+  let eK := schemePointsAlgΓMulEquiv K T
+  let eH := schemePointsAlgΓMulEquiv H T
+  have hmap : AlgHom.mapDomain f.hom (eK g) = 1 := by
+    calc
+      AlgHom.mapDomain f.hom (eK g) =
+          eH (pointMap ((hopfSpec (CommRingCat.of R)).map f.op) T g) := by
+        rw [schemePointsAlgΓMulEquiv_pointMap]
+      _ = eH 1 := congrArg eH (MonoidHom.mem_ker.mp hg)
+      _ = 1 := map_one eH
+  have hmem : eK g ∈ CommHopfAlgCat.quotientPointsSubgroup K
+      (CommHopfAlgCat.kernelHopfIdeal f) ((algΓ (CommRingCat.of R)).obj T).unop :=
+    (CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff f _ (eK g)).mp hmap
+  have hp := CommHopfAlgCat.isCentralPoint_of_mem_quotientPointsSubgroup
+    K (CommHopfAlgCat.kernelHopfIdeal f) hf _ hmem
+  rw [Subgroup.mem_center_iff]
+  intro h
+  apply eK.injective
+  simpa only [map_mul] using (hp.commute (eK h)).eq.symm
+
+/-- If the induced affine group-scheme morphism has central kernel on all scheme-valued points,
+then its represented kernel Hopf ideal is central. -/
+theorem isCentral_kernelHopfIdeal_of_hasCentralKernel_hopfSpec_map
+    {H K : CommHopfAlgCat.{u} R} (f : H ⟶ K)
+    (hf : HasCentralKernel ((hopfSpec (CommRingCat.of R)).map f.op)) :
+    (CommHopfAlgCat.kernelHopfIdeal f).IsCentral := by
+  rw [CommHopfAlgCat.isCentral_iff_forall_isCentralPoint]
+  intro A g hg
+  rw [HopfAlgebra.isCentralPoint_def]
+  intro B _ _ φ h
+  let gB := AlgHom.mapValue φ g
+  have hgB : gB ∈ CommHopfAlgCat.quotientPointsSubgroup K
+      (CommHopfAlgCat.kernelHopfIdeal f) (CommAlgCat.of R B) :=
+    CommHopfAlgCat.mapPoints_mem_quotientPointsSubgroup K
+      (CommHopfAlgCat.kernelHopfIdeal f) (CommAlgCat.ofHom φ) hg
+  have hmap : (CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB = 1 :=
+    (CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff f (CommAlgCat.of R B) gB).mpr hgB
+  let eH := CommHopfAlgCat.mapMulEquivOfPresentation H B
+    (G := (hopfSpec (CommRingCat.of R)).obj (Opposite.op H)) rfl
+  let eK := CommHopfAlgCat.mapMulEquivOfPresentation K B
+    (G := (hopfSpec (CommRingCat.of R)).obj (Opposite.op K)) rfl
+  have hnat : eK gB ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom =
+      eH ((CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB) := by
+    simpa only [eqToHom_refl, Category.comp_id, Category.id_comp] using
+      (CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain B
+        (hG := rfl) (hH' := rfl) eH eK
+        (fun p ↦ CommHopfAlgCat.mapMulEquivOfPresentation_apply_left H B rfl rfl p)
+        (fun p ↦ CommHopfAlgCat.mapMulEquivOfPresentation_apply_left K B rfl rfl p) f gB)
+  have hsg : eK gB ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom = 1 := by
+    calc
+      _ = eH ((CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB) := hnat
+      _ = eH 1 := congrArg eH hmap
+      _ = 1 := map_one eH
+  have hker : eK gB ∈
+      (pointMap ((hopfSpec (CommRingCat.of R)).map f.op)
+        ((Spec (CommRingCat.of B)).asOver (Spec (CommRingCat.of R)))).ker := by
+    apply MonoidHom.mem_ker.mpr
+    exact (pointMap_apply _ _ _).trans hsg
+  have hcenter := (hasCentralKernel_iff_pointMap_ker_le_center
+    ((hopfSpec (CommRingCat.of R)).map f.op)).mp hf _ hker
+  have hs := (Subgroup.mem_center_iff.mp hcenter) (eK h)
+  rw [commute_iff_eq]
+  apply eK.injective
+  simpa only [map_mul] using hs.symm
+
+/-- **Coordinate criterion for a central kernel.** The affine group-scheme morphism induced by
+`f : H ⟶ K` has central kernel exactly when its represented kernel Hopf ideal is central. -/
+theorem hasCentralKernel_hopfSpec_map_iff {H K : CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    HasCentralKernel ((hopfSpec (CommRingCat.of R)).map f.op) ↔
+      (CommHopfAlgCat.kernelHopfIdeal f).IsCentral :=
+  ⟨isCentral_kernelHopfIdeal_of_hasCentralKernel_hopfSpec_map f,
+    hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal f⟩
+
+section Field
+
+variable {k : Type u} [Field k] {H K : CommHopfAlgCat.{u} k}
+
+/-- **Coordinate criterion for a central isogeny.** A Hopf-spectrum morphism is a central
+isogeny exactly when it is an isogeny and its represented kernel Hopf ideal is central. -/
+theorem isCentralIsogeny_hopfSpec_map_iff (f : H ⟶ K) :
+    IsCentralIsogeny ((hopfSpec (CommRingCat.of k)).map f.op) ↔
+      IsIsogeny ((hopfSpec (CommRingCat.of k)).map f.op) ∧
+        (CommHopfAlgCat.kernelHopfIdeal f).IsCentral := by
+  constructor
+  · intro hf
+    exact ⟨hf.isIsogeny,
+      (hasCentralKernel_hopfSpec_map_iff f).mp hf.hasCentralKernel⟩
+  · rintro ⟨hf, hker⟩
+    apply (isCentralIsogeny_iff _).mpr
+    exact ⟨hf.isFinite, hf.flat, hf.surjective,
+      (hasCentralKernel_hopfSpec_map_iff f).mpr hker⟩
+
+/-- An isogeny induced by a coordinate Hopf morphism is central when its represented kernel Hopf
+ideal is central. -/
+theorem IsIsogeny.isCentral_of_isCentral_kernelHopfIdeal (f : H ⟶ K)
+    (hf : IsIsogeny ((hopfSpec (CommRingCat.of k)).map f.op))
+    (hker : (CommHopfAlgCat.kernelHopfIdeal f).IsCentral) :
+    IsCentralIsogeny ((hopfSpec (CommRingCat.of k)).map f.op) :=
+  (isCentralIsogeny_hopfSpec_map_iff f).mpr ⟨hf, hker⟩
+
+/-- The represented kernel Hopf ideal of a central affine group-scheme isogeny is central. -/
+theorem IsCentralIsogeny.isCentral_kernelHopfIdeal (f : H ⟶ K)
+    (hf : IsCentralIsogeny ((hopfSpec (CommRingCat.of k)).map f.op)) :
+    (CommHopfAlgCat.kernelHopfIdeal f).IsCentral :=
+  (isCentralIsogeny_hopfSpec_map_iff f).mp hf |>.2
+
+end Field
+
+end TauCeti.GroupScheme

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
@@ -21,19 +21,13 @@ central kernel for that morphism:
 * `GroupScheme.HasCentralKernel` tests the kernel on points valued in every scheme over the base;
 * `HopfIdeal.IsCentral` says that the represented kernel Hopf ideal is central.
 
-The bridge must account for nonaffine test schemes in `HasCentralKernel`. For an arbitrary test
-scheme `T`, the relative `Γ-Spec` adjunction identifies its maps to `Spec H` with algebra maps
-from `H` to the relative global sections of `T`. The first main construction upgrades that
-adjunction equivalence to a multiplicative equivalence, so the group law on all scheme-valued
-points is convolution on global sections. Naturality in `H` then identifies the kernel of the
-scheme-valued point map with the points cut out by `kernelHopfIdeal f`.
+The bridge must account for nonaffine test schemes in `HasCentralKernel`. It uses the relative
+`Γ-Spec` multiplicative equivalence from `CommHopfAlgCat.SchemePoints`, so the group law on all
+scheme-valued points is convolution on global sections. Naturality in `H` then identifies the
+kernel of the scheme-valued point map with the points cut out by `kernelHopfIdeal f`.
 
 ## Main declarations
 
-* `TauCeti.GroupScheme.schemePointsAlgΓMulEquiv`: maps from an arbitrary relative scheme to an
-  affine Hopf spectrum are convolution points valued in its relative global sections.
-* `TauCeti.GroupScheme.schemePointsAlgΓMulEquiv_mapDomain`: this comparison is contravariantly
-  natural in the coordinate Hopf algebra.
 * `TauCeti.GroupScheme.hasCentralKernel_hopfSpec_map_iff`: the induced affine group-scheme morphism
   has central kernel exactly when its kernel Hopf ideal is central.
 * `TauCeti.GroupScheme.isCentralIsogeny_hopfSpec_map_iff`: the resulting coordinate criterion
@@ -44,10 +38,9 @@ scheme-valued point map with the points cut out by `kernelHopfIdeal f`.
 * J. S. Milne, *Algebraic Groups* (2017), §§1.k, 2, and 18.a.
 * W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapters 2 and 10.
 
-The relative global-sections comparison uses Mathlib's `algΓAlgSpecAdjunction`; on affine test
-schemes it specializes to Mathlib's `AlgebraicGeometry.Spec.mapMulEquiv`. This synchronizes the
-Hopf-algebra and group-scheme formulations of central isogenies required in Layer 6 of the
-ReductiveGroups roadmap.
+The relative global-sections comparison uses Mathlib's `algΓAlgSpecAdjunction` and
+`AlgebraicGeometry.Spec.mapMulEquiv`. This synchronizes the Hopf-algebra and group-scheme
+formulations of central isogenies required in Layer 6 of the ReductiveGroups roadmap.
 -/
 
 public section
@@ -63,132 +56,16 @@ universe u
 
 variable {R : Type u} [CommRing R]
 
-/-- The relative `Γ-Spec` adjunction as an equivalence between scheme-valued points and
-convolution points, before recording multiplicativity. -/
-private noncomputable def schemePointsAlgΓEquiv
-    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R))) :
-    (T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) ≃
-      WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) := by
-  let e₀ := (algΓAlgSpecAdjunction (CommRingCat.of R)).homEquiv T
-    (Opposite.op (CommAlgCat.of R H))
-  exact e₀.symm.trans
-    { toFun := fun f ↦ toConv f.unop.hom
-      invFun := fun f ↦ (CommAlgCat.ofHom f.ofConv).op
-      left_inv := by intro f; rfl
-      right_inv := by intro f; rfl }
-
-/-- The adjunction unit, with its target presented as the relative spectrum of global sections. -/
-private noncomputable def algΓUnitToSpec (T : Over (Spec (CommRingCat.of R))) :
-    T ⟶ (Spec (CommRingCat.of ((algΓ (CommRingCat.of R)).obj T).unop)).asOver
-      (Spec (CommRingCat.of R)) :=
-  (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫ eqToHom (by rfl)
-
-/-- A convolution point over the global sections of `T`, regarded as a `T`-valued point through
-the relative spectrum presentation. -/
-private noncomputable def algΓPointSchemePoint
-    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R)))
-    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
-    T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X :=
-  algΓUnitToSpec T ≫
-    CommHopfAlgCat.mapMulEquivOfPresentation H _ rfl p
-
-private theorem algΓPointSchemePoint_eq_symm
-    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R)))
-    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
-    algΓPointSchemePoint H T p = (schemePointsAlgΓEquiv H T).symm p := by
-  rw [show (schemePointsAlgΓEquiv H T).symm p =
-      (algΓAlgSpecAdjunction (CommRingCat.of R)).unit.app T ≫
-        (algSpec (CommRingCat.of R)).map (CommAlgCat.ofHom p.ofConv).op by rfl]
-  unfold algΓPointSchemePoint algΓUnitToSpec
-  apply Over.OverMorphism.ext
-  simp only [Over.comp_left, Category.assoc]
-  rw [CommHopfAlgCat.mapMulEquivOfPresentation_apply_left H _ rfl rfl]
-  rfl
-
-private theorem algΓPointSchemePoint_mul
-    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R)))
-    (p q : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
-    algΓPointSchemePoint H T (p * q) =
-      algΓPointSchemePoint H T p * algΓPointSchemePoint H T q := by
-  unfold algΓPointSchemePoint
-  rw [map_mul, MonObj.comp_mul]
-
-/-- Maps from an arbitrary scheme `T` over `Spec R` to the affine group scheme represented by
-`H` are the convolution group of `H`-points valued in the relative global sections of `T`.
-
-Unlike `AlgebraicGeometry.Spec.mapMulEquiv`, the test scheme here need not be affine. The
-equivalence is the relative `Γ-Spec` adjunction, with its target given the convolution group law.
--/
-noncomputable def schemePointsAlgΓMulEquiv
-    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R))) :
-    (T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) ≃*
-      WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) :=
-  { schemePointsAlgΓEquiv H T with
-    map_mul' := by
-      intro g h
-      apply (schemePointsAlgΓEquiv H T).symm.injective
-      calc
-        _ = g * h := (schemePointsAlgΓEquiv H T).symm_apply_apply (g * h)
-        _ = algΓPointSchemePoint H T (schemePointsAlgΓEquiv H T g) *
-            algΓPointSchemePoint H T (schemePointsAlgΓEquiv H T h) := by
-          rw [algΓPointSchemePoint_eq_symm, algΓPointSchemePoint_eq_symm,
-            Equiv.symm_apply_apply, Equiv.symm_apply_apply]
-        _ = algΓPointSchemePoint H T
-            (schemePointsAlgΓEquiv H T g * schemePointsAlgΓEquiv H T h) :=
-          (algΓPointSchemePoint_mul H T _ _).symm
-        _ = (schemePointsAlgΓEquiv H T).symm
-            (schemePointsAlgΓEquiv H T g * schemePointsAlgΓEquiv H T h) :=
-          algΓPointSchemePoint_eq_symm H T _ }
-
-private theorem schemePointsAlgΓMulEquiv_symm_apply
-    (H : CommHopfAlgCat.{u} R) (T : Over (Spec (CommRingCat.of R)))
-    (p : WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop)) :
-    (schemePointsAlgΓMulEquiv H T).symm p = algΓPointSchemePoint H T p :=
-  (algΓPointSchemePoint_eq_symm H T p).symm
-
-/-- The global-sections comparison is contravariantly natural in the coordinate Hopf algebra.
-Postcomposing a scheme-valued point with `Spec f` is precomposition of its algebra point by `f`.
--/
-theorem schemePointsAlgΓMulEquiv_mapDomain
-    {H K : CommHopfAlgCat.{u} R} (T : Over (Spec (CommRingCat.of R))) (f : H ⟶ K)
-    (g : T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) :
-    schemePointsAlgΓMulEquiv H T
-        (g ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom) =
-      AlgHom.mapDomain f.hom (schemePointsAlgΓMulEquiv K T g) := by
-  let A : CommAlgCat R := ((algΓ (CommRingCat.of R)).obj T).unop
-  let eH := schemePointsAlgΓMulEquiv H T
-  let eK := schemePointsAlgΓMulEquiv K T
-  apply eH.symm.injective
-  calc
-    eH.symm (eH (g ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom)) =
-        g ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom := eH.symm_apply_apply _
-    _ = eH.symm (AlgHom.mapDomain f.hom (eK g)) := by
-      rw [← eK.symm_apply_apply g]
-      rw [eK.apply_symm_apply]
-      rw [schemePointsAlgΓMulEquiv_symm_apply, schemePointsAlgΓMulEquiv_symm_apply]
-      unfold algΓPointSchemePoint
-      rw [Category.assoc]
-      congr 1
-      simpa only [A, eqToHom_refl, Category.comp_id, Category.id_comp,
-        CommHopfAlgCat.mapPointsFunctor_app_apply, AlgHom.mapDomain_apply] using
-        (CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain (R := R) A
-          (hG := rfl) (hH' := rfl)
-          (CommHopfAlgCat.mapMulEquivOfPresentation H A rfl)
-          (CommHopfAlgCat.mapMulEquivOfPresentation K A rfl)
-          (fun p ↦ CommHopfAlgCat.mapMulEquivOfPresentation_apply_left H A rfl rfl p)
-          (fun p ↦ CommHopfAlgCat.mapMulEquivOfPresentation_apply_left K A rfl rfl p)
-          f (eK g))
-
 /-- The map on scheme-valued points of an affine Hopf-spectrum morphism becomes precomposition
 by its coordinate Hopf morphism on relative global sections. -/
 theorem schemePointsAlgΓMulEquiv_pointMap
     {H K : CommHopfAlgCat.{u} R} (T : Over (Spec (CommRingCat.of R))) (f : H ⟶ K)
     (g : T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) :
-    schemePointsAlgΓMulEquiv H T
+    CommHopfAlgCat.schemePointsAlgΓMulEquiv H T
         (pointMap ((hopfSpec (CommRingCat.of R)).map f.op) T g) =
-      AlgHom.mapDomain f.hom (schemePointsAlgΓMulEquiv K T g) := by
+      AlgHom.mapDomain f.hom (CommHopfAlgCat.schemePointsAlgΓMulEquiv K T g) := by
   rw [pointMap_apply]
-  exact schemePointsAlgΓMulEquiv_mapDomain T f g
+  exact CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain T f.hom g
 
 /-- If the represented kernel Hopf ideal is central, then the induced affine group-scheme
 morphism has central kernel on points valued in every scheme over the base. -/
@@ -197,13 +74,20 @@ theorem hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal
     HasCentralKernel ((hopfSpec (CommRingCat.of R)).map f.op) := by
   rw [hasCentralKernel_iff_pointMap_ker_le_center]
   intro T g hg
-  let eK := schemePointsAlgΓMulEquiv K T
-  let eH := schemePointsAlgΓMulEquiv H T
+  let eK :
+      (T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) ≃*
+        WithConv (K →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) :=
+    CommHopfAlgCat.schemePointsAlgΓMulEquiv K T
+  let eH :
+      (T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) ≃*
+        WithConv (H →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) :=
+    CommHopfAlgCat.schemePointsAlgΓMulEquiv H T
   have hmap : AlgHom.mapDomain f.hom (eK g) = 1 := by
     calc
       AlgHom.mapDomain f.hom (eK g) =
           eH (pointMap ((hopfSpec (CommRingCat.of R)).map f.op) T g) := by
-        rw [schemePointsAlgΓMulEquiv_pointMap]
+        dsimp only [eH, eK]
+        exact (schemePointsAlgΓMulEquiv_pointMap T f g).symm
       _ = eH 1 := congrArg eH (MonoidHom.mem_ker.mp hg)
       _ = 1 := map_one eH
   have hmem : eK g ∈ CommHopfAlgCat.quotientPointsSubgroup K
@@ -214,7 +98,8 @@ theorem hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal
   rw [Subgroup.mem_center_iff]
   intro h
   apply eK.injective
-  simpa only [map_mul] using (hp.commute (eK h)).eq.symm
+  rw [map_mul, map_mul]
+  exact (hp.commute (eK h)).eq.symm
 
 /-- If the induced affine group-scheme morphism has central kernel on all scheme-valued points,
 then its represented kernel Hopf ideal is central. -/
@@ -233,17 +118,18 @@ theorem isCentral_kernelHopfIdeal_of_hasCentralKernel_hopfSpec_map
       (CommHopfAlgCat.kernelHopfIdeal f) (CommAlgCat.ofHom φ) hg
   have hmap : (CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB = 1 :=
     (CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff f (CommAlgCat.of R B) gB).mpr hgB
-  let eH := CommHopfAlgCat.mapMulEquivOfPresentation H B
-    (G := (hopfSpec (CommRingCat.of R)).obj (Opposite.op H)) rfl
-  let eK := CommHopfAlgCat.mapMulEquivOfPresentation K B
-    (G := (hopfSpec (CommRingCat.of R)).obj (Opposite.op K)) rfl
+  let eH : WithConv (H →ₐ[R] B) ≃*
+      ((Spec (CommRingCat.of B)).asOver (Spec (CommRingCat.of R)) ⟶
+        ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) :=
+    AlgebraicGeometry.Spec.mapMulEquiv
+  let eK : WithConv (K →ₐ[R] B) ≃*
+      ((Spec (CommRingCat.of B)).asOver (Spec (CommRingCat.of R)) ⟶
+        ((hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) :=
+    AlgebraicGeometry.Spec.mapMulEquiv
   have hnat : eK gB ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom =
       eH ((CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB) := by
-    simpa only [eqToHom_refl, Category.comp_id, Category.id_comp] using
-      (CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain B
-        (hG := rfl) (hH' := rfl) eH eK
-        (fun p ↦ CommHopfAlgCat.mapMulEquivOfPresentation_apply_left H B rfl rfl p)
-        (fun p ↦ CommHopfAlgCat.mapMulEquivOfPresentation_apply_left K B rfl rfl p) f gB)
+    dsimp only [eH, eK]
+    exact (CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R B) f.hom gB).symm
   have hsg : eK gB ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom = 1 := by
     calc
       _ = eH ((CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB) := hnat
@@ -279,28 +165,8 @@ theorem isCentralIsogeny_hopfSpec_map_iff (f : H ⟶ K) :
     IsCentralIsogeny ((hopfSpec (CommRingCat.of k)).map f.op) ↔
       IsIsogeny ((hopfSpec (CommRingCat.of k)).map f.op) ∧
         (CommHopfAlgCat.kernelHopfIdeal f).IsCentral := by
-  constructor
-  · intro hf
-    exact ⟨hf.isIsogeny,
-      (hasCentralKernel_hopfSpec_map_iff f).mp hf.hasCentralKernel⟩
-  · rintro ⟨hf, hker⟩
-    apply (isCentralIsogeny_iff _).mpr
-    exact ⟨hf.isFinite, hf.flat, hf.surjective,
-      (hasCentralKernel_hopfSpec_map_iff f).mpr hker⟩
-
-/-- An isogeny induced by a coordinate Hopf morphism is central when its represented kernel Hopf
-ideal is central. -/
-theorem IsIsogeny.isCentral_of_isCentral_kernelHopfIdeal (f : H ⟶ K)
-    (hf : IsIsogeny ((hopfSpec (CommRingCat.of k)).map f.op))
-    (hker : (CommHopfAlgCat.kernelHopfIdeal f).IsCentral) :
-    IsCentralIsogeny ((hopfSpec (CommRingCat.of k)).map f.op) :=
-  (isCentralIsogeny_hopfSpec_map_iff f).mpr ⟨hf, hker⟩
-
-/-- The represented kernel Hopf ideal of a central affine group-scheme isogeny is central. -/
-theorem IsCentralIsogeny.isCentral_kernelHopfIdeal (f : H ⟶ K)
-    (hf : IsCentralIsogeny ((hopfSpec (CommRingCat.of k)).map f.op)) :
-    (CommHopfAlgCat.kernelHopfIdeal f).IsCentral :=
-  (isCentralIsogeny_hopfSpec_map_iff f).mp hf |>.2
+  rw [isCentralIsogeny_iff, isIsogeny_iff]
+  simp only [and_assoc, hasCentralKernel_hopfSpec_map_iff]
 
 end Field
 

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Coordinate.lean
@@ -65,7 +65,7 @@ theorem schemePointsAlgΓMulEquiv_pointMap
         (pointMap ((hopfSpec (CommRingCat.of R)).map f.op) T g) =
       AlgHom.mapDomain f.hom (CommHopfAlgCat.schemePointsAlgΓMulEquiv K T g) := by
   rw [pointMap_apply]
-  exact CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapDomain T f.hom g
+  exact CommHopfAlgCat.schemePointsAlgΓMulEquiv_mapPointsFunctor T f g
 
 /-- If the represented kernel Hopf ideal is central, then the induced affine group-scheme
 morphism has central kernel on points valued in every scheme over the base. -/
@@ -74,6 +74,7 @@ theorem hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal
     HasCentralKernel ((hopfSpec (CommRingCat.of R)).map f.op) := by
   rw [hasCentralKernel_iff_pointMap_ker_le_center]
   intro T g hg
+  -- The `hopfSpec` objects unfold to the relative spectrum presentations used by the comparison.
   let eK :
       (T ⟶ ((hopfSpec (CommRingCat.of R)).obj (Opposite.op K)).X) ≃*
         WithConv (K →ₐ[R] ((algΓ (CommRingCat.of R)).obj T).unop) :=
@@ -90,6 +91,7 @@ theorem hasCentralKernel_hopfSpec_map_of_isCentral_kernelHopfIdeal
         exact (schemePointsAlgΓMulEquiv_pointMap T f g).symm
       _ = eH 1 := congrArg eH (MonoidHom.mem_ker.mp hg)
       _ = 1 := map_one eH
+  rw [AlgHom.mapDomain_apply, ← CommHopfAlgCat.mapPointsFunctor_app_apply] at hmap
   have hmem : eK g ∈ CommHopfAlgCat.quotientPointsSubgroup K
       (CommHopfAlgCat.kernelHopfIdeal f) ((algΓ (CommRingCat.of R)).obj T).unop :=
     (CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff f _ (eK g)).mp hmap
@@ -118,6 +120,7 @@ theorem isCentral_kernelHopfIdeal_of_hasCentralKernel_hopfSpec_map
       (CommHopfAlgCat.kernelHopfIdeal f) (CommAlgCat.ofHom φ) hg
   have hmap : (CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB = 1 :=
     (CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff f (CommAlgCat.of R B) gB).mpr hgB
+  -- The `hopfSpec` objects unfold to the relative spectrum presentations used by `mapMulEquiv`.
   let eH : WithConv (H →ₐ[R] B) ≃*
       ((Spec (CommRingCat.of B)).asOver (Spec (CommRingCat.of R)) ⟶
         ((hopfSpec (CommRingCat.of R)).obj (Opposite.op H)).X) :=
@@ -129,7 +132,7 @@ theorem isCentral_kernelHopfIdeal_of_hasCentralKernel_hopfSpec_map
   have hnat : eK gB ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom =
       eH ((CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB) := by
     dsimp only [eH, eK]
-    exact (CommHopfAlgCat.mapMulEquiv_mapDomain (CommAlgCat.of R B) f.hom gB).symm
+    exact (CommHopfAlgCat.mapMulEquiv_mapPointsFunctor (CommAlgCat.of R B) f gB).symm
   have hsg : eK gB ≫ ((hopfSpec (CommRingCat.of R)).map f.op).hom.hom = 1 := by
     calc
       _ = eH ((CommHopfAlgCat.mapPointsFunctor f).app (CommAlgCat.of R B) gB) := hnat


### PR DESCRIPTION
This PR identifies central kernels of affine Hopf-spectrum morphisms with central kernel Hopf ideals, using the relative `Γ-Spec` adjunction to cover every scheme-valued point required by `HasCentralKernel`.

It advances the exact `ReductiveGroups/README.md` Layer 6 milestone “Develop the radical, the centre `Z(G)`, the derived group `G_der`, central isogenies, and the simply connected and adjoint forms,” specifically its central-isogenies target. The existing pointwise group-scheme and coordinate Hopf-ideal APIs were parallel; this criterion makes the coordinate kernel result directly usable by the central-isogeny interface.

After this PR, the Layer 6 milestone still needs the structural theory of radicals, centres, derived groups, composition and quotient behavior for central isogenies, and the simply connected and adjoint forms.

The new `Coordinate` module supplies the multiplicative relative-global-sections comparison, proves its coordinate naturality, establishes both directions of the central-kernel criterion, and packages the result for central isogenies. No Mathlib implementation is vendored; the proof reuses Mathlib's `AlgebraicGeometry.algΓAlgSpecAdjunction` together with Tau Ceti's presentation-aware wrapper around `AlgebraicGeometry.Spec.mapMulEquiv`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"central-kernel-hopf-ideal-iff"}-->

🤖 Prepared with Codex
