### PR TITLE
feat: define the excursion process of a sequence

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
+++ b/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.List.Intervals
+public import TauCeti.Combinatorics.Enumerative.LoopWord
+public import TauCeti.Combinatorics.Enumerative.SuccessorArray
+
+/-!
+# The excursion process of a sequence
+
+Fix a state `a` of a sequence `x : ℕ → α`.  Its `k`-th excursion from `a` is the finite
+list of values strictly between the `k`-th and `(k + 1)`-st visits to `a`.  This file defines that
+list as `TauCeti.excursion x a k` and packages the first `m` excursions as
+`TauCeti.excursionPrefix x a m`.
+
+When `x` visits `a` infinitely often, the visit times are genuine and strictly increasing.  The
+main reconstruction theorem then says that spelling out the first `m` excursions with
+`TauCeti.loopPath` recovers exactly the segment of `x` between its zeroth and `m`-th visits:
+
+```text
+loopPath a (excursionPrefix x a m)
+  = (List.Ico (visitTime x a 0) (visitTime x a m + 1)).map x.
+```
+
+In particular, if `x 0 = a`, this is the initial path segment through its `m`-th return to `a`.
+This is the combinatorial bridge from the finite excursion-reordering theorem in
+`TauCeti.Probability.Exchangeability.Excursion` to the exchangeability of the excursion process
+of a recurrent Markov exchangeable path.
+
+## Main definitions
+
+* `TauCeti.excursion`: the finite word strictly between two consecutive visits to a state.
+* `TauCeti.excursionPrefix`: the list of the first `m` excursions.
+
+## Main results
+
+* `TauCeti.not_mem_excursion`: an excursion does not visit its base state.
+* `TauCeti.loopPath_excursionPrefix`: the first excursions reconstruct the corresponding segment
+  of the original sequence.
+* `TauCeti.loopSteps_excursionPrefix`: the number of reconstructed transitions is the difference
+  of the endpoint visit times.
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115–130.
+* Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, "Markov exchangeability".
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable rather than
+Markov exchangeable sequences.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+variable {α : Type*} {x : ℕ → α} {a : α} {k m : ℕ}
+
+/-! ## Excursions and finite prefixes -/
+
+/-- The `k`-th excursion of `x` from `a`: the finite list of values at the times strictly between
+the `k`-th and `(k + 1)`-st visits to `a`.
+
+If either visit does not exist, `visitTime` uses its documented junk value and this interval may
+be empty.  The reconstruction API below assumes that `x` visits `a` infinitely often. -/
+def excursion (x : ℕ → α) (a : α) (k : ℕ) : List α :=
+  (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x
+
+private theorem excursion_def_private (x : ℕ → α) (a : α) (k : ℕ) :
+    excursion x a k =
+      (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x :=
+  rfl
+
+/-- The defining equation of an excursion. -/
+theorem excursion_def (x : ℕ → α) (a : α) (k : ℕ) :
+    excursion x a k =
+      (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x :=
+  excursion_def_private x a k
+
+/-- The list of the first `m` excursions of `x` from `a`. -/
+def excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) : List (List α) :=
+  (List.range m).map (excursion x a)
+
+private theorem excursionPrefix_def_private (x : ℕ → α) (a : α) (m : ℕ) :
+    excursionPrefix x a m = (List.range m).map (excursion x a) :=
+  rfl
+
+/-- The defining equation of a finite excursion prefix. -/
+theorem excursionPrefix_def (x : ℕ → α) (a : α) (m : ℕ) :
+    excursionPrefix x a m = (List.range m).map (excursion x a) :=
+  excursionPrefix_def_private x a m
+
+@[simp]
+theorem excursionPrefix_zero (x : ℕ → α) (a : α) : excursionPrefix x a 0 = [] := by
+  rw [excursionPrefix_def]
+  simp
+
+@[simp]
+theorem excursionPrefix_succ (x : ℕ → α) (a : α) (m : ℕ) :
+    excursionPrefix x a (m + 1) = excursionPrefix x a m ++ [excursion x a m] := by
+  rw [excursionPrefix_def, excursionPrefix_def, List.range_succ, List.map_append]
+  rfl
+
+@[simp]
+theorem length_excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) :
+    (excursionPrefix x a m).length = m := by
+  simp [excursionPrefix_def]
+
+/-! ## Elementary properties -/
+
+/-- The length of an excursion is the gap between its endpoint visit times, less one. -/
+theorem length_excursion (x : ℕ → α) (a : α) (k : ℕ) :
+    (excursion x a k).length = visitTime x a (k + 1) - visitTime x a k - 1 := by
+  rw [excursion_def, List.length_map, List.Ico.length]
+  omega
+
+/-- An excursion never contains its base state.  This remains true in the finite-visit case,
+where `visitTime` may make the interval empty. -/
+theorem not_mem_excursion (x : ℕ → α) (a : α) (k : ℕ) : a ∉ excursion x a k := by
+  rw [excursion_def]
+  intro ha
+  obtain ⟨n, hn, hxn⟩ := List.mem_map.1 ha
+  have hnmem := List.Ico.mem.1 hn
+  have hle' : n ≤ Nat.nth (fun i => x i = a) k :=
+    Nat.le_nth_of_lt_nth_succ (by simpa only [visitTime_def] using hnmem.2) hxn
+  have hle : n ≤ visitTime x a k := by simpa only [visitTime_def] using hle'
+  omega
+
+/-! ## Reconstruction -/
+
+/-- Appending excursion lists splices their loop paths at the shared base state. -/
+private theorem loopPath_append (a : α) (bs cs : List (List α)) :
+    loopPath a (bs ++ cs) = (loopPath a bs).dropLast ++ loopPath a cs := by
+  induction bs with
+  | nil => simp
+  | cons e bs ih =>
+      have hne : loopPath a bs ≠ [] := by cases bs <;> simp
+      have hdrop : (loopPath a (e :: bs)).dropLast =
+          a :: (e ++ (loopPath a bs).dropLast) := by
+        rw [loopPath_cons]
+        calc
+          (a :: (e ++ loopPath a bs)).dropLast = ((a :: e) ++ loopPath a bs).dropLast := by
+            simp
+          _ = (a :: e) ++ (loopPath a bs).dropLast :=
+            List.dropLast_append_of_ne_nil hne
+          _ = a :: (e ++ (loopPath a bs).dropLast) := by simp
+      rw [List.cons_append, loopPath_cons, ih, hdrop]
+      rw [List.cons_append, List.append_assoc]
+
+/-- A single genuine excursion spells out exactly the segment between its two endpoint visits. -/
+theorem loopPath_singleton_excursion (h : {n | x n = a}.Infinite) (k : ℕ) :
+    loopPath a [excursion x a k] =
+      (List.Ico (visitTime x a k) (visitTime x a (k + 1) + 1)).map x := by
+  rw [loopPath_cons, loopPath_nil, excursion_def]
+  have hk := visitTime_apply_of_infinite h k
+  have hk1 := visitTime_apply_of_infinite h (k + 1)
+  have hlt : visitTime x a k < visitTime x a (k + 1) :=
+    visitTime_strictMono_of_infinite h (by omega)
+  have hsucc : visitTime x a k + 1 ≤ visitTime x a (k + 1) := by omega
+  have hIco :
+      List.Ico (visitTime x a k) (visitTime x a (k + 1) + 1) =
+        [visitTime x a k] ++
+          List.Ico (visitTime x a k + 1) (visitTime x a (k + 1)) ++
+            [visitTime x a (k + 1)] := by
+    rw [← List.Ico.succ_singleton,
+      List.Ico.append_consecutive (Nat.le_succ _) hsucc,
+      ← List.Ico.succ_singleton,
+      List.Ico.append_consecutive hlt.le (Nat.le_succ _)]
+  rw [hIco, List.map_append, List.map_append, List.map_singleton, List.map_singleton, hk, hk1]
+  rfl
+
+/-- The loop path of the first `m` genuine excursions is the original sequence segment from the
+zeroth through the `m`-th visit to the base state. -/
+theorem loopPath_excursionPrefix (h : {n | x n = a}.Infinite) (m : ℕ) :
+    loopPath a (excursionPrefix x a m) =
+      (List.Ico (visitTime x a 0) (visitTime x a m + 1)).map x := by
+  induction m with
+  | zero =>
+      simp only [excursionPrefix_zero, loopPath_nil]
+      rw [List.Ico.succ_singleton, List.map_singleton, visitTime_apply_of_infinite h]
+  | succ m ih =>
+      rw [excursionPrefix_succ, loopPath_append, ih, loopPath_singleton_excursion h]
+      have hmono := (visitTime_strictMono_of_infinite h).monotone (Nat.zero_le m)
+      have hdrop :
+          ((List.Ico (visitTime x a 0) (visitTime x a m + 1)).map x).dropLast =
+            (List.Ico (visitTime x a 0) (visitTime x a m)).map x := by
+        rw [List.Ico.succ_top hmono, List.map_append, List.map_singleton,
+          List.dropLast_append_cons]
+        simp
+      rw [hdrop, ← List.map_append, List.Ico.append_consecutive hmono
+        ((visitTime_strictMono_of_infinite h m.lt_succ_self).le.trans (Nat.le_succ _))]
+
+/-- The first `m` genuine excursions contain exactly the transitions between the zeroth and
+`m`-th visits to the base state. -/
+theorem loopSteps_excursionPrefix (h : {n | x n = a}.Infinite) (m : ℕ) :
+    loopSteps (excursionPrefix x a m) = visitTime x a m - visitTime x a 0 := by
+  have hlen := congrArg List.length (loopPath_excursionPrefix h m)
+  rw [length_loopPath, List.length_map, List.Ico.length] at hlen
+  omega
+
+/-- For a sequence starting at `a`, the first `m` excursions reconstruct its initial segment
+through the `m`-th return. -/
+theorem loopPath_excursionPrefix_of_zero (h : {n | x n = a}.Infinite) (h0 : x 0 = a) (m : ℕ) :
+    loopPath a (excursionPrefix x a m) =
+      (List.range (visitTime x a m + 1)).map x := by
+  rw [loopPath_excursionPrefix h, visitTime_zero_of_eq h0, List.Ico.zero_bot]
+
+/-- For a sequence starting at `a`, the first `m` excursions have total duration equal to its
+`m`-th return time. -/
+theorem loopSteps_excursionPrefix_of_zero (h : {n | x n = a}.Infinite) (h0 : x 0 = a) (m : ℕ) :
+    loopSteps (excursionPrefix x a m) = visitTime x a m := by
+  rw [loopSteps_excursionPrefix h, visitTime_zero_of_eq h0, Nat.sub_zero]
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
+++ b/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
@@ -69,28 +69,24 @@ variable {α : Type*} {x : ℕ → α} {a : α} {k m : ℕ}
 the `k`-th and `(k + 1)`-st visits to `a`.
 
 If either visit does not exist, `visitTime` uses its documented junk value and this interval may
-be empty.
-
-Exposed so that `TauCeti.excursion_def` is a `rfl` proof of an exported equation. -/
-@[expose] def excursion (x : ℕ → α) (a : α) (k : ℕ) : List α :=
+be empty. -/
+def excursion (x : ℕ → α) (a : α) (k : ℕ) : List α :=
   (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x
 
 /-- The defining equation of an excursion. -/
 theorem excursion_def (x : ℕ → α) (a : α) (k : ℕ) :
     excursion x a k =
       (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x :=
-  rfl
+  (rfl)
 
-/-- The list of the first `m` excursions of `x` from `a`.
-
-Exposed so that `TauCeti.excursionPrefix_def` is a `rfl` proof of an exported equation. -/
-@[expose] def excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) : List (List α) :=
+/-- The list of the first `m` excursions of `x` from `a`. -/
+def excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) : List (List α) :=
   (List.range m).map (excursion x a)
 
 /-- The defining equation of a finite excursion prefix. -/
 theorem excursionPrefix_def (x : ℕ → α) (a : α) (m : ℕ) :
     excursionPrefix x a m = (List.range m).map (excursion x a) :=
-  rfl
+  (rfl)
 
 @[simp]
 theorem excursionPrefix_zero (x : ℕ → α) (a : α) : excursionPrefix x a 0 = [] := by

--- a/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
+++ b/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
@@ -17,8 +17,8 @@ list of values strictly between the `k`-th and `(k + 1)`-st visits to `a`.  This
 list as `TauCeti.excursion x a k` and packages the first `m` excursions as
 `TauCeti.excursionPrefix x a m`.
 
-When `x` visits `a` infinitely often, the visit times are genuine and strictly increasing.  The
-main reconstruction theorem then says that spelling out the first `m` excursions with
+When the `m`-th visit exists, the visit times through `m` are genuine and strictly increasing.
+The main reconstruction theorem then says that spelling out the first `m` excursions with
 `TauCeti.loopPath` recovers exactly the segment of `x` between its zeroth and `m`-th visits:
 
 ```text
@@ -26,8 +26,9 @@ loopPath a (excursionPrefix x a m)
   = (List.Ico (visitTime x a 0) (visitTime x a m + 1)).map x.
 ```
 
-In particular, if `x 0 = a`, this is the initial path segment through its `m`-th return to `a`.
-This is the combinatorial bridge from the finite excursion-reordering theorem in
+In particular this applies whenever `x` visits `a` infinitely often, and if `x 0 = a`, the result
+is the initial path segment through its `m`-th return to `a`.  This is the combinatorial bridge
+from the finite excursion-reordering theorem in
 `TauCeti.Probability.Exchangeability.Excursion` to the exchangeability of the excursion process
 of a recurrent Markov exchangeable path.
 
@@ -68,7 +69,7 @@ variable {α : Type*} {x : ℕ → α} {a : α} {k m : ℕ}
 the `k`-th and `(k + 1)`-st visits to `a`.
 
 If either visit does not exist, `visitTime` uses its documented junk value and this interval may
-be empty.  The reconstruction API below assumes that `x` visits `a` infinitely often. -/
+be empty. -/
 def excursion (x : ℕ → α) (a : α) (k : ℕ) : List α :=
   (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x
 
@@ -112,9 +113,29 @@ theorem length_excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) :
     (excursionPrefix x a m).length = m := by
   simp [excursionPrefix_def]
 
+/-- Membership in an excursion is membership in the corresponding open interval of times. -/
+theorem mem_excursion_iff {b : α} :
+    b ∈ excursion x a k ↔
+      ∃ n, visitTime x a k < n ∧ n < visitTime x a (k + 1) ∧ x n = b := by
+  rw [excursion_def]
+  constructor
+  · intro hb
+    obtain ⟨n, hn, hxn⟩ := List.mem_map.1 hb
+    obtain ⟨hnk, hnk1⟩ := List.Ico.mem.1 hn
+    exact ⟨n, by omega, hnk1, hxn⟩
+  · rintro ⟨n, hnk, hnk1, hxn⟩
+    exact List.mem_map.2 ⟨n, List.Ico.mem.2 ⟨by omega, hnk1⟩, hxn⟩
+
+/-- The `k`-th entry of a finite excursion prefix is the `k`-th excursion. -/
+@[simp]
+theorem getElem_excursionPrefix (hk : k < m) :
+    (excursionPrefix x a m)[k]'(by simpa using hk) = excursion x a k := by
+  simp [excursionPrefix_def]
+
 /-! ## Elementary properties -/
 
 /-- The length of an excursion is the gap between its endpoint visit times, less one. -/
+@[simp]
 theorem length_excursion (x : ℕ → α) (a : α) (k : ℕ) :
     (excursion x a k).length = visitTime x a (k + 1) - visitTime x a k - 1 := by
   rw [excursion_def, List.length_map, List.Ico.length]
@@ -122,6 +143,7 @@ theorem length_excursion (x : ℕ → α) (a : α) (k : ℕ) :
 
 /-- An excursion never contains its base state.  This remains true in the finite-visit case,
 where `visitTime` may make the interval empty. -/
+@[simp]
 theorem not_mem_excursion (x : ℕ → α) (a : α) (k : ℕ) : a ∉ excursion x a k := by
   rw [excursion_def]
   intro ha
@@ -133,6 +155,38 @@ theorem not_mem_excursion (x : ℕ → α) (a : α) (k : ℕ) : a ∉ excursion 
   omega
 
 /-! ## Reconstruction -/
+
+/-- If the `m`-th visit exists, all visit times through `m` are genuine and consecutive visit
+times through `m` are strictly increasing. -/
+private theorem visitTime_data_of_exists_visitCount
+    (h : ∃ n, x n = a ∧ visitCount x a n = m) :
+    (∀ k ≤ m, x (visitTime x a k) = a ∧ visitCount x a (visitTime x a k) = k) ∧
+      ∀ i j, i < j → j ≤ m → visitTime x a i < visitTime x a j := by
+  classical
+  obtain ⟨n, hn, hcount⟩ := h
+  have hcard : ∀ hf : {n | x n = a}.Finite, m < hf.toFinset.card := by
+    intro hf
+    rw [← hcount, visitCount_eq_count]
+    exact Nat.count_lt_card hf hn
+  constructor
+  · intro k hk
+    have hkcard : ∀ hf : {n | x n = a}.Finite, k < hf.toFinset.card :=
+      fun hf => hk.trans_lt (hcard hf)
+    constructor
+    · simpa only [visitTime_def] using Nat.nth_mem k hkcard
+    · rw [visitCount_eq_count, visitTime_def]
+      exact Nat.count_nth hkcard
+  · intro i j hij hj
+    have hjcard : ∀ hf : {n | x n = a}.Finite, j < hf.toFinset.card :=
+      fun hf => hj.trans_lt (hcard hf)
+    simpa only [visitTime_def] using Nat.nth_lt_nth' hij hjcard
+
+/-- Infinite visits supply a finite witness for every visit count. -/
+private theorem exists_visitCount_of_infinite (h : {n | x n = a}.Infinite) (m : ℕ) :
+    ∃ n, x n = a ∧ visitCount x a n = m := by
+  refine ⟨visitTime x a m, visitTime_apply_of_infinite h m, ?_⟩
+  apply (visitTime_strictMono_of_infinite h).injective
+  rw [visitTime_visitCount (visitTime_apply_of_infinite h m)]
 
 /-- Appending excursion lists splices their loop paths at the shared base state. -/
 private theorem loopPath_append (a : α) (bs cs : List (List α)) :
@@ -153,15 +207,17 @@ private theorem loopPath_append (a : α) (bs cs : List (List α)) :
       rw [List.cons_append, loopPath_cons, ih, hdrop]
       rw [List.cons_append, List.append_assoc]
 
-/-- A single genuine excursion spells out exactly the segment between its two endpoint visits. -/
-theorem loopPath_singleton_excursion (h : {n | x n = a}.Infinite) (k : ℕ) :
+/-- A single excursion whose next endpoint exists spells out exactly the segment between its two
+endpoint visits. -/
+theorem loopPath_singleton_excursion
+    (h : ∃ n, x n = a ∧ visitCount x a n = k + 1) :
     loopPath a [excursion x a k] =
       (List.Ico (visitTime x a k) (visitTime x a (k + 1) + 1)).map x := by
   rw [loopPath_cons, loopPath_nil, excursion_def]
-  have hk := visitTime_apply_of_infinite h k
-  have hk1 := visitTime_apply_of_infinite h (k + 1)
-  have hlt : visitTime x a k < visitTime x a (k + 1) :=
-    visitTime_strictMono_of_infinite h (by omega)
+  obtain ⟨happly, hmono⟩ := visitTime_data_of_exists_visitCount h
+  have hk := (happly k (by omega)).1
+  have hk1 := (happly (k + 1) le_rfl).1
+  have hlt := hmono k (k + 1) (by omega) le_rfl
   have hsucc : visitTime x a k + 1 ≤ visitTime x a (k + 1) := by omega
   have hIco :
       List.Ico (visitTime x a k) (visitTime x a (k + 1) + 1) =
@@ -175,18 +231,32 @@ theorem loopPath_singleton_excursion (h : {n | x n = a}.Infinite) (k : ℕ) :
   rw [hIco, List.map_append, List.map_append, List.map_singleton, List.map_singleton, hk, hk1]
   rfl
 
-/-- The loop path of the first `m` genuine excursions is the original sequence segment from the
-zeroth through the `m`-th visit to the base state. -/
-theorem loopPath_excursionPrefix (h : {n | x n = a}.Infinite) (m : ℕ) :
+/-- The infinite-visit form of `loopPath_singleton_excursion`. -/
+theorem loopPath_singleton_excursion_of_infinite (h : {n | x n = a}.Infinite) (k : ℕ) :
+    loopPath a [excursion x a k] =
+      (List.Ico (visitTime x a k) (visitTime x a (k + 1) + 1)).map x :=
+  loopPath_singleton_excursion (exists_visitCount_of_infinite h (k + 1))
+
+/-- If the `m`-th visit exists, the loop path of the first `m` excursions is the original sequence
+segment from the zeroth through the `m`-th visit to the base state. -/
+theorem loopPath_excursionPrefix (h : ∃ n, x n = a ∧ visitCount x a n = m) :
     loopPath a (excursionPrefix x a m) =
       (List.Ico (visitTime x a 0) (visitTime x a m + 1)).map x := by
   induction m with
   | zero =>
       simp only [excursionPrefix_zero, loopPath_nil]
-      rw [List.Ico.succ_singleton, List.map_singleton, visitTime_apply_of_infinite h]
+      rw [List.Ico.succ_singleton, List.map_singleton,
+        (visitTime_data_of_exists_visitCount h).1 0 le_rfl |>.1]
   | succ m ih =>
-      rw [excursionPrefix_succ, loopPath_append, ih, loopPath_singleton_excursion h]
-      have hmono := (visitTime_strictMono_of_infinite h).monotone (Nat.zero_le m)
+      obtain ⟨happly, hstrict⟩ := visitTime_data_of_exists_visitCount h
+      have hm : ∃ n, x n = a ∧ visitCount x a n = m :=
+        ⟨visitTime x a m, (happly m (by omega)).1, (happly m (by omega)).2⟩
+      have hm1 : ∃ n, x n = a ∧ visitCount x a n = m + 1 := h
+      rw [excursionPrefix_succ, loopPath_append, ih hm, loopPath_singleton_excursion hm1]
+      have hmono : visitTime x a 0 ≤ visitTime x a m := by
+        by_cases hm0 : m = 0
+        · simp [hm0]
+        · exact (hstrict 0 m (Nat.pos_of_ne_zero hm0) (by omega)).le
       have hdrop :
           ((List.Ico (visitTime x a 0) (visitTime x a m + 1)).map x).dropLast =
             (List.Ico (visitTime x a 0) (visitTime x a m)).map x := by
@@ -194,28 +264,54 @@ theorem loopPath_excursionPrefix (h : {n | x n = a}.Infinite) (m : ℕ) :
           List.dropLast_append_cons]
         simp
       rw [hdrop, ← List.map_append, List.Ico.append_consecutive hmono
-        ((visitTime_strictMono_of_infinite h m.lt_succ_self).le.trans (Nat.le_succ _))]
+        ((hstrict m (m + 1) m.lt_succ_self le_rfl).le.trans (Nat.le_succ _))]
 
