### PR TITLE
feat: the lattice homology of a one-vertex plumbing is a single U-tower

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -320,6 +320,7 @@ theorem characteristicWeight_mk_singleton (P : PlumbingGraph V)
 
 /-- The lower-face exponent of a one-dimensional cube is the drop from its weight to the weight
 of its base point. -/
+@[simp]
 theorem characteristicLowerFaceExponent_mk_singleton (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
     characteristicLowerFaceExponent P k ⟨x, {v}⟩ v =
@@ -333,6 +334,7 @@ theorem characteristicLowerFaceExponent_mk_singleton (P : PlumbingGraph V)
 
 /-- The upper-face exponent of a one-dimensional cube is the drop from its weight to the weight
 of its far endpoint. -/
+@[simp]
 theorem characteristicUpperFaceExponent_mk_singleton (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
     characteristicUpperFaceExponent P k

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -320,30 +320,31 @@ theorem characteristicWeight_mk_singleton (P : PlumbingGraph V)
 
 /-- The lower-face exponent of a one-dimensional cube is the drop from its weight to the weight
 of its base point. -/
+@[simp]
 theorem characteristicLowerFaceExponent_mk_singleton (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
-    characteristicLowerFaceExponent P k ⟨x, {v}⟩ v =
+    P.characteristicLowerFaceExponent k x {v} v =
       (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
         P.characteristicWeight k x).toNat := by
   have h := characteristicLowerFaceExponent_natCast P k ⟨x, {v}⟩ v
   rw [characteristicWeight_mk_singleton] at h
-  simp only [eraseDirection_mk, Finset.erase_singleton, characteristicWeight_mk,
-    PlumbingGraph.characteristicCubeWeight_empty] at h
+  simp only [characteristicLowerFaceExponent_mk, eraseDirection_mk, Finset.erase_singleton,
+    characteristicWeight_mk, PlumbingGraph.characteristicCubeWeight_empty] at h
   omega
 
 /-- The upper-face exponent of a one-dimensional cube is the drop from its weight to the weight
 of its far endpoint. -/
+@[simp]
 theorem characteristicUpperFaceExponent_mk_singleton (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
-    characteristicUpperFaceExponent P k
-        (⟨x, {v}⟩ : PlumbingCube V) (Finset.mem_singleton_self v) =
+    P.characteristicUpperFaceExponent k x {v} (Finset.mem_singleton_self v) =
       (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
         P.characteristicWeight k (x + Pi.single v 1)).toNat := by
   have h := characteristicUpperFaceExponent_natCast P k
     (⟨x, {v}⟩ : PlumbingCube V) (Finset.mem_singleton_self v)
   rw [characteristicWeight_mk_singleton] at h
-  simp only [upperFace_mk, Finset.erase_singleton, characteristicWeight_mk,
-    PlumbingGraph.characteristicCubeWeight_empty] at h
+  simp only [characteristicUpperFaceExponent_mk, upperFace_mk, Finset.erase_singleton,
+    characteristicWeight_mk, PlumbingGraph.characteristicCubeWeight_empty] at h
   omega
 
 end Singleton

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -320,7 +320,6 @@ theorem characteristicWeight_mk_singleton (P : PlumbingGraph V)
 
 /-- The lower-face exponent of a one-dimensional cube is the drop from its weight to the weight
 of its base point. -/
-@[simp]
 theorem characteristicLowerFaceExponent_mk_singleton (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
     characteristicLowerFaceExponent P k ⟨x, {v}⟩ v =
@@ -334,7 +333,6 @@ theorem characteristicLowerFaceExponent_mk_singleton (P : PlumbingGraph V)
 
 /-- The upper-face exponent of a one-dimensional cube is the drop from its weight to the weight
 of its far endpoint. -/
-@[simp]
 theorem characteristicUpperFaceExponent_mk_singleton (P : PlumbingGraph V)
     (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
     characteristicUpperFaceExponent P k

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -49,6 +49,14 @@ lattice-homology differential can use directly.
 * `TauCeti.PlumbingCube.characteristicLowerFaceExponent` and
   `TauCeti.PlumbingCube.characteristicUpperFaceExponent`: the bundled face exponents.
 
+## Main results
+
+* `TauCeti.PlumbingCube.characteristicWeight_mk_singleton`: the weight of a
+  one-dimensional cube is the larger of its endpoint weights.
+* `TauCeti.PlumbingCube.characteristicLowerFaceExponent_mk_singleton` and
+  `TauCeti.PlumbingCube.characteristicUpperFaceExponent_mk_singleton`: the two face exponents of
+  a one-dimensional cube.
+
 ## References
 
 This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L
@@ -292,6 +300,53 @@ theorem characteristicUpperFaceExponent_natCast [Fintype V] (P : PlumbingGraph V
   by
     simp [characteristicUpperFaceExponent_def, characteristicWeight_def, upperFace_base,
       upperFace_directions]
+
+/-! ### One-dimensional cubes -/
+
+section Singleton
+
+variable [Fintype V]
+
+/-- The characteristic cube weight of a one-dimensional cube is the larger of its two endpoint
+weights. -/
+theorem characteristicWeight_mk_singleton (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
+    characteristicWeight P k ⟨x, {v}⟩ =
+      max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) := by
+  rw [characteristicWeight_mk,
+    P.characteristicCubeWeight_eq_max_erase k x (Finset.mem_singleton_self v),
+    Finset.erase_singleton, PlumbingGraph.characteristicCubeWeight_empty,
+    PlumbingGraph.characteristicCubeWeight_empty]
+
+/-- The lower-face exponent of a one-dimensional cube is the drop from its weight to the weight
+of its base point. -/
+theorem characteristicLowerFaceExponent_mk_singleton (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
+    characteristicLowerFaceExponent P k ⟨x, {v}⟩ v =
+      (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
+        P.characteristicWeight k x).toNat := by
+  have h := characteristicLowerFaceExponent_natCast P k ⟨x, {v}⟩ v
+  rw [characteristicWeight_mk_singleton] at h
+  simp only [eraseDirection_mk, Finset.erase_singleton, characteristicWeight_mk,
+    PlumbingGraph.characteristicCubeWeight_empty] at h
+  omega
+
+/-- The upper-face exponent of a one-dimensional cube is the drop from its weight to the weight
+of its far endpoint. -/
+theorem characteristicUpperFaceExponent_mk_singleton (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
+    characteristicUpperFaceExponent P k
+        (⟨x, {v}⟩ : PlumbingCube V) (Finset.mem_singleton_self v) =
+      (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
+        P.characteristicWeight k (x + Pi.single v 1)).toNat := by
+  have h := characteristicUpperFaceExponent_natCast P k
+    (⟨x, {v}⟩ : PlumbingCube V) (Finset.mem_singleton_self v)
+  rw [characteristicWeight_mk_singleton] at h
+  simp only [upperFace_mk, Finset.erase_singleton, characteristicWeight_mk,
+    PlumbingGraph.characteristicCubeWeight_empty] at h
+  omega
+
+end Singleton
 
 /-- The lower exponent is zero exactly when erasing the direction leaves the bundled weight
 unchanged. -/

--- a/TauCeti/LowDimTopology/Plumbing/Differential.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Differential.lean
@@ -154,6 +154,8 @@ theorem latticeDifferential_single_mk_singleton (P : PlumbingGraph V)
       {w // w ∈ ({v} : Finset V)}) (Finset.mem_attach _ _)
       (fun w _ hw => absurd (Subtype.ext (Finset.mem_singleton.mp w.property)) hw)]
   rw [PlumbingCube.lowerFace_mk, PlumbingCube.upperFace_mk, Finset.erase_singleton,
+    PlumbingCube.characteristicLowerFaceExponent_mk,
+    PlumbingCube.characteristicUpperFaceExponent_mk,
     PlumbingCube.characteristicLowerFaceExponent_mk_singleton,
     PlumbingCube.characteristicUpperFaceExponent_mk_singleton]
 

--- a/TauCeti/LowDimTopology/Plumbing/Differential.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Differential.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Polynomial.Basic
 public import Mathlib.LinearAlgebra.Finsupp.LSum
 public import TauCeti.LowDimTopology.Plumbing.Cube.Face.Exponent
+public import TauCeti.LowDimTopology.Plumbing.Cube.Generator
 import Mathlib.Algebra.CharP.Two
 
 /-!
@@ -37,6 +38,11 @@ oriented cubical differential.
 ## Main results
 
 * `TauCeti.PlumbingGraph.latticeDifferential_single`: the differential on a basis cube.
+* `TauCeti.PlumbingGraph.latticeDifferential_single_mk_singleton`: the differential on a
+  one-dimensional basis cube.
+* `TauCeti.PlumbingGraph.single_add_sub_smul_single_mem_range` and
+  `TauCeti.PlumbingGraph.single_sub_smul_single_add_mem_range`: the boundary relations between
+  adjacent lattice points.
 * `TauCeti.PlumbingGraph.latticeDifferential_comp_self`: the lattice differential squares to
   zero.
 * `TauCeti.PlumbingGraph.latticeDifferential_eq_zero_of_isEmpty`: the zero-vertex
@@ -117,6 +123,68 @@ theorem latticeDifferential_apply
       c.sum fun C a => a • @latticeDifferentialOnGenerator V decV finV P k C := by
   rw [latticeDifferential, Finsupp.lsum_apply]
   simp [Finsupp.sum, LinearMap.smulRight_apply]
+
+/-! ### One-dimensional cubes and adjacent lattice points -/
+
+namespace PlumbingChain
+
+omit decV finV in
+/-- Subtraction of plumbing chains is addition, the coefficients having characteristic two. -/
+private theorem sub_eq_add (c d : PlumbingChain V) : c - d = c + d := by
+  rw [sub_eq_add_neg, ← neg_one_smul PlumbingCoefficient d, CharTwo.neg_eq, one_smul]
+
+end PlumbingChain
+
+/-- The lattice differential of a one-dimensional cube generator: each endpoint appears,
+weighted by the drop from the cube weight to that endpoint's weight. -/
+theorem latticeDifferential_single_mk_singleton (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (v : V) :
+    P.latticeDifferential k (Finsupp.single ⟨x, {v}⟩ 1) =
+      Finsupp.single (⟨x, ∅⟩ : PlumbingCube V)
+          (Polynomial.X ^
+            (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
+              P.characteristicWeight k x).toNat) +
+        Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V)
+          (Polynomial.X ^
+            (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
+              P.characteristicWeight k (x + Pi.single v 1)).toNat) := by
+  classical
+  rw [latticeDifferential_single, one_smul, latticeDifferentialOnGenerator_def,
+    Finset.sum_eq_single_of_mem (⟨v, Finset.mem_singleton_self v⟩ :
+      {w // w ∈ ({v} : Finset V)}) (Finset.mem_attach _ _)
+      (fun w _ hw => absurd (Subtype.ext (Finset.mem_singleton.mp w.property)) hw)]
+  rw [PlumbingCube.lowerFace_mk, PlumbingCube.upperFace_mk, Finset.erase_singleton,
+    PlumbingCube.characteristicLowerFaceExponent_mk_singleton,
+    PlumbingCube.characteristicUpperFaceExponent_mk_singleton]
+
+/-- Crossing a one-dimensional cube towards a lattice point of no smaller weight: the far
+endpoint is, modulo boundaries, `U ^ d` times the near one. -/
+theorem single_add_sub_smul_single_mem_range (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (v : V)
+    (h : P.characteristicWeight k x ≤ P.characteristicWeight k (x + Pi.single v 1)) :
+    Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V) 1 -
+        (Polynomial.X : PlumbingCoefficient) ^ (P.characteristicWeight k (x + Pi.single v 1) -
+            P.characteristicWeight k x).toNat •
+          Finsupp.single (⟨x, ∅⟩ : PlumbingCube V) 1 ∈
+      LinearMap.range (P.latticeDifferential k) := by
+  refine ⟨Finsupp.single ⟨x, {v}⟩ 1, ?_⟩
+  rw [latticeDifferential_single_mk_singleton, max_eq_right h, sub_self, Int.toNat_zero,
+    pow_zero, PlumbingChain.sub_eq_add, Finsupp.smul_single, smul_eq_mul, mul_one]
+  exact add_comm _ _
+
+/-- Crossing a one-dimensional cube away from a lattice point of no larger weight: the near
+endpoint is, modulo boundaries, `U ^ d` times the far one. -/
+theorem single_sub_smul_single_add_mem_range (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (x : V → ℤ) (v : V)
+    (h : P.characteristicWeight k (x + Pi.single v 1) ≤ P.characteristicWeight k x) :
+    Finsupp.single (⟨x, ∅⟩ : PlumbingCube V) 1 -
+        (Polynomial.X : PlumbingCoefficient) ^ (P.characteristicWeight k x -
+            P.characteristicWeight k (x + Pi.single v 1)).toNat •
+          Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V) 1 ∈
+      LinearMap.range (P.latticeDifferential k) := by
+  refine ⟨Finsupp.single ⟨x, {v}⟩ 1, ?_⟩
+  rw [latticeDifferential_single_mk_singleton, max_eq_left h, sub_self, Int.toNat_zero,
+    pow_zero, PlumbingChain.sub_eq_add, Finsupp.smul_single, smul_eq_mul, mul_one]
 
 /-! ### Cancellation around codimension-two faces -/
 

--- a/TauCeti/LowDimTopology/Plumbing/Differential.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Differential.lean
@@ -40,6 +40,8 @@ oriented cubical differential.
 * `TauCeti.PlumbingGraph.latticeDifferential_single`: the differential on a basis cube.
 * `TauCeti.PlumbingGraph.latticeDifferential_single_mk_singleton`: the differential on a
   one-dimensional basis cube.
+* `TauCeti.PlumbingGraph.latticeDifferential_eq_zero_of_forall_directions_eq_empty`: a chain
+  supported on lattice points is a cycle.
 * `TauCeti.PlumbingGraph.single_add_sub_smul_single_mem_range` and
   `TauCeti.PlumbingGraph.single_sub_smul_single_add_mem_range`: the boundary relations between
   adjacent lattice points.
@@ -123,6 +125,24 @@ theorem latticeDifferential_apply
       c.sum fun C a => a • @latticeDifferentialOnGenerator V decV finV P k C := by
   rw [latticeDifferential, Finsupp.lsum_apply]
   simp [Finsupp.sum, LinearMap.smulRight_apply]
+
+/-- A zero-dimensional cube has no directions to differentiate along, so it is a cycle. -/
+@[simp]
+theorem latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions = ∅) :
+    P.latticeDifferentialOnGenerator k C = 0 := by
+  rw [latticeDifferentialOnGenerator_def]
+  refine Finset.sum_eq_zero fun v _ => ?_
+  have : (v : V) ∈ (∅ : Finset V) := by rw [← hC]; exact v.property
+  exact absurd this (Finset.notMem_empty _)
+
+/-- A chain supported in cubical degree zero is a cycle: a lattice point has no faces. -/
+theorem latticeDifferential_eq_zero_of_forall_directions_eq_empty (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {c : PlumbingChain V}
+    (hc : ∀ C ∈ c.support, C.directions = ∅) : P.latticeDifferential k c = 0 := by
+  rw [latticeDifferential_apply, Finsupp.sum]
+  refine Finset.sum_eq_zero fun C hC => ?_
+  rw [P.latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty k (hc C hC), smul_zero]
 
 /-! ### One-dimensional cubes and adjacent lattice points -/
 

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -40,6 +40,8 @@ canonically isomorphic to its whole chain module.
 * `TauCeti.PlumbingGraph.latticeHomology`: its canonical `𝔽₂[U]`-module homology.
 * `TauCeti.PlumbingGraph.latticeHomologyCycleMap`: the map taking a coefficient to the homology
   class of its multiple of a fixed cycle.
+* `TauCeti.PlumbingGraph.latticeHomologyCycleMap_surjective`: that map is surjective as soon as
+  every cycle differs from a multiple of the fixed cycle by a boundary.
 * `TauCeti.PlumbingGraph.latticeHomologyIsoChainOfIsEmpty`: the homology of a zero-vertex
   plumbing is its full chain module.
 * `TauCeti.PlumbingGraph.latticeHomologyIsoCoefficientOfIsEmpty`: that chain module has one
@@ -138,6 +140,10 @@ private theorem latticeShortComplex_g_hom_apply (P : PlumbingGraph V)
     (k : P.characteristicVectors) (c : PlumbingChain V) :
     (P.latticeShortComplex k).g.hom c = P.latticeDifferential k c := rfl
 
+private theorem latticeShortComplex_f_hom_apply (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (c : PlumbingChain V) :
+    (P.latticeShortComplex k).f.hom c = P.latticeDifferential k c := rfl
+
 /-- The linear map sending `a : 𝔽₂[U]` to the homology class of `a • c`, for a lattice
 cycle `c`. -/
 noncomputable def latticeHomologyCycleMap (P : PlumbingGraph V) (k : P.characteristicVectors)
@@ -189,6 +195,45 @@ theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
       rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero]
       exact hz
     exact (congrArg (fun x => S.moduleCatHomologyIso.inv x) hq).trans (map_zero _)
+
+/-- A cycle whose class generates lattice homology: if every cycle differs from a multiple of `c`
+by a boundary, then `latticeHomologyCycleMap` is surjective.
+
+Like `latticeHomologyCycleMap_apply_eq_zero_iff`, this has to be stated here: the body of
+`latticeShortComplex` is not exposed, so a downstream file cannot see that it is the lattice
+differential in both positions, and hence cannot use Mathlib's explicit
+cycles-modulo-boundaries description of the homology of a short complex of modules. -/
+theorem latticeHomologyCycleMap_surjective (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (c : PlumbingChain V)
+    (hc : P.latticeDifferential k c = 0)
+    (hgen : ∀ z : PlumbingChain V, P.latticeDifferential k z = 0 →
+      ∃ a : PlumbingCoefficient, z - a • c ∈ LinearMap.range (P.latticeDifferential k)) :
+    Function.Surjective (P.latticeHomologyCycleMap k c hc) := by
+  intro y
+  let S := P.latticeShortComplex k
+  let z : LinearMap.ker S.g.hom := ⟨c, (P.latticeShortComplex_g_hom_apply k c).trans hc⟩
+  let q : S.moduleCatLeftHomologyData.H :=
+    (LinearMap.range S.moduleCatToCycles).mkQ z
+  -- Every homology class is the class of an honest cycle.
+  obtain ⟨w, hw⟩ := Submodule.mkQ_surjective (LinearMap.range S.moduleCatToCycles)
+    (S.moduleCatHomologyIso.hom y)
+  have hcycle : P.latticeDifferential k w.val = 0 :=
+    (P.latticeShortComplex_g_hom_apply k w.val).symm.trans (LinearMap.mem_ker.mp w.property)
+  obtain ⟨a, b, hb⟩ := hgen w.val hcycle
+  -- The cycles `w` and `a • z` differ by the boundary of `b`, so they agree in homology.
+  have hmem : w - a • z ∈ LinearMap.range S.moduleCatToCycles :=
+    ⟨b, Subtype.ext ((P.latticeShortComplex_f_hom_apply k b).trans hb)⟩
+  refine ⟨a, ?_⟩
+  -- `moduleCatHomologyIso` is Mathlib's interface from abstract homology to the explicit
+  -- kernel/range quotient; unfolding the local cycle map is what makes it usable here.
+  change S.moduleCatHomologyIso.inv (a • q) = y
+  have hq : a • q = S.moduleCatHomologyIso.hom y := by
+    refine Eq.trans ?_ hw
+    change (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = _
+    rw [Submodule.mkQ_apply, Submodule.mkQ_apply, Submodule.Quotient.eq]
+    exact neg_sub w (a • z) ▸ Submodule.neg_mem _ hmem
+  rw [hq]
+  exact S.moduleCatHomologyIso.hom_inv_id_apply y
 
 /-- The characteristic-two lattice homology of a zero-vertex plumbing is canonically isomorphic
 to its whole plumbing-chain module. -/

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -156,6 +156,16 @@ noncomputable def latticeHomologyCycleMap (P : PlumbingGraph V) (k : P.character
   S.moduleCatHomologyIso.inv.hom.comp
     (LinearMap.toSpanSingleton PlumbingCoefficient S.moduleCatLeftHomologyData.H q)
 
+/-- The cycle map sends a coefficient to the corresponding scalar multiple of the chosen cycle in
+the explicit cycles-modulo-boundaries model of short-complex homology. -/
+private theorem latticeHomologyCycleMap_apply (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (c : PlumbingChain V)
+    (hc : P.latticeDifferential k c = 0) (a : PlumbingCoefficient) :
+    P.latticeHomologyCycleMap k c hc a =
+      (P.latticeShortComplex k).moduleCatHomologyIso.inv
+        ((LinearMap.range (P.latticeShortComplex k).moduleCatToCycles).mkQ
+          (a • ⟨c, (P.latticeShortComplex_g_hom_apply k c).trans hc⟩)) := rfl
+
 /-- A coefficient maps to zero under `latticeHomologyCycleMap` exactly when its multiple of the
 cycle is a boundary. -/
 @[simp]
@@ -166,21 +176,16 @@ theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
       a • c ∈ LinearMap.range (P.latticeDifferential k) := by
   let S := P.latticeShortComplex k
   let z : LinearMap.ker S.g.hom := ⟨c, (P.latticeShortComplex_g_hom_apply k c).trans hc⟩
-  let q : S.moduleCatLeftHomologyData.H :=
-    (LinearMap.range S.moduleCatToCycles).mkQ z
-  -- `moduleCatHomologyIso` is Mathlib's interface from abstract homology to the explicit
-  -- kernel/range quotient. Unfolding the local cycle map here is necessary to use that interface;
-  -- rewriting across it instead fails because `latticeHomology` remains opaque to the rewriter.
-  change S.moduleCatHomologyIso.inv (a • q) = 0 ↔ _
+  rw [latticeHomologyCycleMap_apply]
+  change S.moduleCatHomologyIso.inv
+      ((LinearMap.range S.moduleCatToCycles).mkQ (a • z)) = 0 ↔ _
   constructor
   · intro ha
-    have hq : a • q = 0 := by
-      have hz := S.moduleCatHomologyIso.inv_hom_id_apply (a • q)
+    have hq : (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0 := by
+      have hz := S.moduleCatHomologyIso.inv_hom_id_apply
+        ((LinearMap.range S.moduleCatToCycles).mkQ (a • z))
       rw [ha, map_zero] at hz
       exact hz.symm
-    -- The local `q` is definitionally the quotient projection of `z`; expose that single
-    -- application so `Submodule.Quotient.mk_eq_zero` can characterize its kernel.
-    change (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0 at hq
     rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero] at hq
     obtain ⟨b, hb⟩ := hq
     exact ⟨b, congrArg Subtype.val hb⟩
@@ -189,9 +194,7 @@ theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
       refine ⟨b, ?_⟩
       apply Subtype.ext
       exact hb
-    have hq : a • q = 0 := by
-      -- As above, this is the concrete application rule for the quotient projection defining `q`.
-      change (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0
+    have hq : (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0 := by
       rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero]
       exact hz
     exact (congrArg (fun x => S.moduleCatHomologyIso.inv x) hq).trans (map_zero _)
@@ -212,8 +215,6 @@ theorem latticeHomologyCycleMap_surjective (P : PlumbingGraph V)
   intro y
   let S := P.latticeShortComplex k
   let z : LinearMap.ker S.g.hom := ⟨c, (P.latticeShortComplex_g_hom_apply k c).trans hc⟩
-  let q : S.moduleCatLeftHomologyData.H :=
-    (LinearMap.range S.moduleCatToCycles).mkQ z
   -- Every homology class is the class of an honest cycle.
   obtain ⟨w, hw⟩ := Submodule.mkQ_surjective (LinearMap.range S.moduleCatToCycles)
     (S.moduleCatHomologyIso.hom y)
@@ -224,12 +225,12 @@ theorem latticeHomologyCycleMap_surjective (P : PlumbingGraph V)
   have hmem : w - a • z ∈ LinearMap.range S.moduleCatToCycles :=
     ⟨b, Subtype.ext ((P.latticeShortComplex_f_hom_apply k b).trans hb)⟩
   refine ⟨a, ?_⟩
-  -- `moduleCatHomologyIso` is Mathlib's interface from abstract homology to the explicit
-  -- kernel/range quotient; unfolding the local cycle map is what makes it usable here.
-  change S.moduleCatHomologyIso.inv (a • q) = y
-  have hq : a • q = S.moduleCatHomologyIso.hom y := by
+  rw [latticeHomologyCycleMap_apply]
+  change S.moduleCatHomologyIso.inv
+      ((LinearMap.range S.moduleCatToCycles).mkQ (a • z)) = y
+  have hq : (LinearMap.range S.moduleCatToCycles).mkQ (a • z) =
+      S.moduleCatHomologyIso.hom y := by
     refine Eq.trans ?_ hw
-    change (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = _
     rw [Submodule.mkQ_apply, Submodule.mkQ_apply, Submodule.Quotient.eq]
     exact neg_sub w (a • z) ▸ Submodule.neg_mem _ hmem
   rw [hq]

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -176,15 +176,20 @@ theorem latticeHomologyCycleMap_apply_eq_zero_iff (P : PlumbingGraph V)
       a • c ∈ LinearMap.range (P.latticeDifferential k) := by
   let S := P.latticeShortComplex k
   let z : LinearMap.ker S.g.hom := ⟨c, (P.latticeShortComplex_g_hom_apply k c).trans hc⟩
-  rw [latticeHomologyCycleMap_apply]
-  change S.moduleCatHomologyIso.inv
-      ((LinearMap.range S.moduleCatToCycles).mkQ (a • z)) = 0 ↔ _
+  have hmap : P.latticeHomologyCycleMap k c hc a =
+      S.moduleCatHomologyIso.inv
+        ((LinearMap.range S.moduleCatToCycles).mkQ (a • z)) := by
+    simpa only [S, z] using P.latticeHomologyCycleMap_apply k c hc a
+  rw [hmap]
   constructor
   · intro ha
+    have ha' : S.moduleCatHomologyIso.inv
+        ((LinearMap.range S.moduleCatToCycles).mkQ (a • z)) = (0 : S.homology) := by
+      exact ha
     have hq : (LinearMap.range S.moduleCatToCycles).mkQ (a • z) = 0 := by
       have hz := S.moduleCatHomologyIso.inv_hom_id_apply
         ((LinearMap.range S.moduleCatToCycles).mkQ (a • z))
-      rw [ha, map_zero] at hz
+      rw [ha', map_zero] at hz
       exact hz.symm
     rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero] at hq
     obtain ⟨b, hb⟩ := hq
@@ -225,9 +230,11 @@ theorem latticeHomologyCycleMap_surjective (P : PlumbingGraph V)
   have hmem : w - a • z ∈ LinearMap.range S.moduleCatToCycles :=
     ⟨b, Subtype.ext ((P.latticeShortComplex_f_hom_apply k b).trans hb)⟩
   refine ⟨a, ?_⟩
-  rw [latticeHomologyCycleMap_apply]
-  change S.moduleCatHomologyIso.inv
-      ((LinearMap.range S.moduleCatToCycles).mkQ (a • z)) = y
+  have hmap : P.latticeHomologyCycleMap k c hc a =
+      S.moduleCatHomologyIso.inv
+        ((LinearMap.range S.moduleCatToCycles).mkQ (a • z)) := by
+    simpa only [S, z] using P.latticeHomologyCycleMap_apply k c hc a
+  rw [hmap]
   have hq : (LinearMap.range S.moduleCatToCycles).mkQ (a • z) =
       S.moduleCatHomologyIso.hom y := by
     refine Eq.trans ?_ hw

--- a/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
@@ -1,0 +1,529 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.Tower
+import TauCeti.LowDimTopology.Plumbing.Cube.Weight.Recursion
+import TauCeti.LowDimTopology.Plumbing.DiagonalDominance
+import TauCeti.LowDimTopology.Plumbing.TopDegree
+import TauCeti.LowDimTopology.Plumbing.Weight.Polarization
+
+/-!
+# The lattice homology of a one-vertex plumbing
+
+Némethi's lattice homology of a plumbing graph `P` with a characteristic covector `k` is the
+homology of the free `𝔽₂[U]`-module on the cubes of the lattice `V → ℤ`, each codimension-one
+face in the differential weighted by the drop in the characteristic cube weight. This file
+computes the total, ungraded homology of that complex when `P` has a single vertex, the smallest
+plumbing whose differential is not forced to vanish: the answer is a single `U`-tower,
+
+`ℍ(P, k) ≅ 𝔽₂[U]`,
+
+for every characteristic covector, hence for every spin^c structure. A one-vertex plumbing with
+framing `w < 0` is the disc bundle over the sphere with Euler number `w`, whose boundary is the
+lens space `L(-w, 1)`, and one tower per spin^c structure is the value the literature records for
+`HF⁻` of a lens space. Up to now the only computed lattice homology was that of the zero-vertex
+plumbing, where the differential vanishes for lack of directions.
+
+Two facts drive the computation. First, the lattice is `ℤ`, so the only cubes are lattice points
+and edges; the lattice differential is injective on chains of edges, so every cycle is a chain of
+lattice points. Second, the characteristic weight is a convex quadratic in the single lattice
+coordinate: its first difference `χ_k(x + E) - χ_k(x) = -(k_v + w) / 2 - w x` increases with `x`
+because `w < 0`, so from a minimizer `x₀` the weight is nondecreasing to the right and
+nonincreasing to the left. An edge therefore relates its two endpoints by
+`[x'] = U ^ (χ_k(x') - χ_k(x)) [x]` with `x` the lighter endpoint, and inducting in both
+directions along the lattice writes every lattice point as `U ^ (χ_k(x) - min χ_k)` times `[x₀]`.
+So the class of `x₀` generates lattice homology, and the augmentation already used for the
+`U`-tower shows it generates freely.
+
+## Main definitions
+
+* `TauCeti.PlumbingGraph.latticeHomologyEquivCoefficient`: the lattice homology of a one-vertex
+  negative-definite plumbing, identified with `𝔽₂[U]`.
+* `TauCeti.oneVertexPlumbing`: the plumbing graph with a single vertex of a given framing.
+
+## Main results
+
+* `TauCeti.PlumbingCube.characteristicWeight_edge`,
+  `TauCeti.PlumbingCube.characteristicLowerFaceExponent_edge`,
+  `TauCeti.PlumbingCube.characteristicUpperFaceExponent_edge`: the weight of a one-dimensional
+  cube and the two `U`-exponents its faces carry.
+* `TauCeti.PlumbingGraph.latticeDifferential_single_edge`: the lattice differential of an edge.
+* `TauCeti.PlumbingGraph.single_add_sub_smul_single_mem_range` and
+  `TauCeti.PlumbingGraph.single_sub_smul_single_add_mem_range`: crossing an edge multiplies the
+  class of its lighter endpoint by the intervening power of `U`.
+* `TauCeti.PlumbingGraph.directions_eq_empty_of_latticeDifferential_eq_zero`: on a rank-one
+  lattice every cycle is a chain of lattice points.
+* `TauCeti.PlumbingGraph.single_sub_smul_single_mem_range`: every lattice point of a rank-one
+  negative-definite plumbing lattice is a `U`-multiple of a minimal-weight one, modulo boundaries.
+* `TauCeti.PlumbingGraph.latticeHomologyCycleMap_bijective`: the cycle map of any augmentation-one
+  cycle is an isomorphism `𝔽₂[U] ≅ ℍ(P, k)`.
+* `TauCeti.oneVertexPlumbingLatticeHomologyEquiv`: that isomorphism for the explicit one-vertex
+  plumbing of negative framing.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"),
+whose acceptance criterion asks for the lattice homology of a concrete negative-definite plumbing,
+matched against the literature. The complex and its weights follow A. Némethi,
+[arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+namespace PlumbingChain
+
+variable {V : Type u}
+
+/-- Negation is trivial on plumbing chains, whose coefficients have characteristic two. -/
+private theorem neg_eq_self (c : PlumbingChain V) : -c = c := by
+  rw [← neg_one_smul PlumbingCoefficient c, CharTwo.neg_eq, one_smul]
+
+/-- Subtraction of plumbing chains is addition, the coefficients having characteristic two. -/
+private theorem sub_eq_add (c d : PlumbingChain V) : c - d = c + d := by
+  rw [sub_eq_add_neg, neg_eq_self]
+
+/-- Telescoping one step: comparing `a` with a multiple of `c` splits into the comparison of `a`
+with a multiple of an intermediate chain `b` and that comparison for `b` and `c`. -/
+private theorem sub_mul_smul (r s : PlumbingCoefficient) (a b c : PlumbingChain V) :
+    a - (r * s) • c = (a - r • b) + r • (b - s • c) := by
+  rw [smul_sub, smul_smul]
+  abel
+
+end PlumbingChain
+
+/-! ### The weights of an edge -/
+
+namespace PlumbingCube
+
+variable {V : Type u} [DecidableEq V] [Fintype V] (P : PlumbingGraph V)
+  (k : P.characteristicVectors) (x : V → ℤ) (v : V)
+
+/-- The characteristic cube weight of an edge is the larger of its two endpoint weights. -/
+theorem characteristicWeight_edge :
+    characteristicWeight P k ⟨x, {v}⟩ =
+      max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) := by
+  rw [characteristicWeight_mk,
+    P.characteristicCubeWeight_eq_max_erase k x (Finset.mem_singleton_self v),
+    Finset.erase_singleton, PlumbingGraph.characteristicCubeWeight_empty,
+    PlumbingGraph.characteristicCubeWeight_empty]
+
+/-- The lower-face exponent of an edge: the drop from the edge weight to the weight of its base
+point. -/
+theorem characteristicLowerFaceExponent_edge :
+    characteristicLowerFaceExponent P k ⟨x, {v}⟩ v =
+      (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
+        P.characteristicWeight k x).toNat := by
+  have h := characteristicLowerFaceExponent_natCast P k ⟨x, {v}⟩ v
+  rw [characteristicWeight_edge] at h
+  simp only [eraseDirection_mk, Finset.erase_singleton, characteristicWeight_mk,
+    PlumbingGraph.characteristicCubeWeight_empty] at h
+  omega
+
+/-- The upper-face exponent of an edge: the drop from the edge weight to the weight of its far
+endpoint. -/
+theorem characteristicUpperFaceExponent_edge :
+    characteristicUpperFaceExponent P k
+        (⟨x, {v}⟩ : PlumbingCube V) (Finset.mem_singleton_self v) =
+      (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
+        P.characteristicWeight k (x + Pi.single v 1)).toNat := by
+  have h := characteristicUpperFaceExponent_natCast P k
+    (⟨x, {v}⟩ : PlumbingCube V) (Finset.mem_singleton_self v)
+  rw [characteristicWeight_edge] at h
+  simp only [upperFace_mk, Finset.erase_singleton, characteristicWeight_mk,
+    PlumbingGraph.characteristicCubeWeight_empty] at h
+  omega
+
+end PlumbingCube
+
+namespace PlumbingGraph
+
+variable {V : Type u} [DecidableEq V] [Fintype V]
+
+/-! ### The differential of an edge -/
+
+section Edge
+
+variable (P : PlumbingGraph V) (k : P.characteristicVectors) (x : V → ℤ) (v : V)
+
+/-- The lattice differential of an edge generator: each endpoint appears, weighted by the drop
+from the edge weight to that endpoint's weight. One of the two exponents is always zero. -/
+theorem latticeDifferential_single_edge :
+    P.latticeDifferential k (Finsupp.single ⟨x, {v}⟩ 1) =
+      Finsupp.single (⟨x, ∅⟩ : PlumbingCube V)
+          (Polynomial.X ^
+            (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
+              P.characteristicWeight k x).toNat) +
+        Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V)
+          (Polynomial.X ^
+            (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
+              P.characteristicWeight k (x + Pi.single v 1)).toNat) := by
+  classical
+  rw [latticeDifferential_single, one_smul, latticeDifferentialOnGenerator_def,
+    Finset.sum_eq_single_of_mem (⟨v, Finset.mem_singleton_self v⟩ :
+      {w // w ∈ ({v} : Finset V)}) (Finset.mem_attach _ _)
+      (fun w _ hw => absurd (Subtype.ext (Finset.mem_singleton.mp w.property)) hw)]
+  rw [PlumbingCube.lowerFace_mk, PlumbingCube.upperFace_mk, Finset.erase_singleton,
+    PlumbingCube.characteristicLowerFaceExponent_edge,
+    PlumbingCube.characteristicUpperFaceExponent_edge]
+
+end Edge
+
+/-! ### Moving between adjacent lattice points -/
+
+section Step
+
+variable (P : PlumbingGraph V) (k : P.characteristicVectors) (x : V → ℤ) (v : V)
+
+/-- Crossing an edge towards a lattice point of no smaller weight: the far endpoint is, modulo
+boundaries, `U ^ d` times the near one, where `d` is the gap between their weights. -/
+theorem single_add_sub_smul_single_mem_range
+    (h : P.characteristicWeight k x ≤ P.characteristicWeight k (x + Pi.single v 1)) :
+    Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V) 1 -
+        (Polynomial.X : PlumbingCoefficient) ^ (P.characteristicWeight k (x + Pi.single v 1) -
+            P.characteristicWeight k x).toNat •
+          Finsupp.single (⟨x, ∅⟩ : PlumbingCube V) 1 ∈
+      LinearMap.range (P.latticeDifferential k) := by
+  refine ⟨Finsupp.single ⟨x, {v}⟩ 1, ?_⟩
+  rw [latticeDifferential_single_edge, max_eq_right h, sub_self, Int.toNat_zero, pow_zero,
+    PlumbingChain.sub_eq_add, Finsupp.smul_single, smul_eq_mul, mul_one]
+  exact add_comm _ _
+
+/-- Crossing an edge away from a lattice point of no larger weight: the near endpoint is, modulo
+boundaries, `U ^ d` times the far one, where `d` is the gap between their weights. -/
+theorem single_sub_smul_single_add_mem_range
+    (h : P.characteristicWeight k (x + Pi.single v 1) ≤ P.characteristicWeight k x) :
+    Finsupp.single (⟨x, ∅⟩ : PlumbingCube V) 1 -
+        (Polynomial.X : PlumbingCoefficient) ^ (P.characteristicWeight k x -
+            P.characteristicWeight k (x + Pi.single v 1)).toNat •
+          Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V) 1 ∈
+      LinearMap.range (P.latticeDifferential k) := by
+  refine ⟨Finsupp.single ⟨x, {v}⟩ 1, ?_⟩
+  rw [latticeDifferential_single_edge, max_eq_left h, sub_self, Int.toNat_zero, pow_zero,
+    PlumbingChain.sub_eq_add, Finsupp.smul_single, smul_eq_mul, mul_one]
+
+end Step
+
+/-! ### Chains of lattice points -/
+
+/-- A chain supported in cubical degree zero is a cycle: a lattice point has no faces. -/
+theorem latticeDifferential_eq_zero_of_forall_directions_eq_empty (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {c : PlumbingChain V}
+    (hc : ∀ C ∈ c.support, C.directions = ∅) : P.latticeDifferential k c = 0 := by
+  rw [latticeDifferential_apply, Finsupp.sum]
+  refine Finset.sum_eq_zero fun C hC => ?_
+  rw [P.latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty k (hc C hC), smul_zero]
+
+/-! ### The rank-one lattice -/
+
+section Unique
+
+variable [Unique V] (P : PlumbingGraph V) (k : P.characteristicVectors)
+
+/-- On a rank-one lattice the first difference of the characteristic weight along the unique basis
+direction is an affine function of the lattice coordinate, with slope the framing. -/
+private theorem characteristicWeight_add_single_sub (x : V → ℤ) :
+    P.characteristicWeight k (x + Pi.single default 1) - P.characteristicWeight k x =
+      -((k.val default + P.weight default) / 2) - x default * P.weight default := by
+  have hsum : (∑ i, x i * P.intersectionMatrix i default) = x default * P.weight default := by
+    rw [Finset.univ_unique, Finset.sum_singleton, intersectionMatrix_diag]
+  rw [characteristicWeight_add_single, hsum]
+  ring
+
+/-- The first difference of the characteristic weight is monotone along the lattice, since the
+framing of a negative-definite plumbing is negative. -/
+private theorem characteristicWeight_add_single_sub_le (hw : P.weight default < 0) (x y : V → ℤ)
+    (hxy : x default ≤ y default) :
+    P.characteristicWeight k (x + Pi.single default 1) - P.characteristicWeight k x ≤
+      P.characteristicWeight k (y + Pi.single default 1) - P.characteristicWeight k y := by
+  rw [characteristicWeight_add_single_sub, characteristicWeight_add_single_sub]
+  have h1 : (0 : ℤ) ≤ y default - x default := by omega
+  have h2 : (0 : ℤ) < -P.weight default := by omega
+  nlinarith
+
+variable {x₀ : V → ℤ}
+  (hmin : ∀ y : V → ℤ, P.characteristicWeight k x₀ ≤ P.characteristicWeight k y)
+
+include hmin in
+/-- Beyond a minimizer the characteristic weight is nondecreasing. -/
+private theorem characteristicWeight_le_add_single (hw : P.weight default < 0) {x : V → ℤ}
+    (hle : x₀ default ≤ x default) :
+    P.characteristicWeight k x ≤ P.characteristicWeight k (x + Pi.single default 1) := by
+  have h0 : 0 ≤ P.characteristicWeight k (x₀ + Pi.single default 1) -
+      P.characteristicWeight k x₀ := sub_nonneg.mpr (hmin _)
+  have := characteristicWeight_add_single_sub_le P k hw x₀ x hle
+  linarith
+
+include hmin in
+/-- Before a minimizer the characteristic weight is nonincreasing. -/
+private theorem characteristicWeight_add_single_le (hw : P.weight default < 0) {x : V → ℤ}
+    (hlt : x default < x₀ default) :
+    P.characteristicWeight k (x + Pi.single default 1) ≤ P.characteristicWeight k x := by
+  have hz : (x₀ - Pi.single default (1 : ℤ)) + Pi.single default 1 = x₀ := sub_add_cancel _ _
+  have hzd : (x₀ - Pi.single default (1 : ℤ) : V → ℤ) default = x₀ default - 1 := by simp
+  have h0 : P.characteristicWeight k ((x₀ - Pi.single default (1 : ℤ)) + Pi.single default 1) -
+      P.characteristicWeight k (x₀ - Pi.single default (1 : ℤ)) ≤ 0 := by
+    rw [hz]
+    linarith [hmin (x₀ - Pi.single default (1 : ℤ))]
+  have := characteristicWeight_add_single_sub_le P k hw x (x₀ - Pi.single default (1 : ℤ))
+    (by omega)
+  linarith
+
+include hmin in
+/-- The lattice-point generation statement, as an induction on the lattice coordinate: from a
+minimizer the characteristic weight increases monotonically in both directions, so each step
+across an edge multiplies the class of the previous point by the intervening `U`-power. -/
+private theorem single_sub_smul_single_mem_range_aux (hw : P.weight default < 0) :
+    ∀ n : ℤ, ∀ y : V → ℤ, y default = n →
+      Finsupp.single (⟨y, ∅⟩ : PlumbingCube V) 1 -
+          (Polynomial.X : PlumbingCoefficient) ^
+              (P.characteristicWeight k y - P.characteristicWeight k x₀).toNat •
+            Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1 ∈
+        LinearMap.range (P.latticeDifferential k) := by
+  have hbase : ∀ y : V → ℤ, y default = x₀ default →
+      Finsupp.single (⟨y, ∅⟩ : PlumbingCube V) 1 -
+          (Polynomial.X : PlumbingCoefficient) ^
+              (P.characteristicWeight k y - P.characteristicWeight k x₀).toNat •
+            Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1 ∈
+        LinearMap.range (P.latticeDifferential k) := by
+    intro y hy
+    have hyx : y = x₀ := funext fun i => by rw [Subsingleton.elim i default]; exact hy
+    rw [hyx, sub_self, Int.toNat_zero, pow_zero, one_smul, sub_self]
+    exact Submodule.zero_mem _
+  intro n
+  rcases le_total (x₀ default) n with hle | hle
+  · induction n, hle using Int.leInduction with
+    | base => exact hbase
+    | succ n hn ih =>
+      intro y hy
+      have hzd : (y - Pi.single default (1 : ℤ) : V → ℤ) default = n := by simp [hy]
+      have hzy : y - Pi.single default (1 : ℤ) + Pi.single default 1 = y := sub_add_cancel _ _
+      have hle' : P.characteristicWeight k (y - Pi.single default (1 : ℤ)) ≤
+          P.characteristicWeight k (y - Pi.single default (1 : ℤ) + Pi.single default 1) :=
+        characteristicWeight_le_add_single P k hmin hw (by rw [hzd]; exact hn)
+      have hminz := hmin (y - Pi.single default (1 : ℤ))
+      have hsum := Submodule.add_mem _
+        (single_add_sub_smul_single_mem_range P k (y - Pi.single default (1 : ℤ)) default hle')
+        (Submodule.smul_mem (LinearMap.range (P.latticeDifferential k))
+          ((Polynomial.X : PlumbingCoefficient) ^
+            (P.characteristicWeight k (y - Pi.single default (1 : ℤ) + Pi.single default 1) -
+              P.characteristicWeight k (y - Pi.single default (1 : ℤ))).toNat)
+          (ih (y - Pi.single default (1 : ℤ)) hzd))
+      rw [← PlumbingChain.sub_mul_smul, ← pow_add,
+        show (P.characteristicWeight k (y - Pi.single default (1 : ℤ) + Pi.single default 1) -
+              P.characteristicWeight k (y - Pi.single default (1 : ℤ))).toNat +
+            (P.characteristicWeight k (y - Pi.single default (1 : ℤ)) -
+              P.characteristicWeight k x₀).toNat =
+          (P.characteristicWeight k (y - Pi.single default (1 : ℤ) + Pi.single default 1) -
+            P.characteristicWeight k x₀).toNat from by omega] at hsum
+      rwa [hzy] at hsum
+  · induction n, hle using Int.leInductionDown with
+    | base => exact hbase
+    | pred n hn ih =>
+      intro y hy
+      have hyd : (y + Pi.single default (1 : ℤ) : V → ℤ) default = n := by simp [hy]
+      have hle' : P.characteristicWeight k (y + Pi.single default 1) ≤
+          P.characteristicWeight k y :=
+        characteristicWeight_add_single_le P k hmin hw (by omega)
+      have hminz := hmin (y + Pi.single default (1 : ℤ))
+      have hsum := Submodule.add_mem _
+        (single_sub_smul_single_add_mem_range P k y default hle')
+        (Submodule.smul_mem (LinearMap.range (P.latticeDifferential k))
+          ((Polynomial.X : PlumbingCoefficient) ^
+            (P.characteristicWeight k y -
+              P.characteristicWeight k (y + Pi.single default 1)).toNat)
+          (ih (y + Pi.single default (1 : ℤ)) hyd))
+      rwa [← PlumbingChain.sub_mul_smul, ← pow_add,
+        show (P.characteristicWeight k y -
+              P.characteristicWeight k (y + Pi.single default 1)).toNat +
+            (P.characteristicWeight k (y + Pi.single default 1) -
+              P.characteristicWeight k x₀).toNat =
+          (P.characteristicWeight k y - P.characteristicWeight k x₀).toNat from by omega] at hsum
+
+include hmin in
+/-- Modulo boundaries, a chain of lattice points is its augmentation times a fixed minimal-weight
+lattice point. -/
+private theorem sub_augmentation_smul_single_mem_range_aux (hw : P.weight default < 0)
+    (hx₀ : P.characteristicWeight k x₀ = P.sInfCharacteristicWeight k) {c : PlumbingChain V}
+    (hc : ∀ C ∈ c.support, C.directions = ∅) :
+    c - P.latticeAugmentation k c • Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1 ∈
+      LinearMap.range (P.latticeDifferential k) := by
+  classical
+  set F : PlumbingChain V →ₗ[PlumbingCoefficient] PlumbingChain V :=
+    LinearMap.id - (LinearMap.toSpanSingleton PlumbingCoefficient (PlumbingChain V)
+      (Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1)).comp (P.latticeAugmentation k) with hF
+  have hFapply : ∀ z : PlumbingChain V,
+      F z = z - P.latticeAugmentation k z •
+        Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1 := by
+    intro z
+    rw [hF]
+    rfl
+  have hcsum : F c = c.sum fun C a => F (Finsupp.single C a) := by
+    rw [← map_finsuppSum, Finsupp.sum_single]
+  rw [← hFapply c, hcsum, Finsupp.sum]
+  refine Submodule.sum_mem _ fun C hC => ?_
+  rw [← Finsupp.smul_single_one C (c C), map_smul]
+  refine Submodule.smul_mem _ _ ?_
+  rw [hFapply, latticeAugmentation_single,
+    P.latticeAugmentationCoefficient_of_directions_eq_empty k (hc C hC), one_mul]
+  have hbase := single_sub_smul_single_mem_range_aux P k hmin hw (C.base default) C.base rfl
+  rw [hx₀, ← (PlumbingCube.ext rfl (hc C hC) : C = ⟨C.base, ∅⟩)] at hbase
+  exact hbase
+
+end Unique
+
+/-! ### Cycles of a rank-one lattice -/
+
+/-- On a rank-one plumbing lattice every cycle is a chain of lattice points: the only cubes of
+positive dimension are the edges, and the lattice differential is injective on chains of edges. -/
+theorem directions_eq_empty_of_latticeDifferential_eq_zero [Unique V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {c : PlumbingChain V} (hc : P.latticeDifferential k c = 0)
+    {C : PlumbingCube V} (hC : C ∈ c.support) : C.directions = ∅ := by
+  classical
+  by_contra hne
+  set p : PlumbingCube V → Prop := fun D => D.directions = ∅
+  have hzero : P.latticeDifferential k (c.filter p) = 0 := by
+    refine P.latticeDifferential_eq_zero_of_forall_directions_eq_empty k fun D hD => ?_
+    rw [Finsupp.support_filter, Finset.mem_filter] at hD
+    exact hD.2
+  have hdir : ∀ D ∈ (c.filter fun D => ¬ p D).support, D.directions = (Finset.univ : Finset V) := by
+    intro D hD
+    rw [Finsupp.support_filter, Finset.mem_filter] at hD
+    rw [Finset.univ_unique]
+    refine (Finset.subset_singleton_iff.mp ?_).resolve_left hD.2
+    rw [← Finset.univ_unique]
+    exact Finset.subset_univ D.directions
+  have hne' : (c.filter fun D => ¬ p D) ≠ 0 := by
+    intro h0
+    have : C ∈ (c.filter fun D => ¬ p D).support := by
+      rw [Finsupp.support_filter, Finset.mem_filter]
+      exact ⟨hC, hne⟩
+    rw [h0] at this
+    simp at this
+  refine P.latticeDifferential_ne_zero_of_directions_eq k (Finset.mem_univ (default : V))
+    hdir hne' ?_
+  have hsum := Finsupp.filter_add_filter_not c p
+  rw [← hsum, map_add, hzero, zero_add] at hc
+  exact hc
+
+/-! ### The lattice homology of a one-vertex plumbing -/
+
+section Homology
+
+variable [Unique V] (P : PlumbingGraph V) (k : P.characteristicVectors)
+
+/-- Every lattice point of a rank-one negative-definite plumbing lattice is, modulo boundaries,
+`U ^ (χ_k(x) - min χ_k)` times a fixed lattice point of minimal weight. -/
+theorem single_sub_smul_single_mem_range (h : P.IsNegativeDefinite) {x₀ : V → ℤ}
+    (hx₀ : P.characteristicWeight k x₀ = P.sInfCharacteristicWeight k) (x : V → ℤ) :
+    Finsupp.single (⟨x, ∅⟩ : PlumbingCube V) 1 -
+        (Polynomial.X : PlumbingCoefficient) ^
+            (P.characteristicWeight k x - P.sInfCharacteristicWeight k).toNat •
+          Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1 ∈
+      LinearMap.range (P.latticeDifferential k) := by
+  have hmin : ∀ y : V → ℤ, P.characteristicWeight k x₀ ≤ P.characteristicWeight k y := fun y => by
+    rw [hx₀]
+    exact P.sInfCharacteristicWeight_le h k y
+  have hbase := single_sub_smul_single_mem_range_aux P k hmin
+    (IsNegativeDefinite.weight_neg P h default) (x default) x rfl
+  rwa [hx₀] at hbase
+
+/-- On a rank-one negative-definite plumbing every cycle differs from a multiple of a fixed
+minimal-weight lattice point by a boundary: cycles are chains of lattice points, and each lattice
+point is a `U`-multiple of the minimal one. -/
+theorem sub_augmentation_smul_single_mem_range (h : P.IsNegativeDefinite) {x₀ : V → ℤ}
+    (hx₀ : P.characteristicWeight k x₀ = P.sInfCharacteristicWeight k) {c : PlumbingChain V}
+    (hc : P.latticeDifferential k c = 0) :
+    c - P.latticeAugmentation k c • Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1 ∈
+      LinearMap.range (P.latticeDifferential k) := by
+  have hmin : ∀ y : V → ℤ, P.characteristicWeight k x₀ ≤ P.characteristicWeight k y := fun y => by
+    rw [hx₀]
+    exact P.sInfCharacteristicWeight_le h k y
+  exact sub_augmentation_smul_single_mem_range_aux P k hmin
+    (IsNegativeDefinite.weight_neg P h default) hx₀
+    fun C hC => P.directions_eq_empty_of_latticeDifferential_eq_zero k hc hC
+
+/-- **The lattice homology of a one-vertex negative-definite plumbing is a single `U`-tower.**
+Any cycle of augmentation one has bijective cycle map: injectivity is the tower of
+`latticeHomologyCycleMap_injective`, and surjectivity holds because every cycle is a chain of
+lattice points and every lattice point is a `U`-multiple of a minimal-weight one. -/
+theorem latticeHomologyCycleMap_bijective (h : P.IsNegativeDefinite) (c : PlumbingChain V)
+    (hc : P.latticeDifferential k c = 0) (hone : P.latticeAugmentation k c = 1) :
+    Function.Bijective (P.latticeHomologyCycleMap k c hc) := by
+  obtain ⟨x₀, hx₀⟩ := P.exists_characteristicWeight_eq_sInfCharacteristicWeight h k
+  refine ⟨P.latticeHomologyCycleMap_injective h k c hc hone,
+    P.latticeHomologyCycleMap_surjective k c hc fun z hz => ⟨P.latticeAugmentation k z, ?_⟩⟩
+  have hz₀ := sub_augmentation_smul_single_mem_range P k h hx₀ hz
+  have hc₀ := sub_augmentation_smul_single_mem_range P k h hx₀ hc
+  rw [hone, one_smul] at hc₀
+  have hsplit : z - P.latticeAugmentation k z • c =
+      (z - P.latticeAugmentation k z • Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1) -
+        P.latticeAugmentation k z •
+          (c - Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1) := by
+    rw [smul_sub]
+    abel
+  rw [hsplit]
+  exact Submodule.sub_mem _ hz₀ (Submodule.smul_mem _ _ hc₀)
+
+/-- The lattice homology of a one-vertex negative-definite plumbing is free of rank one over
+`𝔽₂[U]`, generated by the class of a lattice point of minimal characteristic weight. -/
+noncomputable def latticeHomologyEquivCoefficient (h : P.IsNegativeDefinite) :
+    PlumbingCoefficient ≃ₗ[PlumbingCoefficient] P.latticeHomology k :=
+  LinearEquiv.ofBijective
+    (P.latticeHomologyCycleMap k (P.exists_cycle_latticeAugmentation_eq_one h k).choose
+      (P.exists_cycle_latticeAugmentation_eq_one h k).choose_spec.1)
+    (latticeHomologyCycleMap_bijective P k h _ _
+      (P.exists_cycle_latticeAugmentation_eq_one h k).choose_spec.2)
+
+end Homology
+
+end PlumbingGraph
+
+/-! ### The one-vertex plumbings -/
+
+/-- The one-vertex plumbing with framing `w`: a single sphere of self-intersection `w`. For
+`w < 0` its boundary three-manifold is the lens space `L(-w, 1)`. -/
+def oneVertexPlumbing (w : ℤ) : PlumbingGraph (Fin 1) where
+  toSimpleGraph := ⊥
+  decidableAdj := inferInstance
+  weight := fun _ => w
+
+/-- The intersection matrix of a one-vertex plumbing is its framing. -/
+@[simp]
+theorem oneVertexPlumbing_intersectionMatrix (w : ℤ) :
+    (oneVertexPlumbing w).intersectionMatrix = !![w] := by
+  ext i j
+  fin_cases i
+  fin_cases j
+  simp [oneVertexPlumbing]
+
+/-- A one-vertex plumbing with negative framing is negative definite. -/
+theorem oneVertexPlumbing_isNegativeDefinite {w : ℤ} (hw : w < 0) :
+    (oneVertexPlumbing w).IsNegativeDefinite := by
+  refine PlumbingGraph.isNegativeDefinite_of_degree_lt_neg_weight _ fun i => ?_
+  have hnb : (oneVertexPlumbing w).toSimpleGraph.neighborFinset i = ∅ := by
+    rw [Finset.eq_empty_iff_forall_notMem]
+    intro j hj
+    rw [SimpleGraph.mem_neighborFinset] at hj
+    simp [oneVertexPlumbing] at hj
+  have hdeg : (oneVertexPlumbing w).toSimpleGraph.degree i = 0 := by
+    rw [SimpleGraph.degree, hnb, Finset.card_empty]
+  rw [hdeg]
+  simpa [oneVertexPlumbing] using hw
+
+/-- The lattice homology of the one-vertex plumbing with negative framing `w` is, in every
+spin^c structure, a free `𝔽₂[U]`-module of rank one: exactly one `U`-tower, which is the value
+the literature records for the lens space `L(-w, 1)`. -/
+noncomputable def oneVertexPlumbingLatticeHomologyEquiv {w : ℤ} (hw : w < 0)
+    (k : (oneVertexPlumbing w).characteristicVectors) :
+    PlumbingCoefficient ≃ₗ[PlumbingCoefficient] (oneVertexPlumbing w).latticeHomology k :=
+  PlumbingGraph.latticeHomologyEquivCoefficient _ k (oneVertexPlumbing_isNegativeDefinite hw)
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
@@ -330,13 +330,14 @@ theorem sub_augmentation_smul_single_mem_range_of_unique (h : P.IsNegativeDefini
     fun C hC => P.directions_eq_empty_of_latticeDifferential_eq_zero_of_unique k hc hC
 
 /-- **The lattice homology of a one-vertex negative-definite plumbing is a single `U`-tower.**
-Any cycle of augmentation one has bijective cycle map: injectivity is the tower of
-`latticeHomologyCycleMap_injective`, and surjectivity holds because every cycle is a chain of
-lattice points and every lattice point is a `U`-multiple of a minimal-weight one. -/
+The cycle map of any augmentation-one cycle is a bijection. -/
 theorem latticeHomologyCycleMap_bijective_of_unique (h : P.IsNegativeDefinite)
     (c : PlumbingChain V)
     (hc : P.latticeDifferential k c = 0) (hone : P.latticeAugmentation k c = 1) :
     Function.Bijective (P.latticeHomologyCycleMap k c hc) := by
+  -- Injectivity is the `U`-tower of `latticeHomologyCycleMap_injective`; surjectivity holds
+  -- because every cycle is a chain of lattice points and every lattice point is a `U`-multiple
+  -- of a minimal-weight one.
   obtain ⟨x₀, hx₀⟩ := P.exists_characteristicWeight_eq_sInfCharacteristicWeight h k
   refine ⟨P.latticeHomologyCycleMap_injective h k c hc hone,
     P.latticeHomologyCycleMap_surjective k c hc fun z hz => ⟨P.latticeAugmentation k z, ?_⟩⟩
@@ -399,6 +400,7 @@ theorem oneVertexPlumbing_toSimpleGraph (w : ℤ) :
   simp [oneVertexPlumbing]
 
 /-- The intersection matrix of a one-vertex plumbing is its framing. -/
+@[simp]
 theorem oneVertexPlumbing_intersectionMatrix (w : ℤ) :
     (oneVertexPlumbing w).intersectionMatrix = !![w] := by
   ext i j
@@ -407,7 +409,7 @@ theorem oneVertexPlumbing_intersectionMatrix (w : ℤ) :
   simp [oneVertexPlumbing]
 
 /-- A one-vertex plumbing with negative framing is negative definite. -/
-theorem oneVertexPlumbing_isNegativeDefinite {w : ℤ} (hw : w < 0) :
+theorem isNegativeDefinite_oneVertexPlumbing {w : ℤ} (hw : w < 0) :
     (oneVertexPlumbing w).IsNegativeDefinite := by
   refine PlumbingGraph.isNegativeDefinite_of_degree_lt_neg_weight _ fun i => ?_
   have hdeg : (oneVertexPlumbing w).toSimpleGraph.degree i = 0 := by
@@ -423,7 +425,7 @@ the lens-space computation of Ozsváth–Szabó,
 noncomputable def coefficientEquivOneVertexPlumbingLatticeHomology {w : ℤ} (hw : w < 0)
     (k : (oneVertexPlumbing w).characteristicVectors) :
     PlumbingCoefficient ≃ₗ[PlumbingCoefficient] (oneVertexPlumbing w).latticeHomology k :=
-  let h := oneVertexPlumbing_isNegativeDefinite hw
+  let h := isNegativeDefinite_oneVertexPlumbing hw
   let e := (oneVertexPlumbing w).exists_cycle_latticeAugmentation_eq_one h k
   PlumbingGraph.coefficientEquivLatticeHomologyOfUnique _ k h e.choose e.choose_spec.1
     e.choose_spec.2

--- a/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
@@ -17,16 +17,18 @@ import TauCeti.LowDimTopology.Plumbing.Weight.Polarization
 Némethi's lattice homology of a plumbing graph `P` with a characteristic covector `k` is the
 homology of the free `𝔽₂[U]`-module on the cubes of the lattice `V → ℤ`, each codimension-one
 face in the differential weighted by the drop in the characteristic cube weight. This file
-computes the total, ungraded homology of that complex when `P` has a single vertex, the smallest
-plumbing whose differential is not forced to vanish: the answer is a single `U`-tower,
+computes the total, ungraded homology of that complex when `P` has a single vertex of negative
+framing, the smallest plumbing whose differential is not forced to vanish: the answer is a single
+`U`-tower,
 
 `ℍ(P, k) ≅ 𝔽₂[U]`,
 
 for every characteristic covector, hence for every spin^c structure. A one-vertex plumbing with
 framing `w < 0` is the disc bundle over the sphere with Euler number `w`, whose boundary is the
-lens space `L(-w, 1)`, and one tower per spin^c structure is the value the literature records for
-`HF⁻` of a lens space. Up to now the only computed lattice homology was that of the zero-vertex
-plumbing, where the differential vanishes for lack of directions.
+lens space `L(-w, 1)`, and one tower per spin^c structure agrees with the lens-space computation
+of Ozsváth–Szabó, [arXiv:math/0203265](https://arxiv.org/abs/math/0203265). Up to now the only
+computed lattice homology was that of the zero-vertex plumbing, where the differential vanishes
+for lack of directions.
 
 Two facts drive the computation. First, the lattice is `ℤ`, so the only cubes are lattice points
 and edges; the lattice differential is injective on chains of edges, so every cycle is a chain of
@@ -41,35 +43,32 @@ So the class of `x₀` generates lattice homology, and the augmentation already 
 
 ## Main definitions
 
-* `TauCeti.PlumbingGraph.latticeHomologyEquivCoefficient`: the lattice homology of a one-vertex
-  negative-definite plumbing, identified with `𝔽₂[U]`.
+* `TauCeti.PlumbingGraph.coefficientEquivLatticeHomologyOfUnique`: the lattice homology of a
+  one-vertex negative-definite plumbing, identified with `𝔽₂[U]` using a specified
+  augmentation-one cycle.
 * `TauCeti.oneVertexPlumbing`: the plumbing graph with a single vertex of a given framing.
 
 ## Main results
 
-* `TauCeti.PlumbingCube.characteristicWeight_edge`,
-  `TauCeti.PlumbingCube.characteristicLowerFaceExponent_edge`,
-  `TauCeti.PlumbingCube.characteristicUpperFaceExponent_edge`: the weight of a one-dimensional
-  cube and the two `U`-exponents its faces carry.
-* `TauCeti.PlumbingGraph.latticeDifferential_single_edge`: the lattice differential of an edge.
-* `TauCeti.PlumbingGraph.single_add_sub_smul_single_mem_range` and
-  `TauCeti.PlumbingGraph.single_sub_smul_single_add_mem_range`: crossing an edge multiplies the
-  class of its lighter endpoint by the intervening power of `U`.
-* `TauCeti.PlumbingGraph.directions_eq_empty_of_latticeDifferential_eq_zero`: on a rank-one
-  lattice every cycle is a chain of lattice points.
-* `TauCeti.PlumbingGraph.single_sub_smul_single_mem_range`: every lattice point of a rank-one
-  negative-definite plumbing lattice is a `U`-multiple of a minimal-weight one, modulo boundaries.
-* `TauCeti.PlumbingGraph.latticeHomologyCycleMap_bijective`: the cycle map of any augmentation-one
-  cycle is an isomorphism `𝔽₂[U] ≅ ℍ(P, k)`.
-* `TauCeti.oneVertexPlumbingLatticeHomologyEquiv`: that isomorphism for the explicit one-vertex
-  plumbing of negative framing.
+* `TauCeti.PlumbingGraph.directions_eq_empty_of_latticeDifferential_eq_zero_of_unique`: on a
+  rank-one lattice every cycle is a chain of lattice points.
+* `TauCeti.PlumbingGraph.single_sub_smul_single_mem_range_of_unique`: every lattice point of a
+  rank-one negative-definite plumbing lattice is a `U`-multiple of a minimal-weight one, modulo
+  boundaries.
+* `TauCeti.PlumbingGraph.latticeHomologyCycleMap_bijective_of_unique`: for a rank-one
+  negative-definite plumbing, the cycle map of any augmentation-one cycle is an isomorphism
+  `𝔽₂[U] ≅ ℍ(P, k)`.
+* `TauCeti.coefficientEquivOneVertexPlumbingLatticeHomology`: that isomorphism for the explicit
+  one-vertex plumbing of negative framing.
 
 ## References
 
 This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"),
 whose acceptance criterion asks for the lattice homology of a concrete negative-definite plumbing,
 matched against the literature. The complex and its weights follow A. Némethi,
-[arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3.
+[arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3. The comparison computation for
+`HF⁻` of lens spaces is due to P. Ozsváth and Z. Szabó,
+[arXiv:math/0203265](https://arxiv.org/abs/math/0203265).
 -/
 
 public section
@@ -82,10 +81,6 @@ namespace PlumbingChain
 
 variable {V : Type u}
 
-/-- Subtraction of plumbing chains is addition, the coefficients having characteristic two. -/
-private theorem sub_eq_add (c d : PlumbingChain V) : c - d = c + d := by
-  rw [sub_eq_add_neg, ← neg_one_smul PlumbingCoefficient d, CharTwo.neg_eq, one_smul]
-
 /-- Telescoping one step: comparing `a` with a multiple of `c` splits into the comparison of `a`
 with a multiple of an intermediate chain `b` and that comparison for `b` and `c`. -/
 private theorem sub_mul_smul (r s : PlumbingCoefficient) (a b c : PlumbingChain V) :
@@ -95,127 +90,9 @@ private theorem sub_mul_smul (r s : PlumbingCoefficient) (a b c : PlumbingChain 
 
 end PlumbingChain
 
-/-! ### The weights of an edge -/
-
-namespace PlumbingCube
-
-variable {V : Type u} [DecidableEq V] [Fintype V] (P : PlumbingGraph V)
-  (k : P.characteristicVectors) (x : V → ℤ) (v : V)
-
-/-- The characteristic cube weight of an edge is the larger of its two endpoint weights. -/
-theorem characteristicWeight_edge :
-    characteristicWeight P k ⟨x, {v}⟩ =
-      max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) := by
-  rw [characteristicWeight_mk,
-    P.characteristicCubeWeight_eq_max_erase k x (Finset.mem_singleton_self v),
-    Finset.erase_singleton, PlumbingGraph.characteristicCubeWeight_empty,
-    PlumbingGraph.characteristicCubeWeight_empty]
-
-/-- The lower-face exponent of an edge: the drop from the edge weight to the weight of its base
-point. -/
-theorem characteristicLowerFaceExponent_edge :
-    characteristicLowerFaceExponent P k ⟨x, {v}⟩ v =
-      (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
-        P.characteristicWeight k x).toNat := by
-  have h := characteristicLowerFaceExponent_natCast P k ⟨x, {v}⟩ v
-  rw [characteristicWeight_edge] at h
-  simp only [eraseDirection_mk, Finset.erase_singleton, characteristicWeight_mk,
-    PlumbingGraph.characteristicCubeWeight_empty] at h
-  omega
-
-/-- The upper-face exponent of an edge: the drop from the edge weight to the weight of its far
-endpoint. -/
-theorem characteristicUpperFaceExponent_edge :
-    characteristicUpperFaceExponent P k
-        (⟨x, {v}⟩ : PlumbingCube V) (Finset.mem_singleton_self v) =
-      (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
-        P.characteristicWeight k (x + Pi.single v 1)).toNat := by
-  have h := characteristicUpperFaceExponent_natCast P k
-    (⟨x, {v}⟩ : PlumbingCube V) (Finset.mem_singleton_self v)
-  rw [characteristicWeight_edge] at h
-  simp only [upperFace_mk, Finset.erase_singleton, characteristicWeight_mk,
-    PlumbingGraph.characteristicCubeWeight_empty] at h
-  omega
-
-end PlumbingCube
-
 namespace PlumbingGraph
 
 variable {V : Type u} [DecidableEq V] [Fintype V]
-
-/-! ### The differential of an edge -/
-
-section Edge
-
-variable (P : PlumbingGraph V) (k : P.characteristicVectors) (x : V → ℤ) (v : V)
-
-/-- The lattice differential of an edge generator: each endpoint appears, weighted by the drop
-from the edge weight to that endpoint's weight. One of the two exponents is always zero. -/
-theorem latticeDifferential_single_edge :
-    P.latticeDifferential k (Finsupp.single ⟨x, {v}⟩ 1) =
-      Finsupp.single (⟨x, ∅⟩ : PlumbingCube V)
-          (Polynomial.X ^
-            (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
-              P.characteristicWeight k x).toNat) +
-        Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V)
-          (Polynomial.X ^
-            (max (P.characteristicWeight k x) (P.characteristicWeight k (x + Pi.single v 1)) -
-              P.characteristicWeight k (x + Pi.single v 1)).toNat) := by
-  classical
-  rw [latticeDifferential_single, one_smul, latticeDifferentialOnGenerator_def,
-    Finset.sum_eq_single_of_mem (⟨v, Finset.mem_singleton_self v⟩ :
-      {w // w ∈ ({v} : Finset V)}) (Finset.mem_attach _ _)
-      (fun w _ hw => absurd (Subtype.ext (Finset.mem_singleton.mp w.property)) hw)]
-  rw [PlumbingCube.lowerFace_mk, PlumbingCube.upperFace_mk, Finset.erase_singleton,
-    PlumbingCube.characteristicLowerFaceExponent_edge,
-    PlumbingCube.characteristicUpperFaceExponent_edge]
-
-end Edge
-
-/-! ### Moving between adjacent lattice points -/
-
-section Step
-
-variable (P : PlumbingGraph V) (k : P.characteristicVectors) (x : V → ℤ) (v : V)
-
-/-- Crossing an edge towards a lattice point of no smaller weight: the far endpoint is, modulo
-boundaries, `U ^ d` times the near one, where `d` is the gap between their weights. -/
-theorem single_add_sub_smul_single_mem_range
-    (h : P.characteristicWeight k x ≤ P.characteristicWeight k (x + Pi.single v 1)) :
-    Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V) 1 -
-        (Polynomial.X : PlumbingCoefficient) ^ (P.characteristicWeight k (x + Pi.single v 1) -
-            P.characteristicWeight k x).toNat •
-          Finsupp.single (⟨x, ∅⟩ : PlumbingCube V) 1 ∈
-      LinearMap.range (P.latticeDifferential k) := by
-  refine ⟨Finsupp.single ⟨x, {v}⟩ 1, ?_⟩
-  rw [latticeDifferential_single_edge, max_eq_right h, sub_self, Int.toNat_zero, pow_zero,
-    PlumbingChain.sub_eq_add, Finsupp.smul_single, smul_eq_mul, mul_one]
-  exact add_comm _ _
-
-/-- Crossing an edge away from a lattice point of no larger weight: the near endpoint is, modulo
-boundaries, `U ^ d` times the far one, where `d` is the gap between their weights. -/
-theorem single_sub_smul_single_add_mem_range
-    (h : P.characteristicWeight k (x + Pi.single v 1) ≤ P.characteristicWeight k x) :
-    Finsupp.single (⟨x, ∅⟩ : PlumbingCube V) 1 -
-        (Polynomial.X : PlumbingCoefficient) ^ (P.characteristicWeight k x -
-            P.characteristicWeight k (x + Pi.single v 1)).toNat •
-          Finsupp.single (⟨x + Pi.single v 1, ∅⟩ : PlumbingCube V) 1 ∈
-      LinearMap.range (P.latticeDifferential k) := by
-  refine ⟨Finsupp.single ⟨x, {v}⟩ 1, ?_⟩
-  rw [latticeDifferential_single_edge, max_eq_left h, sub_self, Int.toNat_zero, pow_zero,
-    PlumbingChain.sub_eq_add, Finsupp.smul_single, smul_eq_mul, mul_one]
-
-end Step
-
-/-! ### Chains of lattice points -/
-
-/-- A chain supported in cubical degree zero is a cycle: a lattice point has no faces. -/
-theorem latticeDifferential_eq_zero_of_forall_directions_eq_empty (P : PlumbingGraph V)
-    (k : P.characteristicVectors) {c : PlumbingChain V}
-    (hc : ∀ C ∈ c.support, C.directions = ∅) : P.latticeDifferential k c = 0 := by
-  rw [latticeDifferential_apply, Finsupp.sum]
-  refine Finset.sum_eq_zero fun C hC => ?_
-  rw [P.latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty k (hc C hC), smul_zero]
 
 /-! ### The rank-one lattice -/
 
@@ -224,7 +101,8 @@ section Unique
 variable [Unique V] (P : PlumbingGraph V) (k : P.characteristicVectors)
 
 /-- On a rank-one lattice the first difference of the characteristic weight along the unique basis
-direction is an affine function of the lattice coordinate, with slope the framing. -/
+direction is an affine function of the lattice coordinate, with slope the negative of the
+framing. -/
 private theorem characteristicWeight_add_single_sub (x : V → ℤ) :
     P.characteristicWeight k (x + Pi.single default 1) - P.characteristicWeight k x =
       -((k.val default + P.weight default) / 2) - x default * P.weight default := by
@@ -272,6 +150,23 @@ private theorem characteristicWeight_add_single_le (hw : P.weight default < 0) {
     (by omega)
   linarith
 
+omit [Unique V] in
+/-- Compose two congruences modulo lattice boundaries. -/
+private theorem sub_smul_mem_range_trans {r s : PlumbingCoefficient} {a b c : PlumbingChain V}
+    (h₁ : a - r • b ∈ LinearMap.range (P.latticeDifferential k))
+    (h₂ : b - s • c ∈ LinearMap.range (P.latticeDifferential k)) :
+    a - (r * s) • c ∈ LinearMap.range (P.latticeDifferential k) := by
+  rw [PlumbingChain.sub_mul_smul]
+  exact Submodule.add_mem _ h₁ (Submodule.smul_mem _ r h₂)
+
+/-- Powers of `U` telescope when the three exponents come from an ordered triple of weights. -/
+private theorem X_pow_sub_mul_X_pow_sub {a b c : ℤ} (hcb : c ≤ b) (hba : b ≤ a) :
+    (Polynomial.X : PlumbingCoefficient) ^ (a - b).toNat *
+        Polynomial.X ^ (b - c).toNat = Polynomial.X ^ (a - c).toNat := by
+  rw [← pow_add]
+  congr 1
+  omega
+
 include hmin in
 /-- The lattice-point generation statement, as an induction on the lattice coordinate: from a
 minimizer the characteristic weight increases monotonically in both directions, so each step
@@ -305,20 +200,11 @@ private theorem single_sub_smul_single_mem_range_aux (hw : P.weight default < 0)
           P.characteristicWeight k (y - Pi.single default (1 : ℤ) + Pi.single default 1) :=
         characteristicWeight_le_add_single P k hmin hw (by rw [hzd]; exact hn)
       have hminz := hmin (y - Pi.single default (1 : ℤ))
-      have hsum := Submodule.add_mem _
-        (single_add_sub_smul_single_mem_range P k (y - Pi.single default (1 : ℤ)) default hle')
-        (Submodule.smul_mem (LinearMap.range (P.latticeDifferential k))
-          ((Polynomial.X : PlumbingCoefficient) ^
-            (P.characteristicWeight k (y - Pi.single default (1 : ℤ) + Pi.single default 1) -
-              P.characteristicWeight k (y - Pi.single default (1 : ℤ))).toNat)
-          (ih (y - Pi.single default (1 : ℤ)) hzd))
-      rw [← PlumbingChain.sub_mul_smul, ← pow_add,
-        show (P.characteristicWeight k (y - Pi.single default (1 : ℤ) + Pi.single default 1) -
-              P.characteristicWeight k (y - Pi.single default (1 : ℤ))).toNat +
-            (P.characteristicWeight k (y - Pi.single default (1 : ℤ)) -
-              P.characteristicWeight k x₀).toNat =
-          (P.characteristicWeight k (y - Pi.single default (1 : ℤ) + Pi.single default 1) -
-            P.characteristicWeight k x₀).toNat from by omega] at hsum
+      have hstep :=
+        single_add_sub_smul_single_mem_range P k (y - Pi.single default (1 : ℤ)) default hle'
+      have hind := ih (y - Pi.single default (1 : ℤ)) hzd
+      have hsum := sub_smul_mem_range_trans P k hstep hind
+      rw [X_pow_sub_mul_X_pow_sub hminz hle'] at hsum
       rwa [hzy] at hsum
   · induction n, hle using Int.leInductionDown with
     | base => exact hbase
@@ -329,19 +215,10 @@ private theorem single_sub_smul_single_mem_range_aux (hw : P.weight default < 0)
           P.characteristicWeight k y :=
         characteristicWeight_add_single_le P k hmin hw (by omega)
       have hminz := hmin (y + Pi.single default (1 : ℤ))
-      have hsum := Submodule.add_mem _
-        (single_sub_smul_single_add_mem_range P k y default hle')
-        (Submodule.smul_mem (LinearMap.range (P.latticeDifferential k))
-          ((Polynomial.X : PlumbingCoefficient) ^
-            (P.characteristicWeight k y -
-              P.characteristicWeight k (y + Pi.single default 1)).toNat)
-          (ih (y + Pi.single default (1 : ℤ)) hyd))
-      rwa [← PlumbingChain.sub_mul_smul, ← pow_add,
-        show (P.characteristicWeight k y -
-              P.characteristicWeight k (y + Pi.single default 1)).toNat +
-            (P.characteristicWeight k (y + Pi.single default 1) -
-              P.characteristicWeight k x₀).toNat =
-          (P.characteristicWeight k y - P.characteristicWeight k x₀).toNat from by omega] at hsum
+      have hstep := single_sub_smul_single_add_mem_range P k y default hle'
+      have hind := ih (y + Pi.single default (1 : ℤ)) hyd
+      have hsum := sub_smul_mem_range_trans P k hstep hind
+      rwa [X_pow_sub_mul_X_pow_sub hminz hle'] at hsum
 
 include hmin in
 /-- Modulo boundaries, a chain of lattice points is its augmentation times a fixed minimal-weight
@@ -379,7 +256,8 @@ end Unique
 
 /-- On a rank-one plumbing lattice every cycle is a chain of lattice points: the only cubes of
 positive dimension are the edges, and the lattice differential is injective on chains of edges. -/
-theorem directions_eq_empty_of_latticeDifferential_eq_zero [Unique V] (P : PlumbingGraph V)
+theorem directions_eq_empty_of_latticeDifferential_eq_zero_of_unique [Unique V]
+    (P : PlumbingGraph V)
     (k : P.characteristicVectors) {c : PlumbingChain V} (hc : P.latticeDifferential k c = 0)
     {C : PlumbingCube V} (hC : C ∈ c.support) : C.directions = ∅ := by
   classical
@@ -415,18 +293,24 @@ section Homology
 
 variable [Unique V] (P : PlumbingGraph V) (k : P.characteristicVectors)
 
+omit [Unique V] in
+/-- A lattice point realizing the infimum of the characteristic weight is a minimizer. -/
+private theorem characteristicWeight_le_of_eq_sInf (h : P.IsNegativeDefinite) {x₀ : V → ℤ}
+    (hx₀ : P.characteristicWeight k x₀ = P.sInfCharacteristicWeight k) (y : V → ℤ) :
+    P.characteristicWeight k x₀ ≤ P.characteristicWeight k y := by
+  rw [hx₀]
+  exact P.sInfCharacteristicWeight_le h k y
+
 /-- Every lattice point of a rank-one negative-definite plumbing lattice is, modulo boundaries,
 `U ^ (χ_k(x) - min χ_k)` times a fixed lattice point of minimal weight. -/
-theorem single_sub_smul_single_mem_range (h : P.IsNegativeDefinite) {x₀ : V → ℤ}
+theorem single_sub_smul_single_mem_range_of_unique (h : P.IsNegativeDefinite) {x₀ : V → ℤ}
     (hx₀ : P.characteristicWeight k x₀ = P.sInfCharacteristicWeight k) (x : V → ℤ) :
     Finsupp.single (⟨x, ∅⟩ : PlumbingCube V) 1 -
         (Polynomial.X : PlumbingCoefficient) ^
             (P.characteristicWeight k x - P.sInfCharacteristicWeight k).toNat •
           Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1 ∈
       LinearMap.range (P.latticeDifferential k) := by
-  have hmin : ∀ y : V → ℤ, P.characteristicWeight k x₀ ≤ P.characteristicWeight k y := fun y => by
-    rw [hx₀]
-    exact P.sInfCharacteristicWeight_le h k y
+  have hmin := characteristicWeight_le_of_eq_sInf P k h hx₀
   have hbase := single_sub_smul_single_mem_range_aux P k hmin
     (IsNegativeDefinite.weight_neg P h default) (x default) x rfl
   rwa [hx₀] at hbase
@@ -434,30 +318,30 @@ theorem single_sub_smul_single_mem_range (h : P.IsNegativeDefinite) {x₀ : V �
 /-- On a rank-one negative-definite plumbing every cycle differs from a multiple of a fixed
 minimal-weight lattice point by a boundary: cycles are chains of lattice points, and each lattice
 point is a `U`-multiple of the minimal one. -/
-theorem sub_augmentation_smul_single_mem_range (h : P.IsNegativeDefinite) {x₀ : V → ℤ}
+theorem sub_augmentation_smul_single_mem_range_of_unique (h : P.IsNegativeDefinite)
+    {x₀ : V → ℤ}
     (hx₀ : P.characteristicWeight k x₀ = P.sInfCharacteristicWeight k) {c : PlumbingChain V}
     (hc : P.latticeDifferential k c = 0) :
     c - P.latticeAugmentation k c • Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1 ∈
       LinearMap.range (P.latticeDifferential k) := by
-  have hmin : ∀ y : V → ℤ, P.characteristicWeight k x₀ ≤ P.characteristicWeight k y := fun y => by
-    rw [hx₀]
-    exact P.sInfCharacteristicWeight_le h k y
+  have hmin := characteristicWeight_le_of_eq_sInf P k h hx₀
   exact sub_augmentation_smul_single_mem_range_aux P k hmin
     (IsNegativeDefinite.weight_neg P h default) hx₀
-    fun C hC => P.directions_eq_empty_of_latticeDifferential_eq_zero k hc hC
+    fun C hC => P.directions_eq_empty_of_latticeDifferential_eq_zero_of_unique k hc hC
 
 /-- **The lattice homology of a one-vertex negative-definite plumbing is a single `U`-tower.**
 Any cycle of augmentation one has bijective cycle map: injectivity is the tower of
 `latticeHomologyCycleMap_injective`, and surjectivity holds because every cycle is a chain of
 lattice points and every lattice point is a `U`-multiple of a minimal-weight one. -/
-theorem latticeHomologyCycleMap_bijective (h : P.IsNegativeDefinite) (c : PlumbingChain V)
+theorem latticeHomologyCycleMap_bijective_of_unique (h : P.IsNegativeDefinite)
+    (c : PlumbingChain V)
     (hc : P.latticeDifferential k c = 0) (hone : P.latticeAugmentation k c = 1) :
     Function.Bijective (P.latticeHomologyCycleMap k c hc) := by
   obtain ⟨x₀, hx₀⟩ := P.exists_characteristicWeight_eq_sInfCharacteristicWeight h k
   refine ⟨P.latticeHomologyCycleMap_injective h k c hc hone,
     P.latticeHomologyCycleMap_surjective k c hc fun z hz => ⟨P.latticeAugmentation k z, ?_⟩⟩
-  have hz₀ := sub_augmentation_smul_single_mem_range P k h hx₀ hz
-  have hc₀ := sub_augmentation_smul_single_mem_range P k h hx₀ hc
+  have hz₀ := sub_augmentation_smul_single_mem_range_of_unique P k h hx₀ hz
+  have hc₀ := sub_augmentation_smul_single_mem_range_of_unique P k h hx₀ hc
   rw [hone, one_smul] at hc₀
   have hsplit : z - P.latticeAugmentation k z • c =
       (z - P.latticeAugmentation k z • Finsupp.single (⟨x₀, ∅⟩ : PlumbingCube V) 1) -
@@ -468,15 +352,26 @@ theorem latticeHomologyCycleMap_bijective (h : P.IsNegativeDefinite) (c : Plumbi
   rw [hsplit]
   exact Submodule.sub_mem _ hz₀ (Submodule.smul_mem _ _ hc₀)
 
-/-- The lattice homology of a one-vertex negative-definite plumbing is free of rank one over
-`𝔽₂[U]`, generated by the class of a lattice point of minimal characteristic weight. -/
-noncomputable def latticeHomologyEquivCoefficient (h : P.IsNegativeDefinite) :
+/-- The class of a specified augmentation-one cycle identifies `𝔽₂[U]` with the lattice
+homology of a rank-one negative-definite plumbing. -/
+noncomputable def coefficientEquivLatticeHomologyOfUnique (h : P.IsNegativeDefinite)
+    (c : PlumbingChain V) (hc : P.latticeDifferential k c = 0)
+    (hone : P.latticeAugmentation k c = 1) :
     PlumbingCoefficient ≃ₗ[PlumbingCoefficient] P.latticeHomology k :=
   LinearEquiv.ofBijective
-    (P.latticeHomologyCycleMap k (P.exists_cycle_latticeAugmentation_eq_one h k).choose
-      (P.exists_cycle_latticeAugmentation_eq_one h k).choose_spec.1)
-    (latticeHomologyCycleMap_bijective P k h _ _
-      (P.exists_cycle_latticeAugmentation_eq_one h k).choose_spec.2)
+    (P.latticeHomologyCycleMap k c hc)
+    (latticeHomologyCycleMap_bijective_of_unique P k h c hc hone)
+
+/-- The equivalence specified by an augmentation-one cycle sends a coefficient to the homology
+class of its multiple of that cycle. -/
+@[simp]
+theorem coefficientEquivLatticeHomologyOfUnique_apply (h : P.IsNegativeDefinite)
+    (c : PlumbingChain V) (hc : P.latticeDifferential k c = 0)
+    (hone : P.latticeAugmentation k c = 1) (a : PlumbingCoefficient) :
+    coefficientEquivLatticeHomologyOfUnique P k h c hc hone a =
+      P.latticeHomologyCycleMap k c hc a := by
+  rw [coefficientEquivLatticeHomologyOfUnique]
+  rfl
 
 end Homology
 
@@ -491,8 +386,19 @@ def oneVertexPlumbing (w : ℤ) : PlumbingGraph (Fin 1) where
   decidableAdj := inferInstance
   weight := fun _ => w
 
-/-- The intersection matrix of a one-vertex plumbing is its framing. -/
+/-- Every vertex of the one-vertex plumbing has the specified framing. -/
 @[simp]
+theorem oneVertexPlumbing_weight (w : ℤ) (i : Fin 1) :
+    (oneVertexPlumbing w).weight i = w := by
+  simp [oneVertexPlumbing]
+
+/-- The one-vertex plumbing has no graph edges. -/
+@[simp]
+theorem oneVertexPlumbing_toSimpleGraph (w : ℤ) :
+    (oneVertexPlumbing w).toSimpleGraph = ⊥ := by
+  simp [oneVertexPlumbing]
+
+/-- The intersection matrix of a one-vertex plumbing is its framing. -/
 theorem oneVertexPlumbing_intersectionMatrix (w : ℤ) :
     (oneVertexPlumbing w).intersectionMatrix = !![w] := by
   ext i j
@@ -504,22 +410,22 @@ theorem oneVertexPlumbing_intersectionMatrix (w : ℤ) :
 theorem oneVertexPlumbing_isNegativeDefinite {w : ℤ} (hw : w < 0) :
     (oneVertexPlumbing w).IsNegativeDefinite := by
   refine PlumbingGraph.isNegativeDefinite_of_degree_lt_neg_weight _ fun i => ?_
-  have hnb : (oneVertexPlumbing w).toSimpleGraph.neighborFinset i = ∅ := by
-    rw [Finset.eq_empty_iff_forall_notMem]
-    intro j hj
-    rw [SimpleGraph.mem_neighborFinset] at hj
-    simp [oneVertexPlumbing] at hj
   have hdeg : (oneVertexPlumbing w).toSimpleGraph.degree i = 0 := by
-    rw [SimpleGraph.degree, hnb, Finset.card_empty]
-  rw [hdeg]
-  simpa [oneVertexPlumbing] using hw
+    unfold oneVertexPlumbing
+    exact SimpleGraph.bot_degree i
+  rw [hdeg, oneVertexPlumbing_weight]
+  omega
 
 /-- The lattice homology of the one-vertex plumbing with negative framing `w` is, in every
-spin^c structure, a free `𝔽₂[U]`-module of rank one: exactly one `U`-tower, which is the value
-the literature records for the lens space `L(-w, 1)`. -/
-noncomputable def oneVertexPlumbingLatticeHomologyEquiv {w : ℤ} (hw : w < 0)
+spin^c structure, a free `𝔽₂[U]`-module of rank one: exactly one `U`-tower, agreeing with
+the lens-space computation of Ozsváth–Szabó,
+[arXiv:math/0203265](https://arxiv.org/abs/math/0203265). -/
+noncomputable def coefficientEquivOneVertexPlumbingLatticeHomology {w : ℤ} (hw : w < 0)
     (k : (oneVertexPlumbing w).characteristicVectors) :
     PlumbingCoefficient ≃ₗ[PlumbingCoefficient] (oneVertexPlumbing w).latticeHomology k :=
-  PlumbingGraph.latticeHomologyEquivCoefficient _ k (oneVertexPlumbing_isNegativeDefinite hw)
+  let h := oneVertexPlumbing_isNegativeDefinite hw
+  let e := (oneVertexPlumbing w).exists_cycle_latticeAugmentation_eq_one h k
+  PlumbingGraph.coefficientEquivLatticeHomologyOfUnique _ k h e.choose e.choose_spec.1
+    e.choose_spec.2
 
 end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/OneVertex.lean
@@ -82,13 +82,9 @@ namespace PlumbingChain
 
 variable {V : Type u}
 
-/-- Negation is trivial on plumbing chains, whose coefficients have characteristic two. -/
-private theorem neg_eq_self (c : PlumbingChain V) : -c = c := by
-  rw [← neg_one_smul PlumbingCoefficient c, CharTwo.neg_eq, one_smul]
-
 /-- Subtraction of plumbing chains is addition, the coefficients having characteristic two. -/
 private theorem sub_eq_add (c d : PlumbingChain V) : c - d = c + d := by
-  rw [sub_eq_add_neg, neg_eq_self]
+  rw [sub_eq_add_neg, ← neg_one_smul PlumbingCoefficient d, CharTwo.neg_eq, one_smul]
 
 /-- Telescoping one step: comparing `a` with a multiple of `c` splits into the comparison of `a`
 with a multiple of an intermediate chain `b` and that comparison for `b` and `c`. -/

--- a/TauCeti/LowDimTopology/Plumbing/Tower.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Tower.lean
@@ -47,6 +47,8 @@ future work.
   satisfies the chain-level nonboundary criterion for the `U`-tower.
 * `TauCeti.PlumbingGraph.exists_injective_latticeHomologyCycleMap`: the resulting map from
   `𝔽₂[U]` into lattice homology is injective.
+* `TauCeti.PlumbingGraph.latticeDifferential_eq_zero_of_forall_directions_eq_empty`: a chain
+  supported on lattice points is a cycle.
 * `TauCeti.PlumbingGraph.not_isZero_latticeHomology`: the lattice homology of a negative-definite
   plumbing is nonzero.
 
@@ -131,6 +133,14 @@ theorem latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty (P : Plumb
   refine Finset.sum_eq_zero fun v _ => ?_
   have : (v : V) ∈ (∅ : Finset V) := by rw [← hC]; exact v.property
   exact absurd this (Finset.notMem_empty _)
+
+/-- A chain supported in cubical degree zero is a cycle: a lattice point has no faces. -/
+theorem latticeDifferential_eq_zero_of_forall_directions_eq_empty (P : PlumbingGraph V)
+    (k : P.characteristicVectors) {c : PlumbingChain V}
+    (hc : ∀ C ∈ c.support, C.directions = ∅) : P.latticeDifferential k c = 0 := by
+  rw [latticeDifferential_apply, Finsupp.sum]
+  refine Finset.sum_eq_zero fun C hC => ?_
+  rw [P.latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty k (hc C hC), smul_zero]
 
 /-- The augmentation kills the differential of a single cube.
 

--- a/TauCeti/LowDimTopology/Plumbing/Tower.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Tower.lean
@@ -47,8 +47,6 @@ future work.
   satisfies the chain-level nonboundary criterion for the `U`-tower.
 * `TauCeti.PlumbingGraph.exists_injective_latticeHomologyCycleMap`: the resulting map from
   `𝔽₂[U]` into lattice homology is injective.
-* `TauCeti.PlumbingGraph.latticeDifferential_eq_zero_of_forall_directions_eq_empty`: a chain
-  supported on lattice points is a cycle.
 * `TauCeti.PlumbingGraph.not_isZero_latticeHomology`: the lattice homology of a negative-definite
   plumbing is nonzero.
 
@@ -123,24 +121,6 @@ theorem latticeAugmentation_eq_zero_of_mem_degreePart (P : PlumbingGraph V)
     rw [PlumbingCube.dimension, hempty, Finset.card_empty] at hdim
     exact hq hdim.symm
   simp [P.latticeAugmentationCoefficient_of_directions_ne_empty k hne]
-
-/-- A zero-dimensional cube has no directions to differentiate along, so it is a cycle. -/
-@[simp]
-theorem latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty (P : PlumbingGraph V)
-    (k : P.characteristicVectors) {C : PlumbingCube V} (hC : C.directions = ∅) :
-    P.latticeDifferentialOnGenerator k C = 0 := by
-  rw [latticeDifferentialOnGenerator_def]
-  refine Finset.sum_eq_zero fun v _ => ?_
-  have : (v : V) ∈ (∅ : Finset V) := by rw [← hC]; exact v.property
-  exact absurd this (Finset.notMem_empty _)
-
-/-- A chain supported in cubical degree zero is a cycle: a lattice point has no faces. -/
-theorem latticeDifferential_eq_zero_of_forall_directions_eq_empty (P : PlumbingGraph V)
-    (k : P.characteristicVectors) {c : PlumbingChain V}
-    (hc : ∀ C ∈ c.support, C.directions = ∅) : P.latticeDifferential k c = 0 := by
-  rw [latticeDifferential_apply, Finsupp.sum]
-  refine Finset.sum_eq_zero fun C hC => ?_
-  rw [P.latticeDifferentialOnGenerator_eq_zero_of_directions_eq_empty k (hc C hC), smul_zero]
 
 /-- The augmentation kills the differential of a single cube.
 


### PR DESCRIPTION
This PR computes the characteristic-two lattice homology of a negative-definite plumbing graph with a single vertex: for every characteristic covector it is free of rank one over `𝔽₂[U]`, generated by the class of a lattice point of minimal characteristic weight. It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L ("lattice homology"), whose acceptance criterion asks that "`ℍ` of a concrete negative-definite plumbing … matches the literature": a one-vertex plumbing with framing `w < 0` bounds the lens space `L(-w, 1)`, and one `U`-tower per spin^c structure is exactly what the literature records for `HF⁻` of a lens space. Until now the only computed lattice homology was that of the zero-vertex plumbing, where the differential vanishes for lack of directions; `Tower.lean` had shown the invariant is nonzero for a negative-definite plumbing but not what it is. After this PR the milestone still needs the higher-rank computations — the `E₈` plumbing of the acceptance criterion — together with `ℤ[U]` coefficients and invariance under the remaining Neumann moves.

Two facts drive the computation. The rank-one lattice has only points and edges, and the lattice differential is injective on chains sharing a nonempty direction set (already on `main`), so every cycle is a chain of lattice points. And the characteristic weight is a convex quadratic in the single lattice coordinate: its first difference `χ_k(x + E) − χ_k(x) = −(k_v + w)/2 − w x` increases with `x` because the framing `w` is negative, so from a minimizer the weight is nondecreasing to the right and nonincreasing to the left. The differential of an edge is therefore `U^(W − χ_k(x)) x + U^(W − χ_k(x')) x'` with `W` the larger endpoint weight, which relates the two endpoints by `[x'] = U^(χ_k(x') − χ_k(x)) [x]` for `x` the lighter one; inducting along the lattice in both directions writes every lattice point as `U^(χ_k(x) − min χ_k)` times the minimal one. That makes the cycle map of any augmentation-one cycle surjective, and the augmentation of `Tower.lean` already made it injective, so it is an isomorphism `𝔽₂[U] ≅ ℍ(P, k)`.

This was the most effective distinct current step for Lane L: the roadmap status lists "lattice homology of a concrete plumbing" as an open frontier item ("`E₈` and the complex both exist, but nothing computes `ℍ`"), the surrounding infrastructure — cube weights, face exponents, the weight minimum, the `U`-tower augmentation, and top-degree injectivity — was all in place, and the rank-one case is the first one in which the differential does any work. No open PR touches Lane L.

Add `TauCeti/LowDimTopology/Plumbing/OneVertex.lean` (529 lines) and extend `TauCeti/LowDimTopology/Plumbing/Homology.lean` by 45 lines with `latticeHomologyCycleMap_surjective`, the surjectivity companion of the existing `latticeHomologyCycleMap_apply_eq_zero_iff`; it has to live there because the body of `latticeShortComplex` is not exposed, so a downstream file cannot reach Mathlib's explicit cycles-modulo-boundaries description of the homology of a short complex of modules. The new file reuses Mathlib's `ShortComplex` module API, `Int.leInduction` and `Int.leInductionDown`, `Finsupp.filter_add_filter_not`, `Submodule` closure lemmas and `CharTwo.neg_eq`, together with Tau Ceti's existing cube-weight recursion, face-exponent casts, weight polarization, minimal characteristic weight, lattice augmentation and top-degree injectivity. No Mathlib source is vendored. The construction and its weight conventions follow A. Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3, as credited in the module documentation.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"lattice-homology-one-vertex-plumbing"}-->

🤖 Prepared with Claude Code
