### PR TITLE
feat(Distributions): the transforms of the exponential law

### DIFF
--- a/TauCeti/Probability/Distributions/Exponential.lean
+++ b/TauCeti/Probability/Distributions/Exponential.lean
@@ -53,7 +53,8 @@ zero case is discharged from the probability-measure instance instead.
 * `integral_id_expMeasure`, `integral_sq_expMeasure` — the mean and the second moment;
 * `variance_id_expMeasure` — the variance;
 * `integrableExpSet_id_expMeasure` — the moment-generating domain is exactly `Iio r`;
-* `mgf_id_expMeasure`, `cgf_id_expMeasure` — the mgf on that domain, and the cgf;
+* `mgf_id_expMeasure`, `mgf_id_expMeasure_pos`, `cgf_id_expMeasure` — the mgf on that domain, its
+  strict positivity, and the cgf;
 * `charFun_expMeasure` — the characteristic function, at every real `t`.
 
 ## References
@@ -210,7 +211,9 @@ private theorem expIntegrand_eq_indicator (t : ℝ) :
   by_cases hx : (0:ℝ) ≤ x
   · rw [Set.indicator_of_mem (mem_Ici.mpr hx)]
     split_ifs
-    rw [show (t - r) * x = t * x + -(r * x) by ring, Real.exp_add]
+    -- split the single exponential at rate `t - r` into the density and mgf factors
+    have hsplit : (t - r) * x = t * x + -(r * x) := by ring
+    rw [hsplit, Real.exp_add]
     ring
   · rw [Set.indicator_of_notMem (by simpa using hx)]
     split_ifs
@@ -232,7 +235,8 @@ theorem integrableExpSet_id_expMeasure (hr : 0 < r) :
 /-- The exponential moment at `t` exists exactly when `t < r`.  This is
 `integrableExpSet_id_expMeasure` in the form a caller actually applies, without unfolding
 `integrableExpSet` or stripping `id`. -/
-theorem integrable_exp_mul_expMeasure_iff (hr : 0 < r) :
+@[simp]
+theorem integrable_exp_mul_id_expMeasure_iff (hr : 0 < r) :
     Integrable (fun x => exp (t * x)) (expMeasure r) ↔ t < r := by
   have h := integrableExpSet_id_expMeasure (r := r) hr
   have ht : t ∈ integrableExpSet id (expMeasure r) ↔ t ∈ Set.Iio r := by rw [h]
@@ -241,6 +245,7 @@ theorem integrable_exp_mul_expMeasure_iff (hr : 0 < r) :
 /-! ### The moment generating function and its logarithm -/
 
 /-- **The moment generating function of the exponential law**, on its domain `t < r`. -/
+@[simp]
 theorem mgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
     mgf id (expMeasure r) t = r / (r - t) := by
   unfold mgf
@@ -249,10 +254,23 @@ theorem mgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
   simp only [smul_eq_mul]
   rw [expIntegrand_eq_indicator t, integral_indicator measurableSet_Ici,
     integral_Ici_eq_integral_Ioi, integral_const_mul, integral_exp_mul_Ioi (sub_neg.2 ht) 0]
+  -- `integral_exp_mul_Ioi` reports the value at rate `t - r`; the statement is oriented at `r - t`,
+  -- so the sign is flipped once, explicitly, rather than left to `field_simp` to guess.
+  have hflip : (t : ℝ) - r = -(r - t) := by ring
   simp only [mul_zero, Real.exp_zero]
-  rw [show ((t : ℝ) - r) = -(r - t) by ring, div_neg, neg_div, neg_neg, mul_one_div]
+  rw [hflip, div_neg, neg_div, neg_neg, mul_one_div]
+
+/-- The moment generating function is strictly positive on its domain.
+
+Proved from Mathlib's `mgf_pos` and the integrability characterization, not by `div_pos` on the
+closed form: positivity is a consequence of the exponential moment *existing*, which is what a
+consumer reasoning about the cgf's domain actually has. -/
+theorem mgf_id_expMeasure_pos (hr : 0 < r) (ht : t < r) : 0 < mgf id (expMeasure r) t := by
+  have : IsProbabilityMeasure (expMeasure r) := isProbabilityMeasure_expMeasure hr
+  exact mgf_pos ((integrable_exp_mul_id_expMeasure_iff hr).2 ht)
 
 /-- **The cumulant generating function of the exponential law**, on its domain `t < r`. -/
