### PR TITLE
feat: classify all covering spaces by fundamental-groupoid actions

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean
@@ -112,18 +112,20 @@ theorem actionCoveringSpace_proj :
   CoveringSpace.mk_proj _ _
 
 /-- The characteristic equality of total spaces, viewed as a homeomorphism. -/
-def actionCoverTotalSpaceHomeomorph : (actionCoveringSpace x₀ A : TopCat) ≃ₜ ActionCover x₀ A :=
+private def actionCoverTotalSpaceHomeomorph :
+    (actionCoveringSpace x₀ A : TopCat) ≃ₜ ActionCover x₀ A :=
   TopCat.homeoOfIso (eqToIso (actionCoveringSpace_coe x₀ A))
 
 /-- The characteristic total-space homeomorphism commutes with the two projections. -/
 @[simp]
-theorem actionCoverProj_actionCoverTotalSpaceHomeomorph (e : (actionCoveringSpace x₀ A : TopCat)) :
+private theorem actionCoverProj_actionCoverTotalSpaceHomeomorph
+    (e : (actionCoveringSpace x₀ A : TopCat)) :
     actionCoverProj x₀ A (actionCoverTotalSpaceHomeomorph x₀ A e) =
       (actionCoveringSpace x₀ A).proj e :=
   (DFunLike.congr_fun (congrArg TopCat.Hom.hom (actionCoveringSpace_proj x₀ A)) e).symm
 
 /-- Transport from the fibre of the bundled cover to the fibre of its projection. -/
-def actionCoverFiberTransport :
+private def actionCoverFiberTransport :
     ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀} ≃ actionCoverProj x₀ A ⁻¹' {x₀} :=
   ((actionCoverTotalSpaceHomeomorph x₀ A).subtype fun e => by
     simp only [Set.mem_preimage, Set.mem_singleton_iff]
@@ -131,7 +133,7 @@ def actionCoverFiberTransport :
 
 /-- On underlying points, fibre transport applies the characteristic homeomorphism. -/
 @[simp]
-theorem actionCoverFiberTransport_apply_coe
+private theorem actionCoverFiberTransport_apply_coe
     (e : ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀}) :
     (actionCoverFiberTransport x₀ A e : ActionCover x₀ A) =
       actionCoverTotalSpaceHomeomorph x₀ A e :=
@@ -139,7 +141,7 @@ theorem actionCoverFiberTransport_apply_coe
 
 /-- Fibre transport commutes with monodromy. -/
 @[simp]
-theorem actionCoverFiberTransport_apply_monodromy (g : FundamentalGroup X x₀)
+private theorem actionCoverFiberTransport_apply_monodromy (g : FundamentalGroup X x₀)
     (e : ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀}) :
     actionCoverFiberTransport x₀ A
         ((actionCoveringSpace x₀ A).isCoveringMap_proj.monodromy g e) =
@@ -159,14 +161,16 @@ omit [TopologicalSpace A] [DiscreteTopology A] in
 /-- **The fibre of the cover attached to `A` over `x₀` is `A`.** A point of `A` labels the class
 of the pair it forms with the constant-path point of the universal cover. -/
 def actionCoverFiberEquiv : A ≃ actionCoverProj x₀ A ⁻¹' {x₀} :=
-  BalancedProduct.fiberEquiv A _ isQuotientCoveringMap (basepointLift x₀)
+  BalancedProduct.fiberEquiv A _ (fun h => proj_eq_iff_mem_orbit.mp h) (basepointLift x₀)
 
