### PR TITLE
feat(Topology): a product of nonarchimedean groups is nonarchimedean

### DIFF
--- a/TauCeti/Topology/Algebra/Nonarchimedean/Pi.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Pi.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+
+/-!
+# Products of nonarchimedean groups and rings
+
+An arbitrary product of nonarchimedean groups is nonarchimedean, and likewise for rings.
+Mathlib has only the binary case, `Prod.instNonarchimedeanGroup`; these are the `Pi` analogues,
+stated over an unrestricted index type.
+
+No finiteness hypothesis is needed. A neighbourhood of the identity in the product topology
+contains a box that constrains only finitely many coordinates, so shrinking those finitely many
+factors to open subgroups and leaving the rest unconstrained produces an open subgroup inside it.
+
+These live in the `Pi` namespace of the construction they describe rather than in a `TauCeti`
+one, following `TauCeti/Topology/Algebra/Nonarchimedean/Completion.lean`.
+
+## Main results
+
+* `Pi.instNonarchimedeanGroup`: a product of nonarchimedean groups is nonarchimedean, together
+  with its additive version `Pi.instNonarchimedeanAddGroup`.
+* `Pi.instNonarchimedeanRing`: a product of nonarchimedean rings is nonarchimedean.
+
+## Implementation notes
+
+Mathlib's `library_note «non-Archimedean non-instances»` explains why the *subgroup basis*
+lemmas cannot be instances: they would send typeclass search after an
+`@IsTopologicalAddGroup β ?m1 ?m2` whose topology and group structure are both unknown. That
+obstruction does not arise here, since every structure on `∀ i, G i` is fixed by the
+corresponding `Pi` instance, which is also why Mathlib states the binary case as an instance.
+
+## References
+
+* Mathlib's `Mathlib/Topology/Algebra/Nonarchimedean/Basic.lean`, whose
+  `Prod.instNonarchimedeanGroup` these generalise.
+-/
+
+public section
+
+open Filter
+
+/-- A product of nonarchimedean groups is nonarchimedean. -/
+@[to_additive /-- A product of nonarchimedean additive groups is nonarchimedean. -/]
+instance Pi.instNonarchimedeanGroup {ι : Type*} {G : ι → Type*} [∀ i, Group (G i)]
+    [∀ i, TopologicalSpace (G i)] [∀ i, NonarchimedeanGroup (G i)] :
+    NonarchimedeanGroup (∀ i, G i) where
+  is_nonarchimedean U hU := by
+    rw [nhds_pi] at hU
+    obtain ⟨I, hI, V, hV, hVU⟩ := Filter.mem_pi.mp hU
+    choose W hW using fun i ↦ NonarchimedeanGroup.is_nonarchimedean (V i) (hV i)
+    refine ⟨⟨Subgroup.pi I fun i ↦ (W i).toSubgroup, ?_⟩, ?_⟩
+    · exact isOpen_set_pi hI fun i _ ↦ (W i).isOpen
+    · exact (Set.pi_mono fun i _ ↦ hW i).trans hVU
+
+/-- A product of nonarchimedean rings is nonarchimedean. -/
+instance Pi.instNonarchimedeanRing {ι : Type*} {R : ι → Type*} [∀ i, Ring (R i)]
+    [∀ i, TopologicalSpace (R i)] [∀ i, NonarchimedeanRing (R i)] :
+    NonarchimedeanRing (∀ i, R i) where
+  is_nonarchimedean := NonarchimedeanAddGroup.is_nonarchimedean


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"nonarchimedean-pi-instances"}-->

An arbitrary product of nonarchimedean groups is nonarchimedean, and likewise for rings.
Mathlib has only the binary case (`Prod.instNonarchimedeanGroup`,
`Mathlib/Topology/Algebra/Nonarchimedean/Basic.lean:101`); these are the `Pi` analogues.

No finiteness hypothesis is needed. A neighbourhood of the identity in the product topology
contains a box constraining only finitely many coordinates, so shrinking those finitely many
factors to open subgroups and leaving the rest unconstrained gives an open subgroup inside it —
`Subgroup.pi` over the finite constrained set, open by `isOpen_set_pi`.

## Why this is needed

Layer 4.1 step 1 of `AdicSpaces/README.md` — Remark 8.29, `M ⊗_A A⟨X⟩ ≅ M⟨X⟩` for finitely
generated `M`. The surjectivity half is #3994. The remaining half needs a *strict* presentation
`Aⁿ ↠ M`, obtained from `TauCeti.Huber.IsTateRing.isOpenMap`
(`TauCeti/RingTheory/Huber/OpenMapping.lean:119`), whose source-side hypothesis bundle includes

```
[NonarchimedeanAddGroup M]
```

Instantiating that source at `Fin n → A` therefore requires `NonarchimedeanAddGroup (Fin n → A)`,
which is exactly what is missing: the linear-combination map `a ↦ ∑ aᵢ • gᵢ` cannot be shown open
without it.

## Absence

* No instance: `grep` over every line of Mathlib containing both `instance` and
  `Nonarchimedean` returns `Prod.instNonarchimedeanGroup` and the `Prod` ring instance, and no
  `Pi`/`∀`-indexed one.
* No theorem form either (the trap of concluding "absent" from a failed `infer_instance` alone):
  the same sweep restricted to `theorem`/`lemma` lines turns up only `nonarchimedean_of_emb`,
  the `SubmodulesBasis`/`RingSubgroupsBasis` topology constructions, and `AdicTopology`.
* Compiled probe: `example … : NonarchimedeanGroup (∀ i, G i) := by infer_instance` fails to
  synthesize before this PR, and `NonarchimedeanAddGroup (Fin n → A)` for a nonarchimedean ring
  `A` resolves after it.
* The nearest existing product statement is `Mathlib/Topology/MetricSpace/Ultra/Pi.lean`, which
  is about `IsUltrametricDist` on metric spaces. It reaches `NonarchimedeanGroup` only through
  `IsUltrametricDist.nonarchimedeanGroup` for *normed* groups, so it does not cover a general
  topological nonarchimedean group such as `Aⁿ` for a Huber ring `A`. (`NonarchimedeanGroup` is
  a `Prop` class, so the two routes cannot form a diamond.)

## On the library note

`Mathlib/Topology/Algebra/Nonarchimedean/Bases.lean:335` carries
`library_note «non-Archimedean non-instances»`, explaining why the subgroup-basis lemmas cannot
be instances: they would send typeclass search after an `@IsTopologicalAddGroup β ?m1 ?m2` whose
topology and group structure are both unknown. That obstruction does not apply here — every
structure on `∀ i, G i` is fixed by the corresponding `Pi` instance — which is also why Mathlib
states the binary case as an instance. This is recorded in the file's Implementation notes.

Provenance: no external source; Mathlib @ `4fae4090fac7` was swept for prior art as above.
