### PR TITLE
feat(Topology): Nakayama for a matrix with topologically nilpotent entries

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/Module.lean
+++ b/TauCeti/LinearAlgebra/Matrix/Module.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Module
+
+/-!
+# Vanishing of a family fixed by a matrix
+
+A family `y : n → P` in a module over a ring `A` satisfying `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` is exactly a
+fixed point of the `Matrix n n A`-action on `n → P`, so it is killed by `1 - B`. If `1 - B` is
+a unit, `y` vanishes.
+
+This is pure algebra: no topology, and `A` need not be commutative. It is stated here rather
+than beside the topological criteria that produce `IsUnit (1 - B)`, so that consumers do not
+have to import a ring theory they do not use — in particular it applies where `P` is an
+abstract subquotient with no topology of its own.
+
+## Main results
+
+* `TauCeti.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul`: a family fixed by `B` vanishes as
+  soon as `1 - B` is a unit.
+
+## References
+
+* [S. Bosch, U. Güntzer and R. Remmert, *Non-Archimedean Analysis*][bosch_guntzer_remmert],
+  §3.7.2/1, where this is the algebraic engine behind closedness of finitely generated
+  submodules.
+-/
+
+public section
+
+open scoped Matrix.Module
+
+namespace TauCeti
+
+/-- **Nakayama once `1 - B` is known to be a unit.** A family with `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` is killed by
+`1 - B` under the `Matrix n n A`-action on `n → P`, so invertibility of `1 - B` forces `y = 0`.
+
+Nothing topological appears: `P` carries no topology, and `A` is an arbitrary ring — the matrix
+action needs no commutativity. -/
+theorem eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul {A : Type*} [Ring A] {n : Type*}
+    [Fintype n] [DecidableEq n] {P : Type*} [AddCommGroup P] [Module A P]
+    {B : Matrix n n A} (hU : IsUnit (1 - B))
+    {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) : y = 0 := by
+  have hrel : (1 - B) • y = 0 := by
+    funext i
+    simp only [Matrix.Module.smul_apply, Matrix.sub_apply, sub_smul, Finset.sum_sub_distrib,
+      Matrix.one_apply, ite_smul, zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ite_true,
+      one_smul, Pi.zero_apply]
+    rw [← hy i, sub_self]
+  exact hU.smul_eq_zero.mp hrel
+
+end TauCeti

--- a/TauCeti/RingTheory/Huber/Matrix.lean
+++ b/TauCeti/RingTheory/Huber/Matrix.lean
@@ -17,17 +17,20 @@ Over a complete nonarchimedean ring, `1 - B` is invertible as soon as every entr
 topologically nilpotent, and consequently a family satisfying `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` vanishes.
 
 The vanishing argument is split from its topological input. Once `1 - B` is a unit the conclusion
-is pure algebra, and `TauCeti.Huber.eq_zero_of_isUnit_one_sub` states it that way: the module `P`
-carries **no topology**, which is what lets it be applied where `P` is an abstract subquotient.
+is pure algebra, and `TauCeti.Huber.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul` states
+it that way: the module `P` carries **no topology**, and `A` need not be commutative, which is
+what lets it be applied where `P` is an abstract subquotient.
 
 ## Main results
 
-* `TauCeti.Huber.eq_zero_of_isUnit_one_sub`: the algebraic core — a family fixed by `B` vanishes
-  as soon as `1 - B` is a unit. No topology on `P`, and none on `A` beyond what `B` needs.
+* `TauCeti.Huber.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul`: the algebraic core — a
+  family fixed by `B` vanishes as soon as `1 - B` is a unit. No topology on `P`, and `A` is an
+  arbitrary ring.
 * `TauCeti.Huber.isTopologicallyNilpotent_one_sub_det_one_sub`: `1 - det (1 - B)` is topologically
   nilpotent.
 * `TauCeti.Huber.isUnit_one_sub_of_isTopologicallyNilpotent_entries`: hence `1 - B` is a unit.
-* `TauCeti.Huber.eq_zero_of_forall_eq_sum_smul`: the two combined.
+* `TauCeti.Huber.eq_zero_of_isTopologicallyNilpotent_entries_of_forall_eq_sum_smul`:
+  the two combined.
 
 ## References
 
@@ -61,10 +64,12 @@ namespace TauCeti.Huber
 /-- **Nakayama once `1 - B` is known to be a unit.** A family with `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` is killed by
 `1 - B` under the `Matrix n n A`-action on `n → P`, so invertibility of `1 - B` forces `y = 0`.
 
-Nothing topological appears: `P` carries no topology, and `A` is an arbitrary commutative ring.
+Nothing topological appears: `P` carries no topology, and `A` is an arbitrary ring — the
+matrix action needs no commutativity.
 The topological content of this file is entirely in producing `hU`. -/