-omit [TopologicalSpace A] [DiscreteTopology A] in
+omit [LocallyPathConnectedSpace X] [PathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
+  [TopologicalSpace A] [DiscreteTopology A] in
 @[simp]
 theorem actionCoverFiberEquiv_apply_coe (a : A) :
     (actionCoverFiberEquiv x₀ A a : ActionCover x₀ A) =
       BalancedProduct.mk (FundamentalGroup X x₀) (basepointLift x₀ : UniversalCover x₀) a :=
-  BalancedProduct.fiberEquiv_apply_coe A _ isQuotientCoveringMap (basepointLift x₀) a
+  BalancedProduct.fiberEquiv_apply_coe A _ (fun h => proj_eq_iff_mem_orbit.mp h)
+    (basepointLift x₀) a
 
 /-- **The fibre identification is equivariant**: the monodromy of a loop class on the fibre of
 the cover attached to `A` is the action of that loop class on `A`. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Action
+public import TauCeti.Topology.Covering.BalancedProduct
+public import TauCeti.Topology.Covering.Category
+public import TauCeti.Topology.Homotopy.Monodromy.Functoriality
+
+/-!
+# The covering space attached to a fundamental-group set
+
+Let `X` be path connected, locally path connected and semilocally simply connected, and let `A`
+be a set with an action of `π₁(X, x₀)`. The universal cover `UniversalCover x₀` is the total
+space of a quotient covering map for `π₁(X, x₀)`, so the balanced product
+
+`ActionCover x₀ A = UniversalCover x₀ ×_{π₁(X, x₀)} A`
+
+is a covering space of `X` by `TauCeti.BalancedProduct.isCoveringMap_proj`, and its fibre over
+`x₀` is `A`.
+
+The action is arbitrary: it is neither assumed transitive nor nonempty, so the resulting cover is
+in general disconnected. That is the point. The transitive case is already available as the
+quotient of the universal cover by a stabiliser
+(`TauCeti.UniversalCover.stabilizerCover`), and a connected cover is exactly what such a quotient
+produces; a general action needs the disjoint union of one such quotient per orbit, which is what
+the balanced product provides in one step.
+
+The fibre identification is equivariant. The map `e ↦ ⟦(e, a)⟧` from the universal cover is a map
+of covering spaces over `X`, and monodromy is functorial in such maps, so monodromy on the fibre
+of `ActionCover x₀ A` is computed by monodromy on the fibre of the universal cover, which is the
+fundamental-group action by `TauCeti.UniversalCover.monodromy_basepointLift`. Because that action
+prepends the *inverse* loop class, the inverse cancels against the exchange
+`⟦(g • e, a)⟧ = ⟦(e, g⁻¹ • a)⟧` and no `ᵐᵒᵖ` appears here.
+
+## Main declarations
+
+* `TauCeti.UniversalCover.ActionCover`: the balanced product of the universal cover with `A`.
+* `TauCeti.UniversalCover.isCoveringMap_actionCoverProj`: **its projection is a covering map.**
+* `TauCeti.UniversalCover.actionCoveringSpace`: the same cover, bundled as an object of
+  `TauCeti.CoveringSpace`.
+* `TauCeti.UniversalCover.actionCoverFiberEquiv`: its fibre over `x₀` is `A`, and
+  `TauCeti.UniversalCover.monodromy_actionCoverFiberEquiv` says the identification intertwines
+  monodromy with the given action.
+
+## References
+
+This is the object half of the essential surjectivity of monodromy on *all* covering spaces,
+the disconnected case of `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, which asks
+for covers to be classified by functors out of the fundamental groupoid. It consumes the
+based-path universal cover adapted from Kim Morrison's
+[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292) and Mathlib's
+quotient-covering-map interface due to Junyan Xu.
+-/
+
+public section
+noncomputable section
+
+open CategoryTheory Topology
+
+universe u
+
+namespace TauCeti.UniversalCover
+
+variable {X : Type u} [TopologicalSpace X] [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X] (x₀ : X) (A : Type u)
+  [MulAction (FundamentalGroup X x₀) A] [TopologicalSpace A] [DiscreteTopology A]
+
+/-- The total space of the covering space attached to a `π₁(X, x₀)`-set `A`: the balanced product
+of the universal cover with `A`. -/
+abbrev ActionCover : Type u := BalancedProduct (FundamentalGroup X x₀) (UniversalCover x₀) A
+
+/-- The projection of the cover attached to `A` down to the base.
+
+This wrapper is `@[expose]` because every statement about it below is the corresponding statement
+about `TauCeti.BalancedProduct.proj`, read through the definition. -/
+@[expose]
+def actionCoverProj : ActionCover x₀ A → X :=
+  BalancedProduct.proj A fun g e => proj_smul g e
+
+omit [LocallyPathConnectedSpace X] [PathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
+  [DiscreteTopology A] [TopologicalSpace A] in
+@[simp]
+theorem actionCoverProj_mk (e : UniversalCover x₀) (a : A) :
+    actionCoverProj x₀ A (BalancedProduct.mk (FundamentalGroup X x₀) e a) = proj e :=
+  BalancedProduct.proj_mk A _ e a
+
+omit [LocallyPathConnectedSpace X] [PathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
+  [DiscreteTopology A] in
+theorem continuous_actionCoverProj : Continuous (actionCoverProj x₀ A) :=
+  BalancedProduct.continuous_proj A _ (continuous_proj x₀)
+
+/-- **The cover attached to a `π₁(X, x₀)`-set is a covering space of `X`.** -/
+theorem isCoveringMap_actionCoverProj : IsCoveringMap (actionCoverProj x₀ A) :=
+  BalancedProduct.isCoveringMap_proj A _ isQuotientCoveringMap
+
+/-- The cover attached to a `π₁(X, x₀)`-set, bundled as a covering space over `X`.
+
+`@[expose]` for the same reason as `actionCoverProj`: the total-space and projection equations
+below are `TauCeti.CoveringSpace.mk_coe` and `…mk_proj` read through this definition. -/
+@[expose]
+def actionCoveringSpace : CoveringSpace (TopCat.of X) :=
+  CoveringSpace.mk (TopCat.ofHom ⟨actionCoverProj x₀ A, continuous_actionCoverProj x₀ A⟩)
+    (isCoveringMap_actionCoverProj x₀ A)
+
+/-- The total space of the bundled cover attached to `A` is `ActionCover x₀ A`. -/
+@[simp]
+theorem actionCoveringSpace_coe :
+    (actionCoveringSpace x₀ A : TopCat) = TopCat.of (ActionCover x₀ A) :=
+  CoveringSpace.mk_coe _ _
+
+/-- The projection of the bundled cover attached to `A` is `actionCoverProj`. -/
+theorem actionCoveringSpace_proj :
+    (actionCoveringSpace x₀ A).proj =
+      eqToHom (actionCoveringSpace_coe x₀ A) ≫
+        TopCat.ofHom ⟨actionCoverProj x₀ A, continuous_actionCoverProj x₀ A⟩ :=
+  CoveringSpace.mk_proj _ _
+
+/-- The characteristic equality of total spaces, viewed as a homeomorphism. -/
+def actionCoverTotalSpaceHomeomorph : (actionCoveringSpace x₀ A : TopCat) ≃ₜ ActionCover x₀ A :=
+  TopCat.homeoOfIso (eqToIso (actionCoveringSpace_coe x₀ A))
+
+/-- The characteristic total-space homeomorphism commutes with the two projections. -/
+theorem actionCoverProj_actionCoverTotalSpaceHomeomorph (e : (actionCoveringSpace x₀ A : TopCat)) :
+    actionCoverProj x₀ A (actionCoverTotalSpaceHomeomorph x₀ A e) =
+      (actionCoveringSpace x₀ A).proj e :=
+  (DFunLike.congr_fun (congrArg TopCat.Hom.hom (actionCoveringSpace_proj x₀ A)) e).symm
+
+/-- Transport from the fibre of the bundled cover to the fibre of its projection. -/
+def actionCoverFiberTransport :
+    ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀} ≃ actionCoverProj x₀ A ⁻¹' {x₀} :=
+  ((actionCoverTotalSpaceHomeomorph x₀ A).subtype fun e => by
+    simp only [Set.mem_preimage, Set.mem_singleton_iff]
+    rw [actionCoverProj_actionCoverTotalSpaceHomeomorph x₀ A e]).toEquiv
+
+/-- On underlying points, fibre transport applies the characteristic homeomorphism. -/
+@[simp]
+private theorem actionCoverFiberTransport_apply_coe
+    (e : ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀}) :
+    (actionCoverFiberTransport x₀ A e : ActionCover x₀ A) =
+      actionCoverTotalSpaceHomeomorph x₀ A e :=
+  (rfl)
+
+/-- Fibre transport commutes with monodromy. -/
+@[simp]
+theorem actionCoverFiberTransport_apply_monodromy (g : FundamentalGroup X x₀)
+    (e : ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀}) :
+    actionCoverFiberTransport x₀ A
+        ((actionCoveringSpace x₀ A).isCoveringMap_proj.monodromy g e) =
+      (isCoveringMap_actionCoverProj x₀ A).monodromy g (actionCoverFiberTransport x₀ A e) := by
+  have hmonodromy := TauCeti.IsCoveringMap.fiberMap_monodromy
+    (actionCoveringSpace x₀ A).isCoveringMap_proj (isCoveringMap_actionCoverProj x₀ A)
+    (actionCoverTotalSpaceHomeomorph x₀ A)
+    (funext (actionCoverProj_actionCoverTotalSpaceHomeomorph x₀ A)) g e
+  have hfiberMap (e' : ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀}) :
+      TauCeti.IsCoveringMap.fiberMap (actionCoverTotalSpaceHomeomorph x₀ A)
+          (funext (actionCoverProj_actionCoverTotalSpaceHomeomorph x₀ A)) x₀ e' =
+        actionCoverFiberTransport x₀ A e' :=
+    Subtype.ext (TauCeti.IsCoveringMap.fiberMap_apply_coe _ _ x₀ e')
+  simpa only [hfiberMap] using hmonodromy
+
+/-- **The fibre of the cover attached to `A` over `x₀` is `A`.** A point of `A` labels the class
+of the pair it forms with the constant-path point of the universal cover. -/
+@[expose]
+def actionCoverFiberEquiv : A ≃ actionCoverProj x₀ A ⁻¹' {x₀} :=
+  BalancedProduct.fiberEquiv A _ isQuotientCoveringMap (basepointLift x₀)
+
+@[simp]
+theorem actionCoverFiberEquiv_apply_coe (a : A) :
+    (actionCoverFiberEquiv x₀ A a : ActionCover x₀ A) =
+      BalancedProduct.mk (FundamentalGroup X x₀) (basepointLift x₀ : UniversalCover x₀) a :=
+  BalancedProduct.fiberEquiv_apply_coe A _ isQuotientCoveringMap (basepointLift x₀) a
+
+/-- **The fibre identification is equivariant**: the monodromy of a loop class on the fibre of
+the cover attached to `A` is the action of that loop class on `A`. -/
+theorem monodromy_actionCoverFiberEquiv (g : FundamentalGroup X x₀) (a : A) :
+    (isCoveringMap_actionCoverProj x₀ A).monodromy g (actionCoverFiberEquiv x₀ A a) =
+      actionCoverFiberEquiv x₀ A (g • a) := by
+  -- Attaching the label `a` is a map of covering spaces over `X`, so it intertwines monodromy.
+  let ι : C(UniversalCover x₀, ActionCover x₀ A) :=
+    ⟨fun e => BalancedProduct.mk (FundamentalGroup X x₀) e a,
+      continuous_quotient_mk'.comp (continuous_id.prodMk continuous_const)⟩
+  have hcomp : actionCoverProj x₀ A ∘ ι = proj := funext fun e => actionCoverProj_mk x₀ A e a
+  have key := TauCeti.IsCoveringMap.fiberMap_monodromy (isCoveringMap x₀)
+    (isCoveringMap_actionCoverProj x₀ A) ι hcomp g (basepointLift x₀)
+  have hbase : actionCoverFiberEquiv x₀ A a =
+      TauCeti.IsCoveringMap.fiberMap ι hcomp x₀ (basepointLift x₀) :=
+    Subtype.ext ((actionCoverFiberEquiv_apply_coe x₀ A a).trans
+      (TauCeti.IsCoveringMap.fiberMap_apply_coe ι hcomp x₀ (basepointLift x₀)).symm)
+  rw [hbase, ← key]
+  refine Subtype.ext ?_
+  rw [TauCeti.IsCoveringMap.fiberMap_apply_coe, actionCoverFiberEquiv_apply_coe]
+  change BalancedProduct.mk (FundamentalGroup X x₀)
+      ((isCoveringMap x₀).monodromy g (basepointLift x₀) : UniversalCover x₀) a =
+    BalancedProduct.mk (FundamentalGroup X x₀) (basepointLift x₀ : UniversalCover x₀) (g • a)
+  rw [monodromy_basepointLift, BalancedProduct.mk_smul_left, inv_inv]
+
+/-- **The fibre of the bundled cover attached to `A` over `x₀` is `A`.** -/
+def actionCoveringSpaceFiberEquiv : ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀} ≃ A :=
+  (actionCoverFiberTransport x₀ A).trans (actionCoverFiberEquiv x₀ A).symm
+
+/-- **The bundled fibre identification is equivariant**: monodromy on the fibre of the cover
+attached to `A` agrees with the given action of the fundamental group on `A`. -/
+@[simp]
+theorem actionCoveringSpaceFiberEquiv_apply_monodromy (g : FundamentalGroup X x₀)
+    (e : ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀}) :
+    actionCoveringSpaceFiberEquiv x₀ A
+        ((actionCoveringSpace x₀ A).isCoveringMap_proj.monodromy g e) =
+      g • actionCoveringSpaceFiberEquiv x₀ A e := by
+  obtain ⟨a, ha⟩ := (actionCoverFiberEquiv x₀ A).surjective (actionCoverFiberTransport x₀ A e)
+  rw [actionCoveringSpaceFiberEquiv, Equiv.trans_apply, Equiv.trans_apply,
+    actionCoverFiberTransport_apply_monodromy, ← ha, monodromy_actionCoverFiberEquiv,
+    Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+
+end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean
@@ -73,11 +73,7 @@ variable {X : Type u} [TopologicalSpace X] [LocallyPathConnectedSpace X] [PathCo
 of the universal cover with `A`. -/
 abbrev ActionCover : Type u := BalancedProduct (FundamentalGroup X x₀) (UniversalCover x₀) A
 
-/-- The projection of the cover attached to `A` down to the base.
-
-This wrapper is `@[expose]` because every statement about it below is the corresponding statement
-about `TauCeti.BalancedProduct.proj`, read through the definition. -/
-@[expose]
+/-- The projection of the cover attached to `A` down to the base. -/
 def actionCoverProj : ActionCover x₀ A → X :=
   BalancedProduct.proj A fun g e => proj_smul g e
 
@@ -97,11 +93,7 @@ theorem continuous_actionCoverProj : Continuous (actionCoverProj x₀ A) :=
 theorem isCoveringMap_actionCoverProj : IsCoveringMap (actionCoverProj x₀ A) :=
   BalancedProduct.isCoveringMap_proj A _ isQuotientCoveringMap
 
-/-- The cover attached to a `π₁(X, x₀)`-set, bundled as a covering space over `X`.
-
-`@[expose]` for the same reason as `actionCoverProj`: the total-space and projection equations
-below are `TauCeti.CoveringSpace.mk_coe` and `…mk_proj` read through this definition. -/
-@[expose]
+/-- The cover attached to a `π₁(X, x₀)`-set, bundled as a covering space over `X`. -/
 def actionCoveringSpace : CoveringSpace (TopCat.of X) :=
   CoveringSpace.mk (TopCat.ofHom ⟨actionCoverProj x₀ A, continuous_actionCoverProj x₀ A⟩)
     (isCoveringMap_actionCoverProj x₀ A)
@@ -138,7 +130,7 @@ def actionCoverFiberTransport :
 
 /-- On underlying points, fibre transport applies the characteristic homeomorphism. -/
 @[simp]
-private theorem actionCoverFiberTransport_apply_coe
+theorem actionCoverFiberTransport_apply_coe
     (e : ⇑(actionCoveringSpace x₀ A).proj ⁻¹' {x₀}) :
     (actionCoverFiberTransport x₀ A e : ActionCover x₀ A) =
       actionCoverTotalSpaceHomeomorph x₀ A e :=
@@ -164,7 +156,6 @@ theorem actionCoverFiberTransport_apply_monodromy (g : FundamentalGroup X x₀)
 
 /-- **The fibre of the cover attached to `A` over `x₀` is `A`.** A point of `A` labels the class
 of the pair it forms with the constant-path point of the universal cover. -/
-@[expose]
 def actionCoverFiberEquiv : A ≃ actionCoverProj x₀ A ⁻¹' {x₀} :=
   BalancedProduct.fiberEquiv A _ isQuotientCoveringMap (basepointLift x₀)
 
@@ -193,6 +184,8 @@ theorem monodromy_actionCoverFiberEquiv (g : FundamentalGroup X x₀) (a : A) :
   rw [hbase, ← key]
   refine Subtype.ext ?_
   rw [TauCeti.IsCoveringMap.fiberMap_apply_coe, actionCoverFiberEquiv_apply_coe]
+  -- The application lemmas expose the maps, but leave coercions from the two fibre subtypes.
+  -- This reduction records exactly their underlying points before rewriting quotient classes.
   change BalancedProduct.mk (FundamentalGroup X x₀)
       ((isCoveringMap x₀).monodromy g (basepointLift x₀) : UniversalCover x₀) a =
     BalancedProduct.mk (FundamentalGroup X x₀) (basepointLift x₀ : UniversalCover x₀) (g • a)

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean
@@ -116,6 +116,7 @@ def actionCoverTotalSpaceHomeomorph : (actionCoveringSpace x₀ A : TopCat) ≃�
   TopCat.homeoOfIso (eqToIso (actionCoveringSpace_coe x₀ A))
 
 /-- The characteristic total-space homeomorphism commutes with the two projections. -/
+@[simp]
 theorem actionCoverProj_actionCoverTotalSpaceHomeomorph (e : (actionCoveringSpace x₀ A : TopCat)) :
     actionCoverProj x₀ A (actionCoverTotalSpaceHomeomorph x₀ A e) =
       (actionCoveringSpace x₀ A).proj e :=
@@ -154,11 +155,13 @@ theorem actionCoverFiberTransport_apply_monodromy (g : FundamentalGroup X x₀)
     Subtype.ext (TauCeti.IsCoveringMap.fiberMap_apply_coe _ _ x₀ e')
   simpa only [hfiberMap] using hmonodromy
 
+omit [TopologicalSpace A] [DiscreteTopology A] in
 /-- **The fibre of the cover attached to `A` over `x₀` is `A`.** A point of `A` labels the class
 of the pair it forms with the constant-path point of the universal cover. -/
 def actionCoverFiberEquiv : A ≃ actionCoverProj x₀ A ⁻¹' {x₀} :=
   BalancedProduct.fiberEquiv A _ isQuotientCoveringMap (basepointLift x₀)
 
+omit [TopologicalSpace A] [DiscreteTopology A] in
 @[simp]
 theorem actionCoverFiberEquiv_apply_coe (a : A) :
     (actionCoverFiberEquiv x₀ A a : ActionCover x₀ A) =
@@ -167,6 +170,7 @@ theorem actionCoverFiberEquiv_apply_coe (a : A) :
 
 /-- **The fibre identification is equivariant**: the monodromy of a loop class on the fibre of
 the cover attached to `A` is the action of that loop class on `A`. -/
+@[simp]
 theorem monodromy_actionCoverFiberEquiv (g : FundamentalGroup X x₀) (a : A) :
     (isCoveringMap_actionCoverProj x₀ A).monodromy g (actionCoverFiberEquiv x₀ A a) =
       actionCoverFiberEquiv x₀ A (g • a) := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/MonodromyEquivalence.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/MonodromyEquivalence.lean
@@ -6,12 +6,13 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicTopology.FundamentalGroup.Basic
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.ActionCover
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Reconstruction
 public import TauCeti.CategoryTheory.Groupoid.ConnectedFunctor
 public import TauCeti.Topology.Covering.Monodromy.Transitive
 
 /-!
-# Connected covers are classified by transitive fundamental-groupoid actions
+# Covers are classified by fundamental-groupoid actions
 
 Let `X` be path connected, locally path connected and semilocally simply connected. This file
 proves that monodromy
@@ -38,6 +39,16 @@ connectedness makes the fundamental groupoid connected, which is what the transp
 is also what makes the fibres of a connected cover nonempty; semilocal simple connectedness is
 what produces the universal cover the reconstruction quotients.
 
+Dropping both restrictions — connectedness of the cover, transitivity of the action — gives the
+classification of *all* covering spaces of `X` by *all* functors from its fundamental groupoid to
+types. Full faithfulness is again the lifting criterion, already packaged in
+`TauCeti.Topology.Covering.Monodromy.Basic` and `…Monodromy.Full`, and essential surjectivity is
+again reconstruction at `x₀` followed by transport, but the cover reconstructed from an arbitrary
+`π₁(X, x₀)`-set is the balanced product of
+`TauCeti.AlgebraicTopology.UniversalCover.Classification.ActionCover` rather than a quotient of
+the universal cover by a stabiliser: the latter is connected, so it can only realise a transitive
+action, while the former realises the disjoint union of one such quotient per orbit in one step.
+
 ## Main declarations
 
 * `TauCeti.FundamentalGroupoidAction.basepointMulAction`: the action of `π₁(X, x₀)` on the value
@@ -46,16 +57,22 @@ what produces the universal cover the reconstruction quotients.
   is the monodromy of a connected cover.
 * `TauCeti.ConnectedCoveringSpace.monodromyEquivalence`: **connected covering spaces of `X` are
   equivalent to transitive fundamental-groupoid actions.**
+* `TauCeti.CoveringSpace.exists_monodromyFunctor_iso`: every fundamental-groupoid action is the
+  monodromy of a covering space.
+* `TauCeti.CoveringSpace.monodromyEquivalence`: **covering spaces of `X` are equivalent to
+  functors from its fundamental groupoid to types.**
 
 ## References
 
 This completes the alternative monodromy-functor lens on Stage 2, item 8 of
 `TauCetiRoadmap/UniversalCovers/README.md`, which asks for the classification of connected covers
-by transitive `π₁(X)`-sets; see Hatcher, *Algebraic Topology*, Section 1.3. It consumes the
-based-path universal cover adapted from Kim Morrison's
-[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292) and the
+by transitive `π₁(X)`-sets and of covers in general by functors out of the fundamental groupoid;
+see Hatcher, *Algebraic Topology*, Section 1.3. It consumes the based-path universal cover
+adapted from Kim Morrison's
+[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292), the
 stabiliser-cover reconstruction of
-`TauCeti.AlgebraicTopology.UniversalCover.Classification.Reconstruction`.
+`TauCeti.AlgebraicTopology.UniversalCover.Classification.Reconstruction`, and the balanced-product
+cover of `TauCeti.AlgebraicTopology.UniversalCover.Classification.ActionCover`.
 -/
 
 public section
@@ -149,5 +166,52 @@ theorem monodromyEquivalence_functor (X : TopCat.{u}) [PathConnectedSpace X]
   (rfl)
 
 end ConnectedCoveringSpace
+
+namespace CoveringSpace
+
+variable {X : TopCat.{u}} [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+/-- **Every fundamental-groupoid action is the monodromy of a covering space.** The cover is the
+balanced product of the universal cover with the value of the action at a basepoint. -/
+theorem exists_monodromyFunctor_iso (F : FundamentalGroupoid X ⥤ Type u) :
+    ∃ p : CoveringSpace X, Nonempty ((monodromyFunctor X).obj p ≅ F) := by
+  obtain ⟨x₀⟩ := (inferInstance : Nonempty (X : Type u))
+  let _ := FundamentalGroupoidAction.basepointMulAction F x₀
+  let _ : TopologicalSpace (F.obj (FundamentalGroupoid.mk x₀)) := ⊥
+  have : DiscreteTopology (F.obj (FundamentalGroupoid.mk x₀)) := ⟨rfl⟩
+  refine ⟨UniversalCover.actionCoveringSpace x₀ (F.obj (FundamentalGroupoid.mk x₀)), ⟨?_⟩⟩
+  refine eqToIso (monodromyFunctor_obj _) ≪≫
+    TauCeti.Groupoid.natIsoOfEnd
+      (FundamentalGroupoid.nonempty_hom (FundamentalGroupoid.mk x₀))
+      (UniversalCover.actionCoveringSpaceFiberEquiv x₀
+        (F.obj (FundamentalGroupoid.mk x₀))).toIso (fun g => ?_)
+  refine ConcreteCategory.hom_ext _ _ fun z => ?_
+  simp only [types_comp_apply]
+  exact UniversalCover.actionCoveringSpaceFiberEquiv_apply_monodromy x₀
+    (F.obj (FundamentalGroupoid.mk x₀)) g z
+
+/-- Covering-space monodromy is essentially surjective. -/
+instance monodromyFunctor_essSurj : (monodromyFunctor X).EssSurj where
+  mem_essImage F := exists_monodromyFunctor_iso F
+
+/-- Covering-space monodromy is fully faithful and essentially surjective. -/
+instance monodromyFunctor_isEquivalence : (monodromyFunctor X).IsEquivalence where
+
+/-- **The classification of covering spaces by fundamental-groupoid actions.** Over a
+path-connected, locally path-connected, semilocally simply connected base, monodromy is an
+equivalence from covering spaces to functors from the fundamental groupoid to types. -/
+def monodromyEquivalence (X : TopCat.{u}) [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] :
+    CoveringSpace X ≌ (FundamentalGroupoid X ⥤ Type u) :=
+  (monodromyFunctor X).asEquivalence
+
+@[simp]
+theorem monodromyEquivalence_functor (X : TopCat.{u}) [PathConnectedSpace X]
+    [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] :
+    (monodromyEquivalence X).functor = monodromyFunctor X :=
+  (rfl)
+
+end CoveringSpace
 
 end TauCeti

--- a/TauCeti/Topology/Covering/BalancedProduct.lean
+++ b/TauCeti/Topology/Covering/BalancedProduct.lean
@@ -279,6 +279,8 @@ noncomputable def fiberEquiv (hqc : IsQuotientCoveringMap q G) {x : X} (e : q �
     obtain ⟨g, hg⟩ := hqc.apply_eq_iff_mem_orbit.mp (hz.trans e.2.symm)
     have hge : g • (e : E) = w := hg
     refine ⟨g⁻¹ • b, Subtype.ext ?_⟩
+    -- `fiberEquiv_apply_coe` is only available after this `Equiv.ofBijective` construction.
+    -- Here `change` exposes its defining map after `Subtype.ext` removes the fibre wrapper.
     change mk G (e : E) (g⁻¹ • b) = mk G w b
     rw [← mk_smul_left g (e : E) b, hge]
 

--- a/TauCeti/Topology/Covering/BalancedProduct.lean
+++ b/TauCeti/Topology/Covering/BalancedProduct.lean
@@ -1,0 +1,296 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Covering.Quotient
+
+/-!
+# The balanced product of a quotient covering map with a discrete set
+
+Let a group `G` act on a space `E` so that `q : E → X` presents `X` as the quotient `E / G` in
+the strong sense of Mathlib's `IsQuotientCoveringMap`: the fibres of `q` are the orbits, and every
+point of `E` has a neighbourhood whose `G`-translates are pairwise disjoint. For a discrete
+`G`-set `A`, the *balanced product* `BalancedProduct G E A` is the quotient of `E × A` by the
+diagonal action of `G`. Since `q` is invariant along the first factor it descends to
+
+`BalancedProduct.proj A : BalancedProduct G E A → X`,
+
+and the theorem of this file is that this projection is a covering map, with fibre `A`.
+
+Neither space is assumed connected, and no local connectedness of `X` is needed. Over the base
+set `q '' U` cut out by a set `U` whose `G`-translates are pairwise disjoint, the sheets of the
+projection are the images of `U ×ˢ {a}`, one for each `a : A`, and each defining property of a
+sheet comes straight from the disjointness of those translates: two points of `U` with the same
+class differ by a group element carrying `U` into itself, hence by the identity.
+
+The intended reading is the cover of `X` attached to a set acted on by the deck group of a
+regular cover. For `E` the universal cover of `X` and `G` its fundamental group, this is the
+covering space attached to an arbitrary `π₁(X, x₀)`-set; no transitivity, and hence no
+connectedness of the resulting cover, is assumed. The transitive case `A = G ⧸ H`, where the
+balanced product is `E / H`, is `TauCeti.IsQuotientCoveringMap.isCoveringMap_of_comp`, proved
+there for an abstract presentation of `E / H` rather than for a fixed model.
+
+## Main declarations
+
+* `TauCeti.BalancedProduct`: the quotient of `E × A` by the diagonal action of `G`.
+* `TauCeti.isQuotientCoveringMap_quotientMk_of_smul_disjoint`: an action with locally pairwise
+  disjoint translates presents its orbit space as a quotient covering map.
+* `TauCeti.BalancedProduct.isQuotientCoveringMap_mk`: the class map `E × A → E ×_G A` is one such.
+* `TauCeti.BalancedProduct.isCoveringMap_proj`: **the balanced product of a quotient covering map
+  with a discrete set is a covering map.**
+* `TauCeti.BalancedProduct.fiberEquiv`: its fibre over `q e` is `A`, through `a ↦ ⟦(e, a)⟧`.
+
+## References
+
+The `IsQuotientCoveringMap` interface used here — the predicate itself, its `disjoint` and
+`apply_eq_iff_mem_orbit` fields, `IsQuotientCoveringMap.isOpenQuotientMap`, and
+`IsOpen.trivializationDiscrete` — is Junyan Xu's, in `Mathlib/Topology/Covering/Quotient.lean`
+and `Mathlib/Topology/Covering/Basic.lean`. The sheet bookkeeping follows the subgroup case in
+`TauCeti/Topology/Covering/Quotient.lean`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Pointwise Topology
+
+section OrbitQuotient
+
+variable {E : Type*} [TopologicalSpace E] {G : Type*} [Group G] [MulAction G E]
+
+/-- **An action whose translates are locally pairwise disjoint presents its orbit space as a
+quotient covering map.** This is the free, not necessarily properly discontinuous, form of
+Mathlib's `isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul`: no local compactness
+or separation of `E` is assumed. -/
+theorem isQuotientCoveringMap_quotientMk_of_smul_disjoint [ContinuousConstSMul G E]
+    (hdisj : ∀ e : E, ∃ U ∈ 𝓝 e, ∀ g : G, ((g • ·) '' U ∩ U).Nonempty → g = 1) :
+    IsQuotientCoveringMap (Quotient.mk (MulAction.orbitRel G E)) G where
+  __ := isQuotientMap_quotient_mk'
+  apply_eq_iff_mem_orbit := Quotient.eq''
+  disjoint := hdisj
+
+end OrbitQuotient
+
+variable {E X A : Type*} {G : Type*} [Group G] [MulAction G E] [MulAction G A] {q : E → X}
+
+/-- The **balanced product** `E ×_G A` of a `G`-space `E` and a `G`-set `A`: the quotient of
+`E × A` by the diagonal action of `G`. -/
+abbrev BalancedProduct (G E A : Type*) [Group G] [MulAction G E] [MulAction G A] : Type _ :=
+  Quotient (MulAction.orbitRel G (E × A))
+
+namespace BalancedProduct
+
+/-- The class of a pair in the balanced product. -/
+abbrev mk (G : Type*) [Group G] [MulAction G E] [MulAction G A] (e : E) (a : A) :
+    BalancedProduct G E A :=
+  Quotient.mk (MulAction.orbitRel G (E × A)) (e, a)
+
+/-- Two pairs have the same class exactly when they lie in the same diagonal orbit. -/
+theorem mk_eq_mk_iff {e e' : E} {a a' : A} :
+    mk G e a = mk G e' a' ↔ (e, a) ∈ MulAction.orbit G (e', a') :=
+  Quotient.eq''
+
+/-- Moving a point of `E × A` by `g` in the first coordinate is the same as moving it by `g⁻¹`
+in the second. -/
+theorem mk_smul_left (g : G) (e : E) (a : A) : mk G (g • e) a = mk G e (g⁻¹ • a) :=
+  Quotient.sound ⟨g, by simp⟩
+
+variable (hq : ∀ (g : G) (e : E), q (g • e) = q e)
+
+variable (A) in
+/-- A `G`-invariant map `q : E → X` descends to the balanced product. -/
+def proj : BalancedProduct G E A → X :=
+  Quotient.lift (fun p => q p.1) fun _ _ h => by
+    obtain ⟨g, hg⟩ := h
+    rw [← hg]
+    exact hq g _
+
+variable (A) in
+@[simp]
+theorem proj_mk (e : E) (a : A) : proj A hq (mk G e a) = q e :=
+  (rfl)
+
+section Covering
+
+variable [TopologicalSpace E] [TopologicalSpace X] [TopologicalSpace A]
+
+variable (A) in
+/-- The descended projection is continuous when `q` is. -/
+theorem continuous_proj (hqc : Continuous q) : Continuous (proj A hq) :=
+  (hqc.comp continuous_fst).quotient_lift _
+
+variable [DiscreteTopology A]
+
+variable (A) in
+/-- The class map onto the balanced product is a quotient covering map for the diagonal action,
+as soon as the action on `E` is one: a neighbourhood `U` of `e` with pairwise disjoint translates
+gives the neighbourhood `U ×ˢ univ` of `(e, a)`, whose translates are again pairwise disjoint. -/
+theorem isQuotientCoveringMap_mk (hqc : IsQuotientCoveringMap q G) :
+    IsQuotientCoveringMap
+      (Quotient.mk (MulAction.orbitRel G (E × A)) : E × A → BalancedProduct G E A) G := by
+  have : ContinuousConstSMul G E := hqc.toContinuousConstSMul
+  have : ContinuousConstSMul G A := ⟨fun _ => continuous_of_discreteTopology⟩
+  refine isQuotientCoveringMap_quotientMk_of_smul_disjoint fun p => ?_
+  obtain ⟨U, hU, hdisj⟩ := hqc.disjoint p.1
+  refine ⟨U ×ˢ Set.univ, prod_mem_nhds hU Filter.univ_mem, fun g hg => hdisj g ?_⟩
+  obtain ⟨z, ⟨w, hw, hwz⟩, hz⟩ := hg
+  exact ⟨z.1, ⟨w.1, hw.1, congrArg Prod.fst hwz⟩, hz.1⟩
+
+variable (A) in
+/-- The evenly covered neighbourhood of `q e` cut out by a set `U` around `e` whose `G`-translates
+are pairwise disjoint. Its sheets are the classes of `U ×ˢ {a}`, indexed by `a : A`. -/
+private theorem isEvenlyCovered_of_smul_disjoint [Nonempty A] (hqc : IsQuotientCoveringMap q G)
+    {U : Set E} (hUo : IsOpen U) (hdisj : ∀ g : G, ((g • ·) '' U ∩ U).Nonempty → g = 1) {e : E}
+    (heU : e ∈ U) :
+    IsEvenlyCovered (proj A hq) (q e) (proj A hq ⁻¹' {q e}) := by
+  have hcsG : ContinuousConstSMul G E := hqc.toContinuousConstSMul
+  have ht := isQuotientCoveringMap_mk A hqc
+  have hrc : Continuous (proj A hq) := continuous_proj A hq hqc.continuous
+  have hVo : IsOpen (q '' U) := hqc.isOpenQuotientMap.isOpenMap _ hUo
+  set S : A → Set (BalancedProduct G E A) :=
+    fun a => Quotient.mk (MulAction.orbitRel G (E × A)) '' (U ×ˢ {a}) with hS
+  have hSo : ∀ a, IsOpen (S a) := fun a =>
+    ht.isOpenQuotientMap.isOpenMap _ (hUo.prod (isOpen_discrete _))
+  -- A point of the sheet indexed by `a` is the class of `(u, a)` for a unique `u ∈ U`.
+  have hmemS : ∀ (a : A) (z : BalancedProduct G E A), z ∈ S a ↔ ∃ u ∈ U, mk G u a = z := by
+    intro a z
+    simp only [hS]
+    constructor
+    · rintro ⟨⟨u, a'⟩, ⟨hu, ha'⟩, rfl⟩
+      obtain rfl : a' = a := ha'
+      exact ⟨u, hu, rfl⟩
+    · rintro ⟨u, hu, rfl⟩
+      exact ⟨(u, a), ⟨hu, rfl⟩, rfl⟩
+  -- Two points of `U` with the same class agree, together with their labels.
+  have hkey : ∀ {u u' : E} {a a' : A}, u ∈ U → u' ∈ U → mk G u a = mk G u' a' →
+      u = u' ∧ a = a' := by
+    intro u u' a a' hu hu' hEq
+    obtain ⟨g, hg⟩ := mk_eq_mk_iff.mp hEq
+    have hg1 : g • (u', a') = (u, a) := hg
+    have hgu : g • u' = u := congrArg Prod.fst hg1
+    rw [hdisj g ⟨u, ⟨u', hu', hgu⟩, hu⟩, one_smul] at hg1
+    exact ⟨(Prod.ext_iff.mp hg1).1.symm, (Prod.ext_iff.mp hg1).2.symm⟩
+  have : Nonempty (X → BalancedProduct G E A) := ⟨fun _ => mk G e (Classical.arbitrary A)⟩
+  refine IsEvenlyCovered.to_isEvenlyCovered_preimage
+    (IsEvenlyCovered.of_trivialization (f := proj A hq)
+      (t := hVo.trivializationDiscrete S (q '' U) ?_ ?_ ?_ ?_ ?_) ⟨e, heU, rfl⟩)
+  · -- Openness inside the base set is detected on any single sheet.
+    intro a W hWV
+    refine ⟨fun hW => (hW.preimage hrc).inter (hSo a), fun hW => ?_⟩
+    -- The slice at `a` of the preimage of that open set, cut down to `U`, is `q ⁻¹' W ∩ U`.
+    have hslice : IsOpen (q ⁻¹' W ∩ U) := by
+      have hopen : IsOpen (Quotient.mk (MulAction.orbitRel G (E × A)) ⁻¹'
+          (proj A hq ⁻¹' W ∩ S a)) := hW.preimage continuous_quotient_mk'
+      have hcont : Continuous fun u : E => (u, a) := continuous_id.prodMk continuous_const
+      have heq : q ⁻¹' W ∩ U = ((fun u : E => (u, a)) ⁻¹'
+          (Quotient.mk (MulAction.orbitRel G (E × A)) ⁻¹' (proj A hq ⁻¹' W ∩ S a))) ∩ U := by
+        ext u
+        constructor
+        · rintro ⟨hqu, hu⟩
+          exact ⟨⟨hqu, (hmemS a _).mpr ⟨u, hu, rfl⟩⟩, hu⟩
+        · rintro ⟨⟨hw, -⟩, hu⟩
+          exact ⟨hw, hu⟩
+      rw [heq]
+      exact (hopen.preimage hcont).inter hUo
+    rw [← hqc.toIsQuotientMap.isOpen_preimage]
+    -- The preimage of `W` is covered by the translates of that slice, because `W ⊆ q '' U`.
+    have hcover : q ⁻¹' W = ⋃ k : G, k • (q ⁻¹' W ∩ U) := by
+      refine Set.Subset.antisymm (fun w hw => ?_) (Set.iUnion_subset fun k w hw => ?_)
+      · obtain ⟨u, hu, hqu⟩ := hWV hw
+        obtain ⟨m, hm⟩ := hqc.apply_eq_iff_mem_orbit.mp hqu.symm
+        refine Set.mem_iUnion.mpr ⟨m, Set.mem_smul_set.mpr ⟨u, ⟨?_, hu⟩, hm⟩⟩
+        rw [Set.mem_preimage, hqu]
+        exact hw
+      · obtain ⟨w', ⟨hw', -⟩, rfl⟩ := Set.mem_smul_set.mp hw
+        rw [Set.mem_preimage, hqc.map_smul]
+        exact hw'
+    rw [hcover]
+    exact isOpen_iUnion fun k => hslice.smul k
+  · -- The projection is injective on each sheet.
+    intro a z hz z' hz' hzz'
+    obtain ⟨u, hu, rfl⟩ := (hmemS a z).mp hz
+    obtain ⟨u', hu', rfl⟩ := (hmemS a z').mp hz'
+    rw [proj_mk, proj_mk] at hzz'
+    obtain ⟨m, hm⟩ := hqc.apply_eq_iff_mem_orbit.mp hzz'
+    have hm1 : m • u' = u := hm
+    rw [hdisj m ⟨u, ⟨u', hu', hm1⟩, hu⟩, one_smul] at hm1
+    rw [hm1]
+  · -- Each sheet surjects onto the base set.
+    rintro a v ⟨u, hu, rfl⟩
+    exact ⟨mk G u a, (hmemS a _).mpr ⟨u, hu, rfl⟩, proj_mk A hq u a⟩
+  · -- Distinct sheets are disjoint.
+    intro a a' hne
+    refine Set.disjoint_left.mpr fun z hz hz' => hne ?_
+    obtain ⟨u, hu, rfl⟩ := (hmemS a z).mp hz
+    obtain ⟨u', hu', hEq⟩ := (hmemS a' _).mp hz'
+    exact (hkey hu' hu hEq).2.symm
+  · -- The sheets exhaust the preimage of the base set.
+    intro z hz
+    obtain ⟨⟨w, b⟩, rfl⟩ := ht.surjective z
+    rw [Set.mem_preimage] at hz
+    obtain ⟨u, hu, hqu⟩ := hz
+    obtain ⟨m, hm⟩ := hqc.apply_eq_iff_mem_orbit.mp hqu.symm
+    have hmu : m • u = w := hm
+    refine Set.mem_iUnion.mpr ⟨m⁻¹ • b, (hmemS _ _).mpr ⟨u, hu, ?_⟩⟩
+    rw [← mk_smul_left m u b, hmu]
+
+variable (A) in
+/-- **The balanced product of a quotient covering map with a discrete set is a covering map.**
+
+If `q : E → X` presents `X` as the quotient of `E` by a group `G` in the sense of
+`IsQuotientCoveringMap`, and `A` is a discrete `G`-set, then the descended projection of the
+balanced product `E ×_G A` to `X` is a covering map. -/
+theorem isCoveringMap_proj (hqc : IsQuotientCoveringMap q G) : IsCoveringMap (proj A hq) := by
+  cases isEmpty_or_nonempty A with
+  | inl _ =>
+    have : IsEmpty (BalancedProduct G E A) := ⟨fun z => by
+      obtain ⟨p, -⟩ := (isQuotientCoveringMap_mk A hqc).surjective z
+      exact isEmptyElim p.2⟩
+    exact IsCoveringMap.of_isEmpty _
+  | inr _ =>
+    intro x
+    obtain ⟨e, rfl⟩ := hqc.surjective x
+    obtain ⟨U, hU, hdisj⟩ := hqc.disjoint e
+    refine isEvenlyCovered_of_smul_disjoint A hq hqc isOpen_interior (fun g hg => hdisj g ?_)
+      (mem_interior_iff_mem_nhds.mpr hU)
+    exact hg.mono (Set.inter_subset_inter (Set.image_mono interior_subset) interior_subset)
+
+variable (A) in
+/-- **The fibre of the balanced product over `q e` is `A`.** The bijection sends `a` to the class
+of `(e, a)`; it depends on the chosen point `e` of the fibre of `q`. -/
+noncomputable def fiberEquiv (hqc : IsQuotientCoveringMap q G) {x : X} (e : q ⁻¹' {x}) :
+    A ≃ proj A hq ⁻¹' {x} := by
+  have hcancel : IsCancelSMul G E := hqc.isCancelSMul
+  refine Equiv.ofBijective (fun a => ⟨mk G (e : E) a, ?_⟩) ⟨?_, ?_⟩
+  · rw [Set.mem_preimage, Set.mem_singleton_iff, proj_mk]
+    exact e.2
+  · intro a a' hEq
+    obtain ⟨g, hg⟩ := mk_eq_mk_iff.mp (congrArg Subtype.val hEq)
+    have hg1 : g • ((e : E), a') = ((e : E), a) := hg
+    rw [IsCancelSMul.eq_one_of_smul (congrArg Prod.fst hg1), one_smul] at hg1
+    exact (Prod.ext_iff.mp hg1).2.symm
+  · rintro ⟨z, hz⟩
+    obtain ⟨⟨w, b⟩, rfl⟩ := (isQuotientCoveringMap_mk A hqc).surjective z
+    rw [Set.mem_preimage, Set.mem_singleton_iff, proj_mk] at hz
+    obtain ⟨g, hg⟩ := hqc.apply_eq_iff_mem_orbit.mp (hz.trans e.2.symm)
+    have hge : g • (e : E) = w := hg
+    refine ⟨g⁻¹ • b, Subtype.ext ?_⟩
+    change mk G (e : E) (g⁻¹ • b) = mk G w b
+    rw [← mk_smul_left g (e : E) b, hge]
+
+variable (A) in
+/-- The fibre bijection of the balanced product sends `a` to the class of `(e, a)`. -/
+@[simp]
+theorem fiberEquiv_apply_coe (hqc : IsQuotientCoveringMap q G) {x : X} (e : q ⁻¹' {x}) (a : A) :
+    (fiberEquiv A hq hqc e a : BalancedProduct G E A) = mk G (e : E) a :=
+  (rfl)
+
+end Covering
+
+end BalancedProduct
+
+end TauCeti

--- a/TauCeti/Topology/Covering/BalancedProduct.lean
+++ b/TauCeti/Topology/Covering/BalancedProduct.lean
@@ -41,7 +41,9 @@ there for an abstract presentation of `E / H` rather than for a fixed model.
 * `TauCeti.BalancedProduct.isQuotientCoveringMap_mk`: the class map `E × A → E ×_G A` is one such.
 * `TauCeti.BalancedProduct.isCoveringMap_proj`: **the balanced product of a quotient covering map
   with a discrete set is a covering map.**
-* `TauCeti.BalancedProduct.fiberEquiv`: its fibre over `q e` is `A`, through `a ↦ ⟦(e, a)⟧`.
+* `TauCeti.BalancedProduct.fiberEquiv`: its fibre over `q e` is `A`, through `a ↦ ⟦(e, a)⟧`. This
+  last bijection is purely algebraic: it uses no topology, only that the action on `E` is free and
+  that the fibres of `q` are its orbits.
 
 ## References
 
@@ -89,13 +91,9 @@ abbrev mk (G : Type*) [Group G] [MulAction G E] [MulAction G A] (e : E) (a : A) 
     BalancedProduct G E A :=
   Quotient.mk (MulAction.orbitRel G (E × A)) (e, a)
 
-/-- Two pairs have the same class exactly when they lie in the same diagonal orbit. -/
-theorem mk_eq_mk_iff {e e' : E} {a a' : A} :
-    mk G e a = mk G e' a' ↔ (e, a) ∈ MulAction.orbit G (e', a') :=
-  Quotient.eq''
-
 /-- Moving a point of `E × A` by `g` in the first coordinate is the same as moving it by `g⁻¹`
 in the second. -/
+@[simp]
 theorem mk_smul_left (g : G) (e : E) (a : A) : mk G (g • e) a = mk G e (g⁻¹ • a) :=
   Quotient.sound ⟨g, by simp⟩
 
@@ -171,7 +169,7 @@ private theorem isEvenlyCovered_of_smul_disjoint [Nonempty A] (hqc : IsQuotientC
   have hkey : ∀ {u u' : E} {a a' : A}, u ∈ U → u' ∈ U → mk G u a = mk G u' a' →
       u = u' ∧ a = a' := by
     intro u u' a a' hu hu' hEq
-    obtain ⟨g, hg⟩ := mk_eq_mk_iff.mp hEq
+    obtain ⟨g, hg⟩ := Quotient.eq''.mp hEq
     have hg1 : g • (u', a') = (u, a) := hg
     have hgu : g • u' = u := congrArg Prod.fst hg1
     rw [hdisj g ⟨u, ⟨u', hu', hgu⟩, hu⟩, one_smul] at hg1
@@ -266,26 +264,27 @@ end Covering
 
 section Fiber
 
-variable [TopologicalSpace E] [TopologicalSpace X]
-
 variable (A) in
-/-- **The fibre of the balanced product over `q e` is `A`.** The bijection sends `a` to the class
-of `(e, a)`; it depends on the chosen point `e` of the fibre of `q`. -/
-noncomputable def fiberEquiv (hqc : IsQuotientCoveringMap q G) {x : X} (e : q ⁻¹' {x}) :
+/-- **The fibre of the balanced product over `x` is `A`.** The bijection sends `a` to the class
+of `(e, a)`; it depends on the chosen point `e` of the fibre of `q`.
+
+Only two consequences of `q` being a quotient covering map are used, and neither involves a
+topology: the action on `E` is free, and points of `E` with the same image lie in one orbit. -/
+noncomputable def fiberEquiv [IsCancelSMul G E]
+    (hfiber : ∀ {e₁ e₂ : E}, q e₁ = q e₂ → e₁ ∈ MulAction.orbit G e₂) {x : X} (e : q ⁻¹' {x}) :
     A ≃ proj A hq ⁻¹' {x} := by
-  have hcancel : IsCancelSMul G E := hqc.isCancelSMul
   refine Equiv.ofBijective (fun a => ⟨mk G (e : E) a, ?_⟩) ⟨?_, ?_⟩
   · rw [Set.mem_preimage, Set.mem_singleton_iff, proj_mk]
     exact e.2
   · intro a a' hEq
-    obtain ⟨g, hg⟩ := mk_eq_mk_iff.mp (congrArg Subtype.val hEq)
+    obtain ⟨g, hg⟩ := Quotient.eq''.mp (congrArg Subtype.val hEq)
     have hg1 : g • ((e : E), a') = ((e : E), a) := hg
     rw [IsCancelSMul.eq_one_of_smul (congrArg Prod.fst hg1), one_smul] at hg1
     exact (Prod.ext_iff.mp hg1).2.symm
   · rintro ⟨z, hz⟩
     obtain ⟨⟨w, b⟩, rfl⟩ := Quotient.mk''_surjective z
     rw [Set.mem_preimage, Set.mem_singleton_iff, proj_mk] at hz
-    obtain ⟨g, hg⟩ := hqc.apply_eq_iff_mem_orbit.mp (hz.trans e.2.symm)
+    obtain ⟨g, hg⟩ := hfiber (hz.trans e.2.symm)
     have hge : g • (e : E) = w := hg
     refine ⟨g⁻¹ • b, Subtype.ext ?_⟩
     -- `fiberEquiv_apply_coe` is only available after this `Equiv.ofBijective` construction.
@@ -296,8 +295,10 @@ noncomputable def fiberEquiv (hqc : IsQuotientCoveringMap q G) {x : X} (e : q �
 variable (A) in
 /-- The fibre bijection of the balanced product sends `a` to the class of `(e, a)`. -/
 @[simp]
-theorem fiberEquiv_apply_coe (hqc : IsQuotientCoveringMap q G) {x : X} (e : q ⁻¹' {x}) (a : A) :
-    (fiberEquiv A hq hqc e a : BalancedProduct G E A) = mk G (e : E) a :=
+theorem fiberEquiv_apply_coe [IsCancelSMul G E]
+    (hfiber : ∀ {e₁ e₂ : E}, q e₁ = q e₂ → e₁ ∈ MulAction.orbit G e₂) {x : X} (e : q ⁻¹' {x})
+    (a : A) :
+    (fiberEquiv A hq hfiber e a : BalancedProduct G E A) = mk G (e : E) a :=
   (rfl)
 
 end Fiber

--- a/TauCeti/Topology/Covering/BalancedProduct.lean
+++ b/TauCeti/Topology/Covering/BalancedProduct.lean
@@ -123,22 +123,23 @@ variable (A) in
 theorem continuous_proj (hqc : Continuous q) : Continuous (proj A hq) :=
   (hqc.comp continuous_fst).quotient_lift _
 
-variable [DiscreteTopology A]
-
 variable (A) in
 /-- The class map onto the balanced product is a quotient covering map for the diagonal action,
-as soon as the action on `E` is one: a neighbourhood `U` of `e` with pairwise disjoint translates
-gives the neighbourhood `U ×ˢ univ` of `(e, a)`, whose translates are again pairwise disjoint. -/
-theorem isQuotientCoveringMap_mk (hqc : IsQuotientCoveringMap q G) :
+as soon as the action on `E` is one and the action on `A` is continuous: a neighbourhood `U` of
+`e` with pairwise disjoint translates gives the neighbourhood `U ×ˢ univ` of `(e, a)`, whose
+translates are again pairwise disjoint. -/
+theorem isQuotientCoveringMap_mk [ContinuousConstSMul G A]
+    (hqc : IsQuotientCoveringMap q G) :
     IsQuotientCoveringMap
       (Quotient.mk (MulAction.orbitRel G (E × A)) : E × A → BalancedProduct G E A) G := by
   have : ContinuousConstSMul G E := hqc.toContinuousConstSMul
-  have : ContinuousConstSMul G A := ⟨fun _ => continuous_of_discreteTopology⟩
   refine isQuotientCoveringMap_quotientMk_of_smul_disjoint fun p => ?_
   obtain ⟨U, hU, hdisj⟩ := hqc.disjoint p.1
   refine ⟨U ×ˢ Set.univ, prod_mem_nhds hU Filter.univ_mem, fun g hg => hdisj g ?_⟩
   obtain ⟨z, ⟨w, hw, hwz⟩, hz⟩ := hg
   exact ⟨z.1, ⟨w.1, hw.1, congrArg Prod.fst hwz⟩, hz.1⟩
+
+variable [DiscreteTopology A]
 
 variable (A) in
 /-- The evenly covered neighbourhood of `q e` cut out by a set `U` around `e` whose `G`-translates
@@ -147,6 +148,7 @@ private theorem isEvenlyCovered_of_smul_disjoint [Nonempty A] (hqc : IsQuotientC
     {U : Set E} (hUo : IsOpen U) (hdisj : ∀ g : G, ((g • ·) '' U ∩ U).Nonempty → g = 1) {e : E}
     (heU : e ∈ U) :
     IsEvenlyCovered (proj A hq) (q e) (proj A hq ⁻¹' {q e}) := by
+  let _ : ContinuousConstSMul G A := ⟨fun _ => continuous_of_discreteTopology⟩
   have hcsG : ContinuousConstSMul G E := hqc.toContinuousConstSMul
   have ht := isQuotientCoveringMap_mk A hqc
   have hrc : Continuous (proj A hq) := continuous_proj A hq hqc.continuous
@@ -245,6 +247,7 @@ If `q : E → X` presents `X` as the quotient of `E` by a group `G` in the sense
 `IsQuotientCoveringMap`, and `A` is a discrete `G`-set, then the descended projection of the
 balanced product `E ×_G A` to `X` is a covering map. -/
 theorem isCoveringMap_proj (hqc : IsQuotientCoveringMap q G) : IsCoveringMap (proj A hq) := by
+  let _ : ContinuousConstSMul G A := ⟨fun _ => continuous_of_discreteTopology⟩
   cases isEmpty_or_nonempty A with
   | inl _ =>
     have : IsEmpty (BalancedProduct G E A) := ⟨fun z => by
@@ -258,6 +261,12 @@ theorem isCoveringMap_proj (hqc : IsQuotientCoveringMap q G) : IsCoveringMap (pr
     refine isEvenlyCovered_of_smul_disjoint A hq hqc isOpen_interior (fun g hg => hdisj g ?_)
       (mem_interior_iff_mem_nhds.mpr hU)
     exact hg.mono (Set.inter_subset_inter (Set.image_mono interior_subset) interior_subset)
+
+end Covering
+
+section Fiber
+
+variable [TopologicalSpace E] [TopologicalSpace X]
 
 variable (A) in
 /-- **The fibre of the balanced product over `q e` is `A`.** The bijection sends `a` to the class
@@ -274,7 +283,7 @@ noncomputable def fiberEquiv (hqc : IsQuotientCoveringMap q G) {x : X} (e : q �
     rw [IsCancelSMul.eq_one_of_smul (congrArg Prod.fst hg1), one_smul] at hg1
     exact (Prod.ext_iff.mp hg1).2.symm
   · rintro ⟨z, hz⟩
-    obtain ⟨⟨w, b⟩, rfl⟩ := (isQuotientCoveringMap_mk A hqc).surjective z
+    obtain ⟨⟨w, b⟩, rfl⟩ := Quotient.mk''_surjective z
     rw [Set.mem_preimage, Set.mem_singleton_iff, proj_mk] at hz
     obtain ⟨g, hg⟩ := hqc.apply_eq_iff_mem_orbit.mp (hz.trans e.2.symm)
     have hge : g • (e : E) = w := hg
@@ -291,7 +300,7 @@ theorem fiberEquiv_apply_coe (hqc : IsQuotientCoveringMap q G) {x : X} (e : q �
     (fiberEquiv A hq hqc e a : BalancedProduct G E A) = mk G (e : E) a :=
   (rfl)
 
-end Covering
+end Fiber
 
 end BalancedProduct
 


### PR DESCRIPTION
This PR classifies **all** covering spaces of a path-connected, locally path-connected,
semilocally simply connected base by functors from its fundamental groupoid to types, closing the
disconnected half of the alternative monodromy-functor lens that Stage 2, item 8 of
`TauCetiRoadmap/UniversalCovers/README.md` asks for: "phrase the classification of connected
covers via transitive `π₁(X)`-sets / the monodromy functor …, with disconnected covers as
functors out of the fundamental groupoid". The connected case is already in the repository as
`TauCeti.ConnectedCoveringSpace.monodromyEquivalence`, and monodromy on all covers is already
faithful and (over a locally path-connected base) full, so the one missing input was essential
surjectivity for an action that is not fibrewise transitive: the cover reconstructed from such an
action is disconnected, so it cannot be a quotient of the universal cover by a stabiliser, which
is the only reconstruction available so far. After this PR the milestone's monodromy-functor lens
is complete in both the connected and the general form, and what remains on that line of the
roadmap is its other suggested route, the Galois-category formulation through Mathlib's
`CategoryTheory.Galois.IsFundamentalgroup`.

`TauCeti/Topology/Covering/BalancedProduct.lean` (296 lines) supplies the missing topology. For a
group `G` acting on `E` with `q : E → X` a quotient covering map and `A` a discrete `G`-set, the
balanced product `BalancedProduct G E A` is the quotient of `E × A` by the diagonal action, and
`q` descends to it. The main theorem, `TauCeti.BalancedProduct.isCoveringMap_proj`, is that the
descended projection is a covering map; `TauCeti.BalancedProduct.fiberEquiv` identifies its fibre
over `q e` with `A`. Neither space is assumed connected and no local connectedness of `X` is
needed: over the base set `q '' U` cut out by a set `U` whose `G`-translates are pairwise
disjoint, the sheets are the classes of `U ×ˢ {a}`, one per `a : A`, and each defining property of
a sheet is the disjointness of those translates. Along the way,
`TauCeti.isQuotientCoveringMap_quotientMk_of_smul_disjoint` records that an action with locally
pairwise disjoint translates presents its orbit space as a quotient covering map — the free rather
than properly discontinuous form of Mathlib's
`isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul`, since the universal cover is not
assumed locally compact or Hausdorff. The subgroup case `A = G ⧸ H`, where the balanced product is
`E / H`, is the existing `TauCeti.IsQuotientCoveringMap.isCoveringMap_of_comp`; that theorem is
stated for an abstract presentation of `E / H` rather than for a fixed model, so it is not an
instance of the statement proved here, and the file documents the relation between the two.

`TauCeti/AlgebraicTopology/UniversalCover/Classification/ActionCover.lean` (218 lines) applies
this to the universal cover: for a `π₁(X, x₀)`-set `A`, `UniversalCover.actionCoveringSpace x₀ A`
is a covering space of `X` whose fibre over `x₀` is `A`, and
`UniversalCover.actionCoveringSpaceFiberEquiv_apply_monodromy` shows the identification is
equivariant. Equivariance is not proved by hand: attaching a fixed label `a` is a map of covering
spaces over `X`, so `TauCeti.IsCoveringMap.fiberMap_monodromy` reduces it to monodromy on the
fibre of the universal cover, which is `UniversalCover.monodromy_basepointLift`. That lemma acts
by the *inverse* loop class, and the inverse cancels against the exchange
`⟦(g • e, a)⟧ = ⟦(e, g⁻¹ • a)⟧`, so no `ᵐᵒᵖ` appears here — unlike in the deck-group
identification `UniversalCover.deckFundamentalGroupEquiv`.

Finally, `Classification/MonodromyEquivalence.lean` gains
`TauCeti.CoveringSpace.exists_monodromyFunctor_iso` and
`TauCeti.CoveringSpace.monodromyEquivalence : CoveringSpace X ≌ (FundamentalGroupoid X ⥤ Type u)`,
beside the connected statements it already carried; its module docstring is updated accordingly.
The reconstruction reuses the same transport as the connected case,
`TauCeti.Groupoid.natIsoOfEnd`, from the equivariant fibre identification at `x₀`.

No Mathlib code is vendored. The results consume Mathlib's `IsQuotientCoveringMap` interface and
`IsOpen.trivializationDiscrete`, both due to Junyan Xu, and the based-path universal cover already
in this repository, adapted from Kim Morrison's
[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292).

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"coveringspace-monodromyequivalence"}-->

🤖 Prepared with Claude Code
