### PR TITLE
feat: add rational Hodge substructures

### DIFF
--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -11,6 +11,7 @@ public import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import Mathlib.LinearAlgebra.TensorProduct.Tower
 public import Mathlib.RingTheory.Flat.Basic
 public import Mathlib.RingTheory.IsTensorProduct
+public import TauCeti.Geometry.Hodge.Conjugation
 
 /-!
 # Rational subspaces in an abstract complexification
@@ -25,6 +26,10 @@ The constructions use Mathlib's `IsBaseChange` interface rather than requiring t
 to be definitionally equal to concrete tensor products. This is essential for geometric Hodge
 structures, whose rational and complex cohomology spaces arrive as abstract base-change models.
 
+Rationality of a subspace is what makes its complexification stable under the lattice-induced
+conjugation, so that stability is proved here, for an arbitrary rational subspace, rather than
+imposed later as structure data.
+
 ## Main declarations
 
 * `TauCeti.Hodge.rationalToComplexLinearEquiv`: the canonical tower equivalence from an abstract
@@ -35,6 +40,10 @@ structures, whose rational and complex cohomology spaces arrive as abstract base
   complexification `ℂ ⊗[ℚ] W` of a rational subspace with that complexified subspace.
 * `TauCeti.Hodge.rationalMapToComplex`: scalar extension of a rational linear map between two
   abstract base-change models.
+* `TauCeti.Hodge.latticeConj_rationalToComplexLinearEquiv_one_tmul`: lattice conjugation fixes
+  every purely rational vector of the ambient complexification.
+* `TauCeti.Hodge.rationalToComplexSubmodule_conj`: the complexification of a rational subspace is
+  stable under lattice-induced conjugation.
 
 The design follows the base-change interface specified in the Hodge structures roadmap. Its only
 nontrivial comparison map is Mathlib's
@@ -45,7 +54,11 @@ tower before the result is transported to the two abstract models.
 
 The signatures are adapted from the proposed definitions in
 [`HodgeStructures/Suggested.lean`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/HodgeStructures/Suggested.lean),
-whose definitive mathematical specification is the accompanying Hodge structures roadmap.
+whose definitive mathematical specification is the accompanying Hodge structures roadmap. In
+particular the statements of `latticeConj_rationalToComplexLinearEquiv_one_tmul` and
+`rationalToComplexSubmodule_conj` are that file's `rationalToComplexLinearEquiv_one_tmul_fixed` and
+`rationalToComplexSubmodule_conj`; the proofs given here are different, being run against the
+abstract base-change interface rather than the concrete tensor model.
 -/
 
 public section
@@ -145,6 +158,55 @@ theorem coe_rationalToComplexSubmoduleEquiv (hℚ : IsBaseChange ℚ ιℚ)
   rw [rationalToComplexSubmoduleEquiv, LinearEquiv.trans_apply,
     LinearEquiv.ofSubmodules_apply, Submodule.toBaseChange.toLinearEquiv_apply]
   rfl
+
+/-- Lattice conjugation fixes the image in `Vℂ` of a purely rational vector `1 ⊗ₜ x`. -/
+theorem latticeConj_rationalToComplexLinearEquiv_one_tmul (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) (x : Vℚ) :
+    latticeConj hℂ (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) =
+      rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x) := by
+  induction x using hℚ.inductionOn with
+  | zero => simp
+  | tmul x => simp
+  | smul q x hx =>
+      have h_tmul : (1 ⊗ₜ[ℚ] (q • x) : ℂ ⊗[ℚ] Vℚ) =
+          (q : ℂ) • (1 ⊗ₜ[ℚ] x) := by
+        rw [TensorProduct.tmul_smul, TensorProduct.smul_tmul']
+        congr 1
+        simp
+      calc
+        latticeConj hℂ (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] (q • x))) =
+            latticeConj hℂ ((q : ℂ) •
+              rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) := by
+          rw [h_tmul, map_smul]
+        _ = starRingEnd ℂ (q : ℂ) • latticeConj hℂ
+              (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) := by
+          rw [map_smulₛₗ]
+        _ = (q : ℂ) • rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x) := by
+          rw [hx]
+          simp
+        _ = rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] (q • x)) := by
+          rw [h_tmul, map_smul]
+  | add x y hx hy =>
+      simpa only [TensorProduct.tmul_add, map_add] using congrArg₂ (fun a b ↦ a + b) hx hy
+
+/-- The complexification of a rational subspace is stable under lattice-induced conjugation. -/
+@[simp]
+theorem rationalToComplexSubmodule_conj (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) (W : Submodule ℚ Vℚ) :
+    (rationalToComplexSubmodule hℚ hℂ W).map (latticeConj hℂ) =
+      rationalToComplexSubmodule hℚ hℂ W := by
+  have hle : (rationalToComplexSubmodule hℚ hℂ W).map (latticeConj hℂ) ≤
+      rationalToComplexSubmodule hℚ hℂ W := by
+    rw [rationalToComplexSubmodule_eq_span, Submodule.map_span]
+    refine Submodule.span_le.mpr ?_
+    rintro _ ⟨x, hx, rfl⟩
+    rcases hx with ⟨x, hx, rfl⟩
+    rw [latticeConj_rationalToComplexLinearEquiv_one_tmul]
+    exact Submodule.subset_span ⟨x, hx, rfl⟩
+  apply le_antisymm hle
+  intro x hx
+  refine ⟨latticeConj hℂ x, hle ⟨x, hx, rfl⟩, ?_⟩
+  simp
 
 section Map
 

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -101,6 +101,7 @@ theorem restrict_toEquiv_apply (ω : Conjugation W) {U : Submodule ℂ W}
 /-- Conjugating inside a stable subspace is conjugating in the ambient space: the image of an
 intersection with the subspace under the restricted conjugation is the intersection with the
 conjugate subspace. -/
+@[simp]
 theorem map_restrict_comap_subtype (ω : Conjugation W) {U : Submodule ℂ W}
     (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) (A : Submodule ℂ W) :
     (A.comap U.subtype).map (ω.restrict hU).toEquiv.toLinearMap =

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -79,7 +79,7 @@ theorem map_map_eq_self (ω : Conjugation W) (U : Submodule ℂ W) :
   simpa only [ω.toEquiv_symm] using h
 
 /-- A conjugation restricted to a stable complex subspace is involutive. -/
