### PR TITLE
feat: the Euler characteristic of a sheaf of modules, and its additivity

### DIFF
--- a/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
@@ -25,9 +25,13 @@ sequences as soon as the truncation degree is one past the last nonvanishing deg
 * `Scheme.Modules.eulerCharBelow_sub_sub`, the exact defect of additivity: the failure of
   `eulerCharBelow` to be additive on a short exact sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is, up to
   sign, the dimension of the image of the last connecting map that the truncation cuts off;
-* `Scheme.Modules.eulerCharBelow_X₂`, the additivity itself, under the vanishing of
-  `Hⁿ(X, M₁)`, and `Scheme.Modules.eulerChar_X₂`, its shape on a curve, where cohomology
-  vanishes above degree one so that `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)`;
+* `Scheme.Modules.eulerCharBelow_eq_add_of_cohomologyδ_eq_zero`, the additivity itself,
+  under the vanishing of the connecting map the truncation cuts off, and
+  `Scheme.Modules.eulerCharBelow_eq_add`, the form in which that vanishing comes from the
+  vanishing of `Hⁿ(X, M₁)`;
+* `Scheme.Modules.finrank_cohomology_zero_sub_one_eq_add`, the shape of the additivity on a
+  curve, where cohomology vanishes above degree one so that
+  `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)`;
 * `Scheme.Modules.eulerCharBelow_congr`, the invariance of the truncated Euler characteristic
   under isomorphism, and `Scheme.Modules.finrank_cohomology_zero`, the identification of
   `dim H⁰(X, M)` with the dimension of the space of global sections.
@@ -37,12 +41,15 @@ sequences as soon as the truncation degree is one past the last nonvanishing deg
 No finiteness assumption is built into `eulerCharBelow`, exactly as none is built into
 Mathlib's `HomologicalComplex.eulerChar`: `Module.finrank` is `0` on an infinite-dimensional
 space, so a degree `i < n` in which `Hⁱ(X, M)` is infinite-dimensional contributes `0` to the
-sum instead of making it meaningless. The alternating sum is therefore the Euler characteristic
-only for a sheaf whose cohomology is finite-dimensional in degrees `< n`: accordingly the
-statements that read it as an Euler characteristic, `eulerCharBelow_sub_sub`,
-`eulerCharBelow_X₂` and `eulerChar_X₂`, assume that finite-dimensionality — and only in the
-degrees below the truncation that they actually sum over, so that the curve statement
-`eulerChar_X₂` needs it in degrees `0` and `1` alone — while
+sum instead of making it meaningless. The alternating sum is therefore read as an Euler
+characteristic when the cohomology is finite-dimensional in the degrees `< n` it sums over:
+accordingly the statements that read it that way, `eulerCharBelow_sub_sub`,
+`eulerCharBelow_eq_add_of_cohomologyδ_eq_zero`, `eulerCharBelow_eq_add` and
+`finrank_cohomology_zero_sub_one_eq_add`, assume that finite-dimensionality — and only in the
+degrees below the truncation that they actually sum over, and only in the degrees where the
+dimension count needs it, so that the curve statement
+`finrank_cohomology_zero_sub_one_eq_add` needs it in degrees `0` and `1` alone, and for the
+first term of the sequence in degree `1` alone — while
 `eulerCharBelow_zero`, `eulerCharBelow_succ`, `eulerCharBelow_two` and `eulerCharBelow_congr`
 are identities of the alternating sum as it stands and need no such hypothesis.
 
@@ -84,9 +91,11 @@ a sheaf of modules on a scheme over a field, truncated at degree `n`.
 
 No finiteness assumption is imposed, just as none is imposed on Mathlib's
 `HomologicalComplex.eulerChar`: a degree `i < n` in which `Hⁱ(X, M)` is infinite-dimensional
-contributes the junk value `finrank k Hⁱ(X, M) = 0`. This sum is thus the Euler characteristic
-`χ(X, M)` precisely for a sheaf whose cohomology is finite-dimensional in degrees `< n` and
-vanishes in degrees `≥ n`; on a curve, the relevant truncation is `n = 2`. -/
+contributes the junk value `finrank k Hⁱ(X, M) = 0`. For this sum to be the Euler
+characteristic `χ(X, M)` it is enough that the cohomology be finite-dimensional in degrees
+`< n` and vanish in degrees `≥ n`; that is a sufficient condition and not a necessary one,
+since a truncation that cuts off finite-dimensional cohomology whose own alternating sum
+vanishes computes `χ(X, M)` just as well. On a curve, the relevant truncation is `n = 2`. -/
 def _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow (M : X.Modules) (n : ℕ) : ℤ :=
   ∑ i ∈ Finset.range n, (-1) ^ i * (finrank k (Cohomology M i) : ℤ)
 
@@ -97,6 +106,7 @@ lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_zero (M : X.Modules
     eulerCharBelow k X M 0 = 0 :=
   Finset.sum_range_zero _
 
+@[simp]
 lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_succ (M : X.Modules) (n : ℕ) :
     eulerCharBelow k X M (n + 1) =
       eulerCharBelow k X M n + (-1) ^ n * (finrank k (Cohomology M n) : ℤ) :=
@@ -203,9 +213,11 @@ private lemma finrank_X₃ (i : ℕ) [FiniteDimensional k (Cohomology S.X₃ i)]
 `Hⁿ(X, M₃) → Hⁿ⁺¹(X, M₁)` that the truncation cuts off.
 
 Finite-dimensionality is only assumed in the degrees the truncation reads, that is in the
-degrees `< n + 1` summed over. -/
+degrees `< n + 1` summed over — and for the first term of the sequence only in the positive
+ones, since the degree-zero contribution of `M₁` is computed by the injectivity of
+`H⁰(X, M₁) → H⁰(X, M₂)` rather than by rank-nullity. -/
 theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
-    (h₁ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₁ i))
+    (h₁ : ∀ i < n + 1, 0 < i → FiniteDimensional k (Cohomology S.X₁ i))
     (h₂ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₂ i))
     (h₃ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₃ i)) :
     eulerCharBelow k X S.X₂ (n + 1) - eulerCharBelow k X S.X₁ (n + 1) -
@@ -222,7 +234,7 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
     push_cast
     ring
   | succ n ih =>
-    have hfd₁ := h₁ (n + 1) (by omega)
+    have hfd₁ := h₁ (n + 1) (by omega) (by omega)
     have hfd₂ := h₂ (n + 1) (by omega)
     have hfd₃ := h₃ (n + 1) (by omega)
     have ih := ih (fun i hi ↦ h₁ i (by omega)) (fun i hi ↦ h₂ i (by omega))
@@ -234,11 +246,31 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
     linear_combination ih
 
 /-- **Additivity of the Euler characteristic.** If `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is a short exact
-sequence of sheaves of modules whose cohomology is finite-dimensional in the degrees `< n` that
-the truncation reads, and `Hⁿ(X, M₁)` vanishes, then the Euler characteristics truncated at `n`
-add up. -/
-theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_X₂ (n : ℕ)
-    (h₁ : ∀ i < n, FiniteDimensional k (Cohomology S.X₁ i))
+sequence of sheaves of modules whose cohomology is finite-dimensional in the degrees
+`< n + 1` that the truncation reads, and the connecting map `Hⁿ(X, M₃) → Hⁿ⁺¹(X, M₁)` that the
+truncation cuts off vanishes, then the Euler characteristics truncated at `n + 1` add up.
+
+This is the exact hypothesis the defect formula `eulerCharBelow_sub_sub` asks for; the usual
+sufficient condition, the vanishing of the whole target `Hⁿ⁺¹(X, M₁)`, is
+`eulerCharBelow_eq_add`. -/
+theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_eq_add_of_cohomologyδ_eq_zero
+    (n : ℕ)
+    (h₁ : ∀ i < n + 1, 0 < i → FiniteDimensional k (Cohomology S.X₁ i))
+    (h₂ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₂ i))
+    (h₃ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₃ i))
+    (hδ : cohomologyδBaseLinear k X hS n (n + 1) rfl = 0) :
+    eulerCharBelow k X S.X₂ (n + 1) =
+      eulerCharBelow k X S.X₁ (n + 1) + eulerCharBelow k X S.X₃ (n + 1) := by
+  have h := eulerCharBelow_sub_sub k hS n h₁ h₂ h₃
+  rw [hδ, LinearMap.range_zero, finrank_bot, Nat.cast_zero, mul_zero] at h
+  linarith
+
+/-- **Additivity of the Euler characteristic under a vanishing target.** If
+`0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is a short exact sequence of sheaves of modules whose cohomology is
+finite-dimensional in the degrees `< n` that the truncation reads, and `Hⁿ(X, M₁)` vanishes,
+then the Euler characteristics truncated at `n` add up. -/
+theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_eq_add (n : ℕ)
+    (h₁ : ∀ i < n, 0 < i → FiniteDimensional k (Cohomology S.X₁ i))
     (h₂ : ∀ i < n, FiniteDimensional k (Cohomology S.X₂ i))
     (h₃ : ∀ i < n, FiniteDimensional k (Cohomology S.X₃ i))
     (hvan : Subsingleton (Cohomology S.X₁ n)) :
@@ -246,26 +278,22 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_X₂ (n : ℕ)
   cases n with
   | zero => simp
   | succ n =>
-    have hrange : LinearMap.range (cohomologyδBaseLinear k X hS n (n + 1) rfl) = ⊥ := by
-      rw [LinearMap.range_eq_bot]
-      exact LinearMap.ext fun _ ↦ Subsingleton.elim _ _
-    have h := eulerCharBelow_sub_sub k hS n h₁ h₂ h₃
-    rw [hrange, finrank_bot, Nat.cast_zero, mul_zero] at h
-    linarith
+    exact eulerCharBelow_eq_add_of_cohomologyδ_eq_zero k hS n h₁ h₂ h₃
+      (LinearMap.ext fun _ ↦ Subsingleton.elim _ _)
 
 /-- **Additivity of the Euler characteristic on a curve.** For a short exact sequence of sheaves
 of modules whose cohomology is finite-dimensional in degrees `0` and `1` and with `H²(X, M₁)`
 vanishing, as it does on a curve, the Euler characteristics
 `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)` add up. -/
-theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerChar_X₂
-    (h₁ : ∀ i < 2, FiniteDimensional k (Cohomology S.X₁ i))
+theorem _root_.AlgebraicGeometry.Scheme.Modules.finrank_cohomology_zero_sub_one_eq_add
+    (h₁ : ∀ i < 2, 0 < i → FiniteDimensional k (Cohomology S.X₁ i))
     (h₂ : ∀ i < 2, FiniteDimensional k (Cohomology S.X₂ i))
     (h₃ : ∀ i < 2, FiniteDimensional k (Cohomology S.X₃ i))
     (hvan : Subsingleton (Cohomology S.X₁ 2)) :
     (finrank k (Cohomology S.X₂ 0) : ℤ) - (finrank k (Cohomology S.X₂ 1) : ℤ) =
       ((finrank k (Cohomology S.X₁ 0) : ℤ) - (finrank k (Cohomology S.X₁ 1) : ℤ)) +
         ((finrank k (Cohomology S.X₃ 0) : ℤ) - (finrank k (Cohomology S.X₃ 1) : ℤ)) := by
-  simpa only [eulerCharBelow_two] using eulerCharBelow_X₂ k hS 2 h₁ h₂ h₃ hvan
+  simpa only [eulerCharBelow_two] using eulerCharBelow_eq_add k hS 2 h₁ h₂ h₃ hvan
 
 end ShortExact
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
@@ -12,16 +12,16 @@ public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 /-!
 # The Euler characteristic of a sheaf of modules on a scheme
 
-For a scheme `X` over a field `k`, the finite-dimensional cohomology `Hⁱ(X, M)` of a sheaf of
-modules is a `k`-vector space, so the alternating sum of its dimensions can be formed. This file
-introduces that alternating sum, truncated at a degree `n`, and proves that it is additive on short
-exact sequences as soon as the truncation degree is one past the last nonvanishing degree.
+For a scheme `X` over a field `k`, the cohomology `Hⁱ(X, M)` of a sheaf of modules is a
+`k`-vector space, so the alternating sum of its dimensions can be formed. This file introduces
+that alternating sum, truncated at a degree `n`, and proves that it is additive on short exact
+sequences as soon as the truncation degree is one past the last nonvanishing degree.
 
 ## Main declarations
 
 * `Scheme.Modules.eulerCharBelow k X M n`, the alternating sum
-  `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)` for a sheaf with finite-dimensional cohomology. If its
-  cohomology also vanishes in degrees `≥ n`, this is the Euler characteristic `χ(X, M)`;
+  `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)`. For a sheaf whose cohomology vanishes in degrees `≥ n` this
+  is the Euler characteristic `χ(X, M)`;
 * `Scheme.Modules.eulerCharBelow_sub_sub`, the exact defect of additivity: the failure of
   `eulerCharBelow` to be additive on a short exact sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is, up to
   sign, the dimension of the image of the last connecting map that the truncation cuts off;
@@ -65,32 +65,27 @@ namespace Scheme.Modules
 
 variable (k : Type u) [Field k] (X : Scheme.{u}) [X.Over (Spec (.of k))]
 
-/-- The alternating sum `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)` of the dimensions of the
-finite-dimensional cohomology of a sheaf of modules on a scheme over a field, truncated at
-degree `n`.
+/-- The alternating sum `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)` of the dimensions of the cohomology of
+a sheaf of modules on a scheme over a field, truncated at degree `n`.
 
 For a sheaf whose cohomology vanishes in degrees `≥ n` this is the Euler characteristic
 `χ(X, M)`; on a curve, the relevant truncation is `n = 2`. -/
-def _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow (M : X.Modules)
-    [∀ i, FiniteDimensional k (Cohomology M i)] (n : ℕ) : ℤ :=
+def _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow (M : X.Modules) (n : ℕ) : ℤ :=
   ∑ i ∈ Finset.range n, (-1) ^ i * (finrank k (Cohomology M i) : ℤ)
 
 variable {X}
 
 @[simp]
-lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_zero (M : X.Modules)
-    [∀ i, FiniteDimensional k (Cohomology M i)] :
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_zero (M : X.Modules) :
     eulerCharBelow k X M 0 = 0 :=
   Finset.sum_range_zero _
 
-lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_succ (M : X.Modules)
-    [∀ i, FiniteDimensional k (Cohomology M i)] (n : ℕ) :
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_succ (M : X.Modules) (n : ℕ) :
     eulerCharBelow k X M (n + 1) =
       eulerCharBelow k X M n + (-1) ^ n * (finrank k (Cohomology M n) : ℤ) :=
   Finset.sum_range_succ _ _
 
-lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_two (M : X.Modules)
-    [∀ i, FiniteDimensional k (Cohomology M i)] :
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_two (M : X.Modules) :
     eulerCharBelow k X M 2 =
       (finrank k (Cohomology M 0) : ℤ) - (finrank k (Cohomology M 1) : ℤ) := by
   rw [eulerCharBelow_succ, eulerCharBelow_succ, eulerCharBelow_zero]
