### PR TITLE
feat: the counting lemma for homomorphism densities of graphons

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/Counting.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Counting.lean
@@ -1,0 +1,279 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.HomDensity.Basic
+public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
+public import TauCeti.MeasureTheory.Constructions.Pi
+
+/-!
+# The counting lemma
+
+The **counting lemma** bounds the gap between the homomorphism densities of a finite graph `F` in
+two graphons on one carrier by the cut norm of their difference:
+
+`|t(F, U) - t(F, W)| ≤ e(F) · ‖U - W‖□`.
+
+It is what makes the cut norm the right notion of distance for dense graph limits: the graph
+observables `t(F, ·)` are Lipschitz in it, uniformly in everything but the number of edges of `F`.
+
+**The proof is a telescope over the edges.** Swap the edges of `F` from `W` to `U` one at a time.
+Each swap changes the integrand at a single edge `e₀ = s(a, b)`, weighted by the product of edge
+factors over the *other* edges of `F`; the gap it contributes is bounded by `‖U - W‖□`, and there
+are `e(F)` swaps. The hybrid stage is indexed by a subset `D` of the edges — the edges already
+swapped — so the induction runs over `D` with the ambient edge set `E` fixed. That is the shape the
+argument needs: an induction on `E` alone would have to carry the already-fixed edge factor of the
+edge being peeled off, which is exactly the weight the single-edge bound consumes.
+
+**One swap is a rectangle test.** `F` is a *simple* graph, so no edge other than `e₀` joins `a` to
+`b`: every other edge misses `a`, or misses `b`, or both. Refreshing the two coordinates `a` and `b`
+(`TauCeti.MeasureTheory.integral_pi_eq_integral_integral_update`) therefore leaves an inner double
+integral whose weights *factor* — one `[0, 1]`-valued function of the new `a`-coordinate, one of the
+new `b`-coordinate — and `abs_testIntegral_le_cutNorm` bounds such a pairing by the cut norm, with
+no loss of constant. The outer integral is over a probability measure, so the bound survives it.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.counting_lemma` — the forward counting lemma
+  `|t(F, U) - t(F, W)| ≤ e(F) · ‖U - W‖□`;
+* `TauCeti.DenseGraphLimits.homDensity_eq_of_cutNorm_sub_eq_zero` — its vanishing case, the
+  same-carrier core of the forward separation direction.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 2 — the forward counting lemma; the
+  signature follows `TauCetiRoadmap/DenseGraphLimits/Suggested.lean`. The cross-carrier coupling
+  form `counting_lemma_coupling`, the descent `homDensityOnSpace` to `GraphonSpace`, weak
+  regularity and total boundedness are separate targets and are not built here.
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), Lemma 10.23.
+* S. Janson, *Graphons, cut norm and distance, couplings and rearrangements*, NYJM Monographs 4
+  (2013), Lemma 7.2.
+-/
+
+public section
+
+noncomputable section
+
+open Function MeasureTheory Set
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+  {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **The analytic core of one swap.** If refreshing the two distinct coordinates `a` and `b`
+factors the integrand as `p z u * q z t * K u t` with `[0, 1]`-valued weights, then the integral is
+bounded by the cut norm of `K`: the inner double integral is a `[0, 1]`-test pairing, and the outer
+integral averages over a probability measure. -/
+private theorem abs_integral_le_cutNorm_of_factors (K : SymmKernel Ω μ) {a b : V} (hab : a ≠ b)
+    (f : (V → Ω) → ℝ) (hf : Integrable f (Measure.pi fun _ : V => μ))
+    (p q : (V → Ω) → Ω → ℝ) (hpm : ∀ z, Measurable (p z)) (hqm : ∀ z, Measurable (q z))
+    (hp1 : ∀ z u, p z u ∈ Icc (0 : ℝ) 1) (hq1 : ∀ z t, q z t ∈ Icc (0 : ℝ) 1)
+    (hfac : ∀ z u t, f (update (update z a u) b t) = p z u * q z t * K u t) :
+    |∫ x, f x ∂(Measure.pi fun _ : V => μ)| ≤ cutNorm μ K := by
+  rw [← TauCeti.MeasureTheory.integral_pi_eq_integral_integral_update μ hab hf]
+  have hbound : ∀ z : V → Ω,
+      ‖∫ w : Ω × Ω, f (update (update z a w.1) b w.2) ∂μ.prod μ‖ ≤ cutNorm μ K := by
+    intro z
+    have hinner : (∫ w : Ω × Ω, f (update (update z a w.1) b w.2) ∂μ.prod μ)
+        = K.testIntegral μ (p z) (q z) := by
+      rw [SymmKernel.testIntegral_def]
+      exact integral_congr_ae (ae_of_all _ fun w => hfac z w.1 w.2)
+    rw [Real.norm_eq_abs, hinner]
+    exact abs_testIntegral_le_cutNorm μ K (hpm z) (hqm z) (hp1 z) (hq1 z)
+  have h := norm_integral_le_of_norm_le_const
+    (μ := Measure.pi fun _ : V => μ) (ae_of_all _ hbound)
+  simpa [Real.norm_eq_abs] using h
+
+/-- **The single-edge bound, with the edge spelled out.** The difference of two graphons at the edge
+`s(a, b)`, weighted by edge factors over any finite family of *other* edges, integrates to at most
+the cut norm of the difference.
+
+Every other edge misses `a` or misses `b` — it cannot contain both, since it would then *be*
+`s(a, b)` — so, once the coordinates `a` and `b` are refreshed, the weight splits into a function of
+the new `a`-coordinate times a function of the new `b`-coordinate. -/
+private theorem abs_integral_prod_mul_sub_le_aux (E : Finset (Sym2 V)) (G : Sym2 V → Graphon Ω μ)
+    (U W : Graphon Ω μ) {a b : V} (hab : a ≠ b) :
+    |∫ x, (∏ e ∈ E.erase s(a, b), edgeFactor (G e) x e)
+        * (U (x a) (x b) - W (x a) (x b)) ∂(Measure.pi fun _ : V => μ)|
+      ≤ cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
+  have hpair : Measurable fun x : V → Ω => (x a, x b) :=
+    (measurable_pi_apply a).prodMk (measurable_pi_apply b)
+  -- the edges other than `s(a, b)`, split by whether they contain `b`
+  have hmem_b : ∀ e ∈ (E.erase s(a, b)).filter (fun e => b ∉ e), b ∉ e := by
+    intro e he
+    exact (Finset.mem_filter.1 he).2
+  have hmem_a : ∀ e ∈ (E.erase s(a, b)).filter (fun e => ¬ b ∉ e), a ∉ e := by
+    intro e he
+    obtain ⟨heE, hb⟩ := Finset.mem_filter.1 he
+    rw [not_not] at hb
+    intro ha
+    exact Finset.ne_of_mem_erase heE ((Sym2.mem_and_mem_iff hab).1 ⟨ha, hb⟩)
+  refine abs_integral_le_cutNorm_of_factors (U.toSymmKernel - W.toSymmKernel) hab _ ?_
+    (fun z u => ∏ e ∈ (E.erase s(a, b)).filter (fun e => b ∉ e),
+      edgeFactor (G e) (update z a u) e)
+    (fun z t => ∏ e ∈ (E.erase s(a, b)).filter (fun e => ¬ b ∉ e),
+      edgeFactor (G e) (update z b t) e)
+    (fun z => (measurable_prod_edgeFactor _ G).comp (measurable_update z))
+    (fun z => (measurable_prod_edgeFactor _ G).comp (measurable_update z))
+    (fun z u => ⟨prod_edgeFactor_nonneg _ G _, prod_edgeFactor_le_one _ G _⟩)
+    (fun z t => ⟨prod_edgeFactor_nonneg _ G _, prod_edgeFactor_le_one _ G _⟩) ?_
+  · -- integrability: the integrand is measurable and bounded by `1`
+    have hm : Measurable fun x : V → Ω => U (x a) (x b) - W (x a) (x b) :=
+      (U.measurable.comp hpair).sub (W.measurable.comp hpair)
+    refine Integrable.mono' (integrable_const 1)
+      ((measurable_prod_edgeFactor _ G).mul hm).aestronglyMeasurable
+      (Filter.Eventually.of_forall fun x => ?_)
+    rw [Real.norm_eq_abs, abs_mul]
+    have h1 : |∏ e ∈ E.erase s(a, b), edgeFactor (G e) x e| ≤ 1 := by
+      rw [abs_of_nonneg (prod_edgeFactor_nonneg _ G x)]
+      exact prod_edgeFactor_le_one _ G x
+    have h2 : |U (x a) (x b) - W (x a) (x b)| ≤ 1 := by
+      rw [abs_le]
+      exact ⟨by linarith [U.nonneg (x a) (x b), W.le_one (x a) (x b)],
+        by linarith [U.le_one (x a) (x b), W.nonneg (x a) (x b)]⟩
+    calc |∏ e ∈ E.erase s(a, b), edgeFactor (G e) x e| * |U (x a) (x b) - W (x a) (x b)|
+        ≤ 1 * 1 := mul_le_mul h1 h2 (abs_nonneg _) zero_le_one
+      _ = 1 := one_mul 1
+  · -- the factorisation after refreshing the two coordinates
+    intro z u t
+    have hva : update (update z a u) b t a = u := by
+      rw [update_of_ne hab t (update z a u), update_self a u z]
+    have hvb : update (update z a u) b t b = t := update_self b t (update z a u)
+    have hsplit : (∏ e ∈ E.erase s(a, b), edgeFactor (G e) (update (update z a u) b t) e)
+        = (∏ e ∈ (E.erase s(a, b)).filter (fun e => b ∉ e),
+            edgeFactor (G e) (update z a u) e)
+          * ∏ e ∈ (E.erase s(a, b)).filter (fun e => ¬ b ∉ e),
+              edgeFactor (G e) (update z b t) e := by
+      rw [← Finset.prod_filter_mul_prod_filter_not (E.erase s(a, b)) (fun e => b ∉ e)]
+      refine congrArg₂ (· * ·) (Finset.prod_congr rfl fun e he => ?_)
+        (Finset.prod_congr rfl fun e he => ?_)
+      · refine edgeFactor_congr (G e) fun v hv => ?_
+        have hvb' : v ≠ b := by rintro rfl; exact hmem_b e he hv
+        exact update_of_ne hvb' t (update z a u)
+      · refine edgeFactor_congr (G e) fun v hv => ?_
+        have hva' : v ≠ a := by rintro rfl; exact hmem_a e he hv
+        by_cases hvb' : v = b
+        · subst hvb'
+          rw [update_self, update_self]
+        · rw [update_of_ne hvb' t (update z a u), update_of_ne hva' u z,
+            update_of_ne hvb' t z]
+    -- `(U - W) u t` is the pointwise difference, by construction of the kernel module structure
+    have hK : (U.toSymmKernel - W.toSymmKernel) u t = U u t - W u t := by
+      simp [SymmKernel.coe_sub]
+    rw [hsplit, hva, hvb, hK]
+
+/-- **The single-edge bound.** The same statement with the swapped edge given as a non-diagonal
+`Sym2` element, which is how the telescope below meets it. -/
+private theorem abs_integral_prod_mul_sub_le (E : Finset (Sym2 V)) (G : Sym2 V → Graphon Ω μ)
+    (U W : Graphon Ω μ) (e₀ : Sym2 V) (he₀ : ¬ e₀.IsDiag) :
+    |∫ x, (∏ e ∈ E.erase e₀, edgeFactor (G e) x e)
+        * (edgeFactor U x e₀ - edgeFactor W x e₀) ∂(Measure.pi fun _ : V => μ)|
+      ≤ cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
+  revert he₀
+  induction e₀ using Sym2.ind with
+  | _ a b =>
+    intro he₀
+    have hab : a ≠ b := fun h => he₀ (Sym2.mk_isDiag_iff.2 h)
+    simpa using abs_integral_prod_mul_sub_le_aux E G U W hab
+
+/-- **The telescope.** Swapping the edges in a subset `D` of `E` from `W` to `U`, one edge at a
+time, costs at most `‖U - W‖□` per swap. -/
+private theorem abs_integral_hybrid_sub_le (E : Finset (Sym2 V)) (hE : ∀ e ∈ E, ¬ e.IsDiag)
+    (U W : Graphon Ω μ) (D : Finset (Sym2 V)) : D ⊆ E →
+    |(∫ x, ∏ e ∈ E, edgeFactor (if e ∈ D then U else W) x e ∂(Measure.pi fun _ : V => μ))
+        - ∫ x, ∏ e ∈ E, edgeFactor W x e ∂(Measure.pi fun _ : V => μ)|
+      ≤ D.card * cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
+  induction D using Finset.induction_on with
+  | empty => intro _; simp
+  | @insert e₀ D' he₀D' ih =>
+    intro hsub
+    have he₀E : e₀ ∈ E := hsub (Finset.mem_insert_self e₀ D')
+    have hD'E : D' ⊆ E := (Finset.subset_insert _ _).trans hsub
+    have key : ∀ x : V → Ω,
+        (∏ e ∈ E, edgeFactor (if e ∈ insert e₀ D' then U else W) x e)
+          - (∏ e ∈ E, edgeFactor (if e ∈ D' then U else W) x e)
+        = (∏ e ∈ E.erase e₀, edgeFactor (if e ∈ D' then U else W) x e)
+            * (edgeFactor U x e₀ - edgeFactor W x e₀) := by
+      intro x
+      rw [← Finset.prod_erase_mul E
+          (fun e => edgeFactor (if e ∈ insert e₀ D' then U else W) x e) he₀E,
+        ← Finset.prod_erase_mul E (fun e => edgeFactor (if e ∈ D' then U else W) x e) he₀E]
+      have hcongr : ∀ e ∈ E.erase e₀,
+          edgeFactor (if e ∈ insert e₀ D' then U else W) x e
+            = edgeFactor (if e ∈ D' then U else W) x e := by
+        intro e he
+        have hmem : (e ∈ insert e₀ D') ↔ e ∈ D' := by
+          simp [Finset.mem_insert, Finset.ne_of_mem_erase he]
+        simp only [hmem]
+      rw [Finset.prod_congr rfl hcongr]
+      have h1 : (if e₀ ∈ insert e₀ D' then U else W) = U := by simp
+      have h2 : (if e₀ ∈ D' then U else W) = W := by simp [he₀D']
+      rw [h1, h2]
+      ring
+    have hstep :
+        |(∫ x, ∏ e ∈ E, edgeFactor (if e ∈ insert e₀ D' then U else W) x e
+              ∂(Measure.pi fun _ : V => μ))
+            - ∫ x, ∏ e ∈ E, edgeFactor (if e ∈ D' then U else W) x e
+              ∂(Measure.pi fun _ : V => μ)|
+          ≤ cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
+      rw [← integral_sub (integrable_prod_edgeFactor E _) (integrable_prod_edgeFactor E _)]
+      have hfun : (fun x : V → Ω =>
+            (∏ e ∈ E, edgeFactor (if e ∈ insert e₀ D' then U else W) x e)
+              - ∏ e ∈ E, edgeFactor (if e ∈ D' then U else W) x e)
+          = fun x : V → Ω => (∏ e ∈ E.erase e₀, edgeFactor (if e ∈ D' then U else W) x e)
+              * (edgeFactor U x e₀ - edgeFactor W x e₀) := funext key
+      rw [hfun]
+      exact abs_integral_prod_mul_sub_le E _ U W e₀ (hE e₀ he₀E)
+    have htri := abs_sub_le
+      (∫ x, ∏ e ∈ E, edgeFactor (if e ∈ insert e₀ D' then U else W) x e
+        ∂(Measure.pi fun _ : V => μ))
+      (∫ x, ∏ e ∈ E, edgeFactor (if e ∈ D' then U else W) x e
+        ∂(Measure.pi fun _ : V => μ))
+      (∫ x, ∏ e ∈ E, edgeFactor W x e ∂(Measure.pi fun _ : V => μ))
+    have hcard : ((insert e₀ D').card : ℝ) = D'.card + 1 := by
+      rw [Finset.card_insert_of_notMem he₀D']
+      push_cast
+      ring
+    rw [hcard]
+    linarith [htri, hstep, ih hD'E]
+
+omit [DecidableEq V] in
+/-- **The counting lemma.** The homomorphism densities of a finite graph `F` in two graphons on one
+carrier differ by at most `e(F)` times the cut norm of their difference. The argument to `cutNorm`
+is the *kernel* `U - W`: a difference of graphons is not a graphon, which is exactly why the cut
+norm is defined on symmetric kernels. -/
+theorem counting_lemma (F : SimpleGraph V) [DecidableRel F.Adj] (U W : Graphon Ω μ) :
+    |homDensity F U - homDensity F W|
+      ≤ (F.edgeFinset.card : ℝ) * cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
+  classical
+  have hE : ∀ e ∈ F.edgeFinset, ¬ e.IsDiag := fun _ he =>
+    SimpleGraph.not_isDiag_of_mem_edgeFinset he
+  have h := abs_integral_hybrid_sub_le F.edgeFinset hE U W F.edgeFinset Finset.Subset.rfl
+  have hrw : (∫ x, ∏ e ∈ F.edgeFinset, edgeFactor (if e ∈ F.edgeFinset then U else W) x e
+        ∂(Measure.pi fun _ : V => μ))
+      = ∫ x, ∏ e ∈ F.edgeFinset, edgeFactor U x e ∂(Measure.pi fun _ : V => μ) :=
+    integral_congr_ae (ae_of_all _ fun x => Finset.prod_congr rfl fun e he => by simp [he])
+  rw [hrw] at h
+  rw [homDensity_def, homDensity_def]
+  exact h
+
+omit [DecidableEq V] in
+/-- Two graphons whose difference has vanishing cut norm have the same homomorphism densities: the
+counting lemma with a vanishing right-hand side.  This is the same-carrier core of the forward
+separation direction, which the cross-carrier coupling form upgrades. -/
+theorem homDensity_eq_of_cutNorm_sub_eq_zero (F : SimpleGraph V) [DecidableRel F.Adj]
+    (U W : Graphon Ω μ) (h : cutNorm μ (U.toSymmKernel - W.toSymmKernel) = 0) :
+    homDensity F U = homDensity F W := by
+  have hle := counting_lemma F U W
+  rw [h, mul_zero] at hle
+  exact sub_eq_zero.1 (abs_eq_zero.1 (le_antisymm hle (abs_nonneg _)))
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/Counting.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Counting.lean
@@ -38,9 +38,7 @@ no loss of constant. The outer integral is over a probability measure, so the bo
 ## Main results
 
 * `TauCeti.DenseGraphLimits.counting_lemma` — the forward counting lemma
-  `|t(F, U) - t(F, W)| ≤ e(F) · ‖U - W‖□`;
-* `TauCeti.DenseGraphLimits.homDensity_eq_of_cutNorm_sub_eq_zero` — its vanishing case, the
-  same-carrier core of the forward separation direction.
+  `|t(F, U) - t(F, W)| ≤ e(F) · ‖U - W‖□`.
 
 ## References
 
@@ -255,17 +253,6 @@ theorem counting_lemma (F : SimpleGraph V) [DecidableRel F.Adj] (U W : Graphon �
   rw [hrw] at h
   rw [homDensity_def, homDensity_def]
   exact h
-
-omit [DecidableEq V] in
-/-- Two graphons whose difference has vanishing cut norm have the same homomorphism densities: the
-counting lemma with a vanishing right-hand side.  This is the same-carrier core of the forward
-separation direction, which the cross-carrier coupling form upgrades. -/
-theorem homDensity_eq_of_cutNorm_sub_eq_zero (F : SimpleGraph V) [DecidableRel F.Adj]
-    (U W : Graphon Ω μ) (h : cutNorm μ (U.toSymmKernel - W.toSymmKernel) = 0) :
-    homDensity F U = homDensity F W := by
-  have hle := counting_lemma F U W
-  rw [h, mul_zero] at hle
-  exact sub_eq_zero.1 (abs_eq_zero.1 (le_antisymm hle (abs_nonneg _)))
 
 end DenseGraphLimits
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Counting.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Counting.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.HomDensity.Basic
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
-public import TauCeti.MeasureTheory.Constructions.Pi
+public import TauCeti.MeasureTheory.Integral.Pi
 
 /-!
 # The counting lemma
@@ -30,7 +30,7 @@ edge being peeled off, which is exactly the weight the single-edge bound consume
 
 **One swap is a rectangle test.** `F` is a *simple* graph, so no edge other than `e₀` joins `a` to
 `b`: every other edge misses `a`, or misses `b`, or both. Refreshing the two coordinates `a` and `b`
-(`TauCeti.MeasureTheory.integral_pi_eq_integral_integral_update`) therefore leaves an inner double
+(`TauCeti.integral_pi_eq_integral_integral_update`) therefore leaves an inner double
 integral whose weights *factor* — one `[0, 1]`-valued function of the new `a`-coordinate, one of the
 new `b`-coordinate — and `abs_testIntegral_le_cutNorm` bounds such a pairing by the cut norm, with
 no loss of constant. The outer integral is over a probability measure, so the bound survives it.
@@ -76,7 +76,7 @@ private theorem abs_integral_le_cutNorm_of_factors (K : SymmKernel Ω μ) {a b :
     (hp1 : ∀ z u, p z u ∈ Icc (0 : ℝ) 1) (hq1 : ∀ z t, q z t ∈ Icc (0 : ℝ) 1)
     (hfac : ∀ z u t, f (update (update z a u) b t) = p z u * q z t * K u t) :
     |∫ x, f x ∂(Measure.pi fun _ : V => μ)| ≤ cutNorm μ K := by
-  rw [← TauCeti.MeasureTheory.integral_pi_eq_integral_integral_update μ hab hf]
+  rw [TauCeti.integral_pi_eq_integral_integral_update (fun _ : V => μ) hab hf]
   have hbound : ∀ z : V → Ω,
       ‖∫ w : Ω × Ω, f (update (update z a w.1) b w.2) ∂μ.prod μ‖ ≤ cutNorm μ K := by
     intro z
@@ -102,8 +102,6 @@ private theorem abs_integral_prod_mul_sub_le_aux (E : Finset (Sym2 V)) (G : Sym2
     |∫ x, (∏ e ∈ E.erase s(a, b), edgeFactor (G e) x e)
         * (U (x a) (x b) - W (x a) (x b)) ∂(Measure.pi fun _ : V => μ)|
       ≤ cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
-  have hpair : Measurable fun x : V → Ω => (x a, x b) :=
-    (measurable_pi_apply a).prodMk (measurable_pi_apply b)
   -- the edges other than `s(a, b)`, split by whether they contain `b`
   have hmem_b : ∀ e ∈ (E.erase s(a, b)).filter (fun e => b ∉ e), b ∉ e := by
     intro e he
@@ -123,23 +121,18 @@ private theorem abs_integral_prod_mul_sub_le_aux (E : Finset (Sym2 V)) (G : Sym2
     (fun z => (measurable_prod_edgeFactor _ G).comp (measurable_update z))
     (fun z u => ⟨prod_edgeFactor_nonneg _ G _, prod_edgeFactor_le_one _ G _⟩)
     (fun z t => ⟨prod_edgeFactor_nonneg _ G _, prod_edgeFactor_le_one _ G _⟩) ?_
-  · -- integrability: the integrand is measurable and bounded by `1`
-    have hm : Measurable fun x : V → Ω => U (x a) (x b) - W (x a) (x b) :=
-      (U.measurable.comp hpair).sub (W.measurable.comp hpair)
-    refine Integrable.mono' (integrable_const 1)
-      ((measurable_prod_edgeFactor _ G).mul hm).aestronglyMeasurable
-      (Filter.Eventually.of_forall fun x => ?_)
-    rw [Real.norm_eq_abs, abs_mul]
-    have h1 : |∏ e ∈ E.erase s(a, b), edgeFactor (G e) x e| ≤ 1 := by
-      rw [abs_of_nonneg (prod_edgeFactor_nonneg _ G x)]
-      exact prod_edgeFactor_le_one _ G x
+  · -- integrability: reuse the integrable edge-factor product and bound the difference by `1`
+    have hm : Measurable fun x : V → Ω => U (x a) (x b) - W (x a) (x b) := by
+      convert (measurable_edgeFactor U s(a, b)).sub (measurable_edgeFactor W s(a, b)) using 1
+      funext x
+      rw [Pi.sub_apply, edgeFactor_mk, edgeFactor_mk]
+    refine (integrable_prod_edgeFactor (E.erase s(a, b)) G).mul_bdd (c := 1)
+      hm.aestronglyMeasurable (ae_of_all _ fun x => ?_)
     have h2 : |U (x a) (x b) - W (x a) (x b)| ≤ 1 := by
       rw [abs_le]
       exact ⟨by linarith [U.nonneg (x a) (x b), W.le_one (x a) (x b)],
         by linarith [U.le_one (x a) (x b), W.nonneg (x a) (x b)]⟩
-    calc |∏ e ∈ E.erase s(a, b), edgeFactor (G e) x e| * |U (x a) (x b) - W (x a) (x b)|
-        ≤ 1 * 1 := mul_le_mul h1 h2 (abs_nonneg _) zero_le_one
-      _ = 1 := one_mul 1
+    simpa only [edgeFactor_mk, Real.norm_eq_abs] using h2
   · -- the factorisation after refreshing the two coordinates
     intro z u t
     have hva : update (update z a u) b t a = u := by
@@ -180,7 +173,7 @@ private theorem abs_integral_prod_mul_sub_le (E : Finset (Sym2 V)) (G : Sym2 V �
   | _ a b =>
     intro he₀
     have hab : a ≠ b := fun h => he₀ (Sym2.mk_isDiag_iff.2 h)
-    simpa using abs_integral_prod_mul_sub_le_aux E G U W hab
+    simpa only [edgeFactor_mk] using abs_integral_prod_mul_sub_le_aux E G U W hab
 
 /-- **The telescope.** Swapping the edges in a subset `D` of `E` from `W` to `U`, one edge at a
 time, costs at most `‖U - W‖□` per swap. -/

--- a/TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Basic.lean
@@ -160,11 +160,6 @@ theorem homDensity_def :
     homDensity F W =
       ∫ x, ∏ e ∈ F.edgeFinset, edgeFactor W x e ∂(Measure.pi fun _ : V => μ) := (rfl)
 
-/-- The integrand of `homDensity` is measurable. -/
-theorem measurable_homDensity_integrand :
-    Measurable fun x : V → Ω => ∏ e ∈ F.edgeFinset, edgeFactor W x e :=
-  measurable_prod_edgeFactor F.edgeFinset fun _ => W
-
 /-- The integrand of `homDensity` is nonnegative. -/
 theorem homDensity_integrand_nonneg (x : V → Ω) :
     0 ≤ ∏ e ∈ F.edgeFinset, edgeFactor W x e :=

--- a/TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/HomDensity/Basic.lean
@@ -37,6 +37,12 @@ here needs a nonempty-carrier hypothesis.
 
 ## Main results
 
+* `edgeFactor_congr` — an edge factor depends only on the assignment along that edge;
+* `measurable_prod_edgeFactor`, `prod_edgeFactor_nonneg`, `prod_edgeFactor_le_one` and
+  `integrable_prod_edgeFactor` — the basic analytic facts about a finite product of edge factors,
+  each edge read in its own graphon.  The integrand of `homDensity` is the special case of one
+  graphon on the edges of `F`, and the telescoping proof of the counting lemma needs the general
+  form;
 * `homDensity_nonneg`, `homDensity_le_one` — `t(F, W) ∈ [0, 1]`, with no hypotheses;
 * `homDensity_const` — the Erdős–Rényi value `t(F, W_p) = p ^ e(F)`, the first real consumer of both
   the graphon carrier and this definition.
@@ -97,6 +103,45 @@ theorem measurable_edgeFactor (W : Graphon Ω μ) (e : Sym2 V) :
       (measurable_pi_apply a).prodMk (measurable_pi_apply b)
     exact W.measurable.comp h
 
+omit [Fintype V] in
+/-- The value of a graphon on an edge depends only on the vertex assignment along that edge.  This
+is what lets an edge factor be read off after the assignment has been altered away from the edge. -/
+theorem edgeFactor_congr (W : Graphon Ω μ) {x y : V → Ω} {e : Sym2 V}
+    (h : ∀ v ∈ e, x v = y v) : edgeFactor W x e = edgeFactor W y e := by
+  induction e using Sym2.ind with
+  | _ a b => rw [edgeFactor_mk, edgeFactor_mk, h a (by simp), h b (by simp)]
+
+omit [Fintype V] in
+/-- A finite product of edge factors, each edge read in its own graphon, depends measurably on the
+vertex assignment. -/
+theorem measurable_prod_edgeFactor (E : Finset (Sym2 V)) (G : Sym2 V → Graphon Ω μ) :
+    Measurable fun x : V → Ω => ∏ e ∈ E, edgeFactor (G e) x e :=
+  Finset.measurable_prod _ fun e _ => measurable_edgeFactor (G e) e
+
+omit [Fintype V] in
+/-- A finite product of edge factors is nonnegative. -/
+theorem prod_edgeFactor_nonneg (E : Finset (Sym2 V)) (G : Sym2 V → Graphon Ω μ) (x : V → Ω) :
+    0 ≤ ∏ e ∈ E, edgeFactor (G e) x e :=
+  Finset.prod_nonneg fun e _ => edgeFactor_nonneg (G e) x e
+
+omit [Fintype V] in
+/-- A finite product of edge factors is at most `1`: every factor lies in `[0, 1]`. -/
+theorem prod_edgeFactor_le_one (E : Finset (Sym2 V)) (G : Sym2 V → Graphon Ω μ) (x : V → Ω) :
+    ∏ e ∈ E, edgeFactor (G e) x e ≤ 1 :=
+  Finset.prod_le_one (fun e _ => edgeFactor_nonneg (G e) x e)
+    fun e _ => edgeFactor_le_one (G e) x e
+
+/-- A finite product of edge factors is integrable against the product measure: it is measurable
+and `[0, 1]`-valued on a probability space. -/
+theorem integrable_prod_edgeFactor (E : Finset (Sym2 V)) (G : Sym2 V → Graphon Ω μ) :
+    Integrable (fun x : V → Ω => ∏ e ∈ E, edgeFactor (G e) x e)
+      (Measure.pi fun _ : V => μ) := by
+  refine Integrable.mono' (integrable_const 1)
+    (measurable_prod_edgeFactor E G).aestronglyMeasurable
+    (Filter.Eventually.of_forall fun x => ?_)
+  rw [Real.norm_eq_abs, abs_of_nonneg (prod_edgeFactor_nonneg E G x)]
+  exact prod_edgeFactor_le_one E G x
+
 /-- The **homomorphism density** `t(F, W)`: the integral, over vertex assignments, of the product of
 `W` along the edges of `F`.
 
@@ -118,28 +163,24 @@ theorem homDensity_def :
 /-- The integrand of `homDensity` is measurable. -/
 theorem measurable_homDensity_integrand :
     Measurable fun x : V → Ω => ∏ e ∈ F.edgeFinset, edgeFactor W x e :=
-  Finset.measurable_prod _ fun e _ => measurable_edgeFactor W e
+  measurable_prod_edgeFactor F.edgeFinset fun _ => W
 
 /-- The integrand of `homDensity` is nonnegative. -/
 theorem homDensity_integrand_nonneg (x : V → Ω) :
     0 ≤ ∏ e ∈ F.edgeFinset, edgeFactor W x e :=
-  Finset.prod_nonneg fun e _ => edgeFactor_nonneg W x e
+  prod_edgeFactor_nonneg F.edgeFinset (fun _ => W) x
 
 /-- The integrand of `homDensity` is at most `1`: it is a product of factors in `[0, 1]`. -/
 theorem homDensity_integrand_le_one (x : V → Ω) :
     ∏ e ∈ F.edgeFinset, edgeFactor W x e ≤ 1 :=
-  Finset.prod_le_one (fun e _ => edgeFactor_nonneg W x e) fun e _ => edgeFactor_le_one W x e
+  prod_edgeFactor_le_one F.edgeFinset (fun _ => W) x
 
 /-- The integrand of `homDensity` is integrable: it is measurable and bounded on a probability
 space. -/
 theorem integrable_homDensity_integrand :
     Integrable (fun x : V → Ω => ∏ e ∈ F.edgeFinset, edgeFactor W x e)
-      (Measure.pi fun _ : V => μ) := by
-  refine Integrable.mono' (integrable_const 1)
-    (measurable_homDensity_integrand F W).aestronglyMeasurable (Filter.Eventually.of_forall ?_)
-  intro x
-  rw [Real.norm_eq_abs, abs_of_nonneg (homDensity_integrand_nonneg F W x)]
-  exact homDensity_integrand_le_one F W x
+      (Measure.pi fun _ : V => μ) :=
+  integrable_prod_edgeFactor F.edgeFinset fun _ => W
 
 /-- A homomorphism density is nonnegative. -/
 theorem homDensity_nonneg : 0 ≤ homDensity F W :=

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
@@ -229,9 +229,8 @@ theorem testIntegral_comm [SFinite μ] (K : SymmKernel Ω μ) (u v : Ω → ℝ)
 /-- The inner integral of a kernel against a single test function, `x ↦ ∫ v(y) K(x,y)`.
 
 This is the partial pairing that the extremal step of the factor sandwich optimises over.  When `μ`
-is finite and `v` is measurable and `[-1,1]`-valued — the hypotheses `exists_pm_one_left` carries —
-the supremum over the remaining test function is attained at the sign of this function.  The
-definition itself asks nothing of `v`. -/
+is finite and `v` is measurable and `[-1,1]`-valued, the partial pairing is measurable and
+integrable. The definition itself asks nothing of `v`. -/
 noncomputable def partialIntegral (K : SymmKernel Ω μ) (v : Ω → ℝ) (x : Ω) : ℝ :=
   ∫ y, v y * K x y ∂μ
 
@@ -255,6 +254,15 @@ theorem integrable_partialIntegral [IsFiniteMeasure μ] (K : SymmKernel Ω μ) {
   have h := (K.integrable_testIntegrand μ measurable_const hv h1 hv1).integral_prod_left
   simp only [one_mul] at h
   exact h
+
+/-- Multiplying a partial pairing by a measurable `[-1,1]`-valued function preserves
+integrability. -/
+private theorem integrable_mul_partialIntegral [IsFiniteMeasure μ] (K : SymmKernel Ω μ)
+    {v w : Ω → ℝ} (hv : Measurable v) (hv1 : ∀ y, v y ∈ Icc (-1 : ℝ) 1)
+    (hw : Measurable w) (hw1 : ∀ x, w x ∈ Icc (-1 : ℝ) 1) :
+    Integrable (fun x => w x * K.partialIntegral μ v x) μ :=
+  (K.integrable_partialIntegral μ hv hv1).bdd_mul hw.aestronglyMeasurable
+    (ae_of_all _ fun x => abs_le.2 (hw1 x))
 
 /-- A test integral is the integral of the left test function against the partial pairing.
 
@@ -457,6 +465,12 @@ theorem cutNorm_smul (c : ℝ) (K : SymmKernel Ω μ) :
   simp only [SymmKernel.rectIntegral_smul, abs_mul,
     Real.mul_iSup_of_nonneg (abs_nonneg c)]
 
+omit [MeasurableSpace Ω] in
+/-- An indicator of the constant-one function takes values in `[-1,1]`. -/
+private theorem indicator_one_mem_Icc_neg_one_one (A : Set Ω) (x : Ω) :
+    A.indicator (1 : Ω → ℝ) x ∈ Icc (-1 : ℝ) 1 := by
+  by_cases hx : x ∈ A <;> simp [hx]
+
 /-- The extremal step for `[0,1]`-valued test functions.  The pairing is affine in the left test
 function, so it lies between the pairings against the indicator of the set where the partial
 pairing is nonnegative and the indicator of the complement; one of those two indicators therefore
@@ -470,30 +484,21 @@ private theorem exists_indicator_left_of_mem_Icc (K : SymmKernel Ω μ)
   have hu1' : ∀ x, u x ∈ Icc (-1 : ℝ) 1 := fun x => ⟨by linarith [(hu1 x).1], (hu1 x).2⟩
   set g := K.partialIntegral μ v with hgdef
   have hgm : Measurable g := K.measurable_partialIntegral μ hv
-  have hgint : Integrable g μ := K.integrable_partialIntegral μ hv hv1
   set S : Set Ω := {x | 0 ≤ g x} with hSdef
   have hS : MeasurableSet S := measurableSet_le measurable_const hgm
   have hind : ∀ A : Set Ω, MeasurableSet A → Measurable (A.indicator (1 : Ω → ℝ)) :=
     fun _ hA => measurable_one.indicator hA
-  have hmem : ∀ (A : Set Ω) (x : Ω), A.indicator (1 : Ω → ℝ) x ∈ Icc (-1 : ℝ) 1 := by
-    intro A x
-    by_cases hx : x ∈ A <;> simp [hx]
-  have hprod : ∀ w : Ω → ℝ, Measurable w → (∀ x, w x ∈ Icc (-1 : ℝ) 1) →
-      Integrable (fun x => w x * g x) μ := by
-    intro w hw hw1
-    refine Integrable.mono' hgint.abs (hw.mul hgm).aestronglyMeasurable (ae_of_all _ fun x => ?_)
-    rw [Real.norm_eq_abs, abs_mul]
-    calc |w x| * |g x| ≤ 1 * |g x| := by gcongr; exact abs_le.2 (hw1 x)
-      _ = |g x| := one_mul _
   have hrepr : ∀ w : Ω → ℝ, Measurable w → (∀ x, w x ∈ Icc (-1 : ℝ) 1) →
       K.testIntegral μ w v = ∫ x, w x * g x ∂μ := fun w hw hw1 =>
     K.testIntegral_eq_integral_partialIntegral μ (K.integrable_testIntegrand μ hw hv hw1 hv1)
+  have hgnonpos : ∀ x ∉ S, g x ≤ 0 := fun x hx =>
+    le_of_lt (lt_of_not_ge (by simpa [hSdef] using hx))
   have hlow : ∀ x, Sᶜ.indicator (1 : Ω → ℝ) x * g x ≤ u x * g x := by
     intro x
     by_cases hx : x ∈ S
     · rw [Set.indicator_of_notMem (by simpa using hx), zero_mul]
       exact mul_nonneg (hu1 x).1 hx
-    · have hgx : g x ≤ 0 := le_of_lt (lt_of_not_ge (by simpa [hSdef] using hx))
+    · have hgx := hgnonpos x hx
       rw [Set.indicator_of_mem (by simpa using hx), Pi.one_apply]
       exact mul_le_mul_of_nonpos_right (hu1 x).2 hgx
   have hhigh : ∀ x, u x * g x ≤ S.indicator (1 : Ω → ℝ) x * g x := by
@@ -501,16 +506,21 @@ private theorem exists_indicator_left_of_mem_Icc (K : SymmKernel Ω μ)
     by_cases hx : x ∈ S
     · rw [Set.indicator_of_mem hx, Pi.one_apply]
       exact mul_le_mul_of_nonneg_right (hu1 x).2 hx
-    · have hgx : g x ≤ 0 := le_of_lt (lt_of_not_ge (by simpa [hSdef] using hx))
+    · have hgx := hgnonpos x hx
       rw [Set.indicator_of_notMem hx, zero_mul]
       nlinarith [(hu1 x).1, hgx]
   set IA := ∫ x, S.indicator (1 : Ω → ℝ) x * g x ∂μ with hIA
   set IB := ∫ x, Sᶜ.indicator (1 : Ω → ℝ) x * g x ∂μ with hIB
   set IC := ∫ x, u x * g x ∂μ with hIC
   have hBC : IB ≤ IC :=
-    integral_mono (hprod _ (hind _ hS.compl) (hmem _)) (hprod _ hu hu1') hlow
+    integral_mono
+      (K.integrable_mul_partialIntegral μ hv hv1 (hind _ hS.compl)
+        (indicator_one_mem_Icc_neg_one_one _))
+      (K.integrable_mul_partialIntegral μ hv hv1 hu hu1') hlow
   have hCA : IC ≤ IA :=
-    integral_mono (hprod _ hu hu1') (hprod _ (hind _ hS) (hmem _)) hhigh
+    integral_mono (K.integrable_mul_partialIntegral μ hv hv1 hu hu1')
+      (K.integrable_mul_partialIntegral μ hv hv1 (hind _ hS)
+        (indicator_one_mem_Icc_neg_one_one _)) hhigh
   have hA0 : 0 ≤ IA := by
     refine integral_nonneg fun x => ?_
     simp only [Pi.zero_apply]
@@ -522,15 +532,18 @@ private theorem exists_indicator_left_of_mem_Icc (K : SymmKernel Ω μ)
     simp only [Pi.zero_apply]
     by_cases hx : x ∈ S
     · rw [Set.indicator_of_notMem (by simpa using hx), zero_mul]
-    · have hgx : g x ≤ 0 := le_of_lt (lt_of_not_ge (by simpa [hSdef] using hx))
+    · have hgx := hgnonpos x hx
       rw [Set.indicator_of_mem (by simpa using hx), Pi.one_apply, one_mul]
       exact hgx
   rcases le_total (-IB) IA with h | h
   · refine ⟨S, hS, ?_⟩
-    rw [hrepr u hu hu1', hrepr _ (hind _ hS) (hmem _), ← hIC, ← hIA, abs_of_nonneg hA0]
+    rw [hrepr u hu hu1', hrepr _ (hind _ hS) (indicator_one_mem_Icc_neg_one_one _),
+      ← hIC, ← hIA, abs_of_nonneg hA0]
     exact abs_le.2 ⟨by linarith, hCA⟩
   · refine ⟨Sᶜ, hS.compl, ?_⟩
-    rw [hrepr u hu hu1', hrepr _ (hind _ hS.compl) (hmem _), ← hIC, ← hIB, abs_of_nonpos hB0]
+    rw [hrepr u hu hu1',
+      hrepr _ (hind _ hS.compl) (indicator_one_mem_Icc_neg_one_one _), ← hIC, ← hIB,
+      abs_of_nonpos hB0]
     exact abs_le.2 ⟨by linarith, by linarith⟩
 
 /-- **Every `[0,1]`-test integral is bounded by the cut norm.**  The pairing is affine in each test
@@ -544,12 +557,10 @@ theorem abs_testIntegral_le_cutNorm (K : SymmKernel Ω μ) {u v : Ω → ℝ}
     |K.testIntegral μ u v| ≤ cutNorm μ K := by
   have hv1' : ∀ y, v y ∈ Icc (-1 : ℝ) 1 := fun y => ⟨by linarith [(hv1 y).1], (hv1 y).2⟩
   obtain ⟨S, hS, hSle⟩ := exists_indicator_left_of_mem_Icc μ K hu hv hu1 hv1'
-  have hmemS : ∀ x, S.indicator (1 : Ω → ℝ) x ∈ Icc (-1 : ℝ) 1 := by
-    intro x
-    by_cases hx : x ∈ S <;> simp [hx]
   rw [K.testIntegral_comm μ (S.indicator 1) v] at hSle
   obtain ⟨T, hT, hTle⟩ :=
-    exists_indicator_left_of_mem_Icc μ K hv (measurable_one.indicator hS) hv1 hmemS
+    exists_indicator_left_of_mem_Icc μ K hv (measurable_one.indicator hS) hv1
+      (indicator_one_mem_Icc_neg_one_one _)
   calc |K.testIntegral μ u v|
       ≤ |K.testIntegral μ v (S.indicator 1)| := hSle
     _ ≤ |K.testIntegral μ (T.indicator 1) (S.indicator 1)| := hTle
@@ -654,120 +665,72 @@ theorem cutNorm_le_cutNormSigned (K : SymmKernel Ω μ) : cutNorm μ K ≤ cutNo
   refine cutNorm_le μ fun S hS T hT => ?_
   rw [← K.testIntegral_indicator_one μ hS hT]
   refine abs_testIntegral_le_cutNormSigned μ K (measurable_one.indicator hS)
-    (measurable_one.indicator hT) (fun x => ?_) fun y => ?_
-  · by_cases hx : x ∈ S <;> simp [hx]
-  · by_cases hy : y ∈ T <;> simp [hy]
-
-/-- The extremal step: replacing the left test function by the sign of the inner integral can only
-increase the pairing, and the replacement is `±1`-valued. -/
-private theorem exists_pm_one_left (K : SymmKernel Ω μ) {u v : Ω → ℝ}
-    (hu : Measurable u) (hv : Measurable v)
-    (hu1 : ∀ x, u x ∈ Icc (-1 : ℝ) 1) (hv1 : ∀ y, v y ∈ Icc (-1 : ℝ) 1) :
-    ∃ w : Ω → ℝ, Measurable w ∧ (∀ x, w x = 1 ∨ w x = -1) ∧
-      |K.testIntegral μ u v| ≤ K.testIntegral μ w v := by
-  set g := K.partialIntegral μ v with hg_def
-  have hg : Measurable g := K.measurable_partialIntegral μ hv
-  have hgint : Integrable g μ := K.integrable_partialIntegral μ hv hv1
-  refine ⟨fun x => if 0 ≤ g x then 1 else -1, ?_, ?_, ?_⟩
-  · exact Measurable.ite (measurableSet_le measurable_const hg) measurable_const measurable_const
-  · intro x; by_cases hx : 0 ≤ g x <;> simp [hx]
-  · have hw1 : ∀ x, (if 0 ≤ g x then (1 : ℝ) else -1) ∈ Icc (-1 : ℝ) 1 := by
-      intro x; by_cases hx : 0 ≤ g x <;> simp [hx]
-    have hwm : Measurable fun x => if 0 ≤ g x then (1 : ℝ) else -1 :=
-      Measurable.ite (measurableSet_le measurable_const hg) measurable_const measurable_const
-    rw [K.testIntegral_eq_integral_partialIntegral μ
-        (K.integrable_testIntegrand μ hu hv hu1 hv1),
-      K.testIntegral_eq_integral_partialIntegral μ
-        (K.integrable_testIntegrand μ hwm hv hw1 hv1), ← hg_def]
-    have hint : Integrable (fun x => u x * g x) μ :=
-      Integrable.mono' hgint.abs (hu.mul hg).aestronglyMeasurable
-        (ae_of_all _ fun x => by
-          rw [Real.norm_eq_abs, abs_mul]
-          calc |u x| * |g x| ≤ 1 * |g x| := by gcongr; exact abs_le.2 (hu1 x)
-            _ = |g x| := one_mul _)
-    calc |∫ x, u x * g x ∂μ|
-        ≤ ∫ x, |u x * g x| ∂μ := abs_integral_le_integral_abs
-      _ ≤ ∫ x, |g x| ∂μ := by
-          refine integral_mono hint.abs hgint.abs fun x => ?_
-          rw [abs_mul]
-          calc |u x| * |g x| ≤ 1 * |g x| := by gcongr; exact abs_le.2 (hu1 x)
-            _ = |g x| := one_mul _
-      _ = ∫ x, (if 0 ≤ g x then (1 : ℝ) else -1) * g x ∂μ := by
-          refine integral_congr_ae (ae_of_all _ fun x => ?_)
-          by_cases hx : 0 ≤ g x
-          · simp [hx, abs_of_nonneg hx]
-          · simp [hx, abs_of_neg (lt_of_not_ge hx)]
-
-omit [MeasurableSpace Ω] in
-private theorem mem_Icc_of_pm {w : Ω → ℝ} (hw : ∀ x, w x = 1 ∨ w x = -1) (x : Ω) :
-    w x ∈ Icc (-1 : ℝ) 1 := by
-  rcases hw x with h | h <;> rw [h] <;> constructor <;> norm_num
-
-/-- A `±1`-valued measurable function is the indicator of a measurable set minus the indicator of
-its complement. -/
-private theorem exists_indicator_sub_of_pm {u : Ω → ℝ} (hu : Measurable u)
-    (hu' : ∀ x, u x = 1 ∨ u x = -1) :
-    ∃ S : Set Ω, MeasurableSet S ∧ u = S.indicator 1 - Sᶜ.indicator 1 := by
-  refine ⟨u ⁻¹' {1}, hu (measurableSet_singleton 1), ?_⟩
-  funext x
-  by_cases hx : u x = 1
-  · simp [Set.mem_preimage, hx]
-  · have hxS : x ∉ u ⁻¹' {1} := by simpa using hx
-    have hx' : u x = -1 := (hu' x).resolve_left hx
-    simp [hxS, hx']
-
-/-- The four-rectangle bound: a pairing of `±1`-valued test functions splits into the four
-rectangles cut out by the two sets, each bounded by the cut norm. -/
-private theorem abs_testIntegral_le_four_mul_cutNorm_of_pm (K : SymmKernel Ω μ) {u v : Ω → ℝ}
-    (hu : Measurable u) (hv : Measurable v)
-    (hu' : ∀ x, u x = 1 ∨ u x = -1) (hv' : ∀ y, v y = 1 ∨ v y = -1) :
-    |K.testIntegral μ u v| ≤ 4 * cutNorm μ K := by
-  obtain ⟨S, hS, hu_eq⟩ := exists_indicator_sub_of_pm hu hu'
-  obtain ⟨T, hT, hv_eq⟩ := exists_indicator_sub_of_pm hv hv'
-  have hind : ∀ A : Set Ω, MeasurableSet A → Measurable (A.indicator (1 : Ω → ℝ)) :=
-    fun _ hA => measurable_one.indicator hA
-  have hmem : ∀ (A : Set Ω) (x : Ω), A.indicator (1 : Ω → ℝ) x ∈ Icc (-1 : ℝ) 1 := by
-    intro A x
-    by_cases hx : x ∈ A <;> simp [hx]
-  rw [hv_eq, K.testIntegral_sub_right μ
-      (K.integrable_testIntegrand μ hu (hind T hT) (mem_Icc_of_pm hu') (hmem T))
-      (K.integrable_testIntegrand μ hu (hind Tᶜ hT.compl) (mem_Icc_of_pm hu') (hmem Tᶜ)),
-    hu_eq,
-    K.testIntegral_sub_left μ
-      (K.integrable_testIntegrand μ (hind S hS) (hind T hT) (hmem S) (hmem T))
-      (K.integrable_testIntegrand μ (hind Sᶜ hS.compl) (hind T hT) (hmem Sᶜ) (hmem T)),
-    K.testIntegral_sub_left μ
-      (K.integrable_testIntegrand μ (hind S hS) (hind Tᶜ hT.compl) (hmem S) (hmem Tᶜ))
-      (K.integrable_testIntegrand μ (hind Sᶜ hS.compl) (hind Tᶜ hT.compl) (hmem Sᶜ) (hmem Tᶜ)),
-    K.testIntegral_indicator_one μ hS hT, K.testIntegral_indicator_one μ hS.compl hT,
-    K.testIntegral_indicator_one μ hS hT.compl,
-    K.testIntegral_indicator_one μ hS.compl hT.compl]
-  obtain ⟨l1, r1⟩ := abs_le.1 (abs_rectIntegral_le_cutNorm μ K hS hT)
-  obtain ⟨l2, r2⟩ := abs_le.1 (abs_rectIntegral_le_cutNorm μ K hS.compl hT)
-  obtain ⟨l3, r3⟩ := abs_le.1 (abs_rectIntegral_le_cutNorm μ K hS hT.compl)
-  obtain ⟨l4, r4⟩ := abs_le.1 (abs_rectIntegral_le_cutNorm μ K hS.compl hT.compl)
-  exact abs_le.2 ⟨by linarith, by linarith⟩
+    (measurable_one.indicator hT) (indicator_one_mem_Icc_neg_one_one _)
+      (indicator_one_mem_Icc_neg_one_one _)
 
 /-- **Upper side of the factor sandwich.** Relaxing indicators to `[-1,1]`-valued test functions
 increases the cut norm by at most a factor of `4`. -/
 theorem cutNormSigned_le_four_mul_cutNorm (K : SymmKernel Ω μ) :
     cutNormSigned μ K ≤ 4 * cutNorm μ K := by
   refine cutNormSigned_le μ fun u v hu hv hu1 hv1 => ?_
-  obtain ⟨w, hw, hw', hle⟩ := exists_pm_one_left μ K hu hv hu1 hv1
-  obtain ⟨z, hz, hz', hle2⟩ :=
-    exists_pm_one_left μ K hv hw hv1 (mem_Icc_of_pm hw')
-  have e1 : K.testIntegral μ w v = K.testIntegral μ v w := K.testIntegral_comm μ w v
-  have e2 : K.testIntegral μ z w = K.testIntegral μ w z := K.testIntegral_comm μ z w
-  have h4 : |K.testIntegral μ w z| ≤ 4 * cutNorm μ K :=
-    abs_testIntegral_le_four_mul_cutNorm_of_pm μ K hw hz hw' hz'
-  calc |K.testIntegral μ u v|
-      ≤ K.testIntegral μ w v := hle
-    _ = K.testIntegral μ v w := e1
-    _ ≤ |K.testIntegral μ v w| := le_abs_self _
-    _ ≤ K.testIntegral μ z w := hle2
-    _ = K.testIntegral μ w z := e2
-    _ ≤ |K.testIntegral μ w z| := le_abs_self _
-    _ ≤ 4 * cutNorm μ K := h4
+  let up := fun x => max (u x) 0
+  let un := fun x => max (-u x) 0
+  let vp := fun x => max (v x) 0
+  let vn := fun x => max (-v x) 0
+  have hupm : Measurable up := hu.max measurable_const
+  have hunm : Measurable un := hu.neg.max measurable_const
+  have hvpm : Measurable vp := hv.max measurable_const
+  have hvnm : Measurable vn := hv.neg.max measurable_const
+  have hup1 : ∀ x, up x ∈ Icc (0 : ℝ) 1 := fun x =>
+    ⟨le_max_right _ _, max_le (hu1 x).2 zero_le_one⟩
+  have hun1 : ∀ x, un x ∈ Icc (0 : ℝ) 1 := fun x =>
+    ⟨le_max_right _ _, max_le (by linarith [(hu1 x).1]) zero_le_one⟩
+  have hvp1 : ∀ x, vp x ∈ Icc (0 : ℝ) 1 := fun x =>
+    ⟨le_max_right _ _, max_le (hv1 x).2 zero_le_one⟩
+  have hvn1 : ∀ x, vn x ∈ Icc (0 : ℝ) 1 := fun x =>
+    ⟨le_max_right _ _, max_le (by linarith [(hv1 x).1]) zero_le_one⟩
+  have hup1' : ∀ x, up x ∈ Icc (-1 : ℝ) 1 := fun x =>
+    ⟨by linarith [(hup1 x).1], (hup1 x).2⟩
+  have hun1' : ∀ x, un x ∈ Icc (-1 : ℝ) 1 := fun x =>
+    ⟨by linarith [(hun1 x).1], (hun1 x).2⟩
+  have hvp1' : ∀ x, vp x ∈ Icc (-1 : ℝ) 1 := fun x =>
+    ⟨by linarith [(hvp1 x).1], (hvp1 x).2⟩
+  have hvn1' : ∀ x, vn x ∈ Icc (-1 : ℝ) 1 := fun x =>
+    ⟨by linarith [(hvn1 x).1], (hvn1 x).2⟩
+  have hu_eq : u = up - un := by
+    funext x
+    exact (max_zero_sub_max_neg_zero_eq_self (u x)).symm
+  have hv_eq : v = vp - vn := by
+    funext x
+    exact (max_zero_sub_max_neg_zero_eq_self (v x)).symm
+  have hu_sub1 : ∀ x, (up - un) x ∈ Icc (-1 : ℝ) 1 := by
+    rw [← hu_eq]
+    exact hu1
+  have hpp := abs_testIntegral_le_cutNorm μ K hupm hvpm hup1 hvp1
+  have hmp := abs_testIntegral_le_cutNorm μ K hunm hvpm hun1 hvp1
+  have hpm := abs_testIntegral_le_cutNorm μ K hupm hvnm hup1 hvn1
+  have hmm := abs_testIntegral_le_cutNorm μ K hunm hvnm hun1 hvn1
+  rw [hu_eq, hv_eq,
+    K.testIntegral_sub_right μ
+      (K.integrable_testIntegrand μ (hupm.sub hunm) hvpm hu_sub1 hvp1')
+      (K.integrable_testIntegrand μ (hupm.sub hunm) hvnm hu_sub1 hvn1'),
+    K.testIntegral_sub_left μ
+      (K.integrable_testIntegrand μ hupm hvpm hup1' hvp1')
+      (K.integrable_testIntegrand μ hunm hvpm hun1' hvp1'),
+    K.testIntegral_sub_left μ
+      (K.integrable_testIntegrand μ hupm hvnm hup1' hvn1')
+      (K.integrable_testIntegrand μ hunm hvnm hun1' hvn1')]
+  calc
+    |K.testIntegral μ up vp - K.testIntegral μ un vp -
+        (K.testIntegral μ up vn - K.testIntegral μ un vn)|
+        ≤ |K.testIntegral μ up vp - K.testIntegral μ un vp| +
+            |K.testIntegral μ up vn - K.testIntegral μ un vn| := abs_sub _ _
+    _ ≤ (|K.testIntegral μ up vp| + |K.testIntegral μ un vp|) +
+          (|K.testIntegral μ up vn| + |K.testIntegral μ un vn|) :=
+      add_le_add (abs_sub _ _) (abs_sub _ _)
+    _ ≤ (cutNorm μ K + cutNorm μ K) + (cutNorm μ K + cutNorm μ K) :=
+      add_le_add (add_le_add hpp hmp) (add_le_add hpm hmm)
+    _ = 4 * cutNorm μ K := by ring
 
 end DenseGraphLimits
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
@@ -43,6 +43,9 @@ pointwise algebra happens before integration; a later layer proves invariance un
   supremum.
 * `cutNorm_zero`, `cutNorm_neg`, `cutNorm_add_le`, and `cutNorm_smul` are the seminorm laws.
 * `cutNorm_le_integral_abs` bounds the cut norm by the `L¹` norm.
+* `abs_testIntegral_le_cutNorm` bounds every `[0,1]`-test integral by the cut norm itself, with no
+  loss of constant — the form the counting lemma consumes, where the weights read off the other
+  edges of a graph are `[0,1]`-valued.
 * `abs_testIntegral_le_cutNormSigned` and `cutNormSigned_le` are the corresponding introduction and
   elimination rules for the signed cut norm.
 * `cutNorm_le_cutNormSigned` and `cutNormSigned_le_four_mul_cutNorm` are the two sides of the
@@ -453,6 +456,105 @@ theorem cutNorm_smul (c : ℝ) (K : SymmKernel Ω μ) :
   rw [cutNorm_eq_cutNormSet, cutNormSet_def, cutNorm_eq_cutNormSet, cutNormSet_def]
   simp only [SymmKernel.rectIntegral_smul, abs_mul,
     Real.mul_iSup_of_nonneg (abs_nonneg c)]
+
+/-- The extremal step for `[0,1]`-valued test functions.  The pairing is affine in the left test
+function, so it lies between the pairings against the indicator of the set where the partial
+pairing is nonnegative and the indicator of the complement; one of those two indicators therefore
+does at least as well in absolute value. -/
+private theorem exists_indicator_left_of_mem_Icc (K : SymmKernel Ω μ)
+    {u v : Ω → ℝ} (hu : Measurable u) (hv : Measurable v)
+    (hu1 : ∀ x, u x ∈ Icc (0 : ℝ) 1) (hv1 : ∀ y, v y ∈ Icc (-1 : ℝ) 1) :
+    ∃ S : Set Ω, MeasurableSet S ∧
+      |K.testIntegral μ u v| ≤ |K.testIntegral μ (S.indicator 1) v| := by
+  classical
+  have hu1' : ∀ x, u x ∈ Icc (-1 : ℝ) 1 := fun x => ⟨by linarith [(hu1 x).1], (hu1 x).2⟩
+  set g := K.partialIntegral μ v with hgdef
+  have hgm : Measurable g := K.measurable_partialIntegral μ hv
+  have hgint : Integrable g μ := K.integrable_partialIntegral μ hv hv1
+  set S : Set Ω := {x | 0 ≤ g x} with hSdef
+  have hS : MeasurableSet S := measurableSet_le measurable_const hgm
+  have hind : ∀ A : Set Ω, MeasurableSet A → Measurable (A.indicator (1 : Ω → ℝ)) :=
+    fun _ hA => measurable_one.indicator hA
+  have hmem : ∀ (A : Set Ω) (x : Ω), A.indicator (1 : Ω → ℝ) x ∈ Icc (-1 : ℝ) 1 := by
+    intro A x
+    by_cases hx : x ∈ A <;> simp [hx]
+  have hprod : ∀ w : Ω → ℝ, Measurable w → (∀ x, w x ∈ Icc (-1 : ℝ) 1) →
+      Integrable (fun x => w x * g x) μ := by
+    intro w hw hw1
+    refine Integrable.mono' hgint.abs (hw.mul hgm).aestronglyMeasurable (ae_of_all _ fun x => ?_)
+    rw [Real.norm_eq_abs, abs_mul]
+    calc |w x| * |g x| ≤ 1 * |g x| := by gcongr; exact abs_le.2 (hw1 x)
+      _ = |g x| := one_mul _
+  have hrepr : ∀ w : Ω → ℝ, Measurable w → (∀ x, w x ∈ Icc (-1 : ℝ) 1) →
+      K.testIntegral μ w v = ∫ x, w x * g x ∂μ := fun w hw hw1 =>
+    K.testIntegral_eq_integral_partialIntegral μ (K.integrable_testIntegrand μ hw hv hw1 hv1)
+  have hlow : ∀ x, Sᶜ.indicator (1 : Ω → ℝ) x * g x ≤ u x * g x := by
+    intro x
+    by_cases hx : x ∈ S
+    · rw [Set.indicator_of_notMem (by simpa using hx), zero_mul]
+      exact mul_nonneg (hu1 x).1 hx
+    · have hgx : g x ≤ 0 := le_of_lt (lt_of_not_ge (by simpa [hSdef] using hx))
+      rw [Set.indicator_of_mem (by simpa using hx), Pi.one_apply]
+      exact mul_le_mul_of_nonpos_right (hu1 x).2 hgx
+  have hhigh : ∀ x, u x * g x ≤ S.indicator (1 : Ω → ℝ) x * g x := by
+    intro x
+    by_cases hx : x ∈ S
+    · rw [Set.indicator_of_mem hx, Pi.one_apply]
+      exact mul_le_mul_of_nonneg_right (hu1 x).2 hx
+    · have hgx : g x ≤ 0 := le_of_lt (lt_of_not_ge (by simpa [hSdef] using hx))
+      rw [Set.indicator_of_notMem hx, zero_mul]
+      nlinarith [(hu1 x).1, hgx]
+  set IA := ∫ x, S.indicator (1 : Ω → ℝ) x * g x ∂μ with hIA
+  set IB := ∫ x, Sᶜ.indicator (1 : Ω → ℝ) x * g x ∂μ with hIB
+  set IC := ∫ x, u x * g x ∂μ with hIC
+  have hBC : IB ≤ IC :=
+    integral_mono (hprod _ (hind _ hS.compl) (hmem _)) (hprod _ hu hu1') hlow
+  have hCA : IC ≤ IA :=
+    integral_mono (hprod _ hu hu1') (hprod _ (hind _ hS) (hmem _)) hhigh
+  have hA0 : 0 ≤ IA := by
+    refine integral_nonneg fun x => ?_
+    simp only [Pi.zero_apply]
+    by_cases hx : x ∈ S
+    · rw [Set.indicator_of_mem hx, Pi.one_apply, one_mul]; exact hx
+    · rw [Set.indicator_of_notMem hx, zero_mul]
+  have hB0 : IB ≤ 0 := by
+    refine integral_nonpos fun x => ?_
+    simp only [Pi.zero_apply]
+    by_cases hx : x ∈ S
+    · rw [Set.indicator_of_notMem (by simpa using hx), zero_mul]
+    · have hgx : g x ≤ 0 := le_of_lt (lt_of_not_ge (by simpa [hSdef] using hx))
+      rw [Set.indicator_of_mem (by simpa using hx), Pi.one_apply, one_mul]
+      exact hgx
+  rcases le_total (-IB) IA with h | h
+  · refine ⟨S, hS, ?_⟩
+    rw [hrepr u hu hu1', hrepr _ (hind _ hS) (hmem _), ← hIC, ← hIA, abs_of_nonneg hA0]
+    exact abs_le.2 ⟨by linarith, hCA⟩
+  · refine ⟨Sᶜ, hS.compl, ?_⟩
+    rw [hrepr u hu hu1', hrepr _ (hind _ hS.compl) (hmem _), ← hIC, ← hIB, abs_of_nonpos hB0]
+    exact abs_le.2 ⟨by linarith, by linarith⟩
+
+/-- **Every `[0,1]`-test integral is bounded by the cut norm.**  The pairing is affine in each test
+function, so replacing a `[0,1]`-valued test function by a suitable indicator only increases the
+absolute pairing; doing so on both sides lands on a measurable rectangle.  Unlike the
+`[-1,1]`-valued case (`cutNormSigned_le_four_mul_cutNorm`) there is no factor of `4`, which is what
+makes this the form the counting lemma consumes. -/
+theorem abs_testIntegral_le_cutNorm (K : SymmKernel Ω μ) {u v : Ω → ℝ}
+    (hu : Measurable u) (hv : Measurable v)
+    (hu1 : ∀ x, u x ∈ Icc (0 : ℝ) 1) (hv1 : ∀ y, v y ∈ Icc (0 : ℝ) 1) :
+    |K.testIntegral μ u v| ≤ cutNorm μ K := by
+  have hv1' : ∀ y, v y ∈ Icc (-1 : ℝ) 1 := fun y => ⟨by linarith [(hv1 y).1], (hv1 y).2⟩
+  obtain ⟨S, hS, hSle⟩ := exists_indicator_left_of_mem_Icc μ K hu hv hu1 hv1'
+  have hmemS : ∀ x, S.indicator (1 : Ω → ℝ) x ∈ Icc (-1 : ℝ) 1 := by
+    intro x
+    by_cases hx : x ∈ S <;> simp [hx]
+  rw [K.testIntegral_comm μ (S.indicator 1) v] at hSle
+  obtain ⟨T, hT, hTle⟩ :=
+    exists_indicator_left_of_mem_Icc μ K hv (measurable_one.indicator hS) hv1 hmemS
+  calc |K.testIntegral μ u v|
+      ≤ |K.testIntegral μ v (S.indicator 1)| := hSle
+    _ ≤ |K.testIntegral μ (T.indicator 1) (S.indicator 1)| := hTle
+    _ = |K.rectIntegral μ T S| := by rw [K.testIntegral_indicator_one μ hT hS]
+    _ ≤ cutNorm μ K := abs_rectIntegral_le_cutNorm μ K hT hS
 
 /-- The signed cut norm is the iterated supremum over measurable `[-1,1]`-valued test functions. -/
 theorem cutNormSigned_def (K : SymmKernel Ω μ) :

--- a/TauCeti/MeasureTheory/Constructions/Pi.lean
+++ b/TauCeti/MeasureTheory/Constructions/Pi.lean
@@ -8,10 +8,10 @@ module
 public import Mathlib.MeasureTheory.Constructions.Pi
 
 /-!
-# Refreshing two coordinates of a finite product of probability measures
+# Refreshing two coordinates of a finite product measure
 
-Over a finite product `Measure.pi μ` of probability measures, overwriting two *distinct*
-coordinates by an independent pair samples the same law: the map
+Over a finite product `Measure.pi μ` of sigma-finite measures, overwriting two *distinct*
+probability coordinates by an independent pair samples the same law: the map
 
 `(z, s, t) ↦ Function.update (Function.update z a s) b t`
 
@@ -50,7 +50,8 @@ variable {ι : Type*} [Fintype ι] [DecidableEq ι] {α : ι → Type*}
 /-- Overwriting the two distinct coordinates `a` and `b` of a product-distributed assignment by an
 independent pair leaves the product law unchanged. -/
 theorem measurePreserving_update_update (μ : ∀ i, Measure (α i))
-    [∀ i, IsProbabilityMeasure (μ i)] {a b : ι} (hab : a ≠ b) :
+    [∀ i, SigmaFinite (μ i)] {a b : ι} [IsProbabilityMeasure (μ a)]
+    [IsProbabilityMeasure (μ b)] (hab : a ≠ b) :
     MeasurePreserving
       (fun w : (∀ i, α i) × α a × α b => update (update w.1 a w.2.1) b w.2.2)
       ((Measure.pi μ).prod ((μ a).prod (μ b))) (Measure.pi μ) := by
@@ -98,6 +99,16 @@ theorem measurePreserving_update_update (μ : ∀ i, Measure (α i))
       (MeasurableEquiv.piUnique fun i : t => α i)
       (measurePreserving_piUnique fun i : t => μ i)
   have hselected := (measurePreserving_piFinsetUnion hdis μ).comp (hsingleA.prod hsingleB)
+  have hpi : (@Measure.pi (Subtype p) (fun i => α i)
+      (Finset.Subtype.fintype (s ∪ t)) (fun i => inferInstance) fun i => μ i) =
+      @Measure.pi (Subtype p) (fun i => α i) (Subtype.fintype p)
+        (fun i => inferInstance) fun i => μ i := by
+    congr 1
+    exact Subsingleton.elim _ _
+  let _ : IsProbabilityMeasure (@Measure.pi (Subtype p) (fun i => α i) (Subtype.fintype p)
+      (fun i => inferInstance) fun i => μ i) := by
+    rw [← hpi, ← hselected.map_eq]
+    exact Measure.isProbabilityMeasure_map hselected.measurable.aemeasurable
   have hrest := measurePreserving_snd.comp hsplit
   have hcombine := (hselected.prod hrest).comp
     (Measure.measurePreserving_swap (μ := Measure.pi μ) (ν := (μ a).prod (μ b)))
@@ -108,12 +119,6 @@ theorem measurePreserving_update_update (μ : ∀ i, Measure (α i))
       ((@Measure.pi (Subtype p) (fun i => α i) (Subtype.fintype p)
           (fun i => inferInstance) fun i => μ i).prod
         (Measure.pi fun i : {i // ¬p i} => μ i)) := by
-    have hpi : (@Measure.pi (Subtype p) (fun i => α i)
-        (Finset.Subtype.fintype (s ∪ t)) (fun i => inferInstance) fun i => μ i) =
-        @Measure.pi (Subtype p) (fun i => α i) (Subtype.fintype p)
-          (fun i => inferInstance) fun i => μ i := by
-      congr 1
-      exact Subsingleton.elim _ _
     refine ⟨hcombine.measurable, ?_⟩
     exact hcombine.map_eq.trans
       (congrArg (fun m => m.prod (Measure.pi fun i : {i // ¬p i} => μ i)) hpi)

--- a/TauCeti/MeasureTheory/Constructions/Pi.lean
+++ b/TauCeti/MeasureTheory/Constructions/Pi.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.MeasureTheory.Constructions.Pi
+public import Mathlib.MeasureTheory.Integral.Prod
+
+/-!
+# Refreshing two coordinates of a finite product of probability measures
+
+Over a finite product `Measure.pi fun _ : ι => μ` of copies of one probability measure, overwriting
+two *distinct* coordinates by an independent pair samples the same law: the map
+
+`(z, s, t) ↦ Function.update (Function.update z a s) b t`
+
+pushes `(Measure.pi fun _ => μ) ⊗ (μ ⊗ μ)` forward to `Measure.pi fun _ => μ`. The two overwritten
+coordinates carry the fresh sample and the remaining coordinates keep the ones they had, which is
+the product law again. Combined with Fubini this turns an integral over `ι → Ω` into an outer
+integral over the ambient assignment and an inner *double* integral over the two singled-out
+coordinates — what an estimate that treats two coordinates specially needs.
+
+The hypothesis `a ≠ b` is essential: for `a = b` the second update overwrites the first, and the
+first coordinate of the fresh pair is discarded.
+
+## Main statements
+
+* `TauCeti.MeasureTheory.measurePreserving_update_update` — the two-coordinate refresh is measure
+  preserving;
+* `TauCeti.MeasureTheory.integral_pi_eq_integral_integral_update` — the resulting Fubini identity.
+
+## Implementation
+
+The measure-preserving statement is checked on measurable boxes through `Measure.pi_eq`. The
+preimage of a box `univ.pi s` is again a box: the two fresh coordinates are constrained by `s a`
+and `s b`, and the ambient assignment by `s` with those two entries relaxed to `Set.univ` — which
+is `Function.update (Function.update s a univ) b univ`, so the same three evaluation rules for a
+doubly updated function drive both the set computation and the product computation.
+-/
+
+public section
+
+open Function MeasureTheory Set
+
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] {Ω : Type*} [MeasurableSpace Ω]
+
+/-- Overwriting the two distinct coordinates `a` and `b` of a product-distributed assignment by an
+independent pair leaves the product law unchanged. -/
+theorem measurePreserving_update_update (μ : Measure Ω) [IsProbabilityMeasure μ] {a b : ι}
+    (hab : a ≠ b) :
+    MeasurePreserving (fun w : (ι → Ω) × Ω × Ω => update (update w.1 a w.2.1) b w.2.2)
+      ((Measure.pi fun _ : ι => μ).prod (μ.prod μ)) (Measure.pi fun _ : ι => μ) := by
+  have hmeas : Measurable
+      fun w : (ι → Ω) × Ω × Ω => update (update w.1 a w.2.1) b w.2.2 := by fun_prop
+  refine ⟨hmeas, ?_⟩
+  refine (Measure.pi_eq fun s hs => ?_).symm
+  -- The three evaluation rules for a doubly updated assignment.
+  have hzb : ∀ (z : ι → Ω) (u t : Ω), update (update z a u) b t b = t :=
+    fun z u t => update_self b t (update z a u)
+  have hza : ∀ (z : ι → Ω) (u t : Ω), update (update z a u) b t a = u := by
+    intro z u t
+    rw [update_of_ne hab t (update z a u), update_self a u z]
+  have hzo : ∀ (z : ι → Ω) (u t : Ω) (i : ι), i ≠ a → i ≠ b →
+      update (update z a u) b t i = z i := by
+    intro z u t i hia hib
+    rw [update_of_ne hib t (update z a u), update_of_ne hia u z]
+  -- The assignment box: `s` with the two overwritten entries relaxed to `Set.univ`.
+  set s' : ι → Set Ω := update (update s a univ) b univ with hs'
+  have hs'b : s' b = univ := by rw [hs']; exact update_self b univ (update s a univ)
+  have hs'a : s' a = univ := by
+    rw [hs', update_of_ne hab univ (update s a univ), update_self a univ s]
+  have hs'o : ∀ i, i ≠ a → i ≠ b → s' i = s i := by
+    intro i hia hib
+    rw [hs', update_of_ne hib univ (update s a univ), update_of_ne hia univ s]
+  have hpre : (fun w : (ι → Ω) × Ω × Ω => update (update w.1 a w.2.1) b w.2.2) ⁻¹' univ.pi s =
+      (univ.pi s') ×ˢ (s a ×ˢ s b) := by
+    ext ⟨z, u, t⟩
+    simp only [mem_preimage, Set.mem_univ_pi, Set.mem_prod]
+    constructor
+    · intro h
+      refine ⟨fun i => ?_, ?_, ?_⟩
+      · by_cases hib : i = b
+        · rw [hib, hs'b]; exact mem_univ t
+        · by_cases hia : i = a
+          · rw [hia, hs'a]; exact mem_univ u
+          · rw [hs'o i hia hib]
+            have := h i
+            rwa [hzo z u t i hia hib] at this
+      · have := h a; rwa [hza] at this
+      · have := h b; rwa [hzb] at this
+    · rintro ⟨hz, hu, ht⟩ i
+      by_cases hib : i = b
+      · rw [hib, hzb]; rw [hib] at *; exact ht
+      · by_cases hia : i = a
+        · rw [hia, hza]; rw [hia] at *; exact hu
+        · rw [hzo z u t i hia hib]
+          have := hz i
+          rwa [hs'o i hia hib] at this
+  rw [Measure.map_apply hmeas (MeasurableSet.univ_pi hs), hpre, Measure.prod_prod,
+    Measure.prod_prod, Measure.pi_pi]
+  have hb' : b ∈ Finset.univ.erase a := Finset.mem_erase.2 ⟨hab.symm, Finset.mem_univ b⟩
+  have hrest : ∏ i ∈ (Finset.univ.erase a).erase b, μ (s' i)
+      = ∏ i ∈ (Finset.univ.erase a).erase b, μ (s i) := by
+    refine Finset.prod_congr rfl fun i hi => ?_
+    rw [hs'o i (Finset.ne_of_mem_erase (Finset.mem_of_mem_erase hi))
+      (Finset.ne_of_mem_erase hi)]
+  have h1 : (∏ i ∈ (Finset.univ.erase a).erase b, μ (s i)) * μ (s b) * μ (s a)
+      = ∏ i, μ (s i) := by
+    rw [Finset.prod_erase_mul (Finset.univ.erase a) (fun i => μ (s i)) hb',
+      Finset.prod_erase_mul Finset.univ (fun i => μ (s i)) (Finset.mem_univ a)]
+  have h2 : (∏ i ∈ (Finset.univ.erase a).erase b, μ (s' i)) * μ (s' b) * μ (s' a)
+      = ∏ i, μ (s' i) := by
+    rw [Finset.prod_erase_mul (Finset.univ.erase a) (fun i => μ (s' i)) hb',
+      Finset.prod_erase_mul Finset.univ (fun i => μ (s' i)) (Finset.mem_univ a)]
+  calc (∏ i, μ (s' i)) * (μ (s a) * μ (s b))
+      = ((∏ i ∈ (Finset.univ.erase a).erase b, μ (s' i)) * μ (s' b) * μ (s' a))
+          * (μ (s a) * μ (s b)) := by rw [h2]
+    _ = (∏ i ∈ (Finset.univ.erase a).erase b, μ (s i)) * μ (s b) * μ (s a) := by
+        rw [hrest, hs'a, hs'b, measure_univ]; ring
+    _ = ∏ i, μ (s i) := h1
+
+/-- **Fubini after a two-coordinate refresh.** An integral over `ι → Ω` against a finite product of
+copies of a probability measure is an outer integral over the assignment and an inner integral over
+a fresh independent pair placed at the two distinct coordinates `a` and `b`. -/
+theorem integral_pi_eq_integral_integral_update {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] (μ : Measure Ω) [IsProbabilityMeasure μ] {a b : ι} (hab : a ≠ b)
+    {f : (ι → Ω) → E} (hf : Integrable f (Measure.pi fun _ : ι => μ)) :
+    ∫ z, (∫ p : Ω × Ω, f (update (update z a p.1) b p.2) ∂μ.prod μ)
+        ∂(Measure.pi fun _ : ι => μ)
+      = ∫ x, f x ∂(Measure.pi fun _ : ι => μ) := by
+  set g : (ι → Ω) × Ω × Ω → ι → Ω :=
+    fun w => update (update w.1 a w.2.1) b w.2.2 with hg
+  have hmp := measurePreserving_update_update (ι := ι) μ hab
+  have hcomp : Integrable (fun w => f (g w))
+      ((Measure.pi fun _ : ι => μ).prod (μ.prod μ)) :=
+    hmp.integrable_comp_of_integrable hf
+  have hae : AEStronglyMeasurable f
+      (Measure.map g ((Measure.pi fun _ : ι => μ).prod (μ.prod μ))) := by
+    rw [hmp.map_eq]
+    exact hf.aestronglyMeasurable
+  calc ∫ z, (∫ p : Ω × Ω, f (update (update z a p.1) b p.2) ∂μ.prod μ)
+        ∂(Measure.pi fun _ : ι => μ)
+      = ∫ w, f (g w) ∂((Measure.pi fun _ : ι => μ).prod (μ.prod μ)) :=
+        (integral_prod _ hcomp).symm
+    _ = ∫ x, f x ∂(Measure.map g ((Measure.pi fun _ : ι => μ).prod (μ.prod μ))) :=
+        (integral_map hmp.measurable.aemeasurable hae).symm
+    _ = ∫ x, f x ∂(Measure.pi fun _ : ι => μ) := by rw [hmp.map_eq]
+
+end MeasureTheory
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Constructions/Pi.lean
+++ b/TauCeti/MeasureTheory/Constructions/Pi.lean
@@ -62,20 +62,32 @@ theorem measurePreserving_update_update (μ : ∀ i, Measure (α i))
   let unionEquiv := MeasurableEquiv.piFinsetUnion α hdis
   let singleA := (MeasurableEquiv.piUnique fun i : s => α i).symm
   let singleB := (MeasurableEquiv.piUnique fun i : t => α i).symm
+  have singleA_apply (u : α a) : singleA u ⟨a, by simp [s]⟩ = u := by
+    simp only [singleA, MeasurableEquiv.piUnique_symm_apply]
+    unfold uniqueElim
+    rfl
+  have singleB_apply (v : α b) : singleB v ⟨b, by simp [t]⟩ = v := by
+    simp only [singleB, MeasurableEquiv.piUnique_symm_apply]
+    unfold uniqueElim
+    rfl
   have unionEquiv_a (u : α a) (v : α b) (ha : a ∈ s ∪ t) :
       unionEquiv (singleA u, singleB v) ⟨a, ha⟩ = u := by
-    change (Equiv.piFinsetUnion α hdis) (singleA u, singleB v) ⟨a, ha⟩ = u
+    rw [show unionEquiv (singleA u, singleB v) ⟨a, ha⟩ =
+      (Equiv.piFinsetUnion α hdis) (singleA u, singleB v) ⟨a, ha⟩ from rfl]
     rw [Equiv.piFinsetUnion_left α hdis (by simp [s]) ha]
-    change uniqueElim (α := fun i : s => α i) u (⟨a, by simp [s]⟩ : s) = u
-    unfold uniqueElim
-    rfl
+    exact singleA_apply u
   have unionEquiv_b (u : α a) (v : α b) (hb : b ∈ s ∪ t) :
       unionEquiv (singleA u, singleB v) ⟨b, hb⟩ = v := by
-    change (Equiv.piFinsetUnion α hdis) (singleA u, singleB v) ⟨b, hb⟩ = v
+    rw [show unionEquiv (singleA u, singleB v) ⟨b, hb⟩ =
+      (Equiv.piFinsetUnion α hdis) (singleA u, singleB v) ⟨b, hb⟩ from rfl]
     rw [Equiv.piFinsetUnion_right α hdis (by simp [t]) hb]
-    change uniqueElim (α := fun i : t => α i) v (⟨b, by simp [t]⟩ : t) = v
-    unfold uniqueElim
-    rfl
+    exact singleB_apply v
+  have splitEquiv_symm_apply (x : ∀ i : Subtype p, α i)
+      (y : ∀ i : {i // ¬p i}, α i) (i : ι) :
+      splitEquiv.symm (x, y) i = if hi : p i then x ⟨i, hi⟩ else y ⟨i, hi⟩ :=
+    Equiv.piEquivPiSubtypeProd_symm_apply p α (x, y) i
+  have splitEquiv_snd_apply (z : ∀ i, α i) (i : ι) (hi : ¬p i) :
+      (splitEquiv z).2 ⟨i, hi⟩ = z i := rfl
   have hsplit := measurePreserving_piEquivPiSubtypeProd μ p
   have hsingleA : MeasurePreserving singleA (μ a) (Measure.pi fun i : s => μ i) := by
     simpa [singleA, s] using MeasurePreserving.symm
@@ -108,36 +120,25 @@ theorem measurePreserving_update_update (μ : ∀ i, Measure (α i))
   have hrefresh := (MeasurePreserving.symm splitEquiv hsplit).comp hcombine'
   refine hrefresh.congr (by fun_prop) (ae_of_all _ fun w => ?_)
   funext i
+  -- `MeasurePreserving.comp` stores this composite function definitionally; expose it once, then
+  -- use the application lemmas above for all measurable-equivalence wrappers.
   change splitEquiv.symm
       (unionEquiv (singleA w.2.1, singleB w.2.2), (splitEquiv w.1).2) i =
     update (update w.1 a w.2.1) b w.2.2 i
+  rw [splitEquiv_symm_apply]
   by_cases hia : i = a
   · subst i
-    change (Equiv.piEquivPiSubtypeProd p α).symm
-      (unionEquiv (singleA w.2.1, singleB w.2.2),
-        ((Equiv.piEquivPiSubtypeProd p α) w.1).2) a =
-      update (update w.1 a w.2.1) b w.2.2 a
-    rw [Equiv.piEquivPiSubtypeProd_symm_apply]
     simp only [p, s, t, Finset.mem_union, Finset.mem_singleton, true_or, dite_true]
     rw [unionEquiv_a]
     simp [hab]
   · by_cases hib : i = b
     · subst i
       rw [update_self]
-      change (Equiv.piEquivPiSubtypeProd p α).symm
-        (unionEquiv (singleA w.2.1, singleB w.2.2),
-          ((Equiv.piEquivPiSubtypeProd p α) w.1).2) b = w.2.2
-      rw [Equiv.piEquivPiSubtypeProd_symm_apply]
       simp only [p, s, t, Finset.mem_union, Finset.mem_singleton, or_true, dite_true]
       rw [unionEquiv_b]
-    · change (Equiv.piEquivPiSubtypeProd p α).symm
-        (unionEquiv (singleA w.2.1, singleB w.2.2),
-          ((Equiv.piEquivPiSubtypeProd p α) w.1).2) i =
-        update (update w.1 a w.2.1) b w.2.2 i
-      rw [Equiv.piEquivPiSubtypeProd_symm_apply]
-      simp only [p, s, t, Finset.mem_union, Finset.mem_singleton, hia, hib, false_or,
+    · simp only [p, s, t, Finset.mem_union, Finset.mem_singleton, hia, hib, false_or,
         dite_false]
-      change w.1 i = update (update w.1 a w.2.1) b w.2.2 i
+      rw [splitEquiv_snd_apply]
       rw [update_of_ne hib, update_of_ne hia]
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Constructions/Pi.lean
+++ b/TauCeti/MeasureTheory/Constructions/Pi.lean
@@ -6,30 +6,27 @@ Authors: Claude
 module
 
 public import Mathlib.MeasureTheory.Constructions.Pi
-public import Mathlib.MeasureTheory.Integral.Prod
 
 /-!
 # Refreshing two coordinates of a finite product of probability measures
 
-Over a finite product `Measure.pi fun _ : ι => μ` of copies of one probability measure, overwriting
-two *distinct* coordinates by an independent pair samples the same law: the map
+Over a finite product `Measure.pi μ` of probability measures, overwriting two *distinct*
+coordinates by an independent pair samples the same law: the map
 
 `(z, s, t) ↦ Function.update (Function.update z a s) b t`
 
-pushes `(Measure.pi fun _ => μ) ⊗ (μ ⊗ μ)` forward to `Measure.pi fun _ => μ`. The two overwritten
-coordinates carry the fresh sample and the remaining coordinates keep the ones they had, which is
-the product law again. Combined with Fubini this turns an integral over `ι → Ω` into an outer
-integral over the ambient assignment and an inner *double* integral over the two singled-out
-coordinates — what an estimate that treats two coordinates specially needs.
+pushes `(Measure.pi μ) ⊗ (μ a ⊗ μ b)` forward to `Measure.pi μ`. The two overwritten coordinates
+carry the fresh samples and the remaining coordinates keep the ones they had, which is the product
+law again.
 
-The hypothesis `a ≠ b` is essential: for `a = b` the second update overwrites the first, and the
-first coordinate of the fresh pair is discarded.
+For `a = b` the pair degenerates to a single refresh because the second update overwrites the
+first. The distinctness hypothesis records the two-slot factorisation needed by consumers of this
+construction.
 
 ## Main statements
 
-* `TauCeti.MeasureTheory.measurePreserving_update_update` — the two-coordinate refresh is measure
-  preserving;
-* `TauCeti.MeasureTheory.integral_pi_eq_integral_integral_update` — the resulting Fubini identity.
+* `TauCeti.measurePreserving_update_update` — the two-coordinate refresh is measure
+  preserving.
 
 ## Implementation
 
@@ -48,39 +45,41 @@ open scoped ENNReal
 
 namespace TauCeti
 
-namespace MeasureTheory
-
-variable {ι : Type*} [Fintype ι] [DecidableEq ι] {Ω : Type*} [MeasurableSpace Ω]
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] {α : ι → Type*}
+  [∀ i, MeasurableSpace (α i)]
 
 /-- Overwriting the two distinct coordinates `a` and `b` of a product-distributed assignment by an
 independent pair leaves the product law unchanged. -/
-theorem measurePreserving_update_update (μ : Measure Ω) [IsProbabilityMeasure μ] {a b : ι}
-    (hab : a ≠ b) :
-    MeasurePreserving (fun w : (ι → Ω) × Ω × Ω => update (update w.1 a w.2.1) b w.2.2)
-      ((Measure.pi fun _ : ι => μ).prod (μ.prod μ)) (Measure.pi fun _ : ι => μ) := by
+theorem measurePreserving_update_update (μ : ∀ i, Measure (α i))
+    [∀ i, IsProbabilityMeasure (μ i)] {a b : ι} (hab : a ≠ b) :
+    MeasurePreserving
+      (fun w : (∀ i, α i) × α a × α b => update (update w.1 a w.2.1) b w.2.2)
+      ((Measure.pi μ).prod ((μ a).prod (μ b))) (Measure.pi μ) := by
   have hmeas : Measurable
-      fun w : (ι → Ω) × Ω × Ω => update (update w.1 a w.2.1) b w.2.2 := by fun_prop
+      fun w : (∀ i, α i) × α a × α b => update (update w.1 a w.2.1) b w.2.2 := by fun_prop
   refine ⟨hmeas, ?_⟩
   refine (Measure.pi_eq fun s hs => ?_).symm
   -- The three evaluation rules for a doubly updated assignment.
-  have hzb : ∀ (z : ι → Ω) (u t : Ω), update (update z a u) b t b = t :=
+  have hzb : ∀ (z : ∀ i, α i) (u : α a) (t : α b), update (update z a u) b t b = t :=
     fun z u t => update_self b t (update z a u)
-  have hza : ∀ (z : ι → Ω) (u t : Ω), update (update z a u) b t a = u := by
+  have hza : ∀ (z : ∀ i, α i) (u : α a) (t : α b), update (update z a u) b t a = u := by
     intro z u t
     rw [update_of_ne hab t (update z a u), update_self a u z]
-  have hzo : ∀ (z : ι → Ω) (u t : Ω) (i : ι), i ≠ a → i ≠ b →
+  have hzo : ∀ (z : ∀ i, α i) (u : α a) (t : α b) (i : ι), i ≠ a → i ≠ b →
       update (update z a u) b t i = z i := by
     intro z u t i hia hib
     rw [update_of_ne hib t (update z a u), update_of_ne hia u z]
   -- The assignment box: `s` with the two overwritten entries relaxed to `Set.univ`.
-  set s' : ι → Set Ω := update (update s a univ) b univ with hs'
+  set s' : ∀ i, Set (α i) := update (update s a univ) b univ with hs'
   have hs'b : s' b = univ := by rw [hs']; exact update_self b univ (update s a univ)
   have hs'a : s' a = univ := by
     rw [hs', update_of_ne hab univ (update s a univ), update_self a univ s]
   have hs'o : ∀ i, i ≠ a → i ≠ b → s' i = s i := by
     intro i hia hib
     rw [hs', update_of_ne hib univ (update s a univ), update_of_ne hia univ s]
-  have hpre : (fun w : (ι → Ω) × Ω × Ω => update (update w.1 a w.2.1) b w.2.2) ⁻¹' univ.pi s =
+  have hpre :
+      (fun w : (∀ i, α i) × α a × α b => update (update w.1 a w.2.1) b w.2.2) ⁻¹'
+          univ.pi s =
       (univ.pi s') ×ˢ (s a ×ˢ s b) := by
     ext ⟨z, u, t⟩
     simp only [mem_preimage, Set.mem_univ_pi, Set.mem_prod]
@@ -98,62 +97,38 @@ theorem measurePreserving_update_update (μ : Measure Ω) [IsProbabilityMeasure 
       · have := h b; rwa [hzb] at this
     · rintro ⟨hz, hu, ht⟩ i
       by_cases hib : i = b
-      · rw [hib, hzb]; rw [hib] at *; exact ht
+      · subst hib
+        rw [hzb]
+        exact ht
       · by_cases hia : i = a
-        · rw [hia, hza]; rw [hia] at *; exact hu
+        · subst hia
+          rw [hza]
+          exact hu
         · rw [hzo z u t i hia hib]
           have := hz i
           rwa [hs'o i hia hib] at this
   rw [Measure.map_apply hmeas (MeasurableSet.univ_pi hs), hpre, Measure.prod_prod,
     Measure.prod_prod, Measure.pi_pi]
   have hb' : b ∈ Finset.univ.erase a := Finset.mem_erase.2 ⟨hab.symm, Finset.mem_univ b⟩
-  have hrest : ∏ i ∈ (Finset.univ.erase a).erase b, μ (s' i)
-      = ∏ i ∈ (Finset.univ.erase a).erase b, μ (s i) := by
+  have hrest : ∏ i ∈ (Finset.univ.erase a).erase b, μ i (s' i)
+      = ∏ i ∈ (Finset.univ.erase a).erase b, μ i (s i) := by
     refine Finset.prod_congr rfl fun i hi => ?_
     rw [hs'o i (Finset.ne_of_mem_erase (Finset.mem_of_mem_erase hi))
       (Finset.ne_of_mem_erase hi)]
-  have h1 : (∏ i ∈ (Finset.univ.erase a).erase b, μ (s i)) * μ (s b) * μ (s a)
-      = ∏ i, μ (s i) := by
-    rw [Finset.prod_erase_mul (Finset.univ.erase a) (fun i => μ (s i)) hb',
-      Finset.prod_erase_mul Finset.univ (fun i => μ (s i)) (Finset.mem_univ a)]
-  have h2 : (∏ i ∈ (Finset.univ.erase a).erase b, μ (s' i)) * μ (s' b) * μ (s' a)
-      = ∏ i, μ (s' i) := by
-    rw [Finset.prod_erase_mul (Finset.univ.erase a) (fun i => μ (s' i)) hb',
-      Finset.prod_erase_mul Finset.univ (fun i => μ (s' i)) (Finset.mem_univ a)]
-  calc (∏ i, μ (s' i)) * (μ (s a) * μ (s b))
-      = ((∏ i ∈ (Finset.univ.erase a).erase b, μ (s' i)) * μ (s' b) * μ (s' a))
-          * (μ (s a) * μ (s b)) := by rw [h2]
-    _ = (∏ i ∈ (Finset.univ.erase a).erase b, μ (s i)) * μ (s b) * μ (s a) := by
-        rw [hrest, hs'a, hs'b, measure_univ]; ring
-    _ = ∏ i, μ (s i) := h1
-
-/-- **Fubini after a two-coordinate refresh.** An integral over `ι → Ω` against a finite product of
-copies of a probability measure is an outer integral over the assignment and an inner integral over
-a fresh independent pair placed at the two distinct coordinates `a` and `b`. -/
-theorem integral_pi_eq_integral_integral_update {E : Type*} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] (μ : Measure Ω) [IsProbabilityMeasure μ] {a b : ι} (hab : a ≠ b)
-    {f : (ι → Ω) → E} (hf : Integrable f (Measure.pi fun _ : ι => μ)) :
-    ∫ z, (∫ p : Ω × Ω, f (update (update z a p.1) b p.2) ∂μ.prod μ)
-        ∂(Measure.pi fun _ : ι => μ)
-      = ∫ x, f x ∂(Measure.pi fun _ : ι => μ) := by
-  set g : (ι → Ω) × Ω × Ω → ι → Ω :=
-    fun w => update (update w.1 a w.2.1) b w.2.2 with hg
-  have hmp := measurePreserving_update_update (ι := ι) μ hab
-  have hcomp : Integrable (fun w => f (g w))
-      ((Measure.pi fun _ : ι => μ).prod (μ.prod μ)) :=
-    hmp.integrable_comp_of_integrable hf
-  have hae : AEStronglyMeasurable f
-      (Measure.map g ((Measure.pi fun _ : ι => μ).prod (μ.prod μ))) := by
-    rw [hmp.map_eq]
-    exact hf.aestronglyMeasurable
-  calc ∫ z, (∫ p : Ω × Ω, f (update (update z a p.1) b p.2) ∂μ.prod μ)
-        ∂(Measure.pi fun _ : ι => μ)
-      = ∫ w, f (g w) ∂((Measure.pi fun _ : ι => μ).prod (μ.prod μ)) :=
-        (integral_prod _ hcomp).symm
-    _ = ∫ x, f x ∂(Measure.map g ((Measure.pi fun _ : ι => μ).prod (μ.prod μ))) :=
-        (integral_map hmp.measurable.aemeasurable hae).symm
-    _ = ∫ x, f x ∂(Measure.pi fun _ : ι => μ) := by rw [hmp.map_eq]
-
-end MeasureTheory
+  have h1 : (∏ i ∈ (Finset.univ.erase a).erase b, μ i (s i)) * μ b (s b) * μ a (s a)
+      = ∏ i, μ i (s i) := by
+    rw [Finset.prod_erase_mul (Finset.univ.erase a) (fun i => μ i (s i)) hb',
+      Finset.prod_erase_mul Finset.univ (fun i => μ i (s i)) (Finset.mem_univ a)]
+  have h2 : (∏ i ∈ (Finset.univ.erase a).erase b, μ i (s' i)) * μ b (s' b) * μ a (s' a)
+      = ∏ i, μ i (s' i) := by
+    rw [Finset.prod_erase_mul (Finset.univ.erase a) (fun i => μ i (s' i)) hb',
+      Finset.prod_erase_mul Finset.univ (fun i => μ i (s' i)) (Finset.mem_univ a)]
+  calc (∏ i, μ i (s' i)) * (μ a (s a) * μ b (s b))
+      = ((∏ i ∈ (Finset.univ.erase a).erase b, μ i (s' i)) * μ b (s' b) * μ a (s' a))
+          * (μ a (s a) * μ b (s b)) := by rw [h2]
+    _ = (∏ i ∈ (Finset.univ.erase a).erase b, μ i (s i)) * μ b (s b) * μ a (s a) := by
+        rw [hrest, hs'a, hs'b, measure_univ (μ := μ a), measure_univ (μ := μ b)]
+        ring
+    _ = ∏ i, μ i (s i) := h1
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Constructions/Pi.lean
+++ b/TauCeti/MeasureTheory/Constructions/Pi.lean
@@ -71,17 +71,19 @@ theorem measurePreserving_update_update (μ : ∀ i, Measure (α i))
     simp only [singleB, MeasurableEquiv.piUnique_symm_apply]
     unfold uniqueElim
     rfl
+  -- `MeasurableEquiv.piFinsetUnion` is by definition `Equiv.piFinsetUnion` carrying the
+  -- measurability proofs, and Mathlib states the componentwise lemmas
+  -- `Equiv.piFinsetUnion_left`/`_right` only for the bare equivalence. Bridge the two once here,
+  -- so that neither case below unfolds the measurable-equivalence wrapper again.
+  have unionEquiv_coe (w : ((i : s) → α i) × ((i : t) → α i)) :
+      unionEquiv w = Equiv.piFinsetUnion α hdis w := rfl
   have unionEquiv_a (u : α a) (v : α b) (ha : a ∈ s ∪ t) :
       unionEquiv (singleA u, singleB v) ⟨a, ha⟩ = u := by
-    rw [show unionEquiv (singleA u, singleB v) ⟨a, ha⟩ =
-      (Equiv.piFinsetUnion α hdis) (singleA u, singleB v) ⟨a, ha⟩ from rfl]
-    rw [Equiv.piFinsetUnion_left α hdis (by simp [s]) ha]
+    rw [unionEquiv_coe, Equiv.piFinsetUnion_left α hdis (by simp [s]) ha]
     exact singleA_apply u
   have unionEquiv_b (u : α a) (v : α b) (hb : b ∈ s ∪ t) :
       unionEquiv (singleA u, singleB v) ⟨b, hb⟩ = v := by
-    rw [show unionEquiv (singleA u, singleB v) ⟨b, hb⟩ =
-      (Equiv.piFinsetUnion α hdis) (singleA u, singleB v) ⟨b, hb⟩ from rfl]
-    rw [Equiv.piFinsetUnion_right α hdis (by simp [t]) hb]
+    rw [unionEquiv_coe, Equiv.piFinsetUnion_right α hdis (by simp [t]) hb]
     exact singleB_apply v
   have splitEquiv_symm_apply (x : ∀ i : Subtype p, α i)
       (y : ∀ i : {i // ¬p i}, α i) (i : ι) :

--- a/TauCeti/MeasureTheory/Constructions/Pi.lean
+++ b/TauCeti/MeasureTheory/Constructions/Pi.lean
@@ -30,11 +30,10 @@ construction.
 
 ## Implementation
 
-The measure-preserving statement is checked on measurable boxes through `Measure.pi_eq`. The
-preimage of a box `univ.pi s` is again a box: the two fresh coordinates are constrained by `s a`
-and `s b`, and the ambient assignment by `s` with those two entries relaxed to `Set.univ` — which
-is `Function.update (Function.update s a univ) b univ`, so the same three evaluation rules for a
-doubly updated function drive both the set computation and the product computation.
+The proof splits the product into the coordinates `{a, b}` and their complement using Mathlib's
+measure-preserving product equivalences. The fresh pair replaces the selected coordinates, while
+the complementary coordinates are projected from the original assignment; recombining the two
+parts is pointwise the double update.
 -/
 
 public section
@@ -55,80 +54,90 @@ theorem measurePreserving_update_update (μ : ∀ i, Measure (α i))
     MeasurePreserving
       (fun w : (∀ i, α i) × α a × α b => update (update w.1 a w.2.1) b w.2.2)
       ((Measure.pi μ).prod ((μ a).prod (μ b))) (Measure.pi μ) := by
-  have hmeas : Measurable
-      fun w : (∀ i, α i) × α a × α b => update (update w.1 a w.2.1) b w.2.2 := by fun_prop
-  refine ⟨hmeas, ?_⟩
-  refine (Measure.pi_eq fun s hs => ?_).symm
-  -- The three evaluation rules for a doubly updated assignment.
-  have hzb : ∀ (z : ∀ i, α i) (u : α a) (t : α b), update (update z a u) b t b = t :=
-    fun z u t => update_self b t (update z a u)
-  have hza : ∀ (z : ∀ i, α i) (u : α a) (t : α b), update (update z a u) b t a = u := by
-    intro z u t
-    rw [update_of_ne hab t (update z a u), update_self a u z]
-  have hzo : ∀ (z : ∀ i, α i) (u : α a) (t : α b) (i : ι), i ≠ a → i ≠ b →
-      update (update z a u) b t i = z i := by
-    intro z u t i hia hib
-    rw [update_of_ne hib t (update z a u), update_of_ne hia u z]
-  -- The assignment box: `s` with the two overwritten entries relaxed to `Set.univ`.
-  set s' : ∀ i, Set (α i) := update (update s a univ) b univ with hs'
-  have hs'b : s' b = univ := by rw [hs']; exact update_self b univ (update s a univ)
-  have hs'a : s' a = univ := by
-    rw [hs', update_of_ne hab univ (update s a univ), update_self a univ s]
-  have hs'o : ∀ i, i ≠ a → i ≠ b → s' i = s i := by
-    intro i hia hib
-    rw [hs', update_of_ne hib univ (update s a univ), update_of_ne hia univ s]
-  have hpre :
-      (fun w : (∀ i, α i) × α a × α b => update (update w.1 a w.2.1) b w.2.2) ⁻¹'
-          univ.pi s =
-      (univ.pi s') ×ˢ (s a ×ˢ s b) := by
-    ext ⟨z, u, t⟩
-    simp only [mem_preimage, Set.mem_univ_pi, Set.mem_prod]
-    constructor
-    · intro h
-      refine ⟨fun i => ?_, ?_, ?_⟩
-      · by_cases hib : i = b
-        · rw [hib, hs'b]; exact mem_univ t
-        · by_cases hia : i = a
-          · rw [hia, hs'a]; exact mem_univ u
-          · rw [hs'o i hia hib]
-            have := h i
-            rwa [hzo z u t i hia hib] at this
-      · have := h a; rwa [hza] at this
-      · have := h b; rwa [hzb] at this
-    · rintro ⟨hz, hu, ht⟩ i
-      by_cases hib : i = b
-      · subst hib
-        rw [hzb]
-        exact ht
-      · by_cases hia : i = a
-        · subst hia
-          rw [hza]
-          exact hu
-        · rw [hzo z u t i hia hib]
-          have := hz i
-          rwa [hs'o i hia hib] at this
-  rw [Measure.map_apply hmeas (MeasurableSet.univ_pi hs), hpre, Measure.prod_prod,
-    Measure.prod_prod, Measure.pi_pi]
-  have hb' : b ∈ Finset.univ.erase a := Finset.mem_erase.2 ⟨hab.symm, Finset.mem_univ b⟩
-  have hrest : ∏ i ∈ (Finset.univ.erase a).erase b, μ i (s' i)
-      = ∏ i ∈ (Finset.univ.erase a).erase b, μ i (s i) := by
-    refine Finset.prod_congr rfl fun i hi => ?_
-    rw [hs'o i (Finset.ne_of_mem_erase (Finset.mem_of_mem_erase hi))
-      (Finset.ne_of_mem_erase hi)]
-  have h1 : (∏ i ∈ (Finset.univ.erase a).erase b, μ i (s i)) * μ b (s b) * μ a (s a)
-      = ∏ i, μ i (s i) := by
-    rw [Finset.prod_erase_mul (Finset.univ.erase a) (fun i => μ i (s i)) hb',
-      Finset.prod_erase_mul Finset.univ (fun i => μ i (s i)) (Finset.mem_univ a)]
-  have h2 : (∏ i ∈ (Finset.univ.erase a).erase b, μ i (s' i)) * μ b (s' b) * μ a (s' a)
-      = ∏ i, μ i (s' i) := by
-    rw [Finset.prod_erase_mul (Finset.univ.erase a) (fun i => μ i (s' i)) hb',
-      Finset.prod_erase_mul Finset.univ (fun i => μ i (s' i)) (Finset.mem_univ a)]
-  calc (∏ i, μ i (s' i)) * (μ a (s a) * μ b (s b))
-      = ((∏ i ∈ (Finset.univ.erase a).erase b, μ i (s' i)) * μ b (s' b) * μ a (s' a))
-          * (μ a (s a) * μ b (s b)) := by rw [h2]
-    _ = (∏ i ∈ (Finset.univ.erase a).erase b, μ i (s i)) * μ b (s b) * μ a (s a) := by
-        rw [hrest, hs'a, hs'b, measure_univ (μ := μ a), measure_univ (μ := μ b)]
-        ring
-    _ = ∏ i, μ i (s i) := h1
+  let s : Finset ι := {a}
+  let t : Finset ι := {b}
+  have hdis : Disjoint s t := by simp [s, t, hab]
+  let p : ι → Prop := fun i => i ∈ s ∪ t
+  let splitEquiv := MeasurableEquiv.piEquivPiSubtypeProd α p
+  let unionEquiv := MeasurableEquiv.piFinsetUnion α hdis
+  let singleA := (MeasurableEquiv.piUnique fun i : s => α i).symm
+  let singleB := (MeasurableEquiv.piUnique fun i : t => α i).symm
+  have unionEquiv_a (u : α a) (v : α b) (ha : a ∈ s ∪ t) :
+      unionEquiv (singleA u, singleB v) ⟨a, ha⟩ = u := by
+    change (Equiv.piFinsetUnion α hdis) (singleA u, singleB v) ⟨a, ha⟩ = u
+    rw [Equiv.piFinsetUnion_left α hdis (by simp [s]) ha]
+    change uniqueElim (α := fun i : s => α i) u (⟨a, by simp [s]⟩ : s) = u
+    unfold uniqueElim
+    rfl
+  have unionEquiv_b (u : α a) (v : α b) (hb : b ∈ s ∪ t) :
+      unionEquiv (singleA u, singleB v) ⟨b, hb⟩ = v := by
+    change (Equiv.piFinsetUnion α hdis) (singleA u, singleB v) ⟨b, hb⟩ = v
+    rw [Equiv.piFinsetUnion_right α hdis (by simp [t]) hb]
+    change uniqueElim (α := fun i : t => α i) v (⟨b, by simp [t]⟩ : t) = v
+    unfold uniqueElim
+    rfl
+  have hsplit := measurePreserving_piEquivPiSubtypeProd μ p
+  have hsingleA : MeasurePreserving singleA (μ a) (Measure.pi fun i : s => μ i) := by
+    simpa [singleA, s] using MeasurePreserving.symm
+      (MeasurableEquiv.piUnique fun i : s => α i)
+      (measurePreserving_piUnique fun i : s => μ i)
+  have hsingleB : MeasurePreserving singleB (μ b) (Measure.pi fun i : t => μ i) := by
+    simpa [singleB, t] using MeasurePreserving.symm
+      (MeasurableEquiv.piUnique fun i : t => α i)
+      (measurePreserving_piUnique fun i : t => μ i)
+  have hselected := (measurePreserving_piFinsetUnion hdis μ).comp (hsingleA.prod hsingleB)
+  have hrest := measurePreserving_snd.comp hsplit
+  have hcombine := (hselected.prod hrest).comp
+    (Measure.measurePreserving_swap (μ := Measure.pi μ) (ν := (μ a).prod (μ b)))
+  have hcombine' : MeasurePreserving
+      (Prod.map ((MeasurableEquiv.piFinsetUnion α hdis) ∘ Prod.map singleA singleB)
+        (Prod.snd ∘ MeasurableEquiv.piEquivPiSubtypeProd α p) ∘ Prod.swap)
+      ((Measure.pi μ).prod ((μ a).prod (μ b)))
+      ((@Measure.pi (Subtype p) (fun i => α i) (Subtype.fintype p)
+          (fun i => inferInstance) fun i => μ i).prod
+        (Measure.pi fun i : {i // ¬p i} => μ i)) := by
+    have hpi : (@Measure.pi (Subtype p) (fun i => α i)
+        (Finset.Subtype.fintype (s ∪ t)) (fun i => inferInstance) fun i => μ i) =
+        @Measure.pi (Subtype p) (fun i => α i) (Subtype.fintype p)
+          (fun i => inferInstance) fun i => μ i := by
+      congr 1
+      exact Subsingleton.elim _ _
+    refine ⟨hcombine.measurable, ?_⟩
+    exact hcombine.map_eq.trans
+      (congrArg (fun m => m.prod (Measure.pi fun i : {i // ¬p i} => μ i)) hpi)
+  have hrefresh := (MeasurePreserving.symm splitEquiv hsplit).comp hcombine'
+  refine hrefresh.congr (by fun_prop) (ae_of_all _ fun w => ?_)
+  funext i
+  change splitEquiv.symm
+      (unionEquiv (singleA w.2.1, singleB w.2.2), (splitEquiv w.1).2) i =
+    update (update w.1 a w.2.1) b w.2.2 i
+  by_cases hia : i = a
+  · subst i
+    change (Equiv.piEquivPiSubtypeProd p α).symm
+      (unionEquiv (singleA w.2.1, singleB w.2.2),
+        ((Equiv.piEquivPiSubtypeProd p α) w.1).2) a =
+      update (update w.1 a w.2.1) b w.2.2 a
+    rw [Equiv.piEquivPiSubtypeProd_symm_apply]
+    simp only [p, s, t, Finset.mem_union, Finset.mem_singleton, true_or, dite_true]
+    rw [unionEquiv_a]
+    simp [hab]
+  · by_cases hib : i = b
+    · subst i
+      rw [update_self]
+      change (Equiv.piEquivPiSubtypeProd p α).symm
+        (unionEquiv (singleA w.2.1, singleB w.2.2),
+          ((Equiv.piEquivPiSubtypeProd p α) w.1).2) b = w.2.2
+      rw [Equiv.piEquivPiSubtypeProd_symm_apply]
+      simp only [p, s, t, Finset.mem_union, Finset.mem_singleton, or_true, dite_true]
+      rw [unionEquiv_b]
+    · change (Equiv.piEquivPiSubtypeProd p α).symm
+        (unionEquiv (singleA w.2.1, singleB w.2.2),
+          ((Equiv.piEquivPiSubtypeProd p α) w.1).2) i =
+        update (update w.1 a w.2.1) b w.2.2 i
+      rw [Equiv.piEquivPiSubtypeProd_symm_apply]
+      simp only [p, s, t, Finset.mem_union, Finset.mem_singleton, hia, hib, false_or,
+        dite_false]
+      change w.1 i = update (update w.1 a w.2.1) b w.2.2 i
+      rw [update_of_ne hib, update_of_ne hia]
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Pi.lean
+++ b/TauCeti/MeasureTheory/Integral/Pi.lean
@@ -47,12 +47,13 @@ namespace TauCeti
 variable {ι : Type*} [Fintype ι] [DecidableEq ι] {α : ι → Type*}
   [∀ i, MeasurableSpace (α i)]
 
-/-- **Fubini after a two-coordinate refresh.** An integral against a finite product of probability
+/-- **Fubini after a two-coordinate refresh.** An integral against a finite product of sigma-finite
 measures is an outer integral over the assignment and an inner integral over a fresh independent
-pair placed at the two distinct coordinates `a` and `b`. -/
+pair placed at the two distinct probability coordinates `a` and `b`. -/
 theorem integral_pi_eq_integral_integral_update {E : Type*} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] (μ : ∀ i, Measure (α i)) [∀ i, IsProbabilityMeasure (μ i)]
-    {a b : ι} (hab : a ≠ b) {f : (∀ i, α i) → E} (hf : Integrable f (Measure.pi μ)) :
+    [NormedSpace ℝ E] (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] {a b : ι}
+    [IsProbabilityMeasure (μ a)] [IsProbabilityMeasure (μ b)] (hab : a ≠ b)
+    {f : (∀ i, α i) → E} (hf : Integrable f (Measure.pi μ)) :
     ∫ x, f x ∂(Measure.pi μ) =
       ∫ z, (∫ p : α a × α b, f (update (update z a p.1) b p.2) ∂(μ a).prod (μ b))
         ∂(Measure.pi μ) := by

--- a/TauCeti/MeasureTheory/Integral/Pi.lean
+++ b/TauCeti/MeasureTheory/Integral/Pi.lean
@@ -6,9 +6,15 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.MeasureTheory.Integral.Pi
+public import Mathlib.MeasureTheory.Integral.Prod
+public import TauCeti.MeasureTheory.Constructions.Pi
 
 /-!
-# Lower integrals of coordinatewise products over a finite product measure
+# Integrals over finite product measures
+
+This file collects integration results for finite product measures. In addition to the lower
+integral product formula, it gives a Fubini identity obtained by refreshing two coordinates with
+independent samples.
 
 The `ℝ≥0∞`-valued companion of Mathlib's `MeasureTheory.integral_fintype_prod_eq_prod`: over
 `MeasureTheory.Measure.pi`, the lower integral of a product `∏ i, f i (x i)` of functions each
@@ -26,15 +32,46 @@ Mathlib's: reduce a `Fin (n + 1)`-indexed product to a binary product measure al
 
 * `TauCeti.lintegral_fintype_prod_eq_prod`: the product formula, for measurable factors.
 * `TauCeti.lintegral_fintype_prod_eq_prod₀`: the same for almost everywhere measurable factors.
+* `TauCeti.integral_pi_eq_integral_integral_update`: the two-coordinate Fubini
+  identity.
 -/
 
 public section
 
-open MeasureTheory MeasureTheory.Measure
+open Function MeasureTheory MeasureTheory.Measure
 
 open scoped ENNReal
 
 namespace TauCeti
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] {α : ι → Type*}
+  [∀ i, MeasurableSpace (α i)]
+
+/-- **Fubini after a two-coordinate refresh.** An integral against a finite product of probability
+measures is an outer integral over the assignment and an inner integral over a fresh independent
+pair placed at the two distinct coordinates `a` and `b`. -/
+theorem integral_pi_eq_integral_integral_update {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] (μ : ∀ i, Measure (α i)) [∀ i, IsProbabilityMeasure (μ i)]
+    {a b : ι} (hab : a ≠ b) {f : (∀ i, α i) → E} (hf : Integrable f (Measure.pi μ)) :
+    ∫ x, f x ∂(Measure.pi μ) =
+      ∫ z, (∫ p : α a × α b, f (update (update z a p.1) b p.2) ∂(μ a).prod (μ b))
+        ∂(Measure.pi μ) := by
+  set g : ((∀ i, α i) × α a × α b) → (∀ i, α i) :=
+    fun w => update (update w.1 a w.2.1) b w.2.2 with hg
+  have hmp := measurePreserving_update_update μ hab
+  have hcomp : Integrable (fun w => f (g w)) ((Measure.pi μ).prod ((μ a).prod (μ b))) :=
+    hmp.integrable_comp_of_integrable hf
+  have hae : AEStronglyMeasurable f
+      (Measure.map g ((Measure.pi μ).prod ((μ a).prod (μ b)))) := by
+    rw [hmp.map_eq]
+    exact hf.aestronglyMeasurable
+  calc ∫ x, f x ∂(Measure.pi μ)
+      = ∫ x, f x ∂(Measure.map g ((Measure.pi μ).prod ((μ a).prod (μ b)))) := by
+        rw [hmp.map_eq]
+    _ = ∫ w, f (g w) ∂((Measure.pi μ).prod ((μ a).prod (μ b))) :=
+        integral_map hmp.measurable.aemeasurable hae
+    _ = ∫ z, (∫ p : α a × α b, f (update (update z a p.1) b p.2) ∂(μ a).prod (μ b))
+          ∂(Measure.pi μ) := integral_prod _ hcomp
 
 /-- The product formula for a `Fin n`-indexed product measure, by induction on `n`. -/
 private theorem lintegral_fin_nat_prod_eq_prod {n : ℕ} {α : Fin n → Type*}


### PR DESCRIPTION
This PR proves `counting_lemma`, the forward counting lemma of the dense graph limits roadmap: for a finite graph `F` and two graphons `U`, `W` on one probability carrier, `|t(F, U) − t(F, W)| ≤ (F.edgeFinset.card : ℝ) * cutNorm μ (U.toSymmKernel - W.toSymmKernel)`. This is the statement pinned in `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` under "**Layer 2 (forward counting lemma).** The argument to `cutNorm` is the *kernel* `U - W`; the prefactor is `(F.edgeFinset.card : ℝ)` (prose `e(F)`)", and it is the first item of the roadmap's Layer 2 and one of its non-negotiable acceptance gates. The milestone it serves is Layer 2, "counting, regularity, total boundedness". What remains in that milestone after this PR is the cross-carrier coupling form `counting_lemma_coupling`, the descent `homDensityOnSpace` of `t(F, ·)` to `GraphonSpace`, the block-average step objects with the analytic energy stack, Frieze–Kannan weak regularity, and total boundedness.

Everything the statement needs was already on `main`: `homDensity` (#3745), `cutNorm` on symmetric kernels (#3665, #3844, #3928), and the `SymmKernel` module structure that makes `U - W` a literal kernel (#3551). The lemma itself grepped to zero, and it gates the rest of the spine — the coupling form, the descent to the quotient, and the easy direction of Layer-6a separation all run through it. It is disjoint from the one open graphon PR, #4141, which defines `cutDist`; nothing here mentions couplings or the cut distance.

The proof telescopes over the edges. A hybrid stage is indexed by the subset `D` of edges already swapped from `W` to `U`, with the ambient edge set `E` held fixed, and the induction runs on `D`. That is the shape the argument needs: an induction on `E` alone would have to carry the already-fixed edge factor of the edge being peeled off, and that factor is precisely the weight the single-edge bound consumes. One swap changes the integrand at a single edge `e₀ = s(a, b)` with `a ≠ b`, weighted by the product of edge factors over the other edges. Because `F` is a *simple* graph, no other edge joins `a` to `b` — an edge containing both would *be* `s(a, b)`, by `Sym2.mem_and_mem_iff` — so every other edge misses `a` or misses `b`. Refreshing the two coordinates `a` and `b` therefore leaves an inner double integral whose weight factors as a `[0,1]`-valued function of the new `a`-coordinate times one of the new `b`-coordinate; that pairing is bounded by the cut norm, and the outer integral is over a probability measure. Summing the `e(F)` swaps gives the prefactor. The vanishing case is recorded as `homDensity_eq_of_cutNorm_sub_eq_zero`, the same-carrier core of the forward separation direction.

Three supporting pieces land where they belong rather than inline. `abs_testIntegral_le_cutNorm` in `Kernel/CutNorm.lean` bounds every `[0,1]`-test integral by the cut norm *with no loss of constant*, unlike the `[-1,1]`-valued `cutNormSigned_le_four_mul_cutNorm` already on `main`: the pairing is affine in each test function, so replacing a `[0,1]`-valued function by the indicator of the set where the partial pairing is nonnegative, or by the indicator of its complement, can only increase the absolute pairing, and doing that on both sides lands on a measurable rectangle. A factor of four here would be a factor of four in the counting lemma, so the sharp form is the one the roadmap's prefactor requires. In `HomDensity/Basic.lean`, `edgeFactor_congr` says an edge factor depends only on the assignment along that edge — the fact that lets a factor be read off after the assignment has been altered away from the edge — and `measurable_prod_edgeFactor` / `prod_edgeFactor_nonneg` / `prod_edgeFactor_le_one` / `integrable_prod_edgeFactor` give the analytic facts for a product of edge factors over an arbitrary finset with a *per-edge* graphon, which the hybrid stages need. The four existing `homDensity_integrand_*` lemmas are now one-line specialisations of these rather than separate proofs; their statements and names are unchanged.

`TauCeti/MeasureTheory/Constructions/Pi.lean` is new and graphon-independent, as the roadmap's "General-purpose prerequisites" section asks for Layer-0 product-measure plumbing. It proves that overwriting two *distinct* coordinates of a product-distributed assignment by an independent pair leaves the product law unchanged (`measurePreserving_update_update`) and derives the Fubini identity `integral_pi_eq_integral_integral_update`. The hypothesis `a ≠ b` is essential: for `a = b` the second update overwrites the first. Mathlib has `measurePreserving_piEquivPiSubtypeProd`, `measurePreserving_piCongrLeft` and `measurePreserving_finTwoArrow`, but composing them to single out two named coordinates costs more bookkeeping than checking the box identity directly through `Measure.pi_eq`, which is what this file does; the preimage of a box is again a box, with the two overwritten entries relaxed to `Set.univ`.

No Mathlib source was vendored. The `cameronfreer/graphon` and `math-commons/graphons` snapshots the roadmap names as secondary provenance were not consulted for this proof.

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"counting-lemma"}-->

🤖 Prepared with Claude Code
