### PR TITLE
feat: descend unipotence to faithfully flat images

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/FaithfullyFlatPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/FaithfullyFlatPoints.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
+public import TauCeti.RingTheory.FiniteType.FaithfullyFlatPoints
+
+/-!
+# Points of faithfully flat affine group morphisms
+
+Let `f : H ⟶ K` be a morphism of commutative Hopf algebras over a commutative ring `R`.
+Contravariantly, it represents an affine group morphism from `Spec K` to `Spec H`. If the
+underlying algebra map is faithfully flat and of finite type, this morphism is surjective on
+points valued in every algebraically closed field over `R`.
+
+The algebraic point-lifting theorem is
+`AlgHom.surjective_comp_right_of_faithfullyFlat`. The result here records it in the group-valued
+functor-of-points API, where precomposition is the component of
+`CommHopfAlgCat.mapPointsFunctor f`.
+
+## Main declaration
+
+* `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_surjective_of_faithfullyFlat`: a faithfully flat
+  finite-type coordinate morphism induces a surjection on algebraically closed points.
+
+## References
+
+* The Stacks Project, Tag 00HQ, Lemma 10.39.16.
+* The Stacks Project, Tag 00FV, *Hilbert Nullstellensatz*.
+
+This is the group-valued point-lifting interface used in Layer 5, "The unipotent radical", of the
+ReductiveGroups roadmap. Applied to the faithfully flat morphism from an affine group onto its
+scheme-theoretic image, it lets properties of source points descend to all image points.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u v w
+
+variable {R : Type u} [CommRing R]
+variable {H K : _root_.CommHopfAlgCat.{v} R}
+variable (L : Type w) [Field L] [Algebra R L] [IsAlgClosed L]
+
+/-- A faithfully flat finite-type morphism of commutative Hopf algebras is surjective on points
+valued in an algebraically closed field.
+
+The conclusion is stated for the component of the group-valued points functor, rather than for
+bare algebra maps, so it can be used directly with group-theoretic point properties. -/
+theorem mapPointsFunctor_app_surjective_of_faithfullyFlat (f : H ⟶ K)
+    (hfinite : f.hom.toAlgHom.FiniteType)
+    (hflat : f.hom.toAlgHom.toRingHom.FaithfullyFlat) :
+    Function.Surjective ((mapPointsFunctor f).app (CommAlgCat.of R L)) := by
+  intro p
+  obtain ⟨q, hq⟩ := AlgHom.surjective_comp_right_of_faithfullyFlat
+    f.hom.toAlgHom hfinite hflat p.ofConv
+  refine ⟨WithConv.toConv q, ?_⟩
+  apply WithConv.ofConv_injective
+  rw [mapPointsFunctor_app_apply]
+  simpa only [WithConv.ofConv_toConv] using hq
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
@@ -12,11 +12,12 @@ public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
 /-!
 # Unipotence of faithfully flat affine group images
 
-Let `f : H ⟶ K` be a morphism of commutative Hopf algebras over a field. Contravariantly,
-`f` represents a homomorphism from `Spec K` to `Spec H`, and its scheme-theoretic image has
-coordinate algebra `CommHopfAlgCat.image f = H / ker f`. When the canonical inclusion
-`CommHopfAlgCat.image f ⟶ K` is faithfully flat and `K` is of finite type over the ground
-field, every algebraically closed point of the image lifts to a point of `Spec K`.
+Let `f : H ⟶ K` be a finite-type faithfully flat morphism of commutative Hopf algebras over a
+field. Contravariantly, every algebraically closed point of `Spec H` lifts to a point of
+`Spec K`, so geometric unipotence descends from `K` to `H`. In particular, for an arbitrary
+morphism, its scheme-theoretic image has coordinate algebra
+`CommHopfAlgCat.image f = H / ker f`; finite type of `K` makes the canonical inclusion
+`CommHopfAlgCat.image f ⟶ K` finite type, giving the image result.
 
 Unipotence is preserved when a point is precomposed with a Hopf-algebra morphism. It therefore
 descends from `Spec K` to the scheme-theoretic image. This supplies the geometric-point step in
@@ -26,6 +27,8 @@ unipotent.
 
 ## Main declaration
 
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_faithfullyFlat`: geometric
+  unipotence descends along a finite-type faithfully flat coordinate morphism.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.image_of_faithfullyFlat`: a
   faithfully flat finite-type affine group image has only unipotent geometric points when its
   source does.
@@ -56,6 +59,24 @@ namespace geometricallyUnipotentPointsCommHopfAlgProperty
 variable {k : Type u} [Field k]
 variable {H K : _root_.CommHopfAlgCat.{v} k}
 
