### PR TITLE
feat: add symplectic long-root subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean
@@ -342,6 +342,15 @@ noncomputable def coordinateMap :
   CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra R (m + m))
     (definingHopfIdeal R m)
 
+/-- The symplectic coordinate map is the canonical quotient morphism by the defining Hopf
+ideal. -/
+theorem coordinateMap_def :
+    coordinateMap R m =
+      CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra R (m + m))
+        (definingHopfIdeal R m) := by
+  unfold coordinateMap
+  rfl
+
 /-- The symplectic coordinate morphism sends an ambient coordinate to its quotient class. -/
 theorem coordinateMap_apply (h : GeneralLinear.coordinateHopfAlgebra R (m + m)) :
     (coordinateMap R m).hom h =
@@ -364,6 +373,15 @@ noncomputable def groupScheme :=
   CommHopfAlgCat.quotientSpec (GeneralLinear.coordinateHopfAlgebra R (m + m))
     (definingHopfIdeal R m)
 
+/-- The symplectic group scheme is the quotient spectrum of its coordinate Hopf algebra. -/
+theorem groupScheme_def :
+    groupScheme R m =
+      CommHopfAlgCat.quotientSpec (GeneralLinear.coordinateHopfAlgebra R (m + m))
+        (definingHopfIdeal R m) := by
+  unfold groupScheme
+  rfl
+
+/-- The quotient-spectrum inclusion into the Hopf spectrum of the ambient coordinate algebra. -/
 private noncomputable def groupSchemeι :=
   CommHopfAlgCat.quotientSpecι (GeneralLinear.coordinateHopfAlgebra R (m + m))
     (definingHopfIdeal R m)
@@ -371,7 +389,19 @@ private noncomputable def groupSchemeι :=
 /-- The closed-subgroup inclusion from the symplectic subgroup scheme into the named general
 linear group scheme. -/
 noncomputable def inclusion : groupScheme R m ⟶ GeneralLinear.groupScheme R (m + m) :=
-  groupSchemeι R m ≫ (eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom
+  eqToHom (groupScheme_def R m) ≫ groupSchemeι R m ≫
+    (eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom
+
+/-- The symplectic inclusion is the relative spectrum of the quotient coordinate map, followed
+by transport to the named general-linear presentation. -/
+theorem inclusion_def :
+    inclusion R m =
+      eqToHom (groupScheme_def R m) ≫
+        CommHopfAlgCat.quotientSpecι
+          (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m) ≫
+        (eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom := by
+  unfold inclusion groupSchemeι
+  rfl
 
 private theorem inclusion_hom_left :
     (inclusion R m).hom.hom.left =
@@ -564,6 +594,18 @@ theorem pointsMulEquiv_coe
     (fun g => (pointsSubgroupToGLSymplecticFin R m g : GLSymplecticFin m A).1)
     hcomponent.symm
 
+/-- Mapping a symplectic point along the quotient coordinate morphism gives its ambient
+general-linear point. -/
+theorem mapPointsFunctor_coordinateMap_app
+    (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R m)
+      (CommAlgCat.of R A)) :
+    (CommHopfAlgCat.mapPointsFunctor (coordinateMap R m)).app (CommAlgCat.of R A) f =
+      CommHopfAlgCat.quotientPointsHom
+        (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m)
+        (CommAlgCat.of R A) f := by
+  apply WithConv.ext
+  rfl
+
 /-- The ambient point attached to a symplectic matrix is the general-linear point attached to
 its ordinary inclusion. -/
 @[simp]
@@ -574,6 +616,26 @@ theorem quotientPointsHom_pointsMulEquiv_symm (g : GLSymplecticFin m A) :
       (GeneralLinear.pointsMulEquiv (R := R) (A := A) (m + m)).symm g.1 := by
   apply (GeneralLinear.pointsMulEquiv (R := R) (A := A) (m + m)).injective
   rw [pointsMulEquiv_coe, MulEquiv.apply_symm_apply, MulEquiv.apply_symm_apply]
+
+variable {B : Type w} [CommRing B] [Algebra R B]
+
+/-- The symplectic point equivalence is natural in the value algebra: postcomposition of Hopf
+points agrees with entrywise mapping of symplectic matrices. -/
+theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
+    (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R m)
+      (CommAlgCat.of R A)) :
+    pointsMulEquiv (R := R) (A := B) m
+        (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R m)
+          (CommAlgCat.ofHom phi) f) =
+      GLSymplecticFin.map m A phi.toRingHom
+        (pointsMulEquiv (R := R) (A := A) m f) := by
+  apply Subtype.ext
+  have hcoe_lhs := pointsMulEquiv_coe (R := R) (A := B) m
+    (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R m) (CommAlgCat.ofHom phi) f)
+  have hcoe_rhs := pointsMulEquiv_coe (R := R) (A := A) m f
+  rw [← hcoe_lhs, ← CommHopfAlgCat.mapPoints_quotientPointsHom,
+    HopfAlgebra.mapPoints_apply, CommAlgCat.hom_ofHom, ← AlgHom.mapValue_apply,
+    GeneralLinear.pointsMulEquiv_mapValue, hcoe_rhs, GLSymplecticFin.coe_map]
 
 /-- The points identification, read in `Fin m ⊕ Fin m` coordinates: the points of the symplectic
 coordinate Hopf algebra are `TauCeti.GLSymplectic (Fin m) A`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean
@@ -85,7 +85,7 @@ open CategoryTheory Matrix WithConv
 
 namespace TauCeti.Symplectic
 
-universe u w
+universe u v w
 
 variable (R : Type u) [CommRing R] (m : ℕ)
 
@@ -617,7 +617,7 @@ theorem quotientPointsHom_pointsMulEquiv_symm (g : GLSymplecticFin m A) :
   apply (GeneralLinear.pointsMulEquiv (R := R) (A := A) (m + m)).injective
   rw [pointsMulEquiv_coe, MulEquiv.apply_symm_apply, MulEquiv.apply_symm_apply]
 
-variable {B : Type w} [CommRing B] [Algebra R B]
+variable {B : Type v} [CommRing B] [Algebra R B]
 
 /-- The symplectic point equivalence is natural in the value algebra: postcomposition of Hopf
 points agrees with entrywise mapping of symplectic matrices. -/
@@ -625,16 +625,26 @@ theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
     (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R m)
       (CommAlgCat.of R A)) :
     pointsMulEquiv (R := R) (A := B) m
-        (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R m)
-          (CommAlgCat.ofHom phi) f) =
+        (AlgHom.mapValue (H := coordinateHopfAlgebra R m) phi f) =
       GLSymplecticFin.map m A phi.toRingHom
         (pointsMulEquiv (R := R) (A := A) m f) := by
   apply Subtype.ext
   have hcoe_lhs := pointsMulEquiv_coe (R := R) (A := B) m
