### PR TITLE
feat(EllipticCurve): the tangent slope at (X, Y) and the doubling formulas

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -106,11 +106,11 @@ The nonvanishing block adapts, at the same `main` revision, `ψᵤ_ne_zero` (`:1
 source name kept) and `polyToField_ψ₂Sq` (`:154`, here `polyToField_Ψ₂Sq`: the constant in its
 conclusion is `Ψ₂Sq`, capitalised). The first two port essentially unchanged, both retracting to
 the cusp curve at `(1, 1)` through `ringEval`, where `ψₙ` reads off as `n` and `φₙ` as `1`. One
-departure beyond the `ψᵤ` respelling, and it is confined to `polyToField_Ψ₂Sq`: the source clears
-the Weierstrass polynomial by rewriting with its own `polyToField_polynomial`, which has no
-counterpart here, so the proof instead pushes the coordinate-ring identity
-`Affine.CoordinateRing.mk_ψ₂_sq` into the field of fractions, where that vanishing is already
-absorbed by the quotient.
+departure beyond the `ψᵤ` respelling, and it is confined to `polyToField_Ψ₂Sq`: the source expands
+`ψ₂_sq` and clears the Weierstrass polynomial term by hand with `polyToField_polynomial`. That
+lemma exists here too (`EllipticCurve/Universal.lean`), but this proof does not need it — Mathlib
+packages the same cancellation as the coordinate-ring identity `Affine.CoordinateRing.mk_ψ₂_sq`,
+which is what the proof pushes into the field of fractions.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -46,7 +46,8 @@ the division-polynomial expressions: `addX … = smulX 2` and `addY … = smulY 
   coordinates at `n` — the long-Weierstrass correction that `ω_neg` carries, in the universal
   field.
 * `WeierstrassCurve.Universal.Affine.smulY_sub_negY`: the vertical gap at an `n`-fold multiple is
-  `ψ₂ₙ/ψₙ⁴`, and `smulY_one_ne_negY` is its `n = 1` consequence — `(X, Y)` is not `2`-torsion.
+  `ψ₂ₙ/ψₙ⁴`, whence `smulY_ne_negY` — no nonzero multiple of `(X, Y)` is `2`-torsion — and its
+  `n = 1` case `smulY_one_ne_negY`.
 * `WeierstrassCurve.Universal.Affine.slopeOne_eq_neg_div`: the tangent slope at `(X, Y)` is
   `-Wₓ/ψ₂`, the ratio of the two partial derivatives of the Weierstrass polynomial.
 * `WeierstrassCurve.Universal.Affine.addX_smul_one_smul_one`,
@@ -83,6 +84,11 @@ The tangent-and-doubling block below adds, at the same revision, `smulY_sub_negY
 `smulY_one_sub_negY` (`:233`), `smulY_one_ne_negY` (`:237`), `slopeOne` (`:241`),
 `slopeOne_eq_neg_div` (`:244`), `addX_smul_one_smul_one` (`:261`) and `addY_smul_one_smul_one`
 (`:277`), with the same `ψᵤ` respelling and one added equation lemma, `slopeOne_def`.
+
+One statement is generalised rather than transcribed. The source proves only `smulY_one_ne_negY`
+(`:237`); here `smulY_ne_negY` states it for every `n ≠ 0`, which `smulY_sub_negY` already gives —
+the gap `ψ₂ₙ/ψₙ⁴` is a quotient of nonzero elements — and the source's statement is recovered as
+the `n = 1` case.
 
 None of the source's four private field-level auxiliaries in that range is ported, because none
 of them has a consumer left here.
@@ -258,12 +264,18 @@ lemma smulY_one_sub_negY :
     smulY 1 - pointedCurve.toAffine.negY (smulX 1) (smulY 1) = polyToField (curve.ψ 2) := by
   rw [smulY_sub_negY one_ne_zero, mul_one, ψ_one, map_one, one_pow, div_one]
 
-/-- **The distinguished point is not `2`-torsion.** `(X, Y)` differs from its own negative,
-because the gap between them is `ψ₂`, which is nonzero in the universal field. This is the side
-condition that selects the tangent branch of `Affine.slope` in `slopeOne_eq_neg_div`. -/
-lemma smulY_one_ne_negY : smulY 1 ≠ pointedCurve.toAffine.negY (smulX 1) (smulY 1) := by
-  rw [← sub_ne_zero, smulY_one_sub_negY]
-  exact polyToField_ψ_ne_zero two_ne_zero
+/-- **No nonzero multiple of the distinguished point is `2`-torsion.** The gap computed above is
+`ψ₂ₙ/ψₙ⁴`, a quotient of nonzero elements, so it never vanishes. -/
+lemma smulY_ne_negY (h0 : n ≠ 0) :
+    smulY n ≠ pointedCurve.toAffine.negY (smulX n) (smulY n) := by
+  rw [← sub_ne_zero, smulY_sub_negY h0]
+  exact div_ne_zero (polyToField_ψ_ne_zero (by omega))
+    (pow_ne_zero _ (polyToField_ψ_ne_zero h0))
+
+/-- **The distinguished point itself is not `2`-torsion**, the case of `smulY_ne_negY` that
+selects the tangent branch of `Affine.slope` in `slopeOne_eq_neg_div`. -/
+lemma smulY_one_ne_negY : smulY 1 ≠ pointedCurve.toAffine.negY (smulX 1) (smulY 1) :=
+  smulY_ne_negY one_ne_zero
 
 open scoped Classical in
 /-- The slope of the tangent line to `pointedCurve` at its distinguished point `(X, Y)`: Mathlib's

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -20,10 +20,18 @@ nonvanishing, the difference `smulX m - smulX n` as a single quotient, and the s
 statement `smulX m = smulX n ↔ m = n ∨ m = -n`. `smulY`'s own sign rule is here too: negating
 a nonzero index negates the point, so `smulY (-n)` is the `negY` of `(smulX n, smulY n)`.
 
+The second half of the file turns that calculus on the point `(X, Y)` itself. The vertical gap
+`smulY n - negY (smulX n) (smulY n)` is `ψ₂ₙ/ψₙ⁴`, hence nonzero, so no multiple of the
+distinguished point is `2`-torsion; at `n = 1` the gap is `ψ₂`, which selects the tangent branch of
+Mathlib's `Affine.slope` and gives the tangent slope `slopeOne` the closed form `-Wₓ/ψ₂`. Feeding
+that slope to Mathlib's affine addition formula doubles the point, and both coordinates come out as
+the division-polynomial expressions: `addX … = smulX 2` and `addY … = smulY 2`.
+
 ## Main definitions
 
 * `WeierstrassCurve.Universal.Affine.smulX`: the rational function `φₙ/ψₙ²`.
 * `WeierstrassCurve.Universal.Affine.smulY`: the rational function `ωₙ/ψₙ³`.
+* `WeierstrassCurve.Universal.Affine.slopeOne`: the slope of the tangent at `(X, Y)`.
 
 ## Main results
 
@@ -37,6 +45,13 @@ a nonzero index negates the point, so `smulY (-n)` is the `negY` of `(smulX n, s
 * `WeierstrassCurve.Universal.Affine.smulY_neg`: for `n ≠ 0`, `smulY (-n)` is the `negY` of the
   coordinates at `n` — the long-Weierstrass correction that `ω_neg` carries, in the universal
   field.
+* `WeierstrassCurve.Universal.Affine.smulY_sub_negY`: the vertical gap at an `n`-fold multiple is
+  `ψ₂ₙ/ψₙ⁴`, and `smulY_one_ne_negY` is its `n = 1` consequence — `(X, Y)` is not `2`-torsion.
+* `WeierstrassCurve.Universal.Affine.slopeOne_eq_neg_div`: the tangent slope at `(X, Y)` is
+  `-Wₓ/ψ₂`, the ratio of the two partial derivatives of the Weierstrass polynomial.
+* `WeierstrassCurve.Universal.Affine.addX_smul_one_smul_one`,
+  `.addY_smul_one_smul_one`: doubling `(X, Y)` along that tangent with Mathlib's affine addition
+  formula returns `(smulX 2, smulY 2)` — the base case of the scalar-multiplication induction.
 
 ## Provenance
 
@@ -64,8 +79,41 @@ maps a polynomial-level identity with `congrArg polyToField` and clears the deno
 `field_simp` and `linear_combination`. Finally `@[simp]` is added to `smulX_neg`, `smulY_neg`,
 `smulX_ne_zero` and `smulX_eq_smulX_iff`; the source tags only the four value lemmas.
 
-`smulX_sub_sub_smulX_add` (`:196`) is deliberately not ported here: its consumers are the slope
-and addition formulas, and it ships with them.
+The tangent-and-doubling block below adds, at the same revision, `smulY_sub_negY` (`:227`),
+`smulY_one_sub_negY` (`:233`), `smulY_one_ne_negY` (`:237`), `slopeOne` (`:241`),
+`slopeOne_eq_neg_div` (`:244`), `addX_smul_one_smul_one` (`:261`) and `addY_smul_one_smul_one`
+(`:277`), with the same `ψᵤ` respelling and one added equation lemma, `slopeOne_def`.
+
+None of the source's four private field-level auxiliaries in that range is ported, because none
+of them has a consumer left here.
+
+* `smulY_sub_negY_aux` (`:222`) is not needed: `smulY_sub_negY` runs through this file's own
+  `smulY_neg` — negating the index negates the point — which already reads its coordinate identity
+  off Mathlib's `Jacobian.negY_of_Z_ne_zero`. What is left is `ω_neg`, `ω_spec` and `ψ_mul_ψc`,
+  with no field-level algebra to package.
+* `addX_smul_one_smul_one_aux` (`:252`) has no call site **in the source either**: at
+  `1c1c7466` the name occurs exactly once repo-wide per copy, its own definition.
+* `addX_smul_ring_identity` (`:257`) and `addY_smul_one_smul_one_aux` (`:271`) each package the
+  residue of one `field_simp` in the source's normal form. Both residues differ here, and
+  `linear_combination` against the mapped certificate, respectively `ring`, closes each in a line.
+
+Two further departures. Mathlib's `Affine.slope` is defined by cases and `Universal.Field` carries
+no `DecidableEq`; the source supplies one with a namespace-wide
+`attribute [local instance] Classical.propDecidable`, narrowed here to `open scoped Classical in`
+on `slopeOne` and `slopeOne_def`, the only two declarations whose statements mention `slope`.
+And the map-direction problem recorded above for `smulX_eq` recurs at every proof in the block.
+Measured against the `unusedSimpArgs` linter at this pin: bare `map_sub` and `map_neg` fire at no
+site, while bare `map_mul`, `map_add`, `map_pow` and `map_ofNat` fire at all of them — the
+unexposed instances are `Sub` and `Neg`. Each `map_*` names its hom regardless, for uniformity
+with the rest of the file. Naming alone is not enough in the last three proofs, which state their
+polynomial-level certificate as a `have` and map it with `congrArg polyToField`, the shape
+`smulX_eq` uses: `polyToField_apply` is `@[simp]` here, so `field_simp` shatters
+`polyToField (C X)` into `algebraMap _ _ (AdjoinRoot.of _ X)` while leaving
+`polyToField curve.polynomialX` folded, and the two sides of the goal then share no atoms.
+
+`smulX_sub_sub_smulX_add` (`:196`) is still deliberately not ported: its only consumer at the pin
+is `smulX_add` (`:300`), the addition formula for two distinct multiples, which ships with a later
+slice.
 -/
 
 public section
@@ -183,5 +231,108 @@ lemma smulX_ne_smulX (ne : m ≠ n) (ne_neg : m ≠ -n) : smulX m ≠ smulX n :=
     exact smulX_ne_smulX h.1 h.2
   · rintro (rfl | rfl)
     exacts [rfl, smulX_neg]
+
+/-- **The vertical gap at an `n`-fold multiple is `ψ₂ₙ/ψₙ⁴`**: the amount by which `smulY n`
+exceeds the `Y`-coordinate of the negated point. Being a quotient of nonzero `ψ`'s it never
+vanishes, which is what puts every such point in the tangent branch of `Affine.slope`.
+
+The proof reads the negated coordinate off `smulY_neg` — negating the index is negating the point —
+so that the gap becomes `smulY n - smulY (-n)`; `ω_neg` turns its numerator into
+`2ωₙ + a₁φₙψₙ + a₃ψₙ³`, which `ω_spec` names `ψc n` and `ψ_mul_ψc` divides into `ψ₂ₙ/ψₙ`. -/
+lemma smulY_sub_negY (h0 : n ≠ 0) :
+    smulY n - pointedCurve.toAffine.negY (smulX n) (smulY n) =
+      polyToField (curve.ψ (2 * n)) / polyToField (curve.ψ n) ^ 4 := by
+  have hψ : polyToField (curve.ψ n) ≠ 0 := polyToField_ψ_ne_zero h0
+  have h : curve.ψ n * (2 * curve.ω n + CC curve.a₁ * curve.φ n * curve.ψ n
+      + CC curve.a₃ * curve.ψ n ^ 3) = curve.ψ (2 * n) := by rw [ω_spec, ψ_mul_ψc]
+  have hF := congrArg polyToField h
+  simp only [map_mul polyToField, map_add polyToField, map_pow polyToField, map_ofNat] at hF
+  rw [← smulY_neg h0, smulY_def, smulY_def, ψ_neg, ω_neg]
+  simp only [map_add polyToField, map_mul polyToField, map_pow polyToField, map_neg polyToField]
+  field_simp
+  linear_combination hF
+
+/-- The gap at the distinguished point itself is `ψ₂`: at `n = 1` the numerator `ψ₂ₙ` is `ψ₂` and
+the denominator `ψₙ⁴` is `1`. -/
+lemma smulY_one_sub_negY :
+    smulY 1 - pointedCurve.toAffine.negY (smulX 1) (smulY 1) = polyToField (curve.ψ 2) := by
+  rw [smulY_sub_negY one_ne_zero, mul_one, ψ_one, map_one, one_pow, div_one]
+
+/-- **The distinguished point is not `2`-torsion.** `(X, Y)` differs from its own negative,
+because the gap between them is `ψ₂`, which is nonzero in the universal field. This is the side
+condition that selects the tangent branch of `Affine.slope` in `slopeOne_eq_neg_div`. -/
+lemma smulY_one_ne_negY : smulY 1 ≠ pointedCurve.toAffine.negY (smulX 1) (smulY 1) := by
+  rw [← sub_ne_zero, smulY_one_sub_negY]
+  exact polyToField_ψ_ne_zero two_ne_zero
+
+open scoped Classical in
+/-- The slope of the tangent line to `pointedCurve` at its distinguished point `(X, Y)`: Mathlib's
+`Affine.slope` at the coincident pair `(X, Y), (X, Y)`. `Universal.Field` carries no `DecidableEq`
+instance and `Affine.slope` is defined by cases, hence the classical one. -/
+def slopeOne : Universal.Field :=
+  pointedCurve.toAffine.slope (smulX 1) (smulX 1) (smulY 1) (smulY 1)
+
+open scoped Classical in
+/-- The defining formula for `slopeOne`. The definition body is not exposed, so this equation
+lemma is how a consumer in another module computes with it. -/
+theorem slopeOne_def :
+    slopeOne = pointedCurve.toAffine.slope (smulX 1) (smulX 1) (smulY 1) (smulY 1) := (rfl)
+
+/-- **The tangent slope in closed form**: `-Wₓ/ψ₂`, the two partial derivatives of the Weierstrass
+polynomial at `(X, Y)`. `smulY_one_ne_negY` puts `Affine.slope` in its tangent branch, whose
+denominator `smulY 1 - negY …` is `ψ₂` by `smulY_one_sub_negY`; the numerator is then `polynomialX`
+read backwards. -/
+lemma slopeOne_eq_neg_div :
+    slopeOne = -polyToField curve.polynomialX / polyToField (curve.ψ 2) := by
+  have h : curve.polynomialX
+      = CC curve.a₁ * Y - (3 * C X ^ 2 + 2 * CC curve.a₂ * C X + CC curve.a₄) := by
+    simp_rw [Affine.polynomialX, CC]
+    simp only [map_ofNat, C_add, C_mul, C_pow]
+  rw [slopeOne_def, Affine.slope_of_Y_ne rfl smulY_one_ne_negY, smulY_one_sub_negY, h,
+    smulX_one, smulY_one, pointedCurve_a₁, pointedCurve_a₂, pointedCurve_a₄]
+  simp only [map_add polyToField, map_sub polyToField, map_mul polyToField,
+    map_pow polyToField, map_ofNat]
+  ring
+
+/-- **Doubling the distinguished point, `X`-coordinate.** Mathlib's affine addition formula, run
+on `(X, Y)` against itself along the tangent `slopeOne`, returns `smulX 2`.
+
+The certificate is `C_Ψ₃`, which expresses `Ψ₃` through the partial derivatives of the Weierstrass
+polynomial: pushed into the universal field, `Ψ₂Sq` becomes `ψ₂²` (`polyToField_Ψ₂Sq`) and the
+Weierstrass polynomial itself vanishes (`polyToField_polynomial`), leaving exactly the numerator
+identity that clearing `ψ₂²` out of `addX` demands. -/
+lemma addX_smul_one_smul_one :
+    pointedCurve.toAffine.addX (smulX 1) (smulX 1) slopeOne = smulX 2 := by
+  have hψ₂ : polyToField (curve.ψ 2) ≠ 0 := polyToField_ψ_ne_zero two_ne_zero
+  have hF := congrArg polyToField (C_Ψ₃ curve)
+  simp only [map_sub polyToField, map_add polyToField, map_mul polyToField, map_pow polyToField,
+    map_ofNat, polyToField_Ψ₂Sq, polyToField_polynomial, mul_zero, ← ψ_three, ← ψ_two] at hF
+  rw [Affine.addX, slopeOne_eq_neg_div, smulX_two, smulX_one, pointedCurve_a₁, pointedCurve_a₂]
+  field_simp
+  linear_combination hF
+
+/-- **Doubling the distinguished point, `Y`-coordinate.** The same formula returns `smulY 2`,
+which is what identifies `(smulX 2, smulY 2)` as `2 • (X, Y)`.
+
+Here the certificate is `ω_def` at `2`: the reduced-invariant denominator is `1` and the
+complement's auxiliary term `0` (`reducedInvarDenom_two`, `complEDS₂Aux_two`), the multiples of
+the Weierstrass polynomial vanish in the field, `polynomialY` is `ψ₂` and `C Ψ₃` is `ψ₃`, so `ω₂`
+becomes `(a₁ψ₂ - Wₓ)ψ₃ + (-Y - a₁X - a₃)ψ₂³` — the numerator `addY` produces over `ψ₂³`. -/
+lemma addY_smul_one_smul_one :
+    pointedCurve.toAffine.addY (smulX 1) (smulX 1) (smulY 1) slopeOne = smulY 2 := by
+  have hψ₂ : polyToField (curve.ψ 2) ≠ 0 := polyToField_ψ_ne_zero two_ne_zero
+  have hY : Affine.polynomialY curve = curve.ψ 2 := by rw [ψ_two, ψ₂]
+  have hneg : Affine.negPolynomial curve
+      = -(Y : Poly) - (CC curve.a₁ * C X + CC curve.a₃) := by
+    rw [Affine.negPolynomial]
+    simp only [C_add, C_mul]
+  have hF := congrArg polyToField (ω_def curve 2)
+  simp only [reducedInvarDenom_two, complEDS₂Aux_two, one_mul, sub_zero, hY, hneg, ← ψ_three,
+    map_add polyToField, map_sub polyToField, map_mul polyToField, map_pow polyToField,
+    map_neg polyToField, map_ofNat, polyToField_polynomial, mul_zero, zero_mul, add_zero] at hF
+  rw [Affine.addY, Affine.negAddY, addX_smul_one_smul_one, smulY_one, smulX_two, smulX_one,
+    slopeOne_eq_neg_div, Affine.negY, pointedCurve_a₁, pointedCurve_a₃, smulY_def 2, hF]
+  field_simp
+  ring
 
 end WeierstrassCurve.Universal.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -240,11 +240,10 @@ lemma smulX_ne_smulX (ne : m ≠ n) (ne_neg : m ≠ -n) : smulX m ≠ smulX n :=
 
 /-- **The gap between `smulY n` and the `negY` of its own pair is `ψ₂ₙ/ψₙ⁴`.** Being a quotient of
 nonzero `ψ`'s it never vanishes, which is what puts the pair `(smulX n, smulY n)` in the tangent
-branch of `Affine.slope`.
-
-The proof reads the negated coordinate off `smulY_neg` — negating the index is negating the point —
-so that the gap becomes `smulY n - smulY (-n)`; `ω_neg` turns its numerator into
-`2ωₙ + a₁φₙψₙ + a₃ψₙ³`, which `ω_spec` names `ψc n` and `ψ_mul_ψc` divides into `ψ₂ₙ/ψₙ`. -/
+branch of `Affine.slope`. -/
+-- The proof reads the negated coordinate off `smulY_neg`, so the gap becomes
+-- `smulY n - smulY (-n)`; `ω_neg` turns the numerator into `2ωₙ + a₁φₙψₙ + a₃ψₙ³`, which
+-- `ω_spec` names `ψc n` and `ψ_mul_ψc` divides into `ψ₂ₙ/ψₙ`.
 lemma smulY_sub_negY (h0 : n ≠ 0) :
     smulY n - pointedCurve.toAffine.negY (smulX n) (smulY n) =
       polyToField (curve.ψ (2 * n)) / polyToField (curve.ψ n) ^ 4 := by
@@ -290,10 +289,8 @@ lemma is how a consumer in another module computes with it. -/
 theorem slopeOne_def :
     slopeOne = pointedCurve.toAffine.slope (smulX 1) (smulX 1) (smulY 1) (smulY 1) := (rfl)
 
-/-- **The tangent slope in closed form**: `-Wₓ/ψ₂`, the two partial derivatives of the Weierstrass
-polynomial at `(X, Y)`. `smulY_one_ne_negY` puts `Affine.slope` in its tangent branch, whose
-denominator `smulY 1 - negY …` is `ψ₂` by `smulY_one_sub_negY`; the numerator is then `polynomialX`
-read backwards. -/
+/-- **The tangent slope in closed form**: `-Wₓ/ψ₂`, the ratio of the two partial derivatives of
+the Weierstrass polynomial at `(X, Y)`. -/
 lemma slopeOne_eq_neg_div :
     slopeOne = -polyToField curve.polynomialX / polyToField (curve.ψ 2) := by
   have h : curve.polynomialX
@@ -307,12 +304,10 @@ lemma slopeOne_eq_neg_div :
   ring
 
 /-- **Mathlib's `addX` at `(smulX 1, smulX 1)` along the tangent slope is `smulX 2`.** The affine
-addition formula run on the distinguished point against itself lands on the value at `2`.
-
-The certificate is `C_Ψ₃`, which expresses `Ψ₃` through the partial derivatives of the Weierstrass
-polynomial: pushed into the universal field, `Ψ₂Sq` becomes `ψ₂²` (`polyToField_Ψ₂Sq`) and the
-Weierstrass polynomial itself vanishes (`polyToField_polynomial`), leaving exactly the numerator
-identity that clearing `ψ₂²` out of `addX` demands. -/
+addition formula run on the distinguished point against itself lands on the value at `2`. -/
+-- The certificate is `C_Ψ₃`, expressing `Ψ₃` through the partial derivatives: in the universal
+-- field `Ψ₂Sq` becomes `ψ₂²` and the Weierstrass polynomial vanishes, leaving the numerator
+-- identity that clearing `ψ₂²` out of `addX` demands.
 lemma addX_smul_one_smul_one :
     pointedCurve.toAffine.addX (smulX 1) (smulX 1) slopeOne = smulX 2 := by
   have hψ₂ : polyToField (curve.ψ 2) ≠ 0 := polyToField_ψ_ne_zero two_ne_zero
@@ -325,12 +320,10 @@ lemma addX_smul_one_smul_one :
 
 /-- **The same for `addY`: it returns `smulY 2`.** Together with the previous lemma this is the
 doubling step the later identification of `n • (X, Y)` runs through — that identification itself
-is proved in the scalar-multiplication development, not here.
-
-Here the certificate is `ω_def` at `2`: the reduced-invariant denominator is `1` and the
-complement's auxiliary term `0` (`reducedInvarDenom_two`, `complEDS₂Aux_two`), the multiples of
-the Weierstrass polynomial vanish in the field, `polynomialY` is `ψ₂` and `C Ψ₃` is `ψ₃`, so `ω₂`
-becomes `(a₁ψ₂ - Wₓ)ψ₃ + (-Y - a₁X - a₃)ψ₂³` — the numerator `addY` produces over `ψ₂³`. -/
+is proved in the scalar-multiplication development, not here. -/
+-- The certificate is `ω_def` at `2`: the reduced-invariant denominator is `1` and the
+-- complement's auxiliary term `0`, the multiples of the Weierstrass polynomial vanish,
+-- `polynomialY` is `ψ₂` and `C Ψ₃` is `ψ₃`, giving the numerator `addY` produces over `ψ₂³`.
 lemma addY_smul_one_smul_one :
     pointedCurve.toAffine.addY (smulX 1) (smulX 1) (smulY 1) slopeOne = smulY 2 := by
   have hψ₂ : polyToField (curve.ψ 2) ≠ 0 := polyToField_ψ_ne_zero two_ne_zero

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -20,12 +20,12 @@ nonvanishing, the difference `smulX m - smulX n` as a single quotient, and the s
 statement `smulX m = smulX n ↔ m = n ∨ m = -n`. `smulY`'s own sign rule is here too: negating
 a nonzero index negates the point, so `smulY (-n)` is the `negY` of `(smulX n, smulY n)`.
 
-The second half of the file turns that calculus on the point `(X, Y)` itself. The vertical gap
-`smulY n - negY (smulX n) (smulY n)` is `ψ₂ₙ/ψₙ⁴`, hence nonzero, so no multiple of the
-distinguished point is `2`-torsion; at `n = 1` the gap is `ψ₂`, which selects the tangent branch of
-Mathlib's `Affine.slope` and gives the tangent slope `slopeOne` the closed form `-Wₓ/ψ₂`. Feeding
-that slope to Mathlib's affine addition formula doubles the point, and both coordinates come out as
-the division-polynomial expressions: `addX … = smulX 2` and `addY … = smulY 2`.
+The second half of the file turns that calculus on the pair `(smulX 1, smulY 1)`, which is the
+distinguished point `(X, Y)` itself. The vertical gap `smulY n - negY (smulX n) (smulY n)` is
+`ψ₂ₙ/ψₙ⁴`, hence nonzero, so `smulY n` never equals the `negY` of its own pair; at `n = 1` the gap
+is `ψ₂`, which selects the tangent branch of Mathlib's `Affine.slope` and gives the tangent slope
+`slopeOne` the closed form `-Wₓ/ψ₂`. Feeding that slope to Mathlib's affine addition formula sends
+`(smulX 1, smulY 1)` to `(smulX 2, smulY 2)`: `addX … = smulX 2` and `addY … = smulY 2`.
 
 ## Main definitions
 
@@ -45,9 +45,9 @@ the division-polynomial expressions: `addX … = smulX 2` and `addY … = smulY 
 * `WeierstrassCurve.Universal.Affine.smulY_neg`: for `n ≠ 0`, `smulY (-n)` is the `negY` of the
   coordinates at `n` — the long-Weierstrass correction that `ω_neg` carries, in the universal
   field.
-* `WeierstrassCurve.Universal.Affine.smulY_sub_negY`: the vertical gap at an `n`-fold multiple is
-  `ψ₂ₙ/ψₙ⁴`, whence `smulY_ne_negY` — no nonzero multiple of `(X, Y)` is `2`-torsion — and its
-  `n = 1` case `smulY_one_ne_negY`.
+* `WeierstrassCurve.Universal.Affine.smulY_sub_negY`: the gap `smulY n - negY (smulX n) (smulY n)`
+  is `ψ₂ₙ/ψₙ⁴`, whence `smulY_ne_negY` — the gap never vanishes for `n ≠ 0` — and its `n = 1` case
+  `smulY_one_ne_negY`.
 * `WeierstrassCurve.Universal.Affine.slopeOne_eq_neg_div`: the tangent slope at `(X, Y)` is
   `-Wₓ/ψ₂`, the ratio of the two partial derivatives of the Weierstrass polynomial.
 * `WeierstrassCurve.Universal.Affine.addX_smul_one_smul_one`,
@@ -188,7 +188,7 @@ lemma smulX_two : smulX 2 = smulX 1 - polyToField (curve.ψ 3) / polyToField (cu
 lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
     smulX m - smulX n = polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m)) /
       (polyToField (curve.ψ n) * polyToField (curve.ψ m)) ^ 2 := by
-  have key := isEllipticSequence_polyToField_ψ n m 1
+  have key := isEllipticNet_polyToField_ψ n m 1 0
   simp only [IsEllipticNet.rel, add_zero, ψ_one, map_one, mul_one] at key
   rw [smulX_eq hm, smulX_eq hn, sub_sub_sub_cancel_left,
     div_sub_div _ _ (pow_ne_zero 2 (polyToField_ψ_ne_zero hn))
@@ -238,9 +238,9 @@ lemma smulX_ne_smulX (ne : m ≠ n) (ne_neg : m ≠ -n) : smulX m ≠ smulX n :=
   · rintro (rfl | rfl)
     exacts [rfl, smulX_neg]
 
-/-- **The vertical gap at an `n`-fold multiple is `ψ₂ₙ/ψₙ⁴`**: the amount by which `smulY n`
-exceeds the `Y`-coordinate of the negated point. Being a quotient of nonzero `ψ`'s it never
-vanishes, which is what puts every such point in the tangent branch of `Affine.slope`.
+/-- **The gap between `smulY n` and the `negY` of its own pair is `ψ₂ₙ/ψₙ⁴`.** Being a quotient of
+nonzero `ψ`'s it never vanishes, which is what puts the pair `(smulX n, smulY n)` in the tangent
+branch of `Affine.slope`.
 
 The proof reads the negated coordinate off `smulY_neg` — negating the index is negating the point —
 so that the gap becomes `smulY n - smulY (-n)`; `ω_neg` turns its numerator into
@@ -264,16 +264,16 @@ lemma smulY_one_sub_negY :
     smulY 1 - pointedCurve.toAffine.negY (smulX 1) (smulY 1) = polyToField (curve.ψ 2) := by
   rw [smulY_sub_negY one_ne_zero, mul_one, ψ_one, map_one, one_pow, div_one]
 
-/-- **No nonzero multiple of the distinguished point is `2`-torsion.** The gap computed above is
-`ψ₂ₙ/ψₙ⁴`, a quotient of nonzero elements, so it never vanishes. -/
+/-- **`smulY n` never equals the `negY` of its own pair, for `n ≠ 0`.** The gap computed above is
+`ψ₂ₙ/ψₙ⁴`, a quotient of nonzero elements. -/
 lemma smulY_ne_negY (h0 : n ≠ 0) :
     smulY n ≠ pointedCurve.toAffine.negY (smulX n) (smulY n) := by
   rw [← sub_ne_zero, smulY_sub_negY h0]
   exact div_ne_zero (polyToField_ψ_ne_zero (by omega))
     (pow_ne_zero _ (polyToField_ψ_ne_zero h0))
 
-/-- **The distinguished point itself is not `2`-torsion**, the case of `smulY_ne_negY` that
-selects the tangent branch of `Affine.slope` in `slopeOne_eq_neg_div`. -/
+/-- **The `n = 1` case**, at the distinguished point itself: this is what selects the tangent
+branch of `Affine.slope` in `slopeOne_eq_neg_div`. -/
 lemma smulY_one_ne_negY : smulY 1 ≠ pointedCurve.toAffine.negY (smulX 1) (smulY 1) :=
   smulY_ne_negY one_ne_zero
 
@@ -306,8 +306,8 @@ lemma slopeOne_eq_neg_div :
     map_pow polyToField, map_ofNat]
   ring
 
-/-- **Doubling the distinguished point, `X`-coordinate.** Mathlib's affine addition formula, run
-on `(X, Y)` against itself along the tangent `slopeOne`, returns `smulX 2`.
+/-- **Mathlib's `addX` at `(smulX 1, smulX 1)` along the tangent slope is `smulX 2`.** The affine
+addition formula run on the distinguished point against itself lands on the value at `2`.
 
 The certificate is `C_Ψ₃`, which expresses `Ψ₃` through the partial derivatives of the Weierstrass
 polynomial: pushed into the universal field, `Ψ₂Sq` becomes `ψ₂²` (`polyToField_Ψ₂Sq`) and the
@@ -323,8 +323,9 @@ lemma addX_smul_one_smul_one :
   field_simp
   linear_combination hF
 
-/-- **Doubling the distinguished point, `Y`-coordinate.** The same formula returns `smulY 2`,
-which is what identifies `(smulX 2, smulY 2)` as `2 • (X, Y)`.
+/-- **The same for `addY`: it returns `smulY 2`.** Together with the previous lemma this is the
+doubling step the later identification of `n • (X, Y)` runs through — that identification itself
+is proved in the scalar-multiplication development, not here.
 
 Here the certificate is `ω_def` at `2`: the reduced-invariant denominator is `1` and the
 complement's auxiliary term `0` (`reducedInvarDenom_two`, `complEDS₂Aux_two`), the multiples of

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -188,7 +188,7 @@ lemma smulX_two : smulX 2 = smulX 1 - polyToField (curve.ψ 3) / polyToField (cu
 lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
     smulX m - smulX n = polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m)) /
       (polyToField (curve.ψ n) * polyToField (curve.ψ m)) ^ 2 := by
-  have key := isEllipticNet_polyToField_ψ n m 1 0
+  have key := isEllipticSequence_polyToField_ψ n m 1
   simp only [IsEllipticNet.rel, add_zero, ψ_one, map_one, mul_one] at key
   rw [smulX_eq hm, smulX_eq hn, sub_sub_sub_cancel_left,
     div_sub_div _ _ (pow_ne_zero 2 (polyToField_ψ_ne_zero hn))

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
@@ -34,6 +34,8 @@ polynomial) with distinguished point `(X,Y)`.
 
 ## Main results
 
+* `WeierstrassCurve.Universal.polyToField_polynomial`: the Weierstrass polynomial vanishes in the
+  universal field — the relation `Universal.Ring` is the quotient by.
 * `WeierstrassCurve.Universal.equation_point`: `(X,Y)` satisfies the affine Weierstrass equation
   of `pointedCurve` — the universal curve really is pointed.
 * `WeierstrassCurve.map_specialize`: every Weierstrass curve is a specialization of the universal
@@ -110,6 +112,16 @@ would do. The section is a plain `public section` for the reason spelled out in
 would publish every proof body to make a handful of `rfl`s go through. And `equation_point` opens
 with `change` where the source has `show`, that step rewriting the goal rather than only naming it
 (`linter.style.show`).
+
+`polyToField_polynomial` is the source's declaration of that name (its `:120`), and the last of
+this file's declarations to arrive; `equation_point`, which the source also routes through it,
+does so here too. One difference: upstream it is `@[simp]`, and here it must not be. `simp` can
+already prove the statement, because this file's `polyToField_apply` is `@[simp]` where the
+source's is not, and the tag therefore fails `scripts/lint-env.sh` with a fresh
+`simpNF` violation (*"simp can prove this: by simp only [\*, polyToField_apply, AdjoinRoot.mk_self,
+map_zero]"*). Untagged, that run reports no new violations. Being redundant for `simp` does not
+make the name redundant: three proofs cite it by name, `equation_point` here and the two doubling
+formulas in `DivisionPolynomial/ZSMul.lean`.
 -/
 
 public section
@@ -192,6 +204,15 @@ the fraction field. -/
 lemma polyToField_apply (p : Poly) :
     polyToField p = algebraMap Universal.Ring _ (AdjoinRoot.mk _ p) := (rfl)
 
+/-- **The Weierstrass polynomial vanishes in the universal field.** It is exactly the element
+`Universal.Ring` quotients out, so `polyToField` kills it — which is how an identity over
+`pointedCurve` discards the multiples of `curve.polynomial` that clearing denominators throws up.
+
+Not `@[simp]`, unlike upstream: `polyToField_apply` is `@[simp]` here, so `simp` already reaches
+`0` on its own and simpNF rejects the tag as redundant. -/
+lemma polyToField_polynomial : polyToField curve.polynomial = 0 := by
+  rw [polyToField_apply, AdjoinRoot.mk_self, map_zero]
+
 /-- The structure map of `Universal.Field` over the coefficient ring factors through `Poly`: the
 coefficients `A₁,⋯,A₆` reach the universal field by the same route as `X` and `Y` do. Rewriting
 with this turns a statement about `algebraMap` into one about `polyToField`. -/
@@ -252,9 +273,8 @@ lemma equation_point : pointedCurve.toAffine.Equation (polyToField (C X)) (polyT
   have : ∀ p, evalEval (polyToField (C X)) (polyToField Y)
       (p.map (mapRingHom (algebraMap _ Universal.Field))) = polyToField p :=
     fun p ↦ congr($h p)
-  -- The Weierstrass polynomial vanishes at `(X, Y)`: it is exactly what was quotiented out, so
-  -- `AdjoinRoot.mk_self` closes the goal through `polyToField_apply`.
-  rw [Affine.map_polynomial, this, polyToField_apply, AdjoinRoot.mk_self, map_zero]
+  -- The Weierstrass polynomial vanishes at `(X, Y)`: it is exactly what was quotiented out.
+  rw [Affine.map_polynomial, this, polyToField_polynomial]
 
 open Polynomial Affine in
 /-- The distinguished point on the universal pointed Weierstrass curve. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
@@ -206,10 +206,9 @@ lemma polyToField_apply (p : Poly) :
 
 /-- **The Weierstrass polynomial vanishes in the universal field.** It is exactly the element
 `Universal.Ring` quotients out, so `polyToField` kills it — which is how an identity over
-`pointedCurve` discards the multiples of `curve.polynomial` that clearing denominators throws up.
-
-Not `@[simp]`, unlike upstream: `polyToField_apply` is `@[simp]` here, so `simp` already reaches
-`0` on its own and simpNF rejects the tag as redundant. -/
+`pointedCurve` discards the multiples of `curve.polynomial` that clearing denominators throws up. -/
+-- Not `@[simp]`, unlike upstream: `polyToField_apply` is `@[simp]` here, so `simp` already reaches
+-- `0` on its own and a full-library `lint-env` run rejects the tag as a simpNF duplicate.
 lemma polyToField_polynomial : polyToField curve.polynomial = 0 := by
   rw [polyToField_apply, AdjoinRoot.mk_self, map_zero]
 


### PR DESCRIPTION
> Rebased onto current `main` after #3987 merged; the diff is the slopes block appended to
> `ZSMul.lean`, plus one lemma and two docstring corrections.

The tangent slope at the universal curve's distinguished point, and the doubling formulas.

```lean
lemma smulY_sub_negY (h0 : n ≠ 0) :
    smulY n - pointedCurve.toAffine.negY (smulX n) (smulY n) =
      polyToField (curve.ψ (2 * n)) / polyToField (curve.ψ n) ^ 4
lemma smulY_one_ne_negY : smulY 1 ≠ pointedCurve.toAffine.negY (smulX 1) (smulY 1)
def slopeOne : Universal.Field                       -- the tangent slope at (X, Y)
lemma slopeOne_eq_neg_div : slopeOne = -polyToField curve.polynomialX / polyToField (curve.ψ 2)
lemma addX_smul_one_smul_one : pointedCurve.toAffine.addX (smulX 1) (smulX 1) slopeOne = smulX 2
lemma addY_smul_one_smul_one :
    pointedCurve.toAffine.addY (smulX 1) (smulX 1) (smulY 1) slopeOne = smulY 2
```

plus `smulY_one_sub_negY` and the equation lemma `slopeOne_def`.

## What it closes

#3987 gave the coordinates `smulX`/`smulY` and the `smulX` calculus. This adds the geometry: the
vertical gap `smulY n - negY …` as `ψ₂ₙ/ψₙ⁴`, its value `ψ₂` at the distinguished point (hence that
point is not 2-torsion), the tangent slope in closed form `-Wₓ/ψ₂`, and the two one-one addition
formulas identifying Mathlib's `addX`/`addY` at `(X, Y)` with the coordinates at `2`. Those two are
what a scalar-multiplication induction consumes at its doubling step.

## `polyToField_polynomial`, and why it is not `@[simp]`

Added to `EllipticCurve/Universal.lean` beside `polyToField_apply`:

```lean
lemma polyToField_polynomial : polyToField curve.polynomial = 0 := by
  rw [polyToField_apply, AdjoinRoot.mk_self, map_zero]
```

**Deliberately untagged, unlike the source, and the evidence is a full-library `lint-env` diff.**
With `@[simp]` the run reports exactly one new violation:

```
[simpNF] #check WeierstrassCurve.Universal.polyToField_polynomial /- simp can prove this:
  by simp only [*, polyToField_apply, @AdjoinRoot.mk_self, @map_zero] -/
LINT-ENV: FAIL — 1 new violation(s)
```

The cause is a genuine difference from upstream: **TauCeti's `polyToField_apply` is `@[simp]`
where the source's is not**, so `simp` already reaches `0`. Untagged, the report is byte-identical
to the pre-change run. The reason is in the lemma's docstring so nobody re-proposes the tag.

**`equation_point` now consumes it**, replacing its inline
`polyToField_apply, AdjoinRoot.mk_self, map_zero`. Three consumers in all — that call site plus
the two addition lemmas — which is what makes the lemma an API rather than a one-site extraction.

## Reuse: four of the source's five private auxiliaries are not ported

- **`smulY_sub_negY_aux`** is unnecessary. `smulY_sub_negY` rewrites through this file's own
  `smulY_neg`, which already reads its coordinate identity off Mathlib's
  `Jacobian.negY_of_Z_ne_zero` — so the Mathlib lemma is reused transitively and no new private
  helper appears.
- **`addX_smul_one_smul_one_aux` is dead code in the source itself.** Repo-wide at the pin,
  `git grep -c` gives exactly **1** occurrence per copy — its own definition — in both
  `projects/NagellLutz/` and `projects/HasseWeil/`. Positive control: `addX_smul_ring_identity`
  gives **2** (definition plus one use). Porting it would add a zero-consumer private lemma.
- **`addX_smul_ring_identity`** and **`addY_smul_one_smul_one_aux`** each package one `field_simp`
  residue in the source's normal form. Both residues differ here and `linear_combination`/`ring`
  closes each in a line.

All three surviving `have hψ`/`hψ₂` nonvanishing hypotheses were checked to be load-bearing by
deletion; each removal breaks its proof (`ring failed` ×2, `unsolved goals` ×1).

## The map-direction trap, measured

Every `map_*` here names its ring hom. To check that was necessary rather than cargo-culted, the
names were mechanically stripped from the whole new block and the file rebuilt: **four of five
proofs break.** A sharper second probe — naming only `map_sub` and `map_neg`, leaving
`map_mul`/`map_add`/`map_pow`/`map_ofNat` bare — builds clean, so at this pin the unexposed
instances are precisely `Sub` and `Neg`. All are named anyway, for uniformity with `smulX_eq` and
`smulY_neg`.

Naming alone was **not** sufficient in three proofs. `polyToField_apply` being `@[simp]` means a
bare `field_simp` shatters `polyToField (C X)` into `algebraMap _ _ (AdjoinRoot.of _ X)` while
leaving `polyToField curve.polynomialX` folded, so the two sides share no atoms. Those proofs state
the certificate at the polynomial level, map it with `congrArg polyToField`, normalise with one
named `simp only`, and finish with `linear_combination`/`ring`.

## A docstring this PR falsifies, corrected here

#3997 landed a sentence on main saying the source's `polyToField_polynomial` "has no counterpart
here". This PR gives it one, so that clause is corrected in the same change rather than left
stale.

The proof of `polyToField_Ψ₂Sq` is **not** rewritten to use the new lemma, though that would match
the source. Mathlib carries both routes adjacently — `ψ₂_sq` (`Basic.lean:125`) and
`Affine.CoordinateRing.mk_ψ₂_sq` (`:128`), the second proved from the first — and `mk_ψ₂_sq` is the
packaged form of exactly the cancellation the source performs by hand with `ψ₂_sq`,
`polyToField_polynomial`, `mul_zero`, `add_zero`. Our proof already uses the packaged form.

## Gates

Full-library `lake build` PASS (8646 jobs) and `scripts/lint-env.sh` PASS (64 grandfathered,
6 ratchetable, byte-identical to the pre-change run) — both re-run against the **current** pin,
mathlib `72f9c607bb3a`, read from `lake-manifest.json`. Targeted builds 1998 + 2026 jobs.
`lean_diagnostic_messages` empty on both files. Residue greps zero against a live positive control.
Max line width 100 codepoints, none over. No declaration exceeds 20 lines, so `/decompose-proof`
is n/a. `/cleanup` ran with `/simplify` (three implicitly-used `have` bindings identified and each
verified load-bearing by deletion) and `/buzz` (whole-file rebuild 2.4s against a 2.1s import
baseline — FAST-BOARD, so per-declaration profiling would measure noise).

## Roadmap

New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
Nagell–Lutz**", whose stated route is the division-polynomial formula for `n • P`. These are the
tangent-and-doubling identities that formula's induction runs through.

## Provenance

Ported from J. Xu and D. K. Angdinata's `projects/NagellLutz/LutzNagell/ZSMul.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`):
`smulY_sub_negY` (`:227`), `smulY_one_sub_negY` (`:233`), `smulY_one_ne_negY` (`:237`), `slopeOne`
(`:241`), `slopeOne_eq_neg_div` (`:244`), `addX_smul_one_smul_one` (`:261`),
`addY_smul_one_smul_one` (`:277`); and `polyToField_polynomial` from that project's
`Universal.lean` (`:120`). The four unported auxiliaries are `:222`, `:252`, `:257`, `:271`, each
with its reason above. Name mapping: `ψc_spec`→`ψ_mul_ψc`, `C_Ψ₃_eq`→`C_Ψ₃`,
`polyToField_ψ₂Sq`→`polyToField_Ψ₂Sq`, `redInvarDenom_two`→`reducedInvarDenom_two`,
`compl₂EDSAux_two`→`complEDS₂Aux_two`, `ψᵤ n`→`polyToField (curve.ψ n)`. `Universal.Field` has no
`DecidableEq` and `Affine.slope` is defined by cases, so the source's namespace-wide
`attribute [local instance] Classical.propDecidable` is narrowed to `open scoped Classical in` on
the two declarations mentioning `slope`, the idiom `Affine/FunctionField/InfinityPlace.lean` uses.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-slopes"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
