### PR TITLE
feat(HeckeSlash): the Hecke ring acting additively on modular forms

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -9,27 +9,39 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Gamma1
 public import TauCeti.NumberTheory.HeckeRing.Associativity
 
 /-!
-# The Hecke ring acting on modular forms
+# The `ℤ`-linear extension of the Hecke slash operators to the Hecke ring
 
-`heckeSlashGamma1ModularFormEnd` attaches a `ℂ`-linear endomorphism of `M_k(Γ₁(N))` to a single
-double coset. This file extends that assignment `ℤ`-linearly to the whole Hecke ring
-`𝕋 Δ₀(N) Γ₁(N) ℤ`, so that the abstract ring acts on the space of modular forms.
+`heckeSlashGamma1ModularFormEnd` attaches a `ℂ`-linear endomorphism of `M_k(Γ₁(N))` to a
+single double coset. This file extends that assignment `ℤ`-linearly over the basis of the
+Hecke ring `𝕋 Δ₀(N) Γ₁(N) ℤ`, assigning an endomorphism of `M_k(Γ₁(N))` to each ring element.
 
-The extension is additive in the ring element, which is packaged as `heckeSlashGamma1RingHom`.
-Multiplicativity — Shimura's Proposition 3.37, the identification of the convolution structure
-constants with the reindexing of an iterated slash sum — is *not* proved here, so this is
-deliberately an `AddMonoidHom` and not yet the roadmap's `RingHom`.
+This is **not** yet a ring action: multiplicativity is Shimura §3.4 and is not proved here,
+and the value on `1` is recorded only as the operator of the identity double coset, not as
+the identity endomorphism. What is delivered is the `ℤ`-linear assignment.
+
+The extension is `Finsupp.linearCombination` at the coefficient ring `ℤ`, so linearity in the
+ring element is inherited rather than reproved — `map_zero` and `map_add` apply directly. The
+two lemmas proved here are the ones specific to this setting: the value on a basis element and
+on the ring identity.
 
 ## Main definitions
 
-* `heckeSlashGamma1RingEnd`: the `Finsupp.sum` extension of `heckeSlashGamma1ModularFormEnd`.
-* `heckeSlashGamma1RingHom`: the same map bundled as an additive monoid homomorphism.
+* `heckeSlashGamma1RingModularFormLinearMap`: the `ℤ`-linear extension of
+  `heckeSlashGamma1ModularFormEnd` to the Hecke ring.
 
 ## Main results
 
-* `heckeSlashGamma1RingEnd_zero`, `heckeSlashGamma1RingEnd_single`,
-  `heckeSlashGamma1RingEnd_add`, `heckeSlashGamma1RingEnd_one`: the computation rules, giving
-  the value on `0`, on a basis element, on a sum, and on the ring identity.
+* `heckeSlashGamma1RingModularFormLinearMap_single`: the value on a basis element is the
+  scaled operator of that double coset.
+* `heckeSlashGamma1RingModularFormLinearMap_single_apply`: the same, evaluated on a form.
+* `heckeSlashGamma1RingModularFormLinearMap_one`: the ring identity is sent to the operator of
+  the identity double coset.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4 (the action of the Hecke ring on automorphic forms).
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.2.
 -/
 
 open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
@@ -38,59 +50,43 @@ open scoped MatrixGroups ModularForm HeckeCosetModule
 
 namespace HeckeRing.GL2
 
-@[expose] public section
+public section
 
 variable {N : ℕ} [NeZero N] (k : ℤ)
 
-/-- **The Hecke ring acting on modular forms**: the `ℤ`-linear extension of
-`heckeSlashGamma1ModularFormEnd` from a single double coset to a formal `ℤ`-combination of
-them. -/
-noncomputable def heckeSlashGamma1RingEnd
-    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
-    Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
-  T.sum fun D c ↦ c • heckeSlashGamma1ModularFormEnd k D
+/-- The `ℤ`-linear extension of `heckeSlashGamma1ModularFormEnd` to formal `ℤ`-combinations of
+double cosets: `ℤ`-linear in the ring element, but not known to be multiplicative, so this is
+not yet a ring action. -/
+noncomputable def heckeSlashGamma1RingModularFormLinearMap :
+    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →ₗ[ℤ]
+      Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  Finsupp.linearCombination ℤ (heckeSlashGamma1ModularFormEnd k)
 
