### PR TITLE
feat: the vertex, arrow and volume basis of a zigzag algebra

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -709,11 +709,13 @@ noncomputable def liftLinear : pathAlgebra k Q →ₗ[k] B :=
   (pathAlgebraBasis k Q).constr k F
 
 /-- The linear extension of an assignment agrees with it on the basis paths. -/
+@[simp]
 theorem liftLinear_ofPath (x : Quiver.TotalPath Q) : liftLinear k F (ofPath x) = F x := by
   have h := (pathAlgebraBasis k Q).constr_basis k F x
   rwa [coe_pathAlgebraBasis] at h
 
 /-- The linear extension of an assignment on a basis path with a coefficient. -/
+@[simp]
 theorem liftLinear_single (x : Quiver.TotalPath Q) (c : k) :
     liftLinear k F (single x c) = c • F x := by
   rw [single_eq_smul_ofPath, map_smul, liftLinear_ofPath]

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Basic.lean
@@ -411,6 +411,11 @@ noncomputable def ofPath (x : Quiver.TotalPath Q) : pathAlgebra k Q :=
 theorem ofPath_eq_single (x : Quiver.TotalPath Q) :
     (ofPath x : pathAlgebra k Q) = single x 1 := (rfl)
 
+/-- A basis path carrying a coefficient is that coefficient acting on the basis element. -/
+theorem single_eq_smul_ofPath (x : Quiver.TotalPath Q) (c : k) :
+    (single x c : pathAlgebra k Q) = c • ofPath x := by
+  rw [ofPath_eq_single, smul_single, mul_one]
+
 /-- Two composable paths multiply to their concatenation, later factor first. -/
 @[simp]
 theorem ofPath_mul_ofPath_of_comp {a b c : Q} (p : _root_.Quiver.Path a b)
@@ -697,20 +702,21 @@ section Lift
 variable (k : Type w) {Q : Type u} {B : Type*} [CommSemiring k] [Quiver.{v} Q]
   [Semiring B] [Algebra k B] (F : Quiver.TotalPath Q → B)
 
-/-- The `k`-linear map extending an assignment of algebra elements to the basis paths. Private:
-only its algebra-homomorphism upgrade `TauCeti.PathAlgebra.liftAlgHom` is public. -/
-private noncomputable def liftLinear : pathAlgebra k Q →ₗ[k] B :=
+/-- The `k`-linear map extending an assignment of algebra elements to the basis paths. Its
+algebra-homomorphism upgrade, available when the assignment is multiplicative, is
+`TauCeti.PathAlgebra.liftAlgHom`. -/
+noncomputable def liftLinear : pathAlgebra k Q →ₗ[k] B :=
   (pathAlgebraBasis k Q).constr k F
 
-private theorem liftLinear_ofPath (x : Quiver.TotalPath Q) : liftLinear k F (ofPath x) = F x := by
+/-- The linear extension of an assignment agrees with it on the basis paths. -/
+theorem liftLinear_ofPath (x : Quiver.TotalPath Q) : liftLinear k F (ofPath x) = F x := by
   have h := (pathAlgebraBasis k Q).constr_basis k F x
   rwa [coe_pathAlgebraBasis] at h
 
-private theorem liftLinear_single (x : Quiver.TotalPath Q) (c : k) :
+/-- The linear extension of an assignment on a basis path with a coefficient. -/
+theorem liftLinear_single (x : Quiver.TotalPath Q) (c : k) :
     liftLinear k F (single x c) = c • F x := by
-  have hx : (single x c : pathAlgebra k Q) = c • ofPath x := by
-    rw [ofPath_eq_single, smul_single, mul_one]
-  rw [hx, map_smul, liftLinear_ofPath]
+  rw [single_eq_smul_ofPath, map_smul, liftLinear_ofPath]
 
 variable (hcomp : ∀ {a b c : Q} (p : _root_.Quiver.Path a b) (q : _root_.Quiver.Path c a),
     F ⟨a, b, p⟩ * F ⟨c, a, q⟩ = F ⟨c, b, q.comp p⟩)

--- a/TauCeti/RepresentationTheory/Quiver/Representation/OfModule.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/OfModule.lean
@@ -352,11 +352,9 @@ noncomputable def moduleHomOfQuiverRepHom
         obtain ⟨b, c', p⟩ := y
         -- the induction hands the basis element in the `single` form, while
         -- `TauCeti.moduleHomAux_ofPath_smul` is stated on `TauCeti.ofPath`; the two differ by the
-        -- scalar `c`, which `single p c = c • ofPath p` extracts
-        have hsingle : (single (⟨b, c', p⟩ : Quiver.TotalPath Q) c : pathAlgebra k Q)
-            = c • ofPath ⟨b, c', p⟩ := by rw [ofPath_eq_single, smul_single, mul_one]
-        rw [hsingle, smul_assoc, map_smul, moduleHomAux_ofPath_smul, RingHom.id_apply,
-          smul_assoc] }
+        -- scalar `c`, which `TauCeti.PathAlgebra.single_eq_smul_ofPath` extracts
+        rw [single_eq_smul_ofPath, smul_assoc, map_smul, moduleHomAux_ofPath_smul,
+          RingHom.id_apply, smul_assoc] }
 
 /-- The recovered map, spelled out: glue the components of `φ` along the vertex projections. -/
 theorem moduleHomOfQuiverRepHom_apply [Fintype Q]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean
@@ -13,10 +13,10 @@ public import TauCeti.RepresentationTheory.Quiver.Zigzag.Relations
 # The vertex, arrow and volume basis of a zigzag algebra
 
 The zigzag relation quotient `TauCeti.nonisolatedZigzagQuotient` of a finite simple graph `G` kills
-every path of length at least three and identifies all the backtracks based at one vertex. What
-survives is spanned by the vertex idempotents, the oriented edges, and one *volume* class per
-vertex. This file proves that these classes are a basis whenever `G` has no isolated vertex, and
-reads off the dimension `2|V| + 2|E|`.
+every length-two path whose endpoints differ, identifies all the backtracks based at one vertex,
+and kills every path of length at least three. What survives is spanned by the vertex idempotents,
+the oriented edges, and one *volume* class per vertex. This file proves that these classes are a
+basis whenever `G` has no isolated vertex, and reads off the dimension `2|V| + 2|E|`.
 
 Spanning is immediate from the relations. Independence is the substantive half, and is proved by
 exhibiting a coordinate map. The path algebra is free on the paths of the doubled quiver, so a
@@ -27,23 +27,24 @@ when both outer paths are trivial, the relator itself, so this map kills the rel
 therefore separates the candidate basis classes, which it sends to distinct basis paths.
 
 The hypothesis is that every vertex has a neighbour: an isolated vertex carries no backtrack, so
-its volume class does not exist. For a connected graph with at least two vertices the hypothesis is
-automatic, which is the form the roadmap's dimension count takes.
+its volume class does not exist. For a preconnected graph with at least two vertices the hypothesis
+is automatic, which is the form the roadmap's dimension count takes.
 
 ## Main definitions
 
 * `TauCeti.zigzagVolume`: the volume class of a vertex, the common image of its backtracks.
-* `TauCeti.ZigzagBasisIndex`: vertices in degree zero, darts in degree one, vertices in degree two.
+* `TauCeti.ZigzagBasisIndex`: one index per vertex, carrying its idempotent, one per dart, carrying
+  its arrow, and one more per vertex, carrying its volume class.
 * `TauCeti.zigzagBasisFun`: the vertex, arrow and volume family.
 * `TauCeti.zigzagBasis`: that family, as a basis of the zigzag relation quotient.
 
 ## Main results
 
-* `TauCeti.linearIndependent_zigzagBasisFun` and `TauCeti.span_range_zigzagBasisFun`: the family is
-  independent and spans.
+* `TauCeti.linearIndependent_zigzagBasisFun` and `TauCeti.span_range_zigzagBasisFun_eq_top`: the
+  family is independent and spans.
 * `TauCeti.finrank_nonisolatedZigzagQuotient`: the dimension is `2|V| + 2|E|`.
-* `TauCeti.finrank_nonisolatedZigzagQuotient_of_connected`: the same count for a connected graph
-  with at least two vertices.
+* `TauCeti.finrank_nonisolatedZigzagQuotient_of_preconnected`: the same count for a preconnected
+  graph with at least two vertices.
 
 ## References
 
@@ -83,6 +84,17 @@ private theorem length_volumeLoop {i j : V} (h : G.Adj i j) : (volumeLoop G i).l
   rw [volumeLoop, dite_eq_left (⟨j, h⟩ : ∃ j, G.Adj i j)]
   exact length_backtrackPath G _
 
+/-- A chosen dart out of each vertex of a graph with no isolated vertex. -/
+private noncomputable def volumeDart (hns : ∀ i : V, ∃ j, G.Adj i j) (i : V) : G.Dart :=
+  ⟨(i, (hns i).choose), (hns i).choose_spec⟩
+
+/-- The chosen backtrack at a vertex is the backtrack along the chosen dart out of it. -/
+private theorem ofPath_volumePath_eq_backtrackElem (hns : ∀ i : V, ∃ j, G.Adj i j) (i : V) :
+    (ofPath (volumePath G i) : pathAlgebra k (DoubledQuiver G))
+      = backtrackElem G k (volumeDart G hns i).adj := by
+  rw [volumePath, volumeLoop, dite_eq_left (hns i), backtrackElem_eq_ofPath]
+  rfl
+
 /-! ### Volume classes -/
 
 variable [Finite V]
