### PR TITLE
feat(EllipticCurve): two minimal models have equal v(Δ), so v(u) = 1

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MinimalModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MinimalModel.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Reduction
 
 /-!
-# Minimality from a unit `c₄`
+# Minimal models: a criterion, and the comparison of two of them
 
 Mathlib defines `WeierstrassCurve.IsMinimal` by a maximality property — the valuation of the
 discriminant is maximal among all integral models isomorphic to the given one — and derives
@@ -16,13 +16,24 @@ minimality only from that property or from a class that already extends it. Esta
 *given* equation therefore means quantifying over every change of variables, which is not something
 a caller can discharge by hand.
 
-This file supplies the cheapest sufficient condition: an integral Weierstrass equation whose `c₄`
-is a **unit** at the place is already minimal.
+This file supplies the cheapest sufficient condition — an integral Weierstrass equation whose `c₄`
+is a **unit** at the place is already minimal — and then the comparison any two minimal models
+admit: they have the same discriminant valuation, so a change of variables between them has a
+scaling factor of valuation `1`.
 
 ## Main results
 
 * `WeierstrassCurve.isMinimal_of_valuation_c₄_eq_one`: over the fraction field of a discrete
   valuation ring, an integral Weierstrass equation with `v (c₄) = 1` is minimal.
+* `WeierstrassCurve.valuation_Δ_eq_of_isMinimal_smul`: two minimal models related by a change of
+  variables have equal `v (Δ)`.
+* `WeierstrassCurve.valuation_u_eq_one_of_isMinimal_smul`: for an elliptic curve, the scaling
+  factor of such a change of variables satisfies `v (u) = 1`.
+
+The last is the shape a consumer needs. `v (u) = 1` over a discrete valuation ring says `u` is a
+unit of `R`, which is the hypothesis that lets a change of variables between two integral models be
+descended to `R` — and thence lets properties of the reduction, such as split multiplicative
+reduction, transfer between minimal models.
 
 ## Why this is the useful form
 
