### PR TITLE
feat: identify the center of SLn

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
@@ -45,6 +45,18 @@ lemma mapPoints_quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
       quotientPointsHom H I B (HopfAlgebra.mapPoints (H := quotient H I) χ f) := by
   exact mapPointsFunctor_naturality_apply (R := R) (mkQuotient H I) χ f
 
+/-- The quotient-points inclusion commutes with post-composition, including when the source and
+target value algebras lie in different universes. -/
+lemma mapValue_quotientPointsHom (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) {A : Type w} {B : Type w'}
+    [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+    (χ : A →ₐ[R] B)
+    (f : HopfAlgebra.points (R := R) (H := quotient H I) (CommAlgCat.of R A)) :
+    AlgHom.mapValue χ (quotientPointsHom H I (CommAlgCat.of R A) f) =
+      quotientPointsHom H I (CommAlgCat.of R B) (AlgHom.mapValue χ f) := by
+  rw [quotientPointsHom_apply, quotientPointsHom_apply, AlgHom.mapValue_apply,
+    AlgHom.mapValue_apply, AlgHom.comp_assoc]
+
 /-- Post-composition by an algebra homomorphism preserves the ambient-point subgroup cut out by a
 Hopf ideal, including when the source and target value algebras lie in different universes. -/
 lemma mapValue_mem_quotientPointsSubgroup (H : _root_.CommHopfAlgCat.{v} R)

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
@@ -61,7 +61,7 @@ namespace TauCeti
 
 namespace SpecialLinear
 
-universe u w
+universe u v w
 
 variable (R : Type u) [CommRing R] (n : ℕ)
 
@@ -417,7 +417,7 @@ theorem quotientPointsHom_pointsMulEquiv_symm
   apply (GeneralLinear.pointsMulEquiv (R := R) (A := A) n).injective
   rw [pointsMulEquiv_toGL, MulEquiv.apply_symm_apply, MulEquiv.apply_symm_apply]
 
-variable {B : Type w} [CommRing B] [Algebra R B]
+variable {B : Type v} [CommRing B] [Algebra R B]
 
 /-- The special-linear point equivalence is natural in the value algebra: postcomposition of Hopf
 points agrees with entrywise mapping of determinant-one matrices. -/
@@ -425,13 +425,22 @@ theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
     (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R n)
       (CommAlgCat.of R A)) :
     (pointsMulEquiv (R := R) (A := B) n)
-        (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R n)
-          (CommAlgCat.ofHom phi) f) =
+        (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi f) =
       Matrix.SpecialLinearGroup.map phi.toRingHom
         ((pointsMulEquiv (R := R) (A := A) n) f) := by
+  have hquot :
+      CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n)
+          (CommAlgCat.of R B) (AlgHom.mapValue phi f) =
+        AlgHom.mapValue phi
+          (CommHopfAlgCat.quotientPointsHom
+            (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n)
+            (CommAlgCat.of R A) f) := by
+    rw [CommHopfAlgCat.quotientPointsHom_apply,
+      CommHopfAlgCat.quotientPointsHom_apply, AlgHom.mapValue_apply]
+    rfl
   apply Matrix.SpecialLinearGroup.toGL_injective
-  rw [← pointsMulEquiv_toGL, ← CommHopfAlgCat.mapPoints_quotientPointsHom]
-  rw [HopfAlgebra.mapPoints_apply, ← AlgHom.mapValue_apply]
+  rw [← pointsMulEquiv_toGL, hquot]
   rw [GeneralLinear.pointsMulEquiv_mapValue, pointsMulEquiv_toGL]
   apply Matrix.GeneralLinearGroup.ext
   intro i j
@@ -499,6 +508,10 @@ noncomputable def pointsNatIso :
       intro A B phi
       ext f
       apply ULift.ext
+      change (pointsMulEquiv (R := R) (A := B) n)
+          (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi.hom f) =
+        Matrix.SpecialLinearGroup.map phi.hom.toRingHom
+          ((pointsMulEquiv (R := R) (A := A) n) f)
       exact pointsMulEquiv_mapValue (R := R) (A := A) (B := B) n phi.hom f)
 
 /-- After transport along `specialLinearFunctor_obj`, the forward component of `pointsNatIso` is

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
@@ -508,10 +508,9 @@ noncomputable def pointsNatIso :
       intro A B phi
       ext f
       apply ULift.ext
-      change (pointsMulEquiv (R := R) (A := B) n)
-          (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi.hom f) =
-        Matrix.SpecialLinearGroup.map phi.hom.toRingHom
-          ((pointsMulEquiv (R := R) (A := A) n) f)
+      -- The natural isomorphism is still being constructed, so no component rewrite lemma is
+      -- available here. The functor maps and `MulEquiv.toGrpIso` reduce definitionally; after
+      -- removing the universe lift, the square is exactly the named pointwise naturality result.
       exact pointsMulEquiv_mapValue (R := R) (A := A) (B := B) n phi.hom f)
 
 /-- After transport along `specialLinearFunctor_obj`, the forward component of `pointsNatIso` is

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
@@ -428,19 +428,8 @@ theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
         (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi f) =
       Matrix.SpecialLinearGroup.map phi.toRingHom
         ((pointsMulEquiv (R := R) (A := A) n) f) := by
-  have hquot :
-      CommHopfAlgCat.quotientPointsHom
-          (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n)
-          (CommAlgCat.of R B) (AlgHom.mapValue phi f) =
-        AlgHom.mapValue phi
-          (CommHopfAlgCat.quotientPointsHom
-            (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n)
-            (CommAlgCat.of R A) f) := by
-    rw [CommHopfAlgCat.quotientPointsHom_apply,
-      CommHopfAlgCat.quotientPointsHom_apply, AlgHom.mapValue_apply]
-    rfl
   apply Matrix.SpecialLinearGroup.toGL_injective