@@ -101,6 +113,18 @@ theorem zigzagVolume_eq_zigzagMk_backtrackElem {i j : V} (h : G.Adj i j) :
   rw [zigzagVolume, dite_eq_left (⟨j, h⟩ : ∃ j, G.Adj i j)]
   exact zigzagMk_backtrackElem_eq k G _ h
 
+/-- The class of a backtrack is the volume class of its base vertex. This is the direction
+automation can use: both endpoints are determined by the adjacency on the left-hand side. -/
+@[simp]
+theorem zigzagMk_backtrackElem_eq_zigzagVolume {i j : V} (h : G.Adj i j) :
+    zigzagMk k G (backtrackElem G k h) = zigzagVolume k G i :=
+  (zigzagVolume_eq_zigzagMk_backtrackElem k G h).symm
+
+/-- The volume class of an isolated vertex is the junk value `0`: it carries no backtrack. -/
+theorem zigzagVolume_eq_zero_of_isIsolated {i : V} (h : G.IsIsolated i) :
+    zigzagVolume k G i = 0 := by
+  rw [zigzagVolume, dite_eq_right fun hi => SimpleGraph.exists_adj_iff_not_isIsolated.mp hi h]
+
 private theorem zigzagMk_ofPath_volumePath {i j : V} (h : G.Adj i j) :
     zigzagMk k G (ofPath (volumePath G i)) = zigzagVolume k G i := by
   have hex : ∃ j, G.Adj i j := ⟨j, h⟩
@@ -109,8 +133,9 @@ private theorem zigzagMk_ofPath_volumePath {i j : V} (h : G.Adj i j) :
 
 /-! ### The vertex, arrow and volume family -/
 
-/-- The homogeneous basis indices of a zigzag algebra: a vertex in path degree zero, an oriented
-edge in path degree one, and a volume class at a vertex in path degree two. -/
+/-- The basis indices of a zigzag algebra: a vertex, carrying its idempotent, an oriented edge,
+carrying its arrow, and a vertex again, carrying its volume class. The three blocks are
+represented by paths of length zero, one and two respectively. -/
 abbrev ZigzagBasisIndex : Type _ := V ⊕ G.Dart ⊕ V
 
 /-- The vertex, arrow and volume family of a zigzag algebra: the class of a vertex idempotent, the
@@ -165,23 +190,18 @@ private noncomputable def shortCoord (x : Quiver.TotalPath (DoubledQuiver G)) :
 /-- The coordinate map of the zigzag relations: the `k`-linear extension of `shortCoord`. -/
 private noncomputable def shortProj :
     pathAlgebra k (DoubledQuiver G) →ₗ[k] pathAlgebra k (DoubledQuiver G) :=
-  (pathAlgebraBasis k (DoubledQuiver G)).constr k (shortCoord k G)
-
-private theorem shortProj_ofPath (x : Quiver.TotalPath (DoubledQuiver G)) :
-    shortProj k G (ofPath x) = shortCoord k G x := by
-  have hx : (ofPath x : pathAlgebra k (DoubledQuiver G))
-      = pathAlgebraBasis k (DoubledQuiver G) x := by rw [coe_pathAlgebraBasis]
-  rw [shortProj, hx, Module.Basis.constr_basis]
+  liftLinear k (shortCoord k G)
 
 private theorem shortProj_ofPath_of_length_le_one {a b : DoubledQuiver G}
     (p : _root_.Quiver.Path a b) (hp : p.length ≤ 1) :
     shortProj k G (ofPath ⟨a, b, p⟩) = ofPath ⟨a, b, p⟩ := by
-  rw [shortProj_ofPath, shortCoord, ite_eq_left hp]
+  rw [shortProj, liftLinear_ofPath, shortCoord, ite_eq_left hp]
 
 private theorem shortProj_ofPath_eq_zero_of_three_le {a b : DoubledQuiver G}
     (p : _root_.Quiver.Path a b) (hp : 3 ≤ p.length) :
     shortProj k G (ofPath ⟨a, b, p⟩) = 0 := by
-  rw [shortProj_ofPath, shortCoord, ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)),
+  rw [shortProj, liftLinear_ofPath, shortCoord,
+    ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)),
     ite_eq_right fun h => by
       have h2 : p.length = 2 := h.1
       omega]
@@ -189,56 +209,66 @@ private theorem shortProj_ofPath_eq_zero_of_three_le {a b : DoubledQuiver G}
 private theorem shortProj_ofPath_eq_zero_of_ne {a b : DoubledQuiver G}
     (p : _root_.Quiver.Path a b) (hp : p.length = 2) (hne : b ≠ a) :
     shortProj k G (ofPath ⟨a, b, p⟩) = 0 := by
-  rw [shortProj_ofPath, shortCoord, ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)),
-    ite_eq_right fun h => hne h.2]
+  rw [shortProj, liftLinear_ofPath, shortCoord,
+    ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)), ite_eq_right fun h => hne h.2]
 
 private theorem shortProj_ofPath_of_loop {a : DoubledQuiver G} (p : _root_.Quiver.Path a a)
     (hp : p.length = 2) :
     shortProj k G (ofPath ⟨a, a, p⟩) = ofPath (volumePath G ((vertexEquiv G).symm a)) := by
-  rw [shortProj_ofPath, shortCoord, ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)),
-    ite_eq_left ⟨hp, rfl⟩]
+  rw [shortProj, liftLinear_ofPath, shortCoord,
+    ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)), ite_eq_left ⟨hp, rfl⟩]
 
-private theorem shortProj_ofPath_zigzagBasisPath (hns : ∀ i : V, ∃ j, G.Adj i j)
-    (b : ZigzagBasisIndex G) :
+private theorem shortProj_ofPath_zigzagBasisPath (b : ZigzagBasisIndex G) :
     shortProj k G (ofPath (zigzagBasisPath G b)) = ofPath (zigzagBasisPath G b) := by
   rcases b with i | d | i
   · exact shortProj_ofPath_of_length_le_one k G _ (by simp)
   · exact shortProj_ofPath_of_length_le_one k G _ (by simp)
-  · obtain ⟨j, h⟩ := hns i
-    simp only [zigzagBasisPath]
-    refine (shortProj_ofPath_of_loop k G (volumeLoop G i) (length_volumeLoop G h)).trans ?_
-    rw [vertexEquiv_symm_vertex]
+  · simp only [zigzagBasisPath]
+    by_cases h : ∃ j, G.Adj i j
+    · obtain ⟨j, hj⟩ := h
+      refine (shortProj_ofPath_of_loop k G (volumeLoop G i) (length_volumeLoop G hj)).trans ?_
+      rw [vertexEquiv_symm_vertex]
+    · rw [volumePath, volumeLoop, dite_eq_right h]
+      exact shortProj_ofPath_of_length_le_one k G _ (by simp)
 
 /-! ### The coordinate map kills the relation ideal -/
 
-/-- Sandwiching a path of length at least two between two basis paths: the product either vanishes,
-or is a path of length at least three unless both outer paths are trivial. -/
+/-- A path of length at least two, sandwiched between two composable paths of positive total
+length, is killed by the coordinate map: the composite has length at least three. -/
+private theorem shortProj_sandwich_of_pos {a b c e : DoubledQuiver G}
+    (p : _root_.Quiver.Path a b) (r : _root_.Quiver.Path c a) (q : _root_.Quiver.Path e c)
+    (hr : 2 ≤ r.length) (hpq : 0 < p.length + q.length) :
+    shortProj k G (ofPath ⟨a, b, p⟩ * ofPath ⟨c, a, r⟩ * ofPath ⟨e, c, q⟩) = 0 := by
+  rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp]
+  refine shortProj_ofPath_eq_zero_of_three_le k G _ ?_
+  rw [_root_.Quiver.Path.length_comp, _root_.Quiver.Path.length_comp]
+  omega
+
+/-- Sandwiching between two paths a path of length at least two that the coordinate map already
+kills is again killed by the coordinate map. -/
 private theorem shortProj_sandwich_ofPath {a b c d e f : DoubledQuiver G}
     (p : _root_.Quiver.Path a b) (r : _root_.Quiver.Path c d) (q : _root_.Quiver.Path e f)
     (hr : 2 ≤ r.length) (hzero : shortProj k G (ofPath ⟨c, d, r⟩) = 0) :
     shortProj k G (ofPath ⟨a, b, p⟩ * ofPath ⟨c, d, r⟩ * ofPath ⟨e, f, q⟩) = 0 := by
   by_cases hda : d = a
-  · by_cases hfc : f = c
-    · subst hda
-      subst hfc
-      rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp]
+  · subst hda
+    by_cases hfc : f = c
+    · subst hfc
       rcases Nat.eq_zero_or_pos (p.length + q.length) with hlen | hlen
       · have hp : p.length = 0 := by omega
         have hq : q.length = 0 := by omega
-        cases p with
-        | cons _ _ => simp at hp
-        | nil =>
-          cases q with
-          | cons _ _ => simp at hq
-          | nil => rwa [_root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp]
-      · refine shortProj_ofPath_eq_zero_of_three_le k G _ ?_
-        rw [_root_.Quiver.Path.length_comp, _root_.Quiver.Path.length_comp]
-        omega
-    · subst hda
-      rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_not_composable hfc, map_zero]
+        obtain rfl := p.eq_of_length_zero hp
+        obtain rfl := p.eq_nil_of_length_zero hp
+        obtain rfl := q.eq_of_length_zero hq
+        obtain rfl := q.eq_nil_of_length_zero hq
+        rwa [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
+          _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp]
+      · exact shortProj_sandwich_of_pos k G p r q hr hlen
+    · rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_not_composable hfc, map_zero]
   · rw [ofPath_mul_ofPath_of_not_composable hda, zero_mul, map_zero]
 
