### PR TITLE
feat(Multiquadratic): the 2-rank of Cl(ℚ(√-21)) is 2

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -56,7 +56,8 @@ theorem exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top :
   refine ⟨integralSqrt hx, minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
       norm_num at hq
       nlinarith [mul_self_nonneg q]), ?_⟩
-  rw [algebraMap_integralSqrt hx]
+  have hθx : ((integralSqrt hx : 𝓞 K) : K) = x := algebraMap_integralSqrt hx
+  rw [hθx]
   exact AdjoinRoot.adjoinRoot_eq_top
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -19,8 +19,8 @@ either of them.
 
 ## Main results
 
-* `TauCeti.NumberField.exists_isIntegralGen_adjoinRoot_sqrt_neg_twenty_one`: the model carries an
-  integral generator whose minimal polynomial is `X² + 21` and which generates the field over `ℚ`.
+* `TauCeti.NumberField.exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top`: the model has an
+  integral generator with minimal polynomial `X² + 21` generating the field over `ℚ`.
 -/
 
 public section
@@ -42,7 +42,7 @@ instance irreducible_sqrt_neg_twenty_one : Fact (Irreducible (X ^ 2 - C (-21 : �
 /-- The concrete model `AdjoinRoot (X² + 21)` of `ℚ(√-21)` carries an integral generator with
 minimal polynomial `X² + 21` generating the field over `ℚ`: the presentation data shared by the
 class-number and `2`-rank worked examples for this field. -/
-theorem exists_isIntegralGen_adjoinRoot_sqrt_neg_twenty_one :
+theorem exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top :
     ∃ θ : 𝓞 (AdjoinRoot (X ^ 2 - C (-21 : ℚ))),
       minpoly ℤ θ = X ^ 2 - C (-21 : ℤ) ∧
         Algebra.adjoin ℚ {(θ : AdjoinRoot (X ^ 2 - C (-21 : ℚ)))} = ⊤ := by

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -30,7 +30,11 @@ open scoped NumberField
 
 namespace TauCeti.NumberField
 
-local instance : Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
+/-- `X² + 21` is irreducible over `ℚ`, so `AdjoinRoot (X² + 21)` is a field. Exported (rather than
+declared `local` in each consumer) with an explicit, field-specific name: an anonymous instance
+would receive an auto-generated name that ignores the radicand, colliding with the sibling
+`ℚ(√-N)` files' instances when they are imported together. -/
+instance irreducible_sqrt_neg_twenty_one : Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
   exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
     (fun q _ => by nlinarith [sq_nonneg q])⟩
 

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -6,7 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.AdjoinRoot
-public import TauCeti.NumberTheory.NumberField.IntegralSqrt
+public import Mathlib.NumberTheory.NumberField.Basic
+import TauCeti.NumberTheory.NumberField.IntegralSqrt
 import Mathlib.FieldTheory.KummerPolynomial
 
 /-!

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -56,12 +56,7 @@ theorem exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top :
   refine ⟨integralSqrt hx, minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
       norm_num at hq
       nlinarith [mul_self_nonneg q]), ?_⟩
-  have hfne : (X ^ 2 - C (-21 : ℚ)) ≠ 0 :=
-    (monic_X_pow_sub_C (-21 : ℚ) (by norm_num)).ne_zero
-  have hpb := (AdjoinRoot.powerBasis (f := X ^ 2 - C (-21 : ℚ)) hfne).adjoin_gen_eq_top
-  rw [AdjoinRoot.powerBasis_gen] at hpb
-  have hθx : ((integralSqrt hx : 𝓞 K) : K) = x := algebraMap_integralSqrt hx
-  rw [hθx]
-  exact hpb
+  rw [algebraMap_integralSqrt hx]
+  exact AdjoinRoot.adjoinRoot_eq_top
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -30,11 +30,12 @@ open scoped NumberField
 
 namespace TauCeti.NumberField
 
-/-- `X² + 21` is irreducible over `ℚ`, so `AdjoinRoot (X² + 21)` is a field. Exported (rather than
-declared `local` in each consumer) with an explicit, field-specific name: an anonymous instance
-would receive an auto-generated name that ignores the radicand, colliding with the sibling
-`ℚ(√-N)` files' instances when they are imported together. -/
-instance irreducible_sqrt_neg_twenty_one : Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
+/-- `X² + 21` is irreducible over `ℚ`, so `AdjoinRoot (X² + 21)` is a field. The instance carries an
+explicit, field-specific name because an anonymous `Fact (Irreducible …)` instance receives an
+auto-generated name that ignores the radicand: the `-21` and `-5` instances would then collide under
+one name when the whole library is loaded for the axioms audit. -/
+local instance fact_irreducible_sqrt_neg_twenty_one :
+    Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
   exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
     (fun q _ => by nlinarith [sq_nonneg q])⟩
 

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -30,12 +30,12 @@ open scoped NumberField
 
 namespace TauCeti.NumberField
 
-/-- `X² + 21` is irreducible over `ℚ`, so `AdjoinRoot (X² + 21)` is a field. The instance carries an
-explicit, field-specific name because an anonymous `Fact (Irreducible …)` instance receives an
-auto-generated name that ignores the radicand: the `-21` and `-5` instances would then collide under
-one name when the whole library is loaded for the axioms audit. -/
-local instance fact_irreducible_sqrt_neg_twenty_one :
-    Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
+/-- `X² + 21` is irreducible over `ℚ`, so `AdjoinRoot (X² + 21)` is a field. Declared once here (and
+reused via `public import` by both worked-example modules) with an explicit, field-specific name: an
+anonymous `Fact (Irreducible …)` instance receives an auto-generated name that ignores the radicand,
+so the `-21` and `-5` instances would collide under one name when the whole library is loaded for
+the axioms audit. -/
+instance irreducible_sqrt_neg_twenty_one : Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
   exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
     (fun q _ => by nlinarith [sq_nonneg q])⟩
 

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.AdjoinRoot
+public import TauCeti.NumberTheory.NumberField.IntegralSqrt
+import Mathlib.FieldTheory.KummerPolynomial
+
+/-!
+# The `AdjoinRoot (X² + 21)` model of `ℚ(√-21)`
+
+The concrete number field `AdjoinRoot (X² + 21)` serving as the canonical model of `ℚ(√-21)`,
+together with its integral generator. This presentation datum is foundational: it is shared by both
+the class-number and the `2`-rank worked examples for this field, so it lives here rather than in
+either of them.
+
+## Main results
+
+* `TauCeti.NumberField.exists_isIntegralGen_adjoinRoot_sqrt_neg_twenty_one`: the model carries an
+  integral generator whose minimal polynomial is `X² + 21` and which generates the field over `ℚ`.
+-/
+
+public section
+
+open NumberField Polynomial
+open scoped NumberField
+
+namespace TauCeti.NumberField
+
+local instance : Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
+  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+    (fun q _ => by nlinarith [sq_nonneg q])⟩
+
+/-- The concrete model `AdjoinRoot (X² + 21)` of `ℚ(√-21)` carries an integral generator with
+minimal polynomial `X² + 21` generating the field over `ℚ`: the presentation data shared by the
+class-number and `2`-rank worked examples for this field. -/
+theorem exists_isIntegralGen_adjoinRoot_sqrt_neg_twenty_one :
+    ∃ θ : 𝓞 (AdjoinRoot (X ^ 2 - C (-21 : ℚ))),
+      minpoly ℤ θ = X ^ 2 - C (-21 : ℤ) ∧
+        Algebra.adjoin ℚ {(θ : AdjoinRoot (X ^ 2 - C (-21 : ℚ)))} = ⊤ := by
+  let K := AdjoinRoot (X ^ 2 - C (-21 : ℚ))
+  let x : K := AdjoinRoot.root (X ^ 2 - C (-21 : ℚ))
+  have hx : x ^ 2 = algebraMap ℤ K (-21 : ℤ) := by
+    have hroot := AdjoinRoot.eval₂_root (X ^ 2 - C (-21 : ℚ))
+    rw [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C, ← AdjoinRoot.algebraMap_eq, sub_eq_zero] at hroot
+    rw [hroot, IsScalarTower.algebraMap_apply ℤ ℚ K]
+    norm_num
+  refine ⟨integralSqrt hx, minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
+      norm_num at hq
+      nlinarith [mul_self_nonneg q]), ?_⟩
+  have hfne : (X ^ 2 - C (-21 : ℚ)) ≠ 0 :=
+    (monic_X_pow_sub_C (-21 : ℚ) (by norm_num)).ne_zero
+  have hpb := (AdjoinRoot.powerBasis (f := X ^ 2 - C (-21 : ℚ)) hfne).adjoin_gen_eq_top
+  rw [AdjoinRoot.powerBasis_gen] at hpb
+  have hθx : ((integralSqrt hx : 𝓞 K) : K) = x := algebraMap_integralSqrt hx
+  rw [hθx]
+  exact hpb
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
@@ -8,9 +8,9 @@ module
 public import Mathlib.NumberTheory.NumberField.ClassNumber
 public import Mathlib.RingTheory.AdjoinRoot
 import Mathlib.Analysis.Real.Pi.Bounds
+import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
 import TauCeti.NumberTheory.Multiquadratic.Quadratic.RamifiedPrime.Independence
 import TauCeti.NumberTheory.NumberField.ClassGroupElementaryTwoQuotient
-import TauCeti.NumberTheory.NumberField.IntegralSqrt
 import TauCeti.NumberTheory.NumberField.PrimeIdeal
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 import TauCeti.NumberTheory.NumberField.Quadratic.RingOfIntegers
@@ -313,26 +313,7 @@ has class number `4`. -/
 @[simp]
 theorem classNumber_adjoinRoot_sqrt_neg_twenty_one_eq_four :
     NumberField.classNumber (AdjoinRoot (X ^ 2 - C (-21 : ℚ))) = 4 := by
-  let K := AdjoinRoot (X ^ 2 - C (-21 : ℚ))
-  let x : K := AdjoinRoot.root (X ^ 2 - C (-21 : ℚ))
-  have hx : x ^ 2 = algebraMap ℤ K (-21 : ℤ) := by
-    have hroot := AdjoinRoot.eval₂_root (X ^ 2 - C (-21 : ℚ))
-    rw [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C, ← AdjoinRoot.algebraMap_eq, sub_eq_zero] at hroot
-    rw [hroot, IsScalarTower.algebraMap_apply ℤ ℚ K]
-    norm_num
-  let θ : 𝓞 K := integralSqrt hx
-  have hmin : minpoly ℤ θ = X ^ 2 - C (-21 : ℤ) :=
-    minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
-      norm_num at hq
-      nlinarith [mul_self_nonneg q])
-  have hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤ := by
-    have hfne : (X ^ 2 - C (-21 : ℚ)) ≠ 0 :=
-      (monic_X_pow_sub_C (-21 : ℚ) (by norm_num)).ne_zero
-    have hpb := (AdjoinRoot.powerBasis (f := X ^ 2 - C (-21 : ℚ)) hfne).adjoin_gen_eq_top
-    rw [AdjoinRoot.powerBasis_gen] at hpb
-    have hθx : (θ : K) = x := algebraMap_integralSqrt hx
-    rw [hθx]
-    exact hpb
+  obtain ⟨θ, hmin, hgen⟩ := exists_isIntegralGen_adjoinRoot_sqrt_neg_twenty_one
   exact classNumber_eq_four_of_minpoly_eq_X_sq_add_twenty_one hmin hgen
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.NumberField.ClassNumber
-public import Mathlib.RingTheory.AdjoinRoot
 public import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
 import Mathlib.Analysis.Real.Pi.Bounds
 import TauCeti.NumberTheory.Multiquadratic.Quadratic.RamifiedPrime.Independence

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
@@ -303,6 +303,11 @@ theorem classNumber_eq_four_of_minpoly_eq_X_sq_add_twenty_one
   obtain ⟨n, hn⟩ := hfourdvd
   omega
 
