### PR TITLE
feat: add multiplicative-type affine group schemes

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/Basic.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.FiniteType
-public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
 
 /-!
 # Diagonalizable group schemes
@@ -48,6 +48,10 @@ ring in `Type u`.
 * `TauCeti.DiagonalizableGroup.isAffine_groupScheme`: `D(G)` is affine.
 * `TauCeti.DiagonalizableGroup.locallyOfFiniteType_groupScheme`: `D(G) ⟶ Spec R` is
   locally of finite type.
+* `TauCeti.DiagonalizableGroup.finiteTypeGroupScheme`: `D(G)` bundled as a finite-type affine
+  group scheme.
+* `TauCeti.DiagonalizableGroup.finiteTypeGroupSchemeIso`: its comparison with the object produced
+  by the finite-type Hopf/group-scheme anti-equivalence.
 * `TauCeti.DiagonalizableGroup.schemeFunctor_faithful` and
   `TauCeti.DiagonalizableGroup.schemeFunctor_full`: faithfulness over a nontrivial base and
   fullness over a base with connected prime spectrum.
@@ -288,6 +292,31 @@ instance locallyOfFiniteType_groupScheme (G : FGCommGrpCat.{u}) :
     rw [← AlgebraicGeometry.specOverSpec_over]
     infer_instance
   exact locallyOfFiniteType_comp _ _
