### PR TITLE
feat(Huber): Wedhorn 7.41, a continuous archimedean valuation is bounded by one on A°

### DIFF
--- a/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
@@ -58,9 +58,10 @@ The archimedean hypothesis is on the value group, which is what height one suppl
 archimedean codomain gives it by `MulArchimedean.comap`.
 
 The witness `b` is what analyticity supplies (Wedhorn Remark 7.40(1)), and it is not removable.
-Give `A` the discrete topology: every element is then power-bounded, every valuation is continuous
-(`Valuation.isContinuous_of_discreteTopology`), and `0` is the only topologically nilpotent
-element, so no witness exists — and any `v` with `1 < v a` refutes the conclusion. -/
+Give a *reduced* `A` the discrete topology: every element is then power-bounded, every valuation
+is continuous (`Valuation.isContinuous_of_discreteTopology`), and a power of `x` vanishes only if
+`x` does, so `0` is the sole topologically nilpotent element and no witness exists. Discrete `ℚ`
+carrying a `p`-adic valuation is such an `A`, and there `1 < v p⁻¹` refutes the conclusion. -/
 theorem IsContinuous.le_one_of_isPowerBounded {v : Valuation A Γ₀}
     [MulArchimedean (MonoidWithZeroHom.ValueGroup₀ (.ofClass v))] (hv : v.IsContinuous)
     {b : A} (hb : IsTopologicallyNilpotent b) (hb0 : v b ≠ 0) {a : A}
@@ -73,8 +74,8 @@ theorem IsContinuous.le_one_of_isPowerBounded {v : Valuation A Γ₀}
   obtain ⟨n, hn'⟩ := MulArchimedean.arch (v.restrict b)⁻¹ hgt'
   -- transport the comparison back to `Γ₀` along the strictly monotone embedding
   have hn : (v b)⁻¹ ≤ v a ^ n := by
-    have := MonoidWithZeroHom.ValueGroup₀.embedding_strictMono.le_iff_le.mpr hn'
-    simpa only [map_pow, map_inv₀, embedding_restrict] using this
+    simpa only [map_pow, map_inv₀, embedding_restrict] using
+      MonoidWithZeroHom.ValueGroup₀.embedding_strictMono.le_iff_le.mpr hn'
   -- so `a ^ n * b` has value at least `1`
   have hab : (1 : Γ₀) ≤ v (a ^ n * b) := by
     rw [map_mul, map_pow, ← inv_mul_cancel₀ hb0]

--- a/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
@@ -11,15 +11,18 @@ public import TauCeti.RingTheory.Valuation.Continuous.TopologicallyNilpotent
 /-!
 # A continuous archimedean valuation is bounded by one on the power-bounded elements
 
-**Wedhorn Proposition 7.41.** If `v` is a continuous valuation whose value monoid is
+**Wedhorn Proposition 7.41.** If `v` is a continuous valuation whose codomain `Γ₀` is
 archimedean, and some topologically nilpotent `b` has `v b ≠ 0`, then `v a ≤ 1` for every
 power-bounded `a`.
 
-The two hypotheses on `v` are what Wedhorn's `x ∈ Cont(A)ᵃ of height 1` supplies. Height one
-gives archimedean value group — Mathlib's `Valuation.nonempty_rankOne_iff_mulArchimedean` is that
-equivalence — and analyticity gives the topologically nilpotent `b` with `v b ≠ 0`, which is
-Wedhorn's Remark 7.40(1). Stating the archimedean property and the witness directly rather than
-through `Valuation.RankOne` and `IsAnalyticPoint` keeps the statement at the level its proof uses.
+The two hypotheses on `v` are what Wedhorn's `x ∈ Cont(A)ᵃ of height 1` supplies, with one
+caveat worth stating precisely. `[MulArchimedean Γ₀]` is a condition on the **codomain**, not on
+the value group: Mathlib's `Valuation.nonempty_rankOne_iff_mulArchimedean` yields
+`MulArchimedean (MonoidWithZeroHom.ValueGroup₀ (.ofClass v))`, which is weaker. Height one
+therefore supplies this hypothesis only when `Γ₀` *is* the value group — as it is for `Spv A`,
+whose valuations land in `ValuativeRel.ValueGroupWithZero`. A rank-one valuation into a
+non-archimedean `Γ₀` is not covered here. Analyticity gives the topologically nilpotent `b` with
+`v b ≠ 0`, which is Wedhorn's Remark 7.40(1).
 
 The argument is Wedhorn's. Suppose `1 < v a`. Archimedeanness gives `n` with
 `(v b)⁻¹ ≤ v a ^ n`, hence `1 ≤ v (a ^ n * b)`. But `a ^ n` is power-bounded and `b` is
