### PR TITLE
feat: make monotone conformal extensions injective

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/MonotoneExtension.lean
+++ b/TauCeti/Analysis/Complex/Conformal/MonotoneExtension.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.ArcConstancy
+public import TauCeti.Analysis.Complex.Conformal.ClusterSet
+public import TauCeti.Topology.JordanCurve.Monotone
+
+/-!
+# Injectivity of a monotone conformal extension
+
+This file isolates the remaining topological input in the injectivity half of Carathéodory's
+boundary correspondence. Let `F` be continuous on a closed disc, holomorphic and injective on its
+interior. If every point fibre of the boundary restriction is connected, then `F` is injective on
+the boundary and hence on the whole closed disc.
+
+The proof joins two existing parts of the conformal-mapping development. Boundary uniqueness in
+`TauCeti/Analysis/Complex/Conformal/ArcConstancy.lean` says that a conformal map is constant on no
+relative open arc of the bounding circle, so each boundary fibre has empty interior. The monotone
+Jordan-curve theorem in `TauCeti/Topology/JordanCurve/Monotone.lean` then turns connectedness of the
+fibres into injectivity. Finally,
+`TauCeti.injOn_closure_of_injOn_frontier` propagates boundary injectivity across the closed disc,
+since a boundary value of a conformal map cannot also be an interior value.
+
+For the layer **L5** Carathéodory milestone, the continuous extension is supplied by the
+length–area and plane-separation argument. The result here shows that upgrading it to the requested
+homeomorphism of closures needs exactly the monotonicity of its boundary restriction; it does not
+assume or assert that monotonicity for an arbitrary continuous extension.
+
+## Main results
+
+* `TauCeti.injOn_sphere_of_isPreconnected_boundary_fiber` — a monotone boundary restriction of a
+  conformal disc map is injective.
+* `TauCeti.injOn_sphere_iff_isPreconnected_boundary_fiber` — monotonicity of the boundary
+  restriction is exactly its injectivity.
+* `TauCeti.injOn_closedBall_of_isPreconnected_boundary_fiber` — the extension is injective on the
+  closed disc.
+* `TauCeti.bijOn_closedBall_closure_image_of_isPreconnected_boundary_fiber` — consequently it is a
+  bijection from the closed disc onto the closure of the conformal image; the existing
+  `TauCeti.closureHomeomorph` packages this bijection as a homeomorphism.
+
+## References
+
+* C. Carathéodory, *Über die gegenseitige Beziehung der Ränder bei der konformen Abbildung*,
+  Math. Ann. **73** (1913).
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Ch. 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open Metric Set Topology
+
+variable {c : ℂ} {r : ℝ} {F : ℂ → ℂ}
+
+/-- **A conformal disc map with a monotone boundary restriction is injective on the circle.**
+Suppose `F` is continuous on `closedBall c r`, holomorphic and injective on `ball c r`, and every
+point fibre of its restriction to `sphere c r` is preconnected. Then the restriction is injective.
+
+The fibre-interior hypothesis of
+`TauCeti.IsJordanCurve.injective_of_isPreconnected_fiber_of_interior_fiber_eq_empty` is exactly
+`TauCeti.interior_setOf_eq_eq_empty_of_injOn`, the boundary uniqueness theorem for a conformal map.
+-/
+theorem injOn_sphere_of_isPreconnected_boundary_fiber (hr : 0 < r)
+    (hcont : ContinuousOn F (closedBall c r)) (hdiff : DifferentiableOn ℂ F (ball c r))
+    (hinj : InjOn F (ball c r))
+    (hpre : ∀ a, IsPreconnected {z : sphere c r | F z = a}) : InjOn F (sphere c r) := by
+  have hcontinuous : Continuous (fun z : sphere c r ↦ F z) :=
+    hcont.mono sphere_subset_closedBall |>.domRestrict
+  have hrestricted : Function.Injective (fun z : sphere c r ↦ F z) :=
+    (isJordanCurve_sphere c hr).injective_of_isPreconnected_fiber_of_interior_fiber_eq_empty
+      hcontinuous hpre fun a ↦ interior_setOf_eq_eq_empty_of_injOn hr hcont hdiff hinj a
+  intro x hx y hy hxy
+  have hxy' : (fun z : sphere c r ↦ F z) ⟨x, hx⟩ = (fun z : sphere c r ↦ F z) ⟨y, hy⟩ :=
+    hxy
+  exact congrArg Subtype.val (hrestricted hxy')
+
+/-- **For a conformal extension, boundary monotonicity is equivalent to boundary injectivity.**
+Boundary uniqueness makes every point fibre interiorless, so
+`TauCeti.IsJordanCurve.injective_iff_isPreconnected_fiber_of_interior_fiber_eq_empty` applies to
+the restriction of `F` to `sphere c r`.
+
+This equivalence makes the outstanding geometric input in the Carathéodory injectivity argument
+precise: proving that the boundary fibres are preconnected is neither weaker nor stronger than the
+required boundary injectivity once the conformal and continuity hypotheses are available. -/
+theorem injOn_sphere_iff_isPreconnected_boundary_fiber (hr : 0 < r)
+    (hcont : ContinuousOn F (closedBall c r)) (hdiff : DifferentiableOn ℂ F (ball c r))
+    (hinj : InjOn F (ball c r)) :
+    InjOn F (sphere c r) ↔ ∀ a, IsPreconnected {z : sphere c r | F z = a} := by
+  have hcontinuous : Continuous (fun z : sphere c r ↦ F z) :=
+    hcont.mono sphere_subset_closedBall |>.domRestrict
+  have hiff :=
+    (isJordanCurve_sphere c hr).injective_iff_isPreconnected_fiber_of_interior_fiber_eq_empty
+      hcontinuous fun a ↦ interior_setOf_eq_eq_empty_of_injOn hr hcont hdiff hinj a
+  constructor
+  · intro hboundary
+    apply hiff.mp
+    intro x y hxy
+    exact Subtype.ext (hboundary x.2 y.2 hxy)
+  · exact injOn_sphere_of_isPreconnected_boundary_fiber hr hcont hdiff hinj
+
+/-- **A conformal disc map with a monotone boundary restriction is injective on the closed
+disc.** Boundary injectivity comes from
+`TauCeti.injOn_sphere_of_isPreconnected_boundary_fiber`; the interior and boundary images are
+disjoint by conformal properness, so `TauCeti.injOn_closure_of_injOn_frontier` gives injectivity on
+the closure. -/
+theorem injOn_closedBall_of_isPreconnected_boundary_fiber (hr : 0 < r)
+    (hcont : ContinuousOn F (closedBall c r)) (hdiff : DifferentiableOn ℂ F (ball c r))
+    (hinj : InjOn F (ball c r))
+    (hpre : ∀ a, IsPreconnected {z : sphere c r | F z = a}) : InjOn F (closedBall c r) := by
+  have hclosure : closure (ball c r) = closedBall c r := closure_ball c hr.ne'
+  have hfrontier : frontier (ball c r) = sphere c r := frontier_ball c hr.ne'
+  rw [← hclosure]
+  refine injOn_closure_of_injOn_frontier isOpen_ball hdiff hinj ?_ (fun _ _ ↦ rfl) ?_
+  · simpa only [hclosure] using hcont
+  · simpa only [hfrontier] using
+      injOn_sphere_of_isPreconnected_boundary_fiber hr hcont hdiff hinj hpre
+
+/-- **A monotone conformal extension is a bijection of the closed disc with the closure of its
+image.** This is the set-level conclusion needed to instantiate `TauCeti.closureHomeomorph`.
+Surjectivity is continuity on the compact closed disc; injectivity is
+`TauCeti.injOn_closedBall_of_isPreconnected_boundary_fiber`. -/
+theorem bijOn_closedBall_closure_image_of_isPreconnected_boundary_fiber (hr : 0 < r)
+    (hcont : ContinuousOn F (closedBall c r)) (hdiff : DifferentiableOn ℂ F (ball c r))
+    (hinj : InjOn F (ball c r))
+    (hpre : ∀ a, IsPreconnected {z : sphere c r | F z = a}) :
+    BijOn F (closedBall c r) (closure (F '' ball c r)) := by
+  have hclosure : closure (ball c r) = closedBall c r := closure_ball c hr.ne'
+  rw [← hclosure]
+  exact bijOn_closure_closure_image (isBounded_ball : Bornology.IsBounded (ball c r))
+    (by simpa only [hclosure] using hcont) (fun _ _ ↦ rfl)
+    (by simpa only [hclosure] using
+      injOn_closedBall_of_isPreconnected_boundary_fiber hr hcont hdiff hinj hpre)
+
+end TauCeti

--- a/TauCeti/Topology/JordanCurve/Monotone.lean
+++ b/TauCeti/Topology/JordanCurve/Monotone.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Topology.JordanCurve.Subcontinuum
+
+/-!
+# Monotone maps from a Jordan curve
+
+A continuous map from a Jordan curve is called *monotone* when each of its point fibres is
+connected. This file records the rigidity consequence needed by the Carathéodory boundary
+correspondence: a monotone map whose fibres have empty interior is injective.
+
+The argument is intrinsic to the curve. A point fibre is compact by continuity and compactness of
+the Jordan curve, and it is preconnected by monotonicity. If it had two points, the classification
+of subcontinua of a Jordan curve in `TauCeti/Topology/JordanCurve/Subcontinuum.lean` would force it
+to contain a relative open arc. Equivalently, the nowhere-dense criterion
+`TauCeti.IsJordanCurve.subsingleton_of_subset_closure_sdiff` makes every fibre a subsingleton.
+
+The theorem is phrased for a map whose domain is the subtype `C`. Thus its fibres and their
+interiors are taken in the topology of the curve itself, which is the natural form for boundary
+maps and avoids an ambient-space side condition.
+
+## Main result
+
+* `TauCeti.IsJordanCurve.injective_of_isPreconnected_fiber_of_interior_fiber_eq_empty` — a
+  continuous map from a Jordan curve with preconnected, interiorless point fibres is injective.
+* `TauCeti.IsJordanCurve.injective_iff_isPreconnected_fiber_of_interior_fiber_eq_empty` — under
+  the same interior condition, monotonicity is equivalent to injectivity.
+
+## References
+
+* G. T. Whyburn, *Analytic Topology*, Ch. VII.
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Ch. 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open Set Topology
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y]
+  [T2Space X] [T1Space Y] {C : Set X} {g : C → Y}
+
+/-- **A monotone map from a Jordan curve with interiorless fibres is injective.** Let `C` be a
+Jordan curve and `g : C → Y` a continuous map to a `T₁` space. If every point fibre of `g` is
+preconnected and has empty interior in `C`, then `g` is injective.
+
+Continuity makes each fibre closed, hence compact because `C` is compact. Empty interior says its
+complement is dense. The fibre is therefore a nowhere-dense subcontinuum of the Jordan curve, so
+`TauCeti.IsJordanCurve.subsingleton_of_subset_closure_sdiff` makes it a subsingleton. -/
+theorem IsJordanCurve.injective_of_isPreconnected_fiber_of_interior_fiber_eq_empty
+    (hC : IsJordanCurve C) (hg : Continuous g)
+    (hpre : ∀ y, IsPreconnected {x | g x = y})
+    (hinterior : ∀ y, interior {x | g x = y} = ∅) : Function.Injective g := by
+  let _ : CompactSpace C := isCompact_iff_compactSpace.mp hC.isCompact
+  have hJ : IsJordanCurve (univ : Set C) := by
+    obtain ⟨e⟩ := isJordanCurve_iff.mp hC
+    exact isJordanCurve_iff.mpr ⟨(Homeomorph.Set.univ C).trans e⟩
+  intro x y hxy
+  let S : Set C := {z | g z = g x}
+  have hScompact : IsCompact S := by
+    exact (isClosed_singleton.preimage hg).isCompact
+  have hSdense : S ⊆ closure ((univ : Set C) \ S) := by
+    have hdense : Dense Sᶜ := interior_eq_empty_iff_dense_compl.mp (hinterior (g x))
+    rw [← compl_eq_univ_sdiff, hdense.closure_eq]
+    exact subset_univ S
+  have hSsub : S.Subsingleton :=
+    hJ.subsingleton_of_subset_closure_sdiff (subset_univ S) hScompact (hpre (g x)) hSdense
+  exact hSsub (by simp [S]) (by simp [S, hxy])
+
+/-- **For an interiorless-fibre map from a Jordan curve, monotonicity is equivalent to
+injectivity.** The forward implication is
+`TauCeti.IsJordanCurve.injective_of_isPreconnected_fiber_of_interior_fiber_eq_empty`. Conversely,
+an injective map has empty or singleton point fibres, hence preconnected fibres; this direction
+needs neither continuity nor the Jordan-curve hypothesis. -/
+theorem IsJordanCurve.injective_iff_isPreconnected_fiber_of_interior_fiber_eq_empty
+    (hC : IsJordanCurve C) (hg : Continuous g)
+    (hinterior : ∀ y, interior {x | g x = y} = ∅) :
+    Function.Injective g ↔ ∀ y, IsPreconnected {x | g x = y} := by
+  constructor
+  · intro hinj y
+    have hsub : ({x | g x = y} : Set C).Subsingleton := by
+      intro x hx z hz
+      exact hinj (hx.trans hz.symm)
+    exact hsub.isPreconnected
+  · exact fun hpre ↦
+      hC.injective_of_isPreconnected_fiber_of_interior_fiber_eq_empty hg hpre hinterior
+
+end TauCeti


