### PR TITLE
feat(EllipticCurve): torsion points of a Weierstrass curve are integral

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Torsion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Torsion.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Degree
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Eval
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.ZSMul
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Integrality
+-- Not `public`: `evalEval_ψ₂_sq` is used only inside `den_dvd_four_of_order_two`'s proof,
+-- so importers of this file have no reason to see `Discriminant`.
+import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Discriminant
+
+/-!
+# Integrality of torsion away from order two, under a squarefree hypothesis
+
+The Nagell–Lutz statement is that a torsion point of an integral Weierstrass model has integral
+coordinates. **This file does not prove that.** It proves the cases a squarefree hypothesis makes
+accessible — an `n`-torsion point for odd `n` with `(n : R)` squarefree, or for even `n` with
+`(n / 2 : R)` squarefree provided the point is not itself two-torsion — over an arbitrary unique
+factorisation domain `R` with fraction field `K` rather than only over `ℤ/ℚ`. Order two is
+genuinely excluded: such a point need not be integral, and what is proved instead is the
+denominator bound `den(x) ∣ 4`.
+
+The bridge from the group law to polynomials is `ZSMul.lean`'s
+`evalEval_ψ_eq_zero_of_zsmul_eq_zero`: if
+`n • P = 0` then `ψₙ` vanishes at `P`. That turns a torsion hypothesis into a polynomial root,
+and the root feeds `isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff` from
+`EllipticCurve/Integrality.lean`, whose squarefree-leading-coefficient hypothesis is supplied by
+Mathlib's `leadingCoeff_preΨ` (`= n` for odd `n` and `= n / 2` for even `n`) and
+`leadingCoeff_Ψ₂Sq` (`= 4`). Only the `x`-coordinate is stated: `y` is then integral by
+`Integrality.lean`'s `isInteger_y_of_equation_of_isInteger_x`, which needs nothing about torsion.
+
+## Main results
+
+* `WeierstrassCurve.isInteger_x_of_odd_torsion_of_squarefree`: for an **odd** `n` with `(n : R)`
+  squarefree, an `n`-torsion point has integral `x`. The odd-prime case the Nagell–Lutz route
+  quotes is the specialisation `n = p`; primality is not used.
+* `WeierstrassCurve.isInteger_x_of_even_torsion_of_squarefree`: for an **even** `n` with
+  `(n / 2 : R)` squarefree and `(2 : R) ≠ 0`, an `n`-torsion point that is not two-torsion has
+  integral `x`. `WeierstrassCurve.isInteger_x_of_order_four_of_squarefree` is the case `n = 4`,
+  where `4 / 2 = 2` collapses both arithmetic premises into `Squarefree (2 : R)`.
+* `WeierstrassCurve.den_dvd_four_of_order_two`: order two is the genuine exception — the
+  coordinates need not be integral, but the denominator of `x` divides `4`.
+
+## Roadmap
+
+New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
+Nagell–Lutz**", whose route is stated at `:830`–`:831` as "division polynomials". The roadmap asks
+for the theorem over `ℚ` for both integral models; these are the UFD-level statements that
+specialise to it.
+
+## Provenance
+
+Ported from J. Xu and D. K. Angdinata's
+`projects/NagellLutz/LutzNagell/LutzNagellTheorem/PIDPrimeOrder.lean` in AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`):
+`x_isInteger_of_odd_prime_torsion_squarefree`
+(`:118`), `two_nsmul_eq_zero_of_ψ₂_eq_zero` (`:143`), `integrality_of_order_four_squarefree`
+(`:156`) and `den_dvd_of_order_two` (`:183`). That file is byte-identical at `9fec8eba7652`, the
+revision the roadmap pins, so the citations hold at either.
+
+Its remaining two declarations are **already in this repository** and are called rather than
+restated: `isInteger_of_root_squarefree_leading_coeff` (`:88`) is `Integrality.lean`'s
+`isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff`, and
+`y_isInteger_of_x_isInteger_on_curve` (`:42`) is its `isInteger_y_of_equation_of_isInteger_x`.
+
+Five adaptations. The source's `curveK R K W` (`PIDCurve.lean:32`) is **not ported**: it is a bare
+abbreviation for `W.map (algebraMap R K)`, and Mathlib defines `W.baseChange K` to be exactly that
+— `rfl`-equal — so this file uses `baseChange`, matching `Integrality.lean` and `Denominator.lean`.
+Its companion `curveK_equation_iff` is then just `Affine.equation_iff` and is not needed at all.
+Two wrappers are likewise declined because this repository already carries both of their halves:
+`evalEval_ψ_odd` (`EvalBridge.lean:62`) is the one-line composite
+`(evalEval_ψ_eq_evalEval_Ψ …).trans (evalEval_Ψ_odd …)`, inlined here at its one call site; and
+`prime_order_integrality_squarefree` (`:205`) is the conjunction of
+`x_isInteger_of_odd_prime_torsion_squarefree` with `y_isInteger_of_x_isInteger_on_curve`, so
+callers pair `isInteger_x_of_odd_torsion_of_squarefree` with
+`isInteger_y_of_equation_of_isInteger_x` directly.
+The source's `evalEval_ψ_eq_zero_of_zsmul_eq_zero` (`:67`) is ported, but **into `ZSMul.lean`**
+rather than here: it is a field-level corollary of `zsmul_point_eq_smulEval` with no UFD content,
+so placing it beside its own input keeps consumers of the scalar-multiplication bridge from having
+to import this file. It also drops the source's `[DecidableEq F]`, which TauCeti's
+`zsmul_point_eq_smulEval` does not require. Finally the names are restated to describe their
+conclusions: `x_isInteger_of_odd_prime_torsion_squarefree` →
+`isInteger_x_of_odd_torsion_of_squarefree` (**generalised**: the source assumes an odd prime, but
+primality is used there only to rule out `n = 2`, so this holds for any odd index and covers odd
+composite torsion), `integrality_of_order_four_squarefree` →
+`isInteger_x_of_even_torsion_of_squarefree` (**generalised** the same way: the source's argument
+splits `ψ₄ = preΨ₄ * ψ₂` and reads off `leadingCoeff preΨ₄ = 2`, and `Ψ n = C (preΨ n) * ψ₂` with
+`leadingCoeff (preΨ n) = n / 2` runs it verbatim at every even index; the source's own index is
+kept as `isInteger_x_of_order_four_of_squarefree`), `den_dvd_of_order_two` →
+`den_dvd_four_of_order_two`, `two_nsmul_eq_zero_of_ψ₂_eq_zero` →
+`two_zsmul_eq_zero_of_evalEval_ψ₂_eq_zero`, restated for the Jacobian point so that the even-index
+theorem needs no `[DecidableEq K]`; that one carries no integrality content and lives in
+`DivisionPolynomial/ZSMul.lean`, which this file consumes.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve
+
+open TauCeti.WeierstrassCurve
+
+
+variable {R : Type*} [CommRing R] [IsDomain R] [UniqueFactorizationMonoid R]
+variable {K : Type*} [Field K] [DecidableEq K] [Algebra R K] [IsFractionRing R K]
+variable (W : WeierstrassCurve R)
+
+omit [DecidableEq K] in
+/-- For an **odd** `n` with `(n : R)` squarefree, an `n`-torsion point has integral
+`x`-coordinate.
+
+`ψₙ` vanishes at the point; for odd `n` that value is `preΨₙ` evaluated at `x` alone, whose
+leading coefficient is `n` — squarefree by hypothesis, which is what the rational-root argument
+in `Integrality.lean` needs.
+
+Oddness is the only arithmetic input: the source states this for an odd prime, but primality is
+used there solely to rule out `n = 2`, so odd composite torsion is covered by the same proof.
+The `y`-coordinate follows by `isInteger_y_of_equation_of_isInteger_x`. -/
+theorem isInteger_x_of_odd_torsion_of_squarefree {x y : K}
+    (hns : (W.baseChange K).toAffine.Nonsingular x y)
+    {n : ℤ} (hodd : ¬Even n)
+    (htors : n • (Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)) = 0)
+    (hsf : Squarefree (n : R)) : IsLocalization.IsInteger R x := by
+  have hψ := evalEval_ψ_eq_zero_of_zsmul_eq_zero (W.baseChange K) hns n htors
+  -- The source's `evalEval_ψ_odd` is this composition; only its two halves are ported here.
+  rw [(evalEval_ψ_eq_evalEval_Ψ (W.baseChange K) hns.left n).trans
+    (evalEval_Ψ_odd (W.baseChange K) n hodd)] at hψ
+  have hmap : (W.baseChange K).preΨ n = (W.preΨ n).map (algebraMap R K) :=
+    WeierstrassCurve.map_preΨ ..
+  rw [hmap, eval_map, ← aeval_def] at hψ
+  have hsf_lc : Squarefree (W.preΨ n).leadingCoeff := by
+    rw [W.leadingCoeff_preΨ hsf.ne_zero, ite_eq_right hodd]
+    exact hsf
+  exact isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff W hns.left hψ hsf_lc
+
+omit [DecidableEq K] in
+/-- For an **even** `n` with `(n / 2 : R)` squarefree, a point killed by `n` but **not** by `2`
+has integral `x`-coordinate.
+
+`ψₙ` vanishes at the point, and for even `n` it is `preΨₙ * ψ₂`; the second factor vanishing
+would make the point two-torsion, which `h2ne` excludes, so the first vanishes, and `preΨₙ` has
+leading coefficient `n / 2`. Excluding order two is not a technicality — a two-torsion point need
+not be integral at all, and `den_dvd_four_of_order_two` is everything that survives there.
+
+`h2` is needed on top of `hsf`: it is `n / 2` that is squarefree, and `(n : R) = 2 * (n / 2 : R)`
+is what the leading-coefficient formula asks to be nonzero. The `y`-coordinate follows by
+`isInteger_y_of_equation_of_isInteger_x`. -/
+theorem isInteger_x_of_even_torsion_of_squarefree {x y : K}
+    (hns : (W.baseChange K).toAffine.Nonsingular x y)
+    {n : ℤ} (heven : Even n)
+    (htors : n • (Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)) = 0)
+    (h2ne : (2 : ℤ) • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns) ≠ 0)
+    (h2 : (2 : R) ≠ 0) (hsf : Squarefree ((n / 2 : ℤ) : R)) :
+    IsLocalization.IsInteger R x := by
+  have hψ := evalEval_ψ_eq_zero_of_zsmul_eq_zero (W.baseChange K) hns n htors
+  rw [evalEval_ψ_eq_evalEval_Ψ (W.baseChange K) hns.left n, _root_.WeierstrassCurve.Ψ,
+    ite_eq_left heven, evalEval_mul, evalEval_C] at hψ
+  rcases mul_eq_zero.mp hψ with hpreΨ | hψ₂
+  · have hmap : (W.baseChange K).preΨ n = (W.preΨ n).map (algebraMap R K) :=
+      WeierstrassCurve.map_preΨ ..
+    rw [hmap, eval_map, ← aeval_def] at hpreΨ
+    have hn : (n : R) ≠ 0 := by
+      rw [← Int.two_mul_ediv_two_of_even heven]
+      push_cast
+      exact mul_ne_zero h2 hsf.ne_zero
+    have hsf_lc : Squarefree (W.preΨ n).leadingCoeff := by
+      rw [W.leadingCoeff_preΨ hn, ite_eq_left heven]
+      exact hsf
+    exact isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff W hns.left hpreΨ hsf_lc
+  · exact absurd (two_zsmul_eq_zero_of_evalEval_ψ₂_eq_zero (W.baseChange K) hns hψ₂) h2ne
+
+omit [DecidableEq K] in
+/-- **An order-four point is integral when `(2 : R)` is squarefree.** The index-four case of
+`isInteger_x_of_even_torsion_of_squarefree`, and the statement the Nagell–Lutz route quotes:
+`4 / 2 = 2`, so a single squarefree hypothesis carries both of that theorem's arithmetic
+premises. -/
+theorem isInteger_x_of_order_four_of_squarefree {x y : K}
+    (hns : (W.baseChange K).toAffine.Nonsingular x y)
+    (h4 : (4 : ℤ) • (Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)) = 0)
+    (h2ne : (2 : ℤ) • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns) ≠ 0)
+    (hsf : Squarefree (2 : R)) : IsLocalization.IsInteger R x :=
+  isInteger_x_of_even_torsion_of_squarefree W hns (by decide) h4 h2ne hsf.ne_zero
+    (by simpa using hsf)
+
+omit [DecidableEq K] in
+/-- **Order two is the exception, and its denominator divides `4`.** A two-torsion point need not
+have integral coordinates; `ψ₂` vanishing forces `Ψ₂Sq` to vanish at `x`, and that polynomial's
+leading coefficient is `4`. -/
+theorem den_dvd_four_of_order_two {x y : K}
+    (hns : (W.baseChange K).toAffine.Nonsingular x y)
+    (h2 : (2 : ℤ) • (Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)) = 0) :
+    (IsFractionRing.den R x : R) ∣ (4 : R) := by
+  -- In characteristic dividing `4` the statement is `_ ∣ 0`; the rational-root argument is only
+  -- needed when `Ψ₂Sq` actually has leading coefficient `4`.
+  rcases eq_or_ne (4 : R) 0 with h4 | h4_ne
+  · rw [h4]
+    exact dvd_zero _
+  have hψ := evalEval_ψ_eq_zero_of_zsmul_eq_zero (W.baseChange K) hns 2 h2
+  rw [WeierstrassCurve.ψ_two] at hψ
+  have hΨ_zero : (W.baseChange K).Ψ₂Sq.eval x = 0 := by
+    rw [← evalEval_ψ₂_sq (W.baseChange K) hns.left, hψ, zero_pow two_ne_zero]
+  have hmap : (W.baseChange K).Ψ₂Sq = W.Ψ₂Sq.map (algebraMap R K) :=
+    WeierstrassCurve.map_Ψ₂Sq ..
+  rw [hmap, eval_map, ← aeval_def] at hΨ_zero
+  have hdvd := den_dvd_of_is_root hΨ_zero
+  rwa [W.leadingCoeff_Ψ₂Sq h4_ne] at hdvd
+
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -112,6 +112,8 @@ is the statement the Nagell–Lutz layer consumes.
 * `WeierstrassCurve.zsmul_point_eq_smulEval`: **the headline**. Over a field, `n • (x, y)`
   in Jacobian
   coordinates is `(φₙ(x,y) : ωₙ(x,y) : ψₙ(x,y))`, for every nonsingular `(x, y)` and every `n`.
+* `WeierstrassCurve.two_zsmul_eq_zero_of_evalEval_ψ₂_eq_zero`: the converse at `n = 2` — a
+  vanishing `ψ₂` at a nonsingular point forces `2 • P = 0`.
 
 ## Provenance
 
@@ -1045,5 +1047,40 @@ theorem zsmul_point_eq_smulEval {x y : F} (h : Affine.Nonsingular W x y) (n : �
     refine Quotient.sound ⟨-1, ?_⟩
     simp_rw [smulEval_neg]
     rfl
+
+/-- If `ψ₂` vanishes at `(x, y)` then `2 • P = 0`: the point equals its own negation, so adding
+it to itself lands at infinity. Field-local — no base ring is involved.
+
+Stated for the Jacobian point, matching the rest of the torsion API and
+`evalEval_ψ_eq_zero_of_zsmul_eq_zero`. The affine group law is defined by cases and so needs
+`DecidableEq`, but only inside the proof, where `classical` supplies it; the statement does not. -/
+theorem two_zsmul_eq_zero_of_evalEval_ψ₂_eq_zero {x y : F}
+    (hns : W.toAffine.Nonsingular x y) (hψ : W.ψ₂.evalEval x y = 0) :
+    (2 : ℤ) • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns) = 0 := by
+  classical
+  rw [WeierstrassCurve.ψ₂, Affine.evalEval_polynomialY] at hψ
+  have hy : y = W.toAffine.negY x y := by simp only [Affine.negY]; linear_combination hψ
+  have haff : (2 : ℕ) • (Affine.Point.some _ _ hns) = 0 := by
+    rw [two_nsmul]; exact Affine.Point.add_self_of_Y_eq hy
+  have h := congrArg (Jacobian.Point.toAffineAddEquiv W).symm haff
+  rw [map_nsmul, map_zero] at h
+  rw [← natCast_zsmul] at h
+  exact_mod_cast h
+
+/-- **A torsion point is a root of its division polynomial.** If `n • P = 0` in the Jacobian
+point group, then `ψₙ` vanishes at `P`.
+
+This is where `zsmul_point_eq_smulEval` is consumed: it identifies `n • P` with the class of
+`(φₙ(x,y) : ωₙ(x,y) : ψₙ(x,y))`, and a Jacobian class is the point at infinity exactly when its
+`Z`-coordinate vanishes. -/
+theorem evalEval_ψ_eq_zero_of_zsmul_eq_zero {x y : F}
+    (hns : W.toAffine.Nonsingular x y) (n : ℤ)
+    (htors : n • (Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)) = 0) :
+    (W.ψ n).evalEval x y = 0 := by
+  have heval := zsmul_point_eq_smulEval W hns n
+  have hzero := Jacobian.Point.zero_point (W' := W.toJacobian)
+  rw [Jacobian.Point.ext_iff] at htors
+  rw [heval, hzero] at htors
+  exact (Jacobian.Z_eq_zero_of_equiv (Quotient.exact htors)).mpr rfl
 
 end WeierstrassCurve


### PR DESCRIPTION
> **#4040 has landed** (`e60f62c2d`), so this branch is rebuilt directly on `main` rather than
> carrying it. The `ZSMul.lean` and `Universal.lean` content this diff used to duplicate is now
> upstream — 21 of the 23 declarations it added to `ZSMul.lean`, and all of `Universal.lean`, which
> is byte-identical to `main`. **What remains is the slice proper: one new file,
> `DivisionPolynomial/Torsion.lean` (214 lines, four theorems), plus the two `ZSMul.lean` lemmas
> those theorems consume.**

The Nagell–Lutz statement, in the cases a squarefree hypothesis makes accessible — and over an
arbitrary UFD `R` with fraction field `K`, not only `ℤ/ℚ`.

```lean
theorem isInteger_x_of_odd_torsion_of_squarefree
    (hns : (W.baseChange K).toAffine.Nonsingular x y)
    {n : ℤ} (hodd : ¬Even n) (htors : n • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns) = 0)
    (hsf : Squarefree (n : R)) : IsLocalization.IsInteger R x

