### PR TITLE
feat: multiply normal semidirect products

### DIFF
--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
@@ -85,6 +85,11 @@ variable (A : Action G N)
 def act {X : C} (g : X ⟶ G) (n : X ⟶ N) : X ⟶ N :=
   lift g n ≫ A.hom
 
+/-- The action on generalized points is induced by the action morphism. -/
+theorem act_def {X : C} (g : X ⟶ G) (n : X ⟶ N) :
+    A.act g n = lift g n ≫ A.hom :=
+  (rfl)
+
 @[simp]
 theorem one_act_apply {X : C} (n : X ⟶ N) : A.act (1 : X ⟶ G) n = n :=
   A.one_act X n

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
@@ -322,6 +322,46 @@ theorem pointMulEquiv_comp_inr {X : C} (g : X ⟶ G) :
   rw [h]
   exact A.pointIso.inv_hom_id_app_apply (op X) (SemidirectProduct.inr g)
 
+/-- The first projection of the canonical inclusion of the normal factor is the identity. -/
+@[simp, reassoc]
+theorem inl_hom_fst :
+    letI := A.semidirectProductGrpObj
+    A.inl.hom.hom ≫ fst N G = 𝟙 N := by
+  let _ := A.semidirectProductGrpObj
+  have h := congrArg SemidirectProduct.left
+    (A.pointMulEquiv_comp_inl (X := N) (𝟙 N))
+  simpa only [pointMulEquiv_left, SemidirectProduct.left_inl, Category.id_comp] using h
+
+/-- The second projection of the canonical inclusion of the normal factor is the unit. -/
+@[simp, reassoc]
+theorem inl_hom_snd :
+    letI := A.semidirectProductGrpObj
+    A.inl.hom.hom ≫ snd N G = (1 : N ⟶ G) := by
+  let _ := A.semidirectProductGrpObj
+  have h := congrArg SemidirectProduct.right
+    (A.pointMulEquiv_comp_inl (X := N) (𝟙 N))
+  simpa only [pointMulEquiv_right, SemidirectProduct.right_inl, Category.id_comp] using h
+
+/-- The first projection of the canonical inclusion of the acting factor is the unit. -/
+@[simp, reassoc]
+theorem inr_hom_fst :
+    letI := A.semidirectProductGrpObj
+    A.inr.hom.hom ≫ fst N G = (1 : G ⟶ N) := by
+  let _ := A.semidirectProductGrpObj
+  have h := congrArg SemidirectProduct.left
+    (A.pointMulEquiv_comp_inr (X := G) (𝟙 G))
+  simpa only [pointMulEquiv_left, SemidirectProduct.left_inr, Category.id_comp] using h
+
+/-- The second projection of the canonical inclusion of the acting factor is the identity. -/
+@[simp, reassoc]
+theorem inr_hom_snd :
+    letI := A.semidirectProductGrpObj
+    A.inr.hom.hom ≫ snd N G = 𝟙 G := by
+  let _ := A.semidirectProductGrpObj
+  have h := congrArg SemidirectProduct.right
+    (A.pointMulEquiv_comp_inr (X := G) (𝟙 G))
+  simpa only [pointMulEquiv_right, SemidirectProduct.right_inr, Category.id_comp] using h
+
 /-- On generalized points, the canonical projection is `SemidirectProduct.rightHom`. -/
 @[simp]
 theorem comp_rightHom {X : C} (x : X ⟶ N ⊗ G) :

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
@@ -76,20 +76,13 @@ noncomputable def normalConjugation (i : N ⟶ G) [IsMonHom.Normal i]
     simp_rw [← Category.assoc, lift_comp_mapLeft]
     exact TauCeti.normalConjugation_mul_right i (h ≫ j) n₁ n₂
 
-/-- The morphism underlying conjugation along `j`. -/
-theorem normalConjugation_hom (i : N ⟶ G) [IsMonHom.Normal i]
-    (j : H ⟶ G) [IsMonHom j] :
-    (normalConjugation i j).hom =
-      lift (fst H N ≫ j) (snd H N) ≫ TauCeti.normalConjugation i :=
-  (rfl)
-
 /-- The action by conjugation along `j` evaluates as ambient conjugation through `j`. -/
 @[simp]
 theorem normalConjugation_act (i : N ⟶ G) [IsMonHom.Normal i]
     (j : H ⟶ G) [IsMonHom j] (h : X ⟶ H) (n : X ⟶ N) :
     (normalConjugation i j).act h n =
       lift (h ≫ j) n ≫ TauCeti.normalConjugation i := by
