### PR TITLE
feat(HeckeSlash): the Hecke ring acting additively on cusp forms

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/CuspRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/CuspRing.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Gamma1
+public import TauCeti.NumberTheory.HeckeRing.Associativity
+
+/-!
+# The Hecke ring acting on cusp forms
+
+`heckeSlashGamma1CuspFormEnd` attaches a `ℂ`-linear endomorphism of `S_k(Γ₁(N))` to a single
+double coset. This file extends that assignment `ℤ`-linearly to the whole Hecke ring
+`𝕋 Δ₀(N) Γ₁(N) ℤ`, so that the abstract ring acts on the space of cusp forms.
+
+The extension is additive in the ring element, which is packaged as
+`heckeSlashGamma1CuspRingHom`. Multiplicativity — Shimura's Proposition 3.37 — is *not* proved
+here, so this is deliberately an `AddMonoidHom` and not yet a `RingHom`.
+
+## Main definitions
+
+* `heckeSlashGamma1CuspRingEnd`: the `Finsupp.sum` extension of `heckeSlashGamma1CuspFormEnd`.
+* `heckeSlashGamma1CuspRingHom`: the same map bundled as an additive monoid homomorphism.
+
+## Main results
+
+* `heckeSlashGamma1CuspRingEnd_zero`, `heckeSlashGamma1CuspRingEnd_single`,
+  `heckeSlashGamma1CuspRingEnd_add`, `heckeSlashGamma1CuspRingEnd_one`: the computation rules,
+  giving the value on `0`, on a basis element, on a sum, and on the ring identity.
+-/
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
+  HeckeRing.GLn
+open scoped MatrixGroups ModularForm HeckeCosetModule
+
+namespace HeckeRing.GL2
+
+@[expose] public section
+
+variable {N : ℕ} [NeZero N] (k : ℤ)
+
+/-- **The Hecke ring acting on cusp forms**: the `ℤ`-linear extension of
+`heckeSlashGamma1CuspFormEnd` from a single double coset to a formal `ℤ`-combination of
+them. -/
+noncomputable def heckeSlashGamma1CuspRingEnd
+    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
+    Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  T.sum fun D c ↦ c • heckeSlashGamma1CuspFormEnd k D
+
+@[simp] lemma heckeSlashGamma1CuspRingEnd_zero :
+    heckeSlashGamma1CuspRingEnd (N := N) k 0 = 0 :=
+  Finsupp.sum_zero_index
+
+/-- The action on a basis element is the scaled operator of that double coset. -/
+@[simp] lemma heckeSlashGamma1CuspRingEnd_single
+    (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
+    (c : ℤ) :
+    heckeSlashGamma1CuspRingEnd (N := N) k (HeckeCosetModule.single ℤ D c) =
+      c • heckeSlashGamma1CuspFormEnd k D :=
+  HeckeCosetModule.sum_single_index ℤ (by simp)
+
+/-- The action is additive in the ring element. -/
+@[simp] lemma heckeSlashGamma1CuspRingEnd_add
+    (T₁ T₂ : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
+    heckeSlashGamma1CuspRingEnd (N := N) k (T₁ + T₂) =
+      heckeSlashGamma1CuspRingEnd (N := N) k T₁ + heckeSlashGamma1CuspRingEnd (N := N) k T₂ :=
+  Finsupp.sum_add_index' (by simp) (by intro a b₁ b₂; rw [add_smul])
+
+/-- The identity of the Hecke ring acts by the operator of the identity double coset. -/
+@[simp] lemma heckeSlashGamma1CuspRingEnd_one :
+    heckeSlashGamma1CuspRingEnd (N := N) k 1 =
+      heckeSlashGamma1CuspFormEnd k (1 : HeckeCoset (Delta0 N)
+        ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))) := by
+  change heckeSlashGamma1CuspRingEnd (N := N) k (HeckeCosetModule.single ℤ 1 1) = _
+  rw [heckeSlashGamma1CuspRingEnd_single]
+  norm_num
+
+/-- **The additive action of the Hecke ring on cusp forms.** Multiplicativity is Shimura's
+Proposition 3.37 and is not available yet, so the ring acts additively here rather than by a
+`RingHom`. -/
+noncomputable def heckeSlashGamma1CuspRingHom :
+    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →+
+      Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) where
+  toFun := heckeSlashGamma1CuspRingEnd k
+  map_zero' := heckeSlashGamma1CuspRingEnd_zero k
+  map_add' := heckeSlashGamma1CuspRingEnd_add k
+
+@[simp] lemma heckeSlashGamma1CuspRingHom_apply
+    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
+    heckeSlashGamma1CuspRingHom (N := N) k T = heckeSlashGamma1CuspRingEnd (N := N) k T := (rfl)
+
+end
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/CuspRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/CuspRing.lean
@@ -15,20 +15,23 @@ public import TauCeti.NumberTheory.HeckeRing.Associativity
 double coset. This file extends that assignment `ℤ`-linearly to the whole Hecke ring
 `𝕋 Δ₀(N) Γ₁(N) ℤ`, so that the abstract ring acts on the space of cusp forms.
 