@@ -115,8 +110,7 @@ lemma _root_.AlgebraicGeometry.Scheme.Modules.finrank_cohomology_congr {M N : X.
 is what makes an invariant such as the degree `χ(L) - χ(𝒪_X)` of a line bundle well defined on
 the Picard group. -/
 lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_congr {M N : X.Modules}
-    [∀ i, FiniteDimensional k (Cohomology M i)]
-    [∀ i, FiniteDimensional k (Cohomology N i)] (e : M ≅ N) (n : ℕ) :
+    (e : M ≅ N) (n : ℕ) :
     eulerCharBelow k X M n = eulerCharBelow k X N n :=
   Finset.sum_congr rfl fun i _ ↦ by rw [finrank_cohomology_congr k e i]
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
@@ -33,7 +33,8 @@ sequences as soon as the truncation degree is one past the last nonvanishing deg
   curve, where cohomology vanishes above degree one so that
   `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)`;
 * `Scheme.Modules.eulerCharBelow_congr`, the invariance of the truncated Euler characteristic
-  under isomorphism, and `Scheme.Modules.finrank_cohomology_zero`, the identification of
+  under isomorphism, and
+  `Scheme.Modules.finrank_cohomology_zero_eq_finrank_globalSections`, the identification of
   `dim H⁰(X, M)` with the dimension of the space of global sections.
 
 ## Junk values
@@ -45,11 +46,15 @@ sum instead of making it meaningless. The alternating sum is therefore read as a
 characteristic when the cohomology is finite-dimensional in the degrees `< n` it sums over:
 accordingly the statements that read it that way, `eulerCharBelow_sub_sub`,
 `eulerCharBelow_eq_add_of_cohomologyδ_eq_zero`, `eulerCharBelow_eq_add` and
-`finrank_cohomology_zero_sub_one_eq_add`, assume that finite-dimensionality — and only in the
-degrees below the truncation that they actually sum over, and only in the degrees where the
-dimension count needs it, so that the curve statement
-`finrank_cohomology_zero_sub_one_eq_add` needs it in degrees `0` and `1` alone, and for the
-first term of the sequence in degree `1` alone — while
+`finrank_cohomology_zero_sub_one_eq_add`, assume that finite-dimensionality — but only where
+the dimension count really needs it. For the middle term of the sequence that is the degrees
+below the truncation; for the first term only the positive ones among them, since the
+degree-zero contribution of `M₁` is computed by an injectivity; and for the third term nothing
+at all, since exactness makes `Hⁱ(X, M₃)` finite-dimensional as soon as `Hⁱ(X, M₂)` and
+`Hⁱ⁺¹(X, M₁)` are — only `eulerCharBelow_sub_sub`, whose defect term lives in the top degree
+the truncation reads, still assumes it there. So the curve statement
+`finrank_cohomology_zero_sub_one_eq_add` assumes finite-dimensionality of `Hⁱ(X, M₂)` in
+degrees `0` and `1` and of `H¹(X, M₁)`, and of nothing else — while
 `eulerCharBelow_zero`, `eulerCharBelow_succ`, `eulerCharBelow_two` and `eulerCharBelow_congr`
 are identities of the alternating sum as it stands and need no such hypothesis.
 
@@ -65,7 +70,8 @@ proved by induction on a divisor. It is therefore Layer B infrastructure for
 
 No formalization is vendored. The alternating-sum bookkeeping reuses Mathlib's
 `LinearMap.finrank_range_add_finrank_ker`, `LinearMap.finrank_range_of_inj` and
-`Function.Exact.linearMap_ker_eq`; the long exact sequence and the linearity of its maps are
+`Function.Exact.linearMap_ker_eq`, and the finite-dimensionality that exactness supplies is
+Mathlib's `Module.Finite.of_exact`; the long exact sequence and the linearity of its maps are
 `TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean`.
 -/
 
@@ -119,7 +125,9 @@ lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_two (M : X.Modules)
   ring
 
 /-- The dimension of `H⁰(X, M)` is the dimension of the space of global sections of `M`. -/
-lemma _root_.AlgebraicGeometry.Scheme.Modules.finrank_cohomology_zero (M : X.Modules) :
+@[simp]
+lemma _root_.AlgebraicGeometry.Scheme.Modules.finrank_cohomology_zero_eq_finrank_globalSections
+    (M : X.Modules) :
     finrank k (Cohomology M 0) = finrank k Γ(M, ⊤) :=
   (cohomologyZeroBaseLinearEquiv k X M).finrank_eq
 
@@ -158,6 +166,35 @@ private lemma coe_cohomologyδBaseLinear (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
     ⇑(cohomologyδBaseLinear k X hS n₀ n₁ h) = ⇑(cohomologyδ hS n₀ n₁ h) := by
   funext x
   exact cohomologyδBaseLinear_apply k X hS n₀ n₁ h x
+
+/-- The long exact cohomology sequence is exact at `Hⁱ(X, M₃)`, as a sequence of vector spaces
+over the base field. -/
+private lemma exact_cohomologyMapBaseLinear_cohomologyδBaseLinear (i : ℕ) :
+    Function.Exact (cohomologyMapBaseLinear k X S.g i)
+      (cohomologyδBaseLinear k X hS i (i + 1) rfl) := by
+  simpa only [coe_cohomologyδBaseLinear, coe_cohomologyMapBaseLinear] using
+    exact_cohomologyMap_cohomologyδ hS i (i + 1) rfl
+
+/-- `Hⁱ(X, M₃)` is squeezed by the exact sequence between `Hⁱ(X, M₂)` and `Hⁱ⁺¹(X, M₁)`, so it
+is finite-dimensional as soon as those two are: the third term of the sequence needs no
+finite-dimensionality hypothesis of its own. -/
+private lemma finiteDimensional_X₃ (i : ℕ) [FiniteDimensional k (Cohomology S.X₂ i)]
+    [FiniteDimensional k (Cohomology S.X₁ (i + 1))] :
+    FiniteDimensional k (Cohomology S.X₃ i) := by
+  have hex : Function.Exact (cohomologyMapBaseLinear k X S.g i)
+      (cohomologyδBaseLinear k X hS i (i + 1) rfl).rangeRestrict := by
+    rw [LinearMap.exact_iff, LinearMap.ker_rangeRestrict, ← LinearMap.exact_iff]
+    exact exact_cohomologyMapBaseLinear_cohomologyδBaseLinear k hS i
+  exact Module.Finite.of_exact hex (LinearMap.surjective_rangeRestrict _)
+
+/-- When the connecting map out of `Hⁿ(X, M₃)` vanishes, `Hⁿ(X, M₂) → Hⁿ(X, M₃)` is onto, so
+`Hⁿ(X, M₃)` is finite-dimensional as soon as `Hⁿ(X, M₂)` is. -/
+private lemma finiteDimensional_X₃_of_cohomologyδ_eq_zero (n : ℕ)
+    [FiniteDimensional k (Cohomology S.X₂ n)]
+    (hδ : cohomologyδBaseLinear k X hS n (n + 1) rfl = 0) :
+    FiniteDimensional k (Cohomology S.X₃ n) :=
+  Module.Finite.of_surjective (cohomologyMapBaseLinear k X S.g n) fun x ↦
+    (exact_cohomologyMapBaseLinear_cohomologyδBaseLinear k hS n x).1 (by simp [hδ])
 
 /-- Rank-nullity in degree zero for the first term: the map on `H⁰` is injective, so its image
 has the dimension of `H⁰(X, M₁)`. -/
@@ -201,12 +238,8 @@ private lemma finrank_X₃ (i : ℕ) [FiniteDimensional k (Cohomology S.X₃ i)]
     finrank k (Cohomology S.X₃ i) =
       finrank k (LinearMap.range (cohomologyδBaseLinear k X hS i (i + 1) rfl)) +
         finrank k (LinearMap.range (cohomologyMapBaseLinear k X S.g i)) := by
-  have hex : Function.Exact (cohomologyMapBaseLinear k X S.g i)
-      (cohomologyδBaseLinear k X hS i (i + 1) rfl) := by
-    simpa only [coe_cohomologyδBaseLinear, coe_cohomologyMapBaseLinear] using
-      exact_cohomologyMap_cohomologyδ hS i (i + 1) rfl
   rw [← LinearMap.finrank_range_add_finrank_ker (cohomologyδBaseLinear k X hS i (i + 1) rfl),
-    hex.linearMap_ker_eq]
+    (exact_cohomologyMapBaseLinear_cohomologyδBaseLinear k hS i).linearMap_ker_eq]
 
 /-- The defect of additivity of the truncated Euler characteristic on a short exact sequence
 `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is, up to sign, the dimension of the image of the connecting map
@@ -215,11 +248,12 @@ private lemma finrank_X₃ (i : ℕ) [FiniteDimensional k (Cohomology S.X₃ i)]
 Finite-dimensionality is only assumed in the degrees the truncation reads, that is in the
 degrees `< n + 1` summed over — and for the first term of the sequence only in the positive
 ones, since the degree-zero contribution of `M₁` is computed by the injectivity of
-`H⁰(X, M₁) → H⁰(X, M₂)` rather than by rank-nullity. -/
+`H⁰(X, M₁) → H⁰(X, M₂)` rather than by rank-nullity, and for the third term only in the top
+degree `n`, since exactness supplies it in the lower ones. -/
 theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
     (h₁ : ∀ i < n + 1, 0 < i → FiniteDimensional k (Cohomology S.X₁ i))
     (h₂ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₂ i))
-    (h₃ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₃ i)) :
+    (h₃ : FiniteDimensional k (Cohomology S.X₃ n)) :
     eulerCharBelow k X S.X₂ (n + 1) - eulerCharBelow k X S.X₁ (n + 1) -
         eulerCharBelow k X S.X₃ (n + 1) =
       (-1) ^ (n + 1) *
@@ -227,7 +261,6 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
   induction n with
   | zero =>
     have hfd₂ := h₂ 0 (by omega)
-    have hfd₃ := h₃ 0 (by omega)
     rw [eulerCharBelow_succ k S.X₂ 0, eulerCharBelow_succ k S.X₁ 0,
       eulerCharBelow_succ k S.X₃ 0, eulerCharBelow_zero, eulerCharBelow_zero,
       eulerCharBelow_zero, finrank_X₁_zero k hS, finrank_X₂ k hS 0, finrank_X₃ k hS 0]
@@ -236,9 +269,9 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
   | succ n ih =>
     have hfd₁ := h₁ (n + 1) (by omega) (by omega)
     have hfd₂ := h₂ (n + 1) (by omega)
-    have hfd₃ := h₃ (n + 1) (by omega)
+    have hfd₂' := h₂ n (by omega)
     have ih := ih (fun i hi ↦ h₁ i (by omega)) (fun i hi ↦ h₂ i (by omega))
-      (fun i hi ↦ h₃ i (by omega))
+      (finiteDimensional_X₃ k hS n)
     rw [eulerCharBelow_succ k S.X₂ (n + 1), eulerCharBelow_succ k S.X₁ (n + 1),
       eulerCharBelow_succ k S.X₃ (n + 1), finrank_X₁_succ k hS n, finrank_X₂ k hS (n + 1),
       finrank_X₃ k hS (n + 1)]
@@ -246,9 +279,11 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
     linear_combination ih
 
 /-- **Additivity of the Euler characteristic.** If `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is a short exact
-sequence of sheaves of modules whose cohomology is finite-dimensional in the degrees
-`< n + 1` that the truncation reads, and the connecting map `Hⁿ(X, M₃) → Hⁿ⁺¹(X, M₁)` that the
-truncation cuts off vanishes, then the Euler characteristics truncated at `n + 1` add up.
+sequence of sheaves of modules whose first two terms have finite-dimensional cohomology in the
+degrees `< n + 1` that the truncation reads, and the connecting map `Hⁿ(X, M₃) → Hⁿ⁺¹(X, M₁)`
+that the truncation cuts off vanishes, then the Euler characteristics truncated at `n + 1` add
+up. The third term needs no hypothesis: exactness makes its cohomology finite-dimensional in
+those degrees too.
 
 This is the exact hypothesis the defect formula `eulerCharBelow_sub_sub` asks for; the usual
 sufficient condition, the vanishing of the whole target `Hⁿ⁺¹(X, M₁)`, is
@@ -257,43 +292,42 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_eq_add_of_cohomol
     (n : ℕ)
     (h₁ : ∀ i < n + 1, 0 < i → FiniteDimensional k (Cohomology S.X₁ i))
     (h₂ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₂ i))
-    (h₃ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₃ i))
     (hδ : cohomologyδBaseLinear k X hS n (n + 1) rfl = 0) :
     eulerCharBelow k X S.X₂ (n + 1) =
       eulerCharBelow k X S.X₁ (n + 1) + eulerCharBelow k X S.X₃ (n + 1) := by
-  have h := eulerCharBelow_sub_sub k hS n h₁ h₂ h₃
+  have hfd₂ := h₂ n (by omega)
+  have h := eulerCharBelow_sub_sub k hS n h₁ h₂
+    (finiteDimensional_X₃_of_cohomologyδ_eq_zero k hS n hδ)
   rw [hδ, LinearMap.range_zero, finrank_bot, Nat.cast_zero, mul_zero] at h
   linarith
 
 /-- **Additivity of the Euler characteristic under a vanishing target.** If
-`0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is a short exact sequence of sheaves of modules whose cohomology is
-finite-dimensional in the degrees `< n` that the truncation reads, and `Hⁿ(X, M₁)` vanishes,
-then the Euler characteristics truncated at `n` add up. -/
+`0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is a short exact sequence of sheaves of modules whose first two terms
+have finite-dimensional cohomology in the degrees `< n` that the truncation reads, and
+`Hⁿ(X, M₁)` vanishes, then the Euler characteristics truncated at `n` add up. -/
 theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_eq_add (n : ℕ)
     (h₁ : ∀ i < n, 0 < i → FiniteDimensional k (Cohomology S.X₁ i))
     (h₂ : ∀ i < n, FiniteDimensional k (Cohomology S.X₂ i))
-    (h₃ : ∀ i < n, FiniteDimensional k (Cohomology S.X₃ i))
     (hvan : Subsingleton (Cohomology S.X₁ n)) :
     eulerCharBelow k X S.X₂ n = eulerCharBelow k X S.X₁ n + eulerCharBelow k X S.X₃ n := by
   cases n with
   | zero => simp
   | succ n =>
-    exact eulerCharBelow_eq_add_of_cohomologyδ_eq_zero k hS n h₁ h₂ h₃
+    exact eulerCharBelow_eq_add_of_cohomologyδ_eq_zero k hS n h₁ h₂
       (LinearMap.ext fun _ ↦ Subsingleton.elim _ _)
 
 /-- **Additivity of the Euler characteristic on a curve.** For a short exact sequence of sheaves
-of modules whose cohomology is finite-dimensional in degrees `0` and `1` and with `H²(X, M₁)`
-vanishing, as it does on a curve, the Euler characteristics
+of modules whose first two terms have finite-dimensional cohomology in degrees `0` and `1` and
+with `H²(X, M₁)` vanishing, as it does on a curve, the Euler characteristics
 `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)` add up. -/
 theorem _root_.AlgebraicGeometry.Scheme.Modules.finrank_cohomology_zero_sub_one_eq_add
     (h₁ : ∀ i < 2, 0 < i → FiniteDimensional k (Cohomology S.X₁ i))
     (h₂ : ∀ i < 2, FiniteDimensional k (Cohomology S.X₂ i))
