### PR TITLE
feat(Huber): the restricted-series functor detects kernels coefficientwise

### DIFF
--- a/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
@@ -45,6 +45,11 @@ where the convergent/restricted power series ring is (5.6.1) in §5.6.
   out of a module with a countable neighbourhood basis at `0` — the lifted coefficients can then
   be chosen to still tend to `0`, which lifting them one at a time does not give. This is what
   lets Wedhorn's Remark 8.29 descend from a presentation.
+* `mem_ker_restrictedMvPowerSeriesSubmoduleMap` and
+  `restrictedMvPowerSeriesSubmoduleMap_injective`: the kernel of the induced map is detected
+  coefficientwise, so the functor preserves injectivity. Together with
+  `restrictedMvPowerSeriesSubmoduleMap_surjective` these are the exactness inputs Remark 8.29
+  needs at the two ends.
 * `restrictedMvPowerSeriesSubmodule_ext`: coefficientwise agreement is equality in `M⟨T₁, …, Tₖ⟩`
   — the elimination rule `MvPowerSeries.ext` cannot supply at module coefficients.
 * `coeff_coe_smul_restrictedMvPowerSeriesSubring`: the scalar action on `A⟨T₁, …, Tₖ⟩` is
@@ -618,6 +623,37 @@ theorem restrictedMvPowerSeriesSubmoduleMap_surjective {k : ℕ} {A M N : Type*}
     restrictedMvPowerSeriesSubmodule_ext fun s ↦ ?_⟩
   rw [coeff_restrictedMvPowerSeriesSubmoduleMap]
   exact hfg s
+
+/-- **The kernel is coefficientwise**: a restricted series is killed by `φ` exactly when every one
+of its coefficients is. `MvPowerSeries` is a `def` for a function type and `M⟨T₁, …, Tₖ⟩` is a
+`Submodule` of it, so this criterion is two coercions away from `LinearMap.mem_ker`. -/
+theorem mem_ker_restrictedMvPowerSeriesSubmoduleMap {k : ℕ} {A M N : Type*} [Semiring A]
+    [AddCommMonoid M] [TopologicalSpace M] [Module A M] [ContinuousAdd M]
+    [ContinuousConstSMul A M] [AddCommMonoid N] [TopologicalSpace N] [Module A N]
+    [ContinuousAdd N] [ContinuousConstSMul A N] (φ : M →ₗ[A] N) (hφ : ContinuousAt φ 0)
+    {f : restrictedMvPowerSeriesSubmodule k A M} :
+    f ∈ LinearMap.ker (restrictedMvPowerSeriesSubmoduleMap (k := k) φ hφ) ↔
+      ∀ s, ((f : MvPowerSeries (Fin k) M) : (Fin k →₀ ℕ) → M) s ∈ LinearMap.ker φ := by
+  simp only [LinearMap.mem_ker]
+  constructor
+  · intro h s
+    rw [← coeff_restrictedMvPowerSeriesSubmoduleMap φ hφ f s, h]
+    rfl
+  · intro h
+    ext s
+    rw [coeff_restrictedMvPowerSeriesSubmoduleMap]
+    exact h s
+
+/-- **`M ↦ M⟨T₁, …, Tₖ⟩` preserves injectivity.** -/
+theorem restrictedMvPowerSeriesSubmoduleMap_injective {k : ℕ} {A M N : Type*} [Semiring A]
+    [AddCommMonoid M] [TopologicalSpace M] [Module A M] [ContinuousAdd M]
+    [ContinuousConstSMul A M] [AddCommMonoid N] [TopologicalSpace N] [Module A N]
+    [ContinuousAdd N] [ContinuousConstSMul A N] (φ : M →ₗ[A] N) (hφ : ContinuousAt φ 0)
+    (hinj : Function.Injective φ) :
+    Function.Injective (restrictedMvPowerSeriesSubmoduleMap (k := k) φ hφ) := fun f g h ↦
+  restrictedMvPowerSeriesSubmodule_ext fun s ↦ hinj <| by
+    rw [← coeff_restrictedMvPowerSeriesSubmoduleMap φ hφ f s,
+      ← coeff_restrictedMvPowerSeriesSubmoduleMap φ hφ g s, h]
 
 /-- **`A⟨T₁, …, Tₖ⟩` as a submodule over itself**: at `M = A` the subring and the submodule cut
 out the same series, so they are `A`-linearly isomorphic.

--- a/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
@@ -82,8 +82,10 @@ coefficient binders — `[Zero]` and a topology, where the original asked for a 
 `IsRestricted.smul`, `restrictedMvPowerSeriesSubmodule`, `mem_restrictedMvPowerSeriesSubmodule`,
 `isRestricted_pi_iff`, `restrictedMvPowerSeriesSubmodulePiEquiv` and
 `restrictedMvPowerSeriesSubringLinearEquiv`, each with its computation lemmas, together with
