### PR TITLE
feat: the Bernstein representing measure, measurably in a parameter

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
@@ -32,6 +32,8 @@ uniqueness both live in `Laplace/Representation.lean`.
 
 * `TauCeti.exists_representsLaplace_of_isContinuousCompletelyMonotoneOnIoi`
 * `TauCeti.hausdorff_bernstein_widder`, `TauCeti.hausdorff_bernstein_widder_existsUnique`
+* `TauCeti.bernsteinMeasure`: the canonical representing measure, with its uniqueness,
+  total-mass, and algebraic API.
 
 ## References
 
@@ -44,7 +46,7 @@ S. Bernstein (1928) and D. V. Widder, *The Laplace Transform*, Chapter IV.
 
 public section
 
-open MeasureTheory Set Filter
+open MeasureTheory ProbabilityTheory Set Filter
 open scoped BoundedContinuousFunction ContDiff ENNReal NNReal Topology
 
 namespace TauCeti
@@ -366,5 +368,90 @@ theorem hausdorff_bernstein_widder_existsUnique (f : ℝ → ℝ) :
   rw [hausdorff_bernstein_widder]
   exact ⟨fun ⟨μ, hμ⟩ => ⟨μ, hμ, fun ν hν => hν.unique hμ⟩,
     fun ⟨μ, hμ, _⟩ => ⟨μ, hμ⟩⟩
+
+/-! ## The canonical representing measure -/
+
+variable {f : ℝ → ℝ}
+
+open Classical in
+/-- **The Bernstein representing measure** of `f`: the unique finite measure on `ℝ≥0` whose
+Laplace transform is `f` on `[0, ∞)`, when `f` has one, and the zero measure otherwise.
+
+By `TauCeti.hausdorff_bernstein_widder` a representing measure exists exactly when `f` is
+continuous on `[0, ∞)` and completely monotone on `(0, ∞)`. -/
+noncomputable def bernsteinMeasure (f : ℝ → ℝ) : Measure ℝ≥0 :=
+  if h : ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f then h.choose else 0
+
+/-- Outside the hypotheses of the Hausdorff--Bernstein--Widder theorem the Bernstein measure is
+`0`. -/
+theorem bernsteinMeasure_eq_zero_of_not (h : ¬ ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f) :
+    bernsteinMeasure f = 0 := by
+  classical
+  rw [bernsteinMeasure, dite_eq_right h]
+
+/-- **The Bernstein measure represents its function.** -/
+theorem representsLaplace_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f) :
+    RepresentsLaplace (bernsteinMeasure f) f := by
+  classical
+  have h : ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := (hausdorff_bernstein_widder f).mp hf
+  rw [bernsteinMeasure, dite_eq_left h]
+  exact h.choose_spec
+
+/-- The Bernstein measure of any function is finite: for a represented function this is the
+finiteness of its representing measure, and otherwise the measure is `0`. -/
+instance isFiniteMeasure_bernsteinMeasure (f : ℝ → ℝ) : IsFiniteMeasure (bernsteinMeasure f) := by
+  classical
+  rw [bernsteinMeasure]
+  split
+  · rename_i h
+    exact h.choose_spec.isFiniteMeasure
+  · infer_instance
+
+/-- **Uniqueness of the Bernstein measure.** Any finite measure representing `f` by its Laplace
+transform is the Bernstein measure of `f`. No hypothesis on `f` is needed: a represented function
+is automatically continuous and completely monotone. -/
+theorem eq_bernsteinMeasure (μ : Measure ℝ≥0) (hμ : RepresentsLaplace μ f) :
+    μ = bernsteinMeasure f :=
+  hμ.unique (representsLaplace_bernsteinMeasure hμ.isContinuousCompletelyMonotoneOnIoi)
+
+/-- The Laplace transform of the Bernstein measure recovers the function on `[0, ∞)`. -/
+@[grind =>]
+theorem laplaceTransform_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f) {t : ℝ}
+    (ht : 0 ≤ t) : laplaceTransform (bernsteinMeasure f) t = f t :=
+  ((representsLaplace_bernsteinMeasure hf).eq_laplaceTransform ht).symm
+
+/-- The total mass of the Bernstein measure is the value of the function at `0`. -/
+theorem bernsteinMeasure_real_univ (hf : IsContinuousCompletelyMonotoneOnIoi f) :
+    (bernsteinMeasure f).real univ = f 0 :=
+  ((representsLaplace_bernsteinMeasure hf).apply_zero).symm
+
+/-- The total mass of the Bernstein measure, as an extended nonnegative real. -/
+theorem bernsteinMeasure_univ (hf : IsContinuousCompletelyMonotoneOnIoi f) :
+    bernsteinMeasure f univ = ENNReal.ofReal (f 0) := by
+  rw [← bernsteinMeasure_real_univ hf, measureReal_def,
+    ENNReal.ofReal_toReal (measure_ne_top _ _)]
+
+/-- A function with total mass `1` has a probability measure for its Bernstein measure. -/
+theorem isProbabilityMeasure_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f)
+    (hf0 : f 0 = 1) : IsProbabilityMeasure (bernsteinMeasure f) :=
+  isProbabilityMeasure_iff_real.mpr <| by rw [bernsteinMeasure_real_univ hf, hf0]
+
+/-- The Bernstein measure of the zero function is the zero measure. -/
+@[simp]
+theorem bernsteinMeasure_zero : bernsteinMeasure (fun _ : ℝ => (0 : ℝ)) = 0 :=
+  (eq_bernsteinMeasure 0 representsLaplace_zero).symm
+
+/-- The Bernstein measure turns sums of functions into sums of measures. -/
+theorem bernsteinMeasure_add {g : ℝ → ℝ} (hf : IsContinuousCompletelyMonotoneOnIoi f)
+    (hg : IsContinuousCompletelyMonotoneOnIoi g) :
+    bernsteinMeasure (f + g) = bernsteinMeasure f + bernsteinMeasure g :=
+  (eq_bernsteinMeasure _ ((representsLaplace_bernsteinMeasure hf).add
+    (representsLaplace_bernsteinMeasure hg))).symm
+
+/-- The Bernstein measure turns nonnegative scalar multiples of functions into scalar multiples of
+measures. -/
+theorem bernsteinMeasure_const_mul (hf : IsContinuousCompletelyMonotoneOnIoi f) (c : ℝ≥0) :
+    bernsteinMeasure (fun t => (c : ℝ) * f t) = (c : ℝ≥0∞) • bernsteinMeasure f :=
+  (eq_bernsteinMeasure _ ((representsLaplace_bernsteinMeasure hf).smul c)).symm
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
@@ -421,11 +421,13 @@ theorem laplaceTransform_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOn
   ((representsLaplace_bernsteinMeasure hf).eq_laplaceTransform ht).symm
 
 /-- The total mass of the Bernstein measure is the value of the function at `0`. -/