-@[simp] lemma heckeSlashGamma1RingEnd_zero :
-    heckeSlashGamma1RingEnd (N := N) k 0 = 0 :=
-  Finsupp.sum_zero_index
-
-/-- The action on a basis element is the scaled operator of that double coset. -/
-@[simp] lemma heckeSlashGamma1RingEnd_single
+/-- The value on a basis element is the scaled operator of that double coset. -/
+@[simp] lemma heckeSlashGamma1RingModularFormLinearMap_single
     (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
     (c : ℤ) :
-    heckeSlashGamma1RingEnd (N := N) k (HeckeCosetModule.single ℤ D c) =
+    heckeSlashGamma1RingModularFormLinearMap (N := N) k (HeckeCosetModule.single ℤ D c) =
       c • heckeSlashGamma1ModularFormEnd k D :=
   HeckeCosetModule.sum_single_index ℤ (by simp)
 
-/-- The action is additive in the ring element. -/
-@[simp] lemma heckeSlashGamma1RingEnd_add
-    (T₁ T₂ : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
-    heckeSlashGamma1RingEnd (N := N) k (T₁ + T₂) =
-      heckeSlashGamma1RingEnd (N := N) k T₁ + heckeSlashGamma1RingEnd (N := N) k T₂ :=
-  Finsupp.sum_add_index' (by simp) (by intro a b₁ b₂; rw [add_smul])
+/-- The value on a basis element, evaluated on a modular form. Not a `simp` lemma: `simp`
+reaches this from `heckeSlashGamma1RingModularFormLinearMap_single` already, so tagging both
+would make the pair a `simpNF` normal-form conflict. -/
+lemma heckeSlashGamma1RingModularFormLinearMap_single_apply
+    (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
+    (c : ℤ) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    heckeSlashGamma1RingModularFormLinearMap (N := N) k (HeckeCosetModule.single ℤ D c) f =
+      c • heckeSlashGamma1ModularFormEnd k D f := by
+  rw [heckeSlashGamma1RingModularFormLinearMap_single]
+  rfl
 
-/-- The identity of the Hecke ring acts by the operator of the identity double coset. -/
-@[simp] lemma heckeSlashGamma1RingEnd_one :
-    heckeSlashGamma1RingEnd (N := N) k 1 =
+/-- The ring identity is sent to the operator of the identity double coset. -/
+@[simp] lemma heckeSlashGamma1RingModularFormLinearMap_one :
+    heckeSlashGamma1RingModularFormLinearMap (N := N) k 1 =
       heckeSlashGamma1ModularFormEnd k (1 : HeckeCoset (Delta0 N)
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))) := by
-  change heckeSlashGamma1RingEnd (N := N) k (HeckeCosetModule.single ℤ 1 1) = _
-  rw [heckeSlashGamma1RingEnd_single]
-  norm_num
-
-/-- **The additive action of the Hecke ring on modular forms.** Multiplicativity is Shimura's
-Proposition 3.37 and is not available yet, so the ring acts additively here rather than by the
-`RingHom` the theory ultimately wants. -/
-noncomputable def heckeSlashGamma1RingHom :
-    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →+
-      Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) where
-  toFun := heckeSlashGamma1RingEnd k
-  map_zero' := heckeSlashGamma1RingEnd_zero k
-  map_add' := heckeSlashGamma1RingEnd_add k
-
-@[simp] lemma heckeSlashGamma1RingHom_apply
-    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
-    heckeSlashGamma1RingHom (N := N) k T = heckeSlashGamma1RingEnd (N := N) k T := (rfl)
+  rw [HeckeCosetModule.one_def, heckeSlashGamma1RingModularFormLinearMap_single, one_smul]
 
 end
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -43,6 +43,14 @@ noncomputable def heckeSlashSumRing {N : ℕ} [NeZero N] (k : ℤ)
     heckeSlashSumRing (N := N) k 0 f = 0 :=
   Finsupp.sum_zero_index
 
