### PR TITLE
feat: the discriminant form of an even overlattice is H⊥/H

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -34,6 +34,8 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
   bilinear orthogonal complement.
 * `TauCeti.FiniteQuadraticModule.orthogonalQuotient`: the quadratic module induced on
   `H^⊥ / H` by a quadratic-isotropic subgroup `H`.
+* `TauCeti.FiniteQuadraticModule.orthogonalQuotientCongr`: the canonical isometry between the
+  orthogonal quotients along equal subgroups.
 
 ## References
 
@@ -639,6 +641,25 @@ theorem orthogonalQuotientMk_eq_iff (H : AddSubgroup A) (hH : A.IsIsotropic H)
     (A.restrict (A.toFiniteBilinearModule.orthogonalComplement H))
     (A.subgroupInOrthogonalComplement H)
     (A.subgroupInOrthogonalComplement_le_quadraticRadical hH) x y
+
+/-- Equal quadratic-isotropic subgroups induce the same orthogonal quotient, up to the canonical
+isometry. -/
+noncomputable def orthogonalQuotientCongr {H K : AddSubgroup A} (hH : A.IsIsotropic H)
+    (hK : A.IsIsotropic K) (h : H = K) :
+    Isometry (A.orthogonalQuotient H hH) (A.orthogonalQuotient K hK) := by
+  subst h
+  exact QuadraticMap.IsometryEquiv.refl _
+
+/-- The canonical isometry between the orthogonal quotients along equal subgroups is the identity
+on representatives. -/
+@[simp]
+theorem orthogonalQuotientCongr_orthogonalQuotientMk {H K : AddSubgroup A} (hH : A.IsIsotropic H)
+    (hK : A.IsIsotropic K) (h : H = K)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    A.orthogonalQuotientCongr hH hK h (A.orthogonalQuotientMk H hH x) =
+      A.orthogonalQuotientMk K hK ⟨x.1, h ▸ x.2⟩ := by
+  subst h
+  rfl
 
 /-- If `A` is nondegenerate, the quadratic module induced on `H^⊥ / H` is nondegenerate. -/
 theorem IsNondegenerate.isNondegenerate_orthogonalQuotient (hA : A.IsNondegenerate)

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -107,6 +107,12 @@ namespace Isometry
 
 variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
 
+/-- Applying a composite quadratic isometry applies its two factors in order. -/
+@[simp]
+theorem trans_apply {C : FiniteQuadraticModule} (f : Isometry A B) (g : Isometry B C) (x : A) :
+    (f.trans g) x = g (f x) :=
+  rfl
+
 /-- A quadratic isometry induces an isometry of the canonical polar bilinear modules. -/
 def toFiniteBilinearModule (f : Isometry A B) :
     FiniteBilinearModule.Isometry A.toFiniteBilinearModule B.toFiniteBilinearModule where

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Dual.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Dual.lean
@@ -142,6 +142,18 @@ theorem mem_discriminantSubgroup_dual_iff (M : L.IntermediateCarrier)
 
 variable [L.IsNondegenerate]
 
+/-- The dual carrier of the lattice carried by an integral intermediate carrier is the dual
+intermediate carrier. -/
+theorem IsIntegral.toIntegralLattice_dualCarrier {M : L.IntermediateCarrier} (hM : IsIntegral M) :
+    hM.toIntegralLattice.dualCarrier = (dual M).1 := by
+  rw [coe_dual, IntegralLattice.dualCarrier, hM.toIntegralLattice_form,
+    hM.toIntegralLattice_carrier]
+
+/-- Since `L ≤ M`, the dual carrier of `M` is contained in the dual carrier of `L`. -/
+theorem IsIntegral.dualCarrier_le {M : L.IntermediateCarrier} (hM : IsIntegral M) :
+    hM.toIntegralLattice.dualCarrier ≤ L.dualCarrier := fun _ hx ↦
+  (dual M).2.2 (by rwa [hM.toIntegralLattice_dualCarrier] at hx)
+
 /-- **The dual of an intermediate carrier is the orthogonal complement of its subgroup.** Under
 the correspondence between intermediate carriers and subgroups of the discriminant group, taking
 the dual submodule corresponds to taking the orthogonal complement in the discriminant bilinear

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -333,19 +333,24 @@ theorem discriminantOrthogonalQuotientIsometryOfSubgroup_mk (hL : L.IsEven)
         (L.discriminantQuadraticModule hL).orthogonalQuotientMk H hH
           ⟨hM.isIntegral.dualClassHom y,
             by
-              change hM.isIntegral.dualClassHom y ∈
-                L.discriminantBilinearModule.orthogonalComplement H
-              simpa only [L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup] using
-                hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩ := by
+              have hmem := hM.isIntegral.dualClassHom_mem_orthogonalComplement y
+              rw [L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup] at hmem
+              exact hmem⟩ := by
   dsimp only
   intro y
   let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
   rw [discriminantOrthogonalQuotientIsometryOfSubgroup]
