### PR TITLE
feat: preserve central isogenies under base change

### DIFF
--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -108,7 +108,7 @@ private noncomputable def baseChangePointMulEquiv
     rw [mapPullbackAdj_homEquiv_symm_left]
     simp only [Hom.mul_def, Over.comp_left, Over.lift_left,
       mapPullbackAdj_homEquiv_symm_left]
-    change T ⟶ (Over.pullback s).obj G.X at p q
+    rw [Functor.mapGrp_obj_X] at p q
     rw [congrArg Over.Hom.left (pullbackMapGrp_mul s G), Over.comp_left]
     have hmap :
         Over.Hom.left ((Over.pullback s).map μ[G.X]) ≫

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -74,16 +74,6 @@ private theorem mapPullbackAdj_homEquiv_symm_left
   -- computation rule in its public definition.
   rfl
 
-/-- The multiplication of a group object transported by `Over.pullback` is the lax-monoidal
-comparison map followed by the pullback of the original multiplication. -/
-private theorem pullbackMapGrp_mul
-    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k))
-    (G : Grp (Over (Spec (CommRingCat.of k)))) :
-    μ[((Over.pullback s).mapGrp.obj G).X] =
-      Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X ≫
-        (Over.pullback s).map μ[G.X] :=
-  Functor.obj.μ_def (F := Over.pullback s) G.X
-
 /-- The adjunction between postcomposition and pullback identifies points of a base-changed group
 scheme with points of the original group scheme over the same test scheme viewed over the old
 base. This identification is multiplicative. -/
@@ -109,7 +99,7 @@ private noncomputable def baseChangePointMulEquiv
     simp only [Hom.mul_def, Over.comp_left, Over.lift_left,
       mapPullbackAdj_homEquiv_symm_left]
     rw [Functor.mapGrp_obj_X] at p q
