### PR TITLE
feat: compute the rational Dixon table for Q8

### DIFF
--- a/TauCeti/GroupTheory/SpecificGroups/Quaternion.lean
+++ b/TauCeti/GroupTheory/SpecificGroups/Quaternion.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.SpecificGroups.Quaternion
+
+/-!
+# A computable enumeration of the quaternion groups
+
+Mathlib equips `QuaternionGroup n` with a `Fintype` instance when `n` is nonzero, but converting
+that instance to a list is noncomputable.  The Dixon--Schneider character-table algorithm needs a
+list whose reduction can be evaluated by the kernel.  `TauCeti.quaternionElements` lists the two
+constructors at every index and `TauCeti.mem_quaternionElements` proves that the list is exhaustive.
+
+The file also records the exponent of `QuaternionGroup 2`, the quaternion group of order eight,
+in the form used by its explicit Dixon-prime certificate.
+
+## Main definitions
+
+* `TauCeti.quaternionElements`: a computable enumeration of `QuaternionGroup n`.
+
+## Main results
+
+* `TauCeti.mem_quaternionElements`: the enumeration contains every group element.
+* `TauCeti.exponent_quaternionGroup_two`: `QuaternionGroup 2` has exponent four.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- The elements `a 0, xa 0, ..., a (2n-1), xa (2n-1)` of `QuaternionGroup n`.  For nonzero
+`n` this lists all `4 * n` elements.  The body is exposed so downstream class-data computations
+can reduce it in the kernel. -/
+@[expose] def quaternionElements (n : ℕ) : List (QuaternionGroup n) :=
+  (List.range (2 * n)).flatMap fun i : ℕ =>
+    [QuaternionGroup.a (i : ZMod (2 * n)), QuaternionGroup.xa (i : ZMod (2 * n))]
+
+/-- The enumeration `TauCeti.quaternionElements` exhausts `QuaternionGroup n` when `n` is
+nonzero. -/
+theorem mem_quaternionElements {n : ℕ} [NeZero n] (g : QuaternionGroup n) :
+    g ∈ quaternionElements n := by
+  have hmem : ∀ i : ZMod (2 * n), i.val ∈ List.range (2 * n) :=
+    fun i => List.mem_range.mpr (ZMod.val_lt i)
+  cases g with
+  | a i =>
+      refine List.mem_flatMap.mpr ⟨i.val, hmem i, ?_⟩
+      rw [ZMod.natCast_rightInverse i]
+      simp
+  | xa i =>
+      refine List.mem_flatMap.mpr ⟨i.val, hmem i, ?_⟩
+      rw [ZMod.natCast_rightInverse i]
+      simp
+
+/-- The quaternion group of order eight has exponent four. -/
+@[simp]
+theorem exponent_quaternionGroup_two : Monoid.exponent (QuaternionGroup 2) = 4 := by
+  rw [QuaternionGroup.exponent]
+  decide
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/Quaternion.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/Quaternion.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.GroupTheory.SpecificGroups.Quaternion
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.Basic
+
+/-!
+# Class data for the quaternion group of order eight
+
+This file feeds the computable enumeration `TauCeti.quaternionElements` to
+`TauCeti.ClassData.ofList` and evaluates the conjugacy classes and class-algebra structure constants
+of `QuaternionGroup 2`.  The five classes have representatives `1`, `-1`, and one member of each
+of the three pairs of quaternion units.  Their structure constants agree with those of
+`DihedralGroup 4`, as expected from the equality of the two groups' character tables.
+
+## Main definitions
+
+* `TauCeti.quaternionClassData`: computable class data for `QuaternionGroup n`.
+
+## Main results
+
+* `TauCeti.numClasses_quaternionClassData_two`: there are five conjugacy classes.
+* `TauCeti.card_classFinset_quaternionClassData_two`: their sizes are `1, 1, 2, 2, 2`.
+* `TauCeti.structureConstantTable_quaternionClassData_two`: the complete class multiplication
+  table, evaluated by the kernel.
+
+## References
+
+This is the `Q₈ = QuaternionGroup 2` input for the rational-table milestone in Layer 6 of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md).
+-/
+
+public section
+
+namespace TauCeti
+
+/-- Class data for `QuaternionGroup n`, computed from `TauCeti.quaternionElements`. -/
+@[expose] def quaternionClassData (n : ℕ) [NeZero n] : ClassData (QuaternionGroup n) :=
+  ClassData.ofList (quaternionElements n) fun g =>
+    ⟨g, mem_quaternionElements g, IsConj.refl g⟩
+
+/-- **The quaternion group of order eight has five conjugacy classes.** -/
+theorem numClasses_quaternionClassData_two : (quaternionClassData 2).numClasses = 5 := by
+  decide
+
+/-- **The conjugacy classes of the quaternion group of order eight have sizes
+`1, 1, 2, 2, 2`.**  The numbering produced by `TauCeti.ClassData.ofList` has representatives
+`a 0`, `a 2`, `xa 2`, `a 3`, and `xa 3`: the identity, the central element of order two, and
+one member of each pair of elements of order four. -/
+theorem card_classFinset_quaternionClassData_two :
+    (quaternionClassData 2).classes.map Finset.card = [1, 1, 2, 2, 2] := by
+  decide
+
+/-- **The structure constants of the quaternion group of order eight.**  Each noncentral class
+square is `2K₀ + 2K₁`, and the product of two distinct noncentral classes is twice the third.
+This is the entire group-specific input to the Dixon--Schneider computation. -/
+theorem structureConstantTable_quaternionClassData_two :
+    (quaternionClassData 2).structureConstantTable =
+      [[[1, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0], [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]],
+       [[0, 1, 0, 0, 0], [1, 0, 0, 0, 0], [0, 0, 1, 0, 0], [0, 0, 0, 1, 0], [0, 0, 0, 0, 1]],
+       [[0, 0, 1, 0, 0], [0, 0, 1, 0, 0], [2, 2, 0, 0, 0], [0, 0, 0, 0, 2], [0, 0, 0, 2, 0]],
+       [[0, 0, 0, 1, 0], [0, 0, 0, 1, 0], [0, 0, 0, 0, 2], [2, 2, 0, 0, 0], [0, 0, 2, 0, 0]],
+       [[0, 0, 0, 0, 1], [0, 0, 0, 0, 1], [0, 0, 0, 2, 0], [0, 0, 2, 0, 0], [2, 2, 0, 0, 0]]] := by
+  decide
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Quaternion.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Quaternion.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.GroupTheory.SpecificGroups.Quaternion
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Prime
+
+/-!
+# Dixon prime data for the quaternion group of order eight
+
+The executable Dixon--Schneider algorithm receives a certified prime rather than searching for
+one noncomputably.  This file certifies `5` for `QuaternionGroup 2`, together with `2` as a
+primitive fourth root of unity modulo `5`.
+
+## Main definitions
+
+* `TauCeti.quaternionGroupTwoDixonPrimeData`: Dixon prime data for `QuaternionGroup 2`.
+
+## References
+
+* The roadmap `RepresentationTheory/CharacterTheory`, Layer 6, "Certified Dixon prime data".
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **`5` is a good Dixon prime for the quaternion group of order eight**: `5 ∤ 8`, its
+exponent `4` divides `5 - 1`, and `2⌊√8⌋ = 4 < 5`. -/
+theorem isGoodDixonPrime_quaternionGroup_two_five : IsGoodDixonPrime (QuaternionGroup 2) 5 := by
+  refine ⟨by decide, ?_, ?_, ?_⟩
+  · rw [Nat.card_eq_fintype_card, QuaternionGroup.card]
+    decide
+  · rw [exponent_quaternionGroup_two]
+  · rw [Nat.card_eq_fintype_card, QuaternionGroup.card]
+    have h : Nat.sqrt (4 * 2) < 3 := Nat.sqrt_lt.2 (by norm_num)
+    omega
+
+/-- Dixon prime data for `QuaternionGroup 2`: the prime `5`, with `2` as the primitive fourth
+root of unity modulo `5`. -/
+@[expose] def quaternionGroupTwoDixonPrimeData : DixonPrimeData (QuaternionGroup 2) where
+  p := 5
+  root := 2
+  isGoodDixonPrime := isGoodDixonPrime_quaternionGroup_two_five
+  isPrimitiveRoot_root := by
+    rw [exponent_quaternionGroup_two]
+    exact .mk_of_lt 2 (by norm_num) (by decide) fun l hl0 hl4 => by interval_cases l <;> decide
+
+/-- The prime carried by `TauCeti.quaternionGroupTwoDixonPrimeData` is `5`. -/
+@[simp]
+theorem quaternionGroupTwoDixonPrimeData_p : quaternionGroupTwoDixonPrimeData.p = 5 := rfl
+
+/-- The primitive fourth root carried by `TauCeti.quaternionGroupTwoDixonPrimeData` is `2`. -/
+@[simp]
+theorem quaternionGroupTwoDixonPrimeData_root : quaternionGroupTwoDixonPrimeData.root = 2 := rfl
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Quaternion.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Quaternion.lean
@@ -41,7 +41,7 @@ theorem isGoodDixonPrime_quaternionGroup_two_five : IsGoodDixonPrime (Quaternion
 
 /-- Dixon prime data for `QuaternionGroup 2`: the prime `5`, with `2` as the primitive fourth
 root of unity modulo `5`. -/
-@[expose] def quaternionGroupTwoDixonPrimeData : DixonPrimeData (QuaternionGroup 2) where
+def quaternionGroupTwoDixonPrimeData : DixonPrimeData (QuaternionGroup 2) where
   p := 5
   root := 2
   isGoodDixonPrime := isGoodDixonPrime_quaternionGroup_two_five
@@ -51,10 +51,10 @@ root of unity modulo `5`. -/
 
 /-- The prime carried by `TauCeti.quaternionGroupTwoDixonPrimeData` is `5`. -/
 @[simp]
-theorem quaternionGroupTwoDixonPrimeData_p : quaternionGroupTwoDixonPrimeData.p = 5 := rfl
+theorem quaternionGroupTwoDixonPrimeData_p : quaternionGroupTwoDixonPrimeData.p = 5 := (rfl)
 
 /-- The primitive fourth root carried by `TauCeti.quaternionGroupTwoDixonPrimeData` is `2`. -/
 @[simp]
-theorem quaternionGroupTwoDixonPrimeData_root : quaternionGroupTwoDixonPrimeData.root = 2 := rfl
+theorem quaternionGroupTwoDixonPrimeData_root : quaternionGroupTwoDixonPrimeData.root = 2 := (rfl)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean
@@ -1,0 +1,253 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Data.ZMod.ValMinAbs
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.CentralCharacterCount
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.Quaternion
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Quaternion
+
+/-!
+# The rational Dixon computation for the quaternion group of order eight
+
+This file runs the rational stage of the Dixon--Schneider character-table algorithm for
+`QuaternionGroup 2`.  Its five numbered conjugacy classes have sizes `[1, 1, 2, 2, 2]`.
+Reducing modulo the certified good prime `5`, the simultaneous eigenrow search returns exactly
+the reductions of the five rows displayed in `TauCeti.quaternionGroupTwoCentralCharacterTable`.
+
+Each displayed row is checked against the computed structure constants, while the good-prime
+count theorem supplies completeness of the modular search.  Signed least representatives modulo
+`5` then recover the integral central-character rows.  Degree recovery converts these to the
+ordinary table, which is the same matrix as the table of `DihedralGroup 4`, the classical example
+of nonisomorphic groups with equal character tables.
+
+## Main definitions
+
+* `TauCeti.quaternionGroupTwoCentralCharacterTable`: the five integral central-character rows.
+* `TauCeti.quaternionGroupTwoModularCentralRows`: their reductions modulo `5`.
+* `TauCeti.quaternionGroupTwoCharacterTable`: the resulting ordinary integral character table.
+
+## Main results
+
+* `TauCeti.quaternionGroupTwo_centralCharacterSearch`: the modular search returns exactly the
+  displayed reductions.
+* `TauCeti.quaternionGroupTwo_valMinAbs_centralCharacterTable`: signed least representatives lift
+  every modular entry to the displayed integer.
+* `TauCeti.quaternionGroupTwo_degree_mul_centralCharacterTable`: the division-free conversion to
+  the ordinary character table.
+
+## References
+
+This closes the `Q₈ = QuaternionGroup 2` part of "Rational tables (first executable milestone)"
+in Layer 6 of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md).
+
+* J. D. Dixon, *High speed computation of group characters*, Numerische Mathematik 10 (1967),
+  446--450.
+* G. Schneider, *Dixon's character table algorithm revisited*, J. Symbolic Comput. 9 (1990),
+  601--606.
+-/
+
+public section
+
+namespace TauCeti
+
+open Matrix
+
+local instance : Fact (Nat.Prime 5) := ⟨by decide⟩
+
+/-- The numbered conjugacy classes of the quaternion group of order eight. -/
+abbrev QuaternionGroupTwoClassIndex := Fin (quaternionClassData 2).numClasses
+
+/-- **The integral central-character table of the quaternion group of order eight.** Columns
+follow `TauCeti.quaternionClassData 2`: the identity, the central element of order two, and the
+three classes consisting of a pair of quaternion units. -/
+def quaternionGroupTwoCentralCharacterTable :
+    Matrix QuaternionGroupTwoClassIndex QuaternionGroupTwoClassIndex ℤ :=
+  !![1,  1,  2,  2,  2;
+     1,  1,  2, -2, -2;
+     1,  1, -2,  2, -2;
+     1,  1, -2, -2,  2;
+     1, -1,  0,  0,  0]
+
+/-- The quaternion and dihedral groups of order eight have the same central-character matrix in
+their respective class numberings. -/
+@[simp]
+theorem quaternionGroupTwoCentralCharacterTable_apply
+    (i j : QuaternionGroupTwoClassIndex) :
+    quaternionGroupTwoCentralCharacterTable i j =
+      !![1,  1,  2,  2,  2;
+         1,  1,  2, -2, -2;
+         1,  1, -2,  2, -2;
+         1,  1, -2, -2,  2;
+         1, -1,  0,  0,  0] i j := by
+  rfl
+
+/-- The five central-character rows reduced modulo the certified Dixon prime `5`. -/
+def quaternionGroupTwoModularCentralRows :
+    Finset (QuaternionGroupTwoClassIndex → ZMod 5) :=
+  Finset.univ.image fun i j => (quaternionGroupTwoCentralCharacterTable i j : ZMod 5)
+
+/-- A modular row is displayed exactly when it is the reduction of a row of the integral table. -/
+@[simp]
+theorem mem_quaternionGroupTwoModularCentralRows_iff
+    {a : QuaternionGroupTwoClassIndex → ZMod 5} :
+    a ∈ quaternionGroupTwoModularCentralRows ↔
+      ∃ i, (fun j => (quaternionGroupTwoCentralCharacterTable i j : ZMod 5)) = a := by
+  simp [quaternionGroupTwoModularCentralRows]
+
+/-- Each integral row is a simultaneous eigenrow of the integral class-multiplication matrices. -/
+theorem isModularEigenrow_quaternionGroupTwoCentralCharacterTable_int
+    (i : QuaternionGroupTwoClassIndex) :
+    (quaternionClassData 2).IsModularEigenrow
+      (fun j => quaternionGroupTwoCentralCharacterTable i j) := by
+  rw [(quaternionClassData 2).isModularEigenrow_iff]
+  simp only [quaternionGroupTwoCentralCharacterTable_apply]
+  fin_cases i <;> decide
+
+/-- Reindexing an integral row by the actual conjugacy classes gives a class-algebra eigenrow. -/
+theorem isClassEigenrow_quaternionGroupTwoCentralCharacterTable
+    (i : QuaternionGroupTwoClassIndex) :
+    IsClassEigenrow ((quaternionClassData 2).reindexModularRow
+      fun j => quaternionGroupTwoCentralCharacterTable i j) :=
+  ((quaternionClassData 2).isModularEigenrow_iff_isClassEigenrow _).mp
+    (isModularEigenrow_quaternionGroupTwoCentralCharacterTable_int i)
+
+/-- Every displayed reduction is a simultaneous eigenrow over `ZMod 5`. -/
+theorem isModularEigenrow_quaternionGroupTwoCentralCharacterTable_zmod
+    (i : QuaternionGroupTwoClassIndex) :
+    (quaternionClassData 2).IsModularEigenrow
+      (fun j => (quaternionGroupTwoCentralCharacterTable i j : ZMod 5)) := by
+  rw [(quaternionClassData 2).isModularEigenrow_iff]
+  simp only [quaternionGroupTwoCentralCharacterTable_apply]
+  fin_cases i <;> decide
+
+/-- The explicit set of modular rows has five elements. -/
+@[simp]
+theorem card_quaternionGroupTwoModularCentralRows :
+    quaternionGroupTwoModularCentralRows.card = 5 := by
+  decide
+
+/-- **The executable modular central-character search for `QuaternionGroup 2` returns precisely
+the five displayed reductions.** -/
+theorem quaternionGroupTwo_centralCharacterSearch :
+    (quaternionClassData 2).centralCharacterSearch (F := ZMod 5) =
+      quaternionGroupTwoModularCentralRows := by
+  symm
+  apply Finset.eq_of_subset_of_card_le
+  · rw [quaternionGroupTwoModularCentralRows, Finset.image_subset_iff]
+    intro i _
+    rw [(quaternionClassData 2).mem_centralCharacterSearch]
+    exact ⟨by fin_cases i <;> decide,
+      isModularEigenrow_quaternionGroupTwoCentralCharacterTable_zmod i⟩
+  · rw [(quaternionClassData 2).card_centralCharacterSearch_of_isGoodDixonPrime
+      isGoodDixonPrime_quaternionGroup_two_five,
+      card_quaternionGroupTwoModularCentralRows, numClasses_quaternionClassData_two]
+
+/-- **Signed least representatives modulo `5` recover the integral central-character table.** -/
+theorem quaternionGroupTwo_valMinAbs_centralCharacterTable
+    (i j : QuaternionGroupTwoClassIndex) :
+    ((quaternionGroupTwoCentralCharacterTable i j : ZMod 5)).valMinAbs =
+      quaternionGroupTwoCentralCharacterTable i j := by
+  rw [quaternionGroupTwoCentralCharacterTable_apply]
+  apply ZMod.valMinAbs_intCast_of_two_mul_natAbs_lt
+  fin_cases i <;> fin_cases j <;> decide
+
+/-- The signed integral rows obtained from the output of the modular search. -/
+def quaternionGroupTwoLiftedCentralRows :
+    Finset (QuaternionGroupTwoClassIndex → ℤ) :=
+  ((quaternionClassData 2).centralCharacterSearch (F := ZMod 5)).image
+    fun a j => (a j).valMinAbs
+
+/-- **The rational lift is exactly the displayed integral central-character table, up to row
+order.** -/
+theorem quaternionGroupTwo_liftedCentralRows :
+    quaternionGroupTwoLiftedCentralRows =
+      Finset.univ.image fun i => quaternionGroupTwoCentralCharacterTable i := by
+  rw [quaternionGroupTwoLiftedCentralRows, quaternionGroupTwo_centralCharacterSearch,
+    quaternionGroupTwoModularCentralRows, Finset.image_image]
+  apply Finset.image_congr
+  intro i _
+  funext j
+  exact quaternionGroupTwo_valMinAbs_centralCharacterTable i j
+
+/-- A lifted row occurs exactly when it is a row of the displayed integral table. -/
+@[simp]
+theorem mem_quaternionGroupTwoLiftedCentralRows_iff
+    {a : QuaternionGroupTwoClassIndex → ℤ} :
+    a ∈ quaternionGroupTwoLiftedCentralRows ↔
+      ∃ i, quaternionGroupTwoCentralCharacterTable i = a := by
+  rw [quaternionGroupTwo_liftedCentralRows]
+  simp
+
+/-- The degrees attached to the five central-character rows. -/
+def quaternionGroupTwoCharacterDegrees : QuaternionGroupTwoClassIndex → ℕ :=
+  ![1, 1, 1, 1, 2]
+
+/-- The quaternion and dihedral groups of order eight have the same degree vector. -/
+@[simp]
+theorem quaternionGroupTwoCharacterDegrees_apply (i : QuaternionGroupTwoClassIndex) :
+    quaternionGroupTwoCharacterDegrees i = ![1, 1, 1, 1, 2] i := by
+  rfl
+
+/-- **The integral character table produced by the rational Dixon computation for the quaternion
+group of order eight.** -/
+def quaternionGroupTwoCharacterTable :
+    Matrix QuaternionGroupTwoClassIndex QuaternionGroupTwoClassIndex ℤ :=
+  !![1,  1,  1,  1,  1;
+     1,  1,  1, -1, -1;
+     1,  1, -1,  1, -1;
+     1,  1, -1, -1,  1;
+     2, -2,  0,  0,  0]
+
+/-- **The quaternion and dihedral groups of order eight have the same ordinary character matrix**
+in their respective class numberings. -/
+@[simp]
+theorem quaternionGroupTwoCharacterTable_apply (i j : QuaternionGroupTwoClassIndex) :
+    quaternionGroupTwoCharacterTable i j =
+      !![1,  1,  1,  1,  1;
+         1,  1,  1, -1, -1;
+         1,  1, -1,  1, -1;
+         1,  1, -1, -1,  1;
+         2, -2,  0,  0,  0] i j := by
+  rfl
+
+/-- **Division-free conversion from central characters to ordinary characters.** For every row
+`i` and numbered conjugacy class `j`, `degree i * omega i j = |K_j| * chi i j`. -/
+theorem quaternionGroupTwo_degree_mul_centralCharacterTable
+    (i j : QuaternionGroupTwoClassIndex) :
+    (quaternionGroupTwoCharacterDegrees i : ℤ) *
+        quaternionGroupTwoCentralCharacterTable i j =
+      ((quaternionClassData 2).classFinset j).card * quaternionGroupTwoCharacterTable i j := by
+  simp only [quaternionGroupTwoCharacterDegrees_apply,
+    quaternionGroupTwoCentralCharacterTable_apply, quaternionGroupTwoCharacterTable_apply]
+  fin_cases i <;> fin_cases j <;> decide
+
+/-- The displayed degrees are positive and divide the order of `QuaternionGroup 2`. -/
+theorem quaternionGroupTwo_characterDegrees_pos_and_dvd (i : QuaternionGroupTwoClassIndex) :
+    0 < quaternionGroupTwoCharacterDegrees i ∧
+      quaternionGroupTwoCharacterDegrees i ∣ Nat.card (QuaternionGroup 2) := by
+  rw [Nat.card_eq_fintype_card, QuaternionGroup.card]
+  simp only [quaternionGroupTwoCharacterDegrees_apply]
+  fin_cases i <;> decide
+
+/-- The squares of the displayed degrees sum to the group order. -/
+theorem quaternionGroupTwo_sum_characterDegrees_sq :
+    ∑ i, quaternionGroupTwoCharacterDegrees i ^ 2 = Nat.card (QuaternionGroup 2) := by
+  rw [Nat.card_eq_fintype_card, QuaternionGroup.card]
+  simp only [quaternionGroupTwoCharacterDegrees_apply]
+  decide
+
+/-- The ordinary character rows satisfy the class-size weighted orthogonality relations. -/
+theorem quaternionGroupTwo_characterTable_orthogonal (i j : QuaternionGroupTwoClassIndex) :
+    ∑ k, ((quaternionClassData 2).classFinset k).card *
+        quaternionGroupTwoCharacterTable i k * quaternionGroupTwoCharacterTable j k =
+      if i = j then Nat.card (QuaternionGroup 2) else 0 := by
+  rw [Nat.card_eq_fintype_card, QuaternionGroup.card]
+  simp only [quaternionGroupTwoCharacterTable_apply]
+  fin_cases i <;> fin_cases j <;> decide
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean
@@ -49,6 +49,9 @@ in Layer 6 of the
   446--450.
 * G. Schneider, *Dixon's character table algorithm revisited*, J. Symbolic Comput. 9 (1990),
   601--606.
