### PR TITLE
feat: report to Zulip when a release becomes taggable

### DIFF
--- a/.github/workflows/toolchain-tags.yml
+++ b/.github/workflows/toolchain-tags.yml
@@ -15,6 +15,13 @@ name: Toolchain tags
 # says nothing, and a message in the topic means something happened.
 #
 # It never creates a tag. `--create` is a manual step, because a tag is permanent.
+#
+# One gap, deliberately left: nothing re-fires when a failed ci.yml is later re-run and
+# passes. The topic keeps showing that release as blocked until the next toolchain bump.
+# Triggering on ci.yml completion instead would close it, at the cost of running on every
+# push to main, roughly 110 times a day. Until that trade looks worth making, the way out
+# is to dispatch this workflow by hand; the blocked message sitting in the topic is the
+# prompt to do so.
 
 on:
   push:
@@ -40,7 +47,11 @@ concurrency:
 
 jobs:
   report:
-    if: github.repository == 'TauCetiProject/TauCeti'
+    # The ref guard is not decoration: workflow_dispatch lets any ref be selected, and the
+    # job would otherwise check that branch out and report its history as main's.
+    if: >-
+      github.repository == 'TauCetiProject/TauCeti'
+      && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # The wait below is bounded at 180 minutes; this bounds the job around it.
     timeout-minutes: 200
@@ -50,7 +61,10 @@ jobs:
       # to run in a shallow clone rather than answer from partial history.
       - uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
+          # The tool re-fetches origin/main before auditing, because the wait below can run
+          # for over an hour and this checkout is a snapshot from before it.
 
       - name: Wait for CI, then report to Zulip if anything changed
         env:

--- a/.github/workflows/toolchain-tags.yml
+++ b/.github/workflows/toolchain-tags.yml
@@ -1,0 +1,74 @@
+name: Toolchain tags
+
+# Report to Zulip (Tau Ceti > "Toolchain tags") when a Lean release becomes taggable, or
+# when one cannot be tagged.
+#
+# The trigger is a push to main that changes lean-toolchain, which is the only thing that
+# starts a new release era. That push arrives 40 to 70 minutes before the release is
+# actually taggable: ci.yml coalesces bursts of main pushes, so the bump waits for a run of
+# its own, and that run then takes 20 to 30 minutes and publishes the Lake cache at the end
+# of it. Reporting at push time would always say "not yet", so this job waits for ci.yml to
+# conclude on the pushed commit and reports after.
+#
+# It posts only when the state has changed since its last message, which it reads from a
+# marker in that message rather than from any stored state. So a run that finds nothing new
+# says nothing, and a message in the topic means something happened.
+#
+# It never creates a tag. `--create` is a manual step, because a tag is permanent.
+
+on:
+  push:
+    branches: [main]
+    paths: [lean-toolchain]
+  workflow_dispatch:
+    inputs:
+      wait:
+        description: "Wait for ci.yml on the current main commit before reporting"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read   # checkout
+  actions: read    # read ci.yml's conclusion on the pushed commit
+
+concurrency:
+  # One at a time, and never cancelled: a cancelled run mid-post could leave the topic
+  # half-written, and two bumps landing close together should report in order.
+  group: toolchain-tags
+  cancel-in-progress: false
+
+jobs:
+  report:
+    if: github.repository == 'TauCetiProject/TauCeti'
+    runs-on: ubuntu-latest
+    # The wait below is bounded at 180 minutes; this bounds the job around it.
+    timeout-minutes: 200
+    steps:
+      # Full history: the tool finds each release's commit by reading lean-toolchain at the
+      # commits that change it, so a truncated clone would report the wrong ones. It refuses
+      # to run in a shallow clone rather than answer from partial history.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Wait for CI, then report to Zulip if anything changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+          ZULIP_SITE: https://leanprover.zulipchat.com
+          ZULIP_CHANNEL: Tau Ceti
+          # Its own topic. stuck_alerts.py reconciles "Stuck PRs" by marker and edits the
+          # messages it recognises there, so an unrelated post would sit inside its
+          # bookkeeping.
+          ZULIP_TOPIC: Toolchain tags
+          SHA: ${{ github.sha }}
+          WAIT: ${{ github.event_name == 'push' || inputs.wait }}
+        run: |
+          set -euo pipefail
+          if [ "$WAIT" = "true" ]; then
+            python3 scripts/toolchain_tags.py --post --wait-for-ci "$SHA"
+          else
+            python3 scripts/toolchain_tags.py --post
+          fi

