### PR TITLE
feat: compose completely monotone and Bernstein functions

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -66,6 +66,8 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
   scalar multiples.
 * `TauCeti.IsCompletelyMonotoneOnIoi`: the open-half-line analogue, using ordinary iterated
   derivatives on `(0, ∞)`.
+* `TauCeti.IsCompletelyMonotoneOnIoi.differentiableOn`: a completely monotone function on
+  `(0, ∞)` is differentiable there.
 * `TauCeti.IsContinuousCompletelyMonotoneOnIoi`: the closed-half-line predicate used by the
   finite-measure Hausdorff--Bernstein--Widder theorem: continuity on `[0, ∞)` plus complete
   monotonicity on `(0, ∞)`.

--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -351,6 +351,10 @@ variable {f g : ℝ → ℝ}
 @[grind →]
 lemma contDiffOn (hf : IsCompletelyMonotoneOnIoi f) : ContDiffOn ℝ ∞ f (Ioi 0) := hf.1
 
+/-- A completely monotone function on `(0, ∞)` is differentiable there. -/
+lemma differentiableOn (hf : IsCompletelyMonotoneOnIoi f) : DifferentiableOn ℝ f (Ioi 0) :=
+  hf.contDiffOn.differentiableOn (by simp)
+
 /-- The sign-alternation property on `(0, ∞)`. -/
 @[grind =>]
 lemma neg_one_pow_mul_iteratedDeriv_nonneg (hf : IsCompletelyMonotoneOnIoi f) (n : ℕ) {t : ℝ}
@@ -487,7 +491,7 @@ lemma antitoneOn (hf : IsContinuousCompletelyMonotoneOnIoi f) : AntitoneOn f (Ic
   refine antitoneOn_of_deriv_nonpos (convex_Ici 0) hf.continuousOn
     (by
       simpa [interior_Ici] using
-        hf.isCompletelyMonotoneOnIoi.contDiffOn.differentiableOn (by simp))
+        hf.isCompletelyMonotoneOnIoi.differentiableOn)
     fun x hx => ?_
   rw [interior_Ici] at hx
   exact hf.isCompletelyMonotoneOnIoi.deriv_nonpos hx

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
@@ -37,10 +37,13 @@ nonnegative scalar multiples, and the basic catalogue — constants, the identit
 * `TauCeti.IsBernsteinFunction`: the predicate that `f` is continuous and nonnegative on
   `[0, ∞)`, smooth on `(0, ∞)`, and has completely monotone ordinary derivative on `(0, ∞)`.
 * `TauCeti.IsBernsteinFunction.nonneg`, `TauCeti.IsBernsteinFunction.deriv_nonneg`,
-  `TauCeti.IsBernsteinFunction.monotoneOn`, `TauCeti.IsBernsteinFunction.concaveOn`,
-  `TauCeti.IsBernsteinFunction.eq_zero_of_eq_zero`: a Bernstein function is nonnegative, has
-  nonnegative derivative, is nondecreasing and concave on `[0, ∞)`, and either is positive on
-  `(0, ∞)` or vanishes on `[0, ∞)`.
+  `TauCeti.IsBernsteinFunction.monotoneOn`, `TauCeti.IsBernsteinFunction.concaveOn`: a Bernstein
+  function is nonnegative, has nonnegative derivative, and is nondecreasing and concave on
+  `[0, ∞)`.
+* `TauCeti.IsBernsteinFunction.eq_zero_of_eq_zero`,
+  `TauCeti.IsBernsteinFunction.forall_eq_zero_or_forall_pos`: a zero at one positive point
+  propagates across `[0, ∞)`, and every Bernstein function either vanishes there or is positive on
+  `(0, ∞)`.
 * `TauCeti.IsBernsteinFunction.congr`: the property depends only on the values on `[0, ∞)`.
 * `TauCeti.IsBernsteinFunction.add`, `TauCeti.IsBernsteinFunction.smul`,
   `TauCeti.IsBernsteinFunction.const_add`, `TauCeti.IsBernsteinFunction.sum`: closure under sums,
@@ -140,13 +143,17 @@ theorem eq_zero_of_eq_zero (hf : IsBernsteinFunction f) {t₀ : ℝ}
         hlt.le (by rw [h₀, hzero]))
       (hf.nonneg ht)
 
-/-- If a Bernstein function is nonzero at one positive point, it is positive throughout the open
-half-line. -/
-theorem pos_of_ne_zero (hf : IsBernsteinFunction f) {t₀ : ℝ} (ht₀ : 0 < t₀)
-    (h₀ : f t₀ ≠ 0) {t : ℝ} (ht : 0 < t) : 0 < f t := by
-  rcases (hf.nonneg ht.le).lt_or_eq with hlt | heq
-  · exact hlt
-  · exact absurd (hf.eq_zero_of_eq_zero ht heq.symm ht₀.le) h₀
+/-- A Bernstein function either vanishes on the whole closed half-line or is positive throughout
+the open half-line. -/
+theorem forall_eq_zero_or_forall_pos (hf : IsBernsteinFunction f) :
+    (∀ t : ℝ, 0 ≤ t → f t = 0) ∨ (∀ t : ℝ, 0 < t → 0 < f t) := by
+  by_cases hvanish : ∃ t₀ : ℝ, 0 < t₀ ∧ f t₀ = 0
+  · obtain ⟨t₀, ht₀, h₀⟩ := hvanish
+    exact Or.inl fun _ ht => hf.eq_zero_of_eq_zero ht₀ h₀ ht
+  · refine Or.inr fun t ht => ?_
+    rcases (hf.nonneg ht.le).lt_or_eq with hpos | hzero
+    · exact hpos
+    · exact (hvanish ⟨t, ht, hzero.symm⟩).elim
 
 /-- Being a Bernstein function depends only on the values on `[0, ∞)`. -/
 theorem congr (hf : IsBernsteinFunction f) (h : Set.EqOn g f (Ici 0)) :

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
@@ -37,9 +37,10 @@ nonnegative scalar multiples, and the basic catalogue — constants, the identit
 * `TauCeti.IsBernsteinFunction`: the predicate that `f` is continuous and nonnegative on
   `[0, ∞)`, smooth on `(0, ∞)`, and has completely monotone ordinary derivative on `(0, ∞)`.
 * `TauCeti.IsBernsteinFunction.nonneg`, `TauCeti.IsBernsteinFunction.deriv_nonneg`,
-  `TauCeti.IsBernsteinFunction.monotoneOn`, `TauCeti.IsBernsteinFunction.concaveOn`: a Bernstein
-  function is nonnegative, has nonnegative derivative, is nondecreasing, and is concave on
-  `[0, ∞)`.
+  `TauCeti.IsBernsteinFunction.monotoneOn`, `TauCeti.IsBernsteinFunction.concaveOn`,
+  `TauCeti.IsBernsteinFunction.eq_zero_of_eq_zero`: a Bernstein function is nonnegative, has
+  nonnegative derivative, is nondecreasing and concave on `[0, ∞)`, and either is positive on
+  `(0, ∞)` or vanishes on `[0, ∞)`.
 * `TauCeti.IsBernsteinFunction.congr`: the property depends only on the values on `[0, ∞)`.
 * `TauCeti.IsBernsteinFunction.add`, `TauCeti.IsBernsteinFunction.smul`,
   `TauCeti.IsBernsteinFunction.const_add`, `TauCeti.IsBernsteinFunction.sum`: closure under sums,
@@ -119,12 +120,33 @@ lemma monotoneOn (hf : IsBernsteinFunction f) : MonotoneOn f (Ici 0) := by
 lemma concaveOn (hf : IsBernsteinFunction f) : ConcaveOn ℝ (Ici 0) f := by
   refine concaveOn_of_deriv2_nonpos (convex_Ici 0) hf.continuousOn
     (hf.differentiableOn.mono (by rw [interior_Ici]))
-    ((hf.deriv_isCompletelyMonotoneOnIoi.contDiffOn.differentiableOn (by simp)).mono
-      (by rw [interior_Ici]))
+    (hf.deriv_isCompletelyMonotoneOnIoi.differentiableOn.mono (by rw [interior_Ici]))
     fun x hx => ?_
   rw [interior_Ici] at hx
   simpa [Function.iterate_succ, Function.iterate_zero, Function.comp_def] using
     hf.deriv_isCompletelyMonotoneOnIoi.deriv_nonpos hx
