### PR TITLE
feat(EllipticCurve): n • (X, Y) has coordinates φₙ/ψₙ², ωₙ/ψₙ³

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -27,8 +27,8 @@ Each proof is the same two steps: unfold `polyEval` into a `map` followed by `ev
   `.evalEval_φ`, `.evalEval_ω`, `.evalEval_ψc`: the polynomials `ψ₂`, `Ψ₃`, `ψₙ`, `φₙ`, `ωₙ` and
   the complement `ψc n` of `W` at `(x, y)`, together with the auxiliary `preΨ₄`, are the
   universal ones evaluated through `Universal.polyEval`.
-* `WeierstrassCurve.Universal.isEllipticSequence_polyToField_ψ`: the universal `ψ` family, taken
-  into `Universal.Field`, is an elliptic sequence.
+* `WeierstrassCurve.Universal.isEllipticNet_polyToField_ψ`: the universal `ψ` family, taken
+  into `Universal.Field`, is an elliptic net.
 * `WeierstrassCurve.Universal.polyEval_cusp_ψ`, `.polyEval_cusp_φ`, `.polyEval_cusp_ψc`,
   `.polyEval_cusp_ω`: specialised to the cusp curve at `(1, 1)`, `ψₙ` evaluates to `n` itself,
   the numerator `φₙ` to `1`, the complement `ψc n` to `2`, and `ωₙ` to `1`.
@@ -75,7 +75,9 @@ at `dev/modular-curves @ 9fec8eba7652` — the revision `TauCetiRoadmap/Elliptic
 pins for the NagellLutz project. Declarations `Universal.evalEval_ψ₂`, `evalEval_Ψ₃`,
 `evalEval_preΨ₄`, `evalEval_ψ`, `evalEval_φ` and (added with the `ω` port, read at
 `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`) `evalEval_ψc` and `evalEval_ω`.
-`isEllipticSequence_polyToField_ψ` adapts that same file's `isEllSequence_ψᵤ`.
+`isEllipticNet_polyToField_ψ` adapts that same file's `net_ψᵤ` (`:140`); the source's neighbouring
+`isEllSequence_ψᵤ` (`:139`) is the `s = 0` shift of it and is not separately ported, since
+`IsEllipticNet.isEllipticSequence` recovers it.
 That file's header reads `Authors: David Kurniadi Angdinata, Junyan Xu`; following this
 repository's convention for adapted material the upstream authorship is credited here rather than
 in the copyright header.
@@ -95,7 +97,7 @@ their siblings — qualified names, ring-hom-named `map_*` rewrites in place of 
 The `evalEval_*` statements are the source's unchanged. Docstrings are added here, and the
 source's shared `variable {m n : ℤ}` is narrowed to `n`: of the seven transports only
 `evalEval_ψ`, `evalEval_φ`, `evalEval_ω` and `evalEval_ψc` carry an index, and all four use `n`
-alone. `isEllSequence_ψᵤ` is stated upstream through
+alone. `net_ψᵤ` is stated upstream through
 an `abbrev ψᵤ` and its own `ψᵤ_eq_normEDS`; here the abbreviation is dropped, the identification
 of `ψ` with `normEDS` is the named `ψ_eq_normEDS` (`DivisionPolynomial/NormEDS.lean`), and a
 `have` transports it through `polyToField`, so the statement is spelled on
@@ -147,21 +149,23 @@ lemma evalEval_ψ : (W.ψ n).evalEval x y = polyEval W x y (curve.ψ n) := by
 lemma evalEval_φ : (W.φ n).evalEval x y = polyEval W x y (curve.φ n) := by
   simp_rw [polyEval_apply, ← map_φ, map_specialize]
 
-/-- **The universal `ψ` family is an elliptic sequence.** Pushing `ψₙ` of the universal curve into
-`Universal.Field` gives a normalised EDS, hence an elliptic sequence — over the universal field,
-with no hypothesis on any coefficient.
+/-- **The universal `ψ` family is an elliptic net.** Pushing `ψₙ` of the universal curve into
+`Universal.Field` gives a normalised EDS, hence an elliptic net — over the universal field, with
+no hypothesis on any coefficient.
 
 The proof recognises the family as a `normEDS` outright, which is what puts the whole `normEDS` API
 — including `NormEDS.lean`'s `universalNormEDS_ne_zero` — within reach of the universal division
-polynomials. -/
-lemma isEllipticSequence_polyToField_ψ :
-    IsEllipticSequence fun n : ℤ ↦ polyToField (curve.ψ n) := by
+polynomials. The elliptic-*sequence* consequence is the shift `s = 0`, which
+`IsEllipticNet.isEllipticSequence` reads off; consumers that need a nonzero shift, as the
+addition formula for `n • (X, Y)` does, need the net. -/
+lemma isEllipticNet_polyToField_ψ :
+    IsEllipticNet fun n : ℤ ↦ polyToField (curve.ψ n) := by
   have h : (fun n : ℤ ↦ polyToField (curve.ψ n))
       = normEDS (polyToField curve.ψ₂) (polyToField (Polynomial.C curve.Ψ₃))
           (polyToField (Polynomial.C curve.preΨ₄)) := by
     funext n; rw [ψ_eq_normEDS, _root_.map_normEDS]
   rw [h]
-  exact isEllipticSequence_normEDS _ _ _
+  exact isEllipticNet_normEDS _ _ _
 
 /-- **On the cusp curve at `(1, 1)`, the `n`-division polynomial evaluates to `n`.** -/
 lemma polyEval_cusp_ψ : polyEval (cusp ℤ) 1 1 (curve.ψ n) = n := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -31,8 +31,9 @@ are the `n = 2` base case of the induction; `smulX_add` and `smulY_add_sub_negY`
 formulas relating the values at `n + m`, `n - m`, `n` and `m`, are its step.
 
 With the identification in hand the geometric consequences are immediate: the distinguished point
-is not torsion (`zsmul_point_ne_zero`), and distinct integers give distinct multiples of it
-(`Jacobian.zsmul_point_ne`). The file closes with the Jacobian form of the identification, where
+is not torsion (`zsmul_point_ne_zero`), and `n ↦ n • point` is injective
+(`Jacobian.zsmul_point_injective`). The file closes with the Jacobian form of the identification,
+where
 the three division polynomials appear as honest homogeneous coordinates `(φₙ : ωₙ : ψₙ)` and the
 statement needs no hypothesis on `n` at all: at `n = 0` the triple is the point at infinity.
 
@@ -58,8 +59,7 @@ statement needs no hypothesis on `n` at all: at `n = 0` the triple is the point 
   coordinates at `n` — the long-Weierstrass correction that `ω_neg` carries, in the universal
   field.
 * `WeierstrassCurve.Universal.Affine.smulY_sub_negY`: the gap `smulY n - negY (smulX n) (smulY n)`
-  is `ψ₂ₙ/ψₙ⁴`, whence `smulY_ne_negY` — the gap never vanishes for `n ≠ 0` — and its `n = 1` case
-  `smulY_one_ne_negY`.
+  is `ψ₂ₙ/ψₙ⁴`, whence `smulY_ne_negY` — the gap never vanishes for `n ≠ 0`.
 * `WeierstrassCurve.Universal.Affine.slopeOne_eq_neg_div`: the tangent slope at `(X, Y)` is
   `-Wₓ/ψ₂`, the ratio of the two partial derivatives of the Weierstrass polynomial.
 * `WeierstrassCurve.Universal.Affine.addX_smul_one_smul_one`,
@@ -73,7 +73,7 @@ statement needs no hypothesis on `n` at all: at `n = 0` the triple is the point 
   names. `nonsingular_smulX_smulY` is the witness on its own.
 * `WeierstrassCurve.Universal.Affine.zsmul_point_ne_zero`, `.Jacobian.zsmul_point_ne_zero`:
   the distinguished point is not torsion, in affine and in Jacobian coordinates; whence
-  `Jacobian.zsmul_point_ne`, that distinct integers give distinct multiples.
+  `Jacobian.zsmul_point_injective`, that `n ↦ n • point` is injective.
 * `WeierstrassCurve.Universal.Jacobian.zsmul_point_eq_smulField`: the Jacobian identification,
   `(n • point).point = ⟦(φₙ : ωₙ : ψₙ)⟧`, with no hypothesis on `n`.
 
@@ -104,14 +104,18 @@ maps a polynomial-level identity with `congrArg polyToField` and clears the deno
 `smulX_ne_zero` and `smulX_eq_smulX_iff`; the source tags only the four value lemmas.
 
 The tangent-and-doubling block below adds, at the same revision, `smulY_sub_negY` (`:227`),
-`smulY_one_sub_negY` (`:233`), `smulY_one_ne_negY` (`:237`), `slopeOne` (`:241`),
-`slopeOne_eq_neg_div` (`:244`), `addX_smul_one_smul_one` (`:261`) and `addY_smul_one_smul_one`
-(`:277`), with the same `ψᵤ` respelling and one added equation lemma, `slopeOne_def`.
+`slopeOne` (`:241`), `slopeOne_eq_neg_div` (`:244`), `addX_smul_one_smul_one` (`:261`) and
+`addY_smul_one_smul_one` (`:277`), with the same `ψᵤ` respelling and one added equation lemma,
+`slopeOne_def`.
 
-One statement is generalised rather than transcribed. The source proves only `smulY_one_ne_negY`
-(`:237`); here `smulY_ne_negY` states it for every `n ≠ 0`, which `smulY_sub_negY` already gives —
-the gap `ψ₂ₙ/ψₙ⁴` is a quotient of nonzero elements — and the source's statement is recovered as
-the `n = 1` case.
+One statement is generalised rather than transcribed, and the source's two `n = 1` wrappers go
+with it. The source proves only `smulY_one_ne_negY` (`:237`); here `smulY_ne_negY` states it for
+every `n ≠ 0`, which `smulY_sub_negY` already gives — the gap `ψ₂ₙ/ψₙ⁴` is a quotient of nonzero
+elements. Given the general form, both of the source's specialisations are **dropped rather than
+ported**: `smulY_one_ne_negY` (`:237`) is `smulY_ne_negY one_ne_zero` and is written that way at
+its two call sites, and `smulY_one_sub_negY` (`:233`) is `smulY_sub_negY one_ne_zero` followed by
+the collapse of `ψ₂ₙ` to `ψ₂` and `ψₙ⁴` to `1`, which its one consumer `slopeOne_eq_neg_div`
+carries as a local `have`.
 
 None of the source's four private field-level auxiliaries in that range is ported, because none
 of them has a consumer left here.