@@ -46,16 +49,21 @@ open TauCeti Valuation
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀] [MulArchimedean Γ₀]
 
-/-- **Wedhorn Proposition 7.41.** A continuous valuation with archimedean value monoid, which is
-nonzero on some topologically nilpotent element, is bounded by `1` on the power-bounded elements.
+/-- **Wedhorn Proposition 7.41.** A continuous valuation whose codomain is archimedean, and which
+is nonzero on some topologically nilpotent element, is bounded by `1` on the power-bounded elements.
 
-The witness `b` is what analyticity supplies (Wedhorn Remark 7.40(1)); without it the statement
-fails, since the trivial valuation is continuous and unbounded on `A°`. -/
+`[MulArchimedean Γ₀]` constrains the codomain rather than the value group; see the module
+docstring for when height one supplies it.
+
+The witness `b` is what analyticity supplies (Wedhorn Remark 7.40(1)), and it is not removable.
+Give `A` the discrete topology: every element is then power-bounded, every valuation is continuous
+(`Valuation.isContinuous_of_discreteTopology`), and `0` is the only topologically nilpotent
+element, so no witness exists — and any `v` with `1 < v a` refutes the conclusion. -/
 theorem le_one_of_isPowerBounded {v : Valuation A Γ₀} (hv : v.IsContinuous) {b : A}
     (hb : IsTopologicallyNilpotent b) (hb0 : v b ≠ 0) {a : A} (ha : IsPowerBounded a) :
     v a ≤ 1 := by
   by_contra! hgt
-  -- archimedeanness of the value monoid: some power of `v a` overtakes `(v b)⁻¹`
+  -- archimedeanness of `Γ₀`: some power of `v a` overtakes `(v b)⁻¹`
   obtain ⟨n, hn⟩ := MulArchimedean.arch (v b)⁻¹ hgt
   -- so `a ^ n * b` has value at least `1`
   have hab : (1 : Γ₀) ≤ v (a ^ n * b) := by

--- a/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
@@ -31,7 +31,9 @@ topologically nilpotent, so `a ^ n * b` is topologically nilpotent, and continui
 
 ## Main results
 
-* `TauCeti.Huber.le_one_of_isPowerBounded`: Proposition 7.41.
+* `Valuation.IsContinuous.le_one_of_isPowerBounded`: Proposition 7.41. Stated in the
+  `Valuation.IsContinuous` namespace so it is reachable by dot notation on the continuity
+  hypothesis, alongside `Valuation.IsContinuous.lt_one_of_isTopologicallyNilpotent`.
 
 ## References
 
@@ -42,9 +44,9 @@ topologically nilpotent, so `a ^ n * b` is topologically nilpotent, and continui
 
 public section
 
-namespace TauCeti.Huber
+namespace Valuation
 
-open TauCeti Valuation
+open TauCeti.Huber
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀] [MulArchimedean Γ₀]
@@ -59,9 +61,9 @@ The witness `b` is what analyticity supplies (Wedhorn Remark 7.40(1)), and it is
 Give `A` the discrete topology: every element is then power-bounded, every valuation is continuous
 (`Valuation.isContinuous_of_discreteTopology`), and `0` is the only topologically nilpotent
 element, so no witness exists — and any `v` with `1 < v a` refutes the conclusion. -/
