### PR TITLE
feat: add smooth local collar diffeomorphisms

### DIFF
--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
@@ -92,13 +92,7 @@ def normalOpens (_h : IsProductCollarChart k φ V ε) :
 height. -/
 @[simp]
 theorem mem_normalOpens (h : IsProductCollarChart k φ V ε) {t : EuclideanHalfSpace 1} :
-    t ∈ (h.normalOpens : Set (EuclideanHalfSpace 1)) ↔ t.1 0 < ε := by
-  have hopen : (h.normalOpens : Set (EuclideanHalfSpace 1)) =
-      EuclideanHalfSpace.normalIio ε := by
-    rw [normalOpens.eq_def]
-    rfl
-  rw [hopen]
-  exact EuclideanHalfSpace.mem_normalIio
+    t ∈ h.normalOpens ↔ t.1 0 < ε := EuclideanHalfSpace.mem_normalIio
 
 private def prodEquiv (h : IsProductCollarChart k φ V ε) :
     h.sourceOpens ≃ h.boundaryOpens × h.normalOpens where
@@ -335,7 +329,6 @@ theorem coe_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k �
 
 /-- In collar coordinates, the boundary retraction keeps the tangential coordinate and sets the
 normal coordinate to zero. -/
-@[simp]
 theorem map_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
     (y : h.sourceOpens) :
     φ (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
@@ -59,43 +59,43 @@ namespace IsProductCollarChart
 variable {φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)}
   {V : Set (EuclideanSpace ℝ (Fin n))} {ε : ℝ}
 
-/-- The source of a product collar chart, regarded as an open submanifold of the ambient
-manifold. -/
-def sourceOpens (_h : IsProductCollarChart k φ V ε) : TopologicalSpace.Opens M :=
+/-- The source of a chart, regarded as an open submanifold of the ambient manifold. -/
+def sourceOpens
+    (φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)) :
+    TopologicalSpace.Opens M :=
   ⟨φ.source, φ.open_source⟩
 
-/-- Membership in the open source of a product collar chart is membership in the chart source. -/
+omit [ChartedSpace (EuclideanHalfSpace (n + 1)) M] in
+/-- Membership in the open source of a chart is membership in the chart source. -/
 @[simp]
-theorem mem_sourceOpens (h : IsProductCollarChart k φ V ε) {x : M} :
-    x ∈ h.sourceOpens ↔ x ∈ φ.source := Iff.rfl
+theorem mem_sourceOpens {x : M} : x ∈ sourceOpens φ ↔ x ∈ φ.source := Iff.rfl
 
-/-- The part of the boundary in the source of a product collar chart, regarded as an open
-submanifold of the canonical boundary manifold. -/
-def boundaryOpens (_h : IsProductCollarChart k φ V ε) :
+/-- The part of the boundary in the source of a chart, regarded as an open submanifold of the
+canonical boundary manifold. -/
+def boundaryOpens
+    (φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)) :
     TopologicalSpace.Opens ↥((𝓡∂ (n + 1)).boundary M) :=
   ⟨Subtype.val ⁻¹' φ.source, φ.open_source.preimage continuous_subtype_val⟩
 
 /-- A boundary point belongs to the collar base exactly when its ambient point belongs to the
 chart source. -/
 @[simp]
-theorem mem_boundaryOpens (h : IsProductCollarChart k φ V ε)
-    {x : ↥((𝓡∂ (n + 1)).boundary M)} :
-    x ∈ h.boundaryOpens ↔ (x : M) ∈ φ.source := Iff.rfl
+theorem mem_boundaryOpens {x : ↥((𝓡∂ (n + 1)).boundary M)} :
+    x ∈ boundaryOpens φ ↔ (x : M) ∈ φ.source := Iff.rfl
 
-/-- The normal interval of a product collar chart, regarded as an open submanifold of the
+/-- The normal interval below a positive height, regarded as an open submanifold of the
 one-dimensional half-space. -/
-def normalOpens (_h : IsProductCollarChart k φ V ε) :
-    TopologicalSpace.Opens (EuclideanHalfSpace 1) :=
+def normalOpens (ε : ℝ) : TopologicalSpace.Opens (EuclideanHalfSpace 1) :=
   ⟨EuclideanHalfSpace.normalIio ε, EuclideanHalfSpace.isOpen_normalIio ε⟩
 
 /-- A normal coordinate belongs to the collar interval exactly when it is smaller than the collar
 height. -/
 @[simp]
-theorem mem_normalOpens (h : IsProductCollarChart k φ V ε) {t : EuclideanHalfSpace 1} :
-    t ∈ h.normalOpens ↔ t.1 0 < ε := EuclideanHalfSpace.mem_normalIio
+theorem mem_normalOpens {t : EuclideanHalfSpace 1} :
+    t ∈ normalOpens ε ↔ t.1 0 < ε := EuclideanHalfSpace.mem_normalIio
 
 private def prodEquiv (h : IsProductCollarChart k φ V ε) :
-    h.sourceOpens ≃ h.boundaryOpens × h.normalOpens where
+    sourceOpens φ ≃ boundaryOpens φ × normalOpens ε where
   toFun y := by
     have hyφ : φ y ∈ φ.target := φ.map_source y.2
     have hybox : φ y ∈ V ×ˢ EuclideanHalfSpace.normalIio ε := h.target_eq ▸ hyφ
@@ -145,17 +145,43 @@ private def prodEquiv (h : IsProductCollarChart k φ V ε) :
       rw [h.target_eq]
       exact ⟨(h.target_eq ▸ hqtarget).1, p.2.2⟩
 
-private theorem coe_prodEquiv_fst (h : IsProductCollarChart k φ V ε) (y : h.sourceOpens) :
+private theorem coe_prodEquiv_fst (h : IsProductCollarChart k φ V ε) (y : sourceOpens φ) :
     (((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
       φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := rfl
 
-private theorem coe_prodEquiv_snd (h : IsProductCollarChart k φ V ε) (y : h.sourceOpens) :
+private theorem coe_prodEquiv_snd (h : IsProductCollarChart k φ V ε) (y : sourceOpens φ) :
     ((h.prodEquiv y).2 : EuclideanHalfSpace 1) = (φ y).2 := rfl
 
 private theorem coe_prodEquiv_symm (h : IsProductCollarChart k φ V ε)
-    (p : h.boundaryOpens × h.normalOpens) :
+    (p : boundaryOpens φ × normalOpens ε) :
     (h.prodEquiv.symm p : M) =
       φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := rfl
+
+private theorem boundary_coe_comp_prodEquiv_fst (h : IsProductCollarChart k φ V ε) :
+    (Subtype.val ∘ fun y : sourceOpens φ ↦
+      ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) =
+      fun y : sourceOpens φ ↦ φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
+  funext y
+  exact coe_prodEquiv_fst h y
+
+private theorem boundaryOpens_coe_comp_prodEquiv_fst
+    (h : IsProductCollarChart k φ V ε) :
+    (Subtype.val ∘ fun y : sourceOpens φ ↦ (h.prodEquiv y).1) =
+      fun y ↦ ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) := rfl
+
+private theorem normalOpens_coe_comp_prodEquiv_snd
+    (h : IsProductCollarChart k φ V ε) :
+    (Subtype.val ∘ fun y : sourceOpens φ ↦ (h.prodEquiv y).2) =
+      fun y : sourceOpens φ ↦ (φ y).2 := by
+  funext y
+  exact coe_prodEquiv_snd h y
+
+private theorem sourceOpens_coe_comp_prodEquiv_symm
+    (h : IsProductCollarChart k φ V ε) :
+    (Subtype.val ∘ h.prodEquiv.symm) = fun p : boundaryOpens φ × normalOpens ε ↦
+      φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := by
+  funext p
+  exact coe_prodEquiv_symm h p
 
 variable [IsManifold (𝓡∂ (n + 1)) k M]
 
@@ -165,90 +191,90 @@ from Boundary.Charts. -/
 def diffeomorphProd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
     let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
       IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-    Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) h.sourceOpens
-      (h.boundaryOpens × h.normalOpens) k := by
+    Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) (sourceOpens φ)
+      (boundaryOpens φ × normalOpens ε) k := by
   letI : IsManifold (𝓡∂ (n + 1)) 1 M :=
     IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
   letI : IsManifold 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
       ↥((𝓡∂ (n + 1)).boundary M) := isManifold_boundary M hk
   refine { toEquiv := h.prodEquiv, contMDiff_toFun := ?_, contMDiff_invFun := ?_ }
   · have hφ : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-        (fun y : h.sourceOpens ↦ φ y) := by
+        (fun y : sourceOpens φ ↦ φ y) := by
       intro y
       rw [contMDiffAt_subtype_iff]
       exact (h.contMDiffOn y y.2).contMDiffAt (φ.open_source.mem_nhds y.2)
     have hzero : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-        (fun y : h.sourceOpens ↦ ((φ y).1, (0 : EuclideanHalfSpace 1))) :=
+        (fun y : sourceOpens φ ↦ ((φ y).1, (0 : EuclideanHalfSpace 1))) :=
       hφ.fst.prodMk contMDiff_const
-    have hzero_mem (y : h.sourceOpens) :
+    have hzero_mem (y : sourceOpens φ) :
         ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target := by
       rw [h.target_eq]
       exact ⟨(h.target_eq ▸ φ.map_source y.2).1,
         EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
     have hretractAmbient : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ (n + 1)) k
-        (fun y : h.sourceOpens ↦ φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1))) := by
+        (fun y : sourceOpens φ ↦ φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1))) := by
       intro y
       exact ((h.contMDiffOn_symm _ (hzero_mem y)).contMDiffAt
         (φ.open_target.mem_nhds (hzero_mem y))).comp y hzero.contMDiffAt
     have hretractBoundary : ContMDiff (𝓡∂ (n + 1))
         𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
-        (fun y : h.sourceOpens ↦ ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) := by
+        (fun y : sourceOpens φ ↦ ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) := by
       apply (ContMDiff.iff_comp_isImmersion
         (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).isImmersion).2
       refine ⟨?_, ?_⟩
       · exact continuous_induced_rng.2 hretractAmbient.continuous
-      · convert hretractAmbient using 1
-        rfl
+      · rw [boundary_coe_comp_prodEquiv_fst h]
+        exact hretractAmbient
     have hretract : ContMDiff (𝓡∂ (n + 1))
         𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
-        (fun y : h.sourceOpens ↦ (h.prodEquiv y).1) := by
+        (fun y : sourceOpens φ ↦ (h.prodEquiv y).1) := by
       apply (ContMDiff.iff_comp_isImmersion
-        (Manifold.IsImmersion.of_opens h.boundaryOpens)).2
+        (Manifold.IsImmersion.of_opens (boundaryOpens φ))).2
       refine ⟨?_, ?_⟩
       · exact continuous_induced_rng.2 hretractBoundary.continuous
-      · convert hretractBoundary using 1
-        rfl
+      · rw [boundaryOpens_coe_comp_prodEquiv_fst h]
+        exact hretractBoundary
     have hnormal : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ 1) k
-        (fun y : h.sourceOpens ↦ (h.prodEquiv y).2) := by
+        (fun y : sourceOpens φ ↦ (h.prodEquiv y).2) := by
       apply (ContMDiff.iff_comp_isImmersion
-        (Manifold.IsImmersion.of_opens h.normalOpens)).2
+        (Manifold.IsImmersion.of_opens (normalOpens ε))).2
       refine ⟨?_, ?_⟩
       · exact continuous_induced_rng.2 hφ.snd.continuous
-      · convert hφ.snd using 1
-        rfl
+      · rw [normalOpens_coe_comp_prodEquiv_snd h]
+        exact hφ.snd
     exact hretract.prodMk hnormal
   · have hboundaryVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
-        (fun p : h.boundaryOpens × h.normalOpens ↦ (p.1.1 : M)) := by
+        (fun p : boundaryOpens φ × normalOpens ε ↦ (p.1.1 : M)) := by
       exact (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).contMDiff.comp
         (contMDiff_subtype_val.comp contMDiff_fst)
     have hφboundary : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-        (fun p : h.boundaryOpens × h.normalOpens ↦ φ p.1.1) := by
+        (fun p : boundaryOpens φ × normalOpens ε ↦ φ p.1.1) := by
       intro p
       exact ((h.contMDiffOn p.1.1 p.1.2).contMDiffAt
         (φ.open_source.mem_nhds p.1.2)).comp p hboundaryVal.contMDiffAt
     have hnormalVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ 1) k
-        (fun p : h.boundaryOpens × h.normalOpens ↦ (p.2 : EuclideanHalfSpace 1)) :=
+        (fun p : boundaryOpens φ × normalOpens ε ↦ (p.2 : EuclideanHalfSpace 1)) :=
       contMDiff_subtype_val.comp contMDiff_snd
     have hpair : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-        (fun p : h.boundaryOpens × h.normalOpens ↦
+        (fun p : boundaryOpens φ × normalOpens ε ↦
           ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) :=
       hφboundary.fst.prodMk hnormalVal
-    have hpair_mem (p : h.boundaryOpens × h.normalOpens) :
+    have hpair_mem (p : boundaryOpens φ × normalOpens ε) :
         ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) ∈ φ.target := by
       rw [h.target_eq]
       exact ⟨(h.target_eq ▸ φ.map_source p.1.2).1, p.2.2⟩
     have hassembleAmbient : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
-        (fun p : h.boundaryOpens × h.normalOpens ↦
+        (fun p : boundaryOpens φ × normalOpens ε ↦
           φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) := by
       intro p
       exact ((h.contMDiffOn_symm _ (hpair_mem p)).contMDiffAt
         (φ.open_target.mem_nhds (hpair_mem p))).comp p hpair.contMDiffAt
     apply (ContMDiff.iff_comp_isImmersion
-      (Manifold.IsImmersion.of_opens h.sourceOpens)).2
+      (Manifold.IsImmersion.of_opens (sourceOpens φ))).2
     refine ⟨?_, ?_⟩
     · exact continuous_induced_rng.2 hassembleAmbient.continuous
