### PR TITLE
feat: prove dynamic unipotent points are unipotent

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
@@ -7,8 +7,8 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Dynamic.Parabolic
 public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Basic
-public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
-public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
+import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
+import Mathlib.LinearAlgebra.Charpoly.ToMatrix
 
 /-!
 # Unipotence of the dynamic unipotent subgroup
@@ -63,6 +63,19 @@ private theorem charpoly_conjugate {B : Type w} [CommRing B] [Algebra R B]
     simp [LinearEquiv.conj_apply, Comodule.pointsAction_toLinearMap]
   rw [hEnd, LinearEquiv.charpoly_conj]
 
+private theorem charpoly_endOfPoint_comp {B D : Type w} [CommRing B] [Algebra R B]
+    [CommRing D] [Algebra R D] (M : FGComoduleCat.{u, v, u} R H)
+    (b : Basis (Module.Free.ChooseBasisIndex R M) R M) (g : H →ₐ[R] B) (f : B →ₐ[R] D) :
+    (Comodule.endOfPoint M (f.comp g)).charpoly =
+      (Comodule.endOfPoint M g).charpoly.map f := by
+  rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M (f.comp g)) (b.baseChange D),
+    ← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g) (b.baseChange B),
+    Comodule.toMatrix_endOfPoint, Comodule.toMatrix_endOfPoint, ← Matrix.charpoly_map,
+    Matrix.map_map]
+  apply congrArg Matrix.charpoly
+  ext i j
+  rfl
+
 /-- Every point of the dynamic unipotent subgroup attached to a cocharacter is unipotent in
 every finite-dimensional representation. -/
 theorem isUnipotentPoint_of_mem_unipotent
@@ -101,17 +114,25 @@ theorem isUnipotentPoint_of_mem_unipotent
   have hLaurentCharpoly :
       (P.map Polynomial.toLaurent).charpoly =
         (G.map LaurentPolynomial.C).charpoly := by
-    rw [hLaurentMatrix]
-    rw [← Comodule.toMatrix_endOfPoint b]
-    rw [LinearMap.charpoly_toMatrix]
-    rw [conjugate_apply, charpoly_conjugate]
-    rw [constPoint_apply]
-    rw [← LinearMap.charpoly_toMatrix
-      (Comodule.endOfPoint M
-        (toConv ((IsScalarTower.toAlgHom R A (LaurentPolynomial A)).comp g.ofConv)).ofConv)
-      (b.baseChange (LaurentPolynomial A))]
-    simp only [Comodule.toMatrix_endOfPoint, G, C, Matrix.map_map]
-    congr 2
+    let f := IsScalarTower.toAlgHom R A (LaurentPolynomial A)
+    have hf : (f : A →+* LaurentPolynomial A) = LaurentPolynomial.C := by
+      apply RingHom.ext
+      intro a
+      exact (LaurentPolynomial.C_eq_algebraMap a).symm
+    calc
+      (P.map Polynomial.toLaurent).charpoly =
+          (C.map (conjugate A l g).ofConv).charpoly := congrArg Matrix.charpoly hLaurentMatrix
+      _ = (Comodule.endOfPoint M (conjugate A l g).ofConv).charpoly := by
+        rw [← Comodule.toMatrix_endOfPoint b, LinearMap.charpoly_toMatrix]
+      _ = (Comodule.endOfPoint M (constPoint A g).ofConv).charpoly := by
+        rw [conjugate_apply, charpoly_conjugate]
+      _ = (Comodule.endOfPoint M (f.comp g.ofConv)).charpoly := by rw [constPoint_apply]
+      _ = (Comodule.endOfPoint M g.ofConv).charpoly.map f :=
+        charpoly_endOfPoint_comp M b g.ofConv f
+      _ = G.charpoly.map LaurentPolynomial.C := by
+        rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange A),
+          Comodule.toMatrix_endOfPoint, hf]
+      _ = (G.map LaurentPolynomial.C).charpoly := by rw [Matrix.charpoly_map]
   have hpolyCharpoly : P.charpoly = G.charpoly.map Polynomial.C := by
     apply Polynomial.map_injective _ Polynomial.toLaurent_injective
     calc

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
@@ -50,7 +50,7 @@ noncomputable section
 
 variable {R : Type u} {H : Type v} {A : Type w}
 variable [Field R] [Semiring H] [_root_.HopfAlgebra R H]