+
+/-- A Bernstein function that vanishes at one positive point vanishes on the whole closed
+half-line. -/
+theorem eq_zero_of_eq_zero (hf : IsBernsteinFunction f) {t₀ : ℝ}
+    (ht₀ : 0 < t₀) (h₀ : f t₀ = 0) {t : ℝ} (ht : 0 ≤ t) : f t = 0 := by
+  have hzero : f 0 = 0 :=
+    le_antisymm (h₀ ▸ hf.monotoneOn (mem_Ici.2 le_rfl) (mem_Ici.2 ht₀.le) ht₀.le)
+      (hf.nonneg le_rfl)
+  rcases le_or_gt t t₀ with hle | hlt
+  · exact le_antisymm (h₀ ▸ hf.monotoneOn (mem_Ici.2 ht) (mem_Ici.2 ht₀.le) hle) (hf.nonneg ht)
+  · exact le_antisymm
+      (h₀ ▸ hf.concaveOn.right_le_of_le_left'' (mem_Ici.2 le_rfl) (mem_Ici.2 ht) ht₀
+        hlt.le (by rw [h₀, hzero]))
+      (hf.nonneg ht)
+
+/-- If a Bernstein function is nonzero at one positive point, it is positive throughout the open
+half-line. -/
+theorem pos_of_ne_zero (hf : IsBernsteinFunction f) {t₀ : ℝ} (ht₀ : 0 < t₀)
+    (h₀ : f t₀ ≠ 0) {t : ℝ} (ht : 0 < t) : 0 < f t := by
+  rcases (hf.nonneg ht.le).lt_or_eq with hlt | heq
+  · exact hlt
+  · exact absurd (hf.eq_zero_of_eq_zero ht heq.symm ht₀.le) h₀
 
 /-- Being a Bernstein function depends only on the values on `[0, ∞)`. -/
 theorem congr (hf : IsBernsteinFunction f) (h : Set.EqOn g f (Ici 0)) :

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Composition.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Composition.lean
@@ -19,15 +19,14 @@ closed under composition, and the prototype `t ↦ e^{-x f(t)}` is completely mo
 
 ## The induction
 
-Writing `F = g ∘ f`, the chain and product rules give `F' = -\,[(-g') ∘ f] \cdot f'`, in which
+Writing `F = g ∘ f`, the chain and product rules give `F' = -[(-g') ∘ f] · f'`, in which
 both `-g'` and `f'` are completely monotone. Iterating this substitution never returns to a
 composition alone, but always to a *product* of a composition with a completely monotone factor.
-The workhorse `TauCeti.IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul` therefore carries
-that product along: for completely monotone `g` and `h`, `t ↦ g (f t) · h t` is completely
-monotone, that is,
+The private induction therefore carries that product along: for completely monotone `g` and `h`,
+`t ↦ g (f t) · h t` is completely monotone, that is,
 `0 ≤ (-1)ⁿ dⁿ/dtⁿ [g(f t) · h t]` on `(0, ∞)`, proved by induction on `n` from the identity
 
-`d/dt [g(f t) · h t] = -\,[(-g')(f t) · (f' t · h t)] - [g(f t) · (-h' t)]`,
+`d/dt [g(f t) · h t] = -[(-g')(f t) · (f' t · h t)] - [g(f t) · (-h' t)]`,
 
 whose two bracketed terms are again of the same shape, with `(-g', f' · h)` and `(g, -h')` in
 place of `(g, h)`. Taking `h = 1` gives the composition theorem.
@@ -41,10 +40,6 @@ In that degenerate case the composition is the constant `g 0`, and the theorems 
 
 ## Main declarations
 
-* `TauCeti.IsBernsteinFunction.eq_zero_of_eq_zero`: a Bernstein function with a zero on `(0, ∞)`
-  vanishes identically on `[0, ∞)`.
-* `TauCeti.IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul`: the product form
-  `t ↦ g (f t) · h t` that the induction proves.
 * `TauCeti.IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction`: the open-half-line composition
   theorem, under the positivity hypothesis on the inner function.
 * `TauCeti.IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction`: **a completely monotone
@@ -68,56 +63,41 @@ namespace TauCeti
 
 variable {f g h : ℝ → ℝ}
 
