### PR TITLE
doc(EllipticCurve): pin the Silverman citations for relative Frobenius and omega

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -46,9 +46,12 @@ and naturality in the coefficient ring for both families.
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], Exercise 3.7, which defines
   the `(ψ, φ, ω)` triple and whose part (d) is the identity `[m]P = (φₘ/ψₘ², ωₘ/ψₘ³)` that makes
-  `ω` the `Y`-coordinate numerator. Silverman normalises by `4y ωₘ = ψₘ₋₁² ψₘ₊₂ - ψₘ₋₂ ψₘ₊₁²`;
-  `ω_spec` below is the equivalent long-Weierstrass form, and the identity itself is proved in
-  the scalar-multiplication development, not here.
+  `ω` the `Y`-coordinate numerator. That exercise is stated in short Weierstrass form and
+  normalises by `4y ωₘ = ψₘ₋₁² ψₘ₊₂ - ψₘ₋₂ ψₘ₊₁²`, a right-hand side that `ψ_mul_ψc` reads as
+  `ψ₂ ψcₘ`; with `a₁ = a₃ = 0`, where `ψ₂ = 2y`, it therefore says `2 ωₘ = ψcₘ`. `ω_spec` below
+  is the long-Weierstrass form, agreeing with Silverman's `ωₘ` exactly when `a₁ = a₃ = 0`: its
+  extra `a₁ φₘ ψₘ + a₃ ψₘ³` is what keeps part (d) true for a general Weierstrass equation. The
+  identity itself is proved in the scalar-multiplication development, not here.
 
 ## Provenance
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -45,18 +45,21 @@ and naturality in the coefficient ring for both families.
 ## References
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], Exercise 3.7, which defines
-  the `(ψ, φ, ω)` triple and whose part (d) is the identity `[m]P = (φₘ/ψₘ², ωₘ/ψₘ³)` that makes
-  `ω` a `Y`-coordinate numerator. The exercise is posed for a general Weierstrass equation
-  `y² + a₁xy + a₃y = x³ + a₂x² + a₄x + a₆`, the short form being offered only as an optional
-  simplification. Its printed normalisation `4y ωₘ = ψₘ₋₁² ψₘ₊₂ + ψₘ₋₂ ψₘ₊₁²` is corrected by
-  Silverman's errata (the entry `Pages 105-106, Exercise 3.7` of
+  the `(ψ, φ, ω)` triple for a general Weierstrass equation
+  `y² + a₁xy + a₃y = x³ + a₂x² + a₄x + a₆` (the short form is offered there only as an optional
+  simplification), and whose part (d), `[m]P = (φₘ/ψₘ², ωₘ/ψₘ³)`, is what makes `ω` a
+  `Y`-coordinate numerator. That identity is proved in the scalar-multiplication development, not
+  here, and it is the thing that fixes the normalisation of `ω` taken here.
+
+  The exercise's own recurrence fixes a different normalisation, and the two part company off the
+  short form. Its printed `4y ωₘ = ψₘ₋₁² ψₘ₊₂ + ψₘ₋₂ ψₘ₊₁²` is corrected by Silverman's errata
+  (the entry `Pages 105-106, Exercise 3.7` of
   `math.brown.edu/johsilve/AEC/AECErrata2013.pdf`) to
-  `2 (2y + a₁x + a₃) ωₘ = ψₘ₋₁² ψₘ₊₂ - ψₘ₋₂ ψₘ₊₁²`, whose right-hand side `ψ_mul_ψc` reads as
-  `ψ₂ ψcₘ`: Silverman's `ωₘ` is `ψcₘ / 2`. `ω_spec` below differs from that by the
-  `a₁ φₘ ψₘ + a₃ ψₘ³` it carries, so the two agree exactly when `a₁ = a₃ = 0`. Silverman's
-  `ωₘ/ψₘ³` evaluates to `(2Y + a₁X + a₃)/2` at `[m]P`, where the `ω` defined here evaluates to
-  the `Y`-coordinate itself, which is what `ω_one` records at `m = 1`. That identity is proved in
-  the scalar-multiplication development, not here.
+  `2 (2y + a₁x + a₃) ωₘ = ψₘ₋₁² ψₘ₊₂ - ψₘ₋₂ ψₘ₊₁²`; as `ψ_mul_ψc` reads that right-hand side as
+  `ψ₂ ψcₘ`, and `ψ₂ = 2y + a₁x + a₃`, the corrected recurrence says `2 ωₘ = ψcₘ`, so `ω₁` is
+  `(2y + a₁x + a₃)/2`. Part (d) instead forces `ω₁ = y`, which is what `ω_one` records; the two
+  normalisations agree exactly when `a₁ = a₃ = 0`. `ω_spec` below is the part-(d) one, its extra
+  `a₁ φₘ ψₘ + a₃ ψₘ³` being precisely that discrepancy.
 
 ## Provenance
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -46,12 +46,17 @@ and naturality in the coefficient ring for both families.
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], Exercise 3.7, which defines
   the `(ψ, φ, ω)` triple and whose part (d) is the identity `[m]P = (φₘ/ψₘ², ωₘ/ψₘ³)` that makes
