### PR TITLE
feat: decompose subgroup calculations by primary parts

### DIFF
--- a/TauCeti/Algebra/Group/PrimaryDecomposition.lean
+++ b/TauCeti/Algebra/Group/PrimaryDecomposition.lean
@@ -13,7 +13,7 @@ public import Mathlib.GroupTheory.Torsion
 
 This file packages the canonical decomposition of a finite abelian group as the product of its
 prime-primary components. The equivalence sends a tuple of primary elements to their sum in the
-ambient group.
+ambient group. It also defines the part of an additive subgroup lying in one primary component.
 
 The proof follows the cardinality argument used by Mathlib's `Sylow.directProductOfNormal`:
 primary components for distinct primes have coprime cardinalities, and the product of those
@@ -23,6 +23,7 @@ and uses Mathlib's canonical `AddCommGroup.primaryComponent` subgroups.
 
 ## Main results
 
+* `AddSubgroup.primaryPart`: the part of a subgroup in one primary component.
 * `TauCeti.AddCommGroup.primaryDecomposition`: a finite abelian group is additively equivalent to
   the product of its prime-primary components.
 * `TauCeti.AddCommGroup.primaryDecomposition_apply`: the equivalence is the sum of the component
@@ -37,6 +38,23 @@ This is the group-theoretic input to the primary-decomposition part of Layer 3 o
 -/
 
 public section