-  rw [Action.act_def, normalConjugation_hom, ← Category.assoc, lift_comp_mapLeft]
+  rw [Action.act_def, normalConjugation, ← Category.assoc, lift_comp_mapLeft]
 
 /-- The generalized-point homomorphism from the normal semidirect product to the ambient group. -/
 private noncomputable def normalSemidirectMulPointHom

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.CategoryTheory.Monoidal.Normal
+public import TauCeti.CategoryTheory.Monoidal.SemidirectProduct.Basic
+
+/-!
+# Multiplication from semidirect products of internal subgroups
+
+Let `i : N ⟶ G` be a normal subgroup object and let `j : H ⟶ G` be another internal-group
+homomorphism. Conjugation through `j` gives an action of `H` on `N`. This file constructs that
+action and the canonical internal-group homomorphism
+
+```text
+N ⋊ H ⟶ G,    (n, h) ↦ i(n) * j(h).
+```
+
+The construction is characterized on generalized points and on the two canonical inclusions.
+For two normal closed subgroup schemes, its scheme-theoretic image is their product. This is the
+binary-product map used in the maximal-dimension construction of the unipotent radical.
+
+## Main declarations
+
+* `TauCeti.GrpObj.Action.normalConjugation`: conjugation along a map into the ambient group.
+* `TauCeti.GrpObj.Action.normalSemidirectMul`: multiplication from the resulting semidirect
+  product into the ambient group.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and §6.a.
+* A. Borel, *Linear Algebraic Groups*, Proposition 14.4.
+
+This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap. It supplies the
+group-scheme multiplication homomorphism whose scheme-theoretic image is the product of two
+normal connected smooth unipotent closed subgroups.
+-/
+
+public section
+
+open CategoryTheory Limits Opposite MonoidalCategory CartesianMonoidalCategory MonObj
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.GrpObj.Action
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [CartesianMonoidalCategory C]
+variable {G N H X : C} [GrpObj G] [GrpObj N] [GrpObj H]
+
+omit [GrpObj G] [GrpObj N] [GrpObj H] in
+/-- Mapping the first component of a product commutes with forming a pair of generalized
+points. -/
+private theorem lift_comp_mapLeft (j : H ⟶ G) (h : X ⟶ H) (n : X ⟶ N) :
+    lift h n ≫ lift (fst H N ≫ j) (snd H N) = lift (h ≫ j) n := by
+  ext <;> simp
+
+/-- Conjugation by an internal group mapping to `G` acts on a normal subgroup object of `G`.
+
+If `i : N ⟶ G` is normal and `j : H ⟶ G` is an internal-group homomorphism, the action sends
+`(h, n)` to the unique element of `N` whose image in `G` is `j(h) * i(n) * j(h)⁻¹`. -/
+noncomputable def normalConjugation (i : N ⟶ G) [IsMonHom.Normal i]
+    (j : H ⟶ G) [IsMonHom j] : Action H N where
+  hom := lift (fst H N ≫ j) (snd H N) ≫ TauCeti.normalConjugation i
+  one_act Y n := by
+    rw [← Category.assoc, lift_comp_mapLeft, MonObj.one_comp]
+    exact TauCeti.normalConjugation_one_left i n
+  mul_act Y h₁ h₂ n := by
+    simp_rw [← Category.assoc, lift_comp_mapLeft]
+    rw [MonObj.mul_comp]
+    exact TauCeti.normalConjugation_mul_left i (h₁ ≫ j) (h₂ ≫ j) n
+  act_mul Y h n₁ n₂ := by
+    simp_rw [← Category.assoc, lift_comp_mapLeft]
+    exact TauCeti.normalConjugation_mul_right i (h ≫ j) n₁ n₂
+
+/-- The morphism underlying conjugation along `j`. -/
+theorem normalConjugation_hom (i : N ⟶ G) [IsMonHom.Normal i]
+    (j : H ⟶ G) [IsMonHom j] :
+    (normalConjugation i j).hom =
+      lift (fst H N ≫ j) (snd H N) ≫ TauCeti.normalConjugation i :=
+  (rfl)
+
+/-- The action by conjugation along `j` evaluates as ambient conjugation through `j`. -/
+@[simp]
+theorem normalConjugation_act (i : N ⟶ G) [IsMonHom.Normal i]
+    (j : H ⟶ G) [IsMonHom j] (h : X ⟶ H) (n : X ⟶ N) :
+    (normalConjugation i j).act h n =
+      lift (h ≫ j) n ≫ TauCeti.normalConjugation i := by
+  rw [Action.act_def, normalConjugation_hom, ← Category.assoc, lift_comp_mapLeft]
+
+/-- The generalized-point homomorphism from the normal semidirect product to the ambient group. -/
+private noncomputable def normalSemidirectMulPointHom
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] (X : C) :
+    let A := normalConjugation i j
+    letI := A.semidirectProductGrpObj
+    (X ⟶ N ⊗ H) →* (X ⟶ G) := by
+  let A := normalConjugation i j
+  letI := A.semidirectProductGrpObj
+  let fi : (X ⟶ N) →* (X ⟶ G) :=
+    { toFun := fun n ↦ n ≫ i
+      map_one' := MonObj.one_comp i
+      map_mul' := fun n m ↦ MonObj.mul_comp n m i }
+  let fj : (X ⟶ H) →* (X ⟶ G) :=
+    { toFun := fun h ↦ h ≫ j
+      map_one' := MonObj.one_comp j
+      map_mul' := fun h k ↦ MonObj.mul_comp h k j }
+  let m : ((X ⟶ N) ⋊[A.toMulAutHom X] (X ⟶ H)) →* (X ⟶ G) :=
+    SemidirectProduct.lift fi fj (by
+      intro h
+      ext n
+      simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulAut.conj_apply]
+      dsimp only [fi, fj, A]
+      rw [Action.toMulAutHom_apply, normalConjugation_act]
+      -- The local monoid-homomorphism constructors have no application simp lemma.
+      change (lift (h ≫ j) n ≫ TauCeti.normalConjugation i) ≫ i =
+        (h ≫ j) * (n ≫ i) * (h ≫ j)⁻¹
+      simpa only [Category.assoc] using
+        TauCeti.lift_normalConjugation_comp i (h ≫ j) n)
+  exact m.comp (A.pointMulEquiv X).toMonoidHom
+
+/-- On generalized points, normal semidirect multiplication is the product of the two ambient
+images. -/
+private theorem normalSemidirectMulPointHom_apply
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j]
+    (x : X ⟶ N ⊗ H) :
+    normalSemidirectMulPointHom i j X x =
+      (x ≫ fst N H ≫ i) * (x ≫ snd N H ≫ j) := by
+  simp [normalSemidirectMulPointHom, SemidirectProduct.lift,
+    pointMulEquiv_left, pointMulEquiv_right]
+
+/-- The generalized-point maps defining normal semidirect multiplication are natural in the
+source object. -/
+private noncomputable def normalSemidirectMulNatTrans
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] :
+    let A := normalConjugation i j
+    (yonedaGrp (C := C)).obj A.semidirectProduct ⟶
+      (yonedaGrp (C := C)).obj (Grp.mk G) := by
+  let A := normalConjugation i j
+  letI := A.semidirectProductGrpObj
+  exact
+    { app := fun X ↦ GrpCat.ofHom (normalSemidirectMulPointHom i j (unop X))
+      naturality := by
+        intro Y Z f
+        apply GrpCat.hom_ext
+        apply MonoidHom.ext
+        intro x
+        let x' : unop Y ⟶ N ⊗ H := x
+        -- The two `GrpCat` composition wrappers have no application lemma, so expose their
+        -- underlying precomposition maps before using the pointwise formula.
+        change normalSemidirectMulPointHom i j (unop Z) (f.unop ≫ x') =
+          f.unop ≫ normalSemidirectMulPointHom i j (unop Y) x'
+        rw [normalSemidirectMulPointHom_apply i j x',
+          normalSemidirectMulPointHom_apply]
+        rw [comp_mul]
+        simp only [Category.assoc] }
+
+/-- Multiplication from the semidirect product determined by a normal subgroup map.
+
+On generalized points this sends `(n, h)` to `i(n) * j(h)`. -/
+noncomputable def normalSemidirectMul
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] :
+    let A := normalConjugation i j
+    A.semidirectProduct ⟶ Grp.mk G := by
+  let A := normalConjugation i j
+  exact yonedaGrpFullyFaithful.preimage (normalSemidirectMulNatTrans i j)
+
+/-- Normal semidirect multiplication sends a generalized point to the product of its two
+ambient components. -/
+@[simp]
+theorem comp_normalSemidirectMul
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j]
+    (x : X ⟶ N ⊗ H) :
+    let A := normalConjugation i j
+    letI := A.semidirectProductGrpObj
+    x ≫ (normalSemidirectMul i j).hom.hom =
+      (x ≫ fst N H ≫ i) * (x ≫ snd N H ≫ j) := by
+  let A := normalConjugation i j
+  let _ := A.semidirectProductGrpObj
+  have h := congrArg (fun F ↦ F.app (op X) x)
+    (yonedaGrpFullyFaithful.map_preimage (normalSemidirectMulNatTrans i j))
+  exact h.trans (normalSemidirectMulPointHom_apply i j x)
+
+/-- Normal semidirect multiplication restricts to the normal subgroup map on the first
+canonical factor. -/
+@[simp, reassoc]
+theorem inl_comp_normalSemidirectMul
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] :
+    let A := normalConjugation i j
+    A.inl ≫ normalSemidirectMul i j = Grp.ofHom i := by
+  let A := normalConjugation i j
+  let _ := A.semidirectProductGrpObj
+  apply Grp.hom_ext
+  have hleft := congrArg SemidirectProduct.left
+    (A.pointMulEquiv_comp_inl (X := N) (𝟙 N))
+  have hright := congrArg SemidirectProduct.right
+    (A.pointMulEquiv_comp_inl (X := N) (𝟙 N))
+  simp only [pointMulEquiv_left, pointMulEquiv_right, SemidirectProduct.left_inl,
+    SemidirectProduct.right_inl, Category.id_comp] at hleft hright
+  dsimp only [A] at hleft hright
+  rw [Grp.comp_hom_hom, comp_normalSemidirectMul]
+  rw [← Category.assoc, hleft, Category.id_comp]
+  rw [← Category.assoc, hright, MonObj.one_comp]
+  exact mul_one i
+
+/-- Normal semidirect multiplication restricts to the second ambient map on the second canonical
+factor. -/
+@[simp, reassoc]
+theorem inr_comp_normalSemidirectMul
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] :
+    let A := normalConjugation i j
+    A.inr ≫ normalSemidirectMul i j = Grp.ofHom j := by
+  let A := normalConjugation i j
+  let _ := A.semidirectProductGrpObj
+  apply Grp.hom_ext
+  have hleft := congrArg SemidirectProduct.left
+    (A.pointMulEquiv_comp_inr (X := H) (𝟙 H))
+  have hright := congrArg SemidirectProduct.right
+    (A.pointMulEquiv_comp_inr (X := H) (𝟙 H))
+  simp only [pointMulEquiv_left, pointMulEquiv_right, SemidirectProduct.left_inr,
+    SemidirectProduct.right_inr, Category.id_comp] at hleft hright
+  dsimp only [A] at hleft hright
+  rw [Grp.comp_hom_hom, comp_normalSemidirectMul]
+  rw [← Category.assoc, hleft, MonObj.one_comp]
+  rw [← Category.assoc, hright, Category.id_comp]
+  exact one_mul j
+
+end TauCeti.GrpObj.Action

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
@@ -186,12 +186,8 @@ theorem inl_comp_normalSemidirectMul
   let A := normalConjugation i j
   let _ := A.semidirectProductGrpObj
   apply Grp.hom_ext