-  rw [← pointsMulEquiv_toGL, hquot]
+  rw [← pointsMulEquiv_toGL, ← CommHopfAlgCat.mapValue_quotientPointsHom]
   rw [GeneralLinear.pointsMulEquiv_mapValue, pointsMulEquiv_toGL]
   apply Matrix.GeneralLinearGroup.ext
   intro i j

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
@@ -96,15 +96,21 @@ noncomputable def scalarRootsPoints {A : Type v} [CommRing A] [Algebra R A] :
   (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm.toMonoidHom.comp
     (({
       toFun ζ := ⟨Matrix.scalar (Fin n) (((ζ : Aˣ) : A)), by
+        -- `Matrix.scalar` is defined as a diagonal matrix, while the available determinant
+        -- lemma is stated for `Matrix.diagonal`; expose that representation before rewriting.
         change (Matrix.diagonal fun _ : Fin n ↦ (((ζ : Aˣ) : A))).det = 1
         rw [Matrix.det_diagonal]
         simpa using congrArg Units.val ζ.property⟩
       map_one' := by
         apply Subtype.ext
+        -- The special-linear group inherits its identity through the matrix subtype, so after
+        -- subtype extensionality this reduction exposes the underlying scalar-matrix identity.
         change Matrix.scalar (Fin n) (1 : A) = 1
         exact map_one (Matrix.scalar (Fin n))
       map_mul' ζ ξ := by
         apply Subtype.ext
+        -- Likewise, subtype multiplication and the coercions from roots of unity reduce to the
+        -- underlying matrix product; this is the form recognized by the scalar-matrix simp API.
         change Matrix.scalar (Fin n) ((((ζ * ξ : rootsOfUnity n A) : Aˣ) : A)) =
           Matrix.scalar (Fin n) (((ζ : Aˣ) : A)) *
             Matrix.scalar (Fin n) (((ξ : Aˣ) : A))
@@ -127,6 +133,8 @@ theorem pointsMulEquiv_scalarRootsPoints {A : Type v} [CommRing A] [Algebra R A]
         simpa using congrArg Units.val
           (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f).property⟩ :
         Matrix.SpecialLinearGroup (Fin n) A) := by
+  -- This is the application lemma for `scalarRootsPoints` itself, so no earlier propositional
+  -- rewrite can expose its defining composite. Unfold just far enough to use `apply_symm_apply`.
   change (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n)
     ((TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm _) = _
   rw [MulEquiv.apply_symm_apply]

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
@@ -1,0 +1,313 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+public import TauCeti.Algebra.AlgebraicGroup.Center.Basic
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity.Basic
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
+
+/-!
+# The center of the special linear group
+
+For a field `k` and a positive integer `n`, this file identifies the center of the special
+linear group scheme `SLₙ` with the roots-of-unity group scheme `μₙ`. A root of unity acts by
+its scalar matrix. Mathlib's equivalence
+`Matrix.SpecialLinearGroup.center_equiv_rootsOfUnity'` supplies the matrix-theoretic
+classification of the center; universal centrality then upgrades it to the represented center.
+
+The natural pointwise equivalence and full faithfulness of the Hopf-algebra functor of points
+give an isomorphism
+
+```text
+  k[SLₙ] / I(Z(SLₙ)) ≅ k[Multiplicative (ZMod n)]
+```
+
+of commutative Hopf algebras. This is the center calculation used by the standard central
+isogeny from `SLₙ` toward its adjoint form.
+
+## Main declarations
+
+* `TauCeti.SpecialLinear.scalarRootsPoints`: the scalar-matrix map from `μₙ`-points to
+  `SLₙ`-points.
+* `TauCeti.SpecialLinear.scalarRootsCenterNatIso`: the natural isomorphism from `μₙ`-points
+  to the represented center of `SLₙ`.
+* `TauCeti.SpecialLinear.centerCoordinateIso`: the center coordinate Hopf algebra of `SLₙ`
+  is the group algebra of `Multiplicative (ZMod n)`.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Examples 2.4 and 5.49, and §18.a.
+
+This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap:
+the center and central-isogeny input for the simply connected and adjoint forms.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+namespace SpecialLinear
+
+universe u
+
+variable {R : Type u} [CommRing R]
+variable (n : ℕ)
+
+/-- The center of the special linear group in positive rank is the group of `n`th roots of
+unity. This specializes Mathlib's finite-index-type equivalence to matrices indexed by `Fin n`. -/
+noncomputable def centerMulEquivRootsOfUnity (hn : 0 < n)
+    (A : Type u) [CommRing A] :
+    Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) ≃* rootsOfUnity n A :=
+  (Matrix.SpecialLinearGroup.center_equiv_rootsOfUnity' (R := A)
+    (⟨0, hn⟩ : Fin n)).trans <| MulEquiv.subgroupCongr <| by
+      rw [Fintype.card_fin]
+
+/-- The inverse center equivalence sends a root of unity to its scalar matrix. -/
+theorem coe_centerMulEquivRootsOfUnity_symm_apply (hn : 0 < n)
+    (A : Type u) [CommRing A] (ζ : rootsOfUnity n A) :
+    (((centerMulEquivRootsOfUnity n hn A).symm ζ :
+        Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) =
+      Matrix.scalar (Fin n) ((ζ : Aˣ) : A) := by
+  let hcard : rootsOfUnity (Fintype.card (Fin n)) A = rootsOfUnity n A :=
+    congrArg (fun m ↦ rootsOfUnity m A) (Fintype.card_fin n)
+  have hunit :
+      (((MulEquiv.subgroupCongr hcard).symm ζ :
+        rootsOfUnity (Fintype.card (Fin n)) A) : Aˣ) = (ζ : Aˣ) :=
+    MulEquiv.subgroupCongr_symm_apply hcard ζ
+  have hval := congrArg Units.val hunit
+  -- Unfolding the two equivalences leaves the scalar action used by Mathlib's inverse.
+  change (((((MulEquiv.subgroupCongr hcard).symm ζ :
+      rootsOfUnity (Fintype.card (Fin n)) A) : Aˣ) : A) •
+        (1 : Matrix (Fin n) (Fin n) A)) = Matrix.scalar (Fin n) ((ζ : Aˣ) : A)
+  rw [hval, Matrix.smul_one_eq_diagonal]
+  rfl
+
+/-- Send a roots-of-unity point to the corresponding scalar special-linear point. -/
+noncomputable def scalarRootsPoints (hn : 0 < n) {A : Type u} [CommRing A] [Algebra R A] :
+    WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A) →*
+      WithConv (coordinateHopfAlgebra R n →ₐ[R] A) :=
+  (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm.toMonoidHom.comp
+    ((Subgroup.subtype _).comp
+      ((centerMulEquivRootsOfUnity n hn A).symm.toMonoidHom.comp
+        (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).toMonoidHom))
+
+/-- Under the standard point equivalences, `scalarRootsPoints` is the central scalar matrix
+attached to a root of unity. -/
+@[simp]
+theorem pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
+    {A : Type u} [CommRing A] [Algebra R A]
+    (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
+    TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n
+        (scalarRootsPoints n hn f) =
+      (centerMulEquivRootsOfUnity n hn A).symm
+          (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f) := by
+  simp [scalarRootsPoints]
+
+/-- The central special-linear matrix attached to a root of unity is a scalar matrix. -/
+theorem coe_pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
+    {A : Type u} [CommRing A] [Algebra R A]
+    (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
+    ((TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n
+        (scalarRootsPoints n hn f) :
+        Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) =
+      Matrix.scalar (Fin n)
+        ((RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f : Aˣ) : A) := by
+  rw [pointsMulEquiv_scalarRootsPoints]
+  exact coe_centerMulEquivRootsOfUnity_symm_apply n hn A _
+
+/-- The scalar roots-of-unity map is injective in positive rank. -/
+theorem scalarRootsPoints_injective (hn : 0 < n)
+    {A : Type u} [CommRing A] [Algebra R A] :
+    Function.Injective (scalarRootsPoints (R := R) n hn (A := A)) := by
+  intro f g hfg
+  apply (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).injective
+  apply (centerMulEquivRootsOfUnity n hn A).symm.injective
+  apply Subtype.val_injective
+  have h := congrArg (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n) hfg
+  rw [pointsMulEquiv_scalarRootsPoints, pointsMulEquiv_scalarRootsPoints] at h
+  exact h
+
+/-- The scalar roots-of-unity construction is natural in the value algebra. -/
+theorem mapValue_scalarRootsPoints (hn : 0 < n)
+    {A B : Type u} [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+    (φ : A →ₐ[R] B)
+    (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
+    AlgHom.mapValue (H := coordinateHopfAlgebra R n) φ (scalarRootsPoints n hn f) =
+      scalarRootsPoints n hn
+        (AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (ZMod n))) φ f) := by
+  apply (SpecialLinear.pointsMulEquiv (R := R) (A := B) n).injective
+  have hmap := SpecialLinear.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) n φ
+    (scalarRootsPoints n hn f)
+  rw [HopfAlgebra.mapPoints_apply, CommAlgCat.hom_ofHom, ← AlgHom.mapValue_apply] at hmap
+  rw [hmap, pointsMulEquiv_scalarRootsPoints]
+  apply SetCoe.ext
+  ext i j
+  let ζA := RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f
+  let fB := AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (ZMod n))) φ f
+  have hA := congrFun₂ (coe_centerMulEquivRootsOfUnity_symm_apply n hn A ζA) i j
+  have hB := congrFun₂ (coe_pointsMulEquiv_scalarRootsPoints n hn fB) i j
+  -- Strip the two bundled matrix subtypes so the entrywise scalar calculation is visible.
+  change φ (((((centerMulEquivRootsOfUnity n hn A).symm ζA :
+      Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) i j)) =
+    ((SpecialLinear.pointsMulEquiv (R := R) (A := B) n (scalarRootsPoints n hn fB) :
+      Matrix.SpecialLinearGroup (Fin n) B) : Matrix (Fin n) (Fin n) B) i j
+  rw [hA, hB]
+  rw [RootsOfUnityGroup.pointsMulEquiv_mapValue]
+  by_cases hij : i = j <;>
+    simp [hij, ζA, RootsOfUnityGroup.pointsMulEquiv_apply]
+
+section Center
+
+variable {k : Type u} [Field k]
+
+/-- Every roots-of-unity scalar point is a point of the represented center of `SLₙ`. -/
+theorem scalarRootsPoints_mem_centerPointsSubgroup (hn : 0 < n)
+    {A : Type u} [CommRing A] [Algebra k A]
+    (f : WithConv (MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[k] A)) :
+    scalarRootsPoints n hn f ∈ CommHopfAlgCat.centerPointsSubgroup
+      (coordinateHopfAlgebra k n) (CommAlgCat.of k A) := by
+  rw [CommHopfAlgCat.mem_centerPointsSubgroup_iff, HopfAlgebra.isCentralPoint_def]
+  intro B _ _ φ g
+  apply (SpecialLinear.pointsMulEquiv (R := k) (A := B) n).injective
+  rw [map_mul, map_mul, mapValue_scalarRootsPoints,
+    pointsMulEquiv_scalarRootsPoints]
+  exact ((centerMulEquivRootsOfUnity n hn B).symm
+      (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := B) n
+        (AlgHom.mapValue (H := MonoidAlgebra k (Multiplicative (ZMod n))) φ f))).property.comm _
+
+/-- The scalar roots-of-unity map with codomain restricted to the represented center. -/
+noncomputable def scalarRootsCenterHom (hn : 0 < n) (A : CommAlgCat.{u} k) :
+    HopfAlgebra.points (R := k)
+        (H := MonoidAlgebra k (Multiplicative (ZMod n))) A →*
+      CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A :=
+  (scalarRootsPoints (R := k) n hn (A := A)).codRestrict
+    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
+    (scalarRootsPoints_mem_centerPointsSubgroup n hn)
+
+/-- In positive rank, scalar roots of unity give every universally central point of `SLₙ`. -/
+theorem scalarRootsCenterHom_bijective (hn : 0 < n) (A : CommAlgCat.{u} k) :
+    Function.Bijective (scalarRootsCenterHom n hn A) := by
+  constructor
+  · intro f g hfg
+    apply scalarRootsPoints_injective (R := k) n hn
+    exact congrArg Subtype.val hfg
+  · intro g
+    have hgcentral :
+        SpecialLinear.pointsMulEquiv (R := k) (A := A) n g.1 ∈
+          Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) := by
+      rw [Subgroup.mem_center_iff]
+      intro h
+      let q := (SpecialLinear.pointsMulEquiv (R := k) (A := A) n).symm h
+      have hcomm :=
+        (CommHopfAlgCat.mem_centerPointsSubgroup_iff
+          (coordinateHopfAlgebra k n) A g.1).mp g.2
+      have hcommq := hcomm.commute q
+      simpa [q] using ((hcommq.map
+        (SpecialLinear.pointsMulEquiv (R := k) (A := A) n).toMonoidHom).symm.eq)
+    let c : Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) :=
+      ⟨SpecialLinear.pointsMulEquiv (R := k) (A := A) n g.1, hgcentral⟩
+    let ζ : rootsOfUnity n A :=
+      centerMulEquivRootsOfUnity n hn A c
+    refine ⟨(RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm ζ, ?_⟩
+    apply Subtype.ext
+    change scalarRootsPoints n hn
+      ((RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm ζ) = g.1
+    apply (SpecialLinear.pointsMulEquiv (R := k) (A := A) n).injective
+    rw [pointsMulEquiv_scalarRootsPoints, MulEquiv.apply_symm_apply]
+    exact congrArg Subtype.val
+      ((centerMulEquivRootsOfUnity n hn A).symm_apply_apply c)
+
+/-- For every value algebra, scalar roots of unity identify `μₙ` with the represented center
+of `SLₙ`. -/
+noncomputable def scalarRootsCenterIso (hn : 0 < n) (A : CommAlgCat.{u} k) :
+    HopfAlgebra.points (R := k)
+        (H := MonoidAlgebra k (Multiplicative (ZMod n))) A ≅
+      GrpCat.of (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) :=
+  (MulEquiv.ofBijective (scalarRootsCenterHom n hn A)
+    (scalarRootsCenterHom_bijective n hn A)).toGrpIso
+
+/-- The forward component of `scalarRootsCenterIso` is the scalar-matrix homomorphism. -/
+@[simp]
+theorem scalarRootsCenterIso_hom_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
+    (f : HopfAlgebra.points (R := k)
+      (H := MonoidAlgebra k (Multiplicative (ZMod n))) A) :
+    (scalarRootsCenterIso n hn A).hom f = scalarRootsCenterHom n hn A f := by
+  rfl
+
+/-- Scalar roots of unity identify the `μₙ` point functor with the represented center
+subfunctor of `SLₙ`. -/
+noncomputable def scalarRootsCenterNatIso (hn : 0 < n) :
+    HopfAlgebra.pointsFunctor (R := k)
+        (H := MonoidAlgebra k (Multiplicative (ZMod n))) ≅
+      CommHopfAlgCat.quotientPointsSubgroupFunctor
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n)) :=
+  NatIso.ofComponents (scalarRootsCenterIso n hn) (by
+    intro A B φ
+    ext f
+    apply Subtype.ext
+    change scalarRootsPoints n hn
+        (AlgHom.mapValue (H := MonoidAlgebra k (Multiplicative (ZMod n))) φ.hom f) =
+      AlgHom.mapValue (H := coordinateHopfAlgebra k n) φ.hom
+        (scalarRootsPoints n hn f)
+    exact (mapValue_scalarRootsPoints n hn φ.hom f).symm)
+
+/-- The natural isomorphism sends a `μₙ`-point to its scalar matrix. -/
+@[simp]
+theorem scalarRootsCenterNatIso_hom_app_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
+    (f : HopfAlgebra.points (R := k)
+      (H := MonoidAlgebra k (Multiplicative (ZMod n))) A) :
+    CategoryTheory.ConcreteCategory.hom
+        (X := (HopfAlgebra.pointsFunctor (R := k)
+          (H := MonoidAlgebra k (Multiplicative (ZMod n)))).obj A)
+        (Y := GrpCat.of (CommHopfAlgCat.centerPointsSubgroup
+          (coordinateHopfAlgebra k n) A))
+        ((scalarRootsCenterNatIso n hn).hom.app A) f =
+      scalarRootsCenterHom n hn A f := by
+  rfl
+
+/-- The point functor of `μₙ` is naturally isomorphic to the point functor represented by the
+center coordinate Hopf algebra of `SLₙ`. -/
+noncomputable def scalarRootsCenterCoordinatePointsNatIso (hn : 0 < n) :
+    (CommHopfAlgCat.pointsFunctor (R := k)).obj
+        (Opposite.op (CommHopfAlgCat.of k
+          (MonoidAlgebra k (Multiplicative (ZMod n))))) ≅
+      (CommHopfAlgCat.pointsFunctor (R := k)).obj
+        (Opposite.op (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n)
+          (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n)))) :=
+  scalarRootsCenterNatIso n hn ≪≫
+    (CommHopfAlgCat.quotientPointsSubgroupNatIso
+      (coordinateHopfAlgebra k n)
+      (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))).symm
+
+/-- The coordinate Hopf algebra of the center of positive-rank `SLₙ` is the group algebra of
+`Multiplicative (ZMod n)`, the coordinate Hopf algebra of `μₙ`. -/
+noncomputable def centerCoordinateIso (hn : 0 < n) :
+    CommHopfAlgCat.quotient (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n)) ≅
+      CommHopfAlgCat.of k (MonoidAlgebra k (Multiplicative (ZMod n))) :=
+  Iso.unop <| (Functor.FullyFaithful.ofFullyFaithful
+    (CommHopfAlgCat.pointsFunctor (R := k))).preimageIso
+      (scalarRootsCenterCoordinatePointsNatIso n hn)
+
+/-- Applying the functor of points to `centerCoordinateIso` recovers the scalar-matrix natural
+isomorphism used to construct it. -/
+theorem pointsFunctor_mapIso_centerCoordinateIso (hn : 0 < n) :
+    (CommHopfAlgCat.pointsFunctor (R := k)).mapIso (centerCoordinateIso n hn).op =
+      scalarRootsCenterCoordinatePointsNatIso n hn := by
+  apply Iso.ext
+  exact (Functor.FullyFaithful.ofFullyFaithful
+    (CommHopfAlgCat.pointsFunctor (R := k))).map_preimage _
+
+end Center
+
+end SpecialLinear
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
 public import TauCeti.Algebra.AlgebraicGroup.Center.Basic
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 public import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity.Basic
@@ -91,118 +90,132 @@ theorem coe_centerMulEquivRootsOfUnity_symm_apply (hn : 0 < n)
   rfl
 
 /-- Send a roots-of-unity point to the corresponding scalar special-linear point. -/