-    (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R m) (CommAlgCat.ofHom phi) f)
+    (AlgHom.mapValue (H := coordinateHopfAlgebra R m) phi f)
   have hcoe_rhs := pointsMulEquiv_coe (R := R) (A := A) m f
-  rw [← hcoe_lhs, ← CommHopfAlgCat.mapPoints_quotientPointsHom,
-    HopfAlgebra.mapPoints_apply, CommAlgCat.hom_ofHom, ← AlgHom.mapValue_apply,
+  have hnatural :
+      CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m)
+          (CommAlgCat.of R B) (AlgHom.mapValue phi f) =
+        AlgHom.mapValue phi
+          (CommHopfAlgCat.quotientPointsHom
+            (GeneralLinear.coordinateHopfAlgebra R (m + m)) (definingHopfIdeal R m)
+            (CommAlgCat.of R A) f) := by
+    apply WithConv.ext
+    ext h
+    -- After extensionality, both sides apply `phi` after `f` and the canonical quotient map.
+    rfl
+  rw [← hcoe_lhs, hnatural,
     GeneralLinear.pointsMulEquiv_mapValue, hcoe_rhs, GLSymplecticFin.coe_map]
 
 /-- The points identification, read in `Fin m ⊕ Fin m` coordinates: the points of the symplectic

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/RootSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/RootSubgroup.lean
@@ -56,14 +56,14 @@ open scoped CategoryTheory.MonObj
 
 namespace TauCeti.Symplectic
 
-universe u w
+universe u v w
 
 variable {R : Type u} [CommRing R] {m : ℕ} {i : Fin m}
 
 section Points
 
 variable {A : Type w} [CommRing A] [Algebra R A]
-variable {B : Type w} [CommRing B] [Algebra R B]
+variable {B : Type v} [CommRing B] [Algebra R B]
 
 /-- The positive long-root homomorphism on `A`-points, sending `c` to
 `1 + c E_{i,m+i}` in `Sp₂ₘ(A)`. -/
@@ -135,9 +135,6 @@ theorem mapValue_positiveLongRootSubgroupPoints (phi : A →ₐ[R] B) (i : Fin m
       positiveLongRootSubgroupPoints i
         (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f) := by
   apply (pointsMulEquiv (R := R) (A := B) m).injective
-  change pointsMulEquiv (R := R) (A := B) m
-      (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R m)
-        (CommAlgCat.ofHom phi) (positiveLongRootSubgroupPoints i f)) = _
   rw [pointsMulEquiv_mapValue, pointsMulEquiv_positiveLongRootSubgroupPoints,
     pointsMulEquiv_positiveLongRootSubgroupPoints,
     GLSymplecticFin.map_positiveLongRootTransvectionUnit,
@@ -152,9 +149,6 @@ theorem mapValue_negativeLongRootSubgroupPoints (phi : A →ₐ[R] B) (i : Fin m
       negativeLongRootSubgroupPoints i
         (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f) := by
   apply (pointsMulEquiv (R := R) (A := B) m).injective
-  change pointsMulEquiv (R := R) (A := B) m
-      (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R m)
-        (CommAlgCat.ofHom phi) (negativeLongRootSubgroupPoints i f)) = _
   rw [pointsMulEquiv_mapValue, pointsMulEquiv_negativeLongRootSubgroupPoints,
     pointsMulEquiv_negativeLongRootSubgroupPoints,
     GLSymplecticFin.map_negativeLongRootTransvectionUnit,
@@ -166,7 +160,7 @@ end Points
 section Functor
 
 /-- The natural transformation of group-valued points for the positive long root `2eᵢ`. -/
-@[expose] noncomputable def positiveLongRootSubgroupPointsMap (i : Fin m) :
+noncomputable def positiveLongRootSubgroupPointsMap (i : Fin m) :
     HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
       HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R m) where
   app A := GrpCat.ofHom (positiveLongRootSubgroupPoints (A := A) i)
@@ -175,7 +169,7 @@ section Functor
     exact (mapValue_positiveLongRootSubgroupPoints phi.hom i f).symm
 
 /-- The natural transformation of group-valued points for the negative long root `-2eᵢ`. -/
-@[expose] noncomputable def negativeLongRootSubgroupPointsMap (i : Fin m) :
+noncomputable def negativeLongRootSubgroupPointsMap (i : Fin m) :
     HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
       HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R m) where
   app A := GrpCat.ofHom (negativeLongRootSubgroupPoints (A := A) i)
@@ -188,7 +182,8 @@ homomorphism. -/
 @[simp]
 theorem positiveLongRootSubgroupPointsMap_app (i : Fin m) (A : CommAlgCat.{w} R) :
     (positiveLongRootSubgroupPointsMap (R := R) i).app A =
-      GrpCat.ofHom (positiveLongRootSubgroupPoints i) :=
+      GrpCat.ofHom (positiveLongRootSubgroupPoints i) := by
+  unfold positiveLongRootSubgroupPointsMap
   rfl
 
 /-- A component of the negative long-root natural transformation is the corresponding point
@@ -196,7 +191,8 @@ homomorphism. -/
 @[simp]
 theorem negativeLongRootSubgroupPointsMap_app (i : Fin m) (A : CommAlgCat.{w} R) :
     (negativeLongRootSubgroupPointsMap (R := R) i).app A =
-      GrpCat.ofHom (negativeLongRootSubgroupPoints i) :=
+      GrpCat.ofHom (negativeLongRootSubgroupPoints i) := by
+  unfold negativeLongRootSubgroupPointsMap
   rfl
 
 end Functor
@@ -282,6 +278,8 @@ theorem coordinateMap_comp_positiveLongRootSubgroupCoordinateMap (i : Fin m) :
   apply (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R)).map_injective
   rw [op_comp, Functor.map_comp, CommHopfAlgCat.pointsFunctor_map,
     CommHopfAlgCat.pointsFunctor_map, CommHopfAlgCat.pointsFunctor_map]
+  -- Mapping an opposite composite reverses it; `change` only removes the functor and
+  -- opposite-category wrappers left by the preceding public rewrite lemmas.
   change CommHopfAlgCat.mapPointsFunctor
       (positiveLongRootSubgroupCoordinateMap (R := R) i) ≫
         CommHopfAlgCat.mapPointsFunctor (coordinateMap R m) =
@@ -293,6 +291,8 @@ theorem coordinateMap_comp_positiveLongRootSubgroupCoordinateMap (i : Fin m) :
   ext A f
   rw [NatTrans.comp_app, positiveLongRootSubgroupPointsMap_app,
     GeneralLinear.rootSubgroupPointsMap_app]
+  -- The component morphisms are `GrpCat.ofHom` wrappers, whose coercions to functions are
+  -- definitionally the displayed point homomorphisms; no separate coercion lemma is provided.
   change (CommHopfAlgCat.mapPointsFunctor (coordinateMap R m)).app A
       (positiveLongRootSubgroupPoints i f) =
     GeneralLinear.rootSubgroupPoints (GLSymplecticFin.positiveLongRoot_indices_ne i) f