-  change ((L.discriminantQuadraticModule hL).orthogonalQuotientCongr
-      (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
-      (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H))
-        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y)) = _
-  rw [discriminantOrthogonalQuotientIsometry_mk]
+  rw [show
+    ((discriminantOrthogonalQuotientIsometry hL hM).trans
+      ((L.discriminantQuadraticModule hL).orthogonalQuotientCongr
+        (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
+        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)))
+          (Submodule.Quotient.mk y) =
+      (L.discriminantQuadraticModule hL).orthogonalQuotientCongr
+        (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
+        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)
+        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y)) by rfl,
+    discriminantOrthogonalQuotientIsometry_mk]
   exact (L.discriminantQuadraticModule hL).orthogonalQuotientCongr_orthogonalQuotientMk
     (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
     (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -82,25 +82,6 @@ variable {L : IntegralLattice V} [L.IsNondegenerate] {M : L.IntermediateCarrier}
 
 namespace IntermediateCarrier
 
-/-! ## The dual carrier of an overlattice -/
-
-/-- The dual carrier of the lattice carried by an integral intermediate carrier is the dual
-intermediate carrier. -/
-theorem IsIntegral.toIntegralLattice_dualCarrier (hM : IsIntegral M) :
-    hM.toIntegralLattice.dualCarrier = (dual M).1 := by
-  rw [coe_dual, IntegralLattice.dualCarrier, hM.toIntegralLattice_form,
-    hM.toIntegralLattice_carrier]
-
-/-- A vector of `Mᵛ` belongs to the dual intermediate carrier. -/
-theorem IsIntegral.mem_dual_of_mem_dualCarrier (hM : IsIntegral M) {x : V}
-    (hx : x ∈ hM.toIntegralLattice.dualCarrier) : x ∈ (dual M).1 := by
-  rwa [hM.toIntegralLattice_dualCarrier] at hx
-
-/-- Since `L ≤ M`, the dual carrier of `M` is contained in the dual carrier of `L`. -/
-theorem IsIntegral.dualCarrier_le (hM : IsIntegral M) :
-    hM.toIntegralLattice.dualCarrier ≤ L.dualCarrier := fun _ hx ↦
-  (dual M).2.2 (hM.mem_dual_of_mem_dualCarrier hx)
-
 /-- The discriminant class in `A_L` of a vector of `Mᵛ`. -/
 noncomputable def IsIntegral.dualClassHom (hM : IsIntegral M) :
     hM.toIntegralLattice.dualCarrier →ₗ[ℤ] L.DiscriminantGroup :=
@@ -119,10 +100,10 @@ theorem IsIntegral.dualClassHom_mem_orthogonalComplement (hM : IsIntegral M)
       L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M) := by
   rw [← discriminantSubgroup_dual, hM.dualClassHom_apply]
   exact (L.mk_mem_discriminantSubgroup_iff (dual M) _).mpr
-    (hM.mem_dual_of_mem_dualCarrier y.2)
+    (by rw [← hM.toIntegralLattice_dualCarrier]; exact y.2)
 
-/-- **Evenness of an overlattice is quadratic isotropy of its subgroup**, packaged for use as the
-isotropy hypothesis of the orthogonal quotient. -/
+/-- Evenness of an overlattice implies quadratic isotropy of its discriminant subgroup, packaged
+for use as the isotropy hypothesis of the orthogonal quotient. -/
 theorem IsEven.isIsotropic_discriminantSubgroup (hL : L.IsEven) (hM : IsEven M) :
     (L.discriminantQuadraticModule hL).IsIsotropic (L.discriminantSubgroup M) :=
   (isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM
@@ -286,6 +267,7 @@ theorem discriminantOrthogonalQuotientIsometry_apply
 
 /-- **The representative formula.** The comparison isometry sends the class in `A_M` of a dual
 vector of `M` to the class in `H⊥ / H` of its discriminant class in `A_L`. -/
+@[simp]
 theorem discriminantOrthogonalQuotientIsometry_mk
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y) =
@@ -328,27 +310,59 @@ quadratic-isotropic subgroup `H` of the discriminant group of an even nondegener
 This is the form in which the ADE glue calculations use the comparison isometry. -/
 noncomputable def discriminantOrthogonalQuotientIsometryOfSubgroup (hL : L.IsEven)
     {H : AddSubgroup L.DiscriminantGroup}
-    (hM : IntermediateCarrier.IsEven (L.intermediateCarrierOfDiscriminantSubgroup H)) :
+    (hH : (L.discriminantQuadraticModule hL).IsIsotropic H) :
+    let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
     FiniteQuadraticModule.Isometry
       (hM.isIntegral.toIntegralLattice.discriminantQuadraticModule
         hM.isEven_toIntegralLattice)
-      ((L.discriminantQuadraticModule hL).orthogonalQuotient H
-        ((L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mp hM)) :=
-  (discriminantOrthogonalQuotientIsometry hL hM).trans
+      ((L.discriminantQuadraticModule hL).orthogonalQuotient H hH) := by
+  let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
+  exact (discriminantOrthogonalQuotientIsometry hL hM).trans
     ((L.discriminantQuadraticModule hL).orthogonalQuotientCongr
-      (IsEven.isIsotropic_discriminantSubgroup hL hM)
-      ((L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mp hM)
+      (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
       (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H))
+
+/-- The subgroup-level comparison isometry sends a representative to its discriminant class in
+`H⊥ / H`. -/
+@[simp]
+theorem discriminantOrthogonalQuotientIsometryOfSubgroup_mk (hL : L.IsEven)
+    {H : AddSubgroup L.DiscriminantGroup}
+    (hH : (L.discriminantQuadraticModule hL).IsIsotropic H) :
+    let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
+    ∀ y : hM.isIntegral.toIntegralLattice.dualCarrier,
+      L.discriminantOrthogonalQuotientIsometryOfSubgroup hL hH (Submodule.Quotient.mk y) =
+        (L.discriminantQuadraticModule hL).orthogonalQuotientMk H hH
+          ⟨hM.isIntegral.dualClassHom y,
+            by
+              change hM.isIntegral.dualClassHom y ∈
+                L.discriminantBilinearModule.orthogonalComplement H
+              simpa only [L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup] using
+                hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩ := by
+  dsimp only
+  intro y
+  let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
+  rw [discriminantOrthogonalQuotientIsometryOfSubgroup]
+  change ((L.discriminantQuadraticModule hL).orthogonalQuotientCongr
+      (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
+      (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H))
+        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y)) = _
+  rw [discriminantOrthogonalQuotientIsometry_mk]
+  exact (L.discriminantQuadraticModule hL).orthogonalQuotientCongr_orthogonalQuotientMk
+    (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
+    (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)
+    ⟨hM.isIntegral.dualClassHom y,
+      hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩
 
 /-- **The order of `H⊥ / H` is the discriminant of the overlattice glued along `H`.** -/
 theorem natCard_orthogonalQuotient_of_subgroup (hL : L.IsEven)
     {H : AddSubgroup L.DiscriminantGroup}
-    (hM : IntermediateCarrier.IsEven (L.intermediateCarrierOfDiscriminantSubgroup H)) :
-    Nat.card ((L.discriminantQuadraticModule hL).orthogonalQuotient H
-        ((L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mp hM)) =
-      hM.isIntegral.toIntegralLattice.discriminant :=
-  (Nat.card_congr (L.discriminantOrthogonalQuotientIsometryOfSubgroup hL
-      hM).toLinearEquiv.toEquiv).symm.trans
+    (hH : (L.discriminantQuadraticModule hL).IsIsotropic H) :
+    let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
+    Nat.card ((L.discriminantQuadraticModule hL).orthogonalQuotient H hH) =
+      hM.isIntegral.toIntegralLattice.discriminant := by
+  let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
+  exact (Nat.card_congr (L.discriminantOrthogonalQuotientIsometryOfSubgroup hL
+      hH).toLinearEquiv.toEquiv).symm.trans
     hM.isIntegral.toIntegralLattice.natCard_discriminantGroup
 
 end IntegralLattice

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
 public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual
-public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Index
+public import TauCeti.LinearAlgebra.IntegralLattice.Unimodular
 
 /-!
 # The discriminant form of an even overlattice
@@ -108,7 +108,7 @@ variable (hL : L.IsEven) (hM : IsEven M)
 
 /-- The homomorphism `Mᵛ → H⊥ / H` sending a dual vector of `M` to the class of its discriminant
 class in `A_L`. -/
-noncomputable def dualCarrierToOrthogonalQuotient :
+private noncomputable def dualCarrierToOrthogonalQuotient :
     hM.isIntegral.toIntegralLattice.dualCarrier →+
       (L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
         ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM) :=
@@ -119,8 +119,7 @@ noncomputable def dualCarrierToOrthogonalQuotient :
       hM.isIntegral.dualClassHom_mem_orthogonalComplement)
 
 /-- The homomorphism `Mᵛ → H⊥ / H` unfolded on a vector of `Mᵛ`. -/
-@[simp]
-theorem dualCarrierToOrthogonalQuotient_apply
+private theorem dualCarrierToOrthogonalQuotient_apply
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     dualCarrierToOrthogonalQuotient hL hM y =
       (L.discriminantQuadraticModule hL).orthogonalQuotientMk _
@@ -129,7 +128,7 @@ theorem dualCarrierToOrthogonalQuotient_apply
           hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩ := (rfl)
 
 /-- A dual vector of `M` has trivial class in `H⊥ / H` exactly when it already lies in `M`. -/
-theorem dualCarrierToOrthogonalQuotient_eq_zero_iff
+private theorem dualCarrierToOrthogonalQuotient_eq_zero_iff
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     dualCarrierToOrthogonalQuotient hL hM y = 0 ↔ (y : V) ∈ M.1 :=
   ((L.discriminantQuadraticModule hL).orthogonalQuotientMk_eq_zero_iff
@@ -139,7 +138,7 @@ theorem dualCarrierToOrthogonalQuotient_eq_zero_iff
     (L.mk_mem_discriminantSubgroup_iff M _)
 
 /-- The induced homomorphism `A_M → H⊥ / H` on the discriminant group of the overlattice. -/
-noncomputable def discriminantOrthogonalQuotientHom :
+private noncomputable def discriminantOrthogonalQuotientHom :
     hM.isIntegral.toIntegralLattice.DiscriminantGroup →ₗ[ℤ]
       (L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
         ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM) :=
@@ -151,15 +150,14 @@ noncomputable def discriminantOrthogonalQuotientHom :
     exact (hM.isIntegral.toIntegralLattice.mem_carrierInDual_iff y).mp hy)
 
 /-- The induced homomorphism on `A_M` is computed by its representative homomorphism. -/
-@[simp]
-theorem discriminantOrthogonalQuotientHom_mk
+private theorem discriminantOrthogonalQuotientHom_mk
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     discriminantOrthogonalQuotientHom hL hM (Submodule.Quotient.mk y) =
       dualCarrierToOrthogonalQuotient hL hM y := (rfl)
 
 /-- A vector of `Mᵛ` whose discriminant class lies in `H` already lies in `M`, so the induced
 homomorphism is injective. -/
-theorem discriminantOrthogonalQuotientHom_injective :
+private theorem discriminantOrthogonalQuotientHom_injective :
     Function.Injective (discriminantOrthogonalQuotientHom hL hM) := by
   refine (injective_iff_map_eq_zero _).mpr fun a ha ↦ ?_
   induction a using Submodule.Quotient.induction_on with
@@ -172,7 +170,7 @@ theorem discriminantOrthogonalQuotientHom_injective :
 
 /-- Every class of `H⊥` is the discriminant class of a vector of `Mᵛ`, so the induced
 homomorphism is surjective. -/
-theorem discriminantOrthogonalQuotientHom_surjective :
+private theorem discriminantOrthogonalQuotientHom_surjective :
     Function.Surjective (discriminantOrthogonalQuotientHom hL hM) := by
   intro q
   obtain ⟨z, rfl⟩ := (L.discriminantQuadraticModule hL).orthogonalQuotientMk_surjective
@@ -191,7 +189,7 @@ theorem discriminantOrthogonalQuotientHom_surjective :
 
 /-- The quadratic value in `H⊥ / H` of the class of a dual vector of `M` is the ambient
 half-norm. -/
-theorem quadratic_dualCarrierToOrthogonalQuotient
+private theorem quadratic_dualCarrierToOrthogonalQuotient
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
         ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).quadratic
@@ -203,24 +201,6 @@ theorem quadratic_dualCarrierToOrthogonalQuotient
         hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans
     ((L.discriminantQuadraticModule_quadratic hL _).trans
       (L.discriminantQuadraticMap_mk hL ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩))
-
-/-- The pairing in `H⊥ / H` of the classes of two dual vectors of `M` is the ambient form
-modulo `ℤ`. -/
-theorem pairing_dualCarrierToOrthogonalQuotient
-    (y z : hM.isIntegral.toIntegralLattice.dualCarrier) :
-    ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
-        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).toFiniteBilinearModule.pairing
-        (dualCarrierToOrthogonalQuotient hL hM y) (dualCarrierToOrthogonalQuotient hL hM z) =
-      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) :=
-  ((L.discriminantQuadraticModule hL).orthogonalQuotient_pairing_mk
-      (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
-      ⟨hM.isIntegral.dualClassHom y,
-        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩
-      ⟨hM.isIntegral.dualClassHom z,
-        hM.isIntegral.dualClassHom_mem_orthogonalComplement z⟩).trans
-    ((L.discriminantBilinearModule_pairing _ _).trans
-      (L.discriminantPairing_mk ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩
-        ⟨(z : V), hM.isIntegral.dualCarrier_le z.2⟩))
 
 /-- The quadratic value in `A_M` of the class of a dual vector of `M` is the ambient
 half-norm. -/
@@ -253,15 +233,9 @@ noncomputable def discriminantOrthogonalQuotientIsometry :
       exact (quadratic_dualCarrierToOrthogonalQuotient hL hM y).trans
         (quadratic_discriminantQuadraticModule_toIntegralLattice_mk hM y).symm
 
-/-- The comparison isometry acts through its underlying homomorphism. -/
-@[simp]
-theorem discriminantOrthogonalQuotientIsometry_apply
-    (a : hM.isIntegral.toIntegralLattice.DiscriminantGroup) :
-    discriminantOrthogonalQuotientIsometry hL hM a =
-      discriminantOrthogonalQuotientHom hL hM a := (rfl)
-
 /-- **The representative formula.** The comparison isometry sends the class in `A_M` of a dual
 vector of `M` to the class in `H⊥ / H` of its discriminant class in `A_L`. -/
+@[simp]
 theorem discriminantOrthogonalQuotientIsometry_mk
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y) =
@@ -269,6 +243,35 @@ theorem discriminantOrthogonalQuotientIsometry_mk
         ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
         ⟨hM.isIntegral.dualClassHom y,
           hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩ := (rfl)
+
+/-- The quadratic value in `H⊥ / H` of the image of the class of a dual vector of `M` is the
+ambient half-norm. -/
+theorem quadratic_discriminantOrthogonalQuotientIsometry_mk
+    (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).quadratic
+        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y)) =
+      ((L.form y y / 2 : ℚ) : AddCircle (1 : ℚ)) :=
+  quadratic_dualCarrierToOrthogonalQuotient hL hM y
+
+/-- The pairing in `H⊥ / H` of the images of the classes of two dual vectors of `M` is the
+ambient form modulo `ℤ`. -/
+theorem pairing_discriminantOrthogonalQuotientIsometry_mk
+    (y z : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).toFiniteBilinearModule.pairing
+        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y))
+        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk z)) =
+      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) :=
+  ((L.discriminantQuadraticModule hL).orthogonalQuotient_pairing_mk
+      (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
+      ⟨hM.isIntegral.dualClassHom y,
+        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩
+      ⟨hM.isIntegral.dualClassHom z,
+        hM.isIntegral.dualClassHom_mem_orthogonalComplement z⟩).trans
+    ((L.discriminantBilinearModule_pairing _ _).trans
+      (L.discriminantPairing_mk ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩
+        ⟨(z : V), hM.isIntegral.dualCarrier_le z.2⟩))
 
 /-! ## Numerical consequences -/
 
@@ -335,18 +338,8 @@ theorem discriminantOrthogonalQuotientIsometryOfSubgroup_mk (hL : L.IsEven)
   intro y
   let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
   rw [discriminantOrthogonalQuotientIsometryOfSubgroup]
-  rw [show
-    ((discriminantOrthogonalQuotientIsometry hL hM).trans
-      ((L.discriminantQuadraticModule hL).orthogonalQuotientCongr
-        ((isEven_iff_isIsotropic_discriminantSubgroup hL _).mp hM) hH
-        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)))
-          (Submodule.Quotient.mk y) =
-      (L.discriminantQuadraticModule hL).orthogonalQuotientCongr
-        ((isEven_iff_isIsotropic_discriminantSubgroup hL _).mp hM) hH
-        (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)
-        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y)) by
-      apply FiniteQuadraticModule.Isometry.trans_apply,
-    discriminantOrthogonalQuotientIsometry_mk]
+  refine (FiniteQuadraticModule.Isometry.trans_apply _ _ _).trans ?_
+  rw [discriminantOrthogonalQuotientIsometry_mk]
   exact (L.discriminantQuadraticModule hL).orthogonalQuotientCongr_orthogonalQuotientMk
     ((isEven_iff_isIsotropic_discriminantSubgroup hL _).mp hM) hH
     (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -102,12 +102,6 @@ theorem IsIntegral.dualClassHom_mem_orthogonalComplement (hM : IsIntegral M)
   exact (L.mk_mem_discriminantSubgroup_iff (dual M) _).mpr
     (by rw [← hM.toIntegralLattice_dualCarrier]; exact y.2)
 
-/-- Evenness of an overlattice implies quadratic isotropy of its discriminant subgroup, packaged
-for use as the isotropy hypothesis of the orthogonal quotient. -/
-theorem IsEven.isIsotropic_discriminantSubgroup (hL : L.IsEven) (hM : IsEven M) :
-    (L.discriminantQuadraticModule hL).IsIsotropic (L.discriminantSubgroup M) :=
-  (isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM
-
 /-! ## The comparison isometry -/
 
 variable (hL : L.IsEven) (hM : IsEven M)
@@ -117,19 +111,20 @@ class in `A_L`. -/
 noncomputable def dualCarrierToOrthogonalQuotient :
     hM.isIntegral.toIntegralLattice.dualCarrier →+
       (L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
-        (IsEven.isIsotropic_discriminantSubgroup hL hM) :=
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM) :=
   ((L.discriminantQuadraticModule hL).orthogonalQuotientMk _
-      (IsEven.isIsotropic_discriminantSubgroup hL hM)).comp
+      ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).comp
     (AddMonoidHom.codRestrict hM.isIntegral.dualClassHom.toAddMonoidHom
       (L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M))
       hM.isIntegral.dualClassHom_mem_orthogonalComplement)
 
 /-- The homomorphism `Mᵛ → H⊥ / H` unfolded on a vector of `Mᵛ`. -/