-theorem eq_zero_of_isUnit_one_sub {A : Type*} [CommRing A] {n : Type*} [Fintype n] [DecidableEq n]
-    {P : Type*} [AddCommGroup P] [Module A P] {B : Matrix n n A} (hU : IsUnit (1 - B))
+theorem eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul {A : Type*} [Ring A] {n : Type*}
+    [Fintype n] [DecidableEq n] {P : Type*} [AddCommGroup P] [Module A P]
+    {B : Matrix n n A} (hU : IsUnit (1 - B))
     {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) : y = 0 := by
   have hrel : (1 - B) • y = 0 := by
     funext i
@@ -128,12 +133,13 @@ theorem isUnit_one_sub_of_isTopologicallyNilpotent_entries {B : Matrix n n A}
 omit [DecidableEq n] in
 /-- **Nakayama for topologically nilpotent entries.** If every entry of `B` is topologically
 nilpotent and `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` for every `i`, then every `yᵢ` vanishes. This is
-`TauCeti.Huber.eq_zero_of_isUnit_one_sub` with its hypothesis discharged. -/
-theorem eq_zero_of_forall_eq_sum_smul {P : Type*} [AddCommGroup P] [Module A P]
-    {B : Matrix n n A} (hB : ∀ i j, IsTopologicallyNilpotent (B i j))
+`TauCeti.Huber.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul` with its hypothesis discharged. -/
+theorem eq_zero_of_isTopologicallyNilpotent_entries_of_forall_eq_sum_smul {P : Type*}
+    [AddCommGroup P] [Module A P] {B : Matrix n n A} (hB : ∀ i j, IsTopologicallyNilpotent (B i j))
     {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) (k : n) : y k = 0 := by
   classical
-  have := eq_zero_of_isUnit_one_sub (isUnit_one_sub_of_isTopologicallyNilpotent_entries hB) hy
+  have := eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul
+    (isUnit_one_sub_of_isTopologicallyNilpotent_entries hB) hy
   rw [this, Pi.zero_apply]
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Matrix.lean
+++ b/TauCeti/RingTheory/Huber/Matrix.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.LinearAlgebra.Matrix.Module
 public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 public import TauCeti.RingTheory.Huber.PowerBounded
 public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
@@ -15,30 +16,70 @@ public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
 Over a complete nonarchimedean ring, `1 - B` is invertible as soon as every entry of `B` is
 topologically nilpotent, and consequently a family satisfying `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` vanishes.
 
-The module the family lives in carries **no topology**: the whole topological input is the
-invertibility of `1 - B`, after which the conclusion is linear algebra. That is what makes this
-usable where the module is an abstract subquotient.
+The vanishing argument is split from its topological input. Once `1 - B` is a unit the conclusion
+is pure algebra, and `TauCeti.Huber.eq_zero_of_isUnit_one_sub` states it that way: the module `P`
+carries **no topology**, which is what lets it be applied where `P` is an abstract subquotient.
 
 ## Main results
 
+* `TauCeti.Huber.eq_zero_of_isUnit_one_sub`: the algebraic core — a family fixed by `B` vanishes
+  as soon as `1 - B` is a unit. No topology on `P`, and none on `A` beyond what `B` needs.
 * `TauCeti.Huber.isTopologicallyNilpotent_one_sub_det_one_sub`: `1 - det (1 - B)` is topologically
   nilpotent.
 * `TauCeti.Huber.isUnit_one_sub_of_isTopologicallyNilpotent_entries`: hence `1 - B` is a unit.
-* `TauCeti.Huber.eq_zero_of_forall_eq_sum_smul`: a family fixed by such a `B` is zero.
+* `TauCeti.Huber.eq_zero_of_forall_eq_sum_smul`: the two combined.
 
 ## References
 
 * [S. Bosch, U. Güntzer and R. Remmert, *Non-Archimedean Analysis*][bosch_guntzer_remmert],
   §3.7.2/1, where this is the algebraic engine behind closedness of finitely generated submodules.
+
+## Provenance
+
+AINTLIB (`github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9`, Apache-2.0) has all three of the
+topological statements in `projects/AdicSpaces/Adic spaces/Bounded.lean` —
+`IsTopologicallyNilpotent.one_sub_det_one_sub_matrix` (:666),
+`IsTopologicallyNilpotent.isUnit_one_sub_matrix` (:704) and
+`eq_zero_of_forall_eq_sum_topNilp_smul` (:740) — and takes **the same route**: lift to the
+power-bounded subring, reduce modulo the topologically nilpotent ideal, apply `RingHom.map_det`,
+then `Matrix.isUnit_iff_isUnit_det`. This module was written against this repository's own API and
+compared afterwards; since the routes coincide it should be read as a re-derivation of that
+argument rather than an independent one. Nothing was copied: the names differ throughout, the
+hypotheses here are the plain nonarchimedean bundle rather than AINTLIB's section variables, the
+vanishing step goes through Mathlib's `Matrix.Module` action, and the algebraic core is split out,
+which AINTLIB does not do.
 -/
 
 public section
 