-/-- The first `m` genuine excursions contain exactly the transitions between the zeroth and
-`m`-th visits to the base state. -/
-theorem loopSteps_excursionPrefix (h : {n | x n = a}.Infinite) (m : ℕ) :
+/-- The infinite-visit form of `loopPath_excursionPrefix`. -/
+theorem loopPath_excursionPrefix_of_infinite (h : {n | x n = a}.Infinite) (m : ℕ) :
+    loopPath a (excursionPrefix x a m) =
+      (List.Ico (visitTime x a 0) (visitTime x a m + 1)).map x :=
+  loopPath_excursionPrefix (exists_visitCount_of_infinite h m)
+
+/-- If the `m`-th visit exists, the first `m` excursions contain exactly the transitions between
+the zeroth and `m`-th visits to the base state. -/
+theorem loopSteps_excursionPrefix (h : ∃ n, x n = a ∧ visitCount x a n = m) :
     loopSteps (excursionPrefix x a m) = visitTime x a m - visitTime x a 0 := by
-  have hlen := congrArg List.length (loopPath_excursionPrefix h m)
+  have hlen := congrArg List.length (loopPath_excursionPrefix h)
   rw [length_loopPath, List.length_map, List.Ico.length] at hlen
   omega
 
-/-- For a sequence starting at `a`, the first `m` excursions reconstruct its initial segment
-through the `m`-th return. -/
-theorem loopPath_excursionPrefix_of_zero (h : {n | x n = a}.Infinite) (h0 : x 0 = a) (m : ℕ) :
+/-- The infinite-visit form of `loopSteps_excursionPrefix`. -/
+theorem loopSteps_excursionPrefix_of_infinite (h : {n | x n = a}.Infinite) (m : ℕ) :
+    loopSteps (excursionPrefix x a m) = visitTime x a m - visitTime x a 0 :=
+  loopSteps_excursionPrefix (exists_visitCount_of_infinite h m)
+
+/-- If the `m`-th visit exists for a sequence starting at `a`, its first `m` excursions reconstruct
+the initial segment through the `m`-th return. -/
+theorem loopPath_excursionPrefix_of_zero
+    (h : ∃ n, x n = a ∧ visitCount x a n = m) (h0 : x 0 = a) :
     loopPath a (excursionPrefix x a m) =
       (List.range (visitTime x a m + 1)).map x := by
   rw [loopPath_excursionPrefix h, visitTime_zero_of_eq h0, List.Ico.zero_bot]
 
