### PR TITLE
feat(HopfRinow): port chart Gram matrices

### DIFF
--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -16,9 +16,9 @@ public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 /-!
 # Chart Gram matrices of a Riemannian metric
 
-This file constructs the Gram matrix of the canonical Riemannian metric in the local frame
-induced by a tangent-bundle trivialization and proves that its entries and the entries of its
-inverse are smooth on the trivialization base set. The construction uses
+This file constructs the Gram matrix of the metric supplied by a `RiemannianBundle` instance in
+the local frame induced by a tangent-bundle trivialization and proves that its entries and the
+entries of its inverse are smooth on the trivialization base set. The construction uses
 `Bundle.Trivialization.localFrame` and `Bundle.Trivialization.basisAt`, so it applies unchanged
 when the model space has dimension zero.
 
@@ -26,8 +26,8 @@ The Gram-matrix and inverse-matrix declarations are adapted from stages 1--5 of 
 Poincare-Conjecture source file
 `DoCarmoLib/Riemannian/TensorBundle/MusicalIso.lean`, revision
 `24f32e4d600878bfaac6bc2f2f9324175571c321`. That source uses an explicit metric and a custom
-chart frame; here Mathlib's canonical `RiemannianBundle` metric and local-frame API replace them.
-As in the source, inverse-entry smoothness is proved through the determinant and adjugate formula.
+chart frame; here the metric supplied by Mathlib's `RiemannianBundle` instance and its local-frame
+API replace them.
 
 ## Main definitions and results
 
