### PR TITLE
feat: choose a maximal-dimensional unipotent candidate

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -38,6 +38,7 @@ needed in Layer 2 of the ReductiveGroups roadmap.
 * `TauCeti.HopfIdeal.quotientCotangentMap_surjective`: right exactness of the conormal sequence.
 * `TauCeti.HopfIdeal.ker_quotientCotangentMap`: its kernel is the conormal subspace.
 * `TauCeti.HopfIdeal.finrank_quotientLie_add_finrank_conormal`: the resulting dimension formula.
+* `TauCeti.HopfIdeal.finrank_quotientLie_le`: the resulting closed-subgroup dimension bound.
 
 ## References
 
@@ -258,6 +259,18 @@ theorem finrank_quotientLie_add_finrank_conormal (I : HopfIdeal k H)
     Derivation.finrank_eq_finrank_cotangentSpace (k := k) (H := H)
   rw [hquotient, hambient]
   exact finrank_quotientCotangent_add_finrank_conormal I
+
+/-- The Lie dimension of a closed subgroup is at most the Lie dimension of the ambient affine
+group when the ambient cotangent space is finite-dimensional. -/
+theorem finrank_quotientLie_le (I : HopfIdeal k H)
+    [FiniteDimensional k (Bialgebra.CotangentSpace k H)] :
+    Module.finrank k
+        (Derivation k (H ⧸ I.toIdeal)
+          (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) ≤
+      Module.finrank k
+        (Derivation k H (Bialgebra.CounitAlgebra k H k)) := by
+  have h := finrank_quotientLie_add_finrank_conormal I
+  omega
 
 end Field
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
@@ -44,8 +44,8 @@ a maximal-dimension candidate contains every other one and is the unipotent radi
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), Proposition 17.4.
-* A. Borel, *Linear Algebraic Groups*, Proposition 14.4.
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§6.45–6.46.
+* A. Borel, *Linear Algebraic Groups*, §11.21.
 
 This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap. It supplies the
 maximal-dimension choice used after closure of connected normal smooth unipotent subgroups under

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
@@ -17,7 +17,8 @@ public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 
 Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field. A candidate
 for its unipotent radical is a connected normal smooth unipotent closed subgroup. In Hopf
-coordinates this is a Hopf ideal `I` whose quotient `H/I` has those properties.
+coordinates this is a normal Hopf ideal `I` whose quotient `H/I` is geometrically connected,
+smooth, and geometrically unipotent.
 
 This file proves the boundedness step in the standard maximal-dimension construction. The
 trivial subgroup, cut out by the augmentation ideal, is a candidate. The Lie dimension of every
@@ -34,9 +35,9 @@ a maximal-dimension candidate contains every other one and is the unipotent radi
   subgroup in coordinate-Hopf-algebra form.
 * `TauCeti.HopfIdeal.isUnipotentRadicalCandidate_augmentation`: the identity subgroup is a
   candidate.
-* `TauCeti.HopfIdeal.lieFinrank_quotient_le`: the Lie dimension of a closed subgroup is bounded
+* `TauCeti.HopfIdeal.finrank_quotientLie_le`: the Lie dimension of a closed subgroup is bounded
   by that of the ambient affine group.
-* `TauCeti.HopfIdeal.exists_isUnipotentRadicalCandidate_maximal_lieFinrank`: existence of a
+* `TauCeti.HopfIdeal.exists_isUnipotentRadicalCandidate_maximal_finrank_quotientLie`: existence of a
   candidate of maximal Lie dimension.
 
 ## References
@@ -150,24 +151,12 @@ theorem isUnipotentRadicalCandidate_augmentation
   · exact (smoothUnipotentCommHopfAlgProperty k).prop_of_iso
       (quotientAugmentationIso H).symm smoothUnipotent_trivial
 