-    (h₃ : ∀ i < 2, FiniteDimensional k (Cohomology S.X₃ i))
     (hvan : Subsingleton (Cohomology S.X₁ 2)) :
     (finrank k (Cohomology S.X₂ 0) : ℤ) - (finrank k (Cohomology S.X₂ 1) : ℤ) =
       ((finrank k (Cohomology S.X₁ 0) : ℤ) - (finrank k (Cohomology S.X₁ 1) : ℤ)) +
         ((finrank k (Cohomology S.X₃ 0) : ℤ) - (finrank k (Cohomology S.X₃ 1) : ℤ)) := by
-  simpa only [eulerCharBelow_two] using eulerCharBelow_eq_add k hS 2 h₁ h₂ h₃ hvan
+  simpa only [eulerCharBelow_two] using eulerCharBelow_eq_add k hS 2 h₁ h₂ hvan
 
 end ShortExact
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
@@ -40,7 +40,9 @@ space, so a degree `i < n` in which `Hⁱ(X, M)` is infinite-dimensional contrib
 sum instead of making it meaningless. The alternating sum is therefore the Euler characteristic
 only for a sheaf whose cohomology is finite-dimensional in degrees `< n`: accordingly the
 statements that read it as an Euler characteristic, `eulerCharBelow_sub_sub`,
-`eulerCharBelow_X₂` and `eulerChar_X₂`, all assume that finite-dimensionality, while
+`eulerCharBelow_X₂` and `eulerChar_X₂`, assume that finite-dimensionality — and only in the
+degrees below the truncation that they actually sum over, so that the curve statement
+`eulerChar_X₂` needs it in degrees `0` and `1` alone — while
 `eulerCharBelow_zero`, `eulerCharBelow_succ`, `eulerCharBelow_two` and `eulerCharBelow_congr`
 are identities of the alternating sum as it stands and need no such hypothesis.
 
@@ -196,26 +198,35 @@ private lemma finrank_X₃ (i : ℕ) [FiniteDimensional k (Cohomology S.X₃ i)]
   rw [← LinearMap.finrank_range_add_finrank_ker (cohomologyδBaseLinear k X hS i (i + 1) rfl),
     hex.linearMap_ker_eq]
 
-variable [∀ i, FiniteDimensional k (Cohomology S.X₁ i)]
-  [∀ i, FiniteDimensional k (Cohomology S.X₂ i)]
-  [∀ i, FiniteDimensional k (Cohomology S.X₃ i)]
-
 /-- The defect of additivity of the truncated Euler characteristic on a short exact sequence
 `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is, up to sign, the dimension of the image of the connecting map
-`Hⁿ(X, M₃) → Hⁿ⁺¹(X, M₁)` that the truncation cuts off. -/
-theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ) :
+`Hⁿ(X, M₃) → Hⁿ⁺¹(X, M₁)` that the truncation cuts off.
+
+Finite-dimensionality is only assumed in the degrees the truncation reads, that is in the
+degrees `< n + 1` summed over. -/
+theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
+    (h₁ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₁ i))
+    (h₂ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₂ i))
+    (h₃ : ∀ i < n + 1, FiniteDimensional k (Cohomology S.X₃ i)) :
     eulerCharBelow k X S.X₂ (n + 1) - eulerCharBelow k X S.X₁ (n + 1) -
         eulerCharBelow k X S.X₃ (n + 1) =
       (-1) ^ (n + 1) *
         (finrank k (LinearMap.range (cohomologyδBaseLinear k X hS n (n + 1) rfl)) : ℤ) := by
   induction n with
   | zero =>
+    have hfd₂ := h₂ 0 (by omega)
+    have hfd₃ := h₃ 0 (by omega)
     rw [eulerCharBelow_succ k S.X₂ 0, eulerCharBelow_succ k S.X₁ 0,
       eulerCharBelow_succ k S.X₃ 0, eulerCharBelow_zero, eulerCharBelow_zero,
       eulerCharBelow_zero, finrank_X₁_zero k hS, finrank_X₂ k hS 0, finrank_X₃ k hS 0]
     push_cast
     ring
   | succ n ih =>
+    have hfd₁ := h₁ (n + 1) (by omega)
+    have hfd₂ := h₂ (n + 1) (by omega)
+    have hfd₃ := h₃ (n + 1) (by omega)
+    have ih := ih (fun i hi ↦ h₁ i (by omega)) (fun i hi ↦ h₂ i (by omega))
+      (fun i hi ↦ h₃ i (by omega))
     rw [eulerCharBelow_succ k S.X₂ (n + 1), eulerCharBelow_succ k S.X₁ (n + 1),
       eulerCharBelow_succ k S.X₃ (n + 1), finrank_X₁_succ k hS n, finrank_X₂ k hS (n + 1),
       finrank_X₃ k hS (n + 1)]
@@ -223,9 +234,13 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ)
     linear_combination ih
 
 /-- **Additivity of the Euler characteristic.** If `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is a short exact
-sequence of sheaves of modules with finite-dimensional cohomology, and `Hⁿ(X, M₁)` vanishes,
-then the Euler characteristics truncated at `n` add up. -/
+sequence of sheaves of modules whose cohomology is finite-dimensional in the degrees `< n` that
+the truncation reads, and `Hⁿ(X, M₁)` vanishes, then the Euler characteristics truncated at `n`
+add up. -/
 theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_X₂ (n : ℕ)
+    (h₁ : ∀ i < n, FiniteDimensional k (Cohomology S.X₁ i))
+    (h₂ : ∀ i < n, FiniteDimensional k (Cohomology S.X₂ i))
+    (h₃ : ∀ i < n, FiniteDimensional k (Cohomology S.X₃ i))
     (hvan : Subsingleton (Cohomology S.X₁ n)) :
     eulerCharBelow k X S.X₂ n = eulerCharBelow k X S.X₁ n + eulerCharBelow k X S.X₃ n := by
   cases n with
@@ -234,19 +249,23 @@ theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_X₂ (n : ℕ)
     have hrange : LinearMap.range (cohomologyδBaseLinear k X hS n (n + 1) rfl) = ⊥ := by
       rw [LinearMap.range_eq_bot]
       exact LinearMap.ext fun _ ↦ Subsingleton.elim _ _
-    have h := eulerCharBelow_sub_sub k hS n
+    have h := eulerCharBelow_sub_sub k hS n h₁ h₂ h₃
     rw [hrange, finrank_bot, Nat.cast_zero, mul_zero] at h
     linarith
 
 /-- **Additivity of the Euler characteristic on a curve.** For a short exact sequence of sheaves
-of modules with finite-dimensional cohomology and with `H²(X, M₁)` vanishing, as it does on a
-curve, the Euler characteristics `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)` add up. -/
+of modules whose cohomology is finite-dimensional in degrees `0` and `1` and with `H²(X, M₁)`
+vanishing, as it does on a curve, the Euler characteristics
+`χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)` add up. -/
 theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerChar_X₂
+    (h₁ : ∀ i < 2, FiniteDimensional k (Cohomology S.X₁ i))
+    (h₂ : ∀ i < 2, FiniteDimensional k (Cohomology S.X₂ i))
+    (h₃ : ∀ i < 2, FiniteDimensional k (Cohomology S.X₃ i))
     (hvan : Subsingleton (Cohomology S.X₁ 2)) :
     (finrank k (Cohomology S.X₂ 0) : ℤ) - (finrank k (Cohomology S.X₂ 1) : ℤ) =
       ((finrank k (Cohomology S.X₁ 0) : ℤ) - (finrank k (Cohomology S.X₁ 1) : ℤ)) +
         ((finrank k (Cohomology S.X₃ 0) : ℤ) - (finrank k (Cohomology S.X₃ 1) : ℤ)) := by
-  simpa only [eulerCharBelow_two] using eulerCharBelow_X₂ k hS 2 hvan
+  simpa only [eulerCharBelow_two] using eulerCharBelow_X₂ k hS 2 h₁ h₂ h₃ hvan
 
 end ShortExact
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
@@ -12,16 +12,16 @@ public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 /-!
 # The Euler characteristic of a sheaf of modules on a scheme
 
-For a scheme `X` over a field `k`, the cohomology `Hⁱ(X, M)` of a sheaf of modules is a
-`k`-vector space, so the alternating sum of its dimensions can be formed. This file introduces
-that alternating sum, truncated at a degree `n`, and proves that it is additive on short exact
-sequences as soon as the truncation degree is one past the last nonvanishing degree.
+For a scheme `X` over a field `k`, the finite-dimensional cohomology `Hⁱ(X, M)` of a sheaf of
+modules is a `k`-vector space, so the alternating sum of its dimensions can be formed. This file
+introduces that alternating sum, truncated at a degree `n`, and proves that it is additive on short
+exact sequences as soon as the truncation degree is one past the last nonvanishing degree.
 
 ## Main declarations
 
 * `Scheme.Modules.eulerCharBelow k X M n`, the alternating sum
-  `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)`. For a sheaf whose cohomology vanishes in degrees `≥ n` this
-  is the Euler characteristic `χ(X, M)`;
+  `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)` for a sheaf with finite-dimensional cohomology. If its
+  cohomology also vanishes in degrees `≥ n`, this is the Euler characteristic `χ(X, M)`;
 * `Scheme.Modules.eulerCharBelow_sub_sub`, the exact defect of additivity: the failure of
   `eulerCharBelow` to be additive on a short exact sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is, up to
   sign, the dimension of the image of the last connecting map that the truncation cuts off;
@@ -65,27 +65,32 @@ namespace Scheme.Modules
 
 variable (k : Type u) [Field k] (X : Scheme.{u}) [X.Over (Spec (.of k))]
 
-/-- The alternating sum `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)` of the dimensions of the cohomology of
-a sheaf of modules on a scheme over a field, truncated at degree `n`.
+/-- The alternating sum `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)` of the dimensions of the
+finite-dimensional cohomology of a sheaf of modules on a scheme over a field, truncated at
+degree `n`.
 
 For a sheaf whose cohomology vanishes in degrees `≥ n` this is the Euler characteristic
 `χ(X, M)`; on a curve, the relevant truncation is `n = 2`. -/
