### PR TITLE
feat: prove nontriviality of the E6 diagram automorphism

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/Assembly.lean
@@ -10,7 +10,7 @@ public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.A
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.B.Datum
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.C.Datum
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.D.Basic
-public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E7.Datum
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E8.Datum
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.F4.Basic

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/DiagramAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/DiagramAutomorphism.lean
@@ -55,8 +55,6 @@ The group of node permutations that the construction consumes is
 
 * `TauCeti.DynkinType.diagramRootPerm_simpleIndex`: the induced permutation extends `σ` along the
   Bourbaki numbering of the simple roots.
-* `TauCeti.DynkinType.image_diagramRootPerm_simplyConnectedBase_support`: the induced permutation
-  preserves the support of the pinned base.
 * `TauCeti.DynkinType.root_diagramRootPerm` and `TauCeti.DynkinType.coroot_diagramRootPerm`: every
   root and coroot has its coordinates permuted by `σ`.
 * `TauCeti.DynkinType.eq_diagramAut`: an automorphism of the pinned datum whose weight map is the
@@ -130,32 +128,6 @@ numbering of the simple roots. -/
     (t.simpleSupportEquiv ht i)
   rw [diagramRootPerm, rationalDiagramAut, ← coe_simpleSupportEquiv, h]
   simp
-
-/-- The induced root permutation preserves the support of the pinned simply connected base. -/
-@[simp] theorem image_diagramRootPerm_simplyConnectedBase_support
-    (hσ : σ ∈ t.diagramSymmetry) :
-    (t.simplyConnectedBase ht).support.image (diagramRootPerm ht hσ) =
-      (t.simplyConnectedBase ht).support := by
-  ext i
-  simp only [Finset.mem_image]
-  constructor
-  · rintro ⟨j, hj, rfl⟩
-    rw [mem_support_simplyConnectedBase] at hj ⊢
-    let a : Fin t.rank := ⟨j, hj⟩
-    have hja : j = t.simpleIndex ht a := by
-      apply Fin.ext
-      rw [simpleIndex_val]
-    rw [hja, diagramRootPerm_simpleIndex, simpleIndex_val]
-    exact (σ a).isLt
-  · intro hi
-    rw [mem_support_simplyConnectedBase] at hi
-    let a : Fin t.rank := ⟨i, hi⟩
-    refine ⟨t.simpleIndex ht (σ.symm a), ?_, ?_⟩
-    · rw [mem_support_simplyConnectedBase, simpleIndex_val]
-      exact (σ.symm a).isLt
-    · rw [diagramRootPerm_simpleIndex, Equiv.apply_symm_apply]
-      apply Fin.ext
-      rw [simpleIndex_val]
 
 /-! ## The coordinates are permuted by the node permutation -/
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/DiagramAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/DiagramAutomorphism.lean
@@ -55,11 +55,15 @@ The group of node permutations that the construction consumes is
 
 * `TauCeti.DynkinType.diagramRootPerm_simpleIndex`: the induced permutation extends `σ` along the
   Bourbaki numbering of the simple roots.
+* `TauCeti.DynkinType.image_diagramRootPerm_simplyConnectedBase_support`: the induced permutation
+  preserves the support of the pinned base.
 * `TauCeti.DynkinType.root_diagramRootPerm` and `TauCeti.DynkinType.coroot_diagramRootPerm`: every
   root and coroot has its coordinates permuted by `σ`.
 * `TauCeti.DynkinType.eq_diagramAut`: an automorphism of the pinned datum whose weight map is the
   coordinate permutation is the diagram automorphism, so the construction is the unique such
   automorphism.
+* `TauCeti.DynkinType.diagramAut_eq_one_iff`: the induced automorphism is trivial exactly when the
+  node permutation is trivial.
 * `TauCeti.DynkinType.diagramAut_pow_eq_one`: a node permutation of finite order induces an
   automorphism of the same finite order relation.
 
@@ -126,6 +130,32 @@ numbering of the simple roots. -/
     (t.simpleSupportEquiv ht i)
   rw [diagramRootPerm, rationalDiagramAut, ← coe_simpleSupportEquiv, h]
   simp
+
+/-- The induced root permutation preserves the support of the pinned simply connected base. -/
+@[simp] theorem image_diagramRootPerm_simplyConnectedBase_support
+    (hσ : σ ∈ t.diagramSymmetry) :
+    (t.simplyConnectedBase ht).support.image (diagramRootPerm ht hσ) =
+      (t.simplyConnectedBase ht).support := by
+  ext i
+  simp only [Finset.mem_image]
+  constructor
+  · rintro ⟨j, hj, rfl⟩
+    rw [mem_support_simplyConnectedBase] at hj ⊢
+    let a : Fin t.rank := ⟨j, hj⟩
+    have hja : j = t.simpleIndex ht a := by
+      apply Fin.ext
+      rw [simpleIndex_val]
+    rw [hja, diagramRootPerm_simpleIndex, simpleIndex_val]
+    exact (σ a).isLt
+  · intro hi
+    rw [mem_support_simplyConnectedBase] at hi
+    let a : Fin t.rank := ⟨i, hi⟩
+    refine ⟨t.simpleIndex ht (σ.symm a), ?_, ?_⟩
+    · rw [mem_support_simplyConnectedBase, simpleIndex_val]
+      exact (σ.symm a).isLt
+    · rw [diagramRootPerm_simpleIndex, Equiv.apply_symm_apply]
+      apply Fin.ext
+      rw [simpleIndex_val]
 
 /-! ## The coordinates are permuted by the node permutation -/
 
