### PR TITLE
feat: quadratic orthogonal quotients

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -363,98 +363,141 @@ theorem IsIsotropic.toIntSubmodule_le_quadraticRadical {K : AddSubgroup A}
   rw [QuadraticMap.polarBilin_apply_apply, A.polar_eq_pairing, LinearMap.zero_apply]
   exact A.toFiniteBilinearModule.mem_radical_iff x |>.mp (hKrad hx) y
 
-/-- The finite quadratic module obtained by quotienting a quadratic-isotropic subgroup contained
-in the radical of the polar pairing.
+/-- A subgroup contained in the radical of the quadratic map is quadratic-isotropic. -/
+theorem isIsotropic_of_toIntSubmodule_le_quadraticRadical {K : AddSubgroup A}
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) : A.IsIsotropic K :=
+  fun _ hx ↦ (hK hx).1
+
+/-- A subgroup contained in the radical of the quadratic map is contained in the radical of the
+polar pairing. -/
+theorem le_radical_of_toIntSubmodule_le_quadraticRadical {K : AddSubgroup A}
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
+    K ≤ A.toFiniteBilinearModule.radical := by
+  intro x hx
+  rw [A.toFiniteBilinearModule.mem_radical_iff]
+  intro y
+  rw [← A.polar_eq_pairing, ← QuadraticMap.polarBilin_apply_apply, (hK hx).2,
+    LinearMap.zero_apply]
+
+/-- The finite quadratic module obtained by quotienting by a subgroup contained in the radical of
+the quadratic map. That radical consists of the isotropic elements of the radical of the polar
+pairing, so this is exactly the condition making the quadratic map descend.
 
 The underlying bilinear module is the corresponding quotient of the polar pairing, while the
-quadratic map is Mathlib's `QuadraticMap.lift`. -/
+quadratic map is Mathlib's `QuadraticMap.lift`.
+
+Exposed for the same reason as `FiniteBilinearModule.quotientOfLeRadical`: so that its carrier
+reduces to the `Submodule` quotient and maps out of it are definable. -/
 @[expose] noncomputable def quotientOfIsotropicRadical (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
     FiniteQuadraticModule where
-  toFiniteBilinearModule := A.toFiniteBilinearModule.quotientOfLeRadical K hKrad
-  quadratic := A.quadratic.lift K.toIntSubmodule
-    (IsIsotropic.toIntSubmodule_le_quadraticRadical A hK hKrad)
+  toFiniteBilinearModule := A.toFiniteBilinearModule.quotientOfLeRadical K
+    (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK)
+  quadratic := A.quadratic.lift K.toIntSubmodule hK
   polar_eq_pairing' x y := by
     unfold FiniteBilinearModule.quotientOfLeRadical
     induction x using Submodule.Quotient.induction_on with | H x =>
     induction y using Submodule.Quotient.induction_on with | H y =>
     -- Expose the two quotient lifts; their public representative lemmas then determine both sides.
-    change (A.quadratic.lift K.toIntSubmodule
-        (IsIsotropic.toIntSubmodule_le_quadraticRadical A hK hKrad))
+    change (A.quadratic.lift K.toIntSubmodule hK)
           (Submodule.Quotient.mk x + Submodule.Quotient.mk y) -
         A.quadratic x - A.quadratic y =
-      A.toFiniteBilinearModule.quotientOfLeRadicalBilin K hKrad
+      A.toFiniteBilinearModule.quotientOfLeRadicalBilin K
+          (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK)
         (Submodule.Quotient.mk x) (Submodule.Quotient.mk y)
     rw [← Submodule.Quotient.mk_add, QuadraticMap.lift_mk,
       A.toFiniteBilinearModule.quotientOfLeRadicalBilin_mk]
     exact A.polar_eq_pairing x y
 
-/-- The quotient map onto a quadratic quotient by an isotropic subgroup of the radical. -/
+/-- The quotient map onto a quadratic quotient by a subgroup of the quadratic radical. -/
 noncomputable def quotientOfIsotropicRadicalMk (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
-    A →+ A.quotientOfIsotropicRadical K hK hKrad :=
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
+    A →+ A.quotientOfIsotropicRadical K hK :=
   K.toIntSubmodule.mkQ.toAddMonoidHom
 
 /-- The quotient quadratic map is represented by the original quadratic map. -/
 @[simp]
 theorem quotientOfIsotropicRadical_quadratic_mk (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) (x : A) :
-    (A.quotientOfIsotropicRadical K hK hKrad).quadratic
-      (A.quotientOfIsotropicRadicalMk K hK hKrad x) = A.quadratic x := by
-  exact QuadraticMap.lift_mk (IsIsotropic.toIntSubmodule_le_quadraticRadical A hK hKrad) x
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x : A) :
+    (A.quotientOfIsotropicRadical K hK).quadratic
+      (A.quotientOfIsotropicRadicalMk K hK x) = A.quadratic x := by
+  exact QuadraticMap.lift_mk hK x
 
 /-- The quotient polar pairing is represented by the original pairing. -/
 @[simp]
 theorem quotientOfIsotropicRadical_pairing_mk (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) (x y : A) :
-    (A.quotientOfIsotropicRadical K hK hKrad).toFiniteBilinearModule.pairing
-      (A.quotientOfIsotropicRadicalMk K hK hKrad x)
-      (A.quotientOfIsotropicRadicalMk K hK hKrad y) =
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x y : A) :
+    (A.quotientOfIsotropicRadical K hK).toFiniteBilinearModule.pairing
+      (A.quotientOfIsotropicRadicalMk K hK x)
+      (A.quotientOfIsotropicRadicalMk K hK y) =
         A.toFiniteBilinearModule.pairing x y := by
-  rw [← (A.quotientOfIsotropicRadical K hK hKrad).polar_eq_pairing,
-    QuadraticMap.polar, ← map_add, A.quotientOfIsotropicRadical_quadratic_mk,
-    A.quotientOfIsotropicRadical_quadratic_mk,
-    A.quotientOfIsotropicRadical_quadratic_mk]
-  exact A.polar_eq_pairing x y
+  -- The quotient pairing *is* the descended polar pairing; unfold the opaque `CharacterModule`
+  -- alias so that its representative lemma applies.
+  change A.toFiniteBilinearModule.quotientOfLeRadicalBilin K
+      (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK)
+      (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) = _
+  exact A.toFiniteBilinearModule.quotientOfLeRadicalBilin_mk K
+    (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK) x y
 
 /-- The quotient map onto a quadratic quotient is surjective. -/
 theorem quotientOfIsotropicRadicalMk_surjective (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
-    Function.Surjective (A.quotientOfIsotropicRadicalMk K hK hKrad) :=
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
+    Function.Surjective (A.quotientOfIsotropicRadicalMk K hK) :=
   K.toIntSubmodule.mkQ_surjective
+
+/-- Every element of a quadratic quotient is the class of a representative. -/
+@[elab_as_elim]
+theorem quotientOfIsotropicRadical_induction_on (K : AddSubgroup A)
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical)
+    {motive : A.quotientOfIsotropicRadical K hK → Prop}
+    (q : A.quotientOfIsotropicRadical K hK)
+    (mk : ∀ x : A, motive (A.quotientOfIsotropicRadicalMk K hK x)) : motive q := by
+  obtain ⟨x, rfl⟩ := A.quotientOfIsotropicRadicalMk_surjective K hK q
+  exact mk x
 
 /-- A representative has zero class in a quadratic quotient exactly when it belongs to the
 subgroup being divided out. -/
 @[simp]
 theorem quotientOfIsotropicRadicalMk_eq_zero_iff (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) (x : A) :
