### PR TITLE
refactor(Huber): factor out the idealImage nilpotence lemma

### DIFF
--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -42,9 +42,6 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
 * `TauCeti.Huber.IsAdic.comap`: an adic topology transports along a ring equivalence that is an
   inducing map. This is what lets a ring of definition carry an ideal of definition that natively
   lives in a merely equivalent ring, which is what `TauCeti.Huber.PairOfDefinition` needs.
-* `TauCeti.Huber.IsHuberRing.exists_nhds_zero_forall_isTopologicallyNilpotent`:
-  a Huber ring has a whole neighbourhood of zero of topologically nilpotent elements — the form
-  an argument over a matrix needs, where every entry must be nilpotent at once.
 * `TauCeti.Huber.IsHuberRing.toNonarchimedeanRing`: a Huber ring is nonarchimedean.
 * `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`: its neighbourhoods of zero are
   countably generated. With the previous bullet these are exactly the two hypotheses Henkel's open
@@ -357,6 +354,18 @@ theorem isTopologicallyNilpotent_of_mem_idealOfDefinition (P : PairOfDefinition 
   refine (P.mem_idealImage n).mpr ⟨a ^ m, ?_, by push_cast; ring⟩
   exact Ideal.pow_le_pow_right hm (Ideal.pow_mem_pow ha m)
 
+/-- **An element of the image of `Iⁿ` is topologically nilpotent**, for `n ≠ 0`. Unpacking the
+membership gives an element of `Iⁿ ⊆ I`, so `isTopologicallyNilpotent_of_mem_idealOfDefinition`
+applies. This is the form consumers meet, `idealImage` being what
+`TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero` is stated with.
+
+`n ≠ 0` is needed, not incidental: `I ^ 0 = ⊤`, so `idealImage 0` is the image of the whole ring
+of definition and its elements are not topologically nilpotent in general. -/
+theorem isTopologicallyNilpotent_of_mem_idealImage (P : PairOfDefinition A) {n : ℕ} (hn : n ≠ 0)
+    {a : A} (ha : a ∈ P.idealImage n) : IsTopologicallyNilpotent a := by
+  obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage n).mp ha
+  exact P.isTopologicallyNilpotent_of_mem_idealOfDefinition (Ideal.pow_le_self hn hy)
+
 /-- A ring admitting a pair of definition is nonarchimedean. -/
 theorem toNonarchimedeanRing [IsTopologicalRing A] (P : PairOfDefinition A) :
     NonarchimedeanRing A where
@@ -483,28 +492,6 @@ point — it is what lets a Huber ring be handed to that theorem without the cal
 anything. -/
 instance IsHuberRing.isCountablyGenerated_nhds_zero : (𝓝 (0 : A)).IsCountablyGenerated :=
   IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦ P.hasBasis_nhds_zero.isCountablyGenerated
-
-/-- **A Huber ring has a neighbourhood of zero all of whose elements are topologically
-nilpotent.** The image of an ideal of definition is such a neighbourhood: it is open, and its
-elements are topologically nilpotent because their powers run through the images of the `Iⁿ`,
-which are a basis of `𝓝 0`.
-
-Being able to *choose* a whole neighbourhood, rather than one element at a time, is what
-arguments over a matrix need — every entry drawn from `W` is then topologically nilpotent at
-once, which is the hypothesis of Nakayama for such a matrix. Note the statement asks nothing of
-`A` beyond being Huber; no pseudouniformiser and no Tate hypothesis appear.
-
-Provenance: AINTLIB (`github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9`, Apache-2.0,
-`projects/AdicSpaces/`) states the same shape under `[IsTateRing A]`, taking `W = ϖ • A°` for a
-pseudouniformiser `ϖ`. Consulted, not ported: this version assumes only that `A` is Huber, where
-no pseudouniformiser need exist. -/
-theorem IsHuberRing.exists_nhds_zero_forall_isTopologicallyNilpotent :
-    ∃ W ∈ 𝓝 (0 : A), ∀ a ∈ W, IsTopologicallyNilpotent a :=
-  IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦
-    ⟨(P.idealImage 1 : Set A), (P.isOpen_idealImage 1).mem_nhds (P.idealImage 1).zero_mem,
-      fun a (ha : a ∈ P.idealImage 1) ↦ by
-        obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage 1).mp ha
-        exact P.isTopologicallyNilpotent_of_mem_idealOfDefinition (by simpa using hy)⟩
 
 /-- Wedhorn Corollary 6.4: the power-bounded subring of a Huber ring is open. -/
 theorem isOpen_powerBoundedSubring : IsOpen (powerBoundedSubring A : Set A) := by

