### PR TITLE
refactor: cut GLn by an arbitrary constant form

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/ConstantForm/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/ConstantForm/Basic.lean
@@ -1,0 +1,461 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Scheme
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
+
+/-!
+# The subgroup scheme of `GLₙ` preserving a constant matrix
+
+For a commutative ring `R`, a natural number `n`, and a **constant** matrix
+`C : Matrix (Fin n) (Fin n) R`, the entries of the matrix relation
+
+```text
+X C Xᵀ - C
+```
+
+— `X` the localized generic matrix of `GL n`, `C` read in the coordinate Hopf algebra through
+the structure morphism — generate a Hopf ideal in the coordinate Hopf algebra of `GL n`. Its
+quotient represents the closed subgroup scheme of `GL n` preserving `C`. On every commutative
+`R`-algebra `A`, its points are the invertible matrices `M` with `M C Mᵀ = C`.
+
+Nothing is assumed of `C`: it is an arbitrary square matrix over the base, not required to be
+invertible, symmetric, alternating, or nondegenerate, and the construction includes `n = 0` and
+the zero ring. The classical families are the specializations at a constant form:
+`TauCeti.Orthogonal` takes `C = 1` and `TauCeti.Symplectic` takes `C = Jₘ`, each adding its own
+identification of the points with the corresponding matrix group. This file supplies everything
+those specializations share: the relation matrix, the Hopf ideal with its three closure
+conditions, the quotient, the group scheme with its closed immersion into `GLₙ`, and the
+ambient membership criterion `M C Mᵀ = C`; local finite type comes from the generic
+`GeneralLinear.locallyOfFiniteType_hopfIdealQuotientSpec` instance, which applies to the
+reducible `groupScheme` directly.
+
+The three Hopf-ideal closure conditions are proved by matrix algebra rather than coordinate by
+coordinate. Writing `f := X C Xᵀ - C` for the matrix of generators and mapping it entrywise
+through the relevant algebra morphisms — each of which fixes `C`, being an `R`-algebra
+morphism:
+
+* the counit sends `X` to the identity matrix, so it sends `f` to `1 C 1ᵀ - C = 0`;
+* the comultiplication sends `X` to `Y Z`, where `Y` and `Z` are the two tensor inclusions of
+  `X`, and
+
+  ```text
+  (Y Z) C (Y Z)ᵀ - C = Y (Z C Zᵀ - C) Yᵀ + (Y C Yᵀ - C),
+  ```
+
+  whose two summands are the right and left tensor inclusions of `f` framed by matrices, so
+  every entry lies in the right or left tensor ideal;
+* the antipode sends `X` to its inverse matrix, and
+
+  ```text
+  X⁻¹ C (X⁻¹)ᵀ - C = -(X⁻¹ (X C Xᵀ - C) (X⁻¹)ᵀ),
+  ```
+
+  so every entry of the antipode image is a combination of the generators.
+
+That each identity holds for an arbitrary constant `C` is what makes the classical examples
+specializations rather than separate constructions: no step inverts `C`, transposes it, or uses
+a relation between `C` and `Cᵀ`.
+
+## Main declarations
+
+* `TauCeti.ConstantForm.relationMatrix`: the matrix of defining relations `X C Xᵀ - C`.
+* `TauCeti.ConstantForm.definingHopfIdeal`: the Hopf ideal its entries generate.
+* `TauCeti.ConstantForm.coordinateHopfAlgebra` and `TauCeti.ConstantForm.coordinateMap`: the
+  quotient coordinate Hopf algebra and the quotient morphism onto it.
+* `TauCeti.ConstantForm.groupScheme` and `TauCeti.ConstantForm.inclusion`: the subgroup scheme
+  preserving `C` and its closed immersion into the general linear group scheme — the generic
+  `GeneralLinear.hopfIdealInclusion` at the defining Hopf ideal — with `groupScheme_def` and
+  `inclusion_def` exposing the quotient-spectrum presentations.
+* `TauCeti.ConstantForm.mem_definingPointsSubgroup_iff`: an ambient point is cut out exactly
+  when its matrix `M` satisfies `M C Mᵀ = C`.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §2.3, where the orthogonal and symplectic groups are
+  introduced as the subgroups of `GLₙ` cut out by the entries of a form relation.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes* (1979), Chapter 1, for such groups
+  as representable functors on commutative rings.
+* The Stacks Project, [Tag 022W](https://stacks.math.columbia.edu/tag/022W), for the ambient
+  general linear group scheme.
+
+The matrix form of the closure computations is standard, and the framing identities above are
+not adapted from either reference. The proofs themselves are those of the merged worked
+examples `TauCeti.Symplectic` (for `C = Jₘ`) and `TauCeti.Orthogonal` (for `C = 1`),
+generalized here to an arbitrary `C`: the declaration order and proof plan are theirs, and
+those two files now consume this one rather than repeating it. `TauCeti.Symplectic` recorded
+the generalization in its own module docstring — that the computations "apply verbatim to
+`X C Xᵀ - C` for any constant matrix `C`" — before it was carried out.
+-/
+
+public section
+
+open CategoryTheory Matrix WithConv
+
+namespace TauCeti.ConstantForm
+
+universe u w
+
+variable (R : Type u) [CommRing R] (n : ℕ)
+
+/-! ### The defining relation matrix -/
+
+variable (C : Matrix (Fin n) (Fin n) R)
+
+/-- **The matrix of defining relations** of the subgroup scheme preserving `C`:
+`X C Xᵀ - C` over the coordinate Hopf algebra of `GL n`. -/
+noncomputable def relationMatrix :
+    Matrix (Fin n) (Fin n) (GeneralLinear.coordinateHopfAlgebra R n) :=
+  GeneralLinear.genericMatrix R n *
+      C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n)) *
+      (GeneralLinear.genericMatrix R n)ᵀ -
+    C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n))
+
+/-- The relation matrix is the constant form transported by the generic matrix, minus the
+form: `X C Xᵀ - C`. -/
+theorem relationMatrix_def :
+    relationMatrix R n C =
+      GeneralLinear.genericMatrix R n *
+          C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n)) *
+          (GeneralLinear.genericMatrix R n)ᵀ -
+        C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n)) := by
+  rw [relationMatrix]
+
+/-- The set of defining relations: the entries of the relation matrix. -/
+def relationSet : Set (GeneralLinear.coordinateHopfAlgebra R n) :=
+  Set.range fun ij : Fin n × Fin n => relationMatrix R n C ij.1 ij.2
+
+/-- Every entry of the relation matrix is a defining relation. -/
+theorem relationMatrix_mem_relationSet (i j : Fin n) :
+    relationMatrix R n C i j ∈ relationSet R n C :=
+  ⟨(i, j), rfl⟩
+
+/-- An element is a defining relation exactly when it is an entry of the relation matrix. -/
+@[simp] theorem mem_relationSet_iff {x : GeneralLinear.coordinateHopfAlgebra R n} :
+    x ∈ relationSet R n C ↔ ∃ i j, relationMatrix R n C i j = x :=
+  Set.mem_range.trans Prod.exists
+
+/-- Mapping the relation matrix through an algebra morphism gives the relation of the images:
+the generic matrix maps entrywise, and the constant form maps to the constant form. -/
+@[simp] theorem relationMatrix_map {T : Type*} [CommRing T] [Algebra R T]
+    (phi : GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] T) :
+    (relationMatrix R n C).map phi =
+      (GeneralLinear.genericMatrix R n).map phi * C.map (algebraMap R T) *
+          ((GeneralLinear.genericMatrix R n).map phi)ᵀ -
+        C.map (algebraMap R T) := by
+  have hC : (C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n))).map phi =
+      C.map (algebraMap R T) := by
+    rw [Matrix.map_map]
+    exact congrArg _ (funext fun r => phi.commutes r)
+  rw [relationMatrix, Matrix.map_sub, Matrix.map_mul, Matrix.map_mul, hC, Matrix.transpose_map]
+  exact fun a b => map_sub phi a b
+
+/-- An entry of a framed relation matrix `P (X C Xᵀ - C) Q` lies in any ideal containing the
+entries of the middle factor. This is the only membership computation the closure proofs
+need. -/
+private theorem entry_mul_mul_mem {S : Type*} [CommRing S] (K : Ideal S) {μ : ℕ}
+    {M : Matrix (Fin μ) (Fin μ) S} (hM : ∀ k l, M k l ∈ K)
+    (P Q : Matrix (Fin μ) (Fin μ) S) (i j : Fin μ) : (P * M * Q) i j ∈ K := by
+  rw [Matrix.mul_apply]
+  refine Ideal.sum_mem _ fun k _ => ?_
+  rw [Matrix.mul_apply, Finset.sum_mul]
+  refine Ideal.sum_mem _ fun t _ => ?_
+  exact Ideal.mul_mem_right _ _ (Ideal.mul_mem_left _ _ (hM t k))
+
+/-! ### The three Hopf-ideal closure conditions -/
+
+/-- The counit vanishes on every defining relation. -/
+private theorem counit_relationMatrix (i j : Fin n) :
+    Coalgebra.counit (R := R) (relationMatrix R n C i j) = 0 := by
+  have h := congrFun (congrFun (relationMatrix_map R n C
+    (Bialgebra.counitAlgHom R (GeneralLinear.coordinateHopfAlgebra R n))) i) j
+  rw [Matrix.map_apply, Bialgebra.counitAlgHom_apply] at h
+  rw [h, GeneralLinear.map_counit_genericMatrix, Algebra.algebraMap_self, RingHom.coe_id,
+    Matrix.map_id, Matrix.transpose_one, Matrix.one_mul, Matrix.mul_one, sub_self,
+    Matrix.zero_apply]
+
+/-- The comultiplication of the relation matrix decomposes as a right-tensor-framed copy of the
+relations plus the left tensor inclusion of the relations. -/
+private theorem relationMatrix_map_comul :
+    (relationMatrix R n C).map
+        (Bialgebra.comulAlgHom R (GeneralLinear.coordinateHopfAlgebra R n)) =
+      (GeneralLinear.genericMatrix R n).map (Algebra.TensorProduct.includeLeft (R := R) (S := R)) *
+          (relationMatrix R n C).map (Algebra.TensorProduct.includeRight (R := R)) *
+          ((GeneralLinear.genericMatrix R n).map
+            (Algebra.TensorProduct.includeLeft (R := R) (S := R)))ᵀ +
+        (relationMatrix R n C).map
+          (Algebra.TensorProduct.includeLeft (R := R) (S := R)) := by
+  rw [relationMatrix_map R n C, relationMatrix_map R n C, relationMatrix_map R n C,
+    GeneralLinear.map_comul_genericMatrix, Matrix.transpose_mul]
+  conv_rhs => rw [Matrix.mul_sub, Matrix.sub_mul, sub_add_sub_cancel]
+  simp only [Matrix.mul_assoc]
+
+/-- The comultiplication of every defining relation lies in the sum of the left and right tensor
+ideals of the span of the relations. -/
+private theorem comul_relationMatrix_mem (i j : Fin n) :
+    Coalgebra.comul (R := R) (relationMatrix R n C i j) ∈
+      HopfIdeal.leftTensorIdeal (R := R)
+          (H := GeneralLinear.coordinateHopfAlgebra R n)
+          (Ideal.span (relationSet R n C)) ⊔
+        HopfIdeal.rightTensorIdeal (R := R)
+          (H := GeneralLinear.coordinateHopfAlgebra R n)
+          (Ideal.span (relationSet R n C)) := by
+  have h := congrFun (congrFun (relationMatrix_map_comul R n C) i) j
+  rw [Matrix.map_apply, Bialgebra.comulAlgHom_apply] at h
+  rw [h, Matrix.add_apply]
+  refine Ideal.add_mem _ (Ideal.mem_sup_right ?_) (Ideal.mem_sup_left ?_)
+  · refine entry_mul_mul_mem _ (fun k l => ?_) _ _ i j
+    rw [Matrix.map_apply]
+    exact HopfIdeal.includeRight_mem_rightTensorIdeal (R := R)
+      (H := GeneralLinear.coordinateHopfAlgebra R n)
+      (Ideal.subset_span (relationMatrix_mem_relationSet R n C k l))
+  · rw [Matrix.map_apply]
+    exact HopfIdeal.includeLeft_mem_leftTensorIdeal (R := R)
+      (H := GeneralLinear.coordinateHopfAlgebra R n)
+      (Ideal.subset_span (relationMatrix_mem_relationSet R n C i j))
+
+/-- The antipode image of the relation matrix is the negative of the relation matrix framed by
+the bundled inverse: `X⁻¹ C (X⁻¹)ᵀ - C = -(X⁻¹ (X C Xᵀ - C) (X⁻¹)ᵀ)`. -/
+private theorem relationMatrix_map_antipode :
+    (relationMatrix R n C).map
+        (HopfAlgebra.antipodeAlgHom (R := R)
+          (A := GeneralLinear.coordinateHopfAlgebra R n)) =
+      -((GeneralLinear.genericMatrix R n)⁻¹ * relationMatrix R n C *
+        ((GeneralLinear.genericMatrix R n)⁻¹)ᵀ) := by
+  have ht : (GeneralLinear.genericMatrix R n)ᵀ * ((GeneralLinear.genericMatrix R n)⁻¹)ᵀ = 1 := by
+    rw [← Matrix.transpose_mul,
+      Matrix.nonsing_inv_mul _ (GeneralLinear.isUnit_det_genericMatrix R n),
+      Matrix.transpose_one]
+  have hkey : (GeneralLinear.genericMatrix R n)⁻¹ * relationMatrix R n C *
+      ((GeneralLinear.genericMatrix R n)⁻¹)ᵀ =
+      C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n)) -
+        (GeneralLinear.genericMatrix R n)⁻¹ *
+          C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n)) *
+          ((GeneralLinear.genericMatrix R n)⁻¹)ᵀ := by
+    rw [relationMatrix, Matrix.mul_sub, Matrix.sub_mul]
+    congr 1
+    calc (GeneralLinear.genericMatrix R n)⁻¹ *
+          (GeneralLinear.genericMatrix R n *
+            C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n)) *
+            (GeneralLinear.genericMatrix R n)ᵀ) * ((GeneralLinear.genericMatrix R n)⁻¹)ᵀ
+        = (GeneralLinear.genericMatrix R n)⁻¹ * GeneralLinear.genericMatrix R n *
+            C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n)) *
+            ((GeneralLinear.genericMatrix R n)ᵀ * ((GeneralLinear.genericMatrix R n)⁻¹)ᵀ) := by
+          simp only [Matrix.mul_assoc]
+      _ = C.map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R n)) := by
+          rw [Matrix.nonsing_inv_mul _ (GeneralLinear.isUnit_det_genericMatrix R n), ht,
+            Matrix.one_mul, Matrix.mul_one]
+  rw [relationMatrix_map R n C, GeneralLinear.map_antipode_genericMatrix, hkey, neg_sub]
+
+/-- The antipode carries every defining relation into the span of the relations. -/
+private theorem antipode_relationMatrix_mem (i j : Fin n) :
+    HopfAlgebra.antipode R (relationMatrix R n C i j) ∈ Ideal.span (relationSet R n C) := by
+  have h := congrFun (congrFun (relationMatrix_map_antipode R n C) i) j
+  rw [Matrix.map_apply, HopfAlgebra.antipodeAlgHom_apply] at h
+  rw [h, Matrix.neg_apply]
+  exact neg_mem (entry_mul_mul_mem _
+    (fun k l => Ideal.subset_span (relationMatrix_mem_relationSet R n C k l)) _ _ i j)
+
+/-! ### The defining Hopf ideal and quotient -/
+
+/-- **The Hopf ideal preserving `C`**: the ideal of the coordinate Hopf algebra of `GL n`
+generated by the entries of `X C Xᵀ - C`, with the three closure conditions extended from the
+generators across the span. -/
+noncomputable def definingHopfIdeal :
+    HopfIdeal R (GeneralLinear.coordinateHopfAlgebra R n) :=
+  HopfIdeal.ofSpan (relationSet R n C)
+    (fun x hx => by
+      obtain ⟨ij, rfl⟩ := hx
+      exact comul_relationMatrix_mem R n C ij.1 ij.2)
+    (fun x hx => by
+      obtain ⟨ij, rfl⟩ := hx
+      exact counit_relationMatrix R n C ij.1 ij.2)
+    (fun x hx => by
+      obtain ⟨ij, rfl⟩ := hx
+      exact antipode_relationMatrix_mem R n C ij.1 ij.2)
+
+/-- The underlying ideal of the defining Hopf ideal is the span of the defining relations. -/
+@[simp]
+theorem definingHopfIdeal_toIdeal :
+    (definingHopfIdeal R n C).toIdeal = Ideal.span (relationSet R n C) := by
+  rw [definingHopfIdeal, HopfIdeal.ofSpan_toIdeal]
+
+/-- The coordinate Hopf algebra of the subgroup scheme of `GL n` preserving `C`. -/
+noncomputable abbrev coordinateHopfAlgebra : _root_.CommHopfAlgCat.{u} R :=
+  CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R n)
+    (definingHopfIdeal R n C)
+
+/-- The quotient coordinate morphism from `O(GL n)` to the coordinate Hopf algebra of the
+subgroup scheme preserving `C`. -/
+noncomputable def coordinateMap :
+    GeneralLinear.coordinateHopfAlgebra R n ⟶ coordinateHopfAlgebra R n C :=
+  CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra R n)
+    (definingHopfIdeal R n C)
+
+/-- The coordinate map is the canonical quotient morphism by the defining Hopf ideal. -/
+theorem coordinateMap_def :
+    coordinateMap R n C =
+      CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra R n)
+        (definingHopfIdeal R n C) := by
+  unfold coordinateMap
+  rfl
+
+/-- The coordinate morphism sends an ambient coordinate to its quotient class. -/
+-- Not `@[simp]`: its left-hand side subsumes that of the `@[simp]` elimination lemma
+-- `coordinateMap_relationMatrix`, and the raw quotient-class form is not the normal form —
+-- the named morphism is. All uses are explicit `rw`.
+theorem coordinateMap_apply (h : GeneralLinear.coordinateHopfAlgebra R n) :
+    (coordinateMap R n C).hom h =
+      Ideal.Quotient.mkₐ R (definingHopfIdeal R n C).toIdeal h := by
+  unfold coordinateMap
+  exact CommHopfAlgCat.mkQuotient_apply
+    (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n C) h
+
+/-- Every defining relation vanishes in the quotient coordinate Hopf algebra. -/
+@[simp]
+theorem coordinateMap_relationMatrix (i j : Fin n) :
+    (coordinateMap R n C).hom (relationMatrix R n C i j) = 0 := by
+  rw [coordinateMap_def]
+  exact (CommHopfAlgCat.mkQuotient_eq_zero_iff _ _ _).mpr
+    (definingHopfIdeal_toIdeal R n C ▸
+      Ideal.subset_span (relationMatrix_mem_relationSet R n C i j))
+
+/-! ### The group scheme and its closed immersion -/
+
+/-- The subgroup scheme of `GL n` preserving `C`. -/
+noncomputable abbrev groupScheme :=
+  CommHopfAlgCat.quotientSpec (GeneralLinear.coordinateHopfAlgebra R n)
+    (definingHopfIdeal R n C)
+
+/-- The subgroup scheme preserving `C` is the quotient spectrum of its coordinate Hopf
+algebra. -/
+theorem groupScheme_def :
+    groupScheme R n C =
+      CommHopfAlgCat.quotientSpec (GeneralLinear.coordinateHopfAlgebra R n)
+        (definingHopfIdeal R n C) :=
+  rfl
+
+/-- The closed-subgroup inclusion into the named general linear group scheme: the generic
+Hopf-ideal closed immersion `GeneralLinear.hopfIdealInclusion` at the defining Hopf ideal. -/
+noncomputable def inclusion : groupScheme R n C ⟶ GeneralLinear.groupScheme R n :=
+  GeneralLinear.hopfIdealInclusion R n (definingHopfIdeal R n C)
+
+/-- The inclusion is the generic Hopf-ideal closed immersion at the defining Hopf ideal. -/
+theorem inclusion_def :
+    inclusion R n C = GeneralLinear.hopfIdealInclusion R n (definingHopfIdeal R n C) := by
+  unfold inclusion
+  rfl
+
+/-- The inclusion into the named general linear group scheme is a closed immersion. -/
+instance isClosedImmersion_inclusion :
+    AlgebraicGeometry.IsClosedImmersion (inclusion R n C).hom.hom.left := by
+  rw [inclusion_def]
+  infer_instance
+
+/-- The quotient coordinate Hopf algebra, bundled with its finite-type property. -/
+noncomputable def finiteTypeCoordinateHopfAlgebra : FiniteTypeCommHopfAlgCat R :=
+  FiniteTypeCommHopfAlgCat.quotient
+    -- Not `GeneralLinear.finiteTypeCoordinateHopfAlgebra`: its body is not exposed, so its
+    -- underlying object matches the coordinate Hopf algebra only propositionally here, and the
+    -- defining Hopf ideal would not typecheck against it. The bundle is rebuilt with the
+    -- object definitionally in place.
+    (⟨GeneralLinear.coordinateHopfAlgebra R n,
+      inferInstanceAs (Algebra.FiniteType R (GeneralLinear.coordinateHopfAlgebra R n))⟩ :
+      FiniteTypeCommHopfAlgCat R)
+    (definingHopfIdeal R n C)
+
+/-- The finite-type package has the quotient coordinate Hopf algebra as its underlying
+object. -/
+@[simp]
+theorem finiteTypeCoordinateHopfAlgebra_obj :
+    (finiteTypeCoordinateHopfAlgebra R n C).obj = coordinateHopfAlgebra R n C := by
+  rw [finiteTypeCoordinateHopfAlgebra]
+
+
+/-! ### Algebra-valued points -/
+
+section Points
+
+variable {A : Type w} [CommRing A] [Algebra R A]
+
+/-- Mapping a point along the quotient coordinate morphism gives its ambient general-linear
+point. `CommHopfAlgCat.quotientPointsHom` is by definition the points map induced by the
+quotient morphism, so this is `coordinateMap_def` read on points; it is stated here to glue
+the two applied forms at a value algebra. -/
+-- Not `@[simp]`: `CommHopfAlgCat.mapPointsFunctor_app_apply` already rewrites the left-hand
+-- side to its composition form before this lemma could apply.
+theorem mapPointsFunctor_coordinateMap_app
+    (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R n C)
+      (CommAlgCat.of R A)) :
+    (CommHopfAlgCat.mapPointsFunctor (coordinateMap R n C)).app (CommAlgCat.of R A) f =
+      CommHopfAlgCat.quotientPointsHom
+        (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n C)
+        (CommAlgCat.of R A) f := by
+  apply WithConv.ext
+  rfl
+
+/-- Evaluating the relation matrix at a point gives the form relation of its matrix. -/
+private theorem ofConv_relationMatrix
+    (g : HopfAlgebra.points (R := R)
+      (H := GeneralLinear.coordinateHopfAlgebra R n) (CommAlgCat.of R A)) :
+    (relationMatrix R n C).map g.ofConv =
+      (GeneralLinear.pointToGeneralLinear n g : Matrix (Fin n) (Fin n) A) *
+          C.map (algebraMap R A) *
+          (GeneralLinear.pointToGeneralLinear n g : Matrix (Fin n) (Fin n) A)ᵀ -
+        C.map (algebraMap R A) := by
+  have hg : (GeneralLinear.genericMatrix R n).map g.ofConv =
+      (GeneralLinear.pointToGeneralLinear n g : Matrix (Fin n) (Fin n) A) := by
+    ext i j
+    rw [Matrix.map_apply, GeneralLinear.genericMatrix_apply]
+    exact (GeneralLinear.pointToGeneralLinear_apply n g i j).symm
+  rw [relationMatrix_map R n C g.ofConv, hg]
+
+/-- **The ambient membership criterion**: an ambient point belongs to the subgroup cut out by
+the defining Hopf ideal exactly when its matrix `M` satisfies `M C Mᵀ = C`.
+
+This is the criterion the classical specializations consume: `TauCeti.Orthogonal` restates it
+as membership in `Matrix.orthogonalGroup` (the `simp` normal form there), while
+`TauCeti.Symplectic` uses it internally to build its points identification. It is deliberately
+not a `simp` lemma — the orthogonal restatement is the normal form a user wants on that side,
+and the symplectic side rewrites with it explicitly. -/
+theorem mem_definingPointsSubgroup_iff
+    (g : HopfAlgebra.points (R := R)
+      (H := GeneralLinear.coordinateHopfAlgebra R n) (CommAlgCat.of R A)) :
+    g ∈ CommHopfAlgCat.quotientPointsSubgroup
+        (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n C)
+        (CommAlgCat.of R A) ↔
+      (GeneralLinear.pointsMulEquiv n g : Matrix (Fin n) (Fin n) A) * C.map (algebraMap R A) *
+          (GeneralLinear.pointsMulEquiv n g : Matrix (Fin n) (Fin n) A)ᵀ =
+        C.map (algebraMap R A) := by
+  rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff, GeneralLinear.pointsMulEquiv_apply]
+  constructor
+  · intro h
+    have hzero : (relationMatrix R n C).map g.ofConv = 0 := by
+      ext i j
+      rw [Matrix.map_apply, Matrix.zero_apply]
+      exact h _ (HopfIdeal.mem_toIdeal.mp
+        (definingHopfIdeal_toIdeal R n C ▸
+          Ideal.subset_span (relationMatrix_mem_relationSet R n C i j)))
+    rw [ofConv_relationMatrix R n C g] at hzero
+    exact sub_eq_zero.mp hzero
+  · intro h y hy
+    have hzero : (relationMatrix R n C).map g.ofConv = 0 := by
+      rw [ofConv_relationMatrix R n C g]
+      exact sub_eq_zero.mpr h
+    have hle : Ideal.span (relationSet R n C) ≤
+        RingHom.ker (g.ofConv :
+          GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] A) := by
+      rw [Ideal.span_le]
+      rintro _ ⟨ij, rfl⟩
+      have := congrFun (congrFun hzero ij.1) ij.2
+      rw [Matrix.map_apply, Matrix.zero_apply] at this
+      exact this
+    exact hle (definingHopfIdeal_toIdeal R n C ▸ HopfIdeal.mem_toIdeal.mpr hy)
+
+end Points
+
+end TauCeti.ConstantForm

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/HopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/HopfAlgebra.lean
@@ -623,6 +623,39 @@ theorem coordinateHopfAlgebra_antipode_X (i j : Fin n) :
       coordinateHopfAlgebraAlgEquiv R n ((localizedGenericMatrix R n)⁻¹ i j) := by
   rw [coordinateHopfAlgebra_antipode_apply, antipode_X]
 