-    rw [congrArg Over.Hom.left (pullbackMapGrp_mul s G), Over.comp_left]
+    erw [congrArg Over.Hom.left (Functor.obj.μ_def (F := Over.pullback s) G.X), Over.comp_left]
     have hmap :
         Over.Hom.left ((Over.pullback s).map μ[G.X]) ≫
             (Limits.pullback.fst G.X.hom s :

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -59,7 +59,6 @@ theorem IsIsogeny.baseChange
     MorphismProperty.overPullbackMap _ _ hf.flat,
     MorphismProperty.overPullbackMap _ _ hf.surjective⟩
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The adjunction between postcomposition and pullback identifies points of a base-changed group
 scheme with points of the original group scheme over the same test scheme viewed over the old
 base. This identification is multiplicative. -/
@@ -74,49 +73,81 @@ private noncomputable def baseChangePointMulEquiv
   left_inv := (Over.mapPullbackAdj s).homEquiv T G.X |>.right_inv
   right_inv := (Over.mapPullbackAdj s).homEquiv T G.X |>.left_inv
   map_mul' p q := by
-    ext
+    let pLeft : ((Over.map s).obj T).left ⟶ Limits.pullback G.X.hom s := p.left
+    let qLeft : ((Over.map s).obj T).left ⟶ Limits.pullback G.X.hom s := q.left
+    have hpq :
+        pLeft ≫ Limits.pullback.snd G.X.hom s =
+          qLeft ≫ Limits.pullback.snd G.X.hom s :=
+      p.w.trans q.w.symm
     have hleft (r : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
         Over.Hom.left (((Over.mapPullbackAdj s).homEquiv T G.X).symm r) =
           Over.Hom.left r ≫ Limits.pullback.fst G.X.hom s :=
       rfl
-    rw [hleft (p * q)]
-    simp only [Hom.mul_def]
-    simp only [Over.comp_left, Over.lift_left]
-    simp only [hleft]
-    change T ⟶ (Over.pullback s).obj G.X at p q
-    have hmul :
-        Over.Hom.left μ[((Over.pullback s).mapGrp.obj G).X] =
-          Over.Hom.left
-            (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X ≫
-              (Over.pullback s).map μ[G.X]) :=
-      rfl
-    rw [hmul]
-    simp only [Over.comp_left]
-    simp only [Category.assoc, Over.pullback_map_left, Limits.pullback.lift_fst]
-    have hpq :
-        Over.Hom.left p ≫ Limits.pullback.snd G.X.hom s =
-          Over.Hom.left q ≫ Limits.pullback.snd G.X.hom s :=
-      p.w.trans q.w.symm
+    have hmulPoint :
+        Over.Hom.left (p * q) =
+          (Limits.pullback.lift pLeft qLeft hpq ≫
+              Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
+            Over.Hom.left ((Over.pullback s).map μ[G.X]) := (rfl)
+    ext
+    rw [hleft (p * q), hmulPoint]
+    simp only [Hom.mul_def, Over.comp_left, Over.lift_left, hleft]
+    have hfst :
+        Limits.pullback.fst ((Over.pullback s).obj G.X).hom
+            ((Over.pullback s).obj G.X).hom =
+          Limits.pullback.fst (Limits.pullback.snd G.X.hom s)
+            (Limits.pullback.snd G.X.hom s) := (rfl)
+    have hsnd :
+        Limits.pullback.snd ((Over.pullback s).obj G.X).hom
+            ((Over.pullback s).obj G.X).hom =
+          Limits.pullback.snd (Limits.pullback.snd G.X.hom s)
+            (Limits.pullback.snd G.X.hom s) := (rfl)
+    have hmap :
+        Over.Hom.left ((Over.pullback s).map μ[G.X]) ≫
+            (Limits.pullback.fst G.X.hom s :
+              ((Over.pullback s).mapGrp.obj G).X.left ⟶ G.X.left) =
+          Limits.pullback.fst (MonoidalCategoryStruct.tensorObj G.X G.X).hom s ≫
+            Over.Hom.left μ[G.X] := by
+      simp only [Over.pullback_map_left, Limits.pullback.lift_fst]
+    have hmap_assoc :
+        (((Limits.pullback.lift pLeft qLeft hpq ≫
+              Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
+            Over.Hom.left ((Over.pullback s).map μ[G.X])) ≫
+          (Limits.pullback.fst G.X.hom s :
+            ((Over.pullback s).mapGrp.obj G).X.left ⟶ G.X.left)) =
+        (((Limits.pullback.lift pLeft qLeft hpq ≫
+              Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
+            Limits.pullback.fst (MonoidalCategoryStruct.tensorObj G.X G.X).hom s) ≫
+          Over.Hom.left μ[G.X]) := by
+      simp only [Category.assoc, hmap]
     have hpair :
-        (Limits.pullback.lift (Over.Hom.left p) (Over.Hom.left q) hpq ≫
+        (Limits.pullback.lift pLeft qLeft hpq ≫
             Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
           Limits.pullback.fst _ s =
         Limits.pullback.lift
-          (Over.Hom.left p ≫ Limits.pullback.fst G.X.hom s)
-          (Over.Hom.left q ≫ Limits.pullback.fst G.X.hom s)
+          (pLeft ≫ Limits.pullback.fst G.X.hom s)
+          (qLeft ≫ Limits.pullback.fst G.X.hom s)
           (by
             simp only [Category.assoc, Limits.pullback.condition]
             simpa only [Category.assoc] using congrArg (fun z ↦ z ≫ s) hpq) := by
       apply Limits.pullback.hom_ext
       · rw [Category.assoc, Category.assoc,
-          Over.μ_pullback_left_fst_fst G.X G.X]
-        simp
+          Over.μ_pullback_left_fst_fst G.X G.X, hfst]
+        simp only [Limits.pullback.lift_fst_assoc, Limits.pullback.lift_fst]
       · rw [Category.assoc, Category.assoc,
-          Over.μ_pullback_left_fst_snd G.X G.X]
-        simp
-    exact congrArg (fun z ↦ z ≫ Over.Hom.left μ[G.X]) hpair
+          Over.μ_pullback_left_fst_snd G.X G.X, hsnd]
+        simp only [Limits.pullback.lift_snd_assoc, Limits.pullback.lift_snd]
+    exact (hmap_assoc.trans
+      (congrArg (fun z ↦ z ≫ Over.Hom.left μ[G.X]) hpair))
 
-set_option backward.isDefEq.respectTransparency false in
+/-- The point-group equivalence is the underlying pullback-adjunction equivalence. -/
+private theorem baseChangePointMulEquiv_apply
+    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k))
+    (G : Grp (Over (Spec (CommRingCat.of k))))
+    (T : Over (Spec (CommRingCat.of L)))
+    (p : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
+    baseChangePointMulEquiv s G T p =
+      ((Over.mapPullbackAdj s).homEquiv T G.X).symm p := (rfl)
+
 /-- The point-group identification intertwines a base-changed morphism with the original
 morphism. -/
 private theorem baseChangePointMulEquiv_pointMap
@@ -126,20 +157,9 @@ private theorem baseChangePointMulEquiv_pointMap
     baseChangePointMulEquiv s H T
         (pointMap ((Over.pullback s).mapGrp.map f) T p) =
       pointMap f ((Over.map s).obj T) (baseChangePointMulEquiv s G T p) := by
-  ext
-  have hleftG :
-      Over.Hom.left (baseChangePointMulEquiv s G T p) =
-        Over.Hom.left p ≫ Limits.pullback.fst G.X.hom s :=
-    rfl
-  have hleftH
-      (q : T ⟶ ((Over.pullback s).mapGrp.obj H).X) :
-      Over.Hom.left (baseChangePointMulEquiv s H T q) =
-        Over.Hom.left q ≫ Limits.pullback.fst H.X.hom s :=
-    rfl
-  rw [hleftH, pointMap_apply, Over.comp_left, Functor.mapGrp_map_hom_hom]
-  simp only [Category.assoc, Over.pullback_map_left, Limits.pullback.lift_fst]
-  rw [pointMap_apply, Over.comp_left, hleftG]
-  simp only [Category.assoc]
+  simp only [baseChangePointMulEquiv_apply, pointMap_apply,
+    Functor.mapGrp_map_hom_hom]
+  exact ((Over.mapPullbackAdj s).homEquiv_naturality_right_symm p f.hom.hom)
 
 /-- Base change along a morphism between spectra of fields preserves central isogenies. -/
 theorem IsCentralIsogeny.baseChange

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -27,6 +27,8 @@ group-scheme base change is the pullback functor on the over category, lifted to
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), §18.a.
+* Mathlib's `Over.mapPullbackAdj` and the cartesian-monoidal structure on `Over.pullback` provide
+  the point identification and its compatibility with multiplication.
 
 The base-change argument follows
 `TauCeti.AlgebraicGeometry.AbelianVariety.IsIsogeny.baseChange`.
@@ -59,6 +61,29 @@ theorem IsIsogeny.baseChange
     MorphismProperty.overPullbackMap _ _ hf.flat,
     MorphismProperty.overPullbackMap _ _ hf.surjective⟩
 
+/-- The underlying map of the inverse pullback-adjunction equivalence is postcomposition with the
+first pullback projection. -/
+private theorem mapPullbackAdj_homEquiv_symm_left
+    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k))
+    (G : Grp (Over (Spec (CommRingCat.of k))))
+    (T : Over (Spec (CommRingCat.of L)))
+    (p : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
+    Over.Hom.left (((Over.mapPullbackAdj s).homEquiv T G.X).symm p) =
+      Over.Hom.left p ≫ Limits.pullback.fst G.X.hom s := by
+  -- `mapPullbackAdj` has no projection lemma for its hom-equivalence; this is exactly the
+  -- computation rule in its public definition.
+  rfl
+
+/-- The multiplication of a group object transported by `Over.pullback` is the lax-monoidal
+comparison map followed by the pullback of the original multiplication. -/
+private theorem pullbackMapGrp_mul
+    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k))
+    (G : Grp (Over (Spec (CommRingCat.of k)))) :
+    μ[((Over.pullback s).mapGrp.obj G).X] =
+      Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X ≫
+        (Over.pullback s).map μ[G.X] :=
+  Functor.obj.μ_def (F := Over.pullback s) G.X
+
 /-- The adjunction between postcomposition and pullback identifies points of a base-changed group
 scheme with points of the original group scheme over the same test scheme viewed over the old
 base. This identification is multiplicative. -/