-theorem le_one_of_isPowerBounded {v : Valuation A Γ₀} (hv : v.IsContinuous) {b : A}
-    (hb : IsTopologicallyNilpotent b) (hb0 : v b ≠ 0) {a : A} (ha : IsPowerBounded a) :
-    v a ≤ 1 := by
+theorem IsContinuous.le_one_of_isPowerBounded {v : Valuation A Γ₀} (hv : v.IsContinuous)
+    {b : A} (hb : IsTopologicallyNilpotent b) (hb0 : v b ≠ 0) {a : A}
+    (ha : IsPowerBounded a) : v a ≤ 1 := by
   by_contra! hgt
   -- archimedeanness of `Γ₀`: some power of `v a` overtakes `(v b)⁻¹`
   obtain ⟨n, hn⟩ := MulArchimedean.arch (v b)⁻¹ hgt
@@ -73,6 +75,4 @@ theorem le_one_of_isPowerBounded {v : Valuation A Γ₀} (hv : v.IsContinuous) {
   exact absurd hab (not_le.mpr (hv.lt_one_of_isTopologicallyNilpotent
     ((ha.pow n).isTopologicallyNilpotent_mul hb)))
 
-end Huber
-
-end TauCeti
+end Valuation

--- a/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
@@ -22,9 +22,9 @@ Wedhorn's Remark 7.40(1). Stating the archimedean property and the witness direc
 through `Valuation.RankOne` and `IsAnalyticPoint` keeps the statement at the level its proof uses.
 
 The argument is Wedhorn's. Suppose `1 < v a`. Archimedeanness gives `n` with
-`1 < v a ^ n * v b`, so `1 < v (a ^ n * b)`. But `a ^ n` is power-bounded and `b` is
+`(v b)⁻¹ ≤ v a ^ n`, hence `1 ≤ v (a ^ n * b)`. But `a ^ n` is power-bounded and `b` is
 topologically nilpotent, so `a ^ n * b` is topologically nilpotent, and continuity forces
-`v (a ^ n * b) < 1`.
+`v (a ^ n * b) < 1`. The two bounds are incompatible, so no such `a` exists.
 
 ## Main results
 
@@ -54,8 +54,7 @@ fails, since the trivial valuation is continuous and unbounded on `A°`. -/
 theorem le_one_of_isPowerBounded {v : Valuation A Γ₀} (hv : v.IsContinuous) {b : A}
     (hb : IsTopologicallyNilpotent b) (hb0 : v b ≠ 0) {a : A} (ha : IsPowerBounded a) :
     v a ≤ 1 := by
-  by_contra hgt
-  rw [not_le] at hgt
+  by_contra! hgt
   -- archimedeanness of the value monoid: some power of `v a` overtakes `(v b)⁻¹`
   obtain ⟨n, hn⟩ := MulArchimedean.arch (v b)⁻¹ hgt
   -- so `a ^ n * b` has value at least `1`

--- a/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
@@ -11,18 +11,17 @@ public import TauCeti.RingTheory.Valuation.Continuous.TopologicallyNilpotent
 /-!
 # A continuous archimedean valuation is bounded by one on the power-bounded elements
 
-**Wedhorn Proposition 7.41.** If `v` is a continuous valuation whose codomain `Γ₀` is
+**Wedhorn Proposition 7.41.** If `v` is a continuous valuation whose value group is
 archimedean, and some topologically nilpotent `b` has `v b ≠ 0`, then `v a ≤ 1` for every
 power-bounded `a`.
 
-The two hypotheses on `v` are what Wedhorn's `x ∈ Cont(A)ᵃ of height 1` supplies, with one
-caveat worth stating precisely. `[MulArchimedean Γ₀]` is a condition on the **codomain**, not on
-the value group: Mathlib's `Valuation.nonempty_rankOne_iff_mulArchimedean` yields
-`MulArchimedean (MonoidWithZeroHom.ValueGroup₀ (.ofClass v))`, which is weaker. Height one
-therefore supplies this hypothesis only when `Γ₀` *is* the value group — as it is for `Spv A`,
-whose valuations land in `ValuativeRel.ValueGroupWithZero`. A rank-one valuation into a
-non-archimedean `Γ₀` is not covered here. Analyticity gives the topologically nilpotent `b` with
-`v b ≠ 0`, which is Wedhorn's Remark 7.40(1).
+The two hypotheses on `v` are what Wedhorn's `x ∈ Cont(A)ᵃ of height 1` supplies. The
+archimedean condition is imposed on the **value group** `MonoidWithZeroHom.ValueGroup₀ v`, not on
+the codomain, which is what Mathlib's `Valuation.nonempty_rankOne_iff_mulArchimedean` actually
+yields from height one; a caller who happens to have an archimedean codomain gets the instance by
+`MulArchimedean.comap embedding.toMonoidHom embedding_strictMono`. The archimedean step therefore
+runs in `Γ_v` and transports back along the strictly monotone embedding. Analyticity gives the
+topologically nilpotent `b` with `v b ≠ 0`, which is Wedhorn's Remark 7.40(1).
 
 The argument is Wedhorn's. Suppose `1 < v a`. Archimedeanness gives `n` with
 `(v b)⁻¹ ≤ v a ^ n`, hence `1 ≤ v (a ^ n * b)`. But `a ^ n` is power-bounded and `b` is
@@ -49,24 +48,33 @@ namespace Valuation
 open TauCeti.Huber
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
-variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀] [MulArchimedean Γ₀]
+variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀]
 
