### PR TITLE
feat: make array mixing laws permutation invariant

### DIFF
--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -82,10 +82,10 @@ The a.e.-measurability hypothesis `∀ p, AEMeasurable (X p) μ` is what turns a
 array into a law identity for a read-off; the definitions themselves are hypothesis-free.
 
 This is the entry point of the Layer 8 target "exchangeable arrays and the Aldous–Hoover
-representation" in `TauCetiRoadmap/Exchangeability/README.md`. The Aldous–Hoover representation
-itself needs, beyond the row de Finetti theorem proved here, the identification of the rows'
-directing measure as an almost surely exchangeable law on `ℕ → α`, and a second application of
-de Finetti inside it.
+representation" in `TauCetiRoadmap/Exchangeability/README.md`. The next law-level consequence of
+the row and column decompositions is in `Arrays.MixingLaw`: the law of either directing measure is
+invariant when every path coordinate is permuted. This is deliberately weaker than saying that the
+directing measure is almost surely an exchangeable law, which is false in general.
 
 ## References
 

--- a/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
@@ -88,18 +88,16 @@ private theorem mixingLaw_map_eq_of_blockLaw_map_eq
   exact mixedIID_mixingLaw_unique hY hmap' hν
 
 /-- **The row mixing law inherits column symmetry.** For any mixing representative `ν` of the
-row process, column invariance of the array law implies that pushing `ν` forward by any
-permutation of path coordinates does not change its law under `μ`.
+row process, invariance of the array law under the column permutation `τ` implies that pushing
+`ν` forward by `τ` does not change its law under `μ`.
 
 This is a statement about the law `μ.map ν`, not an almost-sure assertion that each measure
 `ν ω` is exchangeable. The latter is false in general. -/
 theorem mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
-    (hcol : ∀ τ : Equiv.Perm ℕ,
-      (μ.map fun ω p ↦ X (p.1, τ p.2) ω) = μ.map fun ω p ↦ X p ω)
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α} {τ : Equiv.Perm ℕ}
+    (hcol : (μ.map fun ω p ↦ X (p.1, τ p.2) ω) = μ.map fun ω p ↦ X p ω)
     (hX : ∀ p, AEMeasurable (X p) μ)
-    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayRow X) ν)
-    (τ : Equiv.Perm ℕ) :
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayRow X) ν) :
     μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν := by
   apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex τ)
     (aemeasurable_arrayRow hX)
@@ -120,7 +118,7 @@ theorem mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant
   have hF : Measurable F := measurable_pi_lambda _ fun i ↦ measurable_pi_lambda _ fun j ↦
     measurable_pi_apply (k i, j)
   rw [← map_map_array (X := fun p ↦ X (p.1, τ p.2)) (fun p ↦ hX _) hF,
-    ← map_map_array hX hF, hcol τ]
+    ← map_map_array hX hF, hcol]
 
 /-- **The row mixing law of a separately exchangeable array inherits the column symmetry.** -/
 theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq
@@ -130,17 +128,15 @@ theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq
     (τ : Equiv.Perm ℕ) :
     μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν :=
   mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant
-    (fun τ ↦ separatelyExchangeable_iff.mp h 1 τ) hX hν τ
+    (separatelyExchangeable_iff.mp h 1 τ) hX hν
 
 /-- **The column mixing law inherits row symmetry.** This is the transpose of
 `mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant`. -/
 theorem mixingLaw_map_permReindex_arrayCol_eq_of_row_invariant
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
-    (hrow : ∀ σ : Equiv.Perm ℕ,
-      (μ.map fun ω p ↦ X (σ p.1, p.2) ω) = μ.map fun ω p ↦ X p ω)
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α} {σ : Equiv.Perm ℕ}
+    (hrow : (μ.map fun ω p ↦ X (σ p.1, p.2) ω) = μ.map fun ω p ↦ X p ω)
     (hX : ∀ p, AEMeasurable (X p) μ)
-    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayCol X) ν)
-    (σ : Equiv.Perm ℕ) :
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayCol X) ν) :
     μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν := by
   apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex σ)
     (aemeasurable_arrayCol hX)
