### PR TITLE
feat(Multiquadratic): |Gal(K_gen/K)| = |Cl/Cl²| for imaginary quadratic fields

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -57,6 +57,8 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     have h1 : (0 : ℚ) ≤ ((d : ℤ) : ℚ) := hr ▸ mul_self_nonneg r
     have h2 : ((d : ℤ) : ℚ) < 0 := by exact_mod_cast hneg
     linarith
+  have : NumberField (candidateGenusFieldBase hd) :=
+    NumberField.of_intermediateField (candidateGenusFieldBase hd)
   have : Finite (ClassGroup (𝓞 (candidateGenusFieldBase hd))) := inferInstance
   rw [card_aut_candidateGenusField_over_base hd hnsq,
     TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -30,8 +30,8 @@ Euler to Eisenstein*, §2.2.
 
 ## Main result
 
-* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base_eq_two_pow_twoRank`: for imaginary
-  `K`, `|Gal(K_gen/K)| = 2 ^ (2-rank Cl(K)) = |Cl(K)/Cl(K)²|`.
+* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient`: for
+  imaginary `K`, `|Gal(K_gen/K)| = |Cl(K)/Cl(K)²|`.
 -/
 
 public section
@@ -43,16 +43,15 @@ namespace TauCeti.Multiquadratic
 
 variable {d : ℤ}
 
-/-- **The relative candidate-genus-field Galois group has order `2 ^ (2-rank Cl(K))`.** For an
-imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals
-`2 ^ (2-rank Cl(K))`, which is the cardinality `|Cl(K)/Cl(K)²|`; both are `2 ^ (t - 1)`, where `t`
-is the number of rational primes ramifying in `K`. This is the
-numerical content of the summit isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` — the two sides have equal
-order — established without class field theory. -/
-theorem card_aut_candidateGenusField_over_base_eq_two_pow_twoRank
+/-- **The relative candidate-genus-field Galois group and `Cl(K)/Cl(K)²` have equal order.** For an
+imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals `|Cl(K)/Cl(K)²|`
+— both are `2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`. This is the
+cardinality shadow of the summit isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`, established without
+class field theory. -/
+theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     (hd : Squarefree d) (hneg : d < 0) :
     Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
-      2 ^ TauCeti.ClassGroup.twoRank (𝓞 (candidateGenusFieldBase hd)) := by
+      Nat.card (TauCeti.ClassGroup.ElementaryTwoQuotient (𝓞 (candidateGenusFieldBase hd))) := by
   have hnsq : ¬ IsSquare ((d : ℤ) : ℚ) := by
     rintro ⟨r, hr⟩
     have h1 : (0 : ℚ) ≤ ((d : ℤ) : ℚ) := hr ▸ mul_self_nonneg r
@@ -60,7 +59,10 @@ theorem card_aut_candidateGenusField_over_base_eq_two_pow_twoRank
     linarith
   have : NumberField (candidateGenusFieldBase hd) :=
     NumberField.of_intermediateField (candidateGenusFieldBase hd)
+  have : Fintype (ClassGroup (𝓞 (candidateGenusFieldBase hd))) :=
+    NumberField.RingOfIntegers.instFintypeClassGroup
   rw [card_aut_candidateGenusField_over_base hd hnsq,
+    TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
     twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
       (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hneg,
     card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -60,7 +60,8 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
   have : NumberField (candidateGenusFieldBase hd) :=
     NumberField.of_intermediateField (candidateGenusFieldBase hd)
   have : Fintype (ClassGroup (𝓞 (candidateGenusFieldBase hd))) :=
-    NumberField.RingOfIntegers.instFintypeClassGroup
+    ClassGroup.fintypeOfAdmissibleOfFinite ℚ (candidateGenusFieldBase hd)
+      AbsoluteValue.absIsAdmissible
   rw [card_aut_candidateGenusField_over_base hd hnsq,
     TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
     twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -9,6 +9,7 @@ public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.G
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
 import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.RamifiedPrimes
 import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Quadratic
+import Mathlib.NumberTheory.NumberField.ClassNumber
 
 /-!
 # The relative candidate-genus-field Galois group has the same order as `Cl / Cl²`
@@ -59,9 +60,7 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     linarith
   have : NumberField (candidateGenusFieldBase hd) :=
     NumberField.of_intermediateField (candidateGenusFieldBase hd)
-  have : Fintype (ClassGroup (𝓞 (candidateGenusFieldBase hd))) :=
-    ClassGroup.fintypeOfAdmissibleOfFinite ℚ (candidateGenusFieldBase hd)
-      AbsoluteValue.absIsAdmissible
+  have : Finite (ClassGroup (𝓞 (candidateGenusFieldBase hd))) := inferInstance
   rw [card_aut_candidateGenusField_over_base hd hnsq,
     TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
     twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -30,8 +30,8 @@ Euler to Eisenstein*, §2.2.
 
 ## Main result
 
-* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient`: for
-  imaginary `K`, `|Gal(K_gen/K)| = |Cl(K)/Cl(K)²|`.
+* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base_eq_two_pow_twoRank`: for imaginary
+  `K`, `|Gal(K_gen/K)| = 2 ^ (2-rank Cl(K)) = |Cl(K)/Cl(K)²|`.
 -/
 
 public section
@@ -43,15 +43,16 @@ namespace TauCeti.Multiquadratic
 
 variable {d : ℤ}
 
-/-- **The relative candidate-genus-field Galois group and `Cl(K)/Cl(K)²` have equal order.** For an
-imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals `|Cl(K)/Cl(K)²|`
-— both are `2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`. This is the
-cardinality shadow of the summit isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`, established without
-class field theory. -/
-theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
+/-- **The relative candidate-genus-field Galois group has order `2 ^ (2-rank Cl(K))`.** For an
+imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals
+`2 ^ (2-rank Cl(K))`, which is the cardinality `|Cl(K)/Cl(K)²|`; both are `2 ^ (t - 1)`, where `t`
+is the number of rational primes ramifying in `K`. This is the
+numerical content of the summit isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` — the two sides have equal
+order — established without class field theory. -/
+theorem card_aut_candidateGenusField_over_base_eq_two_pow_twoRank
     (hd : Squarefree d) (hneg : d < 0) :
     Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
-      Nat.card (TauCeti.ClassGroup.ElementaryTwoQuotient (𝓞 (candidateGenusFieldBase hd))) := by
+      2 ^ TauCeti.ClassGroup.twoRank (𝓞 (candidateGenusFieldBase hd)) := by
   have hnsq : ¬ IsSquare ((d : ℤ) : ℚ) := by
     rintro ⟨r, hr⟩
     have h1 : (0 : ℚ) ≤ ((d : ℤ) : ℚ) := hr ▸ mul_self_nonneg r
@@ -59,9 +60,7 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     linarith
   have : NumberField (candidateGenusFieldBase hd) :=
     NumberField.of_intermediateField (candidateGenusFieldBase hd)
-  have : Finite (ClassGroup (𝓞 (candidateGenusFieldBase hd))) := inferInstance
   rw [card_aut_candidateGenusField_over_base hd hnsq,
-    TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
     twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
       (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hneg,
     card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -57,6 +57,7 @@ theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
     have h1 : (0 : ℚ) ≤ ((d : ℤ) : ℚ) := hr ▸ mul_self_nonneg r
     have h2 : ((d : ℤ) : ℚ) < 0 := by exact_mod_cast hneg
     linarith
+  have : Finite (ClassGroup (𝓞 (candidateGenusFieldBase hd))) := inferInstance
   rw [card_aut_candidateGenusField_over_base hd hnsq,
     TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
     twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Relative/ClassGroup.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.GaloisGroup
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
+import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.RamifiedPrimes
+import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Quadratic
+
+/-!
+# The relative candidate-genus-field Galois group has the same order as `Cl / Cl²`
+
+For an imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree) let `K_gen` be its candidate
+genus field. This file records that the relative Galois group `Gal(K_gen/K)` has the same order as
+the maximal elementary-`2` quotient `Cl(K) / Cl(K)²` of the ideal class group: both equal
+`2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`.
+
+This is the numerical content of the genus-theoretic summit isomorphism
+`Gal(K_gen/K) ≅ Cl(K) / Cl(K)²` — the two sides have equal cardinality — established **without class
+field theory**, by combining the field-theoretic relative degree `[K_gen : K] = 2 ^ (t - 1)`
+(`card_aut_candidateGenusField_over_base`) with the class-group `2`-rank theorem
+`2-rank Cl(K) = t - 1` (`twoRank_eq_ncard_ramifiedPrimes_sub_one`). The isomorphism itself needs the
+Artin reciprocity map and is not proved here.
+
+See D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and F. Lemmermeyer, *Reciprocity Laws: From
+Euler to Eisenstein*, §2.2.
+
+## Main result
+
+* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient`: for
+  imaginary `K`, `|Gal(K_gen/K)| = |Cl(K)/Cl(K)²|`.
+-/
+
+public section
+
+open Polynomial
+open scoped NumberField
+
+namespace TauCeti.Multiquadratic
+
+variable {d : ℤ}
+
+/-- **The relative candidate-genus-field Galois group and `Cl(K)/Cl(K)²` have equal order.** For an
+imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), `|Gal(K_gen/K)|` equals `|Cl(K)/Cl(K)²|`
+— both are `2 ^ (t - 1)`, where `t` is the number of rational primes ramifying in `K`. This is the
+cardinality shadow of the summit isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`, established without
+class field theory. -/
+theorem card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient
+    (hd : Squarefree d) (hneg : d < 0) :
+    Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) =
+      Nat.card (TauCeti.ClassGroup.ElementaryTwoQuotient (𝓞 (candidateGenusFieldBase hd))) := by
+  have hnsq : ¬ IsSquare ((d : ℤ) : ℚ) := by
+    rintro ⟨r, hr⟩
+    have h1 : (0 : ℚ) ≤ ((d : ℤ) : ℚ) := hr ▸ mul_self_nonneg r
+    have h2 : ((d : ℤ) : ℚ) < 0 := by exact_mod_cast hneg
+    linarith
+  rw [card_aut_candidateGenusField_over_base hd hnsq,
+    TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_two_pow_twoRank,
+    twoRank_eq_ncard_ramifiedPrimes_sub_one (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd hneg,
+    card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
+      (minpoly_candidateGenusFieldBaseGen hd hnsq)
+      (adjoin_candidateGenusFieldBaseGen_eq_top hd) hd]
+
+end TauCeti.Multiquadratic


### PR DESCRIPTION
For an imaginary quadratic field `K = ℚ(√d)` (`d < 0` squarefree), the relative Galois group of the candidate genus field over its embedded base has the same order as the maximal elementary-2 quotient `Cl(K)/Cl(K)²` — both equal `2^(t-1)`, where `t` is the number of ramified primes:

`card_aut_candidateGenusField_over_base_eq_card_elementaryTwoQuotient`.

This is the **numerical content of the genus-theoretic summit isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`** — the two sides have equal cardinality — established **without class field theory**, by combining the field-theoretic relative degree `[K_gen : K] = 2^(t-1)` (`card_aut_candidateGenusField_over_base`) with the class-group 2-rank theorem `2-rank Cl(K) = t-1` (`twoRank_eq_ncard_ramifiedPrimes_sub_one`). The isomorphism itself needs the Artin reciprocity map and is not claimed here.

**Roadmap node.** `TauCetiRoadmap/Multiquadratic/README.md`, heading *### Layer 3: the genus field and the 2-rank theorem (the summit)*. The Layer-3 target is the isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`; this PR supplies its cardinality half, the direct consequence of the just-completed 2-rank theorem and the merged relative-degree `2^(t-1)`. No new axioms.

Roadmap: Multiquadratic