+/-- Geometric unipotence descends along a finite-type faithfully flat coordinate morphism. -/
+theorem of_faithfullyFlat (f : H ⟶ K) (hfinite : f.hom.toAlgHom.FiniteType)
+    (hflat : f.hom.toAlgHom.toRingHom.FaithfullyFlat)
+    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k H := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
+  intro g
+  obtain ⟨(q : WithConv (K →ₐ[k] AlgebraicClosure k)), hq⟩ :=
+    CommHopfAlgCat.mapPointsFunctor_app_surjective_of_faithfullyFlat
+      (AlgebraicClosure k) f hfinite hflat g
+  have hqunipotent := (hK q).mapDomain f.hom
+  have hmap : AlgHom.mapDomain f.hom q = g := by
+    rw [AlgHom.mapDomain_apply]
+    rw [CommHopfAlgCat.mapPointsFunctor_app_apply] at hq
+    exact hq
+  rw [hmap] at hqunipotent
+  exact hqunipotent
+
 /-- The scheme-theoretic image of a finite-type geometrically unipotent affine group is
 geometrically unipotent when the source-to-image morphism is faithfully flat.
 
@@ -66,19 +87,12 @@ theorem image_of_faithfullyFlat (f : H ⟶ K) [Algebra.FiniteType k K]
     (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K)
     (hflat : (CommHopfAlgCat.imageι f).hom.toAlgHom.toRingHom.FaithfullyFlat) :
     geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.image f) := by
-  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
-  intro g
   have hfinite : (CommHopfAlgCat.imageι f).hom.toAlgHom.FiniteType := by
     apply AlgHom.FiniteType.of_comp_finiteType
       (f := Algebra.ofId k (CommHopfAlgCat.image f))
     rw [Algebra.comp_ofId]
     exact RingHom.finiteType_algebraMap.mpr inferInstance
