### PR TITLE
feat: recover the law of a natural-number random variable from its pgf

### DIFF
--- a/TauCeti/Probability/GeneratingFunction.lean
+++ b/TauCeti/Probability/GeneratingFunction.lean
@@ -250,9 +250,8 @@ the mass of `{0}`.  This is the `n = 0` case of `iteratedDeriv_pgf_zero`, which 
 away from `iteratedDeriv`. -/
 @[simp]
 theorem pgf_zero (ν : Measure ℕ) [IsFiniteMeasure ν] : pgf id ν 0 = ν.real {0} := by
-  refine (hasSum_pgf ν (by norm_num)).unique ?_
-  simpa using hasSum_single (f := fun n : ℕ => ν.real {n} * (0 : ℝ) ^ n) 0
-    fun n hn => by simp [zero_pow hn]
+  have h := iteratedDeriv_pgf_zero ν 0
+  rwa [iteratedDeriv_zero, Nat.factorial_zero, Nat.cast_one, one_mul] at h
 
 /-- The derivative at the origin of the probability-generating function of a finite measure on `ℕ`
 is the mass of `{1}`.  This is the `n = 1` case of `iteratedDeriv_pgf_zero`, which `simp`

--- a/TauCeti/Probability/GeneratingFunction.lean
+++ b/TauCeti/Probability/GeneratingFunction.lean
@@ -23,12 +23,12 @@ import Mathlib.Probability.Independence.Integration
 This file defines the probability-generating function of a natural-number-valued random variable
 and establishes its basic measure-theoretic API.  The central results relate it to Mathlib's
 moment-generating function and show that it turns sums of independent random variables into
-products.  The file then identifies a finite measure on `ℕ` with the sum of the power series
-carrying its singleton masses, so that the generating function is analytic on the open unit
-interval and its Taylor coefficients at the origin recover those masses; consequently a law on `ℕ`
-is determined by its generating function near `0`.  Finally it computes the generating functions of
-the standard discrete families: Bernoulli, binomial, Poisson, and geometric, the last one on its
-exact integrability domain.
+products.  The file then identifies the generating function of a finite measure on `ℕ` with the
+sum of the power series carrying its singleton masses, so that the generating function is analytic
+on the open unit interval and its Taylor coefficients at the origin recover those masses;
+consequently a law on `ℕ` is determined by its generating function near `0`.  Finally it computes
+the generating functions of the standard discrete families: Bernoulli, binomial, Poisson, and
+geometric, the last one on its exact integrability domain.
 
 These results implement the definition, the generic API, the coefficient-recovery and uniqueness
 statements, and the distribution-specific formulas of the probability-generating-function target
@@ -48,11 +48,12 @@ corresponding measure-integral formulas directly.
 * `TauCeti.Probability.IndepFun.pgf_add` and `TauCeti.Probability.iIndepFun.pgf_sum` —
   multiplicativity over binary and finite sums of independent random variables.
 * `TauCeti.Probability.hasSum_pgf` and `TauCeti.Probability.pgf_eq_tsum` — the power-series
-  expansion in the singleton masses, valid on the open unit interval.
+  expansion in the singleton masses, valid on the closed unit interval.
 * `TauCeti.Probability.hasFPowerSeriesOnBall_pgf` and `TauCeti.Probability.analyticOnNhd_pgf` —
   analyticity on the open unit ball.
 * `TauCeti.Probability.iteratedDeriv_pgf_zero` — the Taylor coefficients at the origin are the
-  singleton masses.
+  singleton masses, with `TauCeti.Probability.pgf_zero` and `TauCeti.Probability.deriv_pgf_zero`
+  reading off the first two.
 * `TauCeti.Probability.measure_eq_of_pgf_eventuallyEq` and
   `TauCeti.Probability.identDistrib_of_pgf_eventuallyEq` — uniqueness of the law from the germ of
   the generating function at `0`, with the corollaries