@@ -312,6 +342,24 @@ theorem eq_diagramAut {g : (t.simplyConnectedRootDatum ht).Aut} (hσ : σ ∈ t.
   apply LinearEquiv.toLinearMap_injective
   refine LinearMap.ext fun x => funext fun j => ?_
   simp [Equiv.Perm.one_def]
+
+/-- The diagram automorphism is trivial exactly when its node permutation is trivial. In
+particular, the construction is faithful on diagram symmetries. -/
+@[simp] theorem diagramAut_eq_one_iff (hσ : σ ∈ t.diagramSymmetry) :
+    diagramAut ht hσ = 1 ↔ σ = 1 := by
+  constructor
+  · intro h
+    apply Equiv.ext
+    intro i
+    have hindex := congrArg (fun g : (t.simplyConnectedRootDatum ht).Aut =>
+      g.indexEquiv (t.simpleIndex ht i)) h
+    simp only [diagramAut_indexEquiv, diagramRootPerm_simpleIndex,
+      RootPairing.Equiv.toHom_one, RootPairing.Hom.indexEquiv_one, Equiv.refl_apply] at hindex
+    have hval := congrArg Fin.val hindex
+    apply Fin.ext
+    simpa only [simpleIndex_val, Equiv.Perm.one_def, Equiv.refl_apply] using hval
+  · rintro rfl
+    exact diagramAut_one ht
 
 /-- The construction is multiplicative in the node permutation. -/
 @[simp] theorem diagramAut_mul (hσ : σ ∈ t.diagramSymmetry) (hτ : τ ∈ t.diagramSymmetry) :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/Basic.lean
@@ -337,10 +337,68 @@ modulo `36` is used, a positive root and its negative reflecting alike. -/
 private def e6ReflectionIndex (i j : Fin 72) : Fin 72 :=
   e6ReflectionTable ⟨(i : ℕ) % 36, Nat.mod_lt _ (by omega)⟩ j
 
+/-- The coroot reflection identity for a positive-root index and an arbitrary root index. -/
+private abbrev e6ReflectionIndexCorootProp (i : Fin 36) (j : Fin 72) : Prop :=
+  e6Coroot j - (e6Root (e6PositiveIndex i) ⬝ᵥ e6Coroot j) • e6Coroot (e6PositiveIndex i) =
+    e6Coroot (e6ReflectionIndex (e6PositiveIndex i) j)
+
+private lemma e6ReflectionIndex_coroot_pos_zero (i : Fin 6) (j : Fin 72) :
+    e6ReflectionIndexCorootProp ⟨i, by omega⟩ j := by
+  fin_cases i <;> decide +kernel +revert
+
+private lemma e6ReflectionIndex_coroot_pos_six (i : Fin 6) (j : Fin 72) :
+    e6ReflectionIndexCorootProp ⟨i + 6, by omega⟩ j := by
+  fin_cases i <;> decide +kernel +revert
+
+private lemma e6ReflectionIndex_coroot_pos_twelve (i : Fin 6) (j : Fin 72) :
+    e6ReflectionIndexCorootProp ⟨i + 12, by omega⟩ j := by
+  fin_cases i <;> decide +kernel +revert
+
+private lemma e6ReflectionIndex_coroot_pos_eighteen (i : Fin 6) (j : Fin 72) :
+    e6ReflectionIndexCorootProp ⟨i + 18, by omega⟩ j := by
+  fin_cases i <;> decide +kernel +revert
+
+private lemma e6ReflectionIndex_coroot_pos_twenty_four (i : Fin 6) (j : Fin 72) :
+    e6ReflectionIndexCorootProp ⟨i + 24, by omega⟩ j := by
+  fin_cases i <;> decide +kernel +revert
+
+private lemma e6ReflectionIndex_coroot_pos_thirty (i : Fin 6) (j : Fin 72) :
+    e6ReflectionIndexCorootProp ⟨i + 30, by omega⟩ j := by
+  fin_cases i <;> decide +kernel +revert
+
 private lemma e6ReflectionIndex_coroot_pos (i : Fin 36) (j : Fin 72) :
     e6Coroot j - (e6Root (e6PositiveIndex i) ⬝ᵥ e6Coroot j) • e6Coroot (e6PositiveIndex i) =
       e6Coroot (e6ReflectionIndex (e6PositiveIndex i) j) := by
-  decide +kernel +revert
+  change e6ReflectionIndexCorootProp i j
+  rcases lt_or_ge (i : ℕ) 6 with hi | hi
+  · let a : Fin 6 := ⟨i, hi⟩
+    have hia : i = (⟨a, by omega⟩ : Fin 36) := Fin.ext rfl
+    rw [hia]
+    exact e6ReflectionIndex_coroot_pos_zero a j
+  rcases lt_or_ge (i : ℕ) 12 with hi' | hi'
+  · let a : Fin 6 := ⟨(i : ℕ) - 6, by omega⟩
+    have hia : i = (⟨a + 6, by omega⟩ : Fin 36) := Fin.ext (by simp [a]; omega)
+    rw [hia]
+    exact e6ReflectionIndex_coroot_pos_six a j
+  rcases lt_or_ge (i : ℕ) 18 with hi'' | hi''
+  · let a : Fin 6 := ⟨(i : ℕ) - 12, by omega⟩
+    have hia : i = (⟨a + 12, by omega⟩ : Fin 36) := Fin.ext (by simp [a]; omega)
+    rw [hia]
+    exact e6ReflectionIndex_coroot_pos_twelve a j
+  rcases lt_or_ge (i : ℕ) 24 with hi''' | hi'''
+  · let a : Fin 6 := ⟨(i : ℕ) - 18, by omega⟩
+    have hia : i = (⟨a + 18, by omega⟩ : Fin 36) := Fin.ext (by simp [a]; omega)
+    rw [hia]
+    exact e6ReflectionIndex_coroot_pos_eighteen a j
+  rcases lt_or_ge (i : ℕ) 30 with hi'''' | hi''''
+  · let a : Fin 6 := ⟨(i : ℕ) - 24, by omega⟩
+    have hia : i = (⟨a + 24, by omega⟩ : Fin 36) := Fin.ext (by simp [a]; omega)
+    rw [hia]
+    exact e6ReflectionIndex_coroot_pos_twenty_four a j
+  · let a : Fin 6 := ⟨(i : ℕ) - 30, by omega⟩
+    have hia : i = (⟨a + 30, by omega⟩ : Fin 36) := Fin.ext (by simp [a]; omega)
+    rw [hia]
+    exact e6ReflectionIndex_coroot_pos_thirty a j
 
 private lemma e6ReflectionIndex_e6NegativeIndex (i : Fin 36) (j : Fin 72) :
     e6ReflectionIndex (e6NegativeIndex i) j = e6ReflectionIndex (e6PositiveIndex i) j := by
@@ -521,6 +579,7 @@ theorem pairing_e6SimpleIndex (i j : Fin 6) :
   rw [e6SimplyConnectedRootDatum_pairing, root_e6SimpleIndex, coroot_e6SimpleIndex,
     dotProduct_single, mul_one]
 
+/-- Identify the support of the type-`E₆` base with its six Bourbaki-numbered nodes. -/
 private def e6BaseEquiv : e6SimplyConnectedBase.support ≃ Fin 6 where
   toFun x := ⟨(x : Fin 72), mem_e6SimpleSupport.mp x.2⟩
   invFun i := ⟨e6SimpleIndex i, mem_e6SimpleSupport.mpr (by simp)⟩

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/Basic.lean
@@ -369,6 +369,8 @@ private lemma e6ReflectionIndex_coroot_pos_thirty (i : Fin 6) (j : Fin 72) :
 private lemma e6ReflectionIndex_coroot_pos (i : Fin 36) (j : Fin 72) :
     e6Coroot j - (e6Root (e6PositiveIndex i) ⬝ᵥ e6Coroot j) • e6Coroot (e6PositiveIndex i) =
       e6Coroot (e6ReflectionIndex (e6PositiveIndex i) j) := by
+  -- Fold the displayed equality into the proposition abbreviation used by the six kernel-checked
+  -- block lemmas; ordinary rewriting cannot select those lemmas while the goal is unfolded.
   change e6ReflectionIndexCorootProp i j
   rcases lt_or_ge (i : ℕ) 6 with hi | hi
   · let a : Fin 6 := ⟨i, hi⟩

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -1,0 +1,321 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- `RootPairing.isReduced_of_pairing_comm` supplies the local reducedness witness used by the
+-- base-induction proof that the lattice involution preserves the set of roots.
+import TauCeti.LinearAlgebra.RootSystem.Reduced
+public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
+
+/-!
+# The graph automorphism of the pinned type `E₆` root datum
+
+The Dynkin diagram of type `E₆` has an involution exchanging Bourbaki nodes `1 ↔ 6` and
+`3 ↔ 5`.
+The character and cocharacter lattices of `TauCeti.DynkinType.e6SimplyConnectedRootDatum` are
+written in bases indexed by those nodes, so the involution acts on each lattice by reindexing
+coordinates with `TauCeti.graphPermE6`.
+
+This file packages those lattice maps and the induced permutation of all seventy-two roots as an
+automorphism of the pinned root datum. Its restriction to the pinned simple roots is exactly
+`TauCeti.graphPermE6`, the numbered permutation used for the graph-twisted family `²E₆`.
+
+## Main declarations
+
+* `TauCeti.DynkinType.e6GraphIndexEquiv`: the induced permutation of all root indices.
+* `TauCeti.DynkinType.e6GraphAut`: the graph automorphism of the pinned simply connected datum.
+* `TauCeti.DynkinType.e6GraphAut_sq`: the automorphism has square one.
+* `TauCeti.DynkinType.image_e6GraphAut_indexEquiv_e6SimplyConnectedBase_support`: the pinned base
+  support is preserved.
+
+## References
+
+The coordinates and node numbering follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*,
+Plate V. The graph automorphism and its role in the twisted family `²E₆` follow R. W. Carter,
+*Simple Groups of Lie Type*, §12.2.
+
+This supplies the type-`E₆` root-datum input to the pinned-isomorphism target in Layer 9 of the
+ReductiveGroups roadmap. The pinned isomorphism theorem will lift it to the group-scheme
+automorphism used in the graph-twisted Steinberg endomorphism.
+-/
+
+public section
+
+namespace TauCeti
+
+open Function Set
+
+namespace DynkinType
+
+/-! ## The lattice and root-index permutations -/
+
+private lemma graphPermE6_symm : graphPermE6.symm = graphPermE6 := by
+  exact (mul_eq_one_iff_eq_inv.mp (by simpa only [pow_two] using graphPermE6_sq)).symm
+
+private lemma graphPermE6_apply_apply (i : Fin 6) : graphPermE6 (graphPermE6 i) = i := by
+  have h := congrArg (fun e : Equiv.Perm (Fin 6) => e i) graphPermE6_sq
+  simpa only [pow_two, Equiv.Perm.mul_apply, Equiv.Perm.one_apply] using h
+
+/-- Reindex fundamental-weight or simple-coroot coordinates by the `E₆` graph permutation. -/
+private def e6GraphLatticeEquiv : (Fin 6 → ℤ) ≃ₗ[ℤ] Fin 6 → ℤ :=
+  LinearEquiv.piCongrLeft' ℤ (fun _ : Fin 6 => ℤ) graphPermE6
+
+private lemma e6GraphLatticeEquiv_apply (x : Fin 6 → ℤ) (i : Fin 6) :
+    e6GraphLatticeEquiv x i = x (graphPermE6 i) := by
+  rw [e6GraphLatticeEquiv, LinearEquiv.piCongrLeft'_apply, graphPermE6_symm]
+
+private lemma e6GraphLatticeEquiv_involutive : Involutive e6GraphLatticeEquiv := by
+  intro x
+  funext i
+  rw [e6GraphLatticeEquiv_apply, e6GraphLatticeEquiv_apply]
+  rw [graphPermE6_apply_apply]
+
+private lemma e6GraphLatticeEquiv_dotProduct (x y : Fin 6 → ℤ) :
+    e6GraphLatticeEquiv x ⬝ᵥ e6GraphLatticeEquiv y = x ⬝ᵥ y := by
+  simp only [dotProduct, e6GraphLatticeEquiv_apply]
+  apply Fintype.sum_equiv graphPermE6
+  intro i
+  rfl
+
+private lemma e6GraphLatticeEquiv_dotProduct_left (x y : Fin 6 → ℤ) :
+    e6GraphLatticeEquiv x ⬝ᵥ y = x ⬝ᵥ e6GraphLatticeEquiv y := by
+  have h := e6GraphLatticeEquiv_dotProduct x (e6GraphLatticeEquiv y)
+  rw [e6GraphLatticeEquiv_involutive] at h
+  exact h
+
+private lemma e6GraphLatticeEquiv_simpleCoroot (i : Fin 6) :
+    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.coroot (e6SimpleIndex i)) =
+      e6SimplyConnectedRootDatum.coroot (e6SimpleIndex (graphPermE6 i)) := by
+  simp only [e6SimplyConnectedRootDatum_coroot, coroot_e6SimpleIndex]
+  funext j
+  rw [e6GraphLatticeEquiv_apply]
+  simp only [Pi.single_apply]
+  by_cases hji : graphPermE6 j = i
+  · have hij : j = graphPermE6 i := by
+      rw [← graphPermE6_apply_apply j, hji]
+    simp only [hij, graphPermE6_apply_apply, ↓reduceIte]
+  · have hij : j ≠ graphPermE6 i := by
+      intro hij
+      apply hji
+      rw [hij, graphPermE6_apply_apply]
+    simp only [hji, hij, ↓reduceIte]
+
+private lemma e6GraphLatticeEquiv_simpleRoot (i : Fin 6) :
+    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root (e6SimpleIndex i)) =
+      e6SimplyConnectedRootDatum.root (e6SimpleIndex (graphPermE6 i)) := by
+  simp only [e6SimplyConnectedRootDatum_root, root_e6SimpleIndex]
+  funext j
+  rw [e6GraphLatticeEquiv_apply]
+  have h := cartanMatrix_E6_graphPermE6 i (graphPermE6 j)
+  simpa only [DynkinType.cartanMatrix_E6, graphPermE6_apply_apply] using h.symm
+
+private lemma e6GraphLatticeEquiv_mulVec (x : Fin 6 → ℤ) :
+    e6GraphLatticeEquiv ((CartanMatrix.E 6).mulVec x) =
+      (CartanMatrix.E 6).mulVec (e6GraphLatticeEquiv x) := by
+  funext j
+  simp only [Matrix.mulVec, dotProduct, e6GraphLatticeEquiv_apply]
+  apply Fintype.sum_equiv graphPermE6
+  intro i
+  rw [graphPermE6_apply_apply]
+  have h := cartanMatrix_E6_graphPermE6 j (graphPermE6 i)
+  simpa only [DynkinType.cartanMatrix_E6, graphPermE6_apply_apply] using
+    congrArg (fun z => z * x i) h
+
+private lemma e6GraphLatticeEquiv_root_mem_range (i : Fin 72) :
+    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i) ∈
+      range e6SimplyConnectedRootDatum.root := by
+  let _ : e6SimplyConnectedRootDatum.IsReduced :=
+    RootPairing.isReduced_of_pairing_comm _ fun j k => by
+      simpa only [e6SimplyConnectedRootDatum_pairing] using
+        e6Root_dotProduct_e6Coroot_comm j k
+  apply e6SimplyConnectedBase.induction_reflect i
+  · intro j hj
+    rw [e6SimplyConnectedRootDatum.root_reflectionPerm,
+      e6SimplyConnectedRootDatum.reflection_apply_self, map_neg,
+      e6SimplyConnectedRootDatum.neg_mem_range_root_iff]
+    exact hj
+  · intro j hj
+    rw [mem_e6SimplyConnectedBase_support] at hj
+    let a : Fin 6 := ⟨j, hj⟩
+    have hja : j = e6SimpleIndex a := by
+      apply Fin.ext
+      rw [e6SimpleIndex_val]
+    refine ⟨e6SimpleIndex (graphPermE6 a), ?_⟩
+    rw [hja, e6GraphLatticeEquiv_simpleRoot]
+  · intro j k hj hk
+    obtain ⟨l, hl⟩ := hj
+    rw [mem_e6SimplyConnectedBase_support] at hk
+    let a : Fin 6 := ⟨k, hk⟩
+    have hka : k = e6SimpleIndex a := by
+      apply Fin.ext
+      rw [e6SimpleIndex_val]
+    have hpair : e6SimplyConnectedRootDatum.pairing l (e6SimpleIndex (graphPermE6 a)) =
+        e6SimplyConnectedRootDatum.pairing j k := by
+      -- Expose `pairing` as the perfect bilinear map so the two lattice-equivariance facts apply.
+      change e6SimplyConnectedRootDatum.toLinearMap (e6SimplyConnectedRootDatum.root l)
+          (e6SimplyConnectedRootDatum.coroot (e6SimpleIndex (graphPermE6 a))) =
+        e6SimplyConnectedRootDatum.toLinearMap (e6SimplyConnectedRootDatum.root j)
+          (e6SimplyConnectedRootDatum.coroot k)
+      rw [hl, ← e6GraphLatticeEquiv_simpleCoroot, hka,
+        e6SimplyConnectedRootDatum_toLinearMap,
+        e6SimplyConnectedRootDatum_toLinearMap, e6GraphLatticeEquiv_dotProduct]
+    refine ⟨e6SimplyConnectedRootDatum.reflectionPerm
+      (e6SimpleIndex (graphPermE6 a)) l, ?_⟩
+    rw [e6SimplyConnectedRootDatum.root_reflectionPerm,
+      e6SimplyConnectedRootDatum.root_reflectionPerm,
+      e6SimplyConnectedRootDatum.reflection_apply,
+      e6SimplyConnectedRootDatum.reflection_apply, map_sub, map_smul,
+      hka, e6GraphLatticeEquiv_simpleRoot]
+    rw [← hl, e6SimplyConnectedRootDatum.root_coroot'_eq_pairing,
+      e6SimplyConnectedRootDatum.root_coroot'_eq_pairing, hpair, ← hka]
+
+/-- The root index selected by the image of a root under the lattice involution. -/
+private noncomputable def e6GraphIndex (i : Fin 72) : Fin 72 :=
+  e6SimplyConnectedRootDatum.root.invOfMemRange
+    ⟨e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i),
+      e6GraphLatticeEquiv_root_mem_range i⟩
+
+private lemma root_e6GraphIndex (i : Fin 72) :
+    e6SimplyConnectedRootDatum.root (e6GraphIndex i) =
+      e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i) :=
+  e6SimplyConnectedRootDatum.root.left_inv_of_invOfMemRange
+    ⟨e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i),
+      e6GraphLatticeEquiv_root_mem_range i⟩
+
+private lemma e6GraphIndex_involutive : Involutive e6GraphIndex := by
+  intro i
+  apply e6SimplyConnectedRootDatum.root.injective
+  rw [root_e6GraphIndex, root_e6GraphIndex, e6GraphLatticeEquiv_involutive]
+
+/-- The permutation of all roots induced by the graph symmetry, expressed on the native root
+indices of the pinned type-`E₆` datum. -/
+noncomputable def e6GraphIndexEquiv : Equiv.Perm (Fin 72) :=
+  e6GraphIndex_involutive.toPerm
+
+private lemma e6GraphLatticeEquiv_root (i : Fin 72) :
+    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i) =
+      e6SimplyConnectedRootDatum.root (e6GraphIndexEquiv i) := by
+  exact (root_e6GraphIndex i).symm
+
+/-- Applying the type-`E₆` root permutation twice is the identity. -/
+@[simp] theorem e6GraphIndexEquiv_apply_apply (i : Fin 72) :
+    e6GraphIndexEquiv (e6GraphIndexEquiv i) = i := by
+  apply e6SimplyConnectedRootDatum.root.injective
+  rw [← e6GraphLatticeEquiv_root, ← e6GraphLatticeEquiv_root,
+    e6GraphLatticeEquiv_involutive]
+
+private lemma e6GraphIndexEquiv_symm : e6GraphIndexEquiv.symm = e6GraphIndexEquiv := by
+  apply Equiv.ext
+  intro i
+  rw [Equiv.symm_apply_eq, e6GraphIndexEquiv_apply_apply]
+
+private lemma e6GraphLatticeEquiv_coroot (i : Fin 72) :
+    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.coroot i) =
+      e6SimplyConnectedRootDatum.coroot (e6GraphIndexEquiv i) := by
+  simp only [e6SimplyConnectedRootDatum_coroot]
+  apply Matrix.mulVec_injective_of_det_ne_zero (by rw [CartanMatrix.E₆_det]; norm_num)
+  rw [← e6GraphLatticeEquiv_mulVec, ← e6Root_eq_mulVec, ← e6Root_eq_mulVec]
+  simpa only [← e6SimplyConnectedRootDatum_root] using e6GraphLatticeEquiv_root i
+
+/-! ## The root-datum automorphism -/
+
+/-- The diagram symmetry as an automorphism of the pinned simply connected root datum of type
+`E₆`. Both lattice maps exchange the node coordinates according to `TauCeti.graphPermE6`, and the
+root-index map is the induced permutation of the seventy-two roots. -/
+noncomputable def e6GraphAut : _root_.RootPairing.Aut e6SimplyConnectedRootDatum where
+  weightMap := e6GraphLatticeEquiv.toLinearMap
+  coweightMap := e6GraphLatticeEquiv.toLinearMap
+  indexEquiv := e6GraphIndexEquiv
+  weight_coweight_transpose := by
+    ext y x
+    change e6SimplyConnectedRootDatum.toLinearMap
+        (e6GraphLatticeEquiv (Pi.single x 1)) (Pi.single y 1) =
+      e6SimplyConnectedRootDatum.toLinearMap (Pi.single x 1)
+        (e6GraphLatticeEquiv (Pi.single y 1))
+    rw [e6SimplyConnectedRootDatum_toLinearMap, e6SimplyConnectedRootDatum_toLinearMap]
+    exact e6GraphLatticeEquiv_dotProduct_left _ _
+  root_weightMap := by
+    funext i
+    exact e6GraphLatticeEquiv_root i
+  coroot_coweightMap := by
+    funext i
+    rw [e6GraphIndexEquiv_symm]
+    exact e6GraphLatticeEquiv_coroot i
+  bijective_weightMap := e6GraphLatticeEquiv.bijective
+  bijective_coweightMap := e6GraphLatticeEquiv.bijective
+
+/-- The character-lattice action of the type-`E₆` graph automorphism permutes the node
+coordinates. -/
+@[simp] theorem weightMap_e6GraphAut_apply (x : Fin 6 → ℤ) (i : Fin 6) :
+    e6GraphAut.weightMap x i = x (graphPermE6 i) :=
+  e6GraphLatticeEquiv_apply x i
+
+/-- The cocharacter-lattice action of the type-`E₆` graph automorphism permutes the node
+coordinates. -/
+@[simp] theorem coweightMap_e6GraphAut_apply (x : Fin 6 → ℤ) (i : Fin 6) :
+    e6GraphAut.coweightMap x i = x (graphPermE6 i) :=
+  e6GraphLatticeEquiv_apply x i
+
+/-- The root-index action of the type-`E₆` graph automorphism restricts to the numbered diagram
+involution on the pinned simple roots. -/
+@[simp] theorem indexEquiv_e6GraphAut_e6SimpleIndex (i : Fin 6) :
+    e6GraphAut.indexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i) := by
+  change e6GraphIndexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i)
+  apply e6SimplyConnectedRootDatum.root.injective
+  rw [← e6GraphLatticeEquiv_root, e6GraphLatticeEquiv_simpleRoot]
+
+/-- Applying the type-`E₆` graph automorphism twice is the identity. -/
+@[simp] theorem e6GraphAut_sq : e6GraphAut ^ 2 = 1 := by
+  apply _root_.RootPairing.Equiv.ext
+  · apply LinearMap.ext
+    exact e6GraphLatticeEquiv_involutive
+  · apply LinearMap.ext
+    exact e6GraphLatticeEquiv_involutive
+  · apply Equiv.ext
+    exact e6GraphIndexEquiv_apply_apply
+
+/-- The type-`E₆` graph automorphism is nontrivial: it exchanges the first and sixth simple
+roots. -/
+theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
+  intro h
+  have hindex := congrArg (fun e => e.indexEquiv (e6SimpleIndex 0)) h
+  simp only [indexEquiv_e6GraphAut_e6SimpleIndex, graphPermE6_apply_zero] at hindex
+  change e6SimpleIndex 5 = e6SimpleIndex 0 at hindex
+  have := congrArg Fin.val hindex
+  simp only [e6SimpleIndex_val] at this
+  omega
+
+/-- The graph symmetry preserves the support of the pinned type-`E₆` base. Together with
+`RootPairing.Base.support_map_eq`, this computes the support of the transported base. -/
+@[simp] theorem image_e6GraphAut_indexEquiv_e6SimplyConnectedBase_support :
+    e6SimplyConnectedBase.support.image e6GraphAut.indexEquiv =
+      e6SimplyConnectedBase.support := by
+  ext i
+  simp only [Finset.mem_image]
+  constructor
+  · rintro ⟨j, hj, rfl⟩
+    rw [mem_e6SimplyConnectedBase_support] at hj ⊢
+    let a : Fin 6 := ⟨j, hj⟩
+    have hja : j = e6SimpleIndex a := by
+      apply Fin.ext
+      rw [e6SimpleIndex_val]
+    rw [hja, indexEquiv_e6GraphAut_e6SimpleIndex, e6SimpleIndex_val]
+    exact (graphPermE6 a).isLt
+  · intro hi
+    rw [mem_e6SimplyConnectedBase_support] at hi
+    let a : Fin 6 := ⟨i, hi⟩
+    refine ⟨e6SimpleIndex (graphPermE6 a), ?_, ?_⟩
+    · rw [mem_e6SimplyConnectedBase_support, e6SimpleIndex_val]
+      exact (graphPermE6 a).isLt
+    · rw [indexEquiv_e6GraphAut_e6SimpleIndex]
+      rw [graphPermE6_apply_apply]
+      apply Fin.ext
+      rw [e6SimpleIndex_val]
+
+end DynkinType
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -208,11 +208,6 @@ private lemma e6GraphLatticeEquiv_root (i : Fin 72) :
   rw [← e6GraphLatticeEquiv_root, ← e6GraphLatticeEquiv_root,
     e6GraphLatticeEquiv_involutive]
 