-noncomputable def scalarRootsPoints (hn : 0 < n) {A : Type v} [CommRing A] [Algebra R A] :
+noncomputable def scalarRootsPoints {A : Type v} [CommRing A] [Algebra R A] :
     WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A) →*
       WithConv (coordinateHopfAlgebra R n →ₐ[R] A) :=
   (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm.toMonoidHom.comp
-    ((Subgroup.subtype _).comp
-      ((centerMulEquivRootsOfUnity n hn A).symm.toMonoidHom.comp
-        (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).toMonoidHom))
+    (({
+      toFun ζ := ⟨Matrix.scalar (Fin n) (((ζ : Aˣ) : A)), by
+        change (Matrix.diagonal fun _ : Fin n ↦ (((ζ : Aˣ) : A))).det = 1
+        rw [Matrix.det_diagonal]
+        simpa using congrArg Units.val ζ.property⟩
+      map_one' := by
+        apply Subtype.ext
+        change Matrix.scalar (Fin n) (1 : A) = 1
+        exact map_one (Matrix.scalar (Fin n))
+      map_mul' ζ ξ := by
+        apply Subtype.ext
+        change Matrix.scalar (Fin n) ((((ζ * ξ : rootsOfUnity n A) : Aˣ) : A)) =
+          Matrix.scalar (Fin n) (((ζ : Aˣ) : A)) *
+            Matrix.scalar (Fin n) (((ξ : Aˣ) : A))
+        simp
+    } : rootsOfUnity n A →* Matrix.SpecialLinearGroup (Fin n) A).comp
+      (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).toMonoidHom)
 
 /-- Under the standard point equivalences, `scalarRootsPoints` is the central scalar matrix
 attached to a root of unity. -/
 @[simp]
-theorem pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
-    {A : Type v} [CommRing A] [Algebra R A]
+theorem pointsMulEquiv_scalarRootsPoints {A : Type v} [CommRing A] [Algebra R A]
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
     TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n
-        (scalarRootsPoints n hn f) =
-      (centerMulEquivRootsOfUnity n hn A).symm
-          (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f) := by
-  simp [scalarRootsPoints]
+        (scalarRootsPoints n f) =
+      (⟨Matrix.scalar (Fin n)
+          ((RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f : Aˣ) : A), by
+        change (Matrix.diagonal fun _ : Fin n ↦
+          ((RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f : Aˣ) : A)).det = 1
+        rw [Matrix.det_diagonal]
+        simpa using congrArg Units.val
+          (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f).property⟩ :
+        Matrix.SpecialLinearGroup (Fin n) A) := by
+  change (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n)
+    ((TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm _) = _
+  rw [MulEquiv.apply_symm_apply]
+  rfl
 
 /-- The central special-linear matrix attached to a root of unity is a scalar matrix. -/
 @[simp]
-theorem coe_pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
-    {A : Type v} [CommRing A] [Algebra R A]
+theorem coe_pointsMulEquiv_scalarRootsPoints {A : Type v} [CommRing A] [Algebra R A]
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
     ((TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n
-        (scalarRootsPoints n hn f) :
+        (scalarRootsPoints n f) :
         Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) =
       Matrix.scalar (Fin n)
         ((RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f : Aˣ) : A) := by
   rw [pointsMulEquiv_scalarRootsPoints]
-  exact coe_centerMulEquivRootsOfUnity_symm_apply n hn A _
 
 /-- For `0 < n`, the scalar roots-of-unity map is injective. -/
 theorem scalarRootsPoints_injective (hn : 0 < n)
     {A : Type v} [CommRing A] [Algebra R A] :
-    Function.Injective (scalarRootsPoints (R := R) n hn (A := A)) := by
+    Function.Injective (scalarRootsPoints (R := R) n (A := A)) := by
   intro f g hfg
   apply (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).injective
-  apply (centerMulEquivRootsOfUnity n hn A).symm.injective
-  apply Subtype.val_injective
+  apply Subtype.ext
+  apply Units.ext
   have h := congrArg (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n) hfg
-  rw [pointsMulEquiv_scalarRootsPoints, pointsMulEquiv_scalarRootsPoints] at h
-  exact h
+  have hmatrix := congrArg Subtype.val h
+  rw [coe_pointsMulEquiv_scalarRootsPoints,
+    coe_pointsMulEquiv_scalarRootsPoints] at hmatrix
+  have hentry := congrFun₂ hmatrix (⟨0, hn⟩ : Fin n) ⟨0, hn⟩
+  simpa using hentry
 
 /-- The scalar roots-of-unity construction is natural in the value algebra. -/
-theorem mapValue_scalarRootsPoints (hn : 0 < n)
-    {A : Type v} {B : Type w} [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+theorem mapValue_scalarRootsPoints {A : Type v} {B : Type w}
+    [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
     (φ : A →ₐ[R] B)
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
-    AlgHom.mapValue (H := coordinateHopfAlgebra R n) φ (scalarRootsPoints n hn f) =
-      scalarRootsPoints n hn
+    AlgHom.mapValue (H := coordinateHopfAlgebra R n) φ (scalarRootsPoints n f) =
+      scalarRootsPoints n
         (AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (ZMod n))) φ f) := by
   apply (SpecialLinear.pointsMulEquiv (R := R) (A := B) n).injective
   have hmap := SpecialLinear.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) n φ
-    (scalarRootsPoints n hn f)
-  rw [hmap, pointsMulEquiv_scalarRootsPoints]
-  apply SetCoe.ext
+    (scalarRootsPoints n f)
+  rw [hmap]
+  apply Subtype.ext
+  rw [Matrix.SpecialLinearGroup.map_apply_coe,
+    coe_pointsMulEquiv_scalarRootsPoints, coe_pointsMulEquiv_scalarRootsPoints]
   ext i j
-  let ζA := RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f
-  let fB := AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (ZMod n))) φ f
-  have hA := congrFun₂ (coe_centerMulEquivRootsOfUnity_symm_apply n hn A ζA) i j
-  have hB := congrFun₂ (coe_pointsMulEquiv_scalarRootsPoints n hn fB) i j
-  -- Strip the two bundled matrix subtypes so the entrywise scalar calculation is visible.
-  change φ (((((centerMulEquivRootsOfUnity n hn A).symm ζA :
-      Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) i j)) =
-    ((SpecialLinear.pointsMulEquiv (R := R) (A := B) n (scalarRootsPoints n hn fB) :
-      Matrix.SpecialLinearGroup (Fin n) B) : Matrix (Fin n) (Fin n) B) i j
-  rw [hA, hB]
   rw [RootsOfUnityGroup.pointsMulEquiv_mapValue]
   by_cases hij : i = j <;>
-    simp [hij, ζA, RootsOfUnityGroup.pointsMulEquiv_apply]
+    simp [hij, RootsOfUnityGroup.pointsMulEquiv_apply]
 
 section Center
 
 variable {k : Type u} [Field k]
 
 /-- Every roots-of-unity scalar point is a point of the represented center of `SLₙ`. -/
-theorem scalarRootsPoints_mem_centerPointsSubgroup (hn : 0 < n)
-    {A : Type u} [CommRing A] [Algebra k A]
+theorem scalarRootsPoints_mem_centerPointsSubgroup {A : Type u} [CommRing A] [Algebra k A]
     (f : WithConv (MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[k] A)) :
-    scalarRootsPoints n hn f ∈ CommHopfAlgCat.centerPointsSubgroup
+    scalarRootsPoints n f ∈ CommHopfAlgCat.centerPointsSubgroup
       (coordinateHopfAlgebra k n) (CommAlgCat.of k A) := by
   rw [CommHopfAlgCat.mem_centerPointsSubgroup_iff, HopfAlgebra.isCentralPoint_def]
   intro B _ _ φ g
   apply (SpecialLinear.pointsMulEquiv (R := k) (A := B) n).injective
   rw [map_mul, map_mul, mapValue_scalarRootsPoints,
     pointsMulEquiv_scalarRootsPoints]
-  exact ((centerMulEquivRootsOfUnity n hn B).symm
-      (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := B) n
-        (AlgHom.mapValue (H := MonoidAlgebra k (Multiplicative (ZMod n))) φ f))).property.comm _
+  apply Subtype.ext
+  exact (Matrix.scalar_commute _ (fun r ↦ Commute.all _ r)
+    (SpecialLinear.pointsMulEquiv (R := k) (A := B) n g).1).eq
 
 /-- The scalar roots-of-unity map with codomain restricted to the represented center. -/
-noncomputable def scalarRootsCenterHom (hn : 0 < n) (A : CommAlgCat.{u} k) :
+noncomputable def scalarRootsCenterHom (A : CommAlgCat.{u} k) :
     HopfAlgebra.points (R := k)
         (H := MonoidAlgebra k (Multiplicative (ZMod n))) A →*
       CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A :=
-  (scalarRootsPoints (R := k) n hn (A := A)).codRestrict
+  (scalarRootsPoints (R := k) n (A := A)).codRestrict
     (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
-    (scalarRootsPoints_mem_centerPointsSubgroup n hn)
+    (scalarRootsPoints_mem_centerPointsSubgroup n)
 
 /-- The value of `scalarRootsCenterHom` is the underlying scalar special-linear point. -/
 @[simp]
-theorem coe_scalarRootsCenterHom_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
+theorem coe_scalarRootsCenterHom_apply (A : CommAlgCat.{u} k)
     (f : HopfAlgebra.points (R := k)
       (H := MonoidAlgebra k (Multiplicative (ZMod n))) A) :
-    (scalarRootsCenterHom n hn A f).1 = scalarRootsPoints n hn f := by
+    (scalarRootsCenterHom n A f).1 = scalarRootsPoints n f := by
   rfl
 
 /-- For `0 < n`, scalar roots of unity give every universally central point of `SLₙ`. -/
 theorem scalarRootsCenterHom_bijective (hn : 0 < n) (A : CommAlgCat.{u} k) :
-    Function.Bijective (scalarRootsCenterHom n hn A) := by
+    Function.Bijective (scalarRootsCenterHom n A) := by
   constructor
   · intro f g hfg
     apply scalarRootsPoints_injective (R := k) n hn
@@ -211,15 +224,10 @@ theorem scalarRootsCenterHom_bijective (hn : 0 < n) (A : CommAlgCat.{u} k) :
     have hgcentral :
         SpecialLinear.pointsMulEquiv (R := k) (A := A) n g.1 ∈
           Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) := by
-      rw [Subgroup.mem_center_iff]
-      intro h
-      let q := (SpecialLinear.pointsMulEquiv (R := k) (A := A) n).symm h
-      have hcomm :=
-        (CommHopfAlgCat.mem_centerPointsSubgroup_iff
-          (coordinateHopfAlgebra k n) A g.1).mp g.2
-      have hcommq := hcomm.commute q
-      simpa [q] using ((hcommq.map
-        (SpecialLinear.pointsMulEquiv (R := k) (A := A) n).toMonoidHom).symm.eq)
+      apply MulEquivClass.apply_mem_center
+      apply HopfAlgebra.center_le_center
+      rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
+      exact g.2
     let c : Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) :=
       ⟨SpecialLinear.pointsMulEquiv (R := k) (A := A) n g.1, hgcentral⟩
     let ζ : rootsOfUnity n A :=
@@ -228,9 +236,13 @@ theorem scalarRootsCenterHom_bijective (hn : 0 < n) (A : CommAlgCat.{u} k) :
     apply Subtype.ext
     rw [coe_scalarRootsCenterHom_apply]
     apply (SpecialLinear.pointsMulEquiv (R := k) (A := A) n).injective
-    rw [pointsMulEquiv_scalarRootsPoints, MulEquiv.apply_symm_apply]
-    exact congrArg Subtype.val
-      ((centerMulEquivRootsOfUnity n hn A).symm_apply_apply c)
+    apply Subtype.ext
+    rw [coe_pointsMulEquiv_scalarRootsPoints, MulEquiv.apply_symm_apply,
+      ← coe_centerMulEquivRootsOfUnity_symm_apply n hn A ζ]
+    simpa only [ζ] using
+      congrArg (fun x : Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) ↦
+        (((x : Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A)))
+        ((centerMulEquivRootsOfUnity n hn A).symm_apply_apply c)
 
 /-- For every value algebra, scalar roots of unity identify `μₙ` with the represented center
 of `SLₙ`. -/
@@ -238,7 +250,7 @@ noncomputable def scalarRootsCenterIso (hn : 0 < n) (A : CommAlgCat.{u} k) :
     HopfAlgebra.points (R := k)
         (H := MonoidAlgebra k (Multiplicative (ZMod n))) A ≅
       GrpCat.of (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) :=