-  have hleft := congrArg SemidirectProduct.left
-    (A.pointMulEquiv_comp_inl (X := N) (𝟙 N))
-  have hright := congrArg SemidirectProduct.right
-    (A.pointMulEquiv_comp_inl (X := N) (𝟙 N))
-  simp only [pointMulEquiv_left, pointMulEquiv_right, SemidirectProduct.left_inl,
-    SemidirectProduct.right_inl, Category.id_comp] at hleft hright
+  have hleft := A.inl_hom_fst
+  have hright := A.inl_hom_snd
   dsimp only [A] at hleft hright
   rw [Grp.comp_hom_hom, comp_normalSemidirectMul]
   rw [← Category.assoc, hleft, Category.id_comp]
@@ -208,12 +204,8 @@ theorem inr_comp_normalSemidirectMul
   let A := normalConjugation i j
   let _ := A.semidirectProductGrpObj
   apply Grp.hom_ext
-  have hleft := congrArg SemidirectProduct.left
-    (A.pointMulEquiv_comp_inr (X := H) (𝟙 H))
-  have hright := congrArg SemidirectProduct.right
-    (A.pointMulEquiv_comp_inr (X := H) (𝟙 H))
-  simp only [pointMulEquiv_left, pointMulEquiv_right, SemidirectProduct.left_inr,
-    SemidirectProduct.right_inr, Category.id_comp] at hleft hright
+  have hleft := A.inr_hom_fst
+  have hright := A.inr_hom_snd
   dsimp only [A] at hleft hright
   rw [Grp.comp_hom_hom, comp_normalSemidirectMul]
   rw [← Category.assoc, hleft, MonObj.one_comp]