-  `ω` the `Y`-coordinate numerator. That exercise is stated in short Weierstrass form and
-  normalises by `4y ωₘ = ψₘ₋₁² ψₘ₊₂ - ψₘ₋₂ ψₘ₊₁²`, a right-hand side that `ψ_mul_ψc` reads as
-  `ψ₂ ψcₘ`; with `a₁ = a₃ = 0`, where `ψ₂ = 2y`, it therefore says `2 ωₘ = ψcₘ`. `ω_spec` below
-  is the long-Weierstrass form, agreeing with Silverman's `ωₘ` exactly when `a₁ = a₃ = 0`: its
-  extra `a₁ φₘ ψₘ + a₃ ψₘ³` is what keeps part (d) true for a general Weierstrass equation. The
-  identity itself is proved in the scalar-multiplication development, not here.
+  `ω` a `Y`-coordinate numerator. The exercise is posed for a general Weierstrass equation
+  `y² + a₁xy + a₃y = x³ + a₂x² + a₄x + a₆`, the short form being offered only as an optional
+  simplification. Its printed normalisation `4y ωₘ = ψₘ₋₁² ψₘ₊₂ + ψₘ₋₂ ψₘ₊₁²` is corrected by
+  Silverman's errata (the entry `Pages 105-106, Exercise 3.7` of
+  `math.brown.edu/johsilve/AEC/AECErrata2013.pdf`) to
+  `2 (2y + a₁x + a₃) ωₘ = ψₘ₋₁² ψₘ₊₂ - ψₘ₋₂ ψₘ₊₁²`, whose right-hand side `ψ_mul_ψc` reads as
+  `ψ₂ ψcₘ`: Silverman's `ωₘ` is `ψcₘ / 2`. `ω_spec` below differs from that by the
+  `a₁ φₘ ψₘ + a₃ ψₘ³` it carries, so the two agree exactly when `a₁ = a₃ = 0`. Silverman's
+  `ωₘ/ψₘ³` evaluates to `(2Y + a₁X + a₃)/2` at `[m]P`, where the `ω` defined here evaluates to
+  the `Y`-coordinate itself, which is what `ω_one` records at `m = 1`. That identity is proved in
+  the scalar-multiplication development, not here.
 
 ## Provenance
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -15,9 +15,9 @@ public import TauCeti.NumberTheory.EllipticDivisibilitySequence.ReducedInvariant
 
 `ω n` is the bivariate polynomial that the scalar-multiplication development identifies as the
 second (Jacobian) coordinate of multiplication by `n` on a Weierstrass curve — that
-identification is proved there, not here. This file supplies the polynomial itself, completing
-the `(φ, ψ)` pair of Mathlib's division-polynomial API: it defines `ω` and the 2-complement
-`ψc` of `ψ`, and proves the defining identity
+identification belongs there, not here, and is not yet in the library. This file supplies the
+polynomial itself, completing the `(φ, ψ)` pair of Mathlib's division-polynomial API: it defines
+`ω` and the 2-complement `ψc` of `ψ`, and proves the defining identity
 
 `2 ω n + a₁ φ n ψ n + a₃ (ψ n)³ = ψc n`,
 
@@ -48,8 +48,10 @@ and naturality in the coefficient ring for both families.
   the `(ψ, φ, ω)` triple for a general Weierstrass equation
   `y² + a₁xy + a₃y = x³ + a₂x² + a₄x + a₆` (the short form is offered there only as an optional
   simplification), and whose part (d), `[m]P = (φₘ/ψₘ², ωₘ/ψₘ³)`, is what makes `ω` a