+/-- The action on a basis element is the scaled slash sum of that double coset. -/
+@[simp] lemma heckeSlashSumRing_single {N : ℕ} [NeZero N] (k : ℤ)
+    (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
+    (c : ℤ) (f : ℍ → ℂ) :
+    heckeSlashSumRing (N := N) k (HeckeCosetModule.single ℤ D c) f =
+      (c : ℂ) • heckeSlashSum k D f :=
+  HeckeCosetModule.sum_single_index ℤ (by simp)
+
 end
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -9,21 +9,27 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Gamma1
 public import TauCeti.NumberTheory.HeckeRing.Associativity
 
 /-!
-# The Hecke ring acting on functions by slash sums
+# The Hecke ring acting on modular forms
 
-`heckeSlashSum` attaches an operator on `ℍ → ℂ` to a single double coset. This file extends
-that assignment `ℤ`-linearly to the whole Hecke ring `𝕋 Δ Γ ℤ`, giving the action through
-which the abstract ring acts on spaces of modular forms.
+`heckeSlashGamma1ModularFormEnd` attaches a `ℂ`-linear endomorphism of `M_k(Γ₁(N))` to a single
+double coset. This file extends that assignment `ℤ`-linearly to the whole Hecke ring
+`𝕋 Δ₀(N) Γ₁(N) ℤ`, so that the abstract ring acts on the space of modular forms.
+
+The extension is additive in the ring element, which is packaged as `heckeSlashGamma1RingHom`.
+Multiplicativity — Shimura's Proposition 3.37, the identification of the convolution structure
+constants with the reindexing of an iterated slash sum — is *not* proved here, so this is
+deliberately an `AddMonoidHom` and not yet the roadmap's `RingHom`.
 
 ## Main definitions
 
-* `heckeSlashSumRing`: the `Finsupp.sum` extension of `heckeSlashSum` to `𝕋 Δ Γ ℤ`.
+* `heckeSlashGamma1RingEnd`: the `Finsupp.sum` extension of `heckeSlashGamma1ModularFormEnd`.
+* `heckeSlashGamma1RingHom`: the same map bundled as an additive monoid homomorphism.
 
 ## Main results
 
-* `heckeSlashSumRing_zero`, `heckeSlashSumRing_single`, `heckeSlashSumRing_add`,
-  `heckeSlashSumRing_one`: the computation rules, giving the value on `0`, on a basis
-  element, on a sum, and on the ring identity.
+* `heckeSlashGamma1RingEnd_zero`, `heckeSlashGamma1RingEnd_single`,
+  `heckeSlashGamma1RingEnd_add`, `heckeSlashGamma1RingEnd_one`: the computation rules, giving
+  the value on `0`, on a basis element, on a sum, and on the ring identity.
 -/
 
 open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
@@ -34,41 +40,57 @@ namespace HeckeRing.GL2
 
 @[expose] public section
 
-variable {G : Type*} [Group G] {Δ : Submonoid G} {Γ : Subgroup G}
+variable {N : ℕ} [NeZero N] (k : ℤ)
 
-/-- **The Hecke ring acting by slash sums**: the `ℤ`-linear extension of `heckeSlashSum` from a
-single double coset to a formal `ℤ`-combination of them. -/
-noncomputable def heckeSlashSumRing {N : ℕ} [NeZero N] (k : ℤ)
-    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) (f : ℍ → ℂ) : ℍ → ℂ :=
-  T.sum fun D c ↦ (c : ℂ) • heckeSlashSum k D f
+/-- **The Hecke ring acting on modular forms**: the `ℤ`-linear extension of
+`heckeSlashGamma1ModularFormEnd` from a single double coset to a formal `ℤ`-combination of
+them. -/
+noncomputable def heckeSlashGamma1RingEnd
+    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
+    Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  T.sum fun D c ↦ c • heckeSlashGamma1ModularFormEnd k D
 