-  (MulEquiv.ofBijective (scalarRootsCenterHom n hn A)
+  (MulEquiv.ofBijective (scalarRootsCenterHom n A)
     (scalarRootsCenterHom_bijective n hn A)).toGrpIso
 
 /-- The forward component of `scalarRootsCenterIso` is the scalar-matrix homomorphism. -/
@@ -246,7 +258,7 @@ noncomputable def scalarRootsCenterIso (hn : 0 < n) (A : CommAlgCat.{u} k) :
 theorem scalarRootsCenterIso_hom_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
     (f : HopfAlgebra.points (R := k)
       (H := MonoidAlgebra k (Multiplicative (ZMod n))) A) :
-    (scalarRootsCenterIso n hn A).hom f = scalarRootsCenterHom n hn A f := by
+    (scalarRootsCenterIso n hn A).hom f = scalarRootsCenterHom n A f := by
   rfl
 
 /-- Scalar roots of unity identify the `μₙ` point functor with the represented center
@@ -264,7 +276,7 @@ noncomputable def scalarRootsCenterNatIso (hn : 0 < n) :
     -- The component and its application lemma cannot be used while this natural isomorphism is
     -- being constructed. After subgroup extensionality, `codRestrict` and the restricted functor
     -- map reduce definitionally, leaving precisely the scalar-point naturality theorem.
-    exact (mapValue_scalarRootsPoints n hn φ.hom f).symm)
+    exact (mapValue_scalarRootsPoints n φ.hom f).symm)
 
 /-- The natural isomorphism sends a `μₙ`-point to its scalar matrix. -/
 @[simp]
@@ -277,7 +289,7 @@ theorem scalarRootsCenterNatIso_hom_app_apply (hn : 0 < n) (A : CommAlgCat.{u} k
         (Y := GrpCat.of (CommHopfAlgCat.centerPointsSubgroup
           (coordinateHopfAlgebra k n) A))
         ((scalarRootsCenterNatIso n hn).hom.app A) f =
-      scalarRootsCenterHom n hn A f := by
+      scalarRootsCenterHom n A f := by
   rfl
 
 /-- The point functor of `μₙ` is naturally isomorphic to the point functor represented by the

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
@@ -87,7 +87,7 @@ theorem coe_rootsOfUnityScalarSL {A : Type v} [CommRing A] (ζ : rootsOfUnity n 
   rfl
 
 /-- Send a roots-of-unity point to the corresponding scalar special-linear point. -/
-@[expose] noncomputable def rootsOfUnityScalarPoints
+noncomputable def rootsOfUnityScalarPoints
     {R : Type u} [CommRing R] {A : Type v} [CommRing A] [Algebra R A] :
     WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A) →*
       WithConv (coordinateHopfAlgebra R n →ₐ[R] A) :=
@@ -175,7 +175,7 @@ theorem isCentralPoint_rootsOfUnityScalarPoints
     (SpecialLinear.pointsMulEquiv (R := S) (A := B) n g).1).eq
 
 /-- The scalar roots-of-unity map with codomain restricted to the universal center. -/
-@[expose] noncomputable def rootsOfUnityScalarCenterHom
+noncomputable def rootsOfUnityScalarCenterHom
     (A : Type u) [CommRing A] [Algebra S A] :
     WithConv (MonoidAlgebra S (Multiplicative (ZMod n)) →ₐ[S] A) →*
       HopfAlgebra.center S (coordinateHopfAlgebra S n) A :=
@@ -224,7 +224,7 @@ theorem rootsOfUnityScalarCenterHom_bijective (hn : 0 < n)
 
 /-- For `0 < n`, scalar roots of unity identify `μₙ` with the universal center of `SLₙ`
 pointwise over any commutative base ring. -/
-@[expose] noncomputable def rootsOfUnityScalarCenterMulEquiv (hn : 0 < n)
+noncomputable def rootsOfUnityScalarCenterMulEquiv (hn : 0 < n)
     (A : Type u) [CommRing A] [Algebra S A] :
     WithConv (MonoidAlgebra S (Multiplicative (ZMod n)) →ₐ[S] A) ≃*
       HopfAlgebra.center S (coordinateHopfAlgebra S n) A :=
@@ -240,7 +240,7 @@ theorem rootsOfUnityScalarCenterMulEquiv_apply (hn : 0 < n)
   rfl
 
 /-- Read the root of unity from the upper-left entry of a universally central `SLₙ`-point. -/
-@[expose] noncomputable def rootsOfUnityOfCenterPoint (hn : 0 < n)
+noncomputable def rootsOfUnityOfCenterPoint (hn : 0 < n)
     {A : Type u} [CommRing A] [Algebra S A]
     (g : HopfAlgebra.center S (coordinateHopfAlgebra S n) A) : rootsOfUnity n A :=
   Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A
@@ -316,13 +316,16 @@ theorem rootsOfUnityScalarCenterIso_inv_apply (hn : 0 < n) (A : CommAlgCat.{u} k
           (⟨g.1, by
             rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
             exact g.2⟩ : HopfAlgebra.center k (coordinateHopfAlgebra k n) A)) := by
+  -- This theorem establishes the public inverse-application rule. The isomorphism is assembled
+  -- from `MulEquiv.trans` and `MulEquiv.toGrpIso`, for which there is no application rewrite
+  -- lemma connecting the categorical inverse to the underlying multiplicative equivalence.
   change (rootsOfUnityScalarCenterMulEquiv (S := k) n hn A).symm _ = _
   rw [rootsOfUnityScalarCenterMulEquiv_symm_apply]
   congr 2
 
 /-- Scalar roots of unity identify the `μₙ` point functor with the represented center
 subfunctor of `SLₙ`. -/
-@[expose] noncomputable def rootsOfUnityScalarCenterNatIso (hn : 0 < n) :
+noncomputable def rootsOfUnityScalarCenterNatIso (hn : 0 < n) :
     HopfAlgebra.pointsFunctor (R := k)
         (H := MonoidAlgebra k (Multiplicative (ZMod n))) ≅
       CommHopfAlgCat.quotientPointsSubgroupFunctor
@@ -332,6 +335,9 @@ subfunctor of `SLₙ`. -/
     intro A B φ
     ext f
     apply Subtype.ext
+    -- Naturality is presented as an equality of composed `GrpCat` morphisms. There is no
+    -- rewrite lemma that lowers those compositions and their concrete coercions to applications;
+    -- `change` exposes that layer, after which the public component and value-map lemmas apply.
     change ((rootsOfUnityScalarCenterIso n hn B).hom
         (AlgHom.mapValue φ.hom f)).1 =
       AlgHom.mapValue φ.hom ((rootsOfUnityScalarCenterIso n hn A).hom f).1
@@ -379,7 +385,7 @@ theorem rootsOfUnityScalarCenterNatIso_inv_app_apply
 
 /-- The point functor of `μₙ` is naturally isomorphic to the point functor represented by the
 center coordinate Hopf algebra of `SLₙ`. -/
-@[expose] noncomputable def rootsOfUnityScalarCenterCoordinatePointsNatIso (hn : 0 < n) :
+noncomputable def rootsOfUnityScalarCenterCoordinatePointsNatIso (hn : 0 < n) :
     (CommHopfAlgCat.pointsFunctor (R := k)).obj
         (Opposite.op (CommHopfAlgCat.of k
           (MonoidAlgebra k (Multiplicative (ZMod n))))) ≅
@@ -390,26 +396,6 @@ center coordinate Hopf algebra of `SLₙ`. -/
     (CommHopfAlgCat.quotientPointsSubgroupNatIso
       (coordinateHopfAlgebra k n)
       (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))).symm
-
-/-- The forward coordinate-center natural transformation first sends a root of unity to the
-represented center and then lifts that center point through the quotient coordinate algebra. -/
-theorem rootsOfUnityScalarCenterCoordinatePointsNatIso_hom (hn : 0 < n) :
-    (rootsOfUnityScalarCenterCoordinatePointsNatIso n hn).hom =
-      (rootsOfUnityScalarCenterNatIso n hn).hom ≫
-        (CommHopfAlgCat.quotientPointsSubgroupNatIso
-          (coordinateHopfAlgebra k n)
-          (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))).inv :=
-  Iso.trans_hom _ _
-
-/-- The inverse coordinate-center natural transformation includes a quotient point into `SLₙ`
-and then reads off its root of unity. -/
-theorem rootsOfUnityScalarCenterCoordinatePointsNatIso_inv (hn : 0 < n) :
-    (rootsOfUnityScalarCenterCoordinatePointsNatIso n hn).inv =
-      (CommHopfAlgCat.quotientPointsSubgroupNatIso
-        (coordinateHopfAlgebra k n)
-        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))).hom ≫
-          (rootsOfUnityScalarCenterNatIso n hn).inv :=
-  Iso.trans_inv _ _
 
 /-- For `0 < n`, the coordinate Hopf algebra of the center of `SLₙ` is the group algebra of
 `Multiplicative (ZMod n)`, the coordinate Hopf algebra of `μₙ`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
@@ -60,7 +60,7 @@ universe u v w
 variable (n : ℕ)
 
 /-- The scalar-matrix homomorphism from `n`th roots of unity to `SL(Fin n, A)`. -/
-@[expose] noncomputable def rootsOfUnityScalarSL {A : Type v} [CommRing A] :
+noncomputable def rootsOfUnityScalarSL {A : Type v} [CommRing A] :
     rootsOfUnity n A →* Matrix.SpecialLinearGroup (Fin n) A where
   toFun ζ := (⟨Matrix.scalar (Fin n) ((ζ : Aˣ) : A), by
     rw [Matrix.scalar_apply, Matrix.det_diagonal]
@@ -84,7 +84,7 @@ variable (n : ℕ)
 theorem coe_rootsOfUnityScalarSL {A : Type v} [CommRing A] (ζ : rootsOfUnity n A) :
     ((rootsOfUnityScalarSL n ζ : Matrix.SpecialLinearGroup (Fin n) A) :
       Matrix (Fin n) (Fin n) A) = Matrix.scalar (Fin n) ((ζ : Aˣ) : A) :=
-  rfl
+  (rfl)
 
 /-- Send a roots-of-unity point to the corresponding scalar special-linear point. -/
 noncomputable def rootsOfUnityScalarPoints

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
@@ -55,15 +55,15 @@ namespace TauCeti
 
 namespace SpecialLinear
 
-universe u
+universe u v w
 
 variable {R : Type u} [CommRing R]
 variable (n : ℕ)
 
-/-- The center of the special linear group in positive rank is the group of `n`th roots of
-unity. This specializes Mathlib's finite-index-type equivalence to matrices indexed by `Fin n`. -/
+/-- For `0 < n`, the center of the special linear group is the group of `n`th roots of unity.
+This specializes Mathlib's finite-index-type equivalence to matrices indexed by `Fin n`. -/
 noncomputable def centerMulEquivRootsOfUnity (hn : 0 < n)
-    (A : Type u) [CommRing A] :
+    (A : Type v) [CommRing A] :
     Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) ≃* rootsOfUnity n A :=
   (Matrix.SpecialLinearGroup.center_equiv_rootsOfUnity' (R := A)
     (⟨0, hn⟩ : Fin n)).trans <| MulEquiv.subgroupCongr <| by
@@ -71,7 +71,7 @@ noncomputable def centerMulEquivRootsOfUnity (hn : 0 < n)
 
 /-- The inverse center equivalence sends a root of unity to its scalar matrix. -/
 theorem coe_centerMulEquivRootsOfUnity_symm_apply (hn : 0 < n)