-theorem restrict_involutive (ω : Conjugation W) {U : Submodule ℂ W}
+private theorem restrict_involutive (ω : Conjugation W) {U : Submodule ℂ W}
     (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) :
     Function.Involutive (ω.toEquiv.toLinearMap.restrict hU) := fun x ↦ by
   ext

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -27,6 +27,7 @@ complexification models.
 * `TauCeti.Hodge.latticeConj`: conjugation on an abstract complex base-change model.
 * `TauCeti.Hodge.latticeConj_unique`: uniqueness among conjugate-linear maps fixing the integral
   module.
+* `TauCeti.Hodge.Conjugation.restrict`: the conjugation induced on a stable complex subspace.
 * `TauCeti.Hodge.latticeConjugation`: the abstract map bundled as a `Conjugation`.
 * `TauCeti.Hodge.integralMapToComplex`: complexification of an integral linear map between abstract
   complexification models.
@@ -76,6 +77,36 @@ theorem map_map_eq_self (ω : Conjugation W) (U : Submodule ℂ W) :
   have h : (U.map ω.toEquiv.toLinearMap).map ω.toEquiv.symm.toLinearMap = U :=
     (Submodule.map_symm_eq_iff ω.toEquiv).2 rfl
   simpa only [ω.toEquiv_symm] using h
+
+/-- A conjugation restricted to a stable complex subspace is involutive. -/
+theorem restrict_involutive (ω : Conjugation W) {U : Submodule ℂ W}
+    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) :
+    Function.Involutive (ω.toEquiv.toLinearMap.restrict hU) := fun x ↦ by
+  ext
+  simp
+
+/-- The conjugation induced on a complex subspace stable under a given conjugation. -/
+noncomputable def restrict (ω : Conjugation W) {U : Submodule ℂ W}
+    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) : Conjugation U where
+  toEquiv := LinearEquiv.ofInvolutive _ (ω.restrict_involutive hU)
+  involutive := ω.restrict_involutive hU
+
+/-- A restricted conjugation acts as the ambient one. -/
+@[simp]
+theorem restrict_toEquiv_apply (ω : Conjugation W) {U : Submodule ℂ W}
+    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) (x : U) :
+    ((ω.restrict hU).toEquiv x : W) = ω.toEquiv x :=
+  (rfl)
+
+/-- Conjugating inside a stable subspace is conjugating in the ambient space: the image of an
+intersection with the subspace under the restricted conjugation is the intersection with the
+conjugate subspace. -/
+theorem map_restrict_comap_subtype (ω : Conjugation W) {U : Submodule ℂ W}
+    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) (A : Submodule ℂ W) :
+    (A.comap U.subtype).map (ω.restrict hU).toEquiv.toLinearMap =
+      (A.map ω.toEquiv.toLinearMap).comap U.subtype := by
+  ext x
+  simp
 
 end Conjugation
 
@@ -227,6 +258,14 @@ noncomputable def latticeConjugation (hℂ : IsBaseChange ℂ ιℂ) : Conjugati
 theorem latticeConjugation_toEquiv_apply (hℂ : IsBaseChange ℂ ιℂ) (x : Vℂ) :
     (latticeConjugation hℂ).toEquiv x = latticeConj hℂ x :=
   by simp [latticeConjugation]
+
+/-- The linear map underlying bundled lattice conjugation is `latticeConj`, bridging the bundled
+spelling used by `HodgeStructureOn` and the bare spelling used by the base-change API. This is not
+a `simp` lemma: rewriting with it discards the equivalence, and with it `simp`'s ability to see
+that conjugating a subspace preserves `⊤`. -/
+theorem latticeConjugation_toLinearMap (hℂ : IsBaseChange ℂ ιℂ) :
+    (latticeConjugation hℂ).toEquiv.toLinearMap = latticeConj hℂ :=
+  (rfl)
 
 /-- Bundled lattice conjugation fixes the image of the integral module. -/
 theorem latticeConjugation_toEquiv_ι (hℂ : IsBaseChange ℂ ιℂ) (v : V) :

--- a/TauCeti/Geometry/Hodge/RationalSubstructure.lean
+++ b/TauCeti/Geometry/Hodge/RationalSubstructure.lean
@@ -7,40 +7,43 @@ module
 
 public import TauCeti.Geometry.Hodge.BaseChange
 public import TauCeti.Geometry.Hodge.Decomposition
+public import TauCeti.LinearAlgebra.Submodule.Compl
 
 /-!
 # Rational substructures of pure Hodge structures
 
-A rational Hodge substructure is a rational subspace whose complexification is the direct sum of
-its intersections with the Hodge components. This file packages that condition and derives the
-componentwise decomposition of the complexified subspace.
+A rational Hodge substructure is a rational subspace whose complexification is spanned by its
+intersections with the Hodge components. This file packages that condition and equips the
+complexified subspace with the pure Hodge structure it inherits from the ambient one, so that the
+whole `HodgeStructureOn` API applies to it — in particular the Hodge decomposition of the
+complexified subspace into its own components is `HodgeStructureOn.isInternal_piece`, not a second
+copy of that argument.
 
-Rationality also makes the complexification stable under the lattice-induced conjugation. This is
-proved for every rational subspace before imposing the Hodge condition; a rational Hodge
-substructure therefore carries no redundant conjugation-stability field.
+Conjugation stability of the complexification is not a field of the structure: it holds for every
+rational subspace, by `rationalToComplexSubmodule_conj`, so the ambient conjugation restricts to
+the complexification and supplies the conjugation of the induced structure.
 
 The definition and its base-change interface are those specified in Layer L1 of
 `TauCetiRoadmap/HodgeStructures/README.md`, following Voisin, *Hodge Theory and Complex Algebraic
-Geometry I*, §7.1.2.
+Geometry I*, §7.1.2. The induced structure is what makes a rational Hodge substructure a subobject
+of a Hodge structure, as the semisimplicity milestone of that layer requires.
 
-The signatures of `rationalToComplexSubmodule_conj`, `RationalHodgeSubstructure`, and `WC` are
-adapted from the roadmap's formal companion
+The signatures of `RationalHodgeSubstructure` and `RationalHodgeSubstructure.WC` are adapted from
+the roadmap's formal companion
 [`HodgeStructures/Suggested.lean`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/HodgeStructures/Suggested.lean).
 
 ## Main declarations
 
-* `TauCeti.Hodge.rationalToComplexSubmodule_conj`: complexifications of rational subspaces are
-  stable under lattice-induced conjugation.
 * `TauCeti.Hodge.RationalHodgeSubstructure`: a rational subspace split by the Hodge components.