+/-- The counit sends the bundled generic matrix to the identity matrix. -/
+@[simp]
+theorem map_counit_genericMatrix :
+    (genericMatrix R n).map (Bialgebra.counitAlgHom R (coordinateHopfAlgebra R n)) = 1 := by
+  ext i j
+  rw [Matrix.map_apply, genericMatrix_apply, Bialgebra.counitAlgHom_apply,
+    coordinateHopfAlgebra_counit_X, Matrix.one_apply]
+
+/-- The comultiplication sends the bundled generic matrix to the product of its two tensor
+inclusions: `Δ X = (X ⊗ 1)(1 ⊗ X)`. -/
+@[simp]
+theorem map_comul_genericMatrix :
+    (genericMatrix R n).map (Bialgebra.comulAlgHom R (coordinateHopfAlgebra R n)) =
+      (genericMatrix R n).map (Algebra.TensorProduct.includeLeft (R := R) (S := R)) *
+        (genericMatrix R n).map (Algebra.TensorProduct.includeRight (R := R)) := by
+  ext i j
+  rw [Matrix.map_apply, genericMatrix_apply, Bialgebra.comulAlgHom_apply,
+    coordinateHopfAlgebra_comul_X, Matrix.mul_apply]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  rw [Matrix.map_apply, Matrix.map_apply, genericMatrix_apply, genericMatrix_apply,
+    Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
+    Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_one]
+
+/-- The antipode sends the bundled generic matrix to its bundled inverse. -/
+@[simp]
+theorem map_antipode_genericMatrix :
+    (genericMatrix R n).map
+        (HopfAlgebra.antipodeAlgHom (R := R) (A := coordinateHopfAlgebra R n)) =
+      (genericMatrix R n)⁻¹ := by
+  ext i j
+  rw [Matrix.map_apply, genericMatrix_apply, HopfAlgebra.antipodeAlgHom_apply,
+    coordinateHopfAlgebra_antipode_X, genericMatrix_inv_apply]
+
 /-- Two algebra homomorphisms out of the bundled coordinate Hopf algebra of `GLₙ` are equal if
 they agree on the localized generic entries. This is the bundled counterpart of
 `algHom_ext_away`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Orthogonal/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Orthogonal/Basic.lean