-/-- The Lie dimension of a closed subgroup is at most the Lie dimension of the ambient
-finite-type affine group. -/
-theorem lieFinrank_quotient_le (H : FiniteTypeCommHopfAlgCat.{u, u} k)
-    (I : HopfIdeal k H) :
-    Module.finrank k
-        (Derivation k (H ⧸ I.toIdeal)
-          (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) ≤
-      Module.finrank k
-        (Derivation k H (Bialgebra.CounitAlgebra k H k)) := by
-  have h := finrank_quotientLie_add_finrank_conormal I
-  omega
-
 /-- There exists a connected normal smooth unipotent closed subgroup of maximal Lie dimension.
 
 The theorem asserts maximality only among unipotent-radical candidates. Turning this candidate
 into the greatest such subgroup requires the separate binary-product theorem: the product with
 any other candidate is again a candidate and cannot have larger dimension. -/
-theorem exists_isUnipotentRadicalCandidate_maximal_lieFinrank
+theorem exists_isUnipotentRadicalCandidate_maximal_finrank_quotientLie
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     ∃ I : HopfIdeal k H,
       IsUnipotentRadicalCandidate H I ∧
@@ -187,7 +176,7 @@ theorem exists_isUnipotentRadicalCandidate_maximal_lieFinrank
     apply (Set.finite_Iic
       (Module.finrank k (Derivation k H (Bialgebra.CounitAlgebra k H k)))).subset
     rintro n ⟨I, _, rfl⟩
-    exact lieFinrank_quotient_le H I
+    exact finrank_quotientLie_le I
   have hdimensions_nonempty : dimensions.Nonempty := by
     exact ⟨_, augmentation k H, isUnipotentRadicalCandidate_augmentation H, rfl⟩
   obtain ⟨n, hn, hnmax⟩ :=

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
@@ -142,7 +142,8 @@ finite-type affine group. -/
 theorem isUnipotentRadicalCandidate_augmentation
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     IsUnipotentRadicalCandidate H (augmentation k H) := by
-  refine ⟨(CommHopfAlgCat.isCentral_augmentation H.obj).isNormal, ?_, ?_⟩
+  refine IsUnipotentRadicalCandidate.mk
+    (CommHopfAlgCat.isCentral_augmentation H.obj).isNormal ?_ ?_
   · exact (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
       ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
         (_root_.CommHopfAlgCat.{u} k)).mapIso (quotientAugmentationIso H).symm)

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Cotangent
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
+public import TauCeti.Algebra.AlgebraicGroup.Trivial
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+
+/-!
+# Candidates for the unipotent radical
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field. A candidate
+for its unipotent radical is a connected normal smooth unipotent closed subgroup. In Hopf
+coordinates this is a Hopf ideal `I` whose quotient `H/I` has those properties.
+
+This file proves the boundedness step in the standard maximal-dimension construction. The
+trivial subgroup, cut out by the augmentation ideal, is a candidate. The Lie dimension of every
+candidate is bounded by the Lie dimension of the ambient group, by the conormal exact sequence.
+Consequently the set of Lie dimensions attained by candidates is a nonempty finite set of natural
+numbers, and some candidate has maximal Lie dimension.
+
+Binary-product closure is the next step: once the product of two candidates is again a candidate,
+a maximal-dimension candidate contains every other one and is the unipotent radical.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate`: a connected normal smooth unipotent closed
+  subgroup in coordinate-Hopf-algebra form.
+* `TauCeti.HopfIdeal.isUnipotentRadicalCandidate_augmentation`: the identity subgroup is a
+  candidate.
+* `TauCeti.HopfIdeal.lieFinrank_quotient_le`: the Lie dimension of a closed subgroup is bounded
+  by that of the ambient affine group.
+* `TauCeti.HopfIdeal.exists_isUnipotentRadicalCandidate_maximal_lieFinrank`: existence of a
+  candidate of maximal Lie dimension.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 17.4.
+* A. Borel, *Linear Algebraic Groups*, Proposition 14.4.
+
+This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap. It supplies the
+maximal-dimension choice used after closure of connected normal smooth unipotent subgroups under
+binary products.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal
+
+variable {k : Type u} [Field k]
+
+/-- A Hopf ideal cuts out an **unipotent-radical candidate** when the represented closed subgroup
+is normal, geometrically connected, smooth, and geometrically unipotent.
+
+Normality is a property of the ideal in the ambient coordinate Hopf algebra. The other three
+conditions are properties of its finite-type quotient coordinate Hopf algebra. -/
+def IsUnipotentRadicalCandidate (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (I : HopfIdeal k H) : Prop :=
+  I.IsNormal ∧
+    geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
+    smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I)
+
+/-- Characterization of an unipotent-radical candidate by normality, connectedness, and smooth
+unipotence of the quotient coordinate algebra. -/
+@[simp]
+theorem isUnipotentRadicalCandidate_iff (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (I : HopfIdeal k H) :
+    IsUnipotentRadicalCandidate H I ↔
+      I.IsNormal ∧
+        geometricallyConnectedCommHopfAlgProperty k
+          (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
+        smoothUnipotentCommHopfAlgProperty k
+          (FiniteTypeCommHopfAlgCat.quotient H I) :=
+  Iff.rfl
+
+namespace IsUnipotentRadicalCandidate
+
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
+
+/-- A unipotent-radical candidate is normal in the ambient affine group. -/
+theorem isNormal (hI : IsUnipotentRadicalCandidate H I) : I.IsNormal :=
+  hI.1
+
+/-- A unipotent-radical candidate is geometrically connected. -/
+theorem geometricallyConnected (hI : IsUnipotentRadicalCandidate H I) :
+    geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+  hI.2.1
+
+/-- A unipotent-radical candidate is smooth unipotent. -/
+theorem smoothUnipotent (hI : IsUnipotentRadicalCandidate H I) :
+    smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I) :=
+  hI.2.2
+
+end IsUnipotentRadicalCandidate
+
+/-- The quotient by the augmentation ideal is the trivial finite-type Hopf algebra. -/
+private noncomputable def quotientAugmentationIso
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    FiniteTypeCommHopfAlgCat.quotient H (augmentation k H) ≅
+      FiniteTypeCommHopfAlgCat.of k k := by
+  rw [augmentation_def]
+  exact ObjectProperty.isoMk _ <| _root_.CommHopfAlgCat.isoMk <|
+    kerLiftBialgEquiv (Bialgebra.counitBialgHom k H) Bialgebra.counit_surjective
+
+/-- The trivial finite-type affine group is geometrically connected. -/
+private theorem geometricallyConnected_trivial :
+    geometricallyConnectedCommHopfAlgProperty k (_root_.CommHopfAlgCat.of k k) := by
+  rw [geometricallyConnectedCommHopfAlgProperty_iff]
+  intro K _ _
+  exact (PrimeSpectrum.homeomorphOfRingEquiv
+    (Algebra.TensorProduct.lid k K).toRingEquiv).connectedSpace_iff.mpr inferInstance
+
+/-- The trivial finite-type affine group is smooth unipotent. -/
+private theorem smoothUnipotent_trivial :
+    smoothUnipotentCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.of k k) := by
+  rw [smoothUnipotentCommHopfAlgProperty_iff]
+  refine ⟨⟨inferInstance, inferInstance⟩, fun g ↦ ?_⟩
+  rw [TrivialGroup.convPoint_eq_one g]
+  exact HopfAlgebra.isUnipotentPoint_one
+
+/-- The augmentation ideal cuts out the identity subgroup, hence is an unipotent-radical
+candidate. This makes the family of candidates nonempty without any hypothesis on the ambient
+finite-type affine group. -/
+theorem isUnipotentRadicalCandidate_augmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    IsUnipotentRadicalCandidate H (augmentation k H) := by
+  refine ⟨(CommHopfAlgCat.isCentral_augmentation H.obj).isNormal, ?_, ?_⟩
+  · exact (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
+      ((forget₂ (FiniteTypeCommHopfAlgCat.{u, u} k)
+        (_root_.CommHopfAlgCat.{u} k)).mapIso (quotientAugmentationIso H).symm)
+      geometricallyConnected_trivial
+  · exact (smoothUnipotentCommHopfAlgProperty k).prop_of_iso
+      (quotientAugmentationIso H).symm smoothUnipotent_trivial
+
+/-- The Lie dimension of a closed subgroup is at most the Lie dimension of the ambient
+finite-type affine group. -/
+theorem lieFinrank_quotient_le (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (I : HopfIdeal k H) :
+    Module.finrank k
+        (Derivation k (H ⧸ I.toIdeal)
+          (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) ≤
+      Module.finrank k
+        (Derivation k H (Bialgebra.CounitAlgebra k H k)) := by
+  have h := finrank_quotientLie_add_finrank_conormal I
+  omega
+
+/-- There exists a connected normal smooth unipotent closed subgroup of maximal Lie dimension.
+
+The theorem asserts maximality only among unipotent-radical candidates. Turning this candidate
+into the greatest such subgroup requires the separate binary-product theorem: the product with
+any other candidate is again a candidate and cannot have larger dimension. -/
+theorem exists_isUnipotentRadicalCandidate_maximal_lieFinrank
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    ∃ I : HopfIdeal k H,
+      IsUnipotentRadicalCandidate H I ∧
+        ∀ J : HopfIdeal k H, IsUnipotentRadicalCandidate H J →
+          Module.finrank k
+              (Derivation k (H ⧸ J.toIdeal)
+                (Bialgebra.CounitAlgebra k (H ⧸ J.toIdeal) k)) ≤
+            Module.finrank k
+              (Derivation k (H ⧸ I.toIdeal)
+                (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) := by
+  let dimensions : Set ℕ := {n | ∃ I : HopfIdeal k H,
+    IsUnipotentRadicalCandidate H I ∧
+      Module.finrank k
+        (Derivation k (H ⧸ I.toIdeal)
+          (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) = n}
+  have hdimensions_finite : dimensions.Finite := by
+    apply (Set.finite_Iic
+      (Module.finrank k (Derivation k H (Bialgebra.CounitAlgebra k H k)))).subset
+    rintro n ⟨I, _, rfl⟩
+    exact lieFinrank_quotient_le H I
+  have hdimensions_nonempty : dimensions.Nonempty := by
+    exact ⟨_, augmentation k H, isUnipotentRadicalCandidate_augmentation H, rfl⟩
+  obtain ⟨n, hn, hnmax⟩ :=
+    Set.exists_max_image dimensions id hdimensions_finite hdimensions_nonempty
+  obtain ⟨I, hI, hIn⟩ := hn
+  refine ⟨I, hI, fun J hJ ↦ ?_⟩
+  have hJmem : Module.finrank k
+      (Derivation k (H ⧸ J.toIdeal)
+        (Bialgebra.CounitAlgebra k (H ⧸ J.toIdeal) k)) ∈ dimensions :=
+    ⟨J, hJ, rfl⟩
+  simpa only [id_eq, hIn] using hnmax _ hJmem
+
+end HopfIdeal
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
@@ -83,6 +83,16 @@ namespace IsUnipotentRadicalCandidate
 
 variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
 
+/-- A normal Hopf ideal with geometrically connected, smooth unipotent quotient is a
+unipotent-radical candidate. -/
+theorem mk (h_normal : I.IsNormal)
+    (h_connected : geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj)
+    (h_smoothUnipotent : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I)) :
+    IsUnipotentRadicalCandidate H I :=
+  ⟨h_normal, h_connected, h_smoothUnipotent⟩
+
 /-- A unipotent-radical candidate is normal in the ambient affine group. -/
 theorem isNormal (hI : IsUnipotentRadicalCandidate H I) : I.IsNormal :=
   hI.1

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
@@ -7,9 +7,11 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Cotangent
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Central
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
-public import TauCeti.Algebra.AlgebraicGroup.Trivial
+import TauCeti.Algebra.AlgebraicGroup.Trivial
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 
 /-!
@@ -76,19 +78,6 @@ def IsUnipotentRadicalCandidate (H : FiniteTypeCommHopfAlgCat.{u, u} k)
       (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
     smoothUnipotentCommHopfAlgProperty k
       (FiniteTypeCommHopfAlgCat.quotient H I)
-
-/-- Characterization of an unipotent-radical candidate by normality, connectedness, and smooth
-unipotence of the quotient coordinate algebra. -/
-@[simp]
-theorem isUnipotentRadicalCandidate_iff (H : FiniteTypeCommHopfAlgCat.{u, u} k)
-    (I : HopfIdeal k H) :
-    IsUnipotentRadicalCandidate H I ↔
-      I.IsNormal ∧
-        geometricallyConnectedCommHopfAlgProperty k
-          (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
-        smoothUnipotentCommHopfAlgProperty k
-          (FiniteTypeCommHopfAlgCat.quotient H I) :=
-  Iff.rfl
 
 namespace IsUnipotentRadicalCandidate
 


### PR DESCRIPTION
This PR packages connected normal smooth-unipotent closed subgroups as unipotent-radical candidates and proves that one attains the maximal Lie dimension. It advances the exact ReductiveGroups Layer 5 target “The unipotent radical `R_u(G)` (the hard core, SGA3/Borel level): the maximal connected normal unipotent closed subgroup,” specifically its standard maximal-dimension construction.

The augmentation ideal supplies a candidate, and the existing conormal exact-sequence dimension formula bounds every candidate’s Lie dimension by that of the ambient finite-type affine group; finiteness of the bounded set of attained dimensions then yields a maximum. This is the most effective independent next step while binary-product closure follows the in-flight semidirect-product and affine-image work. After this PR, it remains to prove binary-product closure, use equal dimension plus containment to show the maximal candidate contains every candidate, and bundle the resulting unipotent radical and maximality API.

The new `TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Basic` module adds the candidate predicate, its property projections, the identity-subgroup witness, the closed-subgroup Lie-dimension bound, and maximal-dimension existence. It reuses Tau Ceti’s quotient, connectedness, smooth-unipotence, augmentation, and conormal infrastructure; no Mathlib infrastructure is vendored. The mathematical construction follows Milne, *Algebraic Groups*, Proposition 17.4, and Borel, *Linear Algebraic Groups*, Proposition 14.4, as cited in the module.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"maximal-lie-dimension-unipotent-candidate"}-->

🤖 Prepared with Codex
