### PR TITLE
doc: name Shimura's Proposition 3.37 where it is the statement being proved

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
@@ -46,7 +46,7 @@ recurrences — is a separate milestone and is not proved here.
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
-  §3.4–3.5.
+  §3.4, Proposition 3.37, instantiated at `Γ₁ = Γ₂ = Γ₁(N)`.
 * [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.2.
 -/
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -68,7 +68,8 @@ instance of `ModularFormClass` (`Mathlib/NumberTheory/ModularForms/Basic.lean`).
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
-  §3.4.
+  §3.4, Proposition 3.37: `[Γ₁ α Γ₂]ₖ` sends `A_k(Γ₁), G_k(Γ₁), S_k(Γ₁)` into
+  `A_k(Γ₂), G_k(Γ₂), S_k(Γ₂)`, the statement this file completes for `G_k` and `S_k`.
 -/
 
 public section

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean
@@ -69,7 +69,7 @@ instance of `ModularFormClass` (`Mathlib/NumberTheory/ModularForms/Basic.lean`).
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
   §3.4, Proposition 3.37: `[Γ₁ α Γ₂]ₖ` sends `A_k(Γ₁), G_k(Γ₁), S_k(Γ₁)` into
-  `A_k(Γ₂), G_k(Γ₂), S_k(Γ₂)`, the statement this file completes for `G_k` and `S_k`.
+  `A_k(Γ₂), G_k(Γ₂), S_k(Γ₂)`, instantiated here at `Γ₁ = Γ₂ = G`.
 -/
 
 public section


### PR DESCRIPTION
This PR replaces the bare section references in `HeckeSlash/ModularForm.lean` and
`HeckeSlash/Gamma1.lean` with the proposition those files prove. Shimura's Proposition 3.37 is
"`[Γ₁ α Γ₂]ₖ` sends `A_k(Γ₁), G_k(Γ₁), S_k(Γ₁)` into `A_k(Γ₂), G_k(Γ₂), S_k(Γ₂)`, respectively",
stated immediately after (3.4.1) defines the operator through the right-coset decomposition.
`Form.lean`, `Invariance.lean` and `Reindex.lean` already cite it by number; these two, which
build the modular-form and cusp-form endomorphisms, named only the section.

Roadmap: ModularForms

🤖 Prepared with Claude Code