@@ -316,6 +316,8 @@ theorem coordinateMap_comp_negativeLongRootSubgroupCoordinateMap (i : Fin m) :
   apply (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R)).map_injective
   rw [op_comp, Functor.map_comp, CommHopfAlgCat.pointsFunctor_map,
     CommHopfAlgCat.pointsFunctor_map, CommHopfAlgCat.pointsFunctor_map]
+  -- Mapping an opposite composite reverses it; `change` only removes the functor and
+  -- opposite-category wrappers left by the preceding public rewrite lemmas.
   change CommHopfAlgCat.mapPointsFunctor
       (negativeLongRootSubgroupCoordinateMap (R := R) i) ≫
         CommHopfAlgCat.mapPointsFunctor (coordinateMap R m) =
@@ -327,6 +329,8 @@ theorem coordinateMap_comp_negativeLongRootSubgroupCoordinateMap (i : Fin m) :
   ext A f
   rw [NatTrans.comp_app, negativeLongRootSubgroupPointsMap_app,
     GeneralLinear.rootSubgroupPointsMap_app]
+  -- The component morphisms are `GrpCat.ofHom` wrappers, whose coercions to functions are
+  -- definitionally the displayed point homomorphisms; no separate coercion lemma is provided.
   change (CommHopfAlgCat.mapPointsFunctor (coordinateMap R m)).app A
       (negativeLongRootSubgroupPoints i f) =
     GeneralLinear.rootSubgroupPoints (GLSymplecticFin.negativeLongRoot_indices_ne i) f
@@ -348,6 +352,17 @@ noncomputable def positiveLongRootSubgroup (i : Fin m) :
       (positiveLongRootSubgroupCoordinateMap i).op ≫
     eqToHom (groupScheme_def R m).symm
 