-/-- **Wedhorn Proposition 7.41.** A continuous valuation whose codomain is archimedean, and which
-is nonzero on some topologically nilpotent element, is bounded by `1` on the power-bounded elements.
+/-- **Wedhorn Proposition 7.41.** A continuous valuation whose value group is archimedean, and
+which is nonzero on some topologically nilpotent element, is bounded by `1` on the power-bounded
+elements.
 
-`[MulArchimedean Γ₀]` constrains the codomain rather than the value group; see the module
-docstring for when height one supplies it.
+The archimedean hypothesis is on the value group, which is what height one supplies; an
+archimedean codomain gives it by `MulArchimedean.comap`.
 
 The witness `b` is what analyticity supplies (Wedhorn Remark 7.40(1)), and it is not removable.
 Give `A` the discrete topology: every element is then power-bounded, every valuation is continuous
 (`Valuation.isContinuous_of_discreteTopology`), and `0` is the only topologically nilpotent
 element, so no witness exists — and any `v` with `1 < v a` refutes the conclusion. -/
-theorem IsContinuous.le_one_of_isPowerBounded {v : Valuation A Γ₀} (hv : v.IsContinuous)
+theorem IsContinuous.le_one_of_isPowerBounded {v : Valuation A Γ₀}
+    [MulArchimedean (MonoidWithZeroHom.ValueGroup₀ (.ofClass v))] (hv : v.IsContinuous)
     {b : A} (hb : IsTopologicallyNilpotent b) (hb0 : v b ≠ 0) {a : A}
     (ha : IsPowerBounded a) : v a ≤ 1 := by
   by_contra! hgt
-  -- archimedeanness of `Γ₀`: some power of `v a` overtakes `(v b)⁻¹`
-  obtain ⟨n, hn⟩ := MulArchimedean.arch (v b)⁻¹ hgt
+  -- archimedeanness of the value group `Γ_v`: some power of `v a` overtakes `(v b)⁻¹` there
+  have hgt' : 1 < v.restrict a := by
+    refine MonoidWithZeroHom.ValueGroup₀.embedding_strictMono.lt_iff_lt.mp ?_
+    simpa only [map_one, embedding_restrict] using hgt
+  obtain ⟨n, hn'⟩ := MulArchimedean.arch (v.restrict b)⁻¹ hgt'
+  -- transport the comparison back to `Γ₀` along the strictly monotone embedding
+  have hn : (v b)⁻¹ ≤ v a ^ n := by
+    have := MonoidWithZeroHom.ValueGroup₀.embedding_strictMono.le_iff_le.mpr hn'
+    simpa only [map_pow, map_inv₀, embedding_restrict] using this
   -- so `a ^ n * b` has value at least `1`
   have hab : (1 : Γ₀) ≤ v (a ^ n * b) := by
     rw [map_mul, map_pow, ← inv_mul_cancel₀ hb0]

