### PR TITLE
doc: point the Borel and Springer citations at their numbered results

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Embedding.lean
@@ -48,7 +48,9 @@ roadmap's smooth formulation.
 ## References
 
 * J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
-* T. A. Springer, *Linear Algebraic Groups*, §2.4.
+* T. A. Springer, *Linear Algebraic Groups*, Proposition 2.4.12: a subgroup of `GLₙ` consisting
+  of unipotent matrices is conjugate into `Uₙ`. A. Borel, *Linear Algebraic Groups*, §4.8 has the
+  same statement, with its Corollary the closed-subgroup form proved here.
 
 This closes the Kolchin and faithful-embedding step of Layer 5, "Unipotent groups", of the
 ReductiveGroups roadmap for reduced groups over an algebraically closed field.

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Solvable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Solvable.lean
@@ -25,8 +25,10 @@ solvable.
 
 ## References
 
-* A. Borel, *Linear Algebraic Groups*, Proposition 4.8.
-* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+* A. Borel, *Linear Algebraic Groups*, §4.8, Theorem, whose "in particular, `G` is a nilpotent
+  group" is the classical form of what is proved here.
+* T. A. Springer, *Linear Algebraic Groups*, Corollary 2.4.13: a unipotent linear algebraic group
+  is nilpotent, hence solvable.
 
 This completes the point-group solvability implication needed in Layer 5 of the ReductiveGroups
 roadmap.

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Exists.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Exists.lean
@@ -40,7 +40,9 @@ induction in the Lie--Kolchin theorem.
 ## References
 
 * J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
-* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+* T. A. Springer, *Linear Algebraic Groups*, Lemma 2.4.2(i): a set of pairwise commuting
+  matrices is simultaneously conjugate into the upper-triangular matrices, by the induction on an
+  eigenspace of a non-scalar member that is used here.
 -/
 
 public section

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Exists.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Exists.lean
@@ -40,9 +40,11 @@ induction in the Lie--Kolchin theorem.
 ## References
 
 * J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
-* T. A. Springer, *Linear Algebraic Groups*, Lemma 2.4.2(i): a set of pairwise commuting
-  matrices is simultaneously conjugate into the upper-triangular matrices, by the induction on an
-  eigenspace of a non-scalar member that is used here.
+* T. A. Springer, *Linear Algebraic Groups*, Lemma 2.4.2(i): over an algebraically closed field,
+  a set of pairwise commuting matrices is simultaneously conjugate into the upper-triangular
+  matrices, by the induction on an eigenspace of a non-scalar member that is used here.  The
+  results below take triangularizability as a hypothesis instead, so that they also apply over a
+  field that is not algebraically closed.
 -/
 
 public section

--- a/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Kolchin.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/JointEigenvector/Kolchin.lean
@@ -34,8 +34,10 @@ fixed tensor by applying a base-field linear functional to its scalar coefficien
 
 ## References
 
-* A. Borel, *Linear Algebraic Groups*, Proposition 4.8.
-* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+* A. Borel, *Linear Algebraic Groups*, §4.8, Theorem. Its proof is the one used here: pass to an
+  irreducible submodule, span `End V` by Burnside, and kill `g - 1` with the trace pairing.
+* T. A. Springer, *Linear Algebraic Groups*, Proposition 2.4.12, the same statement in the
+  conjugate-into-`Uₙ` form, by the same argument.
 -/
 
 public section


### PR DESCRIPTION
This PR replaces four bare section references with the results they stand for. Borel labels 4.8 a
Theorem rather than a Proposition, and Springer's §2.4 is titled "Jordan decomposition", so neither
pointer reached the statement being cited.

Each of the four files gets the one result that matches it. `Kolchin.lean` and
`Unipotent/Embedding.lean` get Springer's Proposition 2.4.12, a unipotent subgroup of `GLₙ` being
conjugate into `Uₙ`; `Unipotent/Solvable.lean` gets Corollary 2.4.13, a unipotent linear algebraic
group being nilpotent and hence solvable; and `JointEigenvector/Exists.lean` gets Lemma 2.4.2(i),
simultaneous triangularisation of a commuting family. The two proof methods are recorded where they
coincide with the formal ones: Borel §4.8 runs the Burnside-plus-trace argument of `Kolchin.lean`,
and Springer 2.4.2 runs the induction on an eigenspace of a nonscalar member that
`Exists.lean` runs.

The five other files citing Springer §2.4 are untouched: they are about the Jordan decomposition
itself, for which the section reference is the right one.

Roadmap: ReductiveGroups

🤖 Prepared with Claude Code