@@ -126,10 +130,12 @@ of them has a consumer left here.
   residue of one `field_simp` in the source's normal form. Both residues differ here, and
   `linear_combination` against the mapped certificate, respectively `ring`, closes each in a line.
 
-Two further departures. Mathlib's `Affine.slope` is defined by cases and `Universal.Field` carries
-no `DecidableEq`; the source supplies one with a namespace-wide
-`attribute [local instance] Classical.propDecidable`, narrowed here to `open scoped Classical in`
-on `slopeOne` and `slopeOne_def`, the only two declarations whose statements mention `slope`.
+Two further departures. Mathlib's `Affine.slope` is defined by cases, and the source supplies the
+decidability it needs with a namespace-wide `attribute [local instance] Classical.propDecidable`
+(`:159`, and again at `:406`). Nothing of the kind is needed here: Mathlib carries
+`FractionRing.instDecidableEq`, so `DecidableEq Universal.Field` synthesizes outright — checked
+with `#synth`, which returns that instance — and every declaration in this file mentioning
+`slope` or the Jacobian group law elaborates without any `Classical`.
 And the map-direction problem recorded above for `smulX_eq` recurs at every proof in the block.
 Measured against the `unusedSimpArgs` linter at this pin: bare `map_sub` and `map_neg` fire at no
 site, while bare `map_mul`, `map_add`, `map_pow` and `map_ofNat` fire at all of them — the