-`IsRestricted.map`, `restrictedMvPowerSeriesSubmoduleMap` with its laws and
-`restrictedMvPowerSeriesSubmoduleMap_surjective`, and
+`IsRestricted.map`, `restrictedMvPowerSeriesSubmoduleMap` with its laws,
+`restrictedMvPowerSeriesSubmoduleMap_surjective`,
+`mem_ker_restrictedMvPowerSeriesSubmoduleMap` and
+`restrictedMvPowerSeriesSubmoduleMap_injective`, and
 `coeff_coe_smul_restrictedMvPowerSeriesSubring`.
 
 **None of those has an AINTLIB counterpart**, for three different reasons.
@@ -93,6 +95,9 @@ induced-map material: AINTLIB states restricted series over a coefficient *ring*
 induced map at module coefficients and a fortiori no surjectivity statement about one. Wedhorn
 Remark 8.29 is credited for the mathematics; the lifting construction it delegates to
 (`TauCeti.exists_lift_tendsto_cofinite_nhds`) is original here too.
+`mem_ker_restrictedMvPowerSeriesSubmoduleMap` and
+`restrictedMvPowerSeriesSubmoduleMap_injective` are the same statement at the other end of the
+exactness, and have no counterpart there for the same reason.
 
 The two product statements — `isRestricted_pi_iff` and `restrictedMvPowerSeriesSubmodulePiEquiv` —
 have none because the source states restrictedness only for a single coefficient module and never
@@ -624,9 +629,9 @@ theorem restrictedMvPowerSeriesSubmoduleMap_surjective {k : ℕ} {A M N : Type*}
   rw [coeff_restrictedMvPowerSeriesSubmoduleMap]
   exact hfg s
 
-/-- **The kernel is coefficientwise**: a restricted series is killed by `φ` exactly when every one
-of its coefficients is. `MvPowerSeries` is a `def` for a function type and `M⟨T₁, …, Tₖ⟩` is a
-`Submodule` of it, so this criterion is two coercions away from `LinearMap.mem_ker`. -/
+/-- **The kernel is coefficientwise**: a restricted series is killed by `φ` exactly when every
+one of its coefficients is. -/
+@[simp]
 theorem mem_ker_restrictedMvPowerSeriesSubmoduleMap {k : ℕ} {A M N : Type*} [Semiring A]
     [AddCommMonoid M] [TopologicalSpace M] [Module A M] [ContinuousAdd M]
     [ContinuousConstSMul A M] [AddCommMonoid N] [TopologicalSpace N] [Module A N]

--- a/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
@@ -45,7 +45,7 @@ where the convergent/restricted power series ring is (5.6.1) in §5.6.
   out of a module with a countable neighbourhood basis at `0` — the lifted coefficients can then
   be chosen to still tend to `0`, which lifting them one at a time does not give. This is what
   lets Wedhorn's Remark 8.29 descend from a presentation.
-* `mem_ker_restrictedMvPowerSeriesSubmoduleMap` and
+* `restrictedMvPowerSeriesSubmoduleMap_eq_zero_iff` and
   `restrictedMvPowerSeriesSubmoduleMap_injective`: the kernel of the induced map is detected
   coefficientwise, so the functor preserves injectivity. Together with
   `restrictedMvPowerSeriesSubmoduleMap_surjective` these are the exactness inputs Remark 8.29
@@ -84,7 +84,7 @@ coefficient binders — `[Zero]` and a topology, where the original asked for a 
 `restrictedMvPowerSeriesSubringLinearEquiv`, each with its computation lemmas, together with
 `IsRestricted.map`, `restrictedMvPowerSeriesSubmoduleMap` with its laws,
 `restrictedMvPowerSeriesSubmoduleMap_surjective`,
-`mem_ker_restrictedMvPowerSeriesSubmoduleMap` and
+`restrictedMvPowerSeriesSubmoduleMap_eq_zero_iff` and
 `restrictedMvPowerSeriesSubmoduleMap_injective`, and
 `coeff_coe_smul_restrictedMvPowerSeriesSubring`.
 
@@ -95,7 +95,7 @@ induced-map material: AINTLIB states restricted series over a coefficient *ring*
 induced map at module coefficients and a fortiori no surjectivity statement about one. Wedhorn
 Remark 8.29 is credited for the mathematics; the lifting construction it delegates to
 (`TauCeti.exists_lift_tendsto_cofinite_nhds`) is original here too.
-`mem_ker_restrictedMvPowerSeriesSubmoduleMap` and
+`restrictedMvPowerSeriesSubmoduleMap_eq_zero_iff` and
 `restrictedMvPowerSeriesSubmoduleMap_injective` are the same statement at the other end of the
 exactness, and have no counterpart there for the same reason.
 