+open scoped Matrix.Module
+
 namespace TauCeti.Huber
 
+/-! ### The algebraic core -/
+
+/-- **Nakayama once `1 - B` is known to be a unit.** A family with `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` is killed by
+`1 - B` under the `Matrix n n A`-action on `n → P`, so invertibility of `1 - B` forces `y = 0`.
+
+Nothing topological appears: `P` carries no topology, and `A` is an arbitrary commutative ring.
+The topological content of this file is entirely in producing `hU`. -/
+theorem eq_zero_of_isUnit_one_sub {A : Type*} [CommRing A] {n : Type*} [Fintype n] [DecidableEq n]
+    {P : Type*} [AddCommGroup P] [Module A P] {B : Matrix n n A} (hU : IsUnit (1 - B))
+    {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) : y = 0 := by
+  have hrel : (1 - B) • y = 0 := by
+    funext i
+    simp only [Matrix.Module.smul_apply, Matrix.sub_apply, sub_smul, Finset.sum_sub_distrib,
+      Matrix.one_apply, ite_smul, zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ite_true,
+      one_smul, Pi.zero_apply]
+    rw [← hy i, sub_self]
+  obtain ⟨U, hUeq⟩ := hU
+  simpa [smul_smul, ← hUeq, ← mul_smul] using
+    congrArg (fun v ↦ (↑U⁻¹ : Matrix n n A) • v) hrel
+
+/-! ### The topological input -/
+
 variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
