### PR TITLE
fix: report the releases that can never be tagged

### DIFF
--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -33,10 +33,16 @@ and recorded it.
 
 ## What it does not cover
 
-A release `main` never ran on gets no tag, and nothing here will construct one. Today that
-is `v4.33.0`, whose window on Mathlib master was fifteen hours and which the daily bump
-stepped straight over, and the patch releases `v4.32.1` and `v4.32.2`, which Mathlib cut on
-its `stable` branch and which `check-bump.sh` could never have let this repository pin.
+A release `main` never ran on gets no tag, and nothing here will construct one, but the
+report still lists it as `unreachable` rather than leaving it out: an audit whose job is to
+say which releases have no tag is not allowed to answer by omission. Today that is
+`v4.33.0`, whose window on Mathlib master was fifteen hours and which the daily bump stepped
+straight over, and the patch releases `v4.32.1` and `v4.32.2`, which Mathlib cut on its
+`stable` branch and which `check-bump.sh` could never have let this repository pin at all.
+
+Knowing which of those two it is matters. A stepped-over release is a near miss the bump
+could avoid another day; a `stable`-branch release is permanently out of reach and no
+amount of automation here will change that.
 
 Releases older than `v4.33.0-rc1` are out of scope, because the Lake cache does not reach
 back that far and a tag could not promise a usable one. That bound is `EARLIEST_RELEASE` in

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -176,6 +176,59 @@ class Report(unittest.TestCase):
             self.assertIn(row["status"], tt.STATUSES)
 
 
+class UnreachableReleases(unittest.TestCase):
+    """A release main never ran on must be REPORTED, not omitted.
+
+    The audit exists to say which releases have no tag. Walking only the toolchains main
+    ran on answered a different question and left `v4.33.0`, which the daily bump stepped
+    over, and the two `stable`-branch patch releases silently absent."""
+
+    def test_a_skipped_release_is_unreachable_not_missing(self):
+        row = tt._unreachable_row("v4.33.0", {})
+        self.assertEqual(row["status"], "unreachable")
+        self.assertIsNone(row["commit"])
+        self.assertIn("never ran", row["reason"])
+
+    def test_a_skipped_release_below_the_cutoff_is_out_of_scope(self):
+        # v4.32.1 is both unreachable and older than the cache; the cache bound is the
+        # more useful thing to say, since it applies to its neighbours too.
+        row = tt._unreachable_row("v4.32.1", {})
+        self.assertEqual(row["status"], "out-of-scope")
+        self.assertIn(tt.EARLIEST_RELEASE, row["reason"])
+
+    def test_the_report_explains_why_no_tag_is_possible(self):
+        rows = [tt._unreachable_row("v4.33.0", {})]
+        text = tt.render(rows)
+        self.assertIn("No tag is possible", text)
+        self.assertIn("stepped over", text)
+        self.assertIn("stable", text)
+
+    def test_a_table_row_without_a_commit_renders(self):
+        text = tt.render([tt._unreachable_row("v4.33.0", {})])
+        self.assertIn("v4.33.0", text)
+
+    def test_the_audit_covers_releases_main_never_ran_on(self):
+        original = {name: getattr(tt, name)
+                    for name in ("mathlib_releases", "eras", "existing_tags",
+                                 "mathlib_pin", "ci_passed", "cache_published")}
+        for name, value in original.items():
+            self.addCleanup(setattr, tt, name, value)
+        tt.mathlib_releases = lambda: ["v4.33.0-rc1", "v4.33.0", "v4.34.0-rc1"]
+        tt.eras = lambda ref=None: [
+            {"release": "v4.33.0-rc1", "toolchain": "leanprover/lean4:v4.33.0-rc1",
+             "commit": "a" * 40, "index": 1},
+            {"release": "v4.34.0-rc1", "toolchain": "leanprover/lean4:v4.34.0-rc1",
+             "commit": "b" * 40, "index": 2},
+        ]
+        tt.existing_tags = lambda: {"v4.33.0-rc1": "a" * 40}
+        tt.mathlib_pin = lambda sha: "c" * 40
+        tt.ci_passed = lambda sha: "success"
+        tt.cache_published = lambda toolchain, sha: True
+        rows = {r["release"]: r["status"] for r in tt.audit()}
+        self.assertEqual(rows, {"v4.33.0-rc1": "tagged", "v4.33.0": "unreachable",
+                                "v4.34.0-rc1": "ready"})
+
+
 class CommandLine(unittest.TestCase):
     def test_create_without_a_release_or_all_is_an_error(self):
         original = tt.audit

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -210,6 +210,18 @@ def cache_published(toolchain, sha):
     raise RuntimeError(f"the cache answered HTTP {code} for {url}; that is not a verdict")
 
 