-  `Y`-coordinate numerator. That identity is proved in the scalar-multiplication development, not
-  here, and it is the thing that fixes the normalisation of `ω` taken here.
+  `Y`-coordinate numerator and fixes the normalisation of `ω` taken here. Part (d) has no Lean
+  statement anywhere in this library yet: `DivisionPolynomial/ZSMul.lean` defines `smulY n` as
+  `ωₙ/ψₙ³`, but identifying that rational function with the `Y`-coordinate of `n • P` remains to
+  be proved.
 
   The exercise's own recurrence fixes a different normalisation, and the two part company off the
   short form. Its printed `4y ωₘ = ψₘ₋₁² ψₘ₊₂ + ψₘ₋₂ ψₘ₊₁²` is corrected by Silverman's errata

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -42,6 +42,14 @@ and naturality in the coefficient ring for both families.
 * `WeierstrassCurve.map_ψc`, `.map_ω`, `.baseChange_ψc`, `.baseChange_ω`: naturality in the
   coefficient ring, in both the ring-hom and the algebra-tower form of the `ψ`/`φ` siblings.
 
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], Exercise 3.7, which defines
+  the `(ψ, φ, ω)` triple and whose part (d) is the identity `[m]P = (φₘ/ψₘ², ωₘ/ψₘ³)` that makes
+  `ω` the `Y`-coordinate numerator. Silverman normalises by `4y ωₘ = ψₘ₋₁² ψₘ₊₂ + ψₘ₋₂ ψₘ₊₁²`;
+  `ω_spec` below is the equivalent long-Weierstrass form, and the identity itself is proved in
+  the scalar-multiplication development, not here.
+
 ## Provenance
 
 Ported from J. Xu and D. K. Angdinata's `LutzNagell/DivisionPolynomialOmega.lean` in AINTLIB

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Omega.lean
@@ -46,7 +46,7 @@ and naturality in the coefficient ring for both families.
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], Exercise 3.7, which defines
   the `(ψ, φ, ω)` triple and whose part (d) is the identity `[m]P = (φₘ/ψₘ², ωₘ/ψₘ³)` that makes
-  `ω` the `Y`-coordinate numerator. Silverman normalises by `4y ωₘ = ψₘ₋₁² ψₘ₊₂ + ψₘ₋₂ ψₘ₊₁²`;
+  `ω` the `Y`-coordinate numerator. Silverman normalises by `4y ωₘ = ψₘ₋₁² ψₘ₊₂ - ψₘ₋₂ ψₘ₊₁²`;
   `ω_spec` below is the equivalent long-Weierstrass form, and the identity itself is proved in
   the scalar-multiplication development, not here.
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/RelativeFrobenius.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/RelativeFrobenius.lean
@@ -80,7 +80,14 @@ AEC II.2.12, and Verschiebung remain.
 
 ## References
 
-* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.11, whose N.B. is the
+  reason this file exists: over an imperfect `F`, parts (b) and (c) (pure inseparability and
+  degree `p`) survive unchanged, but part (a), the identification `φ* F(W⁽ᵖ⁾) = F(W)ᵖ`, does not.
+  Accordingly only the containment `F(W)ᵖ ⊆ φ* F(W⁽ᵖ⁾)` is proved here, as
+  `TauCeti.Isogeny.pow_mem_fieldRange_relativeFrobeniusIsogeny`, which is all pure
+  inseparability needs. Over a finite, hence perfect, base there is no gap, and
+  `Isogeny/Frobenius.lean` identifies the pullback with the `q`-power map outright
+  (`fieldPullback_frobeniusIsogeny`).
 
 ## Provenance
 


### PR DESCRIPTION
This PR names the numbered results behind two elliptic-curve files.

`Isogeny/RelativeFrobenius.lean` referenced II.2 while its own theorem docstrings already cite
II.2.11(b) and II.2.11(c). The reference now names the proposition and records its N.B.: over an
imperfect base, parts (b) and (c) survive but part (a), the identification `φ* F(W⁽ᵖ⁾) = F(W)ᵖ`,
does not. That is exactly why this file proves only the containment
`pow_mem_fieldRange_relativeFrobeniusIsogeny`, where `Isogeny/Frobenius.lean` can identify the
pullback with the `q`-power map outright over a finite base.

`DivisionPolynomial/Omega.lean` cited no Silverman at all. Exercise 3.7 is where the `(ψ, φ, ω)`
triple is defined and where part (d) gives `[m]P = (φₘ/ψₘ², ωₘ/ψₘ³)`; the entry also records
that Silverman's normalisation differs from `ω_spec`, and that the multiplication-by-`n` identity
itself is not proved in this file.

Roadmap: EllipticCurves

🤖 Prepared with Claude Code