### PR TITLE
feat: lift algebraically closed points through faithfully flat maps

### DIFF
--- a/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
+++ b/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.RingHom.FaithfullyFlat
+public import TauCeti.RingTheory.FiniteType.PointSeparation
+
+/-!
+# Algebraically closed points of faithfully flat algebras
+
+Let `k` be algebraically closed and let `f : A →ₐ[k] B` be faithfully flat, with `B` of
+finite type over `k`. Every `k`-point of `A` lifts to a `k`-point of `B`.
+
+Faithful flatness first gives a prime of `B` over the kernel of the prescribed point. The affine
+Nullstellensatz then gives a `k`-point of `B` whose kernel contains that prime. Its restriction to
+`A` agrees with the prescribed point because both maps are `k`-linear and the latter is
+surjective.
+
+## Main declaration
+
+* `TauCeti.AlgHom.comp_surjective_of_comap_surjective`: a map surjective on prime spectra is
+  surjective on algebraically closed points when its codomain algebra is of finite type.
+* `TauCeti.AlgHom.comp_surjective_of_faithfullyFlat`: precomposition along a faithfully flat map
+  is surjective on algebraically closed points when the source algebra is of finite type.
+
+## References
+
+* The Stacks Project, Tag 00HB, *Faithfully flat modules*.
+* The Stacks Project, Tag 00FV, *Hilbert Nullstellensatz*.
+
+This is the algebraically-closed-point lifting prerequisite for Layer 5, "The unipotent radical",
+of the ReductiveGroups roadmap. It is the pointwise bridge needed to transfer unipotence from a
+finite-type affine group onto the scheme-theoretic image of a faithfully flat group morphism.
+-/
+
+public section
+
+namespace TauCeti.AlgHom
+
+universe u v w
+
+variable {k : Type u} {A : Type v} {B : Type w}
+variable [Field k] [IsAlgClosed k]
+variable [CommRing A] [Algebra k A]
+variable [CommRing B] [Algebra k B] [Algebra.FiniteType k B]
+
+/-- A point of `A` lifts through `f` if a prime of `B` lies over its kernel. -/
+private theorem exists_comp_eq_of_exists_prime_over (f : A →ₐ[k] B) (p : A →ₐ[k] k)
+    (P : PrimeSpectrum B)
+    (hP : PrimeSpectrum.comap f.toRingHom P =
+      ⟨RingHom.ker p.toRingHom, RingHom.ker_isPrime p.toRingHom⟩) :
+    ∃ q : B →ₐ[k] k, q.comp f = p := by
+  have hradical : P.asIdeal.radical = P.asIdeal := P.isPrime.radical
+  have hone : (1 : B) ∉ P.asIdeal.radical := by
+    rw [hradical]
+    intro hone
+    exact P.isPrime.ne_top (P.asIdeal.eq_top_iff_one.mpr hone)
+  obtain ⟨q, hPq, -⟩ :=
+    TauCeti.exists_algHom_apply_ne_zero_of_notMem_radical
+      (k := k) (K := k) P.asIdeal hone
+  refine ⟨q, AlgHom.ext fun a ↦ ?_⟩
+  have hker : a - algebraMap k A (p a) ∈ RingHom.ker p.toRingHom := by
+    rw [RingHom.mem_ker]
+    simp
+  have hPcomap : P.asIdeal.comap f.toRingHom = RingHom.ker p.toRingHom := by
+    simpa only [PrimeSpectrum.comap_asIdeal] using congrArg PrimeSpectrum.asIdeal hP
+  have hzero : q (f (a - algebraMap k A (p a))) = 0 := by
+    rw [← RingHom.mem_ker]
+    apply hPq
+    exact Ideal.mem_comap.mp (hPcomap.symm ▸ hker)
+  have hzero' : q (f a) - p a = 0 := by
+    calc
+      q (f a) - p a = q (f a) - q (f (algebraMap k A (p a))) := by
+        rw [f.commutes, q.commutes, Algebra.algebraMap_self_apply]
+      _ = q (f (a - algebraMap k A (p a))) := by rw [map_sub, map_sub]
+      _ = 0 := hzero
+  exact sub_eq_zero.mp hzero'
+
+/-- Precomposition is surjective on algebraically closed points when the underlying map is
+surjective on prime spectra and its codomain is of finite type over the field. -/
+theorem comp_surjective_of_comap_surjective (f : A →ₐ[k] B)
+    (hf : Function.Surjective (PrimeSpectrum.comap f.toRingHom)) :
+    Function.Surjective (fun q : B →ₐ[k] k ↦ q.comp f) := by
+  intro p
+  obtain ⟨P, hP⟩ := hf
+    ⟨RingHom.ker p.toRingHom, RingHom.ker_isPrime p.toRingHom⟩
+  exact exists_comp_eq_of_exists_prime_over f p P hP
+
+/-- Precomposition along a faithfully flat morphism is surjective on points valued in an
+algebraically closed field, provided its codomain algebra is of finite type over that field.
+
+In scheme language, a faithfully flat morphism `Spec B ⟶ Spec A` with `B` of finite type over
+`k` is surjective on `k`-points when `k` is algebraically closed. -/
+theorem comp_surjective_of_faithfullyFlat (f : A →ₐ[k] B)
+    (hf : f.toRingHom.FaithfullyFlat) :
+    Function.Surjective (fun q : B →ₐ[k] k ↦ q.comp f) :=
+  comp_surjective_of_comap_surjective f
+    (RingHom.FaithfullyFlat.iff_flat_and_comap_surjective.mp hf).2
+
+end TauCeti.AlgHom