-@[simp] lemma heckeSlashSumRing_zero {N : ℕ} [NeZero N] (k : ℤ) (f : ℍ → ℂ) :
-    heckeSlashSumRing (N := N) k 0 f = 0 :=
+@[simp] lemma heckeSlashGamma1RingEnd_zero :
+    heckeSlashGamma1RingEnd (N := N) k 0 = 0 :=
   Finsupp.sum_zero_index
 
-/-- The action on a basis element is the scaled slash sum of that double coset. -/
-@[simp] lemma heckeSlashSumRing_single {N : ℕ} [NeZero N] (k : ℤ)
+/-- The action on a basis element is the scaled operator of that double coset. -/
+@[simp] lemma heckeSlashGamma1RingEnd_single
     (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
-    (c : ℤ) (f : ℍ → ℂ) :
-    heckeSlashSumRing (N := N) k (HeckeCosetModule.single ℤ D c) f =
-      (c : ℂ) • heckeSlashSum k D f :=
+    (c : ℤ) :
+    heckeSlashGamma1RingEnd (N := N) k (HeckeCosetModule.single ℤ D c) =
+      c • heckeSlashGamma1ModularFormEnd k D :=
   HeckeCosetModule.sum_single_index ℤ (by simp)
 
 /-- The action is additive in the ring element. -/
-@[simp] lemma heckeSlashSumRing_add {N : ℕ} [NeZero N] (k : ℤ)
-    (T₁ T₂ : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) (f : ℍ → ℂ) :
-    heckeSlashSumRing (N := N) k (T₁ + T₂) f =
-      heckeSlashSumRing (N := N) k T₁ f + heckeSlashSumRing (N := N) k T₂ f :=
-  Finsupp.sum_add_index' (by simp) (by intro a b₁ b₂; push_cast; rw [add_smul])
+@[simp] lemma heckeSlashGamma1RingEnd_add
+    (T₁ T₂ : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
+    heckeSlashGamma1RingEnd (N := N) k (T₁ + T₂) =
+      heckeSlashGamma1RingEnd (N := N) k T₁ + heckeSlashGamma1RingEnd (N := N) k T₂ :=
+  Finsupp.sum_add_index' (by simp) (by intro a b₁ b₂; rw [add_smul])
 
-/-- The identity of the Hecke ring acts by the slash sum of the identity double coset. -/
-@[simp] lemma heckeSlashSumRing_one {N : ℕ} [NeZero N] (k : ℤ) (f : ℍ → ℂ) :
-    heckeSlashSumRing (N := N) k 1 f =
-      heckeSlashSum k (1 : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ))
-        ((Gamma1 N).map (mapGL ℚ))) f := by
-  change heckeSlashSumRing (N := N) k (HeckeCosetModule.single ℤ 1 1) f = _
-  rw [heckeSlashSumRing_single]
+/-- The identity of the Hecke ring acts by the operator of the identity double coset. -/
+@[simp] lemma heckeSlashGamma1RingEnd_one :
+    heckeSlashGamma1RingEnd (N := N) k 1 =
+      heckeSlashGamma1ModularFormEnd k (1 : HeckeCoset (Delta0 N)
+        ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))) := by
+  change heckeSlashGamma1RingEnd (N := N) k (HeckeCosetModule.single ℤ 1 1) = _
+  rw [heckeSlashGamma1RingEnd_single]
   norm_num
