### PR TITLE
feat: the place of a height one prime of an affine model

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
@@ -20,7 +20,9 @@ file proves the forward direction of the places ↔ height one primes correspond
 the normalized `𝔭`-adic valuation. The prime in question is the centre `{r : R | ord_P r > 0}` of
 the place on `R`, so the valuation ring of the place is the localization of `R` there. The converse
 — that every height one prime of `R` arises this way, which upgrades this injection into a
-bijection — is not proved here; it belongs to the module constructing a place from a prime.
+bijection — is not proved here; it is proved in
+`TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean`, which constructs the place of a
+prime.
 
 This is the "places → height one primes" half of the affine-model dictionary that reduces divisor
 theory on the finite chart of a model to Mathlib's factorization calculus for fractional ideals.
@@ -40,6 +42,9 @@ integrally closed, then swallows everything integral over `k[x]`.
 * `TauCeti.Place.existsUnique_valuation_eq`: the uniqueness statement, and
   `TauCeti.Place.valuationSubringAtPrime_eq_integers`: the valuation ring of the place is the
   localization of the model at the centre.
+* `TauCeti.Place.ord_algebraMap_eq_multiplicity_center`: the coefficient formula
+  `ord_P r = mult_(centre) (r)`, which reads an order at the place off the factorization of an
+  ideal of the model.
 
 ## References
 
@@ -127,6 +132,17 @@ theorem mem_center_asIdeal_iff_ord_pos {r : R} (hr : r ≠ 0) :
   rw [mem_center_asIdeal, P.valuation_eq_exp_neg_ord hr', ← WithZero.exp_zero (M := ℤ),
     WithZero.exp_lt_exp]
   omega
+
+/-- **The coefficient formula at a place finite on an affine model**: the order at `P` of a
+nonzero element of the model is the multiplicity of the centre of `P` in the ideal it generates.
+This is what turns a divisor supported on the finite chart of a model into a factorization of
+ideals. The hypothesis `r ≠ 0` guards the junk values `ord_P 0 = 0` and `mult_𝔭 ⊥ = 1`. -/
+theorem ord_algebraMap_eq_multiplicity_center {r : R} (hr : r ≠ 0) :
+    P.ord (algebraMap R F r) = multiplicity (P.center hR).asIdeal (Ideal.span {r}) := by
+  have hr' : algebraMap R F r ≠ 0 := (map_ne_zero_iff _ (IsFractionRing.injective R F)).mpr hr
+  rw [P.ord_eq_iff_valuation_eq_exp_neg hr', ← P.valuation_center hR,
+    HeightOneSpectrum.valuation_of_algebraMap,
+    HeightOneSpectrum.intValuation_eq_exp_neg_multiplicity _ hr]
 
 /-- A height one prime whose adic valuation is that of `P` is the centre of `P`. -/
 theorem eq_center {𝔭 : HeightOneSpectrum R} (h : 𝔭.valuation F = P.valuation) :