@@ -84,6 +95,55 @@ theorem isMinimal_of_valuation_c₄_eq_one (W : WeierstrassCurve K) [IsIntegral 
   rw [variableChange_c₄, map_mul, map_pow, hc₄, mul_one] at hint
   simpa [variableChange_Δ, map_mul, map_pow] using mul_le_of_le_one_left'
     (pow_le_one' ((pow_le_one_iff (by norm_num)).mp hint) 12)
+
+/-! ### Comparing two minimal models
+
+`IsMinimal` says the discriminant valuation is maximal among integral models. Two minimal models of
+the same curve therefore pin each other: each is at least as good as the other, so their
+valuations agree, and the change of variables between them can only scale `Δ` by a unit. -/
+
+/-- **No integral change of variables increases the discriminant valuation of a minimal model.**
+This is the maximality field of `IsMinimal`, with the `MaximalFor` comparison discharged. -/
+theorem valuation_Δ_aux_smul_le {W : WeierstrassCurve K} [hm : IsMinimal R W]
+    (D : VariableChange K) (hint : IsIntegral R (D • W)) :
+    valuation_Δ_aux R (D • W) ≤ valuation_Δ_aux R ((1 : VariableChange K) • W) :=
+  (le_total (valuation_Δ_aux R ((1 : VariableChange K) • W)) (valuation_Δ_aux R (D • W))).elim
+    (hm.val_Δ_maximal.2 hint) id
+
+/-- **Two minimal models related by a change of variables have the same discriminant valuation.**
+Antisymmetry: the change carries `W₁` to `W₂` and its inverse carries `W₂` back, and neither can
+increase the valuation. -/
+theorem valuation_Δ_eq_of_isMinimal_smul {W₁ W₂ : WeierstrassCurve K} [IsMinimal R W₁]
+    [IsMinimal R W₂] (D : VariableChange K) (hD : D • W₁ = W₂) :
+    valuation K (maximalIdeal R) W₂.Δ = valuation K (maximalIdeal R) W₁.Δ := by
+  rw [← valuation_Δ_aux_eq_of_isIntegral R W₂, ← valuation_Δ_aux_eq_of_isIntegral R W₁]
+  refine le_antisymm (Subtype.coe_le_coe.mpr ?_) (Subtype.coe_le_coe.mpr ?_)
+  · have hsub := valuation_Δ_aux_smul_le R D
+      (show IsIntegral R (D • W₁) by rw [hD]; infer_instance)
+    rwa [hD, one_smul] at hsub
+  · have hW₁eq : W₁ = D⁻¹ • W₂ := by rw [← hD, inv_smul_smul]
+    have hsub := valuation_Δ_aux_smul_le R D⁻¹
+      (show IsIntegral R (D⁻¹ • W₂) by rw [← hW₁eq]; infer_instance)
+    rwa [← hW₁eq, one_smul] at hsub
+
+/-- **The scaling factor of a change of variables between two minimal models of an elliptic curve
+has valuation `1`.** A change of variables scales `Δ` by `u⁻¹²`; since the two discriminant
+valuations agree and are nonzero, `v (u)¹² = 1`, and the value group is torsion-free. -/
+theorem valuation_u_eq_one_of_isMinimal_smul {W₁ W₂ : WeierstrassCurve K} [IsMinimal R W₁]
+    [IsMinimal R W₂] [W₁.IsElliptic] (D : VariableChange K) (hD : D • W₁ = W₂) :
+    valuation K (maximalIdeal R) ↑D.u = 1 := by
+  have hΔ0 : valuation K (maximalIdeal R) W₁.Δ ≠ 0 :=
+    (Valuation.ne_zero_iff _).mpr W₁.isUnit_Δ.ne_zero
+  have h12 : valuation K (maximalIdeal R) ↑D.u ^ 12 = 1 := by
+    have key : valuation K (maximalIdeal R) W₁.Δ
+        = (valuation K (maximalIdeal R) ↑D.u)⁻¹ ^ 12 * valuation K (maximalIdeal R) W₁.Δ := by
+      conv_lhs => rw [← valuation_Δ_eq_of_isMinimal_smul R D hD, ← hD, variableChange_Δ]
+      rw [map_mul, map_pow, Units.val_inv_eq_inv_val, map_inv₀]
+    have h1 : (valuation K (maximalIdeal R) ↑D.u)⁻¹ ^ 12 = 1 :=
+      mul_right_cancel₀ hΔ0 (key.symm.trans (one_mul _).symm)
+    rw [inv_pow] at h1
+    exact inv_eq_one.mp h1
+  exact (pow_eq_one_iff_of_nonneg zero_le (by norm_num)).mp h12
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MinimalModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MinimalModel.lean
@@ -61,10 +61,20 @@ definitions involved, and belongs upstream once its consumers are in place.
 
 Ported from FLT, https://github.com/ImperialCollegeLondon/FLT
 @ `bc2fe8ff7396469a16c2a6d51d6117f5825d93a0` (Apache-2.0), file
-`FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, declaration
-`WeierstrassCurve.isMinimal_of_valuation_c₄_eq_one`, by Kevin Buzzard. Statement and proof are
-taken unchanged; only the section's variable block is restated and the `open`s are narrowed to
-Mathlib's own `Minimal` section, since this file carries no other declarations.
+`FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, by Kevin Buzzard — the source commit
+is FLT PR #1088, "Quadratic twist to split multiplicative reduction". Four declarations are taken
+from it:
+
+* `isMinimal_of_valuation_c₄_eq_one`;
+* `valuation_Δ_aux_smul_le`;
+* `valuation_Δ_eq_of_isMinimal_smul`;
+* `valuation_u_eq_one_of_isMinimal_smul`.
+
+Statements and proofs are taken unchanged, with three deliberate divergences: the section's
+variable block is restated here; the `open`s are narrowed to those of Mathlib's own `Minimal`
+section; and `valuation_Δ_aux_smul_le` is **private** here where the source exports it, because it
+is phrased through the internal `valuation_Δ_aux` rather than the ordinary valuation and exists only
+to serve the comparison below.
 -/
 
 public section
@@ -103,8 +113,10 @@ the same curve therefore pin each other: each is at least as good as the other, 
 valuations agree, and the change of variables between them can only scale `Δ` by a unit. -/
 
 /-- **No integral change of variables increases the discriminant valuation of a minimal model.**
-This is the maximality field of `IsMinimal`, with the `MaximalFor` comparison discharged. -/
-theorem valuation_Δ_aux_smul_le {W : WeierstrassCurve K} [hm : IsMinimal R W]
+This is the maximality field of `IsMinimal`, with the `MaximalFor` comparison discharged. Kept
+private: it is stated through `valuation_Δ_aux`, Mathlib's internal `{v // v ≤ 1}` wrapper, whereas
+the results below speak of the ordinary valuation. -/
+private theorem valuation_Δ_aux_smul_le {W : WeierstrassCurve K} [hm : IsMinimal R W]
     (D : VariableChange K) (hint : IsIntegral R (D • W)) :
     valuation_Δ_aux R (D • W) ≤ valuation_Δ_aux R ((1 : VariableChange K) • W) :=
   (le_total (valuation_Δ_aux R ((1 : VariableChange K) • W)) (valuation_Δ_aux R (D • W))).elim
@@ -118,12 +130,10 @@ theorem valuation_Δ_eq_of_isMinimal_smul {W₁ W₂ : WeierstrassCurve K} [IsMi
     valuation K (maximalIdeal R) W₂.Δ = valuation K (maximalIdeal R) W₁.Δ := by
   rw [← valuation_Δ_aux_eq_of_isIntegral R W₂, ← valuation_Δ_aux_eq_of_isIntegral R W₁]
   refine le_antisymm (Subtype.coe_le_coe.mpr ?_) (Subtype.coe_le_coe.mpr ?_)
-  · have hsub := valuation_Δ_aux_smul_le R D
-      (show IsIntegral R (D • W₁) by rw [hD]; infer_instance)
+  · have hsub := valuation_Δ_aux_smul_le R D (by rw [hD]; infer_instance)
     rwa [hD, one_smul] at hsub
   · have hW₁eq : W₁ = D⁻¹ • W₂ := by rw [← hD, inv_smul_smul]
-    have hsub := valuation_Δ_aux_smul_le R D⁻¹
-      (show IsIntegral R (D⁻¹ • W₂) by rw [← hW₁eq]; infer_instance)
+    have hsub := valuation_Δ_aux_smul_le R D⁻¹ (by rw [← hW₁eq]; infer_instance)
     rwa [← hW₁eq, one_smul] at hsub
 
 /-- **The scaling factor of a change of variables between two minimal models of an elliptic curve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MinimalModel.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MinimalModel.lean
@@ -123,11 +123,14 @@ private theorem valuation_Δ_aux_smul_le {W : WeierstrassCurve K} [hm : IsMinima
     (hm.val_Δ_maximal.2 hint) id
 
 /-- **Two minimal models related by a change of variables have the same discriminant valuation.**
-Antisymmetry: the change carries `W₁` to `W₂` and its inverse carries `W₂` back, and neither can
-increase the valuation. -/
+So `v (Δ)` is an invariant of the curve at this place rather than of the chosen model: any two
+minimal models of the same curve agree on it, and a consumer may read it off whichever model it
+holds. -/
 theorem valuation_Δ_eq_of_isMinimal_smul {W₁ W₂ : WeierstrassCurve K} [IsMinimal R W₁]
     [IsMinimal R W₂] (D : VariableChange K) (hD : D • W₁ = W₂) :
     valuation K (maximalIdeal R) W₂.Δ = valuation K (maximalIdeal R) W₁.Δ := by
+  -- Antisymmetry: `D` carries `W₁` to `W₂` and `D⁻¹` carries `W₂` back, and by minimality neither
+  -- direction can increase the valuation.
   rw [← valuation_Δ_aux_eq_of_isIntegral R W₂, ← valuation_Δ_aux_eq_of_isIntegral R W₁]
   refine le_antisymm (Subtype.coe_le_coe.mpr ?_) (Subtype.coe_le_coe.mpr ?_)
   · have hsub := valuation_Δ_aux_smul_le R D (by rw [hD]; infer_instance)
@@ -137,11 +140,15 @@ theorem valuation_Δ_eq_of_isMinimal_smul {W₁ W₂ : WeierstrassCurve K} [IsMi
     rwa [← hW₁eq, one_smul] at hsub
 
 /-- **The scaling factor of a change of variables between two minimal models of an elliptic curve
-has valuation `1`.** A change of variables scales `Δ` by `u⁻¹²`; since the two discriminant
-valuations agree and are nonzero, `v (u)¹² = 1`, and the value group is torsion-free. -/
+has valuation `1`.** Over a discrete valuation ring that says `u` is a **unit**: it and its inverse
+are both integral, so such a change of variables is as integral as its coordinates allow. This is
+the hypothesis `VariableChange.exists_baseChange_eq_of_smul_eq` asks for, and hence the step by
+which a property of the reduction transfers between two minimal models of one curve. -/
 theorem valuation_u_eq_one_of_isMinimal_smul {W₁ W₂ : WeierstrassCurve K} [IsMinimal R W₁]
     [IsMinimal R W₂] [W₁.IsElliptic] (D : VariableChange K) (hD : D • W₁ = W₂) :
     valuation K (maximalIdeal R) ↑D.u = 1 := by
+  -- A change of variables scales `Δ` by `u⁻¹²`. The two discriminant valuations agree and are
+  -- nonzero, so `v (u)¹² = 1`, and the value group is torsion-free.
   have hΔ0 : valuation K (maximalIdeal R) W₁.Δ ≠ 0 :=
     (Valuation.ne_zero_iff _).mpr W₁.isUnit_Δ.ne_zero
   have h12 : valuation K (maximalIdeal R) ↑D.u ^ 12 = 1 := by


### PR DESCRIPTION
```lean
theorem WeierstrassCurve.valuation_Δ_eq_of_isMinimal_smul {W₁ W₂ : WeierstrassCurve K}
    [IsMinimal R W₁] [IsMinimal R W₂] (D : VariableChange K) (hD : D • W₁ = W₂) :
    valuation K (maximalIdeal R) W₂.Δ = valuation K (maximalIdeal R) W₁.Δ

theorem WeierstrassCurve.valuation_u_eq_one_of_isMinimal_smul {W₁ W₂ : WeierstrassCurve K}
    [IsMinimal R W₁] [IsMinimal R W₂] [W₁.IsElliptic] (D : VariableChange K) (hD : D • W₁ = W₂) :
    valuation K (maximalIdeal R) ↑D.u = 1
```

Two public theorems appended to `EllipticCurve/MinimalModel.lean`, no new file, no new definitions.
A third lemma, `valuation_Δ_aux_smul_le`, carries the maximality field of `IsMinimal` with its
`MaximalFor` comparison discharged; it is **private** — the source exports it, but it is phrased
through Mathlib's internal `valuation_Δ_aux` wrapper rather than the ordinary valuation, and its only
role is to serve the comparison. That divergence is recorded in the file's provenance.

## Why this is needed

Mathlib's `IsMinimal` is a maximality property, and nothing is derived *from* it about two minimal
models of the same curve. Silverman VII.1.3(b) — minimal models over a discrete valuation ring are
unique up to a change of variables with unit scaling factor — has no counterpart in Mathlib: of the
eight declarations there mentioning `IsMinimal` (the class, its `IsIntegral` instance, `reduction`,
the three reduction classes, the good-reduction criterion, the trichotomy) **none compares two
models**, and nothing in Mathlib or TauCeti asserts that a change of variables between minimal
models has `v (u) = 1`.

That last statement is the one downstream work needs. Over a discrete valuation ring `v (u) = 1`
says `u` is a unit of `R`, which is exactly the hypothesis of
`WeierstrassCurve.VariableChange.exists_baseChange_eq_of_smul_eq` (#3990) — so the pair lets a
change of variables between two minimal models be descended to `R`, and properties of the reduction
transfer along it. The roadmap target is the Layer-5 headline at
`TauCetiRoadmap/EllipticCurves/README.md:786`, "a curve with **nonsplit** multiplicative reduction
acquires **split** reduction after a separable quadratic twist"; the step that consumes both is
invariance of split multiplicative reduction under isomorphism of minimal models, which is the next
slice and now has both of its inputs.

## The proof

Antisymmetry, then torsion-freeness of the value group:

* `valuation_Δ_aux_smul_le` (private) — a minimal model's discriminant valuation is maximal among
  integral changes of variables, so no integral change raises it. Four lines: `le_total` and the
  maximality field.
* `valuation_Δ_eq_of_isMinimal_smul` — apply that to `D` and to `D⁻¹`. Each direction says the
  other model is no better, so the valuations agree.
* `valuation_u_eq_one_of_isMinimal_smul` — a change of variables scales `Δ` by `u⁻¹²`. With the two
  valuations equal and `Δ ≠ 0` for an elliptic curve, `v (u)⁻¹² = 1`, and `pow_eq_one_iff_of_nonneg`
  finishes. This is the only one of the three that needs `[W₁.IsElliptic]`, and it needs it only for
  `Δ ≠ 0`.

## Placement

These extend `EllipticCurve/MinimalModel.lean` rather than opening a file: that module already holds
the minimality criterion `isMinimal_of_valuation_c₄_eq_one` (#3953), already carries exactly the
variable block these need, and its only import — Mathlib's `EllipticCurve.Reduction` — supplies
every lemma used. The module docstring is retitled and its `## Main results` extended accordingly.

## Gates

`lake build` green for the module and for the full library (8642 jobs); `scripts/lint-style.sh`
green; `scripts/lint-env.sh` **PASS**, no new violations; longest line 99 characters; no `sorry`,
no `native_decide`, no `maxHeartbeats`; every declaration span under the 30-line guidance.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"reduction-minimal-model-comparison"}-->

Provenance: github.com/ImperialCollegeLondon/FLT @ bc2fe8ff7396469a16c2a6d51d6117f5825d93a0,
Apache-2.0, file `FLT/Mathlib/AlgebraicGeometry/EllipticCurve/Reduction.lean`, declarations
`valuation_Δ_aux_smul_le`, `valuation_Δ_eq_of_isMinimal_smul` and
`valuation_u_eq_one_of_isMinimal_smul`, by Kevin Buzzard — FLT PR #1088, "Quadratic twist to split
multiplicative reduction", the seed the roadmap names for this milestone. Statements and proofs are
taken unchanged; the `open`s are those of Mathlib's own `Minimal` section, already in place in the
destination file. Every read of the source was `git show bc2fe8ff:<path>`, never a working-tree
grep: that clone holds only 25 `.lean` files and is partial.