-/-- Sandwiching the difference of two length-two loops at one vertex between two basis paths. -/
+/-- Sandwiching between two paths the difference of two length-two loops at one vertex is killed
+by the coordinate map: the two loops have the same coordinate. -/
 private theorem shortProj_sandwich_sub {a b c e f : DoubledQuiver G}
     (p : _root_.Quiver.Path a b) (r₁ r₂ : _root_.Quiver.Path c c)
     (q : _root_.Quiver.Path e f) (h₁ : r₁.length = 2) (h₂ : r₂.length = 2) :
@@ -246,30 +276,23 @@ private theorem shortProj_sandwich_sub {a b c e f : DoubledQuiver G}
       (ofPath ⟨a, b, p⟩ * (ofPath ⟨c, c, r₁⟩ - ofPath ⟨c, c, r₂⟩) * ofPath ⟨e, f, q⟩) = 0 := by
   rw [mul_sub, sub_mul, map_sub]
   by_cases hca : c = a
-  · by_cases hfc : f = c
-    · subst hca
-      subst hfc
-      rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
-        ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp]
+  · subst hca
+    by_cases hfc : f = c
+    · subst hfc
       rcases Nat.eq_zero_or_pos (p.length + q.length) with hlen | hlen
       · have hp : p.length = 0 := by omega
         have hq : q.length = 0 := by omega
-        cases p with
-        | cons _ _ => simp at hp
-        | nil =>
-          cases q with
-          | cons _ _ => simp at hq
-          | nil =>
-            rw [_root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp,
-              _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp,
-              shortProj_ofPath_of_loop k G r₁ h₁, shortProj_ofPath_of_loop k G r₂ h₂, sub_self]
-      · rw [shortProj_ofPath_eq_zero_of_three_le k G (q.comp (r₁.comp p)) (by
-            rw [_root_.Quiver.Path.length_comp, _root_.Quiver.Path.length_comp]; omega),
-          shortProj_ofPath_eq_zero_of_three_le k G (q.comp (r₂.comp p)) (by
-            rw [_root_.Quiver.Path.length_comp, _root_.Quiver.Path.length_comp]; omega),
-          sub_zero]
-    · subst hca
-      rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
+        obtain rfl := p.eq_of_length_zero hp
+        obtain rfl := p.eq_nil_of_length_zero hp
+        obtain rfl := q.eq_of_length_zero hq
+        obtain rfl := q.eq_nil_of_length_zero hq
+        rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
+          ofPath_mul_ofPath_of_comp, _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp,
+          _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp,
+          shortProj_ofPath_of_loop k G r₁ h₁, shortProj_ofPath_of_loop k G r₂ h₂, sub_self]
+      · rw [shortProj_sandwich_of_pos k G p r₁ q h₁.ge hlen,
+          shortProj_sandwich_of_pos k G p r₂ q h₂.ge hlen, sub_zero]
+    · rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
         ofPath_mul_ofPath_of_not_composable hfc, ofPath_mul_ofPath_of_not_composable hfc]
       simp
   · rw [ofPath_mul_ofPath_of_not_composable hca, ofPath_mul_ofPath_of_not_composable hca]
@@ -303,12 +326,9 @@ private theorem shortProj_mul_relator_mul {x : pathAlgebra k (DoubledQuiver G)}
     | zero => simp
     | add v₁ v₂ hv₁ hv₂ => rw [mul_add, map_add, hv₁, hv₂, add_zero]
     | single pv cv =>
-      have hu : (single pu cu : pathAlgebra k (DoubledQuiver G)) = cu • ofPath pu := by
-        rw [ofPath_eq_single, smul_single, mul_one]
-      have hv : (single pv cv : pathAlgebra k (DoubledQuiver G)) = cv • ofPath pv := by
-        rw [ofPath_eq_single, smul_single, mul_one]
-      rw [hu, hv, smul_mul_assoc, smul_mul_assoc, mul_smul_comm, map_smul, map_smul,
-        shortProj_ofPath_mul_relator_mul_ofPath k G hx, smul_zero, smul_zero]
+      rw [single_eq_smul_ofPath, single_eq_smul_ofPath, smul_mul_assoc, smul_mul_assoc,
+        mul_smul_comm, map_smul, map_smul, shortProj_ofPath_mul_relator_mul_ofPath k G hx,
+        smul_zero, smul_zero]
 
 private theorem shortProj_eq_zero_of_mem_zigzagIdeal {x : pathAlgebra k (DoubledQuiver G)}
     (hx : x ∈ zigzagIdeal k G) : shortProj k G x = 0 := by