-variable [Field A] [Algebra R A]
+variable [CommRing A] [Algebra R A]
 
 private theorem charpoly_conjugate {B : Type w} [CommRing B] [Algebra R B]
     (M : FGComoduleCat.{u, v, u} R H) (x y : WithConv (H →ₐ[R] B)) :
@@ -74,7 +74,7 @@ private theorem charpoly_endOfPoint_comp {B D : Type w} [CommRing B] [Algebra R 
     Matrix.map_map]
   apply congrArg Matrix.charpoly
   ext i j
-  rfl
+  simp [Matrix.map_apply]
 
 /-- Every point of the dynamic unipotent subgroup attached to a cocharacter is unipotent in
 every finite-dimensional representation. -/
@@ -154,15 +154,26 @@ theorem isUnipotentPoint_of_mem_unipotent
         simp
       _ = (1 : Matrix (Module.Free.ChooseBasisIndex R M)
           (Module.Free.ChooseBasisIndex R M) A).charpoly := hzeroCharpoly
-  apply (LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly_eq _).2
   have hcoe :
       ((LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
           LinearMap.GeneralLinearGroup A (A ⊗[R] M)) : Module.End A (A ⊗[R] M)) =
         Comodule.endOfPoint M g.ofConv := by
     exact Comodule.pointsAction_toLinearMap M g
