### PR TITLE
feat: prove equivariant affine group images normal

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean
@@ -13,10 +13,10 @@ public import TauCeti.Algebra.HopfAlgebra.Kernel
 
 Let `f : H ⟶ K` be a morphism of commutative Hopf algebras over a field, representing a
 homomorphism from `Spec K` to `Spec H`. Its scheme-theoretic image has coordinate algebra
-`H / ker f`. This file proves that the image is normal when the ambient conjugation action on
-`Spec H` lifts to an action on `Spec K` making the homomorphism equivariant.
+`H / ker f`. This file proves that the image is normal when ambient conjugation admits an
+algebra-homomorphic lift along the coordinate map.
 
-In coordinate algebras, a lifted action is an algebra homomorphism
+In coordinate algebras, such a lift is an algebra homomorphism
 
 ```text
 α♯ : K ⟶ H ⊗ K
@@ -87,17 +87,18 @@ private theorem ker_tensorProduct_map_id (f : H →ₐ[k] K) :
     rw [map_zero]
     exact (AlgHom.congr_fun hcomp x).trans hx
   · intro hx
-    change Algebra.TensorProduct.map (AlgHom.id k H) q x = 0 at hx
+    have hx' : Algebra.TensorProduct.map (AlgHom.id k H) q x = 0 := by
+      simpa only [AlgHom.coe_toRingHom] using hx
     rw [← AlgHom.congr_fun hcomp x]
-    simp only [AlgHom.comp_apply, hx, map_zero]
+    simp only [AlgHom.comp_apply, hx', map_zero]
 
 /-- **An equivariant affine-group homomorphism has normal scheme-theoretic image.**
 
 The morphism `f : H →ₐc[k] K` is contravariant: it represents a homomorphism from the
 affine group with coordinate algebra `K` into the ambient group with coordinate algebra `H`.
-The algebra homomorphism `action` represents an action of the ambient group on the source. The
-displayed equality says that `f` intertwines this action with ambient conjugation. Consequently
-the kernel Hopf ideal, and hence the scheme-theoretic image `Spec (H / ker f)`, is normal. -/
+The algebra homomorphism `action` lifts ambient conjugation along `f`; no action-law hypotheses
+are required. Consequently the kernel Hopf ideal, and hence the scheme-theoretic image
+`Spec (H / ker f)`, is normal. -/
 theorem isNormal_ker_of_conjugation_equivariant (f : H →ₐc[k] K)
     (action : K →ₐ[k] H ⊗[k] K)
     (equivariant :

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
+public import TauCeti.Algebra.HopfAlgebra.Kernel
+
+/-!
+# Normal scheme-theoretic images
+
+Let `f : H ⟶ K` be a morphism of commutative Hopf algebras over a field, representing a
+homomorphism from `Spec K` to `Spec H`. Its scheme-theoretic image has coordinate algebra
+`H / ker f`. This file proves that the image is normal when the ambient conjugation action on
+`Spec H` lifts to an action on `Spec K` making the homomorphism equivariant.
+
+In coordinate algebras, a lifted action is an algebra homomorphism
+
+```text
+α♯ : K ⟶ H ⊗ K
+```
+
+such that `(id ⊗ f) ∘ conj♯ = α♯ ∘ f`. If `f(x) = 0`, equivariance says that
+`(id ⊗ f)(conj♯(x)) = 0`. Exactness of tensoring over the ground field identifies this kernel
+with `H ⊗ ker f`, which is precisely normality of the image Hopf ideal.
+
+## Main declaration
+
+* `TauCeti.HopfIdeal.isNormal_ker_of_conjugation_equivariant`: the scheme-theoretic image of an
+  equivariant affine-group homomorphism is normal.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §5.a and §10.20.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §§16--17.
+
+This is the normality prerequisite for Layer 5, "The unipotent radical", of the ReductiveGroups
+roadmap. Applied to multiplication from the semidirect product of two normal closed subgroups,
+the lifted action is simultaneous ambient conjugation and the image is their normal product.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w
+
+namespace HopfIdeal
+
+variable {k : Type u} [Field k]
+variable {H : Type v} {K : Type w}
+variable [CommRing H] [CommRing K]
+variable [HopfAlgebra k H] [HopfAlgebra k K]
+
+/-- Tensoring on the left by an algebra over a field carries the kernel of an algebra map to
+the corresponding right tensor ideal. This local form is used to detect normality from an
+equivariant action. -/
+private theorem ker_tensorProduct_map_id (f : H →ₐ[k] K) :
+    RingHom.ker (Algebra.TensorProduct.map (AlgHom.id k H) f) =
+      rightTensorIdeal (R := k) (H := H) (RingHom.ker f) := by
+  let I := RingHom.ker f
+  let q : H →ₐ[k] H ⧸ I := Ideal.Quotient.mkₐ k I
+  let f' : (H ⧸ I) →ₐ[k] K := Ideal.kerLiftAlg f
+  have hf' : Function.Injective f' := Ideal.kerLiftAlg_injective f
+  have htensor : Function.Injective
+      (Algebra.TensorProduct.map (AlgHom.id k H) f') := by
+    exact TensorProduct.map_injective_of_flat_flat
+      (AlgHom.id k H).toLinearMap f'.toLinearMap Function.injective_id hf'
+  have hcomp :
+      (Algebra.TensorProduct.map (AlgHom.id k H) f').comp
+          (Algebra.TensorProduct.map (AlgHom.id k H) q) =
+        Algebra.TensorProduct.map (AlgHom.id k H) f := by
+    have hright : f'.comp q = f := by
+      ext x
+      exact Ideal.kerLiftAlg_mk f x
+    rw [← Algebra.TensorProduct.map_comp, AlgHom.id_comp, hright]
+  rw [← ker_tensorProduct_map_id_quotient I]
+  ext x
+  rw [RingHom.mem_ker, RingHom.mem_ker]
+  constructor
+  · intro hx
+    apply htensor
+    rw [map_zero]
+    exact (AlgHom.congr_fun hcomp x).trans hx
+  · intro hx
+    change Algebra.TensorProduct.map (AlgHom.id k H) q x = 0 at hx
+    rw [← AlgHom.congr_fun hcomp x]
+    simp only [AlgHom.comp_apply, hx, map_zero]
+
+/-- **An equivariant affine-group homomorphism has normal scheme-theoretic image.**
+
+The morphism `f : H →ₐc[k] K` is contravariant: it represents a homomorphism from the
+affine group with coordinate algebra `K` into the ambient group with coordinate algebra `H`.
+The algebra homomorphism `action` represents an action of the ambient group on the source. The
+displayed equality says that `f` intertwines this action with ambient conjugation. Consequently
+the kernel Hopf ideal, and hence the scheme-theoretic image `Spec (H / ker f)`, is normal. -/
+theorem isNormal_ker_of_conjugation_equivariant (f : H →ₐc[k] K)
+    (action : K →ₐ[k] H ⊗[k] K)
+    (equivariant :
+      (Algebra.TensorProduct.map (AlgHom.id k H) f.toAlgHom).comp
+          (HopfAlgebra.conjugationAlgHom (R := k) (H := H)) =
+        action.comp f.toAlgHom) :
+    (ker f).IsNormal := by
+  rw [isNormal_iff_conjugation_mem]
+  intro x hx
+  rw [ker_toIdeal]
+  rw [← ker_tensorProduct_map_id f.toAlgHom, RingHom.mem_ker]
+  have hfx : f x = 0 := (mem_ker f).mp hx
+  calc
+    Algebra.TensorProduct.map (AlgHom.id k H) f.toAlgHom
+        (HopfAlgebra.conjugationAlgHom (R := k) (H := H) x) =
+        action (f x) := AlgHom.congr_fun equivariant x
+    _ = 0 := by rw [hfx, map_zero]
+
+end HopfIdeal
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean
@@ -35,9 +35,8 @@ with `H ⊗ ker f`, which is precisely normality of the image Hopf ideal.
 
 * J. S. Milne, *Algebraic Groups* (2017), §5.a and §10.20.
 * W. C. Waterhouse, *Introduction to Affine Group Schemes*, §§16--17.
-* The quotient-factoring argument is `ker_lTensor_eq_rightTensorIdeal` from
-  `TauCeti.Algebra.HopfAlgebra.Kernel`, using Mathlib's
-  `TensorProduct.map_injective_of_flat_flat'` for the exactness step.
+* The tensor-kernel identity is `ker_lTensor_eq_rightTensorIdeal` from
+  `TauCeti.Algebra.HopfAlgebra.Kernel`, using Mathlib's `Module.Flat.ker_lTensor_eq`.
 
 This is the normality prerequisite for Layer 5, "The unipotent radical", of the ReductiveGroups
 roadmap. Applied to multiplication from the semidirect product of two normal closed subgroups,

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean
@@ -11,7 +11,7 @@ public import TauCeti.Algebra.HopfAlgebra.Kernel
 /-!
 # Normal scheme-theoretic images
 
