### PR TITLE
fix: report a hand-made tag rather than denying it exists

### DIFF
--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -44,6 +44,13 @@ Knowing which of those two it is matters. A stepped-over release is a near miss 
 could avoid another day; a `stable`-branch release is permanently out of reach and no
 amount of automation here will change that.
 
+Such a release can still be tagged by hand, off a `main` commit, and `v4.33.0` was: one
+commit off `afb1aacb`, the last `main` commit before the bump jumped, changing only the two
+pin files so that no source differs from that commit. It was built from source against
+mathlib v4.33.0 and passes the audits, but nothing publishes a Lake cache for a commit off
+`main`, so a checkout recompiles the library. The report calls such a tag `tagged` and says
+it was constructed; `--create` will never make one.
+
 Releases older than `v4.33.0-rc1` are out of scope, because the Lake cache does not reach
 back that far and a tag could not promise a usable one. That bound is `EARLIEST_RELEASE` in
 the script; raise it if the cache is ever pruned, never lower it.

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -196,6 +196,17 @@ class UnreachableReleases(unittest.TestCase):
         self.assertEqual(row["status"], "out-of-scope")
         self.assertIn(tt.EARLIEST_RELEASE, row["reason"])
 
+    def test_a_hand_made_tag_on_an_unreachable_release_is_reported_as_tagged(self):
+        # A release main never ran on can still be tagged by hand off a main commit. The
+        # report saying "no tag is possible" over the top of an existing tag would be the
+        # tool contradicting the repository.
+        row = tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})
+        self.assertEqual(row["status"], "tagged")
+        self.assertEqual(row["commit"], "e" * 40)
+        self.assertIn("constructed by hand", row["reason"])
+        self.assertIn("no published Lake cache", row["reason"])
+        self.assertNotIn("No tag is possible", tt.render([row]))
+
     def test_the_report_explains_why_no_tag_is_possible(self):
         rows = [tt._unreachable_row("v4.33.0", {})]
         text = tt.render(rows)

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -326,6 +326,15 @@ def _unreachable_row(release, tags):
            "index": None, "mathlib_rev": None, "tagged_at": tags.get(release),
            "status": "unreachable",
            "reason": "main never ran on this toolchain, so there is no commit to tag"}
+    if row["tagged_at"]:
+        # Someone made one by hand anyway, off a main commit, which is the only way a
+        # release main never ran on can have a tag at all. Saying "no tag is possible" over
+        # the top of an existing tag is the report contradicting the repository.
+        row["status"] = "tagged"
+        row["commit"] = row["tagged_at"]
+        row["reason"] = ("constructed by hand: main never ran on this toolchain, so this "
+                         "is not a main commit and carries no published Lake cache")
+        return row
     if release_key(release) < release_key(EARLIEST_RELEASE):
         row["status"] = "out-of-scope"
         row["reason"] = f"predates {EARLIEST_RELEASE}, before the Lake cache existed"


### PR DESCRIPTION
This PR teaches the audit about a tag made by hand for a release `main` never ran on.

`v4.33.0` now has such a tag. Mathlib's window for it on master was about fifteen hours and the daily bump stepped over it, so there is no `main` commit to tag; the tag points at one constructed commit off `afb1aacb`, the last `main` commit before the bump jumped, changing only `lean-toolchain` and `lake-manifest.json` so no source differs from that commit. It builds from source against mathlib v4.33.0, 7439 jobs, with the axiom audit, the module-system audit and the environment lint all passing.

The report did not know any of that. It printed "No tag is possible for these" over the top of an existing tag, which is the tool contradicting the repository. Such a release now reports as `tagged`, with the note that it was constructed by hand and carries no published Lake cache, which is the one respect in which it is weaker than the tags on `main` commits. `--create` still will not make one: constructing a commit is a deliberate manual act.

Roadmap: none

🤖 Prepared with Claude Code