-  rw [hcoe, ← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange A),
-    Comodule.toMatrix_endOfPoint, hGCharpoly, Matrix.charpoly_one,
-    ← Module.finrank_eq_card_basis (b.baseChange A)]
+  rw [LinearMap.GeneralLinearGroup.isUnipotent_def, hcoe]
+  have hEndCharpoly :
+      (Comodule.endOfPoint M g.ofConv).charpoly =
+        (Polynomial.X - 1) ^ Fintype.card (Module.Free.ChooseBasisIndex R M) := by
+    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange A),
+      Comodule.toMatrix_endOfPoint, hGCharpoly, Matrix.charpoly_one]
+  have hnilCharpoly :
+      (Comodule.endOfPoint M g.ofConv - 1).charpoly =
+        Polynomial.X ^ Fintype.card (Module.Free.ChooseBasisIndex R M) := by
+    have hchar := LinearMap.charpoly_sub_smul (Comodule.endOfPoint M g.ofConv) (1 : A)
+    rw [hEndCharpoly] at hchar
+    simpa using hchar
+  refine ⟨Fintype.card (Module.Free.ChooseBasisIndex R M), ?_⟩
+  rw [← @Polynomial.aeval_X_pow A, ← hnilCharpoly,
+    LinearMap.aeval_self_charpoly]
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Dynamic.Parabolic
+public import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
+public import Mathlib.LinearAlgebra.Charpoly.ToMatrix
+
+/-!
+# Unipotence of the dynamic unipotent subgroup
+
+For a cocharacter `l : 𝔾ₘ → G`, the dynamic subgroup `U(l)` consists of the points whose
+conjugates by `l(t)` extend to `t = 0` with limit one. This file proves that these points are
+unipotent in the representation-theoretic sense: they act unipotently in every finite-dimensional
+comodule.
+
+The proof applies a representation to the extending polynomial family. Over the Laurent
+polynomials the family is conjugate to the original action, so its characteristic polynomial is
+constant. At the origin the family is the identity, hence that constant is `(X - 1) ^ n`.
+
+## Main declaration
+
+* `TauCeti.Cocharacter.isUnipotentPoint_of_mem_unipotent`: every point of the dynamic unipotent
+  subgroup is a unipotent point.
+
+## References
+
+* G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
+* B. Conrad, O. Gabber, G. Prasad, *Pseudo-reductive Groups*, §2.1.
+
+This completes the pointwise unipotence assertion implicit in the dynamic route to parabolic and
+Levi subgroups in Layer 7 of the ReductiveGroups roadmap, using the representation-theoretic
+definition from Layer 5.
+-/
+
+public section
+
+open Module Polynomial WithConv
+open scoped TensorProduct
+
+namespace TauCeti.Cocharacter
+
+universe u v w
+
+noncomputable section
+
+variable {R : Type u} {H : Type v} {A : Type w}
+variable [Field R] [Semiring H] [_root_.HopfAlgebra R H]
+variable [Field A] [Algebra R A]
+
+private theorem charpoly_conjugate {B : Type w} [CommRing B] [Algebra R B]
+    (M : FGComoduleCat.{u, v, u} R H) (x y : WithConv (H →ₐ[R] B)) :
+    (Comodule.endOfPoint M (x * y * x⁻¹).ofConv).charpoly =
+      (Comodule.endOfPoint M y.ofConv).charpoly := by
+  have hEnd : Comodule.endOfPoint M (x * y * x⁻¹).ofConv =
+      (Comodule.pointsAction M x).conj (Comodule.endOfPoint M y.ofConv) := by
+    rw [← Comodule.pointsAction_toLinearMap M]
+    ext z
+    simp [LinearEquiv.conj_apply, Comodule.pointsAction_toLinearMap]
+  rw [hEnd, LinearEquiv.charpoly_conj]
+
+/-- Every point of the dynamic unipotent subgroup attached to a cocharacter is unipotent in
+every finite-dimensional representation. -/
+theorem isUnipotentPoint_of_mem_unipotent
+    (l : H →ₐc[R] LaurentPolynomial R) {g : WithConv (H →ₐ[R] A)}
+    (hg : g ∈ unipotent A l) : HopfAlgebra.IsUnipotentPoint g := by
+  rw [HopfAlgebra.isUnipotentPoint_def]
+  intro M
+  obtain ⟨hgP, hlimit⟩ := mem_unipotent_iff.mp hg
+  let E := extend A l ⟨g, hgP⟩
+  let b := Module.Free.chooseBasis R M
+  let C := Comodule.coefficientMatrix (C := H) b
+  let P : Matrix (Module.Free.ChooseBasisIndex R M) (Module.Free.ChooseBasisIndex R M)
+      (Polynomial A) := C.map E.ofConv
+  let G : Matrix (Module.Free.ChooseBasisIndex R M) (Module.Free.ChooseBasisIndex R M) A :=
+    C.map g.ofConv
+  have hzeroPoint : evalZeroPoint A E = 1 := by
+    simpa only [E, limit_apply] using hlimit
+  have hzeroMatrix : P.map (Polynomial.evalRingHom (0 : A)) = 1 := by
+    calc
+      P.map (Polynomial.evalRingHom (0 : A)) =
+          C.map (evalZeroPoint A E).ofConv := by
+        ext i j
+        simp [P, C, evalZeroPoint_apply, Matrix.map_apply]
+      _ = C.map (1 : WithConv (H →ₐ[R] A)).ofConv := by rw [hzeroPoint]
+      _ = 1 := by
+        rw [← Comodule.toMatrix_endOfPoint b]
+        simp
+  have hLaurentMatrix :
+      P.map Polynomial.toLaurent =
+        C.map (conjugate A l g).ofConv := by
+    calc
+      P.map Polynomial.toLaurent = C.map (ofPolyPoint A E).ofConv := by
+        ext i j
+        simp [P, C, ofPolyPoint_apply, Matrix.map_apply]
+      _ = C.map (conjugate A l g).ofConv := by rw [ofPolyPoint_extend]
+  have hLaurentCharpoly :
+      (P.map Polynomial.toLaurent).charpoly =
+        (G.map LaurentPolynomial.C).charpoly := by
+    rw [hLaurentMatrix]
+    rw [← Comodule.toMatrix_endOfPoint b]
+    rw [LinearMap.charpoly_toMatrix]
+    rw [conjugate_apply, charpoly_conjugate]
+    rw [constPoint_apply]
+    rw [← LinearMap.charpoly_toMatrix
+      (Comodule.endOfPoint M
+        (toConv ((IsScalarTower.toAlgHom R A (LaurentPolynomial A)).comp g.ofConv)).ofConv)
+      (b.baseChange (LaurentPolynomial A))]
+    simp only [Comodule.toMatrix_endOfPoint, G, C, Matrix.map_map]
+    congr 2
+  have hpolyCharpoly : P.charpoly = G.charpoly.map Polynomial.C := by
+    apply Polynomial.map_injective _ Polynomial.toLaurent_injective
+    calc
+      P.charpoly.map Polynomial.toLaurent =
+          G.charpoly.map LaurentPolynomial.C := by
+        simpa only [Matrix.charpoly_map] using hLaurentCharpoly
+      _ = (G.charpoly.map Polynomial.C).map Polynomial.toLaurent := by
+        ext n
+        simp
+  have hGCharpoly : G.charpoly =
+      (1 : Matrix (Module.Free.ChooseBasisIndex R M)
+        (Module.Free.ChooseBasisIndex R M) A).charpoly := by
+    have hzeroCharpoly := congrArg Matrix.charpoly hzeroMatrix
+    rw [Matrix.charpoly_map, hpolyCharpoly, Polynomial.map_map] at hzeroCharpoly
+    calc
+      G.charpoly = G.charpoly.map
+          ((Polynomial.evalRingHom (0 : A)).comp Polynomial.C) := by
+        ext n
+        simp
+      _ = (1 : Matrix (Module.Free.ChooseBasisIndex R M)
+          (Module.Free.ChooseBasisIndex R M) A).charpoly := hzeroCharpoly
+  apply (LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly_eq _).2
+  have hcoe :
+      ((LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
+          LinearMap.GeneralLinearGroup A (A ⊗[R] M)) : Module.End A (A ⊗[R] M)) =
+        Comodule.endOfPoint M g.ofConv := by
+    exact Comodule.pointsAction_toLinearMap M g
+  rw [hcoe, ← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange A),
+    Comodule.toMatrix_endOfPoint, hGCharpoly, Matrix.charpoly_one,
+    ← Module.finrank_eq_card_basis (b.baseChange A)]
+
+end
+
+end TauCeti.Cocharacter

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean
@@ -159,21 +159,18 @@ theorem isUnipotentPoint_of_mem_unipotent
           LinearMap.GeneralLinearGroup A (A ⊗[R] M)) : Module.End A (A ⊗[R] M)) =
         Comodule.endOfPoint M g.ofConv := by
     exact Comodule.pointsAction_toLinearMap M g