+
+/-- **The additive action of the Hecke ring on modular forms.** Multiplicativity is Shimura's
+Proposition 3.37 and is not available yet, so the ring acts additively here rather than by the
+`RingHom` the theory ultimately wants. -/
+noncomputable def heckeSlashGamma1RingHom :
+    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →+
+      Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) where
+  toFun := heckeSlashGamma1RingEnd k
+  map_zero' := heckeSlashGamma1RingEnd_zero k
+  map_add' := heckeSlashGamma1RingEnd_add k
+
+@[simp] lemma heckeSlashGamma1RingHom_apply
+    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
+    heckeSlashGamma1RingHom (N := N) k T = heckeSlashGamma1RingEnd (N := N) k T := (rfl)
 
 end
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -21,8 +21,7 @@ the identity endomorphism. What is delivered is the `ℤ`-linear assignment.
 
 The extension is `Finsupp.linearCombination` at the coefficient ring `ℤ`, so linearity in the
 ring element is inherited rather than reproved — `map_zero` and `map_add` apply directly. The
-two lemmas proved here are the ones specific to this setting: the value on a basis element and
-on the ring identity.
+one lemma proved here is the one specific to this setting: the value on a basis element.
 
 ## Main definitions
 
@@ -32,10 +31,9 @@ on the ring identity.
 ## Main results
 
 * `heckeSlashGamma1RingModularFormLinearMap_single`: the value on a basis element is the
-  scaled operator of that double coset.
-* `heckeSlashGamma1RingModularFormLinearMap_single_apply`: the same, evaluated on a form.
-* `heckeSlashGamma1RingModularFormLinearMap_one`: the ring identity is sent to the operator of
-  the identity double coset.
+  scaled operator of that double coset. Together with `map_zero`/`map_add` and
+  `HeckeCosetModule.one_def` this determines the map, so no further computation rules are
+  restated here.
 
 ## References
 
@@ -69,24 +67,6 @@ noncomputable def heckeSlashGamma1RingModularFormLinearMap :
     heckeSlashGamma1RingModularFormLinearMap (N := N) k (HeckeCosetModule.single ℤ D c) =
       c • heckeSlashGamma1ModularFormEnd k D :=
   HeckeCosetModule.sum_single_index ℤ (by simp)
-
-/-- The value on a basis element, evaluated on a modular form. Not a `simp` lemma: `simp`
-reaches this from `heckeSlashGamma1RingModularFormLinearMap_single` already, so tagging both
-would make the pair a `simpNF` normal-form conflict. -/
-lemma heckeSlashGamma1RingModularFormLinearMap_single_apply
-    (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
-    (c : ℤ) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
-    heckeSlashGamma1RingModularFormLinearMap (N := N) k (HeckeCosetModule.single ℤ D c) f =
-      c • heckeSlashGamma1ModularFormEnd k D f := by
-  rw [heckeSlashGamma1RingModularFormLinearMap_single]
-  rfl
-
-/-- The ring identity is sent to the operator of the identity double coset. -/
-@[simp] lemma heckeSlashGamma1RingModularFormLinearMap_one :
-    heckeSlashGamma1RingModularFormLinearMap (N := N) k 1 =
-      heckeSlashGamma1ModularFormEnd k (1 : HeckeCoset (Delta0 N)
-        ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))) := by
-  rw [HeckeCosetModule.one_def, heckeSlashGamma1RingModularFormLinearMap_single, one_smul]
 
 end
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -21,8 +21,9 @@ which the abstract ring acts on spaces of modular forms.
 
 ## Main results
 
-* `heckeSlashSumRing_zero`, `heckeSlashSumRing_single`, `heckeSlashSumRing_add`: the
-  computation rules, giving the value on `0`, on a basis element, and on a sum.
+* `heckeSlashSumRing_zero`, `heckeSlashSumRing_single`, `heckeSlashSumRing_add`,
+  `heckeSlashSumRing_one`: the computation rules, giving the value on `0`, on a basis
+  element, on a sum, and on the ring identity.
 -/
 
 open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
@@ -59,6 +60,15 @@ noncomputable def heckeSlashSumRing {N : ℕ} [NeZero N] (k : ℤ)
     heckeSlashSumRing (N := N) k (T₁ + T₂) f =
       heckeSlashSumRing (N := N) k T₁ f + heckeSlashSumRing (N := N) k T₂ f :=
   Finsupp.sum_add_index' (by simp) (by intro a b₁ b₂; push_cast; rw [add_smul])