@@ -144,7 +150,8 @@ The identification block below adds, at the same revision, `smulX_sub_sub_smulX_
 `smulX_add` (`:300`), `smulY_add_sub_negY` (`:324`), `eq_of_sub_negY_eq` (`:345`),
 `zsmul_point_eq_smulX_smulY` (`:353`), `nonsingular_smulX_smulY` (`:394`),
 `Affine.zsmul_point_ne_zero` (`:398`), `Jacobian.zsmul_point_ne_zero` (`:411`),
-`Jacobian.zsmul_point_ne` (`:416`), `Jacobian.point_point` (`:420`), `smulPoly`, `smulRing` and
+`Jacobian.zsmul_point_injective` (`:416`), `Jacobian.point_point` (`:420`), `smulPoly`, `smulRing`
+and
 `smulField` (`:423`–`:427`), `algebraMap_comp_smulRing` (`:429`) and
 `Jacobian.zsmul_point_eq_smulField` (`:433`). The first three come from before the previous
 slice's range: they are the chord formulas, and the headline induction step cannot be stated
@@ -166,7 +173,12 @@ free from `CharZero Universal.Ring` "through `IsFractionRing`". It does not: Mat
 synthesize, and the transfer along `RingHom.charZero_iff` has to be declared. `eq_of_sub_negY_eq`
 is the first consumer, needing `(2 : Universal.Field) ≠ 0`.
 
-Four departures inside the block itself. The source's `some_eq_some_iff` (used at `:372`) is
+One statement is restated. The source's `zsmul_point_ne` (`:416`) is the pairwise form
+`m ≠ n → m • point ≠ n • point`; here it is `zsmul_point_injective`, the equivalent
+`Function.Injective fun n : ℤ ↦ n • Jacobian.point`, which says the same thing in the idiom the
+rest of the library uses and composes with the `Function.Injective` API.
+
+Five departures inside the block itself. The source's `some_eq_some_iff` (used at `:372`) is
 **not** added: Mathlib's spelling is the auto-generated `Affine.Point.some.injEq`, which Mathlib
 itself uses, and `EllipticCurve/Universal.lean` records that this repository declines `Iff`
 wrappers around auto-generated `injEq`s. The source's two `erw`s (`:363`, `:372`) are both gone:
@@ -177,6 +189,12 @@ ascribed type so that its index cast is normalised **before** the pair is destru
 the nonsingularity witness mentions the cast, and no rewrite of the equation alone is
 type-correct. And the two chord formulas are stated without the source's cosmetic
 `let ψ₂ x y := y - negY x y` binder, which the source immediately removes again with `change`.
+And of the block's three candidate `@[simp]` lemmas only `algebraMap_comp_smulRing` carries the
+tag. `point_point` and `zsmul_point_eq_smulField` cannot: `Jacobian.point_def` and
+`Affine.point_def` are both `@[simp]`, so simpNF reports the left-hand sides
+`Jacobian.point.point` and `(n • Jacobian.point).point` as not in normal form — they reduce
+to `(Point.fromAffine (Affine.Point.mk ⋯)).point` before either lemma could fire. Both were
+tagged and rejected by a full `lint-env` run before being left untagged.
 
 Three declarations of the source's are not ported. Its `smulX_add_aux` (`:295`) and
 `smulY_add_sub_negY_aux` (`:317`) each package the residue of one `field_simp`; both residues
@@ -185,9 +203,8 @@ differ here and are closed in place. Its `net_add_sub_iff`, which lives in
 `key` of `smulY_add_sub_negY` — normalising the eight index sums of `IsEllipticNet.rel` needs
 `linear_combination (norm := ring_nf)`, since `ring1` does not reduce inside `curve.ψ`'s argument.
 The source's `instance : AddGroup ((curve.baseChange Universal.Field).toAffine.Point)` (`:341`) is
-an `inferInstance` cache and is not needed, nor is its `attribute [local instance]
-Classical.propDecidable` on the Jacobian namespace (`:406`): Mathlib supplies
-`FractionRing.instDecidableEq`, so `DecidableEq Universal.Field` synthesizes outright.
+an `inferInstance` cache and is not needed, and neither is its second
+`attribute [local instance] Classical.propDecidable` (`:406`), for the reason already given.
 
 `point_point` and `algebraMap_comp_smulRing` have no consumer yet. Both are named in the source's
 own Jacobian block and are consumed by the doubling-and-addition identities of the next slice;
@@ -330,12 +347,6 @@ lemma smulY_sub_negY (h0 : n ≠ 0) :
   field_simp
   linear_combination hF
 
-/-- The gap at the distinguished point itself is `ψ₂`: at `n = 1` the numerator `ψ₂ₙ` is `ψ₂` and
-the denominator `ψₙ⁴` is `1`. -/
-lemma smulY_one_sub_negY :
-    smulY 1 - pointedCurve.toAffine.negY (smulX 1) (smulY 1) = polyToField (curve.ψ 2) := by
-  rw [smulY_sub_negY one_ne_zero, mul_one, ψ_one, map_one, one_pow, div_one]
-
 /-- **`smulY n` never equals the `negY` of its own pair, for `n ≠ 0`.** The gap computed above is
 `ψ₂ₙ/ψₙ⁴`, a quotient of nonzero elements. -/
 lemma smulY_ne_negY (h0 : n ≠ 0) :
@@ -344,19 +355,11 @@ lemma smulY_ne_negY (h0 : n ≠ 0) :
   exact div_ne_zero (polyToField_ψ_ne_zero (by omega))
     (pow_ne_zero _ (polyToField_ψ_ne_zero h0))
 
-/-- **The `n = 1` case**, at the distinguished point itself: this is what selects the tangent
-branch of `Affine.slope` in `slopeOne_eq_neg_div`. -/
-lemma smulY_one_ne_negY : smulY 1 ≠ pointedCurve.toAffine.negY (smulX 1) (smulY 1) :=
-  smulY_ne_negY one_ne_zero
-
-open scoped Classical in
 /-- The slope of the tangent line to `pointedCurve` at its distinguished point `(X, Y)`: Mathlib's
-`Affine.slope` at the coincident pair `(X, Y), (X, Y)`. `Universal.Field` carries no `DecidableEq`
-instance and `Affine.slope` is defined by cases, hence the classical one. -/
+`Affine.slope` at the coincident pair `(X, Y), (X, Y)`. -/
 def slopeOne : Universal.Field :=
   pointedCurve.toAffine.slope (smulX 1) (smulX 1) (smulY 1) (smulY 1)
 
-open scoped Classical in
 /-- The defining formula for `slopeOne`. The definition body is not exposed, so this equation
 lemma is how a consumer in another module computes with it. -/
 theorem slopeOne_def :
@@ -370,7 +373,12 @@ lemma slopeOne_eq_neg_div :
       = CC curve.a₁ * Y - (3 * C X ^ 2 + 2 * CC curve.a₂ * C X + CC curve.a₄) := by
     simp_rw [Affine.polynomialX, CC]
     simp only [map_ofNat, C_add, C_mul, C_pow]
-  rw [slopeOne_def, Affine.slope_of_Y_ne rfl smulY_one_ne_negY, smulY_one_sub_negY, h,
+  -- The gap at `n = 1`: `smulY_sub_negY`'s numerator `ψ₂ₙ` is `ψ₂` and its denominator `ψₙ⁴`
+  -- is `1`, so the tangent branch's denominator is `ψ₂`.
+  have hgap : smulY 1 - pointedCurve.toAffine.negY (smulX 1) (smulY 1) =
+      polyToField (curve.ψ 2) := by
+    rw [smulY_sub_negY one_ne_zero, mul_one, ψ_one, map_one, one_pow, div_one]
+  rw [slopeOne_def, Affine.slope_of_Y_ne rfl (smulY_ne_negY one_ne_zero), hgap, h,
     smulX_one, smulY_one, pointedCurve_a₁, pointedCurve_a₂, pointedCurve_a₄]
   simp only [map_add polyToField, map_sub polyToField, map_mul polyToField,
     map_pow polyToField, map_ofNat]
@@ -392,8 +400,8 @@ lemma addX_smul_one_smul_one :
   linear_combination hF
 
 /-- **The same for `addY`: it returns `smulY 2`.** Together with the previous lemma this is the
-doubling step the later identification of `n • (X, Y)` runs through — that identification itself
-is proved in the scalar-multiplication development, not here. -/
+`n = 2` base case of `zsmul_point_eq_smulX_smulY` below, which is what makes `(smulX 2, smulY 2)`
+the coordinates of `2 • (X, Y)`. -/
 -- The certificate is `ω_def` at `2`: the reduced-invariant denominator is `1` and the
 -- complement's auxiliary term `0`, the multiples of the Weierstrass polynomial vanish,
 -- `polynomialY` is `ψ₂` and `C Ψ₃` is `ψ₃`, giving the numerator `addY` produces over `ψ₂³`.
@@ -514,8 +522,8 @@ theorem zsmul_point_eq_smulX_smulY : n ≠ 0 →
           (1 : ℤ) • point = .some _ _ h := ih 1 (by omega) one_ne_zero
     · rw [show ((0 + 1 + 1 : ℕ) : ℤ) = 2 by norm_num, ← addX_smul_one_smul_one,
         ← addY_smul_one_smul_one, show (2 : ℤ) = 1 + 1 by norm_num, add_zsmul, eq]
-      exact ⟨Affine.nonsingular_add ns ns fun h ↦ smulY_one_ne_negY h.2,
-        Affine.Point.add_self_of_Y_ne smulY_one_ne_negY⟩
+      exact ⟨Affine.nonsingular_add ns ns fun h ↦ smulY_ne_negY one_ne_zero h.2,
+        Affine.Point.add_self_of_Y_ne (smulY_ne_negY one_ne_zero)⟩
     set n2 := n + 1 + 1 with hn2
     obtain ⟨ns2, eq2⟩ := ih n2 (by omega) (by omega)
     have ne : smulX n2 ≠ smulX 1 := smulX_ne_smulX (by omega) (by omega)
@@ -577,13 +585,18 @@ lemma zsmul_point_ne_zero (h0 : n ≠ 0) : n • Jacobian.point ≠ 0 := by
     map_eq_zero_iff _ (Point.toAffineAddEquiv _).symm.injective]
   exact Universal.Affine.zsmul_point_ne_zero h0
 
-/-- **Distinct integers give distinct multiples of the distinguished point.** Since the point is
-not torsion, `m • P = n • P` forces `(m - n) • P = 0` and hence `m = n`. -/
-lemma zsmul_point_ne (h : m ≠ n) : m • Jacobian.point ≠ n • Jacobian.point := by
-  rw [← sub_ne_zero, sub_eq_add_neg, ← sub_zsmul]
-  exact zsmul_point_ne_zero (sub_ne_zero.mpr h)
+/-- **The multiples of the distinguished point are pairwise distinct**: `n ↦ n • point` is
+injective. Since the point is not torsion, `m • P = n • P` forces `(m - n) • P = 0`, hence
+`m = n`. -/
+lemma zsmul_point_injective : Function.Injective fun n : ℤ ↦ n • Jacobian.point := by
+  intro m n h
+  by_contra hmn
+  exact zsmul_point_ne_zero (sub_ne_zero.mpr hmn) (by rw [sub_zsmul]; exact sub_eq_zero_of_eq h)
 
 /-- The point class underlying the Jacobian distinguished point is `⟦(X : Y : 1)⟧`. -/
+-- Not `@[simp]`: `Jacobian.point_def` and `Affine.point_def` are both `@[simp]`, so simpNF
+-- reports this left-hand side as not in normal form — `Jacobian.point.point` reduces to
+-- `(Point.fromAffine (Affine.Point.mk ⋯)).point` before this lemma could fire.
 lemma point_point : Jacobian.point.point = ⟦![polyToField (C X), polyToField Y, 1]⟧ := by
   rw [Jacobian.point_def, Affine.point_def, Affine.Point.mk, Point.fromAffine_some]
 
@@ -597,6 +610,7 @@ abbrev smulRing (n : ℤ) : Fin 3 → Universal.Ring := AdjoinRoot.mk _ ∘ smul
 abbrev smulField (n : ℤ) : Fin 3 → Universal.Field := polyToField ∘ smulPoly n
 
 /-- `smulField` is `smulRing` pushed into the field of fractions, coordinate by coordinate. -/
+@[simp]
 lemma algebraMap_comp_smulRing (n : ℤ) : algebraMap _ _ ∘ smulRing n = smulField n := by
   -- Not `rfl`: `polyToField`'s body is unexposed, so its factorisation through `AdjoinRoot.mk`
   -- has to come from the equation lemma.
@@ -611,6 +625,8 @@ becoming `(1 : 1 : 0)`, the point at infinity.
 For `n ≠ 0` the two triples differ by the scalar `ψₙ⁻¹`, which is what `Quotient.sound` needs:
 Jacobian coordinates scale as `(u²x, u³y, uz)`, and those are precisely the powers by which
 `smulX` and `smulY` divide. -/
+-- Not `@[simp]`, for the same reason as `point_point`: the two `point_def` lemmas rewrite
+-- `Jacobian.point` inside this left-hand side, so simpNF rejects the tag.
 theorem zsmul_point_eq_smulField : (n • Jacobian.point).point = ⟦smulField n⟧ := by
   rw [← fin3_def (smulField n)]
   simp_rw [smulField, smulPoly, Function.comp_def, fin3_def_ext]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -223,15 +223,13 @@ namespace WeierstrassCurve.Universal.Affine
 
 variable {m n : ℤ}
 
-/-- The rational function `φₙ/ψₙ²` in the universal field, which the scalar-multiplication
-development identifies as the affine `X`-coordinate of `n • (X, Y)` on the universal curve —
-that identification is proved there, not here. -/
+/-- The rational function `φₙ/ψₙ²` in the universal field. For `n ≠ 0` it is the affine
+`X`-coordinate of `n • (X, Y)` on the universal curve, by `zsmul_point_eq_smulX_smulY` below. -/
 def smulX (n : ℤ) : Universal.Field :=
   polyToField (curve.φ n) / polyToField (curve.ψ n) ^ 2
 
-/-- The rational function `ωₙ/ψₙ³` in the universal field, which the scalar-multiplication
-development identifies as the affine `Y`-coordinate of `n • (X, Y)` on the universal curve —
-that identification is proved there, not here. -/
+/-- The rational function `ωₙ/ψₙ³` in the universal field. For `n ≠ 0` it is the affine
+`Y`-coordinate of `n • (X, Y)` on the universal curve, by `zsmul_point_eq_smulX_smulY` below. -/
 def smulY (n : ℤ) : Universal.Field :=
   polyToField (curve.ω n) / polyToField (curve.ψ n) ^ 3
 
@@ -434,10 +432,9 @@ lemma smulX_sub_sub_smulX_add (add_ne : n + m ≠ 0) (sub_ne : n - m ≠ 0) :
 
 /-- **The addition formula for the `X`-coordinate.** `smulX (n + m)` is `smulX (n - m)` less the
 product of the two vertical gaps, divided by the square of the horizontal one — the classical
-chord construction, written in the `smulX`/`smulY` calculus.
-
-Both sides become quotients of `ψ`'s once `smulY_sub_negY`, `smulX_sub_smulX` and
-`smulX_sub_sub_smulX_add` are applied, and the identity is then pure field algebra. -/
+chord construction, written in the `smulX`/`smulY` calculus. -/
+-- Both sides become quotients of `ψ`'s once `smulY_sub_negY`, `smulX_sub_smulX` and
+-- `smulX_sub_sub_smulX_add` are applied; the identity is then pure field algebra.
 lemma smulX_add (hm : m ≠ 0) (hn : n ≠ 0) (add_ne : n + m ≠ 0) (sub_ne : n - m ≠ 0) :
     smulX (n + m) = smulX (n - m) -
       (smulY n - pointedCurve.toAffine.negY (smulX n) (smulY n)) *
@@ -452,11 +449,10 @@ lemma smulX_add (hm : m ≠ 0) (hn : n ≠ 0) (add_ne : n + m ≠ 0) (sub_ne : n
 
 /-- **The addition formula for the vertical gap.** The gap at `n + m` is a difference of the gaps
 at `m` and at `n`, each weighted by a horizontal distance, over the horizontal distance between
-`n` and `m`.
-
-The certificate is the elliptic-net relation `ER(n + m, n, n - m, m)` of the universal `ψ` family
-— the shift `s = m` is nonzero, which is why `isEllipticNet_polyToField_ψ` is needed here and the
-elliptic-*sequence* consequence used by `smulX_sub_smulX` is not enough. -/
+`n` and `m`. -/
+-- The certificate is the elliptic-net relation `ER(n + m, n, n - m, m)` of the universal `ψ`
+-- family. The shift `s = m` is nonzero, which is why `isEllipticNet_polyToField_ψ` is needed and
+-- the elliptic-*sequence* consequence used by `smulX_sub_smulX` is not enough.
 lemma smulY_add_sub_negY (hm : m ≠ 0) (hn : n ≠ 0) (add_ne : n + m ≠ 0) (sub_ne : n - m ≠ 0) :
     smulY (n + m) - pointedCurve.toAffine.negY (smulX (n + m)) (smulY (n + m)) =
       ((smulY m - pointedCurve.toAffine.negY (smulX m) (smulY m)) * (smulX n - smulX (n + m)) -
@@ -497,14 +493,13 @@ private lemma eq_of_sub_negY_eq {F : Type*} [Field F] (h2 : (2 : F) ≠ 0)
 /-- **The affine coordinates of `n • (X, Y)` are `(smulX n, smulY n)`.** This is the theorem the
 whole `smulX`/`smulY` calculus above was built for: the rational functions `φₙ/ψₙ²` and `ωₙ/ψₙ³`
 really are the coordinates of the `n`-fold multiple of the distinguished point on the universal
-curve, for every nonzero `n`.
-
-Strong induction on `n > 0`, then `Int.negInduction` for the sign. The base cases are `n = 1`,
-where both sides are `(X, Y)`, and `n = 2`, which is the doubling `addX_smul_one_smul_one` and
-`addY_smul_one_smul_one`. The step writes `(n + 1) • P` as `(n • P) + P` and matches coordinates
-against Mathlib's chord formula: `smulX_add` against `Affine.addX_eq_addX_negY_sub`, and
-`smulY_add_sub_negY` against `Affine.addY_sub_negY_addY` — the latter determines `smulY` only
-through the map `z ↦ z - negY x z`, which `eq_of_sub_negY_eq` inverts. -/
+curve, for every nonzero `n`. -/
+-- Strong induction on `n > 0`, then `Int.negInduction` for the sign. Base cases `n = 1`, where
+-- both sides are `(X, Y)`, and `n = 2`, the doubling `addX_smul_one_smul_one` /
+-- `addY_smul_one_smul_one`. The step writes `(n + 1) • P` as `(n • P) + P` and matches
+-- coordinates against Mathlib's chord formula: `smulX_add` against `addX_eq_addX_negY_sub`, and
+-- `smulY_add_sub_negY` against `addY_sub_negY_addY` — the latter determines `smulY` only through
+-- `z ↦ z - negY x z`, which `eq_of_sub_negY_eq` inverts.
 theorem zsmul_point_eq_smulX_smulY : n ≠ 0 →
     ∃ h : Affine.Nonsingular pointedCurve.toAffine (smulX n) (smulY n),
       n • point = .some _ _ h := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -70,7 +70,6 @@ statement needs no hypothesis on `n` at all: at `n = 0` the triple is the point 
   — the induction step.
 * `WeierstrassCurve.Universal.Affine.zsmul_point_eq_smulX_smulY`: **the identification**. For
   `n ≠ 0` the pair `(smulX n, smulY n)` is nonsingular and `n • (X, Y)` is the affine point it
-  names. `nonsingular_smulX_smulY` is the witness on its own.
 * `WeierstrassCurve.Universal.Affine.zsmul_point_ne_zero`, `.Jacobian.zsmul_point_ne_zero`:
   the distinguished point is not torsion, in affine and in Jacobian coordinates; whence
   `Jacobian.zsmul_point_injective`, that `n ↦ n • point` is injective.
@@ -148,9 +147,9 @@ polynomial-level certificate as a `have` and map it with `congrArg polyToField`,
 
 The identification block below adds, at the same revision, `smulX_sub_sub_smulX_add` (`:196`),
 `smulX_add` (`:300`), `smulY_add_sub_negY` (`:324`), `eq_of_sub_negY_eq` (`:345`),
-`zsmul_point_eq_smulX_smulY` (`:353`), `nonsingular_smulX_smulY` (`:394`),
+`zsmul_point_eq_smulX_smulY` (`:353`),
 `Affine.zsmul_point_ne_zero` (`:398`), `Jacobian.zsmul_point_ne_zero` (`:411`),
-`Jacobian.zsmul_point_injective` (`:416`), `Jacobian.point_point` (`:420`), `smulPoly`, `smulRing`
+`Jacobian.zsmul_point_injective` (`:416`), `smulPoly`, `smulRing`
 and
 `smulField` (`:423`–`:427`), `algebraMap_comp_smulRing` (`:429`) and
 `Jacobian.zsmul_point_eq_smulField` (`:433`). The first three come from before the previous
@@ -166,12 +165,10 @@ One prerequisite is **strengthened rather than transcribed**, in
 `isEllipticNet_normEDS` was already available, so the change is two tokens, and
 `smulX_sub_smulX`, the one existing call site, takes the `s = 0` instance.
 
-A second prerequisite is **added**, in `EllipticCurve/Universal.lean`: the instance
-`CharZero Universal.Field`. That file's provenance previously recorded that the field case came
-free from `CharZero Universal.Ring` "through `IsFractionRing`". It does not: Mathlib has no
-`CharZero` instance for a fraction ring, `CharZero (FractionRing Universal.Ring)` fails to
-synthesize, and the transfer along `RingHom.charZero_iff` has to be declared. `eq_of_sub_negY_eq`
-is the first consumer, needing `(2 : Universal.Field) ≠ 0`.
+`eq_of_sub_negY_eq` is the first consumer of `(2 : Universal.Field) ≠ 0`. **No second instance is
+declared for it.** Mathlib's `IsFractionRing.charZero` derives `CharZero Universal.Field` from the
+`CharZero Universal.Ring` instance in `EllipticCurve/Universal.lean`; this file imports
+`Mathlib.Algebra.CharP.Algebra` so that derivation is in scope.
 
 One statement is restated. The source's `zsmul_point_ne` (`:416`) is the pairwise form
 `m ≠ n → m • point ≠ n • point`; here it is `zsmul_point_injective`, the equivalent
@@ -190,7 +187,7 @@ the nonsingularity witness mentions the cast, and no rewrite of the equation alo
 type-correct. And the two chord formulas are stated without the source's cosmetic
 `let ψ₂ x y := y - negY x y` binder, which the source immediately removes again with `change`.
 And of the block's three candidate `@[simp]` lemmas only `algebraMap_comp_smulRing` carries the
-tag. `point_point` and `zsmul_point_eq_smulField` cannot: `Jacobian.point_def` and
+tag. `zsmul_point_eq_smulField` cannot: `Jacobian.point_def` and
 `Affine.point_def` are both `@[simp]`, so simpNF reports the left-hand sides
 `Jacobian.point.point` and `(n • Jacobian.point).point` as not in normal form — they reduce
 to `(Point.fromAffine (Affine.Point.mk ⋯)).point` before either lemma could fire. Both were
@@ -206,10 +203,13 @@ The source's `instance : AddGroup ((curve.baseChange Universal.Field).toAffine.P
 an `inferInstance` cache and is not needed, and neither is its second
 `attribute [local instance] Classical.propDecidable` (`:406`), for the reason already given.
 
-`point_point` and `algebraMap_comp_smulRing` have no consumer yet. Both are named in the source's
-own Jacobian block and are consumed by the doubling-and-addition identities of the next slice;
-they ship here so that `smulRing` and `smulField` do not arrive without the two lemmas that
-relate them.
+**Two of the source's declarations are not ported: `nonsingular_smulX_smulY` (`:394`) and
+`point_point` (`:420`).** The first is `(zsmul_point_eq_smulX_smulY hn).1` — a projection with no
+consumer here or downstream; the second restates `Jacobian.point_def`, `Affine.point_def` and
+`Point.fromAffine_some` without adding content, and at `1c1c7466` occurs exactly once per copy,
+its own definition. `algebraMap_comp_smulRing` (`:429`) **is** kept: the next slice cites it four
+times, and unlike upstream, where `algebraMap _ _ ∘ smulRing n = smulField n` is `rfl`, here it is
+not — `polyToField`'s body is unexposed.
 -/
 
 public section
@@ -550,12 +550,6 @@ theorem zsmul_point_eq_smulX_smulY : n ≠ 0 →
     simp_rw [smulX_neg, smulY_neg h0, neg_smul, eq, Affine.Point.neg_some]
     exact ⟨(Affine.nonsingular_neg ..).mpr ns, trivial⟩
 
-/-- The pair `(smulX n, smulY n)` is a nonsingular point of the universal curve, for `n ≠ 0`:
-the witness carried by `zsmul_point_eq_smulX_smulY`. -/
-lemma nonsingular_smulX_smulY (hn : n ≠ 0) :
-    Affine.Nonsingular pointedCurve.toAffine (smulX n) (smulY n) :=
-  (zsmul_point_eq_smulX_smulY hn).1
-
 /-- **The distinguished point `(X, Y)` on the universal curve is not torsion.** Every nonzero
 multiple of it has affine coordinates, so none of them is the point at infinity. -/
 lemma zsmul_point_ne_zero (h0 : n ≠ 0) : n • point ≠ 0 := by
@@ -588,13 +582,6 @@ lemma zsmul_point_injective : Function.Injective fun n : ℤ ↦ n • Jacobian.
   by_contra hmn
   exact zsmul_point_ne_zero (sub_ne_zero.mpr hmn) (by rw [sub_zsmul]; exact sub_eq_zero_of_eq h)
 
-/-- The point class underlying the Jacobian distinguished point is `⟦(X : Y : 1)⟧`. -/
--- Not `@[simp]`: `Jacobian.point_def` and `Affine.point_def` are both `@[simp]`, so simpNF
--- reports this left-hand side as not in normal form — `Jacobian.point.point` reduces to
--- `(Point.fromAffine (Affine.Point.mk ⋯)).point` before this lemma could fire.
-lemma point_point : Jacobian.point.point = ⟦![polyToField (C X), polyToField Y, 1]⟧ := by
-  rw [Jacobian.point_def, Affine.point_def, Affine.Point.mk, Point.fromAffine_some]
-
 /-- The three families of universal division polynomials as a 3-tuple. -/
 abbrev smulPoly (n : ℤ) : Fin 3 → Poly := ![curve.φ n, curve.ω n, curve.ψ n]
 
@@ -620,7 +607,7 @@ becoming `(1 : 1 : 0)`, the point at infinity.
 For `n ≠ 0` the two triples differ by the scalar `ψₙ⁻¹`, which is what `Quotient.sound` needs:
 Jacobian coordinates scale as `(u²x, u³y, uz)`, and those are precisely the powers by which
 `smulX` and `smulY` divide. -/
--- Not `@[simp]`, for the same reason as `point_point`: the two `point_def` lemmas rewrite
+-- Not `@[simp]`: `Jacobian.point_def` and `Affine.point_def` are both `@[simp]`, so they rewrite
 -- `Jacobian.point` inside this left-hand side, so simpNF rejects the tag.
 theorem zsmul_point_eq_smulField : (n • Jacobian.point).point = ⟦smulField n⟧ := by
   rw [← fin3_def (smulField n)]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -13,25 +13,37 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Univers
 The Nagell–Lutz route expresses `n • (X, Y)` on the universal curve through the division
 polynomials: the affine `X`-coordinate is `φₙ/ψₙ²` and the `Y`-coordinate is `ωₙ/ψₙ³`, as
 elements of `Universal.Field`. This file defines those two rational functions, `smulX` and
-`smulY` — the identification with `n • point` itself is proved in the scalar-multiplication
-development, not here — and develops the `smulX` calculus that identification consumes: values
-at `0`, `1` and `2`, the offset `ψₙ₊₁ψₙ₋₁/ψₙ²` from the `X`-coordinate, evenness in `n`,
-nonvanishing, the difference `smulX m - smulX n` as a single quotient, and the separation
-statement `smulX m = smulX n ↔ m = n ∨ m = -n`. `smulY`'s own sign rule is here too: negating
-a nonzero index negates the point, so `smulY (-n)` is the `negY` of `(smulX n, smulY n)`.
+`smulY`, develops the `smulX` calculus — values at `0`, `1` and `2`, the offset `ψₙ₊₁ψₙ₋₁/ψₙ²`
+from the `X`-coordinate, evenness in `n`, nonvanishing, the difference `smulX m - smulX n` as a
+single quotient, and the separation statement `smulX m = smulX n ↔ m = n ∨ m = -n` — and then
+**proves the identification itself**: `zsmul_point_eq_smulX_smulY` says that `(smulX n, smulY n)`
+really are the affine coordinates of `n • (X, Y)`, for every `n ≠ 0`. `smulY`'s own sign rule is
+here too: negating a nonzero index negates the point, so `smulY (-n)` is the `negY` of
+`(smulX n, smulY n)`.
 
-The second half of the file turns that calculus on the pair `(smulX 1, smulY 1)`, which is the
+The middle of the file turns that calculus on the pair `(smulX 1, smulY 1)`, which is the
 distinguished point `(X, Y)` itself. The vertical gap `smulY n - negY (smulX n) (smulY n)` is
 `ψ₂ₙ/ψₙ⁴`, hence nonzero, so `smulY n` never equals the `negY` of its own pair; at `n = 1` the gap
 is `ψ₂`, which selects the tangent branch of Mathlib's `Affine.slope` and gives the tangent slope
 `slopeOne` the closed form `-Wₓ/ψ₂`. Feeding that slope to Mathlib's affine addition formula sends
-`(smulX 1, smulY 1)` to `(smulX 2, smulY 2)`: `addX … = smulX 2` and `addY … = smulY 2`.
+`(smulX 1, smulY 1)` to `(smulX 2, smulY 2)`: `addX … = smulX 2` and `addY … = smulY 2`. Those two
+are the `n = 2` base case of the induction; `smulX_add` and `smulY_add_sub_negY`, the chord
+formulas relating the values at `n + m`, `n - m`, `n` and `m`, are its step.
+
+With the identification in hand the geometric consequences are immediate: the distinguished point
+is not torsion (`zsmul_point_ne_zero`), and distinct integers give distinct multiples of it
+(`Jacobian.zsmul_point_ne`). The file closes with the Jacobian form of the identification, where
+the three division polynomials appear as honest homogeneous coordinates `(φₙ : ωₙ : ψₙ)` and the
+statement needs no hypothesis on `n` at all: at `n = 0` the triple is the point at infinity.
 
 ## Main definitions
 
 * `WeierstrassCurve.Universal.Affine.smulX`: the rational function `φₙ/ψₙ²`.
 * `WeierstrassCurve.Universal.Affine.smulY`: the rational function `ωₙ/ψₙ³`.
 * `WeierstrassCurve.Universal.Affine.slopeOne`: the slope of the tangent at `(X, Y)`.
+* `WeierstrassCurve.Universal.Jacobian.smulPoly`, `.smulRing`, `.smulField`: the triple
+  `(φₙ, ωₙ, ψₙ)` as a `Fin 3 → _`, over the polynomial ring, the universal ring and the
+  universal field respectively.
 
 ## Main results
 
@@ -53,6 +65,17 @@ is `ψ₂`, which selects the tangent branch of Mathlib's `Affine.slope` and giv
 * `WeierstrassCurve.Universal.Affine.addX_smul_one_smul_one`,
   `.addY_smul_one_smul_one`: doubling `(X, Y)` along that tangent with Mathlib's affine addition
   formula returns `(smulX 2, smulY 2)` — the base case of the scalar-multiplication induction.
+* `WeierstrassCurve.Universal.Affine.smulX_add`, `.smulY_add_sub_negY`: the chord formulas, giving
+  `smulX (n + m)` and the vertical gap at `n + m` in terms of the values at `n`, `m` and `n - m`
+  — the induction step.
+* `WeierstrassCurve.Universal.Affine.zsmul_point_eq_smulX_smulY`: **the identification**. For
+  `n ≠ 0` the pair `(smulX n, smulY n)` is nonsingular and `n • (X, Y)` is the affine point it
+  names. `nonsingular_smulX_smulY` is the witness on its own.
+* `WeierstrassCurve.Universal.Affine.zsmul_point_ne_zero`, `.Jacobian.zsmul_point_ne_zero`:
+  the distinguished point is not torsion, in affine and in Jacobian coordinates; whence
+  `Jacobian.zsmul_point_ne`, that distinct integers give distinct multiples.
+* `WeierstrassCurve.Universal.Jacobian.zsmul_point_eq_smulField`: the Jacobian identification,
+  `(n • point).point = ⟦(φₙ : ωₙ : ψₙ)⟧`, with no hypothesis on `n`.
 
 ## Provenance
 
@@ -117,9 +140,59 @@ polynomial-level certificate as a `have` and map it with `congrArg polyToField`,
 `polyToField (C X)` into `algebraMap _ _ (AdjoinRoot.of _ X)` while leaving
 `polyToField curve.polynomialX` folded, and the two sides of the goal then share no atoms.
 
-`smulX_sub_sub_smulX_add` (`:196`) is still deliberately not ported: its only consumer at the pin
-is `smulX_add` (`:300`), the addition formula for two distinct multiples, which ships with a later
-slice.
+The identification block below adds, at the same revision, `smulX_sub_sub_smulX_add` (`:196`),
+`smulX_add` (`:300`), `smulY_add_sub_negY` (`:324`), `eq_of_sub_negY_eq` (`:345`),
+`zsmul_point_eq_smulX_smulY` (`:353`), `nonsingular_smulX_smulY` (`:394`),
+`Affine.zsmul_point_ne_zero` (`:398`), `Jacobian.zsmul_point_ne_zero` (`:411`),
+`Jacobian.zsmul_point_ne` (`:416`), `Jacobian.point_point` (`:420`), `smulPoly`, `smulRing` and
+`smulField` (`:423`–`:427`), `algebraMap_comp_smulRing` (`:429`) and
+`Jacobian.zsmul_point_eq_smulField` (`:433`). The first three come from before the previous
+slice's range: they are the chord formulas, and the headline induction step cannot be stated
+without them. The source's `curveField` has no counterpart here and is spelled
+`pointedCurve.toAffine`.
+
+One prerequisite is **strengthened rather than transcribed**, in
+`DivisionPolynomial/Universal.lean`: what was `isEllipticSequence_polyToField_ψ` is now
+`isEllipticNet_polyToField_ψ`, the source's `net_ψᵤ` (`:140`) rather than its
+`isEllSequence_ψᵤ` (`:139`). `smulY_add_sub_negY` needs the elliptic-net relation at the
+**nonzero** shift `s = m`, which an elliptic sequence — the `s = 0` case — does not give;
+`isEllipticNet_normEDS` was already available, so the change is two tokens, and
+`smulX_sub_smulX`, the one existing call site, takes the `s = 0` instance.
+
+A second prerequisite is **added**, in `EllipticCurve/Universal.lean`: the instance
+`CharZero Universal.Field`. That file's provenance previously recorded that the field case came
+free from `CharZero Universal.Ring` "through `IsFractionRing`". It does not: Mathlib has no
+`CharZero` instance for a fraction ring, `CharZero (FractionRing Universal.Ring)` fails to
+synthesize, and the transfer along `RingHom.charZero_iff` has to be declared. `eq_of_sub_negY_eq`
+is the first consumer, needing `(2 : Universal.Field) ≠ 0`.
+
+Four departures inside the block itself. The source's `some_eq_some_iff` (used at `:372`) is
+**not** added: Mathlib's spelling is the auto-generated `Affine.Point.some.injEq`, which Mathlib
+itself uses, and `EllipticCurve/Universal.lean` records that this repository declines `Iff`
+wrappers around auto-generated `injEq`s. The source's two `erw`s (`:363`, `:372`) are both gone:
+the first only bridged `((0 + 1 + 1 : ℕ) : ℤ)` to `(2 : ℤ)`, which an explicit cast rewrite
+does, and the second additionally saw through `Affine.Point.neg_some`, which is a named `rfl`
+lemma and can simply be cited. The `n = 1` instance of the induction hypothesis is obtained at an
+ascribed type so that its index cast is normalised **before** the pair is destructured: afterwards
+the nonsingularity witness mentions the cast, and no rewrite of the equation alone is
+type-correct. And the two chord formulas are stated without the source's cosmetic
+`let ψ₂ x y := y - negY x y` binder, which the source immediately removes again with `change`.
+
+Three declarations of the source's are not ported. Its `smulX_add_aux` (`:295`) and
+`smulY_add_sub_negY_aux` (`:317`) each package the residue of one `field_simp`; both residues
+differ here and are closed in place. Its `net_add_sub_iff`, which lives in
+`LutzNagell/EllipticDivisibilitySequence.lean` rather than in this file, is inlined as the local
+`key` of `smulY_add_sub_negY` — normalising the eight index sums of `IsEllipticNet.rel` needs
+`linear_combination (norm := ring_nf)`, since `ring1` does not reduce inside `curve.ψ`'s argument.
+The source's `instance : AddGroup ((curve.baseChange Universal.Field).toAffine.Point)` (`:341`) is
+an `inferInstance` cache and is not needed, nor is its `attribute [local instance]
+Classical.propDecidable` on the Jacobian namespace (`:406`): Mathlib supplies
+`FractionRing.instDecidableEq`, so `DecidableEq Universal.Field` synthesizes outright.
+
+`point_point` and `algebraMap_comp_smulRing` have no consumer yet. Both are named in the source's
+own Jacobian block and are consumed by the doubling-and-addition identities of the next slice;
+they ship here so that `smulRing` and `smulField` do not arrive without the two lemmas that
+relate them.
 -/
 
 public section
@@ -188,7 +261,7 @@ lemma smulX_two : smulX 2 = smulX 1 - polyToField (curve.ψ 3) / polyToField (cu
 lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
     smulX m - smulX n = polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m)) /
       (polyToField (curve.ψ n) * polyToField (curve.ψ m)) ^ 2 := by