-  rw [LinearMap.GeneralLinearGroup.isUnipotent_def, hcoe]
   have hEndCharpoly :
       (Comodule.endOfPoint M g.ofConv).charpoly =
         (Polynomial.X - 1) ^ Fintype.card (Module.Free.ChooseBasisIndex R M) := by
     rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv) (b.baseChange A),
       Comodule.toMatrix_endOfPoint, hGCharpoly, Matrix.charpoly_one]
-  have hnilCharpoly :
-      (Comodule.endOfPoint M g.ofConv - 1).charpoly =
-        Polynomial.X ^ Fintype.card (Module.Free.ChooseBasisIndex R M) := by
-    have hchar := LinearMap.charpoly_sub_smul (Comodule.endOfPoint M g.ofConv) (1 : A)
-    rw [hEndCharpoly] at hchar
-    simpa using hchar
-  refine ⟨Fintype.card (Module.Free.ChooseBasisIndex R M), ?_⟩
-  rw [← @Polynomial.aeval_X_pow A, ← hnilCharpoly,
-    LinearMap.aeval_self_charpoly]
+  have hActionCharpoly :
+      ((LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g) :
+          LinearMap.GeneralLinearGroup A (A ⊗[R] M)) : Module.End A (A ⊗[R] M)).charpoly =
+        (Polynomial.X - 1) ^ Fintype.card (Module.Free.ChooseBasisIndex R M) := by
+    rw [hcoe]
+    exact hEndCharpoly
+  exact LinearMap.GeneralLinearGroup.isUnipotent_of_charpoly_eq _ hActionCharpoly
 
 end
 

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
@@ -33,8 +33,8 @@ Products require commutativity. Indeed, writing `g = 1 + x` and `h = 1 + y`, the
 * `LinearMap.GeneralLinearGroup.IsUnipotent`: a linear automorphism is unipotent when its
   difference from the identity is nilpotent.
 * `LinearMap.GeneralLinearGroup.isUnipotent_def`: the defining nilpotence criterion.
-* `LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly_eq`: the characteristic-polynomial
-  criterion over a field.
+* `LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly`: the characteristic-polynomial
+  criterion over an integral domain.
 * `LinearMap.GeneralLinearGroup.isUnipotent_one`: the identity automorphism is unipotent.
 * `LinearMap.GeneralLinearGroup.IsUnipotent.inv`: the inverse of a unipotent automorphism is
   unipotent.
@@ -78,11 +78,11 @@ theorem isUnipotent_def (g : GeneralLinearGroup K V) :
     IsUnipotent g ↔ _root_.IsNilpotent ((g : End K V) - 1) :=
   Iff.rfl
 
