### PR TITLE
feat: degree zero of continuous cohomology, compatibly with compatible pairs

### DIFF
--- a/TauCeti/RepresentationTheory/Continuous/Invariants.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Invariants.lean
@@ -41,6 +41,8 @@ homomorphism `G → G ⧸ S` together with the inclusion `Xˢ ↪ X`.
   `ContRepresentation.invariants_restrict_top`: the two degenerate subgroups.
 * `TopRep.quotientToInvariantsMap_comp_quotientToInvariantsι`: naturality of the inclusion of the
   invariants.
+* `TopRep.isIso_invariantsResMap_quotientToInvariantsι`: taking quotient invariants and then
+  invariants under the quotient recovers the original invariants.
 
 These declarations live in the root `ContRepresentation` and `TopRep` namespaces, rather than
 under `TauCeti`, so that dot notation on the Mathlib types they extend elaborates.
@@ -196,6 +198,54 @@ theorem quotientToInvariantsMap_comp_quotientToInvariantsι {X Y : TopRep R G} (
         quotientToInvariantsι Y S = quotientToInvariantsι X S ≫ f := by
   ext v
   rfl
+
+/-- A `G`-invariant vector is `S`-invariant, and the element of `X^S` it becomes is invariant under
+the induced `G ⧸ S`-action. -/
+private noncomputable def invariantsToQuotientToInvariants :
+    invariants X ⟶ invariants (quotientToInvariants X S) :=
+  TopModuleCat.ofHom
+    ((X.ρ.invariants.subtypeL.codRestrict (X.ρ.restrict S.subtype).invariants
+        fun v ↦ invariants_le_invariants_restrict X.ρ S.subtype v.2).codRestrict
+      (ContRepresentation.quotientToInvariants X.ρ S).invariants fun v g ↦ by
+        induction g using QuotientGroup.induction_on with
+        | H g =>
+          refine Subtype.ext ?_
+          rw [coe_quotientToInvariants_mk_apply]
+          exact v.2 g)
+
+-- The two nested `codRestrict`s above change only the proofs of membership in the nested invariant
+-- submodules, not the underlying vector.
+private theorem coe_invariantsToQuotientToInvariants_apply (v : X.ρ.invariants) :
+    (((invariantsToQuotientToInvariants X S) v :
+      (X.ρ.restrict S.subtype).invariants) : X.V) = (v : X.V) := by
+  rfl
+
+-- Likewise, `invariantsResMap` applied to the inclusion of `S`-invariants retains the vector and
+-- only repackages its invariance proof.
+private theorem coe_invariantsResMap_quotientToInvariantsι_apply
+    (v : (ContRepresentation.quotientToInvariants X.ρ S).invariants) :
+    ((invariantsResMap (QuotientGroup.mk' S : G →* G ⧸ S)
+        (quotientToInvariantsι X S) v : X.ρ.invariants) : X.V) =
+      ((v : (X.ρ.restrict S.subtype).invariants) : X.V) := by
+  rfl
+
+/-- **`(X^S)^{G/S}` is canonically isomorphic to `X^G`.** The map induced on invariants by the
+inclusion `X^S ⟶ X` is an isomorphism, with inverse preserving the underlying vector. -/
+theorem isIso_invariantsResMap_quotientToInvariantsι :
+    IsIso (invariantsResMap (QuotientGroup.mk' S : G →* G ⧸ S)
+      (quotientToInvariantsι X S)) :=
+  ⟨invariantsToQuotientToInvariants X S,
+    by
+      ext v
+      exact (coe_invariantsResMap_quotientToInvariantsι_apply X S v).trans
+        (coe_invariantsToQuotientToInvariants_apply X S
+          (invariantsResMap (QuotientGroup.mk' S : G →* G ⧸ S)
+            (quotientToInvariantsι X S) v)),
+    by
+      ext v
+      exact (coe_invariantsToQuotientToInvariants_apply X S v).trans
+        (coe_invariantsResMap_quotientToInvariantsι_apply X S
+          ((invariantsToQuotientToInvariants X S) v))⟩
 
 -- Exposed: the generated `@[simps]` field lemmas are `rfl`-proofs about this body.
 variable (R G) in

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/DegreeZero.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/DegreeZero.lean
@@ -31,10 +31,9 @@ commutes (`TauCeti.ContinuousCohomology.map_comp_zeroIso_hom`), and the three na
 Two consequences are recorded because later layers use them rather than the square itself. First,
 `H⁰_cont(G, -)` and the invariants functor are naturally isomorphic
 (`TauCeti.ContinuousCohomology.zeroIsoNatIso`). Second, inflation is an isomorphism in degree zero
-(`TauCeti.ContinuousCohomology.isIso_infl_zero`): `(X^N)^{G/N} = X^G` on the nose, so the
-degree-zero edge of the inflation-restriction sequence is an equality of subobjects of `X`, and
-restriction is a monomorphism in degree zero (`TauCeti.ContinuousCohomology.mono_res_zero`) because
-`X^G ⊆ X^S`.
+(`TauCeti.ContinuousCohomology.isIso_infl_zero`): `(X^N)^{G/N}` and `X^G` are canonically
+isomorphic by explicit mutually inverse maps that preserve the underlying vector. Restriction is a
+monomorphism in degree zero (`TauCeti.ContinuousCohomology.mono_res_zero`) because `X^G ⊆ X^S`.
 
 The route to the square is the explicit evaluation formula
 `TauCeti.ContinuousCohomology.coe_zeroIso_hom_π`: a `0`-cocycle of the homogeneous complex is an
@@ -83,21 +82,21 @@ section Evaluation
 
 /-- The comparison of the categorical cocycles with the concrete kernel is the inclusion of the
 cocycles into the cochains. -/
-theorem cocycles₀Iso_hom_comp_kerι (X : TopRep R G) :
+private theorem cocycles₀Iso_hom_comp_kerι (X : TopRep R G) :
     (cocycles₀Iso X).hom ≫ TopModuleCat.kerι _ = (homogeneousCochains X).iCycles 0 := by
   rw [cocycles₀Iso, Limits.KernelFork.mapIsoOfIsLimit_hom]
   exact (Limits.KernelFork.mapOfIsLimit_ι _ (TopModuleCat.isLimitKer _) _).trans
     (Category.comp_id _)
 
 /-- `cocycles₀Iso` read on elements: it does nothing to the underlying cochain. -/
-theorem coe_cocycles₀Iso_hom (X : TopRep R G) (σ : cocycles X 0) :
+private theorem coe_cocycles₀Iso_hom (X : TopRep R G) (σ : cocycles X 0) :
     ((cocycles₀Iso X).hom σ : (homogeneousCochains X).X 0) =
       (homogeneousCochains X).iCycles 0 σ :=
   congr($(cocycles₀Iso_hom_comp_kerι X) σ)
 
 /-- In degree zero the cocycles already are the cohomology, so `zeroIso` may be read off on
 cocycles. -/
-theorem π_comp_zeroIso_hom (X : TopRep R G) :
+private theorem π_comp_zeroIso_hom (X : TopRep R G) :
     π X 0 ≫ (zeroIso X).hom = (cocycles₀Iso X).hom ≫ (TopModuleCat.ofIso (d₀kerIso X)).hom := by
   simp [zeroIso]
 
@@ -131,12 +130,15 @@ theorem map_comp_zeroIso_hom (φ : H →ₜ* G) {X : TopRep R G} {Y : TopRep R H
       = (cochainsMap φ f).f 0 ((homogeneousCochains X).iCycles 0 σ) :=
     congr($(HomologicalComplex.cyclesMap_i (cochainsMap φ f) 0) σ)
   rw [coe_zeroIso_hom_π Y, hcyc]
-  change _ = f.hom (((zeroIso X).hom (π X 0 σ) : X.V))
+  simp only [TopRep.invariantsResMap, TopModuleCat.hom_ofHom,
+    ContIntertwiningMap.mapInvariantsOfRes_apply]
   rw [coe_zeroIso_hom_π X, cochainsMap_f, resolutionMap_succ]
   set v := ((homogeneousCochains X).iCycles 0 σ : (homogeneousCochains X).X 0)
-  -- the cochain pullback precomposes with `φ`, and `φ 1 = 1`
-  change (Hom.hom f) (v.1 (φ 1)) = (Hom.hom f) (v.1 1)
-  rw [map_one]
+  -- `coind₁ResMap_apply` exposes that the cochain pullback precomposes with `φ`.
+  simp only [TopRep.invariantsResMap, TopModuleCat.hom_ofHom, TopRep.hom_ofHom,
+    resolutionMap_zero]
+  rw [ContIntertwiningMap.mapInvariantsOfRes_apply,
+    ContRepresentation.coind₁ResMap_apply, map_one φ]
 
 /-- Coefficient maps in degree zero are the maps induced on invariants. -/
 @[reassoc]
@@ -157,6 +159,13 @@ noncomputable def zeroIsoNatIso :
 @[simp]
 theorem zeroIsoNatIso_hom_app (X : TopRep R G) :
     (zeroIsoNatIso R G).hom.app X = (zeroIso X).hom :=
+  (rfl)
+
+/-- The inverse components of `zeroIsoNatIso` are the inverses of Mathlib's
+`ContinuousCohomology.zeroIso`. -/
+@[simp]
+theorem zeroIsoNatIso_inv_app (X : TopRep R G) :
+    (zeroIsoNatIso R G).inv.app X = (zeroIso X).inv :=
   (rfl)
 
 /-- Restriction in degree zero is the inclusion `X^G ⊆ X^S` of invariants. -/
@@ -265,15 +274,46 @@ noncomputable def invariantsToQuotientToInvariants :
           rw [ContRepresentation.coe_quotientToInvariants_mk_apply]
           exact v.2 g)
 
+-- The two nested `codRestrict`s in `invariantsToQuotientToInvariants` change only the proofs of
+-- membership in the nested invariant submodules, not the underlying vector.
 omit [TopologicalSpace G] [IsTopologicalGroup G] in
-/-- **`(X^N)^{G/N} = X^G`.** The coefficient half of inflation is an isomorphism on invariants. -/
+private theorem coe_invariantsToQuotientToInvariants_apply (v : X.ρ.invariants) :
+    (((invariantsToQuotientToInvariants N X) v :
+      (X.ρ.restrict N.subtype).invariants) : X.V) = (v : X.V) := by
+  rfl
+
+-- Likewise, `invariantsResMap` applied to the inclusion of `N`-invariants retains the vector and
+-- only repackages its invariance proof.
+omit [TopologicalSpace G] [IsTopologicalGroup G] in
+private theorem coe_invariantsResMap_quotientToInvariantsι_apply
+    (v : (ContRepresentation.quotientToInvariants X.ρ N).invariants) :
+    ((TopRep.invariantsResMap (QuotientGroup.mk' N : G →* G ⧸ N)
+        (TopRep.quotientToInvariantsι X N) v : X.ρ.invariants) : X.V) =
+      ((v : (X.ρ.restrict N.subtype).invariants) : X.V) := by
+  rfl
+
+omit [TopologicalSpace G] [IsTopologicalGroup G] in
+/-- **`(X^N)^{G/N}` is canonically isomorphic to `X^G`.** The explicit mutually inverse maps
+preserve the underlying vector. -/
 theorem isIso_invariantsResMap_quotientToInvariantsι :
     IsIso (TopRep.invariantsResMap (QuotientGroup.mk' N : G →* G ⧸ N)
       (TopRep.quotientToInvariantsι X N)) :=
-  ⟨invariantsToQuotientToInvariants N X, by ext v; rfl, by ext v; rfl⟩
+  ⟨invariantsToQuotientToInvariants N X,
+    by
+      ext v
+      exact (coe_invariantsResMap_quotientToInvariantsι_apply N X v).trans
+        (coe_invariantsToQuotientToInvariants_apply N X
+          (TopRep.invariantsResMap (QuotientGroup.mk' N : G →* G ⧸ N)
+            (TopRep.quotientToInvariantsι X N) v)),
+    by
+      ext v
+      exact (coe_invariantsToQuotientToInvariants_apply N X v).trans
+        (coe_invariantsResMap_quotientToInvariantsι_apply N X
+          ((invariantsToQuotientToInvariants N X) v))⟩
 
-/-- **Inflation is an isomorphism in degree zero**: `H⁰(G ⧸ N, X^N) = (X^N)^{G/N} = X^G`. This is
-the degree-zero edge of the inflation-restriction sequence. -/
+/-- **Inflation is an isomorphism in degree zero**: `H⁰(G ⧸ N, X^N)`, `(X^N)^{G/N}`, and
+`X^G` are canonically isomorphic, with the coefficient comparison preserving the underlying
+vector. This is the degree-zero edge of the inflation-restriction sequence. -/
 theorem isIso_infl_zero : IsIso (TauCeti.ContinuousCohomology.infl N X 0) := by
   have := isIso_invariantsResMap_quotientToInvariantsι N X
   exact IsIso.of_isIso_fac_right (infl_comp_zeroIso_hom N X)

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/DegreeZero.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/DegreeZero.lean
@@ -102,7 +102,8 @@ private theorem π_comp_zeroIso_hom (X : TopRep R G) :
 
 /-- **The evaluation formula for `zeroIso`.** A homogeneous `0`-cochain of `X` is a `G`-invariant
 element of `C(G, X)`; `zeroIso` sends the class of a `0`-cocycle to its value at `1`. Every
-statement below is this formula together with `φ 1 = 1`. -/
+compatible-pair square below, including its coefficient, restriction, and inflation
+specializations, follows from this formula together with `φ 1 = 1`. -/
 theorem coe_zeroIso_hom_π (X : TopRep R G) (σ : cocycles X 0) :
     (((zeroIso X).hom (π X 0 σ)) : X.V) = ((homogeneousCochains X).iCycles 0 σ).1 1 := by
   have h := congr($(π_comp_zeroIso_hom X) σ)
@@ -237,85 +238,28 @@ end Class
 
 section Edge
 
-omit [TopologicalSpace G] [IsTopologicalGroup G] in
-/-- Restriction is injective on invariants: an element fixed by all of `G` is determined by the
-element of `X^S` it becomes. -/
-theorem injective_invariantsResMap_subtype (S : Subgroup G) (X : TopRep R G) :
-    Function.Injective (TopRep.invariantsResMap (S.subtype : S →* G)
-      (𝟙 (TopRep.res (S.subtype : S →* G) X))) := by
-  intro a b hab
-  ext
-  exact congrArg
-    (fun w : (TopRep.res (S.subtype : S →* G) X).ρ.invariants ↦ (w : X.V)) hab
-
 /-- **Restriction is a monomorphism in degree zero.** This is the degree-zero left edge of the
 inflation-restriction sequence: `X^G ⊆ X^S`. -/
 theorem mono_res_zero (S : Subgroup G) (X : TopRep R G) :
     Mono (TauCeti.ContinuousCohomology.res S X 0) := by
+  have hinjective : Function.Injective (TopRep.invariantsResMap (S.subtype : S →* G)
+      (𝟙 (TopRep.res (S.subtype : S →* G) X))) := by
+    intro a b hab
+    ext
+    exact congrArg
+      (fun w : (TopRep.res (S.subtype : S →* G) X).ρ.invariants ↦ (w : X.V)) hab
   have : Mono (TopRep.invariantsResMap (S.subtype : S →* G)
       (𝟙 (TopRep.res (S.subtype : S →* G) X))) :=
-    ConcreteCategory.mono_of_injective _ (injective_invariantsResMap_subtype S X)
+    ConcreteCategory.mono_of_injective _ hinjective
   exact mono_of_mono_fac (res_comp_zeroIso_hom S X)
 
 variable (N : Subgroup G) [N.Normal] (X : TopRep R G)
-
-/-- A `G`-invariant vector is `N`-invariant, and the element of `X^N` it becomes is invariant under
-the induced `G ⧸ N`-action. This is the inverse of the degree-zero inflation, read on
-invariants. -/
-noncomputable def invariantsToQuotientToInvariants :
-    TopRep.invariants X ⟶ TopRep.invariants (TopRep.quotientToInvariants X N) :=
-  TopModuleCat.ofHom
-    ((X.ρ.invariants.subtypeL.codRestrict (X.ρ.restrict N.subtype).invariants
-        fun v ↦ ContRepresentation.invariants_le_invariants_restrict X.ρ N.subtype v.2).codRestrict
-      (ContRepresentation.quotientToInvariants X.ρ N).invariants fun v g ↦ by
-        induction g using QuotientGroup.induction_on with
-        | H g =>
-          refine Subtype.ext ?_
-          rw [ContRepresentation.coe_quotientToInvariants_mk_apply]
-          exact v.2 g)
-
--- The two nested `codRestrict`s in `invariantsToQuotientToInvariants` change only the proofs of
--- membership in the nested invariant submodules, not the underlying vector.
-omit [TopologicalSpace G] [IsTopologicalGroup G] in
-private theorem coe_invariantsToQuotientToInvariants_apply (v : X.ρ.invariants) :
-    (((invariantsToQuotientToInvariants N X) v :
-      (X.ρ.restrict N.subtype).invariants) : X.V) = (v : X.V) := by
-  rfl
-
--- Likewise, `invariantsResMap` applied to the inclusion of `N`-invariants retains the vector and
--- only repackages its invariance proof.
-omit [TopologicalSpace G] [IsTopologicalGroup G] in
-private theorem coe_invariantsResMap_quotientToInvariantsι_apply
-    (v : (ContRepresentation.quotientToInvariants X.ρ N).invariants) :
-    ((TopRep.invariantsResMap (QuotientGroup.mk' N : G →* G ⧸ N)
-        (TopRep.quotientToInvariantsι X N) v : X.ρ.invariants) : X.V) =
-      ((v : (X.ρ.restrict N.subtype).invariants) : X.V) := by
-  rfl
-
-omit [TopologicalSpace G] [IsTopologicalGroup G] in
-/-- **`(X^N)^{G/N}` is canonically isomorphic to `X^G`.** The explicit mutually inverse maps
-preserve the underlying vector. -/
-theorem isIso_invariantsResMap_quotientToInvariantsι :
-    IsIso (TopRep.invariantsResMap (QuotientGroup.mk' N : G →* G ⧸ N)
-      (TopRep.quotientToInvariantsι X N)) :=
-  ⟨invariantsToQuotientToInvariants N X,
-    by
-      ext v
-      exact (coe_invariantsResMap_quotientToInvariantsι_apply N X v).trans
-        (coe_invariantsToQuotientToInvariants_apply N X
-          (TopRep.invariantsResMap (QuotientGroup.mk' N : G →* G ⧸ N)
-            (TopRep.quotientToInvariantsι X N) v)),
-    by
-      ext v
-      exact (coe_invariantsToQuotientToInvariants_apply N X v).trans
-        (coe_invariantsResMap_quotientToInvariantsι_apply N X
-          ((invariantsToQuotientToInvariants N X) v))⟩
 
 /-- **Inflation is an isomorphism in degree zero**: `H⁰(G ⧸ N, X^N)`, `(X^N)^{G/N}`, and
 `X^G` are canonically isomorphic, with the coefficient comparison preserving the underlying
 vector. This is the degree-zero edge of the inflation-restriction sequence. -/
 theorem isIso_infl_zero : IsIso (TauCeti.ContinuousCohomology.infl N X 0) := by
-  have := isIso_invariantsResMap_quotientToInvariantsι N X
+  have := TopRep.isIso_invariantsResMap_quotientToInvariantsι X N
   exact IsIso.of_isIso_fac_right (infl_comp_zeroIso_hom N X)
 
 end Edge

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/DegreeZero.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/DegreeZero.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.Homological.ContCohomology.LowDegree
+public import TauCeti.RepresentationTheory.Homological.ContCohomology.Functoriality
+
+/-!
+# Degree zero of continuous cohomology, and compatible pairs
+
+Mathlib computes one degree of continuous cohomology: `ContinuousCohomology.zeroIso` identifies
+`H⁰_cont(G, X)` with the invariants `X^G`. That identification is only usable once it is known to
+transport the *maps*, and this file supplies exactly that. For a continuous homomorphism
+`φ : H →ₜ* G` and a morphism `f : TopRep.res φ X ⟶ Y` of topological `H`-representations, the
+square
+
+```
+H⁰_cont(G, X) --map φ f 0--> H⁰_cont(H, Y)
+     |                             |
+  zeroIso X                     zeroIso Y
+     v                             v
+    X^G  ----invariantsResMap---->  Y^H
+```
+
+commutes (`TauCeti.ContinuousCohomology.map_comp_zeroIso_hom`), and the three named instances of
+`ContinuousCohomology.map` — coefficient maps, restriction and inflation — inherit it.
+
+Two consequences are recorded because later layers use them rather than the square itself. First,
+`H⁰_cont(G, -)` and the invariants functor are naturally isomorphic
+(`TauCeti.ContinuousCohomology.zeroIsoNatIso`). Second, inflation is an isomorphism in degree zero
+(`TauCeti.ContinuousCohomology.isIso_infl_zero`): `(X^N)^{G/N} = X^G` on the nose, so the
+degree-zero edge of the inflation-restriction sequence is an equality of subobjects of `X`, and
+restriction is a monomorphism in degree zero (`TauCeti.ContinuousCohomology.mono_res_zero`) because
+`X^G ⊆ X^S`.
+
+The route to the square is the explicit evaluation formula
+`TauCeti.ContinuousCohomology.coe_zeroIso_hom_π`: a `0`-cocycle of the homogeneous complex is an
+invariant element of `C(G, X)`, and `zeroIso` reads off its value at `1`. Compatible-pair
+functoriality precomposes with `φ`, and `φ 1 = 1`, which is the whole content.
+
+This implements the "Degree 0" milestone of Layer 1, "the canonical carrier and its
+functoriality", of the human-authored roadmap at `TauCetiRoadmap/ProfiniteCohomology/README.md`,
+together with the invariant-class constructor `degreeZeroClass` that the same layer names.
+
+## Main definitions
+
+* `TauCeti.ContinuousCohomology.degreeZeroClass`: the degree-zero class of an invariant vector.
+* `TauCeti.ContinuousCohomology.zeroIsoNatIso`: `H⁰_cont(G, -) ≅ (-)^G` as functors.
+
+## Main results
+
+* `TauCeti.ContinuousCohomology.map_comp_zeroIso_hom`: compatible-pair functoriality commutes with
+  `zeroIso`.
+* `TauCeti.ContinuousCohomology.coeffMap_comp_zeroIso_hom`,
+  `TauCeti.ContinuousCohomology.res_comp_zeroIso_hom`,
+  `TauCeti.ContinuousCohomology.infl_comp_zeroIso_hom`: the same for the three named instances.
+* `TauCeti.ContinuousCohomology.map_degreeZeroClass`: compatible-pair functoriality on classes of
+  invariant vectors.
+* `TauCeti.ContinuousCohomology.isIso_infl_zero`, `TauCeti.ContinuousCohomology.mono_res_zero`:
+  the degree-zero edge of inflation-restriction.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+namespace ContinuousCohomology
+
+open _root_.ContinuousCohomology TopRep
+
+universe u v
+
+variable {R : Type u} [Ring R] [TopologicalSpace R]
+  {G H : Type v} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [Group H] [TopologicalSpace H] [IsTopologicalGroup H]
+
+section Evaluation
+
+/-- The comparison of the categorical cocycles with the concrete kernel is the inclusion of the
+cocycles into the cochains. -/
+theorem cocycles₀Iso_hom_comp_kerι (X : TopRep R G) :
+    (cocycles₀Iso X).hom ≫ TopModuleCat.kerι _ = (homogeneousCochains X).iCycles 0 := by
+  rw [cocycles₀Iso, Limits.KernelFork.mapIsoOfIsLimit_hom]
+  exact (Limits.KernelFork.mapOfIsLimit_ι _ (TopModuleCat.isLimitKer _) _).trans
+    (Category.comp_id _)
+
+/-- `cocycles₀Iso` read on elements: it does nothing to the underlying cochain. -/
+theorem coe_cocycles₀Iso_hom (X : TopRep R G) (σ : cocycles X 0) :
+    ((cocycles₀Iso X).hom σ : (homogeneousCochains X).X 0) =
+      (homogeneousCochains X).iCycles 0 σ :=
+  congr($(cocycles₀Iso_hom_comp_kerι X) σ)
+
+/-- In degree zero the cocycles already are the cohomology, so `zeroIso` may be read off on
+cocycles. -/
+theorem π_comp_zeroIso_hom (X : TopRep R G) :
+    π X 0 ≫ (zeroIso X).hom = (cocycles₀Iso X).hom ≫ (TopModuleCat.ofIso (d₀kerIso X)).hom := by
+  simp [zeroIso]
+
+/-- **The evaluation formula for `zeroIso`.** A homogeneous `0`-cochain of `X` is a `G`-invariant
+element of `C(G, X)`; `zeroIso` sends the class of a `0`-cocycle to its value at `1`. Every
+statement below is this formula together with `φ 1 = 1`. -/
+theorem coe_zeroIso_hom_π (X : TopRep R G) (σ : cocycles X 0) :
+    (((zeroIso X).hom (π X 0 σ)) : X.V) = ((homogeneousCochains X).iCycles 0 σ).1 1 := by
+  have h := congr($(π_comp_zeroIso_hom X) σ)
+  simp only [ConcreteCategory.comp_apply] at h
+  rw [h, ← coe_cocycles₀Iso_hom]
+  rfl
+
+end Evaluation
+
+section CompatiblePair
+
+/-- **Degree zero is compatible with compatible pairs.** For a continuous homomorphism
+`φ : H →ₜ* G` and a morphism `f : TopRep.res φ X ⟶ Y`, the map `ContinuousCohomology.map φ f 0`
+becomes, under `ContinuousCohomology.zeroIso`, the map `X^G ⟶ Y^H` induced by `f`. This is what
+makes Layer 3's low-degree comparisons checkable at `n = 0`. -/
+@[reassoc]
+theorem map_comp_zeroIso_hom (φ : H →ₜ* G) {X : TopRep R G} {Y : TopRep R H}
+    (f : TopRep.res (φ : H →* G) X ⟶ Y) :
+    _root_.ContinuousCohomology.map φ f 0 ≫ (zeroIso Y).hom =
+      (zeroIso X).hom ≫ TopRep.invariantsResMap (φ : H →* G) f := by
+  rw [← cancel_epi (π X 0), _root_.ContinuousCohomology.π_map_assoc]
+  ext σ
+  simp only [ConcreteCategory.comp_apply]
+  have hcyc : (homogeneousCochains Y).iCycles 0 (cocyclesMap φ f 0 σ)
+      = (cochainsMap φ f).f 0 ((homogeneousCochains X).iCycles 0 σ) :=
+    congr($(HomologicalComplex.cyclesMap_i (cochainsMap φ f) 0) σ)
+  rw [coe_zeroIso_hom_π Y, hcyc]
+  change _ = f.hom (((zeroIso X).hom (π X 0 σ) : X.V))
+  rw [coe_zeroIso_hom_π X, cochainsMap_f, resolutionMap_succ]
+  set v := ((homogeneousCochains X).iCycles 0 σ : (homogeneousCochains X).X 0)
+  -- the cochain pullback precomposes with `φ`, and `φ 1 = 1`
+  change (Hom.hom f) (v.1 (φ 1)) = (Hom.hom f) (v.1 1)
+  rw [map_one]
+
+/-- Coefficient maps in degree zero are the maps induced on invariants. -/
+@[reassoc]
+theorem coeffMap_comp_zeroIso_hom {X Y : TopRep R G} (f : X ⟶ Y) :
+    coeffMap f 0 ≫ (zeroIso Y).hom =
+      (zeroIso X).hom ≫ (TopRep.invariantsFunctor R G).map f := by
+  rw [coeffMap_def]
+  exact map_comp_zeroIso_hom (ContinuousMonoidHom.id G) f
+
+variable (R G) in
+/-- **Degree-zero continuous cohomology is the invariants functor.** The functorial form of
+`ContinuousCohomology.zeroIso`; its naturality is `coeffMap_comp_zeroIso_hom`. -/
+noncomputable def zeroIsoNatIso :
+    continuousCohomologyFunctor R G 0 ≅ TopRep.invariantsFunctor R G :=
+  NatIso.ofComponents (fun X ↦ zeroIso X) fun f ↦ coeffMap_comp_zeroIso_hom f
+
+/-- The components of `zeroIsoNatIso` are Mathlib's `ContinuousCohomology.zeroIso`. -/
+@[simp]
+theorem zeroIsoNatIso_hom_app (X : TopRep R G) :
+    (zeroIsoNatIso R G).hom.app X = (zeroIso X).hom :=
+  (rfl)
+
+/-- Restriction in degree zero is the inclusion `X^G ⊆ X^S` of invariants. -/
+@[reassoc]
+theorem res_comp_zeroIso_hom (S : Subgroup G) (X : TopRep R G) :
+    TauCeti.ContinuousCohomology.res S X 0 ≫
+        (zeroIso (TopRep.res (S.subtype : S →* G) X)).hom =
+      (zeroIso X).hom ≫
+        TopRep.invariantsResMap (S.subtype : S →* G)
+          (𝟙 (TopRep.res (S.subtype : S →* G) X)) := by
+  rw [res_def]
+  exact map_comp_zeroIso_hom (ContinuousMonoidHom.subgroupSubtype S)
+    (𝟙 (TopRep.res (S.subtype : S →* G) X))
+
+/-- Inflation in degree zero is the inclusion `(X^N)^{G/N} ⊆ X^G` of invariants. -/
+@[reassoc]
+theorem infl_comp_zeroIso_hom (N : Subgroup G) [N.Normal] (X : TopRep R G) :
+    TauCeti.ContinuousCohomology.infl N X 0 ≫ (zeroIso X).hom =
+      (zeroIso (TopRep.quotientToInvariants X N)).hom ≫
+        TopRep.invariantsResMap (QuotientGroup.mk' N : G →* G ⧸ N)
+          (TopRep.quotientToInvariantsι X N) := by
+  rw [infl_def]
+  exact map_comp_zeroIso_hom (ContinuousMonoidHom.quotientMk N)
+    (TopRep.quotientToInvariantsι X N)
+
+end CompatiblePair
+
+section Class
+
+variable {X : TopRep R G} {Y : TopRep R H}
+
+/-- The inverse form of `map_comp_zeroIso_hom`, which is what acts on classes. -/
+@[reassoc]
+theorem zeroIso_inv_comp_map (φ : H →ₜ* G) (f : TopRep.res (φ : H →* G) X ⟶ Y) :
+    (zeroIso X).inv ≫ _root_.ContinuousCohomology.map φ f 0 =
+      TopRep.invariantsResMap (φ : H →* G) f ≫ (zeroIso Y).inv := by
+  rw [Iso.inv_comp_eq, ← Category.assoc, Iso.eq_comp_inv]
+  exact map_comp_zeroIso_hom φ f
+
+/-- **The degree-zero class of an invariant vector.** Degree zero is the invariants, so an
+invariant element of `X` has a continuous cohomology class; this is `zeroIso` read backwards on
+elements. -/
+noncomputable def degreeZeroClass (X : TopRep R G) (u : X.V) (hu : ∀ g : G, X.ρ g u = u) :
+    continuousCohomology 0 X :=
+  (zeroIso X).inv ⟨u, (ContRepresentation.mem_invariants u).2 hu⟩
+
+/-- `zeroIso` recovers the invariant vector a degree-zero class was built from. -/
+@[simp]
+theorem coe_zeroIso_hom_degreeZeroClass (u : X.V) (hu : ∀ g : G, X.ρ g u = u) :
+    (((zeroIso X).hom (degreeZeroClass X u hu)) : X.V) = u := by
+  simp [degreeZeroClass]
+
+/-- Every degree-zero class is the class of an invariant vector. -/
+theorem exists_degreeZeroClass_eq (x : continuousCohomology 0 X) :
+    ∃ (u : X.V) (hu : ∀ g : G, X.ρ g u = u), degreeZeroClass X u hu = x :=
+  ⟨((zeroIso X).hom x : X.V), (ContRepresentation.mem_invariants _).1 ((zeroIso X).hom x).2,
+    congr($((zeroIso X).hom_inv_id) x)⟩
+
+/-- **Compatible-pair functoriality on the class of an invariant vector.** -/
+@[simp]
+theorem map_degreeZeroClass (φ : H →ₜ* G) (f : TopRep.res (φ : H →* G) X ⟶ Y) (u : X.V)
+    (hu : ∀ g : G, X.ρ g u = u) :
+    _root_.ContinuousCohomology.map φ f 0 (degreeZeroClass X u hu) =
+      degreeZeroClass Y (f.hom u) fun h ↦ by
+        rw [← f.hom.isIntertwining h u, ContRepresentation.restrict_apply_apply, hu] :=
+  congr($(zeroIso_inv_comp_map φ f) ⟨u, (ContRepresentation.mem_invariants u).2 hu⟩)
+
+end Class
+
+section Edge
+
+omit [TopologicalSpace G] [IsTopologicalGroup G] in
+/-- Restriction is injective on invariants: an element fixed by all of `G` is determined by the
+element of `X^S` it becomes. -/
+theorem injective_invariantsResMap_subtype (S : Subgroup G) (X : TopRep R G) :
+    Function.Injective (TopRep.invariantsResMap (S.subtype : S →* G)
+      (𝟙 (TopRep.res (S.subtype : S →* G) X))) := by
+  intro a b hab
+  ext
+  exact congrArg
+    (fun w : (TopRep.res (S.subtype : S →* G) X).ρ.invariants ↦ (w : X.V)) hab
+
+/-- **Restriction is a monomorphism in degree zero.** This is the degree-zero left edge of the
+inflation-restriction sequence: `X^G ⊆ X^S`. -/
+theorem mono_res_zero (S : Subgroup G) (X : TopRep R G) :
+    Mono (TauCeti.ContinuousCohomology.res S X 0) := by
+  have : Mono (TopRep.invariantsResMap (S.subtype : S →* G)
+      (𝟙 (TopRep.res (S.subtype : S →* G) X))) :=
+    ConcreteCategory.mono_of_injective _ (injective_invariantsResMap_subtype S X)
+  exact mono_of_mono_fac (res_comp_zeroIso_hom S X)
+
+variable (N : Subgroup G) [N.Normal] (X : TopRep R G)
+
+/-- A `G`-invariant vector is `N`-invariant, and the element of `X^N` it becomes is invariant under
+the induced `G ⧸ N`-action. This is the inverse of the degree-zero inflation, read on
+invariants. -/
+noncomputable def invariantsToQuotientToInvariants :
+    TopRep.invariants X ⟶ TopRep.invariants (TopRep.quotientToInvariants X N) :=
+  TopModuleCat.ofHom
+    ((X.ρ.invariants.subtypeL.codRestrict (X.ρ.restrict N.subtype).invariants
+        fun v ↦ ContRepresentation.invariants_le_invariants_restrict X.ρ N.subtype v.2).codRestrict
+      (ContRepresentation.quotientToInvariants X.ρ N).invariants fun v g ↦ by
+        induction g using QuotientGroup.induction_on with
+        | H g =>
+          refine Subtype.ext ?_
+          rw [ContRepresentation.coe_quotientToInvariants_mk_apply]
+          exact v.2 g)
+
+omit [TopologicalSpace G] [IsTopologicalGroup G] in
+/-- **`(X^N)^{G/N} = X^G`.** The coefficient half of inflation is an isomorphism on invariants. -/
+theorem isIso_invariantsResMap_quotientToInvariantsι :
+    IsIso (TopRep.invariantsResMap (QuotientGroup.mk' N : G →* G ⧸ N)
+      (TopRep.quotientToInvariantsι X N)) :=
+  ⟨invariantsToQuotientToInvariants N X, by ext v; rfl, by ext v; rfl⟩
+
+/-- **Inflation is an isomorphism in degree zero**: `H⁰(G ⧸ N, X^N) = (X^N)^{G/N} = X^G`. This is
+the degree-zero edge of the inflation-restriction sequence. -/
+theorem isIso_infl_zero : IsIso (TauCeti.ContinuousCohomology.infl N X 0) := by
+  have := isIso_invariantsResMap_quotientToInvariantsι N X
+  exact IsIso.of_isIso_fac_right (infl_comp_zeroIso_hom N X)
+
+end Edge
+
+end ContinuousCohomology
+
+end TauCeti


### PR DESCRIPTION
This PR makes Mathlib's one computed degree of continuous cohomology usable by proving that it transports the maps and not only the groups. `ContinuousCohomology.zeroIso` identifies `H⁰_cont(G, X)` with the invariants `X^G`; for a continuous homomorphism `φ : H →ₜ* G` and a morphism `f : TopRep.res φ X ⟶ Y`, `TauCeti.ContinuousCohomology.map_comp_zeroIso_hom` shows that `ContinuousCohomology.map φ f 0` becomes `TopRep.invariantsResMap φ f` under that identification, and the three named instances of `ContinuousCohomology.map` merged in #4049 — `coeffMap`, `res` and `infl` — inherit the square as `coeffMap_comp_zeroIso_hom`, `res_comp_zeroIso_hom` and `infl_comp_zeroIso_hom`. The route is one explicit computation, `coe_zeroIso_hom_π`: a `0`-cocycle of the homogeneous complex is a `G`-invariant element of `C(G, X)` and `zeroIso` reads off its value at `1`, while compatible-pair functoriality precomposes with `φ`; the content of every statement here is `φ 1 = 1`.

Three consumers of the square are recorded with it, because later layers name these rather than the square. `zeroIsoNatIso : continuousCohomologyFunctor R G 0 ≅ TopRep.invariantsFunctor R G` is the functorial form, whose naturality is exactly the coefficient case. `degreeZeroClass X u hu` is the class of an invariant vector, with `zeroIso` recovering `u` (`coe_zeroIso_hom_degreeZeroClass`), every class arising that way (`exists_degreeZeroClass_eq`), and compatible pairs acting by `u ↦ f u` (`map_degreeZeroClass`). Finally the degree-zero edge of inflation-restriction: `isIso_infl_zero` proves inflation is an isomorphism in degree zero, since `(X^N)^{G/N}` and `X^G` are the same submodule of `X` (`isIso_invariantsResMap_quotientToInvariantsι`, with the inverse `invariantsToQuotientToInvariants` built by two `codRestrict`s), and `mono_res_zero` proves restriction is a monomorphism there, since `X^G ⊆ X^S`.

This closes the "Degree 0" milestone bullet of Layer 1, "the canonical carrier and its functoriality", of `TauCetiRoadmap/ProfiniteCohomology/README.md`, which states it as: "`map φ f 0` commutes with `continuousCohomologyZeroIso` and the induced map on invariants, which is what makes the low-degree comparisons of Layer 3 checkable at `n = 0` before any of the harder degrees exist." (The pinned Mathlib names that isomorphism `ContinuousCohomology.zeroIso`.) It also supplies `degreeZeroClass`, which the same layer names in `Suggested.lean` as "Layer 1, the class of an invariant coefficient in degree 0". Of Layer 1 there then remain the smooth-discrete dictionary (in flight in #4043) and the additivity and `R`-linearity bullet; after those, Layer 1 is complete and Layer 3's comparison isomorphisms become expressible.

No Mathlib infrastructure is vendored: the file consumes `ContinuousCohomology.zeroIso`, `cocycles₀Iso`, `d₀kerIso`, `cochainsMap`, `map`, `π_map`, `TopRep.invariantsResMap`, `TopRep.invariantsFunctor` and `ContinuousLinearMap.codRestrict` from the pin, together with `TopRep.quotientToInvariants` and `TopRep.quotientToInvariantsι` from this repository.

New file: `TauCeti/RepresentationTheory/Homological/ContCohomology/DegreeZero.lean` (285 lines).

Roadmap: ProfiniteCohomology

<!--tauceti-target:v1 {"focus":"ProfiniteCohomology","id":"map-comp-zeroiso"}-->

🤖 Prepared with Claude Code
