### PR TITLE
feat(EllipticCurve): coordinates of scalar multiplication on the universal curve

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -140,7 +140,7 @@ private lemma smulY_neg_aux {F : Type*} [Field F] {a₁ a₃ x y z : F} (hz : z 
 
 /-- Negating a nonzero index negates the point: `smulY (-n)` is the long-Weierstrass `negY`
 of the coordinates `(smulX n, smulY n)`. -/
-lemma smulY_neg (h0 : n ≠ 0) :
+@[simp] lemma smulY_neg (h0 : n ≠ 0) :
     smulY (-n) = pointedCurve.toAffine.negY (smulX n) (smulY n) := by
   simp only [WeierstrassCurve.Affine.negY, pointedCurve_a₁, pointedCurve_a₃, smulX_def, smulY_def,
     ψ_neg, ω_neg, map_add, map_neg polyToField, map_mul, map_pow]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -45,16 +45,25 @@ Ported from J. Xu and D. K. Angdinata's `projects/NagellLutz/LutzNagell/ZSMul.le
 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`): `smulX` (`:164`), `smulY` (`:168`), the value
 lemmas (`:171`–`:174`), `smulX_eq` (`:176`), `smulX_two` (`:183`), `smulX_sub_smulX` (`:186`),
 `smulX_neg` (`:201`), `smulX_ne_zero` (`:203`), `smulX_ne_smulX` (`:206`),
-`smulX_eq_smulX_iff` (`:217`), and `smulY_neg` with its private field-level auxiliary
-(`:288`–`:291`), pulled forward from the slope slice's range so that `smulY` does not ship
-without its negative-index rule. The source's `ψᵤ` abbreviation is dropped in favour of
-`polyToField (curve.ψ n)`, the `DivisionPolynomial/Universal.lean` convention. Three departures
-beyond the respelling: the elliptic-sequence step of `smulX_sub_smulX` is respelt through
-`IsEllipticNet.rel` and `linear_combination` (the source converts against its
-`isEllSequence_ψᵤ`, a statement shape Mathlib has since replaced); the equation lemmas
-`smulX_def` and `smulY_def` are added for consumers in other modules, as in `Omega.lean`; and
-`smulY_neg` names its ring hom (`map_neg polyToField`) where the source unfolds `ψᵤ`, because
-an unnamed `map_neg` does not fire on a `polyToField` application in this direction.
+`smulX_eq_smulX_iff` (`:217`), and `smulY_neg` (`:290`), pulled forward from the slope slice's
+range so that `smulY` does not ship without its negative-index rule. The source's `ψᵤ`
+abbreviation is dropped in favour of `polyToField (curve.ψ n)`, the
+`DivisionPolynomial/Universal.lean` convention.
+
+Five departures beyond that respelling. The elliptic-sequence step of `smulX_sub_smulX` is
+respelt through `IsEllipticNet.rel` and `linear_combination` (the source converts against its
+`isEllSequence_ψᵤ`, a statement shape Mathlib has since replaced). The equation lemmas
+`smulX_def` and `smulY_def` are added for consumers in other modules, as in `Omega.lean`.
+`smulY_neg` reads its coordinate identity off Mathlib's `Jacobian.negY_of_Z_ne_zero` at
+`(φₙ : ωₙ : ψₙ)` instead of the source's private field-level auxiliary (`:286`), still naming
+its ring hom (`map_neg polyToField`) where the source unfolds `ψᵤ`, because an unnamed
+`map_neg` does not fire on a `polyToField` application in this direction. `smulX_eq` meets that
+same direction problem — the source's forward
+`simp only [φ, ψᵤ, map_sub, map_mul, map_pow, ← add_div]` does not fire here — so it instead
+maps a polynomial-level identity with `congrArg polyToField` and clears the denominator with
+`field_simp` and `linear_combination`. Finally `@[simp]` is added to `smulX_neg`,
+`smulX_ne_zero` and `smulX_eq_smulX_iff`, which the source leaves untagged.
+
 `smulX_sub_sub_smulX_add` (`:196`) is deliberately not ported here: its consumers are the slope
 and addition formulas, and it ships with them.
 -/
@@ -106,11 +115,15 @@ theorem smulY_def (n : ℤ) : smulY n = polyToField (curve.ω n) / polyToField (
 lemma smulX_eq (hn : n ≠ 0) :
     smulX n = smulX 1 - polyToField (curve.ψ (n + 1)) * polyToField (curve.ψ (n - 1)) /
       polyToField (curve.ψ n) ^ 2 := by
+  have hψ : polyToField (curve.ψ n) ≠ 0 := polyToField_ψ_ne_zero hn
   have h : curve.φ n + curve.ψ (n + 1) * curve.ψ (n - 1) = C X * curve.ψ n ^ 2 := by
     rw [WeierstrassCurve.φ]
     ring
-  rw [smulX_def, eq_sub_iff_add_eq, ← add_div, ← map_mul, ← map_add, h,
-    div_eq_iff (pow_ne_zero 2 (polyToField_ψ_ne_zero hn)), smulX_one, ← map_pow, ← map_mul]
+  have hF := congrArg polyToField h
+  simp only [map_add polyToField, map_mul polyToField, map_pow polyToField] at hF
+  rw [smulX_def, smulX_one]
+  field_simp
+  linear_combination hF
 
 /-- `smulX` at `2`, in terms of the `X`-coordinate and `ψ₃/ψ₂²`. -/
 lemma smulX_two : smulX 2 = smulX 1 - polyToField (curve.ψ 3) / polyToField (curve.ψ 2) ^ 2 := by
@@ -132,22 +145,25 @@ lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
 /-- `smulX` is even in `n`. -/
 @[simp] lemma smulX_neg : smulX (-n) = smulX n := by simp [smulX_def, φ_neg, ψ_neg]
 
-private lemma smulY_neg_aux {F : Type*} [Field F] {a₁ a₃ x y z : F} (hz : z ≠ 0) :
-    (y + a₁ * x * z + a₃ * z ^ 3) / (-z) ^ 3 = -(y / z ^ 3) - a₁ * (x / z ^ 2) - a₃ := by
-  rw [neg_pow]
-  field_simp
-  ring
-
 /-- Negating a nonzero index negates the point: `smulY (-n)` is the long-Weierstrass `negY`
 of the coordinates `(smulX n, smulY n)`. -/
 @[simp] lemma smulY_neg (h0 : n ≠ 0) :
     smulY (-n) = pointedCurve.toAffine.negY (smulX n) (smulY n) := by
-  simp only [WeierstrassCurve.Affine.negY, pointedCurve_a₁, pointedCurve_a₃, smulX_def, smulY_def,
-    ψ_neg, ω_neg, map_add, map_neg polyToField, map_mul, map_pow]
-  exact smulY_neg_aux (polyToField_ψ_ne_zero h0)
+  -- The identity is Mathlib's Jacobian-to-affine `negY` formula at `(φₙ : ωₙ : ψₙ)`.
+  have key := WeierstrassCurve.Jacobian.negY_of_Z_ne_zero (W := pointedCurve)
+    (P := ![polyToField (curve.φ n), polyToField (curve.ω n), polyToField (curve.ψ n)])
+    (by simpa using polyToField_ψ_ne_zero h0)
+  simp only [WeierstrassCurve.Jacobian.negY_eq, pointedCurve_a₁, pointedCurve_a₃,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two,
+    Matrix.tail_cons] at key
+  refine .trans ?_ key
+  -- `ω_neg` negates the numerator and `ψ_neg` the denominator's cube, so the signs cancel.
+  rw [smulY_def, ψ_neg, ω_neg]
+  simp only [map_add polyToField, map_mul polyToField, map_pow polyToField, map_neg polyToField]
+  ring
 
 /-- `smulX n` is nonzero for `n ≠ 0`. -/
-lemma smulX_ne_zero (h0 : n ≠ 0) : smulX n ≠ 0 :=
+@[simp] lemma smulX_ne_zero (h0 : n ≠ 0) : smulX n ≠ 0 :=
   div_ne_zero polyToField_φ_ne_zero (pow_ne_zero _ <| polyToField_ψ_ne_zero h0)
 
 /-- `smulX` separates indices that agree in neither order nor sign. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Omega
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Universal
 
 /-!
@@ -18,7 +17,8 @@ elements of `Universal.Field`. This file defines those two rational functions, `
 development, not here — and develops the `smulX` calculus that identification consumes: values
 at `0`, `1` and `2`, the offset `ψₙ₊₁ψₙ₋₁/ψₙ²` from the `X`-coordinate, evenness in `n`,
 nonvanishing, the difference `smulX m - smulX n` as a single quotient, and the separation
-statement `smulX m = smulX n ↔ m = n ∨ m = -n`.
+statement `smulX m = smulX n ↔ m = n ∨ m = -n`. `smulY`'s own negative-index rule is here too:
+a negative index negates the point, so `smulY (-n)` is the `negY` of `(smulX n, smulY n)`.
 
 ## Main definitions
 
@@ -34,6 +34,8 @@ statement `smulX m = smulX n ↔ m = n ∨ m = -n`.
 * `WeierstrassCurve.Universal.Affine.smulX_ne_zero`: `smulX n ≠ 0` for `n ≠ 0`.
 * `WeierstrassCurve.Universal.Affine.smulX_eq_smulX_iff`: `smulX m = smulX n ↔ m = n ∨ m = -n`,
   the field-level form of the fact that `x`-coordinates separate multiples up to sign.
+* `WeierstrassCurve.Universal.Affine.smulY_neg`: `smulY (-n)` is the `negY` of the coordinates
+  at `n` — the long-Weierstrass correction that `ω_neg` carries, read in the universal field.
 
 ## Provenance
 
@@ -41,13 +43,17 @@ Ported from J. Xu and D. K. Angdinata's `projects/NagellLutz/LutzNagell/ZSMul.le
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @
 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`): `smulX` (`:164`), `smulY` (`:168`), the value
 lemmas (`:171`–`:174`), `smulX_eq` (`:176`), `smulX_two` (`:183`), `smulX_sub_smulX` (`:186`),
-`smulX_neg` (`:201`), `smulX_ne_zero` (`:203`), `smulX_ne_smulX` (`:206`) and
-`smulX_eq_smulX_iff` (`:217`). The source's `ψᵤ` abbreviation is dropped in favour of
-`polyToField (curve.ψ n)`, the `DivisionPolynomial/Universal.lean` convention. Two departures
+`smulX_neg` (`:201`), `smulX_ne_zero` (`:203`), `smulX_ne_smulX` (`:206`),
+`smulX_eq_smulX_iff` (`:217`), and `smulY_neg` with its private field-level auxiliary
+(`:288`–`:291`), pulled forward from the slope slice's range so that `smulY` does not ship
+without its negative-index rule. The source's `ψᵤ` abbreviation is dropped in favour of
+`polyToField (curve.ψ n)`, the `DivisionPolynomial/Universal.lean` convention. Three departures
 beyond the respelling: the elliptic-sequence step of `smulX_sub_smulX` is respelt through
 `IsEllipticNet.rel` and `linear_combination` (the source converts against its
-`isEllSequence_ψᵤ`, a statement shape Mathlib has since replaced), and the equation lemmas
-`smulX_def` and `smulY_def` are added for consumers in other modules, as in `Omega.lean`.
+`isEllSequence_ψᵤ`, a statement shape Mathlib has since replaced); the equation lemmas
+`smulX_def` and `smulY_def` are added for consumers in other modules, as in `Omega.lean`; and
+`smulY_neg` names its ring hom (`map_neg polyToField`) where the source unfolds `ψᵤ`, because
+an unnamed `map_neg` does not fire on a `polyToField` application in this direction.
 `smulX_sub_sub_smulX_add` (`:196`) is deliberately not ported here: its consumers are the slope
 and addition formulas, and it ships with them.
 -/
@@ -123,7 +129,21 @@ lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
   linear_combination -key
 
 /-- `smulX` is even in `n`. -/
-lemma smulX_neg : smulX (-n) = smulX n := by simp [smulX_def, φ_neg, ψ_neg]
+@[simp] lemma smulX_neg : smulX (-n) = smulX n := by simp [smulX_def, φ_neg, ψ_neg]
+
+private lemma smulY_neg_aux {F : Type*} [Field F] {a₁ a₃ x y z : F} (hz : z ≠ 0) :
+    (y + a₁ * x * z + a₃ * z ^ 3) / (-z) ^ 3 = -(y / z ^ 3) - a₁ * (x / z ^ 2) - a₃ := by
+  rw [neg_pow]
+  field_simp
+  ring
+
+/-- `smulY` at a negative index is the negation of the point at the positive one: the
+long-Weierstrass `negY` of the coordinates `(smulX n, smulY n)`. -/
+lemma smulY_neg (h0 : n ≠ 0) :
+    smulY (-n) = pointedCurve.toAffine.negY (smulX n) (smulY n) := by
+  simp only [WeierstrassCurve.Affine.negY, pointedCurve_a₁, pointedCurve_a₃, smulX_def, smulY_def,
+    ψ_neg, ω_neg, map_add, map_neg polyToField, map_mul, map_pow]
+  exact smulY_neg_aux (polyToField_ψ_ne_zero h0)
 
 /-- `smulX n` is nonzero for `n ≠ 0`. -/
 lemma smulX_ne_zero (h0 : n ≠ 0) : smulX n ≠ 0 :=
@@ -140,7 +160,7 @@ lemma smulX_ne_smulX (ne : m ≠ n) (ne_neg : m ≠ -n) : smulX m ≠ smulX n :=
     apply polyToField_ψ_ne_zero <;> omega
 
 /-- Two values of `smulX` agree exactly when the indices agree up to sign. -/
-lemma smulX_eq_smulX_iff : smulX m = smulX n ↔ m = n ∨ m = -n := by
+@[simp] lemma smulX_eq_smulX_iff : smulX m = smulX n ↔ m = n ∨ m = -n := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · contrapose! h
     exact smulX_ne_smulX h.1 h.2

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -17,8 +17,8 @@ elements of `Universal.Field`. This file defines those two rational functions, `
 development, not here — and develops the `smulX` calculus that identification consumes: values
 at `0`, `1` and `2`, the offset `ψₙ₊₁ψₙ₋₁/ψₙ²` from the `X`-coordinate, evenness in `n`,
 nonvanishing, the difference `smulX m - smulX n` as a single quotient, and the separation
-statement `smulX m = smulX n ↔ m = n ∨ m = -n`. `smulY`'s own negative-index rule is here too:
-a negative index negates the point, so `smulY (-n)` is the `negY` of `(smulX n, smulY n)`.
+statement `smulX m = smulX n ↔ m = n ∨ m = -n`. `smulY`'s own sign rule is here too: negating
+a nonzero index negates the point, so `smulY (-n)` is the `negY` of `(smulX n, smulY n)`.
 
 ## Main definitions
 
@@ -34,8 +34,9 @@ a negative index negates the point, so `smulY (-n)` is the `negY` of `(smulX n, 
 * `WeierstrassCurve.Universal.Affine.smulX_ne_zero`: `smulX n ≠ 0` for `n ≠ 0`.
 * `WeierstrassCurve.Universal.Affine.smulX_eq_smulX_iff`: `smulX m = smulX n ↔ m = n ∨ m = -n`,
   the field-level form of the fact that `x`-coordinates separate multiples up to sign.
-* `WeierstrassCurve.Universal.Affine.smulY_neg`: `smulY (-n)` is the `negY` of the coordinates
-  at `n` — the long-Weierstrass correction that `ω_neg` carries, read in the universal field.
+* `WeierstrassCurve.Universal.Affine.smulY_neg`: for `n ≠ 0`, `smulY (-n)` is the `negY` of the
+  coordinates at `n` — the long-Weierstrass correction that `ω_neg` carries, in the universal
+  field.
 
 ## Provenance
 
@@ -137,8 +138,8 @@ private lemma smulY_neg_aux {F : Type*} [Field F] {a₁ a₃ x y z : F} (hz : z 
   field_simp
   ring
 
-/-- `smulY` at a negative index is the negation of the point at the positive one: the
-long-Weierstrass `negY` of the coordinates `(smulX n, smulY n)`. -/
+/-- Negating a nonzero index negates the point: `smulY (-n)` is the long-Weierstrass `negY`
+of the coordinates `(smulX n, smulY n)`. -/
 lemma smulY_neg (h0 : n ≠ 0) :
     smulY (-n) = pointedCurve.toAffine.negY (smulX n) (smulY n) := by
   simp only [WeierstrassCurve.Affine.negY, pointedCurve_a₁, pointedCurve_a₃, smulX_def, smulY_def,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Omega
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Universal
+
+/-!
+# Coordinates of scalar multiplication on the universal curve
+
+The Nagell–Lutz route expresses `n • (X, Y)` on the universal curve through the division
+polynomials: the affine `X`-coordinate is `φₙ/ψₙ²` and the `Y`-coordinate is `ωₙ/ψₙ³`, as
+elements of `Universal.Field`. This file defines those two rational functions, `smulX` and
+`smulY` — the identification with `n • point` itself is proved in the scalar-multiplication
+development, not here — and develops the `smulX` calculus that identification consumes: values
+at `0`, `1` and `2`, evenness in `n`, nonvanishing, the difference `smulX m - smulX n` as a
+single quotient, and the separation statement `smulX m = smulX n ↔ m = n ∨ m = -n`.
+
+## Main definitions
+
+* `WeierstrassCurve.Universal.Affine.smulX`: the rational function `φₙ/ψₙ²`.
+* `WeierstrassCurve.Universal.Affine.smulY`: the rational function `ωₙ/ψₙ³`.
+
+## Main results
+
+* `WeierstrassCurve.Universal.Affine.smulX_sub_smulX`: `smulX m - smulX n` as a single
+  quotient, by the elliptic-sequence relation of the universal `ψ` family.
+* `WeierstrassCurve.Universal.Affine.smulX_ne_zero`: `smulX n ≠ 0` for `n ≠ 0`.
+* `WeierstrassCurve.Universal.Affine.smulX_eq_smulX_iff`: `smulX m = smulX n ↔ m = n ∨ m = -n`,
+  the field-level form of the fact that `x`-coordinates separate multiples up to sign.
+
+## Provenance
+
+Ported from J. Xu and D. K. Angdinata's `projects/NagellLutz/LutzNagell/ZSMul.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @
+1c1c74664e40071c2c2165bc55ca2616a67ccd6b`): `smulX` (`:164`), `smulY` (`:168`), the value
+lemmas (`:171`–`:174`), `smulX_eq` (`:176`), `smulX_two` (`:183`), `smulX_sub_smulX` (`:186`),
+`smulX_neg` (`:201`), `smulX_ne_zero` (`:203`), `smulX_ne_smulX` (`:206`) and
+`smulX_eq_smulX_iff` (`:217`). The source's `ψᵤ` abbreviation is dropped in favour of
+`polyToField (curve.ψ n)`, the `DivisionPolynomial/Universal.lean` convention. Two departures
+beyond the respelling: the elliptic-sequence step of `smulX_sub_smulX` is respelt through
+`IsEllipticNet.rel` and `linear_combination` (the source converts against its
+`isEllSequence_ψᵤ`, a statement shape Mathlib has since replaced), and the equation lemmas
+`smulX_def` and `smulY_def` are added for consumers in other modules, as in `Omega.lean`.
+`smulX_sub_sub_smulX_add` (`:196`) is deliberately not ported here: its consumers are the slope
+and addition formulas, and it ships with them.
+-/
+
+public section
+
+noncomputable section
+
+open Polynomial
+open scoped Polynomial.Bivariate
+
+namespace WeierstrassCurve.Universal.Affine
+
+variable {m n : ℤ}
+
+/-- The rational function `φₙ/ψₙ²` in the universal field, which the scalar-multiplication
+development identifies as the affine `X`-coordinate of `n • (X, Y)` on the universal curve —
+that identification is proved there, not here. -/
+def smulX (n : ℤ) : Universal.Field :=
+  polyToField (curve.φ n) / polyToField (curve.ψ n) ^ 2
+
+/-- The rational function `ωₙ/ψₙ³` in the universal field, which the scalar-multiplication
+development identifies as the affine `Y`-coordinate of `n • (X, Y)` on the universal curve —
+that identification is proved there, not here. -/
+def smulY (n : ℤ) : Universal.Field :=
+  polyToField (curve.ω n) / polyToField (curve.ψ n) ^ 3
+
+/-- The defining formula for `smulX`. The definition body is not exposed, so this equation
+lemma is how a consumer in another module computes with it. -/
+theorem smulX_def (n : ℤ) :
+    smulX n = polyToField (curve.φ n) / polyToField (curve.ψ n) ^ 2 := (rfl)
+
+/-- The defining formula for `smulY`. The definition body is not exposed, so this equation
+lemma is how a consumer in another module computes with it. -/
+theorem smulY_def (n : ℤ) :
+    smulY n = polyToField (curve.ω n) / polyToField (curve.ψ n) ^ 3 := (rfl)
+
+/-- `smulX` at `0` is `0`. -/
+@[simp] lemma smulX_zero : smulX 0 = 0 := by simp [smulX_def]
+
+/-- `smulY` at `0` is `0`. -/
+@[simp] lemma smulY_zero : smulY 0 = 0 := by simp [smulY_def]
+
+/-- `smulX` at `1` is the `X`-coordinate itself. -/
+@[simp] lemma smulX_one : smulX 1 = polyToField (C X) := by simp [smulX_def]
+
+/-- `smulY` at `1` is the `Y`-coordinate itself. -/
+@[simp] lemma smulY_one : smulY 1 = polyToField Y := by simp [smulY_def]
+
+/-- `smulX n` differs from the `X`-coordinate by `ψₙ₊₁ψₙ₋₁/ψₙ²`. -/
+lemma smulX_eq (hn : n ≠ 0) :
+    smulX n = smulX 1 -
+      polyToField (curve.ψ (n + 1)) * polyToField (curve.ψ (n - 1)) /
+        polyToField (curve.ψ n) ^ 2 := by
+  have h : curve.φ n + curve.ψ (n + 1) * curve.ψ (n - 1) = C X * curve.ψ n ^ 2 := by
+    rw [WeierstrassCurve.φ]
+    ring
+  rw [smulX_def, eq_sub_iff_add_eq, ← add_div, ← map_mul, ← map_add, h,
+    div_eq_iff (pow_ne_zero 2 (polyToField_ψ_ne_zero hn)), smulX_one, ← map_pow, ← map_mul]
+
+/-- `smulX` at `2`, in terms of the `X`-coordinate and `ψ₃/ψ₂²`. -/
+lemma smulX_two :
+    smulX 2 = smulX 1 - polyToField (curve.ψ 3) / polyToField (curve.ψ 2) ^ 2 := by
+  simp [smulX_eq two_ne_zero]
+
+/-- The difference of two values of `smulX` as a single quotient: the numerator is
+`ψₙ₊ₘψₙ₋ₘ`, by the elliptic-sequence relation of the universal `ψ` family. -/
+lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
+    smulX m - smulX n =
+      polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m)) /
+        (polyToField (curve.ψ n) * polyToField (curve.ψ m)) ^ 2 := by
+  have key := isEllipticSequence_polyToField_ψ n m 1
+  simp only [IsEllipticNet.rel, add_zero, ψ_one, map_one, mul_one] at key
+  rw [smulX_eq hm, smulX_eq hn, sub_sub_sub_cancel_left,
+    div_sub_div _ _ (pow_ne_zero 2 (polyToField_ψ_ne_zero hn))
+      (pow_ne_zero 2 (polyToField_ψ_ne_zero hm)), mul_pow]
+  congr 1
+  linear_combination -key
+
+/-- `smulX` is even in `n`. -/
+lemma smulX_neg : smulX (-n) = smulX n := by
+  have h : curve.ψ (-n) ^ 2 = curve.ψ n ^ 2 := by
+    rw [ψ_neg]
+    ring
+  rw [smulX_def, smulX_def, φ_neg, ← map_pow, ← map_pow, h]
+
+/-- `smulX n` is nonzero for `n ≠ 0`. -/
+lemma smulX_ne_zero (h0 : n ≠ 0) : smulX n ≠ 0 :=
+  div_ne_zero polyToField_φ_ne_zero (pow_ne_zero _ <| polyToField_ψ_ne_zero h0)
+
+/-- `smulX` separates indices that agree in neither order nor sign. -/
+lemma smulX_ne_smulX (ne : m ≠ n) (ne_neg : m ≠ -n) : smulX m ≠ smulX n := by
+  obtain rfl | hm := eq_or_ne m 0
+  · rw [smulX_zero]
+    exact (smulX_ne_zero ne.symm).symm
+  obtain rfl | hn := eq_or_ne n 0
+  · rw [smulX_zero]
+    exact smulX_ne_zero ne
+  rw [← sub_ne_zero, smulX_sub_smulX hm hn]
+  rw [ne_comm, ← sub_ne_zero] at ne
+  rw [Ne, ← add_eq_zero_iff_eq_neg, add_comm] at ne_neg
+  refine div_ne_zero (mul_ne_zero ?_ ?_) (pow_ne_zero _ <| mul_ne_zero ?_ ?_) <;>
+    apply polyToField_ψ_ne_zero <;> assumption
+
+/-- Two values of `smulX` agree exactly when the indices agree up to sign. -/
+lemma smulX_eq_smulX_iff : smulX m = smulX n ↔ m = n ∨ m = -n := by
+  refine ⟨fun h ↦ ?_, ?_⟩
+  · contrapose! h
+    exact smulX_ne_smulX h.1 h.2
+  · rintro (rfl | rfl)
+    exacts [rfl, smulX_neg]
+
+end WeierstrassCurve.Universal.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -16,8 +16,9 @@ polynomials: the affine `X`-coordinate is `φₙ/ψₙ²` and the `Y`-coordinate
 elements of `Universal.Field`. This file defines those two rational functions, `smulX` and
 `smulY` — the identification with `n • point` itself is proved in the scalar-multiplication
 development, not here — and develops the `smulX` calculus that identification consumes: values
-at `0`, `1` and `2`, evenness in `n`, nonvanishing, the difference `smulX m - smulX n` as a
-single quotient, and the separation statement `smulX m = smulX n ↔ m = n ∨ m = -n`.
+at `0`, `1` and `2`, the offset `ψₙ₊₁ψₙ₋₁/ψₙ²` from the `X`-coordinate, evenness in `n`,
+nonvanishing, the difference `smulX m - smulX n` as a single quotient, and the separation
+statement `smulX m = smulX n ↔ m = n ∨ m = -n`.
 
 ## Main definitions
 
@@ -26,6 +27,8 @@ single quotient, and the separation statement `smulX m = smulX n ↔ m = n ∨ m
 
 ## Main results
 
+* `WeierstrassCurve.Universal.Affine.smulX_eq`: `smulX n = smulX 1 - ψₙ₊₁ψₙ₋₁/ψₙ²` for `n ≠ 0`,
+  the offset from the `X`-coordinate that `smulX_two` and `smulX_sub_smulX` both run through.
 * `WeierstrassCurve.Universal.Affine.smulX_sub_smulX`: `smulX m - smulX n` as a single
   quotient, by the elliptic-sequence relation of the universal `ψ` family.
 * `WeierstrassCurve.Universal.Affine.smulX_ne_zero`: `smulX n ≠ 0` for `n ≠ 0`.
@@ -74,13 +77,11 @@ def smulY (n : ℤ) : Universal.Field :=
 
 /-- The defining formula for `smulX`. The definition body is not exposed, so this equation
 lemma is how a consumer in another module computes with it. -/
-theorem smulX_def (n : ℤ) :
-    smulX n = polyToField (curve.φ n) / polyToField (curve.ψ n) ^ 2 := (rfl)
+theorem smulX_def (n : ℤ) : smulX n = polyToField (curve.φ n) / polyToField (curve.ψ n) ^ 2 := (rfl)
 
 /-- The defining formula for `smulY`. The definition body is not exposed, so this equation
 lemma is how a consumer in another module computes with it. -/
-theorem smulY_def (n : ℤ) :
-    smulY n = polyToField (curve.ω n) / polyToField (curve.ψ n) ^ 3 := (rfl)
+theorem smulY_def (n : ℤ) : smulY n = polyToField (curve.ω n) / polyToField (curve.ψ n) ^ 3 := (rfl)
 
 /-- `smulX` at `0` is `0`. -/
 @[simp] lemma smulX_zero : smulX 0 = 0 := by simp [smulX_def]
@@ -96,9 +97,8 @@ theorem smulY_def (n : ℤ) :
 
 /-- `smulX n` differs from the `X`-coordinate by `ψₙ₊₁ψₙ₋₁/ψₙ²`. -/
 lemma smulX_eq (hn : n ≠ 0) :
-    smulX n = smulX 1 -
-      polyToField (curve.ψ (n + 1)) * polyToField (curve.ψ (n - 1)) /
-        polyToField (curve.ψ n) ^ 2 := by
+    smulX n = smulX 1 - polyToField (curve.ψ (n + 1)) * polyToField (curve.ψ (n - 1)) /
+      polyToField (curve.ψ n) ^ 2 := by
   have h : curve.φ n + curve.ψ (n + 1) * curve.ψ (n - 1) = C X * curve.ψ n ^ 2 := by
     rw [WeierstrassCurve.φ]
     ring
@@ -106,16 +106,14 @@ lemma smulX_eq (hn : n ≠ 0) :
     div_eq_iff (pow_ne_zero 2 (polyToField_ψ_ne_zero hn)), smulX_one, ← map_pow, ← map_mul]
 
 /-- `smulX` at `2`, in terms of the `X`-coordinate and `ψ₃/ψ₂²`. -/