+
+/-- The identity of the Hecke ring acts by the slash sum of the identity double coset. -/
+@[simp] lemma heckeSlashSumRing_one {N : ℕ} [NeZero N] (k : ℤ) (f : ℍ → ℂ) :
+    heckeSlashSumRing (N := N) k 1 f =
+      heckeSlashSum k (1 : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ))
+        ((Gamma1 N).map (mapGL ℚ))) f := by
+  change heckeSlashSumRing (N := N) k (HeckeCosetModule.single ℤ 1 1) f = _
+  rw [heckeSlashSumRing_single]
+  norm_num
 
 end
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -6,7 +6,7 @@ Authors: Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Gamma1
-public import TauCeti.NumberTheory.HeckeRing.Associativity
+public import TauCeti.NumberTheory.HeckeRing.Basic
 
 /-!
 # The `ℤ`-linear extension of the Hecke slash operators to the Hecke ring

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -54,7 +54,11 @@ variable {N : ℕ} [NeZero N] (k : ℤ)
 
 /-- The `ℤ`-linear extension of `heckeSlashGamma1ModularFormEnd` to formal `ℤ`-combinations of
 double cosets: `ℤ`-linear in the ring element, but not known to be multiplicative, so this is
-not yet a ring action. -/
+not yet a ring action.
+
+`𝕋 Δ H ℤ` unfolds to `HeckeCoset Δ H H →₀ ℤ` carrying the transported module structure, which
+is why `Finsupp.linearCombination` applies at this type: the ascription below crosses the
+`HeckeCosetModule` wrapper. -/
 noncomputable def heckeSlashGamma1RingModularFormLinearMap :
     𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →ₗ[ℤ]
       Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
@@ -66,7 +70,10 @@ noncomputable def heckeSlashGamma1RingModularFormLinearMap :
     (c : ℤ) :
     heckeSlashGamma1RingModularFormLinearMap (N := N) k (HeckeCosetModule.single ℤ D c) =
       c • heckeSlashGamma1ModularFormEnd k D :=
-  HeckeCosetModule.sum_single_index ℤ (by simp)
+  -- `Finsupp.linearCombination_apply` names the step to the `Finsupp.sum` shape, rather than
+  -- leaving it to delta-unfolding of `linearCombination`; the side goal is then explicit.
+  (Finsupp.linearCombination_apply (R := ℤ) (v := heckeSlashGamma1ModularFormEnd k) _).trans
+    (HeckeCosetModule.sum_single_index ℤ (zero_smul _ _))
 
 end
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -51,6 +51,13 @@ noncomputable def heckeSlashSumRing {N : ℕ} [NeZero N] (k : ℤ)
       (c : ℂ) • heckeSlashSum k D f :=
   HeckeCosetModule.sum_single_index ℤ (by simp)
 
+/-- The action is additive in the ring element. -/
+@[simp] lemma heckeSlashSumRing_add {N : ℕ} [NeZero N] (k : ℤ)
+    (T₁ T₂ : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) (f : ℍ → ℂ) :
+    heckeSlashSumRing (N := N) k (T₁ + T₂) f =
+      heckeSlashSumRing (N := N) k T₁ f + heckeSlashSumRing (N := N) k T₂ f :=
+  Finsupp.sum_add_index' (by simp) (by intro a b₁ b₂; push_cast; rw [add_smul])
+
 end
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -21,6 +21,8 @@ which the abstract ring acts on spaces of modular forms.
 
 ## Main results
 
+* `heckeSlashSumRing_zero`, `heckeSlashSumRing_single`, `heckeSlashSumRing_add`: the
+  computation rules, giving the value on `0`, on a basis element, and on a sum.
 -/
 
 open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -6,7 +6,6 @@ Authors: Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Gamma1
-public import TauCeti.NumberTheory.HeckeRing.Basic
 
 /-!
 # The `ℤ`-linear extension of the Hecke slash operators to the Hecke ring
