### PR TITLE
feat: prove smooth affine groups geometrically reduced

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean
@@ -6,19 +6,21 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.AlgebraicGeometry.Group.Smooth
+public import TauCeti.RingTheory.Smooth.GeometricallyReduced
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.GeometricallyReduced
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Smooth
 
 /-!
-# Smoothness of geometrically reduced affine groups
+# Smoothness and geometric reducedness of affine groups
 
 Mathlib proves that a geometrically reduced group scheme locally of finite type over a field is
-smooth. Transporting that theorem through Tau Ceti's affine Hopf/group-scheme dictionary gives
-the coordinate criterion
+smooth. Conversely, a smooth algebra over a field remains smooth, and hence reduced, after every
+field extension. Transporting both directions through Tau Ceti's affine Hopf/group-scheme
+dictionary gives the coordinate criterion
 
 ```text
-finite type + geometrically reduced ⇒ smooth.
+finite type + commutative Hopf algebra: geometrically reduced ⇔ smooth.
 ```
 
 The finite-type hypothesis is kept separate throughout. In particular, neither geometric
@@ -28,26 +30,48 @@ reducedness nor smoothness is built into the category of commutative Hopf algebr
 
 * `TauCeti.smoothCommHopfAlgProperty_of_geometricallyReduced`: a finite-type geometrically
   reduced commutative Hopf algebra over a field is smooth.
+* `TauCeti.geometricallyReducedCommHopfAlgProperty_of_smooth`: a smooth commutative Hopf algebra
+  over a field is geometrically reduced.
+* `TauCeti.smoothCommHopfAlgProperty_iff_geometricallyReduced`: the finite-type equivalence.
 
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), Proposition 1.26 and Corollary 1.27.
 
 This advances Layer 2, "Smoothness and dimension tools via `Lie(G)`", of the ReductiveGroups
-roadmap. The scheme-theoretic input is Mathlib's `AlgebraicGeometry.smooth_of_grpObj`.
+roadmap. The forward implication uses Mathlib's `AlgebraicGeometry.smooth_of_grpObj`; the reverse
+uses `TauCeti.isReduced_of_smooth_of_field` after arbitrary field extension.
 -/
 
 public section
 
 open CategoryTheory
+open scoped TensorProduct
 
 namespace TauCeti
 
 open AlgebraicGeometry
 
-universe u
+universe u v
 
 noncomputable section
+
+/-- **A smooth commutative Hopf algebra over a field is geometrically reduced.**
+
+Smoothness is preserved by extension of the ground field. The resulting tensor product is
+reduced by `TauCeti.isReduced_of_smooth_of_field`; commuting the tensor factors puts the result
+in the orientation used by `geometricallyReducedCommHopfAlgProperty`. -/
+theorem geometricallyReducedCommHopfAlgProperty_of_smooth
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k)
+    (hH : smoothCommHopfAlgProperty k H) :
+    geometricallyReducedCommHopfAlgProperty k H := by
+  rw [geometricallyReducedCommHopfAlgProperty_iff]
+  intro K _ _
+  let _ : Algebra.Smooth k H := (smoothCommHopfAlgProperty_iff H).mp hH
+  let _ : Algebra.Smooth K (K ⊗[k] H) := Algebra.Smooth.baseChange k H K
+  let _ : IsReduced (K ⊗[k] H) := isReduced_of_smooth_of_field K (K ⊗[k] H)
+  exact isReduced_of_injective (Algebra.TensorProduct.comm k H K).toRingHom
+    (Algebra.TensorProduct.comm k H K).injective
 
 /-- **A finite-type geometrically reduced commutative Hopf algebra over a field is smooth.**
 -/
@@ -69,6 +93,14 @@ theorem smoothCommHopfAlgProperty_of_geometricallyReduced
   apply (algebraSmooth_iff_smooth_hopfSpec k H).mpr
   rw [smoothAffineGroupSchemeProperty_iff]
   exact smooth_of_grpObj _