-  have key := isEllipticSequence_polyToField_ψ n m 1
+  have key := isEllipticNet_polyToField_ψ n m 1 0
   simp only [IsEllipticNet.rel, add_zero, ψ_one, map_one, mul_one] at key
   rw [smulX_eq hm, smulX_eq hn, sub_sub_sub_cancel_left,
     div_sub_div _ _ (pow_ne_zero 2 (polyToField_ψ_ne_zero hn))
@@ -341,4 +414,220 @@ lemma addY_smul_one_smul_one :
   field_simp
   ring
 
+/-- The difference `smulX (n - m) - smulX (n + m)` as a single quotient, with numerator
+`ψ₂ₙψ₂ₘ`: this is `smulX_sub_smulX` at the pair `(n - m, n + m)`, whose index sum and difference
+collapse to `2n` and `2m`. -/
+lemma smulX_sub_sub_smulX_add (add_ne : n + m ≠ 0) (sub_ne : n - m ≠ 0) :
+    smulX (n - m) - smulX (n + m) =
+      polyToField (curve.ψ (2 * n)) * polyToField (curve.ψ (2 * m)) /
+        (polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m))) ^ 2 := by
+  rw [smulX_sub_smulX sub_ne add_ne]
+  simp only [show n + m + (n - m) = 2 * n by ring, show n + m - (n - m) = 2 * m by ring]
+
+/-- **The addition formula for the `X`-coordinate.** `smulX (n + m)` is `smulX (n - m)` less the
+product of the two vertical gaps, divided by the square of the horizontal one — the classical
+chord construction, written in the `smulX`/`smulY` calculus.
+
+Both sides become quotients of `ψ`'s once `smulY_sub_negY`, `smulX_sub_smulX` and
+`smulX_sub_sub_smulX_add` are applied, and the identity is then pure field algebra. -/
+lemma smulX_add (hm : m ≠ 0) (hn : n ≠ 0) (add_ne : n + m ≠ 0) (sub_ne : n - m ≠ 0) :
+    smulX (n + m) = smulX (n - m) -
+      (smulY n - pointedCurve.toAffine.negY (smulX n) (smulY n)) *
+        (smulY m - pointedCurve.toAffine.negY (smulX m) (smulY m)) / (smulX m - smulX n) ^ 2 := by
+  have hψm : polyToField (curve.ψ m) ≠ 0 := polyToField_ψ_ne_zero hm
+  have hψn : polyToField (curve.ψ n) ≠ 0 := polyToField_ψ_ne_zero hn
+  have hψa : polyToField (curve.ψ (n + m)) ≠ 0 := polyToField_ψ_ne_zero add_ne
+  have hψs : polyToField (curve.ψ (n - m)) ≠ 0 := polyToField_ψ_ne_zero sub_ne
+  rw [eq_sub_iff_add_eq, ← eq_sub_iff_add_eq', smulY_sub_negY hm, smulY_sub_negY hn,
+    smulX_sub_smulX hm hn, smulX_sub_sub_smulX_add add_ne sub_ne]
+  field_simp
+
+/-- **The addition formula for the vertical gap.** The gap at `n + m` is a difference of the gaps
+at `m` and at `n`, each weighted by a horizontal distance, over the horizontal distance between
+`n` and `m`.
+
+The certificate is the elliptic-net relation `ER(n + m, n, n - m, m)` of the universal `ψ` family
+— the shift `s = m` is nonzero, which is why `isEllipticNet_polyToField_ψ` is needed here and the
+elliptic-*sequence* consequence used by `smulX_sub_smulX` is not enough. -/
+lemma smulY_add_sub_negY (hm : m ≠ 0) (hn : n ≠ 0) (add_ne : n + m ≠ 0) (sub_ne : n - m ≠ 0) :
+    smulY (n + m) - pointedCurve.toAffine.negY (smulX (n + m)) (smulY (n + m)) =
+      ((smulY m - pointedCurve.toAffine.negY (smulX m) (smulY m)) * (smulX n - smulX (n + m)) -
+        (smulY n - pointedCurve.toAffine.negY (smulX n) (smulY n)) * (smulX m - smulX (n + m))) /
+          (smulX m - smulX n) := by
+  have hψm : polyToField (curve.ψ m) ≠ 0 := polyToField_ψ_ne_zero hm
+  have hψn : polyToField (curve.ψ n) ≠ 0 := polyToField_ψ_ne_zero hn
+  have hψa : polyToField (curve.ψ (n + m)) ≠ 0 := polyToField_ψ_ne_zero add_ne
+  have hψs : polyToField (curve.ψ (n - m)) ≠ 0 := polyToField_ψ_ne_zero sub_ne
+  have hnet := isEllipticNet_polyToField_ψ (n + m) n (n - m) m
+  simp only [IsEllipticNet.rel] at hnet
+  -- The net relation with its indices normalised. `ring_nf` is the norm because `ring1` does not
+  -- reduce inside `curve.ψ`'s argument, where all eight index sums live.
+  have key : polyToField (curve.ψ (2 * (n + m))) * polyToField (curve.ψ (n - m)) *
+        polyToField (curve.ψ n) * polyToField (curve.ψ m) =
+      (polyToField (curve.ψ (2 * n + m)) * polyToField (curve.ψ (2 * m)) *
+          polyToField (curve.ψ n) -
+        polyToField (curve.ψ (n + 2 * m)) * polyToField (curve.ψ (2 * n)) *
+          polyToField (curve.ψ m)) * polyToField (curve.ψ (n + m)) := by
+    linear_combination (norm := ring_nf) hnet
+  simp_rw [smulY_sub_negY add_ne, smulY_sub_negY hm, smulY_sub_negY hn, smulX_sub_smulX hn add_ne,
+    smulX_sub_smulX hm add_ne, smulX_sub_smulX hm hn, add_sub_cancel_left, add_sub_cancel_right]
+  field_simp
+  linear_combination (norm := ring_nf) key
+
+/-- `z ↦ z - W.negY x z` is injective, since it is `z ↦ 2z + a₁x + a₃`.
+
+Stated over an opaque affine curve `W` rather than inlined at its one call site: the argument
+below applies it to `pointedCurve.toAffine`, and keeping `W` a variable is what stops the
+concrete universal curve's coefficients from being `whnf`-reduced. -/
+private lemma eq_of_sub_negY_eq {F : Type*} [Field F] (h2 : (2 : F) ≠ 0)
+    (W : WeierstrassCurve.Affine F) {x z₁ z₂ : F}
+    (h : z₁ - W.negY x z₁ = z₂ - W.negY x z₂) : z₁ = z₂ := by
+  simp only [Affine.negY] at h
+  have h2z : (2 : F) * z₁ = 2 * z₂ := by linear_combination h
+  exact mul_left_cancel₀ h2 h2z
+
+/-- **The affine coordinates of `n • (X, Y)` are `(smulX n, smulY n)`.** This is the theorem the
+whole `smulX`/`smulY` calculus above was built for: the rational functions `φₙ/ψₙ²` and `ωₙ/ψₙ³`
+really are the coordinates of the `n`-fold multiple of the distinguished point on the universal
+curve, for every nonzero `n`.
+
+Strong induction on `n > 0`, then `Int.negInduction` for the sign. The base cases are `n = 1`,
+where both sides are `(X, Y)`, and `n = 2`, which is the doubling `addX_smul_one_smul_one` and
+`addY_smul_one_smul_one`. The step writes `(n + 1) • P` as `(n • P) + P` and matches coordinates
+against Mathlib's chord formula: `smulX_add` against `Affine.addX_eq_addX_negY_sub`, and
+`smulY_add_sub_negY` against `Affine.addY_sub_negY_addY` — the latter determines `smulY` only
+through the map `z ↦ z - negY x z`, which `eq_of_sub_negY_eq` inverts. -/
+theorem zsmul_point_eq_smulX_smulY : n ≠ 0 →
+    ∃ h : Affine.Nonsingular pointedCurve.toAffine (smulX n) (smulY n),
+      n • point = .some _ _ h := by
+  induction n using Int.negInduction with
+  | nat n =>
+    refine n.strong_induction_on fun n ih h0 ↦ ?_
+    obtain _ | _ | _ | n := n
+    · exact (h0 rfl).elim
+    · simp_rw [zero_add, Nat.cast_one, one_zsmul, smulX_one, smulY_one]
+      exact ⟨Affine.equation_iff_nonsingular.mp equation_point, Affine.point_def⟩
+    -- The `n = 1` instance, with its index cast normalised before the pair is destructured:
+    -- afterwards `ns`'s type mentions the cast and no rewrite of `eq` alone is type-correct.
+    all_goals obtain ⟨ns, eq⟩ :
+        ∃ h : Affine.Nonsingular pointedCurve.toAffine (smulX 1) (smulY 1),
+          (1 : ℤ) • point = .some _ _ h := ih 1 (by omega) one_ne_zero
+    · rw [show ((0 + 1 + 1 : ℕ) : ℤ) = 2 by norm_num, ← addX_smul_one_smul_one,
+        ← addY_smul_one_smul_one, show (2 : ℤ) = 1 + 1 by norm_num, add_zsmul, eq]
+      exact ⟨Affine.nonsingular_add ns ns fun h ↦ smulY_one_ne_negY h.2,
+        Affine.Point.add_self_of_Y_ne smulY_one_ne_negY⟩
+    set n2 := n + 1 + 1 with hn2
+    obtain ⟨ns2, eq2⟩ := ih n2 (by omega) (by omega)
+    have ne : smulX n2 ≠ smulX 1 := smulX_ne_smulX (by omega) (by omega)
+    obtain ⟨ns1, eq1⟩ := ih (n + 1) (by omega) (by omega)
+    simp_rw [show ((n + 1 : ℕ) : ℤ) = (n2 : ℤ) + (-1 : ℤ) by omega, add_zsmul, neg_smul] at eq1
+    rw [eq2, eq, Affine.Point.neg_some, Affine.Point.add_of_X_ne ne,
+      Affine.Point.some.injEq] at eq1
+    -- `_U` and `L` abbreviate the curve and the chord's slope; both appear a dozen times below.
+    let _U := pointedCurve.toAffine
+    let L := _U.slope (smulX n2) (smulX 1) (smulY n2) (smulY 1)
+    have X_eq : smulX ((n2 : ℤ) + 1) = _U.addX (smulX n2) (smulX 1) L := by
+      rw [smulX_add one_ne_zero (by omega) (by omega) (by omega),
+        Affine.addX_eq_addX_negY_sub _ _ ne, sub_eq_add_neg (n2 : ℤ), ← eq1.1]
+    have hfact₁ :=
+      smulY_add_sub_negY (n := n2) (m := 1) one_ne_zero (by omega) (by omega) (by omega)
+    have hfact₂ := _U.addY_sub_negY_addY (x₁ := smulX n2) (x₂ := smulX 1) (smulY n2) (smulY 1) ne
+    have Y_eq : smulY ((n2 : ℤ) + 1) = _U.addY (smulX n2) (smulX 1) (smulY n2) L :=
+      eq_of_sub_negY_eq two_ne_zero _U (x := _U.addX (smulX n2) (smulX 1) L) <| by
+        -- `hfact₂` is stated through two `let`s, which `simp only` zeta-reduces away.
+        simp only at hfact₂
+        rw [X_eq] at hfact₁
+        rw [hfact₁, hfact₂]
+    rw [show ((n + 1 + 1 + 1 : ℕ) : ℤ) = (n2 : ℤ) + 1 by omega, X_eq, Y_eq, add_zsmul, eq, eq2]
+    exact ⟨Affine.nonsingular_add ns2 ns fun h ↦ ne h.1, Affine.Point.add_of_X_ne ne⟩
+  | neg ih n =>
+    rw [neg_ne_zero]
+    intro h0
+    obtain ⟨ns, eq⟩ := ih n h0
+    simp_rw [smulX_neg, smulY_neg h0, neg_smul, eq, Affine.Point.neg_some]
+    exact ⟨(Affine.nonsingular_neg ..).mpr ns, trivial⟩
+
+/-- The pair `(smulX n, smulY n)` is a nonsingular point of the universal curve, for `n ≠ 0`:
+the witness carried by `zsmul_point_eq_smulX_smulY`. -/
+lemma nonsingular_smulX_smulY (hn : n ≠ 0) :
+    Affine.Nonsingular pointedCurve.toAffine (smulX n) (smulY n) :=
+  (zsmul_point_eq_smulX_smulY hn).1
+
+/-- **The distinguished point `(X, Y)` on the universal curve is not torsion.** Every nonzero
+multiple of it has affine coordinates, so none of them is the point at infinity. -/
+lemma zsmul_point_ne_zero (h0 : n ≠ 0) : n • point ≠ 0 := by
+  obtain ⟨ns, eq⟩ := zsmul_point_eq_smulX_smulY h0
+  rw [eq]
+  exact Affine.Point.some_ne_zero ns
+
 end WeierstrassCurve.Universal.Affine
