### PR TITLE
feat: add Bernoulli moments and transforms

### DIFF
--- a/TauCeti/Probability/Distributions/Bernoulli.lean
+++ b/TauCeti/Probability/Distributions/Bernoulli.lean
@@ -59,11 +59,13 @@ theorem variance_id_bernoulliMeasure (p : I) :
   ring_nf
 
 /-- A real-valued Bernoulli random variable with success probability `p` has mean `p`. -/
+-- This cannot be a simp lemma because `p` does not occur on the left-hand side.
 theorem integral_of_hasLaw_bernoulliMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
     {X : Ω → ℝ} {p : I} (hX : HasLaw X Ber((1 : ℝ), 0, p) P) : P[X] = (p : ℝ) := by
   rw [hX.integral_eq, integral_id_bernoulliMeasure]
 
 /-- A real-valued Bernoulli random variable with success probability `p` has variance `p(1-p)`. -/
+-- This cannot be a simp lemma because `p` does not occur on the left-hand side.
 theorem variance_of_hasLaw_bernoulliMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
     {X : Ω → ℝ} {p : I} (hX : HasLaw X Ber((1 : ℝ), 0, p) P) :
     Var[X; P] = (p : ℝ) * (1 - p) := by

--- a/TauCeti/Probability/Distributions/Bernoulli.lean
+++ b/TauCeti/Probability/Distributions/Bernoulli.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.Distributions.Bernoulli
+public import Mathlib.Probability.HasLaw
+public import Mathlib.Probability.Moments.Basic
+public import Mathlib.Probability.Moments.Variance
+public import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
+
+/-!
+# Elementary theory of the Bernoulli distribution
+
+This file computes the elementary moments and transforms of the real-valued Bernoulli law
+`Ber((1 : ℝ), 0, p)`. It uses Mathlib's convention that the value `1` has mass `p` and the value
+`0` has mass `1 - p`.
+
+## Main results
+
+* `integral_id_bernoulliMeasure` and `variance_id_bernoulliMeasure` give the mean and variance;
+* `integral_of_hasLaw_bernoulliMeasure` and `variance_of_hasLaw_bernoulliMeasure` give the
+  corresponding random-variable statements;
+* `mgf_id_bernoulliMeasure` and `cgf_id_bernoulliMeasure` compute the moment- and
+  cumulant-generating functions;
+* `charFun_bernoulliMeasure` computes the characteristic function.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 1, “Bernoulli and binomial”.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+open scoped ProbabilityTheory unitInterval
+
+namespace TauCeti
+
+namespace Probability
+
+/-- The mean of the real-valued Bernoulli law with success probability `p` is `p`. -/
+theorem integral_id_bernoulliMeasure (p : I) :
+    ∫ x, x ∂Ber((1 : ℝ), 0, p) = (p : ℝ) := by
+  rw [integral_bernoulliMeasure]
+  simp
+
+/-- The variance of the real-valued Bernoulli law with success probability `p` is `p(1-p)`. -/
+theorem variance_id_bernoulliMeasure (p : I) :
+    Var[id; Ber((1 : ℝ), 0, p)] = (p : ℝ) * (1 - p) := by
+  rw [variance_eq_integral (by fun_prop), integral_bernoulliMeasure]
+  simp [integral_id_bernoulliMeasure]
+  ring_nf
+
+/-- A real-valued Bernoulli random variable with success probability `p` has mean `p`. -/
+theorem integral_of_hasLaw_bernoulliMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
+    {X : Ω → ℝ} {p : I} (hX : HasLaw X Ber((1 : ℝ), 0, p) P) : P[X] = (p : ℝ) := by
+  rw [hX.integral_eq, integral_id_bernoulliMeasure]
+
+/-- A real-valued Bernoulli random variable with success probability `p` has variance `p(1-p)`. -/
+theorem variance_of_hasLaw_bernoulliMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
+    {X : Ω → ℝ} {p : I} (hX : HasLaw X Ber((1 : ℝ), 0, p) P) :
+    Var[X; P] = (p : ℝ) * (1 - p) := by
+  rw [hX.variance_eq, variance_id_bernoulliMeasure]
+
+/-- The moment-generating function of the real-valued Bernoulli law. -/
+theorem mgf_id_bernoulliMeasure (p : I) (t : ℝ) :
+    mgf id Ber((1 : ℝ), 0, p) t = 1 - (p : ℝ) + (p : ℝ) * Real.exp t := by
+  rw [mgf, integral_bernoulliMeasure]
+  simp
+  ring_nf
+
+/-- The moment-generating function of a real-valued Bernoulli law is strictly positive. -/
+theorem mgf_id_bernoulliMeasure_pos (p : I) (t : ℝ) :
+    0 < mgf id Ber((1 : ℝ), 0, p) t := by
+  rw [mgf_id_bernoulliMeasure]
+  by_cases hp : (p : ℝ) = 1
+  · simpa [hp] using Real.exp_pos t
+  · have hp' : (p : ℝ) < 1 := lt_of_le_of_ne p.2.2 hp
+    exact add_pos_of_pos_of_nonneg (sub_pos.mpr hp')
+      (mul_nonneg p.2.1 (Real.exp_pos t).le)
+
+/-- The cumulant-generating function of the real-valued Bernoulli law. -/
+theorem cgf_id_bernoulliMeasure (p : I) (t : ℝ) :
+    cgf id Ber((1 : ℝ), 0, p) t =
+      Real.log (1 - (p : ℝ) + (p : ℝ) * Real.exp t) := by
+  rw [cgf, mgf_id_bernoulliMeasure]
+
+/-- The characteristic function of the real-valued Bernoulli law. -/
+theorem charFun_bernoulliMeasure (p : I) (t : ℝ) :
+    charFun Ber((1 : ℝ), 0, p) t =
+      1 - (p : ℂ) + (p : ℂ) * Complex.exp (Complex.I * t) := by
+  rw [charFun_apply_real, integral_bernoulliMeasure]
+  simp
+  ring_nf
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Bernoulli.lean
+++ b/TauCeti/Probability/Distributions/Bernoulli.lean
@@ -44,12 +44,14 @@ namespace TauCeti
 namespace Probability
 
 /-- The mean of the real-valued Bernoulli law with success probability `p` is `p`. -/
+@[simp]
 theorem integral_id_bernoulliMeasure (p : I) :
     ∫ x, x ∂Ber((1 : ℝ), 0, p) = (p : ℝ) := by
   rw [integral_bernoulliMeasure]
   simp
 
 /-- The variance of the real-valued Bernoulli law with success probability `p` is `p(1-p)`. -/
+@[simp]
 theorem variance_id_bernoulliMeasure (p : I) :
     Var[id; Ber((1 : ℝ), 0, p)] = (p : ℝ) * (1 - p) := by
   rw [variance_eq_integral (by fun_prop), integral_bernoulliMeasure]
@@ -57,17 +59,20 @@ theorem variance_id_bernoulliMeasure (p : I) :
   ring_nf
 
 /-- A real-valued Bernoulli random variable with success probability `p` has mean `p`. -/
+@[simp]
 theorem integral_of_hasLaw_bernoulliMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
     {X : Ω → ℝ} {p : I} (hX : HasLaw X Ber((1 : ℝ), 0, p) P) : P[X] = (p : ℝ) := by
   rw [hX.integral_eq, integral_id_bernoulliMeasure]
 
 /-- A real-valued Bernoulli random variable with success probability `p` has variance `p(1-p)`. -/
+@[simp]
 theorem variance_of_hasLaw_bernoulliMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
     {X : Ω → ℝ} {p : I} (hX : HasLaw X Ber((1 : ℝ), 0, p) P) :
     Var[X; P] = (p : ℝ) * (1 - p) := by
   rw [hX.variance_eq, variance_id_bernoulliMeasure]
 
 /-- The moment-generating function of the real-valued Bernoulli law. -/
+@[simp]
 theorem mgf_id_bernoulliMeasure (p : I) (t : ℝ) :
     mgf id Ber((1 : ℝ), 0, p) t = 1 - (p : ℝ) + (p : ℝ) * Real.exp t := by
   rw [mgf, integral_bernoulliMeasure]
@@ -80,12 +85,14 @@ theorem mgf_id_bernoulliMeasure_pos (p : I) (t : ℝ) :
   exact mgf_pos (integrable_bernoulliMeasure (1 : ℝ) 0 p fun x => Real.exp (t * id x))
 
 /-- The cumulant-generating function of the real-valued Bernoulli law. -/
+@[simp]
 theorem cgf_id_bernoulliMeasure (p : I) (t : ℝ) :
     cgf id Ber((1 : ℝ), 0, p) t =
       Real.log (1 - (p : ℝ) + (p : ℝ) * Real.exp t) := by
   rw [cgf, mgf_id_bernoulliMeasure]
 
 /-- The characteristic function of the real-valued Bernoulli law. -/
+@[simp]
 theorem charFun_bernoulliMeasure (p : I) (t : ℝ) :
     charFun Ber((1 : ℝ), 0, p) t =
       1 - (p : ℂ) + (p : ℂ) * Complex.exp (Complex.I * t) := by

--- a/TauCeti/Probability/Distributions/Bernoulli.lean
+++ b/TauCeti/Probability/Distributions/Bernoulli.lean
@@ -59,13 +59,11 @@ theorem variance_id_bernoulliMeasure (p : I) :
   ring_nf
 
 /-- A real-valued Bernoulli random variable with success probability `p` has mean `p`. -/
-@[simp]
 theorem integral_of_hasLaw_bernoulliMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
     {X : Ω → ℝ} {p : I} (hX : HasLaw X Ber((1 : ℝ), 0, p) P) : P[X] = (p : ℝ) := by
   rw [hX.integral_eq, integral_id_bernoulliMeasure]
 
 /-- A real-valued Bernoulli random variable with success probability `p` has variance `p(1-p)`. -/
-@[simp]
 theorem variance_of_hasLaw_bernoulliMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
     {X : Ω → ℝ} {p : I} (hX : HasLaw X Ber((1 : ℝ), 0, p) P) :
     Var[X; P] = (p : ℝ) * (1 - p) := by

--- a/TauCeti/Probability/Distributions/Bernoulli.lean
+++ b/TauCeti/Probability/Distributions/Bernoulli.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Probability.Distributions.Bernoulli
 public import Mathlib.Probability.HasLaw
 public import Mathlib.Probability.Moments.Basic
-public import Mathlib.Probability.Moments.Variance
 public import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
 
 /-!
@@ -78,12 +77,7 @@ theorem mgf_id_bernoulliMeasure (p : I) (t : ℝ) :
 /-- The moment-generating function of a real-valued Bernoulli law is strictly positive. -/
 theorem mgf_id_bernoulliMeasure_pos (p : I) (t : ℝ) :
     0 < mgf id Ber((1 : ℝ), 0, p) t := by
-  rw [mgf_id_bernoulliMeasure]
-  by_cases hp : (p : ℝ) = 1
-  · simpa [hp] using Real.exp_pos t
-  · have hp' : (p : ℝ) < 1 := lt_of_le_of_ne p.2.2 hp
-    exact add_pos_of_pos_of_nonneg (sub_pos.mpr hp')
-      (mul_nonneg p.2.1 (Real.exp_pos t).le)
+  exact mgf_pos (integrable_bernoulliMeasure (1 : ℝ) 0 p fun x => Real.exp (t * id x))
 
 /-- The cumulant-generating function of the real-valued Bernoulli law. -/
 theorem cgf_id_bernoulliMeasure (p : I) (t : ℝ) :


### PR DESCRIPTION
This PR completes the Bernoulli half of the first family in `TauCetiRoadmap/StandardDistributions/README.md`, Layer 1, milestone “complete the elementary theory of existing distributions”: compute the mean, variance, moment-generating function, cumulant-generating function, and characteristic function of `Ber((1 : ℝ), 0, p)`, and expose the mean and variance through `HasLaw`.

This is the most effective current step on that milestone because Layer 0 is complete on `main`, the Poisson and exponential families already have open PRs, and the Bernoulli formulas are the base expressions that the same roadmap entry raises to the `n`th power for the binomial law. The formulas cover the full closed parameter interval, including `p = 0` and `p = 1`; `mgf_id_bernoulliMeasure_pos` also records that the real logarithm in the cgf formula is applied to a positive value.

After this PR, the Bernoulli/binomial entry still needs the binomial variance, mgf, cgf, and characteristic function, native convolution, and the law of a sum of i.i.d. Bernoulli variables. The cumulative-mass target remains assigned to Layer 2’s incomplete-beta development.

Add `TauCeti/Probability/Distributions/Bernoulli.lean` (104 lines). The proofs reuse Mathlib’s `integral_bernoulliMeasure`, `HasLaw.integral_eq`, and `HasLaw.variance_eq`; no Mathlib infrastructure or external formalization is vendored.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"bernoulli-elementary-theory"}-->

🤖 Prepared with Codex