-    · convert hassembleAmbient using 1
-      rfl
+    · rw [sourceOpens_coe_comp_prodEquiv_symm h]
+      exact hassembleAmbient
 
 private theorem diffeomorphProd_toEquiv (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
     let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
@@ -264,13 +290,13 @@ section Characteristic
 zero and reading back through the collar chart. -/
 @[simp]
 theorem coe_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : h.sourceOpens) :
+    (y : sourceOpens φ) :
     (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
       φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
   let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
     IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
   have heq := congrArg
-    (fun e : h.sourceOpens ≃ h.boundaryOpens × h.normalOpens ↦
+    (fun e : sourceOpens φ ≃ boundaryOpens φ × normalOpens ε ↦
       (e y).1)
     (diffeomorphProd_toEquiv h hk)
   calc
@@ -280,19 +306,19 @@ theorem coe_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠
       congrArg (fun p ↦ ((p.1 : ↥((𝓡∂ (n + 1)).boundary M)) : M))
         (congrFun (Diffeomorph.coe_toEquiv (h.diffeomorphProd hk)) y).symm
     _ = ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) :=
-      congrArg (fun q : h.boundaryOpens ↦
+      congrArg (fun q : boundaryOpens φ ↦
         (((q : ↥((𝓡∂ (n + 1)).boundary M)) : M))) heq
     _ = φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := coe_prodEquiv_fst h y
 
 /-- The normal component of the local collar is the normal component of the collar chart. -/
 @[simp]
 theorem coe_diffeomorphProd_snd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : h.sourceOpens) :
+    (y : sourceOpens φ) :
     ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) = (φ y).2 := by
   let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
     IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
   have heq : ((h.diffeomorphProd hk).toEquiv y).2 = (h.prodEquiv y).2 := congrArg
-    (fun e : h.sourceOpens ≃ h.boundaryOpens × h.normalOpens ↦
+    (fun e : sourceOpens φ ≃ boundaryOpens φ × normalOpens ε ↦
       (e y).2)
     (diffeomorphProd_toEquiv h hk)
   calc
@@ -301,14 +327,14 @@ theorem coe_diffeomorphProd_snd (h : IsProductCollarChart k φ V ε) (hk : k ≠
       congrArg (fun p ↦ (p.2 : EuclideanHalfSpace 1))
         (congrFun (Diffeomorph.coe_toEquiv (h.diffeomorphProd hk)) y).symm
     _ = ((h.prodEquiv y).2 : EuclideanHalfSpace 1) :=
-      congrArg (fun t : h.normalOpens ↦ (t : EuclideanHalfSpace 1)) heq
+      congrArg (fun t : normalOpens ε ↦ (t : EuclideanHalfSpace 1)) heq
     _ = (φ y).2 := coe_prodEquiv_snd h y
 
 /-- The inverse local collar forms a collar-coordinate pair and reads it back through the
 chart. -/
 @[simp]
 theorem coe_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (p : h.boundaryOpens × h.normalOpens) :
+    (p : boundaryOpens φ × normalOpens ε) :
     let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
       IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
     ((h.diffeomorphProd hk).symm p : M) =
@@ -317,12 +343,12 @@ theorem coe_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k �
     IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
   have heq : ((h.diffeomorphProd hk).toEquiv.symm p : M) =
       (h.prodEquiv.symm p : M) := congrArg
-    (fun e : h.sourceOpens ≃ h.boundaryOpens × h.normalOpens ↦ (e.symm p : M))
+    (fun e : sourceOpens φ ≃ boundaryOpens φ × normalOpens ε ↦ (e.symm p : M))
     (diffeomorphProd_toEquiv h hk)
   calc
     ((h.diffeomorphProd hk).symm p : M) =
         ((h.diffeomorphProd hk).toEquiv.symm p : M) :=
-      congrArg (fun q : h.sourceOpens ↦ (q : M))
+      congrArg (fun q : sourceOpens φ ↦ (q : M))
         (congrFun (Diffeomorph.toEquiv_coe_symm (h.diffeomorphProd hk)) p).symm
     _ = (h.prodEquiv.symm p : M) := heq
     _ = φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := coe_prodEquiv_symm h p
@@ -330,7 +356,7 @@ theorem coe_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k �
 /-- In collar coordinates, the boundary retraction keeps the tangential coordinate and sets the
 normal coordinate to zero. -/
 theorem map_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : h.sourceOpens) :
+    (y : sourceOpens φ) :
     φ (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
       ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
   rw [coe_diffeomorphProd_fst]
@@ -352,12 +378,13 @@ theorem exists_diffeomorphProd_of_mem_boundary [IsManifold (𝓡∂ (n + 1)) k M
     (hk : k ≠ 0) {x : M} (hx : x ∈ (𝓡∂ (n + 1)).boundary M) :
     ∃ (φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1))
       (V : Set (EuclideanSpace ℝ (Fin n))) (ε : ℝ)
-      (h : IsProductCollarChart k φ V ε),
-      x ∈ h.sourceOpens ∧
+      (_h : IsProductCollarChart k φ V ε),
+      x ∈ IsProductCollarChart.sourceOpens φ ∧
         let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
           IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-        Nonempty (Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) h.sourceOpens
-          (h.boundaryOpens × h.normalOpens) k) := by
+        Nonempty (Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1))
+          (IsProductCollarChart.sourceOpens φ)
+          (IsProductCollarChart.boundaryOpens φ × IsProductCollarChart.normalOpens ε) k) := by
   obtain ⟨φ, V, ε, hxφ, h⟩ := exists_isProductCollarChart_of_mem_boundary hk hx
   exact ⟨φ, V, ε, h, hxφ, ⟨h.diffeomorphProd hk⟩⟩
 

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
@@ -10,35 +10,42 @@ public import TauCeti.Geometry.Manifold.Boundary.Collar.Local
 /-!
 # Smooth local collars of a manifold with boundary
 
-The module Boundary.Collar.Local shrinks collar coordinates around a boundary point to a product
-box and extracts a homeomorphism with a product of the boundary and a half-open interval. This file
-proves that product decomposition is smooth for the canonical manifold structure on the boundary.
+`Boundary.Collar.Local` shrinks collar coordinates around a boundary point to a product box and
+extracts a homeomorphism with a product of the boundary and a half-open interval. This file
+constructs a smooth product decomposition for the canonical manifold structure on the boundary.
 
-For a product collar chart φ, the source, its boundary part, and its normal interval are recorded
-as open submanifolds. The diffeomorphism IsProductCollarChart.diffeomorphProd sends a point to its
-boundary retraction and normal coordinate. Its inverse takes a boundary point and a normal
-coordinate and reads the resulting pair back through φ.
+For a product collar chart `φ`, the diffeomorphism
+`TauCeti.IsProductCollarChart.diffeomorphProd` sends a point to its boundary retraction and normal
+coordinate. Its underlying equivalence is obtained from
+`TauCeti.IsProductCollarChart.homeomorphProd`, after identifying the boundary factor with an open
+subspace of the canonical boundary manifold. Its inverse combines a boundary point and a normal
+coordinate and reads the resulting pair back through `φ`.
 
 This is the smooth local-product step in the collar-neighbourhood target of Layer 1 of the
-GeometricTopology roadmap. The global collar theorem still requires patching these local
+`GeometricTopology` roadmap. The global collar theorem still requires patching these local
 diffeomorphisms along the whole boundary.
 
 ## Main definitions
 
-* TauCeti.IsProductCollarChart.sourceOpens: the source of a product collar chart as an open
-  submanifold of the ambient manifold.
-* TauCeti.IsProductCollarChart.boundaryOpens: the boundary part of that source as an open
-  submanifold of the canonical boundary manifold.
-* TauCeti.IsProductCollarChart.normalOpens: the normal interval as an open submanifold of the
-  one-dimensional half-space.
-* TauCeti.IsProductCollarChart.diffeomorphProd: the canonical smooth local collar.
-* TauCeti.exists_diffeomorphProd_of_mem_boundary: every boundary point lies in the source of such
-  a smooth local collar.
+* `TauCeti.IsProductCollarChart.diffeomorphProd`: the canonical smooth local collar.
+
+## Main results
+
+* `TauCeti.IsProductCollarChart.contMDiff_boundaryRetract`: the boundary retraction of a product
+  collar chart is `C^k`.
+* `TauCeti.IsProductCollarChart.map_diffeomorphProd_fst` and
+  `TauCeti.IsProductCollarChart.coe_diffeomorphProd_snd`: the forward coordinate formulas.
+* `TauCeti.IsProductCollarChart.map_diffeomorphProd_symm`: the inverse coordinate formula.
+* `TauCeti.IsProductCollarChart.diffeomorphProd_apply_of_mem_boundary`: the local collar fixes the
+  boundary and gives it normal coordinate zero.
+* `TauCeti.IsProductCollarChart.coe_diffeomorphProd_fst_eq_homeomorphProd_fst` and
+  `TauCeti.IsProductCollarChart.coe_diffeomorphProd_snd_eq_homeomorphProd_snd`: the smooth and
+  topological local collars have the same underlying map.
 
 ## References
 
-* M. Hirsch, Differential Topology, Springer GTM 33 (1976), Theorem 6.1.
-* J. Lee, Introduction to Smooth Manifolds, Springer GTM 218, 2nd ed. (2013), Theorem 9.25.
+* M. Hirsch, *Differential Topology*, Springer GTM 33 (1976), Theorem 6.1.
+* J. Lee, *Introduction to Smooth Manifolds*, Springer GTM 218, 2nd ed. (2013), Theorem 9.25.
 -/
 
 public section
@@ -59,333 +66,299 @@ namespace IsProductCollarChart
 variable {φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)}
   {V : Set (EuclideanSpace ℝ (Fin n))} {ε : ℝ}
 
-/-- The source of a chart, regarded as an open submanifold of the ambient manifold. -/
-def sourceOpens
-    (φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)) :
-    TopologicalSpace.Opens M :=
-  ⟨φ.source, φ.open_source⟩
+private theorem source_mem (h : IsProductCollarChart k φ V ε) (y : h.sourceOpens) :
+    (y : M) ∈ φ.source :=
+  h.mem_sourceOpens.1 y.2
 
-omit [ChartedSpace (EuclideanHalfSpace (n + 1)) M] in
-/-- Membership in the open source of a chart is membership in the chart source. -/
-@[simp]
-theorem mem_sourceOpens {x : M} : x ∈ sourceOpens φ ↔ x ∈ φ.source := Iff.rfl
+private theorem sourceSubtype_mem
+    (h : IsProductCollarChart k φ V ε) (y : h.sourceBoundaryOpens) : (y.1 : M) ∈ φ.source :=
+  h.mem_sourceBoundaryOpens.1 y.2
 
-/-- The part of the boundary in the source of a chart, regarded as an open submanifold of the
-canonical boundary manifold. -/
-def boundaryOpens
-    (φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)) :
-    TopologicalSpace.Opens ↥((𝓡∂ (n + 1)).boundary M) :=
-  ⟨Subtype.val ⁻¹' φ.source, φ.open_source.preimage continuous_subtype_val⟩
-
-/-- A boundary point belongs to the collar base exactly when its ambient point belongs to the
-chart source. -/
-@[simp]
-theorem mem_boundaryOpens {x : ↥((𝓡∂ (n + 1)).boundary M)} :
-    x ∈ boundaryOpens φ ↔ (x : M) ∈ φ.source := Iff.rfl
-
-/-- The normal interval below a positive height, regarded as an open submanifold of the
-one-dimensional half-space. -/
-def normalOpens (ε : ℝ) : TopologicalSpace.Opens (EuclideanHalfSpace 1) :=
-  ⟨EuclideanHalfSpace.normalIio ε, EuclideanHalfSpace.isOpen_normalIio ε⟩
-
-/-- A normal coordinate belongs to the collar interval exactly when it is smaller than the collar
-height. -/
-@[simp]
-theorem mem_normalOpens {t : EuclideanHalfSpace 1} :
-    t ∈ normalOpens ε ↔ t.1 0 < ε := EuclideanHalfSpace.mem_normalIio
+private theorem normalIio_mem (t : EuclideanHalfSpace.normalIioOpens ε) :
+    (t : EuclideanHalfSpace 1) ∈ EuclideanHalfSpace.normalIio ε :=
+  EuclideanHalfSpace.mem_normalIio.2 (EuclideanHalfSpace.mem_normalIioOpens.1 t.2)
 
 private def prodEquiv (h : IsProductCollarChart k φ V ε) :
-    sourceOpens φ ≃ boundaryOpens φ × normalOpens ε where
-  toFun y := by
-    have hyφ : φ y ∈ φ.target := φ.map_source y.2
-    have hybox : φ y ∈ V ×ˢ EuclideanHalfSpace.normalIio ε := h.target_eq ▸ hyφ
-    have hzero : ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target := by
-      rw [h.target_eq]
-      exact ⟨hybox.1, EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
-    let q := φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1))
-    have hqsource : q ∈ φ.source := φ.map_target hzero
-    have hqboundary : q ∈ (𝓡∂ (n + 1)).boundary M := by
-      rw [h.mem_boundary_iff q hqsource, φ.right_inv hzero]
-      exact EuclideanHalfSpace.val_zero_apply
-    exact (⟨⟨q, hqboundary⟩, hqsource⟩, ⟨(φ y).2, hybox.2⟩)
-  invFun p := by
-    have hqtarget : φ p.1.1 ∈ φ.target := φ.map_source p.1.2
-    have hqbox : φ p.1.1 ∈ V ×ˢ EuclideanHalfSpace.normalIio ε := h.target_eq ▸ hqtarget
-    have hpbox : ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) ∈ φ.target := by
-      rw [h.target_eq]
-      exact ⟨hqbox.1, p.2.2⟩
-    exact ⟨φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)), φ.map_target hpbox⟩
-  left_inv y := by
-    have hybox : φ y ∈ V ×ˢ EuclideanHalfSpace.normalIio ε :=
-      h.target_eq ▸ φ.map_source y.2
-    have hzero : ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target := by
-      rw [h.target_eq]
-      exact ⟨hybox.1, EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
-    apply Subtype.ext
-    simp only
-    rw [φ.right_inv hzero]
-    exact φ.left_inv y.2
-  right_inv p := by
-    have hqtarget : φ p.1.1 ∈ φ.target := φ.map_source p.1.2
-    have hpbox : ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) ∈ φ.target := by
-      rw [h.target_eq]
-      exact ⟨(h.target_eq ▸ hqtarget).1, p.2.2⟩
-    have hqzero : (φ p.1.1).2 = 0 := EuclideanHalfSpace.eq_zero_iff.2 <|
-      (h.mem_boundary_iff p.1.1 p.1.2).1 p.1.1.2
-    apply Prod.ext
-    · apply Subtype.ext
-      apply Subtype.ext
-      simp only
-      rw [φ.right_inv hpbox]
-      rw [← hqzero]
-      exact φ.left_inv p.1.2
-    · apply Subtype.ext
-      simp only
-      rw [φ.right_inv]
-      rw [h.target_eq]
-      exact ⟨(h.target_eq ▸ hqtarget).1, p.2.2⟩
+    h.sourceOpens ≃ h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε :=
+  h.homeomorphProdOpens.toEquiv
 