--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean
@@ -1,0 +1,277 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
+public import Mathlib.RingTheory.Ideal.Quotient.Operations
+public import TauCeti.FieldTheory.FunctionField.AffineModel.Place
+
+/-!
+# Affine models: the place of a height one prime, and the two-way correspondence
+
+An *affine model* of `F / k` is a Dedekind `k`-subalgebra `R` of `F` whose fraction field is `F`.
+`TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean` sends a place of `F / k` that is finite
+on `R` to a height one prime of `R`, its centre. This file supplies the other direction: the
+normalized `𝔭`-adic valuation of `F` attached to a height one prime `𝔭` of `R` is trivial on the
+constants — every nonzero constant is a unit of `R`, hence lies outside `𝔭` — so it *is* a place
+of `F / k`. The two constructions are mutually inverse, which packages the correspondence as a
+bijection
+
+`{P : Place k F | R ⊆ 𝒪_P} ≃ HeightOneSpectrum R`.
+
+The correspondence is then made quantitative. On `R` the order function of the place of `𝔭` is
+the multiplicity of `𝔭` in a principal ideal, so divisor coefficients on the finite chart are read
+off from Mathlib's factorization calculus; and the residue field of the place of `𝔭` is `R ⧸ 𝔭`,
+so the degree of the place is the residue degree `[R ⧸ 𝔭 : k]` of the prime. Together these say
+that divisor theory on the finite chart of a model is exactly the ideal theory of the model.
+
+## Main definitions
+
+* `TauCeti.Place.ofPrime`: the place of `F / k` attached to a height one prime of an affine
+  model.
+* `TauCeti.Place.residueHomOfPrime`: evaluation of the elements of the model at that place, a
+  `k`-algebra map `R → F_P` with kernel `𝔭` (`TauCeti.Place.ker_residueHomOfPrime`).
+* `TauCeti.Place.heightOneSpectrumEquiv`: the bijection between the places finite on a model and
+  the height one primes of the model.
+
+## Main results
+
+* `TauCeti.Place.center_ofPrime` and `TauCeti.Place.ofPrime_center`: the two constructions are
+  mutually inverse, and `TauCeti.Place.exists_eq_ofPrime_iff` identifies the places in the image
+  as exactly the places finite on the model.
+* `TauCeti.Place.ord_ofPrime_algebraMap`: the coefficient formula `ord_P r = mult_𝔭 (r)`.
+* `TauCeti.Place.residueFieldAlgEquivOfPrime`: the residue field of the place of `𝔭` is `R ⧸ 𝔭`,
+  whence `TauCeti.Place.degree_ofPrime`: `deg P = [R ⧸ 𝔭 : k]`.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Sections I.1 and III.2.
+-/
+
+public section
+
+open IsDedekindDomain
+
+namespace TauCeti
+
+namespace Place
+
+universe u v w
+
+variable {k : Type u} {F : Type v} [Field k] [Field F] [Algebra k F]
+  {R : Type w} [CommRing R] [IsDedekindDomain R] [Algebra k R] [Algebra R F]
+  [IsScalarTower k R F] [IsFractionRing R F]
+
+section OfPrime
+
+variable (k F)
+
+/-- **The place of `F / k` attached to a height one prime `𝔭` of an affine model `R`**: its
+valuation is Mathlib's normalized `𝔭`-adic valuation of `F`. Triviality on the constants is the
+only thing to check, and it holds because a nonzero constant is a unit of `R` and therefore
+avoids `𝔭`. -/
+noncomputable def ofPrime (𝔭 : HeightOneSpectrum R) : Place k F where
+  valuation := 𝔭.valuation F
+  valuation_surjective := 𝔭.valuation_surjective F
+  isTrivialOn := ⟨fun c hc ↦ by
+    rw [IsScalarTower.algebraMap_apply k R F, HeightOneSpectrum.valuation_eq_one_iff_notMem]
+    exact fun h ↦ 𝔭.isPrime.ne_top (Ideal.eq_top_of_isUnit_mem _ h
+      (isUnit_iff_exists_inv.mpr ⟨algebraMap k R c⁻¹, by
+        rw [← map_mul, mul_inv_cancel₀ hc, map_one]⟩))⟩
+
+variable (𝔭 : HeightOneSpectrum R)
+
+@[simp]
+theorem valuation_ofPrime : (ofPrime k F 𝔭).valuation = 𝔭.valuation F := (rfl)
+
+/-- An affine model is contained in the valuation ring of the place of each of its height one
+primes: the place of `𝔭` is finite on `R`. -/
+theorem algebraMap_mem_integers_ofPrime (r : R) :
+    algebraMap R F r ∈ (ofPrime k F 𝔭).integers :=
+  (ofPrime k F 𝔭).mem_integers_iff.mpr (by rw [valuation_ofPrime]; exact 𝔭.valuation_le_one r)
+
+/-- The valuation of the place of `𝔭` extends the `𝔭`-adic valuation of the model. -/
+theorem valuation_ofPrime_algebraMap (r : R) :
+    (ofPrime k F 𝔭).valuation (algebraMap R F r) = 𝔭.intValuation r := by
+  rw [valuation_ofPrime, HeightOneSpectrum.valuation_of_algebraMap]
+
+/-- The elements of the model with a zero at the place of `𝔭` are exactly the elements of `𝔭`. -/
+theorem valuation_ofPrime_algebraMap_lt_one_iff {r : R} :
+    (ofPrime k F 𝔭).valuation (algebraMap R F r) < 1 ↔ r ∈ 𝔭.asIdeal := by
+  rw [valuation_ofPrime, HeightOneSpectrum.valuation_lt_one_iff_mem]
+
+/-- **The coefficient formula on the finite chart**: the order at the place of `𝔭` of an element
+of the model is the multiplicity of `𝔭` in the ideal it generates. This is what turns a divisor
+supported on the finite chart into a factorization of ideals. -/
+theorem ord_ofPrime_algebraMap {r : R} (hr : r ≠ 0) :
+    (ofPrime k F 𝔭).ord (algebraMap R F r) = multiplicity 𝔭.asIdeal (Ideal.span {r}) := by
+  have hr' : algebraMap R F r ≠ 0 := (map_ne_zero_iff _ (IsFractionRing.injective R F)).mpr hr
+  rw [(ofPrime k F 𝔭).ord_eq_iff_valuation_eq_exp_neg hr', valuation_ofPrime_algebraMap,
+    HeightOneSpectrum.intValuation_eq_exp_neg_multiplicity 𝔭 hr]
+
+end OfPrime
+
+section Correspondence
+
+variable (k F)
+
+/-- The centre on `R` of the place of a height one prime `𝔭` of `R` is `𝔭` itself. -/
+@[simp]
+theorem center_ofPrime (𝔭 : HeightOneSpectrum R) :
+    (ofPrime k F 𝔭).center (algebraMap_mem_integers_ofPrime k F 𝔭) = 𝔭 :=
+  ((ofPrime k F 𝔭).eq_center _ (valuation_ofPrime k F 𝔭).symm).symm
+
+/-- The place of the centre on `R` of a place finite on `R` is that place. -/
+@[simp]
+theorem ofPrime_center (P : Place k F) (hR : ∀ r : R, algebraMap R F r ∈ P.integers) :
+    ofPrime k F (P.center hR) = P :=
+  Place.ext (by rw [valuation_ofPrime, P.valuation_center hR])
+
+/-- The valuation ring of the place of `𝔭` is the localization of the model at `𝔭`. -/
+theorem valuationSubringAtPrime_eq_integers_ofPrime (𝔭 : HeightOneSpectrum R) :
+    HeightOneSpectrum.valuationSubringAtPrime F 𝔭 = (ofPrime k F 𝔭).integers := by
+  have h := (ofPrime k F 𝔭).valuationSubringAtPrime_eq_integers
+    (algebraMap_mem_integers_ofPrime k F 𝔭)
+  rwa [center_ofPrime] at h
+
+variable (R) in
+/-- **The places of `F / k` finite on an affine model `R` are exactly the height one primes of
+`R`** (Stichtenoth, Section III.2): the centre of a place and the adic place of a prime are
+mutually inverse bijections. -/
+noncomputable def heightOneSpectrumEquiv :
+    {P : Place k F // ∀ r : R, algebraMap R F r ∈ P.integers} ≃ HeightOneSpectrum R where
+  toFun P := P.1.center P.2
+  invFun 𝔭 := ⟨ofPrime k F 𝔭, algebraMap_mem_integers_ofPrime k F 𝔭⟩
+  left_inv P := Subtype.ext (ofPrime_center k F P.1 P.2)
+  right_inv 𝔭 := center_ofPrime k F 𝔭
+
+@[simp]
+theorem heightOneSpectrumEquiv_apply
+    (P : {P : Place k F // ∀ r : R, algebraMap R F r ∈ P.integers}) :
+    heightOneSpectrumEquiv k F R P = P.1.center P.2 := (rfl)
+
+@[simp]
+theorem heightOneSpectrumEquiv_symm_apply (𝔭 : HeightOneSpectrum R) :
+    ((heightOneSpectrumEquiv k F R).symm 𝔭).1 = ofPrime k F 𝔭 := (rfl)
+
+/-- Distinct height one primes of a model give distinct places. -/
+theorem ofPrime_injective : Function.Injective (ofPrime (R := R) k F) := fun 𝔭 𝔮 h ↦
+  HeightOneSpectrum.eq_of_valuation_isEquiv_valuation (K := F)
+    (by rw [← valuation_ofPrime k F 𝔭, ← valuation_ofPrime k F 𝔮, h])
+
+/-- **A place of `F / k` is the place of a height one prime of an affine model `R` exactly when
+it is finite on `R`**: the image of `TauCeti.Place.ofPrime` is the finite chart of the model. -/
+theorem exists_eq_ofPrime_iff (P : Place k F) :
+    (∃ 𝔭 : HeightOneSpectrum R, ofPrime k F 𝔭 = P) ↔ ∀ r : R, algebraMap R F r ∈ P.integers :=
+  ⟨fun ⟨𝔭, h⟩ r ↦ h ▸ algebraMap_mem_integers_ofPrime k F 𝔭 r,
+    fun hR ↦ ⟨P.center hR, ofPrime_center k F P hR⟩⟩
+
+end Correspondence
+
+section ResidueField
+
+variable (k F) (𝔭 : HeightOneSpectrum R)
+
+/-- The elements of an affine model, viewed inside the valuation ring of the place of one of its
+height one primes. -/
+noncomputable def toIntegersOfPrime : R →+* (ofPrime k F 𝔭).integers :=
+  (algebraMap R F).codRestrict _ (algebraMap_mem_integers_ofPrime k F 𝔭)
+
+@[simp]
+theorem coe_toIntegersOfPrime (r : R) :
+    (toIntegersOfPrime k F 𝔭 r : F) = algebraMap R F r := (rfl)
+
+/-- **Evaluation of the elements of an affine model at the place of one of its height one
+primes**, as a map of `k`-algebras `R → F_P`. It is surjective with kernel `𝔭`, which is the
+content of `TauCeti.Place.residueFieldAlgEquivOfPrime`. -/
+noncomputable def residueHomOfPrime : R →ₐ[k] (ofPrime k F 𝔭).ResidueField :=
+  { (IsLocalRing.residue (ofPrime k F 𝔭).integers).comp (toIntegersOfPrime k F 𝔭) with
+    commutes' := fun c ↦ by
+      rw [IsScalarTower.algebraMap_apply k (ofPrime k F 𝔭).integers (ofPrime k F 𝔭).ResidueField,
+        IsLocalRing.ResidueField.algebraMap_eq]
+      exact congrArg (IsLocalRing.residue _)
+        (Subtype.ext (IsScalarTower.algebraMap_apply k R F c).symm) }
+
+theorem residueHomOfPrime_apply (r : R) : residueHomOfPrime k F 𝔭 r =
+    IsLocalRing.residue (ofPrime k F 𝔭).integers (toIntegersOfPrime k F 𝔭 r) := (rfl)
+
+/-- **The elements of the model that vanish at the place of `𝔭` are exactly the elements of
+`𝔭`.** -/
+theorem ker_residueHomOfPrime : RingHom.ker (residueHomOfPrime k F 𝔭) = 𝔭.asIdeal := by
+  ext r
+  rw [RingHom.mem_ker, residueHomOfPrime_apply,
+    (ofPrime k F 𝔭).residue_eq_zero_iff_valuation_lt_one, coe_toIntegersOfPrime,
+    valuation_ofPrime_algebraMap_lt_one_iff]
+
+/-- **Every residue at the place of `𝔭` is the residue of an element of the model.** A function
+integral at the place is a fraction `n / d` of elements of the model with `d ∉ 𝔭`; inverting `d`
+in the field `R ⧸ 𝔭` produces an element of `R` with the same residue. -/
+theorem residueHomOfPrime_surjective : Function.Surjective (residueHomOfPrime k F 𝔭) := by
+  intro y
+  obtain ⟨a, rfl⟩ := IsLocalRing.residue_surjective y
+  obtain ⟨n, d, hnd⟩ := HeightOneSpectrum.exists_primeCompl_mul_eq_of_integer 𝔭 (a : F)
+    (by rw [← valuation_ofPrime k F 𝔭]; exact (ofPrime k F 𝔭).mem_integers_iff.mp a.2)
+  obtain ⟨c, hmem⟩ : ∃ c : R, n - (d : R) * c ∈ 𝔭.asIdeal := by
+    obtain ⟨y, i, hi, hyd⟩ := 𝔭.isMaximal.exists_inv d.2
+    refine ⟨y * n, ?_⟩
+    have h : n - (d : R) * (y * n) = i * n := by linear_combination (-n) * hyd
+    exact h ▸ Ideal.mul_mem_right n _ hi
+  refine ⟨c, ?_⟩
+  have hcoe : ((a - toIntegersOfPrime k F 𝔭 c : (ofPrime k F 𝔭).integers) : F)
+      = (a : F) - algebraMap R F c := by
+    push_cast
+    rw [coe_toIntegersOfPrime]
+  have hdval : (ofPrime k F 𝔭).valuation (algebraMap R F (d : R)) = 1 := by
+    rw [valuation_ofPrime, HeightOneSpectrum.valuation_eq_one_iff_notMem]
+    exact d.2
+  have hprod : ((a : F) - algebraMap R F c) * algebraMap R F (d : R)
+      = algebraMap R F (n - (d : R) * c) := by
+    rw [map_sub, map_mul, sub_mul, hnd]
+    ring
+  have hzero : IsLocalRing.residue (ofPrime k F 𝔭).integers
+      (a - toIntegersOfPrime k F 𝔭 c) = 0 := by
+    rw [(ofPrime k F 𝔭).residue_eq_zero_iff_valuation_lt_one]
+    calc (ofPrime k F 𝔭).valuation ((a - toIntegersOfPrime k F 𝔭 c : (ofPrime k F 𝔭).integers) : F)
+        = (ofPrime k F 𝔭).valuation ((a : F) - algebraMap R F c) *
+            (ofPrime k F 𝔭).valuation (algebraMap R F (d : R)) := by rw [hcoe, hdval, mul_one]
+      _ = (ofPrime k F 𝔭).valuation (algebraMap R F (n - (d : R) * c)) := by
+            rw [← map_mul, hprod]
+      _ < 1 := (valuation_ofPrime_algebraMap_lt_one_iff k F 𝔭).mpr hmem
+  rw [residueHomOfPrime_apply]
+  exact (sub_eq_zero.mp (by rwa [map_sub] at hzero)).symm
+
+/-- **The residue field of the place of a height one prime `𝔭` of an affine model is `R ⧸ 𝔭`**,
+as `k`-algebras. -/
+noncomputable def residueFieldAlgEquivOfPrime :
+    (R ⧸ 𝔭.asIdeal) ≃ₐ[k] (ofPrime k F 𝔭).ResidueField :=
+  (Ideal.quotientEquivAlgOfEq k (ker_residueHomOfPrime k F 𝔭).symm).trans
+    (Ideal.quotientKerAlgEquivOfSurjective (residueHomOfPrime_surjective k F 𝔭))
+
+@[simp]
+theorem residueFieldAlgEquivOfPrime_mk (r : R) :
+    residueFieldAlgEquivOfPrime k F 𝔭 (Ideal.Quotient.mk 𝔭.asIdeal r)
+      = residueHomOfPrime k F 𝔭 r := (rfl)
+
+/-- **The degree of the place of `𝔭` is the residue degree of `𝔭`**: the weight a divisor
+attaches to a place of the finite chart is the one Mathlib's ideal theory attaches to the
+corresponding prime. -/
+theorem degree_ofPrime : (ofPrime k F 𝔭).degree = Module.finrank k (R ⧸ 𝔭.asIdeal) := by
+  rw [(ofPrime k F 𝔭).degree_eq_finrank]
+  exact ((residueFieldAlgEquivOfPrime k F 𝔭).toLinearEquiv.finrank_eq).symm
+
+/-- The degree of a place finite on an affine model is the residue degree of its centre. -/
+theorem degree_eq_finrank_quotient_center (P : Place k F)
+    (hR : ∀ r : R, algebraMap R F r ∈ P.integers) :
+    P.degree = Module.finrank k (R ⧸ (P.center hR).asIdeal) := by
+  conv_lhs => rw [← ofPrime_center k F P hR]
+  exact degree_ofPrime k F (P.center hR)
+
+end ResidueField
+
+end Place
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean
@@ -42,9 +42,11 @@ that divisor theory on the finite chart of a model is exactly the ideal theory o
 * `TauCeti.Place.center_ofPrime` and `TauCeti.Place.ofPrime_center`: the two constructions are
   mutually inverse, and `TauCeti.Place.exists_eq_ofPrime_iff` identifies the places in the image
   as exactly the places finite on the model.
-* `TauCeti.Place.ord_ofPrime_algebraMap`: the coefficient formula `ord_P r = mult_𝔭 (r)`.
-* `TauCeti.Place.residueFieldAlgEquivOfPrime`: the residue field of the place of `𝔭` is `R ⧸ 𝔭`,
-  whence `TauCeti.Place.degree_ofPrime`: `deg P = [R ⧸ 𝔭 : k]`.
+* `TauCeti.Place.ord_ofPrime_algebraMap`: the coefficient formula `ord_P r = mult_𝔭 (r)`, for
+  `r ≠ 0`; `TauCeti.Place.ord_algebraMap_eq_multiplicity_center` is the same formula read off the
+  centre of a place finite on the model.
+* `TauCeti.Place.quotientAlgEquivResidueFieldOfPrime`: the residue field of the place of `𝔭` is
+  `R ⧸ 𝔭`, whence `TauCeti.Place.degree_ofPrime`: `deg P = [R ⧸ 𝔭 : k]`.
 
 ## References
 
@@ -79,9 +81,7 @@ noncomputable def ofPrime (𝔭 : HeightOneSpectrum R) : Place k F where
   valuation_surjective := 𝔭.valuation_surjective F
   isTrivialOn := ⟨fun c hc ↦ by
     rw [IsScalarTower.algebraMap_apply k R F, HeightOneSpectrum.valuation_eq_one_iff_notMem]
-    exact fun h ↦ 𝔭.isPrime.ne_top (Ideal.eq_top_of_isUnit_mem _ h
-      (isUnit_iff_exists_inv.mpr ⟨algebraMap k R c⁻¹, by
-        rw [← map_mul, mul_inv_cancel₀ hc, map_one]⟩))⟩
+    exact Ideal.notMem_of_isUnit _ ((isUnit_iff_ne_zero.mpr hc).map (algebraMap k R))⟩
 
 variable (𝔭 : HeightOneSpectrum R)
 
@@ -104,9 +104,10 @@ theorem valuation_ofPrime_algebraMap_lt_one_iff {r : R} :
     (ofPrime k F 𝔭).valuation (algebraMap R F r) < 1 ↔ r ∈ 𝔭.asIdeal := by
   rw [valuation_ofPrime, HeightOneSpectrum.valuation_lt_one_iff_mem]
 
-/-- **The coefficient formula on the finite chart**: the order at the place of `𝔭` of an element
-of the model is the multiplicity of `𝔭` in the ideal it generates. This is what turns a divisor
-supported on the finite chart into a factorization of ideals. -/
+/-- **The coefficient formula on the finite chart**: the order at the place of `𝔭` of a nonzero
+element of the model is the multiplicity of `𝔭` in the ideal it generates. This is what turns a
+divisor supported on the finite chart into a factorization of ideals. The hypothesis `r ≠ 0`
+guards the junk values `ord_P 0 = 0` and `multiplicity 𝔭 ⊥ = 1`. -/
 theorem ord_ofPrime_algebraMap {r : R} (hr : r ≠ 0) :
     (ofPrime k F 𝔭).ord (algebraMap R F r) = multiplicity 𝔭.asIdeal (Ideal.span {r}) := by
   have hr' : algebraMap R F r ≠ 0 := (map_ne_zero_iff _ (IsFractionRing.injective R F)).mpr hr
@@ -134,9 +135,8 @@ theorem ofPrime_center (P : Place k F) (hR : ∀ r : R, algebraMap R F r ∈ P.i
 /-- The valuation ring of the place of `𝔭` is the localization of the model at `𝔭`. -/
 theorem valuationSubringAtPrime_eq_integers_ofPrime (𝔭 : HeightOneSpectrum R) :
     HeightOneSpectrum.valuationSubringAtPrime F 𝔭 = (ofPrime k F 𝔭).integers := by
-  have h := (ofPrime k F 𝔭).valuationSubringAtPrime_eq_integers
-    (algebraMap_mem_integers_ofPrime k F 𝔭)
-  rwa [center_ofPrime] at h
+  rw [HeightOneSpectrum.valuationSubringAtPrime_eq_valuationSubring, ← valuation_ofPrime k F 𝔭]
+  exact SetLike.ext fun _ ↦ (ofPrime k F 𝔭).mem_integers_iff.symm
 
 variable (R) in
 /-- **The places of `F / k` finite on an affine model `R` are exactly the height one primes of
@@ -155,7 +155,7 @@ theorem heightOneSpectrumEquiv_apply
     heightOneSpectrumEquiv k F R P = P.1.center P.2 := (rfl)
 
 @[simp]
-theorem heightOneSpectrumEquiv_symm_apply (𝔭 : HeightOneSpectrum R) :
+theorem coe_heightOneSpectrumEquiv_symm_apply (𝔭 : HeightOneSpectrum R) :
     ((heightOneSpectrumEquiv k F R).symm 𝔭).1 = ofPrime k F 𝔭 := (rfl)
 
 /-- Distinct height one primes of a model give distinct places. -/
@@ -170,26 +170,41 @@ theorem exists_eq_ofPrime_iff (P : Place k F) :
   ⟨fun ⟨𝔭, h⟩ r ↦ h ▸ algebraMap_mem_integers_ofPrime k F 𝔭 r,
     fun hR ↦ ⟨P.center hR, ofPrime_center k F P hR⟩⟩
 
+/-- **The coefficient formula at a place finite on an affine model**: the order at `P` of a
+nonzero element of the model is the multiplicity of the centre of `P` in the ideal it generates.
+This is `TauCeti.Place.ord_ofPrime_algebraMap` in the form in which
+`TauCeti.Place.exists_eq_ofPrime_iff` hands a place of the finite chart over. -/
+theorem ord_algebraMap_eq_multiplicity_center (P : Place k F)
+    (hR : ∀ r : R, algebraMap R F r ∈ P.integers) {r : R} (hr : r ≠ 0) :
+    P.ord (algebraMap R F r) = multiplicity (P.center hR).asIdeal (Ideal.span {r}) := by
+  conv_lhs => rw [← ofPrime_center k F P hR]
+  exact ord_ofPrime_algebraMap k F (P.center hR) hr
+
 end Correspondence
 
 section ResidueField
 
 variable (k F) (𝔭 : HeightOneSpectrum R)
 
-/-- The elements of an affine model, viewed inside the valuation ring of the place of one of its
-height one primes. -/
-noncomputable def toIntegersOfPrime : R →+* (ofPrime k F 𝔭).integers :=
-  (algebraMap R F).codRestrict _ (algebraMap_mem_integers_ofPrime k F 𝔭)
+/-- An affine model lies in the valuation ring of the place of each of its height one primes, so
+that valuation ring is an `R`-algebra. -/
+noncomputable instance : Algebra R (ofPrime k F 𝔭).integers :=
+  ((algebraMap R F).codRestrict _ (algebraMap_mem_integers_ofPrime k F 𝔭)).toAlgebra
+
+/-- The `R`-algebra structure on the valuation ring of the place of `𝔭` is the one induced by
+the inclusion of the model in `F`. -/
+instance : IsScalarTower R (ofPrime k F 𝔭).integers F := .of_algebraMap_eq fun _ ↦ rfl
 
 @[simp]
-theorem coe_toIntegersOfPrime (r : R) :
-    (toIntegersOfPrime k F 𝔭 r : F) = algebraMap R F r := (rfl)
+theorem coe_algebraMap_integers_ofPrime (r : R) :
+    (algebraMap R (ofPrime k F 𝔭).integers r : F) = algebraMap R F r := (rfl)
 
 /-- **Evaluation of the elements of an affine model at the place of one of its height one
 primes**, as a map of `k`-algebras `R → F_P`. It is surjective with kernel `𝔭`, which is the
-content of `TauCeti.Place.residueFieldAlgEquivOfPrime`. -/
+content of `TauCeti.Place.quotientAlgEquivResidueFieldOfPrime`. -/
 noncomputable def residueHomOfPrime : R →ₐ[k] (ofPrime k F 𝔭).ResidueField :=
-  { (IsLocalRing.residue (ofPrime k F 𝔭).integers).comp (toIntegersOfPrime k F 𝔭) with
+  { (IsLocalRing.residue (ofPrime k F 𝔭).integers).comp
+      (algebraMap R (ofPrime k F 𝔭).integers) with
     commutes' := fun c ↦ by
       rw [IsScalarTower.algebraMap_apply k (ofPrime k F 𝔭).integers (ofPrime k F 𝔭).ResidueField,
         IsLocalRing.ResidueField.algebraMap_eq]
@@ -197,63 +212,44 @@ noncomputable def residueHomOfPrime : R →ₐ[k] (ofPrime k F 𝔭).ResidueFiel
         (Subtype.ext (IsScalarTower.algebraMap_apply k R F c).symm) }
 
 theorem residueHomOfPrime_apply (r : R) : residueHomOfPrime k F 𝔭 r =
-    IsLocalRing.residue (ofPrime k F 𝔭).integers (toIntegersOfPrime k F 𝔭 r) := (rfl)
+    IsLocalRing.residue (ofPrime k F 𝔭).integers (algebraMap R (ofPrime k F 𝔭).integers r) :=
+  (rfl)
 
 /-- **The elements of the model that vanish at the place of `𝔭` are exactly the elements of
 `𝔭`.** -/
+@[simp]
 theorem ker_residueHomOfPrime : RingHom.ker (residueHomOfPrime k F 𝔭) = 𝔭.asIdeal := by
   ext r
   rw [RingHom.mem_ker, residueHomOfPrime_apply,
-    (ofPrime k F 𝔭).residue_eq_zero_iff_valuation_lt_one, coe_toIntegersOfPrime,
+    (ofPrime k F 𝔭).residue_eq_zero_iff_valuation_lt_one, coe_algebraMap_integers_ofPrime,
     valuation_ofPrime_algebraMap_lt_one_iff]
 
-/-- **Every residue at the place of `𝔭` is the residue of an element of the model.** A function
-integral at the place is a fraction `n / d` of elements of the model with `d ∉ 𝔭`; inverting `d`
-in the field `R ⧸ 𝔭` produces an element of `R` with the same residue. -/
+/-- **Every residue at the place of `𝔭` is the residue of an element of the model.** This is
+Mathlib's approximation theorem for the `𝔭`-adic valuation, at the accuracy `1`: a function
+integral at the place is within `1` of an element of the model, so the two have the same
+residue. -/
 theorem residueHomOfPrime_surjective : Function.Surjective (residueHomOfPrime k F 𝔭) := by
   intro y
   obtain ⟨a, rfl⟩ := IsLocalRing.residue_surjective y
-  obtain ⟨n, d, hnd⟩ := HeightOneSpectrum.exists_primeCompl_mul_eq_of_integer 𝔭 (a : F)
-    (by rw [← valuation_ofPrime k F 𝔭]; exact (ofPrime k F 𝔭).mem_integers_iff.mp a.2)
-  obtain ⟨c, hmem⟩ : ∃ c : R, n - (d : R) * c ∈ 𝔭.asIdeal := by
-    obtain ⟨y, i, hi, hyd⟩ := 𝔭.isMaximal.exists_inv d.2
-    refine ⟨y * n, ?_⟩
-    have h : n - (d : R) * (y * n) = i * n := by linear_combination (-n) * hyd
-    exact h ▸ Ideal.mul_mem_right n _ hi
+  obtain ⟨c, hc⟩ := HeightOneSpectrum.exists_valuation_sub_lt_of_integer 𝔭
+    (by rw [← valuation_ofPrime k F 𝔭]; exact (ofPrime k F 𝔭).mem_integers_iff.mp a.2) 1
+  rw [Units.val_one] at hc
   refine ⟨c, ?_⟩
-  have hcoe : ((a - toIntegersOfPrime k F 𝔭 c : (ofPrime k F 𝔭).integers) : F)
-      = (a : F) - algebraMap R F c := by
-    push_cast
-    rw [coe_toIntegersOfPrime]
-  have hdval : (ofPrime k F 𝔭).valuation (algebraMap R F (d : R)) = 1 := by
-    rw [valuation_ofPrime, HeightOneSpectrum.valuation_eq_one_iff_notMem]
-    exact d.2
-  have hprod : ((a : F) - algebraMap R F c) * algebraMap R F (d : R)
-      = algebraMap R F (n - (d : R) * c) := by
-    rw [map_sub, map_mul, sub_mul, hnd]
-    ring
-  have hzero : IsLocalRing.residue (ofPrime k F 𝔭).integers
-      (a - toIntegersOfPrime k F 𝔭 c) = 0 := by
-    rw [(ofPrime k F 𝔭).residue_eq_zero_iff_valuation_lt_one]
-    calc (ofPrime k F 𝔭).valuation ((a - toIntegersOfPrime k F 𝔭 c : (ofPrime k F 𝔭).integers) : F)
-        = (ofPrime k F 𝔭).valuation ((a : F) - algebraMap R F c) *
-            (ofPrime k F 𝔭).valuation (algebraMap R F (d : R)) := by rw [hcoe, hdval, mul_one]
-      _ = (ofPrime k F 𝔭).valuation (algebraMap R F (n - (d : R) * c)) := by
-            rw [← map_mul, hprod]
-      _ < 1 := (valuation_ofPrime_algebraMap_lt_one_iff k F 𝔭).mpr hmem
-  rw [residueHomOfPrime_apply]
-  exact (sub_eq_zero.mp (by rwa [map_sub] at hzero)).symm
+  rw [residueHomOfPrime_apply, ← sub_eq_zero, ← map_sub,
+    (ofPrime k F 𝔭).residue_eq_zero_iff_valuation_lt_one, valuation_ofPrime]
+  push_cast [coe_algebraMap_integers_ofPrime]
+  exact hc
 
 /-- **The residue field of the place of a height one prime `𝔭` of an affine model is `R ⧸ 𝔭`**,
 as `k`-algebras. -/
-noncomputable def residueFieldAlgEquivOfPrime :
+noncomputable def quotientAlgEquivResidueFieldOfPrime :
     (R ⧸ 𝔭.asIdeal) ≃ₐ[k] (ofPrime k F 𝔭).ResidueField :=
   (Ideal.quotientEquivAlgOfEq k (ker_residueHomOfPrime k F 𝔭).symm).trans
     (Ideal.quotientKerAlgEquivOfSurjective (residueHomOfPrime_surjective k F 𝔭))
 
 @[simp]
-theorem residueFieldAlgEquivOfPrime_mk (r : R) :
-    residueFieldAlgEquivOfPrime k F 𝔭 (Ideal.Quotient.mk 𝔭.asIdeal r)
+theorem quotientAlgEquivResidueFieldOfPrime_mk (r : R) :
+    quotientAlgEquivResidueFieldOfPrime k F 𝔭 (Ideal.Quotient.mk 𝔭.asIdeal r)
       = residueHomOfPrime k F 𝔭 r := (rfl)
 
 /-- **The degree of the place of `𝔭` is the residue degree of `𝔭`**: the weight a divisor
@@ -261,7 +257,7 @@ attaches to a place of the finite chart is the one Mathlib's ideal theory attach
 corresponding prime. -/
 theorem degree_ofPrime : (ofPrime k F 𝔭).degree = Module.finrank k (R ⧸ 𝔭.asIdeal) := by
   rw [(ofPrime k F 𝔭).degree_eq_finrank]
-  exact ((residueFieldAlgEquivOfPrime k F 𝔭).toLinearEquiv.finrank_eq).symm
+  exact ((quotientAlgEquivResidueFieldOfPrime k F 𝔭).toLinearEquiv.finrank_eq).symm
 
 /-- The degree of a place finite on an affine model is the residue degree of its centre. -/
 theorem degree_eq_finrank_quotient_center (P : Place k F)

--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean
@@ -211,6 +211,7 @@ noncomputable def residueHomOfPrime : R →ₐ[k] (ofPrime k F 𝔭).ResidueFiel
       exact congrArg (IsLocalRing.residue _)
         (Subtype.ext (IsScalarTower.algebraMap_apply k R F c).symm) }
 
+@[simp]
 theorem residueHomOfPrime_apply (r : R) : residueHomOfPrime k F 𝔭 r =
     IsLocalRing.residue (ofPrime k F 𝔭).integers (algebraMap R (ofPrime k F 𝔭).integers r) :=
   (rfl)

--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 public import Mathlib.RingTheory.Ideal.Quotient.Operations
 public import TauCeti.FieldTheory.FunctionField.AffineModel.Place
 
@@ -32,8 +31,9 @@ that divisor theory on the finite chart of a model is exactly the ideal theory o
 
 * `TauCeti.Place.ofPrime`: the place of `F / k` attached to a height one prime of an affine
   model.
-* `TauCeti.Place.residueHomOfPrime`: evaluation of the elements of the model at that place, a
-  `k`-algebra map `R → F_P` with kernel `𝔭` (`TauCeti.Place.ker_residueHomOfPrime`).
+* `TauCeti.Place.residueHom`: evaluation of the elements of the model at a place finite on it, a
+  `k`-algebra map `R → F_P` whose kernel is the centre of the place
+  (`TauCeti.Place.ker_residueHom`).
 * `TauCeti.Place.heightOneSpectrumEquiv`: the bijection between the places finite on a model and
   the height one primes of the model.
 
@@ -43,10 +43,11 @@ that divisor theory on the finite chart of a model is exactly the ideal theory o
   mutually inverse, and `TauCeti.Place.exists_eq_ofPrime_iff` identifies the places in the image
   as exactly the places finite on the model.
 * `TauCeti.Place.ord_ofPrime_algebraMap`: the coefficient formula `ord_P r = mult_𝔭 (r)`, for
-  `r ≠ 0`; `TauCeti.Place.ord_algebraMap_eq_multiplicity_center` is the same formula read off the
-  centre of a place finite on the model.
-* `TauCeti.Place.quotientAlgEquivResidueFieldOfPrime`: the residue field of the place of `𝔭` is
-  `R ⧸ 𝔭`, whence `TauCeti.Place.degree_ofPrime`: `deg P = [R ⧸ 𝔭 : k]`.
+  `r ≠ 0`, the `𝔭`-form of `TauCeti.Place.ord_algebraMap_eq_multiplicity_center`.
+* `TauCeti.Place.quotientAlgEquivResidueField`: the residue field of a place finite on the model
+  is `R` modulo the centre of the place, whence `TauCeti.Place.degree_eq_finrank_quotient_center`;
+  `TauCeti.Place.quotientAlgEquivResidueFieldOfPrime` and `TauCeti.Place.degree_ofPrime` are the
+  `𝔭`-forms, `F_P = R ⧸ 𝔭` and `deg P = [R ⧸ 𝔭 : k]`.
 
 ## References
 
@@ -104,16 +105,6 @@ theorem valuation_ofPrime_algebraMap_lt_one_iff {r : R} :
     (ofPrime k F 𝔭).valuation (algebraMap R F r) < 1 ↔ r ∈ 𝔭.asIdeal := by
   rw [valuation_ofPrime, HeightOneSpectrum.valuation_lt_one_iff_mem]
 
-/-- **The coefficient formula on the finite chart**: the order at the place of `𝔭` of a nonzero
-element of the model is the multiplicity of `𝔭` in the ideal it generates. This is what turns a
-divisor supported on the finite chart into a factorization of ideals. The hypothesis `r ≠ 0`
-guards the junk values `ord_P 0 = 0` and `multiplicity 𝔭 ⊥ = 1`. -/
-theorem ord_ofPrime_algebraMap {r : R} (hr : r ≠ 0) :
-    (ofPrime k F 𝔭).ord (algebraMap R F r) = multiplicity 𝔭.asIdeal (Ideal.span {r}) := by
-  have hr' : algebraMap R F r ≠ 0 := (map_ne_zero_iff _ (IsFractionRing.injective R F)).mpr hr
-  rw [(ofPrime k F 𝔭).ord_eq_iff_valuation_eq_exp_neg hr', valuation_ofPrime_algebraMap,
-    HeightOneSpectrum.intValuation_eq_exp_neg_multiplicity 𝔭 hr]
-
 end OfPrime
 
 section Correspondence
@@ -131,12 +122,6 @@ theorem center_ofPrime (𝔭 : HeightOneSpectrum R) :
 theorem ofPrime_center (P : Place k F) (hR : ∀ r : R, algebraMap R F r ∈ P.integers) :
     ofPrime k F (P.center hR) = P :=
   Place.ext (by rw [valuation_ofPrime, P.valuation_center hR])
-
-/-- The valuation ring of the place of `𝔭` is the localization of the model at `𝔭`. -/
-theorem valuationSubringAtPrime_eq_integers_ofPrime (𝔭 : HeightOneSpectrum R) :
-    HeightOneSpectrum.valuationSubringAtPrime F 𝔭 = (ofPrime k F 𝔭).integers := by
-  rw [HeightOneSpectrum.valuationSubringAtPrime_eq_valuationSubring, ← valuation_ofPrime k F 𝔭]
-  exact SetLike.ext fun _ ↦ (ofPrime k F 𝔭).mem_integers_iff.symm
 
 variable (R) in
 /-- **The places of `F / k` finite on an affine model `R` are exactly the height one primes of
@@ -170,104 +155,111 @@ theorem exists_eq_ofPrime_iff (P : Place k F) :
   ⟨fun ⟨𝔭, h⟩ r ↦ h ▸ algebraMap_mem_integers_ofPrime k F 𝔭 r,
     fun hR ↦ ⟨P.center hR, ofPrime_center k F P hR⟩⟩
 
-/-- **The coefficient formula at a place finite on an affine model**: the order at `P` of a
-nonzero element of the model is the multiplicity of the centre of `P` in the ideal it generates.
-This is `TauCeti.Place.ord_ofPrime_algebraMap` in the form in which
-`TauCeti.Place.exists_eq_ofPrime_iff` hands a place of the finite chart over. -/
-theorem ord_algebraMap_eq_multiplicity_center (P : Place k F)
-    (hR : ∀ r : R, algebraMap R F r ∈ P.integers) {r : R} (hr : r ≠ 0) :
-    P.ord (algebraMap R F r) = multiplicity (P.center hR).asIdeal (Ideal.span {r}) := by
-  conv_lhs => rw [← ofPrime_center k F P hR]
-  exact ord_ofPrime_algebraMap k F (P.center hR) hr
+/-- **The coefficient formula on the finite chart**: the order at the place of `𝔭` of a nonzero
+element of the model is the multiplicity of `𝔭` in the ideal it generates. This is
+`TauCeti.Place.ord_algebraMap_eq_multiplicity_center` at the place of `𝔭`, whose centre is `𝔭`,
+and it is what turns a divisor supported on the finite chart into a factorization of ideals. -/
+theorem ord_ofPrime_algebraMap (𝔭 : HeightOneSpectrum R) {r : R} (hr : r ≠ 0) :
+    (ofPrime k F 𝔭).ord (algebraMap R F r) = multiplicity 𝔭.asIdeal (Ideal.span {r}) := by
+  rw [(ofPrime k F 𝔭).ord_algebraMap_eq_multiplicity_center
+    (algebraMap_mem_integers_ofPrime k F 𝔭) hr, center_ofPrime]
 
 end Correspondence
 
 section ResidueField
 
-variable (k F) (𝔭 : HeightOneSpectrum R)
+variable (P : Place k F) (hR : ∀ r : R, algebraMap R F r ∈ P.integers)
 
-/-- An affine model lies in the valuation ring of the place of each of its height one primes, so
-that valuation ring is an `R`-algebra. -/
-noncomputable instance : Algebra R (ofPrime k F 𝔭).integers :=
-  ((algebraMap R F).codRestrict _ (algebraMap_mem_integers_ofPrime k F 𝔭)).toAlgebra
+include hR
 
-/-- The `R`-algebra structure on the valuation ring of the place of `𝔭` is the one induced by
-the inclusion of the model in `F`. -/
-instance : IsScalarTower R (ofPrime k F 𝔭).integers F := .of_algebraMap_eq fun _ ↦ rfl
-
-@[simp]
-theorem coe_algebraMap_integers_ofPrime (r : R) :
-    (algebraMap R (ofPrime k F 𝔭).integers r : F) = algebraMap R F r := (rfl)
-
-/-- **Evaluation of the elements of an affine model at the place of one of its height one
-primes**, as a map of `k`-algebras `R → F_P`. It is surjective with kernel `𝔭`, which is the
-content of `TauCeti.Place.quotientAlgEquivResidueFieldOfPrime`. -/
-noncomputable def residueHomOfPrime : R →ₐ[k] (ofPrime k F 𝔭).ResidueField :=
-  { (IsLocalRing.residue (ofPrime k F 𝔭).integers).comp
-      (algebraMap R (ofPrime k F 𝔭).integers) with
+/-- **Evaluation of the elements of an affine model at a place finite on it**, as a map of
+`k`-algebras `R → F_P`. It is surjective with kernel the centre of the place, which is the
+content of `TauCeti.Place.quotientAlgEquivResidueField`. -/
+noncomputable def residueHom : R →ₐ[k] P.ResidueField :=
+  { (IsLocalRing.residue P.integers).comp ((algebraMap R F).codRestrict P.integers hR) with
     commutes' := fun c ↦ by
-      rw [IsScalarTower.algebraMap_apply k (ofPrime k F 𝔭).integers (ofPrime k F 𝔭).ResidueField,
+      rw [IsScalarTower.algebraMap_apply k P.integers P.ResidueField,
         IsLocalRing.ResidueField.algebraMap_eq]
       exact congrArg (IsLocalRing.residue _)
         (Subtype.ext (IsScalarTower.algebraMap_apply k R F c).symm) }
 
+omit [IsDedekindDomain R] [IsFractionRing R F] in
 @[simp]
-theorem residueHomOfPrime_apply (r : R) : residueHomOfPrime k F 𝔭 r =
-    IsLocalRing.residue (ofPrime k F 𝔭).integers (algebraMap R (ofPrime k F 𝔭).integers r) :=
-  (rfl)
+theorem residueHom_apply (r : R) :
+    P.residueHom hR r = IsLocalRing.residue P.integers ⟨algebraMap R F r, hR r⟩ := (rfl)
 
-/-- **The elements of the model that vanish at the place of `𝔭` are exactly the elements of
-`𝔭`.** -/
+/-- **The kernel of evaluation at `P` is the centre of `P` on the model**: this is the
+evaluation-map form of `TauCeti.Place.mem_center_asIdeal`, which says the same thing about the
+valuation of `P`. -/
 @[simp]
-theorem ker_residueHomOfPrime : RingHom.ker (residueHomOfPrime k F 𝔭) = 𝔭.asIdeal := by
+theorem ker_residueHom : RingHom.ker (P.residueHom hR) = (P.center hR).asIdeal := by
   ext r
-  rw [RingHom.mem_ker, residueHomOfPrime_apply,
-    (ofPrime k F 𝔭).residue_eq_zero_iff_valuation_lt_one, coe_algebraMap_integers_ofPrime,
-    valuation_ofPrime_algebraMap_lt_one_iff]
+  rw [RingHom.mem_ker, residueHom_apply, P.residue_eq_zero_iff_valuation_lt_one,
+    P.mem_center_asIdeal hR]
 
-/-- **Every residue at the place of `𝔭` is the residue of an element of the model.** This is
-Mathlib's approximation theorem for the `𝔭`-adic valuation, at the accuracy `1`: a function
-integral at the place is within `1` of an element of the model, so the two have the same
-residue. -/
-theorem residueHomOfPrime_surjective : Function.Surjective (residueHomOfPrime k F 𝔭) := by
+/-- **Every residue at a place finite on an affine model is the residue of an element of the
+model.** This is Mathlib's approximation theorem for the adic valuation of the centre, at the
+accuracy `1`: a function integral at the place is within `1` of an element of the model, so the
+two have the same residue. -/
+theorem residueHom_surjective : Function.Surjective (P.residueHom hR) := by
   intro y
   obtain ⟨a, rfl⟩ := IsLocalRing.residue_surjective y
-  obtain ⟨c, hc⟩ := HeightOneSpectrum.exists_valuation_sub_lt_of_integer 𝔭
-    (by rw [← valuation_ofPrime k F 𝔭]; exact (ofPrime k F 𝔭).mem_integers_iff.mp a.2) 1
-  rw [Units.val_one] at hc
+  obtain ⟨c, hc⟩ := HeightOneSpectrum.exists_valuation_sub_lt_of_integer (P.center hR)
+    (by rw [P.valuation_center hR]; exact P.mem_integers_iff.mp a.2) 1
+  rw [Units.val_one, P.valuation_center hR] at hc
   refine ⟨c, ?_⟩
-  rw [residueHomOfPrime_apply, ← sub_eq_zero, ← map_sub,
-    (ofPrime k F 𝔭).residue_eq_zero_iff_valuation_lt_one, valuation_ofPrime]
-  push_cast [coe_algebraMap_integers_ofPrime]
+  rw [residueHom_apply, ← sub_eq_zero, ← map_sub, P.residue_eq_zero_iff_valuation_lt_one]
+  push_cast
   exact hc
 
+/-- **The residue field of a place finite on an affine model is the model modulo the centre of
+the place**, as `k`-algebras. -/
+noncomputable def quotientAlgEquivResidueField :
+    (R ⧸ (P.center hR).asIdeal) ≃ₐ[k] P.ResidueField :=
+  (Ideal.quotientEquivAlgOfEq k (P.ker_residueHom hR).symm).trans
+    (Ideal.quotientKerAlgEquivOfSurjective (P.residueHom_surjective hR))
+
+@[simp]
+theorem quotientAlgEquivResidueField_mk (r : R) :
+    P.quotientAlgEquivResidueField hR (Ideal.Quotient.mk (P.center hR).asIdeal r)
+      = P.residueHom hR r := (rfl)
+
+/-- **The degree of a place finite on an affine model is the residue degree of its centre**: the
+weight a divisor attaches to a place of the finite chart is the one Mathlib's ideal theory
+attaches to the corresponding prime. -/
+theorem degree_eq_finrank_quotient_center :
+    P.degree = Module.finrank k (R ⧸ (P.center hR).asIdeal) := by
+  rw [P.degree_eq_finrank]
+  exact ((P.quotientAlgEquivResidueField hR).toLinearEquiv.finrank_eq).symm
+
+end ResidueField
+
+section ResidueFieldOfPrime
+
+variable (k F) (𝔭 : HeightOneSpectrum R)
+
 /-- **The residue field of the place of a height one prime `𝔭` of an affine model is `R ⧸ 𝔭`**,
-as `k`-algebras. -/
+as `k`-algebras: this is `TauCeti.Place.quotientAlgEquivResidueField` at the place of `𝔭`, whose
+centre is `𝔭`. -/
 noncomputable def quotientAlgEquivResidueFieldOfPrime :
     (R ⧸ 𝔭.asIdeal) ≃ₐ[k] (ofPrime k F 𝔭).ResidueField :=
-  (Ideal.quotientEquivAlgOfEq k (ker_residueHomOfPrime k F 𝔭).symm).trans
-    (Ideal.quotientKerAlgEquivOfSurjective (residueHomOfPrime_surjective k F 𝔭))
+  (Ideal.quotientEquivAlgOfEq k
+      (congrArg HeightOneSpectrum.asIdeal (center_ofPrime k F 𝔭)).symm).trans
+    ((ofPrime k F 𝔭).quotientAlgEquivResidueField (algebraMap_mem_integers_ofPrime k F 𝔭))
 
 @[simp]
 theorem quotientAlgEquivResidueFieldOfPrime_mk (r : R) :
     quotientAlgEquivResidueFieldOfPrime k F 𝔭 (Ideal.Quotient.mk 𝔭.asIdeal r)
-      = residueHomOfPrime k F 𝔭 r := (rfl)
+      = (ofPrime k F 𝔭).residueHom (algebraMap_mem_integers_ofPrime k F 𝔭) r := (rfl)
 
 /-- **The degree of the place of `𝔭` is the residue degree of `𝔭`**: the weight a divisor
 attaches to a place of the finite chart is the one Mathlib's ideal theory attaches to the
 corresponding prime. -/
 theorem degree_ofPrime : (ofPrime k F 𝔭).degree = Module.finrank k (R ⧸ 𝔭.asIdeal) := by
-  rw [(ofPrime k F 𝔭).degree_eq_finrank]
-  exact ((quotientAlgEquivResidueFieldOfPrime k F 𝔭).toLinearEquiv.finrank_eq).symm
+  rw [(ofPrime k F 𝔭).degree_eq_finrank_quotient_center (algebraMap_mem_integers_ofPrime k F 𝔭),
+    center_ofPrime]
 
-/-- The degree of a place finite on an affine model is the residue degree of its centre. -/
-theorem degree_eq_finrank_quotient_center (P : Place k F)
-    (hR : ∀ r : R, algebraMap R F r ∈ P.integers) :
-    P.degree = Module.finrank k (R ⧸ (P.center hR).asIdeal) := by
-  conv_lhs => rw [← ofPrime_center k F P hR]
-  exact degree_ofPrime k F (P.center hR)
-
-end ResidueField
+end ResidueFieldOfPrime
 
 end Place
 


### PR DESCRIPTION
This PR supplies the missing direction of the places ↔ height one primes correspondence for
algebraic function fields: the place of `F / k` attached to a height one prime of an affine
model. `TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean` already sends a place finite
on a Dedekind `k`-subalgebra `R ⊆ F` with `Frac R = F` to its centre, a height one prime of `R`;
what was missing is the construction going the other way, and the proof that the two are
mutually inverse. The new `TauCeti.Place.ofPrime` takes Mathlib's normalized `𝔭`-adic valuation
of `F` and checks the one place axiom that is not already recorded there — triviality on the
constants — which holds because a nonzero constant is a unit of `R` and therefore avoids `𝔭`.
`TauCeti.Place.center_ofPrime` and `TauCeti.Place.ofPrime_center` are the two round trips, and
`TauCeti.Place.heightOneSpectrumEquiv` packages them as
`{P : Place k F // R ⊆ 𝒪_P} ≃ HeightOneSpectrum R`, with
`TauCeti.Place.exists_eq_ofPrime_iff` identifying the image of `ofPrime` as exactly the finite
chart of the model.

The correspondence is then made quantitative, in the two ways the divisor layer will consume it.
`TauCeti.Place.ord_algebraMap_eq_multiplicity_center` is the coefficient formula
`ord_P (algebraMap R F r) = multiplicity (centre of P) (r)`, so a divisor coefficient on the
finite chart is read off Mathlib's factorization calculus rather than recomputed;
`TauCeti.Place.ord_ofPrime_algebraMap` is its `𝔭`-form. `TauCeti.Place.residueHom` is evaluation
of the model at a place finite on it, a `k`-algebra map `R → F_P`; its kernel is the centre of the
place, and it is surjective because a function integral at the place is within `1` of an element
of the model, by Mathlib's approximation theorem for the adic valuation. Hence
`TauCeti.Place.quotientAlgEquivResidueField : (R ⧸ centre) ≃ₐ[k] F_P` and
`TauCeti.Place.degree_eq_finrank_quotient_center : deg P = [R ⧸ centre : k]` — the degree a
divisor attaches to a place of the finite chart is the residue degree Mathlib's ideal theory
attaches to the prime — with `TauCeti.Place.quotientAlgEquivResidueFieldOfPrime` and
`TauCeti.Place.degree_ofPrime` as the `𝔭`-forms, `F_P = R ⧸ 𝔭` and `deg P = [R ⧸ 𝔭 : k]`.

This is the AlgebraicCurves roadmap's Layer 2 milestone "Places ↔ height-one primes, as a proved
chain", specifically its second half: "Conversely, for `𝔭 : HeightOneSpectrum R_x`, extend the
local DVR valuation to `F`, normalize it, and prove that contraction recovers `𝔭` and that both
constructions are inverse. Package the resulting bijection … together with the induced
residue-field equivalence, equality of residue degrees, and the `ord_P`/`intValuation`
coefficient formula." After this PR, Layer 2 still needs the finite-normalization theorem that
makes the integral closure `R_x` of `k[x]` in `F` a Dedekind domain without a separability
hypothesis, and the two-chart compatibility identifying the places with `ord_P x < 0` as the
finite-chart primes for `x⁻¹`; the bijection proved here is what those two milestones apply, chart
by chart.

Everything is stated for an arbitrary affine model — a Dedekind `k`-algebra `R` with
`IsFractionRing R F` and `IsScalarTower k R F` — rather than for `R_x` specifically, so the same
statements serve both charts and any holomorphy ring. No Mathlib source was vendored; the proofs
consume `IsDedekindDomain.HeightOneSpectrum.valuation`, `valuation_surjective`,
`exists_valuation_sub_lt_of_integer`, `intValuation_eq_exp_neg_multiplicity` and
`Ideal.quotientKerAlgEquivOfSurjective` as they stand.

Adds `TauCeti/FieldTheory/FunctionField/AffineModel/Prime.lean` (266 lines), and adds the
`k`-free coefficient formula `TauCeti.Place.ord_algebraMap_eq_multiplicity_center` to the sibling
`AffineModel/Place.lean`, whose module docstring now names this module.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"tauceti-place-heightonespectrumequiv"}-->

🤖 Prepared with Claude Code