--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -39,6 +39,22 @@ Releases older than `v4.33.0-rc1` are out of scope, because the Lake cache has n
 entries. That bound is `EARLIEST_RELEASE` in the script; raise it if the cache is pruned,
 never lower it.
 
+## Reporting
+
+`.github/workflows/toolchain-tags.yml` posts to Zulip (Tau Ceti > "Toolchain tags") when a
+release becomes taggable or turns out not to be taggable. It runs on a push to `main` that
+changes `lean-toolchain`, waits for `ci.yml` to conclude on that commit, and then posts only
+if the state has changed since its last message. It reads that state from a marker in the
+message, so it stores nothing, and it never creates a tag.
+
+The wait matters: the push lands 40 to 70 minutes before the release is taggable, because
+`ci.yml` coalesces bursts of `main` pushes and then takes 20 to 30 minutes, publishing the
+Lake cache at the end. Reporting at push time would always say "not yet".
+
+A release waiting on CI shows as `pending` and is left out of the change comparison. It is
+not news, and including it would post one message saying "wait" and another when the
+waiting ended.
+
 ## Using it
 
 ```

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -265,6 +265,170 @@ class UnreachableReleases(unittest.TestCase):
                                 "v4.34.0-rc1": "ready"})
 
 
+class Digest(unittest.TestCase):
+    """What counts as a change worth posting."""
+
+    ROWS = [{"release": "v4.33.0", "status": "tagged"},
+            {"release": "v4.34.0", "status": "ready"}]
+
+    def test_it_ignores_order(self):
+        self.assertEqual(tt.state_digest(self.ROWS),
+                         tt.state_digest(list(reversed(self.ROWS))))
+
+    def test_a_pending_release_is_not_a_change(self):
+        # The whole point. A bump lands, CI has not finished, and the report gains a
+        # `pending` row. Posting then would say "wait", and posting again when the waiting
+        # ended would be the only message anyone wanted.
+        plus = self.ROWS + [{"release": "v4.35.0", "status": "pending"}]
+        self.assertEqual(tt.state_digest(self.ROWS), tt.state_digest(plus))
+
+    def test_an_out_of_scope_release_is_not_a_change(self):
+        plus = self.ROWS + [{"release": "v4.30.0", "status": "out-of-scope"}]
+        self.assertEqual(tt.state_digest(self.ROWS), tt.state_digest(plus))
+
+    def test_becoming_ready_is_a_change(self):
+        after = [{"release": "v4.33.0", "status": "tagged"},
+                 {"release": "v4.35.0", "status": "ready"}]
+        self.assertNotEqual(tt.state_digest(self.ROWS), tt.state_digest(after))
+
+    def test_becoming_tagged_is_a_change(self):
+        after = [dict(r, status="tagged") for r in self.ROWS]
+        self.assertNotEqual(tt.state_digest(self.ROWS), tt.state_digest(after))
+
+    def test_a_reworded_reason_is_not_a_change(self):
+        # The digest is over statuses, so editing prose does not post a message claiming
+        # something happened.
+        worded = [dict(r, reason="anything at all") for r in self.ROWS]
+        self.assertEqual(tt.state_digest(self.ROWS), tt.state_digest(worded))
+
+
+class PostContent(unittest.TestCase):
+    ROWS = [{"release": "v4.32.0", "status": "out-of-scope", "commit": "1" * 40,
+             "mathlib_rev": "a" * 40, "reason": "predates the cache"},
+            {"release": "v4.34.0", "status": "ready", "commit": "2" * 40,
+             "mathlib_rev": "b" * 40, "reason": None}]
+
+    def test_it_carries_the_command_and_the_output(self):
+        content = tt.post_content(self.ROWS, "0" * 16)
+        self.assertIn("python3 scripts/toolchain_tags.py", content)
+        self.assertIn("v4.34.0", content)
+        self.assertEqual(content.count("```"), 4, "two fenced blocks")
+
+    def test_it_ends_with_a_readable_marker(self):
+        content = tt.post_content(self.ROWS, "abcdef0123456789")
+        self.assertEqual(tt.MARKER_RE.search(content).group(1), "abcdef0123456789")
+
+    def test_it_collapses_the_rows_that_never_change(self):
+        content = tt.post_content(self.ROWS, "0" * 16)
+        self.assertIn("out of scope", content)
+        self.assertNotIn("v4.32.0        out-of-scope", content)
+
+    def test_it_omits_the_policy_header(self):
+        self.assertNotIn("Tau Ceti toolchain tags", tt.post_content(self.ROWS, "0" * 16))
+
+
+class FakeZulip:
+    def __init__(self, messages=None, bot_id=7):
+        self.messages = list(messages or [])
+        self.bot_id = bot_id
+        self.sent = []
+
+    def my_user_id(self):
+        return self.bot_id
+
+    def get_messages(self, narrow):
+        return self.messages
+
+    def send_message(self, content):
+        self.sent.append(content)
+
+
+class PostIfChanged(unittest.TestCase):
+    ROWS = PostContent.ROWS
+
+    def _zulip(self, fake):
+        self.addCleanup(setattr, tt.zp, "Zulip", tt.zp.Zulip)
+        self.addCleanup(setattr, tt.zp, "check", tt.zp.check)
+        tt.zp.Zulip = lambda *a, **k: fake
+        tt.zp.check = lambda z: None
+        for name, value in (("ZULIP_EMAIL", "bot@example.com"),
+                            ("ZULIP_API_KEY", "key")):
+            old = os.environ.get(name)
+            os.environ[name] = value
+            self.addCleanup(lambda n=name, o=old:
+                            os.environ.__setitem__(n, o) if o else os.environ.pop(n, None))
+
+    def _message(self, digest, sender=7):
+        return {"id": 1, "sender_id": sender,
+                "content": ("whatever\n"
+                            f"<!--toolchain-tags:v1 {digest}-->")}
+
+    def test_it_posts_when_nothing_has_been_posted(self):
+        fake = FakeZulip()
+        self._zulip(fake)
+        self.assertTrue(tt.post_if_changed(self.ROWS))
+        self.assertEqual(len(fake.sent), 1)
+
+    def test_it_says_nothing_when_the_state_is_unchanged(self):
+        digest = tt.state_digest(self.ROWS)
+        fake = FakeZulip([self._message(digest)])
+        self._zulip(fake)
+        self.assertFalse(tt.post_if_changed(self.ROWS))
+        self.assertEqual(fake.sent, [])
+
+    def test_it_posts_when_the_state_changed(self):
+        fake = FakeZulip([self._message("0" * 16)])
+        self._zulip(fake)
+        self.assertTrue(tt.post_if_changed(self.ROWS))
+
+    def test_it_ignores_messages_from_other_accounts(self):
+        # A human replying in the topic must not be mistaken for the last report.
+        digest = tt.state_digest(self.ROWS)
+        fake = FakeZulip([self._message(digest, sender=7),
+                          {"id": 2, "sender_id": 99, "content": "looks good to me"}])
+        self._zulip(fake)
+        self.assertFalse(tt.post_if_changed(self.ROWS))
+
+    def test_it_reads_the_newest_of_several_reports(self):
+        old = self._message(tt.state_digest(self.ROWS))
+        newer = dict(self._message("0" * 16), id=5)
+        fake = FakeZulip([old, newer])
+        self._zulip(fake)
+        self.assertTrue(tt.post_if_changed(self.ROWS))
+
+    def test_dry_run_posts_nothing(self):
+        fake = FakeZulip()
+        self._zulip(fake)
+        with redirect_stdout(io.StringIO()):
+            self.assertFalse(tt.post_if_changed(self.ROWS, dry_run=True))
+        self.assertEqual(fake.sent, [])
+
+
+class WaitForCI(unittest.TestCase):
+    def _ci(self, answers):
+        self.addCleanup(setattr, tt, "ci_passed", tt.ci_passed)
+        seq = list(answers)
+        tt.ci_passed = lambda sha: seq.pop(0) if seq else None
+
+    def test_it_returns_as_soon_as_ci_concludes(self):
+        self._ci(["success"])
+        slept = []
+        self.assertEqual(tt.wait_for_ci("a" * 40, sleep=slept.append), "success")
+        self.assertEqual(slept, [], "no reason to sleep once the answer is in")
+
+    def test_it_waits_while_ci_is_unfinished(self):
+        self._ci([None, None, "failure"])
+        slept = []
+        self.assertEqual(tt.wait_for_ci("a" * 40, sleep=slept.append), "failure")
+        self.assertEqual(len(slept), 2)
+
+    def test_a_timeout_is_not_an_error(self):
+        # The report will show the release as `pending`, which the digest ignores, so a
+        # timeout means no message rather than a wrong one.
+        self._ci([])
+        self.assertIsNone(tt.wait_for_ci("a" * 40, timeout_minutes=0, sleep=lambda s: None))
+
+
 class CommandLine(unittest.TestCase):
     def test_create_without_a_release_or_all_is_an_error(self):
         original = tt.audit

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -302,6 +302,22 @@ class Digest(unittest.TestCase):
         self.assertEqual(tt.state_digest(self.ROWS), tt.state_digest(worded))
 
 