@@ -161,7 +157,7 @@ theorem mixingLaw_map_permReindex_arrayCol_eq_of_row_invariant
   have hF : Measurable F := measurable_pi_lambda _ fun j ↦ measurable_pi_lambda _ fun i ↦
     measurable_pi_apply (i, k j)
   rw [← map_map_array (X := fun p ↦ X (σ p.1, p.2)) (fun p ↦ hX _) hF,
-    ← map_map_array hX hF, hrow σ]
+    ← map_map_array hX hF, hrow]
 
 /-- **The column mixing law of a separately exchangeable array inherits the row symmetry.** -/
 theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq
@@ -171,7 +167,7 @@ theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq
     (σ : Equiv.Perm ℕ) :
     μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν :=
   mixingLaw_map_permReindex_arrayCol_eq_of_row_invariant
-    (fun σ ↦ separatelyExchangeable_iff.mp h σ 1) hX hν σ
+    (separatelyExchangeable_iff.mp h σ 1) hX hν
 
 /-- **De Finetti for the rows, with the inherited mixing-law symmetry.** A separately
 exchangeable array has a directing measure for its row process whose law is invariant under every

--- a/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
@@ -23,10 +23,11 @@ representative for the row process, then the law of `ν` is invariant under push
 forward by a permutation of path coordinates:
 
 ```text
-μ.map (P ↦ P.map (permReindex τ)) = μ.map ν.
+μ.map (ω ↦ (ν ω).map (permReindex τ)) = μ.map ν.
 ```
 
-The proof uses both halves of separate exchangeability. Mapping each row path by `permReindex τ`
+The proof uses the opposite-axis half of separate exchangeability. Mapping each row path by
+`permReindex τ`
 preserves the row process's finite-dimensional laws by column exchangeability. The
 coordinatewise-map API for `MixedIIDWith` therefore supplies a second mixing representative for
 the original row process, and uniqueness of the mixing law identifies their laws. The column
@@ -86,15 +87,17 @@ private theorem mixingLaw_map_eq_of_blockLaw_map_eq
       exact hmap.blockLaw_eq_mixture k hk
   exact mixedIID_mixingLaw_unique hY hmap' hν
 
-/-- **The row mixing law inherits the column symmetry.** For any mixing representative `ν` of
-the row process, pushing `ν` forward by any permutation of path coordinates does not change its
-law under `μ`.
+/-- **The row mixing law inherits column symmetry.** For any mixing representative `ν` of the
+row process, column invariance of the array law implies that pushing `ν` forward by any
+permutation of path coordinates does not change its law under `μ`.
 
 This is a statement about the law `μ.map ν`, not an almost-sure assertion that each measure
 `ν ω` is exchangeable. The latter is false in general. -/
-theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq
+theorem mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant
     {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hcol : ∀ τ : Equiv.Perm ℕ,
+      (μ.map fun ω p ↦ X (p.1, τ p.2) ω) = μ.map fun ω p ↦ X p ω)
+    (hX : ∀ p, AEMeasurable (X p) μ)
     {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayRow X) ν)
     (τ : Equiv.Perm ℕ) :
     μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν := by
@@ -113,16 +116,29 @@ theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq
     funext ω i j
     rw [arrayRow_apply]
   rw [hleft, hright]
-  simpa using h.map_comp hX 1 τ
-    (F := fun x ↦ fun i : Fin m ↦ fun j ↦ x (k i, j))
-    (measurable_pi_lambda _ fun i ↦ measurable_pi_lambda _ fun j ↦
-      measurable_pi_apply (k i, j))
+  let F : (ℕ × ℕ → α) → (Fin m → ℕ → α) := fun x i j ↦ x (k i, j)
+  have hF : Measurable F := measurable_pi_lambda _ fun i ↦ measurable_pi_lambda _ fun j ↦
+    measurable_pi_apply (k i, j)
+  rw [← map_map_array (X := fun p ↦ X (p.1, τ p.2)) (fun p ↦ hX _) hF,
+    ← map_map_array hX hF, hcol τ]
 