+@[simp]
 theorem dualCarrierToOrthogonalQuotient_apply
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     dualCarrierToOrthogonalQuotient hL hM y =
       (L.discriminantQuadraticModule hL).orthogonalQuotientMk _
-        (IsEven.isIsotropic_discriminantSubgroup hL hM)
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
         ⟨hM.isIntegral.dualClassHom y,
           hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩ := (rfl)
 
@@ -138,7 +133,7 @@ theorem dualCarrierToOrthogonalQuotient_eq_zero_iff
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     dualCarrierToOrthogonalQuotient hL hM y = 0 ↔ (y : V) ∈ M.1 :=
   ((L.discriminantQuadraticModule hL).orthogonalQuotientMk_eq_zero_iff
-      (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM)
+      (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
       ⟨hM.isIntegral.dualClassHom y,
         hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans
     (L.mk_mem_discriminantSubgroup_iff M _)
@@ -147,7 +142,7 @@ theorem dualCarrierToOrthogonalQuotient_eq_zero_iff
 noncomputable def discriminantOrthogonalQuotientHom :
     hM.isIntegral.toIntegralLattice.DiscriminantGroup →ₗ[ℤ]
       (L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
-        (IsEven.isIsotropic_discriminantSubgroup hL hM) :=
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM) :=
   Submodule.liftQ _ (dualCarrierToOrthogonalQuotient hL hM).toIntLinearMap (by
     intro y hy
     rw [LinearMap.mem_ker]
@@ -181,7 +176,7 @@ theorem discriminantOrthogonalQuotientHom_surjective :
     Function.Surjective (discriminantOrthogonalQuotientHom hL hM) := by
   intro q
   obtain ⟨z, rfl⟩ := (L.discriminantQuadraticModule hL).orthogonalQuotientMk_surjective
-    (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM) q
+    (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM) q
   obtain ⟨x, hx⟩ := Submodule.Quotient.mk_surjective L.carrierInDual z.1
   have hxdual : (x : V) ∈ (dual M).1 := by
     refine (L.mk_mem_discriminantSubgroup_iff (dual M) x).mp ?_
@@ -199,11 +194,11 @@ half-norm. -/
 theorem quadratic_dualCarrierToOrthogonalQuotient
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
-        (IsEven.isIsotropic_discriminantSubgroup hL hM)).quadratic
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).quadratic
         (dualCarrierToOrthogonalQuotient hL hM y) =
       ((L.form y y / 2 : ℚ) : AddCircle (1 : ℚ)) :=
   ((L.discriminantQuadraticModule hL).orthogonalQuotient_quadratic_mk
-      (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM)
+      (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
       ⟨hM.isIntegral.dualClassHom y,
         hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans
     ((L.discriminantQuadraticModule_quadratic hL _).trans
@@ -214,11 +209,11 @@ modulo `ℤ`. -/
 theorem pairing_dualCarrierToOrthogonalQuotient
     (y z : hM.isIntegral.toIntegralLattice.dualCarrier) :
     ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
-        (IsEven.isIsotropic_discriminantSubgroup hL hM)).toFiniteBilinearModule.pairing
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)).toFiniteBilinearModule.pairing
         (dualCarrierToOrthogonalQuotient hL hM y) (dualCarrierToOrthogonalQuotient hL hM z) =
       ((L.form y z : ℚ) : AddCircle (1 : ℚ)) :=
   ((L.discriminantQuadraticModule hL).orthogonalQuotient_pairing_mk
-      (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM)
+      (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
       ⟨hM.isIntegral.dualClassHom y,
         hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩
       ⟨hM.isIntegral.dualClassHom z,
@@ -247,7 +242,7 @@ noncomputable def discriminantOrthogonalQuotientIsometry :
       (hM.isIntegral.toIntegralLattice.discriminantQuadraticModule
         hM.isEven_toIntegralLattice)
       ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
-        (IsEven.isIsotropic_discriminantSubgroup hL hM)) where
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)) where
   toLinearEquiv :=
     LinearEquiv.ofBijective (discriminantOrthogonalQuotientHom hL hM)
       ⟨discriminantOrthogonalQuotientHom_injective hL hM,