-/-- For a sequence starting at `a`, the first `m` excursions have total duration equal to its
-`m`-th return time. -/
-theorem loopSteps_excursionPrefix_of_zero (h : {n | x n = a}.Infinite) (h0 : x 0 = a) (m : ℕ) :
+/-- The infinite-visit form of `loopPath_excursionPrefix_of_zero`. -/
+theorem loopPath_excursionPrefix_of_infinite_of_zero
+    (h : {n | x n = a}.Infinite) (h0 : x 0 = a) (m : ℕ) :
+    loopPath a (excursionPrefix x a m) =
+      (List.range (visitTime x a m + 1)).map x :=
+  loopPath_excursionPrefix_of_zero (exists_visitCount_of_infinite h m) h0
+
+/-- If the `m`-th visit exists for a sequence starting at `a`, its first `m` excursions have total
+duration equal to the `m`-th return time. -/
+theorem loopSteps_excursionPrefix_of_zero
+    (h : ∃ n, x n = a ∧ visitCount x a n = m) (h0 : x 0 = a) :
     loopSteps (excursionPrefix x a m) = visitTime x a m := by
   rw [loopSteps_excursionPrefix h, visitTime_zero_of_eq h0, Nat.sub_zero]
+
+/-- The infinite-visit form of `loopSteps_excursionPrefix_of_zero`. -/
+theorem loopSteps_excursionPrefix_of_infinite_of_zero
+    (h : {n | x n = a}.Infinite) (h0 : x 0 = a) (m : ℕ) :
+    loopSteps (excursionPrefix x a m) = visitTime x a m :=
+  loopSteps_excursionPrefix_of_zero (exists_visitCount_of_infinite h m) h0
 
 end TauCeti
 