+local instance irreducible_sqrt_neg_twenty_one :
+    Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
+  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+    (fun q _ => by nlinarith [sq_nonneg q])⟩
+
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`,
 has class number `4`. -/
 @[simp]

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
@@ -303,11 +303,6 @@ theorem classNumber_eq_four_of_minpoly_eq_X_sq_add_twenty_one
   obtain ⟨n, hn⟩ := hfourdvd
   omega
 
-local instance irreducible_sqrt_neg_twenty_one :
-    Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
-  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
-    (fun q _ => by nlinarith [sq_nonneg q])⟩
-
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`,
 has class number `4`. -/
 @[simp]

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
@@ -7,8 +7,8 @@ module
 
 public import Mathlib.NumberTheory.NumberField.ClassNumber
 public import Mathlib.RingTheory.AdjoinRoot
+public import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
 import Mathlib.Analysis.Real.Pi.Bounds
-import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
 import TauCeti.NumberTheory.Multiquadratic.Quadratic.RamifiedPrime.Independence
 import TauCeti.NumberTheory.NumberField.ClassGroupElementaryTwoQuotient
 import TauCeti.NumberTheory.NumberField.PrimeIdeal
@@ -302,11 +302,6 @@ theorem classNumber_eq_four_of_minpoly_eq_X_sq_add_twenty_one
   -- The only multiple of `4` between `4` and `5` is `4`.
   obtain ⟨n, hn⟩ := hfourdvd
   omega