-    (A : Type u) [CommRing A] (ζ : rootsOfUnity n A) :
+    (A : Type v) [CommRing A] (ζ : rootsOfUnity n A) :
     (((centerMulEquivRootsOfUnity n hn A).symm ζ :
         Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) =
       Matrix.scalar (Fin n) ((ζ : Aˣ) : A) := by
@@ -90,7 +90,7 @@ theorem coe_centerMulEquivRootsOfUnity_symm_apply (hn : 0 < n)
   rfl
 
 /-- Send a roots-of-unity point to the corresponding scalar special-linear point. -/
-noncomputable def scalarRootsPoints (hn : 0 < n) {A : Type u} [CommRing A] [Algebra R A] :
+noncomputable def scalarRootsPoints (hn : 0 < n) {A : Type v} [CommRing A] [Algebra R A] :
     WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A) →*
       WithConv (coordinateHopfAlgebra R n →ₐ[R] A) :=
   (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm.toMonoidHom.comp
@@ -102,7 +102,7 @@ noncomputable def scalarRootsPoints (hn : 0 < n) {A : Type u} [CommRing A] [Alge
 attached to a root of unity. -/
 @[simp]
 theorem pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
-    {A : Type u} [CommRing A] [Algebra R A]
+    {A : Type v} [CommRing A] [Algebra R A]
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
     TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n
         (scalarRootsPoints n hn f) =
@@ -112,7 +112,7 @@ theorem pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
 
 /-- The central special-linear matrix attached to a root of unity is a scalar matrix. -/
 theorem coe_pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
-    {A : Type u} [CommRing A] [Algebra R A]
+    {A : Type v} [CommRing A] [Algebra R A]
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
     ((TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n
         (scalarRootsPoints n hn f) :
@@ -122,9 +122,9 @@ theorem coe_pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
   rw [pointsMulEquiv_scalarRootsPoints]
   exact coe_centerMulEquivRootsOfUnity_symm_apply n hn A _
 
-/-- The scalar roots-of-unity map is injective in positive rank. -/
+/-- For `0 < n`, the scalar roots-of-unity map is injective. -/
 theorem scalarRootsPoints_injective (hn : 0 < n)
-    {A : Type u} [CommRing A] [Algebra R A] :
+    {A : Type v} [CommRing A] [Algebra R A] :
     Function.Injective (scalarRootsPoints (R := R) n hn (A := A)) := by
   intro f g hfg
   apply (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).injective
@@ -136,7 +136,7 @@ theorem scalarRootsPoints_injective (hn : 0 < n)
 
 /-- The scalar roots-of-unity construction is natural in the value algebra. -/
 theorem mapValue_scalarRootsPoints (hn : 0 < n)
-    {A B : Type u} [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+    {A : Type v} {B : Type w} [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
     (φ : A →ₐ[R] B)
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
     AlgHom.mapValue (H := coordinateHopfAlgebra R n) φ (scalarRootsPoints n hn f) =
@@ -145,7 +145,6 @@ theorem mapValue_scalarRootsPoints (hn : 0 < n)
   apply (SpecialLinear.pointsMulEquiv (R := R) (A := B) n).injective
   have hmap := SpecialLinear.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) n φ
     (scalarRootsPoints n hn f)
-  rw [HopfAlgebra.mapPoints_apply, CommAlgCat.hom_ofHom, ← AlgHom.mapValue_apply] at hmap
   rw [hmap, pointsMulEquiv_scalarRootsPoints]
   apply SetCoe.ext
   ext i j
@@ -191,7 +190,15 @@ noncomputable def scalarRootsCenterHom (hn : 0 < n) (A : CommAlgCat.{u} k) :
     (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
     (scalarRootsPoints_mem_centerPointsSubgroup n hn)
 
-/-- In positive rank, scalar roots of unity give every universally central point of `SLₙ`. -/
+/-- The value of `scalarRootsCenterHom` is the underlying scalar special-linear point. -/
+@[simp]
+theorem coe_scalarRootsCenterHom_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
+    (f : HopfAlgebra.points (R := k)
+      (H := MonoidAlgebra k (Multiplicative (ZMod n))) A) :
+    (scalarRootsCenterHom n hn A f).1 = scalarRootsPoints n hn f := by
+  rfl
+
+/-- For `0 < n`, scalar roots of unity give every universally central point of `SLₙ`. -/
 theorem scalarRootsCenterHom_bijective (hn : 0 < n) (A : CommAlgCat.{u} k) :
     Function.Bijective (scalarRootsCenterHom n hn A) := by
   constructor
@@ -217,8 +224,7 @@ theorem scalarRootsCenterHom_bijective (hn : 0 < n) (A : CommAlgCat.{u} k) :
       centerMulEquivRootsOfUnity n hn A c
     refine ⟨(RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm ζ, ?_⟩
     apply Subtype.ext
-    change scalarRootsPoints n hn
-      ((RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm ζ) = g.1
+    rw [coe_scalarRootsCenterHom_apply]
     apply (SpecialLinear.pointsMulEquiv (R := k) (A := A) n).injective
     rw [pointsMulEquiv_scalarRootsPoints, MulEquiv.apply_symm_apply]
     exact congrArg Subtype.val
@@ -253,11 +259,19 @@ noncomputable def scalarRootsCenterNatIso (hn : 0 < n) :
     intro A B φ
     ext f
     apply Subtype.ext
-    change scalarRootsPoints n hn
-        (AlgHom.mapValue (H := MonoidAlgebra k (Multiplicative (ZMod n))) φ.hom f) =
+    change ((scalarRootsCenterHom n hn B)
+        (AlgHom.mapValue (H := MonoidAlgebra k (Multiplicative (ZMod n))) φ.hom f)).1 =
       AlgHom.mapValue (H := coordinateHopfAlgebra k n) φ.hom
-        (scalarRootsPoints n hn f)
-    exact (mapValue_scalarRootsPoints n hn φ.hom f).symm)
+        ((scalarRootsCenterHom n hn A f).1)
+    calc
+      _ = scalarRootsPoints n hn
+          (AlgHom.mapValue (H := MonoidAlgebra k (Multiplicative (ZMod n))) φ.hom f) :=
+        coe_scalarRootsCenterHom_apply n hn B _
+      _ = AlgHom.mapValue (H := coordinateHopfAlgebra k n) φ.hom
+          (scalarRootsPoints n hn f) :=
+        (mapValue_scalarRootsPoints n hn φ.hom f).symm
+      _ = _ := congrArg (AlgHom.mapValue (H := coordinateHopfAlgebra k n) φ.hom)
+        (coe_scalarRootsCenterHom_apply n hn A f).symm)
 
 /-- The natural isomorphism sends a `μₙ`-point to its scalar matrix. -/
 @[simp]
@@ -287,7 +301,7 @@ noncomputable def scalarRootsCenterCoordinatePointsNatIso (hn : 0 < n) :
       (coordinateHopfAlgebra k n)
       (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))).symm
 
-/-- The coordinate Hopf algebra of the center of positive-rank `SLₙ` is the group algebra of
+/-- For `0 < n`, the coordinate Hopf algebra of the center of `SLₙ` is the group algebra of
 `Multiplicative (ZMod n)`, the coordinate Hopf algebra of `μₙ`. -/
 noncomputable def centerCoordinateIso (hn : 0 < n) :
     CommHopfAlgCat.quotient (coordinateHopfAlgebra k n)

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
@@ -9,6 +9,7 @@ public import TauCeti.Algebra.AlgebraicGroup.Center.Basic
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 public import TauCeti.Algebra.AlgebraicGroup.RootsOfUnity.Basic
 public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
+public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
 
 /-!
 # The center of the special linear group
@@ -31,12 +32,12 @@ isogeny from `SLₙ` toward its adjoint form.
 
 ## Main declarations
 
-* `TauCeti.SpecialLinear.scalarRootsPoints`: the scalar-matrix map from `μₙ`-points to
+* `TauCeti.SpecialLinear.rootsOfUnityScalarPoints`: the scalar-matrix map from `μₙ`-points to
   `SLₙ`-points.
-* `TauCeti.SpecialLinear.scalarRootsCenterNatIso`: the natural isomorphism from `μₙ`-points
+* `TauCeti.SpecialLinear.rootsOfUnityScalarCenterNatIso`: the natural isomorphism from `μₙ`-points
   to the represented center of `SLₙ`.
-* `TauCeti.SpecialLinear.centerCoordinateIso`: the center coordinate Hopf algebra of `SLₙ`
-  is the group algebra of `Multiplicative (ZMod n)`.
+* `TauCeti.SpecialLinear.centerCoordinateIsoGroupAlgebra`: the center coordinate Hopf algebra of
+  `SLₙ` is the group algebra of `Multiplicative (ZMod n)`.
 
 ## References
 
@@ -56,131 +57,100 @@ namespace SpecialLinear
 
 universe u v w
 
-variable {R : Type u} [CommRing R]
 variable (n : ℕ)
 
-/-- For `0 < n`, the center of the special linear group is the group of `n`th roots of unity.
-This specializes Mathlib's finite-index-type equivalence to matrices indexed by `Fin n`. -/
-noncomputable def centerMulEquivRootsOfUnity (hn : 0 < n)
-    (A : Type v) [CommRing A] :
-    Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) ≃* rootsOfUnity n A :=
-  (Matrix.SpecialLinearGroup.center_equiv_rootsOfUnity' (R := A)
-    (⟨0, hn⟩ : Fin n)).trans <| MulEquiv.subgroupCongr <| by
-      rw [Fintype.card_fin]
+/-- The scalar-matrix homomorphism from `n`th roots of unity to `SL(Fin n, A)`. -/
+@[expose] noncomputable def rootsOfUnityScalarSL {A : Type v} [CommRing A] :
+    rootsOfUnity n A →* Matrix.SpecialLinearGroup (Fin n) A where
+  toFun ζ := (⟨Matrix.scalar (Fin n) ((ζ : Aˣ) : A), by
+    rw [Matrix.scalar_apply, Matrix.det_diagonal]
+    simpa using congrArg Units.val ζ.property⟩ :
+      Matrix.SpecialLinearGroup (Fin n) A)
+  map_one' := by
+    apply Matrix.SpecialLinearGroup.ext
+    intro i j
+    simp [Matrix.scalar_apply]
+  map_mul' ζ ξ := by
+    apply Subtype.ext
+    -- After subtype extensionality, expose the record's `toFun`; all matrix algebra is then
+    -- discharged by the scalar-matrix simp lemmas.
+    change Matrix.scalar (Fin n) ((((ζ * ξ : rootsOfUnity n A) : Aˣ) : A)) =
+      Matrix.scalar (Fin n) (((ζ : Aˣ) : A)) *
+        Matrix.scalar (Fin n) (((ξ : Aˣ) : A))
+    simp
 
-/-- The inverse center equivalence sends a root of unity to its scalar matrix. -/
+/-- The underlying matrix of `rootsOfUnityScalarSL` is the corresponding scalar matrix. -/
 @[simp]
-theorem coe_centerMulEquivRootsOfUnity_symm_apply (hn : 0 < n)
-    (A : Type v) [CommRing A] (ζ : rootsOfUnity n A) :
-    (((centerMulEquivRootsOfUnity n hn A).symm ζ :
-        Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) =
-      Matrix.scalar (Fin n) ((ζ : Aˣ) : A) := by
-  let hcard : rootsOfUnity (Fintype.card (Fin n)) A = rootsOfUnity n A :=
-    congrArg (fun m ↦ rootsOfUnity m A) (Fintype.card_fin n)
-  have hunit :
-      (((MulEquiv.subgroupCongr hcard).symm ζ :
-        rootsOfUnity (Fintype.card (Fin n)) A) : Aˣ) = (ζ : Aˣ) :=
-    MulEquiv.subgroupCongr_symm_apply hcard ζ
-  have hval := congrArg Units.val hunit
-  -- Unfolding the two equivalences leaves the scalar action used by Mathlib's inverse.
-  change (((((MulEquiv.subgroupCongr hcard).symm ζ :
-      rootsOfUnity (Fintype.card (Fin n)) A) : Aˣ) : A) •
-        (1 : Matrix (Fin n) (Fin n) A)) = Matrix.scalar (Fin n) ((ζ : Aˣ) : A)
-  rw [hval, Matrix.smul_one_eq_diagonal]
+theorem coe_rootsOfUnityScalarSL {A : Type v} [CommRing A] (ζ : rootsOfUnity n A) :
+    ((rootsOfUnityScalarSL n ζ : Matrix.SpecialLinearGroup (Fin n) A) :
+      Matrix (Fin n) (Fin n) A) = Matrix.scalar (Fin n) ((ζ : Aˣ) : A) :=
   rfl
 
 /-- Send a roots-of-unity point to the corresponding scalar special-linear point. -/
-noncomputable def scalarRootsPoints {A : Type v} [CommRing A] [Algebra R A] :
+@[expose] noncomputable def rootsOfUnityScalarPoints
+    {R : Type u} [CommRing R] {A : Type v} [CommRing A] [Algebra R A] :
     WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A) →*
       WithConv (coordinateHopfAlgebra R n →ₐ[R] A) :=
-  (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm.toMonoidHom.comp
-    (({
-      toFun ζ := ⟨Matrix.scalar (Fin n) (((ζ : Aˣ) : A)), by
-        -- `Matrix.scalar` is defined as a diagonal matrix, while the available determinant
-        -- lemma is stated for `Matrix.diagonal`; expose that representation before rewriting.
-        change (Matrix.diagonal fun _ : Fin n ↦ (((ζ : Aˣ) : A))).det = 1
-        rw [Matrix.det_diagonal]
-        simpa using congrArg Units.val ζ.property⟩
-      map_one' := by
-        apply Subtype.ext
-        -- The special-linear group inherits its identity through the matrix subtype, so after
-        -- subtype extensionality this reduction exposes the underlying scalar-matrix identity.
-        change Matrix.scalar (Fin n) (1 : A) = 1
-        exact map_one (Matrix.scalar (Fin n))
-      map_mul' ζ ξ := by
-        apply Subtype.ext
-        -- Likewise, subtype multiplication and the coercions from roots of unity reduce to the
-        -- underlying matrix product; this is the form recognized by the scalar-matrix simp API.
-        change Matrix.scalar (Fin n) ((((ζ * ξ : rootsOfUnity n A) : Aˣ) : A)) =
-          Matrix.scalar (Fin n) (((ζ : Aˣ) : A)) *
-            Matrix.scalar (Fin n) (((ξ : Aˣ) : A))
-        simp
-    } : rootsOfUnity n A →* Matrix.SpecialLinearGroup (Fin n) A).comp
-      (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).toMonoidHom)
+  (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm.toMonoidHom.comp <|
+    (rootsOfUnityScalarSL n).comp
+      (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).toMonoidHom
 
-/-- Under the standard point equivalences, `scalarRootsPoints` is the central scalar matrix
+/-- Under the standard point equivalences, `rootsOfUnityScalarPoints` is the scalar matrix
 attached to a root of unity. -/
 @[simp]
-theorem pointsMulEquiv_scalarRootsPoints {A : Type v} [CommRing A] [Algebra R A]
+theorem pointsMulEquiv_rootsOfUnityScalarPoints
+    {R : Type u} [CommRing R] {A : Type v} [CommRing A] [Algebra R A]
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
     TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n
-        (scalarRootsPoints n f) =
-      (⟨Matrix.scalar (Fin n)
-          ((RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f : Aˣ) : A), by
-        change (Matrix.diagonal fun _ : Fin n ↦
-          ((RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f : Aˣ) : A)).det = 1
-        rw [Matrix.det_diagonal]
-        simpa using congrArg Units.val
-          (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f).property⟩ :
-        Matrix.SpecialLinearGroup (Fin n) A) := by
-  -- This is the application lemma for `scalarRootsPoints` itself, so no earlier propositional
-  -- rewrite can expose its defining composite. Unfold just far enough to use `apply_symm_apply`.
-  change (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n)
-    ((TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n).symm _) = _
-  rw [MulEquiv.apply_symm_apply]
-  rfl
+        (rootsOfUnityScalarPoints n f) =
+      rootsOfUnityScalarSL n
+        (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f) := by
+  simp [rootsOfUnityScalarPoints]
 
 /-- The central special-linear matrix attached to a root of unity is a scalar matrix. -/
 @[simp]
-theorem coe_pointsMulEquiv_scalarRootsPoints {A : Type v} [CommRing A] [Algebra R A]
+theorem coe_pointsMulEquiv_rootsOfUnityScalarPoints
+    {R : Type u} [CommRing R] {A : Type v} [CommRing A] [Algebra R A]
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
     ((TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n
-        (scalarRootsPoints n f) :
+        (rootsOfUnityScalarPoints n f) :
         Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) =
       Matrix.scalar (Fin n)
         ((RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n f : Aˣ) : A) := by
-  rw [pointsMulEquiv_scalarRootsPoints]
+  rw [pointsMulEquiv_rootsOfUnityScalarPoints, coe_rootsOfUnityScalarSL]
 
 /-- For `0 < n`, the scalar roots-of-unity map is injective. -/
-theorem scalarRootsPoints_injective (hn : 0 < n)
-    {A : Type v} [CommRing A] [Algebra R A] :
-    Function.Injective (scalarRootsPoints (R := R) n (A := A)) := by
+theorem rootsOfUnityScalarPoints_injective (hn : 0 < n)
+    {R : Type u} [CommRing R] {A : Type v} [CommRing A] [Algebra R A] :
+    Function.Injective (rootsOfUnityScalarPoints (R := R) n (A := A)) := by
   intro f g hfg
   apply (RootsOfUnityGroup.pointsMulEquiv (R := R) (A := A) n).injective
   apply Subtype.ext
   apply Units.ext
   have h := congrArg (TauCeti.SpecialLinear.pointsMulEquiv (R := R) (A := A) n) hfg
   have hmatrix := congrArg Subtype.val h
-  rw [coe_pointsMulEquiv_scalarRootsPoints,
-    coe_pointsMulEquiv_scalarRootsPoints] at hmatrix
-  have hentry := congrFun₂ hmatrix (⟨0, hn⟩ : Fin n) ⟨0, hn⟩
-  simpa using hentry
+  rw [coe_pointsMulEquiv_rootsOfUnityScalarPoints,
+    coe_pointsMulEquiv_rootsOfUnityScalarPoints] at hmatrix
+  exact (@Matrix.scalar_inj (Fin n) A inferInstance inferInstance inferInstance
+    ⟨⟨0, hn⟩⟩ _ _).mp hmatrix
 
 /-- The scalar roots-of-unity construction is natural in the value algebra. -/
-theorem mapValue_scalarRootsPoints {A : Type v} {B : Type w}
+theorem mapValue_rootsOfUnityScalarPoints
+    {R : Type u} [CommRing R] {A : Type v} {B : Type w}
     [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
     (φ : A →ₐ[R] B)
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
-    AlgHom.mapValue (H := coordinateHopfAlgebra R n) φ (scalarRootsPoints n f) =
-      scalarRootsPoints n
+    AlgHom.mapValue (H := coordinateHopfAlgebra R n) φ (rootsOfUnityScalarPoints n f) =
+      rootsOfUnityScalarPoints n
         (AlgHom.mapValue (H := MonoidAlgebra R (Multiplicative (ZMod n))) φ f) := by
   apply (SpecialLinear.pointsMulEquiv (R := R) (A := B) n).injective
   have hmap := SpecialLinear.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) n φ
-    (scalarRootsPoints n f)
+    (rootsOfUnityScalarPoints n f)
   rw [hmap]
   apply Subtype.ext
   rw [Matrix.SpecialLinearGroup.map_apply_coe,
-    coe_pointsMulEquiv_scalarRootsPoints, coe_pointsMulEquiv_scalarRootsPoints]
+    coe_pointsMulEquiv_rootsOfUnityScalarPoints,
+    coe_pointsMulEquiv_rootsOfUnityScalarPoints]
   ext i j
   rw [RootsOfUnityGroup.pointsMulEquiv_mapValue]
   by_cases hij : i = j <;>
@@ -188,147 +158,275 @@ theorem mapValue_scalarRootsPoints {A : Type v} {B : Type w}
 
 section Center
 
-variable {k : Type u} [Field k]
+variable {S : Type u} [CommRing S]
 
-/-- Every roots-of-unity scalar point is a point of the represented center of `SLₙ`. -/
-theorem scalarRootsPoints_mem_centerPointsSubgroup {A : Type u} [CommRing A] [Algebra k A]
-    (f : WithConv (MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[k] A)) :
-    scalarRootsPoints n f ∈ CommHopfAlgCat.centerPointsSubgroup
-      (coordinateHopfAlgebra k n) (CommAlgCat.of k A) := by
-  rw [CommHopfAlgCat.mem_centerPointsSubgroup_iff, HopfAlgebra.isCentralPoint_def]
+/-- A scalar roots-of-unity point is universally central over any commutative base ring. -/
+theorem isCentralPoint_rootsOfUnityScalarPoints
+    {A : Type u} [CommRing A] [Algebra S A]
+    (f : WithConv (MonoidAlgebra S (Multiplicative (ZMod n)) →ₐ[S] A)) :
+    HopfAlgebra.IsCentralPoint (rootsOfUnityScalarPoints n f) := by
+  rw [HopfAlgebra.isCentralPoint_def]
   intro B _ _ φ g
-  apply (SpecialLinear.pointsMulEquiv (R := k) (A := B) n).injective
-  rw [map_mul, map_mul, mapValue_scalarRootsPoints,
-    pointsMulEquiv_scalarRootsPoints]
+  apply (SpecialLinear.pointsMulEquiv (R := S) (A := B) n).injective
+  rw [map_mul, map_mul, mapValue_rootsOfUnityScalarPoints,
+    pointsMulEquiv_rootsOfUnityScalarPoints]
   apply Subtype.ext
   exact (Matrix.scalar_commute _ (fun r ↦ Commute.all _ r)
-    (SpecialLinear.pointsMulEquiv (R := k) (A := B) n g).1).eq
+    (SpecialLinear.pointsMulEquiv (R := S) (A := B) n g).1).eq
 
-/-- The scalar roots-of-unity map with codomain restricted to the represented center. -/
-noncomputable def scalarRootsCenterHom (A : CommAlgCat.{u} k) :
-    HopfAlgebra.points (R := k)
-        (H := MonoidAlgebra k (Multiplicative (ZMod n))) A →*
-      CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A :=
-  (scalarRootsPoints (R := k) n (A := A)).codRestrict
-    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
-    (scalarRootsPoints_mem_centerPointsSubgroup n)
+/-- The scalar roots-of-unity map with codomain restricted to the universal center. -/
+@[expose] noncomputable def rootsOfUnityScalarCenterHom
+    (A : Type u) [CommRing A] [Algebra S A] :
+    WithConv (MonoidAlgebra S (Multiplicative (ZMod n)) →ₐ[S] A) →*
+      HopfAlgebra.center S (coordinateHopfAlgebra S n) A :=
+  (rootsOfUnityScalarPoints (R := S) n (A := A)).codRestrict
+    (HopfAlgebra.center S (coordinateHopfAlgebra S n) A)
+    fun f ↦ HopfAlgebra.mem_center.mpr (isCentralPoint_rootsOfUnityScalarPoints n f)
 
-/-- The value of `scalarRootsCenterHom` is the underlying scalar special-linear point. -/
+/-- The value of `rootsOfUnityScalarCenterHom` is the underlying scalar point. -/
 @[simp]
-theorem coe_scalarRootsCenterHom_apply (A : CommAlgCat.{u} k)
-    (f : HopfAlgebra.points (R := k)
-      (H := MonoidAlgebra k (Multiplicative (ZMod n))) A) :
-    (scalarRootsCenterHom n A f).1 = scalarRootsPoints n f := by
+theorem coe_rootsOfUnityScalarCenterHom_apply
+    (A : Type u) [CommRing A] [Algebra S A]
+    (f : WithConv (MonoidAlgebra S (Multiplicative (ZMod n)) →ₐ[S] A)) :
+    (rootsOfUnityScalarCenterHom n A f).1 = rootsOfUnityScalarPoints n f := by
   rfl
 
 /-- For `0 < n`, scalar roots of unity give every universally central point of `SLₙ`. -/
-theorem scalarRootsCenterHom_bijective (hn : 0 < n) (A : CommAlgCat.{u} k) :
-    Function.Bijective (scalarRootsCenterHom n A) := by
+theorem rootsOfUnityScalarCenterHom_bijective (hn : 0 < n)
+    (A : Type u) [CommRing A] [Algebra S A] :
+    Function.Bijective (rootsOfUnityScalarCenterHom (S := S) n A) := by
   constructor
   · intro f g hfg
-    apply scalarRootsPoints_injective (R := k) n hn
+    apply rootsOfUnityScalarPoints_injective (R := S) n hn
     exact congrArg Subtype.val hfg
   · intro g
     have hgcentral :
-        SpecialLinear.pointsMulEquiv (R := k) (A := A) n g.1 ∈
+        SpecialLinear.pointsMulEquiv (R := S) (A := A) n g.1 ∈
           Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) := by
       apply MulEquivClass.apply_mem_center
       apply HopfAlgebra.center_le_center
-      rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
       exact g.2
     let c : Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) :=
-      ⟨SpecialLinear.pointsMulEquiv (R := k) (A := A) n g.1, hgcentral⟩
+      ⟨SpecialLinear.pointsMulEquiv (R := S) (A := A) n g.1, hgcentral⟩
     let ζ : rootsOfUnity n A :=
-      centerMulEquivRootsOfUnity n hn A c
-    refine ⟨(RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm ζ, ?_⟩
+      Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A c
+    refine ⟨(RootsOfUnityGroup.pointsMulEquiv (R := S) (A := A) n).symm ζ, ?_⟩
     apply Subtype.ext
-    rw [coe_scalarRootsCenterHom_apply]
-    apply (SpecialLinear.pointsMulEquiv (R := k) (A := A) n).injective
+    rw [coe_rootsOfUnityScalarCenterHom_apply]
+    apply (SpecialLinear.pointsMulEquiv (R := S) (A := A) n).injective
     apply Subtype.ext
-    rw [coe_pointsMulEquiv_scalarRootsPoints, MulEquiv.apply_symm_apply,
-      ← coe_centerMulEquivRootsOfUnity_symm_apply n hn A ζ]
+    rw [coe_pointsMulEquiv_rootsOfUnityScalarPoints, MulEquiv.apply_symm_apply,
+      ← Matrix.SpecialLinearGroup.coe_centerMulEquivRootsOfUnityFin_symm_apply n hn A ζ]
     simpa only [ζ] using
       congrArg (fun x : Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) ↦
         (((x : Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A)))
-        ((centerMulEquivRootsOfUnity n hn A).symm_apply_apply c)
+        ((Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A).symm_apply_apply c)
+
+/-- For `0 < n`, scalar roots of unity identify `μₙ` with the universal center of `SLₙ`
+pointwise over any commutative base ring. -/
+@[expose] noncomputable def rootsOfUnityScalarCenterMulEquiv (hn : 0 < n)
+    (A : Type u) [CommRing A] [Algebra S A] :
+    WithConv (MonoidAlgebra S (Multiplicative (ZMod n)) →ₐ[S] A) ≃*
+      HopfAlgebra.center S (coordinateHopfAlgebra S n) A :=
+  MulEquiv.ofBijective (rootsOfUnityScalarCenterHom (S := S) n A)
+    (rootsOfUnityScalarCenterHom_bijective (S := S) n hn A)
+
+/-- The forward map of `rootsOfUnityScalarCenterMulEquiv` is the scalar-point map. -/
+@[simp]
+theorem rootsOfUnityScalarCenterMulEquiv_apply (hn : 0 < n)
+    (A : Type u) [CommRing A] [Algebra S A]
+    (f : WithConv (MonoidAlgebra S (Multiplicative (ZMod n)) →ₐ[S] A)) :
+    (rootsOfUnityScalarCenterMulEquiv n hn A f).1 = rootsOfUnityScalarPoints n f := by
+  rfl
+
+/-- Read the root of unity from the upper-left entry of a universally central `SLₙ`-point. -/
+@[expose] noncomputable def rootsOfUnityOfCenterPoint (hn : 0 < n)
+    {A : Type u} [CommRing A] [Algebra S A]
+    (g : HopfAlgebra.center S (coordinateHopfAlgebra S n) A) : rootsOfUnity n A :=
+  Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A
+    ⟨SpecialLinear.pointsMulEquiv (R := S) (A := A) n g.1, by
+      apply MulEquivClass.apply_mem_center
+      exact HopfAlgebra.center_le_center g.2⟩
+
+/-- The inverse pointwise center equivalence reads off the root of unity from the central
+special-linear matrix. -/
+@[simp]
+theorem rootsOfUnityScalarCenterMulEquiv_symm_apply (hn : 0 < n)
+    (A : Type u) [CommRing A] [Algebra S A]
+    (g : HopfAlgebra.center S (coordinateHopfAlgebra S n) A) :
+    (rootsOfUnityScalarCenterMulEquiv (S := S) n hn A).symm g =
+      (RootsOfUnityGroup.pointsMulEquiv (R := S) (A := A) n).symm
+        (rootsOfUnityOfCenterPoint (S := S) n hn g) := by
+  apply (rootsOfUnityScalarCenterMulEquiv (S := S) n hn A).injective
+  rw [MulEquiv.apply_symm_apply]
+  apply Subtype.ext
+  rw [rootsOfUnityScalarCenterMulEquiv_apply]
+  apply (SpecialLinear.pointsMulEquiv (R := S) (A := A) n).injective
+  apply Subtype.ext
+  rw [coe_pointsMulEquiv_rootsOfUnityScalarPoints, MulEquiv.apply_symm_apply,
+    ← Matrix.SpecialLinearGroup.coe_centerMulEquivRootsOfUnityFin_symm_apply n hn A
+      (rootsOfUnityOfCenterPoint (S := S) n hn g)]
+  simp only [rootsOfUnityOfCenterPoint]
+  simpa only using (congrArg
+    (fun c : Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A) ↦
+      ((c : Matrix.SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A))
+    ((Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin n hn A).symm_apply_apply
+      (⟨SpecialLinear.pointsMulEquiv (R := S) (A := A) n g.1, by
+        apply MulEquivClass.apply_mem_center
+        exact HopfAlgebra.center_le_center g.2⟩ :
+        Subgroup.center (Matrix.SpecialLinearGroup (Fin n) A)))).symm
+
+variable {k : Type u} [Field k]
+
+/-- Every roots-of-unity scalar point is a point of the represented center of `SLₙ`. -/
+theorem rootsOfUnityScalarPoints_mem_centerPointsSubgroup
+    {A : Type u} [CommRing A] [Algebra k A]
+    (f : WithConv (MonoidAlgebra k (Multiplicative (ZMod n)) →ₐ[k] A)) :
+    rootsOfUnityScalarPoints n f ∈ CommHopfAlgCat.centerPointsSubgroup
+      (coordinateHopfAlgebra k n) (CommAlgCat.of k A) :=
+  (CommHopfAlgCat.mem_centerPointsSubgroup_iff _ _ _).2
+    (isCentralPoint_rootsOfUnityScalarPoints n f)
 
 /-- For every value algebra, scalar roots of unity identify `μₙ` with the represented center
 of `SLₙ`. -/
-noncomputable def scalarRootsCenterIso (hn : 0 < n) (A : CommAlgCat.{u} k) :
+noncomputable def rootsOfUnityScalarCenterIso (hn : 0 < n) (A : CommAlgCat.{u} k) :
     HopfAlgebra.points (R := k)
         (H := MonoidAlgebra k (Multiplicative (ZMod n))) A ≅
       GrpCat.of (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) :=
-  (MulEquiv.ofBijective (scalarRootsCenterHom n A)
-    (scalarRootsCenterHom_bijective n hn A)).toGrpIso
+  ((rootsOfUnityScalarCenterMulEquiv (S := k) n hn A).trans <|
+    MulEquiv.subgroupCongr
+      (CommHopfAlgCat.centerPointsSubgroup_eq_center (coordinateHopfAlgebra k n) A).symm).toGrpIso
 
-/-- The forward component of `scalarRootsCenterIso` is the scalar-matrix homomorphism. -/
+/-- The forward component of `rootsOfUnityScalarCenterIso` is the scalar-matrix map. -/
 @[simp]
-theorem scalarRootsCenterIso_hom_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
+theorem rootsOfUnityScalarCenterIso_hom_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
     (f : HopfAlgebra.points (R := k)
       (H := MonoidAlgebra k (Multiplicative (ZMod n))) A) :
-    (scalarRootsCenterIso n hn A).hom f = scalarRootsCenterHom n A f := by
+    ((rootsOfUnityScalarCenterIso n hn A).hom f).1 = rootsOfUnityScalarPoints n f := by
   rfl
+
+/-- The inverse represented-center equivalence reads off the root of unity from the central
+special-linear matrix. -/
+@[simp]
+theorem rootsOfUnityScalarCenterIso_inv_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
+    (g : CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) :
+    (rootsOfUnityScalarCenterIso n hn A).inv g =
+      (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm
+        (rootsOfUnityOfCenterPoint (S := k) n hn
+          (⟨g.1, by
+            rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
+            exact g.2⟩ : HopfAlgebra.center k (coordinateHopfAlgebra k n) A)) := by
+  change (rootsOfUnityScalarCenterMulEquiv (S := k) n hn A).symm _ = _
+  rw [rootsOfUnityScalarCenterMulEquiv_symm_apply]
+  congr 2
 
 /-- Scalar roots of unity identify the `μₙ` point functor with the represented center
 subfunctor of `SLₙ`. -/
-noncomputable def scalarRootsCenterNatIso (hn : 0 < n) :
+@[expose] noncomputable def rootsOfUnityScalarCenterNatIso (hn : 0 < n) :
     HopfAlgebra.pointsFunctor (R := k)
         (H := MonoidAlgebra k (Multiplicative (ZMod n))) ≅
       CommHopfAlgCat.quotientPointsSubgroupFunctor
         (coordinateHopfAlgebra k n)
         (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n)) :=
-  NatIso.ofComponents (scalarRootsCenterIso n hn) (by
+  NatIso.ofComponents (rootsOfUnityScalarCenterIso n hn) (by
     intro A B φ
     ext f
     apply Subtype.ext
-    -- The component and its application lemma cannot be used while this natural isomorphism is
-    -- being constructed. After subgroup extensionality, `codRestrict` and the restricted functor
-    -- map reduce definitionally, leaving precisely the scalar-point naturality theorem.
-    exact (mapValue_scalarRootsPoints n φ.hom f).symm)
+    change ((rootsOfUnityScalarCenterIso n hn B).hom
+        (AlgHom.mapValue φ.hom f)).1 =
+      AlgHom.mapValue φ.hom ((rootsOfUnityScalarCenterIso n hn A).hom f).1
+    calc
+      _ = rootsOfUnityScalarPoints n (AlgHom.mapValue φ.hom f) :=
+        rootsOfUnityScalarCenterIso_hom_apply n hn B _
+      _ = AlgHom.mapValue φ.hom (rootsOfUnityScalarPoints n f) :=
+        (mapValue_rootsOfUnityScalarPoints n φ.hom f).symm
+      _ = _ := congrArg (AlgHom.mapValue φ.hom)
+        (rootsOfUnityScalarCenterIso_hom_apply n hn A f).symm)
 
 /-- The natural isomorphism sends a `μₙ`-point to its scalar matrix. -/
 @[simp]
-theorem scalarRootsCenterNatIso_hom_app_apply (hn : 0 < n) (A : CommAlgCat.{u} k)
+theorem rootsOfUnityScalarCenterNatIso_hom_app_apply
+    (hn : 0 < n) (A : CommAlgCat.{u} k)
     (f : HopfAlgebra.points (R := k)
       (H := MonoidAlgebra k (Multiplicative (ZMod n))) A) :
-    CategoryTheory.ConcreteCategory.hom
+    (CategoryTheory.ConcreteCategory.hom
         (X := (HopfAlgebra.pointsFunctor (R := k)
           (H := MonoidAlgebra k (Multiplicative (ZMod n)))).obj A)
         (Y := GrpCat.of (CommHopfAlgCat.centerPointsSubgroup
           (coordinateHopfAlgebra k n) A))
-        ((scalarRootsCenterNatIso n hn).hom.app A) f =
-      scalarRootsCenterHom n A f := by
-  rfl
+        ((rootsOfUnityScalarCenterNatIso n hn).hom.app A) f).1 =
+      rootsOfUnityScalarPoints n f := by
+  exact rootsOfUnityScalarCenterIso_hom_apply n hn A f
+
+/-- The inverse natural-isomorphism component reads off the root of unity from the central
+special-linear matrix. -/
+@[simp]
+theorem rootsOfUnityScalarCenterNatIso_inv_app_apply
+    (hn : 0 < n) (A : CommAlgCat.{u} k)
+    (g : CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) :
+    CategoryTheory.ConcreteCategory.hom
+        (X := GrpCat.of (CommHopfAlgCat.centerPointsSubgroup
+          (coordinateHopfAlgebra k n) A))
+        (Y := (HopfAlgebra.pointsFunctor (R := k)
+          (H := MonoidAlgebra k (Multiplicative (ZMod n)))).obj A)
+        ((rootsOfUnityScalarCenterNatIso n hn).inv.app A) g =
+      (RootsOfUnityGroup.pointsMulEquiv (R := k) (A := A) n).symm
+        (rootsOfUnityOfCenterPoint (S := k) n hn
+          (⟨g.1, by
+            rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
+            exact g.2⟩ : HopfAlgebra.center k (coordinateHopfAlgebra k n) A)) := by
+  exact rootsOfUnityScalarCenterIso_inv_apply n hn A g
 
 /-- The point functor of `μₙ` is naturally isomorphic to the point functor represented by the
 center coordinate Hopf algebra of `SLₙ`. -/
-noncomputable def scalarRootsCenterCoordinatePointsNatIso (hn : 0 < n) :
+@[expose] noncomputable def rootsOfUnityScalarCenterCoordinatePointsNatIso (hn : 0 < n) :
     (CommHopfAlgCat.pointsFunctor (R := k)).obj
         (Opposite.op (CommHopfAlgCat.of k
           (MonoidAlgebra k (Multiplicative (ZMod n))))) ≅
       (CommHopfAlgCat.pointsFunctor (R := k)).obj
         (Opposite.op (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n)
           (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n)))) :=
-  scalarRootsCenterNatIso n hn ≪≫
+  rootsOfUnityScalarCenterNatIso n hn ≪≫
     (CommHopfAlgCat.quotientPointsSubgroupNatIso
       (coordinateHopfAlgebra k n)
       (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))).symm
 