--- a/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
+++ b/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
@@ -69,33 +69,28 @@ variable {α : Type*} {x : ℕ → α} {a : α} {k m : ℕ}
 the `k`-th and `(k + 1)`-st visits to `a`.
 
 If either visit does not exist, `visitTime` uses its documented junk value and this interval may
-be empty. -/
-def excursion (x : ℕ → α) (a : α) (k : ℕ) : List α :=
-  (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x
+be empty.
 
-private theorem excursion_def_private (x : ℕ → α) (a : α) (k : ℕ) :
-    excursion x a k =
-      (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x :=
-  rfl
+Exposed so that `TauCeti.excursion_def` is a `rfl` proof of an exported equation. -/
+@[expose] def excursion (x : ℕ → α) (a : α) (k : ℕ) : List α :=
+  (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x
 
 /-- The defining equation of an excursion. -/
 theorem excursion_def (x : ℕ → α) (a : α) (k : ℕ) :
     excursion x a k =
       (List.Ico (visitTime x a k + 1) (visitTime x a (k + 1))).map x :=
-  excursion_def_private x a k
-
-/-- The list of the first `m` excursions of `x` from `a`. -/
-def excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) : List (List α) :=
-  (List.range m).map (excursion x a)
-
-private theorem excursionPrefix_def_private (x : ℕ → α) (a : α) (m : ℕ) :
-    excursionPrefix x a m = (List.range m).map (excursion x a) :=
   rfl
+
+/-- The list of the first `m` excursions of `x` from `a`.
+
+Exposed so that `TauCeti.excursionPrefix_def` is a `rfl` proof of an exported equation. -/
+@[expose] def excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) : List (List α) :=
+  (List.range m).map (excursion x a)
 
 /-- The defining equation of a finite excursion prefix. -/
 theorem excursionPrefix_def (x : ℕ → α) (a : α) (m : ℕ) :
     excursionPrefix x a m = (List.range m).map (excursion x a) :=
-  excursionPrefix_def_private x a m
+  rfl
 
 @[simp]
 theorem excursionPrefix_zero (x : ℕ → α) (a : α) : excursionPrefix x a 0 = [] := by
@@ -113,7 +108,11 @@ theorem length_excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) :
     (excursionPrefix x a m).length = m := by
   simp [excursionPrefix_def]
 