@@ -325,54 +345,29 @@ private theorem shortProj_eq_zero_of_mem_zigzagIdeal {x : pathAlgebra k (Doubled
 /-! ### The basis -/
 
 omit [Finite V] in
-/-- The paths underlying the basis family are distinct, so their basis elements of the path algebra
-are independent. -/
+/-- The paths underlying the basis family are the trivial paths, the arrows of the darts, and the
+backtracks along the chosen darts, so their independence is the independence of the vertex
+idempotents, the oriented edges and the backtracks, reindexed along an injection. -/
 private theorem linearIndependent_ofPath_zigzagBasisPath (hns : ∀ i : V, ∃ j, G.Adj i j) :
     LinearIndependent k fun b : ZigzagBasisIndex G =>
       (ofPath (zigzagBasisPath G b) : pathAlgebra k (DoubledQuiver G)) := by
-  have hlen : ∀ b : ZigzagBasisIndex G, (zigzagBasisPath G b).2.2.length =
-      Sum.elim (fun _ : V => 0) (Sum.elim (fun _ : G.Dart => 1) fun _ : V => 2) b := by
-    rintro (i | d | i)
-    · simp [zigzagBasisPath]
-    · simp [zigzagBasisPath]
-    · obtain ⟨j, h⟩ := hns i
-      simp only [zigzagBasisPath, volumePath, Sum.elim_inr]
-      exact length_volumeLoop G h
-  have hinj : Function.Injective (zigzagBasisPath G) := by
-    rintro x y hxy
-    have hl : Sum.elim (fun _ : V => 0) (Sum.elim (fun _ : G.Dart => 1) fun _ : V => 2) x
-        = Sum.elim (fun _ : V => 0) (Sum.elim (fun _ : G.Dart => 1) fun _ : V => 2) y := by
-      rw [← hlen x, ← hlen y, hxy]
-    rcases x with i | ⟨⟨a, b⟩, hab⟩ | i <;> rcases y with i' | ⟨⟨a', b'⟩, ha'b'⟩ | i' <;>
-      simp only [Sum.elim_inl, Sum.elim_inr] at hl
-    · simp only [zigzagBasisPath] at hxy
-      have hv : vertex G i = vertex G i' := by exact congrArg Sigma.fst hxy
-      rw [(vertex_inj G).mp hv]
-    · simp at hl
-    · simp at hl
-    · simp at hl
-    · simp only [zigzagBasisPath] at hxy
-      have h1 : a = a' := (vertex_inj G).mp (by exact congrArg Sigma.fst hxy)
-      have h2 : b = b' := (vertex_inj G).mp
-        (by exact congrArg (fun z : Quiver.TotalPath (DoubledQuiver G) => z.2.1) hxy)
-      subst h1
-      subst h2
-      rfl
-    · simp at hl
-    · simp at hl
-    · simp at hl
-    · simp only [zigzagBasisPath] at hxy
-      have hv : vertex G i = vertex G i' := by
-        rw [← volumePath_fst G i, ← volumePath_fst G i']
-        exact congrArg Sigma.fst hxy
-      rw [(vertex_inj G).mp hv]
   have hfam : (fun b : ZigzagBasisIndex G =>
       (ofPath (zigzagBasisPath G b) : pathAlgebra k (DoubledQuiver G)))
-      = ⇑(pathAlgebraBasis k (DoubledQuiver G)) ∘ zigzagBasisPath G := by
+      = Sum.elim (fun v : V => (vertexIdempotent k (vertex G v) : pathAlgebra k (DoubledQuiver G)))
+          (Sum.elim (fun d : G.Dart => (ofArrow (arrow G d.adj) : pathAlgebra k (DoubledQuiver G)))
+            fun d : G.Dart => backtrackElem G k d.adj) ∘
+        Sum.map id (Sum.map id (volumeDart G hns)) := by
     funext b
-    rw [Function.comp_apply, coe_pathAlgebraBasis]
+    rcases b with i | d | i
+    · simp [zigzagBasisPath, vertexIdempotent_eq_single, ofPath_eq_single]
+    · simp [zigzagBasisPath, arrowPath_eq_toPath]
+    · exact ofPath_volumePath_eq_backtrackElem k G hns i
+  have hdart : Function.Injective (volumeDart G hns) :=
+    fun _ _ h => congrArg (fun d : G.Dart => d.toProd.1) h
   rw [hfam]
-  exact (pathAlgebraBasis k (DoubledQuiver G)).linearIndependent.comp _ hinj
+  exact (linearIndependent_vertexIdempotent_ofArrow_backtrackElem G k).comp _
+    (Sum.map_injective.2 ⟨Function.injective_id,
+      Sum.map_injective.2 ⟨Function.injective_id, hdart⟩⟩)
 
 /-- **The vertex, arrow and volume classes are independent.** -/
 theorem linearIndependent_zigzagBasisFun (hns : ∀ i : V, ∃ j, G.Adj i j) :
@@ -390,10 +385,10 @@ theorem linearIndependent_zigzagBasisFun (hns : ∀ i : V, ∃ j, G.Adj i j) :
   refine linearIndependent_iff.mp (linearIndependent_ofPath_zigzagBasisPath k G hns) l ?_
   rw [← hzero]
   exact congrArg (fun f => Finsupp.linearCombination k f l)
-    (funext fun b => (shortProj_ofPath_zigzagBasisPath k G hns b).symm)
+    (funext fun b => (shortProj_ofPath_zigzagBasisPath k G b).symm)
 
 /-- **The vertex, arrow and volume classes span.** -/
-theorem span_range_zigzagBasisFun :
+theorem span_range_zigzagBasisFun_eq_top :
     Submodule.span k (Set.range (zigzagBasisFun k G)) = ⊤ := by
   have key : ∀ x : Quiver.TotalPath (DoubledQuiver G),
       zigzagMk k G (ofPath x) ∈ Submodule.span k (Set.range (zigzagBasisFun k G)) := by
@@ -421,41 +416,46 @@ theorem span_range_zigzagBasisFun :
           exact Submodule.zero_mem _
     · rw [zigzagMk_ofPath_eq_zero_of_three_le k G ⟨_, _, p⟩ hge]
       exact Submodule.zero_mem _
-  rw [eq_top_iff]
-  rintro x -
-  obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective x
-  rw [← zigzagMk_apply]
-  induction y using PathAlgebra.induction_linear with
-  | zero =>
-    rw [map_zero]
-    exact Submodule.zero_mem _
-  | add y₁ y₂ hy₁ hy₂ =>
-    rw [map_add]
-    exact Submodule.add_mem _ hy₁ hy₂
-  | single z c =>
-    have hz : (single z c : pathAlgebra k (DoubledQuiver G)) = c • ofPath z := by
-      rw [ofPath_eq_single, smul_single, mul_one]
-    rw [hz, map_smul]
-    exact Submodule.smul_mem _ _ (key z)
+  -- the images of *all* the basis paths span the quotient, the quotient map being onto
+  have htop : Submodule.span k (Set.range fun x : Quiver.TotalPath (DoubledQuiver G) =>
+      (zigzagMk k G).toLinearMap (ofPath x)) = ⊤ := by
+    have hsurj : Function.Surjective ⇑(zigzagMk k G).toLinearMap := fun y => by
+      obtain ⟨f, rfl⟩ := Ideal.Quotient.mk_surjective y
+      exact ⟨f, zigzagMk_apply k G f⟩
+    have hmap : Submodule.map (zigzagMk k G).toLinearMap ⊤ = ⊤ := by
+      rw [Submodule.map_top, LinearMap.range_eq_top.2 hsurj]
+    rw [← hmap, ← (pathAlgebraBasis k (DoubledQuiver G)).span_eq, Submodule.map_span,
+      coe_pathAlgebraBasis, ← Set.range_comp]
+    rfl
+  rw [eq_top_iff, ← htop]
+  exact Submodule.span_le.2 (Set.range_subset_iff.2 fun x => SetLike.mem_coe.2 (key x))
 
 /-- **The basis of a zigzag algebra.** For a finite simple graph with no isolated vertex the vertex
 idempotents, the oriented edges, and the volume classes are a basis of the zigzag relation
-quotient, homogeneous of path degrees `0`, `1` and `2`. -/
+quotient. The three blocks are represented by paths of length `0`, `1` and `2`; the path grading
+itself is not formalised in this repository, so homogeneity is not stated here. -/
 noncomputable def zigzagBasis (hns : ∀ i : V, ∃ j, G.Adj i j) :
     Module.Basis (ZigzagBasisIndex G) k (nonisolatedZigzagQuotient k G) :=
   Module.Basis.mk (linearIndependent_zigzagBasisFun k G hns)
-    (span_range_zigzagBasisFun k G).ge
+    (span_range_zigzagBasisFun_eq_top k G).ge
 
 @[simp]
 theorem zigzagBasis_apply (hns : ∀ i : V, ∃ j, G.Adj i j) (b : ZigzagBasisIndex G) :
     zigzagBasis k G hns b = zigzagBasisFun k G b :=
   Module.Basis.mk_apply _ _ _
 
-/-- The volume class of a vertex of a graph with no isolated vertex is nonzero. -/
-theorem zigzagVolume_ne_zero [Nontrivial k] (hns : ∀ i : V, ∃ j, G.Adj i j) (i : V) :
+/-- The volume class of a vertex with a neighbour is nonzero, whatever the rest of the graph does:
+its chosen backtrack survives the coordinate map. -/
+theorem zigzagVolume_ne_zero [Nontrivial k] {i j : V} (h : G.Adj i j) :
     zigzagVolume k G i ≠ 0 := by
-  have hne := (zigzagBasis k G hns).ne_zero (.inr (.inr i))
-  rwa [zigzagBasis_apply, zigzagBasisFun_inr_inr] at hne
+  have hne : (ofPath (volumePath G i) : pathAlgebra k (DoubledQuiver G)) ≠ 0 := by
+    simpa using (pathAlgebraBasis k (DoubledQuiver G)).ne_zero (volumePath G i)
+  intro hvol
+  rw [zigzagVolume_eq_zigzagMk_backtrackElem k G h, zigzagMk_eq_zero_iff] at hvol
+  have hproj := shortProj_eq_zero_of_mem_zigzagIdeal k G hvol
+  rw [backtrackElem_eq_ofPath, shortProj_ofPath_of_loop k G (backtrackPath G h)
+    (length_backtrackPath G h), vertexEquiv_symm_vertex] at hproj
+  exact hne hproj
 
 /-! ### The dimension -/
 
@@ -469,14 +469,13 @@ theorem finrank_nonisolatedZigzagQuotient [Nontrivial k] [Fintype V] [DecidableR
   simp only [ZigzagBasisIndex, Fintype.card_sum, G.dart_card_eq_twice_card_edges]
   ring
 
-/-- **The dimension of the zigzag algebra of a connected graph.** For a connected graph with at
-least two vertices, `dim Z(G) = 2|V| + 2|E|`: connectedness leaves no isolated vertex. -/
-theorem finrank_nonisolatedZigzagQuotient_of_connected [Nontrivial k] [Fintype V]
-    [DecidableRel G.Adj] (hconn : G.Connected) (hcard : 1 < Fintype.card V) :
+/-- **The dimension of the zigzag algebra of a preconnected graph.** For a preconnected graph with
+at least two vertices, `dim Z(G) = 2|V| + 2|E|`: preconnectedness leaves no isolated vertex. -/
+theorem finrank_nonisolatedZigzagQuotient_of_preconnected [Nontrivial k] [Fintype V] [Nontrivial V]
+    [DecidableRel G.Adj] (hconn : G.Preconnected) :
     Module.finrank k (nonisolatedZigzagQuotient k G)
       = 2 * Fintype.card V + 2 * G.edgeFinset.card :=
-  have : Nontrivial V := Fintype.one_lt_card_iff_nontrivial.mp hcard
   finrank_nonisolatedZigzagQuotient k G fun i =>
-    SimpleGraph.exists_adj_iff_not_isIsolated.mpr (hconn.preconnected.not_isIsolated i)
+    SimpleGraph.exists_adj_iff_not_isIsolated.mpr (hconn.not_isIsolated i)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean
@@ -1,0 +1,482 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dimension.StrongRankCondition
+public import Mathlib.RingTheory.FiniteType
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Relations
+
+/-!
+# The vertex, arrow and volume basis of a zigzag algebra
+
+The zigzag relation quotient `TauCeti.nonisolatedZigzagQuotient` of a finite simple graph `G` kills
+every path of length at least three and identifies all the backtracks based at one vertex. What
+survives is spanned by the vertex idempotents, the oriented edges, and one *volume* class per
+vertex. This file proves that these classes are a basis whenever `G` has no isolated vertex, and
+reads off the dimension `2|V| + 2|E|`.
+
+Spanning is immediate from the relations. Independence is the substantive half, and is proved by
+exhibiting a coordinate map. The path algebra is free on the paths of the doubled quiver, so a
+`k`-linear map out of it may be prescribed on paths: send a path of length at most one to itself, a
+length-two path returning to its source to a fixed backtrack there, and everything else to `0`.
+Sandwiching a relator between two basis paths either produces a path of length at least three or,
+when both outer paths are trivial, the relator itself, so this map kills the relation ideal. It
+therefore separates the candidate basis classes, which it sends to distinct basis paths.
+
+The hypothesis is that every vertex has a neighbour: an isolated vertex carries no backtrack, so
+its volume class does not exist. For a connected graph with at least two vertices the hypothesis is
+automatic, which is the form the roadmap's dimension count takes.
+
+## Main definitions
+
+* `TauCeti.zigzagVolume`: the volume class of a vertex, the common image of its backtracks.
+* `TauCeti.ZigzagBasisIndex`: vertices in degree zero, darts in degree one, vertices in degree two.
+* `TauCeti.zigzagBasisFun`: the vertex, arrow and volume family.
+* `TauCeti.zigzagBasis`: that family, as a basis of the zigzag relation quotient.
+
+## Main results
+
+* `TauCeti.linearIndependent_zigzagBasisFun` and `TauCeti.span_range_zigzagBasisFun`: the family is
+  independent and spans.
+* `TauCeti.finrank_nonisolatedZigzagQuotient`: the dimension is `2|V| + 2|E|`.
+* `TauCeti.finrank_nonisolatedZigzagQuotient_of_connected`: the same count for a connected graph
+  with at least two vertices.
+
+## References
+
+This is the first two clauses of Layer 2 of `TauCetiRoadmap/ZigzagPreprojective/README.md`, whose
+target signatures `zigzagBasis` and `finrank_zigzagAlgebra` appear in
+`TauCetiRoadmap/ZigzagPreprojective/Suggested.lean`. See Huerfano--Khovanov, *A category for the
+adjoint representation*, Section 3, and Ehrig--Tubbenhauer, *Algebraic properties of zigzag
+algebras*, Section 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open PathAlgebra DoubledQuiver
+
+universe u w
+
+variable (k : Type w) [CommRing k] {V : Type u} (G : SimpleGraph V)
+
+/-! ### A chosen backtrack at each vertex -/
+
+open scoped Classical in
+/-- A chosen backtrack loop at a vertex. An isolated vertex has none, and the trivial path is used
+as a junk value there. -/
+private noncomputable def volumeLoop (i : V) :
+    _root_.Quiver.Path (vertex G i) (vertex G i) :=
+  if h : ∃ j, G.Adj i j then backtrackPath G h.choose_spec else _root_.Quiver.Path.nil
+
+/-- The chosen backtrack at a vertex, as an indexed path of the doubled quiver. -/
+private noncomputable def volumePath (i : V) : Quiver.TotalPath (DoubledQuiver G) :=
+  ⟨vertex G i, vertex G i, volumeLoop G i⟩
+
+private theorem volumePath_fst (i : V) : (volumePath G i).1 = vertex G i := (rfl)
+
+private theorem length_volumeLoop {i j : V} (h : G.Adj i j) : (volumeLoop G i).length = 2 := by
+  rw [volumeLoop, dite_eq_left (⟨j, h⟩ : ∃ j, G.Adj i j)]
+  exact length_backtrackPath G _
+
+/-! ### Volume classes -/
+
+variable [Finite V]
+
+open scoped Classical in
+/-- The volume class of a vertex of a simple graph: the common image in the zigzag relation
+quotient of all the backtracks based at that vertex, which `TauCeti.zigzagMk_backtrackElem_eq`
+shows is independent of the incident edge chosen. It is the junk value `0` on an isolated vertex,
+which carries no backtrack. -/
+noncomputable def zigzagVolume (i : V) : nonisolatedZigzagQuotient k G :=
+  if h : ∃ j, G.Adj i j then zigzagMk k G (backtrackElem G k h.choose_spec) else 0
+
+/-- The volume class of a vertex is the class of any backtrack based there. -/
+theorem zigzagVolume_eq_zigzagMk_backtrackElem {i j : V} (h : G.Adj i j) :
+    zigzagVolume k G i = zigzagMk k G (backtrackElem G k h) := by
+  rw [zigzagVolume, dite_eq_left (⟨j, h⟩ : ∃ j, G.Adj i j)]
+  exact zigzagMk_backtrackElem_eq k G _ h
+
+private theorem zigzagMk_ofPath_volumePath {i j : V} (h : G.Adj i j) :
+    zigzagMk k G (ofPath (volumePath G i)) = zigzagVolume k G i := by
+  have hex : ∃ j, G.Adj i j := ⟨j, h⟩
+  rw [volumePath, volumeLoop, dite_eq_left hex, zigzagVolume, dite_eq_left hex,
+    backtrackElem_eq_ofPath]
+
+/-! ### The vertex, arrow and volume family -/
+
+/-- The homogeneous basis indices of a zigzag algebra: a vertex in path degree zero, an oriented
+edge in path degree one, and a volume class at a vertex in path degree two. -/
+abbrev ZigzagBasisIndex : Type _ := V ⊕ G.Dart ⊕ V
+
+/-- The vertex, arrow and volume family of a zigzag algebra: the class of a vertex idempotent, the
+class of the arrow of a dart, and the volume class of a vertex. -/
+noncomputable def zigzagBasisFun : ZigzagBasisIndex G → nonisolatedZigzagQuotient k G
+  | .inl i => zigzagMk k G (vertexIdempotent k (vertex G i))
+  | .inr (.inl d) => zigzagMk k G (ofArrow (arrow G d.adj))
+  | .inr (.inr i) => zigzagVolume k G i
+
+@[simp]
+theorem zigzagBasisFun_inl (i : V) :
+    zigzagBasisFun k G (.inl i) = zigzagMk k G (vertexIdempotent k (vertex G i)) := (rfl)
+
+@[simp]
+theorem zigzagBasisFun_inr_inl (d : G.Dart) :
+    zigzagBasisFun k G (.inr (.inl d)) = zigzagMk k G (ofArrow (arrow G d.adj)) := (rfl)
+
+@[simp]
+theorem zigzagBasisFun_inr_inr (i : V) :
+    zigzagBasisFun k G (.inr (.inr i)) = zigzagVolume k G i := (rfl)
+
+/-- The indexed path underlying each member of the basis family: the trivial path at a vertex, the
+arrow of a dart, and the chosen backtrack at a vertex. -/
+private noncomputable def zigzagBasisPath :
+    ZigzagBasisIndex G → Quiver.TotalPath (DoubledQuiver G)
+  | .inl i => ⟨vertex G i, vertex G i, _root_.Quiver.Path.nil⟩
+  | .inr (.inl d) => ⟨vertex G d.fst, vertex G d.snd, arrowPath G d.adj⟩
+  | .inr (.inr i) => volumePath G i
+
+private theorem zigzagMk_ofPath_zigzagBasisPath (hns : ∀ i : V, ∃ j, G.Adj i j)
+    (b : ZigzagBasisIndex G) :
+    zigzagMk k G (ofPath (zigzagBasisPath G b)) = zigzagBasisFun k G b := by
+  rcases b with i | d | i
+  · simp only [zigzagBasisPath, zigzagBasisFun_inl, vertexIdempotent_eq_single, ofPath_eq_single]
+  · simp only [zigzagBasisPath, zigzagBasisFun_inr_inl, ofArrow_eq_ofPath_arrowPath]
+  · obtain ⟨j, h⟩ := hns i
+    simp only [zigzagBasisPath]
+    exact zigzagMk_ofPath_volumePath k G h
+
+/-! ### The coordinate map -/
+
+open scoped Classical in
+/-- The value on a basis path of the coordinate map used to separate the basis classes: a path of
+length at most one goes to itself, a length-two path returning to its source goes to the chosen
+backtrack there, and every other path dies. -/
+private noncomputable def shortCoord (x : Quiver.TotalPath (DoubledQuiver G)) :
+    pathAlgebra k (DoubledQuiver G) :=
+  if x.2.2.length ≤ 1 then ofPath x
+  else if x.2.2.length = 2 ∧ x.2.1 = x.1 then ofPath (volumePath G ((vertexEquiv G).symm x.1))
+  else 0
+
+/-- The coordinate map of the zigzag relations: the `k`-linear extension of `shortCoord`. -/
+private noncomputable def shortProj :
+    pathAlgebra k (DoubledQuiver G) →ₗ[k] pathAlgebra k (DoubledQuiver G) :=
+  (pathAlgebraBasis k (DoubledQuiver G)).constr k (shortCoord k G)
+
+private theorem shortProj_ofPath (x : Quiver.TotalPath (DoubledQuiver G)) :
+    shortProj k G (ofPath x) = shortCoord k G x := by
+  have hx : (ofPath x : pathAlgebra k (DoubledQuiver G))
+      = pathAlgebraBasis k (DoubledQuiver G) x := by rw [coe_pathAlgebraBasis]
+  rw [shortProj, hx, Module.Basis.constr_basis]
+
+private theorem shortProj_ofPath_of_length_le_one {a b : DoubledQuiver G}
+    (p : _root_.Quiver.Path a b) (hp : p.length ≤ 1) :
+    shortProj k G (ofPath ⟨a, b, p⟩) = ofPath ⟨a, b, p⟩ := by
+  rw [shortProj_ofPath, shortCoord, ite_eq_left hp]
+
+private theorem shortProj_ofPath_eq_zero_of_three_le {a b : DoubledQuiver G}
+    (p : _root_.Quiver.Path a b) (hp : 3 ≤ p.length) :
+    shortProj k G (ofPath ⟨a, b, p⟩) = 0 := by
+  rw [shortProj_ofPath, shortCoord, ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)),
+    ite_eq_right fun h => by
+      have h2 : p.length = 2 := h.1
+      omega]
+
+private theorem shortProj_ofPath_eq_zero_of_ne {a b : DoubledQuiver G}
+    (p : _root_.Quiver.Path a b) (hp : p.length = 2) (hne : b ≠ a) :
+    shortProj k G (ofPath ⟨a, b, p⟩) = 0 := by
+  rw [shortProj_ofPath, shortCoord, ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)),
+    ite_eq_right fun h => hne h.2]
+
+private theorem shortProj_ofPath_of_loop {a : DoubledQuiver G} (p : _root_.Quiver.Path a a)
+    (hp : p.length = 2) :
+    shortProj k G (ofPath ⟨a, a, p⟩) = ofPath (volumePath G ((vertexEquiv G).symm a)) := by
+  rw [shortProj_ofPath, shortCoord, ite_eq_right (Nat.not_le.mpr (by omega : 1 < p.length)),
+    ite_eq_left ⟨hp, rfl⟩]
+
+private theorem shortProj_ofPath_zigzagBasisPath (hns : ∀ i : V, ∃ j, G.Adj i j)
+    (b : ZigzagBasisIndex G) :
+    shortProj k G (ofPath (zigzagBasisPath G b)) = ofPath (zigzagBasisPath G b) := by
+  rcases b with i | d | i
+  · exact shortProj_ofPath_of_length_le_one k G _ (by simp)
+  · exact shortProj_ofPath_of_length_le_one k G _ (by simp)
+  · obtain ⟨j, h⟩ := hns i
+    simp only [zigzagBasisPath]
+    refine (shortProj_ofPath_of_loop k G (volumeLoop G i) (length_volumeLoop G h)).trans ?_
+    rw [vertexEquiv_symm_vertex]
+
+/-! ### The coordinate map kills the relation ideal -/
+
+/-- Sandwiching a path of length at least two between two basis paths: the product either vanishes,
+or is a path of length at least three unless both outer paths are trivial. -/
+private theorem shortProj_sandwich_ofPath {a b c d e f : DoubledQuiver G}
+    (p : _root_.Quiver.Path a b) (r : _root_.Quiver.Path c d) (q : _root_.Quiver.Path e f)
+    (hr : 2 ≤ r.length) (hzero : shortProj k G (ofPath ⟨c, d, r⟩) = 0) :
+    shortProj k G (ofPath ⟨a, b, p⟩ * ofPath ⟨c, d, r⟩ * ofPath ⟨e, f, q⟩) = 0 := by
+  by_cases hda : d = a
+  · by_cases hfc : f = c
+    · subst hda
+      subst hfc
+      rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp]
+      rcases Nat.eq_zero_or_pos (p.length + q.length) with hlen | hlen
+      · have hp : p.length = 0 := by omega
+        have hq : q.length = 0 := by omega
+        cases p with
+        | cons _ _ => simp at hp
+        | nil =>
+          cases q with
+          | cons _ _ => simp at hq
+          | nil => rwa [_root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp]
+      · refine shortProj_ofPath_eq_zero_of_three_le k G _ ?_
+        rw [_root_.Quiver.Path.length_comp, _root_.Quiver.Path.length_comp]
+        omega
+    · subst hda
+      rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_not_composable hfc, map_zero]
+  · rw [ofPath_mul_ofPath_of_not_composable hda, zero_mul, map_zero]
+
+/-- Sandwiching the difference of two length-two loops at one vertex between two basis paths. -/
+private theorem shortProj_sandwich_sub {a b c e f : DoubledQuiver G}
+    (p : _root_.Quiver.Path a b) (r₁ r₂ : _root_.Quiver.Path c c)
+    (q : _root_.Quiver.Path e f) (h₁ : r₁.length = 2) (h₂ : r₂.length = 2) :
+    shortProj k G
+      (ofPath ⟨a, b, p⟩ * (ofPath ⟨c, c, r₁⟩ - ofPath ⟨c, c, r₂⟩) * ofPath ⟨e, f, q⟩) = 0 := by
+  rw [mul_sub, sub_mul, map_sub]
+  by_cases hca : c = a
+  · by_cases hfc : f = c
+    · subst hca
+      subst hfc
+      rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
+        ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp]
+      rcases Nat.eq_zero_or_pos (p.length + q.length) with hlen | hlen
+      · have hp : p.length = 0 := by omega
+        have hq : q.length = 0 := by omega
+        cases p with
+        | cons _ _ => simp at hp
+        | nil =>
+          cases q with
+          | cons _ _ => simp at hq
+          | nil =>
+            rw [_root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp,
+              _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp,
+              shortProj_ofPath_of_loop k G r₁ h₁, shortProj_ofPath_of_loop k G r₂ h₂, sub_self]
+      · rw [shortProj_ofPath_eq_zero_of_three_le k G (q.comp (r₁.comp p)) (by
+            rw [_root_.Quiver.Path.length_comp, _root_.Quiver.Path.length_comp]; omega),
+          shortProj_ofPath_eq_zero_of_three_le k G (q.comp (r₂.comp p)) (by
+            rw [_root_.Quiver.Path.length_comp, _root_.Quiver.Path.length_comp]; omega),
+          sub_zero]
+    · subst hca
+      rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
+        ofPath_mul_ofPath_of_not_composable hfc, ofPath_mul_ofPath_of_not_composable hfc]
+      simp
+  · rw [ofPath_mul_ofPath_of_not_composable hca, ofPath_mul_ofPath_of_not_composable hca]
+    simp
+
+private theorem shortProj_ofPath_mul_relator_mul_ofPath {x : pathAlgebra k (DoubledQuiver G)}
+    (hx : IsZigzagRelator k G x) (pu pv : Quiver.TotalPath (DoubledQuiver G)) :
+    shortProj k G (ofPath pu * x * ofPath pv) = 0 := by
+  obtain ⟨a, b, p⟩ := pu
+  obtain ⟨e, f, q⟩ := pv
+  cases hx with
+  | quadratic hq =>
+    cases hq with
+    | nonreturn r hlen hij =>
+      exact shortProj_sandwich_ofPath k G p r q hlen.ge
+        (shortProj_ofPath_eq_zero_of_ne k G r hlen (Ne.symm hij))
+    | equal_backtracks r₁ r₂ hr₁ hr₂ => exact shortProj_sandwich_sub k G p r₁ r₂ q hr₁ hr₂
+  | long_path z hz =>
+    obtain ⟨c, d, r⟩ := z
+    exact shortProj_sandwich_ofPath k G p r q (Nat.le_of_succ_le hz)
+      (shortProj_ofPath_eq_zero_of_three_le k G r hz)
+
+private theorem shortProj_mul_relator_mul {x : pathAlgebra k (DoubledQuiver G)}
+    (hx : IsZigzagRelator k G x) (u v : pathAlgebra k (DoubledQuiver G)) :
+    shortProj k G (u * x * v) = 0 := by
+  induction u using PathAlgebra.induction_linear with
+  | zero => simp
+  | add u₁ u₂ hu₁ hu₂ => rw [add_mul, add_mul, map_add, hu₁, hu₂, add_zero]
+  | single pu cu =>
+    induction v using PathAlgebra.induction_linear with
+    | zero => simp
+    | add v₁ v₂ hv₁ hv₂ => rw [mul_add, map_add, hv₁, hv₂, add_zero]
+    | single pv cv =>
+      have hu : (single pu cu : pathAlgebra k (DoubledQuiver G)) = cu • ofPath pu := by
+        rw [ofPath_eq_single, smul_single, mul_one]
+      have hv : (single pv cv : pathAlgebra k (DoubledQuiver G)) = cv • ofPath pv := by
+        rw [ofPath_eq_single, smul_single, mul_one]
+      rw [hu, hv, smul_mul_assoc, smul_mul_assoc, mul_smul_comm, map_smul, map_smul,
+        shortProj_ofPath_mul_relator_mul_ofPath k G hx, smul_zero, smul_zero]
+
+private theorem shortProj_eq_zero_of_mem_zigzagIdeal {x : pathAlgebra k (DoubledQuiver G)}
+    (hx : x ∈ zigzagIdeal k G) : shortProj k G x = 0 := by
+  rw [zigzagIdeal_eq_span, TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure] at hx
+  induction hx using AddSubgroup.closure_induction with
+  | mem y hy =>
+    obtain ⟨w, hw, v, -, rfl⟩ := hy
+    obtain ⟨u, -, r, hr, rfl⟩ := hw
+    exact shortProj_mul_relator_mul k G hr u v
+  | zero => exact map_zero _
+  | add y z _ _ hy hz => rw [map_add, hy, hz, add_zero]
+  | neg y _ hy => rw [map_neg, hy, neg_zero]
+
+/-! ### The basis -/
+
+omit [Finite V] in
+/-- The paths underlying the basis family are distinct, so their basis elements of the path algebra
+are independent. -/
+private theorem linearIndependent_ofPath_zigzagBasisPath (hns : ∀ i : V, ∃ j, G.Adj i j) :
+    LinearIndependent k fun b : ZigzagBasisIndex G =>
+      (ofPath (zigzagBasisPath G b) : pathAlgebra k (DoubledQuiver G)) := by
+  have hlen : ∀ b : ZigzagBasisIndex G, (zigzagBasisPath G b).2.2.length =
+      Sum.elim (fun _ : V => 0) (Sum.elim (fun _ : G.Dart => 1) fun _ : V => 2) b := by
+    rintro (i | d | i)
+    · simp [zigzagBasisPath]
+    · simp [zigzagBasisPath]
+    · obtain ⟨j, h⟩ := hns i
+      simp only [zigzagBasisPath, volumePath, Sum.elim_inr]
+      exact length_volumeLoop G h
+  have hinj : Function.Injective (zigzagBasisPath G) := by
+    rintro x y hxy
+    have hl : Sum.elim (fun _ : V => 0) (Sum.elim (fun _ : G.Dart => 1) fun _ : V => 2) x
+        = Sum.elim (fun _ : V => 0) (Sum.elim (fun _ : G.Dart => 1) fun _ : V => 2) y := by
+      rw [← hlen x, ← hlen y, hxy]
+    rcases x with i | ⟨⟨a, b⟩, hab⟩ | i <;> rcases y with i' | ⟨⟨a', b'⟩, ha'b'⟩ | i' <;>
+      simp only [Sum.elim_inl, Sum.elim_inr] at hl
+    · simp only [zigzagBasisPath] at hxy
+      have hv : vertex G i = vertex G i' := by exact congrArg Sigma.fst hxy
+      rw [(vertex_inj G).mp hv]
+    · simp at hl
+    · simp at hl
+    · simp at hl
+    · simp only [zigzagBasisPath] at hxy
+      have h1 : a = a' := (vertex_inj G).mp (by exact congrArg Sigma.fst hxy)
+      have h2 : b = b' := (vertex_inj G).mp
+        (by exact congrArg (fun z : Quiver.TotalPath (DoubledQuiver G) => z.2.1) hxy)
+      subst h1
+      subst h2
+      rfl
+    · simp at hl
+    · simp at hl
+    · simp at hl
+    · simp only [zigzagBasisPath] at hxy
+      have hv : vertex G i = vertex G i' := by
+        rw [← volumePath_fst G i, ← volumePath_fst G i']
+        exact congrArg Sigma.fst hxy
+      rw [(vertex_inj G).mp hv]
+  have hfam : (fun b : ZigzagBasisIndex G =>
+      (ofPath (zigzagBasisPath G b) : pathAlgebra k (DoubledQuiver G)))
+      = ⇑(pathAlgebraBasis k (DoubledQuiver G)) ∘ zigzagBasisPath G := by
+    funext b
+    rw [Function.comp_apply, coe_pathAlgebraBasis]
+  rw [hfam]
+  exact (pathAlgebraBasis k (DoubledQuiver G)).linearIndependent.comp _ hinj
+
+/-- **The vertex, arrow and volume classes are independent.** -/
+theorem linearIndependent_zigzagBasisFun (hns : ∀ i : V, ∃ j, G.Adj i j) :
+    LinearIndependent k (zigzagBasisFun k G) := by
+  rw [linearIndependent_iff]
+  intro l hl
+  have hcomp : zigzagBasisFun k G = ⇑(zigzagMk k G).toLinearMap ∘
+      fun b : ZigzagBasisIndex G => (ofPath (zigzagBasisPath G b)) := by
+    funext b
+    rw [Function.comp_apply, AlgHom.toLinearMap_apply,
+      zigzagMk_ofPath_zigzagBasisPath k G hns b]
+  rw [hcomp, ← Finsupp.apply_linearCombination, AlgHom.toLinearMap_apply] at hl
+  have hzero := shortProj_eq_zero_of_mem_zigzagIdeal k G ((zigzagMk_eq_zero_iff k G).mp hl)
+  rw [Finsupp.apply_linearCombination] at hzero
+  refine linearIndependent_iff.mp (linearIndependent_ofPath_zigzagBasisPath k G hns) l ?_
+  rw [← hzero]
+  exact congrArg (fun f => Finsupp.linearCombination k f l)
+    (funext fun b => (shortProj_ofPath_zigzagBasisPath k G hns b).symm)
+
+/-- **The vertex, arrow and volume classes span.** -/
+theorem span_range_zigzagBasisFun :
+    Submodule.span k (Set.range (zigzagBasisFun k G)) = ⊤ := by
+  have key : ∀ x : Quiver.TotalPath (DoubledQuiver G),
+      zigzagMk k G (ofPath x) ∈ Submodule.span k (Set.range (zigzagBasisFun k G)) := by
+    rintro ⟨a, b, p⟩
+    obtain ⟨i, rfl⟩ : ∃ i, a = vertex G i :=
+      ⟨(vertexEquiv G).symm a, (vertexEquiv_symm_apply G a).symm⟩
+    obtain ⟨j, rfl⟩ : ∃ j, b = vertex G j :=
+      ⟨(vertexEquiv G).symm b, (vertexEquiv_symm_apply G b).symm⟩
+    rcases Nat.lt_or_ge p.length 3 with hlt | hge
+    · have hcases : p.length = 0 ∨ p.length = 1 ∨ p.length = 2 := by omega
+      rcases hcases with hp | hp | hp
+      · obtain rfl : i = j := (vertex_inj G).mp (p.eq_of_length_zero hp)
+        obtain rfl : p = _root_.Quiver.Path.nil := p.eq_nil_of_length_zero hp
+        refine Submodule.subset_span ⟨.inl i, ?_⟩
+        rw [zigzagBasisFun_inl, vertexIdempotent_eq_single, ofPath_eq_single]
+      · obtain ⟨h, rfl⟩ := exists_eq_arrowPath G p hp
+        refine Submodule.subset_span ⟨.inr (.inl ⟨(i, j), h⟩), ?_⟩
+        rw [zigzagBasisFun_inr_inl, ofArrow_eq_ofPath_arrowPath]
+      · rcases eq_or_ne i j with rfl | hij
+        · obtain ⟨j', h, rfl⟩ := exists_eq_backtrackPath G p hp
+          refine Submodule.subset_span ⟨.inr (.inr i), ?_⟩
+          rw [zigzagBasisFun_inr_inr, zigzagVolume_eq_zigzagMk_backtrackElem k G h,
+            backtrackElem_eq_ofPath]
+        · rw [zigzagMk_ofPath_eq_zero_of_ne k G p hp ((vertex_injective G).ne hij)]
+          exact Submodule.zero_mem _
+    · rw [zigzagMk_ofPath_eq_zero_of_three_le k G ⟨_, _, p⟩ hge]
+      exact Submodule.zero_mem _
+  rw [eq_top_iff]
+  rintro x -
+  obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective x
+  rw [← zigzagMk_apply]
+  induction y using PathAlgebra.induction_linear with
+  | zero =>
+    rw [map_zero]
+    exact Submodule.zero_mem _
+  | add y₁ y₂ hy₁ hy₂ =>
+    rw [map_add]
+    exact Submodule.add_mem _ hy₁ hy₂
+  | single z c =>
+    have hz : (single z c : pathAlgebra k (DoubledQuiver G)) = c • ofPath z := by
+      rw [ofPath_eq_single, smul_single, mul_one]
+    rw [hz, map_smul]
+    exact Submodule.smul_mem _ _ (key z)
+
+/-- **The basis of a zigzag algebra.** For a finite simple graph with no isolated vertex the vertex
+idempotents, the oriented edges, and the volume classes are a basis of the zigzag relation
+quotient, homogeneous of path degrees `0`, `1` and `2`. -/
+noncomputable def zigzagBasis (hns : ∀ i : V, ∃ j, G.Adj i j) :
+    Module.Basis (ZigzagBasisIndex G) k (nonisolatedZigzagQuotient k G) :=
+  Module.Basis.mk (linearIndependent_zigzagBasisFun k G hns)
+    (span_range_zigzagBasisFun k G).ge
+
+@[simp]
+theorem zigzagBasis_apply (hns : ∀ i : V, ∃ j, G.Adj i j) (b : ZigzagBasisIndex G) :
+    zigzagBasis k G hns b = zigzagBasisFun k G b :=
+  Module.Basis.mk_apply _ _ _
+
+/-- The volume class of a vertex of a graph with no isolated vertex is nonzero. -/
+theorem zigzagVolume_ne_zero [Nontrivial k] (hns : ∀ i : V, ∃ j, G.Adj i j) (i : V) :
+    zigzagVolume k G i ≠ 0 := by
+  have hne := (zigzagBasis k G hns).ne_zero (.inr (.inr i))
+  rwa [zigzagBasis_apply, zigzagBasisFun_inr_inr] at hne
+
+/-! ### The dimension -/
+
+/-- **The dimension of a zigzag algebra.** A finite simple graph with no isolated vertex has
+`dim Z(G) = 2|V| + 2|E|`: two classes at each vertex and two arrows over each edge. -/
+theorem finrank_nonisolatedZigzagQuotient [Nontrivial k] [Fintype V] [DecidableRel G.Adj]
+    (hns : ∀ i : V, ∃ j, G.Adj i j) :
+    Module.finrank k (nonisolatedZigzagQuotient k G)
+      = 2 * Fintype.card V + 2 * G.edgeFinset.card := by
+  rw [Module.finrank_eq_card_basis (zigzagBasis k G hns)]
+  simp only [ZigzagBasisIndex, Fintype.card_sum, G.dart_card_eq_twice_card_edges]
+  ring
+
+/-- **The dimension of the zigzag algebra of a connected graph.** For a connected graph with at
+least two vertices, `dim Z(G) = 2|V| + 2|E|`: connectedness leaves no isolated vertex. -/
+theorem finrank_nonisolatedZigzagQuotient_of_connected [Nontrivial k] [Fintype V]
+    [DecidableRel G.Adj] (hconn : G.Connected) (hcard : 1 < Fintype.card V) :
+    Module.finrank k (nonisolatedZigzagQuotient k G)
+      = 2 * Fintype.card V + 2 * G.edgeFinset.card :=
+  have : Nontrivial V := Fintype.one_lt_card_iff_nontrivial.mp hcard
+  finrank_nonisolatedZigzagQuotient k G fun i =>
+    SimpleGraph.exists_adj_iff_not_isIsolated.mpr (hconn.preconnected.not_isIsolated i)
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean
@@ -121,6 +121,7 @@ theorem zigzagMk_backtrackElem_eq_zigzagVolume {i j : V} (h : G.Adj i j) :
   (zigzagVolume_eq_zigzagMk_backtrackElem k G h).symm
 
 /-- The volume class of an isolated vertex is the junk value `0`: it carries no backtrack. -/
+@[simp]
 theorem zigzagVolume_eq_zero_of_isIsolated {i : V} (h : G.IsIsolated i) :
     zigzagVolume k G i = 0 := by
   rw [zigzagVolume, dite_eq_right fun hi => SimpleGraph.exists_adj_iff_not_isIsolated.mp hi h]
@@ -244,6 +245,19 @@ private theorem shortProj_sandwich_of_pos {a b c e : DoubledQuiver G}
   rw [_root_.Quiver.Path.length_comp, _root_.Quiver.Path.length_comp]
   omega
 
+/-- Sandwiching a path between composable paths of length zero reduces to the middle path. -/
+private theorem shortProj_sandwich_of_length_zero {a b c e : DoubledQuiver G}
+    (p : _root_.Quiver.Path a b) (r : _root_.Quiver.Path c a) (q : _root_.Quiver.Path e c)
+    (hp : p.length = 0) (hq : q.length = 0) :
+    shortProj k G (ofPath ⟨a, b, p⟩ * ofPath ⟨c, a, r⟩ * ofPath ⟨e, c, q⟩) =
+      shortProj k G (ofPath ⟨c, a, r⟩) := by
+  obtain rfl := p.eq_of_length_zero hp
+  obtain rfl := p.eq_nil_of_length_zero hp
+  obtain rfl := q.eq_of_length_zero hq
+  obtain rfl := q.eq_nil_of_length_zero hq
+  rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
+    _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp]
+
 /-- Sandwiching between two paths a path of length at least two that the coordinate map already
 kills is again killed by the coordinate map. -/
 private theorem shortProj_sandwich_ofPath {a b c d e f : DoubledQuiver G}
