### PR TITLE
feat: the regularized incomplete beta function

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Beta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Beta.lean
@@ -79,8 +79,11 @@ theorem intervalIntegrable_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) {u v 
     have hhalf : (1 : ℝ) - 1 / 2 = 1 / 2 := by norm_num
     have hright := (half b a hb).comp_sub_left 1
     simp only [sub_zero, sub_sub_cancel] at hright
-    rw [hhalf, show (fun t : ℝ => (1 - t) ^ (b - 1) * t ^ (a - 1)) =
-      fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1) from funext fun t => mul_comm _ _] at hright
+    have hmul : (fun t : ℝ => (1 - t) ^ (b - 1) * t ^ (a - 1)) =
+        fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1) := by
+      ext t
+      rw [mul_comm]
+    rw [hhalf, hmul] at hright
     exact (half a b ha).trans hright.symm
   refine key.mono_set (uIcc_subset_uIcc ?_ ?_) <;>
     rw [uIcc_of_le (zero_le_one : (0 : ℝ) ≤ 1)]

--- a/TauCeti/Analysis/SpecialFunctions/Beta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Beta.lean
@@ -11,9 +11,10 @@ public import Mathlib.Probability.Distributions.Beta
 # Euler's beta integral, in real-valued interval form
 
 Mathlib defines Euler's beta function `ProbabilityTheory.beta` by the Gamma quotient, and proves
-that it is the value of the *complex* contour integral `Complex.betaIntegral`. This file records
-the real-variable facts about the beta integrand `t ^ (a - 1) * (1 - t) ^ (b - 1)` that a
-real-analysis consumer needs: its interval integrability on `[0, 1]`, the value `Β(a, b)` of its
+that it is the value of `Complex.betaIntegral`, the complex-valued interval integral of
+`t ^ (a - 1) * (1 - t) ^ (b - 1)` over `[0, 1]`. This file records the real-variable facts about
+the real-valued beta integrand `t ^ (a - 1) * (1 - t) ^ (b - 1)` that a real-analysis consumer
+needs: its interval integrability on `[0, 1]`, the value `Β(a, b)` of its
 integral over `[0, 1]`, the derivative of the kernel `t ^ a * (1 - t) ^ b` it primitivises, and
 the splitting of the integrand that raises the second parameter by one. Two parameter identities
 for `Β` itself — symmetry and the unit step in the first parameter — are recorded alongside.
@@ -105,16 +106,19 @@ theorem integral_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) :
   · convert! Complex.betaIntegral_convergent (u := a) (v := b) (by simpa) (by simpa)
     rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (zero_le_one : (0 : ℝ) ≤ 1), IntegrableOn]
 
-/-- The derivative of the kernel `t ^ a * (1 - t) ^ b` primitivised by the beta integrand. Away
-from the two endpoints `0` and `1` no hypothesis on the exponents is needed. -/
-theorem hasDerivAt_rpow_mul_one_sub_rpow (a b : ℝ) {t : ℝ} (ht0 : t ≠ 0) (ht1 : t ≠ 1) :
+/-- The derivative of the kernel `t ^ a * (1 - t) ^ b` primitivised by the beta integrand. Each
+endpoint has to be avoided only when the exponent that degenerates there is smaller than `1`:
+`t ^ a` is differentiable at `0` as soon as `1 ≤ a`, and `(1 - t) ^ b` at `1` as soon as
+`1 ≤ b`. -/
+theorem hasDerivAt_rpow_mul_one_sub_rpow (a b : ℝ) {t : ℝ} (ht0 : t ≠ 0 ∨ 1 ≤ a)
+    (ht1 : t ≠ 1 ∨ 1 ≤ b) :
     HasDerivAt (fun t : ℝ => t ^ a * (1 - t) ^ b)
       (a * (t ^ (a - 1) * (1 - t) ^ b) - b * (t ^ a * (1 - t) ^ (b - 1))) t := by
-  have h1t : (1 : ℝ) - t ≠ 0 := sub_ne_zero_of_ne (Ne.symm ht1)
+  have h1t : (1 : ℝ) - t ≠ 0 ∨ 1 ≤ b := ht1.imp_left fun ht => sub_ne_zero_of_ne (Ne.symm ht)
   have h₁ : HasDerivAt (fun t : ℝ => t ^ a) (a * t ^ (a - 1)) t :=
-    Real.hasDerivAt_rpow_const (Or.inl ht0)
+    Real.hasDerivAt_rpow_const ht0
   have h₂ : HasDerivAt (fun t : ℝ => (1 - t) ^ b) (b * (1 - t) ^ (b - 1) * (-1)) t :=
-    (Real.hasDerivAt_rpow_const (Or.inl h1t)).comp t ((hasDerivAt_id t).const_sub 1)
+    (Real.hasDerivAt_rpow_const h1t).comp t ((hasDerivAt_id t).const_sub 1)
   refine (h₁.mul h₂).congr_deriv ?_
   ring
 