+/-- The forward coordinate-center natural transformation first sends a root of unity to the
+represented center and then lifts that center point through the quotient coordinate algebra. -/
+theorem rootsOfUnityScalarCenterCoordinatePointsNatIso_hom (hn : 0 < n) :
+    (rootsOfUnityScalarCenterCoordinatePointsNatIso n hn).hom =
+      (rootsOfUnityScalarCenterNatIso n hn).hom ≫
+        (CommHopfAlgCat.quotientPointsSubgroupNatIso
+          (coordinateHopfAlgebra k n)
+          (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))).inv :=
+  Iso.trans_hom _ _
+
+/-- The inverse coordinate-center natural transformation includes a quotient point into `SLₙ`
+and then reads off its root of unity. -/
+theorem rootsOfUnityScalarCenterCoordinatePointsNatIso_inv (hn : 0 < n) :
+    (rootsOfUnityScalarCenterCoordinatePointsNatIso n hn).inv =
+      (CommHopfAlgCat.quotientPointsSubgroupNatIso
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))).hom ≫
+          (rootsOfUnityScalarCenterNatIso n hn).inv :=
+  Iso.trans_inv _ _
+
 /-- For `0 < n`, the coordinate Hopf algebra of the center of `SLₙ` is the group algebra of
 `Multiplicative (ZMod n)`, the coordinate Hopf algebra of `μₙ`. -/