+* The formal template is
+  `TauCeti.RepresentationTheory.CharacterTable.Dixon.Rational.DihedralFour`; this file and its
+  quaternion class-data and good-prime prerequisites adapt the corresponding dihedral development.
 -/
 
 public section
@@ -73,8 +76,7 @@ def quaternionGroupTwoCentralCharacterTable :
      1,  1, -2, -2,  2;
      1, -1,  0,  0,  0]
 
-/-- The quaternion and dihedral groups of order eight have the same central-character matrix in
-their respective class numberings. -/
+/-- The entries of the integral central-character table. -/
 @[simp]
 theorem quaternionGroupTwoCentralCharacterTable_apply
     (i j : QuaternionGroupTwoClassIndex) :
@@ -187,7 +189,7 @@ theorem mem_quaternionGroupTwoLiftedCentralRows_iff
 def quaternionGroupTwoCharacterDegrees : QuaternionGroupTwoClassIndex → ℕ :=
   ![1, 1, 1, 1, 2]
 
-/-- The quaternion and dihedral groups of order eight have the same degree vector. -/
+/-- The degrees attached to the central-character rows, entrywise. -/
 @[simp]
 theorem quaternionGroupTwoCharacterDegrees_apply (i : QuaternionGroupTwoClassIndex) :
     quaternionGroupTwoCharacterDegrees i = ![1, 1, 1, 1, 2] i := by