-The extension is additive in the ring element, which is packaged as
-`heckeSlashGamma1CuspRingHom`. Multiplicativity — Shimura's Proposition 3.37 — is *not* proved
-here, so this is deliberately an `AddMonoidHom` and not yet a `RingHom`.
+The extension is `Finsupp.linearCombination` at the coefficient ring `ℤ`, so linearity in the
+ring element is inherited rather than reproved: `map_zero` and `map_add` apply directly. What
+is specific to this setting is the value on a basis element and on the ring identity, proved
+below. Multiplicativity — Shimura's Proposition 3.37 — is *not* proved here, so this is
+deliberately a `ℤ`-linear map and not yet a `RingHom`.
 
 ## Main definitions
 
-* `heckeSlashGamma1CuspRingEnd`: the `Finsupp.sum` extension of `heckeSlashGamma1CuspFormEnd`.
-* `heckeSlashGamma1CuspRingHom`: the same map bundled as an additive monoid homomorphism.
+* `heckeSlashGamma1CuspRingLinearMap`: the `ℤ`-linear extension of
+  `heckeSlashGamma1CuspFormEnd` to the Hecke ring.
 
 ## Main results
 
-* `heckeSlashGamma1CuspRingEnd_zero`, `heckeSlashGamma1CuspRingEnd_single`,
-  `heckeSlashGamma1CuspRingEnd_add`, `heckeSlashGamma1CuspRingEnd_one`: the computation rules,
-  giving the value on `0`, on a basis element, on a sum, and on the ring identity.
+* `heckeSlashGamma1CuspRingLinearMap_single`: the value on a basis element is the scaled
+  operator of that double coset.
+* `heckeSlashGamma1CuspRingLinearMap_one`: the ring identity acts by the operator of the
+  identity double coset.
 -/
 
 open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
@@ -37,59 +40,35 @@ open scoped MatrixGroups ModularForm HeckeCosetModule
 
 namespace HeckeRing.GL2
 
-@[expose] public section
+public section
 
 variable {N : ℕ} [NeZero N] (k : ℤ)
 
 /-- **The Hecke ring acting on cusp forms**: the `ℤ`-linear extension of
 `heckeSlashGamma1CuspFormEnd` from a single double coset to a formal `ℤ`-combination of
-them. -/
-noncomputable def heckeSlashGamma1CuspRingEnd
-    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
-    Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
-  T.sum fun D c ↦ c • heckeSlashGamma1CuspFormEnd k D
+them.
 
-@[simp] lemma heckeSlashGamma1CuspRingEnd_zero :
-    heckeSlashGamma1CuspRingEnd (N := N) k 0 = 0 :=
-  Finsupp.sum_zero_index
+Multiplicativity is Shimura's Proposition 3.37 and is not available yet, so the Hecke ring
+acts `ℤ`-linearly here rather than by a `RingHom`. -/
+noncomputable def heckeSlashGamma1CuspRingLinearMap :
+    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →ₗ[ℤ]
+      Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  Finsupp.linearCombination ℤ (heckeSlashGamma1CuspFormEnd k)
 
 /-- The action on a basis element is the scaled operator of that double coset. -/
-@[simp] lemma heckeSlashGamma1CuspRingEnd_single
+@[simp] lemma heckeSlashGamma1CuspRingLinearMap_single
     (D : HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)))
     (c : ℤ) :
-    heckeSlashGamma1CuspRingEnd (N := N) k (HeckeCosetModule.single ℤ D c) =
+    heckeSlashGamma1CuspRingLinearMap (N := N) k (HeckeCosetModule.single ℤ D c) =
       c • heckeSlashGamma1CuspFormEnd k D :=
   HeckeCosetModule.sum_single_index ℤ (by simp)
 
-/-- The action is additive in the ring element. -/
-@[simp] lemma heckeSlashGamma1CuspRingEnd_add
-    (T₁ T₂ : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
-    heckeSlashGamma1CuspRingEnd (N := N) k (T₁ + T₂) =
-      heckeSlashGamma1CuspRingEnd (N := N) k T₁ + heckeSlashGamma1CuspRingEnd (N := N) k T₂ :=
-  Finsupp.sum_add_index' (by simp) (by intro a b₁ b₂; rw [add_smul])
-
 /-- The identity of the Hecke ring acts by the operator of the identity double coset. -/
-@[simp] lemma heckeSlashGamma1CuspRingEnd_one :
-    heckeSlashGamma1CuspRingEnd (N := N) k 1 =
+@[simp] lemma heckeSlashGamma1CuspRingLinearMap_one :
+    heckeSlashGamma1CuspRingLinearMap (N := N) k 1 =
       heckeSlashGamma1CuspFormEnd k (1 : HeckeCoset (Delta0 N)
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))) := by
-  change heckeSlashGamma1CuspRingEnd (N := N) k (HeckeCosetModule.single ℤ 1 1) = _
-  rw [heckeSlashGamma1CuspRingEnd_single]
-  norm_num
-
-/-- **The additive action of the Hecke ring on cusp forms.** Multiplicativity is Shimura's
-Proposition 3.37 and is not available yet, so the ring acts additively here rather than by a
-`RingHom`. -/
-noncomputable def heckeSlashGamma1CuspRingHom :
-    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →+
-      Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) where
-  toFun := heckeSlashGamma1CuspRingEnd k
-  map_zero' := heckeSlashGamma1CuspRingEnd_zero k
-  map_add' := heckeSlashGamma1CuspRingEnd_add k
-
-@[simp] lemma heckeSlashGamma1CuspRingHom_apply
-    (T : 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ) :
-    heckeSlashGamma1CuspRingHom (N := N) k T = heckeSlashGamma1CuspRingEnd (N := N) k T := (rfl)
+  rw [HeckeCosetModule.one_def, heckeSlashGamma1CuspRingLinearMap_single, one_smul]
 
 end
 


