### PR TITLE
feat: make normal joins of unipotent representations unipotent

### DIFF
--- a/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
@@ -8,11 +8,9 @@ module
 public import Mathlib.RepresentationTheory.Basic
 public import TauCeti.LinearAlgebra.Matrix.Triangular
 import TauCeti.GroupTheory.SemidirectProduct
-import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Kolchin
-import TauCeti.LinearAlgebra.ExtensionBasis
-import TauCeti.RepresentationTheory.Subrepresentation
+import TauCeti.RepresentationTheory.Unipotent.Solvable
+import Mathlib.RepresentationTheory.Invariants
 import Mathlib.RingTheory.Nilpotent.Lemmas
-import Mathlib.Tactic.Group
 
 /-!
 # Joins of normal unipotent linear groups
@@ -35,8 +33,6 @@ of the multiplication image with products of points of the two source subgroups.
   second subgroup acting unipotently have a common nonzero fixed vector.
 * `Representation.exists_basis_isUpperUnitriangular_of_normal_isUnipotent`: if they generate the
   ambient group, it is simultaneously upper unitriangular.
-* `Representation.isNilpotent_sub_one_of_normal_isUnipotent`: every element of that ambient group
-  acts unipotently.
 * `Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipotent`: the corresponding result
   for an arbitrary join inside a larger group.
 
@@ -62,33 +58,6 @@ noncomputable section
 variable {K : Type u} {G : Type w} {V : Type v}
 variable [Field K] [Group G] [AddCommGroup V] [Module K V]
 
-/-- The common fixed space of a subgroup in a representation. -/
-private def fixedSubmodule (rho : Representation K G V) (U : Subgroup G) : Submodule K V where
-  carrier := {x | ∀ u : U, rho u x = x}
-  zero_mem' := by simp
-  add_mem' hx hy u := by simp only [map_add, hx u, hy u]
-  smul_mem' r x hx u := by simp only [map_smul, hx u]
-
-/-- Membership in the common fixed space means being fixed by every subgroup element. -/
-private theorem mem_fixedSubmodule_iff (rho : Representation K G V) (U : Subgroup G) (x : V) :
-    x ∈ fixedSubmodule rho U ↔ ∀ u : U, rho u x = x :=
-  Iff.rfl
-
-/-- The common fixed space of a normal subgroup is an ambient subrepresentation. -/
-private def fixedSubrepresentation (rho : Representation K G V) (U : Subgroup G) [U.Normal] :
-    Subrepresentation rho where
-  toSubmodule := fixedSubmodule rho U
-  apply_mem_toSubmodule g x hx := by
-    rw [mem_fixedSubmodule_iff] at hx ⊢
-    intro u
-    let ugu : U := ⟨g⁻¹ * (u : G) * g,
-      (show U.Normal from inferInstance).conj_mem' (u : G) u.2 g⟩
-    calc
-      rho u (rho g x) = rho (u * g) x := by rw [map_mul, Module.End.mul_apply]
-      _ = rho (g * (g⁻¹ * u * g)) x := by congr 2; group
-      _ = rho g (rho ugu x) := by rw [map_mul, Module.End.mul_apply]
-      _ = rho g x := by rw [hx ugu]
-
 /-- **Common fixed vector for a normal unipotent subgroup and a second unipotent subgroup.**
 If both subgroups act unipotently in a nonzero finite-dimensional representation, they fix a
 common nonzero vector. -/
@@ -100,16 +69,15 @@ theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUnipotent
     ∃ x : V, x ≠ 0 ∧ (∀ u : U, rho u x = x) ∧ ∀ w : W, rho w x = x := by
   obtain ⟨x, hx, hxU⟩ :=
     _root_.Representation.exists_common_fixed_vector_of_isUnipotent (rho.comp U.subtype) hU
-  let S := fixedSubrepresentation rho U
-  have hxS : x ∈ S.toSubmodule := hxU
-  let xS : S.toSubmodule := ⟨x, hxS⟩
-  have : Nontrivial S.toSubmodule := ⟨xS, 0, fun h ↦ hx (congrArg Subtype.val h)⟩
-  let rhoW : Representation K W S.toSubmodule := S.toRepresentation.comp W.subtype
+  let S := Representation.invariants (rho.comp U.subtype)
+  have hxS : x ∈ S := hxU
+  let xS : S := ⟨x, hxS⟩
+  have : Nontrivial S := ⟨xS, 0, fun h ↦ hx (congrArg Subtype.val h)⟩
+  let rhoW : Representation K W S := (rho.toInvariants U).comp W.subtype
   have hW' (w : W) : IsNilpotent (rhoW w - 1) := by
-    have hinvariant : Set.MapsTo (rho (w : G) - (1 : Module.End K V))
-        S.toSubmodule S.toSubmodule := by
+    have hinvariant : Set.MapsTo (rho (w : G) - (1 : Module.End K V)) S S := by
       intro y hy
-      exact S.toSubmodule.sub_mem (S.apply_mem_toSubmodule w hy) hy
+      exact S.sub_mem (Representation.le_comap_invariants rho U (w : G) hy) hy
     have hrestrict := Module.End.isNilpotent.restrict hinvariant (hW w)
     have heq : rhoW w - 1 =
         (rho (w : G) - (1 : Module.End K V)).restrict hinvariant := by
@@ -120,6 +88,77 @@ theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUnipotent
     _root_.Representation.exists_common_fixed_vector_of_isUnipotent rhoW hW'
   refine ⟨y, fun h ↦ hy (Subtype.ext h), y.2, fun w ↦ ?_⟩
   exact congrArg Subtype.val (hyW w)