-private lemma e6GraphIndexEquiv_symm : e6GraphIndexEquiv.symm = e6GraphIndexEquiv := by
-  apply Equiv.ext
-  intro i
-  rw [Equiv.symm_apply_eq, e6GraphIndexEquiv_apply_apply]
-
 private lemma e6GraphLatticeEquiv_coroot (i : Fin 72) :
     e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.coroot i) =
       e6SimplyConnectedRootDatum.coroot (e6GraphIndexEquiv i) := by
@@ -232,6 +227,8 @@ noncomputable def e6GraphAut : _root_.RootPairing.Aut e6SimplyConnectedRootDatum
   indexEquiv := e6GraphIndexEquiv
   weight_coweight_transpose := by
     ext y x
+    -- The structure field equates compositions of linear maps. After extensionality, unfold
+    -- those wrappers to expose the concrete perfect pairing and the two lattice arguments.
     change e6SimplyConnectedRootDatum.toLinearMap
         (e6GraphLatticeEquiv (Pi.single x 1)) (Pi.single y 1) =
       e6SimplyConnectedRootDatum.toLinearMap (Pi.single x 1)
@@ -243,27 +240,45 @@ noncomputable def e6GraphAut : _root_.RootPairing.Aut e6SimplyConnectedRootDatum
     exact e6GraphLatticeEquiv_root i
   coroot_coweightMap := by
     funext i
-    rw [e6GraphIndexEquiv_symm]
+    rw [e6GraphIndexEquiv, Function.Involutive.toPerm_symm e6GraphIndex_involutive]
     exact e6GraphLatticeEquiv_coroot i
   bijective_weightMap := e6GraphLatticeEquiv.bijective
   bijective_coweightMap := e6GraphLatticeEquiv.bijective
 
+/-- The graph automorphism carries every root to the root selected by its public root-index
+permutation. -/
+@[simp] theorem e6GraphAut_weightMap_root (i : Fin 72) :
+    e6GraphAut.weightMap (e6Root i) = e6Root (e6GraphIndexEquiv i) := by
+  -- Expose the linear equivalence packaged as the automorphism's weight linear map.
+  change e6GraphLatticeEquiv (e6Root i) = e6Root (e6GraphIndexEquiv i)
+  simpa only [e6SimplyConnectedRootDatum_root] using e6GraphLatticeEquiv_root i
+
+/-- The graph automorphism carries every coroot to the coroot selected by its public root-index
+permutation. -/
+@[simp] theorem e6GraphAut_coweightMap_coroot (i : Fin 72) :
+    e6GraphAut.coweightMap (e6Coroot i) = e6Coroot (e6GraphIndexEquiv i) := by
+  -- Expose the linear equivalence packaged as the automorphism's coweight linear map.
+  change e6GraphLatticeEquiv (e6Coroot i) = e6Coroot (e6GraphIndexEquiv i)
+  simpa only [e6SimplyConnectedRootDatum_coroot] using e6GraphLatticeEquiv_coroot i
+
 /-- The character-lattice action of the type-`E₆` graph automorphism permutes the node
 coordinates. -/
-@[simp] theorem weightMap_e6GraphAut_apply (x : Fin 6 → ℤ) (i : Fin 6) :
+@[simp] theorem e6GraphAut_weightMap_apply (x : Fin 6 → ℤ) (i : Fin 6) :
     e6GraphAut.weightMap x i = x (graphPermE6 i) :=
   e6GraphLatticeEquiv_apply x i
 
 /-- The cocharacter-lattice action of the type-`E₆` graph automorphism permutes the node
 coordinates. -/
-@[simp] theorem coweightMap_e6GraphAut_apply (x : Fin 6 → ℤ) (i : Fin 6) :
+@[simp] theorem e6GraphAut_coweightMap_apply (x : Fin 6 → ℤ) (i : Fin 6) :
     e6GraphAut.coweightMap x i = x (graphPermE6 i) :=
   e6GraphLatticeEquiv_apply x i
 
 /-- The root-index action of the type-`E₆` graph automorphism restricts to the numbered diagram
 involution on the pinned simple roots. -/
-@[simp] theorem indexEquiv_e6GraphAut_e6SimpleIndex (i : Fin 6) :
+@[simp] theorem e6GraphAut_indexEquiv_e6SimpleIndex (i : Fin 6) :
     e6GraphAut.indexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i) := by
+  -- Unfold the automorphism field to the separately named induced root permutation before using
+  -- the characteristic equation proved from injectivity of the root embedding.
   change e6GraphIndexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i)
   apply e6SimplyConnectedRootDatum.root.injective
   rw [← e6GraphLatticeEquiv_root, e6GraphLatticeEquiv_simpleRoot]
@@ -282,10 +297,14 @@ involution on the pinned simple roots. -/
 roots. -/
 theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
   intro h