### PR DESCRIPTION
This PR makes a continuous conformal extension of a disc injective as soon as its boundary restriction is monotone: if every point fibre on the bounding circle is preconnected, then the restriction is injective, the extension is injective on the whole closed disc, and it is a bijection onto the closure of its conformal image. It also proves the intrinsic Jordan-curve theorem behind this step: a continuous map from a Jordan curve whose point fibres are preconnected and have empty relative interior is injective.

The exact target is `TauCetiRoadmap/ConformalMapping/README.md`, layer L5, “Carathéodory boundary correspondence,” specifically the Jordan-domain milestone that the Riemann map extends to a homeomorphism of closures. The continuity construction and `TauCeti.interior_setOf_eq_eq_empty_of_injOn` already reduce the second half of that milestone to boundary injectivity; this PR proves the sharp equivalence `injOn_sphere_iff_isPreconnected_boundary_fiber`, so the remaining geometric obligation is exactly to prove that the boundary fibres of the Carathéodory extension are preconnected from Jordan-curve plane separation. After this PR, L5 still needs that monotonicity statement and the plane-separation input used by the in-flight conditional continuity theorem, after which `TauCeti.closureHomeomorph` gives the requested homeomorphism.

Add `TauCeti/Topology/JordanCurve/Monotone.lean` (94 lines) and `TauCeti/Analysis/Complex/Conformal/MonotoneExtension.lean` (139 lines). The general proof reuses `TauCeti.IsJordanCurve.subsingleton_of_subset_closure_sdiff`: continuity makes each fibre compact, empty interior makes its complement dense, and a nowhere-dense subcontinuum of a Jordan curve is a singleton. The conformal specialization reuses `TauCeti.interior_setOf_eq_eq_empty_of_injOn`, `TauCeti.injOn_closure_of_injOn_frontier`, and `TauCeti.bijOn_closure_closure_image`; no Mathlib or external formalization is vendored.

The mathematical organization follows Whyburn, *Analytic Topology*, Chapter VII, and Pommerenke, *Boundary Behaviour of Conformal Maps*, Chapter 2, as credited in both module docstrings. Layer L5 is absent from the in-progress Mathlib Riemann-mapping work mathlib4#33505, so this is not a temporary duplicate of upstream infrastructure.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"monotone-boundary-map-injective"}-->

🤖 Prepared with Codex