+
+/-- The diagonalizable group scheme `D(G)` bundled as a finite-type affine group scheme. -/
+noncomputable def finiteTypeGroupScheme (G : FGCommGrpCat.{u}) :
+    FiniteTypeAffineGroupSchemeCat (CommRingCat.of R) :=
+  ⟨⟨groupScheme R G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩,
+    (finiteTypeAffineGroupSchemeProperty_iff _ _).2
+      (locallyOfFiniteType_groupScheme R G)⟩
+
+/-- The underlying group scheme of the bundled finite-type `D(G)` is `groupScheme R G`. -/
+@[simp]
+theorem finiteTypeGroupScheme_obj_obj (G : FGCommGrpCat.{u}) :
+    (finiteTypeGroupScheme R G).obj.obj = groupScheme R G := by
+  rfl
+
+/-- The finite-type Hopf/group-scheme anti-equivalence sends the coordinate ring `R[G]` to the
+bundled diagonalizable group scheme `D(G)`. -/
+noncomputable def finiteTypeGroupSchemeIso (G : FGCommGrpCat.{u}) :
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat R).functor.obj
+        (Opposite.op (coordinateRing R G)) ≅
+      finiteTypeGroupScheme R G :=
+  finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorObjIso R
+      (Opposite.op (coordinateRing R G)) ≪≫
+    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
+      ((affineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
+        (eqToIso (groupScheme_def R G).symm))
 
 /-- Every object produced by the diagonalizable group-scheme functor is affine. -/
 instance isAffine_schemeFunctor_obj (G : (FGCommGrpCat.{u})ᵒᵖ) :

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/MultiplicativeType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme/MultiplicativeType.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Equivalence
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.MultiplicativeType
+
+/-!
+# Multiplicative type of diagonalizable group schemes
+
+Every finite-type diagonalizable group scheme over a field is of multiplicative type. The result
+is first stated for an arbitrary finite-type affine group scheme satisfying the scheme-side
+diagonalizable property, and then specialized to the canonical object `D(G) = Spec k[G]`.
+
+## Main declarations
+
+* `multiplicativeTypeAffineGroupSchemeProperty_of_diagonalizableGroupSchemeProperty`:
+  every finite-type affine group scheme satisfying the diagonalizable property is of
+  multiplicative type.
+* `TauCeti.DiagonalizableGroup.multiplicativeTypeAffineGroupSchemeProperty_groupScheme`: the
+  canonical finite-type diagonalizable group scheme `D(G)` is of multiplicative type.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Definitions 12.7 and 12.14.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+The proof structure follows
+`TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Scheme.LinearlyReductive`, replacing linear
+reductivity by the coordinate-side multiplicative-type property. This supplies a Layer 4 example
+from the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory AlgebraicGeometry Opposite
+
+universe u
+
+namespace DiagonalizableGroup
+
+/-- Every finite-type affine group scheme satisfying the diagonalizable-group property is of
+multiplicative type. -/
+@[grind →]
+theorem multiplicativeTypeAffineGroupSchemeProperty_of_diagonalizableGroupSchemeProperty
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
+    (hG : diagonalizableGroupSchemeProperty k G.obj.obj) :
+    multiplicativeTypeAffineGroupSchemeProperty k G := by
+  have hEssImage : (schemeFunctor k).essImage G.obj.obj := by
+    rw [essImage_schemeFunctor]
+    exact hG
+  obtain ⟨M, ⟨e⟩⟩ := hEssImage
+  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
+  let H : FiniteTypeCommHopfAlgCat.{u, u} k := coordinateRing k M.unop
+  have hE : multiplicativeTypeAffineGroupSchemeProperty k (E.functor.obj (op H)) := by
+    rw [← ObjectProperty.prop_inverseImage_iff
+        (multiplicativeTypeAffineGroupSchemeProperty k) E.functor (op H),
+      multiplicativeTypeAffineGroupSchemeProperty_inverseImage, ObjectProperty.op_iff]
+    exact multiplicativeType_coordinateRing k M.unop
+  have hD : multiplicativeTypeAffineGroupSchemeProperty k
+      (finiteTypeGroupScheme k M.unop) :=
+    (multiplicativeTypeAffineGroupSchemeProperty k).prop_of_iso
+      (finiteTypeGroupSchemeIso k M.unop) hE
+  let e' : finiteTypeGroupScheme k M.unop ≅ G :=
+    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+      ((affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso
+        (eqToIso (finiteTypeGroupScheme_obj_obj k M.unop) ≪≫
+          eqToIso (schemeFunctor_obj k M).symm ≪≫ e))
+  exact (multiplicativeTypeAffineGroupSchemeProperty k).prop_of_iso e' hD
+
+/-- The canonical finite-type diagonalizable group scheme `D(G)` is of multiplicative type. -/
+theorem multiplicativeTypeAffineGroupSchemeProperty_groupScheme
+    (k : Type u) [Field k] (G : FGCommGrpCat.{u}) :
+    multiplicativeTypeAffineGroupSchemeProperty k (finiteTypeGroupScheme k G) := by
+  apply multiplicativeTypeAffineGroupSchemeProperty_of_diagonalizableGroupSchemeProperty
+  rw [← essImage_schemeFunctor]
+  exact ⟨op G, ⟨eqToIso (schemeFunctor_obj k (op G)) ≪≫
+    eqToIso (finiteTypeGroupScheme_obj_obj k G).symm⟩⟩
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/FiniteType.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/FiniteType.lean
@@ -40,6 +40,8 @@ reductive-groups roadmap, while the dictionary records that the two predicates c
   anti-equivalence.
 * `TauCeti.finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso`:
   after both inclusions, the forward functor is Mathlib's `AlgebraicGeometry.hopfSpec`.
+* `TauCeti.finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorObjIso`:
+  the corresponding object-level isomorphism with the bundled Hopf spectrum.
 * `TauCeti.finiteType_objectProperty_iff_coordinate`: transport of an isomorphism-invariant
   object property through the finite-type anti-equivalence.
 
@@ -196,6 +198,23 @@ noncomputable def
       (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
         (CommRingCat.of R))
 
+/-- The object produced by the finite-type Hopf/group-scheme anti-equivalence is the bundled
+finite-type Hopf spectrum. -/
+noncomputable def
+    finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorObjIso
+    (R : Type u) [CommRing R] (H : (FiniteTypeCommHopfAlgCat.{u, u} R)ᵒᵖ) :
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat R).functor.obj H ≅
+      ⟨⟨(hopfSpec (CommRingCat.of R)).obj (op H.unop.obj), by
+          rw [affineGroupSchemeProperty_iff, hopfSpec_obj_X_left]
+          infer_instance⟩,
+        by
+          rw [finiteTypeAffineGroupSchemeProperty_iff]
+          exact (algebraFiniteType_iff_locallyOfFiniteType_hopfSpec R H.unop.obj).mp
+            H.unop.property⟩ :=
+  (finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
+    ((affineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
+      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso R).app H))
+
 /-- An isomorphism-invariant property of affine group schemes can be tested on the coordinate
 Hopf algebra of a finite-type affine group scheme whenever the unrestricted anti-equivalence
 identifies it with a coordinate-side property. -/
@@ -218,11 +237,9 @@ theorem finiteType_objectProperty_iff_coordinate
       (finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.obj (E.functor.obj H) ≅
         (commHopfAlgCatOpEquivAffineGroupSchemeCat
           (CommRingCat.of R)).functor.obj H₀ :=
-    (affineGroupSchemeProperty (CommRingCat.of R)).ι.preimageIso
-      ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso R).app
-          H ≪≫
-        ((commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso
-          (CommRingCat.of R)).app H₀).symm)
+    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.mapIso
+        (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorObjIso R H) ≪≫
+      (commHopfAlgCatOpEquivAffineGroupSchemeCat.functorObjIso R H₀).symm
   let eG :
       (finiteTypeAffineGroupSchemeProperty (CommRingCat.of R)).ι.obj (E.functor.obj H) ≅
         G.obj :=

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/MultiplicativeType.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/MultiplicativeType.lean
@@ -6,7 +6,6 @@ Authors: Codex
 module
 
 import TauCeti.CategoryTheory.ObjectProperty