-/-- Over a field, an automorphism is unipotent exactly when its characteristic polynomial is a
-power of `X - 1`. -/
-theorem isUnipotent_iff_charpoly_eq
-    {F : Type u} {W : Type v} [Field F] [AddCommGroup W] [Module F W]
-    [Module.Finite F W] (g : GeneralLinearGroup F W) :
+/-- Over an integral domain, an automorphism of a finite free module is unipotent exactly when its
+characteristic polynomial is a power of `X - 1`. -/
+theorem isUnipotent_iff_charpoly
+    {F : Type u} {W : Type v} [CommRing F] [IsDomain F] [AddCommGroup W] [Module F W]
+    [Module.Free F W] [Module.Finite F W] (g : GeneralLinearGroup F W) :
     IsUnipotent g ↔
       (g : End F W).charpoly = (Polynomial.X - 1) ^ Module.finrank F W := by
   rw [isUnipotent_def, LinearMap.isNilpotent_iff_charpoly]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.Dimension.Finite
+public import Mathlib.LinearAlgebra.Eigenspace.Zero
 public import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.Algebra.Group.End
 import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
@@ -31,6 +32,8 @@ Products require commutativity. Indeed, writing `g = 1 + x` and `h = 1 + y`, the
 * `LinearMap.GeneralLinearGroup.IsUnipotent`: a linear automorphism is unipotent when its
   difference from the identity is nilpotent.
 * `LinearMap.GeneralLinearGroup.isUnipotent_def`: the defining nilpotence criterion.
+* `LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly_eq`: the characteristic-polynomial
+  criterion over a field.
 * `LinearMap.GeneralLinearGroup.isUnipotent_one`: the identity automorphism is unipotent.
 * `LinearMap.GeneralLinearGroup.IsUnipotent.inv`: the inverse of a unipotent automorphism is
   unipotent.
@@ -73,6 +76,25 @@ identity is nilpotent. -/
 theorem isUnipotent_def (g : GeneralLinearGroup K V) :
     IsUnipotent g ↔ _root_.IsNilpotent ((g : End K V) - 1) :=
   Iff.rfl
+
+/-- Over a field, an automorphism is unipotent exactly when its characteristic polynomial is a
+power of `X - 1`. -/
+theorem isUnipotent_iff_charpoly_eq
+    {F : Type u} {W : Type v} [Field F] [AddCommGroup W] [Module F W]
+    [Module.Finite F W] (g : GeneralLinearGroup F W) :
+    IsUnipotent g ↔
+      (g : End F W).charpoly = (Polynomial.X - 1) ^ Module.finrank F W := by
+  rw [isUnipotent_def, LinearMap.isNilpotent_iff_charpoly]
+  constructor
+  · intro h
+    have hchar := LinearMap.charpoly_sub_smul
+      ((g : End F W) - 1) (-1 : F)
+    rw [h] at hchar
+    simpa [sub_eq_add_neg] using hchar
+  · intro h
+    have hchar := LinearMap.charpoly_sub_smul (g : End F W) (1 : F)
+    rw [h] at hchar
+    simpa using hchar
 
 /-- The identity automorphism is unipotent. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
@@ -33,6 +33,8 @@ Products require commutativity. Indeed, writing `g = 1 + x` and `h = 1 + y`, the
 * `LinearMap.GeneralLinearGroup.IsUnipotent`: a linear automorphism is unipotent when its
   difference from the identity is nilpotent.
 * `LinearMap.GeneralLinearGroup.isUnipotent_def`: the defining nilpotence criterion.
+* `LinearMap.GeneralLinearGroup.isUnipotent_of_charpoly_eq`: the characteristic-polynomial
+  sufficient condition over a commutative ring.
 * `LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly`: the characteristic-polynomial
   criterion over an integral domain.
 * `LinearMap.GeneralLinearGroup.isUnipotent_one`: the identity automorphism is unipotent.
@@ -78,6 +80,23 @@ theorem isUnipotent_def (g : GeneralLinearGroup K V) :
     IsUnipotent g ↔ _root_.IsNilpotent ((g : End K V) - 1) :=
   Iff.rfl
 
+/-- An automorphism of a finite free module over a commutative ring is unipotent if its
+characteristic polynomial is a power of `X - 1`. -/
+theorem isUnipotent_of_charpoly_eq
+    {F : Type u} {W : Type v} [CommRing F] [AddCommGroup W] [Module F W]
+    [Module.Free F W] [Module.Finite F W] (g : GeneralLinearGroup F W) {n : ℕ}
+    (h : (g : End F W).charpoly = (Polynomial.X - 1) ^ n) :
+    IsUnipotent g := by
+  rw [isUnipotent_def]
+  have hchar := LinearMap.charpoly_sub_smul (g : End F W) (1 : F)
+  rw [h] at hchar
+  have hnilCharpoly :
+      ((g : End F W) - 1).charpoly = Polynomial.X ^ n := by
+    simpa using hchar
+  refine ⟨n, ?_⟩
+  rw [← @Polynomial.aeval_X_pow F, ← hnilCharpoly,
+    LinearMap.aeval_self_charpoly]
+
 /-- Over an integral domain, an automorphism of a finite free module is unipotent exactly when its
 characteristic polynomial is a power of `X - 1`. -/
 theorem isUnipotent_iff_charpoly