### PR DESCRIPTION
This PR constructs conjugation along an internal group map and the canonical multiplication homomorphism `N ⋊ H ⟶ G`, sending `(n, h)` to `i(n) * j(h)`, when `i : N ⟶ G` is normal and `j : H ⟶ G` is any internal-group homomorphism.

It advances the exact ReductiveGroups Layer 5 milestone “The unipotent radical `R_u(G)`,” specifically the binary-product step identified by `HopfIdeal.IsUnipotentRadicalCandidate`: the product of two normal connected smooth unipotent closed subgroup schemes is formed as the scheme-theoretic image of multiplication from the conjugation semidirect product. This is the most effective untaken step because the normal conjugation action, internal semidirect product, smoothness and connectedness of affine-group images, maximal-dimensional candidate, and pointwise normal-join theorem are already on `main`, while the open image-unipotence PR #4139 explicitly leaves this multiplication assembly outside its scope.

`GrpObj.Action.normalConjugation` restricts ambient conjugation through `j`; `GrpObj.Action.normalSemidirectMul` applies the ordinary `SemidirectProduct.lift` on every generalized-point group and uses full faithfulness of the group-object Yoneda embedding to recover the internal morphism. `comp_normalSemidirectMul` gives its pointwise formula, while `inl_comp_normalSemidirectMul` and `inr_comp_normalSemidirectMul` characterize its restrictions to both canonical factors. The moved base module also exposes `Action.act_def`, the missing characteristic equation needed to reason about a general action without unfolding its opaque body.

After this PR, the Layer 5 binary-product step still needs faithful flatness of an affine-group homomorphism onto its scheme-theoretic image, image unipotence (currently in #4139), normality of the resulting product, and the dimension argument showing a maximal candidate contains every other candidate.

Adding a second semidirect-product module requires the repository's prefix-directory normalization. The module relocation, with no declaration renames and no compatibility module retained, is:

| Old module | New module |
| --- | --- |
| `TauCeti.CategoryTheory.Monoidal.SemidirectProduct` | `TauCeti.CategoryTheory.Monoidal.SemidirectProduct.Basic` |

No in-repository import used the old path. No Mathlib or external formalization is vendored. The construction reuses Mathlib's `SemidirectProduct.lift` and `yonedaGrpFullyFaithful`, together with Tau Ceti's existing `normalConjugation` and internal semidirect-product API. The mathematical organization follows Milne, *Algebraic Groups* (2017), Proposition 6.42 and §6.a, and Borel, *Linear Algebraic Groups*, Proposition 14.4, as credited in the new module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"normal-semidirect-product-multiplication"}-->

🤖 Prepared with Codex
