### PR TITLE
doc: fill in the bibliography the docstrings cite

### DIFF
--- a/docbuild/docs/references.bib
+++ b/docbuild/docs/references.bib
@@ -45,6 +45,17 @@
   year      = {2005}
 }
 
+@book{fulton-harris1991,
+  author    = {Fulton, William and Harris, Joe},
+  title     = {Representation Theory: A First Course},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {129},
+  publisher = {Springer-Verlag},
+  address   = {New York},
+  year      = {1991},
+  note      = {Readings in Mathematics}
+}
+
 @book{fulton1997,
   author    = {Fulton, William},
   title     = {Young Tableaux: With Applications to Representation Theory and Geometry},
@@ -53,6 +64,14 @@
   publisher = {Cambridge University Press},
   address   = {Cambridge},
   year      = {1997}
+}
+
+@unpublished{grinberg_clifford_2016,
+  author = {Grinberg, Darij},
+  title  = {The Clifford algebra and the Chevalley map: a computational approach (summary
+            version 1)},
+  year   = {2016},
+  url    = {http://mit.edu/~darij/www/algebra/chevalleys.pdf}
 }
 
 @book{humphreys1972,
@@ -164,8 +183,9 @@
 @misc{stacks,
   author = {The {Stacks Project Authors}},
   title  = {The Stacks Project},
-  year   = {2026},
-  url    = {https://stacks.math.columbia.edu}
+  url    = {https://stacks.math.columbia.edu},
+  note   = {Continuously updated; no publication date. Citations here give a permanent tag,
+            which identifies a result across revisions, so no snapshot date is needed}
 }
 
 @book{tenenbaum1995,
@@ -177,4 +197,11 @@
   address   = {Cambridge},
   year      = {1995},
   note      = {Translated from the second French edition by C. B. Thomas}
+}
+
+@misc{wedhorn_adic,
+  author = {Wedhorn, Torsten},
+  title  = {Adic Spaces},
+  year   = {2019},
+  eprint = {arXiv:1910.05934}
 }

--- a/docbuild/docs/references.bib
+++ b/docbuild/docs/references.bib
@@ -1,1 +1,180 @@
 % Tau Ceti bibliography. Add BibTeX entries here to cite them from docstrings.
+%
+% A docstring cites an entry with the markdown reference-link form
+% `[A. Author, *Title*][key]`, which doc-gen4 resolves against this file. A key with no
+% entry here renders as a bare bracketed word, so every key used under `TauCeti/` needs one.
+% Keys are ordered alphabetically.
+
+@book{bourbaki1968,
+  author    = {Bourbaki, Nicolas},
+  title     = {Lie Groups and Lie Algebras, Chapters 4--6},
+  series    = {Elements of Mathematics},
+  publisher = {Springer-Verlag},
+  address   = {Berlin},
+  year      = {2002},
+  note      = {Translated from the 1968 French original by Andrew Pressley}
+}
+
+@article{brauer1937,
+  author  = {Brauer, Richard},
+  title   = {On algebras which are connected with the semisimple continuous groups},
+  journal = {Annals of Mathematics},
+  volume  = {38},
+  number  = {4},
+  pages   = {857--872},
+  year    = {1937}
+}
+
+@book{carter1972,
+  author    = {Carter, Roger W.},
+  title     = {Simple Groups of Lie Type},
+  series    = {Pure and Applied Mathematics},
+  volume    = {28},
+  publisher = {John Wiley \& Sons},
+  address   = {London},
+  year      = {1972}
+}
+
+@book{diamondshurman2005,
+  author    = {Diamond, Fred and Shurman, Jerry},
+  title     = {A First Course in Modular Forms},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {228},
+  publisher = {Springer-Verlag},
+  address   = {New York},
+  year      = {2005}
+}
+
+@book{fulton1997,
+  author    = {Fulton, William},
+  title     = {Young Tableaux: With Applications to Representation Theory and Geometry},
+  series    = {London Mathematical Society Student Texts},
+  volume    = {35},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  year      = {1997}
+}
+
+@book{humphreys1972,
+  author    = {Humphreys, James E.},
+  title     = {Introduction to Lie Algebras and Representation Theory},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {9},
+  publisher = {Springer-Verlag},
+  address   = {New York},
+  year      = {1972}
+}
+
+@book{james1978,
+  author    = {James, Gordon D.},
+  title     = {The Representation Theory of the Symmetric Groups},
+  series    = {Lecture Notes in Mathematics},
+  volume    = {682},
+  publisher = {Springer-Verlag},
+  address   = {Berlin},
+  year      = {1978}
+}
+
+@book{macdonald1995,
+  author    = {Macdonald, Ian G.},
+  title     = {Symmetric Functions and Hall Polynomials},
+  edition   = {2},
+  series    = {Oxford Mathematical Monographs},
+  publisher = {The Clarendon Press, Oxford University Press},
+  address   = {New York},
+  year      = {1995}
+}
+
+@book{milne2017,
+  author    = {Milne, James S.},
+  title     = {Algebraic Groups: The Theory of Group Schemes of Finite Type over a Field},
+  series    = {Cambridge Studies in Advanced Mathematics},
+  volume    = {170},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  year      = {2017}
+}
+
+@book{sagan2001,
+  author    = {Sagan, Bruce E.},
+  title     = {The Symmetric Group: Representations, Combinatorial Algorithms, and Symmetric
+               Functions},
+  edition   = {2},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {203},
+  publisher = {Springer-Verlag},
+  address   = {New York},
+  year      = {2001}
+}
+
+@book{serre1965,
+  author    = {Serre, Jean-Pierre},
+  title     = {Complex Semisimple Lie Algebras},
+  publisher = {Springer-Verlag},
+  address   = {New York},
+  year      = {1987},
+  note      = {Translated by G. A. Jones from the French original, Algèbres de Lie
+               semi-simples complexes, Benjamin, New York, 1966; reprinted in Springer
+               Monographs in Mathematics, 2001}
+}
+
+@book{serre1973,
+  author    = {Serre, Jean-Pierre},
+  title     = {A Course in Arithmetic},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {7},
+  publisher = {Springer-Verlag},
+  address   = {New York--Heidelberg},
+  year      = {1973}
+}
+
+@book{serre1977,
+  author    = {Serre, Jean-Pierre},
+  title     = {Linear Representations of Finite Groups},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {42},
+  publisher = {Springer-Verlag},
+  address   = {New York--Heidelberg},
+  year      = {1977},
+  note      = {Translated from the second French edition by Leonard L. Scott}
+}
+
+@book{shimura1971,
+  author    = {Shimura, Goro},
+  title     = {Introduction to the Arithmetic Theory of Automorphic Functions},
+  series    = {Publications of the Mathematical Society of Japan},
+  volume    = {11},
+  publisher = {Iwanami Shoten and Princeton University Press},
+  address   = {Princeton, NJ},
+  year      = {1971},
+  note      = {Kanô Memorial Lectures 1}
+}
+
+@book{silverman2009,
+  author    = {Silverman, Joseph H.},
+  title     = {The Arithmetic of Elliptic Curves},
+  edition   = {2},
+  series    = {Graduate Texts in Mathematics},
+  volume    = {106},
+  publisher = {Springer},
+  address   = {Dordrecht},
+  year      = {2009}
+}
+
+@misc{stacks,
+  author = {The {Stacks Project Authors}},
+  title  = {The Stacks Project},
+  year   = {2026},
+  url    = {https://stacks.math.columbia.edu}
+}
+
+@book{tenenbaum1995,
+  author    = {Tenenbaum, Gérald},
+  title     = {Introduction to Analytic and Probabilistic Number Theory},
+  series    = {Cambridge Studies in Advanced Mathematics},
+  volume    = {46},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  year      = {1995},
+  note      = {Translated from the second French edition by C. B. Thomas}
+}

--- a/docbuild/docs/references.bib
+++ b/docbuild/docs/references.bib
@@ -4,6 +4,12 @@
 % `[A. Author, *Title*][key]`, which doc-gen4 resolves against this file. A key with no
 % entry here renders as a bare bracketed word, so every key used under `TauCeti/` needs one.
 % Keys are ordered alphabetically.
+%
+% Nine keys are shared with mathlib4's `docs/references.bib` (Apache 2.0): bourbaki1968,
+% diamondshurman2005, grinberg_clifford_2016, humphreys1972, serre1965, serre1973,
+% shimura1971, silverman2009 and wedhorn_adic. Those key names, and the key/year pairings
+% that do not match the edition cited (bourbaki1968, serre1965), follow Mathlib; the entries
+% below are written out in this file's format.
 
 @book{bourbaki1968,
   author    = {Bourbaki, Nicolas},
@@ -200,8 +206,10 @@
 }
 
 @misc{wedhorn_adic,
-  author = {Wedhorn, Torsten},
-  title  = {Adic Spaces},
-  year   = {2019},
-  eprint = {arXiv:1910.05934}
+  author        = {Wedhorn, Torsten},
+  title         = {Adic Spaces},
+  year          = {2019},
+  eprint        = {1910.05934},
+  archiveprefix = {arXiv},
+  url           = {https://arxiv.org/abs/1910.05934}
 }


### PR DESCRIPTION
This PR supplies the twenty BibTeX entries that `TauCeti/` docstrings already cite by key.
`docbuild/docs/references.bib` has held a single comment line since the doc-gen4 build was added
in #1077, so every reference-link citation renders as a bare bracketed key on the published API
docs and `/docs/references.html` is empty. There are 210 such citations, led by `shimura1971`
(61), `wedhorn_adic` (43), `fulton1997` (18), `james1978` (15) and `diamondshurman2005` (15).

Nine of the twenty keys are shared with mathlib4's `docs/references.bib` (Apache 2.0):
`bourbaki1968`, `diamondshurman2005`, `grinberg_clifford_2016`, `humphreys1972`, `serre1965`,
`serre1973`, `shimura1971`, `silverman2009` and `wedhorn_adic`. Those key names, and the
key/year pairings that do not match the edition cited, come from Mathlib along with the
citations themselves; the header records that. The entries are written out in this file's
format rather than copied field for field.

The key set is closed: each of the twenty keys used under `TauCeti/` gets an entry, and no
entry is unused. Three keys carry a year that does not match any edition of the work they name.
`bourbaki1968` is the 1968 French original, cited here in Andrew Pressley's 2002 Springer
translation, which is the title the docstrings use. `serre1965` is *Complex Semisimple Lie
Algebras*, whose French original is Benjamin 1966 and whose translation is Springer 1987; the
entry records both. `stacks` is undated by nature, so it carries no `year`: the docstring cites
it by permanent tag, which identifies a result across revisions. Renaming keys would touch every
citing file, so it is left out of this PR.

Note that `docbuild/` is human-owned, so this needs review rather than the AI merge path.

Roadmap: none

🤖 Prepared with Claude Code