+
+/-- If a normal subgroup and a second subgroup generate the ambient group and each acts
+unipotently, then the whole group acts unipotently. -/
+private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
+    [FiniteDimensional K V]
+    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
+    (hUW : U ⊔ W = ⊤)
+    (hU : ∀ u : U, IsNilpotent (rho u - 1))
+    (hW : ∀ w : W, IsNilpotent (rho w - 1)) (g : G) :
+    IsNilpotent (rho g - 1) := by
+  generalize hdim : finrank K V = d
+  induction d using Nat.strong_induction_on generalizing V with
+  | h d ih =>
+      by_cases hV : Nontrivial V
+      · let _ : Nontrivial V := hV
+        obtain ⟨x, hx, hxU, hxW⟩ :=
+          rho.exists_common_fixed_vector_of_normal_isUnipotent U W hU hW
+        have hfixed (z : G) : rho z x = x := by
+          have hz : z ∈ U ⊔ W := by rw [hUW]; exact Subgroup.mem_top z
+          obtain ⟨u, hu, w, hw, rfl⟩ :=
+            (TauCeti.Subgroup.mem_sup_of_right_le_normalizer_left
+              (H := U) (K := W) (by rw [U.normalizer_eq_top]; exact le_top)).mp hz
+          rw [map_mul, Module.End.mul_apply, hxW ⟨w, hw⟩, hxU ⟨u, hu⟩]
+        let p : Submodule K V := K ∙ x
+        have hpdim : finrank K p = 1 := finrank_span_singleton hx
+        have hp_fixed (z : G) (y : p) : rho z (y : V) = y := by
+          obtain ⟨a, ha⟩ := Submodule.mem_span_singleton.mp y.2
+          rw [← ha, map_smul, hfixed]
+        have hp (z : G) : p ≤ p.comap (rho z) := by
+          intro y hy
+          change rho z y ∈ p
+          rw [hp_fixed z ⟨y, hy⟩]
+          exact hy
+        let q : Representation K G (V ⧸ p) := rho.quotient p hp
+        have hq (z : G) (hz : IsNilpotent (rho z - 1)) : IsNilpotent (q z - 1) := by
+          have hsub : p ≤ p.comap (rho z - 1) := by
+            intro y hy
+            change rho z y - y ∈ p
+            exact p.sub_mem (hp z hy) hy
+          have heq : q z - 1 = p.mapQ p (rho z - 1) hsub := by
+            ext y
+            simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
+          rw [heq]
+          exact Module.End.IsNilpotent.mapQ hsub hz
+        have hqdim : finrank K (V ⧸ p) < d := by
+          have hsum := Module.finrank_quotient_add_finrank_le p
+          rw [hpdim, hdim] at hsum
+          omega
+        obtain ⟨n, hn⟩ := ih (finrank K (V ⧸ p)) hqdim q
+          (fun u ↦ hq u (hU u)) (fun w ↦ hq w (hW w)) rfl
+        let f : Module.End K V := rho g - 1
+        have hsub : p ≤ p.comap f := by
+          intro y hy
+          change rho g y - y ∈ p
+          exact p.sub_mem (hp g hy) hy
+        have heq : q g - 1 = p.mapQ p f hsub := by
+          ext y
+          simp [f, q, Representation.quotient_apply, Submodule.mapQ_apply]
+        rw [heq] at hn
+        refine ⟨n + 1, ?_⟩
+        ext y
+        rw [pow_succ', Module.End.mul_apply]
+        have hymem : (f ^ n) y ∈ p := by
+          apply (Submodule.Quotient.mk_eq_zero p).mp
+          have hz := LinearMap.congr_fun hn (p.mkQ y)
+          rw [← p.mapQ_pow hsub n] at hz
+          simpa only [Submodule.mkQ_apply, Submodule.mapQ_apply, LinearMap.zero_apply] using hz
+        change rho g ((f ^ n) y) - (f ^ n) y = 0
+        rw [hp_fixed g ⟨(f ^ n) y, hymem⟩, sub_self]
+      · let _ : Subsingleton V := not_nontrivial_iff_subsingleton.mp hV
+        exact ⟨1, Subsingleton.elim _ _⟩
 
 /-- A normal subgroup and a second subgroup which generate the ambient group and act unipotently
 are simultaneously upper unitriangular.
@@ -134,134 +173,9 @@ theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_normal_isUnip
     (hU : ∀ u : U, IsNilpotent (rho u - 1))
     (hW : ∀ w : W, IsNilpotent (rho w - 1)) :
     ∃ (n : ℕ) (b : Basis (Fin n) K V),
-      ∀ g, (LinearMap.toMatrixAlgEquiv b (rho g)).IsUpperUnitriangular := by
-  generalize hdim : finrank K V = d
-  induction d using Nat.strong_induction_on generalizing V with
-  | h d ih =>
-      by_cases hV : Nontrivial V
-      · let _ : Nontrivial V := hV
-        -- First find a line fixed by both generators, hence by the group they generate.
-        obtain ⟨x, hx, hxU, hxW⟩ :=
-          rho.exists_common_fixed_vector_of_normal_isUnipotent U W hU hW
-        have hfixed (g : G) : rho g x = x := by
-          have hg : g ∈ U ⊔ W := by rw [hUW]; exact Subgroup.mem_top g
-          obtain ⟨u, hu, w, hw, rfl⟩ :=
-            (TauCeti.Subgroup.mem_sup_of_right_le_normalizer_left
-              (H := U) (K := W) (by rw [U.normalizer_eq_top]; exact le_top)).mp hg
-          rw [map_mul, Module.End.mul_apply, hxW ⟨w, hw⟩, hxU ⟨u, hu⟩]
-        let p : Submodule K V := K ∙ x
-        have hpdim : finrank K p = 1 := finrank_span_singleton hx
-        have hp_fixed (g : G) (y : p) : rho g (y : V) = y := by
-          obtain ⟨a, ha⟩ := Submodule.mem_span_singleton.mp y.2
-          rw [← ha, map_smul, hfixed]
-        have hp (g : G) : p ≤ p.comap (rho g) := by
-          intro y hy
-          change rho g y ∈ p
-          rw [hp_fixed g ⟨y, hy⟩]
-          exact hy
-        let q : Representation K G (V ⧸ p) := rho.quotient p hp
-        have q_apply (g : G) (y : V) : q g (p.mkQ y) = p.mkQ (rho g y) := by
-          simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
-        have hqU (u : U) : IsNilpotent (q u - 1) := by
-          have hsub : p ≤ p.comap (rho u - 1) := by
-            intro y hy
-            change rho u y - y ∈ p
-            exact p.sub_mem (hp u hy) hy
-          have hnil := Module.End.IsNilpotent.mapQ hsub (hU u)
-          have heq : q u - 1 = p.mapQ p (rho u - 1) hsub := by
-            ext y
-            simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
-          rwa [heq]
-        have hqW (w : W) : IsNilpotent (q w - 1) := by
-          have hsub : p ≤ p.comap (rho w - 1) := by
-            intro y hy
-            change rho w y - y ∈ p
-            exact p.sub_mem (hp w hy) hy
-          have hnil := Module.End.IsNilpotent.mapQ hsub (hW w)
-          have heq : q w - 1 = p.mapQ p (rho w - 1) hsub := by
-            ext y
-            simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
-          rwa [heq]
-        have hqdim : finrank K (V ⧸ p) < d := by
-          have hsum := Module.finrank_quotient_add_finrank_le p
-          rw [hpdim, hdim] at hsum
-          omega
-        obtain ⟨n, bq, hbq⟩ := ih (finrank K (V ⧸ p)) hqdim q hqU hqW rfl
-        -- Put the common fixed line before an upper-unitriangular basis of the quotient.
-        let bp : Basis (Fin 1) K p := finBasisOfFinrankEq K p hpdim
-        let b := extensionBasis p bp bq
-        refine ⟨1 + n, b, fun g ↦ ?_⟩
-        rw [Matrix.isUpperUnitriangular_def]
-        constructor
-        -- The extension basis gives four matrix blocks. The lower-left block vanishes because
-        -- `p` is invariant; the lower-right block is the quotient matrix.
-        · intro i j hji
-          obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
-          obtain ⟨j, rfl⟩ := finSumFinEquiv.surjective j
-          cases i with
-          | inl i =>
-              cases j with
-              | inl j =>
-                  simp only [finSumFinEquiv_apply_left] at hji
-                  have := (Fin.strictMono_castAdd n).lt_iff_lt.mp hji
-                  omega
-              | inr j =>
-                  rw [finSumFinEquiv_apply_left, finSumFinEquiv_apply_right] at hji
-                  change 1 + j.val < i.val at hji
-                  omega
-          | inr i =>
-              cases j with
-              | inl j =>
-                  rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_left,
-                    LinearMap.toMatrixAlgEquiv_apply]
-                  have hmem : rho g (bp j : V) ∈ p := hp g (bp j).2
-                  rw [extensionBasis_castAdd,
-                    extensionBasis_repr_natAdd p bp bq (rho g (bp j : V)) i]
-                  simp only [Submodule.mkQ_apply,
-                    (Submodule.Quotient.mk_eq_zero p).mpr hmem, map_zero,
-                    Finsupp.zero_apply]
-              | inr j =>
-                  rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_right,
-                    LinearMap.toMatrixAlgEquiv_apply, extensionBasis_repr_natAdd]
-                  rw [← q_apply]
-                  rw [Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
-                  simpa only [LinearMap.toMatrixAlgEquiv_apply] using
-                    (hbq g |>.isUpperTriangular
-                      ((Fin.strictMono_natAdd 1).lt_iff_lt.mp hji))
-        · intro i
-          obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
-          cases i with
-          | inl i =>
-              rw [finSumFinEquiv_apply_left, LinearMap.toMatrixAlgEquiv_apply,
-                extensionBasis_castAdd]
-              rw [hp_fixed, extensionBasis_repr_castAdd]
-              simp
-          | inr i =>
-              rw [finSumFinEquiv_apply_right, LinearMap.toMatrixAlgEquiv_apply,
-                extensionBasis_repr_natAdd]
-              rw [← q_apply]
-              rw [Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
-              simpa only [LinearMap.toMatrixAlgEquiv_apply] using hbq g |>.apply_diag i
-      · let _ : Subsingleton V := not_nontrivial_iff_subsingleton.mp hV
-        have hzero : finrank K V = 0 := Module.finrank_zero_of_subsingleton
-        let b : Basis (Fin 0) K V := finBasisOfFinrankEq K V hzero
-        refine ⟨0, b, fun g ↦ ?_⟩
-        rw [Matrix.isUpperUnitriangular_def]
-        exact ⟨fun i ↦ Fin.elim0 i, fun i ↦ Fin.elim0 i⟩
-
-/-- If a normal subgroup and a second subgroup generate the ambient group and each acts
-unipotently, then the whole group acts unipotently. -/
-theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
-    [FiniteDimensional K V]
-    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
-    (hUW : U ⊔ W = ⊤)
-    (hU : ∀ u : U, IsNilpotent (rho u - 1))
-    (hW : ∀ w : W, IsNilpotent (rho w - 1)) (g : G) :
-    IsNilpotent (rho g - 1) := by
-  obtain ⟨n, b, hb⟩ :=
-    rho.exists_basis_isUpperUnitriangular_of_normal_isUnipotent U W hUW hU hW
-  rw [← IsNilpotent.map_iff (LinearMap.toMatrixAlgEquiv b).injective]
-  simpa only [map_sub, map_one] using (hb g).isNilpotent_sub_one
+      ∀ g, (LinearMap.toMatrixAlgEquiv b (rho g)).IsUpperUnitriangular :=
+  rho.exists_basis_isUpperUnitriangular_of_isUnipotent
+    (rho.isNilpotent_sub_one_of_normal_isUnipotent U W hUW hU hW)
 
 /-- Every element of the join of a normal unipotent subgroup and a second unipotent subgroup acts
 unipotently.

--- a/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
@@ -5,23 +5,20 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RepresentationTheory.Basic
-public import TauCeti.LinearAlgebra.Matrix.Triangular
 import TauCeti.GroupTheory.SemidirectProduct
-import TauCeti.RepresentationTheory.Unipotent.Solvable
+public import TauCeti.RepresentationTheory.Unipotent.Solvable
 import Mathlib.RepresentationTheory.Invariants
 import Mathlib.RingTheory.Nilpotent.Lemmas
 
 /-!
 # Joins of normal unipotent linear groups
 
-Let `U` be a normal subgroup and `W` a subgroup of a group acting on a finite-dimensional vector
-space. If every element of each subgroup acts unipotently, then every element of `U ⊔ W` acts
-unipotently. The key point is that the common fixed space of `U` is invariant under the ambient
-group. Kolchin's common fixed-vector theorem applied to `W` on that space therefore produces a
-line fixed by both subgroups. Repeating the argument on the quotient gives a simultaneous
-upper-unitriangular basis for their join. Only `U` needs to be normal; this is stronger than the
-binary-product application, where both subgroups are normal.
+Let `U` and `W` be subgroups of a group acting on a finite-dimensional vector space, with `W`
+normalizing `U`. If every element of each subgroup acts unipotently, then every element of `U ⊔ W`
+acts unipotently. The key point is that the common fixed space of `U` is invariant under `W`.
+Kolchin's common fixed-vector theorem applied to `W` on that space therefore produces a line fixed
+by both subgroups. Repeating the argument on the quotient gives a simultaneous upper-unitriangular
+basis for their join. In particular, the result applies when `U` is normal in the ambient group.
 
 This is the linear-algebraic core of closure of connected normal unipotent affine subgroups under
 binary products. The scheme-theoretic argument additionally has to identify the geometric points
@@ -29,8 +26,8 @@ of the multiplication image with products of points of the two source subgroups.
 
 ## Main declarations
 
-* `Representation.exists_common_fixed_vector_of_normal_isUnipotent`: a normal subgroup and a
-  second subgroup acting unipotently have a common nonzero fixed vector.
+* `Representation.exists_common_fixed_vector_of_normal_isUnipotent`: two subgroups, one normalized
+  by the other, acting unipotently have a common nonzero fixed vector.
 * `Representation.exists_basis_isUpperUnitriangular_of_normal_isUnipotent`: if they generate the
   ambient group, it is simultaneously upper unitriangular.
 * `Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipotent`: the corresponding result
@@ -58,10 +55,8 @@ noncomputable section
 variable {K : Type u} {G : Type w} {V : Type v}
 variable [Field K] [Group G] [AddCommGroup V] [Module K V]
 
-/-- **Common fixed vector for a normal unipotent subgroup and a second unipotent subgroup.**
-If both subgroups act unipotently in a nonzero finite-dimensional representation, they fix a
-common nonzero vector. -/
-theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUnipotent
+/-- Common fixed vector when a normal subgroup and a second subgroup act unipotently. -/
+private theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUnipotent_aux
     [FiniteDimensional K V] [Nontrivial V]
     (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
     (hU : ∀ u : U, IsNilpotent (rho u - 1))
@@ -82,18 +77,50 @@ theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUnipotent
     have heq : rhoW w - 1 =
         (rho (w : G) - (1 : Module.End K V)).restrict hinvariant := by
       ext y
-      rfl
+      have hrestrict_apply :=
+        congrArg Subtype.val (LinearMap.restrict_apply hinvariant y)
+      have hrhoW_apply : (rhoW w y : V) = rho (w : G) y := by
+        -- `toInvariants` and representation composition are abbreviations, so their application
+        -- rule is definitional rather than a separately named theorem.
+        rfl
+      rw [LinearMap.sub_apply, Module.End.one_apply, Submodule.coe_sub, hrhoW_apply]
+      simpa only [LinearMap.sub_apply, Module.End.one_apply] using hrestrict_apply.symm
     rwa [heq]
   obtain ⟨y, hy, hyW⟩ :=
     _root_.Representation.exists_common_fixed_vector_of_isUnipotent rhoW hW'
   refine ⟨y, fun h ↦ hy (Subtype.ext h), y.2, fun w ↦ ?_⟩
   exact congrArg Subtype.val (hyW w)
 
-/-- If a normal subgroup and a second subgroup generate the ambient group and each acts
-unipotently, then the whole group acts unipotently. -/
+/-- **Common fixed vector for two unipotent subgroups, one normalized by the other.**
+If `W` normalizes `U` and both subgroups act unipotently in a nonzero finite-dimensional
+representation, they fix a common nonzero vector. -/
+theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUnipotent
+    [FiniteDimensional K V] [Nontrivial V]
+    (rho : Representation K G V) (U W : Subgroup G)
+    (hWU : W ≤ Subgroup.normalizer (U : Set G))
+    (hU : ∀ u : U, IsNilpotent (rho u - 1))
+    (hW : ∀ w : W, IsNilpotent (rho w - 1)) :
+    ∃ x : V, x ≠ 0 ∧ (∀ u : U, rho u x = x) ∧ ∀ w : W, rho w x = x := by
+  let U' : Subgroup (W ⊔ U : Subgroup G) := U.subgroupOf (W ⊔ U)
+  let W' : Subgroup (W ⊔ U : Subgroup G) := W.subgroupOf (W ⊔ U)
+  let rhoJ : Representation K (W ⊔ U : Subgroup G) V := rho.comp (W ⊔ U).subtype
+  let _ : U'.Normal := Subgroup.normal_subgroupOf_sup_of_le_normalizer hWU
+  have hU' (u : U') : IsNilpotent (rhoJ u - 1) := by
+    exact hU ⟨u, u.2⟩
+  have hW' (w : W') : IsNilpotent (rhoJ w - 1) := by
+    exact hW ⟨w, w.2⟩
+  obtain ⟨x, hx, hxU, hxW⟩ :=
+    rhoJ.exists_common_fixed_vector_of_normal_isUnipotent_aux U' W' hU' hW'
+  refine ⟨x, hx, fun u ↦ ?_, fun w ↦ ?_⟩
+  · exact hxU (⟨⟨u, (le_sup_right : U ≤ W ⊔ U) u.2⟩, u.2⟩ : U')
+  · exact hxW (⟨⟨w, (le_sup_left : W ≤ W ⊔ U) w.2⟩, w.2⟩ : W')
+
+/-- If one subgroup is normalized by a second subgroup, they generate the ambient group, and each
+acts unipotently, then the whole group acts unipotently. -/
 private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
     [FiniteDimensional K V]
-    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
+    (rho : Representation K G V) (U W : Subgroup G)
+    (hWU : W ≤ Subgroup.normalizer (U : Set G))
     (hUW : U ⊔ W = ⊤)
     (hU : ∀ u : U, IsNilpotent (rho u - 1))
     (hW : ∀ w : W, IsNilpotent (rho w - 1)) (g : G) :
@@ -104,12 +131,12 @@ private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
       by_cases hV : Nontrivial V
       · let _ : Nontrivial V := hV
         obtain ⟨x, hx, hxU, hxW⟩ :=
-          rho.exists_common_fixed_vector_of_normal_isUnipotent U W hU hW
+          rho.exists_common_fixed_vector_of_normal_isUnipotent U W hWU hU hW
         have hfixed (z : G) : rho z x = x := by
           have hz : z ∈ U ⊔ W := by rw [hUW]; exact Subgroup.mem_top z
           obtain ⟨u, hu, w, hw, rfl⟩ :=
             (TauCeti.Subgroup.mem_sup_of_right_le_normalizer_left
-              (H := U) (K := W) (by rw [U.normalizer_eq_top]; exact le_top)).mp hz
+              (H := U) (K := W) hWU).mp hz
           rw [map_mul, Module.End.mul_apply, hxW ⟨w, hw⟩, hxU ⟨u, hu⟩]
         let p : Submodule K V := K ∙ x
         have hpdim : finrank K p = 1 := finrank_span_singleton hx
@@ -118,18 +145,20 @@ private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
           rw [← ha, map_smul, hfixed]
         have hp (z : G) : p ≤ p.comap (rho z) := by
           intro y hy
-          change rho z y ∈ p
+          rw [Submodule.mem_comap]
           rw [hp_fixed z ⟨y, hy⟩]
           exact hy
         let q : Representation K G (V ⧸ p) := rho.quotient p hp
         have hq (z : G) (hz : IsNilpotent (rho z - 1)) : IsNilpotent (q z - 1) := by
           have hsub : p ≤ p.comap (rho z - 1) := by
             intro y hy
-            change rho z y - y ∈ p
-            exact p.sub_mem (hp z hy) hy
+            rw [Submodule.mem_comap]
+            simpa only [LinearMap.sub_apply, Module.End.one_apply] using p.sub_mem (hp z hy) hy
           have heq : q z - 1 = p.mapQ p (rho z - 1) hsub := by
             ext y
-            simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
+            simp only [Representation.quotient_apply, LinearMap.coe_comp, Function.comp_apply,
+              Submodule.mkQ_apply, LinearMap.sub_apply, Submodule.mapQ_apply, End.one_apply,
+              Submodule.Quotient.mk_sub, q]
           rw [heq]
           exact Module.End.IsNilpotent.mapQ hsub hz
         have hqdim : finrank K (V ⧸ p) < d := by
@@ -141,11 +170,13 @@ private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
         let f : Module.End K V := rho g - 1
         have hsub : p ≤ p.comap f := by
           intro y hy
-          change rho g y - y ∈ p
-          exact p.sub_mem (hp g hy) hy
+          rw [Submodule.mem_comap]
+          simpa only [f, LinearMap.sub_apply, Module.End.one_apply] using p.sub_mem (hp g hy) hy
         have heq : q g - 1 = p.mapQ p f hsub := by
           ext y
-          simp [f, q, Representation.quotient_apply, Submodule.mapQ_apply]
+          simp only [Representation.quotient_apply, LinearMap.coe_comp, Function.comp_apply,
+            Submodule.mkQ_apply, LinearMap.sub_apply, Submodule.mapQ_apply, End.one_apply,
+            Submodule.Quotient.mk_sub, q, f]
         rw [heq] at hn
         refine ⟨n + 1, ?_⟩
         ext y
@@ -155,59 +186,67 @@ private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
           have hz := LinearMap.congr_fun hn (p.mkQ y)
           rw [← p.mapQ_pow hsub n] at hz
           simpa only [Submodule.mkQ_apply, Submodule.mapQ_apply, LinearMap.zero_apply] using hz
-        change rho g ((f ^ n) y) - (f ^ n) y = 0
-        rw [hp_fixed g ⟨(f ^ n) y, hymem⟩, sub_self]
+        rw [LinearMap.sub_apply, Module.End.one_apply, hp_fixed g ⟨(f ^ n) y, hymem⟩, sub_self,
+          LinearMap.zero_apply]
       · let _ : Subsingleton V := not_nontrivial_iff_subsingleton.mp hV
         exact ⟨1, Subsingleton.elim _ _⟩
 
-/-- A normal subgroup and a second subgroup which generate the ambient group and act unipotently
-are simultaneously upper unitriangular.
+/-- Two unipotent subgroups, one normalized by the other, which generate the ambient group are
+simultaneously upper unitriangular.
 
 The generation hypothesis is the natural form used for a product subgroup: after restricting an
 ambient representation to `U ⊔ W`, the images of `U` and `W` generate the whole restricted group.
 -/
 theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_normal_isUnipotent
     [FiniteDimensional K V]
-    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
+    (rho : Representation K G V) (U W : Subgroup G)
+    (hWU : W ≤ Subgroup.normalizer (U : Set G))
     (hUW : U ⊔ W = ⊤)
     (hU : ∀ u : U, IsNilpotent (rho u - 1))
     (hW : ∀ w : W, IsNilpotent (rho w - 1)) :
     ∃ (n : ℕ) (b : Basis (Fin n) K V),
       ∀ g, (LinearMap.toMatrixAlgEquiv b (rho g)).IsUpperUnitriangular :=
   rho.exists_basis_isUpperUnitriangular_of_isUnipotent
-    (rho.isNilpotent_sub_one_of_normal_isUnipotent U W hUW hU hW)
+    (rho.isNilpotent_sub_one_of_normal_isUnipotent U W hWU hUW hU hW)
 
-/-- Every element of the join of a normal unipotent subgroup and a second unipotent subgroup acts
+/-- Every element of the join of two unipotent subgroups, one normalized by the other, acts
 unipotently.
 
-This is the form used for products of subgroup schemes: normality makes the setwise product a
-subgroup, and the join is that product. -/
+This is the form used for products of subgroup schemes: normalization makes the setwise product a
+subgroup, and that product is the join. -/
 theorem _root_.Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipotent
     [FiniteDimensional K V]
-    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
+    (rho : Representation K G V) (U W : Subgroup G)
+    (hWU : W ≤ Subgroup.normalizer (U : Set G))
     (hU : ∀ u : U, IsNilpotent (rho u - 1))
     (hW : ∀ w : W, IsNilpotent (rho w - 1)) {g : G} (hg : g ∈ U ⊔ W) :
     IsNilpotent (rho g - 1) := by
-  let J : Subgroup G := U ⊔ W
+  let J : Subgroup G := W ⊔ U
   let U' : Subgroup J := U.comap J.subtype
   let W' : Subgroup J := W.comap J.subtype
   let rhoJ : Representation K J V := rho.comp J.subtype
-  have hU_le : U ≤ J := le_sup_left
-  have hW_le : W ≤ J := le_sup_right
+  let _ : U'.Normal := Subgroup.normal_subgroupOf_sup_of_le_normalizer hWU
+  have hU_le : U ≤ J := le_sup_right
+  have hW_le : W ≤ J := le_sup_left
   have hU_range : U ≤ J.subtype.range := by simpa only [Subgroup.range_subtype] using hU_le
   have hW_range : W ≤ J.subtype.range := by simpa only [Subgroup.range_subtype] using hW_le
   have hsup : U' ⊔ W' = ⊤ := by
-    rw [show U' ⊔ W' = (U ⊔ W).comap J.subtype from
-      Subgroup.comap_sup_eq_of_le_range J.subtype hU_range hW_range]
+    rw [Subgroup.comap_sup_eq_of_le_range J.subtype hU_range hW_range]
     ext x
     simp only [Subgroup.mem_comap, Subgroup.mem_top, iff_true]
+    rw [sup_comm]
     exact x.2
   have hU' (u : U') : IsNilpotent (rhoJ u - 1) := by
     exact hU ⟨u, u.2⟩
   have hW' (w : W') : IsNilpotent (rhoJ w - 1) := by
     exact hW ⟨w, w.2⟩