@@ -271,7 +266,7 @@ theorem discriminantOrthogonalQuotientIsometry_mk
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y) =
       (L.discriminantQuadraticModule hL).orthogonalQuotientMk _
-        (IsEven.isIsotropic_discriminantSubgroup hL hM)
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)
         ⟨hM.isIntegral.dualClassHom y,
           hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩ := (rfl)
 
@@ -280,7 +275,7 @@ theorem discriminantOrthogonalQuotientIsometry_mk
 /-- **The order of `H⊥ / H` is the discriminant of the overlattice.** -/
 theorem natCard_orthogonalQuotient :
     Nat.card ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
-        (IsEven.isIsotropic_discriminantSubgroup hL hM)) =
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)) =
       hM.isIntegral.toIntegralLattice.discriminant :=
   (Nat.card_congr
       (discriminantOrthogonalQuotientIsometry hL hM).toLinearEquiv.toEquiv).symm.trans
@@ -289,7 +284,7 @@ theorem natCard_orthogonalQuotient :
 /-- **An even overlattice is unimodular exactly when `H⊥ / H` is trivial.** -/
 theorem subsingleton_orthogonalQuotient_iff_isUnimodular :
     Subsingleton ((L.discriminantQuadraticModule hL).orthogonalQuotient
-        (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM)) ↔
+        (L.discriminantSubgroup M) ((isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM)) ↔
       hM.isIntegral.toIntegralLattice.IsUnimodular := by
   rw [hM.isIntegral.toIntegralLattice.isUnimodular_iff_subsingleton_discriminantGroup]
   exact Equiv.subsingleton_congr