-noncomputable def centerCoordinateIso (hn : 0 < n) :
+noncomputable def centerCoordinateIsoGroupAlgebra (hn : 0 < n) :
     CommHopfAlgCat.quotient (coordinateHopfAlgebra k n)
         (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n)) ≅
       CommHopfAlgCat.of k (MonoidAlgebra k (Multiplicative (ZMod n))) :=
   Iso.unop <| (Functor.FullyFaithful.ofFullyFaithful
     (CommHopfAlgCat.pointsFunctor (R := k))).preimageIso
-      (scalarRootsCenterCoordinatePointsNatIso n hn)
+      (rootsOfUnityScalarCenterCoordinatePointsNatIso n hn)
 
-/-- Applying the functor of points to `centerCoordinateIso` recovers the scalar-matrix natural
-isomorphism used to construct it. -/
-theorem pointsFunctor_mapIso_centerCoordinateIso (hn : 0 < n) :
-    (CommHopfAlgCat.pointsFunctor (R := k)).mapIso (centerCoordinateIso n hn).op =
-      scalarRootsCenterCoordinatePointsNatIso n hn := by
+/-- Applying the functor of points to `centerCoordinateIsoGroupAlgebra` recovers the
+scalar-matrix natural isomorphism used to construct it. -/
+theorem pointsFunctor_mapIso_centerCoordinateIsoGroupAlgebra (hn : 0 < n) :
+    (CommHopfAlgCat.pointsFunctor (R := k)).mapIso
+        (centerCoordinateIsoGroupAlgebra n hn).op =
+      rootsOfUnityScalarCenterCoordinatePointsNatIso n hn := by
   apply Iso.ext
   exact (Functor.FullyFaithful.ofFullyFaithful
     (CommHopfAlgCat.pointsFunctor (R := k))).map_preimage _

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean
@@ -70,6 +70,7 @@ noncomputable def centerMulEquivRootsOfUnity (hn : 0 < n)
       rw [Fintype.card_fin]
 
 /-- The inverse center equivalence sends a root of unity to its scalar matrix. -/
