### PR TITLE
feat: the coding representation of a separately exchangeable array

### DIFF
--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -15,6 +15,8 @@ public import TauCeti.Probability.DeFinetti.Representation
 -- realizes a barycenter as a path law, and the process/path-law bridge.
 import TauCeti.Probability.Exchangeability.ConditionallyIID.Construct
 import TauCeti.Probability.Exchangeability.PathSpace.Law.Bridge
+-- Non-public: `map_bind` and `bind_map` are used only inside the naturality proof.
+import TauCeti.MeasureTheory.Measure.GiryMonad
 
 /-!
 # The de Finetti barycenter of a mixing law
@@ -52,6 +54,8 @@ throughout the de Finetti development (`deFinetti_mixture`, `mixedIID_mixingLaw_
 * `deFinettiBarycenter_dirac` — a point mass mixes to a single i.i.d. law.
 * `deFinettiBarycenter_zero`, `deFinettiBarycenter_add`, `deFinettiBarycenter_smul` — affinity in
   the mixing law.
+* `map_pi_deFinettiBarycenter` — naturality in the state space: a coordinatewise pushforward of a
+  barycenter is the barycenter of the pushed-forward mixing law.
 * `exchangeableLaw_deFinettiBarycenter` — every barycenter of a mixing probability law is an
   exchangeable path law.
 * `ExchangeableLaw.existsUnique_mixingLaw` — conversely, an exchangeable probability law on
@@ -144,6 +148,33 @@ theorem deFinettiBarycenter_add (π₁ π₂ : Measure (ProbabilityMeasure α)) 
 theorem deFinettiBarycenter_smul (c : ℝ≥0∞) (π : Measure (ProbabilityMeasure α)) :
     deFinettiBarycenter (c • π) = c • deFinettiBarycenter π :=
   Measure.bind_smul c π _
+
+/-- **The barycenter is natural in the state space.** Pushing every coordinate of a barycenter
+forward by a measurable `f : α → β` gives the barycenter of the mixing law pushed forward by
+`P ↦ P.map f`: drawing `P` from `π` and then an i.i.d. `P`-sequence, and afterwards applying `f`
+to each term, is the same as drawing `P.map f` and then an i.i.d. sequence from it. -/
+theorem map_pi_deFinettiBarycenter {β : Type*} [MeasurableSpace β]
+    (π : Measure (ProbabilityMeasure α)) {f : α → β} (hf : Measurable f) :
+    (deFinettiBarycenter π).map (fun x i => f (x i))
+      = deFinettiBarycenter (π.map fun P => P.map hf.aemeasurable) := by
+  have hmap : Measurable fun P : ProbabilityMeasure α => P.map hf.aemeasurable :=
+    ((Measure.measurable_map f hf).comp measurable_subtype_coe).subtype_mk
+  have hpi : Measurable fun x : ℕ → α => fun i => f (x i) :=
+    measurable_pi_lambda _ fun i => hf.comp (measurable_pi_apply i)
+  calc (deFinettiBarycenter π).map (fun x i => f (x i))
+      = π.bind fun P => (Measure.infinitePi fun _ : ℕ => (P : Measure α)).map
+          fun x i => f (x i) :=
+        TauCeti.MeasureTheory.map_bind
+          TauCeti.MeasureTheory.measurable_infinitePi_const.aemeasurable hpi
+    _ = π.bind fun P => Measure.infinitePi fun _ : ℕ => (P.map hf.aemeasurable : Measure β) :=
+        congrArg (Measure.bind π) (funext fun P => by
+          rw [Measure.infinitePi_map_pi (μ := fun _ : ℕ => (P : Measure α))
+            (f := fun _ : ℕ => f) fun _ => hf]
+          simp)
+    _ = deFinettiBarycenter (π.map fun P => P.map hf.aemeasurable) := by
+        rw [deFinettiBarycenter_def, TauCeti.MeasureTheory.bind_map hmap.aemeasurable
+          TauCeti.MeasureTheory.measurable_infinitePi_const.aemeasurable]
+        rfl
 
 /-- **A barycenter is an exchangeable path law.** Drawing `P` from `π` and then an i.i.d.
 `P`-sequence produces a law invariant under every permutation of the time coordinate.

--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -173,8 +173,7 @@ theorem map_pi_deFinettiBarycenter {β : Type*} [MeasurableSpace β]
           simp)
     _ = deFinettiBarycenter (π.map fun P => P.map hf.aemeasurable) := by
         rw [deFinettiBarycenter_def, TauCeti.MeasureTheory.bind_map hmap.aemeasurable
-          TauCeti.MeasureTheory.measurable_infinitePi_const.aemeasurable]
-        rfl
+          TauCeti.MeasureTheory.measurable_infinitePi_const.aemeasurable, Function.comp_def]
 
 /-- **A barycenter is an exchangeable path law.** Drawing `P` from `π` and then an i.i.d.
 `P`-sequence produces a law invariant under every permutation of the time coordinate.

--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -50,6 +50,8 @@ hypothesis is needed beyond the ones de Finetti already asks of `α`.
 
 * `TauCeti.Probability.SeparatelyExchangeable.jointlyExchangeable` — the implication between the
   two symmetries.
+* `TauCeti.Probability.separatelyExchangeable_iff_map_pairReindex` — the bridge to the array law:
+  separate exchangeability is invariance of the law on `ℕ × ℕ → α` under every pair reindexing.
 * `TauCeti.Probability.separatelyExchangeable_iff_axes` — separate exchangeability splits into
   invariance under row permutations and invariance under column permutations.
 * `TauCeti.Probability.SeparatelyExchangeable.fullyExchangeable_arrayRow` and
@@ -245,6 +247,18 @@ theorem JointlyExchangeable.map_comp {β : Type*} [MeasurableSpace β] {μ : Mea
     (μ.map fun ω => F fun p => X (σ p.1, σ p.2) ω) = μ.map fun ω => F fun p => X p ω := by
   rw [← map_map_array (X := fun p => X (σ p.1, σ p.2)) (fun p => hX _) hF,
     ← map_map_array hX hF, h σ]
+
+/-- **Separate exchangeability is a property of the array law.** It says exactly that the law of
+the array on `ℕ × ℕ → α` is invariant under every pair reindexing, which is the form in which a
+statement about a law rather than a process supplies it. -/
+theorem separatelyExchangeable_iff_map_pairReindex {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    (hX : ∀ p, AEMeasurable (X p) μ) :
+    SeparatelyExchangeable μ X ↔
+      ∀ σ τ : Equiv.Perm ℕ,
+        (μ.map fun ω p => X p ω).map (pairReindex σ τ) = μ.map fun ω p => X p ω :=
+  forall_congr' fun σ => forall_congr' fun τ => by
+    rw [map_map_array hX (measurable_pairReindex σ τ)]
+    rfl
 
 /-! ## Splitting separate exchangeability into its two axes -/
 

--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -52,6 +52,8 @@ hypothesis is needed beyond the ones de Finetti already asks of `α`.
   two symmetries.
 * `TauCeti.Probability.separatelyExchangeable_iff_map_pairReindex` — the bridge to the array law:
   separate exchangeability is invariance of the law on `ℕ × ℕ → α` under every pair reindexing.
+* `TauCeti.Probability.map_uncurry_pathLaw_arrayRow` — the array law is the uncurried path law of
+  the row process.
 * `TauCeti.Probability.separatelyExchangeable_iff_axes` — separate exchangeability splits into
   invariance under row permutations and invariance under column permutations.
 * `TauCeti.Probability.SeparatelyExchangeable.fullyExchangeable_arrayRow` and
@@ -257,8 +259,21 @@ theorem separatelyExchangeable_iff_map_pairReindex {μ : Measure Ω} {X : ℕ ×
       ∀ σ τ : Equiv.Perm ℕ,
         (μ.map fun ω p => X p ω).map (pairReindex σ τ) = μ.map fun ω p => X p ω :=
   forall_congr' fun σ => forall_congr' fun τ => by
-    rw [map_map_array hX (measurable_pairReindex σ τ)]
-    rfl
+    have hread : (fun ω => pairReindex σ τ fun p => X p ω) = fun ω p => X (σ p.1, τ p.2) ω := by
+      funext ω p
+      rw [pairReindex_apply]
+    rw [map_map_array hX (measurable_pairReindex σ τ), hread]
+
+/-- **An array law is the uncurried path law of its row process.** A statement about the law of the
+row process therefore transports to one about the law of the array. -/
+theorem map_uncurry_pathLaw_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    (hX : ∀ p, AEMeasurable (X p) μ) :
+    (pathLaw μ (arrayRow X)).map Function.uncurry = μ.map fun ω p => X p ω := by
+  rw [pathLaw_def, AEMeasurable.map_map_of_aemeasurable measurable_uncurry.aemeasurable
+    (aemeasurable_pi_lambda _ fun i => aemeasurable_arrayRow hX i)]
+  refine congrArg (Measure.map · _) ?_
+  funext ω ⟨i, j⟩
+  simp
 
 /-! ## Splitting separate exchangeability into its two axes -/
 

--- a/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
@@ -111,7 +111,7 @@ variable [StandardBorelSpace α] [Nonempty α]
 /-- The law of the array coded by a parameter and one uniform variable per row, computed through
 its row process: it is the uncurried de Finetti barycenter of the parameter law. -/
 private theorem map_prod_unitIntervalCoding_array
-    (π : Measure (ProbabilityMeasure (ℕ → α))) [SFinite π] :
+    (π : Measure (ProbabilityMeasure (ℕ → α))) :
     ((π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
         fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2)
       = (deFinettiBarycenter π).map Function.uncurry := by
@@ -123,7 +123,7 @@ private theorem map_prod_unitIntervalCoding_array
 of coded paths, and permuting the columns pushes every coded path forward by the time
 permutation. -/
 private theorem map_prod_unitIntervalCoding_array_pairReindex
-    (π : Measure (ProbabilityMeasure (ℕ → α))) [SFinite π] (σ τ : Equiv.Perm ℕ) :
+    (π : Measure (ProbabilityMeasure (ℕ → α))) (σ τ : Equiv.Perm ℕ) :
     ((π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
         fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 (σ p.1)) (τ p.2))
       = (((deFinettiBarycenter π).map (permReindex (α := ℕ → α) σ)).map

--- a/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
@@ -41,8 +41,6 @@ a permutation-invariant mixing law (`separatelyExchangeable_iff_exists_coding`).
 
 ## Main results
 
-* `TauCeti.Probability.map_uncurry_pathLaw_arrayRow` — the law of an array is the uncurried path
-  law of its row process, the transport along which every statement below is read.
 * `TauCeti.Probability.SeparatelyExchangeable.exists_arrayLaw_eq_map_unitIntervalCoding` — **the
   representation**: the law of a separately exchangeable array is the law of the array coded by a
   permutation-invariant mixing law.
@@ -58,7 +56,9 @@ de Finetti barycenter of the mixing law (`map_prod_unitIntervalCoding_eq_deFinet
 value space `ℕ → α`). Both array symmetries are therefore read off that barycenter: permuting the
 rows is exchangeability of the barycenter (`exchangeableLaw_deFinettiBarycenter`), and permuting
 the columns is a coordinatewise pushforward, which by naturality (`map_pi_deFinettiBarycenter`) is