-/-- Membership in an excursion is membership in the corresponding open interval of times. -/
+/-- Membership in an excursion is membership in the corresponding open interval of times.
+
+Deliberately not `@[simp]`: it would rewrite the left-hand side of the `@[simp]` lemma
+`TauCeti.not_mem_excursion` into an existential that `simp` cannot close, so `simp` would stop
+proving that an excursion avoids its base state. -/
 theorem mem_excursion_iff {b : α} :
     b ∈ excursion x a k ↔
       ∃ n, visitTime x a k < n ∧ n < visitTime x a (k + 1) ∧ x n = b := by
@@ -156,57 +155,6 @@ theorem not_mem_excursion (x : ℕ → α) (a : α) (k : ℕ) : a ∉ excursion 
 
 /-! ## Reconstruction -/
 
-/-- If the `m`-th visit exists, all visit times through `m` are genuine and consecutive visit
-times through `m` are strictly increasing. -/
-private theorem visitTime_data_of_exists_visitCount
-    (h : ∃ n, x n = a ∧ visitCount x a n = m) :
-    (∀ k ≤ m, x (visitTime x a k) = a ∧ visitCount x a (visitTime x a k) = k) ∧
-      ∀ i j, i < j → j ≤ m → visitTime x a i < visitTime x a j := by
-  classical
-  obtain ⟨n, hn, hcount⟩ := h
-  have hcard : ∀ hf : {n | x n = a}.Finite, m < hf.toFinset.card := by
-    intro hf
-    rw [← hcount, visitCount_eq_count]
-    exact Nat.count_lt_card hf hn
-  constructor
-  · intro k hk
-    have hkcard : ∀ hf : {n | x n = a}.Finite, k < hf.toFinset.card :=
-      fun hf => hk.trans_lt (hcard hf)
-    constructor
-    · simpa only [visitTime_def] using Nat.nth_mem k hkcard
-    · rw [visitCount_eq_count, visitTime_def]
-      exact Nat.count_nth hkcard
-  · intro i j hij hj
-    have hjcard : ∀ hf : {n | x n = a}.Finite, j < hf.toFinset.card :=
-      fun hf => hj.trans_lt (hcard hf)
-    simpa only [visitTime_def] using Nat.nth_lt_nth' hij hjcard
-
-/-- Infinite visits supply a finite witness for every visit count. -/
-private theorem exists_visitCount_of_infinite (h : {n | x n = a}.Infinite) (m : ℕ) :
-    ∃ n, x n = a ∧ visitCount x a n = m := by
-  refine ⟨visitTime x a m, visitTime_apply_of_infinite h m, ?_⟩
-  apply (visitTime_strictMono_of_infinite h).injective
-  rw [visitTime_visitCount (visitTime_apply_of_infinite h m)]
-
-/-- Appending excursion lists splices their loop paths at the shared base state. -/
-private theorem loopPath_append (a : α) (bs cs : List (List α)) :
-    loopPath a (bs ++ cs) = (loopPath a bs).dropLast ++ loopPath a cs := by
-  induction bs with
-  | nil => simp
-  | cons e bs ih =>
-      have hne : loopPath a bs ≠ [] := by cases bs <;> simp
-      have hdrop : (loopPath a (e :: bs)).dropLast =
-          a :: (e ++ (loopPath a bs).dropLast) := by
-        rw [loopPath_cons]
-        calc
-          (a :: (e ++ loopPath a bs)).dropLast = ((a :: e) ++ loopPath a bs).dropLast := by
-            simp
-          _ = (a :: e) ++ (loopPath a bs).dropLast :=
-            List.dropLast_append_of_ne_nil hne
-          _ = a :: (e ++ (loopPath a bs).dropLast) := by simp
-      rw [List.cons_append, loopPath_cons, ih, hdrop]
-      rw [List.cons_append, List.append_assoc]
-
 /-- A single excursion whose next endpoint exists spells out exactly the segment between its two
 endpoint visits. -/
 theorem loopPath_singleton_excursion
