### PR TITLE
feat: make Fredholm normal forms Ck

### DIFF
--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -48,8 +48,16 @@ Topology*, Appendix A. The local chart is Mathlib's
   reconstruction of the original map from its essential coordinate and obstruction map.
 * `ContinuousLinearMap.FredholmPackage.hasStrictFDerivAt_obstructionMap_self`: the obstruction has
   zero derivative at the base point.
+* `ContinuousLinearMap.FredholmPackage.hasStrictFDerivAt_obstructionSlice_self`: the same for the
+  finite-dimensional slice of the obstruction through the base point.
+* `ContinuousLinearMap.FredholmPackage.contDiffAt_normalFormOpenPartialHomeomorph_symm_self`: the
+  inverse normal-form coordinates have the same `C^k` regularity as the original map, at the
+  normal-form coordinate of the base point.
 * `ContinuousLinearMap.FredholmPackage.contDiffAt_obstructionMap_self`: the obstruction has the
-  same `C^k` regularity as the original map near the base point.
+  same `C^k` regularity as the original map, at the normal-form coordinate of the base point.
+* `ContinuousLinearMap.FredholmPackage.contDiffAt_obstructionSlice_self`: the finite-dimensional
+  obstruction slice through the base point has that same `C^k` regularity; this is the input
+  finite-dimensional Sard needs.
 -/
 
 public section
@@ -158,11 +166,11 @@ theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
   (pkg.hasStrictFDerivAt_normalFormMap_of_hasStrictFDerivAt hf).congr_fderiv
     pkg.prod_projection_eq_normalFormEquivL
 
-/-- The nonlinear normal-form coordinate map has the same `C^k` regularity at its base point as
-the original map. -/
-theorem contDiffAt_normalFormMap {f : E → F} {a : E} {n : ℕ∞ω}
-    (hf : ContDiffAt 𝕜 n f a) :
-    ContDiffAt 𝕜 n (pkg.normalFormMap f a) a := by
+/-- The nonlinear normal-form coordinate map has the same `C^k` regularity as the original map,
+at every point where the latter is `C^k`. -/
+theorem contDiffAt_normalFormMap {f : E → F} {a x : E} {n : ℕ∞ω}
+    (hf : ContDiffAt 𝕜 n f x) :
+    ContDiffAt 𝕜 n (pkg.normalFormMap f a) x := by
   unfold normalFormMap
   fun_prop
 
@@ -229,6 +237,13 @@ theorem normalFormOpenPartialHomeomorph_apply {f : E → F} {a : E}
     pkg.normalFormOpenPartialHomeomorph hf x = pkg.normalFormMap f a x :=
   (pkg.normalFormImplicitFunctionData hf).toOpenPartialHomeomorph_apply x
 