-the barycenter of the pushed-forward mixing law. Only the second uses the hypothesis on `π`.
+the barycenter of the pushed-forward mixing law. Only the second uses the hypothesis on `π`. The
+transport from the row process back to the array is `map_uncurry_pathLaw_arrayRow`, along which
+every statement here is read.
 
 The unit interval is written out rather than through the `unitInterval` scoped notation `I`, whose
 namespace also carries a `σ` notation that would collide with the permutation names used by the
@@ -87,17 +87,6 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- **An array law is the uncurried path law of its row process.** A statement about the law of the
-row process therefore transports to one about the law of the array. -/
-theorem map_uncurry_pathLaw_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
-    (hX : ∀ p, AEMeasurable (X p) μ) :
-    (pathLaw μ (arrayRow X)).map Function.uncurry = μ.map fun ω p => X p ω := by
-  rw [pathLaw_def, AEMeasurable.map_map_of_aemeasurable measurable_uncurry.aemeasurable
-    (aemeasurable_pi_lambda _ fun i => aemeasurable_arrayRow hX i)]
-  congr 1
-  funext ω ⟨i, j⟩
-  simp
-
 section Coding
 
 variable [StandardBorelSpace α] [Nonempty α]
@@ -111,7 +100,9 @@ private theorem map_prod_unitIntervalCoding_array
       = (deFinettiBarycenter π).map Function.uncurry := by
   rw [← map_prod_unitIntervalCoding_eq_deFinettiBarycenter (α := ℕ → α) π,
     Measure.map_map measurable_uncurry (measurable_unitIntervalCodingPath (α := ℕ → α))]