### PR DESCRIPTION
Extends the double-coset Hecke operator on **cusp** forms `ℤ`-linearly to the whole Hecke
ring, as a bundled `ℤ`-linear map.

`heckeSlashGamma1CuspFormEnd` (already on `main`, `HeckeSlash/Gamma1.lean`) attaches a
`ℂ`-linear endomorphism of `S_k(Γ₁(N))` to a single double coset of the Hecke triple
`(Γ₁(N), Δ₀(N))`. This PR extends that assignment over the basis of `𝕋 Δ₀(N) Γ₁(N) ℤ`,
using Mathlib's generic finitely-supported linear-combination map:

```lean
noncomputable def heckeSlashGamma1CuspRingLinearMap :
    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ →ₗ[ℤ]
      Module.End ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
  Finsupp.linearCombination ℤ (heckeSlashGamma1CuspFormEnd k)
```

Because the definition *is* `Finsupp.linearCombination`, linearity in the ring element is
inherited — `map_zero` and `map_add` apply directly and are not restated. The two lemmas
proved here are the ones specific to this setting: the value on a basis element
(`_single`) and on the ring identity (`_one`).

### Why `→ₗ[ℤ]` and not `→+*`

Multiplicativity is Shimura's Proposition 3.37 and is **not** proved here, so the ring acts
`ℤ`-linearly — which is exactly what the computation rules support — rather than by a
`RingHom` whose `map_mul'` is unavailable.

### Relationship to #4142

#4142 does the same for `ModularForm`; this does it for `CuspForm`. They are separate
declarations here because `main` already keeps the single-coset operators separate
(`heckeSlashGamma1ModularFormEnd` and `heckeSlashGamma1CuspFormEnd` in
`HeckeSlash/Gamma1.lean`), and the two endomorphism algebras are of different spaces. The
files are disjoint and neither imports the other.

The cusp-form side is the one strong multiplicity one actually needs: `strongMultiplicityOne`
compares newforms, whose underlying forms live in `S_k(N, χ)`.

### Notes for review

* Nothing here is unconsumed: `_single` and `_one` are the computation content, and the
  zero/additivity rules are Mathlib's `map_zero`/`map_add` on the bundled map rather than
  restated lemmas.
* The extension is taken at the `Module.End` level rather than on raw `ℍ → ℂ` functions, so
  it reuses the existing operator instead of re-deriving it a level down.

Roadmap: ModularForms

Roadmap target — `TauCetiRoadmap/ModularForms/PROGRESS.md:21` records this gap:

> The Hecke development now turns an arbitrary double coset for `(Γ₁(N), Δ₀(N))` into a
> linear endomorphism of modular forms, **with the corresponding operator on cusp forms.** …
> **This is not yet the uniform `T_n` action or a Hecke-ring homomorphism**, and the augmented
> prime sum is not yet identified with the full `T_p` double coset.

and `TauCetiRoadmap/ModularForms/README.md:400-408` states the target this feeds:

```lean
noncomputable def heckeRingHomCharSpace :   -- Φ_χ
    𝕋 (Gamma0_pair N) ℤ →+* Module.End ℂ (modFormCharSpace k χ)
```

Downstream, `TauCetiRoadmap/ModularForms/README.md:603-625` is **Layer 5**, the migration of
AINTLIB's `strongMultiplicityOne` (`StrongMultiplicityOne/ConstantMultiple.lean`), whose
`EigenformAwayFromLevel` is stated through `heckeRingHomCharSpace`. This PR is a prerequisite
in the sense of `CLAUDE.md` ("supplies a prerequisite that a specific target needs"), not a
Layer 5 deliverable itself.

<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecke-ring-additive-action-cusp-forms"}-->

Provenance: no external source — built on TauCeti `main`'s own
`HeckeSlash/Gamma1.lean` (`heckeSlashGamma1CuspFormEnd`) and
`HeckeRing/{Basic,Associativity}.lean` (`HeckeCosetModule.single`, `sum_single_index`, the
`𝕋` ring instances).

