### PR TITLE
feat(MeasureTheory): the exact integrability rate for exp (a * x) on a half-line

### DIFF
--- a/TauCeti/MeasureTheory/Integral/ExpDecay.lean
+++ b/TauCeti/MeasureTheory/Integral/ExpDecay.lean
@@ -78,6 +78,7 @@ private theorem not_integrableOn_exp_mul_Ioi {a c : ℝ} (ha : 0 ≤ a) :
 
 /-- **The exact integrability rate.**  `fun x => exp (a * x)` is integrable on `(c, ∞)` precisely
 when the rate is negative.  Mathlib's `integrableOn_exp_mul_Ioi` is the `←` direction. -/
+@[simp]
 theorem integrableOn_exp_mul_Ioi_iff {a c : ℝ} :
     IntegrableOn (fun x : ℝ => Real.exp (a * x)) (Set.Ioi c) ↔ a < 0 := by
   refine ⟨fun h => ?_, fun ha => integrableOn_exp_mul_Ioi ha c⟩

--- a/TauCeti/MeasureTheory/Integral/ExpDecay.lean
+++ b/TauCeti/MeasureTheory/Integral/ExpDecay.lean
@@ -6,17 +6,25 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+public import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 
 /-!
-# Polynomially weighted exponential integrals
+# Exponential integrals on a half-line
 
-This file records integrability and evaluation of natural powers multiplied by an exponentially
-decaying factor on the positive half-line.
+This file records integrability and evaluation of exponential integrands on a right half-line:
+natural powers multiplied by an exponentially decaying factor, and the exact rate at which a bare
+exponential is integrable.
+
+Mathlib supplies the *sufficient* direction of that last one, `integrableOn_exp_mul_Ioi`, for a
+negative rate.  `integrableOn_exp_mul_Ioi_iff` adds the converse, which is what lets a caller
+describe an exponential-moment domain as an exact set rather than an inclusion.
 
 ## Main results
 
 * `TauCeti.integrableOn_pow_mul_exp_neg_mul_Ioi`: integrability on `(0, ∞)`.
 * `TauCeti.integral_pow_mul_exp_neg_mul_Ioi`: evaluation in terms of a factorial.
+* `TauCeti.integrableOn_exp_mul_Ioi_iff`: `exp (a * ·)` is integrable on `(c, ∞)` exactly when
+  `a < 0`.
 -/
 
 public section
@@ -54,5 +62,26 @@ theorem integral_pow_mul_exp_neg_mul_Ioi (n : ℕ) {a : ℝ} (ha : 0 < a) :
   rw [h', one_div, div_eq_mul_inv, inv_pow]
   ring
 
-end TauCeti
 
+/-- At a nonnegative rate the integrand is bounded below by a positive constant on `(c, ∞)`, a set
+of infinite measure, so it is not integrable there. -/
+private theorem not_integrableOn_exp_mul_Ioi {a c : ℝ} (ha : 0 ≤ a) :
+    ¬ IntegrableOn (fun x : ℝ => Real.exp (a * x)) (Set.Ioi c) := by
+  intro h
+  have hsub : Set.Ioi c ⊆ {x : ℝ | Real.exp (a * c) ≤ Real.exp (a * x)} := by
+    intro x hx
+    exact Real.exp_le_exp.2 (by nlinarith [le_of_lt (Set.mem_Ioi.mp hx)])
+  have h1 : (volume.restrict (Set.Ioi c)) (Set.Ioi c) < ⊤ :=
+    lt_of_le_of_lt (measure_mono hsub) (h.measure_ge_lt_top (Real.exp_pos (a * c)))
+  rw [Measure.restrict_apply_self, Real.volume_Ioi] at h1
+  exact absurd h1 (by simp)
+
+/-- **The exact integrability rate.**  `fun x => exp (a * x)` is integrable on `(c, ∞)` precisely
+when the rate is negative.  Mathlib's `integrableOn_exp_mul_Ioi` is the `←` direction. -/
+theorem integrableOn_exp_mul_Ioi_iff {a c : ℝ} :
+    IntegrableOn (fun x : ℝ => Real.exp (a * x)) (Set.Ioi c) ↔ a < 0 := by
+  refine ⟨fun h => ?_, fun ha => integrableOn_exp_mul_Ioi ha c⟩
+  by_contra hne
+  exact not_integrableOn_exp_mul_Ioi (not_lt.mp hne) h
+
+end TauCeti


### PR DESCRIPTION
The exact rate at which a bare exponential is integrable on a right half-line:

```lean
theorem integrableOn_exp_mul_Ioi_iff {a c : ℝ} :
    IntegrableOn (fun x : ℝ => Real.exp (a * x)) (Set.Ioi c) ↔ a < 0
```

## Why this is its own PR

It is a prerequisite for the exponential-family transforms, where the moment-generating domain is
`integrableExpSet id (expMeasure r) = Set.Iio r` — an **exact set**. Mathlib supplies only the
sufficient direction, `integrableOn_exp_mul_Ioi (ha : a < 0)`, which proves the inclusion
`Iio r ⊆ integrableExpSet` and nothing more. The converse is what closes it, and it has no
distribution in it at all, so it belongs in the generic analytic layer rather than inside a
distributions file.

The divergent direction is elementary and short: at a nonnegative rate the integrand is bounded
below by `exp (a * c) > 0` on `(c, ∞)`, and `Integrable.measure_ge_lt_top` then forces that set to
have finite measure, which `Real.volume_Ioi` contradicts.

## Placement

`ExpDecay.lean` already holds the two half-line exponential-integral facts this repository uses
(`integrableOn_pow_mul_exp_neg_mul_Ioi`, `integral_pow_mul_exp_neg_mul_Ioi`), so this is its topical
home; a second file about exponential integrals on `Ioi` would fragment it. The header did say
"polynomially weighted", which this result is not, so the title and summary are widened to
"exponential integrals on a half-line" and the new result is listed in Main results.

`not_integrableOn_exp_mul_Ioi` is private: the `iff` is the API, and a separately named negation
would be exactly its forward direction under another name.

## Roadmap

Roadmap: StandardDistributions

`TauCetiRoadmap/StandardDistributions/README.md`, **Layer 1: complete the elementary theory of
existing distributions**, the **Exponential** entry:

> **Exponential.** For `0 < r`, prove mean `r⁻¹`, variance `r⁻²`, `integrableExpSet id (expMeasure r)
> = Set.Iio r`, mgf `r / (r - t)` exactly on that domain, characteristic function
> `(r : ℂ) / (r - I * t)`, and memorylessness via `cond`.

The target names the moment-generating domain as an **equality**, `= Set.Iio r`. Mathlib's
`integrableOn_exp_mul_Ioi` gives only the sufficient direction, which proves `Iio r ⊆
integrableExpSet` and no more; this theorem supplies the converse, and is therefore what makes that
exact `integrableExpSet` computation reachable at all.

The attribution line names StandardDistributions rather than `none` because that entry is what
motivates the theorem, even though the file sits under `TauCeti/MeasureTheory/` — code organization
and roadmap scope do not coincide. It is shipped separately from the transforms PR under the
one-topic rule, and advances TauCetiProject/TauCetiRoadmap#272 without closing it.

🤖 Directed by Cameron Freer, drafted by Opus 5