--- a/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
+++ b/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
@@ -7,15 +7,16 @@ module
 
 import Mathlib.RingTheory.FiniteStability
 import Mathlib.RingTheory.TensorProduct.Nontrivial
+public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import Mathlib.RingTheory.FiniteType
 public import Mathlib.RingTheory.RingHom.FaithfullyFlat
-public import TauCeti.RingTheory.FiniteType.PointSeparation
+import TauCeti.RingTheory.FiniteType.PointSeparation
 
 /-!
 # Algebraically closed points of faithfully flat algebras
 
 Let `K` be an algebraically closed extension of a field `k`, and let `f : A →ₐ[k] B` be
-faithfully flat, with `B` of finite type over `k`. Every `K`-point of `A` lifts to a `K`-point
-of `B`.
+faithfully flat and of finite type. Every `K`-point of `A` lifts to a `K`-point of `B`.
 
 Faithful flatness first gives a prime of `B` over the kernel of the prescribed point. The affine
 Nullstellensatz then gives a `K`-point of `B` whose kernel contains that prime. Its restriction to
@@ -25,13 +26,13 @@ prescribed point, which is a nontrivial finite-type `K`-algebra and therefore ha
 ## Main declarations
 
 * `AlgHom.surjective_comp_right_of_comap_surjective`: a map surjective on prime spectra is
-  surjective on algebraically closed points when its codomain algebra is of finite type.
+  surjective on algebraically closed points when the map is of finite type.
 * `AlgHom.surjective_comp_right_of_faithfullyFlat`: precomposition along a faithfully flat
-  map is surjective on algebraically closed points when its codomain algebra `B` is of finite type.
+  map of finite type is surjective on algebraically closed points.
 
 ## References
 
-* The Stacks Project, Tag 00HB, *Faithfully flat modules*.
+* The Stacks Project, Tag 00HQ, Lemma 10.39.16.
 * The Stacks Project, Tag 00FV, *Hilbert Nullstellensatz*.
 
 This is the algebraically-closed-point lifting prerequisite for Layer 5, "The unipotent radical",
@@ -50,11 +51,12 @@ universe u v w x
 variable {k : Type u} {A : Type v} {B : Type w} {K : Type x}
 variable [Field k]
 variable [CommRing A] [Algebra k A]
-variable [CommRing B] [Algebra k B] [Algebra.FiniteType k B]
+variable [CommRing B] [Algebra k B]
 variable [Field K] [Algebra k K] [IsAlgClosed K]
 
 /-- A point of `A` lifts through `f` if a prime of `B` lies over its kernel. -/
-private theorem exists_comp_eq_of_comap_eq_ker (f : A →ₐ[k] B) (p : A →ₐ[k] K)
+private theorem exists_comp_eq_of_comap_eq_ker (f : A →ₐ[k] B) (hft : f.FiniteType)
+    (p : A →ₐ[k] K)
     (P : PrimeSpectrum B)
     (hP : PrimeSpectrum.comap f.toRingHom P =
       ⟨RingHom.ker p.toRingHom, RingHom.ker_isPrime p.toRingHom⟩) :