-  let gJ : J := ⟨g, hg⟩
-  exact rhoJ.isNilpotent_sub_one_of_normal_isUnipotent U' W' hsup hU' hW' gJ
+  have hgJ : g ∈ J := by
+    have hJ : J = U ⊔ W := sup_comm W U
+    rw [hJ]
+    exact hg
+  let gJ : J := ⟨g, hgJ⟩
+  exact rhoJ.isNilpotent_sub_one_of_normal_isUnipotent U' W'
+    Subgroup.le_normalizer_of_normal hsup hU' hW' gJ
 
 end
 

--- a/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
@@ -53,7 +53,7 @@ public section
 
 open Matrix Module
 
-namespace TauCeti.Representation
+namespace TauCeti
 
 universe u v w
 
@@ -297,4 +297,4 @@ theorem _root_.Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipote
 
 end
 
-end TauCeti.Representation
+end TauCeti

--- a/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.Basic
+public import TauCeti.LinearAlgebra.Matrix.Triangular
+import TauCeti.GroupTheory.SemidirectProduct
+import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Kolchin
+import TauCeti.LinearAlgebra.ExtensionBasis
+import TauCeti.RepresentationTheory.Subrepresentation
+import Mathlib.RingTheory.Nilpotent.Lemmas
+import Mathlib.Tactic.Group
+
+/-!
+# Joins of normal unipotent linear groups
+
+Let `U` be a normal subgroup and `W` a subgroup of a group acting on a finite-dimensional vector
+space. If every element of each subgroup acts unipotently, then every element of `U ⊔ W` acts
+unipotently. The key point is that the common fixed space of `U` is invariant under the ambient
+group. Kolchin's common fixed-vector theorem applied to `W` on that space therefore produces a
+line fixed by both subgroups. Repeating the argument on the quotient gives a simultaneous
+upper-unitriangular basis for their join. Only `U` needs to be normal; this is stronger than the
+binary-product application, where both subgroups are normal.
+
+This is the linear-algebraic core of closure of connected normal unipotent affine subgroups under
+binary products. The scheme-theoretic argument additionally has to identify the geometric points
+of the multiplication image with products of points of the two source subgroups.
+
+## Main declarations
+
+* `Representation.exists_common_fixed_vector_of_normal_isUnipotent`: a normal subgroup and a
+  second subgroup acting unipotently have a common nonzero fixed vector.
+* `Representation.exists_basis_isUpperUnitriangular_of_normal_isUnipotent`: if they generate the
+  ambient group, it is simultaneously upper unitriangular.
+* `Representation.isNilpotent_sub_one_of_normal_isUnipotent`: every element of that ambient group
+  acts unipotently.
+* `Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipotent`: the corresponding result
+  for an arbitrary join inside a larger group.
+
+## References
+
+* A. Borel, *Linear Algebraic Groups*, Theorem 4.8 and Proposition 14.4.
+* T. A. Springer, *Linear Algebraic Groups*, Proposition 2.4.12.
+
+This supplies the representation-theoretic product step in Layer 5, "The unipotent radical", of
+the ReductiveGroups roadmap.
+-/
+
+public section
+
+open Matrix Module
+
+namespace TauCeti.Representation
+
+universe u v w
+
+noncomputable section
+
+variable {K : Type u} {G : Type w} {V : Type v}
+variable [Field K] [Group G] [AddCommGroup V] [Module K V]
+
+/-- The common fixed space of a subgroup in a representation. -/
+private def fixedSubmodule (rho : Representation K G V) (U : Subgroup G) : Submodule K V where
+  carrier := {x | ∀ u : U, rho u x = x}
+  zero_mem' := by simp
+  add_mem' hx hy u := by simp only [map_add, hx u, hy u]
+  smul_mem' r x hx u := by simp only [map_smul, hx u]
+
+/-- Membership in the common fixed space means being fixed by every subgroup element. -/
+private theorem mem_fixedSubmodule_iff (rho : Representation K G V) (U : Subgroup G) (x : V) :
+    x ∈ fixedSubmodule rho U ↔ ∀ u : U, rho u x = x :=
+  Iff.rfl
+
+/-- The common fixed space of a normal subgroup is an ambient subrepresentation. -/
+private def fixedSubrepresentation (rho : Representation K G V) (U : Subgroup G) [U.Normal] :
+    Subrepresentation rho where
+  toSubmodule := fixedSubmodule rho U
+  apply_mem_toSubmodule g x hx := by
+    rw [mem_fixedSubmodule_iff] at hx ⊢
+    intro u
+    let ugu : U := ⟨g⁻¹ * (u : G) * g,
+      (show U.Normal from inferInstance).conj_mem' (u : G) u.2 g⟩
+    calc
+      rho u (rho g x) = rho (u * g) x := by rw [map_mul, Module.End.mul_apply]
+      _ = rho (g * (g⁻¹ * u * g)) x := by congr 2; group
+      _ = rho g (rho ugu x) := by rw [map_mul, Module.End.mul_apply]
+      _ = rho g x := by rw [hx ugu]
+
+/-- **Common fixed vector for a normal unipotent subgroup and a second unipotent subgroup.**
+If both subgroups act unipotently in a nonzero finite-dimensional representation, they fix a
+common nonzero vector. -/
+theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUnipotent
+    [FiniteDimensional K V] [Nontrivial V]
+    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
+    (hU : ∀ u : U, IsNilpotent (rho u - 1))
+    (hW : ∀ w : W, IsNilpotent (rho w - 1)) :
+    ∃ x : V, x ≠ 0 ∧ (∀ u : U, rho u x = x) ∧ ∀ w : W, rho w x = x := by
+  obtain ⟨x, hx, hxU⟩ :=
+    _root_.Representation.exists_common_fixed_vector_of_isUnipotent (rho.comp U.subtype) hU
+  let S := fixedSubrepresentation rho U
+  have hxS : x ∈ S.toSubmodule := hxU
+  let xS : S.toSubmodule := ⟨x, hxS⟩
+  have : Nontrivial S.toSubmodule := ⟨xS, 0, fun h ↦ hx (congrArg Subtype.val h)⟩
+  let rhoW : Representation K W S.toSubmodule := S.toRepresentation.comp W.subtype
+  have hW' (w : W) : IsNilpotent (rhoW w - 1) := by
+    have hinvariant : Set.MapsTo (rho (w : G) - (1 : Module.End K V))
+        S.toSubmodule S.toSubmodule := by
+      intro y hy
+      exact S.toSubmodule.sub_mem (S.apply_mem_toSubmodule w hy) hy
+    have hrestrict := Module.End.isNilpotent.restrict hinvariant (hW w)
+    have heq : rhoW w - 1 =
+        (rho (w : G) - (1 : Module.End K V)).restrict hinvariant := by
+      ext y
+      rfl
+    rwa [heq]
+  obtain ⟨y, hy, hyW⟩ :=
+    _root_.Representation.exists_common_fixed_vector_of_isUnipotent rhoW hW'
+  refine ⟨y, fun h ↦ hy (Subtype.ext h), y.2, fun w ↦ ?_⟩
+  exact congrArg Subtype.val (hyW w)
+
+/-- A normal subgroup and a second subgroup which generate the ambient group and act unipotently
+are simultaneously upper unitriangular.
+
+The generation hypothesis is the natural form used for a product subgroup: after restricting an
+ambient representation to `U ⊔ W`, the images of `U` and `W` generate the whole restricted group.
+-/
+theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_normal_isUnipotent
+    [FiniteDimensional K V]
+    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
+    (hUW : U ⊔ W = ⊤)
+    (hU : ∀ u : U, IsNilpotent (rho u - 1))
+    (hW : ∀ w : W, IsNilpotent (rho w - 1)) :
+    ∃ (n : ℕ) (b : Basis (Fin n) K V),
+      ∀ g, (LinearMap.toMatrixAlgEquiv b (rho g)).IsUpperUnitriangular := by
+  generalize hdim : finrank K V = d
+  induction d using Nat.strong_induction_on generalizing V with
+  | h d ih =>
+      by_cases hV : Nontrivial V
+      · let _ : Nontrivial V := hV
+        -- First find a line fixed by both generators, hence by the group they generate.
+        obtain ⟨x, hx, hxU, hxW⟩ :=
+          rho.exists_common_fixed_vector_of_normal_isUnipotent U W hU hW
+        have hfixed (g : G) : rho g x = x := by
+          have hg : g ∈ U ⊔ W := by rw [hUW]; exact Subgroup.mem_top g
+          obtain ⟨u, hu, w, hw, rfl⟩ :=
+            (TauCeti.Subgroup.mem_sup_of_right_le_normalizer_left
+              (H := U) (K := W) (by rw [U.normalizer_eq_top]; exact le_top)).mp hg
+          rw [map_mul, Module.End.mul_apply, hxW ⟨w, hw⟩, hxU ⟨u, hu⟩]
+        let p : Submodule K V := K ∙ x
+        have hpdim : finrank K p = 1 := finrank_span_singleton hx
+        have hp_fixed (g : G) (y : p) : rho g (y : V) = y := by
+          obtain ⟨a, ha⟩ := Submodule.mem_span_singleton.mp y.2
+          rw [← ha, map_smul, hfixed]
+        have hp (g : G) : p ≤ p.comap (rho g) := by
+          intro y hy
+          change rho g y ∈ p
+          rw [hp_fixed g ⟨y, hy⟩]
+          exact hy
+        let q : Representation K G (V ⧸ p) := rho.quotient p hp
+        have q_apply (g : G) (y : V) : q g (p.mkQ y) = p.mkQ (rho g y) := by
+          simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
+        have hqU (u : U) : IsNilpotent (q u - 1) := by
+          have hsub : p ≤ p.comap (rho u - 1) := by
+            intro y hy
+            change rho u y - y ∈ p
+            exact p.sub_mem (hp u hy) hy
+          have hnil := Module.End.IsNilpotent.mapQ hsub (hU u)
+          have heq : q u - 1 = p.mapQ p (rho u - 1) hsub := by
+            ext y
+            simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
+          rwa [heq]
+        have hqW (w : W) : IsNilpotent (q w - 1) := by
+          have hsub : p ≤ p.comap (rho w - 1) := by
+            intro y hy
+            change rho w y - y ∈ p
+            exact p.sub_mem (hp w hy) hy
+          have hnil := Module.End.IsNilpotent.mapQ hsub (hW w)
+          have heq : q w - 1 = p.mapQ p (rho w - 1) hsub := by
+            ext y
+            simp [q, Representation.quotient_apply, Submodule.mapQ_apply]
+          rwa [heq]
+        have hqdim : finrank K (V ⧸ p) < d := by
+          have hsum := Module.finrank_quotient_add_finrank_le p
+          rw [hpdim, hdim] at hsum
+          omega
+        obtain ⟨n, bq, hbq⟩ := ih (finrank K (V ⧸ p)) hqdim q hqU hqW rfl
+        -- Put the common fixed line before an upper-unitriangular basis of the quotient.
+        let bp : Basis (Fin 1) K p := finBasisOfFinrankEq K p hpdim
+        let b := extensionBasis p bp bq
+        refine ⟨1 + n, b, fun g ↦ ?_⟩
+        rw [Matrix.isUpperUnitriangular_def]
+        constructor
+        -- The extension basis gives four matrix blocks. The lower-left block vanishes because
+        -- `p` is invariant; the lower-right block is the quotient matrix.
+        · intro i j hji
+          obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
+          obtain ⟨j, rfl⟩ := finSumFinEquiv.surjective j
+          cases i with
+          | inl i =>
+              cases j with
+              | inl j =>
+                  simp only [finSumFinEquiv_apply_left] at hji
+                  have := (Fin.strictMono_castAdd n).lt_iff_lt.mp hji
+                  omega
+              | inr j =>
+                  rw [finSumFinEquiv_apply_left, finSumFinEquiv_apply_right] at hji
+                  change 1 + j.val < i.val at hji
+                  omega
+          | inr i =>
+              cases j with
+              | inl j =>
+                  rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_left,
+                    LinearMap.toMatrixAlgEquiv_apply]
+                  have hmem : rho g (bp j : V) ∈ p := hp g (bp j).2
+                  rw [extensionBasis_castAdd,
+                    extensionBasis_repr_natAdd p bp bq (rho g (bp j : V)) i]
+                  simp only [Submodule.mkQ_apply,
+                    (Submodule.Quotient.mk_eq_zero p).mpr hmem, map_zero,
+                    Finsupp.zero_apply]
+              | inr j =>
+                  rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_right,
+                    LinearMap.toMatrixAlgEquiv_apply, extensionBasis_repr_natAdd]
+                  rw [← q_apply]
+                  rw [Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
+                  simpa only [LinearMap.toMatrixAlgEquiv_apply] using
+                    (hbq g |>.isUpperTriangular
+                      ((Fin.strictMono_natAdd 1).lt_iff_lt.mp hji))
+        · intro i
+          obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
+          cases i with
+          | inl i =>
+              rw [finSumFinEquiv_apply_left, LinearMap.toMatrixAlgEquiv_apply,
+                extensionBasis_castAdd]
+              rw [hp_fixed, extensionBasis_repr_castAdd]
+              simp
+          | inr i =>
+              rw [finSumFinEquiv_apply_right, LinearMap.toMatrixAlgEquiv_apply,
+                extensionBasis_repr_natAdd]
+              rw [← q_apply]
+              rw [Submodule.mkQ_apply, extensionBasis_natAdd_mkQ]
+              simpa only [LinearMap.toMatrixAlgEquiv_apply] using hbq g |>.apply_diag i
+      · let _ : Subsingleton V := not_nontrivial_iff_subsingleton.mp hV
+        have hzero : finrank K V = 0 := Module.finrank_zero_of_subsingleton
+        let b : Basis (Fin 0) K V := finBasisOfFinrankEq K V hzero
+        refine ⟨0, b, fun g ↦ ?_⟩
+        rw [Matrix.isUpperUnitriangular_def]
+        exact ⟨fun i ↦ Fin.elim0 i, fun i ↦ Fin.elim0 i⟩
+
+/-- If a normal subgroup and a second subgroup generate the ambient group and each acts
+unipotently, then the whole group acts unipotently. -/
+theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
+    [FiniteDimensional K V]
+    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
+    (hUW : U ⊔ W = ⊤)
+    (hU : ∀ u : U, IsNilpotent (rho u - 1))
+    (hW : ∀ w : W, IsNilpotent (rho w - 1)) (g : G) :
+    IsNilpotent (rho g - 1) := by
+  obtain ⟨n, b, hb⟩ :=
+    rho.exists_basis_isUpperUnitriangular_of_normal_isUnipotent U W hUW hU hW
+  rw [← IsNilpotent.map_iff (LinearMap.toMatrixAlgEquiv b).injective]
+  simpa only [map_sub, map_one] using (hb g).isNilpotent_sub_one
+
+/-- Every element of the join of a normal unipotent subgroup and a second unipotent subgroup acts
+unipotently.
+
+This is the form used for products of subgroup schemes: normality makes the setwise product a
+subgroup, and the join is that product. -/
+theorem _root_.Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipotent
+    [FiniteDimensional K V]
+    (rho : Representation K G V) (U W : Subgroup G) [U.Normal]
+    (hU : ∀ u : U, IsNilpotent (rho u - 1))
+    (hW : ∀ w : W, IsNilpotent (rho w - 1)) {g : G} (hg : g ∈ U ⊔ W) :
+    IsNilpotent (rho g - 1) := by
+  let J : Subgroup G := U ⊔ W
+  let U' : Subgroup J := U.comap J.subtype
+  let W' : Subgroup J := W.comap J.subtype
+  let rhoJ : Representation K J V := rho.comp J.subtype
+  have hU_le : U ≤ J := le_sup_left
+  have hW_le : W ≤ J := le_sup_right
+  have hU_range : U ≤ J.subtype.range := by simpa only [Subgroup.range_subtype] using hU_le
+  have hW_range : W ≤ J.subtype.range := by simpa only [Subgroup.range_subtype] using hW_le
+  have hsup : U' ⊔ W' = ⊤ := by
+    rw [show U' ⊔ W' = (U ⊔ W).comap J.subtype from
+      Subgroup.comap_sup_eq_of_le_range J.subtype hU_range hW_range]
+    ext x
+    simp only [Subgroup.mem_comap, Subgroup.mem_top, iff_true]
+    exact x.2
+  have hU' (u : U') : IsNilpotent (rhoJ u - 1) := by
+    exact hU ⟨u, u.2⟩
+  have hW' (w : W') : IsNilpotent (rhoJ w - 1) := by
+    exact hW ⟨w, w.2⟩
+  let gJ : J := ⟨g, hg⟩
+  exact rhoJ.isNilpotent_sub_one_of_normal_isUnipotent U' W' hsup hU' hW' gJ
+
+end
+
+end TauCeti.Representation

