### PR TITLE
feat: the real error function and the Gaussian cumulative distribution function

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Erf.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Erf.lean
@@ -108,7 +108,7 @@ theorem continuous_erf : Continuous erf := differentiable_erf.continuous
 `-(2 / √π * exp (-x ^ 2))`. -/
 theorem hasStrictDerivAt_erfc (x : ℝ) :
     HasStrictDerivAt erfc (-(2 / √π * rexp (-x ^ 2))) x := by
-  rw [show erfc = fun y => 1 - erf y from rfl]
+  rw [funext erfc_def]
   exact (hasStrictDerivAt_erf x).const_sub 1
 
 /-- The derivative of the complementary error function. -/

--- a/TauCeti/Analysis/SpecialFunctions/Erf.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Erf.lean
@@ -59,10 +59,6 @@ theorem erf_def (x : ℝ) : erf x = 2 / √π * ∫ t in (0 : ℝ)..x, rexp (-t 
 /-- The defining formula for the complementary error function. -/
 theorem erfc_def (x : ℝ) : erfc x = 1 - erf x := (rfl)
 
-/-- The Gaussian kernel `t ↦ exp (-t ^ 2)` is continuous. -/
-@[fun_prop]
-theorem continuous_exp_neg_sq : Continuous fun t : ℝ => rexp (-t ^ 2) := by fun_prop
-
 /-- The error function vanishes at the origin. -/
 @[simp]
 theorem erf_zero : erf 0 = 0 := by simp [erf_def]
@@ -89,7 +85,8 @@ theorem erfc_neg (x : ℝ) : erfc (-x) = 2 - erfc x := by
 
 /-- The error function is strictly differentiable, with derivative `2 / √π * exp (-x ^ 2)`. -/
 theorem hasStrictDerivAt_erf (x : ℝ) : HasStrictDerivAt erf (2 / √π * rexp (-x ^ 2)) x :=
-  (continuous_exp_neg_sq.integral_hasStrictDerivAt 0 x).const_mul (2 / √π)
+  ((by fun_prop : Continuous fun t : ℝ => rexp (-t ^ 2)).integral_hasStrictDerivAt 0 x).const_mul
+    (2 / √π)
 
 /-- The derivative of the error function. -/
 theorem hasDerivAt_erf (x : ℝ) : HasDerivAt erf (2 / √π * rexp (-x ^ 2)) x :=
@@ -111,7 +108,7 @@ theorem continuous_erf : Continuous erf := differentiable_erf.continuous
 `-(2 / √π * exp (-x ^ 2))`. -/
 theorem hasStrictDerivAt_erfc (x : ℝ) :
     HasStrictDerivAt erfc (-(2 / √π * rexp (-x ^ 2))) x := by
-  change HasStrictDerivAt (fun y => 1 - erf y) (-(2 / √π * rexp (-x ^ 2))) x
+  rw [show erfc = fun y => 1 - erf y from rfl]
   exact (hasStrictDerivAt_erf x).const_sub 1
 
 /-- The derivative of the complementary error function. -/

--- a/TauCeti/Analysis/SpecialFunctions/Erf.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Erf.lean
@@ -1,0 +1,204 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+
+/-!
+# The error function
+
+This file defines the Gauss error function `erf x = (2 / √π) * ∫ t in 0..x, exp (-t ^ 2)` and its
+complement `erfc x = 1 - erf x`, and develops their elementary real-variable theory: oddness,
+strict monotonicity, the derivative, and the limits at both infinities.
+
+These are the error-function targets of `TauCetiRoadmap/StandardDistributions/README.md`,
+Layer 2.  The names and statement shapes follow those proposed for Mathlib in
+[mathlib4#34053](https://github.com/leanprover-community/mathlib4/pull/34053), so that the
+declarations here can be replaced by Mathlib's once it provides them.  The identification
+`erf x = regularizedGamma (1 / 2) (x ^ 2)` needs the incomplete gamma function and is not proved
+here.
+
+The limits at infinity come from Mathlib's Gaussian integral `integral_gaussian_Ioi` together
+with the improper-integral comparison `MeasureTheory.intervalIntegral_tendsto_integral_Ioi`; the
+derivative is the fundamental theorem of calculus for a continuous integrand.
+
+## Main declarations
+
+* `TauCeti.Real.erf` and `TauCeti.Real.erfc` — the error function and its complement.
+* `TauCeti.Real.erf_neg` — the error function is odd.
+* `TauCeti.Real.hasDerivAt_erf` — its derivative is `2 / √π * exp (-x ^ 2)`.
+* `TauCeti.Real.strictMono_erf` — it is strictly monotone.
+* `TauCeti.Real.tendsto_erf_atTop` and `TauCeti.Real.tendsto_erf_atBot` — its limits are `1` and
+  `-1`, whence `TauCeti.Real.abs_erf_lt_one`.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Filter Set Real
+open scoped Topology
+
+namespace TauCeti
+
+namespace Real
+
+/-- The Gauss error function, `erf x = (2 / √π) * ∫ t in 0..x, exp (-t ^ 2)`. -/
+def erf (x : ℝ) : ℝ := 2 / √π * ∫ t in (0 : ℝ)..x, rexp (-t ^ 2)
+
+/-- The complementary error function, `erfc x = 1 - erf x`. -/
+def erfc (x : ℝ) : ℝ := 1 - erf x
+
+/-- The defining integral formula for the error function. -/
+theorem erf_def (x : ℝ) : erf x = 2 / √π * ∫ t in (0 : ℝ)..x, rexp (-t ^ 2) := (rfl)
+
+/-- The defining formula for the complementary error function. -/
+theorem erfc_def (x : ℝ) : erfc x = 1 - erf x := (rfl)
+
+/-- The complementary error function as a function, for rewriting under binders. -/
+theorem erfc_eq_one_sub_erf : erfc = fun x => 1 - erf x := funext erfc_def
+
+/-- The Gaussian kernel `t ↦ exp (-t ^ 2)` is continuous. -/
+@[fun_prop]
+theorem continuous_exp_neg_sq : Continuous fun t : ℝ => rexp (-t ^ 2) := by fun_prop
+
+/-- The Gaussian kernel `t ↦ exp (-t ^ 2)` is integrable. -/
+theorem integrable_exp_neg_sq : Integrable fun t : ℝ => rexp (-t ^ 2) := by
+  simpa using integrable_exp_neg_mul_sq (b := 1) one_pos
+
+/-- The error function vanishes at the origin. -/
+@[simp]
+theorem erf_zero : erf 0 = 0 := by simp [erf_def]
+
+/-- The complementary error function is `1` at the origin. -/
+@[simp]
+theorem erfc_zero : erfc 0 = 1 := by simp [erfc_def]
+
+/-- The error function is odd. -/
+theorem erf_neg (x : ℝ) : erf (-x) = -erf x := by
+  have h : (∫ t in (0 : ℝ)..x, rexp (-t ^ 2)) = ∫ t in (-x)..(0 : ℝ), rexp (-t ^ 2) := by
+    have hcomp := intervalIntegral.integral_comp_neg (a := (0 : ℝ)) (b := x)
+      fun t : ℝ => rexp (-t ^ 2)
+    simp only [neg_sq, neg_zero] at hcomp
+    exact hcomp
+  rw [erf_def, erf_def, h, intervalIntegral.integral_symm]
+  ring
+
+/-- The complementary error function reflects around the value `1`. -/
+theorem erfc_neg (x : ℝ) : erfc (-x) = 2 - erfc x := by
+  rw [erfc_def, erfc_def, erf_neg]; ring
+
+/-- The error function is strictly differentiable, with derivative `2 / √π * exp (-x ^ 2)`. -/
+theorem hasStrictDerivAt_erf (x : ℝ) : HasStrictDerivAt erf (2 / √π * rexp (-x ^ 2)) x :=
+  (continuous_exp_neg_sq.integral_hasStrictDerivAt 0 x).const_mul (2 / √π)
+
+/-- The derivative of the error function. -/
+theorem hasDerivAt_erf (x : ℝ) : HasDerivAt erf (2 / √π * rexp (-x ^ 2)) x :=
+  (hasStrictDerivAt_erf x).hasDerivAt
+
+/-- The derivative of the error function, in `deriv` form. -/
+@[simp]
+theorem deriv_erf : deriv erf = fun x => 2 / √π * rexp (-x ^ 2) :=
+  funext fun x => (hasDerivAt_erf x).deriv
+
+/-- The error function is differentiable. -/
+theorem differentiable_erf : Differentiable ℝ erf := fun x => (hasDerivAt_erf x).differentiableAt
+
+/-- The error function is continuous. -/
+@[fun_prop]
+theorem continuous_erf : Continuous erf := differentiable_erf.continuous
+
+/-- The derivative of the complementary error function. -/
+theorem hasDerivAt_erfc (x : ℝ) : HasDerivAt erfc (-(2 / √π * rexp (-x ^ 2))) x := by
+  simpa only [erfc_eq_one_sub_erf] using (hasDerivAt_erf x).const_sub 1
+
+/-- The complementary error function is differentiable. -/
+theorem differentiable_erfc : Differentiable ℝ erfc := fun x =>
+  (hasDerivAt_erfc x).differentiableAt
+
+/-- The complementary error function is continuous. -/
+@[fun_prop]
+theorem continuous_erfc : Continuous erfc := differentiable_erfc.continuous
+
+/-- The error function is strictly increasing. -/
+theorem strictMono_erf : StrictMono erf :=
+  strictMono_of_hasDerivAt_pos hasDerivAt_erf fun x => by positivity
+
+/-- The complementary error function is strictly decreasing. -/
+theorem strictAnti_erfc : StrictAnti erfc := fun _ _ h => by
+  simpa only [erfc_def, sub_lt_sub_iff_left] using strictMono_erf h
+
+/-- The error function is positive on the positive half-line. -/
+theorem erf_pos {x : ℝ} (hx : 0 < x) : 0 < erf x := by simpa using strictMono_erf hx
+
+/-- The error function is nonnegative on the nonnegative half-line. -/
+theorem erf_nonneg {x : ℝ} (hx : 0 ≤ x) : 0 ≤ erf x := by simpa using strictMono_erf.monotone hx
+
+/-- The Gaussian integral over the half-line, in the interval-integral form used by `erf`. -/
+theorem tendsto_intervalIntegral_exp_neg_sq_atTop :
+    Tendsto (fun x : ℝ => ∫ t in (0 : ℝ)..x, rexp (-t ^ 2)) atTop (𝓝 (√π / 2)) := by
+  have h := intervalIntegral_tendsto_integral_Ioi (μ := volume)
+    (f := fun t : ℝ => rexp (-t ^ 2)) 0 integrable_exp_neg_sq.integrableOn tendsto_id
+  have hgauss : ∫ t in Ioi (0 : ℝ), rexp (-t ^ 2) = √π / 2 := by
+    simpa using integral_gaussian_Ioi 1
+  rwa [hgauss] at h
+
+/-- The error function tends to `1` at `+∞`. -/
+theorem tendsto_erf_atTop : Tendsto erf atTop (𝓝 1) := by
+  have hπ : √π ≠ 0 := by positivity
+  have h := tendsto_intervalIntegral_exp_neg_sq_atTop.const_mul (2 / √π)
+  rw [show 2 / √π * (√π / 2) = 1 by field_simp] at h
+  exact h.congr fun x => (erf_def x).symm
+
+/-- The error function tends to `-1` at `-∞`. -/
+theorem tendsto_erf_atBot : Tendsto erf atBot (𝓝 (-1)) := by
+  have h := (tendsto_erf_atTop.comp tendsto_neg_atBot_atTop).neg
+  exact h.congr fun x => by simp [Function.comp_apply, erf_neg]
+
+/-- The complementary error function tends to `0` at `+∞`. -/
+theorem tendsto_erfc_atTop : Tendsto erfc atTop (𝓝 0) := by
+  have h : Tendsto (fun x => 1 - erf x) atTop (𝓝 (1 - 1)) :=
+    tendsto_const_nhds.sub tendsto_erf_atTop
+  rw [sub_self] at h
+  exact h.congr fun x => (erfc_def x).symm
+
+/-- The complementary error function tends to `2` at `-∞`. -/
+theorem tendsto_erfc_atBot : Tendsto erfc atBot (𝓝 2) := by
+  have h : Tendsto (fun x => 1 - erf x) atBot (𝓝 (1 - -1)) :=
+    tendsto_const_nhds.sub tendsto_erf_atBot
+  rw [show (1 : ℝ) - -1 = 2 by norm_num] at h
+  exact h.congr fun x => (erfc_def x).symm
+
+/-- The error function is bounded above by `1`. -/
+theorem erf_le_one (x : ℝ) : erf x ≤ 1 :=
+  ge_of_tendsto tendsto_erf_atTop <| eventually_atTop.2 ⟨x, fun _ hy => strictMono_erf.monotone hy⟩
+
+/-- The error function never attains the value `1`. -/
+theorem erf_lt_one (x : ℝ) : erf x < 1 :=
+  (strictMono_erf (lt_add_one x)).trans_le (erf_le_one (x + 1))
+
+/-- The error function never attains the value `-1`. -/
+theorem neg_one_lt_erf (x : ℝ) : -1 < erf x := by
+  have h := erf_lt_one (-x)
+  rw [erf_neg] at h
+  linarith
+
+/-- The error function takes values in the open interval `(-1, 1)`. -/
+theorem abs_erf_lt_one (x : ℝ) : |erf x| < 1 :=
+  abs_lt.2 ⟨neg_one_lt_erf x, erf_lt_one x⟩
+
+/-- The complementary error function is positive. -/
+theorem erfc_pos (x : ℝ) : 0 < erfc x := by
+  rw [erfc_def]; linarith [erf_lt_one x]
+
+/-- The complementary error function is bounded above by `2`, strictly. -/
+theorem erfc_lt_two (x : ℝ) : erfc x < 2 := by
+  rw [erfc_def]; linarith [neg_one_lt_erf x]
+
+end Real
+
+end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Erf.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Erf.lean
@@ -19,8 +19,8 @@ These are the error-function targets of `TauCetiRoadmap/StandardDistributions/RE
 Layer 2.  The names and statement shapes follow those proposed for Mathlib in
 [mathlib4#34053](https://github.com/leanprover-community/mathlib4/pull/34053), so that the
 declarations here can be replaced by Mathlib's once it provides them.  The identification
-`erf x = regularizedGamma (1 / 2) (x ^ 2)` needs the incomplete gamma function and is not proved
-here.
+`erf x = regularizedGamma (1 / 2) (x ^ 2)`, which holds for `0 ≤ x` — the right-hand side is even
+in `x` while `erf` is odd — needs the incomplete gamma function and is not proved here.
 
 The limits at infinity come from Mathlib's Gaussian integral `integral_gaussian_Ioi` together
 with the improper-integral comparison `MeasureTheory.intervalIntegral_tendsto_integral_Ioi`; the
@@ -79,6 +79,7 @@ theorem erf_zero : erf 0 = 0 := by simp [erf_def]
 theorem erfc_zero : erfc 0 = 1 := by simp [erfc_def]
 
 /-- The error function is odd. -/
+@[simp]
 theorem erf_neg (x : ℝ) : erf (-x) = -erf x := by
   have h : (∫ t in (0 : ℝ)..x, rexp (-t ^ 2)) = ∫ t in (-x)..(0 : ℝ), rexp (-t ^ 2) := by
     have hcomp := intervalIntegral.integral_comp_neg (a := (0 : ℝ)) (b := x)
@@ -89,6 +90,7 @@ theorem erf_neg (x : ℝ) : erf (-x) = -erf x := by
   ring
 
 /-- The complementary error function reflects around the value `1`. -/
+@[simp]
 theorem erfc_neg (x : ℝ) : erfc (-x) = 2 - erfc x := by
   rw [erfc_def, erfc_def, erf_neg]; ring
 
@@ -112,9 +114,20 @@ theorem differentiable_erf : Differentiable ℝ erf := fun x => (hasDerivAt_erf 
 @[fun_prop]
 theorem continuous_erf : Continuous erf := differentiable_erf.continuous
 
+/-- The complementary error function is strictly differentiable, with derivative
+`-(2 / √π * exp (-x ^ 2))`. -/
+theorem hasStrictDerivAt_erfc (x : ℝ) :
+    HasStrictDerivAt erfc (-(2 / √π * rexp (-x ^ 2))) x := by
+  simpa only [erfc_eq_one_sub_erf] using (hasStrictDerivAt_erf x).const_sub 1
+
 /-- The derivative of the complementary error function. -/
-theorem hasDerivAt_erfc (x : ℝ) : HasDerivAt erfc (-(2 / √π * rexp (-x ^ 2))) x := by
-  simpa only [erfc_eq_one_sub_erf] using (hasDerivAt_erf x).const_sub 1
+theorem hasDerivAt_erfc (x : ℝ) : HasDerivAt erfc (-(2 / √π * rexp (-x ^ 2))) x :=
+  (hasStrictDerivAt_erfc x).hasDerivAt
+
+/-- The derivative of the complementary error function, in `deriv` form. -/
+@[simp]
+theorem deriv_erfc : deriv erfc = fun x => -(2 / √π * rexp (-x ^ 2)) :=
+  funext fun x => (hasDerivAt_erfc x).deriv
 
 /-- The complementary error function is differentiable. -/
 theorem differentiable_erfc : Differentiable ℝ erfc := fun x =>
@@ -151,8 +164,8 @@ theorem tendsto_intervalIntegral_exp_neg_sq_atTop :
 theorem tendsto_erf_atTop : Tendsto erf atTop (𝓝 1) := by
   have hπ : √π ≠ 0 := by positivity
   have h := tendsto_intervalIntegral_exp_neg_sq_atTop.const_mul (2 / √π)
-  rw [show 2 / √π * (√π / 2) = 1 by field_simp] at h
-  exact h.congr fun x => (erf_def x).symm
+  convert h.congr fun x => (erf_def x).symm using 2
+  field_simp
 
 /-- The error function tends to `-1` at `-∞`. -/
 theorem tendsto_erf_atBot : Tendsto erf atBot (𝓝 (-1)) := by
@@ -170,7 +183,7 @@ theorem tendsto_erfc_atTop : Tendsto erfc atTop (𝓝 0) := by
 theorem tendsto_erfc_atBot : Tendsto erfc atBot (𝓝 2) := by
   have h : Tendsto (fun x => 1 - erf x) atBot (𝓝 (1 - -1)) :=
     tendsto_const_nhds.sub tendsto_erf_atBot
-  rw [show (1 : ℝ) - -1 = 2 by norm_num] at h
+  norm_num at h
   exact h.congr fun x => (erfc_def x).symm
 
 /-- The error function is bounded above by `1`. -/

--- a/TauCeti/Analysis/SpecialFunctions/Erf.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Erf.lean
@@ -59,16 +59,9 @@ theorem erf_def (x : ℝ) : erf x = 2 / √π * ∫ t in (0 : ℝ)..x, rexp (-t 
 /-- The defining formula for the complementary error function. -/
 theorem erfc_def (x : ℝ) : erfc x = 1 - erf x := (rfl)
 
-/-- The complementary error function as a function, for rewriting under binders. -/
-theorem erfc_eq_one_sub_erf : erfc = fun x => 1 - erf x := funext erfc_def
-
 /-- The Gaussian kernel `t ↦ exp (-t ^ 2)` is continuous. -/
 @[fun_prop]
 theorem continuous_exp_neg_sq : Continuous fun t : ℝ => rexp (-t ^ 2) := by fun_prop
-
-/-- The Gaussian kernel `t ↦ exp (-t ^ 2)` is integrable. -/
-theorem integrable_exp_neg_sq : Integrable fun t : ℝ => rexp (-t ^ 2) := by
-  simpa using integrable_exp_neg_mul_sq (b := 1) one_pos
 
 /-- The error function vanishes at the origin. -/
 @[simp]
@@ -118,7 +111,8 @@ theorem continuous_erf : Continuous erf := differentiable_erf.continuous
 `-(2 / √π * exp (-x ^ 2))`. -/
 theorem hasStrictDerivAt_erfc (x : ℝ) :
     HasStrictDerivAt erfc (-(2 / √π * rexp (-x ^ 2))) x := by
-  simpa only [erfc_eq_one_sub_erf] using (hasStrictDerivAt_erf x).const_sub 1
+  change HasStrictDerivAt (fun y => 1 - erf y) (-(2 / √π * rexp (-x ^ 2))) x
+  exact (hasStrictDerivAt_erf x).const_sub 1
 
 /-- The derivative of the complementary error function. -/
 theorem hasDerivAt_erfc (x : ℝ) : HasDerivAt erfc (-(2 / √π * rexp (-x ^ 2))) x :=
@@ -155,7 +149,8 @@ theorem erf_nonneg {x : ℝ} (hx : 0 ≤ x) : 0 ≤ erf x := by simpa using stri
 theorem tendsto_intervalIntegral_exp_neg_sq_atTop :
     Tendsto (fun x : ℝ => ∫ t in (0 : ℝ)..x, rexp (-t ^ 2)) atTop (𝓝 (√π / 2)) := by
   have h := intervalIntegral_tendsto_integral_Ioi (μ := volume)
-    (f := fun t : ℝ => rexp (-t ^ 2)) 0 integrable_exp_neg_sq.integrableOn tendsto_id
+    (f := fun t : ℝ => rexp (-t ^ 2)) 0
+      (by simpa using (integrable_exp_neg_mul_sq (b := 1) one_pos).integrableOn) tendsto_id
   have hgauss : ∫ t in Ioi (0 : ℝ), rexp (-t ^ 2) = √π / 2 := by
     simpa using integral_gaussian_Ioi 1
   rwa [hgauss] at h

--- a/TauCeti/Analysis/SpecialFunctions/Erf.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Erf.lean
@@ -143,7 +143,7 @@ theorem erf_pos {x : ℝ} (hx : 0 < x) : 0 < erf x := by simpa using strictMono_
 theorem erf_nonneg {x : ℝ} (hx : 0 ≤ x) : 0 ≤ erf x := by simpa using strictMono_erf.monotone hx
 
 /-- The Gaussian integral over the half-line, in the interval-integral form used by `erf`. -/
-theorem tendsto_intervalIntegral_exp_neg_sq_atTop :
+private theorem tendsto_intervalIntegral_exp_neg_sq_atTop :
     Tendsto (fun x : ℝ => ∫ t in (0 : ℝ)..x, rexp (-t ^ 2)) atTop (𝓝 (√π / 2)) := by
   have h := intervalIntegral_tendsto_integral_Ioi (μ := volume)
     (f := fun t : ℝ => rexp (-t ^ 2)) 0

--- a/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.SpecialFunctions.Erf
+public import Mathlib.Probability.Distributions.Gaussian.Real
+public import Mathlib.Probability.CDF
+
+/-!
+# The cumulative distribution function of a real Gaussian law
+
+This file computes `ProbabilityTheory.cdf (gaussianReal m v)` in closed form.  For a nonzero
+variance the answer is `(1 + erf ((x - m) / √(2 * v))) / 2`, and at the singular boundary
+`v = 0` the law is a Dirac mass, with the step-function cdf.
+
+These are the Gaussian entries of the closed-form cdf target of
+`TauCetiRoadmap/StandardDistributions/README.md`, Layer 2.
+
+The computation goes through the interval integral of `gaussianPDFReal`, which is an affine
+change of variables away from the integral defining `TauCeti.Real.erf`; the improper integral
+over `Set.Iic x` is then the limit of those interval integrals, using
+`TauCeti.Real.tendsto_erf_atBot` for the contribution at `-∞`.
+
+## Main declarations
+
+* `TauCeti.intervalIntegral_gaussianPDFReal` — the Gaussian density integrates to a difference of
+  error-function values.
+* `TauCeti.integral_Iic_gaussianPDFReal` — the same over a left half-line.
+* `TauCeti.cdf_gaussianReal_eq` — the closed-form cdf for a nonzero variance.
+* `TauCeti.cdf_gaussianReal_zero_one` — the standard Gaussian cdf.
+* `TauCeti.cdf_gaussianReal_zero` — the cdf at the singular boundary `v = 0`.
+* `TauCeti.measureReal_Ioi_gaussianReal` — the upper tail, in terms of `TauCeti.Real.erfc`.
+* `TauCeti.measureReal_le_of_hasLaw_gaussianReal` — the random-variable corollary.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Filter Set Real ProbabilityTheory
+open scoped Topology NNReal
+
+namespace TauCeti
+
+/-- On an interval, the Gaussian density integrates to the difference of two error-function
+values: the affine change of variables `t ↦ (t - m) / √(2 * v)` turns it into the integral
+defining `TauCeti.Real.erf`. -/
+theorem intervalIntegral_gaussianPDFReal (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) (a b : ℝ) :
+    (∫ t in a..b, gaussianPDFReal m v t) =
+      (Real.erf ((b - m) / √(2 * (v : ℝ))) - Real.erf ((a - m) / √(2 * (v : ℝ)))) / 2 := by
+  have hv0 : (0 : ℝ) < v := NNReal.coe_pos.2 (pos_iff_ne_zero.2 hv)
+  set c : ℝ := √(2 * (v : ℝ)) with hcdef
+  have hc : 0 < c := Real.sqrt_pos.2 (by positivity)
+  have hc2 : c ^ 2 = 2 * (v : ℝ) := Real.sq_sqrt (by positivity)
+  -- Rewrite the density as a scalar multiple of the standard Gaussian kernel.
+  have hdens : ∀ t : ℝ,
+      gaussianPDFReal m v t = (√(2 * π * (v : ℝ)))⁻¹ * rexp (-((t - m) / c) ^ 2) := fun t => by
+    rw [gaussianPDFReal, div_pow, hc2, neg_div]
+  simp only [hdens]
+  rw [intervalIntegral.integral_const_mul]
+  -- Change variables.
+  have h1 : (∫ t in a..b, rexp (-((t - m) / c) ^ 2)) =
+      ∫ y in (a - m)..(b - m), rexp (-(y / c) ^ 2) :=
+    intervalIntegral.integral_comp_sub_right (fun y : ℝ => rexp (-(y / c) ^ 2)) m
+  have h2 : (∫ y in (a - m)..(b - m), rexp (-(y / c) ^ 2)) =
+      c • ∫ s in ((a - m) / c)..((b - m) / c), rexp (-s ^ 2) :=
+    intervalIntegral.integral_comp_div (f := fun s : ℝ => rexp (-s ^ 2)) hc.ne'
+  have h3 : (∫ s in ((a - m) / c)..((b - m) / c), rexp (-s ^ 2)) =
+      (∫ s in (0 : ℝ)..((b - m) / c), rexp (-s ^ 2)) -
+        ∫ s in (0 : ℝ)..((a - m) / c), rexp (-s ^ 2) :=
+    (intervalIntegral.integral_interval_sub_left
+      (Real.continuous_exp_neg_sq.intervalIntegrable _ _)
+      (Real.continuous_exp_neg_sq.intervalIntegrable _ _)).symm
+  have herf : ∀ z : ℝ, (∫ s in (0 : ℝ)..z, rexp (-s ^ 2)) = √π / 2 * Real.erf z := fun z => by
+    rw [Real.erf_def]; field_simp
+  -- The remaining constant is `1 / 2`.
+  have hcs : c * √π = √(2 * π * (v : ℝ)) := by
+    rw [hcdef, ← Real.sqrt_mul (by positivity)]
+    congr 1
+    ring
+  rw [h1, h2, h3, herf, herf, smul_eq_mul]
+  rw [eq_div_iff (two_ne_zero), ← hcs]
+  field_simp
+
+/-- Over a left half-line, the Gaussian density integrates to
+`(1 + erf ((x - m) / √(2 * v))) / 2`. -/
+theorem integral_Iic_gaussianPDFReal (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) (x : ℝ) :
+    (∫ t in Iic x, gaussianPDFReal m v t) = (1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2 := by
+  have hv0 : (0 : ℝ) < v := NNReal.coe_pos.2 (pos_iff_ne_zero.2 hv)
+  have hc : 0 < √(2 * (v : ℝ)) := Real.sqrt_pos.2 (by positivity)
+  have hlim := MeasureTheory.intervalIntegral_tendsto_integral_Iic (μ := volume)
+    (f := gaussianPDFReal m v) x (integrable_gaussianPDFReal m v).integrableOn
+    (a := id) tendsto_id
+  have hy : Tendsto (fun y : ℝ => (y - m) / √(2 * (v : ℝ))) atBot atBot :=
+    Tendsto.atBot_div_const hc <| by
+      simpa [sub_eq_add_neg] using
+        tendsto_atBot_add_const_right (f := fun y : ℝ => y) (l := atBot) (-m) tendsto_id
+  have hlim' : Tendsto (fun y : ℝ => ∫ t in y..x, gaussianPDFReal m v t) atBot
+      (𝓝 ((1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2)) := by
+    have h := ((tendsto_const_nhds (x := Real.erf ((x - m) / √(2 * (v : ℝ)))) (f := atBot)).sub
+      (Real.tendsto_erf_atBot.comp hy)).div_const 2
+    rw [show (Real.erf ((x - m) / √(2 * (v : ℝ))) - -1) / 2 =
+      (1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2 by ring] at h
+    exact h.congr fun y => (intervalIntegral_gaussianPDFReal m hv y x).symm
+  exact tendsto_nhds_unique hlim hlim'
+
+/-- The cumulative distribution function of a Gaussian law with nonzero variance. -/
+theorem cdf_gaussianReal_eq (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) (x : ℝ) :
+    cdf (gaussianReal m v) x = (1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2 := by
+  rw [cdf_eq_real, measureReal_def, gaussianReal_apply_eq_integral m hv,
+    ENNReal.toReal_ofReal (integral_nonneg fun t => gaussianPDFReal_nonneg m v t)]
+  exact integral_Iic_gaussianPDFReal m hv x
+
+/-- The cumulative distribution function of the standard Gaussian law. -/
+theorem cdf_gaussianReal_zero_one (x : ℝ) :
+    cdf (gaussianReal 0 1) x = (1 + Real.erf (x / √2)) / 2 := by
+  simpa using cdf_gaussianReal_eq 0 one_ne_zero x
+
+/-- At the singular boundary `v = 0` the Gaussian law is a Dirac mass, and its cumulative
+distribution function is the corresponding step function. -/
+theorem cdf_gaussianReal_zero (m x : ℝ) :
+    cdf (gaussianReal m 0) x = if m ≤ x then 1 else 0 := by
+  rw [gaussianReal_zero_var, cdf_eq_real, measureReal_def, Measure.dirac_apply]
+  by_cases h : m ≤ x <;> simp [h]
+
+/-- The upper tail of a Gaussian law with nonzero variance is half the complementary error
+function. -/
+theorem measureReal_Ioi_gaussianReal (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) (x : ℝ) :
+    (gaussianReal m v).real (Ioi x) = Real.erfc ((x - m) / √(2 * (v : ℝ))) / 2 := by
+  have h : (gaussianReal m v).real (Iic x) = (1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2 := by
+    rw [← cdf_eq_real]
+    exact cdf_gaussianReal_eq m hv x
+  rw [← compl_Iic, measureReal_compl measurableSet_Iic, h, Real.erfc_def]
+  simp only [probReal_univ]
+  ring
+
+/-- A random variable with a Gaussian law of nonzero variance has the error-function cumulative
+distribution function. -/
+theorem measureReal_le_of_hasLaw_gaussianReal {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
+    {X : Ω → ℝ} (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) (hX : HasLaw X (gaussianReal m v) P) (x : ℝ) :
+    P.real {ω | X ω ≤ x} = (1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2 := by
+  rw [hX.measureReal_eq (p := fun y : ℝ => y ≤ x) measurableSet_Iic, Set.Iic_def, ← cdf_eq_real]
+  exact cdf_gaussianReal_eq m hv x
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
@@ -46,11 +46,14 @@ open scoped Topology NNReal
 namespace TauCeti
 
 /-- On an interval, the Gaussian density integrates to the difference of two error-function
-values: the affine change of variables `t ↦ (t - m) / √(2 * v)` turns it into the integral
-defining `TauCeti.Real.erf`. -/
-theorem intervalIntegral_gaussianPDFReal (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) (a b : ℝ) :
+values. Both sides vanish at zero variance; otherwise the affine change of variables
+`t ↦ (t - m) / √(2 * v)` turns the integral into the one defining `TauCeti.Real.erf`. -/
+theorem intervalIntegral_gaussianPDFReal (m : ℝ) {v : ℝ≥0} (a b : ℝ) :
     (∫ t in a..b, gaussianPDFReal m v t) =
       (Real.erf ((b - m) / √(2 * (v : ℝ))) - Real.erf ((a - m) / √(2 * (v : ℝ)))) / 2 := by
+  by_cases hv : v = 0
+  · subst v
+    simp
   have hv0 : (0 : ℝ) < v := NNReal.coe_pos.2 (pos_iff_ne_zero.2 hv)
   set c : ℝ := √(2 * (v : ℝ)) with hcdef
   have hc : 0 < c := Real.sqrt_pos.2 (by positivity)
@@ -102,7 +105,7 @@ theorem integral_Iic_gaussianPDFReal (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) (x :
       (𝓝 ((1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2)) := by
     have h := ((tendsto_const_nhds (x := Real.erf ((x - m) / √(2 * (v : ℝ)))) (f := atBot)).sub
       (Real.tendsto_erf_atBot.comp hy)).div_const 2
-    convert h.congr fun y => (intervalIntegral_gaussianPDFReal m hv y x).symm using 2
+    convert h.congr fun y => (intervalIntegral_gaussianPDFReal m (v := v) y x).symm using 2
     ring
   exact tendsto_nhds_unique hlim hlim'
 

--- a/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
@@ -31,7 +31,7 @@ over `Set.Iic x` is then the limit of those interval integrals, using
 * `TauCeti.integral_Iic_gaussianPDFReal` — the same over a left half-line.
 * `TauCeti.cdf_gaussianReal_eq` — the closed-form cdf for a nonzero variance.
 * `TauCeti.cdf_gaussianReal_zero_one` — the standard Gaussian cdf.
-* `TauCeti.cdf_gaussianReal_zero` — the cdf at the singular boundary `v = 0`.
+* `TauCeti.cdf_gaussianReal_zero_var` — the cdf at the singular boundary `v = 0`.
 * `TauCeti.measureReal_Ioi_gaussianReal` — the upper tail, in terms of `TauCeti.Real.erfc`.
 * `TauCeti.measureReal_le_of_hasLaw_gaussianReal` — the random-variable corollary.
 -/
@@ -102,9 +102,8 @@ theorem integral_Iic_gaussianPDFReal (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) (x :
       (𝓝 ((1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2)) := by
     have h := ((tendsto_const_nhds (x := Real.erf ((x - m) / √(2 * (v : ℝ)))) (f := atBot)).sub
       (Real.tendsto_erf_atBot.comp hy)).div_const 2
-    rw [show (Real.erf ((x - m) / √(2 * (v : ℝ))) - -1) / 2 =
-      (1 + Real.erf ((x - m) / √(2 * (v : ℝ)))) / 2 by ring] at h
-    exact h.congr fun y => (intervalIntegral_gaussianPDFReal m hv y x).symm
+    convert h.congr fun y => (intervalIntegral_gaussianPDFReal m hv y x).symm using 2
+    ring
   exact tendsto_nhds_unique hlim hlim'
 
 /-- The cumulative distribution function of a Gaussian law with nonzero variance. -/
@@ -121,7 +120,7 @@ theorem cdf_gaussianReal_zero_one (x : ℝ) :
 
 /-- At the singular boundary `v = 0` the Gaussian law is a Dirac mass, and its cumulative
 distribution function is the corresponding step function. -/
-theorem cdf_gaussianReal_zero (m x : ℝ) :
+theorem cdf_gaussianReal_zero_var (m x : ℝ) :
     cdf (gaussianReal m 0) x = if m ≤ x then 1 else 0 := by
   rw [gaussianReal_zero_var, cdf_eq_real, measureReal_def, Measure.dirac_apply]
   by_cases h : m ≤ x <;> simp [h]

--- a/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
@@ -72,8 +72,8 @@ theorem intervalIntegral_gaussianPDFReal (m : ℝ) {v : ℝ≥0} (hv : v ≠ 0) 
       (∫ s in (0 : ℝ)..((b - m) / c), rexp (-s ^ 2)) -
         ∫ s in (0 : ℝ)..((a - m) / c), rexp (-s ^ 2) :=
     (intervalIntegral.integral_interval_sub_left
-      (Real.continuous_exp_neg_sq.intervalIntegrable _ _)
-      (Real.continuous_exp_neg_sq.intervalIntegrable _ _)).symm
+      ((by fun_prop : Continuous fun s : ℝ => rexp (-s ^ 2)).intervalIntegrable _ _)
+      ((by fun_prop : Continuous fun s : ℝ => rexp (-s ^ 2)).intervalIntegrable _ _)).symm
   have herf : ∀ z : ℝ, (∫ s in (0 : ℝ)..z, rexp (-s ^ 2)) = √π / 2 * Real.erf z := fun z => by
     rw [Real.erf_def]; field_simp
   -- The remaining constant is `1 / 2`.

--- a/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Cdf.lean
@@ -31,7 +31,7 @@ over `Set.Iic x` is then the limit of those interval integrals, using
 * `TauCeti.integral_Iic_gaussianPDFReal` — the same over a left half-line.
 * `TauCeti.cdf_gaussianReal_eq` — the closed-form cdf for a nonzero variance.
 * `TauCeti.cdf_gaussianReal_zero_one` — the standard Gaussian cdf.
-* `TauCeti.cdf_gaussianReal_zero_var` — the cdf at the singular boundary `v = 0`.
+* `TauCeti.cdf_gaussianReal_zero` — the cdf at the singular boundary `v = 0`.
 * `TauCeti.measureReal_Ioi_gaussianReal` — the upper tail, in terms of `TauCeti.Real.erfc`.
 * `TauCeti.measureReal_le_of_hasLaw_gaussianReal` — the random-variable corollary.
 -/
@@ -120,7 +120,7 @@ theorem cdf_gaussianReal_zero_one (x : ℝ) :
 
 /-- At the singular boundary `v = 0` the Gaussian law is a Dirac mass, and its cumulative
 distribution function is the corresponding step function. -/
-theorem cdf_gaussianReal_zero_var (m x : ℝ) :
+theorem cdf_gaussianReal_zero (m x : ℝ) :
     cdf (gaussianReal m 0) x = if m ≤ x then 1 else 0 := by
   rw [gaussianReal_zero_var, cdf_eq_real, measureReal_def, Measure.dirac_apply]
   by_cases h : m ≤ x <;> simp [h]


### PR DESCRIPTION
This PR defines the Gauss error function `TauCeti.Real.erf` and its complement `TauCeti.Real.erfc`, develops their elementary real-variable theory, and uses them to put the cumulative distribution function of a real Gaussian law into closed form. It serves the Layer 2 milestone "incomplete special functions and closed-form cdfs" of the `StandardDistributions` roadmap, whose targets it covers are the "Error function" bullet (`Real.erf`, `Real.erfc`: oddness, monotonicity, the limits at both infinities, the derivative) and the first two "Closed-form cdfs and tails" bullets (`cdf_gaussianReal_eq` for `v ≠ 0` and `cdf_gaussianReal_zero` at the singular boundary). Layer 2 is otherwise untouched in the repository, and it gates Layer 3, whose Laplace, log-normal, chi-squared, inverse-gamma, Student's t, Fisher's F and negative-binomial cdfs are all stated through these special functions.

`TauCeti/Analysis/SpecialFunctions/Erf.lean` defines `erf x = (2 / √π) * ∫ t in 0..x, exp (-t ^ 2)` and `erfc x = 1 - erf x`, and proves `erf_zero`, `erf_neg`, `erfc_neg`, `hasStrictDerivAt_erf`/`hasDerivAt_erf`/`deriv_erf`, differentiability and continuity of both, `strictMono_erf` and `strictAnti_erfc`, the four limits `tendsto_erf_atTop`, `tendsto_erf_atBot`, `tendsto_erfc_atTop`, `tendsto_erfc_atBot`, and the resulting sharp bounds `erf_lt_one`, `neg_one_lt_erf`, `abs_erf_lt_one`, `erfc_pos`, `erfc_lt_two`. The limits come from Mathlib's `integral_gaussian_Ioi` together with `MeasureTheory.intervalIntegral_tendsto_integral_Ioi`; the derivative is the fundamental theorem of calculus for a continuous integrand. The names and statement shapes follow those proposed for Mathlib in [mathlib4#34053](https://github.com/leanprover-community/mathlib4/pull/34053), as the roadmap directs, so the declarations can be replaced by Mathlib's once its pin provides them; they live in `TauCeti.Real` rather than the root `Real` namespace precisely so that arrival does not clash.

`TauCeti/Probability/Distributions/Gaussian/Cdf.lean` computes `intervalIntegral_gaussianPDFReal`, the integral of `gaussianPDFReal m v` over an interval, as a difference of error-function values by the affine change of variables `t ↦ (t - m) / √(2 * v)`, using Mathlib's `intervalIntegral.integral_comp_sub_right` and `integral_comp_div`. Letting the left endpoint go to `-∞` and applying `tendsto_erf_atBot` gives `integral_Iic_gaussianPDFReal`, hence `cdf_gaussianReal_eq : cdf (gaussianReal m v) x = (1 + erf ((x - m) / √(2 * v))) / 2` for `v ≠ 0`, the standard-normal specialisation `cdf_gaussianReal_zero_one`, and the Dirac boundary `cdf_gaussianReal_zero : cdf (gaussianReal m 0) x = if m ≤ x then 1 else 0`. Two consumer-facing corollaries follow: the upper tail `measureReal_Ioi_gaussianReal` in terms of `erfc`, and the `HasLaw` form `measureReal_le_of_hasLaw_gaussianReal`.

Both files build sorry-free against the pinned Mathlib and pass the axiom audit. No Mathlib infrastructure was vendored; everything is used through the existing `gaussianReal`, `gaussianPDFReal`, `ProbabilityTheory.cdf`, and Gaussian-integral APIs.

After this PR, Layer 2 still needs the lower incomplete gamma function and the regularized incomplete beta function, together with the remaining closed-form cdfs and tails they carry (gamma, beta, the binomial tail, the Poisson tail) and the identity `erf x = regularizedGamma (1 / 2) (x ^ 2)`.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"real-erf"}-->

🤖 Prepared with Claude Code