@@ -257,12 +271,7 @@ private theorem shortProj_sandwich_ofPath {a b c d e f : DoubledQuiver G}
       rcases Nat.eq_zero_or_pos (p.length + q.length) with hlen | hlen
       · have hp : p.length = 0 := by omega
         have hq : q.length = 0 := by omega
-        obtain rfl := p.eq_of_length_zero hp
-        obtain rfl := p.eq_nil_of_length_zero hp
-        obtain rfl := q.eq_of_length_zero hq
-        obtain rfl := q.eq_nil_of_length_zero hq
-        rwa [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
-          _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp]
+        rw [shortProj_sandwich_of_length_zero k G p r q hp hq, hzero]
       · exact shortProj_sandwich_of_pos k G p r q hr hlen
     · rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_not_composable hfc, map_zero]
   · rw [ofPath_mul_ofPath_of_not_composable hda, zero_mul, map_zero]
@@ -282,13 +291,8 @@ private theorem shortProj_sandwich_sub {a b c e f : DoubledQuiver G}
       rcases Nat.eq_zero_or_pos (p.length + q.length) with hlen | hlen
       · have hp : p.length = 0 := by omega
         have hq : q.length = 0 := by omega
-        obtain rfl := p.eq_of_length_zero hp
-        obtain rfl := p.eq_nil_of_length_zero hp
-        obtain rfl := q.eq_of_length_zero hq
-        obtain rfl := q.eq_nil_of_length_zero hq
-        rw [ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp, ofPath_mul_ofPath_of_comp,
-          ofPath_mul_ofPath_of_comp, _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp,
-          _root_.Quiver.Path.comp_nil, _root_.Quiver.Path.nil_comp,
+        rw [shortProj_sandwich_of_length_zero k G p r₁ q hp hq,
+          shortProj_sandwich_of_length_zero k G p r₂ q hp hq,
           shortProj_ofPath_of_loop k G r₁ h₁, shortProj_ofPath_of_loop k G r₂ h₂, sub_self]
       · rw [shortProj_sandwich_of_pos k G p r₁ q h₁.ge hlen,
           shortProj_sandwich_of_pos k G p r₂ q h₂.ge hlen, sub_zero]

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Relations.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Relations.lean
@@ -104,6 +104,10 @@ noncomputable def quadraticZigzagIdeal : TwoSidedIdeal (pathAlgebra k (DoubledQu
 noncomputable def zigzagIdeal : TwoSidedIdeal (pathAlgebra k (DoubledQuiver G)) :=
   TwoSidedIdeal.span {x | IsZigzagRelator k G x}
 
+/-- The uniform relation ideal is the two-sided span of the uniform relators. -/
+theorem zigzagIdeal_eq_span :
+    zigzagIdeal k G = TwoSidedIdeal.span {x | IsZigzagRelator k G x} := (rfl)
+
 /-- Every quadratic relator lies in the ideal it spans. -/
 theorem mem_quadraticZigzagIdeal_of_isQuadraticZigzagRelator
     {x : pathAlgebra k (DoubledQuiver G)} (hx : IsQuadraticZigzagRelator k G x) :


### PR DESCRIPTION
This PR proves that the vertex idempotents, the oriented edges, and the volume classes form a
basis of the zigzag relation quotient `TauCeti.nonisolatedZigzagQuotient` of a finite simple
graph with no isolated vertex, and reads off `dim Z(G) = 2|V| + 2|E|`. It serves Layer 2 of the
`ZigzagPreprojective` roadmap, "bases, dimensions, centers, and symmetric Frobenius traces",
whose first two clauses ask for exactly the homogeneous vertex/arrow/volume basis in path degrees
`0`, `1`, `2` and for the dimension count; the target signatures `zigzagBasis` and
`finrank_zigzagAlgebra` are the ones prototyped in
`TauCetiRoadmap/ZigzagPreprojective/Suggested.lean`. It builds directly on the relation quotient
landed in #3960 and the doubled-quiver short-path API of #3552 and #3697.

Spanning is immediate from the defining relations: a path of length at least three dies, a
length-two path dies unless it returns to its source, and a returning one is a backtrack, whose
class is the volume of its base vertex. Independence is the substantive half. The path algebra is
free on the paths of the doubled quiver, so a `k`-linear map out of it may be prescribed on paths:
send a path of length at most one to itself, a length-two path returning to its source to a fixed
chosen backtrack at that vertex, and every other path to zero. Sandwiching a relator between two
basis paths either produces a path of length at least three, or — when both outer paths are
trivial — reproduces the relator, so this coordinate map kills every generator of the two-sided
relation ideal and hence the whole ideal, via
`TwoSidedIdeal.mem_span_iff_mem_addSubgroup_closure`. It sends the candidate basis classes to
distinct basis paths of the path algebra, which settles independence.

The hypothesis carried by the basis is that every vertex has a neighbour: an isolated vertex has
no backtrack, so it has no volume class, and `zigzagVolume` takes the junk value `0` there. That
is weaker than the roadmap's connected-and-nontrivial hypothesis, and the connected form is
recovered as a corollary through Mathlib's `SimpleGraph.Preconnected.not_isIsolated`. Spanning
needs no hypothesis at all. Everything is proved over an arbitrary commutative coefficient ring,
with `Nontrivial k` added only where a rank is taken.

New file `TauCeti/RepresentationTheory/Quiver/Zigzag/Basis.lean`, adding
`TauCeti.zigzagVolume` with `TauCeti.zigzagMk_backtrackElem_eq_zigzagVolume` and
`TauCeti.zigzagVolume_eq_zero_of_isIsolated`, `TauCeti.ZigzagBasisIndex`,
`TauCeti.zigzagBasisFun`, `TauCeti.zigzagBasis`, `TauCeti.linearIndependent_zigzagBasisFun`,
`TauCeti.span_range_zigzagBasisFun_eq_top`, `TauCeti.zigzagVolume_ne_zero`,
`TauCeti.finrank_nonisolatedZigzagQuotient` and its preconnected corollary. One two-line accessor
`TauCeti.zigzagIdeal_eq_span` is added to `Zigzag/Relations.lean`, since the relation ideal's
defining span is otherwise not visible outside that module and the coordinate-map argument needs
it. Review also asked for two pieces of shared infrastructure in
`Quiver/PathAlgebra/Basic.lean`: the new `TauCeti.PathAlgebra.single_eq_smul_ofPath`, replacing an
open-coded three-line conversion at every site, and `TauCeti.PathAlgebra.liftLinear` with its two
computation lemmas, previously private, which the coordinate map here is an instance of.

The basis is ungraded: its members are represented by paths of length `0`, `1` and `2`, but the
path grading is not formalised in this repository, so the roadmap clause's homogeneity is stated
nowhere here.

What remains in Layer 2 after this PR: the complete multiplication table with the radical
filtration, socle and top; the Frobenius trace `tr(x_i) = 1` with symmetry and nondegeneracy of
`(x, y) ↦ tr(xy)`; the centre of dimension `|V| + 1`; and the skew-parameter versions of all
three. The public componentwise `ZigzagAlgebra`, with the separate `A₁` dual-numbers convention,
also remains, and is what the `2|V| + 2|E|` count will need for its isolated-vertex correction.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"zigzagbasis"}-->

🤖 Prepared with Claude Code