-  rfl
+  refine congrArg (Measure.map · _) ?_
+  funext q ⟨i, j⟩
+  simp
 
 /-- The same computation after reindexing the two axes: permuting the rows reindexes the sequence
 of coded paths, and permuting the columns pushes every coded path forward by the time
@@ -129,7 +120,9 @@ private theorem map_prod_unitIntervalCoding_array_pairReindex
   rw [← map_prod_unitIntervalCoding_eq_deFinettiBarycenter (α := ℕ → α) π,
     Measure.map_map hS hR, Measure.map_map hT (hS.comp hR),
     Measure.map_map measurable_uncurry (hT.comp (hS.comp hR))]
-  rfl
+  refine congrArg (Measure.map · _) ?_
+  funext q ⟨i, j⟩
+  simp
 
 /-- **Coding a permutation-invariant mixing law gives a separately exchangeable array.** Draw a
 path law `P` from `π` and one uniform variable `ϑ i` per row, and let the `(i, j)`-entry be

--- a/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
@@ -87,18 +87,12 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- Reading a sequence of paths as an array is measurable: it is the measurable equivalence
-`MeasurableEquiv.curry`, backwards. -/
-private theorem measurable_uncurry_path :
-    Measurable (Function.uncurry : (ℕ → ℕ → α) → ℕ × ℕ → α) := by
-  simpa only [MeasurableEquiv.coe_curry_symm] using (MeasurableEquiv.curry ℕ ℕ α).symm.measurable
-
 /-- **An array law is the uncurried path law of its row process.** A statement about the law of the
 row process therefore transports to one about the law of the array. -/
 theorem map_uncurry_pathLaw_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
     (hX : ∀ p, AEMeasurable (X p) μ) :
     (pathLaw μ (arrayRow X)).map Function.uncurry = μ.map fun ω p => X p ω := by
