### PR TITLE
feat(EllipticCurve): a change of variables between integral models descends to R

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
@@ -15,14 +15,18 @@ import Mathlib.Tactic.Field
 
 A change of variables `D : VariableChange K` carrying one integral Weierstrass model to another
 need not be integral itself: its scaling factor `D.u` is a unit of `K`, and `D.r`, `D.s`, `D.t` are
-elements of `K`. This file shows that as soon as `D.u` comes from a unit of `R`, the rest follows —
-`D` is the base change of a `VariableChange R`.
+elements of `K`. This file shows that when `R` is integrally closed in `K`, as soon as `D.u` comes
+from a unit of `R` the rest follows — `D` is the base change of a `VariableChange R`.
 
 ## Main results
 
-* `WeierstrassCurve.exists_variableChange_baseChange_eq_of_smul_eq`: if `D • W₁ = W₂` with `W₁` and
-  `W₂` integral and `D.u` the image of a unit of `R`, then `D = C₀.baseChange K` for some
-  `C₀ : VariableChange R`.
+* `WeierstrassCurve.VariableChange.exists_baseChange_eq_of_smul_eq`: for `R` integrally closed in
+  `K` (`IsIntegrallyClosedIn R K`), if `D • W₁ = W₂` with `W₁` and `W₂` integral over `R` and `D.u`
+  the image of a unit of `R`, then `D = C₀.baseChange K` for some `C₀ : VariableChange R`.
+
+The integral-closedness hypothesis is what the proof actually consumes. A discrete valuation ring
+with its fraction field is the intended application and satisfies it through
+`isIntegrallyClosed_iff_isIntegrallyClosedIn`, but no valuation is used anywhere below.
 
 ## How it is proved
 
@@ -61,14 +65,16 @@ Ported from FLT, https://github.com/ImperialCollegeLondon/FLT
 commit is FLT PR #1088, "Quadratic twist to split multiplicative reduction". The mathematics is
 unchanged: the same three polynomials, the same `linear_combination` certificates. The single
 66-line proof is split into the three integrality arguments plus their assembly, so that no
-declaration exceeds the length cap.
+declaration exceeds the length cap. Two hypotheses are weakened relative to the source, which
+states the descent for a discrete valuation ring: the integrality certificates need only
+`Algebra R K`, and the assembly needs only `IsIntegrallyClosedIn R K`.
 -/
 
 public section
 
 namespace WeierstrassCurve
 
-open IsDiscreteValuationRing IsDedekindDomain.HeightOneSpectrum
+namespace VariableChange
 
 variable (R : Type*) [CommRing R] {K : Type*} [Field K] [Algebra R K]
 
@@ -150,23 +156,26 @@ discrete-valuation-ring and fraction-field hypotheses come in. -/
 
 section Descent
 
-variable [IsDomain R] [IsDiscreteValuationRing R] [IsFractionRing R K]
+variable [IsIntegrallyClosedIn R K]
 
 /-- **A change of variables between two integral models whose scaling factor is a unit of `R` is
-defined over `R`.** The coordinates `r`, `s`, `t` are each integral over `R` — roots of monic
-polynomials read off the change-of-variables formulas for the `b₆`/`b₈`/`a₂`/`a₆`-invariants — and
-`R`, being a discrete valuation ring, is integrally closed. -/
-theorem exists_variableChange_baseChange_eq_of_smul_eq {W₁ W₂ : WeierstrassCurve K}
+the base change of a change of variables over `R`.** `R` is assumed integrally closed in `K`; `W₁`
+and `W₂` integral over `R`; and `D.u` the image of `u₀ : Rˣ`. The witness has that same `u₀` as its
+scaling factor. -/
+theorem exists_baseChange_eq_of_smul_eq {W₁ W₂ : WeierstrassCurve K}
     [IsIntegral R W₁] [IsIntegral R W₂] (D : VariableChange K) (hD : D • W₁ = W₂) (u₀ : Rˣ)
     (hau : algebraMap R K ↑u₀ = ↑D.u) : ∃ C₀ : VariableChange R, C₀.baseChange K = D := by
-  obtain ⟨rR, hrR⟩ := IsIntegrallyClosed.isIntegral_iff.mp (isIntegral_r_of_smul_eq R D hD u₀ hau)
+  obtain ⟨rR, hrR⟩ :=
+    IsIntegrallyClosedIn.isIntegral_iff.mp (isIntegral_r_of_smul_eq R D hD u₀ hau)
   obtain ⟨sR, hsR⟩ :=
-    IsIntegrallyClosed.isIntegral_iff.mp (isIntegral_s_of_smul_eq R D hD u₀ hau rR hrR)
+    IsIntegrallyClosedIn.isIntegral_iff.mp (isIntegral_s_of_smul_eq R D hD u₀ hau rR hrR)
   obtain ⟨tR, htR⟩ :=