-/-- **The column mixing law inherits the row symmetry.** This is the transpose of
-`SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq`. -/
-theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq
+/-- **The row mixing law of a separately exchangeable array inherits the column symmetry.** -/
+theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq
     {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
     (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayRow X) ν)
+    (τ : Equiv.Perm ℕ) :
+    μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν :=
+  mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant
+    (fun τ ↦ separatelyExchangeable_iff.mp h 1 τ) hX hν τ
+
+/-- **The column mixing law inherits row symmetry.** This is the transpose of
+`mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant`. -/
+theorem mixingLaw_map_permReindex_arrayCol_eq_of_row_invariant
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (hrow : ∀ σ : Equiv.Perm ℕ,
+      (μ.map fun ω p ↦ X (σ p.1, p.2) ω) = μ.map fun ω p ↦ X p ω)
+    (hX : ∀ p, AEMeasurable (X p) μ)
     {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayCol X) ν)
     (σ : Equiv.Perm ℕ) :
     μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν := by
@@ -141,10 +157,21 @@ theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq
     funext ω j i
     rw [arrayCol_apply]
   rw [hleft, hright]
-  simpa using h.map_comp hX σ 1
-    (F := fun x ↦ fun j : Fin m ↦ fun i ↦ x (i, k j))
-    (measurable_pi_lambda _ fun j ↦ measurable_pi_lambda _ fun i ↦
-      measurable_pi_apply (i, k j))
+  let F : (ℕ × ℕ → α) → (Fin m → ℕ → α) := fun x j i ↦ x (i, k j)
+  have hF : Measurable F := measurable_pi_lambda _ fun j ↦ measurable_pi_lambda _ fun i ↦
+    measurable_pi_apply (i, k j)
+  rw [← map_map_array (X := fun p ↦ X (σ p.1, p.2)) (fun p ↦ hX _) hF,
+    ← map_map_array hX hF, hrow σ]
+
+/-- **The column mixing law of a separately exchangeable array inherits the row symmetry.** -/
+theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayCol X) ν)
+    (σ : Equiv.Perm ℕ) :
+    μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν :=
+  mixingLaw_map_permReindex_arrayCol_eq_of_row_invariant
+    (fun σ ↦ separatelyExchangeable_iff.mp h σ 1) hX hν σ
 
 /-- **De Finetti for the rows, with the inherited mixing-law symmetry.** A separately
 exchangeable array has a directing measure for its row process whose law is invariant under every