theorem isInteger_x_of_even_torsion_of_squarefree
    (hns : (W.baseChange K).toAffine.Nonsingular x y)
    {n : ℤ} (heven : Even n) (htors : n • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns) = 0)
    (h2ne : (2 : ℤ) • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns) ≠ 0)
    (h2 : (2 : R) ≠ 0) (hsf : Squarefree ((n / 2 : ℤ) : R)) : IsLocalization.IsInteger R x
```

plus `isInteger_x_of_order_four_of_squarefree` (the case `n = 4`, where `4 / 2 = 2` collapses both
arithmetic premises back into `Squarefree (2 : R)`) and `den_dvd_four_of_order_two`.

**Only the `x`-coordinate is stated.** `y` is integral by `Integrality.lean`'s
`isInteger_y_of_equation_of_isInteger_x`, which knows nothing about torsion, so pairing the two
into a conjunction would only duplicate an existing lemma's API.

## This is what the division-polynomial development was for

`evalEval_ψ_eq_zero_of_zsmul_eq_zero`, added to `ZSMul.lean` here, turns a group-theoretic
hypothesis into a polynomial one: `n • P = 0` says the Jacobian class of `(φₙ : ωₙ : ψₙ)` is the
point at infinity, which happens exactly when the `Z`-coordinate vanishes, i.e. `ψₙ(x, y) = 0`.
From there the argument is the rational root theorem: the root feeds
`isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff` (`Integrality.lean`), whose
squarefree-leading-coefficient hypothesis comes from Mathlib's `leadingCoeff_preΨ` and
`leadingCoeff_Ψ₂Sq` (`= 4`).

**Order two is the genuine exception and is stated as such.** A two-torsion point need not have
integral coordinates; what survives is `den(x) ∣ 4`. `two_zsmul_eq_zero_of_evalEval_ψ₂_eq_zero`,
the other lemma added to `ZSMul.lean` here, is what lets the even case exclude it.

## Both branches at full index generality

The source proves an odd-**prime** case and an order-**four** case. Neither hypothesis is doing
arithmetic work:

- Odd: primality is used only to rule out `n = 2`, and `leadingCoeff_preΨ = n` for odd `n`, so the
  same proof covers every odd index including composites.
- Even: the source splits `ψ₄ = preΨ₄ · ψ₂` and reads off `leadingCoeff preΨ₄ = 2`. Mathlib's `Ψ`
  is *defined* as `C (preΨ n) * if Even n then ψ₂ else 1`, and `leadingCoeff_preΨ = n / 2` for
  even `n`, so the identical argument runs at every even index. Order four is kept as a named
  specialisation because it is the source's own statement and the one the Nagell–Lutz route
  quotes.

`h2 : (2 : R) ≠ 0` is a genuine hypothesis in the even case rather than a consequence: it is
`n / 2` that is squarefree, and `(n : R) = 2 * (n / 2 : R)` is what `leadingCoeff_preΨ` asks to be
nonzero. At index four `hsf.ne_zero` supplies it, which is why the specialisation still takes a
single squarefree hypothesis.

## Four source declarations are deliberately not ported

- **`curveK` (`PIDCurve.lean:32`)** is `abbrev curveK : WeierstrassCurve K := W.map (algebraMap R K)`.
  Mathlib defines `W.baseChange K` to be exactly that — `W.baseChange K = W.map (algebraMap R K)`
  is proved by `rfl`, which I checked rather than assumed. Every lemma this file calls in
  `Integrality.lean` and `Denominator.lean` is stated over `baseChange`, so using it removes any
  bridging at the call sites. The five `curveK_aᵢ` simp lemmas go with it.
- **`curveK_equation_iff` (`PIDCurve.lean:40`)** is `Affine.equation_iff` after unfolding that
  abbreviation. With `curveK` gone it has no content and is not needed anywhere in the port.
- **`evalEval_ψ_odd` (`EvalBridge.lean:62`)** is the one-line composite
  `(evalEval_ψ_eq_evalEval_Ψ W heq n).trans (evalEval_Ψ_odd W n hodd)`, and this repository already
  carries *both components* while declining the wrapper. The composition is inlined at its one call
  site. (`ψ` and `Ψ` are different polynomials; a rewrite with `evalEval_Ψ_odd` alone fails.)
- **`prime_order_integrality_squarefree` (`:205`)** is the conjunction of the source's own
  `x_isInteger_of_odd_prime_torsion_squarefree` with `y_isInteger_of_x_isInteger_on_curve`. Both
  halves are here — the second as `Integrality.lean`'s `isInteger_y_of_equation_of_isInteger_x` —
  so callers pair them directly rather than through a bundling theorem that asserts nothing new.

Two more are already merged and are **called, not restated**:
`isInteger_of_root_squarefree_leading_coeff` (`:88`) is `Integrality.lean`'s
`isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff`, and
`y_isInteger_of_x_isInteger_on_curve` (`:42`) is its `isInteger_y_of_equation_of_isInteger_x`.

## Instance hypotheses

All four theorems carry `omit [DecidableEq K] in`: `[DecidableEq K]` is a section variable needed
by nothing here, because `two_zsmul_eq_zero_of_evalEval_ψ₂_eq_zero` is stated for the *Jacobian*
point group rather than the affine one, where `add` is defined by cases.

## Gates

Re-run from scratch on the rebuilt branch, based on `main` at `95e321061` (which contains
#4040), against the current pin **mathlib `e310d5e001`**:

- full-library `lake build` exit **0** — 8970 jobs, zero `error` lines in the whole log;
- `scripts/lint-env.sh` exit **0**, `LINT-ENV: PASS` — 64 grandfathered, 6 ratchetable, **no new
  violations**; 5496 docstrings scanned, 0 undocumented;
- `scripts/lint-dot-notation.py` exit **0** — **0 new** (1153 total, 1293 grandfathered, 140
  ratchetable). Both new `ZSMul.lean` lemmas go in the **root** `WeierstrassCurve` namespace, which
  is what keeps this gate at zero.

Max line width 100 codepoints, measured in python on decoded text (not `awk length`, which counts
bytes and over-reports on this file's `Ψ`/`ψ₂` density). `Torsion.lean` is 214 lines with four
theorems; longest proof **23 lines** (`isInteger_x_of_even_torsion_of_squarefree`), under the
30-line flag, so `/decompose-proof` is n/a.

A declaration-set diff against `main` was run over both touched files after the rebuild: **0
declarations removed**, exactly 2 added. That check is the point — the pre-rebuild branch would
have deleted `smulRing_zero`, which #4040 introduced and this branch never had.

## Roadmap

New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
Nagell–Lutz**", whose route is given at `:830`–`:831` as "division polynomials". The roadmap asks
for the theorem over `ℚ` for both integral models; these are the UFD-level statements it
specialises from, and the roadmap's own framing of the content as "**computability**" is what the
squarefree hypotheses deliver.

## Provenance

Ported from J. Xu and D. K. Angdinata's
`projects/NagellLutz/LutzNagell/LutzNagellTheorem/PIDPrimeOrder.lean` in AINTLIB
(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`):
`x_isInteger_of_odd_prime_torsion_squarefree` (`:118`), `two_nsmul_eq_zero_of_ψ₂_eq_zero` (`:143`),
`integrality_of_order_four_squarefree` (`:156`) and `den_dvd_of_order_two` (`:183`).

That file is **byte-identical at `9fec8eba7652`**, the revision the roadmap pins for the NagellLutz
project (`README:1072`), so these citations hold at either revision — verified by blob hash rather
than assumed, because the sibling `projects/HasseWeil` files do *not* have that property.

Names are restated to describe conclusions, and two are generalised as described above:
`x_isInteger_of_odd_prime_torsion_squarefree` → `isInteger_x_of_odd_torsion_of_squarefree`,
`integrality_of_order_four_squarefree` → `isInteger_x_of_even_torsion_of_squarefree` (with
`isInteger_x_of_order_four_of_squarefree` the source's own index), `den_dvd_of_order_two` →
`den_dvd_four_of_order_two`, `two_nsmul_eq_zero_of_ψ₂_eq_zero` →
`two_zsmul_eq_zero_of_evalEval_ψ₂_eq_zero` (in `ZSMul.lean`, added by this PR).

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"prime-order-integrality"}-->

🤖 Prepared with Claude Code (Claude Opus 5)