@@ -318,7 +313,7 @@ noncomputable def discriminantOrthogonalQuotientIsometryOfSubgroup (hL : L.IsEve
   let hM := (L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mpr hH
   exact (discriminantOrthogonalQuotientIsometry hL hM).trans
     ((L.discriminantQuadraticModule hL).orthogonalQuotientCongr
-      (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
+      ((isEven_iff_isIsotropic_discriminantSubgroup hL _).mp hM) hH
       (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H))
 
 /-- The subgroup-level comparison isometry sends a representative to its discriminant class in
@@ -343,16 +338,17 @@ theorem discriminantOrthogonalQuotientIsometryOfSubgroup_mk (hL : L.IsEven)
   rw [show
     ((discriminantOrthogonalQuotientIsometry hL hM).trans
       ((L.discriminantQuadraticModule hL).orthogonalQuotientCongr
-        (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL _).mp hM) hH
         (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)))
           (Submodule.Quotient.mk y) =
       (L.discriminantQuadraticModule hL).orthogonalQuotientCongr
-        (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL _).mp hM) hH
         (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)
-        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y)) by rfl,
+        (discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y)) by
+      apply FiniteQuadraticModule.Isometry.trans_apply,
     discriminantOrthogonalQuotientIsometry_mk]
   exact (L.discriminantQuadraticModule hL).orthogonalQuotientCongr_orthogonalQuotientMk
-    (IsEven.isIsotropic_discriminantSubgroup hL hM) hH
+    ((isEven_iff_isIsotropic_discriminantSubgroup hL _).mp hM) hH
     (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H)
     ⟨hM.isIntegral.dualClassHom y,
       hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Index