@@ -214,10 +162,10 @@ theorem loopPath_singleton_excursion
     loopPath a [excursion x a k] =
       (List.Ico (visitTime x a k) (visitTime x a (k + 1) + 1)).map x := by
   rw [loopPath_cons, loopPath_nil, excursion_def]
-  obtain ⟨happly, hmono⟩ := visitTime_data_of_exists_visitCount h
-  have hk := (happly k (by omega)).1
-  have hk1 := (happly (k + 1) le_rfl).1
-  have hlt := hmono k (k + 1) (by omega) le_rfl
+  have hk := apply_visitTime_of_le h (Nat.le_succ k)
+  have hk1 := apply_visitTime_of_le h le_rfl
+  have hlt : visitTime x a k < visitTime x a (k + 1) :=
+    visitTime_lt_visitTime_of_le h (by omega) le_rfl
   have hsucc : visitTime x a k + 1 ≤ visitTime x a (k + 1) := by omega
   have hIco :
       List.Ico (visitTime x a k) (visitTime x a (k + 1) + 1) =
@@ -245,26 +193,24 @@ theorem loopPath_excursionPrefix (h : ∃ n, x n = a ∧ visitCount x a n = m) :
   induction m with
   | zero =>
       simp only [excursionPrefix_zero, loopPath_nil]
-      rw [List.Ico.succ_singleton, List.map_singleton,
-        (visitTime_data_of_exists_visitCount h).1 0 le_rfl |>.1]
+      rw [List.Ico.succ_singleton, List.map_singleton, apply_visitTime_of_le h le_rfl]
   | succ m ih =>
-      obtain ⟨happly, hstrict⟩ := visitTime_data_of_exists_visitCount h
-      have hm : ∃ n, x n = a ∧ visitCount x a n = m :=
-        ⟨visitTime x a m, (happly m (by omega)).1, (happly m (by omega)).2⟩
-      have hm1 : ∃ n, x n = a ∧ visitCount x a n = m + 1 := h
-      rw [excursionPrefix_succ, loopPath_append, ih hm, loopPath_singleton_excursion hm1]
+      have hm : ∃ n, x n = a ∧ visitCount x a n = m := exists_visitCount_of_le h (Nat.le_succ m)
+      rw [excursionPrefix_succ, loopPath_append, ih hm, loopPath_singleton_excursion h]
+      have hstep : visitTime x a m < visitTime x a (m + 1) :=
+        visitTime_lt_visitTime_of_le h (by omega) le_rfl
       have hmono : visitTime x a 0 ≤ visitTime x a m := by
-        by_cases hm0 : m = 0
-        · simp [hm0]
-        · exact (hstrict 0 m (Nat.pos_of_ne_zero hm0) (by omega)).le
+        rcases Nat.eq_zero_or_pos m with rfl | hm0
+        · exact le_rfl
+        · exact (visitTime_lt_visitTime_of_le (j := m) h hm0 (Nat.le_succ m)).le
       have hdrop :
           ((List.Ico (visitTime x a 0) (visitTime x a m + 1)).map x).dropLast =
             (List.Ico (visitTime x a 0) (visitTime x a m)).map x := by
         rw [List.Ico.succ_top hmono, List.map_append, List.map_singleton,
           List.dropLast_append_cons]
         simp
-      rw [hdrop, ← List.map_append, List.Ico.append_consecutive hmono
-        ((hstrict m (m + 1) m.lt_succ_self le_rfl).le.trans (Nat.le_succ _))]
+      rw [hdrop, ← List.map_append,
+        List.Ico.append_consecutive hmono (hstep.le.trans (Nat.le_succ _))]
 
 /-- The infinite-visit form of `loopPath_excursionPrefix`. -/
 theorem loopPath_excursionPrefix_of_infinite (h : {n | x n = a}.Infinite) (m : ℕ) :

--- a/TauCeti/Combinatorics/Enumerative/LoopWord.lean
+++ b/TauCeti/Combinatorics/Enumerative/LoopWord.lean
@@ -88,6 +88,23 @@ theorem loopPath_cons (a₀ : α) (e : List α) (bs : List (List α)) :
     loopPath a₀ (e :: bs) = a₀ :: (e ++ loopPath a₀ bs) := by
   simp only [loopPath]
 