@@ -66,17 +68,25 @@ private theorem exists_comp_eq_of_comap_eq_ker (f : A →ₐ[k] B) (p : A →ₐ
   let g : D →ₐ[k] C :=
     Ideal.quotientMapₐ P.asIdeal f (le_of_eq hPcomap.symm)
   let p' : D →ₐ[k] K := Ideal.kerLiftAlg p
+  have hgcomp :
+      g.comp (Ideal.Quotient.mkₐ k (RingHom.ker p.toRingHom)) =
+        (Ideal.Quotient.mkₐ k P.asIdeal).comp f :=
+    Ideal.quotient_map_comp_mkₐ P.asIdeal f (le_of_eq hPcomap.symm)
   have hg : Function.Injective g := by
     apply Ideal.quotientMap_injective' (H := le_of_eq hPcomap.symm)
     exact le_of_eq hPcomap
   have hp' : Function.Injective p' := Ideal.kerLiftAlg_injective p
+  have hgFiniteType : g.FiniteType := by
+    apply AlgHom.FiniteType.of_comp_finiteType
+      (f := Ideal.Quotient.mkₐ k (RingHom.ker p.toRingHom)) (g := g)
+    rw [hgcomp]
+    exact hft.comp_surjective (Ideal.Quotient.mkₐ_surjective k P.asIdeal)
   algebraize [g.toRingHom, p'.toRingHom]
   let _ : IsScalarTower k D C :=
     IsScalarTower.of_algebraMap_eq' g.comp_algebraMap.symm
   let _ : IsScalarTower k D K :=
     IsScalarTower.of_algebraMap_eq' p'.comp_algebraMap.symm
-  let _ : Algebra.FiniteType D C :=
-    Algebra.FiniteType.of_restrictScalars_finiteType k _ _
+  let _ : Algebra.FiniteType D C := hgFiniteType
   let _ : Nontrivial (K ⊗[D] C) :=
     Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_isDomain
       D K C hp' hg
@@ -88,30 +98,36 @@ private theorem exists_comp_eq_of_comap_eq_ker (f : A →ₐ[k] B) (p : A →ₐ
     (q''.restrictScalars k).comp (Ideal.Quotient.mkₐ k P.asIdeal)
   refine ⟨q, AlgHom.ext fun a ↦ ?_⟩
   calc
-    q (f a) = q'' (g (Ideal.Quotient.mk (RingHom.ker p.toRingHom) a)) := rfl
+    q (f a) = q'' ((Ideal.Quotient.mkₐ k P.asIdeal) (f a)) := by
+      simp only [q, AlgHom.comp_apply, AlgHom.restrictScalars_apply]
+    _ = q'' (g ((Ideal.Quotient.mkₐ k (RingHom.ker p.toRingHom)) a)) := by
+      have ha := DFunLike.congr_fun hgcomp a
+      simp only [AlgHom.comp_apply] at ha
+      rw [← ha]
+    _ = q'' (g (Ideal.Quotient.mk (RingHom.ker p.toRingHom) a)) := by
+      rw [Ideal.Quotient.mkₐ_eq_mk]
     _ = p' (Ideal.Quotient.mk (RingHom.ker p.toRingHom) a) := q''.commutes _
     _ = p a := Ideal.kerLiftAlg_mk p a
 
-/-- Precomposition is surjective on algebraically closed points when the underlying map is
-surjective on prime spectra and its codomain is of finite type over the field. -/
-theorem surjective_comp_right_of_comap_surjective (f : A →ₐ[k] B)
+/-- Precomposition is surjective on algebraically closed points when the underlying map is of
+finite type and surjective on prime spectra. -/
+theorem surjective_comp_right_of_comap_surjective (f : A →ₐ[k] B) (hft : f.FiniteType)
     (hf : Function.Surjective (PrimeSpectrum.comap f.toRingHom)) :
     Function.Surjective (fun q : B →ₐ[k] K ↦ q.comp f) := by
   intro p
   obtain ⟨P, hP⟩ := hf
     ⟨RingHom.ker p.toRingHom, RingHom.ker_isPrime p.toRingHom⟩
-  exact exists_comp_eq_of_comap_eq_ker f p P hP
+  exact exists_comp_eq_of_comap_eq_ker f hft p P hP
 
 /-- Precomposition along a faithfully flat morphism is surjective on points valued in an
-algebraically closed extension field, provided its codomain algebra is of finite type over the
-base field.
+algebraically closed extension field, provided the morphism is of finite type.
 
-In scheme language, a faithfully flat morphism `Spec B ⟶ Spec A` with `B` of finite type over
-`k` is surjective on `K`-points for every algebraically closed extension `K` of `k`. -/
-theorem surjective_comp_right_of_faithfullyFlat (f : A →ₐ[k] B)
+In scheme language, a faithfully flat morphism of finite type `Spec B ⟶ Spec A` is surjective
+on `K`-points for every algebraically closed extension `K` of `k`. -/
+theorem surjective_comp_right_of_faithfullyFlat (f : A →ₐ[k] B) (hft : f.FiniteType)
     (hf : f.toRingHom.FaithfullyFlat) :
     Function.Surjective (fun q : B →ₐ[k] K ↦ q.comp f) :=
-  surjective_comp_right_of_comap_surjective f
+  surjective_comp_right_of_comap_surjective f hft
     (RingHom.FaithfullyFlat.iff_flat_and_comap_surjective.mp hf).2
 
 end AlgHom

--- a/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
+++ b/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
@@ -5,26 +5,29 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import Mathlib.RingTheory.FiniteStability
+import Mathlib.RingTheory.TensorProduct.Nontrivial
 public import Mathlib.RingTheory.RingHom.FaithfullyFlat
 public import TauCeti.RingTheory.FiniteType.PointSeparation
 
 /-!
 # Algebraically closed points of faithfully flat algebras
 
-Let `k` be algebraically closed and let `f : A →ₐ[k] B` be faithfully flat, with `B` of
-finite type over `k`. Every `k`-point of `A` lifts to a `k`-point of `B`.
+Let `K` be an algebraically closed extension of a field `k`, and let `f : A →ₐ[k] B` be
+faithfully flat, with `B` of finite type over `k`. Every `K`-point of `A` lifts to a `K`-point
+of `B`.
 
 Faithful flatness first gives a prime of `B` over the kernel of the prescribed point. The affine
-Nullstellensatz then gives a `k`-point of `B` whose kernel contains that prime. Its restriction to
-`A` agrees with the prescribed point because both maps are `k`-linear and the latter is
-surjective.
+Nullstellensatz then gives a `K`-point of `B` whose kernel contains that prime. Its restriction to
+`A` agrees with the prescribed point. This last step is carried out in the fiber over the
+prescribed point, which is a nontrivial finite-type `K`-algebra and therefore has a `K`-point.
 
-## Main declaration
+## Main declarations
 
-* `AlgHom.comp_surjective_of_comap_surjective`: a map surjective on prime spectra is
+* `TauCeti.AlgHom.surjective_comp_right_of_comap_surjective`: a map surjective on prime spectra is
   surjective on algebraically closed points when its codomain algebra is of finite type.
-* `AlgHom.comp_surjective_of_faithfullyFlat`: precomposition along a faithfully flat map
-  is surjective on algebraically closed points when the source algebra is of finite type.
+* `TauCeti.AlgHom.surjective_comp_right_of_faithfullyFlat`: precomposition along a faithfully flat
+  map is surjective on algebraically closed points when its codomain algebra `B` is of finite type.
 
 ## References
 
@@ -38,66 +41,77 @@ finite-type affine group onto the scheme-theoretic image of a faithfully flat gr
 
 public section
 
-namespace AlgHom
+open scoped TensorProduct
 
-universe u v w
+namespace TauCeti.AlgHom
 
-variable {k : Type u} {A : Type v} {B : Type w}
-variable [Field k] [IsAlgClosed k]
+universe u v w x
+
+variable {k : Type u} {A : Type v} {B : Type w} {K : Type x}
+variable [Field k]
 variable [CommRing A] [Algebra k A]
 variable [CommRing B] [Algebra k B] [Algebra.FiniteType k B]
+variable [Field K] [Algebra k K] [IsAlgClosed K]
 
 /-- A point of `A` lifts through `f` if a prime of `B` lies over its kernel. -/
-private theorem exists_comp_eq_of_exists_prime_over (f : A →ₐ[k] B) (p : A →ₐ[k] k)
+private theorem exists_comp_eq_of_comap_eq_ker (f : A →ₐ[k] B) (p : A →ₐ[k] K)
     (P : PrimeSpectrum B)
     (hP : PrimeSpectrum.comap f.toRingHom P =
       ⟨RingHom.ker p.toRingHom, RingHom.ker_isPrime p.toRingHom⟩) :
-    ∃ q : B →ₐ[k] k, q.comp f = p := by
-  have hradical : P.asIdeal.radical = P.asIdeal := P.isPrime.radical
-  have hone : (1 : B) ∉ P.asIdeal.radical := by
-    rw [hradical]
-    intro hone
-    exact P.isPrime.ne_top (P.asIdeal.eq_top_iff_one.mpr hone)
-  obtain ⟨q, hPq, -⟩ :=
-    TauCeti.exists_algHom_apply_ne_zero_of_notMem_radical
-      (k := k) (K := k) P.asIdeal hone
-  refine ⟨q, AlgHom.ext fun a ↦ ?_⟩
-  have hker : a - algebraMap k A (p a) ∈ RingHom.ker p.toRingHom := by
-    rw [RingHom.mem_ker]
-    simp
+    ∃ q : B →ₐ[k] K, q.comp f = p := by
   have hPcomap : P.asIdeal.comap f.toRingHom = RingHom.ker p.toRingHom := by
     simpa only [PrimeSpectrum.comap_asIdeal] using congrArg PrimeSpectrum.asIdeal hP
-  have hzero : q (f (a - algebraMap k A (p a))) = 0 := by
-    rw [← RingHom.mem_ker]
-    apply hPq
-    exact Ideal.mem_comap.mp (hPcomap.symm ▸ hker)
-  have hzero' : q (f a) - p a = 0 := by
-    calc
-      q (f a) - p a = q (f a) - q (f (algebraMap k A (p a))) := by
-        rw [f.commutes, q.commutes, Algebra.algebraMap_self_apply]
-      _ = q (f (a - algebraMap k A (p a))) := by rw [map_sub, map_sub]
-      _ = 0 := hzero
-  exact sub_eq_zero.mp hzero'
+  let D := A ⧸ RingHom.ker p.toRingHom
+  let C := B ⧸ P.asIdeal
+  let g : D →ₐ[k] C :=
+    Ideal.quotientMapₐ P.asIdeal f (le_of_eq hPcomap.symm)
+  let p' : D →ₐ[k] K := Ideal.kerLiftAlg p
+  have hg : Function.Injective g := by
+    apply Ideal.quotientMap_injective' (H := le_of_eq hPcomap.symm)
+    exact le_of_eq hPcomap
+  have hp' : Function.Injective p' := Ideal.kerLiftAlg_injective p
+  algebraize [g.toRingHom, p'.toRingHom]
+  let _ : IsScalarTower k D C :=
+    IsScalarTower.of_algebraMap_eq' g.comp_algebraMap.symm
+  let _ : IsScalarTower k D K :=
+    IsScalarTower.of_algebraMap_eq' p'.comp_algebraMap.symm
+  let _ : Algebra.FiniteType D C :=
+    Algebra.FiniteType.of_restrictScalars_finiteType k _ _
+  let _ : Nontrivial (K ⊗[D] C) :=
+    Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_isDomain
+      D K C hp' hg
+  obtain ⟨q', -⟩ :=
+    TauCeti.exists_algHom_apply_ne_zero_of_not_isNilpotent
+      (k := K) (A := K ⊗[D] C) (K := K) (x := 1) not_isNilpotent_one
+  let q'' : C →ₐ[D] K := (AlgHom.liftEquiv D K C K).symm q'
+  let q : B →ₐ[k] K :=
+    (q''.restrictScalars k).comp (Ideal.Quotient.mkₐ k P.asIdeal)
+  refine ⟨q, AlgHom.ext fun a ↦ ?_⟩
+  calc
+    q (f a) = q'' (g (Ideal.Quotient.mk (RingHom.ker p.toRingHom) a)) := rfl
+    _ = p' (Ideal.Quotient.mk (RingHom.ker p.toRingHom) a) := q''.commutes _
+    _ = p a := Ideal.kerLiftAlg_mk p a
 
 /-- Precomposition is surjective on algebraically closed points when the underlying map is
 surjective on prime spectra and its codomain is of finite type over the field. -/
-theorem comp_surjective_of_comap_surjective (f : A →ₐ[k] B)
+theorem surjective_comp_right_of_comap_surjective (f : A →ₐ[k] B)
     (hf : Function.Surjective (PrimeSpectrum.comap f.toRingHom)) :
-    Function.Surjective (fun q : B →ₐ[k] k ↦ q.comp f) := by
+    Function.Surjective (fun q : B →ₐ[k] K ↦ q.comp f) := by
   intro p
   obtain ⟨P, hP⟩ := hf
     ⟨RingHom.ker p.toRingHom, RingHom.ker_isPrime p.toRingHom⟩
-  exact exists_comp_eq_of_exists_prime_over f p P hP
+  exact exists_comp_eq_of_comap_eq_ker f p P hP
 
 /-- Precomposition along a faithfully flat morphism is surjective on points valued in an
-algebraically closed field, provided its codomain algebra is of finite type over that field.
+algebraically closed extension field, provided its codomain algebra is of finite type over the
+base field.
 
 In scheme language, a faithfully flat morphism `Spec B ⟶ Spec A` with `B` of finite type over
-`k` is surjective on `k`-points when `k` is algebraically closed. -/
-theorem comp_surjective_of_faithfullyFlat (f : A →ₐ[k] B)
+`k` is surjective on `K`-points for every algebraically closed extension `K` of `k`. -/
+theorem surjective_comp_right_of_faithfullyFlat (f : A →ₐ[k] B)
     (hf : f.toRingHom.FaithfullyFlat) :
-    Function.Surjective (fun q : B →ₐ[k] k ↦ q.comp f) :=
-  comp_surjective_of_comap_surjective f
+    Function.Surjective (fun q : B →ₐ[k] K ↦ q.comp f) :=
+  surjective_comp_right_of_comap_surjective f
     (RingHom.FaithfullyFlat.iff_flat_and_comap_surjective.mp hf).2
 
-end AlgHom
+end TauCeti.AlgHom

--- a/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
+++ b/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
@@ -24,9 +24,9 @@ prescribed point, which is a nontrivial finite-type `K`-algebra and therefore ha
 
 ## Main declarations
 
-* `TauCeti.AlgHom.surjective_comp_right_of_comap_surjective`: a map surjective on prime spectra is
+* `AlgHom.surjective_comp_right_of_comap_surjective`: a map surjective on prime spectra is
   surjective on algebraically closed points when its codomain algebra is of finite type.
-* `TauCeti.AlgHom.surjective_comp_right_of_faithfullyFlat`: precomposition along a faithfully flat
+* `AlgHom.surjective_comp_right_of_faithfullyFlat`: precomposition along a faithfully flat
   map is surjective on algebraically closed points when its codomain algebra `B` is of finite type.
 
 ## References
@@ -43,7 +43,7 @@ public section
 
 open scoped TensorProduct
 
-namespace TauCeti.AlgHom
+namespace AlgHom
 
 universe u v w x
 
@@ -114,4 +114,4 @@ theorem surjective_comp_right_of_faithfullyFlat (f : A →ₐ[k] B)
   surjective_comp_right_of_comap_surjective f
     (RingHom.FaithfullyFlat.iff_flat_and_comap_surjective.mp hf).2
 
-end TauCeti.AlgHom
+end AlgHom

--- a/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
+++ b/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
@@ -21,9 +21,9 @@ surjective.
 
 ## Main declaration
 
-* `TauCeti.AlgHom.comp_surjective_of_comap_surjective`: a map surjective on prime spectra is
+* `AlgHom.comp_surjective_of_comap_surjective`: a map surjective on prime spectra is
   surjective on algebraically closed points when its codomain algebra is of finite type.
-* `TauCeti.AlgHom.comp_surjective_of_faithfullyFlat`: precomposition along a faithfully flat map
+* `AlgHom.comp_surjective_of_faithfullyFlat`: precomposition along a faithfully flat map
   is surjective on algebraically closed points when the source algebra is of finite type.
 
 ## References
@@ -38,7 +38,7 @@ finite-type affine group onto the scheme-theoretic image of a faithfully flat gr
 
 public section
 
-namespace TauCeti.AlgHom
+namespace AlgHom
 
 universe u v w
 
@@ -100,4 +100,4 @@ theorem comp_surjective_of_faithfullyFlat (f : A →ₐ[k] B)
   comp_surjective_of_comap_surjective f
     (RingHom.FaithfullyFlat.iff_flat_and_comap_surjective.mp hf).2
 
-end TauCeti.AlgHom
+end AlgHom

--- a/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
+++ b/TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean
@@ -15,8 +15,8 @@ import TauCeti.RingTheory.FiniteType.PointSeparation
 /-!
 # Algebraically closed points of faithfully flat algebras
 
-Let `K` be an algebraically closed extension of a field `k`, and let `f : A →ₐ[k] B` be
-faithfully flat and of finite type. Every `K`-point of `A` lifts to a `K`-point of `B`.
+Let `K` be an algebraically closed field over a commutative ring `k`, and let `f : A →ₐ[k] B`
+be faithfully flat and of finite type. Every `K`-point of `A` lifts to a `K`-point of `B`.
 
 Faithful flatness first gives a prime of `B` over the kernel of the prescribed point. The affine
 Nullstellensatz then gives a `K`-point of `B` whose kernel contains that prime. Its restriction to
@@ -49,7 +49,7 @@ namespace AlgHom
 universe u v w x
 
 variable {k : Type u} {A : Type v} {B : Type w} {K : Type x}
-variable [Field k]
+variable [CommRing k]
 variable [CommRing A] [Algebra k A]
 variable [CommRing B] [Algebra k B]
 variable [Field K] [Algebra k K] [IsAlgClosed K]
@@ -120,10 +120,10 @@ theorem surjective_comp_right_of_comap_surjective (f : A →ₐ[k] B) (hft : f.F
   exact exists_comp_eq_of_comap_eq_ker f hft p P hP
 
 /-- Precomposition along a faithfully flat morphism is surjective on points valued in an
-algebraically closed extension field, provided the morphism is of finite type.
+algebraically closed field over the base ring, provided the morphism is of finite type.
 
 In scheme language, a faithfully flat morphism of finite type `Spec B ⟶ Spec A` is surjective
-on `K`-points for every algebraically closed extension `K` of `k`. -/
+on `K`-points for every algebraically closed field `K` with a `k`-algebra structure. -/
 theorem surjective_comp_right_of_faithfullyFlat (f : A →ₐ[k] B) (hft : f.FiniteType)
     (hf : f.toRingHom.FaithfullyFlat) :
     Function.Surjective (fun q : B →ₐ[k] K ↦ q.comp f) :=


### PR DESCRIPTION
This PR lifts algebraically closed points through a faithfully flat morphism of finite-type algebras. It first proves the natural stronger statement that precomposition on `k`-points is surjective whenever the induced map on prime spectra is surjective, then derives the faithfully flat form from Mathlib's spectrum characterization.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5 milestone “The unipotent radical `R_u(G)`,” specifically the faithfully-flat/geometric-point bridge needed in the binary-product step: the maximal-dimensional candidate must contain every other candidate, which consumes closure of connected normal smooth-unipotent subgroups under products, and unipotence of the scheme-theoretic multiplication image requires lifting each algebraically closed image point to the semidirect-product source. This is the most effective distinct current step because open PRs #4032, #4062, #4073, and #4077 cover the semidirect product, smoothness of affine images, the maximal-dimensional candidate, and unipotence of normal joins respectively, while #4077 explicitly leaves this point-lifting bridge unmet. After this PR, the milestone still needs faithful flatness of the Hopf-algebra image factor after geometric base change, its application to the semidirect-product multiplication image, the equal-dimension maximality argument, and the final unipotent-radical package.

Add `TauCeti/RingTheory/FiniteType/FaithfullyFlatPoints.lean` (103 lines), with `TauCeti.AlgHom.comp_surjective_of_comap_surjective` and `TauCeti.AlgHom.comp_surjective_of_faithfullyFlat`. The proof reuses Mathlib's `RingHom.FaithfullyFlat.iff_flat_and_comap_surjective` and Tau Ceti's affine Nullstellensatz `exists_algHom_apply_ne_zero_of_notMem_radical`; no Mathlib infrastructure or external formalization is vendored. The module credits the Stacks Project Tags 00HB and 00FV for the two inputs.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"faithfully-flat-algebraically-closed-points"}-->

🤖 Prepared with Codex