-  rw [pathLaw_def, AEMeasurable.map_map_of_aemeasurable measurable_uncurry_path.aemeasurable
+  rw [pathLaw_def, AEMeasurable.map_map_of_aemeasurable measurable_uncurry.aemeasurable
     (aemeasurable_pi_lambda _ fun i => aemeasurable_arrayRow hX i)]
   congr 1
   funext ω ⟨i, j⟩
@@ -116,7 +110,7 @@ private theorem map_prod_unitIntervalCoding_array
         fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2)
       = (deFinettiBarycenter π).map Function.uncurry := by
   rw [← map_prod_unitIntervalCoding_eq_deFinettiBarycenter (α := ℕ → α) π,
-    Measure.map_map measurable_uncurry_path (measurable_unitIntervalCodingPath (α := ℕ → α))]
+    Measure.map_map measurable_uncurry (measurable_unitIntervalCodingPath (α := ℕ → α))]
   rfl
 
 /-- The same computation after reindexing the two axes: permuting the rows reindexes the sequence
@@ -134,7 +128,7 @@ private theorem map_prod_unitIntervalCoding_array_pairReindex
     measurable_pi_lambda _ fun i => (measurable_reindex τ).comp (measurable_pi_apply i)
   rw [← map_prod_unitIntervalCoding_eq_deFinettiBarycenter (α := ℕ → α) π,
     Measure.map_map hS hR, Measure.map_map hT (hS.comp hR),
-    Measure.map_map measurable_uncurry_path (hT.comp (hS.comp hR))]
+    Measure.map_map measurable_uncurry (hT.comp (hS.comp hR))]
   rfl
 
 /-- **Coding a permutation-invariant mixing law gives a separately exchangeable array.** Draw a