@@ -79,28 +104,12 @@ private noncomputable def baseChangePointMulEquiv
         pLeft ≫ Limits.pullback.snd G.X.hom s =
           qLeft ≫ Limits.pullback.snd G.X.hom s :=
       p.w.trans q.w.symm
-    have hleft (r : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
-        Over.Hom.left (((Over.mapPullbackAdj s).homEquiv T G.X).symm r) =
-          Over.Hom.left r ≫ Limits.pullback.fst G.X.hom s :=
-      rfl
-    have hmulPoint :
-        Over.Hom.left (p * q) =
-          (Limits.pullback.lift pLeft qLeft hpq ≫
-              Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
-            Over.Hom.left ((Over.pullback s).map μ[G.X]) := (rfl)
     ext
-    rw [hleft (p * q), hmulPoint]
-    simp only [Hom.mul_def, Over.comp_left, Over.lift_left, hleft]
-    have hfst :
-        Limits.pullback.fst ((Over.pullback s).obj G.X).hom
-            ((Over.pullback s).obj G.X).hom =
-          Limits.pullback.fst (Limits.pullback.snd G.X.hom s)
-            (Limits.pullback.snd G.X.hom s) := (rfl)
-    have hsnd :
-        Limits.pullback.snd ((Over.pullback s).obj G.X).hom
-            ((Over.pullback s).obj G.X).hom =
-          Limits.pullback.snd (Limits.pullback.snd G.X.hom s)
-            (Limits.pullback.snd G.X.hom s) := (rfl)
+    rw [mapPullbackAdj_homEquiv_symm_left]
+    simp only [Hom.mul_def, Over.comp_left, Over.lift_left,
+      mapPullbackAdj_homEquiv_symm_left]
+    change T ⟶ (Over.pullback s).obj G.X at p q
+    rw [congrArg Over.Hom.left (pullbackMapGrp_mul s G), Over.comp_left]
     have hmap :
         Over.Hom.left ((Over.pullback s).map μ[G.X]) ≫
             (Limits.pullback.fst G.X.hom s :
@@ -131,11 +140,13 @@ private noncomputable def baseChangePointMulEquiv
             simpa only [Category.assoc] using congrArg (fun z ↦ z ≫ s) hpq) := by
       apply Limits.pullback.hom_ext
       · rw [Category.assoc, Category.assoc,
-          Over.μ_pullback_left_fst_fst G.X G.X, hfst]
-        simp only [Limits.pullback.lift_fst_assoc, Limits.pullback.lift_fst]
+          Over.μ_pullback_left_fst_fst G.X G.X]
+        simp only [Over.pullback_obj_hom, Limits.pullback.lift_fst_assoc,
+          Limits.pullback.lift_fst]
       · rw [Category.assoc, Category.assoc,
-          Over.μ_pullback_left_fst_snd G.X G.X, hsnd]
-        simp only [Limits.pullback.lift_snd_assoc, Limits.pullback.lift_snd]
+          Over.μ_pullback_left_fst_snd G.X G.X]
+        simp only [Over.pullback_obj_hom, Limits.pullback.lift_snd_assoc,
+          Limits.pullback.lift_snd]
     exact (hmap_assoc.trans
       (congrArg (fun z ↦ z ≫ Over.Hom.left μ[G.X]) hpair))
 

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -83,6 +83,57 @@ private theorem mapPullbackAdj_homEquiv_symm_left
   -- computation rule in its public definition.
   rfl
 
