### PR TITLE
doc: cite Bender-Knuth and Stanley for the involution and the symmetry proof

### DIFF
--- a/TauCeti/Combinatorics/Young/BenderKnuth.lean
+++ b/TauCeti/Combinatorics/Young/BenderKnuth.lean
@@ -53,6 +53,8 @@ endpoints depend only on `a` and `b`, which a recut does not move.
 
 ## References
 
+* E. A. Bender and D. E. Knuth, *Enumeration of plane partitions*, J. Combinatorial Theory **13**
+  (1972), 40--54, where the involution originates.
 * [W. Fulton, *Young Tableaux*][fulton1997], Section 2.2.
 * [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
   Layer 7.

--- a/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Symmetric.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Symmetric/Schur/Symmetric.lean
@@ -51,6 +51,10 @@ polynomials they generalize already live.
 
 ## References
 
+* R. P. Stanley, *Enumerative Combinatorics*, Volume 2, §7.10, Theorem 7.10.2: the skew Schur
+  function is symmetric, proved by the same reduction to interchanging `xᵢ` and `x_{i+1}`. The
+  involution is that of E. A. Bender and D. E. Knuth, *Enumeration of plane partitions*,
+  J. Combinatorial Theory **13** (1972), 40--54.
 * [W. Fulton, *Young Tableaux*][fulton1997], Section 2.2.
 * [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
   Layer 7.


### PR DESCRIPTION
This PR names the two sources behind the Bender-Knuth involution and the symmetry of the Schur
polynomials, neither of which was cited. The involution is from E. A. Bender and D. E. Knuth,
*Enumeration of plane partitions*, J. Combinatorial Theory 13 (1972), 40-54. Stanley,
*Enumerative Combinatorics* Volume 2, Theorem 7.10.2 proves that the skew Schur function is
symmetric by the same reduction the formal proof makes, to invariance under interchanging two
adjacent variables. Fulton's *Young Tableaux* §2.2 stays as the tableau reference.

Roadmap: RepresentationTheory

🤖 Prepared with Claude Code