-* `TauCeti.Hodge.RationalHodgeSubstructure.isInternal_piece`: the induced componentwise direct-sum
-  decomposition.
+* `TauCeti.Hodge.RationalHodgeSubstructure.conjugation`: the conjugation induced on its
+  complexification.
+* `TauCeti.Hodge.RationalHodgeSubstructure.hodgeStructure`: the pure Hodge structure induced on its
+  complexification, whose Hodge components are the intersections with the ambient ones.
 -/
 
 public section
 
 namespace TauCeti.Hodge
-
-open scoped DirectSum TensorProduct
 
 universe u v w
 
@@ -50,56 +53,7 @@ variable [AddCommGroup Vℚ] [Module ℚ Vℚ]
 variable [AddCommGroup Vℂ] [Module ℂ Vℂ]
 variable {ιℚ : Vℤ →ₗ[ℤ] Vℚ} {ιℂ : Vℤ →ₗ[ℤ] Vℂ}
 variable {hℚ : IsBaseChange ℚ ιℚ} {hℂ : IsBaseChange ℂ ιℂ}
-
-/-- Conjugation commutes with the canonical map from the rationalification into the
-complexification. -/
-private theorem latticeConj_rationalToComplexLinearEquiv_one_tmul (x : Vℚ) :
-    latticeConj hℂ (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) =
-      rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x) := by
-  induction x using hℚ.inductionOn with
-  | zero => simp
-  | tmul x => simp
-  | smul q x hx =>
-      have h_tmul : (1 ⊗ₜ[ℚ] (q • x) : ℂ ⊗[ℚ] Vℚ) =
-          (q : ℂ) • (1 ⊗ₜ[ℚ] x) := by
-        rw [TensorProduct.tmul_smul, TensorProduct.smul_tmul']
-        congr 1
-        simp
-      calc
-        latticeConj hℂ (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] (q • x))) =
-            latticeConj hℂ ((q : ℂ) •
-              rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) := by
-          rw [h_tmul, map_smul]
-        _ = starRingEnd ℂ (q : ℂ) • latticeConj hℂ
-              (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) := by
-          rw [map_smulₛₗ]
-        _ = (q : ℂ) • rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x) := by
-          rw [hx]
-          simp
-        _ = rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] (q • x)) := by
-          rw [h_tmul, map_smul]
-  | add x y hx hy =>
-      simpa only [TensorProduct.tmul_add, map_add] using congrArg₂ (fun a b ↦ a + b) hx hy
-
-/-- The complexification of a rational subspace is stable under lattice-induced conjugation. -/
-@[simp]
-theorem rationalToComplexSubmodule_conj (W : Submodule ℚ Vℚ) :
-    (rationalToComplexSubmodule hℚ hℂ W).map (latticeConj hℂ) =
-      rationalToComplexSubmodule hℚ hℂ W := by
-  have hle : (rationalToComplexSubmodule hℚ hℂ W).map (latticeConj hℂ) ≤
-      rationalToComplexSubmodule hℚ hℂ W := by
-    rw [rationalToComplexSubmodule_eq_span, Submodule.map_span]
-    refine Submodule.span_le.mpr ?_
-    rintro _ ⟨x, hx, rfl⟩
-    rcases hx with ⟨x, hx, rfl⟩
-    rw [latticeConj_rationalToComplexLinearEquiv_one_tmul]
-    exact Submodule.subset_span ⟨x, hx, rfl⟩
-  apply le_antisymm hle
-  intro x hx
-  refine ⟨latticeConj hℂ x, hle ⟨x, hx, rfl⟩, ?_⟩
-  simp
-
-variable {n : ℤ} (hs : HodgeStructure hℂ n)
+variable {n : ℤ} {hs : HodgeStructure hℂ n}
 
 /-- A rational Hodge substructure of a pure Hodge structure.
 
@@ -107,7 +61,7 @@ Its rational subspace `WQ` complexifies to the sum of its intersections with the
 components. Stability under conjugation is not a field: it follows from rationality via
 `rationalToComplexSubmodule_conj`. -/
 @[ext]
-structure RationalHodgeSubstructure where
+structure RationalHodgeSubstructure (hℚ : IsBaseChange ℚ ιℚ) (hs : HodgeStructure hℂ n) where
   /-- The underlying rational subspace. -/
   WQ : Submodule ℚ Vℚ
   /-- The complexification is spanned by its intersections with the Hodge components. -/
@@ -116,140 +70,127 @@ structure RationalHodgeSubstructure where
 
 namespace RationalHodgeSubstructure
 
-variable {hs}
-
 /-- The complexification of a rational Hodge substructure inside the ambient complexification. -/
-noncomputable def WC (W : RationalHodgeSubstructure (hℚ := hℚ) hs) : Submodule ℂ Vℂ :=
+noncomputable def WC (W : RationalHodgeSubstructure hℚ hs) : Submodule ℂ Vℂ :=
   rationalToComplexSubmodule hℚ hℂ W.WQ
 
-/-- The `p`-th Hodge component of a rational Hodge substructure, as a subspace of its
-complexification. -/
-noncomputable def piece (W : RationalHodgeSubstructure (hℚ := hℚ) hs) (p : ℤ) :
-    Submodule ℂ W.WC :=
-  (hs.piece p).comap W.WC.subtype
+/-- The complexification of a rational Hodge substructure is the complexification of its rational
+subspace. -/
+theorem WC_def (W : RationalHodgeSubstructure hℚ hs) :
+    W.WC = rationalToComplexSubmodule hℚ hℂ W.WQ :=
+  (rfl)
 
 /-- The complexification is the supremum of its intersections with the ambient Hodge
 components. -/