+@[simp]
 theorem coe_centerMulEquivRootsOfUnity_symm_apply (hn : 0 < n)
     (A : Type v) [CommRing A] (ζ : rootsOfUnity n A) :
     (((centerMulEquivRootsOfUnity n hn A).symm ζ :
@@ -111,6 +112,7 @@ theorem pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
   simp [scalarRootsPoints]
 
 /-- The central special-linear matrix attached to a root of unity is a scalar matrix. -/
+@[simp]
 theorem coe_pointsMulEquiv_scalarRootsPoints (hn : 0 < n)
     {A : Type v} [CommRing A] [Algebra R A]
     (f : WithConv (MonoidAlgebra R (Multiplicative (ZMod n)) →ₐ[R] A)) :
@@ -259,19 +261,10 @@ noncomputable def scalarRootsCenterNatIso (hn : 0 < n) :
     intro A B φ
     ext f
     apply Subtype.ext
-    change ((scalarRootsCenterHom n hn B)
-        (AlgHom.mapValue (H := MonoidAlgebra k (Multiplicative (ZMod n))) φ.hom f)).1 =
-      AlgHom.mapValue (H := coordinateHopfAlgebra k n) φ.hom
-        ((scalarRootsCenterHom n hn A f).1)
-    calc
-      _ = scalarRootsPoints n hn
-          (AlgHom.mapValue (H := MonoidAlgebra k (Multiplicative (ZMod n))) φ.hom f) :=
-        coe_scalarRootsCenterHom_apply n hn B _
-      _ = AlgHom.mapValue (H := coordinateHopfAlgebra k n) φ.hom
-          (scalarRootsPoints n hn f) :=
-        (mapValue_scalarRootsPoints n hn φ.hom f).symm
-      _ = _ := congrArg (AlgHom.mapValue (H := coordinateHopfAlgebra k n) φ.hom)
-        (coe_scalarRootsCenterHom_apply n hn A f).symm)
+    -- The component and its application lemma cannot be used while this natural isomorphism is
+    -- being constructed. After subgroup extensionality, `codRestrict` and the restricted functor
+    -- map reduce definitionally, leaving precisely the scalar-point naturality theorem.
+    exact (mapValue_scalarRootsPoints n hn φ.hom f).symm)
 
 /-- The natural isomorphism sends a `μₙ`-point to its scalar matrix. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/RootSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/RootSubgroup.lean
@@ -115,12 +115,6 @@ theorem mapValue_rootSubgroupPoints (φ : A →ₐ[R] B) (hij : i ≠ j)
       rootSubgroupPoints hij
         (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) φ f) := by
   apply (pointsMulEquiv (R := R) (A := B) N).injective
-  -- `AlgHom.mapValue` and `HopfAlgebra.mapPoints` expose the same postcomposition map, but there
-  -- is no comparison lemma between the bundled applications; restate it in the form used by the
-  -- public naturality theorem `pointsMulEquiv_mapValue`.
-  change (pointsMulEquiv (R := R) (A := B) N)
-      (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R N)
-        (CommAlgCat.ofHom φ) (rootSubgroupPoints hij f)) = _
   rw [pointsMulEquiv_mapValue,
     pointsMulEquiv_rootSubgroupPoints,
     pointsMulEquiv_rootSubgroupPoints, Matrix.SpecialLinearGroup.map_transvection,

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Data.ZMod.Basic
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
-public import Mathlib.RingTheory.RootsOfUnity.Basic
 import Mathlib.Tactic.LinearCombination
 import TauCeti.Data.ZMod.Units
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -8,11 +8,12 @@ module
 public import Mathlib.Data.ZMod.Basic
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+public import Mathlib.RingTheory.RootsOfUnity.Basic
 import Mathlib.Tactic.LinearCombination
 import TauCeti.Data.ZMod.Units
 
 /-!
-# Special linear groups: reduction, the centre, and coordinate descriptions
+# Special linear groups: reduction, centers, and coordinate descriptions
 
 The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong approximation for
 `SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
@@ -24,6 +25,9 @@ a matrix with a prescribed bottom row `(N, p)`: it is the Bézout relation `m p 
 statement moves around:
 over a commutative ring without zero divisors the centre of `SL₂` is exactly `{±I}`, the
 scalar form Mathlib gives having no other square roots of `1` to offer.
+
+The general positive-size center is identified with the corresponding roots-of-unity group by
+specializing Mathlib's finite-index-type equivalence to `Fin n`.
 
 The surjectivity is ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/HeckeRIngs/GLn/SL2Surjection.lean`, Chris Birkbeck). Prerequisite for the
@@ -40,6 +44,8 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
   with `coe_mapGL_int_rat_fin_two` its `ℤ`-to-`ℚ` specialization.
 * `Matrix.SpecialLinearGroup.mul_sub_mul_eq_one_of_lowerRow`: a bottom row `(N, p)` gives the
   Bézout relation `m p - n N = 1`.
+* `Matrix.SpecialLinearGroup.centerMulEquivRootsOfUnityFin`: the center of `SL(Fin n, A)` is
+  `rootsOfUnity n A` when `0 < n`.
 * `Matrix.SpecialLinearGroup.mem_center_iff_eq_one_or_eq_neg_one`: the centre of `SL₂` is
   `{±I}` when `R` has no zero divisors.
 * `Matrix.SpecialLinearGroup.finite_center` and
@@ -96,6 +102,37 @@ top row `(m, n)` satisfies `m p - n N = 1`. -/
 lemma mul_sub_mul_eq_one_of_lowerRow {N p : ℕ} {σ : SL(2, ℤ)} (hσ10 : σ 1 0 = (N : ℤ))
     (hσ11 : σ 1 1 = (p : ℤ)) : σ 0 0 * (p : ℤ) - σ 0 1 * (N : ℤ) = 1 := by
   simpa only [hσ10, hσ11] using fin_two_mul_sub_mul_eq_one σ
+
+/-- For `0 < n`, the center of `SL(Fin n, A)` is the group of `n`th roots of unity. -/
+noncomputable def centerMulEquivRootsOfUnityFin (n : ℕ) (hn : 0 < n)
+    (A : Type*) [CommRing A] :
+    Subgroup.center (SpecialLinearGroup (Fin n) A) ≃* rootsOfUnity n A :=
+  (center_equiv_rootsOfUnity' (R := A) (⟨0, hn⟩ : Fin n)).trans <|
+    MulEquiv.subgroupCongr <| by rw [Fintype.card_fin]
+
+/-- The center equivalence reads off the upper-left entry of a central matrix. -/
+@[simp]
+theorem coe_centerMulEquivRootsOfUnityFin_apply (n : ℕ) (hn : 0 < n)
+    (A : Type*) [CommRing A] (c : Subgroup.center (SpecialLinearGroup (Fin n) A)) :
+    (((centerMulEquivRootsOfUnityFin n hn A c : rootsOfUnity n A) : Aˣ) : A) =
+      ((c : SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A)
+        (⟨0, hn⟩ : Fin n) ⟨0, hn⟩ := by
+  simp [centerMulEquivRootsOfUnityFin, center_equiv_rootsOfUnity'_apply]
+
+/-- The inverse center equivalence sends a root of unity to its scalar matrix. -/
+@[simp]
+theorem coe_centerMulEquivRootsOfUnityFin_symm_apply (n : ℕ) (hn : 0 < n)
+    (A : Type*) [CommRing A] (ζ : rootsOfUnity n A) :
+    (((centerMulEquivRootsOfUnityFin n hn A).symm ζ :
+        SpecialLinearGroup (Fin n) A) : Matrix (Fin n) (Fin n) A) =
+      Matrix.scalar (Fin n) ((ζ : Aˣ) : A) := by
+  rw [← scalar_eq_coe_self_center
+    ((centerMulEquivRootsOfUnityFin n hn A).symm ζ) (⟨0, hn⟩ : Fin n)]
+  congr 1
+  have h := congrArg (fun ξ : rootsOfUnity n A ↦ ((ξ : Aˣ) : A))
+    ((centerMulEquivRootsOfUnityFin n hn A).apply_symm_apply ζ)
+  rw [coe_centerMulEquivRootsOfUnityFin_apply] at h
+  exact h
 
 /-- `-I` maps to `-I` under `SL(n, R) → GL(n, S)`. -/
 @[simp]


### PR DESCRIPTION
This PR identifies the represented center of positive-rank `SLₙ` with `μₙ`. It specializes Mathlib's center classification to `Fin n`, constructs the scalar-matrix map naturally on algebra-valued points, proves that it is an isomorphism onto universally central points, and uses full faithfulness of the commutative-Hopf functor of points to obtain `k[SLₙ] / I(Z(SLₙ)) ≅ k[Multiplicative (ZMod n)]`.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Reductive and semisimple groups,” specifically “Develop the ... centre `Z(G)`, ... central isogenies, and the simply connected and adjoint forms.” This is the most effective unclaimed step because the general center, `SLₙ`, and `μₙ` are already represented on `main`, while the standard central isogeny from the simply connected type-A group toward its adjoint form needs its central kernel identified scheme-theoretically. After this PR, the milestone still needs the projective special-linear adjoint quotient and its central-isogeny properties, as well as the general constructions and universal properties of simply connected and adjoint forms.

The new module `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Center.lean` has 313 lines. It reuses Mathlib's `Matrix.SpecialLinearGroup.center_equiv_rootsOfUnity'`, Tau Ceti's roots-of-unity and special-linear point equivalences, the universal center construction, and full faithfulness of the Hopf point functor; no Mathlib implementation or external formalization is vendored. The mathematics follows Milne, *Algebraic Groups* (2017), Examples 2.4 and 5.49 and §18.a, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-linear-center-roots-of-unity"}-->

🤖 Prepared with Codex
