### PR TITLE
feat: the classical T_p at every prime, from the good-prime coset decomposition

### DIFF
--- a/TauCeti/Data/ZMod/Divisibility.lean
+++ b/TauCeti/Data/ZMod/Divisibility.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Data.ZMod.Basic
+
+/-!
+# Solving the linear congruence `j b ≡ a` modulo `n`
+
+A linear congruence with unit coefficient is solvable: if `b` is a unit modulo `n`, then some
+residue `j : ZMod n` satisfies `n ∣ a - j.val * b` over `ℤ`. The solution is `j = a b⁻¹`, and it
+is returned as a residue class together with its canonical representative `j.val`, which is the
+form a coset representative indexed by `Fin n` needs.
+
+## Main results
+
+* `ZMod.exists_dvd_sub_val_mul`: the congruence `j b ≡ a (mod n)` has a solution `j : ZMod n`
+  whenever `b` is a unit modulo `n`.
+-/
+
+public section
+
+namespace ZMod
+
+/-- **A linear congruence with unit coefficient is solvable.** If `b` is a unit modulo `n`, then
+`n ∣ a - j.val * b` for some `j : ZMod n`, namely `j = a b⁻¹`. -/
+lemma exists_dvd_sub_val_mul (n : ℕ) [NeZero n] (a b : ℤ)
+    (hb : IsUnit ((b : ℤ) : ZMod n)) : ∃ j : ZMod n, (n : ℤ) ∣ a - (j.val : ℤ) * b := by
+  obtain ⟨u, hu⟩ := hb
+  refine ⟨(a : ZMod n) * ↑u⁻¹, ?_⟩
+  rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
+  push_cast
+  rw [ZMod.natCast_zmod_val, mul_assoc]
+  -- the coerced product collapses: `↑b = ↑u` by `hu`, and `u⁻¹ * u = 1` in the units
+  have hunit : (↑u⁻¹ * ((b : ℤ) : ZMod n) : ZMod n) = 1 := by rw [← hu, Units.inv_mul]
+  rw [hunit, mul_one, sub_self]
+
+end ZMod

--- a/TauCeti/Data/ZMod/Divisibility.lean
+++ b/TauCeti/Data/ZMod/Divisibility.lean
@@ -15,6 +15,11 @@ residue `j : ZMod n` satisfies `n ∣ a - j.val * b` over `ℤ`. The solution is
 is returned as a residue class together with its canonical representative `j.val`, which is the
 form a coset representative indexed by `Fin n` needs.
 
+Extracted from `TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean`, where it was private;
+that index calculation was ported from the AINTLIB `LeanModularForms` project
+(`LeanModularForms/HeckeRIngs/GL2/CongruenceIndex.lean`, Chris Birkbeck, Apache-2.0). The lemma is
+consumed there and in `HeckeRing/GL2/Gamma1/CoprimeCosets.lean`.
+
 ## Main results
 
 * `ZMod.exists_dvd_sub_val_mul`: the congruence `j b ≡ a (mod n)` has a solution `j : ZMod n`

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -16,7 +16,8 @@ import TauCeti.Data.ZMod.Units
 
 The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong approximation for
 `SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
-`-I` to `-I`.
+`-I` to `-I`. Basic coordinate descriptions for `SL₂` and its image under `mapGL` are also
+recorded here for downstream matrix computations.
 
 The third result pins down `±I` itself, which is what the base-change statement moves around:
 over a commutative ring without zero divisors the centre of `SL₂` is exactly `{±I}`, the
@@ -31,6 +32,8 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
 
 * `Matrix.SpecialLinearGroup.map_intCast_zmod_surjective`: strong approximation for `SL₂`.
 * `Matrix.SpecialLinearGroup.mapGL_neg_one`: `mapGL S (-1) = -1`.
+* `Matrix.SpecialLinearGroup.det_fin_two`: the determinant-one identity in coordinates.
+* `Matrix.SpecialLinearGroup.coe_mapGL_fin_two`: the entrywise matrix of `mapGL ℚ` on `SL₂(ℤ)`.
 * `Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one`: the centre of `SL₂` is
   `{±I}` when `R` has no zero divisors.
 
@@ -44,9 +47,24 @@ public section
 
 open Matrix
 
+open scoped MatrixGroups
+
 variable {d : ℕ}
 
 namespace Matrix.SpecialLinearGroup
+
+/-- The determinant-one identity for an element of `SL₂(R)`, written in coordinates. -/
+lemma det_fin_two {R : Type*} [CommRing R] (g : SL(2, R)) :
+    g 0 0 * g 1 1 - g 0 1 * g 1 0 = 1 := by
+  simpa only [Matrix.det_fin_two] using g.det_coe
+
+/-- The rational matrix of `mapGL ℚ σ`, written entrywise for `σ ∈ SL₂(ℤ)`. -/
+lemma coe_mapGL_fin_two (σ : SL(2, ℤ)) :
+    (↑(mapGL ℚ σ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      !![((σ 0 0 : ℤ) : ℚ), ((σ 0 1 : ℤ) : ℚ); ((σ 1 0 : ℤ) : ℚ), ((σ 1 1 : ℤ) : ℚ)] := by
+  rw [mapGL_coe_matrix]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp
 
 /-- `-I` maps to `-I` under `SL(n, R) → GL(n, S)`. -/
 @[simp]
@@ -127,7 +145,7 @@ private lemma inv_mul_zero_zero_eq_one
     (h0 : M 0 0 = g 0 0) (h1 : M 1 0 = g 1 0) : (M⁻¹ * g) 0 0 = 1 := by
   have hdet : M 0 0 * M 1 1 - M 0 1 * M 1 0 = 1 := by
     have h := M.det_coe
-    rwa [det_fin_two] at h
+    rwa [Matrix.det_fin_two] at h
   rw [mul_apply_zero_zero, inv_apply_zero_zero, inv_apply_zero_one, ← h0, ← h1]
   linear_combination hdet
 
@@ -140,7 +158,7 @@ private lemma exists_map_eq_of_col_eq (h : SpecialLinearGroup (Fin 2) (ZMod d))
   obtain ⟨t₀, ht₀⟩ := ZMod.intCast_surjective (h 0 1)
   have h11 : h 1 1 = 1 := by
     have hdet := h.det_coe
-    rw [det_fin_two] at hdet
+    rw [Matrix.det_fin_two] at hdet
     rw [h00, h10] at hdet
     linear_combination hdet
   refine ⟨transvection (by decide : (0 : Fin 2) ≠ 1) t₀, ?_⟩

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -12,7 +12,7 @@ import Mathlib.Tactic.LinearCombination
 import TauCeti.Data.ZMod.Units
 
 /-!
-# Special linear groups: surjectivity of reduction, the centre, and the image of `-I`
+# Special linear groups: reduction, the centre, and coordinate descriptions
 
 The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong approximation for
 `SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
@@ -20,7 +20,8 @@ The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong
 recorded here for downstream matrix computations, together with what the determinant says about
 a matrix with a prescribed bottom row `(N, p)`: it is the Bézout relation `m p - n N = 1`.
 
-The third result pins down `±I` itself, which is what the base-change statement moves around:
+`mem_center_iff_eq_one_or_eq_neg_one` pins down `±I` itself, which is what the base-change
+statement moves around:
 over a commutative ring without zero divisors the centre of `SL₂` is exactly `{±I}`, the
 scalar form Mathlib gives having no other square roots of `1` to offer.
 
@@ -33,13 +34,12 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
 
 * `Matrix.SpecialLinearGroup.map_intCast_zmod_surjective`: strong approximation for `SL₂`.
 * `Matrix.SpecialLinearGroup.mapGL_neg_one`: `mapGL S (-1) = -1`.
-* `Matrix.SpecialLinearGroup.det_fin_two`: the determinant-one identity in coordinates.
-* `Matrix.SpecialLinearGroup.coe_mapGL_fin_two`: the entrywise matrix of `mapGL ℚ` on `SL₂(ℤ)`.
-* `Matrix.SpecialLinearGroup.bezout_of_lowerRow`, together with
-  `Matrix.SpecialLinearGroup.coprime_of_lowerRow` and
-  `Matrix.SpecialLinearGroup.intCast_mul_eq_one_of_lowerRow`: a bottom row `(N, p)` is a Bézout
-  relation, so it forces `p` and `N` to be coprime, and the diagonal entries to be mutually
-  inverse modulo `N`.
+* `Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one`: the determinant-one identity in
+  coordinates.
+* `Matrix.SpecialLinearGroup.coe_mapGL_fin_two`: the entrywise matrix of `mapGL S` on `SL₂(R)`,
+  with `coe_mapGL_int_rat_fin_two` its `ℤ`-to-`ℚ` specialization.
+* `Matrix.SpecialLinearGroup.mul_sub_mul_eq_one_of_lowerRow`: a bottom row `(N, p)` gives the
+  Bézout relation `m p - n N = 1`.
 * `Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one`: the centre of `SL₂` is
   `{±I}` when `R` has no zero divisors.
 
@@ -60,39 +60,32 @@ variable {d : ℕ}
 namespace Matrix.SpecialLinearGroup
 
 /-- The determinant-one identity for an element of `SL₂(R)`, written in coordinates. -/
-lemma det_fin_two {R : Type*} [CommRing R] (g : SL(2, R)) :
+lemma fin_two_mul_sub_mul_eq_one {R : Type*} [CommRing R] (g : SL(2, R)) :
     g 0 0 * g 1 1 - g 0 1 * g 1 0 = 1 := by
   simpa only [Matrix.det_fin_two] using g.det_coe
 