--- a/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- Public: the array symmetry and the inherited invariance of the row mixing law are the
+-- hypothesis and the conclusion of the representation.
+public import TauCeti.Probability.Exchangeability.Arrays.MixingLaw
+-- Public: the coding map and the barycenter identity it satisfies appear in every statement.
+public import TauCeti.Probability.DeFinetti.Coding
+-- Non-public: the mixture form of a row path law is used only inside proofs.
+import TauCeti.Probability.Exchangeability.MixedIID.Mixture
+
+/-!
+# The coding representation of a separately exchangeable array
+
+De Finetti's theorem turns an exchangeable sequence into a fixed measurable function of its
+directing measure and independent uniform noise (`deFinetti_coding`). This file does the same for
+the rows of a **separately exchangeable array**: an array `X : ℕ × ℕ → Ω → α` over a nonempty
+standard Borel state space satisfies
+
+```text
+X (i, j)  =ᵈ  f P (ϑ i) j,
+```
+
+for the canonical coding map `f = unitIntervalCoding (ℕ → α)`, a single random parameter
+`P : ProbabilityMeasure (ℕ → α)` drawn from a mixing law `π`, and an independent i.i.d. uniform
+sequence `ϑ` carrying one variable per row. All the randomness of the array beyond the global
+parameter sits in the per-row noise, which is the shape the Aldous–Hoover representation takes;
+the finer resolution of a row path into a per-column and a per-cell source is not carried out
+here, and the column symmetry enters only through the invariance of `π`.
+
+That invariance is what makes the representation exact rather than one-directional. The mixing
+law of the rows is invariant under pushing a path law forward by a permutation of the time
+coordinate (`SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq`), and, conversely,
+coding *any* mixing law with that invariance produces a separately exchangeable array. So over a
+nonempty standard Borel state space, separate exchangeability of an array is exactly codability by
+a permutation-invariant mixing law (`separatelyExchangeable_iff_exists_coding`).
+
+## Main results
+
+* `TauCeti.Probability.map_uncurry_pathLaw_arrayRow` — the law of an array is the uncurried path
+  law of its row process, the transport along which every statement below is read.
+* `TauCeti.Probability.SeparatelyExchangeable.exists_arrayLaw_eq_map_unitIntervalCoding` — **the
+  representation**: the law of a separately exchangeable array is the law of the array coded by a
+  permutation-invariant mixing law.
+* `TauCeti.Probability.separatelyExchangeable_unitIntervalCoding` — the converse: the
+  array coded by a permutation-invariant mixing law is separately exchangeable.
+* `TauCeti.Probability.separatelyExchangeable_iff_exists_coding` — the resulting
+  characterization.
+
+## Implementation
+
+The row process of the coded array is the coded sequence in path space, so its law is the
+de Finetti barycenter of the mixing law (`map_prod_unitIntervalCoding_eq_deFinettiBarycenter` at
+value space `ℕ → α`). Both array symmetries are therefore read off that barycenter: permuting the
+rows is exchangeability of the barycenter (`exchangeableLaw_deFinettiBarycenter`), and permuting
+the columns is a coordinatewise pushforward, which by naturality (`map_pi_deFinettiBarycenter`) is
+the barycenter of the pushed-forward mixing law. Only the second uses the hypothesis on `π`.
+
+The unit interval is written out rather than through the `unitInterval` scoped notation `I`, whose
+namespace also carries a `σ` notation that would collide with the permutation names used by the
+neighbouring array files.
+
+## References
+
+* O. Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005, Chapter 7.
+* D. Aldous, "Representations for partially exchangeable arrays of random variables", *Journal of
+  Multivariate Analysis* 11 (1981), 581–598.
+* O. Kallenberg, *Foundations of Modern Probability*, 3rd ed., Lemma 4.22, for the coding map.
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable sequences
+rather than arrays.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- Reading a sequence of paths as an array is measurable: it is the measurable equivalence
+`MeasurableEquiv.curry`, backwards. -/
+private theorem measurable_uncurry_path :
+    Measurable (Function.uncurry : (ℕ → ℕ → α) → ℕ × ℕ → α) := by
+  simpa only [MeasurableEquiv.coe_curry_symm] using (MeasurableEquiv.curry ℕ ℕ α).symm.measurable
+
+/-- **An array law is the uncurried path law of its row process.** A statement about the law of the
+row process therefore transports to one about the law of the array. -/
+theorem map_uncurry_pathLaw_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    (hX : ∀ p, AEMeasurable (X p) μ) :
+    (pathLaw μ (arrayRow X)).map Function.uncurry = μ.map fun ω p => X p ω := by
+  rw [pathLaw_def, AEMeasurable.map_map_of_aemeasurable measurable_uncurry_path.aemeasurable
+    (aemeasurable_pi_lambda _ fun i => aemeasurable_arrayRow hX i)]
+  congr 1
+  funext ω ⟨i, j⟩
+  simp
+
+section Coding
+
+variable [StandardBorelSpace α] [Nonempty α]
+
+/-- The law of the array coded by a parameter and one uniform variable per row, computed through
+its row process: it is the uncurried de Finetti barycenter of the parameter law. -/
+private theorem map_prod_unitIntervalCoding_array
+    (π : Measure (ProbabilityMeasure (ℕ → α))) [SFinite π] :
+    ((π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+        fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2)
+      = (deFinettiBarycenter π).map Function.uncurry := by
+  rw [← map_prod_unitIntervalCoding_eq_deFinettiBarycenter (α := ℕ → α) π,
+    Measure.map_map measurable_uncurry_path (measurable_unitIntervalCodingPath (α := ℕ → α))]
+  rfl
+
+/-- The same computation after reindexing the two axes: permuting the rows reindexes the sequence
+of coded paths, and permuting the columns pushes every coded path forward by the time
+permutation. -/
+private theorem map_prod_unitIntervalCoding_array_pairReindex
+    (π : Measure (ProbabilityMeasure (ℕ → α))) [SFinite π] (σ τ : Equiv.Perm ℕ) :
+    ((π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+        fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 (σ p.1)) (τ p.2))
+      = (((deFinettiBarycenter π).map (permReindex (α := ℕ → α) σ)).map
+          fun x i => permReindex (α := α) τ (x i)).map Function.uncurry := by
+  have hR := measurable_unitIntervalCodingPath (α := ℕ → α)
+  have hS : Measurable (permReindex (α := ℕ → α) σ) := measurable_reindex σ
+  have hT : Measurable fun x : ℕ → ℕ → α => fun i => permReindex (α := α) τ (x i) :=
+    measurable_pi_lambda _ fun i => (measurable_reindex τ).comp (measurable_pi_apply i)
+  rw [← map_prod_unitIntervalCoding_eq_deFinettiBarycenter (α := ℕ → α) π,
+    Measure.map_map hS hR, Measure.map_map hT (hS.comp hR),
+    Measure.map_map measurable_uncurry_path (hT.comp (hS.comp hR))]
+  rfl
+
+/-- **Coding a permutation-invariant mixing law gives a separately exchangeable array.** Draw a
+path law `P` from `π` and one uniform variable `ϑ i` per row, and let the `(i, j)`-entry be
+`unitIntervalCoding (ℕ → α) P (ϑ i) j`. Permuting the rows permutes the i.i.d. noise, so it always
+leaves the law alone; permuting the columns pushes `P` forward by that time permutation, so it
+leaves the law alone exactly because `π` is invariant under that pushforward. -/
+theorem separatelyExchangeable_unitIntervalCoding
+    (π : Measure (ProbabilityMeasure (ℕ → α))) [IsProbabilityMeasure π]
+    (hπ : ∀ τ : Equiv.Perm ℕ,
+      π.map (fun P => P.map (measurable_reindex (α := α) τ).aemeasurable) = π) :
+    SeparatelyExchangeable
+        (π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval)))
+      fun p q => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2 := by
+  refine separatelyExchangeable_iff.mpr fun σ τ => ?_
+  have hrow : (deFinettiBarycenter π).map (permReindex (α := ℕ → α) σ) = deFinettiBarycenter π :=
+    (exchangeableLaw_deFinettiBarycenter (π := π)).map_permReindex σ
+  have hcol : ((deFinettiBarycenter π).map fun x : ℕ → ℕ → α =>
+      fun i => permReindex (α := α) τ (x i)) = deFinettiBarycenter π := by
+    have hnat := map_pi_deFinettiBarycenter π (measurable_reindex (α := α) τ)
+    rw [hπ τ] at hnat
+    exact hnat
+  calc ((π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+          fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 (σ p.1)) (τ p.2))
+      = (((deFinettiBarycenter π).map (permReindex (α := ℕ → α) σ)).map
+          fun x i => permReindex (α := α) τ (x i)).map Function.uncurry :=
+        map_prod_unitIntervalCoding_array_pairReindex π σ τ
+    _ = (deFinettiBarycenter π).map Function.uncurry := by rw [hrow, hcol]
+    _ = (π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+          fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2 :=
+        (map_prod_unitIntervalCoding_array π).symm
+
+/-- Every entry of a coded array is measurable in the parameter and the noise. -/
+theorem measurable_unitIntervalCoding_entry (p : ℕ × ℕ) :
+    Measurable fun q : ProbabilityMeasure (ℕ → α) × (ℕ → unitInterval) =>
+      unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2 :=
+  (measurable_pi_apply p.2).comp ((measurable_uncurry_unitIntervalCoding (ℕ → α)).comp
+    (measurable_fst.prodMk ((measurable_pi_apply p.1).comp measurable_snd)))
+
+/-- **The coding representation of a separately exchangeable array.** Over a nonempty standard
+Borel state space, the law of a separately exchangeable array is the law of the array coded by a
+single random path law `P` and one independent uniform variable per row: the `(i, j)`-entry is
+`unitIntervalCoding (ℕ → α) P (ϑ i) j`.
+
+The mixing law `π` of `P` is the law of a directing measure for the row process, and it inherits
+the column symmetry as invariance under pushing a path law forward by a time permutation. -/
+theorem SeparatelyExchangeable.exists_arrayLaw_eq_map_unitIntervalCoding
+    {μ : Measure Ω} [IsProbabilityMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ∃ π : ProbabilityMeasure (ProbabilityMeasure (ℕ → α)),
+      (∀ τ : Equiv.Perm ℕ,
+          (π : Measure (ProbabilityMeasure (ℕ → α))).map
+            (fun P => P.map (measurable_reindex (α := α) τ).aemeasurable) = π) ∧
+        (μ.map fun ω p => X p ω) =
+          ((π : Measure (ProbabilityMeasure (ℕ → α))).prod
+              (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+            fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2 := by
+  obtain ⟨ν, hν, hinv⟩ := h.exists_directing_arrayRow_mixingLaw_invariant hX
+  have hν_meas : Measurable ν :=
+    (mixedIIDWith_of_conditionallyIIDWith hν).measurable_mixingRepresentative
+  have hprob : IsProbabilityMeasure (μ.map ν) :=
+    Measure.isProbabilityMeasure_map hν_meas.aemeasurable
+  refine ⟨⟨μ.map ν, hprob⟩, fun τ => ?_, ?_⟩
+  · have hmap : Measurable fun P : ProbabilityMeasure (ℕ → α) =>
+        P.map (measurable_reindex (α := α) τ).aemeasurable :=
+      ((Measure.measurable_map _ (measurable_reindex τ)).comp measurable_subtype_coe).subtype_mk
+    simp only [ProbabilityMeasure.coe_mk]
+    rw [AEMeasurable.map_map_of_aemeasurable hmap.aemeasurable hν_meas.aemeasurable]
+    exact hinv τ
+  · have hpath : pathLaw μ (arrayRow X) = deFinettiBarycenter (μ.map ν) := by
+      rw [deFinettiBarycenter_def]
+      exact pathLaw_eq_bind_infinitePi_of_mixedIIDWith (aemeasurable_arrayRow hX)
+        (mixedIIDWith_of_conditionallyIIDWith hν)
+    simp only [ProbabilityMeasure.coe_mk]
+    rw [map_prod_unitIntervalCoding_array (μ.map ν), ← hpath, map_uncurry_pathLaw_arrayRow hX]
+
+/-- **Separate exchangeability is exactly codability by a permutation-invariant mixing law.** Over
+a nonempty standard Borel state space, an array has the law of a coded array — one random path law
+and one independent uniform variable per row — exactly when it is separately exchangeable, the
+mixing law being invariant under pushing a path law forward by a time permutation. -/
+theorem separatelyExchangeable_iff_exists_coding {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ × ℕ → Ω → α} (hX : ∀ p, AEMeasurable (X p) μ) :
+    SeparatelyExchangeable μ X ↔
+      ∃ π : ProbabilityMeasure (ProbabilityMeasure (ℕ → α)),
+        (∀ τ : Equiv.Perm ℕ,
+            (π : Measure (ProbabilityMeasure (ℕ → α))).map
+              (fun P => P.map (measurable_reindex (α := α) τ).aemeasurable) = π) ∧
+          (μ.map fun ω p => X p ω) =
+            ((π : Measure (ProbabilityMeasure (ℕ → α))).prod
+                (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+              fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2 := by
+  refine ⟨fun h => h.exists_arrayLaw_eq_map_unitIntervalCoding hX, ?_⟩
+  rintro ⟨π, hπ, hlaw⟩
+  have : IsProbabilityMeasure (π : Measure (ProbabilityMeasure (ℕ → α))) := π.2
+  have hcoded := separatelyExchangeable_unitIntervalCoding
+    (π : Measure (ProbabilityMeasure (ℕ → α))) hπ
+  rw [separatelyExchangeable_iff_map_pairReindex
+    fun p => (measurable_unitIntervalCoding_entry p).aemeasurable] at hcoded
+  rw [separatelyExchangeable_iff_map_pairReindex hX]
+  simp only [hlaw]
+  exact hcoded
+
+end Coding
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR represents the law of a separately exchangeable array as the law of the array coded by one global random parameter and one independent uniform variable per row: for a nonempty standard Borel state space `α`, the `(i, j)`-entry of a separately exchangeable `X : ℕ × ℕ → Ω → α` has the law of `unitIntervalCoding (ℕ → α) P (ϑ i) j`, where `P` is a random path law drawn from a mixing law `π` and `ϑ` is an independent i.i.d. uniform sequence indexed by the rows. It also proves the converse — coding any mixing law that is invariant under pushing a path law forward by a permutation of the time coordinate produces a separately exchangeable array — so that over such an `α` separate exchangeability of an array is exactly codability by a permutation-invariant mixing law.

This advances the Layer 8 milestone "exchangeable arrays and the Aldous–Hoover representation" of `TauCetiRoadmap/Exchangeability/README.md`. That milestone's target is a functional representation, and `TauCeti/Probability/DeFinetti/Coding.lean` already supplies the sequence case (`deFinetti_coding`, `exchangeableLaw_iff_exists_coding`), described there as "the base of that tower"; the array files supply the row decomposition (`SeparatelyExchangeable.conditionallyIID_arrayRow`) and the inherited symmetry of the row mixing law (`SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq`). This is the step that turns those conditional-law statements into the functional form Aldous–Hoover is stated in, at the first level of the tower. What remains for that milestone after this PR is the second level: resolving a coded row path `unitIntervalCoding (ℕ → α) P (ϑ i)` further into a per-column and a per-cell source of randomness, which is Aldous's argument and is deliberately not attempted here — the module docstring says so explicitly rather than letting the name suggest otherwise.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"separately-exchangeable-array-row-coding"}-->

The new module is `TauCeti/Probability/Exchangeability/Arrays/Coding.lean`, joining the existing `Arrays/` subdirectory beside `Basic.lean` and `MixingLaw.lean`. It adds `map_uncurry_pathLaw_arrayRow` (an array law is the uncurried path law of its row process, the transport every statement is read along), `separatelyExchangeable_unitIntervalCoding` (the converse direction), `measurable_unitIntervalCoding_entry`, `SeparatelyExchangeable.exists_arrayLaw_eq_map_unitIntervalCoding` (the representation) and `separatelyExchangeable_iff_exists_coding` (the characterization). Two prerequisites go to their canonical homes rather than into the new file: `separatelyExchangeable_iff_map_pairReindex` in `Arrays/Basic.lean`, the process-to-array-law bridge for the predicate defined there, and `map_pi_deFinettiBarycenter` in `DeFinetti/Barycenter.lean`, naturality of the de Finetti barycenter in the state space, which is the general fact that makes the column symmetry computable and which no statement about arrays appears in.

Both array symmetries are read off the barycenter of the mixing law, since the row process of a coded array is the coded sequence in path space: permuting the rows is exchangeability of the barycenter, and permuting the columns is a coordinatewise pushforward, which by the new naturality lemma is the barycenter of the pushed-forward mixing law. Only the latter uses the hypothesis on the mixing law, which is why the row axis is symmetry-free and the column axis is exactly where the invariance is spent. The unit interval is written `unitInterval` rather than through the scoped notation `I`, because the same namespace exports a `σ` notation that collides with the permutation binder names used throughout `Arrays/`; the module docstring records this.

The mathematics follows Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Chapter 7, and Aldous, "Representations for partially exchangeable arrays of random variables" (1981), for the array statements, and Kallenberg, *Foundations of Modern Probability*, Lemma 4.22, for the coding map, which is Mathlib's `ProbabilityTheory.Kernel.exists_measurable_map_eq_unitInterval` as already packaged by `TauCeti.Probability.unitIntervalCoding`. No Mathlib PR material is vendored, and no material is adapted from `cameronfreer/exchangeability`, which treats exchangeable sequences rather than arrays.

🤖 Prepared with Claude Code