+@[simp]
 theorem bernsteinMeasure_real_univ (hf : IsContinuousCompletelyMonotoneOnIoi f) :
     (bernsteinMeasure f).real univ = f 0 :=
   ((representsLaplace_bernsteinMeasure hf).apply_zero).symm
 
 /-- The total mass of the Bernstein measure, as an extended nonnegative real. -/
+@[simp]
 theorem bernsteinMeasure_univ (hf : IsContinuousCompletelyMonotoneOnIoi f) :
     bernsteinMeasure f univ = ENNReal.ofReal (f 0) := by
   rw [← bernsteinMeasure_real_univ hf, measureReal_def,

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Kernel.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Kernel.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Bernstein.HausdorffBernsteinWidder
+public import TauCeti.Analysis.CompletelyMonotone.Laplace.Measurability
+public import Mathlib.Probability.Kernel.Defs
+
+/-!
+# The Bernstein representing measure, and its kernel form
+
+The Hausdorff--Bernstein--Widder theorem attaches to a completely monotone function `f` on
+`[0, ∞)` a *unique* finite measure on `ℝ≥0` whose Laplace transform is `f`. This file names that
+measure, `TauCeti.bernsteinMeasure`, develops its basic API, and — the point of the file — shows
+that it depends **measurably** on a parameter: a family `a ↦ f a` of completely monotone
+functions whose values at the natural numbers are measurable in `a` has Bernstein measures
+forming a `ProbabilityTheory.Kernel`.
+
+Measurability is not a selection statement. The representing measure is unique, so the family
+`a ↦ bernsteinMeasure (f a)` is already determined; what has to be proved is that this
+particular family is measurable, and that is
+`TauCeti.measurable_of_measurable_laplaceTransform_natCast`, applied to the identity
+`laplaceTransform (bernsteinMeasure (f a)) n = f a n`.
+
+## Main declarations
+
+* `TauCeti.bernsteinMeasure`: the representing measure of a completely monotone function, and
+  the zero measure for a function that has none.
+* `TauCeti.representsLaplace_bernsteinMeasure`, `TauCeti.eq_bernsteinMeasure`: it represents its
+  function, and it is the only finite measure that does.
+* `TauCeti.bernsteinMeasure_add`, `TauCeti.bernsteinMeasure_const_mul`,
+  `TauCeti.bernsteinMeasure_univ`: the algebraic API and the total mass.
+* `TauCeti.measurable_bernsteinMeasure`: measurable dependence on a parameter.
+* `TauCeti.bernsteinMeasureKernel`: the resulting kernel, with its finiteness criterion.
+
+## References
+
+The finite-measure representation is the Hausdorff--Bernstein--Widder theorem, after
+S. Bernstein (1928) and D. V. Widder, *The Laplace Transform*, Chapter IV; see also
+R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions* (de Gruyter, 2nd ed. 2012),
+Theorem 1.4.
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
+  (BCR semigroup--Bochner).
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory Set
+open scoped ENNReal NNReal
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+open Classical in
+/-- **The Bernstein representing measure** of `f`: the unique finite measure on `ℝ≥0` whose
+Laplace transform is `f` on `[0, ∞)`, when `f` has one, and the zero measure otherwise.
+
+By `TauCeti.hausdorff_bernstein_widder` a representing measure exists exactly when `f` is
+continuous on `[0, ∞)` and completely monotone on `(0, ∞)`. -/
+noncomputable def bernsteinMeasure (f : ℝ → ℝ) : Measure ℝ≥0 :=
+  if h : ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f then h.choose else 0
+
+/-- Outside the hypotheses of the Hausdorff--Bernstein--Widder theorem the Bernstein measure is
+`0`. -/
+theorem bernsteinMeasure_eq_zero_of_not (h : ¬ ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f) :
+    bernsteinMeasure f = 0 := by
+  classical
+  rw [bernsteinMeasure, dite_eq_right h]
+
+/-- **The Bernstein measure represents its function.** -/
+theorem representsLaplace_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f) :
+    RepresentsLaplace (bernsteinMeasure f) f := by
+  classical
+  have h : ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := (hausdorff_bernstein_widder f).mp hf
+  rw [bernsteinMeasure, dite_eq_left h]
+  exact h.choose_spec
+
+/-- The Bernstein measure of any function is finite: for a represented function this is the
+finiteness of its representing measure, and otherwise the measure is `0`. -/
+instance isFiniteMeasure_bernsteinMeasure (f : ℝ → ℝ) : IsFiniteMeasure (bernsteinMeasure f) := by
+  classical
+  rw [bernsteinMeasure]
+  split
+  · rename_i h
+    exact h.choose_spec.isFiniteMeasure
+  · infer_instance
+
+/-- **Uniqueness of the Bernstein measure.** Any finite measure representing `f` by its Laplace
+transform is the Bernstein measure of `f`. No hypothesis on `f` is needed: a represented function
+is automatically continuous and completely monotone. -/
+theorem eq_bernsteinMeasure (μ : Measure ℝ≥0) (hμ : RepresentsLaplace μ f) :
+    μ = bernsteinMeasure f :=
+  hμ.unique (representsLaplace_bernsteinMeasure hμ.isContinuousCompletelyMonotoneOnIoi)
+
+/-- The Laplace transform of the Bernstein measure recovers the function on `[0, ∞)`. -/
+theorem laplaceTransform_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f) {t : ℝ}
+    (ht : 0 ≤ t) : laplaceTransform (bernsteinMeasure f) t = f t :=
+  ((representsLaplace_bernsteinMeasure hf).eq_laplaceTransform ht).symm
+
+/-- The total mass of the Bernstein measure is the value of the function at `0`. -/
+theorem bernsteinMeasure_real_univ (hf : IsContinuousCompletelyMonotoneOnIoi f) :
+    (bernsteinMeasure f).real univ = f 0 :=
+  ((representsLaplace_bernsteinMeasure hf).apply_zero).symm
+
+/-- The total mass of the Bernstein measure, as an extended nonnegative real. -/
+theorem bernsteinMeasure_univ (hf : IsContinuousCompletelyMonotoneOnIoi f) :
+    bernsteinMeasure f univ = ENNReal.ofReal (f 0) := by
+  rw [← bernsteinMeasure_real_univ hf, measureReal_def,
+    ENNReal.ofReal_toReal (measure_ne_top _ _)]
+
+/-- A function with total mass `1` has a probability measure for its Bernstein measure. -/
+theorem isProbabilityMeasure_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f)
+    (hf0 : f 0 = 1) : IsProbabilityMeasure (bernsteinMeasure f) :=
+  isProbabilityMeasure_iff_real.mpr <| by rw [bernsteinMeasure_real_univ hf, hf0]
+
+/-- The Bernstein measure of the zero function is the zero measure. -/
+@[simp]
+theorem bernsteinMeasure_zero : bernsteinMeasure (fun _ : ℝ => (0 : ℝ)) = 0 :=
+  (eq_bernsteinMeasure 0 representsLaplace_zero).symm
+
+/-- The Bernstein measure turns sums of functions into sums of measures. -/
+theorem bernsteinMeasure_add {g : ℝ → ℝ} (hf : IsContinuousCompletelyMonotoneOnIoi f)
+    (hg : IsContinuousCompletelyMonotoneOnIoi g) :
+    bernsteinMeasure (f + g) = bernsteinMeasure f + bernsteinMeasure g :=
+  (eq_bernsteinMeasure _ ((representsLaplace_bernsteinMeasure hf).add
+    (representsLaplace_bernsteinMeasure hg))).symm
+
+/-- The Bernstein measure turns nonnegative scalar multiples of functions into scalar multiples of
+measures. -/
+theorem bernsteinMeasure_const_mul (hf : IsContinuousCompletelyMonotoneOnIoi f) (c : ℝ≥0) :
+    bernsteinMeasure (fun t => (c : ℝ) * f t) = (c : ℝ≥0∞) • bernsteinMeasure f :=
+  (eq_bernsteinMeasure _ ((representsLaplace_bernsteinMeasure hf).smul c)).symm
+
+/-! ## Measurable dependence on a parameter -/
+
+variable {α : Type*} [MeasurableSpace α] {F : α → ℝ → ℝ}
+
+/-- **The Bernstein measure depends measurably on a parameter.** If every member of a family of
+functions is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`, and if the family is
+measurable in the parameter at each natural number, then the family of Bernstein measures is
+measurable for the Giry σ-algebra.
+
+Only the values at natural numbers enter, because a finite measure on `ℝ≥0` is already determined
+by its Laplace transform there. -/
+theorem measurable_bernsteinMeasure (hcm : ∀ a, IsContinuousCompletelyMonotoneOnIoi (F a))
+    (hmeas : ∀ n : ℕ, Measurable fun a => F a (n : ℝ)) :
+    Measurable fun a => bernsteinMeasure (F a) := by
+  refine measurable_of_measurable_laplaceTransform_natCast fun n => ?_
+  have hrw : (fun a => laplaceTransform (bernsteinMeasure (F a)) (n : ℝ))
+      = fun a => F a (n : ℝ) := by
+    funext a
+    exact laplaceTransform_bernsteinMeasure (hcm a) (Nat.cast_nonneg n)
+  rw [hrw]
+  exact hmeas n
+
+/-- **The Bernstein kernel of a measurable family.** The Bernstein representing measures of a
+measurable family of completely monotone functions assemble into a kernel from the parameter
+space to `ℝ≥0`. -/
+noncomputable def bernsteinMeasureKernel (F : α → ℝ → ℝ)
+    (hcm : ∀ a, IsContinuousCompletelyMonotoneOnIoi (F a))
+    (hmeas : ∀ n : ℕ, Measurable fun a => F a (n : ℝ)) : Kernel α ℝ≥0 :=
+  ⟨fun a => bernsteinMeasure (F a), measurable_bernsteinMeasure hcm hmeas⟩
+
+@[simp]
+theorem bernsteinMeasureKernel_apply (hcm : ∀ a, IsContinuousCompletelyMonotoneOnIoi (F a))
+    (hmeas : ∀ n : ℕ, Measurable fun a => F a (n : ℝ)) (a : α) :
+    bernsteinMeasureKernel F hcm hmeas a = bernsteinMeasure (F a) :=
+  (rfl)
+
+/-- Every fibre of the Bernstein kernel represents the corresponding member of the family. -/
+theorem representsLaplace_bernsteinMeasureKernel
+    (hcm : ∀ a, IsContinuousCompletelyMonotoneOnIoi (F a))
+    (hmeas : ∀ n : ℕ, Measurable fun a => F a (n : ℝ)) (a : α) :
+    RepresentsLaplace (bernsteinMeasureKernel F hcm hmeas a) (F a) := by
+  rw [bernsteinMeasureKernel_apply]
+  exact representsLaplace_bernsteinMeasure (hcm a)
+
+/-- The Bernstein kernel is finite as soon as the values of the family at `0` are bounded; those
+values are exactly the fibre masses. -/
+theorem isFiniteKernel_bernsteinMeasureKernel
+    (hcm : ∀ a, IsContinuousCompletelyMonotoneOnIoi (F a))
+    (hmeas : ∀ n : ℕ, Measurable fun a => F a (n : ℝ)) {C : ℝ} (hC : ∀ a, F a 0 ≤ C) :
+    IsFiniteKernel (bernsteinMeasureKernel F hcm hmeas) := by
+  refine ⟨ENNReal.ofReal C, ENNReal.ofReal_lt_top, fun a => ?_⟩
+  rw [bernsteinMeasureKernel_apply, bernsteinMeasure_univ (hcm a)]
+  exact ENNReal.ofReal_le_ofReal (hC a)
+
+/-- A family of normalized functions gives a Markov kernel. -/
+theorem isMarkovKernel_bernsteinMeasureKernel
+    (hcm : ∀ a, IsContinuousCompletelyMonotoneOnIoi (F a))
+    (hmeas : ∀ n : ℕ, Measurable fun a => F a (n : ℝ)) (hone : ∀ a, F a 0 = 1) :
+    IsMarkovKernel (bernsteinMeasureKernel F hcm hmeas) := by
+  refine ⟨fun a => ?_⟩
+  rw [bernsteinMeasureKernel_apply]
+  exact isProbabilityMeasure_bernsteinMeasure (hcm a) (hone a)
+
+end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Kernel.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Kernel.lean
@@ -10,14 +10,13 @@ public import TauCeti.Analysis.CompletelyMonotone.Laplace.Measurability
 public import Mathlib.Probability.Kernel.Defs
 
 /-!
-# The Bernstein representing measure, and its kernel form
+# Measurable Bernstein measures and their kernel form
 
-The Hausdorff--Bernstein--Widder theorem attaches to a completely monotone function `f` on
-`[0, ∞)` a *unique* finite measure on `ℝ≥0` whose Laplace transform is `f`. This file names that
-measure, `TauCeti.bernsteinMeasure`, develops its basic API, and — the point of the file — shows
-that it depends **measurably** on a parameter: a family `a ↦ f a` of completely monotone
-functions whose values at the natural numbers are measurable in `a` has Bernstein measures
-forming a `ProbabilityTheory.Kernel`.
+The Hausdorff--Bernstein--Widder theorem and its basic representing-measure API live in
+`TauCeti.Analysis.CompletelyMonotone.Bernstein.HausdorffBernsteinWidder`. This file shows that
+the Bernstein measure depends **measurably** on a parameter: a family `a ↦ f a` of completely
+monotone functions whose values at the natural numbers are measurable in `a` has Bernstein
+measures forming a `ProbabilityTheory.Kernel`.
 
 Measurability is not a selection statement. The representing measure is unique, so the family
 `a ↦ bernsteinMeasure (f a)` is already determined; what has to be proved is that this
@@ -27,12 +26,6 @@ particular family is measurable, and that is
 
 ## Main declarations
 
-* `TauCeti.bernsteinMeasure`: the representing measure of a completely monotone function, and
-  the zero measure for a function that has none.
-* `TauCeti.representsLaplace_bernsteinMeasure`, `TauCeti.eq_bernsteinMeasure`: it represents its
-  function, and it is the only finite measure that does.
-* `TauCeti.bernsteinMeasure_add`, `TauCeti.bernsteinMeasure_const_mul`,
-  `TauCeti.bernsteinMeasure_univ`: the algebraic API and the total mass.
 * `TauCeti.measurable_bernsteinMeasure`: measurable dependence on a parameter.
 * `TauCeti.bernsteinMeasureKernel`: the resulting kernel, with its finiteness criterion.
 
@@ -53,90 +46,6 @@ open MeasureTheory ProbabilityTheory Set
 open scoped ENNReal NNReal
 
 namespace TauCeti
-
-variable {f : ℝ → ℝ}
-
-open Classical in
-/-- **The Bernstein representing measure** of `f`: the unique finite measure on `ℝ≥0` whose
-Laplace transform is `f` on `[0, ∞)`, when `f` has one, and the zero measure otherwise.
-
-By `TauCeti.hausdorff_bernstein_widder` a representing measure exists exactly when `f` is
-continuous on `[0, ∞)` and completely monotone on `(0, ∞)`. -/
-noncomputable def bernsteinMeasure (f : ℝ → ℝ) : Measure ℝ≥0 :=
-  if h : ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f then h.choose else 0
-
-/-- Outside the hypotheses of the Hausdorff--Bernstein--Widder theorem the Bernstein measure is
-`0`. -/
-theorem bernsteinMeasure_eq_zero_of_not (h : ¬ ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f) :
-    bernsteinMeasure f = 0 := by
-  classical
-  rw [bernsteinMeasure, dite_eq_right h]
-
-/-- **The Bernstein measure represents its function.** -/
-theorem representsLaplace_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f) :
-    RepresentsLaplace (bernsteinMeasure f) f := by
-  classical
-  have h : ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := (hausdorff_bernstein_widder f).mp hf
-  rw [bernsteinMeasure, dite_eq_left h]
-  exact h.choose_spec
-
-/-- The Bernstein measure of any function is finite: for a represented function this is the
-finiteness of its representing measure, and otherwise the measure is `0`. -/
-instance isFiniteMeasure_bernsteinMeasure (f : ℝ → ℝ) : IsFiniteMeasure (bernsteinMeasure f) := by
-  classical
-  rw [bernsteinMeasure]
-  split
-  · rename_i h
-    exact h.choose_spec.isFiniteMeasure
-  · infer_instance
-
-/-- **Uniqueness of the Bernstein measure.** Any finite measure representing `f` by its Laplace
-transform is the Bernstein measure of `f`. No hypothesis on `f` is needed: a represented function
-is automatically continuous and completely monotone. -/
-theorem eq_bernsteinMeasure (μ : Measure ℝ≥0) (hμ : RepresentsLaplace μ f) :
-    μ = bernsteinMeasure f :=
-  hμ.unique (representsLaplace_bernsteinMeasure hμ.isContinuousCompletelyMonotoneOnIoi)
-
-/-- The Laplace transform of the Bernstein measure recovers the function on `[0, ∞)`. -/
-theorem laplaceTransform_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f) {t : ℝ}
-    (ht : 0 ≤ t) : laplaceTransform (bernsteinMeasure f) t = f t :=
-  ((representsLaplace_bernsteinMeasure hf).eq_laplaceTransform ht).symm
-
-/-- The total mass of the Bernstein measure is the value of the function at `0`. -/
-theorem bernsteinMeasure_real_univ (hf : IsContinuousCompletelyMonotoneOnIoi f) :
-    (bernsteinMeasure f).real univ = f 0 :=
-  ((representsLaplace_bernsteinMeasure hf).apply_zero).symm
-
-/-- The total mass of the Bernstein measure, as an extended nonnegative real. -/
-theorem bernsteinMeasure_univ (hf : IsContinuousCompletelyMonotoneOnIoi f) :
-    bernsteinMeasure f univ = ENNReal.ofReal (f 0) := by
-  rw [← bernsteinMeasure_real_univ hf, measureReal_def,
-    ENNReal.ofReal_toReal (measure_ne_top _ _)]
-
-/-- A function with total mass `1` has a probability measure for its Bernstein measure. -/
-theorem isProbabilityMeasure_bernsteinMeasure (hf : IsContinuousCompletelyMonotoneOnIoi f)
-    (hf0 : f 0 = 1) : IsProbabilityMeasure (bernsteinMeasure f) :=
-  isProbabilityMeasure_iff_real.mpr <| by rw [bernsteinMeasure_real_univ hf, hf0]
-
-/-- The Bernstein measure of the zero function is the zero measure. -/
-@[simp]
-theorem bernsteinMeasure_zero : bernsteinMeasure (fun _ : ℝ => (0 : ℝ)) = 0 :=
-  (eq_bernsteinMeasure 0 representsLaplace_zero).symm
-
-/-- The Bernstein measure turns sums of functions into sums of measures. -/
-theorem bernsteinMeasure_add {g : ℝ → ℝ} (hf : IsContinuousCompletelyMonotoneOnIoi f)
-    (hg : IsContinuousCompletelyMonotoneOnIoi g) :
-    bernsteinMeasure (f + g) = bernsteinMeasure f + bernsteinMeasure g :=
-  (eq_bernsteinMeasure _ ((representsLaplace_bernsteinMeasure hf).add
-    (representsLaplace_bernsteinMeasure hg))).symm
-
-/-- The Bernstein measure turns nonnegative scalar multiples of functions into scalar multiples of
-measures. -/
-theorem bernsteinMeasure_const_mul (hf : IsContinuousCompletelyMonotoneOnIoi f) (c : ℝ≥0) :
-    bernsteinMeasure (fun t => (c : ℝ) * f t) = (c : ℝ≥0∞) • bernsteinMeasure f :=
-  (eq_bernsteinMeasure _ ((representsLaplace_bernsteinMeasure hf).smul c)).symm
-
-/-! ## Measurable dependence on a parameter -/
 
 variable {α : Type*} [MeasurableSpace α] {F : α → ℝ → ℝ}
 

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Measurability.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Measurability.lean
@@ -22,12 +22,11 @@ determinacy statement to a *measurable* one: a family `a ↦ μ a` of finite mea
 is measurable for the Giry σ-algebra as soon as each of the scalar functions
 `a ↦ laplaceTransform (μ a) n`, `n : ℕ`, is measurable.
 
-The proof is the exponential change of variables `p ↦ e^{-p}` (`TauCeti.expNegUnitInterval`),
-which carries `ℝ≥0` into the unit interval and turns the Laplace transform at `n` into the
-`n`-th moment. Weierstrass approximation then makes `a ↦ ∫ g dμ a` measurable for every
-continuous `g` on the interval, the outer approximation of a closed set by bounded continuous
-functions transfers this to `a ↦ μ a F` for closed `F`, and the closed sets are a π-system
-generating the Borel σ-algebra.
+The proof uses the exponential change of variables `p ↦ e^{-p}`, which carries `ℝ≥0` into the
+unit interval and turns the Laplace transform at `n` into the `n`-th moment. Weierstrass
+approximation then makes `a ↦ ∫ g dμ a` measurable for every continuous `g` on the interval, the
+outer approximation of a closed set by bounded continuous functions transfers this to
+`a ↦ μ a F` for closed `F`, and the closed sets are a π-system generating the Borel σ-algebra.
 
 Because a *unique* finite measure is attached to each parameter value, no measurable-selection
 theorem is involved: the family is whatever it is, and the theorem merely certifies it
@@ -36,10 +35,6 @@ measurable. This is what turns a fibrewise Bernstein representation into a kerne
 
 ## Main declarations
 
-* `TauCeti.expNegUnitInterval` and `TauCeti.negLogNNReal`: the mutually inverse exponential and
-  logarithmic changes of variables between `ℝ≥0` and the unit interval.
-* `TauCeti.integral_pow_map_expNegUnitInterval`: under the change of variables the Laplace
-  transform at `n : ℕ` becomes the `n`-th moment.
 * `TauCeti.measurable_of_measurable_laplaceTransform_natCast`: a family of finite measures on
   `ℝ≥0` is measurable when its Laplace transforms at the natural numbers are.
 
@@ -64,51 +59,51 @@ namespace TauCeti
 /-- The exponential change of variables `p ↦ e^{-p}`, viewed as a map from `ℝ≥0` to the unit
 interval `[0, 1]`. It is injective with left inverse `TauCeti.negLogNNReal`, and it converts the
 Laplace transform of a measure on `ℝ≥0` into the moment sequence of the image measure. -/
-noncomputable def expNegUnitInterval (p : ℝ≥0) : ↥(Set.Icc (0 : ℝ) 1) :=
+private noncomputable def expNegUnitInterval (p : ℝ≥0) : ↥(Set.Icc (0 : ℝ) 1) :=
   ⟨Real.exp (-(p : ℝ)), (Real.exp_pos _).le,
     Real.exp_le_one_iff.2 (neg_nonpos.2 p.coe_nonneg)⟩
 
 /-- The logarithmic change of variables `x ↦ -log x`, truncated to `ℝ≥0`; it is a left inverse of
 `TauCeti.expNegUnitInterval`. -/
-noncomputable def negLogNNReal (x : ↥(Set.Icc (0 : ℝ) 1)) : ℝ≥0 :=
+private noncomputable def negLogNNReal (x : ↥(Set.Icc (0 : ℝ) 1)) : ℝ≥0 :=
   Real.toNNReal (-Real.log (x : ℝ))
 
 /-- The value of the exponential change of variables, as a real number. -/
 @[simp]
-lemma coe_expNegUnitInterval (p : ℝ≥0) :
+private lemma coe_expNegUnitInterval (p : ℝ≥0) :
     (expNegUnitInterval p : ℝ) = Real.exp (-(p : ℝ)) :=
   (rfl)
 
 /-- The exponential change of variables is continuous. -/
-lemma continuous_expNegUnitInterval : Continuous expNegUnitInterval :=
+private lemma continuous_expNegUnitInterval : Continuous expNegUnitInterval :=
   Continuous.subtype_mk
     (Real.continuous_exp.comp (continuous_neg.comp NNReal.continuous_coe)) _
 
 /-- The exponential change of variables is measurable. -/
-lemma measurable_expNegUnitInterval : Measurable expNegUnitInterval :=
+private lemma measurable_expNegUnitInterval : Measurable expNegUnitInterval :=
   continuous_expNegUnitInterval.measurable
 
 /-- The logarithmic change of variables is measurable. It is not continuous at `0`, which is
 harmless: `0` is outside the range of `TauCeti.expNegUnitInterval`. -/
-lemma measurable_negLogNNReal : Measurable negLogNNReal :=
+private lemma measurable_negLogNNReal : Measurable negLogNNReal :=
   measurable_real_toNNReal.comp ((Real.measurable_log.comp measurable_subtype_coe).neg)
 
 /-- The logarithmic change of variables is a left inverse of the exponential one. -/
 @[simp]
-lemma negLogNNReal_expNegUnitInterval (p : ℝ≥0) :
+private lemma negLogNNReal_expNegUnitInterval (p : ℝ≥0) :
     negLogNNReal (expNegUnitInterval p) = p := by
   simp [negLogNNReal, Real.log_exp]
 
 /-- The exponential change of variables is undone by pushing the image measure forward along
 `TauCeti.negLogNNReal`. -/
-lemma map_negLogNNReal_map_expNegUnitInterval (μ : Measure ℝ≥0) :
+private lemma map_negLogNNReal_map_expNegUnitInterval (μ : Measure ℝ≥0) :
     ((μ.map expNegUnitInterval).map negLogNNReal) = μ := by
   rw [Measure.map_map measurable_negLogNNReal measurable_expNegUnitInterval]
   simp [Function.comp_def, Measure.map_id']
 
 /-- Under the exponential change of variables the Laplace transform of `μ` at a natural number
 `n` is the `n`-th moment of the image measure. -/
-lemma integral_pow_map_expNegUnitInterval (μ : Measure ℝ≥0) (n : ℕ) :
+private lemma integral_pow_map_expNegUnitInterval (μ : Measure ℝ≥0) (n : ℕ) :
     ∫ x, ((x : ℝ)) ^ n ∂(μ.map expNegUnitInterval) = laplaceTransform μ n := by
   have hsm : AEStronglyMeasurable (fun x : ↥(Set.Icc (0 : ℝ) 1) => ((x : ℝ)) ^ n)
       (μ.map expNegUnitInterval) := Continuous.aestronglyMeasurable (by fun_prop)

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Measurability.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Measurability.lean
@@ -108,7 +108,7 @@ lemma map_negLogNNReal_map_expNegUnitInterval (μ : Measure ℝ≥0) :
 
 /-- Under the exponential change of variables the Laplace transform of `μ` at a natural number
 `n` is the `n`-th moment of the image measure. -/
-lemma integral_pow_map_expNegUnitInterval (μ : Measure ℝ≥0) [IsFiniteMeasure μ] (n : ℕ) :
+lemma integral_pow_map_expNegUnitInterval (μ : Measure ℝ≥0) (n : ℕ) :
     ∫ x, ((x : ℝ)) ^ n ∂(μ.map expNegUnitInterval) = laplaceTransform μ n := by
   have hsm : AEStronglyMeasurable (fun x : ↥(Set.Icc (0 : ℝ) 1) => ((x : ℝ)) ^ n)
       (μ.map expNegUnitInterval) := Continuous.aestronglyMeasurable (by fun_prop)

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Measurability.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Measurability.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Laplace.Representation
+-- Non-public: the Giry-monad measurability criterion, the outer approximation of closed sets by
+-- bounded continuous functions and the Weierstrass approximation theorem are used inside proofs
+-- only; none of them appears in a statement below.
+import Mathlib.MeasureTheory.Measure.GiryMonad
+import Mathlib.MeasureTheory.Measure.HasOuterApproxClosed
+import Mathlib.Topology.ContinuousMap.Weierstrass
+
+/-!
+# Measurable families of finite measures on `ℝ≥0`
+
+A finite measure on `ℝ≥0` is determined by its Laplace transform at the natural numbers
+(`TauCeti.Measure.ext_of_forall_laplaceTransform_natCast_eq`). This file upgrades that
+determinacy statement to a *measurable* one: a family `a ↦ μ a` of finite measures on `ℝ≥0`
+is measurable for the Giry σ-algebra as soon as each of the scalar functions
+`a ↦ laplaceTransform (μ a) n`, `n : ℕ`, is measurable.
+
+The proof is the exponential change of variables `p ↦ e^{-p}` (`TauCeti.expNegUnitInterval`),
+which carries `ℝ≥0` into the unit interval and turns the Laplace transform at `n` into the
+`n`-th moment. Weierstrass approximation then makes `a ↦ ∫ g dμ a` measurable for every
+continuous `g` on the interval, the outer approximation of a closed set by bounded continuous
+functions transfers this to `a ↦ μ a F` for closed `F`, and the closed sets are a π-system
+generating the Borel σ-algebra.
+
+Because a *unique* finite measure is attached to each parameter value, no measurable-selection
+theorem is involved: the family is whatever it is, and the theorem merely certifies it
+measurable. This is what turns a fibrewise Bernstein representation into a kernel, in
+`TauCeti/Analysis/CompletelyMonotone/Bernstein/Kernel.lean`.
+
+## Main declarations
+
+* `TauCeti.expNegUnitInterval` and `TauCeti.negLogNNReal`: the mutually inverse exponential and
+  logarithmic changes of variables between `ℝ≥0` and the unit interval.
+* `TauCeti.integral_pow_map_expNegUnitInterval`: under the change of variables the Laplace
+  transform at `n : ℕ` becomes the `n`-th moment.
+* `TauCeti.measurable_of_measurable_laplaceTransform_natCast`: a family of finite measures on
+  `ℝ≥0` is measurable when its Laplace transforms at the natural numbers are.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012), Chapter 1.
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
+  (BCR semigroup--Bochner).
+-/
+
+public section
+
+open Filter MeasureTheory Set
+open scoped BoundedContinuousFunction ENNReal NNReal Topology
+
+namespace TauCeti
+
+/-! ## The exponential change of variables -/
+
+/-- The exponential change of variables `p ↦ e^{-p}`, viewed as a map from `ℝ≥0` to the unit
+interval `[0, 1]`. It is injective with left inverse `TauCeti.negLogNNReal`, and it converts the
+Laplace transform of a measure on `ℝ≥0` into the moment sequence of the image measure. -/
+noncomputable def expNegUnitInterval (p : ℝ≥0) : ↥(Set.Icc (0 : ℝ) 1) :=
+  ⟨Real.exp (-(p : ℝ)), (Real.exp_pos _).le,
+    Real.exp_le_one_iff.2 (neg_nonpos.2 p.coe_nonneg)⟩
+
+/-- The logarithmic change of variables `x ↦ -log x`, truncated to `ℝ≥0`; it is a left inverse of
+`TauCeti.expNegUnitInterval`. -/
+noncomputable def negLogNNReal (x : ↥(Set.Icc (0 : ℝ) 1)) : ℝ≥0 :=
+  Real.toNNReal (-Real.log (x : ℝ))
+
+/-- The value of the exponential change of variables, as a real number. -/
+@[simp]
+lemma coe_expNegUnitInterval (p : ℝ≥0) :
+    (expNegUnitInterval p : ℝ) = Real.exp (-(p : ℝ)) :=
+  (rfl)
+
+/-- The exponential change of variables is continuous. -/
+lemma continuous_expNegUnitInterval : Continuous expNegUnitInterval :=
+  Continuous.subtype_mk
+    (Real.continuous_exp.comp (continuous_neg.comp NNReal.continuous_coe)) _
+
+/-- The exponential change of variables is measurable. -/
+lemma measurable_expNegUnitInterval : Measurable expNegUnitInterval :=
+  continuous_expNegUnitInterval.measurable
+
+/-- The logarithmic change of variables is measurable. It is not continuous at `0`, which is
+harmless: `0` is outside the range of `TauCeti.expNegUnitInterval`. -/
+lemma measurable_negLogNNReal : Measurable negLogNNReal :=
+  measurable_real_toNNReal.comp ((Real.measurable_log.comp measurable_subtype_coe).neg)
+
+/-- The logarithmic change of variables is a left inverse of the exponential one. -/
+@[simp]
+lemma negLogNNReal_expNegUnitInterval (p : ℝ≥0) :
+    negLogNNReal (expNegUnitInterval p) = p := by
+  simp [negLogNNReal, Real.log_exp]
+
+/-- The exponential change of variables is undone by pushing the image measure forward along
+`TauCeti.negLogNNReal`. -/
+lemma map_negLogNNReal_map_expNegUnitInterval (μ : Measure ℝ≥0) :
+    ((μ.map expNegUnitInterval).map negLogNNReal) = μ := by
+  rw [Measure.map_map measurable_negLogNNReal measurable_expNegUnitInterval]
+  simp [Function.comp_def, Measure.map_id']
+
+/-- Under the exponential change of variables the Laplace transform of `μ` at a natural number
+`n` is the `n`-th moment of the image measure. -/
+lemma integral_pow_map_expNegUnitInterval (μ : Measure ℝ≥0) [IsFiniteMeasure μ] (n : ℕ) :
+    ∫ x, ((x : ℝ)) ^ n ∂(μ.map expNegUnitInterval) = laplaceTransform μ n := by
+  have hsm : AEStronglyMeasurable (fun x : ↥(Set.Icc (0 : ℝ) 1) => ((x : ℝ)) ^ n)
+      (μ.map expNegUnitInterval) := Continuous.aestronglyMeasurable (by fun_prop)
+  rw [integral_map measurable_expNegUnitInterval.aemeasurable hsm, laplaceTransform_apply]
+  refine integral_congr_ae (Filter.Eventually.of_forall fun p => ?_)
+  simp only [coe_expNegUnitInterval, ← Real.exp_nat_mul]
+  congr 1
+  ring
+
+/-! ## Measurability of a family from its Laplace transforms -/
+
+/-- A continuous function on the unit interval is integrable against any finite measure. -/
+private lemma integrable_of_continuous_Icc {ν : Measure ↥(Set.Icc (0 : ℝ) 1)} [IsFiniteMeasure ν]
+    {f : ↥(Set.Icc (0 : ℝ) 1) → ℝ} (hf : Continuous f) : Integrable f ν :=
+  hf.integrable_of_hasCompactSupport (HasCompactSupport.of_compactSpace f)
+
+/-- **Measurability from Laplace transforms.** A family of finite measures on `ℝ≥0` indexed by a
+measurable space is measurable for the Giry σ-algebra as soon as each of the functions
+`a ↦ laplaceTransform (μ a) n`, for `n : ℕ`, is measurable.
+
+Only the natural-number values of the transforms are used, matching the determinacy statement
+`TauCeti.Measure.ext_of_forall_laplaceTransform_natCast_eq`. -/
+theorem measurable_of_measurable_laplaceTransform_natCast {α : Type*} [MeasurableSpace α]
+    {μ : α → Measure ℝ≥0} [∀ a, IsFiniteMeasure (μ a)]
+    (h : ∀ n : ℕ, Measurable fun a => laplaceTransform (μ a) n) :
+    Measurable μ := by
+  set ν : α → Measure ↥(Set.Icc (0 : ℝ) 1) := fun a => (μ a).map expNegUnitInterval with hνdef
+  -- The moments of the image measures are measurable in the parameter.
+  have hmom : ∀ n : ℕ, Measurable fun a => ∫ x, ((x : ℝ)) ^ n ∂(ν a) := by
+    intro n
+    have hrw : (fun a => ∫ x, ((x : ℝ)) ^ n ∂(ν a))
+        = fun a => laplaceTransform (μ a) n := by
+      funext a
+      simpa only [hνdef] using integral_pow_map_expNegUnitInterval (μ a) n
+    rw [hrw]
+    exact h n
+  -- Hence so are the integrals of polynomials.
+  have hpoly : ∀ p : Polynomial ℝ, Measurable fun a => ∫ x, p.eval ((x : ℝ)) ∂(ν a) := by
+    intro p
+    have hrw : (fun a => ∫ x, p.eval ((x : ℝ)) ∂(ν a))
+        = fun a => ∑ i ∈ Finset.range (p.natDegree + 1),
+            p.coeff i * ∫ x, ((x : ℝ)) ^ i ∂(ν a) := by
+      funext a
+      simp_rw [Polynomial.eval_eq_sum_range]
+      rw [integral_finsetSum _ fun i _ =>
+        integrable_of_continuous_Icc
+          (f := fun x : ↥(Set.Icc (0 : ℝ) 1) => p.coeff i * ((x : ℝ)) ^ i) (by fun_prop)]
+      simp_rw [integral_const_mul]
+    rw [hrw]
+    exact Finset.measurable_sum _ fun i _ => measurable_const.mul (hmom i)
+  -- Weierstrass approximation extends this to all continuous functions.
+  have hcont : ∀ g : C(↥(Set.Icc (0 : ℝ) 1), ℝ), Measurable fun a => ∫ x, g x ∂(ν a) := by
+    intro g
+    have happrox : ∀ n : ℕ, ∃ p : Polynomial ℝ,
+        ‖p.toContinuousMapOn (Set.Icc (0 : ℝ) 1) - g‖ < 1 / (n + 1) := fun n =>
+      exists_polynomial_near_continuousMap 0 1 g (1 / (n + 1)) (by positivity)
+    choose q hq using happrox
+    have hbound : ∀ (n : ℕ) (x : ↥(Set.Icc (0 : ℝ) 1)),
+        ‖(q n).eval ((x : ℝ)) - g x‖ ≤ 1 / ((n : ℝ) + 1) := by
+      intro n x
+      have hx := ContinuousMap.norm_coe_le_norm
+        ((q n).toContinuousMapOn (Set.Icc (0 : ℝ) 1) - g) x
+      simpa using hx.trans (hq n).le
+    refine measurable_of_tendsto_metrizable
+      (f := fun n a => ∫ x, (q n).eval ((x : ℝ)) ∂(ν a)) (fun n => hpoly (q n)) ?_
+    rw [tendsto_pi_nhds]
+    intro a
+    have hgint : Integrable (fun x => g x) (ν a) := integrable_of_continuous_Icc g.continuous
+    have hqint : ∀ n, Integrable (fun x : ↥(Set.Icc (0 : ℝ) 1) => (q n).eval ((x : ℝ))) (ν a) :=
+      fun n => integrable_of_continuous_Icc ((q n).continuous.comp continuous_subtype_val)
+    have key : ∀ n : ℕ, ‖(∫ x, (q n).eval ((x : ℝ)) ∂(ν a)) - ∫ x, g x ∂(ν a)‖
+        ≤ (1 / ((n : ℝ) + 1)) * (ν a).real Set.univ := by
+      intro n
+      rw [← integral_sub (hqint n) hgint]
+      exact norm_integral_le_of_norm_le_const
+        (Filter.Eventually.of_forall fun x => hbound n x)
+    rw [tendsto_iff_norm_sub_tendsto_zero]
+    refine squeeze_zero (fun n => norm_nonneg _) key ?_
+    simpa using tendsto_one_div_add_atTop_nhds_zero_nat.mul_const ((ν a).real Set.univ)
+  -- Non-negative bounded continuous test functions, in `ℝ≥0∞` form.
+  have hlint : ∀ g : ↥(Set.Icc (0 : ℝ) 1) →ᵇ ℝ≥0,
+      Measurable fun a => ∫⁻ x, (g x : ℝ≥0∞) ∂(ν a) := by
+    intro g
+    have hrw : (fun a => ∫⁻ x, (g x : ℝ≥0∞) ∂(ν a))
+        = fun a => ENNReal.ofReal (∫ x, ((g x : ℝ)) ∂(ν a)) := by
+      funext a
+      rw [← BoundedContinuousFunction.toReal_lintegral_coe_eq_integral g (ν a),
+        ENNReal.ofReal_toReal (BoundedContinuousFunction.lintegral_lt_top_of_nnreal (ν a) g).ne]
+    rw [hrw]
+    exact ENNReal.measurable_ofReal.comp
+      (hcont ⟨fun x => (g x : ℝ), NNReal.continuous_coe.comp g.continuous⟩)
+  -- Outer approximation of closed sets transfers measurability to closed sets.
+  have hclosed : ∀ F : Set ↥(Set.Icc (0 : ℝ) 1), IsClosed F → Measurable fun a => ν a F := by
+    intro F hF
+    have hrw : (fun a => ν a F)
+        = fun a => liminf (fun n => ∫⁻ x, (hF.apprSeq n x : ℝ≥0∞) ∂(ν a)) atTop := by
+      funext a
+      exact (HasOuterApproxClosed.tendsto_lintegral_apprSeq hF (ν a)).liminf_eq.symm
+    rw [hrw]
+    exact Measurable.liminf fun n => hlint (hF.apprSeq n)
+  -- The closed sets are a π-system generating the Borel σ-algebra.
+  have hνmeas : Measurable ν := by
+    refine Measurable.measure_of_isPiSystem ?_ isPiSystem_isClosed
+      (fun F hF => hclosed F hF) (hclosed _ isClosed_univ)
+    rw [BorelSpace.measurable_eq (α := ↥(Set.Icc (0 : ℝ) 1)), borel_eq_generateFrom_isClosed]
+  -- Undo the change of variables.
+  have hrw : μ = fun a => (ν a).map negLogNNReal := by
+    funext a
+    simpa only [hνdef] using (map_negLogNNReal_map_expNegUnitInterval (μ a)).symm
+  rw [hrw]
+  exact (Measure.measurable_map negLogNNReal measurable_negLogNNReal).comp hνmeas
+
+end TauCeti


### PR DESCRIPTION
This PR names the representing measure of the Hausdorff--Bernstein--Widder theorem and proves that it depends measurably on a parameter, so that a measurable family of completely monotone functions has an honest kernel of Bernstein measures. `TauCeti.bernsteinMeasure f` is the unique finite measure on `ℝ≥0` whose Laplace transform is `f` on `[0, ∞)` (the zero measure when `f` has none), with the expected API: it represents its function, it is the only finite measure that does (`TauCeti.eq_bernsteinMeasure`), its total mass is `f 0`, and it is additive and positively homogeneous. The measurability statement is `TauCeti.measurable_bernsteinMeasure`: if every `F a` is continuous on `[0, ∞)` and completely monotone on `(0, ∞)`, and `a ↦ F a n` is measurable for every natural number `n`, then `a ↦ bernsteinMeasure (F a)` is measurable for the Giry σ-algebra; `TauCeti.bernsteinMeasureKernel` packages it as a `ProbabilityTheory.Kernel`, with criteria for that kernel to be finite or Markov.

This is not a measurable-selection theorem, and deliberately so: the representing measure is unique, so the family `a ↦ bernsteinMeasure (F a)` is already pinned down and only its measurability is at issue. The engine is a general statement about measures rather than about Bernstein's theorem, `TauCeti.measurable_of_measurable_laplaceTransform_natCast`: a family of finite measures on `ℝ≥0` is measurable as soon as its Laplace transforms at the natural numbers are. It is the measurable refinement of the determinacy lemma `TauCeti.Measure.ext_of_forall_laplaceTransform_natCast_eq` already in the repository, and it uses exactly the same data. The proof pushes the measures forward along the exponential change of variables `p ↦ e^{-p}` into `[0, 1]`, where the Laplace transform at `n` becomes the `n`-th moment; Weierstrass approximation makes the integral of every continuous function measurable in the parameter, the outer approximation of a closed set by bounded continuous functions (Mathlib's `IsClosed.apprSeq`) transfers that to the measure of a closed set, and the closed sets are a π-system generating the Borel σ-algebra, so Mathlib's `Measurable.measure_of_isPiSystem` finishes. The pushforward is undone by the measurable left inverse `x ↦ -log x`.

The exact roadmap target is `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, **Milestone 2 — BCR semigroup--Bochner** (`bcr_semigroup_bochner`), specifically its existence half; the uniqueness half is already proved as `TauCeti.Measure.ext_of_forall_laplaceFourierTransform_eq`. The existence half is the problem of realizing the antitone family of spatial Bochner measures `t ↦ bochnerMeasure (F (t, ·))` as the Laplace-weighted slices of one measure on `ℝ≥0 × V`, and the route being built in the repository converts that into a fibrewise Bernstein problem: apply Bernstein's theorem to the Radon--Nikodym densities `q ↦ d(bochnerMeasure (F (t, ·)))/d(bochnerMeasure (F (0, ·))) q` for almost every spatial frequency `q`, then collect the resulting measures into a kernel from `V` to `ℝ≥0`. Collecting them is the step this PR supplies: a fibrewise application of Bernstein's theorem returns one measure per `q` with no measurability attached, and the whole reduction is useless without it. Nothing here duplicates the two open PRs on this path — TauCeti#4202 supplies the finite-difference form of complete monotonicity that the densities satisfy, and TauCeti#4244 supplies the reduction of the representation to such a kernel — and both consume this file's conclusion rather than restate it.

What remains for the milestone after this PR: the fibrewise input itself, namely that the Radon--Nikodym densities are completely monotone in time for almost every `q` and measurable in `q`, after which `TauCeti.bernsteinMeasureKernel` produces the kernel the reduction asks for.

The two new modules are `TauCeti/Analysis/CompletelyMonotone/Laplace/Measurability.lean` (224 lines) and `TauCeti/Analysis/CompletelyMonotone/Bernstein/Kernel.lean` (202 lines). No Mathlib infrastructure was vendored: the Weierstrass approximation theorem, `IsClosed.apprSeq`, `Measurable.measure_of_isPiSystem` and `Measure.measurable_map` are all consumed from Mathlib as they stand, and `TauCeti.hausdorff_bernstein_widder`, `TauCeti.RepresentsLaplace` and `TauCeti.laplaceTransform` from this repository.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"bernstein-measure-kernel"}-->

🤖 Prepared with Claude Code
