### PR TITLE
fix: ask whether a hand-made tag has a cache, rather than asserting it has none

### DIFF
--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -47,9 +47,15 @@ amount of automation here will change that.
 Such a release can still be tagged by hand, off a `main` commit, and `v4.33.0` was: one
 commit off `afb1aacb`, the last `main` commit before the bump jumped, changing only the two
 pin files so that no source differs from that commit. It was built from source against
-mathlib v4.33.0 and passes the audits, but nothing publishes a Lake cache for a commit off
-`main`, so a checkout recompiles the library. The report calls such a tag `tagged` and says
-it was constructed; `--create` will never make one.
+mathlib v4.33.0, passes the audits, and its oleans were uploaded to the Lake cache by hand,
+so a checkout of it builds without recompiling: verified from a fresh clone, 7439 targets
+up to date in eighteen seconds.
+
+Nothing publishes for a commit off `main` automatically, so that upload was a manual step
+(`lake cache stage`, then `lake cache put-staged` from a modern Lake with `--rev` and
+`--toolchain`, since v4.33.0's own Lake has neither flag). The report therefore asks the
+cache rather than assuming: it calls such a tag `tagged`, says it was constructed by hand,
+and says whether a cache was found. `--create` will never make one.
 
 Releases older than `v4.33.0-rc1` are out of scope, because the Lake cache does not reach
 back that far and a tag could not promise a usable one. That bound is `EARLIEST_RELEASE` in

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -196,7 +196,7 @@ class UnreachableReleases(unittest.TestCase):
         self.assertEqual(row["status"], "out-of-scope")
         self.assertIn(tt.EARLIEST_RELEASE, row["reason"])
 
-    def _with_cache(self, answer):
+    def _with_cache_answer(self, answer):
         original = tt.cache_published
         self.addCleanup(setattr, tt, "cache_published", original)
         def fake(toolchain, sha):
@@ -209,7 +209,7 @@ class UnreachableReleases(unittest.TestCase):
         # A release main never ran on can still be tagged by hand off a main commit. The
         # report saying "no tag is possible" over the top of an existing tag would be the
         # tool contradicting the repository.
-        self._with_cache(False)
+        self._with_cache_answer(False)
         row = tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})
         self.assertEqual(row["status"], "tagged")
         self.assertEqual(row["commit"], "e" * 40)
@@ -220,15 +220,15 @@ class UnreachableReleases(unittest.TestCase):
         # Nothing publishes for a commit off main automatically, so "no cache" is the usual
         # answer, but one can be uploaded by hand. Asserting it rather than asking made the
         # report wrong the moment that happened.
-        self._with_cache(True)
+        self._with_cache_answer(True)
         self.assertIn("a Lake cache was published",
                       tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})["reason"])
-        self._with_cache(False)
+        self._with_cache_answer(False)
         self.assertIn("no published Lake cache",
                       tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})["reason"])
 
     def test_an_unreadable_cache_is_not_reported_as_absent(self):
-        self._with_cache(RuntimeError("the cache answered HTTP 500"))
+        self._with_cache_answer(RuntimeError("the cache answered HTTP 500"))
         self.assertIn("could not be checked",
                       tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})["reason"])
 

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -196,16 +196,41 @@ class UnreachableReleases(unittest.TestCase):
         self.assertEqual(row["status"], "out-of-scope")
         self.assertIn(tt.EARLIEST_RELEASE, row["reason"])
 
+    def _with_cache(self, answer):
+        original = tt.cache_published
+        self.addCleanup(setattr, tt, "cache_published", original)
+        def fake(toolchain, sha):
+            if isinstance(answer, Exception):
+                raise answer
+            return answer
+        tt.cache_published = fake
+
     def test_a_hand_made_tag_on_an_unreachable_release_is_reported_as_tagged(self):
         # A release main never ran on can still be tagged by hand off a main commit. The
         # report saying "no tag is possible" over the top of an existing tag would be the
         # tool contradicting the repository.
+        self._with_cache(False)
         row = tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})
         self.assertEqual(row["status"], "tagged")
         self.assertEqual(row["commit"], "e" * 40)
         self.assertIn("constructed by hand", row["reason"])
-        self.assertIn("no published Lake cache", row["reason"])
         self.assertNotIn("No tag is possible", tt.render([row]))
+
+    def test_whether_a_hand_made_tag_has_a_cache_is_checked_not_assumed(self):
+        # Nothing publishes for a commit off main automatically, so "no cache" is the usual
+        # answer, but one can be uploaded by hand. Asserting it rather than asking made the
+        # report wrong the moment that happened.
+        self._with_cache(True)
+        self.assertIn("a Lake cache was published",
+                      tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})["reason"])
+        self._with_cache(False)
+        self.assertIn("no published Lake cache",
+                      tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})["reason"])
+
+    def test_an_unreadable_cache_is_not_reported_as_absent(self):
+        self._with_cache(RuntimeError("the cache answered HTTP 500"))
+        self.assertIn("could not be checked",
+                      tt._unreachable_row("v4.33.0", {"v4.33.0": "e" * 40})["reason"])
 
     def test_the_report_explains_why_no_tag_is_possible(self):
         rows = [tt._unreachable_row("v4.33.0", {})]

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -332,8 +332,20 @@ def _unreachable_row(release, tags):
         # the top of an existing tag is the report contradicting the repository.
         row["status"] = "tagged"
         row["commit"] = row["tagged_at"]
-        row["reason"] = ("constructed by hand: main never ran on this toolchain, so this "
-                         "is not a main commit and carries no published Lake cache")
+        # Whether it has a cache is a question, not an assumption. Nothing publishes for a
+        # commit off main automatically, so the usual answer is no, but one can be uploaded
+        # by hand and this said otherwise for as long as it took someone to notice.
+        try:
+            cached = cache_published(row["toolchain"], row["commit"])
+        except RuntimeError:
+            cached = None
+        row["reason"] = "constructed by hand: main never ran on this toolchain"
+        if cached is True:
+            row["reason"] += ", and a Lake cache was published for it"
+        elif cached is False:
+            row["reason"] += ", and it has no published Lake cache, so a checkout recompiles"
+        else:
+            row["reason"] += "; its Lake cache could not be checked"
         return row
     if release_key(release) < release_key(EARLIEST_RELEASE):
         row["status"] = "out-of-scope"


### PR DESCRIPTION
The audit hardcoded "carries no published Lake cache" for a tag constructed off `main`. That is the usual answer, because nothing publishes for such a commit automatically, but it is not a fact the tool knows, and it stopped being true: `v4.33.0`'s oleans have now been staged and uploaded by hand, and the report went on claiming otherwise.

It asks the cache now, and distinguishes a cache that is absent from one it could not check, so a transient failure does not read as "no cache".

Verified from a fresh clone at the tag: `lake exe cache get`, then `lake cache get` against the public endpoint, then `lake build --no-build` reports all 7439 targets up to date in eighteen seconds with nothing recompiled.

Roadmap: none

🤖 Prepared with Claude Code