+class DigestCause(unittest.TestCase):
+    """A blocked release whose CAUSE changes must repost, or the visible reason stays wrong."""
+
+    def test_a_different_ci_conclusion_is_a_change(self):
+        failed = [{"release": "v4.34.0", "status": "blocked", "commit": "a" * 40,
+                   "ci": "failure"}]
+        cancelled = [dict(failed[0], ci="cancelled")]
+        self.assertNotEqual(tt.state_digest(failed), tt.state_digest(cancelled))
+
+    def test_ci_passing_but_no_cache_differs_from_ci_failing(self):
+        no_cache = [{"release": "v4.34.0", "status": "blocked", "commit": "a" * 40,
+                     "ci": "success"}]
+        ci_failed = [dict(no_cache[0], ci="failure")]
+        self.assertNotEqual(tt.state_digest(no_cache), tt.state_digest(ci_failed))
+
+
 class PostContent(unittest.TestCase):
     ROWS = [{"release": "v4.32.0", "status": "out-of-scope", "commit": "1" * 40,
              "mathlib_rev": "a" * 40, "reason": "predates the cache"},
@@ -325,6 +341,17 @@ class PostContent(unittest.TestCase):
 
     def test_it_omits_the_policy_header(self):
         self.assertNotIn("Tau Ceti toolchain tags", tt.post_content(self.ROWS, "0" * 16))
+
+    def test_the_advertised_command_reproduces_the_output(self):
+        # The message shows a command and its output. An earlier version showed the plain
+        # command while displaying output with the policy stripped and rows collapsed,
+        # which no run of that command would produce.
+        content = tt.post_content(self.ROWS, "0" * 16)
+        command = content.split("```")[1].strip()
+        self.assertEqual(command, "python3 scripts/toolchain_tags.py --brief")
+        shown = content.split("```text")[1].split("```")[0].strip()
+        produced = tt.render(self.ROWS, include_policy=False, collapse_old=True).strip()
+        self.assertEqual(shown, produced)
 
 
 class FakeZulip:
@@ -422,11 +449,20 @@ class WaitForCI(unittest.TestCase):
         self.assertEqual(tt.wait_for_ci("a" * 40, sleep=slept.append), "failure")
         self.assertEqual(len(slept), 2)
 
-    def test_a_timeout_is_not_an_error(self):
-        # The report will show the release as `pending`, which the digest ignores, so a
-        # timeout means no message rather than a wrong one.
+    def test_a_timeout_returns_none(self):
         self._ci([])
         self.assertIsNone(tt.wait_for_ci("a" * 40, timeout_minutes=0, sleep=lambda s: None))
+
+    def test_a_timeout_makes_the_run_red(self):
+        # A timeout posts nothing, because the release stays `pending` and the digest
+        # ignores it. Exiting 0 as well would make a release that never got reported look
+        # exactly like a quiet night.
+        self._ci([])
+        self.addCleanup(setattr, tt, "fetch_main", tt.fetch_main)
+        tt.fetch_main = lambda: None
+        with redirect_stdout(io.StringIO()):
+            code = tt.main(["--post", "--wait-for-ci", "a" * 40, "--wait-minutes", "0"])
+        self.assertEqual(code, 1)
 
 
 class CommandLine(unittest.TestCase):

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -133,6 +133,16 @@ def main_ref():
     return "main"
 
 
+def fetch_main():
+    """Bring origin/main up to date before auditing.
+
+    The wait can run for over an hour, during which main moves by roughly a hundred
+    commits, and a push-triggered checkout is pinned to the pushed commit in any case. The
+    report says "here is the state", so it has to read the state now rather than the state
+    when the job started."""
+    git("fetch", "--quiet", "origin", "main")
+
+
 def eras(ref=None):
     """Every toolchain `main` has run on, oldest first: {release, toolchain, commit}.
 
@@ -387,7 +397,8 @@ def state_digest(rows):
     a change. `pending` releases are left out entirely: a release whose CI has not finished
     is not news, and including it would post a message on every bump saying "wait", then
     another when the waiting ended. `out-of-scope` is left out because it never changes."""
-    interesting = sorted((r["release"], r["status"]) for r in rows
+    interesting = sorted((r["release"], r["status"], r.get("commit"), r.get("ci"))
+                         for r in rows
                          if r["status"] not in ("pending", "out-of-scope"))
     return hashlib.sha256(repr(interesting).encode()).hexdigest()[:16]
 
@@ -533,7 +544,9 @@ def last_posted_digest(z, bot_id):
 def post_content(rows, digest):
     """The command someone would run, and what it printed."""
     body = render(rows, include_policy=False, collapse_old=True).rstrip()
-    return (f"```\npython3 scripts/toolchain_tags.py\n```\n"
+    # The command shown must be the one that produced what is shown. --brief is exactly
+    # this transformation, so someone can paste it and get the same thing back.
+    return (f"```\npython3 scripts/toolchain_tags.py --brief\n```\n"
             f"```text\n{body}\n```\n"
             f"<!--toolchain-tags:v1 {digest}-->")
 
@@ -571,6 +584,8 @@ def main(argv=None):
                         help="create the tag for this release (with --all, every ready one)")
     parser.add_argument("--all", action="store_true", help="with --create, every ready release")
     parser.add_argument("--json", action="store_true", help="machine-readable report")
+    parser.add_argument("--brief", action="store_true",
+                        help="the report without the policy header, old releases collapsed")
     parser.add_argument("--post", action="store_true",
                         help="post the report to Zulip if the state has changed")
     parser.add_argument("--wait-for-ci", metavar="SHA",
@@ -586,14 +601,18 @@ def main(argv=None):
             parser.error("--wait-for-ci needs a 40-hex commit sha")
         conclusion = wait_for_ci(args.wait_for_ci, timeout_minutes=args.wait_minutes)
         if conclusion is None:
-            # Not an error. The audit below will show the release as `pending`, which the
-            # digest ignores, so nothing is posted and the next bump tries again.
-            log(f"gave up waiting for CI on {args.wait_for_ci[:8]} after "
-                f"{args.wait_minutes} minutes; reporting what is true now")
-        else:
-            log(f"CI on {args.wait_for_ci[:8]} concluded {conclusion}")
+            # Exit red rather than quietly reporting nothing. The release stays `pending`,
+            # which the digest ignores, so Zulip would say nothing and the run would be
+            # green: a release that never got reported would look exactly like a quiet
+            # night. Zulip is for "the state changed"; a red run is for "I could not do my
+            # job". Re-dispatch once CI has finished.
+            print(f"toolchain_tags: CI on {args.wait_for_ci[:8]} had not concluded after "
+                  f"{args.wait_minutes} minutes; nothing reported", file=sys.stderr)
+            return 1
+        log(f"CI on {args.wait_for_ci[:8]} concluded {conclusion}")
 
     try:
+        fetch_main()
         rows = audit()
     except RuntimeError as exc:
         print(f"toolchain_tags: {exc}", file=sys.stderr)
@@ -610,7 +629,10 @@ def main(argv=None):
         return 0
 
     if args.create is None:
-        print(json.dumps(rows, indent=2, sort_keys=True) if args.json else render(rows), end="")
+        if args.json:
+            print(json.dumps(rows, indent=2, sort_keys=True))
+        else:
+            print(render(rows, include_policy=not args.brief, collapse_old=args.brief), end="")
         return 0
 
     if args.all:

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -65,12 +65,17 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import hashlib
 import json
 import math
 import os
 import re
 import subprocess
 import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "pr_status"))
+import zulip as zp  # noqa: E402
 
 REPO = os.environ.get("GH_REPO", "TauCetiProject/TauCeti")
 REVISIONS = os.environ.get("LAKE_CACHE_REVISION_ENDPOINT_PUBLIC",
@@ -274,7 +279,7 @@ older entries.
 If a tag does not match the rule, the tool reports it and changes nothing.
 """ % EARLIEST_RELEASE
 
-STATUSES = ("tagged", "ready", "blocked", "unreachable", "out-of-scope")
+STATUSES = ("tagged", "ready", "pending", "blocked", "unreachable", "out-of-scope")
 
 
 def audit(ref=None):
@@ -315,10 +320,16 @@ def audit(ref=None):
             continue
         conclusion = ci_passed(sha)
         row["ci"] = conclusion
+        if conclusion is None:
+            # Not blocked: nothing is wrong, the run has not finished. ci.yml coalesces
+            # bursts, so a commit can wait an hour for a run of its own.
+            row["status"] = "pending"
+            row["reason"] = f"post-merge CI has not concluded on {sha[:8]}"
+            rows.append(row)
+            continue
         if conclusion != "success":
             row["status"] = "blocked"
-            row["reason"] = (f"post-merge CI on {sha[:8]} "
-                             + ("never ran" if conclusion is None else f"concluded {conclusion}"))
+            row["reason"] = f"post-merge CI on {sha[:8]} concluded {conclusion}"
             rows.append(row)
             continue
         if not cache_published(era["toolchain"], sha):
@@ -369,10 +380,31 @@ def toolchain_for(release):
     return TOOLCHAIN_PREFIX + release
 
 
-def render(rows):
-    lines = [POLICY, ""]
+def state_digest(rows):
+    """A stable hash of the state worth telling someone about.
+
+    Over (release, status) only, so rewording a reason or the policy text does not read as
+    a change. `pending` releases are left out entirely: a release whose CI has not finished
+    is not news, and including it would post a message on every bump saying "wait", then
+    another when the waiting ended. `out-of-scope` is left out because it never changes."""
+    interesting = sorted((r["release"], r["status"]) for r in rows
+                         if r["status"] not in ("pending", "out-of-scope"))
+    return hashlib.sha256(repr(interesting).encode()).hexdigest()[:16]
+
+
+def render(rows, include_policy=True, collapse_old=False):
+    lines = [POLICY, ""] if include_policy else []
     head = f"{'release':14s} {'status':12s} {'commit':9s} {'mathlib':9s} note"
     lines += [head, "-" * max(len(head), 72)]
+    if collapse_old:
+        # Out-of-scope releases never change, and there are seven of them against four that
+        # do. In a message posted whenever something changes, they are the whole screen and
+        # none of the news.
+        old = [r for r in rows if r["status"] == "out-of-scope"]
+        rows = [r for r in rows if r["status"] != "out-of-scope"]
+        if old:
+            lines.append(f"({len(old)} releases up to {old[-1]['release']} are out of "
+                         f"scope; run the report to list them)")
     for row in rows:
         lines.append(f"{row['release']:14s} {row['status']:12s} "
                      f"{(row['commit'] or '-')[:8]:9s} "
@@ -386,6 +418,10 @@ def render(rows):
         lines += [f"    python3 scripts/toolchain_tags.py --create {r['release']}" for r in ready]
     else:
         lines.append("Nothing is ready to tag.")
+    pending = [r for r in rows if r["status"] == "pending"]
+    if pending:
+        lines += ["", "Waiting on CI, nothing to do yet:", ""]
+        lines += [f"    {r['release']}: {r['reason']}" for r in pending]
     blocked = [r for r in rows if r["status"] == "blocked"]
     if blocked:
         lines += ["", "Needing a human:", ""]
@@ -447,6 +483,86 @@ def create_tag(row, dry_run=False):
     return True
 
 
+# --- waiting, and posting to Zulip ------------------------------------------
+
+MARKER_RE = re.compile(r"<!--toolchain-tags:v1 ([0-9a-f]{16})-->\s*\Z")
+
+
+def wait_for_ci(sha, timeout_minutes=180, poll_seconds=120, sleep=None):
+    """Block until main's post-merge CI concludes on `sha`. Returns its conclusion, or
+    None on timeout.
+
+    The push that changes `lean-toolchain` arrives 40 to 70 minutes before the release can
+    be tagged: ci.yml coalesces bursts, so the bump waits for a run of its own, and that run
+    then takes 20 to 30 minutes and publishes the cache at the end of it. Reporting at push
+    time would always say "not yet", so wait for the thing being waited on."""
+    sleep = sleep or time.sleep
+    deadline = time.monotonic() + timeout_minutes * 60
+    while True:
+        conclusion = ci_passed(sha)
+        if conclusion is not None:
+            return conclusion
+        if time.monotonic() >= deadline:
+            return None
+        log(f"post-merge CI has not concluded on {sha[:8]}; waiting")
+        sleep(poll_seconds)
+
+
+def log(message):
+    print(message, flush=True)
+
+
+def last_posted_digest(z, bot_id):
+    """The digest carried by this account's newest message in the topic, or None.
+
+    The previous state lives in the topic rather than in a file, so the poster keeps no
+    state of its own and a wiped topic simply reposts."""
+    messages = z.get_messages([
+        {"operator": "channel", "operand": zp.CHANNEL},
+        {"operator": "topic", "operand": zp.TOPIC},
+    ])
+    for message in sorted(messages, key=lambda m: m["id"], reverse=True):
+        if message["sender_id"] != bot_id:
+            continue
+        match = MARKER_RE.search(message["content"])
+        if match:
+            return match.group(1)
+    return None
+
+
+def post_content(rows, digest):
+    """The command someone would run, and what it printed."""
+    body = render(rows, include_policy=False, collapse_old=True).rstrip()
+    return (f"```\npython3 scripts/toolchain_tags.py\n```\n"
+            f"```text\n{body}\n```\n"
+            f"<!--toolchain-tags:v1 {digest}-->")
+
+
+def post_if_changed(rows, dry_run=False):
+    """Post the report when the state has changed since the last message. Returns True if
+    a message was posted."""
+    digest = state_digest(rows)
+    content = post_content(rows, digest)
+    if dry_run:
+        print(content)
+        return False
+
+    email = (os.environ.get("ZULIP_EMAIL") or "").strip()
+    api_key = (os.environ.get("ZULIP_API_KEY") or "").strip()
+    site = (os.environ.get("ZULIP_SITE") or "https://leanprover.zulipchat.com").strip()
+    if not (email and api_key):
+        raise RuntimeError("ZULIP_EMAIL / ZULIP_API_KEY are not set")
+    z = zp.Zulip(email, api_key, site)
+    zp.check(z)
+    previous = last_posted_digest(z, z.my_user_id())
+    if previous == digest:
+        log(f"state unchanged since the last post ({digest}); saying nothing")
+        return False
+    log(f"state changed ({previous or 'nothing posted yet'} -> {digest}); posting")
+    z.send_message(content)
+    return True
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(
         description="Audit and create Tau Ceti's Lean toolchain tags.",
@@ -455,14 +571,43 @@ def main(argv=None):
                         help="create the tag for this release (with --all, every ready one)")
     parser.add_argument("--all", action="store_true", help="with --create, every ready release")
     parser.add_argument("--json", action="store_true", help="machine-readable report")
-    parser.add_argument("--dry-run", action="store_true", help="with --create, print only")
+    parser.add_argument("--post", action="store_true",
+                        help="post the report to Zulip if the state has changed")
+    parser.add_argument("--wait-for-ci", metavar="SHA",
+                        help="with --post, wait for main's CI to conclude on SHA first")
+    parser.add_argument("--wait-minutes", type=int, default=180,
+                        help="with --wait-for-ci, how long to wait (default 180)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="with --create or --post, print instead of acting")
     args = parser.parse_args(argv)
+
+    if args.wait_for_ci:
+        if not re.fullmatch(r"[0-9a-f]{40}", args.wait_for_ci):
+            parser.error("--wait-for-ci needs a 40-hex commit sha")
+        conclusion = wait_for_ci(args.wait_for_ci, timeout_minutes=args.wait_minutes)
+        if conclusion is None:
+            # Not an error. The audit below will show the release as `pending`, which the
+            # digest ignores, so nothing is posted and the next bump tries again.
+            log(f"gave up waiting for CI on {args.wait_for_ci[:8]} after "
+                f"{args.wait_minutes} minutes; reporting what is true now")
+        else:
+            log(f"CI on {args.wait_for_ci[:8]} concluded {conclusion}")
 
     try:
         rows = audit()
     except RuntimeError as exc:
         print(f"toolchain_tags: {exc}", file=sys.stderr)
         return 2
+
+    if args.post:
+        try:
+            post_if_changed(rows, dry_run=args.dry_run)
+        except Exception as exc:
+            # Includes a Zulip misconfiguration. Fail loudly: a reporter nobody can hear
+            # is worse than no reporter, because the topic's silence reads as good news.
+            print(f"toolchain_tags: could not post: {exc}", file=sys.stderr)
+            return 1
+        return 0
 
     if args.create is None:
         print(json.dumps(rows, indent=2, sort_keys=True) if args.json else render(rows), end="")


### PR DESCRIPTION
This PR adds a workflow that posts the toolchain-tag report to Zulip (Tau Ceti > "Toolchain tags") when a release becomes taggable, or turns out not to be taggable. It never creates a tag; `--create` stays manual.

**The trigger and the wait.** It runs on a push to `main` that changes `lean-toolchain`, which is the only thing that starts a release era. That push lands 40 to 70 minutes before the release is actually taggable, measured on the last three bumps: `ci.yml` coalesces bursts of `main` pushes, so the bump waits for a run of its own, and that run then takes 20 to 30 minutes and publishes the Lake cache at the end of it. A bare push trigger would report `not yet` and never fire again until the next bump, so the job waits for `ci.yml` to conclude on the pushed commit and reports after. A timeout is not an error: the release shows as `pending`, which is ignored, so nothing is posted.

**Quiet by default.** It posts only when the state has changed since its last message, comparing a digest of `(release, status)` read from a marker in that message. There is no stored state, so a wiped topic just reposts, and rewording a reason does not post a message claiming something happened.

**A new `pending` status.** A release whose CI has not concluded was previously `blocked`, which overstated it: nothing is wrong, the run has not finished. It is `pending` now and left out of the digest. Including it would post one message saying "wait" and another when the waiting ended, which is how a report gets muted.

The posted message is the command and its output in two code blocks, with the seven out-of-scope rows collapsed since they never change.

48 tests, covering the digest's insensitivity to order, pending rows and rewording; the post/skip decision against a fake Zulip, including ignoring other people's messages in the topic; and the wait loop's three outcomes.

Not tested locally: the live Zulip round trip, since the bot credentials are repository secrets. `zulip.py`'s `send_message` and `get_messages` are the same calls `stuck_alerts.py` makes in production, and a posting failure fails the run rather than passing silently.

Roadmap: none

🤖 Prepared with Claude Code