+/-- The positive long-root subgroup is the relative spectrum of its coordinate morphism,
+transported to the named source and target schemes. -/
+theorem positiveLongRootSubgroup_def (i : Fin m) :
+    positiveLongRootSubgroup (R := R) i =
+      eqToHom (AdditiveGroup.groupScheme_def R) ≫
+        (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+          (positiveLongRootSubgroupCoordinateMap i).op ≫
+        eqToHom (groupScheme_def R m).symm := by
+  unfold positiveLongRootSubgroup
+  rfl
+
 /-- **The negative long-root subgroup of `Sp₂ₘ` attached to `-2eᵢ`**, as an affine
 group-scheme morphism. -/
 noncomputable def negativeLongRootSubgroup (i : Fin m) :
@@ -357,6 +372,17 @@ noncomputable def negativeLongRootSubgroup (i : Fin m) :
       (negativeLongRootSubgroupCoordinateMap i).op ≫
     eqToHom (groupScheme_def R m).symm
 
+/-- The negative long-root subgroup is the relative spectrum of its coordinate morphism,
+transported to the named source and target schemes. -/
+theorem negativeLongRootSubgroup_def (i : Fin m) :
+    negativeLongRootSubgroup (R := R) i =
+      eqToHom (AdditiveGroup.groupScheme_def R) ≫
+        (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+          (negativeLongRootSubgroupCoordinateMap i).op ≫
+        eqToHom (groupScheme_def R m).symm := by
+  unfold negativeLongRootSubgroup
+  rfl
+
 /-- The positive long-root subgroup followed by the symplectic inclusion is the corresponding
 general-linear root subgroup. -/
 @[simp]
@@ -364,7 +390,7 @@ theorem positiveLongRootSubgroup_comp_inclusion (i : Fin m) :
     positiveLongRootSubgroup (R := R) i ≫ inclusion R m =
       GeneralLinear.rootSubgroup (R := R)
         (GLSymplecticFin.positiveLongRoot_indices_ne i) := by
-  rw [positiveLongRootSubgroup, inclusion_def, GeneralLinear.rootSubgroup_def]
+  rw [positiveLongRootSubgroup_def, inclusion_def, GeneralLinear.rootSubgroup_def]
   simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
   rw [CommHopfAlgCat.quotientSpecι_def]
   rw [← coordinateMap_def]
@@ -383,7 +409,7 @@ theorem negativeLongRootSubgroup_comp_inclusion (i : Fin m) :
     negativeLongRootSubgroup (R := R) i ≫ inclusion R m =
       GeneralLinear.rootSubgroup (R := R)
         (GLSymplecticFin.negativeLongRoot_indices_ne i) := by
-  rw [negativeLongRootSubgroup, inclusion_def, GeneralLinear.rootSubgroup_def]
+  rw [negativeLongRootSubgroup_def, inclusion_def, GeneralLinear.rootSubgroup_def]
   simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
   rw [CommHopfAlgCat.quotientSpecι_def]
   rw [← coordinateMap_def]

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/RootSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/RootSubgroup.lean
@@ -1,0 +1,400 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- The ambient root subgroups supply the coordinate maps through which the symplectic maps factor.
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.RootSubgroup
+-- The symplectic scheme and its point equivalence identify the target of the root maps.
+public import TauCeti.Algebra.AlgebraicGroup.Symplectic.Basic
+
+/-!
+# Long-root subgroups of the symplectic group
+
+For `i : Fin m`, the elementary matrices
+
+```text
+x_{2eᵢ}(c)  = 1 + c E_{i,m+i},
+x_{-2eᵢ}(c) = 1 + c E_{m+i,i}
+```
+
+preserve the standard alternating form. This file promotes these two one-parameter families to
+affine group-scheme morphisms `𝔾ₐ → Sp₂ₘ` over an arbitrary commutative base ring. They
+are the root subgroups belonging to the positive and negative long roots `±2eᵢ` of type `Cₘ`.
+
+The construction first gives the natural homomorphisms on algebra-valued points using
+`TauCeti.GLSymplecticFin.positiveLongRootTransvectionHom` and its negative analogue. Full
+faithfulness of the functor of points recovers the two coordinate Hopf-algebra morphisms, and
+relative spectrum gives the group-scheme maps. Their composites with the closed immersion
+`Sp₂ₘ → GL₂ₘ` are proved to be the corresponding general-linear root subgroups. Thus the
+factorization through the symplectic equations is recorded scheme-theoretically, over every base.
+
+The short roots `±eᵢ ± eⱼ` require products of two commuting elementary matrices and are not
+constructed here.
+
+## Main definitions
+
+* `TauCeti.Symplectic.positiveLongRootSubgroupPoints` and
+  `TauCeti.Symplectic.negativeLongRootSubgroupPoints`: the homomorphisms on algebra-valued points.
+* `TauCeti.Symplectic.positiveLongRootSubgroupCoordinateMap` and
+  `TauCeti.Symplectic.negativeLongRootSubgroupCoordinateMap`: their coordinate morphisms.
+* `TauCeti.Symplectic.positiveLongRootSubgroup` and
+  `TauCeti.Symplectic.negativeLongRootSubgroup`: the affine group-scheme morphisms.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §21 and §24.6.
+* R. W. Carter, *Simple Groups of Lie Type* (1972), §11.3.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory WithConv
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.Symplectic
+
+universe u w
+
+variable {R : Type u} [CommRing R] {m : ℕ} {i : Fin m}
+
+section Points
+
+variable {A : Type w} [CommRing A] [Algebra R A]
+variable {B : Type w} [CommRing B] [Algebra R B]
+
+/-- The positive long-root homomorphism on `A`-points, sending `c` to
+`1 + c E_{i,m+i}` in `Sp₂ₘ(A)`. -/
+noncomputable def positiveLongRootSubgroupPoints (i : Fin m) :
+    WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A) →*
+      WithConv (coordinateHopfAlgebra R m →ₐ[R] A) :=
+  (pointsMulEquiv (R := R) (A := A) m).symm.toMonoidHom.comp
+    ((GLSymplecticFin.positiveLongRootTransvectionHom i).comp
+      (AdditiveGroup.gaPointsMulEquiv (R := R) (A := A)).toMonoidHom)
+
+/-- The negative long-root homomorphism on `A`-points, sending `c` to
+`1 + c E_{m+i,i}` in `Sp₂ₘ(A)`. -/
+noncomputable def negativeLongRootSubgroupPoints (i : Fin m) :
+    WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A) →*
+      WithConv (coordinateHopfAlgebra R m →ₐ[R] A) :=
+  (pointsMulEquiv (R := R) (A := A) m).symm.toMonoidHom.comp
+    ((GLSymplecticFin.negativeLongRootTransvectionHom i).comp
+      (AdditiveGroup.gaPointsMulEquiv (R := R) (A := A)).toMonoidHom)
+
+/-- Under the symplectic point equivalence, the positive long-root point is its elementary
+transvection. -/
+@[simp]
+theorem pointsMulEquiv_positiveLongRootSubgroupPoints (i : Fin m)
+    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    pointsMulEquiv (R := R) (A := A) m (positiveLongRootSubgroupPoints i f) =
+      GLSymplecticFin.positiveLongRootTransvectionUnit i
+        (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := R) (A := A) f)) := by
+  rw [positiveLongRootSubgroupPoints]
+  simp
+
+/-- Under the symplectic point equivalence, the negative long-root point is its elementary
+transvection. -/
+@[simp]
+theorem pointsMulEquiv_negativeLongRootSubgroupPoints (i : Fin m)
+    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    pointsMulEquiv (R := R) (A := A) m (negativeLongRootSubgroupPoints i f) =
+      GLSymplecticFin.negativeLongRootTransvectionUnit i
+        (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv (R := R) (A := A) f)) := by
+  rw [negativeLongRootSubgroupPoints]
+  simp
+
+/-- The positive long-root subgroup is injective on algebra-valued points. -/
+theorem positiveLongRootSubgroupPoints_injective (i : Fin m) :
+    Function.Injective (positiveLongRootSubgroupPoints (R := R) (A := A) i) := by
+  intro f g h
+  have hSp := congrArg (pointsMulEquiv (R := R) (A := A) m) h
+  rw [pointsMulEquiv_positiveLongRootSubgroupPoints,
+    pointsMulEquiv_positiveLongRootSubgroupPoints] at hSp
+  have hparam := GLSymplecticFin.positiveLongRootTransvectionUnit_injective i hSp
+  apply (AdditiveGroup.gaPointsMulEquiv (R := R) (A := A)).injective
+  exact Multiplicative.toAdd.injective hparam
+
+/-- The negative long-root subgroup is injective on algebra-valued points. -/
+theorem negativeLongRootSubgroupPoints_injective (i : Fin m) :
+    Function.Injective (negativeLongRootSubgroupPoints (R := R) (A := A) i) := by
+  intro f g h
+  have hSp := congrArg (pointsMulEquiv (R := R) (A := A) m) h
+  rw [pointsMulEquiv_negativeLongRootSubgroupPoints,
+    pointsMulEquiv_negativeLongRootSubgroupPoints] at hSp
+  have hparam := GLSymplecticFin.negativeLongRootTransvectionUnit_injective i hSp
+  apply (AdditiveGroup.gaPointsMulEquiv (R := R) (A := A)).injective
+  exact Multiplicative.toAdd.injective hparam
+
+/-- The positive long-root subgroup on points is natural in the value algebra. -/
+theorem mapValue_positiveLongRootSubgroupPoints (phi : A →ₐ[R] B) (i : Fin m)
+    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    AlgHom.mapValue (H := coordinateHopfAlgebra R m) phi
+        (positiveLongRootSubgroupPoints i f) =
+      positiveLongRootSubgroupPoints i
+        (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f) := by
+  apply (pointsMulEquiv (R := R) (A := B) m).injective
+  change pointsMulEquiv (R := R) (A := B) m
+      (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R m)
+        (CommAlgCat.ofHom phi) (positiveLongRootSubgroupPoints i f)) = _
+  rw [pointsMulEquiv_mapValue, pointsMulEquiv_positiveLongRootSubgroupPoints,
+    pointsMulEquiv_positiveLongRootSubgroupPoints,
+    GLSymplecticFin.map_positiveLongRootTransvectionUnit,
+    AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue]
+  rfl
+
+/-- The negative long-root subgroup on points is natural in the value algebra. -/
+theorem mapValue_negativeLongRootSubgroupPoints (phi : A →ₐ[R] B) (i : Fin m)
+    (f : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    AlgHom.mapValue (H := coordinateHopfAlgebra R m) phi
+        (negativeLongRootSubgroupPoints i f) =
+      negativeLongRootSubgroupPoints i
+        (AlgHom.mapValue (H := AdditiveGroup.coordinateHopfAlgebra R) phi f) := by
+  apply (pointsMulEquiv (R := R) (A := B) m).injective
+  change pointsMulEquiv (R := R) (A := B) m
+      (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R m)
+        (CommAlgCat.ofHom phi) (negativeLongRootSubgroupPoints i f)) = _
+  rw [pointsMulEquiv_mapValue, pointsMulEquiv_negativeLongRootSubgroupPoints,
+    pointsMulEquiv_negativeLongRootSubgroupPoints,
+    GLSymplecticFin.map_negativeLongRootTransvectionUnit,
+    AdditiveGroup.toAdd_gaPointsMulEquiv_mapValue]
+  rfl
+
+end Points
+
+section Functor
+
+/-- The natural transformation of group-valued points for the positive long root `2eᵢ`. -/
+@[expose] noncomputable def positiveLongRootSubgroupPointsMap (i : Fin m) :
+    HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
+      HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R m) where
+  app A := GrpCat.ofHom (positiveLongRootSubgroupPoints (A := A) i)
+  naturality _ _ phi := by
+    ext f
+    exact (mapValue_positiveLongRootSubgroupPoints phi.hom i f).symm
+
+/-- The natural transformation of group-valued points for the negative long root `-2eᵢ`. -/
+@[expose] noncomputable def negativeLongRootSubgroupPointsMap (i : Fin m) :
+    HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
+      HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R m) where
+  app A := GrpCat.ofHom (negativeLongRootSubgroupPoints (A := A) i)
+  naturality _ _ phi := by
+    ext f
+    exact (mapValue_negativeLongRootSubgroupPoints phi.hom i f).symm
+
+/-- A component of the positive long-root natural transformation is the corresponding point
+homomorphism. -/
+@[simp]
+theorem positiveLongRootSubgroupPointsMap_app (i : Fin m) (A : CommAlgCat.{w} R) :
+    (positiveLongRootSubgroupPointsMap (R := R) i).app A =
+      GrpCat.ofHom (positiveLongRootSubgroupPoints i) :=
+  rfl
+
+/-- A component of the negative long-root natural transformation is the corresponding point
+homomorphism. -/
+@[simp]
+theorem negativeLongRootSubgroupPointsMap_app (i : Fin m) (A : CommAlgCat.{w} R) :
+    (negativeLongRootSubgroupPointsMap (R := R) i).app A =
+      GrpCat.ofHom (negativeLongRootSubgroupPoints i) :=
+  rfl
+
+end Functor
+
+section Scheme
+
+/-- The coordinate morphism of the positive long-root subgroup, recovered from its natural
+action on points. -/
+noncomputable def positiveLongRootSubgroupCoordinateMap (i : Fin m) :
+    coordinateHopfAlgebra R m ⟶ AdditiveGroup.coordinateHopfAlgebra R :=
+  ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
+      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
+    (positiveLongRootSubgroupPointsMap.{u, u} (R := R) i)).unop
+
+/-- The coordinate morphism of the negative long-root subgroup, recovered from its natural
+action on points. -/
+noncomputable def negativeLongRootSubgroupCoordinateMap (i : Fin m) :
+    coordinateHopfAlgebra R m ⟶ AdditiveGroup.coordinateHopfAlgebra R :=
+  ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
+      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
+    (negativeLongRootSubgroupPointsMap.{u, u} (R := R) i)).unop
+
+/-- Precomposition by the positive long-root coordinate morphism gives its natural point map. -/
+theorem mapPointsFunctor_positiveLongRootSubgroupCoordinateMap (i : Fin m) :
+    (CommHopfAlgCat.mapPointsFunctor.{u, u, u}
+      (positiveLongRootSubgroupCoordinateMap (R := R) i) :
+      HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
+        HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R m)) =
+      positiveLongRootSubgroupPointsMap.{u, u} i := by
+  unfold positiveLongRootSubgroupCoordinateMap
+  rw [← CommHopfAlgCat.pointsFunctor_map]
+  exact Functor.map_preimage
+    (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
+      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+
+/-- Precomposition by the negative long-root coordinate morphism gives its natural point map. -/
+theorem mapPointsFunctor_negativeLongRootSubgroupCoordinateMap (i : Fin m) :
+    (CommHopfAlgCat.mapPointsFunctor.{u, u, u}
+      (negativeLongRootSubgroupCoordinateMap (R := R) i) :
+      HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
+        HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R m)) =
+      negativeLongRootSubgroupPointsMap.{u, u} i := by
+  unfold negativeLongRootSubgroupCoordinateMap
+  rw [← CommHopfAlgCat.pointsFunctor_map]
+  exact Functor.map_preimage
+    (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
+      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+
+/-- On a same-universe algebra, the positive coordinate morphism induces the constructed point
+homomorphism. -/
+@[simp]
+theorem mapPointsFunctor_positiveLongRootSubgroupCoordinateMap_app (i : Fin m)
+    (A : CommAlgCat.{u} R)
+    (f : HopfAlgebra.points (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) A) :
+    (CommHopfAlgCat.mapPointsFunctor
+      (positiveLongRootSubgroupCoordinateMap (R := R) i)).app A f =
+      positiveLongRootSubgroupPoints i f := by
+  rw [mapPointsFunctor_positiveLongRootSubgroupCoordinateMap,
+    positiveLongRootSubgroupPointsMap_app]
+  rfl
+
+/-- On a same-universe algebra, the negative coordinate morphism induces the constructed point
+homomorphism. -/
+@[simp]
+theorem mapPointsFunctor_negativeLongRootSubgroupCoordinateMap_app (i : Fin m)
+    (A : CommAlgCat.{u} R)
+    (f : HopfAlgebra.points (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) A) :
+    (CommHopfAlgCat.mapPointsFunctor
+      (negativeLongRootSubgroupCoordinateMap (R := R) i)).app A f =
+      negativeLongRootSubgroupPoints i f := by
+  rw [mapPointsFunctor_negativeLongRootSubgroupCoordinateMap,
+    negativeLongRootSubgroupPointsMap_app]
+  rfl
+
+/-- The positive long-root coordinate morphism factors the matching general-linear root
+coordinate morphism through the symplectic quotient. -/
+@[simp]
+theorem coordinateMap_comp_positiveLongRootSubgroupCoordinateMap (i : Fin m) :
+    coordinateMap R m ≫ positiveLongRootSubgroupCoordinateMap i =
+      GeneralLinear.rootSubgroupCoordinateMap
+        (GLSymplecticFin.positiveLongRoot_indices_ne i) := by
+  apply Quiver.Hom.op_inj
+  apply (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R)).map_injective
+  rw [op_comp, Functor.map_comp, CommHopfAlgCat.pointsFunctor_map,
+    CommHopfAlgCat.pointsFunctor_map, CommHopfAlgCat.pointsFunctor_map]
+  change CommHopfAlgCat.mapPointsFunctor
+      (positiveLongRootSubgroupCoordinateMap (R := R) i) ≫
+        CommHopfAlgCat.mapPointsFunctor (coordinateMap R m) =
+    CommHopfAlgCat.mapPointsFunctor
+      (GeneralLinear.rootSubgroupCoordinateMap (R := R)
+        (GLSymplecticFin.positiveLongRoot_indices_ne i))
+  rw [mapPointsFunctor_positiveLongRootSubgroupCoordinateMap,
+    GeneralLinear.mapPointsFunctor_rootSubgroupCoordinateMap]
+  ext A f
+  rw [NatTrans.comp_app, positiveLongRootSubgroupPointsMap_app,
+    GeneralLinear.rootSubgroupPointsMap_app]
+  change (CommHopfAlgCat.mapPointsFunctor (coordinateMap R m)).app A
+      (positiveLongRootSubgroupPoints i f) =
+    GeneralLinear.rootSubgroupPoints (GLSymplecticFin.positiveLongRoot_indices_ne i) f
+  rw [mapPointsFunctor_coordinateMap_app]
+  apply (GeneralLinear.pointsMulEquiv (R := R) (A := A) (m + m)).injective
+  rw [pointsMulEquiv_coe]
+  have hSp := pointsMulEquiv_positiveLongRootSubgroupPoints
+    (R := R) (A := A) i f
+  have hGL := GeneralLinear.pointsMulEquiv_rootSubgroupPoints
+    (R := R) (A := A) (GLSymplecticFin.positiveLongRoot_indices_ne i) f
+  rw [hSp, hGL, GLSymplecticFin.coe_positiveLongRootTransvectionUnit]
+
+/-- The negative long-root coordinate morphism factors the matching general-linear root
+coordinate morphism through the symplectic quotient. -/
+@[simp]
+theorem coordinateMap_comp_negativeLongRootSubgroupCoordinateMap (i : Fin m) :
+    coordinateMap R m ≫ negativeLongRootSubgroupCoordinateMap i =
+      GeneralLinear.rootSubgroupCoordinateMap
+        (GLSymplecticFin.negativeLongRoot_indices_ne i) := by
+  apply Quiver.Hom.op_inj
+  apply (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R)).map_injective
+  rw [op_comp, Functor.map_comp, CommHopfAlgCat.pointsFunctor_map,
+    CommHopfAlgCat.pointsFunctor_map, CommHopfAlgCat.pointsFunctor_map]
+  change CommHopfAlgCat.mapPointsFunctor
+      (negativeLongRootSubgroupCoordinateMap (R := R) i) ≫
+        CommHopfAlgCat.mapPointsFunctor (coordinateMap R m) =
+    CommHopfAlgCat.mapPointsFunctor
+      (GeneralLinear.rootSubgroupCoordinateMap (R := R)
+        (GLSymplecticFin.negativeLongRoot_indices_ne i))
+  rw [mapPointsFunctor_negativeLongRootSubgroupCoordinateMap,
+    GeneralLinear.mapPointsFunctor_rootSubgroupCoordinateMap]
+  ext A f
+  rw [NatTrans.comp_app, negativeLongRootSubgroupPointsMap_app,
+    GeneralLinear.rootSubgroupPointsMap_app]
+  change (CommHopfAlgCat.mapPointsFunctor (coordinateMap R m)).app A
+      (negativeLongRootSubgroupPoints i f) =
+    GeneralLinear.rootSubgroupPoints (GLSymplecticFin.negativeLongRoot_indices_ne i) f
+  rw [mapPointsFunctor_coordinateMap_app]
+  apply (GeneralLinear.pointsMulEquiv (R := R) (A := A) (m + m)).injective
+  rw [pointsMulEquiv_coe]
+  have hSp := pointsMulEquiv_negativeLongRootSubgroupPoints
+    (R := R) (A := A) i f
+  have hGL := GeneralLinear.pointsMulEquiv_rootSubgroupPoints
+    (R := R) (A := A) (GLSymplecticFin.negativeLongRoot_indices_ne i) f
+  rw [hSp, hGL, GLSymplecticFin.coe_negativeLongRootTransvectionUnit]
+
+/-- **The positive long-root subgroup of `Sp₂ₘ` attached to `2eᵢ`**, as an affine
+group-scheme morphism. -/
+noncomputable def positiveLongRootSubgroup (i : Fin m) :
+    AdditiveGroup.groupScheme R ⟶ groupScheme R m :=
+  eqToHom (AdditiveGroup.groupScheme_def R) ≫
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+      (positiveLongRootSubgroupCoordinateMap i).op ≫
+    eqToHom (groupScheme_def R m).symm
+
+/-- **The negative long-root subgroup of `Sp₂ₘ` attached to `-2eᵢ`**, as an affine
+group-scheme morphism. -/
+noncomputable def negativeLongRootSubgroup (i : Fin m) :
+    AdditiveGroup.groupScheme R ⟶ groupScheme R m :=
+  eqToHom (AdditiveGroup.groupScheme_def R) ≫
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+      (negativeLongRootSubgroupCoordinateMap i).op ≫
+    eqToHom (groupScheme_def R m).symm
+
+/-- The positive long-root subgroup followed by the symplectic inclusion is the corresponding
+general-linear root subgroup. -/
+@[simp]
+theorem positiveLongRootSubgroup_comp_inclusion (i : Fin m) :
+    positiveLongRootSubgroup (R := R) i ≫ inclusion R m =
+      GeneralLinear.rootSubgroup (R := R)
+        (GLSymplecticFin.positiveLongRoot_indices_ne i) := by
+  rw [positiveLongRootSubgroup, inclusion_def, GeneralLinear.rootSubgroup_def]
+  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+  rw [CommHopfAlgCat.quotientSpecι_def]
+  rw [← coordinateMap_def]
+  rw [← Category.assoc
+    ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+      (positiveLongRootSubgroupCoordinateMap i).op)
+    ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map (coordinateMap R m).op)
+    ((eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom)]
+  rw [← Functor.map_comp, ← op_comp, coordinateMap_comp_positiveLongRootSubgroupCoordinateMap]
+  simp only [eqToIso.hom]
+
+/-- The negative long-root subgroup followed by the symplectic inclusion is the corresponding
+general-linear root subgroup. -/
+@[simp]
+theorem negativeLongRootSubgroup_comp_inclusion (i : Fin m) :
+    negativeLongRootSubgroup (R := R) i ≫ inclusion R m =
+      GeneralLinear.rootSubgroup (R := R)
+        (GLSymplecticFin.negativeLongRoot_indices_ne i) := by
+  rw [negativeLongRootSubgroup, inclusion_def, GeneralLinear.rootSubgroup_def]
+  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+  rw [CommHopfAlgCat.quotientSpecι_def]
+  rw [← coordinateMap_def]
+  rw [← Category.assoc
+    ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+      (negativeLongRootSubgroupCoordinateMap i).op)
+    ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map (coordinateMap R m).op)
+    ((eqToIso (GeneralLinear.groupScheme_def R (m + m)).symm).hom)]
+  rw [← Functor.map_comp, ← op_comp, coordinateMap_comp_negativeLongRootSubgroupCoordinateMap]
+  simp only [eqToIso.hom]
+
+end Scheme
+
+end TauCeti.Symplectic

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic.lean
@@ -329,6 +329,8 @@ def map {S : Type*} [CommRing S] (f : R →+* S) :
   toFun M := ⟨Matrix.GeneralLinearGroup.map f M, by
     have hM := M.2
     rw [mem_iff] at hM ⊢
