### PR TITLE
doc: say what the tool does automatically, and how to repair the rest

### DIFF
--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -1,10 +1,7 @@
 # Toolchain tags
 
-Tau Ceti carries a plain `vX.Y.Z` tag for each Lean release, the way Mathlib does, so a
-project on Lean v4.34.0 can check out `v4.34.0` here and get a tree that builds.
-
-`scripts/toolchain_tags.py` is the authority on what exists, what does not, and what to do
-about it. It prints the rule with its report, so nothing below is needed to act on a gap.
+Tau Ceti tags eligible Lean releases as `vX`, the way Mathlib does, so a project on Lean
+v4.34.0 can check out `v4.34.0` here and get a tree that builds.
 
 ## The rule
 
@@ -13,50 +10,34 @@ about it. It prints the rule with its report, so nothing below is needed to act 
 Mathlib puts its `vX` tag on the commit that bumps its own `lean-toolchain` to X, and
 `scripts/check-bump.sh` requires this repository's toolchain to match Mathlib's at whatever
 it pins. The first `main` commit on toolchain X therefore pins Mathlib at or after Mathlib's
-`vX` tag. Finding every tag target means reading `lean-toolchain` at the few commits that
-change it, and nothing else.
+`vX` tag. The tag message gives the pin.
 
-An earlier design aimed at *exact* Mathlib pins. That required constructing release commits
-on their own branches, building them from source, and publishing their caches, and it did
-not survive review. A pin a little past Mathlib's tag is not worth that much machinery; the
-tag message gives the pin.
+Exact Mathlib pins were tried and dropped: they need release commits constructed on their
+own branches, built from source, and their caches published.
 
 ## What a tag promises
 
 The commit is on that Lean toolchain, its post-merge CI passed, and its oleans are in the
-Lake artifact cache, so a checkout builds without recompiling the library. Both facts are
-checked before a tag is created, and neither needs a rebuild: `main` already did the work
-and recorded it.
+Lake artifact cache, so a checkout builds without recompiling the library. The tool checks
+the recorded CI result and the published cache; neither needs a rebuild.
 
 ## What it does not cover
 
-A release `main` never ran on gets no tag, and nothing here will construct one, but the
-report still lists it as `unreachable` rather than leaving it out: an audit whose job is to
-say which releases have no tag is not allowed to answer by omission. Today that is
-`v4.33.0`, whose window on Mathlib master was fifteen hours and which the daily bump stepped
-straight over, and the patch releases `v4.32.1` and `v4.32.2`, which Mathlib cut on its
-`stable` branch and which `check-bump.sh` could never have let this repository pin at all.
+The tool tags only commits on `main`, and reports a release `main` never ran on as
+`unreachable`. Two things cause that, and they differ in what can be done about them: the
+daily bump stepped over the release's window on Mathlib master, which a later bump could
+avoid, or Mathlib cut the release on its `stable` branch, which `check-bump.sh` will not let
+this repository pin at all.
 
-Knowing which of those two it is matters. A stepped-over release is a near miss the bump
-could avoid another day; a `stable`-branch release is permanently out of reach and no
-amount of automation here will change that.
+Such a release can still be tagged by hand off a `main` commit. `v4.33.0` is one: a commit
+off `afb1aacb` changing only the two pin files, built from source, with its cache uploaded
+manually. The report marks it `tagged`, notes that it was constructed, and says whether it
+found a cache. `--create` does not construct these; the procedure is in the module docstring
+of `scripts/toolchain_tags.py`.
 