@@ -167,26 +168,27 @@ A finite measure on `ℕ` is the weighted sum of Dirac masses `∑ ν {n} • δ
 generating function is the sum of the power series `∑ ν.real {n} * t ^ n`.  The masses are
 bounded by the total mass, so that series converges on the whole open unit ball and the generating
 function is analytic there.  Reading its Taylor coefficients at the origin returns the masses, and
-hence a probability measure on `ℕ` is determined by its generating function near `0`. -/
+hence a finite measure on `ℕ`, in particular a probability measure, is determined by its generating
+function near `0`. -/
 
 section Coefficients
 
 open FormalMultilinearSeries
 
 /-- Under a finite measure on `ℕ`, the probability-generating function is the sum of the power
-series whose coefficients are the singleton masses, on the open unit interval. -/
-theorem hasSum_pgf (ν : Measure ℕ) [IsFiniteMeasure ν] {t : ℝ} (ht : |t| < 1) :
+series whose coefficients are the singleton masses, on the closed unit interval. -/
+theorem hasSum_pgf (ν : Measure ℕ) [IsFiniteMeasure ν] {t : ℝ} (ht : |t| ≤ 1) :
     HasSum (fun n => ν.real {n} * t ^ n) (pgf id ν t) := by
-  have hbound : ∀ n : ℕ, ‖ν.real {n} * t ^ n‖ ≤ ν.real Set.univ * |t| ^ n := by
+  have hbound : ∀ n : ℕ, ‖ν.real {n} * t ^ n‖ ≤ ν.real {n} := by
     intro n
     rw [norm_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_pow,
       abs_of_nonneg measureReal_nonneg]
-    have hmass : ν.real {n} ≤ ν.real Set.univ := measureReal_mono (Set.subset_univ _)
-    exact mul_le_mul_of_nonneg_right hmass (by positivity)
+    exact mul_le_of_le_one_right measureReal_nonneg (pow_le_one₀ (abs_nonneg t) ht)
   have hsum : Summable fun n => ν.real {n} * t ^ n :=
-    Summable.of_norm_bounded ((summable_geometric_of_lt_one (abs_nonneg t) ht).mul_left _) hbound
+    Summable.of_norm_bounded (summable_measure_toReal (fun n => measurableSet_singleton n)
+      fun _ _ hmn => Set.disjoint_singleton.mpr hmn) hbound
   have hint : Integrable (fun n : ℕ => t ^ n) ν :=
-    integrable_pow_of_abs_le_one (X := id) aemeasurable_id ht.le
+    integrable_pow_of_abs_le_one (X := id) aemeasurable_id ht
   have hpgf : pgf id ν t = ∑' n : ℕ, ν.real {n} * t ^ n := by
     rw [pgf_def]
     simp only [id_eq]
@@ -196,8 +198,8 @@ theorem hasSum_pgf (ν : Measure ℕ) [IsFiniteMeasure ν] {t : ℝ} (ht : |t| <
   exact hsum.hasSum
 
 /-- The power-series expansion of the probability-generating function of a finite measure on `ℕ`
-on the open unit interval. -/
-theorem pgf_eq_tsum (ν : Measure ℕ) [IsFiniteMeasure ν] {t : ℝ} (ht : |t| < 1) :
+on the closed unit interval. -/
+theorem pgf_eq_tsum (ν : Measure ℕ) [IsFiniteMeasure ν] {t : ℝ} (ht : |t| ≤ 1) :
     pgf id ν t = ∑' n : ℕ, ν.real {n} * t ^ n :=
   (hasSum_pgf ν ht).tsum_eq.symm
 
@@ -220,7 +222,7 @@ theorem hasFPowerSeriesOnBall_pgf (ν : Measure ℕ) [IsFiniteMeasure ν] :
       rw [mem_eball_zero_iff, ← ofReal_norm, ENNReal.ofReal_lt_one] at hy
       simpa using hy
     simpa only [ofScalars_apply_eq, smul_eq_mul, zero_add] using
-      hasSum_pgf ν hy'
+      hasSum_pgf ν hy'.le
 
 /-- The probability-generating function of a finite measure on `ℕ` is analytic on the open unit
 interval. -/
@@ -243,17 +245,31 @@ theorem iteratedDeriv_pgf_zero (ν : Measure ℕ) [IsFiniteMeasure ν] (n : ℕ)
   rw [eq_comm, div_eq_iff (Nat.cast_ne_zero.mpr n.factorial_ne_zero)] at hcoeff
   rw [hcoeff, mul_comm]
 
+/-- Evaluating at the origin the probability-generating function of a finite measure on `ℕ` gives
+the mass of `{0}`.  This is the `n = 0` case of `iteratedDeriv_pgf_zero`, which `simp` normalises
+away from `iteratedDeriv`. -/
+@[simp]
+theorem pgf_zero (ν : Measure ℕ) [IsFiniteMeasure ν] : pgf id ν 0 = ν.real {0} := by
+  refine (hasSum_pgf ν (by norm_num)).unique ?_
+  simpa using hasSum_single (f := fun n : ℕ => ν.real {n} * (0 : ℝ) ^ n) 0
+    fun n hn => by simp [zero_pow hn]
+
+/-- The derivative at the origin of the probability-generating function of a finite measure on `ℕ`
+is the mass of `{1}`.  This is the `n = 1` case of `iteratedDeriv_pgf_zero`, which `simp`
+normalises away from `iteratedDeriv`. -/
+@[simp]
+theorem deriv_pgf_zero (ν : Measure ℕ) [IsFiniteMeasure ν] : deriv (pgf id ν) 0 = ν.real {1} := by
+  rw [← iteratedDeriv_one, iteratedDeriv_pgf_zero]
+  simp
+
 /-- A finite measure on `ℕ`, in particular a probability measure, is determined by the germ at the
 origin of its probability-generating function. -/
 theorem measure_eq_of_pgf_eventuallyEq {ν ν' : Measure ℕ} [IsFiniteMeasure ν] [IsFiniteMeasure ν']
     (h : pgf id ν =ᶠ[nhds 0] pgf id ν') : ν = ν' := by
-  refine Measure.ext_of_singleton fun n => ?_
+  refine ext_iff_measureReal_singleton.mpr fun n => ?_
   have hderiv := h.iteratedDeriv_eq n
   rw [iteratedDeriv_pgf_zero, iteratedDeriv_pgf_zero] at hderiv
-  have hmass : ν.real {n} = ν'.real {n} :=
-    mul_left_cancel₀ (Nat.cast_ne_zero.mpr n.factorial_ne_zero) hderiv
-  rwa [measureReal_def, measureReal_def,
-    ENNReal.toReal_eq_toReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)] at hmass
+  exact mul_left_cancel₀ (Nat.cast_ne_zero.mpr n.factorial_ne_zero) hderiv
 
 /-- A finite measure on `ℕ`, in particular a probability measure, is determined by its
 probability-generating function on the open unit interval. -/

--- a/TauCeti/Probability/GeneratingFunction.lean
+++ b/TauCeti/Probability/GeneratingFunction.lean
@@ -5,10 +5,16 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Analysis.Analytic.OfScalars
+public import Mathlib.Analysis.Calculus.IteratedDeriv.Defs
+public import Mathlib.Probability.IdentDistrib
 public import Mathlib.Probability.Moments.Basic
 public import Mathlib.Probability.Distributions.Binomial
 public import Mathlib.Probability.Distributions.Geometric
 public import Mathlib.Probability.Distributions.Poisson.Basic
+import Mathlib.Analysis.Analytic.Uniqueness
+import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
 import Mathlib.Probability.Independence.Integration
 
 /-!
@@ -17,13 +23,16 @@ import Mathlib.Probability.Independence.Integration
 This file defines the probability-generating function of a natural-number-valued random variable
 and establishes its basic measure-theoretic API.  The central results relate it to Mathlib's
 moment-generating function and show that it turns sums of independent random variables into
-products.  The file then computes the generating functions of the standard discrete families:
-Bernoulli, binomial, Poisson, and geometric, the last one on its exact integrability domain.
+products.  The file then identifies a finite measure on `ℕ` with the sum of the power series
+carrying its singleton masses, so that the generating function is analytic on the open unit
+interval and its Taylor coefficients at the origin recover those masses; consequently a law on `ℕ`
+is determined by its generating function near `0`.  Finally it computes the generating functions of
+the standard discrete families: Bernoulli, binomial, Poisson, and geometric, the last one on its
+exact integrability domain.
 
-These results implement the definition, the generic API and the distribution-specific formulas of
-the probability-generating-function target in `TauCetiRoadmap/StandardDistributions/README.md`,
-Layer 1.  Recovering the coefficients at the origin, and the resulting uniqueness theorem, remain
-future work.
+These results implement the definition, the generic API, the coefficient-recovery and uniqueness
+statements, and the distribution-specific formulas of the probability-generating-function target
+in `TauCetiRoadmap/StandardDistributions/README.md`, Layer 1.
 
 The Poisson series calculation follows the proof pattern of Mathlib's
 `ProbabilityTheory.charFun_map_cast_poissonMeasure`: both factor the Poisson weights out of the
@@ -38,6 +47,15 @@ corresponding measure-integral formulas directly.
   integrable under a finite measure.
 * `TauCeti.Probability.IndepFun.pgf_add` and `TauCeti.Probability.iIndepFun.pgf_sum` —
   multiplicativity over binary and finite sums of independent random variables.
+* `TauCeti.Probability.hasSum_pgf` and `TauCeti.Probability.pgf_eq_tsum` — the power-series
+  expansion in the singleton masses, valid on the open unit interval.
+* `TauCeti.Probability.hasFPowerSeriesOnBall_pgf` and `TauCeti.Probability.analyticOnNhd_pgf` —
+  analyticity on the open unit ball.
+* `TauCeti.Probability.iteratedDeriv_pgf_zero` — the Taylor coefficients at the origin are the
+  singleton masses.
+* `TauCeti.Probability.measure_eq_of_pgf_eqOn` and
+  `TauCeti.Probability.identDistrib_of_pgf_eqOn` — uniqueness of the law from the generating
+  function on `(-1, 1)`.
 * `TauCeti.Probability.pgf_bernoulliMeasure`, `pgf_binomial`, `pgf_poissonMeasure`, and
   `pgf_geometricMeasure` — the standard discrete-family formulas.
 -/
@@ -140,6 +158,115 @@ theorem iIndepFun.pgf_sum {ι : Type*} {X : ι → Ω → ℕ} (h_indep : iIndep
       rw [Finset.sum_insert hi, Finset.prod_insert hi,
         IndepFun.pgf_add (h_indep.indepFun_finsetSum_of_notMem₀ h_meas hi).symm (h_meas i)
           (Finset.aemeasurable_sum s fun j _ => h_meas j) t, hrec]
+
+/-! ### Coefficient recovery and uniqueness
+
+A finite measure on `ℕ` is the weighted sum of Dirac masses `∑ ν {n} • δ n`, so its
+generating function is the sum of the power series `∑ ν.real {n} * t ^ n`.  The masses are
+bounded by the total mass, so that series converges on the whole open unit ball and the generating
+function is analytic there.  Reading its Taylor coefficients at the origin returns the masses, and
+hence a probability measure on `ℕ` is determined by its generating function near `0`. -/
+
+section Coefficients
+
+open FormalMultilinearSeries
+
+/-- Under a finite measure on `ℕ`, the probability-generating function is the sum of the power
+series whose coefficients are the singleton masses, on the open unit interval. -/
+theorem hasSum_pgf (ν : Measure ℕ) [IsFiniteMeasure ν] {t : ℝ} (ht : |t| < 1) :
+    HasSum (fun n => ν.real {n} * t ^ n) (pgf id ν t) := by
+  have hbound : ∀ n : ℕ, ‖ν.real {n} * t ^ n‖ ≤ ν.real Set.univ * |t| ^ n := by
+    intro n
+    rw [norm_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_pow,
+      abs_of_nonneg measureReal_nonneg]
+    have hmass : ν.real {n} ≤ ν.real Set.univ := measureReal_mono (Set.subset_univ _)
+    exact mul_le_mul_of_nonneg_right hmass (by positivity)
+  have hsum : Summable fun n => ν.real {n} * t ^ n :=
+    Summable.of_norm_bounded ((summable_geometric_of_lt_one (abs_nonneg t) ht).mul_left _) hbound
+  have hint : Integrable (fun n : ℕ => t ^ n) ν :=
+    integrable_pow_of_abs_le_one (X := id) aemeasurable_id ht.le
+  have hpgf : pgf id ν t = ∑' n : ℕ, ν.real {n} * t ^ n := by
+    rw [pgf_def]
+    simp only [id_eq]
+    rw [integral_countable hint]
+    simp only [smul_eq_mul]
+  rw [hpgf]
+  exact hsum.hasSum
+
+/-- The power-series expansion of the probability-generating function of a finite measure on `ℕ`
+on the open unit interval. -/
+theorem pgf_eq_tsum (ν : Measure ℕ) [IsFiniteMeasure ν] {t : ℝ} (ht : |t| < 1) :
+    pgf id ν t = ∑' n : ℕ, ν.real {n} * t ^ n :=
+  (hasSum_pgf ν ht).tsum_eq.symm
+
+/-- The probability-generating function of a finite measure on `ℕ` has, at the origin, the formal
+power series whose coefficients are the singleton masses, and that series converges on the open
+unit ball. -/
+theorem hasFPowerSeriesOnBall_pgf (ν : Measure ℕ) [IsFiniteMeasure ν] :
+    HasFPowerSeriesOnBall (pgf id ν) (ofScalars ℝ fun n => ν.real {n}) 0 1 where
+  r_le := by
+    have := (ofScalars ℝ fun n => ν.real {n}).le_radius_of_bound (r := 1) (ν.real Set.univ)
+      fun n => by
+        rw [ofScalars_norm, Real.norm_eq_abs, abs_of_nonneg measureReal_nonneg]
+        have hmass : ν.real {n} ≤ ν.real Set.univ := measureReal_mono (Set.subset_univ _)
+        simpa using hmass
+    simpa using this
+  r_pos := one_pos
+  hasSum := by
+    intro y hy
+    have hy' : |y| < 1 := by
+      rw [mem_eball_zero_iff, ← ofReal_norm, ENNReal.ofReal_lt_one] at hy
+      simpa using hy
+    simpa only [ofScalars_apply_eq, smul_eq_mul, zero_add] using
+      hasSum_pgf ν hy'
+
+/-- The probability-generating function of a finite measure on `ℕ` is analytic on the open unit
+interval. -/
+theorem analyticOnNhd_pgf (ν : Measure ℕ) [IsFiniteMeasure ν] :
+    AnalyticOnNhd ℝ (pgf id ν) (Set.Ioo (-1) 1) :=
+  (hasFPowerSeriesOnBall_pgf ν).analyticOnNhd.mono fun x hx => by
+    rw [mem_eball_zero_iff, ← ofReal_norm, ENNReal.ofReal_lt_one]
+    simpa [abs_lt] using hx
+
+/-- The Taylor coefficients at the origin of the probability-generating function of a finite
+measure on `ℕ` are its singleton masses. -/
+theorem iteratedDeriv_pgf_zero (ν : Measure ℕ) [IsFiniteMeasure ν] (n : ℕ) :
+    iteratedDeriv n (pgf id ν) 0 = (n.factorial : ℝ) * ν.real {n} := by
+  have h₁ : HasFPowerSeriesAt (pgf id ν) (ofScalars ℝ fun k => ν.real {k}) 0 :=
+    ⟨1, hasFPowerSeriesOnBall_pgf ν⟩
+  have hcoeff := congrArg (fun p : FormalMultilinearSeries ℝ ℝ ℝ => p.coeff n)
+    (h₁.eq_formalMultilinearSeries h₁.analyticAt.hasFPowerSeriesAt)
+  simp only [coeff_ofScalars] at hcoeff
+  rw [eq_comm, div_eq_iff (Nat.cast_ne_zero.mpr n.factorial_ne_zero)] at hcoeff
+  rw [hcoeff, mul_comm]
+
+/-- A finite measure on `ℕ`, in particular a probability measure, is determined by its
+probability-generating function on the open unit interval. -/
+theorem measure_eq_of_pgf_eqOn {ν ν' : Measure ℕ} [IsFiniteMeasure ν] [IsFiniteMeasure ν']
+    (h : Set.EqOn (pgf id ν) (pgf id ν') (Set.Ioo (-1) 1)) : ν = ν' := by
+  refine Measure.ext_of_singleton fun n => ?_
+  have hev : pgf id ν =ᶠ[nhds 0] pgf id ν' :=
+    Filter.eventuallyEq_of_mem (Ioo_mem_nhds (by norm_num) (by norm_num)) h
+  have hderiv := hev.iteratedDeriv_eq n
+  rw [iteratedDeriv_pgf_zero, iteratedDeriv_pgf_zero] at hderiv
+  have hmass : ν.real {n} = ν'.real {n} :=
+    mul_left_cancel₀ (Nat.cast_ne_zero.mpr n.factorial_ne_zero) hderiv
+  rwa [measureReal_def, measureReal_def,
+    ENNReal.toReal_eq_toReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)] at hmass
+
+/-- Two natural-number-valued random variables whose probability-generating functions agree on the
+open unit interval are identically distributed. -/
+theorem identDistrib_of_pgf_eqOn {Ω' : Type*} [MeasurableSpace Ω'] {P : Measure Ω} {Q : Measure Ω'}
+    [IsFiniteMeasure P] [IsFiniteMeasure Q] {X : Ω → ℕ} {Y : Ω' → ℕ}
+    (hX : AEMeasurable X P) (hY : AEMeasurable Y Q)
+    (h : Set.EqOn (pgf X P) (pgf Y Q) (Set.Ioo (-1) 1)) : IdentDistrib X Y P Q := by
+  have := P.isFiniteMeasure_map X
+  have := Q.isFiniteMeasure_map Y
+  refine ⟨hX, hY, measure_eq_of_pgf_eqOn fun t ht => ?_⟩
+  rw [pgf_map hX, pgf_map hY]
+  exact h ht
+
+end Coefficients
 
 section NamedDistributions
 

--- a/TauCeti/Probability/GeneratingFunction.lean
+++ b/TauCeti/Probability/GeneratingFunction.lean
@@ -53,9 +53,11 @@ corresponding measure-integral formulas directly.
   analyticity on the open unit ball.
 * `TauCeti.Probability.iteratedDeriv_pgf_zero` — the Taylor coefficients at the origin are the
   singleton masses.
-* `TauCeti.Probability.measure_eq_of_pgf_eqOn` and
-  `TauCeti.Probability.identDistrib_of_pgf_eqOn` — uniqueness of the law from the generating
-  function on `(-1, 1)`.
+* `TauCeti.Probability.measure_eq_of_pgf_eventuallyEq` and
+  `TauCeti.Probability.identDistrib_of_pgf_eventuallyEq` — uniqueness of the law from the germ of
+  the generating function at `0`, with the corollaries
+  `TauCeti.Probability.measure_eq_of_pgf_eqOn` and `TauCeti.Probability.identDistrib_of_pgf_eqOn`
+  reading the hypothesis off `(-1, 1)`.
 * `TauCeti.Probability.pgf_bernoulliMeasure`, `pgf_binomial`, `pgf_poissonMeasure`, and
   `pgf_geometricMeasure` — the standard discrete-family formulas.
 -/
@@ -230,6 +232,7 @@ theorem analyticOnNhd_pgf (ν : Measure ℕ) [IsFiniteMeasure ν] :
 
 /-- The Taylor coefficients at the origin of the probability-generating function of a finite
 measure on `ℕ` are its singleton masses. -/
+@[simp]
 theorem iteratedDeriv_pgf_zero (ν : Measure ℕ) [IsFiniteMeasure ν] (n : ℕ) :
     iteratedDeriv n (pgf id ν) 0 = (n.factorial : ℝ) * ν.real {n} := by
   have h₁ : HasFPowerSeriesAt (pgf id ν) (ofScalars ℝ fun k => ν.real {k}) 0 :=
@@ -240,31 +243,46 @@ theorem iteratedDeriv_pgf_zero (ν : Measure ℕ) [IsFiniteMeasure ν] (n : ℕ)
   rw [eq_comm, div_eq_iff (Nat.cast_ne_zero.mpr n.factorial_ne_zero)] at hcoeff
   rw [hcoeff, mul_comm]
 
-/-- A finite measure on `ℕ`, in particular a probability measure, is determined by its
-probability-generating function on the open unit interval. -/
-theorem measure_eq_of_pgf_eqOn {ν ν' : Measure ℕ} [IsFiniteMeasure ν] [IsFiniteMeasure ν']
-    (h : Set.EqOn (pgf id ν) (pgf id ν') (Set.Ioo (-1) 1)) : ν = ν' := by
+/-- A finite measure on `ℕ`, in particular a probability measure, is determined by the germ at the
+origin of its probability-generating function. -/
+theorem measure_eq_of_pgf_eventuallyEq {ν ν' : Measure ℕ} [IsFiniteMeasure ν] [IsFiniteMeasure ν']
+    (h : pgf id ν =ᶠ[nhds 0] pgf id ν') : ν = ν' := by
   refine Measure.ext_of_singleton fun n => ?_
-  have hev : pgf id ν =ᶠ[nhds 0] pgf id ν' :=
-    Filter.eventuallyEq_of_mem (Ioo_mem_nhds (by norm_num) (by norm_num)) h
-  have hderiv := hev.iteratedDeriv_eq n
+  have hderiv := h.iteratedDeriv_eq n
   rw [iteratedDeriv_pgf_zero, iteratedDeriv_pgf_zero] at hderiv
   have hmass : ν.real {n} = ν'.real {n} :=
     mul_left_cancel₀ (Nat.cast_ne_zero.mpr n.factorial_ne_zero) hderiv
   rwa [measureReal_def, measureReal_def,
     ENNReal.toReal_eq_toReal_iff' (measure_ne_top _ _) (measure_ne_top _ _)] at hmass
 
+/-- A finite measure on `ℕ`, in particular a probability measure, is determined by its
+probability-generating function on the open unit interval. -/
+theorem measure_eq_of_pgf_eqOn {ν ν' : Measure ℕ} [IsFiniteMeasure ν] [IsFiniteMeasure ν']
+    (h : Set.EqOn (pgf id ν) (pgf id ν') (Set.Ioo (-1) 1)) : ν = ν' :=
+  measure_eq_of_pgf_eventuallyEq
+    (Filter.eventuallyEq_of_mem (Ioo_mem_nhds (by norm_num) (by norm_num)) h)
+
+/-- Two natural-number-valued random variables whose probability-generating functions agree near
+the origin are identically distributed. -/
+theorem identDistrib_of_pgf_eventuallyEq {Ω' : Type*} [MeasurableSpace Ω'] {P : Measure Ω}
+    {Q : Measure Ω'} [IsFiniteMeasure P] [IsFiniteMeasure Q] {X : Ω → ℕ} {Y : Ω' → ℕ}
+    (hX : AEMeasurable X P) (hY : AEMeasurable Y Q) (h : pgf X P =ᶠ[nhds 0] pgf Y Q) :
+    IdentDistrib X Y P Q := by
+  have := P.isFiniteMeasure_map X
+  have := Q.isFiniteMeasure_map Y
+  refine ⟨hX, hY, measure_eq_of_pgf_eventuallyEq ?_⟩
+  filter_upwards [h] with t ht
+  rw [pgf_map hX, pgf_map hY]
+  exact ht
+
 /-- Two natural-number-valued random variables whose probability-generating functions agree on the
 open unit interval are identically distributed. -/
 theorem identDistrib_of_pgf_eqOn {Ω' : Type*} [MeasurableSpace Ω'] {P : Measure Ω} {Q : Measure Ω'}
     [IsFiniteMeasure P] [IsFiniteMeasure Q] {X : Ω → ℕ} {Y : Ω' → ℕ}
     (hX : AEMeasurable X P) (hY : AEMeasurable Y Q)
-    (h : Set.EqOn (pgf X P) (pgf Y Q) (Set.Ioo (-1) 1)) : IdentDistrib X Y P Q := by
-  have := P.isFiniteMeasure_map X
-  have := Q.isFiniteMeasure_map Y
-  refine ⟨hX, hY, measure_eq_of_pgf_eqOn fun t ht => ?_⟩
-  rw [pgf_map hX, pgf_map hY]
-  exact h ht
+    (h : Set.EqOn (pgf X P) (pgf Y Q) (Set.Ioo (-1) 1)) : IdentDistrib X Y P Q :=
+  identDistrib_of_pgf_eventuallyEq hX hY
+    (Filter.eventuallyEq_of_mem (Ioo_mem_nhds (by norm_num) (by norm_num)) h)
 
 end Coefficients
 


### PR DESCRIPTION
This PR closes the probability-generating-function target of the `StandardDistributions` roadmap's Layer 1 milestone, "complete the elementary theory of existing distributions", by supplying the two pieces its bullet still lacked: coefficient recovery at the origin, `iteratedDeriv n (pgf id μ) 0 = n ! * μ.real {n}`, and the resulting uniqueness statement `measure_eq_of_pgf_eqOn`, which is also the layer's completion check "Equality of pgfs on `(-1, 1)` determines the native law on `ℕ`". The module docstring of `TauCeti/Probability/GeneratingFunction.lean` named exactly these two results as future work when the definition and the family formulas landed in #4085; that sentence is now removed, since Layer 1's pgf bullet is complete.

The route is the classical one, done at the level of measures. A finite measure on `ℕ` is a weighted sum of Dirac masses, so `integral_countable` turns the defining integral into `∑' n, μ.real {n} * t ^ n`; the masses are bounded by the total mass, so the series is dominated by a geometric series and `hasSum_pgf` converges on `|t| < 1`. That bound also bounds the norms of `FormalMultilinearSeries.ofScalars ℝ (fun n => μ.real {n})`, giving convergence radius at least one, so `hasFPowerSeriesOnBall_pgf` exhibits the generating function as the sum of that series on the open unit ball and `analyticOnNhd_pgf` records analyticity on `(-1, 1)`. Comparing this series with the Taylor series supplied by `AnalyticAt.hasFPowerSeriesAt`, through the one-dimensional uniqueness theorem `HasFPowerSeriesAt.eq_formalMultilinearSeries`, identifies the coefficients. Uniqueness then follows because `Set.Ioo (-1) 1` is a neighbourhood of `0`, so equal generating functions there have equal derivatives at `0`, hence equal singleton masses, hence are equal by `Measure.ext_of_singleton`; `identDistrib_of_pgf_eqOn` is the random-variable corollary, stated with `IdentDistrib` as the roadmap's reuse list directs. The measure-level results are proved for finite measures rather than only probability measures, which the proofs give for free.

The one file touched is `TauCeti/Probability/GeneratingFunction.lean`, which grows by about 130 lines to 359. No Mathlib source was vendored; the new imports are `Mathlib.Analysis.Analytic.OfScalars`, `Mathlib.Analysis.Analytic.Uniqueness`, `Mathlib.Analysis.Calculus.IteratedDeriv.{Defs,Lemmas}`, `Mathlib.MeasureTheory.Integral.Bochner.SumMeasure` and `Mathlib.Probability.IdentDistrib`. Mathlib has no probability-generating function of its own, and the roadmap records this as a named gap in Mathlib's undergraduate curriculum.

What remains of Layer 1 after this PR is the per-family elementary theory still in flight or unwritten — gamma (#4136), Pareto (#4108), exponential (#4106, #3955), geometric (#4083), and the Cauchy entry beyond the cdf of #4182.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"measure-eq-of-pgf-eqon"}-->

🤖 Prepared with Claude Code