--- a/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.Arrays.Basic
+import TauCeti.Probability.Exchangeability.MixedIID.Map
+import TauCeti.Probability.Exchangeability.MixedIID.Mixture
+
+/-!
+# Mixing laws of separately exchangeable arrays
+
+Applying de Finetti's theorem to the rows of a separately exchangeable array gives a random
+probability measure on row paths. The remaining column symmetry does not generally make this
+random measure exchangeable almost surely. For example, if every row equals one common i.i.d.
+random path `Y`, then the row directing measure is `δ_Y`, which is almost surely not an
+exchangeable measure.
+
+The correct inherited symmetry is at the level of the **mixing law**. If `ν` is any mixing
+representative for the row process, then the law of `ν` is invariant under pushing every measure
+forward by a permutation of path coordinates:
+
+```text
+μ.map (P ↦ P.map (permReindex τ)) = μ.map ν.
+```
+
+The proof uses both halves of separate exchangeability. Mapping each row path by `permReindex τ`
+preserves the row process's finite-dimensional laws by column exchangeability. The
+coordinatewise-map API for `MixedIIDWith` therefore supplies a second mixing representative for
+the original row process, and uniqueness of the mixing law identifies their laws. The column
+statement is the symmetric argument using row exchangeability.
+
+The existential corollaries retain genuine directing measures: de Finetti supplies
+`ConditionallyIIDWith`, while the invariance follows after forgetting only to its mixture
+identity. These results are the next law-level input to the separately exchangeable-array branch
+of the Aldous–Hoover milestone in `TauCetiRoadmap/Exchangeability/README.md`, Layer 8.
+
+## Main results
+
+* `SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq` — the row mixing law is invariant
+  under coordinate permutations;
+* `SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq` — the symmetric column statement;
+* `SeparatelyExchangeable.exists_directing_arrayRow_mixingLaw_invariant` and
+  `SeparatelyExchangeable.exists_directing_arrayCol_mixingLaw_invariant` — directing-measure
+  versions supplied by de Finetti.
+
+## References
+
+* O. Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005, Chapter 7.
+* D. Aldous, "Representations for partially exchangeable arrays of random variables", *Journal of
+  Multivariate Analysis* 11 (1981), 581–598.
+
+No material is adapted from `cameronfreer/exchangeability`, which treats sequences rather than
+exchangeable arrays.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α Ω : Type*} [MeasurableSpace α] [MeasurableSpace Ω]
+
+/-- If a measurable coordinatewise map preserves every finite-dimensional law of a mixed i.i.d.
+process, then it preserves the law of any mixing representative. This is the uniqueness argument
+shared by the row and column statements below. -/
+private theorem mixingLaw_map_eq_of_blockLaw_map_eq
+    {μ : Measure Ω} [IsFiniteMeasure μ] {Y : ℕ → Ω → (ℕ → α)}
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ Y ν)
+    {f : (ℕ → α) → (ℕ → α)} (hf : Measurable f)
+    (hY : ∀ i, AEMeasurable (Y i) μ)
+    (hblock : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      blockLaw μ (fun i ω ↦ f (Y i ω)) k = blockLaw μ Y k) :
+    μ.map (fun ω ↦ (ν ω).map hf.aemeasurable) = μ.map ν := by
+  have hmap := hν.map_values hf hY
+  have hmap' : MixedIIDWith μ Y (fun ω ↦ (ν ω).map hf.aemeasurable) :=
+    MixedIIDWith.intro hmap.measurable_mixingRepresentative fun m k hk ↦ by
+      rw [← hblock m k hk]
+      exact hmap.blockLaw_eq_mixture k hk
+  exact mixedIID_mixingLaw_unique hY hmap' hν
+
+/-- **The row mixing law inherits the column symmetry.** For any mixing representative `ν` of
+the row process, pushing `ν` forward by any permutation of path coordinates does not change its
+law under `μ`.
+
+This is a statement about the law `μ.map ν`, not an almost-sure assertion that each measure
+`ν ω` is exchangeable. The latter is false in general. -/
+theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayRow X) ν)
+    (τ : Equiv.Perm ℕ) :
+    μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν := by
+  apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex τ)
+    (aemeasurable_arrayRow hX)
+  intro m k _
+  rw [blockLaw_def, blockLaw_def]
+  have hleft :
+      (fun ω ↦ fun i : Fin m ↦ fun j ↦ arrayRow X (k i) ω (τ j)) =
+        fun ω ↦ fun i : Fin m ↦ fun j ↦ X (k i, τ j) ω := by
+    funext ω i j
+    rw [arrayRow_apply]
+  have hright :
+      (fun ω ↦ fun i : Fin m ↦ arrayRow X (k i) ω) =
+        fun ω ↦ fun i : Fin m ↦ fun j ↦ X (k i, j) ω := by
+    funext ω i j
+    rw [arrayRow_apply]
+  rw [hleft, hright]
+  simpa using h.map_comp hX 1 τ
+    (F := fun x ↦ fun i : Fin m ↦ fun j ↦ x (k i, j))
+    (measurable_pi_lambda _ fun i ↦ measurable_pi_lambda _ fun j ↦
+      measurable_pi_apply (k i, j))
+
+/-- **The column mixing law inherits the row symmetry.** This is the transpose of
+`SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq`. -/
+theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayCol X) ν)
+    (σ : Equiv.Perm ℕ) :
+    μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν := by
+  apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex σ)
+    (aemeasurable_arrayCol hX)
+  intro m k _
+  rw [blockLaw_def, blockLaw_def]
+  have hleft :
+      (fun ω ↦ fun j : Fin m ↦ fun i ↦ arrayCol X (k j) ω (σ i)) =
+        fun ω ↦ fun j : Fin m ↦ fun i ↦ X (σ i, k j) ω := by
+    funext ω j i
+    rw [arrayCol_apply]
+  have hright :
+      (fun ω ↦ fun j : Fin m ↦ arrayCol X (k j) ω) =
+        fun ω ↦ fun j : Fin m ↦ fun i ↦ X (i, k j) ω := by
+    funext ω j i
+    rw [arrayCol_apply]
+  rw [hleft, hright]
+  simpa using h.map_comp hX σ 1
+    (F := fun x ↦ fun j : Fin m ↦ fun i ↦ x (i, k j))
+    (measurable_pi_lambda _ fun j ↦ measurable_pi_lambda _ fun i ↦
+      measurable_pi_apply (i, k j))
+
+/-- **De Finetti for the rows, with the inherited mixing-law symmetry.** A separately
+exchangeable array has a directing measure for its row process whose law is invariant under every
+permutation of the path coordinates. -/
+theorem SeparatelyExchangeable.exists_directing_arrayRow_mixingLaw_invariant
+    [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ∃ ν : Ω → ProbabilityMeasure (ℕ → α), ConditionallyIIDWith μ (arrayRow X) ν ∧
+      ∀ τ : Equiv.Perm ℕ,
+        μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν := by
+  obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayRow hX).exists_directing
+  exact ⟨ν, hν, fun τ ↦
+    h.mixingLaw_map_permReindex_arrayRow_eq hX (mixedIIDWith_of_conditionallyIIDWith hν) τ⟩
+
+/-- **De Finetti for the columns, with the inherited mixing-law symmetry.** -/
+theorem SeparatelyExchangeable.exists_directing_arrayCol_mixingLaw_invariant
+    [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ∃ ν : Ω → ProbabilityMeasure (ℕ → α), ConditionallyIIDWith μ (arrayCol X) ν ∧
+      ∀ σ : Equiv.Perm ℕ,
+        μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν := by
+  obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayCol hX).exists_directing
+  exact ⟨ν, hν, fun σ ↦
+    h.mixingLaw_map_permReindex_arrayCol_eq hX (mixedIIDWith_of_conditionallyIIDWith hν) σ⟩
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the mixing law of the row process of a separately exchangeable array is invariant under pushing every row-path measure forward by a coordinate permutation, and proves the symmetric column statement. It retains the result for any supplied `MixedIIDWith` representative at an arbitrary finite base measure, then combines it with de Finetti to produce genuine `ConditionallyIIDWith` directing measures carrying the same law-level invariance.