+/-- Concatenating two lists of excursions splices their loops at the shared base letter: the
+final letter of the first loop is the initial letter of the second. -/
+theorem loopPath_append (a₀ : α) (bs cs : List (List α)) :
+    loopPath a₀ (bs ++ cs) = (loopPath a₀ bs).dropLast ++ loopPath a₀ cs := by
+  induction bs with
+  | nil => simp
+  | cons e bs ih =>
+    have hne : loopPath a₀ bs ≠ [] := by cases bs <;> simp
+    have hdrop : (loopPath a₀ (e :: bs)).dropLast = a₀ :: (e ++ (loopPath a₀ bs).dropLast) := by
+      rw [loopPath_cons]
+      calc
+        (a₀ :: (e ++ loopPath a₀ bs)).dropLast = ((a₀ :: e) ++ loopPath a₀ bs).dropLast := by
+          simp
+        _ = (a₀ :: e) ++ (loopPath a₀ bs).dropLast := List.dropLast_append_of_ne_nil hne
+        _ = a₀ :: (e ++ (loopPath a₀ bs).dropLast) := by simp
+    rw [List.cons_append, loopPath_cons, ih, hdrop, List.cons_append, List.append_assoc]
+
 /-- The number of transitions of a loop with the given excursions: each excursion contributes its
 own length, plus the one step that returns to the base letter. -/
 def loopSteps (bs : List (List α)) : ℕ :=

--- a/TauCeti/Combinatorics/Enumerative/SuccessorArray.lean
+++ b/TauCeti/Combinatorics/Enumerative/SuccessorArray.lean
@@ -27,8 +27,10 @@ The reconstruction is total: entries after the last genuine visit use the junk v
 
 * `TauCeti.successorArray_visitCount`: the defining step relation of the successor array.
 * `TauCeti.visitTime_eq_iff`: the fibres of the visit times, including the junk-value branch.
-* `TauCeti.visitTime_apply_of_infinite` and `TauCeti.visitTime_strictMono_of_infinite`: visit
+* `TauCeti.apply_visitTime_of_infinite` and `TauCeti.visitTime_strictMono_of_infinite`: visit
   times are genuine and strictly increasing when the value occurs infinitely often.
+* `TauCeti.apply_visitTime_of_le` and `TauCeti.visitTime_lt_visitTime_of_le`: the same two facts
+  below a visit that is known to exist.
 * `TauCeti.eq_pathOfSuccessors`: the uniqueness principle for the reconstruction.
 * `TauCeti.pathOfSuccessors_successorArray`: reconstruction inverts the successor decomposition.
 
@@ -110,7 +112,7 @@ section Counting
 
 attribute [local instance] Classical.decEq
 
-variable {α : Type*} {x y : ℕ → α} {a : α} {k m n : ℕ}
+variable {α : Type*} {x y : ℕ → α} {a : α} {j k m n : ℕ}
 
 /-- Visit counts are `Nat.count` of the visiting predicate. -/
 theorem visitCount_eq_count [DecidableEq α] (x : ℕ → α) (a : α) (n : ℕ) :
@@ -174,7 +176,7 @@ theorem visitTime_eq_iff :
     Nat.nth_eq_iff (p := fun i => x i = a) (k := k) (m := m)
 
 /-- If `x` visits `a` infinitely often, every visit time is a genuine visit. -/
-theorem visitTime_apply_of_infinite (h : {n | x n = a}.Infinite) (k : ℕ) :
+theorem apply_visitTime_of_infinite (h : {n | x n = a}.Infinite) (k : ℕ) :
     x (visitTime x a k) = a := by
   simpa only [visitTime_def] using Nat.nth_mem_of_infinite h k
 
@@ -191,6 +193,49 @@ theorem visitTime_strictMono_of_infinite (h : {n | x n = a}.Infinite) :
 @[simp]
 theorem visitTime_zero_of_eq (h : x 0 = a) : visitTime x a 0 = 0 := by
   rw [visitTime_def, Nat.nth_zero_of_zero h]
+
+/-- If `x` visits `a` only finitely often, the number of visits before a genuine visit is smaller
+than the total number of visits. -/
+theorem visitCount_lt_card (hf : {n | x n = a}.Finite) (hn : x n = a) :
+    visitCount x a n < hf.toFinset.card := by
+  rw [visitCount_eq_count]
+  exact Nat.count_lt_card hf hn
+
+/-- If some time is the `m`-th visit of `x` to `a`, then every earlier visit is realised too: for
+`k ≤ m` some time is the `k`-th visit. -/
+theorem exists_visitCount_of_le (h : ∃ n, x n = a ∧ visitCount x a n = m) (hk : k ≤ m) :
+    ∃ n, x n = a ∧ visitCount x a n = k := by
+  obtain ⟨n, hn, hcount⟩ := h
+  have hcard : ∀ hf : {n | x n = a}.Finite, k < hf.toFinset.card := fun hf =>
+    hk.trans_lt (hcount ▸ visitCount_lt_card hf hn)
+  refine ⟨visitTime x a k, ?_, ?_⟩
+  · simpa only [visitTime_def] using Nat.nth_mem k hcard
+  · rw [visitCount_eq_count, visitTime_def]
+    exact Nat.count_nth hcard
+
+/-- If some time is the `m`-th visit of `x` to `a`, then the `k`-th visit time is a genuine visit
+for every `k ≤ m`. -/
+theorem apply_visitTime_of_le (h : ∃ n, x n = a ∧ visitCount x a n = m) (hk : k ≤ m) :
+    x (visitTime x a k) = a := by
+  obtain ⟨n, hn, hcount⟩ := exists_visitCount_of_le h hk
+  rw [← hcount, visitTime_visitCount hn]
+  exact hn
+
+/-- If some time is the `m`-th visit of `x` to `a`, the visit times up to `m` are strictly
+increasing. -/
+theorem visitTime_lt_visitTime_of_le (h : ∃ n, x n = a ∧ visitCount x a n = m) (hkj : k < j)
+    (hj : j ≤ m) : visitTime x a k < visitTime x a j := by
+  obtain ⟨n, hn, hcount⟩ := h
+  have hcard : ∀ hf : {n | x n = a}.Finite, j < hf.toFinset.card := fun hf =>
+    hj.trans_lt (hcount ▸ visitCount_lt_card hf hn)
+  simpa only [visitTime_def] using Nat.nth_lt_nth' hkj hcard
+
+/-- If `x` visits `a` infinitely often, every visit count is realised. -/
+theorem exists_visitCount_of_infinite (h : {n | x n = a}.Infinite) (m : ℕ) :
+    ∃ n, x n = a ∧ visitCount x a n = m := by
+  refine ⟨visitTime x a m, apply_visitTime_of_infinite h m, ?_⟩
+  apply (visitTime_strictMono_of_infinite h).injective
+  rw [visitTime_visitCount (apply_visitTime_of_infinite h m)]
 
 end Counting
 

