### PR TITLE
refactor(EllipticCurve): integral closedness relative to K, not a fraction field

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -34,8 +34,9 @@ arbitrary `R`-algebra, with the fraction-field version as a corollary.
   leading coefficient.
 * `TauCeti.WeierstrassCurve.isIntegral_y_of_equation_of_isIntegral_x`: over **any** `R`-algebra, a
   point whose `x`-coordinate is integral over `R` has `y`-coordinate integral over `R`.
-* `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x`: its fraction-field corollary,
-  the shape the Nagell–Lutz argument consumes.
+* `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x`: its `IsLocalization.IsInteger`
+  corollary over any `K` in which `R` is integrally closed, the shape the Nagell–Lutz argument
+  consumes.
 
 Both are stated for an arbitrary point: no torsion, ellipticity or minimality hypothesis. In the
 Nagell–Lutz argument the polynomial `f` is a division polynomial, whose leading coefficient is the
@@ -104,22 +105,27 @@ theorem isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff
 
 end UniqueFactorization
 
-section IntegrallyClosed
+end FractionField
 
-variable [IsIntegrallyClosed R]
+section IntegrallyClosedIn
 
-/-- **On the curve over a fraction field, an integral `x`-coordinate forces an integral
-`y`-coordinate.** The `IsLocalization.IsInteger` form of `isIntegral_y_of_equation_of_isIntegral_x`,
-which is the shape the Nagell–Lutz argument consumes. -/
+variable {K : Type*} [Field K] [Algebra R K] [IsIntegrallyClosedIn R K] {x y : K}
+
+/-- **On the curve, an integral `x`-coordinate forces an integral `y`-coordinate.** The
+`IsLocalization.IsInteger` form of `isIntegral_y_of_equation_of_isIntegral_x`, which is the shape
+the Nagell–Lutz argument consumes.
+
+`K` need not be a fraction field of `R`: integral closedness **relative to `K`** is what the
+argument uses, and it is strictly weaker than `[IsIntegrallyClosed R] [IsFractionRing R K]` —
+those two imply it (`isIntegrallyClosed_iff_isIntegrallyClosedIn`, and Mathlib supplies the
+instance), but not conversely. -/
 theorem isInteger_y_of_equation_of_isInteger_x (h : (W.baseChange K).toAffine.Equation x y)
     (hx : IsLocalization.IsInteger R x) : IsLocalization.IsInteger R y := by
   obtain ⟨x₀, hx₀⟩ := hx
-  exact RingHom.mem_rangeS.mpr (IsIntegrallyClosed.isIntegral_iff.mp
+  exact RingHom.mem_rangeS.mpr (IsIntegrallyClosedIn.isIntegral_iff.mp
     (isIntegral_y_of_equation_of_isIntegral_x W h (hx₀ ▸ isIntegral_algebraMap)))
 
-end IntegrallyClosed
-
-end FractionField
+end IntegrallyClosedIn
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -25,7 +25,8 @@ denominator at all, so `den x` is a unit and `x` is integral.
 The second is a consequence of the curve equation alone: once `x` comes from `R`, `y` is a root of
 the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)` over `R`, so `y` is integral over
 `R`. That step needs no domain, fraction-field or factorisation hypothesis, so it is stated over an
-arbitrary `R`-algebra, with the fraction-field version as a corollary.
+arbitrary `R`-algebra, with the `IsLocalization.IsInteger` form as a corollary over any commutative
+`R`-algebra in which `R` is integrally closed.
 
 ## Main results
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -35,8 +35,8 @@ arbitrary `R`-algebra, with the fraction-field version as a corollary.
 * `TauCeti.WeierstrassCurve.isIntegral_y_of_equation_of_isIntegral_x`: over **any** `R`-algebra, a
   point whose `x`-coordinate is integral over `R` has `y`-coordinate integral over `R`.
 * `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x`: its `IsLocalization.IsInteger`
-  corollary over any `K` in which `R` is integrally closed, the shape the Nagell–Lutz argument
-  consumes.
+  corollary over any commutative `R`-algebra in which `R` is integrally closed, the shape the
+  Nagell–Lutz argument consumes.
 
 Both are stated for an arbitrary point: no torsion, ellipticity or minimality hypothesis. In the
 Nagell–Lutz argument the polynomial `f` is a division polynomial, whose leading coefficient is the
@@ -109,16 +109,17 @@ end FractionField
 
 section IntegrallyClosedIn
 
-variable {K : Type*} [Field K] [Algebra R K] [IsIntegrallyClosedIn R K] {x y : K}
+variable {K : Type*} [CommRing K] [Algebra R K] [IsIntegrallyClosedIn R K] {x y : K}
 
 /-- **On the curve, an integral `x`-coordinate forces an integral `y`-coordinate.** The
 `IsLocalization.IsInteger` form of `isIntegral_y_of_equation_of_isIntegral_x`, which is the shape
 the Nagell–Lutz argument consumes.
 
-`K` need not be a fraction field of `R`: integral closedness **relative to `K`** is what the
-argument uses, and it is strictly weaker than `[IsIntegrallyClosed R] [IsFractionRing R K]` —
-those two imply it (`isIntegrallyClosed_iff_isIntegrallyClosedIn`, and Mathlib supplies the
-instance), but not conversely. -/
+`K` need not be a fraction field of `R`, nor even a field: integral closedness **relative to `K`**
+is what the argument uses, over any commutative `R`-algebra. It is strictly weaker than
+`[IsIntegrallyClosed R] [IsFractionRing R K]` — those two imply it
+(`isIntegrallyClosed_iff_isIntegrallyClosedIn`, and Mathlib supplies the instance), but not
+conversely. -/
 theorem isInteger_y_of_equation_of_isInteger_x (h : (W.baseChange K).toAffine.Equation x y)
     (hx : IsLocalization.IsInteger R x) : IsLocalization.IsInteger R y := by
   obtain ⟨x₀, hx₀⟩ := hx


### PR DESCRIPTION
`isInteger_y_of_equation_of_isInteger_x` asked for more than its proof uses. One file, one
signature, no new declarations.

```lean
-- before: variable [IsFractionRing R K] … [IsIntegrallyClosed R]
-- after:  variable [IsIntegrallyClosedIn R K]
theorem isInteger_y_of_equation_of_isInteger_x (h : (W.baseChange K).toAffine.Equation x y)
    (hx : IsLocalization.IsInteger R x) : IsLocalization.IsInteger R y