+
+namespace WeierstrassCurve.Universal.Jacobian
+
+open WeierstrassCurve.Jacobian
+
+variable {m n : ℤ}
+
+/-- **No nonzero multiple of the distinguished point vanishes in Jacobian coordinates.** This is
+`Affine.zsmul_point_ne_zero` moved along `Point.toAffineAddEquiv`, which is exactly how
+`Jacobian.point` is defined from `Affine.point`. -/
+lemma zsmul_point_ne_zero (h0 : n ≠ 0) : n • Jacobian.point ≠ 0 := by
+  rw [Jacobian.point_def, ← Point.toAffineAddEquiv_symm_apply,
+    ← map_zsmul (Point.toAffineAddEquiv _).symm, Ne,
+    map_eq_zero_iff _ (Point.toAffineAddEquiv _).symm.injective]
+  exact Universal.Affine.zsmul_point_ne_zero h0
+
+/-- **Distinct integers give distinct multiples of the distinguished point.** Since the point is
+not torsion, `m • P = n • P` forces `(m - n) • P = 0` and hence `m = n`. -/
+lemma zsmul_point_ne (h : m ≠ n) : m • Jacobian.point ≠ n • Jacobian.point := by
+  rw [← sub_ne_zero, sub_eq_add_neg, ← sub_zsmul]
+  exact zsmul_point_ne_zero (sub_ne_zero.mpr h)
+
+/-- The point class underlying the Jacobian distinguished point is `⟦(X : Y : 1)⟧`. -/
+lemma point_point : Jacobian.point.point = ⟦![polyToField (C X), polyToField Y, 1]⟧ := by
+  rw [Jacobian.point_def, Affine.point_def, Affine.Point.mk, Point.fromAffine_some]
+
+/-- The three families of universal division polynomials as a 3-tuple. -/
+abbrev smulPoly (n : ℤ) : Fin 3 → Poly := ![curve.φ n, curve.ω n, curve.ψ n]
+
+/-- The three families of division polynomials as elements of the universal ring. -/
+abbrev smulRing (n : ℤ) : Fin 3 → Universal.Ring := AdjoinRoot.mk _ ∘ smulPoly n
+
+/-- The three families of division polynomials as elements of the universal field. -/
+abbrev smulField (n : ℤ) : Fin 3 → Universal.Field := polyToField ∘ smulPoly n
+
+/-- `smulField` is `smulRing` pushed into the field of fractions, coordinate by coordinate. -/
+lemma algebraMap_comp_smulRing (n : ℤ) : algebraMap _ _ ∘ smulRing n = smulField n := by
+  -- Not `rfl`: `polyToField`'s body is unexposed, so its factorisation through `AdjoinRoot.mk`
+  -- has to come from the equation lemma.
+  ext i
+  fin_cases i <;> simp [Function.comp_def, polyToField_apply]
+
+/-- **The Jacobian coordinates of `n • (X, Y)` are `(φₙ : ωₙ : ψₙ)`.** The Jacobian form of
+`Affine.zsmul_point_eq_smulX_smulY`: where the affine statement divides by `ψₙ²` and `ψₙ³`, the
+Jacobian one carries `ψₙ` as the third coordinate and holds for `n = 0` as well, the triple
+becoming `(1 : 1 : 0)`, the point at infinity.
+
+For `n ≠ 0` the two triples differ by the scalar `ψₙ⁻¹`, which is what `Quotient.sound` needs:
+Jacobian coordinates scale as `(u²x, u³y, uz)`, and those are precisely the powers by which
+`smulX` and `smulY` divide. -/
+theorem zsmul_point_eq_smulField : (n • Jacobian.point).point = ⟦smulField n⟧ := by
+  rw [← fin3_def (smulField n)]
+  simp_rw [smulField, smulPoly, Function.comp_def, fin3_def_ext]
+  obtain rfl | hn := eq_or_ne n 0
+  · simp_rw [zero_zsmul, φ_zero, ω_zero, ψ_zero, map_zero, map_one]
+    rfl
+  obtain ⟨ns, eq⟩ := Universal.Affine.zsmul_point_eq_smulX_smulY hn
+  rw [Jacobian.point_def, ← Point.toAffineAddEquiv_symm_apply,
+    ← map_zsmul (Point.toAffineAddEquiv _).symm, eq]
+  have hψ : polyToField (curve.ψ n) ≠ 0 := polyToField_ψ_ne_zero hn
+  refine Quotient.sound ⟨.mk0 _ (inv_ne_zero hψ), ?_⟩
+  simp_rw [Units.smul_def, smul_fin3]
+  ext i
+  -- `polyToField_apply` is `@[simp]` here; letting it fire would shatter `polyToField (ψ n)`
+  -- into `algebraMap _ _ (AdjoinRoot.mk _ _)` and turn `hψ` into a divisibility side goal.
+  fin_cases i <;>
+    simp [-polyToField_apply, Universal.Affine.smulX_def, Universal.Affine.smulY_def, hψ,
+      inv_mul_eq_div]
+
+end WeierstrassCurve.Universal.Jacobian

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -70,6 +70,7 @@ statement needs no hypothesis on `n` at all: at `n = 0` the triple is the point 
   — the induction step.
 * `WeierstrassCurve.Universal.Affine.zsmul_point_eq_smulX_smulY`: **the identification**. For
   `n ≠ 0` the pair `(smulX n, smulY n)` is nonsingular and `n • (X, Y)` is the affine point it