--- a/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
+++ b/TauCeti/RingTheory/Huber/Continuous/PowerBounded.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Huber.PowerBounded
+public import TauCeti.RingTheory.Valuation.Continuous.TopologicallyNilpotent
+
+/-!
+# A continuous archimedean valuation is bounded by one on the power-bounded elements
+
+**Wedhorn Proposition 7.41.** If `v` is a continuous valuation whose value monoid is
+archimedean, and some topologically nilpotent `b` has `v b ≠ 0`, then `v a ≤ 1` for every
+power-bounded `a`.
+
+The two hypotheses on `v` are what Wedhorn's `x ∈ Cont(A)ᵃ of height 1` supplies. Height one
+gives archimedean value group — Mathlib's `Valuation.nonempty_rankOne_iff_mulArchimedean` is that
+equivalence — and analyticity gives the topologically nilpotent `b` with `v b ≠ 0`, which is
+Wedhorn's Remark 7.40(1). Stating the archimedean property and the witness directly rather than
+through `Valuation.RankOne` and `IsAnalyticPoint` keeps the statement at the level its proof uses.
+
+The argument is Wedhorn's. Suppose `1 < v a`. Archimedeanness gives `n` with
+`1 < v a ^ n * v b`, so `1 < v (a ^ n * b)`. But `a ^ n` is power-bounded and `b` is
+topologically nilpotent, so `a ^ n * b` is topologically nilpotent, and continuity forces
+`v (a ^ n * b) < 1`.
+
+## Main results
+
+* `TauCeti.Huber.le_one_of_isPowerBounded`: Proposition 7.41.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Proposition 7.41, whose proof
+  this follows step by step, together with Remark 7.40(1) for the witness `b` and Proposition
+  1.14 for height one implying archimedean.
+-/
+
+public section
+
+namespace TauCeti.Huber
+
+open TauCeti Valuation
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A]
+variable {Γ₀ : Type*} [LinearOrderedCommGroupWithZero Γ₀] [MulArchimedean Γ₀]
+
+/-- **Wedhorn Proposition 7.41.** A continuous valuation with archimedean value monoid, which is
+nonzero on some topologically nilpotent element, is bounded by `1` on the power-bounded elements.
+
+The witness `b` is what analyticity supplies (Wedhorn Remark 7.40(1)); without it the statement
+fails, since the trivial valuation is continuous and unbounded on `A°`. -/
+theorem le_one_of_isPowerBounded {v : Valuation A Γ₀} (hv : v.IsContinuous) {b : A}
+    (hb : IsTopologicallyNilpotent b) (hb0 : v b ≠ 0) {a : A} (ha : IsPowerBounded a) :
+    v a ≤ 1 := by
+  by_contra hgt
+  rw [not_le] at hgt
+  -- archimedeanness of the value monoid: some power of `v a` overtakes `(v b)⁻¹`
+  obtain ⟨n, hn⟩ := MulArchimedean.arch (v b)⁻¹ hgt
+  -- so `a ^ n * b` has value at least `1`
+  have hab : (1 : Γ₀) ≤ v (a ^ n * b) := by
+    rw [map_mul, map_pow, ← inv_mul_cancel₀ hb0]
+    exact mul_le_mul' hn le_rfl
+  -- but it is topologically nilpotent, and a continuous valuation is `< 1` there
+  exact absurd hab (not_le.mpr (hv.lt_one_of_isTopologicallyNilpotent
+    ((ha.pow n).isTopologicallyNilpotent_mul hb)))
+
+end Huber
+
+end TauCeti


### PR DESCRIPTION
Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"wedhorn-741-continuous-archimedean-le-one"}-->

**Wedhorn Proposition 7.41.** A continuous valuation whose value monoid is archimedean, and which
is nonzero on some topologically nilpotent element, is bounded by `1` on the power-bounded elements.