-private theorem coe_prodEquiv_fst (h : IsProductCollarChart k φ V ε) (y : sourceOpens φ) :
+private theorem coe_prodEquiv_fst (h : IsProductCollarChart k φ V ε)
+    (y : h.sourceOpens) :
     (((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
-      φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := rfl
+      φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
+  rw [← h.map_homeomorphProdOpens_fst y]
+  exact (φ.left_inv
+    (h.mem_sourceBoundaryOpens.1 (h.prodEquiv y).1.2)).symm
 
-private theorem coe_prodEquiv_snd (h : IsProductCollarChart k φ V ε) (y : sourceOpens φ) :
-    ((h.prodEquiv y).2 : EuclideanHalfSpace 1) = (φ y).2 := rfl
+private theorem coe_prodEquiv_snd (h : IsProductCollarChart k φ V ε)
+    (y : h.sourceOpens) :
+    ((h.prodEquiv y).2 : EuclideanHalfSpace 1) = (φ y).2 :=
+  h.coe_homeomorphProdOpens_snd y
+
+private theorem map_prodEquiv_fst (h : IsProductCollarChart k φ V ε)
+    (y : h.sourceOpens) :
+    φ (((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+      ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
+  exact h.map_homeomorphProdOpens_fst y
 
 private theorem coe_prodEquiv_symm (h : IsProductCollarChart k φ V ε)
-    (p : boundaryOpens φ × normalOpens ε) :
+    (p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε) :
     (h.prodEquiv.symm p : M) =
-      φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := rfl
-
-private theorem boundary_coe_comp_prodEquiv_fst (h : IsProductCollarChart k φ V ε) :
-    (Subtype.val ∘ fun y : sourceOpens φ ↦
-      ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) =
-      fun y : sourceOpens φ ↦ φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
-  funext y
-  exact coe_prodEquiv_fst h y
-
-private theorem boundaryOpens_coe_comp_prodEquiv_fst
-    (h : IsProductCollarChart k φ V ε) :
-    (Subtype.val ∘ fun y : sourceOpens φ ↦ (h.prodEquiv y).1) =
-      fun y ↦ ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) := rfl
-
-private theorem normalOpens_coe_comp_prodEquiv_snd
-    (h : IsProductCollarChart k φ V ε) :
-    (Subtype.val ∘ fun y : sourceOpens φ ↦ (h.prodEquiv y).2) =
-      fun y : sourceOpens φ ↦ (φ y).2 := by
-  funext y
-  exact coe_prodEquiv_snd h y
-
-private theorem sourceOpens_coe_comp_prodEquiv_symm
-    (h : IsProductCollarChart k φ V ε) :
-    (Subtype.val ∘ h.prodEquiv.symm) = fun p : boundaryOpens φ × normalOpens ε ↦
       φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := by
-  funext p
-  exact coe_prodEquiv_symm h p
+  let y := h.prodEquiv.symm p
+  have hp : h.prodEquiv y = p := h.prodEquiv.apply_symm_apply p
+  have hfirst :
+      (((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) = (p.1.1 : M) :=
+    congrArg (fun q ↦ (((q.1 : ↥((𝓡∂ (n + 1)).boundary M)) : M))) hp
+  have hfst : (φ p.1.1).1 = (φ y).1 := by
+    have hmap := congrArg Prod.fst (h.map_prodEquiv_fst y)
+    rwa [hfirst] at hmap
+  have hsnd : (φ y).2 = (p.2 : EuclideanHalfSpace 1) :=
+    (h.coe_prodEquiv_snd y).symm.trans
+      (congrArg (fun q ↦ (q.2 : EuclideanHalfSpace 1)) hp)
+  calc
+    (h.prodEquiv.symm p : M) = φ.symm (φ y) := (φ.left_inv (source_mem h y)).symm
+    _ = φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) :=
+      congrArg φ.symm (Prod.ext hfst.symm hsnd)
+
+/-- The boundary retraction of a product collar chart is `C^k`: it sets the normal coordinate to
+zero and reads the result back through the chart. -/
+theorem contMDiff_boundaryRetract (h : IsProductCollarChart k φ V ε) :
+    ContMDiff (𝓡∂ (n + 1)) (𝓡∂ (n + 1)) k
+      (fun y : h.sourceOpens ↦
+        φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1))) := by
+  have hφ : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+      (fun y : h.sourceOpens ↦ φ y) := by
+    intro y
+    rw [contMDiffAt_subtype_iff]
+    exact (h.contMDiffOn y (source_mem h y)).contMDiffAt
+      (φ.open_source.mem_nhds (source_mem h y))
+  have hzero : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+      (fun y : h.sourceOpens ↦
+        ((φ y).1, (0 : EuclideanHalfSpace 1))) :=
+    hφ.fst.prodMk contMDiff_const
+  intro y
+  exact ((h.contMDiffOn_symm _ (h.fst_zero_mem_target (source_mem h y))).contMDiffAt
+    (φ.open_target.mem_nhds (h.fst_zero_mem_target (source_mem h y)))).comp y hzero.contMDiffAt
 
 variable [IsManifold (𝓡∂ (n + 1)) k M]
 
-/-- A product collar chart gives a C^k diffeomorphism from its source to the product of its
-boundary part and its normal interval. The boundary factor uses the canonical manifold structure
-from Boundary.Charts. -/
+private theorem contMDiff_prodEquiv (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
+    let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+      IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+    ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k h.prodEquiv := by
+  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+  let _ : IsManifold 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+      ↥((𝓡∂ (n + 1)).boundary M) := isManifold_boundary M hk
+  have hretractBoundary : ContMDiff (𝓡∂ (n + 1))
+      𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+      (fun y : h.sourceOpens ↦
+        ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) := by
+    apply (ContMDiff.iff_comp_isImmersion
+      (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).isImmersion).2
+    refine ⟨?_, ?_⟩
+    · apply continuous_induced_rng.2
+      convert h.contMDiff_boundaryRetract.continuous using 1
+      funext y
+      exact h.coe_prodEquiv_fst y
+    · convert h.contMDiff_boundaryRetract using 1
+      funext y
+      exact h.coe_prodEquiv_fst y
+  have hretract : ContMDiff (𝓡∂ (n + 1))
+      𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+      (fun y : h.sourceOpens ↦ (h.prodEquiv y).1) := by
+    intro y
+    have hcomp : ContMDiffAt (𝓡∂ (n + 1))
+        𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+        (Subtype.val ∘ fun y : h.sourceOpens ↦ (h.prodEquiv y).1) y := by
+      change ContMDiffAt (𝓡∂ (n + 1)) 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+        (fun y : h.sourceOpens ↦
+          ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) y
+      exact hretractBoundary y
+    exact (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 hcomp
+  have hφ : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+      (fun y : h.sourceOpens ↦ φ y) := by
+    intro y
+    rw [contMDiffAt_subtype_iff]
+    exact (h.contMDiffOn y (source_mem h y)).contMDiffAt
+      (φ.open_source.mem_nhds (source_mem h y))
+  have hnormal : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ 1) k
+      (fun y : h.sourceOpens ↦ (h.prodEquiv y).2) := by
+    intro y
+    have hcomp : ContMDiffAt (𝓡∂ (n + 1)) (𝓡∂ 1) k
+        (Subtype.val ∘ fun y : h.sourceOpens ↦ (h.prodEquiv y).2) y := by
+      change ContMDiffAt (𝓡∂ (n + 1)) (𝓡∂ 1) k
+        (fun y : h.sourceOpens ↦
+          ((h.prodEquiv y).2 : EuclideanHalfSpace 1)) y
+      convert hφ.snd y using 1
+      funext z
+      exact h.coe_prodEquiv_snd z
+    exact (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 hcomp
+  exact hretract.prodMk hnormal
+
+private theorem contMDiff_prodEquiv_symm (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
+    let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+      IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+    ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k h.prodEquiv.symm := by
+  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+  let _ : IsManifold 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+      ↥((𝓡∂ (n + 1)).boundary M) := isManifold_boundary M hk
+  have hboundaryVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
+      (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦ (p.1.1 : M)) :=
+    (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).contMDiff.comp
+      (contMDiff_subtype_val.comp contMDiff_fst)
+  have hφboundary : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+      (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦ φ p.1.1) := by
+    intro p
+    exact ((h.contMDiffOn p.1.1 (sourceSubtype_mem h p.1)).contMDiffAt
+      (φ.open_source.mem_nhds (sourceSubtype_mem h p.1))).comp p hboundaryVal.contMDiffAt
+  have hnormalVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ 1) k
+      (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦
+        (p.2 : EuclideanHalfSpace 1)) :=
+    contMDiff_subtype_val.comp contMDiff_snd
+  have hpair : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+      (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦
+        ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) :=
+    hφboundary.fst.prodMk hnormalVal
+  have hassembleAmbient : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
+      (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦
+        φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) := by
+    intro p
+    exact ((h.contMDiffOn_symm _
+      (h.mk_mem_target (sourceSubtype_mem h p.1) (normalIio_mem p.2))).contMDiffAt
+      (φ.open_target.mem_nhds
+        (h.mk_mem_target (sourceSubtype_mem h p.1) (normalIio_mem p.2)))).comp p hpair.contMDiffAt
+  change ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k h.prodEquiv.symm
+  intro p
+  have hcomp : ContMDiffAt ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
+      (Subtype.val ∘ h.prodEquiv.symm) p := by
+    change ContMDiffAt ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
+      (fun p ↦ (h.prodEquiv.symm p : M)) p
+    convert hassembleAmbient p using 1
+    funext q
+    exact h.coe_prodEquiv_symm q
+  exact (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 hcomp
+
+/-- A product collar chart gives a `C^k` diffeomorphism from its open source to the product of its
+open boundary part and open normal interval. Its underlying equivalence is the existing
+`IsProductCollarChart.homeomorphProd`, transported across the canonical identification of the
+boundary factor. -/
 def diffeomorphProd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
     let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
       IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-    Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) (sourceOpens φ)
-      (boundaryOpens φ × normalOpens ε) k := by
-  letI : IsManifold (𝓡∂ (n + 1)) 1 M :=
-    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-  letI : IsManifold 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
-      ↥((𝓡∂ (n + 1)).boundary M) := isManifold_boundary M hk
-  refine { toEquiv := h.prodEquiv, contMDiff_toFun := ?_, contMDiff_invFun := ?_ }
-  · have hφ : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-        (fun y : sourceOpens φ ↦ φ y) := by
-      intro y
-      rw [contMDiffAt_subtype_iff]
-      exact (h.contMDiffOn y y.2).contMDiffAt (φ.open_source.mem_nhds y.2)
-    have hzero : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-        (fun y : sourceOpens φ ↦ ((φ y).1, (0 : EuclideanHalfSpace 1))) :=
-      hφ.fst.prodMk contMDiff_const
-    have hzero_mem (y : sourceOpens φ) :
-        ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target := by
-      rw [h.target_eq]
-      exact ⟨(h.target_eq ▸ φ.map_source y.2).1,
-        EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
-    have hretractAmbient : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ (n + 1)) k
-        (fun y : sourceOpens φ ↦ φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1))) := by
-      intro y
-      exact ((h.contMDiffOn_symm _ (hzero_mem y)).contMDiffAt
-        (φ.open_target.mem_nhds (hzero_mem y))).comp y hzero.contMDiffAt
-    have hretractBoundary : ContMDiff (𝓡∂ (n + 1))
-        𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
-        (fun y : sourceOpens φ ↦ ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) := by
-      apply (ContMDiff.iff_comp_isImmersion
-        (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).isImmersion).2
-      refine ⟨?_, ?_⟩
-      · exact continuous_induced_rng.2 hretractAmbient.continuous
-      · rw [boundary_coe_comp_prodEquiv_fst h]
-        exact hretractAmbient
-    have hretract : ContMDiff (𝓡∂ (n + 1))
-        𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
-        (fun y : sourceOpens φ ↦ (h.prodEquiv y).1) := by
-      apply (ContMDiff.iff_comp_isImmersion
-        (Manifold.IsImmersion.of_opens (boundaryOpens φ))).2
-      refine ⟨?_, ?_⟩
-      · exact continuous_induced_rng.2 hretractBoundary.continuous
-      · rw [boundaryOpens_coe_comp_prodEquiv_fst h]
-        exact hretractBoundary
-    have hnormal : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ 1) k
-        (fun y : sourceOpens φ ↦ (h.prodEquiv y).2) := by
-      apply (ContMDiff.iff_comp_isImmersion
-        (Manifold.IsImmersion.of_opens (normalOpens ε))).2
-      refine ⟨?_, ?_⟩
-      · exact continuous_induced_rng.2 hφ.snd.continuous
-      · rw [normalOpens_coe_comp_prodEquiv_snd h]
-        exact hφ.snd
-    exact hretract.prodMk hnormal
-  · have hboundaryVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
-        (fun p : boundaryOpens φ × normalOpens ε ↦ (p.1.1 : M)) := by
-      exact (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).contMDiff.comp
-        (contMDiff_subtype_val.comp contMDiff_fst)
-    have hφboundary : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-        (fun p : boundaryOpens φ × normalOpens ε ↦ φ p.1.1) := by
-      intro p
-      exact ((h.contMDiffOn p.1.1 p.1.2).contMDiffAt
-        (φ.open_source.mem_nhds p.1.2)).comp p hboundaryVal.contMDiffAt
-    have hnormalVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ 1) k
-        (fun p : boundaryOpens φ × normalOpens ε ↦ (p.2 : EuclideanHalfSpace 1)) :=
-      contMDiff_subtype_val.comp contMDiff_snd
-    have hpair : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-        (fun p : boundaryOpens φ × normalOpens ε ↦
-          ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) :=
-      hφboundary.fst.prodMk hnormalVal
-    have hpair_mem (p : boundaryOpens φ × normalOpens ε) :
-        ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) ∈ φ.target := by
-      rw [h.target_eq]
-      exact ⟨(h.target_eq ▸ φ.map_source p.1.2).1, p.2.2⟩
-    have hassembleAmbient : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
-        (fun p : boundaryOpens φ × normalOpens ε ↦
-          φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) := by
-      intro p
-      exact ((h.contMDiffOn_symm _ (hpair_mem p)).contMDiffAt
-        (φ.open_target.mem_nhds (hpair_mem p))).comp p hpair.contMDiffAt
-    apply (ContMDiff.iff_comp_isImmersion
-      (Manifold.IsImmersion.of_opens (sourceOpens φ))).2
-    refine ⟨?_, ?_⟩
-    · exact continuous_induced_rng.2 hassembleAmbient.continuous
-    · rw [sourceOpens_coe_comp_prodEquiv_symm h]
-      exact hassembleAmbient
-
-private theorem diffeomorphProd_toEquiv (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
-    let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
-      IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-    (h.diffeomorphProd hk).toEquiv = h.prodEquiv := by
+    Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1))
+      h.sourceOpens (h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε) k :=
   let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
     IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-  rw [diffeomorphProd.eq_def]
