### PR TITLE
feat: prove tori are reductive

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Torus/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Torus/Reductive.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeType.Semisimple
+public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
+public import TauCeti.Algebra.AlgebraicGroup.Torus.SmoothConnected
+
+/-!
+# Tori are reductive
+
+A torus over a field is smooth and geometrically connected, and its geometric fibre is a
+diagonalizable group. Every closed subgroup of a diagonalizable group has only semisimple
+geometric points. If such a subgroup is also smooth and unipotent, smoothness makes its
+coordinate ring reduced, while semisimple--unipotent rigidity makes it trivial. Thus a torus
+has no nontrivial connected normal smooth unipotent closed subgroup and is reductive.
+
+The proof applies equally to non-split tori: all subgroup tests in the definition of reductivity
+are made after extension to an algebraic closure, where the torus is split.
+
+## Main declarations
+
+* `TauCeti.torusCommHopfAlgProperty.reductive`: every torus is reductive.
+* `TauCeti.splitTorusCommHopfAlgProperty.reductive`: every split torus is reductive.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Corollary 12.41 and §21.a.
+* T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
+
+This completes the torus worked example requested in Layers 4 and 6 of the ReductiveGroups
+roadmap. It uses geometric unipotence, rather than complete reducibility, so it is valid in every
+characteristic.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+namespace torusCommHopfAlgProperty
+
+variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
+
+/-- **Every torus over a field is reductive.**
+
+This uses the geometric-unipotent-radical characterization, and hence holds in arbitrary
+characteristic. -/
+@[grind →]
+theorem reductive (hH : torusCommHopfAlgProperty k H) :
+    reductiveCommHopfAlgProperty k H := by
+  rw [reductiveCommHopfAlgProperty_iff]
+  refine ⟨(smoothCommHopfAlgProperty_iff H.obj).mp (hH.smooth k H),
+    hH.geometricallyConnected k H, ?_⟩
+  intro I _ _ hI
+  have hI' := (smoothUnipotentCommHopfAlgProperty_iff (AlgebraicClosure k)
+    (FiniteTypeCommHopfAlgCat.quotient
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I)).mp hI
+  let _ : Algebra.Smooth (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) := hI'.1
+  let _ : IsReduced
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I) :=
+    isReduced_of_smooth_of_field (AlgebraicClosure k) _
+  apply (hH.multiplicativeType k H).eq_augmentation_of_geometricallyUnipotent k H I
+  exact (geometricallyUnipotentPointsCommHopfAlgProperty_iff (AlgebraicClosure k) _).mpr hI'.2
+
+end torusCommHopfAlgProperty
+
+namespace splitTorusCommHopfAlgProperty
+
+variable {k : Type u} [Field k] {H : FiniteTypeCommHopfAlgCat.{u, u} k}
+
+/-- **Every split torus over a field is reductive.** -/
+@[grind →]
+theorem reductive (hH : splitTorusCommHopfAlgProperty k H) :
+    reductiveCommHopfAlgProperty k H :=
+  (hH.torus k H).reductive
+
+end splitTorusCommHopfAlgProperty
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Torus.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Torus.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+import TauCeti.CategoryTheory.ObjectProperty
+public import TauCeti.Algebra.AlgebraicGroup.Torus.Reductive
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Reductive
+
+/-!
+# Torus affine group schemes
+
+This file transports the coordinate-Hopf-algebra definition of a torus to finite-type affine
+group schemes over a field. A group scheme is a torus when its coordinate Hopf algebra becomes a
+finite-rank split-torus coordinate ring after extension to an algebraic closure.
+
+The resulting full subcategory is anti-equivalent to torus coordinate Hopf algebras. Every object
+in it is reductive, synchronizing the theorem that tori are reductive between the coordinate and
+scheme models.
+
+## Main declarations
+
+* `TauCeti.torusAffineGroupSchemeProperty`: the torus property for finite-type affine group
+  schemes over a field.
+* `TauCeti.TorusAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.torusAffineGroupSchemeProperty.reductive`: every torus affine group scheme is
+  reductive.
+* `TauCeti.smooth_of_torusAffineGroupSchemeProperty` and
+  `TauCeti.geometricallyConnected_of_torusAffineGroupSchemeProperty`: structural properties of
+  torus affine group schemes.
+* `TauCeti.torusCommHopfAlgCatOpEquivTorusAffineGroupSchemeCat`: the restricted affine
+  Hopf/group-scheme anti-equivalence.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Definitions 12.14 and 12.17 and Corollary 12.41.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+This supplies the scheme-side torus model and its reductivity theorem for Layers 4 and 6 of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory AlgebraicGeometry Opposite
+
+universe u
+
+/-- The object property selecting torus affine group schemes of finite type over a field.
+
+The property is transported through the finite-type affine Hopf/group-scheme anti-equivalence,
+so it retains the coordinate definition by splitting over an algebraic closure. -/
+def torusAffineGroupSchemeProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :=
+  (torusCommHopfAlgProperty k).op.inverseImage
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse
+
+/-- A finite-type affine group scheme is a torus exactly when its coordinate Hopf algebra,
+supplied by the affine anti-equivalence, is a torus. -/
+@[simp]
+theorem torusAffineGroupSchemeProperty_iff
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
+    torusAffineGroupSchemeProperty k G ↔
+      torusCommHopfAlgProperty k
+        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop :=
+  Iff.rfl
+
+/-- Being a torus is invariant under isomorphisms of finite-type affine group schemes. -/
+instance (k : Type u) [Field k] :
+    (torusAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms := by
+  unfold torusAffineGroupSchemeProperty
+  infer_instance
+
+/-- The category of torus affine group schemes of finite type over a field. -/
+abbrev TorusAffineGroupSchemeCat (k : Type u) [Field k] :=
+  (torusAffineGroupSchemeProperty k).FullSubcategory
+
+namespace torusAffineGroupSchemeProperty
+
+/-- **Every torus affine group scheme over a field is reductive.** -/
+@[grind →]
+theorem reductive
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
+    (hG : torusAffineGroupSchemeProperty k G) :
+    reductiveAffineGroupSchemeProperty k G := by
+  rw [reductiveAffineGroupSchemeProperty_iff]
+  exact ((torusAffineGroupSchemeProperty_iff k G).mp hG).reductive
+
+end torusAffineGroupSchemeProperty
+
+/-- A finite-type affine group scheme satisfying the torus property has smooth structural
+morphism. -/
+theorem smooth_of_torusAffineGroupSchemeProperty
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
+    (hG : torusAffineGroupSchemeProperty k G) :
+    Smooth G.obj.obj.X.hom :=
+  smooth_of_reductiveAffineGroupSchemeProperty k G
+    (torusAffineGroupSchemeProperty.reductive k G hG)
+
+/-- Objects of `TorusAffineGroupSchemeCat k` have smooth structural morphism. -/
+instance (k : Type u) [Field k] (G : TorusAffineGroupSchemeCat k) :
+    Smooth G.obj.obj.obj.X.hom :=
+  smooth_of_torusAffineGroupSchemeProperty k G.obj G.property
+
+/-- A finite-type affine group scheme satisfying the torus property has geometrically connected
+structural morphism. -/
+theorem geometricallyConnected_of_torusAffineGroupSchemeProperty
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
+    (hG : torusAffineGroupSchemeProperty k G) :
+    GeometricallyConnected G.obj.obj.X.hom :=
+  geometricallyConnected_of_reductiveAffineGroupSchemeProperty k G
+    (torusAffineGroupSchemeProperty.reductive k G hG)
+
+/-- Objects of `TorusAffineGroupSchemeCat k` have geometrically connected structural morphism. -/
+instance (k : Type u) [Field k] (G : TorusAffineGroupSchemeCat k) :
+    GeometricallyConnected G.obj.obj.obj.X.hom :=
+  geometricallyConnected_of_torusAffineGroupSchemeProperty k G.obj G.property
+
+/-- Under the finite-type affine Hopf/group-scheme anti-equivalence, the inverse image of the
+torus property on group schemes is the torus property on coordinate Hopf algebras. -/
+theorem torusAffineGroupSchemeProperty_inverseImage
+    (k : Type u) [Field k] :
+    (torusAffineGroupSchemeProperty k).inverseImage
+        (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
+      (torusCommHopfAlgProperty k).op := by
+  unfold torusAffineGroupSchemeProperty
+  exact ObjectProperty.inverseImage_functor_inverseImage_inverse _ _
+
+/-- `Spec` restricts to an anti-equivalence from torus coordinate Hopf algebras to torus affine
+group schemes. -/
+noncomputable def torusCommHopfAlgCatOpEquivTorusAffineGroupSchemeCat
+    (k : Type u) [Field k] :
+    (TorusCommHopfAlgCat.{u} k)ᵒᵖ ≌ TorusAffineGroupSchemeCat k :=
+  (ObjectProperty.opEquivalence (torusCommHopfAlgProperty k)).symm.trans <|
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).congrFullSubcategory
+      (torusAffineGroupSchemeProperty_inverseImage k)
+
+/-- The forward torus anti-equivalence followed by the inclusions into finite-type affine group
+schemes is definitionally the finite-type anti-equivalence after forgetting the torus property. -/
+private noncomputable def torusCommHopfAlgCatOpEquivTorusAffineGroupSchemeCatFunctorCompιIso
+    (k : Type u) [Field k] :
+    (torusCommHopfAlgCatOpEquivTorusAffineGroupSchemeCat k).functor ⋙
+        (torusAffineGroupSchemeProperty k).ι ≅
+      (forget₂ (TorusCommHopfAlgCat.{u} k)
+          (FiniteTypeCommHopfAlgCat.{u, u} k)).op ⋙
+        (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor :=
+  Iso.refl _
+
+/-- The forward torus anti-equivalence, followed by the inclusions into finite-type affine group
+schemes and affine group schemes, is Mathlib's `hopfSpec` after forgetting the torus and
+finite-type proofs. This is the computation interface for the restricted equivalence. -/
+noncomputable def torusCommHopfAlgCatOpEquivTorusAffineGroupSchemeCat.functorCompιIso
+    (k : Type u) [Field k] :
+    (torusCommHopfAlgCatOpEquivTorusAffineGroupSchemeCat k).functor ⋙
+          (torusAffineGroupSchemeProperty k).ι ⋙
+          (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
+      (forget₂ (TorusCommHopfAlgCat.{u} k)
+          (FiniteTypeCommHopfAlgCat.{u, u} k)).op ⋙
+        (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
+  Functor.isoWhiskerRight
+      (torusCommHopfAlgCatOpEquivTorusAffineGroupSchemeCatFunctorCompιIso k)
+      ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of k)).ι) ≪≫
+    Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft
+      (forget₂ (TorusCommHopfAlgCat.{u} k)
+        (FiniteTypeCommHopfAlgCat.{u, u} k)).op
+      (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k)
+
+end TauCeti


### PR DESCRIPTION
This PR proves that every torus over a field is reductive and transports both the torus property and the theorem to finite-type affine group schemes. Apply the geometric definition honestly in arbitrary characteristic: smoothness makes every smooth unipotent closed subgroup reduced, while the already-established semisimple-point property for groups of multiplicative type forces that subgroup to be trivial.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4 milestone “Tori: split and non-split,” together with the worked-example requirement to prove tori reductive via triviality of the geometric unipotent radical, and Layer 6 milestone “Reductive and semisimple groups.” This is the most effective current step because the prerequisite chain—torus smoothness and geometric connectedness, semisimplicity of diagonalizable-group points, and semisimple–unipotent rigidity—is already on `main`, so this PR closes the advertised torus example instead of adding another satellite around the heavily occupied Layer 9 lane.

The coordinate theorem `torusCommHopfAlgProperty.reductive` proves the stronger subgroup statement needed by the definition: every smooth geometrically unipotent closed subgroup of the geometric fibre is trivial, without using normality or connectedness. The split-torus corollary follows through the existing split-to-geometric torus theorem. On the scheme side, `torusAffineGroupSchemeProperty`, `TorusAffineGroupSchemeCat`, and `torusCommHopfAlgCatOpEquivTorusAffineGroupSchemeCat` synchronize the coordinate and affine-group-scheme models, while the reductivity, smoothness, and geometric-connectedness interfaces make the result directly consumable.

After this PR, the Layer 4 torus milestone still needs the inverse Galois-descent construction and anti-equivalence for non-split tori; the broader Layer 6 milestone still needs the structural relationships among the radical, centre, and derived subgroup and the simply connected and adjoint forms.

No Mathlib source or external formalization is vendored. The proof reuses Tau Ceti’s multiplicative-type semisimple-point theorem and reduced semisimple–unipotent rigidity, together with the smooth-implies-reduced result over a field. The mathematics follows Milne, *Algebraic Groups* (2017), Corollary 12.41 and §21.a, and Springer, *Linear Algebraic Groups*, Chapter 8, as cited in the module documentation.

Add `TauCeti/Algebra/AlgebraicGroup/Torus/Reductive.lean` (90 lines) and `TauCeti/AlgebraicGeometry/AffineGroupScheme/Torus.lean` (180 lines), for 270 lines total.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tori-reductive"}-->

🤖 Prepared with Codex