-Such a release can still be tagged by hand, off a `main` commit, and `v4.33.0` was: one
-commit off `afb1aacb`, the last `main` commit before the bump jumped, changing only the two
-pin files so that no source differs from that commit. It was built from source against
-mathlib v4.33.0, passes the audits, and its oleans were uploaded to the Lake cache by hand,
-so a checkout of it builds without recompiling: verified from a fresh clone, 7439 targets
-up to date in eighteen seconds.
-
-Nothing publishes for a commit off `main` automatically, so that upload was a manual step
-(`lake cache stage`, then `lake cache put-staged` from a modern Lake with `--rev` and
-`--toolchain`, since v4.33.0's own Lake has neither flag). The report therefore asks the
-cache rather than assuming: it calls such a tag `tagged`, says it was constructed by hand,
-and says whether a cache was found. `--create` will never make one.
-
-Releases older than `v4.33.0-rc1` are out of scope, because the Lake cache does not reach
-back that far and a tag could not promise a usable one. That bound is `EARLIEST_RELEASE` in
-the script; raise it if the cache is ever pruned, never lower it.
+Releases older than `v4.33.0-rc1` are out of scope, because the Lake cache has no older
+entries. That bound is `EARLIEST_RELEASE` in the script; raise it if the cache is pruned,
+never lower it.
 
 ## Using it
 
@@ -66,8 +47,7 @@ python3 scripts/toolchain_tags.py --create v4.34.0     # one tag
 python3 scripts/toolchain_tags.py --create --all       # every ready release
 ```
 
-Run it after a bump lands on a new toolchain. There is no schedule, because every run of
-`--create` leaves a permanent tag and nothing here is urgent enough to do unattended. Creating a tag needs a `gh` login with write access; the report needs only read.
+Run `--create` after a bump lands on a new toolchain. It needs a `gh` login with write
+access; the report needs only read.
 
-Tags are never moved. If one disagrees with the rule, the tool reports it and stops; that
-is a question for a human, and no instruction it prints will delete or force a tag.
+If a tag does not match the rule, the tool reports it and changes nothing.

--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -10,19 +10,16 @@ about it. It prints the rule with its report, so nothing below is needed to act 
 
 **`vX` is the first commit on `main` whose `lean-toolchain` is `leanprover/lean4:X`.**
 
-That is the whole policy, and it is deliberately not cleverer than that.
+Mathlib puts its `vX` tag on the commit that bumps its own `lean-toolchain` to X, and
+`scripts/check-bump.sh` requires this repository's toolchain to match Mathlib's at whatever
+it pins. The first `main` commit on toolchain X therefore pins Mathlib at or after Mathlib's
+`vX` tag. Finding every tag target means reading `lean-toolchain` at the few commits that
+change it, and nothing else.
 
-It gives the property worth having for free. Mathlib puts its own `vX` tag on the commit
-that bumps its `lean-toolchain` to X, and `scripts/check-bump.sh` already forces this
-repository's toolchain to equal Mathlib's at whatever it pins. So the first `main` commit
-on toolchain X necessarily pins Mathlib at or after Mathlib's own `vX` tag. Nothing has to
-compute that, compare pins, derive a base, or ask Mathlib anything: reading `lean-toolchain`
-at the handful of commits that change it is enough to find every tag target.
-
-An earlier design chased *exact* Mathlib pins, which meant constructing release commits on
-their own branches, building them from source, and publishing their caches, none of which
-survived review. The pin being a little past Mathlib's tag is not worth that machinery. The
-tag message records the pin so a reader can see for themselves.
+An earlier design aimed at *exact* Mathlib pins. That required constructing release commits
+on their own branches, building them from source, and publishing their caches, and it did
+not survive review. A pin a little past Mathlib's tag is not worth that much machinery; the
+tag message gives the pin.
 
 ## What a tag promises
 
@@ -69,9 +66,8 @@ python3 scripts/toolchain_tags.py --create v4.34.0     # one tag
 python3 scripts/toolchain_tags.py --create --all       # every ready release
 ```
 
-Run it after a bump lands on a new toolchain. It is deliberately not on a schedule: every
-run of `--create` leaves a permanent tag, and there is no hurry that justifies making that
-unattended. Creating a tag needs a `gh` login with write access; the report needs only read.
+Run it after a bump lands on a new toolchain. There is no schedule, because every run of
+`--create` leaves a permanent tag and nothing here is urgent enough to do unattended. Creating a tag needs a `gh` login with write access; the report needs only read.
 
 Tags are never moved. If one disagrees with the rule, the tool reports it and stops; that
 is a question for a human, and no instruction it prints will delete or force a tag.

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -147,7 +147,7 @@ class Report(unittest.TestCase):
 
     def test_the_rule_is_part_of_the_output(self):
         text = tt.render(self.ROWS)
-        self.assertIn("FIRST commit on `main`", text)
+        self.assertIn("first commit on `main`", text)
         self.assertIn("Tags are never moved", text)
 
     def test_it_names_the_command_for_each_ready_release(self):
@@ -277,7 +277,7 @@ class CommandLine(unittest.TestCase):
         out = io.StringIO()
         with redirect_stdout(out), self.assertRaises(SystemExit):
             tt.main(["--help"])
-        self.assertIn("FIRST commit on `main`", out.getvalue())
+        self.assertIn("first commit on `main`", out.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -148,7 +148,7 @@ class Report(unittest.TestCase):
     def test_the_rule_is_part_of_the_output(self):
         text = tt.render(self.ROWS)
         self.assertIn("first commit on `main`", text)
-        self.assertIn("Tags are never moved", text)
+        self.assertIn("reports it and changes nothing", text)
 
     def test_it_names_the_command_for_each_ready_release(self):
         text = tt.render(self.ROWS)

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -1,52 +1,50 @@
 #!/usr/bin/env python3
 """Audit and create Tau Ceti's Lean toolchain tags (`v4.33.0-rc2`, `v4.34.0`, ...).
 
-Mathlib tags every Lean release, so a downstream project on Lean v4.34.0 can check out
-mathlib at `v4.34.0` and get a tree that builds. This gives Tau Ceti the same thing.
+Mathlib tags every Lean release, so a project on Lean v4.34.0 can check out mathlib at
+`v4.34.0` and get a tree that builds. These tags do the same for Tau Ceti.
 
-## What this tool does automatically
+## What the tool does
 
-`vX` is the FIRST commit on `main` whose `lean-toolchain` is `leanprover/lean4:X`, and
-`--create` tags it once its post-merge CI has passed and its oleans are in the Lake cache.
-Neither check needs a rebuild: `main` already did the work and recorded it.
+`vX` is the first commit on `main` whose `lean-toolchain` is `leanprover/lean4:X`.
+`--create` tags that commit once its post-merge CI has passed and its oleans are in the
+Lake cache. Both facts are already recorded, so no rebuild is needed to check them.
 
-The rule is deliberately not cleverer than that, and it gives the property worth having for
-free. Mathlib puts its own `vX` tag on the commit that bumps its `lean-toolchain` to X, and
-`scripts/check-bump.sh` forces Tau Ceti's toolchain to equal mathlib's at whatever it pins,
-so the first `main` commit on toolchain X necessarily pins mathlib at or after mathlib's own
-`vX` tag. Nothing here compares pins, derives a base, or asks mathlib anything except which
-releases exist. The pin is rarely mathlib's tag exactly; the tag message records it.
+Mathlib puts its `vX` tag on the commit that bumps its own `lean-toolchain` to X, and
+`scripts/check-bump.sh` requires Tau Ceti's toolchain to match mathlib's at whatever it
+pins. The first `main` commit on toolchain X therefore pins mathlib at or after mathlib's
+`vX` tag, without this tool comparing pins or asking mathlib for anything but the list of
+releases. The pin is usually a little past the tag; the tag message gives it.
 
-## What it does not do, and how to repair that by hand
+## What it leaves to a human
 
-It only ever tags a commit on `main`, so a release `main` never ran on is reported
-`unreachable` and left alone. That happens two ways: the daily bump stepped over the
-release's window on mathlib master, which for a stable release has been as short as fifteen
-hours, or mathlib cut it on its `stable` branch where `check-bump.sh` could never have let
-this repository pin it at all.
+Only commits on `main` are tagged. A release `main` never ran on is reported `unreachable`.
+Two things cause that: the daily bump stepped over the release's window on mathlib master,
+which for a stable release has been fifteen hours, or mathlib cut the release on its
+`stable` branch, which `check-bump.sh` will not let this repository pin.
 
-Such a release can still be tagged, by hand, and `v4.33.0` was. The recipe, in full:
+Tagging one anyway takes four steps. `v4.33.0` was done this way:
 
-  1. Branch `releases/vX` from the last `main` commit before the bump jumped, and change
-     ONLY `lean-toolchain` and `lake-manifest.json`, pinning mathlib at its own `vX` tag.
-     No source may differ from that `main` commit.
-  2. Build it from source and run the audits and lints that commit defines. This is the
-     step that can fail, since the pin moves forward by a bump's worth or more.
-  3. Optionally publish its oleans, which nothing does automatically for a commit off
-     `main`: `lake build --no-build -o .lake/outputs.jsonl`, `lake cache stage`, then
-     `lake cache put-staged --rev <sha> --toolchain leanprover/lean4:vX` run from a Lake at
-     v4.34.0-rc1 or later, because older ones have neither flag. Read the mapping back
-     afterwards and diff it against the staged one.
-  4. Tag the commit, annotated, recording that it was constructed and what it promises.
+  1. Branch `releases/vX` from the last `main` commit before the bump jumped. Change
+     `lean-toolchain` and `lake-manifest.json` to pin mathlib at its `vX` tag, and nothing
+     else, so no source differs from that `main` commit.
+  2. Build from source and run the audits and lints that commit defines. The pin moves
+     forward by at least a bump's worth, so this is where it can fail.
+  3. To publish the oleans, which does not happen automatically off `main`:
+     `lake build --no-build -o .lake/outputs.jsonl`, `lake cache stage`, then
+     `lake cache put-staged --rev <sha> --toolchain leanprover/lean4:vX`. Run that from a
+     Lake at v4.34.0-rc1 or later; earlier ones lack both flags. Then fetch the published
+     mapping and diff it against the staged one.
+  4. Create the annotated tag, recording that the commit was constructed.
 
-The report then shows it as `tagged`, notes it was constructed, and says whether it found a
-cache for it. `--create` will never construct such a commit: that is a deliberate manual
-act with a build in the middle of it.
+The report then shows the release as `tagged`, notes the commit was constructed, and says
+whether it found a cache. `--create` will not do any of this: step 2 is a build, and the
+whole thing should be someone's decision.
 
-Releases older than `EARLIEST_RELEASE` are out of scope, cache and all: the Lake cache does
-not reach back that far, so a tag could not promise a usable one.
+Releases older than `EARLIEST_RELEASE` are out of scope, because the Lake cache does not
+reach back that far.
 
-Tags are never moved. If one disagrees with the rule, it is reported and left for a human.
+Tags are never moved. A tag that does not match the rule is reported, not changed.
 
 ## Usage
 
@@ -256,27 +254,26 @@ POLICY = """\
 Tau Ceti toolchain tags
 =======================
 
-`vX` is the FIRST commit on `main` whose lean-toolchain is `leanprover/lean4:X`.
+`vX` is the first commit on `main` whose lean-toolchain is `leanprover/lean4:X`.
 
-That is the whole rule. Mathlib tags the commit that bumps its own toolchain to X, and
-check-bump.sh forces this repository's toolchain to equal mathlib's at whatever it pins, so
-such a commit necessarily pins mathlib at or after mathlib's own `vX` tag. The tag message
-records the pin so a reader can see how far past it is.
+Mathlib puts its `vX` tag on the commit that bumps its own toolchain to X, and
+check-bump.sh requires this repository's toolchain to match mathlib's at whatever it pins,
+so such a commit pins mathlib at or after mathlib's `vX` tag. The tag message gives the pin.
 
-A tag is created only once that commit's post-merge CI has passed and its oleans are in the
-Lake artifact cache, so a checkout builds without recompiling the library. Neither needs a
-rebuild: main already did the work.
+A tag is created once that commit's post-merge CI has passed and its oleans are in the Lake
+artifact cache, so a checkout builds without recompiling the library. Both facts are already
+recorded; checking them needs no rebuild.
 
-This tool only ever tags a commit on main, so a release main never ran on is reported
-`unreachable` and left alone: either the daily bump stepped over its window on mathlib
-master, or mathlib cut it on its `stable` branch where check-bump.sh could never have let
-this repository pin it. Such a release can still be tagged BY HAND, off a main commit, and
-v4.33.0 was; the recipe is in this script's module docstring.
+Only commits on main are tagged. A release main never ran on is reported `unreachable`:
+either the daily bump stepped over its window on mathlib master, or mathlib cut it on its
+`stable` branch, which check-bump.sh will not let this repository pin. Tagging one anyway
+takes four manual steps, including a build; v4.33.0 was done that way, and the steps are in
+this script's module docstring.
 
-Releases older than %s are out of scope: the Lake cache does not reach
-back that far, so a tag could not promise one.
+Releases older than %s are out of scope, because the Lake cache does not reach back that
+far.
 
-Tags are never moved. If one disagrees with this rule, that is a question for a human.
+Tags are never moved. A tag that does not match the rule is reported, not changed.
 """ % EARLIEST_RELEASE
 
 STATUSES = ("tagged", "ready", "blocked", "unreachable", "out-of-scope")

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -8,20 +8,19 @@ Mathlib tags every Lean release, so a project on Lean v4.34.0 can check out math
 
 `vX` is the first commit on `main` whose `lean-toolchain` is `leanprover/lean4:X`.
 `--create` tags that commit once its post-merge CI has passed and its oleans are in the
-Lake cache. Both facts are already recorded, so no rebuild is needed to check them.
+Lake cache. The tool reads both from what is already recorded, without rebuilding.
 
 Mathlib puts its `vX` tag on the commit that bumps its own `lean-toolchain` to X, and
 `scripts/check-bump.sh` requires Tau Ceti's toolchain to match mathlib's at whatever it
 pins. The first `main` commit on toolchain X therefore pins mathlib at or after mathlib's
-`vX` tag, without this tool comparing pins or asking mathlib for anything but the list of
-releases. The pin is usually a little past the tag; the tag message gives it.
+`vX` tag. The pin is usually a little past it; the tag message gives it.
 
 ## What it leaves to a human
 
-Only commits on `main` are tagged. A release `main` never ran on is reported `unreachable`.
-Two things cause that: the daily bump stepped over the release's window on mathlib master,
-which for a stable release has been fifteen hours, or mathlib cut the release on its
-`stable` branch, which `check-bump.sh` will not let this repository pin.
+The tool tags only commits on `main`, and reports a release `main` never ran on as
+`unreachable`. Two things cause that: the daily bump stepped over the release's window on
+mathlib master, which for a stable release has been fifteen hours, or mathlib cut the
+release on its `stable` branch, which `check-bump.sh` will not let this repository pin.
 
 Tagging one anyway takes four steps. `v4.33.0` was done this way:
 
@@ -38,13 +37,12 @@ Tagging one anyway takes four steps. `v4.33.0` was done this way:
   4. Create the annotated tag, recording that the commit was constructed.
 
 The report then shows the release as `tagged`, notes the commit was constructed, and says
-whether it found a cache. `--create` will not do any of this: step 2 is a build, and the
-whole thing should be someone's decision.
+whether it found a cache. `--create` does not do any of this; step 2 is a build.
 
 Releases older than `EARLIEST_RELEASE` are out of scope, because the Lake cache does not
 reach back that far.
 
-Tags are never moved. A tag that does not match the rule is reported, not changed.
+If a tag does not match the rule, the tool reports it and changes nothing.
 
 ## Usage
 
@@ -261,19 +259,19 @@ check-bump.sh requires this repository's toolchain to match mathlib's at whateve
 so such a commit pins mathlib at or after mathlib's `vX` tag. The tag message gives the pin.
 
 A tag is created once that commit's post-merge CI has passed and its oleans are in the Lake
-artifact cache, so a checkout builds without recompiling the library. Both facts are already
-recorded; checking them needs no rebuild.
+artifact cache, so a checkout builds without recompiling the library. The tool reads both
+from what is already recorded, without rebuilding.
 
-Only commits on main are tagged. A release main never ran on is reported `unreachable`:
-either the daily bump stepped over its window on mathlib master, or mathlib cut it on its
-`stable` branch, which check-bump.sh will not let this repository pin. Tagging one anyway
-takes four manual steps, including a build; v4.33.0 was done that way, and the steps are in
-this script's module docstring.
+The tool tags only commits on main, and reports a release main never ran on as
+`unreachable`: either the daily bump stepped over its window on mathlib master, or mathlib
+cut it on its `stable` branch, which check-bump.sh will not let this repository pin. Tagging
+one anyway takes four manual steps, including a build. v4.33.0 was done that way; the steps
+are in this script's module docstring.
 
-Releases older than %s are out of scope, because the Lake cache does not reach back that
-far.
+Releases older than %s are out of scope, because the Lake cache has no
+older entries.
 
-Tags are never moved. A tag that does not match the rule is reported, not changed.
+If a tag does not match the rule, the tool reports it and changes nothing.
 """ % EARLIEST_RELEASE
 
 STATUSES = ("tagged", "ready", "blocked", "unreachable", "out-of-scope")

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -4,42 +4,56 @@
 Mathlib tags every Lean release, so a downstream project on Lean v4.34.0 can check out
 mathlib at `v4.34.0` and get a tree that builds. This gives Tau Ceti the same thing.
 
-## The rule, in one line
+## What this tool does automatically
 
-`vX` is the FIRST commit on `main` whose `lean-toolchain` is `leanprover/lean4:X`.
+`vX` is the FIRST commit on `main` whose `lean-toolchain` is `leanprover/lean4:X`, and
+`--create` tags it once its post-merge CI has passed and its oleans are in the Lake cache.
+Neither check needs a rebuild: `main` already did the work and recorded it.
 
-That is the whole policy, and it is deliberately not cleverer than that. It gives the
-property you actually want for free: mathlib puts its own `vX` tag on the commit that bumps
-its `lean-toolchain` to X, and `scripts/check-bump.sh` already forces Tau Ceti's toolchain
-to equal mathlib's at whatever it pins. So the first `main` commit on toolchain X
-necessarily pins mathlib at or after mathlib's own `vX` tag. Nothing here has to compute
-that, compare pins, derive a base, or ask mathlib anything at all.
+The rule is deliberately not cleverer than that, and it gives the property worth having for
+free. Mathlib puts its own `vX` tag on the commit that bumps its `lean-toolchain` to X, and
+`scripts/check-bump.sh` forces Tau Ceti's toolchain to equal mathlib's at whatever it pins,
+so the first `main` commit on toolchain X necessarily pins mathlib at or after mathlib's own
+`vX` tag. Nothing here compares pins, derives a base, or asks mathlib anything except which
+releases exist. The pin is rarely mathlib's tag exactly; the tag message records it.
 
-Two consequences worth stating plainly, because they are the cost of the simplicity:
+## What it does not do, and how to repair that by hand
 
-  * A release `main` never ran on gets no tag. Today that is `v4.33.0`, whose window on
-    mathlib master was fifteen hours and which the daily bump stepped over, and the patch
-    releases `v4.32.1` and `v4.32.2`, which mathlib cut on its `stable` branch and which
-    `check-bump.sh` could never have let this repository pin in the first place.
-  * The mathlib pin is whatever `main` had, which is at or past mathlib's tag but rarely
-    exactly it. The tag message records the pin so a reader can see how far past.
+It only ever tags a commit on `main`, so a release `main` never ran on is reported
+`unreachable` and left alone. That happens two ways: the daily bump stepped over the
+release's window on mathlib master, which for a stable release has been as short as fifteen
+hours, or mathlib cut it on its `stable` branch where `check-bump.sh` could never have let
+this repository pin it at all.
 
-## What a tag promises
+Such a release can still be tagged, by hand, and `v4.33.0` was. The recipe, in full:
 
-The commit is on that Lean toolchain, its post-merge CI passed, and its oleans are in the
-Lake artifact cache, so a checkout builds without recompiling the library. Both of those
-are checked before a tag is created; neither needs a rebuild, because `main` already did
-the work and recorded it.
+  1. Branch `releases/vX` from the last `main` commit before the bump jumped, and change
+     ONLY `lean-toolchain` and `lake-manifest.json`, pinning mathlib at its own `vX` tag.
+     No source may differ from that `main` commit.
+  2. Build it from source and run the audits and lints that commit defines. This is the
+     step that can fail, since the pin moves forward by a bump's worth or more.
+  3. Optionally publish its oleans, which nothing does automatically for a commit off
+     `main`: `lake build --no-build -o .lake/outputs.jsonl`, `lake cache stage`, then
+     `lake cache put-staged --rev <sha> --toolchain leanprover/lean4:vX` run from a Lake at
+     v4.34.0-rc1 or later, because older ones have neither flag. Read the mapping back
+     afterwards and diff it against the staged one.
+  4. Tag the commit, annotated, recording that it was constructed and what it promises.
 
-Releases before the Lake cache existed, everything up to and including `v4.32.0`, are
-deliberately out of scope: there is no cache to promise. See `EARLIEST_RELEASE`.
+The report then shows it as `tagged`, notes it was constructed, and says whether it found a
+cache for it. `--create` will never construct such a commit: that is a deliberate manual
+act with a build in the middle of it.
+
+Releases older than `EARLIEST_RELEASE` are out of scope, cache and all: the Lake cache does
+not reach back that far, so a tag could not promise a usable one.
+
+Tags are never moved. If one disagrees with the rule, it is reported and left for a human.
 
 ## Usage
 
-    toolchain_tags.py                     # the report
-    toolchain_tags.py --json              # the same, machine-readable
+    toolchain_tags.py                        # the report
+    toolchain_tags.py --json                 # the same, machine-readable
     toolchain_tags.py --create v4.33.0-rc2   # create one tag
-    toolchain_tags.py --create --all      # create every tag that is ready
+    toolchain_tags.py --create --all         # create every tag that is ready
     toolchain_tags.py --create --all --dry-run
 
 ## Environment
@@ -253,11 +267,14 @@ A tag is created only once that commit's post-merge CI has passed and its oleans
 Lake artifact cache, so a checkout builds without recompiling the library. Neither needs a
 rebuild: main already did the work.
 
-A release main never ran on gets no tag, and nothing here will construct one, but it is
-still reported: either the daily bump stepped over its window on mathlib master, or mathlib
-cut it on its `stable` branch and check-bump.sh could never have let this repository pin it.
-Releases older than %s are out of scope: the Lake cache does not reach back that far, so a
-tag could not promise a usable cache.
+This tool only ever tags a commit on main, so a release main never ran on is reported
+`unreachable` and left alone: either the daily bump stepped over its window on mathlib
+master, or mathlib cut it on its `stable` branch where check-bump.sh could never have let
+this repository pin it. Such a release can still be tagged BY HAND, off a main commit, and
+v4.33.0 was; the recipe is in this script's module docstring.
+
+Releases older than %s are out of scope: the Lake cache does not reach
+back that far, so a tag could not promise one.
 
 Tags are never moved. If one disagrees with this rule, that is a question for a human.
 """ % EARLIEST_RELEASE


### PR DESCRIPTION
Both the module docstring and the policy text the report prints still claimed that a release `main` never ran on "gets no tag, and nothing here will construct one". The second half is true of the tool; the first half stopped being true of the repository when `v4.33.0` was tagged by hand off a `main` commit.

The docstring now separates the two. **Automatic**: `vX` is the first `main` commit on toolchain X, and `--create` tags it once its post-merge CI has passed and its oleans are in the Lake cache, neither of which needs a rebuild. **Not automatic**: a release `main` skipped, which is reported `unreachable`, with the four-step recipe this session used to repair one — branch off the last `main` commit before the jump changing only the two pin files, build it and run that commit's audits, optionally stage and publish its oleans with a Lake at v4.34.0-rc1 or later since older ones lack `--rev` and `--service`, then tag it annotated.

The report's own policy text gets the same correction in two sentences and points at the docstring for the recipe, so the output stays short.

Roadmap: none

🤖 Prepared with Claude Code