### PR TITLE
docs(Huber): cite Wedhorn 7.18 and 7.41 for the criterion, not Definition 7.14

### DIFF
--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
@@ -81,10 +81,12 @@ the same factor-of-an-inverted-element argument Mathlib packages as
 across the completion. Its
 power-boundedness condition is *not* proved — it is carried as the field
 `HasLocLiftPowerBounded.locLift_divByS_isPowerBounded` of a hypothesis class, because from a bare
-containment it needs a valuative criterion for integrality: Wedhorn Proposition 7.18, whose own
-proof is the bare citation [Hu2] Lemma 3.3, together with Proposition 7.41, which bounds a
-height-one continuous valuation by `1` on `A°`. AINTLIB calls that combination an *adic
-Nullstellensatz*, a name Wedhorn does not use, and records it as an open ticket. Restricting
+containment it needs a valuative criterion for integrality. Wedhorn's is Proposition 7.18, whose
+own proof is the bare citation [Hu2] Lemma 3.3; he applies it in Lemma 8.1 through Proposition
+7.52(1), a reformulation of 7.18(1). AINTLIB instead reduces to height one, pairing 7.18 with
+Proposition 7.41, which bounds a height-one continuous valuation by `1` on `A°`; it calls that
+combination an *adic Nullstellensatz*, a name Wedhorn does not use, and records it as an open
+ticket. Restricting
 attention to a refining presentation is what removes that dependency: the fraction in question is
 then a distinguished one, and `isPowerBounded_divBy` already covers it.
 So the construction here is unconditional where AINTLIB's rests on an assumed class.