+/-- After the pullback functor's lax-monoidal map and the pulled-back multiplication, the first
+projection agrees with multiplication after projecting the pair. -/
+private theorem pullback_laxMonoidal_map_mul_fst
+    (s : Y ⟶ X) (G : Grp (Over X)) (T : Over Y)
+    (pLeft qLeft : ((Over.map s).obj T).left ⟶ Limits.pullback G.X.hom s)
+    (hpq : pLeft ≫ Limits.pullback.snd G.X.hom s =
+      qLeft ≫ Limits.pullback.snd G.X.hom s) :
+    (((Limits.pullback.lift pLeft qLeft hpq ≫
+          Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
+        Over.Hom.left ((Over.pullback s).map μ[G.X])) ≫
+      (Limits.pullback.fst G.X.hom s :
+        ((Over.pullback s).mapGrp.obj G).X.left ⟶ G.X.left)) =
+    (((Limits.pullback.lift pLeft qLeft hpq ≫
+          Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
+        Limits.pullback.fst (MonoidalCategoryStruct.tensorObj G.X G.X).hom s) ≫
+      Over.Hom.left μ[G.X]) := by
+  have hmap :
+      Over.Hom.left ((Over.pullback s).map μ[G.X]) ≫
+          (Limits.pullback.fst G.X.hom s :
+            ((Over.pullback s).mapGrp.obj G).X.left ⟶ G.X.left) =
+        Limits.pullback.fst (MonoidalCategoryStruct.tensorObj G.X G.X).hom s ≫
+          Over.Hom.left μ[G.X] := by
+    simp only [Over.pullback_map_left, Limits.pullback.lift_fst]
+  simp only [Category.assoc, hmap]
+
+/-- Pairing two points, applying the pullback functor's lax-monoidal map, and then projecting to
+the original tensor product pairs the two projected points. -/
+private theorem pullback_laxMonoidal_pair_fst
+    (s : Y ⟶ X) (G : Grp (Over X)) (T : Over Y)
+    (pLeft qLeft : ((Over.map s).obj T).left ⟶ Limits.pullback G.X.hom s)
+    (hpq : pLeft ≫ Limits.pullback.snd G.X.hom s =
+      qLeft ≫ Limits.pullback.snd G.X.hom s) :
+    (Limits.pullback.lift pLeft qLeft hpq ≫
+        Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
+      Limits.pullback.fst _ s =
+    Limits.pullback.lift
+      (pLeft ≫ Limits.pullback.fst G.X.hom s)
+      (qLeft ≫ Limits.pullback.fst G.X.hom s)
+      (by
+        simp only [Category.assoc, Limits.pullback.condition]
+        simpa only [Category.assoc] using congrArg (fun z ↦ z ≫ s) hpq) := by
+  apply Limits.pullback.hom_ext
+  · rw [Category.assoc, Category.assoc,
+      Over.μ_pullback_left_fst_fst G.X G.X]
+    simp only [Over.pullback_obj_hom, Limits.pullback.lift_fst_assoc,
+      Limits.pullback.lift_fst]
+  · rw [Category.assoc, Category.assoc,
+      Over.μ_pullback_left_fst_snd G.X G.X]
+    simp only [Over.pullback_obj_hom, Limits.pullback.lift_snd_assoc,
+      Limits.pullback.lift_snd]
+
 /-- The adjunction between postcomposition and pullback identifies points of a base-changed group
 scheme with points of the original group scheme over the same test scheme viewed over the old
 base. This identification is multiplicative. -/
@@ -107,47 +158,12 @@ noncomputable def baseChangePointMulEquiv
       mapPullbackAdj_homEquiv_symm_left]
     rw [Functor.mapGrp_obj_X] at p q
     erw [congrArg Over.Hom.left (Functor.obj.μ_def (F := Over.pullback s) G.X), Over.comp_left]
-    have hmap :
-        Over.Hom.left ((Over.pullback s).map μ[G.X]) ≫
-            (Limits.pullback.fst G.X.hom s :
-              ((Over.pullback s).mapGrp.obj G).X.left ⟶ G.X.left) =
-          Limits.pullback.fst (MonoidalCategoryStruct.tensorObj G.X G.X).hom s ≫
-            Over.Hom.left μ[G.X] := by
-      simp only [Over.pullback_map_left, Limits.pullback.lift_fst]
-    have hmap_assoc :
-        (((Limits.pullback.lift pLeft qLeft hpq ≫
-              Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
-            Over.Hom.left ((Over.pullback s).map μ[G.X])) ≫
-          (Limits.pullback.fst G.X.hom s :
-            ((Over.pullback s).mapGrp.obj G).X.left ⟶ G.X.left)) =
-        (((Limits.pullback.lift pLeft qLeft hpq ≫
-              Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
-            Limits.pullback.fst (MonoidalCategoryStruct.tensorObj G.X G.X).hom s) ≫
-          Over.Hom.left μ[G.X]) := by
-      simp only [Category.assoc, hmap]
-    have hpair :
-        (Limits.pullback.lift pLeft qLeft hpq ≫
-            Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
-          Limits.pullback.fst _ s =
-        Limits.pullback.lift
-          (pLeft ≫ Limits.pullback.fst G.X.hom s)
-          (qLeft ≫ Limits.pullback.fst G.X.hom s)
-          (by
-            simp only [Category.assoc, Limits.pullback.condition]
-            simpa only [Category.assoc] using congrArg (fun z ↦ z ≫ s) hpq) := by
-      apply Limits.pullback.hom_ext
-      · rw [Category.assoc, Category.assoc,
-          Over.μ_pullback_left_fst_fst G.X G.X]
-        simp only [Over.pullback_obj_hom, Limits.pullback.lift_fst_assoc,
-          Limits.pullback.lift_fst]
-      · rw [Category.assoc, Category.assoc,
-          Over.μ_pullback_left_fst_snd G.X G.X]
-        simp only [Over.pullback_obj_hom, Limits.pullback.lift_snd_assoc,
-          Limits.pullback.lift_snd]
-    exact (hmap_assoc.trans
-      (congrArg (fun z ↦ z ≫ Over.Hom.left μ[G.X]) hpair))
+    exact (pullback_laxMonoidal_map_mul_fst s G T pLeft qLeft hpq).trans
+      (congrArg (fun z ↦ z ≫ Over.Hom.left μ[G.X])
+        (pullback_laxMonoidal_pair_fst s G T pLeft qLeft hpq))
 
 /-- The point-group equivalence is the underlying pullback-adjunction equivalence. -/
+@[simp]
 theorem baseChangePointMulEquiv_apply
     (s : Y ⟶ X) (G : Grp (Over X)) (T : Over Y)
     (p : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
@@ -155,6 +171,7 @@ theorem baseChangePointMulEquiv_apply
       ((Over.mapPullbackAdj s).homEquiv T G.X).symm p := (rfl)
 
 /-- The inverse point-group equivalence is the forward pullback-adjunction equivalence. -/
+@[simp]
 theorem baseChangePointMulEquiv_symm_apply
     (s : Y ⟶ X) (G : Grp (Over X)) (T : Over Y)
     (p : (Over.map s).obj T ⟶ G.X) :

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -11,13 +11,16 @@ public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Basic
 # Base change of group-scheme isogenies
 
 This file proves that isogenies of group schemes over a field remain isogenies after base change
-along a morphism between spectra of fields. For a commutative source, the base-changed isogeny is
-central. The group-scheme base change is the pullback functor on the over category, lifted to group
-objects.
+along a morphism between spectra of fields. The point groups before and after base change are
+identified through the pullback adjunction, which shows that central kernels remain central. For a
+commutative source, the base-changed isogeny is central without any centrality hypothesis. The
+group-scheme base change is the pullback functor on the over category, lifted to group objects.
 
 ## Main declarations
 
 * `TauCeti.GroupScheme.IsIsogeny.baseChange`: isogenies remain isogenies after base change.
+* `TauCeti.GroupScheme.IsCentralIsogeny.baseChange`: central isogenies remain central after base
+  change.
 * `TauCeti.GroupScheme.IsIsogeny.baseChange_isCentral_of_isCommMonObj`: the base change of an
   isogeny from a commutative source is a central isogeny.
 
@@ -35,6 +38,7 @@ ReductiveGroups roadmap.
 public section
 
 open CategoryTheory
+open scoped CategoryTheory.MonObj
 namespace TauCeti.GroupScheme
 
 open AlgebraicGeometry
@@ -54,6 +58,111 @@ theorem IsIsogeny.baseChange
   exact ⟨MorphismProperty.overPullbackMap _ _ hf.isFinite,
     MorphismProperty.overPullbackMap _ _ hf.flat,
     MorphismProperty.overPullbackMap _ _ hf.surjective⟩
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The adjunction between postcomposition and pullback identifies points of a base-changed group
+scheme with points of the original group scheme over the same test scheme viewed over the old
+base. This identification is multiplicative. -/
+private noncomputable def baseChangePointMulEquiv
+    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k))
+    (G : Grp (Over (Spec (CommRingCat.of k))))
+    (T : Over (Spec (CommRingCat.of L))) :
+    (T ⟶ ((Over.pullback s).mapGrp.obj G).X) ≃*
+      ((Over.map s).obj T ⟶ G.X) where
+  toFun p := ((Over.mapPullbackAdj s).homEquiv T G.X).symm p
+  invFun p := (Over.mapPullbackAdj s).homEquiv T G.X p
+  left_inv := (Over.mapPullbackAdj s).homEquiv T G.X |>.right_inv
+  right_inv := (Over.mapPullbackAdj s).homEquiv T G.X |>.left_inv
+  map_mul' p q := by
+    ext
+    have hleft (r : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
+        Over.Hom.left (((Over.mapPullbackAdj s).homEquiv T G.X).symm r) =
+          Over.Hom.left r ≫ Limits.pullback.fst G.X.hom s :=
+      rfl
+    rw [hleft (p * q)]
+    simp only [Hom.mul_def]
+    simp only [Over.comp_left, Over.lift_left]
+    simp only [hleft]
+    change T ⟶ (Over.pullback s).obj G.X at p q
+    have hmul :
+        Over.Hom.left μ[((Over.pullback s).mapGrp.obj G).X] =
+          Over.Hom.left
+            (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X ≫
+              (Over.pullback s).map μ[G.X]) :=
+      rfl
+    rw [hmul]
+    simp only [Over.comp_left]
+    simp only [Category.assoc, Over.pullback_map_left, Limits.pullback.lift_fst]
+    have hpq :
+        Over.Hom.left p ≫ Limits.pullback.snd G.X.hom s =
+          Over.Hom.left q ≫ Limits.pullback.snd G.X.hom s :=
+      p.w.trans q.w.symm
+    have hpair :
+        (Limits.pullback.lift (Over.Hom.left p) (Over.Hom.left q) hpq ≫
+            Over.Hom.left (Functor.LaxMonoidal.μ (Over.pullback s) G.X G.X)) ≫
+          Limits.pullback.fst _ s =
+        Limits.pullback.lift
+          (Over.Hom.left p ≫ Limits.pullback.fst G.X.hom s)
+          (Over.Hom.left q ≫ Limits.pullback.fst G.X.hom s)
+          (by
+            simp only [Category.assoc, Limits.pullback.condition]
+            simpa only [Category.assoc] using congrArg (fun z ↦ z ≫ s) hpq) := by
+      apply Limits.pullback.hom_ext
+      · rw [Category.assoc, Category.assoc,
+          Over.μ_pullback_left_fst_fst G.X G.X]
+        simp
+      · rw [Category.assoc, Category.assoc,
+          Over.μ_pullback_left_fst_snd G.X G.X]
+        simp
+    exact congrArg (fun z ↦ z ≫ Over.Hom.left μ[G.X]) hpair
+
+set_option backward.isDefEq.respectTransparency false in
+/-- The point-group identification intertwines a base-changed morphism with the original
+morphism. -/
+private theorem baseChangePointMulEquiv_pointMap
+    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k)) (f : G ⟶ H)
+    (T : Over (Spec (CommRingCat.of L)))
+    (p : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
+    baseChangePointMulEquiv s H T
+        (pointMap ((Over.pullback s).mapGrp.map f) T p) =
+      pointMap f ((Over.map s).obj T) (baseChangePointMulEquiv s G T p) := by
+  ext
+  have hleftG :
+      Over.Hom.left (baseChangePointMulEquiv s G T p) =
+        Over.Hom.left p ≫ Limits.pullback.fst G.X.hom s :=
+    rfl
+  have hleftH
+      (q : T ⟶ ((Over.pullback s).mapGrp.obj H).X) :
+      Over.Hom.left (baseChangePointMulEquiv s H T q) =
+        Over.Hom.left q ≫ Limits.pullback.fst H.X.hom s :=
+    rfl
+  rw [hleftH, pointMap_apply, Over.comp_left, Functor.mapGrp_map_hom_hom]
+  simp only [Category.assoc, Over.pullback_map_left, Limits.pullback.lift_fst]
+  rw [pointMap_apply, Over.comp_left, hleftG]
+  simp only [Category.assoc]
+
+/-- Base change along a morphism between spectra of fields preserves central isogenies. -/
+theorem IsCentralIsogeny.baseChange
+    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k)) {f : G ⟶ H}
+    (hf : IsCentralIsogeny f) :
+    IsCentralIsogeny ((Over.pullback s).mapGrp.map f) := by
+  rw [isCentralIsogeny_iff]
+  have hi := hf.isIsogeny.baseChange s
+  refine ⟨hi.isFinite, hi.flat, hi.surjective, ?_⟩
+  rw [hasCentralKernel_iff_pointMap_ker_le_center]
+  intro T p hp
+  rw [Subgroup.mem_center_iff]
+  intro q
+  let eG := baseChangePointMulEquiv s G T
+  have hp₀ : pointMap ((Over.pullback s).mapGrp.map f) T p = 1 :=
+    (MonoidHom.mem_ker).mp hp
+  have hp' : pointMap f ((Over.map s).obj T) (eG p) = 1 := by
+    rw [← baseChangePointMulEquiv_pointMap, hp₀, map_one]
+  have hf' := (hasCentralKernel_iff_pointMap_ker_le_center f).mp hf.hasCentralKernel
+  have hc := Subgroup.mem_center_iff.mp
+    (hf' ((Over.map s).obj T) ((MonoidHom.mem_ker).mpr hp')) (eG q)
+  apply eG.injective
+  simpa only [map_mul] using hc
 
 /-- The base change of an isogeny from a commutative group scheme is a central isogeny. -/
 theorem IsIsogeny.baseChange_isCentral_of_isCommMonObj

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/BaseChange.lean
@@ -10,14 +10,19 @@ public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Basic
 /-!
 # Base change of group-scheme isogenies
 
-This file proves that isogenies of group schemes over a field remain isogenies after base change
-along a morphism between spectra of fields. The point groups before and after base change are
-identified through the pullback adjunction, which shows that central kernels remain central. For a
-commutative source, the base-changed isogeny is central without any centrality hypothesis. The
-group-scheme base change is the pullback functor on the over category, lifted to group objects.
+This file proves that central kernels of group-scheme morphisms remain central after arbitrary
+base change, by identifying the point groups before and after base change through the pullback
+adjunction. Consequently, isogenies and central isogenies over a field remain so after base change
+along a morphism between spectra of fields. For a commutative source, the base-changed isogeny is
+central without any centrality hypothesis. The group-scheme base change is the pullback functor on
+the over category, lifted to group objects.
 
 ## Main declarations
 
+* `TauCeti.GroupScheme.baseChangePointMulEquiv`: the multiplicative point-group identification
+  furnished by the pullback adjunction.
+* `TauCeti.GroupScheme.HasCentralKernel.baseChange`: central kernels remain central after arbitrary
+  base change.
 * `TauCeti.GroupScheme.IsIsogeny.baseChange`: isogenies remain isogenies after base change.
 * `TauCeti.GroupScheme.IsCentralIsogeny.baseChange`: central isogenies remain central after base
   change.
@@ -61,12 +66,16 @@ theorem IsIsogeny.baseChange
     MorphismProperty.overPullbackMap _ _ hf.flat,
     MorphismProperty.overPullbackMap _ _ hf.surjective⟩
 
+end Field
+
+section BaseChange
+
+variable {X Y : Scheme.{u}} {G H : Grp (Over X)}
+
 /-- The underlying map of the inverse pullback-adjunction equivalence is postcomposition with the
 first pullback projection. -/
 private theorem mapPullbackAdj_homEquiv_symm_left
-    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k))
-    (G : Grp (Over (Spec (CommRingCat.of k))))
-    (T : Over (Spec (CommRingCat.of L)))
+    (s : Y ⟶ X) (G : Grp (Over X)) (T : Over Y)
     (p : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
     Over.Hom.left (((Over.mapPullbackAdj s).homEquiv T G.X).symm p) =
       Over.Hom.left p ≫ Limits.pullback.fst G.X.hom s := by
@@ -77,10 +86,8 @@ private theorem mapPullbackAdj_homEquiv_symm_left
 /-- The adjunction between postcomposition and pullback identifies points of a base-changed group
 scheme with points of the original group scheme over the same test scheme viewed over the old
 base. This identification is multiplicative. -/
-private noncomputable def baseChangePointMulEquiv
-    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k))
-    (G : Grp (Over (Spec (CommRingCat.of k))))
-    (T : Over (Spec (CommRingCat.of L))) :
+noncomputable def baseChangePointMulEquiv
+    (s : Y ⟶ X) (G : Grp (Over X)) (T : Over Y) :
     (T ⟶ ((Over.pullback s).mapGrp.obj G).X) ≃*
       ((Over.map s).obj T ⟶ G.X) where
   toFun p := ((Over.mapPullbackAdj s).homEquiv T G.X).symm p
