### PR TITLE
feat: add the Cauchy cumulative distribution function

### DIFF
--- a/TauCeti/Probability/Distributions/Cauchy.lean
+++ b/TauCeti/Probability/Distributions/Cauchy.lean
@@ -26,7 +26,9 @@ not absolutely continuous.
 
 ## Main results
 
-* `TauCeti.hasDerivAt_arctan_div_cauchyPDFReal` — the derivative underlying the cdf formula;
+* `TauCeti.hasDerivAt_arctan_div_pi` — the derivative underlying the cdf formula;
+* `TauCeti.integral_Iic_cauchyPDFReal` — the integral of the Cauchy density over a left
+  half-line;
 * `TauCeti.cdf_cauchyMeasure_of_scale_ne_zero` — the Cauchy cdf at nonzero scale;
 * `TauCeti.cdf_cauchyMeasure_zero_scale` — the cdf of the zero-scale Dirac law;
 * `TauCeti.integral_id_cauchyMeasure_zero_scale` and
@@ -50,15 +52,15 @@ open Filter MeasureTheory ProbabilityTheory Set
 open scoped ENNReal NNReal ProbabilityTheory
 
 /-- The scaled arctangent has the Cauchy density as its derivative. -/
-theorem hasDerivAt_arctan_div_cauchyPDFReal (x₀ : ℝ) (γ : ℝ≥0) (y : ℝ) :
-    HasDerivAt (fun z => Real.pi⁻¹ * Real.arctan ((z - x₀) / (γ : ℝ)))
+theorem hasDerivAt_arctan_div_pi (x₀ : ℝ) (γ : ℝ≥0) (y : ℝ) :
+    HasDerivAt (fun z => Real.arctan ((z - x₀) / (γ : ℝ)) / Real.pi)
       (cauchyPDFReal x₀ γ y) y := by
   have hinner : HasDerivAt (fun z : ℝ => (z - x₀) / (γ : ℝ)) (γ : ℝ)⁻¹ y := by
     simpa only [one_div] using ((hasDerivAt_id' y).sub_const x₀).div_const (γ : ℝ)
-  have h := ((Real.hasDerivAt_arctan ((y - x₀) / (γ : ℝ))).comp y hinner).const_mul
-    Real.pi⁻¹
+  have h := ((Real.hasDerivAt_arctan ((y - x₀) / (γ : ℝ))).comp y hinner).div_const
+    Real.pi
   have hvalue :
-      Real.pi⁻¹ * ((1 / (1 + ((y - x₀) / (γ : ℝ)) ^ 2)) * (γ : ℝ)⁻¹) =
+      ((1 / (1 + ((y - x₀) / (γ : ℝ)) ^ 2)) * (γ : ℝ)⁻¹) / Real.pi =
         cauchyPDFReal x₀ γ y := by
     rw [cauchyPDFReal_def', NNReal.coe_inv]
     ring
@@ -66,23 +68,23 @@ theorem hasDerivAt_arctan_div_cauchyPDFReal (x₀ : ℝ) (γ : ℝ≥0) (y : ℝ
 
 /-- The Cauchy density has the expected antiderivative on a left half-line. This is the analytic
 calculation behind `cdf_cauchyMeasure_of_scale_ne_zero`. -/
-private theorem integral_Iic_cauchyPDFReal (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : ℝ) :
+theorem integral_Iic_cauchyPDFReal (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : ℝ) :
     ∫ y in Iic x, cauchyPDFReal x₀ γ y =
       1 / 2 + Real.arctan ((x - x₀) / (γ : ℝ)) / Real.pi := by
-  let F : ℝ → ℝ := fun y => Real.pi⁻¹ * Real.arctan ((y - x₀) / (γ : ℝ))
+  let F : ℝ → ℝ := fun y => Real.arctan ((y - x₀) / (γ : ℝ)) / Real.pi
   have hint : IntegrableOn (cauchyPDFReal x₀ γ) (Iic x) :=
     (integrable_cauchyPDFReal (γ := γ) x₀).integrableOn
   have hsub_bot : Tendsto (fun y : ℝ => y - x₀) atBot atBot := by
     simpa [sub_eq_add_neg] using tendsto_atBot_add_const_right atBot (-x₀) tendsto_id
   have hinner_bot : Tendsto (fun y : ℝ => (y - x₀) / (γ : ℝ)) atBot atBot :=
     hsub_bot.atBot_div_const (NNReal.coe_pos.mpr (pos_iff_ne_zero.mpr hγ))
-  have hF_bot : Tendsto F atBot (nhds (Real.pi⁻¹ * (-(Real.pi / 2)))) := by
+  have hF_bot : Tendsto F atBot (nhds ((-(Real.pi / 2)) / Real.pi)) := by
     have harctan : Tendsto (fun y : ℝ => Real.arctan ((y - x₀) / (γ : ℝ))) atBot
         (nhds (-(Real.pi / 2))) :=
       (Real.tendsto_arctan_atBot.mono_right nhdsWithin_le_nhds).comp hinner_bot
-    simpa only [F] using harctan.const_mul Real.pi⁻¹
+    simpa only [F] using harctan.div_const Real.pi
   rw [integral_Iic_of_hasDerivAt_of_tendsto'
-    (fun y _ => hasDerivAt_arctan_div_cauchyPDFReal x₀ γ y) hint hF_bot]
+    (fun y _ => hasDerivAt_arctan_div_pi x₀ γ y) hint hF_bot]
   field_simp [Real.pi_ne_zero]
   ring
 
@@ -91,7 +93,7 @@ private theorem integral_Iic_cauchyPDFReal (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ
 theorem cdf_cauchyMeasure_of_scale_ne_zero (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : ℝ) :
     cdf (cauchyMeasure x₀ γ) x =
       1 / 2 + Real.arctan ((x - x₀) / (γ : ℝ)) / Real.pi := by
-  rw [cdf_eq_real, cauchyMeasure_of_scale_ne_zero x₀ hγ, Measure.real,
+  rw [cdf_eq_real, cauchyMeasure_of_scale_ne_zero x₀ hγ, measureReal_def,
     withDensity_apply _ measurableSet_Iic]
   have hnonneg : 0 ≤ᵐ[volume.restrict (Iic x)] cauchyPDFReal x₀ γ :=
     ae_of_all _ fun y => (cauchyPDF_pos x₀ hγ y).le
@@ -124,11 +126,11 @@ theorem integrableExpSet_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
 /-- The moment-generating function of the zero-scale Cauchy law. -/
 theorem mgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
     mgf id (cauchyMeasure x₀ 0) t = Real.exp (t * x₀) := by
-  simpa using (mgf_dirac' (X := id) (ω := x₀) (t := t))
+  rw [cauchyMeasure_zero_scale, mgf_dirac', id_eq]
 
 /-- The cumulant-generating function of the zero-scale Cauchy law. -/
 theorem cgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
     cgf id (cauchyMeasure x₀ 0) t = t * x₀ := by
-  rw [cauchyMeasure_zero_scale, cgf_dirac, id_eq]
+  rw [cauchyMeasure_zero_scale, cgf_dirac', id_eq]
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Cauchy.lean
+++ b/TauCeti/Probability/Distributions/Cauchy.lean
@@ -101,26 +101,22 @@ theorem cdf_cauchyMeasure_eq (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : �
 
 /-- **The cumulative distribution function at zero scale.** Mathlib totalizes the Cauchy family
 by setting `cauchyMeasure x₀ 0 = Measure.dirac x₀`. -/
-@[simp]
 theorem cdf_cauchyMeasure_zero_scale (x₀ x : ℝ) :
     cdf (cauchyMeasure x₀ 0) x = if x₀ ≤ x then 1 else 0 := by
   rw [cauchyMeasure_zero_scale, cdf_eq_real, Measure.real]
   by_cases h : x₀ ≤ x <;> simp [Measure.dirac_apply' _ measurableSet_Iic, h]
 
 /-- The mean of the zero-scale Cauchy law is its location. -/
-@[simp]
 theorem integral_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
     ∫ x, x ∂cauchyMeasure x₀ 0 = x₀ := by
   rw [cauchyMeasure_zero_scale, integral_dirac]
 
 /-- The zero-scale Cauchy law has zero variance. -/
-@[simp]
 theorem variance_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
     variance id (cauchyMeasure x₀ 0) = 0 := by
   rw [cauchyMeasure_zero_scale, variance_dirac]
 
 /-- Every exponential moment of the zero-scale Cauchy law exists. -/
-@[simp]
 theorem integrableExpSet_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
     integrableExpSet id (cauchyMeasure x₀ 0) = Set.univ := by
   ext t
@@ -129,13 +125,11 @@ theorem integrableExpSet_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
   exact integrable_dirac (by simp)
 
 /-- The moment-generating function of the zero-scale Cauchy law. -/
-@[simp]
 theorem mgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
     mgf id (cauchyMeasure x₀ 0) t = Real.exp (t * x₀) := by
   simpa using (mgf_dirac' (X := id) (ω := x₀) (t := t))
 
 /-- The cumulant-generating function of the zero-scale Cauchy law. -/
-@[simp]
 theorem cgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
     cgf id (cauchyMeasure x₀ 0) t = t * x₀ := by
   rw [cgf, mgf_id_cauchyMeasure_zero_scale, Real.log_exp]

--- a/TauCeti/Probability/Distributions/Cauchy.lean
+++ b/TauCeti/Probability/Distributions/Cauchy.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
+public import Mathlib.Probability.CDF
+public import Mathlib.Probability.Distributions.Cauchy
+public import Mathlib.Probability.Moments.Basic
+public import Mathlib.Probability.Moments.IntegrableExpMul
+public import Mathlib.Probability.Moments.Variance
+
+/-!
+# The cumulative distribution function of the Cauchy distribution
+
+This file computes the cumulative distribution function of Mathlib's Cauchy law. For nonzero
+scale `γ`, its value at `x` is
+
+`1 / 2 + arctan ((x - x₀) / γ) / π`.
+
+At scale zero Mathlib defines `cauchyMeasure x₀ 0` to be the Dirac mass at `x₀`. The file records
+the corresponding cumulative distribution function, mean, variance, exponential-integrability
+domain, moment-generating function, and cumulant-generating function. Keeping the singular case
+separate prevents the density calculation for positive scale from being applied where the law is
+not absolutely continuous.
+
+## Main results
+
+* `TauCeti.cdf_cauchyMeasure_eq` — the Cauchy cdf at nonzero scale;
+* `TauCeti.cdf_cauchyMeasure_zero_scale` — the cdf of the zero-scale Dirac law;
+* `TauCeti.integral_id_cauchyMeasure_zero_scale` and
+  `TauCeti.variance_id_cauchyMeasure_zero_scale` — its mean and variance;
+* `TauCeti.integrableExpSet_id_cauchyMeasure_zero_scale`,
+  `TauCeti.mgf_id_cauchyMeasure_zero_scale`, and
+  `TauCeti.cgf_id_cauchyMeasure_zero_scale` — its exponential moments.
+
+## References
+
+* Tau Ceti roadmap, `StandardDistributions`, Layer 1, "Cauchy".
+* N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Univariate Distributions*, vol. 1,
+  2nd ed., Wiley, 1994.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter MeasureTheory ProbabilityTheory Set
+open scoped ENNReal NNReal ProbabilityTheory
+
+/-- The Cauchy density has the expected antiderivative on a left half-line. This is the analytic
+calculation behind `cdf_cauchyMeasure_eq`. -/
+private theorem integral_Iic_cauchyPDFReal (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : ℝ) :
+    ∫ y in Iic x, cauchyPDFReal x₀ γ y =
+      1 / 2 + Real.arctan ((x - x₀) / (γ : ℝ)) / Real.pi := by
+  have hγr : (γ : ℝ) ≠ 0 := NNReal.coe_ne_zero.mpr hγ
+  let F : ℝ → ℝ := fun y => Real.pi⁻¹ * Real.arctan ((y - x₀) / (γ : ℝ))
+  have hderiv (y : ℝ) : HasDerivAt F (cauchyPDFReal x₀ γ y) y := by
+    have hinner : HasDerivAt (fun z : ℝ => (z - x₀) / (γ : ℝ)) (γ : ℝ)⁻¹ y := by
+      simpa only [one_div] using ((hasDerivAt_id' y).sub_const x₀).div_const (γ : ℝ)
+    have h := ((Real.hasDerivAt_arctan ((y - x₀) / (γ : ℝ))).comp y hinner).const_mul
+      Real.pi⁻¹
+    have hvalue :
+        Real.pi⁻¹ * ((1 / (1 + ((y - x₀) / (γ : ℝ)) ^ 2)) * (γ : ℝ)⁻¹) =
+          cauchyPDFReal x₀ γ y := by
+      rw [cauchyPDFReal_def']
+      field_simp [hγr]
+      simp [hγr]
+    simpa only [F, Function.comp_apply, hvalue] using h
+  have hint : IntegrableOn (cauchyPDFReal x₀ γ) (Iic x) :=
+    (integrable_cauchyPDFReal (γ := γ) x₀).integrableOn
+  have hsub_bot : Tendsto (fun y : ℝ => y - x₀) atBot atBot := by
+    simpa [sub_eq_add_neg] using tendsto_atBot_add_const_right atBot (-x₀) tendsto_id
+  have hinner_bot : Tendsto (fun y : ℝ => (y - x₀) / (γ : ℝ)) atBot atBot :=
+    hsub_bot.atBot_div_const (NNReal.coe_pos.mpr (pos_iff_ne_zero.mpr hγ))
+  have hF_bot : Tendsto F atBot (nhds (Real.pi⁻¹ * (-(Real.pi / 2)))) := by
+    have harctan : Tendsto (fun y : ℝ => Real.arctan ((y - x₀) / (γ : ℝ))) atBot
+        (nhds (-(Real.pi / 2))) :=
+      (Real.tendsto_arctan_atBot.mono_right nhdsWithin_le_nhds).comp hinner_bot
+    simpa only [F] using harctan.const_mul Real.pi⁻¹
+  rw [integral_Iic_of_hasDerivAt_of_tendsto' (fun y _ => hderiv y) hint hF_bot]
+  dsimp only [F]
+  field_simp [Real.pi_ne_zero]
+  ring
+
+/-- **The cumulative distribution function of a nondegenerate Cauchy law.** -/
+@[simp]
+theorem cdf_cauchyMeasure_eq (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : ℝ) :
+    cdf (cauchyMeasure x₀ γ) x =
+      1 / 2 + Real.arctan ((x - x₀) / (γ : ℝ)) / Real.pi := by
+  rw [cdf_eq_real, cauchyMeasure_of_scale_ne_zero x₀ hγ, Measure.real,
+    withDensity_apply _ measurableSet_Iic]
+  have hnonneg : 0 ≤ᵐ[volume.restrict (Iic x)] cauchyPDFReal x₀ γ :=
+    ae_of_all _ fun y => (cauchyPDF_pos x₀ hγ y).le
+  simp_rw [cauchyPDF_def]
+  rw [← integral_eq_lintegral_of_nonneg_ae hnonneg
+    (measurable_cauchyPDFReal x₀ γ).aestronglyMeasurable]
+  exact integral_Iic_cauchyPDFReal x₀ hγ x
+
+/-- **The cumulative distribution function at zero scale.** Mathlib totalizes the Cauchy family
+by setting `cauchyMeasure x₀ 0 = Measure.dirac x₀`. -/
+@[simp]
+theorem cdf_cauchyMeasure_zero_scale (x₀ x : ℝ) :
+    cdf (cauchyMeasure x₀ 0) x = if x₀ ≤ x then 1 else 0 := by
+  rw [cauchyMeasure_zero_scale, cdf_eq_real, Measure.real]
+  by_cases h : x₀ ≤ x <;> simp [Measure.dirac_apply' _ measurableSet_Iic, h]
+
+/-- The mean of the zero-scale Cauchy law is its location. -/
+@[simp]
+theorem integral_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
+    ∫ x, x ∂cauchyMeasure x₀ 0 = x₀ := by
+  rw [cauchyMeasure_zero_scale, integral_dirac]
+
+/-- The zero-scale Cauchy law has zero variance. -/
+@[simp]
+theorem variance_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
+    variance id (cauchyMeasure x₀ 0) = 0 := by
+  rw [cauchyMeasure_zero_scale, variance_dirac]
+
+/-- Every exponential moment of the zero-scale Cauchy law exists. -/
+@[simp]
+theorem integrableExpSet_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
+    integrableExpSet id (cauchyMeasure x₀ 0) = Set.univ := by
+  ext t
+  simp only [integrableExpSet, Set.mem_ofPred_eq, cauchyMeasure_zero_scale, Set.mem_univ,
+    iff_true]
+  exact integrable_dirac (by simp)
+
+/-- The moment-generating function of the zero-scale Cauchy law. -/
+@[simp]
+theorem mgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
+    mgf id (cauchyMeasure x₀ 0) t = Real.exp (t * x₀) := by
+  simpa using (mgf_dirac' (X := id) (ω := x₀) (t := t))
+
+/-- The cumulant-generating function of the zero-scale Cauchy law. -/
+@[simp]
+theorem cgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
+    cgf id (cauchyMeasure x₀ 0) t = t * x₀ := by
+  rw [cgf, mgf_id_cauchyMeasure_zero_scale, Real.log_exp]
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Cauchy.lean
+++ b/TauCeti/Probability/Distributions/Cauchy.lean
@@ -6,11 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
-public import Mathlib.Probability.CDF
 public import Mathlib.Probability.Distributions.Cauchy
-public import Mathlib.Probability.Moments.Basic
-public import Mathlib.Probability.Moments.IntegrableExpMul
 public import Mathlib.Probability.Moments.Variance
+public import TauCeti.Probability.Distributions.Dirac
 
 /-!
 # The cumulative distribution function of the Cauchy distribution
@@ -28,7 +26,8 @@ not absolutely continuous.
 
 ## Main results
 
-* `TauCeti.cdf_cauchyMeasure_eq` — the Cauchy cdf at nonzero scale;
+* `TauCeti.hasDerivAt_arctan_div_cauchyPDFReal` — the derivative underlying the cdf formula;
+* `TauCeti.cdf_cauchyMeasure_of_scale_ne_zero` — the Cauchy cdf at nonzero scale;
 * `TauCeti.cdf_cauchyMeasure_zero_scale` — the cdf of the zero-scale Dirac law;
 * `TauCeti.integral_id_cauchyMeasure_zero_scale` and
   `TauCeti.variance_id_cauchyMeasure_zero_scale` — its mean and variance;
@@ -50,25 +49,27 @@ namespace TauCeti
 open Filter MeasureTheory ProbabilityTheory Set
 open scoped ENNReal NNReal ProbabilityTheory
 
+/-- The scaled arctangent has the Cauchy density as its derivative. -/
+theorem hasDerivAt_arctan_div_cauchyPDFReal (x₀ : ℝ) (γ : ℝ≥0) (y : ℝ) :
+    HasDerivAt (fun z => Real.pi⁻¹ * Real.arctan ((z - x₀) / (γ : ℝ)))
+      (cauchyPDFReal x₀ γ y) y := by
+  have hinner : HasDerivAt (fun z : ℝ => (z - x₀) / (γ : ℝ)) (γ : ℝ)⁻¹ y := by
+    simpa only [one_div] using ((hasDerivAt_id' y).sub_const x₀).div_const (γ : ℝ)
+  have h := ((Real.hasDerivAt_arctan ((y - x₀) / (γ : ℝ))).comp y hinner).const_mul
+    Real.pi⁻¹
+  have hvalue :
+      Real.pi⁻¹ * ((1 / (1 + ((y - x₀) / (γ : ℝ)) ^ 2)) * (γ : ℝ)⁻¹) =
+        cauchyPDFReal x₀ γ y := by
+    rw [cauchyPDFReal_def', NNReal.coe_inv]
+    ring
+  simpa only [Function.comp_apply, hvalue] using h
+
 /-- The Cauchy density has the expected antiderivative on a left half-line. This is the analytic
-calculation behind `cdf_cauchyMeasure_eq`. -/
+calculation behind `cdf_cauchyMeasure_of_scale_ne_zero`. -/
 private theorem integral_Iic_cauchyPDFReal (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : ℝ) :
     ∫ y in Iic x, cauchyPDFReal x₀ γ y =
       1 / 2 + Real.arctan ((x - x₀) / (γ : ℝ)) / Real.pi := by
-  have hγr : (γ : ℝ) ≠ 0 := NNReal.coe_ne_zero.mpr hγ
   let F : ℝ → ℝ := fun y => Real.pi⁻¹ * Real.arctan ((y - x₀) / (γ : ℝ))
-  have hderiv (y : ℝ) : HasDerivAt F (cauchyPDFReal x₀ γ y) y := by
-    have hinner : HasDerivAt (fun z : ℝ => (z - x₀) / (γ : ℝ)) (γ : ℝ)⁻¹ y := by
-      simpa only [one_div] using ((hasDerivAt_id' y).sub_const x₀).div_const (γ : ℝ)
-    have h := ((Real.hasDerivAt_arctan ((y - x₀) / (γ : ℝ))).comp y hinner).const_mul
-      Real.pi⁻¹
-    have hvalue :
-        Real.pi⁻¹ * ((1 / (1 + ((y - x₀) / (γ : ℝ)) ^ 2)) * (γ : ℝ)⁻¹) =
-          cauchyPDFReal x₀ γ y := by
-      rw [cauchyPDFReal_def']
-      field_simp [hγr]
-      simp [hγr]
-    simpa only [F, Function.comp_apply, hvalue] using h
   have hint : IntegrableOn (cauchyPDFReal x₀ γ) (Iic x) :=
     (integrable_cauchyPDFReal (γ := γ) x₀).integrableOn
   have hsub_bot : Tendsto (fun y : ℝ => y - x₀) atBot atBot := by
@@ -80,14 +81,14 @@ private theorem integral_Iic_cauchyPDFReal (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ
         (nhds (-(Real.pi / 2))) :=
       (Real.tendsto_arctan_atBot.mono_right nhdsWithin_le_nhds).comp hinner_bot
     simpa only [F] using harctan.const_mul Real.pi⁻¹
-  rw [integral_Iic_of_hasDerivAt_of_tendsto' (fun y _ => hderiv y) hint hF_bot]
-  dsimp only [F]
+  rw [integral_Iic_of_hasDerivAt_of_tendsto'
+    (fun y _ => hasDerivAt_arctan_div_cauchyPDFReal x₀ γ y) hint hF_bot]
   field_simp [Real.pi_ne_zero]
   ring
 
 /-- **The cumulative distribution function of a nondegenerate Cauchy law.** -/
 @[simp]
-theorem cdf_cauchyMeasure_eq (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : ℝ) :
+theorem cdf_cauchyMeasure_of_scale_ne_zero (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : ℝ) :
     cdf (cauchyMeasure x₀ γ) x =
       1 / 2 + Real.arctan ((x - x₀) / (γ : ℝ)) / Real.pi := by
   rw [cdf_eq_real, cauchyMeasure_of_scale_ne_zero x₀ hγ, Measure.real,
@@ -103,8 +104,7 @@ theorem cdf_cauchyMeasure_eq (x₀ : ℝ) {γ : ℝ≥0} (hγ : γ ≠ 0) (x : �
 by setting `cauchyMeasure x₀ 0 = Measure.dirac x₀`. -/
 theorem cdf_cauchyMeasure_zero_scale (x₀ x : ℝ) :
     cdf (cauchyMeasure x₀ 0) x = if x₀ ≤ x then 1 else 0 := by
-  rw [cauchyMeasure_zero_scale, cdf_eq_real, Measure.real]
-  by_cases h : x₀ ≤ x <;> simp [Measure.dirac_apply' _ measurableSet_Iic, h]
+  rw [cauchyMeasure_zero_scale, cdf_dirac]
 
 /-- The mean of the zero-scale Cauchy law is its location. -/
 theorem integral_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
@@ -119,10 +119,7 @@ theorem variance_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
 /-- Every exponential moment of the zero-scale Cauchy law exists. -/
 theorem integrableExpSet_id_cauchyMeasure_zero_scale (x₀ : ℝ) :
     integrableExpSet id (cauchyMeasure x₀ 0) = Set.univ := by
-  ext t
-  simp only [integrableExpSet, Set.mem_ofPred_eq, cauchyMeasure_zero_scale, Set.mem_univ,
-    iff_true]
-  exact integrable_dirac (by simp)
+  rw [cauchyMeasure_zero_scale, integrableExpSet_dirac]
 
 /-- The moment-generating function of the zero-scale Cauchy law. -/
 theorem mgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
@@ -132,6 +129,6 @@ theorem mgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
 /-- The cumulant-generating function of the zero-scale Cauchy law. -/
 theorem cgf_id_cauchyMeasure_zero_scale (x₀ t : ℝ) :
     cgf id (cauchyMeasure x₀ 0) t = t * x₀ := by
-  rw [cgf, mgf_id_cauchyMeasure_zero_scale, Real.log_exp]
+  rw [cauchyMeasure_zero_scale, cgf_dirac, id_eq]
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Dirac.lean
+++ b/TauCeti/Probability/Distributions/Dirac.lean
@@ -12,8 +12,16 @@ public import Mathlib.Probability.Moments.IntegrableExpMul
 /-!
 # Distributional formulas for Dirac measures
 
-This file records formulas for cumulative and exponential generating functions of Dirac measures.
-They provide the common boundary-case API for distribution families that degenerate to a point mass.
+This file records the cumulative distribution function of a real Dirac measure, and the
+exponential-integrability domain and cumulant-generating function of a real-valued statistic under
+a Dirac measure. The moment-generating function is already available in Mathlib as
+`ProbabilityTheory.mgf_dirac'`.
+
+## Main results
+
+* `TauCeti.cdf_dirac` — the cdf of a real Dirac measure;
+* `TauCeti.integrableExpSet_dirac` — every exponential moment exists under a Dirac measure;
+* `TauCeti.cgf_dirac'` — the cumulant-generating function under a Dirac measure.
 -/
 
 public section
@@ -25,23 +33,23 @@ open MeasureTheory ProbabilityTheory Set
 /-- The cumulative distribution function of a Dirac measure is a step function. -/
 @[simp]
 theorem cdf_dirac (a x : ℝ) : cdf (Measure.dirac a) x = if a ≤ x then 1 else 0 := by
-  rw [cdf_eq_real, Measure.real]
+  rw [cdf_eq_real, measureReal_def]
   by_cases h : a ≤ x <;> simp [Measure.dirac_apply' _ measurableSet_Iic, h]
 
 /-- Every exponential moment of a Dirac measure exists. -/
 @[simp]
-theorem integrableExpSet_dirac {Omega : Type*} [MeasurableSpace Omega]
-    [MeasurableSingletonClass Omega] (X : Omega → ℝ) (omega : Omega) :
-    integrableExpSet X (Measure.dirac omega) = Set.univ := by
+theorem integrableExpSet_dirac {Ω : Type*} [MeasurableSpace Ω]
+    [MeasurableSingletonClass Ω] (X : Ω → ℝ) (ω : Ω) :
+    integrableExpSet X (Measure.dirac ω) = Set.univ := by
   ext t
   simp only [integrableExpSet, Set.mem_ofPred_eq, Set.mem_univ, iff_true]
   exact integrable_dirac (by simp)
 
 /-- The cumulant-generating function of a Dirac measure is linear. -/
 @[simp]
-theorem cgf_dirac {Omega : Type*} [MeasurableSpace Omega] [MeasurableSingletonClass Omega]
-    (X : Omega → ℝ) (omega : Omega) (t : ℝ) :
-    cgf X (Measure.dirac omega) t = t * X omega := by
+theorem cgf_dirac' {Ω : Type*} [MeasurableSpace Ω] [MeasurableSingletonClass Ω]
+    (X : Ω → ℝ) (ω : Ω) (t : ℝ) :
+    cgf X (Measure.dirac ω) t = t * X ω := by
   rw [cgf, mgf_dirac', Real.log_exp]
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Dirac.lean
+++ b/TauCeti/Probability/Distributions/Dirac.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.CDF
+public import Mathlib.Probability.Moments.Basic
+public import Mathlib.Probability.Moments.IntegrableExpMul
+
+/-!
+# Distributional formulas for Dirac measures
+
+This file records formulas for cumulative and exponential generating functions of Dirac measures.
+They provide the common boundary-case API for distribution families that degenerate to a point mass.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory ProbabilityTheory Set
+
+/-- The cumulative distribution function of a Dirac measure is a step function. -/
+@[simp]
+theorem cdf_dirac (a x : ℝ) : cdf (Measure.dirac a) x = if a ≤ x then 1 else 0 := by
+  rw [cdf_eq_real, Measure.real]
+  by_cases h : a ≤ x <;> simp [Measure.dirac_apply' _ measurableSet_Iic, h]
+
+/-- Every exponential moment of a Dirac measure exists. -/
+@[simp]
+theorem integrableExpSet_dirac {Omega : Type*} [MeasurableSpace Omega]
+    [MeasurableSingletonClass Omega] (X : Omega → ℝ) (omega : Omega) :
+    integrableExpSet X (Measure.dirac omega) = Set.univ := by
+  ext t
+  simp only [integrableExpSet, Set.mem_ofPred_eq, Set.mem_univ, iff_true]
+  exact integrable_dirac (by simp)
+
+/-- The cumulant-generating function of a Dirac measure is linear. -/
+@[simp]
+theorem cgf_dirac {Omega : Type*} [MeasurableSpace Omega] [MeasurableSingletonClass Omega]
+    (X : Omega → ℝ) (omega : Omega) (t : ℝ) :
+    cgf X (Measure.dirac omega) t = t * X omega := by
+  rw [cgf, mgf_dirac', Real.log_exp]
+
+end TauCeti


### PR DESCRIPTION
This PR computes the Cauchy cumulative distribution function for every scale: it proves the arctangent formula when `γ ≠ 0` and the Dirac step function when `γ = 0`. It also records all zero-scale formulas requested by the same target—mean, variance, exponential-integrability domain, mgf, and cgf—so the singular boundary case is complete.

This advances the exact `StandardDistributions` Layer 1 “Cauchy” target, specifically its nonzero-scale cdf formula and zero-scale Dirac formulas. The Layer 1 elementary-distribution milestone still needs the Cauchy characteristic function, the nonzero-scale integrability and nonintegrability results, and stability of positive finite iid averages after this PR.

The designated `ContourIntegration` roadmap's next unmet Layer 1 milestone is the exact Haefliger–Wu crossing-angle identity, but its necessary excise-and-cap step is already in flight in #4155. This PR therefore takes the next unclaimed critical-path family entry in `StandardDistributions` rather than overlapping that work.

The density calculation reuses Mathlib's `cauchyMeasure_of_scale_ne_zero`, `cauchyPDFReal_def'`, `integrable_cauchyPDFReal`, `integral_Iic_of_hasDerivAt_of_tendsto'`, and arctangent limit; no Mathlib infrastructure is vendored.

The verification commands are `lake exe cache get`, `lake build`, and `lake exe axioms`.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"cauchy-cdf"}-->

🤖 Prepared with Codex
