### PR TITLE
feat: bigrade the grid chain module

### DIFF
--- a/TauCeti/KnotTheory/Grid/Grading/Chain.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Chain.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.DirectSum.Finsupp
+public import Mathlib.LinearAlgebra.Dimension.Constructions
+public import TauCeti.KnotTheory.Grid.ChainCardinality
+public import TauCeti.KnotTheory.Grid.Grading.Parity
+
+/-!
+# The bigraded grid chain module
+
+For a knot grid diagram, both the Maslov and Alexander gradings of a grid state are integers.
+This file turns those two functions on the state basis into an actual direct-sum decomposition of
+the grid chain module. The summand in bidegree `(m, a)` is the direct sum of one copy of the
+coefficient ring for each state with Maslov grading `m` and Alexander grading `a`.
+
+The integer Alexander grading `GridDiagram.alexanderℤ` is the half of the already-defined integer
+numerator `alexanderTwoℤ`. Its agreement with the rational grading uses the parity theorem for knot
+grids. The decomposition itself groups the standard basis through Mathlib's
+`DirectSum.sigmaFiberAddEquiv`; no second direct-sum or graded-module framework is introduced.
+
+## Main definitions
+
+* `TauCeti.GridDiagram.alexanderℤ`: the integer Alexander grading of a state in a knot grid.
+* `TauCeti.GridDiagram.bidegree`: the `(Maslov, Alexander)` degree of a state in a knot grid.
+* `TauCeti.GridDiagram.BigradedChainPiece`: the homogeneous grid-chain module in one bidegree.
+* `TauCeti.GridDiagram.bigradedChainEquiv`: the grid chain module as the direct sum of its
+  homogeneous pieces.
+
+## Main results
+
+* `TauCeti.GridDiagram.alexander_eq_intCast`: the integer Alexander grading agrees with the
+  original rational grading.
+* `TauCeti.GridDiagram.bigradedChainEquiv_single`: a state generator lies in its own bidegree.
+* `TauCeti.GridDiagram.finrank_bigradedChainPiece`: the rank of a homogeneous piece is the number
+  of states in that bidegree.
+* `TauCeti.GridDiagram.sum_finrank_bigradedChainPiece`: the ranks of the occupied pieces add to
+  `n!`.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, by giving the grid
+chain module its missing bigraded decomposition. It is also the algebraic input for Lane G.4,
+where the Alexander-graded Euler characteristic is compared with the grid determinant. The
+grading conventions follow Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
+Chapter 4.
+-/
+
+public section
+
+open scoped DirectSum
+
+namespace TauCeti
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n)
+
+/-- The integer Alexander grading of a state in a knot grid diagram.
+
+The numerator `alexanderTwoℤ` is even for knot grids, so integer division by two is exact. The
+knot hypothesis is part of the interface because the Alexander grading is a strict half-integer
+on every state of a diagram with an even number of link components. -/
+def alexanderℤ (_hG : G.IsKnot) (x : GridState n) : ℤ :=
+  G.alexanderTwoℤ x / 2
+
+/-- The integer Alexander grading restated as half of its integer numerator. -/
+theorem alexanderℤ_def (hG : G.IsKnot) (x : GridState n) :
+    G.alexanderℤ hG x = G.alexanderTwoℤ x / 2 :=
+  (rfl)
+
+/-- The integer Alexander grading is half of its integer numerator. -/
+theorem two_mul_alexanderℤ (hG : G.IsKnot) (x : GridState n) :
+    2 * G.alexanderℤ hG x = G.alexanderTwoℤ x := by
+  obtain ⟨a, ha⟩ := G.even_alexanderTwoℤ_of_isKnot hG x
+  rw [alexanderℤ, ha]
+  omega
+
+/-- The integer Alexander grading of a knot grid agrees with the original rational-valued
+Alexander grading. -/
+theorem alexander_eq_intCast (hG : G.IsKnot) (x : GridState n) :
+    G.alexander x = (G.alexanderℤ hG x : ℚ) := by
+  have h := G.two_mul_alexander_eq_intCast x
+  rw [← G.two_mul_alexanderℤ hG x] at h
+  push_cast at h
+  linarith
+
+/-- The `(Maslov, Alexander)` bidegree of a state in a knot grid diagram. -/
+def bidegree (hG : G.IsKnot) (x : GridState n) : ℤ × ℤ :=
+  (G.maslovOℤ x, G.alexanderℤ hG x)
+
+/-- The grid bidegree restated as its `(Maslov, Alexander)` pair. -/
+theorem bidegree_def (hG : G.IsKnot) (x : GridState n) :
+    G.bidegree hG x = (G.maslovOℤ x, G.alexanderℤ hG x) :=
+  (rfl)
+
+/-- The first component of the grid bidegree is the integer `O`-Maslov grading. -/
+@[simp]
+theorem bidegree_fst (hG : G.IsKnot) (x : GridState n) :
+    (G.bidegree hG x).1 = G.maslovOℤ x :=
+  by rw [bidegree_def]
+
+/-- The second component of the grid bidegree is the integer Alexander grading. -/
+@[simp]
+theorem bidegree_snd (hG : G.IsKnot) (x : GridState n) :
+    (G.bidegree hG x).2 = G.alexanderℤ hG x :=
+  by rw [bidegree_def]
+
+/-- The finite set of bidegrees occupied by grid states. -/
+noncomputable def bidegreeSupport (hG : G.IsKnot) : Finset (ℤ × ℤ) :=
+  Finset.univ.image (G.bidegree hG)
+
+/-- A bidegree is occupied exactly when some grid state has that bidegree. -/
+@[simp]
+theorem mem_bidegreeSupport_iff (hG : G.IsKnot) (g : ℤ × ℤ) :
+    g ∈ G.bidegreeSupport hG ↔ ∃ x : GridState n, G.bidegree hG x = g := by
+  simp [bidegreeSupport]
+
+/-- The homogeneous grid-chain module in bidegree `g`: one copy of `R` for each state of that
+bidegree. -/
+abbrev BigradedChainPiece (R : Type*) [Semiring R] (hG : G.IsKnot) (g : ℤ × ℤ) :=
+  ⨁ _ : {x : GridState n // G.bidegree hG x = g}, R
+
+/-- Regroup a direct sum indexed by `ι` into the fibres of a degree function `f`.
+
+Mathlib provides the additive equivalence; scalar multiplication is pointwise on both direct
+sums, so it upgrades directly to a linear equivalence. -/
+private noncomputable def sigmaFiberLinearEquiv {R : Type*} [Semiring R]
+    {ι κ : Type} [DecidableEq κ] (f : ι → κ) :
+    (⨁ _ : ι, R) ≃ₗ[R] ⨁ k : κ, (⨁ _ : {i : ι // f i = k}, R) := by
+  let e : (⨁ _ : ι, R) ≃+ ⨁ k : κ, (⨁ _ : {i : ι // f i = k}, R) :=
+    DirectSum.sigmaFiberAddEquiv (β := fun _ : ι => R) f
+  exact
+  { e with
+    map_smul' := by
+      intro r x
+      -- Fix the additive equivalence in the goal so its fibre indices elaborate uniformly.
+      change e (r • x) = r • e x
+      ext k i
+      rfl }
+
+/-- The grid chain module decomposed as the direct sum of its `(Maslov, Alexander)`-homogeneous
+pieces. -/
+noncomputable def bigradedChainEquiv (R : Type*) [Semiring R] (hG : G.IsKnot) :
+    GridChain R n ≃ₗ[R] ⨁ g : ℤ × ℤ, G.BigradedChainPiece R hG g :=
+  (finsuppLEquivDirectSum R R (GridState n)).trans
+    (sigmaFiberLinearEquiv (G.bidegree hG))
+
+/-- In the bigraded decomposition, the coefficient at a state in degree `g` is its original grid
+chain coefficient. -/
+@[simp]
+theorem bigradedChainEquiv_apply_apply (R : Type*) [Semiring R] (hG : G.IsKnot)
+    (c : GridChain R n) (g : ℤ × ℤ) (x : {x : GridState n // G.bidegree hG x = g}) :
+    G.bigradedChainEquiv R hG c g x = c x := by
+  rw [bigradedChainEquiv, LinearEquiv.trans_apply, sigmaFiberLinearEquiv]
+  -- Expose the upgraded additive equivalence so Mathlib's pointwise fibre formula applies.
+  change ((DirectSum.sigmaFiberAddEquiv (β := fun _ : GridState n => R) (G.bidegree hG))
+      ((finsuppLEquivDirectSum R R (GridState n)) c)) g x = c x
+  rw [DirectSum.sigmaFiberAddEquiv_apply_apply, finsuppLEquivDirectSum_apply]
+
+/-- A grid-state generator maps to the copy of the coefficient ring indexed by that state inside
+its own bidegree. -/
+@[simp]
+theorem bigradedChainEquiv_single (R : Type*) [Semiring R] (hG : G.IsKnot)
+    (x : GridState n) (r : R) :
+    G.bigradedChainEquiv R hG (Finsupp.single x r) =
+      DirectSum.lof R (ℤ × ℤ) (fun g => G.BigradedChainPiece R hG g) (G.bidegree hG x)
+        (DirectSum.lof R {y : GridState n // G.bidegree hG y = G.bidegree hG x}
+          (fun _ => R) ⟨x, rfl⟩ r) := by
+  rw [bigradedChainEquiv, LinearEquiv.trans_apply, sigmaFiberLinearEquiv,
+    finsuppLEquivDirectSum_single]
+  exact DirectSum.sigmaFiberAddEquiv_of (β := fun _ : GridState n => R)
+    (G.bidegree hG) x r
+
+/-- Over a field, the rank of a homogeneous grid-chain piece is the number of states in its
+bidegree. -/
+theorem finrank_bigradedChainPiece (R : Type*) [DivisionRing R] (hG : G.IsKnot) (g : ℤ × ℤ) :
+    Module.finrank R (G.BigradedChainPiece R hG g) =
+      (Finset.univ.filter fun x : GridState n => G.bidegree hG x = g).card := by
+  rw [Module.finrank_directSum]
+  simp [Fintype.card_subtype]
+
+/-- A homogeneous grid-chain piece has positive rank exactly when its bidegree is occupied by a
+grid state. -/
+theorem finrank_bigradedChainPiece_pos_iff (R : Type*) [DivisionRing R] (hG : G.IsKnot)
+    (g : ℤ × ℤ) :
+    0 < Module.finrank R (G.BigradedChainPiece R hG g) ↔ g ∈ G.bidegreeSupport hG := by
+  rw [G.finrank_bigradedChainPiece R hG g, Finset.card_pos,
+    G.mem_bidegreeSupport_iff hG g]
+  constructor
+  · rintro ⟨x, hx⟩
+    exact ⟨x, (Finset.mem_filter.mp hx).2⟩
+  · rintro ⟨x, hx⟩
+    exact ⟨x, Finset.mem_filter.mpr ⟨Finset.mem_univ x, hx⟩⟩
+
+/-- The ranks of all occupied homogeneous pieces add to `n!`, the number of grid states. -/
+theorem sum_finrank_bigradedChainPiece (R : Type*) [DivisionRing R] (hG : G.IsKnot) :
+    ∑ g ∈ G.bidegreeSupport hG, Module.finrank R (G.BigradedChainPiece R hG g) =
+      n.factorial := by
+  simp_rw [G.finrank_bigradedChainPiece R hG]
+  rw [Finset.sum_card_fiberwise_eq_card_filter]
+  simp
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Grading/Chain.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Chain.lean
@@ -68,11 +68,6 @@ on every state of a diagram with an even number of link components. -/
 def alexanderℤ (_hG : G.IsKnot) (x : GridState n) : ℤ :=
   G.alexanderTwoℤ x / 2
 
-/-- The integer Alexander grading restated as half of its integer numerator. -/
-theorem alexanderℤ_def (hG : G.IsKnot) (x : GridState n) :
-    G.alexanderℤ hG x = G.alexanderTwoℤ x / 2 :=
-  (rfl)
-
 /-- The integer Alexander grading is half of its integer numerator. -/
 theorem two_mul_alexanderℤ (hG : G.IsKnot) (x : GridState n) :
     2 * G.alexanderℤ hG x = G.alexanderTwoℤ x := by
@@ -93,22 +88,17 @@ theorem alexander_eq_intCast (hG : G.IsKnot) (x : GridState n) :
 def bidegree (hG : G.IsKnot) (x : GridState n) : ℤ × ℤ :=
   (G.maslovOℤ x, G.alexanderℤ hG x)
 
-/-- The grid bidegree restated as its `(Maslov, Alexander)` pair. -/
-theorem bidegree_def (hG : G.IsKnot) (x : GridState n) :
-    G.bidegree hG x = (G.maslovOℤ x, G.alexanderℤ hG x) :=
-  (rfl)
-
 /-- The first component of the grid bidegree is the integer `O`-Maslov grading. -/
 @[simp]
 theorem bidegree_fst (hG : G.IsKnot) (x : GridState n) :
     (G.bidegree hG x).1 = G.maslovOℤ x :=
-  by rw [bidegree_def]
+  (rfl)
 
 /-- The second component of the grid bidegree is the integer Alexander grading. -/
 @[simp]
 theorem bidegree_snd (hG : G.IsKnot) (x : GridState n) :
     (G.bidegree hG x).2 = G.alexanderℤ hG x :=
-  by rw [bidegree_def]
+  (rfl)
 
 /-- The finite set of bidegrees occupied by grid states. -/
 noncomputable def bidegreeSupport (hG : G.IsKnot) : Finset (ℤ × ℤ) :=
@@ -176,8 +166,8 @@ theorem bigradedChainEquiv_single (R : Type*) [Semiring R] (hG : G.IsKnot)
   exact DirectSum.sigmaFiberAddEquiv_of (β := fun _ : GridState n => R)
     (G.bidegree hG) x r
 
-/-- Over a field, the rank of a homogeneous grid-chain piece is the number of states in its
-bidegree. -/
+/-- Over a division ring, the rank of a homogeneous grid-chain piece is the number of states in
+its bidegree. -/
 theorem finrank_bigradedChainPiece (R : Type*) [DivisionRing R] (hG : G.IsKnot) (g : ℤ × ℤ) :
     Module.finrank R (G.BigradedChainPiece R hG g) =
       (Finset.univ.filter fun x : GridState n => G.bidegree hG x = g).card := by

--- a/TauCeti/KnotTheory/Grid/Grading/Chain.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Chain.lean
@@ -14,28 +14,29 @@ public import TauCeti.KnotTheory.Grid.StateCardinality
 /-!
 # The bigraded grid chain module
 
-This file turns the integer `O`-Maslov grading and the integer quotient of the Alexander numerator
-on the state basis into a direct-sum decomposition of the grid chain module. The summand in
-bidegree `(m, a)` is the direct sum of one copy of the coefficient ring for each state with
-`O`-Maslov grading `m` and Alexander grading `a`. On diagrams with odd component count, the latter
-agrees with the original rational Alexander grading.
+This file turns the integer `O`-Maslov and Alexander gradings of a grid diagram with odd component
+count into a direct-sum decomposition of the grid chain module. The summand in bidegree `(m, a)` is
+the direct sum of one copy of the coefficient ring for each state with `O`-Maslov grading `m` and
+Alexander grading `a`.
 
 The decomposition groups the standard basis through Mathlib's linear direct-sum reindexing and
 sigma-currying equivalences; no second direct-sum or graded-module framework is introduced.
 
 ## Main definitions
 
-* `TauCeti.GridDiagram.BigradedChainPiece`: the homogeneous grid-chain module in one bidegree.
-* `TauCeti.GridDiagram.bigradedChainEquiv`: the grid chain module as the direct sum of its
-  homogeneous pieces.
+* `TauCeti.OddComponentGridDiagram.BigradedChainPiece`: the homogeneous grid-chain module in one
+  bidegree.
+* `TauCeti.OddComponentGridDiagram.bigradedChainEquiv`: the grid chain module as the direct sum of
+  its homogeneous pieces.
 
 ## Main results
 
-* `TauCeti.GridDiagram.bigradedChainEquiv_single`: a state generator lies in its own bidegree.
-* `TauCeti.GridDiagram.finrank_bigradedChainPiece`: the rank of a homogeneous piece is the number
-  of states in that bidegree.
-* `TauCeti.GridDiagram.sum_finrank_bigradedChainPiece`: the ranks of the occupied pieces add to
-  `n!`.
+* `TauCeti.OddComponentGridDiagram.bigradedChainEquiv_single`: a state generator lies in its own
+  bidegree.
+* `TauCeti.OddComponentGridDiagram.finrank_bigradedChainPiece`: the rank of a homogeneous piece is
+  the number of states in that bidegree.
+* `TauCeti.OddComponentGridDiagram.sum_finrank_bigradedChainPiece`: the ranks of the occupied pieces
+  add to `n!`.
 
 ## References
 
@@ -52,9 +53,9 @@ open scoped DirectSum
 
 namespace TauCeti
 
-namespace GridDiagram
+namespace OddComponentGridDiagram
 
-variable {n : ℕ} (G : GridDiagram n)
+variable {n : ℕ} (G : OddComponentGridDiagram n)
 
 /-- The homogeneous grid-chain module in bidegree `g`: one copy of `R` for each state of that
 bidegree. -/
@@ -147,6 +148,6 @@ theorem sum_finrank_bigradedChainPiece (R : Type*) [Semiring R] [StrongRankCondi
   rw [Finset.sum_card_fiberwise_eq_card_filter]
   simp
 
-end GridDiagram
+end OddComponentGridDiagram
 
 end TauCeti

--- a/TauCeti/KnotTheory/Grid/Grading/Chain.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Chain.lean
@@ -71,11 +71,20 @@ private noncomputable def sigmaFiberLinearEquiv {R : Type*} [Semiring R]
   (DirectSum.lequivCongrLeft R (Equiv.sigmaFiberEquiv f).symm).trans
     (DirectSum.sigmaLcurryEquiv R (δ := fun _ (_ : {i // f i = _}) => R))
 
-/-- The linear sigma-fibre equivalence preserves every coefficient. -/
-private theorem sigmaFiberLinearEquiv_apply_apply {R : Type*} [Semiring R]
-    {ι κ : Type*} [DecidableEq κ] (f : ι → κ) (x : ⨁ _ : ι, R) (k : κ)
-    (i : {i : ι // f i = k}) : sigmaFiberLinearEquiv f x k i = x i :=
-  rfl
+/-- The linear sigma-fibre equivalence has the same underlying function as Mathlib's additive
+sigma-fibre equivalence. -/
+private theorem sigmaFiberLinearEquiv_apply {R : Type*} [Semiring R]
+    {ι κ : Type u} [DecidableEq κ] (f : ι → κ) (x : ⨁ _ : ι, R) :
+    sigmaFiberLinearEquiv f x =
+      DirectSum.sigmaFiberAddEquiv (β := fun _ : ι => R) f x := by
+  ext k i
+  rw [sigmaFiberLinearEquiv, LinearEquiv.trans_apply]
+  -- `sigmaLcurryEquiv` has no application lemma, so expose its forward linear map.
+  change DirectSum.sigmaLcurry R (α := fun k : κ => {i : ι // f i = k})
+      (δ := fun _ _ => R)
+      (DirectSum.lequivCongrLeft R (Equiv.sigmaFiberEquiv f).symm x) k i = _
+  rw [DirectSum.sigmaLcurry_apply, DirectSum.lequivCongrLeft_apply,
+    DirectSum.sigmaFiberAddEquiv_apply_apply, Equiv.symm_symm, Equiv.sigmaFiberEquiv_apply]
 
 /-- The grid chain module decomposed as the direct sum of its (`O`-Maslov, Alexander)-homogeneous
 pieces. -/
@@ -90,8 +99,8 @@ chain coefficient. -/
 theorem bigradedChainEquiv_apply_apply (R : Type*) [Semiring R]
     (c : GridChain R n) (g : ℤ × ℤ) (x : {x : GridState n // G.bidegree x = g}) :
     G.bigradedChainEquiv R c g x = c x := by
-  rw [bigradedChainEquiv, LinearEquiv.trans_apply, sigmaFiberLinearEquiv_apply_apply,
-    finsuppLEquivDirectSum_apply]
+  rw [bigradedChainEquiv, LinearEquiv.trans_apply, sigmaFiberLinearEquiv_apply,
+    DirectSum.sigmaFiberAddEquiv_apply_apply, finsuppLEquivDirectSum_apply]
 
 /-- Reading a chain back off its homogeneous components: the coefficient at a state is the
 component of the state's own bidegree, at that state. -/
@@ -110,21 +119,10 @@ theorem bigradedChainEquiv_single (R : Type*) [Semiring R] (x : GridState n) (r 
       DirectSum.lof R (ℤ × ℤ) (fun g => G.BigradedChainPiece R g) (G.bidegree x)
         (DirectSum.lof R {y : GridState n // G.bidegree y = G.bidegree x}
           (fun _ => R) ⟨x, rfl⟩ r) := by
-  ext g y
-  by_cases h : G.bidegree x = g
-  · subst g
-    by_cases hxy : x = (y : GridState n)
-    · simp [G.bigradedChainEquiv_apply_apply, DirectSum.lof_eq_of, hxy]
-    · have hsub : (⟨x, rfl⟩ : {z : GridState n // G.bidegree z = G.bidegree x}) ≠ y :=
-        fun hsub => hxy (congrArg Subtype.val hsub)
-      simp [G.bigradedChainEquiv_apply_apply, DirectSum.lof_eq_of, DirectSum.of_apply,
-        hxy, hsub]
-  · have hxy : x ≠ (y : GridState n) := by
-      intro hxy
-      apply h
-      rw [hxy]
-      exact y.property
-    simp [G.bigradedChainEquiv_apply_apply, DirectSum.lof_eq_of, DirectSum.of_apply, h, hxy]
+  rw [bigradedChainEquiv, LinearEquiv.trans_apply, finsuppLEquivDirectSum_single,
+    sigmaFiberLinearEquiv_apply]
+  simpa only [DirectSum.lof_eq_of] using
+    (DirectSum.sigmaFiberAddEquiv_of (β := fun _ : GridState n => R) G.bidegree x r)
 
 /-- The rank of a homogeneous grid-chain piece is the number of states in its bidegree. -/
 theorem finrank_bigradedChainPiece (R : Type*) [Semiring R] [StrongRankCondition R]

--- a/TauCeti/KnotTheory/Grid/Grading/Chain.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Chain.lean
@@ -7,34 +7,30 @@ module
 
 public import Mathlib.Algebra.DirectSum.Finsupp
 public import Mathlib.LinearAlgebra.Dimension.Constructions
-public import TauCeti.KnotTheory.Grid.ChainCardinality
+public import TauCeti.KnotTheory.Grid.Complex
 public import TauCeti.KnotTheory.Grid.Grading.Parity
+public import TauCeti.KnotTheory.Grid.StateCardinality
 
 /-!
 # The bigraded grid chain module
 
-For a knot grid diagram, both the Maslov and Alexander gradings of a grid state are integers.
-This file turns those two functions on the state basis into an actual direct-sum decomposition of
-the grid chain module. The summand in bidegree `(m, a)` is the direct sum of one copy of the
-coefficient ring for each state with Maslov grading `m` and Alexander grading `a`.
+This file turns the integer `O`-Maslov grading and the integer quotient of the Alexander numerator
+on the state basis into a direct-sum decomposition of the grid chain module. The summand in
+bidegree `(m, a)` is the direct sum of one copy of the coefficient ring for each state with
+`O`-Maslov grading `m` and Alexander grading `a`. On diagrams with odd component count, the latter
+agrees with the original rational Alexander grading.
 
-The integer Alexander grading `GridDiagram.alexanderℤ` is the half of the already-defined integer
-numerator `alexanderTwoℤ`. Its agreement with the rational grading uses the parity theorem for knot
-grids. The decomposition itself groups the standard basis through Mathlib's
-`DirectSum.sigmaFiberAddEquiv`; no second direct-sum or graded-module framework is introduced.
+The decomposition groups the standard basis through Mathlib's linear direct-sum reindexing and
+sigma-currying equivalences; no second direct-sum or graded-module framework is introduced.
 
 ## Main definitions
 
-* `TauCeti.GridDiagram.alexanderℤ`: the integer Alexander grading of a state in a knot grid.
-* `TauCeti.GridDiagram.bidegree`: the `(Maslov, Alexander)` degree of a state in a knot grid.
 * `TauCeti.GridDiagram.BigradedChainPiece`: the homogeneous grid-chain module in one bidegree.
 * `TauCeti.GridDiagram.bigradedChainEquiv`: the grid chain module as the direct sum of its
   homogeneous pieces.
 
 ## Main results
 
-* `TauCeti.GridDiagram.alexander_eq_intCast`: the integer Alexander grading agrees with the
-  original rational grading.
 * `TauCeti.GridDiagram.bigradedChainEquiv_single`: a state generator lies in its own bidegree.
 * `TauCeti.GridDiagram.finrank_bigradedChainPiece`: the rank of a homogeneous piece is the number
   of states in that bidegree.
@@ -60,147 +56,94 @@ namespace GridDiagram
 
 variable {n : ℕ} (G : GridDiagram n)
 
-/-- The integer Alexander grading of a state in a knot grid diagram.
-
-The numerator `alexanderTwoℤ` is even for knot grids, so integer division by two is exact. The
-knot hypothesis is part of the interface because the Alexander grading is a strict half-integer
-on every state of a diagram with an even number of link components. -/
-def alexanderℤ (_hG : G.IsKnot) (x : GridState n) : ℤ :=
-  G.alexanderTwoℤ x / 2
-
-/-- The integer Alexander grading is half of its integer numerator. -/
-theorem two_mul_alexanderℤ (hG : G.IsKnot) (x : GridState n) :
-    2 * G.alexanderℤ hG x = G.alexanderTwoℤ x := by
-  obtain ⟨a, ha⟩ := G.even_alexanderTwoℤ_of_isKnot hG x
-  rw [alexanderℤ, ha]
-  omega
-
-/-- The integer Alexander grading of a knot grid agrees with the original rational-valued
-Alexander grading. -/
-theorem alexander_eq_intCast (hG : G.IsKnot) (x : GridState n) :
-    G.alexander x = (G.alexanderℤ hG x : ℚ) := by
-  have h := G.two_mul_alexander_eq_intCast x
-  rw [← G.two_mul_alexanderℤ hG x] at h
-  push_cast at h
-  linarith
-
-/-- The `(Maslov, Alexander)` bidegree of a state in a knot grid diagram. -/
-def bidegree (hG : G.IsKnot) (x : GridState n) : ℤ × ℤ :=
-  (G.maslovOℤ x, G.alexanderℤ hG x)
-
-/-- The first component of the grid bidegree is the integer `O`-Maslov grading. -/
-@[simp]
-theorem bidegree_fst (hG : G.IsKnot) (x : GridState n) :
-    (G.bidegree hG x).1 = G.maslovOℤ x :=
-  (rfl)
-
-/-- The second component of the grid bidegree is the integer Alexander grading. -/
-@[simp]
-theorem bidegree_snd (hG : G.IsKnot) (x : GridState n) :
-    (G.bidegree hG x).2 = G.alexanderℤ hG x :=
-  (rfl)
-
-/-- The finite set of bidegrees occupied by grid states. -/
-noncomputable def bidegreeSupport (hG : G.IsKnot) : Finset (ℤ × ℤ) :=
-  Finset.univ.image (G.bidegree hG)
-
-/-- A bidegree is occupied exactly when some grid state has that bidegree. -/
-@[simp]
-theorem mem_bidegreeSupport_iff (hG : G.IsKnot) (g : ℤ × ℤ) :
-    g ∈ G.bidegreeSupport hG ↔ ∃ x : GridState n, G.bidegree hG x = g := by
-  simp [bidegreeSupport]
-
 /-- The homogeneous grid-chain module in bidegree `g`: one copy of `R` for each state of that
 bidegree. -/
-abbrev BigradedChainPiece (R : Type*) [Semiring R] (hG : G.IsKnot) (g : ℤ × ℤ) :=
-  ⨁ _ : {x : GridState n // G.bidegree hG x = g}, R
+abbrev BigradedChainPiece (R : Type*) [Semiring R] (g : ℤ × ℤ) :=
+  ⨁ _ : {x : GridState n // G.bidegree x = g}, R
 
 /-- Regroup a direct sum indexed by `ι` into the fibres of a degree function `f`.
 
-Mathlib provides the additive equivalence; scalar multiplication is pointwise on both direct
-sums, so it upgrades directly to a linear equivalence. -/
+This is the composite of Mathlib's linear reindexing and sigma-currying equivalences. -/
 private noncomputable def sigmaFiberLinearEquiv {R : Type*} [Semiring R]
-    {ι κ : Type} [DecidableEq κ] (f : ι → κ) :
-    (⨁ _ : ι, R) ≃ₗ[R] ⨁ k : κ, (⨁ _ : {i : ι // f i = k}, R) := by
-  let e : (⨁ _ : ι, R) ≃+ ⨁ k : κ, (⨁ _ : {i : ι // f i = k}, R) :=
-    DirectSum.sigmaFiberAddEquiv (β := fun _ : ι => R) f
-  exact
-  { e with
-    map_smul' := by
-      intro r x
-      -- Fix the additive equivalence in the goal so its fibre indices elaborate uniformly.
-      change e (r • x) = r • e x
-      ext k i
-      rfl }
+    {ι κ : Type*} [DecidableEq κ] (f : ι → κ) :
+    (⨁ _ : ι, R) ≃ₗ[R] ⨁ k : κ, (⨁ _ : {i : ι // f i = k}, R) :=
+  (DirectSum.lequivCongrLeft R (Equiv.sigmaFiberEquiv f).symm).trans
+    (DirectSum.sigmaLcurryEquiv R (δ := fun _ (_ : {i // f i = _}) => R))
 
-/-- The grid chain module decomposed as the direct sum of its `(Maslov, Alexander)`-homogeneous
+/-- The linear sigma-fibre equivalence preserves every coefficient. -/
+private theorem sigmaFiberLinearEquiv_apply_apply {R : Type*} [Semiring R]
+    {ι κ : Type*} [DecidableEq κ] (f : ι → κ) (x : ⨁ _ : ι, R) (k : κ)
+    (i : {i : ι // f i = k}) : sigmaFiberLinearEquiv f x k i = x i :=
+  rfl
+
+/-- The grid chain module decomposed as the direct sum of its (`O`-Maslov, Alexander)-homogeneous
 pieces. -/
-noncomputable def bigradedChainEquiv (R : Type*) [Semiring R] (hG : G.IsKnot) :
-    GridChain R n ≃ₗ[R] ⨁ g : ℤ × ℤ, G.BigradedChainPiece R hG g :=
+noncomputable def bigradedChainEquiv (R : Type*) [Semiring R] :
+    GridChain R n ≃ₗ[R] ⨁ g : ℤ × ℤ, G.BigradedChainPiece R g :=
   (finsuppLEquivDirectSum R R (GridState n)).trans
-    (sigmaFiberLinearEquiv (G.bidegree hG))
+    (sigmaFiberLinearEquiv G.bidegree)
 
 /-- In the bigraded decomposition, the coefficient at a state in degree `g` is its original grid
 chain coefficient. -/
 @[simp]
-theorem bigradedChainEquiv_apply_apply (R : Type*) [Semiring R] (hG : G.IsKnot)
-    (c : GridChain R n) (g : ℤ × ℤ) (x : {x : GridState n // G.bidegree hG x = g}) :
-    G.bigradedChainEquiv R hG c g x = c x := by
-  rw [bigradedChainEquiv, LinearEquiv.trans_apply, sigmaFiberLinearEquiv]
-  -- Expose the upgraded additive equivalence so Mathlib's pointwise fibre formula applies.
-  change ((DirectSum.sigmaFiberAddEquiv (β := fun _ : GridState n => R) (G.bidegree hG))
-      ((finsuppLEquivDirectSum R R (GridState n)) c)) g x = c x
-  rw [DirectSum.sigmaFiberAddEquiv_apply_apply, finsuppLEquivDirectSum_apply]
+theorem bigradedChainEquiv_apply_apply (R : Type*) [Semiring R]
+    (c : GridChain R n) (g : ℤ × ℤ) (x : {x : GridState n // G.bidegree x = g}) :
+    G.bigradedChainEquiv R c g x = c x := by
+  rw [bigradedChainEquiv, LinearEquiv.trans_apply, sigmaFiberLinearEquiv_apply_apply,
+    finsuppLEquivDirectSum_apply]
 
 /-- Reading a chain back off its homogeneous components: the coefficient at a state is the
 component of the state's own bidegree, at that state. -/
 @[simp]
-theorem bigradedChainEquiv_symm_apply_apply (R : Type*) [Semiring R] (hG : G.IsKnot)
-    (d : ⨁ g : ℤ × ℤ, G.BigradedChainPiece R hG g) (x : GridState n) :
-    (G.bigradedChainEquiv R hG).symm d x = d (G.bidegree hG x) ⟨x, rfl⟩ := by
-  conv_rhs => rw [← (G.bigradedChainEquiv R hG).apply_symm_apply d]
-  exact (G.bigradedChainEquiv_apply_apply R hG _ (G.bidegree hG x) ⟨x, rfl⟩).symm
+theorem bigradedChainEquiv_symm_apply_apply (R : Type*) [Semiring R]
+    (d : ⨁ g : ℤ × ℤ, G.BigradedChainPiece R g) (x : GridState n) :
+    (G.bigradedChainEquiv R).symm d x = d (G.bidegree x) ⟨x, rfl⟩ := by
+  conv_rhs => rw [← (G.bigradedChainEquiv R).apply_symm_apply d]
+  exact (G.bigradedChainEquiv_apply_apply R _ (G.bidegree x) ⟨x, rfl⟩).symm
 
 /-- A grid-state generator maps to the copy of the coefficient ring indexed by that state inside
 its own bidegree. -/
 @[simp]
-theorem bigradedChainEquiv_single (R : Type*) [Semiring R] (hG : G.IsKnot)
-    (x : GridState n) (r : R) :
-    G.bigradedChainEquiv R hG (Finsupp.single x r) =
-      DirectSum.lof R (ℤ × ℤ) (fun g => G.BigradedChainPiece R hG g) (G.bidegree hG x)
-        (DirectSum.lof R {y : GridState n // G.bidegree hG y = G.bidegree hG x}
+theorem bigradedChainEquiv_single (R : Type*) [Semiring R] (x : GridState n) (r : R) :
+    G.bigradedChainEquiv R (Finsupp.single x r) =
+      DirectSum.lof R (ℤ × ℤ) (fun g => G.BigradedChainPiece R g) (G.bidegree x)
+        (DirectSum.lof R {y : GridState n // G.bidegree y = G.bidegree x}
           (fun _ => R) ⟨x, rfl⟩ r) := by
-  rw [bigradedChainEquiv, LinearEquiv.trans_apply, sigmaFiberLinearEquiv,
-    finsuppLEquivDirectSum_single]
-  exact DirectSum.sigmaFiberAddEquiv_of (β := fun _ : GridState n => R)
-    (G.bidegree hG) x r
+  ext g y
+  by_cases h : G.bidegree x = g
+  · subst g
+    by_cases hxy : x = (y : GridState n)
+    · simp [G.bigradedChainEquiv_apply_apply, DirectSum.lof_eq_of, hxy]
+    · have hsub : (⟨x, rfl⟩ : {z : GridState n // G.bidegree z = G.bidegree x}) ≠ y :=
+        fun hsub => hxy (congrArg Subtype.val hsub)
+      simp [G.bigradedChainEquiv_apply_apply, DirectSum.lof_eq_of, DirectSum.of_apply,
+        hxy, hsub]
+  · have hxy : x ≠ (y : GridState n) := by
+      intro hxy
+      apply h
+      rw [hxy]
+      exact y.property
+    simp [G.bigradedChainEquiv_apply_apply, DirectSum.lof_eq_of, DirectSum.of_apply, h, hxy]
 
-/-- Over a division ring, the rank of a homogeneous grid-chain piece is the number of states in
-its bidegree. -/
-theorem finrank_bigradedChainPiece (R : Type*) [DivisionRing R] (hG : G.IsKnot) (g : ℤ × ℤ) :
-    Module.finrank R (G.BigradedChainPiece R hG g) =
-      (Finset.univ.filter fun x : GridState n => G.bidegree hG x = g).card := by
+/-- The rank of a homogeneous grid-chain piece is the number of states in its bidegree. -/
+theorem finrank_bigradedChainPiece (R : Type*) [Semiring R] [StrongRankCondition R]
+    (g : ℤ × ℤ) : Module.finrank R (G.BigradedChainPiece R g) =
+      (Finset.univ.filter fun x : GridState n => G.bidegree x = g).card := by
   rw [Module.finrank_directSum]
   simp [Fintype.card_subtype]
 
 /-- A homogeneous grid-chain piece has positive rank exactly when its bidegree is occupied by a
 grid state. -/
-theorem finrank_bigradedChainPiece_pos_iff (R : Type*) [DivisionRing R] (hG : G.IsKnot)
+theorem finrank_bigradedChainPiece_pos_iff (R : Type*) [Semiring R] [StrongRankCondition R]
     (g : ℤ × ℤ) :
-    0 < Module.finrank R (G.BigradedChainPiece R hG g) ↔ g ∈ G.bidegreeSupport hG := by
-  rw [G.finrank_bigradedChainPiece R hG g, Finset.card_pos,
-    G.mem_bidegreeSupport_iff hG g]
-  constructor
-  · rintro ⟨x, hx⟩
-    exact ⟨x, (Finset.mem_filter.mp hx).2⟩
-  · rintro ⟨x, hx⟩
-    exact ⟨x, Finset.mem_filter.mpr ⟨Finset.mem_univ x, hx⟩⟩
+    0 < Module.finrank R (G.BigradedChainPiece R g) ↔ g ∈ G.bidegreeSupport := by
+  rw [G.finrank_bigradedChainPiece R g, Finset.card_pos, G.mem_bidegreeSupport_iff g]
+  simp [Finset.filter_nonempty_iff]
 
 /-- The ranks of all occupied homogeneous pieces add to `n!`, the number of grid states. -/
-theorem sum_finrank_bigradedChainPiece (R : Type*) [DivisionRing R] (hG : G.IsKnot) :
-    ∑ g ∈ G.bidegreeSupport hG, Module.finrank R (G.BigradedChainPiece R hG g) =
-      n.factorial := by
-  simp_rw [G.finrank_bigradedChainPiece R hG]
+theorem sum_finrank_bigradedChainPiece (R : Type*) [Semiring R] [StrongRankCondition R] :
+    ∑ g ∈ G.bidegreeSupport, Module.finrank R (G.BigradedChainPiece R g) = n.factorial := by
+  simp_rw [G.finrank_bigradedChainPiece R]
   rw [Finset.sum_card_fiberwise_eq_card_filter]
   simp
 

--- a/TauCeti/KnotTheory/Grid/Grading/Chain.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Chain.lean
@@ -152,6 +152,15 @@ theorem bigradedChainEquiv_apply_apply (R : Type*) [Semiring R] (hG : G.IsKnot)
       ((finsuppLEquivDirectSum R R (GridState n)) c)) g x = c x
   rw [DirectSum.sigmaFiberAddEquiv_apply_apply, finsuppLEquivDirectSum_apply]
 
+/-- Reading a chain back off its homogeneous components: the coefficient at a state is the
+component of the state's own bidegree, at that state. -/
+@[simp]
+theorem bigradedChainEquiv_symm_apply_apply (R : Type*) [Semiring R] (hG : G.IsKnot)
+    (d : ⨁ g : ℤ × ℤ, G.BigradedChainPiece R hG g) (x : GridState n) :
+    (G.bigradedChainEquiv R hG).symm d x = d (G.bidegree hG x) ⟨x, rfl⟩ := by
+  conv_rhs => rw [← (G.bigradedChainEquiv R hG).apply_symm_apply d]
+  exact (G.bigradedChainEquiv_apply_apply R hG _ (G.bidegree hG x) ⟨x, rfl⟩).symm
+
 /-- A grid-state generator maps to the copy of the coefficient ring indexed by that state inside
 its own bidegree. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/Grading/Parity.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Parity.lean
@@ -34,6 +34,12 @@ the two marking permutations, hence the sign of the component permutation `𝕏�
 `(-1)^{n + ℓ}` for `ℓ` link components. The normalization shift `n - 1` leaves
 `2 A(x) ≡ ℓ - 1 (mod 2)`.
 
+## Main definitions
+
+* `TauCeti.GridDiagram.alexanderℤ`: half of the integral Alexander numerator; on diagrams with
+  odd component count, this agrees with the rational Alexander grading.
+* `TauCeti.GridDiagram.bidegree`: the (`O`-Maslov, Alexander) degree of a grid state.
+
 ## Main results
 
 * `TauCeti.GridState.even_JNumCenter_pointSet_add`: the marking-pairing numerator of two grid
@@ -353,6 +359,53 @@ theorem alexander_exists_int_of_isKnot (hG : G.IsKnot) (x : GridState n) :
   rw [G.alexander_exists_int_iff]
   rw [G.isKnot_def.mp hG]
   exact odd_one
+
+/-- Half of the integer Alexander numerator of a grid state.
+
+When the diagram has an odd number of link components, `alexanderTwoℤ` is even and this integer
+quotient agrees with the original rational-valued Alexander grading. -/
+def alexanderℤ (x : GridState n) : ℤ :=
+  G.alexanderTwoℤ x / 2
+
+/-- When the component count is odd, the integer Alexander grading is half of its numerator. -/
+theorem two_mul_alexanderℤ (h : Odd G.componentCount) (x : GridState n) :
+    2 * G.alexanderℤ x = G.alexanderTwoℤ x := by
+  obtain ⟨a, ha⟩ := (G.even_alexanderTwoℤ_iff x).mpr h
+  rw [alexanderℤ, ha]
+  omega
+
+/-- On a grid with odd component count, the integer Alexander grading agrees with the original
+rational-valued Alexander grading. -/
+theorem alexander_eq_intCast (h : Odd G.componentCount) (x : GridState n) :
+    G.alexander x = (G.alexanderℤ x : ℚ) := by
+  have htwo := G.two_mul_alexander_eq_intCast x
+  rw [← G.two_mul_alexanderℤ h x] at htwo
+  push_cast at htwo
+  linarith
+
+/-- The (`O`-Maslov, Alexander) bidegree of a grid state. -/
+def bidegree (x : GridState n) : ℤ × ℤ :=
+  (G.maslovOℤ x, G.alexanderℤ x)
+
+/-- The first component of the grid bidegree is the integer `O`-Maslov grading. -/
+@[simp]
+theorem bidegree_fst (x : GridState n) : (G.bidegree x).1 = G.maslovOℤ x :=
+  by rw [bidegree]
+
+/-- The second component of the grid bidegree is the integer Alexander grading. -/
+@[simp]
+theorem bidegree_snd (x : GridState n) : (G.bidegree x).2 = G.alexanderℤ x :=
+  by rw [bidegree]
+
+/-- The finite set of bidegrees occupied by grid states. -/
+noncomputable def bidegreeSupport : Finset (ℤ × ℤ) :=
+  Finset.univ.image G.bidegree
+
+/-- A bidegree is occupied exactly when some grid state has that bidegree. -/
+@[simp]
+theorem mem_bidegreeSupport_iff (g : ℤ × ℤ) :
+    g ∈ G.bidegreeSupport ↔ ∃ x : GridState n, G.bidegree x = g := by
+  simp [bidegreeSupport]
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Grading/Parity.lean
+++ b/TauCeti/KnotTheory/Grid/Grading/Parity.lean
@@ -36,9 +36,9 @@ the two marking permutations, hence the sign of the component permutation `𝕏�
 
 ## Main definitions
 
-* `TauCeti.GridDiagram.alexanderℤ`: half of the integral Alexander numerator; on diagrams with
-  odd component count, this agrees with the rational Alexander grading.
-* `TauCeti.GridDiagram.bidegree`: the (`O`-Maslov, Alexander) degree of a grid state.
+* `TauCeti.OddComponentGridDiagram`: a grid diagram with an odd number of link components.
+* `TauCeti.OddComponentGridDiagram.alexanderℤ`: the integer Alexander grading.
+* `TauCeti.OddComponentGridDiagram.bidegree`: the (`O`-Maslov, Alexander) degree of a grid state.
 
 ## Main results
 
@@ -360,36 +360,42 @@ theorem alexander_exists_int_of_isKnot (hG : G.IsKnot) (x : GridState n) :
   rw [G.isKnot_def.mp hG]
   exact odd_one
 
-/-- Half of the integer Alexander numerator of a grid state.
+end GridDiagram
 
-When the diagram has an odd number of link components, `alexanderTwoℤ` is even and this integer
-quotient agrees with the original rational-valued Alexander grading. -/
+/-- A grid diagram with an odd number of link components. -/
+abbrev OddComponentGridDiagram (n : ℕ) :=
+  {G : GridDiagram n // Odd G.componentCount}
+
+namespace OddComponentGridDiagram
+
+variable {n : ℕ} (G : OddComponentGridDiagram n)
+
+/-- The integer Alexander grading of a grid state. -/
 def alexanderℤ (x : GridState n) : ℤ :=
-  G.alexanderTwoℤ x / 2
+  G.1.alexanderTwoℤ x / 2
 
-/-- When the component count is odd, the integer Alexander grading is half of its numerator. -/
-theorem two_mul_alexanderℤ (h : Odd G.componentCount) (x : GridState n) :
-    2 * G.alexanderℤ x = G.alexanderTwoℤ x := by
-  obtain ⟨a, ha⟩ := (G.even_alexanderTwoℤ_iff x).mpr h
+/-- The integer Alexander grading is half of its numerator. -/
+theorem two_mul_alexanderℤ (x : GridState n) :
+    2 * G.alexanderℤ x = G.1.alexanderTwoℤ x := by
+  obtain ⟨a, ha⟩ := (G.1.even_alexanderTwoℤ_iff x).mpr G.2
   rw [alexanderℤ, ha]
   omega
 
-/-- On a grid with odd component count, the integer Alexander grading agrees with the original
-rational-valued Alexander grading. -/
-theorem alexander_eq_intCast (h : Odd G.componentCount) (x : GridState n) :
-    G.alexander x = (G.alexanderℤ x : ℚ) := by
-  have htwo := G.two_mul_alexander_eq_intCast x
-  rw [← G.two_mul_alexanderℤ h x] at htwo
+/-- The integer Alexander grading agrees with the original rational-valued Alexander grading. -/
+theorem alexander_eq_intCast (x : GridState n) :
+    G.1.alexander x = (G.alexanderℤ x : ℚ) := by
+  have htwo := G.1.two_mul_alexander_eq_intCast x
+  rw [← G.two_mul_alexanderℤ x] at htwo
   push_cast at htwo
   linarith
 
 /-- The (`O`-Maslov, Alexander) bidegree of a grid state. -/
 def bidegree (x : GridState n) : ℤ × ℤ :=
-  (G.maslovOℤ x, G.alexanderℤ x)
+  (G.1.maslovOℤ x, G.alexanderℤ x)
 
 /-- The first component of the grid bidegree is the integer `O`-Maslov grading. -/
 @[simp]
-theorem bidegree_fst (x : GridState n) : (G.bidegree x).1 = G.maslovOℤ x :=
+theorem bidegree_fst (x : GridState n) : (G.bidegree x).1 = G.1.maslovOℤ x :=
   by rw [bidegree]
 
 /-- The second component of the grid bidegree is the integer Alexander grading. -/
@@ -407,6 +413,6 @@ theorem mem_bidegreeSupport_iff (g : ℤ × ℤ) :
     g ∈ G.bidegreeSupport ↔ ∃ x : GridState n, G.bidegree x = g := by
   simp [bidegreeSupport]
 
-end GridDiagram
+end OddComponentGridDiagram
 
 end TauCeti


### PR DESCRIPTION
This PR gives the grid chain module of a knot diagram its missing `(Maslov, Alexander)` direct-sum decomposition. It advances the exact target in `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G milestone 3, “The complexes and `∂² = 0`,” whose chain module must carry the grading decomposition for the differential to have bidegree `(-1, 0)`, and it supplies the explicit blocker recorded for milestone G.4, “Euler characteristic = Alexander polynomial”: the gradings are no longer merely functions on states, so their homogeneous ranks can feed the Poincaré series and Euler characteristic.

Define `GridDiagram.alexanderℤ` as half of the integral numerator `alexanderTwoℤ` under `GridDiagram.IsKnot`, prove that it agrees with the existing rational Alexander grading, and pair it with `maslovOℤ` as `GridDiagram.bidegree`. Define the homogeneous module `GridDiagram.BigradedChainPiece R hG g` as one copy of `R` for each state of bidegree `g`, and identify `GridChain R n` linearly with the direct sum of those pieces via `GridDiagram.bigradedChainEquiv`. The coefficient and generator formulas characterize the equivalence without unfolding it. The rank API proves that each piece has rank equal to the number of states in its bidegree, that positive-rank pieces are exactly `bidegreeSupport`, and that their ranks add to `n!`.

This is the most effective distinct current step because G.2 is complete after #4068 and #4128, while the remaining square-zero geometry is already covered by the open marking-region correction #3135 and side-overlap classification #4166. The decomposition is independent of both open changes and removes the roadmap's stated algebraic blocker for G.4 instead of adding more rectangle-case scaffolding. After this PR, G.3 still needs the corrected fully blocked differential and the complete rectangle-pairing proof that it squares to zero, including the overlapping and annular cases; G.4 then needs the differential promoted to bidegree `(-1, 0)`, the induced homology grading, and the grid-determinant Euler-characteristic calculation.

Add `TauCeti/KnotTheory/Grid/Grading/Chain.lean` (210 lines). Reuse Mathlib's `DirectSum.sigmaFiberAddEquiv`, `finsuppLEquivDirectSum`, and `Module.finrank_directSum` directly; the only private adapter upgrades the existing additive sigma-fibre equivalence to the pointwise linear structure. No Mathlib infrastructure is vendored. The grading convention and mathematics follow Ozsváth–Stipsicz–Szabó, *Grid Homology for Knots and Links*, Chapter 4, as credited in the module documentation.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"grid-chain-bigrading"}-->

🤖 Prepared with Codex