--- a/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
@@ -26,12 +26,12 @@ of the multiplication image with products of points of the two source subgroups.
 
 ## Main declarations
 
-* `Representation.exists_common_fixed_vector_of_normal_isUnipotent`: two subgroups, one normalized
-  by the other, acting unipotently have a common nonzero fixed vector.
-* `Representation.exists_basis_isUpperUnitriangular_of_normal_isUnipotent`: if they generate the
-  ambient group, it is simultaneously upper unitriangular.
-* `Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipotent`: the corresponding result
-  for an arbitrary join inside a larger group.
+* `Representation.exists_common_fixed_vector_of_le_normalizer_isUnipotent`: two subgroups, one
+  normalized by the other, acting unipotently have a common nonzero fixed vector.
+* `Representation.exists_basis_isUpperUnitriangular_of_le_normalizer_isUnipotent`: if they generate
+  the ambient group, it is simultaneously upper unitriangular.
+* `Representation.isNilpotent_sub_one_of_mem_sup_of_le_normalizer_isUnipotent`: the corresponding
+  result for an arbitrary join inside a larger group.
 
 ## References
 
@@ -94,7 +94,7 @@ private theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUni
 /-- **Common fixed vector for two unipotent subgroups, one normalized by the other.**
 If `W` normalizes `U` and both subgroups act unipotently in a nonzero finite-dimensional
 representation, they fix a common nonzero vector. -/