+  { toEquiv := h.prodEquiv
+    contMDiff_toFun := h.contMDiff_prodEquiv hk
+    contMDiff_invFun := h.contMDiff_prodEquiv_symm hk }
 
 section Characteristic
 
-/-- The boundary component of the local collar is obtained by setting the normal coordinate to
-zero and reading back through the collar chart. -/
-@[simp]
-theorem coe_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : sourceOpens φ) :
+/-- The boundary component of the smooth local collar agrees with the boundary component of the
+topological local collar. -/
+theorem coe_diffeomorphProd_fst_eq_homeomorphProd_fst
+    (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (y : h.sourceOpens) :
     (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
-      φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
-  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
-    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-  have heq := congrArg
-    (fun e : sourceOpens φ ≃ boundaryOpens φ × normalOpens ε ↦
-      (e y).1)
-    (diffeomorphProd_toEquiv h hk)
-  calc
-    (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
-        (((h.diffeomorphProd hk).toEquiv y).1 :
-          ↥((𝓡∂ (n + 1)).boundary M)) :=
-      congrArg (fun p ↦ ((p.1 : ↥((𝓡∂ (n + 1)).boundary M)) : M))
-        (congrFun (Diffeomorph.coe_toEquiv (h.diffeomorphProd hk)) y).symm
-    _ = ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) :=
-      congrArg (fun q : boundaryOpens φ ↦
-        (((q : ↥((𝓡∂ (n + 1)).boundary M)) : M))) heq
-    _ = φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := coe_prodEquiv_fst h y
+      ((h.homeomorphProd ⟨y, h.mem_sourceOpens.1 y.2⟩).1 : M) :=
+  h.coe_homeomorphProdOpens_fst_eq_homeomorphProd_fst y
 
-/-- The normal component of the local collar is the normal component of the collar chart. -/
+/-- The normal component of the smooth local collar agrees with the normal component of the
+topological local collar. -/
+theorem coe_diffeomorphProd_snd_eq_homeomorphProd_snd
+    (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (y : h.sourceOpens) :
+    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) =
+      ((h.homeomorphProd ⟨y, h.mem_sourceOpens.1 y.2⟩).2 : EuclideanHalfSpace 1) :=
+  h.coe_homeomorphProdOpens_snd_eq_homeomorphProd_snd y
+
+/-- The boundary component of the smooth local collar is obtained by setting the normal
+coordinate to zero and reading back through the collar chart. -/
+theorem coe_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (y : h.sourceOpens) :
+    (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+      φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) :=
+  h.coe_prodEquiv_fst y
+
+/-- The normal component of the smooth local collar is the normal component of the collar chart. -/
 @[simp]
 theorem coe_diffeomorphProd_snd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : sourceOpens φ) :
-    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) = (φ y).2 := by
-  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
-    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-  have heq : ((h.diffeomorphProd hk).toEquiv y).2 = (h.prodEquiv y).2 := congrArg
-    (fun e : sourceOpens φ ≃ boundaryOpens φ × normalOpens ε ↦
-      (e y).2)
-    (diffeomorphProd_toEquiv h hk)
-  calc
-    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) =
-        (((h.diffeomorphProd hk).toEquiv y).2 : EuclideanHalfSpace 1) :=
-      congrArg (fun p ↦ (p.2 : EuclideanHalfSpace 1))
-        (congrFun (Diffeomorph.coe_toEquiv (h.diffeomorphProd hk)) y).symm
-    _ = ((h.prodEquiv y).2 : EuclideanHalfSpace 1) :=
-      congrArg (fun t : normalOpens ε ↦ (t : EuclideanHalfSpace 1)) heq
-    _ = (φ y).2 := coe_prodEquiv_snd h y
+    (y : h.sourceOpens) :
+    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) = (φ y).2 :=
+  h.coe_prodEquiv_snd y
 
-/-- The inverse local collar forms a collar-coordinate pair and reads it back through the
+/-- The inverse smooth local collar forms a collar-coordinate pair and reads it back through the
 chart. -/
-@[simp]
 theorem coe_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (p : boundaryOpens φ × normalOpens ε) :
+    (p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε) :
     let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
       IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
     ((h.diffeomorphProd hk).symm p : M) =
-      φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := by
-  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
-    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-  have heq : ((h.diffeomorphProd hk).toEquiv.symm p : M) =
-      (h.prodEquiv.symm p : M) := congrArg
-    (fun e : sourceOpens φ ≃ boundaryOpens φ × normalOpens ε ↦ (e.symm p : M))
-    (diffeomorphProd_toEquiv h hk)
-  calc
-    ((h.diffeomorphProd hk).symm p : M) =
-        ((h.diffeomorphProd hk).toEquiv.symm p : M) :=
-      congrArg (fun q : sourceOpens φ ↦ (q : M))
-        (congrFun (Diffeomorph.toEquiv_coe_symm (h.diffeomorphProd hk)) p).symm
-    _ = (h.prodEquiv.symm p : M) := heq
-    _ = φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := coe_prodEquiv_symm h p
+      φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) :=
+  h.coe_prodEquiv_symm p
 
 /-- In collar coordinates, the boundary retraction keeps the tangential coordinate and sets the
 normal coordinate to zero. -/
+@[simp]
 theorem map_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : sourceOpens φ) :
+    (y : h.sourceOpens) :
     φ (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
-      ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
-  rw [coe_diffeomorphProd_fst]
-  apply φ.right_inv
-  rw [h.target_eq]
-  exact ⟨(h.target_eq ▸ φ.map_source y.2).1,
-    EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
+      ((φ y).1, (0 : EuclideanHalfSpace 1)) :=
+  h.map_prodEquiv_fst y
+
+/-- Applying the collar chart after the inverse smooth local collar recovers the supplied
+tangential and normal coordinates. -/
+@[simp]
+theorem map_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε) :
+    let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+      IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+    φ ((h.diffeomorphProd hk).symm p : M) =
+      ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := by
+  rw [coe_diffeomorphProd_symm]
+  exact φ.right_inv (h.mk_mem_target (sourceSubtype_mem h p.1) (normalIio_mem p.2))
+
+/-- On the boundary, the smooth local collar is the identity in the boundary factor and has zero
+normal coordinate. -/
+theorem diffeomorphProd_apply_of_mem_boundary (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (y : h.sourceOpens)
+    (hy : (y : M) ∈ (𝓡∂ (n + 1)).boundary M) :
+    h.diffeomorphProd hk y =
+      (⟨⟨(y : M), hy⟩,
+        h.mem_sourceBoundaryOpens.2 (h.mem_sourceOpens.1 y.2)⟩,
+        ⟨0, EuclideanHalfSpace.mem_normalIioOpens.2
+          (EuclideanHalfSpace.mem_normalIio.1
+            (EuclideanHalfSpace.zero_mem_normalIio h.height_pos))⟩) := by
+  have hyzero : (φ y).2 = 0 :=
+    EuclideanHalfSpace.eq_zero_iff.2 ((h.mem_boundary_iff y (source_mem h y)).1 hy)
+  apply Prod.ext
+  · apply Subtype.ext
+    apply Subtype.ext
+    change (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) = (y : M)
+    rw [coe_diffeomorphProd_fst]
+    calc
+      φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) = φ.symm (φ y) :=
+        congrArg φ.symm (Prod.ext (rfl) hyzero.symm)
+      _ = y := φ.left_inv (source_mem h y)
+  · apply Subtype.ext
+    rw [coe_diffeomorphProd_snd]
+    exact hyzero
+
+/-- The normal component of the smooth local collar vanishes on the boundary. -/
+theorem coe_diffeomorphProd_snd_of_mem_boundary
+    (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (y : h.sourceOpens)
+    (hy : (y : M) ∈ (𝓡∂ (n + 1)).boundary M) :
+    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) = 0 := by
+  rw [coe_diffeomorphProd_snd]
+  exact EuclideanHalfSpace.eq_zero_iff.2 ((h.mem_boundary_iff y (source_mem h y)).1 hy)
 
 end Characteristic
 
 end IsProductCollarChart