-/-! ### Bernstein functions with a zero -/
-
-/-- A Bernstein function that vanishes at one positive point vanishes on the whole closed
-half-line. Monotonicity pushes the value at the origin down to `0`, and concavity then traps the
-graph between the chord through the two zeros and the horizontal axis. -/
-theorem IsBernsteinFunction.eq_zero_of_eq_zero (hf : IsBernsteinFunction f) {t₀ : ℝ}
-    (ht₀ : 0 < t₀) (h₀ : f t₀ = 0) {t : ℝ} (ht : 0 ≤ t) : f t = 0 := by
-  have hzero : f 0 = 0 :=
-    le_antisymm (h₀ ▸ hf.monotoneOn (mem_Ici.2 le_rfl) (mem_Ici.2 ht₀.le) ht₀.le)
-      (hf.nonneg le_rfl)
-  rcases le_or_gt t t₀ with hle | hlt
-  · exact le_antisymm (h₀ ▸ hf.monotoneOn (mem_Ici.2 ht) (mem_Ici.2 ht₀.le) hle) (hf.nonneg ht)
-  · have htpos : 0 < t := ht₀.trans hlt
-    have hb : 0 < t₀ / t := div_pos ht₀ htpos
-    have hb1 : t₀ / t < 1 := (div_lt_one htpos).2 hlt
-    have hchord : (1 - t₀ / t) • (0 : ℝ) + (t₀ / t) • t = t₀ := by
-      rw [smul_eq_mul, smul_eq_mul, mul_zero, zero_add, div_mul_cancel₀ _ htpos.ne']
-    have hcc := hf.concaveOn.2 (mem_Ici.2 le_rfl) (mem_Ici.2 ht)
-      (by linarith : (0 : ℝ) ≤ 1 - t₀ / t) hb.le (by ring)
-    rw [hchord, hzero, h₀] at hcc
-    simp only [smul_eq_mul, mul_zero, zero_add] at hcc
-    nlinarith [hf.nonneg ht]
-
-/-- A Bernstein function with no zero on the open half-line is positive there: this is the
-dichotomy that lets the composition theorems split into a degenerate constant case and the main
-case, where the inner function stays inside `(0, ∞)`. -/
-theorem IsBernsteinFunction.pos_of_forall_ne_zero (hf : IsBernsteinFunction f)
-    (hne : ¬∃ t₀ : ℝ, 0 < t₀ ∧ f t₀ = 0) {t : ℝ} (ht : 0 < t) : 0 < f t := by
-  rcases (hf.nonneg ht.le).lt_or_eq with hlt | heq
-  · exact hlt
-  · exact absurd ⟨t, ht, heq.symm⟩ hne
-
 /-! ### The composition induction -/
+
+/-- Smoothness of the product used in the composition induction. -/
+private theorem contDiffOn_comp_mul (hf : IsBernsteinFunction f)
+    (hpos : ∀ t : ℝ, 0 < t → 0 < f t) (hg : IsCompletelyMonotoneOnIoi g)
+    (hh : IsCompletelyMonotoneOnIoi h) :
+    ContDiffOn ℝ ∞ (fun u => g (f u) * h u) (Ioi 0) :=
+  (hg.contDiffOn.comp hf.contDiffOn fun u hu => mem_Ioi.2 (hpos u hu)).mul hh.contDiffOn
+
+/-- The chain rule when an inner function maps the open half-line to itself. -/
+private theorem hasDerivAt_comp_of_mapsTo (hf : DifferentiableOn ℝ f (Ioi 0))
+    (hg : DifferentiableOn ℝ g (Ioi 0)) (hmaps : MapsTo f (Ioi 0) (Ioi 0))
+    {u : ℝ} (hu : u ∈ Ioi 0) :
+    HasDerivAt (fun v => g (f v)) (deriv g (f u) * deriv f u) u :=
+  HasDerivAt.comp u
+    (hg.differentiableAt (isOpen_Ioi.mem_nhds (hmaps hu))).hasDerivAt
+    (hf.differentiableAt (isOpen_Ioi.mem_nhds hu)).hasDerivAt
+
+/-- The sign calculation in the composition induction. -/
+private theorem neg_one_pow_succ_mul_neg_add (n : ℕ) (a b : ℝ) :
+    (-1 : ℝ) ^ (n + 1) * -(a + b) = (-1 : ℝ) ^ n * a + (-1 : ℝ) ^ n * b := by
+  rw [pow_succ]
+  ring
 
 /-- The induction behind the composition theorem: for a Bernstein function `f` that is positive
 on `(0, ∞)` and completely monotone `g` and `h`, every alternating derivative of the product
 `t ↦ g (f t) · h t` is nonnegative on `(0, ∞)`.
 
 The functions `g` and `h` are quantified inside the statement because the induction step feeds
-the hypothesis two *different* pairs; `IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul`
-is the usable form. -/
+the hypothesis two *different* pairs. -/
 private theorem neg_one_pow_mul_iteratedDeriv_comp_mul_nonneg (hf : IsBernsteinFunction f)
     (hpos : ∀ t : ℝ, 0 < t → 0 < f t) (n : ℕ) :
     ∀ g h : ℝ → ℝ, IsCompletelyMonotoneOnIoi g → IsCompletelyMonotoneOnIoi h →
       ∀ t : ℝ, 0 < t → 0 ≤ (-1 : ℝ) ^ n * iteratedDeriv n (fun u => g (f u) * h u) t := by
   have hmaps : MapsTo f (Ioi 0) (Ioi 0) := fun u hu => mem_Ioi.2 (hpos u hu)
-  -- Smoothness of the model product `t ↦ g (f t) · h t`, needed to split iterated derivatives.
-  have hsmooth : ∀ g h : ℝ → ℝ, IsCompletelyMonotoneOnIoi g → IsCompletelyMonotoneOnIoi h →
-      ContDiffOn ℝ ∞ (fun u => g (f u) * h u) (Ioi 0) := fun g h hg hh =>
-    (hg.contDiffOn.comp hf.contDiffOn hmaps).mul hh.contDiffOn
   induction n with
   | zero =>
       intro g h hg hh t ht
@@ -133,18 +113,11 @@ private theorem neg_one_pow_mul_iteratedDeriv_comp_mul_nonneg (hf : IsBernsteinF
       have hderiv : ∀ u ∈ Ioi (0 : ℝ), deriv (fun v => g (f v) * h v) u =
           -(-deriv g (f u) * (deriv f u * h u) + g (f u) * -deriv h u) := by
         intro u hu
-        have hdf : HasDerivAt f (deriv f u) u :=
-          (hf.differentiableOn.differentiableAt (isOpen_Ioi.mem_nhds hu)).hasDerivAt
-        have hdg : HasDerivAt g (deriv g (f u)) (f u) :=
-          ((hg.contDiffOn.differentiableOn (by simp)).differentiableAt
-            (isOpen_Ioi.mem_nhds (mem_Ioi.2 (hpos u hu)))).hasDerivAt
         have hdh : HasDerivAt h (deriv h u) u :=
-          ((hh.contDiffOn.differentiableOn (by simp)).differentiableAt
-            (isOpen_Ioi.mem_nhds hu)).hasDerivAt
-        have hcomp : HasDerivAt (fun v => g (f v)) (deriv g (f u) * deriv f u) u :=
-          HasDerivAt.comp u hdg hdf
+          (hh.differentiableOn.differentiableAt (isOpen_Ioi.mem_nhds hu)).hasDerivAt
         have hprod : HasDerivAt (fun v => g (f v) * h v)
-            (deriv g (f u) * deriv f u * h u + g (f u) * deriv h u) u := hcomp.mul hdh
+            (deriv g (f u) * deriv f u * h u + g (f u) * deriv h u) u :=
+          (hasDerivAt_comp_of_mapsTo hf.differentiableOn hg.differentiableOn hmaps hu).mul hdh
         rw [hprod.deriv]
         ring
       have hEq : deriv (fun v => g (f v) * h v) =ᶠ[𝓝 t]
@@ -152,51 +125,37 @@ private theorem neg_one_pow_mul_iteratedDeriv_comp_mul_nonneg (hf : IsBernsteinF
         eventually_of_mem (isOpen_Ioi.mem_nhds ht) hderiv
       -- Both summands are smooth, so the `n`-th derivative of the sum splits.
       have hA : ContDiffAt ℝ (n : WithTop ℕ∞) (fun u => -deriv g (f u) * (deriv f u * h u)) t :=
-        ((hsmooth _ _ hg₁ hh₁).contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by exact_mod_cast le_top)
+        ((contDiffOn_comp_mul hf hpos hg₁ hh₁).contDiffAt
+          (isOpen_Ioi.mem_nhds ht)).of_le (by exact_mod_cast le_top)
       have hB : ContDiffAt ℝ (n : WithTop ℕ∞) (fun u => g (f u) * -deriv h u) t :=
-        ((hsmooth _ _ hg hh₂).contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by exact_mod_cast le_top)
+        ((contDiffOn_comp_mul hf hpos hg hh₂).contDiffAt
+          (isOpen_Ioi.mem_nhds ht)).of_le (by exact_mod_cast le_top)
       have hIHA : 0 ≤ (-1 : ℝ) ^ n *
           iteratedDeriv n (fun u => -deriv g (f u) * (deriv f u * h u)) t :=
         ih (fun s => -deriv g s) (fun u => deriv f u * h u) hg₁ hh₁ t ht
       have hIHB : 0 ≤ (-1 : ℝ) ^ n * iteratedDeriv n (fun u => g (f u) * -deriv h u) t :=
         ih g (fun u => -deriv h u) hg hh₂ t ht
       rw [iteratedDeriv_succ', hEq.iteratedDeriv_eq n, iteratedDeriv_fun_neg,
-        iteratedDeriv_fun_add hA hB]
-      have hsign : (-1 : ℝ) ^ (n + 1) *
-            -(iteratedDeriv n (fun u => -deriv g (f u) * (deriv f u * h u)) t +
-              iteratedDeriv n (fun u => g (f u) * -deriv h u) t) =
-          (-1 : ℝ) ^ n * iteratedDeriv n (fun u => -deriv g (f u) * (deriv f u * h u)) t +
-            (-1 : ℝ) ^ n * iteratedDeriv n (fun u => g (f u) * -deriv h u) t := by
-        rw [pow_succ]
-        ring
-      rw [hsign]
+        iteratedDeriv_fun_add hA hB, neg_one_pow_succ_mul_neg_add]
       exact add_nonneg hIHA hIHB
 
 /-! ### Composition theorems -/
 
-/-- **The product form of the open-half-line composition theorem.** For completely monotone `g`
-and `h` and a Bernstein function `f` that is positive on `(0, ∞)`, the product `t ↦ g (f t) · h t`
-is completely monotone on `(0, ∞)`.
-
-The extra factor `h` is what makes the induction close: differentiating once turns the pair
-`(g, h)` into the two pairs `(-g', f' · h)` and `(g, -h')`, both again completely monotone. -/
-theorem IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul (hg : IsCompletelyMonotoneOnIoi g)
-    (hh : IsCompletelyMonotoneOnIoi h) (hf : IsBernsteinFunction f)
-    (hpos : ∀ t : ℝ, 0 < t → 0 < f t) :
-    IsCompletelyMonotoneOnIoi fun u => g (f u) * h u :=
-  ⟨(hg.contDiffOn.comp hf.contDiffOn fun u hu => mem_Ioi.2 (hpos u hu)).mul hh.contDiffOn,
-    fun n t ht => neg_one_pow_mul_iteratedDeriv_comp_mul_nonneg hf hpos n g h hg hh t ht⟩
-
 /-- **Composition on the open half-line.** If `g` is completely monotone on `(0, ∞)` and `f` is a
 Bernstein function that is positive on `(0, ∞)`, then `g ∘ f` is completely monotone on `(0, ∞)`.
 The positivity hypothesis is what keeps `f t` inside the open half-line, where `g` is smooth; it
-is removed in `TauCeti.IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction`. -/
+is traded for continuity of `g` on `[0, ∞)` in
+`TauCeti.IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction`, since the degenerate case
+evaluates `g` at `0`. -/
 theorem IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction (hg : IsCompletelyMonotoneOnIoi g)
     (hf : IsBernsteinFunction f) (hpos : ∀ t : ℝ, 0 < t → 0 < f t) :
     IsCompletelyMonotoneOnIoi (g ∘ f) := by
   have hone : IsCompletelyMonotoneOnIoi fun _ : ℝ => (1 : ℝ) :=
     (isCompletelyMonotone_const zero_le_one).isCompletelyMonotoneOnIoi
-  refine (hg.comp_isBernsteinFunction_mul hone hf hpos).congr fun u _ => ?_
+  have hprod : IsCompletelyMonotoneOnIoi fun u => g (f u) * (1 : ℝ) :=
+    ⟨contDiffOn_comp_mul hf hpos hg hone,
+      fun n t ht => neg_one_pow_mul_iteratedDeriv_comp_mul_nonneg hf hpos n g _ hg hone t ht⟩
+  refine hprod.congr fun u _ => ?_
   simp [Function.comp_apply]
 
 /-- **A completely monotone function composed with a Bernstein function is completely
@@ -216,7 +175,7 @@ theorem IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction
     intro t ht
     simp [Function.comp_apply, hf.eq_zero_of_eq_zero ht₀ h₀ (le_of_lt ht)]
   · exact hg.isCompletelyMonotoneOnIoi.comp_isBernsteinFunction hf
-      fun t ht => hf.pos_of_forall_ne_zero hvanish ht
+      fun t ht => hf.pos_of_ne_zero ht (fun h => hvanish ⟨t, ht, h⟩) ht
 
 /-- **Bernstein functions are closed under composition.** The derivative of `g ∘ f` is
 `(g' ∘ f) · f'`, a product of the composition theorem's output with a completely monotone
@@ -227,22 +186,18 @@ theorem IsBernsteinFunction.comp (hg : IsBernsteinFunction g) (hf : IsBernsteinF
   · obtain ⟨t₀, ht₀, h₀⟩ := hvanish
     refine (isBernsteinFunction_const (hg.nonneg le_rfl)).congr fun t ht => ?_
     simp [Function.comp_apply, hf.eq_zero_of_eq_zero ht₀ h₀ (mem_Ici.1 ht)]
-  · have hpos : ∀ t : ℝ, 0 < t → 0 < f t := fun t ht => hf.pos_of_forall_ne_zero hvanish ht
+  · have hpos : ∀ t : ℝ, 0 < t → 0 < f t :=
+      fun t ht => hf.pos_of_ne_zero ht (fun h => hvanish ⟨t, ht, h⟩) ht
     have hmaps : MapsTo f (Ioi 0) (Ioi 0) := fun u hu => mem_Ioi.2 (hpos u hu)
     refine isBernsteinFunction_iff.mpr
       ⟨hg.continuousOn.comp hf.continuousOn fun u hu => mem_Ici.2 (hf.nonneg hu),
         hg.contDiffOn.comp hf.contDiffOn hmaps,
         fun t ht => hg.nonneg (hf.nonneg ht), ?_⟩
     have hcm : IsCompletelyMonotoneOnIoi fun u => deriv g (f u) * deriv f u :=
-      hg.deriv_isCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul
-        hf.deriv_isCompletelyMonotoneOnIoi hf hpos
+      ((hg.deriv_isCompletelyMonotoneOnIoi.comp_isBernsteinFunction hf hpos).mul
+        hf.deriv_isCompletelyMonotoneOnIoi).congr fun _ _ => rfl
     refine hcm.congr fun u hu => ?_
-    have hdf : HasDerivAt f (deriv f u) u :=
-      (hf.differentiableOn.differentiableAt (isOpen_Ioi.mem_nhds hu)).hasDerivAt
-    have hdg : HasDerivAt g (deriv g (f u)) (f u) :=
-      (hg.differentiableOn.differentiableAt
-        (isOpen_Ioi.mem_nhds (mem_Ioi.2 (hpos u hu)))).hasDerivAt
-    exact (HasDerivAt.comp u hdg hdf).deriv
+    exact (hasDerivAt_comp_of_mapsTo hf.differentiableOn hg.differentiableOn hmaps hu).deriv
 
 /-- The prototype completely monotone functions attached to a Bernstein function: for `x ≥ 0`,
 the composition `t ↦ e^{-x f(t)}` is completely monotone on the closed half-line. These are the

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Composition.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Composition.lean
@@ -43,10 +43,11 @@ In that degenerate case the composition is the constant `g 0`, and the theorems 
 * `TauCeti.IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction`: the open-half-line composition
   theorem, under the positivity hypothesis on the inner function.
 * `TauCeti.IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction`: **a completely monotone
-  function composed with a Bernstein function is completely monotone** on the closed half-line.
+  function composed with a Bernstein function is continuous on `[0, ∞)` and completely monotone
+  on `(0, ∞)`**.
 * `TauCeti.IsBernsteinFunction.comp`: Bernstein functions are closed under composition.
 * `TauCeti.IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul`: the prototype
-  `t ↦ e^{-x f(t)}` is completely monotone.
+  `t ↦ e^{-x f(t)}` is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`.
 
 ## References
 
@@ -169,26 +170,21 @@ theorem IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction
     (hf : IsBernsteinFunction f) : IsContinuousCompletelyMonotoneOnIoi (g ∘ f) := by
   refine isContinuousCompletelyMonotoneOnIoi_iff.mpr
     ⟨hg.continuousOn.comp hf.continuousOn fun u hu => mem_Ici.2 (hf.nonneg hu), ?_⟩
-  by_cases hvanish : ∃ t₀ : ℝ, 0 < t₀ ∧ f t₀ = 0
-  · obtain ⟨t₀, ht₀, h₀⟩ := hvanish
-    refine (isCompletelyMonotone_const (hg.nonneg le_rfl)).isCompletelyMonotoneOnIoi.congr ?_
+  rcases hf.forall_eq_zero_or_forall_pos with hzero | hpos
+  · refine (isCompletelyMonotone_const (hg.nonneg le_rfl)).isCompletelyMonotoneOnIoi.congr ?_
     intro t ht
-    simp [Function.comp_apply, hf.eq_zero_of_eq_zero ht₀ h₀ (le_of_lt ht)]
-  · exact hg.isCompletelyMonotoneOnIoi.comp_isBernsteinFunction hf
-      fun t ht => hf.pos_of_ne_zero ht (fun h => hvanish ⟨t, ht, h⟩) ht
+    simp [Function.comp_apply, hzero t ht.le]
+  · exact hg.isCompletelyMonotoneOnIoi.comp_isBernsteinFunction hf hpos
 
 /-- **Bernstein functions are closed under composition.** The derivative of `g ∘ f` is
 `(g' ∘ f) · f'`, a product of the composition theorem's output with a completely monotone
 factor. -/
 theorem IsBernsteinFunction.comp (hg : IsBernsteinFunction g) (hf : IsBernsteinFunction f) :
     IsBernsteinFunction (g ∘ f) := by
-  by_cases hvanish : ∃ t₀ : ℝ, 0 < t₀ ∧ f t₀ = 0
-  · obtain ⟨t₀, ht₀, h₀⟩ := hvanish
-    refine (isBernsteinFunction_const (hg.nonneg le_rfl)).congr fun t ht => ?_
-    simp [Function.comp_apply, hf.eq_zero_of_eq_zero ht₀ h₀ (mem_Ici.1 ht)]
-  · have hpos : ∀ t : ℝ, 0 < t → 0 < f t :=
-      fun t ht => hf.pos_of_ne_zero ht (fun h => hvanish ⟨t, ht, h⟩) ht
-    have hmaps : MapsTo f (Ioi 0) (Ioi 0) := fun u hu => mem_Ioi.2 (hpos u hu)
+  rcases hf.forall_eq_zero_or_forall_pos with hzero | hpos
+  · refine (isBernsteinFunction_const (hg.nonneg le_rfl)).congr fun t ht => ?_
+    simp [Function.comp_apply, hzero t (mem_Ici.1 ht)]
+  · have hmaps : MapsTo f (Ioi 0) (Ioi 0) := fun u hu => mem_Ioi.2 (hpos u hu)
     refine isBernsteinFunction_iff.mpr
       ⟨hg.continuousOn.comp hf.continuousOn fun u hu => mem_Ici.2 (hf.nonneg hu),
         hg.contDiffOn.comp hf.contDiffOn hmaps,
@@ -200,8 +196,8 @@ theorem IsBernsteinFunction.comp (hg : IsBernsteinFunction g) (hf : IsBernsteinF
     exact (hasDerivAt_comp_of_mapsTo hf.differentiableOn hg.differentiableOn hmaps hu).deriv
 
 /-- The prototype completely monotone functions attached to a Bernstein function: for `x ≥ 0`,
-the composition `t ↦ e^{-x f(t)}` is completely monotone on the closed half-line. These are the
-Laplace transforms of the one-parameter convolution semigroup subordinate to `f`. -/
+the composition `t ↦ e^{-x f(t)}` is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`.
+These are the Laplace transforms of the one-parameter convolution semigroup subordinate to `f`. -/
 theorem IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul
     (hf : IsBernsteinFunction f) {x : ℝ} (hx : 0 ≤ x) :
     IsContinuousCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t) :=

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Composition
+public import TauCeti.Analysis.CompletelyMonotone.Power
+-- Proof-only: the derivative and the continuity of a real power with a constant exponent.
+import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
+import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
+
+/-!
+# Fractional powers are Bernstein functions
+
+The power `t ↦ t^s` with `0 ≤ s ≤ 1` is a Bernstein function: it is nonnegative and continuous
+on `[0, ∞)`, smooth on `(0, ∞)`, and its derivative `t ↦ s · t^{s-1}` is the completely monotone
+negative power of `TauCeti.isCompletelyMonotoneOnIoi_rpow_neg`, since `s - 1 = -(1 - s)` with
+`1 - s ≥ 0`.
+
+Feeding this into `TauCeti.IsCompletelyMonotone.comp_isBernsteinFunction` produces the stretched
+exponentials `t ↦ e^{-x t^s}`, the completely monotone functions whose representing measures are
+the one-sided `s`-stable laws; they are the acceptance example the `OneParameterSemigroups`
+roadmap asks the composition closure to deliver. The endpoint `s = 1` recovers the exponential
+`t ↦ e^{-x t}` and `s = 0` the constant `t ↦ e^{-x}`.
+
+## Main declarations
+
+* `TauCeti.isBernsteinFunction_rpow`: `t ↦ t^s` is a Bernstein function for `0 ≤ s ≤ 1`.
+* `TauCeti.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul_rpow`: the stretched exponential
+  `t ↦ e^{-x t^s}` is completely monotone.
+* `TauCeti.exists_representsLaplace_exp_neg_mul_rpow`: its representing measure.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012), Example 1.5 and Chapter 5.
+-/
+
+public section
+
+open MeasureTheory Set
+open scoped ContDiff NNReal
+
+namespace TauCeti
+
+/-- For `0 ≤ s ≤ 1` the power `t ↦ t^s` is a Bernstein function: its derivative is the
+completely monotone negative power `t ↦ s · t^{-(1-s)}`. -/
+theorem isBernsteinFunction_rpow {s : ℝ} (hs : 0 ≤ s) (hs₁ : s ≤ 1) :
+    IsBernsteinFunction fun t : ℝ => t ^ s := by
+  have hderiv : EqOn (deriv fun t : ℝ => t ^ s) (s • fun t : ℝ => t ^ (-(1 - s))) (Ioi 0) := by
+    intro t ht
+    rw [(Real.hasDerivAt_rpow_const (Or.inl (mem_Ioi.mp ht).ne')).deriv]
+    simp [Pi.smul_apply, smul_eq_mul, neg_sub]
+  exact isBernsteinFunction_iff.mpr
+    ⟨(Real.continuous_rpow_const hs).continuousOn,
+      fun t ht => (Real.contDiffAt_rpow_const_of_ne (mem_Ioi.mp ht).ne').contDiffWithinAt,
+      fun t ht => Real.rpow_nonneg ht s,
+      ((isCompletelyMonotoneOnIoi_rpow_neg (by linarith : (0 : ℝ) ≤ 1 - s)).smul hs).congr hderiv⟩
+
+/-- The **stretched exponential** `t ↦ e^{-x t^s}` is completely monotone on `[0, ∞)` for
+`x ≥ 0` and `0 ≤ s ≤ 1`: it is the composition of the completely monotone `t ↦ e^{-x t}` with the
+Bernstein function `t ↦ t^s`. -/
+theorem isContinuousCompletelyMonotoneOnIoi_exp_neg_mul_rpow {x s : ℝ} (hx : 0 ≤ x) (hs : 0 ≤ s)
+    (hs₁ : s ≤ 1) :
+    IsContinuousCompletelyMonotoneOnIoi fun t : ℝ => Real.exp (-x * t ^ s) :=
+  (isBernsteinFunction_rpow hs hs₁).isContinuousCompletelyMonotoneOnIoi_exp_neg_mul hx
+
+/-- The stretched exponential `t ↦ e^{-x t^s}` is the Laplace transform of a finite positive
+measure on `ℝ≥0`, namely the law of the one-sided `s`-stable variable scaled by `x`. -/
+theorem exists_representsLaplace_exp_neg_mul_rpow {x s : ℝ} (hx : 0 ≤ x) (hs : 0 ≤ s)
+    (hs₁ : s ≤ 1) :
+    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ fun t : ℝ => Real.exp (-x * t ^ s) :=
+  (hausdorff_bernstein_widder _).mp
+    (isContinuousCompletelyMonotoneOnIoi_exp_neg_mul_rpow hx hs hs₁)
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Analysis.CompletelyMonotone.Composition
 public import TauCeti.Analysis.CompletelyMonotone.Power
 -- Proof-only: the derivative and the continuity of a real power with a constant exponent.
-import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 import Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 
 /-!
@@ -19,18 +18,16 @@ on `[0, ∞)`, smooth on `(0, ∞)`, and its derivative `t ↦ s · t^{s-1}` is 
 negative power of `TauCeti.isCompletelyMonotoneOnIoi_rpow_neg`, since `s - 1 = -(1 - s)` with
 `1 - s ≥ 0`.
 
-Feeding this into `TauCeti.IsCompletelyMonotone.comp_isBernsteinFunction` produces the stretched
-exponentials `t ↦ e^{-x t^s}`, the completely monotone functions whose representing measures are
-the one-sided `s`-stable laws; they are the acceptance example the `OneParameterSemigroups`
-roadmap asks the composition closure to deliver. The endpoint `s = 1` recovers the exponential
-`t ↦ e^{-x t}` and `s = 0` the constant `t ↦ e^{-x}`.
+Feeding this into `TauCeti.IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction` produces
+the stretched exponentials `t ↦ e^{-x t^s}`. These are the acceptance example the
+`OneParameterSemigroups` roadmap asks the composition closure to deliver. The endpoint `s = 1`
+recovers the exponential `t ↦ e^{-x t}` and `s = 0` the constant `t ↦ e^{-x}`.
 
 ## Main declarations
 
 * `TauCeti.isBernsteinFunction_rpow`: `t ↦ t^s` is a Bernstein function for `0 ≤ s ≤ 1`.
 * `TauCeti.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul_rpow`: the stretched exponential
   `t ↦ e^{-x t^s}` is completely monotone.
-* `TauCeti.exists_representsLaplace_exp_neg_mul_rpow`: its representing measure.
 
 ## References
 
@@ -40,8 +37,8 @@ roadmap asks the composition closure to deliver. The endpoint `s = 1` recovers t
 
 public section
 
-open MeasureTheory Set
-open scoped ContDiff NNReal
+open Set
+open scoped ContDiff
 
 namespace TauCeti
 
@@ -66,13 +63,5 @@ theorem isContinuousCompletelyMonotoneOnIoi_exp_neg_mul_rpow {x s : ℝ} (hx : 0
     (hs₁ : s ≤ 1) :
     IsContinuousCompletelyMonotoneOnIoi fun t : ℝ => Real.exp (-x * t ^ s) :=
   (isBernsteinFunction_rpow hs hs₁).isContinuousCompletelyMonotoneOnIoi_exp_neg_mul hx
-
-/-- The stretched exponential `t ↦ e^{-x t^s}` is the Laplace transform of a finite positive
-measure on `ℝ≥0`, namely the law of the one-sided `s`-stable variable scaled by `x`. -/
-theorem exists_representsLaplace_exp_neg_mul_rpow {x s : ℝ} (hx : 0 ≤ x) (hs : 0 ≤ s)
-    (hs₁ : s ≤ 1) :
-    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ fun t : ℝ => Real.exp (-x * t ^ s) :=
-  (hausdorff_bernstein_widder _).mp
-    (isContinuousCompletelyMonotoneOnIoi_exp_neg_mul_rpow hx hs hs₁)
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean
@@ -27,7 +27,7 @@ recovers the exponential `t ↦ e^{-x t}` and `s = 0` the constant `t ↦ e^{-x}
 
 * `TauCeti.isBernsteinFunction_rpow`: `t ↦ t^s` is a Bernstein function for `0 ≤ s ≤ 1`.
 * `TauCeti.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul_rpow`: the stretched exponential
-  `t ↦ e^{-x t^s}` is completely monotone.
+  `t ↦ e^{-x t^s}` is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`.
 
 ## References
 
@@ -56,9 +56,11 @@ theorem isBernsteinFunction_rpow {s : ℝ} (hs : 0 ≤ s) (hs₁ : s ≤ 1) :
       fun t ht => Real.rpow_nonneg ht s,
       ((isCompletelyMonotoneOnIoi_rpow_neg (by linarith : (0 : ℝ) ≤ 1 - s)).smul hs).congr hderiv⟩
 
-/-- The **stretched exponential** `t ↦ e^{-x t^s}` is completely monotone on `[0, ∞)` for
-`x ≥ 0` and `0 ≤ s ≤ 1`: it is the composition of the completely monotone `t ↦ e^{-x t}` with the
-Bernstein function `t ↦ t^s`. -/
+/-- The **stretched exponential** `t ↦ e^{-x t^s}` is continuous on `[0, ∞)` and completely
+monotone on `(0, ∞)` for `x ≥ 0` and `0 ≤ s ≤ 1`: it is the composition of the completely
+monotone `t ↦ e^{-x t}` with the Bernstein function `t ↦ t^s`. For `x > 0` and `0 < s < 1`, its
+derivative is singular at the origin, so the stronger closed-half-line `IsCompletelyMonotone`
+predicate fails. -/
 theorem isContinuousCompletelyMonotoneOnIoi_exp_neg_mul_rpow {x s : ℝ} (hx : 0 ≤ x) (hs : 0 ≤ s)
     (hs₁ : s ≤ 1) :
     IsContinuousCompletelyMonotoneOnIoi fun t : ℝ => Real.exp (-x * t ^ s) :=

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.CompletelyMonotone.Composition
+public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Composition
 public import TauCeti.Analysis.CompletelyMonotone.Power
 -- Proof-only: the derivative and the continuity of a real power with a constant exponent.
 import Mathlib.Analysis.SpecialFunctions.Pow.Deriv

--- a/TauCeti/Analysis/CompletelyMonotone/Composition.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Composition.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
 public import TauCeti.Analysis.CompletelyMonotone.OpenClosure
-public import TauCeti.Analysis.CompletelyMonotone.Bernstein.HausdorffBernsteinWidder
 
 /-!
 # Composing completely monotone and Bernstein functions
@@ -48,13 +47,11 @@ In that degenerate case the composition is the constant `g 0`, and the theorems 
   `t ↦ g (f t) · h t` that the induction proves.
 * `TauCeti.IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction`: the open-half-line composition
   theorem, under the positivity hypothesis on the inner function.
-* `TauCeti.IsCompletelyMonotone.comp_isBernsteinFunction`: **a completely monotone function
-  composed with a Bernstein function is completely monotone** on the closed half-line.
+* `TauCeti.IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction`: **a completely monotone
+  function composed with a Bernstein function is completely monotone** on the closed half-line.
 * `TauCeti.IsBernsteinFunction.comp`: Bernstein functions are closed under composition.
 * `TauCeti.IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul`: the prototype
   `t ↦ e^{-x f(t)}` is completely monotone.
-* `TauCeti.IsCompletelyMonotone.exists_representsLaplace_comp_isBernsteinFunction`: subordination,
-  the representing measure of `g ∘ f` supplied by Hausdorff--Bernstein--Widder.
 
 ## References
 
@@ -64,8 +61,8 @@ In that degenerate case the composition is the constant `g 0`, and the theorems 
 
 public section
 
-open MeasureTheory Set Filter
-open scoped ContDiff NNReal Topology
+open Set Filter
+open scoped ContDiff Topology
 
 namespace TauCeti
 
@@ -193,7 +190,7 @@ theorem IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul (hg : IsCompletel
 /-- **Composition on the open half-line.** If `g` is completely monotone on `(0, ∞)` and `f` is a
 Bernstein function that is positive on `(0, ∞)`, then `g ∘ f` is completely monotone on `(0, ∞)`.
 The positivity hypothesis is what keeps `f t` inside the open half-line, where `g` is smooth; it
-is removed in `TauCeti.IsCompletelyMonotone.comp_isBernsteinFunction`. -/
+is removed in `TauCeti.IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction`. -/
 theorem IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction (hg : IsCompletelyMonotoneOnIoi g)
     (hf : IsBernsteinFunction f) (hpos : ∀ t : ℝ, 0 < t → 0 < f t) :
     IsCompletelyMonotoneOnIoi (g ∘ f) := by
@@ -203,16 +200,16 @@ theorem IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction (hg : IsCompletelyMon
   simp [Function.comp_apply]
 
 /-- **A completely monotone function composed with a Bernstein function is completely
-monotone.** This is the closure property the `OneParameterSemigroups` roadmap asks for in Part B;
-together with `TauCeti.hausdorff_bernstein_widder` it is the analytic form of subordination.
+monotone.** This is the closure property the `OneParameterSemigroups` roadmap asks for in Part B.
 
 The conclusion is the closed-half-line predicate `IsContinuousCompletelyMonotoneOnIoi`, not the
 stronger `IsCompletelyMonotone`: a Bernstein function such as `t ↦ √t` has no finite right
-derivative at the origin, so neither does the composition. -/
-theorem IsCompletelyMonotone.comp_isBernsteinFunction (hg : IsCompletelyMonotone g)
+derivative at the origin, so the composition need not have one. -/
+theorem IsContinuousCompletelyMonotoneOnIoi.comp_isBernsteinFunction
+    (hg : IsContinuousCompletelyMonotoneOnIoi g)
     (hf : IsBernsteinFunction f) : IsContinuousCompletelyMonotoneOnIoi (g ∘ f) := by
   refine isContinuousCompletelyMonotoneOnIoi_iff.mpr
-    ⟨hg.contDiffOn.continuousOn.comp hf.continuousOn fun u hu => mem_Ici.2 (hf.nonneg hu), ?_⟩
+    ⟨hg.continuousOn.comp hf.continuousOn fun u hu => mem_Ici.2 (hf.nonneg hu), ?_⟩
   by_cases hvanish : ∃ t₀ : ℝ, 0 < t₀ ∧ f t₀ = 0
   · obtain ⟨t₀, ht₀, h₀⟩ := hvanish
     refine (isCompletelyMonotone_const (hg.nonneg le_rfl)).isCompletelyMonotoneOnIoi.congr ?_
@@ -253,20 +250,7 @@ Laplace transforms of the one-parameter convolution semigroup subordinate to `f`
 theorem IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul
     (hf : IsBernsteinFunction f) {x : ℝ} (hx : 0 ≤ x) :
     IsContinuousCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t) :=
-  (isCompletelyMonotone_exp_neg_mul hx).comp_isBernsteinFunction hf
-
-/-- **Subordination.** The composition of a completely monotone function with a Bernstein
-function is again the Laplace transform of a finite positive measure on `ℝ≥0`; the measure is
-supplied by the Hausdorff--Bernstein--Widder representation. -/
-theorem IsCompletelyMonotone.exists_representsLaplace_comp_isBernsteinFunction
-    (hg : IsCompletelyMonotone g) (hf : IsBernsteinFunction f) :
-    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ (g ∘ f) :=
-  (hausdorff_bernstein_widder _).mp (hg.comp_isBernsteinFunction hf)
-
-/-- The representing measure of the subordinate transform `t ↦ e^{-x f(t)}`. -/
-theorem IsBernsteinFunction.exists_representsLaplace_exp_neg_mul (hf : IsBernsteinFunction f)
-    {x : ℝ} (hx : 0 ≤ x) :
-    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ fun t => Real.exp (-x * f t) :=
-  (hausdorff_bernstein_widder _).mp (hf.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul hx)
+  (IsContinuousCompletelyMonotoneOnIoi.of_isCompletelyMonotone
+    (isCompletelyMonotone_exp_neg_mul hx)).comp_isBernsteinFunction hf
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Composition.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Composition.lean
@@ -1,0 +1,272 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
+public import TauCeti.Analysis.CompletelyMonotone.OpenClosure
+public import TauCeti.Analysis.CompletelyMonotone.Bernstein.HausdorffBernsteinWidder
+
+/-!
+# Composing completely monotone and Bernstein functions
+
+This file proves the composition closure property called for by the `OneParameterSemigroups`
+roadmap, Part B: if `g` is completely monotone and `f` is a Bernstein function, then `g ∘ f` is
+again completely monotone. Two companions come out of the same argument: Bernstein functions are
+closed under composition, and the prototype `t ↦ e^{-x f(t)}` is completely monotone for every
+`x ≥ 0` and every Bernstein `f`.
+
+## The induction
+
+Writing `F = g ∘ f`, the chain and product rules give `F' = -\,[(-g') ∘ f] \cdot f'`, in which
+both `-g'` and `f'` are completely monotone. Iterating this substitution never returns to a
+composition alone, but always to a *product* of a composition with a completely monotone factor.
+The workhorse `TauCeti.IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul` therefore carries
+that product along: for completely monotone `g` and `h`, `t ↦ g (f t) · h t` is completely
+monotone, that is,
+`0 ≤ (-1)ⁿ dⁿ/dtⁿ [g(f t) · h t]` on `(0, ∞)`, proved by induction on `n` from the identity
+
+`d/dt [g(f t) · h t] = -\,[(-g')(f t) · (f' t · h t)] - [g(f t) · (-h' t)]`,
+
+whose two bracketed terms are again of the same shape, with `(-g', f' · h)` and `(g, -h')` in
+place of `(g, h)`. Taking `h = 1` gives the composition theorem.
+
+The argument runs on the *open* half-line, where a Bernstein function is smooth and where its
+values are positive, so that the derivatives of `g` at `f t` are honest two-sided derivatives.
+That positivity is not automatic — a Bernstein function may vanish — but the failure is total:
+`TauCeti.IsBernsteinFunction.eq_zero_of_eq_zero` shows that a Bernstein function vanishing at one
+positive point vanishes on all of `[0, ∞)`, because it is nonnegative, nondecreasing and concave.
+In that degenerate case the composition is the constant `g 0`, and the theorems are immediate.
+
+## Main declarations
+
+* `TauCeti.IsBernsteinFunction.eq_zero_of_eq_zero`: a Bernstein function with a zero on `(0, ∞)`
+  vanishes identically on `[0, ∞)`.
+* `TauCeti.IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul`: the product form
+  `t ↦ g (f t) · h t` that the induction proves.
+* `TauCeti.IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction`: the open-half-line composition
+  theorem, under the positivity hypothesis on the inner function.
+* `TauCeti.IsCompletelyMonotone.comp_isBernsteinFunction`: **a completely monotone function
+  composed with a Bernstein function is completely monotone** on the closed half-line.
+* `TauCeti.IsBernsteinFunction.comp`: Bernstein functions are closed under composition.
+* `TauCeti.IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul`: the prototype
+  `t ↦ e^{-x f(t)}` is completely monotone.
+* `TauCeti.IsCompletelyMonotone.exists_representsLaplace_comp_isBernsteinFunction`: subordination,
+  the representing measure of `g ∘ f` supplied by Hausdorff--Bernstein--Widder.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012), Theorem 3.7 and Corollary 3.8.
+-/
+
+public section
+
+open MeasureTheory Set Filter
+open scoped ContDiff NNReal Topology
+
+namespace TauCeti
+
+variable {f g h : ℝ → ℝ}
+
+/-! ### Bernstein functions with a zero -/
+
+/-- A Bernstein function that vanishes at one positive point vanishes on the whole closed
+half-line. Monotonicity pushes the value at the origin down to `0`, and concavity then traps the
+graph between the chord through the two zeros and the horizontal axis. -/
+theorem IsBernsteinFunction.eq_zero_of_eq_zero (hf : IsBernsteinFunction f) {t₀ : ℝ}
+    (ht₀ : 0 < t₀) (h₀ : f t₀ = 0) {t : ℝ} (ht : 0 ≤ t) : f t = 0 := by
+  have hzero : f 0 = 0 :=
+    le_antisymm (h₀ ▸ hf.monotoneOn (mem_Ici.2 le_rfl) (mem_Ici.2 ht₀.le) ht₀.le)
+      (hf.nonneg le_rfl)
+  rcases le_or_gt t t₀ with hle | hlt
+  · exact le_antisymm (h₀ ▸ hf.monotoneOn (mem_Ici.2 ht) (mem_Ici.2 ht₀.le) hle) (hf.nonneg ht)
+  · have htpos : 0 < t := ht₀.trans hlt
+    have hb : 0 < t₀ / t := div_pos ht₀ htpos
+    have hb1 : t₀ / t < 1 := (div_lt_one htpos).2 hlt
+    have hchord : (1 - t₀ / t) • (0 : ℝ) + (t₀ / t) • t = t₀ := by
+      rw [smul_eq_mul, smul_eq_mul, mul_zero, zero_add, div_mul_cancel₀ _ htpos.ne']
+    have hcc := hf.concaveOn.2 (mem_Ici.2 le_rfl) (mem_Ici.2 ht)
+      (by linarith : (0 : ℝ) ≤ 1 - t₀ / t) hb.le (by ring)
+    rw [hchord, hzero, h₀] at hcc
+    simp only [smul_eq_mul, mul_zero, zero_add] at hcc
+    nlinarith [hf.nonneg ht]
+
+/-- A Bernstein function with no zero on the open half-line is positive there: this is the
+dichotomy that lets the composition theorems split into a degenerate constant case and the main
+case, where the inner function stays inside `(0, ∞)`. -/
+theorem IsBernsteinFunction.pos_of_forall_ne_zero (hf : IsBernsteinFunction f)
+    (hne : ¬∃ t₀ : ℝ, 0 < t₀ ∧ f t₀ = 0) {t : ℝ} (ht : 0 < t) : 0 < f t := by
+  rcases (hf.nonneg ht.le).lt_or_eq with hlt | heq
+  · exact hlt
+  · exact absurd ⟨t, ht, heq.symm⟩ hne
+
+/-! ### The composition induction -/
+
+/-- The induction behind the composition theorem: for a Bernstein function `f` that is positive
+on `(0, ∞)` and completely monotone `g` and `h`, every alternating derivative of the product
+`t ↦ g (f t) · h t` is nonnegative on `(0, ∞)`.
+
+The functions `g` and `h` are quantified inside the statement because the induction step feeds
+the hypothesis two *different* pairs; `IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul`
+is the usable form. -/
+private theorem neg_one_pow_mul_iteratedDeriv_comp_mul_nonneg (hf : IsBernsteinFunction f)
+    (hpos : ∀ t : ℝ, 0 < t → 0 < f t) (n : ℕ) :
+    ∀ g h : ℝ → ℝ, IsCompletelyMonotoneOnIoi g → IsCompletelyMonotoneOnIoi h →
+      ∀ t : ℝ, 0 < t → 0 ≤ (-1 : ℝ) ^ n * iteratedDeriv n (fun u => g (f u) * h u) t := by
+  have hmaps : MapsTo f (Ioi 0) (Ioi 0) := fun u hu => mem_Ioi.2 (hpos u hu)
+  -- Smoothness of the model product `t ↦ g (f t) · h t`, needed to split iterated derivatives.
+  have hsmooth : ∀ g h : ℝ → ℝ, IsCompletelyMonotoneOnIoi g → IsCompletelyMonotoneOnIoi h →
+      ContDiffOn ℝ ∞ (fun u => g (f u) * h u) (Ioi 0) := fun g h hg hh =>
+    (hg.contDiffOn.comp hf.contDiffOn hmaps).mul hh.contDiffOn
+  induction n with
+  | zero =>
+      intro g h hg hh t ht
+      simpa [iteratedDeriv_zero] using mul_nonneg (hg.nonneg (hpos t ht)) (hh.nonneg ht)
+  | succ n ih =>
+      intro g h hg hh t ht
+      -- The three completely monotone ingredients of the differentiated product.
+      have hg₁ : IsCompletelyMonotoneOnIoi fun s => -deriv g s := hg.neg_deriv
+      have hh₁ : IsCompletelyMonotoneOnIoi fun u => deriv f u * h u :=
+        (hf.deriv_isCompletelyMonotoneOnIoi.mul hh).congr fun _ _ => rfl
+      have hh₂ : IsCompletelyMonotoneOnIoi fun u => -deriv h u := hh.neg_deriv
+      -- Differentiating once produces exactly the two pairs the induction hypothesis wants.
+      have hderiv : ∀ u ∈ Ioi (0 : ℝ), deriv (fun v => g (f v) * h v) u =
+          -(-deriv g (f u) * (deriv f u * h u) + g (f u) * -deriv h u) := by
+        intro u hu
+        have hdf : HasDerivAt f (deriv f u) u :=
+          (hf.differentiableOn.differentiableAt (isOpen_Ioi.mem_nhds hu)).hasDerivAt
+        have hdg : HasDerivAt g (deriv g (f u)) (f u) :=
+          ((hg.contDiffOn.differentiableOn (by simp)).differentiableAt
+            (isOpen_Ioi.mem_nhds (mem_Ioi.2 (hpos u hu)))).hasDerivAt
+        have hdh : HasDerivAt h (deriv h u) u :=
+          ((hh.contDiffOn.differentiableOn (by simp)).differentiableAt
+            (isOpen_Ioi.mem_nhds hu)).hasDerivAt
+        have hcomp : HasDerivAt (fun v => g (f v)) (deriv g (f u) * deriv f u) u :=
+          HasDerivAt.comp u hdg hdf
+        have hprod : HasDerivAt (fun v => g (f v) * h v)
+            (deriv g (f u) * deriv f u * h u + g (f u) * deriv h u) u := hcomp.mul hdh
+        rw [hprod.deriv]
+        ring
+      have hEq : deriv (fun v => g (f v) * h v) =ᶠ[𝓝 t]
+          fun u => -(-deriv g (f u) * (deriv f u * h u) + g (f u) * -deriv h u) :=
+        eventually_of_mem (isOpen_Ioi.mem_nhds ht) hderiv
+      -- Both summands are smooth, so the `n`-th derivative of the sum splits.
+      have hA : ContDiffAt ℝ (n : WithTop ℕ∞) (fun u => -deriv g (f u) * (deriv f u * h u)) t :=
+        ((hsmooth _ _ hg₁ hh₁).contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by exact_mod_cast le_top)
+      have hB : ContDiffAt ℝ (n : WithTop ℕ∞) (fun u => g (f u) * -deriv h u) t :=
+        ((hsmooth _ _ hg hh₂).contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by exact_mod_cast le_top)
+      have hIHA : 0 ≤ (-1 : ℝ) ^ n *
+          iteratedDeriv n (fun u => -deriv g (f u) * (deriv f u * h u)) t :=
+        ih (fun s => -deriv g s) (fun u => deriv f u * h u) hg₁ hh₁ t ht
+      have hIHB : 0 ≤ (-1 : ℝ) ^ n * iteratedDeriv n (fun u => g (f u) * -deriv h u) t :=
+        ih g (fun u => -deriv h u) hg hh₂ t ht
+      rw [iteratedDeriv_succ', hEq.iteratedDeriv_eq n, iteratedDeriv_fun_neg,
+        iteratedDeriv_fun_add hA hB]
+      have hsign : (-1 : ℝ) ^ (n + 1) *
+            -(iteratedDeriv n (fun u => -deriv g (f u) * (deriv f u * h u)) t +
+              iteratedDeriv n (fun u => g (f u) * -deriv h u) t) =
+          (-1 : ℝ) ^ n * iteratedDeriv n (fun u => -deriv g (f u) * (deriv f u * h u)) t +
+            (-1 : ℝ) ^ n * iteratedDeriv n (fun u => g (f u) * -deriv h u) t := by
+        rw [pow_succ]
+        ring
+      rw [hsign]
+      exact add_nonneg hIHA hIHB
+
+/-! ### Composition theorems -/
+
+/-- **The product form of the open-half-line composition theorem.** For completely monotone `g`
+and `h` and a Bernstein function `f` that is positive on `(0, ∞)`, the product `t ↦ g (f t) · h t`
+is completely monotone on `(0, ∞)`.
+
+The extra factor `h` is what makes the induction close: differentiating once turns the pair
+`(g, h)` into the two pairs `(-g', f' · h)` and `(g, -h')`, both again completely monotone. -/
+theorem IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul (hg : IsCompletelyMonotoneOnIoi g)
+    (hh : IsCompletelyMonotoneOnIoi h) (hf : IsBernsteinFunction f)
+    (hpos : ∀ t : ℝ, 0 < t → 0 < f t) :
+    IsCompletelyMonotoneOnIoi fun u => g (f u) * h u :=
+  ⟨(hg.contDiffOn.comp hf.contDiffOn fun u hu => mem_Ioi.2 (hpos u hu)).mul hh.contDiffOn,
+    fun n t ht => neg_one_pow_mul_iteratedDeriv_comp_mul_nonneg hf hpos n g h hg hh t ht⟩
+
+/-- **Composition on the open half-line.** If `g` is completely monotone on `(0, ∞)` and `f` is a
+Bernstein function that is positive on `(0, ∞)`, then `g ∘ f` is completely monotone on `(0, ∞)`.
+The positivity hypothesis is what keeps `f t` inside the open half-line, where `g` is smooth; it
+is removed in `TauCeti.IsCompletelyMonotone.comp_isBernsteinFunction`. -/
+theorem IsCompletelyMonotoneOnIoi.comp_isBernsteinFunction (hg : IsCompletelyMonotoneOnIoi g)
+    (hf : IsBernsteinFunction f) (hpos : ∀ t : ℝ, 0 < t → 0 < f t) :
+    IsCompletelyMonotoneOnIoi (g ∘ f) := by
+  have hone : IsCompletelyMonotoneOnIoi fun _ : ℝ => (1 : ℝ) :=
+    (isCompletelyMonotone_const zero_le_one).isCompletelyMonotoneOnIoi
+  refine (hg.comp_isBernsteinFunction_mul hone hf hpos).congr fun u _ => ?_
+  simp [Function.comp_apply]
+
+/-- **A completely monotone function composed with a Bernstein function is completely
+monotone.** This is the closure property the `OneParameterSemigroups` roadmap asks for in Part B;
+together with `TauCeti.hausdorff_bernstein_widder` it is the analytic form of subordination.
+
+The conclusion is the closed-half-line predicate `IsContinuousCompletelyMonotoneOnIoi`, not the
+stronger `IsCompletelyMonotone`: a Bernstein function such as `t ↦ √t` has no finite right
+derivative at the origin, so neither does the composition. -/
+theorem IsCompletelyMonotone.comp_isBernsteinFunction (hg : IsCompletelyMonotone g)
+    (hf : IsBernsteinFunction f) : IsContinuousCompletelyMonotoneOnIoi (g ∘ f) := by
+  refine isContinuousCompletelyMonotoneOnIoi_iff.mpr
+    ⟨hg.contDiffOn.continuousOn.comp hf.continuousOn fun u hu => mem_Ici.2 (hf.nonneg hu), ?_⟩
+  by_cases hvanish : ∃ t₀ : ℝ, 0 < t₀ ∧ f t₀ = 0
+  · obtain ⟨t₀, ht₀, h₀⟩ := hvanish
+    refine (isCompletelyMonotone_const (hg.nonneg le_rfl)).isCompletelyMonotoneOnIoi.congr ?_
+    intro t ht
+    simp [Function.comp_apply, hf.eq_zero_of_eq_zero ht₀ h₀ (le_of_lt ht)]
+  · exact hg.isCompletelyMonotoneOnIoi.comp_isBernsteinFunction hf
+      fun t ht => hf.pos_of_forall_ne_zero hvanish ht
+
+/-- **Bernstein functions are closed under composition.** The derivative of `g ∘ f` is
+`(g' ∘ f) · f'`, a product of the composition theorem's output with a completely monotone
+factor. -/
+theorem IsBernsteinFunction.comp (hg : IsBernsteinFunction g) (hf : IsBernsteinFunction f) :
+    IsBernsteinFunction (g ∘ f) := by
+  by_cases hvanish : ∃ t₀ : ℝ, 0 < t₀ ∧ f t₀ = 0
+  · obtain ⟨t₀, ht₀, h₀⟩ := hvanish
+    refine (isBernsteinFunction_const (hg.nonneg le_rfl)).congr fun t ht => ?_
+    simp [Function.comp_apply, hf.eq_zero_of_eq_zero ht₀ h₀ (mem_Ici.1 ht)]
+  · have hpos : ∀ t : ℝ, 0 < t → 0 < f t := fun t ht => hf.pos_of_forall_ne_zero hvanish ht
+    have hmaps : MapsTo f (Ioi 0) (Ioi 0) := fun u hu => mem_Ioi.2 (hpos u hu)
+    refine isBernsteinFunction_iff.mpr
+      ⟨hg.continuousOn.comp hf.continuousOn fun u hu => mem_Ici.2 (hf.nonneg hu),
+        hg.contDiffOn.comp hf.contDiffOn hmaps,
+        fun t ht => hg.nonneg (hf.nonneg ht), ?_⟩
+    have hcm : IsCompletelyMonotoneOnIoi fun u => deriv g (f u) * deriv f u :=
+      hg.deriv_isCompletelyMonotoneOnIoi.comp_isBernsteinFunction_mul
+        hf.deriv_isCompletelyMonotoneOnIoi hf hpos
+    refine hcm.congr fun u hu => ?_
+    have hdf : HasDerivAt f (deriv f u) u :=
+      (hf.differentiableOn.differentiableAt (isOpen_Ioi.mem_nhds hu)).hasDerivAt
+    have hdg : HasDerivAt g (deriv g (f u)) (f u) :=
+      (hg.differentiableOn.differentiableAt
+        (isOpen_Ioi.mem_nhds (mem_Ioi.2 (hpos u hu)))).hasDerivAt
+    exact (HasDerivAt.comp u hdg hdf).deriv
+
+/-- The prototype completely monotone functions attached to a Bernstein function: for `x ≥ 0`,
+the composition `t ↦ e^{-x f(t)}` is completely monotone on the closed half-line. These are the
+Laplace transforms of the one-parameter convolution semigroup subordinate to `f`. -/
+theorem IsBernsteinFunction.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul
+    (hf : IsBernsteinFunction f) {x : ℝ} (hx : 0 ≤ x) :
+    IsContinuousCompletelyMonotoneOnIoi fun t => Real.exp (-x * f t) :=
+  (isCompletelyMonotone_exp_neg_mul hx).comp_isBernsteinFunction hf
+
+/-- **Subordination.** The composition of a completely monotone function with a Bernstein
+function is again the Laplace transform of a finite positive measure on `ℝ≥0`; the measure is
+supplied by the Hausdorff--Bernstein--Widder representation. -/
+theorem IsCompletelyMonotone.exists_representsLaplace_comp_isBernsteinFunction
+    (hg : IsCompletelyMonotone g) (hf : IsBernsteinFunction f) :
+    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ (g ∘ f) :=
+  (hausdorff_bernstein_widder _).mp (hg.comp_isBernsteinFunction hf)
+
+/-- The representing measure of the subordinate transform `t ↦ e^{-x f(t)}`. -/
+theorem IsBernsteinFunction.exists_representsLaplace_exp_neg_mul (hf : IsBernsteinFunction f)
+    {x : ℝ} (hx : 0 ≤ x) :
+    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ fun t => Real.exp (-x * f t) :=
+  (hausdorff_bernstein_widder _).mp (hf.isContinuousCompletelyMonotoneOnIoi_exp_neg_mul hx)
+
+end TauCeti


### PR DESCRIPTION
This PR proves that a completely monotone function composed with a Bernstein function is again completely monotone, and equips the result with the companions that make it usable: Bernstein functions are closed under composition, the prototype `t ↦ e^{-x f(t)}` is completely monotone for every Bernstein `f` and every `x ≥ 0`, and the stretched exponential `t ↦ e^{-x t^s}` with `0 ≤ s ≤ 1` is the acceptance example that falls out.

This is the composition bullet of Part B's "API to develop" in `TauCetiRoadmap/OneParameterSemigroups/README.md` — "**composition** `g ∘ f` of completely monotone `g` with a Bernstein function `f` is completely monotone" — the last closure property of the Part B milestone (Bernstein's theorem) that the roadmap names and that `STATUS.md` still lists as untouched ("as is composition of a completely monotone function with a Bernstein one"). It also supplies Part B's "closure used to build new completely monotone functions from these" acceptance example, since the stretched exponentials are exactly what the closure manufactures out of `t ↦ e^{-xt}`. After this PR, Part B still needs the Lévy–Khinchine representation of Bernstein functions and the Stieltjes / completely-monotone ↔ Bernstein correspondences.

The proof runs on the open half-line, where a Bernstein function is smooth. The chain and product rules give `(g ∘ f)' = -[(-g') ∘ f] · f'`, so iterating never returns to a bare composition but always to a product of a composition with a completely monotone factor. A private induction carries that factor along: for completely monotone `g` and `h`, `t ↦ g (f t) · h t` is completely monotone, proved by induction on the order from the single-step identity `d/dt [g(f t) · h t] = -[(-g')(f t) · (f' t · h t)] - [g(f t) · (-h' t)]`, whose two bracketed terms have the same shape with `(-g', f' · h)` and `(g, -h')` in place of `(g, h)`. Taking `h = 1` gives the composition theorem, while the Bernstein-composition theorem combines that result with product closure. The inner function has to stay inside `(0, ∞)` for the derivatives of `g` at `f t` to be two-sided; that is not automatic, so `IsBernsteinFunction.eq_zero_of_eq_zero` shows the failure is total — a Bernstein function is nonnegative, nondecreasing and concave, so one zero on `(0, ∞)` forces it to vanish on all of `[0, ∞)` — and the degenerate case reduces to a constant. The conclusion is stated with `IsContinuousCompletelyMonotoneOnIoi`, not the stronger `IsCompletelyMonotone`, because a Bernstein function such as `t ↦ √t` has no finite right derivative at the origin.

Files added: `TauCeti/Analysis/CompletelyMonotone/Bernstein/Composition.lean` and `TauCeti/Analysis/CompletelyMonotone/Bernstein/Power.lean`; the latter proves `t ↦ t^s` Bernstein for `0 ≤ s ≤ 1` by reading its derivative as the existing completely monotone negative power `TauCeti.isCompletelyMonotoneOnIoi_rpow_neg`. Everything reuses the existing predicates and closure API — `IsCompletelyMonotoneOnIoi.mul`, `.neg_deriv`, `.congr`, `IsBernsteinFunction.monotoneOn`, `.concaveOn`, `.deriv_isCompletelyMonotoneOnIoi` — plus Mathlib's `iteratedDeriv` calculus; no Mathlib infrastructure is vendored.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"completely-monotone-comp-bernstein"}-->

🤖 Prepared with Claude Code
