### PR TITLE
feat: the inertia subgroups generate the Galois group of a number field

### DIFF
--- a/TauCeti/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/TauCeti/FieldTheory/Galois/IsGaloisGroup.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.Galois.IsGaloisGroup
+
+/-!
+# The index of a subgroup of a Galois group
+
+For a tower of fields `E ⊆ F ⊆ K` in which `K` is Galois over `E` with Galois group `G` and
+Galois over `F` with Galois group a subgroup `H` of `G`, the index of `H` in `G` is the degree
+`[F : E]`. This is the counting half of the Galois correspondence, in the `IsGaloisGroup` form:
+Mathlib's `IsGaloisGroup.card_eq_finrank` gives `Nat.card H = [K : F]` and
+`Nat.card G = [K : E]`, and the tower law cancels `[K : F]`.
+
+## Main results
+
+* `IsGaloisGroup.index_eq_finrank`: `H.index = Module.finrank E F`.
+
+## Provenance
+
+Built directly on Mathlib's `IsGaloisGroup.card_eq_finrank` and `Module.finrank_mul_finrank`.
+-/
+
+public section
+
+namespace IsGaloisGroup
+
+/-- **The index of a subgroup is the degree of its fixed field.** If `K` is Galois over `E` with
+Galois group `G` and `H` is a subgroup of `G` whose fixed field is `F`, then `H.index = [F : E]`.
+This is `IsGaloisGroup.card_eq_finrank` at the two ends of the tower `E ⊆ F ⊆ K`, combined with
+the tower law for degrees. -/
+theorem index_eq_finrank {G : Type*} [Group G] (H : Subgroup G) (E F K : Type*) [Field E]
+    [Field F] [Field K] [Algebra E F] [Algebra F K] [Algebra E K] [IsScalarTower E F K]
+    [FiniteDimensional F K] [MulSemiringAction G K] [IsGaloisGroup G E K] [IsGaloisGroup H F K] :
+    H.index = Module.finrank E F := by
+  have h : H.index * Nat.card H = Nat.card G := Subgroup.index_mul_card H
+  rw [card_eq_finrank H F K, card_eq_finrank G E K, ← Module.finrank_mul_finrank E F K] at h
+  exact Nat.eq_of_mul_eq_mul_right Module.finrank_pos h
+
+end IsGaloisGroup

--- a/TauCeti/NumberTheory/NumberField/Inertia.lean
+++ b/TauCeti/NumberTheory/NumberField/Inertia.lean
@@ -48,7 +48,7 @@ fields is Kummer theory over `ℚ` and is not formalised here.
   field of `H`, then the inertia subgroup at `P` meets `H` trivially.
 * `NumberField.pow_index_eq_one_of_isUnramifiedIn`: if `G` is abelian and `K` is unramified over
   the fixed field `F` of `H` at every prime of `𝓞 F`, then the exponent of `G` divides `H.index`,
-  which is `Module.finrank ℚ F` by `NumberField.index_eq_finrank`.
+  which is `Module.finrank ℚ F` by `IsGaloisGroup.index_eq_finrank`.
 
 ## References
 