-  have hindex := congrArg (fun e => e.indexEquiv (e6SimpleIndex 0)) h
-  simp only [indexEquiv_e6GraphAut_e6SimpleIndex, graphPermE6_apply_zero] at hindex
-  change e6SimpleIndex 5 = e6SimpleIndex 0 at hindex
-  have := congrArg Fin.val hindex
+  have hsimple : e6SimpleIndex 5 = e6SimpleIndex 0 := by
+    calc
+      e6SimpleIndex 5 = e6GraphAut.indexEquiv (e6SimpleIndex 0) := by
+        rw [e6GraphAut_indexEquiv_e6SimpleIndex, graphPermE6_apply_zero]
+      _ = (1 : _root_.RootPairing.Aut e6SimplyConnectedRootDatum).indexEquiv
+          (e6SimpleIndex 0) := congrArg (fun e => e.indexEquiv (e6SimpleIndex 0)) h
+      _ = e6SimpleIndex 0 := rfl
+  have := congrArg Fin.val hsimple
   simp only [e6SimpleIndex_val] at this
   omega
 
@@ -303,7 +322,7 @@ theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
     have hja : j = e6SimpleIndex a := by
       apply Fin.ext
       rw [e6SimpleIndex_val]
-    rw [hja, indexEquiv_e6GraphAut_e6SimpleIndex, e6SimpleIndex_val]
+    rw [hja, e6GraphAut_indexEquiv_e6SimpleIndex, e6SimpleIndex_val]
     exact (graphPermE6 a).isLt
   · intro hi
     rw [mem_e6SimplyConnectedBase_support] at hi
@@ -311,7 +330,7 @@ theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
     refine ⟨e6SimpleIndex (graphPermE6 a), ?_, ?_⟩
     · rw [mem_e6SimplyConnectedBase_support, e6SimpleIndex_val]
       exact (graphPermE6 a).isLt
-    · rw [indexEquiv_e6GraphAut_e6SimpleIndex]
+    · rw [e6GraphAut_indexEquiv_e6SimpleIndex]
       rw [graphPermE6_apply_apply]
       apply Fin.ext
       rw [e6SimpleIndex_val]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -11,15 +11,15 @@ public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
 /-!
 # The graph automorphism of the pinned type `E₆` root datum
 
-This file records two type-`E₆` consequences of applying the general diagram-automorphism
-construction `TauCeti.DynkinType.diagramAut` to the order-two symmetry `TauCeti.graphPermE6` of
-the Bourbaki-numbered `E₆` diagram: nontriviality and preservation of the pinned base.
+This file records the type-`E₆` nontriviality consequence of applying the general
+diagram-automorphism construction `TauCeti.DynkinType.diagramAut` to the order-two symmetry
+`TauCeti.graphPermE6` of the Bourbaki-numbered `E₆` diagram. Preservation of the pinned base is
+the specialization of the generic simp theorem
+`TauCeti.DynkinType.image_diagramRootPerm_simplyConnectedBase_support`.
 
 ## Main declarations
 
 * `TauCeti.DynkinType.diagramAut_graphPermE6_ne_one`: the induced automorphism is nontrivial.
-* `TauCeti.DynkinType.image_diagramRootPerm_e6SimplyConnectedBase_support`: the induced root
-  permutation preserves the pinned-base support.
 
 ## References
 
@@ -45,80 +45,11 @@ theorem diagramAut_graphPermE6_ne_one :
     diagramAut valid_E6 (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) ≠ 1 := by
   let hσ : graphPermE6 ∈ E6.diagramSymmetry :=
     mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6
-  change diagramAut valid_E6 hσ ≠ 1
-  let x : Fin 6 → ℤ := Pi.single 5 1
   intro h
-  have hvalue := congrArg (fun g => g.weightMap x (0 : Fin 6)) h
-  simp only [_root_.RootPairing.Equiv.toHom_one, _root_.RootPairing.Hom.weightMap_one,
-    LinearMap.id_coe] at hvalue
-  have hsymm : graphPermE6.symm = graphPermE6 :=
-    (mul_eq_one_iff_eq_inv.mp (by simpa only [pow_two] using graphPermE6_sq)).symm
-  have hmap := diagramAut_weightMap valid_E6 hσ
-  have hx := LinearMap.congr_fun hmap x
-  have haction := congrFun hx (0 : Fin 6)
-  have heval :
-      (LinearEquiv.funCongrLeft ℤ ℤ graphPermE6.symm) x 0 = x (graphPermE6 0) := by
-    change x (graphPermE6.symm 0) = x (graphPermE6 0)
-    rw [hsymm]
-  have haction' := haction.trans heval
-  have hbad := haction'.symm.trans hvalue
-  simp only [x, graphPermE6_apply_zero, Pi.single_apply] at hbad
-  change (1 : ℤ) = 0 at hbad
-  norm_num at hbad
-
-/-- The induced root permutation preserves the support of the pinned type-`E₆` base. Together with
-`RootPairing.Base.support_map_eq`, this computes the support of the transported base. -/
-theorem image_diagramRootPerm_e6SimplyConnectedBase_support :
-    e6SimplyConnectedBase.support.image
-        (diagramRootPerm valid_E6
-          (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) : Equiv.Perm (Fin 72)) =
-      e6SimplyConnectedBase.support := by
-  let hσ : graphPermE6 ∈ E6.diagramSymmetry :=
-    mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6
-  let p : Equiv.Perm (Fin 72) := diagramRootPerm valid_E6 hσ
-  change e6SimplyConnectedBase.support.image p = e6SimplyConnectedBase.support
-  have hsimple (a : Fin 6) :
-      p (e6SimpleIndex a) = e6SimpleIndex (graphPermE6 a) := by
-    have ha : E6.simpleIndex valid_E6 a = e6SimpleIndex a := by
-      apply Fin.ext
-      simpa only [e6SimpleIndex_val] using simpleIndex_val E6 valid_E6 a
-    have hσa : E6.simpleIndex valid_E6 (graphPermE6 a) =
-        e6SimpleIndex (graphPermE6 a) := by
-      apply Fin.ext
-      simpa only [e6SimpleIndex_val] using simpleIndex_val E6 valid_E6 (graphPermE6 a)
-    rw [← ha]
-    change diagramRootPerm valid_E6 hσ (E6.simpleIndex valid_E6 a) = _
-    exact (diagramRootPerm_simpleIndex valid_E6 hσ a).trans hσa
-  have hmem : ∀ j : Fin 72, j ∈ e6SimplyConnectedBase.support →
-      p j ∈ e6SimplyConnectedBase.support := by
-    intro j hj
-    rw [mem_e6SimplyConnectedBase_support] at hj ⊢
-    let a : Fin 6 := ⟨j, hj⟩
-    have hja : j = e6SimpleIndex a := by
-      apply Fin.ext
-      rw [e6SimpleIndex_val]
-    rw [hja, hsimple, e6SimpleIndex_val]
-    exact (graphPermE6 a).isLt
-  ext i
-  simp only [Finset.mem_image]
-  constructor
-  · rintro ⟨j, hj, rfl⟩
-    exact hmem j hj
-  · intro hi
-    rw [mem_e6SimplyConnectedBase_support] at hi
-    let a : Fin 6 := ⟨i, hi⟩
-    refine ⟨e6SimpleIndex (graphPermE6 a), ?_, ?_⟩
-    · rw [mem_e6SimplyConnectedBase_support, e6SimpleIndex_val]
-      exact (graphPermE6 a).isLt
-    · rw [hsimple]
-      have haa : graphPermE6 (graphPermE6 a) = a := by
-        have ha := congrArg (fun e : Equiv.Perm (Fin 6) => e a) graphPermE6_sq
-        simp only [pow_two, Equiv.Perm.mul_apply] at ha
-        change graphPermE6 (graphPermE6 a) = a at ha
-        exact ha
-      rw [haa]
-      apply Fin.ext
-      rw [e6SimpleIndex_val]
+  have hσ_one : graphPermE6 = 1 := (diagramAut_eq_one_iff valid_E6 hσ).mp h
+  have hzero := congrArg (fun e : Equiv.Perm (Fin 6) => e 0) hσ_one
+  simp only [graphPermE6_apply_zero, Equiv.Perm.one_def, Equiv.refl_apply] at hzero
+  omega
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -11,18 +11,15 @@ public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
 /-!
 # The graph automorphism of the pinned type `E₆` root datum
 
-This file specializes the general diagram-automorphism construction
-`TauCeti.DynkinType.diagramAut` to the order-two symmetry `TauCeti.graphPermE6` of the
-Bourbaki-numbered `E₆` diagram. It gives short type-`E₆` names for the resulting automorphism and
-root-index permutation, and records their nontriviality and preservation of the pinned base.
+This file records two type-`E₆` consequences of applying the general diagram-automorphism
+construction `TauCeti.DynkinType.diagramAut` to the order-two symmetry `TauCeti.graphPermE6` of
+the Bourbaki-numbered `E₆` diagram: nontriviality and preservation of the pinned base.
 
 ## Main declarations
 
-* `TauCeti.DynkinType.e6GraphIndexEquiv`: the induced permutation of all root indices.
-* `TauCeti.DynkinType.e6GraphAut`: the graph automorphism of the pinned simply connected datum.
-* `TauCeti.DynkinType.e6GraphAut_sq`: the automorphism has square one.
-* `TauCeti.DynkinType.image_e6GraphIndexEquiv_e6SimplyConnectedBase_support`: the pinned base
-  support is preserved.
+* `TauCeti.DynkinType.diagramAut_graphPermE6_ne_one`: the induced automorphism is nontrivial.
+* `TauCeti.DynkinType.image_diagramRootPerm_e6SimplyConnectedBase_support`: the induced root
+  permutation preserves the pinned-base support.
 
 ## References
 
@@ -42,113 +39,65 @@ open TauCeti
 
 noncomputable section
 