@@ -141,19 +148,23 @@ private noncomputable def baseChangePointMulEquiv
       (congrArg (fun z ↦ z ≫ Over.Hom.left μ[G.X]) hpair))
 
 /-- The point-group equivalence is the underlying pullback-adjunction equivalence. -/
-private theorem baseChangePointMulEquiv_apply
-    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k))
-    (G : Grp (Over (Spec (CommRingCat.of k))))
-    (T : Over (Spec (CommRingCat.of L)))
+theorem baseChangePointMulEquiv_apply
+    (s : Y ⟶ X) (G : Grp (Over X)) (T : Over Y)
     (p : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
     baseChangePointMulEquiv s G T p =
       ((Over.mapPullbackAdj s).homEquiv T G.X).symm p := (rfl)
 
+/-- The inverse point-group equivalence is the forward pullback-adjunction equivalence. -/
+theorem baseChangePointMulEquiv_symm_apply
+    (s : Y ⟶ X) (G : Grp (Over X)) (T : Over Y)
+    (p : (Over.map s).obj T ⟶ G.X) :
+    (baseChangePointMulEquiv s G T).symm p =
+      (Over.mapPullbackAdj s).homEquiv T G.X p := (rfl)
+
 /-- The point-group identification intertwines a base-changed morphism with the original
 morphism. -/
-private theorem baseChangePointMulEquiv_pointMap
-    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k)) (f : G ⟶ H)
-    (T : Over (Spec (CommRingCat.of L)))
+theorem baseChangePointMulEquiv_pointMap
+    (s : Y ⟶ X) (f : G ⟶ H) (T : Over Y)
     (p : T ⟶ ((Over.pullback s).mapGrp.obj G).X) :
     baseChangePointMulEquiv s H T
         (pointMap ((Over.pullback s).mapGrp.map f) T p) =