@@ -77,6 +77,22 @@ theorem card_inertia_eq_ramificationIdx (R : Type*) {S : Type*} [CommRing R] [Co
 
 end Ideal
 
+namespace IsGaloisGroup
+
+/-- **The index of a subgroup is the degree of its fixed field.** If `K` is Galois over `E` with
+Galois group `G` and `H` is a subgroup of `G` whose fixed field is `F`, then `H.index = [F : E]`.
+This is `IsGaloisGroup.card_eq_finrank` at the two ends of the tower `E ⊆ F ⊆ K`, combined with
+the tower law for degrees. -/
+theorem index_eq_finrank {G : Type*} [Group G] (H : Subgroup G) (E F K : Type*) [Field E]
+    [Field F] [Field K] [Algebra E F] [Algebra F K] [Algebra E K] [IsScalarTower E F K]
+    [FiniteDimensional F K] [MulSemiringAction G K] [IsGaloisGroup G E K] [IsGaloisGroup H F K] :
+    H.index = Module.finrank E F := by
+  have h : H.index * Nat.card H = Nat.card G := Subgroup.index_mul_card H
+  rw [card_eq_finrank H F K, card_eq_finrank G E K, ← Module.finrank_mul_finrank E F K] at h
+  exact Nat.eq_of_mul_eq_mul_right Module.finrank_pos h
+
+end IsGaloisGroup
+
 namespace NumberField
 
 /-- **A number field unramified at every finite prime is `ℚ`.** If every nonzero prime of `𝓞 F`
@@ -91,17 +107,6 @@ theorem finrank_eq_one_of_forall_ramificationIdx_eq_one {F : Type*} [Field F] [N
   have : q.LiesOver (Ideal.span {(p : ℤ)}) := hqp
   refine h q inferInstance (Ideal.ne_bot_of_liesOver_of_ne_bot (p := Ideal.span {(p : ℤ)}) ?_ q)
   simpa using hp.ne_zero
-
-/-- **The index of a subgroup is the degree of its fixed field.** If `K` is Galois over `ℚ` with
-Galois group `G` and `H` is a subgroup with fixed field `F`, then `H.index = [F : ℚ]`. -/
-theorem index_eq_finrank {G : Type*} [Group G] (H : Subgroup G) (F K : Type*) [Field F] [Field K]
-    [NumberField K] [MulSemiringAction G K] [IsGaloisGroup G ℚ K] [NumberField F] [Algebra ℚ F]
-    [Algebra F K] [IsScalarTower ℚ F K] [IsGaloisGroup H F K] :
-    H.index = Module.finrank ℚ F := by
-  have h : H.index * Nat.card H = Nat.card G := Subgroup.index_mul_card H
-  rw [IsGaloisGroup.card_eq_finrank H F K, IsGaloisGroup.card_eq_finrank G ℚ K,
-    ← Module.finrank_mul_finrank ℚ F K] at h
-  exact Nat.eq_of_mul_eq_mul_right Module.finrank_pos h
 
 section Generation
 
@@ -146,8 +151,8 @@ theorem eq_top_of_forall_inertia_le {H : Subgroup G}
     exact Nat.eq_of_mul_eq_mul_right (Ideal.ramificationIdx_pos (R := ℤ) (q := P))
       (by rw [one_mul, ← htower])
   -- Hence `F` is unramified over `ℚ`, so `F = ℚ` by Minkowski's theorem, and `H` has index `1`.
-  exact Subgroup.index_eq_one.mp
-    ((index_eq_finrank H F K).trans (finrank_eq_one_of_forall_ramificationIdx_eq_one hq))
+  exact Subgroup.index_eq_one.mp ((IsGaloisGroup.index_eq_finrank H ℚ F K).trans
+    (finrank_eq_one_of_forall_ramificationIdx_eq_one hq))
 
 /-- **The inertia subgroups generate the Galois group.** For a number field `K` Galois over `ℚ`
 with Galois group `G`, the supremum of the inertia subgroups of the maximal ideals of `𝓞 K`
@@ -195,7 +200,7 @@ open scoped IsMulCommutative in
 /-- **An abelian extension of `ℚ` unramified over a subfield has exponent dividing its degree.**
 Let `K` be a number field, Galois over `ℚ` with abelian Galois group `G`, and let `H` be a
 subgroup whose fixed field `F` has every prime unramified in `𝓞 K`. Then `g ^ H.index = 1` for
-every `g : G`, and `H.index` is `Module.finrank ℚ F` by `NumberField.index_eq_finrank`.
+every `g : G`, and `H.index` is `Module.finrank ℚ F` by `IsGaloisGroup.index_eq_finrank`.
 
 Indeed each inertia subgroup is killed by `H.index`
 (`NumberField.pow_index_eq_one_of_ramificationIdx_eq_one`), and in an abelian group the elements

--- a/TauCeti/NumberTheory/NumberField/Inertia.lean
+++ b/TauCeti/NumberTheory/NumberField/Inertia.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.NumberTheory.NumberField.ExistsRamified
 public import Mathlib.RingTheory.Spectrum.Maximal.Defs
+public import TauCeti.FieldTheory.Galois.IsGaloisGroup
+public import TauCeti.NumberTheory.RamificationInertia.Galois
 
 /-!
 # The inertia subgroups generate the Galois group of a number field
@@ -14,7 +16,8 @@ public import Mathlib.RingTheory.Spectrum.Maximal.Defs
 Let `K` be a number field that is Galois over `ℚ`, with Galois group `G` acting on the ring of
 integers `𝓞 K`. Each maximal ideal `P` of `𝓞 K` carries an inertia subgroup `P.inertia G`, the
 elements of `G` acting trivially on `𝓞 K ⧸ P`, and its cardinality is the ramification index of
-`P` over `ℤ` (`Ideal.card_inertia_eq_ramificationIdx`). This file proves that these subgroups
+`P` over `ℤ` (`Ideal.card_inertia_eq_ramificationIdx`, in
+`TauCeti/NumberTheory/RamificationInertia/Galois.lean`). This file proves that these subgroups
 generate all of `G`:
 
 `⨆ P : MaximalSpectrum (𝓞 K), P.asIdeal.inertia G = ⊤`.
@@ -48,7 +51,8 @@ fields is Kummer theory over `ℚ` and is not formalised here.
   field of `H`, then the inertia subgroup at `P` meets `H` trivially.
 * `NumberField.pow_index_eq_one_of_isUnramifiedIn`: if `G` is abelian and `K` is unramified over
   the fixed field `F` of `H` at every prime of `𝓞 F`, then the exponent of `G` divides `H.index`,
-  which is `Module.finrank ℚ F` by `IsGaloisGroup.index_eq_finrank`.
+  which is `Module.finrank ℚ F` by `IsGaloisGroup.index_eq_finrank` (in
+  `TauCeti/FieldTheory/Galois/IsGaloisGroup.lean`).
 
 ## References
 
@@ -61,37 +65,6 @@ F. Lemmermeyer, *Reciprocity Laws: from Euler to Eisenstein*, §2.2.
 public section
 
 open scoped NumberField
-
-namespace Ideal
-
-/-- The cardinality of the inertia subgroup of `P` is the ramification index of `P` over `R`.
-This is `Ideal.card_inertia_eq_ramificationIdxIn` stated with the ramification index of `P`
-itself rather than with `Ideal.ramificationIdxIn` of the ideal below it. -/
-theorem card_inertia_eq_ramificationIdx (R : Type*) {S : Type*} [CommRing R] [CommRing S]
-    [Algebra R S] [IsDomain R] [IsDomain S] [Module.Finite R S] [Module.Flat R S] (G : Type*)
-    [Group G] [Finite G] [MulSemiringAction G S] [IsGaloisGroup G R S] (P : Ideal S) [P.IsPrime]
-    [PerfectField (P.under R).ResidueField] :
-    Nat.card (P.inertia G) = P.ramificationIdx R :=
-  (card_inertia_eq_ramificationIdxIn (G := G) (P.under R) P).trans
-    (ramificationIdxIn_eq_ramificationIdx (P.under R) P G)
-
-end Ideal
-
-namespace IsGaloisGroup
-
-/-- **The index of a subgroup is the degree of its fixed field.** If `K` is Galois over `E` with
-Galois group `G` and `H` is a subgroup of `G` whose fixed field is `F`, then `H.index = [F : E]`.
-This is `IsGaloisGroup.card_eq_finrank` at the two ends of the tower `E ⊆ F ⊆ K`, combined with
-the tower law for degrees. -/
-theorem index_eq_finrank {G : Type*} [Group G] (H : Subgroup G) (E F K : Type*) [Field E]
-    [Field F] [Field K] [Algebra E F] [Algebra F K] [Algebra E K] [IsScalarTower E F K]
-    [FiniteDimensional F K] [MulSemiringAction G K] [IsGaloisGroup G E K] [IsGaloisGroup H F K] :
-    H.index = Module.finrank E F := by
-  have h : H.index * Nat.card H = Nat.card G := Subgroup.index_mul_card H
-  rw [card_eq_finrank H F K, card_eq_finrank G E K, ← Module.finrank_mul_finrank E F K] at h
-  exact Nat.eq_of_mul_eq_mul_right Module.finrank_pos h
-
-end IsGaloisGroup
 
 namespace NumberField
 

--- a/TauCeti/NumberTheory/NumberField/Inertia.lean
+++ b/TauCeti/NumberTheory/NumberField/Inertia.lean
@@ -130,7 +130,7 @@ theorem eq_top_of_forall_inertia_le {H : Subgroup G}
 /-- **The inertia subgroups generate the Galois group.** For a number field `K` Galois over `ℚ`
 with Galois group `G`, the supremum of the inertia subgroups of the maximal ideals of `𝓞 K`
 is `⊤`. -/
-theorem iSup_inertia_eq_top : ⨆ P : MaximalSpectrum (𝓞 K), P.asIdeal.inertia G = ⊤ :=
+@[simp] theorem iSup_inertia_eq_top : ⨆ P : MaximalSpectrum (𝓞 K), P.asIdeal.inertia G = ⊤ :=
   eq_top_of_forall_inertia_le fun P hP =>
     le_iSup (fun Q : MaximalSpectrum (𝓞 K) => Q.asIdeal.inertia G) ⟨P, hP⟩
 

--- a/TauCeti/NumberTheory/NumberField/Inertia.lean
+++ b/TauCeti/NumberTheory/NumberField/Inertia.lean
@@ -5,10 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.FieldTheory.Galois.IsGaloisGroup
-public import Mathlib.GroupTheory.IndexNormal
 public import Mathlib.NumberTheory.NumberField.ExistsRamified
-public import Mathlib.NumberTheory.RamificationInertia.Galois
 public import Mathlib.RingTheory.Spectrum.Maximal.Defs
 
 /-!
@@ -48,7 +45,7 @@ over a quadratic subfield is multiquadratic.
 * `NumberField.iSup_inertia_eq_top`, `NumberField.closure_iUnion_inertia_eq_top`: the packaged
   generation statements.
 * `NumberField.disjoint_inertia_of_isUnramifiedIn`: if `K` is unramified over the fixed field of
-  `H` at all finite places, then every inertia subgroup meets `H` trivially.
+  `H` at the prime below `P`, then the inertia subgroup at `P` meets `H` trivially.
 * `NumberField.sq_eq_one_of_index_eq_two`, `NumberField.sq_eq_one_of_finrank_eq_two`: an abelian
   extension of `ℚ` unramified at all finite places over a quadratic subfield has Galois group of
   exponent dividing `2`.
@@ -105,7 +102,8 @@ theorem eq_top_of_forall_inertia_le {H : Subgroup G}
       rw [Ideal.card_inertia_eq_ramificationIdxIn (G := H) (P.under (𝓞 F)) P,
         Ideal.ramificationIdxIn_eq_ramificationIdx (P.under (𝓞 F)) P H]
     have hcard : Nat.card (P.inertia H) = Nat.card (P.inertia G) := by
-      have hsub : P.inertia H = (P.inertia G).subgroupOf H := rfl
+      have hsub : P.inertia H = (P.inertia G).subgroupOf H :=
+        (AddSubgroup.subgroupOf_inertia (I := P.toAddSubgroup) H).symm
       rw [hsub]
       exact Nat.card_congr (Subgroup.subgroupOfEquivOfLe (h P hPmax)).toEquiv
     have hEq : P.ramificationIdx (𝓞 F) = P.ramificationIdx ℤ := by rw [← hH, hcard, hG]
@@ -149,33 +147,32 @@ variable {K : Type*} [Field K] [NumberField K] {G : Type*} [Group G] [Finite G]
 
 omit [IsGaloisGroup G ℚ K] [Algebra ℚ F] [IsScalarTower ℚ F K] in
 /-- **An unramified subextension meets every inertia subgroup trivially.** Let `H` be a subgroup
-of `G` whose fixed field is `F`. If every prime of `𝓞 F` is unramified in `𝓞 K`, then the inertia
-subgroup of a prime `P` of `𝓞 K` is disjoint from `H`, since its intersection with `H` is the
-inertia subgroup of `P` over `𝓞 F`, of order `e(P / 𝓞 F) = 1`. -/
+of `G` whose fixed field is `F`. If the prime below `P` is unramified in `𝓞 K`, then the inertia
+subgroup of `P` is disjoint from `H`, since its intersection with `H` is the inertia subgroup of
+`P` over `𝓞 F`, of order `e(P / 𝓞 F) = 1`. -/
 theorem disjoint_inertia_of_isUnramifiedIn (H : Subgroup G) [IsGaloisGroup H F K]
-    (hunr : ∀ q : Ideal (𝓞 F), q.IsPrime → Algebra.IsUnramifiedIn (𝓞 K) q)
-    (P : Ideal (𝓞 K)) (hP : P.IsPrime) : Disjoint (P.inertia G) H := by
+    (P : Ideal (𝓞 K)) (hP : P.IsPrime)
+    (hunr : Algebra.IsUnramifiedIn (𝓞 K) (P.under (𝓞 F))) : Disjoint (P.inertia G) H := by
   have : P.IsPrime := hP
   have : IsGaloisGroup H (𝓞 F) (𝓞 K) := IsGaloisGroup.of_isFractionRing H (𝓞 F) (𝓞 K) F K
   rw [← Subgroup.subgroupOf_eq_bot]
   refine Subgroup.eq_bot_of_card_eq _ ?_
-  have hsub : (P.inertia G).subgroupOf H = P.inertia H := rfl
-  rw [hsub, Ideal.card_inertia_eq_ramificationIdxIn (G := H) (P.under (𝓞 F)) P,
+  rw [AddSubgroup.subgroupOf_inertia,
+    Ideal.card_inertia_eq_ramificationIdxIn (G := H) (P.under (𝓞 F)) P,
     Ideal.ramificationIdxIn_eq_ramificationIdx (P.under (𝓞 F)) P H]
-  exact (hunr (P.under (𝓞 F)) inferInstance).ramificationIdx_eq_one inferInstance
+  exact hunr.ramificationIdx_eq_one inferInstance
 
 omit [IsGaloisGroup G ℚ K] [Algebra ℚ F] [IsScalarTower ℚ F K] in
-/-- **Inertia over a quadratic subfield is killed by squaring.** If the fixed field `F` of an
-index-`2` subgroup `H` of `G` has every prime unramified in `𝓞 K`, then any element of an inertia
-subgroup of `G` squares to `1`: its square lies in `H` because `H` has index `2`, and it lies in
-the inertia subgroup, which meets `H` trivially. -/
+/-- **Inertia over a quadratic subfield is killed by squaring.** If the prime below `P` in the
+fixed field `F` of an index-`2` subgroup `H` of `G` is unramified in `𝓞 K`, then any element of
+the inertia subgroup at `P` squares to `1`: its square lies in `H` because `H` has index `2`, and
+it lies in the inertia subgroup, which meets `H` trivially. -/
 theorem sq_eq_one_of_mem_inertia {H : Subgroup G} [IsGaloisGroup H F K] (hindex : H.index = 2)
-    (hunr : ∀ q : Ideal (𝓞 F), q.IsPrime → Algebra.IsUnramifiedIn (𝓞 K) q)
-    {P : Ideal (𝓞 K)} (hP : P.IsPrime) {g : G} (hg : g ∈ P.inertia G) : g ^ 2 = 1 := by
-  have hmem : g ^ 2 ∈ H := by
-    rw [sq]
-    exact (Subgroup.mul_mem_iff_of_index_two hindex).mpr Iff.rfl
-  exact Subgroup.disjoint_def.mp (disjoint_inertia_of_isUnramifiedIn H hunr P hP)
+    {P : Ideal (𝓞 K)} (hP : P.IsPrime)
+    (hunr : Algebra.IsUnramifiedIn (𝓞 K) (P.under (𝓞 F)))
+    {g : G} (hg : g ∈ P.inertia G) : g ^ 2 = 1 := by
+  have hmem : g ^ 2 ∈ H := Subgroup.sq_mem_of_index_two hindex g
+  exact Subgroup.disjoint_def.mp (disjoint_inertia_of_isUnramifiedIn H P hP hunr)
     (pow_mem hg 2) hmem
 
 omit [Algebra ℚ F] [IsScalarTower ℚ F K] in
@@ -195,7 +192,9 @@ theorem sq_eq_one_of_index_eq_two [IsMulCommutative G] (H : Subgroup G) [IsGaloi
     g ^ 2 = 1 := by
   have h : (powMonoidHom 2 : G →* G).ker = ⊤ :=
     eq_top_of_forall_inertia_le fun P hP x hx => by
-      simpa [MonoidHom.mem_ker] using sq_eq_one_of_mem_inertia hindex hunr hP.isPrime hx
+      simpa [MonoidHom.mem_ker] using
+        sq_eq_one_of_mem_inertia (F := F) hindex hP.isPrime
+          (hunr (P.under (𝓞 F)) inferInstance) hx
   simpa [MonoidHom.mem_ker] using (h ▸ Subgroup.mem_top g : g ∈ (powMonoidHom 2 : G →* G).ker)
 
 open scoped IsMulCommutative in

--- a/TauCeti/NumberTheory/NumberField/Inertia.lean
+++ b/TauCeti/NumberTheory/NumberField/Inertia.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.Galois.IsGaloisGroup
+public import Mathlib.GroupTheory.IndexNormal
+public import Mathlib.NumberTheory.NumberField.ExistsRamified
+public import Mathlib.NumberTheory.RamificationInertia.Galois
+public import Mathlib.RingTheory.Spectrum.Maximal.Defs
+
+/-!
+# The inertia subgroups generate the Galois group of a number field
+
+Let `K` be a number field that is Galois over `ℚ`, with Galois group `G` acting on the ring of
+integers `𝓞 K`. Each maximal ideal `P` of `𝓞 K` carries an inertia subgroup `P.inertia G`, the
+elements of `G` acting trivially on `𝓞 K ⧸ P`, and its cardinality is the ramification index of
+`P` over `ℤ` (`Ideal.card_inertia_eq_ramificationIdxIn`). This file proves that these subgroups
+generate all of `G`:
+
+`⨆ P : MaximalSpectrum (𝓞 K), P.asIdeal.inertia G = ⊤`.
+
+The proof is Minkowski's theorem in disguise. If `H` contains every inertia subgroup, then over
+the fixed field `F` of `H` every prime `P` of `𝓞 K` has the same inertia group as it does over
+`ℚ` — because `P.inertia H` is `P.inertia G` intersected with `H`, which is all of it — so the
+absolute ramification indices at the top and at the intermediate level agree, and
+multiplicativity of ramification in the tower `ℤ ⊆ 𝓞 F ⊆ 𝓞 K` forces `F` to be unramified over
+`ℚ` at every finite prime. Minkowski's bound on the discriminant
+(`NumberField.exists_not_isUnramifiedIn`) leaves `F = ℚ`, that is `H = ⊤`.
+
+This is the missing input flagged as a TODO of `Mathlib/RingTheory/Polynomial/Morse.lean`, whose
+`Polynomial.Splits.surjective_toPermHom_of_iSup_inertia_eq_top` takes generation by inertia
+subgroups as a hypothesis.
+
+The second half of the file draws the consequence that genus theory needs. If `M` is abelian over
+`ℚ` and unramified at all finite places over a quadratic subfield `F`, then the inertia subgroup
+of a prime of `𝓞 M` meets `Gal(M/F)` trivially, so it injects into the two-element quotient
+`Gal(M/ℚ) ⧸ Gal(M/F)` and every element of it squares to `1`. Generation by inertia then makes
+the whole of `Gal(M/ℚ)` an elementary abelian `2`-group: an abelian extension of `ℚ` unramified
+over a quadratic subfield is multiquadratic.
+
+## Main results
+
+* `NumberField.eq_top_of_forall_inertia_le`: a subgroup of `G` containing every inertia subgroup
+  is `⊤`.
+* `NumberField.iSup_inertia_eq_top`, `NumberField.closure_iUnion_inertia_eq_top`: the packaged
+  generation statements.
+* `NumberField.disjoint_inertia_of_isUnramifiedIn`: if `K` is unramified over the fixed field of
+  `H` at all finite places, then every inertia subgroup meets `H` trivially.
+* `NumberField.sq_eq_one_of_index_eq_two`, `NumberField.sq_eq_one_of_finrank_eq_two`: an abelian
+  extension of `ℚ` unramified at all finite places over a quadratic subfield has Galois group of
+  exponent dividing `2`.
+
+## References
+
+Generation of a Galois group by inertia subgroups is Section 4.4 of [J. P. Serre, *Topics in
+Galois Theory*][serre-galois]; the genus-theoretic consequence is the standard proof that the
+genus field is multiquadratic, as in D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and
+F. Lemmermeyer, *Reciprocity Laws: from Euler to Eisenstein*, §2.2.
+-/
+
+public section
+
+open scoped NumberField
+
+namespace NumberField
+
+section Generation
+
+variable {K : Type*} [Field K] [NumberField K] (G : Type*) [Group G] [Finite G]
+  [MulSemiringAction G K] [IsGaloisGroup G ℚ K]
+
+variable {G} in
+/-- **A subgroup containing every inertia subgroup is everything.** Let `K` be a number field
+Galois over `ℚ` with Galois group `G`. If a subgroup `H` of `G` contains the inertia subgroup of
+every maximal ideal of `𝓞 K`, then `H = ⊤`.
+
+The fixed field `F` of `H` inherits no ramification: for a prime `P` of `𝓞 K` the inertia
+subgroups of `P` in `H` and in `G` coincide, so the ramification indices `e(P / ℤ)` and
+`e(P / 𝓞 F)` agree and the intermediate index `e(𝔮 / ℤ)` is `1`. By Minkowski's theorem a number
+field unramified over `ℚ` is `ℚ`, so `F = ℚ`. -/
+theorem eq_top_of_forall_inertia_le {H : Subgroup G}
+    (h : ∀ P : Ideal (𝓞 K), P.IsMaximal → P.inertia G ≤ H) : H = ⊤ := by
+  classical
+  set F : IntermediateField ℚ K := FixedPoints.intermediateField H with hF
+  have : IsGaloisGroup H (𝓞 F) (𝓞 K) :=
+    IsGaloisGroup.of_isFractionRing H (𝓞 F) (𝓞 K) F K
+  -- Every nonzero prime of `𝓞 F` is unramified over `ℤ`.
+  have hq : ∀ q : Ideal (𝓞 F), q.IsPrime → q ≠ ⊥ → q.ramificationIdx ℤ = 1 := by
+    intro q hqp hq0
+    have : q.IsPrime := hqp
+    obtain ⟨P, hPp, hPq⟩ := (inferInstance : Nonempty (Ideal.primesOver q (𝓞 K))).some
+    have : P.IsPrime := hPp
+    have : P.LiesOver q := hPq
+    have hPmax : P.IsMaximal := hPp.isMaximal (Ideal.ne_bot_of_liesOver_of_ne_bot hq0 P)
+    have htower : P.ramificationIdx ℤ = q.ramificationIdx ℤ * P.ramificationIdx (𝓞 F) :=
+      Ideal.ramificationIdx_tower (R := ℤ) q P
+    -- The two inertia subgroups of `P`, over `ℚ` and over `F`, have the same cardinality.
+    have hG : Nat.card (P.inertia G) = P.ramificationIdx ℤ := by
+      rw [Ideal.card_inertia_eq_ramificationIdxIn (G := G) (P.under ℤ) P,
+        Ideal.ramificationIdxIn_eq_ramificationIdx (P.under ℤ) P G]
+    have hH : Nat.card (P.inertia H) = P.ramificationIdx (𝓞 F) := by
+      rw [Ideal.card_inertia_eq_ramificationIdxIn (G := H) (P.under (𝓞 F)) P,
+        Ideal.ramificationIdxIn_eq_ramificationIdx (P.under (𝓞 F)) P H]
+    have hcard : Nat.card (P.inertia H) = Nat.card (P.inertia G) := by
+      have hsub : P.inertia H = (P.inertia G).subgroupOf H := rfl
+      rw [hsub]
+      exact Nat.card_congr (Subgroup.subgroupOfEquivOfLe (h P hPmax)).toEquiv
+    have hEq : P.ramificationIdx (𝓞 F) = P.ramificationIdx ℤ := by rw [← hH, hcard, hG]
+    rw [hEq] at htower
+    exact Nat.eq_of_mul_eq_mul_right (Ideal.ramificationIdx_pos (R := ℤ) (q := P))
+      (by rw [one_mul, ← htower])
+  -- Hence `F` is unramified over `ℚ`, so `F = ℚ` by Minkowski's theorem.
+  have hrank : Module.finrank ℚ F = 1 := by
+    by_contra hne
+    obtain ⟨p, hp, hnu⟩ := NumberField.exists_not_isUnramifiedIn (K := F) (𝒪 := 𝓞 F) hne
+    refine hnu (Algebra.isUnramifiedIn_iff_forall_ramificationIdx_eq_one.mpr fun q _ hqp => ?_)
+    have : q.LiesOver (Ideal.span {(p : ℤ)}) := hqp
+    refine hq q inferInstance
+      (Ideal.ne_bot_of_liesOver_of_ne_bot (p := Ideal.span {(p : ℤ)}) ?_ q)
+    simpa using hp.ne_zero
+  refine Subgroup.eq_top_of_card_eq H ?_
+  rw [IsGaloisGroup.card_eq_finrank H F K, IsGaloisGroup.card_eq_finrank G ℚ K,
+    ← Module.finrank_mul_finrank ℚ F K, hrank, one_mul]
+
+/-- **The inertia subgroups generate the Galois group.** For a number field `K` Galois over `ℚ`
+with Galois group `G`, the supremum of the inertia subgroups of the maximal ideals of `𝓞 K`
+is `⊤`. -/
+theorem iSup_inertia_eq_top : ⨆ P : MaximalSpectrum (𝓞 K), P.asIdeal.inertia G = ⊤ :=
+  eq_top_of_forall_inertia_le fun P hP =>
+    le_iSup (fun Q : MaximalSpectrum (𝓞 K) => Q.asIdeal.inertia G) ⟨P, hP⟩
+
+/-- The union of the inertia subgroups of the maximal ideals of `𝓞 K` generates `G`. This is the
+`Subgroup.closure` form of `NumberField.iSup_inertia_eq_top`. -/
+theorem closure_iUnion_inertia_eq_top :
+    Subgroup.closure (⋃ P : MaximalSpectrum (𝓞 K), (P.asIdeal.inertia G : Set G)) = ⊤ := by
+  rw [Subgroup.closure_iUnion]
+  simpa using iSup_inertia_eq_top G
+
+end Generation
+
+section Unramified
+
+variable {K : Type*} [Field K] [NumberField K] {G : Type*} [Group G] [Finite G]
+  [MulSemiringAction G K] [IsGaloisGroup G ℚ K]
+  {F : Type*} [Field F] [NumberField F] [Algebra ℚ F] [Algebra F K] [IsScalarTower ℚ F K]
+
+omit [IsGaloisGroup G ℚ K] [Algebra ℚ F] [IsScalarTower ℚ F K] in
+/-- **An unramified subextension meets every inertia subgroup trivially.** Let `H` be a subgroup
+of `G` whose fixed field is `F`. If every prime of `𝓞 F` is unramified in `𝓞 K`, then the inertia
+subgroup of a prime `P` of `𝓞 K` is disjoint from `H`, since its intersection with `H` is the
+inertia subgroup of `P` over `𝓞 F`, of order `e(P / 𝓞 F) = 1`. -/
+theorem disjoint_inertia_of_isUnramifiedIn (H : Subgroup G) [IsGaloisGroup H F K]
+    (hunr : ∀ q : Ideal (𝓞 F), q.IsPrime → Algebra.IsUnramifiedIn (𝓞 K) q)
+    (P : Ideal (𝓞 K)) (hP : P.IsPrime) : Disjoint (P.inertia G) H := by
+  have : P.IsPrime := hP
+  have : IsGaloisGroup H (𝓞 F) (𝓞 K) := IsGaloisGroup.of_isFractionRing H (𝓞 F) (𝓞 K) F K
+  rw [← Subgroup.subgroupOf_eq_bot]
+  refine Subgroup.eq_bot_of_card_eq _ ?_
+  have hsub : (P.inertia G).subgroupOf H = P.inertia H := rfl
+  rw [hsub, Ideal.card_inertia_eq_ramificationIdxIn (G := H) (P.under (𝓞 F)) P,
+    Ideal.ramificationIdxIn_eq_ramificationIdx (P.under (𝓞 F)) P H]
+  exact (hunr (P.under (𝓞 F)) inferInstance).ramificationIdx_eq_one inferInstance
+
+omit [IsGaloisGroup G ℚ K] [Algebra ℚ F] [IsScalarTower ℚ F K] in
+/-- **Inertia over a quadratic subfield is killed by squaring.** If the fixed field `F` of an
+index-`2` subgroup `H` of `G` has every prime unramified in `𝓞 K`, then any element of an inertia
+subgroup of `G` squares to `1`: its square lies in `H` because `H` has index `2`, and it lies in
+the inertia subgroup, which meets `H` trivially. -/
+theorem sq_eq_one_of_mem_inertia {H : Subgroup G} [IsGaloisGroup H F K] (hindex : H.index = 2)
+    (hunr : ∀ q : Ideal (𝓞 F), q.IsPrime → Algebra.IsUnramifiedIn (𝓞 K) q)
+    {P : Ideal (𝓞 K)} (hP : P.IsPrime) {g : G} (hg : g ∈ P.inertia G) : g ^ 2 = 1 := by
+  have hmem : g ^ 2 ∈ H := by
+    rw [sq]
+    exact (Subgroup.mul_mem_iff_of_index_two hindex).mpr Iff.rfl
+  exact Subgroup.disjoint_def.mp (disjoint_inertia_of_isUnramifiedIn H hunr P hP)
+    (pow_mem hg 2) hmem
+
+omit [Algebra ℚ F] [IsScalarTower ℚ F K] in
+open scoped IsMulCommutative in
+/-- **An abelian extension of `ℚ` unramified over a quadratic subfield is multiquadratic.** Let
+`K` be a number field, Galois over `ℚ` with abelian Galois group `G`, and let `H` be a subgroup of
+index `2` whose fixed field `F` has every prime unramified in `𝓞 K`. Then every element of `G`
+squares to `1`.
+
+Indeed each inertia subgroup consists of elements squaring to `1`
+(`NumberField.sq_eq_one_of_mem_inertia`), and in an abelian group those elements form a subgroup;
+since the inertia subgroups generate `G` (`NumberField.eq_top_of_forall_inertia_le`), that
+subgroup is all of `G`. -/
+theorem sq_eq_one_of_index_eq_two [IsMulCommutative G] (H : Subgroup G) [IsGaloisGroup H F K]
+    (hindex : H.index = 2)
+    (hunr : ∀ q : Ideal (𝓞 F), q.IsPrime → Algebra.IsUnramifiedIn (𝓞 K) q) (g : G) :
+    g ^ 2 = 1 := by
+  have h : (powMonoidHom 2 : G →* G).ker = ⊤ :=
+    eq_top_of_forall_inertia_le fun P hP x hx => by
+      simpa [MonoidHom.mem_ker] using sq_eq_one_of_mem_inertia hindex hunr hP.isPrime hx
+  simpa [MonoidHom.mem_ker] using (h ▸ Subgroup.mem_top g : g ∈ (powMonoidHom 2 : G →* G).ker)
+
+open scoped IsMulCommutative in
+/-- **The degree form of `NumberField.sq_eq_one_of_index_eq_two`.** If `K` is Galois over `ℚ` with
+abelian Galois group `G`, if `F` is the fixed field of `H` and is quadratic over `ℚ`, and if every
+prime of `𝓞 F` is unramified in `𝓞 K`, then every element of `G` squares to `1`. The index of `H`
+is the degree of its fixed field, here `2`. -/
+theorem sq_eq_one_of_finrank_eq_two [IsMulCommutative G] (H : Subgroup G) [IsGaloisGroup H F K]
+    (hF : Module.finrank ℚ F = 2)
+    (hunr : ∀ q : Ideal (𝓞 F), q.IsPrime → Algebra.IsUnramifiedIn (𝓞 K) q) (g : G) :
+    g ^ 2 = 1 := by
+  refine sq_eq_one_of_index_eq_two H ?_ hunr g
+  have h : H.index * Nat.card H = Nat.card G := Subgroup.index_mul_card H
+  rw [IsGaloisGroup.card_eq_finrank H F K, IsGaloisGroup.card_eq_finrank G ℚ K,
+    ← Module.finrank_mul_finrank ℚ F K, hF] at h
+  exact Nat.eq_of_mul_eq_mul_right Module.finrank_pos h
+
+end Unramified
+
+end NumberField

--- a/TauCeti/NumberTheory/NumberField/Inertia.lean
+++ b/TauCeti/NumberTheory/NumberField/Inertia.lean
@@ -14,7 +14,7 @@ public import Mathlib.RingTheory.Spectrum.Maximal.Defs
 Let `K` be a number field that is Galois over `ℚ`, with Galois group `G` acting on the ring of
 integers `𝓞 K`. Each maximal ideal `P` of `𝓞 K` carries an inertia subgroup `P.inertia G`, the
 elements of `G` acting trivially on `𝓞 K ⧸ P`, and its cardinality is the ramification index of
-`P` over `ℤ` (`Ideal.card_inertia_eq_ramificationIdxIn`). This file proves that these subgroups
+`P` over `ℤ` (`Ideal.card_inertia_eq_ramificationIdx`). This file proves that these subgroups
 generate all of `G`:
 
 `⨆ P : MaximalSpectrum (𝓞 K), P.asIdeal.inertia G = ⊤`.
@@ -32,23 +32,23 @@ This is the missing input flagged as a TODO of `Mathlib/RingTheory/Polynomial/Mo
 subgroups as a hypothesis.
 
 The second half of the file draws the consequence that genus theory needs. If `M` is abelian over
-`ℚ` and unramified at all finite places over a quadratic subfield `F`, then the inertia subgroup
-of a prime of `𝓞 M` meets `Gal(M/F)` trivially, so it injects into the two-element quotient
-`Gal(M/ℚ) ⧸ Gal(M/F)` and every element of it squares to `1`. Generation by inertia then makes
-the whole of `Gal(M/ℚ)` an elementary abelian `2`-group: an abelian extension of `ℚ` unramified
-over a quadratic subfield is multiquadratic.
+`ℚ` and unramified at all finite places over the fixed field `F` of a subgroup `H`, then the
+inertia subgroup of a prime of `𝓞 M` meets `Gal(M/F)` trivially, so every element of it is killed
+by the index of `H`. Generation by inertia promotes this to all of `Gal(M/ℚ)`, whose exponent
+therefore divides `H.index = [F : ℚ]`. Taking `F` quadratic is the classical first step towards
+the genus field being multiquadratic; the passage from exponent `2` to a compositum of quadratic
+fields is Kummer theory over `ℚ` and is not formalised here.
 
 ## Main results
 
 * `NumberField.eq_top_of_forall_inertia_le`: a subgroup of `G` containing every inertia subgroup
   is `⊤`.
-* `NumberField.iSup_inertia_eq_top`, `NumberField.closure_iUnion_inertia_eq_top`: the packaged
-  generation statements.
-* `NumberField.disjoint_inertia_of_isUnramifiedIn`: if `K` is unramified over the fixed field of
-  `H` at the prime below `P`, then the inertia subgroup at `P` meets `H` trivially.
-* `NumberField.sq_eq_one_of_index_eq_two`, `NumberField.sq_eq_one_of_finrank_eq_two`: an abelian
-  extension of `ℚ` unramified at all finite places over a quadratic subfield has Galois group of
-  exponent dividing `2`.
+* `NumberField.iSup_inertia_eq_top`: the packaged generation statement.
+* `NumberField.disjoint_inertia_of_ramificationIdx_eq_one`: if `P` is unramified over the fixed
+  field of `H`, then the inertia subgroup at `P` meets `H` trivially.
+* `NumberField.pow_index_eq_one_of_isUnramifiedIn`: if `G` is abelian and `K` is unramified over
+  the fixed field `F` of `H` at every prime of `𝓞 F`, then the exponent of `G` divides `H.index`,
+  which is `Module.finrank ℚ F` by `NumberField.index_eq_finrank`.
 
 ## References
 
@@ -62,7 +62,46 @@ public section
 
 open scoped NumberField
 
+namespace Ideal
+
+/-- The cardinality of the inertia subgroup of `P` is the ramification index of `P` over `R`.
+This is `Ideal.card_inertia_eq_ramificationIdxIn` stated with the ramification index of `P`
+itself rather than with `Ideal.ramificationIdxIn` of the ideal below it. -/
+theorem card_inertia_eq_ramificationIdx (R : Type*) {S : Type*} [CommRing R] [CommRing S]
+    [Algebra R S] [IsDomain R] [IsDomain S] [Module.Finite R S] [Module.Flat R S] (G : Type*)
+    [Group G] [Finite G] [MulSemiringAction G S] [IsGaloisGroup G R S] (P : Ideal S) [P.IsPrime]
+    [PerfectField (P.under R).ResidueField] :
+    Nat.card (P.inertia G) = P.ramificationIdx R :=
+  (card_inertia_eq_ramificationIdxIn (G := G) (P.under R) P).trans
+    (ramificationIdxIn_eq_ramificationIdx (P.under R) P G)
+
+end Ideal
+
 namespace NumberField
+
+/-- **A number field unramified at every finite prime is `ℚ`.** If every nonzero prime of `𝓞 F`
+is unramified over `ℤ`, then `Module.finrank ℚ F = 1`. This is Minkowski's bound on the
+discriminant, in the form `NumberField.exists_not_isUnramifiedIn`. -/
+theorem finrank_eq_one_of_forall_ramificationIdx_eq_one {F : Type*} [Field F] [NumberField F]
+    (h : ∀ q : Ideal (𝓞 F), q.IsPrime → q ≠ ⊥ → q.ramificationIdx ℤ = 1) :
+    Module.finrank ℚ F = 1 := by
+  by_contra hne
+  obtain ⟨p, hp, hnu⟩ := NumberField.exists_not_isUnramifiedIn (K := F) (𝒪 := 𝓞 F) hne
+  refine hnu (Algebra.isUnramifiedIn_iff_forall_ramificationIdx_eq_one.mpr fun q _ hqp => ?_)
+  have : q.LiesOver (Ideal.span {(p : ℤ)}) := hqp
+  refine h q inferInstance (Ideal.ne_bot_of_liesOver_of_ne_bot (p := Ideal.span {(p : ℤ)}) ?_ q)
+  simpa using hp.ne_zero
+
+/-- **The index of a subgroup is the degree of its fixed field.** If `K` is Galois over `ℚ` with
+Galois group `G` and `H` is a subgroup with fixed field `F`, then `H.index = [F : ℚ]`. -/
+theorem index_eq_finrank {G : Type*} [Group G] (H : Subgroup G) (F K : Type*) [Field F] [Field K]
+    [NumberField K] [MulSemiringAction G K] [IsGaloisGroup G ℚ K] [NumberField F] [Algebra ℚ F]
+    [Algebra F K] [IsScalarTower ℚ F K] [IsGaloisGroup H F K] :
+    H.index = Module.finrank ℚ F := by
+  have h : H.index * Nat.card H = Nat.card G := Subgroup.index_mul_card H
+  rw [IsGaloisGroup.card_eq_finrank H F K, IsGaloisGroup.card_eq_finrank G ℚ K,
+    ← Module.finrank_mul_finrank ℚ F K] at h
+  exact Nat.eq_of_mul_eq_mul_right Module.finrank_pos h
 
 section Generation
 
@@ -81,7 +120,7 @@ field unramified over `ℚ` is `ℚ`, so `F = ℚ`. -/
 theorem eq_top_of_forall_inertia_le {H : Subgroup G}
     (h : ∀ P : Ideal (𝓞 K), P.IsMaximal → P.inertia G ≤ H) : H = ⊤ := by
   classical
-  set F : IntermediateField ℚ K := FixedPoints.intermediateField H with hF
+  set F : IntermediateField ℚ K := FixedPoints.intermediateField H
   have : IsGaloisGroup H (𝓞 F) (𝓞 K) :=
     IsGaloisGroup.of_isFractionRing H (𝓞 F) (𝓞 K) F K
   -- Every nonzero prime of `𝓞 F` is unramified over `ℤ`.
@@ -95,33 +134,20 @@ theorem eq_top_of_forall_inertia_le {H : Subgroup G}
     have htower : P.ramificationIdx ℤ = q.ramificationIdx ℤ * P.ramificationIdx (𝓞 F) :=
       Ideal.ramificationIdx_tower (R := ℤ) q P
     -- The two inertia subgroups of `P`, over `ℚ` and over `F`, have the same cardinality.
-    have hG : Nat.card (P.inertia G) = P.ramificationIdx ℤ := by
-      rw [Ideal.card_inertia_eq_ramificationIdxIn (G := G) (P.under ℤ) P,
-        Ideal.ramificationIdxIn_eq_ramificationIdx (P.under ℤ) P G]
-    have hH : Nat.card (P.inertia H) = P.ramificationIdx (𝓞 F) := by
-      rw [Ideal.card_inertia_eq_ramificationIdxIn (G := H) (P.under (𝓞 F)) P,
-        Ideal.ramificationIdxIn_eq_ramificationIdx (P.under (𝓞 F)) P H]
     have hcard : Nat.card (P.inertia H) = Nat.card (P.inertia G) := by
       have hsub : P.inertia H = (P.inertia G).subgroupOf H :=
         (AddSubgroup.subgroupOf_inertia (I := P.toAddSubgroup) H).symm
       rw [hsub]
       exact Nat.card_congr (Subgroup.subgroupOfEquivOfLe (h P hPmax)).toEquiv
-    have hEq : P.ramificationIdx (𝓞 F) = P.ramificationIdx ℤ := by rw [← hH, hcard, hG]
+    have hEq : P.ramificationIdx (𝓞 F) = P.ramificationIdx ℤ := by
+      rw [← Ideal.card_inertia_eq_ramificationIdx (𝓞 F) H P, hcard,
+        Ideal.card_inertia_eq_ramificationIdx ℤ G P]
     rw [hEq] at htower
     exact Nat.eq_of_mul_eq_mul_right (Ideal.ramificationIdx_pos (R := ℤ) (q := P))
       (by rw [one_mul, ← htower])
-  -- Hence `F` is unramified over `ℚ`, so `F = ℚ` by Minkowski's theorem.
-  have hrank : Module.finrank ℚ F = 1 := by
-    by_contra hne
-    obtain ⟨p, hp, hnu⟩ := NumberField.exists_not_isUnramifiedIn (K := F) (𝒪 := 𝓞 F) hne
-    refine hnu (Algebra.isUnramifiedIn_iff_forall_ramificationIdx_eq_one.mpr fun q _ hqp => ?_)
-    have : q.LiesOver (Ideal.span {(p : ℤ)}) := hqp
-    refine hq q inferInstance
-      (Ideal.ne_bot_of_liesOver_of_ne_bot (p := Ideal.span {(p : ℤ)}) ?_ q)
-    simpa using hp.ne_zero
-  refine Subgroup.eq_top_of_card_eq H ?_
-  rw [IsGaloisGroup.card_eq_finrank H F K, IsGaloisGroup.card_eq_finrank G ℚ K,
-    ← Module.finrank_mul_finrank ℚ F K, hrank, one_mul]
+  -- Hence `F` is unramified over `ℚ`, so `F = ℚ` by Minkowski's theorem, and `H` has index `1`.
+  exact Subgroup.index_eq_one.mp
+    ((index_eq_finrank H F K).trans (finrank_eq_one_of_forall_ramificationIdx_eq_one hq))
 
 /-- **The inertia subgroups generate the Galois group.** For a number field `K` Galois over `ℚ`
 with Galois group `G`, the supremum of the inertia subgroups of the maximal ideals of `𝓞 K`
@@ -129,13 +155,6 @@ is `⊤`. -/
 theorem iSup_inertia_eq_top : ⨆ P : MaximalSpectrum (𝓞 K), P.asIdeal.inertia G = ⊤ :=
   eq_top_of_forall_inertia_le fun P hP =>
     le_iSup (fun Q : MaximalSpectrum (𝓞 K) => Q.asIdeal.inertia G) ⟨P, hP⟩
-
-/-- The union of the inertia subgroups of the maximal ideals of `𝓞 K` generates `G`. This is the
-`Subgroup.closure` form of `NumberField.iSup_inertia_eq_top`. -/
-theorem closure_iUnion_inertia_eq_top :
-    Subgroup.closure (⋃ P : MaximalSpectrum (𝓞 K), (P.asIdeal.inertia G : Set G)) = ⊤ := by
-  rw [Subgroup.closure_iUnion]
-  simpa using iSup_inertia_eq_top G
 
 end Generation
 
@@ -146,71 +165,58 @@ variable {K : Type*} [Field K] [NumberField K] {G : Type*} [Group G] [Finite G]
   {F : Type*} [Field F] [NumberField F] [Algebra ℚ F] [Algebra F K] [IsScalarTower ℚ F K]
 
 omit [IsGaloisGroup G ℚ K] [Algebra ℚ F] [IsScalarTower ℚ F K] in
-/-- **An unramified subextension meets every inertia subgroup trivially.** Let `H` be a subgroup
-of `G` whose fixed field is `F`. If the prime below `P` is unramified in `𝓞 K`, then the inertia
-subgroup of `P` is disjoint from `H`, since its intersection with `H` is the inertia subgroup of
-`P` over `𝓞 F`, of order `e(P / 𝓞 F) = 1`. -/
-theorem disjoint_inertia_of_isUnramifiedIn (H : Subgroup G) [IsGaloisGroup H F K]
-    (P : Ideal (𝓞 K)) (hP : P.IsPrime)
-    (hunr : Algebra.IsUnramifiedIn (𝓞 K) (P.under (𝓞 F))) : Disjoint (P.inertia G) H := by
+/-- **The inertia subgroup at an unramified prime meets `H` trivially.** Let `H` be a subgroup of
+`G` whose fixed field is `F`. If `P` is unramified over `𝓞 F`, then the inertia subgroup of `P`
+is disjoint from `H`, since its intersection with `H` is the inertia subgroup of `P` over `𝓞 F`,
+of order `e(P / 𝓞 F) = 1`. -/
+theorem disjoint_inertia_of_ramificationIdx_eq_one (H : Subgroup G) [IsGaloisGroup H F K]
+    (P : Ideal (𝓞 K)) (hP : P.IsPrime) (hunr : P.ramificationIdx (𝓞 F) = 1) :
+    Disjoint (P.inertia G) H := by
   have : P.IsPrime := hP
   have : IsGaloisGroup H (𝓞 F) (𝓞 K) := IsGaloisGroup.of_isFractionRing H (𝓞 F) (𝓞 K) F K
   rw [← Subgroup.subgroupOf_eq_bot]
   refine Subgroup.eq_bot_of_card_eq _ ?_
-  rw [AddSubgroup.subgroupOf_inertia,
-    Ideal.card_inertia_eq_ramificationIdxIn (G := H) (P.under (𝓞 F)) P,
-    Ideal.ramificationIdxIn_eq_ramificationIdx (P.under (𝓞 F)) P H]
-  exact hunr.ramificationIdx_eq_one inferInstance
+  rw [AddSubgroup.subgroupOf_inertia, Ideal.card_inertia_eq_ramificationIdx (𝓞 F) H P]
+  exact hunr
 
 omit [IsGaloisGroup G ℚ K] [Algebra ℚ F] [IsScalarTower ℚ F K] in
-/-- **Inertia over a quadratic subfield is killed by squaring.** If the prime below `P` in the
-fixed field `F` of an index-`2` subgroup `H` of `G` is unramified in `𝓞 K`, then any element of
-the inertia subgroup at `P` squares to `1`: its square lies in `H` because `H` has index `2`, and
-it lies in the inertia subgroup, which meets `H` trivially. -/
-theorem sq_eq_one_of_mem_inertia {H : Subgroup G} [IsGaloisGroup H F K] (hindex : H.index = 2)
-    {P : Ideal (𝓞 K)} (hP : P.IsPrime)
-    (hunr : Algebra.IsUnramifiedIn (𝓞 K) (P.under (𝓞 F)))
-    {g : G} (hg : g ∈ P.inertia G) : g ^ 2 = 1 := by
-  have hmem : g ^ 2 ∈ H := Subgroup.sq_mem_of_index_two hindex g
-  exact Subgroup.disjoint_def.mp (disjoint_inertia_of_isUnramifiedIn H P hP hunr)
-    (pow_mem hg 2) hmem
+/-- **The index of `H` kills inertia at a prime unramified over the fixed field.** If `H` is a
+normal subgroup of `G` with fixed field `F` and `P` is unramified over `𝓞 F`, then every element
+of the inertia subgroup at `P` is killed by `H.index`: its `H.index`-th power lies in `H`, and it
+lies in the inertia subgroup, which meets `H` trivially. -/
+theorem pow_index_eq_one_of_ramificationIdx_eq_one {H : Subgroup G} [H.Normal]
+    [IsGaloisGroup H F K] {P : Ideal (𝓞 K)} (hP : P.IsPrime)
+    (hunr : P.ramificationIdx (𝓞 F) = 1) {g : G} (hg : g ∈ P.inertia G) : g ^ H.index = 1 :=
+  Subgroup.disjoint_def.mp (disjoint_inertia_of_ramificationIdx_eq_one H P hP hunr)
+    (pow_mem hg _) (H.pow_index_mem g)
 
 omit [Algebra ℚ F] [IsScalarTower ℚ F K] in
 open scoped IsMulCommutative in
-/-- **An abelian extension of `ℚ` unramified over a quadratic subfield is multiquadratic.** Let
-`K` be a number field, Galois over `ℚ` with abelian Galois group `G`, and let `H` be a subgroup of
-index `2` whose fixed field `F` has every prime unramified in `𝓞 K`. Then every element of `G`
-squares to `1`.
+/-- **An abelian extension of `ℚ` unramified over a subfield has exponent dividing its degree.**
+Let `K` be a number field, Galois over `ℚ` with abelian Galois group `G`, and let `H` be a
+subgroup whose fixed field `F` has every prime unramified in `𝓞 K`. Then `g ^ H.index = 1` for
+every `g : G`, and `H.index` is `Module.finrank ℚ F` by `NumberField.index_eq_finrank`.
 
-Indeed each inertia subgroup consists of elements squaring to `1`
-(`NumberField.sq_eq_one_of_mem_inertia`), and in an abelian group those elements form a subgroup;
-since the inertia subgroups generate `G` (`NumberField.eq_top_of_forall_inertia_le`), that
-subgroup is all of `G`. -/
-theorem sq_eq_one_of_index_eq_two [IsMulCommutative G] (H : Subgroup G) [IsGaloisGroup H F K]
-    (hindex : H.index = 2)
+Indeed each inertia subgroup is killed by `H.index`
+(`NumberField.pow_index_eq_one_of_ramificationIdx_eq_one`), and in an abelian group the elements
+killed by a fixed exponent form a subgroup; since the inertia subgroups generate `G`
+(`NumberField.eq_top_of_forall_inertia_le`), that subgroup is all of `G`.
+
+For `F` quadratic this says that an abelian extension of `ℚ` unramified over a quadratic subfield
+has exponent dividing `2`; by Kummer theory over `ℚ` — not formalised here — such an extension is
+a compositum of quadratic fields. -/
+theorem pow_index_eq_one_of_isUnramifiedIn [IsMulCommutative G] (H : Subgroup G)
+    [IsGaloisGroup H F K]
     (hunr : ∀ q : Ideal (𝓞 F), q.IsPrime → Algebra.IsUnramifiedIn (𝓞 K) q) (g : G) :
-    g ^ 2 = 1 := by
-  have h : (powMonoidHom 2 : G →* G).ker = ⊤ :=
+    g ^ H.index = 1 := by
+  have h : (powMonoidHom H.index : G →* G).ker = ⊤ :=
     eq_top_of_forall_inertia_le fun P hP x hx => by
+      have : P.IsPrime := hP.isPrime
       simpa [MonoidHom.mem_ker] using
-        sq_eq_one_of_mem_inertia (F := F) hindex hP.isPrime
-          (hunr (P.under (𝓞 F)) inferInstance) hx
-  simpa [MonoidHom.mem_ker] using (h ▸ Subgroup.mem_top g : g ∈ (powMonoidHom 2 : G →* G).ker)
-
-open scoped IsMulCommutative in
-/-- **The degree form of `NumberField.sq_eq_one_of_index_eq_two`.** If `K` is Galois over `ℚ` with
-abelian Galois group `G`, if `F` is the fixed field of `H` and is quadratic over `ℚ`, and if every
-prime of `𝓞 F` is unramified in `𝓞 K`, then every element of `G` squares to `1`. The index of `H`
-is the degree of its fixed field, here `2`. -/
-theorem sq_eq_one_of_finrank_eq_two [IsMulCommutative G] (H : Subgroup G) [IsGaloisGroup H F K]
-    (hF : Module.finrank ℚ F = 2)
-    (hunr : ∀ q : Ideal (𝓞 F), q.IsPrime → Algebra.IsUnramifiedIn (𝓞 K) q) (g : G) :
-    g ^ 2 = 1 := by
-  refine sq_eq_one_of_index_eq_two H ?_ hunr g
-  have h : H.index * Nat.card H = Nat.card G := Subgroup.index_mul_card H
-  rw [IsGaloisGroup.card_eq_finrank H F K, IsGaloisGroup.card_eq_finrank G ℚ K,
-    ← Module.finrank_mul_finrank ℚ F K, hF] at h
-  exact Nat.eq_of_mul_eq_mul_right Module.finrank_pos h
+        pow_index_eq_one_of_ramificationIdx_eq_one (F := F) (H := H) hP.isPrime
+          ((hunr (P.under (𝓞 F)) inferInstance).ramificationIdx_eq_one inferInstance) hx
+  simpa [MonoidHom.mem_ker] using
+    (h ▸ Subgroup.mem_top g : g ∈ (powMonoidHom H.index : G →* G).ker)
 
 end Unramified
 

--- a/TauCeti/NumberTheory/RamificationInertia/Galois.lean
+++ b/TauCeti/NumberTheory/RamificationInertia/Galois.lean
@@ -10,24 +10,43 @@ public import Mathlib.NumberTheory.RamificationInertia.Galois
 /-!
 # Ramification and inertia counting criteria
 
-This file records a Galois form of the fundamental identity for primes in finite extensions
-of domains: in a Galois extension, the number of primes above a prime ideal is
-maximal exactly when the common ramification index and inertia degree are both `1`.
+This file records two Galois consequences of the fundamental identity for primes in finite
+extensions of domains. First, in a Galois extension the number of primes above a prime ideal is
+maximal exactly when the common ramification index and inertia degree are both `1`. Second, the
+cardinality of the inertia subgroup of a prime `P` upstairs is the ramification index of `P`
+itself over the base, rather than the `Ideal.ramificationIdxIn` of the prime below it.
 
 ## Main results
 
 * `TauCeti.RamificationInertia.ncard_primesOver_eq_natCard_iff_of_isGaloisGroup`:
   the domain/flat Galois counting criterion.
+* `Ideal.card_inertia_eq_ramificationIdx`: the un-`In` form of the inertia count.
 
 ## Provenance
 
 Built directly on Mathlib's Galois fundamental identity
-(`Ideal.ncard_primesOver_mul_ramificationIdxIn_mul_inertiaDegIn`).
+(`Ideal.ncard_primesOver_mul_ramificationIdxIn_mul_inertiaDegIn`) and on its inertia count
+(`Ideal.card_inertia_eq_ramificationIdxIn`).
 -/
 
 public section
 
 open Ideal Module
+
+namespace Ideal
+
+/-- The cardinality of the inertia subgroup of `P` is the ramification index of `P` over `R`.
+This is `Ideal.card_inertia_eq_ramificationIdxIn` stated with the ramification index of `P`
+itself rather than with `Ideal.ramificationIdxIn` of the ideal below it. -/
+theorem card_inertia_eq_ramificationIdx (R : Type*) {S : Type*} [CommRing R] [CommRing S]
+    [Algebra R S] [IsDomain R] [IsDomain S] [Module.Finite R S] [Module.Flat R S] (G : Type*)
+    [Group G] [Finite G] [MulSemiringAction G S] [IsGaloisGroup G R S] (P : Ideal S) [P.IsPrime]
+    [PerfectField (P.under R).ResidueField] :
+    Nat.card (P.inertia G) = P.ramificationIdx R :=
+  (card_inertia_eq_ramificationIdxIn (G := G) (P.under R) P).trans
+    (ramificationIdxIn_eq_ramificationIdx (P.under R) P G)
+
+end Ideal
 
 namespace TauCeti.RamificationInertia
 


### PR DESCRIPTION
This PR proves that the inertia subgroups generate the Galois group of a number field: for `K` Galois over `ℚ` with Galois group `G` acting on `𝓞 K`, `NumberField.iSup_inertia_eq_top` says `⨆ P : MaximalSpectrum (𝓞 K), P.asIdeal.inertia G = ⊤`, with the working form `NumberField.eq_top_of_forall_inertia_le` (a subgroup containing every inertia subgroup is `⊤`). The proof takes the fixed field `F` of such a subgroup `H`: the inertia subgroup of a prime `P` of `𝓞 K` in `H` is its inertia subgroup in `G` intersected with `H`, hence all of it, so `Ideal.card_inertia_eq_ramificationIdx` makes the absolute ramification indices `e(P / ℤ)` and `e(P / 𝓞 F)` equal, and multiplicativity in the tower `ℤ ⊆ 𝓞 F ⊆ 𝓞 K` forces `e(𝔮 / ℤ) = 1` at every prime `𝔮` of `𝓞 F`. Minkowski's discriminant bound, in the form `NumberField.exists_not_isUnramifiedIn`, then gives `Module.finrank ℚ F = 1` (`NumberField.finrank_eq_one_of_forall_ramificationIdx_eq_one`), so `H = ⊤` by counting (`NumberField.index_eq_finrank`).

The milestone is Layer 3 of `TauCetiRoadmap/Multiquadratic/README.md`, "the genus field and the 2-rank theorem (the summit)", whose first target is the intrinsic genus field of `K = ℚ(√d)` — the maximal extension unramified at all places and abelian over `ℚ` — and the identification of `candidateGenusField` with it. The existence half of that identification is in place on `main`: `TauCeti.Multiquadratic.isUnramifiedIn_candidateGenusField` shows the candidate is unramified over the embedded `ℚ(√d)` at all finite places, and for `d < 0` at the infinite ones too. The maximality half is what is missing, and it rests on exactly this theorem: for any `M` abelian over `ℚ` and unramified over `K` one bounds each inertia subgroup of `Gal(M/ℚ)` by the index of `Gal(M/K)`, and generation by inertia turns that bound into a statement about all of `Gal(M/ℚ)`. Nothing else in the repository can produce a global conclusion about `Gal(M/ℚ)` from local ramification data, and Mathlib does not have the theorem either — `Mathlib/RingTheory/Polynomial/Morse.lean` takes `⨆ m : MaximalSpectrum S, m.asIdeal.inertia G = ⊤` as a hypothesis of `Polynomial.Splits.surjective_toPermHom_of_iSup_inertia_eq_top` and lists "specialize to the case of number fields where generation by inertia subgroups is a consequence of Minkowski's theorem" as a TODO.

The second half of the file draws that consequence, so the theorem lands with the consumer the milestone needs rather than as a bare tool. `NumberField.disjoint_inertia_of_ramificationIdx_eq_one` says that when `P` is unramified over the fixed field `F` of `H`, its inertia subgroup is disjoint from `H`, because their intersection is the inertia subgroup over `𝓞 F` and has order `e(P / 𝓞 F) = 1`. For `H` normal this makes every element of that inertia subgroup killed by `H.index` (`NumberField.pow_index_eq_one_of_ramificationIdx_eq_one`), since its `H.index`-th power lies in `H` by `Subgroup.pow_index_mem`. In an abelian `G` the elements killed by a fixed exponent form a subgroup, so generation by inertia promotes that to `NumberField.pow_index_eq_one_of_isUnramifiedIn`: the exponent of `G` divides `H.index`, which is `Module.finrank ℚ F` by `NumberField.index_eq_finrank`. Instantiated at a quadratic `F` this is the classical step that an everywhere-unramified abelian extension of a quadratic field has exponent `2`, and it is the shape in which the genus-field maximality argument will consume it; the passage from exponent `2` to a compositum of quadratic fields is Kummer theory over `ℚ` and is not formalised here.

The ramification-index computations, the disjointness lemma and the exponent statement are stated for an abstract `IsGaloisGroup G ℚ K` rather than for `Gal(K/ℚ)`, matching Mathlib's `Ideal.card_inertia_eq_ramificationIdxIn`; the middle lemmas carry `omit` clauses recording that they need neither the rational base nor Galois-ness over it. `Ideal.card_inertia_eq_ramificationIdx` is the un-`In` form of Mathlib's lemma, stated once because the file needs it three times. What remains after this PR, before the genus field is identified, is the intrinsic definition of the genus field of `ℚ(√d)` together with the Kummer-theoretic step that an exponent-`2` abelian extension of `ℚ` is a compositum of quadratic fields whose discriminants divide `disc K`, and then `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`.

`TauCeti/NumberTheory/NumberField/Inertia.lean` is new (223 lines); no existing file changes. No Mathlib source or external formalization is vendored. Generation of a Galois group by inertia subgroups is Section 4.4 of J. P. Serre, *Topics in Galois Theory*; the genus-theoretic consequence is standard, as in D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and F. Lemmermeyer, *Reciprocity Laws: from Euler to Eisenstein*, §2.2.

### Review round 1

All five flagged rubrics are addressed in `507cbd3`. One deliberate deviation, flagged here rather than contested: **generality** suggested keeping the index-`2` and degree-`2` statements as one-line corollaries of the general forms "if a concrete consumer wants it". There is no in-repository consumer yet, and such a corollary would be exactly the consumerless one-rewrite wrapper that **reuse** removed in the same round (`closure_iUnion_inertia_eq_top`), so the `2` cases are left to the caller: `hindex ▸ pow_index_eq_one_of_isUnramifiedIn H hunr g`, or `(index_eq_finrank H F K).trans hF ▸ …` from the degree side.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"isup-inertia-eq-top"}-->

🤖 Prepared with Claude Code



### Review round 2

The single blocking finding — **generality** on `index_eq_finrank` — is addressed in `29c2e76`.
The lemma is now stated over an arbitrary base field: for a tower `E ⊆ F ⊆ K` with
`[IsGaloisGroup G E K]` and `[IsGaloisGroup H F K]` it reads `H.index = Module.finrank E F`,
and the two `NumberField` assumptions are replaced by `[FiniteDimensional F K]`, the only
finiteness the cancellation `Nat.eq_of_mul_eq_mul_right Module.finrank_pos` consumes (weaker
than `[Finite G]`; the call site gets it from `IntermediateField.finiteDimensional_right`).
Since nothing about the statement is number-theoretic any more, it moved to
`namespace IsGaloisGroup`, next to the file's other general helper
`Ideal.card_inertia_eq_ramificationIdx`, and the two docstring references were updated.


### Review round 3

**placement** is addressed in `7642480`. The two general helpers leave the NumberField module:
`Ideal.card_inertia_eq_ramificationIdx` moves to
`TauCeti/NumberTheory/RamificationInertia/Galois.lean` — the existing generic module for Galois
consequences of the fundamental identity, whose single `public import` already supplies both
Mathlib lemmas the proof composes — and `IsGaloisGroup.index_eq_finrank` moves to a new
`TauCeti/FieldTheory/Galois/IsGaloisGroup.lean`, mirroring the Mathlib module that states
`IsGaloisGroup.card_eq_finrank`. `Inertia.lean` imports both; no statement changed.

**reuse** is contested rather than fixed. Its fix — delete `Ideal.card_inertia_eq_ramificationIdx`
and re-inline the `card_inertia_eq_ramificationIdxIn` + `ramificationIdxIn_eq_ramificationIdx`
chain at the three call sites — is verbatim the state that **proof-quality** blocked at `f1e66b8`
("repeated verbatim three times … _Fix:_ State it once, e.g. `theorem
card_inertia_eq_ramificationIdx (R) …`"), and that rubric is green on `507cbd3`/`29c2e76` only
because the duplication was factored out. It also contradicts **placement**'s fix on the same
round, which asks for the declaration to be *moved* to a general module. And this rubric approved
the identical declaration one commit earlier: `git diff 507cbd3 29c2e76` leaves
`card_inertia_eq_ramificationIdx` byte-identical, yet reuse read `507cbd3` as ✅ and `29c2e76` as
🟡. The evidence is in the thread reply.
