### PR TITLE
doc(OptimalTransport): cite Villani for couplings, transport cost and gluing

### DIFF
--- a/TauCeti/MeasureTheory/OptimalTransport/Cost.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Cost.lean
@@ -75,6 +75,14 @@ integral along a pushforward (`TauCeti.transportCost_comp_swap`,
 This supplies the nonnegative-cost interface from Layer 1, item 1 of the optimal-transport
 roadmap. The parallel signed `EReal` interface for costs bounded below by an integrable split
 function is a separate definition family and is not part of this module.
+
+## References
+
+* C. Villani, *Topics in Optimal Transportation*, Graduate Studies in Mathematics 58, 2003,
+  §1.1.1, where "Kantorovich's mass transportation problem consists in minimizing the linear
+  functional `π ↦ ∫ c dπ`" over the transference plans. Villani takes `μ` and `ν` to be
+  probability measures and `c` nonnegative measurable; `TauCeti.transportCost` drops the
+  normalisation and reads `c` into `ℝ≥0∞`, so an infeasible pair simply gets the value `∞`.
 -/
 
 public section

--- a/TauCeti/MeasureTheory/OptimalTransport/Coupling.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Coupling.lean
@@ -60,6 +60,13 @@ elaborate there anyway. Dot notation on `hπ` works under either namespace; the 
 forced by the lint rule and matches `TauCeti.MultiCoupling`.
 
 This is Layer 0, item 1 of the optimal-transport roadmap.
+
+## References
+
+* C. Villani, *Optimal Transport: Old and New*, Grundlehren 338, 2009, Chapter 1
+  ("Couplings and changes of variables"), Definition 1.1, which is this relation for two
+  probability measures. `TauCeti.IsCoupling` states it for arbitrary measures, so the
+  probability case is the bundled `TauCeti.Coupling`.
 -/
 
 public section

--- a/TauCeti/MeasureTheory/OptimalTransport/Gluing.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Gluing.lean
@@ -58,6 +58,14 @@ The hypothesis relating the two plans is stated as `π.snd = σ.fst` rather than
 predicate: gluing needs neither of the two outer marginals, only the agreement of the middle one,
 and stating it this way keeps the theorems usable by any packaging of couplings built on
 `MeasureTheory.Measure.fst`/`MeasureTheory.Measure.snd`.
+
+## References
+
+* C. Villani, *Topics in Optimal Transportation*, Graduate Studies in Mathematics 58, 2003,
+  Lemma 7.6 ("Gluing lemma"), and *Optimal Transport: Old and New*, Grundlehren 338, 2009,
+  Chapter 1. Both state it for three Polish probability spaces; the versions here ask for a
+  standard Borel structure on one outer space only, nothing on the middle space `Y`, and no
+  normalisation of the plans.
 -/
 
 public section


### PR DESCRIPTION
This PR gives `TauCeti/MeasureTheory/OptimalTransport/` its first literature references. The
directory carried roadmap pointers but no textbook citation in any of its seven files, so a
reader had nothing to check the conventions against.

`Coupling.lean` now cites Villani, *Optimal Transport: Old and New*, Chapter 1, Definition 1.1;
`Cost.lean` cites *Topics in Optimal Transportation* §1.1.1, where the Kantorovich problem is
"minimizing the linear functional `π ↦ ∫ c dπ`"; `Gluing.lean` cites Lemma 7.6 of the same book.
Each entry also names where the statement here is more general than the book's: arbitrary rather
than probability measures, `ℝ≥0∞`-valued costs, and a standard Borel hypothesis on one outer
space rather than three Polish spaces.

Roadmap: OptimalTransport

🤖 Prepared with Claude Code