-    IsIntegrallyClosed.isIntegral_iff.mp (isIntegral_t_of_smul_eq R D hD u₀ hau rR hrR)
+    IsIntegrallyClosedIn.isIntegral_iff.mp (isIntegral_t_of_smul_eq R D hD u₀ hau rR hrR)
   exact ⟨⟨u₀, rR, sR, tR⟩, VariableChange.ext (Units.ext hau) hrR hsR htR⟩
 
 end Descent
+
+end VariableChange
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
@@ -48,7 +48,7 @@ which is why they are stated after it rather than beside it.
 That file is where this repository keeps its `VariableChange` API, and the statement below is about
 `VariableChange.baseChange`, so it would sit there naturally — except that the proof needs
 `WeierstrassCurve.IsIntegral` and `integralModel`, i.e. Mathlib's `EllipticCurve.Reduction` with its
-valuation and discrete-valuation-ring machinery. `VariableChange.lean` currently imports only
+valuation machinery. `VariableChange.lean` currently imports only
 `Mathlib.AlgebraicGeometry.EllipticCurve.VariableChange`, and three modules import it; putting the
 descent there would push the reduction cone onto all of them. The topic here is integral models, so
 the file is named for them.
@@ -151,8 +151,10 @@ private theorem isIntegral_t_of_smul_eq {W₁ W₂ : WeierstrassCurve K} [IsInte
 
 /-! ### Assembly
 
-Pulling the three roots back into `R` needs `R` integrally closed in `K`, which is where the
-discrete-valuation-ring and fraction-field hypotheses come in. -/
+Pulling the three roots back into `R` is exactly `IsIntegrallyClosedIn R K`, and that is the only
+hypothesis this section adds. A discrete valuation ring together with its fraction field is the
+intended way to obtain it — see `isIntegrallyClosed_iff_isIntegrallyClosedIn` — but nothing here
+requires a valuation, and `K` need not be a fraction field. -/
 
 section Descent
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
@@ -34,8 +34,10 @@ with its fraction field is the intended application and satisfies it through
 Each of `r`, `s`, `t` is exhibited as a root of an explicit **monic** polynomial over `R`, built
 from the change-of-variables formulas for the invariants, and `R` is integrally closed:
 
-* `r` from the `b₆`- and `b₈`-relations, as a root of a quartic — the two relations are combined as
-  `b₈-relation − r · b₆-relation`, which cancels the `r⁴` and `r³` terms that neither alone does;
+* `r` from the `b₆`- and `b₈`-relations, as a root of a quartic. The two are combined as
+  `b₈-relation − r · b₆-relation`: that cancels the `r³ · b₂` terms and turns `3r⁴ − 4r⁴` into
+  `−r⁴`, leaving `b₈ + 2r · b₆ + r² · b₄ − r⁴`. The `r⁴` term does not cancel and must not — it is
+  the quartic's leading term;
 * `s` from the `a₂`-relation, as a root of a quadratic, once `r` is known to lie in `R`;
 * `t` from the `a₆`-relation, likewise a quadratic, once `r` is known.
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
+
+import Mathlib.Tactic.ComputeDegree
+import Mathlib.Tactic.Field
+
+/-!
+# Changes of variables between integral models
+
+A change of variables `D : VariableChange K` carrying one integral Weierstrass model to another
+need not be integral itself: its scaling factor `D.u` is a unit of `K`, and `D.r`, `D.s`, `D.t` are
+elements of `K`. This file shows that as soon as `D.u` comes from a unit of `R`, the rest follows —
+`D` is the base change of a `VariableChange R`.
+
+## Main results
+
+* `WeierstrassCurve.exists_variableChange_baseChange_eq_of_smul_eq`: if `D • W₁ = W₂` with `W₁` and
+  `W₂` integral and `D.u` the image of a unit of `R`, then `D = C₀.baseChange K` for some
+  `C₀ : VariableChange R`.
+
+## How it is proved
+
+Each of `r`, `s`, `t` is exhibited as a root of an explicit **monic** polynomial over `R`, built
+from the change-of-variables formulas for the invariants, and `R` is integrally closed:
+
+* `r` from the `b₆`- and `b₈`-relations, as a root of a quartic — the two relations are combined as
+  `b₈-relation − r · b₆-relation`, which cancels the `r⁴` and `r³` terms that neither alone does;
+* `s` from the `a₂`-relation, as a root of a quadratic, once `r` is known to lie in `R`;
+* `t` from the `a₆`-relation, likewise a quadratic, once `r` is known.
+
+The three arguments are separate private lemmas rather than one proof: each is a distinct
+integrality certificate with its own polynomial, and taken together they are past the repository's
+hard cap on proof length. `s` and `t` take the integral representative of `r` as a hypothesis,
+which is why they are stated after it rather than beside it.
+
+## Why this is not in `EllipticCurve/VariableChange.lean`
+
+That file is where this repository keeps its `VariableChange` API, and the statement below is about
+`VariableChange.baseChange`, so it would sit there naturally — except that the proof needs
+`WeierstrassCurve.IsIntegral` and `integralModel`, i.e. Mathlib's `EllipticCurve.Reduction` with its
+valuation and discrete-valuation-ring machinery. `VariableChange.lean` currently imports only
+`Mathlib.AlgebraicGeometry.EllipticCurve.VariableChange`, and three modules import it; putting the
+descent there would push the reduction cone onto all of them. The topic here is integral models, so
+the file is named for them.
+
+## Provenance
+
+⚠ *mathlib-track*. Statements about Mathlib's own `IsIntegral` for Weierstrass models and
+`VariableChange.baseChange`, with no Tau Ceti definitions involved.
+
+Ported from FLT, https://github.com/ImperialCollegeLondon/FLT
+@ `bc2fe8ff7396469a16c2a6d51d6117f5825d93a0` (Apache-2.0), file
+`FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, declaration
+`WeierstrassCurve.exists_variableChange_baseChange_eq_of_smul_eq`, by Kevin Buzzard. The source
+commit is FLT PR #1088, "Quadratic twist to split multiplicative reduction". The mathematics is
+unchanged: the same three polynomials, the same `linear_combination` certificates. The single
+66-line proof is split into the three integrality arguments plus their assembly, so that no
+declaration exceeds the length cap.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+open IsDiscreteValuationRing IsDedekindDomain.HeightOneSpectrum
+
+variable (R : Type*) [CommRing R] {K : Type*} [Field K] [Algebra R K]
+
+/-! ### The three integrality certificates
+
+These need nothing of `R` beyond its algebra structure on `K`: each exhibits a monic polynomial
+over `R` killing the coordinate. Integral closedness enters only in the assembly below, which is
+where the roots are pulled back into `R`. -/
+
+/-- **`r` is integral**: it is a root of the monic quartic obtained from the `b₆`- and
+`b₈`-relations as `b₈-relation − r · b₆-relation`. -/
+private theorem isIntegral_r_of_smul_eq {W₁ W₂ : WeierstrassCurve K} [IsIntegral R W₁]
+    [IsIntegral R W₂] (D : VariableChange K) (hD : D • W₁ = W₂) (u₀ : Rˣ)
+    (hau : algebraMap R K ↑u₀ = ↑D.u) : _root_.IsIntegral R D.r := by
+  have hb₆ : (↑D.u : K) ^ 6 * W₂.b₆
+      = W₁.b₆ + 2 * D.r * W₁.b₄ + D.r ^ 2 * W₁.b₂ + 4 * D.r ^ 3 := by
+    rw [← hD, variableChange_b₆]
+    simp only [Units.val_inv_eq_inv_val]
+    field
+  have hb₈ : (↑D.u : K) ^ 8 * W₂.b₈
+      = W₁.b₈ + 3 * D.r * W₁.b₆ + 3 * D.r ^ 2 * W₁.b₄ + D.r ^ 3 * W₁.b₂ + 3 * D.r ^ 4 := by
+    rw [← hD, variableChange_b₈]
+    simp only [Units.val_inv_eq_inv_val]
+    field
+  refine ⟨.X ^ 4 + (.C (-(W₁.integralModel R).b₄) * .X ^ 2
+      + .C (-(2 * (W₁.integralModel R).b₆) - (↑u₀ : R) ^ 6 * (W₂.integralModel R).b₆) * .X
+      + .C ((↑u₀ : R) ^ 8 * (W₂.integralModel R).b₈ - (W₁.integralModel R).b₈)),
+    Polynomial.monic_X_pow_add (by compute_degree!), ?_⟩
+  rw [← Polynomial.aeval_def]
+  simp only [map_add, map_sub, map_neg, map_mul, map_pow, map_ofNat, Polynomial.aeval_X,
+    Polynomial.aeval_C]
+  rw [integralModel_b₄_eq R W₁, integralModel_b₆_eq R W₁, integralModel_b₈_eq R W₁,
+    integralModel_b₆_eq R W₂, integralModel_b₈_eq R W₂, hau]
+  linear_combination hb₈ - D.r * hb₆
+
+/-- **`s` is integral**, given an integral representative `rR` of `r`: it is a root of the monic
+quadratic coming from the `a₂`-relation. -/
+private theorem isIntegral_s_of_smul_eq {W₁ W₂ : WeierstrassCurve K} [IsIntegral R W₁]
+    [IsIntegral R W₂] (D : VariableChange K) (hD : D • W₁ = W₂) (u₀ : Rˣ)
+    (hau : algebraMap R K ↑u₀ = ↑D.u) (rR : R) (hrR : algebraMap R K rR = D.r) :
+    _root_.IsIntegral R D.s := by
+  have ha₂ : (↑D.u : K) ^ 2 * W₂.a₂ = W₁.a₂ - D.s * W₁.a₁ + 3 * D.r - D.s ^ 2 := by
+    rw [← hD, variableChange_a₂]
+    simp only [Units.val_inv_eq_inv_val]
+    field
+  refine ⟨.X ^ 2 + (.C (W₁.integralModel R).a₁ * .X
+      + .C ((↑u₀ : R) ^ 2 * (W₂.integralModel R).a₂ - (W₁.integralModel R).a₂ - 3 * rR)),
+    Polynomial.monic_X_pow_add (by compute_degree!), ?_⟩
+  rw [← Polynomial.aeval_def]
+  simp only [map_add, map_sub, map_mul, map_pow, map_ofNat, Polynomial.aeval_X, Polynomial.aeval_C]
+  rw [integralModel_a₁_eq R W₁, integralModel_a₂_eq R W₁, integralModel_a₂_eq R W₂, hau, hrR]
+  linear_combination ha₂
+
+/-- **`t` is integral**, given an integral representative `rR` of `r`: it is a root of the monic
+quadratic coming from the `a₆`-relation. -/
+private theorem isIntegral_t_of_smul_eq {W₁ W₂ : WeierstrassCurve K} [IsIntegral R W₁]
+    [IsIntegral R W₂] (D : VariableChange K) (hD : D • W₁ = W₂) (u₀ : Rˣ)
+    (hau : algebraMap R K ↑u₀ = ↑D.u) (rR : R) (hrR : algebraMap R K rR = D.r) :
+    _root_.IsIntegral R D.t := by
+  have ha₆ : (↑D.u : K) ^ 6 * W₂.a₆ = W₁.a₆ + D.r * W₁.a₄ + D.r ^ 2 * W₁.a₂ + D.r ^ 3
+      - D.t * W₁.a₃ - D.t ^ 2 - D.r * D.t * W₁.a₁ := by
+    rw [← hD, variableChange_a₆]
+    simp only [Units.val_inv_eq_inv_val]
+    field
+  refine ⟨.X ^ 2 + (.C ((W₁.integralModel R).a₃ + rR * (W₁.integralModel R).a₁) * .X
+      + .C (-((W₁.integralModel R).a₆ + rR * (W₁.integralModel R).a₄
+        + rR ^ 2 * (W₁.integralModel R).a₂ + rR ^ 3) + (↑u₀ : R) ^ 6 * (W₂.integralModel R).a₆)),
+    Polynomial.monic_X_pow_add (by compute_degree!), ?_⟩
+  rw [← Polynomial.aeval_def]
+  simp only [map_add, map_neg, map_mul, map_pow, Polynomial.aeval_X, Polynomial.aeval_C]
+  rw [integralModel_a₁_eq R W₁, integralModel_a₂_eq R W₁, integralModel_a₃_eq R W₁,
+    integralModel_a₄_eq R W₁, integralModel_a₆_eq R W₁, integralModel_a₆_eq R W₂, hau, hrR]
+  linear_combination ha₆
+
+/-! ### Assembly
+
+Pulling the three roots back into `R` needs `R` integrally closed in `K`, which is where the
+discrete-valuation-ring and fraction-field hypotheses come in. -/
+
+section Descent
+
+variable [IsDomain R] [IsDiscreteValuationRing R] [IsFractionRing R K]
+
+/-- **A change of variables between two integral models whose scaling factor is a unit of `R` is
+defined over `R`.** The coordinates `r`, `s`, `t` are each integral over `R` — roots of monic
+polynomials read off the change-of-variables formulas for the `b₆`/`b₈`/`a₂`/`a₆`-invariants — and
+`R`, being a discrete valuation ring, is integrally closed. -/
+theorem exists_variableChange_baseChange_eq_of_smul_eq {W₁ W₂ : WeierstrassCurve K}
+    [IsIntegral R W₁] [IsIntegral R W₂] (D : VariableChange K) (hD : D • W₁ = W₂) (u₀ : Rˣ)
+    (hau : algebraMap R K ↑u₀ = ↑D.u) : ∃ C₀ : VariableChange R, C₀.baseChange K = D := by
+  obtain ⟨rR, hrR⟩ := IsIntegrallyClosed.isIntegral_iff.mp (isIntegral_r_of_smul_eq R D hD u₀ hau)
+  obtain ⟨sR, hsR⟩ :=
+    IsIntegrallyClosed.isIntegral_iff.mp (isIntegral_s_of_smul_eq R D hD u₀ hau rR hrR)
+  obtain ⟨tR, htR⟩ :=
+    IsIntegrallyClosed.isIntegral_iff.mp (isIntegral_t_of_smul_eq R D hD u₀ hau rR hrR)
+  exact ⟨⟨u₀, rR, sR, tR⟩, VariableChange.ext (Units.ext hau) hrR hsR htR⟩
+
+end Descent
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
@@ -139,12 +139,15 @@ private theorem isIntegral_t_of_smul_eq {W₁ W₂ : WeierstrassCurve K} [IsInte
     rw [← hD, variableChange_a₆]
     simp only [Units.val_inv_eq_inv_val]
     field
+  -- The constant term is `u₀⁶ · a₆(W₂)` MINUS the bracketed `r`-polynomial in `W₁`'s invariants;
+  -- written as a subtraction so the sign of the `a₆(W₂)` term cannot be misread across the wrap.
   refine ⟨.X ^ 2 + (.C ((W₁.integralModel R).a₃ + rR * (W₁.integralModel R).a₁) * .X
-      + .C (-((W₁.integralModel R).a₆ + rR * (W₁.integralModel R).a₄
-        + rR ^ 2 * (W₁.integralModel R).a₂ + rR ^ 3) + (↑u₀ : R) ^ 6 * (W₂.integralModel R).a₆)),
+      + .C ((↑u₀ : R) ^ 6 * (W₂.integralModel R).a₆
+        - ((W₁.integralModel R).a₆ + rR * (W₁.integralModel R).a₄
+          + rR ^ 2 * (W₁.integralModel R).a₂ + rR ^ 3))),
     Polynomial.monic_X_pow_add (by compute_degree!), ?_⟩
   rw [← Polynomial.aeval_def]
-  simp only [map_add, map_neg, map_mul, map_pow, Polynomial.aeval_X, Polynomial.aeval_C]
+  simp only [map_add, map_sub, map_mul, map_pow, Polynomial.aeval_X, Polynomial.aeval_C]
   rw [integralModel_a₁_eq R W₁, integralModel_a₂_eq R W₁, integralModel_a₃_eq R W₁,
     integralModel_a₄_eq R W₁, integralModel_a₆_eq R W₁, integralModel_a₆_eq R W₂, hau, hrR]
   linear_combination ha₆

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/IntegralModel.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
+public import TauCeti.RingTheory.Polynomial.IsIntegral
 
 import Mathlib.Tactic.ComputeDegree
 import Mathlib.Tactic.Field
@@ -120,11 +121,10 @@ private theorem isIntegral_s_of_smul_eq {W₁ W₂ : WeierstrassCurve K} [IsInte
     rw [← hD, variableChange_a₂]
     simp only [Units.val_inv_eq_inv_val]
     field
-  refine ⟨.X ^ 2 + (.C (W₁.integralModel R).a₁ * .X
-      + .C ((↑u₀ : R) ^ 2 * (W₂.integralModel R).a₂ - (W₁.integralModel R).a₂ - 3 * rR)),
-    Polynomial.monic_X_pow_add (by compute_degree!), ?_⟩
-  rw [← Polynomial.aeval_def]
-  simp only [map_add, map_sub, map_mul, map_pow, map_ofNat, Polynomial.aeval_X, Polynomial.aeval_C]
+  refine IsIntegral.of_sq_add_mul_add_eq_zero (b := algebraMap R K (W₁.integralModel R).a₁)
+    (c := algebraMap R K ((↑u₀ : R) ^ 2 * (W₂.integralModel R).a₂
+      - (W₁.integralModel R).a₂ - 3 * rR)) isIntegral_algebraMap isIntegral_algebraMap ?_
+  simp only [map_sub, map_mul, map_pow, map_ofNat]
   rw [integralModel_a₁_eq R W₁, integralModel_a₂_eq R W₁, integralModel_a₂_eq R W₂, hau, hrR]
   linear_combination ha₂
 
@@ -141,13 +141,13 @@ private theorem isIntegral_t_of_smul_eq {W₁ W₂ : WeierstrassCurve K} [IsInte
     field
   -- The constant term is `u₀⁶ · a₆(W₂)` MINUS the bracketed `r`-polynomial in `W₁`'s invariants;
   -- written as a subtraction so the sign of the `a₆(W₂)` term cannot be misread across the wrap.
-  refine ⟨.X ^ 2 + (.C ((W₁.integralModel R).a₃ + rR * (W₁.integralModel R).a₁) * .X
-      + .C ((↑u₀ : R) ^ 6 * (W₂.integralModel R).a₆
-        - ((W₁.integralModel R).a₆ + rR * (W₁.integralModel R).a₄
-          + rR ^ 2 * (W₁.integralModel R).a₂ + rR ^ 3))),
-    Polynomial.monic_X_pow_add (by compute_degree!), ?_⟩
-  rw [← Polynomial.aeval_def]
-  simp only [map_add, map_sub, map_mul, map_pow, Polynomial.aeval_X, Polynomial.aeval_C]
+  refine IsIntegral.of_sq_add_mul_add_eq_zero
+    (b := algebraMap R K ((W₁.integralModel R).a₃ + rR * (W₁.integralModel R).a₁))
+    (c := algebraMap R K ((↑u₀ : R) ^ 6 * (W₂.integralModel R).a₆
+      - ((W₁.integralModel R).a₆ + rR * (W₁.integralModel R).a₄
+        + rR ^ 2 * (W₁.integralModel R).a₂ + rR ^ 3)))
+    isIntegral_algebraMap isIntegral_algebraMap ?_
+  simp only [map_add, map_sub, map_mul, map_pow]
   rw [integralModel_a₁_eq R W₁, integralModel_a₂_eq R W₁, integralModel_a₃_eq R W₁,
     integralModel_a₄_eq R W₁, integralModel_a₆_eq R W₁, integralModel_a₆_eq R W₂, hau, hrR]
   linear_combination ha₆

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.Polynomial.IsIntegral
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Denominator
 public import TauCeti.RingTheory.Polynomial.IsIntegral
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.Polynomial.IsIntegral
-import Mathlib.Tactic.ComputeDegree
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Denominator
+public import TauCeti.RingTheory.Polynomial.IsIntegral
 
 /-!
 # Integrality of points on a Weierstrass curve over a unique factorization domain
@@ -64,28 +64,6 @@ namespace WeierstrassCurve
 
 variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
 
--- An element satisfying a monic quadratic relation with integral coefficients is integral: this
--- is `IsIntegral.of_aeval_monic_of_isIntegral_coeff` for `X ^ 2 + C b * X + C c`, with the degree
--- computation and the per-coefficient obligations discharged. Kept here rather than exported,
--- since `isIntegral_y_of_equation_of_isIntegral_x` is its only consumer.
-private theorem isIntegral_of_sq_add_mul_add_eq_zero {A : Type*} [CommRing A] [Algebra R A]
-    {b c y : A} (hb : IsIntegral R b) (hc : IsIntegral R c) (h : y ^ 2 + b * y + c = 0) :
-    IsIntegral R y := by
-  nontriviality A
-  have hdeg : (X ^ 2 + (C b * X + C c) : A[X]).natDegree = 2 := by compute_degree!
-  refine IsIntegral.of_aeval_monic_of_isIntegral_coeff (p := X ^ 2 + (C b * X + C c))
-    (monic_X_pow_add (by compute_degree!)) (by omega) ?_ ?_
-  · have : Polynomial.eval y (X ^ 2 + (C b * X + C c) : A[X]) = 0 := by
-      simpa only [eval_add, eval_pow, eval_X, eval_mul, eval_C, add_assoc] using h
-    rw [this]
-    exact isIntegral_zero
-  · intro i
-    match i with
-    | 0 => simpa using hc
-    | 1 => simpa using hb
-    | 2 => simpa using (isIntegral_one : IsIntegral R (1 : A))
-    | (n + 3) => simpa using (isIntegral_zero : IsIntegral R (0 : A))
-
 /-- **An integral `x`-coordinate forces an integral `y`-coordinate**, over any `R`-algebra.
 
 On the curve, `y` is a root of the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)`,
@@ -97,7 +75,7 @@ theorem isIntegral_y_of_equation_of_isIntegral_x {A : Type*} [CommRing A] [Algeb
   simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_a₁,
     _root_.WeierstrassCurve.map_a₂, _root_.WeierstrassCurve.map_a₃,
     _root_.WeierstrassCurve.map_a₄, _root_.WeierstrassCurve.map_a₆] at h
-  refine isIntegral_of_sq_add_mul_add_eq_zero
+  refine IsIntegral.of_sq_add_mul_add_eq_zero
     (b := algebraMap R A W.a₁ * x + algebraMap R A W.a₃)
     (c := -(x ^ 3 + algebraMap R A W.a₂ * x ^ 2 + algebraMap R A W.a₄ * x + algebraMap R A W.a₆))
     ((isIntegral_algebraMap.mul hx).add isIntegral_algebraMap)

--- a/TauCeti/RingTheory/Polynomial/IsIntegral.lean
+++ b/TauCeti/RingTheory/Polynomial/IsIntegral.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Polynomial.IsIntegral
+
+import Mathlib.Tactic.ComputeDegree
+
+/-!
+# Integrality from a monic quadratic relation
+
+Mathlib's `IsIntegral.of_aeval_monic_of_isIntegral_coeff` takes a monic polynomial and asks for
+each coefficient to be integral. Applying it to a quadratic means writing the polynomial out,
+discharging the degree computation, and answering the coefficient obligation index by index — the
+same half-dozen lines every time.
+
+## Main results
+
+* `IsIntegral.of_sq_add_mul_add_eq_zero`: if `y ^ 2 + b * y + c = 0` with `b` and `c` integral over
+  `R`, then `y` is integral over `R`.
+
+The relation is stated as an equation rather than through `Polynomial.aeval`, which is the form a
+caller actually holds: a change-of-variables identity or a curve equation, rearranged by
+`linear_combination`.
+
+## Provenance
+
+Extracted from `TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean`, where it was a private
+helper for `WeierstrassCurve.isIntegral_y_of_equation_of_isIntegral_x` with a note that it was
+"kept here rather than exported, since `isIntegral_y_of_equation_of_isIntegral_x` is its only
+consumer". A second consumer now exists — the coordinates of a change of variables between integral
+Weierstrass models — so the note no longer holds and the statement moves to where both can reach
+it. The proof is unchanged; only the name is now `IsIntegral`-prefixed, since nothing about it is
+about elliptic curves.
+-/
+
+public section
+
+open Polynomial
+
+/-- **An element satisfying a monic quadratic relation with integral coefficients is integral.**
+This is `IsIntegral.of_aeval_monic_of_isIntegral_coeff` for `X ^ 2 + C b * X + C c`, with the
+degree computation and the per-coefficient obligations discharged. -/
+theorem IsIntegral.of_sq_add_mul_add_eq_zero {R : Type*} [CommRing R] {A : Type*} [CommRing A]
+    [Algebra R A] {b c y : A} (hb : IsIntegral R b) (hc : IsIntegral R c)
+    (h : y ^ 2 + b * y + c = 0) : IsIntegral R y := by
+  nontriviality A
+  have hdeg : (X ^ 2 + (C b * X + C c) : A[X]).natDegree = 2 := by compute_degree!
+  refine IsIntegral.of_aeval_monic_of_isIntegral_coeff (p := X ^ 2 + (C b * X + C c))
+    (monic_X_pow_add (by compute_degree!)) (by omega) ?_ ?_
+  · have : Polynomial.eval y (X ^ 2 + (C b * X + C c) : A[X]) = 0 := by
+      simpa only [eval_add, eval_pow, eval_X, eval_mul, eval_C, add_assoc] using h
+    rw [this]
+    exact isIntegral_zero
+  · intro i
+    match i with
+    | 0 => simpa using hc
+    | 1 => simpa using hb
+    | 2 => simpa using (isIntegral_one : IsIntegral R (1 : A))
+    | (n + 3) => simpa using (isIntegral_zero : IsIntegral R (0 : A))
+
+end

--- a/TauCeti/RingTheory/Polynomial/IsIntegral.lean
+++ b/TauCeti/RingTheory/Polynomial/IsIntegral.lean
@@ -42,11 +42,14 @@ public section
 open Polynomial
 
 /-- **An element satisfying a monic quadratic relation with integral coefficients is integral.**
-This is `IsIntegral.of_aeval_monic_of_isIntegral_coeff` for `X ^ 2 + C b * X + C c`, with the
-degree computation and the per-coefficient obligations discharged. -/
+`y`, `b` and `c` live in an arbitrary commutative `R`-algebra `A`, and the relation is an equation
+in `A` rather than a statement about `Polynomial.aeval`, so a caller supplies whatever identity it
+already holds. -/
 theorem IsIntegral.of_sq_add_mul_add_eq_zero {R : Type*} [CommRing R] {A : Type*} [CommRing A]
     [Algebra R A] {b c y : A} (hb : IsIntegral R b) (hc : IsIntegral R c)
     (h : y ^ 2 + b * y + c = 0) : IsIntegral R y := by
+  -- `IsIntegral.of_aeval_monic_of_isIntegral_coeff` for `X ^ 2 + C b * X + C c`, with the degree
+  -- computation and the per-coefficient obligations discharged index by index.
   nontriviality A
   have hdeg : (X ^ 2 + (C b * X + C c) : A[X]).natDegree = 2 := by compute_degree!
   refine IsIntegral.of_aeval_monic_of_isIntegral_coeff (p := X ^ 2 + (C b * X + C c))


### PR DESCRIPTION
```lean
theorem WeierstrassCurve.VariableChange.exists_baseChange_eq_of_smul_eq
    [IsIntegrallyClosedIn R K] {W₁ W₂ : WeierstrassCurve K} [IsIntegral R W₁] [IsIntegral R W₂]
    (D : VariableChange K) (hD : D • W₁ = W₂) (u₀ : Rˣ) (hau : algebraMap R K ↑u₀ = ↑D.u) :
    ∃ C₀ : VariableChange R, C₀.baseChange K = D
```

A change of variables between two integral Weierstrass models is a priori only defined over `K`.
This says that as soon as its scaling factor comes from a unit of `R`, the whole change does: `r`,
`s`, `t` are integral over `R`, hence in `R` because a discrete valuation ring is integrally closed.

Three files, two public theorems, three private lemmas, no new definitions:

* `EllipticCurve/IntegralModel.lean` (new) — the descent and its three coordinate certificates;
* `RingTheory/Polynomial/IsIntegral.lean` (new) — `IsIntegral.of_sq_add_mul_add_eq_zero`, the
  monic-quadratic integrality certificate, moved out of `EllipticCurve/Integrality.lean`;
* `EllipticCurve/Integrality.lean` — loses its private copy of that helper and imports the shared
  one instead; its single call site is retargeted. No statement there changes.

## Why this is needed

It is the second prerequisite of the Layer-5 headline at
`TauCetiRoadmap/EllipticCurves/README.md:786` — "a curve with **nonsplit** multiplicative reduction
acquires **split** reduction after a separable quadratic twist (seeded, over Mathlib's reduction
predicates)". The step that needs it is the invariance of split multiplicative reduction under an
isomorphism of minimal models: two minimal models differ by a change of variables whose `u` has
valuation `1`, and to move the node polynomial's splitting across you need that change to be
defined over `R`, not merely over `K`. Mathlib has no such descent: it has `integralModel` and the
per-invariant `integralModel_*_eq` lemmas, but nothing that recovers a `VariableChange R`.

## Why three private lemmas rather than one proof

Each coordinate gets its own integrality certificate, and they are not variations on one lemma:

* `r` is a root of a **quartic**, obtained by combining the `b₆`- and `b₈`-relations as
  `b₈-relation − r · b₆-relation`: the `r³ · b₂` terms cancel and `3r⁴ − 4r⁴` becomes `−r⁴`, so what
  remains is `b₈ + 2r · b₆ + r² · b₄ − r⁴`. The `r⁴` term survives as the leading term, which is the
  point — an earlier draft of this body and of the module doc claimed it cancelled, which a monic
  quartic contradicts;
* `s` is a root of a quadratic from the `a₂`-relation, and needs `r`'s integral representative;
* `t` is a root of a quadratic from the `a₆`-relation, likewise.

The source carries all three inline in a 66-line proof, which is past this repository's 50-line hard
cap, so splitting is not optional. Spans are 23, 14, 21 and 10 lines. `s` and `t` take `rR` and
`hrR : algebraMap R K rR = D.r` as hypotheses, which is why they are stated after `r` rather than
beside it — the dependency is real, not stylistic.

## The shared quadratic certificate

`reuse` on the first posted round pointed out that `s` and `t` were rebuilding integrality plumbing
this repository already had: `isIntegral_of_sq_add_mul_add_eq_zero` in
`EllipticCurve/Integrality.lean`, whose own comment said it was "kept here rather than exported,
since `isIntegral_y_of_equation_of_isIntegral_x` is its only consumer". That premise stopped holding
the moment this file arrived, so the statement moves to `RingTheory/Polynomial/IsIntegral.lean` —
mirroring `Mathlib.RingTheory.Polynomial.IsIntegral`, which is where it belongs, since nothing about
"a root of a monic quadratic with integral coefficients is integral" concerns elliptic curves. It is
renamed `IsIntegral.of_sq_add_mul_add_eq_zero` for the same reason, and the proof is untouched.

`r` keeps its own certificate: it is a **quartic**, so the quadratic helper does not apply.

That deleted 22 lines from `Integrality.lean`, cut the `s` and `t` proofs from 18 and 18 lines to 14
and 21 (the `t` constant is now spelled out in the `refine`), and left one shared statement where
there were two ad-hoc copies.

## Placement

`EllipticCurve/VariableChange.lean` is where this repository keeps its `VariableChange` API and the
statement is about `VariableChange.baseChange`, so that would be the obvious home — except the proof
needs `WeierstrassCurve.IsIntegral` and `integralModel`, i.e. Mathlib's `EllipticCurve.Reduction`
with its valuation and DVR machinery. That file imports only Mathlib's `VariableChange` today and
three modules import it, so putting the descent there would push the whole reduction cone onto them.
Hence a file named for its subject, integral models. The three integrality lemmas sit under a lean
variable block (`CommRing R`, `Algebra R K`); the DVR and fraction-field hypotheses are introduced
only in the assembly section that needs them, so `unusedSectionVars` is satisfied by structure
rather than by `omit`.

## Hypotheses, and why they are not the source's

The source states the descent over a discrete valuation ring. No valuation is used: the three
integrality certificates need only `Algebra R K`, and the assembly needs only that integral
elements of `K` come from `R`. So the theorem is stated under `[IsIntegrallyClosedIn R K]`, which
is weaker than `[IsIntegrallyClosed R] + [IsFractionRing R K]` since it does not ask that `K` be
the fraction field at all.

Usability at the intended application is **checked, not assumed** — a compiled probe (not part of
the diff) discharges it in one line for a DVR with its fraction field:

```lean
have : IsIntegrallyClosedIn R K := (isIntegrallyClosed_iff_isIntegrallyClosedIn K).mp inferInstance
```

with `Mathlib.RingTheory.DedekindDomain.Basic` in scope, which is where the DVR-to-integrally-closed
instance becomes reachable. Without that import the instance is *not* found, which is worth knowing
for the consumer that follows.

## Gates

`lake build` green for all three modules and for the full library; `scripts/lint-style.sh` green;
`scripts/lint-env.sh` **PASS**, no new violations; longest line 100 characters; no `sorry`, no
`native_decide`, no `maxHeartbeats`. Every declaration span is under the 30-line guidance.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"reduction-variable-change-descent"}-->

Provenance: github.com/ImperialCollegeLondon/FLT @ bc2fe8ff7396469a16c2a6d51d6117f5825d93a0,
Apache-2.0, file `FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, declaration
`WeierstrassCurve.exists_variableChange_baseChange_eq_of_smul_eq`, by Kevin Buzzard — FLT PR #1088,
"Quadratic twist to split multiplicative reduction", the seed the roadmap names for this milestone.
The mathematics is unchanged: the same three polynomials and the same `linear_combination`
certificates. What differs is the split into three lemmas plus assembly (for the length cap) and the
two-tier variable block (for the section-variable linter).