-theorem WC_eq_iSup_inf_piece (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
+theorem WC_eq_iSup_inf_piece (W : RationalHodgeSubstructure hℚ hs) :
     W.WC = ⨆ p, W.WC ⊓ hs.piece p :=
   W.hodge_spanning
 
-/-- Membership in an induced Hodge component is detected in the ambient space. -/
-@[simp]
-theorem mem_piece_iff (W : RationalHodgeSubstructure (hℚ := hℚ) hs) (p : ℤ) (x : W.WC) :
-    x ∈ W.piece p ↔ (x : Vℂ) ∈ hs.piece p :=
-  Iff.rfl
-
-/-- Mapping an induced Hodge component into the ambient space gives the intersection of the
-complexification with the corresponding ambient Hodge component. -/
-@[simp]
-theorem map_piece_subtype (W : RationalHodgeSubstructure (hℚ := hℚ) hs) (p : ℤ) :
-    (W.piece p).map W.WC.subtype = W.WC ⊓ hs.piece p := by
-  exact Submodule.map_comap_subtype W.WC (hs.piece p)
-
 /-- The complexification of a rational Hodge substructure is stable under conjugation. -/
 @[simp]
-theorem map_WC_conj (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
-    W.WC.map (latticeConj hℂ) = W.WC :=
-  rationalToComplexSubmodule_conj W.WQ
+theorem map_WC_conj (W : RationalHodgeSubstructure hℚ hs) :
+    W.WC.map (latticeConjugation hℂ).toEquiv.toLinearMap = W.WC := by
+  rw [latticeConjugation_toLinearMap, WC_def]
+  exact rationalToComplexSubmodule_conj hℚ hℂ W.WQ
 
 /-- Conjugation carries every vector of a rational Hodge substructure back into its
 complexification. -/
-theorem conj_mem_WC (W : RationalHodgeSubstructure (hℚ := hℚ) hs) {x : Vℂ} (hx : x ∈ W.WC) :
-    latticeConj hℂ x ∈ W.WC := by
+theorem conj_mem_WC (W : RationalHodgeSubstructure hℚ hs) {x : Vℂ} (hx : x ∈ W.WC) :
+    (latticeConjugation hℂ).toEquiv x ∈ W.WC := by
   rw [← W.map_WC_conj]
   exact Submodule.mem_map_of_mem hx
 
-/-- Conjugation exchanges the induced Hodge components in complementary degrees. -/
-theorem conj_mem_piece (W : RationalHodgeSubstructure (hℚ := hℚ) hs) {p : ℤ} {x : W.WC}
-    (hx : x ∈ W.piece p) :
-    (⟨latticeConj hℂ x, W.conj_mem_WC x.property⟩ : W.WC) ∈ W.piece (n - p) := by
-  rw [W.mem_piece_iff]
-  simpa only [latticeConjugation_toEquiv_apply] using
-    hs.conj_mem_piece ((W.mem_piece_iff p x).mp hx)
+/-- The conjugation induced on the complexification of a rational Hodge substructure. -/
+noncomputable def conjugation (W : RationalHodgeSubstructure hℚ hs) : Conjugation W.WC :=
+  (latticeConjugation hℂ).restrict fun _ hx ↦ W.conj_mem_WC hx
 
-/-- The induced Hodge components span the complexification of a rational Hodge substructure. -/
-theorem iSup_piece_eq_top (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
-    ⨆ p, W.piece p = ⊤ := by
-  apply Submodule.map_injective_of_injective W.WC.subtype_injective
-  rw [Submodule.map_iSup, Submodule.map_subtype_top]
-  simp_rw [W.map_piece_subtype]
-  exact W.WC_eq_iSup_inf_piece.symm
-
-/-- The induced Hodge components of a rational Hodge substructure are independent. -/
-theorem piece_iSupIndep (W : RationalHodgeSubstructure (hℚ := hℚ) hs) : iSupIndep W.piece := by
-  have hambient : iSupIndep (fun p ↦ W.WC ⊓ hs.piece p) :=
-    hs.piece_iSupIndep.mono fun _ ↦ inf_le_right
-  let e : Submodule ℂ W.WC ≃o Set.Iic W.WC := W.WC.mapIic
-  let B : ℤ → Set.Iic W.WC := fun p ↦
-    ⟨W.WC ⊓ hs.piece p, (inf_le_left : W.WC ⊓ hs.piece p ≤ W.WC)⟩
-  have hB : iSupIndep B := by
-    apply iSupIndep.of_coe_Iic_comp
-    -- `of_coe_Iic_comp` leaves the coercion from the interval visible in the goal.
-    change iSupIndep (fun p ↦ W.WC ⊓ hs.piece p)
-    exact hambient
-  suffices (e ∘ W.piece) = B by
-    rw [← iSupIndep_map_orderIso_iff e, this]
-    exact hB
-  ext p x
-  -- `mapIic` represents a submodule of `W.WC` by its image under the subtype map.
-  change x ∈ (W.piece p).map W.WC.subtype ↔ x ∈ W.WC ⊓ hs.piece p
-  rw [W.map_piece_subtype]
-
-/-- The induced Hodge components form an internal direct sum of the complexification. -/
-theorem isInternal_piece (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
-    DirectSum.IsInternal W.piece := by
-  classical
-  exact DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top
-    W.piece_iSupIndep W.iSup_piece_eq_top
-
-/-- The Hodge decomposition of a rational Hodge substructure as a linear equivalence. -/
-noncomputable def decomposition (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
-    W.WC ≃ₗ[ℂ] ⨁ p, W.piece p :=
-  (LinearEquiv.ofBijective (DirectSum.coeLinearMap W.piece) W.isInternal_piece).symm
-
-/-- The inverse of the Hodge decomposition sums the induced components. -/
+/-- The induced conjugation acts as the ambient lattice conjugation. -/
 @[simp]
-theorem decomposition_symm_apply (W : RationalHodgeSubstructure (hℚ := hℚ) hs)
-    (x : ⨁ p, W.piece p) :
-    W.decomposition.symm x = DirectSum.coeLinearMap W.piece x := by
-  rw [decomposition, LinearEquiv.symm_symm]
-  rfl
+theorem conjugation_toEquiv_apply (W : RationalHodgeSubstructure hℚ hs) (x : W.WC) :
+    (W.conjugation.toEquiv x : Vℂ) = latticeConj hℂ x := by
+  simp [conjugation]
 
-/-- A vector in one induced Hodge component decomposes as that component alone. -/
-theorem decomposition_apply_of_mem
-    (W : RationalHodgeSubstructure (hℚ := hℚ) hs) {p : ℤ} {x : W.WC}
-    (hx : x ∈ W.piece p) :
-    W.decomposition x = DirectSum.lof ℂ ℤ (fun q ↦ W.piece q) p ⟨x, hx⟩ :=
-  W.decomposition.symm.injective (by simp)
+/-- Conjugating inside the complexification is conjugating in the ambient complexification. -/
+theorem map_comap_subtype_conjugation (W : RationalHodgeSubstructure hℚ hs)
+    (A : Submodule ℂ Vℂ) :
+    (A.comap W.WC.subtype).map W.conjugation.toEquiv.toLinearMap =
+      (A.map (latticeConjugation hℂ).toEquiv.toLinearMap).comap W.WC.subtype :=
+  Conjugation.map_restrict_comap_subtype _ _ _
+
+/-- A filtration step and the complementary conjugate step together cover the complexification:
+every ambient Hodge component lies in one of the two. -/
+theorem WC_le_inf_F_sup_inf_conjF (W : RationalHodgeSubstructure hℚ hs) (p : ℤ) :
+    W.WC ≤ W.WC ⊓ hs.F p ⊔ W.WC ⊓ hs.conjF (n + 1 - p) := by
+  conv_lhs => rw [W.WC_eq_iSup_inf_piece]
+  refine iSup_le fun q ↦ ?_
+  rcases lt_or_ge q p with hq | hq
+  · exact le_sup_of_le_right (inf_le_inf_left _ (hs.piece_le_conjF_of_lt hq))
+  · exact le_sup_of_le_left (inf_le_inf_left _ ((hs.piece_le_F q).trans (hs.F_antitone hq)))
+
+/-- The pure Hodge structure induced on the complexification of a rational Hodge substructure: its
+filtration is the ambient filtration intersected with the complexification, and it is opposed
+because the ambient components cover the complexification. -/
+noncomputable def hodgeStructure (W : RationalHodgeSubstructure hℚ hs) :
+    HodgeStructureOn W.WC W.conjugation n where
+  F p := (hs.F p).comap W.WC.subtype
+  F_antitone _ _ hpq := Submodule.comap_mono (hs.F_antitone hpq)
+  F_top := by
+    obtain ⟨p, hp⟩ := hs.F_top
+    exact ⟨p, by rw [hp]; exact Submodule.comap_subtype_eq_top.2 le_top⟩
+  opposed p := by
+    rw [W.map_comap_subtype_conjugation, ← hs.conjF_def]
+    exact isCompl_comap_subtype (hs.isCompl_F_conjF p).disjoint (W.WC_le_inf_F_sup_inf_conjF p)
+
+/-- The induced Hodge filtration is the ambient filtration intersected with the
+complexification. -/
+@[simp]
+theorem hodgeStructure_F (W : RationalHodgeSubstructure hℚ hs) (p : ℤ) :
+    W.hodgeStructure.F p = (hs.F p).comap W.WC.subtype :=
+  (rfl)
+
+/-- The induced conjugate filtration is the ambient conjugate filtration intersected with the
+complexification. -/
+@[simp]
+theorem hodgeStructure_conjF (W : RationalHodgeSubstructure hℚ hs) (p : ℤ) :
+    W.hodgeStructure.conjF p = (hs.conjF p).comap W.WC.subtype := by
+  rw [HodgeStructureOn.conjF_def, hodgeStructure_F, W.map_comap_subtype_conjugation,
+    ← hs.conjF_def]
+
+/-- An induced Hodge component is the ambient Hodge component of the same degree intersected with
+the complexification. -/
+@[simp]
+theorem hodgeStructure_piece (W : RationalHodgeSubstructure hℚ hs) (p : ℤ) :
+    W.hodgeStructure.piece p = (hs.piece p).comap W.WC.subtype := by
+  rw [HodgeStructureOn.piece_def, hodgeStructure_F, hodgeStructure_conjF, hs.piece_def,
+    Submodule.comap_inf]
 
 /-- The zero rational subspace is a rational Hodge substructure. -/
-noncomputable def bot : RationalHodgeSubstructure (hℚ := hℚ) hs where
+noncomputable def bot : RationalHodgeSubstructure hℚ hs where
   WQ := ⊥
   hodge_spanning := by simp
 
 /-- The whole rational space is a rational Hodge substructure. -/
-noncomputable def top : RationalHodgeSubstructure (hℚ := hℚ) hs where
+noncomputable def top : RationalHodgeSubstructure hℚ hs where
   WQ := ⊤
   hodge_spanning := by
     simp only [rationalToComplexSubmodule_top, top_inf_eq]
     exact hs.iSup_piece_eq_top.symm
 
 @[simp]
-theorem bot_WQ : (bot : RationalHodgeSubstructure (hℚ := hℚ) hs).WQ = ⊥ :=
+theorem bot_WQ : (bot : RationalHodgeSubstructure hℚ hs).WQ = ⊥ :=
   by rw [bot]
 
 @[simp]
-theorem bot_WC : (bot : RationalHodgeSubstructure (hℚ := hℚ) hs).WC = ⊥ := by
-  rw [WC, bot_WQ, rationalToComplexSubmodule_bot]
+theorem bot_WC : (bot : RationalHodgeSubstructure hℚ hs).WC = ⊥ := by
+  rw [WC_def, bot_WQ, rationalToComplexSubmodule_bot]
 
 @[simp]
-theorem top_WQ : (top : RationalHodgeSubstructure (hℚ := hℚ) hs).WQ = ⊤ :=
+theorem top_WQ : (top : RationalHodgeSubstructure hℚ hs).WQ = ⊤ :=
   by rw [top]
 
 @[simp]
-theorem top_WC : (top : RationalHodgeSubstructure (hℚ := hℚ) hs).WC = ⊤ := by
-  rw [WC, top_WQ, rationalToComplexSubmodule_top]
+theorem top_WC : (top : RationalHodgeSubstructure hℚ hs).WC = ⊤ := by
+  rw [WC_def, top_WQ, rationalToComplexSubmodule_top]
 
 end RationalHodgeSubstructure
 

--- a/TauCeti/Geometry/Hodge/RationalSubstructure.lean
+++ b/TauCeti/Geometry/Hodge/RationalSubstructure.lean
@@ -1,0 +1,256 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Hodge.BaseChange
+public import TauCeti.Geometry.Hodge.Decomposition
+
+/-!
+# Rational substructures of pure Hodge structures
+
+A rational Hodge substructure is a rational subspace whose complexification is the direct sum of
+its intersections with the Hodge components. This file packages that condition and derives the
+componentwise decomposition of the complexified subspace.
+
+Rationality also makes the complexification stable under the lattice-induced conjugation. This is
+proved for every rational subspace before imposing the Hodge condition; a rational Hodge
+substructure therefore carries no redundant conjugation-stability field.
+
+The definition and its base-change interface are those specified in Layer L1 of
+`TauCetiRoadmap/HodgeStructures/README.md`, following Voisin, *Hodge Theory and Complex Algebraic
+Geometry I*, §7.1.2.
+
+The signatures of `rationalToComplexSubmodule_conj`, `RationalHodgeSubstructure`, and `WC` are
+adapted from the roadmap's formal companion
+[`HodgeStructures/Suggested.lean`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/HodgeStructures/Suggested.lean).
+
+## Main declarations
+
+* `TauCeti.Hodge.rationalToComplexSubmodule_conj`: complexifications of rational subspaces are
+  stable under lattice-induced conjugation.
+* `TauCeti.Hodge.RationalHodgeSubstructure`: a rational subspace split by the Hodge components.
+* `TauCeti.Hodge.RationalHodgeSubstructure.isInternal_piece`: the induced componentwise direct-sum
+  decomposition.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+open scoped DirectSum TensorProduct
+
+universe u v w
+
+variable {Vℤ : Type u} {Vℚ : Type v} {Vℂ : Type w}
+variable [AddCommGroup Vℤ]
+variable [AddCommGroup Vℚ] [Module ℚ Vℚ]
+variable [AddCommGroup Vℂ] [Module ℂ Vℂ]
+variable {ιℚ : Vℤ →ₗ[ℤ] Vℚ} {ιℂ : Vℤ →ₗ[ℤ] Vℂ}
+variable {hℚ : IsBaseChange ℚ ιℚ} {hℂ : IsBaseChange ℂ ιℂ}
+
+/-- Conjugation commutes with the canonical map from the rationalification into the
+complexification. -/
+private theorem latticeConj_rationalToComplexLinearEquiv_one_tmul (x : Vℚ) :
+    latticeConj hℂ (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) =
+      rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x) := by
+  induction x using hℚ.inductionOn with
+  | zero => simp
+  | tmul x => simp
+  | smul q x hx =>
+      have h_tmul : (1 ⊗ₜ[ℚ] (q • x) : ℂ ⊗[ℚ] Vℚ) =
+          (q : ℂ) • (1 ⊗ₜ[ℚ] x) := by
+        rw [TensorProduct.tmul_smul, TensorProduct.smul_tmul']
+        congr 1
+        simp
+      calc
+        latticeConj hℂ (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] (q • x))) =
+            latticeConj hℂ ((q : ℂ) •
+              rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) := by
+          rw [h_tmul, map_smul]
+        _ = starRingEnd ℂ (q : ℂ) • latticeConj hℂ
+              (rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x)) := by
+          rw [map_smulₛₗ]
+        _ = (q : ℂ) • rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] x) := by
+          rw [hx]
+          simp
+        _ = rationalToComplexLinearEquiv hℚ hℂ (1 ⊗ₜ[ℚ] (q • x)) := by
+          rw [h_tmul, map_smul]
+  | add x y hx hy =>
+      simpa only [TensorProduct.tmul_add, map_add] using congrArg₂ (fun a b ↦ a + b) hx hy
+
+/-- The complexification of a rational subspace is stable under lattice-induced conjugation. -/
+@[simp]
+theorem rationalToComplexSubmodule_conj (W : Submodule ℚ Vℚ) :
+    (rationalToComplexSubmodule hℚ hℂ W).map (latticeConj hℂ) =
+      rationalToComplexSubmodule hℚ hℂ W := by
+  have hle : (rationalToComplexSubmodule hℚ hℂ W).map (latticeConj hℂ) ≤
+      rationalToComplexSubmodule hℚ hℂ W := by
+    rw [rationalToComplexSubmodule_eq_span, Submodule.map_span]
+    refine Submodule.span_le.mpr ?_
+    rintro _ ⟨x, hx, rfl⟩
+    rcases hx with ⟨x, hx, rfl⟩
+    rw [latticeConj_rationalToComplexLinearEquiv_one_tmul]
+    exact Submodule.subset_span ⟨x, hx, rfl⟩
+  apply le_antisymm hle
+  intro x hx
+  refine ⟨latticeConj hℂ x, hle ⟨x, hx, rfl⟩, ?_⟩
+  simp
+
+variable {n : ℤ} (hs : HodgeStructure hℂ n)
+
+/-- A rational Hodge substructure of a pure Hodge structure.
+
+Its rational subspace `WQ` complexifies to the sum of its intersections with the Hodge
+components. Stability under conjugation is not a field: it follows from rationality via
+`rationalToComplexSubmodule_conj`. -/
+@[ext]
+structure RationalHodgeSubstructure where
+  /-- The underlying rational subspace. -/
+  WQ : Submodule ℚ Vℚ
+  /-- The complexification is spanned by its intersections with the Hodge components. -/
+  hodge_spanning : rationalToComplexSubmodule hℚ hℂ WQ =
+    ⨆ p, rationalToComplexSubmodule hℚ hℂ WQ ⊓ hs.piece p
+
+namespace RationalHodgeSubstructure
+
+variable {hs}
+
+/-- The complexification of a rational Hodge substructure inside the ambient complexification. -/
+noncomputable def WC (W : RationalHodgeSubstructure (hℚ := hℚ) hs) : Submodule ℂ Vℂ :=
+  rationalToComplexSubmodule hℚ hℂ W.WQ
+
+/-- The `p`-th Hodge component of a rational Hodge substructure, as a subspace of its
+complexification. -/
+noncomputable def piece (W : RationalHodgeSubstructure (hℚ := hℚ) hs) (p : ℤ) :
+    Submodule ℂ W.WC :=
+  (hs.piece p).comap W.WC.subtype
+
+/-- The complexification is the supremum of its intersections with the ambient Hodge
+components. -/
+theorem WC_eq_iSup_inf_piece (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
+    W.WC = ⨆ p, W.WC ⊓ hs.piece p :=
+  W.hodge_spanning
+
+/-- Membership in an induced Hodge component is detected in the ambient space. -/
+@[simp]
+theorem mem_piece_iff (W : RationalHodgeSubstructure (hℚ := hℚ) hs) (p : ℤ) (x : W.WC) :
+    x ∈ W.piece p ↔ (x : Vℂ) ∈ hs.piece p :=
+  Iff.rfl
+
+/-- Mapping an induced Hodge component into the ambient space gives the intersection of the
+complexification with the corresponding ambient Hodge component. -/
+@[simp]
+theorem map_piece_subtype (W : RationalHodgeSubstructure (hℚ := hℚ) hs) (p : ℤ) :
+    (W.piece p).map W.WC.subtype = W.WC ⊓ hs.piece p := by
+  exact Submodule.map_comap_subtype W.WC (hs.piece p)
+
+/-- The complexification of a rational Hodge substructure is stable under conjugation. -/
+@[simp]
+theorem map_WC_conj (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
+    W.WC.map (latticeConj hℂ) = W.WC :=
+  rationalToComplexSubmodule_conj W.WQ
+
+/-- Conjugation carries every vector of a rational Hodge substructure back into its
+complexification. -/
+theorem conj_mem_WC (W : RationalHodgeSubstructure (hℚ := hℚ) hs) {x : Vℂ} (hx : x ∈ W.WC) :
+    latticeConj hℂ x ∈ W.WC := by
+  rw [← W.map_WC_conj]
+  exact Submodule.mem_map_of_mem hx
+
+/-- Conjugation exchanges the induced Hodge components in complementary degrees. -/
+theorem conj_mem_piece (W : RationalHodgeSubstructure (hℚ := hℚ) hs) {p : ℤ} {x : W.WC}
+    (hx : x ∈ W.piece p) :
+    (⟨latticeConj hℂ x, W.conj_mem_WC x.property⟩ : W.WC) ∈ W.piece (n - p) := by
+  rw [W.mem_piece_iff]
+  simpa only [latticeConjugation_toEquiv_apply] using
+    hs.conj_mem_piece ((W.mem_piece_iff p x).mp hx)
+
+/-- The induced Hodge components span the complexification of a rational Hodge substructure. -/
+theorem iSup_piece_eq_top (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
+    ⨆ p, W.piece p = ⊤ := by
+  apply Submodule.map_injective_of_injective W.WC.subtype_injective
+  rw [Submodule.map_iSup, Submodule.map_subtype_top]
+  simp_rw [W.map_piece_subtype]
+  exact W.WC_eq_iSup_inf_piece.symm
+
+/-- The induced Hodge components of a rational Hodge substructure are independent. -/
+theorem piece_iSupIndep (W : RationalHodgeSubstructure (hℚ := hℚ) hs) : iSupIndep W.piece := by
+  have hambient : iSupIndep (fun p ↦ W.WC ⊓ hs.piece p) :=
+    hs.piece_iSupIndep.mono fun _ ↦ inf_le_right
+  let e : Submodule ℂ W.WC ≃o Set.Iic W.WC := W.WC.mapIic
+  let B : ℤ → Set.Iic W.WC := fun p ↦
+    ⟨W.WC ⊓ hs.piece p, (inf_le_left : W.WC ⊓ hs.piece p ≤ W.WC)⟩
+  have hB : iSupIndep B := by
+    apply iSupIndep.of_coe_Iic_comp
+    -- `of_coe_Iic_comp` leaves the coercion from the interval visible in the goal.
+    change iSupIndep (fun p ↦ W.WC ⊓ hs.piece p)
+    exact hambient
+  suffices (e ∘ W.piece) = B by
+    rw [← iSupIndep_map_orderIso_iff e, this]
+    exact hB
+  ext p x
+  -- `mapIic` represents a submodule of `W.WC` by its image under the subtype map.
+  change x ∈ (W.piece p).map W.WC.subtype ↔ x ∈ W.WC ⊓ hs.piece p
+  rw [W.map_piece_subtype]
+
+/-- The induced Hodge components form an internal direct sum of the complexification. -/
+theorem isInternal_piece (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
+    DirectSum.IsInternal W.piece := by
+  classical
+  exact DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top
+    W.piece_iSupIndep W.iSup_piece_eq_top
+
+/-- The Hodge decomposition of a rational Hodge substructure as a linear equivalence. -/
+noncomputable def decomposition (W : RationalHodgeSubstructure (hℚ := hℚ) hs) :
+    W.WC ≃ₗ[ℂ] ⨁ p, W.piece p :=
+  (LinearEquiv.ofBijective (DirectSum.coeLinearMap W.piece) W.isInternal_piece).symm
+
+/-- The inverse of the Hodge decomposition sums the induced components. -/
+@[simp]
+theorem decomposition_symm_apply (W : RationalHodgeSubstructure (hℚ := hℚ) hs)
+    (x : ⨁ p, W.piece p) :
+    W.decomposition.symm x = DirectSum.coeLinearMap W.piece x := by
+  rw [decomposition, LinearEquiv.symm_symm]
+  rfl
+
+/-- A vector in one induced Hodge component decomposes as that component alone. -/
+theorem decomposition_apply_of_mem
+    (W : RationalHodgeSubstructure (hℚ := hℚ) hs) {p : ℤ} {x : W.WC}
+    (hx : x ∈ W.piece p) :
+    W.decomposition x = DirectSum.lof ℂ ℤ (fun q ↦ W.piece q) p ⟨x, hx⟩ :=
+  W.decomposition.symm.injective (by simp)
+
+/-- The zero rational subspace is a rational Hodge substructure. -/
+noncomputable def bot : RationalHodgeSubstructure (hℚ := hℚ) hs where
+  WQ := ⊥
+  hodge_spanning := by simp
+
+/-- The whole rational space is a rational Hodge substructure. -/
+noncomputable def top : RationalHodgeSubstructure (hℚ := hℚ) hs where
+  WQ := ⊤
+  hodge_spanning := by
+    simp only [rationalToComplexSubmodule_top, top_inf_eq]
+    exact hs.iSup_piece_eq_top.symm
+
+@[simp]
+theorem bot_WQ : (bot : RationalHodgeSubstructure (hℚ := hℚ) hs).WQ = ⊥ :=
+  by rw [bot]
+
+@[simp]
+theorem bot_WC : (bot : RationalHodgeSubstructure (hℚ := hℚ) hs).WC = ⊥ := by
+  rw [WC, bot_WQ, rationalToComplexSubmodule_bot]
+
+@[simp]
+theorem top_WQ : (top : RationalHodgeSubstructure (hℚ := hℚ) hs).WQ = ⊤ :=
+  by rw [top]
+
+@[simp]
+theorem top_WC : (top : RationalHodgeSubstructure (hℚ := hℚ) hs).WC = ⊤ := by
+  rw [WC, top_WQ, rationalToComplexSubmodule_top]
+
+end RationalHodgeSubstructure
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/RationalSubstructure.lean
+++ b/TauCeti/Geometry/Hodge/RationalSubstructure.lean
@@ -111,6 +111,7 @@ theorem conjugation_toEquiv_apply (W : RationalHodgeSubstructure hℚ hs) (x : W
   simp [conjugation]
 
 /-- Conjugating inside the complexification is conjugating in the ambient complexification. -/
+@[simp]
 theorem map_comap_subtype_conjugation (W : RationalHodgeSubstructure hℚ hs)
     (A : Submodule ℂ Vℂ) :
     (A.comap W.WC.subtype).map W.conjugation.toEquiv.toLinearMap =
@@ -139,7 +140,8 @@ noncomputable def hodgeStructure (W : RationalHodgeSubstructure hℚ hs) :
     exact ⟨p, by rw [hp]; exact Submodule.comap_subtype_eq_top.2 le_top⟩
   opposed p := by
     rw [W.map_comap_subtype_conjugation, ← hs.conjF_def]
-    exact isCompl_comap_subtype (hs.isCompl_F_conjF p).disjoint (W.WC_le_inf_F_sup_inf_conjF p)
+    exact TauCeti.Submodule.isCompl_comap_subtype (hs.isCompl_F_conjF p).disjoint
+      (W.WC_le_inf_F_sup_inf_conjF p)
 
 /-- The induced Hodge filtration is the ambient filtration intersected with the
 complexification. -/

--- a/TauCeti/LinearAlgebra/Submodule/Compl.lean
+++ b/TauCeti/LinearAlgebra/Submodule/Compl.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Span.Basic
+
+/-!
+# Complementary submodules induced on a subspace
+
+Mathlib's `Submodule.isCompl_comap_subtype_of_isCompl_of_le` restricts a complementary pair to a
+subspace that contains one of the two. This file records the variant that applies when neither
+member of the pair lies in the subspace: a disjoint pair cuts a subspace `U` into a complementary
+pair as soon as the two intersections with `U` span `U` — for a general `U` a genuine hypothesis,
+not a consequence of spanning the ambient module.
+
+## Main results
+
+* `TauCeti.isCompl_comap_subtype`: a disjoint pair of submodules whose intersections with `U` span
+  `U` restricts to a complementary pair of submodules of `U`.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+variable {R : Type u} {M : Type v} [Ring R] [AddCommGroup M] [Module R M]
+
+/-- A disjoint pair of submodules whose intersections with a subspace `U` span `U` cuts `U` into a
+complementary pair of submodules. -/
+theorem isCompl_comap_subtype {U A B : Submodule R M} (hAB : Disjoint A B)
+    (hU : U ≤ U ⊓ A ⊔ U ⊓ B) :
+    IsCompl (A.comap U.subtype) (B.comap U.subtype) := by
+  constructor
+  · rw [disjoint_iff, ← Submodule.comap_inf, disjoint_iff.mp hAB, Submodule.comap_bot,
+      Submodule.ker_subtype]
+  · rw [codisjoint_iff]
+    refine Submodule.map_injective_of_injective U.subtype_injective ?_
+    rw [Submodule.map_sup, Submodule.map_comap_subtype, Submodule.map_comap_subtype,
+      Submodule.map_subtype_top]
+    exact le_antisymm (sup_le inf_le_left inf_le_left) hU
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Submodule/Compl.lean
+++ b/TauCeti/LinearAlgebra/Submodule/Compl.lean
@@ -18,8 +18,8 @@ not a consequence of spanning the ambient module.
 
 ## Main results
 
-* `TauCeti.isCompl_comap_subtype`: a disjoint pair of submodules whose intersections with `U` span
-  `U` restricts to a complementary pair of submodules of `U`.
+* `TauCeti.Submodule.isCompl_comap_subtype`: a disjoint pair of submodules whose intersections with
+  `U` span `U` restricts to a complementary pair of submodules of `U`.
 -/
 
 public section
@@ -28,7 +28,9 @@ namespace TauCeti
 
 universe u v
 
-variable {R : Type u} {M : Type v} [Ring R] [AddCommGroup M] [Module R M]
+namespace Submodule
+
+variable {R : Type u} {M : Type v} [Semiring R] [AddCommMonoid M] [Module R M]
 
 /-- A disjoint pair of submodules whose intersections with a subspace `U` span `U` cuts `U` into a
 complementary pair of submodules. -/
@@ -43,5 +45,7 @@ theorem isCompl_comap_subtype {U A B : Submodule R M} (hAB : Disjoint A B)
     rw [Submodule.map_sup, Submodule.map_comap_subtype, Submodule.map_comap_subtype,
       Submodule.map_subtype_top]
     exact le_antisymm (sup_le inf_le_left inf_le_left) hU
+
+end Submodule
 
 end TauCeti


### PR DESCRIPTION
This PR packages a rational subspace of a pure Hodge structure as `RationalHodgeSubstructure` precisely when its complexification is spanned by its intersections with the Hodge components, and equips that complexification with the pure Hodge structure it inherits from the ambient one. It advances the exact Layer L1 definition target in `TauCetiRoadmap/HodgeStructures/README.md`: “`RationalHodgeSubstructure`” with the complex side derived from its rational subspace, on the critical path to the L1 milestone that every rational Hodge substructure of a polarizable Hodge structure has an orthogonal rational Hodge-substructure complement and hence that polarizable rational Hodge structures are semisimple.

Conjugation stability of the complexification is a theorem about arbitrary rational subspaces rather than structure data, so it lives in `BaseChange.lean` with the rest of the `rationalToComplexSubmodule` API. `TauCeti/Geometry/Hodge/RationalSubstructure.lean` then defines the substructure and its complexification `WC`, restricts the ambient conjugation to `WC`, and builds `RationalHodgeSubstructure.hodgeStructure : HodgeStructureOn W.WC W.conjugation n`: the induced filtration is the ambient filtration intersected with `WC`, and opposedness follows from `hodge_spanning` because every ambient Hodge component lies in one of the two adjacent steps. Consequently the induced components, their independence, their spanning, the internal direct sum and the decomposition equivalence are the ambient `HodgeStructureOn` API applied to that object, not a second copy of it; `hodgeStructure_piece` identifies an induced component with the intersection with the ambient one. The zero and whole rational subspaces provide concrete witnesses.

The signatures of `RationalHodgeSubstructure` and `RationalHodgeSubstructure.WC` are adapted from the roadmap's formal companion `HodgeStructures/Suggested.lean`, credited in the module, as are `latticeConj_rationalToComplexLinearEquiv_one_tmul` (its `rationalToComplexLinearEquiv_one_tmul_fixed`) and `rationalToComplexSubmodule_conj`, credited in `BaseChange.lean`; the proofs given here are different, being run against the abstract base-change interface. The mathematical definition follows Voisin, *Hodge Theory and Complex Algebraic Geometry I*, §7.1.2. The one general lattice fact behind opposedness — a disjoint pair of submodules whose intersections with `U` span `U` cuts `U` into a complementary pair — is factored out as `TauCeti.Submodule.isCompl_comap_subtype`, a sibling of Mathlib's `Submodule.isCompl_comap_subtype_of_isCompl_of_le`, which needs one member of the pair to lie in `U`.

After this PR, the L1 milestone still needs the positive Hodge form to identify the polarizing-form orthogonal complement as a rational Hodge substructure, prove it complements the original substructure over both `ℚ` and `ℂ`, and bundle the resulting semisimplicity statement.

New files: `TauCeti/Geometry/Hodge/RationalSubstructure.lean` (197 lines) and `TauCeti/LinearAlgebra/Submodule/Compl.lean` (51 lines).

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"rational-hodge-substructure"}-->

🤖 Prepared with Codex