@@ -72,6 +71,9 @@ noncomputable def heckeSlashGamma1RingModularFormLinearMap :
       c • heckeSlashGamma1ModularFormEnd k D :=
   -- `Finsupp.linearCombination_apply` names the step to the `Finsupp.sum` shape, rather than
   -- leaving it to delta-unfolding of `linearCombination`; the side goal is then explicit.
+  -- `Finsupp.linearCombination_single` does NOT apply here: `HeckeCosetModule.single` is a
+  -- separate, non-exposed `def`, so that lemma's left-hand side does not match — which is why
+  -- the wrapper `HeckeCosetModule.sum_single_index` exists.
   (Finsupp.linearCombination_apply (R := ℤ) (v := heckeSlashGamma1ModularFormEnd k) _).trans
     (HeckeCosetModule.sum_single_index ℤ (zero_smul _ _))
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Ring.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Gamma1
+public import TauCeti.NumberTheory.HeckeRing.Associativity
+
+/-!
+# The Hecke ring acting on functions by slash sums
+
+`heckeSlashSum` attaches an operator on `ℍ → ℂ` to a single double coset. This file extends
+that assignment `ℤ`-linearly to the whole Hecke ring `𝕋 Δ Γ ℤ`, giving the action through
+which the abstract ring acts on spaces of modular forms.
+
+## Main definitions
+
+* `heckeSlashSumRing`: the `Finsupp.sum` extension of `heckeSlashSum` to `𝕋 Δ Γ ℤ`.
+
+## Main results
+
+-/
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
+  HeckeRing.GLn
+open scoped MatrixGroups ModularForm HeckeCosetModule
+
+namespace HeckeRing.GL2
+
+@[expose] public section
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {Γ : Subgroup G}
+
+/-- **The Hecke ring acting by slash sums**: the `ℤ`-linear extension of `heckeSlashSum` from a
+single double coset to a formal `ℤ`-combination of them. -/
+noncomputable def heckeSlashSumRing {N : ℕ} [NeZero N] (k : ℤ)
+    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) (f : ℍ → ℂ) : ℍ → ℂ :=
+  T.sum fun D c ↦ (c : ℂ) • heckeSlashSum k D f
+
+@[simp] lemma heckeSlashSumRing_zero {N : ℕ} [NeZero N] (k : ℤ) (f : ℍ → ℂ) :
+    heckeSlashSumRing (N := N) k 0 f = 0 :=
+  Finsupp.sum_zero_index
+
+end
+
+end HeckeRing.GL2


### PR DESCRIPTION
Extends the double-coset Hecke operator on modular forms `ℤ`-linearly over the basis of the
Hecke ring `𝕋 Δ₀(N) Γ₁(N) ℤ`, using Mathlib's generic finitely-supported linear-combination
map:

```lean
noncomputable def heckeSlashGamma1RingModularFormLinearMap :
    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →ₗ[ℤ]
      Module.End ℂ (ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
  Finsupp.linearCombination ℤ (heckeSlashGamma1ModularFormEnd k)
```

Because the definition *is* `Finsupp.linearCombination`, linearity in the ring element is
inherited — `map_zero`/`map_add` apply directly and are not restated. The single lemma proved
here is the one specific to this setting: the value on a basis element (`_single`). Together
with `HeckeCosetModule.one_def` that determines the map on the ring identity too, so no further
computation rules are restated.

**This is not a ring action, and the file does not say it is.** Multiplicativity is unproved, so
the title, module docstring and declaration docstrings all say "`ℤ`-linear extension".

### Round 2 — response to the round-1 review

Eight of the nine findings are addressed in `10fd92946`:

| Rubric | Change |
|---|---|
| reuse | definition is `Finsupp.linearCombination ℤ`; `_zero`/`_add` deleted (now `map_zero`/`map_add`); one public name, no `rfl` bridge |
| reuse (round 2) | `_single_apply` and `_one` deleted as derived — see below |
| proof-quality (round 2) | resolved by that deletion; the `rfl` it flagged was inside `_single_apply` |
| api-design | `public section` without `@[expose]`; `_single_apply` added so no consumer needs the body |
| naming | `heckeSlashGamma1RingHom` (a `→+`) → `heckeSlashGamma1RingModularFormLinearMap` (a `→ₗ[ℤ]`), freeing `…RingHom` for the eventual `→+*` |
| correctness | the seven "acts on" claims reworded; the handedness point is moot now that no ring-hom shape is asserted |
| documentation | title and docstrings restated; no declaration is undocumented; Main results matches |
| attribution | `## References` added citing [shimura1971] §3.4 and Diamond–Shurman §5.2; the "Proposition 3.37" citation dropped — the repo uses 3.37 for the *mapping* statement (`Gamma1.lean:48-49`), so citing it for multiplicativity was wrong |
| proof-quality | `change` → `rw [HeckeCosetModule.one_def, …_single, one_smul]` |

### Round 3 — the `reuse` finding was contested and sustained

Round-1 **api-design** had explicitly asked for `_single_apply` ("Add the elimination rules …"),
and round-1 **proof-quality** prescribed `_one`'s proof rather than its removal, so round 2's
request to delete both reversed them. I contested in-thread rather than silently complying and
letting the earlier rubrics re-fire. The re-review on `10fd929` **sustained the finding**, so
both declarations are now deleted and the Main-results list updated to match. `api-design`,
`documentation` and `proof-quality` are expected to stay green on the smaller surface; if
api-design re-fires asking for the evaluated-form lemma back, that is the contradiction the
contest recorded and it will need settling between the two rubrics rather than by another edit
here.

### scope — the finding is right, and the description was wrong

The round-1 `scope` finding says this PR is built on a different ring and space than the
target it cited. **That is correct**, and the previous description overclaimed. Checked
against `origin/main` of TauCetiRoadmap:

- the cited target is `heckeRingHomCharSpace : 𝕋 (Gamma0_pair N) ℤ →+* Module.End ℂ
  (modFormCharSpace k χ)` — the **Γ₀-pair** ring on the **character space**
  (`ModularForms/README.md:407-408`);
- this PR builds the **Γ₁-pair** ring on **all** of `M_k(Γ₁(N))`;
- and `README.md:431-439` states that in the Γ₁-pair ring the diamonds are honest double
  cosets while in the Γ₀-pair ring they are the identity, so "keeping the two rings and
  their two diamond descriptions straight is part of the layer". The reduction is not
  automatic, and I am not claiming it.

So this is **not** a prerequisite of `heckeRingHomCharSpace`. What it is: the Γ₁-pair half of
Layer 2(b)'s "the ring homomorphism from the abstract ring" (`README.md:399-401`), which is
the flank where the diamond operators are honest double cosets.

I have not added `map_mul'`, and there is no in-repo consumer yet — so if the reviewer's
first option (land it together with the multiplicative content, or not at all) is the
project's preference, that is a legitimate call to make on this PR and I will not argue it
away. Flagging rather than papering over.

### generality — partly dissolved, partly open

The finding asks that the extension be proved once for a general family rather than copied
per space. Adopting `Finsupp.linearCombination` does that: there is no longer any duplicated
*proof* content between this PR and #4143 — each is a one-line definition plus the two
setting-specific lemmas. The remaining half of the finding — making the level generic in
`{G : Subgroup SL(2,ℤ)}` rather than fixing `Γ₁(N)` — is **not** done here and is a real
design change spanning both PRs; it wants its own PR rather than a fold-in.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke-ring-additive-action-modular-forms"}-->

Provenance: no external source — built on TauCeti `main`'s own
`heckeSlashGamma1ModularFormEnd` (`HeckeSlash/Gamma1.lean:69`) and `HeckeCosetModule`
(`HeckeRing/Basic.lean`), plus Mathlib's `Finsupp.linearCombination`.