--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -42,8 +42,6 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
 * `TauCeti.Huber.IsAdic.comap`: an adic topology transports along a ring equivalence that is an
   inducing map. This is what lets a ring of definition carry an ideal of definition that natively
   lives in a merely equivalent ring, which is what `TauCeti.Huber.PairOfDefinition` needs.
-* `TauCeti.Huber.PairOfDefinition.isTopologicallyNilpotent_of_mem_idealImage`:
-  the same read in `A` rather than in `A₀`.
 * `TauCeti.Huber.IsHuberRing.exists_nhds_zero_forall_isTopologicallyNilpotent`:
   a Huber ring has a whole neighbourhood of zero of topologically nilpotent elements — the form
   an argument over a matrix needs, where every entry must be nilpotent at once.
@@ -359,14 +357,6 @@ theorem isTopologicallyNilpotent_of_mem_idealOfDefinition (P : PairOfDefinition 
   refine (P.mem_idealImage n).mpr ⟨a ^ m, ?_, by push_cast; ring⟩
   exact Ideal.pow_le_pow_right hm (Ideal.pow_mem_pow ha m)
 
-/-- **The image of the ideal of definition consists of topologically nilpotent elements.** This is
-`TauCeti.Huber.PairOfDefinition.isTopologicallyNilpotent_of_mem_idealOfDefinition` read in `A`
-rather than in `A₀`, which is the form a consumer working in `A` wants. -/
-theorem isTopologicallyNilpotent_of_mem_idealImage (P : PairOfDefinition A) {a : A}
-    (ha : a ∈ P.idealImage 1) : IsTopologicallyNilpotent a := by
-  obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage 1).mp ha
-  exact P.isTopologicallyNilpotent_of_mem_idealOfDefinition (by simpa using hy)
-
 /-- A ring admitting a pair of definition is nonarchimedean. -/
 theorem toNonarchimedeanRing [IsTopologicalRing A] (P : PairOfDefinition A) :
     NonarchimedeanRing A where
@@ -502,12 +492,19 @@ which are a basis of `𝓝 0`.
 Being able to *choose* a whole neighbourhood, rather than one element at a time, is what
 arguments over a matrix need — every entry drawn from `W` is then topologically nilpotent at
 once, which is the hypothesis of Nakayama for such a matrix. Note the statement asks nothing of
-`A` beyond being Huber; no pseudouniformiser and no Tate hypothesis appear. -/
+`A` beyond being Huber; no pseudouniformiser and no Tate hypothesis appear.
+
+Provenance: AINTLIB (`github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9`, Apache-2.0,
+`projects/AdicSpaces/`) states the same shape under `[IsTateRing A]`, taking `W = ϖ • A°` for a
+pseudouniformiser `ϖ`. Consulted, not ported: this version assumes only that `A` is Huber, where
+no pseudouniformiser need exist. -/
 theorem IsHuberRing.exists_nhds_zero_forall_isTopologicallyNilpotent :
     ∃ W ∈ 𝓝 (0 : A), ∀ a ∈ W, IsTopologicallyNilpotent a :=
   IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦
     ⟨(P.idealImage 1 : Set A), (P.isOpen_idealImage 1).mem_nhds (P.idealImage 1).zero_mem,