+
+/-- For a finite-type commutative Hopf algebra over a field, smoothness is equivalent to geometric
+reducedness. -/
+theorem smoothCommHopfAlgProperty_iff_geometricallyReduced
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{u} k) [Algebra.FiniteType k H] :
+    smoothCommHopfAlgProperty k H ↔ geometricallyReducedCommHopfAlgProperty k H :=
+  ⟨geometricallyReducedCommHopfAlgProperty_of_smooth k H,
+    smoothCommHopfAlgProperty_of_geometricallyReduced k H⟩
 
 end
 

--- a/TauCeti/RingTheory/Smooth/GeometricallyReduced.lean
+++ b/TauCeti/RingTheory/Smooth/GeometricallyReduced.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Etale.Field
+public import Mathlib.RingTheory.LocalProperties.Reduced
+public import Mathlib.RingTheory.Nilpotent.GeometricallyReduced
+public import Mathlib.RingTheory.RingHom.StandardSmooth
+
+/-!
+# Smooth algebras over fields are geometrically reduced
+
+This file proves that a smooth algebra over a field is geometrically reduced. The main argument
+first treats a standard-smooth algebra `A`. Such an algebra admits an étale map from a polynomial
+ring `P`; after extending scalars from `P` to its fraction field, the resulting algebra is étale
+over a field and hence reduced. Flatness of `A` over `P` makes the natural map from `A` into this
+generic fibre injective, so `A` itself is reduced.
+
+An arbitrary smooth algebra is covered by standard-smooth basic localizations. Reducedness on
+this cover detects nilpotents in the original algebra. Applying the result after extension to an
+algebraic closure gives geometric reducedness.
+
+## Main declarations
+
+* `TauCeti.isReduced_of_standardSmooth_of_field`: a standard-smooth algebra over a field is
+  reduced.
+* `TauCeti.isReduced_of_smooth_of_field`: a smooth algebra over a field is reduced.
+* `TauCeti.isGeometricallyReduced_of_smooth`: a smooth algebra over a field is geometrically
+  reduced.
+
+## References
+
+* The Stacks Project, Section 10.140, *Smooth algebras over fields*.
+
+This is the commutative-algebra input for the equivalence between smoothness and geometric
+reducedness of finite-type affine group schemes in Layer 2 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v
+
+/-- A standard-smooth algebra over a field is reduced.
+
+The algebra embeds into the base change along the fraction field of a polynomial ring over which
+it is étale. The base change is reduced because it is étale over a field. -/
+theorem isReduced_of_standardSmooth_of_field
+    (k : Type u) (A : Type v) [Field k] [CommRing A] [Algebra k A]
+    [Algebra.IsStandardSmooth k A] : IsReduced A := by
+  by_cases hA : Nontrivial A
+  · let _ : Nontrivial A := hA
+    have hs : (algebraMap k A).IsStandardSmooth := by
+      rw [RingHom.isStandardSmooth_algebraMap]
+      infer_instance
+    obtain ⟨n, g, _, hg⟩ := hs.exists_etale_mvPolynomial
+    let _ : Algebra (MvPolynomial (Fin n) k) A := g.toAlgebra
+    let _ : Algebra.Etale (MvPolynomial (Fin n) k) A := hg.toAlgebra
+    let F := FractionRing (MvPolynomial (Fin n) k)
+    let B := F ⊗[MvPolynomial (Fin n) k] A
+    let _ : Algebra.Etale F B :=
+      Algebra.Etale.baseChange (MvPolynomial (Fin n) k) A F
+    let _ : IsReduced B := Algebra.FormallyUnramified.isReduced_of_field F B
+    exact isReduced_of_injective
+      (Algebra.TensorProduct.includeRight (R := MvPolynomial (Fin n) k) (A := F) (B := A))
+      (Algebra.TensorProduct.includeRight_injective (IsFractionRing.injective _ F))
+  · let _ : Subsingleton A := not_nontrivial_iff_subsingleton.mp hA
+    infer_instance
+
+/-- A smooth algebra over a field is reduced. -/
+theorem isReduced_of_smooth_of_field
+    (k : Type u) (A : Type v) [Field k] [CommRing A] [Algebra k A]
+    [Algebra.Smooth k A] : IsReduced A := by
+  obtain ⟨s, hs, hsmooth⟩ := Algebra.Smooth.exists_span_eq_top_isStandardSmooth k A
+  constructor
+  intro x hx
+  apply Module.eq_zero_of_isLocalized_span s hs
+    (fun r : s ↦ Localization.Away r.1)
+    (fun r : s ↦ Algebra.linearMap A (Localization.Away r.1))
+  intro r
+  let _ : Algebra.IsStandardSmooth k (Localization.Away r.1) := hsmooth r.1 r.2
+  let _ : IsReduced (Localization.Away r.1) :=
+    isReduced_of_standardSmooth_of_field k (Localization.Away r.1)
+  exact (hx.map (algebraMap A (Localization.Away r.1))).eq_zero
+
+/-- A smooth algebra over a field is geometrically reduced. -/
+theorem isGeometricallyReduced_of_smooth
+    (k : Type u) (A : Type v) [Field k] [CommRing A] [Algebra k A]
+    [Algebra.Smooth k A] : Algebra.IsGeometricallyReduced k A := by
+  rw [Algebra.isGeometricallyReduced_field_iff]
+  exact isReduced_of_smooth_of_field (AlgebraicClosure k) (AlgebraicClosure k ⊗[k] A)
+
+end TauCeti