-def _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow (M : X.Modules) (n : ℕ) : ℤ :=
+def _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow (M : X.Modules)
+    [∀ i, FiniteDimensional k (Cohomology M i)] (n : ℕ) : ℤ :=
   ∑ i ∈ Finset.range n, (-1) ^ i * (finrank k (Cohomology M i) : ℤ)
 
 variable {X}
 
 @[simp]
-lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_zero (M : X.Modules) :
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_zero (M : X.Modules)
+    [∀ i, FiniteDimensional k (Cohomology M i)] :
     eulerCharBelow k X M 0 = 0 :=
   Finset.sum_range_zero _
 
-lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_succ (M : X.Modules) (n : ℕ) :
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_succ (M : X.Modules)
+    [∀ i, FiniteDimensional k (Cohomology M i)] (n : ℕ) :
     eulerCharBelow k X M (n + 1) =
       eulerCharBelow k X M n + (-1) ^ n * (finrank k (Cohomology M n) : ℤ) :=
   Finset.sum_range_succ _ _
 
-lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_two (M : X.Modules) :
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_two (M : X.Modules)
+    [∀ i, FiniteDimensional k (Cohomology M i)] :
     eulerCharBelow k X M 2 =
       (finrank k (Cohomology M 0) : ℤ) - (finrank k (Cohomology M 1) : ℤ) := by
   rw [eulerCharBelow_succ, eulerCharBelow_succ, eulerCharBelow_zero]
