### PR TITLE
refactor(HeckeRing): state the Γ₀ coset layer at the unfolded spelling

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Basic.lean
@@ -75,7 +75,7 @@ noncomputable def Gamma0Image : Subgroup (GL (Fin 2) ℚ) :=
 /-- `Gamma0Image N` unfolded. Stated here, in the file where the definition lives, because
 downstream modules cannot see through the `def`: without this lemma a containment proved for
 `Gamma0Image N` cannot be reused where `(Gamma0 N).map (mapGL ℚ)` is expected. -/
-lemma Gamma0Image_eq : Gamma0Image N = (Gamma0 N).map (mapGL ℚ) := by
+lemma Gamma0Image_def : Gamma0Image N = (Gamma0 N).map (mapGL ℚ) := by
   rw [Gamma0Image]
 
 /-- `Γ₀(N) ≤ Δ₀(N)`: an element of `Γ₀(N)` has `ad ≡ 1` modulo `N`, since `c ≡ 0` and the

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Basic.lean
@@ -72,6 +72,12 @@ noncomputable def Gamma0Image : Subgroup (GL (Fin 2) ℚ) :=
     g ∈ Gamma0Image N ↔ ∃ σ ∈ Gamma0 N, mapGL ℚ σ = g := by
   rw [Gamma0Image, Subgroup.mem_map]
 
+/-- `Gamma0Image N` unfolded. Stated here, in the file where the definition lives, because
+downstream modules cannot see through the `def`: without this lemma a containment proved for
+`Gamma0Image N` cannot be reused where `(Gamma0 N).map (mapGL ℚ)` is expected. -/
+lemma Gamma0Image_eq : Gamma0Image N = (Gamma0 N).map (mapGL ℚ) := by
+  rw [Gamma0Image]
+
 /-- `Γ₀(N) ≤ Δ₀(N)`: an element of `Γ₀(N)` has `ad ≡ 1` modulo `N`, since `c ≡ 0` and the
 determinant is one, so its upper-left entry is a unit — which is exactly what `Δ₀(N)` asks.
 This containment is also what puts the diamond operators into the Hecke ring of `Γ₁(N)`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -73,8 +73,8 @@ noncomputable def toLevelOneCoset :
     HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ))
       ((Gamma0 N).map (mapGL ℚ)) →
       HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
-  HeckeCoset.map (Delta0_le_posDetInt N) (Gamma0Image_eq N ▸ Gamma0Image_le_SLnZ N)
-    (Gamma0Image_eq N ▸ Gamma0Image_le_SLnZ N)
+  HeckeCoset.map (Delta0_le_posDetInt N) (Gamma0_map_le_SLnZ N)
+    (Gamma0_map_le_SLnZ N)
 
 /-- The computation rule for `toLevelOneCoset`: it keeps the representative and forgets the
 level. -/
@@ -91,8 +91,8 @@ private lemma intMatrix_det_eq_of_mem_doubleCoset {a b : GL (Fin 2) ℚ}
     {A B : Matrix (Fin 2) (Fin 2) ℤ}
     (hA : (↑a : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (hB : (↑b : Matrix (Fin 2) (Fin 2) ℚ) = B.map (Int.cast : ℤ → ℚ)) : B.det = A.det := by
-  have hdet := det_eq_of_mem_doubleCoset_of_le_SLnZ 2 (Gamma0Image_eq N ▸ Gamma0Image_le_SLnZ N)
-    (Gamma0Image_eq N ▸ Gamma0Image_le_SLnZ N) hb
+  have hdet := det_eq_of_mem_doubleCoset_of_le_SLnZ 2 (Gamma0_map_le_SLnZ N)
+    (Gamma0_map_le_SLnZ N) hb
   have hcast : ((B.det : ℤ) : ℚ) = ((A.det : ℤ) : ℚ) := by
     rw [Int.cast_det B, Int.cast_det A, ← hB, ← hA]; exact hdet
   exact_mod_cast hcast

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/CosetMap.lean
@@ -16,14 +16,15 @@ public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.DoubleCoset
 
 ```lean
 noncomputable def toLevelOneCoset :
-    HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) →
+    HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)) →
       HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2)
 ```
 
 and it is **injective on the cosets whose determinant is coprime to the level**
 (`toLevelOneCoset_injOn`). Injectivity is the content: two `Γ₀(N)`-double cosets
 with the same level-one double coset are recovered from it by intersecting with `Δ₀(N)`, which
-is exactly `doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image`.
+is exactly `doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map`.
 
 This is the injectivity step towards a later good-prime comparison of `R(Γ₀(N), Δ₀(N))` with
 the level-one Hecke ring. Neither surjectivity nor compatibility with the Hecke-ring operations
@@ -69,34 +70,37 @@ variable (N : ℕ)
 coset of the same element, as the `HeckeCoset.map` of the three inclusions `Δ₀(N) ≤ Δ`,
 `Γ₀(N) ≤ SL₂(ℤ)` (twice). -/
 noncomputable def toLevelOneCoset :
-    HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) →
+    HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)) →
       HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2) :=