+/-- The Fredholm normal-form homeomorphism, read as a function, is the normal-form coordinate
+map. -/
+theorem coe_normalFormOpenPartialHomeomorph {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    ⇑(pkg.normalFormOpenPartialHomeomorph hf) = pkg.normalFormMap f a :=
+  funext (pkg.normalFormOpenPartialHomeomorph_apply hf)
+
 /-- The base point belongs to the source of the Fredholm normal-form homeomorphism. -/
 theorem mem_normalFormOpenPartialHomeomorph_source {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
@@ -244,6 +259,17 @@ theorem normalFormOpenPartialHomeomorph_self_mem_target {f : E → F} {a : E}
   exact (pkg.normalFormImplicitFunctionData hf).map_pt_mem_toOpenPartialHomeomorph_target
 
 /-- Applying the inverse normal-form coordinate map to the coordinate of the base point returns
+the base point, in the package's own `pkg.decCodom.proj` spelling. The `@[simp]` form
+`normalFormOpenPartialHomeomorph_symm_self` below is the same statement after `simp` has unfolded
+that projection; this variant is the one the other proofs in this file rewrite with. -/
+private theorem normalFormOpenPartialHomeomorph_symm_proj_self {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    (pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0) = a := by
+  rw [← pkg.normalFormMap_self f a, ← pkg.normalFormOpenPartialHomeomorph_apply hf]
+  exact (pkg.normalFormOpenPartialHomeomorph hf).left_inv
+    (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
+
+/-- Applying the inverse normal-form coordinate map to the coordinate of the base point returns
 the base point. -/
 @[simp]
 theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
@@ -251,18 +277,16 @@ theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
     (pkg.normalFormOpenPartialHomeomorph hf).symm
       (pkg.decCodom.X₁.projectionOnto pkg.decCodom.X₀ pkg.decCodom.isTopCompl.isCompl (f a), 0) =
         a := by
-  rw [← Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
-    ← pkg.normalFormMap_self f a,
-    ← pkg.normalFormOpenPartialHomeomorph_apply hf]
-  exact (pkg.normalFormOpenPartialHomeomorph hf).left_inv
-    (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
+  rw [← Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl]
+  exact pkg.normalFormOpenPartialHomeomorph_symm_proj_self hf
 
 /-! ### The finite-dimensional obstruction map -/
 
 /-- The inessential-codomain component of `f` in Fredholm normal-form coordinates. Its codomain is
-finite dimensional by `pkg.decCodom.finite_X₀`; fixing the first coordinate restricts it to a map
-between the finite-dimensional spaces `pkg.decDom.X₀` and `pkg.decCodom.X₀`. Applying Sard to
-that slice additionally requires suitable neighborhood regularity. Values outside the target of
+finite dimensional by `pkg.decCodom.finite_X₀`; fixing the first coordinate gives
+`pkg.obstructionSlice`, a map between the finite-dimensional spaces `pkg.decDom.X₀` and
+`pkg.decCodom.X₀`, whose neighborhood regularity at the base coordinate — the remaining input for
+Sard — is `pkg.contDiffAt_obstructionSlice_self`. Values outside the target of
 `pkg.normalFormOpenPartialHomeomorph hf` are irrelevant, as for any
 `OpenPartialHomeomorph` inverse. -/
 def obstructionMap {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
@@ -301,15 +325,7 @@ of `f a`. Not a `simp` lemma: `obstructionMap_apply` and
 theorem obstructionMap_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
     pkg.obstructionMap hf (pkg.decCodom.proj (f a), 0) =
       pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (f a) := by
-  rw [pkg.obstructionMap_apply hf, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
-    pkg.normalFormOpenPartialHomeomorph_symm_self hf]
-
-/-- At the base coordinate the obstruction slice is the complementary-codomain component of
-`f a`. -/
-theorem obstructionSlice_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
-    pkg.obstructionSlice hf (pkg.decCodom.proj (f a)) 0 =
-      pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (f a) :=
-  pkg.obstructionMap_self hf
+  rw [pkg.obstructionMap_apply hf, pkg.normalFormOpenPartialHomeomorph_symm_proj_self hf]
 
 /-- In normal-form coordinates, the essential component of `f` is the first coordinate. -/
 theorem proj_apply_normalFormOpenPartialHomeomorph_symm {f : E → F} {a : E}
@@ -389,8 +405,7 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
   have hinv := pkg.hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self hf
   have hf' : HasStrictFDerivAt f T
       ((pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0)) := by
-    simpa only [Submodule.coe_projectionOntoL,
-      pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
+    rwa [pkg.normalFormOpenPartialHomeomorph_symm_proj_self hf]
   have hcomp : HasStrictFDerivAt
       (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y)))
       (P.comp (T.comp (pkg.normalFormEquivL.symm :
@@ -408,48 +423,43 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
   filter_upwards [] with y
   exact (pkg.obstructionMap_apply hf y).symm
 
-end Chart
-
-end ContinuousLinearMap.FredholmPackage
+/-- The finite-dimensional obstruction slice through the base point has zero derivative at the
+base coordinate: this is the statement `hasStrictFDerivAt_obstructionMap_self` reduced to the
+finite-dimensional kernel direction, which is where Sard is applied. -/
+theorem hasStrictFDerivAt_obstructionSlice_self {f : E → F} {a : E}
+    (hf : HasStrictFDerivAt f T a) :
+    HasStrictFDerivAt (pkg.obstructionSlice hf (pkg.decCodom.proj (f a)))
+      (0 : pkg.decDom.X₀ →L[𝕜] pkg.decCodom.X₀) 0 := by
+  have hcomp := (pkg.hasStrictFDerivAt_obstructionMap_self hf).comp (0 : pkg.decDom.X₀)
+    ((hasStrictFDerivAt_const (pkg.decCodom.proj (f a)) (0 : pkg.decDom.X₀)).prodMk
+      (hasStrictFDerivAt_id (0 : pkg.decDom.X₀)))
+  rw [funext (pkg.obstructionSlice_apply hf (pkg.decCodom.proj (f a)))]
+  exact hcomp.congr_fderiv (ContinuousLinearMap.zero_comp _)
 
 /-! ### Smoothness of the finite-dimensional reduction -/
 
-namespace ContinuousLinearMap.FredholmPackage
+/-- The normal-form chart has the same `C^k` regularity as the original map, at every point where
+the latter is `C^k`. -/
+theorem contDiffAt_normalFormOpenPartialHomeomorph {f : E → F} {a x : E} {n : ℕ∞ω}
+    (hfd : HasStrictFDerivAt f T a) (hf : ContDiffAt 𝕜 n f x) :
+    ContDiffAt 𝕜 n (pkg.normalFormOpenPartialHomeomorph hfd) x := by
+  rw [pkg.coe_normalFormOpenPartialHomeomorph hfd]
+  exact pkg.contDiffAt_normalFormMap hf
 
-section Regularity
-
-variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
-  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
-  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
-  {T : E →L[𝕜] F} (pkg : ContinuousLinearMap.FredholmPackage T)
-
-local instance : CompleteSpace pkg.decDom.X₀ :=
-  pkg.decDom.isTopCompl.isClosed'.completeSpace_coe
-
-local instance : CompleteSpace pkg.decCodom.X₁ :=
-  haveI : CompleteSpace pkg.decDom.X₁ := pkg.decDom.isTopCompl.isClosed.completeSpace_coe
-  (pkg.equiv.isUniformEmbedding.completeSpace_congr pkg.equiv.surjective).mp inferInstance
-
-/-- If `f` is `C^k` at the base point, then the inverse normal-form coordinates are `C^k` at
-the corresponding point. This uses the existing local homeomorphism and the smooth inverse
-function theorem, so it also covers `k = 0`. -/
+/-- If `f` is `C^k` at the base point, then the inverse normal-form coordinates are `C^k` at the
+coordinate of that point. Here `n` may be any value in `ℕ∞ω`, including `0` and `ω`. -/
 theorem contDiffAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E} {n : ℕ∞ω}
     (hfd : HasStrictFDerivAt f T a) (hf : ContDiffAt 𝕜 n f a) :
     ContDiffAt 𝕜 n (pkg.normalFormOpenPartialHomeomorph hfd).symm
       (pkg.decCodom.proj (f a), 0) := by
+  have hpt := pkg.normalFormOpenPartialHomeomorph_symm_proj_self hfd
   apply (pkg.normalFormOpenPartialHomeomorph hfd).contDiffAt_symm
     (f₀' := pkg.normalFormEquivL)
     (pkg.normalFormOpenPartialHomeomorph_self_mem_target hfd)
-  · have hfun : ⇑(pkg.normalFormOpenPartialHomeomorph hfd) = pkg.normalFormMap f a :=
-      funext (pkg.normalFormOpenPartialHomeomorph_apply hfd)
-    rw [hfun, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
-      pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
+  · rw [hpt, pkg.coe_normalFormOpenPartialHomeomorph hfd]
     exact (pkg.hasStrictFDerivAt_normalFormMap hfd).hasFDerivAt
-  · have hfun : ⇑(pkg.normalFormOpenPartialHomeomorph hfd) = pkg.normalFormMap f a :=
-      funext (pkg.normalFormOpenPartialHomeomorph_apply hfd)
-    rw [hfun, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
-      pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
-    exact pkg.contDiffAt_normalFormMap hf
+  · rw [hpt]
+    exact pkg.contDiffAt_normalFormOpenPartialHomeomorph hfd hf
 
 /-- If `f` is `C^k` at a point with Fredholm derivative, then its finite-dimensional obstruction
 in Lyapunov--Schmidt coordinates is `C^k` at the corresponding normal-form coordinate. -/
@@ -460,32 +470,22 @@ theorem contDiffAt_obstructionMap_self {f : E → F} {a : E} {n : ℕ∞ω}
   have hinv := pkg.contDiffAt_normalFormOpenPartialHomeomorph_symm_self hfd hf
   have hf' : ContDiffAt 𝕜 n f
       ((pkg.normalFormOpenPartialHomeomorph hfd).symm (pkg.decCodom.proj (f a), 0)) := by
-    rw [Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
-      pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
-    exact hf
+    rwa [pkg.normalFormOpenPartialHomeomorph_symm_proj_self hfd]
   have hcomp := P.contDiff.contDiffAt.comp _ (hf'.comp _ hinv)
-  change ContDiffAt 𝕜 n
-    (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hfd).symm y)))
-      (pkg.decCodom.proj (f a), 0)
-  exact hcomp
-
-/-- Fixing the essential coordinate of a `C^k` obstruction map gives a `C^k` map on the
-finite-dimensional kernel coordinate. -/
-theorem contDiffAt_obstructionSlice {f : E → F} {a : E} {n : ℕ∞ω}
-    (hfd : HasStrictFDerivAt f T a) {y : pkg.decCodom.X₁} {z : pkg.decDom.X₀}
-    (h : ContDiffAt 𝕜 n (pkg.obstructionMap hfd) (y, z)) :
-    ContDiffAt 𝕜 n (pkg.obstructionSlice hfd y) z := by
-  change ContDiffAt 𝕜 n (fun z ↦ pkg.obstructionMap hfd (y, z)) z
-  exact h.comp z (contDiffAt_const.prodMk contDiffAt_id)
+  apply hcomp.congr_of_eventuallyEq
+  filter_upwards [] with y
+  exact pkg.obstructionMap_apply hfd y
 
 /-- The finite-dimensional obstruction slice through the base point inherits the `C^k`
-regularity of the original map. -/
+regularity of the original map. This is the regularity input for finite-dimensional Sard. -/
 theorem contDiffAt_obstructionSlice_self {f : E → F} {a : E} {n : ℕ∞ω}
     (hfd : HasStrictFDerivAt f T a) (hf : ContDiffAt 𝕜 n f a) :
-    ContDiffAt 𝕜 n (pkg.obstructionSlice hfd (pkg.decCodom.proj (f a))) 0 :=
-  pkg.contDiffAt_obstructionSlice hfd (pkg.contDiffAt_obstructionMap_self hfd hf)
+    ContDiffAt 𝕜 n (pkg.obstructionSlice hfd (pkg.decCodom.proj (f a))) 0 := by
+  rw [funext (pkg.obstructionSlice_apply hfd (pkg.decCodom.proj (f a)))]
+  exact (pkg.contDiffAt_obstructionMap_self hfd hf).comp 0
+    (contDiffAt_const.prodMk contDiffAt_id)
 
-end Regularity
+end Chart
 
 end ContinuousLinearMap.FredholmPackage
 

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -237,13 +237,6 @@ theorem normalFormOpenPartialHomeomorph_apply {f : E → F} {a : E}
     pkg.normalFormOpenPartialHomeomorph hf x = pkg.normalFormMap f a x :=
   (pkg.normalFormImplicitFunctionData hf).toOpenPartialHomeomorph_apply x
 
-/-- The Fredholm normal-form homeomorphism, read as a function, is the normal-form coordinate
-map. -/
-theorem coe_normalFormOpenPartialHomeomorph {f : E → F} {a : E}
-    (hf : HasStrictFDerivAt f T a) :
-    ⇑(pkg.normalFormOpenPartialHomeomorph hf) = pkg.normalFormMap f a :=
-  funext (pkg.normalFormOpenPartialHomeomorph_apply hf)
-
 /-- The base point belongs to the source of the Fredholm normal-form homeomorphism. -/
 theorem mem_normalFormOpenPartialHomeomorph_source {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
@@ -259,17 +252,6 @@ theorem normalFormOpenPartialHomeomorph_self_mem_target {f : E → F} {a : E}
   exact (pkg.normalFormImplicitFunctionData hf).map_pt_mem_toOpenPartialHomeomorph_target
 
 /-- Applying the inverse normal-form coordinate map to the coordinate of the base point returns
-the base point, in the package's own `pkg.decCodom.proj` spelling. The `@[simp]` form
-`normalFormOpenPartialHomeomorph_symm_self` below is the same statement after `simp` has unfolded
-that projection; this variant is the one the other proofs in this file rewrite with. -/
-private theorem normalFormOpenPartialHomeomorph_symm_proj_self {f : E → F} {a : E}
-    (hf : HasStrictFDerivAt f T a) :
-    (pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0) = a := by
-  rw [← pkg.normalFormMap_self f a, ← pkg.normalFormOpenPartialHomeomorph_apply hf]
-  exact (pkg.normalFormOpenPartialHomeomorph hf).left_inv
-    (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
-
-/-- Applying the inverse normal-form coordinate map to the coordinate of the base point returns
 the base point. -/
 @[simp]
 theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
@@ -277,8 +259,10 @@ theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
     (pkg.normalFormOpenPartialHomeomorph hf).symm
       (pkg.decCodom.X₁.projectionOnto pkg.decCodom.X₀ pkg.decCodom.isTopCompl.isCompl (f a), 0) =
         a := by
-  rw [← Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl]
-  exact pkg.normalFormOpenPartialHomeomorph_symm_proj_self hf
+  rw [← Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+    ← pkg.normalFormMap_self f a, ← pkg.normalFormOpenPartialHomeomorph_apply hf]
+  exact (pkg.normalFormOpenPartialHomeomorph hf).left_inv
+    (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
 
 /-! ### The finite-dimensional obstruction map -/
 
@@ -325,7 +309,8 @@ of `f a`. Not a `simp` lemma: `obstructionMap_apply` and
 theorem obstructionMap_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
     pkg.obstructionMap hf (pkg.decCodom.proj (f a), 0) =
       pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (f a) := by
-  rw [pkg.obstructionMap_apply hf, pkg.normalFormOpenPartialHomeomorph_symm_proj_self hf]
+  rw [pkg.obstructionMap_apply hf, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+    pkg.normalFormOpenPartialHomeomorph_symm_self hf]
 
 /-- In normal-form coordinates, the essential component of `f` is the first coordinate. -/
 theorem proj_apply_normalFormOpenPartialHomeomorph_symm {f : E → F} {a : E}
@@ -405,7 +390,8 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
   have hinv := pkg.hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self hf
   have hf' : HasStrictFDerivAt f T
       ((pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0)) := by
-    rwa [pkg.normalFormOpenPartialHomeomorph_symm_proj_self hf]
+    simpa only [Submodule.coe_projectionOntoL,
+      pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
   have hcomp : HasStrictFDerivAt
       (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y)))
       (P.comp (T.comp (pkg.normalFormEquivL.symm :
@@ -443,7 +429,7 @@ the latter is `C^k`. -/
 theorem contDiffAt_normalFormOpenPartialHomeomorph {f : E → F} {a x : E} {n : ℕ∞ω}
     (hfd : HasStrictFDerivAt f T a) (hf : ContDiffAt 𝕜 n f x) :
     ContDiffAt 𝕜 n (pkg.normalFormOpenPartialHomeomorph hfd) x := by
-  rw [pkg.coe_normalFormOpenPartialHomeomorph hfd]
+  rw [funext (pkg.normalFormOpenPartialHomeomorph_apply hfd)]
   exact pkg.contDiffAt_normalFormMap hf
 
 /-- If `f` is `C^k` at the base point, then the inverse normal-form coordinates are `C^k` at the
@@ -452,11 +438,14 @@ theorem contDiffAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : 
     (hfd : HasStrictFDerivAt f T a) (hf : ContDiffAt 𝕜 n f a) :
     ContDiffAt 𝕜 n (pkg.normalFormOpenPartialHomeomorph hfd).symm
       (pkg.decCodom.proj (f a), 0) := by
-  have hpt := pkg.normalFormOpenPartialHomeomorph_symm_proj_self hfd
+  have hpt : (pkg.normalFormOpenPartialHomeomorph hfd).symm
+      (pkg.decCodom.proj (f a), 0) = a := by
+    simpa only [Submodule.coe_projectionOntoL] using
+      pkg.normalFormOpenPartialHomeomorph_symm_self hfd
   apply (pkg.normalFormOpenPartialHomeomorph hfd).contDiffAt_symm
     (f₀' := pkg.normalFormEquivL)
     (pkg.normalFormOpenPartialHomeomorph_self_mem_target hfd)
-  · rw [hpt, pkg.coe_normalFormOpenPartialHomeomorph hfd]
+  · rw [hpt, funext (pkg.normalFormOpenPartialHomeomorph_apply hfd)]
     exact (pkg.hasStrictFDerivAt_normalFormMap hfd).hasFDerivAt
   · rw [hpt]
     exact pkg.contDiffAt_normalFormOpenPartialHomeomorph hfd hf
@@ -470,7 +459,8 @@ theorem contDiffAt_obstructionMap_self {f : E → F} {a : E} {n : ℕ∞ω}
   have hinv := pkg.contDiffAt_normalFormOpenPartialHomeomorph_symm_self hfd hf
   have hf' : ContDiffAt 𝕜 n f
       ((pkg.normalFormOpenPartialHomeomorph hfd).symm (pkg.decCodom.proj (f a), 0)) := by
-    rwa [pkg.normalFormOpenPartialHomeomorph_symm_proj_self hfd]
+    simpa only [Submodule.coe_projectionOntoL,
+      pkg.normalFormOpenPartialHomeomorph_symm_self hfd] using hf
   have hcomp := P.contDiff.contDiffAt.comp _ (hf'.comp _ hinv)
   apply hcomp.congr_of_eventuallyEq
   filter_upwards [] with y

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -249,8 +249,10 @@ the base point. -/
 theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
     (pkg.normalFormOpenPartialHomeomorph hf).symm
-      (pkg.decCodom.proj (f a), 0) = a := by
-  rw [← pkg.normalFormMap_self f a,
+      (pkg.decCodom.X₁.projectionOnto pkg.decCodom.X₀ pkg.decCodom.isTopCompl.isCompl (f a), 0) =
+        a := by
+  rw [← Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+    ← pkg.normalFormMap_self f a,
     ← pkg.normalFormOpenPartialHomeomorph_apply hf]
   exact (pkg.normalFormOpenPartialHomeomorph hf).left_inv
     (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
@@ -299,7 +301,8 @@ of `f a`. Not a `simp` lemma: `obstructionMap_apply` and
 theorem obstructionMap_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
     pkg.obstructionMap hf (pkg.decCodom.proj (f a), 0) =
       pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (f a) := by
-  rw [pkg.obstructionMap_apply hf, pkg.normalFormOpenPartialHomeomorph_symm_self hf]
+  rw [pkg.obstructionMap_apply hf, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+    pkg.normalFormOpenPartialHomeomorph_symm_self hf]
 
 /-- At the base coordinate the obstruction slice is the complementary-codomain component of
 `f a`. -/
@@ -386,7 +389,8 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
   have hinv := pkg.hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self hf
   have hf' : HasStrictFDerivAt f T
       ((pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0)) := by
-    simpa only [pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
+    simpa only [Submodule.coe_projectionOntoL,
+      pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
   have hcomp : HasStrictFDerivAt
       (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y)))
       (P.comp (T.comp (pkg.normalFormEquivL.symm :
@@ -438,11 +442,13 @@ theorem contDiffAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : 
     (pkg.normalFormOpenPartialHomeomorph_self_mem_target hfd)
   · have hfun : ⇑(pkg.normalFormOpenPartialHomeomorph hfd) = pkg.normalFormMap f a :=
       funext (pkg.normalFormOpenPartialHomeomorph_apply hfd)
-    rw [hfun, pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
+    rw [hfun, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+      pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
     exact (pkg.hasStrictFDerivAt_normalFormMap hfd).hasFDerivAt
   · have hfun : ⇑(pkg.normalFormOpenPartialHomeomorph hfd) = pkg.normalFormMap f a :=
       funext (pkg.normalFormOpenPartialHomeomorph_apply hfd)
-    rw [hfun, pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
+    rw [hfun, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+      pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
     exact pkg.contDiffAt_normalFormMap hf
 
 /-- If `f` is `C^k` at a point with Fredholm derivative, then its finite-dimensional obstruction
@@ -454,7 +460,8 @@ theorem contDiffAt_obstructionMap_self {f : E → F} {a : E} {n : ℕ∞ω}
   have hinv := pkg.contDiffAt_normalFormOpenPartialHomeomorph_symm_self hfd hf
   have hf' : ContDiffAt 𝕜 n f
       ((pkg.normalFormOpenPartialHomeomorph hfd).symm (pkg.decCodom.proj (f a), 0)) := by
-    rw [pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
+    rw [Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
+      pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
     exact hf
   have hcomp := P.contDiff.contDiffAt.comp _ (hf'.comp _ hinv)
   change ContDiffAt 𝕜 n

--- a/TauCeti/Analysis/Fredholm/NormalForm.lean
+++ b/TauCeti/Analysis/Fredholm/NormalForm.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Fredholm.Basic
 public import Mathlib.Analysis.Calculus.Implicit
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
 
 /-!
 # Local normal form of a Fredholm map
@@ -15,10 +16,9 @@ This file gives the Lyapunov--Schmidt finite-dimensional reduction of a nonlinea
 where its derivative is Fredholm. A Fredholm package splits the domain and codomain into
 essential parts, on which the derivative is invertible, and finite-dimensional inessential
 parts. Projecting the nonlinear map to the essential codomain and retaining the inessential
-domain coordinate gives a local homeomorphism. This is the first-order, topological part of the
-finite-dimensional reduction; applying Sard additionally requires neighborhood `C^k` regularity
-of the chart and obstruction under corresponding hypotheses on the original map. In these
-coordinates the original map has the form
+domain coordinate gives a local homeomorphism. When the original map is `C^k`, the inverse
+coordinates and the finite-dimensional obstruction are `C^k` as germs at the base point. In
+these coordinates the original map has the form
 
 `(r, k) ↦ r + q(r, k)`,
 
@@ -42,10 +42,14 @@ Topology*, Appendix A. The local chart is Mathlib's
   defined by that map.
 * `ContinuousLinearMap.FredholmPackage.obstructionMap`: the remainder valued in the
   finite-dimensional complementary codomain direction.
+* `ContinuousLinearMap.FredholmPackage.obstructionSlice`: the finite-dimensional obstruction
+  obtained by fixing the essential coordinate.
 * `ContinuousLinearMap.FredholmPackage.apply_normalFormOpenPartialHomeomorph_symm`:
   reconstruction of the original map from its essential coordinate and obstruction map.
 * `ContinuousLinearMap.FredholmPackage.hasStrictFDerivAt_obstructionMap_self`: the obstruction has
   zero derivative at the base point.
+* `ContinuousLinearMap.FredholmPackage.contDiffAt_obstructionMap_self`: the obstruction has the
+  same `C^k` regularity as the original map near the base point.
 -/
 
 public section
@@ -53,6 +57,8 @@ public section
 noncomputable section
 
 open Set
+
+open scoped ContDiff
 
 namespace ContinuousLinearMap.FredholmPackage
 
@@ -152,6 +158,14 @@ theorem hasStrictFDerivAt_normalFormMap {f : E → F} {a : E}
   (pkg.hasStrictFDerivAt_normalFormMap_of_hasStrictFDerivAt hf).congr_fderiv
     pkg.prod_projection_eq_normalFormEquivL
 
+/-- The nonlinear normal-form coordinate map has the same `C^k` regularity at its base point as
+the original map. -/
+theorem contDiffAt_normalFormMap {f : E → F} {a : E} {n : ℕ∞ω}
+    (hf : ContDiffAt 𝕜 n f a) :
+    ContDiffAt 𝕜 n (pkg.normalFormMap f a) a := by
+  unfold normalFormMap
+  fun_prop
+
 /-- The essential component of the Fredholm operator factors through the package equivalence. -/
 private theorem proj_comp_eq :
     pkg.decCodom.proj.comp T =
@@ -235,10 +249,8 @@ the base point. -/
 theorem normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E}
     (hf : HasStrictFDerivAt f T a) :
     (pkg.normalFormOpenPartialHomeomorph hf).symm
-      (pkg.decCodom.X₁.projectionOnto pkg.decCodom.X₀ pkg.decCodom.isTopCompl.isCompl (f a), 0) =
-        a := by
-  rw [← Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
-    ← pkg.normalFormMap_self f a,
+      (pkg.decCodom.proj (f a), 0) = a := by
+  rw [← pkg.normalFormMap_self f a,
     ← pkg.normalFormOpenPartialHomeomorph_apply hf]
   exact (pkg.normalFormOpenPartialHomeomorph hf).left_inv
     (pkg.mem_normalFormOpenPartialHomeomorph_source hf)
@@ -256,6 +268,13 @@ def obstructionMap {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
   pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
     (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y))
 
+/-- The finite-dimensional obstruction map obtained by fixing the essential codomain coordinate.
+Both its domain and codomain are finite dimensional. This is the map to which finite-dimensional
+Sard is applied in the Lyapunov--Schmidt proof of Sard--Smale. -/
+def obstructionSlice {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
+    (y : pkg.decCodom.X₁) (z : pkg.decDom.X₀) : pkg.decCodom.X₀ :=
+  pkg.obstructionMap hf (y, z)
+
 /-- The obstruction map is the complementary-codomain projection of `f` after applying the
 inverse normal-form coordinates. -/
 @[simp]
@@ -267,14 +286,27 @@ theorem obstructionMap_apply {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a
   unfold obstructionMap
   rfl
 
+/-- The obstruction slice is the obstruction map with its essential coordinate fixed. -/
+@[simp]
+theorem obstructionSlice_apply {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a)
+    (y : pkg.decCodom.X₁) (z : pkg.decDom.X₀) :
+    pkg.obstructionSlice hf y z = pkg.obstructionMap hf (y, z) := by
+  rfl
+
 /-- At the coordinate of the base point the obstruction is the inessential-codomain component
 of `f a`. Not a `simp` lemma: `obstructionMap_apply` and
 `normalFormOpenPartialHomeomorph_symm_self` already rewrite the left-hand side. -/
 theorem obstructionMap_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
     pkg.obstructionMap hf (pkg.decCodom.proj (f a), 0) =
       pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (f a) := by
-  rw [pkg.obstructionMap_apply hf, Submodule.coe_projectionOntoL pkg.decCodom.isTopCompl,
-    pkg.normalFormOpenPartialHomeomorph_symm_self hf]
+  rw [pkg.obstructionMap_apply hf, pkg.normalFormOpenPartialHomeomorph_symm_self hf]
+
+/-- At the base coordinate the obstruction slice is the complementary-codomain component of
+`f a`. -/
+theorem obstructionSlice_self {f : E → F} {a : E} (hf : HasStrictFDerivAt f T a) :
+    pkg.obstructionSlice hf (pkg.decCodom.proj (f a)) 0 =
+      pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm (f a) :=
+  pkg.obstructionMap_self hf
 
 /-- In normal-form coordinates, the essential component of `f` is the first coordinate. -/
 theorem proj_apply_normalFormOpenPartialHomeomorph_symm {f : E → F} {a : E}
@@ -354,8 +386,7 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
   have hinv := pkg.hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self hf
   have hf' : HasStrictFDerivAt f T
       ((pkg.normalFormOpenPartialHomeomorph hf).symm (pkg.decCodom.proj (f a), 0)) := by
-    simpa only [Submodule.coe_projectionOntoL,
-      pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
+    simpa only [pkg.normalFormOpenPartialHomeomorph_symm_self hf] using hf
   have hcomp : HasStrictFDerivAt
       (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hf).symm y)))
       (P.comp (T.comp (pkg.normalFormEquivL.symm :
@@ -374,6 +405,80 @@ theorem hasStrictFDerivAt_obstructionMap_self {f : E → F} {a : E}
   exact (pkg.obstructionMap_apply hf y).symm
 
 end Chart
+
+end ContinuousLinearMap.FredholmPackage
+
+/-! ### Smoothness of the finite-dimensional reduction -/
+
+namespace ContinuousLinearMap.FredholmPackage
+
+section Regularity
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+  {T : E →L[𝕜] F} (pkg : ContinuousLinearMap.FredholmPackage T)
+
+local instance : CompleteSpace pkg.decDom.X₀ :=
+  pkg.decDom.isTopCompl.isClosed'.completeSpace_coe
+
+local instance : CompleteSpace pkg.decCodom.X₁ :=
+  haveI : CompleteSpace pkg.decDom.X₁ := pkg.decDom.isTopCompl.isClosed.completeSpace_coe
+  (pkg.equiv.isUniformEmbedding.completeSpace_congr pkg.equiv.surjective).mp inferInstance
+
+/-- If `f` is `C^k` at the base point, then the inverse normal-form coordinates are `C^k` at
+the corresponding point. This uses the existing local homeomorphism and the smooth inverse
+function theorem, so it also covers `k = 0`. -/
+theorem contDiffAt_normalFormOpenPartialHomeomorph_symm_self {f : E → F} {a : E} {n : ℕ∞ω}
+    (hfd : HasStrictFDerivAt f T a) (hf : ContDiffAt 𝕜 n f a) :
+    ContDiffAt 𝕜 n (pkg.normalFormOpenPartialHomeomorph hfd).symm
+      (pkg.decCodom.proj (f a), 0) := by
+  apply (pkg.normalFormOpenPartialHomeomorph hfd).contDiffAt_symm
+    (f₀' := pkg.normalFormEquivL)
+    (pkg.normalFormOpenPartialHomeomorph_self_mem_target hfd)
+  · have hfun : ⇑(pkg.normalFormOpenPartialHomeomorph hfd) = pkg.normalFormMap f a :=
+      funext (pkg.normalFormOpenPartialHomeomorph_apply hfd)
+    rw [hfun, pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
+    exact (pkg.hasStrictFDerivAt_normalFormMap hfd).hasFDerivAt
+  · have hfun : ⇑(pkg.normalFormOpenPartialHomeomorph hfd) = pkg.normalFormMap f a :=
+      funext (pkg.normalFormOpenPartialHomeomorph_apply hfd)
+    rw [hfun, pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
+    exact pkg.contDiffAt_normalFormMap hf
+
+/-- If `f` is `C^k` at a point with Fredholm derivative, then its finite-dimensional obstruction
+in Lyapunov--Schmidt coordinates is `C^k` at the corresponding normal-form coordinate. -/
+theorem contDiffAt_obstructionMap_self {f : E → F} {a : E} {n : ℕ∞ω}
+    (hfd : HasStrictFDerivAt f T a) (hf : ContDiffAt 𝕜 n f a) :
+    ContDiffAt 𝕜 n (pkg.obstructionMap hfd) (pkg.decCodom.proj (f a), 0) := by
+  let P := pkg.decCodom.X₀.projectionOntoL pkg.decCodom.X₁ pkg.decCodom.isTopCompl.symm
+  have hinv := pkg.contDiffAt_normalFormOpenPartialHomeomorph_symm_self hfd hf
+  have hf' : ContDiffAt 𝕜 n f
+      ((pkg.normalFormOpenPartialHomeomorph hfd).symm (pkg.decCodom.proj (f a), 0)) := by
+    rw [pkg.normalFormOpenPartialHomeomorph_symm_self hfd]
+    exact hf
+  have hcomp := P.contDiff.contDiffAt.comp _ (hf'.comp _ hinv)
+  change ContDiffAt 𝕜 n
+    (fun y ↦ P (f ((pkg.normalFormOpenPartialHomeomorph hfd).symm y)))
+      (pkg.decCodom.proj (f a), 0)
+  exact hcomp
+
+/-- Fixing the essential coordinate of a `C^k` obstruction map gives a `C^k` map on the
+finite-dimensional kernel coordinate. -/
+theorem contDiffAt_obstructionSlice {f : E → F} {a : E} {n : ℕ∞ω}
+    (hfd : HasStrictFDerivAt f T a) {y : pkg.decCodom.X₁} {z : pkg.decDom.X₀}
+    (h : ContDiffAt 𝕜 n (pkg.obstructionMap hfd) (y, z)) :
+    ContDiffAt 𝕜 n (pkg.obstructionSlice hfd y) z := by
+  change ContDiffAt 𝕜 n (fun z ↦ pkg.obstructionMap hfd (y, z)) z
+  exact h.comp z (contDiffAt_const.prodMk contDiffAt_id)
+
+/-- The finite-dimensional obstruction slice through the base point inherits the `C^k`
+regularity of the original map. -/
+theorem contDiffAt_obstructionSlice_self {f : E → F} {a : E} {n : ℕ∞ω}
+    (hfd : HasStrictFDerivAt f T a) (hf : ContDiffAt 𝕜 n f a) :
+    ContDiffAt 𝕜 n (pkg.obstructionSlice hfd (pkg.decCodom.proj (f a))) 0 :=
+  pkg.contDiffAt_obstructionSlice hfd (pkg.contDiffAt_obstructionMap_self hfd hf)
+
+end Regularity
 
 end ContinuousLinearMap.FredholmPackage
 


### PR DESCRIPTION
This PR equips the Lyapunov--Schmidt normal form of a nonlinear Fredholm map with the `C^k` regularity that finite-dimensional Sard needs. It proves that the normal-form coordinate map inherits the regularity of the original map, that the inverse local coordinates are `C^k` at the base coordinate, and hence that the finite-dimensional obstruction germ and its kernel-coordinate slice are `C^k` there.

The exact target is `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F0, “the nonlinear-analysis substrate,” specifically Sard--Smale and the package asserting that the zero set of a Fredholm section is generically a manifold of dimension its index. The existing `TauCeti.Analysis.Fredholm.NormalForm` already supplied the topological Lyapunov--Schmidt reduction and explicitly left neighborhood regularity as the missing input for Sard. Finite-dimensional Morse--Sard is now in flight as TauCeti#4125, so this is the distinct immediate step that makes its theorem applicable to the normal-form obstruction.

The new `ContinuousLinearMap.FredholmPackage.obstructionSlice` names the map between the package's finite-dimensional kernel and cokernel complements obtained by fixing the essential coordinate, with its characteristic lemma and its derivative at the base coordinate. `contDiffAt_normalFormOpenPartialHomeomorph_symm_self`, `contDiffAt_obstructionMap_self`, and `contDiffAt_obstructionSlice_self` supply arbitrary-order regularity without weakening the scalar-field generality of the existing normal form. The public `@[simp]` lemma `normalFormOpenPartialHomeomorph_symm_self` keeps its `Submodule.projectionOnto` statement, which is its simp normal form: `FredholmDecomposition.proj` is an `abbrev` for `projectionOntoL` and `Submodule.coe_projectionOntoL` is `@[simp]`, so a `decCodom.proj`-spelled left-hand side would be rewritten further and trip `simpNF`. The `decCodom.proj` spelling is instead carried by a private helper, `normalFormOpenPartialHomeomorph_symm_proj_self`, which every proof in the file rewrites with.

This is the most effective current Lane F0 step because Morse--Sard itself is already claimed, while the normal form on `main` stopped exactly before the smooth inverse and obstruction regularity needed by Sard--Smale. After this PR, Lane F0 still needs the local Sard--Smale critical-value argument relating nonsurjectivity of the original derivative to critical points of the obstruction slices, followed by the Baire-category globalization and the generic regular-level-set theorem.

The proof follows Smale, *An infinite dimensional version of Sard's theorem* (1965), and McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix A, as cited in the module documentation. It reuses Mathlib's `OpenPartialHomeomorph.contDiffAt_symm`, continuous-linear-map `ContDiff` calculus, and `ContinuousLinearMap.FredholmPackage`; no Mathlib implementation is vendored.

The single modified file is `TauCeti/Analysis/Fredholm/NormalForm.lean`.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm-normal-form-regularity"}-->

🤖 Prepared with Codex