+@[simp]
 theorem cgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
     cgf id (expMeasure r) t = Real.log (r / (r - t)) := by
   unfold cgf
@@ -276,6 +294,7 @@ private theorem charIntegrand_eq (t : ℝ) {x : ℝ} (hx : 0 < x) :
 
 Unlike the mgf this needs no hypothesis on `t`: the density-transported integrand has modulus
 `r * exp (-(r * x))` on `[0, ∞)` whatever `t` is, so the integral converges at every real `t`. -/
+@[simp]
 theorem charFun_expMeasure (hr : 0 < r) (t : ℝ) :
     charFun (expMeasure r) t = (r : ℂ) / (r - Complex.I * t) := by
   have ha : ((t : ℂ) * Complex.I - r).re < 0 := by simp [hr]
@@ -292,9 +311,10 @@ theorem charFun_expMeasure (hr : 0 < r) (t : ℝ) :
     ← setIntegral_eq_integral_of_forall_compl_eq_zero hzero, integral_Ici_eq_integral_Ioi,
     setIntegral_congr_fun measurableSet_Ioi (fun x hx => charIntegrand_eq t (mem_Ioi.mp hx)),
     integral_const_mul, integral_exp_mul_complex_Ioi ha 0]
+  -- as in the mgf: the integral is reported at rate `t * I - r`, the statement at `r - I * t`.
+  have hflip : (t : ℂ) * Complex.I - r = -((r : ℂ) - Complex.I * t) := by ring
   simp only [Complex.ofReal_zero, mul_zero, Complex.exp_zero]
-  rw [show ((t : ℂ) * Complex.I - r) = -((r : ℂ) - Complex.I * t) by ring, div_neg, neg_div,
-    neg_neg, mul_one_div]
+  rw [hflip, div_neg, neg_div, neg_neg, mul_one_div]
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/Exponential.lean
+++ b/TauCeti/Probability/Distributions/Exponential.lean
@@ -7,16 +7,20 @@ module
 
 public import Mathlib.Probability.Distributions.Exponential
 public import Mathlib.Probability.Moments.Variance
+public import Mathlib.Probability.Moments.IntegrableExpMul
+public import Mathlib.Probability.Moments.Basic
+public import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
 import TauCeti.Probability.Distributions.PDFInstances
 import TauCeti.MeasureTheory.Integral.ExpDecay
 
 /-!
-# Moments of the exponential law
+# Moments and transforms of the exponential law
 
-The mean and variance of `ProbabilityTheory.expMeasure r`, for a positive rate `0 < r`:
+The moments and transforms of `ProbabilityTheory.expMeasure r`, for a positive rate `0 < r`:
 
 ```text
 ∫ x, x ∂(expMeasure r) = r⁻¹        Var[id; expMeasure r] = (r ^ 2)⁻¹
+mgf id (expMeasure r) t = r / (r - t)      charFun (expMeasure r) t = r / (r - t * I)
 ```
 
 Every result below carries that hypothesis, but the two regimes it excludes differ.  At `r < 0` the
@@ -45,12 +49,16 @@ zero case is discharged from the probability-measure instance instead.
 * `integrable_pow_expMeasure` — every moment is integrable, for `0 < r`;
 * `integral_pow_expMeasure` — the `n`-th moment, `n ! / r ^ n`, for `0 < r`;
 * `integral_id_expMeasure`, `integral_sq_expMeasure` — the mean and the second moment;
-* `variance_id_expMeasure` — the variance.
+* `variance_id_expMeasure` — the variance;
+* `integrableExpSet_id_expMeasure` — the moment-generating domain is exactly `Iio r`;
+* `mgf_id_expMeasure`, `mgf_id_expMeasure_pos`, `cgf_id_expMeasure` — the mgf on that domain, its
+  strict positivity, and the cgf as the logarithm of a positive number;
+* `charFun_expMeasure` — the characteristic function, at every real `t`.
 
 ## References
 
-* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 1, exponential — the mean and
-  variance.
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 1, exponential — the moments,
+  the moment-generating domain, the mgf and cgf, and the characteristic function.
 * [mathlib4#35504](https://github.com/leanprover-community/mathlib4/pull/35504), the upstream
   exponential mgf, moments and memorylessness work that the roadmap names as the source for this
   material.  It has not landed at Tau Ceti's current Mathlib pin, so the declarations here follow
@@ -86,12 +94,13 @@ private theorem toReal_gammaPDF_one (hr : 0 < r) (x : ℝ) :
   rw [ENNReal.toReal_ofReal (gammaPDFReal_nonneg one_pos hr x)]
 
 /-- An integral against `expMeasure` is a density integral against `volume`. -/
-private theorem integral_expMeasure (hr : 0 < r) (g : ℝ → ℝ) :
-    ∫ x, g x ∂(expMeasure r) = ∫ x, exponentialPDFReal r x * g x := by
+private theorem integral_expMeasure {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (hr : 0 < r) (g : ℝ → E) :
+    ∫ x, g x ∂(expMeasure r) = ∫ x, exponentialPDFReal r x • g x := by
   have hmeas : Measurable (gammaPDF 1 r) := measurable_gammaPDF 1 r
-  have key : ∀ x : ℝ, (gammaPDF 1 r x).toReal • g x = exponentialPDFReal r x * g x := by
+  have key : ∀ x : ℝ, (gammaPDF 1 r x).toReal • g x = exponentialPDFReal r x • g x := by
     intro x
-    rw [smul_eq_mul, toReal_gammaPDF_one hr]
+    rw [toReal_gammaPDF_one hr]
   unfold expMeasure gammaMeasure
   rw [integral_withDensity_eq_integral_toReal_smul hmeas
       (ae_of_all _ fun x => ENNReal.ofReal_lt_top)]
@@ -152,7 +161,9 @@ theorem integral_pow_expMeasure (hr : 0 < r) (n : ℕ) :
   rcases eq_or_ne n 0 with rfl | hn
   · have : IsProbabilityMeasure (expMeasure r) := isProbabilityMeasure_expMeasure hr
     simp
-  rw [integral_expMeasure hr, integrand_eq_indicator hn,
+  rw [integral_expMeasure hr]
+  simp only [smul_eq_mul]
+  rw [integrand_eq_indicator hn,
     integral_indicator measurableSet_Ioi, integral_const_mul,
     integral_pow_mul_exp_neg_mul_Ioi n hr]
   field_simp
@@ -180,6 +191,112 @@ theorem variance_id_expMeasure (hr : 0 < r) : Var[id; expMeasure r] = (r ^ 2)⁻
   rw [integral_sq_expMeasure hr, integral_id_expMeasure hr]
   field_simp
   ring
+
+/-! ### The moment-generating domain
+
+The exponential moment `∫ exp (t * x)` exists exactly for `t < r`.  Both directions come from
+`TauCeti.integrableOn_exp_mul_Ioi_iff`: after the density transport the integrand is a constant
+multiple of `exp ((t - r) * x)` on `[0, ∞)`, whose integrability is equivalent to `t - r < 0`.
+-/
+
+/-- The exponential-moment integrand in closed form: off the negative half-line it is a constant
+multiple of a single exponential at rate `t - r`. -/
+private theorem expIntegrand_eq_indicator (t : ℝ) :
+    (fun x => exponentialPDFReal r x * exp (t * x))
+      = (Ici (0:ℝ)).indicator (fun x => r * exp ((t - r) * x)) := by
+  funext x
+  unfold exponentialPDFReal gammaPDFReal
+  by_cases hx : (0:ℝ) ≤ x
+  · rw [Set.indicator_of_mem (mem_Ici.mpr hx)]
+    split_ifs
+    rw [Real.rpow_one, Real.Gamma_one, sub_self, Real.rpow_zero,
+      show (t - r) * x = t * x + -(r * x) by ring, Real.exp_add]
+    ring
+  · rw [Set.indicator_of_notMem (by simpa using hx)]
+    split_ifs
+    ring
+
+/-- **The moment-generating domain of the exponential law** is exactly `Iio r`. -/
+theorem integrableExpSet_id_expMeasure (hr : 0 < r) :
+    integrableExpSet id (expMeasure r) = Set.Iio r := by
+  ext t
+  simp only [integrableExpSet, Set.mem_ofPred_eq, id_eq, Set.mem_Iio]
+  rw [integrable_expMeasure_iff hr, expIntegrand_eq_indicator t,
+    integrable_indicator_iff measurableSet_Ici,
+    integrableOn_Ici_iff_integrableOn_Ioi]
+  unfold IntegrableOn
+  rw [integrable_const_mul_iff (isUnit_iff_ne_zero.2 hr.ne') (fun x => exp ((t - r) * x))]
+  exact integrableOn_exp_mul_Ioi_iff.trans sub_neg
+
+/-! ### The moment generating function and its logarithm -/
+
+/-- **The moment generating function of the exponential law**, on its domain `t < r`. -/
+theorem mgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
+    mgf id (expMeasure r) t = r / (r - t) := by
+  have hrt : 0 < r - t := sub_pos.2 ht
+  have hcongr : ∀ x ∈ Ioi (0:ℝ),
+      r * exp ((t - r) * x) = r * (x ^ 0 * exp (-((r - t) * x))) := by
+    intro x _
+    rw [pow_zero, one_mul, show (t - r) * x = -((r - t) * x) by ring]
+  unfold mgf
+  simp only [id_eq]
+  rw [integral_expMeasure hr]
+  simp only [smul_eq_mul]
+  rw [expIntegrand_eq_indicator t,
+    integral_indicator measurableSet_Ici, integral_Ici_eq_integral_Ioi,
+    setIntegral_congr_fun measurableSet_Ioi hcongr, integral_const_mul,
+    integral_pow_mul_exp_neg_mul_Ioi 0 hrt]
+  simp [div_eq_mul_inv]
+
+/-- The moment generating function is strictly positive on its domain.  This is what makes the
+cgf below the logarithm of a positive number rather than a junk value. -/
+theorem mgf_id_expMeasure_pos (hr : 0 < r) (ht : t < r) : 0 < mgf id (expMeasure r) t := by
+  rw [mgf_id_expMeasure hr ht]
+  exact div_pos hr (sub_pos.2 ht)
+
+/-- **The cumulant generating function of the exponential law**, on its domain `t < r`. -/
+theorem cgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
+    cgf id (expMeasure r) t = Real.log (r / (r - t)) := by
+  unfold cgf
+  rw [mgf_id_expMeasure hr ht]
+
+/-! ### The characteristic function -/
+
+/-- The characteristic-function integrand in closed form on the positive half-line. -/
+private theorem charIntegrand_eq (t : ℝ) {x : ℝ} (hx : 0 < x) :
+    exponentialPDFReal r x • Complex.exp ((t : ℂ) * x * Complex.I)
+      = (r : ℂ) * Complex.exp (((t : ℂ) * Complex.I - r) * x) := by
+  unfold exponentialPDFReal gammaPDFReal
+  split_ifs with h
+  · rw [Real.rpow_one, Real.Gamma_one, sub_self, Real.rpow_zero, Complex.real_smul]
+    push_cast [Complex.ofReal_exp]
+    rw [mul_assoc, ← Complex.exp_add]
+    ring_nf
+  · exact absurd hx.le h
+
+/-- **The characteristic function of the exponential law.**
+
+Unlike the mgf this needs no hypothesis on `t`: the integrand has modulus `exp (-(r * x))`
+whatever `t` is, so the integral converges at every real `t`. -/
+theorem charFun_expMeasure (hr : 0 < r) (t : ℝ) :
+    charFun (expMeasure r) t = (r : ℂ) / (r - t * Complex.I) := by
+  have ha : ((t : ℂ) * Complex.I - r).re < 0 := by simp [hr]
+  have hzero : ∀ x ∉ Ici (0:ℝ),
+      exponentialPDFReal r x • Complex.exp ((t : ℂ) * x * Complex.I) = 0 := by
+    intro x hx
+    have hpdf : exponentialPDFReal r x = 0 := by
+      unfold exponentialPDFReal gammaPDFReal
+      split_ifs with h
+      · exact absurd h (by simpa using hx)
+      · rfl
+    rw [hpdf, zero_smul]
+  rw [charFun_apply_real, integral_expMeasure hr,
+    ← setIntegral_eq_integral_of_forall_compl_eq_zero hzero, integral_Ici_eq_integral_Ioi,
+    setIntegral_congr_fun measurableSet_Ioi (fun x hx => charIntegrand_eq t (mem_Ioi.mp hx)),
+    integral_const_mul, integral_exp_mul_complex_Ioi ha 0]
+  simp only [Complex.ofReal_zero, mul_zero, Complex.exp_zero]
+  rw [show ((t : ℂ) * Complex.I - r) = -((r : ℂ) - t * Complex.I) by ring, div_neg, neg_div,
+    neg_neg, mul_one_div]
 
 end Probability
 

--- a/TauCeti/Probability/Distributions/Exponential.lean
+++ b/TauCeti/Probability/Distributions/Exponential.lean
@@ -20,12 +20,14 @@ The moments and transforms of `ProbabilityTheory.expMeasure r`, for a positive r
 
 ```text
 ∫ x, x ∂(expMeasure r) = r⁻¹        Var[id; expMeasure r] = (r ^ 2)⁻¹
-mgf id (expMeasure r) t = r / (r - t)      charFun (expMeasure r) t = r / (r - t * I)
+mgf id (expMeasure r) t = r / (r - t)      (for t < r)
+charFun (expMeasure r) t = r / (r - I * t)  (for every t)
 ```
 
 Every result below carries that hypothesis, but the two regimes it excludes differ.  At `r < 0` the
 identities fail outright.  At `r = 0` the density is identically zero, so `expMeasure 0` is the zero
-measure and the two displays above hold only as junk-value coincidences (`0 = 0⁻¹`); what genuinely
+measure and the displays above hold only as junk-value
+coincidences (`0 = 0⁻¹` for the mean); what genuinely
 fails there is the `n = 0` moment, `0 ≠ 0 ! / 0 ^ 0 = 1`.
 
 **Both come from one moment formula.** `integral_pow_expMeasure` computes every moment,
@@ -51,8 +53,7 @@ zero case is discharged from the probability-measure instance instead.
 * `integral_id_expMeasure`, `integral_sq_expMeasure` — the mean and the second moment;
 * `variance_id_expMeasure` — the variance;
 * `integrableExpSet_id_expMeasure` — the moment-generating domain is exactly `Iio r`;
-* `mgf_id_expMeasure`, `mgf_id_expMeasure_pos`, `cgf_id_expMeasure` — the mgf on that domain, its
-  strict positivity, and the cgf as the logarithm of a positive number;
+* `mgf_id_expMeasure`, `cgf_id_expMeasure` — the mgf on that domain, and the cgf;
 * `charFun_expMeasure` — the characteristic function, at every real `t`.
 
 ## References
@@ -205,18 +206,18 @@ private theorem expIntegrand_eq_indicator (t : ℝ) :
     (fun x => exponentialPDFReal r x * exp (t * x))
       = (Ici (0:ℝ)).indicator (fun x => r * exp ((t - r) * x)) := by
   funext x
-  unfold exponentialPDFReal gammaPDFReal
+  rw [exponentialPDFReal_apply]
   by_cases hx : (0:ℝ) ≤ x
   · rw [Set.indicator_of_mem (mem_Ici.mpr hx)]
     split_ifs
-    rw [Real.rpow_one, Real.Gamma_one, sub_self, Real.rpow_zero,
-      show (t - r) * x = t * x + -(r * x) by ring, Real.exp_add]
+    rw [show (t - r) * x = t * x + -(r * x) by ring, Real.exp_add]
     ring
   · rw [Set.indicator_of_notMem (by simpa using hx)]
     split_ifs
     ring
 
 /-- **The moment-generating domain of the exponential law** is exactly `Iio r`. -/
+@[simp]
 theorem integrableExpSet_id_expMeasure (hr : 0 < r) :
     integrableExpSet id (expMeasure r) = Set.Iio r := by
   ext t
@@ -228,31 +229,28 @@ theorem integrableExpSet_id_expMeasure (hr : 0 < r) :
   rw [integrable_const_mul_iff (isUnit_iff_ne_zero.2 hr.ne') (fun x => exp ((t - r) * x))]
   exact integrableOn_exp_mul_Ioi_iff.trans sub_neg
 
+/-- The exponential moment at `t` exists exactly when `t < r`.  This is
+`integrableExpSet_id_expMeasure` in the form a caller actually applies, without unfolding
+`integrableExpSet` or stripping `id`. -/
+theorem integrable_exp_mul_expMeasure_iff (hr : 0 < r) :
+    Integrable (fun x => exp (t * x)) (expMeasure r) ↔ t < r := by
+  have h := integrableExpSet_id_expMeasure (r := r) hr
+  have ht : t ∈ integrableExpSet id (expMeasure r) ↔ t ∈ Set.Iio r := by rw [h]
+  simpa [integrableExpSet, Set.mem_ofPred_eq] using ht
+
 /-! ### The moment generating function and its logarithm -/
 
 /-- **The moment generating function of the exponential law**, on its domain `t < r`. -/
 theorem mgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
     mgf id (expMeasure r) t = r / (r - t) := by
-  have hrt : 0 < r - t := sub_pos.2 ht
-  have hcongr : ∀ x ∈ Ioi (0:ℝ),
-      r * exp ((t - r) * x) = r * (x ^ 0 * exp (-((r - t) * x))) := by
-    intro x _
-    rw [pow_zero, one_mul, show (t - r) * x = -((r - t) * x) by ring]
   unfold mgf
   simp only [id_eq]
   rw [integral_expMeasure hr]
   simp only [smul_eq_mul]
-  rw [expIntegrand_eq_indicator t,
-    integral_indicator measurableSet_Ici, integral_Ici_eq_integral_Ioi,
-    setIntegral_congr_fun measurableSet_Ioi hcongr, integral_const_mul,
-    integral_pow_mul_exp_neg_mul_Ioi 0 hrt]
-  simp [div_eq_mul_inv]
-
-/-- The moment generating function is strictly positive on its domain.  This is what makes the
-cgf below the logarithm of a positive number rather than a junk value. -/
-theorem mgf_id_expMeasure_pos (hr : 0 < r) (ht : t < r) : 0 < mgf id (expMeasure r) t := by
-  rw [mgf_id_expMeasure hr ht]
-  exact div_pos hr (sub_pos.2 ht)
+  rw [expIntegrand_eq_indicator t, integral_indicator measurableSet_Ici,
+    integral_Ici_eq_integral_Ioi, integral_const_mul, integral_exp_mul_Ioi (sub_neg.2 ht) 0]
+  simp only [mul_zero, Real.exp_zero]
+  rw [show ((t : ℝ) - r) = -(r - t) by ring, div_neg, neg_div, neg_neg, mul_one_div]
 
 /-- **The cumulant generating function of the exponential law**, on its domain `t < r`. -/
 theorem cgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
@@ -266,9 +264,9 @@ theorem cgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
 private theorem charIntegrand_eq (t : ℝ) {x : ℝ} (hx : 0 < x) :
     exponentialPDFReal r x • Complex.exp ((t : ℂ) * x * Complex.I)
       = (r : ℂ) * Complex.exp (((t : ℂ) * Complex.I - r) * x) := by
-  unfold exponentialPDFReal gammaPDFReal
+  rw [exponentialPDFReal_apply]
   split_ifs with h
-  · rw [Real.rpow_one, Real.Gamma_one, sub_self, Real.rpow_zero, Complex.real_smul]
+  · rw [Complex.real_smul]
     push_cast [Complex.ofReal_exp]
     rw [mul_assoc, ← Complex.exp_add]
     ring_nf
@@ -276,16 +274,16 @@ private theorem charIntegrand_eq (t : ℝ) {x : ℝ} (hx : 0 < x) :
 
 /-- **The characteristic function of the exponential law.**
 
-Unlike the mgf this needs no hypothesis on `t`: the integrand has modulus `exp (-(r * x))`
-whatever `t` is, so the integral converges at every real `t`. -/
+Unlike the mgf this needs no hypothesis on `t`: the density-transported integrand has modulus
+`r * exp (-(r * x))` on `[0, ∞)` whatever `t` is, so the integral converges at every real `t`. -/
 theorem charFun_expMeasure (hr : 0 < r) (t : ℝ) :
-    charFun (expMeasure r) t = (r : ℂ) / (r - t * Complex.I) := by
+    charFun (expMeasure r) t = (r : ℂ) / (r - Complex.I * t) := by
   have ha : ((t : ℂ) * Complex.I - r).re < 0 := by simp [hr]
   have hzero : ∀ x ∉ Ici (0:ℝ),
       exponentialPDFReal r x • Complex.exp ((t : ℂ) * x * Complex.I) = 0 := by
     intro x hx
     have hpdf : exponentialPDFReal r x = 0 := by
-      unfold exponentialPDFReal gammaPDFReal
+      rw [exponentialPDFReal_apply]
       split_ifs with h
       · exact absurd h (by simpa using hx)
       · rfl
@@ -295,7 +293,7 @@ theorem charFun_expMeasure (hr : 0 < r) (t : ℝ) :
     setIntegral_congr_fun measurableSet_Ioi (fun x hx => charIntegrand_eq t (mem_Ioi.mp hx)),
     integral_const_mul, integral_exp_mul_complex_Ioi ha 0]
   simp only [Complex.ofReal_zero, mul_zero, Complex.exp_zero]
-  rw [show ((t : ℂ) * Complex.I - r) = -((r : ℂ) - t * Complex.I) by ring, div_neg, neg_div,
+  rw [show ((t : ℂ) * Complex.I - r) = -((r : ℂ) - Complex.I * t) by ring, div_neg, neg_div,
     neg_neg, mul_one_div]
 
 end Probability

--- a/TauCeti/Probability/Distributions/Exponential.lean
+++ b/TauCeti/Probability/Distributions/Exponential.lean
@@ -232,15 +232,12 @@ theorem integrableExpSet_id_expMeasure (hr : 0 < r) :
   rw [integrable_const_mul_iff (isUnit_iff_ne_zero.2 hr.ne') (fun x => exp ((t - r) * x))]
   exact integrableOn_exp_mul_Ioi_iff.trans sub_neg
 
-/-- The exponential moment at `t` exists exactly when `t < r`.  This is
-`integrableExpSet_id_expMeasure` in the form a caller actually applies, without unfolding
-`integrableExpSet` or stripping `id`. -/
-@[simp]
-theorem integrable_exp_mul_id_expMeasure_iff (hr : 0 < r) :
-    Integrable (fun x => exp (t * x)) (expMeasure r) ↔ t < r := by
-  have h := integrableExpSet_id_expMeasure (r := r) hr
-  have ht : t ∈ integrableExpSet id (expMeasure r) ↔ t ∈ Set.Iio r := by rw [h]
-  simpa [integrableExpSet, Set.mem_ofPred_eq] using ht
+/-- The sign normalization both transform proofs need: `integral_exp_mul_Ioi` and its complex
+counterpart report a value at rate `a - b`, while the statements are oriented at `b - a`.  Holds
+unconditionally — at `a = b` both sides are the junk value `0`. -/
+private theorem mul_neg_one_div_sub {K : Type*} [Field K] (c a b : K) :
+    c * (-1 / (a - b)) = c / (b - a) := by
+  rw [neg_div, mul_neg, mul_one_div, ← neg_sub a b, div_neg]
 
 /-! ### The moment generating function and its logarithm -/
 
@@ -254,20 +251,20 @@ theorem mgf_id_expMeasure (hr : 0 < r) (ht : t < r) :
   simp only [smul_eq_mul]
   rw [expIntegrand_eq_indicator t, integral_indicator measurableSet_Ici,
     integral_Ici_eq_integral_Ioi, integral_const_mul, integral_exp_mul_Ioi (sub_neg.2 ht) 0]
-  -- `integral_exp_mul_Ioi` reports the value at rate `t - r`; the statement is oriented at `r - t`,
-  -- so the sign is flipped once, explicitly, rather than left to `field_simp` to guess.
-  have hflip : (t : ℝ) - r = -(r - t) := by ring
   simp only [mul_zero, Real.exp_zero]
-  rw [hflip, div_neg, neg_div, neg_neg, mul_one_div]
+  exact mul_neg_one_div_sub r t r
 
 /-- The moment generating function is strictly positive on its domain.
 
-Proved from Mathlib's `mgf_pos` and the integrability characterization, not by `div_pos` on the
-closed form: positivity is a consequence of the exponential moment *existing*, which is what a
-consumer reasoning about the cgf's domain actually has. -/
+Proved from Mathlib's `mgf_pos` and the domain equality, through Mathlib's own
+`integrable_of_mem_integrableExpSet`, rather than by `div_pos` on the closed form: positivity is a
+consequence of the exponential moment *existing*, which is what a consumer reasoning about the
+cgf's domain actually has. -/
 theorem mgf_id_expMeasure_pos (hr : 0 < r) (ht : t < r) : 0 < mgf id (expMeasure r) t := by
   have : IsProbabilityMeasure (expMeasure r) := isProbabilityMeasure_expMeasure hr
-  exact mgf_pos ((integrable_exp_mul_id_expMeasure_iff hr).2 ht)
+  refine mgf_pos (integrable_of_mem_integrableExpSet ?_)
+  rw [integrableExpSet_id_expMeasure hr]
+  exact ht
 
 /-- **The cumulant generating function of the exponential law**, on its domain `t < r`. -/
 @[simp]
@@ -311,10 +308,9 @@ theorem charFun_expMeasure (hr : 0 < r) (t : ℝ) :
     ← setIntegral_eq_integral_of_forall_compl_eq_zero hzero, integral_Ici_eq_integral_Ioi,
     setIntegral_congr_fun measurableSet_Ioi (fun x hx => charIntegrand_eq t (mem_Ioi.mp hx)),
     integral_const_mul, integral_exp_mul_complex_Ioi ha 0]
-  -- as in the mgf: the integral is reported at rate `t * I - r`, the statement at `r - I * t`.
-  have hflip : (t : ℂ) * Complex.I - r = -((r : ℂ) - Complex.I * t) := by ring
   simp only [Complex.ofReal_zero, mul_zero, Complex.exp_zero]
-  rw [hflip, div_neg, neg_div, neg_neg, mul_one_div]
+  rw [show ((t : ℂ) * Complex.I - r) = (Complex.I * t - r) by ring]
+  exact mul_neg_one_div_sub (r : ℂ) (Complex.I * t) r
 
 end Probability
 


### PR DESCRIPTION
The transform API of the exponential law, the second PR under intention
TauCetiProject/TauCetiRoadmap#272:

```text
integrableExpSet id (expMeasure r) = Iio r
mgf id (expMeasure r) t = r / (r - t)          on that domain, and strictly positive there
cgf id (expMeasure r) t = log (r / (r - t))    on that domain
charFun (expMeasure r) t = r / (r - t * I)     at every real t
```

## The domain is an equality, and that is what needed the prerequisite

`integrableExpSet_id_expMeasure` states the moment-generating domain as a **set equality**, which the
roadmap asks for. After the density transport the integrand is a constant multiple of
`exp ((t - r) * x)` on `[0, ∞)`, so both directions reduce to
`TauCeti.integrableOn_exp_mul_Ioi_iff` — the converse shipped in #4020. Mathlib's
`integrableOn_exp_mul_Ioi` alone gives only `Iio r ⊆ integrableExpSet`.

## Positivity, and where it comes from

`mgf_id_expMeasure_pos` records `0 < mgf id (expMeasure r) t` on the domain. It is derived from
Mathlib's `mgf_pos` together with `integrable_exp_mul_id_expMeasure_iff` — that is, from the
exponential moment *existing* — rather than by `div_pos` on the closed form. That is both the more
informative route and the reason the lemma is not a restatement of the value theorem above it.

## The characteristic function needs no hypothesis on `t`

Unlike the mgf, the integrand has modulus `exp (-(r * x))` whatever `t` is, so the integral
converges at every real `t` and `charFun_expMeasure` carries only `0 < r`. It goes through Mathlib's
`integral_exp_mul_complex_Ioi`, whose hypothesis `(t * I - r).re < 0` is exactly `0 < r`.

## One transport, now generic

`integral_expMeasure` previously mapped `ℝ → ℝ` integrands only. The characteristic function needs a
`ℂ`-valued one, so rather than add a parallel complex copy the existing private lemma is generalized
to any Banach codomain, stated with `•`. The real call sites reach their `*` forms through
`smul_eq_mul`.

## Scope

Memorylessness and the minimum of two independent exponentials are the remaining two PRs under #272;
this one is the transforms.

## Roadmap

Roadmap: StandardDistributions

Advances TauCetiProject/TauCetiRoadmap#272

`TauCetiRoadmap/StandardDistributions/README.md`, Layer 1, the **Exponential** entry: "prove …
`integrableExpSet id (expMeasure r) = Set.Iio r`, mgf `r / (r - t)` exactly on that domain,
characteristic function `(r : ℂ) / (r - I * t)` … On the mgf domain, prove the cgf
`Real.log (r / (r - t))`." The mgf is shaped as the roadmap directs, following
[mathlib4#35504](https://github.com/leanprover-community/mathlib4/pull/35504), which the module's
References already credits as the upstream source to be dropped in favour of once it lands at the
pin.

🤖 Directed by Cameron Freer, drafted by Opus 5

