### PR TITLE
feat: make smooth morphisms geometrically reduced

### DIFF
--- a/TauCeti/AlgebraicGeometry/Morphisms/Smooth/GeometricallyReduced.lean
+++ b/TauCeti/AlgebraicGeometry/Morphisms/Smooth/GeometricallyReduced.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Geometrically.Reduced
+public import Mathlib.AlgebraicGeometry.Morphisms.Smooth
+public import TauCeti.RingTheory.Smooth.GeometricallyReduced
+
+/-!
+# Smooth morphisms are geometrically reduced
+
+A smooth morphism of schemes has geometrically reduced fibres. After base change to a field,
+smoothness is preserved, and an affine cover of the source has smooth coordinate algebras over
+the ring of global functions of the target. That ring is isomorphic to the field, so the
+coordinate algebras are reduced by `TauCeti.isReduced_of_smooth_of_field`.
+
+The main result is the instance `AlgebraicGeometry.Smooth.geometricallyReduced`. It supplies the
+geometric-reducedness half of the Jacobian challenge's standing-hypotheses deduction that a
+smooth, geometrically connected curve is geometrically integral. The remaining irreducibility
+half uses that the local rings of a smooth scheme over a field are regular domains.
+
+No formalization is vendored. The commutative-algebra input is
+`TauCeti.isReduced_of_smooth_of_field`; the passage from affine opens to the whole scheme uses
+Mathlib's `AlgebraicGeometry.IsReduced.of_openCover`.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+private theorem isReduced_of_smooth_toSpec_field (K : Type u) [Field K]
+    {X : Scheme.{u}} (f : X ⟶ Spec (.of K)) [Smooth f] : IsReduced X := by
+  let hred : ∀ i, IsReduced (X.affineCover.X i) := fun i ↦ by
+    let _ := ((Scheme.ΓSpecIso (.of K)).commRingCatIsoToRingEquiv.toMulEquiv.isField
+      (Field.toIsField K)).toField
+    have hf : ((X.affineCover.f i ≫ f).appTop).hom.Smooth :=
+      HasRingHomProperty.appTop @Smooth _
+        (HasRingHomProperty.comp_of_isOpenImmersion @Smooth (X.affineCover.f i) f inferInstance)
+    let _ : Algebra Γ(Spec (.of K), ⊤) Γ(X.affineCover.X i, ⊤) :=
+      ((X.affineCover.f i ≫ f).appTop).hom.toAlgebra
+    let _ : Algebra.Smooth Γ(Spec (.of K), ⊤) Γ(X.affineCover.X i, ⊤) := hf.toAlgebra
+    let _ : _root_.IsReduced Γ(X.affineCover.X i, ⊤) :=
+      isReduced_of_smooth_of_field Γ(Spec (.of K), ⊤) Γ(X.affineCover.X i, ⊤)
+    exact isReduced_of_isAffine_isReduced (X.affineCover.X i)
+  exact @IsReduced.of_openCover X X.affineCover hred
+
+/-- Every smooth morphism of schemes is geometrically reduced. -/
+instance (priority := low) Smooth.geometricallyReduced {X Y : Scheme.{u}} (f : X ⟶ Y)
+    [Smooth f] : GeometricallyReduced f := by
+  constructor
+  intro K _ y Z fst snd h
+  let _ : Smooth snd := MorphismProperty.of_isPullback h inferInstance
+  exact isReduced_of_smooth_toSpec_field K snd
+
+end AlgebraicGeometry
+
+end TauCeti


### PR DESCRIPTION
This PR makes every smooth morphism of schemes geometrically reduced. After an arbitrary field-valued base change, it covers the source by affine opens, reads smoothness on each coordinate-ring map, applies `TauCeti.isReduced_of_smooth_of_field`, and glues reducedness across the affine cover. The result is exposed as the low-priority instance `TauCeti.AlgebraicGeometry.Smooth.geometricallyReduced`; the field-target reduction used by its proof stays private.

The exact roadmap target is the **Standing hypotheses** paragraph of `TauCetiRoadmap/JacobianChallenge/README.md`: “record as a lemma that such a curve is geometrically integral (smoothness ⇒ geometric reducedness; regular + connected ⇒ irreducible).” This PR supplies the first named implication at its natural generality and connects the merged commutative-algebra theorem to scheme morphisms. It is the next effective step because `TauCeti/AlgebraicGeometry/IrreducibleOfConnectedDomainStalk.lean` already supplies the connected-domain-stalks-to-irreducible half once smooth geometric fibres are shown to have domain stalks, while the only open JacobianChallenge PR concerns Euler-characteristic additivity.

What remains after this PR for the standing-hypotheses milestone is to prove that local rings of a smooth scheme over a field are regular domains, apply the existing connected-domain-stalk theorem after every field extension, and combine irreducibility with the geometric reducedness supplied here to obtain geometric integrality.

Add `TauCeti/AlgebraicGeometry/Morphisms/Smooth/GeometricallyReduced.lean` (66 lines). The proof reuses Mathlib’s stability of `Smooth` under base change, `HasRingHomProperty.appTop`, `AlgebraicGeometry.IsReduced.of_openCover`, and the affine reducedness criterion, together with `TauCeti.isReduced_of_smooth_of_field`. The underlying smooth-algebra result follows the Stacks Project, Section 10.140, as credited in its existing module documentation; no Mathlib source or external formalization is vendored.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"smooth-geometrically-reduced"}-->

🤖 Prepared with Codex