+    -- Membership stores the same matrix equation through the `GL` and subtype coercions;
+    -- no public lemma exposes all of those wrappers at once.
     change M.1.val.map f * JFin m S * (M.1.val.map f)ᵀ = JFin m S
     simpa only [Matrix.map_mul, Matrix.transpose_map, JFin_map] using
       congrArg (fun X => X.map f) hM⟩
@@ -404,6 +406,8 @@ private theorem lowerLongRoot_mem (i : Fin m) (c : R) :
 def positiveLongRootTransvectionUnit (i : Fin m) (c : R) : GLSymplecticFin m R :=
   ⟨transvectionUnit (positiveLongRoot_indices_ne i) c, by
     rw [GLSymplecticFin, Subgroup.mem_comap]
+    -- Membership in the comap is definitionally membership after `reindexGL`; there is no
+    -- dedicated theorem for this specialized transvection goal.
     change reindexGL m R (transvectionUnit (positiveLongRoot_indices_ne i) c) ∈ _
     rw [reindexGL_transvectionUnit]
     exact upperLongRoot_mem i c⟩
@@ -420,6 +424,8 @@ theorem coe_positiveLongRootTransvectionUnit (i : Fin m) (c : R) :
 def negativeLongRootTransvectionUnit (i : Fin m) (c : R) : GLSymplecticFin m R :=
   ⟨transvectionUnit (negativeLongRoot_indices_ne i) c, by
     rw [GLSymplecticFin, Subgroup.mem_comap]