@@ -6,25 +6,23 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.UnitaryGroup
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.FunctorOfPoints
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Scheme
+public import TauCeti.Algebra.AlgebraicGroup.ConstantForm.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Naturality
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
-import TauCeti.CategoryTheory.Comma.Over
 
 /-!
 # The orthogonal subgroup scheme of `GLₙ`
 
-For a commutative ring `R` and `n : ℕ`, the entries of the matrix relation
+For a commutative ring `R` and `n : ℕ`, the orthogonal subgroup scheme `Oₙ` of `GL n` is the
+subgroup scheme preserving the constant form `1`: the specialization of
+`TauCeti.ConstantForm` at `C = 1`, cut out of `GL n` by the entries of
 
 ```text
 X Xᵀ - 1
 ```
 
-— `X` the localized generic matrix of `GL n` — generate a Hopf ideal in the coordinate Hopf
-algebra of `GL n`. Its quotient represents the closed subgroup scheme `Oₙ` of orthogonal
-matrices. On every commutative `R`-algebra `A`, its group of points is Mathlib's existing
-group `Matrix.orthogonalGroup (Fin n) A` of matrices with `M * Mᵀ = 1`.
+for `X` the localized generic matrix. On every commutative `R`-algebra `A`, its group of points
+is Mathlib's existing group `Matrix.orthogonalGroup (Fin n) A` of matrices with `M * Mᵀ = 1`,
+and that identification is what this file adds to the general construction.
 
 This is the orthogonal group of the **standard symmetric bilinear form**, the scheme of the
 functor `A ↦ {M | M Mᵀ = 1}` over every commutative ring. It is the classical worked example in