-  HeckeCoset.map (Delta0_le_posDetInt N) (Gamma0Image_le_SLnZ N) (Gamma0Image_le_SLnZ N)
+  HeckeCoset.map (Delta0_le_posDetInt N) (Gamma0Image_eq N ▸ Gamma0Image_le_SLnZ N)
+    (Gamma0Image_eq N ▸ Gamma0Image_le_SLnZ N)
 
 /-- The computation rule for `toLevelOneCoset`: it keeps the representative and forgets the
 level. -/
 @[simp] lemma toLevelOneCoset_mk (g : Delta0 N) :
-    toLevelOneCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) g) =
+    toLevelOneCoset N (HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) g) =
       HeckeCoset.mk (SLnZ 2) (SLnZ 2) (Submonoid.inclusion (Delta0_le_posDetInt N) g) :=
   HeckeCoset.map_mk _ _ _ g
 
 /-- The integral matrices of two elements of one `Γ₀(N)`-double coset have equal determinant:
 `Γ₀(N) ≤ SL₂(ℤ)`, and the determinant is constant on an `SL₂(ℤ)`-double coset. -/
 private lemma intMatrix_det_eq_of_mem_doubleCoset {a b : GL (Fin 2) ℚ}
-    (hb : b ∈ DoubleCoset.doubleCoset a (Gamma0Image N) (Gamma0Image N))
+    (hb : b ∈ DoubleCoset.doubleCoset a ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)))
     {A B : Matrix (Fin 2) (Fin 2) ℤ}
     (hA : (↑a : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (hB : (↑b : Matrix (Fin 2) (Fin 2) ℚ) = B.map (Int.cast : ℤ → ℚ)) : B.det = A.det := by
-  have hdet := det_eq_of_mem_doubleCoset_of_le_SLnZ 2 (Gamma0Image_le_SLnZ N)
-    (Gamma0Image_le_SLnZ N) hb
+  have hdet := det_eq_of_mem_doubleCoset_of_le_SLnZ 2 (Gamma0Image_eq N ▸ Gamma0Image_le_SLnZ N)
+    (Gamma0Image_eq N ▸ Gamma0Image_le_SLnZ N) hb
   have hcast : ((B.det : ℤ) : ℚ) = ((A.det : ℤ) : ℚ) := by
     rw [Int.cast_det B, Int.cast_det A, ← hB, ← hA]; exact hdet
   exact_mod_cast hcast
 
 /-- Coprimality of the determinant to the level depends only on the double coset. -/
 private lemma coprimeDet_congr {a b : Delta0 N}
-    (h : HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) a =
-      HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) b) :
+    (h : HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) a =
+      HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) b) :
     CoprimeDet N a ↔ CoprimeDet N b := by
   obtain ⟨Aa, hAa, -, -, -⟩ := (mem_Delta0_iff N).mp a.2
   obtain ⟨Ab, hAb, -, -, -⟩ := (mem_Delta0_iff N).mp b.2
@@ -105,13 +109,16 @@ private lemma coprimeDet_congr {a b : Delta0 N}
   rw [coprimeDet_iff N hAa, coprimeDet_iff N hAb, hba]
 
 /-- Coprimality of the determinant to the level, as a predicate on `Γ₀(N)`-double cosets. -/
-def CoprimeDetCoset : HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) → Prop :=
+def CoprimeDetCoset : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)) → Prop :=
   Quotient.lift (CoprimeDet N)
     (fun _ _ hab ↦ propext (coprimeDet_congr N (Quotient.sound hab)))
 
 /-- `CoprimeDetCoset` is `CoprimeDet` on any representative. -/
 @[simp] lemma coprimeDetCoset_mk (g : Delta0 N) :