-theorem _root_.Representation.exists_common_fixed_vector_of_normal_isUnipotent
+theorem _root_.Representation.exists_common_fixed_vector_of_le_normalizer_isUnipotent
     [FiniteDimensional K V] [Nontrivial V]
     (rho : Representation K G V) (U W : Subgroup G)
     (hWU : W ≤ Subgroup.normalizer (U : Set G))
@@ -131,7 +131,7 @@ private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
       by_cases hV : Nontrivial V
       · let _ : Nontrivial V := hV
         obtain ⟨x, hx, hxU, hxW⟩ :=
-          rho.exists_common_fixed_vector_of_normal_isUnipotent U W hWU hU hW
+          rho.exists_common_fixed_vector_of_le_normalizer_isUnipotent U W hWU hU hW
         have hfixed (z : G) : rho z x = x := by
           have hz : z ∈ U ⊔ W := by rw [hUW]; exact Subgroup.mem_top z
           obtain ⟨u, hu, w, hw, rfl⟩ :=
@@ -197,7 +197,7 @@ simultaneously upper unitriangular.
 The generation hypothesis is the natural form used for a product subgroup: after restricting an
 ambient representation to `U ⊔ W`, the images of `U` and `W` generate the whole restricted group.
 -/
-theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_normal_isUnipotent
+theorem _root_.Representation.exists_basis_isUpperUnitriangular_of_le_normalizer_isUnipotent
     [FiniteDimensional K V]
     (rho : Representation K G V) (U W : Subgroup G)
     (hWU : W ≤ Subgroup.normalizer (U : Set G))