--- a/TauCeti/Combinatorics/Enumerative/SuccessorArray.lean
+++ b/TauCeti/Combinatorics/Enumerative/SuccessorArray.lean
@@ -27,6 +27,8 @@ The reconstruction is total: entries after the last genuine visit use the junk v
 
 * `TauCeti.successorArray_visitCount`: the defining step relation of the successor array.
 * `TauCeti.visitTime_eq_iff`: the fibres of the visit times, including the junk-value branch.
+* `TauCeti.visitTime_apply_of_infinite` and `TauCeti.visitTime_strictMono_of_infinite`: visit
+  times are genuine and strictly increasing when the value occurs infinitely often.
 * `TauCeti.eq_pathOfSuccessors`: the uniqueness principle for the reconstruction.
 * `TauCeti.pathOfSuccessors_successorArray`: reconstruction inverts the successor decomposition.
 
@@ -170,6 +172,25 @@ theorem visitTime_eq_iff :
   classical
   simpa only [visitTime_def, visitCount_eq_count] using
     Nat.nth_eq_iff (p := fun i => x i = a) (k := k) (m := m)
+
+/-- If `x` visits `a` infinitely often, every visit time is a genuine visit. -/
+theorem visitTime_apply_of_infinite (h : {n | x n = a}.Infinite) (k : ℕ) :
+    x (visitTime x a k) = a := by
+  simpa only [visitTime_def] using Nat.nth_mem_of_infinite h k
+
+/-- The visit times of an infinitely often visited value are strictly increasing. -/
+theorem visitTime_strictMono_of_infinite (h : {n | x n = a}.Infinite) :
+    StrictMono (visitTime x a) := by
+  have heq : visitTime x a = Nat.nth fun n => x n = a := by
+    funext k
+    exact visitTime_def x a k
+  rw [heq]
+  exact Nat.nth_strictMono h
+
+/-- If a sequence starts at `a`, its zeroth visit to `a` occurs at time zero. -/
+@[simp]
+theorem visitTime_zero_of_eq (h : x 0 = a) : visitTime x a 0 = 0 := by
+  rw [visitTime_def, Nat.nth_zero_of_zero h]
 
 end Counting
 

--- a/TauCeti/Probability/Exchangeability/Excursion.lean
+++ b/TauCeti/Probability/Exchangeability/Excursion.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Combinatorics.Enumerative.LoopWord
+public import TauCeti.Combinatorics.Enumerative.ExcursionProcess
 public import TauCeti.Probability.Exchangeability.MarkovExchangeable
 
 /-!
@@ -35,10 +35,12 @@ This is the finite-path symmetry that Diaconis and Freedman's representation the
 exchangeable processes rests on: a recurrent Markov exchangeable process returns to its initial
 state infinitely often, so its excursions from that state form a genuine sequence of random
 finite paths, and the identities below are that sequence's finite-dimensional exchangeability.
-Assembling them into an exchangeable process, and running de Finetti on it to exhibit the process
-as a mixture of Markov chains (`TauCeti.Probability.MixedMarkovChain`, whose converse direction is
-`TauCeti.Probability.MixedMarkovChainWith.markovExchangeable`), needs a recurrence hypothesis and
-the excursion process itself; neither is set up here.
+The combinatorial excursion process and its reconstruction of a recurrent path segment are set up
+in `TauCeti.Combinatorics.Enumerative.ExcursionProcess`.  Assembling the probability identities
+below into exchangeability of that process, and running de Finetti on it to exhibit the original
+process as a mixture of Markov chains (`TauCeti.Probability.MixedMarkovChain`, whose converse
+direction is `TauCeti.Probability.MixedMarkovChainWith.markovExchangeable`), still needs the
+recurrence hypothesis at the process level.
 
 ## Main results
 


### PR DESCRIPTION
This PR defines the canonical excursion process of a sequence: `TauCeti.excursion x a k` is the finite word strictly between the `k`-th and `(k + 1)`-st visits to `a`, and `TauCeti.excursionPrefix x a m` collects its first `m` excursions. It proves that excursions avoid their base state, that their lengths are the gaps between consecutive visit times, and, when `a` is visited infinitely often, that spelling the first `m` excursions with `loopPath` recovers exactly the original sequence segment from its zeroth through its `m`-th visit. The versions for a path starting at `a` identify this segment with the prefix through the `m`-th return and its number of transitions with that return time.

This advances Layer 8 of `TauCetiRoadmap/Exchangeability/README.md`, milestone “Markov exchangeability,” whose target is the Diaconis–Freedman representation theorem that a recurrent Markov exchangeable process is a mixture of Markov chains. The finite excursion-reordering theorem already on `main` explicitly left the excursion process itself unset; this PR supplies the canonical process and the reconstruction identity that turns a finite list of its values into exactly the loop event whose mass that theorem controls. This is the most effective current step because it connects that landed finite symmetry directly to the recurrence and successor-array work already in flight, without duplicating either.

After this PR, the milestone still needs process-level recurrence to instantiate the infinitude hypothesis, exchangeability of the resulting excursion process (equivalently the required row exchangeability of the successor array), and the final change of variables from the row directing measure back to the path law.

Add `TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean` (224 lines), add the three general visit-time facts it consumes beside `visitTime` in `SuccessorArray.lean`, and update the existing probability excursion module to import and describe the new bridge. The implementation reuses Mathlib’s `List.Ico` interval API and `Nat.nth` facts (`nth_mem_of_infinite`, `nth_strictMono`, and `le_nth_of_lt_nth_succ`); no Mathlib or external formalization is vendored. The construction and its role follow Diaconis and Freedman, “de Finetti’s theorem for Markov chains,” *Annals of Probability* 8 (1980), 115–130, as credited in the module documentation; no material is adapted from `cameronfreer/exchangeability`.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"excursion-process"}-->

🤖 Prepared with Codex
