### PR TITLE
feat: regroup ideal coefficients by norm

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Basic
+public import Mathlib.Data.Set.Card.Arithmetic
+public import Mathlib.NumberTheory.ArithmeticFunction.Defs
+public import Mathlib.NumberTheory.NumberField.DedekindZeta
+
+/-!
+# Regrouping ideal arithmetic functions by absolute norm
+
+This file defines `TauCeti.normCoeff`, the ordinary arithmetic function obtained by summing an
+`IdealArithmeticFunction` over each fibre of the absolute norm.  These fibres are finite by
+`Ideal.finite_setOfPred_absNorm_eq`, so the coefficients are honest finite sums.  The resulting
+function has value zero at `0`, as required by Mathlib's `ArithmeticFunction` carrier.
+
+The basic API records the values at zero and one and compatibility with the additive operations,
+complex scalar multiplication, and complex conjugation.  For the constant-one ideal arithmetic
+function, the positive coefficients are the numbers of integral ideals of the corresponding norm;
+hence its `LSeries` is Mathlib's `NumberField.dedekindZeta`.
+
+## Roadmap role
+
+This is the finite-norm-fibre part of Layer **1.1** of
+`TauCetiRoadmap/ArithmeticDirichletSeries/README.md`.  The next layer step uses these coefficients
+to regroup an absolutely convergent series over nonzero ideals into a Mathlib `LSeries`.
+
+## References
+
+* J. Neukirch, *Algebraic Number Theory*, Chapter VII.
+* G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters II--III.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped nonZeroDivisors NumberField
+
+variable (K : Type*) [Field K] [NumberField K]
+
+private theorem finite_normFiber (n : ℕ) :
+    {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n}.Finite := by
+  exact (Ideal.finite_setOfPred_absNorm_eq n).preimage Subtype.val_injective.injOn
+
+/-- Regroup an ideal arithmetic function by absolute norm.
+
+The coefficient at `n` is the finite sum of `f I` over the nonzero integral ideals `I` whose
+absolute norm is `n`.  Use `normCoeff_apply` for this formula. -/
+noncomputable def normCoeff (f : IdealArithmeticFunction K) : ArithmeticFunction ℂ where
+  toFun n := ∑ᶠ I ∈ {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n}, f I
+  map_zero' := by
+    apply finsum_mem_eq_zero_of_forall_eq_zero
+    intro I hI
+    exact (mem_nonZeroDivisors_iff_ne_zero.mp I.property (Ideal.absNorm_eq_zero_iff.mp hI)).elim
+
+/-- The value of `normCoeff f` is the finite sum of `f` over the corresponding absolute-norm
+fibre. -/
+theorem normCoeff_apply (f : IdealArithmeticFunction K) (n : ℕ) :
+    normCoeff K f n =
+      ∑ᶠ I ∈ {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n}, f I :=
+  (rfl)
+
+/-- The summand defining a norm coefficient has finite support. -/
+theorem normCoeff_summand_hasFiniteSupport (f : IdealArithmeticFunction K) (n : ℕ) :
+    (Set.indicator
+      {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n} f).HasFiniteSupport :=
+  (finite_normFiber K n).subset Set.support_indicator_subset
+
+/-- The zeroth norm coefficient is zero. -/
+@[simp]
+theorem normCoeff_zero (f : IdealArithmeticFunction K) : normCoeff K f 0 = 0 := by
+  rw [normCoeff_apply]
+  apply finsum_mem_eq_zero_of_forall_eq_zero
+  intro I hI
+  exact (mem_nonZeroDivisors_iff_ne_zero.mp I.property (Ideal.absNorm_eq_zero_iff.mp hI)).elim
+
+/-- There is a unique nonzero integral ideal of absolute norm one, namely the unit ideal. -/
+@[simp]
+theorem normCoeff_one (f : IdealArithmeticFunction K) : normCoeff K f 1 = f 1 := by
+  rw [normCoeff_apply]
+  have hfiber :
+      {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = 1} = {1} := by
+    ext I
+    simp [Ideal.absNorm_eq_one_iff, Subtype.ext_iff]
+  rw [hfiber]
+  simp
+
+/-- Regrouping the zero ideal arithmetic function gives the zero arithmetic function. -/
+@[simp]
+theorem normCoeff_zero_fun : normCoeff K (0 : IdealArithmeticFunction K) = 0 := by
+  ext n
+  simp [normCoeff_apply]
+
+/-- Regrouping commutes with pointwise addition. -/
+@[simp]
+theorem normCoeff_add (f g : IdealArithmeticFunction K) :
+    normCoeff K (f + g) = normCoeff K f + normCoeff K g := by
+  ext n
+  simp only [normCoeff_apply, Pi.add_apply, ArithmeticFunction.add_apply]
+  exact finsum_mem_add_distrib (finite_normFiber K n)
+
+/-- Regrouping commutes with pointwise negation. -/
+@[simp]
+theorem normCoeff_neg (f : IdealArithmeticFunction K) :
+    normCoeff K (-f) = -normCoeff K f := by
+  ext n
+  simp only [normCoeff_apply, Pi.neg_apply, ArithmeticFunction.neg_apply]
+  exact finsum_mem_neg_distrib f (finite_normFiber K n)
+
+/-- Regrouping commutes with pointwise subtraction. -/
+@[simp]
+theorem normCoeff_sub (f g : IdealArithmeticFunction K) :
+    normCoeff K (f - g) = normCoeff K f - normCoeff K g := by
+  rw [sub_eq_add_neg, normCoeff_add, normCoeff_neg, sub_eq_add_neg]
+
+/-- Regrouping commutes with complex scalar multiplication. -/
+@[simp]
+theorem normCoeff_smul (c : ℂ) (f : IdealArithmeticFunction K) :
+    normCoeff K (c • f) = c • normCoeff K f := by
+  ext n
+  simp only [normCoeff_apply, Pi.smul_apply, ArithmeticFunction.smul_map]
+  exact (DistribSMul.toAddMonoidHom ℂ c).map_finsum_mem f (finite_normFiber K n) |>.symm
+
+/-- Regrouping commutes with coefficientwise complex conjugation. -/
+theorem normCoeff_conj_apply (f : IdealArithmeticFunction K) (n : ℕ) :
+    normCoeff K (fun I ↦ star (f I)) n = star (normCoeff K f n) := by
+  simp only [normCoeff_apply]
+  exact ((starAddEquiv : ℂ ≃+ ℂ).map_finsum_mem f (finite_normFiber K n)).symm
+
+private noncomputable def normFiberEquiv (n : ℕ) (hn : n ≠ 0) :
+    {I : (Ideal (𝓞 K))⁰ // Ideal.absNorm (I : Ideal (𝓞 K)) = n} ≃
+      {I : Ideal (𝓞 K) // Ideal.absNorm I = n} where
+  toFun I := ⟨I.1, I.2⟩
+  invFun I := ⟨⟨I.1, by
+    rw [mem_nonZeroDivisors_iff_ne_zero]
+    intro hI
+    apply hn
+    rw [← I.2, Ideal.absNorm_eq_zero_iff]
+    simpa only [Submodule.zero_eq_bot] using hI⟩, I.2⟩
+  left_inv I := rfl
+  right_inv I := rfl
+
+/-- For positive `n`, the coefficient of the constant-one ideal arithmetic function is the number
+of integral ideals of absolute norm `n`. -/
+theorem normCoeff_one_apply_of_ne_zero (n : ℕ) (hn : n ≠ 0) :
+    normCoeff K (1 : IdealArithmeticFunction K) n =
+      (Nat.card {I : Ideal (𝓞 K) // Ideal.absNorm I = n} : ℂ) := by
+  rw [normCoeff_apply]
+  rw [finsum_mem_eq_finite_toFinset_sum _ (finite_normFiber K n)]
+  simp only [Pi.one_apply, Finset.sum_const, nsmul_eq_mul, mul_one]
+  norm_cast
+  rw [← Set.ncard_eq_toFinset_card
+    {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n} (finite_normFiber K n),
+    ← Nat.card_coe_set_eq]
+  exact Nat.card_congr (normFiberEquiv K n hn)
+
+/-- The `LSeries` obtained from the constant-one ideal arithmetic function is Mathlib's Dedekind
+zeta function.  The two coefficient functions differ at `0`, which `LSeries` ignores. -/
+theorem LSeries_normCoeff_one (s : ℂ) :
+    LSeries (normCoeff K (1 : IdealArithmeticFunction K)) s = NumberField.dedekindZeta K s := by
+  unfold NumberField.dedekindZeta
+  exact LSeries_congr (fun hn ↦ normCoeff_one_apply_of_ne_zero K _ hn) s
+
+end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
@@ -6,9 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Basic
-public import Mathlib.Data.Set.Card.Arithmetic
 public import Mathlib.NumberTheory.ArithmeticFunction.Defs
-public import Mathlib.NumberTheory.NumberField.DedekindZeta
+public import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 
 /-!
 # Regrouping ideal arithmetic functions by absolute norm
@@ -20,9 +19,7 @@ function has value zero at `0`, as required by Mathlib's `ArithmeticFunction` ca
 is available from `ArithmeticFunction.map_zero`.
 
 The construction is bundled as a complex-linear map.  The basic API records the value at one and
-compatibility with complex conjugation.  For the constant-one ideal arithmetic function, the
-positive coefficients are the numbers of integral ideals of the corresponding norm; hence its
-`LSeries` is Mathlib's `NumberField.dedekindZeta`.
+compatibility with complex conjugation.
 
 ## Roadmap role
 
@@ -84,7 +81,7 @@ theorem hasFiniteSupport_normCoeff_summand (f : IdealArithmeticFunction K) (n : 
 
 /-- There is a unique nonzero integral ideal of absolute norm one, namely the unit ideal. -/
 @[simp]
-theorem normCoeff_one (f : IdealArithmeticFunction K) : normCoeff K f 1 = f 1 := by
+theorem normCoeff_apply_one (f : IdealArithmeticFunction K) : normCoeff K f 1 = f 1 := by
   rw [normCoeff_apply]
   have hfiber :
       {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = 1} = {1} := by
@@ -99,39 +96,5 @@ theorem normCoeff_star_apply (f : IdealArithmeticFunction K) (n : ℕ) :
     normCoeff K (fun I ↦ (starRingEnd ℂ) (f I)) n = star (normCoeff K f n) := by
   simp only [normCoeff_apply]
   exact ((starAddEquiv : ℂ ≃+ ℂ).map_finsum_mem f (finite_normFiber K n)).symm
-
-private noncomputable def normFiberEquiv (n : ℕ) (hn : n ≠ 0) :
-    {I : (Ideal (𝓞 K))⁰ // Ideal.absNorm (I : Ideal (𝓞 K)) = n} ≃
-      {I : Ideal (𝓞 K) // Ideal.absNorm I = n} where
-  toFun I := ⟨I.1, I.2⟩
-  invFun I := ⟨⟨I.1, by
-    rw [mem_nonZeroDivisors_iff_ne_zero]
-    intro hI
-    apply hn
-    rw [← I.2, Ideal.absNorm_eq_zero_iff]
-    simpa only [Submodule.zero_eq_bot] using hI⟩, I.2⟩
-  left_inv I := rfl
-  right_inv I := rfl
-
-/-- For positive `n`, the coefficient of the constant-one ideal arithmetic function is the number
-of integral ideals of absolute norm `n`. -/
-theorem normCoeff_one_apply_of_ne_zero (n : ℕ) (hn : n ≠ 0) :
-    normCoeff K (1 : IdealArithmeticFunction K) n =
-      (Nat.card {I : Ideal (𝓞 K) // Ideal.absNorm I = n} : ℂ) := by
-  rw [normCoeff_apply]
-  rw [finsum_mem_eq_finite_toFinset_sum _ (finite_normFiber K n)]
-  simp only [Pi.one_apply, Finset.sum_const, nsmul_eq_mul, mul_one]
-  norm_cast
-  rw [← Set.ncard_eq_toFinset_card
-    {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n} (finite_normFiber K n),
-    ← Nat.card_coe_set_eq]
-  exact Nat.card_congr (normFiberEquiv K n hn)
-
-/-- The `LSeries` obtained from the constant-one ideal arithmetic function is Mathlib's Dedekind
-zeta function.  The two coefficient functions differ at `0`, which `LSeries` ignores. -/
-theorem LSeries_normCoeff_one (s : ℂ) :
-    LSeries (normCoeff K (1 : IdealArithmeticFunction K)) s = NumberField.dedekindZeta K s := by
-  unfold NumberField.dedekindZeta
-  exact LSeries_congr (fun hn ↦ normCoeff_one_apply_of_ne_zero K _ hn) s
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
@@ -122,7 +122,7 @@ theorem normCoeff_smul (c : ℂ) (f : IdealArithmeticFunction K) :
 /-- Regrouping commutes with coefficientwise complex conjugation. -/
 @[simp]
 theorem normCoeff_conj_apply (f : IdealArithmeticFunction K) (n : ℕ) :
-    normCoeff K (fun I ↦ star (f I)) n = star (normCoeff K f n) := by
+    normCoeff K (fun I ↦ (starRingEnd ℂ) (f I)) n = star (normCoeff K f n) := by
   simp only [normCoeff_apply]
   exact ((starAddEquiv : ℂ ≃+ ℂ).map_finsum_mem f (finite_normFiber K n)).symm
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
@@ -16,9 +16,10 @@ public import Mathlib.NumberTheory.NumberField.DedekindZeta
 This file defines `TauCeti.normCoeff`, the ordinary arithmetic function obtained by summing an
 `IdealArithmeticFunction` over each fibre of the absolute norm.  These fibres are finite by
 `Ideal.finite_setOfPred_absNorm_eq`, so the coefficients are honest finite sums.  The resulting
-function has value zero at `0`, as required by Mathlib's `ArithmeticFunction` carrier.
+function has value zero at `0`, as required by Mathlib's `ArithmeticFunction` carrier; that value
+is available from `ArithmeticFunction.map_zero`.
 
-The basic API records the values at zero and one and compatibility with the additive operations,
+The basic API records the value at one and compatibility with the additive operations,
 complex scalar multiplication, and complex conjugation.  For the constant-one ideal arithmetic
 function, the positive coefficients are the numbers of integral ideals of the corresponding norm;
 hence its `LSeries` is Mathlib's `NumberField.dedekindZeta`.
@@ -70,14 +71,6 @@ theorem normCoeff_summand_hasFiniteSupport (f : IdealArithmeticFunction K) (n : 
     (Set.indicator
       {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n} f).HasFiniteSupport :=
   (finite_normFiber K n).subset Set.support_indicator_subset
-
-/-- The zeroth norm coefficient is zero. -/
-@[simp]
-theorem normCoeff_zero (f : IdealArithmeticFunction K) : normCoeff K f 0 = 0 := by
-  rw [normCoeff_apply]
-  apply finsum_mem_eq_zero_of_forall_eq_zero
-  intro I hI
-  exact (mem_nonZeroDivisors_iff_ne_zero.mp I.property (Ideal.absNorm_eq_zero_iff.mp hI)).elim
 
 /-- There is a unique nonzero integral ideal of absolute norm one, namely the unit ideal. -/
 @[simp]

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
@@ -19,10 +19,10 @@ This file defines `TauCeti.normCoeff`, the ordinary arithmetic function obtained
 function has value zero at `0`, as required by Mathlib's `ArithmeticFunction` carrier; that value
 is available from `ArithmeticFunction.map_zero`.
 
-The basic API records the value at one and compatibility with the additive operations,
-complex scalar multiplication, and complex conjugation.  For the constant-one ideal arithmetic
-function, the positive coefficients are the numbers of integral ideals of the corresponding norm;
-hence its `LSeries` is Mathlib's `NumberField.dedekindZeta`.
+The construction is bundled as a complex-linear map.  The basic API records the value at one and
+compatibility with complex conjugation.  For the constant-one ideal arithmetic function, the
+positive coefficients are the numbers of integral ideals of the corresponding norm; hence its
+`LSeries` is Mathlib's `NumberField.dedekindZeta`.
 
 ## Roadmap role
 
@@ -48,16 +48,26 @@ private theorem finite_normFiber (n : ℕ) :
     {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n}.Finite := by
   exact (Ideal.finite_setOfPred_absNorm_eq n).preimage Subtype.val_injective.injOn
 
-/-- Regroup an ideal arithmetic function by absolute norm.
+/-- Regroup ideal arithmetic functions by absolute norm as a complex-linear map.
 
 The coefficient at `n` is the finite sum of `f I` over the nonzero integral ideals `I` whose
 absolute norm is `n`.  Use `normCoeff_apply` for this formula. -/
-noncomputable def normCoeff (f : IdealArithmeticFunction K) : ArithmeticFunction ℂ where
-  toFun n := ∑ᶠ I ∈ {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n}, f I
-  map_zero' := by
-    apply finsum_mem_eq_zero_of_forall_eq_zero
-    intro I hI
-    exact (mem_nonZeroDivisors_iff_ne_zero.mp I.property (Ideal.absNorm_eq_zero_iff.mp hI)).elim
+noncomputable def normCoeff : IdealArithmeticFunction K →ₗ[ℂ] ArithmeticFunction ℂ where
+  toFun f :=
+    { toFun n := ∑ᶠ I ∈ {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n}, f I
+      map_zero' := by
+        apply finsum_mem_eq_zero_of_forall_eq_zero
+        intro I hI
+        exact
+          (mem_nonZeroDivisors_iff_ne_zero.mp I.property (Ideal.absNorm_eq_zero_iff.mp hI)).elim }
+  map_add' f g := by
+    ext n
+    simp only [Pi.add_apply]
+    exact finsum_mem_add_distrib (finite_normFiber K n)
+  map_smul' c f := by
+    ext n
+    simp only [Pi.smul_apply]
+    exact (DistribSMul.toAddMonoidHom ℂ c).map_finsum_mem f (finite_normFiber K n) |>.symm
 
 /-- The value of `normCoeff f` is the finite sum of `f` over the corresponding absolute-norm
 fibre. -/
@@ -83,45 +93,9 @@ theorem normCoeff_one (f : IdealArithmeticFunction K) : normCoeff K f 1 = f 1 :=
   rw [hfiber]
   simp
 
-/-- Regrouping the zero ideal arithmetic function gives the zero arithmetic function. -/
-@[simp]
-theorem normCoeff_zero : normCoeff K (0 : IdealArithmeticFunction K) = 0 := by
-  ext n
-  simp [normCoeff_apply]
-
-/-- Regrouping commutes with pointwise addition. -/
-@[simp]
-theorem normCoeff_add (f g : IdealArithmeticFunction K) :
-    normCoeff K (f + g) = normCoeff K f + normCoeff K g := by
-  ext n
-  simp only [normCoeff_apply, Pi.add_apply, ArithmeticFunction.add_apply]
-  exact finsum_mem_add_distrib (finite_normFiber K n)
-
-/-- Regrouping commutes with pointwise negation. -/
-@[simp]
-theorem normCoeff_neg (f : IdealArithmeticFunction K) :
-    normCoeff K (-f) = -normCoeff K f := by
-  ext n
-  simp only [normCoeff_apply, Pi.neg_apply, ArithmeticFunction.neg_apply]
-  exact finsum_mem_neg_distrib f (finite_normFiber K n)
-
-/-- Regrouping commutes with pointwise subtraction. -/
-@[simp]
-theorem normCoeff_sub (f g : IdealArithmeticFunction K) :
-    normCoeff K (f - g) = normCoeff K f - normCoeff K g := by
-  rw [sub_eq_add_neg, normCoeff_add, normCoeff_neg, sub_eq_add_neg]
-
-/-- Regrouping commutes with complex scalar multiplication. -/
-@[simp]
-theorem normCoeff_smul (c : ℂ) (f : IdealArithmeticFunction K) :
-    normCoeff K (c • f) = c • normCoeff K f := by
-  ext n
-  simp only [normCoeff_apply, Pi.smul_apply, ArithmeticFunction.smul_map]
-  exact (DistribSMul.toAddMonoidHom ℂ c).map_finsum_mem f (finite_normFiber K n) |>.symm
-
 /-- Regrouping commutes with coefficientwise complex conjugation. -/
 @[simp]
-theorem normCoeff_conj_apply (f : IdealArithmeticFunction K) (n : ℕ) :
+theorem normCoeff_star_apply (f : IdealArithmeticFunction K) (n : ℕ) :
     normCoeff K (fun I ↦ (starRingEnd ℂ) (f I)) n = star (normCoeff K f n) := by
   simp only [normCoeff_apply]
   exact ((starAddEquiv : ℂ ≃+ ℂ).map_finsum_mem f (finite_normFiber K n)).symm

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/NormCoeff.lean
@@ -67,7 +67,7 @@ theorem normCoeff_apply (f : IdealArithmeticFunction K) (n : ℕ) :
   (rfl)
 
 /-- The summand defining a norm coefficient has finite support. -/
-theorem normCoeff_summand_hasFiniteSupport (f : IdealArithmeticFunction K) (n : ℕ) :
+theorem hasFiniteSupport_normCoeff_summand (f : IdealArithmeticFunction K) (n : ℕ) :
     (Set.indicator
       {I : (Ideal (𝓞 K))⁰ | Ideal.absNorm (I : Ideal (𝓞 K)) = n} f).HasFiniteSupport :=
   (finite_normFiber K n).subset Set.support_indicator_subset
@@ -85,7 +85,7 @@ theorem normCoeff_one (f : IdealArithmeticFunction K) : normCoeff K f 1 = f 1 :=
 
 /-- Regrouping the zero ideal arithmetic function gives the zero arithmetic function. -/
 @[simp]
-theorem normCoeff_zero_fun : normCoeff K (0 : IdealArithmeticFunction K) = 0 := by
+theorem normCoeff_zero : normCoeff K (0 : IdealArithmeticFunction K) = 0 := by
   ext n
   simp [normCoeff_apply]
 
@@ -120,6 +120,7 @@ theorem normCoeff_smul (c : ℂ) (f : IdealArithmeticFunction K) :
   exact (DistribSMul.toAddMonoidHom ℂ c).map_finsum_mem f (finite_normFiber K n) |>.symm
 
 /-- Regrouping commutes with coefficientwise complex conjugation. -/
+@[simp]
 theorem normCoeff_conj_apply (f : IdealArithmeticFunction K) (n : ℕ) :
     normCoeff K (fun I ↦ star (f I)) n = star (normCoeff K f n) := by
   simp only [normCoeff_apply]


### PR DESCRIPTION
This PR defines `TauCeti.normCoeff`, the Layer 1.1 coefficient-by-norm map, by summing an `IdealArithmeticFunction` over the finite fibre of `Ideal.absNorm`. It advances the exact target `TauCetiRoadmap/ArithmeticDirichletSeries/README.md`, Layer 1.1, “Finite norm fibres,” in the Layer 1 milestone “norm fibres and Mathlib `LSeries`.” The implementation uses Mathlib's `Ideal.finite_setOfPred_absNorm_eq`, `ArithmeticFunction`, and finite-sum APIs directly; no Mathlib code is vendored.

The new module proves the characteristic fibre-sum formula and finite-support fact, records the value at `1`, bundles the construction as a complex-linear map, and proves compatibility with coefficientwise complex conjugation. The Layer 1.3 trivial-weight specialization is deliberately deferred until `regroupByNorm` and the Layer 0 trivial-weight API have landed.

This is the most effective distinct next step because Layer 0.1 is merged, the remaining Layer 0 weight-carrier work is already covered by open PRs, and `normCoeff` depends only on the merged general carrier while supplying the coefficient object consumed immediately by regrouping and convolution transport. After this PR, Layer 1.1 still needs compatibility with the general and imaginary norm twists and field equivalences once the corresponding Layer 0 weight and functoriality APIs land; Layer 1.2 then proves `regroupByNorm`.

The organization and finite-fibre construction follow Neukirch, *Algebraic Number Theory*, Chapter VII, and Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters II–III, as also credited in the module documentation.

Roadmap: ArithmeticDirichletSeries

<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"normcoeff"}-->

🤖 Prepared with Codex