-
-/-- Every boundary point of a positive-regularity manifold with boundary lies in a product collar
-chart whose source is diffeomorphic to the product of its boundary part and its normal interval.
-
-This is the local smooth collar theorem. The global collar theorem asks for one source containing
-the entire boundary, rather than one source around each boundary point. -/
-theorem exists_diffeomorphProd_of_mem_boundary [IsManifold (𝓡∂ (n + 1)) k M]
-    (hk : k ≠ 0) {x : M} (hx : x ∈ (𝓡∂ (n + 1)).boundary M) :
-    ∃ (φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1))
-      (V : Set (EuclideanSpace ℝ (Fin n))) (ε : ℝ)
-      (_h : IsProductCollarChart k φ V ε),
-      x ∈ IsProductCollarChart.sourceOpens φ ∧
-        let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
-          IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-        Nonempty (Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1))
-          (IsProductCollarChart.sourceOpens φ)
-          (IsProductCollarChart.boundaryOpens φ × IsProductCollarChart.normalOpens ε) k) := by
-  obtain ⟨φ, V, ε, hxφ, h⟩ := exists_isProductCollarChart_of_mem_boundary hk hx
-  exact ⟨φ, V, ε, h, hxφ, ⟨h.diffeomorphProd hk⟩⟩
 
 end TauCeti

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
@@ -1,0 +1,371 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.Boundary.Collar.Local
+
+/-!
+# Smooth local collars of a manifold with boundary
+
+The module Boundary.Collar.Local shrinks collar coordinates around a boundary point to a product
+box and extracts a homeomorphism with a product of the boundary and a half-open interval. This file
+proves that product decomposition is smooth for the canonical manifold structure on the boundary.
+
+For a product collar chart φ, the source, its boundary part, and its normal interval are recorded
+as open submanifolds. The diffeomorphism IsProductCollarChart.diffeomorphProd sends a point to its
+boundary retraction and normal coordinate. Its inverse takes a boundary point and a normal
+coordinate and reads the resulting pair back through φ.
+
+This is the smooth local-product step in the collar-neighbourhood target of Layer 1 of the
+GeometricTopology roadmap. The global collar theorem still requires patching these local
+diffeomorphisms along the whole boundary.
+
+## Main definitions
+
+* TauCeti.IsProductCollarChart.sourceOpens: the source of a product collar chart as an open
+  submanifold of the ambient manifold.
+* TauCeti.IsProductCollarChart.boundaryOpens: the boundary part of that source as an open
+  submanifold of the canonical boundary manifold.
+* TauCeti.IsProductCollarChart.normalOpens: the normal interval as an open submanifold of the
+  one-dimensional half-space.
+* TauCeti.IsProductCollarChart.diffeomorphProd: the canonical smooth local collar.
+* TauCeti.exists_diffeomorphProd_of_mem_boundary: every boundary point lies in the source of such
+  a smooth local collar.
+
+## References
+
+* M. Hirsch, Differential Topology, Springer GTM 33 (1976), Theorem 6.1.
+* J. Lee, Introduction to Smooth Manifolds, Springer GTM 218, 2nd ed. (2013), Theorem 9.25.
+-/
+
+public section
+
+noncomputable section
+
+open Function Set Topology
+
+open scoped Manifold ContDiff
+
+namespace TauCeti
+
+variable {n : ℕ} {k : WithTop ℕ∞} {M : Type*} [TopologicalSpace M]
+  [ChartedSpace (EuclideanHalfSpace (n + 1)) M]
+
+namespace IsProductCollarChart
+
+variable {φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)}
+  {V : Set (EuclideanSpace ℝ (Fin n))} {ε : ℝ}
+
+/-- The source of a product collar chart, regarded as an open submanifold of the ambient
+manifold. -/
+def sourceOpens (_h : IsProductCollarChart k φ V ε) : TopologicalSpace.Opens M :=
+  ⟨φ.source, φ.open_source⟩
+
+/-- Membership in the open source of a product collar chart is membership in the chart source. -/
+@[simp]
+theorem mem_sourceOpens (h : IsProductCollarChart k φ V ε) {x : M} :
+    x ∈ h.sourceOpens ↔ x ∈ φ.source := Iff.rfl
+
+/-- The part of the boundary in the source of a product collar chart, regarded as an open
+submanifold of the canonical boundary manifold. -/
+def boundaryOpens (_h : IsProductCollarChart k φ V ε) :
+    TopologicalSpace.Opens ↥((𝓡∂ (n + 1)).boundary M) :=
+  ⟨Subtype.val ⁻¹' φ.source, φ.open_source.preimage continuous_subtype_val⟩
+
+/-- A boundary point belongs to the collar base exactly when its ambient point belongs to the
+chart source. -/
+@[simp]
+theorem mem_boundaryOpens (h : IsProductCollarChart k φ V ε)
+    {x : ↥((𝓡∂ (n + 1)).boundary M)} :
+    x ∈ h.boundaryOpens ↔ (x : M) ∈ φ.source := Iff.rfl
+
+/-- The normal interval of a product collar chart, regarded as an open submanifold of the
+one-dimensional half-space. -/
+def normalOpens (_h : IsProductCollarChart k φ V ε) :
+    TopologicalSpace.Opens (EuclideanHalfSpace 1) :=
+  ⟨EuclideanHalfSpace.normalIio ε, EuclideanHalfSpace.isOpen_normalIio ε⟩
+
+/-- A normal coordinate belongs to the collar interval exactly when it is smaller than the collar
+height. -/
+@[simp]
+theorem mem_normalOpens (h : IsProductCollarChart k φ V ε) {t : EuclideanHalfSpace 1} :
+    t ∈ (h.normalOpens : Set (EuclideanHalfSpace 1)) ↔ t.1 0 < ε := by
+  have hopen : (h.normalOpens : Set (EuclideanHalfSpace 1)) =
+      EuclideanHalfSpace.normalIio ε := by
+    rw [normalOpens.eq_def]
+    rfl
+  rw [hopen]
+  exact EuclideanHalfSpace.mem_normalIio
+
+private def prodEquiv (h : IsProductCollarChart k φ V ε) :
+    h.sourceOpens ≃ h.boundaryOpens × h.normalOpens where
+  toFun y := by
+    have hyφ : φ y ∈ φ.target := φ.map_source y.2
+    have hybox : φ y ∈ V ×ˢ EuclideanHalfSpace.normalIio ε := h.target_eq ▸ hyφ
+    have hzero : ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target := by
+      rw [h.target_eq]
+      exact ⟨hybox.1, EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
+    let q := φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1))
+    have hqsource : q ∈ φ.source := φ.map_target hzero
+    have hqboundary : q ∈ (𝓡∂ (n + 1)).boundary M := by
+      rw [h.mem_boundary_iff q hqsource, φ.right_inv hzero]
+      exact EuclideanHalfSpace.val_zero_apply
+    exact (⟨⟨q, hqboundary⟩, hqsource⟩, ⟨(φ y).2, hybox.2⟩)
+  invFun p := by
+    have hqtarget : φ p.1.1 ∈ φ.target := φ.map_source p.1.2
+    have hqbox : φ p.1.1 ∈ V ×ˢ EuclideanHalfSpace.normalIio ε := h.target_eq ▸ hqtarget
+    have hpbox : ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) ∈ φ.target := by
+      rw [h.target_eq]
+      exact ⟨hqbox.1, p.2.2⟩
+    exact ⟨φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)), φ.map_target hpbox⟩
+  left_inv y := by
+    have hybox : φ y ∈ V ×ˢ EuclideanHalfSpace.normalIio ε :=
+      h.target_eq ▸ φ.map_source y.2
+    have hzero : ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target := by
+      rw [h.target_eq]
+      exact ⟨hybox.1, EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
+    apply Subtype.ext
+    simp only
+    rw [φ.right_inv hzero]
+    exact φ.left_inv y.2
+  right_inv p := by
+    have hqtarget : φ p.1.1 ∈ φ.target := φ.map_source p.1.2
+    have hpbox : ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) ∈ φ.target := by
+      rw [h.target_eq]
+      exact ⟨(h.target_eq ▸ hqtarget).1, p.2.2⟩
+    have hqzero : (φ p.1.1).2 = 0 := EuclideanHalfSpace.eq_zero_iff.2 <|
+      (h.mem_boundary_iff p.1.1 p.1.2).1 p.1.1.2
+    apply Prod.ext
+    · apply Subtype.ext
+      apply Subtype.ext
+      simp only
+      rw [φ.right_inv hpbox]
+      rw [← hqzero]
+      exact φ.left_inv p.1.2
+    · apply Subtype.ext
+      simp only
+      rw [φ.right_inv]
+      rw [h.target_eq]
+      exact ⟨(h.target_eq ▸ hqtarget).1, p.2.2⟩
+
+private theorem coe_prodEquiv_fst (h : IsProductCollarChart k φ V ε) (y : h.sourceOpens) :
+    (((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+      φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := rfl
+
+private theorem coe_prodEquiv_snd (h : IsProductCollarChart k φ V ε) (y : h.sourceOpens) :
+    ((h.prodEquiv y).2 : EuclideanHalfSpace 1) = (φ y).2 := rfl
+
+private theorem coe_prodEquiv_symm (h : IsProductCollarChart k φ V ε)
+    (p : h.boundaryOpens × h.normalOpens) :
+    (h.prodEquiv.symm p : M) =
+      φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := rfl
+
+variable [IsManifold (𝓡∂ (n + 1)) k M]
+
+/-- A product collar chart gives a C^k diffeomorphism from its source to the product of its
+boundary part and its normal interval. The boundary factor uses the canonical manifold structure
+from Boundary.Charts. -/
+def diffeomorphProd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
+    let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+      IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+    Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) h.sourceOpens
+      (h.boundaryOpens × h.normalOpens) k := by
+  letI : IsManifold (𝓡∂ (n + 1)) 1 M :=
+    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+  letI : IsManifold 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+      ↥((𝓡∂ (n + 1)).boundary M) := isManifold_boundary M hk
+  refine { toEquiv := h.prodEquiv, contMDiff_toFun := ?_, contMDiff_invFun := ?_ }
+  · have hφ : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+        (fun y : h.sourceOpens ↦ φ y) := by
+      intro y
+      rw [contMDiffAt_subtype_iff]
+      exact (h.contMDiffOn y y.2).contMDiffAt (φ.open_source.mem_nhds y.2)
+    have hzero : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+        (fun y : h.sourceOpens ↦ ((φ y).1, (0 : EuclideanHalfSpace 1))) :=
+      hφ.fst.prodMk contMDiff_const
+    have hzero_mem (y : h.sourceOpens) :
+        ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target := by
+      rw [h.target_eq]
+      exact ⟨(h.target_eq ▸ φ.map_source y.2).1,
+        EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
+    have hretractAmbient : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ (n + 1)) k
+        (fun y : h.sourceOpens ↦ φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1))) := by
+      intro y
+      exact ((h.contMDiffOn_symm _ (hzero_mem y)).contMDiffAt
+        (φ.open_target.mem_nhds (hzero_mem y))).comp y hzero.contMDiffAt
+    have hretractBoundary : ContMDiff (𝓡∂ (n + 1))
+        𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+        (fun y : h.sourceOpens ↦ ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) := by
+      apply (ContMDiff.iff_comp_isImmersion
+        (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).isImmersion).2
+      refine ⟨?_, ?_⟩
+      · exact continuous_induced_rng.2 hretractAmbient.continuous
+      · convert hretractAmbient using 1
+        rfl
+    have hretract : ContMDiff (𝓡∂ (n + 1))
+        𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
+        (fun y : h.sourceOpens ↦ (h.prodEquiv y).1) := by
+      apply (ContMDiff.iff_comp_isImmersion
+        (Manifold.IsImmersion.of_opens h.boundaryOpens)).2
+      refine ⟨?_, ?_⟩
+      · exact continuous_induced_rng.2 hretractBoundary.continuous
+      · convert hretractBoundary using 1
+        rfl
+    have hnormal : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ 1) k
+        (fun y : h.sourceOpens ↦ (h.prodEquiv y).2) := by
+      apply (ContMDiff.iff_comp_isImmersion
+        (Manifold.IsImmersion.of_opens h.normalOpens)).2
+      refine ⟨?_, ?_⟩
+      · exact continuous_induced_rng.2 hφ.snd.continuous
+      · convert hφ.snd using 1
+        rfl
+    exact hretract.prodMk hnormal
+  · have hboundaryVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
+        (fun p : h.boundaryOpens × h.normalOpens ↦ (p.1.1 : M)) := by
+      exact (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).contMDiff.comp
+        (contMDiff_subtype_val.comp contMDiff_fst)
+    have hφboundary : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+        (fun p : h.boundaryOpens × h.normalOpens ↦ φ p.1.1) := by
+      intro p
+      exact ((h.contMDiffOn p.1.1 p.1.2).contMDiffAt
+        (φ.open_source.mem_nhds p.1.2)).comp p hboundaryVal.contMDiffAt
+    have hnormalVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ 1) k
+        (fun p : h.boundaryOpens × h.normalOpens ↦ (p.2 : EuclideanHalfSpace 1)) :=
+      contMDiff_subtype_val.comp contMDiff_snd
+    have hpair : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
+        (fun p : h.boundaryOpens × h.normalOpens ↦
+          ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) :=
+      hφboundary.fst.prodMk hnormalVal
+    have hpair_mem (p : h.boundaryOpens × h.normalOpens) :
+        ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) ∈ φ.target := by
+      rw [h.target_eq]
+      exact ⟨(h.target_eq ▸ φ.map_source p.1.2).1, p.2.2⟩
+    have hassembleAmbient : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
+        (fun p : h.boundaryOpens × h.normalOpens ↦
+          φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) := by
+      intro p
+      exact ((h.contMDiffOn_symm _ (hpair_mem p)).contMDiffAt
+        (φ.open_target.mem_nhds (hpair_mem p))).comp p hpair.contMDiffAt
+    apply (ContMDiff.iff_comp_isImmersion
+      (Manifold.IsImmersion.of_opens h.sourceOpens)).2
+    refine ⟨?_, ?_⟩
+    · exact continuous_induced_rng.2 hassembleAmbient.continuous
+    · convert hassembleAmbient using 1
+      rfl
+
+private theorem diffeomorphProd_toEquiv (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
+    let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+      IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+    (h.diffeomorphProd hk).toEquiv = h.prodEquiv := by
+  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+  rw [diffeomorphProd.eq_def]
+
+section Characteristic
+
+/-- The boundary component of the local collar is obtained by setting the normal coordinate to
+zero and reading back through the collar chart. -/
+@[simp]
+theorem coe_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (y : h.sourceOpens) :
+    (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+      φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
+  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+  have heq := congrArg
+    (fun e : h.sourceOpens ≃ h.boundaryOpens × h.normalOpens ↦
+      (e y).1)
+    (diffeomorphProd_toEquiv h hk)
+  calc
+    (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+        (((h.diffeomorphProd hk).toEquiv y).1 :
+          ↥((𝓡∂ (n + 1)).boundary M)) :=
+      congrArg (fun p ↦ ((p.1 : ↥((𝓡∂ (n + 1)).boundary M)) : M))
+        (congrFun (Diffeomorph.coe_toEquiv (h.diffeomorphProd hk)) y).symm
+    _ = ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) :=
+      congrArg (fun q : h.boundaryOpens ↦
+        (((q : ↥((𝓡∂ (n + 1)).boundary M)) : M))) heq
+    _ = φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := coe_prodEquiv_fst h y
+
+/-- The normal component of the local collar is the normal component of the collar chart. -/
+@[simp]
+theorem coe_diffeomorphProd_snd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (y : h.sourceOpens) :
+    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) = (φ y).2 := by
+  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+  have heq : ((h.diffeomorphProd hk).toEquiv y).2 = (h.prodEquiv y).2 := congrArg
+    (fun e : h.sourceOpens ≃ h.boundaryOpens × h.normalOpens ↦
+      (e y).2)
+    (diffeomorphProd_toEquiv h hk)
+  calc
+    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) =
+        (((h.diffeomorphProd hk).toEquiv y).2 : EuclideanHalfSpace 1) :=
+      congrArg (fun p ↦ (p.2 : EuclideanHalfSpace 1))
+        (congrFun (Diffeomorph.coe_toEquiv (h.diffeomorphProd hk)) y).symm
+    _ = ((h.prodEquiv y).2 : EuclideanHalfSpace 1) :=
+      congrArg (fun t : h.normalOpens ↦ (t : EuclideanHalfSpace 1)) heq
+    _ = (φ y).2 := coe_prodEquiv_snd h y
+
+/-- The inverse local collar forms a collar-coordinate pair and reads it back through the
+chart. -/
+@[simp]
+theorem coe_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (p : h.boundaryOpens × h.normalOpens) :
+    let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+      IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+    ((h.diffeomorphProd hk).symm p : M) =
+      φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := by
+  let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+    IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+  have heq : ((h.diffeomorphProd hk).toEquiv.symm p : M) =
+      (h.prodEquiv.symm p : M) := congrArg
+    (fun e : h.sourceOpens ≃ h.boundaryOpens × h.normalOpens ↦ (e.symm p : M))
+    (diffeomorphProd_toEquiv h hk)
+  calc
+    ((h.diffeomorphProd hk).symm p : M) =
+        ((h.diffeomorphProd hk).toEquiv.symm p : M) :=
+      congrArg (fun q : h.sourceOpens ↦ (q : M))
+        (congrFun (Diffeomorph.toEquiv_coe_symm (h.diffeomorphProd hk)) p).symm
+    _ = (h.prodEquiv.symm p : M) := heq
+    _ = φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := coe_prodEquiv_symm h p
+
+/-- In collar coordinates, the boundary retraction keeps the tangential coordinate and sets the
+normal coordinate to zero. -/
+@[simp]
+theorem map_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
+    (y : h.sourceOpens) :
+    φ (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+      ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
+  rw [coe_diffeomorphProd_fst]
+  apply φ.right_inv
+  rw [h.target_eq]
+  exact ⟨(h.target_eq ▸ φ.map_source y.2).1,
+    EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
+
+end Characteristic
+
+end IsProductCollarChart
+
+/-- Every boundary point of a positive-regularity manifold with boundary lies in a product collar
+chart whose source is diffeomorphic to the product of its boundary part and its normal interval.
+
+This is the local smooth collar theorem. The global collar theorem asks for one source containing
+the entire boundary, rather than one source around each boundary point. -/
+theorem exists_diffeomorphProd_of_mem_boundary [IsManifold (𝓡∂ (n + 1)) k M]
+    (hk : k ≠ 0) {x : M} (hx : x ∈ (𝓡∂ (n + 1)).boundary M) :
+    ∃ (φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1))
+      (V : Set (EuclideanSpace ℝ (Fin n))) (ε : ℝ)
+      (h : IsProductCollarChart k φ V ε),
+      x ∈ h.sourceOpens ∧
+        let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
+          IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
+        Nonempty (Diffeomorph (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) h.sourceOpens
+          (h.boundaryOpens × h.normalOpens) k) := by
+  obtain ⟨φ, V, ε, hxφ, h⟩ := exists_isProductCollarChart_of_mem_boundary hk hx
+  exact ⟨φ, V, ε, h, hxφ, ⟨h.diffeomorphProd hk⟩⟩
+
+end TauCeti

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
@@ -249,6 +249,7 @@ theorem map_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k �
 
 /-- On the boundary, the smooth local collar is the identity in the boundary factor and has zero
 normal coordinate. -/