-Let `f : H ⟶ K` be a morphism of commutative Hopf algebras over a field, representing a
+Let `f : H →ₐc[k] K` be a morphism of commutative Hopf algebras over a field, representing a
 homomorphism from `Spec K` to `Spec H`. Its scheme-theoretic image has coordinate algebra
 `H / ker f`. This file proves that the image is normal when ambient conjugation admits an
 algebra-homomorphic lift along the coordinate map.
@@ -19,7 +19,7 @@ algebra-homomorphic lift along the coordinate map.
 In coordinate algebras, such a lift is an algebra homomorphism
 
 ```text
-α♯ : K ⟶ H ⊗ K
+α♯ : K →ₐ[k] H ⊗[k] K
 ```
 
 such that `(id ⊗ f) ∘ conj♯ = α♯ ∘ f`. If `f(x) = 0`, equivariance says that
@@ -35,6 +35,9 @@ with `H ⊗ ker f`, which is precisely normality of the image Hopf ideal.
 
 * J. S. Milne, *Algebraic Groups* (2017), §5.a and §10.20.
 * W. C. Waterhouse, *Introduction to Affine Group Schemes*, §§16--17.
+* The quotient-factoring argument is `ker_lTensor_eq_rightTensorIdeal` from
+  `TauCeti.Algebra.HopfAlgebra.Kernel`, using Mathlib's
+  `TensorProduct.map_injective_of_flat_flat'` for the exactness step.
 
 This is the normality prerequisite for Layer 5, "The unipotent radical", of the ReductiveGroups
 roadmap. Applied to multiplication from the semidirect product of two normal closed subgroups,