-  [IsUniformAddGroup A] [NonarchimedeanRing A]
-  {n : Type*} [Fintype n] [DecidableEq n]
+  [IsUniformAddGroup A] [NonarchimedeanRing A] {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- The entries of `B`, viewed in `A°`. Topologically nilpotent elements are power-bounded, so
 this is well defined, and it is what puts `B` inside the ideal `A°°` where the determinant
@@ -57,7 +98,6 @@ theorem isTopologicallyNilpotent_one_sub_det_one_sub {B : Matrix n n A}
     IsTopologicallyNilpotent (1 - (1 - B).det) := by
   set I := topologicallyNilpotentIdeal A with hI
   set B' := toPowerBoundedMatrix B hB with hB'
-  -- Modulo `A°°` the matrix `1 - B'` is the identity, so its determinant is `1`.
   have hmap : (Ideal.Quotient.mk I).mapMatrix (1 - B') = 1 := by
     ext i j
     have hzero : Ideal.Quotient.mk I (B' i j) = 0 :=
@@ -66,7 +106,6 @@ theorem isTopologicallyNilpotent_one_sub_det_one_sub {B : Matrix n n A}
       Matrix.one_apply, apply_ite (Ideal.Quotient.mk I)]
   have hmod : Ideal.Quotient.mk I (1 - B').det = 1 := by
     rw [RingHom.map_det, hmap, Matrix.det_one]
-  -- So `1 - det (1 - B')` lies in `A°°`, and `A°°` is topological nilpotence.
   have hmem : (1 : powerBoundedSubring A) - (1 - B').det ∈ I := by
     rw [← Ideal.Quotient.eq_zero_iff_mem, map_sub, hmod, map_one, sub_self]
   have hcoemap : (powerBoundedSubring A).subtype.mapMatrix (1 - B') = 1 - B := by
@@ -74,9 +113,8 @@ theorem isTopologicallyNilpotent_one_sub_det_one_sub {B : Matrix n n A}
     simp [RingHom.mapMatrix_apply, Matrix.map_apply, Matrix.sub_apply, Matrix.one_apply,
       hB', toPowerBoundedMatrix, apply_ite ((↑) : powerBoundedSubring A → A)]
   have hcoe : ((1 - B').det : A) = (1 - B).det := by
-    rw [show (((1 - B').det : powerBoundedSubring A) : A)
-      = (powerBoundedSubring A).subtype (1 - B').det from rfl,
-      RingHom.map_det, hcoemap]
+    simpa only [← RingHom.map_det, Subring.coe_subtype] using
+      congrArg Matrix.det hcoemap
   simpa [hcoe] using (mem_topologicallyNilpotentIdeal.mp hmem)
 
 /-- **`1 - B` is invertible when every entry of `B` is topologically nilpotent.** The determinant
@@ -89,29 +127,13 @@ theorem isUnit_one_sub_of_isTopologicallyNilpotent_entries {B : Matrix n n A}
 
 omit [DecidableEq n] in
 /-- **Nakayama for topologically nilpotent entries.** If every entry of `B` is topologically
-nilpotent and `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` for every `i`, then every `yᵢ` vanishes.
-
-`P` carries no topology: `1 - B` is a unit by the statement above, and applying its inverse to the
-relation `∑ⱼ (1 - B)ᵢⱼ • yⱼ = 0` is pure linear algebra. -/
+nilpotent and `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` for every `i`, then every `yᵢ` vanishes. This is
+`TauCeti.Huber.eq_zero_of_isUnit_one_sub` with its hypothesis discharged. -/
 theorem eq_zero_of_forall_eq_sum_smul {P : Type*} [AddCommGroup P] [Module A P]
     {B : Matrix n n A} (hB : ∀ i j, IsTopologicallyNilpotent (B i j))
     {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) (k : n) : y k = 0 := by
   classical
-  obtain ⟨U, hU⟩ := isUnit_one_sub_of_isTopologicallyNilpotent_entries hB
-  -- The relation says `(1 - B)` kills `y` in the sense of the matrix action on `n → P`.
-  have hrel : ∀ i, ∑ j, (1 - B) i j • y j = 0 := by
-    intro i
-    simp only [Matrix.sub_apply, sub_smul, Finset.sum_sub_distrib, Matrix.one_apply,
-      ite_smul, zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ite_true, one_smul]
-    rw [← hy i, sub_self]
-  -- Apply the inverse: `y k = ∑ⱼ (U⁻¹ (1 - B))ₖⱼ • yⱼ`, and the inner sums all vanish.
-  have hinv : (↑U⁻¹ : Matrix n n A) * (1 - B) = 1 := by rw [← hU]; exact U.inv_mul
-  calc y k = ∑ j, (1 : Matrix n n A) k j • y j := by
-        simp [Matrix.one_apply, ite_smul]
-    _ = ∑ j, ((↑U⁻¹ : Matrix n n A) * (1 - B)) k j • y j := by rw [hinv]
-    _ = ∑ i, (↑U⁻¹ : Matrix n n A) k i • ∑ j, (1 - B) i j • y j := by
-        simp_rw [Matrix.mul_apply, Finset.sum_smul, ← smul_smul, Finset.smul_sum]
-        exact Finset.sum_comm
-    _ = 0 := by simp only [hrel, smul_zero, Finset.sum_const_zero]
+  have := eq_zero_of_isUnit_one_sub (isUnit_one_sub_of_isTopologicallyNilpotent_entries hB) hy
+  rw [this, Pi.zero_apply]
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Matrix.lean
+++ b/TauCeti/RingTheory/Huber/Matrix.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.Module
 public import TauCeti.LinearAlgebra.Matrix.Module
 public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 public import TauCeti.RingTheory.Huber.PowerBounded

--- a/TauCeti/RingTheory/Huber/Matrix.lean
+++ b/TauCeti/RingTheory/Huber/Matrix.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Matrix.Module
+public import TauCeti.LinearAlgebra.Matrix.Module
 public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 public import TauCeti.RingTheory.Huber.PowerBounded
 public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
@@ -17,20 +18,19 @@ Over a complete nonarchimedean ring, `1 - B` is invertible as soon as every entr
 topologically nilpotent, and consequently a family satisfying `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` vanishes.
 
 The vanishing argument is split from its topological input. Once `1 - B` is a unit the conclusion
-is pure algebra, and `TauCeti.Huber.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul` states
-it that way: the module `P` carries **no topology**, and `A` need not be commutative, which is
-what lets it be applied where `P` is an abstract subquotient.
+is pure algebra, and `TauCeti.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul` states it that way
+in `TauCeti.LinearAlgebra.Matrix.Module`, where it needs no ring theory at all: the module `P`
+carries **no topology**, and `A` need not be commutative, which is what lets it be applied where
+`P` is an abstract subquotient. This file supplies only the topological input.
 
 ## Main results
 
-* `TauCeti.Huber.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul`: the algebraic core — a
-  family fixed by `B` vanishes as soon as `1 - B` is a unit. No topology on `P`, and `A` is an
-  arbitrary ring.
 * `TauCeti.Huber.isTopologicallyNilpotent_one_sub_det_one_sub`: `1 - det (1 - B)` is topologically
   nilpotent.
 * `TauCeti.Huber.isUnit_one_sub_of_isTopologicallyNilpotent_entries`: hence `1 - B` is a unit.
-* `TauCeti.Huber.eq_zero_of_isTopologicallyNilpotent_entries_of_forall_eq_sum_smul`:
-  the two combined.
+* `TauCeti.Huber.eq_zero_of_isTopologicallyNilpotent_entries_of_forall_eq_sum_smul`: the
+  topological criterion combined with the algebraic core, which is imported from
+  `TauCeti.LinearAlgebra.Matrix.Module`.
 
 ## References
 
@@ -59,32 +59,12 @@ open scoped Matrix.Module
 
 namespace TauCeti.Huber
 
-/-! ### The algebraic core -/
+/-! ### The determinant modulo topologically nilpotent entries -/
 
-/-- **Nakayama once `1 - B` is known to be a unit.** A family with `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` is killed by
-`1 - B` under the `Matrix n n A`-action on `n → P`, so invertibility of `1 - B` forces `y = 0`.
+section Topological
 
-Nothing topological appears: `P` carries no topology, and `A` is an arbitrary ring — the
-matrix action needs no commutativity.
-The topological content of this file is entirely in producing `hU`. -/
-theorem eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul {A : Type*} [Ring A] {n : Type*}
-    [Fintype n] [DecidableEq n] {P : Type*} [AddCommGroup P] [Module A P]
-    {B : Matrix n n A} (hU : IsUnit (1 - B))
-    {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) : y = 0 := by
-  have hrel : (1 - B) • y = 0 := by
-    funext i
-    simp only [Matrix.Module.smul_apply, Matrix.sub_apply, sub_smul, Finset.sum_sub_distrib,
-      Matrix.one_apply, ite_smul, zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ite_true,
-      one_smul, Pi.zero_apply]
-    rw [← hy i, sub_self]
-  obtain ⟨U, hUeq⟩ := hU
-  simpa [smul_smul, ← hUeq, ← mul_smul] using
-    congrArg (fun v ↦ (↑U⁻¹ : Matrix n n A) • v) hrel
-
-/-! ### The topological input -/
-
-variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
-  [IsUniformAddGroup A] [NonarchimedeanRing A] {n : Type*} [Fintype n] [DecidableEq n]
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+  {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- The entries of `B`, viewed in `A°`. Topologically nilpotent elements are power-bounded, so
 this is well defined, and it is what puts `B` inside the ideal `A°°` where the determinant
@@ -94,7 +74,6 @@ private def toPowerBoundedMatrix (B : Matrix n n A)
   Matrix.of fun i j ↦ ⟨B i j, mem_powerBoundedSubring.mpr
     (IsPowerBounded.of_isTopologicallyNilpotent (hB i j))⟩
 
-omit [T2Space A] [CompleteSpace A] [IsUniformAddGroup A] in
 /-- **The determinant of `1 - B` is `1` up to a topologically nilpotent error.** Every entry of
 `B` lies in the ideal `A°°` of `A°`, so `1 - B` reduces to the identity modulo that ideal and its
 determinant reduces to `1`. -/
@@ -122,6 +101,15 @@ theorem isTopologicallyNilpotent_one_sub_det_one_sub {B : Matrix n n A}
       congrArg Matrix.det hcoemap
   simpa [hcoe] using (mem_topologicallyNilpotentIdeal.mp hmem)
 
+end Topological
+
+/-! ### Invertibility, and Nakayama -/
+
+section Complete
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
+  [IsUniformAddGroup A] [NonarchimedeanRing A] {n : Type*} [Fintype n] [DecidableEq n]
+
 /-- **`1 - B` is invertible when every entry of `B` is topologically nilpotent.** The determinant
 is `1` minus a topologically nilpotent element, hence a unit by the geometric series, and a square
 matrix over a commutative ring is a unit exactly when its determinant is. -/
@@ -132,14 +120,16 @@ theorem isUnit_one_sub_of_isTopologicallyNilpotent_entries {B : Matrix n n A}
 
 omit [DecidableEq n] in
 /-- **Nakayama for topologically nilpotent entries.** If every entry of `B` is topologically
-nilpotent and `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` for every `i`, then every `yᵢ` vanishes. This is
-`TauCeti.Huber.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul` with its hypothesis discharged. -/
+nilpotent and `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` for every `i`, then the whole family vanishes. This is
+`TauCeti.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul` with its hypothesis discharged; a
+consumer wanting a single coordinate applies `congrFun`. -/
 theorem eq_zero_of_isTopologicallyNilpotent_entries_of_forall_eq_sum_smul {P : Type*}
     [AddCommGroup P] [Module A P] {B : Matrix n n A} (hB : ∀ i j, IsTopologicallyNilpotent (B i j))
-    {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) (k : n) : y k = 0 := by
+    {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) : y = 0 := by
   classical
-  have := eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul
+  exact eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul
     (isUnit_one_sub_of_isTopologicallyNilpotent_entries hB) hy
-  rw [this, Pi.zero_apply]
+
+end Complete
 
 end TauCeti.Huber

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Matrix.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Matrix.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+public import TauCeti.RingTheory.Huber.PowerBounded
+public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
+
+/-!
+# Nakayama for a matrix with topologically nilpotent entries
+
+Over a complete nonarchimedean ring, `1 - B` is invertible as soon as every entry of `B` is
+topologically nilpotent, and consequently a family satisfying `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` vanishes.
+
+The module the family lives in carries **no topology**: the whole topological input is the
+invertibility of `1 - B`, after which the conclusion is linear algebra. That is what makes this
+usable where the module is an abstract subquotient.
+
+## Main results
+
+* `TauCeti.Huber.isTopologicallyNilpotent_one_sub_det_one_sub`: `1 - det (1 - B)` is topologically
+  nilpotent.
+* `TauCeti.Huber.isUnit_one_sub_of_isTopologicallyNilpotent_entries`: hence `1 - B` is a unit.
+* `TauCeti.Huber.eq_zero_of_forall_eq_sum_smul`: a family fixed by such a `B` is zero.
+
+## References
+
+* [S. Bosch, U. Güntzer and R. Remmert, *Non-Archimedean Analysis*][bosch_guntzer_remmert],
+  §3.7.2/1, where this is the algebraic engine behind closedness of finitely generated submodules.
+-/
+
+public section
+
+namespace TauCeti.Huber
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
+  [IsUniformAddGroup A] [NonarchimedeanRing A]
+  {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The entries of `B`, viewed in `A°`. Topologically nilpotent elements are power-bounded, so
+this is well defined, and it is what puts `B` inside the ideal `A°°` where the determinant
+computation happens. -/
+private def toPowerBoundedMatrix (B : Matrix n n A)
+    (hB : ∀ i j, IsTopologicallyNilpotent (B i j)) : Matrix n n (powerBoundedSubring A) :=
+  Matrix.of fun i j ↦ ⟨B i j, mem_powerBoundedSubring.mpr
+    (IsPowerBounded.of_isTopologicallyNilpotent (hB i j))⟩
+
+omit [T2Space A] [CompleteSpace A] [IsUniformAddGroup A] in
+/-- **The determinant of `1 - B` is `1` up to a topologically nilpotent error.** Every entry of
+`B` lies in the ideal `A°°` of `A°`, so `1 - B` reduces to the identity modulo that ideal and its
+determinant reduces to `1`. -/
+theorem isTopologicallyNilpotent_one_sub_det_one_sub {B : Matrix n n A}
+    (hB : ∀ i j, IsTopologicallyNilpotent (B i j)) :
+    IsTopologicallyNilpotent (1 - (1 - B).det) := by
+  set I := topologicallyNilpotentIdeal A with hI
+  set B' := toPowerBoundedMatrix B hB with hB'
+  -- Modulo `A°°` the matrix `1 - B'` is the identity, so its determinant is `1`.
+  have hmap : (Ideal.Quotient.mk I).mapMatrix (1 - B') = 1 := by
+    ext i j
+    have hzero : Ideal.Quotient.mk I (B' i j) = 0 :=
+      (Ideal.Quotient.eq_zero_iff_mem).mpr (mem_topologicallyNilpotentIdeal.mpr (hB i j))
+    simp [RingHom.mapMatrix_apply, Matrix.map_apply, Matrix.sub_apply, hzero,
+      Matrix.one_apply, apply_ite (Ideal.Quotient.mk I)]
+  have hmod : Ideal.Quotient.mk I (1 - B').det = 1 := by
+    rw [RingHom.map_det, hmap, Matrix.det_one]
+  -- So `1 - det (1 - B')` lies in `A°°`, and `A°°` is topological nilpotence.
+  have hmem : (1 : powerBoundedSubring A) - (1 - B').det ∈ I := by
+    rw [← Ideal.Quotient.eq_zero_iff_mem, map_sub, hmod, map_one, sub_self]
+  have hcoemap : (powerBoundedSubring A).subtype.mapMatrix (1 - B') = 1 - B := by
+    ext i j
+    simp [RingHom.mapMatrix_apply, Matrix.map_apply, Matrix.sub_apply, Matrix.one_apply,
+      hB', toPowerBoundedMatrix, apply_ite ((↑) : powerBoundedSubring A → A)]
+  have hcoe : ((1 - B').det : A) = (1 - B).det := by
+    rw [show (((1 - B').det : powerBoundedSubring A) : A)
+      = (powerBoundedSubring A).subtype (1 - B').det from rfl,
+      RingHom.map_det, hcoemap]
+  simpa [hcoe] using (mem_topologicallyNilpotentIdeal.mp hmem)
+
+/-- **`1 - B` is invertible when every entry of `B` is topologically nilpotent.** The determinant
+is `1` minus a topologically nilpotent element, hence a unit by the geometric series, and a square
+matrix over a commutative ring is a unit exactly when its determinant is. -/
+theorem isUnit_one_sub_of_isTopologicallyNilpotent_entries {B : Matrix n n A}
+    (hB : ∀ i j, IsTopologicallyNilpotent (B i j)) : IsUnit (1 - B) := by
+  rw [Matrix.isUnit_iff_isUnit_det]
+  simpa using (isTopologicallyNilpotent_one_sub_det_one_sub hB).isUnit_one_sub
+
+omit [DecidableEq n] in
+/-- **Nakayama for topologically nilpotent entries.** If every entry of `B` is topologically
+nilpotent and `yᵢ = ∑ⱼ Bᵢⱼ • yⱼ` for every `i`, then every `yᵢ` vanishes.
+
+`P` carries no topology: `1 - B` is a unit by the statement above, and applying its inverse to the
+relation `∑ⱼ (1 - B)ᵢⱼ • yⱼ = 0` is pure linear algebra. -/
+theorem eq_zero_of_forall_eq_sum_smul {P : Type*} [AddCommGroup P] [Module A P]
+    {B : Matrix n n A} (hB : ∀ i j, IsTopologicallyNilpotent (B i j))
+    {y : n → P} (hy : ∀ i, y i = ∑ j, B i j • y j) (k : n) : y k = 0 := by
+  classical
+  obtain ⟨U, hU⟩ := isUnit_one_sub_of_isTopologicallyNilpotent_entries hB
+  -- The relation says `(1 - B)` kills `y` in the sense of the matrix action on `n → P`.
+  have hrel : ∀ i, ∑ j, (1 - B) i j • y j = 0 := by
+    intro i
+    simp only [Matrix.sub_apply, sub_smul, Finset.sum_sub_distrib, Matrix.one_apply,
+      ite_smul, zero_smul, Finset.sum_ite_eq, Finset.mem_univ, ite_true, one_smul]
+    rw [← hy i, sub_self]
+  -- Apply the inverse: `y k = ∑ⱼ (U⁻¹ (1 - B))ₖⱼ • yⱼ`, and the inner sums all vanish.
+  have hinv : (↑U⁻¹ : Matrix n n A) * (1 - B) = 1 := by rw [← hU]; exact U.inv_mul
+  calc y k = ∑ j, (1 : Matrix n n A) k j • y j := by
+        simp [Matrix.one_apply, ite_smul]
+    _ = ∑ j, ((↑U⁻¹ : Matrix n n A) * (1 - B)) k j • y j := by rw [hinv]
+    _ = ∑ i, (↑U⁻¹ : Matrix n n A) k i • ∑ j, (1 - B) i j • y j := by
+        simp_rw [Matrix.mul_apply, Finset.sum_smul, ← smul_smul, Finset.smul_sum]
+        exact Finset.sum_comm
+    _ = 0 := by simp only [hrel, smul_zero, Finset.sum_const_zero]
+
+end TauCeti.Huber


### PR DESCRIPTION
Over a complete nonarchimedean ring, a family fixed by a matrix with topologically nilpotent
entries vanishes:

```text
isTopologicallyNilpotent_one_sub_det_one_sub  (∀ i j, IsTopologicallyNilpotent (B i j)) :
  IsTopologicallyNilpotent (1 - (1 - B).det)

isUnit_one_sub_of_isTopologicallyNilpotent_entries : IsUnit (1 - B)

eq_zero_of_isTopologicallyNilpotent_entries_of_forall_eq_sum_smul  {P} [AddCommGroup P]
    [Module A P]
    (hy : ∀ i, y i = ∑ j, B i j • y j) : y = 0
```

## The algebraic core is a separate module

`TauCeti.eq_zero_of_isUnit_one_sub_of_forall_eq_sum_smul` takes `hU : IsUnit (1 - B)` and
concludes `y = 0`, with **no topology on `P` and `A` an arbitrary `Ring`** — the matrix action
needs no commutativity, so it applies at scalar rings such as `Mat₂(ℤ)`. Because it is generic
matrix-module algebra rather than Huber material, it lives in its own file,
`TauCeti/LinearAlgebra/Matrix/Module.lean`, which imports nothing beyond
`Mathlib.LinearAlgebra.Matrix.Module`; `RingTheory/Huber/Matrix.lean` imports it back. Nothing
is left behind at the old name.

The topological theorem is that core with its hypothesis discharged, so a caller who obtains
invertibility another way never touches the nonarchimedean machinery — and now does not have to
import Huber's ring theory either.

`RingTheory/Huber/Matrix.lean` is split accordingly: a `Topological` section carrying only
`[TopologicalSpace A] [NonarchimedeanRing A]`, which is all `powerBoundedSubring` and the
determinant computation need, and a `Complete` section adding uniformity and completeness for
the geometric series.

## The point of the last statement is what `P` is *not*

`P` carries **no topology**. All the topological input is spent on making `1 - B` a unit; after
that the conclusion is linear algebra. That is what lets it be applied where `P` is an abstract
subquotient with no topology of its own — which is how BGR §3.7.2/1 uses it to prove that a
finitely generated submodule of a complete Tate module is closed.

## The determinant step

`1 - B` reduces to the identity modulo the ideal of topologically nilpotent elements, so its
determinant reduces to `1`. Concretely: each `B i j` is topologically nilpotent, hence power
bounded, so `B` lifts to a matrix over `A°`; its entries lie in `A°°`, the ideal
`TauCeti.Huber.topologicallyNilpotentIdeal`; reduction along `Ideal.Quotient.mk` carries `1 - B'`
to `1`, and `RingHom.map_det` carries the determinant with it. Pushing back down gives
`det (1 - B) = 1 - t` with `t` topologically nilpotent, which is a unit by
`IsTopologicallyNilpotent.isUnit_one_sub` — the geometric series already on `main` — and
`Matrix.isUnit_iff_isUnit_det` finishes.

Every ingredient was already on `main`: `powerBoundedSubring`, `topologicallyNilpotentIdeal` and
`IsPowerBounded.of_isTopologicallyNilpotent` in `Huber/PowerBounded.lean`, and
`IsTopologicallyNilpotent.isUnit_one_sub` in `Nonarchimedean/GeometricSeries.lean`. Nothing new
about topological nilpotence is proved here.

Note that mathlib's `IsTopologicallyNilpotent.add`/`.mul_left`/`.mul_right` are **unusable** in
this setting — they assume `[IsLinearTopology R R]`, which no nonzero Tate ring satisfies, as
`Huber/PowerBounded.lean`'s own docstring records. The nonarchimedean replacements it supplies are
what the ideal `A°°` is built from, and this PR consumes that ideal rather than re-deriving the
closure properties.

## Where it is going

BGR §3.7.2/1 → Wedhorn Proposition 6.18(2) ("`u` is continuous and open onto its image") → middle
exactness of `Aⁿ⟨X⟩ → Aᵐ⟨X⟩ → M⟨X⟩` → the injectivity half of Remark 8.29, which is
`TauCetiRoadmap/AdicSpaces/README.md` Layer 4.1 step 1. The surjectivity half is #3994.
Propositions 6.17–6.18 are named as outstanding in two module docstrings already on `main`
(`Huber/ZeroSequenceOfUnits.lean:35`, `Topology/Algebra/OpenMapping/Basic.lean:65`); this is the
bottom of that chain and the only part of it that needs no submodule-topology instances.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"matrix-nakayama-topologically-nilpotent"}-->

Provenance: AINTLIB (`github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9`, Apache-2.0,
`projects/AdicSpaces/Adic spaces/Bounded.lean`) **has all three statements** —
`IsTopologicallyNilpotent.one_sub_det_one_sub_matrix` (:666),
`IsTopologicallyNilpotent.isUnit_one_sub_matrix` (:704) and
`eq_zero_of_forall_eq_sum_topNilp_smul` (:740). I wrote this from TauCeti's own on-main API and
then read theirs, and **the route is the same**: lift to the power-bounded subring, reduce modulo
the topologically nilpotent ideal, apply `RingHom.map_det`, then
`Matrix.isUnit_iff_isUnit_det`. It is the natural proof, so the agreement is not evidence either
way — a reviewer should treat this as a re-derivation of AINTLIB's argument rather than an
independent one. Nothing was copied: the names differ throughout (`topologicallyNilpotentIdeal`
vs `topNilpIdeal`, `powerBoundedSubring` vs `powerBoundedSubring.toSubring`), the hypotheses here
are the plain nonarchimedean bundle rather than AINTLIB's section variables (which include
`[HasLocLiftPowerBounded A]`, the typeclass TauCeti deliberately replaced), and the final Nakayama
step is a `calc` through `U⁻¹ * (1 - B) = 1` rather than their factored
`eq_zero_of_isUnit_matrix_of_forall_sum_smul_eq_zero`. Mathlib absence checked by untruncated grep
for each statement name and for `Matrix`-valued `isUnit_one_sub` forms: 0 hits.