@@ -162,14 +173,10 @@ private theorem baseChangePointMulEquiv_pointMap
     Functor.mapGrp_map_hom_hom]
   exact ((Over.mapPullbackAdj s).homEquiv_naturality_right_symm p f.hom.hom)
 
-/-- Base change along a morphism between spectra of fields preserves central isogenies. -/
-theorem IsCentralIsogeny.baseChange
-    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k)) {f : G ⟶ H}
-    (hf : IsCentralIsogeny f) :
-    IsCentralIsogeny ((Over.pullback s).mapGrp.map f) := by
-  rw [isCentralIsogeny_iff]
-  have hi := hf.isIsogeny.baseChange s
-  refine ⟨hi.isFinite, hi.flat, hi.surjective, ?_⟩
+/-- Arbitrary base change preserves central kernels of group-scheme morphisms. -/
+theorem HasCentralKernel.baseChange
+    (s : Y ⟶ X) {f : G ⟶ H} (hf : HasCentralKernel f) :
+    HasCentralKernel ((Over.pullback s).mapGrp.map f) := by
   rw [hasCentralKernel_iff_pointMap_ker_le_center]
   intro T p hp
   rw [Subgroup.mem_center_iff]
@@ -179,11 +186,27 @@ theorem IsCentralIsogeny.baseChange
     (MonoidHom.mem_ker).mp hp
   have hp' : pointMap f ((Over.map s).obj T) (eG p) = 1 := by
     rw [← baseChangePointMulEquiv_pointMap, hp₀, map_one]