@@ -110,7 +115,8 @@ lemma _root_.AlgebraicGeometry.Scheme.Modules.finrank_cohomology_congr {M N : X.
 is what makes an invariant such as the degree `χ(L) - χ(𝒪_X)` of a line bundle well defined on
 the Picard group. -/
 lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_congr {M N : X.Modules}
-    (e : M ≅ N) (n : ℕ) :
+    [∀ i, FiniteDimensional k (Cohomology M i)]
+    [∀ i, FiniteDimensional k (Cohomology N i)] (e : M ≅ N) (n : ℕ) :
     eulerCharBelow k X M n = eulerCharBelow k X N n :=
   Finset.sum_congr rfl fun i _ ↦ by rw [finrank_cohomology_congr k e i]
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
@@ -20,8 +20,8 @@ sequences as soon as the truncation degree is one past the last nonvanishing deg
 ## Main declarations
 
 * `Scheme.Modules.eulerCharBelow k X M n`, the alternating sum
-  `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)`. For a sheaf whose cohomology vanishes in degrees `≥ n` this
-  is the Euler characteristic `χ(X, M)`;
+  `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)`. For a sheaf whose cohomology is finite-dimensional in
+  degrees `< n` and vanishes in degrees `≥ n` this is the Euler characteristic `χ(X, M)`;
 * `Scheme.Modules.eulerCharBelow_sub_sub`, the exact defect of additivity: the failure of
   `eulerCharBelow` to be additive on a short exact sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is, up to
   sign, the dimension of the image of the last connecting map that the truncation cuts off;
@@ -31,6 +31,18 @@ sequences as soon as the truncation degree is one past the last nonvanishing deg
 * `Scheme.Modules.eulerCharBelow_congr`, the invariance of the truncated Euler characteristic
   under isomorphism, and `Scheme.Modules.finrank_cohomology_zero`, the identification of
   `dim H⁰(X, M)` with the dimension of the space of global sections.
+
+## Junk values
+
+No finiteness assumption is built into `eulerCharBelow`, exactly as none is built into
+Mathlib's `HomologicalComplex.eulerChar`: `Module.finrank` is `0` on an infinite-dimensional
+space, so a degree `i < n` in which `Hⁱ(X, M)` is infinite-dimensional contributes `0` to the
+sum instead of making it meaningless. The alternating sum is therefore the Euler characteristic
+only for a sheaf whose cohomology is finite-dimensional in degrees `< n`: accordingly the
+statements that read it as an Euler characteristic, `eulerCharBelow_sub_sub`,
+`eulerCharBelow_X₂` and `eulerChar_X₂`, all assume that finite-dimensionality, while
+`eulerCharBelow_zero`, `eulerCharBelow_succ`, `eulerCharBelow_two` and `eulerCharBelow_congr`
+are identities of the alternating sum as it stands and need no such hypothesis.
 
 The proof is the usual dimension count in the long exact cohomology sequence: the rank-nullity
 theorem turns each of the three cohomology dimensions in degree `i` into a sum of two ranks of
@@ -68,8 +80,11 @@ variable (k : Type u) [Field k] (X : Scheme.{u}) [X.Over (Spec (.of k))]
 /-- The alternating sum `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)` of the dimensions of the cohomology of
 a sheaf of modules on a scheme over a field, truncated at degree `n`.
 
-For a sheaf whose cohomology vanishes in degrees `≥ n` this is the Euler characteristic
-`χ(X, M)`; on a curve, the relevant truncation is `n = 2`. -/
+No finiteness assumption is imposed, just as none is imposed on Mathlib's
+`HomologicalComplex.eulerChar`: a degree `i < n` in which `Hⁱ(X, M)` is infinite-dimensional
+contributes the junk value `finrank k Hⁱ(X, M) = 0`. This sum is thus the Euler characteristic
+`χ(X, M)` precisely for a sheaf whose cohomology is finite-dimensional in degrees `< n` and
+vanishes in degrees `≥ n`; on a curve, the relevant truncation is `n = 2`. -/
 def _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow (M : X.Modules) (n : ℕ) : ℤ :=
   ∑ i ∈ Finset.range n, (-1) ^ i * (finrank k (Cohomology M i) : ℤ)
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.Cohomology.LongExactSequence
+public import Mathlib.Algebra.Exact.Basic
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+
+/-!
+# The Euler characteristic of a sheaf of modules on a scheme
+
+For a scheme `X` over a field `k`, the cohomology `Hⁱ(X, M)` of a sheaf of modules is a
+`k`-vector space, so the alternating sum of its dimensions can be formed. This file introduces
+that alternating sum, truncated at a degree `n`, and proves that it is additive on short exact
+sequences as soon as the truncation degree is one past the last nonvanishing degree.
+
+## Main declarations
+
+* `Scheme.Modules.eulerCharBelow k X M n`, the alternating sum
+  `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)`. For a sheaf whose cohomology vanishes in degrees `≥ n` this
+  is the Euler characteristic `χ(X, M)`;
+* `Scheme.Modules.eulerCharBelow_sub_sub`, the exact defect of additivity: the failure of
+  `eulerCharBelow` to be additive on a short exact sequence `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is, up to
+  sign, the dimension of the image of the last connecting map that the truncation cuts off;
+* `Scheme.Modules.eulerCharBelow_X₂`, the additivity itself, under the vanishing of
+  `Hⁿ(X, M₁)`, and `Scheme.Modules.eulerChar_X₂`, its shape on a curve, where cohomology
+  vanishes above degree one so that `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)`;
+* `Scheme.Modules.eulerCharBelow_congr`, the invariance of the truncated Euler characteristic
+  under isomorphism, and `Scheme.Modules.finrank_cohomology_zero`, the identification of
+  `dim H⁰(X, M)` with the dimension of the space of global sections.
+
+The proof is the usual dimension count in the long exact cohomology sequence: the rank-nullity
+theorem turns each of the three cohomology dimensions in degree `i` into a sum of two ranks of
+maps of the sequence, and the alternating sum telescopes down to the single rank left over at
+the truncation degree.
+
+Additivity of the Euler characteristic is what makes the degree of a line bundle on a curve,
+`deg L := χ(L) - χ(𝒪_X)`, behave additively, and it is the step from which Riemann-Roch is
+proved by induction on a divisor. It is therefore Layer B infrastructure for
+`TauCetiRoadmap/JacobianChallenge/README.md`, "genus, Riemann-Roch, Serre duality".
+
+No formalization is vendored. The alternating-sum bookkeeping reuses Mathlib's
+`LinearMap.finrank_range_add_finrank_ker`, `LinearMap.finrank_range_of_inj` and
+`Function.Exact.linearMap_ker_eq`; the long exact sequence and the linearity of its maps are
+`TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean`.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry Scheme.Modules
+open Module (finrank)
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+namespace Scheme.Modules
+
+variable (k : Type u) [Field k] (X : Scheme.{u}) [X.Over (Spec (.of k))]
+
+/-- The alternating sum `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)` of the dimensions of the cohomology of
+a sheaf of modules on a scheme over a field, truncated at degree `n`.
+
+For a sheaf whose cohomology vanishes in degrees `≥ n` this is the Euler characteristic
+`χ(X, M)`; on a curve, the relevant truncation is `n = 2`. -/
+def _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow (M : X.Modules) (n : ℕ) : ℤ :=
+  ∑ i ∈ Finset.range n, (-1) ^ i * (finrank k (Cohomology M i) : ℤ)
+
+variable {X}
+
+@[simp]
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_zero (M : X.Modules) :
+    eulerCharBelow k X M 0 = 0 :=
+  Finset.sum_range_zero _
+
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_succ (M : X.Modules) (n : ℕ) :
+    eulerCharBelow k X M (n + 1) =
+      eulerCharBelow k X M n + (-1) ^ n * (finrank k (Cohomology M n) : ℤ) :=
+  Finset.sum_range_succ _ _
+
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_two (M : X.Modules) :
+    eulerCharBelow k X M 2 =
+      (finrank k (Cohomology M 0) : ℤ) - (finrank k (Cohomology M 1) : ℤ) := by
+  rw [eulerCharBelow_succ, eulerCharBelow_succ, eulerCharBelow_zero]
+  ring
+
+/-- The dimension of `H⁰(X, M)` is the dimension of the space of global sections of `M`. -/
+lemma _root_.AlgebraicGeometry.Scheme.Modules.finrank_cohomology_zero (M : X.Modules) :
+    finrank k (Cohomology M 0) = finrank k Γ(M, ⊤) :=
+  (cohomologyZeroBaseLinearEquiv k X M).finrank_eq
+
+/-- Isomorphic sheaves of modules have the same cohomology dimensions. -/
+lemma _root_.AlgebraicGeometry.Scheme.Modules.finrank_cohomology_congr {M N : X.Modules}
+    (e : M ≅ N) (i : ℕ) :
+    finrank k (Cohomology M i) = finrank k (Cohomology N i) :=
+  LinearEquiv.finrank_eq <|
+    LinearEquiv.ofLinearMap (cohomologyMapBaseLinear k X e.hom i)
+      (cohomologyMapBaseLinear k X e.inv i)
+      (by rw [← cohomologyMapBaseLinear_comp, e.inv_hom_id, cohomologyMapBaseLinear_id])
+      (by rw [← cohomologyMapBaseLinear_comp, e.hom_inv_id, cohomologyMapBaseLinear_id])
+
+/-- The truncated Euler characteristic only depends on the isomorphism class of the sheaf. This
+is what makes an invariant such as the degree `χ(L) - χ(𝒪_X)` of a line bundle well defined on
+the Picard group. -/
+lemma _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_congr {M N : X.Modules}
+    (e : M ≅ N) (n : ℕ) :
+    eulerCharBelow k X M n = eulerCharBelow k X N n :=
+  Finset.sum_congr rfl fun i _ ↦ by rw [finrank_cohomology_congr k e i]
+
+section ShortExact
+
+variable {S : ShortComplex X.Modules} (hS : S.ShortExact)
+
+omit hS in
+private lemma coe_cohomologyMapBaseLinear {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
+    ⇑(cohomologyMapBaseLinear k X f i) = ⇑(cohomologyMap f i) := by
+  funext x
+  rw [cohomologyMapBaseLinear_apply, cohomologyFunctor_map]
+  rfl
+
+include hS
+
+private lemma coe_cohomologyδBaseLinear (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    ⇑(cohomologyδBaseLinear k X hS n₀ n₁ h) = ⇑(cohomologyδ hS n₀ n₁ h) := by
+  funext x
+  exact cohomologyδBaseLinear_apply k X hS n₀ n₁ h x
+
+/-- Rank-nullity in degree zero for the first term: the map on `H⁰` is injective, so its image
+has the dimension of `H⁰(X, M₁)`. -/
+private lemma finrank_X₁_zero :
+    finrank k (Cohomology S.X₁ 0) =
+      finrank k (LinearMap.range (cohomologyMapBaseLinear k X S.f 0)) := by
+  have := hS.mono_f
+  have hinj : Function.Injective (cohomologyMapBaseLinear k X S.f 0) := by
+    rw [coe_cohomologyMapBaseLinear]
+    exact cohomologyMap_injective S.f
+  exact (LinearMap.finrank_range_of_inj hinj).symm
+
+/-- Rank-nullity in positive degrees for the first term: the kernel of `Hⁱ⁺¹(M₁) → Hⁱ⁺¹(M₂)` is
+the image of the connecting map out of `Hⁱ(M₃)`. -/
+private lemma finrank_X₁_succ (i : ℕ) [FiniteDimensional k (Cohomology S.X₁ (i + 1))] :
+    finrank k (Cohomology S.X₁ (i + 1)) =
+      finrank k (LinearMap.range (cohomologyMapBaseLinear k X S.f (i + 1))) +
+        finrank k (LinearMap.range (cohomologyδBaseLinear k X hS i (i + 1) rfl)) := by
+  have hex : Function.Exact (cohomologyδBaseLinear k X hS i (i + 1) rfl)
+      (cohomologyMapBaseLinear k X S.f (i + 1)) := by
+    simpa only [coe_cohomologyδBaseLinear, coe_cohomologyMapBaseLinear] using
+      exact_cohomologyδ_cohomologyMap hS i (i + 1) rfl
+  rw [← LinearMap.finrank_range_add_finrank_ker (cohomologyMapBaseLinear k X S.f (i + 1)),
+    hex.linearMap_ker_eq]
+
+/-- Rank-nullity for the middle term: the kernel of `Hⁱ(M₂) → Hⁱ(M₃)` is the image of
+`Hⁱ(M₁) → Hⁱ(M₂)`. -/
+private lemma finrank_X₂ (i : ℕ) [FiniteDimensional k (Cohomology S.X₂ i)] :
+    finrank k (Cohomology S.X₂ i) =
+      finrank k (LinearMap.range (cohomologyMapBaseLinear k X S.g i)) +
+        finrank k (LinearMap.range (cohomologyMapBaseLinear k X S.f i)) := by
+  have hex : Function.Exact (cohomologyMapBaseLinear k X S.f i)
+      (cohomologyMapBaseLinear k X S.g i) := by
+    simpa only [coe_cohomologyMapBaseLinear] using exact_cohomologyMap_cohomologyMap hS i
+  rw [← LinearMap.finrank_range_add_finrank_ker (cohomologyMapBaseLinear k X S.g i),
+    hex.linearMap_ker_eq]
+
+/-- Rank-nullity for the last term: the kernel of the connecting map out of `Hⁱ(M₃)` is the
+image of `Hⁱ(M₂) → Hⁱ(M₃)`. -/
+private lemma finrank_X₃ (i : ℕ) [FiniteDimensional k (Cohomology S.X₃ i)] :
+    finrank k (Cohomology S.X₃ i) =
+      finrank k (LinearMap.range (cohomologyδBaseLinear k X hS i (i + 1) rfl)) +
+        finrank k (LinearMap.range (cohomologyMapBaseLinear k X S.g i)) := by
+  have hex : Function.Exact (cohomologyMapBaseLinear k X S.g i)
+      (cohomologyδBaseLinear k X hS i (i + 1) rfl) := by
+    simpa only [coe_cohomologyδBaseLinear, coe_cohomologyMapBaseLinear] using
+      exact_cohomologyMap_cohomologyδ hS i (i + 1) rfl
+  rw [← LinearMap.finrank_range_add_finrank_ker (cohomologyδBaseLinear k X hS i (i + 1) rfl),
+    hex.linearMap_ker_eq]
+
+variable [∀ i, FiniteDimensional k (Cohomology S.X₁ i)]
+  [∀ i, FiniteDimensional k (Cohomology S.X₂ i)]
+  [∀ i, FiniteDimensional k (Cohomology S.X₃ i)]
+
+/-- The defect of additivity of the truncated Euler characteristic on a short exact sequence
+`0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is, up to sign, the dimension of the image of the connecting map
+`Hⁿ(X, M₃) → Hⁿ⁺¹(X, M₁)` that the truncation cuts off. -/
+theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_sub_sub (n : ℕ) :
+    eulerCharBelow k X S.X₂ (n + 1) - eulerCharBelow k X S.X₁ (n + 1) -
+        eulerCharBelow k X S.X₃ (n + 1) =
+      (-1) ^ (n + 1) *
+        (finrank k (LinearMap.range (cohomologyδBaseLinear k X hS n (n + 1) rfl)) : ℤ) := by
+  induction n with
+  | zero =>
+    rw [eulerCharBelow_succ k S.X₂ 0, eulerCharBelow_succ k S.X₁ 0,
+      eulerCharBelow_succ k S.X₃ 0, eulerCharBelow_zero, eulerCharBelow_zero,
+      eulerCharBelow_zero, finrank_X₁_zero k hS, finrank_X₂ k hS 0, finrank_X₃ k hS 0]
+    push_cast
+    ring
+  | succ n ih =>
+    rw [eulerCharBelow_succ k S.X₂ (n + 1), eulerCharBelow_succ k S.X₁ (n + 1),
+      eulerCharBelow_succ k S.X₃ (n + 1), finrank_X₁_succ k hS n, finrank_X₂ k hS (n + 1),
+      finrank_X₃ k hS (n + 1)]
+    push_cast
+    linear_combination ih
+
+/-- **Additivity of the Euler characteristic.** If `0 ⟶ M₁ ⟶ M₂ ⟶ M₃ ⟶ 0` is a short exact
+sequence of sheaves of modules with finite-dimensional cohomology, and `Hⁿ(X, M₁)` vanishes,
+then the Euler characteristics truncated at `n` add up. -/
+theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerCharBelow_X₂ (n : ℕ)
+    (hvan : Subsingleton (Cohomology S.X₁ n)) :
+    eulerCharBelow k X S.X₂ n = eulerCharBelow k X S.X₁ n + eulerCharBelow k X S.X₃ n := by
+  cases n with
+  | zero => simp
+  | succ n =>
+    have hrange : LinearMap.range (cohomologyδBaseLinear k X hS n (n + 1) rfl) = ⊥ := by
+      rw [LinearMap.range_eq_bot]
+      exact LinearMap.ext fun _ ↦ Subsingleton.elim _ _
+    have h := eulerCharBelow_sub_sub k hS n
+    rw [hrange, finrank_bot, Nat.cast_zero, mul_zero] at h
+    linarith
+
+/-- **Additivity of the Euler characteristic on a curve.** For a short exact sequence of sheaves
+of modules with finite-dimensional cohomology and with `H²(X, M₁)` vanishing, as it does on a
+curve, the Euler characteristics `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)` add up. -/
+theorem _root_.AlgebraicGeometry.Scheme.Modules.eulerChar_X₂
+    (hvan : Subsingleton (Cohomology S.X₁ 2)) :
+    (finrank k (Cohomology S.X₂ 0) : ℤ) - (finrank k (Cohomology S.X₂ 1) : ℤ) =
+      ((finrank k (Cohomology S.X₁ 0) : ℤ) - (finrank k (Cohomology S.X₁ 1) : ℤ)) +
+        ((finrank k (Cohomology S.X₃ 0) : ℤ) - (finrank k (Cohomology S.X₃ 1) : ℤ)) := by
+  simpa only [eulerCharBelow_two] using eulerCharBelow_X₂ k hS 2 hvan
+
+end ShortExact
+
+end Scheme.Modules
+
+end
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
@@ -185,36 +185,12 @@ theorem sections_surjective (h₁ : Subsingleton (Cohomology S.X₁ 1)) :
 omit hS in
 /-- Multiplication by a global function on cohomology is the map induced by multiplication by
 that function on the coefficient sheaf. -/
+@[simp]
 lemma _root_.AlgebraicGeometry.Scheme.Modules.cohomologyMap_globalSectionsSmul (M : X.Modules)
     (i : ℕ) (r : Γ(X, ⊤)) (x : Cohomology M i) :
     cohomologyMap (globalSectionsSmul M r) i x = r • x := by
   rw [cohomology_smul, cohomologyFunctor_map]
   rfl