--- a/TauCeti/Analysis/SpecialFunctions/Beta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Beta.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.Distributions.Beta
+
+/-!
+# Euler's beta integral, in real-valued interval form
+
+Mathlib defines Euler's beta function `ProbabilityTheory.beta` by the Gamma quotient, and proves
+that it is the value of the *complex* contour integral `Complex.betaIntegral`. This file records
+the real-variable facts about the beta integrand `t ^ (a - 1) * (1 - t) ^ (b - 1)` that a
+real-analysis consumer needs: its interval integrability on `[0, 1]`, the value `Β(a, b)` of its
+integral over `[0, 1]`, the derivative of the kernel `t ^ a * (1 - t) ^ b` it primitivises, and
+the splitting of the integrand that raises the second parameter by one. Two parameter identities
+for `Β` itself — symmetry and the unit step in the first parameter — are recorded alongside.
+
+These are the analytic prerequisites of
+`TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean`, and
+`TauCeti/Probability/Distributions/Beta.lean` uses the beta integral for its moment formula.
+
+## Main results
+
+* `TauCeti.intervalIntegrable_rpow_mul_one_sub_rpow` — interval integrability of the beta
+  integrand between any two points of `[0, 1]`;
+* `TauCeti.integral_rpow_mul_one_sub_rpow` — Euler's beta integral,
+  `∫ t in 0..1, t ^ (a - 1) * (1 - t) ^ (b - 1) = Β(a, b)`;
+* `TauCeti.hasDerivAt_rpow_mul_one_sub_rpow` — the derivative of `t ^ a * (1 - t) ^ b`;
+* `TauCeti.integral_rpow_mul_one_sub_rpow_add_one_right` — raising the second parameter by one
+  splits the integral as a difference;
+* `ProbabilityTheory.beta_comm` — symmetry of `Β`;
+* `ProbabilityTheory.beta_add_one_left` — the unit step `Β(a + 1, b) = a / (a + b) * Β(a, b)`.
+
+## Implementation notes
+
+The proof of `TauCeti.intervalIntegrable_rpow_mul_one_sub_rpow` transposes the argument of
+Mathlib's `Complex.betaIntegral_convergent` and `Complex.betaIntegral_convergent_left` to the
+real-valued setting: split `[0, 1]` at `1 / 2` and handle each endpoint singularity with
+`intervalIntegral.intervalIntegrable_rpow'` against a factor that is continuous there, obtaining
+the right half from the left one by the reflection `t ↦ 1 - t`. The proof of
+`TauCeti.integral_rpow_mul_one_sub_rpow` adapts the normalization argument for
+`ProbabilityTheory.betaMeasure` in Mathlib, `ProbabilityTheory.lintegral_betaPDF_eq_one`:
+descend from `Complex.betaIntegral` by taking real parts.
+
+## References
+
+* Tau Ceti roadmap, `StandardDistributions`, Layer 2, "Regularized incomplete beta", for which
+  these are the prerequisites.
+* [NIST Digital Library of Mathematical Functions, §5.12](https://dlmf.nist.gov/5.12).
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory ProbabilityTheory Set
+
+variable {a b x : ℝ}
+
+/-- The integrand `t ^ (a - 1) * (1 - t) ^ (b - 1)` of Euler's beta integral is interval
+integrable between any two points of `[0, 1]`. Both endpoint singularities are integrable
+precisely because the exponents exceed `-1`. -/
+theorem intervalIntegrable_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) {u v : ℝ}
+    (hu : u ∈ Icc (0 : ℝ) 1) (hv : v ∈ Icc (0 : ℝ) 1) :
+    IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) volume u v := by
+  -- only the singularity at `0` needs an argument; the one at `1` is its mirror image
+  have half : ∀ p q : ℝ, 0 < p →
+      IntervalIntegrable (fun t : ℝ => t ^ (p - 1) * (1 - t) ^ (q - 1)) volume 0 (1 / 2) := by
+    intro p q hp
+    refine (intervalIntegral.intervalIntegrable_rpow' (by linarith)).mul_continuousOn ?_
+    refine ContinuousOn.rpow_const (by fun_prop) fun t ht => Or.inl ?_
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1 / 2)] at ht
+    have ht1 : t < 1 := by linarith [ht.2]
+    exact sub_ne_zero_of_ne ht1.ne'
+  have key : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) volume 0 1 := by
+    have hhalf : (1 : ℝ) - 1 / 2 = 1 / 2 := by norm_num
+    have hright := (half b a hb).comp_sub_left 1
+    simp only [sub_zero, sub_sub_cancel] at hright
+    rw [hhalf, show (fun t : ℝ => (1 - t) ^ (b - 1) * t ^ (a - 1)) =
+      fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1) from funext fun t => mul_comm _ _] at hright
+    exact (half a b ha).trans hright.symm
+  refine key.mono_set (uIcc_subset_uIcc ?_ ?_) <;>
+    rw [uIcc_of_le (zero_le_one : (0 : ℝ) ≤ 1)]
+  exacts [hu, hv]
+
+/-- Euler's beta integral, in real-valued interval form: for positive parameters the integral of
+`t ^ (a - 1) * (1 - t) ^ (b - 1)` over `[0, 1]` is `Β(a, b)`. -/
+theorem integral_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) :
+    ∫ t in (0 : ℝ)..1, t ^ (a - 1) * (1 - t) ^ (b - 1) = beta a b := by
+  rw [beta_eq_betaIntegralReal a b ha hb, Complex.betaIntegral,
+    intervalIntegral.integral_of_le (zero_le_one : (0 : ℝ) ≤ 1),
+    intervalIntegral.integral_of_le (zero_le_one : (0 : ℝ) ≤ 1),
+    ← RCLike.re_to_complex, ← integral_re]
+  · refine setIntegral_congr_fun measurableSet_Ioc fun t ⟨ht0, ht1⟩ ↦ ?_
+    norm_cast
+    rw [← Complex.ofReal_cpow, ← Complex.ofReal_cpow, RCLike.re_to_complex,
+      Complex.re_mul_ofReal, Complex.ofReal_re]
+    all_goals linarith
+  · convert! Complex.betaIntegral_convergent (u := a) (v := b) (by simpa) (by simpa)
+    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (zero_le_one : (0 : ℝ) ≤ 1), IntegrableOn]
+
+/-- The derivative of the kernel `t ^ a * (1 - t) ^ b` primitivised by the beta integrand. Away
+from the two endpoints `0` and `1` no hypothesis on the exponents is needed. -/
+theorem hasDerivAt_rpow_mul_one_sub_rpow (a b : ℝ) {t : ℝ} (ht0 : t ≠ 0) (ht1 : t ≠ 1) :
+    HasDerivAt (fun t : ℝ => t ^ a * (1 - t) ^ b)
+      (a * (t ^ (a - 1) * (1 - t) ^ b) - b * (t ^ a * (1 - t) ^ (b - 1))) t := by
+  have h1t : (1 : ℝ) - t ≠ 0 := sub_ne_zero_of_ne (Ne.symm ht1)
+  have h₁ : HasDerivAt (fun t : ℝ => t ^ a) (a * t ^ (a - 1)) t :=
+    Real.hasDerivAt_rpow_const (Or.inl ht0)
+  have h₂ : HasDerivAt (fun t : ℝ => (1 - t) ^ b) (b * (1 - t) ^ (b - 1) * (-1)) t :=
+    (Real.hasDerivAt_rpow_const (Or.inl h1t)).comp t ((hasDerivAt_id t).const_sub 1)
+  refine (h₁.mul h₂).congr_deriv ?_
+  ring
+
+/-- Raising the second parameter of the beta integrand by one splits its integral as a
+difference: off the endpoints
+`t ^ (a - 1) * (1 - t) ^ b = t ^ (a - 1) * (1 - t) ^ (b - 1) - t ^ a * (1 - t) ^ (b - 1)`. -/
+theorem integral_rpow_mul_one_sub_rpow_add_one_right (ha : 0 < a) (hb : 0 < b)
+    (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    ∫ t in (0 : ℝ)..x, t ^ (a - 1) * (1 - t) ^ b =
+      (∫ t in (0 : ℝ)..x, t ^ (a - 1) * (1 - t) ^ (b - 1)) -
+        ∫ t in (0 : ℝ)..x, t ^ a * (1 - t) ^ (b - 1) := by
+  have hmem : x ∈ Icc (0 : ℝ) 1 := ⟨hx0, hx1⟩
+  have hzero : (0 : ℝ) ∈ Icc (0 : ℝ) 1 := ⟨le_rfl, zero_le_one⟩
+  have hI := intervalIntegrable_rpow_mul_one_sub_rpow ha hb hzero hmem
+  have hJ : IntervalIntegrable (fun t : ℝ => t ^ a * (1 - t) ^ (b - 1)) volume 0 x := by
+    simpa using
+      intervalIntegrable_rpow_mul_one_sub_rpow (by linarith : (0 : ℝ) < a + 1) hb hzero hmem
+  rw [← intervalIntegral.integral_sub hI hJ]
+  refine intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t ht => ?_)
+  rw [uIoc_of_le hx0] at ht
+  have ht0 : 0 < t := ht.1
+  rcases eq_or_lt_of_le (ht.2.trans hx1) with rfl | ht1
+  · rw [Real.one_rpow, Real.one_rpow, sub_self, Real.zero_rpow hb.ne']
+    ring
+  · have h1t : (0 : ℝ) < 1 - t := by linarith
+    rw [Real.rpow_sub_one ht0.ne' a, Real.rpow_sub_one h1t.ne' b]
+    field_simp
+
+end TauCeti
+
+namespace ProbabilityTheory
+
+variable {a b : ℝ}
+
+/-- Euler's beta function is symmetric in its two parameters. -/
+theorem beta_comm (a b : ℝ) : beta a b = beta b a := by
+  rw [ProbabilityTheory.beta, ProbabilityTheory.beta, mul_comm (Real.Gamma a), add_comm a b]
+
+/-- The unit step of Euler's beta function in its first parameter. -/
+theorem beta_add_one_left (ha : a ≠ 0) (hab : a + b ≠ 0) :
+    beta (a + 1) b = a / (a + b) * beta a b := by
+  have hshift : a + 1 + b = a + b + 1 := by ring
+  rw [ProbabilityTheory.beta, ProbabilityTheory.beta, hshift, Real.Gamma_add_one ha,
+    Real.Gamma_add_one hab]
+  field_simp
+
+end ProbabilityTheory

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
@@ -38,7 +38,7 @@ makes the binomial-tail formula `(binomial n p).real {k | m ≤ k} = I_p(m, n - 
 * `TauCeti.regularizedIncompleteBeta_reflect` — the reflection formula
   `I_x(a, b) = 1 - I_{1-x}(b, a)`;
 * `TauCeti.regularizedIncompleteBeta_add_one_left` — the unit-step recurrence
-  `I_x(a + 1, b) = I_x(a, b) - x ^ a * (1 - x) ^ b / (a * Β(a, b))`.
+  `I_x(a + 1, b) = I_x(a, b) - x ^ a * (1 - x) ^ b / (a * Β(a, b))`, for `0 ≤ x ≤ 1`.
 
 Four auxiliary results about Euler's beta function itself are proved on the way and are stated for
 reuse: `TauCeti.intervalIntegrable_rpow_mul_one_sub_rpow` and
@@ -356,7 +356,11 @@ theorem regularizedIncompleteBeta_reflect (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
 
 /-- The unit-step recurrence in the first parameter,
 `I_x(a + 1, b) = I_x(a, b) - x ^ a * (1 - x) ^ b / (a * Β(a, b))`, in the form of
-[DLMF 8.17.20](https://dlmf.nist.gov/8.17.E20). -/
+[DLMF 8.17.20](https://dlmf.nist.gov/8.17.E20).
+
+The argument is restricted to `0 ≤ x ≤ 1`: outside `[0, 1]` the clamping freezes both regularized
+values at `0` or at `1` while the subtracted term keeps varying with `x`, so the displayed formula
+fails there. -/
 theorem regularizedIncompleteBeta_add_one_left (ha : 0 < a) (hb : 0 < b)
     (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
     regularizedIncompleteBeta (a + 1) b x = regularizedIncompleteBeta a b x -

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
@@ -76,17 +76,20 @@ theorem intervalIntegrable_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) {u v 
       refine (intervalIntegral.intervalIntegrable_rpow' (by linarith)).mul_continuousOn ?_
       refine ContinuousOn.rpow_const (by fun_prop) fun t ht => Or.inl ?_
       rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1 / 2)] at ht
-      exact sub_ne_zero_of_ne (show t < 1 by linarith [ht.2]).ne'
+      have ht1 : t < 1 := by linarith [ht.2]
+      exact sub_ne_zero_of_ne ht1.ne'
     have hright : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1))
         volume (1 / 2) 1 := by
       have hbase : IntervalIntegrable (fun t : ℝ => (1 - t) ^ (b - 1)) volume 1 (1 / 2) := by
         have h := (intervalIntegral.intervalIntegrable_rpow' (a := 0) (b := 1 / 2)
           (r := b - 1) (by linarith)).comp_sub_left 1
-        rwa [sub_zero, show (1 : ℝ) - 1 / 2 = 1 / 2 by norm_num] at h
+        have hhalf : (1 : ℝ) - 1 / 2 = 1 / 2 := by norm_num
+        rwa [sub_zero, hhalf] at h
       refine (hbase.continuousOn_mul ?_).symm
       refine ContinuousOn.rpow_const (by fun_prop) fun t ht => Or.inl ?_
       rw [uIcc_of_ge (by norm_num : (1 / 2 : ℝ) ≤ 1)] at ht
-      exact (show (0 : ℝ) < t by linarith [ht.1]).ne'
+      have ht0 : (0 : ℝ) < t := by linarith [ht.1]
+      exact ht0.ne'
     exact hleft.trans hright
   refine key.mono_set (uIcc_subset_uIcc ?_ ?_) <;>
     rw [uIcc_of_le (zero_le_one : (0 : ℝ) ≤ 1)]
@@ -383,10 +386,10 @@ theorem regularizedIncompleteBeta_add_one_left (ha : 0 < a) (hb : 0 < b)
     · rw [Real.one_rpow, Real.one_rpow, sub_self, Real.zero_rpow hb.ne']
       ring
     · have h1t : (0 : ℝ) < 1 - t := by linarith
-      rw [show b = b - 1 + 1 by ring, Real.rpow_add h1t, Real.rpow_one]
-      nth_rewrite 3 [show a = a - 1 + 1 by ring]
-      rw [Real.rpow_add ht0, Real.rpow_one]
-      ring_nf
+      have hapow : t ^ (a - 1) = t ^ a / t := Real.rpow_sub_one ht0.ne' a
+      have hbpow : (1 - t) ^ (b - 1) = (1 - t) ^ b / (1 - t) := Real.rpow_sub_one h1t.ne' b
+      rw [hapow, hbpow]
+      field_simp
   -- the fundamental theorem of calculus applied to `t ^ a * (1 - t) ^ b`
   have hftc : ∫ t in (0 : ℝ)..x, (a * (t ^ (a - 1) * (1 - t) ^ b) -
       b * (t ^ a * (1 - t) ^ (b - 1))) = x ^ a * (1 - x) ^ b := by
@@ -397,7 +400,8 @@ theorem regularizedIncompleteBeta_add_one_left (ha : 0 < a) (hb : 0 < b)
         (a * (t ^ (a - 1) * (1 - t) ^ b) - b * (t ^ a * (1 - t) ^ (b - 1))) (Ioi t) t := by
       intro t ht
       have ht0 : t ≠ 0 := ht.1.ne'
-      have h1t : (1 : ℝ) - t ≠ 0 := sub_ne_zero_of_ne (show t < 1 by linarith [ht.2]).ne'
+      have ht1 : t < 1 := by linarith [ht.2]
+      have h1t : (1 : ℝ) - t ≠ 0 := sub_ne_zero_of_ne ht1.ne'
       have h₁ : HasDerivAt (fun t : ℝ => t ^ a) (a * t ^ (a - 1)) t :=
         Real.hasDerivAt_rpow_const (Or.inl ht0)
       have h₂ : HasDerivAt (fun t : ℝ => (1 - t) ^ b) (b * (1 - t) ^ (b - 1) * (-1)) t :=

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
@@ -39,7 +39,7 @@ The real-variable theory of Euler's beta integral that the construction rests on
 * `TauCeti.regularizedIncompleteBeta_eq_zero_of_neg_left` and
   `TauCeti.regularizedIncompleteBeta_eq_zero_of_nonpos_right` — the default value `0` outside the
   parameter range;
-* `TauCeti.monotone_regularizedIncompleteBeta` — monotonicity, for every choice of parameters;
+* `TauCeti.regularizedIncompleteBeta_monotone` — monotonicity, for every choice of parameters;
 * `TauCeti.regularizedIncompleteBeta_nonneg` and `TauCeti.regularizedIncompleteBeta_le_one` —
   the range `[0, 1]`, for every choice of parameters;
 * `TauCeti.continuous_regularizedIncompleteBeta` — continuity on all of `ℝ`;
@@ -176,7 +176,7 @@ private lemma beta_integrand_nonneg {t : ℝ} (ht : t ∈ Icc (0 : ℝ) 1) :
 /-- The regularized incomplete beta function is monotone, for every choice of parameters: it is a
 normalized integral of a nonnegative density when `0 < a` and `0 < b`, the unit step at `0` when
 `a = 0 < b`, and the zero function for all remaining parameters. -/
-theorem monotone_regularizedIncompleteBeta (a b : ℝ) :
+theorem regularizedIncompleteBeta_monotone (a b : ℝ) :
     Monotone (regularizedIncompleteBeta a b) := by
   rcases le_or_gt b 0 with hb | hb
   · exact fun x y _ => (regularizedIncompleteBeta_eq_zero_of_nonpos_right hb a x).le.trans
@@ -216,7 +216,7 @@ theorem regularizedIncompleteBeta_nonneg (a b x : ℝ) :
     0 ≤ regularizedIncompleteBeta a b x :=
   (regularizedIncompleteBeta_eq_zero_of_neg a b
       ((min_le_right x (-1)).trans_lt (by norm_num))).symm.trans_le
-    (monotone_regularizedIncompleteBeta a b (min_le_left x (-1)))
+    (regularizedIncompleteBeta_monotone a b (min_le_left x (-1)))
 
 /-- The regularized incomplete beta function is at most `1`. -/
 theorem regularizedIncompleteBeta_le_one (a b x : ℝ) :
@@ -228,7 +228,7 @@ theorem regularizedIncompleteBeta_le_one (a b x : ℝ) :
   · rcases le_or_gt 0 x with hx | hx
     · exact (regularizedIncompleteBeta_zero_left hb hx).le
     · exact (regularizedIncompleteBeta_eq_zero_of_neg 0 b hx).trans_le zero_le_one
-  · exact (monotone_regularizedIncompleteBeta a b (le_max_left x 1)).trans_eq
+  · exact (regularizedIncompleteBeta_monotone a b (le_max_left x 1)).trans_eq
       (regularizedIncompleteBeta_eq_one_of_one_le ha.le hb (le_max_right x 1))
 
 /-- The regularized incomplete beta function is continuous on all of `ℝ`, including at the two
@@ -333,8 +333,8 @@ theorem regularizedIncompleteBeta_add_one_left (ha : 0 < a) (hb : 0 < b)
         ((continuous_const.sub continuous_id).rpow_const fun _ => Or.inr hb.le)).continuousOn
     have hderivf : ∀ t ∈ Ioo (0 : ℝ) x, HasDerivWithinAt (fun t : ℝ => t ^ a * (1 - t) ^ b)
         (a * (t ^ (a - 1) * (1 - t) ^ b) - b * (t ^ a * (1 - t) ^ (b - 1))) (Ioi t) t :=
-      fun t ht => (hasDerivAt_rpow_mul_one_sub_rpow a b ht.1.ne'
-        (ht.2.trans_le hx1).ne).hasDerivWithinAt
+      fun t ht => (hasDerivAt_rpow_mul_one_sub_rpow a b (Or.inl ht.1.ne')
+        (Or.inl (ht.2.trans_le hx1).ne)).hasDerivWithinAt
     have hint : IntervalIntegrable (fun t : ℝ => a * (t ^ (a - 1) * (1 - t) ^ b) -
         b * (t ^ a * (1 - t) ^ (b - 1))) volume 0 x := (hA.const_mul a).sub (hJ.const_mul b)
     rw [intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le hx0 hcontf hderivf hint,

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
@@ -116,12 +116,11 @@ theorem beta_comm (a b : ℝ) : beta a b = beta b a := by
   rw [ProbabilityTheory.beta, ProbabilityTheory.beta, mul_comm, add_comm]
 
 /-- The unit step of Euler's beta function in its first parameter. -/
-theorem beta_add_one_left (ha : 0 < a) (hb : 0 < b) :
+theorem beta_add_one_left (ha : a ≠ 0) (hab : a + b ≠ 0) :
     beta (a + 1) b = a / (a + b) * beta a b := by
-  have hab : (0 : ℝ) < a + b := by linarith
   have hshift : a + 1 + b = a + b + 1 := by ring
-  rw [ProbabilityTheory.beta, ProbabilityTheory.beta, hshift, Real.Gamma_add_one ha.ne',
-    Real.Gamma_add_one hab.ne']
+  rw [ProbabilityTheory.beta, ProbabilityTheory.beta, hshift, Real.Gamma_add_one ha,
+    Real.Gamma_add_one hab]
   field_simp
 
 /-! ## The regularized incomplete beta function -/
@@ -417,7 +416,8 @@ theorem regularizedIncompleteBeta_add_one_left (ha : 0 < a) (hb : 0 < b)
   rw [intervalIntegral.integral_sub (hA.const_mul a) (hJ.const_mul b),
     intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul, hsplit] at hftc
   rw [regularizedIncompleteBeta_of_pos ha1 hb, regularizedIncompleteBeta_of_pos ha hb,
-    max_eq_left hx0, min_eq_right hx1, add_sub_cancel_right, beta_add_one_left ha hb]
+    max_eq_left hx0, min_eq_right hx1, add_sub_cancel_right,
+    beta_add_one_left ha.ne' hab.ne']
   have hbeta := (beta_pos ha hb).ne'
   field_simp
   linarith [hftc]

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Probability.Distributions.Beta
+public import TauCeti.Analysis.SpecialFunctions.Beta
 
 /-!
 # The regularized incomplete beta function
@@ -23,29 +23,31 @@ records the cdf of the weak limit `betaMeasure a b → Measure.dirac 0` as `a �
 makes the binomial-tail formula `(binomial n p).real {k | m ≤ k} = I_p(m, n - m + 1)` hold at
 `m = 0` without a separate case.
 
+The real-variable theory of Euler's beta integral that the construction rests on lives in
+`TauCeti/Analysis/SpecialFunctions/Beta.lean`.
+
 ## Main results
 
 * `TauCeti.regularizedIncompleteBeta` — the definition;
+* `TauCeti.regularizedIncompleteBeta_def_of_pos` and
+  `TauCeti.regularizedIncompleteBeta_def_of_mem_Icc` — the defining normalized integral, with the
+  clamp displayed and with the clamp already discharged on `[0, 1]`;
 * `TauCeti.regularizedIncompleteBeta_zero_left` — the value `1` at the boundary `a = 0`;
-* `TauCeti.regularizedIncompleteBeta_of_nonpos`, `TauCeti.regularizedIncompleteBeta_of_neg` and
-  `TauCeti.regularizedIncompleteBeta_of_one_le` — the values `0` and `1` off `(0, 1)`;
-* `TauCeti.regularizedIncompleteBeta_of_neg_left` and
-  `TauCeti.regularizedIncompleteBeta_of_nonpos_right` — the default value `0` outside the
+* `TauCeti.regularizedIncompleteBeta_eq_zero_of_nonpos`,
+  `TauCeti.regularizedIncompleteBeta_eq_zero_of_neg` and
+  `TauCeti.regularizedIncompleteBeta_eq_one_of_one_le` — the values `0` and `1` off `(0, 1)`;
+* `TauCeti.regularizedIncompleteBeta_eq_zero_of_neg_left` and
+  `TauCeti.regularizedIncompleteBeta_eq_zero_of_nonpos_right` — the default value `0` outside the
   parameter range;
 * `TauCeti.monotone_regularizedIncompleteBeta` — monotonicity, for every choice of parameters;
+* `TauCeti.regularizedIncompleteBeta_nonneg` and `TauCeti.regularizedIncompleteBeta_le_one` —
+  the range `[0, 1]`, for every choice of parameters;
 * `TauCeti.continuous_regularizedIncompleteBeta` — continuity on all of `ℝ`;
 * `TauCeti.hasDerivAt_regularizedIncompleteBeta` — the derivative on `(0, 1)`;
-* `TauCeti.regularizedIncompleteBeta_reflect` — the reflection formula
+* `TauCeti.regularizedIncompleteBeta_symm` — the reflection formula
   `I_x(a, b) = 1 - I_{1-x}(b, a)`;
 * `TauCeti.regularizedIncompleteBeta_add_one_left` — the unit-step recurrence
   `I_x(a + 1, b) = I_x(a, b) - x ^ a * (1 - x) ^ b / (a * Β(a, b))`, for `0 ≤ x ≤ 1`.
-
-Four auxiliary results about Euler's beta function itself are proved on the way and are stated for
-reuse: `TauCeti.intervalIntegrable_rpow_mul_one_sub_rpow` and
-`TauCeti.integral_rpow_mul_one_sub_rpow` for its integral — the latter replaces the private
-calculation previously used by `TauCeti/Probability/Distributions/Beta.lean` — together with
-`TauCeti.beta_comm` and `TauCeti.beta_add_one_left`, the two parameter identities behind the
-reflection formula and the recurrence.
 
 ## References
 
@@ -61,69 +63,6 @@ namespace TauCeti
 open MeasureTheory ProbabilityTheory Set
 
 variable {a b x : ℝ}
-
-/-! ## Euler's beta integral -/
-
-/-- The integrand `t ^ (a - 1) * (1 - t) ^ (b - 1)` of Euler's beta integral is interval
-integrable between any two points of `[0, 1]`. Both endpoint singularities are integrable
-precisely because the exponents exceed `-1`. -/
-theorem intervalIntegrable_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) {u v : ℝ}
-    (hu : u ∈ Icc (0 : ℝ) 1) (hv : v ∈ Icc (0 : ℝ) 1) :
-    IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) volume u v := by
-  have key : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) volume 0 1 := by
-    have hleft : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1))
-        volume 0 (1 / 2) := by
-      refine (intervalIntegral.intervalIntegrable_rpow' (by linarith)).mul_continuousOn ?_
-      refine ContinuousOn.rpow_const (by fun_prop) fun t ht => Or.inl ?_
-      rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1 / 2)] at ht
-      have ht1 : t < 1 := by linarith [ht.2]
-      exact sub_ne_zero_of_ne ht1.ne'
-    have hright : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1))
-        volume (1 / 2) 1 := by
-      have hbase : IntervalIntegrable (fun t : ℝ => (1 - t) ^ (b - 1)) volume 1 (1 / 2) := by
-        have h := (intervalIntegral.intervalIntegrable_rpow' (a := 0) (b := 1 / 2)
-          (r := b - 1) (by linarith)).comp_sub_left 1
-        have hhalf : (1 : ℝ) - 1 / 2 = 1 / 2 := by norm_num
-        rwa [sub_zero, hhalf] at h
-      refine (hbase.continuousOn_mul ?_).symm
-      refine ContinuousOn.rpow_const (by fun_prop) fun t ht => Or.inl ?_
-      rw [uIcc_of_ge (by norm_num : (1 / 2 : ℝ) ≤ 1)] at ht
-      have ht0 : (0 : ℝ) < t := by linarith [ht.1]
-      exact ht0.ne'
-    exact hleft.trans hright
-  refine key.mono_set (uIcc_subset_uIcc ?_ ?_) <;>
-    rw [uIcc_of_le (zero_le_one : (0 : ℝ) ≤ 1)]
-  exacts [hu, hv]
-
-/-- Euler's beta integral, in real-valued interval form: for positive parameters the integral of
-`t ^ (a - 1) * (1 - t) ^ (b - 1)` over `[0, 1]` is `Β(a, b)`. -/
-theorem integral_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) :
-    ∫ t in (0 : ℝ)..1, t ^ (a - 1) * (1 - t) ^ (b - 1) = beta a b := by
-  rw [beta_eq_betaIntegralReal a b ha hb, Complex.betaIntegral,
-    intervalIntegral.integral_of_le (zero_le_one : (0 : ℝ) ≤ 1),
-    intervalIntegral.integral_of_le (zero_le_one : (0 : ℝ) ≤ 1),
-    ← RCLike.re_to_complex, ← integral_re]
-  · refine setIntegral_congr_fun measurableSet_Ioc fun t ⟨ht0, ht1⟩ ↦ ?_
-    norm_cast
-    rw [← Complex.ofReal_cpow, ← Complex.ofReal_cpow, RCLike.re_to_complex,
-      Complex.re_mul_ofReal, Complex.ofReal_re]
-    all_goals linarith
-  · convert! Complex.betaIntegral_convergent (u := a) (v := b) (by simpa) (by simpa)
-    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (zero_le_one : (0 : ℝ) ≤ 1), IntegrableOn]
-
-/-- Euler's beta function is symmetric in its two parameters. -/
-theorem beta_comm (a b : ℝ) : beta a b = beta b a := by
-  rw [ProbabilityTheory.beta, ProbabilityTheory.beta, mul_comm, add_comm]
-
-/-- The unit step of Euler's beta function in its first parameter. -/
-theorem beta_add_one_left (ha : a ≠ 0) (hab : a + b ≠ 0) :
-    beta (a + 1) b = a / (a + b) * beta a b := by
-  have hshift : a + 1 + b = a + b + 1 := by ring
-  rw [ProbabilityTheory.beta, ProbabilityTheory.beta, hshift, Real.Gamma_add_one ha,
-    Real.Gamma_add_one hab]
-  field_simp
-
-/-! ## The regularized incomplete beta function -/
 
 /-- The regularized incomplete beta function `I_x(a, b)`, extended to all real arguments by
 clamping `x` to `[0, 1]`. It is zero outside the positive parameter range, except that