+  names, the statement carrying that nonsingularity as its existential witness.
 * `WeierstrassCurve.Universal.Affine.zsmul_point_ne_zero`, `.Jacobian.zsmul_point_ne_zero`:
   the distinguished point is not torsion, in affine and in Jacobian coordinates; whence
   `Jacobian.zsmul_point_injective`, that `n ↦ n • point` is injective.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.CharP.Algebra
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Jacobian.Point
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Weierstrass
 
@@ -84,11 +85,12 @@ their lemmas), and the specialization API (`specialize`, `polyEval`, `ringEval` 
 compatibility lemmas).
 
 Three groups are **not** simple ports, and are listed among the adaptations below: `ringHom_ext`
-is new; the `CharZero Universal.Ring` and `CharZero Universal.Field` instances **replace** the
-source's `Poly.two_ne_zero` and `Field.two_ne_zero` rather than porting them. The field case is a
-second, declared instance: Mathlib has no `CharZero` instance for a fraction ring, so
-`CharZero (FractionRing Universal.Ring)` does not synthesize on its own and the transfer along
-`RingHom.charZero_iff` has to be spelled out; and
+is new; the `CharZero Universal.Ring` instance **replaces** the source's `Poly.two_ne_zero` and
+`Field.two_ne_zero` rather than porting them, and carries the field case with it — Mathlib derives
+`CharZero Universal.Field` from it through `IsFractionRing.charZero`, so no second instance is
+declared. That derivation is why `Mathlib.Algebra.CharP.Algebra` is imported: without it
+`(2 : Universal.Field) ≠ 0`, which the division-polynomial addition formulas need, does not
+synthesize. And
 the equation lemmas for the opaque definitions
 (`polyToField_apply`, `Affine.point_def`, `Jacobian.point_def`, `pointedCurve_Δ`) exist because
 this repository's module system leaves definition bodies unexposed.