-private theorem graphPermE6_mem_diagramSymmetry :
-    graphPermE6 ∈ E6.diagramSymmetry :=
-  mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6
-
-/-- The permutation of all roots induced by the `E₆` graph symmetry, expressed on the native root
-indices of the pinned datum. -/
-def e6GraphIndexEquiv : Equiv.Perm (Fin 72) :=
-  diagramRootPerm valid_E6 graphPermE6_mem_diagramSymmetry
-
-/-- The order-two diagram symmetry as an automorphism of the pinned simply connected root datum of
-type `E₆`. -/
-def e6GraphAut := diagramAut valid_E6 graphPermE6_mem_diagramSymmetry
-
-/-- The root-index permutation packaged by the type-`E₆` graph automorphism is the separately
-named specialization of the general induced permutation. -/
-@[simp] theorem e6GraphAut_indexEquiv : e6GraphAut.indexEquiv = e6GraphIndexEquiv := by
-  exact diagramAut_indexEquiv valid_E6 graphPermE6_mem_diagramSymmetry
-
-/-- The character-lattice action of the type-`E₆` graph automorphism permutes the node
-coordinates. This is not a simp lemma because its left side normalizes across the opaque
-`E6.rank = 6` equation. -/
-theorem weightMap_e6GraphAut_apply (x : Fin 6 → ℤ) (i : Fin 6) :
-    e6GraphAut.weightMap x i = x (graphPermE6 i) := by
-  change Fin 6 → ℤ at x
-  change Fin 6 at i
-  have h : graphPermE6.symm = graphPermE6 :=
-    (mul_eq_one_iff_eq_inv.mp (by simpa only [pow_two] using graphPermE6_sq)).symm
-  have hmap := diagramAut_weightMap valid_E6 graphPermE6_mem_diagramSymmetry
-  have hx := LinearMap.congr_fun hmap x
-  have hxi := congrFun hx i
-  have heval : (LinearEquiv.funCongrLeft ℤ ℤ graphPermE6.symm) x i =
-      x (graphPermE6 i) := by
-    change x (graphPermE6.symm i) = x (graphPermE6 i)
-    rw [h]
-  simpa only [e6GraphAut] using hxi.trans heval
-
-/-- The cocharacter-lattice action of the type-`E₆` graph automorphism permutes the node
-coordinates. As for `weightMap_e6GraphAut_apply`, the opaque rank equation prevents a simp-normal
-left side. -/
-theorem coweightMap_e6GraphAut_apply (x : Fin 6 → ℤ) (i : Fin 6) :
-    e6GraphAut.coweightMap x i = x (graphPermE6 i) := by
-  change Fin 6 → ℤ at x
-  change Fin 6 at i
-  have hmap := diagramAut_coweightMap valid_E6 graphPermE6_mem_diagramSymmetry
-  have hx := LinearMap.congr_fun hmap x
-  have hxi := congrFun hx i
-  have heval : (LinearEquiv.funCongrLeft ℤ ℤ graphPermE6) x i =
-      x (graphPermE6 i) := rfl
-  simpa only [e6GraphAut] using hxi.trans heval
-
-/-- The type-`E₆` root permutation restricts to the numbered diagram involution on the pinned
-simple roots. -/
-@[simp] theorem e6GraphIndexEquiv_e6SimpleIndex (i : Fin 6) :
-    e6GraphIndexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i) := by
-  have hi : E6.simpleIndex valid_E6 i = e6SimpleIndex i := by
-    apply Fin.ext
-    simpa only [e6SimpleIndex_val] using simpleIndex_val E6 valid_E6 i
-  have hσi : E6.simpleIndex valid_E6 (graphPermE6 i) =
-      e6SimpleIndex (graphPermE6 i) := by
-    apply Fin.ext
-    simpa only [e6SimpleIndex_val] using simpleIndex_val E6 valid_E6 (graphPermE6 i)
-  rw [← hi, e6GraphIndexEquiv]
-  exact (diagramRootPerm_simpleIndex valid_E6 graphPermE6_mem_diagramSymmetry i).trans hσi
-
-/-- Applying the type-`E₆` graph automorphism twice is the identity. -/
-@[simp] theorem e6GraphAut_sq : e6GraphAut ^ 2 = 1 := by
-  exact diagramAut_pow_eq_one valid_E6 graphPermE6_mem_diagramSymmetry graphPermE6_sq
-
-/-- Applying the type-`E₆` root permutation twice is the identity. -/
-@[simp] theorem e6GraphIndexEquiv_apply_apply (i : Fin 72) :
-    e6GraphIndexEquiv (e6GraphIndexEquiv i) = i := by
-  have h := congrArg (fun g => g.indexEquiv) e6GraphAut_sq
-  simp only [pow_two, _root_.RootPairing.Equiv.mul_eq_comp,
-    _root_.RootPairing.Equiv.toHom_comp, _root_.RootPairing.Hom.comp,
-    e6GraphAut_indexEquiv, _root_.RootPairing.Equiv.toHom_one,
-    _root_.RootPairing.Hom.indexEquiv_one] at h
-  have hi := DFunLike.congr_fun h i
-  change e6GraphIndexEquiv (e6GraphIndexEquiv i) = i at hi
-  exact hi
-
 /-- The type-`E₆` graph automorphism is nontrivial: it exchanges the first and sixth simple
 roots. -/
-theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
+theorem diagramAut_graphPermE6_ne_one :
+    diagramAut valid_E6 (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) ≠ 1 := by
+  let hσ : graphPermE6 ∈ E6.diagramSymmetry :=
+    mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6
+  change diagramAut valid_E6 hσ ≠ 1
+  let x : Fin 6 → ℤ := Pi.single 5 1
   intro h
-  have hvalue := congrArg (fun g => g.weightMap (Pi.single (5 : Fin 6) 1) (0 : Fin 6)) h
+  have hvalue := congrArg (fun g => g.weightMap x (0 : Fin 6)) h
   simp only [_root_.RootPairing.Equiv.toHom_one, _root_.RootPairing.Hom.weightMap_one,
-    LinearMap.id_coe, id_eq] at hvalue
-  have haction := weightMap_e6GraphAut_apply (Pi.single (5 : Fin 6) 1) (0 : Fin 6)
-  have hbad := haction.symm.trans hvalue
-  simp only [graphPermE6_apply_zero, Pi.single_apply] at hbad
+    LinearMap.id_coe] at hvalue
+  have hsymm : graphPermE6.symm = graphPermE6 :=
+    (mul_eq_one_iff_eq_inv.mp (by simpa only [pow_two] using graphPermE6_sq)).symm
+  have hmap := diagramAut_weightMap valid_E6 hσ
+  have hx := LinearMap.congr_fun hmap x
+  have haction := congrFun hx (0 : Fin 6)
+  have heval :
+      (LinearEquiv.funCongrLeft ℤ ℤ graphPermE6.symm) x 0 = x (graphPermE6 0) := by
+    change x (graphPermE6.symm 0) = x (graphPermE6 0)
+    rw [hsymm]
+  have haction' := haction.trans heval
+  have hbad := haction'.symm.trans hvalue
+  simp only [x, graphPermE6_apply_zero, Pi.single_apply] at hbad
   change (1 : ℤ) = 0 at hbad
   norm_num at hbad
 
 /-- The induced root permutation preserves the support of the pinned type-`E₆` base. Together with
 `RootPairing.Base.support_map_eq`, this computes the support of the transported base. -/
-@[simp] theorem image_e6GraphIndexEquiv_e6SimplyConnectedBase_support :
-    e6SimplyConnectedBase.support.image e6GraphIndexEquiv =
+theorem image_diagramRootPerm_e6SimplyConnectedBase_support :
+    e6SimplyConnectedBase.support.image
+        (diagramRootPerm valid_E6
+          (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) : Equiv.Perm (Fin 72)) =
       e6SimplyConnectedBase.support := by
+  let hσ : graphPermE6 ∈ E6.diagramSymmetry :=
+    mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6
+  let p : Equiv.Perm (Fin 72) := diagramRootPerm valid_E6 hσ
+  change e6SimplyConnectedBase.support.image p = e6SimplyConnectedBase.support
+  have hsimple (a : Fin 6) :
+      p (e6SimpleIndex a) = e6SimpleIndex (graphPermE6 a) := by
+    have ha : E6.simpleIndex valid_E6 a = e6SimpleIndex a := by
+      apply Fin.ext
+      simpa only [e6SimpleIndex_val] using simpleIndex_val E6 valid_E6 a
+    have hσa : E6.simpleIndex valid_E6 (graphPermE6 a) =
+        e6SimpleIndex (graphPermE6 a) := by
+      apply Fin.ext
+      simpa only [e6SimpleIndex_val] using simpleIndex_val E6 valid_E6 (graphPermE6 a)
+    rw [← ha]
+    change diagramRootPerm valid_E6 hσ (E6.simpleIndex valid_E6 a) = _
+    exact (diagramRootPerm_simpleIndex valid_E6 hσ a).trans hσa
   have hmem : ∀ j : Fin 72, j ∈ e6SimplyConnectedBase.support →
-      e6GraphIndexEquiv j ∈ e6SimplyConnectedBase.support := by
+      p j ∈ e6SimplyConnectedBase.support := by
     intro j hj
     rw [mem_e6SimplyConnectedBase_support] at hj ⊢
     let a : Fin 6 := ⟨j, hj⟩
     have hja : j = e6SimpleIndex a := by
       apply Fin.ext
       rw [e6SimpleIndex_val]
-    rw [hja, e6GraphIndexEquiv_e6SimpleIndex, e6SimpleIndex_val]
+    rw [hja, hsimple, e6SimpleIndex_val]
     exact (graphPermE6 a).isLt
   ext i
   simp only [Finset.mem_image]
@@ -156,7 +105,20 @@ theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
   · rintro ⟨j, hj, rfl⟩
     exact hmem j hj
   · intro hi
-    exact ⟨e6GraphIndexEquiv i, hmem i hi, e6GraphIndexEquiv_apply_apply i⟩
+    rw [mem_e6SimplyConnectedBase_support] at hi
+    let a : Fin 6 := ⟨i, hi⟩
+    refine ⟨e6SimpleIndex (graphPermE6 a), ?_, ?_⟩
+    · rw [mem_e6SimplyConnectedBase_support, e6SimpleIndex_val]
+      exact (graphPermE6 a).isLt
+    · rw [hsimple]
+      have haa : graphPermE6 (graphPermE6 a) = a := by
+        have ha := congrArg (fun e : Equiv.Perm (Fin 6) => e a) graphPermE6_sq
+        simp only [pow_two, Equiv.Perm.mul_apply] at ha
+        change graphPermE6 (graphPermE6 a) = a at ha
+        exact ha
+      rw [haa]
+      apply Fin.ext
+      rw [e6SimpleIndex_val]
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -20,6 +20,7 @@ generic simp theorem
 ## Main declarations
 
 * `TauCeti.DynkinType.e6GraphAut`: the graph automorphism of the pinned type-`E₆` root datum.
+* `TauCeti.DynkinType.e6GraphAut_sq`: this automorphism is an involution.
 * `TauCeti.DynkinType.e6GraphAut_ne_one`: this automorphism is nontrivial.
 
 ## References
@@ -44,6 +45,11 @@ noncomputable section
 the nontrivial symmetry of the Bourbaki-numbered Dynkin diagram. -/
 def e6GraphAut : (E6.simplyConnectedRootDatum valid_E6).Aut :=
   diagramAut valid_E6 (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)
+
+/-- Applying the type-`E₆` graph automorphism twice is the identity. -/
+@[simp] theorem e6GraphAut_sq : e6GraphAut ^ 2 = 1 :=
+  diagramAut_pow_eq_one valid_E6
+    (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) graphPermE6_sq
 
 /-- The root-index action bundled in the type-`E₆` graph automorphism is the permutation induced
 by the nontrivial symmetry of its Dynkin diagram. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -5,24 +5,16 @@ Authors: The Tau Ceti contributors
 -/
 module
 
--- `RootPairing.isReduced_of_pairing_comm` supplies the local reducedness witness used by the
--- base-induction proof that the lattice involution preserves the set of roots.
-import TauCeti.LinearAlgebra.RootSystem.Reduced
-public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.DiagramAutomorphism
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
 
 /-!
 # The graph automorphism of the pinned type `E₆` root datum
 
-The Dynkin diagram of type `E₆` has an involution exchanging Bourbaki nodes `1 ↔ 6` and
-`3 ↔ 5`.
-The character and cocharacter lattices of `TauCeti.DynkinType.e6SimplyConnectedRootDatum` are
-written in bases indexed by those nodes, so the involution acts on each lattice by reindexing
-coordinates with `TauCeti.graphPermE6`.
-
-This file packages those lattice maps and the induced permutation of all seventy-two roots as an
-automorphism of the pinned root datum. Its restriction to the pinned simple roots is exactly
-`TauCeti.graphPermE6`, the numbered permutation used for the graph-twisted family `²E₆`.
+This file specializes the general diagram-automorphism construction
+`TauCeti.DynkinType.diagramAut` to the order-two symmetry `TauCeti.graphPermE6` of the
+Bourbaki-numbered `E₆` diagram. It gives short type-`E₆` names for the resulting automorphism and
+root-index permutation, and records their nontriviality and preservation of the pinned base.
 
 ## Main declarations
 
@@ -38,271 +30,119 @@ The coordinates and node numbering follow Bourbaki, *Lie Groups and Lie Algebras
 Plate V. The graph automorphism and its role in the twisted family `²E₆` follow R. W. Carter,
 *Simple Groups of Lie Type*, §12.2.
 
-This supplies the type-`E₆` root-datum input to the pinned-isomorphism target in Layer 9 of the
-ReductiveGroups roadmap. The pinned isomorphism theorem will lift it to the group-scheme
-automorphism used in the graph-twisted Steinberg endomorphism.
+The pinned-isomorphism target in Layer 9 of the ReductiveGroups roadmap lifts root-datum
+automorphisms such as this one to pinned group-scheme automorphisms.
 -/
 
 public section
 
-namespace TauCeti
+namespace TauCeti.DynkinType
 
-open Function Set
+open TauCeti
 
-namespace DynkinType
+noncomputable section
 
-/-! ## The lattice and root-index permutations -/
+private theorem graphPermE6_mem_diagramSymmetry :
+    graphPermE6 ∈ E6.diagramSymmetry :=
+  mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6
 
-private lemma graphPermE6_symm : graphPermE6.symm = graphPermE6 := by
-  exact (mul_eq_one_iff_eq_inv.mp (by simpa only [pow_two] using graphPermE6_sq)).symm
+/-- The permutation of all roots induced by the `E₆` graph symmetry, expressed on the native root
+indices of the pinned datum. -/
+def e6GraphIndexEquiv : Equiv.Perm (Fin 72) :=
+  diagramRootPerm valid_E6 graphPermE6_mem_diagramSymmetry
 