@@ -141,7 +80,7 @@ private lemma clamp_mem_Icc (x : ℝ) : min 1 (max x 0) ∈ Icc (0 : ℝ) 1 :=
 
 /-- On the positive parameter range the regularized incomplete beta function is the normalized
 integral of the beta integrand up to the clamped argument. -/
-theorem regularizedIncompleteBeta_of_pos (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
+theorem regularizedIncompleteBeta_def_of_pos (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
     regularizedIncompleteBeta a b x =
       (∫ t in (0 : ℝ)..min 1 (max x 0), t ^ (a - 1) * (1 - t) ^ (b - 1)) / beta a b := by
   rw [regularizedIncompleteBeta]
@@ -149,6 +88,15 @@ theorem regularizedIncompleteBeta_of_pos (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
   · exact absurd h₁.1 ha.ne'
   · rfl
   · exact absurd ⟨ha, hb⟩ h₂
+
+/-- On the support `[0, 1]` the clamp is invisible: the regularized incomplete beta function is
+the normalized integral of the beta integrand up to `x` itself. This is the form in which the
+cumulative distribution functions built from `TauCeti.regularizedIncompleteBeta` are used. -/
+theorem regularizedIncompleteBeta_def_of_mem_Icc (ha : 0 < a) (hb : 0 < b)
+    (hx : x ∈ Icc (0 : ℝ) 1) :
+    regularizedIncompleteBeta a b x =
+      (∫ t in (0 : ℝ)..x, t ^ (a - 1) * (1 - t) ^ (b - 1)) / beta a b := by
+  rw [regularizedIncompleteBeta_def_of_pos ha hb, max_eq_left hx.1, min_eq_right hx.2]
 
 /-- The boundary convention at `a = 0`: the regularized incomplete beta function is the cdf of
 `Measure.dirac 0`, the weak limit of `betaMeasure a b` as `a → 0⁺`. -/
@@ -164,7 +112,7 @@ theorem regularizedIncompleteBeta_zero_left (hb : 0 < b) (hx : 0 ≤ x) :
 /-- The regularized incomplete beta function vanishes when its first parameter is negative: no
 beta law is attached to such parameters, and the definition takes its default value there. -/
 @[simp]
-theorem regularizedIncompleteBeta_of_neg_left (ha : a < 0) (b x : ℝ) :
+theorem regularizedIncompleteBeta_eq_zero_of_neg_left (ha : a < 0) (b x : ℝ) :
     regularizedIncompleteBeta a b x = 0 := by
   rw [regularizedIncompleteBeta]
   split_ifs with h₁ h₂
@@ -176,7 +124,7 @@ theorem regularizedIncompleteBeta_of_neg_left (ha : a < 0) (b x : ℝ) :
 Unlike the first parameter, the second admits no exceptional value at `0`: the weak limit of
 `betaMeasure a b` as `b → 0⁺` is `Measure.dirac 1`, whose cdf is not the constant `1`. -/
 @[simp]
-theorem regularizedIncompleteBeta_of_nonpos_right (hb : b ≤ 0) (a x : ℝ) :
+theorem regularizedIncompleteBeta_eq_zero_of_nonpos_right (hb : b ≤ 0) (a x : ℝ) :
     regularizedIncompleteBeta a b x = 0 := by
   rw [regularizedIncompleteBeta]
   split_ifs with h₁ h₂
@@ -187,7 +135,7 @@ theorem regularizedIncompleteBeta_of_nonpos_right (hb : b ≤ 0) (a x : ℝ) :
 /-- The regularized incomplete beta function vanishes strictly below the support of the beta law,
 for every choice of parameters: the exceptional value `1` at `a = 0` is taken from `0` onwards. -/
 @[simp]
-theorem regularizedIncompleteBeta_of_neg (a b : ℝ) (hx : x < 0) :
+theorem regularizedIncompleteBeta_eq_zero_of_neg (a b : ℝ) (hx : x < 0) :
     regularizedIncompleteBeta a b x = 0 := by
   rw [regularizedIncompleteBeta]
   split_ifs with h₁ h₂
@@ -198,9 +146,10 @@ theorem regularizedIncompleteBeta_of_neg (a b : ℝ) (hx : x < 0) :
 
 /-- The regularized incomplete beta function vanishes below the support of the beta law. The
 hypothesis `a ≠ 0` is needed only at `x = 0`, where the boundary convention gives the value `1`;
-`TauCeti.regularizedIncompleteBeta_of_neg` is the unconditional statement strictly below `0`. -/
+`TauCeti.regularizedIncompleteBeta_eq_zero_of_neg` is the unconditional statement strictly below
+`0`. -/
 @[simp]
-theorem regularizedIncompleteBeta_of_nonpos (ha : a ≠ 0) (b : ℝ) (hx : x ≤ 0) :
+theorem regularizedIncompleteBeta_eq_zero_of_nonpos (ha : a ≠ 0) (b : ℝ) (hx : x ≤ 0) :
     regularizedIncompleteBeta a b x = 0 := by
   rw [regularizedIncompleteBeta]
   split_ifs with h₁ h₂
@@ -212,11 +161,11 @@ theorem regularizedIncompleteBeta_of_nonpos (ha : a ≠ 0) (b : ℝ) (hx : x ≤
 /-- The regularized incomplete beta function is `1` above the support of the beta law, including
 at the boundary parameter `a = 0`. -/
 @[simp]
-theorem regularizedIncompleteBeta_of_one_le (ha : 0 ≤ a) (hb : 0 < b) (hx : 1 ≤ x) :
+theorem regularizedIncompleteBeta_eq_one_of_one_le (ha : 0 ≤ a) (hb : 0 < b) (hx : 1 ≤ x) :
     regularizedIncompleteBeta a b x = 1 := by
   rcases ha.eq_or_lt with rfl | ha
   · exact regularizedIncompleteBeta_zero_left hb (by linarith)
-  · rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_left (by linarith : (0 : ℝ) ≤ x),
+  · rw [regularizedIncompleteBeta_def_of_pos ha hb, max_eq_left (by linarith : (0 : ℝ) ≤ x),
       min_eq_left hx, integral_rpow_mul_one_sub_rpow ha hb, div_self (beta_pos ha hb).ne']
 
 /-- The beta integrand is nonnegative on `[0, 1]`. -/
@@ -230,20 +179,20 @@ normalized integral of a nonnegative density when `0 < a` and `0 < b`, the unit 
 theorem monotone_regularizedIncompleteBeta (a b : ℝ) :
     Monotone (regularizedIncompleteBeta a b) := by
   rcases le_or_gt b 0 with hb | hb
-  · exact fun x y _ => (regularizedIncompleteBeta_of_nonpos_right hb a x).le.trans
-      (regularizedIncompleteBeta_of_nonpos_right hb a y).ge
+  · exact fun x y _ => (regularizedIncompleteBeta_eq_zero_of_nonpos_right hb a x).le.trans
+      (regularizedIncompleteBeta_eq_zero_of_nonpos_right hb a y).ge
   rcases lt_trichotomy a 0 with ha | rfl | ha
-  · exact fun x y _ => (regularizedIncompleteBeta_of_neg_left ha b x).le.trans
-      (regularizedIncompleteBeta_of_neg_left ha b y).ge
+  · exact fun x y _ => (regularizedIncompleteBeta_eq_zero_of_neg_left ha b x).le.trans
+      (regularizedIncompleteBeta_eq_zero_of_neg_left ha b y).ge
   -- the boundary parameter `a = 0`, where the function is the unit step at `0`
   · intro x y hxy
     rcases le_or_gt 0 x with hx | hx
     · exact ((regularizedIncompleteBeta_zero_left hb hx).trans
         (regularizedIncompleteBeta_zero_left hb (hx.trans hxy)).symm).le
-    · refine (regularizedIncompleteBeta_of_neg 0 b hx).le.trans ?_
+    · refine (regularizedIncompleteBeta_eq_zero_of_neg 0 b hx).le.trans ?_
       rcases le_or_gt 0 y with hy | hy
       · exact zero_le_one.trans (regularizedIncompleteBeta_zero_left hb hy).ge
-      · exact (regularizedIncompleteBeta_of_neg 0 b hy).ge
+      · exact (regularizedIncompleteBeta_eq_zero_of_neg 0 b hy).ge
   -- the positive parameter range, where the integrand is nonnegative
   · intro x y hxy
     have hx := clamp_mem_Icc x
@@ -257,7 +206,7 @@ theorem monotone_regularizedIncompleteBeta (a b : ℝ) :
         t ^ (a - 1) * (1 - t) ^ (b - 1) :=
       intervalIntegral.integral_nonneg hle fun t ht =>
         beta_integrand_nonneg ⟨hx.1.trans ht.1, ht.2.trans hy.2⟩
-    rw [regularizedIncompleteBeta_of_pos ha hb, regularizedIncompleteBeta_of_pos ha hb]
+    rw [regularizedIncompleteBeta_def_of_pos ha hb, regularizedIncompleteBeta_def_of_pos ha hb]
     gcongr
     · exact (beta_pos ha hb).le
     · linarith
@@ -265,7 +214,7 @@ theorem monotone_regularizedIncompleteBeta (a b : ℝ) :
 /-- The regularized incomplete beta function is nonnegative. -/
 theorem regularizedIncompleteBeta_nonneg (a b x : ℝ) :
     0 ≤ regularizedIncompleteBeta a b x :=
-  (regularizedIncompleteBeta_of_neg a b
+  (regularizedIncompleteBeta_eq_zero_of_neg a b
       ((min_le_right x (-1)).trans_lt (by norm_num))).symm.trans_le
     (monotone_regularizedIncompleteBeta a b (min_le_left x (-1)))
 
@@ -273,14 +222,14 @@ theorem regularizedIncompleteBeta_nonneg (a b x : ℝ) :
 theorem regularizedIncompleteBeta_le_one (a b x : ℝ) :
     regularizedIncompleteBeta a b x ≤ 1 := by
   rcases le_or_gt b 0 with hb | hb
-  · exact (regularizedIncompleteBeta_of_nonpos_right hb a x).trans_le zero_le_one
+  · exact (regularizedIncompleteBeta_eq_zero_of_nonpos_right hb a x).trans_le zero_le_one
   rcases lt_trichotomy a 0 with ha | rfl | ha
-  · exact (regularizedIncompleteBeta_of_neg_left ha b x).trans_le zero_le_one
+  · exact (regularizedIncompleteBeta_eq_zero_of_neg_left ha b x).trans_le zero_le_one
   · rcases le_or_gt 0 x with hx | hx
     · exact (regularizedIncompleteBeta_zero_left hb hx).le
-    · exact (regularizedIncompleteBeta_of_neg 0 b hx).trans_le zero_le_one
+    · exact (regularizedIncompleteBeta_eq_zero_of_neg 0 b hx).trans_le zero_le_one
   · exact (monotone_regularizedIncompleteBeta a b (le_max_left x 1)).trans_eq
-      (regularizedIncompleteBeta_of_one_le ha.le hb (le_max_right x 1))
+      (regularizedIncompleteBeta_eq_one_of_one_le ha.le hb (le_max_right x 1))
 
 /-- The regularized incomplete beta function is continuous on all of `ℝ`, including at the two
 endpoints of the support, where the integrand may blow up. -/
@@ -295,7 +244,7 @@ theorem continuous_regularizedIncompleteBeta (ha : 0 < a) (hb : 0 < b) :
         rw [uIcc_of_le (zero_le_one : (0 : ℝ) ≤ 1)]; exact clamp_mem_Icc x
   have hfun : regularizedIncompleteBeta a b =
       fun x : ℝ => (∫ t in (0 : ℝ)..min 1 (max x 0), t ^ (a - 1) * (1 - t) ^ (b - 1)) / beta a b :=
-    funext (regularizedIncompleteBeta_of_pos ha hb)
+    funext (regularizedIncompleteBeta_def_of_pos ha hb)
   rw [hfun]
   exact hc.div_const (beta a b)
 
@@ -316,21 +265,21 @@ theorem hasDerivAt_regularizedIncompleteBeta (ha : 0 < a) (hb : 0 < b)
     hmble.stronglyMeasurable.stronglyMeasurableAtFilter hcont).div_const (beta a b)
   refine hderiv.congr_of_eventuallyEq ?_
   filter_upwards [Ioo_mem_nhds hx0 hx1] with y hy
-  rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_left hy.1.le, min_eq_right hy.2.le]
+  exact regularizedIncompleteBeta_def_of_mem_Icc ha hb ⟨hy.1.le, hy.2.le⟩
 
 /-- The reflection formula `I_x(a, b) = 1 - I_{1-x}(b, a)`, valid at every real argument: the
 clamping convention makes both sides constant outside `[0, 1]`, so no restriction on `x` is
 needed. Positivity of both parameters is needed, however: at `a = 0 < b` and `x < 0` the left
 side is `0` while the right side is `1`, because `regularizedIncompleteBeta b 0` vanishes
 identically. -/
-theorem regularizedIncompleteBeta_reflect (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
+theorem regularizedIncompleteBeta_symm (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
     regularizedIncompleteBeta a b x = 1 - regularizedIncompleteBeta b a (1 - x) := by
   rcases lt_or_ge x 0 with hx0 | hx0
-  · rw [regularizedIncompleteBeta_of_neg a b hx0,
-      regularizedIncompleteBeta_of_one_le hb.le ha (by linarith), sub_self]
+  · rw [regularizedIncompleteBeta_eq_zero_of_neg a b hx0,
+      regularizedIncompleteBeta_eq_one_of_one_le hb.le ha (by linarith), sub_self]
   rcases lt_or_ge 1 x with hx1 | hx1
-  · rw [regularizedIncompleteBeta_of_one_le ha.le hb hx1.le,
-      regularizedIncompleteBeta_of_neg b a (by linarith), sub_zero]
+  · rw [regularizedIncompleteBeta_eq_one_of_one_le ha.le hb hx1.le,
+      regularizedIncompleteBeta_eq_zero_of_neg b a (by linarith), sub_zero]
   have hmem : x ∈ Icc (0 : ℝ) 1 := ⟨hx0, hx1⟩
   have hmem' : 1 - x ∈ Icc (0 : ℝ) 1 := ⟨by linarith, by linarith⟩
   have hflip : (fun t : ℝ => t ^ (b - 1) * (1 - t) ^ (a - 1)) =
@@ -348,9 +297,9 @@ theorem regularizedIncompleteBeta_reflect (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
     (intervalIntegrable_rpow_mul_one_sub_rpow ha hb (mem_Icc.2 ⟨le_rfl, zero_le_one⟩) hmem)
     (intervalIntegrable_rpow_mul_one_sub_rpow ha hb hmem (mem_Icc.2 ⟨zero_le_one, le_rfl⟩))
   rw [integral_rpow_mul_one_sub_rpow ha hb] at hadd
-  rw [regularizedIncompleteBeta_of_pos ha hb, regularizedIncompleteBeta_of_pos hb ha,
-    max_eq_left hx0, min_eq_right hx1, max_eq_left hmem'.1, min_eq_right hmem'.2, hsub,
-    beta_comm b a, eq_sub_iff_add_eq, ← add_div, hadd, div_self (beta_pos ha hb).ne']
+  rw [regularizedIncompleteBeta_def_of_mem_Icc ha hb hmem,
+    regularizedIncompleteBeta_def_of_mem_Icc hb ha hmem', hsub, beta_comm b a,
+    eq_sub_iff_add_eq, ← add_div, hadd, div_self (beta_pos ha hb).ne']
 
 /-! ## The unit-step recurrence -/
 
@@ -370,60 +319,35 @@ theorem regularizedIncompleteBeta_add_one_left (ha : 0 < a) (hb : 0 < b)
   have hab : (0 : ℝ) < a + b := by linarith
   have hmem : x ∈ Icc (0 : ℝ) 1 := ⟨hx0, hx1⟩
   have hzero : (0 : ℝ) ∈ Icc (0 : ℝ) 1 := ⟨le_rfl, zero_le_one⟩
-  -- the three integrals appearing in the recurrence
-  have hI := intervalIntegrable_rpow_mul_one_sub_rpow ha hb hzero hmem
+  -- the two integrals produced by the derivative of `t ^ a * (1 - t) ^ b`
   have hJ : IntervalIntegrable (fun t : ℝ => t ^ a * (1 - t) ^ (b - 1)) volume 0 x := by
     simpa using intervalIntegrable_rpow_mul_one_sub_rpow ha1 hb hzero hmem
   have hA : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ b) volume 0 x := by
     simpa using intervalIntegrable_rpow_mul_one_sub_rpow ha hb1 hzero hmem
-  -- splitting `(1 - t) ^ b = (1 - t) ^ (b - 1) * (1 - t)`
-  have hsplit : ∫ t in (0 : ℝ)..x, t ^ (a - 1) * (1 - t) ^ b =
-      (∫ t in (0 : ℝ)..x, t ^ (a - 1) * (1 - t) ^ (b - 1)) -
-        ∫ t in (0 : ℝ)..x, t ^ a * (1 - t) ^ (b - 1) := by
-    rw [← intervalIntegral.integral_sub hI hJ]
-    refine intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t ht => ?_)
-    rw [uIoc_of_le hx0] at ht
-    have ht0 : 0 < t := ht.1
-    have ht1 : t ≤ 1 := ht.2.trans hx1
-    rcases eq_or_lt_of_le ht1 with rfl | ht1'
-    · rw [Real.one_rpow, Real.one_rpow, sub_self, Real.zero_rpow hb.ne']
-      ring
-    · have h1t : (0 : ℝ) < 1 - t := by linarith
-      have hapow : t ^ (a - 1) = t ^ a / t := Real.rpow_sub_one ht0.ne' a
-      have hbpow : (1 - t) ^ (b - 1) = (1 - t) ^ b / (1 - t) := Real.rpow_sub_one h1t.ne' b
-      rw [hapow, hbpow]
-      field_simp
-  -- the fundamental theorem of calculus applied to `t ^ a * (1 - t) ^ b`
+  -- the fundamental theorem of calculus applied to `t ^ a * (1 - t) ^ b`, whose derivative is
+  -- asked for only on the open interval, where neither endpoint singularity is met
   have hftc : ∫ t in (0 : ℝ)..x, (a * (t ^ (a - 1) * (1 - t) ^ b) -
       b * (t ^ a * (1 - t) ^ (b - 1))) = x ^ a * (1 - x) ^ b := by
     have hcontf : ContinuousOn (fun t : ℝ => t ^ a * (1 - t) ^ b) (Icc 0 x) :=
       ((Real.continuous_rpow_const ha.le).mul
         ((continuous_const.sub continuous_id).rpow_const fun _ => Or.inr hb.le)).continuousOn
     have hderivf : ∀ t ∈ Ioo (0 : ℝ) x, HasDerivWithinAt (fun t : ℝ => t ^ a * (1 - t) ^ b)
-        (a * (t ^ (a - 1) * (1 - t) ^ b) - b * (t ^ a * (1 - t) ^ (b - 1))) (Ioi t) t := by
-      intro t ht
-      have ht0 : t ≠ 0 := ht.1.ne'
-      have ht1 : t < 1 := by linarith [ht.2]
-      have h1t : (1 : ℝ) - t ≠ 0 := sub_ne_zero_of_ne ht1.ne'
-      have h₁ : HasDerivAt (fun t : ℝ => t ^ a) (a * t ^ (a - 1)) t :=
-        Real.hasDerivAt_rpow_const (Or.inl ht0)
-      have h₂ : HasDerivAt (fun t : ℝ => (1 - t) ^ b) (b * (1 - t) ^ (b - 1) * (-1)) t :=
-        (Real.hasDerivAt_rpow_const (Or.inl h1t)).comp t
-          ((hasDerivAt_id t).const_sub 1)
-      have := h₁.mul h₂
-      refine (this.congr_deriv ?_).hasDerivWithinAt
-      ring_nf
+        (a * (t ^ (a - 1) * (1 - t) ^ b) - b * (t ^ a * (1 - t) ^ (b - 1))) (Ioi t) t :=
+      fun t ht => (hasDerivAt_rpow_mul_one_sub_rpow a b ht.1.ne'
+        (ht.2.trans_le hx1).ne).hasDerivWithinAt
     have hint : IntervalIntegrable (fun t : ℝ => a * (t ^ (a - 1) * (1 - t) ^ b) -
         b * (t ^ a * (1 - t) ^ (b - 1))) volume 0 x := (hA.const_mul a).sub (hJ.const_mul b)
     rw [intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le hx0 hcontf hderivf hint,
       Real.zero_rpow ha.ne', zero_mul, sub_zero]
+  -- expand the integral of the derivative, and split off one power of `1 - t`
   rw [intervalIntegral.integral_sub (hA.const_mul a) (hJ.const_mul b),
-    intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul, hsplit] at hftc
-  rw [regularizedIncompleteBeta_of_pos ha1 hb, regularizedIncompleteBeta_of_pos ha hb,
-    max_eq_left hx0, min_eq_right hx1, add_sub_cancel_right,
+    intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul,
+    integral_rpow_mul_one_sub_rpow_add_one_right ha hb hx0 hx1] at hftc
+  rw [regularizedIncompleteBeta_def_of_mem_Icc ha1 hb hmem,
+    regularizedIncompleteBeta_def_of_mem_Icc ha hb hmem, add_sub_cancel_right,
     beta_add_one_left ha.ne' hab.ne']
   have hbeta := (beta_pos ha hb).ne'
-  field_simp
-  linarith [hftc]
+  field_simp [hbeta, ha.ne', hab.ne']
+  linear_combination -hftc
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
@@ -27,10 +27,13 @@ makes the binomial-tail formula `(binomial n p).real {k | m ≤ k} = I_p(m, n - 
 
 * `TauCeti.regularizedIncompleteBeta` — the definition;
 * `TauCeti.regularizedIncompleteBeta_zero_left` — the value `1` at the boundary `a = 0`;
-* `TauCeti.regularizedIncompleteBeta_of_nonpos` and
+* `TauCeti.regularizedIncompleteBeta_of_nonpos`, `TauCeti.regularizedIncompleteBeta_of_neg` and
   `TauCeti.regularizedIncompleteBeta_of_one_le` — the values `0` and `1` off `(0, 1)`;
-* `TauCeti.monotone_regularizedIncompleteBeta` and
-  `TauCeti.continuous_regularizedIncompleteBeta` — monotonicity and continuity on all of `ℝ`;
+* `TauCeti.regularizedIncompleteBeta_of_neg_left` and
+  `TauCeti.regularizedIncompleteBeta_of_nonpos_right` — the default value `0` outside the
+  parameter range;
+* `TauCeti.monotone_regularizedIncompleteBeta` — monotonicity, for every choice of parameters;
+* `TauCeti.continuous_regularizedIncompleteBeta` — continuity on all of `ℝ`;
 * `TauCeti.hasDerivAt_regularizedIncompleteBeta` — the derivative on `(0, 1)`;
 * `TauCeti.regularizedIncompleteBeta_reflect` — the reflection formula
   `I_x(a, b) = 1 - I_{1-x}(b, a)`;
@@ -147,6 +150,7 @@ theorem regularizedIncompleteBeta_of_pos (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
 
 /-- The boundary convention at `a = 0`: the regularized incomplete beta function is the cdf of
 `Measure.dirac 0`, the weak limit of `betaMeasure a b` as `a → 0⁺`. -/
+@[simp]
 theorem regularizedIncompleteBeta_zero_left (hb : 0 < b) (hx : 0 ≤ x) :
     regularizedIncompleteBeta 0 b x = 1 := by
   rw [regularizedIncompleteBeta]
@@ -155,54 +159,126 @@ theorem regularizedIncompleteBeta_zero_left (hb : 0 < b) (hx : 0 ≤ x) :
   · exact absurd ⟨rfl, hb, hx⟩ h₁
   · exact absurd ⟨rfl, hb, hx⟩ h₁
 
-/-- The regularized incomplete beta function vanishes below the support of the beta law. -/
-theorem regularizedIncompleteBeta_of_nonpos (ha : 0 < a) (hb : 0 < b) (hx : x ≤ 0) :
+/-- The regularized incomplete beta function vanishes when its first parameter is negative: no
+beta law is attached to such parameters, and the definition takes its default value there. -/
+@[simp]
+theorem regularizedIncompleteBeta_of_neg_left (ha : a < 0) (b x : ℝ) :
     regularizedIncompleteBeta a b x = 0 := by
-  rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_right hx,
-    min_eq_right (zero_le_one : (0 : ℝ) ≤ 1), intervalIntegral.integral_same, zero_div]
+  rw [regularizedIncompleteBeta]
+  split_ifs with h₁ h₂
+  · exact absurd h₁.1 ha.ne
+  · exact absurd h₂.1 (not_lt.2 ha.le)
+  · rfl
 
-/-- The regularized incomplete beta function is `1` above the support of the beta law. -/
-theorem regularizedIncompleteBeta_of_one_le (ha : 0 < a) (hb : 0 < b) (hx : 1 ≤ x) :
+/-- The regularized incomplete beta function vanishes when its second parameter is nonpositive.
+Unlike the first parameter, the second admits no exceptional value at `0`: the weak limit of
+`betaMeasure a b` as `b → 0⁺` is `Measure.dirac 1`, whose cdf is not the constant `1`. -/
+@[simp]
+theorem regularizedIncompleteBeta_of_nonpos_right (hb : b ≤ 0) (a x : ℝ) :
+    regularizedIncompleteBeta a b x = 0 := by
+  rw [regularizedIncompleteBeta]
+  split_ifs with h₁ h₂
+  · exact absurd h₁.2.1 (not_lt.2 hb)
+  · exact absurd h₂.2 (not_lt.2 hb)
+  · rfl
+
+/-- The regularized incomplete beta function vanishes strictly below the support of the beta law,
+for every choice of parameters: the exceptional value `1` at `a = 0` is taken from `0` onwards. -/
+@[simp]
+theorem regularizedIncompleteBeta_of_neg (a b : ℝ) (hx : x < 0) :
+    regularizedIncompleteBeta a b x = 0 := by
+  rw [regularizedIncompleteBeta]
+  split_ifs with h₁ h₂
+  · exact absurd h₁.2.2 (not_le.2 hx)
+  · rw [max_eq_right hx.le, min_eq_right (zero_le_one : (0 : ℝ) ≤ 1),
+      intervalIntegral.integral_same, zero_div]
+  · rfl
+
+/-- The regularized incomplete beta function vanishes below the support of the beta law. The
+hypothesis `a ≠ 0` is needed only at `x = 0`, where the boundary convention gives the value `1`;
+`TauCeti.regularizedIncompleteBeta_of_neg` is the unconditional statement strictly below `0`. -/
+@[simp]
+theorem regularizedIncompleteBeta_of_nonpos (ha : a ≠ 0) (b : ℝ) (hx : x ≤ 0) :
+    regularizedIncompleteBeta a b x = 0 := by
+  rw [regularizedIncompleteBeta]
+  split_ifs with h₁ h₂
+  · exact absurd h₁.1 ha
+  · rw [max_eq_right hx, min_eq_right (zero_le_one : (0 : ℝ) ≤ 1),
+      intervalIntegral.integral_same, zero_div]
+  · rfl
+
+/-- The regularized incomplete beta function is `1` above the support of the beta law, including
+at the boundary parameter `a = 0`. -/
+@[simp]
+theorem regularizedIncompleteBeta_of_one_le (ha : 0 ≤ a) (hb : 0 < b) (hx : 1 ≤ x) :
     regularizedIncompleteBeta a b x = 1 := by
-  rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_left (by linarith : (0 : ℝ) ≤ x),
-    min_eq_left hx, integral_rpow_mul_one_sub_rpow ha hb, div_self (beta_pos ha hb).ne']
+  rcases ha.eq_or_lt with rfl | ha
+  · exact regularizedIncompleteBeta_zero_left hb (by linarith)
+  · rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_left (by linarith : (0 : ℝ) ≤ x),
+      min_eq_left hx, integral_rpow_mul_one_sub_rpow ha hb, div_self (beta_pos ha hb).ne']
 
 /-- The beta integrand is nonnegative on `[0, 1]`. -/
 private lemma beta_integrand_nonneg {t : ℝ} (ht : t ∈ Icc (0 : ℝ) 1) :
     0 ≤ t ^ (a - 1) * (1 - t) ^ (b - 1) :=
   mul_nonneg (Real.rpow_nonneg ht.1 _) (Real.rpow_nonneg (by linarith [ht.2]) _)
 
-/-- The regularized incomplete beta function is monotone. -/
-theorem monotone_regularizedIncompleteBeta (ha : 0 < a) (hb : 0 < b) :
+/-- The regularized incomplete beta function is monotone, for every choice of parameters: it is a
+normalized integral of a nonnegative density when `0 < a` and `0 < b`, the unit step at `0` when
+`a = 0 < b`, and the zero function for all remaining parameters. -/
+theorem monotone_regularizedIncompleteBeta (a b : ℝ) :
     Monotone (regularizedIncompleteBeta a b) := by
-  intro x y hxy
-  have hx := clamp_mem_Icc x
-  have hy := clamp_mem_Icc y
-  have hle : min 1 (max x 0) ≤ min 1 (max y 0) := min_le_min le_rfl (max_le_max hxy le_rfl)
-  have hadd := intervalIntegral.integral_add_adjacent_intervals
-    (f := fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) (μ := volume)
-    (intervalIntegrable_rpow_mul_one_sub_rpow ha hb (mem_Icc.2 ⟨le_rfl, zero_le_one⟩) hx)
-    (intervalIntegrable_rpow_mul_one_sub_rpow ha hb hx hy)
-  have hnonneg : 0 ≤ ∫ t in (min 1 (max x 0))..(min 1 (max y 0)),
-      t ^ (a - 1) * (1 - t) ^ (b - 1) :=
-    intervalIntegral.integral_nonneg hle fun t ht =>
-      beta_integrand_nonneg ⟨hx.1.trans ht.1, ht.2.trans hy.2⟩
-  rw [regularizedIncompleteBeta_of_pos ha hb, regularizedIncompleteBeta_of_pos ha hb]
-  gcongr
-  · exact (beta_pos ha hb).le
-  · linarith
+  rcases le_or_gt b 0 with hb | hb
+  · exact fun x y _ => (regularizedIncompleteBeta_of_nonpos_right hb a x).le.trans
+      (regularizedIncompleteBeta_of_nonpos_right hb a y).ge
+  rcases lt_trichotomy a 0 with ha | rfl | ha
+  · exact fun x y _ => (regularizedIncompleteBeta_of_neg_left ha b x).le.trans
+      (regularizedIncompleteBeta_of_neg_left ha b y).ge
+  -- the boundary parameter `a = 0`, where the function is the unit step at `0`
+  · intro x y hxy
+    rcases le_or_gt 0 x with hx | hx
+    · exact ((regularizedIncompleteBeta_zero_left hb hx).trans
+        (regularizedIncompleteBeta_zero_left hb (hx.trans hxy)).symm).le
+    · refine (regularizedIncompleteBeta_of_neg 0 b hx).le.trans ?_
+      rcases le_or_gt 0 y with hy | hy
+      · exact zero_le_one.trans (regularizedIncompleteBeta_zero_left hb hy).ge
+      · exact (regularizedIncompleteBeta_of_neg 0 b hy).ge
+  -- the positive parameter range, where the integrand is nonnegative
+  · intro x y hxy
+    have hx := clamp_mem_Icc x
+    have hy := clamp_mem_Icc y
+    have hle : min 1 (max x 0) ≤ min 1 (max y 0) := min_le_min le_rfl (max_le_max hxy le_rfl)
+    have hadd := intervalIntegral.integral_add_adjacent_intervals
+      (f := fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) (μ := volume)
+      (intervalIntegrable_rpow_mul_one_sub_rpow ha hb (mem_Icc.2 ⟨le_rfl, zero_le_one⟩) hx)
+      (intervalIntegrable_rpow_mul_one_sub_rpow ha hb hx hy)
+    have hnonneg : 0 ≤ ∫ t in (min 1 (max x 0))..(min 1 (max y 0)),
+        t ^ (a - 1) * (1 - t) ^ (b - 1) :=
+      intervalIntegral.integral_nonneg hle fun t ht =>
+        beta_integrand_nonneg ⟨hx.1.trans ht.1, ht.2.trans hy.2⟩
+    rw [regularizedIncompleteBeta_of_pos ha hb, regularizedIncompleteBeta_of_pos ha hb]
+    gcongr
+    · exact (beta_pos ha hb).le
+    · linarith
 
 /-- The regularized incomplete beta function is nonnegative. -/
-theorem regularizedIncompleteBeta_nonneg (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
+theorem regularizedIncompleteBeta_nonneg (a b x : ℝ) :
     0 ≤ regularizedIncompleteBeta a b x :=
-  (regularizedIncompleteBeta_of_nonpos ha hb (min_le_right x 0)).symm.trans_le
-    (monotone_regularizedIncompleteBeta ha hb (min_le_left x 0))
+  (regularizedIncompleteBeta_of_neg a b
+      ((min_le_right x (-1)).trans_lt (by norm_num))).symm.trans_le
+    (monotone_regularizedIncompleteBeta a b (min_le_left x (-1)))
 
 /-- The regularized incomplete beta function is at most `1`. -/
-theorem regularizedIncompleteBeta_le_one (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
-    regularizedIncompleteBeta a b x ≤ 1 :=
-  (monotone_regularizedIncompleteBeta ha hb (le_max_left x 1)).trans_eq
-    (regularizedIncompleteBeta_of_one_le ha hb (le_max_right x 1))
+theorem regularizedIncompleteBeta_le_one (a b x : ℝ) :
+    regularizedIncompleteBeta a b x ≤ 1 := by
+  rcases le_or_gt b 0 with hb | hb
+  · exact (regularizedIncompleteBeta_of_nonpos_right hb a x).trans_le zero_le_one
+  rcases lt_trichotomy a 0 with ha | rfl | ha
+  · exact (regularizedIncompleteBeta_of_neg_left ha b x).trans_le zero_le_one
+  · rcases le_or_gt 0 x with hx | hx
+    · exact (regularizedIncompleteBeta_zero_left hb hx).le
+    · exact (regularizedIncompleteBeta_of_neg 0 b hx).trans_le zero_le_one
+  · exact (monotone_regularizedIncompleteBeta a b (le_max_left x 1)).trans_eq
+      (regularizedIncompleteBeta_of_one_le ha.le hb (le_max_right x 1))
 
 /-- The regularized incomplete beta function is continuous on all of `ℝ`, including at the two
 endpoints of the support, where the integrand may blow up. -/
@@ -240,12 +316,19 @@ theorem hasDerivAt_regularizedIncompleteBeta (ha : 0 < a) (hb : 0 < b)
   filter_upwards [Ioo_mem_nhds hx0 hx1] with y hy
   rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_left hy.1.le, min_eq_right hy.2.le]
 
-/-- The reflection formula `I_x(a, b) = 1 - I_{1-x}(b, a)`. It is stated only on `[0, 1]`: the two
-`a = 0` and `b = 0` boundary conventions record two different atomic limit laws, so no reflection
-identity can hold at both. -/
-theorem regularizedIncompleteBeta_reflect (ha : 0 < a) (hb : 0 < b)
-    (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+/-- The reflection formula `I_x(a, b) = 1 - I_{1-x}(b, a)`, valid at every real argument: the
+clamping convention makes both sides constant outside `[0, 1]`, so no restriction on `x` is
+needed. Positivity of both parameters is needed, however: at `a = 0 < b` and `x < 0` the left
+side is `0` while the right side is `1`, because `regularizedIncompleteBeta b 0` vanishes
+identically. -/
+theorem regularizedIncompleteBeta_reflect (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
     regularizedIncompleteBeta a b x = 1 - regularizedIncompleteBeta b a (1 - x) := by
+  rcases lt_or_ge x 0 with hx0 | hx0
+  · rw [regularizedIncompleteBeta_of_neg a b hx0,
+      regularizedIncompleteBeta_of_one_le hb.le ha (by linarith), sub_self]
+  rcases lt_or_ge 1 x with hx1 | hx1
+  · rw [regularizedIncompleteBeta_of_one_le ha.le hb hx1.le,
+      regularizedIncompleteBeta_of_neg b a (by linarith), sub_zero]
   have hmem : x ∈ Icc (0 : ℝ) 1 := ⟨hx0, hx1⟩
   have hmem' : 1 - x ∈ Icc (0 : ℝ) 1 := ⟨by linarith, by linarith⟩
   have hflip : (fun t : ℝ => t ^ (b - 1) * (1 - t) ^ (a - 1)) =

--- a/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean
@@ -1,0 +1,338 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.Distributions.Beta
+
+/-!
+# The regularized incomplete beta function
+
+For positive shape parameters `a` and `b` the *regularized incomplete beta function* is
+`I_x(a, b) = (∫ t in 0..x, t ^ (a - 1) * (1 - t) ^ (b - 1)) / Β(a, b)`, where `Β` is Euler's beta
+function `ProbabilityTheory.beta`. It is the cumulative distribution function of the beta law, and
+it also expresses the cumulative distribution functions of Student's `t`, Fisher's `F` and the
+negative binomial law, together with the binomial tail.
+
+`TauCeti.regularizedIncompleteBeta` clamps its argument to `[0, 1]`, so it is defined — and equal
+to the cdf of the beta law — on all of `ℝ`. Outside the positive parameter range it is zero, with
+one deliberate exception: `regularizedIncompleteBeta 0 b x = 1` for `0 < b` and `0 ≤ x`. This
+records the cdf of the weak limit `betaMeasure a b → Measure.dirac 0` as `a → 0⁺`, and it is what
+makes the binomial-tail formula `(binomial n p).real {k | m ≤ k} = I_p(m, n - m + 1)` hold at
+`m = 0` without a separate case.
+
+## Main results
+
+* `TauCeti.regularizedIncompleteBeta` — the definition;
+* `TauCeti.regularizedIncompleteBeta_zero_left` — the value `1` at the boundary `a = 0`;
+* `TauCeti.regularizedIncompleteBeta_of_nonpos` and
+  `TauCeti.regularizedIncompleteBeta_of_one_le` — the values `0` and `1` off `(0, 1)`;
+* `TauCeti.monotone_regularizedIncompleteBeta` and
+  `TauCeti.continuous_regularizedIncompleteBeta` — monotonicity and continuity on all of `ℝ`;
+* `TauCeti.hasDerivAt_regularizedIncompleteBeta` — the derivative on `(0, 1)`;
+* `TauCeti.regularizedIncompleteBeta_reflect` — the reflection formula
+  `I_x(a, b) = 1 - I_{1-x}(b, a)`;
+* `TauCeti.regularizedIncompleteBeta_add_one_left` — the unit-step recurrence
+  `I_x(a + 1, b) = I_x(a, b) - x ^ a * (1 - x) ^ b / (a * Β(a, b))`.
+
+Four auxiliary results about Euler's beta function itself are proved on the way and are stated for
+reuse: `TauCeti.intervalIntegrable_rpow_mul_one_sub_rpow` and
+`TauCeti.integral_rpow_mul_one_sub_rpow` for its integral — the latter replaces the private
+calculation previously used by `TauCeti/Probability/Distributions/Beta.lean` — together with
+`TauCeti.beta_comm` and `TauCeti.beta_add_one_left`, the two parameter identities behind the
+reflection formula and the recurrence.
+
+## References
+
+* Tau Ceti roadmap, `StandardDistributions`, Layer 2, "Regularized incomplete beta".
+* [NIST Digital Library of Mathematical Functions, §8.17](https://dlmf.nist.gov/8.17); the
+  recurrence is [8.17.20](https://dlmf.nist.gov/8.17.E20).
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory ProbabilityTheory Set
+
+variable {a b x : ℝ}
+
+/-! ## Euler's beta integral -/
+
+/-- The integrand `t ^ (a - 1) * (1 - t) ^ (b - 1)` of Euler's beta integral is interval
+integrable between any two points of `[0, 1]`. Both endpoint singularities are integrable
+precisely because the exponents exceed `-1`. -/
+theorem intervalIntegrable_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) {u v : ℝ}
+    (hu : u ∈ Icc (0 : ℝ) 1) (hv : v ∈ Icc (0 : ℝ) 1) :
+    IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) volume u v := by
+  have key : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) volume 0 1 := by
+    have hleft : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1))
+        volume 0 (1 / 2) := by
+      refine (intervalIntegral.intervalIntegrable_rpow' (by linarith)).mul_continuousOn ?_
+      refine ContinuousOn.rpow_const (by fun_prop) fun t ht => Or.inl ?_
+      rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1 / 2)] at ht
+      exact sub_ne_zero_of_ne (show t < 1 by linarith [ht.2]).ne'
+    have hright : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1))
+        volume (1 / 2) 1 := by
+      have hbase : IntervalIntegrable (fun t : ℝ => (1 - t) ^ (b - 1)) volume 1 (1 / 2) := by
+        have h := (intervalIntegral.intervalIntegrable_rpow' (a := 0) (b := 1 / 2)
+          (r := b - 1) (by linarith)).comp_sub_left 1
+        rwa [sub_zero, show (1 : ℝ) - 1 / 2 = 1 / 2 by norm_num] at h
+      refine (hbase.continuousOn_mul ?_).symm
+      refine ContinuousOn.rpow_const (by fun_prop) fun t ht => Or.inl ?_
+      rw [uIcc_of_ge (by norm_num : (1 / 2 : ℝ) ≤ 1)] at ht
+      exact (show (0 : ℝ) < t by linarith [ht.1]).ne'
+    exact hleft.trans hright
+  refine key.mono_set (uIcc_subset_uIcc ?_ ?_) <;>
+    rw [uIcc_of_le (zero_le_one : (0 : ℝ) ≤ 1)]
+  exacts [hu, hv]
+
+/-- Euler's beta integral, in real-valued interval form: for positive parameters the integral of
+`t ^ (a - 1) * (1 - t) ^ (b - 1)` over `[0, 1]` is `Β(a, b)`. -/
+theorem integral_rpow_mul_one_sub_rpow (ha : 0 < a) (hb : 0 < b) :
+    ∫ t in (0 : ℝ)..1, t ^ (a - 1) * (1 - t) ^ (b - 1) = beta a b := by
+  rw [beta_eq_betaIntegralReal a b ha hb, Complex.betaIntegral,
+    intervalIntegral.integral_of_le (zero_le_one : (0 : ℝ) ≤ 1),
+    intervalIntegral.integral_of_le (zero_le_one : (0 : ℝ) ≤ 1),
+    ← RCLike.re_to_complex, ← integral_re]
+  · refine setIntegral_congr_fun measurableSet_Ioc fun t ⟨ht0, ht1⟩ ↦ ?_
+    norm_cast
+    rw [← Complex.ofReal_cpow, ← Complex.ofReal_cpow, RCLike.re_to_complex,
+      Complex.re_mul_ofReal, Complex.ofReal_re]
+    all_goals linarith
+  · convert! Complex.betaIntegral_convergent (u := a) (v := b) (by simpa) (by simpa)
+    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (zero_le_one : (0 : ℝ) ≤ 1), IntegrableOn]
+
+/-- Euler's beta function is symmetric in its two parameters. -/
+theorem beta_comm (a b : ℝ) : beta a b = beta b a := by
+  rw [ProbabilityTheory.beta, ProbabilityTheory.beta, mul_comm, add_comm]
+
+/-- The unit step of Euler's beta function in its first parameter. -/
+theorem beta_add_one_left (ha : 0 < a) (hb : 0 < b) :
+    beta (a + 1) b = a / (a + b) * beta a b := by
+  have hab : (0 : ℝ) < a + b := by linarith
+  have hshift : a + 1 + b = a + b + 1 := by ring
+  rw [ProbabilityTheory.beta, ProbabilityTheory.beta, hshift, Real.Gamma_add_one ha.ne',
+    Real.Gamma_add_one hab.ne']
+  field_simp
+
+/-! ## The regularized incomplete beta function -/
+
+/-- The regularized incomplete beta function `I_x(a, b)`, extended to all real arguments by
+clamping `x` to `[0, 1]`. It is zero outside the positive parameter range, except that
+`regularizedIncompleteBeta 0 b x = 1` for `0 < b` and `0 ≤ x`; that convention records the cdf of
+the weak limit of `betaMeasure a b` as `a → 0⁺`. -/
+noncomputable def regularizedIncompleteBeta (a b x : ℝ) : ℝ :=
+  if a = 0 ∧ 0 < b ∧ 0 ≤ x then 1
+  else if 0 < a ∧ 0 < b then
+    (∫ t in (0 : ℝ)..min 1 (max x 0), t ^ (a - 1) * (1 - t) ^ (b - 1)) / beta a b
+  else 0
+
+/-- The clamped argument of `TauCeti.regularizedIncompleteBeta` lies in `[0, 1]`. -/
+private lemma clamp_mem_Icc (x : ℝ) : min 1 (max x 0) ∈ Icc (0 : ℝ) 1 :=
+  ⟨le_min zero_le_one (le_max_right x 0), min_le_left _ _⟩
+
+/-- On the positive parameter range the regularized incomplete beta function is the normalized
+integral of the beta integrand up to the clamped argument. -/
+theorem regularizedIncompleteBeta_of_pos (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
+    regularizedIncompleteBeta a b x =
+      (∫ t in (0 : ℝ)..min 1 (max x 0), t ^ (a - 1) * (1 - t) ^ (b - 1)) / beta a b := by
+  rw [regularizedIncompleteBeta]
+  split_ifs with h₁ h₂
+  · exact absurd h₁.1 ha.ne'
+  · rfl
+  · exact absurd ⟨ha, hb⟩ h₂
+
+/-- The boundary convention at `a = 0`: the regularized incomplete beta function is the cdf of
+`Measure.dirac 0`, the weak limit of `betaMeasure a b` as `a → 0⁺`. -/
+theorem regularizedIncompleteBeta_zero_left (hb : 0 < b) (hx : 0 ≤ x) :
+    regularizedIncompleteBeta 0 b x = 1 := by
+  rw [regularizedIncompleteBeta]
+  split_ifs with h₁ h₂
+  · rfl
+  · exact absurd ⟨rfl, hb, hx⟩ h₁
+  · exact absurd ⟨rfl, hb, hx⟩ h₁
+
+/-- The regularized incomplete beta function vanishes below the support of the beta law. -/
+theorem regularizedIncompleteBeta_of_nonpos (ha : 0 < a) (hb : 0 < b) (hx : x ≤ 0) :
+    regularizedIncompleteBeta a b x = 0 := by
+  rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_right hx,
+    min_eq_right (zero_le_one : (0 : ℝ) ≤ 1), intervalIntegral.integral_same, zero_div]
+
+/-- The regularized incomplete beta function is `1` above the support of the beta law. -/
+theorem regularizedIncompleteBeta_of_one_le (ha : 0 < a) (hb : 0 < b) (hx : 1 ≤ x) :
+    regularizedIncompleteBeta a b x = 1 := by
+  rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_left (by linarith : (0 : ℝ) ≤ x),
+    min_eq_left hx, integral_rpow_mul_one_sub_rpow ha hb, div_self (beta_pos ha hb).ne']
+
+/-- The beta integrand is nonnegative on `[0, 1]`. -/
+private lemma beta_integrand_nonneg {t : ℝ} (ht : t ∈ Icc (0 : ℝ) 1) :
+    0 ≤ t ^ (a - 1) * (1 - t) ^ (b - 1) :=
+  mul_nonneg (Real.rpow_nonneg ht.1 _) (Real.rpow_nonneg (by linarith [ht.2]) _)
+
+/-- The regularized incomplete beta function is monotone. -/
+theorem monotone_regularizedIncompleteBeta (ha : 0 < a) (hb : 0 < b) :
+    Monotone (regularizedIncompleteBeta a b) := by
+  intro x y hxy
+  have hx := clamp_mem_Icc x
+  have hy := clamp_mem_Icc y
+  have hle : min 1 (max x 0) ≤ min 1 (max y 0) := min_le_min le_rfl (max_le_max hxy le_rfl)
+  have hadd := intervalIntegral.integral_add_adjacent_intervals
+    (f := fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) (μ := volume)
+    (intervalIntegrable_rpow_mul_one_sub_rpow ha hb (mem_Icc.2 ⟨le_rfl, zero_le_one⟩) hx)
+    (intervalIntegrable_rpow_mul_one_sub_rpow ha hb hx hy)
+  have hnonneg : 0 ≤ ∫ t in (min 1 (max x 0))..(min 1 (max y 0)),
+      t ^ (a - 1) * (1 - t) ^ (b - 1) :=
+    intervalIntegral.integral_nonneg hle fun t ht =>
+      beta_integrand_nonneg ⟨hx.1.trans ht.1, ht.2.trans hy.2⟩
+  rw [regularizedIncompleteBeta_of_pos ha hb, regularizedIncompleteBeta_of_pos ha hb]
+  gcongr
+  · exact (beta_pos ha hb).le
+  · linarith
+
+/-- The regularized incomplete beta function is nonnegative. -/
+theorem regularizedIncompleteBeta_nonneg (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
+    0 ≤ regularizedIncompleteBeta a b x :=
+  (regularizedIncompleteBeta_of_nonpos ha hb (min_le_right x 0)).symm.trans_le
+    (monotone_regularizedIncompleteBeta ha hb (min_le_left x 0))
+
+/-- The regularized incomplete beta function is at most `1`. -/
+theorem regularizedIncompleteBeta_le_one (ha : 0 < a) (hb : 0 < b) (x : ℝ) :
+    regularizedIncompleteBeta a b x ≤ 1 :=
+  (monotone_regularizedIncompleteBeta ha hb (le_max_left x 1)).trans_eq
+    (regularizedIncompleteBeta_of_one_le ha hb (le_max_right x 1))
+
+/-- The regularized incomplete beta function is continuous on all of `ℝ`, including at the two
+endpoints of the support, where the integrand may blow up. -/
+theorem continuous_regularizedIncompleteBeta (ha : 0 < a) (hb : 0 < b) :
+    Continuous (regularizedIncompleteBeta a b) := by
+  have hII := intervalIntegrable_rpow_mul_one_sub_rpow ha hb
+    (u := 0) (v := 1) (mem_Icc.2 ⟨le_rfl, zero_le_one⟩) (mem_Icc.2 ⟨zero_le_one, le_rfl⟩)
+  have hc : Continuous fun x : ℝ =>
+      ∫ t in (0 : ℝ)..min 1 (max x 0), t ^ (a - 1) * (1 - t) ^ (b - 1) :=
+    (intervalIntegral.continuousOn_primitive_interval' hII left_mem_uIcc).comp_continuous
+      (by fun_prop) fun x => by
+        rw [uIcc_of_le (zero_le_one : (0 : ℝ) ≤ 1)]; exact clamp_mem_Icc x
+  have hfun : regularizedIncompleteBeta a b =
+      fun x : ℝ => (∫ t in (0 : ℝ)..min 1 (max x 0), t ^ (a - 1) * (1 - t) ^ (b - 1)) / beta a b :=
+    funext (regularizedIncompleteBeta_of_pos ha hb)
+  rw [hfun]
+  exact hc.div_const (beta a b)
+
+/-- The derivative of the regularized incomplete beta function on the open unit interval is the
+normalized beta density. No differentiability is claimed at the endpoints: for `a < 1` or `b < 1`
+the density is unbounded there. -/
+theorem hasDerivAt_regularizedIncompleteBeta (ha : 0 < a) (hb : 0 < b)
+    (hx0 : 0 < x) (hx1 : x < 1) :
+    HasDerivAt (regularizedIncompleteBeta a b)
+      (x ^ (a - 1) * (1 - x) ^ (b - 1) / beta a b) x := by
+  have hII := intervalIntegrable_rpow_mul_one_sub_rpow ha hb
+    (u := 0) (v := x) (mem_Icc.2 ⟨le_rfl, zero_le_one⟩) (mem_Icc.2 ⟨hx0.le, hx1.le⟩)
+  have hmble : Measurable fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1) := by fun_prop
+  have hcont : ContinuousAt (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) x := by
+    refine ContinuousAt.mul (Real.continuousAt_rpow_const x (a - 1) (Or.inl hx0.ne')) ?_
+    exact ContinuousAt.rpow_const (by fun_prop) (Or.inl (sub_ne_zero_of_ne hx1.ne'))
+  have hderiv := (intervalIntegral.integral_hasDerivAt_right hII
+    hmble.stronglyMeasurable.stronglyMeasurableAtFilter hcont).div_const (beta a b)
+  refine hderiv.congr_of_eventuallyEq ?_
+  filter_upwards [Ioo_mem_nhds hx0 hx1] with y hy
+  rw [regularizedIncompleteBeta_of_pos ha hb, max_eq_left hy.1.le, min_eq_right hy.2.le]
+
+/-- The reflection formula `I_x(a, b) = 1 - I_{1-x}(b, a)`. It is stated only on `[0, 1]`: the two
+`a = 0` and `b = 0` boundary conventions record two different atomic limit laws, so no reflection
+identity can hold at both. -/
+theorem regularizedIncompleteBeta_reflect (ha : 0 < a) (hb : 0 < b)
+    (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    regularizedIncompleteBeta a b x = 1 - regularizedIncompleteBeta b a (1 - x) := by
+  have hmem : x ∈ Icc (0 : ℝ) 1 := ⟨hx0, hx1⟩
+  have hmem' : 1 - x ∈ Icc (0 : ℝ) 1 := ⟨by linarith, by linarith⟩
+  have hflip : (fun t : ℝ => t ^ (b - 1) * (1 - t) ^ (a - 1)) =
+      fun t : ℝ => (fun s : ℝ => s ^ (a - 1) * (1 - s) ^ (b - 1)) (1 - t) := by
+    funext t
+    simp only [sub_sub_cancel]
+    rw [mul_comm]
+  have hsub : ∫ t in (0 : ℝ)..(1 - x), t ^ (b - 1) * (1 - t) ^ (a - 1) =
+      ∫ t in x..1, t ^ (a - 1) * (1 - t) ^ (b - 1) := by
+    rw [hflip, intervalIntegral.integral_comp_sub_left
+      (fun s : ℝ => s ^ (a - 1) * (1 - s) ^ (b - 1)) 1]
+    norm_num
+  have hadd := intervalIntegral.integral_add_adjacent_intervals
+    (f := fun t : ℝ => t ^ (a - 1) * (1 - t) ^ (b - 1)) (μ := volume)
+    (intervalIntegrable_rpow_mul_one_sub_rpow ha hb (mem_Icc.2 ⟨le_rfl, zero_le_one⟩) hmem)
+    (intervalIntegrable_rpow_mul_one_sub_rpow ha hb hmem (mem_Icc.2 ⟨zero_le_one, le_rfl⟩))
+  rw [integral_rpow_mul_one_sub_rpow ha hb] at hadd
+  rw [regularizedIncompleteBeta_of_pos ha hb, regularizedIncompleteBeta_of_pos hb ha,
+    max_eq_left hx0, min_eq_right hx1, max_eq_left hmem'.1, min_eq_right hmem'.2, hsub,
+    beta_comm b a, eq_sub_iff_add_eq, ← add_div, hadd, div_self (beta_pos ha hb).ne']
+
+/-! ## The unit-step recurrence -/
+
+/-- The unit-step recurrence in the first parameter,
+`I_x(a + 1, b) = I_x(a, b) - x ^ a * (1 - x) ^ b / (a * Β(a, b))`, in the form of
+[DLMF 8.17.20](https://dlmf.nist.gov/8.17.E20). -/
+theorem regularizedIncompleteBeta_add_one_left (ha : 0 < a) (hb : 0 < b)
+    (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    regularizedIncompleteBeta (a + 1) b x = regularizedIncompleteBeta a b x -
+      x ^ a * (1 - x) ^ b / (a * beta a b) := by
+  have ha1 : (0 : ℝ) < a + 1 := by linarith
+  have hb1 : (0 : ℝ) < b + 1 := by linarith
+  have hab : (0 : ℝ) < a + b := by linarith
+  have hmem : x ∈ Icc (0 : ℝ) 1 := ⟨hx0, hx1⟩
+  have hzero : (0 : ℝ) ∈ Icc (0 : ℝ) 1 := ⟨le_rfl, zero_le_one⟩
+  -- the three integrals appearing in the recurrence
+  have hI := intervalIntegrable_rpow_mul_one_sub_rpow ha hb hzero hmem
+  have hJ : IntervalIntegrable (fun t : ℝ => t ^ a * (1 - t) ^ (b - 1)) volume 0 x := by
+    simpa using intervalIntegrable_rpow_mul_one_sub_rpow ha1 hb hzero hmem
+  have hA : IntervalIntegrable (fun t : ℝ => t ^ (a - 1) * (1 - t) ^ b) volume 0 x := by
+    simpa using intervalIntegrable_rpow_mul_one_sub_rpow ha hb1 hzero hmem
+  -- splitting `(1 - t) ^ b = (1 - t) ^ (b - 1) * (1 - t)`
+  have hsplit : ∫ t in (0 : ℝ)..x, t ^ (a - 1) * (1 - t) ^ b =
+      (∫ t in (0 : ℝ)..x, t ^ (a - 1) * (1 - t) ^ (b - 1)) -
+        ∫ t in (0 : ℝ)..x, t ^ a * (1 - t) ^ (b - 1) := by
+    rw [← intervalIntegral.integral_sub hI hJ]
+    refine intervalIntegral.integral_congr_ae (Filter.Eventually.of_forall fun t ht => ?_)
+    rw [uIoc_of_le hx0] at ht
+    have ht0 : 0 < t := ht.1
+    have ht1 : t ≤ 1 := ht.2.trans hx1
+    rcases eq_or_lt_of_le ht1 with rfl | ht1'
+    · rw [Real.one_rpow, Real.one_rpow, sub_self, Real.zero_rpow hb.ne']
+      ring
+    · have h1t : (0 : ℝ) < 1 - t := by linarith
+      rw [show b = b - 1 + 1 by ring, Real.rpow_add h1t, Real.rpow_one]
+      nth_rewrite 3 [show a = a - 1 + 1 by ring]
+      rw [Real.rpow_add ht0, Real.rpow_one]
+      ring_nf
+  -- the fundamental theorem of calculus applied to `t ^ a * (1 - t) ^ b`
+  have hftc : ∫ t in (0 : ℝ)..x, (a * (t ^ (a - 1) * (1 - t) ^ b) -
+      b * (t ^ a * (1 - t) ^ (b - 1))) = x ^ a * (1 - x) ^ b := by
+    have hcontf : ContinuousOn (fun t : ℝ => t ^ a * (1 - t) ^ b) (Icc 0 x) :=
+      ((Real.continuous_rpow_const ha.le).mul
+        ((continuous_const.sub continuous_id).rpow_const fun _ => Or.inr hb.le)).continuousOn
+    have hderivf : ∀ t ∈ Ioo (0 : ℝ) x, HasDerivWithinAt (fun t : ℝ => t ^ a * (1 - t) ^ b)
+        (a * (t ^ (a - 1) * (1 - t) ^ b) - b * (t ^ a * (1 - t) ^ (b - 1))) (Ioi t) t := by
+      intro t ht
+      have ht0 : t ≠ 0 := ht.1.ne'
+      have h1t : (1 : ℝ) - t ≠ 0 := sub_ne_zero_of_ne (show t < 1 by linarith [ht.2]).ne'
+      have h₁ : HasDerivAt (fun t : ℝ => t ^ a) (a * t ^ (a - 1)) t :=
+        Real.hasDerivAt_rpow_const (Or.inl ht0)
+      have h₂ : HasDerivAt (fun t : ℝ => (1 - t) ^ b) (b * (1 - t) ^ (b - 1) * (-1)) t :=
+        (Real.hasDerivAt_rpow_const (Or.inl h1t)).comp t
+          ((hasDerivAt_id t).const_sub 1)
+      have := h₁.mul h₂
+      refine (this.congr_deriv ?_).hasDerivWithinAt
+      ring_nf
+    have hint : IntervalIntegrable (fun t : ℝ => a * (t ^ (a - 1) * (1 - t) ^ b) -
+        b * (t ^ a * (1 - t) ^ (b - 1))) volume 0 x := (hA.const_mul a).sub (hJ.const_mul b)
+    rw [intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le hx0 hcontf hderivf hint,
+      Real.zero_rpow ha.ne', zero_mul, sub_zero]
+  rw [intervalIntegral.integral_sub (hA.const_mul a) (hJ.const_mul b),
+    intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul, hsplit] at hftc
+  rw [regularizedIncompleteBeta_of_pos ha1 hb, regularizedIncompleteBeta_of_pos ha hb,
+    max_eq_left hx0, min_eq_right hx1, add_sub_cancel_right, beta_add_one_left ha hb]
+  have hbeta := (beta_pos ha hb).ne'
+  field_simp
+  linarith [hftc]
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Beta.lean
+++ b/TauCeti/Probability/Distributions/Beta.lean
@@ -6,10 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Probability.Distributions.Beta
-public import TauCeti.Analysis.SpecialFunctions.IncompleteBeta
 public import Mathlib.Probability.Moments.Basic
 public import Mathlib.Probability.Moments.IntegrableExpMul
 import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
+import TauCeti.Analysis.SpecialFunctions.IncompleteBeta
 
 /-!
 # Elementary theory of the beta distribution

--- a/TauCeti/Probability/Distributions/Beta.lean
+++ b/TauCeti/Probability/Distributions/Beta.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Probability.Distributions.Beta
+public import TauCeti.Analysis.SpecialFunctions.IncompleteBeta
 public import Mathlib.Probability.Moments.Basic
 public import Mathlib.Probability.Moments.IntegrableExpMul
 import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
@@ -56,21 +57,6 @@ private lemma toReal_betaPDF {α β : ℝ} (hα : 0 < α) (hβ : 0 < β) (x : �
     (ENNReal.ofReal (betaPDFReal α β x)).toReal = betaPDFReal α β x :=
   ENNReal.toReal_ofReal (betaPDFReal_nonneg hα hβ x)
 
-/-- Euler's beta integral in real-valued form. This is the calculation used internally by the
-moment formula. -/
-private lemma integral_rpow_mul_one_sub_rpow {α β : ℝ} (hα : 0 < α) (hβ : 0 < β) :
-    ∫ x in Set.Ioo 0 1, x ^ (α - 1) * (1 - x) ^ (β - 1) = beta α β := by
-  rw [beta_eq_betaIntegralReal α β hα hβ, Complex.betaIntegral,
-    intervalIntegral.integral_of_le (by norm_num), ← integral_Ioc_eq_integral_Ioo,
-    ← RCLike.re_to_complex, ← integral_re]
-  · refine setIntegral_congr_fun measurableSet_Ioc fun x ⟨hx0, hx1⟩ ↦ ?_
-    norm_cast
-    rw [← Complex.ofReal_cpow, ← Complex.ofReal_cpow, RCLike.re_to_complex,
-      Complex.re_mul_ofReal, Complex.ofReal_re]
-    all_goals linarith
-  · convert! Complex.betaIntegral_convergent (u := α) (v := β) (by simpa) (by simpa)
-    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le (by norm_num), IntegrableOn]
-
 /-- The beta distribution is carried by the unit interval. -/
 theorem ae_mem_Icc_betaMeasure (α β : ℝ) :
     ∀ᵐ x ∂betaMeasure α β, x ∈ Set.Icc (0 : ℝ) 1 := by
@@ -113,7 +99,9 @@ theorem integral_pow_betaMeasure {α β : ℝ} (hα : 0 < α) (hβ : 0 < β) (n 
             congr 3
             ring_nf
       _ = (1 / beta α β) * beta (α + n) β := by
-        rw [integral_const_mul, integral_rpow_mul_one_sub_rpow hαn hβ]
+        rw [integral_const_mul, ← integral_Ioc_eq_integral_Ioo,
+          ← intervalIntegral.integral_of_le (zero_le_one : (0 : ℝ) ≤ 1),
+          integral_rpow_mul_one_sub_rpow hαn hβ]
       _ = Real.Gamma (α + n) * Real.Gamma (α + β) /
             (Real.Gamma α * Real.Gamma (α + β + n)) := by
         rw [beta, beta]

--- a/TauCeti/Probability/Distributions/Beta.lean
+++ b/TauCeti/Probability/Distributions/Beta.lean
@@ -9,7 +9,7 @@ public import Mathlib.Probability.Distributions.Beta
 public import Mathlib.Probability.Moments.Basic
 public import Mathlib.Probability.Moments.IntegrableExpMul
 import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
-import TauCeti.Analysis.SpecialFunctions.IncompleteBeta
+import TauCeti.Analysis.SpecialFunctions.Beta
 
 /-!
 # Elementary theory of the beta distribution
@@ -27,8 +27,9 @@ moment exists.
   `α * β / ((α + β) ^ 2 * (α + β + 1))`;
 * `TauCeti.integrableExpSet_id_betaMeasure` — every exponential moment exists.
 
-The integral calculation follows the normalization argument for `ProbabilityTheory.betaMeasure`
-in Mathlib: rewrite the density integral as Euler's beta integral, then use the Gamma quotient.
+The moment calculation rewrites the density integral as Euler's beta integral — the real-valued
+`TauCeti.integral_rpow_mul_one_sub_rpow`, proved in
+`TauCeti/Analysis/SpecialFunctions/Beta.lean` — and then uses the Gamma quotient.
 
 ## References
 


### PR DESCRIPTION
This PR defines the regularized incomplete beta function `TauCeti.regularizedIncompleteBeta` and develops the real-variable theory the `StandardDistributions` roadmap asks of it. It serves the Layer 2 milestone "incomplete special functions and closed-form cdfs", covering that layer's "Regularized incomplete beta" target in full: the definition with the stated clamping and boundary conventions, the value `1` at `a = 0`, the values `0` and `1` off the support, continuity and monotonicity on all of `ℝ`, differentiability stated only on `(0, 1)`, the reflection formula `I_x(a, b) = 1 - I_{1-x}(b, a)` at every real argument, and the unit-step recurrence `I_x(a + 1, b) = I_x(a, b) - x ^ a * (1 - x) ^ b / (a * Β(a, b))` in the form of [DLMF 8.17.20](https://dlmf.nist.gov/8.17.E20). After this PR, Layer 2 still needs the closed-form cdf and tail bullet — `cdf_betaMeasure_eq`, `binomial_tail_eq_regularizedIncompleteBeta`, and the incomplete-gamma-side identities — of which the Gaussian cdfs are in flight in #4161 and the lower incomplete gamma itself in #4234; this PR is the missing beta-side special function that the remaining cdfs, and the Layer 3 Student's `t`, Fisher `F` and negative-binomial cdfs, all consume.

The definition follows the roadmap verbatim, including the deliberate exception `regularizedIncompleteBeta 0 b x = 1` for `0 < b` and `0 ≤ x`, which records the cdf of the weak limit `betaMeasure a b → Measure.dirac 0` as `a → 0⁺` and is what makes the `m = 0` case of the binomial-tail formula hold without a separate branch; the default value stays `0` at `b = 0`, and the reflection formula is stated only for positive parameters, since the two atomic limit laws cannot both be recorded by one identity at their discontinuities. The evaluation API is total: every branch of the definition — `a < 0`, `b ≤ 0`, `a = 0` with `x < 0`, and the two edges of the support — has a `@[simp]` lemma giving its value, and monotonicity, nonnegativity and the bound by `1` hold for arbitrary parameters.

Three points of the mathematics are worth flagging. Interval integrability of `t ^ (a - 1) * (1 - t) ^ (b - 1)` is proved by splitting `[0, 1]` at `1/2` and reflecting, so each endpoint singularity is handled by Mathlib's `intervalIntegral.intervalIntegrable_rpow'` against a factor that is continuous there; the clamped upper limit means only integrability inside `[0, 1]` is ever needed. Continuity at the endpoints — where the density itself blows up for `a < 1` or `b < 1` — comes from `intervalIntegral.continuousOn_primitive_interval'`, not from continuity of the integrand. The recurrence is proved without an improper integration by parts: the fundamental theorem of calculus is applied to `t ^ a * (1 - t) ^ b` through `intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le`, which asks for the derivative only on the open interval, and the resulting identity is combined with the algebraic split `t ^ (a - 1) * (1 - t) ^ b = t ^ (a - 1) * (1 - t) ^ (b - 1) - t ^ a * (1 - t) ^ (b - 1)` and with `beta (a + 1) b = a / (a + b) * beta a b`.

The real-variable theory of Euler's *complete* beta integral that all of this rests on lives in its own module, `TauCeti/Analysis/SpecialFunctions/Beta.lean`: interval integrability of the integrand on `[0, 1]`, the beta integral `TauCeti.integral_rpow_mul_one_sub_rpow` itself, the derivative of the kernel `t ^ a * (1 - t) ^ b`, the splitting that raises the second parameter by one, and the two `Β` identities `ProbabilityTheory.beta_comm` and `ProbabilityTheory.beta_add_one_left`. `TauCeti.integral_rpow_mul_one_sub_rpow` replaces the private copy that `TauCeti/Probability/Distributions/Beta.lean` carried for its moment formula; that file now imports the complete-beta module — not the incomplete-beta one — and reuses the public lemma, so the calculation exists once. Nothing else in that file changes.

**On the roadmap's layer order.** Layer 2 is where this belongs, and it is not gated on Layer 1 being *finished*. The roadmap's "Ordering and claim size" section enumerates each later layer's prerequisites explicitly — "Layer 4 requires Layers 1–3", "The rest requires Layers 0–2", "Layer 6 requires Layers 3–5" — and assigns Layer 2 none; its preamble says why: "This layer develops reusable analysis, not distribution-specific infrastructure." Where the two layers touch, the dependency runs from Layer 1 *to* Layer 2: Layer 1's Bernoulli/binomial bullet defers the cumulative-mass formula to "Layer 2's binomial-tail identity", its Poisson bullet defers the native cumulative-mass formula and the cast-law cdf to "Layer 2's tail identity", and its real-Gaussian bullet ends "The cdf appears in Layer 2." Concretely, the new module's transitive `TauCeti` import closure is empty — it imports `Mathlib.Probability.Distributions.Beta` and nothing else — so no Layer 0 or Layer 1 declaration can be a prerequisite of it. Layer 1 is meanwhile well under way: ten of its fourteen key declarations are on `main` or in an open PR (#4246, #4227), and Layer 2 already has `Erf.lean` and `Gaussian/Cdf.lean` on `main` from #4161, with #4234 open for the incomplete gamma.

New files: `TauCeti/Analysis/SpecialFunctions/Beta.lean` and `TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean`. No Mathlib source was vendored; the two proofs that follow a Mathlib argument (`ProbabilityTheory.lintegral_betaPDF_eq_one` and `Complex.betaIntegral_convergent`) say so in the complete-beta module's docstring.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"regularized-incomplete-beta"}-->

🤖 Prepared with Claude Code