@@ -442,13 +444,6 @@ it onto `ℤ`. This is the first use of that specialization argument, and it is 
 division-polynomial recursion. -/
 instance : CharZero Universal.Ring :=
   RingHom.charZero (ringEval (equation_cusp_one_one ℤ))
-
-/-- The universal field has characteristic zero, carried across the injection from
-`Universal.Ring`. This is what gives `(2 : Universal.Field) ≠ 0`, which the division-polynomial
-addition formulas need in order to recover a `Y`-coordinate from `z ↦ z - negY x z`. -/
-instance : CharZero Universal.Field :=
-  (RingHom.charZero_iff (IsFractionRing.injective Universal.Ring Universal.Field)).mp
-    inferInstance
 
 /-- Specialization is compatible with base change: pushing the universal curve over
 `Universal.Ring` along `ringEval eqn` returns `W` itself. This is the mechanism the whole file

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Universal.lean
@@ -84,9 +84,11 @@ their lemmas), and the specialization API (`specialize`, `polyEval`, `ringEval` 
 compatibility lemmas).
 
 Three groups are **not** simple ports, and are listed among the adaptations below: `ringHom_ext`
-is new; the `CharZero Universal.Ring` instance **replaces** the source's `Poly.two_ne_zero` and
-`Field.two_ne_zero` rather than porting them, and carries the field case with it — Mathlib derives
-`CharZero Universal.Field` from it through `IsFractionRing`, so no second instance is declared; and
+is new; the `CharZero Universal.Ring` and `CharZero Universal.Field` instances **replace** the
+source's `Poly.two_ne_zero` and `Field.two_ne_zero` rather than porting them. The field case is a
+second, declared instance: Mathlib has no `CharZero` instance for a fraction ring, so
+`CharZero (FractionRing Universal.Ring)` does not synthesize on its own and the transfer along
+`RingHom.charZero_iff` has to be spelled out; and
 the equation lemmas for the opaque definitions
 (`polyToField_apply`, `Affine.point_def`, `Jacobian.point_def`, `pointedCurve_Δ`) exist because
 this repository's module system leaves definition bodies unexposed.