+
+/-!
+# The discriminant form of an even overlattice
+
+Let `L` be an even nondegenerate integral lattice and let `L ≤ M ≤ Lᵛ` be an even intermediate
+carrier, that is an even overlattice of `L` inside the common rational ambient space. The
+correspondence of `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Isotropic` attaches to `M`
+the subgroup `H = M / L` of the discriminant group `A_L = Lᵛ / L`, and evenness of `M` is exactly
+isotropy of `H` for the discriminant quadratic form. This file computes the discriminant quadratic
+module of `M` itself:
+
+```text
+A_M ≅ H⊥ / H,   H = M / L ≤ A_L.
+```
+
+This is the last step of Nikulin's gluing recipe, and it is what identifies the discriminant form
+of a glued lattice without recomputing a dual lattice from scratch. The proof is the composite
+
+```text
+Mᵛ ↪ Lᵛ ↠ A_L,
+```
+
+which lands in `H⊥` because the dual of an intermediate carrier corresponds to the orthogonal
+complement of its subgroup, is surjective onto `H⊥` for the same reason, and whose fibre over `H`
+is exactly `M`. The composite therefore descends to an additive bijection `A_M ≃ H⊥ / H`, and it
+preserves the half-norm quadratic form because both sides are represented by `B(x, x) / 2` modulo
+`ℤ` at the same ambient vector `x`.
+
+Two consequences are recorded. The order of `H⊥ / H` is the discriminant of `M`, and `M` is
+unimodular exactly when `H⊥ / H` is trivial — the quotient-side reading of the Lagrangian
+criterion of `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual`. The isometry is also
+restated for the overlattice `L_H` glued along a quadratic-isotropic subgroup `H ≤ A_L`, which is
+the form in which the ADE glue calculations use it.
+
+Two things are deliberately left out. The bilinear analogue for a merely integral overlattice of
+an odd lattice needs the orthogonal quotient of a finite *bilinear* module, which the library does
+not yet have. And naturality of the comparison isometry under a lattice isometry needs the induced
+map of orthogonal quotients, which is likewise still missing from the finite-quadratic-module
+layer.
+
+## Main declarations
+
+* `TauCeti.IntegralLattice.IntermediateCarrier.discriminantOrthogonalQuotientIsometry`: the
+  isometry `A_M ≅ H⊥ / H` of finite quadratic modules.
+* `TauCeti.IntegralLattice.IntermediateCarrier.discriminantOrthogonalQuotientIsometry_mk`: its
+  value on the class of a vector of `Mᵛ`.
+* `TauCeti.IntegralLattice.IntermediateCarrier.natCard_orthogonalQuotient`: the order of
+  `H⊥ / H` is the discriminant of `M`.
+* `TauCeti.IntegralLattice.IntermediateCarrier.subsingleton_orthogonalQuotient_iff_isUnimodular`:
+  `M` is unimodular exactly when `H⊥ / H` is trivial.
+* `TauCeti.IntegralLattice.discriminantOrthogonalQuotientIsometryOfSubgroup`: the same isometry
+  read as `A_(L_H) ≅ H⊥ / H` for a quadratic-isotropic subgroup `H` of `A_L`.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.4,
+  Proposition 1.4.1, stated there in the full-norm `ℚ/2ℤ` convention.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+* `TauCetiRoadmap/IntegralLattices/README.md`, Layer 4.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+namespace IntegralLattice
+
+variable {V : Type u} [AddCommGroup V] [Module ℚ V]
+variable {L : IntegralLattice V} [L.IsNondegenerate] {M : L.IntermediateCarrier}
+
+namespace IntermediateCarrier
+
+/-! ## The dual carrier of an overlattice -/
+
+/-- The dual carrier of the lattice carried by an integral intermediate carrier is the dual
+intermediate carrier. -/
+theorem IsIntegral.toIntegralLattice_dualCarrier (hM : IsIntegral M) :
+    hM.toIntegralLattice.dualCarrier = (dual M).1 := by
+  rw [coe_dual, IntegralLattice.dualCarrier, hM.toIntegralLattice_form,
+    hM.toIntegralLattice_carrier]
+
+/-- A vector of `Mᵛ` belongs to the dual intermediate carrier. -/
+theorem IsIntegral.mem_dual_of_mem_dualCarrier (hM : IsIntegral M) {x : V}
+    (hx : x ∈ hM.toIntegralLattice.dualCarrier) : x ∈ (dual M).1 := by
+  rwa [hM.toIntegralLattice_dualCarrier] at hx
+
+/-- Since `L ≤ M`, the dual carrier of `M` is contained in the dual carrier of `L`. -/
+theorem IsIntegral.dualCarrier_le (hM : IsIntegral M) :
+    hM.toIntegralLattice.dualCarrier ≤ L.dualCarrier := fun _ hx ↦
+  (dual M).2.2 (hM.mem_dual_of_mem_dualCarrier hx)
+
+/-- The discriminant class in `A_L` of a vector of `Mᵛ`. -/
+noncomputable def IsIntegral.dualClassHom (hM : IsIntegral M) :
+    hM.toIntegralLattice.dualCarrier →ₗ[ℤ] L.DiscriminantGroup :=
+  L.carrierInDual.mkQ.comp (Submodule.inclusion hM.dualCarrier_le)
+
+@[simp]
+theorem IsIntegral.dualClassHom_apply (hM : IsIntegral M)
+    (y : hM.toIntegralLattice.dualCarrier) :
+    hM.dualClassHom y = Submodule.Quotient.mk ⟨(y : V), hM.dualCarrier_le y.2⟩ := (rfl)
+
+/-- The discriminant class of a vector of `Mᵛ` is orthogonal to `H = M / L`, because the dual
+of an intermediate carrier corresponds to the orthogonal complement of its subgroup. -/
+theorem IsIntegral.dualClassHom_mem_orthogonalComplement (hM : IsIntegral M)
+    (y : hM.toIntegralLattice.dualCarrier) :
+    hM.dualClassHom y ∈
+      L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M) := by
+  rw [← discriminantSubgroup_dual, hM.dualClassHom_apply]
+  exact (L.mk_mem_discriminantSubgroup_iff (dual M) _).mpr
+    (hM.mem_dual_of_mem_dualCarrier y.2)
+
+/-- **Evenness of an overlattice is quadratic isotropy of its subgroup**, packaged for use as the
+isotropy hypothesis of the orthogonal quotient. -/
+theorem IsEven.isIsotropic_discriminantSubgroup (hL : L.IsEven) (hM : IsEven M) :
+    (L.discriminantQuadraticModule hL).IsIsotropic (L.discriminantSubgroup M) :=
+  (isEven_iff_isIsotropic_discriminantSubgroup hL M).mp hM
+
+/-! ## The comparison isometry -/
+
+variable (hL : L.IsEven) (hM : IsEven M)
+
+/-- The homomorphism `Mᵛ → H⊥ / H` sending a dual vector of `M` to the class of its discriminant
+class in `A_L`. -/
+noncomputable def dualCarrierToOrthogonalQuotient :
+    hM.isIntegral.toIntegralLattice.dualCarrier →+
+      (L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
+        (IsEven.isIsotropic_discriminantSubgroup hL hM) :=
+  ((L.discriminantQuadraticModule hL).orthogonalQuotientMk _
+      (IsEven.isIsotropic_discriminantSubgroup hL hM)).comp
+    (AddMonoidHom.codRestrict hM.isIntegral.dualClassHom.toAddMonoidHom
+      (L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup M))
+      hM.isIntegral.dualClassHom_mem_orthogonalComplement)
+
+/-- The homomorphism `Mᵛ → H⊥ / H` unfolded on a vector of `Mᵛ`. -/
+theorem dualCarrierToOrthogonalQuotient_apply
+    (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    dualCarrierToOrthogonalQuotient hL hM y =
+      (L.discriminantQuadraticModule hL).orthogonalQuotientMk _
+        (IsEven.isIsotropic_discriminantSubgroup hL hM)
+        ⟨hM.isIntegral.dualClassHom y,
+          hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩ := (rfl)
+
+/-- A dual vector of `M` has trivial class in `H⊥ / H` exactly when it already lies in `M`. -/
+theorem dualCarrierToOrthogonalQuotient_eq_zero_iff
+    (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    dualCarrierToOrthogonalQuotient hL hM y = 0 ↔ (y : V) ∈ M.1 :=
+  ((L.discriminantQuadraticModule hL).orthogonalQuotientMk_eq_zero_iff
+      (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM)
+      ⟨hM.isIntegral.dualClassHom y,
+        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans
+    (L.mk_mem_discriminantSubgroup_iff M _)
+
+/-- The induced homomorphism `A_M → H⊥ / H` on the discriminant group of the overlattice. -/
+noncomputable def discriminantOrthogonalQuotientHom :
+    hM.isIntegral.toIntegralLattice.DiscriminantGroup →ₗ[ℤ]
+      (L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
+        (IsEven.isIsotropic_discriminantSubgroup hL hM) :=
+  Submodule.liftQ _ (dualCarrierToOrthogonalQuotient hL hM).toIntLinearMap (by
+    intro y hy
+    rw [LinearMap.mem_ker]
+    refine (dualCarrierToOrthogonalQuotient_eq_zero_iff hL hM y).mpr ?_
+    rw [← hM.isIntegral.toIntegralLattice_carrier]
+    exact (hM.isIntegral.toIntegralLattice.mem_carrierInDual_iff y).mp hy)
+
+/-- The induced homomorphism on `A_M` is computed by its representative homomorphism. -/
+@[simp]
+theorem discriminantOrthogonalQuotientHom_mk
+    (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    discriminantOrthogonalQuotientHom hL hM (Submodule.Quotient.mk y) =
+      dualCarrierToOrthogonalQuotient hL hM y := (rfl)
+
+/-- A vector of `Mᵛ` whose discriminant class lies in `H` already lies in `M`, so the induced
+homomorphism is injective. -/
+theorem discriminantOrthogonalQuotientHom_injective :
+    Function.Injective (discriminantOrthogonalQuotientHom hL hM) := by
+  refine (injective_iff_map_eq_zero _).mpr fun a ha ↦ ?_
+  induction a using Submodule.Quotient.induction_on with
+  | _ y =>
+    rw [discriminantOrthogonalQuotientHom_mk,
+      dualCarrierToOrthogonalQuotient_eq_zero_iff] at ha
+    rw [Submodule.Quotient.mk_eq_zero, hM.isIntegral.toIntegralLattice.mem_carrierInDual_iff,
+      hM.isIntegral.toIntegralLattice_carrier]
+    exact ha
+
+/-- Every class of `H⊥` is the discriminant class of a vector of `Mᵛ`, so the induced
+homomorphism is surjective. -/
+theorem discriminantOrthogonalQuotientHom_surjective :
+    Function.Surjective (discriminantOrthogonalQuotientHom hL hM) := by
+  intro q
+  obtain ⟨z, rfl⟩ := (L.discriminantQuadraticModule hL).orthogonalQuotientMk_surjective
+    (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM) q
+  obtain ⟨x, hx⟩ := Submodule.Quotient.mk_surjective L.carrierInDual z.1
+  have hxdual : (x : V) ∈ (dual M).1 := by
+    refine (L.mk_mem_discriminantSubgroup_iff (dual M) x).mp ?_
+    rw [discriminantSubgroup_dual, hx]
+    exact z.2
+  have hy : (x : V) ∈ hM.isIntegral.toIntegralLattice.dualCarrier := by
+    rw [hM.isIntegral.toIntegralLattice_dualCarrier]
+    exact hxdual
+  refine ⟨Submodule.Quotient.mk ⟨(x : V), hy⟩, ?_⟩
+  rw [discriminantOrthogonalQuotientHom_mk, dualCarrierToOrthogonalQuotient_apply]
+  exact congrArg _ (Subtype.ext hx)
+
+/-- The quadratic value in `H⊥ / H` of the class of a dual vector of `M` is the ambient
+half-norm. -/
+theorem quadratic_dualCarrierToOrthogonalQuotient
+    (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
+        (IsEven.isIsotropic_discriminantSubgroup hL hM)).quadratic
+        (dualCarrierToOrthogonalQuotient hL hM y) =
+      ((L.form y y / 2 : ℚ) : AddCircle (1 : ℚ)) :=
+  ((L.discriminantQuadraticModule hL).orthogonalQuotient_quadratic_mk
+      (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM)
+      ⟨hM.isIntegral.dualClassHom y,
+        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩).trans
+    ((L.discriminantQuadraticModule_quadratic hL _).trans
+      (L.discriminantQuadraticMap_mk hL ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩))
+
+/-- The pairing in `H⊥ / H` of the classes of two dual vectors of `M` is the ambient form
+modulo `ℤ`. -/
+theorem pairing_dualCarrierToOrthogonalQuotient
+    (y z : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
+        (IsEven.isIsotropic_discriminantSubgroup hL hM)).toFiniteBilinearModule.pairing
+        (dualCarrierToOrthogonalQuotient hL hM y) (dualCarrierToOrthogonalQuotient hL hM z) =
+      ((L.form y z : ℚ) : AddCircle (1 : ℚ)) :=
+  ((L.discriminantQuadraticModule hL).orthogonalQuotient_pairing_mk
+      (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM)
+      ⟨hM.isIntegral.dualClassHom y,
+        hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩
+      ⟨hM.isIntegral.dualClassHom z,
+        hM.isIntegral.dualClassHom_mem_orthogonalComplement z⟩).trans
+    ((L.discriminantBilinearModule_pairing _ _).trans
+      (L.discriminantPairing_mk ⟨(y : V), hM.isIntegral.dualCarrier_le y.2⟩
+        ⟨(z : V), hM.isIntegral.dualCarrier_le z.2⟩))
+
+/-- The quadratic value in `A_M` of the class of a dual vector of `M` is the ambient
+half-norm. -/
+theorem quadratic_discriminantQuadraticModule_toIntegralLattice_mk
+    (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    (hM.isIntegral.toIntegralLattice.discriminantQuadraticModule
+        hM.isEven_toIntegralLattice).quadratic (Submodule.Quotient.mk y) =
+      ((L.form y y / 2 : ℚ) : AddCircle (1 : ℚ)) := by
+  rw [discriminantQuadraticModule_quadratic, discriminantQuadraticMap_mk,
+    hM.isIntegral.toIntegralLattice_form]
+
+/-- **The discriminant form of an even overlattice.** For an even overlattice `L ≤ M ≤ Lᵛ` with
+subgroup `H = M / L` of the discriminant group of `L`, the discriminant quadratic module of `M`
+is `H⊥ / H`.
+
+This is Nikulin's Proposition 1.4.1, in the half-norm `ℚ/ℤ` convention. -/
+noncomputable def discriminantOrthogonalQuotientIsometry :
+    FiniteQuadraticModule.Isometry
+      (hM.isIntegral.toIntegralLattice.discriminantQuadraticModule
+        hM.isEven_toIntegralLattice)
+      ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
+        (IsEven.isIsotropic_discriminantSubgroup hL hM)) where
+  toLinearEquiv :=
+    LinearEquiv.ofBijective (discriminantOrthogonalQuotientHom hL hM)
+      ⟨discriminantOrthogonalQuotientHom_injective hL hM,
+        discriminantOrthogonalQuotientHom_surjective hL hM⟩
+  map_app' a := by
+    induction a using Submodule.Quotient.induction_on with
+    | _ y =>
+      exact (quadratic_dualCarrierToOrthogonalQuotient hL hM y).trans
+        (quadratic_discriminantQuadraticModule_toIntegralLattice_mk hM y).symm
+
+/-- The comparison isometry acts through its underlying homomorphism. -/
+@[simp]
+theorem discriminantOrthogonalQuotientIsometry_apply
+    (a : hM.isIntegral.toIntegralLattice.DiscriminantGroup) :
+    discriminantOrthogonalQuotientIsometry hL hM a =
+      discriminantOrthogonalQuotientHom hL hM a := (rfl)
+
+/-- **The representative formula.** The comparison isometry sends the class in `A_M` of a dual
+vector of `M` to the class in `H⊥ / H` of its discriminant class in `A_L`. -/
+theorem discriminantOrthogonalQuotientIsometry_mk
+    (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
+    discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y) =
+      (L.discriminantQuadraticModule hL).orthogonalQuotientMk _
+        (IsEven.isIsotropic_discriminantSubgroup hL hM)
+        ⟨hM.isIntegral.dualClassHom y,
+          hM.isIntegral.dualClassHom_mem_orthogonalComplement y⟩ := (rfl)
+
+/-! ## Numerical consequences -/
+
+/-- **The order of `H⊥ / H` is the discriminant of the overlattice.** -/
+theorem natCard_orthogonalQuotient :
+    Nat.card ((L.discriminantQuadraticModule hL).orthogonalQuotient (L.discriminantSubgroup M)
+        (IsEven.isIsotropic_discriminantSubgroup hL hM)) =
+      hM.isIntegral.toIntegralLattice.discriminant :=
+  (Nat.card_congr
+      (discriminantOrthogonalQuotientIsometry hL hM).toLinearEquiv.toEquiv).symm.trans
+    hM.isIntegral.toIntegralLattice.natCard_discriminantGroup
+
+/-- **An even overlattice is unimodular exactly when `H⊥ / H` is trivial.** -/
+theorem subsingleton_orthogonalQuotient_iff_isUnimodular :
+    Subsingleton ((L.discriminantQuadraticModule hL).orthogonalQuotient
+        (L.discriminantSubgroup M) (IsEven.isIsotropic_discriminantSubgroup hL hM)) ↔
+      hM.isIntegral.toIntegralLattice.IsUnimodular := by
+  rw [hM.isIntegral.toIntegralLattice.isUnimodular_iff_subsingleton_discriminantGroup]
+  exact Equiv.subsingleton_congr
+    (discriminantOrthogonalQuotientIsometry hL hM).toLinearEquiv.toEquiv.symm
+
+end IntermediateCarrier
+
+/-! ## The comparison isometry read on subgroups -/
+
+open IntermediateCarrier
+
+variable (L)
+
+/-- **The discriminant form of a glued even overlattice:** `A_(L_H) ≅ H⊥ / H` for a
+quadratic-isotropic subgroup `H` of the discriminant group of an even nondegenerate lattice.
+
+This is the form in which the ADE glue calculations use the comparison isometry. -/
+noncomputable def discriminantOrthogonalQuotientIsometryOfSubgroup (hL : L.IsEven)
+    {H : AddSubgroup L.DiscriminantGroup}
+    (hM : IntermediateCarrier.IsEven (L.intermediateCarrierOfDiscriminantSubgroup H)) :
+    FiniteQuadraticModule.Isometry
+      (hM.isIntegral.toIntegralLattice.discriminantQuadraticModule
+        hM.isEven_toIntegralLattice)
+      ((L.discriminantQuadraticModule hL).orthogonalQuotient H
+        ((L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mp hM)) :=
+  (discriminantOrthogonalQuotientIsometry hL hM).trans
+    ((L.discriminantQuadraticModule hL).orthogonalQuotientCongr
+      (IsEven.isIsotropic_discriminantSubgroup hL hM)
+      ((L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mp hM)
+      (L.discriminantSubgroup_intermediateCarrierOfDiscriminantSubgroup H))
+
+/-- **The order of `H⊥ / H` is the discriminant of the overlattice glued along `H`.** -/
+theorem natCard_orthogonalQuotient_of_subgroup (hL : L.IsEven)
+    {H : AddSubgroup L.DiscriminantGroup}
+    (hM : IntermediateCarrier.IsEven (L.intermediateCarrierOfDiscriminantSubgroup H)) :
+    Nat.card ((L.discriminantQuadraticModule hL).orthogonalQuotient H
+        ((L.isEven_intermediateCarrierOfDiscriminantSubgroup_iff hL H).mp hM)) =
+      hM.isIntegral.toIntegralLattice.discriminant :=
+  (Nat.card_congr (L.discriminantOrthogonalQuotientIsometryOfSubgroup hL
+      hM).toLinearEquiv.toEquiv).symm.trans
+    hM.isIntegral.toIntegralLattice.natCard_discriminantGroup
+
+end IntegralLattice
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -267,7 +267,6 @@ theorem discriminantOrthogonalQuotientIsometry_apply
 
 /-- **The representative formula.** The comparison isometry sends the class in `A_M` of a dual
 vector of `M` to the class in `H⊥ / H` of its discriminant class in `A_L`. -/
-@[simp]
 theorem discriminantOrthogonalQuotientIsometry_mk
     (y : hM.isIntegral.toIntegralLattice.dualCarrier) :
     discriminantOrthogonalQuotientIsometry hL hM (Submodule.Quotient.mk y) =


### PR DESCRIPTION
This PR constructs Nikulin's comparison isometry `A_M ≅ H⊥ / H` for an even overlattice, the fourth bullet of Layer 4 of `TauCetiRoadmap/IntegralLattices/README.md` ("For isotropic `H`, define the induced form on `H^⊥/H` and construct the natural isometry `A_{L_H} ≅ H^⊥/H` ... in the even case"). Let `L` be an even nondegenerate integral lattice, let `L ≤ M ≤ Lᵛ` be an even intermediate carrier, and let `H = M / L` be the quadratic-isotropic subgroup of `A_L` it cuts out. The isometry is the descent of the composite `Mᵛ ↪ Lᵛ ↠ A_L`, which lands on `H⊥` and has fibre `M` over `H`, both by the landed identification `Mᵛ / L = (M / L)⊥`. It preserves the half-norm quadratic form because both sides evaluate to `B(x, x) / 2` modulo `ℤ` at the same ambient vector.

This is the most effective current step on that milestone because everything else Layer 4 asks for is already on `main` — the intermediate-carrier correspondence (#3775), its integral/even refinements, the index and discriminant scaling law (#3896), naturality (#4057), and the dual/Lagrangian identification (#4171) — and the abstract `H⊥ / H` of a finite quadratic module landed in #4176. What was missing was the bridge between the two: nothing on `main` connected the discriminant quadratic module of an overlattice to the orthogonal quotient of the discriminant quadratic module of the lattice below it. Layer 5's `D₈ ⊂ E₈` target closes with "check that the general comparison gives `A_{D₈^+} ≅ H^⊥/H = 0`", so this is the general theorem that calculation calls; the `D₈⁺` carrier itself is in flight in #4181 and is untouched here.

The new module is `TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean` (356 lines). It proves the dual carrier of the lattice carried by an integral intermediate carrier is the dual intermediate carrier, builds the discriminant-class homomorphism `Mᵛ →ₗ[ℤ] A_L` and shows it lands in `H⊥`, descends it through `Submodule.liftQ`, proves injectivity and surjectivity from the membership criteria of the correspondence, and packages the result as a `FiniteQuadraticModule.Isometry`. Alongside it come the representative formulae for the map, its quadratic values and its polar pairing values, the order computation `#(H⊥ / H) = disc(M)`, the criterion that `M` is unimodular exactly when `H⊥ / H` is trivial, and the restatement `A_(L_H) ≅ H⊥ / H` for the overlattice glued along a quadratic-isotropic subgroup `H ≤ A_L`, which is the shape the ADE glue calculations use.

`TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean` gains 21 lines: `orthogonalQuotientCongr`, the canonical isometry between the orthogonal quotients along equal quadratic-isotropic subgroups, and its representative formula. It is what turns the intermediate-carrier statement into the `L_H` statement, since `L.discriminantSubgroup (L_H) = H` is a propositional equality inside a dependent type.

The numerical scaling law `disc(M) · |H|² = disc(L)` is deliberately not restated: it already follows on `main` from `IsIntegral.discriminant_mul_index_sq` and `index_eq_natCard_discriminantSubgroup`. No Mathlib source is vendored; the construction consumes Mathlib's `Submodule.liftQ`, `Submodule.inclusion`, `AddMonoidHom.codRestrict`, `LinearEquiv.ofBijective`, and `QuadraticMap.IsometryEquiv` through the project's existing discriminant, overlattice, and finite-quadratic-module interfaces.

After this PR, Layer 4 still owes naturality of the comparison isometry under a lattice isometry and under orthogonal direct sums, which first needs the induced map of orthogonal quotients in the finite-quadratic-module layer; and the bilinear analogue for a merely integral overlattice of an odd lattice, which needs the orthogonal quotient of a finite *bilinear* module, in flight as #3805. Both gaps are named in the module docstring.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"discriminant-group-of-overlattice-isometric-to-h-perp-mod-h"}-->

🤖 Prepared with Claude Code