-
-omit hS in
-/-- Multiplication by a global function, as an endomorphism of a short complex of sheaves of
-modules. -/
-def globalSectionsSmulShortComplex (S : ShortComplex X.Modules) (r : Γ(X, ⊤)) : S ⟶ S where
-  τ₁ := globalSectionsSmul S.X₁ r
-  τ₂ := globalSectionsSmul S.X₂ r
-  τ₃ := globalSectionsSmul S.X₃ r
-  comm₁₂ := globalSectionsSmul_naturality S.f r
-  comm₂₃ := globalSectionsSmul_naturality S.g r
-
-omit hS in
-@[simp]
-lemma globalSectionsSmulShortComplex_τ₁ (S : ShortComplex X.Modules) (r : Γ(X, ⊤)) :
-    (globalSectionsSmulShortComplex S r).τ₁ = globalSectionsSmul S.X₁ r := (rfl)
-
-omit hS in
-@[simp]
-lemma globalSectionsSmulShortComplex_τ₂ (S : ShortComplex X.Modules) (r : Γ(X, ⊤)) :
-    (globalSectionsSmulShortComplex S r).τ₂ = globalSectionsSmul S.X₂ r := (rfl)
-
-omit hS in
-@[simp]
-lemma globalSectionsSmulShortComplex_τ₃ (S : ShortComplex X.Modules) (r : Γ(X, ⊤)) :
-    (globalSectionsSmulShortComplex S r).τ₃ = globalSectionsSmul S.X₃ r := (rfl)
 
 omit hS in
 /-- The connecting map is natural in the short exact sequence: a morphism `φ : S₁ ⟶ S₂` of short