-/-- The rational matrix of `mapGL ℚ σ`, written entrywise for `σ ∈ SL₂(ℤ)`. -/
-lemma coe_mapGL_fin_two (σ : SL(2, ℤ)) :
-    (↑(mapGL ℚ σ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      !![((σ 0 0 : ℤ) : ℚ), ((σ 0 1 : ℤ) : ℚ); ((σ 1 0 : ℤ) : ℚ), ((σ 1 1 : ℤ) : ℚ)] := by
+/-- The matrix of `mapGL S σ`, written entrywise for `σ ∈ SL₂(R)`. -/
+lemma coe_mapGL_fin_two {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
+    (σ : SL(2, R)) :
+    (↑(mapGL S σ) : Matrix (Fin 2) (Fin 2) S) =
+      !![algebraMap R S (σ 0 0), algebraMap R S (σ 0 1);
+        algebraMap R S (σ 1 0), algebraMap R S (σ 1 1)] := by
   rw [mapGL_coe_matrix]
   ext i j
   fin_cases i <;> fin_cases j <;> simp
 
+/-- The rational matrix of `mapGL ℚ σ`, written entrywise for `σ ∈ SL₂(ℤ)`. -/
+lemma coe_mapGL_int_rat_fin_two (σ : SL(2, ℤ)) :
+    (↑(mapGL ℚ σ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      !![((σ 0 0 : ℤ) : ℚ), ((σ 0 1 : ℤ) : ℚ);
+        ((σ 1 0 : ℤ) : ℚ), ((σ 1 1 : ℤ) : ℚ)] := by
+  simpa only [eq_intCast] using coe_mapGL_fin_two (S := ℚ) σ
+
 /-- **The bottom row of an `SL₂(ℤ)` matrix is a Bézout relation.** If it is `(N, p)`, then the
 top row `(m, n)` satisfies `m p - n N = 1`. -/
-lemma bezout_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
+lemma mul_sub_mul_eq_one_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
     (hσ11 : σ 1 1 = (p : ℤ)) : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := by
-  simpa only [hσ10, hσ11] using det_fin_two σ
-
-/-- A bottom row `(N, p)` of an `SL₂(ℤ)` matrix forces `p` and `N` to be coprime. -/
-lemma coprime_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
-    (hσ11 : σ 1 1 = (p : ℤ)) : Nat.Coprime p N :=
-  Nat.isCoprime_iff_coprime.mp (by
-    rw [← hσ10, ← hσ11]
-    exact (isCoprime_row σ 1).symm)
-
-/-- If the bottom row of `σ ∈ SL₂(ℤ)` is `(N, p)`, then its upper-left entry `m` satisfies
-`m p = 1` in `ZMod N`. -/
-lemma intCast_mul_eq_one_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
-    (hσ11 : σ 1 1 = (p : ℤ)) : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
-  have h := congrArg (Int.cast : ℤ → ZMod N) (bezout_of_lowerRow hσ10 hσ11)
-  push_cast at h ⊢
-  rw [ZMod.natCast_self] at h
-  linear_combination h
+  simpa only [hσ10, hσ11] using fin_two_mul_sub_mul_eq_one σ
 
 /-- `-I` maps to `-I` under `SL(n, R) → GL(n, S)`. -/
 @[simp]
@@ -171,9 +164,8 @@ private lemma inv_mul_one_zero_eq_zero
 private lemma inv_mul_zero_zero_eq_one
     (M g : SpecialLinearGroup (Fin 2) R)
     (h0 : M 0 0 = g 0 0) (h1 : M 1 0 = g 1 0) : (M⁻¹ * g) 0 0 = 1 := by
-  have hdet : M 0 0 * M 1 1 - M 0 1 * M 1 0 = 1 := by
-    have h := M.det_coe
-    rwa [Matrix.det_fin_two] at h
+  have hdet : M 0 0 * M 1 1 - M 0 1 * M 1 0 = 1 :=
+    fin_two_mul_sub_mul_eq_one M
   rw [mul_apply_zero_zero, inv_apply_zero_zero, inv_apply_zero_one, ← h0, ← h1]
   linear_combination hdet
 
@@ -185,8 +177,7 @@ private lemma exists_map_eq_of_col_eq (h : SpecialLinearGroup (Fin 2) (ZMod d))
       SpecialLinearGroup.map (Int.castRingHom (ZMod d)) τ = h := by
   obtain ⟨t₀, ht₀⟩ := ZMod.intCast_surjective (h 0 1)
   have h11 : h 1 1 = 1 := by
-    have hdet := h.det_coe
-    rw [Matrix.det_fin_two] at hdet
+    have hdet := fin_two_mul_sub_mul_eq_one h
     rw [h00, h10] at hdet
     linear_combination hdet
   refine ⟨transvection (by decide : (0 : Fin 2) ≠ 1) t₀, ?_⟩

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -37,7 +37,7 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
 * `Matrix.SpecialLinearGroup.coe_mapGL_fin_two`: the entrywise matrix of `mapGL ℚ` on `SL₂(ℤ)`.
 * `Matrix.SpecialLinearGroup.bezout_of_lowerRow`, together with
   `Matrix.SpecialLinearGroup.coprime_of_lowerRow` and
-  `Matrix.SpecialLinearGroup.intCast_mul_of_lowerRow`: a bottom row `(N, p)` is a Bézout
+  `Matrix.SpecialLinearGroup.intCast_mul_eq_one_of_lowerRow`: a bottom row `(N, p)` is a Bézout
   relation, so it forces `p` and `N` to be coprime, and the diagonal entries to be mutually
   inverse modulo `N`.
 * `Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one`: the centre of `SL₂` is
@@ -87,7 +87,7 @@ lemma coprime_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : �
 
 /-- If the bottom row of `σ ∈ SL₂(ℤ)` is `(N, p)`, then its upper-left entry `m` satisfies
 `m p = 1` in `ZMod N`. -/
-lemma intCast_mul_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
+lemma intCast_mul_eq_one_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
     (hσ11 : σ 1 1 = (p : ℤ)) : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
   have h := congrArg (Int.cast : ℤ → ZMod N) (bezout_of_lowerRow hσ10 hσ11)
   push_cast at h ⊢

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -17,7 +17,8 @@ import TauCeti.Data.ZMod.Units
 The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong approximation for
 `SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
 `-I` to `-I`. Basic coordinate descriptions for `SL₂` and its image under `mapGL` are also
-recorded here for downstream matrix computations.
+recorded here for downstream matrix computations, together with what the determinant says about
+a matrix with a prescribed bottom row `(N, p)`: it is the Bézout relation `m p - n N = 1`.
 
 The third result pins down `±I` itself, which is what the base-change statement moves around:
 over a commutative ring without zero divisors the centre of `SL₂` is exactly `{±I}`, the
@@ -34,6 +35,11 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
 * `Matrix.SpecialLinearGroup.mapGL_neg_one`: `mapGL S (-1) = -1`.
 * `Matrix.SpecialLinearGroup.det_fin_two`: the determinant-one identity in coordinates.
 * `Matrix.SpecialLinearGroup.coe_mapGL_fin_two`: the entrywise matrix of `mapGL ℚ` on `SL₂(ℤ)`.
+* `Matrix.SpecialLinearGroup.bezout_of_lowerRow`, together with
+  `Matrix.SpecialLinearGroup.coprime_of_lowerRow` and
+  `Matrix.SpecialLinearGroup.intCast_mul_of_lowerRow`: a bottom row `(N, p)` is a Bézout
+  relation, so it forces `p` and `N` to be coprime, and the diagonal entries to be mutually
+  inverse modulo `N`.
 * `Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one`: the centre of `SL₂` is
   `{±I}` when `R` has no zero divisors.
 
@@ -65,6 +71,28 @@ lemma coe_mapGL_fin_two (σ : SL(2, ℤ)) :
   rw [mapGL_coe_matrix]
   ext i j
   fin_cases i <;> fin_cases j <;> simp
+
+/-- **The bottom row of an `SL₂(ℤ)` matrix is a Bézout relation.** If it is `(N, p)`, then the
+top row `(m, n)` satisfies `m p - n N = 1`. -/
+lemma bezout_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := by
+  simpa only [hσ10, hσ11] using det_fin_two σ
+
+/-- A bottom row `(N, p)` of an `SL₂(ℤ)` matrix forces `p` and `N` to be coprime. -/
+lemma coprime_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) : Nat.Coprime p N :=
+  Nat.isCoprime_iff_coprime.mp (by
+    rw [← hσ10, ← hσ11]
+    exact (isCoprime_row σ 1).symm)
+
+/-- If the bottom row of `σ ∈ SL₂(ℤ)` is `(N, p)`, then its upper-left entry `m` satisfies
+`m p = 1` in `ZMod N`. -/
+lemma intCast_mul_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
+  have h := congrArg (Int.cast : ℤ → ZMod N) (bezout_of_lowerRow hσ10 hσ11)
+  push_cast at h ⊢
+  rw [ZMod.natCast_self] at h
+  linear_combination h
 
 /-- `-I` maps to `-I` under `SL(n, R) → GL(n, S)`. -/
 @[simp]

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -66,6 +66,8 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
   `DoubleCoset.op_mul_out_inv_smul_injective`: Shimura's decomposition `Γ₁gΓ₂ = ⊔ᵥ Γ₁(gτᵥ⁻¹)`
   into *right* cosets, indexed without repetition by `DecompQuotient Γ₂ Γ₁ g⁻¹` — the mirror of
   `DoubleCoset.doubleCoset_eq_iUnion_leftCosets` and `mk_out_mul_injective`.
+* `DoubleCoset.doubleCoset_eq_iUnion_rightCosets_of_forall_exists`: a criterion for a supplied
+  family of right-coset representatives to cover a double coset.
 * `IsHeckeTriple.commensurable_conjAct_inv_left`, and the `Finite` instance beside it: that
   right-coset index is finite, the mirror of the `Fintype` instance on `DecompQuotient H₁ H₂ g`.
 
@@ -236,6 +238,30 @@ lemma doubleCoset_eq_iUnion_rightCosets (Γ₁ Γ₂ : Subgroup G) (g : G) :
     have h := conj_mem_of_mk_eq (H₁ := Γ₂) (H₂ := Γ₁) g⁻¹ (Quotient.out_eq (QuotientGroup.mk t⁻¹))
     simpa [mul_assoc] using h
   · exact Set.subset_iUnion_of_subset ((v.out)⁻¹) (le_of_eq (by simp))
+
+/-- **A right-coset decomposition criterion.** Suppose every product `a * g` with `g ∈ Γ`
+factors as `d * rep i` with `d ∈ Γ`, and conversely every `rep i` equals `a * g` for some
+`g ∈ Γ`. Then the double coset `Γ a Γ` is the union of the right cosets `Γ · rep i`.
+
+This criterion proves coverage only; injectivity of the representative family is a separate
+property. -/
+lemma doubleCoset_eq_iUnion_rightCosets_of_forall_exists {ι : Type*} (Γ : Subgroup G) (a : G)
+    (rep : ι → G)
+    (hforward : ∀ g : G, g ∈ Γ → ∃ (i : ι) (d : G), d ∈ Γ ∧ a * g = d * rep i)
+    (hreverse : ∀ i : ι, ∃ g : G, g ∈ Γ ∧ a * g = rep i) :
+    doubleCoset a Γ Γ = ⋃ i : ι, MulOpposite.op (rep i) • (Γ : Set G) := by
+  refine Set.Subset.antisymm (fun x hx ↦ ?_) (Set.iUnion_subset fun i x hx ↦ ?_)
+  · obtain ⟨g₁, hg₁, g₂, hg₂, rfl⟩ := mem_doubleCoset.mp hx
+    obtain ⟨i, d, hd, heq⟩ := hforward g₂ hg₂
+    refine Set.mem_iUnion.mpr ⟨i, (mem_rightCoset_iff _).mpr ?_⟩
+    have hx' : g₁ * a * g₂ * (rep i)⁻¹ = g₁ * d := by
+      rw [mul_assoc g₁, heq, mul_assoc, mul_inv_cancel_right]
+    rw [hx']
+    exact Γ.mul_mem hg₁ hd
+  · obtain ⟨g, hg, hgeq⟩ := hreverse i
+    refine mem_doubleCoset.mpr ⟨x * (rep i)⁻¹, (mem_rightCoset_iff _).mp hx,
+      g, hg, ?_⟩
+    rw [mul_assoc, hgeq, inv_mul_cancel_right]
 
 /-- The right cosets of `doubleCoset_eq_iUnion_rightCosets` are pairwise distinct, so that union
 is a partition and the sum of a `Γ₁`-invariant function over it counts each coset once. -/

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -239,17 +239,18 @@ lemma doubleCoset_eq_iUnion_rightCosets (Γ₁ Γ₂ : Subgroup G) (g : G) :
     simpa [mul_assoc] using h
   · exact Set.subset_iUnion_of_subset ((v.out)⁻¹) (le_of_eq (by simp))
 
-/-- **A right-coset decomposition criterion.** Suppose every product `a * g` with `g ∈ Γ`
-factors as `d * rep i` with `d ∈ Γ`, and conversely every `rep i` equals `a * g` for some
-`g ∈ Γ`. Then the double coset `Γ a Γ` is the union of the right cosets `Γ · rep i`.
+/-- **A right-coset decomposition criterion.** Suppose every product `a * g` with `g ∈ Γ₂`
+factors as `d * rep i` with `d ∈ Γ₁`, and conversely every `rep i` equals `a * g` for some
+`g ∈ Γ₂`. Then the double coset `Γ₁ a Γ₂` is the union of the right cosets
+`Γ₁ · rep i`.
 
 This criterion proves coverage only; injectivity of the representative family is a separate
 property. -/
-lemma doubleCoset_eq_iUnion_rightCosets_of_forall_exists {ι : Type*} (Γ : Subgroup G) (a : G)
-    (rep : ι → G)
-    (hforward : ∀ g : G, g ∈ Γ → ∃ (i : ι) (d : G), d ∈ Γ ∧ a * g = d * rep i)
-    (hreverse : ∀ i : ι, ∃ g : G, g ∈ Γ ∧ a * g = rep i) :
-    doubleCoset a Γ Γ = ⋃ i : ι, MulOpposite.op (rep i) • (Γ : Set G) := by
+lemma doubleCoset_eq_iUnion_rightCosets_of_forall_exists {ι : Type*} (Γ₁ Γ₂ : Subgroup G)
+    (a : G) (rep : ι → G)
+    (hforward : ∀ g : G, g ∈ Γ₂ → ∃ (i : ι) (d : G), d ∈ Γ₁ ∧ a * g = d * rep i)
+    (hreverse : ∀ i : ι, ∃ g : G, g ∈ Γ₂ ∧ a * g = rep i) :
+    doubleCoset a Γ₁ Γ₂ = ⋃ i : ι, MulOpposite.op (rep i) • (Γ₁ : Set G) := by
   refine Set.Subset.antisymm (fun x hx ↦ ?_) (Set.iUnion_subset fun i x hx ↦ ?_)
   · obtain ⟨g₁, hg₁, g₂, hg₂, rfl⟩ := mem_doubleCoset.mp hx
     obtain ⟨i, d, hd, heq⟩ := hforward g₂ hg₂
@@ -257,7 +258,7 @@ lemma doubleCoset_eq_iUnion_rightCosets_of_forall_exists {ι : Type*} (Γ : Subg
     have hx' : g₁ * a * g₂ * (rep i)⁻¹ = g₁ * d := by
       rw [mul_assoc g₁, heq, mul_assoc, mul_inv_cancel_right]
     rw [hx']
-    exact Γ.mul_mem hg₁ hd
+    exact Γ₁.mul_mem hg₁ hd
   · obtain ⟨g, hg, hgeq⟩ := hreverse i
     refine mem_doubleCoset.mpr ⟨x * (rep i)⁻¹, (mem_rightCoset_iff _).mp hx,
       g, hg, ?_⟩

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -47,6 +47,8 @@ these representatives are in `GL2/UpperTriangularDelta0.lean`.
   `a = ![1, p]`, as an identity of natural numbers — the two fibres `Fin (![1, p] 1 / ![1, p] 0)`
   is `Fin (p / 1)`, which `finCongr` carries to `Fin p` along `p / 1 = p`.
 
+* `HeckeRing.GL2.coe_mapGL_fin_two`: the `!![…]` matrix of `mapGL ℚ σ`, the entrywise form in
+  which the coset computations of this directory read an `SL₂(ℤ)` matrix.
 * `HeckeRing.GL2.coe_upperTriRep`: the entrywise description of the representative:
   `!![1, b; 0, p]`.
 * `HeckeRing.GL2.upperTriRep_apply_one_zero`: the representatives are upper triangular — the
@@ -83,9 +85,21 @@ public section
 
 namespace HeckeRing.GL2
 
-open HeckeRing.GLn
+open HeckeRing.GLn Matrix.SpecialLinearGroup
+
+open scoped MatrixGroups
 
 variable (p : ℕ)
+
+/-- **The rational matrix of `mapGL ℚ σ` in `!![…]` form.** This is `mapGL_coe_matrix` read at
+`n = 2`, where the entrywise description is the one the coset computations of this directory
+match against. -/
+lemma coe_mapGL_fin_two (σ : SL(2, ℤ)) :
+    (↑(mapGL ℚ σ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      !![((σ 0 0 : ℤ) : ℚ), ((σ 0 1 : ℤ) : ℚ); ((σ 1 0 : ℤ) : ℚ), ((σ 1 1 : ℤ) : ℚ)] := by
+  rw [Matrix.SpecialLinearGroup.mapGL_coe_matrix]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp
 
 /-- At `n = 2` there is exactly one ordered index pair, `(0, 1)`, so `UpperTriEntries` is a
 function on a one-element type. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -83,9 +83,7 @@ public section
 
 namespace HeckeRing.GL2
 
-open HeckeRing.GLn Matrix.SpecialLinearGroup
-
-open scoped MatrixGroups
+open HeckeRing.GLn
 
 variable (p : ℕ)
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -47,8 +47,6 @@ these representatives are in `GL2/UpperTriangularDelta0.lean`.
   `a = ![1, p]`, as an identity of natural numbers — the two fibres `Fin (![1, p] 1 / ![1, p] 0)`
   is `Fin (p / 1)`, which `finCongr` carries to `Fin p` along `p / 1 = p`.
 
-* `HeckeRing.GL2.coe_mapGL_fin_two`: the `!![…]` matrix of `mapGL ℚ σ`, the entrywise form in
-  which the coset computations of this directory read an `SL₂(ℤ)` matrix.
 * `HeckeRing.GL2.coe_upperTriRep`: the entrywise description of the representative:
   `!![1, b; 0, p]`.
 * `HeckeRing.GL2.upperTriRep_apply_one_zero`: the representatives are upper triangular — the
@@ -90,16 +88,6 @@ open HeckeRing.GLn Matrix.SpecialLinearGroup
 open scoped MatrixGroups
 
 variable (p : ℕ)
-
-/-- **The rational matrix of `mapGL ℚ σ` in `!![…]` form.** This is `mapGL_coe_matrix` read at
-`n = 2`, where the entrywise description is the one the coset computations of this directory
-match against. -/
-lemma coe_mapGL_fin_two (σ : SL(2, ℤ)) :
-    (↑(mapGL ℚ σ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      !![((σ 0 0 : ℤ) : ℚ), ((σ 0 1 : ℤ) : ℚ); ((σ 1 0 : ℤ) : ℚ), ((σ 1 1 : ℤ) : ℚ)] := by
-  rw [Matrix.SpecialLinearGroup.mapGL_coe_matrix]
-  ext i j
-  fin_cases i <;> fin_cases j <;> simp
 
 /-- At `n = 2` there is exactly one ordered index pair, `(0, 1)`, so `UpperTriEntries` is a
 function on a one-element type. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
@@ -1,0 +1,409 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.UpperTriCosets
+
+import Mathlib.Algebra.Field.ZMod
+
+/-!
+# The double coset `Γ₁(N) · diag(1, p) · Γ₁(N)` at a prime `p ∤ N`
+
+`Gamma1/UpperTriCosets.lean` decomposes this double coset at `p ∣ N`, where the `p`
+representatives `!![1, b; 0, p]` exhaust it. At a prime `p ∤ N` they do not: there is exactly one
+further right coset, and this file produces it, giving Diamond–Shurman's Proposition 5.2.1 in its
+remaining case,
+
+`Γ₁(N) · diag(1, p) · Γ₁(N) = (⋃_{b < p} Γ₁(N) · !![1, b; 0, p])  ∪  Γ₁(N) · σ · diag(p, 1)`,
+
+a disjoint union of `p + 1` **right** cosets. Here `σ = !![m, n; N, p]` is any integral matrix
+with `m p − n N = 1`: an element of `Γ₀(N)`, *not* of `Γ₁(N)`, and it is that twist which later
+supplies the factor `χ(p)` in the Hecke recurrence at a good prime.
+
+## Where the hypotheses enter
+
+The whole statement is carried by the bottom row of `σ`. Its two entries `N` and `p` together
+with `det σ = 1` say exactly `m p − n N = 1` (`bezout_of_lowerRow`), so such a `σ` exists
+precisely when `p` and `N` are coprime (`coprime_of_lowerRow`, and `gamma0Twist` for the converse,
+built from `Nat.gcdA` / `Nat.gcdB`). Everything below is stated for an arbitrary such `σ`, which
+keeps the coprimality implicit in the data rather than as a side hypothesis, and lets the caller
+supply whichever Bézout witness it already has.
+
+Primality is used **once**, and only in the forward inclusion: writing `γ = !![a, b; c, d]` for
+an element of `Γ₁(N)`, the product `diag(1, p) · γ` lands in an upper-triangular coset as soon as
+the congruence `a j ≡ b (mod p)` is solvable, which for `p ∤ a` needs `a` invertible modulo `p`.
+The complementary case `p ∣ a` is where the twisted coset is used, and it needs no primality:
+
+`diag(1, p) · γ = !![a − b N, b m − a′ n; p(c − d N), p d m − c n] · σ · diag(p, 1)`,  `a = p a′`,
+
+whose left factor has determinant `(a d − b c)(m p − n N) = 1` and lies in `Γ₁(N)` because
+`N ∣ c` and `m p ≡ 1 (mod N)`. (For composite `p ∤ N` neither branch covers a `γ` with
+`1 < gcd(a, p) < p`, and indeed the coset count is then not `p + 1`.)
+
+Disjointness of the last coset from the others is integrality: comparing `σ · diag(p, 1)` with
+`!![1, b; 0, p]` forces `p ∣ n`, which `m p − n N = 1` forbids.
+
+## Main definitions
+
+* `HeckeRing.GL2.gamma0Twist`: the Bézout matrix `!![gcdA, −gcdB; N, p]`, a witness `σ` for
+  coprime `p` and `N`, with `gamma0Twist_mem_Gamma0` and
+  `gamma0Twist_toHomUnits_Gamma0Map` recording that it is the `Γ₀(N)` element of lower-right
+  entry the unit `p mod N`.
+* `HeckeRing.GL2.primeRep`: the `p + 1` right-coset representatives, indexed by `Option (Fin p)`
+  — `some b` the upper-triangular `!![1, b; 0, p]`, `none` the twisted `σ · diag(p, 1)`.
+
+## Main results
+
+* `HeckeRing.GL2.bezout_of_lowerRow`, `HeckeRing.GL2.coprime_of_lowerRow`: the bottom row of `σ`
+  is a Bézout relation for `p` and `N`.
+* `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_twist`: the factorisation of `diag(1, p) · γ`
+  through the twisted representative, for `p ∣ a`.
+* `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none`:
+  `diag(1, p) · !![m p, n; N, 1] = σ · diag(p, 1)` with `!![m p, n; N, 1] ∈ Γ₁(N)` — the reverse
+  inclusion for the twisted coset.
+* `HeckeRing.GL2.op_primeRep_smul_injective`: the `p + 1` right cosets are pairwise distinct.
+* `HeckeRing.GL2.doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`: **the decomposition**,
+  and `HeckeRing.GL2.doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets_of_prime` the same
+  statement read at the chosen representative of `diagCosetGamma1 N p`, which is the shape the
+  slash sum of `ModularForms/HeckeSlash/Independence.lean` consumes.
+
+## Provenance
+
+No code is transcribed. The statement is Diamond–Shurman Proposition 5.2.1 in the case `p ∤ N`,
+proved here for this repository's own representative families `natDiagGL`, `upperTriRep` and
+`scaleRep`. The AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0) organises the same
+case as the `heckeT_p_coprime` branch of `heckeT_p_all`
+(`LeanModularForms/HeckeRIngs/GL2/HeckeT_n.lean`), on the operator rather than the coset side;
+the coset statement below is what identifies the two, and is proved from the group law here.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Proposition 5.2.1.
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4–3.5.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup CongruenceSubgroup DoubleCoset HeckeRing.GLn
+
+open scoped MatrixGroups Pointwise
+
+namespace HeckeRing.GL2
+
+variable {N p : ℕ} {σ : SL(2, ℤ)}
+
+/-- **The bottom row of `σ` is a Bézout relation.** If the bottom row of an `SL₂(ℤ)` matrix is
+`(N, p)`, then its determinant identity reads `m p − n N = 1` for the top row `(m, n)`. This is
+the only property of the twist that the decomposition uses. -/
+lemma bezout_of_lowerRow (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) :
+    σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := by
+  have hdet : σ 0 0 * σ 1 1 - σ 0 1 * σ 1 0 = 1 := by
+    have := σ.2
+    rwa [Matrix.det_fin_two] at this
+  rwa [hσ10, hσ11] at hdet
+
+/-- **Such a twist exists only for coprime `p` and `N`.** The Bézout relation of
+`bezout_of_lowerRow` exhibits `1` as an integral combination of `p` and `N`. -/
+lemma coprime_of_lowerRow (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) :
+    Nat.Coprime p N :=
+  Nat.isCoprime_iff_coprime.mp
+    ⟨σ 0 0, -σ 0 1, by linear_combination bezout_of_lowerRow hσ10 hσ11⟩
+
+/-- **The Bézout twist** `!![gcdA(p, N), −gcdB(p, N); N, p]`, the canonical witness for the
+converse of `coprime_of_lowerRow`: an `SL₂(ℤ)` matrix with bottom row `(N, p)`, hence an element
+of `Γ₀(N)` with lower-right entry `p`. It exists exactly because `p` and `N` are coprime, and its
+top row is Mathlib's extended-Euclid pair. -/
+noncomputable def gamma0Twist (N p : ℕ) (h : Nat.Coprime p N) : SL(2, ℤ) :=
+  ⟨!![Nat.gcdA p N, -Nat.gcdB p N; (N : ℤ), (p : ℤ)], by
+    have hb : ((Nat.gcd p N : ℕ) : ℤ) = p * Nat.gcdA p N + N * Nat.gcdB p N :=
+      Nat.gcd_eq_gcd_ab p N
+    rw [show Nat.gcd p N = 1 from h] at hb
+    push_cast at hb
+    rw [Matrix.det_fin_two_of]
+    linear_combination -hb⟩
+
+/-- The matrix of the Bézout twist. -/
+@[simp] lemma coe_gamma0Twist (h : Nat.Coprime p N) :
+    ((gamma0Twist N p h : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ) =
+      !![Nat.gcdA p N, -Nat.gcdB p N; (N : ℤ), (p : ℤ)] := (rfl)
+
+/-- The lower-left entry of the Bézout twist is `N`, so it lies in `Γ₀(N)`. -/
+@[simp] lemma gamma0Twist_apply_one_zero (h : Nat.Coprime p N) :
+    (gamma0Twist N p h) 1 0 = (N : ℤ) := by
+  rw [show ((gamma0Twist N p h : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ) = _ from coe_gamma0Twist h]
+  simp
+
+/-- The lower-right entry of the Bézout twist is `p`: it is the `Γ₀(N)` element through which the
+diamond operator `⟨p⟩` is computed. -/
+@[simp] lemma gamma0Twist_apply_one_one (h : Nat.Coprime p N) :
+    (gamma0Twist N p h) 1 1 = (p : ℤ) := by
+  rw [show ((gamma0Twist N p h : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ) = _ from coe_gamma0Twist h]
+  simp
+
+/-- **The Bézout twist lies in `Γ₀(N)`**, its lower-left entry being `N`. Together with
+`gamma0Twist_apply_one_one` this is what makes slashing by it the diamond operator `⟨p⟩`. -/
+lemma gamma0Twist_mem_Gamma0 (h : Nat.Coprime p N) : gamma0Twist N p h ∈ Gamma0 N := by
+  rw [Gamma0_mem, gamma0Twist_apply_one_zero h]
+  simp
+
+/-- The lower-right entry of the Bézout twist, read as a unit of `ZMod N`: it is the class of
+`p`. This is what makes slashing by the twist the diamond operator `⟨p⟩`. -/
+lemma gamma0Twist_toHomUnits_Gamma0Map (h : Nat.Coprime p N) :
+    (Gamma0Map N).toHomUnits ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩ =
+      ZMod.unitOfCoprime p h :=
+  Units.ext (by simp [Gamma0Map, gamma0Twist_apply_one_one h])
+
+/-- **The `p + 1` right-coset representatives of the good-prime `Tₚ`.** The `p` upper-triangular
+matrices `!![1, b; 0, p]`, indexed by `some b`, together with the twisted diagonal
+`σ · diag(p, 1)`, indexed by `none`. The index type `Option (Fin p)` is what the slash-sum
+machinery of `HeckeSlash/Independence.lean` sums over. -/
+noncomputable def primeRep (σ : SL(2, ℤ)) (p : ℕ) : Option (Fin p) → GL (Fin 2) ℚ
+  | some b => upperTriRep p b
+  | none => mapGL ℚ σ * scaleRep p
+
+/-- The representative indexed by `some b` is the `b`-th upper-triangular matrix. -/
+@[simp] lemma primeRep_some (σ : SL(2, ℤ)) (p : ℕ) (b : Fin p) :
+    primeRep σ p (some b) = upperTriRep p b := (rfl)
+
+/-- The representative indexed by `none` is the twisted diagonal `σ · diag(p, 1)`. -/
+@[simp] lemma primeRep_none (σ : SL(2, ℤ)) (p : ℕ) :
+    primeRep σ p none = mapGL ℚ σ * scaleRep p := (rfl)
+
+/-- The matrix of the twisted representative: `σ · diag(p, 1) = !![m p, n; N p, p]`. -/
+lemma coe_primeRep_none (hp : 0 < p) :
+    (↑(primeRep σ p none) : Matrix (Fin 2) (Fin 2) ℚ) =
+      !![((σ 0 0 : ℤ) : ℚ) * (p : ℚ), ((σ 0 1 : ℤ) : ℚ);
+        ((σ 1 0 : ℤ) : ℚ) * (p : ℚ), ((σ 1 1 : ℤ) : ℚ)] := by
+  rw [primeRep_none, Units.val_mul, coe_mapGL_fin_two, coe_scaleRep p hp, Matrix.mul_fin_two]
+  congrm !![?_, ?_; ?_, ?_] <;> ring1
+
+/-- **The forward factorisation through the twisted coset.** For `γ = !![a, b; c, d] ∈ Γ₁(N)`
+with `p ∣ a`, the product `diag(1, p) · γ` lies in the right coset `Γ₁(N) · σ · diag(p, 1)`:
+
+`diag(1, p) · γ = !![a − b N, b m − a′ n; p(c − d N), p d m − c n] · σ · diag(p, 1)`,  `a = p a′`.
+
+No primality is used, and the divisibility `p ∣ a` is what makes the upper-right entry of the
+left factor integral. -/
+lemma exists_mem_Gamma1_natDiagGL_mul_twist (hp : 0 < p) (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma1 N) (hpa : (p : ℤ) ∣ γ 0 0) :
+    ∃ δ : SL(2, ℤ), δ ∈ Gamma1 N ∧
+      natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * primeRep σ p none := by
+  obtain ⟨ha, hd, hc⟩ := (Gamma1_mem N γ).mp hγ
+  obtain ⟨a', ha'⟩ := hpa
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := bezout_of_lowerRow hσ10 hσ11
+  have hγdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := by
+    have := γ.2
+    rwa [Matrix.det_fin_two] at this
+  -- the new left factor
+  have hdet : (!![γ 0 0 - γ 0 1 * (N : ℤ), γ 0 1 * σ 0 0 - a' * σ 0 1;
+      (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)), (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1] :
+      Matrix (Fin 2) (Fin 2) ℤ).det = 1 := by
+    rw [Matrix.det_fin_two_of]
+    linear_combination hγdet + (γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0) * hσdet +
+      (σ 0 1 * (γ 1 1 * (N : ℤ) - γ 1 0)) * ha'
+  obtain ⟨δ, hδmat⟩ : ∃ δ : SL(2, ℤ), (δ : Matrix (Fin 2) (Fin 2) ℤ) =
+      !![γ 0 0 - γ 0 1 * (N : ℤ), γ 0 1 * σ 0 0 - a' * σ 0 1;
+        (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)), (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1] :=
+    ⟨⟨_, hdet⟩, rfl⟩
+  -- `m p ≡ 1 (mod N)`, the congruence that puts the left factor in `Γ₁(N)`
+  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
+    have := congrArg (Int.cast : ℤ → ZMod N) hσdet
+    push_cast at this ⊢
+    rw [ZMod.natCast_self] at this
+    linear_combination this
+  refine ⟨δ, ?_, ?_⟩
+  · refine (Gamma1_mem N δ).mpr ⟨?_, ?_, ?_⟩
+    · have h : ((γ 0 0 - γ 0 1 * (N : ℤ) : ℤ) : ZMod N) = 1 := by
+        push_cast
+        rw [ha, ZMod.natCast_self]
+        ring
+      simpa [hδmat] using h
+    · have h : (((p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1 : ℤ) : ZMod N) = 1 := by
+        push_cast at hmp ⊢
+        rw [hc]
+        linear_combination (((γ 1 1 : ℤ) : ZMod N)) * hmp + hd
+      simpa [hδmat] using h
+    · have h : (((p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)) : ℤ) : ZMod N) = 0 := by
+        push_cast
+        rw [hc, ZMod.natCast_self]
+        ring
+      simpa [hδmat] using h
+  · refine Units.ext ?_
+    have e00 : (δ 0 0 : ℤ) = γ 0 0 - γ 0 1 * (N : ℤ) := by rw [hδmat]; simp
+    have e01 : (δ 0 1 : ℤ) = γ 0 1 * σ 0 0 - a' * σ 0 1 := by rw [hδmat]; simp
+    have e10 : (δ 1 0 : ℤ) = (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)) := by rw [hδmat]; simp
+    have e11 : (δ 1 1 : ℤ) = (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1 := by rw [hδmat]; simp
+    have hσdetQ : ((σ 0 0 : ℤ) : ℚ) * (p : ℚ) - ((σ 0 1 : ℤ) : ℚ) * (N : ℚ) = 1 := by
+      exact_mod_cast congrArg (Int.cast : ℤ → ℚ) hσdet
+    have haQ : ((γ 0 0 : ℤ) : ℚ) = (p : ℚ) * ((a' : ℤ) : ℚ) := by
+      exact_mod_cast congrArg (Int.cast : ℤ → ℚ) ha'
+    rw [Units.val_mul, Units.val_mul, coe_natDiagGL_one hp, coe_primeRep_none hp,
+      coe_mapGL_fin_two γ, coe_mapGL_fin_two δ, e00, e01, e10, e11, hσ10, hσ11,
+      Matrix.mul_fin_two, Matrix.mul_fin_two]
+    push_cast
+    congrm !![?_, ?_; ?_, ?_]
+    · linear_combination (-(p : ℚ) * ((a' : ℤ) : ℚ)) * hσdetQ +
+        (1 - ((σ 0 0 : ℤ) : ℚ) * (p : ℚ)) * haQ
+    · linear_combination (-((γ 0 1 : ℤ) : ℚ)) * hσdetQ - ((σ 0 1 : ℤ) : ℚ) * haQ
+    · linear_combination (-(p : ℚ) * ((γ 1 0 : ℤ) : ℚ)) * hσdetQ
+    · linear_combination (-(p : ℚ) * ((γ 1 1 : ℤ) : ℚ)) * hσdetQ
+
+/-- **The witness for the reverse inclusion.** The matrix `!![m p, n; N, 1]` lies in `Γ₁(N)` —
+its determinant is the Bézout relation and `m p ≡ 1 (mod N)` — and moving it across
+`diag(1, p)` produces exactly the twisted representative. -/
+lemma exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none (hp : 0 < p) (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) :
+    ∃ γ : SL(2, ℤ), γ ∈ Gamma1 N ∧
+      natDiagGL 2 ![1, p] * mapGL ℚ γ = primeRep σ p none := by
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := bezout_of_lowerRow hσ10 hσ11
+  have hdet : (!![σ 0 0 * (p : ℤ), σ 0 1; (N : ℤ), 1] : Matrix (Fin 2) (Fin 2) ℤ).det = 1 := by
+    rw [Matrix.det_fin_two_of]
+    linear_combination hσdet
+  obtain ⟨γ, hγmat⟩ : ∃ γ : SL(2, ℤ), (γ : Matrix (Fin 2) (Fin 2) ℤ) =
+      !![σ 0 0 * (p : ℤ), σ 0 1; (N : ℤ), 1] := ⟨⟨_, hdet⟩, rfl⟩
+  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
+    have := congrArg (Int.cast : ℤ → ZMod N) hσdet
+    push_cast at this ⊢
+    rw [ZMod.natCast_self] at this
+    linear_combination this
+  refine ⟨γ, (Gamma1_mem N γ).mpr ⟨?_, ?_, ?_⟩, ?_⟩
+  · simpa [hγmat] using hmp
+  · simp [hγmat]
+  · simp [hγmat]
+  · refine Units.ext ?_
+    have e00 : (γ 0 0 : ℤ) = σ 0 0 * (p : ℤ) := by rw [hγmat]; simp
+    have e01 : (γ 0 1 : ℤ) = σ 0 1 := by rw [hγmat]; simp
+    have e10 : (γ 1 0 : ℤ) = (N : ℤ) := by rw [hγmat]; simp
+    have e11 : (γ 1 1 : ℤ) = 1 := by rw [hγmat]; simp
+    rw [Units.val_mul, coe_natDiagGL_one hp, coe_primeRep_none hp, coe_mapGL_fin_two γ,
+      e00, e01, e10, e11, hσ10, hσ11, Matrix.mul_fin_two]
+    push_cast
+    congrm !![?_, ?_; ?_, ?_] <;> ring1
+
+/-- **The forward inclusion.** For a prime `p` and `γ ∈ Γ₁(N)`, the product `diag(1, p) · γ` lies
+in one of the `p + 1` right cosets: an upper-triangular one when `p ∤ a`, where the congruence
+`a j ≡ b (mod p)` is solvable because `a` is then invertible modulo the prime `p`, and the
+twisted one when `p ∣ a`. -/
+lemma exists_mem_Gamma1_natDiagGL_mul_primeRep (hp : p.Prime) (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma1 N) :
+    ∃ (i : Option (Fin p)) (δ : SL(2, ℤ)), δ ∈ Gamma1 N ∧
+      natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * primeRep σ p i := by
+  by_cases hpa : (p : ℤ) ∣ γ 0 0
+  · obtain ⟨δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_twist hp.pos hσ10 hσ11 hγ hpa
+    exact ⟨none, δ, hδ, heq⟩
+  · have : Fact p.Prime := ⟨hp⟩
+    have : NeZero p := ⟨hp.pos.ne'⟩
+    have ha : ((γ 0 0 : ℤ) : ZMod p) ≠ 0 := fun hz ↦
+      hpa ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hz)
+    set j : ZMod p := ((γ 0 1 : ℤ) : ZMod p) / ((γ 0 0 : ℤ) : ZMod p) with hjdef
+    have hjlt : j.val < p := ZMod.val_lt j
+    have hdvd : (p : ℤ) ∣ γ 0 1 - γ 0 0 * (j.val : ℕ) := by
+      rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
+      push_cast
+      rw [ZMod.natCast_val, ZMod.cast_id, hjdef]
+      field_simp
+      ring
+    obtain ⟨δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_of_dvd hp.pos hγ hjlt hdvd
+    exact ⟨some ⟨j.val, hjlt⟩, δ, hδ, by rw [primeRep_some]; exact heq⟩
+
+/-- **The `p + 1` right cosets are pairwise distinct.** The `p` upper-triangular ones are
+separated by `op_upperTriRep_smul_injective`; separating the twisted one from them is
+integrality. If `Γ₁(N) · !![1, b; 0, p] = Γ₁(N) · σ · diag(p, 1)`, comparing the top rows gives
+`n = p (m b + σ'₀₁)` for some `σ' ∈ Γ₁(N)`, so `p ∣ n`, and then `m p − n N = 1` makes `p` a
+divisor of `1`. -/
+theorem op_primeRep_smul_injective (hp : p.Prime) (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) :
+    Function.Injective fun i : Option (Fin p) ↦
+      MulOpposite.op (primeRep σ p i) • (((Gamma1 N).map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) := by
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := bezout_of_lowerRow hσ10 hσ11
+  -- the twisted coset is not one of the upper-triangular ones
+  have hne : ∀ b : Fin p,
+      MulOpposite.op (primeRep σ p (some b)) • (((Gamma1 N).map (mapGL ℚ)) :
+          Set (GL (Fin 2) ℚ)) ≠
+        MulOpposite.op (primeRep σ p none) • (((Gamma1 N).map (mapGL ℚ)) :
+          Set (GL (Fin 2) ℚ)) := by
+    intro b heq
+    obtain ⟨τ, hτ, hτeq⟩ := Subgroup.mem_map.mp ((rightCoset_eq_iff _).mp heq)
+    have hmul : (mapGL ℚ τ : GL (Fin 2) ℚ) * upperTriRep p b = primeRep σ p none := by
+      rw [hτeq, ← primeRep_some σ p b, inv_mul_cancel_right]
+    have hmat : (↑(mapGL ℚ τ) : Matrix (Fin 2) (Fin 2) ℚ) * !![1, (b : ℚ); 0, (p : ℚ)] =
+        (↑(primeRep σ p none) : Matrix (Fin 2) (Fin 2) ℚ) := by
+      rw [← coe_upperTriRep, ← Units.val_mul, hmul]
+    rw [coe_mapGL_fin_two, coe_primeRep_none hp.pos, Matrix.mul_fin_two] at hmat
+    have h00 : ((τ 0 0 : ℤ) : ℚ) = ((σ 0 0 : ℤ) : ℚ) * (p : ℚ) := by
+      simpa using congrFun (congrFun hmat 0) 0
+    have h01 : ((τ 0 0 : ℤ) : ℚ) * (b : ℚ) + ((τ 0 1 : ℤ) : ℚ) * (p : ℚ) = ((σ 0 1 : ℤ) : ℚ) := by
+      simpa using congrFun (congrFun hmat 0) 1
+    rw [h00] at h01
+    have hn : (σ 0 1 : ℤ) = (p : ℤ) * (σ 0 0 * (b : ℕ) + τ 0 1) := by
+      have hQ : ((σ 0 1 : ℤ) : ℚ) = (((p : ℤ) * (σ 0 0 * (b : ℕ) + τ 0 1) : ℤ) : ℚ) := by
+        push_cast at h01 ⊢
+        linarith
+      exact_mod_cast hQ
+    have hdvd : (p : ℤ) ∣ 1 :=
+      ⟨σ 0 0 - (σ 0 0 * (b : ℕ) + τ 0 1) * (N : ℤ), by linear_combination -hσdet - (N : ℤ) * hn⟩
+    have hle := Int.le_of_dvd one_pos hdvd
+    have htwo : 2 ≤ (p : ℤ) := by exact_mod_cast hp.two_le
+    omega
+  rintro (_ | b₁) (_ | b₂) h
+  · rfl
+  · exact absurd h.symm (hne b₂)
+  · exact absurd h (hne b₁)
+  · simpa using op_upperTriRep_smul_injective (G := Gamma1 N) (by simpa using h)
+
+/-- **The `Tₚ` double coset at a prime `p ∤ N` is the union of `p + 1` right cosets.**
+`Γ₁(N) · diag(1, p) · Γ₁(N) = ⋃_{j < p} Γ₁(N) · !![1, j; 0, p]  ∪  Γ₁(N) · σ · diag(p, 1)`,
+Diamond–Shurman's Proposition 5.2.1 in the case `p ∤ N` — the coprimality being carried by the
+existence of the twist `σ` rather than stated separately (`coprime_of_lowerRow`).
+
+The inclusion `⊆` is `exists_mem_Gamma1_natDiagGL_mul_primeRep` and is where primality enters;
+`⊇` is `natDiagGL_mul_mapGL_T_zpow` on the upper-triangular cosets and
+`exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none` on the twisted one. That the union is disjoint
+is `op_primeRep_smul_injective`. -/
+theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime (hp : p.Prime)
+    (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) :
+    doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
+      ⋃ i : Option (Fin p), MulOpposite.op (primeRep σ p i) •
+        ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
+  refine Set.Subset.antisymm (fun x hx ↦ ?_) (Set.iUnion_subset fun i x hx ↦ ?_)
+  · obtain ⟨g₁, hg₁, g₂, hg₂, rfl⟩ := mem_doubleCoset.mp hx
+    obtain ⟨γ₂, hγ₂, rfl⟩ := Subgroup.mem_map.mp hg₂
+    obtain ⟨i, δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_primeRep hp hσ10 hσ11 hγ₂
+    refine Set.mem_iUnion.mpr ⟨i, (mem_rightCoset_iff _).mpr ?_⟩
+    have hx' : g₁ * natDiagGL 2 ![1, p] * mapGL ℚ γ₂ * (primeRep σ p i)⁻¹ = g₁ * mapGL ℚ δ := by
+      rw [mul_assoc g₁, heq, mul_assoc, mul_inv_cancel_right]
+    rw [hx']
+    exact mul_mem hg₁ (Subgroup.mem_map_of_mem _ hδ)
+  · obtain ⟨γ, hγ, hγeq⟩ : ∃ γ : SL(2, ℤ), γ ∈ Gamma1 N ∧
+        natDiagGL 2 ![1, p] * mapGL ℚ γ = primeRep σ p i := by
+      cases i with
+      | none => exact exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none hp.pos hσ10 hσ11
+      | some b =>
+        exact ⟨ModularGroup.T ^ (b : ℤ), T_zpow_mem_Gamma1 N _, by
+          rw [primeRep_some, natDiagGL_mul_mapGL_T_zpow hp.pos b]⟩
+    refine mem_doubleCoset.mpr ⟨x * (primeRep σ p i)⁻¹, (mem_rightCoset_iff _).mp hx,
+      mapGL ℚ γ, Subgroup.mem_map_of_mem _ hγ, ?_⟩
+    rw [mul_assoc, hγeq, inv_mul_cancel_right]
+
+/-- The decomposition of `doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`, read at the
+chosen representative `D.out` of `diagCosetGamma1 N p` — the shape the slash-sum machinery of
+`HeckeSlash/Independence.lean` consumes. -/
+theorem doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets_of_prime (hp : p.Prime)
+    (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) :
+    doubleCoset ((diagCosetGamma1 N p).out : GL (Fin 2) ℚ)
+        ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
+      ⋃ i : Option (Fin p), MulOpposite.op (primeRep σ p i) •
+        ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
+  have hout : HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      (diagCosetGamma1 N p).out = diagCosetGamma1 N p := Quotient.out_eq _
+  rw [HeckeCoset.eq_iff.mp (hout.trans (diagCosetGamma1_def N p)),
+    doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime hp hσ10 hσ11]
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
@@ -152,7 +152,7 @@ lemma exists_mem_Gamma1_natDiagGL_mul_primeRep_none_of_dvd (hp : 0 < p)
     ⟨⟨_, hdet⟩, rfl⟩
   -- `m p ≡ 1 (mod N)`, the congruence that puts the left factor in `Γ₁(N)`
   have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 :=
-    intCast_mul_of_lowerRow hσ10 hσ11
+    intCast_mul_eq_one_of_lowerRow hσ10 hσ11
   refine ⟨δ, ?_, ?_⟩
   · refine (Gamma1_mem N δ).mpr ⟨?_, ?_, ?_⟩
     · have h : ((γ 0 0 - γ 0 1 * (N : ℤ) : ℤ) : ZMod N) = 1 := by
@@ -204,7 +204,7 @@ lemma exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none (hp : 0 < p) (hσ10 : σ 
   obtain ⟨γ, hγmat⟩ : ∃ γ : SL(2, ℤ), (γ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![σ 0 0 * (p : ℤ), σ 0 1; (N : ℤ), 1] := ⟨⟨_, hdet⟩, rfl⟩
   have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 :=
-    intCast_mul_of_lowerRow hσ10 hσ11
+    intCast_mul_eq_one_of_lowerRow hσ10 hσ11
   refine ⟨γ, (Gamma1_mem N γ).mpr ⟨?_, ?_, ?_⟩, ?_⟩
   · simpa [hγmat] using hmp
   · simp [hγmat]

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
@@ -342,7 +342,8 @@ theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime (hp : p.Prime)
       ⋃ i : Option (Fin p), MulOpposite.op (primeRep σ p i) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
   apply doubleCoset_eq_iUnion_rightCosets_of_forall_exists
-      ((Gamma1 N).map (mapGL ℚ)) (natDiagGL 2 ![1, p]) (primeRep σ p)
+      ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      (natDiagGL 2 ![1, p]) (primeRep σ p)
   · intro g hg
     obtain ⟨γ, hγ, rfl⟩ := Subgroup.mem_map.mp hg
     obtain ⟨i, δ, hδ, heq⟩ :=

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.UpperTriCosets
 
-import Mathlib.Algebra.Field.ZMod
+import Mathlib.Algebra.CharP.Invertible
 
 /-!
 # The double coset `Γ₁(N) · diag(1, p) · Γ₁(N)` at a prime `p ∤ N`
@@ -27,15 +27,16 @@ supplies the factor `χ(p)` in the Hecke recurrence at a good prime.
 
 The whole statement is carried by the bottom row of `σ`. Its two entries `N` and `p` together
 with `det σ = 1` say exactly `m p − n N = 1` (`bezout_of_lowerRow`), so such a `σ` exists
-precisely when `p` and `N` are coprime (`coprime_of_lowerRow`, and `gamma0Twist` for the converse,
-built from `Nat.gcdA` / `Nat.gcdB`). Everything below is stated for an arbitrary such `σ`, which
+precisely when `p` and `N` are coprime (`coprime_of_lowerRow`). Everything below is stated for
+an arbitrary such `σ`, which
 keeps the coprimality implicit in the data rather than as a side hypothesis, and lets the caller
 supply whichever Bézout witness it already has.
 
-Primality is used **once**, and only in the forward inclusion: writing `γ = !![a, b; c, d]` for
-an element of `Γ₁(N)`, the product `diag(1, p) · γ` lands in an upper-triangular coset as soon as
-the congruence `a j ≡ b (mod p)` is solvable, which for `p ∤ a` needs `a` invertible modulo `p`.
-The complementary case `p ∣ a` is where the twisted coset is used, and it needs no primality:
+The field property supplied by primality is used only in the forward inclusion: writing
+`γ = !![a, b; c, d]` for an element of `Γ₁(N)`, the product `diag(1, p) · γ` lands in an
+upper-triangular coset as soon as the congruence `a j ≡ b (mod p)` is solvable, which for `p ∤ a`
+needs `a` invertible modulo `p`. The complementary case `p ∣ a` is where the twisted coset is
+used, and it needs no primality:
 
 `diag(1, p) · γ = !![a − b N, b m − a′ n; p(c − d N), p d m − c n] · σ · diag(p, 1)`,  `a = p a′`,
 
@@ -43,24 +44,18 @@ whose left factor has determinant `(a d − b c)(m p − n N) = 1` and lies in `
 `N ∣ c` and `m p ≡ 1 (mod N)`. (For composite `p ∤ N` neither branch covers a `γ` with
 `1 < gcd(a, p) < p`, and indeed the coset count is then not `p + 1`.)
 
-Disjointness of the last coset from the others is integrality: comparing `σ · diag(p, 1)` with
-`!![1, b; 0, p]` forces `p ∣ n`, which `m p − n N = 1` forbids.
+Disjointness of the last coset from the others uses only `1 < p` and integrality: comparing
+`σ · diag(p, 1)` with `!![1, b; 0, p]` forces `p ∣ n`, which `m p − n N = 1` forbids.
 
 ## Main definitions
 
-* `HeckeRing.GL2.gamma0Twist`: the Bézout matrix `!![gcdA, −gcdB; N, p]`, a witness `σ` for
-  coprime `p` and `N`, with `gamma0Twist_mem_Gamma0` and
-  `gamma0Twist_toHomUnits_Gamma0Map` recording that it is the `Γ₀(N)` element of lower-right
-  entry the unit `p mod N`.
 * `HeckeRing.GL2.primeRep`: the `p + 1` right-coset representatives, indexed by `Option (Fin p)`
   — `some b` the upper-triangular `!![1, b; 0, p]`, `none` the twisted `σ · diag(p, 1)`.
 
 ## Main results
 
-* `HeckeRing.GL2.bezout_of_lowerRow`, `HeckeRing.GL2.coprime_of_lowerRow`: the bottom row of `σ`
-  is a Bézout relation for `p` and `N`.
-* `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_twist`: the factorisation of `diag(1, p) · γ`
-  through the twisted representative, for `p ∣ a`.
+* `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_primeRep_none_of_dvd`: the factorisation of
+  `diag(1, p) · γ` through the twisted representative, for `p ∣ a`.
 * `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none`:
   `diag(1, p) · !![m p, n; N, 1] = σ · diag(p, 1)` with `!![m p, n; N, 1] ∈ Γ₁(N)` — the reverse
   inclusion for the twisted coset.
@@ -97,67 +92,6 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ} {σ : SL(2, ℤ)}
 
-/-- **The bottom row of `σ` is a Bézout relation.** If the bottom row of an `SL₂(ℤ)` matrix is
-`(N, p)`, then its determinant identity reads `m p − n N = 1` for the top row `(m, n)`. This is
-the only property of the twist that the decomposition uses. -/
-lemma bezout_of_lowerRow (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) :
-    σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := by
-  have hdet : σ 0 0 * σ 1 1 - σ 0 1 * σ 1 0 = 1 := by
-    have := σ.2
-    rwa [Matrix.det_fin_two] at this
-  rwa [hσ10, hσ11] at hdet
-
-/-- **Such a twist exists only for coprime `p` and `N`.** The Bézout relation of
-`bezout_of_lowerRow` exhibits `1` as an integral combination of `p` and `N`. -/
-lemma coprime_of_lowerRow (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) :
-    Nat.Coprime p N :=
-  Nat.isCoprime_iff_coprime.mp
-    ⟨σ 0 0, -σ 0 1, by linear_combination bezout_of_lowerRow hσ10 hσ11⟩
-
-/-- **The Bézout twist** `!![gcdA(p, N), −gcdB(p, N); N, p]`, the canonical witness for the
-converse of `coprime_of_lowerRow`: an `SL₂(ℤ)` matrix with bottom row `(N, p)`, hence an element
-of `Γ₀(N)` with lower-right entry `p`. It exists exactly because `p` and `N` are coprime, and its
-top row is Mathlib's extended-Euclid pair. -/
-noncomputable def gamma0Twist (N p : ℕ) (h : Nat.Coprime p N) : SL(2, ℤ) :=
-  ⟨!![Nat.gcdA p N, -Nat.gcdB p N; (N : ℤ), (p : ℤ)], by
-    have hb : ((Nat.gcd p N : ℕ) : ℤ) = p * Nat.gcdA p N + N * Nat.gcdB p N :=
-      Nat.gcd_eq_gcd_ab p N
-    rw [show Nat.gcd p N = 1 from h] at hb
-    push_cast at hb
-    rw [Matrix.det_fin_two_of]
-    linear_combination -hb⟩
-
-/-- The matrix of the Bézout twist. -/
-@[simp] lemma coe_gamma0Twist (h : Nat.Coprime p N) :
-    ((gamma0Twist N p h : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ) =
-      !![Nat.gcdA p N, -Nat.gcdB p N; (N : ℤ), (p : ℤ)] := (rfl)
-
-/-- The lower-left entry of the Bézout twist is `N`, so it lies in `Γ₀(N)`. -/
-@[simp] lemma gamma0Twist_apply_one_zero (h : Nat.Coprime p N) :
-    (gamma0Twist N p h) 1 0 = (N : ℤ) := by
-  rw [show ((gamma0Twist N p h : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ) = _ from coe_gamma0Twist h]
-  simp
-
-/-- The lower-right entry of the Bézout twist is `p`: it is the `Γ₀(N)` element through which the
-diamond operator `⟨p⟩` is computed. -/
-@[simp] lemma gamma0Twist_apply_one_one (h : Nat.Coprime p N) :
-    (gamma0Twist N p h) 1 1 = (p : ℤ) := by
-  rw [show ((gamma0Twist N p h : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ) = _ from coe_gamma0Twist h]
-  simp
-
-/-- **The Bézout twist lies in `Γ₀(N)`**, its lower-left entry being `N`. Together with
-`gamma0Twist_apply_one_one` this is what makes slashing by it the diamond operator `⟨p⟩`. -/
-lemma gamma0Twist_mem_Gamma0 (h : Nat.Coprime p N) : gamma0Twist N p h ∈ Gamma0 N := by
-  rw [Gamma0_mem, gamma0Twist_apply_one_zero h]
-  simp
-
-/-- The lower-right entry of the Bézout twist, read as a unit of `ZMod N`: it is the class of
-`p`. This is what makes slashing by the twist the diamond operator `⟨p⟩`. -/
-lemma gamma0Twist_toHomUnits_Gamma0Map (h : Nat.Coprime p N) :
-    (Gamma0Map N).toHomUnits ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩ =
-      ZMod.unitOfCoprime p h :=
-  Units.ext (by simp [Gamma0Map, gamma0Twist_apply_one_one h])
-
 /-- **The `p + 1` right-coset representatives of the good-prime `Tₚ`.** The `p` upper-triangular
 matrices `!![1, b; 0, p]`, indexed by `some b`, together with the twisted diagonal
 `σ · diag(p, 1)`, indexed by `none`. The index type `Option (Fin p)` is what the slash-sum
@@ -189,16 +123,16 @@ with `p ∣ a`, the product `diag(1, p) · γ` lies in the right coset `Γ₁(N)
 
 No primality is used, and the divisibility `p ∣ a` is what makes the upper-right entry of the
 left factor integral. -/
-lemma exists_mem_Gamma1_natDiagGL_mul_twist (hp : 0 < p) (hσ10 : σ 1 0 = (N : ℤ))
+lemma exists_mem_Gamma1_natDiagGL_mul_primeRep_none_of_dvd (hp : 0 < p)
+    (hσ10 : σ 1 0 = (N : ℤ))
     (hσ11 : σ 1 1 = (p : ℤ)) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma1 N) (hpa : (p : ℤ) ∣ γ 0 0) :
     ∃ δ : SL(2, ℤ), δ ∈ Gamma1 N ∧
       natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * primeRep σ p none := by
   obtain ⟨ha, hd, hc⟩ := (Gamma1_mem N γ).mp hγ
   obtain ⟨a', ha'⟩ := hpa
   have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := bezout_of_lowerRow hσ10 hσ11
-  have hγdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := by
-    have := γ.2
-    rwa [Matrix.det_fin_two] at this
+  have hγdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 :=
+    Matrix.SpecialLinearGroup.det_fin_two γ
   -- the new left factor
   have hdet : (!![γ 0 0 - γ 0 1 * (N : ℤ), γ 0 1 * σ 0 0 - a' * σ 0 1;
       (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)), (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1] :
@@ -211,11 +145,8 @@ lemma exists_mem_Gamma1_natDiagGL_mul_twist (hp : 0 < p) (hσ10 : σ 1 0 = (N : 
         (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)), (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1] :=
     ⟨⟨_, hdet⟩, rfl⟩
   -- `m p ≡ 1 (mod N)`, the congruence that puts the left factor in `Γ₁(N)`
-  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
-    have := congrArg (Int.cast : ℤ → ZMod N) hσdet
-    push_cast at this ⊢
-    rw [ZMod.natCast_self] at this
-    linear_combination this
+  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 :=
+    intCast_mul_of_lowerRow hσ10 hσ11
   refine ⟨δ, ?_, ?_⟩
   · refine (Gamma1_mem N δ).mpr ⟨?_, ?_, ?_⟩
     · have h : ((γ 0 0 - γ 0 1 * (N : ℤ) : ℤ) : ZMod N) = 1 := by
@@ -266,11 +197,8 @@ lemma exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none (hp : 0 < p) (hσ10 : σ 
     linear_combination hσdet
   obtain ⟨γ, hγmat⟩ : ∃ γ : SL(2, ℤ), (γ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![σ 0 0 * (p : ℤ), σ 0 1; (N : ℤ), 1] := ⟨⟨_, hdet⟩, rfl⟩
-  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
-    have := congrArg (Int.cast : ℤ → ZMod N) hσdet
-    push_cast at this ⊢
-    rw [ZMod.natCast_self] at this
-    linear_combination this
+  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 :=
+    intCast_mul_of_lowerRow hσ10 hσ11
   refine ⟨γ, (Gamma1_mem N γ).mpr ⟨?_, ?_, ?_⟩, ?_⟩
   · simpa [hγmat] using hmp
   · simp [hγmat]
@@ -294,47 +222,45 @@ lemma exists_mem_Gamma1_natDiagGL_mul_primeRep (hp : p.Prime) (hσ10 : σ 1 0 = 
     ∃ (i : Option (Fin p)) (δ : SL(2, ℤ)), δ ∈ Gamma1 N ∧
       natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * primeRep σ p i := by
   by_cases hpa : (p : ℤ) ∣ γ 0 0
-  · obtain ⟨δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_twist hp.pos hσ10 hσ11 hγ hpa
+  · obtain ⟨δ, hδ, heq⟩ :=
+      exists_mem_Gamma1_natDiagGL_mul_primeRep_none_of_dvd hp.pos hσ10 hσ11 hγ hpa
     exact ⟨none, δ, hδ, heq⟩
-  · have : Fact p.Prime := ⟨hp⟩
+  · have hunit : IsUnit ((γ 0 0 : ℤ) : ZMod p) :=
+      (CharP.isUnit_intCast_iff (R := ZMod p) hp).mpr hpa
     have : NeZero p := ⟨hp.pos.ne'⟩
-    have ha : ((γ 0 0 : ℤ) : ZMod p) ≠ 0 := fun hz ↦
-      hpa ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hz)
-    set j : ZMod p := ((γ 0 1 : ℤ) : ZMod p) / ((γ 0 0 : ℤ) : ZMod p) with hjdef
+    obtain ⟨j, hdvd⟩ := exists_dvd_sub_val_mul p (γ 0 1) (γ 0 0) hunit
     have hjlt : j.val < p := ZMod.val_lt j
-    have hdvd : (p : ℤ) ∣ γ 0 1 - γ 0 0 * (j.val : ℕ) := by
-      rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
-      push_cast
-      rw [ZMod.natCast_val, ZMod.cast_id, hjdef]
-      field_simp
-      ring
-    obtain ⟨δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_of_dvd hp.pos hγ hjlt hdvd
+    obtain ⟨δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_of_dvd hp.pos hγ hjlt
+      (by simpa [mul_comm] using hdvd)
     exact ⟨some ⟨j.val, hjlt⟩, δ, hδ, by rw [primeRep_some]; exact heq⟩
 
-/-- **The `p + 1` right cosets are pairwise distinct.** The `p` upper-triangular ones are
-separated by `op_upperTriRep_smul_injective`; separating the twisted one from them is
-integrality. If `Γ₁(N) · !![1, b; 0, p] = Γ₁(N) · σ · diag(p, 1)`, comparing the top rows gives
-`n = p (m b + σ'₀₁)` for some `σ' ∈ Γ₁(N)`, so `p ∣ n`, and then `m p − n N = 1` makes `p` a
+/-- **The `p + 1` right cosets are pairwise distinct for any integral subgroup when `1 < p`.**
+The `p` upper-triangular ones are separated by `op_upperTriRep_smul_injective`; separating the
+twisted one from them is integrality. If
+`G · !![1, b; 0, p] = G · σ · diag(p, 1)`, comparing the top rows gives
+`n = p (m b + σ'₀₁)` for some `σ' ∈ G`, so `p ∣ n`, and then `m p − n N = 1` makes `p` a
 divisor of `1`. -/
-theorem op_primeRep_smul_injective (hp : p.Prime) (hσ10 : σ 1 0 = (N : ℤ))
+theorem op_primeRep_smul_injective {G : Subgroup SL(2, ℤ)} (hp : 1 < p)
+    (hσ10 : σ 1 0 = (N : ℤ))
     (hσ11 : σ 1 1 = (p : ℤ)) :
     Function.Injective fun i : Option (Fin p) ↦
-      MulOpposite.op (primeRep σ p i) • (((Gamma1 N).map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) := by
+      MulOpposite.op (primeRep σ p i) • ((G.map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) := by
+  have hp0 : 0 < p := by omega
   have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := bezout_of_lowerRow hσ10 hσ11
   -- the twisted coset is not one of the upper-triangular ones
   have hne : ∀ b : Fin p,
-      MulOpposite.op (primeRep σ p (some b)) • (((Gamma1 N).map (mapGL ℚ)) :
+      MulOpposite.op (primeRep σ p (some b)) • ((G.map (mapGL ℚ)) :
           Set (GL (Fin 2) ℚ)) ≠
-        MulOpposite.op (primeRep σ p none) • (((Gamma1 N).map (mapGL ℚ)) :
+        MulOpposite.op (primeRep σ p none) • ((G.map (mapGL ℚ)) :
           Set (GL (Fin 2) ℚ)) := by
     intro b heq
-    obtain ⟨τ, hτ, hτeq⟩ := Subgroup.mem_map.mp ((rightCoset_eq_iff _).mp heq)
+    obtain ⟨τ, -, hτeq⟩ := Subgroup.mem_map.mp ((rightCoset_eq_iff _).mp heq)
     have hmul : (mapGL ℚ τ : GL (Fin 2) ℚ) * upperTriRep p b = primeRep σ p none := by
       rw [hτeq, ← primeRep_some σ p b, inv_mul_cancel_right]
     have hmat : (↑(mapGL ℚ τ) : Matrix (Fin 2) (Fin 2) ℚ) * !![1, (b : ℚ); 0, (p : ℚ)] =
         (↑(primeRep σ p none) : Matrix (Fin 2) (Fin 2) ℚ) := by
       rw [← coe_upperTriRep, ← Units.val_mul, hmul]
-    rw [coe_mapGL_fin_two, coe_primeRep_none hp.pos, Matrix.mul_fin_two] at hmat
+    rw [coe_mapGL_fin_two, coe_primeRep_none hp0, Matrix.mul_fin_two] at hmat
     have h00 : ((τ 0 0 : ℤ) : ℚ) = ((σ 0 0 : ℤ) : ℚ) * (p : ℚ) := by
       simpa using congrFun (congrFun hmat 0) 0
     have h01 : ((τ 0 0 : ℤ) : ℚ) * (b : ℚ) + ((τ 0 1 : ℤ) : ℚ) * (p : ℚ) = ((σ 0 1 : ℤ) : ℚ) := by
@@ -348,13 +274,13 @@ theorem op_primeRep_smul_injective (hp : p.Prime) (hσ10 : σ 1 0 = (N : ℤ))
     have hdvd : (p : ℤ) ∣ 1 :=
       ⟨σ 0 0 - (σ 0 0 * (b : ℕ) + τ 0 1) * (N : ℤ), by linear_combination -hσdet - (N : ℤ) * hn⟩
     have hle := Int.le_of_dvd one_pos hdvd
-    have htwo : 2 ≤ (p : ℤ) := by exact_mod_cast hp.two_le
+    have htwo : 2 ≤ (p : ℤ) := by exact_mod_cast hp
     omega
   rintro (_ | b₁) (_ | b₂) h
   · rfl
   · exact absurd h.symm (hne b₂)
   · exact absurd h (hne b₁)
-  · simpa using op_upperTriRep_smul_injective (G := Gamma1 N) (by simpa using h)
+  · simpa using op_upperTriRep_smul_injective (G := G) (by simpa using h)
 
 /-- **The `Tₚ` double coset at a prime `p ∤ N` is the union of `p + 1` right cosets.**
 `Γ₁(N) · diag(1, p) · Γ₁(N) = ⋃_{j < p} Γ₁(N) · !![1, j; 0, p]  ∪  Γ₁(N) · σ · diag(p, 1)`,
@@ -364,31 +290,20 @@ existence of the twist `σ` rather than stated separately (`coprime_of_lowerRow`
 The inclusion `⊆` is `exists_mem_Gamma1_natDiagGL_mul_primeRep` and is where primality enters;
 `⊇` is `natDiagGL_mul_mapGL_T_zpow` on the upper-triangular cosets and
 `exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none` on the twisted one. That the union is disjoint
-is `op_primeRep_smul_injective`. -/
+is `op_primeRep_smul_injective`, which only needs `1 < p`. -/
 theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime (hp : p.Prime)
     (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ)) :
     doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ i : Option (Fin p), MulOpposite.op (primeRep σ p i) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  refine Set.Subset.antisymm (fun x hx ↦ ?_) (Set.iUnion_subset fun i x hx ↦ ?_)
-  · obtain ⟨g₁, hg₁, g₂, hg₂, rfl⟩ := mem_doubleCoset.mp hx
-    obtain ⟨γ₂, hγ₂, rfl⟩ := Subgroup.mem_map.mp hg₂
-    obtain ⟨i, δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_primeRep hp hσ10 hσ11 hγ₂
-    refine Set.mem_iUnion.mpr ⟨i, (mem_rightCoset_iff _).mpr ?_⟩
-    have hx' : g₁ * natDiagGL 2 ![1, p] * mapGL ℚ γ₂ * (primeRep σ p i)⁻¹ = g₁ * mapGL ℚ δ := by
-      rw [mul_assoc g₁, heq, mul_assoc, mul_inv_cancel_right]
-    rw [hx']
-    exact mul_mem hg₁ (Subgroup.mem_map_of_mem _ hδ)
-  · obtain ⟨γ, hγ, hγeq⟩ : ∃ γ : SL(2, ℤ), γ ∈ Gamma1 N ∧
-        natDiagGL 2 ![1, p] * mapGL ℚ γ = primeRep σ p i := by
-      cases i with
-      | none => exact exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none hp.pos hσ10 hσ11
-      | some b =>
-        exact ⟨ModularGroup.T ^ (b : ℤ), T_zpow_mem_Gamma1 N _, by
-          rw [primeRep_some, natDiagGL_mul_mapGL_T_zpow hp.pos b]⟩
-    refine mem_doubleCoset.mpr ⟨x * (primeRep σ p i)⁻¹, (mem_rightCoset_iff _).mp hx,
-      mapGL ℚ γ, Subgroup.mem_map_of_mem _ hγ, ?_⟩
-    rw [mul_assoc, hγeq, inv_mul_cancel_right]
+  apply doubleCoset_natDiagGL_eq_iUnion_rightCosets_of (rep := primeRep σ p)
+  · exact fun γ hγ ↦ exists_mem_Gamma1_natDiagGL_mul_primeRep hp hσ10 hσ11 hγ
+  · intro i
+    cases i with
+    | none => exact exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none hp.pos hσ10 hσ11
+    | some b =>
+      exact ⟨ModularGroup.T ^ (b : ℤ), T_zpow_mem_Gamma1 N _, by
+        rw [primeRep_some, natDiagGL_mul_mapGL_T_zpow hp.pos b]⟩
 
 /-- The decomposition of `doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`, read at the
 chosen representative `D.out` of `diagCosetGamma1 N p` — the shape the slash-sum machinery of
@@ -399,9 +314,7 @@ theorem doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets_of_prime (hp : p.P
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ i : Option (Fin p), MulOpposite.op (primeRep σ p i) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  have hout : HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
-      (diagCosetGamma1 N p).out = diagCosetGamma1 N p := Quotient.out_eq _
-  rw [HeckeCoset.eq_iff.mp (hout.trans (diagCosetGamma1_def N p)),
+  rw [doubleCoset_out_diagCosetGamma1_eq_natDiagGL,
     doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime hp hσ10 hσ11]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
@@ -27,8 +27,9 @@ supplies the factor `χ(p)` in the Hecke recurrence at a good prime.
 ## Where the hypotheses enter
 
 The whole statement is carried by the bottom row of `σ`. Its two entries `N` and `p` together
-with `det σ = 1` say exactly `m p − n N = 1` (`bezout_of_lowerRow`), so such a `σ` exists
-precisely when `p` and `N` are coprime (`coprime_of_lowerRow`). Everything below is stated for
+with `det σ = 1` say exactly `m p − n N = 1`
+(`mul_sub_mul_eq_one_of_lowerRow`), so such a `σ` exists precisely when `p` and `N` are coprime,
+as also follows from `Matrix.SpecialLinearGroup.isCoprime_row`. Everything below is stated for
 an arbitrary such `σ`, which
 keeps the coprimality implicit in the data rather than as a side hypothesis, and lets the caller
 supply whichever Bézout witness it already has.
@@ -60,6 +61,8 @@ Disjointness of the last coset from the others uses only `1 < p` and integrality
 * `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none`:
   `diag(1, p) · !![m p, n; N, 1] = σ · diag(p, 1)` with `!![m p, n; N, 1] ∈ Γ₁(N)` — the reverse
   inclusion for the twisted coset.
+* `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_primeRep`: for prime `p`, every
+  `diag(1, p) · γ` with `γ ∈ Γ₁(N)` lies in one of the `p + 1` right cosets.
 * `HeckeRing.GL2.op_primeRep_smul_injective`: the `p + 1` right cosets are pairwise distinct.
 * `HeckeRing.GL2.doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`: **the decomposition**,
   and `HeckeRing.GL2.doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets_of_prime` the same
@@ -119,8 +122,39 @@ lemma coe_primeRep_none (hp : 0 < p) :
     (↑(primeRep σ p none) : Matrix (Fin 2) (Fin 2) ℚ) =
       !![((σ 0 0 : ℤ) : ℚ) * (p : ℚ), ((σ 0 1 : ℤ) : ℚ);
         ((σ 1 0 : ℤ) : ℚ) * (p : ℚ), ((σ 1 1 : ℤ) : ℚ)] := by
-  rw [primeRep_none, Units.val_mul, coe_mapGL_fin_two, coe_scaleRep p hp, Matrix.mul_fin_two]
+  rw [primeRep_none, Units.val_mul, coe_mapGL_int_rat_fin_two, coe_scaleRep p hp,
+    Matrix.mul_fin_two]
   congrm !![?_, ?_; ?_, ?_] <;> ring1
+
+-- Kept separate so that the repeated rational matrix computation runs on entrywise atoms.
+-- The first use supplies the nontrivial left factor in the forward inclusion; the second
+-- specializes that factor to `1` for the reverse witness.
+private lemma natDiagGL_mul_mapGL_eq_mapGL_mul_primeRep_none_of_entries (hp : 0 < p)
+    (hσ10 : σ 1 0 = (N : ℤ)) (hσ11 : σ 1 1 = (p : ℤ))
+    {γ δ : SL(2, ℤ)} {a' : ℤ} (ha' : γ 0 0 = (p : ℤ) * a')
+    (e00 : δ 0 0 = γ 0 0 - γ 0 1 * (N : ℤ))
+    (e01 : δ 0 1 = γ 0 1 * σ 0 0 - a' * σ 0 1)
+    (e10 : δ 1 0 = (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)))
+    (e11 : δ 1 1 = (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1) :
+    natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * primeRep σ p none := by
+  refine Units.ext ?_
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 :=
+    mul_sub_mul_eq_one_of_lowerRow hσ10 hσ11
+  have hσdetQ : ((σ 0 0 : ℤ) : ℚ) * (p : ℚ) -
+      ((σ 0 1 : ℤ) : ℚ) * (N : ℚ) = 1 := by
+    exact_mod_cast congrArg (Int.cast : ℤ → ℚ) hσdet
+  have haQ : ((γ 0 0 : ℤ) : ℚ) = (p : ℚ) * ((a' : ℤ) : ℚ) := by
+    exact_mod_cast congrArg (Int.cast : ℤ → ℚ) ha'
+  rw [Units.val_mul, Units.val_mul, coe_natDiagGL_one hp, coe_primeRep_none hp,
+    coe_mapGL_int_rat_fin_two γ, coe_mapGL_int_rat_fin_two δ, e00, e01, e10, e11, hσ10, hσ11,
+    Matrix.mul_fin_two, Matrix.mul_fin_two]
+  push_cast
+  congrm !![?_, ?_; ?_, ?_]
+  · linear_combination (-(p : ℚ) * ((a' : ℤ) : ℚ)) * hσdetQ +
+      (1 - ((σ 0 0 : ℤ) : ℚ) * (p : ℚ)) * haQ
+  · linear_combination (-((γ 0 1 : ℤ) : ℚ)) * hσdetQ - ((σ 0 1 : ℤ) : ℚ) * haQ
+  · linear_combination (-(p : ℚ) * ((γ 1 0 : ℤ) : ℚ)) * hσdetQ
+  · linear_combination (-(p : ℚ) * ((γ 1 1 : ℤ) : ℚ)) * hσdetQ
 
 /-- **The forward factorisation through the twisted coset.** For `γ = !![a, b; c, d] ∈ Γ₁(N)`
 with `p ∣ a`, the product `diag(1, p) · γ` lies in the right coset `Γ₁(N) · σ · diag(p, 1)`:
@@ -136,9 +170,10 @@ lemma exists_mem_Gamma1_natDiagGL_mul_primeRep_none_of_dvd (hp : 0 < p)
       natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * primeRep σ p none := by
   obtain ⟨ha, hd, hc⟩ := (Gamma1_mem N γ).mp hγ
   obtain ⟨a', ha'⟩ := hpa
-  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := bezout_of_lowerRow hσ10 hσ11
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 :=
+    mul_sub_mul_eq_one_of_lowerRow hσ10 hσ11
   have hγdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 :=
-    Matrix.SpecialLinearGroup.det_fin_two γ
+    Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one γ
   -- the new left factor
   have hdet : (!![γ 0 0 - γ 0 1 * (N : ℤ), γ 0 1 * σ 0 0 - a' * σ 0 1;
       (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)), (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1] :
@@ -151,8 +186,9 @@ lemma exists_mem_Gamma1_natDiagGL_mul_primeRep_none_of_dvd (hp : 0 < p)
         (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)), (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1] :=
     ⟨⟨_, hdet⟩, rfl⟩
   -- `m p ≡ 1 (mod N)`, the congruence that puts the left factor in `Γ₁(N)`
-  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 :=
-    intCast_mul_eq_one_of_lowerRow hσ10 hσ11
+  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
+    have hσΓ0 : σ ∈ Gamma0 N := Gamma0_mem.mpr (by rw [hσ10]; simp)
+    simpa [hσ11] using intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hσΓ0
   refine ⟨δ, ?_, ?_⟩
   · refine (Gamma1_mem N δ).mpr ⟨?_, ?_, ?_⟩
     · have h : ((γ 0 0 - γ 0 1 * (N : ℤ) : ℤ) : ZMod N) = 1 := by
@@ -170,25 +206,12 @@ lemma exists_mem_Gamma1_natDiagGL_mul_primeRep_none_of_dvd (hp : 0 < p)
         rw [hc, ZMod.natCast_self]
         ring
       simpa [hδmat] using h
-  · refine Units.ext ?_
-    have e00 : (δ 0 0 : ℤ) = γ 0 0 - γ 0 1 * (N : ℤ) := by rw [hδmat]; simp
+  · have e00 : (δ 0 0 : ℤ) = γ 0 0 - γ 0 1 * (N : ℤ) := by rw [hδmat]; simp
     have e01 : (δ 0 1 : ℤ) = γ 0 1 * σ 0 0 - a' * σ 0 1 := by rw [hδmat]; simp
     have e10 : (δ 1 0 : ℤ) = (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)) := by rw [hδmat]; simp
     have e11 : (δ 1 1 : ℤ) = (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1 := by rw [hδmat]; simp
-    have hσdetQ : ((σ 0 0 : ℤ) : ℚ) * (p : ℚ) - ((σ 0 1 : ℤ) : ℚ) * (N : ℚ) = 1 := by
-      exact_mod_cast congrArg (Int.cast : ℤ → ℚ) hσdet
-    have haQ : ((γ 0 0 : ℤ) : ℚ) = (p : ℚ) * ((a' : ℤ) : ℚ) := by
-      exact_mod_cast congrArg (Int.cast : ℤ → ℚ) ha'
-    rw [Units.val_mul, Units.val_mul, coe_natDiagGL_one hp, coe_primeRep_none hp,
-      coe_mapGL_fin_two γ, coe_mapGL_fin_two δ, e00, e01, e10, e11, hσ10, hσ11,
-      Matrix.mul_fin_two, Matrix.mul_fin_two]
-    push_cast
-    congrm !![?_, ?_; ?_, ?_]
-    · linear_combination (-(p : ℚ) * ((a' : ℤ) : ℚ)) * hσdetQ +
-        (1 - ((σ 0 0 : ℤ) : ℚ) * (p : ℚ)) * haQ
-    · linear_combination (-((γ 0 1 : ℤ) : ℚ)) * hσdetQ - ((σ 0 1 : ℤ) : ℚ) * haQ
-    · linear_combination (-(p : ℚ) * ((γ 1 0 : ℤ) : ℚ)) * hσdetQ
-    · linear_combination (-(p : ℚ) * ((γ 1 1 : ℤ) : ℚ)) * hσdetQ
+    exact natDiagGL_mul_mapGL_eq_mapGL_mul_primeRep_none_of_entries hp hσ10 hσ11 ha'
+      e00 e01 e10 e11
 
 /-- **The witness for the reverse inclusion.** The matrix `!![m p, n; N, 1]` lies in `Γ₁(N)` —
 its determinant is the Bézout relation and `m p ≡ 1 (mod N)` — and moving it across
@@ -197,27 +220,41 @@ lemma exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none (hp : 0 < p) (hσ10 : σ 
     (hσ11 : σ 1 1 = (p : ℤ)) :
     ∃ γ : SL(2, ℤ), γ ∈ Gamma1 N ∧
       natDiagGL 2 ![1, p] * mapGL ℚ γ = primeRep σ p none := by
-  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := bezout_of_lowerRow hσ10 hσ11
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 :=
+    mul_sub_mul_eq_one_of_lowerRow hσ10 hσ11
   have hdet : (!![σ 0 0 * (p : ℤ), σ 0 1; (N : ℤ), 1] : Matrix (Fin 2) (Fin 2) ℤ).det = 1 := by
     rw [Matrix.det_fin_two_of]
     linear_combination hσdet
   obtain ⟨γ, hγmat⟩ : ∃ γ : SL(2, ℤ), (γ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![σ 0 0 * (p : ℤ), σ 0 1; (N : ℤ), 1] := ⟨⟨_, hdet⟩, rfl⟩
-  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 :=
-    intCast_mul_eq_one_of_lowerRow hσ10 hσ11
+  have hmp : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
+    have hσΓ0 : σ ∈ Gamma0 N := Gamma0_mem.mpr (by rw [hσ10]; simp)
+    simpa [hσ11] using intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hσΓ0
   refine ⟨γ, (Gamma1_mem N γ).mpr ⟨?_, ?_, ?_⟩, ?_⟩
   · simpa [hγmat] using hmp
   · simp [hγmat]
   · simp [hγmat]
-  · refine Units.ext ?_
-    have e00 : (γ 0 0 : ℤ) = σ 0 0 * (p : ℤ) := by rw [hγmat]; simp
+  · have e00 : (γ 0 0 : ℤ) = σ 0 0 * (p : ℤ) := by rw [hγmat]; simp
     have e01 : (γ 0 1 : ℤ) = σ 0 1 := by rw [hγmat]; simp
     have e10 : (γ 1 0 : ℤ) = (N : ℤ) := by rw [hγmat]; simp
     have e11 : (γ 1 1 : ℤ) = 1 := by rw [hγmat]; simp
-    rw [Units.val_mul, coe_natDiagGL_one hp, coe_primeRep_none hp, coe_mapGL_fin_two γ,
-      e00, e01, e10, e11, hσ10, hσ11, Matrix.mul_fin_two]
-    push_cast
-    congrm !![?_, ?_; ?_, ?_] <;> ring1
+    have ha' : γ 0 0 = (p : ℤ) * σ 0 0 := by rw [e00]; ring
+    have h00 : (1 : SL(2, ℤ)) 0 0 = γ 0 0 - γ 0 1 * (N : ℤ) := by
+      rw [e00, e01]
+      simpa using hσdet.symm
+    have h01 : (1 : SL(2, ℤ)) 0 1 = γ 0 1 * σ 0 0 - σ 0 0 * σ 0 1 := by
+      rw [e01]
+      simp [mul_comm]
+    have h10 : (1 : SL(2, ℤ)) 1 0 = (p : ℤ) * (γ 1 0 - γ 1 1 * (N : ℤ)) := by
+      rw [e10, e11]
+      simp
+    have h11 : (1 : SL(2, ℤ)) 1 1 =
+        (p : ℤ) * γ 1 1 * σ 0 0 - γ 1 0 * σ 0 1 := by
+      rw [e10, e11]
+      simpa [mul_comm] using hσdet.symm
+    simpa using
+      natDiagGL_mul_mapGL_eq_mapGL_mul_primeRep_none_of_entries (σ := σ) hp hσ10 hσ11
+        (δ := (1 : SL(2, ℤ))) (a' := σ 0 0) ha' h00 h01 h10 h11
 
 /-- **The forward inclusion.** For a prime `p` and `γ ∈ Γ₁(N)`, the product `diag(1, p) · γ` lies
 in one of the `p + 1` right cosets: an upper-triangular one when `p ∤ a`, where the congruence
@@ -252,7 +289,8 @@ theorem op_primeRep_smul_injective {G : Subgroup SL(2, ℤ)} (hp : 1 < p)
     Function.Injective fun i : Option (Fin p) ↦
       MulOpposite.op (primeRep σ p i) • ((G.map (mapGL ℚ)) : Set (GL (Fin 2) ℚ)) := by
   have hp0 : 0 < p := by omega
-  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := bezout_of_lowerRow hσ10 hσ11
+  have hσdet : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 :=
+    mul_sub_mul_eq_one_of_lowerRow hσ10 hσ11
   -- the twisted coset is not one of the upper-triangular ones
   have hne : ∀ b : Fin p,
       MulOpposite.op (primeRep σ p (some b)) • ((G.map (mapGL ℚ)) :
@@ -266,7 +304,7 @@ theorem op_primeRep_smul_injective {G : Subgroup SL(2, ℤ)} (hp : 1 < p)
     have hmat : (↑(mapGL ℚ τ) : Matrix (Fin 2) (Fin 2) ℚ) * !![1, (b : ℚ); 0, (p : ℚ)] =
         (↑(primeRep σ p none) : Matrix (Fin 2) (Fin 2) ℚ) := by
       rw [← coe_upperTriRep, ← Units.val_mul, hmul]
-    rw [coe_mapGL_fin_two, coe_primeRep_none hp0, Matrix.mul_fin_two] at hmat
+    rw [coe_mapGL_int_rat_fin_two, coe_primeRep_none hp0, Matrix.mul_fin_two] at hmat
     have h00 : ((τ 0 0 : ℤ) : ℚ) = ((σ 0 0 : ℤ) : ℚ) * (p : ℚ) := by
       simpa using congrFun (congrFun hmat 0) 0
     have h01 : ((τ 0 0 : ℤ) : ℚ) * (b : ℚ) + ((τ 0 1 : ℤ) : ℚ) * (p : ℚ) = ((σ 0 1 : ℤ) : ℚ) := by
@@ -291,7 +329,8 @@ theorem op_primeRep_smul_injective {G : Subgroup SL(2, ℤ)} (hp : 1 < p)
 /-- **The `Tₚ` double coset at a prime `p ∤ N` is the union of `p + 1` right cosets.**
 `Γ₁(N) · diag(1, p) · Γ₁(N) = ⋃_{j < p} Γ₁(N) · !![1, j; 0, p]  ∪  Γ₁(N) · σ · diag(p, 1)`,
 Diamond–Shurman's Proposition 5.2.1 in the case `p ∤ N` — the coprimality being carried by the
-existence of the twist `σ` rather than stated separately (`coprime_of_lowerRow`).
+existence of the twist `σ` rather than stated separately (equivalently, by
+`Matrix.SpecialLinearGroup.isCoprime_row`, the bottom-row entries are coprime).
 
 The inclusion `⊆` is `exists_mem_Gamma1_natDiagGL_mul_primeRep` and is where primality enters;
 `⊇` is `natDiagGL_mul_mapGL_T_zpow` on the upper-triangular cosets and
@@ -302,13 +341,22 @@ theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime (hp : p.Prime)
     doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ i : Option (Fin p), MulOpposite.op (primeRep σ p i) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  apply doubleCoset_natDiagGL_eq_iUnion_rightCosets_of (rep := primeRep σ p)
-  · exact fun γ hγ ↦ exists_mem_Gamma1_natDiagGL_mul_primeRep hp hσ10 hσ11 hγ
+  apply doubleCoset_eq_iUnion_rightCosets_of_forall_exists
+      ((Gamma1 N).map (mapGL ℚ)) (natDiagGL 2 ![1, p]) (primeRep σ p)
+  · intro g hg
+    obtain ⟨γ, hγ, rfl⟩ := Subgroup.mem_map.mp hg
+    obtain ⟨i, δ, hδ, heq⟩ :=
+      exists_mem_Gamma1_natDiagGL_mul_primeRep hp hσ10 hσ11 hγ
+    exact ⟨i, mapGL ℚ δ, Subgroup.mem_map_of_mem _ hδ, heq⟩
   · intro i
     cases i with
-    | none => exact exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none hp.pos hσ10 hσ11
+    | none =>
+      obtain ⟨γ, hγ, heq⟩ :=
+        exists_mem_Gamma1_natDiagGL_mul_eq_primeRep_none hp.pos hσ10 hσ11
+      exact ⟨mapGL ℚ γ, Subgroup.mem_map_of_mem _ hγ, heq⟩
     | some b =>
-      exact ⟨ModularGroup.T ^ (b : ℤ), T_zpow_mem_Gamma1 N _, by
+      exact ⟨mapGL ℚ (ModularGroup.T ^ (b : ℤ)),
+        Subgroup.mem_map_of_mem _ (T_zpow_mem_Gamma1 N _), by
         rw [primeRep_some, natDiagGL_mul_mapGL_T_zpow hp.pos b]⟩
 
 /-- The decomposition of `doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`, read at the
@@ -320,7 +368,7 @@ theorem doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets_of_prime (hp : p.P
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ i : Option (Fin p), MulOpposite.op (primeRep σ p i) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  rw [doubleCoset_out_diagCosetGamma1_eq_natDiagGL,
+  rw [doubleCoset_out_diagCosetGamma1_eq_doubleCoset_natDiagGL,
     doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime hp hσ10 hσ11]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.UpperTriCosets
 
 import Mathlib.Algebra.CharP.Invertible
+import TauCeti.Data.ZMod.Divisibility
 
 /-!
 # The double coset `Γ₁(N) · diag(1, p) · Γ₁(N)` at a prime `p ∤ N`
@@ -92,10 +93,13 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ} {σ : SL(2, ℤ)}
 
-/-- **The `p + 1` right-coset representatives of the good-prime `Tₚ`.** The `p` upper-triangular
-matrices `!![1, b; 0, p]`, indexed by `some b`, together with the twisted diagonal
-`σ · diag(p, 1)`, indexed by `none`. The index type `Option (Fin p)` is what the slash-sum
-machinery of `HeckeSlash/Independence.lean` sums over. -/
+/-- **The family of `p + 1` matrices out of which the good-prime `Tₚ` is built.** The `p`
+upper-triangular matrices `!![1, b; 0, p]`, indexed by `some b`, together with the twisted
+diagonal `σ · diag(p, 1)`, indexed by `none`; the definition makes no assumption on `p` or `σ`.
+They are the right-coset representatives of `Γ₁(N) · diag(1, p) · Γ₁(N)` exactly under the
+hypotheses of `doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`, namely for `p` prime and
+`σ` with bottom row `(N, p)`. The index type `Option (Fin p)` is what the slash-sum machinery of
+`HeckeSlash/Independence.lean` sums over. -/
 noncomputable def primeRep (σ : SL(2, ℤ)) (p : ℕ) : Option (Fin p) → GL (Fin 2) ℚ
   | some b => upperTriRep p b
   | none => mapGL ℚ σ * scaleRep p
@@ -108,7 +112,9 @@ noncomputable def primeRep (σ : SL(2, ℤ)) (p : ℕ) : Option (Fin p) → GL (
 @[simp] lemma primeRep_none (σ : SL(2, ℤ)) (p : ℕ) :
     primeRep σ p none = mapGL ℚ σ * scaleRep p := (rfl)
 
-/-- The matrix of the twisted representative: `σ · diag(p, 1) = !![m p, n; N p, p]`. -/
+/-- The matrix of the twisted representative: multiplying by `diag(p, 1)` on the right scales the
+first column of `σ` by `p`, so `!![a, b; c, d] · diag(p, 1) = !![a p, b; c p, d]`. At the bottom
+row `(N, p)` the decomposition uses, this reads `σ · diag(p, 1) = !![m p, n; N p, p]`. -/
 lemma coe_primeRep_none (hp : 0 < p) :
     (↑(primeRep σ p none) : Matrix (Fin 2) (Fin 2) ℚ) =
       !![((σ 0 0 : ℤ) : ℚ) * (p : ℚ), ((σ 0 1 : ℤ) : ℚ);
@@ -228,7 +234,7 @@ lemma exists_mem_Gamma1_natDiagGL_mul_primeRep (hp : p.Prime) (hσ10 : σ 1 0 = 
   · have hunit : IsUnit ((γ 0 0 : ℤ) : ZMod p) :=
       (CharP.isUnit_intCast_iff (R := ZMod p) hp).mpr hpa
     have : NeZero p := ⟨hp.pos.ne'⟩
-    obtain ⟨j, hdvd⟩ := exists_dvd_sub_val_mul p (γ 0 1) (γ 0 0) hunit
+    obtain ⟨j, hdvd⟩ := ZMod.exists_dvd_sub_val_mul p (γ 0 1) (γ 0 0) hunit
     have hjlt : j.val < p := ZMod.val_lt j
     obtain ⟨δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_of_dvd hp.pos hγ hjlt
       (by simpa [mul_comm] using hdvd)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -277,7 +277,8 @@ theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets (hp : 0 < p) (hpN : p ∣ N)
       ⋃ j : Fin p, MulOpposite.op (upperTriRep p j) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
   apply doubleCoset_eq_iUnion_rightCosets_of_forall_exists
-      ((Gamma1 N).map (mapGL ℚ)) (natDiagGL 2 ![1, p]) (upperTriRep p)
+      ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      (natDiagGL 2 ![1, p]) (upperTriRep p)
   · intro g hg
     obtain ⟨γ, hγ, rfl⟩ := Subgroup.mem_map.mp hg
     obtain ⟨j, δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul hp hpN hγ

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -55,8 +55,10 @@ of `T = !![1, 1; 0, 1]` lies in `Γ₁(N)`.
   in `Δ₀(N)` at every level, and its matrix.
 * `HeckeRing.GL2.natDiagGL_mul_mapGL_T_zpow`: `diag(1, p) · Tᵇ = !![1, b; 0, p]`, the
   reverse inclusion in one line.
-* `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul`: the factorisation
-  `diag(1, p) · γ = δ · !![1, j; 0, p]` with `δ ∈ Γ₁(N)`, the forward inclusion.
+* `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_of_dvd`: the factorisation
+  `diag(1, p) · γ = δ · !![1, j; 0, p]` with `δ ∈ Γ₁(N)`, at any offset `j` with `p ∣ b − a j`;
+  `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul` chooses such an offset from `p ∣ N`, and is
+  the forward inclusion.
 * `HeckeRing.GL2.op_upperTriRep_smul_injective`: the `p` right cosets are pairwise distinct,
   so the union is disjoint. Stated for an arbitrary subgroup of `SL₂(ℤ)`, since only
   integrality is used.
@@ -92,14 +94,6 @@ open scoped MatrixGroups Pointwise
 namespace HeckeRing.GL2
 
 variable {N p : ℕ}
-
-/-- The rational matrix of `mapGL ℚ σ` in `!![…]` form. -/
-private lemma coe_mapGL_fin_two (σ : SL(2, ℤ)) :
-    (↑(mapGL ℚ σ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      !![((σ 0 0 : ℤ) : ℚ), ((σ 0 1 : ℤ) : ℚ); ((σ 1 0 : ℤ) : ℚ), ((σ 1 1 : ℤ) : ℚ)] := by
-  rw [mapGL_coe_matrix]
-  ext i j
-  fin_cases i <;> fin_cases j <;> simp
 
 /-- `diag(1, p) ∈ Δ₀(N)`, for every level `N`: the upper-left entry is `1`, a unit modulo
 anything. This is `natDiagGL_mem_Delta0_of_coprime` with its hypothesis discharged. -/
@@ -149,36 +143,24 @@ lemma natDiagGL_mul_mapGL_T_zpow (hp : 0 < p) (b : Fin p) :
     Matrix.mul_fin_two]
   norm_num
 
-/-- **The forward factorisation.** For `p ∣ N` and `γ ∈ Γ₁(N)`, the product `diag(1, p) · γ`
-lies in one of the `p` right cosets `Γ₁(N) · !![1, j; 0, p]`.
+/-- **The forward factorisation, at a prescribed offset.** If `γ ∈ Γ₁(N)` and the offset
+`j < p` satisfies `p ∣ b − a j` for `γ = !![a, b; c, d]`, then `diag(1, p) · γ` lies in the
+right coset `Γ₁(N) · !![1, j; 0, p]`: explicitly
 
-The offset is `j ≡ b (mod p)` for `γ = !![a, b; c, d]`, which works because `p ∣ N` makes
-`a ≡ 1 (mod p)`; the new left factor `!![a, m; p c, d − c j]` — where `b − a j = p m` — has
-determinant `a d − b c = 1` and stays in `Γ₁(N)` because `N ∣ c`. -/
-lemma exists_mem_Gamma1_natDiagGL_mul (hp : 0 < p) (hpN : p ∣ N) {γ : SL(2, ℤ)}
-    (hγ : γ ∈ Gamma1 N) :
-    ∃ (j : Fin p) (δ : SL(2, ℤ)), δ ∈ Gamma1 N ∧
-      natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * upperTriRep p j := by
+`diag(1, p) · γ = !![a, m; p c, d − c j] · !![1, j; 0, p]`,  `b − a j = p m`,
+
+whose left factor has determinant `a d − b c = 1` and stays in `Γ₁(N)` because `N ∣ c`.
+
+The divisibility on the offset is the only arithmetic input, and it is where the two branches
+of Diamond–Shurman's Proposition 5.2.1 differ: at `p ∣ N` every `γ ∈ Γ₁(N)` admits such a `j`
+(below), while at a prime `p ∤ N` only those with `p ∤ a` do, the rest needing the further coset
+of `Gamma1/CoprimeCosets.lean`. -/
+lemma exists_mem_Gamma1_natDiagGL_mul_of_dvd (hp : 0 < p) {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma1 N)
+    {j : ℕ} (hjlt : j < p) (hj : (p : ℤ) ∣ γ 0 1 - γ 0 0 * j) :
+    ∃ δ : SL(2, ℤ), δ ∈ Gamma1 N ∧
+      natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * upperTriRep p ⟨j, hjlt⟩ := by
   obtain ⟨ha, hd, hc⟩ := (Gamma1_mem N γ).mp hγ
-  have hp' : (0 : ℤ) < p := by exact_mod_cast hp
-  -- the level divisibility, read in `ℤ`
-  have haN : (N : ℤ) ∣ γ 0 0 - 1 := by
-    refine (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp ?_
-    push_cast
-    rw [ha, sub_self]
-  -- the offset `j ≡ b (mod p)`, taken opaquely: only its size and its residue matter
-  obtain ⟨j, hjlt, hpj⟩ : ∃ j : ℕ, j < p ∧ (p : ℤ) ∣ γ 0 1 - j := by
-    have hj0 : (0 : ℤ) ≤ γ 0 1 % p := Int.emod_nonneg _ hp'.ne'
-    refine ⟨(γ 0 1 % p).toNat, ?_, ?_⟩
-    · have := Int.emod_lt_of_pos (γ 0 1) hp'
-      omega
-    · rw [Int.toNat_of_nonneg hj0, Int.emod_def]
-      exact ⟨γ 0 1 / p, by ring⟩
-  have hpa : (p : ℤ) ∣ γ 0 0 - 1 := dvd_trans (Int.natCast_dvd_natCast.mpr hpN) haN
-  obtain ⟨m, hm⟩ : (p : ℤ) ∣ γ 0 1 - γ 0 0 * j := by
-    have : γ 0 1 - γ 0 0 * j = (γ 0 1 - j) - (γ 0 0 - 1) * j := by ring
-    rw [this]
-    exact dvd_sub hpj (Dvd.dvd.mul_right hpa _)
+  obtain ⟨m, hm⟩ := hj
   -- the new left factor
   have hdet : (!![γ 0 0, m; (p : ℤ) * γ 1 0, γ 1 1 - γ 1 0 * j] :
       Matrix (Fin 2) (Fin 2) ℤ).det = 1 := by
@@ -189,7 +171,7 @@ lemma exists_mem_Gamma1_natDiagGL_mul (hp : 0 < p) (hpN : p ∣ N) {γ : SL(2, �
     linear_combination hγdet + γ 1 0 * hm
   obtain ⟨δ, hδmat⟩ : ∃ δ : SL(2, ℤ), (δ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![γ 0 0, m; (p : ℤ) * γ 1 0, γ 1 1 - γ 1 0 * j] := ⟨⟨_, hdet⟩, rfl⟩
-  refine ⟨⟨j, hjlt⟩, δ, ?_, ?_⟩
+  refine ⟨δ, ?_, ?_⟩
   · refine (Gamma1_mem N δ).mpr ⟨?_, ?_, ?_⟩
     · simpa [hδmat] using ha
     · have h : ((γ 1 1 - γ 1 0 * j : ℤ) : ZMod N) = 1 := by push_cast; rw [hd, hc]; ring
@@ -210,6 +192,39 @@ lemma exists_mem_Gamma1_natDiagGL_mul (hp : 0 < p) (hpN : p ∣ N) {γ : SL(2, �
     · rw [hmZ]; push_cast; ring1
     · push_cast; ring1
     · push_cast; ring1
+
+/-- **The forward factorisation at `p ∣ N`.** For `p ∣ N` and `γ ∈ Γ₁(N)`, the product
+`diag(1, p) · γ` lies in one of the `p` right cosets `Γ₁(N) · !![1, j; 0, p]`.
+
+The offset is `j ≡ b (mod p)` for `γ = !![a, b; c, d]`, which works because `p ∣ N` makes
+`a ≡ 1 (mod p)`; the factorisation itself is
+`exists_mem_Gamma1_natDiagGL_mul_of_dvd`. -/
+lemma exists_mem_Gamma1_natDiagGL_mul (hp : 0 < p) (hpN : p ∣ N) {γ : SL(2, ℤ)}
+    (hγ : γ ∈ Gamma1 N) :
+    ∃ (j : Fin p) (δ : SL(2, ℤ)), δ ∈ Gamma1 N ∧
+      natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * upperTriRep p j := by
+  obtain ⟨ha, -, -⟩ := (Gamma1_mem N γ).mp hγ
+  have hp' : (0 : ℤ) < p := by exact_mod_cast hp
+  -- the level divisibility, read in `ℤ`
+  have haN : (N : ℤ) ∣ γ 0 0 - 1 := by
+    refine (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp ?_
+    push_cast
+    rw [ha, sub_self]
+  -- the offset `j ≡ b (mod p)`, taken opaquely: only its size and its residue matter
+  obtain ⟨j, hjlt, hpj⟩ : ∃ j : ℕ, j < p ∧ (p : ℤ) ∣ γ 0 1 - j := by
+    have hj0 : (0 : ℤ) ≤ γ 0 1 % p := Int.emod_nonneg _ hp'.ne'
+    refine ⟨(γ 0 1 % p).toNat, ?_, ?_⟩
+    · have := Int.emod_lt_of_pos (γ 0 1) hp'
+      omega
+    · rw [Int.toNat_of_nonneg hj0, Int.emod_def]
+      exact ⟨γ 0 1 / p, by ring⟩
+  have hpa : (p : ℤ) ∣ γ 0 0 - 1 := dvd_trans (Int.natCast_dvd_natCast.mpr hpN) haN
+  have hj : (p : ℤ) ∣ γ 0 1 - γ 0 0 * j := by
+    have h : γ 0 1 - γ 0 0 * j = (γ 0 1 - j) - (γ 0 0 - 1) * j := by ring
+    rw [h]
+    exact dvd_sub hpj (Dvd.dvd.mul_right hpa _)
+  obtain ⟨δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_of_dvd hp hγ hjlt hj
+  exact ⟨⟨j, hjlt⟩, δ, hδ, heq⟩
 
 /-- **The `p` right cosets are pairwise distinct.** If `Γ · !![1, j₁; 0, p] = Γ · !![1, j₂; 0, p]`
 for a subgroup `Γ` of `SL₂(ℤ)`, then `j₁ = j₂`: the comparison matrix has upper-left entry `1`

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -39,7 +39,8 @@ makes both `p c ≡ 0` and `d - c j ≡ d ≡ 1` modulo `N`.
 
 ⚠ For `p ∤ N` the statement is false: when `p` is prime the double coset then has `p + 1` right
 cosets, the extra one represented by `!![m, n; N, p] · diag(p, 1)` for any `m p − n N = 1`
-(Diamond–Shurman, Proposition 5.2.1). Nothing here is stated in that case.
+(Diamond–Shurman, Proposition 5.2.1). That case is proved in `Gamma1/CoprimeCosets.lean` by
+`doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`.
 
 The reverse inclusion needs no divisibility: `!![1, b; 0, p] = diag(1, p) · Tᵇ` and every power
 of `T = !![1, 1; 0, 1]` lies in `Γ₁(N)`.
@@ -62,6 +63,10 @@ of `T = !![1, 1; 0, 1]` lies in `Γ₁(N)`.
 * `HeckeRing.GL2.op_upperTriRep_smul_injective`: the `p` right cosets are pairwise distinct,
   so the union is disjoint. Stated for an arbitrary subgroup of `SL₂(ℤ)`, since only
   integrality is used.
+* `DoubleCoset.doubleCoset_eq_iUnion_rightCosets_of_forall_exists`: the general criterion
+  turning forward factorizations and reverse witnesses into a right-coset decomposition.
+* `HeckeRing.GL2.doubleCoset_out_diagCosetGamma1_eq_doubleCoset_natDiagGL`: the chosen
+  representative of `diagCosetGamma1 N p` has the canonical double coset.
 * `HeckeRing.GL2.doubleCoset_natDiagGL_eq_iUnion_rightCosets`: the decomposition itself, and
   `HeckeRing.GL2.doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets` the same statement read
   at the chosen representative of `diagCosetGamma1 N p`, which is the shape the slash sum of
@@ -165,7 +170,7 @@ lemma exists_mem_Gamma1_natDiagGL_mul_of_dvd (hp : 0 < p) {γ : SL(2, ℤ)} (hγ
   have hdet : (!![γ 0 0, m; (p : ℤ) * γ 1 0, γ 1 1 - γ 1 0 * j] :
       Matrix (Fin 2) (Fin 2) ℤ).det = 1 := by
     have hγdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 :=
-      Matrix.SpecialLinearGroup.det_fin_two γ
+      Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one γ
     rw [Matrix.det_fin_two_of]
     linear_combination hγdet + γ 1 0 * hm
   obtain ⟨δ, hδmat⟩ : ∃ δ : SL(2, ℤ), (δ : Matrix (Fin 2) (Fin 2) ℤ) =
@@ -184,7 +189,7 @@ lemma exists_mem_Gamma1_natDiagGL_mul_of_dvd (hp : 0 < p) {γ : SL(2, ℤ)} (hγ
     have e10 : (δ 1 0 : ℤ) = (p : ℤ) * γ 1 0 := by rw [hδmat]; simp
     have e11 : (δ 1 1 : ℤ) = γ 1 1 - γ 1 0 * j := by rw [hδmat]; simp
     rw [Units.val_mul, Units.val_mul, coe_natDiagGL_one hp, coe_upperTriRep,
-      coe_mapGL_fin_two γ, coe_mapGL_fin_two δ, e00, e01, e10, e11,
+      coe_mapGL_int_rat_fin_two γ, coe_mapGL_int_rat_fin_two δ, e00, e01, e10, e11,
       Matrix.mul_fin_two, Matrix.mul_fin_two]
     congrm !![?_, ?_; ?_, ?_]
     · ring1
@@ -241,7 +246,7 @@ theorem op_upperTriRep_smul_injective {G : Subgroup SL(2, ℤ)} :
   have hmat : (↑(mapGL ℚ σ) : Matrix (Fin 2) (Fin 2) ℚ) * !![1, (j₁ : ℚ); 0, (p : ℚ)] =
       !![1, (j₂ : ℚ); 0, (p : ℚ)] := by
     rw [← coe_upperTriRep, ← coe_upperTriRep, ← Units.val_mul, hmul]
-  rw [coe_mapGL_fin_two, Matrix.mul_fin_two] at hmat
+  rw [coe_mapGL_int_rat_fin_two, Matrix.mul_fin_two] at hmat
   have h00 : (σ 0 0 : ℤ) = 1 := by simpa using congrFun (congrFun hmat 0) 0
   have h01 : ((σ 0 0 : ℤ) : ℚ) * (j₁ : ℚ) + ((σ 0 1 : ℤ) : ℚ) * (p : ℚ) = (j₂ : ℚ) := by
     simpa using congrFun (congrFun hmat 0) 1
@@ -260,35 +265,6 @@ theorem op_upperTriRep_smul_injective {G : Subgroup SL(2, ℤ)} :
   have := Int.eq_zero_of_abs_lt_dvd hdvd habs
   exact Fin.ext (by omega)
 
-/-- A reusable right-coset decomposition criterion for the double coset of `diag(1, p)`.
-It packages the common set-theoretic argument from forward factorizations and reverse witnesses,
-independently of the chosen representative family. -/
-theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets_of {ι : Type*}
-    (rep : ι → GL (Fin 2) ℚ)
-    (hforward : ∀ γ : SL(2, ℤ), γ ∈ Gamma1 N →
-      ∃ (i : ι) (δ : SL(2, ℤ)), δ ∈ Gamma1 N ∧
-        natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * rep i)
-    (hreverse : ∀ i : ι, ∃ γ : SL(2, ℤ), γ ∈ Gamma1 N ∧
-      natDiagGL 2 ![1, p] * mapGL ℚ γ = rep i) :
-    doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ))
-        ((Gamma1 N).map (mapGL ℚ)) =
-      ⋃ i : ι, MulOpposite.op (rep i) •
-        ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  refine Set.Subset.antisymm (fun x hx ↦ ?_) (Set.iUnion_subset fun i x hx ↦ ?_)
-  · obtain ⟨g₁, hg₁, g₂, hg₂, rfl⟩ := mem_doubleCoset.mp hx
-    obtain ⟨γ₂, hγ₂, rfl⟩ := Subgroup.mem_map.mp hg₂
-    obtain ⟨i, δ, hδ, heq⟩ := hforward γ₂ hγ₂
-    refine Set.mem_iUnion.mpr ⟨i, (mem_rightCoset_iff _).mpr ?_⟩
-    have hx' : g₁ * natDiagGL 2 ![1, p] * mapGL ℚ γ₂ * (rep i)⁻¹ =
-        g₁ * mapGL ℚ δ := by
-      rw [mul_assoc g₁, heq, mul_assoc, mul_inv_cancel_right]
-    rw [hx']
-    exact mul_mem hg₁ (Subgroup.mem_map_of_mem _ hδ)
-  · obtain ⟨γ, hγ, hγeq⟩ := hreverse i
-    refine mem_doubleCoset.mpr ⟨x * (rep i)⁻¹, (mem_rightCoset_iff _).mp hx,
-      mapGL ℚ γ, Subgroup.mem_map_of_mem _ hγ, ?_⟩
-    rw [mul_assoc, hγeq, inv_mul_cancel_right]
-
 /-- **The `Tₚ` double coset at `p ∣ N` is the union of the `p` upper-triangular right cosets.**
 `Γ₁(N) · diag(1, p) · Γ₁(N) = ⋃_{j < p} Γ₁(N) · !![1, j; 0, p]`, Diamond–Shurman's
 Proposition 5.2.1 in the case `p ∣ N`.
@@ -300,15 +276,20 @@ theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets (hp : 0 < p) (hpN : p ∣ N)
     doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ j : Fin p, MulOpposite.op (upperTriRep p j) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  apply doubleCoset_natDiagGL_eq_iUnion_rightCosets_of (rep := upperTriRep p)
-  · exact fun γ hγ ↦ exists_mem_Gamma1_natDiagGL_mul hp hpN hγ
+  apply doubleCoset_eq_iUnion_rightCosets_of_forall_exists
+      ((Gamma1 N).map (mapGL ℚ)) (natDiagGL 2 ![1, p]) (upperTriRep p)
+  · intro g hg
+    obtain ⟨γ, hγ, rfl⟩ := Subgroup.mem_map.mp hg
+    obtain ⟨j, δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul hp hpN hγ
+    exact ⟨j, mapGL ℚ δ, Subgroup.mem_map_of_mem _ hδ, heq⟩
   · intro j
-    exact ⟨ModularGroup.T ^ (j : ℤ), T_zpow_mem_Gamma1 N _,
+    exact ⟨mapGL ℚ (ModularGroup.T ^ (j : ℤ)),
+      Subgroup.mem_map_of_mem _ (T_zpow_mem_Gamma1 N _),
       natDiagGL_mul_mapGL_T_zpow hp j⟩
 
 /-- The chosen representative of `diagCosetGamma1 N p` has the same double coset as the
 canonical matrix `diag(1, p)`. -/
-theorem doubleCoset_out_diagCosetGamma1_eq_natDiagGL :
+theorem doubleCoset_out_diagCosetGamma1_eq_doubleCoset_natDiagGL :
     doubleCoset ((diagCosetGamma1 N p).out : GL (Fin 2) ℚ)
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ))
@@ -325,7 +306,7 @@ theorem doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets (hp : 0 < p) (hpN 
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ j : Fin p, MulOpposite.op (upperTriRep p j) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  rw [doubleCoset_out_diagCosetGamma1_eq_natDiagGL,
+  rw [doubleCoset_out_diagCosetGamma1_eq_doubleCoset_natDiagGL,
     doubleCoset_natDiagGL_eq_iUnion_rightCosets hp hpN]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -164,9 +164,8 @@ lemma exists_mem_Gamma1_natDiagGL_mul_of_dvd (hp : 0 < p) {γ : SL(2, ℤ)} (hγ
   -- the new left factor
   have hdet : (!![γ 0 0, m; (p : ℤ) * γ 1 0, γ 1 1 - γ 1 0 * j] :
       Matrix (Fin 2) (Fin 2) ℤ).det = 1 := by
-    have hγdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := by
-      have := γ.2
-      rwa [Matrix.det_fin_two] at this
+    have hγdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 :=
+      Matrix.SpecialLinearGroup.det_fin_two γ
     rw [Matrix.det_fin_two_of]
     linear_combination hγdet + γ 1 0 * hm
   obtain ⟨δ, hδmat⟩ : ∃ δ : SL(2, ℤ), (δ : Matrix (Fin 2) (Fin 2) ℤ) =
@@ -261,6 +260,35 @@ theorem op_upperTriRep_smul_injective {G : Subgroup SL(2, ℤ)} :
   have := Int.eq_zero_of_abs_lt_dvd hdvd habs
   exact Fin.ext (by omega)
 
+/-- A reusable right-coset decomposition criterion for the double coset of `diag(1, p)`.
+It packages the common set-theoretic argument from forward factorizations and reverse witnesses,
+independently of the chosen representative family. -/
+theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets_of {ι : Type*}
+    (rep : ι → GL (Fin 2) ℚ)
+    (hforward : ∀ γ : SL(2, ℤ), γ ∈ Gamma1 N →
+      ∃ (i : ι) (δ : SL(2, ℤ)), δ ∈ Gamma1 N ∧
+        natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * rep i)
+    (hreverse : ∀ i : ι, ∃ γ : SL(2, ℤ), γ ∈ Gamma1 N ∧
+      natDiagGL 2 ![1, p] * mapGL ℚ γ = rep i) :
+    doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ))
+        ((Gamma1 N).map (mapGL ℚ)) =
+      ⋃ i : ι, MulOpposite.op (rep i) •
+        ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
+  refine Set.Subset.antisymm (fun x hx ↦ ?_) (Set.iUnion_subset fun i x hx ↦ ?_)
+  · obtain ⟨g₁, hg₁, g₂, hg₂, rfl⟩ := mem_doubleCoset.mp hx
+    obtain ⟨γ₂, hγ₂, rfl⟩ := Subgroup.mem_map.mp hg₂
+    obtain ⟨i, δ, hδ, heq⟩ := hforward γ₂ hγ₂
+    refine Set.mem_iUnion.mpr ⟨i, (mem_rightCoset_iff _).mpr ?_⟩
+    have hx' : g₁ * natDiagGL 2 ![1, p] * mapGL ℚ γ₂ * (rep i)⁻¹ =
+        g₁ * mapGL ℚ δ := by
+      rw [mul_assoc g₁, heq, mul_assoc, mul_inv_cancel_right]
+    rw [hx']
+    exact mul_mem hg₁ (Subgroup.mem_map_of_mem _ hδ)
+  · obtain ⟨γ, hγ, hγeq⟩ := hreverse i
+    refine mem_doubleCoset.mpr ⟨x * (rep i)⁻¹, (mem_rightCoset_iff _).mp hx,
+      mapGL ℚ γ, Subgroup.mem_map_of_mem _ hγ, ?_⟩
+    rw [mul_assoc, hγeq, inv_mul_cancel_right]
+
 /-- **The `Tₚ` double coset at `p ∣ N` is the union of the `p` upper-triangular right cosets.**
 `Γ₁(N) · diag(1, p) · Γ₁(N) = ⋃_{j < p} Γ₁(N) · !![1, j; 0, p]`, Diamond–Shurman's
 Proposition 5.2.1 in the case `p ∣ N`.
@@ -272,19 +300,22 @@ theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets (hp : 0 < p) (hpN : p ∣ N)
     doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ j : Fin p, MulOpposite.op (upperTriRep p j) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  refine Set.Subset.antisymm (fun x hx ↦ ?_) (Set.iUnion_subset fun j x hx ↦ ?_)
-  · obtain ⟨g₁, hg₁, g₂, hg₂, rfl⟩ := mem_doubleCoset.mp hx
-    obtain ⟨γ₂, hγ₂, rfl⟩ := Subgroup.mem_map.mp hg₂
-    obtain ⟨j, δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul hp hpN hγ₂
-    refine Set.mem_iUnion.mpr ⟨j, (mem_rightCoset_iff _).mpr ?_⟩
-    have hx' : g₁ * natDiagGL 2 ![1, p] * mapGL ℚ γ₂ * (upperTriRep p j)⁻¹ = g₁ * mapGL ℚ δ := by
-      rw [mul_assoc g₁, heq, mul_assoc, mul_inv_cancel_right]
-    rw [hx']
-    exact mul_mem hg₁ (Subgroup.mem_map_of_mem _ hδ)
-  · refine mem_doubleCoset.mpr ⟨x * (upperTriRep p j)⁻¹, (mem_rightCoset_iff _).mp hx,
-      mapGL ℚ (ModularGroup.T ^ (j : ℤ)),
-      Subgroup.mem_map_of_mem _ (T_zpow_mem_Gamma1 N _), ?_⟩
-    rw [mul_assoc, natDiagGL_mul_mapGL_T_zpow hp j, inv_mul_cancel_right]
+  apply doubleCoset_natDiagGL_eq_iUnion_rightCosets_of (rep := upperTriRep p)
+  · exact fun γ hγ ↦ exists_mem_Gamma1_natDiagGL_mul hp hpN hγ
+  · intro j
+    exact ⟨ModularGroup.T ^ (j : ℤ), T_zpow_mem_Gamma1 N _,
+      natDiagGL_mul_mapGL_T_zpow hp j⟩
+
+/-- The chosen representative of `diagCosetGamma1 N p` has the same double coset as the
+canonical matrix `diag(1, p)`. -/
+theorem doubleCoset_out_diagCosetGamma1_eq_natDiagGL :
+    doubleCoset ((diagCosetGamma1 N p).out : GL (Fin 2) ℚ)
+        ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
+      doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ))
+        ((Gamma1 N).map (mapGL ℚ)) := by
+  have hout : HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      (diagCosetGamma1 N p).out = diagCosetGamma1 N p := Quotient.out_eq _
+  rw [HeckeCoset.eq_iff.mp (hout.trans (diagCosetGamma1_def N p))]
 
 /-- The decomposition of `doubleCoset_natDiagGL_eq_iUnion_rightCosets`, read at the chosen
 representative `D.out` of `diagCosetGamma1 N p` — the shape the slash-sum machinery of
@@ -294,9 +325,7 @@ theorem doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets (hp : 0 < p) (hpN 
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ j : Fin p, MulOpposite.op (upperTriRep p j) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  have hout : HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
-      (diagCosetGamma1 N p).out = diagCosetGamma1 N p := Quotient.out_eq _
-  rw [HeckeCoset.eq_iff.mp (hout.trans (diagCosetGamma1_def N p)),
+  rw [doubleCoset_out_diagCosetGamma1_eq_natDiagGL,
     doubleCoset_natDiagGL_eq_iUnion_rightCosets hp hpN]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -58,6 +58,8 @@ infrastructure independent of the diamond operators.
   under conjugation by `Γ₀(N)` elements in `GL₂(ℝ)`.
 * `CongruenceSubgroup.Gamma0Map_toHomUnits_surjective`: every unit of `ZMod N` is the
   lower-right entry of a matrix in `Γ₀(N)` (via strong approximation for `SL₂`).
+* `CongruenceSubgroup.gamma0Twist`: an explicit `Γ₀(N)` element whose lower-right entry is any
+  natural number coprime to `N`.
 * `CongruenceSubgroup.neg_one_mem_Gamma0` and
   `CongruenceSubgroup.Gamma0Map_toHomUnits_negOne`: `-I ∈ Γ₀(N)`, with lower-right entry the
   unit `-1`; `CongruenceSubgroup.neg_one_mem_Gamma1_iff`: `-I ∈ Γ₁(N) ↔ N ∣ 2`.
@@ -226,6 +228,55 @@ theorem Gamma0Map_toHomUnits_surjective :
   have h11 : ((g 1 1 : ℤ) : ZMod N) = u := by rw [hentry]; simp
   exact ⟨⟨g, Gamma0_mem.mpr h10⟩, Units.ext (by simpa [Gamma0Map] using h11)⟩
 
+/-- The bottom row of an `SL₂(ℤ)` matrix is a Bézout relation: if it is `(N, p)`, then its
+top row `(m, n)` satisfies `m p - n N = 1`. -/
+lemma bezout_of_lowerRow {p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := by
+  simpa only [hσ10, hσ11] using Matrix.SpecialLinearGroup.det_fin_two σ
+
+/-- A bottom row `(N, p)` of an `SL₂(ℤ)` matrix forces `p` and `N` to be coprime. -/
+lemma coprime_of_lowerRow {p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) : Nat.Coprime p N :=
+  Nat.isCoprime_iff_coprime.mp (by
+    rw [← hσ10, ← hσ11]
+    exact (isCoprime_row σ 1).symm)
+
+/-- If the bottom row of `σ ∈ SL₂(ℤ)` is `(N, p)`, then its upper-left entry satisfies
+`m p = 1` in `ZMod N`. -/
+lemma intCast_mul_of_lowerRow {p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
+    (hσ11 : σ 1 1 = (p : ℤ)) : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
+  have h := congrArg (Int.cast : ℤ → ZMod N) (bezout_of_lowerRow hσ10 hσ11)
+  push_cast at h ⊢
+  rw [ZMod.natCast_self] at h
+  linear_combination h
+
+/-- A Bézout matrix with bottom row `(N, p)`, for `p` coprime to `N`. -/
+noncomputable def gamma0Twist (N p : ℕ) (h : Nat.Coprime p N) : SL(2, ℤ) :=
+  ((Nat.isCoprime_iff_coprime.mpr h.symm : IsCoprime (N : ℤ) (p : ℤ)).exists_SL2_row 1).choose
+
+/-- The lower-left entry of the Bézout twist is `N`. -/
+@[simp] lemma gamma0Twist_apply_one_zero {p : ℕ} (h : Nat.Coprime p N) :
+    gamma0Twist N p h 1 0 = (N : ℤ) := by
+  exact ((Nat.isCoprime_iff_coprime.mpr h.symm :
+    IsCoprime (N : ℤ) (p : ℤ)).exists_SL2_row 1).choose_spec.1
+
+/-- The lower-right entry of the Bézout twist is `p`. -/
+@[simp] lemma gamma0Twist_apply_one_one {p : ℕ} (h : Nat.Coprime p N) :
+    gamma0Twist N p h 1 1 = (p : ℤ) := by
+  exact ((Nat.isCoprime_iff_coprime.mpr h.symm :
+    IsCoprime (N : ℤ) (p : ℤ)).exists_SL2_row 1).choose_spec.2
+
+/-- The Bézout twist lies in `Γ₀(N)`. -/
+lemma gamma0Twist_mem_Gamma0 {p : ℕ} (h : Nat.Coprime p N) : gamma0Twist N p h ∈ Gamma0 N := by
+  rw [Gamma0_mem, gamma0Twist_apply_one_zero h]
+  simp
+
+/-- The unit-valued lower-right entry of the Bézout twist is the residue class of `p`. -/
+lemma Gamma0Map_toHomUnits_gamma0Twist {p : ℕ} (h : Nat.Coprime p N) :
+    (Gamma0Map N).toHomUnits ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩ =
+      ZMod.unitOfCoprime p h :=
+  Units.ext (by simp [Gamma0Map, gamma0Twist_apply_one_one h])
+
 /-- `-I` lies in `Γ₀(N)`: its lower-left entry is `0`. -/
 theorem neg_one_mem_Gamma0 : (-1 : SL(2, ℤ)) ∈ Gamma0 N := by
   simp
@@ -270,7 +321,7 @@ is `p` via lower-unitriangular representatives, and the tower multiplies to
 `[SL₂(ℤ) : Γ₀(pᵏ)] = p^(k-1)(p + 1)` for prime `p` and `k ≥ 1` — the degree count of
 Shimura, Theorem 3.24. -/
 
-private lemma exists_dvd_sub_val_mul (p : ℕ) [NeZero p] (a b : ℤ)
+lemma exists_dvd_sub_val_mul (p : ℕ) [NeZero p] (a b : ℤ)
     (hb : IsUnit ((b : ℤ) : ZMod p)) : ∃ j : ZMod p, (p : ℤ) ∣ a - (j.val : ℤ) * b := by
   obtain ⟨u, hu⟩ := hb
   refine ⟨(a : ZMod p) * ↑u⁻¹, ?_⟩

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -136,7 +136,8 @@ identity `ad - bc = 1` with the `bc` term killed by `M ∣ c`. It refines
 theorem intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 {M : ℕ}
     {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma0 M) :
     ((γ 0 0 : ℤ) : ZMod M) * ((γ 1 1 : ℤ) : ZMod M) = 1 := by
-  have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := Matrix.det_fin_two γ.1 ▸ γ.2
+  have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 :=
+    Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one γ
   have h := congrArg (Int.cast : ℤ → ZMod M) hdet
   push_cast at h
   rw [Gamma0_mem.mp hγ] at h
@@ -148,7 +149,7 @@ theorem isUnit_intCast_apply_zero_zero_of_mem_Gamma0 {N : ℕ} {σ : SL(2, ℤ)}
     IsUnit ((σ.1 0 0 : ℤ) : ZMod N) := by
   have h10 : ((σ.1 1 0 : ℤ) : ZMod N) = 0 := Gamma0_mem.mp hσ
   have hdet : σ.1 0 0 * σ.1 1 1 - σ.1 0 1 * σ.1 1 0 = 1 :=
-    Matrix.det_fin_two σ.1 ▸ σ.2
+    Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one σ
   have hcast := congrArg (fun z : ℤ ↦ (z : ZMod N)) hdet
   push_cast at hcast
   rw [h10, mul_zero, sub_zero] at hcast

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -10,6 +10,7 @@ public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
 
 import Mathlib.Algebra.Field.ZMod
+import TauCeti.Data.ZMod.Divisibility
 
 /-!
 # Congruence subgroups: the pair `Γ₁(N) ⊴ Γ₀(N)`, the index of `Γ₀(pᵏ)`, and the level
@@ -228,28 +229,6 @@ theorem Gamma0Map_toHomUnits_surjective :
   have h11 : ((g 1 1 : ℤ) : ZMod N) = u := by rw [hentry]; simp
   exact ⟨⟨g, Gamma0_mem.mpr h10⟩, Units.ext (by simpa [Gamma0Map] using h11)⟩
 
-/-- The bottom row of an `SL₂(ℤ)` matrix is a Bézout relation: if it is `(N, p)`, then its
-top row `(m, n)` satisfies `m p - n N = 1`. -/
-lemma bezout_of_lowerRow {p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
-    (hσ11 : σ 1 1 = (p : ℤ)) : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := by
-  simpa only [hσ10, hσ11] using Matrix.SpecialLinearGroup.det_fin_two σ
-
-/-- A bottom row `(N, p)` of an `SL₂(ℤ)` matrix forces `p` and `N` to be coprime. -/
-lemma coprime_of_lowerRow {p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
-    (hσ11 : σ 1 1 = (p : ℤ)) : Nat.Coprime p N :=
-  Nat.isCoprime_iff_coprime.mp (by
-    rw [← hσ10, ← hσ11]
-    exact (isCoprime_row σ 1).symm)
-
-/-- If the bottom row of `σ ∈ SL₂(ℤ)` is `(N, p)`, then its upper-left entry satisfies
-`m p = 1` in `ZMod N`. -/
-lemma intCast_mul_of_lowerRow {p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
-    (hσ11 : σ 1 1 = (p : ℤ)) : ((σ 0 0 * (p : ℤ) : ℤ) : ZMod N) = 1 := by
-  have h := congrArg (Int.cast : ℤ → ZMod N) (bezout_of_lowerRow hσ10 hσ11)
-  push_cast at h ⊢
-  rw [ZMod.natCast_self] at h
-  linear_combination h
-
 /-- A Bézout matrix with bottom row `(N, p)`, for `p` coprime to `N`. -/
 noncomputable def gamma0Twist (N p : ℕ) (h : Nat.Coprime p N) : SL(2, ℤ) :=
   ((Nat.isCoprime_iff_coprime.mpr h.symm : IsCoprime (N : ℤ) (p : ℤ)).exists_SL2_row 1).choose
@@ -321,17 +300,6 @@ is `p` via lower-unitriangular representatives, and the tower multiplies to
 `[SL₂(ℤ) : Γ₀(pᵏ)] = p^(k-1)(p + 1)` for prime `p` and `k ≥ 1` — the degree count of
 Shimura, Theorem 3.24. -/
 
-lemma exists_dvd_sub_val_mul (p : ℕ) [NeZero p] (a b : ℤ)
-    (hb : IsUnit ((b : ℤ) : ZMod p)) : ∃ j : ZMod p, (p : ℤ) ∣ a - (j.val : ℤ) * b := by
-  obtain ⟨u, hu⟩ := hb
-  refine ⟨(a : ZMod p) * ↑u⁻¹, ?_⟩
-  rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
-  push_cast
-  rw [ZMod.natCast_zmod_val, mul_assoc]
-  -- the coerced product collapses: `↑b = ↑u` by `hu`, and `u⁻¹ * u = 1` in the units
-  have hunit : (↑u⁻¹ * ((b : ℤ) : ZMod p) : ZMod p) = 1 := by rw [← hu, Units.inv_mul]
-  rw [hunit, mul_one, sub_self]
-
 section BaseCase
 
 open ModularGroup
@@ -398,7 +366,7 @@ private lemma Gamma0_prime_index_surj :
       obtain ⟨j, hj⟩ : ∃ j : ZMod p, j * ((σ.1 1 0 : ℤ) : ZMod p) = 1 :=
         Finite.surjective_of_injective (mul_left_injective₀ h) 1
       exact IsUnit.of_mul_eq_one _ (by rwa [mul_comm] at hj)
-    obtain ⟨j₀, hj₀⟩ := exists_dvd_sub_val_mul p (σ.1 0 0) (σ.1 1 0) hunit
+    obtain ⟨j₀, hj₀⟩ := ZMod.exists_dvd_sub_val_mul p (σ.1 0 0) (σ.1 1 0) hunit
     refine ⟨⟨j₀.val, Nat.lt_succ_of_lt (ZMod.val_lt j₀)⟩, ?_⟩
     rw [QuotientGroup.eq, Gamma0_mem]
     simp only [Gamma0Rep, ZMod.val_lt j₀, ite_true]
@@ -471,7 +439,7 @@ private lemma Gamma0_relindex_step_surj (k : ℕ) (hk : 0 < k) :
     isUnit_intCast_apply_zero_zero_of_mem_Gamma0 (Gamma0_mem.mpr (by
       rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
       exact hq ▸ dvd_mul_of_dvd_left (dvd_pow_self _ hk.ne') q))
-  obtain ⟨c₀, hc₀⟩ := exists_dvd_sub_val_mul p q (σ.1 0 0) h00_unit
+  obtain ⟨c₀, hc₀⟩ := ZMod.exists_dvd_sub_val_mul p q (σ.1 0 0) h00_unit
   refine ⟨⟨c₀.val, ZMod.val_lt c₀⟩, ?_⟩
   rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]
   simp only [relindexRep, InvMemClass.coe_inv, MulMemClass.coe_mul]

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -309,7 +309,7 @@ determinant one. -/
 def conjScale (d : ℕ) (γ : SL(2, ℤ)) (c : ℤ) (hc : γ 1 0 = d * c) : SL(2, ℤ) :=
   ⟨!![γ 0 0, (d : ℤ) * γ 0 1; c, γ 1 1], by
     have hdet : (γ 0 0) * (γ 1 1) - (γ 0 1) * (γ 1 0) = 1 :=
-      Matrix.SpecialLinearGroup.det_fin_two γ
+      Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one γ
     rw [hc] at hdet
     rw [Matrix.det_fin_two_of]
     linarith [hdet]⟩

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -308,8 +308,8 @@ entries are rearranged as `(a, b; d c, e) ↦ (a, d b; c, e)`, which is again in
 determinant one. -/
 def conjScale (d : ℕ) (γ : SL(2, ℤ)) (c : ℤ) (hc : γ 1 0 = d * c) : SL(2, ℤ) :=
   ⟨!![γ 0 0, (d : ℤ) * γ 0 1; c, γ 1 1], by
-    have hdet : (γ 0 0) * (γ 1 1) - (γ 0 1) * (γ 1 0) = 1 := by
-      have := γ.2; rwa [Matrix.det_fin_two] at this
+    have hdet : (γ 0 0) * (γ 1 1) - (γ 0 1) * (γ 1 0) = 1 :=
+      Matrix.SpecialLinearGroup.det_fin_two γ
     rw [hc] at hdet
     rw [Matrix.det_fin_two_of]
     linarith [hdet]⟩

--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -39,7 +39,7 @@ re-founded slash action with built-in character) and their names. The Hecke pair
   by `coe_diamondOp`/`coe_diamondOpCusp` as slashing by any representative.
 * `diamondOpHom`/`diamondOpCuspHom`: the diamond operators as monoid homomorphisms into the
   endomorphism algebras.
-* `diamondOpNat`: the same operator indexed by a natural number, `⟨n⟩` of
+* `diamondOpNat`/`diamondOpCuspNat`: the same operator indexed by a natural number, `⟨n⟩` of
   Diamond–Shurman §5.3, extended by zero when `n` is not coprime to `N`.
 * `modFormCharSpace`/`cuspFormCharSpace`: the nebentypus character spaces `M_k(Γ₁(N), χ)` and
   `S_k(Γ₁(N), χ)`, cut out as simultaneous diamond eigenspaces.
@@ -367,4 +367,24 @@ Hecke recurrence be stated without splitting on whether `p` divides the level. -
 @[simp]
 lemma diamondOpNat_of_not_coprime (k : ℤ) {n : ℕ} (h : ¬ Nat.Coprime n N) :
     diamondOpNat (N := N) k n = 0 :=
+  dite_eq_right_of_eq_false (by simpa using h)
+
+/-- The cusp-form diamond operator indexed by a natural number: `⟨n⟩` is `diamondOpCusp` at the
+unit `n mod N` when `n` is coprime to `N`, and `0` otherwise — the cusp-form counterpart of
+`diamondOpNat`, and the reason the prime Hecke operator on `S_k(Γ₁(N))` has one formula at every
+prime rather than one per divisibility case. -/
+noncomputable def diamondOpCuspNat (k : ℤ) (n : ℕ) :
+    CuspForm ((Gamma1 N).map (mapGL ℝ)) k →ₗ[ℂ] CuspForm ((Gamma1 N).map (mapGL ℝ)) k :=
+  if h : Nat.Coprime n N then diamondOpCusp k (ZMod.unitOfCoprime n h) else 0
+
+/-- When `n` is coprime to `N`, `⟨n⟩` is the cusp diamond operator at the unit `n mod N`. -/
+-- Not a `simp` lemma, for the reason given at `diamondOpNat_of_coprime`.
+lemma diamondOpCuspNat_of_coprime (k : ℤ) {n : ℕ} (h : Nat.Coprime n N) :
+    diamondOpCuspNat k n = diamondOpCusp k (ZMod.unitOfCoprime n h) :=
+  dite_eq_left_of_eq_true (by simpa using h)
+
+/-- When `n` is not coprime to `N`, `⟨n⟩` vanishes on cusp forms. -/
+@[simp]
+lemma diamondOpCuspNat_of_not_coprime (k : ℤ) {n : ℕ} (h : ¬ Nat.Coprime n N) :
+    diamondOpCuspNat (N := N) k n = 0 :=
   dite_eq_right_of_eq_false (by simpa using h)

--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.Eigenspace.Basic
 public import TauCeti.NumberTheory.ModularForms.Basic
 public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
+public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 
 /-!
 # Diamond operators and modular forms with character
@@ -49,6 +50,10 @@ re-founded slash action with built-in character) and their names. The Hecke pair
 * `mem_modFormCharSpace_iff_nebentypus`/`mem_cuspFormCharSpace_iff_nebentypus`: membership in the
   character space is the classical nebentypus relation `f ∣[k] g = χ(d_g) • f` for all
   `g ∈ Γ₀(N)`.
+* `slash_mapGL_eq_diamondOpNat`/`slash_mapGL_eq_diamondOpCuspNat`: rational slashing by a
+  suitable `Γ₀(N)` representative is the corresponding natural-indexed diamond operator;
+  `slash_mapGL_gamma0Twist_eq_diamondOpNat` and its cusp counterpart specialize to the explicit
+  Bézout representative.
 
 ## References
 
@@ -388,3 +393,35 @@ lemma diamondOpCuspNat_of_coprime (k : ℤ) {n : ℕ} (h : Nat.Coprime n N) :
 lemma diamondOpCuspNat_of_not_coprime (k : ℤ) {n : ℕ} (h : ¬ Nat.Coprime n N) :
     diamondOpCuspNat (N := N) k n = 0 :=
   dite_eq_right_of_eq_false (by simpa using h)
+
+/-- Slashing by a `Γ₀(N)` representative with lower-right unit `n` is the zero-extended
+diamond operator `⟨n⟩` on modular forms. -/
+theorem slash_mapGL_eq_diamondOpNat {n : ℕ} (k : ℤ) (h : Nat.Coprime n N)
+    (g : ↥(Gamma0 N)) (hg : (Gamma0Map N).toHomUnits g = ZMod.unitOfCoprime n h)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑f ∣[k] (mapGL ℚ (g : SL(2, ℤ)) : GL (Fin 2) ℚ) = ⇑(diamondOpNat k n f) := by
+  rw [ModularForm.rat_slash_mapGL, diamondOpNat_of_coprime k h, coe_diamondOp k _ g hg f]
+
+/-- The cusp-form counterpart of `slash_mapGL_eq_diamondOpNat`. -/
+theorem slash_mapGL_eq_diamondOpCuspNat {n : ℕ} (k : ℤ) (h : Nat.Coprime n N)
+    (g : ↥(Gamma0 N)) (hg : (Gamma0Map N).toHomUnits g = ZMod.unitOfCoprime n h)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑f ∣[k] (mapGL ℚ (g : SL(2, ℤ)) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k n f) := by
+  rw [ModularForm.rat_slash_mapGL, diamondOpCuspNat_of_coprime k h,
+    coe_diamondOpCusp k _ g hg f]
+
+/-- **Slashing by the Bézout twist is the diamond operator `⟨p⟩`.** The twist is the `Γ₀(N)`
+element of lower-right entry `p`, so this is `coe_diamondOp` at that representative, transported
+across the `ℚ`/`ℝ` bridge. -/
+theorem slash_mapGL_gamma0Twist_eq_diamondOpNat {p : ℕ} (k : ℤ) (h : Nat.Coprime p N)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpNat k p f) :=
+  slash_mapGL_eq_diamondOpNat k h ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
+    (Gamma0Map_toHomUnits_gamma0Twist h) f
+
+/-- **Slashing by the Bézout twist is the diamond operator `⟨p⟩`**, on cusp forms. -/
+theorem slash_mapGL_gamma0Twist_eq_diamondOpCuspNat {p : ℕ} (k : ℤ) (h : Nat.Coprime p N)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k p f) :=
+  slash_mapGL_eq_diamondOpCuspNat k h ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
+    (Gamma0Map_toHomUnits_gamma0Twist h) f

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.CoprimeCosets
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.DoubleCoset
+
+/-!
+# The classical `Tₚ` on `M_k(Γ₁(N))` and `S_k(Γ₁(N))`, at every prime
+
+`HeckeSlash/UpperTri/DoubleCoset.lean` identifies the Hecke operator of the double coset
+`Γ₁(N) · diag(1, p) · Γ₁(N)` with the upper-triangular sum `∑_{b < p} f ∣[k] !![1, b; 0, p]`,
+but only for `p ∣ N`, because only there do the `p` upper-triangular matrices exhaust the coset.
+With the good-prime decomposition of `HeckeRing/GL2/Gamma1/CoprimeCosets.lean` in hand, this file
+completes the identification at every prime:
+
+`Tₚ f = ∑_{b < p} f ∣[k] !![1, b; 0, p]  +  (⟨p⟩ f) ∣[k] !![p, 0; 0, 1]`.
+
+**One formula, both cases.** The extra term is not conditional. At `p ∤ N` it is the slash by the
+twisted representative `σ · diag(p, 1)`, and slashing by `σ ∈ Γ₀(N)` — an element with lower-right
+entry `p` — is by definition the diamond operator `⟨p⟩` (`slash_mapGL_gamma0Twist`). At `p ∣ N`
+the zero-extended `⟨p⟩` of `DiamondOperators.lean` *vanishes*, so the term disappears and the
+formula degenerates to the `p ∣ N` statement already proved. That is exactly the uniformity the
+ModularForms roadmap asks for: `Tₚ` is one operator, defined for every `p`, with the modern `Uₚ`
+recovered as the `p ∣ N` case and not introduced separately.
+
+⚠ The twist is essential and is not `heckeSlashUpperTriAddScale`. Over `Γ₁(N)` the untwisted
+`f ∣[k] !![p, 0; 0, 1]` is *not* a term of the coset sum; only after applying `⟨p⟩` does the
+matrix `σ · diag(p, 1)` represent the missing right coset. On a form of nebentypus `χ` the
+diamond acts by the scalar `χ(p)`, which is where the classical factor `χ(p)` in
+`aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k−1} a_{m/p}(f)` comes from
+(`coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace`); the two spellings
+agree exactly when `χ(p) = 1`.
+
+## Main results
+
+* `HeckeRing.GL2.slash_mapGL_gamma0Twist`, `HeckeRing.GL2.slash_mapGL_gamma0Twist_cusp`: slashing
+  by the Bézout twist is the diamond operator `⟨p⟩`.
+* `HeckeRing.GL2.heckeSlashSum_diagCosetGamma1_of_coprime`: the slash sum of the double coset at
+  a prime `p ∤ N`, over the `p + 1` representatives.
+* `HeckeRing.GL2.coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_prime`,
+  `HeckeRing.GL2.coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_prime`: **the classical `Tₚ`,
+  at every prime**, on `M_k(Γ₁(N))` and on `S_k(Γ₁(N))`.
+* `HeckeRing.GL2.coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace` and
+  its cusp-form counterpart: the same formula on a nebentypus space, with the diamond replaced by
+  the scalar `χ(p)`.
+
+## Provenance
+
+No code is transcribed. The shape of the formula is that of `heckeT_p_fun` in the AINTLIB
+`LeanModularForms` project (`HeckeRIngs/GL2/HeckeT_p.lean`, Chris Birkbeck, Apache-2.0), whose
+extra term likewise carries the diamond operator; the derivation here goes through the abstract
+double coset and this repository's own coset decomposition rather than through a bespoke
+definition of the operator.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Proposition 5.2.1 and §5.2–5.3.
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.5.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
+  HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm
+
+namespace HeckeRing.GL2
+
+variable {N p : ℕ} (k : ℤ)
+
+/-- **Slashing by the Bézout twist is the diamond operator `⟨p⟩`.** The twist is the `Γ₀(N)`
+element of lower-right entry `p`, so this is `coe_diamondOp` at that representative, transported
+across the `ℚ`/`ℝ` bridge. -/
+theorem slash_mapGL_gamma0Twist (h : Nat.Coprime p N)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpNat k p f) := by
+  rw [ModularForm.rat_slash_mapGL, diamondOpNat_of_coprime k h,
+    coe_diamondOp k _ ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
+      (gamma0Twist_toHomUnits_Gamma0Map h) f]
+
+/-- **Slashing by the Bézout twist is the diamond operator `⟨p⟩`**, on cusp forms. -/
+theorem slash_mapGL_gamma0Twist_cusp (h : Nat.Coprime p N)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k p f) := by
+  rw [ModularForm.rat_slash_mapGL, diamondOpCuspNat_of_coprime k h,
+    coe_diamondOpCusp k _ ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
+      (gamma0Twist_toHomUnits_Gamma0Map h) f]
+
+variable [NeZero N]
+
+/-- **The slash sum of the `Tₚ` double coset at a prime `p ∤ N`.** This is
+`heckeSlashSum_coe_eq_sum_of_rightCosets` fed with the `p + 1`-fold decomposition of
+`HeckeRing/GL2/Gamma1/CoprimeCosets.lean`; slash-invariance of `f`, the one hypothesis that lemma
+needs, is carried by the form class. -/
+theorem heckeSlashSum_diagCosetGamma1_of_coprime (hp : p.Prime) (h : Nat.Coprime p N)
+    {F : Type*} [FunLike F ℍ ℂ] [SlashInvariantFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (f : F) :
+    heckeSlashSum k (diagCosetGamma1 N p) ⇑f =
+      heckeSlashUpperTri k p ⇑f + ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) * scaleRep p) := by
+  rw [heckeSlashSum_coe_eq_sum_of_rightCosets k (diagCosetGamma1 N p)
+      (primeRep (gamma0Twist N p h) p)
+      (doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets_of_prime hp
+        (gamma0Twist_apply_one_zero h) (gamma0Twist_apply_one_one h))
+      (op_primeRep_smul_injective hp (gamma0Twist_apply_one_zero h)
+        (gamma0Twist_apply_one_one h)) f,
+    Fintype.sum_option, heckeSlashUpperTri_def]
+  simp only [primeRep_some, primeRep_none]
+  exact add_comm _ _
+
+/-- **The classical `Tₚ` on `M_k(Γ₁(N))`, at every prime.** The Hecke operator of the double
+coset `Γ₁(N) · diag(1, p) · Γ₁(N)` is
+
+`Tₚ f = ∑_{b < p} f ∣[k] !![1, b; 0, p] + (⟨p⟩ f) ∣[k] !![p, 0; 0, 1]`,
+
+with **no** case split on whether `p` divides the level: at `p ∣ N` the zero-extended diamond
+`⟨p⟩` vanishes and the formula reduces to the upper-triangular sum, the operator modern papers
+write `Uₚ`. -/
+theorem coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_prime (hp : p.Prime)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeSlashGamma1ModularFormEnd k (diagCosetGamma1 N p) f) =
+      heckeSlashUpperTri k p ⇑f + ⇑(diamondOpNat k p f) ∣[k] scaleRep p := by
+  rw [coe_heckeSlashGamma1ModularFormEnd]
+  by_cases h : Nat.Coprime p N
+  · rw [heckeSlashSum_diagCosetGamma1_of_coprime k hp h f, SlashAction.slash_mul,
+      slash_mapGL_gamma0Twist k h f]
+  · have hpN : p ∣ N := by
+      by_contra hnd
+      exact h ((Nat.Prime.coprime_iff_not_dvd hp).mpr hnd)
+    rw [heckeSlashSum_diagCosetGamma1 k hpN f, diamondOpNat_of_not_coprime k h]
+    simp
+
+/-- **The classical `Tₚ` on `S_k(Γ₁(N))`, at every prime** — the same formula, with the
+cusp-form diamond operator. -/
+theorem coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_prime (hp : p.Prime)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeSlashGamma1CuspFormEnd k (diagCosetGamma1 N p) f) =
+      heckeSlashUpperTri k p ⇑f + ⇑(diamondOpCuspNat k p f) ∣[k] scaleRep p := by
+  rw [coe_heckeSlashGamma1CuspFormEnd]
+  by_cases h : Nat.Coprime p N
+  · rw [heckeSlashSum_diagCosetGamma1_of_coprime k hp h f, SlashAction.slash_mul,
+      slash_mapGL_gamma0Twist_cusp k h f]
+  · have hpN : p ∣ N := by
+      by_contra hnd
+      exact h ((Nat.Prime.coprime_iff_not_dvd hp).mpr hnd)
+    rw [heckeSlashSum_diagCosetGamma1 k hpN f, diamondOpCuspNat_of_not_coprime k h]
+    simp
+
+/-- **`Tₚ` on a nebentypus space `M_k(N, χ)`, at a prime `p ∤ N`.** The diamond acts by the
+scalar `χ(p)`, giving Diamond–Shurman's
+
+`Tₚ f = ∑_{b < p} f ∣[k] !![1, b; 0, p] + χ(p) · f ∣[k] !![p, 0; 0, 1]`,
+
+the slash-level form of the coefficient recurrence
+`aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k−1} a_{m/p}(f)`. -/
+theorem coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace (hp : p.Prime)
+    (h : Nat.Coprime p N) (χ : (ZMod N)ˣ →* ℂˣ)
+    {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ modFormCharSpace k χ) :
+    ⇑(heckeSlashGamma1ModularFormEnd k (diagCosetGamma1 N p) f) =
+      heckeSlashUpperTri k p ⇑f + (χ (ZMod.unitOfCoprime p h) : ℂ) • (⇑f ∣[k] scaleRep p) := by
+  rw [coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_prime k hp f,
+    diamondOpNat_of_coprime k h, diamondOp_apply_of_mem_modFormCharSpace k χ _ hf]
+  congr 1
+  exact ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p) ⇑f _
+
+/-- **`Tₚ` on a nebentypus space `S_k(N, χ)`, at a prime `p ∤ N`.** -/
+theorem coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace (hp : p.Prime)
+    (h : Nat.Coprime p N) (χ : (ZMod N)ˣ →* ℂˣ)
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
+    ⇑(heckeSlashGamma1CuspFormEnd k (diagCosetGamma1 N p) f) =
+      heckeSlashUpperTri k p ⇑f + (χ (ZMod.unitOfCoprime p h) : ℂ) • (⇑f ∣[k] scaleRep p) := by
+  rw [coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_prime k hp f,
+    diamondOpCuspNat_of_coprime k h, diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ _ hf]
+  congr 1
+  exact ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p) ⇑f _
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
@@ -21,14 +21,15 @@ completes the identification at every prime:
 
 **One formula, both cases.** The extra term is not conditional. At `p ∤ N` it is the slash by the
 twisted representative `σ · diag(p, 1)`, and slashing by `σ ∈ Γ₀(N)` — an element with lower-right
-entry `p` — is by definition the diamond operator `⟨p⟩` (`slash_mapGL_gamma0Twist`). At `p ∣ N`
+entry `p` — is by definition the diamond operator `⟨p⟩`
+(`slash_mapGL_gamma0Twist_eq_diamondOpNat`). At `p ∣ N`
 the zero-extended `⟨p⟩` of `DiamondOperators.lean` *vanishes*, so the term disappears and the
 formula degenerates to the `p ∣ N` statement already proved. That is exactly the uniformity the
 ModularForms roadmap asks for: `Tₚ` is one operator, defined for every `p`, with the modern `Uₚ`
 recovered as the `p ∣ N` case and not introduced separately.
 
-⚠ The twist is essential and is not `heckeSlashUpperTriAddScale`. Over `Γ₁(N)` the untwisted
-`f ∣[k] !![p, 0; 0, 1]` is *not* a term of the coset sum; only after applying `⟨p⟩` does the
+⚠ The twist is essential. Over `Γ₁(N)` the untwisted `f ∣[k] !![p, 0; 0, 1]` is *not* a term
+of the coset sum; only after applying `⟨p⟩` does the
 matrix `σ · diag(p, 1)` represent the missing right coset. On a form of nebentypus `χ` the
 diamond acts by the scalar `χ(p)`, which is where the classical factor `χ(p)` in
 `aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k−1} a_{m/p}(f)` comes from
@@ -37,12 +38,13 @@ agree exactly when `χ(p) = 1`.
 
 ## Main results
 
-* `HeckeRing.GL2.slash_mapGL_gamma0Twist`, `HeckeRing.GL2.slash_mapGL_gamma0Twist_cusp`: slashing
-  by the Bézout twist is the diamond operator `⟨p⟩`.
+* `HeckeRing.GL2.slash_mapGL_eq_diamondOpNat` and its cusp-form counterpart: slashing by any
+  suitable `Γ₀(N)` representative is the corresponding diamond operator; the
+  `slash_mapGL_gamma0Twist_eq_*` lemmas specialize them to the Bézout twist.
 * `HeckeRing.GL2.heckeSlashSum_diagCosetGamma1_of_coprime`: the slash sum of the double coset at
   a prime `p ∤ N`, over the `p + 1` representatives.
-* `HeckeRing.GL2.coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_prime`,
-  `HeckeRing.GL2.coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_prime`: **the classical `Tₚ`,
+* `HeckeRing.GL2.coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime`,
+  `HeckeRing.GL2.coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime`: **the classical `Tₚ`,
   at every prime**, on `M_k(Γ₁(N))` and on `S_k(Γ₁(N))`.
 * `HeckeRing.GL2.coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace` and
   its cusp-form counterpart: the same formula on a nebentypus space, with the diamond replaced by
@@ -75,23 +77,37 @@ namespace HeckeRing.GL2
 
 variable {N p : ℕ} (k : ℤ)
 
+/-- Slashing by a `Γ₀(N)` representative with lower-right unit `n` is the zero-extended
+diamond operator `⟨n⟩` on modular forms. -/
+theorem slash_mapGL_eq_diamondOpNat {n : ℕ} (h : Nat.Coprime n N) (g : ↥(Gamma0 N))
+    (hg : (Gamma0Map N).toHomUnits g = ZMod.unitOfCoprime n h)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑f ∣[k] (mapGL ℚ (g : SL(2, ℤ)) : GL (Fin 2) ℚ) = ⇑(diamondOpNat k n f) := by
+  rw [ModularForm.rat_slash_mapGL, diamondOpNat_of_coprime k h, coe_diamondOp k _ g hg f]
+
+/-- The cusp-form counterpart of `slash_mapGL_eq_diamondOpNat`. -/
+theorem slash_mapGL_eq_diamondOpCuspNat {n : ℕ} (h : Nat.Coprime n N) (g : ↥(Gamma0 N))
+    (hg : (Gamma0Map N).toHomUnits g = ZMod.unitOfCoprime n h)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑f ∣[k] (mapGL ℚ (g : SL(2, ℤ)) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k n f) := by
+  rw [ModularForm.rat_slash_mapGL, diamondOpCuspNat_of_coprime k h,
+    coe_diamondOpCusp k _ g hg f]
+
 /-- **Slashing by the Bézout twist is the diamond operator `⟨p⟩`.** The twist is the `Γ₀(N)`
 element of lower-right entry `p`, so this is `coe_diamondOp` at that representative, transported
 across the `ℚ`/`ℝ` bridge. -/
-theorem slash_mapGL_gamma0Twist (h : Nat.Coprime p N)
+theorem slash_mapGL_gamma0Twist_eq_diamondOpNat (h : Nat.Coprime p N)
     (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
-    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpNat k p f) := by
-  rw [ModularForm.rat_slash_mapGL, diamondOpNat_of_coprime k h,
-    coe_diamondOp k _ ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
-      (gamma0Twist_toHomUnits_Gamma0Map h) f]
+    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpNat k p f) :=
+  slash_mapGL_eq_diamondOpNat k h ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
+    (Gamma0Map_toHomUnits_gamma0Twist h) f
 
 /-- **Slashing by the Bézout twist is the diamond operator `⟨p⟩`**, on cusp forms. -/
-theorem slash_mapGL_gamma0Twist_cusp (h : Nat.Coprime p N)
+theorem slash_mapGL_gamma0Twist_eq_diamondOpCuspNat (h : Nat.Coprime p N)
     (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
-    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k p f) := by
-  rw [ModularForm.rat_slash_mapGL, diamondOpCuspNat_of_coprime k h,
-    coe_diamondOpCusp k _ ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
-      (gamma0Twist_toHomUnits_Gamma0Map h) f]
+    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k p f) :=
+  slash_mapGL_eq_diamondOpCuspNat k h ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
+    (Gamma0Map_toHomUnits_gamma0Twist h) f
 
 variable [NeZero N]
 
@@ -107,7 +123,7 @@ theorem heckeSlashSum_diagCosetGamma1_of_coprime (hp : p.Prime) (h : Nat.Coprime
       (primeRep (gamma0Twist N p h) p)
       (doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets_of_prime hp
         (gamma0Twist_apply_one_zero h) (gamma0Twist_apply_one_one h))
-      (op_primeRep_smul_injective hp (gamma0Twist_apply_one_zero h)
+      (op_primeRep_smul_injective (G := Gamma1 N) hp.one_lt (gamma0Twist_apply_one_zero h)
         (gamma0Twist_apply_one_one h)) f,
     Fintype.sum_option, heckeSlashUpperTri_def]
   simp only [primeRep_some, primeRep_none]
@@ -121,33 +137,29 @@ coset `Γ₁(N) · diag(1, p) · Γ₁(N)` is
 with **no** case split on whether `p` divides the level: at `p ∣ N` the zero-extended diamond
 `⟨p⟩` vanishes and the formula reduces to the upper-triangular sum, the operator modern papers
 write `Uₚ`. -/
-theorem coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_prime (hp : p.Prime)
+theorem coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime (hp : p.Prime)
     (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
     ⇑(heckeSlashGamma1ModularFormEnd k (diagCosetGamma1 N p) f) =
       heckeSlashUpperTri k p ⇑f + ⇑(diamondOpNat k p f) ∣[k] scaleRep p := by
   rw [coe_heckeSlashGamma1ModularFormEnd]
   by_cases h : Nat.Coprime p N
   · rw [heckeSlashSum_diagCosetGamma1_of_coprime k hp h f, SlashAction.slash_mul,
-      slash_mapGL_gamma0Twist k h f]
-  · have hpN : p ∣ N := by
-      by_contra hnd
-      exact h ((Nat.Prime.coprime_iff_not_dvd hp).mpr hnd)
+      slash_mapGL_gamma0Twist_eq_diamondOpNat k h f]
+  · have hpN : p ∣ N := hp.dvd_iff_not_coprime.mpr h
     rw [heckeSlashSum_diagCosetGamma1 k hpN f, diamondOpNat_of_not_coprime k h]
     simp
 
 /-- **The classical `Tₚ` on `S_k(Γ₁(N))`, at every prime** — the same formula, with the
 cusp-form diamond operator. -/
-theorem coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_prime (hp : p.Prime)
+theorem coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime (hp : p.Prime)
     (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
     ⇑(heckeSlashGamma1CuspFormEnd k (diagCosetGamma1 N p) f) =
       heckeSlashUpperTri k p ⇑f + ⇑(diamondOpCuspNat k p f) ∣[k] scaleRep p := by
   rw [coe_heckeSlashGamma1CuspFormEnd]
   by_cases h : Nat.Coprime p N
   · rw [heckeSlashSum_diagCosetGamma1_of_coprime k hp h f, SlashAction.slash_mul,
-      slash_mapGL_gamma0Twist_cusp k h f]
-  · have hpN : p ∣ N := by
-      by_contra hnd
-      exact h ((Nat.Prime.coprime_iff_not_dvd hp).mpr hnd)
+      slash_mapGL_gamma0Twist_eq_diamondOpCuspNat k h f]
+  · have hpN : p ∣ N := hp.dvd_iff_not_coprime.mpr h
     rw [heckeSlashSum_diagCosetGamma1 k hpN f, diamondOpCuspNat_of_not_coprime k h]
     simp
 
@@ -163,7 +175,7 @@ theorem coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpa
     {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ modFormCharSpace k χ) :
     ⇑(heckeSlashGamma1ModularFormEnd k (diagCosetGamma1 N p) f) =
       heckeSlashUpperTri k p ⇑f + (χ (ZMod.unitOfCoprime p h) : ℂ) • (⇑f ∣[k] scaleRep p) := by
-  rw [coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_prime k hp f,
+  rw [coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime k hp f,
     diamondOpNat_of_coprime k h, diamondOp_apply_of_mem_modFormCharSpace k χ _ hf]
   congr 1
   exact ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p) ⇑f _
@@ -174,7 +186,7 @@ theorem coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cuspFormCharSpace
     {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
     ⇑(heckeSlashGamma1CuspFormEnd k (diagCosetGamma1 N p) f) =
       heckeSlashUpperTri k p ⇑f + (χ (ZMod.unitOfCoprime p h) : ℂ) • (⇑f ∣[k] scaleRep p) := by
-  rw [coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_prime k hp f,
+  rw [coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime k hp f,
     diamondOpCuspNat_of_coprime k h, diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ _ hf]
   congr 1
   exact ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p) ⇑f _

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
@@ -29,18 +29,15 @@ ModularForms roadmap asks for: `Tₚ` is one operator, defined for every `p`, wi
 recovered as the `p ∣ N` case and not introduced separately.
 
 ⚠ The twist is essential. Over `Γ₁(N)` the untwisted `f ∣[k] !![p, 0; 0, 1]` is *not* a term
-of the coset sum; only after applying `⟨p⟩` does the
-matrix `σ · diag(p, 1)` represent the missing right coset. On a form of nebentypus `χ` the
-diamond acts by the scalar `χ(p)`, which is where the classical factor `χ(p)` in
+of the coset sum. The matrix `σ · diag(p, 1)` is the missing right-coset representative, and
+`f ∣[k] (σ · diag(p, 1)) = (⟨p⟩ f) ∣[k] diag(p, 1)`. On a form of nebentypus `χ` the diamond
+acts by the scalar `χ(p)`, which is where the classical factor `χ(p)` in
 `aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k−1} a_{m/p}(f)` comes from
 (`coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_modFormCharSpace`); the two spellings
 agree exactly when `χ(p) = 1`.
 
 ## Main results
 
-* `HeckeRing.GL2.slash_mapGL_eq_diamondOpNat` and its cusp-form counterpart: slashing by any
-  suitable `Γ₀(N)` representative is the corresponding diamond operator; the
-  `slash_mapGL_gamma0Twist_eq_*` lemmas specialize them to the Bézout twist.
 * `HeckeRing.GL2.heckeSlashSum_diagCosetGamma1_of_coprime`: the slash sum of the double coset at
   a prime `p ∤ N`, over the `p + 1` representatives.
 * `HeckeRing.GL2.coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime`,
@@ -76,38 +73,6 @@ open scoped MatrixGroups ModularForm
 namespace HeckeRing.GL2
 
 variable {N p : ℕ} (k : ℤ)
-
-/-- Slashing by a `Γ₀(N)` representative with lower-right unit `n` is the zero-extended
-diamond operator `⟨n⟩` on modular forms. -/
-theorem slash_mapGL_eq_diamondOpNat {n : ℕ} (h : Nat.Coprime n N) (g : ↥(Gamma0 N))
-    (hg : (Gamma0Map N).toHomUnits g = ZMod.unitOfCoprime n h)
-    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
-    ⇑f ∣[k] (mapGL ℚ (g : SL(2, ℤ)) : GL (Fin 2) ℚ) = ⇑(diamondOpNat k n f) := by
-  rw [ModularForm.rat_slash_mapGL, diamondOpNat_of_coprime k h, coe_diamondOp k _ g hg f]
-
-/-- The cusp-form counterpart of `slash_mapGL_eq_diamondOpNat`. -/
-theorem slash_mapGL_eq_diamondOpCuspNat {n : ℕ} (h : Nat.Coprime n N) (g : ↥(Gamma0 N))
-    (hg : (Gamma0Map N).toHomUnits g = ZMod.unitOfCoprime n h)
-    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
-    ⇑f ∣[k] (mapGL ℚ (g : SL(2, ℤ)) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k n f) := by
-  rw [ModularForm.rat_slash_mapGL, diamondOpCuspNat_of_coprime k h,
-    coe_diamondOpCusp k _ g hg f]
-
-/-- **Slashing by the Bézout twist is the diamond operator `⟨p⟩`.** The twist is the `Γ₀(N)`
-element of lower-right entry `p`, so this is `coe_diamondOp` at that representative, transported
-across the `ℚ`/`ℝ` bridge. -/
-theorem slash_mapGL_gamma0Twist_eq_diamondOpNat (h : Nat.Coprime p N)
-    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
-    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpNat k p f) :=
-  slash_mapGL_eq_diamondOpNat k h ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
-    (Gamma0Map_toHomUnits_gamma0Twist h) f
-
-/-- **Slashing by the Bézout twist is the diamond operator `⟨p⟩`**, on cusp forms. -/
-theorem slash_mapGL_gamma0Twist_eq_diamondOpCuspNat (h : Nat.Coprime p N)
-    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
-    ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k p f) :=
-  slash_mapGL_eq_diamondOpCuspNat k h ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
-    (Gamma0Map_toHomUnits_gamma0Twist h) f
 
 variable [NeZero N]
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
@@ -140,7 +140,8 @@ theorem exists_mem_Gamma0_upperTriRep_mul [NeZero p] (hpN : p ∣ N) {γ : SL(2,
     (hγ : γ ∈ Gamma0 N) (j : Fin p) :
     ∃ γ' : SL(2, ℤ), γ' ∈ Gamma0 N ∧ ((γ' 1 1 : ℤ) : ZMod N) = ((γ 1 1 : ℤ) : ZMod N) ∧
       upperTriRep p j * mapGL ℚ γ = mapGL ℚ γ' * upperTriRep p (upperTriShift p γ j) := by
-  have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 := Matrix.det_fin_two γ.1 ▸ γ.2
+  have hdet : γ 0 0 * γ 1 1 - γ 0 1 * γ 1 0 = 1 :=
+    Matrix.SpecialLinearGroup.fin_two_mul_sub_mul_eq_one γ
   have hcN : ((γ 1 0 : ℤ) : ZMod N) = 0 := Gamma0_mem.mp hγ
   have hγp : γ ∈ Gamma0 p := Gamma0_le_Gamma0_of_dvd hpN hγ
   have had := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 hγp

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
@@ -11,11 +11,11 @@ public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 /-!
 # The upper-triangular part of the Hecke operator
 
-The classical `T_p` is a sum of slashes by the representatives `!![1, b; 0, p]` for `b < p`,
-together with one further term when `p ∤ N`. This file defines both: the triangular sum
-`heckeSlashUpperTri`, and the augmented sum `heckeSlashUpperTriAddScale` adjoining the diagonal
-representative. For each it records `ℂ`-linearity in `f`: zero, addition and scalar multiplication
-are preserved. (Linearity in `f` only; neither is yet bundled as a `LinearMap`.)
+The classical `T_p` contains a sum of slashes by the representatives `!![1, b; 0, p]` for
+`b < p`, together with one further, diamond-twisted term when `p ∤ N`. This file defines the
+triangular sum `heckeSlashUpperTri` and records its `ℂ`-linearity in `f`: zero, addition and
+scalar multiplication are preserved. (Linearity in `f` only; it is not yet bundled as a
+`LinearMap`.)
 
 Why these representatives: mathlib's `IsBoundedAtImInfty.slash` requires `g 1 0 = 0`, so it
 applies when `g` is upper triangular. (Sufficient, not necessary — the zero function stays
@@ -28,10 +28,6 @@ the entrywise description of the representatives is not restated.
 ## Main definitions
 
 * `HeckeRing.GL2.heckeSlashUpperTri`: the sum `∑ b < p, f ∣[k] !![1, b; 0, p]`.
-* `HeckeRing.GL2.heckeSlashUpperTriAddScale`: that sum together with the scaling representative
-  `!![p, 0; 0, 1]`. For **prime** `p ∤ N`, over `Γ₀(N)` and with trivial character, this is the
-  whole `T_p` coset sum; the identification needs both qualifiers and is not proved here.
-
 ## Main results
 
 * `HeckeRing.GL2.heckeSlashUpperTri_def` and `heckeSlashUpperTri_apply`: the characteristic
@@ -39,8 +35,6 @@ the entrywise description of the representatives is not restated.
   its sum.
 * `HeckeRing.GL2.heckeSlashUpperTri_zero`, `heckeSlashUpperTri_add`,
   `heckeSlashUpperTri_smul`: linearity in `f`.
-* `HeckeRing.GL2.heckeSlashUpperTriAddScale_def`, `…_apply`, and `…_zero` / `_add` / `_smul`: the
-  same interface for the augmented sum.
 The representatives themselves, and their upper-triangularity and positive determinant, live in
 `HeckeRing/GL2/CosetDecomposition.lean`; this file is only the slash sum built from them.
 
@@ -53,21 +47,11 @@ The shape is AINTLIB's `heckeT_p_ut`
 representatives — `T_p_upper p _ b` is `upperTriGL` at `n = 2`, `a = ![1, p]` — so AINTLIB's
 `T_p_upper` is not reproduced.
 
-`heckeSlashUpperTriAddScale` follows the same project's `heckeT_p_fun` (`HeckeT_p.lean`, lines
-110-115), which adjoins a diagonal term to `heckeT_p_ut`, and its prime-`T_p` dispatch
-`heckeT_p_all` (`HeckeT_n.lean`, lines 434-437). One deliberate difference, and it is why the
-docstrings below qualify the `T_p` claim: AINTLIB's extra term is
-`(⇑(diamondOp k ⟨p⟩ f)) ∣[k] T_p_lower p`, carrying the diamond operator, where the term here is
-the untwisted `f ∣[k] scaleRep p`. The two agree exactly when the nebentypus is trivial. The
-twisted form needs `diamondOp`, which this file does not import.
-
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
   §3.4.
-* [DS] Diamond–Shurman, *A first course in modular forms*, Proposition 5.2.1 — the `p + 1`
-  representatives of the `T_p` coset decomposition for `p ∤ N`, the source AINTLIB's
-  `heckeT_p_fun` cites for the same statement.
+* [DS] Diamond–Shurman, *A first course in modular forms*, Proposition 5.2.1.
 -/
 
 public section
@@ -113,56 +97,5 @@ scalar generality matches `ModularForm.rat_smul_slash_of_det_pos`. -/
   rw [heckeSlashUpperTri_def, heckeSlashUpperTri_def, Finset.smul_sum]
   exact Finset.sum_congr rfl fun b _ ↦
     ModularForm.rat_smul_slash_of_det_pos k (det_upperTriRep_pos p b) f c
-
-/-- **The upper-triangular sum together with the diagonal term**: the `p` terms of
-`heckeSlashUpperTri` plus `f ∣[k] scaleRep p`.
-
-⚠ This is **not** claimed to be the full `T_p` coset sum. It is that only for **prime** `p ∤ N`,
-over `Γ₀(N)` and with trivial character, where the double coset of `diag(1, p)` has exactly
-`p + 1` left cosets. Both qualifiers are load-bearing: with nebentypus `χ` the diagonal term is
-`χ(p) • f ∣[k] scaleRep p`, and over `Γ₁(N)` the untwisted matrix is not a coset representative at
-all. AINTLIB's `heckeT_p_fun` carries precisely that twist — its extra term is
-`(⟨p⟩ f) ∣[k] T_p_lower p`.
-
-The `p + 1` count is specific to prime `p`; this definition is well formed for every `p` and
-claims no coset decomposition in general, which is why no `Nat.Prime` hypothesis is imposed on
-it.
-
-Every representative summed here is upper triangular — `scaleRep` is diagonal — so
-`IsBoundedAtImInfty.slash` applies to each term exactly as it does to `heckeSlashUpperTri`. -/
-noncomputable def heckeSlashUpperTriAddScale (f : ℍ → ℂ) : ℍ → ℂ :=
-  heckeSlashUpperTri k p f + f ∣[k] scaleRep p
-
-/-- The defining equation of `heckeSlashUpperTriAddScale`, in terms of the partial sum. -/
-lemma heckeSlashUpperTriAddScale_def (f : ℍ → ℂ) :
-    heckeSlashUpperTriAddScale k p f = heckeSlashUpperTri k p f + f ∣[k] scaleRep p := (rfl)
-
-/-- The pointwise form, for consumers working at a point of `ℍ`. -/
-lemma heckeSlashUpperTriAddScale_apply (f : ℍ → ℂ) (τ : ℍ) :
-    heckeSlashUpperTriAddScale k p f τ =
-      (∑ b : Fin p, (f ∣[k] upperTriRep p b) τ) + (f ∣[k] scaleRep p) τ := by
-  rw [heckeSlashUpperTriAddScale_def, Pi.add_apply, heckeSlashUpperTri_apply]
-
-/-- The augmented sum sends the zero function to zero. -/
-@[simp] lemma heckeSlashUpperTriAddScale_zero : heckeSlashUpperTriAddScale k p 0 = 0 := by
-  rw [heckeSlashUpperTriAddScale_def, heckeSlashUpperTri_zero, SlashAction.zero_slash, add_zero]
-
-/-- The augmented sum is additive in `f`, since each slash is. -/
-@[simp] lemma heckeSlashUpperTriAddScale_add (f g : ℍ → ℂ) :
-    heckeSlashUpperTriAddScale k p (f + g) =
-      heckeSlashUpperTriAddScale k p f + heckeSlashUpperTriAddScale k p g := by
-  rw [heckeSlashUpperTriAddScale_def, heckeSlashUpperTriAddScale_def,
-    heckeSlashUpperTriAddScale_def, heckeSlashUpperTri_add, SlashAction.add_slash]
-  ring
-
-/-- **Scalars pass through the augmented sum**, for every `p`. With
-`heckeSlashUpperTriAddScale_add` and `heckeSlashUpperTriAddScale_zero` this is the `ℂ`-linearity
-of `f ↦ heckeSlashUpperTriAddScale k p f`. -/
-@[simp] lemma heckeSlashUpperTriAddScale_smul {α : Type*} [DistribSMul α ℂ]
-    [IsScalarTower α ℂ ℂ]
-    (c : α) (f : ℍ → ℂ) :
-      heckeSlashUpperTriAddScale k p (c • f) = c • heckeSlashUpperTriAddScale k p f := by
-  rw [heckeSlashUpperTriAddScale_def, heckeSlashUpperTriAddScale_def, heckeSlashUpperTri_smul,
-    smul_add, ModularForm.rat_smul_slash_of_det_pos k (det_scaleRep_pos p) f c]
 
 end HeckeRing.GL2


### PR DESCRIPTION
This PR decomposes the Hecke double coset `Γ₁(N) · diag(1, p) · Γ₁(N)` into its `p + 1` right cosets at a prime `p ∤ N`, and uses that to identify the operator of the abstract double coset with the classical `Tₚ` — by one formula that holds at **every** prime, good or bad.

<!--tauceti-target:v1 {"focus":"ModularForms","id":"diagcosetgamma1-coprime-rightcosets"}-->

Roadmap: ModularForms

The milestone is Layer 2(b) of `ModularForms/README.md`, which asks: "⚠ State and keep one **normalization lemma** identifying the abstract double coset `[Γ₁(N)·diag(1,p)·Γ₁(N)]`, acting through the slash action, with the classical `Tₚ` of these recurrences; without it, powers of `p` drift between the abstract and classical sides of the ring homomorphism." It is also the first item on the roadmap's own frontier list (`STATUS.md`: "**Uniform Hecke operators.** Identify the relevant double-coset sums with `T_n` …, and introduce `U_p` only through `U_p = T_p`"). `HeckeSlash/UpperTri/DoubleCoset.lean` (TauCeti#3817, #3822) proved the normalisation lemma at `p ∣ N`, where the `p` matrices `!![1, b; 0, p]` exhaust the coset; the good-prime case, which needs one further coset, was open, and it is the case that carries the nebentypus factor `χ(p)`.

`TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/CoprimeCosets.lean` (407 lines) proves Diamond–Shurman Proposition 5.2.1 in its remaining case: for `p` prime and `p ∤ N`,

```
Γ₁(N) · diag(1, p) · Γ₁(N) = (⋃_{b < p} Γ₁(N) · !![1, b; 0, p]) ∪ Γ₁(N) · σ · diag(p, 1),
```

a disjoint union, where `σ = !![m, n; N, p]` is any integral matrix with `m p − n N = 1` — an element of `Γ₀(N)` and *not* of `Γ₁(N)`. Everything is stated for an arbitrary such `σ`, so the coprimality of `p` and `N` is carried by the data rather than as a side hypothesis (`bezout_of_lowerRow`, `coprime_of_lowerRow`); `gamma0Twist`, built from `Nat.gcdA` / `Nat.gcdB`, supplies the converse witness. Primality is used exactly once, in the forward inclusion at `p ∤ a`, where the congruence `a j ≡ b (mod p)` needs `a` invertible modulo `p`; the complementary branch `p ∣ a` needs none, and produces the twisted coset through the explicit factorisation `diag(1, p) · γ = !![a − bN, bm − a′n; p(c − dN), pdm − cn] · σ · diag(p, 1)` with `a = p a′`. Disjointness of the last coset from the others is integrality: matching it against `!![1, b; 0, p]` would force `p ∣ n`, which `m p − n N = 1` forbids.

`TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean` (184 lines) feeds that decomposition to the existing choice-free slash sum (`heckeSlashSum_coe_eq_sum_of_rightCosets`) and obtains, on `M_k(Γ₁(N))` and on `S_k(Γ₁(N))`,

```
T_p f = ∑_{b < p} f ∣[k] !![1, b; 0, p] + (⟨p⟩ f) ∣[k] !![p, 0; 0, 1]
```

with **no case split on `p ∣ N`**. Slashing by `σ` *is* the diamond operator `⟨p⟩`, since `σ ∈ Γ₀(N)` has lower-right entry `p` (`slash_mapGL_gamma0Twist`); and at `p ∣ N` the zero-extended `⟨p⟩` of `DiamondOperators.lean` vanishes, so the extra term disappears and the statement reduces to the already-proved `p ∣ N` one — the operator modern papers write `Uₚ`, obtained here as the degenerate case of `Tₚ` and not as a second definition, exactly as the roadmap's conventions require. On a nebentypus space the diamond becomes the scalar `χ(p)`, giving the slash-level form of the recurrence with its `χ(p)` in place.

Three existing files change. `Gamma1/UpperTriCosets.lean`: the forward factorisation is generalised to take the offset `j` and its divisibility `p ∣ b − a j` as hypotheses (`exists_mem_Gamma1_natDiagGL_mul_of_dvd`), with the old `p ∣ N` statement rederived from it in three lines — that shared 40-line matrix computation is what the good-prime branch at `p ∤ a` reuses rather than repeats. `GL2/CosetDecomposition.lean` gains the `!![…]` reading of `mapGL ℚ σ`, moved there from its former private home now that a second file needs it. `DiamondOperators.lean` gains `diamondOpCuspNat`, the cusp-form counterpart of the existing `diamondOpNat`, without which the cusp-form formula could not be stated uniformly.

What remains on this milestone after this PR: the `q`-expansion coefficient recurrence `aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k−1} a_{m/p}(f)` — whose two halves are already present as `qExpansion_coeff_heckeSlashUpperTri'` and `qExpansion_slash_natDiagGL_d_one_coeff_Gamma1`, and which this PR's formula is what joins — and then the composite `Tₙ` for general `n` with the ring homomorphism `Φ_χ` onto each character space.

No Mathlib infrastructure is vendored, and no code is transcribed from the AINTLIB `LeanModularForms` project; its `heckeT_p_fun` (`HeckeRIngs/GL2/HeckeT_p.lean`, Chris Birkbeck, Apache-2.0) is the source of the shape of the formula, and is cited where it is followed, but the derivation here runs through the abstract double coset and this repository's own representative families rather than through a bespoke definition of the operator.

🤖 Prepared with Claude Code
