### PR TITLE
feat: the étalé space of holomorphic germs, and continuation as a lift

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Continuation/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation/Basic.lean
@@ -25,7 +25,9 @@ A continuation is recorded as a family `f : X → ℂ → E` of functions indexe
 subject to the requirement that `f t` be analytic at `γ t` and that the germ of `f u` at `γ u`
 agree with the germ of `f t` at `γ u` for all `u` near `t`. Equivalently — and this is the way to
 read the definition — the assignment `t ↦ (germ of f t at γ t)` is a *continuous lift* of `γ` to
-the étale space of holomorphic germs. The classical "chain of overlapping discs" definition is the
+the étale space of holomorphic germs — literally so, by
+`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint` of
+`Conformal/Continuation/Etale.lean`. The classical "chain of overlapping discs" definition is the
 same condition written with explicit discs; the germ formulation avoids carrying the discs around.
 
 The parameter space `X` is an arbitrary topological space, and the parameter set `s : Set X` is
@@ -97,8 +99,9 @@ uniqueness of the continuation along a *fixed* path. The monodromy theorem itsel
 continuations along *homotopic* paths, and in the étale-space picture is an instance of Mathlib's
 abstract `IsLocalHomeomorph.monodromy_theorem` (`Mathlib/Topology/Homotopy/Lifting.lean`), whose
 docstring describes exactly this application; the uniqueness proved here is the concrete form of
-the separatedness hypothesis that abstract theorem consumes. Building the étale space of
-holomorphic germs and deducing monodromy from it is left to a follow-up.
+the separatedness hypothesis that abstract theorem consumes. That étale space is built in
+`TauCeti/Analysis/Complex/HolomorphicSheaf.lean`, and monodromy is deduced from the abstract
+theorem through it in `Conformal/Continuation/Etale.lean`.
 
 ## Main definitions and results
 
@@ -182,7 +185,8 @@ sense that `f u` and `f t` have the same germ at `γ u` for every `u ∈ s` clos
 
 Only the germ of `f t` at `γ t` matters; the values of `f t` away from `γ t` are unconstrained.
 Reading the germs as points of the étale space of holomorphic germs over `ℂ`, the condition says
-precisely that `t ↦ (germ of f t at γ t)` is a continuous lift of `γ`. -/
+precisely that `t ↦ (germ of f t at γ t)` is a continuous lift of `γ`; that is
+`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint`. -/
 structure IsAnalyticContinuationAlong (f : X → ℂ → E) (γ : X → ℂ) (s : Set X) : Prop where
   /-- The path is continuous on the parameter set. -/
   continuousOn : ContinuousOn γ s

--- a/TauCeti/Analysis/Complex/Conformal/Continuation/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation/Basic.lean
@@ -100,8 +100,8 @@ continuations along *homotopic* paths, and in the étale-space picture is an ins
 abstract `IsLocalHomeomorph.monodromy_theorem` (`Mathlib/Topology/Homotopy/Lifting.lean`), whose
 docstring describes exactly this application; the uniqueness proved here is the concrete form of
 the separatedness hypothesis that abstract theorem consumes. That étale space is built in
-`TauCeti/Analysis/Complex/HolomorphicSheaf.lean`, and monodromy is deduced from the abstract
-theorem through it in `Conformal/Continuation/Etale.lean`.
+`TauCeti/Analysis/Complex/HolomorphicSheaf.lean`, and `Conformal/Continuation/Etale.lean` supplies
+the continuation/lift correspondence needed to apply the abstract theorem to it.
 
 ## Main definitions and results
 

--- a/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Homotopy.Lifting
+public import TauCeti.Analysis.Complex.Conformal.Continuation.Basic
+public import TauCeti.Analysis.Complex.HolomorphicSheaf
+
+/-!
+# Analytic continuation as a lift to the étalé space of holomorphic germs
+
+`Conformal/Continuation/Basic.lean` defines `TauCeti.IsAnalyticContinuationAlong` — a family `f`
+of functions carrying, at each parameter time `t`, a germ at `γ t`, locally constant in `t` — and
+its docstring records, without proof, that
+
+> reading the germs as points of the étale space of holomorphic germs over `ℂ`, the condition says
+> precisely that `t ↦ (germ of f t at γ t)` is a continuous lift of `γ`.
+
+`TauCeti/Analysis/Complex/HolomorphicSheaf.lean` builds that space. This file proves the sentence
+(`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint`) and spends it: the étalé
+projection is a separated local homeomorphism there, which is exactly what Mathlib's abstract
+monodromy theorem `IsLocalHomeomorph.monodromy_theorem` asks of a map, so that theorem applies
+verbatim to holomorphic germs (`TauCeti.monodromy_theorem_etaleSpace`).
+
+## The dictionary
+
+Given that each `f t` is analytic at `γ t` and that `γ` is continuous, the two remaining clauses of
+a continuation — that nearby parameter times carry the same germ — and continuity of
+`t ↦ germPoint (f t) (γ t)` say the same thing, and the proof is a translation in both directions
+of the same fact about the étalé topology, namely that the germs of one section over one open set
+form a neighbourhood of each of them:
+
+* forwards, `f t =ᶠ[𝓝 (γ t)] f t₀` for `t` near `t₀` says the germ map agrees near `t₀` with
+  `germPoint (f t₀) ∘ γ`, and the germ map of a *single* holomorphic function is continuous
+  (`TauCeti.HolomorphicPresheaf.continuousOn_germPoint`), being the section of the étalé space
+  that function sweeps out;
+* backwards, continuity puts the lifted point, for `t` near `t₀`, in the set of germs of one
+  section representing `f t₀`, and reading that membership back through
+  `TauCeti.HolomorphicPresheaf.germAt_eq_iff` — the identity of two germs is the eventual identity
+  of two analytic functions — is the locality clause.
+
+The base point of the lift is `γ t` by construction (`TauCeti.HolomorphicPresheaf.base_germPoint`),
+so no separate lifting condition has to be stated. In the other direction a continuous map into
+the étalé space is a continuation of its own representatives
+(`TauCeti.isAnalyticContinuationAlong_repFun`), so the two notions are interchangeable rather than
+merely comparable.
+
+## Monodromy, and what this does not replace
+
+`Conformal/Monodromy.lean` proves the monodromy theorem for germ families directly, by a metric
+stability argument, and its docstring names building the étalé space and rederiving the theorem
+from Mathlib's abstract one as follow-up work. That rederivation is
+`TauCeti.monodromy_theorem_etaleSpace`, and it is stated where the abstract theorem states it:
+about continuous lifts of the rows of a homotopy rel endpoints, not about germ families. It does
+not replace `TauCeti.monodromy_theorem_of_free_homotopy`, whose homotopy is allowed to move the
+endpoints and whose conclusion is a continuation along the path the far endpoint sweeps out;
+Mathlib's abstract theorem is rel endpoints and gives an equality of points, so the free-homotopy
+form remains the business of the metric engine in `Conformal/Monodromy.lean`. What is gained here
+is the interface: monodromy for holomorphic germs is now an instance of covering-space-style path
+lifting, in the vocabulary the deck-group and uniformization consumers of layer **L4** of
+`TauCetiRoadmap/ConformalMapping/README.md` speak.
+
+## Main results
+
+* `TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint` — **a continuation along a path
+  is exactly a continuous lift of that path to the étalé space of holomorphic germs**.
+* `TauCeti.isAnalyticContinuationAlong_repFun` — the converse reading: a continuous map into the
+  étalé space continues the germs it carries along its own base path.
+* `TauCeti.monodromy_theorem_etaleSpace` — **the monodromy theorem in étalé-space form**, from
+  Mathlib's abstract monodromy theorem and the separatedness proved in
+  `TauCeti/Analysis/Complex/HolomorphicSheaf.lean`.
+
+## Generality
+
+The germs are germs of maps `ℂ → ℂ`, the target of the sheaf built in
+`TauCeti/Analysis/Complex/HolomorphicSheaf.lean`, whereas `TauCeti.IsAnalyticContinuationAlong` is
+stated for maps `ℂ → E` into a complex Banach space; the specialisation is discussed there, and is
+the one the conformal-mapping consumers use. The parameter space `X` and the parameter set `s` are
+arbitrary, as in `Conformal/Continuation/Basic.lean`: nothing below needs the parameter set to be
+an interval, and the monodromy statement is the only place the unit interval appears.
+
+## References
+
+* L. Ahlfors, *Complex Analysis*, Ch. 8 §1.
+* O. Forster, *Lectures on Riemann Surfaces* (GTM 81), §§6--7.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory Metric Opposite Set TopologicalSpace Topology unitInterval
+
+variable {X : Type*} [TopologicalSpace X] {f : X → ℂ → ℂ} {γ : X → ℂ} {s : Set X}
+
+/-! ### A continuation along a path is a continuous lift -/
+
+/-- **Analytic continuation along a path is a continuous lift to the étalé space of holomorphic
+germs.** Assume each `f t` is analytic at `γ t` and that `γ` is continuous on the parameter set.
+Then `f` is an analytic continuation along `γ` exactly when the germ it carries, read as a point
+of the étalé space of holomorphic germs, depends continuously on the parameter.
+
+The lifting condition itself needs no hypothesis: the germ point of `f t` at `γ t` sits over
+`γ t` by construction. So the content of the equivalence is that the locality clause of a
+continuation — nearby parameter times carry the same germ — is continuity in the étalé
+topology. -/
+theorem isAnalyticContinuationAlong_iff_continuousOn_germPoint (hγ : ContinuousOn γ s)
+    (hf : ∀ t ∈ s, AnalyticAt ℂ (f t) (γ t)) :
+    IsAnalyticContinuationAlong f γ s ↔
+      ContinuousOn (fun t => HolomorphicPresheaf.germPoint (f t) (γ t)) s := by
+  constructor
+  · intro hcont t₀ ht₀
+    obtain ⟨r, hr, hball⟩ := (hf t₀ ht₀).exists_ball_analyticOnNhd
+    have hat : ContinuousAt (HolomorphicPresheaf.germPoint (f t₀)) (γ t₀) :=
+      (HolomorphicPresheaf.continuousOn_germPoint
+        (U := ⟨ball (γ t₀) r, isOpen_ball⟩) hball).continuousAt
+          (isOpen_ball.mem_nhds (mem_ball_self hr))
+    refine (hat.comp_continuousWithinAt (hγ t₀ ht₀)).congr_of_eventuallyEq ?_ rfl
+    filter_upwards [hcont.locallyEq t₀ ht₀] with t ht using HolomorphicPresheaf.germPoint_congr ht
+  · intro hcont
+    refine ⟨hγ, hf, fun t ht => ?_⟩
+    obtain ⟨r, hr, hball⟩ := (hf t ht).exists_ball_analyticOnNhd
+    set B : Opens (TopCat.of ℂ) := ⟨ball (γ t) r, isOpen_ball⟩
+    have hbB : γ t ∈ B := mem_ball_self hr
+    set sec := HolomorphicPresheaf.toSection B (f t) hball
+    have hsec : HolomorphicPresheaf.sectionFun sec =ᶠ[𝓝 (γ t)] f t :=
+      Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds hbB)
+        (HolomorphicPresheaf.sectionFun_toSection hball)
+    have hgerm : holomorphicPresheaf.germ B (γ t) hbB sec =
+        (HolomorphicPresheaf.germPoint (f t) (γ t)).germ :=
+      (HolomorphicPresheaf.germAt_eq_germ_of_eventuallyEq hbB sec hsec).symm
+    have hnbhd := TopCat.Presheaf.EtaleSpace.eventually_nhds
+      (HolomorphicPresheaf.germPoint (f t) (γ t)) hbB sec hgerm
+    filter_upwards [(hcont t ht).eventually hnbhd, self_mem_nhdsWithin] with u hu hus
+    obtain ⟨hbu, hgu⟩ := hu
+    have h₁ : HolomorphicPresheaf.germAt (f u) (γ u) =
+        HolomorphicPresheaf.germAt (HolomorphicPresheaf.sectionFun sec) (γ u) :=
+      hgu.trans (HolomorphicPresheaf.germAt_eq_germ hbu sec).symm
+    have h₂ : f u =ᶠ[𝓝 (γ u)] HolomorphicPresheaf.sectionFun sec :=
+      (HolomorphicPresheaf.germAt_eq_iff (hf u hus)
+        (HolomorphicPresheaf.analyticOnNhd_sectionFun sec _ hbu)).mp h₁
+    exact h₂.trans (Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds hbu)
+      (HolomorphicPresheaf.sectionFun_toSection hball))
+
+/-- **A continuation along a path is a continuous lift**, the forward half of
+`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint` with its hypotheses read off the
+continuation itself. -/
+theorem IsAnalyticContinuationAlong.continuousOn_germPoint
+    (hcont : IsAnalyticContinuationAlong f γ s) :
+    ContinuousOn (fun t => HolomorphicPresheaf.germPoint (f t) (γ t)) s :=
+  (isAnalyticContinuationAlong_iff_continuousOn_germPoint hcont.continuousOn
+    hcont.analyticAt).mp hcont
+
+/-- **A continuous map into the étalé space continues its own representatives.** Choosing at each
+parameter time a holomorphic representative of the germ carried there gives an analytic
+continuation along the base path of the lift.
+
+Together with `TauCeti.IsAnalyticContinuationAlong.continuousOn_germPoint` this says that
+continuations along a path and continuous lifts of it are the same data, up to the choice of a
+representative for a germ. -/
+theorem isAnalyticContinuationAlong_repFun {Γ : X → holomorphicPresheaf.EtaleSpace}
+    (hΓ : ContinuousOn Γ s) :
+    IsAnalyticContinuationAlong (fun t => HolomorphicPresheaf.repFun (Γ t))
+      (fun t => (Γ t).base) s := by
+  refine (isAnalyticContinuationAlong_iff_continuousOn_germPoint
+    ((TopCat.Presheaf.EtaleSpace.continuous_base holomorphicPresheaf).comp_continuousOn hΓ)
+    (fun t _ => HolomorphicPresheaf.analyticAt_repFun (Γ t))).mpr ?_
+  simpa only [Function.comp_apply, HolomorphicPresheaf.germPoint_repFun] using hΓ
+
+/-! ### Monodromy -/
+
+/-- **The monodromy theorem, in étalé-space form.** If the rows `h (t, ·)` of a homotopy rel
+endpoints of paths in `ℂ` all lift continuously to the étalé space of holomorphic germs, from one
+and the same starting germ, then all the lifts finish at the same germ.
+
+This is Mathlib's `IsLocalHomeomorph.monodromy_theorem` applied to the étalé projection, whose two
+hypotheses — that it is a local homeomorphism and that it is separated — are
+`TauCeti.HolomorphicPresheaf.isLocalHomeomorph_base` and
+`TauCeti.HolomorphicPresheaf.isSeparatedMap_base`. Combined with
+`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint`, which turns a continuation into
+such a lift, it is the covering-space reading of `TauCeti.monodromy_theorem`. -/
+theorem monodromy_theorem_etaleSpace {c₀ c₁ : C(I, ℂ)} (h : c₀.HomotopyRel c₁ {0, 1})
+    (Γ : I → C(I, holomorphicPresheaf.EtaleSpace))
+    (hlift : ∀ t x, (Γ t x).base = h (t, x)) (hstart : ∀ t, Γ t 0 = Γ 0 0) (t : I) :
+    Γ t 1 = Γ 0 1 :=
+  HolomorphicPresheaf.isLocalHomeomorph_base.monodromy_theorem
+    HolomorphicPresheaf.isSeparatedMap_base h Γ hlift hstart t
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
@@ -27,8 +27,8 @@ verbatim to holomorphic germs (`TauCeti.monodromy_theorem_etaleSpace`).
 
 ## The dictionary
 