```

## The hypotheses were never used

The proof has two steps and neither needs a fraction field:

- `isIntegral_y_of_equation_of_isIntegral_x` (same file, `:71`) is stated over `{A} [CommRing A]
  [Algebra R A]` — no closedness, no localisation.
- the closing step was `IsIntegrallyClosed.isIntegral_iff`, which is *itself* defined as
  `IsIntegrallyClosedIn.isIntegral_iff` in
  `Mathlib/RingTheory/IntegralClosure/IntegrallyClosed.lean:248`.

So the general form was one identifier away the whole time. The theorem moves out of
`section FractionField` into its own section carrying only `[Field K] [Algebra R K]
[IsIntegrallyClosedIn R K]`.

## Strictly weaker, and verified so

`isIntegrallyClosed_iff_isIntegrallyClosedIn` is an `iff` **only given `IsFractionRing R K`**, so
the old pair implies the new hypothesis and not conversely. `K` no longer has to be `R`'s fraction
field — the statement now says what it means: `R` is integrally closed *in the ring the
coordinates live in*.

## No caller has to change

Checked before writing the change rather than discovering it in review: Mathlib supplies

```lean
instance [iic : IsIntegrallyClosed R] : IsIntegralClosure R R K   -- IntegrallyClosed.lean:241
```

and `IsIntegrallyClosedIn R K` is an `abbrev` for `IsIntegralClosure R R K`. So any existing
context with `[IsIntegrallyClosed R] [IsFractionRing R K]` still discharges the new hypothesis by
instance search. There are no call sites in `main` today; the consumers are in flight
(`DivisionPolynomial/Torsion.lean` in #4084, and #4088's `Descent.lean`), and both keep working.

## Why now, and why this file

#4088 weakened `isInteger_of_zsmul_isInteger` to `[IsIntegrallyClosedIn R K]` at `generality`'s
request. It could only do that by **bypassing** this lemma and calling
`isIntegral_y_of_equation_of_isIntegral_x` directly with `IsIntegrallyClosedIn.isIntegral_iff`
inline. This PR applies the same weakening at the source, so the bypass becomes unnecessary and
the `y`-coordinate step is named again rather than re-derived at each site.

`Integrality.lean` is touched by none of the four in-flight elliptic PRs, so this lands
independently of them.

## Gates

`lake build` PASS — `BUILD_EXIT=0` **and zero `error` lines in the whole log**, not a tail read;
that distinction cost a round earlier today when a log still being written showed a stale success
line above a real failure. `scripts/lint-env.sh` PASS (64 grandfathered / 6 ratchetable,
unchanged). `scripts/lint-dot-notation.py` **0 new**. Residue zero on code lines for `sorry`,
`native_decide`, `maxHeartbeats`, `#check`, `#eval`, `haveI`, `letI`, `erw`, `lia`, against a live
control (`theorem` 3) — measured with comment regions stripped, because this file's prose
discusses the tokens being audited. Max line width 100 codepoints; file 133 lines.

`/cleanup`: audit clean — copyright and module docstring present, no `set_option`, no `λ`/`$`/
`push_neg`, LSP diagnostics empty on the file. Per-declaration golf and `/buzz` are **n/a**: the
change is a signature weakening plus a section move; the proof body is unchanged except for the
one identifier, and it is four lines. The module docstring's description of this theorem is
updated to match — it previously called it "its fraction-field corollary", which is no longer
what it is.

Post-bump pin, mathlib `79cba2e8b532`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"integrality-closed-in"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