-lemma smulX_two :
-    smulX 2 = smulX 1 - polyToField (curve.ψ 3) / polyToField (curve.ψ 2) ^ 2 := by
+lemma smulX_two : smulX 2 = smulX 1 - polyToField (curve.ψ 3) / polyToField (curve.ψ 2) ^ 2 := by
   simp [smulX_eq two_ne_zero]
 
 /-- The difference of two values of `smulX` as a single quotient: the numerator is
 `ψₙ₊ₘψₙ₋ₘ`, by the elliptic-sequence relation of the universal `ψ` family. -/
 lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
-    smulX m - smulX n =
-      polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m)) /
-        (polyToField (curve.ψ n) * polyToField (curve.ψ m)) ^ 2 := by
+    smulX m - smulX n = polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m)) /
+      (polyToField (curve.ψ n) * polyToField (curve.ψ m)) ^ 2 := by
   have key := isEllipticSequence_polyToField_ψ n m 1
   simp only [IsEllipticNet.rel, add_zero, ψ_one, map_one, mul_one] at key
   rw [smulX_eq hm, smulX_eq hn, sub_sub_sub_cancel_left,
@@ -125,11 +123,7 @@ lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
   linear_combination -key
 
 /-- `smulX` is even in `n`. -/
-lemma smulX_neg : smulX (-n) = smulX n := by
-  have h : curve.ψ (-n) ^ 2 = curve.ψ n ^ 2 := by
-    rw [ψ_neg]
-    ring
-  rw [smulX_def, smulX_def, φ_neg, ← map_pow, ← map_pow, h]
+lemma smulX_neg : smulX (-n) = smulX n := by simp [smulX_def, φ_neg, ψ_neg]
 
 /-- `smulX n` is nonzero for `n ≠ 0`. -/
 lemma smulX_ne_zero (h0 : n ≠ 0) : smulX n ≠ 0 :=
@@ -138,16 +132,12 @@ lemma smulX_ne_zero (h0 : n ≠ 0) : smulX n ≠ 0 :=
 /-- `smulX` separates indices that agree in neither order nor sign. -/
 lemma smulX_ne_smulX (ne : m ≠ n) (ne_neg : m ≠ -n) : smulX m ≠ smulX n := by
   obtain rfl | hm := eq_or_ne m 0
-  · rw [smulX_zero]
-    exact (smulX_ne_zero ne.symm).symm
+  · simpa using (smulX_ne_zero ne.symm).symm
   obtain rfl | hn := eq_or_ne n 0
-  · rw [smulX_zero]
-    exact smulX_ne_zero ne
+  · simpa using smulX_ne_zero ne
   rw [← sub_ne_zero, smulX_sub_smulX hm hn]
-  rw [ne_comm, ← sub_ne_zero] at ne
-  rw [Ne, ← add_eq_zero_iff_eq_neg, add_comm] at ne_neg
   refine div_ne_zero (mul_ne_zero ?_ ?_) (pow_ne_zero _ <| mul_ne_zero ?_ ?_) <;>
-    apply polyToField_ψ_ne_zero <;> assumption
+    apply polyToField_ψ_ne_zero <;> omega
 
 /-- Two values of `smulX` agree exactly when the indices agree up to sign. -/
 lemma smulX_eq_smulX_iff : smulX m = smulX n ↔ m = n ∨ m = -n := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -61,8 +61,8 @@ its ring hom (`map_neg polyToField`) where the source unfolds `ψᵤ`, because a
 same direction problem — the source's forward
 `simp only [φ, ψᵤ, map_sub, map_mul, map_pow, ← add_div]` does not fire here — so it instead
 maps a polynomial-level identity with `congrArg polyToField` and clears the denominator with
-`field_simp` and `linear_combination`. Finally `@[simp]` is added to `smulX_neg`,
-`smulX_ne_zero` and `smulX_eq_smulX_iff`, which the source leaves untagged.
+`field_simp` and `linear_combination`. Finally `@[simp]` is added to `smulX_neg`, `smulY_neg`,
+`smulX_ne_zero` and `smulX_eq_smulX_iff`; the source tags only the four value lemmas.
 
 `smulX_sub_sub_smulX_add` (`:196`) is deliberately not ported here: its consumers are the slope
 and addition formulas, and it ships with them.


### PR DESCRIPTION
> Rebased onto current `main`; the diff is one new file,
> `DivisionPolynomial/ZSMul.lean`.

The coordinate functions of scalar multiplication on the universal curve, and the `smulX`
calculus.

```lean
def smulX (n : ℤ) : Universal.Field := polyToField (curve.φ n) / polyToField (curve.ψ n) ^ 2
def smulY (n : ℤ) : Universal.Field := polyToField (curve.ω n) / polyToField (curve.ψ n) ^ 3
lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
    smulX m - smulX n = polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m)) /
      (polyToField (curve.ψ n) * polyToField (curve.ψ m)) ^ 2
@[simp] lemma smulX_ne_zero (h0 : n ≠ 0) : smulX n ≠ 0
@[simp] lemma smulX_eq_smulX_iff : smulX m = smulX n ↔ m = n ∨ m = -n
```

plus the equation lemmas `smulX_def`/`smulY_def` (the module-system handles, in the
`ψc_def`/`ω_def` pattern), the `@[simp]` values at `0` and `1` for both, `smulX_eq`,
`smulX_two`, `smulX_ne_smulX`, and the two parity rules — `@[simp] smulX_neg` and
`smulY_neg (h0 : n ≠ 0) : smulY (-n) = pointedCurve.toAffine.negY (smulX n) (smulY n)` —
negating a nonzero index negates the point, which is what `ω_neg`'s long-Weierstrass
correction becomes downstairs.

## What it closes

The Nagell–Lutz route's `n • (X, Y)` development identifies the affine coordinates of the
multiple as `φₙ/ψₙ²` and `ωₙ/ψₙ³` in `Universal.Field`. This PR defines those two rational
functions and proves the `smulX` calculus the identification consumes — values, evenness,
nonvanishing (dividing by #3897's lemmas), the difference-as-single-quotient identity (the
elliptic-sequence relation of `ψ` earning its keep), and the separation statement
`smulX m = smulX n ↔ m = n ∨ m = -n`. The identification with `n • point` itself is the
Jacobian-layer headline of a later slice; the slope and addition formulas (`slopeOne`,
`addX/addY` at one-one, `smulX_add`) are the next slice, which consumes everything here.
`smulY_neg` is pulled forward from that slice's source range at the reviewer's request: it is
what makes `smulY`'s negative-index behaviour reachable without unfolding, and the definition
should not ship without it.

## Reuse

`smulX`/`smulY` return nothing on `origin/main` outside this new file (repo grep; positive
control: `polyToField`, 63 occurrences). The statements are not spellable in pinned Mathlib:
`polyToField`, `Universal.Field` and `curve.ω` are this repository's; Mathlib's `smulX`-shaped
names (`Projective.dblX_smul`, `addX_smul`) are rescaling-covariance lemmas about a different
object (verified per declaration during cleanup, five-method blocks in the receipt). Two source
neighbours are deliberately **not** ported here, each shipping with its consumer in the slope
slice: `smulX_sub_sub_smulX_add` (`:196`, consumed by `smulX_add`'s calc) and `net_ψᵤ`
(`:140`, consumed by `smulY_add_sub_negY`) — the same consumer-discipline as #3897's `net_ψᵤ`
deferral.

## Review round 2 — all three findings implemented

**`reuse` was right and my earlier objection was wrong on the facts.** The previous revision
declined this finding, arguing that routing `smulY_neg` through Mathlib's
`Jacobian.negY_of_Z_ne_zero` would pull the Jacobian coordinate framework into a file that
imports only the Affine layer. That cost does not exist: `Jacobian.Formula` is **already
transitively public** here, through
`ZSMul → DivisionPolynomial.Universal → Omega → EllipticCurve.Universal → Jacobian.Point`.
A `#check` probe resolves `Jacobian.negY_of_Z_ne_zero` and `Jacobian.negY_eq` with no import
added, so the finding costs zero import weight and the private `smulY_neg_aux` is deleted.
The one wrinkle worth recording for the next porter: the `x`/`y`/`z` accessors are
`local notation3` in `Jacobian/Basic.lean`, not scoped, so they are unavailable here — the
instantiated hypothesis carries literal `![…] 0/1/2` and a `Matrix.cons_val_*` set reduces them.

**`proof-quality`**: `smulX_eq` no longer runs a directional rewrite chain. It maps the
polynomial-level identity with `congrArg polyToField`, normalises with one `simp only`, then
closes with `field_simp` and `linear_combination`, exactly as the finding proposed.

**`api-design`**: `smulX_ne_zero` is tagged `@[simp]`. Two things were checked rather than
assumed. Both `simpa` call sites in `smulX_ne_smulX` still compile unchanged — as a
*conditional* simp lemma its side goal `?n ≠ 0` is not dischargeable by the default discharger,
so it does not fire there. And there is no simpNF cross-fire: the full-library `lint-env`
output is byte-identical to the pre-tag run, which is the only gate that sees that class.

**Provenance corrected in the same commit.** Deleting the auxiliary falsified the module's
Provenance block, and checking it against the pin turned up an error that predates this round:
the cited span `:288`–`:291` is wrong at both ends — the auxiliary is `:286`–`:288` and
`smulY_neg` is `:290`–`:293`. The block now cites `:290`, records the auxiliary as deliberately
not ported, and lists five departures rather than three (adding the `smulX_eq` reproof and the
four `@[simp]` tags the source does not carry).

## Gates

Targeted `lake build` PASS and full-library build PASS on the rebased base;
`scripts/lint-env.sh` PASS with no new violations (64 grandfathered, 6 ratchetable, output
byte-identical to the pre-change run); `lake exe axioms` clean; `lake exe module-system` clean.
Full `/cleanup` ran per-declaration on all 15 declarations (15/15 all-gates-green), then the
`/simplify` and `/buzz` hand-offs: `/simplify` found the module docstring's Main-results
inventory omitting `smulX_eq`, which two other lemmas run through; `/buzz` profiled FAST-BOARD
(whole-file elaboration ~2.1s against a 2.06s import; largest single item 31.4ms, 32× under the
1000ms budget). The polynomial-level-`have` + field-side-rewrite shapes are forced by the module
system: generic `map_*` rewrites fire on `polyToField` only in the ← direction unless the hom is
named, which is why `smulY_neg` spells its negation step `map_neg polyToField` and why
`smulX_eq`'s source chain had to be replaced rather than transcribed. Line lengths ≤ 100
codepoints (python-verified on decoded text, not bytes; the two `_def` lines sit at exactly 100,
which merged `main` carries 1973 times). No `sorry`/`set_option`. `omega` not `lia` for the
arithmetic side-goals: measured 341 added `omega` lines against 0 added `lia` across the last
300 merged commits. Eight `@[simp]`: the four value lemmas (which the source also tags) plus the
four this repository adds — `smulX_neg`, `smulY_neg`, `smulX_eq_smulX_iff` from the api-design
rubric across P6 rounds, and `smulX_ne_zero` from its round-1 finding on the open PR.

## Roadmap

New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
Nagell–Lutz**", whose stated route is the division-polynomial formula for `n • P`
(`README.md:1163`, the Layer-6 NagellLutz entry naming AINTLIB as the pinned source). These are
that formula's coordinate functions and their basic calculus; they advance that target and
nothing else.

## Provenance

Ported from J. Xu and D. K. Angdinata's `projects/NagellLutz/LutzNagell/ZSMul.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`):
`smulX` (`:164`), `smulY` (`:168`), the value lemmas (`:171`–`:174`), `smulX_eq` (`:176`),
`smulX_two` (`:183`), `smulX_sub_smulX` (`:186`), `smulX_neg` (`:201`), `smulX_ne_zero`
(`:203`), `smulX_ne_smulX` (`:206`), `smulX_eq_smulX_iff` (`:217`), and `smulY_neg` (`:290`).
The source's `ψᵤ` abbreviation is dropped for `polyToField (curve.ψ n)` (house convention).
Five departures, all recorded in the module docstring: the elliptic-sequence step of
`smulX_sub_smulX` is respelt through `IsEllipticNet.rel` and `linear_combination` (Mathlib has
since replaced the source's `isEllSequence` statement shape); the equation lemmas
`smulX_def`/`smulY_def` are added as the cross-module handles, as in `Omega.lean`; `smulY_neg`
reads its coordinate identity off Mathlib's `Jacobian.negY_of_Z_ne_zero` instead of the
source's private auxiliary (`:286`); `smulX_eq` restructures the source's def-unfolding simp
chain into a polynomial-level `have` with field-side rewrites (the module system does not
expose the bodies that chain unfolds); and four `@[simp]` tags are added that the source does
not carry.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-smul-coords"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