@@ -214,7 +214,7 @@ unipotently.
 
 This is the form used for products of subgroup schemes: normalization makes the setwise product a
 subgroup, and that product is the join. -/
-theorem _root_.Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipotent
+theorem _root_.Representation.isNilpotent_sub_one_of_mem_sup_of_le_normalizer_isUnipotent
     [FiniteDimensional K V]
     (rho : Representation K G V) (U W : Subgroup G)
     (hWU : W ≤ Subgroup.normalizer (U : Set G))

--- a/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
+++ b/TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean
@@ -149,17 +149,19 @@ private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
           rw [hp_fixed z ⟨y, hy⟩]
           exact hy
         let q : Representation K G (V ⧸ p) := rho.quotient p hp
+        have quotient_sub_one_eq_mapQ (z : G)
+            (hsub : p ≤ p.comap (rho z - 1)) :
+            q z - 1 = p.mapQ p (rho z - 1) hsub := by
+          ext y
+          simp only [Representation.quotient_apply, LinearMap.coe_comp, Function.comp_apply,
+            Submodule.mkQ_apply, LinearMap.sub_apply, Submodule.mapQ_apply, End.one_apply,
+            Submodule.Quotient.mk_sub, q]
         have hq (z : G) (hz : IsNilpotent (rho z - 1)) : IsNilpotent (q z - 1) := by
           have hsub : p ≤ p.comap (rho z - 1) := by
             intro y hy
             rw [Submodule.mem_comap]
             simpa only [LinearMap.sub_apply, Module.End.one_apply] using p.sub_mem (hp z hy) hy