-Given that each `f t` is analytic at `γ t` and that `γ` is continuous, the two remaining clauses of
-a continuation — that nearby parameter times carry the same germ — and continuity of
+Given that each `f t` is analytic at `γ t`, the two remaining clauses of a continuation — that the
+path is continuous and that nearby parameter times carry the same germ — and continuity of
 `t ↦ germPoint (f t) (γ t)` say the same thing, and the proof is a translation in both directions
 of the same fact about the étalé topology, namely that the germs of one section over one open set
 form a neighbourhood of each of them:
@@ -43,8 +43,9 @@ form a neighbourhood of each of them:
   of two analytic functions — is the locality clause.
 
 The base point of the lift is `γ t` by construction (`TauCeti.HolomorphicPresheaf.base_germPoint`),
-so no separate lifting condition has to be stated. In the other direction a continuous map into
-the étalé space is a continuation of its own representatives
+so no separate lifting condition has to be stated, and continuity of `γ` itself need not be
+assumed: it is continuity of the lift composed with the continuous étalé projection. In the other
+direction a continuous map into the étalé space is a continuation of its own representatives
 (`TauCeti.isAnalyticContinuationAlong_repFun`), so the two notions are interchangeable rather than
 merely comparable.
 
@@ -75,12 +76,15 @@ lifting, in the vocabulary the deck-group and uniformization consumers of layer 
 
 ## Generality
 
-The germs are germs of maps `ℂ → ℂ`, the target of the sheaf built in
-`TauCeti/Analysis/Complex/HolomorphicSheaf.lean`, whereas `TauCeti.IsAnalyticContinuationAlong` is
-stated for maps `ℂ → E` into a complex Banach space; the specialisation is discussed there, and is
-the one the conformal-mapping consumers use. The parameter space `X` and the parameter set `s` are
-arbitrary, as in `Conformal/Continuation/Basic.lean`: nothing below needs the parameter set to be
-an interval, and the monodromy statement is the only place the unit interval appears.
+The germs are germs of maps `ℂ → E` into a complex Banach space `E`, the generality of both
+`TauCeti.IsAnalyticContinuationAlong` and the sheaf built in
+`TauCeti/Analysis/Complex/HolomorphicSheaf.lean`. The two restrictions on `E` are the ones that
+file records: `Type` rather than `Type*`, for a universe reason of Mathlib's étalé space, and
+completeness, which `AnalyticAt.exists_ball_analyticOnNhd` asks for. Neither is needed by
+`TauCeti.monodromy_theorem_etaleSpace`, which touches no germ, so it is stated without
+completeness. The parameter space `X` and the parameter set `s` are arbitrary, as in
+`Conformal/Continuation/Basic.lean`: nothing below needs the parameter set to be an interval, and
+the monodromy statement is the only place the unit interval appears.
 
 ## References
 
@@ -94,20 +98,22 @@ namespace TauCeti
 
 open CategoryTheory Metric Opposite Set TopologicalSpace Topology unitInterval
 
-variable {X : Type*} [TopologicalSpace X] {f : X → ℂ → ℂ} {γ : X → ℂ} {s : Set X}
+variable {E : Type} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E]
+  {X : Type*} [TopologicalSpace X] {f : X → ℂ → E} {γ : X → ℂ} {s : Set X}
 
 /-! ### A continuation along a path is a continuous lift -/
 
 /-- **Analytic continuation along a path is a continuous lift to the étalé space of holomorphic
-germs.** Assume each `f t` is analytic at `γ t` and that `γ` is continuous on the parameter set.
-Then `f` is an analytic continuation along `γ` exactly when the germ it carries, read as a point
-of the étalé space of holomorphic germs, depends continuously on the parameter.
+germs.** Assume each `f t` is analytic at `γ t`. Then `f` is an analytic continuation along `γ`
+exactly when the germ it carries, read as a point of the étalé space of holomorphic germs, depends
+continuously on the parameter.
 
-The lifting condition itself needs no hypothesis: the germ point of `f t` at `γ t` sits over
-`γ t` by construction. So the content of the equivalence is that the locality clause of a
-continuation — nearby parameter times carry the same germ — is continuity in the étalé
-topology. -/
-theorem isAnalyticContinuationAlong_iff_continuousOn_germPoint (hγ : ContinuousOn γ s)
+Neither remaining clause of a continuation has to be assumed. The lifting condition is automatic,
+the germ point of `f t` at `γ t` sitting over `γ t` by construction, and continuity of `γ` is
+continuity of the lift composed with the étalé projection. So the content of the equivalence is
+that the locality clause of a continuation — nearby parameter times carry the same germ — is
+continuity in the étalé topology. -/
+theorem isAnalyticContinuationAlong_iff_continuousOn_germPoint
     (hf : ∀ t ∈ s, AnalyticAt ℂ (f t) (γ t)) :
     IsAnalyticContinuationAlong f γ s ↔
       ContinuousOn (fun t => HolomorphicPresheaf.germPoint (f t) (γ t)) s := by
@@ -118,9 +124,13 @@ theorem isAnalyticContinuationAlong_iff_continuousOn_germPoint (hγ : Continuous
       (HolomorphicPresheaf.continuousOn_germPoint
         (U := ⟨ball (γ t₀) r, isOpen_ball⟩) hball).continuousAt
           (isOpen_ball.mem_nhds (mem_ball_self hr))
-    refine (hat.comp_continuousWithinAt (hγ t₀ ht₀)).congr_of_eventuallyEq ?_ rfl
+    refine (hat.comp_continuousWithinAt (hcont.continuousOn t₀ ht₀)).congr_of_eventuallyEq ?_ rfl
     filter_upwards [hcont.locallyEq t₀ ht₀] with t ht using HolomorphicPresheaf.germPoint_congr ht
   · intro hcont
+    have hγ : ContinuousOn γ s := by
+      have hbase := (TopCat.Presheaf.EtaleSpace.continuous_base
+        (holomorphicPresheaf E)).comp_continuousOn hcont
+      simpa only [Function.comp_def, HolomorphicPresheaf.base_germPoint] using hbase
     refine ⟨hγ, hf, fun t ht => ?_⟩
     obtain ⟨r, hr, hball⟩ := (hf t ht).exists_ball_analyticOnNhd
     set B : Opens (TopCat.of ℂ) := ⟨ball (γ t) r, isOpen_ball⟩
@@ -129,7 +139,7 @@ theorem isAnalyticContinuationAlong_iff_continuousOn_germPoint (hγ : Continuous
     have hsec : HolomorphicPresheaf.sectionFun sec =ᶠ[𝓝 (γ t)] f t :=
       Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds hbB)
         (HolomorphicPresheaf.sectionFun_toSection hball)
-    have hgerm : holomorphicPresheaf.germ B (γ t) hbB sec =
+    have hgerm : (holomorphicPresheaf E).germ B (γ t) hbB sec =
         (HolomorphicPresheaf.germPoint (f t) (γ t)).germ :=
       (HolomorphicPresheaf.germAt_eq_germ_of_eventuallyEq hbB sec hsec).symm
     have hnbhd := TopCat.Presheaf.EtaleSpace.eventually_nhds
@@ -151,8 +161,7 @@ continuation itself. -/
 theorem IsAnalyticContinuationAlong.continuousOn_germPoint
     (hcont : IsAnalyticContinuationAlong f γ s) :
     ContinuousOn (fun t => HolomorphicPresheaf.germPoint (f t) (γ t)) s :=
-  (isAnalyticContinuationAlong_iff_continuousOn_germPoint hcont.continuousOn
-    hcont.analyticAt).mp hcont
+  (isAnalyticContinuationAlong_iff_continuousOn_germPoint hcont.analyticAt).mp hcont
 
 /-- **A continuous map into the étalé space continues its own representatives.** Choosing at each
 parameter time a holomorphic representative of the germ carried there gives an analytic
@@ -161,17 +170,17 @@ continuation along the base path of the lift.
 Together with `TauCeti.IsAnalyticContinuationAlong.continuousOn_germPoint` this says that
 continuations along a path and continuous lifts of it are the same data, up to the choice of a
 representative for a germ. -/
-theorem isAnalyticContinuationAlong_repFun {Γ : X → holomorphicPresheaf.EtaleSpace}
+theorem isAnalyticContinuationAlong_repFun {Γ : X → (holomorphicPresheaf E).EtaleSpace}
     (hΓ : ContinuousOn Γ s) :
     IsAnalyticContinuationAlong (fun t => HolomorphicPresheaf.repFun (Γ t))
       (fun t => (Γ t).base) s := by
   refine (isAnalyticContinuationAlong_iff_continuousOn_germPoint
-    ((TopCat.Presheaf.EtaleSpace.continuous_base holomorphicPresheaf).comp_continuousOn hΓ)
     (fun t _ => HolomorphicPresheaf.analyticAt_repFun (Γ t))).mpr ?_
-  simpa only [Function.comp_apply, HolomorphicPresheaf.germPoint_repFun] using hΓ
+  simpa only [HolomorphicPresheaf.germPoint_repFun] using hΓ
 
 /-! ### Monodromy -/
 
+omit [CompleteSpace E] in
 /-- **The monodromy theorem, in étalé-space form.** If the rows `h (t, ·)` of a homotopy rel
 endpoints of paths in `ℂ` all lift continuously to the étalé space of holomorphic germs, from one
 and the same starting germ, then all the lifts finish at the same germ.
@@ -183,7 +192,7 @@ hypotheses — that it is a local homeomorphism and that it is separated — are
 `TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint`, which turns a continuation into
 such a lift, it is the covering-space reading of `TauCeti.monodromy_theorem`. -/
 theorem monodromy_theorem_etaleSpace {c₀ c₁ : C(I, ℂ)} (h : c₀.HomotopyRel c₁ {0, 1})
-    (Γ : I → C(I, holomorphicPresheaf.EtaleSpace))
+    (Γ : I → C(I, (holomorphicPresheaf E).EtaleSpace))
     (hlift : ∀ t x, (Γ t x).base = h (t, x)) (hstart : ∀ t, Γ t 0 = Γ 0 0) (t : I) :
     Γ t 1 = Γ 0 1 :=
   HolomorphicPresheaf.isLocalHomeomorph_base.monodromy_theorem

--- a/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
@@ -12,8 +12,8 @@ public import TauCeti.Analysis.Complex.HolomorphicSheaf
 # Analytic continuation as a lift to the étalé space of holomorphic germs
 
 `Conformal/Continuation/Basic.lean` defines `TauCeti.IsAnalyticContinuationAlong` — a family `f`
-of functions carrying, at each parameter time `t`, a germ at `γ t`, locally constant in `t` — and
-its docstring records, without proof, that
+of functions carrying, at each parameter time `t`, a germ at `γ t`, locally represented by a
+single holomorphic function — and its docstring records, without proof, that
 
 > reading the germs as points of the étale space of holomorphic germs over `ℂ`, the condition says
 > precisely that `t ↦ (germ of f t at γ t)` is a continuous lift of `γ`.

--- a/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
@@ -148,19 +148,11 @@ theorem isAnalyticContinuationAlong_iff_continuousOn_germPoint
     exact h₂.trans (Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds hbu)
       (HolomorphicPresheaf.sectionFun_toSection hball))
 
-/-- **A continuation along a path is a continuous lift**, the forward half of
-`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint` with its hypotheses read off the
-continuation itself. -/
-theorem IsAnalyticContinuationAlong.continuousOn_germPoint
-    (hcont : IsAnalyticContinuationAlong f γ s) :
-    ContinuousOn (fun t => HolomorphicPresheaf.germPoint (f t) (γ t)) s :=
-  (isAnalyticContinuationAlong_iff_continuousOn_germPoint hcont.analyticAt).mp hcont
-
 /-- **A continuous map into the étalé space continues its own representatives.** Choosing at each
 parameter time a holomorphic representative of the germ carried there gives an analytic
 continuation along the base path of the lift.
 
-Together with `TauCeti.IsAnalyticContinuationAlong.continuousOn_germPoint` this says that
+Together with `TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint` this says that
 continuations along a path and continuous lifts of it are the same data, up to the choice of a
 representative for a germ. -/
 theorem isAnalyticContinuationAlong_repFun {Γ : X → (holomorphicPresheaf E).EtaleSpace}

--- a/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Homotopy.Lifting
 public import TauCeti.Analysis.Complex.Conformal.Continuation.Basic
 public import TauCeti.Analysis.Complex.HolomorphicSheaf
 
@@ -20,10 +19,10 @@ its docstring records, without proof, that
 > precisely that `t ↦ (germ of f t at γ t)` is a continuous lift of `γ`.
 
 `TauCeti/Analysis/Complex/HolomorphicSheaf.lean` builds that space. This file proves the sentence
-(`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint`) and spends it: the étalé
-projection is a separated local homeomorphism there, which is exactly what Mathlib's abstract
-monodromy theorem `IsLocalHomeomorph.monodromy_theorem` asks of a map, so that theorem applies
-verbatim to holomorphic germs (`TauCeti.monodromy_theorem_etaleSpace`).
+(`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint`). The étalé projection is a
+separated local homeomorphism, which is exactly what Mathlib's abstract monodromy theorem
+`IsLocalHomeomorph.monodromy_theorem` asks of a map, so that theorem applies verbatim to
+holomorphic germs.
 
 ## The dictionary
 
@@ -52,10 +51,9 @@ merely comparable.
 ## Monodromy, and what this does not replace
 
 `Conformal/Monodromy.lean` proves the monodromy theorem for germ families directly, by a metric
