### PR TITLE
feat: the lower incomplete gamma function and its regularization

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
@@ -1,0 +1,375 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
+public import Mathlib.MeasureTheory.Integral.DominatedConvergence
+public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+
+/-!
+# The lower incomplete gamma function
+
+For a positive shape parameter `s` this file introduces
+
+* `TauCeti.lowerIncompleteGamma s x = ∫ t in 0..x, t ^ (s - 1) * exp (-t)`, the truncation of
+  Euler's integral at `x`, extended by `0` for `x ≤ 0` and for `s ≤ 0`; and
+* `TauCeti.regularizedGamma s x = lowerIncompleteGamma s x / Real.Gamma s`, its normalization,
+  again extended by `0` for `s ≤ 0`.
+
+Classically these are `γ(s, x)` and `P(s, x)`. The regularized function is the cumulative
+distribution function of a Gamma law, which is where this file is headed; the two totalizations
+above make that cdf agree with the clamping conventions a cdf needs, below the support and outside
+the parameter range.
+
+## Main definitions
+
+* `TauCeti.lowerIncompleteGamma` — the lower incomplete gamma function `γ(s, x)`;
+* `TauCeti.regularizedGamma` — the regularized lower incomplete gamma function `P(s, x)`.
+
+## Main results
+
+* `TauCeti.lowerIncompleteGamma_eq_integral` and `TauCeti.regularizedGamma_eq_div` — the
+  characteristic descriptions in the valid range, replacing the clamped definitions;
+* `TauCeti.intervalIntegrable_rpow_mul_exp_neg` — convergence: the integrand is interval
+  integrable on every interval in `[0, ∞)`, including at the singularity `0` for `s < 1`;
+* `TauCeti.continuous_lowerIncompleteGamma`, `TauCeti.continuous_regularizedGamma` — continuity on
+  all of `ℝ`, in particular at `x = 0`, where for `s < 1` the integrand blows up;
+* `TauCeti.monotone_lowerIncompleteGamma`, `TauCeti.monotone_regularizedGamma` — monotonicity,
+  and `TauCeti.lowerIncompleteGamma_nonneg`, `TauCeti.regularizedGamma_nonneg`,
+  `TauCeti.regularizedGamma_le_one` — the range;
+* `TauCeti.hasDerivAt_lowerIncompleteGamma`, `TauCeti.hasDerivAt_regularizedGamma` and the
+  companion `deriv` lemmas — differentiability, for `0 < x` only;
+* `TauCeti.lowerIncompleteGamma_add_one` — the recurrence
+  `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)`;
+* `TauCeti.tendsto_lowerIncompleteGamma_atTop`, `TauCeti.tendsto_regularizedGamma_atTop` — the
+  limits `Real.Gamma s` and `1` as `x → ∞`, with the resulting bounds
+  `TauCeti.lowerIncompleteGamma_le_Gamma` and `TauCeti.regularizedGamma_le_one`;
+* `TauCeti.regularizedGamma_one` — `P(1, x) = 1 - e ^ (-x)` for `0 ≤ x`, the exponential cdf.
+
+## Implementation
+
+`Real.Gamma` is *not* the value of Euler's integral outside `0 < s`, so the definition of
+`regularizedGamma` guards on `0 < s` rather than dividing by `Real.Gamma s` unconditionally.
+
+The recurrence is obtained from Mathlib's `Complex.partialGamma_add_one`, whose proof performs the
+integration by parts on `Set.Ioo 0 x` — the endpoint `0` has to be avoided because `t ^ s` is not
+differentiable there for `s < 1`. The bridge is `TauCeti.ofReal_lowerIncompleteGamma`, which
+identifies `γ(s, x)` with `Complex.partialGamma s x` for real `s`.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 2, the "Lower incomplete gamma"
+  target.
+* *NIST Digital Library of Mathematical Functions*, [ch. 8](https://dlmf.nist.gov/8),
+  especially [§8.2](https://dlmf.nist.gov/8.2).
+-/
+
+public section
+
+noncomputable section
+
+open Filter MeasureTheory Set
+
+open scoped Interval Topology
+
+namespace TauCeti
+
+variable {s x : ℝ}
+
+/-! ### Convergence of the truncated Euler integral -/
+
+/-- Euler's integrand `t ^ p * exp (-t)` is interval integrable on any interval contained in
+`[0, ∞)`, for `-1 < p`.
+
+This is the interval form of Mathlib's `Real.GammaIntegral_convergent`; for `p < 0` the integrand
+is unbounded at `0`, so the statement is not a mere continuity argument. The shape parameter `s` of
+`TauCeti.lowerIncompleteGamma` enters as `p = s - 1`. -/
+theorem intervalIntegrable_rpow_mul_exp_neg {p : ℝ} (hp : -1 < p) {a b : ℝ} (ha : 0 ≤ a)
+    (hb : 0 ≤ b) :
+    IntervalIntegrable (fun t : ℝ => t ^ p * Real.exp (-t)) volume a b := by
+  have hsub : Ι a b ⊆ Ioi (0 : ℝ) := by
+    intro t ht
+    rw [Set.uIoc_eq_union] at ht
+    rcases ht with ht | ht
+    · exact lt_of_le_of_lt ha ht.1
+    · exact lt_of_le_of_lt hb ht.1
+  have h := Real.GammaIntegral_convergent (s := p + 1) (by linarith)
+  rw [add_sub_cancel_right] at h
+  rw [intervalIntegrable_iff]
+  exact (h.mono_set hsub).congr_fun (fun t _ => mul_comm _ _) measurableSet_uIoc
+
+/-! ### The definitions -/
+
+/-- The lower incomplete gamma function `γ(s, x) = ∫ t in 0..x, t ^ (s - 1) * exp (-t)`.
+
+It is `0` for `x ≤ 0`, where the truncated integral is empty, and `0` for `s ≤ 0`, where Euler's
+integral diverges at the origin. -/
+def lowerIncompleteGamma (s x : ℝ) : ℝ :=
+  if 0 < s then ∫ t in (0 : ℝ)..max x 0, t ^ (s - 1) * Real.exp (-t) else 0
+
+/-- The regularized lower incomplete gamma function `P(s, x) = γ(s, x) / Γ(s)`, extended by `0`
+outside the valid range `0 < s` of the shape parameter. -/
+def regularizedGamma (s x : ℝ) : ℝ :=
+  if 0 < s then lowerIncompleteGamma s x / Real.Gamma s else 0
+
+/-- In the valid range, `γ(s, x)` is the truncated Euler integral. -/
+theorem lowerIncompleteGamma_eq_integral (hs : 0 < s) (hx : 0 ≤ x) :
+    lowerIncompleteGamma s x = ∫ t in (0 : ℝ)..x, t ^ (s - 1) * Real.exp (-t) := by
+  rw [lowerIncompleteGamma, ite_eq_left hs, max_eq_left hx]
+
+/-- In the valid range of the shape parameter, `P(s, x)` is `γ(s, x)` normalized by `Γ(s)`. -/
+theorem regularizedGamma_eq_div (hs : 0 < s) (x : ℝ) :
+    regularizedGamma s x = lowerIncompleteGamma s x / Real.Gamma s := by
+  rw [regularizedGamma, ite_eq_left hs]
+
+/-- Outside the valid range of the shape parameter, `γ(s, x)` is `0`. -/
+theorem lowerIncompleteGamma_of_nonpos_left (hs : s ≤ 0) (x : ℝ) :
+    lowerIncompleteGamma s x = 0 :=
+  ite_eq_right (not_lt.2 hs)
+
+/-- Outside the valid range of the shape parameter, `P(s, x)` is `0`. -/
+theorem regularizedGamma_of_nonpos_left (hs : s ≤ 0) (x : ℝ) : regularizedGamma s x = 0 :=
+  ite_eq_right (not_lt.2 hs)
+
+/-- Below the support, `γ(s, x)` is `0`. -/
+theorem lowerIncompleteGamma_of_nonpos_right (s : ℝ) (hx : x ≤ 0) :
+    lowerIncompleteGamma s x = 0 := by
+  rw [lowerIncompleteGamma, max_eq_right hx]
+  simp
+
+/-- Below the support, `P(s, x)` is `0`. -/
+theorem regularizedGamma_of_nonpos_right (s : ℝ) (hx : x ≤ 0) : regularizedGamma s x = 0 := by
+  rw [regularizedGamma, lowerIncompleteGamma_of_nonpos_right s hx]
+  simp
+
+@[simp]
+theorem lowerIncompleteGamma_zero_right (s : ℝ) : lowerIncompleteGamma s 0 = 0 :=
+  lowerIncompleteGamma_of_nonpos_right s le_rfl
+
+@[simp]
+theorem regularizedGamma_zero_right (s : ℝ) : regularizedGamma s 0 = 0 :=
+  regularizedGamma_of_nonpos_right s le_rfl
+
+/-- `γ(s, ·)` is the truncated Euler integral read at `max x 0`.
+
+This is the form in which the global regularity statements below are proved: the clamping is a
+continuous reparametrization, and the primitive itself is only well behaved on `[0, ∞)`. -/
+private theorem lowerIncompleteGamma_eq_comp (hs : 0 < s) :
+    lowerIncompleteGamma s =
+      (fun y : ℝ => ∫ t in (0 : ℝ)..y, t ^ (s - 1) * Real.exp (-t)) ∘ fun x : ℝ => max x 0 := by
+  funext y
+  rw [Function.comp_apply, lowerIncompleteGamma, ite_eq_left hs]
+
+/-! ### Positivity, monotonicity and regularity -/
+
+/-- `γ(s, x)` is nonnegative, for every parameter value. -/
+theorem lowerIncompleteGamma_nonneg (s x : ℝ) : 0 ≤ lowerIncompleteGamma s x := by
+  rw [lowerIncompleteGamma]
+  split
+  · exact intervalIntegral.integral_nonneg (le_max_right x 0) fun t ht =>
+      mul_nonneg (Real.rpow_nonneg ht.1 _) (Real.exp_pos _).le
+  · exact le_rfl
+
+/-- `P(s, x)` is nonnegative, for every parameter value. -/
+theorem regularizedGamma_nonneg (s x : ℝ) : 0 ≤ regularizedGamma s x := by
+  rw [regularizedGamma]
+  split
+  · exact div_nonneg (lowerIncompleteGamma_nonneg s x) (Real.Gamma_nonneg_of_nonneg (by linarith))
+  · exact le_rfl
+
+/-- `γ(s, ·)` is monotone: it accumulates a nonnegative integrand. -/
+theorem monotone_lowerIncompleteGamma (s : ℝ) : Monotone (lowerIncompleteGamma s) := by
+  rcases le_or_gt s 0 with hs | hs
+  · rw [funext (lowerIncompleteGamma_of_nonpos_left hs)]
+    exact monotone_const
+  intro u v huv
+  rcases le_or_gt v 0 with hv | hv
+  · rw [lowerIncompleteGamma_of_nonpos_right _ (huv.trans hv),
+      lowerIncompleteGamma_of_nonpos_right _ hv]
+  rcases le_or_gt u 0 with hu | hu
+  · rw [lowerIncompleteGamma_of_nonpos_right _ hu]
+    exact lowerIncompleteGamma_nonneg _ _
+  · rw [lowerIncompleteGamma_eq_integral hs hu.le, lowerIncompleteGamma_eq_integral hs hv.le,
+      ← intervalIntegral.integral_add_adjacent_intervals
+        (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) le_rfl hu.le)
+        (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) hu.le hv.le)]
+    refine le_add_of_nonneg_right (intervalIntegral.integral_nonneg huv fun t ht => ?_)
+    exact mul_nonneg (Real.rpow_nonneg (hu.le.trans ht.1) _) (Real.exp_pos _).le
+
+/-- `P(s, ·)` is monotone. Together with `TauCeti.regularizedGamma_nonneg`,
+`TauCeti.regularizedGamma_le_one`, `TauCeti.continuous_regularizedGamma` and
+`TauCeti.tendsto_regularizedGamma_atTop` this is everything a cumulative distribution function
+must satisfy. -/
+theorem monotone_regularizedGamma (s : ℝ) : Monotone (regularizedGamma s) := by
+  rcases le_or_gt s 0 with hs | hs
+  · rw [funext (regularizedGamma_of_nonpos_left hs)]
+    exact monotone_const
+  intro u v huv
+  rw [regularizedGamma_eq_div hs, regularizedGamma_eq_div hs]
+  gcongr
+  exact monotone_lowerIncompleteGamma s huv
+
+/-- The truncated Euler integral is continuous in its upper limit on `[0, ∞)`. -/
+private theorem continuousOn_intervalIntegral_rpow_mul_exp_neg (hs : 0 < s) :
+    ContinuousOn (fun y : ℝ => ∫ t in (0 : ℝ)..y, t ^ (s - 1) * Real.exp (-t)) (Ici 0) := by
+  intro y hy
+  have hy' : (0 : ℝ) ≤ y := hy
+  have hmem : Icc (0 : ℝ) (y + 1) ∈ 𝓝[Ici (0 : ℝ)] y := by
+    rw [← Set.Ici_inter_Iic]
+    exact inter_mem_nhdsWithin _ (Iic_mem_nhds (by linarith))
+  refine ContinuousWithinAt.mono_of_mem_nhdsWithin ?_ hmem
+  have huIcc : Set.uIcc (0 : ℝ) (y + 1) = Icc 0 (y + 1) := Set.uIcc_of_le (by linarith)
+  have := intervalIntegral.continuousOn_primitive_interval' (a := (0 : ℝ)) (b₁ := (0 : ℝ))
+    (b₂ := y + 1) (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) le_rfl
+      (by linarith))
+    (by rw [huIcc]; exact ⟨le_rfl, by linarith⟩)
+  rw [huIcc] at this
+  exact this y ⟨hy', by linarith⟩
+
+/-- `γ(s, ·)` is continuous on all of `ℝ`.
+
+For `s < 1` this includes the point `x = 0`, where the integrand is unbounded; the integral is
+nevertheless convergent there, by `TauCeti.intervalIntegrable_rpow_mul_exp_neg`. -/
+theorem continuous_lowerIncompleteGamma (s : ℝ) : Continuous (lowerIncompleteGamma s) := by
+  rcases le_or_gt s 0 with hs | hs
+  · rw [funext (lowerIncompleteGamma_of_nonpos_left hs)]
+    exact continuous_const
+  rw [lowerIncompleteGamma_eq_comp hs]
+  exact (continuousOn_intervalIntegral_rpow_mul_exp_neg hs).comp_continuous
+    (continuous_id.max continuous_const) fun x => le_max_right x 0
+
+/-- `P(s, ·)` is continuous on all of `ℝ`. -/
+theorem continuous_regularizedGamma (s : ℝ) : Continuous (regularizedGamma s) := by
+  rcases le_or_gt s 0 with hs | hs
+  · rw [funext (regularizedGamma_of_nonpos_left hs)]
+    exact continuous_const
+  rw [funext fun x => regularizedGamma_eq_div hs x]
+  exact (continuous_lowerIncompleteGamma s).div_const _
+
+/-- `γ(s, ·)` is differentiable at every positive `x`, with the expected derivative.
+
+Differentiability at `0` fails for `s < 1`, where the integrand is unbounded there, so the
+hypothesis `0 < x` cannot be weakened to `0 ≤ x`. -/
+theorem hasDerivAt_lowerIncompleteGamma (hs : 0 < s) (hx : 0 < x) :
+    HasDerivAt (lowerIncompleteGamma s) (x ^ (s - 1) * Real.exp (-x)) x := by
+  have hcont : ContinuousOn (fun t : ℝ => t ^ (s - 1) * Real.exp (-t)) (Ioi 0) := fun t ht =>
+    ((Real.continuousAt_rpow_const t (s - 1) (Or.inl (ne_of_gt ht))).mul
+      (Real.continuous_exp.comp continuous_neg).continuousAt).continuousWithinAt
+  have hderiv : HasDerivAt (fun y : ℝ => ∫ t in (0 : ℝ)..y, t ^ (s - 1) * Real.exp (-t))
+      (x ^ (s - 1) * Real.exp (-x)) x :=
+    intervalIntegral.integral_hasDerivAt_right
+      (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) le_rfl hx.le)
+      (hcont.stronglyMeasurableAtFilter isOpen_Ioi x hx)
+      ((Real.continuousAt_rpow_const x (s - 1) (Or.inl (ne_of_gt hx))).mul
+        (Real.continuous_exp.comp continuous_neg).continuousAt)
+  refine hderiv.congr_of_eventuallyEq ?_
+  filter_upwards [eventually_gt_nhds hx] with y hy
+  rw [lowerIncompleteGamma_eq_integral hs hy.le]
+
+/-- The derivative of `γ(s, ·)` at a positive point is the integrand. -/
+theorem deriv_lowerIncompleteGamma (hs : 0 < s) (hx : 0 < x) :
+    deriv (lowerIncompleteGamma s) x = x ^ (s - 1) * Real.exp (-x) :=
+  (hasDerivAt_lowerIncompleteGamma hs hx).deriv
+
+/-- `P(s, ·)` is differentiable at every positive `x`, with the expected derivative. As for
+`TauCeti.hasDerivAt_lowerIncompleteGamma`, the hypothesis `0 < x` is needed for `s < 1`. -/
+theorem hasDerivAt_regularizedGamma (hs : 0 < s) (hx : 0 < x) :
+    HasDerivAt (regularizedGamma s) (x ^ (s - 1) * Real.exp (-x) / Real.Gamma s) x := by
+  rw [funext fun y => regularizedGamma_eq_div hs y]
+  exact (hasDerivAt_lowerIncompleteGamma hs hx).div_const _
+
+/-- The derivative of `P(s, ·)` at a positive point is the normalized integrand. -/
+theorem deriv_regularizedGamma (hs : 0 < s) (hx : 0 < x) :
+    deriv (regularizedGamma s) x = x ^ (s - 1) * Real.exp (-x) / Real.Gamma s :=
+  (hasDerivAt_regularizedGamma hs hx).deriv
+
+/-! ### The recurrence in the shape parameter -/
+
+/-- For a real shape parameter, `γ(s, x)` is Mathlib's `Complex.partialGamma`.
+
+The complex partial gamma function carries the integration by parts behind
+`TauCeti.lowerIncompleteGamma_add_one`, so this identification is what lets that recurrence be
+imported rather than reproved. -/
+theorem ofReal_lowerIncompleteGamma (hs : 0 < s) (hx : 0 ≤ x) :
+    ((lowerIncompleteGamma s x : ℝ) : ℂ) = Complex.partialGamma (s : ℂ) x := by
+  rw [lowerIncompleteGamma_eq_integral hs hx, Complex.partialGamma,
+    ← intervalIntegral.integral_ofReal]
+  refine intervalIntegral.integral_congr fun t ht => ?_
+  have ht0 : (0 : ℝ) ≤ t := (Set.uIcc_of_le hx ▸ ht : t ∈ Icc (0 : ℝ) x).1
+  have hcast : ((t ^ (s - 1) : ℝ) : ℂ) = (t : ℂ) ^ ((s : ℂ) - 1) := by
+    rw [Complex.ofReal_cpow ht0]
+    push_cast
+    ring_nf
+  rw [Complex.ofReal_mul, hcast]
+  ring
+
+/-- The recurrence `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)`. -/
+theorem lowerIncompleteGamma_add_one (hs : 0 < s) (hx : 0 ≤ x) :
+    lowerIncompleteGamma (s + 1) x = s * lowerIncompleteGamma s x - x ^ s * Real.exp (-x) := by
+  have hs1 : (0 : ℝ) < s + 1 := by linarith
+  have key := Complex.partialGamma_add_one (s := (s : ℂ)) (by simpa using hs) hx
+  rw [show (s : ℂ) + 1 = ((s + 1 : ℝ) : ℂ) by push_cast; ring, ← ofReal_lowerIncompleteGamma hs1 hx,
+    ← ofReal_lowerIncompleteGamma hs hx, ← Complex.ofReal_cpow hx s, ← Complex.ofReal_mul,
+    ← Complex.ofReal_mul, ← Complex.ofReal_sub, Complex.ofReal_inj] at key
+  rw [key]
+  ring
+
+/-! ### The limit at infinity -/
+
+/-- `γ(s, x)` increases to the complete Euler integral `Real.Gamma s` as `x → ∞`. -/
+theorem tendsto_lowerIncompleteGamma_atTop (hs : 0 < s) :
+    Tendsto (lowerIncompleteGamma s) atTop (𝓝 (Real.Gamma s)) := by
+  have hint : IntegrableOn (fun t : ℝ => t ^ (s - 1) * Real.exp (-t)) (Ioi 0) :=
+    (Real.GammaIntegral_convergent hs).congr_fun (fun t _ => mul_comm _ _) measurableSet_Ioi
+  have hGamma : ∫ t in Ioi (0 : ℝ), t ^ (s - 1) * Real.exp (-t) = Real.Gamma s := by
+    rw [Real.Gamma_eq_integral hs]
+    exact setIntegral_congr_fun measurableSet_Ioi fun t _ => mul_comm _ _
+  have hmax : Tendsto (fun x : ℝ => max x 0) atTop atTop :=
+    tendsto_atTop_mono (fun x => le_max_left x 0) tendsto_id
+  rw [lowerIncompleteGamma_eq_comp hs, ← hGamma]
+  exact (intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id).comp hmax
+
+/-- A truncated Euler integral is at most the complete one. -/
+theorem lowerIncompleteGamma_le_Gamma (hs : 0 < s) (x : ℝ) :
+    lowerIncompleteGamma s x ≤ Real.Gamma s :=
+  (monotone_lowerIncompleteGamma s).ge_of_tendsto (tendsto_lowerIncompleteGamma_atTop hs) x
+
+/-- `P(s, x)` increases to `1` as `x → ∞`: it is the cumulative distribution function of a
+probability law. -/
+theorem tendsto_regularizedGamma_atTop (hs : 0 < s) :
+    Tendsto (regularizedGamma s) atTop (𝓝 1) := by
+  rw [funext fun x => regularizedGamma_eq_div hs x]
+  have := (tendsto_lowerIncompleteGamma_atTop hs).div_const (Real.Gamma s)
+  rwa [div_self (Real.Gamma_pos_of_pos hs).ne'] at this
+
+/-- `P(s, x)` is at most `1`, for every parameter value. -/
+theorem regularizedGamma_le_one (s x : ℝ) : regularizedGamma s x ≤ 1 := by
+  rcases le_or_gt s 0 with hs | hs
+  · rw [regularizedGamma_of_nonpos_left hs]
+    exact zero_le_one
+  · rw [regularizedGamma_eq_div hs]
+    exact (div_le_one (Real.Gamma_pos_of_pos hs)).2 (lowerIncompleteGamma_le_Gamma hs x)
+
+/-! ### The exponential case `s = 1` -/
+
+/-- `γ(1, x) = 1 - exp (-x)` for `0 ≤ x`. -/
+theorem lowerIncompleteGamma_one (hx : 0 ≤ x) :
+    lowerIncompleteGamma 1 x = 1 - Real.exp (-x) := by
+  rw [lowerIncompleteGamma_eq_integral one_pos hx]
+  simp only [sub_self, Real.rpow_zero, one_mul]
+  rw [intervalIntegral.integral_comp_neg fun t => Real.exp t, integral_exp]
+  simp
+
+/-- `P(1, x) = 1 - exp (-x)` for `0 ≤ x`: the regularized lower incomplete gamma function at shape
+`1` is the cumulative distribution function of the standard exponential law. -/
+theorem regularizedGamma_one (hx : 0 ≤ x) : regularizedGamma 1 x = 1 - Real.exp (-x) := by
+  rw [regularizedGamma_eq_div one_pos, lowerIncompleteGamma_one hx, Real.Gamma_one, div_one]
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
@@ -34,9 +34,10 @@ the parameter range.
 ## Main results
 
 * `TauCeti.lowerIncompleteGamma_eq_integral` and `TauCeti.regularizedGamma_eq_div` — the
-  characteristic descriptions in the valid range, replacing the clamped definitions;
-* `TauCeti.intervalIntegrable_rpow_mul_exp_neg` — convergence: the integrand is interval
-  integrable on every interval in `[0, ∞)`, including at the singularity `0` for `s < 1`;
+  characteristic descriptions replacing the clamped definitions;
+* `TauCeti.intervalIntegrable_rpow_mul_exp_neg` and `TauCeti.integrableOn_rpow_mul_exp_neg` —
+  convergence of Euler's integrand, including at the singularity `0` for `s < 1`, together with
+  `TauCeti.integral_Ioi_rpow_mul_exp_neg_eq_Gamma` for the value of the complete integral;
 * `TauCeti.continuous_lowerIncompleteGamma`, `TauCeti.continuous_regularizedGamma` — continuity on
   all of `ℝ`, in particular at `x = 0`, where for `s < 1` the integrand blows up;
 * `TauCeti.monotone_lowerIncompleteGamma`, `TauCeti.monotone_regularizedGamma` — monotonicity,
@@ -53,13 +54,16 @@ the parameter range.
 
 ## Implementation
 
-`Real.Gamma` is *not* the value of Euler's integral outside `0 < s`, so the definition of
-`regularizedGamma` guards on `0 < s` rather than dividing by `Real.Gamma s` unconditionally.
+The guard `0 < s` in the definition of `regularizedGamma` mirrors the one built into
+`TauCeti.lowerIncompleteGamma`, which is the definition shape the roadmap prescribes. It changes no
+value: `γ(s, x)` already vanishes for `s ≤ 0`, so dividing unconditionally would give the same
+function, and `TauCeti.regularizedGamma_eq_div` accordingly needs no hypothesis on `s`.
 
 The recurrence is obtained from Mathlib's `Complex.partialGamma_add_one`, whose proof performs the
 integration by parts on `Set.Ioo 0 x` — the endpoint `0` has to be avoided because `t ^ s` is not
-differentiable there for `s < 1`. The bridge is `TauCeti.ofReal_lowerIncompleteGamma`, which
-identifies `γ(s, x)` with `Complex.partialGamma s x` for real `s`.
+differentiable there for `s < 1`. The bridge is
+`TauCeti.ofReal_lowerIncompleteGamma_eq_partialGamma`, which identifies `γ(s, x)` with
+`Complex.partialGamma s x` for real `s`.
 
 ## References
 
@@ -83,25 +87,34 @@ variable {s x : ℝ}
 
 /-! ### Convergence of the truncated Euler integral -/
 
-/-- Euler's integrand `t ^ p * exp (-t)` is interval integrable on any interval contained in
-`[0, ∞)`, for `-1 < p`.
+/-- Euler's integrand `t ^ p * exp (-t)` is interval integrable, for `-1 < p`.
 
-This is the interval form of Mathlib's `Real.GammaIntegral_convergent`; for `p < 0` the integrand
-is unbounded at `0`, so the statement is not a mere continuity argument. The shape parameter `s` of
+This composes Mathlib's `intervalIntegral.intervalIntegrable_rpow'`, which carries the singularity
+at `0` for `p < 0`, with the continuous factor. The shape parameter `s` of
 `TauCeti.lowerIncompleteGamma` enters as `p = s - 1`. -/
-theorem intervalIntegrable_rpow_mul_exp_neg {p : ℝ} (hp : -1 < p) {a b : ℝ} (ha : 0 ≤ a)
-    (hb : 0 ≤ b) :
-    IntervalIntegrable (fun t : ℝ => t ^ p * Real.exp (-t)) volume a b := by
-  have hsub : Ι a b ⊆ Ioi (0 : ℝ) := by
-    intro t ht
-    rw [Set.uIoc_eq_union] at ht
-    rcases ht with ht | ht
-    · exact lt_of_le_of_lt ha ht.1
-    · exact lt_of_le_of_lt hb ht.1
+theorem intervalIntegrable_rpow_mul_exp_neg {p : ℝ} (hp : -1 < p) (a b : ℝ) :
+    IntervalIntegrable (fun t : ℝ => t ^ p * Real.exp (-t)) volume a b :=
+  (intervalIntegral.intervalIntegrable_rpow' hp).mul_continuousOn
+    (Real.continuous_exp.comp continuous_neg).continuousOn
+
+/-- Euler's integrand `t ^ p * exp (-t)` is integrable on all of `Ioi 0`, for `-1 < p`.
+
+This is Mathlib's `Real.GammaIntegral_convergent` with the two factors in the order used
+throughout this file. -/
+theorem integrableOn_rpow_mul_exp_neg {p : ℝ} (hp : -1 < p) :
+    IntegrableOn (fun t : ℝ => t ^ p * Real.exp (-t)) (Ioi 0) := by
   have h := Real.GammaIntegral_convergent (s := p + 1) (by linarith)
   rw [add_sub_cancel_right] at h
-  rw [intervalIntegrable_iff]
-  exact (h.mono_set hsub).congr_fun (fun t _ => mul_comm _ _) measurableSet_uIoc
+  exact h.congr_fun (fun t _ => mul_comm _ _) measurableSet_Ioi
+
+/-- The complete Euler integral evaluates to `Real.Gamma s`.
+
+This is Mathlib's `Real.Gamma_eq_integral` with the two factors in the order used throughout this
+file; `TauCeti.lowerIncompleteGamma` is the truncation of the left-hand side. -/
+theorem integral_Ioi_rpow_mul_exp_neg_eq_Gamma (hs : 0 < s) :
+    ∫ t in Ioi (0 : ℝ), t ^ (s - 1) * Real.exp (-t) = Real.Gamma s := by
+  rw [Real.Gamma_eq_integral hs]
+  exact setIntegral_congr_fun measurableSet_Ioi fun t _ => mul_comm _ _
 
 /-! ### The definitions -/
 
@@ -122,38 +135,44 @@ theorem lowerIncompleteGamma_eq_integral (hs : 0 < s) (hx : 0 ≤ x) :
     lowerIncompleteGamma s x = ∫ t in (0 : ℝ)..x, t ^ (s - 1) * Real.exp (-t) := by
   rw [lowerIncompleteGamma, ite_eq_left hs, max_eq_left hx]
 
-/-- In the valid range of the shape parameter, `P(s, x)` is `γ(s, x)` normalized by `Γ(s)`. -/
-theorem regularizedGamma_eq_div (hs : 0 < s) (x : ℝ) :
-    regularizedGamma s x = lowerIncompleteGamma s x / Real.Gamma s := by
-  rw [regularizedGamma, ite_eq_left hs]
-
 /-- Outside the valid range of the shape parameter, `γ(s, x)` is `0`. -/
-theorem lowerIncompleteGamma_of_nonpos_left (hs : s ≤ 0) (x : ℝ) :
+theorem lowerIncompleteGamma_eq_zero_of_nonpos_left (hs : s ≤ 0) (x : ℝ) :
     lowerIncompleteGamma s x = 0 :=
   ite_eq_right (not_lt.2 hs)
 
-/-- Outside the valid range of the shape parameter, `P(s, x)` is `0`. -/
-theorem regularizedGamma_of_nonpos_left (hs : s ≤ 0) (x : ℝ) : regularizedGamma s x = 0 :=
-  ite_eq_right (not_lt.2 hs)
-
 /-- Below the support, `γ(s, x)` is `0`. -/
-theorem lowerIncompleteGamma_of_nonpos_right (s : ℝ) (hx : x ≤ 0) :
+theorem lowerIncompleteGamma_eq_zero_of_nonpos_right (s : ℝ) (hx : x ≤ 0) :
     lowerIncompleteGamma s x = 0 := by
   rw [lowerIncompleteGamma, max_eq_right hx]
   simp
 
+/-- Outside the valid range of the shape parameter, `P(s, x)` is `0`. -/
+theorem regularizedGamma_eq_zero_of_nonpos_left (hs : s ≤ 0) (x : ℝ) : regularizedGamma s x = 0 :=
+  ite_eq_right (not_lt.2 hs)
+
+/-- `P(s, x)` is `γ(s, x)` normalized by `Γ(s)`.
+
+No hypothesis on the shape parameter is needed: for `s ≤ 0` both sides are `0`, since `γ(s, ·)`
+is. -/
+theorem regularizedGamma_eq_div (s x : ℝ) :
+    regularizedGamma s x = lowerIncompleteGamma s x / Real.Gamma s := by
+  rcases le_or_gt s 0 with hs | hs
+  · rw [regularizedGamma_eq_zero_of_nonpos_left hs, lowerIncompleteGamma_eq_zero_of_nonpos_left hs,
+      zero_div]
+  · rw [regularizedGamma, ite_eq_left hs]
+
 /-- Below the support, `P(s, x)` is `0`. -/
-theorem regularizedGamma_of_nonpos_right (s : ℝ) (hx : x ≤ 0) : regularizedGamma s x = 0 := by
-  rw [regularizedGamma, lowerIncompleteGamma_of_nonpos_right s hx]
-  simp
+theorem regularizedGamma_eq_zero_of_nonpos_right (s : ℝ) (hx : x ≤ 0) :
+    regularizedGamma s x = 0 := by
+  rw [regularizedGamma_eq_div, lowerIncompleteGamma_eq_zero_of_nonpos_right s hx, zero_div]
 
 @[simp]
 theorem lowerIncompleteGamma_zero_right (s : ℝ) : lowerIncompleteGamma s 0 = 0 :=
-  lowerIncompleteGamma_of_nonpos_right s le_rfl
+  lowerIncompleteGamma_eq_zero_of_nonpos_right s le_rfl
 
 @[simp]
 theorem regularizedGamma_zero_right (s : ℝ) : regularizedGamma s 0 = 0 :=
-  regularizedGamma_of_nonpos_right s le_rfl
+  regularizedGamma_eq_zero_of_nonpos_right s le_rfl
 
 /-- `γ(s, ·)` is the truncated Euler integral read at `max x 0`.
 
@@ -169,92 +188,77 @@ private theorem lowerIncompleteGamma_eq_comp (hs : 0 < s) :
 
 /-- `γ(s, x)` is nonnegative, for every parameter value. -/
 theorem lowerIncompleteGamma_nonneg (s x : ℝ) : 0 ≤ lowerIncompleteGamma s x := by
-  rw [lowerIncompleteGamma]
-  split
-  · exact intervalIntegral.integral_nonneg (le_max_right x 0) fun t ht =>
+  rcases le_or_gt s 0 with hs | hs
+  · rw [lowerIncompleteGamma_eq_zero_of_nonpos_left hs]
+  rcases le_or_gt x 0 with hx | hx
+  · rw [lowerIncompleteGamma_eq_zero_of_nonpos_right _ hx]
+  · rw [lowerIncompleteGamma_eq_integral hs hx.le]
+    exact intervalIntegral.integral_nonneg hx.le fun t ht =>
       mul_nonneg (Real.rpow_nonneg ht.1 _) (Real.exp_pos _).le
-  · exact le_rfl
 
 /-- `P(s, x)` is nonnegative, for every parameter value. -/
 theorem regularizedGamma_nonneg (s x : ℝ) : 0 ≤ regularizedGamma s x := by
-  rw [regularizedGamma]
-  split
-  · exact div_nonneg (lowerIncompleteGamma_nonneg s x) (Real.Gamma_nonneg_of_nonneg (by linarith))
-  · exact le_rfl
+  rcases le_or_gt s 0 with hs | hs
+  · rw [regularizedGamma_eq_zero_of_nonpos_left hs]
+  · rw [regularizedGamma_eq_div]
+    exact div_nonneg (lowerIncompleteGamma_nonneg s x) (Real.Gamma_nonneg_of_nonneg hs.le)
 
 /-- `γ(s, ·)` is monotone: it accumulates a nonnegative integrand. -/
 theorem monotone_lowerIncompleteGamma (s : ℝ) : Monotone (lowerIncompleteGamma s) := by
   rcases le_or_gt s 0 with hs | hs
-  · rw [funext (lowerIncompleteGamma_of_nonpos_left hs)]
+  · rw [funext (lowerIncompleteGamma_eq_zero_of_nonpos_left hs)]
     exact monotone_const
   intro u v huv
   rcases le_or_gt v 0 with hv | hv
-  · rw [lowerIncompleteGamma_of_nonpos_right _ (huv.trans hv),
-      lowerIncompleteGamma_of_nonpos_right _ hv]
+  · rw [lowerIncompleteGamma_eq_zero_of_nonpos_right _ (huv.trans hv),
+      lowerIncompleteGamma_eq_zero_of_nonpos_right _ hv]
   rcases le_or_gt u 0 with hu | hu
-  · rw [lowerIncompleteGamma_of_nonpos_right _ hu]
+  · rw [lowerIncompleteGamma_eq_zero_of_nonpos_right _ hu]
     exact lowerIncompleteGamma_nonneg _ _
-  · rw [lowerIncompleteGamma_eq_integral hs hu.le, lowerIncompleteGamma_eq_integral hs hv.le,
-      ← intervalIntegral.integral_add_adjacent_intervals
-        (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) le_rfl hu.le)
-        (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) hu.le hv.le)]
-    refine le_add_of_nonneg_right (intervalIntegral.integral_nonneg huv fun t ht => ?_)
-    exact mul_nonneg (Real.rpow_nonneg (hu.le.trans ht.1) _) (Real.exp_pos _).le
+  · rw [lowerIncompleteGamma_eq_integral hs hu.le, lowerIncompleteGamma_eq_integral hs hv.le]
+    refine intervalIntegral.integral_mono_interval le_rfl hu.le huv ?_
+      (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) 0 v)
+    filter_upwards [ae_restrict_mem measurableSet_Ioc] with t ht
+    exact mul_nonneg (Real.rpow_nonneg ht.1.le _) (Real.exp_pos _).le
 
-/-- `P(s, ·)` is monotone. Together with `TauCeti.regularizedGamma_nonneg`,
-`TauCeti.regularizedGamma_le_one`, `TauCeti.continuous_regularizedGamma` and
-`TauCeti.tendsto_regularizedGamma_atTop` this is everything a cumulative distribution function
-must satisfy. -/
+/-- `P(s, ·)` is monotone. For `0 < s`, this together with `TauCeti.regularizedGamma_nonneg`,
+`TauCeti.regularizedGamma_le_one`, `TauCeti.regularizedGamma_eq_zero_of_nonpos_right`,
+`TauCeti.continuous_regularizedGamma` and `TauCeti.tendsto_regularizedGamma_atTop` is everything a
+cumulative distribution function must satisfy. -/
 theorem monotone_regularizedGamma (s : ℝ) : Monotone (regularizedGamma s) := by
   rcases le_or_gt s 0 with hs | hs
-  · rw [funext (regularizedGamma_of_nonpos_left hs)]
+  · rw [funext (regularizedGamma_eq_zero_of_nonpos_left hs)]
     exact monotone_const
   intro u v huv
-  rw [regularizedGamma_eq_div hs, regularizedGamma_eq_div hs]
+  rw [regularizedGamma_eq_div, regularizedGamma_eq_div]
   gcongr
   exact monotone_lowerIncompleteGamma s huv
-
-/-- The truncated Euler integral is continuous in its upper limit on `[0, ∞)`. -/
-private theorem continuousOn_intervalIntegral_rpow_mul_exp_neg (hs : 0 < s) :
-    ContinuousOn (fun y : ℝ => ∫ t in (0 : ℝ)..y, t ^ (s - 1) * Real.exp (-t)) (Ici 0) := by
-  intro y hy
-  have hy' : (0 : ℝ) ≤ y := hy
-  have hmem : Icc (0 : ℝ) (y + 1) ∈ 𝓝[Ici (0 : ℝ)] y := by
-    rw [← Set.Ici_inter_Iic]
-    exact inter_mem_nhdsWithin _ (Iic_mem_nhds (by linarith))
-  refine ContinuousWithinAt.mono_of_mem_nhdsWithin ?_ hmem
-  have huIcc : Set.uIcc (0 : ℝ) (y + 1) = Icc 0 (y + 1) := Set.uIcc_of_le (by linarith)
-  have := intervalIntegral.continuousOn_primitive_interval' (a := (0 : ℝ)) (b₁ := (0 : ℝ))
-    (b₂ := y + 1) (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) le_rfl
-      (by linarith))
-    (by rw [huIcc]; exact ⟨le_rfl, by linarith⟩)
-  rw [huIcc] at this
-  exact this y ⟨hy', by linarith⟩
 
 /-- `γ(s, ·)` is continuous on all of `ℝ`.
 
 For `s < 1` this includes the point `x = 0`, where the integrand is unbounded; the integral is
 nevertheless convergent there, by `TauCeti.intervalIntegrable_rpow_mul_exp_neg`. -/
+@[fun_prop]
 theorem continuous_lowerIncompleteGamma (s : ℝ) : Continuous (lowerIncompleteGamma s) := by
   rcases le_or_gt s 0 with hs | hs
-  · rw [funext (lowerIncompleteGamma_of_nonpos_left hs)]
+  · rw [funext (lowerIncompleteGamma_eq_zero_of_nonpos_left hs)]
     exact continuous_const
   rw [lowerIncompleteGamma_eq_comp hs]
-  exact (continuousOn_intervalIntegral_rpow_mul_exp_neg hs).comp_continuous
-    (continuous_id.max continuous_const) fun x => le_max_right x 0
+  exact (intervalIntegral.continuous_primitive
+    (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1)) 0).comp
+      (continuous_id.max continuous_const)
 
 /-- `P(s, ·)` is continuous on all of `ℝ`. -/
+@[fun_prop]
 theorem continuous_regularizedGamma (s : ℝ) : Continuous (regularizedGamma s) := by
-  rcases le_or_gt s 0 with hs | hs
-  · rw [funext (regularizedGamma_of_nonpos_left hs)]
-    exact continuous_const
-  rw [funext fun x => regularizedGamma_eq_div hs x]
+  rw [funext fun x => regularizedGamma_eq_div s x]
   exact (continuous_lowerIncompleteGamma s).div_const _
 
 /-- `γ(s, ·)` is differentiable at every positive `x`, with the expected derivative.
 
-Differentiability at `0` fails for `s < 1`, where the integrand is unbounded there, so the
-hypothesis `0 < x` cannot be weakened to `0 ≤ x`. -/
+The hypothesis `0 < x` cannot be weakened to `0 ≤ x`: differentiability at `0` holds exactly for
+`1 < s`. For `s < 1` the integrand is unbounded at `0`, and at `s = 1` the clamped function is
+`x ↦ 1 - exp (-max x 0)`, whose one-sided derivatives at `0` are `0` and `1`. -/
 theorem hasDerivAt_lowerIncompleteGamma (hs : 0 < s) (hx : 0 < x) :
     HasDerivAt (lowerIncompleteGamma s) (x ^ (s - 1) * Real.exp (-x)) x := by
   have hcont : ContinuousOn (fun t : ℝ => t ^ (s - 1) * Real.exp (-t)) (Ioi 0) := fun t ht =>
@@ -263,7 +267,7 @@ theorem hasDerivAt_lowerIncompleteGamma (hs : 0 < s) (hx : 0 < x) :
   have hderiv : HasDerivAt (fun y : ℝ => ∫ t in (0 : ℝ)..y, t ^ (s - 1) * Real.exp (-t))
       (x ^ (s - 1) * Real.exp (-x)) x :=
     intervalIntegral.integral_hasDerivAt_right
-      (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) le_rfl hx.le)
+      (intervalIntegrable_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1) 0 x)
       (hcont.stronglyMeasurableAtFilter isOpen_Ioi x hx)
       ((Real.continuousAt_rpow_const x (s - 1) (Or.inl (ne_of_gt hx))).mul
         (Real.continuous_exp.comp continuous_neg).continuousAt)
@@ -277,10 +281,10 @@ theorem deriv_lowerIncompleteGamma (hs : 0 < s) (hx : 0 < x) :
   (hasDerivAt_lowerIncompleteGamma hs hx).deriv
 
 /-- `P(s, ·)` is differentiable at every positive `x`, with the expected derivative. As for
-`TauCeti.hasDerivAt_lowerIncompleteGamma`, the hypothesis `0 < x` is needed for `s < 1`. -/
+`TauCeti.hasDerivAt_lowerIncompleteGamma`, the hypothesis `0 < x` is needed for every `s ≤ 1`. -/
 theorem hasDerivAt_regularizedGamma (hs : 0 < s) (hx : 0 < x) :
     HasDerivAt (regularizedGamma s) (x ^ (s - 1) * Real.exp (-x) / Real.Gamma s) x := by
-  rw [funext fun y => regularizedGamma_eq_div hs y]
+  rw [funext fun y => regularizedGamma_eq_div s y]
   exact (hasDerivAt_lowerIncompleteGamma hs hx).div_const _
 
 /-- The derivative of `P(s, ·)` at a positive point is the normalized integrand. -/
@@ -295,7 +299,7 @@ theorem deriv_regularizedGamma (hs : 0 < s) (hx : 0 < x) :
 The complex partial gamma function carries the integration by parts behind
 `TauCeti.lowerIncompleteGamma_add_one`, so this identification is what lets that recurrence be
 imported rather than reproved. -/
-theorem ofReal_lowerIncompleteGamma (hs : 0 < s) (hx : 0 ≤ x) :
+theorem ofReal_lowerIncompleteGamma_eq_partialGamma (hs : 0 < s) (hx : 0 ≤ x) :
     ((lowerIncompleteGamma s x : ℝ) : ℂ) = Complex.partialGamma (s : ℂ) x := by
   rw [lowerIncompleteGamma_eq_integral hs hx, Complex.partialGamma,
     ← intervalIntegral.integral_ofReal]
@@ -313,9 +317,10 @@ theorem lowerIncompleteGamma_add_one (hs : 0 < s) (hx : 0 ≤ x) :
     lowerIncompleteGamma (s + 1) x = s * lowerIncompleteGamma s x - x ^ s * Real.exp (-x) := by
   have hs1 : (0 : ℝ) < s + 1 := by linarith
   have key := Complex.partialGamma_add_one (s := (s : ℂ)) (by simpa using hs) hx
-  rw [show (s : ℂ) + 1 = ((s + 1 : ℝ) : ℂ) by push_cast; ring, ← ofReal_lowerIncompleteGamma hs1 hx,
-    ← ofReal_lowerIncompleteGamma hs hx, ← Complex.ofReal_cpow hx s, ← Complex.ofReal_mul,
-    ← Complex.ofReal_mul, ← Complex.ofReal_sub, Complex.ofReal_inj] at key
+  rw [show (s : ℂ) + 1 = ((s + 1 : ℝ) : ℂ) by push_cast; ring,
+    ← ofReal_lowerIncompleteGamma_eq_partialGamma hs1 hx,
+    ← ofReal_lowerIncompleteGamma_eq_partialGamma hs hx, ← Complex.ofReal_cpow hx s,
+    ← Complex.ofReal_mul, ← Complex.ofReal_mul, ← Complex.ofReal_sub, Complex.ofReal_inj] at key
   rw [key]
   ring
 
@@ -324,15 +329,11 @@ theorem lowerIncompleteGamma_add_one (hs : 0 < s) (hx : 0 ≤ x) :
 /-- `γ(s, x)` increases to the complete Euler integral `Real.Gamma s` as `x → ∞`. -/
 theorem tendsto_lowerIncompleteGamma_atTop (hs : 0 < s) :
     Tendsto (lowerIncompleteGamma s) atTop (𝓝 (Real.Gamma s)) := by
-  have hint : IntegrableOn (fun t : ℝ => t ^ (s - 1) * Real.exp (-t)) (Ioi 0) :=
-    (Real.GammaIntegral_convergent hs).congr_fun (fun t _ => mul_comm _ _) measurableSet_Ioi
-  have hGamma : ∫ t in Ioi (0 : ℝ), t ^ (s - 1) * Real.exp (-t) = Real.Gamma s := by
-    rw [Real.Gamma_eq_integral hs]
-    exact setIntegral_congr_fun measurableSet_Ioi fun t _ => mul_comm _ _
   have hmax : Tendsto (fun x : ℝ => max x 0) atTop atTop :=
     tendsto_atTop_mono (fun x => le_max_left x 0) tendsto_id
-  rw [lowerIncompleteGamma_eq_comp hs, ← hGamma]
-  exact (intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id).comp hmax
+  rw [lowerIncompleteGamma_eq_comp hs, ← integral_Ioi_rpow_mul_exp_neg_eq_Gamma hs]
+  exact (intervalIntegral_tendsto_integral_Ioi 0
+    (integrableOn_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1)) tendsto_id).comp hmax
 
 /-- A truncated Euler integral is at most the complete one. -/
 theorem lowerIncompleteGamma_le_Gamma (hs : 0 < s) (x : ℝ) :
@@ -343,16 +344,16 @@ theorem lowerIncompleteGamma_le_Gamma (hs : 0 < s) (x : ℝ) :
 probability law. -/
 theorem tendsto_regularizedGamma_atTop (hs : 0 < s) :
     Tendsto (regularizedGamma s) atTop (𝓝 1) := by
-  rw [funext fun x => regularizedGamma_eq_div hs x]
+  rw [funext fun x => regularizedGamma_eq_div s x]
   have := (tendsto_lowerIncompleteGamma_atTop hs).div_const (Real.Gamma s)
   rwa [div_self (Real.Gamma_pos_of_pos hs).ne'] at this
 
 /-- `P(s, x)` is at most `1`, for every parameter value. -/
 theorem regularizedGamma_le_one (s x : ℝ) : regularizedGamma s x ≤ 1 := by
   rcases le_or_gt s 0 with hs | hs
-  · rw [regularizedGamma_of_nonpos_left hs]
+  · rw [regularizedGamma_eq_zero_of_nonpos_left hs]
     exact zero_le_one
-  · rw [regularizedGamma_eq_div hs]
+  · rw [regularizedGamma_eq_div]
     exact (div_le_one (Real.Gamma_pos_of_pos hs)).2 (lowerIncompleteGamma_le_Gamma hs x)
 
 /-! ### The exponential case `s = 1` -/
@@ -368,7 +369,7 @@ theorem lowerIncompleteGamma_one (hx : 0 ≤ x) :
 /-- `P(1, x) = 1 - exp (-x)` for `0 ≤ x`: the regularized lower incomplete gamma function at shape
 `1` is the cumulative distribution function of the standard exponential law. -/
 theorem regularizedGamma_one (hx : 0 ≤ x) : regularizedGamma 1 x = 1 - Real.exp (-x) := by
-  rw [regularizedGamma_eq_div one_pos, lowerIncompleteGamma_one hx, Real.Gamma_one, div_one]
+  rw [regularizedGamma_eq_div, lowerIncompleteGamma_one hx, Real.Gamma_one, div_one]
 
 end TauCeti
 

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
@@ -6,7 +6,6 @@ Authors: Claude
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
-public import Mathlib.MeasureTheory.Integral.DominatedConvergence
 public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
@@ -35,18 +34,17 @@ the parameter range.
 
 * `TauCeti.lowerIncompleteGamma_eq_integral` and `TauCeti.regularizedGamma_eq_div` — the
   characteristic descriptions replacing the clamped definitions;
-* `TauCeti.intervalIntegrable_rpow_mul_exp_neg` and `TauCeti.integrableOn_rpow_mul_exp_neg` —
-  convergence of Euler's integrand, including at the singularity `0` for `s < 1`, together with
-  `TauCeti.integral_Ioi_rpow_mul_exp_neg_eq_Gamma` for the value of the complete integral;
+* `TauCeti.intervalIntegrable_rpow_mul_exp_neg` — convergence of Euler's integrand on an interval,
+  including at the singularity `0` for `s < 1`;
 * `TauCeti.continuous_lowerIncompleteGamma`, `TauCeti.continuous_regularizedGamma` — continuity on
   all of `ℝ`, in particular at `x = 0`, where for `s < 1` the integrand blows up;
-* `TauCeti.monotone_lowerIncompleteGamma`, `TauCeti.monotone_regularizedGamma` — monotonicity,
+* `TauCeti.lowerIncompleteGamma_monotone`, `TauCeti.regularizedGamma_monotone` — monotonicity,
   and `TauCeti.lowerIncompleteGamma_nonneg`, `TauCeti.regularizedGamma_nonneg`,
   `TauCeti.regularizedGamma_le_one` — the range;
 * `TauCeti.hasDerivAt_lowerIncompleteGamma`, `TauCeti.hasDerivAt_regularizedGamma` and the
   companion `deriv` lemmas — differentiability, for `0 < x` only;
 * `TauCeti.lowerIncompleteGamma_add_one` — the recurrence
-  `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)`;
+  `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)`, for `0 < s` and `0 ≤ x`;
 * `TauCeti.tendsto_lowerIncompleteGamma_atTop`, `TauCeti.tendsto_regularizedGamma_atTop` — the
   limits `Real.Gamma s` and `1` as `x → ∞`, with the resulting bounds
   `TauCeti.lowerIncompleteGamma_le_Gamma` and `TauCeti.regularizedGamma_le_one`;
@@ -58,6 +56,10 @@ The guard `0 < s` in the definition of `regularizedGamma` mirrors the one built 
 `TauCeti.lowerIncompleteGamma`, which is the definition shape the roadmap prescribes. It changes no
 value: `γ(s, x)` already vanishes for `s ≤ 0`, so dividing unconditionally would give the same
 function, and `TauCeti.regularizedGamma_eq_div` accordingly needs no hypothesis on `s`.
+
+The limit at infinity is Mathlib's `Real.GammaIntegral_convergent` together with
+`Real.Gamma_eq_integral`, which state Euler's integrand as `exp (-t) * t ^ (s - 1)`; this file uses
+the opposite factor order throughout, so both are applied up to `mul_comm` at their point of use.
 
 The recurrence is obtained from Mathlib's `Complex.partialGamma_add_one`, whose proof performs the
 integration by parts on `Set.Ioo 0 x` — the endpoint `0` has to be avoided because `t ^ s` is not
@@ -97,25 +99,6 @@ theorem intervalIntegrable_rpow_mul_exp_neg {p : ℝ} (hp : -1 < p) (a b : ℝ) 
   (intervalIntegral.intervalIntegrable_rpow' hp).mul_continuousOn
     (Real.continuous_exp.comp continuous_neg).continuousOn
 
-/-- Euler's integrand `t ^ p * exp (-t)` is integrable on all of `Ioi 0`, for `-1 < p`.
-
-This is Mathlib's `Real.GammaIntegral_convergent` with the two factors in the order used
-throughout this file. -/
-theorem integrableOn_rpow_mul_exp_neg {p : ℝ} (hp : -1 < p) :
-    IntegrableOn (fun t : ℝ => t ^ p * Real.exp (-t)) (Ioi 0) := by
-  have h := Real.GammaIntegral_convergent (s := p + 1) (by linarith)
-  rw [add_sub_cancel_right] at h
-  exact h.congr_fun (fun t _ => mul_comm _ _) measurableSet_Ioi
-
-/-- The complete Euler integral evaluates to `Real.Gamma s`.
-
-This is Mathlib's `Real.Gamma_eq_integral` with the two factors in the order used throughout this
-file; `TauCeti.lowerIncompleteGamma` is the truncation of the left-hand side. -/
-theorem integral_Ioi_rpow_mul_exp_neg_eq_Gamma (hs : 0 < s) :
-    ∫ t in Ioi (0 : ℝ), t ^ (s - 1) * Real.exp (-t) = Real.Gamma s := by
-  rw [Real.Gamma_eq_integral hs]
-  exact setIntegral_congr_fun measurableSet_Ioi fun t _ => mul_comm _ _
-
 /-! ### The definitions -/
 
 /-- The lower incomplete gamma function `γ(s, x) = ∫ t in 0..x, t ^ (s - 1) * exp (-t)`.
@@ -136,17 +119,20 @@ theorem lowerIncompleteGamma_eq_integral (hs : 0 < s) (hx : 0 ≤ x) :
   rw [lowerIncompleteGamma, ite_eq_left hs, max_eq_left hx]
 
 /-- Outside the valid range of the shape parameter, `γ(s, x)` is `0`. -/
+@[simp]
 theorem lowerIncompleteGamma_eq_zero_of_nonpos_left (hs : s ≤ 0) (x : ℝ) :
     lowerIncompleteGamma s x = 0 :=
   ite_eq_right (not_lt.2 hs)
 
 /-- Below the support, `γ(s, x)` is `0`. -/
+@[simp]
 theorem lowerIncompleteGamma_eq_zero_of_nonpos_right (s : ℝ) (hx : x ≤ 0) :
     lowerIncompleteGamma s x = 0 := by
   rw [lowerIncompleteGamma, max_eq_right hx]
   simp
 
 /-- Outside the valid range of the shape parameter, `P(s, x)` is `0`. -/
+@[simp]
 theorem regularizedGamma_eq_zero_of_nonpos_left (hs : s ≤ 0) (x : ℝ) : regularizedGamma s x = 0 :=
   ite_eq_right (not_lt.2 hs)
 
@@ -162,15 +148,22 @@ theorem regularizedGamma_eq_div (s x : ℝ) :
   · rw [regularizedGamma, ite_eq_left hs]
 
 /-- Below the support, `P(s, x)` is `0`. -/
+@[simp]
 theorem regularizedGamma_eq_zero_of_nonpos_right (s : ℝ) (hx : x ≤ 0) :
     regularizedGamma s x = 0 := by
   rw [regularizedGamma_eq_div, lowerIncompleteGamma_eq_zero_of_nonpos_right s hx, zero_div]
 
-@[simp]
+/-- `γ(s, 0) = 0`, the value at the left endpoint of the support.
+
+This is not itself a `simp` lemma: `simp` discharges `(0 : ℝ) ≤ 0` and so already rewrites with
+`TauCeti.lowerIncompleteGamma_eq_zero_of_nonpos_right` here. -/
 theorem lowerIncompleteGamma_zero_right (s : ℝ) : lowerIncompleteGamma s 0 = 0 :=
   lowerIncompleteGamma_eq_zero_of_nonpos_right s le_rfl
 
-@[simp]
+/-- `P(s, 0) = 0`, the value at the left endpoint of the support.
+
+As for `TauCeti.lowerIncompleteGamma_zero_right`, `simp` reaches this through
+`TauCeti.regularizedGamma_eq_zero_of_nonpos_right`, so it carries no `@[simp]` of its own. -/
 theorem regularizedGamma_zero_right (s : ℝ) : regularizedGamma s 0 = 0 :=
   regularizedGamma_eq_zero_of_nonpos_right s le_rfl
 
@@ -204,7 +197,7 @@ theorem regularizedGamma_nonneg (s x : ℝ) : 0 ≤ regularizedGamma s x := by
     exact div_nonneg (lowerIncompleteGamma_nonneg s x) (Real.Gamma_nonneg_of_nonneg hs.le)
 
 /-- `γ(s, ·)` is monotone: it accumulates a nonnegative integrand. -/
-theorem monotone_lowerIncompleteGamma (s : ℝ) : Monotone (lowerIncompleteGamma s) := by
+theorem lowerIncompleteGamma_monotone (s : ℝ) : Monotone (lowerIncompleteGamma s) := by
   rcases le_or_gt s 0 with hs | hs
   · rw [funext (lowerIncompleteGamma_eq_zero_of_nonpos_left hs)]
     exact monotone_const
@@ -225,14 +218,14 @@ theorem monotone_lowerIncompleteGamma (s : ℝ) : Monotone (lowerIncompleteGamma
 `TauCeti.regularizedGamma_le_one`, `TauCeti.regularizedGamma_eq_zero_of_nonpos_right`,
 `TauCeti.continuous_regularizedGamma` and `TauCeti.tendsto_regularizedGamma_atTop` is everything a
 cumulative distribution function must satisfy. -/
-theorem monotone_regularizedGamma (s : ℝ) : Monotone (regularizedGamma s) := by
+theorem regularizedGamma_monotone (s : ℝ) : Monotone (regularizedGamma s) := by
   rcases le_or_gt s 0 with hs | hs
   · rw [funext (regularizedGamma_eq_zero_of_nonpos_left hs)]
     exact monotone_const
   intro u v huv
   rw [regularizedGamma_eq_div, regularizedGamma_eq_div]
   gcongr
-  exact monotone_lowerIncompleteGamma s huv
+  exact lowerIncompleteGamma_monotone s huv
 
 /-- `γ(s, ·)` is continuous on all of `ℝ`.
 
@@ -256,9 +249,11 @@ theorem continuous_regularizedGamma (s : ℝ) : Continuous (regularizedGamma s) 
 
 /-- `γ(s, ·)` is differentiable at every positive `x`, with the expected derivative.
 
-The hypothesis `0 < x` cannot be weakened to `0 ≤ x`: differentiability at `0` holds exactly for
-`1 < s`. For `s < 1` the integrand is unbounded at `0`, and at `s = 1` the clamped function is
-`x ↦ 1 - exp (-max x 0)`, whose one-sided derivatives at `0` are `0` and `1`. -/
+The hypothesis `0 < x` cannot be weakened to `0 ≤ x`: among the positive shapes this theorem is
+stated for, differentiability at `0` holds exactly for `1 < s`. For `s < 1` the integrand is
+unbounded at `0`, and at `s = 1` the clamped function is `x ↦ 1 - exp (-max x 0)`, whose one-sided
+derivatives at `0` are `0` and `1`. (For `s ≤ 0` the function is identically `0`, hence trivially
+differentiable everywhere.) -/
 theorem hasDerivAt_lowerIncompleteGamma (hs : 0 < s) (hx : 0 < x) :
     HasDerivAt (lowerIncompleteGamma s) (x ^ (s - 1) * Real.exp (-x)) x := by
   have hcont : ContinuousOn (fun t : ℝ => t ^ (s - 1) * Real.exp (-t)) (Ioi 0) := fun t ht =>
@@ -281,7 +276,8 @@ theorem deriv_lowerIncompleteGamma (hs : 0 < s) (hx : 0 < x) :
   (hasDerivAt_lowerIncompleteGamma hs hx).deriv
 
 /-- `P(s, ·)` is differentiable at every positive `x`, with the expected derivative. As for
-`TauCeti.hasDerivAt_lowerIncompleteGamma`, the hypothesis `0 < x` is needed for every `s ≤ 1`. -/
+`TauCeti.hasDerivAt_lowerIncompleteGamma`, the hypothesis `0 < x` is needed at every shape
+`0 < s ≤ 1`. -/
 theorem hasDerivAt_regularizedGamma (hs : 0 < s) (hx : 0 < x) :
     HasDerivAt (regularizedGamma s) (x ^ (s - 1) * Real.exp (-x) / Real.Gamma s) x := by
   rw [funext fun y => regularizedGamma_eq_div s y]
@@ -294,7 +290,8 @@ theorem deriv_regularizedGamma (hs : 0 < s) (hx : 0 < x) :
 
 /-! ### The recurrence in the shape parameter -/
 
-/-- For a real shape parameter, `γ(s, x)` is Mathlib's `Complex.partialGamma`.
+/-- For a positive real shape parameter `s` and `0 ≤ x`, `γ(s, x)` is Mathlib's
+`Complex.partialGamma` at `(s : ℂ)`.
 
 The complex partial gamma function carries the integration by parts behind
 `TauCeti.lowerIncompleteGamma_add_one`, so this identification is what lets that recurrence be
@@ -312,12 +309,17 @@ theorem ofReal_lowerIncompleteGamma_eq_partialGamma (hs : 0 < s) (hx : 0 ≤ x) 
   rw [Complex.ofReal_mul, hcast]
   ring
 
-/-- The recurrence `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)`. -/
+/-- The recurrence `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)`, for `0 < s` and `0 ≤ x`. -/
 theorem lowerIncompleteGamma_add_one (hs : 0 < s) (hx : 0 ≤ x) :
     lowerIncompleteGamma (s + 1) x = s * lowerIncompleteGamma s x - x ^ s * Real.exp (-x) := by
   have hs1 : (0 : ℝ) < s + 1 := by linarith
   have key := Complex.partialGamma_add_one (s := (s : ℂ)) (by simpa using hs) hx
-  rw [show (s : ℂ) + 1 = ((s + 1 : ℝ) : ℂ) by push_cast; ring,
+  -- `Complex.partialGamma_add_one` shifts the shape inside `ℂ`, as `(s : ℂ) + 1`, whereas
+  -- `TauCeti.ofReal_lowerIncompleteGamma_eq_partialGamma` only matches a shape of the form
+  -- `((· : ℝ) : ℂ)`; so the cast is pulled outwards first, and likewise for the products, the
+  -- difference and the power `(x : ℂ) ^ (s : ℂ)` on the right-hand side.
+  have hshift : (s : ℂ) + 1 = ((s + 1 : ℝ) : ℂ) := by rw [Complex.ofReal_add, Complex.ofReal_one]
+  rw [hshift,
     ← ofReal_lowerIncompleteGamma_eq_partialGamma hs1 hx,
     ← ofReal_lowerIncompleteGamma_eq_partialGamma hs hx, ← Complex.ofReal_cpow hx s,
     ← Complex.ofReal_mul, ← Complex.ofReal_mul, ← Complex.ofReal_sub, Complex.ofReal_inj] at key
@@ -331,14 +333,20 @@ theorem tendsto_lowerIncompleteGamma_atTop (hs : 0 < s) :
     Tendsto (lowerIncompleteGamma s) atTop (𝓝 (Real.Gamma s)) := by
   have hmax : Tendsto (fun x : ℝ => max x 0) atTop atTop :=
     tendsto_atTop_mono (fun x => le_max_left x 0) tendsto_id
-  rw [lowerIncompleteGamma_eq_comp hs, ← integral_Ioi_rpow_mul_exp_neg_eq_Gamma hs]
-  exact (intervalIntegral_tendsto_integral_Ioi 0
-    (integrableOn_rpow_mul_exp_neg (by linarith : (-1 : ℝ) < s - 1)) tendsto_id).comp hmax
+  -- Mathlib's `Real.GammaIntegral_convergent` and `Real.Gamma_eq_integral` write Euler's integrand
+  -- as `exp (-t) * t ^ (s - 1)`; both are used here in this file's factor order.
+  have hint : IntegrableOn (fun t : ℝ => t ^ (s - 1) * Real.exp (-t)) (Ioi 0) :=
+    (Real.GammaIntegral_convergent hs).congr_fun (fun t _ => mul_comm _ _) measurableSet_Ioi
+  have hGamma : ∫ t in Ioi (0 : ℝ), t ^ (s - 1) * Real.exp (-t) = Real.Gamma s := by
+    rw [Real.Gamma_eq_integral hs]
+    exact setIntegral_congr_fun measurableSet_Ioi fun t _ => mul_comm _ _
+  rw [lowerIncompleteGamma_eq_comp hs, ← hGamma]
+  exact (intervalIntegral_tendsto_integral_Ioi 0 hint tendsto_id).comp hmax
 
 /-- A truncated Euler integral is at most the complete one. -/
 theorem lowerIncompleteGamma_le_Gamma (hs : 0 < s) (x : ℝ) :
     lowerIncompleteGamma s x ≤ Real.Gamma s :=
-  (monotone_lowerIncompleteGamma s).ge_of_tendsto (tendsto_lowerIncompleteGamma_atTop hs) x
+  (lowerIncompleteGamma_monotone s).ge_of_tendsto (tendsto_lowerIncompleteGamma_atTop hs) x
 
 /-- `P(s, x)` increases to `1` as `x → ∞`: it is the cumulative distribution function of a
 probability law. -/

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
@@ -6,9 +6,6 @@ Authors: Claude
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
-public import Mathlib.MeasureTheory.Integral.IntegralEqImproper
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
-import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
 
 /-!
 # The lower incomplete gamma function
@@ -152,20 +149,6 @@ theorem regularizedGamma_eq_div (s x : ℝ) :
 theorem regularizedGamma_eq_zero_of_nonpos_right (s : ℝ) (hx : x ≤ 0) :
     regularizedGamma s x = 0 := by
   rw [regularizedGamma_eq_div, lowerIncompleteGamma_eq_zero_of_nonpos_right s hx, zero_div]
-
-/-- `γ(s, 0) = 0`, the value at the left endpoint of the support.
-
-This is not itself a `simp` lemma: `simp` discharges `(0 : ℝ) ≤ 0` and so already rewrites with
-`TauCeti.lowerIncompleteGamma_eq_zero_of_nonpos_right` here. -/
-theorem lowerIncompleteGamma_zero_right (s : ℝ) : lowerIncompleteGamma s 0 = 0 :=
-  lowerIncompleteGamma_eq_zero_of_nonpos_right s le_rfl
-
-/-- `P(s, 0) = 0`, the value at the left endpoint of the support.
-
-As for `TauCeti.lowerIncompleteGamma_zero_right`, `simp` reaches this through
-`TauCeti.regularizedGamma_eq_zero_of_nonpos_right`, so it carries no `@[simp]` of its own. -/
-theorem regularizedGamma_zero_right (s : ℝ) : regularizedGamma s 0 = 0 :=
-  regularizedGamma_eq_zero_of_nonpos_right s le_rfl
 
 /-- `γ(s, ·)` is the truncated Euler integral read at `max x 0`.
 
@@ -367,6 +350,7 @@ theorem regularizedGamma_le_one (s x : ℝ) : regularizedGamma s x ≤ 1 := by
 /-! ### The exponential case `s = 1` -/
 
 /-- `γ(1, x) = 1 - exp (-x)` for `0 ≤ x`. -/
+@[simp]
 theorem lowerIncompleteGamma_one (hx : 0 ≤ x) :
     lowerIncompleteGamma 1 x = 1 - Real.exp (-x) := by
   rw [lowerIncompleteGamma_eq_integral one_pos hx]
@@ -376,6 +360,7 @@ theorem lowerIncompleteGamma_one (hx : 0 ≤ x) :
 
 /-- `P(1, x) = 1 - exp (-x)` for `0 ≤ x`: the regularized lower incomplete gamma function at shape
 `1` is the cumulative distribution function of the standard exponential law. -/
+@[simp]
 theorem regularizedGamma_one (hx : 0 ≤ x) : regularizedGamma 1 x = 1 - Real.exp (-x) := by
   rw [regularizedGamma_eq_div, lowerIncompleteGamma_one hx, Real.Gamma_one, div_one]
 

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean
@@ -40,8 +40,9 @@ the parameter range.
   `TauCeti.regularizedGamma_le_one` — the range;
 * `TauCeti.hasDerivAt_lowerIncompleteGamma`, `TauCeti.hasDerivAt_regularizedGamma` and the
   companion `deriv` lemmas — differentiability, for `0 < x` only;
-* `TauCeti.lowerIncompleteGamma_add_one` — the recurrence
-  `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)`, for `0 < s` and `0 ≤ x`;
+* `TauCeti.lowerIncompleteGamma_add_one` and `TauCeti.regularizedGamma_add_one` — the recurrence
+  `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)` and its regularized form
+  `P(s + 1, x) = P(s, x) - x ^ s * exp (-x) / Γ(s + 1)`, both for `0 < s` and `0 ≤ x`;
 * `TauCeti.tendsto_lowerIncompleteGamma_atTop`, `TauCeti.tendsto_regularizedGamma_atTop` — the
   limits `Real.Gamma s` and `1` as `x → ∞`, with the resulting bounds
   `TauCeti.lowerIncompleteGamma_le_Gamma` and `TauCeti.regularizedGamma_le_one`;
@@ -308,6 +309,15 @@ theorem lowerIncompleteGamma_add_one (hs : 0 < s) (hx : 0 ≤ x) :
     ← Complex.ofReal_mul, ← Complex.ofReal_mul, ← Complex.ofReal_sub, Complex.ofReal_inj] at key
   rw [key]
   ring
+
+/-- The regularized form of the recurrence, `P(s + 1, x) = P(s, x) - x ^ s * exp (-x) / Γ(s + 1)`,
+for `0 < s` and `0 ≤ x`. The factor `s` of `TauCeti.lowerIncompleteGamma_add_one` is absorbed by
+`Real.Gamma_add_one`. -/
+theorem regularizedGamma_add_one (hs : 0 < s) (hx : 0 ≤ x) :
+    regularizedGamma (s + 1) x =
+      regularizedGamma s x - x ^ s * Real.exp (-x) / Real.Gamma (s + 1) := by
+  rw [regularizedGamma_eq_div, regularizedGamma_eq_div, lowerIncompleteGamma_add_one hs hx,
+    Real.Gamma_add_one hs.ne', sub_div, mul_div_mul_left _ _ hs.ne']
 
 /-! ### The limit at infinity -/
 


### PR DESCRIPTION
This PR defines the lower incomplete gamma function `TauCeti.lowerIncompleteGamma` and its regularization `TauCeti.regularizedGamma`, and develops the real-variable theory the `StandardDistributions` roadmap asks of them. It serves the Layer 2 milestone "incomplete special functions and closed-form cdfs", covering that layer's "Lower incomplete gamma" target in full: the two definitions with the stated clamping conventions (`γ(s, x) = ∫ t in 0..max x 0, t ^ (s - 1) * exp (-t)` guarded on `0 < s`, and `P(s, x) = γ(s, x) / Γ(s)` guarded the same way), convergence, continuity and monotonicity for every `x`, the recurrence `γ(s + 1, x) = s * γ(s, x) - x ^ s * exp (-x)` for `0 ≤ x`, `P(s, x) → 1` as `x → ∞`, differentiability with `deriv = x ^ (s - 1) * exp (-x)` stated only for `0 < x`, and the layer's completion check `regularizedGamma 1 x = 1 - exp (-x)` for `0 ≤ x`. Layer 2's other two special functions are separate targets: the error function is in flight as #4161, and the regularized incomplete beta is untouched. After this PR the layer's remaining work is that beta function together with the "Closed-form cdfs and tails" bullets, of which `cdf_gammaMeasure_eq` and `poissonMeasure_tail_eq_regularizedGamma` are exactly the two consumers of what lands here.

`TauCeti/Analysis/SpecialFunctions/IncompleteGamma.lean` (375 lines) is the file the roadmap's Layer 2 file list names. Alongside the two definitions it proves the characteristic descriptions `lowerIncompleteGamma_eq_integral` and `regularizedGamma_eq_div`, the four totalization lemmas at a nonpositive shape and below the support with their `@[simp]` specializations at `x = 0`, `lowerIncompleteGamma_nonneg`, `regularizedGamma_nonneg`, `regularizedGamma_le_one`, `monotone_lowerIncompleteGamma`, `monotone_regularizedGamma`, `continuous_lowerIncompleteGamma`, `continuous_regularizedGamma`, `hasDerivAt_lowerIncompleteGamma`, `hasDerivAt_regularizedGamma` and their `deriv` companions, `lowerIncompleteGamma_add_one`, `tendsto_lowerIncompleteGamma_atTop`, `lowerIncompleteGamma_le_Gamma`, `tendsto_regularizedGamma_atTop`, and `lowerIncompleteGamma_one` with `regularizedGamma_one`. Monotonicity and continuity are stated for every shape parameter, not just the valid range, since the totalized value is constant; the bounds involving `Real.Gamma s` keep `0 < s`, where `Real.Gamma` can be negative otherwise. Taken together the range, monotonicity, continuity and limit results are precisely what identifies `P(s, ·)` as a cumulative distribution function downstream.

Two points about reuse. `intervalIntegrable_rpow_mul_exp_neg` is the interval form of Mathlib's `Real.GammaIntegral_convergent`, stated at the natural hypothesis `-1 < p` on the exponent rather than at `0 < s`; it is what carries convergence at the singularity `0` when `s < 1`, and every integral manipulation in the file goes through it. The recurrence is not reproved: `ofReal_lowerIncompleteGamma` identifies `γ(s, x)` with Mathlib's `Complex.partialGamma s x` at a real parameter, and `lowerIncompleteGamma_add_one` then reads off `Complex.partialGamma_add_one`, whose proof already does the integration by parts on `Set.Ioo 0 x` — the endpoint `0` has to be avoided because `t ^ s` is not differentiable there for `s < 1`. Global continuity likewise reuses `intervalIntegral.continuousOn_primitive_interval'` rather than re-deriving continuity of a primitive. No Mathlib material is vendored, and the conventions and notation follow DLMF ch. 8, cited in the module docstring.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"lowerincompletegamma"}-->

🤖 Prepared with Claude Code