-    A.quotientOfIsotropicRadicalMk K hK hKrad x = 0 ↔ x ∈ K := by
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x : A) :
+    A.quotientOfIsotropicRadicalMk K hK x = 0 ↔ x ∈ K := by
   -- Expose the canonical quotient map to apply Mathlib's zero-class criterion.
   change Submodule.Quotient.mk x = 0 ↔ x ∈ K.toIntSubmodule
   exact Submodule.Quotient.mk_eq_zero K.toIntSubmodule
 
-/-- Taking the polar bilinear module commutes with quotienting by a quadratic-isotropic subgroup
-of the radical. -/
+/-- Two representatives have the same class in a quadratic quotient exactly when they differ by an
+element of the subgroup being divided out. -/
+@[simp]
+theorem quotientOfIsotropicRadicalMk_eq_iff (K : AddSubgroup A)
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x y : A) :
+    A.quotientOfIsotropicRadicalMk K hK x = A.quotientOfIsotropicRadicalMk K hK y ↔ x - y ∈ K := by
+  rw [← sub_eq_zero, ← map_sub, A.quotientOfIsotropicRadicalMk_eq_zero_iff K hK]
+
+/-- Taking the polar bilinear module commutes with quotienting by a subgroup of the quadratic
+radical. -/
 @[simp]
 theorem quotientOfIsotropicRadical_toFiniteBilinearModule (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
-    (A.quotientOfIsotropicRadical K hK hKrad).toFiniteBilinearModule =
-      A.toFiniteBilinearModule.quotientOfLeRadical K hKrad := by
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
+    (A.quotientOfIsotropicRadical K hK).toFiniteBilinearModule =
+      A.toFiniteBilinearModule.quotientOfLeRadical K
+        (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK) := by
   rfl
 
 /-- The quadratic quotient is nondegenerate exactly when the subgroup contains the radical of the
 polar pairing. -/
 theorem isNondegenerate_quotientOfIsotropicRadical_iff (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
-    (A.quotientOfIsotropicRadical K hK hKrad).IsNondegenerate ↔
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
+    (A.quotientOfIsotropicRadical K hK).IsNondegenerate ↔
       A.toFiniteBilinearModule.radical ≤ K := by
-  exact A.toFiniteBilinearModule.isNondegenerate_quotientOfLeRadical_iff K hKrad
+  exact A.toFiniteBilinearModule.isNondegenerate_quotientOfLeRadical_iff K
+    (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK)
 
 /-- The order of a quadratic quotient is the index of the subgroup being divided out. -/
 theorem card_quotientOfIsotropicRadical (K : AddSubgroup A)
-    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
-    Nat.card (A.quotientOfIsotropicRadical K hK hKrad) = K.index := by
-  exact A.toFiniteBilinearModule.card_quotientOfLeRadical K hKrad
+    (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
+    Nat.card (A.quotientOfIsotropicRadical K hK) = K.index := by
+  exact A.toFiniteBilinearModule.card_quotientOfLeRadical K
+    (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK)
 
 /-! ### The induced quadratic form on `H^⊥ / H` -/
 
@@ -502,16 +545,28 @@ theorem subgroupInOrthogonalComplement_le_radical {H : AddSubgroup A}
   exact A.toFiniteBilinearModule.mem_orthogonalComplement_iff H y.1 |>.mp y.2 x.1
     (A.mem_subgroupInOrthogonalComplement_iff H x |>.mp hx)
 
+/-- The copy of a quadratic-isotropic subgroup in its orthogonal complement lies in the radical of
+the quadratic map restricted to that complement. -/
+theorem subgroupInOrthogonalComplement_le_quadraticRadical {H : AddSubgroup A}
+    (hH : A.IsIsotropic H) :
+    (A.subgroupInOrthogonalComplement H).toIntSubmodule ≤
+      (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).quadratic.radical :=
+  IsIsotropic.toIntSubmodule_le_quadraticRadical _
+    (A.isIsotropic_subgroupInOrthogonalComplement hH)
+    A.subgroupInOrthogonalComplement_le_radical
+
 /-- The finite quadratic module induced on `H^⊥ / H` by a quadratic-isotropic subgroup `H`.
 
-The form is first restricted to `H^⊥`; the copy of `H` there lies in both its quadratic and
-bilinear radicals, so the restricted form descends to the quotient. -/
+The form is first restricted to `H^⊥`; the copy of `H` there lies in the radical of the restricted
+quadratic map, so the restricted form descends to the quotient.
+
+Exposed for the same reason as `quotientOfIsotropicRadical`: so that its carrier reduces to the
+`Submodule` quotient and maps out of it are definable. -/
 @[expose] noncomputable def orthogonalQuotient (H : AddSubgroup A) (hH : A.IsIsotropic H) :
     FiniteQuadraticModule :=
   (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).quotientOfIsotropicRadical
     (A.subgroupInOrthogonalComplement H)
-    (A.isIsotropic_subgroupInOrthogonalComplement hH)
-    A.subgroupInOrthogonalComplement_le_radical
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
 
 /-- The quotient map from `H^⊥` onto its induced quadratic quotient. -/
 noncomputable def orthogonalQuotientMk (H : AddSubgroup A) (hH : A.IsIsotropic H) :
@@ -520,20 +575,18 @@ noncomputable def orthogonalQuotientMk (H : AddSubgroup A) (hH : A.IsIsotropic H
   quotientOfIsotropicRadicalMk
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
-    (A.isIsotropic_subgroupInOrthogonalComplement hH)
-    A.subgroupInOrthogonalComplement_le_radical
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
 
 /-- The quadratic form on `H^⊥ / H` is represented by the original quadratic form. -/
 @[simp]
 theorem orthogonalQuotient_quadratic_mk (H : AddSubgroup A) (hH : A.IsIsotropic H)
     (x : A.toFiniteBilinearModule.orthogonalComplement H) :
     (A.orthogonalQuotient H hH).quadratic (A.orthogonalQuotientMk H hH x) =
-      A.quadratic x.1 := by
-  exact quotientOfIsotropicRadical_quadratic_mk
+      A.quadratic x.1 :=
+  quotientOfIsotropicRadical_quadratic_mk
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
-    (A.isIsotropic_subgroupInOrthogonalComplement hH)
-    A.subgroupInOrthogonalComplement_le_radical x
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x
 
 /-- The pairing on `H^⊥ / H` is represented by the original polar pairing. -/
 @[simp]
@@ -541,12 +594,11 @@ theorem orthogonalQuotient_pairing_mk (H : AddSubgroup A) (hH : A.IsIsotropic H)
     (x y : A.toFiniteBilinearModule.orthogonalComplement H) :
     (A.orthogonalQuotient H hH).toFiniteBilinearModule.pairing
       (A.orthogonalQuotientMk H hH x) (A.orthogonalQuotientMk H hH y) =
-      A.toFiniteBilinearModule.pairing x.1 y.1 := by
-  exact quotientOfIsotropicRadical_pairing_mk
+      A.toFiniteBilinearModule.pairing x.1 y.1 :=
+  quotientOfIsotropicRadical_pairing_mk
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
-    (A.isIsotropic_subgroupInOrthogonalComplement hH)
-    A.subgroupInOrthogonalComplement_le_radical x y
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x y
 
 /-- The quotient map from `H^⊥` is surjective. -/
 theorem orthogonalQuotientMk_surjective (H : AddSubgroup A) (hH : A.IsIsotropic H) :
@@ -554,8 +606,37 @@ theorem orthogonalQuotientMk_surjective (H : AddSubgroup A) (hH : A.IsIsotropic 
   quotientOfIsotropicRadicalMk_surjective
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
-    (A.isIsotropic_subgroupInOrthogonalComplement hH)
-    A.subgroupInOrthogonalComplement_le_radical
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
+
+/-- Every element of `H^⊥ / H` is the class of an element of `H^⊥`. -/
+@[elab_as_elim]
+theorem orthogonalQuotient_induction_on (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    {motive : A.orthogonalQuotient H hH → Prop} (q : A.orthogonalQuotient H hH)
+    (mk : ∀ x : A.toFiniteBilinearModule.orthogonalComplement H,
+      motive (A.orthogonalQuotientMk H hH x)) : motive q := by
+  obtain ⟨x, rfl⟩ := A.orthogonalQuotientMk_surjective H hH q
+  exact mk x
+
+/-- An element of `H^⊥` has zero class in `H^⊥ / H` exactly when it lies in `H`. -/
+@[simp]
+theorem orthogonalQuotientMk_eq_zero_iff (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    A.orthogonalQuotientMk H hH x = 0 ↔ (x : A) ∈ H :=
+  quotientOfIsotropicRadicalMk_eq_zero_iff
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+    (A.subgroupInOrthogonalComplement H)
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x
+
+/-- Two elements of `H^⊥` have the same class in `H^⊥ / H` exactly when they differ by an element
+of `H`. -/
+@[simp]
+theorem orthogonalQuotientMk_eq_iff (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    (x y : A.toFiniteBilinearModule.orthogonalComplement H) :
+    A.orthogonalQuotientMk H hH x = A.orthogonalQuotientMk H hH y ↔ (x : A) - y ∈ H :=
+  quotientOfIsotropicRadicalMk_eq_iff
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+    (A.subgroupInOrthogonalComplement H)
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x y
 
 /-- If `A` is nondegenerate, the quadratic module induced on `H^⊥ / H` is nondegenerate. -/
 theorem IsNondegenerate.isNondegenerate_orthogonalQuotient (hA : A.IsNondegenerate)
@@ -564,8 +645,7 @@ theorem IsNondegenerate.isNondegenerate_orthogonalQuotient (hA : A.IsNondegenera
   apply (isNondegenerate_quotientOfIsotropicRadical_iff
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
-    (A.isIsotropic_subgroupInOrthogonalComplement hH)
-    A.subgroupInOrthogonalComplement_le_radical).mpr
+    (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)).mpr
   intro x hx
   have hx' : (x.1 : A) ∈ A.toFiniteBilinearModule.orthogonalComplement
       (A.toFiniteBilinearModule.orthogonalComplement H) := by
@@ -591,8 +671,7 @@ theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegener
     exact card_quotientOfIsotropicRadical
       (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
       (A.subgroupInOrthogonalComplement H)
-      (A.isIsotropic_subgroupInOrthogonalComplement hH)
-      A.subgroupInOrthogonalComplement_le_radical
+      (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
   have hquot : Nat.card (A.orthogonalQuotient H hH) * Nat.card H =
       Nat.card (A.toFiniteBilinearModule.orthogonalComplement H) := by
     calc

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -388,7 +388,7 @@ quadratic map is Mathlib's `QuadraticMap.lift`.
 
 Exposed for the same reason as `FiniteBilinearModule.quotientOfLeRadical`: so that its carrier
 reduces to the `Submodule` quotient and maps out of it are definable. -/
-@[expose] noncomputable def quotientOfIsotropicRadical (K : AddSubgroup A)
+@[expose] noncomputable def quotientOfLeQuadraticRadical (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
     FiniteQuadraticModule where
   toFiniteBilinearModule := A.toFiniteBilinearModule.quotientOfLeRadical K
@@ -410,26 +410,26 @@ reduces to the `Submodule` quotient and maps out of it are definable. -/
     exact A.polar_eq_pairing x y
 
 /-- The quotient map onto a quadratic quotient by a subgroup of the quadratic radical. -/
-noncomputable def quotientOfIsotropicRadicalMk (K : AddSubgroup A)
+noncomputable def quotientOfLeQuadraticRadicalMk (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
-    A →+ A.quotientOfIsotropicRadical K hK :=
+    A →+ A.quotientOfLeQuadraticRadical K hK :=
   K.toIntSubmodule.mkQ.toAddMonoidHom
 
 /-- The quotient quadratic map is represented by the original quadratic map. -/
 @[simp]
-theorem quotientOfIsotropicRadical_quadratic_mk (K : AddSubgroup A)
+theorem quotientOfLeQuadraticRadical_quadratic_mk (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x : A) :
-    (A.quotientOfIsotropicRadical K hK).quadratic
-      (A.quotientOfIsotropicRadicalMk K hK x) = A.quadratic x := by
+    (A.quotientOfLeQuadraticRadical K hK).quadratic
+      (A.quotientOfLeQuadraticRadicalMk K hK x) = A.quadratic x := by
   exact QuadraticMap.lift_mk hK x
 
 /-- The quotient polar pairing is represented by the original pairing. -/
 @[simp]
-theorem quotientOfIsotropicRadical_pairing_mk (K : AddSubgroup A)
+theorem quotientOfLeQuadraticRadical_pairing_mk (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x y : A) :
-    (A.quotientOfIsotropicRadical K hK).toFiniteBilinearModule.pairing
-      (A.quotientOfIsotropicRadicalMk K hK x)
-      (A.quotientOfIsotropicRadicalMk K hK y) =
+    (A.quotientOfLeQuadraticRadical K hK).toFiniteBilinearModule.pairing
+      (A.quotientOfLeQuadraticRadicalMk K hK x)
+      (A.quotientOfLeQuadraticRadicalMk K hK y) =
         A.toFiniteBilinearModule.pairing x y := by
   -- The quotient pairing *is* the descended polar pairing; unfold the opaque `CharacterModule`
   -- alias so that its representative lemma applies.
@@ -440,27 +440,27 @@ theorem quotientOfIsotropicRadical_pairing_mk (K : AddSubgroup A)
     (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK) x y
 
 /-- The quotient map onto a quadratic quotient is surjective. -/
-theorem quotientOfIsotropicRadicalMk_surjective (K : AddSubgroup A)
+theorem quotientOfLeQuadraticRadicalMk_surjective (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
-    Function.Surjective (A.quotientOfIsotropicRadicalMk K hK) :=
+    Function.Surjective (A.quotientOfLeQuadraticRadicalMk K hK) :=
   K.toIntSubmodule.mkQ_surjective
 
 /-- Every element of a quadratic quotient is the class of a representative. -/
 @[elab_as_elim]
-theorem quotientOfIsotropicRadical_induction_on (K : AddSubgroup A)
+theorem quotientOfLeQuadraticRadical_induction_on (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical)
-    {motive : A.quotientOfIsotropicRadical K hK → Prop}
-    (q : A.quotientOfIsotropicRadical K hK)
-    (mk : ∀ x : A, motive (A.quotientOfIsotropicRadicalMk K hK x)) : motive q := by
-  obtain ⟨x, rfl⟩ := A.quotientOfIsotropicRadicalMk_surjective K hK q
+    {motive : A.quotientOfLeQuadraticRadical K hK → Prop}
+    (q : A.quotientOfLeQuadraticRadical K hK)
+    (mk : ∀ x : A, motive (A.quotientOfLeQuadraticRadicalMk K hK x)) : motive q := by
+  obtain ⟨x, rfl⟩ := A.quotientOfLeQuadraticRadicalMk_surjective K hK q
   exact mk x
 
 /-- A representative has zero class in a quadratic quotient exactly when it belongs to the
 subgroup being divided out. -/
 @[simp]
-theorem quotientOfIsotropicRadicalMk_eq_zero_iff (K : AddSubgroup A)
+theorem quotientOfLeQuadraticRadicalMk_eq_zero_iff (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x : A) :
-    A.quotientOfIsotropicRadicalMk K hK x = 0 ↔ x ∈ K := by
+    A.quotientOfLeQuadraticRadicalMk K hK x = 0 ↔ x ∈ K := by
   -- Expose the canonical quotient map to apply Mathlib's zero-class criterion.
   change Submodule.Quotient.mk x = 0 ↔ x ∈ K.toIntSubmodule
   exact Submodule.Quotient.mk_eq_zero K.toIntSubmodule
@@ -468,46 +468,47 @@ theorem quotientOfIsotropicRadicalMk_eq_zero_iff (K : AddSubgroup A)
 /-- Two representatives have the same class in a quadratic quotient exactly when they differ by an
 element of the subgroup being divided out. -/
 @[simp]
-theorem quotientOfIsotropicRadicalMk_eq_iff (K : AddSubgroup A)
+theorem quotientOfLeQuadraticRadicalMk_eq_iff (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) (x y : A) :
-    A.quotientOfIsotropicRadicalMk K hK x = A.quotientOfIsotropicRadicalMk K hK y ↔ x - y ∈ K := by
-  rw [← sub_eq_zero, ← map_sub, A.quotientOfIsotropicRadicalMk_eq_zero_iff K hK]
+    A.quotientOfLeQuadraticRadicalMk K hK x =
+      A.quotientOfLeQuadraticRadicalMk K hK y ↔ x - y ∈ K := by
+  rw [← sub_eq_zero, ← map_sub, A.quotientOfLeQuadraticRadicalMk_eq_zero_iff K hK]
 
 /-- Taking the polar bilinear module commutes with quotienting by a subgroup of the quadratic
 radical. -/
 @[simp]
-theorem quotientOfIsotropicRadical_toFiniteBilinearModule (K : AddSubgroup A)
+theorem quotientOfLeQuadraticRadical_toFiniteBilinearModule (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
-    (A.quotientOfIsotropicRadical K hK).toFiniteBilinearModule =
+    (A.quotientOfLeQuadraticRadical K hK).toFiniteBilinearModule =
       A.toFiniteBilinearModule.quotientOfLeRadical K
         (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK) := by
   rfl
 
 /-- The quadratic quotient is nondegenerate exactly when the subgroup contains the radical of the
 polar pairing. -/
-theorem isNondegenerate_quotientOfIsotropicRadical_iff (K : AddSubgroup A)
+theorem isNondegenerate_quotientOfLeQuadraticRadical_iff (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
-    (A.quotientOfIsotropicRadical K hK).IsNondegenerate ↔
+    (A.quotientOfLeQuadraticRadical K hK).IsNondegenerate ↔
       A.toFiniteBilinearModule.radical ≤ K := by
   exact A.toFiniteBilinearModule.isNondegenerate_quotientOfLeRadical_iff K
     (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK)
 
 /-- The order of a quadratic quotient is the index of the subgroup being divided out. -/
-theorem card_quotientOfIsotropicRadical (K : AddSubgroup A)
+theorem card_quotientOfLeQuadraticRadical (K : AddSubgroup A)
     (hK : K.toIntSubmodule ≤ A.quadratic.radical) :
-    Nat.card (A.quotientOfIsotropicRadical K hK) = K.index := by
+    Nat.card (A.quotientOfLeQuadraticRadical K hK) = K.index := by
   exact A.toFiniteBilinearModule.card_quotientOfLeRadical K
     (A.le_radical_of_toIntSubmodule_le_quadraticRadical hK)
 
 /-! ### The induced quadratic form on `H^⊥ / H` -/
 
-/-- The copy of `H` inside its orthogonal complement. For a quadratic-isotropic `H`, the
-containment `H ≤ H^⊥` makes this copy additively equivalent to `H`. -/
+/-- The elements of `H` lying in `H^⊥`, viewed as a subgroup of `H^⊥`. When `H ≤ H^⊥`, this
+intersection is a copy of all of `H`. -/
 def subgroupInOrthogonalComplement (H : AddSubgroup A) :
     AddSubgroup (A.toFiniteBilinearModule.orthogonalComplement H) :=
   H.addSubgroupOf (A.toFiniteBilinearModule.orthogonalComplement H)
 
-/-- Membership in the copy of `H` inside `H^⊥` is membership of the underlying element in
+/-- Membership in `H ∩ H^⊥`, viewed inside `H^⊥`, is membership of the underlying element in
 `H`. -/
 @[simp]
 theorem mem_subgroupInOrthogonalComplement_iff (H : AddSubgroup A)
@@ -515,10 +516,11 @@ theorem mem_subgroupInOrthogonalComplement_iff (H : AddSubgroup A)
     x ∈ A.subgroupInOrthogonalComplement H ↔ (x : A) ∈ H :=
   Iff.rfl
 
-/-- For isotropic `H`, its copy inside `H^⊥` is additively equivalent to `H`. -/
-def subgroupInOrthogonalComplementEquiv {H : AddSubgroup A} (hH : A.IsIsotropic H) :
+/-- If `H ≤ H^⊥`, its copy inside `H^⊥` is additively equivalent to `H`. -/
+def subgroupInOrthogonalComplementEquiv {H : AddSubgroup A}
+    (hH : H ≤ A.toFiniteBilinearModule.orthogonalComplement H) :
     A.subgroupInOrthogonalComplement H ≃+ H :=
-  AddSubgroup.addSubgroupOfEquivOfLe hH.le_orthogonalComplement
+  AddSubgroup.addSubgroupOfEquivOfLe hH
 
 /-- The copy of a quadratic-isotropic subgroup in its orthogonal complement remains
 quadratic-isotropic for the restricted form. -/
@@ -529,8 +531,8 @@ theorem isIsotropic_subgroupInOrthogonalComplement {H : AddSubgroup A}
   intro x hx
   exact hH x.1 (A.mem_subgroupInOrthogonalComplement_iff H x |>.mp hx)
 
-/-- The copy of an isotropic subgroup lies in the radical of the pairing restricted to its
-orthogonal complement. -/
+/-- The elements of `H` lying in `H^⊥` belong to the radical of the pairing restricted to
+`H^⊥`. -/
 theorem subgroupInOrthogonalComplement_le_radical {H : AddSubgroup A}
     : A.subgroupInOrthogonalComplement H ≤
       FiniteBilinearModule.radical
@@ -560,11 +562,11 @@ theorem subgroupInOrthogonalComplement_le_quadraticRadical {H : AddSubgroup A}
 The form is first restricted to `H^⊥`; the copy of `H` there lies in the radical of the restricted
 quadratic map, so the restricted form descends to the quotient.
 
-Exposed for the same reason as `quotientOfIsotropicRadical`: so that its carrier reduces to the
+Exposed for the same reason as `quotientOfLeQuadraticRadical`: so that its carrier reduces to the
 `Submodule` quotient and maps out of it are definable. -/
 @[expose] noncomputable def orthogonalQuotient (H : AddSubgroup A) (hH : A.IsIsotropic H) :
     FiniteQuadraticModule :=
-  (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).quotientOfIsotropicRadical
+  (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).quotientOfLeQuadraticRadical
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
 
@@ -572,7 +574,7 @@ Exposed for the same reason as `quotientOfIsotropicRadical`: so that its carrier
 noncomputable def orthogonalQuotientMk (H : AddSubgroup A) (hH : A.IsIsotropic H) :
     A.toFiniteBilinearModule.orthogonalComplement H →+
       A.orthogonalQuotient H hH :=
-  quotientOfIsotropicRadicalMk
+  quotientOfLeQuadraticRadicalMk
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
@@ -583,7 +585,7 @@ theorem orthogonalQuotient_quadratic_mk (H : AddSubgroup A) (hH : A.IsIsotropic 
     (x : A.toFiniteBilinearModule.orthogonalComplement H) :
     (A.orthogonalQuotient H hH).quadratic (A.orthogonalQuotientMk H hH x) =
       A.quadratic x.1 :=
-  quotientOfIsotropicRadical_quadratic_mk
+  quotientOfLeQuadraticRadical_quadratic_mk
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x
@@ -595,7 +597,7 @@ theorem orthogonalQuotient_pairing_mk (H : AddSubgroup A) (hH : A.IsIsotropic H)
     (A.orthogonalQuotient H hH).toFiniteBilinearModule.pairing
       (A.orthogonalQuotientMk H hH x) (A.orthogonalQuotientMk H hH y) =
       A.toFiniteBilinearModule.pairing x.1 y.1 :=
-  quotientOfIsotropicRadical_pairing_mk
+  quotientOfLeQuadraticRadical_pairing_mk
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x y
@@ -603,7 +605,7 @@ theorem orthogonalQuotient_pairing_mk (H : AddSubgroup A) (hH : A.IsIsotropic H)
 /-- The quotient map from `H^⊥` is surjective. -/
 theorem orthogonalQuotientMk_surjective (H : AddSubgroup A) (hH : A.IsIsotropic H) :
     Function.Surjective (A.orthogonalQuotientMk H hH) :=
-  quotientOfIsotropicRadicalMk_surjective
+  quotientOfLeQuadraticRadicalMk_surjective
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)
@@ -622,7 +624,7 @@ theorem orthogonalQuotient_induction_on (H : AddSubgroup A) (hH : A.IsIsotropic 
 theorem orthogonalQuotientMk_eq_zero_iff (H : AddSubgroup A) (hH : A.IsIsotropic H)
     (x : A.toFiniteBilinearModule.orthogonalComplement H) :
     A.orthogonalQuotientMk H hH x = 0 ↔ (x : A) ∈ H :=
-  quotientOfIsotropicRadicalMk_eq_zero_iff
+  quotientOfLeQuadraticRadicalMk_eq_zero_iff
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x
@@ -633,7 +635,7 @@ of `H`. -/
 theorem orthogonalQuotientMk_eq_iff (H : AddSubgroup A) (hH : A.IsIsotropic H)
     (x y : A.toFiniteBilinearModule.orthogonalComplement H) :
     A.orthogonalQuotientMk H hH x = A.orthogonalQuotientMk H hH y ↔ (x : A) - y ∈ H :=
-  quotientOfIsotropicRadicalMk_eq_iff
+  quotientOfLeQuadraticRadicalMk_eq_iff
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x y
@@ -642,7 +644,7 @@ theorem orthogonalQuotientMk_eq_iff (H : AddSubgroup A) (hH : A.IsIsotropic H)
 theorem IsNondegenerate.isNondegenerate_orthogonalQuotient (hA : A.IsNondegenerate)
     {H : AddSubgroup A} (hH : A.IsIsotropic H) :
     (A.orthogonalQuotient H hH).IsNondegenerate := by
-  apply (isNondegenerate_quotientOfIsotropicRadical_iff
+  apply (isNondegenerate_quotientOfLeQuadraticRadical_iff
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)).mpr
@@ -664,11 +666,11 @@ theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegener
     {H : AddSubgroup A} (hH : A.IsIsotropic H) :
     Nat.card (A.orthogonalQuotient H hH) * Nat.card H ^ 2 = Nat.card A := by
   have hcard : Nat.card (A.subgroupInOrthogonalComplement H) = Nat.card H :=
-    Nat.card_congr (A.subgroupInOrthogonalComplementEquiv hH).toEquiv
+    Nat.card_congr (A.subgroupInOrthogonalComplementEquiv hH.le_orthogonalComplement).toEquiv
   have hindex : Nat.card (A.orthogonalQuotient H hH) =
       (A.subgroupInOrthogonalComplement H).index := by
     unfold orthogonalQuotient
-    exact card_quotientOfIsotropicRadical
+    exact card_quotientOfLeQuadraticRadical
       (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
       (A.subgroupInOrthogonalComplement H)
       (A.subgroupInOrthogonalComplement_le_quadraticRadical hH)

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -5,7 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.FiniteBilinearModule.Basic
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.OrthogonalComplement
+public import Mathlib.Algebra.Group.Subgroup.Map
+public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 public import Mathlib.LinearAlgebra.QuadraticForm.Prod
 
 /-!
@@ -30,6 +32,8 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
 * `TauCeti.FiniteQuadraticModule.IsIsotropic`: quadratic isotropy of an additive subgroup.
 * `TauCeti.FiniteQuadraticModule.IsLagrangian`: a quadratic-isotropic subgroup equal to its
   bilinear orthogonal complement.
+* `TauCeti.FiniteQuadraticModule.orthogonalQuotient`: the quadratic module induced on
+  `H^⊥ / H` by a quadratic-isotropic subgroup `H`.
 
 ## References
 
@@ -344,6 +348,264 @@ theorem IsLagrangian.toFiniteBilinearModule {H : AddSubgroup A} (hH : A.IsLagran
 theorem IsLagrangian.eq_orthogonalComplement {H : AddSubgroup A} (hH : A.IsLagrangian H) :
     H = A.toFiniteBilinearModule.orthogonalComplement H :=
   A.toFiniteBilinearModule.isLagrangian_def H |>.mp hH.2
+
+/-! ## Quotients by isotropic subgroups -/
+
+/-- A quadratic-isotropic subgroup contained in the radical of the polar pairing lies in the
+radical of the quadratic map. This is the exact condition needed to descend the quadratic map to
+the quotient. -/
+theorem IsIsotropic.toIntSubmodule_le_quadraticRadical {K : AddSubgroup A}
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
+    K.toIntSubmodule ≤ A.quadratic.radical := by
+  intro x hx
+  refine ⟨hK x hx, ?_⟩
+  ext y
+  rw [QuadraticMap.polarBilin_apply_apply, A.polar_eq_pairing, LinearMap.zero_apply]
+  exact A.toFiniteBilinearModule.mem_radical_iff x |>.mp (hKrad hx) y
+
+/-- The finite quadratic module obtained by quotienting a quadratic-isotropic subgroup contained
+in the radical of the polar pairing.
+
+The underlying bilinear module is the corresponding quotient of the polar pairing, while the
+quadratic map is Mathlib's `QuadraticMap.lift`. -/
+@[expose] noncomputable def quotientOfIsotropicRadical (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
+    FiniteQuadraticModule where
+  toFiniteBilinearModule := A.toFiniteBilinearModule.quotientOfLeRadical K hKrad
+  quadratic := A.quadratic.lift K.toIntSubmodule
+    (IsIsotropic.toIntSubmodule_le_quadraticRadical A hK hKrad)
+  polar_eq_pairing' x y := by
+    unfold FiniteBilinearModule.quotientOfLeRadical
+    induction x using Submodule.Quotient.induction_on with | H x =>
+    induction y using Submodule.Quotient.induction_on with | H y =>
+    -- Expose the two quotient lifts; their public representative lemmas then determine both sides.
+    change (A.quadratic.lift K.toIntSubmodule
+        (IsIsotropic.toIntSubmodule_le_quadraticRadical A hK hKrad))
+          (Submodule.Quotient.mk x + Submodule.Quotient.mk y) -
+        A.quadratic x - A.quadratic y =
+      A.toFiniteBilinearModule.quotientOfLeRadicalBilin K hKrad
+        (Submodule.Quotient.mk x) (Submodule.Quotient.mk y)
+    rw [← Submodule.Quotient.mk_add, QuadraticMap.lift_mk,
+      A.toFiniteBilinearModule.quotientOfLeRadicalBilin_mk]
+    exact A.polar_eq_pairing x y
+
+/-- The quotient map onto a quadratic quotient by an isotropic subgroup of the radical. -/
+noncomputable def quotientOfIsotropicRadicalMk (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
+    A →+ A.quotientOfIsotropicRadical K hK hKrad :=
+  K.toIntSubmodule.mkQ.toAddMonoidHom
+
+/-- The quotient quadratic map is represented by the original quadratic map. -/
+@[simp]
+theorem quotientOfIsotropicRadical_quadratic_mk (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) (x : A) :
+    (A.quotientOfIsotropicRadical K hK hKrad).quadratic
+      (A.quotientOfIsotropicRadicalMk K hK hKrad x) = A.quadratic x := by
+  exact QuadraticMap.lift_mk (IsIsotropic.toIntSubmodule_le_quadraticRadical A hK hKrad) x
+
+/-- The quotient polar pairing is represented by the original pairing. -/
+@[simp]
+theorem quotientOfIsotropicRadical_pairing_mk (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) (x y : A) :
+    (A.quotientOfIsotropicRadical K hK hKrad).toFiniteBilinearModule.pairing
+      (A.quotientOfIsotropicRadicalMk K hK hKrad x)
+      (A.quotientOfIsotropicRadicalMk K hK hKrad y) =
+        A.toFiniteBilinearModule.pairing x y := by
+  rw [← (A.quotientOfIsotropicRadical K hK hKrad).polar_eq_pairing,
+    QuadraticMap.polar, ← map_add, A.quotientOfIsotropicRadical_quadratic_mk,
+    A.quotientOfIsotropicRadical_quadratic_mk,
+    A.quotientOfIsotropicRadical_quadratic_mk]
+  exact A.polar_eq_pairing x y
+
+/-- The quotient map onto a quadratic quotient is surjective. -/
+theorem quotientOfIsotropicRadicalMk_surjective (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
+    Function.Surjective (A.quotientOfIsotropicRadicalMk K hK hKrad) :=
+  K.toIntSubmodule.mkQ_surjective
+
+/-- A representative has zero class in a quadratic quotient exactly when it belongs to the
+subgroup being divided out. -/
+@[simp]
+theorem quotientOfIsotropicRadicalMk_eq_zero_iff (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) (x : A) :
+    A.quotientOfIsotropicRadicalMk K hK hKrad x = 0 ↔ x ∈ K := by
+  -- Expose the canonical quotient map to apply Mathlib's zero-class criterion.
+  change Submodule.Quotient.mk x = 0 ↔ x ∈ K.toIntSubmodule
+  exact Submodule.Quotient.mk_eq_zero K.toIntSubmodule
+
+/-- Taking the polar bilinear module commutes with quotienting by a quadratic-isotropic subgroup
+of the radical. -/
+@[simp]
+theorem quotientOfIsotropicRadical_toFiniteBilinearModule (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
+    (A.quotientOfIsotropicRadical K hK hKrad).toFiniteBilinearModule =
+      A.toFiniteBilinearModule.quotientOfLeRadical K hKrad := by
+  rfl
+
+/-- The quadratic quotient is nondegenerate exactly when the subgroup contains the radical of the
+polar pairing. -/
+theorem isNondegenerate_quotientOfIsotropicRadical_iff (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
+    (A.quotientOfIsotropicRadical K hK hKrad).IsNondegenerate ↔
+      A.toFiniteBilinearModule.radical ≤ K := by
+  exact A.toFiniteBilinearModule.isNondegenerate_quotientOfLeRadical_iff K hKrad
+
+/-- The order of a quadratic quotient is the index of the subgroup being divided out. -/
+theorem card_quotientOfIsotropicRadical (K : AddSubgroup A)
+    (hK : A.IsIsotropic K) (hKrad : K ≤ A.toFiniteBilinearModule.radical) :
+    Nat.card (A.quotientOfIsotropicRadical K hK hKrad) = K.index := by
+  exact A.toFiniteBilinearModule.card_quotientOfLeRadical K hKrad
+
+/-! ### The induced quadratic form on `H^⊥ / H` -/
+
+/-- The copy of `H` inside its orthogonal complement. For a quadratic-isotropic `H`, the
+containment `H ≤ H^⊥` makes this copy additively equivalent to `H`. -/
+def subgroupInOrthogonalComplement (H : AddSubgroup A) :
+    AddSubgroup (A.toFiniteBilinearModule.orthogonalComplement H) :=
+  H.addSubgroupOf (A.toFiniteBilinearModule.orthogonalComplement H)
+
+/-- Membership in the copy of `H` inside `H^⊥` is membership of the underlying element in
+`H`. -/
+@[simp]
+theorem mem_subgroupInOrthogonalComplement_iff (H : AddSubgroup A)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    x ∈ A.subgroupInOrthogonalComplement H ↔ (x : A) ∈ H :=
+  Iff.rfl
+
+/-- For isotropic `H`, its copy inside `H^⊥` is additively equivalent to `H`. -/
+def subgroupInOrthogonalComplementEquiv {H : AddSubgroup A} (hH : A.IsIsotropic H) :
+    A.subgroupInOrthogonalComplement H ≃+ H :=
+  AddSubgroup.addSubgroupOfEquivOfLe hH.le_orthogonalComplement
+
+/-- The copy of a quadratic-isotropic subgroup in its orthogonal complement remains
+quadratic-isotropic for the restricted form. -/
+theorem isIsotropic_subgroupInOrthogonalComplement {H : AddSubgroup A}
+    (hH : A.IsIsotropic H) :
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).IsIsotropic
+      (A.subgroupInOrthogonalComplement H) := by
+  intro x hx
+  exact hH x.1 (A.mem_subgroupInOrthogonalComplement_iff H x |>.mp hx)
+
+/-- The copy of an isotropic subgroup lies in the radical of the pairing restricted to its
+orthogonal complement. -/
+theorem subgroupInOrthogonalComplement_le_radical {H : AddSubgroup A}
+    : A.subgroupInOrthogonalComplement H ≤
+      FiniteBilinearModule.radical
+        (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).toFiniteBilinearModule := by
+  intro x hx
+  apply FiniteBilinearModule.mem_radical_iff
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).toFiniteBilinearModule x |>.mpr
+  intro y
+  -- The restricted pairing has the same values on the underlying subtype.
+  change A.toFiniteBilinearModule.pairing x.1 y.1 = 0
+  rw [A.toFiniteBilinearModule.pairing_comm]
+  exact A.toFiniteBilinearModule.mem_orthogonalComplement_iff H y.1 |>.mp y.2 x.1
+    (A.mem_subgroupInOrthogonalComplement_iff H x |>.mp hx)
+
+/-- The finite quadratic module induced on `H^⊥ / H` by a quadratic-isotropic subgroup `H`.
+
+The form is first restricted to `H^⊥`; the copy of `H` there lies in both its quadratic and
+bilinear radicals, so the restricted form descends to the quotient. -/
+@[expose] noncomputable def orthogonalQuotient (H : AddSubgroup A) (hH : A.IsIsotropic H) :
+    FiniteQuadraticModule :=
+  (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).quotientOfIsotropicRadical
+    (A.subgroupInOrthogonalComplement H)
+    (A.isIsotropic_subgroupInOrthogonalComplement hH)
+    A.subgroupInOrthogonalComplement_le_radical
+
+/-- The quotient map from `H^⊥` onto its induced quadratic quotient. -/
+noncomputable def orthogonalQuotientMk (H : AddSubgroup A) (hH : A.IsIsotropic H) :
+    A.toFiniteBilinearModule.orthogonalComplement H →+
+      A.orthogonalQuotient H hH :=
+  quotientOfIsotropicRadicalMk
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+    (A.subgroupInOrthogonalComplement H)
+    (A.isIsotropic_subgroupInOrthogonalComplement hH)
+    A.subgroupInOrthogonalComplement_le_radical
+
+/-- The quadratic form on `H^⊥ / H` is represented by the original quadratic form. -/
+@[simp]
+theorem orthogonalQuotient_quadratic_mk (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    (A.orthogonalQuotient H hH).quadratic (A.orthogonalQuotientMk H hH x) =
+      A.quadratic x.1 := by
+  exact quotientOfIsotropicRadical_quadratic_mk
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+    (A.subgroupInOrthogonalComplement H)
+    (A.isIsotropic_subgroupInOrthogonalComplement hH)
+    A.subgroupInOrthogonalComplement_le_radical x
+
+/-- The pairing on `H^⊥ / H` is represented by the original polar pairing. -/
+@[simp]
+theorem orthogonalQuotient_pairing_mk (H : AddSubgroup A) (hH : A.IsIsotropic H)
+    (x y : A.toFiniteBilinearModule.orthogonalComplement H) :
+    (A.orthogonalQuotient H hH).toFiniteBilinearModule.pairing
+      (A.orthogonalQuotientMk H hH x) (A.orthogonalQuotientMk H hH y) =
+      A.toFiniteBilinearModule.pairing x.1 y.1 := by
+  exact quotientOfIsotropicRadical_pairing_mk
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+    (A.subgroupInOrthogonalComplement H)
+    (A.isIsotropic_subgroupInOrthogonalComplement hH)
+    A.subgroupInOrthogonalComplement_le_radical x y
+
+/-- The quotient map from `H^⊥` is surjective. -/
+theorem orthogonalQuotientMk_surjective (H : AddSubgroup A) (hH : A.IsIsotropic H) :
+    Function.Surjective (A.orthogonalQuotientMk H hH) :=
+  quotientOfIsotropicRadicalMk_surjective
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+    (A.subgroupInOrthogonalComplement H)
+    (A.isIsotropic_subgroupInOrthogonalComplement hH)
+    A.subgroupInOrthogonalComplement_le_radical
+
+/-- If `A` is nondegenerate, the quadratic module induced on `H^⊥ / H` is nondegenerate. -/
+theorem IsNondegenerate.isNondegenerate_orthogonalQuotient (hA : A.IsNondegenerate)
+    {H : AddSubgroup A} (hH : A.IsIsotropic H) :
+    (A.orthogonalQuotient H hH).IsNondegenerate := by
+  apply (isNondegenerate_quotientOfIsotropicRadical_iff
+    (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+    (A.subgroupInOrthogonalComplement H)
+    (A.isIsotropic_subgroupInOrthogonalComplement hH)
+    A.subgroupInOrthogonalComplement_le_radical).mpr
+  intro x hx
+  have hx' : (x.1 : A) ∈ A.toFiniteBilinearModule.orthogonalComplement
+      (A.toFiniteBilinearModule.orthogonalComplement H) := by
+    rw [A.toFiniteBilinearModule.mem_orthogonalComplement_iff]
+    intro y hy
+    exact FiniteBilinearModule.mem_radical_iff
+      (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H)).toFiniteBilinearModule x
+      |>.mp hx ⟨y, hy⟩
+  have hdouble := FiniteBilinearModule.IsNondegenerate.orthogonalComplement_orthogonalComplement
+    A.toFiniteBilinearModule hA H
+  rw [hdouble] at hx'
+  exact hx'
+
+/-- For nondegenerate `A`, the order of `H^⊥ / H` multiplied by `|H|²` is `|A|`. -/
+theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegenerate)
+    {H : AddSubgroup A} (hH : A.IsIsotropic H) :
+    Nat.card (A.orthogonalQuotient H hH) * Nat.card H ^ 2 = Nat.card A := by
+  have hcard : Nat.card (A.subgroupInOrthogonalComplement H) = Nat.card H :=
+    Nat.card_congr (A.subgroupInOrthogonalComplementEquiv hH).toEquiv
+  have hindex : Nat.card (A.orthogonalQuotient H hH) =
+      (A.subgroupInOrthogonalComplement H).index := by
+    unfold orthogonalQuotient
+    exact card_quotientOfIsotropicRadical
+      (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
+      (A.subgroupInOrthogonalComplement H)
+      (A.isIsotropic_subgroupInOrthogonalComplement hH)
+      A.subgroupInOrthogonalComplement_le_radical
+  have hquot : Nat.card (A.orthogonalQuotient H hH) * Nat.card H =
+      Nat.card (A.toFiniteBilinearModule.orthogonalComplement H) := by
+    calc
+      Nat.card (A.orthogonalQuotient H hH) * Nat.card H =
+          (A.subgroupInOrthogonalComplement H).index * Nat.card H := by
+            rw [hindex]
+      _ = (A.subgroupInOrthogonalComplement H).index *
+          Nat.card (A.subgroupInOrthogonalComplement H) := congrArg _ hcard.symm
+      _ = Nat.card (A.toFiniteBilinearModule.orthogonalComplement H) :=
+        (A.subgroupInOrthogonalComplement H).index_mul_card
+  rw [pow_two, ← mul_assoc, hquot, mul_comm]
+  exact FiniteBilinearModule.IsNondegenerate.card_mul_card_orthogonalComplement
+    A.toFiniteBilinearModule hA H
 
 end FiniteQuadraticModule
 


### PR DESCRIPTION
This PR constructs the finite quadratic module induced on `H^⊥ / H` by a quadratic-isotropic subgroup `H`, with its quotient map, representative formulas for both the quadratic form and polar pairing, nondegeneracy, and the order identity `|H^⊥ / H| · |H|² = |A|`. It first packages the reusable descent of a finite quadratic module through a quadratic-isotropic subgroup contained in the radical of its polar pairing, then specializes it to the restricted form on `H^⊥`.

The exact target is `TauCetiRoadmap/IntegralLattices/README.md`, Layer 4, fourth bullet: “For isotropic `H`, define the induced form on `H^⊥/H` and construct the natural isometry `A_{L_H} ≅ H^⊥/H`, bilinear in the integral case and quadratic in the even case.” This is the missing quadratic, abstract-module half of that target: open PR #3805 covers the bilinear orthogonal quotient and open PR #4171 identifies dual intermediate carriers with orthogonal complements, without either defining this quadratic refinement. After this PR, the milestone still needs the lattice-side natural bilinear and quadratic isometries `A_{L_H} ≅ H^⊥/H` and their compatibility with index, determinant, isometry transport, and orthogonal sums.

The construction reuses Mathlib's `QuadraticMap.lift`, `AddSubgroup.addSubgroupOfEquivOfLe`, and quotient cardinality API, together with Tau Ceti's existing `FiniteBilinearModule.quotientOfLeRadical` and double-orthogonal-complement theorem. No Mathlib source is vendored. The mathematical construction follows Nikulin §1.4, Proposition 1.4.1 in the roadmap's half-norm convention, with Ebeling, Chapter 1, as the secondary reference; both are recorded in the module documentation.

The existing `TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean` gains 263 lines and remains the canonical home because the new object is a construction on the finite quadratic module developed there; no new module path or compatibility surface is introduced.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"finite-quadratic-orthogonal-quotient"}-->

🤖 Prepared with Codex