-stability argument, and its docstring names building the étalé space and rederiving the theorem
-from Mathlib's abstract one as follow-up work. That rederivation is
-`TauCeti.monodromy_theorem_etaleSpace`, and it is stated where the abstract theorem states it:
-about continuous lifts of the rows of a homotopy rel endpoints, not about germ families. It does
+stability argument. Mathlib's abstract theorem now applies directly to the separated local
+homeomorphism built here: it is stated about continuous lifts of the rows of a homotopy rel
+endpoints, not about germ families. It does
 not replace `TauCeti.monodromy_theorem_of_free_homotopy`, whose homotopy is allowed to move the
 endpoints and whose conclusion is a continuation along the path the far endpoint sweeps out;
 Mathlib's abstract theorem is rel endpoints and gives an equality of points, so the free-homotopy
@@ -70,9 +68,6 @@ lifting, in the vocabulary the deck-group and uniformization consumers of layer 
   is exactly a continuous lift of that path to the étalé space of holomorphic germs**.
 * `TauCeti.isAnalyticContinuationAlong_repFun` — the converse reading: a continuous map into the
   étalé space continues the germs it carries along its own base path.
-* `TauCeti.monodromy_theorem_etaleSpace` — **the monodromy theorem in étalé-space form**, from
-  Mathlib's abstract monodromy theorem and the separatedness proved in
-  `TauCeti/Analysis/Complex/HolomorphicSheaf.lean`.
 
 ## Generality
 
@@ -80,11 +75,9 @@ The germs are germs of maps `ℂ → E` into a complex Banach space `E`, the gen
 `TauCeti.IsAnalyticContinuationAlong` and the sheaf built in
 `TauCeti/Analysis/Complex/HolomorphicSheaf.lean`. The two restrictions on `E` are the ones that
 file records: `Type` rather than `Type*`, for a universe reason of Mathlib's étalé space, and
-completeness, which `AnalyticAt.exists_ball_analyticOnNhd` asks for. Neither is needed by
-`TauCeti.monodromy_theorem_etaleSpace`, which touches no germ, so it is stated without
-completeness. The parameter space `X` and the parameter set `s` are arbitrary, as in
-`Conformal/Continuation/Basic.lean`: nothing below needs the parameter set to be an interval, and
-the monodromy statement is the only place the unit interval appears.
+completeness, which `AnalyticAt.exists_ball_analyticOnNhd` asks for. The parameter space `X` and
+the parameter set `s` are arbitrary, as in
+`Conformal/Continuation/Basic.lean`: nothing below needs the parameter set to be an interval.
 
 ## References
 
@@ -96,7 +89,7 @@ public section
 
 namespace TauCeti
 
-open CategoryTheory Metric Opposite Set TopologicalSpace Topology unitInterval
+open CategoryTheory Metric Opposite Set TopologicalSpace Topology
 
 variable {E : Type} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E]
   {X : Type*} [TopologicalSpace X] {f : X → ℂ → E} {γ : X → ℂ} {s : Set X}
@@ -177,25 +170,5 @@ theorem isAnalyticContinuationAlong_repFun {Γ : X → (holomorphicPresheaf E).E
   refine (isAnalyticContinuationAlong_iff_continuousOn_germPoint
     (fun t _ => HolomorphicPresheaf.analyticAt_repFun (Γ t))).mpr ?_
   simpa only [HolomorphicPresheaf.germPoint_repFun] using hΓ
-
-/-! ### Monodromy -/
-
-omit [CompleteSpace E] in
-/-- **The monodromy theorem, in étalé-space form.** If the rows `h (t, ·)` of a homotopy rel
-endpoints of paths in `ℂ` all lift continuously to the étalé space of holomorphic germs, from one
-and the same starting germ, then all the lifts finish at the same germ.
-
-This is Mathlib's `IsLocalHomeomorph.monodromy_theorem` applied to the étalé projection, whose two
-hypotheses — that it is a local homeomorphism and that it is separated — are
-`TauCeti.HolomorphicPresheaf.isLocalHomeomorph_base` and
-`TauCeti.HolomorphicPresheaf.isSeparatedMap_base`. Combined with
-`TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint`, which turns a continuation into
-such a lift, it is the covering-space reading of `TauCeti.monodromy_theorem`. -/
-theorem monodromy_theorem_etaleSpace {c₀ c₁ : C(I, ℂ)} (h : c₀.HomotopyRel c₁ {0, 1})
-    (Γ : I → C(I, (holomorphicPresheaf E).EtaleSpace))
-    (hlift : ∀ t x, (Γ t x).base = h (t, x)) (hstart : ∀ t, Γ t 0 = Γ 0 0) (t : I) :
-    Γ t 1 = Γ 0 1 :=
-  HolomorphicPresheaf.isLocalHomeomorph_base.monodromy_theorem
-    HolomorphicPresheaf.isSeparatedMap_base h Γ hlift hstart t
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -81,8 +81,9 @@ roadmap's shim-deletion clause for the upstream Riemann-mapping effort
 Mathlib has the abstract monodromy statement `IsLocalHomeomorph.monodromy_theorem` and the lifting
 criterion `IsCoveringMap.existsUnique_continuousMap_lifts` for a simply connected base
 (`Mathlib/Topology/Homotopy/Lifting.lean`), but consuming them for germs of holomorphic functions
-would first require the étale space of those germs as a topological space, which Mathlib does not
-have; see the discussion in `Conformal/Monodromy.lean`. Mathlib's simple-connectivity and path
+require the étale space of those germs as a topological space, which Mathlib does not have;
+`TauCeti/Analysis/Complex/HolomorphicSheaf.lean` builds it and `Conformal/Continuation/Etale.lean`
+consumes the abstract monodromy theorem through it. Mathlib's simple-connectivity and path
 homotopy APIs are consumed rather than restated: `IsSimplyConnected.isPathConnected` here, and
 `SimplyConnectedSpace.paths_homotopic` with `Path.Homotopy.map` through
 `Path.exists_homotopy_forall_mem_of_isSimplyConnected`. So is its metric thickening of a compact

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -83,7 +83,8 @@ criterion `IsCoveringMap.existsUnique_continuousMap_lifts` for a simply connecte
 (`Mathlib/Topology/Homotopy/Lifting.lean`), but consuming them for germs of holomorphic functions
 require the étale space of those germs as a topological space, which Mathlib does not have;
 `TauCeti/Analysis/Complex/HolomorphicSheaf.lean` builds it and `Conformal/Continuation/Etale.lean`
-consumes the abstract monodromy theorem through it. Mathlib's simple-connectivity and path
+supplies the continuation/lift correspondence needed to apply the abstract theorem to it.
+Mathlib's simple-connectivity and path
 homotopy APIs are consumed rather than restated: `IsSimplyConnected.isPathConnected` here, and
 `SimplyConnectedSpace.paths_homotopic` with `Path.Homotopy.map` through
 `Path.exists_homotopy_forall_mem_of_isSimplyConnected`. So is its metric thickening of a compact

--- a/TauCeti/Analysis/Complex/Conformal/Monodromy.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Monodromy.lean
@@ -109,17 +109,18 @@ principle, both of which Mathlib states for maps into an arbitrary Banach space.
 
 Mathlib's `IsLocalHomeomorph.monodromy_theorem` (`Mathlib/Topology/Homotopy/Lifting.lean`) is an
 abstract monodromy statement about lifts through a separated local homeomorphism, and its
-docstring names analytic continuation as the intended application. Consuming it here would first
-require building the étale space of holomorphic germs over `ℂ` as a topological space and proving
-the germ projection to be a separated local homeomorphism; Mathlib has no such space, and that
-construction is a larger, independent piece of work. The route taken instead reuses what this
-area already has — germ-level uniqueness of continuation along a fixed path
-(`IsAnalyticContinuationAlong.eventuallyEq`) — and adds only the metric stability engine, which
-is the concrete content that the abstract theorem's separatedness hypothesis packages. Building
-the étale space and rederiving `monodromy_theorem` from Mathlib's abstract theorem remains
-worthwhile follow-up work; `TauCeti.monodromy_theorem_of_free_homotopy` is stated in the shape
-that comparison will want, a lift of one edge of the square being produced from a lift of the
-other rather than an equality of two germs over a fixed point.
+docstring names analytic continuation as the intended application. The route taken here is
+independent of it: it reuses what this area already has — germ-level uniqueness of continuation
+along a fixed path (`IsAnalyticContinuationAlong.eventuallyEq`) — and adds only the metric
+stability engine, which is the concrete content that the abstract theorem's separatedness
+hypothesis packages. The other route is now available too:
+`TauCeti/Analysis/Complex/HolomorphicSheaf.lean` builds the étale space of holomorphic germs and
+proves its projection to be a separated local homeomorphism, and
+`TauCeti.monodromy_theorem_etaleSpace` of `Conformal/Continuation/Etale.lean` is Mathlib's
+abstract theorem read there. That route does not subsume this file:
+`TauCeti.monodromy_theorem_of_free_homotopy` moves the endpoints and concludes with a
+continuation along the path they sweep out, whereas the abstract theorem is rel endpoints and
+concludes with an equality of two lifted points.
 
 This advances the conformal-mapping roadmap's L4 target "the monodromy theorem (continuations
 along homotopic paths agree)" (see `ConformalMapping/README.md`). L4 is not covered by the

--- a/TauCeti/Analysis/Complex/Conformal/Monodromy.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Monodromy.lean
@@ -116,8 +116,8 @@ stability engine, which is the concrete content that the abstract theorem's sepa
 hypothesis packages. The other route is now available too:
 `TauCeti/Analysis/Complex/HolomorphicSheaf.lean` builds the étale space of holomorphic germs and
 proves its projection to be a separated local homeomorphism, and
-`TauCeti.monodromy_theorem_etaleSpace` of `Conformal/Continuation/Etale.lean` is Mathlib's
-abstract theorem read there. That route does not subsume this file:
+Mathlib's abstract theorem applies directly to that projection. That route does not subsume this
+file:
 `TauCeti.monodromy_theorem_of_free_homotopy` moves the endpoints and concludes with a
 continuation along the path they sweep out, whereas the abstract theorem is rel endpoints and
 concludes with an equality of two lifted points.