```lean
theorem TauCeti.Huber.le_one_of_isPowerBounded {v : Valuation A Γ₀} (hv : v.IsContinuous) {b : A}
    (hb : IsTopologicallyNilpotent b) (hb0 : v b ≠ 0) {a : A} (ha : IsPowerBounded a) :
    v a ≤ 1
```

## Why these hypotheses rather than Wedhorn's

Wedhorn states it for `x ∈ Cont(A)ᵃ` of height 1. The proof uses exactly two consequences of that,
and the statement asks for those instead, which makes it strictly more general and removes any
dependence on `Spa`:

* **height one → archimedean value monoid.** This is his Proposition 1.14, and Mathlib already has
  the equivalence as `Valuation.nonempty_rankOne_iff_mulArchimedean`, so `[MulArchimedean Γ₀]` is
  recoverable from `Valuation.RankOne` and nothing is lost.
* **analytic → a topologically nilpotent `b` with `v b ≠ 0`.** This is his Remark 7.40(1), whose
  content is on `main` as
  `TauCeti.ValuationSpectrum.isAnalyticPoint_iff_exists_mem_extendedIdealOfDefinition_notMem_supp`
  together with the fact that elements of an ideal of definition are topologically nilpotent.

The witness cannot be dropped: the trivial valuation is continuous and unbounded on `A°`. The
declaration docstring says so, so a reader does not try to weaken it.

## Roadmap target

`TauCetiRoadmap/AdicSpaces/README.md` **§3.1 Rational localisation of a Huber pair** ends with:

> A rational subset has many presentations. **Construct the canonical isomorphism between the
> localisations associated with two presentations of the same subset**, prove compatibility for
> three presentations, and construct restriction maps satisfying the identity and composition laws.

Half of that is already on `main`, and it names the missing half itself.
`LocalizationTopology/Presentation.lean:267`, on `presentationRingEquiv`:

> This is the *canonical* half of presentation independence: it says the comparison is an
> isomorphism and is determined by compatibility, **not that the compatibility hypotheses hold for
> two presentations of the same rational subset. Supplying those is a separate step.**

Supplying them needs a valuative criterion for integrality, which AINTLIB's own decomposition
(`PresheafIdentification.lean:1223`) calls "the Wedhorn **7.18 + 7.41** obligation". This PR is
7.41, the half Wedhorn proves outright. It is a prerequisite of a stated roadmap target, which
`.claude/CLAUDE.md` places in scope without a new roadmap node.

## Provenance

T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, **Proposition 7.41**, read from the text. The proof
is his, step for step: assume `1 < v a`; archimedeanness gives `n` with `(v b)⁻¹ ≤ v aⁿ`, so
`1 ≤ v (aⁿ * b)`; but `aⁿ` is power-bounded and `b` is topologically nilpotent, so `aⁿ * b` is
topologically nilpotent and continuity forces `v (aⁿ * b) < 1`.

**Nothing is ported.** AINTLIB @ `37bbdaeb9` states no analogue: its
`locLift_divByS_isPowerBounded` takes its own conclusion as a hypothesis and returns it
(`hpb t ht`), and `HasLocLiftPowerBounded.tate` dispatches through a residual whose body is
`sorry`.

## Not already available

* **Mathlib**: absent. The rank layer is present (`Valuation.RankOne`, `RankLeOne`,
  `nonempty_rankOne_iff_mulArchimedean`) and is used here, but no statement bounds a continuous
  valuation on power-bounded elements — `IsPowerBounded` is a TauCeti notion.
* **TauCeti `main`**: absent. `7.41` appears in no docstring; untruncated grep for
  `le_one_of_isPowerBounded` across `TauCeti/` returns nothing.
* **AINTLIB** @ `37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`: absent, as above.

## Placement

`TauCeti/RingTheory/Huber/Continuous/` is where Huber notions already meet continuous valuations
(`Continuous/Valuation.lean`, `Continuous/OfCofinal.lean`). The `Huber` and
`RingTheory/Valuation/Continuous` trees are import-independent, and the dependency added here runs
Huber → Valuation, the direction the existing files already use, so no cycle is introduced.
