### PR TITLE
feat: the class-group pushforward of an isogeny

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Rank.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Rank.lean
@@ -51,6 +51,14 @@ The hypotheses take arbitrary algebra structures whose structure maps are the pu
 `Isogeny.degree_eq_finrank` and the siblings in this directory: registering such a structure
 globally would be a diamond, since different isogenies induce different ones.
 
+## Provenance
+
+The statement is not among the components `TauCetiRoadmap/EllipticCurves/README.md:1085–1096` lists
+for D. Angdinata's shared isogeny development, and no AINTLIB declaration corresponds to it: the
+one fact about this object that both carry is module-finiteness, which is the sibling
+`IntermediateRing/Finite.lean`. The proof is Mathlib's two localization comparisons of dimension
+against `Isogeny.degree_eq_finrank`.
+
 ## References
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Rank.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Rank.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Degree
+-- Proof-only: the fraction-field property of the intermediate ring and the two-sided
+-- localization comparison of dimensions are used inside the proof, not in the statement.
+import Mathlib.LinearAlgebra.Dimension.Localization
+import Mathlib.RingTheory.Localization.Integral
+
+/-!
+# The intermediate ring has rank the degree of the isogeny
+
+For an isogeny `φ : W₁ → W₂`, the intermediate ring — the integral closure of `W₂.CoordinateRing`
+in `W₁.FunctionField` — has `Module.finrank` over `W₂.CoordinateRing` equal to `φ.degree`.
+
+Geometrically this is the fibre count: the intermediate ring is the ring of functions regular away
+from `φ⁻¹(O₂)`, and it sits over `W₂.CoordinateRing` with rank the degree, so an affine fibre of
+`φ` has `deg φ` points counted with multiplicity. `TauCetiRoadmap/EllipticCurves/README.md` §Layer 1
+names this the place-free route to fibre counting, the alternative to the point–place dictionary of
+Layer 0: "the intermediate ring is locally free of rank `deg φ` over the coordinate ring, so every
+fibre over an affine point has `deg φ` points with multiplicity".
+
+## Main results
+
+* `TauCeti.Isogeny.finrank_intermediateRing`: `[φ.intermediateRing : W₂.CoordinateRing] = deg φ`.
+
+## Design
+
+**No separability, and no normality of the base.** The proof compares two dimensions across
+fraction fields: `W₂.FunctionField` is the fraction field of `W₂.CoordinateRing` by definition, and
+`W₁.FunctionField` is the fraction field of the intermediate ring because the latter is the
+integral closure of `W₂.CoordinateRing` in a finite extension of its fraction field
+(`IsIntegralClosure.isFractionRing_of_finite_extension`, which takes no separability). Both
+one-sided comparisons are `Mathlib/LinearAlgebra/Dimension/Localization.lean`, packaged as
+`IsFractionRing.finrank_eq`. So this file's hypotheses are those of `Isogeny.degree_eq_finrank`
+alone, and Frobenius and the other purely inseparable isogenies are covered — unlike the sibling
+`IntermediateRing/Finite.lean`, whose route through the trace form needs separability.
+
+⚠ The statement is about `Module.finrank`, not local freeness. Over a Dedekind domain a
+module-finite torsion-free module *is* projective and this `finrank` is its constant local rank, so
+the two agree once `IntermediateRing/Finite.lean`'s hypotheses are in force; but that upgrade needs
+finiteness, hence separability, and is not what is proved here. Nothing downstream should read this
+as a projectivity statement.
+
+The hypotheses take arbitrary algebra structures whose structure maps are the pullback, matching
+`Isogeny.degree_eq_finrank` and the siblings in this directory: registering such a structure
+globally would be a diamond, since different isogenies induce different ones.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Isogeny
+
+variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
+
+/-- **The intermediate ring of an isogeny has rank its degree.** The integral closure of
+`W₂.CoordinateRing` in `W₁.FunctionField` is a `W₂.CoordinateRing`-module of rank `deg φ`, the
+degree being the dimension of `W₁.FunctionField` over the pulled-back `W₂.FunctionField`.
+
+Both rings sit inside their fraction fields — `W₂.FunctionField` for the base, and
+`W₁.FunctionField` for the intermediate ring, since it is an integral closure inside a finite
+extension — so the two dimensions are the same number.
+
+No separability is assumed: Frobenius and the other purely inseparable isogenies are covered. -/
+theorem finrank_intermediateRing (φ : Isogeny W₁ W₂)
+    [Algebra W₂.CoordinateRing W₁.FunctionField]
+    [Algebra W₂.FunctionField W₁.FunctionField]
+    [IsScalarTower W₂.CoordinateRing W₂.FunctionField W₁.FunctionField]
+    [Algebra W₂.CoordinateRing φ.intermediateRing]
+    [IsScalarTower W₂.CoordinateRing φ.intermediateRing W₁.FunctionField]
+    (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
+    Module.finrank W₂.CoordinateRing φ.intermediateRing = φ.degree := by
+  have hfield := φ.algebraMap_functionField_eq_fieldPullback h
+  -- the integral-closure property is not assumed: it is what `intermediateRing` is
+  have := φ.isIntegralClosure_intermediateRing h
+  have := φ.finiteDimensional_functionField hfield
+  have : IsFractionRing φ.intermediateRing W₁.FunctionField :=
+    IsIntegralClosure.isFractionRing_of_finite_extension W₂.CoordinateRing W₂.FunctionField
+      W₁.FunctionField φ.intermediateRing
+  rw [φ.degree_eq_finrank hfield]
+  exact (IsFractionRing.finrank_eq W₂.CoordinateRing W₂.FunctionField φ.intermediateRing
+    W₁.FunctionField).symm
+
+end Isogeny
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Separable.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Separable.lean
@@ -65,6 +65,15 @@ mathematics, and that removing it means building Krull–Akizuki or Nagata norma
 first. Nothing here changes that; when the siblings lose the hypothesis, so does this file. The
 rank statement `Isogeny.finrank_intermediateRing` already needs no separability.
 
+## Provenance
+
+⚠ *mathlib-track*, inherited. Every conclusion here is a sibling's conclusion repackaged, and both
+siblings are flagged against `TauCetiRoadmap/EllipticCurves/README.md:1092`, which lists the
+`IntermediateRing` with `intermediateRingFinite` among the components of D. Angdinata's shared
+isogeny development; this file is deduplicated with them when that lands. Nothing is ported from
+AINTLIB: the source states its structural facts for a fixed extension with the algebra structures
+supplied as instance arguments, which is the shape this file exists to remove.
+
 ## References
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Separable.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Separable.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Dedekind
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Finite
+-- Public: `Isogeny/Separability.lean` is where separability of an isogeny is spelled, and where
+-- the instance witnessing it for `id` lives.
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Separability
+-- Public: `Algebra.IsSeparable f.fieldRange L` is the hypothesis of every statement here, and the
+-- transfer across `f.equivFieldRange` is what turns it into the siblings' hypothesis.
+public import TauCeti.FieldTheory.IntermediateField.FieldRange
+public import TauCeti.Algebra.Algebra.Hom
+
+/-!
+# The intermediate ring of a separable isogeny, with no algebra structures to supply
+
+`IntermediateRing/Finite.lean` and `IntermediateRing/Dedekind.lean` state module-finiteness and
+Dedekindness of `φ.intermediateRing` against algebra structures the caller supplies, pinned to the
+pullback by a hypothesis `h`. That is the right shape for a consumer who already holds such
+structures, and the wrong shape for one who holds only `φ`: nothing in the repository registers
+`Algebra W₂.CoordinateRing W₁.FunctionField` or `Algebra W₂.FunctionField W₁.FunctionField`, since
+different isogenies induce different ones and any global instance would be a diamond.
+
+This file closes that gap. Each result below takes **separability of `φ` in the repository's own
+spelling** — `Algebra.IsSeparable φ.fieldPullback.fieldRange W₁.FunctionField`, the definition
+`Isogeny/Separability.lean` works with, which mentions no algebra structure because
+`φ.fieldPullback.fieldRange` is an intermediate field of `W₁.FunctionField` — and builds every
+structure the sibling wants out of `φ` alone.
+
+The bridge between the two spellings of separability is `AlgHom.isSeparable_of_fieldRange`: the
+range restriction `φ.fieldPullback.equivFieldRange` identifies `W₂.FunctionField` with
+`φ.fieldPullback.fieldRange`, so a separable extension of the one is a separable extension of the
+other.
+
+## Main results
+
+* `TauCeti.Isogeny.isSeparable_functionField`: a separable isogeny has separable function-field
+  extension, over `W₂.FunctionField` rather than over the range.
+* `TauCeti.Isogeny.finite_pullbackToIntermediateRing`: the corestricted pullback is a finite ring
+  map — `IntermediateRing/Finite.lean`'s conclusion with nothing to supply.
+* `TauCeti.Isogeny.isDedekindDomain_intermediateRing_of_isSeparable`:
+  `IntermediateRing/Dedekind.lean`'s conclusion with nothing to supply, as an instance.
+
+## Design
+
+**Why `RingHom.Finite` rather than `Module.Finite`.** Module-finiteness of `φ.intermediateRing`
+over `W₂.CoordinateRing` is finiteness *along the corestricted pullback*, and there is no algebra
+instance to state it against. Mathlib's `RingHom.Finite` is exactly the predicate for that
+situation — `letI := f.toAlgebra; Module.Finite A B` — so the conclusion is stated about
+`φ.pullbackToIntermediateRing` and needs no structure in the statement at all. Dedekindness needs
+no such care, being intrinsic to the ring, and is therefore an `instance` where finiteness cannot
+be.
+
+**The consumer is `Isogeny.pushClass`**, whose two structural hypotheses are exactly the two
+conclusions here: an ideal class is extended into `φ.intermediateRing` and normed back down, and
+`ClassGroup.relNorm` is stated over a module-finite extension of Dedekind domains.
+
+**Separability is inherited from the siblings, not introduced here.** Both of them explain at
+length that the hypothesis is a limitation of Mathlib's trace-form route rather than of the
+mathematics, and that removing it means building Krull–Akizuki or Nagata normalization-finiteness
+first. Nothing here changes that; when the siblings lose the hypothesis, so does this file. The
+rank statement `Isogeny.finrank_intermediateRing` already needs no separability.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Isogeny
+
+variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
+
+/-- **A separable isogeny has separable function-field extension.** Separability of `φ` is recorded
+over `φ.fieldPullback.fieldRange`, an intermediate field of `W₁.FunctionField`; this reads it over
+`W₂.FunctionField` instead, which is the form every Mathlib result about a separable extension
+takes.
+
+Stated for an arbitrary algebra structure whose structure map is the pullback, matching
+`Isogeny.degree_eq_finrank` and the siblings in this directory. -/
+theorem isSeparable_functionField (φ : Isogeny W₁ W₂)
+    [Algebra W₂.CoordinateRing W₁.FunctionField]
+    [Algebra W₂.FunctionField W₁.FunctionField]
+    [IsScalarTower W₂.CoordinateRing W₂.FunctionField W₁.FunctionField]
+    [Algebra.IsSeparable φ.fieldPullback.fieldRange W₁.FunctionField]
+    (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
+    Algebra.IsSeparable W₂.FunctionField W₁.FunctionField :=
+  AlgHom.isSeparable_of_fieldRange φ.fieldPullback
+    (φ.algebraMap_functionField_eq_fieldPullback h)
+
+/-- The canonical tower `W₂.CoordinateRing → W₂.FunctionField → W₁.FunctionField` of an isogeny,
+along the pullback and the function-field pullback. Every result below installs it, and it is the
+only thing the two `letI`s do not give directly. -/
+private theorem isScalarTower_pullback (φ : Isogeny W₁ W₂) :
+    letI := φ.pullback.toRingHom.toAlgebra
+    letI := φ.fieldPullback.toRingHom.toAlgebra
+    IsScalarTower W₂.CoordinateRing W₂.FunctionField W₁.FunctionField := by
+  let _ := φ.pullback.toRingHom.toAlgebra
+  let _ := φ.fieldPullback.toRingHom.toAlgebra
+  refine IsScalarTower.of_algebraMap_eq fun x ↦ ?_
+  rw [φ.fieldPullback.algebraMap_toAlgebra_apply, φ.pullback.algebraMap_toAlgebra_apply,
+    fieldPullback_algebraMap]
+
+/-- **The corestricted pullback of a separable isogeny is a finite ring map**: the intermediate
+ring is a finite module over the target coordinate ring, along `φ.pullbackToIntermediateRing`.
+
+This is `Isogeny.moduleFinite_intermediateRing` with the algebra structures built from `φ` rather
+than supplied by the caller, and separability taken in the `fieldRange` spelling of
+`Isogeny/Separability.lean`. Integral closedness of `W₂.CoordinateRing` comes from
+`WeierstrassCurve.Affine.isIntegrallyClosed_coordinateRing` for an elliptic curve. -/
+theorem finite_pullbackToIntermediateRing (φ : Isogeny W₁ W₂)
+    [IsIntegrallyClosed W₂.CoordinateRing]
+    [Algebra.IsSeparable φ.fieldPullback.fieldRange W₁.FunctionField] :
+    φ.pullbackToIntermediateRing.Finite := by
+  let _ := φ.pullback.toRingHom.toAlgebra
+  let _ := φ.fieldPullback.toRingHom.toAlgebra
+  let _ := φ.pullbackToIntermediateRing.toAlgebra
+  have h := φ.pullback.algebraMap_toAlgebra_apply
+  have := φ.isScalarTower_pullback
+  have := φ.isSeparable_functionField h
+  have := φ.isScalarTower_intermediateRing rfl h
+  exact φ.moduleFinite_intermediateRing h
+
+/-- **The intermediate ring of a separable isogeny is a Dedekind domain**, with nothing for the
+caller to supply.
+
+This is `Isogeny.isDedekindDomain_intermediateRing` with the algebra structures built from `φ` and
+separability taken in the `fieldRange` spelling of `Isogeny/Separability.lean`. The Dedekind
+property of `W₂.CoordinateRing` comes from
+`WeierstrassCurve.Affine.isDedekindDomain_coordinateRing` for an elliptic curve.
+
+An `instance`: `Isogeny.pushClass` asks for exactly this hypothesis, and both of the premises are
+themselves classes, so instance search can discharge it whenever the caller has a separable isogeny
+into a curve with Dedekind coordinate ring. -/
+instance isDedekindDomain_intermediateRing_of_isSeparable (φ : Isogeny W₁ W₂)
+    [IsDedekindDomain W₂.CoordinateRing]
+    [Algebra.IsSeparable φ.fieldPullback.fieldRange W₁.FunctionField] :
+    IsDedekindDomain φ.intermediateRing := by
+  let _ := φ.pullback.toRingHom.toAlgebra
+  let _ := φ.fieldPullback.toRingHom.toAlgebra
+  have h := φ.pullback.algebraMap_toAlgebra_apply
+  have := φ.isScalarTower_pullback
+  have := φ.isSeparable_functionField h
+  exact φ.isDedekindDomain_intermediateRing h
+
+end Isogeny
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Separable.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Separable.lean
@@ -31,7 +31,7 @@ spelling** — `Algebra.IsSeparable φ.fieldPullback.fieldRange W₁.FunctionFie
 `φ.fieldPullback.fieldRange` is an intermediate field of `W₁.FunctionField` — and builds every
 structure the sibling wants out of `φ` alone.
 
-The bridge between the two spellings of separability is `AlgHom.isSeparable_of_fieldRange`: the
+The bridge between the two spellings of separability is `TauCeti.isSeparable_of_fieldRange`: the
 range restriction `φ.fieldPullback.equivFieldRange` identifies `W₂.FunctionField` with
 `φ.fieldPullback.fieldRange`, so a separable extension of the one is a separable extension of the
 other.
@@ -101,7 +101,7 @@ theorem isSeparable_functionField (φ : Isogeny W₁ W₂)
     [Algebra.IsSeparable φ.fieldPullback.fieldRange W₁.FunctionField]
     (h : ∀ x, algebraMap W₂.CoordinateRing W₁.FunctionField x = φ.pullback x) :
     Algebra.IsSeparable W₂.FunctionField W₁.FunctionField :=
-  AlgHom.isSeparable_of_fieldRange φ.fieldPullback
+  isSeparable_of_fieldRange φ.fieldPullback
     (φ.algebraMap_functionField_eq_fieldPullback h)
 
 /-- The canonical tower `W₂.CoordinateRing → W₂.FunctionField → W₁.FunctionField` of an isogeny,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/PushClass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/PushClass.lean
@@ -81,6 +81,28 @@ pulled-back `W₃.CoordinateRing` by `ψ.mapsInfinity` — but the composition l
 `Ideal.relNorm` along that tower, which the pinned Mathlib does not carry. The identity law below
 needs no such input.
 
+## Provenance
+
+⚠ *mathlib-track*. `TauCetiRoadmap/EllipticCurves/README.md:1092` lists "`pushClass` by ideal
+extension and relative norm (`ClassGroup.extendedRelNormHom`)" among the components of
+D. Angdinata's shared isogeny development, on the way to `toPointHom`; the sibling `Isogeny` and
+`IntermediateRing` files carry the same flag for the objects it is assembled from. It is built here
+only until those PRs land, and deduplicated when they do.
+
+Nothing is ported. The composite itself is `ClassGroup.extendedRelNormHom`, already in
+`TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean` with its own provenance, and the two
+corestrictions are `IntermediateRing/Basic.lean`'s; what is new here is only that they are joined,
+with the algebra structures pinned. The nearest relative in the AINTLIB project
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/hasse-weil @ 513e83879e2f`, by Chris Birkbeck) is
+`HasseWeil/Pic0/IsogenyClassGroup.lean`, whose `classNorm ∘ classMap` is the **endomorphism** case
+— both sides one class group — as `ExtendedRelNorm.lean` records; no declaration below corresponds
+to one of its declarations.
+
+The roadmap's hypothesis inventory at that same passage predicts `[IsIntegrallyClosed
+W₂.CoordinateRing]` and `[DecidableEq F]` for the class-group half. What is carried here instead is
+`[IsDedekindDomain W₂.CoordinateRing]` — `ClassGroup.relNorm` is stated over Dedekind domains, not
+merely normal ones — and no decidability at all.
+
 ## References
 
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2, III.4.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/PushClass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/PushClass.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Basic
+public import TauCeti.RingTheory.ClassGroup.ExtendedRelNorm
+-- Public: `finite_pullbackToIntermediateRing` occurs in the statement of `pushClass_id`, and the
+-- Dedekind instance beside it is what makes that statement elaborate.
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Separable
+-- Proof-only: the rank of the intermediate ring is what makes the identity's pushforward the
+-- identity, and the degree is read through it; neither occurs in a statement here.
+import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.IntermediateRing.Rank
+
+/-!
+# The class-group pushforward of an isogeny
+
+An isogeny `φ : W₁ → W₂` pushes ideal classes forward,
+`pushClass φ : ClassGroup W₁.CoordinateRing →* ClassGroup W₂.CoordinateRing`, by extending an
+ideal of `W₁.CoordinateRing` into `φ.intermediateRing` — the integral closure of
+`W₂.CoordinateRing` in `W₁.FunctionField`, which receives both coordinate rings — and taking the
+relative ideal norm back down to `W₂.CoordinateRing`. Both steps are already available:
+`ClassGroup.extendedRelNormHom` is exactly this composite for three rings sharing an overring, and
+`IntermediateRing/Basic.lean` corestricts the two coordinate rings into that overring.
+
+This is the middle link of the "points come along" milestone of
+`TauCetiRoadmap/EllipticCurves/README.md` §Layer 1: "Ideal extension into it followed by the
+**relative ideal norm** down to `W₂.CoordinateRing` gives `pushClass` on class groups, whence
+`toPointHom : W₁.Point →+ W₂.Point` through `toClassEquiv`". Conjugating `pushClass` by
+`toClassEquiv` is what remains, and it waits on surjectivity of Mathlib's `Point.toClass` — the
+Layer-0 anchor, of which only the equivalent condition
+`WeierstrassCurve.Affine.Point.toClass_surjective_iff` is in the repository. The point of routing
+the induced map on points this way is that it is additive *by construction*: `pushClass` is a
+monoid homomorphism of class groups, so no separate rigidity theorem (AEC III.4.8) is needed.
+
+## Main definitions
+
+* `TauCeti.Isogeny.pushClass`: the class-group pushforward of an isogeny.
+
+## Main results
+
+* `TauCeti.Isogeny.pushClass_eq_extendedRelNormHom`: `pushClass` is `ClassGroup.extendedRelNormHom`
+  read against any algebra structures agreeing with the two corestrictions — the gateway to that
+  homomorphism's computation rules, `ClassGroup.extendedRelNormHom_apply` and
+  `ClassGroup.extendedRelNormHom_mk0`.
+* `TauCeti.Isogeny.pushClass_id`: **the identity isogeny pushes classes forward by the identity.**
+
+## Design
+
+**The algebra structures are built into the definition, not asked of the caller.** Neither
+`Algebra W₁.CoordinateRing φ.intermediateRing` nor `Algebra W₂.CoordinateRing φ.intermediateRing`
+is a global instance — for an endomorphism the two would be a diamond, which is precisely the
+elaboration problem `ClassGroup/ExtendedRelNorm.lean` records — so `pushClass` installs
+`φ.toIntermediateRing.toAlgebra` and `φ.pullbackToIntermediateRing.toAlgebra` itself. That is what
+makes it more than a specialisation of `ClassGroup.extendedRelNormHom`: it pins the two structures
+that the composite is otherwise free to choose, and the choice is what carries the geometry (the
+source coordinate ring enters as functions, the target through the pullback).
+
+Consequently the two remaining hypotheses are stated so that no structure is needed to write them
+down. Dedekindness of `φ.intermediateRing` is intrinsic to the ring, so it is an instance argument
+and `IntermediateRing/Separable.lean` discharges it by instance search for a separable isogeny into
+a curve with Dedekind coordinate ring; module-finiteness over `W₂.CoordinateRing` is finiteness
+*along* the corestricted pullback, which is Mathlib's `RingHom.Finite` — not a class, so it is
+passed by name, `Isogeny.finite_pullbackToIntermediateRing` being the same file's witness.
+`pushClass_id` below exercises both. Torsion-freeness on either side is not a hypothesis at all: it
+is injectivity of the two corestrictions, proved in `IntermediateRing/Basic.lean`.
+
+**Why the composite is a homomorphism of the *whole* class group.** `ClassGroup.relNorm` is
+multiplicative because `Ideal.relNorm` is, and it descends to classes because the norm of a
+principal ideal is principal; extension of ideals is multiplicative for the same reason. Neither
+step sees the curve. What the curve supplies is the ring in the middle — that
+`W₁.CoordinateRing` lands in the integral closure of `W₂.CoordinateRing` is exactly
+`mapsInfinity`, the pointedness of the isogeny.
+
+**What is not here.** Functoriality `pushClass (ψ ∘ φ) = pushClass ψ ∘ pushClass φ` is left to
+separate work: the intermediate rings of `φ`, `ψ` and `ψ ∘ φ` form a tower — `φ.intermediateRing`
+does sit inside `(ψ.comp φ).intermediateRing`, since `W₂.CoordinateRing` is integral over the
+pulled-back `W₃.CoordinateRing` by `ψ.mapsInfinity` — but the composition law needs transitivity of
+`Ideal.relNorm` along that tower, which the pinned Mathlib does not carry. The identity law below
+needs no such input.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.2, III.4.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Isogeny
+
+variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
+
+/-- **The class-group pushforward of an isogeny.** An ideal class of the source coordinate ring is
+extended into `φ.intermediateRing`, the integral closure of the target coordinate ring in the
+source function field, and normed back down to the target coordinate ring.
+
+The two algebra structures on the intermediate ring are the corestrictions
+`φ.toIntermediateRing` and `φ.pullbackToIntermediateRing` of `IntermediateRing/Basic.lean`; they
+are installed here rather than demanded of the caller, since neither can be a global instance.
+Torsion-freeness over both coordinate rings is their injectivity and so costs no hypothesis. -/
+noncomputable def pushClass (φ : Isogeny W₁ W₂) [IsDedekindDomain W₂.CoordinateRing]
+    [IsDedekindDomain φ.intermediateRing] (hfin : φ.pullbackToIntermediateRing.Finite) :
+    ClassGroup W₁.CoordinateRing →* ClassGroup W₂.CoordinateRing :=
+  letI := φ.toIntermediateRing.toAlgebra
+  letI := φ.pullbackToIntermediateRing.toAlgebra
+  haveI : Module.Finite W₂.CoordinateRing φ.intermediateRing := hfin
+  haveI : Module.IsTorsionFree W₁.CoordinateRing φ.intermediateRing :=
+    Module.isTorsionFree_iff_algebraMap_injective.2 φ.toIntermediateRing_injective
+  haveI : Module.IsTorsionFree W₂.CoordinateRing φ.intermediateRing :=
+    Module.isTorsionFree_iff_algebraMap_injective.2 φ.pullbackToIntermediateRing_injective
+  ClassGroup.extendedRelNormHom W₁.CoordinateRing φ.intermediateRing W₂.CoordinateRing
+
+/-- **`pushClass` is `ClassGroup.extendedRelNormHom` for the two corestrictions.**
+
+Stated for arbitrary algebra structures on `φ.intermediateRing` whose structure maps are the
+corestricted `algebraMap` and the corestricted pullback, so that a caller's own structures are
+accepted rather than only the locally-built ones — the idiom of
+`Isogeny.isIntegralClosure_intermediateRing` and `Isogeny.isScalarTower_intermediateRing`. This is
+how a consumer computes with `pushClass`: rewriting by it turns a goal about the pushforward into
+one about `ClassGroup.extendedRelNormHom`, where `ClassGroup.extendedRelNormHom_apply` unfolds the
+composite and `ClassGroup.extendedRelNormHom_mk0` evaluates it on the class of an integral ideal. -/
+theorem pushClass_eq_extendedRelNormHom (φ : Isogeny W₁ W₂) [IsDedekindDomain W₂.CoordinateRing]
+    [IsDedekindDomain φ.intermediateRing] (hfin : φ.pullbackToIntermediateRing.Finite)
+    [inst₁ : Algebra W₁.CoordinateRing φ.intermediateRing]
+    [inst₂ : Algebra W₂.CoordinateRing φ.intermediateRing]
+    [Module.IsTorsionFree W₁.CoordinateRing φ.intermediateRing]
+    [Module.Finite W₂.CoordinateRing φ.intermediateRing]
+    [Module.IsTorsionFree W₂.CoordinateRing φ.intermediateRing]
+    (h₁ : inst₁ = φ.toIntermediateRing.toAlgebra)
+    (h₂ : inst₂ = φ.pullbackToIntermediateRing.toAlgebra) :
+    φ.pushClass hfin =
+      ClassGroup.extendedRelNormHom W₁.CoordinateRing φ.intermediateRing W₂.CoordinateRing := by
+  -- the remaining instances are propositions, so the two sides agree once the data does
+  subst h₁
+  subst h₂
+  rfl
+
+/-- **The identity isogeny's two corestrictions coincide.** Its pullback is the embedding of the
+coordinate ring in its own function field, so extending an ideal along `toIntermediateRing` and
+norming along `pullbackToIntermediateRing` happen over one and the same ring map. -/
+theorem id_toIntermediateRing (W : WeierstrassCurve.Affine F) :
+    (id W).toIntermediateRing = (id W).pullbackToIntermediateRing := by
+  refine RingHom.ext fun x ↦ Subtype.ext ?_
+  rw [coe_toIntermediateRing, coe_pullbackToIntermediateRing, id_pullback,
+    CoordinatePullback.id_apply]
+
+/-- **The identity isogeny pushes ideal classes forward by the identity.**
+
+Extending and norming back down along one and the same ring map raises a class to the power
+`[φ.intermediateRing : W.CoordinateRing]` (`ClassGroup.relNorm_extendedHom`), and for the identity
+that rank is `deg (id W) = 1` by `Isogeny.finrank_intermediateRing` — the intermediate ring being
+`W.CoordinateRing` itself, sitting in its own function field.
+
+Both structural hypotheses of `pushClass` are discharged rather than assumed: the identity is
+separable (`Isogeny.isSeparable_id`), so `IntermediateRing/Separable.lean` supplies Dedekindness of
+its intermediate ring by instance search and finiteness of the corestricted pullback by name. For
+an elliptic `W` the remaining hypothesis is
+`WeierstrassCurve.Affine.isDedekindDomain_coordinateRing`. -/
+@[simp]
+theorem pushClass_id (W : WeierstrassCurve.Affine F) [IsDedekindDomain W.CoordinateRing] :
+    (id W).pushClass (id W).finite_pullbackToIntermediateRing =
+      MonoidHom.id (ClassGroup W.CoordinateRing) := by
+  let _ := (id W).pullbackToIntermediateRing.toAlgebra
+  have hfin := (id W).finite_pullbackToIntermediateRing
+  have : Module.Finite W.CoordinateRing (id W).intermediateRing := hfin
+  have : Module.IsTorsionFree W.CoordinateRing (id W).intermediateRing :=
+    Module.isTorsionFree_iff_algebraMap_injective.2 (id W).pullbackToIntermediateRing_injective
+  -- the identity pullback is the embedding into the function field, so both corestrictions are
+  -- the registered structure map
+  have hpull : ∀ x, algebraMap W.CoordinateRing W.FunctionField x = (id W).pullback x :=
+    fun x ↦ by rw [id_pullback, CoordinatePullback.id_apply]
+  have := (id W).isScalarTower_intermediateRing rfl hpull
+  have hrank : Module.finrank W.CoordinateRing (id W).intermediateRing = 1 := by
+    rw [(id W).finrank_intermediateRing hpull, degree_id]
+  refine MonoidHom.ext fun c ↦ ?_
+  rw [(id W).pushClass_eq_extendedRelNormHom hfin (congrArg RingHom.toAlgebra
+    (id_toIntermediateRing W).symm) rfl, ClassGroup.extendedRelNormHom_apply,
+    ClassGroup.relNorm_extendedHom, hrank, pow_one, MonoidHom.id_apply]
+
+end Isogeny
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
@@ -170,15 +170,17 @@ theorem separableDegree_ne_zero (φ : Isogeny W₁ W₂) : φ.separableDegree �
 theorem inseparableDegree_ne_zero (φ : Isogeny W₁ W₂) : φ.inseparableDegree ≠ 0 :=
   φ.inseparableDegree_pos.ne'
 
-/-- **The identity isogeny has separable degree one.** -/
-@[simp]
+/-- **The identity isogeny has separable degree one.** Not `@[simp]`: `isSeparable_id` below makes
+`separableDegree_eq_degree_of_isSeparable` and `degree_id` normalise `(id W).separableDegree` to
+`1` already, so a `simp` lemma here would only duplicate them. -/
 theorem separableDegree_id (W : WeierstrassCurve.Affine F) : (id W).separableDegree = 1 := by
   have h : (id W).separableDegree * (id W).inseparableDegree = 1 :=
     ((id W).separableDegree_mul_inseparableDegree.trans (degree_id W))
   exact Nat.eq_one_of_mul_eq_one_right h
 
-/-- **The identity isogeny has inseparable degree one.** -/
-@[simp]
+/-- **The identity isogeny has inseparable degree one.** Not `@[simp]`, for the reason given on
+`separableDegree_id`; it is instead the input to `isSeparable_id`, so it must be proved here from
+the degree factorisation rather than from separability. -/
 theorem inseparableDegree_id (W : WeierstrassCurve.Affine F) : (id W).inseparableDegree = 1 := by
   have h : (id W).separableDegree * (id W).inseparableDegree = 1 :=
     ((id W).separableDegree_mul_inseparableDegree.trans (degree_id W))

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
@@ -35,7 +35,8 @@ this file names those two parts and records that they multiply to the degree.
 * `TauCeti.Isogeny.separableDegree_pos` and `TauCeti.Isogeny.inseparableDegree_pos`: both are
   positive, so neither factor is degenerate.
 * `TauCeti.Isogeny.separableDegree_id` and `TauCeti.Isogeny.inseparableDegree_id`: both are `1`
-  for the identity isogeny.
+  for the identity isogeny, whence `TauCeti.Isogeny.isSeparable_id` — the identity is separable,
+  as an instance.
 * `TauCeti.Isogeny.separableDegree_comp` and `TauCeti.Isogeny.inseparableDegree_comp`: both are
   multiplicative under composition, matching `degree_comp`.
 * `TauCeti.Isogeny.separableDegree_eq_degree_of_isSeparable` and
@@ -227,6 +228,16 @@ theorem inseparableDegree_eq_one_iff_isSeparable (φ : Isogeny W₁ W₂) :
     φ.inseparableDegree = 1 ↔
       Algebra.IsSeparable φ.fieldPullback.fieldRange W₁.FunctionField :=
   φ.inseparableDegree_def ▸ (isSeparable_iff_finInsepDegree_eq_one _ _).symm
+
+/-- **The identity isogeny is separable.** Its function-field pullback is the identity, so the
+extension it measures is trivial; concretely, `inseparableDegree_id` reads `1`, which by
+`inseparableDegree_eq_one_iff_isSeparable` is separability.
+
+An `instance`, so that results carrying separability as a hypothesis apply to `id W` with nothing
+to supply — `Isogeny.pushClass_id` is the consumer. -/
+instance isSeparable_id (W : WeierstrassCurve.Affine F) :
+    Algebra.IsSeparable (id W).fieldPullback.fieldRange W.FunctionField :=
+  ((id W).inseparableDegree_eq_one_iff_isSeparable).1 (inseparableDegree_id W)
 
 variable {W₃ : WeierstrassCurve.Affine F}
 

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -30,6 +30,7 @@ different embeddings `f` induce different structures, so none can be registered 
 * `TauCeti.AlgHom.finrank_fieldRange`: `[L : f.fieldRange] = [L : K]`.
 * `TauCeti.AlgHom.finiteDimensional_of_fieldRange`: finiteness over the range transfers to the
   source — the same identification read for the property rather than the number.
+* `TauCeti.AlgHom.isSeparable_of_fieldRange`: separability over the range transfers to the source.
 * `TauCeti.AlgHom.finSepDegree_fieldRange` and `TauCeti.AlgHom.finInsepDegree_fieldRange`: the
   same for the separable and inseparable degrees. These are the `f.fieldRange` cases of the
   general transports in `TauCeti.FieldTheory.SeparableDegree`, which is where a caller holding
@@ -68,6 +69,20 @@ theorem finiteDimensional_of_fieldRange (f : K →ₐ[F] L) [Algebra K L]
     (h : ∀ z, algebraMap K L z = f z) [FiniteDimensional f.fieldRange L] :
     FiniteDimensional K L :=
   Module.Finite.of_equiv_equiv f.equivFieldRange.toRingEquiv.symm (RingEquiv.refl L) <| by
+    ext z
+    simpa [h] using (_root_.AlgHom.equivFieldRange_apply_coe f (f.equivFieldRange.symm z)).symm
+
+/-- **Separability above the range of a field embedding transfers to its source.** The range
+restriction `f.equivFieldRange` identifies `K` with `f.fieldRange`, so `L` is separable over the
+one exactly when it is over the other.
+
+The counterpart of `finiteDimensional_of_fieldRange` for separability, and needed for the same
+reason: separability of a map of fields is naturally recorded over its *range*, an intermediate
+field of `L`, while every Mathlib result about a separable extension asks for it over a base
+type. -/
+theorem isSeparable_of_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
+    [Algebra.IsSeparable f.fieldRange L] : Algebra.IsSeparable K L :=
+  Algebra.IsSeparable.of_equiv_equiv f.equivFieldRange.toRingEquiv.symm (RingEquiv.refl L) <| by
     ext z
     simpa [h] using (_root_.AlgHom.equivFieldRange_apply_coe f (f.equivFieldRange.symm z)).symm
 

--- a/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
+++ b/TauCeti/FieldTheory/IntermediateField/FieldRange.lean
@@ -30,7 +30,9 @@ different embeddings `f` induce different structures, so none can be registered 
 * `TauCeti.AlgHom.finrank_fieldRange`: `[L : f.fieldRange] = [L : K]`.
 * `TauCeti.AlgHom.finiteDimensional_of_fieldRange`: finiteness over the range transfers to the
   source — the same identification read for the property rather than the number.
-* `TauCeti.AlgHom.isSeparable_of_fieldRange`: separability over the range transfers to the source.
+* `TauCeti.isSeparable_of_fieldRange`: separability over the range transfers to the source. It sits
+  directly in `TauCeti` rather than beside its siblings: `scripts/lint-dot-notation.py` rejects a
+  new `TauCeti.AlgHom` declaration, since that name would not give dot notation on `AlgHom`.
 * `TauCeti.AlgHom.finSepDegree_fieldRange` and `TauCeti.AlgHom.finInsepDegree_fieldRange`: the
   same for the separable and inseparable degrees. These are the `f.fieldRange` cases of the
   general transports in `TauCeti.FieldTheory.SeparableDegree`, which is where a caller holding
@@ -72,20 +74,6 @@ theorem finiteDimensional_of_fieldRange (f : K →ₐ[F] L) [Algebra K L]
     ext z
     simpa [h] using (_root_.AlgHom.equivFieldRange_apply_coe f (f.equivFieldRange.symm z)).symm
 
-/-- **Separability above the range of a field embedding transfers to its source.** The range
-restriction `f.equivFieldRange` identifies `K` with `f.fieldRange`, so `L` is separable over the
-one exactly when it is over the other.
-
-The counterpart of `finiteDimensional_of_fieldRange` for separability, and needed for the same
-reason: separability of a map of fields is naturally recorded over its *range*, an intermediate
-field of `L`, while every Mathlib result about a separable extension asks for it over a base
-type. -/
-theorem isSeparable_of_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
-    [Algebra.IsSeparable f.fieldRange L] : Algebra.IsSeparable K L :=
-  Algebra.IsSeparable.of_equiv_equiv f.equivFieldRange.toRingEquiv.symm (RingEquiv.refl L) <| by
-    ext z
-    simpa [h] using (_root_.AlgHom.equivFieldRange_apply_coe f (f.equivFieldRange.symm z)).symm
-
 /-- **The separable degree above the range of a field embedding equals the one above its
 source.** The `f.fieldRange` case of `Field.finSepDegree_eq_of_surjective`. -/
 theorem finSepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z) :
@@ -113,3 +101,27 @@ theorem finInsepDegree_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, 
       rw [RingHom.algebraMap_toAlgebra]; exact f.equivFieldRange.apply_symm_apply r⟩
 
 end TauCeti.AlgHom
+
+namespace TauCeti
+
+variable {F K L : Type*} [Field F] [Field K] [Field L] [Algebra F K] [Algebra F L]
+
+/-- **Separability above the range of a field embedding transfers to its source.** The range
+restriction `f.equivFieldRange` identifies `K` with `f.fieldRange`, so `L` is separable over the
+one exactly when it is over the other.
+
+The counterpart of `AlgHom.finiteDimensional_of_fieldRange` for separability, and needed for the
+same reason: separability of a map of fields is naturally recorded over its *range*, an intermediate
+field of `L`, while every Mathlib result about a separable extension asks for it over a base type.
+
+Unlike its siblings above this is not in an `AlgHom` namespace, so it is applied as
+`isSeparable_of_fieldRange f` rather than by dot notation: a `TauCeti.AlgHom` name would not
+resolve as dot notation on an `AlgHom` anyway, and `scripts/lint-dot-notation.py` rejects new
+ones. -/
+theorem isSeparable_of_fieldRange (f : K →ₐ[F] L) [Algebra K L] (h : ∀ z, algebraMap K L z = f z)
+    [Algebra.IsSeparable f.fieldRange L] : Algebra.IsSeparable K L :=
+  Algebra.IsSeparable.of_equiv_equiv f.equivFieldRange.toRingEquiv.symm (RingEquiv.refl L) <| by
+    ext z
+    simpa [h] using (_root_.AlgHom.equivFieldRange_apply_coe f (f.equivFieldRange.symm z)).symm
+
+end TauCeti


### PR DESCRIPTION
This PR defines `Isogeny.pushClass`, the map on ideal class groups that an isogeny of affine Weierstrass curves induces: an ideal of `W₁.CoordinateRing` is extended into `φ.intermediateRing` — the integral closure of `W₂.CoordinateRing` in `W₁.FunctionField`, which receives both coordinate rings — and its relative ideal norm is taken down to `W₂.CoordinateRing`. This is the milestone `TauCetiRoadmap/EllipticCurves/README.md` §Layer 1 states as "Ideal extension into it followed by the **relative ideal norm** down to `W₂.CoordinateRing` gives `pushClass` on class groups, whence **`toPointHom : W₁.Point →+ W₂.Point`** (seeded) through `toClassEquiv`", inside the "The intermediate ring and the induced map on points" bullet. Every input that milestone names was already in place — the intermediate ring with its two corestrictions, its module-finiteness, Dedekindness and integral closedness, and the two-ring composite `ClassGroup.extendedRelNormHom` — and `pushClass` is the link that joins them; what remains for the milestone after this PR is conjugating `pushClass` by `toClassEquiv` to get `toPointHom`, which waits on surjectivity of Mathlib's `Point.toClass` (the Layer-0 anchor, of which the repository so far has only the equivalent condition `Point.toClass_surjective_iff`).

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"isogeny-pushclass"}-->

The definition installs the two algebra structures itself rather than asking the caller for them. Neither `Algebra W₁.CoordinateRing φ.intermediateRing` nor `Algebra W₂.CoordinateRing φ.intermediateRing` can be a global instance — for an endomorphism the two would be a diamond, the elaboration problem `TauCeti/RingTheory/ClassGroup/ExtendedRelNorm.lean` already records — so pinning them is exactly what makes `pushClass` more than a specialisation of `ClassGroup.extendedRelNormHom`, and the choice is what carries the geometry: the source coordinate ring enters as functions, the target through the pullback. `Isogeny.pushClass_eq_extendedRelNormHom` is the gateway back to that homomorphism's computation rules, stated against any algebra structures agreeing with the two corestrictions, in the idiom of the existing `isIntegralClosure_intermediateRing` and `isScalarTower_intermediateRing`. Torsion-freeness on either side is not a hypothesis: it is injectivity of the two corestrictions, already proved.

The two hypotheses that remain are stated so that no algebra structure is needed to write them down — Dedekindness of `φ.intermediateRing`, which is intrinsic to the ring, and module-finiteness *along* the corestricted pullback, which is Mathlib's `RingHom.Finite`. `TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/IntermediateRing/Separable.lean` discharges both from separability of the isogeny in the repository's own spelling (`Algebra.IsSeparable φ.fieldPullback.fieldRange W₁.FunctionField`, the form `Isogeny/Separability.lean` works with): it rebuilds every structure the existing `moduleFinite_intermediateRing` and `isDedekindDomain_intermediateRing` ask of a caller out of `φ` alone, with `AlgHom.isSeparable_of_fieldRange` — new in `TauCeti/FieldTheory/IntermediateField/FieldRange.lean`, alongside that file's existing `finrank_fieldRange` and `finiteDimensional_of_fieldRange` — bridging the two spellings of separability. The Dedekind half is an `instance`, so a caller with a separable isogeny never supplies it.

`Isogeny.pushClass_id` is the identity law and exercises the whole stack: extending and norming back down along one and the same ring map raises a class to the power `[φ.intermediateRing : W.CoordinateRing]`, and for the identity that rank is `1`. Reading it off is `Isogeny.finrank_intermediateRing` in the new `IntermediateRing/Rank.lean`: the intermediate ring has `Module.finrank` over `W₂.CoordinateRing` equal to `φ.degree`, since `W₂.FunctionField` and `W₁.FunctionField` are the fraction fields of the two rings. That statement needs **no** separability, so it covers Frobenius and the other purely inseparable isogenies, and it is the `finrank` half of the place-free fibre count Layer 1 records as the alternative to Layer 0's point–place dictionary ("the intermediate ring is locally free of rank `deg φ` over the coordinate ring"); it is deliberately not claimed as local freeness. The identity's separability, `Isogeny.isSeparable_id`, drops out of the existing `inseparableDegree_id` and is added as an instance next to it.

Functoriality `pushClass (ψ ∘ φ) = pushClass ψ ∘ pushClass φ` is left to separate work and the module docstring says why: the intermediate rings do form a tower, but the composition law needs transitivity of `Ideal.relNorm` along it, which the pinned Mathlib does not carry. No Mathlib infrastructure is vendored, and no AINTLIB declaration is ported; the ⚠ mathlib-track flag the sibling `Isogeny` files carry for D. Angdinata's shared development applies to `pushClass` too, and the new module records it.

Verified locally: `lake build` and `lake exe axioms` are both green.

🤖 Prepared with Claude Code