-
-local instance irreducible_sqrt_neg_twenty_one :
-    Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
-  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
-    (fun q _ => by nlinarith [sq_nonneg q])⟩
 
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`,
 has class number `4`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
@@ -308,7 +308,7 @@ has class number `4`. -/
 @[simp]
 theorem classNumber_adjoinRoot_sqrt_neg_twenty_one_eq_four :
     NumberField.classNumber (AdjoinRoot (X ^ 2 - C (-21 : ℚ))) = 4 := by
-  obtain ⟨θ, hmin, hgen⟩ := exists_isIntegralGen_adjoinRoot_sqrt_neg_twenty_one
+  obtain ⟨θ, hmin, hgen⟩ := exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top
   exact classNumber_eq_four_of_minpoly_eq_X_sq_add_twenty_one hmin hgen
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
+import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminants
+import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
+
+/-!
+# The `2`-rank of the class group of `ℚ(√-21)`
+
+Applying the genus-theoretic `2`-rank formula `2-rank Cl(K) = t - 1` to `K = ℚ(√-21)`. The
+fundamental discriminant is `-84 = (-4) · (-3) · (-7)`, a product of three prime discriminants, so
+`t = 3` rational primes ramify (`2`, `3` and `7`) and the `2`-rank of the class group is `2`.
+
+This corroborates the independently proved `NumberField.classNumber ℚ(√-21) = 4`
+(`MinusTwentyOne/ClassNumber.lean`): the class group is `(ℤ/2ℤ)²`, whose `2`-rank is indeed `2`, so
+genus theory (predicting `t - 1 = 2` purely from ramification) and the direct class-number
+computation agree.
+
+## Main results
+
+* `TauCeti.Multiquadratic.twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one`: the
+  presentation-independent statement.
+* `TauCeti.Multiquadratic.twoRank_adjoinRoot_sqrt_neg_twenty_one_eq_two`: on the concrete model
+  `AdjoinRoot (X² + 21)`.
+-/
+
+public section
+
+open Polynomial NumberField
+open scoped NumberField
+
+namespace TauCeti.Multiquadratic
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K}
+
+/-- **The `2`-rank of the class group of `ℚ(√-21)` is `2`.** Its fundamental discriminant `-84`
+factors as `(-4) · (-3) · (-7)` into three prime discriminants, so three rational primes ramify
+(`t = 3`) and `2-rank Cl = t - 1 = 2`. This corroborates `NumberField.classNumber ℚ(√-21) = 4`
+(`Cl ≅ (ℤ/2ℤ)²`). -/
+theorem twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one
+    (hmin : minpoly ℤ θ = X ^ 2 - C (-21 : ℤ)) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    TauCeti.ClassGroup.twoRank (𝓞 K) = 2 := by
+  have hsf : Squarefree (-21 : ℤ) := by
+    rw [← Int.squarefree_natAbs]
+    simpa using (Nat.squarefree_mul (by decide : Nat.Coprime 3 7)).mpr
+      ⟨(by decide : Nat.Prime 3).squarefree, (by decide : Nat.Prime 7).squarefree⟩
+  have hs : ∀ P ∈ ({-4, -3, -7} : Finset ℤ), IsPrimeDiscriminant P := by
+    intro P hP
+    fin_cases hP
+    · exact isPrimeDiscriminant_neg_four
+    · simpa [oddPrimeDiscriminant_of_mod_four_eq_three (by norm_num : 3 % 4 = 3)]
+        using isPrimeDiscriminant_oddPrimeDiscriminant (p := 3) (by decide) (by decide)
+    · simpa [oddPrimeDiscriminant_of_mod_four_eq_three (by norm_num : 7 % 4 = 3)]
+        using isPrimeDiscriminant_oddPrimeDiscriminant (p := 7) (by decide) (by decide)
+  have heven : ∀ P ∈ ({-4, -3, -7} : Finset ℤ), ∀ Q ∈ ({-4, -3, -7} : Finset ℤ),
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant Q → P = Q := by
+    intro P hP Q hQ
+    fin_cases hP <;> fin_cases hQ <;> simp only [IsEvenPrimeDiscriminant] <;> decide
+  have hprod : ∏ P ∈ ({-4, -3, -7} : Finset ℤ), P = fundamentalDiscriminant (-21 : ℤ) := by
+    rw [Finset.prod_insert (by decide : (-4 : ℤ) ∉ ({-3, -7} : Finset ℤ)),
+      Finset.prod_insert (by decide : (-3 : ℤ) ∉ ({-7} : Finset ℤ)), Finset.prod_singleton,
+      fundamentalDiscriminant_of_mod_four_ne_one (by decide : (-21 : ℤ) % 4 ≠ 1)]
+    ring
+  have hncard : (ramifiedPrimes K).ncard = 3 := by
+    rw [ncard_ramifiedPrimes_eq_card hmin hgen hsf hs heven hprod,
+      Finset.card_insert_of_notMem (by decide : (-4 : ℤ) ∉ ({-3, -7} : Finset ℤ)),
+      Finset.card_insert_of_notMem (by decide : (-3 : ℤ) ∉ ({-7} : Finset ℤ)),
+      Finset.card_singleton]
+  rw [twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf (by norm_num), hncard]
+
+local instance : Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
+  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+    (fun q _ => by nlinarith [sq_nonneg q])⟩
+
+/-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`, has
+class-group `2`-rank `2`. Not `@[simp]`: the `@[simp]` lemma `twoRank_def` unfolds the left-hand
+side `twoRank _`, so this closed form is not in simp-normal form (`simpNF` rejects it), unlike the
+non-unfolded `classNumber` companion. -/
+theorem twoRank_adjoinRoot_sqrt_neg_twenty_one_eq_two :
+    TauCeti.ClassGroup.twoRank (𝓞 (AdjoinRoot (X ^ 2 - C (-21 : ℚ)))) = 2 := by
+  obtain ⟨θ, hmin, hgen⟩ := NumberField.exists_isIntegralGen_adjoinRoot_sqrt_neg_twenty_one
+  exact twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one hmin hgen
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
+public import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
 import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminants
-import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
 
 /-!
 # The `2`-rank of the class group of `ℚ(√-21)`
@@ -72,11 +72,6 @@ theorem twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one
       Finset.card_insert_of_notMem (by decide : (-3 : ℤ) ∉ ({-7} : Finset ℤ)),
       Finset.card_singleton]
   rw [twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf (by norm_num), hncard]
-
-local instance fact_irreducible_sqrt_neg_twenty_one :
-    Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
-  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
-    (fun q _ => by nlinarith [sq_nonneg q])⟩
 
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`, has
 class-group `2`-rank `2`. Not `@[simp]`: the `@[simp]` lemma `twoRank_def` unfolds the left-hand

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
@@ -79,7 +79,7 @@ side `twoRank _`, so this closed form is not in simp-normal form (`simpNF` rejec
 non-unfolded `classNumber` companion. -/
 theorem twoRank_adjoinRoot_sqrt_neg_twenty_one_eq_two :
     TauCeti.ClassGroup.twoRank (𝓞 (AdjoinRoot (X ^ 2 - C (-21 : ℚ)))) = 2 := by
-  obtain ⟨θ, hmin, hgen⟩ := NumberField.exists_isIntegralGen_adjoinRoot_sqrt_neg_twenty_one
+  obtain ⟨θ, hmin, hgen⟩ := NumberField.exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top
   exact twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one hmin hgen
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
@@ -73,10 +73,6 @@ theorem twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one
       Finset.card_singleton]
   rw [twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf (by norm_num), hncard]
 
-local instance : Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
-  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
-    (fun q _ => by nlinarith [sq_nonneg q])⟩
-
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`, has
 class-group `2`-rank `2`. Not `@[simp]`: the `@[simp]` lemma `twoRank_def` unfolds the left-hand
 side `twoRank _`, so this closed form is not in simp-normal form (`simpNF` rejects it), unlike the

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
@@ -73,6 +73,11 @@ theorem twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one
       Finset.card_singleton]
   rw [twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf (by norm_num), hncard]
 