### PR DESCRIPTION
This PR proves that every smooth algebra over a field is geometrically reduced, then applies the result after arbitrary field extension to commutative Hopf algebras and records the finite-type equivalence between smoothness and geometric reducedness.

It advances the exact `ReductiveGroups/README.md` standing-hypothesis target “for group schemes locally of finite type over a field, smoothness ⇔ geometric reducedness,” within Layer 2, “Smoothness and dimension tools via `Lie(G)`.” The dependency edge to the current frontier is the Layer 6 worked-example target “prove [tori] reductive”: the in-flight multiplicative-type semisimplicity work reduces a smooth unipotent closed subgroup of a torus to a reduced semisimple-unipotent subgroup, and `TauCeti.isReduced_of_smooth_of_field` supplies precisely that missing reducedness hypothesis.

After this PR, the torus worked example still needs the in-flight semisimplicity result applied to each connected normal smooth unipotent closed subgroup and assembled into `reductiveCommHopfAlgProperty`; the general unipotent radical remains open.

The new generic proof first embeds a standard-smooth algebra into its étale generic fibre over the fraction field of a polynomial ring. Mathlib's étale base-change API makes that fibre reduced, while flat tensor injectivity reflects reducedness to the original algebra. Mathlib's standard-smooth basic-open cover and `Module.eq_zero_of_isLocalized_span` then detect nilpotents in an arbitrary smooth algebra. The Hopf-algebra theorem base-changes smoothness to every extension field and transports reducedness across the tensor-factor swap.

This adds `TauCeti/RingTheory/Smooth/GeometricallyReduced.lean` (99 lines) and extends `TauCeti/Algebra/AlgebraicGroup/Smooth/GeometricallyReduced.lean` with the reverse implication and the finite-type equivalence. The argument follows the standard smooth-algebra result cited in the module documentation from the Stacks Project, Section 10.140. No Mathlib or external formalization is vendored; the proof reuses `RingHom.IsStandardSmooth.exists_etale_mvPolynomial`, `Algebra.Etale.baseChange`, `Algebra.FormallyUnramified.isReduced_of_field`, and `Algebra.Smooth.exists_span_eq_top_isStandardSmooth`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"smooth-geometrically-reduced"}-->

🤖 Prepared with Codex