-  obtain ⟨q, hq⟩ := CommHopfAlgCat.mapPointsFunctor_app_surjective_of_faithfullyFlat
-    (AlgebraicClosure k) (CommHopfAlgCat.imageι f) hfinite hflat g
-  have hqunipotent := (hK q).mapDomain (CommHopfAlgCat.imageι f).hom
-  have hmap : AlgHom.mapDomain (CommHopfAlgCat.imageι f).hom q = g := hq
-  rw [hmap] at hqunipotent
-  exact hqunipotent
+  exact of_faithfullyFlat (CommHopfAlgCat.imageι f) hfinite hflat hK
 
 end geometricallyUnipotentPointsCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.FaithfullyFlatPoints
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+
+/-!
+# Unipotence of faithfully flat affine group images
+
+Let `f : H ⟶ K` be a morphism of commutative Hopf algebras over a field. Contravariantly,
+`f` represents a homomorphism from `Spec K` to `Spec H`, and its scheme-theoretic image has
+coordinate algebra `CommHopfAlgCat.image f = H / ker f`. When the canonical inclusion
+`CommHopfAlgCat.image f ⟶ K` is faithfully flat and `K` is of finite type over the ground
+field, every algebraically closed point of the image lifts to a point of `Spec K`.
+
+Unipotence is preserved when a point is precomposed with a Hopf-algebra morphism. It therefore
+descends from `Spec K` to the scheme-theoretic image. This supplies the geometric-point step in
+forming the product of two normal smooth unipotent closed subgroup schemes: after multiplication
+is realized as a faithfully flat morphism onto its image, the image is again geometrically
+unipotent.
+
+## Main declaration
+
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.image_of_faithfullyFlat`: a
+  faithfully flat finite-type affine group image has only unipotent geometric points when its
+  source does.
+
+## References
+
+* The Stacks Project, Tags 00HQ and 00FV, for algebraically closed points of faithfully flat
+  finite-type algebras.
+* A. Borel, *Linear Algebraic Groups*, Proposition 14.4, for the unipotent-radical application.
+
+This is the algebraically-closed-point bridge for Layer 5, "The unipotent radical", of the
+ReductiveGroups roadmap. It combines point lifting along a faithfully flat finite-type algebra
+map with functoriality of unipotent points. The separate theorem that a homomorphism of affine
+groups is faithfully flat onto its scheme-theoretic image remains the input that discharges the
+hypothesis below.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u v
+
+namespace geometricallyUnipotentPointsCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+variable {H K : _root_.CommHopfAlgCat.{v} k}
+
+/-- The scheme-theoretic image of a finite-type geometrically unipotent affine group is
+geometrically unipotent when the source-to-image morphism is faithfully flat.
+
+The finite-type hypothesis on `K` makes the canonical inclusion of the image coordinate algebra
+into `K` a finite-type algebra map. Faithful flatness then lifts every algebraic-closure-valued
+point of the image to a point of `K`, whose unipotence descends by precomposition. -/
+theorem image_of_faithfullyFlat (f : H ⟶ K) [Algebra.FiniteType k K]
+    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K)
+    (hflat : (CommHopfAlgCat.imageι f).hom.toAlgHom.toRingHom.FaithfullyFlat) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.image f) := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
+  intro g
+  have hfinite : (CommHopfAlgCat.imageι f).hom.toAlgHom.FiniteType := by
+    apply AlgHom.FiniteType.of_comp_finiteType
+      (f := Algebra.ofId k (CommHopfAlgCat.image f))
+    rw [Algebra.comp_ofId]
+    exact RingHom.finiteType_algebraMap.mpr inferInstance
+  obtain ⟨q, hq⟩ := CommHopfAlgCat.mapPointsFunctor_app_surjective_of_faithfullyFlat
+    (AlgebraicClosure k) (CommHopfAlgCat.imageι f) hfinite hflat g
+  have hqunipotent := (hK q).mapDomain (CommHopfAlgCat.imageι f).hom
+  have hmap : AlgHom.mapDomain (CommHopfAlgCat.imageι f).hom q = g := hq
+  rw [hmap] at hqunipotent
+  exact hqunipotent
+
+end geometricallyUnipotentPointsCommHopfAlgProperty
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
@@ -5,19 +5,17 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.FaithfullyFlatPoints
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Basic
-public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.FaithfullyFlat
 
 /-!
 # Unipotence of faithfully flat affine group images
 
-Let `f : H ⟶ K` be a finite-type faithfully flat morphism of commutative Hopf algebras over a
-field. Contravariantly, every algebraically closed point of `Spec H` lifts to a point of
-`Spec K`, so geometric unipotence descends from `K` to `H`. In particular, for an arbitrary
-morphism, its scheme-theoretic image has coordinate algebra
+For a morphism `f : H ⟶ K` of commutative Hopf algebras, its scheme-theoretic image has coordinate
+algebra
 `CommHopfAlgCat.image f = H / ker f`; finite type of `K` makes the canonical inclusion
-`CommHopfAlgCat.image f ⟶ K` finite type, giving the image result.
+`CommHopfAlgCat.image f ⟶ K` finite type. If this inclusion is faithfully flat, every
+algebraically closed point of the image lifts to a point of `Spec K`.
 
 Unipotence is preserved when a point is precomposed with a Hopf-algebra morphism. It therefore
 descends from `Spec K` to the scheme-theoretic image. This supplies the geometric-point step in
@@ -27,28 +25,23 @@ unipotent.
 
 ## Main declaration
 
-* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_faithfullyFlat`: geometric
-  unipotence descends along a finite-type faithfully flat coordinate morphism.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.image_of_faithfullyFlat`: a
   faithfully flat finite-type affine group image has only unipotent geometric points when its
   source does.
 
 ## References
 
-* The Stacks Project, Tags 00HQ and 00FV, for algebraically closed points of faithfully flat
-  finite-type algebras.
 * A. Borel, *Linear Algebraic Groups*, Proposition 14.4, for the unipotent-radical application.
 
-This is the algebraically-closed-point bridge for Layer 5, "The unipotent radical", of the
-ReductiveGroups roadmap. It combines point lifting along a faithfully flat finite-type algebra
-map with functoriality of unipotent points. The separate theorem that a homomorphism of affine
-groups is faithfully flat onto its scheme-theoretic image remains the input that discharges the
-hypothesis below.
+This is the image specialization of the algebraically-closed-point bridge for Layer 5, "The
+unipotent radical", of the ReductiveGroups roadmap. The separate theorem that a homomorphism of
+affine groups is faithfully flat onto its scheme-theoretic image remains the input that discharges
+the hypothesis below.
 -/
 
 public section
 
-open CategoryTheory WithConv
+open CategoryTheory
 
 namespace TauCeti
 
@@ -58,24 +51,6 @@ namespace geometricallyUnipotentPointsCommHopfAlgProperty
 
 variable {k : Type u} [Field k]
 variable {H K : _root_.CommHopfAlgCat.{v} k}
-
-/-- Geometric unipotence descends along a finite-type faithfully flat coordinate morphism. -/
-theorem of_faithfullyFlat (f : H ⟶ K) (hfinite : f.hom.toAlgHom.FiniteType)
-    (hflat : f.hom.toAlgHom.toRingHom.FaithfullyFlat)
-    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
-    geometricallyUnipotentPointsCommHopfAlgProperty k H := by
-  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
-  intro g
-  obtain ⟨(q : WithConv (K →ₐ[k] AlgebraicClosure k)), hq⟩ :=
-    CommHopfAlgCat.mapPointsFunctor_app_surjective_of_faithfullyFlat
-      (AlgebraicClosure k) f hfinite hflat g
-  have hqunipotent := (hK q).mapDomain f.hom
-  have hmap : AlgHom.mapDomain f.hom q = g := by
-    rw [AlgHom.mapDomain_apply]
-    rw [CommHopfAlgCat.mapPointsFunctor_app_apply] at hq
-    exact hq
-  rw [hmap] at hqunipotent
-  exact hqunipotent
 
 /-- The scheme-theoretic image of a finite-type geometrically unipotent affine group is
 geometrically unipotent when the source-to-image morphism is faithfully flat.

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/FaithfullyFlat.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/FaithfullyFlat.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.FaithfullyFlatPoints
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+
+/-!
+# Unipotence under faithfully flat morphisms
+
+Let `f : H ⟶ K` be a finite-type faithfully flat morphism of commutative Hopf algebras over a
+field. Contravariantly, every algebraically closed point of `Spec H` lifts to a point of
+`Spec K`, so geometric unipotence descends from `K` to `H`.
+
+Unipotence is preserved when a point is precomposed with a Hopf-algebra morphism. Point lifting
+along `f` therefore transfers geometric unipotence from its source affine group to its target.
+
+## Main declaration
+
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_faithfullyFlat`: geometric
+  unipotence descends along a finite-type faithfully flat coordinate morphism.
+
+## References
+
+* The Stacks Project, Tags 00HQ and 00FV, for algebraically closed points of faithfully flat
+  finite-type algebras.
+
+This is an algebraically-closed-point bridge for Layer 5, "The unipotent radical", of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u v
+
+namespace geometricallyUnipotentPointsCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+variable {H K : _root_.CommHopfAlgCat.{v} k}
+
+/-- Geometric unipotence descends along a finite-type faithfully flat coordinate morphism. -/
+theorem of_faithfullyFlat (f : H ⟶ K) (hfinite : f.hom.toAlgHom.FiniteType)
+    (hflat : f.hom.toAlgHom.toRingHom.FaithfullyFlat)
+    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k H := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
+  intro g
+  obtain ⟨(q : WithConv (K →ₐ[k] AlgebraicClosure k)), hq⟩ :=
+    CommHopfAlgCat.mapPointsFunctor_app_surjective_of_faithfullyFlat
+      (AlgebraicClosure k) f hfinite hflat g
+  have hqunipotent := (hK q).mapDomain f.hom
+  have hmap : AlgHom.mapDomain f.hom q = g := by
+    rw [AlgHom.mapDomain_apply]
+    rw [CommHopfAlgCat.mapPointsFunctor_app_apply] at hq
+    exact hq
+  rw [hmap] at hqunipotent
+  exact hqunipotent
+
+end geometricallyUnipotentPointsCommHopfAlgProperty
+
+end TauCeti