-private lemma graphPermE6_apply_apply (i : Fin 6) : graphPermE6 (graphPermE6 i) = i := by
-  have h := congrArg (fun e : Equiv.Perm (Fin 6) => e i) graphPermE6_sq
-  simpa only [pow_two, Equiv.Perm.mul_apply, Equiv.Perm.one_apply] using h
-
-/-- Reindex fundamental-weight or simple-coroot coordinates by the `E₆` graph permutation. -/
-private def e6GraphLatticeEquiv : (Fin 6 → ℤ) ≃ₗ[ℤ] Fin 6 → ℤ :=
-  LinearEquiv.piCongrLeft' ℤ (fun _ : Fin 6 => ℤ) graphPermE6
-
-private lemma e6GraphLatticeEquiv_apply (x : Fin 6 → ℤ) (i : Fin 6) :
-    e6GraphLatticeEquiv x i = x (graphPermE6 i) := by
-  rw [e6GraphLatticeEquiv, LinearEquiv.piCongrLeft'_apply, graphPermE6_symm]
-
-private lemma e6GraphLatticeEquiv_involutive : Involutive e6GraphLatticeEquiv := by
-  intro x
-  funext i
-  rw [e6GraphLatticeEquiv_apply, e6GraphLatticeEquiv_apply]
-  rw [graphPermE6_apply_apply]
-
-private lemma e6GraphLatticeEquiv_dotProduct (x y : Fin 6 → ℤ) :
-    e6GraphLatticeEquiv x ⬝ᵥ e6GraphLatticeEquiv y = x ⬝ᵥ y := by
-  simp only [dotProduct, e6GraphLatticeEquiv_apply]
-  apply Fintype.sum_equiv graphPermE6
-  intro i
-  rfl
-
-private lemma e6GraphLatticeEquiv_dotProduct_left (x y : Fin 6 → ℤ) :
-    e6GraphLatticeEquiv x ⬝ᵥ y = x ⬝ᵥ e6GraphLatticeEquiv y := by
-  have h := e6GraphLatticeEquiv_dotProduct x (e6GraphLatticeEquiv y)
-  rw [e6GraphLatticeEquiv_involutive] at h
-  exact h
-
-private lemma e6GraphLatticeEquiv_simpleCoroot (i : Fin 6) :
-    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.coroot (e6SimpleIndex i)) =
-      e6SimplyConnectedRootDatum.coroot (e6SimpleIndex (graphPermE6 i)) := by
-  simp only [e6SimplyConnectedRootDatum_coroot, coroot_e6SimpleIndex]
-  funext j
-  rw [e6GraphLatticeEquiv_apply]
-  simp only [Pi.single_apply]
-  by_cases hji : graphPermE6 j = i
-  · have hij : j = graphPermE6 i := by
-      rw [← graphPermE6_apply_apply j, hji]
-    simp only [hij, graphPermE6_apply_apply, ↓reduceIte]
-  · have hij : j ≠ graphPermE6 i := by
-      intro hij
-      apply hji
-      rw [hij, graphPermE6_apply_apply]
-    simp only [hji, hij, ↓reduceIte]
-
-private lemma e6GraphLatticeEquiv_simpleRoot (i : Fin 6) :
-    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root (e6SimpleIndex i)) =
-      e6SimplyConnectedRootDatum.root (e6SimpleIndex (graphPermE6 i)) := by
-  simp only [e6SimplyConnectedRootDatum_root, root_e6SimpleIndex]
-  funext j
-  rw [e6GraphLatticeEquiv_apply]
-  have h := cartanMatrix_E6_graphPermE6 i (graphPermE6 j)
-  simpa only [DynkinType.cartanMatrix_E6, graphPermE6_apply_apply] using h.symm
-
-private lemma e6GraphLatticeEquiv_mulVec (x : Fin 6 → ℤ) :
-    e6GraphLatticeEquiv ((CartanMatrix.E 6).mulVec x) =
-      (CartanMatrix.E 6).mulVec (e6GraphLatticeEquiv x) := by
-  funext j
-  simp only [Matrix.mulVec, dotProduct, e6GraphLatticeEquiv_apply]
-  apply Fintype.sum_equiv graphPermE6
-  intro i
-  rw [graphPermE6_apply_apply]
-  have h := cartanMatrix_E6_graphPermE6 j (graphPermE6 i)
-  simpa only [DynkinType.cartanMatrix_E6, graphPermE6_apply_apply] using
-    congrArg (fun z => z * x i) h
-
-private lemma e6GraphLatticeEquiv_root_mem_range (i : Fin 72) :
-    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i) ∈
-      range e6SimplyConnectedRootDatum.root := by
-  let _ : e6SimplyConnectedRootDatum.IsReduced :=
-    RootPairing.isReduced_of_pairing_comm _ fun j k => by
-      simpa only [e6SimplyConnectedRootDatum_pairing] using
-        e6Root_dotProduct_e6Coroot_comm j k
-  apply e6SimplyConnectedBase.induction_reflect i
-  · intro j hj
-    rw [e6SimplyConnectedRootDatum.root_reflectionPerm,
-      e6SimplyConnectedRootDatum.reflection_apply_self, map_neg,
-      e6SimplyConnectedRootDatum.neg_mem_range_root_iff]
-    exact hj
-  · intro j hj
-    rw [mem_e6SimplyConnectedBase_support] at hj
-    let a : Fin 6 := ⟨j, hj⟩
-    have hja : j = e6SimpleIndex a := by
-      apply Fin.ext
-      rw [e6SimpleIndex_val]
-    refine ⟨e6SimpleIndex (graphPermE6 a), ?_⟩
-    rw [hja, e6GraphLatticeEquiv_simpleRoot]
-  · intro j k hj hk
-    obtain ⟨l, hl⟩ := hj
-    rw [mem_e6SimplyConnectedBase_support] at hk
-    let a : Fin 6 := ⟨k, hk⟩
-    have hka : k = e6SimpleIndex a := by
-      apply Fin.ext
-      rw [e6SimpleIndex_val]
-    have hpair : e6SimplyConnectedRootDatum.pairing l (e6SimpleIndex (graphPermE6 a)) =
-        e6SimplyConnectedRootDatum.pairing j k := by
-      -- Expose `pairing` as the perfect bilinear map so the two lattice-equivariance facts apply.
-      change e6SimplyConnectedRootDatum.toLinearMap (e6SimplyConnectedRootDatum.root l)
-          (e6SimplyConnectedRootDatum.coroot (e6SimpleIndex (graphPermE6 a))) =
-        e6SimplyConnectedRootDatum.toLinearMap (e6SimplyConnectedRootDatum.root j)
-          (e6SimplyConnectedRootDatum.coroot k)
-      rw [hl, ← e6GraphLatticeEquiv_simpleCoroot, hka,
-        e6SimplyConnectedRootDatum_toLinearMap,
-        e6SimplyConnectedRootDatum_toLinearMap, e6GraphLatticeEquiv_dotProduct]
-    refine ⟨e6SimplyConnectedRootDatum.reflectionPerm
-      (e6SimpleIndex (graphPermE6 a)) l, ?_⟩
-    rw [e6SimplyConnectedRootDatum.root_reflectionPerm,
-      e6SimplyConnectedRootDatum.root_reflectionPerm,
-      e6SimplyConnectedRootDatum.reflection_apply,
-      e6SimplyConnectedRootDatum.reflection_apply, map_sub, map_smul,
-      hka, e6GraphLatticeEquiv_simpleRoot]
-    rw [← hl, e6SimplyConnectedRootDatum.root_coroot'_eq_pairing,
-      e6SimplyConnectedRootDatum.root_coroot'_eq_pairing, hpair, ← hka]
-
-/-- The root index selected by the image of a root under the lattice involution. -/
-private noncomputable def e6GraphIndex (i : Fin 72) : Fin 72 :=
-  e6SimplyConnectedRootDatum.root.invOfMemRange
-    ⟨e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i),
-      e6GraphLatticeEquiv_root_mem_range i⟩
-
-private lemma root_e6GraphIndex (i : Fin 72) :
-    e6SimplyConnectedRootDatum.root (e6GraphIndex i) =
-      e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i) :=
-  e6SimplyConnectedRootDatum.root.left_inv_of_invOfMemRange
-    ⟨e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i),
-      e6GraphLatticeEquiv_root_mem_range i⟩
-
-private lemma e6GraphIndex_involutive : Involutive e6GraphIndex := by
-  intro i
-  apply e6SimplyConnectedRootDatum.root.injective
-  rw [root_e6GraphIndex, root_e6GraphIndex, e6GraphLatticeEquiv_involutive]
-
-/-- The permutation of all roots induced by the graph symmetry, expressed on the native root
-indices of the pinned type-`E₆` datum. -/
-noncomputable def e6GraphIndexEquiv : Equiv.Perm (Fin 72) :=
-  e6GraphIndex_involutive.toPerm
-
-private lemma e6GraphLatticeEquiv_root (i : Fin 72) :
-    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.root i) =
-      e6SimplyConnectedRootDatum.root (e6GraphIndexEquiv i) := by
-  exact (root_e6GraphIndex i).symm
-
-/-- Applying the type-`E₆` root permutation twice is the identity. -/
-@[simp] theorem e6GraphIndexEquiv_apply_apply (i : Fin 72) :
-    e6GraphIndexEquiv (e6GraphIndexEquiv i) = i := by
-  apply e6SimplyConnectedRootDatum.root.injective
-  rw [← e6GraphLatticeEquiv_root, ← e6GraphLatticeEquiv_root,
-    e6GraphLatticeEquiv_involutive]
-
-private lemma e6GraphLatticeEquiv_coroot (i : Fin 72) :
-    e6GraphLatticeEquiv (e6SimplyConnectedRootDatum.coroot i) =
-      e6SimplyConnectedRootDatum.coroot (e6GraphIndexEquiv i) := by
-  simp only [e6SimplyConnectedRootDatum_coroot]
-  apply Matrix.mulVec_injective_of_det_ne_zero (by rw [CartanMatrix.E₆_det]; norm_num)
-  rw [← e6GraphLatticeEquiv_mulVec, ← e6Root_eq_mulVec, ← e6Root_eq_mulVec]
-  simpa only [← e6SimplyConnectedRootDatum_root] using e6GraphLatticeEquiv_root i
-
-/-! ## The root-datum automorphism -/
-
-/-- The diagram symmetry as an automorphism of the pinned simply connected root datum of type
-`E₆`. Both lattice maps exchange the node coordinates according to `TauCeti.graphPermE6`, and the
-root-index map is the induced permutation of the seventy-two roots. -/
-noncomputable def e6GraphAut : _root_.RootPairing.Aut e6SimplyConnectedRootDatum where
-  weightMap := e6GraphLatticeEquiv.toLinearMap
-  coweightMap := e6GraphLatticeEquiv.toLinearMap
-  indexEquiv := e6GraphIndexEquiv
-  weight_coweight_transpose := by
-    ext y x
-    -- The structure field equates compositions of linear maps. After extensionality, unfold
-    -- those wrappers to expose the concrete perfect pairing and the two lattice arguments.
-    change e6SimplyConnectedRootDatum.toLinearMap
-        (e6GraphLatticeEquiv (Pi.single x 1)) (Pi.single y 1) =
-      e6SimplyConnectedRootDatum.toLinearMap (Pi.single x 1)
-        (e6GraphLatticeEquiv (Pi.single y 1))
-    rw [e6SimplyConnectedRootDatum_toLinearMap, e6SimplyConnectedRootDatum_toLinearMap]
-    exact e6GraphLatticeEquiv_dotProduct_left _ _
-  root_weightMap := by
-    funext i
-    exact e6GraphLatticeEquiv_root i
-  coroot_coweightMap := by
-    funext i
-    rw [e6GraphIndexEquiv, Function.Involutive.toPerm_symm e6GraphIndex_involutive]
-    exact e6GraphLatticeEquiv_coroot i
-  bijective_weightMap := e6GraphLatticeEquiv.bijective
-  bijective_coweightMap := e6GraphLatticeEquiv.bijective
+/-- The order-two diagram symmetry as an automorphism of the pinned simply connected root datum of
+type `E₆`. -/
+def e6GraphAut := diagramAut valid_E6 graphPermE6_mem_diagramSymmetry
 
 /-- The root-index permutation packaged by the type-`E₆` graph automorphism is the separately
