### PR TITLE
refactor: generalize radicalQuotient to quotientOfLeRadical

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/OrthogonalComplement.lean
@@ -5,8 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Quotient.Bilinear
-public import TauCeti.LinearAlgebra.FiniteBilinearModule.Basic
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.RadicalQuotient
 
 /-!
 # Orthogonal complements in finite bilinear modules
@@ -27,7 +26,6 @@ subgroup has order whose square is the order of the ambient group.
 
 ## Main declarations
 
-* `TauCeti.FiniteBilinearModule.radicalQuotient`: the nondegenerate quotient by the radical.
 * `TauCeti.FiniteBilinearModule.orthogonalComplement_orthogonalComplement`: the formula
   `H⊥⊥ = H ⊔ rad(A)`.
 * `TauCeti.FiniteBilinearModule.IsNondegenerate.card_mul_card_orthogonalComplement`: the
@@ -47,91 +45,6 @@ namespace TauCeti.FiniteBilinearModule
 universe u
 
 variable (A : FiniteBilinearModule.{u})
-
-/-! ## Quotient by the radical -/
-
-private theorem radical_toIntSubmodule_le_ker :
-    A.radical.toIntSubmodule ≤ A.toBilin.ker := by
-  intro x hx
-  rw [LinearMap.mem_ker]
-  ext y
-  rw [LinearMap.zero_apply, A.toBilin_apply]
-  exact A.mem_radical_iff x |>.mp hx y
-
-/-- The underlying additive quotient of a finite bilinear module by its radical. -/
-private abbrev RadicalQuotient := A.carrier ⧸ A.radical.toIntSubmodule
-
-private noncomputable def radicalQuotientBilin :
-    A.RadicalQuotient →ₗ[ℤ] A.RadicalQuotient →ₗ[ℤ] AddCircle (1 : ℚ) :=
-  LinearMap.IsRefl.liftQ₂ A.toBilin A.radical.toIntSubmodule A.isRefl_toBilin
-    (radical_toIntSubmodule_le_ker A)
-
-/-- The finite bilinear module obtained by quotienting by the radical. -/
-noncomputable def radicalQuotient : FiniteBilinearModule where
-  carrier := A.RadicalQuotient
-  finite := Finite.of_surjective A.radical.toIntSubmodule.mkQ
-    A.radical.toIntSubmodule.mkQ_surjective
-  pairing :=
-    { toFun := fun x ↦
-        (A.radicalQuotientBilin x).toAddMonoidHom
-      map_zero' := by
-        exact congrArg LinearMap.toAddMonoidHom (map_zero A.radicalQuotientBilin)
-      map_add' := by
-        intro x y
-        exact congrArg LinearMap.toAddMonoidHom (map_add A.radicalQuotientBilin x y) }
-  pairing_comm := by
-    intro x y
-    induction x using Submodule.Quotient.induction_on with | H x =>
-    induction y using Submodule.Quotient.induction_on with | H y =>
-    -- `CharacterModule` is an opaque `def` alias for additive homomorphisms, so its evaluation
-    -- cannot be simplified to the quotient bilinear map by a public rewrite lemma.
-    change A.radicalQuotientBilin (Submodule.Quotient.mk x)
-      (Submodule.Quotient.mk y) = A.radicalQuotientBilin (Submodule.Quotient.mk y)
-        (Submodule.Quotient.mk x)
-    rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, LinearMap.liftQ₂_mk,
-      A.toBilin_apply, A.toBilin_apply]
-    exact A.pairing_comm x y
-
-/-- The quotient map from a finite bilinear module to its radical quotient. -/
-noncomputable def radicalQuotientMk : A →+ radicalQuotient A :=
-  A.radical.toIntSubmodule.mkQ.toAddMonoidHom
-
-/-- The quotient pairing is represented by the original pairing on representatives. -/
-@[simp]
-theorem radicalQuotient_pairing_mk (x y : A) :
-    (radicalQuotient A).pairing (radicalQuotientMk A x) (radicalQuotientMk A y) =
-      A.pairing x y := by
-  -- Unfold the opaque `CharacterModule` alias to expose evaluation of the quotient lift.
-  change A.radicalQuotientBilin (Submodule.Quotient.mk x)
-    (Submodule.Quotient.mk y) = A.pairing x y
-  rw [radicalQuotientBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
-
-/-- The quotient map to the radical quotient is surjective. -/
-theorem radicalQuotientMk_surjective : Function.Surjective (radicalQuotientMk A) :=
-  A.radical.toIntSubmodule.mkQ_surjective
-
-/-- The kernel of the radical quotient map is the radical. -/
-@[simp]
-theorem radicalQuotientMk_ker : (radicalQuotientMk A).ker = A.radical := by
-  rw [← A.radical.toIntSubmodule_toAddSubgroup]
-  exact congrArg Submodule.toAddSubgroup A.radical.toIntSubmodule.ker_mkQ
-
-/-- Quotienting a finite bilinear module by its radical produces a nondegenerate module. -/
-theorem isNondegenerate_radicalQuotient : (radicalQuotient A).IsNondegenerate := by
-  apply (radicalQuotient A).isNondegenerate_of_injective
-  rw [injective_iff_map_eq_zero]
-  intro x hx
-  obtain ⟨x, rfl⟩ := radicalQuotientMk_surjective A x
-  rw [← AddMonoidHom.mem_ker, radicalQuotientMk_ker]
-  rw [A.mem_radical_iff]
-  intro y
-  have hxy := DFunLike.congr_fun hx (radicalQuotientMk A y)
-  calc
-    A.pairing x y =
-        (radicalQuotient A).pairing (radicalQuotientMk A x) (radicalQuotientMk A y) :=
-      (radicalQuotient_pairing_mk A x y).symm
-    _ = (0 : CharacterModule (radicalQuotient A)) (radicalQuotientMk A y) := hxy
-    _ = 0 := rfl
 
 /-! ## Character restriction and cardinality -/
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/RadicalQuotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/RadicalQuotient.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Quotient.Bilinear
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Basic
+
+/-!
+# Quotients of a finite bilinear module by a subgroup of its radical
+
+A subgroup `K` of the radical of a finite bilinear module `A` pairs trivially with everything, so
+the pairing descends to the quotient `A / K`:
+
+```text
+b (x + K) (y + K) = b x y.
+```
+
+The resulting module is nondegenerate exactly when `K` is the whole radical, since the radical of
+the quotient is the image of `rad(A)`. Taking `K = rad(A)` therefore gives the canonical
+nondegenerate quotient, and other choices of `K` arise when a specific subgroup is being divided
+out.
+
+Both `quotientOfLeRadical` and `radicalQuotient` are exposed, so their carriers reduce to the
+`Submodule` quotient and a map out of either can be built directly with `Submodule.liftQ` or
+`QuadraticMap.lift`.
+
+## Main declarations
+
+* `TauCeti.FiniteBilinearModule.quotientOfLeRadical`: the quotient by a subgroup of the radical.
+* `TauCeti.FiniteBilinearModule.radical_quotientOfLeRadical`: the radical of the quotient is the
+  image of the radical.
+* `TauCeti.FiniteBilinearModule.isNondegenerate_quotientOfLeRadical_iff`: nondegeneracy holds
+  exactly when the subgroup exhausts the radical.
+* `TauCeti.FiniteBilinearModule.card_quotientOfLeRadical`: the order of the quotient is the index
+  of the subgroup.
+* `TauCeti.FiniteBilinearModule.radicalQuotient`: the nondegenerate quotient by the radical.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+-/
+
+public section
+
+namespace TauCeti.FiniteBilinearModule
+
+universe u
+
+variable (A : FiniteBilinearModule.{u})
+
+/-! ## Quotient by a subgroup of the radical -/
+
+/-- The underlying additive quotient of a finite bilinear module by a subgroup.
+
+This is a `Submodule` quotient, so `Submodule.liftQ` and `QuadraticMap.lift` apply to it. It is
+the carrier of `quotientOfLeRadical` when the subgroup lies in the radical. -/
+abbrev QuotientByAddSubgroup (K : AddSubgroup A) := A.carrier ⧸ K.toIntSubmodule
+
+/-- A subgroup of the radical, read as a `ℤ`-submodule, lies in the kernel of the pairing. -/
+theorem toIntSubmodule_le_ker_toBilin {K : AddSubgroup A} (hK : K ≤ A.radical) :
+    K.toIntSubmodule ≤ A.toBilin.ker := by
+  intro x hx
+  rw [LinearMap.mem_ker]
+  ext y
+  rw [LinearMap.zero_apply, A.toBilin_apply]
+  exact A.mem_radical_iff x |>.mp (hK hx) y
+
+/-- The pairing of a finite bilinear module, descended through a subgroup of its radical.
+
+This is the underlying `ℤ`-bilinear map of `quotientOfLeRadical`. -/
+noncomputable def quotientOfLeRadicalBilin (K : AddSubgroup A) (hK : K ≤ A.radical) :
+    A.QuotientByAddSubgroup K →ₗ[ℤ] A.QuotientByAddSubgroup K →ₗ[ℤ] AddCircle (1 : ℚ) :=
+  LinearMap.IsRefl.liftQ₂ A.toBilin K.toIntSubmodule A.isRefl_toBilin
+    (A.toIntSubmodule_le_ker_toBilin hK)
+
+/-- The descended pairing is computed by the original pairing on representatives. -/
+@[simp]
+theorem quotientOfLeRadicalBilin_mk (K : AddSubgroup A) (hK : K ≤ A.radical) (x y : A) :
+    A.quotientOfLeRadicalBilin K hK (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
+      A.pairing x y := by
+  rw [quotientOfLeRadicalBilin, LinearMap.liftQ₂_mk, A.toBilin_apply]
+
+/-- The finite bilinear module obtained by quotienting by a subgroup of the radical.
+
+The package is exposed so that its carrier projection reduces to the `Submodule` quotient
+`QuotientByAddSubgroup`, which is what a map out of the quotient needs. -/
+@[expose] noncomputable def quotientOfLeRadical (K : AddSubgroup A) (hK : K ≤ A.radical) :
+    FiniteBilinearModule where
+  carrier := A.QuotientByAddSubgroup K
+  finite := Finite.of_surjective K.toIntSubmodule.mkQ K.toIntSubmodule.mkQ_surjective
+  pairing :=
+    { toFun := fun x ↦ (A.quotientOfLeRadicalBilin K hK x).toAddMonoidHom
+      map_zero' := by
+        exact congrArg LinearMap.toAddMonoidHom (map_zero (A.quotientOfLeRadicalBilin K hK))
+      map_add' := by
+        intro x y
+        exact congrArg LinearMap.toAddMonoidHom (map_add (A.quotientOfLeRadicalBilin K hK) x y) }
+  pairing_comm := by
+    intro x y
+    induction x using Submodule.Quotient.induction_on with | H x =>
+    induction y using Submodule.Quotient.induction_on with | H y =>
+    -- `CharacterModule` is an opaque `def` alias for additive homomorphisms, so its evaluation
+    -- cannot be simplified to the quotient bilinear map by a public rewrite lemma.
+    change A.quotientOfLeRadicalBilin K hK (Submodule.Quotient.mk x)
+      (Submodule.Quotient.mk y) = A.quotientOfLeRadicalBilin K hK (Submodule.Quotient.mk y)
+        (Submodule.Quotient.mk x)
+    rw [A.quotientOfLeRadicalBilin_mk K hK, A.quotientOfLeRadicalBilin_mk K hK]
+    exact A.pairing_comm x y
+
+/-- The quotient map onto the quotient by a subgroup of the radical. -/
+noncomputable def quotientOfLeRadicalMk (K : AddSubgroup A) (hK : K ≤ A.radical) :
+    A →+ A.quotientOfLeRadical K hK :=
+  K.toIntSubmodule.mkQ.toAddMonoidHom
+
+/-- The quotient pairing is represented by the original pairing on representatives. -/
+@[simp]
+theorem quotientOfLeRadical_pairing_mk (K : AddSubgroup A) (hK : K ≤ A.radical) (x y : A) :
+    (A.quotientOfLeRadical K hK).pairing (A.quotientOfLeRadicalMk K hK x)
+      (A.quotientOfLeRadicalMk K hK y) = A.pairing x y := by
+  -- Unfold the opaque `CharacterModule` alias to expose evaluation of the quotient lift.
+  change A.quotientOfLeRadicalBilin K hK (Submodule.Quotient.mk x)
+    (Submodule.Quotient.mk y) = A.pairing x y
+  exact A.quotientOfLeRadicalBilin_mk K hK x y
+
+/-- The quotient map by a subgroup of the radical is surjective. -/
+theorem quotientOfLeRadicalMk_surjective (K : AddSubgroup A) (hK : K ≤ A.radical) :
+    Function.Surjective (A.quotientOfLeRadicalMk K hK) :=
+  K.toIntSubmodule.mkQ_surjective
+
+/-- The kernel of the quotient map by a subgroup of the radical is that subgroup. -/
+@[simp]
+theorem quotientOfLeRadicalMk_ker (K : AddSubgroup A) (hK : K ≤ A.radical) :
+    (A.quotientOfLeRadicalMk K hK).ker = K :=
+  (congrArg Submodule.toAddSubgroup K.toIntSubmodule.ker_mkQ).trans
+    K.toIntSubmodule_toAddSubgroup
+
+/-- A class in the quotient vanishes exactly when its representative lies in the subgroup. -/
+@[simp]
+theorem quotientOfLeRadicalMk_eq_zero_iff (K : AddSubgroup A) (hK : K ≤ A.radical) (x : A) :
+    A.quotientOfLeRadicalMk K hK x = 0 ↔ x ∈ K := by
+  rw [← AddMonoidHom.mem_ker, A.quotientOfLeRadicalMk_ker K hK]
+
+/-- **The radical of the quotient** is the image of the radical: quotienting by a subgroup of the
+radical does not create new degeneracy. -/
+theorem radical_quotientOfLeRadical (K : AddSubgroup A) (hK : K ≤ A.radical) :
+    (A.quotientOfLeRadical K hK).radical = A.radical.map (A.quotientOfLeRadicalMk K hK) := by
+  ext q
+  obtain ⟨x, rfl⟩ := A.quotientOfLeRadicalMk_surjective K hK q
+  constructor
+  · intro hq
+    refine ⟨x, (A.mem_radical_iff x).mpr fun y ↦ ?_, rfl⟩
+    rw [← A.quotientOfLeRadical_pairing_mk K hK x y]
+    exact (mem_radical_iff _ _).mp hq _
+  · rintro ⟨z, hz, hzx⟩
+    rw [mem_radical_iff]
+    intro q'
+    obtain ⟨y, rfl⟩ := A.quotientOfLeRadicalMk_surjective K hK q'
+    rw [← hzx, A.quotientOfLeRadical_pairing_mk K hK]
+    exact (A.mem_radical_iff z).mp hz y
+
+/-- **Nondegeneracy of the quotient.** Quotienting by a subgroup of the radical leaves a
+nondegenerate module exactly when that subgroup exhausts the radical. -/
+theorem isNondegenerate_quotientOfLeRadical_iff (K : AddSubgroup A) (hK : K ≤ A.radical) :
+    (A.quotientOfLeRadical K hK).IsNondegenerate ↔ A.radical ≤ K := by
+  rw [isNondegenerate_iff_radical_eq_bot, A.radical_quotientOfLeRadical K hK, eq_bot_iff]
+  constructor
+  · intro h x hx
+    exact (A.quotientOfLeRadicalMk_eq_zero_iff K hK x).mp (h ⟨x, hx, rfl⟩)
+  · rintro h q ⟨x, hx, rfl⟩
+    rw [AddSubgroup.mem_bot, A.quotientOfLeRadicalMk_eq_zero_iff K hK]
+    exact h hx
+
+/-- The order of the quotient by a subgroup of the radical is the index of that subgroup. -/
+theorem card_quotientOfLeRadical (K : AddSubgroup A) (hK : K ≤ A.radical) :
+    Nat.card (A.quotientOfLeRadical K hK) = K.index := by
+  conv_rhs => rw [← A.quotientOfLeRadicalMk_ker K hK]
+  rw [AddSubgroup.index_ker,
+    AddMonoidHom.range_eq_top.mpr (A.quotientOfLeRadicalMk_surjective K hK),
+    AddSubgroup.card_top]
+
+/-! ## Quotient by the radical -/
+
+/-- The finite bilinear module obtained by quotienting by the radical.
+
+Exposed for the same reason as `quotientOfLeRadical`: so that its carrier reduces to the
+`Submodule` quotient and maps out of it are definable. -/
+@[expose] noncomputable def radicalQuotient : FiniteBilinearModule :=
+  A.quotientOfLeRadical A.radical le_rfl
+
+/-- The quotient map from a finite bilinear module to its radical quotient. -/
+noncomputable def radicalQuotientMk : A →+ radicalQuotient A :=
+  A.quotientOfLeRadicalMk A.radical le_rfl
+
+/-- The quotient pairing is represented by the original pairing on representatives. -/
+@[simp]
+theorem radicalQuotient_pairing_mk (x y : A) :
+    (radicalQuotient A).pairing (radicalQuotientMk A x) (radicalQuotientMk A y) =
+      A.pairing x y :=
+  A.quotientOfLeRadical_pairing_mk A.radical le_rfl x y
+
+/-- The quotient map to the radical quotient is surjective. -/
+theorem radicalQuotientMk_surjective : Function.Surjective (radicalQuotientMk A) :=
+  A.quotientOfLeRadicalMk_surjective A.radical le_rfl
+
+/-- The kernel of the radical quotient map is the radical. -/
+@[simp]
+theorem radicalQuotientMk_ker : (radicalQuotientMk A).ker = A.radical :=
+  A.quotientOfLeRadicalMk_ker A.radical le_rfl
+
+/-- Quotienting a finite bilinear module by its radical produces a nondegenerate module. -/
+theorem isNondegenerate_radicalQuotient : (radicalQuotient A).IsNondegenerate :=
+  (A.isNondegenerate_quotientOfLeRadical_iff A.radical le_rfl).mpr le_rfl
+
+end TauCeti.FiniteBilinearModule

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/RadicalQuotient.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/RadicalQuotient.lean
@@ -36,6 +36,8 @@ Both `quotientOfLeRadical` and `radicalQuotient` are exposed, so their carriers 
   exactly when the subgroup exhausts the radical.
 * `TauCeti.FiniteBilinearModule.card_quotientOfLeRadical`: the order of the quotient is the index
   of the subgroup.
+* `TauCeti.FiniteBilinearModule.quotientOfLeRadicalMk_eq_iff`: two elements have the same class
+  exactly when they differ by an element of the subgroup.
 * `TauCeti.FiniteBilinearModule.radicalQuotient`: the nondegenerate quotient by the radical.
 
 ## References
@@ -144,6 +146,13 @@ theorem quotientOfLeRadicalMk_eq_zero_iff (K : AddSubgroup A) (hK : K ≤ A.radi
     A.quotientOfLeRadicalMk K hK x = 0 ↔ x ∈ K := by
   rw [← AddMonoidHom.mem_ker, A.quotientOfLeRadicalMk_ker K hK]
 
+/-- Two elements have the same class in the quotient exactly when they differ by an element of the
+subgroup. -/
+@[simp]
+theorem quotientOfLeRadicalMk_eq_iff (K : AddSubgroup A) (hK : K ≤ A.radical) (x y : A) :
+    A.quotientOfLeRadicalMk K hK x = A.quotientOfLeRadicalMk K hK y ↔ x - y ∈ K := by
+  rw [← sub_eq_zero, ← map_sub, A.quotientOfLeRadicalMk_eq_zero_iff K hK]
+
 /-- **The radical of the quotient** is the image of the radical: quotienting by a subgroup of the
 radical does not create new degeneracy. -/
 theorem radical_quotientOfLeRadical (K : AddSubgroup A) (hK : K ≤ A.radical) :
@@ -210,6 +219,13 @@ theorem radicalQuotientMk_surjective : Function.Surjective (radicalQuotientMk A)
 @[simp]
 theorem radicalQuotientMk_ker : (radicalQuotientMk A).ker = A.radical :=
   A.quotientOfLeRadicalMk_ker A.radical le_rfl
+
+/-- Two elements have the same class in the radical quotient exactly when they differ by an
+element of the radical. -/
+@[simp]
+theorem radicalQuotientMk_eq_iff (x y : A) :
+    A.radicalQuotientMk x = A.radicalQuotientMk y ↔ x - y ∈ A.radical :=
+  A.quotientOfLeRadicalMk_eq_iff A.radical le_rfl x y
 
 /-- Quotienting a finite bilinear module by its radical produces a nondegenerate module. -/
 theorem isNondegenerate_radicalQuotient : (radicalQuotient A).IsNondegenerate :=


### PR DESCRIPTION
Splits the prerequisite refactor out of #3805, as the `scope` review asked:

> the PR bundles a self-contained prerequisite refactor — extracting and generalizing `radicalQuotient` to `quotientOfLeRadical` in a new file — with the new mathematics; split it.

This PR is that refactor on its own. #3805 will be rebased onto it and keep only the new mathematics.

## What changes

`radicalQuotient` lived in `OrthogonalComplement.lean`, and it was one instance of a more general construction. A subgroup `K` of the radical pairs trivially with everything, so the pairing descends to `A / K` for **any** such `K`, not only for `K = rad(A)`:

```text
b (x + K) (y + K) = b x y.
```

This moves the construction into a new `FiniteBilinearModule/RadicalQuotient.lean` and states it at that generality:

* `quotientOfLeRadical (K) (hK : K ≤ A.radical)` — the quotient module, with `quotientOfLeRadicalMk`, the representative formula, surjectivity, the kernel, and the vanishing criterion.
* `radical_quotientOfLeRadical` — the radical of the quotient is the image of `rad(A)`.
* `isNondegenerate_quotientOfLeRadical_iff` — the quotient is nondegenerate exactly when `K` exhausts the radical.
* `card_quotientOfLeRadical` — the order of the quotient is the index of `K`.
* `radicalQuotient` is redefined as the case `K = rad(A)`.

## No public API change

`radicalQuotient_pairing_mk`, `radicalQuotientMk_surjective`, `radicalQuotientMk_ker` and `isNondegenerate_radicalQuotient` keep their statements verbatim; they now derive from the general lemmas instead of carrying their own proofs. `OrthogonalComplement.lean` is the one consumer of this API in the repo — `orthogonalComplement_map_radicalQuotient` and the double-complement formula use it — and it `public import`s the new module, so it and everything downstream of it are untouched. (`IntegralLattice.radicalQuotient` is a separate, unrelated declaration and is not affected.)

The old `private` helpers (`radical_toIntSubmodule_le_ker`, `RadicalQuotient`, `radicalQuotientBilin`) are replaced by their general counterparts. `quotientOfLeRadicalBilin` stays public-but-opaque: only its name needs to be public, since the exposed body of `quotientOfLeRadical` mentions it.

## On `card_quotientOfLeRadical`

Its only consumer is the orthogonal quotient in #3805, which the split moves to the follow-up PR. It is stated here rather than there because it is a general fact about `quotientOfLeRadical` with no reference to orthogonal complements, so `RadicalQuotient.lean` is where it belongs. Every other declaration added here is used within this file.

`lake build` is green (8687 jobs, no errors or warnings) and `lake exe axioms` is green (62021 declarations audited, allowlist only).

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"finite-bilinear-quotient-of-le-radical"}-->