+local instance fact_irreducible_sqrt_neg_twenty_one :
+    Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
+  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+    (fun q _ => by nlinarith [sq_nonneg q])⟩
+
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`, has
 class-group `2`-rank `2`. Not `@[simp]`: the `@[simp]` lemma `twoRank_def` unfolds the left-hand
 side `twoRank _`, so this closed form is not in simp-normal form (`simpNF` rejects it), unlike the


### PR DESCRIPTION
The second worked example of the genus-theoretic 2-rank formula `2-rank Cl(K) = t - 1` (`twoRank_eq_ncard_ramifiedPrimes_sub_one`): for `K = ℚ(√-21)`, the fundamental discriminant `-84 = (-4)·(-3)·(-7)` is a product of three prime discriminants, so `t = 3` rational primes ramify (`2`, `3`, `7`) and the class-group 2-rank is `2`.

This **corroborates** the independently proved `NumberField.classNumber ℚ(√-21) = 4` (`MinusTwentyOne/ClassNumber.lean`): `Cl ≅ (ℤ/2ℤ)²` has 2-rank exactly `2`, so genus theory (predicting `t - 1 = 2` purely from ramification) and the direct class-number computation agree. It is the exact analog, at the next radicand, of the ℚ(√-5) worked example (`MinusFive/TwoRank.lean`).

**Refactor.** The shared `AdjoinRoot (X²+21)` integral generator is extracted into a new foundational `MinusTwentyOne/Basic.lean` (mirroring `MinusFive/Basic.lean`), imported by both `ClassNumber.lean` and the new `TwoRank.lean`, so neither worked example depends on the other's later theory.

**Roadmap node.** `TauCetiRoadmap/Multiquadratic/README.md`, heading *### Layer 3: the genus field and the 2-rank theorem (the summit)*, "Worked examples" — ℚ(√-21) (discriminant -84), the second application of the merged 2-rank theorem to a specific field. No new axioms.

Roadmap: Multiquadratic