@@ -36,30 +34,12 @@ roadmap, built at the same boundary as the symplectic example (`TauCeti.Symplect
 construction and points identification, with no smoothness or reductivity claim. The
 determinant-one cut `SOₙ` itself is built on top of this file in `TauCeti.SpecialOrthogonal`.
 
-The three Hopf-ideal closure conditions are proved by matrix algebra rather than coordinate by
-coordinate, specializing the computations of the symplectic example to the constant form `1`.
-Writing `f := X Xᵀ - 1` for the matrix of generators and mapping it entrywise through the
-relevant algebra morphisms:
-
-* the counit sends `X` to the identity matrix, so it sends `f` to `1 * 1ᵀ - 1 = 0`;
-* the comultiplication sends `X` to `Y Z`, where `Y` and `Z` are the two tensor inclusions of
-  `X`, and
-
-  ```text
-  (Y Z) (Y Z)ᵀ - 1 = Y (Z Zᵀ - 1) Yᵀ + (Y Yᵀ - 1),
-  ```
-
-  whose two summands are the right and left tensor inclusions of `f` framed by matrices, so
-  every entry lies in the right or left tensor ideal;
-* the antipode sends `X` to its inverse matrix, and
-
-  ```text
-  X⁻¹ (X⁻¹)ᵀ - 1 = -(X⁻¹ (X Xᵀ - 1) (X⁻¹)ᵀ),
-  ```
-
-  so every entry of the antipode image is a combination of the generators.
-
-The construction includes `n = 0` and the zero ring.
+The Hopf-ideal closure conditions, the quotient, the group scheme with its closed immersion
+into `GLₙ`, and the ambient membership criterion `M C Mᵀ = C` all come from
+`TauCeti.ConstantForm`, which proves them for an arbitrary constant matrix `C` (local finite
+type is the generic instance for Hopf-ideal quotients of the `GLₙ` coordinate algebra); the
+specializations below fix `C = 1` and the constant form becomes the identity matrix in every
+value algebra. The construction includes `n = 0` and the zero ring.
 
 ## Main declarations
 
@@ -81,10 +61,6 @@ The construction includes `n = 0` and the zero ring.
   orthogonal group as a representable functor on commutative rings.
 * The Stacks Project, [Tag 022W](https://stacks.math.columbia.edu/tag/022W), for the ambient
   general linear group scheme.
-
-The matrix form of the closure computations follows `TauCeti.Symplectic` (there for the
-alternating form `J`, here for the constant form `1`); the framing identities are recorded in
-the module docstring.
 -/
 
 public section
@@ -97,324 +73,35 @@ universe u w
 
 variable (R : Type u) [CommRing R] (n : ℕ)
 
-/-! ### The defining relation matrix -/
+/-! ### The orthogonal specialization of the constant-form construction -/
 
-/-- The localized generic matrix of `GL n`, read in the bundled coordinate Hopf algebra. -/
-noncomputable def genericMatrix :
+/-- **The matrix of defining relations** of the orthogonal subgroup scheme: `X Xᵀ - 1` over the
+coordinate Hopf algebra of `GL n`, the constant-form relation matrix at `C = 1`. -/
+noncomputable abbrev relationMatrix :
     Matrix (Fin n) (Fin n) (GeneralLinear.coordinateHopfAlgebra R n) :=
-  (GeneralLinear.localizedGenericMatrix R n).map
-    (GeneralLinear.coordinateHopfAlgebraAlgEquiv R n)
-
-/-- An entry of the bundled generic matrix is the bundled image of the corresponding polynomial
-generator. -/
-@[simp]
-theorem genericMatrix_apply (i j : Fin n) :
-    genericMatrix R n i j =
-      GeneralLinear.coordinateHopfAlgebraAlgEquiv R n
-        (GeneralLinear.coordinateRingMap R n (MvPolynomial.X (i, j))) := by
-  rw [genericMatrix, Matrix.map_apply, GeneralLinear.localizedGenericMatrix_apply]
-
-/-- The inverse of the localized generic matrix, read in the bundled coordinate Hopf algebra. -/
-private noncomputable def genericMatrixInv :
-    Matrix (Fin n) (Fin n) (GeneralLinear.coordinateHopfAlgebra R n) :=
-  ((GeneralLinear.localizedGenericMatrix R n)⁻¹).map
-    (GeneralLinear.coordinateHopfAlgebraAlgEquiv R n)
-
-/-- The bundled generic matrix and its bundled inverse multiply to the identity. -/
-private theorem genericMatrix_mul_genericMatrixInv :
-    genericMatrix R n * genericMatrixInv R n = 1 := by
-  rw [genericMatrix, genericMatrixInv, ← Matrix.map_mul,
-    Matrix.mul_nonsing_inv _ (GeneralLinear.isUnit_det_localizedGenericMatrix R n)]
-  exact Matrix.map_one _ (map_zero _) (map_one _)
-
-/-- The bundled inverse and the bundled generic matrix multiply to the identity. -/
-private theorem genericMatrixInv_mul_genericMatrix :
-    genericMatrixInv R n * genericMatrix R n = 1 := by
-  rw [genericMatrix, genericMatrixInv, ← Matrix.map_mul,
-    Matrix.nonsing_inv_mul _ (GeneralLinear.isUnit_det_localizedGenericMatrix R n)]
-  exact Matrix.map_one _ (map_zero _) (map_one _)
-
-/-- **The matrix of defining relations** of the orthogonal subgroup scheme:
-`X Xᵀ - 1` over the coordinate Hopf algebra of `GL n`. -/
-noncomputable def relationMatrix :
-    Matrix (Fin n) (Fin n) (GeneralLinear.coordinateHopfAlgebra R n) :=
-  genericMatrix R n * (genericMatrix R n)ᵀ - 1
+  ConstantForm.relationMatrix R n 1
 
 /-- The set of defining relations: the entries of the relation matrix. -/
-def relationSet : Set (GeneralLinear.coordinateHopfAlgebra R n) :=
-  Set.range fun ij : Fin n × Fin n => relationMatrix R n ij.1 ij.2
+abbrev relationSet : Set (GeneralLinear.coordinateHopfAlgebra R n) :=
+  ConstantForm.relationSet R n 1
 
-/-- Every entry of the relation matrix is a defining relation. -/
-theorem relationMatrix_mem_relationSet (i j : Fin n) :
-    relationMatrix R n i j ∈ relationSet R n :=
-  ⟨(i, j), rfl⟩
-
-/-- Mapping the relation matrix through an algebra morphism gives the relation of the images:
-the generic matrix maps entrywise, and the constant matrix `1` maps to `1`. -/
-private theorem relationMatrix_map {T : Type*} [CommRing T] [Algebra R T]
-    (phi : GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] T) :
-    (relationMatrix R n).map phi =
-      (genericMatrix R n).map phi * ((genericMatrix R n).map phi)ᵀ - 1 := by
-  rw [relationMatrix, Matrix.map_sub _ (fun a b => map_sub phi a b), Matrix.map_mul,
-    Matrix.transpose_map, Matrix.map_one _ (map_zero phi) (map_one phi)]
-
-/-- An entry of a framed relation matrix `P (X Xᵀ - 1) Q` lies in any ideal containing the
-entries of the middle factor. This is the only membership computation the closure proofs need. -/
-private theorem entry_mul_mul_mem {S : Type*} [CommRing S] (K : Ideal S) {μ : ℕ}
-    {M : Matrix (Fin μ) (Fin μ) S} (hM : ∀ k l, M k l ∈ K)
-    (P Q : Matrix (Fin μ) (Fin μ) S) (i j : Fin μ) : (P * M * Q) i j ∈ K := by
-  rw [Matrix.mul_apply]
-  refine Ideal.sum_mem _ fun k _ => ?_
-  rw [Matrix.mul_apply, Finset.sum_mul]
-  refine Ideal.sum_mem _ fun t _ => ?_
-  exact Ideal.mul_mem_right _ _ (Ideal.mul_mem_left _ _ (hM t k))
-
-/-! ### The three Hopf-ideal closure conditions -/
-
-/-- The counit sends the bundled generic matrix to the identity matrix. -/
-private theorem genericMatrix_map_counit :
-    (genericMatrix R n).map
-        (Bialgebra.counitAlgHom R (GeneralLinear.coordinateHopfAlgebra R n)) = 1 := by
-  ext i j
-  rw [Matrix.map_apply, genericMatrix_apply, Bialgebra.counitAlgHom_apply,
-    GeneralLinear.coordinateHopfAlgebra_counit_X, Matrix.one_apply]
-
-/-- The counit vanishes on every defining relation. -/
-private theorem counit_relationMatrix (i j : Fin n) :
-    Coalgebra.counit (R := R) (relationMatrix R n i j) = 0 := by
-  have h := congrFun (congrFun (relationMatrix_map R n
-    (Bialgebra.counitAlgHom R (GeneralLinear.coordinateHopfAlgebra R n))) i) j
-  rw [Matrix.map_apply, Bialgebra.counitAlgHom_apply] at h
-  rw [h, genericMatrix_map_counit, Matrix.transpose_one, Matrix.mul_one, sub_self,
-    Matrix.zero_apply]
-
-/-- The comultiplication sends the bundled generic matrix to the product of its two tensor
-inclusions: `Δ X = (X ⊗ 1)(1 ⊗ X)`. -/
-private theorem genericMatrix_map_comul :
-    (genericMatrix R n).map
-        (Bialgebra.comulAlgHom R (GeneralLinear.coordinateHopfAlgebra R n)) =
-      (genericMatrix R n).map
-          (Algebra.TensorProduct.includeLeft (R := R) (S := R)) *
-        (genericMatrix R n).map (Algebra.TensorProduct.includeRight (R := R)) := by
-  ext i j
-  rw [Matrix.map_apply, genericMatrix_apply, Bialgebra.comulAlgHom_apply,
-    GeneralLinear.coordinateHopfAlgebra_comul_X, Matrix.mul_apply]
-  refine Finset.sum_congr rfl fun k _ => ?_
-  rw [Matrix.map_apply, Matrix.map_apply, genericMatrix_apply, genericMatrix_apply,
-    Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
-    Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_one]
-
-/-- The comultiplication of the relation matrix decomposes as a right-tensor-framed copy of the
-relations plus the left tensor inclusion of the relations. -/
-private theorem relationMatrix_map_comul :
-    (relationMatrix R n).map
-        (Bialgebra.comulAlgHom R (GeneralLinear.coordinateHopfAlgebra R n)) =
-      (genericMatrix R n).map (Algebra.TensorProduct.includeLeft (R := R) (S := R)) *
-          (relationMatrix R n).map (Algebra.TensorProduct.includeRight (R := R)) *
-          ((genericMatrix R n).map
-            (Algebra.TensorProduct.includeLeft (R := R) (S := R)))ᵀ +
-        (relationMatrix R n).map
-          (Algebra.TensorProduct.includeLeft (R := R) (S := R)) := by
-  rw [relationMatrix_map R n, relationMatrix_map R n, relationMatrix_map R n,
-    genericMatrix_map_comul, Matrix.transpose_mul]
-  conv_rhs => rw [Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_one, sub_add_sub_cancel]
-  simp only [Matrix.mul_assoc]
-
-/-- The comultiplication of every defining relation lies in the sum of the left and right tensor
-ideals of the span of the relations. -/
-private theorem comul_relationMatrix_mem (i j : Fin n) :
-    Coalgebra.comul (R := R) (relationMatrix R n i j) ∈
-      HopfIdeal.leftTensorIdeal (R := R)
-          (H := GeneralLinear.coordinateHopfAlgebra R n)
-          (Ideal.span (relationSet R n)) ⊔
-        HopfIdeal.rightTensorIdeal (R := R)
-          (H := GeneralLinear.coordinateHopfAlgebra R n)
-          (Ideal.span (relationSet R n)) := by
-  have h := congrFun (congrFun (relationMatrix_map_comul R n) i) j
-  rw [Matrix.map_apply, Bialgebra.comulAlgHom_apply] at h
-  rw [h, Matrix.add_apply]
-  refine Ideal.add_mem _ (Ideal.mem_sup_right ?_) (Ideal.mem_sup_left ?_)
-  · refine entry_mul_mul_mem _ (fun k l => ?_) _ _ i j
-    rw [Matrix.map_apply]
-    exact HopfIdeal.includeRight_mem_rightTensorIdeal (R := R)
-      (H := GeneralLinear.coordinateHopfAlgebra R n)
-      (Ideal.subset_span (relationMatrix_mem_relationSet R n k l))
-  · rw [Matrix.map_apply]
-    exact HopfIdeal.includeLeft_mem_leftTensorIdeal (R := R)
-      (H := GeneralLinear.coordinateHopfAlgebra R n)
-      (Ideal.subset_span (relationMatrix_mem_relationSet R n i j))
-
-/-- The antipode sends the bundled generic matrix to its bundled inverse. -/
-private theorem genericMatrix_map_antipode :
-    (genericMatrix R n).map
-        (HopfAlgebra.antipodeAlgHom (R := R)
-          (A := GeneralLinear.coordinateHopfAlgebra R n)) =
-      genericMatrixInv R n := by
-  ext i j
-  rw [Matrix.map_apply, genericMatrix_apply, HopfAlgebra.antipodeAlgHom_apply,
-    GeneralLinear.coordinateHopfAlgebra_antipode_X, genericMatrixInv, Matrix.map_apply]
-
-/-- The antipode image of the relation matrix is the negative of the relation matrix framed by
-the bundled inverse: `X⁻¹ (X⁻¹)ᵀ - 1 = -(X⁻¹ (X Xᵀ - 1) (X⁻¹)ᵀ)`. -/
-private theorem relationMatrix_map_antipode :
-    (relationMatrix R n).map
-        (HopfAlgebra.antipodeAlgHom (R := R)
-          (A := GeneralLinear.coordinateHopfAlgebra R n)) =
-      -(genericMatrixInv R n * relationMatrix R n * (genericMatrixInv R n)ᵀ) := by
-  have ht : (genericMatrix R n)ᵀ * (genericMatrixInv R n)ᵀ = 1 := by
-    rw [← Matrix.transpose_mul, genericMatrixInv_mul_genericMatrix, Matrix.transpose_one]
-  have hkey : genericMatrixInv R n * relationMatrix R n * (genericMatrixInv R n)ᵀ =
-      1 - genericMatrixInv R n * (genericMatrixInv R n)ᵀ := by
-    rw [relationMatrix, Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_one]
-    congr 1
-    calc genericMatrixInv R n * (genericMatrix R n * (genericMatrix R n)ᵀ) *
-          (genericMatrixInv R n)ᵀ
-        = genericMatrixInv R n * genericMatrix R n *
-            ((genericMatrix R n)ᵀ * (genericMatrixInv R n)ᵀ) := by
-          simp only [Matrix.mul_assoc]
-      _ = 1 := by
-          rw [genericMatrixInv_mul_genericMatrix, ht, Matrix.mul_one]
-  rw [relationMatrix_map R n, genericMatrix_map_antipode, hkey, neg_sub]
-
-/-- The antipode carries every defining relation into the span of the relations. -/
-private theorem antipode_relationMatrix_mem (i j : Fin n) :
-    HopfAlgebra.antipode R (relationMatrix R n i j) ∈ Ideal.span (relationSet R n) := by
-  have h := congrFun (congrFun (relationMatrix_map_antipode R n) i) j
-  rw [Matrix.map_apply, HopfAlgebra.antipodeAlgHom_apply] at h
-  rw [h, Matrix.neg_apply]
-  exact neg_mem (entry_mul_mul_mem _
-    (fun k l => Ideal.subset_span (relationMatrix_mem_relationSet R n k l)) _ _ i j)
-
-/-! ### The defining Hopf ideal and quotient -/
-
-/-- **The orthogonal Hopf ideal**: the ideal of the coordinate Hopf algebra of `GL n`
-generated by the entries of `X Xᵀ - 1`, with the three closure conditions extended from the
-generators across the span. -/
-noncomputable def definingHopfIdeal :
+/-- **The orthogonal Hopf ideal**: the ideal of the coordinate Hopf algebra of `GL n` generated
+by the entries of `X Xᵀ - 1`. -/
+noncomputable abbrev definingHopfIdeal :
     HopfIdeal R (GeneralLinear.coordinateHopfAlgebra R n) :=
-  HopfIdeal.ofIdeal (Ideal.span (relationSet R n))
-    (fun x hx => by
-      induction hx using Submodule.span_induction with
-      | mem y hy => obtain ⟨ij, rfl⟩ := hy; exact comul_relationMatrix_mem R n ij.1 ij.2
-      | zero => rw [map_zero]; exact zero_mem _
-      | add x y _ _ hx hy => rw [map_add]; exact add_mem hx hy
-      | smul h x _ hx =>
-          rw [smul_eq_mul, Bialgebra.comul_mul]
-          exact Ideal.mul_mem_left _ _ hx)
-    (fun x hx => by
-      induction hx using Submodule.span_induction with
-      | mem y hy => obtain ⟨ij, rfl⟩ := hy; exact counit_relationMatrix R n ij.1 ij.2
-      | zero => rw [map_zero]
-      | add x y _ _ hx hy => rw [map_add, hx, hy, add_zero]
-      | smul h x _ hx => rw [smul_eq_mul, Bialgebra.counit_mul, hx, mul_zero])
-    (fun x hx => by
-      induction hx using Submodule.span_induction with
-      | mem y hy => obtain ⟨ij, rfl⟩ := hy; exact antipode_relationMatrix_mem R n ij.1 ij.2
-      | zero => rw [map_zero]; exact zero_mem _
-      | add x y _ _ hx hy => rw [map_add]; exact add_mem hx hy
-      | smul h x _ hx =>
-          rw [smul_eq_mul, HopfAlgebra.antipode_mul_distrib]
-          exact Ideal.mul_mem_left _ _ hx)
-
-/-- The underlying ideal of the orthogonal Hopf ideal is the span of the defining relations. -/
-@[simp]
-theorem definingHopfIdeal_toIdeal :
-    (definingHopfIdeal R n).toIdeal = Ideal.span (relationSet R n) := by
-  rw [HopfIdeal.toIdeal_carrier, definingHopfIdeal, HopfIdeal.ofIdeal_carrier]
+  ConstantForm.definingHopfIdeal R n 1
 
 /-- The coordinate Hopf algebra of the orthogonal subgroup scheme of `GL n`. -/
 noncomputable abbrev coordinateHopfAlgebra : _root_.CommHopfAlgCat.{u} R :=
-  CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R n)
-    (definingHopfIdeal R n)
-
-/-- The quotient coordinate morphism from `O(GL n)` to the orthogonal coordinate Hopf
-algebra. -/
-noncomputable def coordinateMap :
-    GeneralLinear.coordinateHopfAlgebra R n ⟶ coordinateHopfAlgebra R n :=
-  CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra R n)
-    (definingHopfIdeal R n)
-
-/-- The orthogonal coordinate morphism sends an ambient coordinate to its quotient class. -/
-theorem coordinateMap_apply (h : GeneralLinear.coordinateHopfAlgebra R n) :
-    (coordinateMap R n).hom h =
-      Ideal.Quotient.mkₐ R (definingHopfIdeal R n).toIdeal h := by
-  unfold coordinateMap
-  exact CommHopfAlgCat.mkQuotient_apply
-    (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n) h
-
-/-- Every defining relation vanishes in the orthogonal coordinate Hopf algebra. -/
-@[simp]
-theorem coordinateMap_relationMatrix (i j : Fin n) :
-    (coordinateMap R n).hom (relationMatrix R n i j) = 0 := by
-  rw [coordinateMap_apply, Ideal.Quotient.mkₐ_eq_mk]
-  exact Ideal.Quotient.eq_zero_iff_mem.mpr
-    (definingHopfIdeal_toIdeal R n ▸
-      Ideal.subset_span (relationMatrix_mem_relationSet R n i j))
+  ConstantForm.coordinateHopfAlgebra R n 1
 
 /-- The orthogonal subgroup scheme of `GL n`. -/
-noncomputable def groupScheme :=
-  CommHopfAlgCat.quotientSpec (GeneralLinear.coordinateHopfAlgebra R n)
-    (definingHopfIdeal R n)
-
-private noncomputable def groupSchemeι :=
-  CommHopfAlgCat.quotientSpecι (GeneralLinear.coordinateHopfAlgebra R n)
-    (definingHopfIdeal R n)
+noncomputable abbrev groupScheme := ConstantForm.groupScheme R n 1
 
 /-- The closed-subgroup inclusion from the orthogonal subgroup scheme into the named general
 linear group scheme. -/
-noncomputable def inclusion : groupScheme R n ⟶ GeneralLinear.groupScheme R n :=
-  groupSchemeι R n ≫ (eqToIso (GeneralLinear.groupScheme_def R n).symm).hom
-
-private theorem inclusion_hom_left :
-    (inclusion R n).hom.hom.left =
-      (CommHopfAlgCat.quotientSpecι
-        (GeneralLinear.coordinateHopfAlgebra R n)
-        (definingHopfIdeal R n)).hom.hom.left ≫
-      ((eqToIso (GeneralLinear.groupScheme_def R n).symm).hom).hom.hom.left := by
-  rw [inclusion]
-  unfold groupSchemeι
-  rfl
-
-/-- The orthogonal inclusion into the named general linear group scheme is a closed
-immersion. -/
-instance isClosedImmersion_inclusion :
-    AlgebraicGeometry.IsClosedImmersion (inclusion R n).hom.hom.left := by
-  let c := (CommHopfAlgCat.quotientSpecι
-    (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n)).hom.hom.left
-  let e₂ := ((eqToIso (GeneralLinear.groupScheme_def R n).symm).hom).hom.hom.left
-  have hc : AlgebraicGeometry.IsClosedImmersion c := by
-    infer_instance
-  have hc₂ : AlgebraicGeometry.IsClosedImmersion (c ≫ e₂) :=
-    (MorphismProperty.cancel_right_of_respectsIso _ c e₂).2 hc
-  rw [inclusion_hom_left]
-  exact hc₂
-
-/-- The orthogonal coordinate Hopf algebra, bundled with its finite-type property. -/
-noncomputable def finiteTypeCoordinateHopfAlgebra : FiniteTypeCommHopfAlgCat R :=
-  FiniteTypeCommHopfAlgCat.quotient
-    (⟨GeneralLinear.coordinateHopfAlgebra R n, by
-      rw [← GeneralLinear.finiteTypeCoordinateHopfAlgebra_obj]
-      exact (GeneralLinear.finiteTypeCoordinateHopfAlgebra R n).property⟩ :
-      FiniteTypeCommHopfAlgCat R)
-    (definingHopfIdeal R n)
-
-/-- The finite-type package has the orthogonal coordinate Hopf algebra as its underlying
-object. -/
-@[simp]
-theorem finiteTypeCoordinateHopfAlgebra_obj :
-    (finiteTypeCoordinateHopfAlgebra R n).obj = coordinateHopfAlgebra R n := by
-  rw [finiteTypeCoordinateHopfAlgebra]
-
-/-- The structural morphism of the orthogonal subgroup scheme is locally of finite type. -/
-instance locallyOfFiniteType_groupScheme :
-    AlgebraicGeometry.LocallyOfFiniteType (groupScheme R n).X.hom := by
-  unfold groupScheme
-  exact FiniteTypeCommHopfAlgCat.locallyOfFiniteType_quotientSpec
-    (⟨GeneralLinear.coordinateHopfAlgebra R n, by
-        rw [← GeneralLinear.finiteTypeCoordinateHopfAlgebra_obj]
-        exact (GeneralLinear.finiteTypeCoordinateHopfAlgebra R n).property⟩ :
-      FiniteTypeCommHopfAlgCat R)
-    (definingHopfIdeal R n)
+noncomputable abbrev inclusion : groupScheme R n ⟶ GeneralLinear.groupScheme R n :=
+  ConstantForm.inclusion R n 1
 
 /-! ### Algebra-valued points -/
 
@@ -425,21 +112,6 @@ section Points
 attribute [local instance] starRingOfComm
 
 variable {A : Type w} [CommRing A] [Algebra R A]
-
-/-- Evaluating the relation matrix at a point gives the form relation of its matrix. -/
-private theorem ofConv_relationMatrix
-    (g : HopfAlgebra.points (R := R)
-      (H := GeneralLinear.coordinateHopfAlgebra R n) (CommAlgCat.of R A)) :
-    (relationMatrix R n).map g.ofConv =
-      (GeneralLinear.pointToGeneralLinear n g : Matrix (Fin n) (Fin n) A) *
-          (GeneralLinear.pointToGeneralLinear n g : Matrix (Fin n) (Fin n) A)ᵀ -
-        1 := by
-  have hg : (genericMatrix R n).map g.ofConv =
-      (GeneralLinear.pointToGeneralLinear n g : Matrix (Fin n) (Fin n) A) := by
-    ext i j
-    rw [Matrix.map_apply, genericMatrix_apply]
-    exact (GeneralLinear.pointToGeneralLinear_apply n g i j).symm
-  rw [relationMatrix_map R n g.ofConv, hg]
 
 /-- An ambient point belongs to the subgroup cut out by the orthogonal Hopf ideal exactly when
 its matrix is orthogonal. This is the ambient membership criterion that further cuts consume;
@@ -454,31 +126,9 @@ theorem mem_definingPointsSubgroup_iff
         (CommAlgCat.of R A) ↔
       (GeneralLinear.pointsMulEquiv n g : Matrix (Fin n) (Fin n) A) ∈
         Matrix.orthogonalGroup (Fin n) A := by
-  rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff, Matrix.mem_orthogonalGroup_iff,
-    GeneralLinear.pointsMulEquiv_apply]
-  constructor
-  · intro h
-    have hzero : (relationMatrix R n).map g.ofConv = 0 := by
-      ext i j
-      rw [Matrix.map_apply, Matrix.zero_apply]
-      exact h _ (HopfIdeal.mem_toIdeal.mp
-        (definingHopfIdeal_toIdeal R n ▸
-          Ideal.subset_span (relationMatrix_mem_relationSet R n i j)))
-    rw [ofConv_relationMatrix R n g] at hzero
-    exact sub_eq_zero.mp hzero
-  · intro h y hy
-    have hzero : (relationMatrix R n).map g.ofConv = 0 := by
-      rw [ofConv_relationMatrix R n g]
-      exact sub_eq_zero.mpr h
-    have hle : Ideal.span (relationSet R n) ≤
-        RingHom.ker (g.ofConv :
-          GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] A) := by
-      rw [Ideal.span_le]
-      rintro _ ⟨ij, rfl⟩
-      have := congrFun (congrFun hzero ij.1) ij.2
-      rw [Matrix.map_apply, Matrix.zero_apply] at this
-      exact this
-    exact hle (definingHopfIdeal_toIdeal R n ▸ HopfIdeal.mem_toIdeal.mpr hy)
+  rw [ConstantForm.mem_definingPointsSubgroup_iff,
+    Matrix.map_one _ (map_zero _) (map_one _), Matrix.mul_one,
+    Matrix.mem_orthogonalGroup_iff]
 
 /-- Read a cut-out ambient point as an orthogonal matrix. -/
 private noncomputable def pointsSubgroupToOrthogonalGroup

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Basic.lean
@@ -88,7 +88,7 @@ theorem definingHopfIdeal_toIdeal :
         Ideal.span
           {(GeneralLinear.determinantGroupLike R n :
               GeneralLinear.coordinateHopfAlgebra R n) - 1} := by
-  rw [definingHopfIdeal, HopfIdeal.sup_toIdeal, Orthogonal.definingHopfIdeal_toIdeal,
+  rw [definingHopfIdeal, HopfIdeal.sup_toIdeal, ConstantForm.definingHopfIdeal_toIdeal,
     SpecialLinear.definingHopfIdeal_toIdeal]
 
 /-- The coordinate Hopf algebra of the special orthogonal subgroup scheme of `GL n`. -/
@@ -120,7 +120,7 @@ theorem coordinateMap_relationMatrix (i j : Fin n) :
   exact Ideal.Quotient.eq_zero_iff_mem.mpr
     (definingHopfIdeal_toIdeal R n ▸
       Ideal.mem_sup_left
-        (Ideal.subset_span (Orthogonal.relationMatrix_mem_relationSet R n i j)))
+        (Ideal.subset_span (ConstantForm.relationMatrix_mem_relationSet R n 1 i j)))
 
 /-- The generic determinant maps to one in the special orthogonal coordinate Hopf algebra. -/
 @[simp↓]

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/BaseChange.lean
@@ -90,17 +90,13 @@ private theorem coordinateHopfAlgebraBaseChangeIso_hom_relationMatrix (i j : Fin
         (1 ⊗ₜ[R] relationMatrix R m i j) =
       relationMatrix K m i j := by
   rw [← baseChangeAlgHom_apply R K m]
-  have hgeneric : (genericMatrix R m).map (baseChangeAlgHom R K m) = genericMatrix K m := by
-    ext i j
-    rw [Matrix.map_apply, genericMatrix_apply, genericMatrix_apply]
-    have h := congrFun (congrFun
-      (GeneralLinear.coordinateHopfAlgebraBaseChangeIso_hom_genericMatrix R K (m + m)) i) j
-    rw [Matrix.map_apply, GeneralLinear.genericMatrix_apply,
-      GeneralLinear.genericMatrix_apply] at h
-    simpa only [baseChangeAlgHom] using h
-  have hmatrix := relationMatrix_map R m (baseChangeAlgHom R K m)
-  rw [hgeneric] at hmatrix
-  rw [relationMatrix_def K m, JFin_map]
+  have hgeneric : (GeneralLinear.genericMatrix R (m + m)).map (baseChangeAlgHom R K m) =
+      GeneralLinear.genericMatrix K (m + m) := by
+    simpa only [baseChangeAlgHom] using
+      GeneralLinear.coordinateHopfAlgebraBaseChangeIso_hom_genericMatrix R K (m + m)
+  have hmatrix := ConstantForm.relationMatrix_map R (m + m) (JFin m R) (baseChangeAlgHom R K m)
+  rw [hgeneric, JFin_map] at hmatrix
+  rw [relationMatrix_def K m]
   exact congrFun (congrFun hmatrix i) j
 
 /-- The general-linear base-change isomorphism carries the base-changed symplectic defining Hopf
@@ -112,7 +108,8 @@ private theorem map_baseChangeHopfIdeal_definingHopfIdeal :
   refine CommHopfAlgCat.map_baseChangeHopfIdeal_of_toIdeal_eq_span
     (definingHopfIdeal R m) (definingHopfIdeal K m)
     (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K (m + m))
-    (definingHopfIdeal_toIdeal R m) (definingHopfIdeal_toIdeal K m) ?_
+    (ConstantForm.definingHopfIdeal_toIdeal R (m + m) (JFin m R))
+    (ConstantForm.definingHopfIdeal_toIdeal K (m + m) (JFin m K)) ?_
   have hrel (i j : Fin (m + m)) :
       (fun x : GeneralLinear.coordinateHopfAlgebra R (m + m) =>
         (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K (m + m)).hom.hom
@@ -121,11 +118,12 @@ private theorem map_baseChangeHopfIdeal_definingHopfIdeal :
   ext x
   constructor
   · rintro ⟨_, hy, rfl⟩
-    obtain ⟨i, j, rfl⟩ := (mem_relationSet_iff R m).mp hy
-    exact (hrel i j).symm ▸ relationMatrix_mem_relationSet K m i j
+    obtain ⟨i, j, rfl⟩ := (ConstantForm.mem_relationSet_iff R (m + m) (JFin m R)).mp hy
+    exact (hrel i j).symm ▸ ConstantForm.relationMatrix_mem_relationSet K (m + m) (JFin m K) i j
   · intro hx
-    obtain ⟨i, j, rfl⟩ := (mem_relationSet_iff K m).mp hx
-    exact ⟨relationMatrix R m i j, relationMatrix_mem_relationSet R m i j,
+    obtain ⟨i, j, rfl⟩ := (ConstantForm.mem_relationSet_iff K (m + m) (JFin m K)).mp hx
+    exact ⟨relationMatrix R m i j,
+      ConstantForm.relationMatrix_mem_relationSet R (m + m) (JFin m R) i j,
       hrel i j⟩
 
 /-- Base change of the symplectic coordinate Hopf algebra is canonically the symplectic
@@ -157,7 +155,8 @@ noncomputable def finiteTypeCoordinateHopfAlgebraBaseChangeIso :
     FiniteTypeCommHopfAlgCat.baseChange (K := K) (finiteTypeCoordinateHopfAlgebra R m) ≅
       finiteTypeCoordinateHopfAlgebra K m :=
   FiniteTypeCommHopfAlgCat.baseChangeIsoOfObjIso
-    (finiteTypeCoordinateHopfAlgebra_obj R m) (finiteTypeCoordinateHopfAlgebra_obj K m)
+    (finiteTypeCoordinateHopfAlgebra_obj R m)
+    (finiteTypeCoordinateHopfAlgebra_obj K m)
     (coordinateHopfAlgebraBaseChangeIso R K m)
 
 /-- The underlying commutative-Hopf-algebra morphism of the finite-type base-change isomorphism
@@ -169,9 +168,11 @@ theorem finiteTypeCoordinateHopfAlgebraBaseChangeIso_hom :
       (eqToIso (congrArg (CommHopfAlgCat.baseChange (K := K))
           (finiteTypeCoordinateHopfAlgebra_obj R m)) ≪≫
         coordinateHopfAlgebraBaseChangeIso R K m ≪≫
-        eqToIso (finiteTypeCoordinateHopfAlgebra_obj K m).symm).hom := by
+        eqToIso
+          (finiteTypeCoordinateHopfAlgebra_obj K m).symm).hom := by
   exact FiniteTypeCommHopfAlgCat.baseChangeIsoOfObjIso_hom
-    (finiteTypeCoordinateHopfAlgebra_obj R m) (finiteTypeCoordinateHopfAlgebra_obj K m)
+    (finiteTypeCoordinateHopfAlgebra_obj R m)
+    (finiteTypeCoordinateHopfAlgebra_obj K m)
     (coordinateHopfAlgebraBaseChangeIso R K m)
 
 end TauCeti.Symplectic

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean
@@ -5,64 +5,45 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.FunctorOfPoints
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Scheme
+public import TauCeti.Algebra.AlgebraicGroup.ConstantForm.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Naturality
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Basic
-import TauCeti.CategoryTheory.Comma.Over
 
 /-!
 # The symplectic subgroup scheme of `GL₂ₘ`
 
-For a commutative ring `R` and `m : ℕ`, the entries of the matrix relation
+For a commutative ring `R` and `m : ℕ`, the symplectic subgroup scheme `Sp₂ₘ` of `GL (m + m)`
+is the subgroup scheme preserving the standard alternating form `Jₘ`: the specialization of
+`TauCeti.ConstantForm` at `C = Jₘ`, cut out of `GL (m + m)` by the entries of
 
 ```text
 X Jₘ Xᵀ - Jₘ
 ```
 
-— `X` the localized generic matrix of `GL (m + m)`, `Jₘ` the standard alternating form in
-`Fin (m + m)` coordinates — generate a Hopf ideal in the coordinate Hopf algebra of
-`GL (m + m)`. Its quotient represents the closed subgroup scheme `Sp₂ₘ` of symplectic matrices.
-On every commutative `R`-algebra `A`, its points are naturally the existing subgroup
-`TauCeti.GLSymplecticFin m A`, equivalently `TauCeti.GLSymplectic (Fin m) A`.
+for `X` the localized generic matrix and `Jₘ` the standard alternating form in `Fin (m + m)`
+coordinates. On every commutative `R`-algebra `A`, its points are the existing subgroup
+`TauCeti.GLSymplecticFin m A`, equivalently `TauCeti.GLSymplectic (Fin m) A`, and that
+identification is what this file adds to the general construction.
 
 Together with `TauCeti.GLSymplectic`, this completes the `Sp₂ₘ` worked example of the
 ReductiveGroups roadmap at the same boundary as the Borel example
 (`TauCeti.GeneralLinear.Borel`): construction and points identification, with no smoothness or
 reductivity claim.
 
-The three Hopf-ideal closure conditions are proved by matrix algebra rather than coordinate by
-coordinate. Writing `f := X Jₘ Xᵀ - Jₘ` for the matrix of generators and mapping it entrywise
-through the relevant algebra morphisms:
-
-* the counit sends `X` to the identity matrix, so it sends `f` to `1 Jₘ 1ᵀ - Jₘ = 0`;
-* the comultiplication sends `X` to `Y Z`, where `Y` and `Z` are the two tensor inclusions of
-  `X`, and
-
-  ```text
-  (Y Z) Jₘ (Y Z)ᵀ - Jₘ = Y (Z Jₘ Zᵀ - Jₘ) Yᵀ + (Y Jₘ Yᵀ - Jₘ),
-  ```
-
-  whose two summands are the right and left tensor inclusions of `f` framed by matrices, so
-  every entry lies in the right or left tensor ideal;
-* the antipode sends `X` to its inverse matrix, and
-
-  ```text
-  X⁻¹ Jₘ (X⁻¹)ᵀ - Jₘ = -(X⁻¹ (X Jₘ Xᵀ - Jₘ) (X⁻¹)ᵀ),
-  ```
-
-  so every entry of the antipode image is a combination of the generators.
-
-The construction includes `m = 0` and the zero ring, and no invertibility of the form is used:
-the same three computations apply verbatim to `X C Xᵀ - C` for any constant matrix `C`.
+The Hopf-ideal closure conditions, the quotient, the group scheme with its closed immersion
+into `GL (m + m)`, and the ambient membership criterion `M C Mᵀ = C` all come from
+`TauCeti.ConstantForm`, which proves them for an arbitrary constant matrix `C` (local finite
+type is the generic instance for Hopf-ideal quotients of the ambient coordinate algebra); no
+invertibility or nondegeneracy of `Jₘ` is used anywhere. The construction includes `m = 0` and
+the zero ring.
 
 ## Main declarations
 
 * `TauCeti.Symplectic.relationMatrix`: the matrix of defining relations `X Jₘ Xᵀ - Jₘ`.
 * `TauCeti.Symplectic.definingHopfIdeal`: the Hopf ideal its entries generate.
-* `TauCeti.Symplectic.coordinateHopfAlgebra`: the symplectic coordinate Hopf algebra, the
-  quotient by the defining Hopf ideal.
+* `TauCeti.Symplectic.coordinateHopfAlgebra` and `TauCeti.Symplectic.coordinateMap`: the
+  symplectic coordinate Hopf algebra, the quotient by the defining Hopf ideal, and the
+  quotient morphism onto it.
 * `TauCeti.Symplectic.groupScheme` and `TauCeti.Symplectic.inclusion`: the symplectic subgroup
   scheme and its closed immersion into the general linear group scheme.
 * `TauCeti.Symplectic.pointsMulEquiv`: the group of algebra-valued points of the symplectic
@@ -76,8 +57,8 @@ the same three computations apply verbatim to `X C Xᵀ - C` for any constant ma
 * The Stacks Project, [Tag 022W](https://stacks.math.columbia.edu/tag/022W), for the ambient
   general linear group scheme.
 
-The matrix form of the closure computations is standard; the framing identities used here are
-recorded in the module docstring and are not adapted from either reference.
+The closure computations this file relies on, and the framing identities behind them, are
+proved for an arbitrary constant form in `TauCeti.ConstantForm`.
 -/
 
 public section
@@ -90,420 +71,89 @@ universe u v w
 
 variable (R : Type u) [CommRing R] (m : ℕ)
 
-/-! ### The defining relation matrix -/
+/-! ### The symplectic specialization of the constant-form construction -/
 
-/-- The localized generic matrix of `GL (m + m)`, read in the bundled coordinate Hopf algebra. -/
-noncomputable def genericMatrix :
+/-- **The matrix of defining relations** of the symplectic subgroup scheme: `X Jₘ Xᵀ - Jₘ` over
+the coordinate Hopf algebra of `GL (m + m)`, the constant-form relation matrix at `C = Jₘ`. -/
+noncomputable abbrev relationMatrix :
     Matrix (Fin (m + m)) (Fin (m + m)) (GeneralLinear.coordinateHopfAlgebra R (m + m)) :=
-  (GeneralLinear.localizedGenericMatrix R (m + m)).map
-    (GeneralLinear.coordinateHopfAlgebraAlgEquiv R (m + m))
-
-/-- An entry of the bundled generic matrix is the bundled image of the corresponding polynomial
-generator. -/
-theorem genericMatrix_apply (i j : Fin (m + m)) :
-    genericMatrix R m i j =
-      GeneralLinear.coordinateHopfAlgebraAlgEquiv R (m + m)
-        (GeneralLinear.coordinateRingMap R (m + m) (MvPolynomial.X (i, j))) := by
-  rw [genericMatrix, Matrix.map_apply, GeneralLinear.localizedGenericMatrix_apply]
-
-/-- The inverse of the localized generic matrix, read in the bundled coordinate Hopf algebra. -/
-private noncomputable def genericMatrixInv :
-    Matrix (Fin (m + m)) (Fin (m + m)) (GeneralLinear.coordinateHopfAlgebra R (m + m)) :=
-  ((GeneralLinear.localizedGenericMatrix R (m + m))⁻¹).map
-    (GeneralLinear.coordinateHopfAlgebraAlgEquiv R (m + m))
-
-/-- The bundled generic matrix and its bundled inverse multiply to the identity. -/
-private theorem genericMatrix_mul_genericMatrixInv :
-    genericMatrix R m * genericMatrixInv R m = 1 := by
-  rw [genericMatrix, genericMatrixInv, ← Matrix.map_mul,
-    Matrix.mul_nonsing_inv _ (GeneralLinear.isUnit_det_localizedGenericMatrix R (m + m))]
-  exact Matrix.map_one _ (map_zero _) (map_one _)
-
-/-- The bundled inverse and the bundled generic matrix multiply to the identity. -/
-private theorem genericMatrixInv_mul_genericMatrix :
-    genericMatrixInv R m * genericMatrix R m = 1 := by
-  rw [genericMatrix, genericMatrixInv, ← Matrix.map_mul,
-    Matrix.nonsing_inv_mul _ (GeneralLinear.isUnit_det_localizedGenericMatrix R (m + m))]
-  exact Matrix.map_one _ (map_zero _) (map_one _)
-
-/-- **The matrix of defining relations** of the symplectic subgroup scheme:
-`X Jₘ Xᵀ - Jₘ` over the coordinate Hopf algebra of `GL (m + m)`. -/
-noncomputable def relationMatrix :
-    Matrix (Fin (m + m)) (Fin (m + m)) (GeneralLinear.coordinateHopfAlgebra R (m + m)) :=
-  genericMatrix R m *
-      (JFin m R).map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))) *
-      (genericMatrix R m)ᵀ -
-    (JFin m R).map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m)))
+  ConstantForm.relationMatrix R (m + m) (JFin m R)
 
 /-- The relation matrix is the standard alternating form transported by the generic matrix,
 minus the form: `X Jₘ Xᵀ - Jₘ`. -/
 theorem relationMatrix_def :
     relationMatrix R m =
-      genericMatrix R m *
-          (JFin m R).map
-            (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))) *
-          (genericMatrix R m)ᵀ -
-        (JFin m R).map
-          (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))) := by
-  rw [relationMatrix]
+      GeneralLinear.genericMatrix R (m + m) *
+          JFin m (GeneralLinear.coordinateHopfAlgebra R (m + m)) *
+          (GeneralLinear.genericMatrix R (m + m))ᵀ -
+        JFin m (GeneralLinear.coordinateHopfAlgebra R (m + m)) := by
+  rw [relationMatrix, ConstantForm.relationMatrix_def, JFin_map]
 
 /-- The set of defining relations: the entries of the relation matrix. -/
-def relationSet : Set (GeneralLinear.coordinateHopfAlgebra R (m + m)) :=
-  Set.range fun ij : Fin (m + m) × Fin (m + m) => relationMatrix R m ij.1 ij.2
-
-/-- Every entry of the relation matrix is a defining relation. -/
-theorem relationMatrix_mem_relationSet (i j : Fin (m + m)) :
-    relationMatrix R m i j ∈ relationSet R m :=
-  ⟨(i, j), rfl⟩
-
-/-- An element is a symplectic defining relation exactly when it is an entry of the relation
-matrix. -/
-@[simp] theorem mem_relationSet_iff {x : GeneralLinear.coordinateHopfAlgebra R (m + m)} :
-    x ∈ relationSet R m ↔ ∃ i j, relationMatrix R m i j = x := by
-  constructor
-  · rintro ⟨⟨i, j⟩, rfl⟩
-    exact ⟨i, j, rfl⟩
-  · rintro ⟨i, j, rfl⟩
-    exact relationMatrix_mem_relationSet R m i j
-
-/-- Mapping the relation matrix through an algebra morphism gives the relation of the images:
-the generic matrix maps entrywise, and the constant form maps to the constant form. -/
-@[simp] theorem relationMatrix_map {T : Type*} [CommRing T] [Algebra R T]
-    (phi : GeneralLinear.coordinateHopfAlgebra R (m + m) →ₐ[R] T) :
-    (relationMatrix R m).map phi =
-      (genericMatrix R m).map phi * JFin m T *
-          ((genericMatrix R m).map phi)ᵀ -
-        JFin m T := by
-  have hJ : ((JFin m R).map
-        (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m)))).map phi =
-      (JFin m R).map (algebraMap R T) := by
-    rw [Matrix.map_map]
-    exact congrArg _ (funext fun r => phi.commutes r)
-  rw [relationMatrix, Matrix.map_sub, Matrix.map_mul, Matrix.map_mul, hJ, JFin_map,
-    Matrix.transpose_map]
-  exact fun a b => map_sub phi a b
-
-/-- An entry of a framed relation matrix `P (X Jₘ Xᵀ - Jₘ) Q` lies in any ideal containing the
-entries of the middle factor. This is the only membership computation the closure proofs need. -/
-private theorem entry_mul_mul_mem {S : Type*} [CommRing S] (K : Ideal S) {μ : ℕ}
-    {M : Matrix (Fin μ) (Fin μ) S} (hM : ∀ k l, M k l ∈ K)
-    (P Q : Matrix (Fin μ) (Fin μ) S) (i j : Fin μ) : (P * M * Q) i j ∈ K := by
-  rw [Matrix.mul_apply]
-  refine Ideal.sum_mem _ fun k _ => ?_
-  rw [Matrix.mul_apply, Finset.sum_mul]
-  refine Ideal.sum_mem _ fun t _ => ?_
-  exact Ideal.mul_mem_right _ _ (Ideal.mul_mem_left _ _ (hM t k))
-
-/-! ### The three Hopf-ideal closure conditions -/
-
-/-- The counit sends the bundled generic matrix to the identity matrix. -/
-private theorem genericMatrix_map_counit :
-    (genericMatrix R m).map
-        (Bialgebra.counitAlgHom R (GeneralLinear.coordinateHopfAlgebra R (m + m))) = 1 := by
-  ext i j
-  rw [Matrix.map_apply, genericMatrix_apply, Bialgebra.counitAlgHom_apply,
-    GeneralLinear.coordinateHopfAlgebra_counit_X, Matrix.one_apply]
-
-/-- The counit vanishes on every defining relation. -/
-private theorem counit_relationMatrix (i j : Fin (m + m)) :
-    Coalgebra.counit (R := R) (relationMatrix R m i j) = 0 := by
-  have h := congrFun (congrFun (relationMatrix_map R m
-    (Bialgebra.counitAlgHom R (GeneralLinear.coordinateHopfAlgebra R (m + m)))) i) j
-  rw [Matrix.map_apply, Bialgebra.counitAlgHom_apply] at h
-  rw [h, genericMatrix_map_counit, Matrix.transpose_one, Matrix.one_mul, Matrix.mul_one,
-    sub_self, Matrix.zero_apply]
-
-/-- The comultiplication sends the bundled generic matrix to the product of its two tensor
-inclusions: `Δ X = (X ⊗ 1)(1 ⊗ X)`. -/
-private theorem genericMatrix_map_comul :
-    (genericMatrix R m).map
-        (Bialgebra.comulAlgHom R (GeneralLinear.coordinateHopfAlgebra R (m + m))) =
-      (genericMatrix R m).map
-          (Algebra.TensorProduct.includeLeft (R := R) (S := R)) *
-        (genericMatrix R m).map (Algebra.TensorProduct.includeRight (R := R)) := by
-  ext i j
-  rw [Matrix.map_apply, genericMatrix_apply, Bialgebra.comulAlgHom_apply,
-    GeneralLinear.coordinateHopfAlgebra_comul_X, Matrix.mul_apply]
-  refine Finset.sum_congr rfl fun k _ => ?_
-  rw [Matrix.map_apply, Matrix.map_apply, genericMatrix_apply, genericMatrix_apply,
-    Algebra.TensorProduct.includeLeft_apply, Algebra.TensorProduct.includeRight_apply,
-    Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_one]
-
-/-- The comultiplication of the relation matrix decomposes as a right-tensor-framed copy of the
-relations plus the left tensor inclusion of the relations. -/
-private theorem relationMatrix_map_comul :
-    (relationMatrix R m).map
-        (Bialgebra.comulAlgHom R (GeneralLinear.coordinateHopfAlgebra R (m + m))) =
-      (genericMatrix R m).map (Algebra.TensorProduct.includeLeft (R := R) (S := R)) *
-          (relationMatrix R m).map (Algebra.TensorProduct.includeRight (R := R)) *
-          ((genericMatrix R m).map
-            (Algebra.TensorProduct.includeLeft (R := R) (S := R)))ᵀ +
-        (relationMatrix R m).map
-          (Algebra.TensorProduct.includeLeft (R := R) (S := R)) := by
-  rw [relationMatrix_map R m, relationMatrix_map R m, relationMatrix_map R m,
-    genericMatrix_map_comul, Matrix.transpose_mul]
-  conv_rhs => rw [Matrix.mul_sub, Matrix.sub_mul, sub_add_sub_cancel]
-  simp only [Matrix.mul_assoc]
-
-/-- The comultiplication of every defining relation lies in the sum of the left and right tensor
-ideals of the span of the relations. -/
-private theorem comul_relationMatrix_mem (i j : Fin (m + m)) :
-    Coalgebra.comul (R := R) (relationMatrix R m i j) ∈
-      HopfIdeal.leftTensorIdeal (R := R)
-          (H := GeneralLinear.coordinateHopfAlgebra R (m + m))
-          (Ideal.span (relationSet R m)) ⊔
-        HopfIdeal.rightTensorIdeal (R := R)
-          (H := GeneralLinear.coordinateHopfAlgebra R (m + m))
-          (Ideal.span (relationSet R m)) := by
-  have h := congrFun (congrFun (relationMatrix_map_comul R m) i) j
-  rw [Matrix.map_apply, Bialgebra.comulAlgHom_apply] at h
-  rw [h, Matrix.add_apply]
-  refine Ideal.add_mem _ (Ideal.mem_sup_right ?_) (Ideal.mem_sup_left ?_)
-  · refine entry_mul_mul_mem _ (fun k l => ?_) _ _ i j
-    rw [Matrix.map_apply]
-    exact HopfIdeal.includeRight_mem_rightTensorIdeal (R := R)
-      (H := GeneralLinear.coordinateHopfAlgebra R (m + m))
-      (Ideal.subset_span (relationMatrix_mem_relationSet R m k l))
-  · rw [Matrix.map_apply]
-    exact HopfIdeal.includeLeft_mem_leftTensorIdeal (R := R)
-      (H := GeneralLinear.coordinateHopfAlgebra R (m + m))
-      (Ideal.subset_span (relationMatrix_mem_relationSet R m i j))
-
-/-- The antipode sends the bundled generic matrix to its bundled inverse. -/
-private theorem genericMatrix_map_antipode :
-    (genericMatrix R m).map
-        (HopfAlgebra.antipodeAlgHom (R := R)
-          (A := GeneralLinear.coordinateHopfAlgebra R (m + m))) =
-      genericMatrixInv R m := by
-  ext i j
-  rw [Matrix.map_apply, genericMatrix_apply, HopfAlgebra.antipodeAlgHom_apply,
-    GeneralLinear.coordinateHopfAlgebra_antipode_X, genericMatrixInv, Matrix.map_apply]
-
-/-- The antipode image of the relation matrix is the negative of the relation matrix framed by
-the bundled inverse: `X⁻¹ Jₘ (X⁻¹)ᵀ - Jₘ = -(X⁻¹ (X Jₘ Xᵀ - Jₘ) (X⁻¹)ᵀ)`. -/
-private theorem relationMatrix_map_antipode :
-    (relationMatrix R m).map
-        (HopfAlgebra.antipodeAlgHom (R := R)
-          (A := GeneralLinear.coordinateHopfAlgebra R (m + m))) =
-      -(genericMatrixInv R m * relationMatrix R m * (genericMatrixInv R m)ᵀ) := by
-  have ht : (genericMatrix R m)ᵀ * (genericMatrixInv R m)ᵀ = 1 := by
-    rw [← Matrix.transpose_mul, genericMatrixInv_mul_genericMatrix, Matrix.transpose_one]
-  have hkey : genericMatrixInv R m * relationMatrix R m * (genericMatrixInv R m)ᵀ =
-      (JFin m R).map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))) -
-        genericMatrixInv R m *
-          (JFin m R).map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))) *
-          (genericMatrixInv R m)ᵀ := by
-    rw [relationMatrix, Matrix.mul_sub, Matrix.sub_mul]
-    congr 1
-    calc genericMatrixInv R m *
-          (genericMatrix R m *
-            (JFin m R).map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))) *
-            (genericMatrix R m)ᵀ) *
-          (genericMatrixInv R m)ᵀ
-        = genericMatrixInv R m * genericMatrix R m *
-            (JFin m R).map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))) *
-            ((genericMatrix R m)ᵀ * (genericMatrixInv R m)ᵀ) := by
-          simp only [Matrix.mul_assoc]
-      _ = (JFin m R).map (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))) := by
-          rw [genericMatrixInv_mul_genericMatrix, ht, Matrix.one_mul, Matrix.mul_one]
-  rw [relationMatrix_map R m, genericMatrix_map_antipode,
-    ← JFin_map (m := m)
-      (algebraMap R (GeneralLinear.coordinateHopfAlgebra R (m + m))), hkey, neg_sub]
-
-/-- The antipode carries every defining relation into the span of the relations. -/
-private theorem antipode_relationMatrix_mem (i j : Fin (m + m)) :
-    HopfAlgebra.antipode R (relationMatrix R m i j) ∈ Ideal.span (relationSet R m) := by
-  have h := congrFun (congrFun (relationMatrix_map_antipode R m) i) j
-  rw [Matrix.map_apply, HopfAlgebra.antipodeAlgHom_apply] at h
-  rw [h, Matrix.neg_apply]
-  exact neg_mem (entry_mul_mul_mem _
-    (fun k l => Ideal.subset_span (relationMatrix_mem_relationSet R m k l)) _ _ i j)
-
-/-! ### The defining Hopf ideal and quotient -/
+abbrev relationSet : Set (GeneralLinear.coordinateHopfAlgebra R (m + m)) :=
+  ConstantForm.relationSet R (m + m) (JFin m R)
 
 /-- **The symplectic Hopf ideal**: the ideal of the coordinate Hopf algebra of `GL (m + m)`
-generated by the entries of `X Jₘ Xᵀ - Jₘ`, with the three closure conditions extended from the
-generators across the span. -/
-noncomputable def definingHopfIdeal :
+generated by the entries of `X Jₘ Xᵀ - Jₘ`. -/
+noncomputable abbrev definingHopfIdeal :
     HopfIdeal R (GeneralLinear.coordinateHopfAlgebra R (m + m)) :=
-  HopfIdeal.ofIdeal (Ideal.span (relationSet R m))
-    (fun x hx => by
-      induction hx using Submodule.span_induction with
-      | mem y hy => obtain ⟨ij, rfl⟩ := hy; exact comul_relationMatrix_mem R m ij.1 ij.2
-      | zero => rw [map_zero]; exact zero_mem _
-      | add x y _ _ hx hy => rw [map_add]; exact add_mem hx hy
-      | smul h x _ hx =>
-          rw [smul_eq_mul, Bialgebra.comul_mul]
-          exact Ideal.mul_mem_left _ _ hx)
-    (fun x hx => by
-      induction hx using Submodule.span_induction with
-      | mem y hy => obtain ⟨ij, rfl⟩ := hy; exact counit_relationMatrix R m ij.1 ij.2
-      | zero => rw [map_zero]
-      | add x y _ _ hx hy => rw [map_add, hx, hy, add_zero]
-      | smul h x _ hx => rw [smul_eq_mul, Bialgebra.counit_mul, hx, mul_zero])
-    (fun x hx => by
-      induction hx using Submodule.span_induction with
-      | mem y hy => obtain ⟨ij, rfl⟩ := hy; exact antipode_relationMatrix_mem R m ij.1 ij.2
-      | zero => rw [map_zero]; exact zero_mem _
-      | add x y _ _ hx hy => rw [map_add]; exact add_mem hx hy
-      | smul h x _ hx =>
-          rw [smul_eq_mul, HopfAlgebra.antipode_mul_distrib]
-          exact Ideal.mul_mem_left _ _ hx)
-
-/-- The underlying ideal of the symplectic Hopf ideal is the span of the defining relations. -/
-@[simp]
-theorem definingHopfIdeal_toIdeal :
-    (definingHopfIdeal R m).toIdeal = Ideal.span (relationSet R m) := by
-  rw [HopfIdeal.toIdeal_carrier, definingHopfIdeal, HopfIdeal.ofIdeal_carrier]
+  ConstantForm.definingHopfIdeal R (m + m) (JFin m R)
 
 /-- The coordinate Hopf algebra of the symplectic subgroup scheme of `GL (m + m)`. -/
 noncomputable abbrev coordinateHopfAlgebra : _root_.CommHopfAlgCat.{u} R :=
-  CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra R (m + m))
-    (definingHopfIdeal R m)
+  ConstantForm.coordinateHopfAlgebra R (m + m) (JFin m R)
 
 /-- The quotient coordinate morphism from `O(GL (m + m))` to the symplectic coordinate Hopf
 algebra. -/
-noncomputable def coordinateMap :
+noncomputable abbrev coordinateMap :
     GeneralLinear.coordinateHopfAlgebra R (m + m) ⟶ coordinateHopfAlgebra R m :=
-  CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra R (m + m))
-    (definingHopfIdeal R m)
+  ConstantForm.coordinateMap R (m + m) (JFin m R)
 
 /-- The symplectic coordinate map is the canonical quotient morphism by the defining Hopf
 ideal. -/
 theorem coordinateMap_def :
     coordinateMap R m =
       CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra R (m + m))
-        (definingHopfIdeal R m) := by
-  unfold coordinateMap
-  rfl
-
-/-- The symplectic coordinate morphism sends an ambient coordinate to its quotient class. -/
-theorem coordinateMap_apply (h : GeneralLinear.coordinateHopfAlgebra R (m + m)) :
-    (coordinateMap R m).hom h =
-      Ideal.Quotient.mkₐ R (definingHopfIdeal R m).toIdeal h := by
-  unfold coordinateMap
-  exact CommHopfAlgCat.mkQuotient_apply
-    (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m) h
-
-/-- Every defining relation vanishes in the symplectic coordinate Hopf algebra. -/
-@[simp]
-theorem coordinateMap_relationMatrix (i j : Fin (m + m)) :
-    (coordinateMap R m).hom (relationMatrix R m i j) = 0 := by
-  rw [coordinateMap_apply, Ideal.Quotient.mkₐ_eq_mk]
-  exact Ideal.Quotient.eq_zero_iff_mem.mpr
-    (definingHopfIdeal_toIdeal R m ▸
-      Ideal.subset_span (relationMatrix_mem_relationSet R m i j))
+        (definingHopfIdeal R m) :=
+  ConstantForm.coordinateMap_def R (m + m) (JFin m R)
 
 /-- The symplectic subgroup scheme of `GL (m + m)`. -/
-noncomputable def groupScheme :=
-  CommHopfAlgCat.quotientSpec (GeneralLinear.coordinateHopfAlgebra R (m + m))
-    (definingHopfIdeal R m)
+noncomputable abbrev groupScheme := ConstantForm.groupScheme R (m + m) (JFin m R)
 
 /-- The symplectic group scheme is the quotient spectrum of its coordinate Hopf algebra. -/
 theorem groupScheme_def :
     groupScheme R m =
       CommHopfAlgCat.quotientSpec (GeneralLinear.coordinateHopfAlgebra R (m + m))
-        (definingHopfIdeal R m) := by
-  unfold groupScheme
-  rfl
-
-/-- The quotient-spectrum inclusion into the Hopf spectrum of the ambient coordinate algebra. -/
-private noncomputable def groupSchemeι :=
-  CommHopfAlgCat.quotientSpecι (GeneralLinear.coordinateHopfAlgebra R (m + m))
-    (definingHopfIdeal R m)
-
-/-- The closed-subgroup inclusion from the symplectic subgroup scheme into the named general
-linear group scheme. -/
-noncomputable def inclusion : groupScheme R m ⟶ GeneralLinear.groupScheme R (m + m) :=
-  eqToHom (groupScheme_def R m) ≫ groupSchemeι R m ≫
-    (eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom
-
-/-- The symplectic inclusion is the relative spectrum of the quotient coordinate map, followed
-by transport to the named general-linear presentation. -/
-theorem inclusion_def :
-    inclusion R m =
-      eqToHom (groupScheme_def R m) ≫
-        CommHopfAlgCat.quotientSpecι
-          (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m) ≫
-        (eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom := by
-  unfold inclusion groupSchemeι
-  rfl
-
-private theorem inclusion_hom_left :
-    (inclusion R m).hom.hom.left =
-      (CommHopfAlgCat.quotientSpecι
-        (GeneralLinear.coordinateHopfAlgebra R (m + m))
-        (definingHopfIdeal R m)).hom.hom.left ≫
-      ((eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom).hom.hom.left := by
-  rw [inclusion]
-  unfold groupSchemeι
-  rfl
-
-/-- The symplectic inclusion into the named general linear group scheme is a closed
-immersion. -/
-instance isClosedImmersion_inclusion :
-    AlgebraicGeometry.IsClosedImmersion (inclusion R m).hom.hom.left := by
-  let c := (CommHopfAlgCat.quotientSpecι
-    (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m)).hom.hom.left
-  let e₂ := ((eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom).hom.hom.left
-  have hc : AlgebraicGeometry.IsClosedImmersion c := by
-    infer_instance
-  have hc₂ : AlgebraicGeometry.IsClosedImmersion (c ≫ e₂) :=
-    (MorphismProperty.cancel_right_of_respectsIso _ c e₂).2 hc
-  rw [inclusion_hom_left]
-  exact hc₂
+        (definingHopfIdeal R m) :=
+  ConstantForm.groupScheme_def R (m + m) (JFin m R)
 
 /-- The symplectic coordinate Hopf algebra, bundled with its finite-type property. -/
-noncomputable def finiteTypeCoordinateHopfAlgebra : FiniteTypeCommHopfAlgCat R :=
-  FiniteTypeCommHopfAlgCat.quotient
-    (⟨GeneralLinear.coordinateHopfAlgebra R (m + m), by
-      rw [← GeneralLinear.finiteTypeCoordinateHopfAlgebra_obj]
-      exact (GeneralLinear.finiteTypeCoordinateHopfAlgebra R (m + m)).property⟩ :
-      FiniteTypeCommHopfAlgCat R)
-    (definingHopfIdeal R m)
+noncomputable abbrev finiteTypeCoordinateHopfAlgebra : FiniteTypeCommHopfAlgCat R :=
+  ConstantForm.finiteTypeCoordinateHopfAlgebra R (m + m) (JFin m R)
 
 /-- The finite-type package has the symplectic coordinate Hopf algebra as its underlying
 object. -/
-@[simp]
 theorem finiteTypeCoordinateHopfAlgebra_obj :
-    (finiteTypeCoordinateHopfAlgebra R m).obj = coordinateHopfAlgebra R m := by
-  rw [finiteTypeCoordinateHopfAlgebra]
+    (finiteTypeCoordinateHopfAlgebra R m).obj = coordinateHopfAlgebra R m :=
+  ConstantForm.finiteTypeCoordinateHopfAlgebra_obj R (m + m) (JFin m R)
 
-/-- The structural morphism of the symplectic subgroup scheme is locally of finite type. -/
-instance locallyOfFiniteType_groupScheme :
-    AlgebraicGeometry.LocallyOfFiniteType (groupScheme R m).X.hom := by
-  unfold groupScheme
-  exact FiniteTypeCommHopfAlgCat.locallyOfFiniteType_quotientSpec
-    (⟨GeneralLinear.coordinateHopfAlgebra R (m + m), by
-        rw [← GeneralLinear.finiteTypeCoordinateHopfAlgebra_obj]
-        exact (GeneralLinear.finiteTypeCoordinateHopfAlgebra R (m + m)).property⟩ :
-      FiniteTypeCommHopfAlgCat R)
-    (definingHopfIdeal R m)
+/-- The closed-subgroup inclusion from the symplectic subgroup scheme into the named general
+linear group scheme. -/
+noncomputable abbrev inclusion : groupScheme R m ⟶ GeneralLinear.groupScheme R (m + m) :=
+  ConstantForm.inclusion R (m + m) (JFin m R)
+
+/-- The symplectic inclusion is the generic Hopf-ideal closed immersion at the defining Hopf
+ideal. -/
+theorem inclusion_def :
+    inclusion R m =
+      GeneralLinear.hopfIdealInclusion R (m + m) (definingHopfIdeal R m) :=
+  ConstantForm.inclusion_def R (m + m) (JFin m R)
 
 /-! ### Algebra-valued points -/
 
 section Points
 
 variable {A : Type w} [CommRing A] [Algebra R A]
-
-/-- Evaluating the relation matrix at a point gives the form relation of its matrix. -/
-private theorem ofConv_relationMatrix
-    (g : HopfAlgebra.points (R := R)
-      (H := GeneralLinear.coordinateHopfAlgebra R (m + m)) (CommAlgCat.of R A)) :
-    (relationMatrix R m).map g.ofConv =
-      (GeneralLinear.pointToGeneralLinear (m + m) g :
-            Matrix (Fin (m + m)) (Fin (m + m)) A) *
-          JFin m A *
-          (GeneralLinear.pointToGeneralLinear (m + m) g :
-            Matrix (Fin (m + m)) (Fin (m + m)) A)ᵀ -
-        JFin m A := by
-  have hg : (genericMatrix R m).map g.ofConv =
-      (GeneralLinear.pointToGeneralLinear (m + m) g :
-        Matrix (Fin (m + m)) (Fin (m + m)) A) := by
-    ext i j
-    rw [Matrix.map_apply, genericMatrix_apply]
-    exact (GeneralLinear.pointToGeneralLinear_apply (m + m) g i j).symm
-  rw [relationMatrix_map R m g.ofConv, hg]
 
 /-- An ambient point belongs to the subgroup cut out by the symplectic Hopf ideal exactly when
 its matrix is symplectic. -/
@@ -514,31 +164,7 @@ private theorem mem_definingPointsSubgroup_iff
         (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m)
         (CommAlgCat.of R A) ↔
       GeneralLinear.pointsMulEquiv (m + m) g ∈ GLSymplecticFin m A := by
-  rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff, GLSymplecticFin.mem_iff,
-    GeneralLinear.pointsMulEquiv_apply]
-  constructor
-  · intro h
-    have hzero : (relationMatrix R m).map g.ofConv = 0 := by
-      ext i j
-      rw [Matrix.map_apply, Matrix.zero_apply]
-      exact h _ (HopfIdeal.mem_toIdeal.mp
-        (definingHopfIdeal_toIdeal R m ▸
-          Ideal.subset_span (relationMatrix_mem_relationSet R m i j)))
-    rw [ofConv_relationMatrix R m g] at hzero
-    exact sub_eq_zero.mp hzero
-  · intro h y hy
-    have hzero : (relationMatrix R m).map g.ofConv = 0 := by
-      rw [ofConv_relationMatrix R m g]
-      exact sub_eq_zero.mpr h
-    have hle : Ideal.span (relationSet R m) ≤
-        RingHom.ker (g.ofConv :
-          GeneralLinear.coordinateHopfAlgebra R (m + m) →ₐ[R] A) := by
-      rw [Ideal.span_le]
-      rintro _ ⟨ij, rfl⟩
-      have := congrFun (congrFun hzero ij.1) ij.2
-      rw [Matrix.map_apply, Matrix.zero_apply] at this
-      exact this
-    exact hle (definingHopfIdeal_toIdeal R m ▸ HopfIdeal.mem_toIdeal.mpr hy)
+  rw [ConstantForm.mem_definingPointsSubgroup_iff, GLSymplecticFin.mem_iff, JFin_map]
 
 /-- Read a cut-out ambient point as a symplectic matrix. -/
 private noncomputable def pointsSubgroupToGLSymplecticFin
@@ -615,18 +241,6 @@ theorem pointsMulEquiv_coe
     (fun g => (pointsSubgroupToGLSymplecticFin R m g : GLSymplecticFin m A).1)
     hcomponent.symm
 
-/-- Mapping a symplectic point along the quotient coordinate morphism gives its ambient
-general-linear point. -/
-theorem mapPointsFunctor_coordinateMap_app
-    (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R m)
-      (CommAlgCat.of R A)) :
-    (CommHopfAlgCat.mapPointsFunctor (coordinateMap R m)).app (CommAlgCat.of R A) f =
-      CommHopfAlgCat.quotientPointsHom
-        (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m)
-        (CommAlgCat.of R A) f := by
-  apply WithConv.ext
-  rfl
-
 /-- The ambient point attached to a symplectic matrix is the general-linear point attached to
 its ordinary inclusion. -/
 @[simp]
@@ -653,18 +267,8 @@ theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
   have hcoe_lhs := pointsMulEquiv_coe (R := R) (A := B) m
     (AlgHom.mapValue (H := coordinateHopfAlgebra R m) phi f)
   have hcoe_rhs := pointsMulEquiv_coe (R := R) (A := A) m f
-  have hnatural :
-      CommHopfAlgCat.quotientPointsHom
-          (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m)
-          (CommAlgCat.of R B) (AlgHom.mapValue phi f) =
-        AlgHom.mapValue phi
-          (CommHopfAlgCat.quotientPointsHom
-            (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m)
-            (CommAlgCat.of R A) f) := by
-    apply WithConv.ext
-    ext h
-    -- After extensionality, both sides apply `phi` after `f` and the canonical quotient map.
-    rfl
+  have hnatural := (CommHopfAlgCat.mapValue_quotientPointsHom
+    (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m) phi f).symm
   rw [← hcoe_lhs, hnatural,
     GeneralLinear.pointsMulEquiv_mapValue, hcoe_rhs, GLSymplecticFin.coe_map]
 

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/RootSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/RootSubgroup.lean
@@ -415,7 +415,7 @@ theorem coordinateMap_comp_positiveLongRootSubgroupCoordinateMap (i : Fin m) :
   change (CommHopfAlgCat.mapPointsFunctor (coordinateMap R m)).app A
       (positiveLongRootSubgroupPoints i f) =
     GeneralLinear.rootSubgroupPoints (GLSymplecticFin.finSumFinEquiv_inl_ne_inr i i) f
-  rw [mapPointsFunctor_coordinateMap_app]
+  rw [ConstantForm.mapPointsFunctor_coordinateMap_app]
   apply (GeneralLinear.pointsMulEquiv (R := R) (A := A) (m + m)).injective
   rw [pointsMulEquiv_coe]
   have hSp := pointsMulEquiv_positiveLongRootSubgroupPoints
@@ -453,7 +453,7 @@ theorem coordinateMap_comp_negativeLongRootSubgroupCoordinateMap (i : Fin m) :
   change (CommHopfAlgCat.mapPointsFunctor (coordinateMap R m)).app A
       (negativeLongRootSubgroupPoints i f) =
     GeneralLinear.rootSubgroupPoints (GLSymplecticFin.finSumFinEquiv_inr_ne_inl i i) f
-  rw [mapPointsFunctor_coordinateMap_app]
+  rw [ConstantForm.mapPointsFunctor_coordinateMap_app]
   apply (GeneralLinear.pointsMulEquiv (R := R) (A := A) (m + m)).injective
   rw [pointsMulEquiv_coe]
   have hSp := pointsMulEquiv_negativeLongRootSubgroupPoints
@@ -533,8 +533,9 @@ theorem positiveLongRootSubgroup_comp_inclusion (i : Fin m) :
     positiveLongRootSubgroup (R := R) i ≫ inclusion R m =
       GeneralLinear.rootSubgroup (R := R)
         (GLSymplecticFin.finSumFinEquiv_inl_ne_inr i i) := by
-  rw [positiveLongRootSubgroup_def, inclusion_def, GeneralLinear.rootSubgroup_def]
-  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+  rw [positiveLongRootSubgroup_def, inclusion_def,
+    GeneralLinear.hopfIdealInclusion_def, GeneralLinear.rootSubgroup_def]
+  simp only [Category.assoc, eqToHom_refl, Category.id_comp]
   rw [CommHopfAlgCat.quotientSpecι_def]
   rw [← coordinateMap_def]
   rw [← Category.assoc
@@ -552,8 +553,9 @@ theorem negativeLongRootSubgroup_comp_inclusion (i : Fin m) :
     negativeLongRootSubgroup (R := R) i ≫ inclusion R m =
       GeneralLinear.rootSubgroup (R := R)
         (GLSymplecticFin.finSumFinEquiv_inr_ne_inl i i) := by
-  rw [negativeLongRootSubgroup_def, inclusion_def, GeneralLinear.rootSubgroup_def]
-  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+  rw [negativeLongRootSubgroup_def, inclusion_def,
+    GeneralLinear.hopfIdealInclusion_def, GeneralLinear.rootSubgroup_def]
+  simp only [Category.assoc, eqToHom_refl, Category.id_comp]
   rw [CommHopfAlgCat.quotientSpecι_def]
   rw [← coordinateMap_def]
   rw [← Category.assoc


### PR DESCRIPTION
Roadmap: ReductiveGroups

Generalizes the scaffolding shared by the orthogonal and symplectic worked examples to an arbitrary constant matrix and rebases both onto it. `TauCeti.ConstantForm` cuts `GL n` by the entries of `X C Xᵀ - C` for any `C : Matrix (Fin n) (Fin n) R`, and `TauCeti.Orthogonal` (`C = 1`) and `TauCeti.Symplectic` (`C = Jₘ`) become specializations that add only their own points identification. `Orthogonal/Basic.lean` goes 588 → 240 lines and `Symplectic/Basic.lean` 690 → 296 against a 457-line general module: the three Hopf-ideal closure computations, the quotient with its coordinate morphism, the group scheme with its closed immersion, local finite type, the finite-type package, and the ambient membership criterion are now proved once instead of twice.

**Why this is the announced follow-up.** Both #3708 and #3777 pre-announced this refactor in their descriptions, and `Symplectic/Basic.lean`'s module docstring already recorded that its closure computations "apply verbatim to `X C Xᵀ - C` for any constant matrix `C`" — this makes that sentence a theorem instead of a comment. The two files have also begun to diverge: #4698 added `relationMatrix_def`, `mem_relationSet_iff`, and a public `@[simp] relationMatrix_map` on the symplectic side only, while the orthogonal twin of `relationMatrix_map` is still private. The general module carries all three for both sides at once.

**What generalizes, and why it is not an accident.** No step of the construction inverts `C`, transposes it, or uses a relation between `C` and `Cᵀ`, so nothing is assumed of `C` — not invertibility, symmetry, alternation, or nondegeneracy. The three framing identities hold verbatim:

- counit: `1 C 1ᵀ - C = 0`;
- comultiplication: `(Y Z) C (Y Z)ᵀ - C = Y (Z C Zᵀ - C) Yᵀ + (Y C Yᵀ - C)`;
- antipode: `X⁻¹ C (X⁻¹)ᵀ - C = -(X⁻¹ (X C Xᵀ - C) (X⁻¹)ᵀ)`.

The one genuinely new ingredient is that an `R`-algebra morphism fixes the constant form `C.map (algebraMap R T)` (an `AlgHom.commutes` step inside `relationMatrix_map`), which the previous `C = 1` proof got for free from `Matrix.map_one` and the `C = Jₘ` proof from a bespoke `hJ` step. The constant form is deliberately *not* named by a definition: it is the standard composite `C.map (algebraMap R T)`, and a wrapper for it would only block the library's own `Matrix.map_one`/`JFin_map` rewrites at the specializations and force their restatement under new names.

**The name.** `ConstantForm` is the term the merged code already uses for this generalization, and it names what is actually general here: the form is a constant, not a form varying over the base. Mathlib has no group-scheme-level name to match (its `Matrix.orthogonalGroup`/`Matrix.symplecticGroup` are matrix groups, with no affine-group-scheme theory of forms to follow), so no existing convention is departed from.

**Contents.**
- `TauCeti/Algebra/AlgebraicGroup/ConstantForm/Basic.lean` (new): `relationMatrix` with `relationMatrix_def`/`relationMatrix_map`, `relationSet` with `mem_relationSet_iff`, `definingHopfIdeal` — built with `HopfIdeal.ofSpan`, so only the three generator-level closure conditions are proved — `coordinateHopfAlgebra`, `coordinateMap` with `coordinateMap_def`/`coordinateMap_apply`/`coordinateMap_relationMatrix`, `groupScheme` (a reducible abbrev of the quotient spectrum, as the weight-subgroup files do) with `groupScheme_def`, `inclusion` with `inclusion_def` and `isClosedImmersion_inclusion`, `finiteTypeCoordinateHopfAlgebra` with `finiteTypeCoordinateHopfAlgebra_obj`, `mapPointsFunctor_coordinateMap_app`, and `mem_definingPointsSubgroup_iff` in the form `M C Mᵀ = C`. The module builds on the generic layers rather than the idioms the merged specializations hand-rolled before those layers existed: the generic matrix is `GeneralLinear.genericMatrix` (#4388) with its `isUnit_det_genericMatrix`/`genericMatrix_inv_apply` inverse API, and the scheme layer is `GeneralLinear.hopfIdealInclusion` (#4480) with its `isClosedImmersion_hopfIdealInclusion` and `locallyOfFiniteType_hopfIdealQuotientSpec` instances — `inclusion` *is* that generic immersion, the closed-immersion instance is inherited by `infer_instance`, and local finite type needs no restatement at all: the generic instance applies to the reducible `groupScheme` directly. The three morphism computations for the generic matrix (`map_counit_genericMatrix`/`map_comul_genericMatrix`/`map_antipode_genericMatrix`, following the adjacent `map_*_localizedGenericMatrix` naming), which mention no `C`, move to `GeneralLinear/Coordinate/HopfAlgebra.lean` next to `genericMatrix`, public — so the next Hopf-ideal cut of `GL n` finds them. The per-file generic-matrix copies and transport proofs the merged files carried are deleted.
- `Orthogonal/Basic.lean`: the construction becomes reducible specializations at `C = 1`; the file keeps `mem_definingPointsSubgroup_iff` (stated as membership in `Matrix.orthogonalGroup`), `toUnits_mk`, `pointsMulEquiv` and its coercion and `symm` lemmas.
- `Symplectic/Basic.lean`: the same at `C = Jₘ`, keeping the `GLSymplecticFin` identification, `pointsMulEquiv_mapValue`, and the `Fin m ⊕ Fin m` reading. Because `rw` keys on head constants, the general `*_def` lemmas cannot rewrite the named reducible specializations, so the file keeps one-line bridge restatements (`relationMatrix_def`, `coordinateMap_def`, `groupScheme_def`, `inclusion_def`, `finiteTypeCoordinateHopfAlgebra_obj`, each proved by its general counterpart); `RootSubgroup` and `BaseChange` consume them, and the four public root-subgroup presentations state `eqToHom (groupScheme_def R m)` in the symplectic name rather than leaking the `ConstantForm` instantiation.
- `Symplectic/BaseChange.lean` and `Symplectic/RootSubgroup.lean`: proofs retargeted to the general lemmas where the specialized names disappear; their statements keep the named symplectic surface through the abbrevs. Where the specialized `relationMatrix_map` had `JFin m T` built into its right-hand side, the general lemma states `C.map (algebraMap R T)` and the `@[simp]` `JFin_map` rewrite reaches the same normal form.
- `SpecialOrthogonal/Basic.lean`: two references retargeted to the general lemmas. No other consumer exists.

**What stays named, and why.** The surviving specializations are the named object's defining data and the declarations with consumers elsewhere in the repository: `relationMatrix`/`relationSet`, `definingHopfIdeal`, `coordinateHopfAlgebra`, `coordinateMap` (consumed by `Symplectic/RootSubgroup.lean` and `Symplectic/BaseChange.lean`), `groupScheme`, `inclusion`, and `finiteTypeCoordinateHopfAlgebra` (consumed by `Symplectic/BaseChange.lean`). All are `abbrev`s, so the general lemmas apply to them directly; the only restatements are the five one-line `*_def`/`_obj` bridges noted above, each with consumers. Form-agnostic lemmas live only in `ConstantForm`; the specializations restate nothing. `Orthogonal` keeps no `coordinateMap`/`finiteType` layer at all — nothing consumes one there. The previously per-file `coordinateMap_relationMatrix` now exists once, generically; the specialized `Orthogonal.definingHopfIdeal_toIdeal` and `Symplectic.definingHopfIdeal_toIdeal` are deleted, with all use sites updated here.

**Simp conventions.** `ConstantForm.mem_definingPointsSubgroup_iff` is deliberately **not** `@[simp]` while `Orthogonal`'s public restatement is: the general criterion is the stepping stone, `M ∈ orthogonalGroup` is the normal form a user wants there, and the symplectic side consumes the criterion privately inside its points identification. `coordinateMap_relationMatrix` (the quotient's elimination lemma), `mem_relationSet_iff`, `relationMatrix_map`, `definingHopfIdeal_toIdeal`, `finiteTypeCoordinateHopfAlgebra_obj`, and the three relocated `map_*_genericMatrix` lemmas (matching their `@[simp]` siblings in `MatrixMonoid` and `UpperUnitriangular`, and completing the simp chain that `relationMatrix_map` opens) are `@[simp]`. `coordinateMap_apply` is not: its left-hand side subsumes the elimination lemma's, and the raw quotient-class form is not the normal form — the named morphism is; all uses are explicit `rw`. `mapPointsFunctor_coordinateMap_app` is also not `@[simp]`: the simp-normal form of its left-hand side is the composition form that `CommHopfAlgCat.mapPointsFunctor_app_apply` (already `@[simp]`) produces; it survives as a one-line gluing consequence of `coordinateMap_def` — `CommHopfAlgCat.quotientPointsHom` is by definition the points map of the quotient morphism, so no new generic lemma is needed. The `*_def` transport lemmas (`coordinateMap_def`, `groupScheme_def`, `inclusion_def`, `relationMatrix_def`) are likewise not `@[simp]`: the named object is the normal form, and these lemmas exist to move to the quotient presentation on demand, not by default.

**Attribution.** The closure proofs are those of the merged `TauCeti.Symplectic` and `TauCeti.Orthogonal`, generalized; the declaration order and proof plan are theirs, and the new module's docstring says so. The hoisted quotient-morphism and finite-type API follows the merged symplectic form of #4698.

**Not included.** `SpecialOrthogonal` keeps its own quotient/scheme/finite-type block: it is the *determinant cut* on top of `Orthogonal`, cut by a join of Hopf ideals rather than by a constant form, so it is not a `ConstantForm` specialization. Hoisting the quotient-scheme block that `ConstantForm` and `SpecialOrthogonal` still share — parametrized by the Hopf ideal rather than by the form — is the remaining piece of the dedup and is left to a follow-up, since it touches a different generic layer. Likewise, the two points-identification sections are carried over from the merged files in their existing hand-assembled form (via `quotientPointsSubgroupNatIso`); rebasing them onto the newer generic `GeneralLinear.hopfIdealPointsSubgroupMulEquiv` layer is a separate refactor shared with `Borel` and `SpecialLinear`, which use the same idiom, and is out of this PR's single topic.

Verified locally against the Mathlib pin on `main`: `lake build` of `ConstantForm`, `Orthogonal`, `Symplectic`, `SpecialOrthogonal`, `Symplectic.BaseChange`, `Symplectic.RootSubgroup`, and `Symplectic.ChevalleyRelations` is green, a full `lake build` of the library is green, and the `#lint` environment-linter set over those modules reports only the pre-existing `simpNF` entries already in `scripts/lint-baseline.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