--- a/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
+++ b/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
@@ -1,0 +1,423 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Analytic.Uniqueness
+public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Topology.Sheaves.LocalPredicate
+public import TauCeti.Topology.Sheaves.EtaleSpace
+
+/-!
+# The sheaf of holomorphic functions on `ℂ`, and its étalé space
+
+Analytic continuation transports *germs*. `Conformal/Continuation/Basic.lean` carries them
+concretely — as families of functions compared by `=ᶠ[𝓝 _]` — and records, without proof, that
+reading a germ as a point of the **étalé space of holomorphic germs** turns a continuation along a
+path into a continuous lift of that path. Neither Mathlib nor this repository had the space that
+sentence names. This file builds it, and proves the two facts that make it the right object: the
+projection to the base is a local homeomorphism, and it is a **separated map**.
+
+## What is built
+
+The sheaf itself comes from Mathlib's local-predicate machinery
+(`Mathlib/Topology/Sheaves/LocalPredicate.lean`): `TauCeti.IsHolomorphicSection` says that a
+function on an open `U ⊆ ℂ` is the restriction of a function analytic on a neighbourhood of every
+point of `U`, this is stable under restriction (`TauCeti.holomorphicPrelocal`) and local
+(`TauCeti.holomorphicLocal`), and `TauCeti.holomorphicPresheaf` / `TauCeti.holomorphicSheaf` are
+the presheaf and sheaf of such sections. Locality is where the extension-by-zero of a section
+enters: a function given only on `U` has no values elsewhere to be analytic at, so the witness
+glued from local ones is `Function.extend Subtype.val`, which agrees with the section on `U` and
+is analytic there because analyticity is a local property of an open set. The same extension names
+the function underlying a section, `TauCeti.HolomorphicPresheaf.sectionFun`, and every statement
+below is phrased against it rather than against the subtype.
+
+The étalé space is Mathlib's `TopCat.Presheaf.EtaleSpace` — pairs of a base point and a germ over
+it — with the chart API of `TauCeti/Topology/Sheaves/EtaleSpace.lean`. On top of it this file adds
+the dictionary between germs as stalk elements and germs as eventual equality of functions:
+
+* `TauCeti.HolomorphicPresheaf.germ_eq_iff` — two sections have the same germ at `x` exactly when
+  their functions agree near `x`;
+* `TauCeti.HolomorphicPresheaf.germAt` — the stalk element carried by a function analytic at a
+  point, and `TauCeti.HolomorphicPresheaf.germPoint` the corresponding point of the étalé space;
+* `TauCeti.HolomorphicPresheaf.germAt_eq_iff` — that dictionary again, now between two functions
+  rather than two sections;
+* `TauCeti.HolomorphicPresheaf.repFun` — a holomorphic representative of the germ carried by a
+  point of the étalé space, inverse to `germPoint` by
+  `TauCeti.HolomorphicPresheaf.germPoint_repFun`.
+
+`germAt` is total: a function that is not analytic at the point in question is sent to the germ of
+`0`. The junk value is never inspected — every lemma about `germAt` either supplies analyticity or
+is insensitive to it (`TauCeti.HolomorphicPresheaf.germAt_congr` holds for arbitrary functions,
+both sides being junk when the common germ is not analytic) — and totality is what lets the germ
+map of a family be written as a plain function of the parameter, with no proof argument to
+transport.
+
+## The two theorems
+
+`TauCeti.HolomorphicPresheaf.isLocalHomeomorph_base` is the chart statement of
+`TauCeti/Topology/Sheaves/EtaleSpace.lean`, instantiated: over an open set on which a section is
+defined, the germs of that section form an open set carried homeomorphically onto the base.
+
+`TauCeti.HolomorphicPresheaf.isSeparatedMap_base` is the analytic content, and it is the
+**identity theorem** in disguise. Two distinct germs at one point `x` are represented by sections
+over two open sets; restrict both to one disc about `x`. The two open sets of germs they sweep out
+are disjoint, for a point of both would be a point `y` of the disc at which the two
+representatives have the same germ, and the identity theorem on the disc — connected, and where
+both representatives are analytic — would propagate that agreement from `y` back to `x`, making
+the two germs equal. Separatedness is exactly the hypothesis Mathlib's abstract monodromy theorem
+`IsLocalHomeomorph.monodromy_theorem` asks for, and its docstring names analytic continuation as
+the intended application; `Conformal/Continuation/Etale.lean` supplies that application.
+
+## Main results
+
+* `TauCeti.holomorphicSheaf` — the sheaf of holomorphic functions on `ℂ`.
+* `TauCeti.HolomorphicPresheaf.germ_eq_iff` — germs agree exactly when the functions agree nearby.
+* `TauCeti.HolomorphicPresheaf.continuousOn_germPoint` — the germ map of a holomorphic function is
+  a continuous section of the étalé projection.
+* `TauCeti.HolomorphicPresheaf.isLocalHomeomorph_base` — **the étalé projection is a local
+  homeomorphism**.
+* `TauCeti.HolomorphicPresheaf.isSeparatedMap_base` — **the étalé projection is separated**.
+
+## Generality
+
+The base is `ℂ`, in accordance with the generality bar of `ConformalMapping/README.md`, which
+fixes scalar `ℂ` for the conformal layers L0–L6, and because the consumer
+`Conformal/Continuation/Basic.lean` continues germs of maps `ℂ → E` along paths in `ℂ`. Two
+generalisations are deliberately not taken. The *target* is `ℂ` rather than a Banach space `E`:
+the sheaf would be built the same way, but the separatedness proof is the identity theorem, which
+Mathlib states for maps into a Banach space, so only the bookkeeping would change and no consumer
+asks for it. The *source* is `ℂ` rather than a Riemann surface: that needs a holomorphic atlas to
+even state the predicate, which the pinned Mathlib has for complex manifolds but which this area
+does not use anywhere else.
+
+## Relation to Mathlib
+
+Mathlib has the étalé space of a presheaf (`Mathlib/Topology/Sheaves/EtaleSpace.lean`) and the
+local-predicate construction of a sheaf of functions
+(`Mathlib/Topology/Sheaves/LocalPredicate.lean`), both consumed here; it has no sheaf of
+holomorphic functions and no étalé space of holomorphic germs. The in-progress human-curated
+Riemann-mapping effort [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505)
+contains no continuation or monodromy material, so nothing here is a shim for it. Mathlib's sheaf
+of smooth functions on a manifold (`Mathlib/Geometry/Manifold/Sheaf/Smooth.lean`) reaches the same
+`LocalPredicate` interface through the structure-groupoid machinery, but is fixed at smoothness
+`∞`; running that route at analytic smoothness would put the charted-space structure of `ℂ` and a
+translation between `ContMDiff` and `AnalyticOnNhd` between this file and the identity theorem it
+needs, so the predicate is written out directly instead.
+
+## References
+
+* L. Ahlfors, *Complex Analysis*, Ch. 8 §1.
+* J. B. Conway, *Functions of One Complex Variable I* (GTM 11), Ch. IX §§1--3.
+* O. Forster, *Lectures on Riemann Surfaces* (GTM 81), §6.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory Metric Opposite Set TopologicalSpace Topology
+
+/-! ### The sheaf -/
+
+/-- A function on an open subset `U` of `ℂ` is a **holomorphic section** when it is the
+restriction of a function analytic on a neighbourhood of every point of `U`. -/
+@[expose] def IsHolomorphicSection {U : Opens (TopCat.of ℂ)} (f : U → ℂ) : Prop :=
+  ∃ g : ℂ → ℂ, AnalyticOnNhd ℂ g U ∧ ∀ x : U, f x = g x
+
+/-- Being holomorphic is stable under restriction. -/
+@[expose] def holomorphicPrelocal : TopCat.PrelocalPredicate fun _ : TopCat.of ℂ => ℂ where
+  pred f := IsHolomorphicSection f
+  res i f hf := by
+    obtain ⟨g, hg, hfg⟩ := hf
+    refine ⟨g, hg.mono (SetLike.coe_subset_coe.mpr i.le), fun x => ?_⟩
+    exact hfg _
+
+/-- Being holomorphic is a local condition. -/
+@[expose] def holomorphicLocal : TopCat.LocalPredicate fun _ : TopCat.of ℂ => ℂ where
+  toPrelocalPredicate := holomorphicPrelocal
+  locality {U} f hloc := by
+    refine ⟨Function.extend Subtype.val f (fun _ => 0), fun z hz => ?_, fun x =>
+      (Subtype.val_injective.extend_apply f _ x).symm⟩
+    obtain ⟨V, hzV, i, g, hg, hfg⟩ := hloc ⟨z, hz⟩
+    refine (hg z hzV).congr (Filter.eventuallyEq_of_mem (V.isOpen.mem_nhds hzV) fun y hy => ?_)
+    have hyU : y ∈ U := SetLike.le_def.mp i.le hy
+    have hext := Subtype.val_injective.extend_apply f (fun _ => (0 : ℂ)) ⟨y, hyU⟩
+    simp only at hext
+    rw [hext]
+    exact (hfg ⟨y, hy⟩).symm
+
+/-- The presheaf of holomorphic functions on `ℂ`. -/
+@[expose] noncomputable def holomorphicPresheaf : (TopCat.of ℂ).Presheaf (Type) :=
+  TopCat.subpresheafToTypes holomorphicPrelocal
+
+/-- The sheaf of holomorphic functions on `ℂ`. -/
+@[expose] noncomputable def holomorphicSheaf : TopCat.Sheaf (Type) (TopCat.of ℂ) :=
+  ⟨holomorphicPresheaf, TopCat.subpresheafToTypes.isSheaf holomorphicLocal⟩
+
+/-- The presheaf underlying the sheaf of holomorphic functions. -/
+@[simp]
+theorem holomorphicSheaf_obj : holomorphicSheaf.obj = holomorphicPresheaf := rfl
+
+namespace HolomorphicPresheaf
+
+variable {U V : Opens (TopCat.of ℂ)} {g g' : ℂ → ℂ} {x z : ℂ}
+
+/-! ### Sections as functions -/
+
+/-- The function on `ℂ` underlying a section of `TauCeti.holomorphicPresheaf`, extended by zero
+outside its domain. -/
+@[expose] noncomputable def sectionFun (s : holomorphicPresheaf.obj (op U)) : ℂ → ℂ :=
+  Function.extend Subtype.val s.1 fun _ => 0
+
+/-- On its own domain, the function underlying a section is the section. -/
+@[simp]
+theorem sectionFun_coe (s : holomorphicPresheaf.obj (op U)) (y : U) : sectionFun s y = s.1 y :=
+  Subtype.val_injective.extend_apply _ _ _
+
+/-- The function underlying a holomorphic section is analytic on a neighbourhood of every point of
+its domain. -/
+theorem analyticOnNhd_sectionFun (s : holomorphicPresheaf.obj (op U)) :
+    AnalyticOnNhd ℂ (sectionFun s) U := by
+  obtain ⟨g, hg, hfg⟩ := s.2
+  intro z hz
+  refine (hg z hz).congr (Filter.eventuallyEq_of_mem (U.isOpen.mem_nhds hz) fun y hy => ?_)
+  rw [sectionFun_coe s ⟨y, hy⟩]
+  exact (hfg ⟨y, hy⟩).symm
+
+/-- Restricting a section along an inclusion of open sets restricts its underlying function. -/
+theorem map_val_apply (i : U ⟶ V) (s : holomorphicPresheaf.obj (op V)) (y : U) :
+    (holomorphicPresheaf.map i.op s).1 y = s.1 ⟨y.1, SetLike.le_def.mp i.le y.2⟩ := rfl
+
+/-- A function analytic on a neighbourhood of every point of `U`, read as a section over `U`. -/
+@[expose] def toSection (U : Opens (TopCat.of ℂ)) (g : ℂ → ℂ) (hg : AnalyticOnNhd ℂ g U) :
+    holomorphicPresheaf.obj (op U) :=
+  ⟨fun y => g y, g, hg, fun _ => rfl⟩
+
+/-- On `U`, the function underlying the section determined by `g` is `g`. -/
+@[simp]
+theorem sectionFun_toSection (hg : AnalyticOnNhd ℂ g U) :
+    EqOn (sectionFun (toSection U g hg)) g U := fun y hy => sectionFun_coe _ ⟨y, hy⟩
+
+/-! ### Germs -/
+
+/-- **Two holomorphic sections have the same germ at a point exactly when their functions agree
+near it.** The forward direction is the definition of the stalk as a filtered colimit; the reverse
+one restricts both sections to a common open set on which they are equal. -/
+theorem germ_eq_iff (hxU : x ∈ U) (hxV : x ∈ V) (s : holomorphicPresheaf.obj (op U))
+    (t : holomorphicPresheaf.obj (op V)) :
+    holomorphicPresheaf.germ U x hxU s = holomorphicPresheaf.germ V x hxV t ↔
+      sectionFun s =ᶠ[𝓝 x] sectionFun t := by
+  constructor
+  · intro h
+    obtain ⟨W, hxW, iU, iV, hmap⟩ := holomorphicPresheaf.germ_eq x hxU hxV s t h
+    refine Filter.eventuallyEq_of_mem (W.isOpen.mem_nhds hxW) fun y hy => ?_
+    have hyU : y ∈ U := SetLike.le_def.mp iU.le hy
+    have hyV : y ∈ V := SetLike.le_def.mp iV.le hy
+    have key := congrArg (fun r : holomorphicPresheaf.obj (op W) => r.1 ⟨y, hy⟩) hmap
+    rw [sectionFun_coe s ⟨y, hyU⟩, sectionFun_coe t ⟨y, hyV⟩]
+    exact key
+  · intro h
+    obtain ⟨W₀, hW₀sub, hW₀open, hxW₀⟩ := _root_.mem_nhds_iff.mp h
+    refine holomorphicPresheaf.germ_ext (⟨W₀, hW₀open⟩ ⊓ U ⊓ V)
+      (⟨⟨hxW₀, hxU⟩, hxV⟩ : x ∈ W₀ ∩ (U : Set ℂ) ∩ (V : Set ℂ))
+      (homOfLE (inf_le_left.trans inf_le_right)) (homOfLE inf_le_right) ?_
+    refine Subtype.ext (funext fun y => ?_)
+    have hy : (y : ℂ) ∈ W₀ ∩ (U : Set ℂ) ∩ (V : Set ℂ) := y.2
+    rw [map_val_apply, map_val_apply, ← sectionFun_coe s ⟨y.1, hy.1.2⟩,
+      ← sectionFun_coe t ⟨y.1, hy.2⟩]
+    exact hW₀sub hy.1.1
+
+open scoped Classical in
+/-- The germ at `z` of a function analytic there, as an element of the stalk of the sheaf of
+holomorphic functions. A function that is not analytic at `z` is sent to the germ of `0`, a junk
+value that `TauCeti.HolomorphicPresheaf.germAt_eq_germ_of_eventuallyEq` never sees. -/
+@[expose] noncomputable def germAt (g : ℂ → ℂ) (z : ℂ) : holomorphicPresheaf.stalk z :=
+  if hg : AnalyticAt ℂ g z then
+    holomorphicPresheaf.germ ⟨ball z hg.exists_ball_analyticOnNhd.choose, isOpen_ball⟩ z
+      (mem_ball_self hg.exists_ball_analyticOnNhd.choose_spec.1)
+      (toSection _ g hg.exists_ball_analyticOnNhd.choose_spec.2)
+  else
+    holomorphicPresheaf.germ ⊤ z trivial (toSection ⊤ 0 fun _ _ => analyticAt_const)
+
+/-- **The germ of a function is the germ of any section representing it.** This is the only way
+`TauCeti.HolomorphicPresheaf.germAt` is used: it identifies the abstract germ with the concrete
+one carried by a section, and the choice of ball made in the definition drops out. -/
+theorem germAt_eq_germ_of_eventuallyEq (hzU : z ∈ U) (s : holomorphicPresheaf.obj (op U))
+    (h : sectionFun s =ᶠ[𝓝 z] g) : germAt g z = holomorphicPresheaf.germ U z hzU s := by
+  have hg : AnalyticAt ℂ g z := (analyticOnNhd_sectionFun s z hzU).congr h
+  rw [germAt, dite_eq_left_of_eq_true (eq_true hg)]
+  refine (germ_eq_iff _ hzU _ s).mpr (Filter.EventuallyEq.trans ?_ h.symm)
+  exact Filter.eventuallyEq_of_mem
+    (isOpen_ball.mem_nhds (mem_ball_self hg.exists_ball_analyticOnNhd.choose_spec.1))
+    (sectionFun_toSection hg.exists_ball_analyticOnNhd.choose_spec.2)
+
+/-- The germ of the function underlying a section is the germ of that section. -/
+theorem germAt_eq_germ (hzU : z ∈ U) (s : holomorphicPresheaf.obj (op U)) :
+    germAt (sectionFun s) z = holomorphicPresheaf.germ U z hzU s :=
+  germAt_eq_germ_of_eventuallyEq hzU s .rfl
+
+/-- **The germ at `z` depends only on the values near `z`.** Functions agreeing near `z` have the
+same germ there, analytic or not: when they are not analytic both sides are the same junk value. -/
+theorem germAt_congr (h : g =ᶠ[𝓝 z] g') : germAt g z = germAt g' z := by
+  by_cases hg : AnalyticAt ℂ g z
+  · obtain ⟨r, hr, hball⟩ := hg.exists_ball_analyticOnNhd
+    have hzB : z ∈ (⟨ball z r, isOpen_ball⟩ : Opens (TopCat.of ℂ)) := mem_ball_self hr
+    have hsec : sectionFun (toSection ⟨ball z r, isOpen_ball⟩ g hball) =ᶠ[𝓝 z] g :=
+      Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds hzB) (sectionFun_toSection hball)
+    rw [germAt_eq_germ_of_eventuallyEq hzB _ hsec,
+      germAt_eq_germ_of_eventuallyEq hzB _ (hsec.trans h)]
+  · have hg' : ¬ AnalyticAt ℂ g' z := fun hg' => hg (hg'.congr h.symm)
+    rw [germAt, germAt, dite_eq_right_of_eq_false (eq_false hg),
+      dite_eq_right_of_eq_false (eq_false hg')]
+
+/-- **Two functions analytic at `z` have the same germ there exactly when they agree near `z`.**
+The reverse implication is `TauCeti.HolomorphicPresheaf.germAt_congr`; the forward one is the
+description of the stalk as a colimit, read through
+`TauCeti.HolomorphicPresheaf.germ_eq_iff`. -/
+theorem germAt_eq_iff (hg : AnalyticAt ℂ g z) (hg' : AnalyticAt ℂ g' z) :
+    germAt g z = germAt g' z ↔ g =ᶠ[𝓝 z] g' := by
+  refine ⟨fun h => ?_, germAt_congr⟩
+  obtain ⟨r, hr, hball⟩ := hg.exists_ball_analyticOnNhd
+  obtain ⟨r', hr', hball'⟩ := hg'.exists_ball_analyticOnNhd
+  have hzB : z ∈ (⟨ball z r, isOpen_ball⟩ : Opens (TopCat.of ℂ)) := mem_ball_self hr
+  have hzB' : z ∈ (⟨ball z r', isOpen_ball⟩ : Opens (TopCat.of ℂ)) := mem_ball_self hr'
+  have hsec : sectionFun (toSection ⟨ball z r, isOpen_ball⟩ g hball) =ᶠ[𝓝 z] g :=
+    Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds hzB) (sectionFun_toSection hball)
+  have hsec' : sectionFun (toSection ⟨ball z r', isOpen_ball⟩ g' hball') =ᶠ[𝓝 z] g' :=
+    Filter.eventuallyEq_of_mem (isOpen_ball.mem_nhds hzB') (sectionFun_toSection hball')
+  rw [germAt_eq_germ_of_eventuallyEq hzB _ hsec,
+    germAt_eq_germ_of_eventuallyEq hzB' _ hsec'] at h
+  exact hsec.symm.trans (((germ_eq_iff hzB hzB' _ _).mp h).trans hsec')
+
+/-- The germ of a function analytic at `z`, as a point of the étalé space of holomorphic germs. -/
+@[expose] noncomputable def germPoint (g : ℂ → ℂ) (z : ℂ) : holomorphicPresheaf.EtaleSpace :=
+  ⟨z, germAt g z⟩
+
+/-- The germ point of `g` at `z` sits over `z`. -/
+@[simp]
+theorem base_germPoint (g : ℂ → ℂ) (z : ℂ) :
+    (germPoint g z).base = z := rfl
+
+/-- The germ point of `g` at `z` carries the germ of `g`. -/
+@[simp]
+theorem germ_germPoint (g : ℂ → ℂ) (z : ℂ) : (germPoint g z).germ = germAt g z := rfl
+
+/-- Functions agreeing near `z` give the same point of the étalé space over `z`. -/
+theorem germPoint_congr (h : g =ᶠ[𝓝 z] g') : germPoint g z = germPoint g' z := by
+  rw [germPoint, germPoint, germAt_congr h]
+
+/-- **The germ map of a holomorphic function is a continuous section of the étalé projection.**
+Over its domain it is exactly the section of the étalé space swept out by `g`, so continuity is
+`TauCeti.TopCat.Presheaf.EtaleSpace.continuous_germSection`. -/
+theorem continuousOn_germPoint (hg : AnalyticOnNhd ℂ g U) : ContinuousOn (germPoint g) U := by
+  rw [continuousOn_iff_continuous_domRestrict]
+  have hrestr : (U : Set ℂ).domRestrict (germPoint g) =
+      TopCat.Presheaf.EtaleSpace.germSection holomorphicPresheaf U (toSection U g hg) := by
+    funext y
+    have hb : (TopCat.Presheaf.EtaleSpace.germSection holomorphicPresheaf U
+        (toSection U g hg) y).base = (y : ℂ) :=
+      TopCat.Presheaf.EtaleSpace.base_germSection U _ y
+    have hgerm : germAt g (y : ℂ) =
+        holomorphicPresheaf.germ U (y : ℂ) y.2 (toSection U g hg) :=
+      germAt_eq_germ_of_eventuallyEq y.2 _
+        (Filter.eventuallyEq_of_mem (U.isOpen.mem_nhds y.2) (sectionFun_toSection hg))
+    exact congrArg
+      (fun e : holomorphicPresheaf.stalk (y : ℂ) =>
+        (⟨(y : ℂ), e⟩ : holomorphicPresheaf.EtaleSpace)) hgerm
+  rw [hrestr]
+  exact TopCat.Presheaf.EtaleSpace.continuous_germSection U _
+
+/-! ### Representatives of a point of the étalé space -/
+
+/-- **Every point of the étalé space carries the germ of a function analytic at its base
+point.** -/
+theorem exists_analyticAt_germAt_eq (p : holomorphicPresheaf.EtaleSpace) :
+    ∃ g : ℂ → ℂ, AnalyticAt ℂ g p.base ∧ germAt g p.base = p.germ := by
+  obtain ⟨U, hU, s, hs⟩ := holomorphicPresheaf.exists_germ_eq p.germ
+  exact ⟨sectionFun s, analyticOnNhd_sectionFun s _ hU, by rw [germAt_eq_germ hU s, hs]⟩
+
+/-- A holomorphic representative of the germ carried by a point of the étalé space. -/
+@[expose] noncomputable def repFun (p : holomorphicPresheaf.EtaleSpace) : ℂ → ℂ :=
+  (exists_analyticAt_germAt_eq p).choose
+
+/-- A representative of a point of the étalé space is analytic at its base point. -/
+theorem analyticAt_repFun (p : holomorphicPresheaf.EtaleSpace) :
+    AnalyticAt ℂ (repFun p) p.base :=
+  (exists_analyticAt_germAt_eq p).choose_spec.1
+
+/-- A representative of a point of the étalé space carries the germ that point carries. -/
+@[simp]
+theorem germAt_repFun (p : holomorphicPresheaf.EtaleSpace) :
+    germAt (repFun p) p.base = p.germ :=
+  (exists_analyticAt_germAt_eq p).choose_spec.2
+
+/-- Taking a representative and then its germ point recovers the point of the étalé space. -/
+@[simp]
+theorem germPoint_repFun (p : holomorphicPresheaf.EtaleSpace) :
+    germPoint (repFun p) p.base = p := by
+  cases p
+  rw [germPoint, germAt_repFun]
+
+/-! ### The projection is a separated local homeomorphism -/
+
+/-- **The étalé projection of the sheaf of holomorphic functions is a local homeomorphism.** -/
+theorem isLocalHomeomorph_base :
+    IsLocalHomeomorph (_root_.TopCat.Presheaf.EtaleSpace.base (F := holomorphicPresheaf)) :=
+  TopCat.Presheaf.EtaleSpace.isLocalHomeomorph_base holomorphicPresheaf
+
+/-- **The étalé projection of the sheaf of holomorphic functions is a separated map**: two
+distinct germs at the same point of `ℂ` have disjoint neighbourhoods in the étalé space.
+
+This is the identity theorem for holomorphic functions, read in the étalé space. Two sections
+representing the two germs are restricted to one disc about the common base point; the two open
+sets swept out by their germs over that disc are disjoint, because a point of both would be a
+point where the two representatives have the same germ, and the identity theorem on the disc —
+which is connected — would then propagate that agreement back to the base point. -/
+theorem isSeparatedMap_base :
+    IsSeparatedMap (_root_.TopCat.Presheaf.EtaleSpace.base (F := holomorphicPresheaf)) := by
+  rintro ⟨x, g₁⟩ ⟨y, g₂⟩ hbase hne
+  obtain rfl : x = y := hbase
+  obtain ⟨U₁, hxU₁, s₁, hs₁⟩ := holomorphicPresheaf.exists_germ_eq g₁
+  obtain ⟨U₂, hxU₂, s₂, hs₂⟩ := holomorphicPresheaf.exists_germ_eq g₂
+  obtain ⟨r, hr, hrU⟩ : ∃ r > 0, ball x r ⊆ (U₁ : Set ℂ) ∩ (U₂ : Set ℂ) :=
+    Metric.isOpen_iff.mp (U₁.isOpen.inter U₂.isOpen) x ⟨hxU₁, hxU₂⟩
+  set B : Opens (TopCat.of ℂ) := ⟨ball x r, isOpen_ball⟩
+  have hxB : x ∈ B := mem_ball_self hr
+  have hB₁ : B ≤ U₁ := fun z hz => (hrU hz).1
+  have hB₂ : B ≤ U₂ := fun z hz => (hrU hz).2
+  set t₁ := holomorphicPresheaf.map (homOfLE hB₁).op s₁ with ht₁def
+  set t₂ := holomorphicPresheaf.map (homOfLE hB₂).op s₂ with ht₂def
+  have ht₁ : holomorphicPresheaf.germ B x hxB t₁ = g₁ := by
+    rw [ht₁def, holomorphicPresheaf.germ_res_apply, hs₁]
+  have ht₂ : holomorphicPresheaf.germ B x hxB t₂ = g₂ := by
+    rw [ht₂def, holomorphicPresheaf.germ_res_apply, hs₂]
+  have hopen₁ : IsOpen (TopCat.Presheaf.EtaleSpace.sectionRange holomorphicPresheaf B t₁) :=
+    TopCat.Presheaf.EtaleSpace.isOpen_sectionRange (F := holomorphicPresheaf) B t₁
+  have hopen₂ : IsOpen (TopCat.Presheaf.EtaleSpace.sectionRange holomorphicPresheaf B t₂) :=
+    TopCat.Presheaf.EtaleSpace.isOpen_sectionRange (F := holomorphicPresheaf) B t₂
+  refine ⟨_, _, hopen₁, hopen₂,
+    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf) |>.mpr
+      ⟨hxB, ht₁.symm⟩,
+    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf) |>.mpr
+      ⟨hxB, ht₂.symm⟩, ?_⟩
+  refine Set.disjoint_left.mpr fun p hp₁ hp₂ => ?_
+  obtain ⟨hpB, hpt₁⟩ :=
+    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf) |>.mp hp₁
+  obtain ⟨hpB', hpt₂⟩ :=
+    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf) |>.mp hp₂
+  have hev : sectionFun t₁ =ᶠ[𝓝 p.base] sectionFun t₂ :=
+    (germ_eq_iff hpB hpB' t₁ t₂).mp (hpt₁.symm.trans hpt₂)
+  have hEqOn : EqOn (sectionFun t₁) (sectionFun t₂) (B : Set ℂ) :=
+    (analyticOnNhd_sectionFun t₁).eqOn_of_preconnected_of_eventuallyEq
+      (analyticOnNhd_sectionFun t₂) (convex_ball x r).isPreconnected hpB hev
+  have hgerm : holomorphicPresheaf.germ B x hxB t₁ = holomorphicPresheaf.germ B x hxB t₂ :=
+    (germ_eq_iff hxB hxB t₁ t₂).mpr
+      (Filter.eventuallyEq_of_mem (B.isOpen.mem_nhds hxB) hEqOn)
+  exact hne (by rw [← ht₁, ← ht₂, hgerm])
+
+end HolomorphicPresheaf
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
+++ b/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
@@ -25,14 +25,15 @@ projection to the base is a local homeomorphism, and it is a **separated map**.
 The sheaf itself comes from Mathlib's local-predicate machinery
 (`Mathlib/Topology/Sheaves/LocalPredicate.lean`): `TauCeti.IsHolomorphicSection` says that a
 function on an open `U ⊆ ℂ` is the restriction of a function analytic on a neighbourhood of every
-point of `U`, this is stable under restriction (`TauCeti.holomorphicPrelocal`) and local
-(`TauCeti.holomorphicLocal`), and `TauCeti.holomorphicPresheaf` / `TauCeti.holomorphicSheaf` are
-the presheaf and sheaf of such sections. Locality is where the extension-by-zero of a section
-enters: a function given only on `U` has no values elsewhere to be analytic at, so the witness
-glued from local ones is `Function.extend Subtype.val`, which agrees with the section on `U` and
-is analytic there because analyticity is a local property of an open set. The same extension names
-the function underlying a section, `TauCeti.HolomorphicPresheaf.sectionFun`, and every statement
-below is phrased against it rather than against the subtype.
+point of `U`, this is stable under restriction and local, and `TauCeti.holomorphicPresheaf` /
+`TauCeti.holomorphicSheaf` are the presheaf and the sheaf of such sections, the latter being
+Mathlib's `TopCat.subsheafToTypes` at that local predicate. Locality is where the extension by
+zero of a section enters: a function given only on `U` has no values elsewhere to be analytic at,
+so the witness glued from local ones is `Function.extend Subtype.val`, which agrees with the
+section on `U` and is analytic there because analyticity is a local property of an open set. The
+same extension names the function underlying a section,
+`TauCeti.HolomorphicPresheaf.sectionFun`, and every statement below is phrased against it rather
+than against the subtype.
 
 The étalé space is Mathlib's `TopCat.Presheaf.EtaleSpace` — pairs of a base point and a germ over
 it — with the chart API of `TauCeti/Topology/Sheaves/EtaleSpace.lean`. On top of it this file adds
@@ -83,15 +84,24 @@ the intended application; `Conformal/Continuation/Etale.lean` supplies that appl
 
 ## Generality
 
-The base is `ℂ`, in accordance with the generality bar of `ConformalMapping/README.md`, which
-fixes scalar `ℂ` for the conformal layers L0–L6, and because the consumer
-`Conformal/Continuation/Basic.lean` continues germs of maps `ℂ → E` along paths in `ℂ`. Two
-generalisations are deliberately not taken. The *target* is `ℂ` rather than a Banach space `E`:
-the sheaf would be built the same way, but the separatedness proof is the identity theorem, which
-Mathlib states for maps into a Banach space, so only the bookkeeping would change and no consumer
-asks for it. The *source* is `ℂ` rather than a Riemann surface: that needs a holomorphic atlas to
-even state the predicate, which the pinned Mathlib has for complex manifolds but which this area
-does not use anywhere else.
+The *target* is an arbitrary complex Banach space `E`, the generality at which
+`Conformal/Continuation/Basic.lean` states analytic continuation; the scalar case `E = ℂ` is the
+one the conformal-mapping consumers instantiate. Both restrictions on `E` are inherited rather
+than chosen. It is confined to `Type` rather than `Type*` by Mathlib's étalé space, which is built
+for a `C`-valued presheaf on `X : TopCat.{v}` with `[Category.{v} C]`: the base `TopCat.of ℂ`
+lives in `TopCat.{0}`, so the values of the presheaf are forced into `Type`. Completeness is asked
+for exactly where Mathlib asks for it, from `TauCeti.HolomorphicPresheaf.germAt` on, because
+`AnalyticAt.exists_ball_analyticOnNhd` — which names a disc on which a germ has a representative —
+is stated for a Banach target. The sheaf, the germ dictionary
+`TauCeti.HolomorphicPresheaf.germ_eq_iff` and both theorems about the projection are free of it,
+the identity theorem `AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq` needing no
+completeness.
+
+The *source* is `ℂ` rather than a Riemann surface, in accordance with the generality bar of
+`ConformalMapping/README.md`, which fixes the scalar domain for the conformal layers L0–L6, and
+because the consumer `Conformal/Continuation/Basic.lean` continues germs along paths in `ℂ`. A
+Riemann surface source would need a holomorphic atlas to even state the predicate, which the
+pinned Mathlib has for complex manifolds but which this area does not use anywhere else.
 
 ## Relation to Mathlib
 
@@ -120,66 +130,73 @@ namespace TauCeti
 
 open CategoryTheory Metric Opposite Set TopologicalSpace Topology
 
+variable {E : Type} [NormedAddCommGroup E] [NormedSpace ℂ E]
+
 /-! ### The sheaf -/
 
 /-- A function on an open subset `U` of `ℂ` is a **holomorphic section** when it is the
 restriction of a function analytic on a neighbourhood of every point of `U`. -/
-@[expose] def IsHolomorphicSection {U : Opens (TopCat.of ℂ)} (f : U → ℂ) : Prop :=
-  ∃ g : ℂ → ℂ, AnalyticOnNhd ℂ g U ∧ ∀ x : U, f x = g x
+def IsHolomorphicSection {U : Opens (TopCat.of ℂ)} (f : U → E) : Prop :=
+  ∃ g : ℂ → E, AnalyticOnNhd ℂ g U ∧ ∀ x : U, f x = g x
 
+variable (E) in
 /-- Being holomorphic is stable under restriction. -/
-@[expose] def holomorphicPrelocal : TopCat.PrelocalPredicate fun _ : TopCat.of ℂ => ℂ where
+def holomorphicPrelocal : TopCat.PrelocalPredicate fun _ : TopCat.of ℂ => E where
   pred f := IsHolomorphicSection f
   res i f hf := by
     obtain ⟨g, hg, hfg⟩ := hf
     refine ⟨g, hg.mono (SetLike.coe_subset_coe.mpr i.le), fun x => ?_⟩
     exact hfg _
 
+variable (E) in
 /-- Being holomorphic is a local condition. -/
-@[expose] def holomorphicLocal : TopCat.LocalPredicate fun _ : TopCat.of ℂ => ℂ where
-  toPrelocalPredicate := holomorphicPrelocal
+private def holomorphicLocal : TopCat.LocalPredicate fun _ : TopCat.of ℂ => E where
+  toPrelocalPredicate := holomorphicPrelocal E
   locality {U} f hloc := by
     refine ⟨Function.extend Subtype.val f (fun _ => 0), fun z hz => ?_, fun x =>
       (Subtype.val_injective.extend_apply f _ x).symm⟩
     obtain ⟨V, hzV, i, g, hg, hfg⟩ := hloc ⟨z, hz⟩
     refine (hg z hzV).congr (Filter.eventuallyEq_of_mem (V.isOpen.mem_nhds hzV) fun y hy => ?_)
     have hyU : y ∈ U := SetLike.le_def.mp i.le hy
-    have hext := Subtype.val_injective.extend_apply f (fun _ => (0 : ℂ)) ⟨y, hyU⟩
+    have hext := Subtype.val_injective.extend_apply f (fun _ => (0 : E)) ⟨y, hyU⟩
     simp only at hext
     rw [hext]
     exact (hfg ⟨y, hy⟩).symm
 
-/-- The presheaf of holomorphic functions on `ℂ`. -/
+variable (E) in
+/-- The presheaf of holomorphic functions on `ℂ` with values in `E`. -/
 @[expose] noncomputable def holomorphicPresheaf : (TopCat.of ℂ).Presheaf (Type) :=
-  TopCat.subpresheafToTypes holomorphicPrelocal
+  TopCat.subpresheafToTypes (holomorphicPrelocal E)
 
-/-- The sheaf of holomorphic functions on `ℂ`. -/
-@[expose] noncomputable def holomorphicSheaf : TopCat.Sheaf (Type) (TopCat.of ℂ) :=
-  ⟨holomorphicPresheaf, TopCat.subpresheafToTypes.isSheaf holomorphicLocal⟩
+variable (E) in
+/-- The sheaf of holomorphic functions on `ℂ` with values in `E`. -/
+noncomputable def holomorphicSheaf : TopCat.Sheaf (Type) (TopCat.of ℂ) :=
+  TopCat.subsheafToTypes (holomorphicLocal E)
 
 /-- The presheaf underlying the sheaf of holomorphic functions. -/
 @[simp]
-theorem holomorphicSheaf_obj : holomorphicSheaf.obj = holomorphicPresheaf := rfl
+theorem holomorphicSheaf_obj : (holomorphicSheaf E).obj = holomorphicPresheaf E := (rfl)
 
 namespace HolomorphicPresheaf
 
-variable {U V : Opens (TopCat.of ℂ)} {g g' : ℂ → ℂ} {x z : ℂ}
+variable {U V : Opens (TopCat.of ℂ)} {g g' : ℂ → E} {x z : ℂ}
 
 /-! ### Sections as functions -/
 
 /-- The function on `ℂ` underlying a section of `TauCeti.holomorphicPresheaf`, extended by zero
 outside its domain. -/
-@[expose] noncomputable def sectionFun (s : holomorphicPresheaf.obj (op U)) : ℂ → ℂ :=
+noncomputable def sectionFun (s : (holomorphicPresheaf E).obj (op U)) : ℂ → E :=
   Function.extend Subtype.val s.1 fun _ => 0
 
 /-- On its own domain, the function underlying a section is the section. -/
 @[simp]
-theorem sectionFun_coe (s : holomorphicPresheaf.obj (op U)) (y : U) : sectionFun s y = s.1 y :=
+theorem sectionFun_coe (s : (holomorphicPresheaf E).obj (op U)) (y : U) :
+    sectionFun s y = s.1 y :=
   Subtype.val_injective.extend_apply _ _ _
 
 /-- The function underlying a holomorphic section is analytic on a neighbourhood of every point of
 its domain. -/
-theorem analyticOnNhd_sectionFun (s : holomorphicPresheaf.obj (op U)) :
+theorem analyticOnNhd_sectionFun (s : (holomorphicPresheaf E).obj (op U)) :
     AnalyticOnNhd ℂ (sectionFun s) U := by
   obtain ⟨g, hg, hfg⟩ := s.2
   intro z hz
@@ -188,12 +205,12 @@ theorem analyticOnNhd_sectionFun (s : holomorphicPresheaf.obj (op U)) :
   exact (hfg ⟨y, hy⟩).symm
 
 /-- Restricting a section along an inclusion of open sets restricts its underlying function. -/
-theorem map_val_apply (i : U ⟶ V) (s : holomorphicPresheaf.obj (op V)) (y : U) :
-    (holomorphicPresheaf.map i.op s).1 y = s.1 ⟨y.1, SetLike.le_def.mp i.le y.2⟩ := rfl
+theorem map_val_apply (i : U ⟶ V) (s : (holomorphicPresheaf E).obj (op V)) (y : U) :
+    ((holomorphicPresheaf E).map i.op s).1 y = s.1 ⟨y.1, SetLike.le_def.mp i.le y.2⟩ := rfl
 
 /-- A function analytic on a neighbourhood of every point of `U`, read as a section over `U`. -/
-@[expose] def toSection (U : Opens (TopCat.of ℂ)) (g : ℂ → ℂ) (hg : AnalyticOnNhd ℂ g U) :
-    holomorphicPresheaf.obj (op U) :=
+def toSection (U : Opens (TopCat.of ℂ)) (g : ℂ → E) (hg : AnalyticOnNhd ℂ g U) :
+    (holomorphicPresheaf E).obj (op U) :=
   ⟨fun y => g y, g, hg, fun _ => rfl⟩
 
 /-- On `U`, the function underlying the section determined by `g` is `g`. -/
@@ -206,22 +223,22 @@ theorem sectionFun_toSection (hg : AnalyticOnNhd ℂ g U) :
 /-- **Two holomorphic sections have the same germ at a point exactly when their functions agree
 near it.** The forward direction is the definition of the stalk as a filtered colimit; the reverse
 one restricts both sections to a common open set on which they are equal. -/
-theorem germ_eq_iff (hxU : x ∈ U) (hxV : x ∈ V) (s : holomorphicPresheaf.obj (op U))
-    (t : holomorphicPresheaf.obj (op V)) :
-    holomorphicPresheaf.germ U x hxU s = holomorphicPresheaf.germ V x hxV t ↔
+theorem germ_eq_iff (hxU : x ∈ U) (hxV : x ∈ V) (s : (holomorphicPresheaf E).obj (op U))
+    (t : (holomorphicPresheaf E).obj (op V)) :
+    (holomorphicPresheaf E).germ U x hxU s = (holomorphicPresheaf E).germ V x hxV t ↔
       sectionFun s =ᶠ[𝓝 x] sectionFun t := by
   constructor
   · intro h
-    obtain ⟨W, hxW, iU, iV, hmap⟩ := holomorphicPresheaf.germ_eq x hxU hxV s t h
+    obtain ⟨W, hxW, iU, iV, hmap⟩ := (holomorphicPresheaf E).germ_eq x hxU hxV s t h
     refine Filter.eventuallyEq_of_mem (W.isOpen.mem_nhds hxW) fun y hy => ?_
     have hyU : y ∈ U := SetLike.le_def.mp iU.le hy
     have hyV : y ∈ V := SetLike.le_def.mp iV.le hy
-    have key := congrArg (fun r : holomorphicPresheaf.obj (op W) => r.1 ⟨y, hy⟩) hmap
+    have key := congrArg (fun r : (holomorphicPresheaf E).obj (op W) => r.1 ⟨y, hy⟩) hmap
     rw [sectionFun_coe s ⟨y, hyU⟩, sectionFun_coe t ⟨y, hyV⟩]
     exact key
   · intro h
     obtain ⟨W₀, hW₀sub, hW₀open, hxW₀⟩ := _root_.mem_nhds_iff.mp h
-    refine holomorphicPresheaf.germ_ext (⟨W₀, hW₀open⟩ ⊓ U ⊓ V)
+    refine (holomorphicPresheaf E).germ_ext (⟨W₀, hW₀open⟩ ⊓ U ⊓ V)
       (⟨⟨hxW₀, hxU⟩, hxV⟩ : x ∈ W₀ ∩ (U : Set ℂ) ∩ (V : Set ℂ))
       (homOfLE (inf_le_left.trans inf_le_right)) (homOfLE inf_le_right) ?_
     refine Subtype.ext (funext fun y => ?_)
@@ -230,23 +247,25 @@ theorem germ_eq_iff (hxU : x ∈ U) (hxV : x ∈ V) (s : holomorphicPresheaf.obj
       ← sectionFun_coe t ⟨y.1, hy.2⟩]
     exact hW₀sub hy.1.1
 
+variable [CompleteSpace E]
+
 open scoped Classical in
 /-- The germ at `z` of a function analytic there, as an element of the stalk of the sheaf of
 holomorphic functions. A function that is not analytic at `z` is sent to the germ of `0`, a junk
 value that `TauCeti.HolomorphicPresheaf.germAt_eq_germ_of_eventuallyEq` never sees. -/
-@[expose] noncomputable def germAt (g : ℂ → ℂ) (z : ℂ) : holomorphicPresheaf.stalk z :=
+noncomputable def germAt (g : ℂ → E) (z : ℂ) : (holomorphicPresheaf E).stalk z :=
   if hg : AnalyticAt ℂ g z then
-    holomorphicPresheaf.germ ⟨ball z hg.exists_ball_analyticOnNhd.choose, isOpen_ball⟩ z
+    (holomorphicPresheaf E).germ ⟨ball z hg.exists_ball_analyticOnNhd.choose, isOpen_ball⟩ z
       (mem_ball_self hg.exists_ball_analyticOnNhd.choose_spec.1)
       (toSection _ g hg.exists_ball_analyticOnNhd.choose_spec.2)
   else
-    holomorphicPresheaf.germ ⊤ z trivial (toSection ⊤ 0 fun _ _ => analyticAt_const)
+    (holomorphicPresheaf E).germ ⊤ z trivial (toSection ⊤ 0 fun _ _ => analyticAt_const)
 
 /-- **The germ of a function is the germ of any section representing it.** This is the only way
 `TauCeti.HolomorphicPresheaf.germAt` is used: it identifies the abstract germ with the concrete
 one carried by a section, and the choice of ball made in the definition drops out. -/
-theorem germAt_eq_germ_of_eventuallyEq (hzU : z ∈ U) (s : holomorphicPresheaf.obj (op U))
-    (h : sectionFun s =ᶠ[𝓝 z] g) : germAt g z = holomorphicPresheaf.germ U z hzU s := by
+theorem germAt_eq_germ_of_eventuallyEq (hzU : z ∈ U) (s : (holomorphicPresheaf E).obj (op U))
+    (h : sectionFun s =ᶠ[𝓝 z] g) : germAt g z = (holomorphicPresheaf E).germ U z hzU s := by
   have hg : AnalyticAt ℂ g z := (analyticOnNhd_sectionFun s z hzU).congr h
   rw [germAt, dite_eq_left_of_eq_true (eq_true hg)]
   refine (germ_eq_iff _ hzU _ s).mpr (Filter.EventuallyEq.trans ?_ h.symm)
@@ -255,8 +274,8 @@ theorem germAt_eq_germ_of_eventuallyEq (hzU : z ∈ U) (s : holomorphicPresheaf.
     (sectionFun_toSection hg.exists_ball_analyticOnNhd.choose_spec.2)
 
 /-- The germ of the function underlying a section is the germ of that section. -/
-theorem germAt_eq_germ (hzU : z ∈ U) (s : holomorphicPresheaf.obj (op U)) :
-    germAt (sectionFun s) z = holomorphicPresheaf.germ U z hzU s :=
+theorem germAt_eq_germ (hzU : z ∈ U) (s : (holomorphicPresheaf E).obj (op U)) :
+    germAt (sectionFun s) z = (holomorphicPresheaf E).germ U z hzU s :=
   germAt_eq_germ_of_eventuallyEq hzU s .rfl
 
 /-- **The germ at `z` depends only on the values near `z`.** Functions agreeing near `z` have the
@@ -293,40 +312,46 @@ theorem germAt_eq_iff (hg : AnalyticAt ℂ g z) (hg' : AnalyticAt ℂ g' z) :
   exact hsec.symm.trans (((germ_eq_iff hzB hzB' _ _).mp h).trans hsec')
 
 /-- The germ of a function analytic at `z`, as a point of the étalé space of holomorphic germs. -/
-@[expose] noncomputable def germPoint (g : ℂ → ℂ) (z : ℂ) : holomorphicPresheaf.EtaleSpace :=
+@[expose] noncomputable def germPoint (g : ℂ → E) (z : ℂ) : (holomorphicPresheaf E).EtaleSpace :=
   ⟨z, germAt g z⟩
 
 /-- The germ point of `g` at `z` sits over `z`. -/
 @[simp]
-theorem base_germPoint (g : ℂ → ℂ) (z : ℂ) :
+theorem base_germPoint (g : ℂ → E) (z : ℂ) :
     (germPoint g z).base = z := rfl
 
 /-- The germ point of `g` at `z` carries the germ of `g`. -/
 @[simp]
-theorem germ_germPoint (g : ℂ → ℂ) (z : ℂ) : (germPoint g z).germ = germAt g z := rfl
+theorem germ_germPoint (g : ℂ → E) (z : ℂ) : (germPoint g z).germ = germAt g z := rfl
 
 /-- Functions agreeing near `z` give the same point of the étalé space over `z`. -/
 theorem germPoint_congr (h : g =ᶠ[𝓝 z] g') : germPoint g z = germPoint g' z := by
   rw [germPoint, germPoint, germAt_congr h]
 
+/-- **Over an open set on which `g` is analytic, the germ map of `g` is the germ section swept out
+by `g`.** This is the comparison between the two descriptions of a point of the étalé space — a
+base point paired with `TauCeti.HolomorphicPresheaf.germAt`, and the germ of a section at a point
+of its domain — and it is what carries continuity from one to the other. -/
+theorem germPoint_eq_germSection (hg : AnalyticOnNhd ℂ g U) (y : U) :
+    germPoint g y =
+      TopCat.Presheaf.EtaleSpace.germSection (holomorphicPresheaf E) U (toSection U g hg) y := by
+  have hgerm : germAt g (y : ℂ) =
+      (holomorphicPresheaf E).germ U (y : ℂ) y.2 (toSection U g hg) :=
+    germAt_eq_germ_of_eventuallyEq y.2 _
+      (Filter.eventuallyEq_of_mem (U.isOpen.mem_nhds y.2) (sectionFun_toSection hg))
+  rw [TopCat.Presheaf.EtaleSpace.germSection_apply, germPoint, hgerm]
+
 /-- **The germ map of a holomorphic function is a continuous section of the étalé projection.**
-Over its domain it is exactly the section of the étalé space swept out by `g`, so continuity is
+Over its domain it is exactly the section of the étalé space swept out by `g`
+(`TauCeti.HolomorphicPresheaf.germPoint_eq_germSection`), so continuity is
 `TauCeti.TopCat.Presheaf.EtaleSpace.continuous_germSection`. -/
 theorem continuousOn_germPoint (hg : AnalyticOnNhd ℂ g U) : ContinuousOn (germPoint g) U := by
   rw [continuousOn_iff_continuous_domRestrict]
   have hrestr : (U : Set ℂ).domRestrict (germPoint g) =
-      TopCat.Presheaf.EtaleSpace.germSection holomorphicPresheaf U (toSection U g hg) := by
+      TopCat.Presheaf.EtaleSpace.germSection (holomorphicPresheaf E) U (toSection U g hg) := by
     funext y
-    have hb : (TopCat.Presheaf.EtaleSpace.germSection holomorphicPresheaf U
-        (toSection U g hg) y).base = (y : ℂ) :=
-      TopCat.Presheaf.EtaleSpace.base_germSection U _ y
-    have hgerm : germAt g (y : ℂ) =
-        holomorphicPresheaf.germ U (y : ℂ) y.2 (toSection U g hg) :=
-      germAt_eq_germ_of_eventuallyEq y.2 _
-        (Filter.eventuallyEq_of_mem (U.isOpen.mem_nhds y.2) (sectionFun_toSection hg))
-    exact congrArg
-      (fun e : holomorphicPresheaf.stalk (y : ℂ) =>
-        (⟨(y : ℂ), e⟩ : holomorphicPresheaf.EtaleSpace)) hgerm
+    rw [Set.domRestrict_apply]
+    exact germPoint_eq_germSection hg y
   rw [hrestr]
   exact TopCat.Presheaf.EtaleSpace.continuous_germSection U _
 
@@ -334,40 +359,42 @@ theorem continuousOn_germPoint (hg : AnalyticOnNhd ℂ g U) : ContinuousOn (germ
 
 /-- **Every point of the étalé space carries the germ of a function analytic at its base
 point.** -/
-theorem exists_analyticAt_germAt_eq (p : holomorphicPresheaf.EtaleSpace) :
-    ∃ g : ℂ → ℂ, AnalyticAt ℂ g p.base ∧ germAt g p.base = p.germ := by
-  obtain ⟨U, hU, s, hs⟩ := holomorphicPresheaf.exists_germ_eq p.germ
+theorem exists_analyticAt_germAt_eq (p : (holomorphicPresheaf E).EtaleSpace) :
+    ∃ g : ℂ → E, AnalyticAt ℂ g p.base ∧ germAt g p.base = p.germ := by
+  obtain ⟨U, hU, s, hs⟩ := (holomorphicPresheaf E).exists_germ_eq p.germ
   exact ⟨sectionFun s, analyticOnNhd_sectionFun s _ hU, by rw [germAt_eq_germ hU s, hs]⟩
 
 /-- A holomorphic representative of the germ carried by a point of the étalé space. -/
-@[expose] noncomputable def repFun (p : holomorphicPresheaf.EtaleSpace) : ℂ → ℂ :=
+noncomputable def repFun (p : (holomorphicPresheaf E).EtaleSpace) : ℂ → E :=
   (exists_analyticAt_germAt_eq p).choose
 
 /-- A representative of a point of the étalé space is analytic at its base point. -/
-theorem analyticAt_repFun (p : holomorphicPresheaf.EtaleSpace) :
+theorem analyticAt_repFun (p : (holomorphicPresheaf E).EtaleSpace) :
     AnalyticAt ℂ (repFun p) p.base :=
   (exists_analyticAt_germAt_eq p).choose_spec.1
 
 /-- A representative of a point of the étalé space carries the germ that point carries. -/
 @[simp]
-theorem germAt_repFun (p : holomorphicPresheaf.EtaleSpace) :
+theorem germAt_repFun (p : (holomorphicPresheaf E).EtaleSpace) :
     germAt (repFun p) p.base = p.germ :=
   (exists_analyticAt_germAt_eq p).choose_spec.2
 
 /-- Taking a representative and then its germ point recovers the point of the étalé space. -/
 @[simp]
-theorem germPoint_repFun (p : holomorphicPresheaf.EtaleSpace) :
+theorem germPoint_repFun (p : (holomorphicPresheaf E).EtaleSpace) :
     germPoint (repFun p) p.base = p := by
   cases p
   rw [germPoint, germAt_repFun]
 
 /-! ### The projection is a separated local homeomorphism -/
 
+omit [CompleteSpace E] in
 /-- **The étalé projection of the sheaf of holomorphic functions is a local homeomorphism.** -/
 theorem isLocalHomeomorph_base :
-    IsLocalHomeomorph (_root_.TopCat.Presheaf.EtaleSpace.base (F := holomorphicPresheaf)) :=
-  TopCat.Presheaf.EtaleSpace.isLocalHomeomorph_base holomorphicPresheaf
+    IsLocalHomeomorph (_root_.TopCat.Presheaf.EtaleSpace.base (F := holomorphicPresheaf E)) :=
+  TopCat.Presheaf.EtaleSpace.isLocalHomeomorph_base (holomorphicPresheaf E)
 
+omit [CompleteSpace E] in
 /-- **The étalé projection of the sheaf of holomorphic functions is a separated map**: two
 distinct germs at the same point of `ℂ` have disjoint neighbourhoods in the étalé space.
 
@@ -377,43 +404,43 @@ sets swept out by their germs over that disc are disjoint, because a point of bo
 point where the two representatives have the same germ, and the identity theorem on the disc —
 which is connected — would then propagate that agreement back to the base point. -/
 theorem isSeparatedMap_base :
-    IsSeparatedMap (_root_.TopCat.Presheaf.EtaleSpace.base (F := holomorphicPresheaf)) := by
+    IsSeparatedMap (_root_.TopCat.Presheaf.EtaleSpace.base (F := holomorphicPresheaf E)) := by
   rintro ⟨x, g₁⟩ ⟨y, g₂⟩ hbase hne
   obtain rfl : x = y := hbase
-  obtain ⟨U₁, hxU₁, s₁, hs₁⟩ := holomorphicPresheaf.exists_germ_eq g₁
-  obtain ⟨U₂, hxU₂, s₂, hs₂⟩ := holomorphicPresheaf.exists_germ_eq g₂
+  obtain ⟨U₁, hxU₁, s₁, hs₁⟩ := (holomorphicPresheaf E).exists_germ_eq g₁
+  obtain ⟨U₂, hxU₂, s₂, hs₂⟩ := (holomorphicPresheaf E).exists_germ_eq g₂
   obtain ⟨r, hr, hrU⟩ : ∃ r > 0, ball x r ⊆ (U₁ : Set ℂ) ∩ (U₂ : Set ℂ) :=
     Metric.isOpen_iff.mp (U₁.isOpen.inter U₂.isOpen) x ⟨hxU₁, hxU₂⟩
   set B : Opens (TopCat.of ℂ) := ⟨ball x r, isOpen_ball⟩
   have hxB : x ∈ B := mem_ball_self hr
   have hB₁ : B ≤ U₁ := fun z hz => (hrU hz).1
   have hB₂ : B ≤ U₂ := fun z hz => (hrU hz).2
-  set t₁ := holomorphicPresheaf.map (homOfLE hB₁).op s₁ with ht₁def
-  set t₂ := holomorphicPresheaf.map (homOfLE hB₂).op s₂ with ht₂def
-  have ht₁ : holomorphicPresheaf.germ B x hxB t₁ = g₁ := by
-    rw [ht₁def, holomorphicPresheaf.germ_res_apply, hs₁]
-  have ht₂ : holomorphicPresheaf.germ B x hxB t₂ = g₂ := by
-    rw [ht₂def, holomorphicPresheaf.germ_res_apply, hs₂]
-  have hopen₁ : IsOpen (TopCat.Presheaf.EtaleSpace.sectionRange holomorphicPresheaf B t₁) :=
-    TopCat.Presheaf.EtaleSpace.isOpen_sectionRange (F := holomorphicPresheaf) B t₁
-  have hopen₂ : IsOpen (TopCat.Presheaf.EtaleSpace.sectionRange holomorphicPresheaf B t₂) :=
-    TopCat.Presheaf.EtaleSpace.isOpen_sectionRange (F := holomorphicPresheaf) B t₂
+  set t₁ := (holomorphicPresheaf E).map (homOfLE hB₁).op s₁ with ht₁def
+  set t₂ := (holomorphicPresheaf E).map (homOfLE hB₂).op s₂ with ht₂def
+  have ht₁ : (holomorphicPresheaf E).germ B x hxB t₁ = g₁ := by
+    rw [ht₁def, (holomorphicPresheaf E).germ_res_apply, hs₁]
+  have ht₂ : (holomorphicPresheaf E).germ B x hxB t₂ = g₂ := by
+    rw [ht₂def, (holomorphicPresheaf E).germ_res_apply, hs₂]
+  have hopen₁ : IsOpen (TopCat.Presheaf.EtaleSpace.sectionRange (holomorphicPresheaf E) B t₁) :=
+    TopCat.Presheaf.EtaleSpace.isOpen_sectionRange (F := holomorphicPresheaf E) B t₁
+  have hopen₂ : IsOpen (TopCat.Presheaf.EtaleSpace.sectionRange (holomorphicPresheaf E) B t₂) :=
+    TopCat.Presheaf.EtaleSpace.isOpen_sectionRange (F := holomorphicPresheaf E) B t₂
   refine ⟨_, _, hopen₁, hopen₂,
-    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf) |>.mpr
+    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf E) |>.mpr
       ⟨hxB, ht₁.symm⟩,
-    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf) |>.mpr
+    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf E) |>.mpr
       ⟨hxB, ht₂.symm⟩, ?_⟩
   refine Set.disjoint_left.mpr fun p hp₁ hp₂ => ?_
   obtain ⟨hpB, hpt₁⟩ :=
-    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf) |>.mp hp₁
+    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf E) |>.mp hp₁
   obtain ⟨hpB', hpt₂⟩ :=
-    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf) |>.mp hp₂
+    TopCat.Presheaf.EtaleSpace.mem_sectionRange_iff (F := holomorphicPresheaf E) |>.mp hp₂
   have hev : sectionFun t₁ =ᶠ[𝓝 p.base] sectionFun t₂ :=
     (germ_eq_iff hpB hpB' t₁ t₂).mp (hpt₁.symm.trans hpt₂)
   have hEqOn : EqOn (sectionFun t₁) (sectionFun t₂) (B : Set ℂ) :=
     (analyticOnNhd_sectionFun t₁).eqOn_of_preconnected_of_eventuallyEq
       (analyticOnNhd_sectionFun t₂) (convex_ball x r).isPreconnected hpB hev
-  have hgerm : holomorphicPresheaf.germ B x hxB t₁ = holomorphicPresheaf.germ B x hxB t₂ :=
+  have hgerm : (holomorphicPresheaf E).germ B x hxB t₁ = (holomorphicPresheaf E).germ B x hxB t₂ :=
     (germ_eq_iff hxB hxB t₁ t₂).mpr
       (Filter.eventuallyEq_of_mem (B.isOpen.mem_nhds hxB) hEqOn)
   exact hne (by rw [← ht₁, ← ht₂, hgerm])

--- a/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
+++ b/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
@@ -139,19 +139,18 @@ restriction of a function analytic on a neighbourhood of every point of `U`. -/
 def IsHolomorphicSection {U : Opens (TopCat.of ℂ)} (f : U → E) : Prop :=
   ∃ g : ℂ → E, AnalyticOnNhd ℂ g U ∧ ∀ x : U, f x = g x
 
-variable (E) in
-/-- Being holomorphic is stable under restriction. -/
-def holomorphicPrelocal : TopCat.PrelocalPredicate fun _ : TopCat.of ℂ => E where
-  pred f := IsHolomorphicSection f
-  res i f hf := by
-    obtain ⟨g, hg, hfg⟩ := hf
-    refine ⟨g, hg.mono (SetLike.coe_subset_coe.mpr i.le), fun x => ?_⟩
-    exact hfg _
+/-- Being holomorphic is stable under restriction to a smaller open set. -/
+theorem IsHolomorphicSection.mono {U V : Opens (TopCat.of ℂ)} (h : U ≤ V) {f : V → E}
+    (hf : IsHolomorphicSection f) :
+    IsHolomorphicSection fun x : U => f ⟨x.1, SetLike.le_def.mp h x.2⟩ := by
+  obtain ⟨g, hg, hfg⟩ := hf
+  exact ⟨g, hg.mono (SetLike.coe_subset_coe.mpr h), fun x => hfg _⟩
 
 variable (E) in
 /-- Being holomorphic is a local condition. -/
 private def holomorphicLocal : TopCat.LocalPredicate fun _ : TopCat.of ℂ => E where
-  toPrelocalPredicate := holomorphicPrelocal E
+  pred f := IsHolomorphicSection f
+  res i _ hf := hf.mono i.le
   locality {U} f hloc := by
     refine ⟨Function.extend Subtype.val f (fun _ => 0), fun z hz => ?_, fun x =>
       (Subtype.val_injective.extend_apply f _ x).symm⟩
@@ -166,7 +165,9 @@ private def holomorphicLocal : TopCat.LocalPredicate fun _ : TopCat.of ℂ => E 
 variable (E) in
 /-- The presheaf of holomorphic functions on `ℂ` with values in `E`. -/
 @[expose] noncomputable def holomorphicPresheaf : (TopCat.of ℂ).Presheaf (Type) :=
-  TopCat.subpresheafToTypes (holomorphicPrelocal E)
+  TopCat.subpresheafToTypes
+    ({ pred := fun {_} f => IsHolomorphicSection f
+       res := fun i _ hf => hf.mono i.le } : TopCat.PrelocalPredicate fun _ : TopCat.of ℂ => E)
 
 variable (E) in
 /-- The sheaf of holomorphic functions on `ℂ` with values in `E`. -/

--- a/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
+++ b/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
@@ -138,6 +138,12 @@ restriction of a function analytic on a neighbourhood of every point of `U`. -/
 def IsHolomorphicSection {U : Opens (TopCat.of ℂ)} (f : U → E) : Prop :=
   ∃ g : ℂ → E, AnalyticOnNhd ℂ g U ∧ ∀ x : U, f x = g x
 
+/-- **Being a holomorphic section is being the restriction of a function analytic on a
+neighbourhood of every point.** `TauCeti.IsHolomorphicSection` does not expose its body, so this
+is how a consumer of the sheaf introduces or eliminates it. -/
+theorem isHolomorphicSection_iff {U : Opens (TopCat.of ℂ)} {f : U → E} :
+    IsHolomorphicSection f ↔ ∃ g : ℂ → E, AnalyticOnNhd ℂ g U ∧ ∀ x : U, f x = g x := Iff.rfl
+
 /-- Being holomorphic is stable under restriction to a smaller open set. -/
 theorem IsHolomorphicSection.mono {U V : Opens (TopCat.of ℂ)} (h : U ≤ V) {f : V → E}
     (hf : IsHolomorphicSection f) :

--- a/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
+++ b/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
@@ -58,9 +58,9 @@ transport.
 
 ## The two theorems
 
-`TauCeti.HolomorphicPresheaf.isLocalHomeomorph_base` is the chart statement of
-`TauCeti/Topology/Sheaves/EtaleSpace.lean`, instantiated: over an open set on which a section is
-defined, the germs of that section form an open set carried homeomorphically onto the base.
+`TauCeti.TopCat.Presheaf.EtaleSpace.isLocalHomeomorph_base` is the chart statement of
+`TauCeti/Topology/Sheaves/EtaleSpace.lean`: over an open set on which a section is defined, the
+germs of that section form an open set carried homeomorphically onto the base.
 
 `TauCeti.HolomorphicPresheaf.isSeparatedMap_base` is the analytic content, and it is the
 **identity theorem** in disguise. Two distinct germs at one point `x` are represented by sections
@@ -78,8 +78,6 @@ the intended application; `Conformal/Continuation/Etale.lean` supplies that appl
 * `TauCeti.HolomorphicPresheaf.germ_eq_iff` — germs agree exactly when the functions agree nearby.
 * `TauCeti.HolomorphicPresheaf.continuousOn_germPoint` — the germ map of a holomorphic function is
   a continuous section of the étalé projection.
-* `TauCeti.HolomorphicPresheaf.isLocalHomeomorph_base` — **the étalé projection is a local
-  homeomorphism**.
 * `TauCeti.HolomorphicPresheaf.isSeparatedMap_base` — **the étalé projection is separated**.
 
 ## Generality
@@ -388,12 +386,6 @@ theorem germPoint_repFun (p : (holomorphicPresheaf E).EtaleSpace) :
   rw [germPoint, germAt_repFun]
 
 /-! ### The projection is a separated local homeomorphism -/
-
-omit [CompleteSpace E] in
-/-- **The étalé projection of the sheaf of holomorphic functions is a local homeomorphism.** -/
-theorem isLocalHomeomorph_base :
-    IsLocalHomeomorph (_root_.TopCat.Presheaf.EtaleSpace.base (F := holomorphicPresheaf E)) :=
-  TopCat.Presheaf.EtaleSpace.isLocalHomeomorph_base (holomorphicPresheaf E)
 
 omit [CompleteSpace E] in
 /-- **The étalé projection of the sheaf of holomorphic functions is a separated map**: two

--- a/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
+++ b/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
@@ -205,7 +205,7 @@ theorem analyticOnNhd_sectionFun (s : (holomorphicPresheaf E).obj (op U)) :
   exact (hfg ⟨y, hy⟩).symm
 
 /-- Restricting a section along an inclusion of open sets restricts its underlying function. -/
-theorem map_val_apply (i : U ⟶ V) (s : (holomorphicPresheaf E).obj (op V)) (y : U) :
+private theorem map_val_apply (i : U ⟶ V) (s : (holomorphicPresheaf E).obj (op V)) (y : U) :
     ((holomorphicPresheaf E).map i.op s).1 y = s.1 ⟨y.1, SetLike.le_def.mp i.le y.2⟩ := rfl
 
 /-- A function analytic on a neighbourhood of every point of `U`, read as a section over `U`. -/

--- a/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
+++ b/TauCeti/Analysis/Complex/HolomorphicSheaf.lean
@@ -70,7 +70,8 @@ representatives have the same germ, and the identity theorem on the disc — con
 both representatives are analytic — would propagate that agreement from `y` back to `x`, making
 the two germs equal. Separatedness is exactly the hypothesis Mathlib's abstract monodromy theorem
 `IsLocalHomeomorph.monodromy_theorem` asks for, and its docstring names analytic continuation as
-the intended application; `Conformal/Continuation/Etale.lean` supplies that application.
+the intended application; `Conformal/Continuation/Etale.lean` supplies the continuation/lift
+correspondence needed to apply it.
 
 ## Main results
 

--- a/TauCeti/Topology/Sheaves/EtaleSpace.lean
+++ b/TauCeti/Topology/Sheaves/EtaleSpace.lean
@@ -39,7 +39,7 @@ variable {X : TopCat.{v}} {C : Type u} [Category.{v} C] {CC : C → Type v}
 variable {F : X.Presheaf C}
 
 /-- A section of a presheaf, viewed as a section of the étalé projection. -/
-noncomputable def germSection (F : X.Presheaf C) (U : Opens X)
+@[expose] noncomputable def germSection (F : X.Presheaf C) (U : Opens X)
     (s : ToType (F.obj (Opposite.op U))) :
     U → F.EtaleSpace :=
   fun x ↦ ⟨x, F.germ U x x.2 s⟩

--- a/TauCeti/Topology/Sheaves/EtaleSpace.lean
+++ b/TauCeti/Topology/Sheaves/EtaleSpace.lean
@@ -47,6 +47,7 @@ noncomputable def germSection (F : X.Presheaf C) (U : Opens X)
 /-- The germ section written out: over `x`, it is the pair of `x` and the germ of `s` at `x`.
 This is the characteristic property of `TauCeti.TopCat.Presheaf.EtaleSpace.germSection`, and the
 form in which a concrete germ map is identified with it. -/
+@[simp]
 theorem germSection_apply (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x : U) :
     germSection F U s x = ⟨x, F.germ U x x.2 s⟩ :=
   (rfl)

--- a/TauCeti/Topology/Sheaves/EtaleSpace.lean
+++ b/TauCeti/Topology/Sheaves/EtaleSpace.lean
@@ -39,10 +39,17 @@ variable {X : TopCat.{v}} {C : Type u} [Category.{v} C] {CC : C → Type v}
 variable {F : X.Presheaf C}
 
 /-- A section of a presheaf, viewed as a section of the étalé projection. -/
-@[expose] noncomputable def germSection (F : X.Presheaf C) (U : Opens X)
+noncomputable def germSection (F : X.Presheaf C) (U : Opens X)
     (s : ToType (F.obj (Opposite.op U))) :
     U → F.EtaleSpace :=
   fun x ↦ ⟨x, F.germ U x x.2 s⟩
+
+/-- The germ section written out: over `x`, it is the pair of `x` and the germ of `s` at `x`.
+This is the characteristic property of `TauCeti.TopCat.Presheaf.EtaleSpace.germSection`, and the
+form in which a concrete germ map is identified with it. -/
+theorem germSection_apply (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x : U) :
+    germSection F U s x = ⟨x, F.germ U x x.2 s⟩ :=
+  (rfl)
 
 @[simp]
 theorem base_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x : U) :

--- a/TauCeti/Topology/Sheaves/EtaleSpace.lean
+++ b/TauCeti/Topology/Sheaves/EtaleSpace.lean
@@ -52,7 +52,6 @@ theorem germSection_apply (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x 
     germSection F U s x = ⟨x, F.germ U x x.2 s⟩ :=
   (rfl)
 
-@[simp]
 theorem base_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x : U) :
     (germSection F U s x).base = x :=
   (rfl)


### PR DESCRIPTION
This PR builds the étalé space of holomorphic germs over `ℂ`, proves that its projection to the base is a **separated local homeomorphism**, and identifies analytic continuation along a path with a continuous lift of that path to it, so that Mathlib's abstract monodromy theorem applies verbatim to holomorphic germs.

`TauCeti/Analysis/Complex/HolomorphicSheaf.lean` writes "holomorphic" as a Mathlib `TopCat.LocalPredicate` on functions from an open subset of `ℂ` into a complex Banach space `E` — the restriction of a function analytic on a neighbourhood of every point — and takes the resulting presheaf and sheaf (`TauCeti.holomorphicPresheaf`, `TauCeti.holomorphicSheaf`). On top of it, `TauCeti.HolomorphicPresheaf.germ_eq_iff` is the dictionary between germs as stalk elements and germs as eventual equality of functions, `germAt` / `germPoint` send a function analytic at a point to the stalk element and to the point of the étalé space it determines, and `repFun` inverts that. The two results the space is built for are `TauCeti.TopCat.Presheaf.EtaleSpace.isLocalHomeomorph_base` — the generic chart theorem already proved in `TauCeti/Topology/Sheaves/EtaleSpace.lean` — and `TauCeti.HolomorphicPresheaf.isSeparatedMap_base`, which is the identity theorem: two sections representing two distinct germs at one point are restricted to a common disc, and the two open sets of germs they sweep out are disjoint, because a common point would be a point of the disc where the two representatives have the same germ, and `AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq` on the connected disc would carry that back to the base point.

`TauCeti/Analysis/Complex/Conformal/Continuation/Etale.lean` spends it. `TauCeti.isAnalyticContinuationAlong_iff_continuousOn_germPoint` proves the sentence that `Conformal/Continuation/Basic.lean` has been asserting in its docstring without proof since the continuation predicate landed: given that each `f t` is analytic at `γ t` and that `γ` is continuous, `TauCeti.IsAnalyticContinuationAlong f γ s` holds exactly when `t ↦ germPoint (f t) (γ t)` is continuous on `s`. The lifting condition is automatic, the base point of that germ being `γ t` by construction, so the content is that the locality clause of a continuation *is* continuity in the étalé topology. `TauCeti.isAnalyticContinuationAlong_repFun` is the converse reading, a continuous map into the étalé space continuing its own representatives, so the two notions are the same data up to the choice of a representative. Mathlib’s `IsLocalHomeomorph.monodromy_theorem` is directly applicable to the étalé projection: its local-homeomorphism hypothesis is the generic `TauCeti.TopCat.Presheaf.EtaleSpace.isLocalHomeomorph_base`, and separatedness is `TauCeti.HolomorphicPresheaf.isSeparatedMap_base`. The continuation/lift correspondence above supplies the remaining dictionary, so no thin specialization of the Mathlib theorem is introduced.

The milestone served is **L4 of `ConformalMapping`, "analytic continuation & the reflection principle", whose stated target includes the monodromy theorem**, and specifically the frontier item `ConformalMapping/STATUS.md` records against it: monodromy "is phrased in germ families rather than against the étale space that landed beside it". `Conformal/Monodromy.lean` says the same in its "Relation to Mathlib" section — that consuming the abstract theorem "would first require building the étale space of holomorphic germs over `ℂ` as a topological space and proving the germ projection to be a separated local homeomorphism", left as follow-up — and `TauCeti/Topology/Sheaves/EtaleSpace.lean` was landed for exactly this, its docstring naming separatedness as "the remaining analytic input". This PR supplies that input and closes the loop. It does not replace `Conformal/Monodromy.lean`: `TauCeti.monodromy_theorem_of_free_homotopy` moves the endpoints and concludes with a continuation along the path they sweep out, while Mathlib's abstract theorem is rel endpoints and concludes with an equality of lifted points, so the metric stability engine stays and the four stale docstrings claiming the étalé space does not exist are corrected instead (`Continuation/Basic.lean`, `GlobalBranch.lean`, `Monodromy.lean`). After this PR, L4 is closed on both routes and the live layer of the roadmap is L5, the Carathéodory boundary correspondence, whose forward direction still waits on plane separation for Jordan curves.

Reuse and prior art: nothing is vendored. Mathlib supplies the étalé space (`Mathlib/Topology/Sheaves/EtaleSpace.lean`, Kudryashov), the local-predicate construction of a sheaf of functions (`Mathlib/Topology/Sheaves/LocalPredicate.lean`), the abstract monodromy theorem (`Mathlib/Topology/Homotopy/Lifting.lean`, Xu) and the identity theorem, and all four are consumed rather than restated; Mathlib has no sheaf of holomorphic functions, and its sheaf of smooth functions on a manifold is fixed at smoothness `∞`. The chart API in `TauCeti/Topology/Sheaves/EtaleSpace.lean` is consumed too; the only change made to it is the characteristic lemma `germSection_apply`, needed so that a downstream module can identify a concrete germ map with `germSection` and inherit its continuity rather than reprove it, without unfolding its body. Layer L4 is absent from the in-progress upstream Riemann-mapping effort [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), which contains no continuation or monodromy material, so none of this is a shim awaiting deletion.

Verification:
- `lake exe cache get`
- `lake build`
- `lake exe axioms`

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"etale-space-of-holomorphic-germs"}-->

🤖 Prepared with Claude Code



