### PR TITLE
docs(EllipticCurve): describe the departure the nonvanishing port actually makes

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -101,13 +101,16 @@ of `ψ` with `normEDS` is the named `ψ_eq_normEDS` (`DivisionPolynomial/NormEDS
 `have` transports it through `polyToField`, so the statement is spelled on
 `fun n ↦ polyToField (curve.ψ n)` directly.
 
-The nonvanishing block adapts, at the same `main` revision, `ψᵤ_ne_zero` (`:141`, respelt
+The nonvanishing block adapts, at the same `main` revision, `ψᵤ_ne_zero` (`:142`, respelt
 `polyToField_ψ_ne_zero` with the abbreviation dropped as above), `polyToField_φ_ne_zero` (`:148`,
 source name kept) and `polyToField_ψ₂Sq` (`:154`, here `polyToField_Ψ₂Sq`: the constant in its
-conclusion is `Ψ₂Sq`, capitalised). One departure beyond the
-`ψᵤ` respelling: the source rewrites through its `polyToField_polynomial`, which has no
-counterpart here — the vanishing of the Weierstrass polynomial is inlined as a `have` through
-`AdjoinRoot.mk_self`, the same step `Universal.lean`'s `equation_point` uses.
+conclusion is `Ψ₂Sq`, capitalised). The first two port essentially unchanged, both retracting to
+the cusp curve at `(1, 1)` through `ringEval`, where `ψₙ` reads off as `n` and `φₙ` as `1`. One
+departure beyond the `ψᵤ` respelling, and it is confined to `polyToField_Ψ₂Sq`: the source clears
+the Weierstrass polynomial by rewriting with its own `polyToField_polynomial`, which has no
+counterpart here, so the proof instead pushes the coordinate-ring identity
+`Affine.CoordinateRing.mk_ψ₂_sq` into the field of fractions, where that vanishing is already
+absorbed by the quotient.
 -/
 
 public section


### PR DESCRIPTION
A documentation fix to merged code. The Provenance block of
`DivisionPolynomial/Universal.lean` describes a proof step that is not in the file, attributes
the port's one departure to the wrong lemma, and carries an off-by-one line citation. No
declaration, statement or proof changes; the diff is one paragraph of a module docstring.

## The defect

The block currently reads:

> One departure beyond the `ψᵤ` respelling: the source rewrites through its
> `polyToField_polynomial`, which has no counterpart here — the vanishing of the Weierstrass
> polynomial is inlined as a `have` through `AdjoinRoot.mk_self`, the same step
> `Universal.lean`'s `equation_point` uses.

Three things are wrong with it.

**1. There is no such `have`.** `AdjoinRoot.mk_self` does not occur anywhere in this file's
body — grep finds it only inside that sentence. `git log -S 'AdjoinRoot.mk_self'` on this path
returns the single commit that introduced the paragraph, so the described code was never
present: the prose was inaccurate when written, not made stale by later golfing.

**2. It blames the wrong lemma.** The sentence sits in a paragraph about the two nonvanishing
lemmas, which reads as though they are what departs from the source. They do not.
`polyToField_ψ_ne_zero` and `polyToField_φ_ne_zero` port their proofs essentially unchanged,
both retracting to the cusp curve at `(1, 1)` through `ringEval` — they never touch the
Weierstrass polynomial's vanishing at all. At the pinned revision the source uses
`polyToField_polynomial` in exactly one place, `polyToField_ψ₂Sq` (`:155`), so that is the only
lemma with a departure to describe.

**3. `:141` is an off-by-one** — at the pin `ψᵤ_ne_zero` is at `:142`. (`:148` and `:154` in the
same sentence are correct.)

## What the departure actually is

Source (`:155`), clearing the polynomial by rewriting it to zero:

```lean
rw [← map_pow, ψ_two, ψ₂_sq, map_add, map_mul, polyToField_polynomial, mul_zero, add_zero]
```

Here (`polyToField_Ψ₂Sq`), going through the coordinate ring instead, where the quotient has
already absorbed that vanishing — `Affine.CoordinateRing.mk_ψ₂_sq` is Mathlib's
`mk W W.ψ₂ ^ 2 = mk W (C W.Ψ₂Sq)`:

```lean
rw [ψ_two, polyToField_apply, polyToField_apply, ← map_pow]
exact (congrArg (algebraMap Universal.Ring Universal.Field)
  (Affine.CoordinateRing.mk_ψ₂_sq curve)).symm
```

The replacement paragraph says that, adds the one-clause note that the two nonvanishing lemmas
port unchanged, and corrects `:141` to `:142`.

## Not in scope

This PR does **not** add `polyToField_polynomial`. Its consumer count in the repository today is
one (`EllipticCurve/Universal.lean`, inside `equation_point`), which does not justify a named
API lemma; it will be introduced alongside the division-polynomial slope formulas, where two
lemmas genuinely consume it. The point here is only that the prose should describe the code
that exists.

## Gates

`lake build` (full library) PASS; `scripts/lint-env.sh` PASS with no new violations; targeted
module build PASS. Line lengths ≤ 100 codepoints (python-verified on decoded text — this
paragraph contains `ψ`, `φ`, `Ψ`, `ᵤ`, `ₙ` and en-dashes, so a byte count would misreport).
No declaration, statement, proof, attribute or import is touched: the diff is confined to the
module docstring.

## Provenance

The citations corrected here refer to J. Xu and D. K. Angdinata's
`projects/NagellLutz/LutzNagell/ZSMul.lean` in AINTLIB (`github.com/CBirkbeck/AINTLIB`,
Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), the source this file was ported
from. All line numbers were re-measured at that pin with `git show <pin>:<path>`; the local
clone's working tree is at a later revision, so a working-tree grep there reports numbers from
a different commit.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-universal-provenance-fix"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
