### PR TITLE
feat(Huber): a finite spanning family presents a module as an open quotient

### DIFF
--- a/TauCeti/RingTheory/Huber/OpenMapping.lean
+++ b/TauCeti/RingTheory/Huber/OpenMapping.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.RingTheory.Huber.ZeroSequenceOfUnits
 public import TauCeti.Topology.Algebra.OpenMapping.Henkel
+import TauCeti.Topology.Algebra.Nonarchimedean.Pi
 import Mathlib.Topology.Baire.CompleteMetrizable
 
 /-!
@@ -82,6 +83,9 @@ open but that the target's topology is determined by the source's.
   complete pseudometrisable module onto a complete metrisable one over a Tate ring is open.
 * `TauCeti.Huber.IsTateRing.isQuotientMap`: the same map induces the quotient topology on its
   target. This is the form the strict-morphism material will consume.
+* `TauCeti.Huber.IsTateRing.isOpenMap_linearCombination`: a finite spanning family presents the
+  module as an **open** quotient of `Aⁿ`, which is the strict-presentation form the
+  Banach-theorem arguments consume.
 
 ## References
 
@@ -133,6 +137,39 @@ theorem IsTateRing.isQuotientMap (f : M →ₗ[A] N) (hf : Function.Surjective f
     (hfc : ContinuousAt (f : M → N) 0) : IsQuotientMap (f : M → N) :=
   HasZeroSequenceOfUnits.isQuotientMap f hf hfc
     fun _ ↦ (continuous_id.smul continuous_const).continuousAt
+
+section LinearCombination
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [IsUniformAddGroup A] [CompleteSpace A]
+  [(𝓤 A).IsCountablyGenerated] [NonarchimedeanRing A] [IsTateRing A]
+  {N : Type*} [AddCommGroup N] [UniformSpace N] [IsUniformAddGroup N] [CompleteSpace N]
+  [(𝓤 N).IsCountablyGenerated] [T0Space N] [Module A N] [ContinuousSMul A N]
+
+/-- **A finite spanning family presents `N` as an open quotient of `Aⁿ`.** The linear-combination
+map `a ↦ ∑ aᵢ • gᵢ` is surjective because `g` spans and continuous because the action is, hence
+open by `TauCeti.Huber.IsTateRing.isOpenMap`.
+
+Openness is the content. It is what turns "every element of `N` is a combination of the `gᵢ`" into
+"every *small* element is a combination with *small* coefficients", and that quantitative form is
+what the Banach-theorem arguments over a Tate ring consume. This is an ingredient for the
+BGR §3.7.2/1 density argument on the route to Wedhorn 6.17/6.18, not that argument itself.
+
+Nothing is asked of `g` beyond spanning; the hypotheses are `TauCeti.Huber.IsTateRing.isOpenMap`'s,
+with the source instantiated at `Fin n → A` — which is where `A`'s own completeness, countably
+generated uniformity and nonarchimedean structure are spent, since the `Pi` instances carry each
+of them to `Aⁿ`. -/
+theorem IsTateRing.isOpenMap_linearCombination {n : ℕ} (g : Fin n → N)
+    (hspan : Submodule.span A (Set.range g) = ⊤) :
+    IsOpenMap (Fintype.linearCombination A g : (Fin n → A) → N) := by
+  have hsurj : Function.Surjective (Fintype.linearCombination A g) := by
+    rw [← LinearMap.range_eq_top, Fintype.range_linearCombination, hspan]
+  have hcont : Continuous (Fintype.linearCombination A g : (Fin n → A) → N) := by
+    rw [show (Fintype.linearCombination A g : (Fin n → A) → N) = fun a ↦ ∑ i, a i • g i from
+      funext (Fintype.linearCombination_apply A g)]
+    exact continuous_finsetSum _ fun i _ ↦ (continuous_apply i).smul continuous_const
+  exact IsTateRing.isOpenMap _ hsurj hcont.continuousAt
+
+end LinearCombination
 
 end TauCeti.Huber
 

--- a/TauCeti/RingTheory/Huber/OpenMapping.lean
+++ b/TauCeti/RingTheory/Huber/OpenMapping.lean
@@ -84,8 +84,10 @@ open but that the target's topology is determined by the source's.
 * `TauCeti.Huber.IsTateRing.isQuotientMap`: the same map induces the quotient topology on its
   target. This is the form the strict-morphism material will consume.
 * `TauCeti.Huber.IsTateRing.isOpenMap_linearCombination`: a finite spanning family presents the
-  module as an **open** quotient of `Aⁿ`, which is the strict-presentation form the
+  module as an **open** quotient of `ι → A`, which is the strict-presentation form the
   Banach-theorem arguments consume.
+* `TauCeti.Huber.IsTateRing.isQuotientMap_linearCombination`: the same presentation induces the
+  quotient topology, pairing with the above as `isQuotientMap` pairs with `isOpenMap`.
 
 ## References
 
@@ -144,10 +146,22 @@ variable {A : Type*} [CommRing A] [UniformSpace A] [IsUniformAddGroup A] [Comple
   [(𝓤 A).IsCountablyGenerated] [NonarchimedeanRing A] [IsTateRing A]
   {N : Type*} [AddCommGroup N] [UniformSpace N] [IsUniformAddGroup N] [CompleteSpace N]
   [(𝓤 N).IsCountablyGenerated] [T0Space N] [Module A N] [ContinuousSMul A N]
+  {ι : Type*} [Fintype ι]
 
-/-- **A finite spanning family presents `N` as an open quotient of `Aⁿ`.** The linear-combination
-map `a ↦ ∑ aᵢ • gᵢ` is surjective because `g` spans and continuous because the action is, hence
-open by `TauCeti.Huber.IsTateRing.isOpenMap`.
+-- `Continuous ⇑(Fintype.linearCombination A g)` does not expose an application of the map, so
+-- `simp only [Fintype.linearCombination_apply]` has nothing to rewrite; the coercion has to be
+-- turned into the pointwise sum by `funext` before `continuous_finsetSum` applies.
+omit [IsUniformAddGroup A] [CompleteSpace A] [(𝓤 A).IsCountablyGenerated] [NonarchimedeanRing A]
+  [IsTateRing A] [CompleteSpace N] [(𝓤 N).IsCountablyGenerated] [T0Space N] in
+private theorem continuous_linearCombination (g : ι → N) :
+    Continuous (Fintype.linearCombination A g : (ι → A) → N) := by
+  rw [show (Fintype.linearCombination A g : (ι → A) → N) = fun a ↦ ∑ i, a i • g i from
+    funext (Fintype.linearCombination_apply A g)]
+  exact continuous_finsetSum _ fun i _ ↦ (continuous_apply i).smul continuous_const
+
+/-- **A finite spanning family presents `N` as an open quotient of `Aᶥ`.** The
+linear-combination map `a ↦ ∑ aᵢ • gᵢ` is surjective because `g` spans and continuous because
+the action is, hence open by `TauCeti.Huber.IsTateRing.isOpenMap`.
 
 Openness is the content. It is what turns "every element of `N` is a combination of the `gᵢ`" into
 "every *small* element is a combination with *small* coefficients", and that quantitative form is
@@ -155,19 +169,27 @@ what the Banach-theorem arguments over a Tate ring consume. This is an ingredien
 BGR §3.7.2/1 density argument on the route to Wedhorn 6.17/6.18, not that argument itself.
 
 Nothing is asked of `g` beyond spanning; the hypotheses are `TauCeti.Huber.IsTateRing.isOpenMap`'s,
-with the source instantiated at `Fin n → A` — which is where `A`'s own completeness, countably
+with the source instantiated at `ι → A` — which is where `A`'s own completeness, countably
 generated uniformity and nonarchimedean structure are spent, since the `Pi` instances carry each
-of them to `Aⁿ`. -/
-theorem IsTateRing.isOpenMap_linearCombination {n : ℕ} (g : Fin n → N)
+of them to `ι → A`. -/
+theorem IsTateRing.isOpenMap_linearCombination (g : ι → N)
     (hspan : Submodule.span A (Set.range g) = ⊤) :
-    IsOpenMap (Fintype.linearCombination A g : (Fin n → A) → N) := by
-  have hsurj : Function.Surjective (Fintype.linearCombination A g) := by
-    rw [← LinearMap.range_eq_top, Fintype.range_linearCombination, hspan]
-  have hcont : Continuous (Fintype.linearCombination A g : (Fin n → A) → N) := by
-    rw [show (Fintype.linearCombination A g : (Fin n → A) → N) = fun a ↦ ∑ i, a i • g i from
-      funext (Fintype.linearCombination_apply A g)]
-    exact continuous_finsetSum _ fun i _ ↦ (continuous_apply i).smul continuous_const
-  exact IsTateRing.isOpenMap _ hsurj hcont.continuousAt
+    IsOpenMap (Fintype.linearCombination A g : (ι → A) → N) :=
+  IsTateRing.isOpenMap _ (span_range_eq_top_iff_surjective_fintypeLinearCombination A g |>.mp hspan)
+    (continuous_linearCombination g).continuousAt
+
+/-- **The quotient form of `TauCeti.Huber.IsTateRing.isOpenMap_linearCombination`.** A finite
+spanning family does not merely present `N` as an open image of `ι → A`: the topology of `N` is
+the one coinduced along the linear-combination map.
+
+This is the pairing that `TauCeti.Huber.IsTateRing.isQuotientMap` makes with
+`TauCeti.Huber.IsTateRing.isOpenMap`, at the named finite-presentation API. -/
+theorem IsTateRing.isQuotientMap_linearCombination (g : ι → N)
+    (hspan : Submodule.span A (Set.range g) = ⊤) :
+    IsQuotientMap (Fintype.linearCombination A g : (ι → A) → N) :=
+  IsTateRing.isQuotientMap _
+    (span_range_eq_top_iff_surjective_fintypeLinearCombination A g |>.mp hspan)
+    (continuous_linearCombination g).continuousAt
 
 end LinearCombination
 


### PR DESCRIPTION
A finite spanning family of a complete Tate-module presents it as an **open** quotient of
`Aⁿ`, not merely as a quotient. `TauCeti.Huber.IsTateRing.isOpenMap_linearCombination`
states exactly that: for `g : Fin n → N` spanning `N`, the linear-combination map
`Fintype.linearCombination A g : (Fin n → A) →ₗ[A] N` is open.

Openness is the content. It is what turns "every element of `N` is a combination of the
`gᵢ`" into "every *small* element is a combination with *small* coefficients", and that
quantitative form is what the Banach-theorem arguments over a Tate ring consume. This is
an ingredient for the BGR §3.7.2/1 density argument — a dense submodule of a
module-finite complete Tate-module is everything — on the route to Wedhorn 6.17/6.18. It
is not that argument itself.

The proof is `TauCeti.Huber.IsTateRing.isOpenMap`, already in this file, with its two
hypotheses discharged: surjectivity from `Fintype.range_linearCombination` and the
spanning assumption, continuity from `ContinuousSMul`. The source is instantiated at
`Fin n → A`, which is where `A`'s own completeness, countably generated uniformity and
nonarchimedean structure are spent — the `Pi` instances carry each of them to `Aⁿ`, and
`TauCeti.Topology.Algebra.Nonarchimedean.Pi` is imported for that.

Two points a reader may want flagged:

* Openness is stated for the named map rather than existentially. `Fintype.linearCombination`
  is the map, so quantifying it away would cost callers the definitional handle and
  `Fintype.linearCombination_apply`.
* `[NonarchimedeanRing A]` is used in place of `[IsTopologicalRing A]` plus
  `[NonarchimedeanAddGroup A]`. It extends the former and supplies the latter, and stating
  both trips `linter.overlappingInstances`.

**Overlap with #4076, acknowledged — and it conflicts textually.** That PR adds
`isStrictMap_of_isClosed_range` to this same file.

Correction to an earlier version of this description, which claimed a clean merge: **it does
not merge cleanly with #4076.** Verified two ways against `origin/main`, both reporting
`CONFLICT (content)` in `TauCeti/RingTheory/Huber/OpenMapping.lean` — raw pairwise
`git merge-tree --write-tree`, and this branch against a simulated `main + #4076`. Each branch
merges cleanly against `main` *separately*, which is what the earlier claim was actually
measuring.

The conflict is textual, not mathematical. Two hunks, both pure additions at a shared insertion
point: the import block, and the `## Main results` bullet list. The declarations themselves are
disjoint and neither proof references the other, so resolution is mechanical.

#4076 is older and ahead in the merge queue, so it lands first and keeps the file; **this branch
must be rebased onto `main` once #4076 has landed** — that is mandatory here rather than
contingent, since otherwise the merge-group build would hit the conflict and cost this PR its
queue place.

Roadmap: AdicSpaces
<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0.6-open-linear-combination"}-->
Provenance: no external source copied. The statement and proof are written against this
repository's `TauCeti.Huber.IsTateRing.isOpenMap`; the mathematical route (BGR §3.7.2/1 via
Henkel's open mapping theorem) is the one roadmap Layer 0.6 names, read at
TauCetiRoadmap@85038d4b007ae9c16f7bad22e1cee14bb962104c.