@@ -92,9 +94,10 @@ So the construction here is unconditional where AINTLIB's rests on an assumed cl
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), §8.1–§8.2 for the structure
-  presheaf and its restriction maps, and Proposition 8.2 for the containment form. Propositions
-  7.18 and 7.41 are the criterion the containment form needs; Definition 7.14, which names rings
-  of integral elements, is a different result and does not supply it.
+  presheaf and its restriction maps, and Proposition 8.2 for the containment form. Proposition
+  7.18 is the criterion it needs, reached in Lemma 8.1 via Proposition 7.52(1); Proposition 7.41
+  belongs to AINTLIB's height-one reduction rather than to Wedhorn's route. Definition 7.14, which
+  names rings of integral elements, is a different result and does not supply it.
 * [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
   commit `37bbdaeb9`, under `projects/AdicSpaces/`:
   * `Adic spaces/Presheaf.lean` — the restriction maps built from a containment.

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
@@ -96,7 +96,11 @@ So the construction here is unconditional where AINTLIB's rests on an assumed cl
   7.18 and 7.41 are the criterion the containment form needs; Definition 7.14, which names rings
   of integral elements, is a different result and does not supply it.
 * [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
-  commit `37bbdaeb`, `projects/AdicSpaces/Adic spaces/Presheaf.lean`.
+  commit `37bbdaeb9`, under `projects/AdicSpaces/`:
+  * `Adic spaces/Presheaf.lean` — the restriction maps built from a containment.
+  * `Adic spaces/PresheafIdentification.lean` — the decomposition into Propositions 7.18 and 7.41.
+  * `docs/TICKETS-axiom-clean.md` — records that combination as an open ticket, under the *adic
+    Nullstellensatz* name used above.
 -/
 
 namespace TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
+++ b/TauCeti/RingTheory/Huber/LocalizationTopology/Restriction.lean
@@ -26,8 +26,8 @@ homomorphism compatible with the structure maps from `A`.
 
 Refinement is the shape the intersection of two rational subsets produces: `R(T₁/s₁) ∩ R(T₂/s₂)`
 is presented with denominator `s₁ * s₂`, a multiple of each. That is why this elementary notion is
-enough to compare presentations, and it is what keeps an adic Nullstellensatz out of the
-construction — see the Provenance section.
+enough to compare presentations, and it is what keeps a valuative criterion for integrality out
+of the construction — see the Provenance section.
 
 The statements below repeat the uniformity preamble of `locUniformSpace`,
 `isUniformAddGroup_locUniformSpace` and `isTopologicalRing_locUniformSpace`, once per presentation,
@@ -81,15 +81,20 @@ the same factor-of-an-inverted-element argument Mathlib packages as
 across the completion. Its
 power-boundedness condition is *not* proved — it is carried as the field
 `HasLocLiftPowerBounded.locLift_divByS_isPowerBounded` of a hypothesis class, because from a bare
-containment it needs the adic Nullstellensatz (Wedhorn Proposition 7.14), which AINTLIB records as
-an open ticket. Restricting attention to a refining presentation is what removes that dependency:
-the fraction in question is then a distinguished one, and `isPowerBounded_divBy` already covers it.
+containment it needs a valuative criterion for integrality: Wedhorn Proposition 7.18, whose own
+proof is the bare citation [Hu2] Lemma 3.3, together with Proposition 7.41, which bounds a
+height-one continuous valuation by `1` on `A°`. AINTLIB calls that combination an *adic
+Nullstellensatz*, a name Wedhorn does not use, and records it as an open ticket. Restricting
+attention to a refining presentation is what removes that dependency: the fraction in question is
+then a distinguished one, and `isPowerBounded_divBy` already covers it.
 So the construction here is unconditional where AINTLIB's rests on an assumed class.
 
 ## References
 
 * [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), §8.1–§8.2 for the structure
-  presheaf and its restriction maps, and Proposition 8.2 for the containment form.
+  presheaf and its restriction maps, and Proposition 8.2 for the containment form. Propositions
+  7.18 and 7.41 are the criterion the containment form needs; Definition 7.14, which names rings
+  of integral elements, is a different result and does not supply it.
 * [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
   commit `37bbdaeb`, `projects/AdicSpaces/Adic spaces/Presheaf.lean`.
 -/


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"restriction-provenance-cite-7-18-7-41"}-->

`Restriction.lean`'s Provenance section names the result its construction avoids as "the adic
Nullstellensatz (Wedhorn **Proposition** 7.14)". Both halves of that citation are wrong, and the
error matters because this docstring is the repo's own statement of what blocks the containment
form of the restriction maps — it is what a reader consults to size that gap.

**Wedhorn 7.14 is a Definition, and it is already formalised here.**

> Definition 7.14. (1) Let `A` be an f-adic ring and let `A°` be the subring of power-bounded
> elements. A subring `B` of `A` is called ring of integral elements if `B` is open and integrally
> closed in `A` and if `B ⊆ A°`. (2) An affinoid ring is a pair `(A, A⁺)`, …

That is the definition `TauCeti.Huber.Pair` implements, and `Huber/Pair.lean:55` already cites it
correctly as "Definition 7.14, Remark 7.15". It defines the objects; it supplies no criterion for
integrality, so it cannot be what the power-boundedness field is waiting on.

**"Nullstellensatz" is not Wedhorn's word.** It occurs zero times in arXiv:1910.05934v1. The name
comes from AINTLIB's ticket R4, which is fine as informal usage but should not be attached to a
Wedhorn number as though quoted.

**What the obligation actually is.** AINTLIB's own decomposition names it, at
`projects/AdicSpaces/Adic spaces/PresheafIdentification.lean:1223`, as "the Wedhorn 7.18 + 7.41
obligation":

* **Proposition 7.18** — the correspondence `σ : R_A → S_A` between the open integrally closed
  subrings of `A` and their valuation sets. Wedhorn's proof is the bare citation "[Hu2] Lemma 3.3",
  the same shape as 7.47(4) → Huber 2.4.3.
* **Proposition 7.41** — if `x ∈ Cont(A)ᵃ` has height 1 then `x(a) ≤ 1` for all `a ∈ A°`, hence
  `x ∈ Spa(A, A⁺)ᵃ` for every ring of integral elements `A⁺`. Wedhorn proves this outright.

This PR corrects the citation in the Provenance section, adjusts the introduction's forward
reference to match, and records in References that 7.14 is a different result so the next reader
does not repeat the substitution.

## Scope

Documentation of existing code, which `.claude/CLAUDE.md` places in scope with no roadmap claim
("documenting existing code" is listed among the changes that are "always in scope"). No
declaration is added, removed, renamed or reproved; the diff is entirely inside the module
docstring. `Roadmap: AdicSpaces` above is attribution — that is the roadmap this file serves.

## Provenance

* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1 — Definition 7.14, Propositions 7.18 and 7.41,
  read from the text rather than from a secondary citation.
* AINTLIB @ `37bbdaeb9`, `projects/AdicSpaces/Adic spaces/PresheafIdentification.lean` and
  `docs/TICKETS-axiom-clean.md` ticket R4, for the "7.18 + 7.41" decomposition and for the
  informal name.

Nothing is ported; no Lean code is copied or adapted.