### PR DESCRIPTION
This PR proves that geometric unipotence descends from a finite-type affine group to its scheme-theoretic image whenever the source-to-image coordinate inclusion is faithfully flat, and exposes the underlying surjectivity theorem for algebraically closed points in the group-valued functor-of-points API. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5, the milestone “The unipotent radical `R_u(G)`,” specifically the binary-product step: the scheme-theoretic multiplication image of two normal smooth unipotent subgroups must again have only unipotent geometric points.

The dependency edge is explicit. Open PR #4077 proves that the abstract point subgroup generated by the two normal unipotent point subgroups is unipotent, while merged PR #4082 proves that algebraically closed points lift along any faithfully flat finite-type algebra map. `CommHopfAlgCat.mapPointsFunctor_app_surjective_of_faithfullyFlat` now records that lift as surjectivity of the group-valued point map, and `geometricallyUnipotentPointsCommHopfAlgProperty.image_of_faithfullyFlat` applies functoriality of unipotent points to transfer the property onto `H / ker f`. This is the most effective available rung because it consumes the newly landed point-lifting theorem and supplies exactly the image-point conclusion that the in-flight normal-join work leaves open, without overlapping the separate smoothness-of-images PR #4062 or the maximal-candidate PR #4073.

After this PR, the Layer 5 binary-product construction still needs the theorem that an affine group homomorphism is faithfully flat onto its scheme-theoretic image, followed by the scheme-level semidirect-product multiplication assembly and the maximality argument bundling `R_u(G)`.

Adds `TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/FaithfullyFlatPoints.lean` (68 lines) and `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean` (85 lines). The proof reuses `AlgHom.surjective_comp_right_of_faithfullyFlat`, `AlgHom.FiniteType.of_comp_finiteType`, and `HopfAlgebra.IsUnipotentPoint.mapDomain`; no Mathlib infrastructure is vendored. The point-lifting input follows the Stacks Project, Tags 00HQ and 00FV, and the unipotent-radical application follows Borel, *Linear Algebraic Groups*, Proposition 14.4, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"unipotence-of-faithfully-flat-images"}-->

🤖 Prepared with Codex