-  have hf' := (hasCentralKernel_iff_pointMap_ker_le_center f).mp hf.hasCentralKernel
+  have hf' := (hasCentralKernel_iff_pointMap_ker_le_center f).mp hf
   have hc := Subgroup.mem_center_iff.mp
     (hf' ((Over.map s).obj T) ((MonoidHom.mem_ker).mpr hp')) (eG q)
   apply eG.injective
   simpa only [map_mul] using hc
+
+end BaseChange
+
+section Field
+
+variable {k L : Type u} [Field k] [Field L]
+variable {G H : Grp (Over (Spec (CommRingCat.of k)))}
+
+/-- Base change along a morphism between spectra of fields preserves central isogenies. -/
+theorem IsCentralIsogeny.baseChange
+    (s : Spec (CommRingCat.of L) ⟶ Spec (CommRingCat.of k)) {f : G ⟶ H}
+    (hf : IsCentralIsogeny f) :
+    IsCentralIsogeny ((Over.pullback s).mapGrp.map f) := by
+  rw [isCentralIsogeny_iff]
+  have hi := hf.isIsogeny.baseChange s
+  exact ⟨hi.isFinite, hi.flat, hi.surjective, hf.hasCentralKernel.baseChange s⟩
 
 /-- The base change of an isogeny from a commutative group scheme is a central isogeny. -/
 theorem IsIsogeny.baseChange_isCentral_of_isCommMonObj


### PR DESCRIPTION
This PR proves that a central isogeny of group schemes over a field remains a central isogeny after base change along a morphism between spectra of fields. It identifies the base-changed point group with the original point group on the mapped test scheme through `Over.mapPullbackAdj`, proves that identification multiplicative and natural in the group scheme, and transports the all-test-schemes central-kernel condition across it.

This advances the ReductiveGroups Layer 6 milestone target “Develop the radical, the centre, the derived group, central isogenies, and the simply connected and adjoint forms.” The theorem is needed because the roadmap defines geometric structure after extension to an algebraic closure, while the central-isogeny interface must remain available over that extension.

After this PR, Layer 6 still needs the structural relationships among the radical, centre, and derived group and the construction of simply connected and adjoint forms.

Mathlib infrastructure used directly: the `Over.mapPullbackAdj` pullback adjunction and the cartesian-monoidal structure on `Over.pullback`; no infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"central-isogeny-base-change"}-->

🤖 Prepared with Codex
