### PR TITLE
feat: mixed Hodge structures and the graded pieces of a weight filtration

### DIFF
--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -10,7 +10,8 @@ public import Mathlib.Data.Complex.Basic
 public import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import Mathlib.LinearAlgebra.TensorProduct.Tower
 public import Mathlib.RingTheory.Flat.Basic
-public import Mathlib.RingTheory.IsTensorProduct
+public import TauCeti.Geometry.Hodge.Conjugation
+public import TauCeti.RingTheory.IsTensorProduct
 
 /-!
 # Rational subspaces in an abstract complexification
@@ -61,6 +62,18 @@ variable [AddCommGroup Vℤ]
 variable [AddCommGroup Vℚ] [Module ℚ Vℚ]
 variable [AddCommGroup Vℂ] [Module ℂ Vℂ]
 variable {ιℚ : Vℤ →ₗ[ℤ] Vℚ} {ιℂ : Vℤ →ₗ[ℤ] Vℂ}
+
+/-- Lattice conjugation on the complexification `ℂ ⊗[ℚ] U` of a rational vector space conjugates
+the scalar factor of a pure tensor. It is the unique conjugate-linear map fixing `1 ⊗ₜ u`. -/
+@[simp]
+theorem latticeConj_ratTensorMap_tmul (U : Type*) [AddCommGroup U] [Module ℚ U]
+    (z : ℂ) (u : U) :
+    latticeConj (isBaseChange_ratTensorMap ℂ U) (z ⊗ₜ[ℚ] u) =
+      (starRingEnd ℂ) z ⊗ₜ[ℚ] u := by
+  have hz : z ⊗ₜ[ℚ] u = z • ratTensorMap ℂ U u := by
+    rw [ratTensorMap_apply, TensorProduct.smul_tmul', smul_eq_mul, mul_one]
+  rw [hz, map_smulₛₗ, latticeConj_ι, ratTensorMap_apply, TensorProduct.smul_tmul', smul_eq_mul,
+    mul_one]
 
 /-- The canonical tower equivalence from an abstract rational base change to an abstract complex
 base change of the same integral module. -/

--- a/TauCeti/Geometry/Hodge/Graded.lean
+++ b/TauCeti/Geometry/Hodge/Graded.lean
@@ -7,8 +7,6 @@ module
 
 public import Mathlib.LinearAlgebra.TensorProduct.Quotient
 public import TauCeti.Geometry.Hodge.BaseChange
-public import TauCeti.Geometry.Hodge.Structure
-public import TauCeti.RingTheory.IsTensorProduct
 
 /-!
 # Graded pieces of a rational weight filtration
@@ -91,7 +89,8 @@ theorem map_range_lTensor_submoduleOf (hℚ : IsBaseChange ℚ ιℚ) (hℂ : Is
       exact ⟨y, hy, rfl⟩
     · rintro ⟨y, hy, rfl⟩
       exact ⟨1 ⊗ₜ[ℚ] y, ⟨y, hy, rfl⟩, rfl⟩
-  have hrange : LinearMap.range (A.subtype.baseChange ℂ) = Submodule.baseChange ℂ A := rfl
+  have hrange : LinearMap.range (A.subtype.baseChange ℂ) = Submodule.baseChange ℂ A := by
+    rw [Submodule.baseChange]
   apply Submodule.map_injective_of_injective (Submodule.injective_subtype _)
   have step1 : Submodule.map (rationalToComplexSubmodule hℚ hℂ B).subtype
       (Submodule.map (rationalToComplexSubmoduleEquiv hℚ hℂ B).toLinearMap
@@ -133,24 +132,11 @@ theorem gradedComplexEquiv_tmul_mk (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBas
     (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) (k : ℤ) (z : ℂ) (x : WQ k) :
     gradedComplexEquiv hℚ hℂ WQ hWQ k (z ⊗ₜ[ℚ] Submodule.Quotient.mk x) =
       Submodule.Quotient.mk (rationalToComplexSubmoduleEquiv hℚ hℂ (WQ k) (z ⊗ₜ[ℚ] x)) :=
-  (rfl)
-
-section RationalConjugation
-
-variable (U : Type*) [AddCommGroup U] [Module ℚ U]
-
-/-- Lattice conjugation on the complexification `ℂ ⊗[ℚ] U` of a rational vector space conjugates
-the scalar factor of a pure tensor. It is the unique conjugate-linear map fixing `1 ⊗ₜ u`. -/
-@[simp]
-theorem latticeConj_ratTensorMap_tmul (z : ℂ) (u : U) :
-    latticeConj (isBaseChange_ratTensorMap ℂ U) (z ⊗ₜ[ℚ] u) =
-      (starRingEnd ℂ) z ⊗ₜ[ℚ] u := by
-  have hz : z ⊗ₜ[ℚ] u = z • ratTensorMap ℂ U u := by
-    rw [ratTensorMap_apply, TensorProduct.smul_tmul', smul_eq_mul, mul_one]
-  rw [hz, map_smulₛₗ, latticeConj_ι, ratTensorMap_apply, TensorProduct.smul_tmul', smul_eq_mul,
-    mul_one]
-
-end RationalConjugation
+  by
+    rw [gradedComplexEquiv, LinearEquiv.trans_apply,
+      TensorProduct.AlgebraTensorModule.tensorQuotientEquiv_apply_tmul,
+      Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+    congr 1
 
 /-- The Hodge filtration induced on the `k`-th complex graded piece: the image of `F^p ∩ W_k`
 under the quotient map `W_k → W_k / W_{k-1}`. -/
@@ -165,6 +151,31 @@ noncomputable def gradedF (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange �
     Submodule ℂ (ℂ ⊗[ℚ] weightGradedRat WQ k) :=
   (complexGradedF (fun k ↦ rationalToComplexSubmodule hℚ hℂ (WQ k)) F k p).comap
     (gradedComplexEquiv hℚ hℂ WQ hWQ k).toLinearMap
+
+/-- Membership in the induced filtration on a complex graded piece is witnessed by a
+representative in the corresponding ambient Hodge-filtration step. -/
+@[simp]
+theorem mem_complexGradedF_iff (WC F : ℤ → Submodule ℂ Vℂ) (k p : ℤ)
+    (x : weightGradedComplex WC k) :
+    x ∈ complexGradedF WC F k p ↔
+      ∃ y : WC k, (y : Vℂ) ∈ F p ∧ Submodule.Quotient.mk y = x := by
+  rw [complexGradedF]
+  constructor
+  · rintro ⟨y, hy, rfl⟩
+    exact ⟨y, hy.1, rfl⟩
+  · rintro ⟨y, hy, rfl⟩
+    exact ⟨y, ⟨hy, y.property⟩, rfl⟩
+
+/-- Membership in the filtration on a complexified rational graded piece is detected after
+transport to the complex graded piece and represented there by an element of `F p`. -/
+@[simp]
+theorem mem_gradedF_iff (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) (F : ℤ → Submodule ℂ Vℂ) (k p : ℤ)
+    (x : ℂ ⊗[ℚ] weightGradedRat WQ k) :
+    x ∈ gradedF hℚ hℂ WQ hWQ F k p ↔
+      ∃ y : rationalToComplexSubmodule hℚ hℂ (WQ k), (y : Vℂ) ∈ F p ∧
+        Submodule.Quotient.mk y = gradedComplexEquiv hℚ hℂ WQ hWQ k x := by
+  simp [gradedF]
 
 /-- The induced filtration on a complex graded piece is decreasing. -/
 theorem complexGradedF_antitone (WC F : ℤ → Submodule ℂ Vℂ) (hF : Antitone F) (k : ℤ) :

--- a/TauCeti/Geometry/Hodge/Graded.lean
+++ b/TauCeti/Geometry/Hodge/Graded.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.TensorProduct.Quotient
+public import TauCeti.Geometry.Hodge.BaseChange
+public import TauCeti.Geometry.Hodge.Structure
+public import TauCeti.RingTheory.IsTensorProduct
+
+/-!
+# Graded pieces of a rational weight filtration
+
+A mixed Hodge structure carries an increasing weight filtration `W` on the rational model `Vℚ`
+and a decreasing Hodge filtration `F` on the complex model `Vℂ`, and asks that `F` induce a pure
+Hodge structure of weight `k` on each graded piece `grᵂ_k = W_k / W_{k-1}`. This file supplies
+the objects that condition is stated against.
+
+The graded piece is taken **rationally**, and the pure structure lives on its complexification
+`ℂ ⊗[ℚ] grᵂ_k`. That model is preferred to the complex graded piece `(W_k)_ℂ / (W_{k-1})_ℂ`
+because it carries a canonical conjugation for free: `ℂ ⊗[ℚ] U` is a base change of the
+`ℚ`-vector space `U` along `ℤ → ℂ` (`TauCeti.isBaseChange_ratTensorMap`), so
+`TauCeti.Hodge.latticeConj` applies to it verbatim. The two models are identified by
+`TauCeti.Hodge.gradedComplexEquiv`, which says that complexification commutes with the graded
+quotient, and the Hodge filtration is transported across that identification.
+
+## Main declarations
+
+* `TauCeti.Hodge.weightGradedRat`, `TauCeti.Hodge.weightGradedComplex`: the rational and complex
+  graded pieces of a filtration.
+* `TauCeti.Hodge.gradedComplexEquiv`: complexification commutes with the weight-graded quotient.
+* `TauCeti.Hodge.complexGradedF`, `TauCeti.Hodge.gradedF`: the Hodge filtration induced on the
+  complex graded piece and on the complexified rational graded piece.
+* `TauCeti.Hodge.gradedEquivOfEqBotOfEqTop`: across a step where the weight filtration jumps from
+  zero to everything, the complexified graded piece is the whole complex model, compatibly with
+  the conjugations and with the induced filtration.
+
+The conventions for opposed and induced filtrations follow Deligne, *Théorie de Hodge II*,
+§1.2.1; the graded-piece comparison is the one used throughout Peters–Steenbrink, *Mixed Hodge
+Structures*, Ch. 3. The signatures of `weightGradedRat`, `gradedComplexEquiv` and `gradedF` are
+adapted from the proposed definitions in
+[`HodgeStructures/Suggested.lean`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/HodgeStructures/Suggested.lean),
+whose definitive mathematical specification is the accompanying Hodge structures roadmap.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+open scoped TensorProduct
+
+universe u v w
+
+variable {Vℤ : Type u} {Vℚ : Type v} {Vℂ : Type w}
+variable [AddCommGroup Vℤ]
+variable [AddCommGroup Vℚ] [Module ℚ Vℚ]
+variable [AddCommGroup Vℂ] [Module ℂ Vℂ]
+variable {ιℚ : Vℤ →ₗ[ℤ] Vℚ} {ιℂ : Vℤ →ₗ[ℤ] Vℂ}
+
+/-- Complexifying the inclusion of one rational subspace into a larger one, then identifying the
+larger tensor product with the complexified subspace, has the complexification of the smaller
+subspace as its range. -/
+theorem map_range_lTensor_submoduleOf (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    {A B : Submodule ℚ Vℚ} (hAB : A ≤ B) :
+    (LinearMap.range (TensorProduct.AlgebraTensorModule.lTensor ℂ ℂ
+        ((A.submoduleOf B).subtype.restrictScalars ℚ))).map
+        (rationalToComplexSubmoduleEquiv hℚ hℂ B).toLinearMap =
+      (rationalToComplexSubmodule hℚ hℂ A).submoduleOf
+        (rationalToComplexSubmodule hℚ hℂ B) := by
+  have key : (rationalToComplexSubmodule hℚ hℂ B).subtype ∘ₗ
+      (rationalToComplexSubmoduleEquiv hℚ hℂ B).toLinearMap ∘ₗ
+        TensorProduct.AlgebraTensorModule.lTensor ℂ ℂ
+          ((A.submoduleOf B).subtype.restrictScalars ℚ) =
+      (rationalToComplexLinearEquiv hℚ hℂ).toLinearMap ∘ₗ A.subtype.baseChange ℂ ∘ₗ
+        (TensorProduct.AlgebraTensorModule.congr (LinearEquiv.refl ℂ ℂ)
+          (Submodule.submoduleOfEquivOfLe hAB)).toLinearMap := by
+    refine LinearMap.ext fun t ↦ ?_
+    induction t using TensorProduct.induction_on with
+    | zero => simp
+    | tmul z x => simp [Submodule.submoduleOfEquivOfLe]
+    | add x y hx hy => simp only [map_add, hx, hy]
+  have hbase : (Submodule.baseChange ℂ A).map (rationalToComplexLinearEquiv hℚ hℂ).toLinearMap =
+      rationalToComplexSubmodule hℚ hℂ A := by
+    rw [Submodule.baseChange_eq_span, Submodule.map_span, rationalToComplexSubmodule_eq_span]
+    congr 1
+    ext x
+    constructor
+    · rintro ⟨_, ⟨y, hy, rfl⟩, rfl⟩
+      exact ⟨y, hy, rfl⟩
+    · rintro ⟨y, hy, rfl⟩
+      exact ⟨1 ⊗ₜ[ℚ] y, ⟨y, hy, rfl⟩, rfl⟩
+  have hrange : LinearMap.range (A.subtype.baseChange ℂ) = Submodule.baseChange ℂ A := rfl
+  apply Submodule.map_injective_of_injective (Submodule.injective_subtype _)
+  have step1 : Submodule.map (rationalToComplexSubmodule hℚ hℂ B).subtype
+      (Submodule.map (rationalToComplexSubmoduleEquiv hℚ hℂ B).toLinearMap
+        (LinearMap.range (TensorProduct.AlgebraTensorModule.lTensor ℂ ℂ
+          ((A.submoduleOf B).subtype.restrictScalars ℚ)))) =
+      LinearMap.range ((rationalToComplexSubmodule hℚ hℂ B).subtype ∘ₗ
+        (rationalToComplexSubmoduleEquiv hℚ hℂ B).toLinearMap ∘ₗ
+          TensorProduct.AlgebraTensorModule.lTensor ℂ ℂ
+            ((A.submoduleOf B).subtype.restrictScalars ℚ)) := by
+    rw [LinearMap.range_comp, LinearMap.range_comp]
+  rw [step1, key, LinearMap.range_comp, LinearMap.range_comp,
+    LinearMap.range_eq_top.2 (TensorProduct.AlgebraTensorModule.congr (LinearEquiv.refl ℂ ℂ)
+      (Submodule.submoduleOfEquivOfLe hAB)).surjective, Submodule.map_top, hrange, hbase]
+  simp only [Submodule.submoduleOf, Submodule.map_comap_subtype,
+    inf_of_le_right (rationalToComplexSubmodule_mono hℚ hℂ hAB)]
+
+/-- The `k`-th graded piece `grᵂ_k = W_k / W_{k-1}` of an increasing rational filtration `W`.
+The lower step is viewed inside `W_k` through `Submodule.submoduleOf`. -/
+abbrev weightGradedRat (WQ : ℤ → Submodule ℚ Vℚ) (k : ℤ) : Type v :=
+  WQ k ⧸ (WQ (k - 1)).submoduleOf (WQ k)
+
+/-- The `k`-th graded piece of an increasing complex filtration. -/
+abbrev weightGradedComplex (WC : ℤ → Submodule ℂ Vℂ) (k : ℤ) : Type w :=
+  WC k ⧸ (WC (k - 1)).submoduleOf (WC k)
+
+/-- **Complexification commutes with the weight-graded quotient**: the complexification of the
+rational graded piece `grᵂ_k` is the graded piece of the complexified filtration. -/
+noncomputable def gradedComplexEquiv (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) (k : ℤ) :
+    ℂ ⊗[ℚ] weightGradedRat WQ k ≃ₗ[ℂ]
+      weightGradedComplex (fun k ↦ rationalToComplexSubmodule hℚ hℂ (WQ k)) k :=
+  (TensorProduct.AlgebraTensorModule.tensorQuotientEquiv ℂ ℚ ℂ
+      ((WQ (k - 1)).submoduleOf (WQ k))).trans
+    (Submodule.Quotient.equiv _ _ (rationalToComplexSubmoduleEquiv hℚ hℂ (WQ k))
+      (map_range_lTensor_submoduleOf hℚ hℂ (hWQ (by omega))))
+
+@[simp]
+theorem gradedComplexEquiv_tmul_mk (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) (k : ℤ) (z : ℂ) (x : WQ k) :
+    gradedComplexEquiv hℚ hℂ WQ hWQ k (z ⊗ₜ[ℚ] Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (rationalToComplexSubmoduleEquiv hℚ hℂ (WQ k) (z ⊗ₜ[ℚ] x)) :=
+  (rfl)
+
+section RationalConjugation
+
+variable (U : Type*) [AddCommGroup U] [Module ℚ U]
+
+/-- Lattice conjugation on the complexification `ℂ ⊗[ℚ] U` of a rational vector space conjugates
+the scalar factor of a pure tensor. It is the unique conjugate-linear map fixing `1 ⊗ₜ u`. -/
+@[simp]
+theorem latticeConj_ratTensorMap_tmul (z : ℂ) (u : U) :
+    latticeConj (isBaseChange_ratTensorMap ℂ U) (z ⊗ₜ[ℚ] u) =
+      (starRingEnd ℂ) z ⊗ₜ[ℚ] u := by
+  have hz : z ⊗ₜ[ℚ] u = z • ratTensorMap ℂ U u := by
+    rw [ratTensorMap_apply, TensorProduct.smul_tmul', smul_eq_mul, mul_one]
+  rw [hz, map_smulₛₗ, latticeConj_ι, ratTensorMap_apply, TensorProduct.smul_tmul', smul_eq_mul,
+    mul_one]
+
+end RationalConjugation
+
+/-- The Hodge filtration induced on the `k`-th complex graded piece: the image of `F^p ∩ W_k`
+under the quotient map `W_k → W_k / W_{k-1}`. -/
+noncomputable def complexGradedF (WC F : ℤ → Submodule ℂ Vℂ) (k p : ℤ) :
+    Submodule ℂ (weightGradedComplex WC k) :=
+  ((F p ⊓ WC k).submoduleOf (WC k)).map ((WC (k - 1)).submoduleOf (WC k)).mkQ
+
+/-- The Hodge filtration induced on the complexification of the rational graded piece `grᵂ_k`,
+transported from the complex graded piece along `gradedComplexEquiv`. -/
+noncomputable def gradedF (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) (F : ℤ → Submodule ℂ Vℂ) (k p : ℤ) :
+    Submodule ℂ (ℂ ⊗[ℚ] weightGradedRat WQ k) :=
+  (complexGradedF (fun k ↦ rationalToComplexSubmodule hℚ hℂ (WQ k)) F k p).comap
+    (gradedComplexEquiv hℚ hℂ WQ hWQ k).toLinearMap
+
+/-- The induced filtration on a complex graded piece is decreasing. -/
+theorem complexGradedF_antitone (WC F : ℤ → Submodule ℂ Vℂ) (hF : Antitone F) (k : ℤ) :
+    Antitone (complexGradedF WC F k) := fun _ _ h ↦
+  Submodule.map_mono (Submodule.comap_mono (inf_le_inf_right _ (hF h)))
+
+/-- A step where the Hodge filtration is everything induces everything on a graded piece. -/
+@[simp]
+theorem complexGradedF_of_eq_top (WC F : ℤ → Submodule ℂ Vℂ) {k p : ℤ} (hp : F p = ⊤) :
+    complexGradedF WC F k p = ⊤ := by
+  rw [complexGradedF, hp, top_inf_eq, Submodule.submoduleOf_self, Submodule.map_top,
+    Submodule.range_mkQ]
+
+/-- A step where the Hodge filtration is zero induces zero on a graded piece. -/
+@[simp]
+theorem complexGradedF_of_eq_bot (WC F : ℤ → Submodule ℂ Vℂ) {k p : ℤ} (hp : F p = ⊥) :
+    complexGradedF WC F k p = ⊥ := by
+  have hbot : (⊥ : Submodule ℂ Vℂ).submoduleOf (WC k) = ⊥ := by
+    simp [Submodule.submoduleOf]
+  rw [complexGradedF, hp, bot_inf_eq, hbot, Submodule.map_bot]
+
+/-- The filtration induced on a complexified rational graded piece is decreasing. -/
+theorem gradedF_antitone (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) (F : ℤ → Submodule ℂ Vℂ) (hF : Antitone F)
+    (k : ℤ) : Antitone (gradedF hℚ hℂ WQ hWQ F k) := fun _ _ h ↦
+  Submodule.comap_mono (complexGradedF_antitone _ F hF k h)
+
+/-- A step where the Hodge filtration is everything induces everything on a graded piece. -/
+@[simp]
+theorem gradedF_of_eq_top (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) (F : ℤ → Submodule ℂ Vℂ) {k p : ℤ}
+    (hp : F p = ⊤) : gradedF hℚ hℂ WQ hWQ F k p = ⊤ := by
+  rw [gradedF, complexGradedF_of_eq_top _ F hp, Submodule.comap_top]
+
+/-- A step where the Hodge filtration is zero induces zero on a graded piece. -/
+@[simp]
+theorem gradedF_of_eq_bot (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+    (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) (F : ℤ → Submodule ℂ Vℂ) {k p : ℤ}
+    (hp : F p = ⊥) : gradedF hℚ hℂ WQ hWQ F k p = ⊥ := by
+  rw [gradedF, complexGradedF_of_eq_bot _ F hp, Submodule.comap_bot, LinearMap.ker_eq_bot]
+  exact (gradedComplexEquiv hℚ hℂ WQ hWQ k).injective
+
+section Concentrated
+
+variable (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+
+/-- A graded piece across which the weight filtration does not jump is zero. -/
+theorem subsingleton_weightGradedRat {WQ : ℤ → Submodule ℚ Vℚ} {k : ℤ} (h : WQ k ≤ WQ (k - 1)) :
+    Subsingleton (weightGradedRat WQ k) := by
+  obtain ⟨u⟩ := Submodule.unique_quotient_iff_eq_top.2 (Submodule.submoduleOf_eq_top.2 h)
+  exact u.instSubsingleton
+
+variable (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) {k : ℤ}
+  (hbot : WQ (k - 1) = ⊥) (htop : WQ k = ⊤)
+
+include hbot in
+private theorem submoduleOf_rationalToComplexSubmodule_eq_bot :
+    (rationalToComplexSubmodule hℚ hℂ (WQ (k - 1))).submoduleOf
+      (rationalToComplexSubmodule hℚ hℂ (WQ k)) = ⊥ := by
+  rw [hbot, rationalToComplexSubmodule_bot]
+  simp [Submodule.submoduleOf]
+
+/-- Across a step where the weight filtration jumps from zero to everything, the complexification
+of the rational graded piece `grᵂ_k` is the whole complex model. -/
+noncomputable def gradedEquivOfEqBotOfEqTop :
+    ℂ ⊗[ℚ] weightGradedRat WQ k ≃ₗ[ℂ] Vℂ :=
+  (gradedComplexEquiv hℚ hℂ WQ hWQ k).trans
+    ((Submodule.quotEquivOfEqBot _
+        (submoduleOf_rationalToComplexSubmodule_eq_bot hℚ hℂ WQ hbot)).trans
+      ((LinearEquiv.ofEq _ ⊤ (by rw [htop, rationalToComplexSubmodule_top])).trans
+        Submodule.topEquiv))
+
+@[simp]
+theorem gradedEquivOfEqBotOfEqTop_tmul_mk (z : ℂ) (x : WQ k) :
+    gradedEquivOfEqBotOfEqTop hℚ hℂ WQ hWQ hbot htop (z ⊗ₜ[ℚ] Submodule.Quotient.mk x) =
+      rationalToComplexLinearEquiv hℚ hℂ (z ⊗ₜ[ℚ] (x : Vℚ)) := by
+  simp [gradedEquivOfEqBotOfEqTop]
+
+/-- Across such a step, the filtration induced on the graded piece is the Hodge filtration
+itself, read through the identification above. -/
+theorem gradedF_eq_comap (F : ℤ → Submodule ℂ Vℂ) (p : ℤ) :
+    gradedF hℚ hℂ WQ hWQ F k p =
+      (F p).comap (gradedEquivOfEqBotOfEqTop hℚ hℂ WQ hWQ hbot htop).toLinearMap := by
+  have hker := submoduleOf_rationalToComplexSubmodule_eq_bot hℚ hℂ WQ hbot
+  ext t
+  simp only [gradedF, gradedEquivOfEqBotOfEqTop, Submodule.mem_comap, LinearEquiv.coe_coe,
+    LinearEquiv.trans_apply]
+  generalize gradedComplexEquiv hℚ hℂ WQ hWQ k t = q
+  induction q using Submodule.Quotient.induction_on with
+  | _ y =>
+    have hmemS : ∀ z : rationalToComplexSubmodule hℚ hℂ (WQ k),
+        z ∈ (F p ⊓ rationalToComplexSubmodule hℚ hℂ (WQ k)).submoduleOf
+            (rationalToComplexSubmodule hℚ hℂ (WQ k)) ↔ (z : Vℂ) ∈ F p := by
+      intro z
+      simp [Submodule.submoduleOf]
+    simp only [complexGradedF, Submodule.mem_map, Submodule.mkQ_apply,
+      Submodule.quotEquivOfEqBot_apply_mk, Submodule.topEquiv_apply, LinearEquiv.coe_ofEq_apply]
+    constructor
+    · rintro ⟨z, hz, hzy⟩
+      rw [Submodule.Quotient.eq, hker, Submodule.mem_bot, sub_eq_zero] at hzy
+      rw [← hzy]
+      exact (hmemS z).1 hz
+    · intro hy
+      exact ⟨y, (hmemS y).2 hy, rfl⟩
+
+/-- The identification of the graded piece with the whole complex model intertwines the canonical
+conjugation of the complexified rational graded piece with lattice conjugation. -/
+theorem gradedEquivOfEqBotOfEqTop_latticeConj (x : ℂ ⊗[ℚ] weightGradedRat WQ k) :
+    gradedEquivOfEqBotOfEqTop hℚ hℂ WQ hWQ hbot htop
+        (latticeConj (isBaseChange_ratTensorMap ℂ (weightGradedRat WQ k)) x) =
+      latticeConj hℂ (gradedEquivOfEqBotOfEqTop hℚ hℂ WQ hWQ hbot htop x) := by
+  have hfix : ∀ v : Vℤ,
+      ((gradedEquivOfEqBotOfEqTop hℚ hℂ WQ hWQ hbot htop).toLinearMap.comp
+          ((latticeConj (isBaseChange_ratTensorMap ℂ (weightGradedRat WQ k))).comp
+            (gradedEquivOfEqBotOfEqTop hℚ hℂ WQ hWQ hbot htop).symm.toLinearMap)) (ιℂ v) =
+        ιℂ v := by
+    intro v
+    have hmem : ιℚ v ∈ WQ k := by rw [htop]; trivial
+    have hpre : (gradedEquivOfEqBotOfEqTop hℚ hℂ WQ hWQ hbot htop).symm (ιℂ v) =
+        (1 : ℂ) ⊗ₜ[ℚ] Submodule.Quotient.mk ⟨ιℚ v, hmem⟩ := by
+      rw [LinearEquiv.symm_apply_eq, gradedEquivOfEqBotOfEqTop_tmul_mk]
+      simp
+    rw [LinearMap.comp_apply, LinearMap.comp_apply, LinearEquiv.coe_coe, LinearEquiv.coe_coe,
+      hpre, latticeConj_ratTensorMap_tmul, map_one, gradedEquivOfEqBotOfEqTop_tmul_mk]
+    simp
+  have hx := congrArg
+    (fun f : Vℂ →ₛₗ[starRingEnd ℂ] Vℂ ↦ f (gradedEquivOfEqBotOfEqTop hℚ hℂ WQ hWQ hbot htop x))
+    (latticeConj_unique hℂ _ hfix)
+  simpa only [LinearMap.comp_apply, LinearEquiv.coe_coe, LinearEquiv.symm_apply_apply] using hx
+
+end Concentrated
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Graded.lean
+++ b/TauCeti/Geometry/Hodge/Graded.lean
@@ -222,12 +222,6 @@ section Concentrated
 
 variable (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
 
-/-- A graded piece across which the weight filtration does not jump is zero. -/
-theorem subsingleton_weightGradedRat {WQ : ℤ → Submodule ℚ Vℚ} {k : ℤ} (h : WQ k ≤ WQ (k - 1)) :
-    Subsingleton (weightGradedRat WQ k) := by
-  obtain ⟨u⟩ := Submodule.unique_quotient_iff_eq_top.2 (Submodule.submoduleOf_eq_top.2 h)
-  exact u.instSubsingleton
-
 variable (WQ : ℤ → Submodule ℚ Vℚ) (hWQ : Monotone WQ) {k : ℤ}
   (hbot : WQ (k - 1) = ⊥) (htop : WQ k = ⊤)
 

--- a/TauCeti/Geometry/Hodge/Mixed.lean
+++ b/TauCeti/Geometry/Hodge/Mixed.lean
@@ -67,6 +67,7 @@ Hodge filtration `F` is decreasing and bounded on the complex model. Purity is i
 rational graded pieces: for every `k`, the filtration `TauCeti.Hodge.gradedF` induced by `F` on
 the complexification of `grᵂ_k = W_k / W_{k-1}` is the Hodge filtration of a pure Hodge structure
 of weight `k`. -/
+@[ext]
 structure MixedHodgeStructure (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ) where
   /-- The increasing rational weight filtration. -/
   WQ : ℤ → Submodule ℚ Vℚ
@@ -103,6 +104,12 @@ noncomputable def WC (k : ℤ) : Submodule ℂ Vℂ :=
 theorem WC_def (k : ℤ) :
     mhs.WC k = rationalToComplexSubmodule hℚ hℂ (mhs.WQ k) :=
   by rw [WC]
+
+/-- The complexified weight filtration is stable under lattice-induced conjugation. -/
+@[simp]
+theorem WC_conj (k : ℤ) :
+    (mhs.WC k).map (latticeConj hℂ) = mhs.WC k := by
+  simp [WC]
 
 /-- The complexified weight filtration is increasing. -/
 theorem WC_monotone : Monotone mhs.WC := fun _ _ h ↦
@@ -204,7 +211,8 @@ noncomputable def MixedHodgeStructure.ofPure (hs : HodgeStructure hℂ n) :
       rw [HodgeStructureOn.comap_F]
       exact (gradedF_eq_comap hℚ hℂ _ _ _ _ hs.F p).symm
     · have : Subsingleton (weightGradedRat (concentratedWeightFiltration Vℚ n) k) :=
-        subsingleton_weightGradedRat (concentratedWeightFiltration_le_pred hk)
+        Submodule.Quotient.subsingleton_iff.mpr
+          (Submodule.submoduleOf_eq_top.2 (concentratedWeightFiltration_le_pred hk))
       exact ⟨{ F := gradedF hℚ hℂ _ concentratedWeightFiltration_monotone hs.F k
                F_antitone := gradedF_antitone hℚ hℂ _ _ hs.F hs.F_antitone k
                F_top := ⟨0, Subsingleton.elim _ _⟩

--- a/TauCeti/Geometry/Hodge/Mixed.lean
+++ b/TauCeti/Geometry/Hodge/Mixed.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Hodge.Decomposition
+public import TauCeti.Geometry.Hodge.Graded
+public import TauCeti.Geometry.Hodge.Tate
+
+/-!
+# Mixed Hodge structures
+
+A mixed Hodge structure on an integral module is an increasing rational weight filtration `W`
+together with a decreasing complex Hodge filtration `F` inducing a pure Hodge structure of weight
+`k` on every rational graded piece `grᵂ_k = W_k / W_{k-1}`. The graded objects the purity
+condition is stated against are built in `TauCeti/Geometry/Hodge/Graded.lean`.
+
+Purity is recorded as the existence of a `TauCeti.Hodge.HodgeStructure` whose filtration *is* the
+induced one, rather than as a restatement of the pure axioms or as the bare existence of some
+Hodge structure on the graded piece: the former would duplicate the pure object, the latter would
+lose the link with `F`. As a consequence every result about pure Hodge structures — Hodge
+components, the Hodge decomposition, the Weil operator — applies to the graded pieces of a mixed
+Hodge structure through `TauCeti.Hodge.MixedHodgeStructure.gradedHodgeStructure`.
+
+A pure Hodge structure of weight `n` is a mixed Hodge structure whose weight filtration is
+concentrated in degree `n`; this is `TauCeti.Hodge.MixedHodgeStructure.ofPure`, and it makes the
+Tate structure `ℤ(m)` an explicit rank-one inhabitant.
+
+## Main declarations
+
+* `TauCeti.Hodge.MixedHodgeStructure`: the mixed Hodge structure itself.
+* `TauCeti.Hodge.MixedHodgeStructure.WC`: the complexified weight filtration.
+* `TauCeti.Hodge.MixedHodgeStructure.gradedHodgeStructure`: the pure Hodge structure of weight `k`
+  carried by the `k`-th graded piece.
+* `TauCeti.Hodge.MixedHodgeStructure.ofPure`: a pure Hodge structure viewed as a mixed one.
+* `TauCeti.Hodge.tateMixed`: the Tate structure as a mixed Hodge structure.
+
+## References
+
+Deligne, *Théorie de Hodge II*, 1.2.10 and 2.3.5; Peters–Steenbrink, *Mixed Hodge Structures*,
+Ch. 3. The signature of `MixedHodgeStructure` is adapted from the proposed definitions in
+[`HodgeStructures/Suggested.lean`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/HodgeStructures/Suggested.lean),
+whose definitive mathematical specification is the accompanying Hodge structures roadmap.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+open scoped TensorProduct
+
+universe u v w
+
+variable {Vℤ : Type u} {Vℚ : Type v} {Vℂ : Type w}
+variable [AddCommGroup Vℤ]
+variable [AddCommGroup Vℚ] [Module ℚ Vℚ]
+variable [AddCommGroup Vℂ] [Module ℂ Vℂ]
+variable {ιℚ : Vℤ →ₗ[ℤ] Vℚ} {ιℂ : Vℤ →ₗ[ℤ] Vℂ}
+
+/-- A mixed Hodge structure on an integral module `Vℤ` with rational and complex base-change
+models `Vℚ` and `Vℂ`.
+
+The weight filtration `WQ` is increasing, recorded rationally, and finite in both directions; the
+Hodge filtration `F` is decreasing and bounded on the complex model. Purity is imposed on the
+rational graded pieces: for every `k`, the filtration `TauCeti.Hodge.gradedF` induced by `F` on
+the complexification of `grᵂ_k = W_k / W_{k-1}` is the Hodge filtration of a pure Hodge structure
+of weight `k`. -/
+structure MixedHodgeStructure (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ) where
+  /-- The increasing rational weight filtration. -/
+  WQ : ℤ → Submodule ℚ Vℚ
+  /-- The weight filtration is increasing. -/
+  WQ_monotone : Monotone WQ
+  /-- The weight filtration is exhaustive: `W_k` is everything for `k` large. -/
+  WQ_top : ∃ k, WQ k = ⊤
+  /-- The weight filtration is separated: `W_k` is zero for `k` small. -/
+  WQ_bot : ∃ k, WQ k = ⊥
+  /-- The decreasing Hodge filtration on the complex model. -/
+  F : ℤ → Submodule ℂ Vℂ
+  /-- The Hodge filtration is decreasing. -/
+  F_antitone : Antitone F
+  /-- The Hodge filtration is exhaustive: `F^p` is everything for `p` small. -/
+  F_top : ∃ p, F p = ⊤
+  /-- The Hodge filtration is separated: `F^p` is zero for `p` large. -/
+  F_bot : ∃ p, F p = ⊥
+  /-- The `k`-th rational graded piece, complexified, is a pure Hodge structure of weight `k`
+  for the induced filtration. -/
+  graded_pure : ∀ k, ∃ hs : HodgeStructure
+      (isBaseChange_ratTensorMap ℂ (weightGradedRat WQ k)) k,
+    hs.F = gradedF hℚ hℂ WQ WQ_monotone F k
+
+namespace MixedHodgeStructure
+
+variable {hℚ : IsBaseChange ℚ ιℚ} {hℂ : IsBaseChange ℂ ιℂ} (mhs : MixedHodgeStructure hℚ hℂ)
+
+/-- The complexified weight filtration of a mixed Hodge structure. -/
+noncomputable def WC (k : ℤ) : Submodule ℂ Vℂ :=
+  rationalToComplexSubmodule hℚ hℂ (mhs.WQ k)
+
+/-- The complexified weight filtration is increasing. -/
+theorem WC_monotone : Monotone mhs.WC := fun _ _ h ↦
+  rationalToComplexSubmodule_mono hℚ hℂ (mhs.WQ_monotone h)
+
+/-- The complexified weight filtration is exhaustive. -/
+theorem WC_top : ∃ k, mhs.WC k = ⊤ := by
+  obtain ⟨k, hk⟩ := mhs.WQ_top
+  exact ⟨k, by rw [WC, hk, rationalToComplexSubmodule_top]⟩
+
+/-- The complexified weight filtration is separated. -/
+theorem WC_bot : ∃ k, mhs.WC k = ⊥ := by
+  obtain ⟨k, hk⟩ := mhs.WQ_bot
+  exact ⟨k, by rw [WC, hk, rationalToComplexSubmodule_bot]⟩
+
+/-- The pure Hodge structure of weight `k` carried by the complexification of the `k`-th rational
+graded piece. Its filtration is the induced one on the nose, so the whole pure theory applies to
+the graded pieces of a mixed Hodge structure. -/
+noncomputable def gradedHodgeStructure (k : ℤ) :
+    HodgeStructure (isBaseChange_ratTensorMap ℂ (weightGradedRat mhs.WQ k)) k where
+  F := gradedF hℚ hℂ mhs.WQ mhs.WQ_monotone mhs.F k
+  F_antitone := gradedF_antitone hℚ hℂ mhs.WQ mhs.WQ_monotone mhs.F mhs.F_antitone k
+  F_top := by
+    obtain ⟨p, hp⟩ := mhs.F_top
+    exact ⟨p, gradedF_of_eq_top hℚ hℂ mhs.WQ mhs.WQ_monotone mhs.F hp⟩
+  opposed := by
+    obtain ⟨hs, hF⟩ := mhs.graded_pure k
+    exact hF ▸ hs.opposed
+
+@[simp]
+theorem gradedHodgeStructure_F (k : ℤ) :
+    (mhs.gradedHodgeStructure k).F = gradedF hℚ hℂ mhs.WQ mhs.WQ_monotone mhs.F k := (rfl)
+
+/-- The Hodge decomposition of each graded piece of a mixed Hodge structure. -/
+theorem isInternal_gradedHodgeStructure_piece (k : ℤ) :
+    DirectSum.IsInternal (mhs.gradedHodgeStructure k).piece :=
+  HodgeStructureOn.isInternal_piece _
+
+end MixedHodgeStructure
+
+section OfPure
+
+variable (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ)
+
+variable (Vℚ) in
+/-- The weight filtration concentrated in a single degree `n`: everything from degree `n` on,
+zero below. It is the weight filtration of a pure Hodge structure of weight `n`. -/
+def concentratedWeightFiltration (n : ℤ) : ℤ → Submodule ℚ Vℚ :=
+  fun k ↦ if n ≤ k then ⊤ else ⊥
+
+variable {n : ℤ}
+
+@[simp]
+theorem concentratedWeightFiltration_of_le {k : ℤ} (h : n ≤ k) :
+    concentratedWeightFiltration Vℚ n k = ⊤ := by
+  simp [concentratedWeightFiltration, h]
+
+@[simp]
+theorem concentratedWeightFiltration_of_lt {k : ℤ} (h : k < n) :
+    concentratedWeightFiltration Vℚ n k = ⊥ := by
+  simp [concentratedWeightFiltration, Int.not_le.mpr h]
+
+theorem concentratedWeightFiltration_monotone :
+    Monotone (concentratedWeightFiltration Vℚ n) := by
+  intro j k hjk
+  rcases lt_or_ge j n with hj | hj
+  · rw [concentratedWeightFiltration_of_lt hj]
+    exact bot_le
+  · rw [concentratedWeightFiltration_of_le hj, concentratedWeightFiltration_of_le (hj.trans hjk)]
+
+/-- Away from its single jump, the concentrated weight filtration is constant. -/
+theorem concentratedWeightFiltration_le_pred {k : ℤ} (hk : k ≠ n) :
+    concentratedWeightFiltration Vℚ n k ≤ concentratedWeightFiltration Vℚ n (k - 1) := by
+  rcases lt_or_ge k n with hj | hj
+  · rw [concentratedWeightFiltration_of_lt hj]
+    exact bot_le
+  · rw [concentratedWeightFiltration_of_le (by omega : n ≤ k - 1)]
+    exact le_top
+
+/-- **A pure Hodge structure is a mixed Hodge structure.** Its weight filtration is concentrated
+in the single degree `n`, so the only nonzero graded piece is `grᵂ_n`, which is the whole space
+with the given filtration. This exhibits the mixed axioms as satisfiable. -/
+noncomputable def MixedHodgeStructure.ofPure (hs : HodgeStructure hℂ n) :
+    MixedHodgeStructure hℚ hℂ where
+  WQ := concentratedWeightFiltration Vℚ n
+  WQ_monotone := concentratedWeightFiltration_monotone
+  WQ_top := ⟨n, concentratedWeightFiltration_of_le le_rfl⟩
+  WQ_bot := ⟨n - 1, concentratedWeightFiltration_of_lt (by omega)⟩
+  F := hs.F
+  F_antitone := hs.F_antitone
+  F_top := hs.F_top
+  F_bot := hs.F_bot
+  graded_pure k := by
+    rcases eq_or_ne k n with rfl | hk
+    · refine ⟨hs.comap (gradedEquivOfEqBotOfEqTop hℚ hℂ _ concentratedWeightFiltration_monotone
+        (concentratedWeightFiltration_of_lt (by omega)) (concentratedWeightFiltration_of_le le_rfl))
+        (fun x ↦ by simpa using gradedEquivOfEqBotOfEqTop_latticeConj hℚ hℂ _ _ _ _ x), ?_⟩
+      funext p
+      rw [HodgeStructureOn.comap_F]
+      exact (gradedF_eq_comap hℚ hℂ _ _ _ _ hs.F p).symm
+    · have : Subsingleton (weightGradedRat (concentratedWeightFiltration Vℚ n) k) :=
+        subsingleton_weightGradedRat (concentratedWeightFiltration_le_pred hk)
+      exact ⟨{ F := gradedF hℚ hℂ _ concentratedWeightFiltration_monotone hs.F k
+               F_antitone := gradedF_antitone hℚ hℂ _ _ hs.F hs.F_antitone k
+               F_top := ⟨0, Subsingleton.elim _ _⟩
+               opposed := fun _ ↦ ⟨disjoint_iff.2 (Subsingleton.elim _ _),
+                 codisjoint_iff.2 (Subsingleton.elim _ _)⟩ }, rfl⟩
+
+@[simp]
+theorem MixedHodgeStructure.ofPure_WQ (hs : HodgeStructure hℂ n) :
+    (MixedHodgeStructure.ofPure (Vℚ := Vℚ) hℚ hℂ hs).WQ = concentratedWeightFiltration Vℚ n :=
+  (rfl)
+
+@[simp]
+theorem MixedHodgeStructure.ofPure_F (hs : HodgeStructure hℂ n) :
+    (MixedHodgeStructure.ofPure (Vℚ := Vℚ) hℚ hℂ hs).F = hs.F :=
+  (rfl)
+
+/-- The Tate structure `ℤ(m)` as a mixed Hodge structure: a rank-one example whose weight
+filtration jumps in degree `-2m`. -/
+noncomputable def tateMixed (m : ℤ) :
+    MixedHodgeStructure (Vℤ := ℤ) (Vℚ := ℚ) (IsBaseChange.linearMap ℤ ℚ)
+      isBaseChange_tateLatticeMap :=
+  MixedHodgeStructure.ofPure _ _ (tate m)
+
+end OfPure
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Mixed.lean
+++ b/TauCeti/Geometry/Hodge/Mixed.lean
@@ -106,7 +106,6 @@ theorem WC_def (k : ℤ) :
   by rw [WC]
 
 /-- The complexified weight filtration is stable under lattice-induced conjugation. -/
-@[simp]
 theorem WC_conj (k : ℤ) :
     (mhs.WC k).map (latticeConj hℂ) = mhs.WC k := by
   simp [WC]

--- a/TauCeti/Geometry/Hodge/Mixed.lean
+++ b/TauCeti/Geometry/Hodge/Mixed.lean
@@ -98,6 +98,12 @@ variable {hℚ : IsBaseChange ℚ ιℚ} {hℂ : IsBaseChange ℂ ιℂ} (mhs : 
 noncomputable def WC (k : ℤ) : Submodule ℂ Vℂ :=
   rationalToComplexSubmodule hℚ hℂ (mhs.WQ k)
 
+/-- The complex weight filtration is obtained by complexifying the rational weight filtration. -/
+@[simp]
+theorem WC_def (k : ℤ) :
+    mhs.WC k = rationalToComplexSubmodule hℚ hℂ (mhs.WQ k) :=
+  by rw [WC]
+
 /-- The complexified weight filtration is increasing. -/
 theorem WC_monotone : Monotone mhs.WC := fun _ _ h ↦
   rationalToComplexSubmodule_mono hℚ hℂ (mhs.WQ_monotone h)

--- a/TauCeti/Geometry/Hodge/Structure.lean
+++ b/TauCeti/Geometry/Hodge/Structure.lean
@@ -34,6 +34,8 @@ Buzzard, and Joël Riou.
 * `TauCeti.Hodge.HodgeStructureOn.piece`: the Hodge component `H^{p,n-p}`.
 * `TauCeti.Hodge.HodgeStructureOn.conj_piece`: conjugation exchanges `H^{p,n-p}` and
   `H^{n-p,p}`, with `TauCeti.Hodge.HodgeStructureOn.conj_mem_piece` its elementwise form.
+* `TauCeti.Hodge.HodgeStructureOn.comap`: transport of a Hodge structure along a linear
+  equivalence intertwining the conjugations.
 * `TauCeti.Hodge.HodgeStructureOn.IsEffective`: the filtration is supported in bidegrees with
   both indices nonnegative.
 -/
@@ -179,6 +181,50 @@ theorem conj_piece (hs : HodgeStructureOn W ω n) (p : ℤ) :
 theorem conj_mem_piece (hs : HodgeStructureOn W ω n) {p : ℤ} {x : W} (hx : x ∈ hs.piece p) :
     ω.toEquiv x ∈ hs.piece (n - p) :=
   hs.conj_piece p ▸ Submodule.mem_map_of_mem hx
+
+section Comap
+
+variable {W' : Type*} [AddCommGroup W'] [Module ℂ W'] {ω' : Conjugation W'}
+
+/-- Pulling a Hodge structure back along a linear equivalence that intertwines the two
+conjugations. This is how a Hodge structure is transported between two models of the same complex
+vector space, for instance from a complexification to a graded piece identified with it. -/
+noncomputable def comap (e : W ≃ₗ[ℂ] W')
+    (he : ∀ x, e (ω.toEquiv x) = ω'.toEquiv (e x)) (hs : HodgeStructureOn W' ω' n) :
+    HodgeStructureOn W ω n where
+  F p := (hs.F p).comap e.toLinearMap
+  F_antitone _ _ h := Submodule.comap_mono (hs.F_antitone h)
+  F_top := by
+    obtain ⟨p, hp⟩ := hs.F_top
+    exact ⟨p, by rw [hp, Submodule.comap_top]⟩
+  opposed p := by
+    have hmap : ((hs.F (n + 1 - p)).comap e.toLinearMap).map ω.toEquiv.toLinearMap =
+        ((hs.F (n + 1 - p)).map ω'.toEquiv.toLinearMap).comap e.toLinearMap := by
+      ext y
+      simp only [Submodule.mem_map, Submodule.mem_comap, LinearEquiv.coe_coe]
+      constructor
+      · rintro ⟨x, hx, rfl⟩
+        exact ⟨e x, hx, (he x).symm⟩
+      · rintro ⟨z, hz, hzy⟩
+        refine ⟨ω.toEquiv y, ?_, ω.apply_apply y⟩
+        rw [he y, ← hzy, ω'.apply_apply]
+        exact hz
+    rw [hmap]
+    refine ⟨?_, ?_⟩
+    · rw [disjoint_iff, ← Submodule.comap_inf, (hs.opposed p).disjoint.eq_bot,
+        Submodule.comap_bot, LinearMap.ker_eq_bot]
+      exact e.injective
+    · rw [codisjoint_iff, Submodule.comap_equiv_eq_map_symm, Submodule.comap_equiv_eq_map_symm,
+        ← Submodule.map_sup, (hs.opposed p).codisjoint.eq_top, Submodule.map_top,
+        LinearMap.range_eq_top]
+      exact e.symm.surjective
+
+@[simp]
+theorem comap_F (e : W ≃ₗ[ℂ] W') (he : ∀ x, e (ω.toEquiv x) = ω'.toEquiv (e x))
+    (hs : HodgeStructureOn W' ω' n) (p : ℤ) :
+    (hs.comap e he).F p = (hs.F p).comap e.toLinearMap := (rfl)
+
+end Comap
 
 /-- A weight-`n` Hodge structure is effective when its Hodge filtration begins at `F 0 = ⊤`.
 Equivalently, it ends at `F (n + 1) = ⊥`, and its Hodge components can occur only when both

--- a/TauCeti/RingTheory/IsTensorProduct.lean
+++ b/TauCeti/RingTheory/IsTensorProduct.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Module.LinearMap.Rat
+public import Mathlib.RingTheory.IsTensorProduct
+
+/-!
+# Base change of a rational vector space along `ℤ → ℚ`
+
+A `ℚ`-vector space is already its own extension of scalars from `ℤ` to `ℚ`: any additive map out
+of it into a `ℚ`-module is automatically `ℚ`-linear, which is exactly the universal property
+`IsBaseChange` asks for. Consequently, for a `ℚ`-algebra `A`, the concrete tensor product
+`A ⊗[ℚ] U` is a base change of `U` along `ℤ → A`, not merely along `ℚ → A`.
+
+This is what allows a `ℚ`-vector space to be fed to constructions that take an integral module
+together with an abstract model of its complexification, such as the conjugation and the pure
+Hodge structures of `TauCeti/Geometry/Hodge/`.
+
+## Main results
+
+* `TauCeti.isBaseChange_rat_id`: the identity of a `ℚ`-vector space, viewed as `ℤ`-linear,
+  exhibits it as its own rationalification.
+* `TauCeti.isBaseChange_ratTensorMap`: for a `ℚ`-algebra `A`, the map `u ↦ 1 ⊗ₜ u` exhibits
+  `A ⊗[ℚ] U` as the base change of `U` along `ℤ → A`.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped TensorProduct
+
+universe u v
+
+/-- A `ℚ`-vector space is its own rationalification: the identity map, viewed as a map of
+`ℤ`-modules, exhibits `U` as the extension of scalars of `U` along `ℤ → ℚ`. -/
+theorem isBaseChange_rat_id (U : Type u) [AddCommGroup U] [Module ℚ U] :
+    IsBaseChange ℚ ((LinearMap.id : U →ₗ[ℚ] U).restrictScalars ℤ) := by
+  refine IsBaseChange.of_lift_unique _ fun Q _ _ _ _ g ↦ ?_
+  -- A `ℚ`-module is automatically an additive group, which `AddMonoidHom.toRatLinearMap` needs.
+  let _ : AddCommGroup Q := Module.addCommMonoidToAddCommGroup ℚ
+  refine ⟨g.toAddMonoidHom.toRatLinearMap, ?_, fun g' hg' ↦ ?_⟩
+  · ext x
+    rfl
+  · ext x
+    exact congrFun (congrArg (fun h : U →ₗ[ℤ] Q ↦ (h : U → Q)) hg') x
+
+variable (A : Type v) [CommRing A] [Algebra ℚ A]
+variable (U : Type u) [AddCommGroup U] [Module ℚ U]
+
+/-- The canonical map of a rational vector space into its scalar extension `A ⊗[ℚ] U`, viewed as
+a map of `ℤ`-modules. -/
+def ratTensorMap : U →ₗ[ℤ] A ⊗[ℚ] U :=
+  ((TensorProduct.mk ℚ A U 1).restrictScalars ℤ).comp
+    ((LinearMap.id : U →ₗ[ℚ] U).restrictScalars ℤ)
+
+@[simp]
+theorem ratTensorMap_apply (u : U) : ratTensorMap A U u = 1 ⊗ₜ[ℚ] u := (rfl)
+
+/-- For a `ℚ`-algebra `A`, the tensor product `A ⊗[ℚ] U` of a rational vector space is a base
+change of `U` along `ℤ → A`, and not only along `ℚ → A`. -/
+theorem isBaseChange_ratTensorMap : IsBaseChange A (ratTensorMap A U) :=
+  (isBaseChange_rat_id U).comp (TensorProduct.isBaseChange ℚ U A)
+
+end TauCeti


### PR DESCRIPTION
This PR defines `MixedHodgeStructure`, the object of Layer **L2** of `TauCetiRoadmap/HodgeStructures/README.md` ("Mixed Hodge structures; strictness"), together with the graded machinery its purity axiom is stated against: the rational graded piece `grᵂ_k = W_k / W_{k-1}`, the proved isomorphism `gradedComplexEquiv : ℂ ⊗[ℚ] grᵂ_k ≃ (W_k)_ℂ / (W_{k-1})_ℂ` that the roadmap names as an L2 target ("complexification commutes with the quotient"), and the Hodge filtration `gradedF` induced on that complexification. Nothing on `main` and no open PR touches L2 — #4074 and #4133 serve the L1 semisimplicity milestone and #4129 closed L3 — so this is the first step of the mixed theory. After this PR, the L2 milestone still needs Deligne's `(p,q)`-bigrading `I^{p,q}` with its recovery and conjugation relations, and then strictness of a morphism of mixed Hodge structures for both filtrations.

The graded piece is taken rationally and the pure structure lives on `ℂ ⊗[ℚ] grᵂ_k` rather than on the complex quotient, because that model carries a conjugation for free: `TauCeti.isBaseChange_ratTensorMap` shows that for a `ℚ`-vector space `U` the tensor `ℂ ⊗[ℚ] U` is a base change of `U` along `ℤ → ℂ`, not merely along `ℚ → ℂ`, so the repository's `latticeConj`, its uniqueness lemma and the whole `HodgeStructure` interface apply to it verbatim. That rests on the general fact that a `ℚ`-vector space is its own rationalification (`TauCeti.isBaseChange_rat_id`: an additive map out of it into a `ℚ`-module is automatically `ℚ`-linear, which is exactly the `IsBaseChange` universal property), composed with `IsBaseChange.comp`. The comparison `gradedComplexEquiv` is `TensorProduct.AlgebraTensorModule.tensorQuotientEquiv` followed by `Submodule.Quotient.equiv`, whose transport hypothesis is `map_range_lTensor_submoduleOf`: complexifying the inclusion of one rational subspace into a larger one has the complexification of the smaller one as its range.

Purity of a graded piece is recorded as `∃ hs : HodgeStructure …, hs.F = gradedF …` — the existence of a pure Hodge structure whose filtration *is* the induced one. The roadmap's sketch proposes `Nonempty (HodgeStructureOn …)`, but that would lose the link with `F` and admit filtrations that are not pure; restating the four pure axioms would instead duplicate the existing object. The chosen form is the literal reading, and it makes the whole pure theory available on graded pieces through `MixedHodgeStructure.gradedHodgeStructure`, whose filtration is the induced one on the nose; `isInternal_gradedHodgeStructure_piece` records the Hodge decomposition of each graded piece as an immediate consequence. Two of the four pure conditions turn out to be automatic — `gradedF_antitone`, `gradedF_of_eq_top` and `gradedF_of_eq_bot` derive them from the ambient filtration — so only opposedness is genuine input.

Non-vacuity is settled inside the PR. `MixedHodgeStructure.ofPure` exhibits a pure Hodge structure of weight `n` as a mixed one whose weight filtration is concentrated in degree `n`: the graded pieces away from `n` are zero, and at `n` the identification `gradedEquivOfEqBotOfEqTop` carries the ambient structure over, compatibly with the conjugations (`gradedEquivOfEqBotOfEqTop_latticeConj`, proved from uniqueness of `latticeConj`) and with the filtration (`gradedF_eq_comap`). Applied to the already-formalized Tate structure this gives `tateMixed`, an explicit rank-one mixed Hodge structure. The transport itself is factored out as `HodgeStructureOn.comap`, pullback of a pure Hodge structure along a linear equivalence intertwining the conjugations, which belongs with the pure object in `Structure.lean`.

New files: `TauCeti/Geometry/Hodge/Graded.lean` (300 lines), `TauCeti/Geometry/Hodge/Mixed.lean` (227 lines), `TauCeti/RingTheory/IsTensorProduct.lean` (69 lines); `TauCeti/Geometry/Hodge/Structure.lean` grows by 44. No Mathlib source is vendored; the proofs consume `IsBaseChange`, `Submodule.baseChange`/`toBaseChange`, `TensorProduct.AlgebraTensorModule.tensorQuotientEquiv` and `Submodule.Quotient.equiv`. The signatures of `weightGradedRat`, `gradedComplexEquiv`, `gradedF` and `MixedHodgeStructure` are adapted from the roadmap's formal companion `HodgeStructures/Suggested.lean`, credited in both module docstrings; the proofs given here are new, and are run against the abstract base-change interface. The mathematics follows Deligne, *Théorie de Hodge II*, §1.2.1 and 2.3.5, and Peters–Steenbrink, *Mixed Hodge Structures*, Ch. 3.

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"mixed-hodge-structure"}-->

🤖 Prepared with Claude Code