@@ -203,8 +205,7 @@ def quaternionGroupTwoCharacterTable :
      1,  1, -1, -1,  1;
      2, -2,  0,  0,  0]
 
-/-- **The quaternion and dihedral groups of order eight have the same ordinary character matrix**
-in their respective class numberings. -/
+/-- The entries of the ordinary integral character table. -/
 @[simp]
 theorem quaternionGroupTwoCharacterTable_apply (i j : QuaternionGroupTwoClassIndex) :
     quaternionGroupTwoCharacterTable i j =

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean
@@ -20,15 +20,16 @@ the reductions of the five rows displayed in `TauCeti.quaternionGroupTwoCentralC
 
 Each displayed row is checked against the computed structure constants, while the good-prime
 count theorem supplies completeness of the modular search.  Signed least representatives modulo
-`5` then recover the integral central-character rows.  Degree recovery converts these to the
-ordinary table, which is the same matrix as the table of `DihedralGroup 4`, the classical example
-of nonisomorphic groups with equal character tables.
+`5` then recover the integral central-character rows.  The displayed candidate degrees and ordinary
+table are verified by the division-free conversion identity, the degree-square sum, and weighted
+row orthogonality.  The ordinary table is the same matrix as the table of `DihedralGroup 4`, the
+classical example of nonisomorphic groups with equal character tables.
 
 ## Main definitions
 
 * `TauCeti.quaternionGroupTwoCentralCharacterTable`: the five integral central-character rows.
 * `TauCeti.quaternionGroupTwoModularCentralRows`: their reductions modulo `5`.
-* `TauCeti.quaternionGroupTwoCharacterTable`: the resulting ordinary integral character table.
+* `TauCeti.quaternionGroupTwoCharacterTable`: the displayed ordinary integral character table.
 
 ## Main results
 
@@ -195,8 +196,9 @@ theorem quaternionGroupTwoCharacterDegrees_apply (i : QuaternionGroupTwoClassInd
     quaternionGroupTwoCharacterDegrees i = ![1, 1, 1, 1, 2] i := by
   rfl
 
-/-- **The integral character table produced by the rational Dixon computation for the quaternion
-group of order eight.** -/
+/-- **The displayed candidate integral character table for the quaternion group of order eight.**
+The results below verify its conversion from the displayed central-character table, degree-square
+sum, and weighted row orthogonality. -/
 def quaternionGroupTwoCharacterTable :
     Matrix QuaternionGroupTwoClassIndex QuaternionGroupTwoClassIndex ℤ :=
   !![1,  1,  1,  1,  1;


### PR DESCRIPTION
This PR computes the rational Dixon--Schneider character table of `Q₈ = QuaternionGroup 2` from executable class data. Enumerate the eight quaternion-group elements, evaluate the five conjugacy classes and their structure constants, certify `5` as a good Dixon prime, prove that the modular simultaneous-eigenrow search returns exactly the five displayed reductions, lift them by signed least representatives, and verify degree recovery, the degree-square sum, and weighted row orthogonality. The resulting ordinary matrix is the same four-linear-plus-one-degree-two table as `DihedralGroup 4`, now independently certified against `Q₈`'s class algebra.

The exact roadmap target is `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, Layer 6, "Worked examples (acceptance criteria), staged", milestone "Rational tables (first executable milestone)", specifically the `Q₈ = QuaternionGroup 2` table in the stated `D₄`/`Q₈` pair. This is the most effective current step because the `D₄` computation is on `main`, the neighboring `C₂` and `S₃` computations are in flight, and no open work supplies the remaining `Q₈` output.

After this PR, the rational milestone needs the in-flight `C₂` and `S₃` computations to land and the general assembled solver/checker connection; the later Frobenius--Schur layer still distinguishes the shared two-dimensional row by indicator `+1` for `D₄` and `-1` for `Q₈`.

Add `TauCeti/GroupTheory/SpecificGroups/Quaternion.lean` (64 lines), `TauCeti/RepresentationTheory/CharacterTable/Dixon/ClassData/Quaternion.lean` (70 lines), `TauCeti/RepresentationTheory/CharacterTable/Dixon/Quaternion.lean` (60 lines), and `TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/QuaternionEight.lean` (253 lines). Reuse Mathlib's `QuaternionGroup`, Tau Ceti's `ClassData`, good-prime count, modular eigenrow search, and `ZMod.valMinAbs` APIs. The computation follows Dixon's 1967 algorithm and Schneider's simultaneous-eigenspace refinement, both cited in the module documentation, and follows the established in-repository `DihedralFour.lean` worked-example API. No Mathlib code or supplementary snapshot material is vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"quaternion-eight-dixon-character-table"}-->

🤖 Prepared with Codex