+    -- Membership in the comap is definitionally membership after `reindexGL`; there is no
+    -- dedicated theorem for this specialized transvection goal.
     change reindexGL m R (transvectionUnit (negativeLongRoot_indices_ne i) c) ∈ _
     rw [reindexGL_transvectionUnit]
     exact lowerLongRoot_mem i c⟩

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic.lean
@@ -14,6 +14,7 @@ public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 -- `Matrix.reindexAlgEquiv` is the body of `TauCeti.reindexGL`, and `finSumFinEquiv` occurs in
 -- the statements of the `Fin`-indexed section.
 public import Mathlib.LinearAlgebra.Matrix.Reindex
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Transvection
 
 /-!
 # The symplectic group as a subgroup of the general linear group
@@ -321,6 +322,175 @@ theorem coe_mulEquivGLSymplectic (M : GLSymplecticFin m R) :
     ((mulEquivGLSymplectic m R M : GLSymplectic (Fin m) R) : GL (Fin m ⊕ Fin m) R) =
       reindexGL m R (M : GL (Fin (m + m)) R) := by
   simp [mulEquivGLSymplectic]
+
+/-- A ring morphism carries `Fin`-indexed symplectic matrices to symplectic matrices. -/
+def map {S : Type*} [CommRing S] (f : R →+* S) :
+    GLSymplecticFin m R →* GLSymplecticFin m S where
+  toFun M := ⟨Matrix.GeneralLinearGroup.map f M, by
+    have hM := M.2
+    rw [mem_iff] at hM ⊢
+    change M.1.val.map f * JFin m S * (M.1.val.map f)ᵀ = JFin m S
+    simpa only [Matrix.map_mul, Matrix.transpose_map, JFin_map] using
+      congrArg (fun X => X.map f) hM⟩
+  map_one' := Subtype.ext (map_one (Matrix.GeneralLinearGroup.map f))
+  map_mul' M N := Subtype.ext (map_mul (Matrix.GeneralLinearGroup.map f) M.1 N.1)
+
+/-- The underlying general-linear element of a mapped symplectic matrix is its entrywise map. -/
+@[simp]
+theorem coe_map {S : Type*} [CommRing S] (f : R →+* S) (M : GLSymplecticFin m R) :
+    ((GLSymplecticFin.map m R f M : GLSymplecticFin m S) : GL (Fin (m + m)) S) =
+      Matrix.GeneralLinearGroup.map f (M : GL (Fin (m + m)) R) :=
+  (rfl)
+
+end GLSymplecticFin
+
+/-! ### Long-root transvections -/
+
+namespace GLSymplecticFin
+
+variable {m R}
+
+/-- The two indices of the positive long root are distinct. -/
+theorem positiveLongRoot_indices_ne (i : Fin m) :
+    finSumFinEquiv (Sum.inl i) ≠ finSumFinEquiv (Sum.inr i) := by
+  exact finSumFinEquiv.injective.ne Sum.inl_ne_inr
+
+/-- The two indices of the negative long root are distinct. -/
+theorem negativeLongRoot_indices_ne (i : Fin m) :
+    finSumFinEquiv (Sum.inr i) ≠ finSumFinEquiv (Sum.inl i) := by
+  exact finSumFinEquiv.injective.ne Sum.inr_ne_inl
+
+private theorem reindexGL_transvectionUnit (i j : Fin m ⊕ Fin m) (hij : i ≠ j) (c : R) :
+    reindexGL m R
+        (transvectionUnit (finSumFinEquiv.injective.ne hij) c) =
+      transvectionUnit hij c := by
+  apply Matrix.GeneralLinearGroup.ext
+  intro a b
+  simp only [coe_reindexGL, coe_transvectionUnit, Matrix.submatrix_apply]
+  simp [Matrix.transvection, Matrix.single, Matrix.one_apply,
+    finSumFinEquiv.injective.eq_iff]
+
+private theorem upperLongRoot_mem (i : Fin m) (c : R) :
+    transvectionUnit (Sum.inl_ne_inr : (Sum.inl i : Fin m ⊕ Fin m) ≠ Sum.inr i) c ∈
+      GLSymplectic (Fin m) R := by
+  rw [GLSymplectic.mem_iff_mem_symplecticGroup]
+  have hmatrix :
+      (transvectionUnit
+          (Sum.inl_ne_inr : (Sum.inl i : Fin m ⊕ Fin m) ≠ Sum.inr i) c :
+        Matrix (Fin m ⊕ Fin m) (Fin m ⊕ Fin m) R) =
+        Matrix.fromBlocks 1 (Matrix.single i i c) 0 1 := by
+    ext a b
+    cases a <;> cases b <;>
+      simp [Matrix.transvection, Matrix.single, Matrix.fromBlocks, Matrix.one_apply]
+  rw [hmatrix, SymplecticGroup.fromBlocks_mem_iff]
+  simp
+
+private theorem lowerLongRoot_mem (i : Fin m) (c : R) :
+    transvectionUnit (Sum.inr_ne_inl : (Sum.inr i : Fin m ⊕ Fin m) ≠ Sum.inl i) c ∈
+      GLSymplectic (Fin m) R := by
+  rw [GLSymplectic.mem_iff_mem_symplecticGroup]
+  have hmatrix :
+      (transvectionUnit
+          (Sum.inr_ne_inl : (Sum.inr i : Fin m ⊕ Fin m) ≠ Sum.inl i) c :
+        Matrix (Fin m ⊕ Fin m) (Fin m ⊕ Fin m) R) =
+        Matrix.fromBlocks 1 0 (Matrix.single i i c) 1 := by
+    ext a b
+    cases a <;> cases b <;>
+      simp [Matrix.transvection, Matrix.single, Matrix.fromBlocks, Matrix.one_apply]
+  rw [hmatrix, SymplecticGroup.fromBlocks_mem_iff]
+  simp
+
+/-- The symplectic matrix `x_{2eᵢ}(c) = 1 + c E_{i,m+i}`, in `Fin (m + m)` coordinates. -/
+def positiveLongRootTransvectionUnit (i : Fin m) (c : R) : GLSymplecticFin m R :=
+  ⟨transvectionUnit (positiveLongRoot_indices_ne i) c, by
+    rw [GLSymplecticFin, Subgroup.mem_comap]
+    change reindexGL m R (transvectionUnit (positiveLongRoot_indices_ne i) c) ∈ _
+    rw [reindexGL_transvectionUnit]
+    exact upperLongRoot_mem i c⟩
+
+/-- The matrix underlying the positive long-root transvection is the corresponding elementary
+transvection. -/
+@[simp]
+theorem coe_positiveLongRootTransvectionUnit (i : Fin m) (c : R) :
+    ((positiveLongRootTransvectionUnit i c : GLSymplecticFin m R) : GL (Fin (m + m)) R) =
+      transvectionUnit (positiveLongRoot_indices_ne i) c :=
+  by rw [positiveLongRootTransvectionUnit]
+
+/-- The symplectic matrix `x_{-2eᵢ}(c) = 1 + c E_{m+i,i}`, in `Fin (m + m)` coordinates. -/
+def negativeLongRootTransvectionUnit (i : Fin m) (c : R) : GLSymplecticFin m R :=
+  ⟨transvectionUnit (negativeLongRoot_indices_ne i) c, by
+    rw [GLSymplecticFin, Subgroup.mem_comap]
+    change reindexGL m R (transvectionUnit (negativeLongRoot_indices_ne i) c) ∈ _
+    rw [reindexGL_transvectionUnit]
+    exact lowerLongRoot_mem i c⟩
+
+/-- The matrix underlying the negative long-root transvection is the corresponding elementary
+transvection. -/
+@[simp]
+theorem coe_negativeLongRootTransvectionUnit (i : Fin m) (c : R) :
+    ((negativeLongRootTransvectionUnit i c : GLSymplecticFin m R) : GL (Fin (m + m)) R) =
+      transvectionUnit (negativeLongRoot_indices_ne i) c :=
+  by rw [negativeLongRootTransvectionUnit]
+
+/-- The positive long-root transvections form a one-parameter subgroup. -/
+def positiveLongRootTransvectionHom (i : Fin m) :
+    Multiplicative R →* GLSymplecticFin m R where
+  toFun c := positiveLongRootTransvectionUnit i (Multiplicative.toAdd c)
+  map_one' := Subtype.ext (transvectionUnit_zero _)
+  map_mul' c d :=
+    Subtype.ext (transvectionUnit_add _ (Multiplicative.toAdd c) (Multiplicative.toAdd d))
+
+/-- The negative long-root transvections form a one-parameter subgroup. -/
+def negativeLongRootTransvectionHom (i : Fin m) :
+    Multiplicative R →* GLSymplecticFin m R where
+  toFun c := negativeLongRootTransvectionUnit i (Multiplicative.toAdd c)
+  map_one' := Subtype.ext (transvectionUnit_zero _)
+  map_mul' c d :=
+    Subtype.ext (transvectionUnit_add _ (Multiplicative.toAdd c) (Multiplicative.toAdd d))
+
+@[simp]
+theorem positiveLongRootTransvectionHom_apply (i : Fin m) (c : Multiplicative R) :
+    positiveLongRootTransvectionHom i c =
+      positiveLongRootTransvectionUnit i (Multiplicative.toAdd c) :=
+  (rfl)
+
+@[simp]
+theorem negativeLongRootTransvectionHom_apply (i : Fin m) (c : Multiplicative R) :
+    negativeLongRootTransvectionHom i c =
+      negativeLongRootTransvectionUnit i (Multiplicative.toAdd c) :=
+  (rfl)
+
+/-- Positive long-root transvections are natural in the coefficient ring. -/
+@[simp]
+theorem map_positiveLongRootTransvectionUnit {S : Type*} [CommRing S]
+    (f : R →+* S) (i : Fin m) (c : R) :
+    GLSymplecticFin.map m R f (positiveLongRootTransvectionUnit i c) =
+      positiveLongRootTransvectionUnit i (f c) := by
+  apply Subtype.ext
+  rw [GLSymplecticFin.coe_map, coe_positiveLongRootTransvectionUnit,
+    coe_positiveLongRootTransvectionUnit, map_transvectionUnit]
+
+/-- Negative long-root transvections are natural in the coefficient ring. -/
+@[simp]
+theorem map_negativeLongRootTransvectionUnit {S : Type*} [CommRing S]
+    (f : R →+* S) (i : Fin m) (c : R) :
+    GLSymplecticFin.map m R f (negativeLongRootTransvectionUnit i c) =
+      negativeLongRootTransvectionUnit i (f c) := by
+  apply Subtype.ext
+  rw [GLSymplecticFin.coe_map, coe_negativeLongRootTransvectionUnit,
+    coe_negativeLongRootTransvectionUnit, map_transvectionUnit]
+
+/-- Distinct parameters give distinct positive long-root transvections. -/
+theorem positiveLongRootTransvectionUnit_injective (i : Fin m) :
+    Function.Injective (positiveLongRootTransvectionUnit (R := R) i) :=
+  fun _ _ h => transvectionUnit_injective (positiveLongRoot_indices_ne i)
+    (congrArg (fun g : GLSymplecticFin m R => (g : GL (Fin (m + m)) R)) h)
+
+/-- Distinct parameters give distinct negative long-root transvections. -/
+theorem negativeLongRootTransvectionUnit_injective (i : Fin m) :
+    Function.Injective (negativeLongRootTransvectionUnit (R := R) i) :=
+  fun _ _ h => transvectionUnit_injective (negativeLongRoot_indices_ne i)
+    (congrArg (fun g : GLSymplecticFin m R => (g : GL (Fin (m + m)) R)) h)
 
 end GLSymplecticFin
 