+@[simp]
 theorem diffeomorphProd_apply_of_mem_boundary (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
     (y : h.sourceOpens)
     (hy : (y : M) ∈ (𝓡∂ (n + 1)).boundary M) :

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Diffeomorph.lean
@@ -11,14 +11,16 @@ public import TauCeti.Geometry.Manifold.Boundary.Collar.Local
 # Smooth local collars of a manifold with boundary
 
 `Boundary.Collar.Local` shrinks collar coordinates around a boundary point to a product box and
-extracts a homeomorphism with a product of the boundary and a half-open interval. This file
-constructs a smooth product decomposition for the canonical manifold structure on the boundary.
+splits the source of the resulting chart as a product, `IsProductCollarChart.homeomorphProdOpens`,
+whose three factors — the source, its part of the boundary, and the normal interval — are read as
+open subspaces. That splitting is only a homeomorphism. This file constructs the corresponding
+smooth product decomposition for the canonical manifold structure on the boundary.
 
 For a product collar chart `φ`, the diffeomorphism
 `TauCeti.IsProductCollarChart.diffeomorphProd` sends a point to its boundary retraction and normal
-coordinate. Its underlying equivalence is obtained from
-`TauCeti.IsProductCollarChart.homeomorphProd`, after identifying the boundary factor with an open
-subspace of the canonical boundary manifold. Its inverse combines a boundary point and a normal
+coordinate. Its underlying equivalence is the one of
+`TauCeti.IsProductCollarChart.homeomorphProdOpens`, so no topological content is reproved here;
+what is new is that both directions are `C^k`. Its inverse combines a boundary point and a normal
 coordinate and reads the resulting pair back through `φ`.
 
 This is the smooth local-product step in the collar-neighbourhood target of Layer 1 of the
@@ -38,9 +40,8 @@ diffeomorphisms along the whole boundary.
 * `TauCeti.IsProductCollarChart.map_diffeomorphProd_symm`: the inverse coordinate formula.
 * `TauCeti.IsProductCollarChart.diffeomorphProd_apply_of_mem_boundary`: the local collar fixes the
   boundary and gives it normal coordinate zero.
-* `TauCeti.IsProductCollarChart.coe_diffeomorphProd_fst_eq_homeomorphProd_fst` and
-  `TauCeti.IsProductCollarChart.coe_diffeomorphProd_snd_eq_homeomorphProd_snd`: the smooth and
-  topological local collars have the same underlying map.
+* `TauCeti.IsProductCollarChart.coe_diffeomorphProd`: the smooth local collar has the same
+  underlying map as the topological one, so all of the latter's coordinate formulas transfer.
 
 ## References
 
@@ -66,60 +67,38 @@ namespace IsProductCollarChart
 variable {φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)}
   {V : Set (EuclideanSpace ℝ (Fin n))} {ε : ℝ}
 