-      fun _ ha ↦ P.isTopologicallyNilpotent_of_mem_idealImage ha⟩
+      fun a (ha : a ∈ P.idealImage 1) ↦ by
+        obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage 1).mp ha
+        exact P.isTopologicallyNilpotent_of_mem_idealOfDefinition (by simpa using hy)⟩
 
 /-- Wedhorn Corollary 6.4: the power-bounded subring of a Huber ring is open. -/
 theorem isOpen_powerBoundedSubring : IsOpen (powerBoundedSubring A : Set A) := by

--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -42,6 +42,11 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
 * `TauCeti.Huber.IsAdic.comap`: an adic topology transports along a ring equivalence that is an
   inducing map. This is what lets a ring of definition carry an ideal of definition that natively
   lives in a merely equivalent ring, which is what `TauCeti.Huber.PairOfDefinition` needs.
+* `TauCeti.Huber.PairOfDefinition.isTopologicallyNilpotent_of_mem_idealImage`:
+  the same read in `A` rather than in `A₀`.
+* `TauCeti.Huber.IsHuberRing.exists_nhds_zero_forall_isTopologicallyNilpotent`:
+  a Huber ring has a whole neighbourhood of zero of topologically nilpotent elements — the form
+  an argument over a matrix needs, where every entry must be nilpotent at once.
 * `TauCeti.Huber.IsHuberRing.toNonarchimedeanRing`: a Huber ring is nonarchimedean.
 * `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`: its neighbourhoods of zero are
   countably generated. With the previous bullet these are exactly the two hypotheses Henkel's open
@@ -354,6 +359,14 @@ theorem isTopologicallyNilpotent_of_mem_idealOfDefinition (P : PairOfDefinition 
   refine (P.mem_idealImage n).mpr ⟨a ^ m, ?_, by push_cast; ring⟩
   exact Ideal.pow_le_pow_right hm (Ideal.pow_mem_pow ha m)
 
+/-- **The image of the ideal of definition consists of topologically nilpotent elements.** This is
+`TauCeti.Huber.PairOfDefinition.isTopologicallyNilpotent_of_mem_idealOfDefinition` read in `A`
+rather than in `A₀`, which is the form a consumer working in `A` wants. -/
+theorem isTopologicallyNilpotent_of_mem_idealImage (P : PairOfDefinition A) {a : A}
+    (ha : a ∈ P.idealImage 1) : IsTopologicallyNilpotent a := by
+  obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage 1).mp ha
+  exact P.isTopologicallyNilpotent_of_mem_idealOfDefinition (by simpa using hy)
+
 /-- A ring admitting a pair of definition is nonarchimedean. -/
 theorem toNonarchimedeanRing [IsTopologicalRing A] (P : PairOfDefinition A) :
     NonarchimedeanRing A where
@@ -480,6 +493,21 @@ point — it is what lets a Huber ring be handed to that theorem without the cal
 anything. -/
 instance IsHuberRing.isCountablyGenerated_nhds_zero : (𝓝 (0 : A)).IsCountablyGenerated :=
   IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦ P.hasBasis_nhds_zero.isCountablyGenerated
+
+/-- **A Huber ring has a neighbourhood of zero all of whose elements are topologically
+nilpotent.** The image of an ideal of definition is such a neighbourhood: it is open, and its
+elements are topologically nilpotent because their powers run through the images of the `Iⁿ`,
+which are a basis of `𝓝 0`.
+
+Being able to *choose* a whole neighbourhood, rather than one element at a time, is what
+arguments over a matrix need — every entry drawn from `W` is then topologically nilpotent at
+once, which is the hypothesis of Nakayama for such a matrix. Note the statement asks nothing of
+`A` beyond being Huber; no pseudouniformiser and no Tate hypothesis appear. -/
+theorem IsHuberRing.exists_nhds_zero_forall_isTopologicallyNilpotent :
+    ∃ W ∈ 𝓝 (0 : A), ∀ a ∈ W, IsTopologicallyNilpotent a :=
+  IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦
+    ⟨(P.idealImage 1 : Set A), (P.isOpen_idealImage 1).mem_nhds (P.idealImage 1).zero_mem,
+      fun _ ha ↦ P.isTopologicallyNilpotent_of_mem_idealImage ha⟩
 
 /-- Wedhorn Corollary 6.4: the power-bounded subring of a Huber ring is open. -/
 theorem isOpen_powerBoundedSubring : IsOpen (powerBoundedSubring A : Set A) := by