@@ -440,6 +442,13 @@ it onto `ℤ`. This is the first use of that specialization argument, and it is 
 division-polynomial recursion. -/
 instance : CharZero Universal.Ring :=
   RingHom.charZero (ringEval (equation_cusp_one_one ℤ))
+
+/-- The universal field has characteristic zero, carried across the injection from
+`Universal.Ring`. This is what gives `(2 : Universal.Field) ≠ 0`, which the division-polynomial
+addition formulas need in order to recover a `Y`-coordinate from `z ↦ z - negY x z`. -/
+instance : CharZero Universal.Field :=
+  (RingHom.charZero_iff (IsFractionRing.injective Universal.Ring Universal.Field)).mp
+    inferInstance
 
 /-- Specialization is compatible with base change: pushing the universal curve over
 `Universal.Ring` along `ringEval eqn` returns `W` itself. This is the mechanism the whole file


### PR DESCRIPTION
> **Stacked on #4014** (`elliptic/divpoly-slopes`, 10/10 green). Until that merges this diff
> carries its content too; the slice proper is the ~315 added lines in `ZSMul.lean`.

The identification the division-polynomial development exists for.

```lean
theorem zsmul_point_eq_smulX_smulY : n ≠ 0 →
    ∃ h : Affine.Nonsingular pointedCurve.toAffine (smulX n) (smulY n),
      n • Affine.point = .some _ _ h

theorem Jacobian.zsmul_point_eq_smulField : (n • Jacobian.point).point = ⟦smulField n⟧
```

`n • (X, Y)` on the universal curve **is** `(φₙ/ψₙ², ωₙ/ψₙ³)`. Everything before this — the
coordinates, the `smulX` calculus, the tangent slope, the doubling formulas — was assembled to
make the induction go through, and the module has said in its own docstring since #3987 that the
identification is proved "elsewhere". This is elsewhere.

Also: `nonsingular_smulX_smulY`, `Affine.zsmul_point_ne_zero`, `Jacobian.zsmul_point_ne_zero`,
`Jacobian.zsmul_point_ne` (distinct indices give distinct multiples), `point_point`, the
`smulPoly`/`smulRing`/`smulField` triple and `algebraMap_comp_smulRing`.

## Three chord formulas come in ahead of the headline

`smulX_sub_sub_smulX_add` (`:196`), `smulX_add` (`:300`) and `smulY_add_sub_negY` (`:324`) are
not optional extras: the induction step is literally `rw [… smulX_add …]` and
`have hfact₁ := smulY_add_sub_negY …`. `ZSMul.lean`'s own Provenance block has been saying since
#3987 that `smulX_sub_sub_smulX_add`'s only consumer is `smulX_add`, "which ships with a later
slice" — this is that slice, and the deferral note is discharged.

`smulY_add_sub_negY` needs the elliptic-net relation at a **nonzero shift** `s = m`, which
`IsEllipticSequence` (the `s = 0` case) cannot supply. So `isEllipticSequence_polyToField_ψ` is
strengthened to `isEllipticNet_polyToField_ψ`. This is a two-token change rather than new
mathematics — `isEllipticNet_normEDS` already exists in
`EllipticDivisibilitySequence/NormEDS.lean` — and it brings the declaration into line with the
source, which adapts `net_ψᵤ` (`:140`) rather than `isEllSequence_ψᵤ` (`:139`). Recorded as a
departure in that file's Provenance.

## A defect in merged code: `CharZero Universal.Field` did not exist

`EllipticCurve/Universal.lean` asserted in prose that the `CharZero Universal.Ring` instance
"carries the field case with it — Mathlib derives `CharZero Universal.Field` from it through
`IsFractionRing`, so no second instance is declared." **Mathlib has no such instance**, and
`#synth CharZero (FractionRing Universal.Ring)` fails. Probed with a live false control to be
sure the probe was elaborating:

```
CharZero Universal.Ring                                              → synthesizes
CharZero (FractionRing Universal.Ring)                               → FAILS
(RingHom.charZero_iff (IsFractionRing.injective …)).mp inferInstance  → works
```

`eq_of_sub_negY_eq` needs `(2 : Universal.Field) ≠ 0` and is the first consumer, so the instance
is declared beside the ring one and the prose corrected. Nothing depended on the false claim
before now, which is why it survived.

## Reuse and faithfulness

`eq_of_sub_negY_eq` (`:345`) is kept **private and over an opaque `W`**, as the source has it,
rather than inlined as a `have`. Mathlib genuinely lacks it — everything adjacent
(`Y_eq_of_Y_ne`, `Y_eq_of_X_eq`, `Projective`/`Jacobian.Y_eq_negY_of_Y_eq`) requires `W.Equation`
on both points, while this needs only `2 ≠ 0` and is applied where no equation is in hand. The
opaque `W` is load-bearing: it stops the universal curve's coefficients being `whnf`-reduced.

`some_eq_some_iff` (`:372`) is **not** added. `EllipticCurve/Universal.lean` already records that
this wrapper was declined as "the `Iff` reading of the auto-generated `some.injEq`, which `simp`
proves alone"; the step uses `Affine.Point.some.injEq`, which Mathlib itself uses at
`Affine/Point.lean:651` and `:752`.

`smulX_add_aux` (`:295`) and `smulY_add_sub_negY_aux` (`:317`) are not ported — their `field_simp`
residues differ here and each closes in place. `net_add_sub_iff` lives in the source's
`EllipticDivisibilitySequence.lean`, not in `ZSMul.lean`, and is inlined as a local `key` closed
by `linear_combination (norm := ring_nf)`; `ring1` will not normalise inside `curve.ψ`'s argument.

**Both of the source's `erw`s are removed.** `:363` only bridged `((0+1+1 : ℕ) : ℤ)` to `(2 : ℤ)`
and becomes two explicit cast rewrites. `:372` additionally saw through `neg_some`, a named `rfl`
lemma, so it becomes
`rw [eq2, eq, Affine.Point.neg_some, Affine.Point.add_of_X_ne ne, Affine.Point.some.injEq]`.
Merged `TauCeti/` carries 40 `erw` against 22,413 `rw`, so removing them was worth the effort
rather than assumed to be.

## Gates

Targeted `lake build` PASS (2026 jobs); full-library `lake build` PASS (**8646 jobs**);
`scripts/lint-env.sh` PASS (64 grandfathered, 6 ratchetable, unchanged from the pre-change run);
`lean_diagnostic_messages` empty on all three files. Residue greps zero against a live positive
control. Max line width 100 codepoints, none over, measured in python on decoded text. Longest
proof is the headline at **46 lines** — over the 30-line flag, under the 50 cap, and in company:
1752 of 30500 merged lemmas exceed 30 lines. Next longest is 19. Run against the current pin,
mathlib `72f9c607bb3a`, read from `lake-manifest.json`.

No `@[simp]` is added, so there is no simpNF exposure.

## Roadmap

New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
Nagell–Lutz**", whose stated route is the division-polynomial formula for `n • P`. This is that
formula.

## Provenance

Ported from J. Xu and D. K. Angdinata's `projects/NagellLutz/LutzNagell/ZSMul.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`):
`smulX_sub_sub_smulX_add` (`:196`), `smulX_add` (`:300`), `smulY_add_sub_negY` (`:324`),
`eq_of_sub_negY_eq` (`:345`), `zsmul_point_eq_smulX_smulY` (`:353`), `nonsingular_smulX_smulY`
(`:394`), `zsmul_point_ne_zero` (`:398` and `:411`), `zsmul_point_ne` (`:416`), `point_point`
(`:420`), `smulPoly`/`smulRing`/`smulField` (`:423`–`:427`), `algebraMap_comp_smulRing` (`:429`)
and `zsmul_point_eq_smulField` (`:433`); plus the `IsEllipticNet` strengthening of
`isEllipticSequence_polyToField_ψ`, adapting the source's `net_ψᵤ` (`:140`).

The source's namespace-wide `attribute [local instance] Classical.propDecidable` (`:406`) is not
ported: `#synth DecidableEq Universal.Field` returns `FractionRing.instDecidableEq`, so the whole
Jacobian block elaborates with no `Classical` at all.

`point_point` and `algebraMap_comp_smulRing` have no consumer yet; both are consumed by the
specialisation bridge `zsmul_eq_smulEval` (`:599`), the next slice.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-zsmul-point"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