+def mathlib_releases():
+    """Every Lean release mathlib has tagged, oldest first.
+
+    One request, and the only thing this tool asks mathlib. It is needed because the set of
+    toolchains `main` ran on is not the set of releases: a release main stepped over, or
+    could never have pinned, has no era here and would otherwise be missing from a report
+    whose entire job is to say which releases have no tag."""
+    raw = gh("repos/leanprover-community/mathlib4/git/matching-refs/tags/v", jq=".[].ref")
+    names = {ref.rsplit("/", 1)[-1] for ref in raw.splitlines()}
+    return sorted((n for n in names if parse_release(n)), key=release_key)
+
+
 def existing_tags():
     """{release: commit} for the release tags this repository already has."""
     raw = gh_optional(f"repos/{REPO}/git/matching-refs/tags/",
@@ -241,22 +253,38 @@ A tag is created only once that commit's post-merge CI has passed and its oleans
 Lake artifact cache, so a checkout builds without recompiling the library. Neither needs a
 rebuild: main already did the work.
 
-A release main never ran on gets no tag, and nothing here will construct one. Releases
-older than %s are out of scope: the Lake cache does not reach back that far, so a tag could
-not promise a usable cache.
+A release main never ran on gets no tag, and nothing here will construct one, but it is
+still reported: either the daily bump stepped over its window on mathlib master, or mathlib
+cut it on its `stable` branch and check-bump.sh could never have let this repository pin it.
+Releases older than %s are out of scope: the Lake cache does not reach back that far, so a
+tag could not promise a usable cache.
 
 Tags are never moved. If one disagrees with this rule, that is a question for a human.
 """ % EARLIEST_RELEASE
 
-STATUSES = ("tagged", "ready", "blocked", "out-of-scope")
+STATUSES = ("tagged", "ready", "blocked", "unreachable", "out-of-scope")
 
 
 def audit(ref=None):
-    """One row per toolchain main has run on, oldest first."""
+    """One row per Lean release in scope, oldest first.
+
+    Per RELEASE, not per era: a release main never ran on still needs an answer, and
+    "not mentioned" is not an answer."""
     tags = existing_tags()
+    by_release = {era["release"]: era for era in eras(ref)}
+    if not by_release:
+        raise RuntimeError("main has never run on a Lean release toolchain")
+    oldest = min(by_release, key=release_key)
     rows = []
-    for era in eras(ref):
-        release, sha = era["release"], era["commit"]
+
+    for release in sorted(set(mathlib_releases()) | set(by_release), key=release_key):
+        if release_key(release) < release_key(oldest):
+            continue          # predates this repository entirely; not our business
+        era = by_release.get(release)
+        if era is None:
+            rows.append(_unreachable_row(release, tags))
+            continue
+        sha = era["commit"]
         row = dict(era, status=None, reason=None, mathlib_rev=mathlib_pin(sha),
                    tagged_at=tags.get(release))
         if release_key(release) < release_key(EARLIEST_RELEASE):
@@ -291,12 +319,30 @@ def audit(ref=None):
     return rows
 
 
+def _unreachable_row(release, tags):
+    """A release main never ran on. There is no commit to tag and nothing will construct
+    one, so the only useful thing the report can do is say so and why."""
+    row = {"release": release, "toolchain": toolchain_for(release), "commit": None,
+           "index": None, "mathlib_rev": None, "tagged_at": tags.get(release),
+           "status": "unreachable",
+           "reason": "main never ran on this toolchain, so there is no commit to tag"}
+    if release_key(release) < release_key(EARLIEST_RELEASE):
+        row["status"] = "out-of-scope"
+        row["reason"] = f"predates {EARLIEST_RELEASE}, before the Lake cache existed"
+    return row
+
+
+def toolchain_for(release):
+    return TOOLCHAIN_PREFIX + release
+
+
 def render(rows):
     lines = [POLICY, ""]
     head = f"{'release':14s} {'status':12s} {'commit':9s} {'mathlib':9s} note"
     lines += [head, "-" * max(len(head), 72)]
     for row in rows:
-        lines.append(f"{row['release']:14s} {row['status']:12s} {row['commit'][:8]:9s} "
+        lines.append(f"{row['release']:14s} {row['status']:12s} "
+                     f"{(row['commit'] or '-')[:8]:9s} "
                      f"{(row['mathlib_rev'] or '-')[:8]:9s} {row['reason'] or ''}")
     ready = [r for r in rows if r["status"] == "ready"]
     lines.append("")
@@ -311,6 +357,15 @@ def render(rows):
     if blocked:
         lines += ["", "Needing a human:", ""]
         lines += [f"    {r['release']}: {r['reason']}" for r in blocked]
+    unreachable = [r for r in rows if r["status"] == "unreachable"]
+    if unreachable:
+        lines += ["", "No tag is possible for these, and none will be constructed:", ""]
+        lines += [f"    {r['release']}: {r['reason']}" for r in unreachable]
+        lines += ["",
+                  "    Either the daily bump stepped over the release's window on mathlib",
+                  "    master, which for a stable release has been as short as fifteen hours,",
+                  "    or mathlib cut it on its `stable` branch, which check-bump.sh could",
+                  "    never have let this repository pin at all."]
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
This PR makes the audit report every Lean release, including the ones that can never be tagged.

The audit walked the toolchains `main` had run on, which answers a different question from the one it exists to answer. A release `main` never ran on has no era, so it was absent from the report entirely: `v4.33.0`, which the daily bump stepped over, and `v4.32.1` and `v4.32.2`, which mathlib cut on its `stable` branch, simply did not appear. An audit whose job is to say which releases have no tag may not answer by omission.

It now enumerates mathlib's release tags, one request and the only thing this tool asks mathlib, merges them with the eras, and reports every release in scope. One that cannot be tagged is `unreachable`, with the reason, and the report spells out the two ways that happens: the bump stepped over the release's window on mathlib master, which for a stable release has been as short as fifteen hours, or mathlib cut it on `stable` and `check-bump.sh` could never have let this repository pin it at all. The distinction matters, because the first is a near miss the bump could avoid another day and the second is permanently out of reach.

Roadmap: none

🤖 Prepared with Claude Code