### PR TITLE
chore(Huber): reach the generic first-countability route from the Huber API

### DIFF
--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -46,6 +46,8 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
 * `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`: its neighbourhoods of zero are
   countably generated. With the previous bullet these are exactly the two hypotheses Henkel's open
   mapping theorem asks of the underlying group, so both are instances.
+* `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero_pi`: the same for a countable power
+  `ι → A`, which is what makes a free module `Aᵐ` usable by Remark 8.29's comparison map.
 * `TauCeti.Huber.IsHuberRing.quotient`: a quotient of a Huber ring is a Huber ring.
 * `TauCeti.Huber.PairOfDefinition.isBounded_ringOfDefinition`: a ring of definition is bounded,
   hence `A₀ ≤ A°` (`TauCeti.Huber.PairOfDefinition.le_powerBoundedSubring`). This is the
@@ -480,6 +482,24 @@ point — it is what lets a Huber ring be handed to that theorem without the cal
 anything. -/
 instance IsHuberRing.isCountablyGenerated_nhds_zero : (𝓝 (0 : A)).IsCountablyGenerated :=
   IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦ P.hasBasis_nhds_zero.isCountablyGenerated
+
+/-- **A countable power of a Huber ring also has countably generated neighbourhoods of zero.**
+The product topology's filter at `0` is the product of the coordinate filters (`nhds_pi`), and a
+countable product of countably generated filters is countably generated
+(`Filter.pi.isCountablyGenerated`), so this reduces immediately to
+`TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero` above.
+
+Being an instance is again the point, and here it is what makes a *free module* `Aᵐ` usable: the
+comparison map of Wedhorn's Remark 8.29 is surjective for a finitely generated module only under
+`[(nhds (0 : Fin m → A)).IsCountablyGenerated]`
+(`TauCeti.Huber.restrictedMvPowerSeriesBaseChange_surjective_of_presentation`), and nothing else
+supplies that hypothesis. `Countable` rather than `Finite` because `Filter.pi.isCountablyGenerated`
+asks only for that, and the extra generality costs nothing. -/
+instance IsHuberRing.isCountablyGenerated_nhds_zero_pi {ι : Type*} [Countable ι] :
+    (𝓝 (0 : ι → A)).IsCountablyGenerated := by
+  rw [nhds_pi]
+  simp only [Pi.zero_apply]
+  infer_instance
 
 /-- Wedhorn Corollary 6.4: the power-bounded subring of a Huber ring is open. -/
 theorem isOpen_powerBoundedSubring : IsOpen (powerBoundedSubring A : Set A) := by

--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -9,6 +9,7 @@ public import Mathlib.RingTheory.Finiteness.Ideal
 public import Mathlib.Topology.Algebra.Nonarchimedean.AdicTopology
 public import Mathlib.Topology.Algebra.Ring.Ideal
 public import TauCeti.RingTheory.Huber.PowerBounded
+public import TauCeti.Topology.Algebra.Group.FirstCountable
 
 /-!
 # Huber rings and Tate rings
@@ -46,8 +47,6 @@ Huber ring is nonarchimedean, which is exactly the hypothesis under which
 * `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`: its neighbourhoods of zero are
   countably generated. With the previous bullet these are exactly the two hypotheses Henkel's open
   mapping theorem asks of the underlying group, so both are instances.
-* `TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero_pi`: the same for a countable power
-  `ι → A`, which is what makes a free module `Aᵐ` usable by Remark 8.29's comparison map.
 * `TauCeti.Huber.IsHuberRing.quotient`: a quotient of a Huber ring is a Huber ring.
 * `TauCeti.Huber.PairOfDefinition.isBounded_ringOfDefinition`: a ring of definition is bounded,
   hence `A₀ ≤ A°` (`TauCeti.Huber.PairOfDefinition.le_powerBoundedSubring`). This is the
@@ -482,24 +481,6 @@ point — it is what lets a Huber ring be handed to that theorem without the cal
 anything. -/
 instance IsHuberRing.isCountablyGenerated_nhds_zero : (𝓝 (0 : A)).IsCountablyGenerated :=
   IsHuberRing.nonempty_pairOfDefinition.elim fun P ↦ P.hasBasis_nhds_zero.isCountablyGenerated
-
-/-- **A countable power of a Huber ring also has countably generated neighbourhoods of zero.**
-The product topology's filter at `0` is the product of the coordinate filters (`nhds_pi`), and a
-countable product of countably generated filters is countably generated
-(`Filter.pi.isCountablyGenerated`), so this reduces immediately to
-`TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero` above.
-
-Being an instance is again the point, and here it is what makes a *free module* `Aᵐ` usable: the
-comparison map of Wedhorn's Remark 8.29 is surjective for a finitely generated module only under
-`[(nhds (0 : Fin m → A)).IsCountablyGenerated]`
-(`TauCeti.Huber.restrictedMvPowerSeriesBaseChange_surjective_of_presentation`), and nothing else
-supplies that hypothesis. `Countable` rather than `Finite` because `Filter.pi.isCountablyGenerated`
-asks only for that, and the extra generality costs nothing. -/
-instance IsHuberRing.isCountablyGenerated_nhds_zero_pi {ι : Type*} [Countable ι] :
-    (𝓝 (0 : ι → A)).IsCountablyGenerated := by
-  rw [nhds_pi]
-  simp only [Pi.zero_apply]
-  infer_instance
 
 /-- Wedhorn Corollary 6.4: the power-bounded subring of a Huber ring is open. -/
 theorem isOpen_powerBoundedSubring : IsOpen (powerBoundedSubring A : Set A) := by


### PR DESCRIPTION
Makes the generic first-countability route reachable from the Huber API, so that
`(𝓝 (0 : ι → A)).IsCountablyGenerated` holds by instance search for a countable `ι`.

**This PR originally added a bespoke `Pi` instance. The `reuse` review was right that it was
redundant, and I verified that rather than take it on faith** — with
`TauCeti.Topology.Algebra.Group.FirstCountable` imported and **no** new instance, all three steps
compile by `infer_instance`:

```lean
example : FirstCountableTopology A                                    -- from the existing
example {ι : Type*} [Countable ι] : FirstCountableTopology (ι → A)    -- Mathlib's Pi instance
example (m : ℕ) : (𝓝 (0 : Fin m → A)).IsCountablyGenerated           -- what consumers ask for
```

So the instance is deleted and only the import remains.

**What the import buys.** `FirstCountable` is in no relevant closure — not `Huber/Basic`, not
`Huber/OpenMapping`, and not `Restricted/BaseChange`, where
`restrictedMvPowerSeriesBaseChange_surjective_of_presentation` asks for
`[(nhds (0 : Fin m → A)).IsCountablyGenerated]`. Without this import every consumer of that lemma
has to discover and add it; with it, the hypothesis fires for anything downstream of the Huber
API. The import costs two additional modules (`Mathlib.Topology.Algebra.Group.Basic`,
`Mathlib.Topology.Bases`).

**A correction to this PR's original description**, which claimed "nothing else supplies that
hypothesis". That was false: the generic route supplied it all along and was merely unreachable.
The gap was an import, not a missing instance.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"huber-pi-countable-nhds-zero"}-->

Provenance: no port, and no new declaration. The route is
`TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero` (on `main`) →
`SeparatelyContinuousAdd.toFirstCountableTopology`
(`TauCeti/Topology/Algebra/Group/FirstCountable.lean`) → Mathlib's `Pi` first-countability
instance.