@@ -56,65 +59,29 @@ variable {H : Type v} {K : Type w}
 variable [CommRing H] [CommRing K]
 variable [HopfAlgebra k H] [HopfAlgebra k K]
 
-/-- Tensoring on the left by an algebra over a field carries the kernel of an algebra map to
-the corresponding right tensor ideal. This local form is used to detect normality from an
-equivariant action. -/
-private theorem ker_tensorProduct_map_id (f : H →ₐ[k] K) :
-    RingHom.ker (Algebra.TensorProduct.map (AlgHom.id k H) f) =
-      rightTensorIdeal (R := k) (H := H) (RingHom.ker f) := by
-  let I := RingHom.ker f
-  let q : H →ₐ[k] H ⧸ I := Ideal.Quotient.mkₐ k I
-  let f' : (H ⧸ I) →ₐ[k] K := Ideal.kerLiftAlg f
-  have hf' : Function.Injective f' := Ideal.kerLiftAlg_injective f
-  have htensor : Function.Injective
-      (Algebra.TensorProduct.map (AlgHom.id k H) f') := by
-    exact TensorProduct.map_injective_of_flat_flat
-      (AlgHom.id k H).toLinearMap f'.toLinearMap Function.injective_id hf'
-  have hcomp :
-      (Algebra.TensorProduct.map (AlgHom.id k H) f').comp
-          (Algebra.TensorProduct.map (AlgHom.id k H) q) =
-        Algebra.TensorProduct.map (AlgHom.id k H) f := by
-    have hright : f'.comp q = f := by
-      ext x
-      exact Ideal.kerLiftAlg_mk f x
-    rw [← Algebra.TensorProduct.map_comp, AlgHom.id_comp, hright]
-  rw [← ker_tensorProduct_map_id_quotient I]
-  ext x
-  rw [RingHom.mem_ker, RingHom.mem_ker]
-  constructor
-  · intro hx
-    apply htensor
-    rw [map_zero]
-    exact (AlgHom.congr_fun hcomp x).trans hx
-  · intro hx
-    have hx' : Algebra.TensorProduct.map (AlgHom.id k H) q x = 0 := by
-      simpa only [AlgHom.coe_toRingHom] using hx
-    rw [← AlgHom.congr_fun hcomp x]
-    simp only [AlgHom.comp_apply, hx', map_zero]
-
 /-- **An equivariant affine-group homomorphism has normal scheme-theoretic image.**
 
 The morphism `f : H →ₐc[k] K` is contravariant: it represents a homomorphism from the
 affine group with coordinate algebra `K` into the ambient group with coordinate algebra `H`.
-The algebra homomorphism `action` lifts ambient conjugation along `f`; no action-law hypotheses
+The algebra homomorphism `conjLift` lifts ambient conjugation along `f`; no action-law hypotheses
 are required. Consequently the kernel Hopf ideal, and hence the scheme-theoretic image
 `Spec (H / ker f)`, is normal. -/
 theorem isNormal_ker_of_conjugation_equivariant (f : H →ₐc[k] K)
-    (action : K →ₐ[k] H ⊗[k] K)
-    (equivariant :
+    (conjLift : K →ₐ[k] H ⊗[k] K)
+    (hequiv :
       (Algebra.TensorProduct.map (AlgHom.id k H) f.toAlgHom).comp
           (HopfAlgebra.conjugationAlgHom (R := k) (H := H)) =
-        action.comp f.toAlgHom) :
+        conjLift.comp f.toAlgHom) :
     (ker f).IsNormal := by
   rw [isNormal_iff_conjugation_mem]
   intro x hx
   rw [ker_toIdeal]
-  rw [← ker_tensorProduct_map_id f.toAlgHom, RingHom.mem_ker]
+  rw [← ker_lTensor_eq_rightTensorIdeal f.toAlgHom, RingHom.mem_ker]
   have hfx : f x = 0 := (mem_ker f).mp hx
   calc
     Algebra.TensorProduct.map (AlgHom.id k H) f.toAlgHom
         (HopfAlgebra.conjugationAlgHom (R := k) (H := H) x) =
-        action (f x) := AlgHom.congr_fun equivariant x
+        conjLift (f x) := AlgHom.congr_fun hequiv x
     _ = 0 := by rw [hfx, map_zero]
 
 end HopfIdeal

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import Mathlib.LinearAlgebra.TensorProduct.RightExactness
-public import Mathlib.RingTheory.Flat.Basic
+public import Mathlib.RingTheory.Flat.Equalizer
 public import TauCeti.Algebra.Bialgebra.Quotient
 public import TauCeti.Algebra.HopfAlgebra.Basic
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Basic
@@ -44,8 +44,8 @@ dictionary.
 
 ## References
 
-The construction is the standard kernel Hopf ideal. The tensor-kernel exactness step uses
-Mathlib's `Algebra.TensorProduct.map_ker`.
+The construction is the standard kernel Hopf ideal. The tensor-kernel exactness steps use
+Mathlib's `Algebra.TensorProduct.map_ker` and `Module.Flat.ker_lTensor_eq`.
 -/
 
 public section
@@ -77,32 +77,23 @@ private theorem tensor_map_ker_eq_left_sup_right [Algebra R H] {A : Type*} [Ring
   apply congr_arg₂ (· ⊔ ·) <;> rfl
 
 /-- Tensoring on the left by a flat algebra carries the kernel of an algebra map to the
-corresponding right tensor ideal, provided the codomain is flat. -/
+corresponding right tensor ideal. -/
 theorem ker_lTensor_eq_rightTensorIdeal {A B : Type*} [CommRing A] [CommRing B]
-    [Algebra R A] [Algebra R B] [Module.Flat R A] [Module.Flat R B] (f : A →ₐ[R] B) :
+    [Algebra R A] [Algebra R B] [Module.Flat R A] (f : A →ₐ[R] B) :
     RingHom.ker (Algebra.TensorProduct.map (AlgHom.id R A) f) =
       rightTensorIdeal (R := R) (H := A) (RingHom.ker f) := by
-  let I := RingHom.ker f
-  let q : A →ₐ[R] A ⧸ I := Ideal.Quotient.mkₐ R I
-  let f' : (A ⧸ I) →ₐ[R] B := Ideal.kerLiftAlg f
-  have hf' : Function.Injective f' := Ideal.kerLiftAlg_injective f
-  have htensor : Function.Injective
-      (Algebra.TensorProduct.map (AlgHom.id R A) f') := by
-    have h := TensorProduct.map_injective_of_flat_flat'
-      (AlgHom.id R A).toLinearMap f'.toLinearMap Function.injective_id hf'
-    rw [← TensorProduct.AlgebraTensorModule.map_eq,
-      ← Algebra.TensorProduct.toLinearMap_map] at h
-    exact h
-  have hcomp :
-      (Algebra.TensorProduct.map (AlgHom.id R A) f').comp
-          (Algebra.TensorProduct.map (AlgHom.id R A) q) =
-        Algebra.TensorProduct.map (AlgHom.id R A) f := by
-    have hright : f'.comp q = f := by
-      ext x
-      exact Ideal.kerLiftAlg_mk f x
-    rw [← Algebra.TensorProduct.map_comp, AlgHom.id_comp, hright]
-  rw [← ker_tensorProduct_map_id_quotient I, ← hcomp]
-  exact RingHom.ker_comp_of_injective _ htensor
+  rw [← Submodule.restrictScalars_inj R]
+  change LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor R A f.toLinearMap) = _
+  rw [Module.Flat.ker_lTensor_eq]
+  have hker : f.toLinearMap.ker = (RingHom.ker f).restrictScalars R := rfl
+  rw [hker]
+  have hsubtype : ((RingHom.ker f).restrictScalars R).subtype =
+      (RingHom.ker f).subtype.restrictScalars R := by
+    ext
+    rfl
+  rw [hsubtype, rightTensorIdeal_def]
+  exact TensorProduct.AlgebraTensorModule.range_lTensor_idealMap
+    (R := R) A R (RingHom.ker f)
 
 variable [HopfAlgebra R H] [HopfAlgebra R K]
 

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -83,14 +83,32 @@ theorem ker_lTensor_eq_rightTensorIdeal {A B : Type*} [CommRing A] [CommRing B]
     RingHom.ker (Algebra.TensorProduct.map (AlgHom.id R A) f) =
       rightTensorIdeal (R := R) (H := A) (RingHom.ker f) := by
   rw [← Submodule.restrictScalars_inj R]
-  change LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor R A f.toLinearMap) = _
+  have hmap :
+      (RingHom.ker (Algebra.TensorProduct.map (AlgHom.id R A) f)).restrictScalars R =
+        LinearMap.ker (TensorProduct.AlgebraTensorModule.lTensor R A f.toLinearMap) := by
+    have hlinear :
+        (Algebra.TensorProduct.map (AlgHom.id R A) f).toLinearMap =
+          TensorProduct.AlgebraTensorModule.lTensor R A f.toLinearMap := by
+      apply TensorProduct.AlgebraTensorModule.ext
+      intro x y
+      simp only [Algebra.TensorProduct.toLinearMap_map, AlgHom.toLinearMap_id,
+        TensorProduct.AlgebraTensorModule.map_tmul,
+        TensorProduct.AlgebraTensorModule.lTensor_tmul, LinearMap.id_apply]
+    ext x
+    simp only [Submodule.restrictScalars_mem, RingHom.mem_ker, LinearMap.mem_ker]
+    rw [← LinearMap.congr_fun hlinear x]
+    simp only [AlgHom.toLinearMap_apply]
+  rw [hmap]
   rw [Module.Flat.ker_lTensor_eq]
-  have hker : f.toLinearMap.ker = (RingHom.ker f).restrictScalars R := rfl
+  have hker : f.toLinearMap.ker = (RingHom.ker f).restrictScalars R := by
+    ext x
+    simp only [LinearMap.mem_ker, Submodule.restrictScalars_mem, RingHom.mem_ker,
+      AlgHom.toLinearMap_apply]
   rw [hker]
   have hsubtype : ((RingHom.ker f).restrictScalars R).subtype =
       (RingHom.ker f).subtype.restrictScalars R := by
-    ext
-    rfl
+    ext x
+    exact (LinearMap.restrictScalars_apply R (RingHom.ker f).subtype x).symm
   rw [hsubtype, rightTensorIdeal_def]
   exact TensorProduct.AlgebraTensorModule.range_lTensor_idealMap
     (R := R) A R (RingHom.ker f)

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -39,6 +39,8 @@ dictionary.
   by the kernel to the codomain.
 * `TauCeti.HopfIdeal.kerOfSurjective_mkBialgHom`: the kernel of the quotient morphism by `I`
   is `I`.
+* `TauCeti.HopfIdeal.ker_lTensor_eq_rightTensorIdeal`: tensoring on the left by a flat algebra
+  carries the kernel of an algebra map to the corresponding right tensor ideal.
 
 ## References
 
@@ -73,6 +75,34 @@ private theorem tensor_map_ker_eq_left_sup_right [Algebra R H] {A : Type*} [Ring
   -- and `rightTensorIdeal_def` use their `toRingHom`; after the named coercion rewrite
   -- these are the same ideal maps definitionally.
   apply congr_arg₂ (· ⊔ ·) <;> rfl
+
+/-- Tensoring on the left by a flat algebra carries the kernel of an algebra map to the
+corresponding right tensor ideal, provided the codomain is flat. -/
+theorem ker_lTensor_eq_rightTensorIdeal {A B : Type*} [CommRing A] [CommRing B]
+    [Algebra R A] [Algebra R B] [Module.Flat R A] [Module.Flat R B] (f : A →ₐ[R] B) :
+    RingHom.ker (Algebra.TensorProduct.map (AlgHom.id R A) f) =
+      rightTensorIdeal (R := R) (H := A) (RingHom.ker f) := by
+  let I := RingHom.ker f
+  let q : A →ₐ[R] A ⧸ I := Ideal.Quotient.mkₐ R I
+  let f' : (A ⧸ I) →ₐ[R] B := Ideal.kerLiftAlg f
+  have hf' : Function.Injective f' := Ideal.kerLiftAlg_injective f
+  have htensor : Function.Injective
+      (Algebra.TensorProduct.map (AlgHom.id R A) f') := by
+    have h := TensorProduct.map_injective_of_flat_flat'
+      (AlgHom.id R A).toLinearMap f'.toLinearMap Function.injective_id hf'
+    rw [← TensorProduct.AlgebraTensorModule.map_eq,
+      ← Algebra.TensorProduct.toLinearMap_map] at h
+    exact h
+  have hcomp :
+      (Algebra.TensorProduct.map (AlgHom.id R A) f').comp
+          (Algebra.TensorProduct.map (AlgHom.id R A) q) =
+        Algebra.TensorProduct.map (AlgHom.id R A) f := by
+    have hright : f'.comp q = f := by
+      ext x
+      exact Ideal.kerLiftAlg_mk f x
+    rw [← Algebra.TensorProduct.map_comp, AlgHom.id_comp, hright]
+  rw [← ker_tensorProduct_map_id_quotient I, ← hcomp]
+  exact RingHom.ker_comp_of_injective _ htensor
 
 variable [HopfAlgebra R H] [HopfAlgebra R K]
 


### PR DESCRIPTION
This PR proves that an equivariant homomorphism of affine groups has normal scheme-theoretic image. In Hopf coordinates, if `f : H ⟶ K` intertwines ambient conjugation on `H` with a conjugation lift `K ⟶ H ⊗ K`, then `HopfIdeal.ker f` is normal, so `Spec (H / ker f)` is a normal closed subgroup of `Spec H`.

It advances the exact ReductiveGroups Layer 5 milestone “The unipotent radical `R_u(G)`,” specifically the normality step in the binary-product construction consumed by `HopfIdeal.IsUnipotentRadicalCandidate`. The product of two normal connected smooth unipotent subgroup schemes is formed as the scheme-theoretic image of multiplication from their conjugation semidirect product; the multiplication morphism in open PR #4154 is equivariant for simultaneous ambient conjugation, and the theorem here converts that equation into normality of its kernel ideal. This is the most effective distinct step because connectedness and smoothness of affine-group images are already on `main`, image unipotence is covered separately by #4139, and #4154 explicitly leaves image normality outside its scope.

`TauCeti.HopfIdeal.isNormal_ker_of_conjugation_equivariant` uses exactly the datum its conclusion needs: an algebra homomorphism lifting conjugation and its equivariance equation, with no unnecessary action-law or finite-type hypotheses. The proof factors the underlying algebra map through its kernel quotient. Tensoring the injective quotient factor remains injective over the field, so the kernel of `id ⊗ f` is exactly `H ⊗ ker f`; equivariance then sends every element of `ker f` into that right tensor ideal, which is the defining normality criterion.

After this PR, the Layer 5 binary-product step still needs the simultaneous-conjugation lift and equivariance equation instantiated for the semidirect multiplication map after #4154 lands, faithful flatness onto the scheme-theoretic image, the unipotence result in #4139, and the maximal-dimension argument proving the resulting candidate contains every other candidate.

Adds `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Image.lean` (121 lines). The proof reuses Mathlib’s `Ideal.kerLiftAlg`, `TensorProduct.map_injective_of_flat_flat`, and Tau Ceti’s tensor-product quotient-kernel and Hopf-ideal normality APIs; no Mathlib infrastructure or external formalization is vendored. The mathematical statement follows Milne, *Algebraic Groups* (2017), §§5.a and 10.20, and Waterhouse, *Introduction to Affine Group Schemes*, §§16–17, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"equivariant-image-normal"}-->

🤖 Prepared with Codex