--- a/TauCeti/RingTheory/Huber/RingOfDefinition.lean
+++ b/TauCeti/RingTheory/Huber/RingOfDefinition.lean
@@ -458,8 +458,7 @@ theorem isOpen_setOf_isTopologicallyNilpotent :
       obtain ⟨P, hmem, hI⟩ := isTopologicallyNilpotent_iff_exists_mem_idealOfDefinition.mp hx
       exact ⟨P, (P.mem_idealImage 1).mpr ⟨⟨x, hmem⟩, by simpa using hI, rfl⟩⟩
     · rintro ⟨P, hP⟩
-      obtain ⟨y, hy, rfl⟩ := (P.mem_idealImage 1).mp hP
-      exact P.isTopologicallyNilpotent_of_mem_idealOfDefinition (by simpa using hy)
+      exact P.isTopologicallyNilpotent_of_mem_idealImage one_ne_zero hP
   rw [hunion]
   exact isOpen_iUnion fun P ↦ P.isOpen_idealImage 1
 


### PR DESCRIPTION
Factors the conversion from membership in the image of `Iⁿ` to topological nilpotence into a named
lemma, and removes the one duplicate of it:

```text
PairOfDefinition.isTopologicallyNilpotent_of_mem_idealImage
    (P : PairOfDefinition A) (hn : n ≠ 0) : a ∈ P.idealImage n → IsTopologicallyNilpotent a
```

`n ≠ 0` is load-bearing rather than incidental: `I ^ 0 = ⊤`, so `idealImage 0` is the image of the
whole ring of definition and its elements are not topologically nilpotent in general.

The lemma sits in `Huber/Basic.lean` beside `isTopologicallyNilpotent_of_mem_idealOfDefinition`,
which it repackages — the same fact read in `A` rather than in `A₀`, which is the form a consumer
working in `A` wants, `idealImage` being what `hasBasis_nhds_zero` is stated with.
`isOpen_setOf_isTopologicallyNilpotent` (`Huber/RingOfDefinition.lean`) now uses it in place of an
inline `obtain … ; simpa`.

## What this PR no longer contains

It originally added `IsHuberRing.exists_nhds_zero_forall_isTopologicallyNilpotent`, an existential
"there is a neighbourhood of zero all of whose elements are topologically nilpotent". That
theorem has been removed, and the claim in the previous description that the neighbourhood form
was the one that mattered was wrong.

`TauCeti.Huber.isOpen_setOf_isTopologicallyNilpotent` (`Huber/RingOfDefinition.lean:450`) was
already on `main` under the same instances, and gives the *set of all* topologically nilpotent
elements as open — the maximal such neighbourhood. The existential is strictly weaker, including
for the matrix use it was written for: all `n²` entries can be drawn from
`{x | IsTopologicallyNilpotent x}` via
`isOpen_setOf_isTopologicallyNilpotent.mem_nhds IsTopologicallyNilpotent.zero`. The deleted
theorem also sat in `Basic.lean`, upstream of `RingOfDefinition.lean`, so it could not have been
proved from the canonical lemma where it was placed.

What survives from the original work is the factored lemma, which the `reuse`, `api-design` and
`proof-quality` findings all asked for independently.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"huber-nilpotent-neighbourhood-of-zero"}-->

Provenance: none. The remaining lemma factors a proof step already present on `main`
(`Huber/RingOfDefinition.lean:461-462`); no external source is adapted. AINTLIB's
`exists_nhds_zero_forall_isTopologicallyNilpotent`, consulted for the removed theorem, is no
longer relevant to this diff.