@@ -85,17 +104,14 @@ theorem isUnipotent_iff_charpoly
     [Module.Free F W] [Module.Finite F W] (g : GeneralLinearGroup F W) :
     IsUnipotent g ↔
       (g : End F W).charpoly = (Polynomial.X - 1) ^ Module.finrank F W := by
-  rw [isUnipotent_def, LinearMap.isNilpotent_iff_charpoly]
   constructor
   · intro h
+    rw [isUnipotent_def, LinearMap.isNilpotent_iff_charpoly] at h
     have hchar := LinearMap.charpoly_sub_smul
       ((g : End F W) - 1) (-1 : F)
     rw [h] at hchar
     simpa [sub_eq_add_neg] using hchar
-  · intro h
-    have hchar := LinearMap.charpoly_sub_smul (g : End F W) (1 : F)
-    rw [h] at hchar
-    simpa using hchar
+  · exact isUnipotent_of_charpoly_eq g
 
 /-- The identity automorphism is unipotent. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
+++ b/TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean
@@ -7,9 +7,10 @@ module
 
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 public import Mathlib.LinearAlgebra.Dimension.Finite
-public import Mathlib.LinearAlgebra.Eigenspace.Zero
+public import Mathlib.LinearAlgebra.Charpoly.Basic
 public import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.Algebra.Group.End
+import Mathlib.LinearAlgebra.Eigenspace.Zero
 import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
 import Mathlib.Tactic.NoncommRing
 


### PR DESCRIPTION
This PR proves that every point of the dynamic subgroup `Cocharacter.unipotent A l` is unipotent in the roadmap's representation-theoretic sense: it acts unipotently in every finite-dimensional comodule. It advances the exact target in `ReductiveGroups/README.md`, Layer 7, “Bruhat decomposition and BN-pairs / Tits systems,” whose dynamic approach to parabolics, Levi subgroups, and unipotent radicals is to proceed in parallel without full root data, and it consumes Layer 5's definition of a unipotent point through `HopfAlgebra.IsUnipotentPoint`.

Apply an arbitrary finite-dimensional comodule to the polynomial family extending `l(t) g l(t)⁻¹`. After localization from `A[X]` to `A[T;T⁻¹]`, its characteristic polynomial is unchanged by conjugation and therefore equals the characteristic polynomial of the original action. Injectivity of `Polynomial.toLaurent` descends this equality to `A[X]`; evaluation at `X = 0`, where membership in the dynamic subgroup says the limit is the identity, forces the characteristic polynomial to be `(X - 1)^n`. The new general criterion `LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly_eq` then converts that equality to nilpotence of the action minus the identity.

This is the most effective distinct next step because the full pointwise Levi decomposition for a cocharacter is already on `main`, but its subgroup named `unipotent` previously had only the kernel-of-limit characterization and no theorem connecting it to the honest Layer 5 notion; without this result the dynamic construction could not supply a unipotent subgroup to later parabolic or BN-pair consumers. After this PR, the dynamic route still needs representability of these subgroup functors by subgroup schemes and, under the appropriate reductive hypotheses, identification of the represented kernel with the unipotent radical of the parabolic.

Add `TauCeti/Algebra/AlgebraicGroup/Dynamic/Unipotent.lean` (148 lines) and extend `TauCeti/LinearAlgebra/GeneralLinearGroup/Unipotent.lean` by 22 lines with the characteristic-polynomial criterion. Reuse Mathlib's `LinearMap.isNilpotent_iff_charpoly`, `LinearMap.charpoly_sub_smul`, `LinearEquiv.charpoly_conj`, `LinearMap.charpoly_toMatrix`, and `Polynomial.toLaurent_injective`; no Mathlib implementation or external formalization is vendored. The dynamic argument follows Kempf, *Instability in invariant theory*, §2, and Conrad–Gabber–Prasad, *Pseudo-reductive Groups*, §2.1, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"dynamic-unipotent-subgroup-is-unipotent"}-->

🤖 Prepared with Codex