-public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Scheme.Basic
 public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeType.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
 
@@ -27,8 +26,6 @@ category.
 * `TauCeti.multiplicativeTypeAffineGroupSchemeProperty`: the multiplicative-type property for
   finite-type affine group schemes over a field.
 * `TauCeti.MultiplicativeTypeAffineGroupSchemeCat`: the corresponding full subcategory.
-* `TauCeti.DiagonalizableGroup.multiplicativeTypeAffineGroupSchemeProperty_groupScheme`: every
-  canonical finite-type diagonalizable group scheme is of multiplicative type.
 * `TauCeti.multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCat`: the
   restricted affine Hopf/group-scheme anti-equivalence.
 
@@ -81,43 +78,6 @@ instance (k : Type u) [Field k] :
 /-- The category of finite-type affine group schemes of multiplicative type over a field. -/
 abbrev MultiplicativeTypeAffineGroupSchemeCat (k : Type u) [Field k] :=
   (multiplicativeTypeAffineGroupSchemeProperty k).FullSubcategory
-
-namespace DiagonalizableGroup
-
-/-- The canonical finite-type diagonalizable group scheme `D(G)` is of multiplicative type. -/
-@[grind =>]
-theorem multiplicativeTypeAffineGroupSchemeProperty_groupScheme
-    (k : Type u) [Field k] (G : FGCommGrpCat.{u}) :
-    multiplicativeTypeAffineGroupSchemeProperty k
-      ⟨⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩,
-        (finiteTypeAffineGroupSchemeProperty_iff _ _).2
-          (locallyOfFiniteType_groupScheme k G)⟩ := by
-  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
-  let H : FiniteTypeCommHopfAlgCat.{u, u} k := coordinateRing k G
-  let D : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k) :=
-    ⟨⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩,
-      (finiteTypeAffineGroupSchemeProperty_iff _ _).2
-        (locallyOfFiniteType_groupScheme k G)⟩
-  have hE : multiplicativeTypeAffineGroupSchemeProperty k (E.functor.obj (op H)) := by
-    rw [multiplicativeTypeAffineGroupSchemeProperty_iff]
-    exact (multiplicativeTypeCommHopfAlgProperty k).prop_of_iso
-      (Iso.unop (E.unitIso.app (op H))).symm (multiplicativeType_coordinateRing k G)
-  let eGrp :
-      ((affineGroupSchemeProperty (CommRingCat.of k)).ι.obj
-        ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj
-          (E.functor.obj (op H)))) ≅ D.obj.obj :=
-    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app
-        (op H) ≪≫
-      eqToIso (groupScheme_def k G).symm
-  let eAffine :
-      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj
-          (E.functor.obj (op H)) ≅ D.obj :=
-    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso eGrp
-  let e : E.functor.obj (op H) ≅ D :=
-    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso eAffine
-  exact (multiplicativeTypeAffineGroupSchemeProperty k).prop_of_iso e hE
-
-end DiagonalizableGroup
 
 /-- Under the finite-type affine Hopf/group-scheme anti-equivalence, the inverse image of the
 multiplicative-type property on group schemes is the multiplicative-type property on coordinate

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/MultiplicativeType.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/MultiplicativeType.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+import TauCeti.CategoryTheory.ObjectProperty
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Scheme.Basic
+public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeType.Basic
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.FiniteType
+
+/-!
+# Affine group schemes of multiplicative type
+
+This file transports the coordinate-Hopf-algebra definition of a group of multiplicative type to
+finite-type affine group schemes over a field. A group scheme is of multiplicative type when its
+coordinate Hopf algebra becomes diagonalizable after extension to an algebraic closure.
+
+The resulting full subcategory is anti-equivalent to multiplicative-type coordinate Hopf
+algebras. This synchronizes the coordinate and scheme models without requiring the group to split
+over the ground field; finite diagonalizable groups and non-split tori both belong to the resulting
+category.
+
+## Main declarations
+
+* `TauCeti.multiplicativeTypeAffineGroupSchemeProperty`: the multiplicative-type property for
+  finite-type affine group schemes over a field.
+* `TauCeti.MultiplicativeTypeAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.DiagonalizableGroup.multiplicativeTypeAffineGroupSchemeProperty_groupScheme`: every
+  canonical finite-type diagonalizable group scheme is of multiplicative type.
+* `TauCeti.multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCat`: the
+  restricted affine Hopf/group-scheme anti-equivalence.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Definition 12.14 and Theorem 12.23.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.
+
+This supplies the scheme-side model required by Layer 4, "Diagonalizable groups and groups of
+multiplicative type", of the ReductiveGroups roadmap. The construction follows the transport
+pattern of `TauCeti.AlgebraicGeometry.AffineGroupScheme.Torus`.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory AlgebraicGeometry Opposite
+
+universe u
+
+/-- The object property selecting affine group schemes of multiplicative type over a field.
+
+The property is transported through the finite-type affine Hopf/group-scheme anti-equivalence,
+so it retains the coordinate definition by diagonalizability after extension to an algebraic
+closure. -/
+def multiplicativeTypeAffineGroupSchemeProperty (k : Type u) [Field k] :
+    ObjectProperty (FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :=
+  (multiplicativeTypeCommHopfAlgProperty k).op.inverseImage
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse
+
+/-- A finite-type affine group scheme is of multiplicative type exactly when its coordinate Hopf
+algebra, supplied by the affine anti-equivalence, is of multiplicative type. -/
+@[simp]
+theorem multiplicativeTypeAffineGroupSchemeProperty_iff
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k)) :
+    multiplicativeTypeAffineGroupSchemeProperty k G ↔
+      multiplicativeTypeCommHopfAlgProperty k
+        ((finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).inverse.obj G).unop :=
+  Iff.rfl
+
+/-- Being of multiplicative type is invariant under isomorphisms of finite-type affine group
+schemes. -/
+instance (k : Type u) [Field k] :
+    (multiplicativeTypeAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms := by
+  unfold multiplicativeTypeAffineGroupSchemeProperty
+  infer_instance
+
+/-- The category of finite-type affine group schemes of multiplicative type over a field. -/
+abbrev MultiplicativeTypeAffineGroupSchemeCat (k : Type u) [Field k] :=
+  (multiplicativeTypeAffineGroupSchemeProperty k).FullSubcategory
+
+namespace DiagonalizableGroup
+
+/-- The canonical finite-type diagonalizable group scheme `D(G)` is of multiplicative type. -/
+@[grind =>]
+theorem multiplicativeTypeAffineGroupSchemeProperty_groupScheme
+    (k : Type u) [Field k] (G : FGCommGrpCat.{u}) :
+    multiplicativeTypeAffineGroupSchemeProperty k
+      ⟨⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩,
+        (finiteTypeAffineGroupSchemeProperty_iff _ _).2
+          (locallyOfFiniteType_groupScheme k G)⟩ := by
+  let E := finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k
+  let H : FiniteTypeCommHopfAlgCat.{u, u} k := coordinateRing k G
+  let D : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k) :=
+    ⟨⟨groupScheme k G, (affineGroupSchemeProperty_iff _).2 inferInstance⟩,
+      (finiteTypeAffineGroupSchemeProperty_iff _ _).2
+        (locallyOfFiniteType_groupScheme k G)⟩
+  have hE : multiplicativeTypeAffineGroupSchemeProperty k (E.functor.obj (op H)) := by
+    rw [multiplicativeTypeAffineGroupSchemeProperty_iff]
+    exact (multiplicativeTypeCommHopfAlgProperty k).prop_of_iso
+      (Iso.unop (E.unitIso.app (op H))).symm (multiplicativeType_coordinateRing k G)
+  let eGrp :
+      ((affineGroupSchemeProperty (CommRingCat.of k)).ι.obj
+        ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj
+          (E.functor.obj (op H)))) ≅ D.obj.obj :=
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k).app
+        (op H) ≪≫
+      eqToIso (groupScheme_def k G).symm
+  let eAffine :
+      (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.obj
+          (E.functor.obj (op H)) ≅ D.obj :=
+    (affineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso eGrp
+  let e : E.functor.obj (op H) ≅ D :=
+    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι.preimageIso eAffine
+  exact (multiplicativeTypeAffineGroupSchemeProperty k).prop_of_iso e hE
+
+end DiagonalizableGroup
+
+/-- Under the finite-type affine Hopf/group-scheme anti-equivalence, the inverse image of the
+multiplicative-type property on group schemes is the multiplicative-type property on coordinate
+Hopf algebras. -/
+theorem multiplicativeTypeAffineGroupSchemeProperty_inverseImage
+    (k : Type u) [Field k] :
+    (multiplicativeTypeAffineGroupSchemeProperty k).inverseImage
+        (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor =
+      (multiplicativeTypeCommHopfAlgProperty k).op := by
+  unfold multiplicativeTypeAffineGroupSchemeProperty
+  exact ObjectProperty.inverseImage_functor_inverseImage_inverse _ _
+
+/-- `Spec` restricts to an anti-equivalence from multiplicative-type coordinate Hopf algebras to
+affine group schemes of multiplicative type. -/
+noncomputable def
+    multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCat
+    (k : Type u) [Field k] :
+    (MultiplicativeTypeCommHopfAlgCat.{u} k)ᵒᵖ ≌
+      MultiplicativeTypeAffineGroupSchemeCat k :=
+  (ObjectProperty.opEquivalence (multiplicativeTypeCommHopfAlgProperty k)).symm.trans <|
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).congrFullSubcategory
+      (multiplicativeTypeAffineGroupSchemeProperty_inverseImage k)
+
+/-- The forward multiplicative-type anti-equivalence followed by the inclusion into finite-type
+affine group schemes is definitionally the finite-type anti-equivalence after forgetting the
+multiplicative-type property. -/
+private noncomputable def
+    multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCatFunctorCompιIso
+    (k : Type u) [Field k] :
+    (multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCat k).functor ⋙
+        (multiplicativeTypeAffineGroupSchemeProperty k).ι ≅
+      (forget₂ (MultiplicativeTypeCommHopfAlgCat.{u} k)
+          (FiniteTypeCommHopfAlgCat.{u, u} k)).op ⋙
+        (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat k).functor :=
+  Iso.refl _
+
+/-- The forward multiplicative-type anti-equivalence, followed by the inclusions into finite-type
+affine group schemes and affine group schemes, is Mathlib's `hopfSpec` after forgetting the
+multiplicative-type and finite-type proofs. -/
+noncomputable def
+    multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCat.functorCompιIso
+    (k : Type u) [Field k] :
+    (multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCat k).functor ⋙
+          (multiplicativeTypeAffineGroupSchemeProperty k).ι ⋙
+          (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+        (affineGroupSchemeProperty (CommRingCat.of k)).ι ≅
+      (forget₂ (MultiplicativeTypeCommHopfAlgCat.{u} k)
+          (FiniteTypeCommHopfAlgCat.{u, u} k)).op ⋙
+        (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+          (CommHopfAlgCat.{u} k)).op ⋙ hopfSpec (CommRingCat.of k) :=
+  (Functor.isoWhiskerRight
+    (multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCatFunctorCompιIso
+      k)
+    ((finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+      (affineGroupSchemeProperty (CommRingCat.of k)).ι)).trans <|
+  (Functor.associator _ _ _).trans <|
+  Functor.isoWhiskerLeft
+    (forget₂ (MultiplicativeTypeCommHopfAlgCat.{u} k)
+      (FiniteTypeCommHopfAlgCat.{u, u} k)).op
+    (finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat.functorCompιIso k)
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Torus.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Torus.lean
@@ -7,6 +7,7 @@ module
 
 import TauCeti.CategoryTheory.ObjectProperty
 public import TauCeti.Algebra.AlgebraicGroup.Torus.Reductive
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.MultiplicativeType
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Reductive
 
 /-!
@@ -17,14 +18,16 @@ group schemes over a field. A group scheme is a torus when its coordinate Hopf a
 finite-rank split-torus coordinate ring after extension to an algebraic closure.
 
 The resulting full subcategory is anti-equivalent to torus coordinate Hopf algebras. Every object
-in it is reductive, synchronizing the theorem that tori are reductive between the coordinate and
-scheme models.
+in it is of multiplicative type and reductive, synchronizing these structural theorems between the
+coordinate and scheme models.
 
 ## Main declarations
 
 * `TauCeti.torusAffineGroupSchemeProperty`: the torus property for finite-type affine group
   schemes over a field.
 * `TauCeti.TorusAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.torusAffineGroupSchemeProperty.multiplicativeType`: every torus affine group scheme is
+  of multiplicative type.
 * `TauCeti.torusAffineGroupSchemeProperty.reductive`: every torus affine group scheme is
   reductive.
 * `TauCeti.smooth_of_torusAffineGroupSchemeProperty` and
@@ -81,6 +84,16 @@ abbrev TorusAffineGroupSchemeCat (k : Type u) [Field k] :=
   (torusAffineGroupSchemeProperty k).FullSubcategory
 
 namespace torusAffineGroupSchemeProperty
+
+/-- Every torus affine group scheme over a field is of multiplicative type. -/
+@[grind →]
+theorem multiplicativeType
+    (k : Type u) [Field k]
+    (G : FiniteTypeAffineGroupSchemeCat (CommRingCat.of k))
+    (hG : torusAffineGroupSchemeProperty k G) :
+    multiplicativeTypeAffineGroupSchemeProperty k G := by
+  rw [multiplicativeTypeAffineGroupSchemeProperty_iff]
+  exact ((torusAffineGroupSchemeProperty_iff k G).mp hG).multiplicativeType k _
 
 /-- **Every torus affine group scheme over a field is reductive.** -/
 @[grind →]


### PR DESCRIPTION
This PR adds the scheme-side form of groups of multiplicative type: transport the coordinate Hopf-algebra property across the finite-type affine Hopf/group-scheme anti-equivalence, package the resulting full subcategory and restricted anti-equivalence, and record that canonical diagonalizable group schemes and torus affine group schemes satisfy the property.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4, milestone “Diagonalizable groups and groups of multiplicative type,” together with the roadmap-wide requirement to maintain synchronized Hopf-algebra, group-scheme, and functor-of-points models. The coordinate property `multiplicativeTypeCommHopfAlgProperty` and finite-type affine Hopf/group-scheme anti-equivalence were already on `main`; this PR supplies their missing scheme-side interface. After this PR, Layer 4 still needs the faithfully flat Galois-descent scalar-extension comparison and the anti-equivalence between non-split tori and integral Galois lattices.

`TauCeti/AlgebraicGeometry/AffineGroupScheme/MultiplicativeType.lean` (182 lines) defines `multiplicativeTypeAffineGroupSchemeProperty`, `MultiplicativeTypeAffineGroupSchemeCat`, the canonical diagonalizable-group witness, and `multiplicativeTypeCommHopfAlgCatOpEquivMultiplicativeTypeAffineGroupSchemeCat`, with a compatibility isomorphism identifying its forward functor with `hopfSpec`. `TauCeti/AlgebraicGeometry/AffineGroupScheme/Torus.lean` records that every torus affine group scheme is of multiplicative type, so the new predicate is exercised by the existing non-split torus model.

The categorical transport follows the established construction in `TauCeti.AlgebraicGeometry.AffineGroupScheme.Torus`; the mathematical definition follows J. S. Milne, *Algebraic Groups* (2017), Definition 12.14 and Theorem 12.23, and W. C. Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2. No Mathlib infrastructure is vendored; the pinned Mathlib source has no multiplicative-type group-scheme API.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"multiplicative-type-affine-group-schemes"}-->

🤖 Prepared with Codex