-          have heq : q z - 1 = p.mapQ p (rho z - 1) hsub := by
-            ext y
-            simp only [Representation.quotient_apply, LinearMap.coe_comp, Function.comp_apply,
-              Submodule.mkQ_apply, LinearMap.sub_apply, Submodule.mapQ_apply, End.one_apply,
-              Submodule.Quotient.mk_sub, q]
-          rw [heq]
+          rw [quotient_sub_one_eq_mapQ z hsub]
           exact Module.End.IsNilpotent.mapQ hsub hz
         have hqdim : finrank K (V ⧸ p) < d := by
           have hsum := Module.finrank_quotient_add_finrank_le p
@@ -167,17 +169,12 @@ private theorem _root_.Representation.isNilpotent_sub_one_of_normal_isUnipotent
           omega
         obtain ⟨n, hn⟩ := ih (finrank K (V ⧸ p)) hqdim q
           (fun u ↦ hq u (hU u)) (fun w ↦ hq w (hW w)) rfl
-        let f : Module.End K V := rho g - 1
-        have hsub : p ≤ p.comap f := by
+        have hsub : p ≤ p.comap (rho g - 1) := by
           intro y hy
           rw [Submodule.mem_comap]
-          simpa only [f, LinearMap.sub_apply, Module.End.one_apply] using p.sub_mem (hp g hy) hy
-        have heq : q g - 1 = p.mapQ p f hsub := by
-          ext y
-          simp only [Representation.quotient_apply, LinearMap.coe_comp, Function.comp_apply,
-            Submodule.mkQ_apply, LinearMap.sub_apply, Submodule.mapQ_apply, End.one_apply,
-            Submodule.Quotient.mk_sub, q, f]
-        rw [heq] at hn
+          simpa only [LinearMap.sub_apply, Module.End.one_apply] using p.sub_mem (hp g hy) hy
+        rw [quotient_sub_one_eq_mapQ g hsub] at hn
+        let f : Module.End K V := rho g - 1
         refine ⟨n + 1, ?_⟩
         ext y
         rw [pow_succ', Module.End.mul_apply]


### PR DESCRIPTION
This PR proves that the join of a normal subgroup and a second subgroup acting unipotently in a finite-dimensional representation again acts unipotently. It advances the exact `ReductiveGroups/README.md` Layer 5 milestone “The unipotent radical `R_u(G)`,” specifically the binary-product step needed to show that the product of two connected normal smooth unipotent closed subgroup schemes is unipotent.

The dependency edge is: the maximal-dimensional candidate from open PR #4073 must contain every other candidate; that argument consumes closure of candidates under binary products; after the in-flight internal semidirect-product construction #4032 supplies the multiplication morphism and open PR #4062 supplies smoothness of its affine image, the remaining representation-theoretic assertion is that the point subgroup generated by the two normal unipotent point subgroups is itself unipotent. This PR supplies that assertion. After this PR, the milestone still needs the semidirect-product multiplication assembled on schemes, the faithfully-flat/geometric-point bridge identifying points of its scheme-theoretic image with products of source points, and the final maximality argument bundling `R_u(G)`.

The core theorem `Representation.exists_common_fixed_vector_of_normal_isUnipotent` applies the existing Kolchin theorem first to the normal subgroup, observes that its common fixed space is invariant under the ambient group, and applies Kolchin again to the second subgroup on that space. Iterating this construction on quotients gives `Representation.exists_basis_isUpperUnitriangular_of_normal_isUnipotent`; the generated group is simultaneously upper unitriangular, so `Representation.isNilpotent_sub_one_of_normal_isUnipotent` makes every one of its operators unipotent. `Representation.isNilpotent_sub_one_of_mem_sup_of_normal_isUnipotent` restricts this result to an arbitrary join inside a larger group. Only the first subgroup is assumed normal, which is the natural generality and is stronger than the intended application where both are normal.

Add `TauCeti/RepresentationTheory/Unipotent/NormalJoin.lean` (300 lines). The proof reuses `Representation.exists_common_fixed_vector_of_isUnipotent`, the existing extension-basis construction, Mathlib's quotient representation and nilpotence-on-quotients API, and `Matrix.IsUpperUnitriangular.isNilpotent_sub_one`; no Mathlib implementation or external formalization is vendored. The mathematical organization follows Borel, *Linear Algebraic Groups*, Theorem 4.8 and Proposition 14.4, and Springer, *Linear Algebraic Groups*, Proposition 2.4.12, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"normal-join-unipotent-representations"}-->

🤖 Prepared with Codex