-    CoprimeDetCoset N (HeckeCoset.mk (Gamma0Image N) (Gamma0Image N) g) ↔ CoprimeDet N g :=
+    CoprimeDetCoset N
+        (HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) g) ↔
+      CoprimeDet N g :=
   Iff.rfl
 
 /-- **Shimura, Proposition 3.31.** `toLevelOneCoset` is injective on the double cosets whose
@@ -132,9 +139,9 @@ theorem toLevelOneCoset_injOn :
   obtain ⟨Ab, hAb, -, -, -⟩ := (mem_Delta0_iff N).mp D₂.rep.2
   refine HeckeCoset.eq_iff.mpr ?_
   -- each `Γ₀(N)`-double coset is its level-one one cut down to `Δ₀(N)`, and those agree
-  rw [← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ D₁.rep.2 Aa hAa
+  rw [← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map N _ D₁.rep.2 Aa hAa
       ((coprimeDet_iff N hAa).mp hD₁'),
-    ← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image N _ D₂.rep.2 Ab hAb
+    ← doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map N _ D₂.rep.2 Ab hAb
       ((coprimeDet_iff N hAb).mp hD₂'), h]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DiagonalCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DiagonalCoset.lean
@@ -53,7 +53,7 @@ Ported from the AINTLIB `LeanModularForms` project
 
 public section
 
-open Matrix Matrix.SpecialLinearGroup HeckeRing.GLn
+open Matrix Matrix.SpecialLinearGroup HeckeRing.GLn CongruenceSubgroup
 
 open scoped Pointwise MatrixGroups
 
@@ -85,19 +85,20 @@ Coprimality stays in the signature because it is what puts the matrix in `Δ₀(
 under positivity: without it `natDiagGL` falls back to the identity, which lies in `Δ₀(N)`
 regardless of the level. -/
 noncomputable def diagCosetGamma0 (a : Fin 2 → ℕ) (hgcd : (∀ i, 0 < a i) → Nat.Coprime (a 0) N) :
-    HeckeCoset (Delta0 N) (Gamma0Image N) (Gamma0Image N) :=
+    HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) :=
   HeckeCoset.mk _ _ ⟨natDiagGL 2 a, natDiagGL_mem_Delta0_of_coprime N a hgcd⟩
 
 /-- Defining equation for the sealed definition `diagCosetGamma0`. -/
 lemma diagCosetGamma0_def (a : Fin 2 → ℕ) (hgcd : (∀ i, 0 < a i) → Nat.Coprime (a 0) N) :
     diagCosetGamma0 N a hgcd =
-      HeckeCoset.mk (Gamma0Image N) (Gamma0Image N)
+      HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
         ⟨natDiagGL 2 a, natDiagGL_mem_Delta0_of_coprime N a hgcd⟩ := (rfl)
 
 /-- The underlying set of `diagCosetGamma0 a` is the `Γ₀(N)`-double coset of `diag(a)`. -/
 @[simp] lemma diagCosetGamma0_toSet (a : Fin 2 → ℕ) (hgcd : (∀ i, 0 < a i) → Nat.Coprime (a 0) N) :
     (diagCosetGamma0 N a hgcd).toSet =
-      DoubleCoset.doubleCoset (natDiagGL 2 a) (Gamma0Image N) (Gamma0Image N) :=
+      DoubleCoset.doubleCoset (natDiagGL 2 a) ((Gamma0 N).map (mapGL ℚ))
+        ((Gamma0 N).map (mapGL ℚ)) :=
   HeckeCoset.toSet_mk _
 
 /-- The `Γ₀(N)`-coset of `diag(a)` lies over the level-one coset `T(a)`: widening both

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -37,7 +37,7 @@ Ported from the AINTLIB `LeanModularForms` project
 
 ## Main results
 
-* `HeckeRing.GL2.Gamma0Image_le_SLnZ`: `Γ₀(N) ≤ SL₂(ℤ)` inside `GL₂(ℚ)`.
+* `HeckeRing.GL2.Gamma0_map_le_SLnZ`: `Γ₀(N) ≤ SL₂(ℤ)` inside `GL₂(ℚ)`.
 * `HeckeRing.GL2.doubleCoset_Gamma0Image_le_doubleCoset_SLnZ`: `Γ₀(N) α Γ₀(N) ⊆ Γ α Γ`.
 * `HeckeRing.GL2.doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map`: the equality above.
 
@@ -58,8 +58,13 @@ namespace HeckeRing.GL2
 variable (N : ℕ)
 
 /-- `Γ₀(N) ≤ SL₂(ℤ)` as subgroups of `GL₂(ℚ)`: the image of any integral matrix of determinant
-one lies in the range of `mapGL`. -/
-lemma Gamma0Image_le_SLnZ : Gamma0Image N ≤ SLnZ 2 := by
+one lies in the range of `mapGL`.
+
+Stated at the unfolded `(Gamma0 N).map (mapGL ℚ)` so the coset layer can use it directly: the
+`HeckeCoset` types of `CosetMap.lean` are spelled that way, and transporting a folded
+containment along `Gamma0Image_def` at each use site would hide the canonical form. -/
+lemma Gamma0_map_le_SLnZ : (Gamma0 N).map (mapGL ℚ) ≤ SLnZ 2 := by
+  rw [← Gamma0Image_def N]
   intro g hg
   obtain ⟨σ, -, rfl⟩ := (mem_Gamma0Image_iff N).mp hg
   exact (mem_SLnZ_iff 2).mpr ⟨σ, rfl⟩
@@ -68,9 +73,12 @@ lemma Gamma0Image_le_SLnZ : Gamma0Image N ≤ SLnZ 2 := by
 lemma doubleCoset_Gamma0Image_le_doubleCoset_SLnZ (α : GL (Fin 2) ℚ) :
     DoubleCoset.doubleCoset α (Gamma0Image N) (Gamma0Image N) ⊆
       DoubleCoset.doubleCoset α (SLnZ 2) (SLnZ 2) := fun _ hx ↦ by
+  -- this statement is at the folded spelling, so the containment is folded back once here
+  -- rather than at each of the two members
+  have hle : Gamma0Image N ≤ SLnZ 2 := Gamma0Image_def N ▸ Gamma0_map_le_SLnZ N
   rw [DoubleCoset.mem_doubleCoset] at hx ⊢
   obtain ⟨γ₁, hγ₁, γ₂, hγ₂, hx_eq⟩ := hx
-  exact ⟨γ₁, Gamma0Image_le_SLnZ N hγ₁, γ₂, Gamma0Image_le_SLnZ N hγ₂, hx_eq⟩
+  exact ⟨γ₁, hle hγ₁, γ₂, hle hγ₂, hx_eq⟩
 
 /-- If `N ∣ c` and `det` is coprime to `N`, then so is the lower-right entry: modulo `N` the
 determinant is `a * d`, so `d` divides a unit. -/
@@ -203,8 +211,8 @@ theorem doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map
     DoubleCoset.doubleCoset α (SLnZ 2) (SLnZ 2) ∩ (Delta0 N : Set (GL (Fin 2) ℚ)) =
       DoubleCoset.doubleCoset α ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) := by
   -- the conclusion is an equation of *sets*, so the two spellings of `Γ₀(N)` may be exchanged
-  -- by rewriting; the coset *types* of `CosetMap.lean` cannot (see `Gamma0Image_eq`)
-  rw [← Gamma0Image_eq N]
+  -- by rewriting; the coset *types* of `CosetMap.lean` cannot (see `Gamma0Image_def`)
+  rw [← Gamma0Image_def N]
   obtain ⟨B, hB, -, hBN, -⟩ := (mem_Delta0_iff N).mp hα
   -- `Δ₀(N)` already supplies an integral representative with `N ∣ c`, and `hA` identifies it
   -- with `A`, so the divisibility need not be assumed

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -38,7 +38,7 @@ Ported from the AINTLIB `LeanModularForms` project
 ## Main results
 
 * `HeckeRing.GL2.Gamma0_map_le_SLnZ`: `Γ₀(N) ≤ SL₂(ℤ)` inside `GL₂(ℚ)`.
-* `HeckeRing.GL2.doubleCoset_Gamma0Image_le_doubleCoset_SLnZ`: `Γ₀(N) α Γ₀(N) ⊆ Γ α Γ`.
+* `HeckeRing.GL2.doubleCoset_Gamma0_map_le_doubleCoset_SLnZ`: `Γ₀(N) α Γ₀(N) ⊆ Γ α Γ`.
 * `HeckeRing.GL2.doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map`: the equality above.
 
 ## References
@@ -70,15 +70,12 @@ lemma Gamma0_map_le_SLnZ : (Gamma0 N).map (mapGL ℚ) ≤ SLnZ 2 := by
   exact (mem_SLnZ_iff 2).mpr ⟨σ, rfl⟩
 
 /-- `Γ₀(N) α Γ₀(N) ⊆ Γ α Γ`: immediate from `Γ₀(N) ≤ SL₂(ℤ)`. -/
-lemma doubleCoset_Gamma0Image_le_doubleCoset_SLnZ (α : GL (Fin 2) ℚ) :
-    DoubleCoset.doubleCoset α (Gamma0Image N) (Gamma0Image N) ⊆
+lemma doubleCoset_Gamma0_map_le_doubleCoset_SLnZ (α : GL (Fin 2) ℚ) :
+    DoubleCoset.doubleCoset α ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) ⊆
       DoubleCoset.doubleCoset α (SLnZ 2) (SLnZ 2) := fun _ hx ↦ by
-  -- this statement is at the folded spelling, so the containment is folded back once here
-  -- rather than at each of the two members
-  have hle : Gamma0Image N ≤ SLnZ 2 := Gamma0Image_def N ▸ Gamma0_map_le_SLnZ N
   rw [DoubleCoset.mem_doubleCoset] at hx ⊢
   obtain ⟨γ₁, hγ₁, γ₂, hγ₂, hx_eq⟩ := hx
-  exact ⟨γ₁, hle hγ₁, γ₂, hle hγ₂, hx_eq⟩
+  exact ⟨γ₁, Gamma0_map_le_SLnZ N hγ₁, γ₂, Gamma0_map_le_SLnZ N hγ₂, hx_eq⟩
 
 /-- If `N ∣ c` and `det` is coprime to `N`, then so is the lower-right entry: modulo `N` the
 determinant is `a * d`, so `d` divides a unit. -/
@@ -228,7 +225,13 @@ theorem doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map
     obtain ⟨σ₂, rfl⟩ := (mem_SLnZ_iff 2).mp hγ₂
     exact mem_doubleCoset_Gamma0Image_of_mem_Delta0 N α A hA hAN hA11 hdet σ₁ σ₂ hx_delta
   · intro hx
-    refine ⟨doubleCoset_Gamma0Image_le_doubleCoset_SLnZ N α hx, ?_⟩
+    -- the goal was folded above to reuse the private folded lemmas, so the unfolded
+    -- containment is folded back once here
+    have hsub : DoubleCoset.doubleCoset α (Gamma0Image N) (Gamma0Image N) ⊆
+        DoubleCoset.doubleCoset α (SLnZ 2) (SLnZ 2) := by
+      rw [Gamma0Image_def N]
+      exact doubleCoset_Gamma0_map_le_doubleCoset_SLnZ N α
+    refine ⟨hsub hx, ?_⟩
     rw [DoubleCoset.mem_doubleCoset] at hx
     obtain ⟨δ₁, hδ₁, δ₂, hδ₂, rfl⟩ := hx
     exact (Delta0 N).mul_mem ((Delta0 N).mul_mem (Gamma0Image_le_Delta0 N hδ₁) hα)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/DoubleCoset.lean
@@ -39,7 +39,7 @@ Ported from the AINTLIB `LeanModularForms` project
 
 * `HeckeRing.GL2.Gamma0Image_le_SLnZ`: `Γ₀(N) ≤ SL₂(ℤ)` inside `GL₂(ℚ)`.
 * `HeckeRing.GL2.doubleCoset_Gamma0Image_le_doubleCoset_SLnZ`: `Γ₀(N) α Γ₀(N) ⊆ Γ α Γ`.
-* `HeckeRing.GL2.doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image`: the equality above.
+* `HeckeRing.GL2.doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map`: the equality above.
 
 ## References
 
@@ -196,12 +196,15 @@ double coset down to `Δ₀(N)` leaves exactly the `Γ₀(N)`-double coset:
 This is the prerequisite for comparing the level-one and `Γ₀(N)` Hecke operators at an index
 coprime to the level, and so for the later multiplicativity of `T_n` on `M_k(Γ₀(N))`; neither
 comparison nor multiplicativity is proved here — this identifies the two double cosets. -/
-theorem doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0Image
+theorem doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map
     (α : GL (Fin 2) ℚ) (hα : α ∈ Delta0 N) (A : Matrix (Fin 2) (Fin 2) ℤ)
     (hA : (↑α : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (hdet : Int.gcd A.det N = 1) :
     DoubleCoset.doubleCoset α (SLnZ 2) (SLnZ 2) ∩ (Delta0 N : Set (GL (Fin 2) ℚ)) =
-      DoubleCoset.doubleCoset α (Gamma0Image N) (Gamma0Image N) := by
+      DoubleCoset.doubleCoset α ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) := by
+  -- the conclusion is an equation of *sets*, so the two spellings of `Γ₀(N)` may be exchanged
+  -- by rewriting; the coset *types* of `CosetMap.lean` cannot (see `Gamma0Image_eq`)
+  rw [← Gamma0Image_eq N]
   obtain ⟨B, hB, -, hBN, -⟩ := (mem_Delta0_iff N).mp hα
   -- `Δ₀(N)` already supplies an integral representative with `N ∣ c`, and `hA` identifies it
   -- with `A`, so the divisibility need not be assumed


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"gamma0-coset-layer-unfolded"}-->

The `Γ₀(N)` coset layer under `TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/` was stated at the
folded `Gamma0Image N`. Downstream modules cannot see through that `def`, so a containment
proved for `Gamma0Image N` could not be reused where `(Gamma0 N).map (mapGL ℚ)` was expected —
which is the spelling the modular-form side writes its level in, and therefore the form
instance search looks for. This restates the layer at the unfolded spelling.

## What changes

* **`Basic.lean`** — names the definitional bridge

  ```lean
  lemma Gamma0Image_def : Gamma0Image N = (Gamma0 N).map (mapGL ℚ)
  ```

  It has to live in the file where `Gamma0Image` is defined: a `public` proof may not depend on
  an unexposed body, so `rfl` fails even locally and the proof is `rw [Gamma0Image]`, matching
  the neighbouring `mem_Gamma0Image_iff`.

* **`DoubleCoset.lean`** — the `SL₂(ℤ)` containment is **restated** at the unfolded spelling as
  `Gamma0_map_le_SLnZ : (Gamma0 N).map (mapGL ℚ) ≤ SLnZ 2`, so the coset layer uses the
  canonical form directly instead of transporting a folded one. Shimura Lemma 3.29(3) is
  likewise restated in place, not wrapped: its conclusion is an equation of *sets*, so
  `rw [← Gamma0Image_def N]` reduces the unfolded statement to the existing proof, which is
  unchanged. It is renamed `doubleCoset_SLnZ_inter_Delta0_eq_doubleCoset_Gamma0_map` to match.
  Neither old name has any remaining occurrence in the repository.

* **`DiagonalCoset.lean`** — `diagCosetGamma0`, its `_def` and its `_toSet` lemma move to the
  unfolded spelling; `CongruenceSubgroup` joins the `open` line.

* **`CosetMap.lean`** — seven coset-type positions retyped, and the private
  `intMatrix_det_eq_of_mem_doubleCoset` hypothesis retyped. It now calls `Gamma0_map_le_SLnZ`
  directly; the four equality transports it previously carried are gone.

## Why a bridge lemma and not a rewrite at the use sites

A spelling migration cannot be finished by rewriting at use sites. `HeckeCoset Δ H₁ H₂`
*depends* on the subgroups, so folding a goal back with `rw [← Gamma0Image_def N]` in a
coset-type position fails with `motive is not type correct` — no motive exists. Casting a `Prop`
along the bridge does work, which is why the set-level statements can use it while the type
positions had to be genuinely restated. Making the `def` `@[reducible]` or `@[expose]` was tried
and does not help: `@[expose]` is cross-module body visibility, whereas instance search needs
reducibility, and `@[reducible]` triggers a simpNF cascade while still failing instance
synthesis.

Exactly one fold along the bridge remains, inside
`doubleCoset_Gamma0Image_le_doubleCoset_SLnZ`, whose *statement* is at the folded spelling; it
happens once in a named `have` rather than once per member.

## Relation to #4146

Independent, and measured rather than assumed. This branch is cut fresh from `origin/main` and
builds **without** #4146's unfolded `IsHeckeTriple` instance — `Basic.lean` here still carries
the folded instance from `main`. The two touch `Basic.lean` in different hunks and
`git merge-tree --write-tree` reports no conflict in either order. #4146 is where the
`IsHeckeTriple` instance moves to the unfolded spelling; it is open and approved.

Provenance: none — this is a refactor of existing TauCeti code, not a port. AINTLIB has no
folded/unfolded distinction, because it bundles the pair as a `HeckePair`.