+
+namespace AddSubgroup
+
+variable {G : Type*} [AddCommGroup G]
+
+/-- The `p`-primary part of `H`, regarded as a subgroup of the ambient `p`-primary component. -/
+def primaryPart (H : AddSubgroup G) (p : ℕ) :
+    AddSubgroup (AddCommGroup.primaryComponent G p) :=
+  H.comap (AddCommGroup.primaryComponent G p).subtype
+
+@[simp]
+theorem mem_primaryPart_iff (H : AddSubgroup G) (p : ℕ)
+    (x : AddCommGroup.primaryComponent G p) :
+    x ∈ primaryPart H p ↔ (x : G) ∈ H :=
+  Iff.rfl
+
+end AddSubgroup
 
 namespace TauCeti
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Primary.Decomposition
+
+/-!
+# Subgroups and primary decomposition of finite modules
+
+This file proves that the subgroup calculations used with finite bilinear and quadratic modules
+can be performed one prime at a time.  The `p`-primary part of a subgroup is its intersection with
+the ambient `p`-primary component, regarded as a subgroup of that component.  Bilinear and
+quadratic isotropy are equivalent to isotropy of all these primary parts.
+
+Orthogonal complementation is componentwise as well: inside the restricted `p`-primary module, the
+orthogonal complement of the `p`-primary part of `H` is the `p`-primary part of the orthogonal
+complement of `H`.  The reverse inclusion uses the primary decomposition of `H`; components at
+primes different from `p` are automatically orthogonal.
+
+## Main results
+
+* `TauCeti.FiniteBilinearModule.primaryPart`: the part of a subgroup in one primary component.
+* `TauCeti.FiniteBilinearModule.isIsotropic_iff_primaryPart`: bilinear isotropy can be checked on
+  every primary part.
+* `TauCeti.FiniteQuadraticModule.isIsotropic_iff_primaryPart`: quadratic isotropy can be checked on
+  every primary part.
+* `TauCeti.FiniteBilinearModule.primaryPart_orthogonalComplement`: orthogonal complementation
+  commutes with passage to a primary component.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+
+This completes the componentwise-isotropy and orthogonal-complement part of Layer 3 of
+`TauCetiRoadmap/IntegralLattices/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace FiniteBilinearModule
+
+variable (A : FiniteBilinearModule)
+
+/-- The `p`-primary part of `H`, regarded as a subgroup of the ambient `p`-primary component. -/
+def primaryPart (H : AddSubgroup A) (p : ℕ) :
+    AddSubgroup (AddCommGroup.primaryComponent A p) :=
+  H.comap (AddCommGroup.primaryComponent A p).subtype
+
+@[simp]
+theorem mem_primaryPart_iff (H : AddSubgroup A) (p : ℕ)
+    (x : AddCommGroup.primaryComponent A p) :
+    x ∈ A.primaryPart H p ↔ (x : A) ∈ H :=
+  Iff.rfl
+
+private theorem coe_mem_primaryComponent_of_mem_primaryComponent
+    (H : AddSubgroup A) (p : ℕ) (x : AddCommGroup.primaryComponent H p) :
+    ((x : H) : A) ∈ AddCommGroup.primaryComponent A p := by
+  obtain ⟨k, hk⟩ := AddCommGroup.mem_primaryComponent.mp x.2
+  exact AddCommGroup.mem_primaryComponent.mpr ⟨k, congrArg Subtype.val hk⟩
+
+private theorem coe_primaryDecomposition_sum (H : AddSubgroup A) (x : H) :
+    (x : A) = ∑ p : (Nat.card H).primeFactors,
+      (((AddCommGroup.primaryDecomposition H).symm x p : H) : A) := by
+  have h := AddCommGroup.primaryDecomposition_apply H
+    ((AddCommGroup.primaryDecomposition H).symm x)
+  rw [AddEquiv.apply_symm_apply] at h
+  simpa only [map_sum, AddSubgroup.subtype_apply] using congrArg H.subtype h
+
+/-- A subgroup of a finite bilinear module is isotropic if and only if its part in every prime
+primary component is isotropic for the restricted pairing. -/
+theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
+    A.IsIsotropic H ↔
+      ∀ p : ℕ, p.Prime →
+        (A.restrict (AddCommGroup.primaryComponent A p)).IsIsotropic (A.primaryPart H p) := by
+  constructor
+  · intro hH p _
+    rw [(A.restrict (AddCommGroup.primaryComponent A p)).isIsotropic_def]
+    rw [A.isIsotropic_def] at hH
+    intro x hx y hy
+    exact hH x.1 hx y.1 hy
+  · intro hprimary
+    rw [A.isIsotropic_def]
+    intro x hx y hy
+    let xH : H := ⟨x, hx⟩
+    let yH : H := ⟨y, hy⟩
+    let xd := (AddCommGroup.primaryDecomposition H).symm xH
+    let yd := (AddCommGroup.primaryDecomposition H).symm yH
+    calc
+      A.pairing x y =
+          A.pairing (∑ p, ((xd p : H) : A)) (∑ p, ((yd p : H) : A)) := by
+        rw [← A.coe_primaryDecomposition_sum H xH, ← A.coe_primaryDecomposition_sum H yH]
+      _ = ∑ p, A.pairing ((xd p : H) : A) ((yd p : H) : A) := by
+        apply A.pairing_sum_eq_sum_pairing_of_mem_primaryComponent Finset.univ Subtype.val
+        · exact fun p _ ↦ Nat.prime_of_mem_primeFactors p.2
+        · exact fun p _ q _ hpq ↦ by simpa using hpq
+        · exact fun p _ ↦ A.coe_mem_primaryComponent_of_mem_primaryComponent H p (xd p)
+        · exact fun p _ ↦ A.coe_mem_primaryComponent_of_mem_primaryComponent H p (yd p)
+      _ = 0 := by
+        apply Finset.sum_eq_zero
+        intro p _
+        let xp : AddCommGroup.primaryComponent A p.1 :=
+          ⟨((xd p : H) : A), A.coe_mem_primaryComponent_of_mem_primaryComponent H p (xd p)⟩
+        let yp : AddCommGroup.primaryComponent A p.1 :=
+          ⟨((yd p : H) : A), A.coe_mem_primaryComponent_of_mem_primaryComponent H p (yd p)⟩
+        exact (A.restrict (AddCommGroup.primaryComponent A p.1)).isIsotropic_def.mp
+          (hprimary p.1 (Nat.prime_of_mem_primeFactors p.2))
+          xp (xd p).1.2 yp (yd p).1.2
+
+/-- Orthogonal complementation commutes with passage to a prime-primary component. -/
+theorem primaryPart_orthogonalComplement (H : AddSubgroup A) {p : ℕ} (hp : p.Prime) :
+    A.primaryPart (A.orthogonalComplement H) p =
+      (A.restrict (AddCommGroup.primaryComponent A p)).orthogonalComplement
+        (A.primaryPart H p) := by
+  ext x
+  rw [A.mem_primaryPart_iff]
+  constructor
+  · intro hx
+    rw [(A.restrict (AddCommGroup.primaryComponent A p)).mem_orthogonalComplement_iff]
+    intro y hy
+    exact A.mem_orthogonalComplement_iff H x.1 |>.mp hx y.1 hy
+  · intro hx
+    rw [A.mem_orthogonalComplement_iff]
+    intro y hy
+    let yH : H := ⟨y, hy⟩
+    let yd := (AddCommGroup.primaryDecomposition H).symm yH
+    have hydecomp : y = ∑ q, ((yd q : H) : A) := by
+      simpa only [yH, yd] using A.coe_primaryDecomposition_sum H yH
+    rw [hydecomp, map_sum]
+    apply Finset.sum_eq_zero
+    intro q _
+    have hq : q.1.Prime := Nat.prime_of_mem_primeFactors q.2
+    have hyq : ((yd q : H) : A) ∈ AddCommGroup.primaryComponent A q.1 :=
+      A.coe_mem_primaryComponent_of_mem_primaryComponent H q (yd q)
+    by_cases hqp : q.1 = p
+    · let yq : AddCommGroup.primaryComponent A p :=
+        ⟨((yd q : H) : A), hqp ▸ hyq⟩
+      have hyqH : yq ∈ A.primaryPart H p := (yd q).1.2
+      exact (A.restrict (AddCommGroup.primaryComponent A p)).mem_orthogonalComplement_iff
+        (A.primaryPart H p) x |>.mp hx yq hyqH
+    · exact A.pairing_eq_zero_of_mem_primaryComponent hp hq (Ne.symm hqp) x.2 hyq
+
+end FiniteBilinearModule
+
+namespace FiniteQuadraticModule
+
+variable (A : FiniteQuadraticModule)
+
+/-- A subgroup of a finite quadratic module is isotropic if and only if its part in every prime
+primary component is isotropic for the restricted quadratic map. -/
+theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
+    A.IsIsotropic H ↔
+      ∀ p : ℕ, p.Prime →
+        (A.restrict (AddCommGroup.primaryComponent A p)).IsIsotropic
+          (A.toFiniteBilinearModule.primaryPart H p) := by
+  constructor
+  · intro hH p _
+    apply (A.restrict (AddCommGroup.primaryComponent A p)).isIsotropic_def.mpr
+    rw [A.isIsotropic_def] at hH
+    intro x hx
+    exact hH x.1 hx
+  · intro hprimary
+    rw [A.isIsotropic_def]
+    intro x hx
+    let xH : H := ⟨x, hx⟩
+    let xd := (AddCommGroup.primaryDecomposition H).symm xH
+    calc
+      A.quadratic x = A.quadratic (∑ p, ((xd p : H) : A)) := by
+        rw [← A.toFiniteBilinearModule.coe_primaryDecomposition_sum H xH]
+      _ = ∑ p, A.quadratic ((xd p : H) : A) := by
+        apply A.quadratic_sum_of_mem_primaryComponent Finset.univ Subtype.val
+        · exact fun p _ ↦ Nat.prime_of_mem_primeFactors p.2
+        · exact fun p _ q _ hpq ↦ by simpa using hpq
+        · exact fun p _ ↦
+            A.toFiniteBilinearModule.coe_mem_primaryComponent_of_mem_primaryComponent H p (xd p)
+      _ = 0 := by
+        apply Finset.sum_eq_zero
+        intro p _
+        let xp : AddCommGroup.primaryComponent A p.1 :=
+          ⟨((xd p : H) : A),
+            A.toFiniteBilinearModule.coe_mem_primaryComponent_of_mem_primaryComponent H p (xd p)⟩
+        exact (A.restrict (AddCommGroup.primaryComponent A p.1)).isIsotropic_def.mp
+          (hprimary p.1 (Nat.prime_of_mem_primeFactors p.2)) xp (xd p).1.2
+
+end FiniteQuadraticModule
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
@@ -22,7 +22,7 @@ primes different from `p` are automatically orthogonal.
 
 ## Main results
 
-* `TauCeti.FiniteBilinearModule.primaryPart`: the part of a subgroup in one primary component.
+* `TauCeti.AddSubgroup.primaryPart`: the part of a subgroup in one primary component.
 * `TauCeti.FiniteBilinearModule.isIsotropic_iff_primaryPart`: bilinear isotropy can be checked on
   every primary part.
 * `TauCeti.FiniteQuadraticModule.isIsotropic_iff_primaryPart`: quadratic isotropy can be checked on
@@ -43,20 +43,26 @@ public section
 
 namespace TauCeti
 
+namespace AddSubgroup
+
+variable {G : Type*} [AddCommGroup G]
+
+/-- The `p`-primary part of `H`, regarded as a subgroup of the ambient `p`-primary component. -/
+def primaryPart (H : AddSubgroup G) (p : ℕ) :
+    AddSubgroup (AddCommGroup.primaryComponent G p) :=
+  H.comap (AddCommGroup.primaryComponent G p).subtype
+
+@[simp]
+theorem mem_primaryPart_iff (H : AddSubgroup G) (p : ℕ)
+    (x : AddCommGroup.primaryComponent G p) :
+    x ∈ primaryPart H p ↔ (x : G) ∈ H :=
+  Iff.rfl
+
+end AddSubgroup
+
 namespace FiniteBilinearModule
 
 variable (A : FiniteBilinearModule)
-
-/-- The `p`-primary part of `H`, regarded as a subgroup of the ambient `p`-primary component. -/
-def primaryPart (H : AddSubgroup A) (p : ℕ) :
-    AddSubgroup (AddCommGroup.primaryComponent A p) :=
-  H.comap (AddCommGroup.primaryComponent A p).subtype
-
-@[simp]
-theorem mem_primaryPart_iff (H : AddSubgroup A) (p : ℕ)
-    (x : AddCommGroup.primaryComponent A p) :
-    x ∈ A.primaryPart H p ↔ (x : A) ∈ H :=
-  Iff.rfl
 
 private theorem coe_mem_primaryComponent_of_mem_primaryComponent
     (H : AddSubgroup A) (p : ℕ) (x : AddCommGroup.primaryComponent H p) :
@@ -77,7 +83,8 @@ primary component is isotropic for the restricted pairing. -/
 theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
     A.IsIsotropic H ↔
       ∀ p : ℕ, p.Prime →
-        (A.restrict (AddCommGroup.primaryComponent A p)).IsIsotropic (A.primaryPart H p) := by
+        (A.restrict (AddCommGroup.primaryComponent A p)).IsIsotropic
+          (TauCeti.AddSubgroup.primaryPart H p) := by
   constructor
   · intro hH p _
     rw [(A.restrict (AddCommGroup.primaryComponent A p)).isIsotropic_def]
@@ -114,11 +121,11 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
 
 /-- Orthogonal complementation commutes with passage to a prime-primary component. -/
 theorem primaryPart_orthogonalComplement (H : AddSubgroup A) {p : ℕ} (hp : p.Prime) :
-    A.primaryPart (A.orthogonalComplement H) p =
+    TauCeti.AddSubgroup.primaryPart (A.orthogonalComplement H) p =
       (A.restrict (AddCommGroup.primaryComponent A p)).orthogonalComplement
-        (A.primaryPart H p) := by
+        (TauCeti.AddSubgroup.primaryPart H p) := by
   ext x
-  rw [A.mem_primaryPart_iff]
+  rw [TauCeti.AddSubgroup.mem_primaryPart_iff]
   constructor
   · intro hx
     rw [(A.restrict (AddCommGroup.primaryComponent A p)).mem_orthogonalComplement_iff]
@@ -140,9 +147,9 @@ theorem primaryPart_orthogonalComplement (H : AddSubgroup A) {p : ℕ} (hp : p.P
     by_cases hqp : q.1 = p
     · let yq : AddCommGroup.primaryComponent A p :=
         ⟨((yd q : H) : A), hqp ▸ hyq⟩
-      have hyqH : yq ∈ A.primaryPart H p := (yd q).1.2
+      have hyqH : yq ∈ TauCeti.AddSubgroup.primaryPart H p := (yd q).1.2
       exact (A.restrict (AddCommGroup.primaryComponent A p)).mem_orthogonalComplement_iff
-        (A.primaryPart H p) x |>.mp hx yq hyqH
+        (TauCeti.AddSubgroup.primaryPart H p) x |>.mp hx yq hyqH
     · exact A.pairing_eq_zero_of_mem_primaryComponent hp hq (Ne.symm hqp) x.2 hyq
 
 end FiniteBilinearModule
@@ -157,7 +164,7 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
     A.IsIsotropic H ↔
       ∀ p : ℕ, p.Prime →
         (A.restrict (AddCommGroup.primaryComponent A p)).IsIsotropic
-          (A.toFiniteBilinearModule.primaryPart H p) := by
+          (TauCeti.AddSubgroup.primaryPart H p) := by
   constructor
   · intro hH p _
     apply (A.restrict (AddCommGroup.primaryComponent A p)).isIsotropic_def.mpr

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
@@ -120,6 +120,7 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
           xp (xd p).1.2 yp (yd p).1.2
 
 /-- Orthogonal complementation commutes with passage to a prime-primary component. -/
+@[simp]
 theorem primaryPart_orthogonalComplement (H : AddSubgroup A) {p : ℕ} (hp : p.Prime) :
     AddSubgroup.primaryPart (A.orthogonalComplement H) p =
       (A.restrict (AddCommGroup.primaryComponent A p)).orthogonalComplement

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
@@ -22,7 +22,7 @@ primes different from `p` are automatically orthogonal.
 
 ## Main results
 
-* `TauCeti.AddSubgroup.primaryPart`: the part of a subgroup in one primary component.
+* `AddSubgroup.primaryPart`: the part of a subgroup in one primary component.
 * `TauCeti.FiniteBilinearModule.isIsotropic_iff_primaryPart`: bilinear isotropy can be checked on
   every primary part.
 * `TauCeti.FiniteQuadraticModule.isIsotropic_iff_primaryPart`: quadratic isotropy can be checked on
@@ -41,8 +41,6 @@ This completes the componentwise-isotropy and orthogonal-complement part of Laye
 
 public section
 
-namespace TauCeti
-
 namespace AddSubgroup
 
 variable {G : Type*} [AddCommGroup G]
@@ -59,6 +57,8 @@ theorem mem_primaryPart_iff (H : AddSubgroup G) (p : ℕ)
   Iff.rfl
 
 end AddSubgroup
+
+namespace TauCeti
 
 namespace FiniteBilinearModule
 
@@ -84,7 +84,7 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
     A.IsIsotropic H ↔
       ∀ p : ℕ, p.Prime →
         (A.restrict (AddCommGroup.primaryComponent A p)).IsIsotropic
-          (TauCeti.AddSubgroup.primaryPart H p) := by
+          (AddSubgroup.primaryPart H p) := by
   constructor
   · intro hH p _
     rw [(A.restrict (AddCommGroup.primaryComponent A p)).isIsotropic_def]
@@ -121,11 +121,11 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
 
 /-- Orthogonal complementation commutes with passage to a prime-primary component. -/
 theorem primaryPart_orthogonalComplement (H : AddSubgroup A) {p : ℕ} (hp : p.Prime) :
-    TauCeti.AddSubgroup.primaryPart (A.orthogonalComplement H) p =
+    AddSubgroup.primaryPart (A.orthogonalComplement H) p =
       (A.restrict (AddCommGroup.primaryComponent A p)).orthogonalComplement
-        (TauCeti.AddSubgroup.primaryPart H p) := by
+        (AddSubgroup.primaryPart H p) := by
   ext x
-  rw [TauCeti.AddSubgroup.mem_primaryPart_iff]
+  rw [AddSubgroup.mem_primaryPart_iff]
   constructor
   · intro hx
     rw [(A.restrict (AddCommGroup.primaryComponent A p)).mem_orthogonalComplement_iff]
@@ -147,9 +147,9 @@ theorem primaryPart_orthogonalComplement (H : AddSubgroup A) {p : ℕ} (hp : p.P
     by_cases hqp : q.1 = p
     · let yq : AddCommGroup.primaryComponent A p :=
         ⟨((yd q : H) : A), hqp ▸ hyq⟩
-      have hyqH : yq ∈ TauCeti.AddSubgroup.primaryPart H p := (yd q).1.2
+      have hyqH : yq ∈ AddSubgroup.primaryPart H p := (yd q).1.2
       exact (A.restrict (AddCommGroup.primaryComponent A p)).mem_orthogonalComplement_iff
-        (TauCeti.AddSubgroup.primaryPart H p) x |>.mp hx yq hyqH
+        (AddSubgroup.primaryPart H p) x |>.mp hx yq hyqH
     · exact A.pairing_eq_zero_of_mem_primaryComponent hp hq (Ne.symm hqp) x.2 hyq
 
 end FiniteBilinearModule
@@ -164,7 +164,7 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
     A.IsIsotropic H ↔
       ∀ p : ℕ, p.Prime →
         (A.restrict (AddCommGroup.primaryComponent A p)).IsIsotropic
-          (TauCeti.AddSubgroup.primaryPart H p) := by
+          (AddSubgroup.primaryPart H p) := by
   constructor
   · intro hH p _
     apply (A.restrict (AddCommGroup.primaryComponent A p)).isIsotropic_def.mpr

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean
@@ -41,23 +41,6 @@ This completes the componentwise-isotropy and orthogonal-complement part of Laye
 
 public section
 
-namespace AddSubgroup
-
-variable {G : Type*} [AddCommGroup G]
-
-/-- The `p`-primary part of `H`, regarded as a subgroup of the ambient `p`-primary component. -/
-def primaryPart (H : AddSubgroup G) (p : ℕ) :
-    AddSubgroup (AddCommGroup.primaryComponent G p) :=
-  H.comap (AddCommGroup.primaryComponent G p).subtype
-
-@[simp]
-theorem mem_primaryPart_iff (H : AddSubgroup G) (p : ℕ)
-    (x : AddCommGroup.primaryComponent G p) :
-    x ∈ primaryPart H p ↔ (x : G) ∈ H :=
-  Iff.rfl
-
-end AddSubgroup
-
 namespace TauCeti
 
 namespace FiniteBilinearModule
@@ -90,7 +73,8 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
     rw [(A.restrict (AddCommGroup.primaryComponent A p)).isIsotropic_def]
     rw [A.isIsotropic_def] at hH
     intro x hx y hy
-    exact hH x.1 hx y.1 hy
+    exact hH x.1 (AddSubgroup.mem_primaryPart_iff H p x |>.mp hx)
+      y.1 (AddSubgroup.mem_primaryPart_iff H p y |>.mp hy)
   · intro hprimary
     rw [A.isIsotropic_def]
     intro x hx y hy
@@ -117,7 +101,8 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
           ⟨((yd p : H) : A), A.coe_mem_primaryComponent_of_mem_primaryComponent H p (yd p)⟩
         exact (A.restrict (AddCommGroup.primaryComponent A p.1)).isIsotropic_def.mp
           (hprimary p.1 (Nat.prime_of_mem_primeFactors p.2))
-          xp (xd p).1.2 yp (yd p).1.2
+          xp (AddSubgroup.mem_primaryPart_iff H p.1 xp |>.mpr (xd p).1.2)
+          yp (AddSubgroup.mem_primaryPart_iff H p.1 yp |>.mpr (yd p).1.2)
 
 /-- Orthogonal complementation commutes with passage to a prime-primary component. -/
 @[simp]
@@ -131,7 +116,8 @@ theorem primaryPart_orthogonalComplement (H : AddSubgroup A) {p : ℕ} (hp : p.P
   · intro hx
     rw [(A.restrict (AddCommGroup.primaryComponent A p)).mem_orthogonalComplement_iff]
     intro y hy
-    exact A.mem_orthogonalComplement_iff H x.1 |>.mp hx y.1 hy
+    exact A.mem_orthogonalComplement_iff H x.1 |>.mp hx y.1
+      (AddSubgroup.mem_primaryPart_iff H p y |>.mp hy)
   · intro hx
     rw [A.mem_orthogonalComplement_iff]
     intro y hy
@@ -148,7 +134,8 @@ theorem primaryPart_orthogonalComplement (H : AddSubgroup A) {p : ℕ} (hp : p.P
     by_cases hqp : q.1 = p
     · let yq : AddCommGroup.primaryComponent A p :=
         ⟨((yd q : H) : A), hqp ▸ hyq⟩
-      have hyqH : yq ∈ AddSubgroup.primaryPart H p := (yd q).1.2
+      have hyqH : yq ∈ AddSubgroup.primaryPart H p :=
+        AddSubgroup.mem_primaryPart_iff H p yq |>.mpr (yd q).1.2
       exact (A.restrict (AddCommGroup.primaryComponent A p)).mem_orthogonalComplement_iff
         (AddSubgroup.primaryPart H p) x |>.mp hx yq hyqH
     · exact A.pairing_eq_zero_of_mem_primaryComponent hp hq (Ne.symm hqp) x.2 hyq
@@ -171,7 +158,7 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
     apply (A.restrict (AddCommGroup.primaryComponent A p)).isIsotropic_def.mpr
     rw [A.isIsotropic_def] at hH
     intro x hx
-    exact hH x.1 hx
+    exact hH x.1 (AddSubgroup.mem_primaryPart_iff H p x |>.mp hx)
   · intro hprimary
     rw [A.isIsotropic_def]
     intro x hx
@@ -193,7 +180,8 @@ theorem isIsotropic_iff_primaryPart (H : AddSubgroup A) :
           ⟨((xd p : H) : A),
             A.toFiniteBilinearModule.coe_mem_primaryComponent_of_mem_primaryComponent H p (xd p)⟩
         exact (A.restrict (AddCommGroup.primaryComponent A p.1)).isIsotropic_def.mp
-          (hprimary p.1 (Nat.prime_of_mem_primeFactors p.2)) xp (xd p).1.2
+          (hprimary p.1 (Nat.prime_of_mem_primeFactors p.2)) xp
+          (AddSubgroup.mem_primaryPart_iff H p.1 xp |>.mpr (xd p).1.2)
 
 end FiniteQuadraticModule
 


### PR DESCRIPTION
This PR completes the final componentwise calculation requested by the primary-decomposition target in `TauCetiRoadmap/IntegralLattices/README.md`, Layer 3, “finite bilinear and quadratic modules”: prove that bilinear and quadratic isotropy decompose componentwise and that orthogonal complements do too. It defines the `p`-primary part of a subgroup as its intersection with the ambient `p`-primary component, proves bilinear and quadratic isotropy equivalent to isotropy of every primary part, and proves that the primary part of `H^⊥` is exactly the orthogonal complement of the primary part of `H` inside the restricted module.

This is the most effective current step because the canonical primary-decomposition isometries and cross-primary orthogonality are already on `main`, while the PR that introduced those isometries explicitly left this componentwise subgroup API as the remaining work on the target. The proof consumes those results and decomposes each subgroup element through Mathlib's `AddCommGroup.primaryComponent` rather than introducing a parallel primary-component notion. After this PR, the Layer 3 primary-decomposition bullet has no remaining work; the critical path continues in Layer 4 with the lattice-side isometry `A_{L_H} ≅ H^⊥/H` and its quadratic refinement and naturality, while their abstract bilinear quotient is already in flight.

The new 192-line module `TauCeti/LinearAlgebra/FiniteBilinearModule/Primary/Subgroup.lean` supplies the shared subgroup definition, its membership lemma, the two isotropy equivalences, and the orthogonal-complement equality. The mathematical organization follows Nikulin, §1.1, and Ebeling, Chapter 1, as credited in the module documentation. No Mathlib infrastructure is vendored.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"primary-componentwise-isotropy-orthogonal-complements"}-->

🤖 Prepared with Codex