-named induced permutation of all roots. -/
+named specialization of the general induced permutation. -/
 @[simp] theorem e6GraphAut_indexEquiv : e6GraphAut.indexEquiv = e6GraphIndexEquiv := by
-  rw [e6GraphAut]
+  exact diagramAut_indexEquiv valid_E6 graphPermE6_mem_diagramSymmetry
 
 /-- The character-lattice action of the type-`E₆` graph automorphism permutes the node
-coordinates. -/
-@[simp] theorem e6GraphAut_weightMap_apply (x : Fin 6 → ℤ) (i : Fin 6) :
-    e6GraphAut.weightMap x i = x (graphPermE6 i) :=
-  e6GraphLatticeEquiv_apply x i
+coordinates. This is not a simp lemma because its left side normalizes across the opaque
+`E6.rank = 6` equation. -/
+theorem weightMap_e6GraphAut_apply (x : Fin 6 → ℤ) (i : Fin 6) :
+    e6GraphAut.weightMap x i = x (graphPermE6 i) := by
+  change Fin 6 → ℤ at x
+  change Fin 6 at i
+  have h : graphPermE6.symm = graphPermE6 :=
+    (mul_eq_one_iff_eq_inv.mp (by simpa only [pow_two] using graphPermE6_sq)).symm
+  have hmap := diagramAut_weightMap valid_E6 graphPermE6_mem_diagramSymmetry
+  have hx := LinearMap.congr_fun hmap x
+  have hxi := congrFun hx i
+  have heval : (LinearEquiv.funCongrLeft ℤ ℤ graphPermE6.symm) x i =
+      x (graphPermE6 i) := by
+    change x (graphPermE6.symm i) = x (graphPermE6 i)
+    rw [h]
+  simpa only [e6GraphAut] using hxi.trans heval
 
 /-- The cocharacter-lattice action of the type-`E₆` graph automorphism permutes the node
-coordinates. -/
-@[simp] theorem e6GraphAut_coweightMap_apply (x : Fin 6 → ℤ) (i : Fin 6) :
-    e6GraphAut.coweightMap x i = x (graphPermE6 i) :=
-  e6GraphLatticeEquiv_apply x i
+coordinates. As for `weightMap_e6GraphAut_apply`, the opaque rank equation prevents a simp-normal
+left side. -/
+theorem coweightMap_e6GraphAut_apply (x : Fin 6 → ℤ) (i : Fin 6) :
+    e6GraphAut.coweightMap x i = x (graphPermE6 i) := by
+  change Fin 6 → ℤ at x
+  change Fin 6 at i
+  have hmap := diagramAut_coweightMap valid_E6 graphPermE6_mem_diagramSymmetry
+  have hx := LinearMap.congr_fun hmap x
+  have hxi := congrFun hx i
+  have heval : (LinearEquiv.funCongrLeft ℤ ℤ graphPermE6) x i =
+      x (graphPermE6 i) := rfl
+  simpa only [e6GraphAut] using hxi.trans heval
 
 /-- The type-`E₆` root permutation restricts to the numbered diagram involution on the pinned
 simple roots. -/
 @[simp] theorem e6GraphIndexEquiv_e6SimpleIndex (i : Fin 6) :
     e6GraphIndexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i) := by
-  apply e6SimplyConnectedRootDatum.root.injective
-  rw [← e6GraphLatticeEquiv_root, e6GraphLatticeEquiv_simpleRoot]
+  have hi : E6.simpleIndex valid_E6 i = e6SimpleIndex i := by
+    apply Fin.ext
+    simpa only [e6SimpleIndex_val] using simpleIndex_val E6 valid_E6 i
+  have hσi : E6.simpleIndex valid_E6 (graphPermE6 i) =
+      e6SimpleIndex (graphPermE6 i) := by
+    apply Fin.ext
+    simpa only [e6SimpleIndex_val] using simpleIndex_val E6 valid_E6 (graphPermE6 i)
+  rw [← hi, e6GraphIndexEquiv]
+  exact (diagramRootPerm_simpleIndex valid_E6 graphPermE6_mem_diagramSymmetry i).trans hσi
 
 /-- Applying the type-`E₆` graph automorphism twice is the identity. -/
 @[simp] theorem e6GraphAut_sq : e6GraphAut ^ 2 = 1 := by
-  apply _root_.RootPairing.Equiv.ext
-  · apply LinearMap.ext
-    exact e6GraphLatticeEquiv_involutive
-  · apply LinearMap.ext
-    exact e6GraphLatticeEquiv_involutive
-  · apply Equiv.ext
-    exact e6GraphIndexEquiv_apply_apply
+  exact diagramAut_pow_eq_one valid_E6 graphPermE6_mem_diagramSymmetry graphPermE6_sq
+
+/-- Applying the type-`E₆` root permutation twice is the identity. -/
+@[simp] theorem e6GraphIndexEquiv_apply_apply (i : Fin 72) :
+    e6GraphIndexEquiv (e6GraphIndexEquiv i) = i := by
+  have h := congrArg (fun g => g.indexEquiv) e6GraphAut_sq
+  simp only [pow_two, _root_.RootPairing.Equiv.mul_eq_comp,
+    _root_.RootPairing.Equiv.toHom_comp, _root_.RootPairing.Hom.comp,
+    e6GraphAut_indexEquiv, _root_.RootPairing.Equiv.toHom_one,
+    _root_.RootPairing.Hom.indexEquiv_one] at h
+  have hi := DFunLike.congr_fun h i
+  change e6GraphIndexEquiv (e6GraphIndexEquiv i) = i at hi
+  exact hi
 
 /-- The type-`E₆` graph automorphism is nontrivial: it exchanges the first and sixth simple
 roots. -/
 theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
   intro h
-  have hsimple : e6SimpleIndex 5 = e6SimpleIndex 0 := by
-    calc
-      e6SimpleIndex 5 = e6GraphAut.indexEquiv (e6SimpleIndex 0) := by
-        rw [e6GraphAut_indexEquiv, e6GraphIndexEquiv_e6SimpleIndex, graphPermE6_apply_zero]
-      _ = (1 : _root_.RootPairing.Aut e6SimplyConnectedRootDatum).indexEquiv
-          (e6SimpleIndex 0) := congrArg (fun e => e.indexEquiv (e6SimpleIndex 0)) h
-      _ = e6SimpleIndex 0 := rfl
-  have := congrArg Fin.val hsimple
-  simp only [e6SimpleIndex_val] at this
-  omega
+  have hvalue := congrArg (fun g => g.weightMap (Pi.single (5 : Fin 6) 1) (0 : Fin 6)) h
+  simp only [_root_.RootPairing.Equiv.toHom_one, _root_.RootPairing.Hom.weightMap_one,
+    LinearMap.id_coe, id_eq] at hvalue
+  have haction := weightMap_e6GraphAut_apply (Pi.single (5 : Fin 6) 1) (0 : Fin 6)
+  have hbad := haction.symm.trans hvalue
+  simp only [graphPermE6_apply_zero, Pi.single_apply] at hbad
+  change (1 : ℤ) = 0 at hbad
+  norm_num at hbad
 
 /-- The induced root permutation preserves the support of the pinned type-`E₆` base. Together with
 `RootPairing.Base.support_map_eq`, this computes the support of the transported base. -/
 @[simp] theorem image_e6GraphIndexEquiv_e6SimplyConnectedBase_support :
     e6SimplyConnectedBase.support.image e6GraphIndexEquiv =
       e6SimplyConnectedBase.support := by
-  ext i
-  simp only [Finset.mem_image]
-  constructor
-  · rintro ⟨j, hj, rfl⟩
+  have hmem : ∀ j : Fin 72, j ∈ e6SimplyConnectedBase.support →
+      e6GraphIndexEquiv j ∈ e6SimplyConnectedBase.support := by
+    intro j hj
     rw [mem_e6SimplyConnectedBase_support] at hj ⊢
     let a : Fin 6 := ⟨j, hj⟩
     have hja : j = e6SimpleIndex a := by
@@ -310,17 +150,14 @@ theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
       rw [e6SimpleIndex_val]
     rw [hja, e6GraphIndexEquiv_e6SimpleIndex, e6SimpleIndex_val]
     exact (graphPermE6 a).isLt
+  ext i
+  simp only [Finset.mem_image]
+  constructor
+  · rintro ⟨j, hj, rfl⟩
+    exact hmem j hj
   · intro hi
-    rw [mem_e6SimplyConnectedBase_support] at hi
-    let a : Fin 6 := ⟨i, hi⟩
-    refine ⟨e6SimpleIndex (graphPermE6 a), ?_, ?_⟩
-    · rw [mem_e6SimplyConnectedBase_support, e6SimpleIndex_val]
-      exact (graphPermE6 a).isLt
-    · rw [e6GraphIndexEquiv_e6SimpleIndex]
-      rw [graphPermE6_apply_apply]
-      apply Fin.ext
-      rw [e6SimpleIndex_val]
+    exact ⟨e6GraphIndexEquiv i, hmem i hi, e6GraphIndexEquiv_apply_apply i⟩
 
-end DynkinType
+end
 
-end TauCeti
+end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -245,21 +245,10 @@ noncomputable def e6GraphAut : _root_.RootPairing.Aut e6SimplyConnectedRootDatum
   bijective_weightMap := e6GraphLatticeEquiv.bijective
   bijective_coweightMap := e6GraphLatticeEquiv.bijective
 
-/-- The graph automorphism carries every root to the root selected by its public root-index
-permutation. -/
-@[simp] theorem e6GraphAut_weightMap_root (i : Fin 72) :
-    e6GraphAut.weightMap (e6Root i) = e6Root (e6GraphIndexEquiv i) := by
-  -- Expose the linear equivalence packaged as the automorphism's weight linear map.
-  change e6GraphLatticeEquiv (e6Root i) = e6Root (e6GraphIndexEquiv i)
-  simpa only [e6SimplyConnectedRootDatum_root] using e6GraphLatticeEquiv_root i
-
-/-- The graph automorphism carries every coroot to the coroot selected by its public root-index
-permutation. -/
-@[simp] theorem e6GraphAut_coweightMap_coroot (i : Fin 72) :
-    e6GraphAut.coweightMap (e6Coroot i) = e6Coroot (e6GraphIndexEquiv i) := by
-  -- Expose the linear equivalence packaged as the automorphism's coweight linear map.
-  change e6GraphLatticeEquiv (e6Coroot i) = e6Coroot (e6GraphIndexEquiv i)
-  simpa only [e6SimplyConnectedRootDatum_coroot] using e6GraphLatticeEquiv_coroot i
+/-- The root-index permutation packaged by the type-`E₆` graph automorphism is the separately
+named induced permutation of all roots. -/
+theorem e6GraphAut_indexEquiv : e6GraphAut.indexEquiv = e6GraphIndexEquiv := by
+  rw [e6GraphAut]
 
 /-- The character-lattice action of the type-`E₆` graph automorphism permutes the node
 coordinates. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -29,7 +29,7 @@ automorphism of the pinned root datum. Its restriction to the pinned simple root
 * `TauCeti.DynkinType.e6GraphIndexEquiv`: the induced permutation of all root indices.
 * `TauCeti.DynkinType.e6GraphAut`: the graph automorphism of the pinned simply connected datum.
 * `TauCeti.DynkinType.e6GraphAut_sq`: the automorphism has square one.
-* `TauCeti.DynkinType.image_e6GraphAut_indexEquiv_e6SimplyConnectedBase_support`: the pinned base
+* `TauCeti.DynkinType.image_e6GraphIndexEquiv_e6SimplyConnectedBase_support`: the pinned base
   support is preserved.
 
 ## References
@@ -247,7 +247,7 @@ noncomputable def e6GraphAut : _root_.RootPairing.Aut e6SimplyConnectedRootDatum
 
 /-- The root-index permutation packaged by the type-`E₆` graph automorphism is the separately
 named induced permutation of all roots. -/
-theorem e6GraphAut_indexEquiv : e6GraphAut.indexEquiv = e6GraphIndexEquiv := by
+@[simp] theorem e6GraphAut_indexEquiv : e6GraphAut.indexEquiv = e6GraphIndexEquiv := by
   rw [e6GraphAut]
 
 /-- The character-lattice action of the type-`E₆` graph automorphism permutes the node