@@ -238,7 +214,13 @@ def cohomologyδLinear (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     -- connecting map for multiplication by `r` on all three terms.
     change cohomologyδ hS n₀ n₁ h (r • x) = r • cohomologyδ hS n₀ n₁ h x
     rw [← cohomologyMap_globalSectionsSmul, ← cohomologyMap_globalSectionsSmul]
-    exact (cohomologyδ_naturality hS hS (globalSectionsSmulShortComplex S r) n₀ n₁ h x).symm
+    -- Multiplication by `r` on all three terms is an endomorphism of the short complex.
+    exact (cohomologyδ_naturality hS hS
+      { τ₁ := globalSectionsSmul S.X₁ r
+        τ₂ := globalSectionsSmul S.X₂ r
+        τ₃ := globalSectionsSmul S.X₃ r
+        comm₁₂ := globalSectionsSmul_naturality S.f r
+        comm₂₃ := globalSectionsSmul_naturality S.g r } n₀ n₁ h x).symm
 
 @[simp]
 lemma cohomologyδLinear_apply (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) (x : Cohomology S.X₃ n₀) :

--- a/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.Cohomology.Basic
+public import TauCeti.AlgebraicGeometry.Cohomology.Module
 public import TauCeti.AlgebraicGeometry.Modules.Sheaf
 public import TauCeti.CategoryTheory.Sites.SheafCohomology.LongExactSequence
 
@@ -36,7 +37,12 @@ varies the coefficients.
   `Scheme.Modules.subsingleton_cohomology_X₁`, the vanishing consequences;
 * `Scheme.Modules.exact_sections` and `Scheme.Modules.sections_injective`: global sections are
   left exact, and `Scheme.Modules.sections_surjective`: they are exact on the right as soon as
-  `H¹(X, M₁)` vanishes. This last statement is the form in which the sequence is normally used.
+  `H¹(X, M₁)` vanishes. This last statement is the form in which the sequence is normally used;
+* `Scheme.Modules.cohomologyδ_naturality`, the naturality of the connecting map in the short
+  exact sequence, and the linearity it gives: `Scheme.Modules.cohomologyδLinear` over the ring
+  of global functions and `Scheme.Modules.cohomologyδBaseLinear` over the base ring of a scheme
+  over a commutative ring. The maps induced by morphisms of sheaves are already linear, so this
+  makes the whole long exact sequence one of modules; a dimension count in it needs that.
 
 Additivity of the Euler characteristic, and with it Riemann-Roch, rest on this sequence, so it
 is Layer B infrastructure for `TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is
@@ -48,7 +54,7 @@ degree-zero cohomology with global sections is `Scheme.Modules.cohomologyZeroEqu
 
 public section
 
-open CategoryTheory Limits TopologicalSpace AlgebraicGeometry
+open CategoryTheory Limits TopologicalSpace AlgebraicGeometry Scheme.Modules
 
 namespace TauCeti
 
@@ -175,6 +181,98 @@ theorem sections_surjective (h₁ : Subsingleton (Cohomology S.X₁ 1)) :
     ((cohomologyZeroEquiv S.X₃).symm y)
   refine ⟨cohomologyZeroEquiv S.X₂ x, ?_⟩
   rw [← cohomologyZeroEquiv_cohomologyMap, hx, AddEquiv.apply_symm_apply]
+
+omit hS in
+/-- Multiplication by a global function on cohomology is the map induced by multiplication by
+that function on the coefficient sheaf. -/
+lemma _root_.AlgebraicGeometry.Scheme.Modules.cohomologyMap_globalSectionsSmul (M : X.Modules)
+    (i : ℕ) (r : Γ(X, ⊤)) (x : Cohomology M i) :
+    cohomologyMap (globalSectionsSmul M r) i x = r • x := by
+  rw [cohomology_smul, cohomologyFunctor_map]
+  rfl
+
+omit hS in
+/-- Multiplication by a global function, as an endomorphism of a short complex of sheaves of
+modules. -/
+def globalSectionsSmulShortComplex (S : ShortComplex X.Modules) (r : Γ(X, ⊤)) : S ⟶ S where
+  τ₁ := globalSectionsSmul S.X₁ r
+  τ₂ := globalSectionsSmul S.X₂ r
+  τ₃ := globalSectionsSmul S.X₃ r
+  comm₁₂ := globalSectionsSmul_naturality S.f r
+  comm₂₃ := globalSectionsSmul_naturality S.g r
+
+omit hS in
+@[simp]
+lemma globalSectionsSmulShortComplex_τ₁ (S : ShortComplex X.Modules) (r : Γ(X, ⊤)) :
+    (globalSectionsSmulShortComplex S r).τ₁ = globalSectionsSmul S.X₁ r := (rfl)
+
+omit hS in
+@[simp]
+lemma globalSectionsSmulShortComplex_τ₂ (S : ShortComplex X.Modules) (r : Γ(X, ⊤)) :
+    (globalSectionsSmulShortComplex S r).τ₂ = globalSectionsSmul S.X₂ r := (rfl)
+
+omit hS in
+@[simp]
+lemma globalSectionsSmulShortComplex_τ₃ (S : ShortComplex X.Modules) (r : Γ(X, ⊤)) :
+    (globalSectionsSmulShortComplex S r).τ₃ = globalSectionsSmul S.X₃ r := (rfl)
+
+omit hS in
+/-- The connecting map is natural in the short exact sequence: a morphism `φ : S₁ ⟶ S₂` of short
+exact sequences of sheaves of modules makes the square formed by the two connecting maps and the
+maps induced by `φ.τ₃` and `φ.τ₁` commute. -/
+theorem cohomologyδ_naturality {S₁ S₂ : ShortComplex X.Modules} (h₁ : S₁.ShortExact)
+    (h₂ : S₂.ShortExact) (φ : S₁ ⟶ S₂) (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) (x : Cohomology S₁.X₃ n₀) :
+    cohomologyMap φ.τ₁ n₁ (cohomologyδ h₁ n₀ n₁ h x) =
+      cohomologyδ h₂ n₀ n₁ h (cohomologyMap φ.τ₃ n₀ x) :=
+  TauCeti.CategoryTheory.Sheaf.H.δ_naturality (shortExact_map_toSheaf h₁)
+    (shortExact_map_toSheaf h₂) ((toSheaf X).mapShortComplex.map φ) n₀ n₁ h x
+
+/-- The connecting map of the long exact cohomology sequence is linear over the ring of global
+functions. -/
+def cohomologyδLinear (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    Cohomology S.X₃ n₀ →ₗ[Γ(X, ⊤)] Cohomology S.X₁ n₁ where
+  toFun := cohomologyδ hS n₀ n₁ h
+  map_add' := map_add _
+  map_smul' r x := by
+    -- `Module.compHom` exposes its action definitionally, so the goal is the naturality of the
+    -- connecting map for multiplication by `r` on all three terms.
+    change cohomologyδ hS n₀ n₁ h (r • x) = r • cohomologyδ hS n₀ n₁ h x
+    rw [← cohomologyMap_globalSectionsSmul, ← cohomologyMap_globalSectionsSmul]
+    exact (cohomologyδ_naturality hS hS (globalSectionsSmulShortComplex S r) n₀ n₁ h x).symm
+
+@[simp]
+lemma cohomologyδLinear_apply (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) (x : Cohomology S.X₃ n₀) :
+    cohomologyδLinear hS n₀ n₁ h x = cohomologyδ hS n₀ n₁ h x :=
+  (rfl)
+
+section Base
+
+variable (R : Type u) [CommRing R] (X : Scheme.{u}) [X.Over (Spec (.of R))]
+  {S : ShortComplex X.Modules}
+
+omit hS in
+/-- For a scheme over a commutative ring, the connecting map of the long exact cohomology
+sequence is linear over the base ring. -/
+def cohomologyδBaseLinear (hS : S.ShortExact) (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    Cohomology S.X₃ n₀ →ₗ[R] Cohomology S.X₁ n₁ where
+  toFun := cohomologyδ hS n₀ n₁ h
+  map_add' := map_add _
+  map_smul' r x := by
+    rw [base_smul_cohomology]
+    -- As for `cohomologyMapBaseLinear`, normalize the restricted action to the action of global
+    -- functions and apply the linearity already proved there.
+    change cohomologyδLinear hS n₀ n₁ h ((baseRingToGlobalSections R X r) • x) =
+      (baseRingToGlobalSections R X r) • cohomologyδLinear hS n₀ n₁ h x
+    exact (cohomologyδLinear hS n₀ n₁ h).map_smul _ x
+
+omit hS in
+@[simp]
+lemma cohomologyδBaseLinear_apply (hS : S.ShortExact) (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
+    (x : Cohomology S.X₃ n₀) :
+    cohomologyδBaseLinear R X hS n₀ n₁ h x = cohomologyδ hS n₀ n₁ h x :=
+  (rfl)
+
+end Base
 
 end Scheme.Modules
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean
@@ -186,7 +186,7 @@ omit hS in
 /-- Multiplication by a global function on cohomology is the map induced by multiplication by
 that function on the coefficient sheaf. -/
 @[simp]
-lemma _root_.AlgebraicGeometry.Scheme.Modules.cohomologyMap_globalSectionsSmul (M : X.Modules)
+lemma _root_.AlgebraicGeometry.Scheme.Modules.cohomologyMap_globalSectionsSmul_apply (M : X.Modules)
     (i : ℕ) (r : Γ(X, ⊤)) (x : Cohomology M i) :
     cohomologyMap (globalSectionsSmul M r) i x = r • x := by
   rw [cohomology_smul, cohomologyFunctor_map]
@@ -213,7 +213,7 @@ def cohomologyδLinear (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     -- `Module.compHom` exposes its action definitionally, so the goal is the naturality of the
     -- connecting map for multiplication by `r` on all three terms.
     change cohomologyδ hS n₀ n₁ h (r • x) = r • cohomologyδ hS n₀ n₁ h x
-    rw [← cohomologyMap_globalSectionsSmul, ← cohomologyMap_globalSectionsSmul]
+    rw [← cohomologyMap_globalSectionsSmul_apply, ← cohomologyMap_globalSectionsSmul_apply]
     -- Multiplication by `r` on all three terms is an endomorphism of the short complex.
     exact (cohomologyδ_naturality hS hS
       { τ₁ := globalSectionsSmul S.X₁ r

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean
@@ -141,7 +141,7 @@ theorem subsingleton_X₁ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
 omit hS in
 /-- The connecting map is postcomposition with the extension class of the short exact
 sequence. -/
-lemma δ_apply {T : ShortComplex (Sheaf J AddCommGrpCat.{v})} (hT : T.ShortExact)
+private lemma δ_apply {T : ShortComplex (Sheaf J AddCommGrpCat.{v})} (hT : T.ShortExact)
     (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) (x : _root_.CategoryTheory.Sheaf.H T.X₃ n₀) :
     δ hT n₀ n₁ h x = x.comp hT.extClass h :=
   (rfl)

--- a/TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean
+++ b/TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean
@@ -30,7 +30,10 @@ each of the three consecutive pairs.
 * `TauCeti.CategoryTheory.Sheaf.H.map_injective`, the injectivity of `H⁰(F₁) →+ H⁰(F₂)`, which
   is where the sequence starts;
 * `TauCeti.CategoryTheory.Sheaf.H.map_g_surjective`, `H.subsingleton_X₂`, `H.subsingleton_X₃`
-  and `H.subsingleton_X₁`, the vanishing consequences that the sequence is normally used for.
+  and `H.subsingleton_X₁`, the vanishing consequences that the sequence is normally used for;
+* `TauCeti.CategoryTheory.Sheaf.H.δ_naturality`, the naturality of the connecting map in the
+  short exact sequence, which is what makes the sequence one of modules over a ring acting on
+  all three terms rather than merely one of abelian groups.
 
 The six-term form of the sequence as a `ComposableArrows` is already available: it is Mathlib's
 `CategoryTheory.Abelian.Ext.covariantSequence` for the constant sheaf `ℤ`, whose arrows are
@@ -40,7 +43,8 @@ Sheaf cohomology on the small Zariski site of a scheme is the cohomology of a sh
 so this is Layer B infrastructure for `TauCetiRoadmap/JacobianChallenge/README.md`; see
 `TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean`. No formalization is vendored: the
 underlying long exact sequence is Mathlib's `CategoryTheory.Abelian.Ext.covariant_sequence_exact₁'`,
-`covariant_sequence_exact₂'` and `covariant_sequence_exact₃'`.
+`covariant_sequence_exact₂'` and `covariant_sequence_exact₃'`, and the naturality of the
+extension class is Mathlib's `CategoryTheory.ShortComplex.ShortExact.extClass_naturality`.
 -/
 
 public section
@@ -133,6 +137,27 @@ theorem subsingleton_X₁ (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁)
   obtain ⟨x₃, hx₃⟩ := (exact_δ_map hS n₀ n₁ h x).1 (Subsingleton.elim _ _)
   obtain ⟨y₃, hy₃⟩ := (exact_δ_map hS n₀ n₁ h y).1 (Subsingleton.elim _ _)
   rw [← hx₃, ← hy₃, Subsingleton.elim x₃ y₃]
+
+omit hS in
+/-- The connecting map is postcomposition with the extension class of the short exact
+sequence. -/
+lemma δ_apply {T : ShortComplex (Sheaf J AddCommGrpCat.{v})} (hT : T.ShortExact)
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) (x : _root_.CategoryTheory.Sheaf.H T.X₃ n₀) :
+    δ hT n₀ n₁ h x = x.comp hT.extClass h :=
+  (rfl)
+
+omit hS in
+/-- The connecting map of the long exact cohomology sequence is natural in the short exact
+sequence: a morphism `φ : T₁ ⟶ T₂` of short exact sequences of abelian sheaves makes the square
+formed by the two connecting maps and the maps induced by `φ.τ₃` and `φ.τ₁` commute. -/
+theorem δ_naturality {T₁ T₂ : ShortComplex (Sheaf J AddCommGrpCat.{v})}
+    (h₁ : T₁.ShortExact) (h₂ : T₂.ShortExact) (φ : T₁ ⟶ T₂)
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) (x : _root_.CategoryTheory.Sheaf.H T₁.X₃ n₀) :
+    _root_.CategoryTheory.Sheaf.H.map φ.τ₁ n₁ (δ h₁ n₀ n₁ h x) =
+      δ h₂ n₀ n₁ h (_root_.CategoryTheory.Sheaf.H.map φ.τ₃ n₀ x) := by
+  rw [_root_.CategoryTheory.Sheaf.H.map_apply, _root_.CategoryTheory.Sheaf.H.map_apply,
+    δ_apply, δ_apply, Ext.comp_assoc_of_third_deg_zero, Ext.comp_assoc_of_second_deg_zero,
+    ShortComplex.ShortExact.extClass_naturality h₁ h₂ φ]
 
 end H
 


### PR DESCRIPTION
This PR defines the Euler characteristic of a sheaf of modules on a scheme over a field and proves that it is additive on short exact sequences. For `M : X.Modules` and a truncation degree `n`, `Scheme.Modules.eulerCharBelow k X M n` is the alternating sum `∑_{i < n} (-1)ⁱ dim_k Hⁱ(X, M)`; this is the Euler characteristic `χ(X, M)` for a sheaf whose cohomology vanishes in degrees `≥ n`, and on a curve the relevant truncation is `n = 2`, where `Scheme.Modules.eulerChar_X₂` reads `χ(M₂) = χ(M₁) + χ(M₃)` with `χ(X, M) = dim H⁰(X, M) - dim H¹(X, M)`. `Scheme.Modules.eulerCharBelow_sub_sub` computes the defect of additivity at any truncation degree exactly — it is, up to sign, the dimension of the image of the connecting map the truncation cuts off — and `Scheme.Modules.eulerCharBelow_X₂` deduces additivity from the vanishing of `Hⁿ(X, M₁)`. Also included is `Scheme.Modules.eulerCharBelow_congr`, invariance under isomorphism of the coefficient sheaf, which is what will make `deg L := χ(L) - χ(𝒪_X)` well defined on line-bundle classes.

The dimension count is the usual one in the long exact cohomology sequence: rank-nullity splits each cohomology dimension in degree `i` into two ranks of maps of the sequence, and the alternating sum telescopes. That argument needs the long exact sequence to be a sequence of `k`-vector spaces, and the connecting map was only an additive map. So this PR first proves `TauCeti.CategoryTheory.Sheaf.H.δ_naturality`, the naturality of the connecting map in the short exact sequence of abelian sheaves, from Mathlib's `CategoryTheory.ShortComplex.ShortExact.extClass_naturality`; applied to multiplication by a global function on all three terms, this gives `Scheme.Modules.cohomologyδLinear` and `Scheme.Modules.cohomologyδBaseLinear`, the connecting map as a linear map over `Γ(X, ⊤)` and over the base ring. The maps induced by morphisms of sheaves were already known to be linear, so the whole sequence is now one of modules.

The milestone this serves is Layer B of `TauCetiRoadmap/JacobianChallenge/README.md`, "coherent cohomology over `k`: genus, Riemann-Roch, Serre duality" — specifically Riemann-Roch `χ(L) = deg L + 1 - g` and the Euler-characteristic definition of degree, `deg L := χ(L) - χ(𝒪_X)`, both of which the roadmap's Layer A note defers to Layer B. `TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean` already named additivity of the Euler characteristic as the consumer of its sequence; this PR supplies it. What remains for the milestone after this PR: finite-dimensionality of the cohomology of a proper scheme over `k` and the vanishing `H² = 0` on a curve (which discharge the hypotheses assumed here), then the genus, Riemann-Roch and Serre duality themselves.

Files: `TauCeti/AlgebraicGeometry/Cohomology/EulerCharacteristic.lean` (new, 244 lines), with the connecting-map naturality and linearity added to `TauCeti/CategoryTheory/Sites/SheafCohomology/LongExactSequence.lean` and `TauCeti/AlgebraicGeometry/Cohomology/LongExactSequence.lean`, next to the sequence they refine. The alternating-sum bookkeeping reuses Mathlib's `LinearMap.finrank_range_add_finrank_ker`, `LinearMap.finrank_range_of_inj` and `Function.Exact.linearMap_ker_eq`. Declarations with an explicit `X.Modules` argument are placed in the root `AlgebraicGeometry.Scheme.Modules` namespace, following `TauCeti/AlgebraicGeometry/Cohomology/Module.lean` and the dot-notation lint. No formalization is vendored.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"euler-characteristic-additive-scheme-cohomology"}-->

🤖 Prepared with Claude Code