@@ -97,9 +97,9 @@ theorem contMDiffOn_chartLocalFrame {n : ℕ∞ω} [IsManifold I (n + 1) M]
 
 variable [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
 
-/-- The Gram matrix of `chartLocalFrame α` for the canonical Riemannian metric at `x`. Its
-entries are the coordinate metric coefficients used in do Carmo, *Riemannian Geometry*,
-Chapter 2. -/
+/-- The Gram matrix of `chartLocalFrame α` for the fiber inner product supplied by the
+`RiemannianBundle` instance at `x`. Its entries are the coordinate metric coefficients used in
+do Carmo, *Riemannian Geometry*, Chapter 2. -/
 def chartGramMatrix (α : M) (x : M) :
     Matrix (Fin (Module.finrank ℝ E)) (Fin (Module.finrank ℝ E)) ℝ :=
   Matrix.gram ℝ fun i ↦ chartLocalFrame (I := I) α i x
@@ -149,7 +149,7 @@ section Smooth
 variable {n : ℕ∞ω} [IsManifold I (n + 1) M]
   [IsContMDiffRiemannianBundle I n E (fun x : M ↦ TangentSpace I x)]
 
-/-- Every entry of the chart Gram matrix is smooth on the tangent-trivialization base set. -/
+/-- Every entry of the chart Gram matrix is `C^n` on the tangent-trivialization base set. -/
 theorem contMDiffOn_chartGramMatrix_entry
     (α : M) (i j : Fin (Module.finrank ℝ E)) :
     ContMDiffOn I 𝓘(ℝ) n (fun x ↦ chartGramMatrix (I := I) α x i j)
@@ -159,8 +159,8 @@ theorem contMDiffOn_chartGramMatrix_entry
     (contMDiffOn_chartLocalFrame (I := I) (n := n) α i)
     (contMDiffOn_chartLocalFrame (I := I) (n := n) α j)
 
-/-- Every adjugate entry of the chart Gram matrix is smooth on the tangent-trivialization base
-set. The proof realizes the entry as the determinant of a row-updated matrix. -/
+/-- Every adjugate entry of the chart Gram matrix is `C^n` on the tangent-trivialization base
+set. -/
 private lemma contMDiffOn_adjugate_chartGramMatrix_entry
     (α : M) (i j : Fin (Module.finrank ℝ E)) :
     ContMDiffOn I 𝓘(ℝ) n
@@ -220,8 +220,7 @@ section Smooth
 variable {n : ℕ∞ω} [IsManifold I (n + 1) M]
   [IsContMDiffRiemannianBundle I n E (fun x : M ↦ TangentSpace I x)]
 
-/-- Every entry of the inverse chart Gram matrix is smooth on the tangent-trivialization base
-set. Following the source, the proof uses the determinant/adjugate formula. -/
+/-- Every entry of the inverse chart Gram matrix is `C^n` on the tangent-trivialization base set. -/
 theorem contMDiffOn_chartInvGramMatrix_entry
     (α : M) (i j : Fin (Module.finrank ℝ E)) :
     ContMDiffOn I 𝓘(ℝ) n (fun x : M ↦ chartInvGramMatrix (I := I) α x i j)

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -78,8 +78,10 @@ theorem chartLocalFrame_apply_of_mem_baseSet (α : M) {x : M}
     chartLocalFrame (I := I) α i x =
       (trivializationAt E (TangentSpace I) α).basisAt (Module.finBasis ℝ E)
         (by simpa only [TangentBundle.trivializationAt_baseSet] using hx) i := by
-  apply (trivializationAt E (TangentSpace I) α).localFrame_apply_of_mem_baseSet
-  simpa only [TangentBundle.trivializationAt_baseSet] using hx
+  simpa only [chartLocalFrame, TangentBundle.trivializationAt_baseSet] using
+    (trivializationAt E (TangentSpace I) α).localFrame_apply_of_mem_baseSet
+      (Module.finBasis ℝ E) (i := i) (by
+        simpa only [TangentBundle.trivializationAt_baseSet] using hx)
 
 /-- Each member of `chartLocalFrame` is smooth on the tangent-trivialization base set. -/
 theorem chartLocalFrame_contMDiffOn (α : M) (i : Fin (Module.finrank ℝ E)) :

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -73,12 +73,13 @@ def chartLocalFrame (α : M) :
 
 @[simp]
 theorem chartLocalFrame_apply_of_mem_baseSet (α : M) {x : M}
-    (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet)
+    (hx : x ∈ (chartAt H α).source)
     (i : Fin (Module.finrank ℝ E)) :
     chartLocalFrame (I := I) α i x =
-      (trivializationAt E (TangentSpace I) α).basisAt (Module.finBasis ℝ E) hx i :=
-  (trivializationAt E (TangentSpace I) α).localFrame_apply_of_mem_baseSet
-    (Module.finBasis ℝ E) hx
+      (trivializationAt E (TangentSpace I) α).basisAt (Module.finBasis ℝ E)
+        (by simpa only [TangentBundle.trivializationAt_baseSet] using hx) i := by
+  apply (trivializationAt E (TangentSpace I) α).localFrame_apply_of_mem_baseSet
+  simpa only [TangentBundle.trivializationAt_baseSet] using hx
 
 /-- Each member of `chartLocalFrame` is smooth on the tangent-trivialization base set. -/
 theorem chartLocalFrame_contMDiffOn (α : M) (i : Fin (Module.finrank ℝ E)) :

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -104,28 +104,6 @@ def chartGramMatrix (α : M) (x : M) :
     Matrix (Fin (Module.finrank ℝ E)) (Fin (Module.finrank ℝ E)) ℝ :=
   Matrix.gram ℝ fun i ↦ chartLocalFrame (I := I) α i x
 
-/-- Each Gram-matrix entry is the inner product of the corresponding chart-frame vectors. -/
-@[simp]
-theorem chartGramMatrix_apply (α x : M) (i j : Fin (Module.finrank ℝ E)) :
-    chartGramMatrix (I := I) α x i j =
-      inner ℝ (chartLocalFrame (I := I) α i x) (chartLocalFrame (I := I) α j x) := by
-  rw [chartGramMatrix, Matrix.gram_apply]
-
-/-- The chart Gram matrix is Hermitian, equivalently symmetric over `ℝ`. -/
-theorem isHermitian_chartGramMatrix (α x : M) :
-    (chartGramMatrix (I := I) α x).IsHermitian :=
-  Matrix.isHermitian_gram ℝ _
-
-/-- The Gram-matrix quadratic form equals the squared norm, in the canonical Riemannian metric,
-of the corresponding linear combination of chart-frame vectors. -/
-theorem star_dotProduct_chartGramMatrix_mulVec
-    (α x : M) (c : Fin (Module.finrank ℝ E) → ℝ) :
-    star c ⬝ᵥ (chartGramMatrix (I := I) α x) *ᵥ c =
-      inner ℝ
-        (∑ i, c i • chartLocalFrame (I := I) α i x)
-        (∑ j, c j • chartLocalFrame (I := I) α j x) :=
-  Matrix.star_dotProduct_gram_mulVec (𝕜 := ℝ) _ c c
-
 /-- The Gram matrix of the chart-local frame is positive-definite on the tangent-trivialization
 base set. -/
 theorem posDef_chartGramMatrix (α : M) {x : M}

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -61,7 +61,7 @@ namespace Tensor
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
-  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
 
 /-- The chart-local frame obtained from the tangent-bundle trivialization centred at `α` and
 the chosen `Module.finBasis` basis of the model space. Outside the trivialization base set it has
@@ -84,13 +84,15 @@ theorem chartLocalFrame_apply_of_mem_chart_source (α : M) {x : M}
       (Module.finBasis ℝ E) (i := i) (by
         simpa only [TangentBundle.trivializationAt_baseSet] using hx)
 
-/-- Each member of `chartLocalFrame` is smooth on the tangent-trivialization base set. -/
-theorem contMDiffOn_chartLocalFrame {n : ℕ∞ω} [ENat.LEInfty n]
+/-- Each member of `chartLocalFrame` is `C^n` on the tangent-trivialization base set. -/
+theorem contMDiffOn_chartLocalFrame {n : ℕ∞ω} [IsManifold I (n + 1) M]
     (α : M) (i : Fin (Module.finrank ℝ E)) :
     ContMDiffOn I (I.prod 𝓘(ℝ, E)) n
       (fun x ↦ TotalSpace.mk' E x (chartLocalFrame (I := I) α i x))
-      (trivializationAt E (TangentSpace I) α).baseSet :=
-  (trivializationAt E (TangentSpace I) α).contMDiffOn_localFrame_baseSet
+      (trivializationAt E (TangentSpace I) α).baseSet := by
+  let _ : ContMDiffVectorBundle n E (TangentSpace I : M → Type _) I :=
+    TangentBundle.contMDiffVectorBundle
+  exact (trivializationAt E (TangentSpace I) α).contMDiffOn_localFrame_baseSet
     (n := n) (Module.finBasis ℝ E) i
 
 variable [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
@@ -98,7 +100,6 @@ variable [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
 /-- The Gram matrix of `chartLocalFrame α` for the canonical Riemannian metric at `x`. Its
 entries are the coordinate metric coefficients used in do Carmo, *Riemannian Geometry*,
 Chapter 2. -/
-@[expose]
 def chartGramMatrix (α : M) (x : M) :
     Matrix (Fin (Module.finrank ℝ E)) (Fin (Module.finrank ℝ E)) ℝ :=
   Matrix.gram ℝ fun i ↦ chartLocalFrame (I := I) α i x
@@ -107,8 +108,8 @@ def chartGramMatrix (α : M) (x : M) :
 @[simp]
 theorem chartGramMatrix_apply (α x : M) (i j : Fin (Module.finrank ℝ E)) :
     chartGramMatrix (I := I) α x i j =
-      inner ℝ (chartLocalFrame (I := I) α i x) (chartLocalFrame (I := I) α j x) :=
-  rfl
+      inner ℝ (chartLocalFrame (I := I) α i x) (chartLocalFrame (I := I) α j x) := by
+  rw [chartGramMatrix, Matrix.gram_apply]
 
 /-- The chart Gram matrix is Hermitian, equivalently symmetric over `ℝ`. -/
 theorem isHermitian_chartGramMatrix (α x : M) :
@@ -117,7 +118,7 @@ theorem isHermitian_chartGramMatrix (α x : M) :
 
 /-- The Gram-matrix quadratic form equals the squared norm, in the canonical Riemannian metric,
 of the corresponding linear combination of chart-frame vectors. -/
-theorem chartGramMatrix_dotProduct_mulVec
+theorem star_dotProduct_chartGramMatrix_mulVec
     (α x : M) (c : Fin (Module.finrank ℝ E) → ℝ) :
     star c ⬝ᵥ (chartGramMatrix (I := I) α x) *ᵥ c =
       inner ℝ
@@ -132,7 +133,7 @@ theorem posDef_chartGramMatrix (α : M) {x : M}
     (chartGramMatrix (I := I) α x).PosDef :=
   Matrix.posDef_gram_of_linearIndependent <|
     ((trivializationAt E (TangentSpace I) α).isLocalFrameOn_localFrame_baseSet
-      I ∞ (Module.finBasis ℝ E)).linearIndependent hx
+      I 0 (Module.finBasis ℝ E)).linearIndependent hx
 
 /-- The determinant of the chart Gram matrix is strictly positive on the tangent-trivialization
 base set. -/
@@ -167,7 +168,7 @@ private lemma contMDiffOn_matrix_det_of_entries
 
 section Smooth
 
-variable {n : ℕ∞ω} [ENat.LEInfty n]
+variable {n : ℕ∞ω} [IsManifold I (n + 1) M]
   [IsContMDiffRiemannianBundle I n E (fun x : M ↦ TangentSpace I x)]
 
 /-- Every entry of the chart Gram matrix is smooth on the tangent-trivialization base set. -/
@@ -212,29 +213,33 @@ def chartInvGramMatrix (α : M) (x : M) :
     Matrix (Fin (Module.finrank ℝ E)) (Fin (Module.finrank ℝ E)) ℝ :=
   (chartGramMatrix (I := I) α x)⁻¹
 
-/-- On the tangent-trivialization base set, the inverse Gram matrix is a left inverse. -/
+/-- On the chart source, the inverse Gram matrix is a left inverse. -/
 @[simp]
 theorem chartInvGramMatrix_mul_chartGramMatrix (α : M) {x : M}
-    (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
+    (hx : x ∈ (chartAt H α).source) :
     chartInvGramMatrix (I := I) α x * chartGramMatrix (I := I) α x = 1 := by
+  have hx' : x ∈ (trivializationAt E (TangentSpace I) α).baseSet := by
+    simpa only [TangentBundle.trivializationAt_baseSet] using hx
   have hdet_unit : IsUnit (chartGramMatrix (I := I) α x).det :=
-    isUnit_iff_ne_zero.mpr (ne_of_gt (chartGramMatrix_det_pos (I := I) α hx))
+    isUnit_iff_ne_zero.mpr (ne_of_gt (chartGramMatrix_det_pos (I := I) α hx'))
   unfold chartInvGramMatrix
   exact Matrix.nonsing_inv_mul _ hdet_unit
 
-/-- On the tangent-trivialization base set, the inverse Gram matrix is a right inverse. -/
+/-- On the chart source, the inverse Gram matrix is a right inverse. -/
 @[simp]
 theorem chartGramMatrix_mul_chartInvGramMatrix (α : M) {x : M}
-    (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
+    (hx : x ∈ (chartAt H α).source) :
     chartGramMatrix (I := I) α x * chartInvGramMatrix (I := I) α x = 1 := by
+  have hx' : x ∈ (trivializationAt E (TangentSpace I) α).baseSet := by
+    simpa only [TangentBundle.trivializationAt_baseSet] using hx
   have hdet_unit : IsUnit (chartGramMatrix (I := I) α x).det :=
-    isUnit_iff_ne_zero.mpr (ne_of_gt (chartGramMatrix_det_pos (I := I) α hx))
+    isUnit_iff_ne_zero.mpr (ne_of_gt (chartGramMatrix_det_pos (I := I) α hx'))
   unfold chartInvGramMatrix
   exact Matrix.mul_nonsing_inv _ hdet_unit
 
 section Smooth
 
-variable {n : ℕ∞ω} [ENat.LEInfty n]
+variable {n : ℕ∞ω} [IsManifold I (n + 1) M]
   [IsContMDiffRiemannianBundle I n E (fun x : M ↦ TangentSpace I x)]
 
 /-- Every entry of the inverse chart Gram matrix is smooth on the tangent-trivialization base

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -51,6 +51,7 @@ As in the source, inverse-entry smoothness is proved through the determinant and
 -/
 
 noncomputable section
+public section
 
 open Bundle FiberBundle Manifold Set
 open scoped ContDiff Manifold Matrix RealInnerProductSpace Topology
@@ -97,6 +98,7 @@ variable [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
 /-- The Gram matrix of `chartLocalFrame α` for the canonical Riemannian metric at `x`. Its
 entries are the coordinate metric coefficients used in do Carmo, *Riemannian Geometry*,
 Chapter 2. -/
+@[expose]
 def chartGramMatrix (α : M) (x : M) :
     Matrix (Fin (Module.finrank ℝ E)) (Fin (Module.finrank ℝ E)) ℝ :=
   Matrix.gram ℝ fun i ↦ chartLocalFrame (I := I) α i x
@@ -139,6 +141,30 @@ theorem chartGramMatrix_det_pos (α : M) {x : M}
     0 < (chartGramMatrix (I := I) α x).det :=
   (posDef_chartGramMatrix (I := I) α hx).det_pos
 
+/-- Smoothness of a matrix determinant follows from smoothness of all matrix entries. -/
+private lemma contMDiffOn_matrix_det_of_entries
+    {EB : Type*} [NormedAddCommGroup EB] [NormedSpace ℝ EB]
+    {HB : Type*} [TopologicalSpace HB] {IB : ModelWithCorners ℝ EB HB}
+    {X : Type*} [TopologicalSpace X] [ChartedSpace HB X]
+    {n : ℕ∞ω}
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {A : X → Matrix ι ι ℝ} {s : Set X}
+    (hA : ∀ i j, ContMDiffOn IB 𝓘(ℝ) n (fun x ↦ A x i j) s) :
+    ContMDiffOn IB 𝓘(ℝ) n (fun x ↦ (A x).det) s := by
+  classical
+  have hexp :
+      (fun x : X ↦ (A x).det) =
+        fun x : X ↦ ∑ σ : Equiv.Perm ι,
+          (Equiv.Perm.sign σ : ℝ) * ∏ i, A x (σ i) i := by
+    funext x
+    rw [Matrix.det_apply]
+    simp [Units.smul_def]
+  rw [hexp]
+  refine contMDiffOn_finsetSum fun σ _ ↦ ?_
+  refine ContMDiffOn.mul (contMDiffOn_const (c := ((Equiv.Perm.sign σ : ℤ) : ℝ))) ?_
+  refine contMDiffOn_finsetProd fun i _ ↦ ?_
+  exact hA (σ i) i
+
 section Smooth
 
 variable {n : ℕ∞ω} [ENat.LEInfty n]
@@ -153,32 +179,6 @@ theorem contMDiffOn_chartGramMatrix_entry
     (E := fun x : M ↦ TangentSpace I x)
     (contMDiffOn_chartLocalFrame (I := I) (n := n) α i)
     (contMDiffOn_chartLocalFrame (I := I) (n := n) α j)
-
-/-- Smoothness of a matrix determinant follows from smoothness of all matrix entries. -/
-private lemma contMDiffOn_matrix_det_of_entries
-    {ι : Type*} [Fintype ι] [DecidableEq ι]
-    {A : M → Matrix ι ι ℝ} {s : Set M}
-    (hA : ∀ i j, ContMDiffOn I 𝓘(ℝ) n (fun x ↦ A x i j) s) :
-    ContMDiffOn I 𝓘(ℝ) n (fun x ↦ (A x).det) s := by
-  classical
-  have hexp :
-      (fun x : M ↦ (A x).det) =
-        fun x : M ↦ ∑ σ : Equiv.Perm ι,
-          (Equiv.Perm.sign σ : ℝ) * ∏ i, A x (σ i) i := by
-    funext x
-    rw [Matrix.det_apply]
-    simp [Units.smul_def]
-  rw [hexp]
-  refine contMDiffOn_finsetSum fun σ _ ↦ ?_
-  refine ContMDiffOn.mul (contMDiffOn_const (c := ((Equiv.Perm.sign σ : ℤ) : ℝ))) ?_
-  refine contMDiffOn_finsetProd fun i _ ↦ ?_
-  exact hA (σ i) i
-
-/-- The determinant of the chart Gram matrix is smooth on the tangent-trivialization base set. -/
-private lemma contMDiffOn_det_chartGramMatrix (α : M) :
-    ContMDiffOn I 𝓘(ℝ) n (fun x ↦ (chartGramMatrix (I := I) α x).det)
-      (trivializationAt E (TangentSpace I) α).baseSet :=
-  contMDiffOn_matrix_det_of_entries (fun i j ↦ contMDiffOn_chartGramMatrix_entry (I := I) α i j)
 
 /-- Every adjugate entry of the chart Gram matrix is smooth on the tangent-trivialization base
 set. The proof realizes the entry as the determinant of a row-updated matrix. -/
@@ -201,7 +201,7 @@ private lemma contMDiffOn_adjugate_chartGramMatrix_entry
   · subst k
     simp only [Matrix.updateRow_self]
     exact contMDiffOn_const
-  · simp [Matrix.updateRow_apply, hkj]
+  · simp only [Matrix.updateRow_apply, hkj, ite_false]
     exact contMDiffOn_chartGramMatrix_entry (I := I) (n := n) α k l
 
 end Smooth
@@ -251,16 +251,12 @@ theorem contMDiffOn_chartInvGramMatrix_entry
     intro x _
     unfold chartInvGramMatrix
     rw [Matrix.inv_def]
-    simpa only [Matrix.smul_apply, smul_eq_mul, Ring.inverse_eq_inv]
-  refine ContMDiffOn.congr (ContMDiffOn.mul ?_ ?_) hcongr
-  · have hdet_smooth := contMDiffOn_det_chartGramMatrix (I := I) (n := n) α
-    intro x hx
-    have hdet_ne : (chartGramMatrix (I := I) α x).det ≠ 0 :=
-      ne_of_gt (chartGramMatrix_det_pos (I := I) α hx)
-    have hinv : ContDiffAt ℝ n (fun y : ℝ ↦ y⁻¹)
-        (chartGramMatrix (I := I) α x).det :=
-      contDiffAt_inv _ hdet_ne
-    exact hinv.contMDiffAt.comp_contMDiffWithinAt x (hdet_smooth x hx)
+    simp only [Matrix.smul_apply, smul_eq_mul, Ring.inverse_eq_inv]
+  have hdet_smooth := contMDiffOn_matrix_det_of_entries
+    (fun k l ↦ contMDiffOn_chartGramMatrix_entry (I := I) (n := n) α k l)
+  refine ContMDiffOn.congr (ContMDiffOn.mul (hdet_smooth.inv₀ ?_) ?_) hcongr
+  · intro x hx
+    exact ne_of_gt (chartGramMatrix_det_pos (I := I) α hx)
   · exact contMDiffOn_adjugate_chartGramMatrix_entry (I := I) α i j
 
 end Smooth

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -34,11 +34,11 @@ As in the source, inverse-entry smoothness is proved through the determinant and
 * `Riemannian.Tensor.chartLocalFrame`: the frame induced by the tangent trivialization at a chart
   centre and `Module.finBasis`.
 * `Riemannian.Tensor.chartGramMatrix`: the metric Gram matrix in this frame.
-* `Riemannian.Tensor.chartGramMatrix_posDef`: positive-definiteness on the base set.
+* `Riemannian.Tensor.posDef_chartGramMatrix`: positive-definiteness on the base set.
 * `Riemannian.Tensor.chartGramMatrix_det_pos`: strict positivity of its determinant there.
-* `Riemannian.Tensor.chartGramMatrix_entry_contMDiffOn`: smoothness of Gram-matrix entries.
+* `Riemannian.Tensor.contMDiffOn_chartGramMatrix_entry`: smoothness of Gram-matrix entries.
 * `Riemannian.Tensor.chartInvGramMatrix`: the inverse Gram matrix.
-* `Riemannian.Tensor.chartInvGramMatrix_entry_contMDiffOn`: smoothness of inverse entries.
+* `Riemannian.Tensor.contMDiffOn_chartInvGramMatrix_entry`: smoothness of inverse entries.
 
 ## References
 
@@ -49,8 +49,6 @@ As in the source, inverse-entry smoothness is proved through the determinant and
   revision `24f32e4d600878bfaac6bc2f2f9324175571c321` (Apache-2.0).
 
 -/
-
-@[expose] public section
 
 noncomputable section
 
@@ -71,8 +69,10 @@ def chartLocalFrame (α : M) :
     Fin (Module.finrank ℝ E) → (x : M) → TangentSpace I x :=
   (trivializationAt E (TangentSpace I) α).localFrame (Module.finBasis ℝ E)
 
+/-- On the chart source, the local frame agrees with the basis supplied by the tangent
+trivialization. The source membership is the simplified form of the trivialization base set. -/
 @[simp]
-theorem chartLocalFrame_apply_of_mem_baseSet (α : M) {x : M}
+theorem chartLocalFrame_apply_of_mem_chart_source (α : M) {x : M}
     (hx : x ∈ (chartAt H α).source)
     (i : Fin (Module.finrank ℝ E)) :
     chartLocalFrame (I := I) α i x =
@@ -84,12 +84,13 @@ theorem chartLocalFrame_apply_of_mem_baseSet (α : M) {x : M}
         simpa only [TangentBundle.trivializationAt_baseSet] using hx)
 
 /-- Each member of `chartLocalFrame` is smooth on the tangent-trivialization base set. -/
-theorem chartLocalFrame_contMDiffOn (α : M) (i : Fin (Module.finrank ℝ E)) :
-    ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+theorem contMDiffOn_chartLocalFrame {n : ℕ∞ω} [ENat.LEInfty n]
+    (α : M) (i : Fin (Module.finrank ℝ E)) :
+    ContMDiffOn I (I.prod 𝓘(ℝ, E)) n
       (fun x ↦ TotalSpace.mk' E x (chartLocalFrame (I := I) α i x))
       (trivializationAt E (TangentSpace I) α).baseSet :=
   (trivializationAt E (TangentSpace I) α).contMDiffOn_localFrame_baseSet
-    (n := ∞) (Module.finBasis ℝ E) i
+    (n := n) (Module.finBasis ℝ E) i
 
 variable [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
 
@@ -100,6 +101,7 @@ def chartGramMatrix (α : M) (x : M) :
     Matrix (Fin (Module.finrank ℝ E)) (Fin (Module.finrank ℝ E)) ℝ :=
   Matrix.gram ℝ fun i ↦ chartLocalFrame (I := I) α i x
 
+/-- Each Gram-matrix entry is the inner product of the corresponding chart-frame vectors. -/
 @[simp]
 theorem chartGramMatrix_apply (α x : M) (i j : Fin (Module.finrank ℝ E)) :
     chartGramMatrix (I := I) α x i j =
@@ -107,7 +109,7 @@ theorem chartGramMatrix_apply (α x : M) (i j : Fin (Module.finrank ℝ E)) :
   rfl
 
 /-- The chart Gram matrix is Hermitian, equivalently symmetric over `ℝ`. -/
-theorem chartGramMatrix_isHermitian (α x : M) :
+theorem isHermitian_chartGramMatrix (α x : M) :
     (chartGramMatrix (I := I) α x).IsHermitian :=
   Matrix.isHermitian_gram ℝ _
 
@@ -123,7 +125,7 @@ theorem chartGramMatrix_dotProduct_mulVec
 
 /-- The Gram matrix of the chart-local frame is positive-definite on the tangent-trivialization
 base set. -/
-theorem chartGramMatrix_posDef (α : M) {x : M}
+theorem posDef_chartGramMatrix (α : M) {x : M}
     (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
     (chartGramMatrix (I := I) α x).PosDef :=
   Matrix.posDef_gram_of_linearIndependent <|
@@ -135,37 +137,34 @@ base set. -/
 theorem chartGramMatrix_det_pos (α : M) {x : M}
     (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
     0 < (chartGramMatrix (I := I) α x).det :=
-  (chartGramMatrix_posDef (I := I) α hx).det_pos
+  (posDef_chartGramMatrix (I := I) α hx).det_pos
 
 section Smooth
 
-variable [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)]
-
-omit [FiniteDimensional ℝ E] in
-private lemma contMDiffOn_inner_tangent
-    {s : Set M} {X Y : ∀ x : M, TangentSpace I x}
-    (hX : CMDiff[s] ∞ (T% X)) (hY : CMDiff[s] ∞ (T% Y)) :
-    ContMDiffOn I 𝓘(ℝ) ∞ (fun x ↦ inner ℝ (X x) (Y x)) s :=
-  ContMDiffOn.inner_bundle hX hY
+variable {n : ℕ∞ω} [ENat.LEInfty n]
+  [IsContMDiffRiemannianBundle I n E (fun x : M ↦ TangentSpace I x)]
 
 /-- Every entry of the chart Gram matrix is smooth on the tangent-trivialization base set. -/
-theorem chartGramMatrix_entry_contMDiffOn
+theorem contMDiffOn_chartGramMatrix_entry
     (α : M) (i j : Fin (Module.finrank ℝ E)) :
-    ContMDiffOn I 𝓘(ℝ) ∞ (fun x ↦ chartGramMatrix (I := I) α x i j)
+    ContMDiffOn I 𝓘(ℝ) n (fun x ↦ chartGramMatrix (I := I) α x i j)
       (trivializationAt E (TangentSpace I) α).baseSet := by
-  exact contMDiffOn_inner_tangent (chartLocalFrame_contMDiffOn (I := I) α i)
-    (chartLocalFrame_contMDiffOn (I := I) α j)
+  exact ContMDiffOn.inner_bundle (IB := I) (n := n) (F := E)
+    (E := fun x : M ↦ TangentSpace I x)
+    (contMDiffOn_chartLocalFrame (I := I) (n := n) α i)
+    (contMDiffOn_chartLocalFrame (I := I) (n := n) α j)
 
-/-- The determinant of the chart Gram matrix is smooth on the tangent-trivialization base set.
-The proof expands the determinant as a finite sum of finite products of entries. -/
-theorem chartGramMatrix_det_contMDiffOn (α : M) :
-    ContMDiffOn I 𝓘(ℝ) ∞ (fun x ↦ (chartGramMatrix (I := I) α x).det)
-      (trivializationAt E (TangentSpace I) α).baseSet := by
+/-- Smoothness of a matrix determinant follows from smoothness of all matrix entries. -/
+private lemma contMDiffOn_matrix_det_of_entries
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {A : M → Matrix ι ι ℝ} {s : Set M}
+    (hA : ∀ i j, ContMDiffOn I 𝓘(ℝ) n (fun x ↦ A x i j) s) :
+    ContMDiffOn I 𝓘(ℝ) n (fun x ↦ (A x).det) s := by
   classical
   have hexp :
-      (fun x : M ↦ (chartGramMatrix (I := I) α x).det) =
-        fun x : M ↦ ∑ σ : Equiv.Perm (Fin (Module.finrank ℝ E)),
-          (Equiv.Perm.sign σ : ℝ) * ∏ i, chartGramMatrix (I := I) α x (σ i) i := by
+      (fun x : M ↦ (A x).det) =
+        fun x : M ↦ ∑ σ : Equiv.Perm ι,
+          (Equiv.Perm.sign σ : ℝ) * ∏ i, A x (σ i) i := by
     funext x
     rw [Matrix.det_apply]
     simp [Units.smul_def]
@@ -173,13 +172,19 @@ theorem chartGramMatrix_det_contMDiffOn (α : M) :
   refine contMDiffOn_finsetSum fun σ _ ↦ ?_
   refine ContMDiffOn.mul (contMDiffOn_const (c := ((Equiv.Perm.sign σ : ℤ) : ℝ))) ?_
   refine contMDiffOn_finsetProd fun i _ ↦ ?_
-  exact chartGramMatrix_entry_contMDiffOn (I := I) α (σ i) i
+  exact hA (σ i) i
+
+/-- The determinant of the chart Gram matrix is smooth on the tangent-trivialization base set. -/
+private lemma contMDiffOn_det_chartGramMatrix (α : M) :
+    ContMDiffOn I 𝓘(ℝ) n (fun x ↦ (chartGramMatrix (I := I) α x).det)
+      (trivializationAt E (TangentSpace I) α).baseSet :=
+  contMDiffOn_matrix_det_of_entries (fun i j ↦ contMDiffOn_chartGramMatrix_entry (I := I) α i j)
 
 /-- Every adjugate entry of the chart Gram matrix is smooth on the tangent-trivialization base
 set. The proof realizes the entry as the determinant of a row-updated matrix. -/
-theorem chartGramMatrix_adjugate_entry_contMDiffOn
+private lemma contMDiffOn_adjugate_chartGramMatrix_entry
     (α : M) (i j : Fin (Module.finrank ℝ E)) :
-    ContMDiffOn I 𝓘(ℝ) ∞
+    ContMDiffOn I 𝓘(ℝ) n
       (fun x : M ↦ (chartGramMatrix (I := I) α x).adjugate i j)
       (trivializationAt E (TangentSpace I) α).baseSet := by
   classical
@@ -190,38 +195,14 @@ theorem chartGramMatrix_adjugate_entry_contMDiffOn
     funext x
     exact Matrix.adjugate_apply _ _ _
   rw [hexp]
-  have hexp' :
-      (fun x : M ↦ ((chartGramMatrix (I := I) α x).updateRow j
-          (Pi.single i (1 : ℝ))).det) =
-        fun x : M ↦ ∑ σ : Equiv.Perm (Fin (Module.finrank ℝ E)),
-          (Equiv.Perm.sign σ : ℝ) *
-            ∏ k, (chartGramMatrix (I := I) α x).updateRow j
-              (Pi.single i (1 : ℝ)) (σ k) k := by
-    funext x
-    rw [Matrix.det_apply]
-    simp [Units.smul_def]
-  rw [hexp']
-  refine contMDiffOn_finsetSum fun σ _ ↦ ?_
-  refine ContMDiffOn.mul (contMDiffOn_const (c := ((Equiv.Perm.sign σ : ℤ) : ℝ))) ?_
-  refine contMDiffOn_finsetProd fun k _ ↦ ?_
-  by_cases hσk : σ k = j
-  · have heq :
-        (fun x : M ↦ (chartGramMatrix (I := I) α x).updateRow j
-            (Pi.single i (1 : ℝ)) (σ k) k) =
-          fun _ : M ↦
-            Pi.single (M := fun _ : Fin (Module.finrank ℝ E) ↦ ℝ) i (1 : ℝ) k := by
-      funext x
-      rw [hσk, Matrix.updateRow_self]
-    rw [heq]
+  apply contMDiffOn_matrix_det_of_entries
+  intro k l
+  by_cases hkj : k = j
+  · subst k
+    simp only [Matrix.updateRow_self]
     exact contMDiffOn_const
-  · have heq :
-        (fun x : M ↦ (chartGramMatrix (I := I) α x).updateRow j
-            (Pi.single i (1 : ℝ)) (σ k) k) =
-          fun x : M ↦ chartGramMatrix (I := I) α x (σ k) k := by
-      funext x
-      rw [Matrix.updateRow_ne hσk]
-    rw [heq]
-    exact chartGramMatrix_entry_contMDiffOn (I := I) α (σ k) k
+  · simp [Matrix.updateRow_apply, hkj]
+    exact contMDiffOn_chartGramMatrix_entry (I := I) (n := n) α k l
 
 end Smooth
 
@@ -232,6 +213,7 @@ def chartInvGramMatrix (α : M) (x : M) :
   (chartGramMatrix (I := I) α x)⁻¹
 
 /-- On the tangent-trivialization base set, the inverse Gram matrix is a left inverse. -/
+@[simp]
 theorem chartInvGramMatrix_mul_chartGramMatrix (α : M) {x : M}
     (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
     chartInvGramMatrix (I := I) α x * chartGramMatrix (I := I) α x = 1 := by
@@ -241,6 +223,7 @@ theorem chartInvGramMatrix_mul_chartGramMatrix (α : M) {x : M}
   exact Matrix.nonsing_inv_mul _ hdet_unit
 
 /-- On the tangent-trivialization base set, the inverse Gram matrix is a right inverse. -/
+@[simp]
 theorem chartGramMatrix_mul_chartInvGramMatrix (α : M) {x : M}
     (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
     chartGramMatrix (I := I) α x * chartInvGramMatrix (I := I) α x = 1 := by
@@ -251,13 +234,14 @@ theorem chartGramMatrix_mul_chartInvGramMatrix (α : M) {x : M}
 
 section Smooth
 
-variable [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)]
+variable {n : ℕ∞ω} [ENat.LEInfty n]
+  [IsContMDiffRiemannianBundle I n E (fun x : M ↦ TangentSpace I x)]
 
 /-- Every entry of the inverse chart Gram matrix is smooth on the tangent-trivialization base
 set. Following the source, the proof uses the determinant/adjugate formula. -/
-theorem chartInvGramMatrix_entry_contMDiffOn
+theorem contMDiffOn_chartInvGramMatrix_entry
     (α : M) (i j : Fin (Module.finrank ℝ E)) :
-    ContMDiffOn I 𝓘(ℝ) ∞ (fun x : M ↦ chartInvGramMatrix (I := I) α x i j)
+    ContMDiffOn I 𝓘(ℝ) n (fun x : M ↦ chartInvGramMatrix (I := I) α x i j)
       (trivializationAt E (TangentSpace I) α).baseSet := by
   classical
   have hcongr : ∀ x ∈ (trivializationAt E (TangentSpace I) α).baseSet,
@@ -267,23 +251,17 @@ theorem chartInvGramMatrix_entry_contMDiffOn
     intro x _
     unfold chartInvGramMatrix
     rw [Matrix.inv_def]
-    change (Ring.inverse (chartGramMatrix (I := I) α x).det •
-          (chartGramMatrix (I := I) α x).adjugate) i j =
-      ((chartGramMatrix (I := I) α x).det)⁻¹ *
-        (chartGramMatrix (I := I) α x).adjugate i j
-    rw [Matrix.smul_apply, smul_eq_mul]
-    congr 1
-    exact Ring.inverse_eq_inv _
+    simpa only [Matrix.smul_apply, smul_eq_mul, Ring.inverse_eq_inv]
   refine ContMDiffOn.congr (ContMDiffOn.mul ?_ ?_) hcongr
-  · have hdet_smooth := chartGramMatrix_det_contMDiffOn (I := I) α
+  · have hdet_smooth := contMDiffOn_det_chartGramMatrix (I := I) (n := n) α
     intro x hx
     have hdet_ne : (chartGramMatrix (I := I) α x).det ≠ 0 :=
       ne_of_gt (chartGramMatrix_det_pos (I := I) α hx)
-    have hinv : ContDiffAt ℝ ∞ (fun y : ℝ ↦ y⁻¹)
+    have hinv : ContDiffAt ℝ n (fun y : ℝ ↦ y⁻¹)
         (chartGramMatrix (I := I) α x).det :=
       contDiffAt_inv _ hdet_ne
     exact hinv.contMDiffAt.comp_contMDiffWithinAt x (hdet_smooth x hx)
-  · exact chartGramMatrix_adjugate_entry_contMDiffOn (I := I) α i j
+  · exact contMDiffOn_adjugate_chartGramMatrix_entry (I := I) α i j
 
 end Smooth
 

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -1,0 +1,288 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Archon Horizon (claude+codex), Axel Delaval, Chunlei Liu,
+Jinxuan Chen, Wanxu Yang, Zekun Sheng, Yuxuan Liao, Jie Xu
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.GramMatrix
+public import Mathlib.Analysis.Matrix.PosDef
+public import Mathlib.Geometry.Manifold.Algebra.Structures
+public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame
+public import Mathlib.Geometry.Manifold.VectorBundle.Riemannian
+public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+
+/-!
+# Chart Gram matrices of a Riemannian metric
+
+This file constructs the Gram matrix of the canonical Riemannian metric in the local frame
+induced by a tangent-bundle trivialization and proves that its entries and the entries of its
+inverse are smooth on the trivialization base set. The construction uses
+`Bundle.Trivialization.localFrame` and `Bundle.Trivialization.basisAt`, so it applies unchanged
+when the model space has dimension zero.
+
+The Gram-matrix and inverse-matrix declarations are adapted from stages 1--5 of the Apache-2.0
+Poincare-Conjecture source file
+`DoCarmoLib/Riemannian/TensorBundle/MusicalIso.lean`, revision
+`24f32e4d600878bfaac6bc2f2f9324175571c321`. That source uses an explicit metric and a custom
+chart frame; here Mathlib's canonical `RiemannianBundle` metric and local-frame API replace them.
+As in the source, inverse-entry smoothness is proved through the determinant and adjugate formula.
+
+## Main definitions and results
+
+* `Riemannian.Tensor.chartLocalFrame`: the frame induced by the tangent trivialization at a chart
+  centre and `Module.finBasis`.
+* `Riemannian.Tensor.chartGramMatrix`: the metric Gram matrix in this frame.
+* `Riemannian.Tensor.chartGramMatrix_posDef`: positive-definiteness on the base set.
+* `Riemannian.Tensor.chartGramMatrix_det_pos`: strict positivity of its determinant there.
+* `Riemannian.Tensor.chartGramMatrix_entry_contMDiffOn`: smoothness of Gram-matrix entries.
+* `Riemannian.Tensor.chartInvGramMatrix`: the inverse Gram matrix.
+* `Riemannian.Tensor.chartInvGramMatrix_entry_contMDiffOn`: smoothness of inverse entries.
+
+## References
+
+* [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "Regularity of the Levi-Civita connection".
+* M. P. do Carmo, *Riemannian Geometry*, Chapter 2.
+* Poincare-Conjecture, `DoCarmoLib/Riemannian/TensorBundle/MusicalIso.lean`, stages 1--5,
+  revision `24f32e4d600878bfaac6bc2f2f9324175571c321` (Apache-2.0).
+
+-/
+
+@[expose] public section
+
+noncomputable section
+
+open Bundle FiberBundle Manifold Set
+open scoped ContDiff Manifold Matrix RealInnerProductSpace Topology
+
+namespace Riemannian
+namespace Tensor
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+
+/-- The chart-local frame obtained from the tangent-bundle trivialization centred at `α` and
+the chosen `Module.finBasis` basis of the model space. Outside the trivialization base set it has
+Mathlib's standard junk value `0`. -/
+def chartLocalFrame (α : M) :
+    Fin (Module.finrank ℝ E) → (x : M) → TangentSpace I x :=
+  (trivializationAt E (TangentSpace I) α).localFrame (Module.finBasis ℝ E)
+
+@[simp]
+theorem chartLocalFrame_apply_of_mem_baseSet (α : M) {x : M}
+    (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet)
+    (i : Fin (Module.finrank ℝ E)) :
+    chartLocalFrame (I := I) α i x =
+      (trivializationAt E (TangentSpace I) α).basisAt (Module.finBasis ℝ E) hx i :=
+  (trivializationAt E (TangentSpace I) α).localFrame_apply_of_mem_baseSet
+    (Module.finBasis ℝ E) hx
+
+/-- Each member of `chartLocalFrame` is smooth on the tangent-trivialization base set. -/
+theorem chartLocalFrame_contMDiffOn (α : M) (i : Fin (Module.finrank ℝ E)) :
+    ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+      (fun x ↦ TotalSpace.mk' E x (chartLocalFrame (I := I) α i x))
+      (trivializationAt E (TangentSpace I) α).baseSet :=
+  (trivializationAt E (TangentSpace I) α).contMDiffOn_localFrame_baseSet
+    (n := ∞) (Module.finBasis ℝ E) i
+
+variable [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+
+/-- The Gram matrix of `chartLocalFrame α` for the canonical Riemannian metric at `x`. Its
+entries are the coordinate metric coefficients used in do Carmo, *Riemannian Geometry*,
+Chapter 2. -/
+def chartGramMatrix (α : M) (x : M) :
+    Matrix (Fin (Module.finrank ℝ E)) (Fin (Module.finrank ℝ E)) ℝ :=
+  Matrix.gram ℝ fun i ↦ chartLocalFrame (I := I) α i x
+
+@[simp]
+theorem chartGramMatrix_apply (α x : M) (i j : Fin (Module.finrank ℝ E)) :
+    chartGramMatrix (I := I) α x i j =
+      inner ℝ (chartLocalFrame (I := I) α i x) (chartLocalFrame (I := I) α j x) :=
+  rfl
+
+/-- The chart Gram matrix is Hermitian, equivalently symmetric over `ℝ`. -/
+theorem chartGramMatrix_isHermitian (α x : M) :
+    (chartGramMatrix (I := I) α x).IsHermitian :=
+  Matrix.isHermitian_gram ℝ _
+
+/-- The Gram-matrix quadratic form equals the squared norm, in the canonical Riemannian metric,
+of the corresponding linear combination of chart-frame vectors. -/
+theorem chartGramMatrix_dotProduct_mulVec
+    (α x : M) (c : Fin (Module.finrank ℝ E) → ℝ) :
+    star c ⬝ᵥ (chartGramMatrix (I := I) α x) *ᵥ c =
+      inner ℝ
+        (∑ i, c i • chartLocalFrame (I := I) α i x)
+        (∑ j, c j • chartLocalFrame (I := I) α j x) :=
+  Matrix.star_dotProduct_gram_mulVec (𝕜 := ℝ) _ c c
+
+/-- The Gram matrix of the chart-local frame is positive-definite on the tangent-trivialization
+base set. -/
+theorem chartGramMatrix_posDef (α : M) {x : M}
+    (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
+    (chartGramMatrix (I := I) α x).PosDef :=
+  Matrix.posDef_gram_of_linearIndependent <|
+    ((trivializationAt E (TangentSpace I) α).isLocalFrameOn_localFrame_baseSet
+      I ∞ (Module.finBasis ℝ E)).linearIndependent hx
+
+/-- The determinant of the chart Gram matrix is strictly positive on the tangent-trivialization
+base set. -/
+theorem chartGramMatrix_det_pos (α : M) {x : M}
+    (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
+    0 < (chartGramMatrix (I := I) α x).det :=
+  (chartGramMatrix_posDef (I := I) α hx).det_pos
+
+section Smooth
+
+variable [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)]
+
+omit [FiniteDimensional ℝ E] in
+private lemma contMDiffOn_inner_tangent
+    {s : Set M} {X Y : ∀ x : M, TangentSpace I x}
+    (hX : CMDiff[s] ∞ (T% X)) (hY : CMDiff[s] ∞ (T% Y)) :
+    ContMDiffOn I 𝓘(ℝ) ∞ (fun x ↦ inner ℝ (X x) (Y x)) s :=
+  ContMDiffOn.inner_bundle hX hY
+
+/-- Every entry of the chart Gram matrix is smooth on the tangent-trivialization base set. -/
+theorem chartGramMatrix_entry_contMDiffOn
+    (α : M) (i j : Fin (Module.finrank ℝ E)) :
+    ContMDiffOn I 𝓘(ℝ) ∞ (fun x ↦ chartGramMatrix (I := I) α x i j)
+      (trivializationAt E (TangentSpace I) α).baseSet := by
+  exact contMDiffOn_inner_tangent (chartLocalFrame_contMDiffOn (I := I) α i)
+    (chartLocalFrame_contMDiffOn (I := I) α j)
+
+/-- The determinant of the chart Gram matrix is smooth on the tangent-trivialization base set.
+The proof expands the determinant as a finite sum of finite products of entries. -/
+theorem chartGramMatrix_det_contMDiffOn (α : M) :
+    ContMDiffOn I 𝓘(ℝ) ∞ (fun x ↦ (chartGramMatrix (I := I) α x).det)
+      (trivializationAt E (TangentSpace I) α).baseSet := by
+  classical
+  have hexp :
+      (fun x : M ↦ (chartGramMatrix (I := I) α x).det) =
+        fun x : M ↦ ∑ σ : Equiv.Perm (Fin (Module.finrank ℝ E)),
+          (Equiv.Perm.sign σ : ℝ) * ∏ i, chartGramMatrix (I := I) α x (σ i) i := by
+    funext x
+    rw [Matrix.det_apply]
+    simp [Units.smul_def]
+  rw [hexp]
+  refine contMDiffOn_finsetSum fun σ _ ↦ ?_
+  refine ContMDiffOn.mul (contMDiffOn_const (c := ((Equiv.Perm.sign σ : ℤ) : ℝ))) ?_
+  refine contMDiffOn_finsetProd fun i _ ↦ ?_
+  exact chartGramMatrix_entry_contMDiffOn (I := I) α (σ i) i
+
+/-- Every adjugate entry of the chart Gram matrix is smooth on the tangent-trivialization base
+set. The proof realizes the entry as the determinant of a row-updated matrix. -/
+theorem chartGramMatrix_adjugate_entry_contMDiffOn
+    (α : M) (i j : Fin (Module.finrank ℝ E)) :
+    ContMDiffOn I 𝓘(ℝ) ∞
+      (fun x : M ↦ (chartGramMatrix (I := I) α x).adjugate i j)
+      (trivializationAt E (TangentSpace I) α).baseSet := by
+  classical
+  have hexp :
+      (fun x : M ↦ (chartGramMatrix (I := I) α x).adjugate i j) =
+        fun x : M ↦ ((chartGramMatrix (I := I) α x).updateRow j
+          (Pi.single i (1 : ℝ))).det := by
+    funext x
+    exact Matrix.adjugate_apply _ _ _
+  rw [hexp]
+  have hexp' :
+      (fun x : M ↦ ((chartGramMatrix (I := I) α x).updateRow j
+          (Pi.single i (1 : ℝ))).det) =
+        fun x : M ↦ ∑ σ : Equiv.Perm (Fin (Module.finrank ℝ E)),
+          (Equiv.Perm.sign σ : ℝ) *
+            ∏ k, (chartGramMatrix (I := I) α x).updateRow j
+              (Pi.single i (1 : ℝ)) (σ k) k := by
+    funext x
+    rw [Matrix.det_apply]
+    simp [Units.smul_def]
+  rw [hexp']
+  refine contMDiffOn_finsetSum fun σ _ ↦ ?_
+  refine ContMDiffOn.mul (contMDiffOn_const (c := ((Equiv.Perm.sign σ : ℤ) : ℝ))) ?_
+  refine contMDiffOn_finsetProd fun k _ ↦ ?_
+  by_cases hσk : σ k = j
+  · have heq :
+        (fun x : M ↦ (chartGramMatrix (I := I) α x).updateRow j
+            (Pi.single i (1 : ℝ)) (σ k) k) =
+          fun _ : M ↦
+            Pi.single (M := fun _ : Fin (Module.finrank ℝ E) ↦ ℝ) i (1 : ℝ) k := by
+      funext x
+      rw [hσk, Matrix.updateRow_self]
+    rw [heq]
+    exact contMDiffOn_const
+  · have heq :
+        (fun x : M ↦ (chartGramMatrix (I := I) α x).updateRow j
+            (Pi.single i (1 : ℝ)) (σ k) k) =
+          fun x : M ↦ chartGramMatrix (I := I) α x (σ k) k := by
+      funext x
+      rw [Matrix.updateRow_ne hσk]
+    rw [heq]
+    exact chartGramMatrix_entry_contMDiffOn (I := I) α (σ k) k
+
+end Smooth
+
+/-- The inverse coordinate-metric matrix from do Carmo, *Riemannian Geometry*, Chapter 2. On the
+tangent-trivialization base set this is the inverse of a positive-definite matrix. -/
+def chartInvGramMatrix (α : M) (x : M) :
+    Matrix (Fin (Module.finrank ℝ E)) (Fin (Module.finrank ℝ E)) ℝ :=
+  (chartGramMatrix (I := I) α x)⁻¹
+
+/-- On the tangent-trivialization base set, the inverse Gram matrix is a left inverse. -/
+theorem chartInvGramMatrix_mul_chartGramMatrix (α : M) {x : M}
+    (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
+    chartInvGramMatrix (I := I) α x * chartGramMatrix (I := I) α x = 1 := by
+  have hdet_unit : IsUnit (chartGramMatrix (I := I) α x).det :=
+    isUnit_iff_ne_zero.mpr (ne_of_gt (chartGramMatrix_det_pos (I := I) α hx))
+  unfold chartInvGramMatrix
+  exact Matrix.nonsing_inv_mul _ hdet_unit
+
+/-- On the tangent-trivialization base set, the inverse Gram matrix is a right inverse. -/
+theorem chartGramMatrix_mul_chartInvGramMatrix (α : M) {x : M}
+    (hx : x ∈ (trivializationAt E (TangentSpace I) α).baseSet) :
+    chartGramMatrix (I := I) α x * chartInvGramMatrix (I := I) α x = 1 := by
+  have hdet_unit : IsUnit (chartGramMatrix (I := I) α x).det :=
+    isUnit_iff_ne_zero.mpr (ne_of_gt (chartGramMatrix_det_pos (I := I) α hx))
+  unfold chartInvGramMatrix
+  exact Matrix.mul_nonsing_inv _ hdet_unit
+
+section Smooth
+
+variable [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)]
+
+/-- Every entry of the inverse chart Gram matrix is smooth on the tangent-trivialization base
+set. Following the source, the proof uses the determinant/adjugate formula. -/
+theorem chartInvGramMatrix_entry_contMDiffOn
+    (α : M) (i j : Fin (Module.finrank ℝ E)) :
+    ContMDiffOn I 𝓘(ℝ) ∞ (fun x : M ↦ chartInvGramMatrix (I := I) α x i j)
+      (trivializationAt E (TangentSpace I) α).baseSet := by
+  classical
+  have hcongr : ∀ x ∈ (trivializationAt E (TangentSpace I) α).baseSet,
+      chartInvGramMatrix (I := I) α x i j =
+        ((chartGramMatrix (I := I) α x).det)⁻¹ *
+          (chartGramMatrix (I := I) α x).adjugate i j := by
+    intro x _
+    unfold chartInvGramMatrix
+    rw [Matrix.inv_def]
+    change (Ring.inverse (chartGramMatrix (I := I) α x).det •
+          (chartGramMatrix (I := I) α x).adjugate) i j =
+      ((chartGramMatrix (I := I) α x).det)⁻¹ *
+        (chartGramMatrix (I := I) α x).adjugate i j
+    rw [Matrix.smul_apply, smul_eq_mul]
+    congr 1
+    exact Ring.inverse_eq_inv _
+  refine ContMDiffOn.congr (ContMDiffOn.mul ?_ ?_) hcongr
+  · have hdet_smooth := chartGramMatrix_det_contMDiffOn (I := I) α
+    intro x hx
+    have hdet_ne : (chartGramMatrix (I := I) α x).det ≠ 0 :=
+      ne_of_gt (chartGramMatrix_det_pos (I := I) α hx)
+    have hinv : ContDiffAt ℝ ∞ (fun y : ℝ ↦ y⁻¹)
+        (chartGramMatrix (I := I) α x).det :=
+      contDiffAt_inv _ hdet_ne
+    exact hinv.contMDiffAt.comp_contMDiffWithinAt x (hdet_smooth x hx)
+  · exact chartGramMatrix_adjugate_entry_contMDiffOn (I := I) α i j
+
+end Smooth
+
+end Tensor
+end Riemannian


### PR DESCRIPTION
## Summary

- Port the chart Gram matrix construction and its inverse to Tau Ceti's canonical Riemannian bundle API.
- Reuse Mathlib local frames, Gram-matrix, positive-definiteness, determinant, adjugate, and nonsingular-inverse results.
- Prove smoothness of Gram and inverse entries on the trivialization base set.
- Keep the port limited to stages 1--5 of the source; later musical/Riesz constructions remain separate roadmap work.

## Roadmap

Advances `TauCetiRoadmap/HopfRinow/README.md`, Layer 1, "Regularity of the Levi-Civita connection". The implementation is adapted from the Apache-2.0 Poincare-Conjecture source revision `24f32e4d600878bfaac6bc2f2f9324175571c321`.

Roadmap: HopfRinow

## Verification

- `lake env lean TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean`
- `lake env lean --run scripts/HeaderStyle.lean TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean`
- `python3 scripts/lint-dot-notation.py --source-root TauCeti --mathlib-root /home/axel/TauCeti-pr-piecewise-subinterval/.lake/packages/mathlib/Mathlib --baseline scripts/lint-dot-notation-baseline.txt`
- `git diff --check`