The exact roadmap target is `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, “exchangeable arrays and the Aldous–Hoover representation.” The designated milestone is the Aldous–Hoover representation of separately and jointly exchangeable arrays. This is the most effective unclaimed current step because the sequence coding representation and row/column de Finetti decompositions have landed, while the Markov-exchangeability lane is occupied by open PRs; the next array step must identify the symmetry inherited by the row directing object. The inherited statement is deliberately at the mixing-law level: the stronger claim that the directing measure is almost surely exchangeable is false when every row equals one common i.i.d. random path, since the directing measure is then the random Dirac mass at that path.

The proof maps every row by `permReindex`, uses column exchangeability to identify all injective finite-block laws with the original row process, applies `MixedIIDWith.map_values`, and invokes `mixedIID_mixingLaw_unique` to identify the two mixing laws. The column result transposes the argument. What remains after this PR is to turn this invariant random-measure law into the nested functional representation and then assemble the full separately exchangeable and jointly exchangeable Aldous–Hoover theorems.

`TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean` is new (177 lines). The required shared-prefix layout moves the existing array basics without declaration renames:

| Old module | New module |
| --- | --- |
| `TauCeti.Probability.Exchangeability.Arrays` | `TauCeti.Probability.Exchangeability.Arrays.Basic` |

The mathematics follows Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Chapter 7, and Aldous, “Representations for partially exchangeable arrays of random variables” (1981), both credited in the module documentation. No material is adapted from `cameronfreer/exchangeability`, and no Mathlib infrastructure is vendored; the proof consumes the existing `MixedIIDWith.map_values`, `mixedIID_mixingLaw_unique`, and de Finetti APIs.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"row-mixing-law-permutation-invariant"}-->

🤖 Prepared with Codex