@@ -262,13 +262,10 @@ coordinates. -/
     e6GraphAut.coweightMap x i = x (graphPermE6 i) :=
   e6GraphLatticeEquiv_apply x i
 
-/-- The root-index action of the type-`E₆` graph automorphism restricts to the numbered diagram
-involution on the pinned simple roots. -/
-@[simp] theorem e6GraphAut_indexEquiv_e6SimpleIndex (i : Fin 6) :
-    e6GraphAut.indexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i) := by
-  -- Unfold the automorphism field to the separately named induced root permutation before using
-  -- the characteristic equation proved from injectivity of the root embedding.
-  change e6GraphIndexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i)
+/-- The type-`E₆` root permutation restricts to the numbered diagram involution on the pinned
+simple roots. -/
+@[simp] theorem e6GraphIndexEquiv_e6SimpleIndex (i : Fin 6) :
+    e6GraphIndexEquiv (e6SimpleIndex i) = e6SimpleIndex (graphPermE6 i) := by
   apply e6SimplyConnectedRootDatum.root.injective
   rw [← e6GraphLatticeEquiv_root, e6GraphLatticeEquiv_simpleRoot]
 
@@ -289,7 +286,7 @@ theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
   have hsimple : e6SimpleIndex 5 = e6SimpleIndex 0 := by
     calc
       e6SimpleIndex 5 = e6GraphAut.indexEquiv (e6SimpleIndex 0) := by
-        rw [e6GraphAut_indexEquiv_e6SimpleIndex, graphPermE6_apply_zero]
+        rw [e6GraphAut_indexEquiv, e6GraphIndexEquiv_e6SimpleIndex, graphPermE6_apply_zero]
       _ = (1 : _root_.RootPairing.Aut e6SimplyConnectedRootDatum).indexEquiv
           (e6SimpleIndex 0) := congrArg (fun e => e.indexEquiv (e6SimpleIndex 0)) h
       _ = e6SimpleIndex 0 := rfl
@@ -297,10 +294,10 @@ theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
   simp only [e6SimpleIndex_val] at this
   omega
 
-/-- The graph symmetry preserves the support of the pinned type-`E₆` base. Together with
+/-- The induced root permutation preserves the support of the pinned type-`E₆` base. Together with
 `RootPairing.Base.support_map_eq`, this computes the support of the transported base. -/
-@[simp] theorem image_e6GraphAut_indexEquiv_e6SimplyConnectedBase_support :
-    e6SimplyConnectedBase.support.image e6GraphAut.indexEquiv =
+@[simp] theorem image_e6GraphIndexEquiv_e6SimplyConnectedBase_support :
+    e6SimplyConnectedBase.support.image e6GraphIndexEquiv =
       e6SimplyConnectedBase.support := by
   ext i
   simp only [Finset.mem_image]
@@ -311,7 +308,7 @@ theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
     have hja : j = e6SimpleIndex a := by
       apply Fin.ext
       rw [e6SimpleIndex_val]
-    rw [hja, e6GraphAut_indexEquiv_e6SimpleIndex, e6SimpleIndex_val]
+    rw [hja, e6GraphIndexEquiv_e6SimpleIndex, e6SimpleIndex_val]
     exact (graphPermE6 a).isLt
   · intro hi
     rw [mem_e6SimplyConnectedBase_support] at hi
@@ -319,7 +316,7 @@ theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
     refine ⟨e6SimpleIndex (graphPermE6 a), ?_, ?_⟩
     · rw [mem_e6SimplyConnectedBase_support, e6SimpleIndex_val]
       exact (graphPermE6 a).isLt
-    · rw [e6GraphAut_indexEquiv_e6SimpleIndex]
+    · rw [e6GraphIndexEquiv_e6SimpleIndex]
       rw [graphPermE6_apply_apply]
       apply Fin.ext
       rw [e6SimpleIndex_val]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -9,19 +9,17 @@ public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.DiagramA
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
 
 /-!
-# The graph automorphism of the pinned type `E₆` root datum
+# Nontriviality of the type `E₆` diagram automorphism
 
-This file specializes the general diagram-automorphism construction
-`TauCeti.DynkinType.diagramAut` to the order-two symmetry `TauCeti.graphPermE6` of the
-Bourbaki-numbered `E₆` diagram. Preservation of the pinned base is the specialization of the
-generic simp theorem
-`TauCeti.DynkinType.image_diagramRootPerm_simplyConnectedBase_support`.
+This file records the type-`E₆` nontriviality consequence of applying the general
+`TauCeti.DynkinType.diagramAut` construction to the order-two symmetry
+`TauCeti.graphPermE6` of the Bourbaki-numbered diagram. The automorphism itself and its order-two
+relation remain expressed through the generic API, without introducing type-specific aliases.
 
 ## Main declarations
 
-* `TauCeti.DynkinType.e6GraphAut`: the graph automorphism of the pinned type-`E₆` root datum.
-* `TauCeti.DynkinType.e6GraphAut_sq`: this automorphism is an involution.
-* `TauCeti.DynkinType.e6GraphAut_ne_one`: this automorphism is nontrivial.
+* `TauCeti.DynkinType.diagramAut_graphPermE6_ne_one`: the diagram automorphism induced by
+  `TauCeti.graphPermE6` is nontrivial.
 
 ## References
 
@@ -41,37 +39,15 @@ open TauCeti
 
 noncomputable section
 
-/-- The graph automorphism of the pinned simply connected root datum of type `E₆`, induced by
-the nontrivial symmetry of the Bourbaki-numbered Dynkin diagram. -/
-def e6GraphAut : (E6.simplyConnectedRootDatum valid_E6).Aut :=
-  diagramAut valid_E6 (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)
-
-/-- Applying the type-`E₆` graph automorphism twice is the identity. -/
-@[simp] theorem e6GraphAut_sq : e6GraphAut ^ 2 = 1 :=
-  diagramAut_pow_eq_one valid_E6
-    (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) graphPermE6_sq
-
-/-- The root-index action bundled in the type-`E₆` graph automorphism is the permutation induced
-by the nontrivial symmetry of its Dynkin diagram. -/
-@[simp] theorem indexEquiv_e6GraphAut :
-    e6GraphAut.indexEquiv =
-      diagramRootPerm valid_E6
-        (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) := by
-  rw [e6GraphAut]
-  exact diagramAut_indexEquiv valid_E6
-    (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)
-
-/-- The type-`E₆` graph automorphism is nontrivial: it exchanges the first and sixth simple
-roots. -/
-theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
+/-- The canonical diagram automorphism induced by the nontrivial symmetry of the
+Bourbaki-numbered type-`E₆` diagram is nontrivial. -/
+theorem diagramAut_graphPermE6_ne_one :
+    diagramAut valid_E6 (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) ≠ 1 := by
   intro h
   have hσ_one : graphPermE6 = 1 :=
     (diagramAut_eq_one_iff valid_E6
-      (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).mp (by
-        simpa only [e6GraphAut] using h)
-  have hzero := congrArg (fun e : Equiv.Perm (Fin 6) => e 0) hσ_one
-  simp only [graphPermE6_apply_zero, Equiv.Perm.one_def, Equiv.refl_apply] at hzero
-  omega
+      (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).mp h
+  simpa [hσ_one] using orderOf_graphPermE6
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/GraphAutomorphism.lean
@@ -11,15 +11,16 @@ public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic
 /-!
 # The graph automorphism of the pinned type `E₆` root datum
 
-This file records the type-`E₆` nontriviality consequence of applying the general
-diagram-automorphism construction `TauCeti.DynkinType.diagramAut` to the order-two symmetry
-`TauCeti.graphPermE6` of the Bourbaki-numbered `E₆` diagram. Preservation of the pinned base is
-the specialization of the generic simp theorem
+This file specializes the general diagram-automorphism construction
+`TauCeti.DynkinType.diagramAut` to the order-two symmetry `TauCeti.graphPermE6` of the
+Bourbaki-numbered `E₆` diagram. Preservation of the pinned base is the specialization of the
+generic simp theorem
 `TauCeti.DynkinType.image_diagramRootPerm_simplyConnectedBase_support`.
 
 ## Main declarations
 
-* `TauCeti.DynkinType.diagramAut_graphPermE6_ne_one`: the induced automorphism is nontrivial.
+* `TauCeti.DynkinType.e6GraphAut`: the graph automorphism of the pinned type-`E₆` root datum.
+* `TauCeti.DynkinType.e6GraphAut_ne_one`: this automorphism is nontrivial.
 
 ## References
 
@@ -39,14 +40,29 @@ open TauCeti
 
 noncomputable section
 
+/-- The graph automorphism of the pinned simply connected root datum of type `E₆`, induced by
+the nontrivial symmetry of the Bourbaki-numbered Dynkin diagram. -/
+def e6GraphAut : (E6.simplyConnectedRootDatum valid_E6).Aut :=
+  diagramAut valid_E6 (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)
+
+/-- The root-index action bundled in the type-`E₆` graph automorphism is the permutation induced
+by the nontrivial symmetry of its Dynkin diagram. -/
+@[simp] theorem indexEquiv_e6GraphAut :
+    e6GraphAut.indexEquiv =
+      diagramRootPerm valid_E6
+        (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) := by
+  rw [e6GraphAut]
+  exact diagramAut_indexEquiv valid_E6
+    (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)
+
 /-- The type-`E₆` graph automorphism is nontrivial: it exchanges the first and sixth simple
 roots. -/
-theorem diagramAut_graphPermE6_ne_one :
-    diagramAut valid_E6 (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6) ≠ 1 := by
-  let hσ : graphPermE6 ∈ E6.diagramSymmetry :=
-    mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6
+theorem e6GraphAut_ne_one : e6GraphAut ≠ 1 := by
   intro h
-  have hσ_one : graphPermE6 = 1 := (diagramAut_eq_one_iff valid_E6 hσ).mp h
+  have hσ_one : graphPermE6 = 1 :=
+    (diagramAut_eq_one_iff valid_E6
+      (mem_diagramSymmetry_iff.mpr cartanMatrix_E6_graphPermE6)).mp (by
+        simpa only [e6GraphAut] using h)
   have hzero := congrArg (fun e : Equiv.Perm (Fin 6) => e 0) hσ_one
   simp only [graphPermE6_apply_zero, Equiv.Perm.one_def, Equiv.refl_apply] at hzero
   omega

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E8/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E8/Datum.lean
@@ -61,7 +61,7 @@ The coordinates and the node numbering follow Bourbaki, *Lie Groups and Lie Alge
 4--6*, Plate VII, and Humphreys, *Introduction to Lie Algebras and Representation Theory*, section
 12.1. This is the `E₈` branch of the target "a named datum per valid type" in Layer 6 of
 `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`. Its assembly follows
-`TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6`.
+`TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic`.
 -/
 
 namespace TauCeti


### PR DESCRIPTION
This PR records the E₆-specific nontriviality consequence of applying the generic `DynkinType.diagramAut` construction to the Bourbaki diagram involution `graphPermE6`. It strengthens the generic diagram-automorphism API with `diagramAut_eq_one_iff`, proving that the construction is faithful. The E₆ theorem is stated directly about the generic construction rather than introducing a second name for it.

The generic API already supplies the lattice actions, simple-index action, and order relation from `cartanMatrix_E6_graphPermE6` and `graphPermE6_sq`; this PR does not restate those results. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4–6*, Plate V supplies the node numbering, and Carter, *Simple Groups of Lie Type*, §12.2 supplies the graph-automorphism convention and twisted-family role.

It advances the ReductiveGroups Layer 9 milestone “The isomorphism theorem for pinned groups: an isomorphism of root data lifts uniquely to an isomorphism of pinned group schemes.” That theorem consumes the canonical generic diagram automorphism when constructing the graph-twisted ²E₆ Steinberg endomorphism.

Adding a second E6 module requires the repository prefix-directory normalization: `TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6` becomes `TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E6.Basic`. The assembly import and the E₈ documentation reference move with it. The relocated finite reflection proof is split into kernel-checked blocks because an isolated fresh build of the monolithic proof exits with code 137, while the split compiles successfully within the worker memory limit.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"graph-automorphism-type-e6-root-datum"}-->

🤖 Prepared with Codex