### PR DESCRIPTION
This PR constructs the positive and negative long-root subgroup schemes `x_{±2eᵢ} : 𝔾ₐ → Sp₂ₘ` over an arbitrary commutative base ring, proves their formulas and injectivity on algebra-valued points, and identifies their composites with `Sp₂ₘ → GL₂ₘ` as the corresponding elementary general-linear root subgroups.

It advances the ReductiveGroups Layer 9 milestone “Root subgroup maps: `x_α : 𝔾ₐ → G` for each root `α`” by supplying the two long-root families in the existing symplectic worked example. This is the most direct currently unclaimed rung toward the explicit pinned Chevalley–Demazure interface: it establishes a scheme-theoretic root map and its ambient factorization, rather than only a matrix-level preservation fact.

The construction reuses Mathlib's elementary transvections and block-matrix characterization of the symplectic group, then uses Tau Ceti's functor-of-points full faithfulness to recover the coordinate Hopf-algebra morphisms.

After this PR, the short-root maps `±eᵢ ± eⱼ`, the Chevalley commutator relations, and the equations relating all root maps to a pinning remain for this milestone.

The targeted symplectic root-subgroup build succeeds, the changed-declaration axiom audit stays within `propext`, `Classical.choice`, and `Quot.sound`, and the changed-module lint environment reports no violations.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"symplectic-long-root-subgroups"}-->

🤖 Prepared with Codex