@@ -630,16 +630,19 @@ theorem restrictedMvPowerSeriesSubmoduleMap_surjective {k : ℕ} {A M N : Type*}
   exact hfg s
 
 /-- **The kernel is coefficientwise**: a restricted series is killed by `φ` exactly when every
-one of its coefficients is. -/
+one of its coefficients is.
+
+Stated as `… = 0` rather than as membership in `LinearMap.ker`, because `LinearMap.mem_ker` is
+itself a `simp` lemma: it rewrites the membership away first, so a `mem_ker` phrasing could not
+be `@[simp]` — the two chain together, and `f ∈ ker …` still reduces coefficientwise. -/
 @[simp]
-theorem mem_ker_restrictedMvPowerSeriesSubmoduleMap {k : ℕ} {A M N : Type*} [Semiring A]
+theorem restrictedMvPowerSeriesSubmoduleMap_eq_zero_iff {k : ℕ} {A M N : Type*} [Semiring A]
     [AddCommMonoid M] [TopologicalSpace M] [Module A M] [ContinuousAdd M]
     [ContinuousConstSMul A M] [AddCommMonoid N] [TopologicalSpace N] [Module A N]
     [ContinuousAdd N] [ContinuousConstSMul A N] (φ : M →ₗ[A] N) (hφ : ContinuousAt φ 0)
     {f : restrictedMvPowerSeriesSubmodule k A M} :
-    f ∈ LinearMap.ker (restrictedMvPowerSeriesSubmoduleMap (k := k) φ hφ) ↔
-      ∀ s, ((f : MvPowerSeries (Fin k) M) : (Fin k →₀ ℕ) → M) s ∈ LinearMap.ker φ := by
-  simp only [LinearMap.mem_ker]
+    restrictedMvPowerSeriesSubmoduleMap (k := k) φ hφ f = 0 ↔
+      ∀ s, φ (((f : MvPowerSeries (Fin k) M) : (Fin k →₀ ℕ) → M) s) = 0 := by
   constructor
   · intro h s
     rw [← coeff_restrictedMvPowerSeriesSubmoduleMap φ hφ f s, h]


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"restricted-series-kernel-coefficientwise"}-->

```text
restrictedMvPowerSeriesSubmoduleMap_eq_zero_iff  (φ : M →ₗ[A] N) (hφ : ContinuousAt φ 0) :
  restrictedMvPowerSeriesSubmoduleMap φ hφ f = 0 ↔ ∀ s, φ (coeff s f) = 0        (@[simp])

restrictedMvPowerSeriesSubmoduleMap_injective  (hinj : Function.Injective φ) :
  Function.Injective (restrictedMvPowerSeriesSubmoduleMap φ hφ)
```

## Why

Roadmap Layer 4.1 step 1 — Wedhorn Remark 8.29, the natural isomorphism `M ⊗_A A⟨X⟩ ≅ M⟨X⟩` for
finitely generated `M`. The argument runs the functor `M ↦ M⟨T₁,…,Tₖ⟩` over a presentation of
`M` and needs it to be exact. `restrictedMvPowerSeriesSubmoduleMap_surjective` (already on
`main`) is the right-hand end; these two are the left-hand end.

Everything is coefficientwise because `MvPowerSeries` is a `def` for a function type and
`M⟨T₁,…,Tₖ⟩` is a `Submodule` of it.

The kernel criterion is stated as `… = 0` rather than as membership in `LinearMap.ker`, and that
is forced: `LinearMap.mem_ker` is itself a `simp` lemma, so a `mem_ker` phrasing has a left-hand
side that `simp` rewrites away before the lemma can fire, and tagging it `@[simp]` fails the
`simpNF` linter — `lint-env` reports it as a new violation. In the normalised form the two chain,
so `f ∈ ker …` still reduces coefficientwise, which is the point.

## Scope

Both are stated over **general module coefficients**, with no hypothesis relating `M` and `N`
beyond the map. Nothing here is specific to a submodule of the coefficients; the remaining
middle-exactness step is the one that needs that, and it is deliberately not in this PR because
it depends on instances that are still in review (#3963).

## Absence

`restrictedMvPowerSeriesSubmoduleMap_eq_zero_iff` and
`restrictedMvPowerSeriesSubmoduleMap_injective` are both absent from `origin/main`; every
dependency they use — `restrictedMvPowerSeriesSubmoduleMap`,
`coeff_restrictedMvPowerSeriesSubmoduleMap`, `restrictedMvPowerSeriesSubmodule_ext` — is
present. No new imports.

Provenance: no external source. The statements are this repository's own API; the proofs are
the file's own `coeff_…` characterisation.