-private theorem source_mem (h : IsProductCollarChart k φ V ε) (y : h.sourceOpens) :
-    (y : M) ∈ φ.source :=
-  h.mem_sourceOpens.1 y.2
+private theorem contMDiffAt_chart (h : IsProductCollarChart k φ V ε) {y : M} (hy : y ∈ φ.source) :
+    ContMDiffAt (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k φ y :=
+  (h.contMDiffOn y hy).contMDiffAt (φ.open_source.mem_nhds hy)
 
-private theorem sourceSubtype_mem
-    (h : IsProductCollarChart k φ V ε) (y : h.sourceBoundaryOpens) : (y.1 : M) ∈ φ.source :=
-  h.mem_sourceBoundaryOpens.1 y.2
+private theorem contMDiffAt_chart_symm (h : IsProductCollarChart k φ V ε)
+    {p : EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1} (hp : p ∈ φ.target) :
+    ContMDiffAt ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k φ.symm p :=
+  (h.contMDiffOn_symm p hp).contMDiffAt (φ.open_target.mem_nhds hp)
 
-private theorem normalIio_mem (t : EuclideanHalfSpace.normalIioOpens ε) :
-    (t : EuclideanHalfSpace 1) ∈ EuclideanHalfSpace.normalIio ε :=
-  EuclideanHalfSpace.mem_normalIio.2 (EuclideanHalfSpace.mem_normalIioOpens.1 t.2)
+private theorem contMDiff_coe_chart (h : IsProductCollarChart k φ V ε) :
+    ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k (fun y : h.sourceOpens ↦ φ y) := fun y ↦
+  contMDiffAt_subtype_iff.2 (h.contMDiffAt_chart (h.mem_sourceOpens.1 y.2))
 
-private def prodEquiv (h : IsProductCollarChart k φ V ε) :
-    h.sourceOpens ≃ h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε :=
-  h.homeomorphProdOpens.toEquiv
-
-private theorem coe_prodEquiv_fst (h : IsProductCollarChart k φ V ε)
+/-- The boundary component of the local collar, read in the ambient manifold, is the point
+obtained by setting the normal coordinate to zero. -/
+private theorem coe_homeomorphProdOpens_fst (h : IsProductCollarChart k φ V ε)
     (y : h.sourceOpens) :
-    (((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+    (((h.homeomorphProdOpens y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
       φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
   rw [← h.map_homeomorphProdOpens_fst y]
-  exact (φ.left_inv
-    (h.mem_sourceBoundaryOpens.1 (h.prodEquiv y).1.2)).symm
+  exact (φ.left_inv (h.mem_sourceBoundaryOpens.1 (h.homeomorphProdOpens y).1.2)).symm
 
-private theorem coe_prodEquiv_snd (h : IsProductCollarChart k φ V ε)
-    (y : h.sourceOpens) :
-    ((h.prodEquiv y).2 : EuclideanHalfSpace 1) = (φ y).2 :=
-  h.coe_homeomorphProdOpens_snd y
-
-private theorem map_prodEquiv_fst (h : IsProductCollarChart k φ V ε)
-    (y : h.sourceOpens) :
-    φ (((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
-      ((φ y).1, (0 : EuclideanHalfSpace 1)) := by
-  exact h.map_homeomorphProdOpens_fst y
-
-private theorem coe_prodEquiv_symm (h : IsProductCollarChart k φ V ε)
+/-- The inverse local collar reads a boundary point and a normal coordinate back through the
+collar chart. -/
+private theorem coe_homeomorphProdOpens_symm (h : IsProductCollarChart k φ V ε)
     (p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε) :
-    (h.prodEquiv.symm p : M) =
+    (h.homeomorphProdOpens.symm p : M) =
       φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := by
-  let y := h.prodEquiv.symm p
-  have hp : h.prodEquiv y = p := h.prodEquiv.apply_symm_apply p
-  have hfirst :
-      (((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) = (p.1.1 : M) :=
-    congrArg (fun q ↦ (((q.1 : ↥((𝓡∂ (n + 1)).boundary M)) : M))) hp
-  have hfst : (φ p.1.1).1 = (φ y).1 := by
-    have hmap := congrArg Prod.fst (h.map_prodEquiv_fst y)
-    rwa [hfirst] at hmap
-  have hsnd : (φ y).2 = (p.2 : EuclideanHalfSpace 1) :=
-    (h.coe_prodEquiv_snd y).symm.trans
-      (congrArg (fun q ↦ (q.2 : EuclideanHalfSpace 1)) hp)
-  calc
-    (h.prodEquiv.symm p : M) = φ.symm (φ y) := (φ.left_inv (source_mem h y)).symm
-    _ = φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) :=
-      congrArg φ.symm (Prod.ext hfst.symm hsnd)
+  obtain ⟨y, rfl⟩ := h.homeomorphProdOpens.surjective p
+  rw [Homeomorph.symm_apply_apply, h.map_homeomorphProdOpens_fst y,
+    h.coe_homeomorphProdOpens_snd y]
+  exact (φ.left_inv (h.mem_sourceOpens.1 y.2)).symm
 
 /-- The boundary retraction of a product collar chart is `C^k`: it sets the normal coordinate to
 zero and reads the result back through the chart. -/
@@ -127,80 +106,53 @@ theorem contMDiff_boundaryRetract (h : IsProductCollarChart k φ V ε) :
     ContMDiff (𝓡∂ (n + 1)) (𝓡∂ (n + 1)) k
       (fun y : h.sourceOpens ↦
         φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1))) := by
-  have hφ : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-      (fun y : h.sourceOpens ↦ φ y) := by
-    intro y
-    rw [contMDiffAt_subtype_iff]
-    exact (h.contMDiffOn y (source_mem h y)).contMDiffAt
-      (φ.open_source.mem_nhds (source_mem h y))
   have hzero : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
       (fun y : h.sourceOpens ↦
         ((φ y).1, (0 : EuclideanHalfSpace 1))) :=
-    hφ.fst.prodMk contMDiff_const
-  intro y
-  exact ((h.contMDiffOn_symm _ (h.fst_zero_mem_target (source_mem h y))).contMDiffAt
-    (φ.open_target.mem_nhds (h.fst_zero_mem_target (source_mem h y)))).comp y hzero.contMDiffAt
+    h.contMDiff_coe_chart.fst.prodMk contMDiff_const
+  exact fun y ↦ (h.contMDiffAt_chart_symm
+    (h.fst_zero_mem_target (h.mem_sourceOpens.1 y.2))).comp y hzero.contMDiffAt
 
 variable [IsManifold (𝓡∂ (n + 1)) k M]
 
-private theorem contMDiff_prodEquiv (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
+private theorem contMDiff_homeomorphProdOpens (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
     let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
       IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-    ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k h.prodEquiv := by
+    ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k h.homeomorphProdOpens := by
   let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
     IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
   let _ : IsManifold 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
       ↥((𝓡∂ (n + 1)).boundary M) := isManifold_boundary M hk
+  have hretractVal : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ (n + 1)) k
+      (fun y : h.sourceOpens ↦
+        (((h.homeomorphProdOpens y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M)) := by
+    rw [funext h.coe_homeomorphProdOpens_fst]
+    exact h.contMDiff_boundaryRetract
   have hretractBoundary : ContMDiff (𝓡∂ (n + 1))
       𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
       (fun y : h.sourceOpens ↦
-        ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) := by
-    apply (ContMDiff.iff_comp_isImmersion
+        ((h.homeomorphProdOpens y).1 : ↥((𝓡∂ (n + 1)).boundary M))) :=
+    (ContMDiff.iff_comp_isImmersion
       (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).isImmersion).2
-    refine ⟨?_, ?_⟩
-    · apply continuous_induced_rng.2
-      convert h.contMDiff_boundaryRetract.continuous using 1
-      funext y
-      exact h.coe_prodEquiv_fst y
-    · convert h.contMDiff_boundaryRetract using 1
-      funext y
-      exact h.coe_prodEquiv_fst y
+      ⟨continuous_induced_rng.2 hretractVal.continuous, hretractVal⟩
+  have hnormalVal : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ 1) k
+      (fun y : h.sourceOpens ↦ ((h.homeomorphProdOpens y).2 : EuclideanHalfSpace 1)) := by
+    rw [funext h.coe_homeomorphProdOpens_snd]
+    exact h.contMDiff_coe_chart.snd
   have hretract : ContMDiff (𝓡∂ (n + 1))
       𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
-      (fun y : h.sourceOpens ↦ (h.prodEquiv y).1) := by
-    intro y
-    have hcomp : ContMDiffAt (𝓡∂ (n + 1))
-        𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
-        (Subtype.val ∘ fun y : h.sourceOpens ↦ (h.prodEquiv y).1) y := by
-      change ContMDiffAt (𝓡∂ (n + 1)) 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
-        (fun y : h.sourceOpens ↦
-          ((h.prodEquiv y).1 : ↥((𝓡∂ (n + 1)).boundary M))) y
-      exact hretractBoundary y
-    exact (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 hcomp
-  have hφ : ContMDiff (𝓡∂ (n + 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-      (fun y : h.sourceOpens ↦ φ y) := by
-    intro y
-    rw [contMDiffAt_subtype_iff]
-    exact (h.contMDiffOn y (source_mem h y)).contMDiffAt
-      (φ.open_source.mem_nhds (source_mem h y))
+      (fun y : h.sourceOpens ↦ (h.homeomorphProdOpens y).1) := fun y ↦
+    (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 (hretractBoundary y)
   have hnormal : ContMDiff (𝓡∂ (n + 1)) (𝓡∂ 1) k
-      (fun y : h.sourceOpens ↦ (h.prodEquiv y).2) := by
-    intro y
-    have hcomp : ContMDiffAt (𝓡∂ (n + 1)) (𝓡∂ 1) k
-        (Subtype.val ∘ fun y : h.sourceOpens ↦ (h.prodEquiv y).2) y := by
-      change ContMDiffAt (𝓡∂ (n + 1)) (𝓡∂ 1) k
-        (fun y : h.sourceOpens ↦
-          ((h.prodEquiv y).2 : EuclideanHalfSpace 1)) y
-      convert hφ.snd y using 1
-      funext z
-      exact h.coe_prodEquiv_snd z
-    exact (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 hcomp
+      (fun y : h.sourceOpens ↦ (h.homeomorphProdOpens y).2) := fun y ↦
+    (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 (hnormalVal y)
   exact hretract.prodMk hnormal
 
-private theorem contMDiff_prodEquiv_symm (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
+private theorem contMDiff_homeomorphProdOpens_symm (h : IsProductCollarChart k φ V ε)
+    (hk : k ≠ 0) :
     let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
       IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-    ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k h.prodEquiv.symm := by
+    ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k h.homeomorphProdOpens.symm := by
   let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
     IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
   let _ : IsManifold 𝓘(ℝ, EuclideanSpace ℝ (Fin n)) k
@@ -210,41 +162,25 @@ private theorem contMDiff_prodEquiv_symm (h : IsProductCollarChart k φ V ε) (h
     (isSmoothEmbedding_subtypeVal_boundary (n := n) (k := k) M hk).contMDiff.comp
       (contMDiff_subtype_val.comp contMDiff_fst)
   have hφboundary : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
-      (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦ φ p.1.1) := by
-    intro p
-    exact ((h.contMDiffOn p.1.1 (sourceSubtype_mem h p.1)).contMDiffAt
-      (φ.open_source.mem_nhds (sourceSubtype_mem h p.1))).comp p hboundaryVal.contMDiffAt
-  have hnormalVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ 1) k
-      (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦
-        (p.2 : EuclideanHalfSpace 1)) :=
-    contMDiff_subtype_val.comp contMDiff_snd
+      (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦ φ p.1.1) := fun p ↦
+    (h.contMDiffAt_chart (h.mem_sourceBoundaryOpens.1 p.1.2)).comp p hboundaryVal.contMDiffAt
   have hpair : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) ((𝓡 n).prod (𝓡∂ 1)) k
       (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦
         ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) :=
-    hφboundary.fst.prodMk hnormalVal
-  have hassembleAmbient : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
+    hφboundary.fst.prodMk (contMDiff_subtype_val.comp contMDiff_snd)
+  have hassembleVal : ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
       (fun p : h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε ↦
-        φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1))) := by
-    intro p
-    exact ((h.contMDiffOn_symm _
-      (h.mk_mem_target (sourceSubtype_mem h p.1) (normalIio_mem p.2))).contMDiffAt
-      (φ.open_target.mem_nhds
-        (h.mk_mem_target (sourceSubtype_mem h p.1) (normalIio_mem p.2)))).comp p hpair.contMDiffAt
-  change ContMDiff ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k h.prodEquiv.symm
-  intro p
-  have hcomp : ContMDiffAt ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
-      (Subtype.val ∘ h.prodEquiv.symm) p := by
-    change ContMDiffAt ((𝓡 n).prod (𝓡∂ 1)) (𝓡∂ (n + 1)) k
-      (fun p ↦ (h.prodEquiv.symm p : M)) p
-    convert hassembleAmbient p using 1
-    funext q
-    exact h.coe_prodEquiv_symm q
-  exact (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 hcomp
+        (h.homeomorphProdOpens.symm p : M)) := by
+    rw [funext h.coe_homeomorphProdOpens_symm]
+    exact fun p ↦ (h.contMDiffAt_chart_symm (h.mk_mem_target
+      (h.mem_sourceBoundaryOpens.1 p.1.2)
+      (EuclideanHalfSpace.mem_normalIio.2
+        (EuclideanHalfSpace.mem_normalIioOpens.1 p.2.2)))).comp p hpair.contMDiffAt
+  exact fun p ↦ (ChartedSpace.liftPropWithinAt_subtypeVal_comp_iff _ _ _).1 (hassembleVal p)
 
 /-- A product collar chart gives a `C^k` diffeomorphism from its open source to the product of its
-open boundary part and open normal interval. Its underlying equivalence is the existing
-`IsProductCollarChart.homeomorphProd`, transported across the canonical identification of the
-boundary factor. -/
+open boundary part and open normal interval. Its underlying equivalence is the one of the
+topological local collar `IsProductCollarChart.homeomorphProdOpens`. -/
 def diffeomorphProd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
     let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
       IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
@@ -252,29 +188,17 @@ def diffeomorphProd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
       h.sourceOpens (h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε) k :=
   let _ : IsManifold (𝓡∂ (n + 1)) 1 M :=
     IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
-  { toEquiv := h.prodEquiv
-    contMDiff_toFun := h.contMDiff_prodEquiv hk
-    contMDiff_invFun := h.contMDiff_prodEquiv_symm hk }
+  { toEquiv := h.homeomorphProdOpens.toEquiv
+    contMDiff_toFun := h.contMDiff_homeomorphProdOpens hk
+    contMDiff_invFun := h.contMDiff_homeomorphProdOpens_symm hk }
 
 section Characteristic
 
-/-- The boundary component of the smooth local collar agrees with the boundary component of the
-topological local collar. -/
-theorem coe_diffeomorphProd_fst_eq_homeomorphProd_fst
-    (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : h.sourceOpens) :
-    (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
-      ((h.homeomorphProd ⟨y, h.mem_sourceOpens.1 y.2⟩).1 : M) :=
-  h.coe_homeomorphProdOpens_fst_eq_homeomorphProd_fst y
-
-/-- The normal component of the smooth local collar agrees with the normal component of the
-topological local collar. -/
-theorem coe_diffeomorphProd_snd_eq_homeomorphProd_snd
-    (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : h.sourceOpens) :
-    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) =
-      ((h.homeomorphProd ⟨y, h.mem_sourceOpens.1 y.2⟩).2 : EuclideanHalfSpace 1) :=
-  h.coe_homeomorphProdOpens_snd_eq_homeomorphProd_snd y
+/-- **The smooth local collar is the topological one.** Its underlying map is that of
+`IsProductCollarChart.homeomorphProdOpens`, so every coordinate formula proved there transfers. -/
+theorem coe_diffeomorphProd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0) :
+    ⇑(h.diffeomorphProd hk) = ⇑h.homeomorphProdOpens :=
+  funext fun _ ↦ rfl
 
 /-- The boundary component of the smooth local collar is obtained by setting the normal
 coordinate to zero and reading back through the collar chart. -/
@@ -282,14 +206,14 @@ theorem coe_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠
     (y : h.sourceOpens) :
     (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
       φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) :=
-  h.coe_prodEquiv_fst y
+  h.coe_homeomorphProdOpens_fst y
 
 /-- The normal component of the smooth local collar is the normal component of the collar chart. -/
 @[simp]
 theorem coe_diffeomorphProd_snd (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
     (y : h.sourceOpens) :
     ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) = (φ y).2 :=
-  h.coe_prodEquiv_snd y
+  h.coe_homeomorphProdOpens_snd y
 
 /-- The inverse smooth local collar forms a collar-coordinate pair and reads it back through the
 chart. -/
@@ -299,7 +223,7 @@ theorem coe_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k �
       IsManifold.of_le (ENat.one_le_iff_ne_zero_withTop.2 hk)
     ((h.diffeomorphProd hk).symm p : M) =
       φ.symm ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) :=
-  h.coe_prodEquiv_symm p
+  h.coe_homeomorphProdOpens_symm p
 
 /-- In collar coordinates, the boundary retraction keeps the tangential coordinate and sets the
 normal coordinate to zero. -/
@@ -308,7 +232,7 @@ theorem map_diffeomorphProd_fst (h : IsProductCollarChart k φ V ε) (hk : k ≠
     (y : h.sourceOpens) :
     φ (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
       ((φ y).1, (0 : EuclideanHalfSpace 1)) :=
-  h.map_prodEquiv_fst y
+  h.map_homeomorphProdOpens_fst y
 
 /-- Applying the collar chart after the inverse smooth local collar recovers the supplied
 tangential and normal coordinates. -/
@@ -320,7 +244,8 @@ theorem map_diffeomorphProd_symm (h : IsProductCollarChart k φ V ε) (hk : k �
     φ ((h.diffeomorphProd hk).symm p : M) =
       ((φ p.1.1).1, (p.2 : EuclideanHalfSpace 1)) := by
   rw [coe_diffeomorphProd_symm]
-  exact φ.right_inv (h.mk_mem_target (sourceSubtype_mem h p.1) (normalIio_mem p.2))
+  exact φ.right_inv (h.mk_mem_target (h.mem_sourceBoundaryOpens.1 p.1.2)
+    (EuclideanHalfSpace.mem_normalIio.2 (EuclideanHalfSpace.mem_normalIioOpens.1 p.2.2)))
 
 /-- On the boundary, the smooth local collar is the identity in the boundary factor and has zero
 normal coordinate. -/
@@ -334,28 +259,12 @@ theorem diffeomorphProd_apply_of_mem_boundary (h : IsProductCollarChart k φ V �
           (EuclideanHalfSpace.mem_normalIio.1
             (EuclideanHalfSpace.zero_mem_normalIio h.height_pos))⟩) := by
   have hyzero : (φ y).2 = 0 :=
-    EuclideanHalfSpace.eq_zero_iff.2 ((h.mem_boundary_iff y (source_mem h y)).1 hy)
-  apply Prod.ext
-  · apply Subtype.ext
-    apply Subtype.ext
-    change (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) = (y : M)
-    rw [coe_diffeomorphProd_fst]
-    calc
-      φ.symm ((φ y).1, (0 : EuclideanHalfSpace 1)) = φ.symm (φ y) :=
-        congrArg φ.symm (Prod.ext (rfl) hyzero.symm)
-      _ = y := φ.left_inv (source_mem h y)
-  · apply Subtype.ext
-    rw [coe_diffeomorphProd_snd]
-    exact hyzero
-
-/-- The normal component of the smooth local collar vanishes on the boundary. -/
-theorem coe_diffeomorphProd_snd_of_mem_boundary
-    (h : IsProductCollarChart k φ V ε) (hk : k ≠ 0)
-    (y : h.sourceOpens)
-    (hy : (y : M) ∈ (𝓡∂ (n + 1)).boundary M) :
-    ((h.diffeomorphProd hk y).2 : EuclideanHalfSpace 1) = 0 := by
-  rw [coe_diffeomorphProd_snd]
-  exact EuclideanHalfSpace.eq_zero_iff.2 ((h.mem_boundary_iff y (source_mem h y)).1 hy)
+    EuclideanHalfSpace.eq_zero_iff.2 ((h.mem_boundary_iff y (h.mem_sourceOpens.1 y.2)).1 hy)
+  have hfst : (((h.diffeomorphProd hk y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) = (y : M) := by
+    rw [h.coe_diffeomorphProd_fst hk y, ← hyzero]
+    exact φ.left_inv (h.mem_sourceOpens.1 y.2)
+  exact Prod.ext (Subtype.ext (Subtype.ext hfst))
+    (Subtype.ext ((h.coe_diffeomorphProd_snd hk y).trans hyzero))
 
 end Characteristic
 

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Local.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Local.lean
@@ -138,6 +138,26 @@ theorem isOpen_normalIio (ε : ℝ) : IsOpen (normalIio ε) := by
   have : Continuous fun t : EuclideanHalfSpace 1 ↦ t.1 0 := by fun_prop
   exact isOpen_Iio.preimage this
 
+/-- The initial segment `[0, ε)` of the one-dimensional half-space model as an open subspace. It
+is empty for `ε ≤ 0`. -/
+def normalIioOpens (ε : ℝ) : TopologicalSpace.Opens (EuclideanHalfSpace 1) :=
+  ⟨normalIio ε, isOpen_normalIio ε⟩
+
+/-- Membership in the open initial segment is one inequality on the normal coordinate. -/
+@[simp]
+theorem mem_normalIioOpens {ε : ℝ} {t : EuclideanHalfSpace 1} :
+    t ∈ normalIioOpens ε ↔ t.1 0 < ε := mem_normalIio
+
+/-- The initial-segment subtype is canonically homeomorphic to the same set regarded as an open
+subspace. -/
+def homeomorphNormalIioOpens (ε : ℝ) : ↥(normalIio ε) ≃ₜ normalIioOpens ε where
+  toFun t := ⟨t, mem_normalIioOpens.2 (mem_normalIio.1 t.2)⟩
+  invFun t := ⟨t, mem_normalIio.2 (mem_normalIioOpens.1 t.2)⟩
+  left_inv t := Subtype.ext (rfl)
+  right_inv t := Subtype.ext (rfl)
+  continuous_toFun := by fun_prop
+  continuous_invFun := by fun_prop
+
 /-- An initial segment of positive height contains the origin.
 
 Not `@[simp]`: `mem_normalIio` and `val_zero_apply` already reduce this to `0 < ε`. -/
@@ -220,6 +240,49 @@ namespace IsProductCollarChart
 variable {φ : OpenPartialHomeomorph M (EuclideanSpace ℝ (Fin n) × EuclideanHalfSpace 1)}
   {V : Set (EuclideanSpace ℝ (Fin n))} {ε : ℝ}
 
+/-- The source of a product collar chart, regarded as an open submanifold of the ambient
+manifold. -/
+def sourceOpens (_h : IsProductCollarChart k φ V ε) : TopologicalSpace.Opens M :=
+  ⟨φ.source, φ.open_source⟩
+
+/-- Membership in the open source of a product collar chart is membership in the chart source. -/
+@[simp]
+theorem mem_sourceOpens (h : IsProductCollarChart k φ V ε) {x : M} :
+    x ∈ h.sourceOpens ↔ x ∈ φ.source := (Iff.rfl)
+
+/-- The part of the boundary in the source of a product collar chart, regarded as an open
+submanifold of the canonical boundary manifold. -/
+def sourceBoundaryOpens (h : IsProductCollarChart k φ V ε) :
+    TopologicalSpace.Opens ↥((𝓡∂ (n + 1)).boundary M) :=
+  TopologicalSpace.Opens.comap ⟨Subtype.val, continuous_subtype_val⟩ h.sourceOpens
+
+/-- A boundary point belongs to the boundary part of the chart source exactly when its ambient
+point belongs to the chart source. -/
+@[simp]
+theorem mem_sourceBoundaryOpens (h : IsProductCollarChart k φ V ε)
+    {x : ↥((𝓡∂ (n + 1)).boundary M)} :
+    x ∈ h.sourceBoundaryOpens ↔ (x : M) ∈ φ.source := (Iff.rfl)
+
+/-- The tangential coordinate of a point in the source of a product collar chart lies in its
+base. -/
+theorem fst_mem_base (h : IsProductCollarChart k φ V ε) {y : M} (hy : y ∈ φ.source) :
+    (φ y).1 ∈ V :=
+  (h.target_eq ▸ φ.map_source hy).1
+
+/-- Replacing the normal coordinate of a point in a product collar chart by another coordinate
+in its normal interval stays in the chart target. -/
+theorem mk_mem_target (h : IsProductCollarChart k φ V ε) {y : M} (hy : y ∈ φ.source)
+    {t : EuclideanHalfSpace 1} (ht : t ∈ EuclideanHalfSpace.normalIio ε) :
+    ((φ y).1, t) ∈ φ.target := by
+  rw [h.target_eq]
+  exact ⟨h.fst_mem_base hy, ht⟩
+
+/-- Setting the normal coordinate of a point in a product collar chart to zero stays in the chart
+target. -/
+theorem fst_zero_mem_target (h : IsProductCollarChart k φ V ε) {y : M} (hy : y ∈ φ.source) :
+    ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target :=
+  h.mk_mem_target hy (EuclideanHalfSpace.zero_mem_normalIio h.height_pos)
+
 /-- The base of a product collar chart is open: it is a factor of the open target. -/
 theorem isOpen_base (h : IsProductCollarChart k φ V ε) : IsOpen V := by
   have hopen : IsOpen (V ×ˢ EuclideanHalfSpace.normalIio ε) := h.target_eq ▸ φ.open_target
@@ -274,6 +337,49 @@ def homeomorphProd (h : IsProductCollarChart k φ V ε) :
       (Homeomorph.Set.prod V (EuclideanHalfSpace.normalIio ε))).trans
     (h.homeomorphBase.symm.prodCongr (Homeomorph.refl _))
 
+private def sourceHomeomorphOpens (h : IsProductCollarChart k φ V ε) :
+    ↥φ.source ≃ₜ h.sourceOpens where
+  toFun x := ⟨x, h.mem_sourceOpens.2 x.2⟩
+  invFun x := ⟨x, h.mem_sourceOpens.1 x.2⟩
+  left_inv x := Subtype.ext (rfl)
+  right_inv x := Subtype.ext (rfl)
+  continuous_toFun := by fun_prop
+  continuous_invFun := by fun_prop
+
+private def sourceInterHomeomorphSourceBoundaryOpens (h : IsProductCollarChart k φ V ε) :
+    ↥(φ.source ∩ (𝓡∂ (n + 1)).boundary M) ≃ₜ h.sourceBoundaryOpens where
+  toFun x := ⟨⟨x, x.2.2⟩, h.mem_sourceBoundaryOpens.2 x.2.1⟩
+  invFun x := ⟨x.1.1, h.mem_sourceBoundaryOpens.1 x.2, x.1.2⟩
+  left_inv x := Subtype.ext (rfl)
+  right_inv x := Subtype.ext (Subtype.ext (rfl))
+  continuous_toFun := by fun_prop
+  continuous_invFun := by fun_prop
+
+/-- The local collar with its source, boundary part, and normal interval packaged as open
+subspaces. Its underlying map is `homeomorphProd`; only the subtype packaging changes. -/
+def homeomorphProdOpens (h : IsProductCollarChart k φ V ε) :
+    h.sourceOpens ≃ₜ h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε :=
+  h.sourceHomeomorphOpens.symm.trans <|
+    h.homeomorphProd.trans <|
+      h.sourceInterHomeomorphSourceBoundaryOpens.prodCongr
+        (EuclideanHalfSpace.homeomorphNormalIioOpens ε)
+
+/-- The boundary component of the open-subspace local collar agrees with that of
+`homeomorphProd`. -/
+theorem coe_homeomorphProdOpens_fst_eq_homeomorphProd_fst (h : IsProductCollarChart k φ V ε)
+    (y : h.sourceOpens) :
+    (((h.homeomorphProdOpens y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+      ((h.homeomorphProd ⟨y, h.mem_sourceOpens.1 y.2⟩).1 : M) :=
+  (rfl)
+
+/-- The normal component of the open-subspace local collar agrees with that of
+`homeomorphProd`. -/
+theorem coe_homeomorphProdOpens_snd_eq_homeomorphProd_snd (h : IsProductCollarChart k φ V ε)
+    (y : h.sourceOpens) :
+    ((h.homeomorphProdOpens y).2 : EuclideanHalfSpace 1) =
+      ((h.homeomorphProd ⟨y, h.mem_sourceOpens.1 y.2⟩).2 : EuclideanHalfSpace 1) :=
+  (rfl)
+
 /-- The second component of the local collar is the normal coordinate.
 
 Proved by `rfl` for the same reason as `coe_homeomorphBase`: `Homeomorph.Set.prod_apply` does
@@ -288,10 +394,23 @@ homeomorphism down: it is the chart, read in the box. -/
 @[simp]
 theorem map_homeomorphProd_fst (h : IsProductCollarChart k φ V ε) (y : ↥φ.source) :
     φ ((h.homeomorphProd y).1 : M) = ((φ y).1, 0) := by
-  have hmem : ((φ y).1, (0 : EuclideanHalfSpace 1)) ∈ φ.target := by
-    rw [h.target_eq]
-    exact ⟨(h.target_eq ▸ φ.map_source y.2).1, EuclideanHalfSpace.zero_mem_normalIio h.height_pos⟩
-  exact φ.right_inv hmem
+  exact φ.right_inv (h.fst_zero_mem_target y.2)
+
+/-- The second component of the open-subspace local collar is the normal coordinate. -/
+@[simp]
+theorem coe_homeomorphProdOpens_snd (h : IsProductCollarChart k φ V ε)
+    (y : h.sourceOpens) :
+    ((h.homeomorphProdOpens y).2 : EuclideanHalfSpace 1) = (φ y).2 := by
+  rw [coe_homeomorphProdOpens_snd_eq_homeomorphProd_snd, h.coe_homeomorphProd_snd]
+
+/-- The first component of the open-subspace local collar is the boundary retraction in collar
+coordinates. -/
+@[simp]
+theorem map_homeomorphProdOpens_fst (h : IsProductCollarChart k φ V ε)
+    (y : h.sourceOpens) :
+    φ (((h.homeomorphProdOpens y).1 : ↥((𝓡∂ (n + 1)).boundary M)) : M) =
+      ((φ y).1, 0) := by
+  rw [coe_homeomorphProdOpens_fst_eq_homeomorphProd_fst, h.map_homeomorphProd_fst]
 
 end IsProductCollarChart
 

--- a/TauCeti/Geometry/Manifold/Boundary/Collar/Local.lean
+++ b/TauCeti/Geometry/Manifold/Boundary/Collar/Local.lean
@@ -28,13 +28,20 @@ boundary, which is what Hirsch's bump-function argument does and what this file 
 * `TauCeti.EuclideanHalfSpace.normalRay`: the inward normal ray `[0, ∞) → EuclideanHalfSpace 1`,
   the parametrization by which the one-dimensional half-space model is a half-line.
 * `TauCeti.EuclideanHalfSpace.normalIio`: the initial segment `[0, ε)` of the one-dimensional
-  half-space model, cut out by the normal coordinate.
+  half-space model, cut out by the normal coordinate, and
+  `TauCeti.EuclideanHalfSpace.normalIioOpens`: the same segment as an open subspace.
 * `TauCeti.IsProductCollarChart`: a collar chart whose target is a product box `V × [0, ε)`, is
   `C^k` in both directions, and cuts out the boundary as the zero slice of its normal coordinate.
 * `TauCeti.EuclideanHalfSpace.homeomorphNormalIio`: that segment, read by its normal coordinate
   as the real interval `[0, ε)`.
 * `TauCeti.IsProductCollarChart.homeomorphProd`: the local collar itself, a homeomorphism of the
   source of a product collar chart onto (its part of) the boundary times `[0, ε)`.
+* `TauCeti.IsProductCollarChart.sourceOpens` and
+  `TauCeti.IsProductCollarChart.sourceBoundaryOpens`: the source of a product collar chart and its
+  boundary part, as open subspaces of the ambient manifold and of the canonical boundary manifold.
+* `TauCeti.IsProductCollarChart.homeomorphProdOpens`: the local collar with all three of those
+  factors read as open subspaces. This is the packaging the smooth local collar of
+  `Boundary.Collar.Diffeomorph` is built on.
 
 ## Main results
 
@@ -60,7 +67,10 @@ heights anyway.
 target `(U ∩ ∂M) × [0, ε)` is a product of a piece of the boundary manifold of
 `Boundary.Charts` with an interval, and identifying that manifold structure with the one the
 chart transports is a separate step. What is smooth here is the chart itself, through
-`IsProductCollarChart.contMDiffOn` and `IsProductCollarChart.contMDiffOn_symm`.
+`IsProductCollarChart.contMDiffOn` and `IsProductCollarChart.contMDiffOn_symm`. That
+identification is carried out downstream in `Boundary.Collar.Diffeomorph`, where
+`TauCeti.IsProductCollarChart.diffeomorphProd` upgrades `homeomorphProdOpens` to a `C^k`
+diffeomorphism.
 
 ## References
 
@@ -147,16 +157,6 @@ def normalIioOpens (ε : ℝ) : TopologicalSpace.Opens (EuclideanHalfSpace 1) :=
 @[simp]
 theorem mem_normalIioOpens {ε : ℝ} {t : EuclideanHalfSpace 1} :
     t ∈ normalIioOpens ε ↔ t.1 0 < ε := mem_normalIio
-
-/-- The initial-segment subtype is canonically homeomorphic to the same set regarded as an open
-subspace. -/
-def homeomorphNormalIioOpens (ε : ℝ) : ↥(normalIio ε) ≃ₜ normalIioOpens ε where
-  toFun t := ⟨t, mem_normalIioOpens.2 (mem_normalIio.1 t.2)⟩
-  invFun t := ⟨t, mem_normalIio.2 (mem_normalIioOpens.1 t.2)⟩
-  left_inv t := Subtype.ext (rfl)
-  right_inv t := Subtype.ext (rfl)
-  continuous_toFun := by fun_prop
-  continuous_invFun := by fun_prop
 
 /-- An initial segment of positive height contains the origin.
 
@@ -337,15 +337,6 @@ def homeomorphProd (h : IsProductCollarChart k φ V ε) :
       (Homeomorph.Set.prod V (EuclideanHalfSpace.normalIio ε))).trans
     (h.homeomorphBase.symm.prodCongr (Homeomorph.refl _))
 
-private def sourceHomeomorphOpens (h : IsProductCollarChart k φ V ε) :
-    ↥φ.source ≃ₜ h.sourceOpens where
-  toFun x := ⟨x, h.mem_sourceOpens.2 x.2⟩
-  invFun x := ⟨x, h.mem_sourceOpens.1 x.2⟩
-  left_inv x := Subtype.ext (rfl)
-  right_inv x := Subtype.ext (rfl)
-  continuous_toFun := by fun_prop
-  continuous_invFun := by fun_prop
-
 private def sourceInterHomeomorphSourceBoundaryOpens (h : IsProductCollarChart k φ V ε) :
     ↥(φ.source ∩ (𝓡∂ (n + 1)).boundary M) ≃ₜ h.sourceBoundaryOpens where
   toFun x := ⟨⟨x, x.2.2⟩, h.mem_sourceBoundaryOpens.2 x.2.1⟩
@@ -359,10 +350,8 @@ private def sourceInterHomeomorphSourceBoundaryOpens (h : IsProductCollarChart k
 subspaces. Its underlying map is `homeomorphProd`; only the subtype packaging changes. -/
 def homeomorphProdOpens (h : IsProductCollarChart k φ V ε) :
     h.sourceOpens ≃ₜ h.sourceBoundaryOpens × EuclideanHalfSpace.normalIioOpens ε :=
-  h.sourceHomeomorphOpens.symm.trans <|
-    h.homeomorphProd.trans <|
-      h.sourceInterHomeomorphSourceBoundaryOpens.prodCongr
-        (EuclideanHalfSpace.homeomorphNormalIioOpens ε)
+  h.homeomorphProd.trans <|
+    h.sourceInterHomeomorphSourceBoundaryOpens.prodCongr (Homeomorph.refl _)
 
 /-- The boundary component of the open-subspace local collar agrees with that of
 `homeomorphProd`. -/


### PR DESCRIPTION
This PR upgrades each product collar chart to a genuine `C^k` diffeomorphism from its open source onto the product of its open boundary part and open normal interval. It advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 1, the **Collar neighbourhoods** milestone: “A boundary component has a neighbourhood diffeomorphic to ∂M × [0, 1).”

`Collar/Local.lean` now packages the chart source as `IsProductCollarChart.sourceOpens`, its boundary trace as `IsProductCollarChart.sourceBoundaryOpens`, and the half-space interval as `EuclideanHalfSpace.normalIioOpens`. The topological collar is transported to these open-submanifold types as `IsProductCollarChart.homeomorphProdOpens`.

`IsProductCollarChart.diffeomorphProd` reuses that transported equivalence and proves both directions `C^k` using the smooth collar chart, the canonical smooth embedding of the boundary, and Mathlib open-submanifold inclusions. Coordinate formulas characterize both directions, bridge the smooth and topological collars, and show that the collar fixes boundary points with zero normal coordinate. Callers obtain local diffeomorphisms by combining the existing `exists_isProductCollarChart_of_mem_boundary` theorem with `h.diffeomorphProd`.

This is the most effective current step because the canonical boundary manifold, smooth collar coordinates, their product-model manifold structure, and the shrinking to a product box are already on main, while the landed local collar was still only packaged as a homeomorphism. After this PR, the Collar neighbourhoods milestone still needs the global patching theorem producing one smooth product neighbourhood of the entire boundary (and the harmless normal-coordinate rescaling to `[0, 1)`).

No Mathlib infrastructure is vendored. The construction follows Hirsch, *Differential Topology*, Theorem 6.1, and Lee, *Introduction to Smooth Manifolds*, Theorem 9.25, as credited in the module documentation.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"product-collar-diffeomorph"}-->

🤖 Prepared with Codex