### PR TITLE
feat: identify the local crossing cap angle

### DIFF
--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.Log
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 import Mathlib.Topology.UnitInterval
 import TauCeti.Analysis.Contour.Curve.Distance
 
@@ -37,6 +38,8 @@ API does not expose.
   assemble the index integral downstream.
 * `TauCeti.Contour.div_norm_eq_exp_arg_mul_I` — the unit direction of a nonzero complex number
   in polar form, shared with the sector-resonance bridges.
+* `TauCeti.Contour.exp_mul_I_congr_angle` — equal real angles have equal unit complex
+  exponentials.
 
 ## Provenance
 
@@ -277,6 +280,13 @@ theorem div_norm_eq_exp_arg_mul_I {w : ℂ} (hw : w ≠ 0) :
     w / (‖w‖ : ℂ) = Complex.exp ((Complex.arg w : ℂ) * Complex.I) := by
   rw [div_eq_iff (Complex.ofReal_ne_zero.mpr (norm_ne_zero_iff.mpr hw)), mul_comm]
   exact (Complex.norm_mul_exp_arg_mul_I w).symm
+
+/-- Two real representatives of the same `Real.Angle` have the same unit complex exponential.
+This is the coercion bridge from the quotient-valued angle API to complex polar form. -/
+theorem exp_mul_I_congr_angle {x y : ℝ} (h : (x : Real.Angle) = (y : Real.Angle)) :
+    Complex.exp ((x : ℂ) * Complex.I) = Complex.exp ((y : ℂ) * Complex.I) := by
+  have hcircle := congrArg (fun z : Circle => (z : ℂ)) (congrArg Real.Angle.toCircle h)
+  simpa only [Real.Angle.toCircle_coe, Circle.coe_exp] using hcircle
 
 /-- For a nonzero complex number `z`, `exp(I · Im(log z)) = z / ↑‖z‖`. -/
 private lemma exp_I_log_im_eq_div_norm {z : ℂ} (hz : z ≠ 0) :

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -278,6 +278,21 @@ theorem div_norm_eq_exp_arg_mul_I {w : ℂ} (hw : w ≠ 0) :
   rw [div_eq_iff (Complex.ofReal_ne_zero.mpr (norm_ne_zero_iff.mpr hw)), mul_comm]
   exact (Complex.norm_mul_exp_arg_mul_I w).symm
 
+/-- Two real representatives of the same angle have the same complex exponential after
+multiplication by `I`. -/
+theorem exp_mul_I_congr_angle {x y : ℝ} (h : (x : Real.Angle) = (y : Real.Angle)) :
+    Complex.exp ((x : ℂ) * Complex.I) = Complex.exp ((y : ℂ) * Complex.I) := by
+  obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp h
+  have hxy : (x : ℂ) = (y : ℂ) + (k : ℂ) * (2 * (Real.pi : ℂ)) := by
+    have hxy_real : x = y + (k : ℝ) * (2 * Real.pi) := by linarith [hk]
+    rw [hxy_real]
+    push_cast
+    ring
+  rw [hxy, add_mul, Complex.exp_add]
+  have hkI : ((k : ℂ) * (2 * (Real.pi : ℂ))) * Complex.I =
+      (k : ℂ) * (2 * (Real.pi : ℂ) * Complex.I) := by ring
+  rw [hkI, Complex.exp_int_mul_two_pi_mul_I, mul_one]
+
 /-- For a nonzero complex number `z`, `exp(I · Im(log z)) = z / ↑‖z‖`. -/
 private lemma exp_I_log_im_eq_div_norm {z : ℂ} (hz : z ≠ 0) :
     Complex.exp (Complex.I * ((Complex.log z).im : ℂ)) = z / (‖z‖ : ℂ) := by

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -278,21 +278,6 @@ theorem div_norm_eq_exp_arg_mul_I {w : ℂ} (hw : w ≠ 0) :
   rw [div_eq_iff (Complex.ofReal_ne_zero.mpr (norm_ne_zero_iff.mpr hw)), mul_comm]
   exact (Complex.norm_mul_exp_arg_mul_I w).symm
 
-/-- Two real representatives of the same angle have the same complex exponential after
-multiplication by `I`. -/
-theorem exp_mul_I_congr_angle {x y : ℝ} (h : (x : Real.Angle) = (y : Real.Angle)) :
-    Complex.exp ((x : ℂ) * Complex.I) = Complex.exp ((y : ℂ) * Complex.I) := by
-  obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp h
-  have hxy : (x : ℂ) = (y : ℂ) + (k : ℂ) * (2 * (Real.pi : ℂ)) := by
-    have hxy_real : x = y + (k : ℝ) * (2 * Real.pi) := by linarith [hk]
-    rw [hxy_real]
-    push_cast
-    ring
-  rw [hxy, add_mul, Complex.exp_add]
-  have hkI : ((k : ℂ) * (2 * (Real.pi : ℂ))) * Complex.I =
-      (k : ℂ) * (2 * (Real.pi : ℂ) * Complex.I) := by ring
-  rw [hkI, Complex.exp_int_mul_two_pi_mul_I, mul_one]
-
 /-- For a nonzero complex number `z`, `exp(I · Im(log z)) = z / ↑‖z‖`. -/
 private lemma exp_I_log_im_eq_div_norm {z : ℂ} (hz : z ≠ 0) :
     Complex.exp (Complex.I * ((Complex.log z).im : ℂ)) = z / (‖z‖ : ℂ) := by

--- a/TauCeti/Analysis/Contour/Chord/QuotientAsymptotics.lean
+++ b/TauCeti/Analysis/Contour/Chord/QuotientAsymptotics.lean
@@ -38,6 +38,9 @@ Where the two sides share a proof, the statement is parametrised over the within
   one-sided interval lie in the slit plane.
 * `Contour.arg_annular_quotient_tendsto_right` / `_left` — convergence of the annular
   quotient arguments along a positive cutoff `δ(ε) → 0⁺`.
+* `Contour.tendsto_arg_chord_div_tangent_nhdsGT` /
+  `Contour.tendsto_arg_neg_tangent_div_chord_nhdsLT` — the boundary chord-to-tangent arguments
+  converge to zero at the crossing.
 * `Contour.exists_chord_div_tangent_mem_slitPlane_right` /
   `Contour.exists_neg_tangent_div_chord_mem_slitPlane_left` — a window radius on which the
   boundary quotients (chord over tangent on the right, negated tangent over chord on the left)
@@ -208,6 +211,52 @@ theorem arg_tendsto_of_pos_mul_tendsto {α : Type*} {l : Filter α} {c : α → 
   refine ((Complex.continuousAt_arg hQ).tendsto.comp h).congr' ?_
   filter_upwards [hc] with ε hε
   exact Complex.arg_real_mul _ hε
+
+/-- Along the incoming side of a differentiable crossing, the boundary argument
+`arg (-L / (γ t - s))` tends to `0`.  Multiplication by the positive scalar `t₀ - t` removes the
+blow-up and exposes the limit `1`, without changing the argument. -/
+theorem tendsto_arg_neg_tangent_div_chord_nhdsLT (h_at : γ t₀ = s) (hL : L ≠ 0)
+    (h_deriv : HasDerivWithinAt γ L (Iio t₀) t₀) :
+    Tendsto (fun t => ((-L) / (γ t - s)).arg) (𝓝[<] t₀) (𝓝 0) := by
+  have hq := (chord_quotient_tendsto self_notMem_Iio h_deriv h_at).inv₀ hL
+  have hscaled : Tendsto (fun t => (((t₀ - t : ℝ) : ℂ) * ((-L) / (γ t - s))))
+      (𝓝[<] t₀) (𝓝 1) := by
+    convert hq.const_mul L using 1
+    · funext t
+      by_cases ht : t = t₀
+      · subst t
+        simp [h_at]
+      · field_simp
+        push_cast
+        ring
+    · field_simp
+  have hpos : ∀ᶠ t in 𝓝[<] t₀, 0 < t₀ - t := by
+    filter_upwards [self_mem_nhdsWithin] with t ht
+    exact sub_pos.mpr ht
+  simpa using arg_tendsto_of_pos_mul_tendsto
+    (by simp [Complex.mem_slitPlane_iff]) hpos hscaled
+
+/-- Along the outgoing side of a differentiable crossing, the boundary argument
+`arg ((γ t - s) / L)` tends to `0`.  Dividing by the positive scalar `t - t₀` exposes the
+nonzero tangent limit and does not change the argument. -/
+theorem tendsto_arg_chord_div_tangent_nhdsGT (h_at : γ t₀ = s) (hL : L ≠ 0)
+    (h_deriv : HasDerivWithinAt γ L (Ioi t₀) t₀) :
+    Tendsto (fun t => ((γ t - s) / L).arg) (𝓝[>] t₀) (𝓝 0) := by
+  have hq := (chord_quotient_tendsto self_notMem_Ioi h_deriv h_at).div_const L
+  rw [div_self hL] at hq
+  have hscaled : Tendsto
+      (fun t => ((((t - t₀)⁻¹ : ℝ) : ℂ) * ((γ t - s) / L)))
+      (𝓝[>] t₀) (𝓝 1) := by
+    refine hq.congr' ?_
+    filter_upwards [self_mem_nhdsWithin] with t ht
+    have hne : t - t₀ ≠ 0 := sub_ne_zero.mpr ht.ne'
+    push_cast
+    field_simp
+  have hpos : ∀ᶠ t in 𝓝[>] t₀, 0 < (t - t₀)⁻¹ := by
+    filter_upwards [self_mem_nhdsWithin] with t ht
+    exact inv_pos.mpr (sub_pos.mpr ht)
+  simpa using arg_tendsto_of_pos_mul_tendsto
+    (by simp [Complex.mem_slitPlane_iff]) hpos hscaled
 
 /-- **Right annular quotient argument convergence**: along a positive cutoff `δ(ε) → 0⁺`, the
 argument of the annular quotient `(γ (t₀ + r) - s) / (γ (t₀ + δ ε) - s)` converges to the

--- a/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
+++ b/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Analysis.Contour.Crossing.Excision
 public import TauCeti.Analysis.Contour.RegularityConditions
-import TauCeti.Analysis.Contour.Argument.Lift
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 import TauCeti.Analysis.Contour.Chord.QuotientAsymptotics
 
 /-!
@@ -89,12 +89,20 @@ theorem coe_crossingCapSweep_eq_arg_div (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
 /-- The exponential of the cap sweep is the unit endpoint ratio.  Equal endpoint norms turn this
 into the endpoint ratio itself. -/
 theorem exp_crossingCapSweep_mul_I (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
-    (hw_L : w_L ≠ 0) (hw_R : w_R ≠ 0) (hnorm : ‖w_L‖ = ‖w_R‖)
+    (hw_L : w_L ≠ 0) (hnorm : ‖w_L‖ = ‖w_R‖)
     (h_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L)) :
     Complex.exp ((crossingCapSweep γ t₀ L_R L_L w_L w_R : ℂ) * Complex.I) = w_R / w_L := by
-  rw [exp_mul_I_congr_angle
-    (coe_crossingCapSweep_eq_arg_div hL_L hL_R hw_L hw_R h_R h_L)]
+  have hw_R : w_R ≠ 0 := by
+    apply norm_ne_zero_iff.mp
+    rw [← hnorm]
+    exact norm_ne_zero_iff.mpr hw_L
+  have hangle := congrArg (fun z : Circle => (z : ℂ))
+    (congrArg Real.Angle.toCircle
+      (coe_crossingCapSweep_eq_arg_div hL_L hL_R hw_L hw_R h_R h_L))
+  rw [show Complex.exp ((crossingCapSweep γ t₀ L_R L_L w_L w_R : ℂ) * Complex.I) =
+      Complex.exp (((w_R / w_L).arg : ℂ) * Complex.I) by
+        simpa only [Real.Angle.toCircle_coe, Circle.coe_exp] using hangle]
   have hratio_norm : ‖w_R / w_L‖ = 1 := by
     rw [norm_div, ← hnorm, div_self (norm_ne_zero_iff.mpr hw_L)]
   calc
@@ -108,7 +116,7 @@ theorem exp_crossingCapSweep_mul_I (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
 of that radius about `s`, starting at the principal argument of `w_L` and sweeping through
 `crossingCapSweep`, starts at `s + w_L` and ends at `s + w_R`. -/
 theorem circleMap_crossingCapSweep_endpoints (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
-    (hw_L : w_L ≠ 0) (hw_R : w_R ≠ 0) (hnorm : ‖w_L‖ = ‖w_R‖)
+    (hw_L : w_L ≠ 0) (hnorm : ‖w_L‖ = ‖w_R‖)
     (h_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L)) :
     circleMap s ‖w_L‖ w_L.arg = s + w_L ∧
@@ -117,7 +125,7 @@ theorem circleMap_crossingCapSweep_endpoints (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 
   constructor
   · rw [circleMap, Complex.norm_mul_exp_arg_mul_I]
   · rw [circleMap, Complex.ofReal_add, add_mul, Complex.exp_add,
-      exp_crossingCapSweep_mul_I hL_L hL_R hw_L hw_R hnorm h_R h_L]
+      exp_crossingCapSweep_mul_I hL_L hL_R hw_L hnorm h_R h_L]
     have hwL_norm : (‖w_L‖ : ℂ) * Complex.exp ((w_L.arg : ℂ) * Complex.I) = w_L :=
       Complex.norm_mul_exp_arg_mul_I w_L
     calc
@@ -145,9 +153,11 @@ theorem tendsto_arg_neg_tangent_div_chord_nhdsLT (h_at : γ t₀ = s) (hL : L_L 
         push_cast
         ring
     · field_simp
-  simpa using arg_tendsto_of_pos_mul_tendsto (by simp [Complex.mem_slitPlane_iff])
-    ((show ∀ᶠ t in 𝓝[<] t₀, t ∈ Iio t₀ from self_mem_nhdsWithin).mono
-      fun t ht => sub_pos.mpr ht) hscaled
+  have hpos : ∀ᶠ t in 𝓝[<] t₀, 0 < t₀ - t := by
+    filter_upwards [self_mem_nhdsWithin] with t ht
+    exact sub_pos.mpr ht
+  simpa using arg_tendsto_of_pos_mul_tendsto
+    (by simp [Complex.mem_slitPlane_iff]) hpos hscaled
 
 /-- Along the outgoing side of a differentiable crossing, the boundary argument
 `arg ((γ t - s) / L)` tends to `0`.  Dividing by the positive scalar `t - t₀` exposes the
@@ -165,9 +175,11 @@ theorem tendsto_arg_chord_div_tangent_nhdsGT (h_at : γ t₀ = s) (hL : L_R ≠ 
     have hne : t - t₀ ≠ 0 := sub_ne_zero.mpr ht.ne'
     push_cast
     field_simp
-  simpa using arg_tendsto_of_pos_mul_tendsto (by simp [Complex.mem_slitPlane_iff])
-    ((show ∀ᶠ t in 𝓝[>] t₀, t ∈ Ioi t₀ from self_mem_nhdsWithin).mono
-      fun t ht => inv_pos.mpr (sub_pos.mpr ht)) hscaled
+  have hpos : ∀ᶠ t in 𝓝[>] t₀, 0 < (t - t₀)⁻¹ := by
+    filter_upwards [self_mem_nhdsWithin] with t ht
+    exact inv_pos.mpr (sub_pos.mpr ht)
+  simpa using arg_tendsto_of_pos_mul_tendsto
+    (by simp [Complex.mem_slitPlane_iff]) hpos hscaled
 
 /-- **A local cap approaches the reverse model-sector arc.**  As its left and right endpoint
 parameters tend independently to `t₀`, `crossingCapSweep` tends to the negative crossing angle.
@@ -190,7 +202,8 @@ theorem tendsto_crossingCapSweep (h_at : γ t₀ = s) (hL_L : L_L ≠ 0) (hL_R :
 
 /-- **The local crossing loop contributes exactly the crossing angle.**  Suppose the principal
 value on `[l, u]` is the standard pure-imaginary boundary-argument value
-`i · (arg (-L_L / w_L) + arg (w_R / L_R))`, as happens when the endpoint chords have equal norm.
+`i · (arg (-L_L / w_L) + arg (w_R / L_R))`, as supplied by the separate per-window calculation
+under its full hypotheses, including equal endpoint radii.
 The winding number of the crossing window minus that of the circular cap with sweep
 `crossingCapSweep` is then exactly `crossingAngle γ t₀ / 2π`.
 

--- a/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
+++ b/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
@@ -7,8 +7,8 @@ module
 
 public import TauCeti.Analysis.Contour.Crossing.Excision
 public import TauCeti.Analysis.Contour.RegularityConditions
+import TauCeti.Analysis.Contour.Argument.Lift
 import TauCeti.Analysis.Contour.Chord.QuotientAsymptotics
-import TauCeti.Analysis.Contour.Winding.CrossingAngleSum
 
 /-!
 # The capping angle at a crossing
@@ -29,11 +29,12 @@ starting at `w_L` and sweeping through `δ` ends at `w_R`.  Moreover `δ` tends 
 the branch control needed to ensure that a sufficiently local cap is the reverse of the model
 sector arc, rather than that arc with an unnoticed extra turn.
 
-The final theorem records the exact local accounting.  Whenever the principal value on a window
-has the standard boundary-argument value supplied by the per-window calculation, subtracting the
-winding number of this cap leaves exactly `crossingAngle γ t₀ / 2π`.  Exit-time windows have
-equal endpoint radii, so these results are the geometric bridge from that analytic calculation to
-the excision identity in `TauCeti.Analysis.Contour.Crossing.Excision`.
+The final theorem records the exact local accounting.  Its chord identities, equal-radius
+condition, and tangent-limit hypotheses prove that the cap has the same endpoints as the crossing
+window.  Whenever the principal value on that window has the standard boundary-argument value
+supplied by the per-window calculation, subtracting the winding number of the cap leaves exactly
+`crossingAngle γ t₀ / 2π`.  This is the geometric bridge from that analytic calculation to the
+excision identity in `TauCeti.Analysis.Contour.Crossing.Excision`.
 
 ## Main definitions and results
 
@@ -97,12 +98,16 @@ theorem exp_crossingCapSweep_mul_I (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
     apply norm_ne_zero_iff.mp
     rw [← hnorm]
     exact norm_ne_zero_iff.mpr hw_L
-  have hwindow := exp_log_norm_add_arg_eq_mul_exp_crossingAngle
-    hL_L hL_R hw_L hw_R h_R h_L
-  have hlog : Real.log ‖w_R‖ - Real.log ‖w_L‖ = 0 := by rw [← hnorm]; ring
-  simp only [hlog, Complex.ofReal_zero, zero_add] at hwindow
-  rw [crossingCapSweep, Complex.ofReal_sub, sub_mul, Complex.exp_sub, hwindow]
-  exact mul_div_cancel_right₀ (w_R / w_L) (Complex.exp_ne_zero _)
+  rw [exp_mul_I_congr_angle
+    (coe_crossingCapSweep_eq_arg_div hL_L hL_R hw_L hw_R h_R h_L)]
+  have hratio_norm : ‖w_R / w_L‖ = 1 := by
+    rw [norm_div, ← hnorm, div_self (norm_ne_zero_iff.mpr hw_L)]
+  calc
+    Complex.exp (((w_R / w_L).arg : ℂ) * Complex.I) =
+        (‖w_R / w_L‖ : ℂ) * Complex.exp (((w_R / w_L).arg : ℂ) * Complex.I) := by
+          rw [hratio_norm]
+          simp
+    _ = w_R / w_L := Complex.norm_mul_exp_arg_mul_I _
 
 /-- **The cap has the prescribed endpoints.**  If the endpoint chords have equal norm, the circle
 of that radius about `s`, starting at the principal argument of `w_L` and sweeping through
@@ -151,31 +156,42 @@ theorem tendsto_crossingCapSweep (h_at : γ t₀ = s) (hL_L : L_L ≠ 0) (hL_R :
   simpa only [crossingCapSweep, Function.comp_apply, zero_add, zero_sub] using
     (hleft.add hright).sub tendsto_const_nhds
 
-/-- **The local crossing loop contributes exactly the crossing angle.**  Suppose the principal
-value on `[l, u]` is the standard pure-imaginary boundary-argument value
-`i · (arg (-L_L / w_L) + arg (w_R / L_R))`, as supplied by the separate per-window calculation
-under its full hypotheses, including equal endpoint radii.
-The winding number of the crossing window minus that of the circular cap with sweep
-`crossingCapSweep` is then exactly `crossingAngle γ t₀ / 2π`.
-
-Together with `circleMap_crossingCapSweep_endpoints`, this is the one-window local contribution in
-Hungerbühler–Wasem Proposition 2.2. -/
+/-- **The local crossing loop contributes exactly the crossing angle.**  Suppose `w_L` and `w_R`
+are the endpoint chords of `[l, u]`, have equal norm, and the one-sided tangent limits are nonzero.
+Then the circular cap with sweep `crossingCapSweep` joins `γ l` to `γ u`.  If the principal value
+on the window is the standard pure-imaginary boundary-argument value
+`i · (arg (-L_L / w_L) + arg (w_R / L_R))`, as supplied by the separate per-window calculation,
+the winding number of the crossing window minus that of the cap is exactly
+`crossingAngle γ t₀ / 2π`.  Thus the window followed by the reversed cap is the one-window local
+loop contribution in Hungerbühler–Wasem Proposition 2.2. -/
 theorem windingNumber_sub_circleCap_eq_crossingAngle_div_two_pi
-    (hw_L : w_L ≠ 0) (hlu : l ≠ u)
+    (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0) (hw_L : w_L ≠ 0) (hlu : l ≠ u)
+    (hw_l : w_L = γ l - s) (hw_u : w_R = γ u - s) (hnorm : ‖w_L‖ = ‖w_R‖)
+    (h_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
+    (h_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
     (hpv : HasCauchyPVAt γ l u (fun z => (z - s)⁻¹) s
       (((((-L_L) / w_L).arg + (w_R / L_R).arg : ℝ) : ℂ) * Complex.I)) :
-    windingNumber γ l u s -
-        windingNumber (circleCap s ‖w_L‖ l u w_L.arg
-          (w_L.arg + crossingCapSweep γ t₀ L_R L_L w_L w_R)) l u s
-      = (crossingAngle γ t₀ : ℂ) / (2 * (Real.pi : ℂ)) := by
-  rw [windingNumber_eq_of_hasCauchyPVAt hpv,
-    windingNumber_circleCap (norm_ne_zero_iff.mpr hw_L) hlu w_L.arg
-      (w_L.arg + crossingCapSweep γ t₀ L_R L_L w_L w_R)]
-  simp only [add_sub_cancel_left, crossingCapSweep]
-  have hpi : (Real.pi : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr Real.pi_ne_zero
-  field_simp
-  push_cast
-  ring
+    let cap := circleCap s ‖w_L‖ l u w_L.arg
+      (w_L.arg + crossingCapSweep γ t₀ L_R L_L w_L w_R)
+    cap l = γ l ∧ cap u = γ u ∧
+      windingNumber γ l u s - windingNumber cap l u s
+        = (crossingAngle γ t₀ : ℂ) / (2 * (Real.pi : ℂ)) := by
+  dsimp only
+  have hends := circleMap_crossingCapSweep_endpoints (s := s) hL_L hL_R hnorm h_R h_L
+  constructor
+  · rw [circleCap_left, hends.1, hw_l]
+    ring
+  constructor
+  · rw [circleCap_right s ‖w_L‖ hlu w_L.arg, hends.2, hw_u]
+    ring
+  · rw [windingNumber_eq_of_hasCauchyPVAt hpv,
+      windingNumber_circleCap (norm_ne_zero_iff.mpr hw_L) hlu w_L.arg
+        (w_L.arg + crossingCapSweep γ t₀ L_R L_L w_L w_R)]
+    simp only [add_sub_cancel_left, crossingCapSweep]
+    have hpi : (Real.pi : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr Real.pi_ne_zero
+    field_simp
+    push_cast
+    ring
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
+++ b/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
@@ -7,8 +7,8 @@ module
 
 public import TauCeti.Analysis.Contour.Crossing.Excision
 public import TauCeti.Analysis.Contour.RegularityConditions
-import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 import TauCeti.Analysis.Contour.Chord.QuotientAsymptotics
+import TauCeti.Analysis.Contour.Winding.CrossingAngleSum
 
 /-!
 # The capping angle at a crossing
@@ -97,20 +97,12 @@ theorem exp_crossingCapSweep_mul_I (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
     apply norm_ne_zero_iff.mp
     rw [← hnorm]
     exact norm_ne_zero_iff.mpr hw_L
-  have hangle := congrArg (fun z : Circle => (z : ℂ))
-    (congrArg Real.Angle.toCircle
-      (coe_crossingCapSweep_eq_arg_div hL_L hL_R hw_L hw_R h_R h_L))
-  rw [show Complex.exp ((crossingCapSweep γ t₀ L_R L_L w_L w_R : ℂ) * Complex.I) =
-      Complex.exp (((w_R / w_L).arg : ℂ) * Complex.I) by
-        simpa only [Real.Angle.toCircle_coe, Circle.coe_exp] using hangle]
-  have hratio_norm : ‖w_R / w_L‖ = 1 := by
-    rw [norm_div, ← hnorm, div_self (norm_ne_zero_iff.mpr hw_L)]
-  calc
-    Complex.exp (((w_R / w_L).arg : ℂ) * Complex.I) =
-        (‖w_R / w_L‖ : ℂ) * Complex.exp (((w_R / w_L).arg : ℂ) * Complex.I) := by
-          rw [hratio_norm]
-          simp
-    _ = w_R / w_L := Complex.norm_mul_exp_arg_mul_I _
+  have hwindow := exp_log_norm_add_arg_eq_mul_exp_crossingAngle
+    hL_L hL_R hw_L hw_R h_R h_L
+  have hlog : Real.log ‖w_R‖ - Real.log ‖w_L‖ = 0 := by rw [← hnorm]; ring
+  simp only [hlog, Complex.ofReal_zero, zero_add] at hwindow
+  rw [crossingCapSweep, Complex.ofReal_sub, sub_mul, Complex.exp_sub, hwindow]
+  exact mul_div_cancel_right₀ (w_R / w_L) (Complex.exp_ne_zero _)
 
 /-- **The cap has the prescribed endpoints.**  If the endpoint chords have equal norm, the circle
 of that radius about `s`, starting at the principal argument of `w_L` and sweeping through
@@ -139,52 +131,6 @@ theorem circleMap_crossingCapSweep_endpoints (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 
           s + ((‖w_L‖ : ℂ) * Complex.exp ((w_L.arg : ℂ) * Complex.I)) *
             (w_R / w_L) := by ring
       _ = s + w_R := by rw [hwL_norm]; field_simp
-
-/-- Along the incoming side of a differentiable crossing, the boundary argument
-`arg (-L / (γ t - s))` tends to `0`.  Multiplication by the positive scalar `t₀ - t` removes the
-blow-up and exposes the limit `1`, without changing the argument. -/
-theorem tendsto_arg_neg_tangent_div_chord_nhdsLT (h_at : γ t₀ = s) (hL : L_L ≠ 0)
-    (h_deriv : HasDerivWithinAt γ L_L (Iio t₀) t₀) :
-    Tendsto (fun t => ((-L_L) / (γ t - s)).arg) (𝓝[<] t₀) (𝓝 0) := by
-  have hq := (chord_quotient_tendsto self_notMem_Iio h_deriv h_at).inv₀ hL
-  have hscaled : Tendsto (fun t => (((t₀ - t : ℝ) : ℂ) * ((-L_L) / (γ t - s))))
-      (𝓝[<] t₀) (𝓝 1) := by
-    convert hq.const_mul L_L using 1
-    · funext t
-      by_cases ht : t = t₀
-      · subst t
-        simp [h_at]
-      · field_simp
-        push_cast
-        ring
-    · field_simp
-  have hpos : ∀ᶠ t in 𝓝[<] t₀, 0 < t₀ - t := by
-    filter_upwards [self_mem_nhdsWithin] with t ht
-    exact sub_pos.mpr ht
-  simpa using arg_tendsto_of_pos_mul_tendsto
-    (by simp [Complex.mem_slitPlane_iff]) hpos hscaled
-
-/-- Along the outgoing side of a differentiable crossing, the boundary argument
-`arg ((γ t - s) / L)` tends to `0`.  Dividing by the positive scalar `t - t₀` exposes the
-nonzero tangent limit and does not change the argument. -/
-theorem tendsto_arg_chord_div_tangent_nhdsGT (h_at : γ t₀ = s) (hL : L_R ≠ 0)
-    (h_deriv : HasDerivWithinAt γ L_R (Ioi t₀) t₀) :
-    Tendsto (fun t => ((γ t - s) / L_R).arg) (𝓝[>] t₀) (𝓝 0) := by
-  have hq := (chord_quotient_tendsto self_notMem_Ioi h_deriv h_at).div_const L_R
-  rw [div_self hL] at hq
-  have hscaled : Tendsto
-      (fun t => ((((t - t₀)⁻¹ : ℝ) : ℂ) * ((γ t - s) / L_R)))
-      (𝓝[>] t₀) (𝓝 1) := by
-    refine hq.congr' ?_
-    filter_upwards [self_mem_nhdsWithin] with t ht
-    have hne : t - t₀ ≠ 0 := sub_ne_zero.mpr ht.ne'
-    push_cast
-    field_simp
-  have hpos : ∀ᶠ t in 𝓝[>] t₀, 0 < (t - t₀)⁻¹ := by
-    filter_upwards [self_mem_nhdsWithin] with t ht
-    exact inv_pos.mpr (sub_pos.mpr ht)
-  simpa using arg_tendsto_of_pos_mul_tendsto
-    (by simp [Complex.mem_slitPlane_iff]) hpos hscaled
 
 /-- **A local cap approaches the reverse model-sector arc.**  As its left and right endpoint
 parameters tend independently to `t₀`, `crossingCapSweep` tends to the negative crossing angle.

--- a/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
+++ b/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
@@ -116,12 +116,17 @@ theorem exp_crossingCapSweep_mul_I (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
 of that radius about `s`, starting at the principal argument of `w_L` and sweeping through
 `crossingCapSweep`, starts at `s + w_L` and ends at `s + w_R`. -/
 theorem circleMap_crossingCapSweep_endpoints (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
-    (hw_L : w_L ≠ 0) (hnorm : ‖w_L‖ = ‖w_R‖)
+    (hnorm : ‖w_L‖ = ‖w_R‖)
     (h_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L)) :
     circleMap s ‖w_L‖ w_L.arg = s + w_L ∧
       circleMap s ‖w_L‖
           (w_L.arg + crossingCapSweep γ t₀ L_R L_L w_L w_R) = s + w_R := by
+  by_cases hw_L : w_L = 0
+  · have hw_R : w_R = 0 := by
+      apply norm_eq_zero.mp
+      rw [← hnorm, hw_L, norm_zero]
+    simp [circleMap, hw_L, hw_R]
   constructor
   · rw [circleMap, Complex.norm_mul_exp_arg_mul_I]
   · rw [circleMap, Complex.ofReal_add, add_mul, Complex.exp_add,

--- a/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
+++ b/TauCeti/Analysis/Contour/Crossing/CapAngle.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.Crossing.Excision
+public import TauCeti.Analysis.Contour.RegularityConditions
+import TauCeti.Analysis.Contour.Argument.Lift
+import TauCeti.Analysis.Contour.Chord.QuotientAsymptotics
+
+/-!
+# The capping angle at a crossing
+
+Hungerbühler–Wasem Proposition 2.2 replaces a small window around a crossing of a curve through
+`s` by a circular cap.  The local loop is the original crossing window followed by the reverse of
+that cap.  Its winding number is the crossing angle divided by `2π`.
+
+This file identifies the angle through which the cap must run.  If `L_L`, `L_R` are the incoming
+and outgoing tangent limits and `w_L`, `w_R` are the two endpoint chords, put
+
+`δ = arg (-L_L / w_L) + arg (w_R / L_R) - crossingAngle γ t₀`.
+
+The angle identity behind the per-window principal-value calculation says that `δ` is the angle
+from `w_L` to `w_R`, modulo `2π`.  Thus, when the endpoint chords have equal norm, the circular arc
+starting at `w_L` and sweeping through `δ` ends at `w_R`.  Moreover `δ` tends to
+`-crossingAngle γ t₀` as the endpoints tend to the crossing from their respective sides.  This is
+the branch control needed to ensure that a sufficiently local cap is the reverse of the model
+sector arc, rather than that arc with an unnoticed extra turn.
+
+The final theorem records the exact local accounting.  Whenever the principal value on a window
+has the standard boundary-argument value supplied by the per-window calculation, subtracting the
+winding number of this cap leaves exactly `crossingAngle γ t₀ / 2π`.  Exit-time windows have
+equal endpoint radii, so these results are the geometric bridge from that analytic calculation to
+the excision identity in `TauCeti.Analysis.Contour.Crossing.Excision`.
+
+## Main definitions and results
+
+* `TauCeti.Contour.crossingCapSweep` — the signed angular sweep of the cap from the incoming chord
+  to the outgoing chord.
+* `TauCeti.Contour.coe_crossingCapSweep_eq_arg_div` — this sweep is the endpoint-chord angle modulo
+  `2π`.
+* `TauCeti.Contour.circleMap_crossingCapSweep_endpoints` — at equal endpoint radii it gives a
+  circular cap with the required endpoints.
+* `TauCeti.Contour.tendsto_crossingCapSweep` — the sweep converges to the negative crossing angle.
+* `TauCeti.Contour.windingNumber_sub_circleCap_eq_crossingAngle_div_two_pi` — the local loop has
+  winding number `crossingAngle / 2π` once the standard per-window principal value is known.
+
+## References
+
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997 (2018), Proposition 2.2.
+-/
+
+public section
+
+noncomputable section
+
+open Filter Set Topology
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {s L_R L_L w_L w_R : ℂ} {t₀ l u : ℝ}
+
+/-- **The signed sweep of the circular cap at a crossing.**  The two argument terms are exactly
+the boundary arguments in the principal value over the crossing window.  Subtracting the crossing
+angle leaves the angle swept from the left endpoint chord `w_L` to the right endpoint chord `w_R`.
+
+For endpoints sufficiently close to the crossing this tends to `-crossingAngle γ t₀`, because the
+cap runs from the reversed incoming ray to the outgoing ray, opposite to the model-sector arc. -/
+def crossingCapSweep (γ : ℝ → ℂ) (t₀ : ℝ) (L_R L_L w_L w_R : ℂ) : ℝ :=
+  ((-L_L) / w_L).arg + (w_R / L_R).arg - crossingAngle γ t₀
+
+/-- **The cap sweep joins the two endpoint directions.**  Modulo `2π`, `crossingCapSweep` is the
+argument of `w_R / w_L`.  This is the exact angle identity: no small-window assumption is needed
+until one wants to select the representative with no extra full turn. -/
+theorem coe_crossingCapSweep_eq_arg_div (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
+    (hw_L : w_L ≠ 0) (hw_R : w_R ≠ 0)
+    (h_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
+    (h_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L)) :
+    (crossingCapSweep γ t₀ L_R L_L w_L w_R : Real.Angle) =
+      ((w_R / w_L).arg : Real.Angle) := by
+  have h := coe_crossingAngle_eq_arg_neg_div_add_arg_div_sub_arg_div
+    hL_L hL_R hw_L hw_R h_R h_L
+  rw [crossingCapSweep, Real.Angle.coe_sub, Real.Angle.coe_add, h]
+  abel
+
+/-- The exponential of the cap sweep is the unit endpoint ratio.  Equal endpoint norms turn this
+into the endpoint ratio itself. -/
+theorem exp_crossingCapSweep_mul_I (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
+    (hw_L : w_L ≠ 0) (hw_R : w_R ≠ 0) (hnorm : ‖w_L‖ = ‖w_R‖)
+    (h_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
+    (h_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L)) :
+    Complex.exp ((crossingCapSweep γ t₀ L_R L_L w_L w_R : ℂ) * Complex.I) = w_R / w_L := by
+  rw [exp_mul_I_congr_angle
+    (coe_crossingCapSweep_eq_arg_div hL_L hL_R hw_L hw_R h_R h_L)]
+  have hratio_norm : ‖w_R / w_L‖ = 1 := by
+    rw [norm_div, ← hnorm, div_self (norm_ne_zero_iff.mpr hw_L)]
+  calc
+    Complex.exp (((w_R / w_L).arg : ℂ) * Complex.I) =
+        (‖w_R / w_L‖ : ℂ) * Complex.exp (((w_R / w_L).arg : ℂ) * Complex.I) := by
+          rw [hratio_norm]
+          simp
+    _ = w_R / w_L := Complex.norm_mul_exp_arg_mul_I _
+
+/-- **The cap has the prescribed endpoints.**  If the endpoint chords have equal norm, the circle
+of that radius about `s`, starting at the principal argument of `w_L` and sweeping through
+`crossingCapSweep`, starts at `s + w_L` and ends at `s + w_R`. -/
+theorem circleMap_crossingCapSweep_endpoints (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
+    (hw_L : w_L ≠ 0) (hw_R : w_R ≠ 0) (hnorm : ‖w_L‖ = ‖w_R‖)
+    (h_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
+    (h_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L)) :
+    circleMap s ‖w_L‖ w_L.arg = s + w_L ∧
+      circleMap s ‖w_L‖
+          (w_L.arg + crossingCapSweep γ t₀ L_R L_L w_L w_R) = s + w_R := by
+  constructor
+  · rw [circleMap, Complex.norm_mul_exp_arg_mul_I]
+  · rw [circleMap, Complex.ofReal_add, add_mul, Complex.exp_add,
+      exp_crossingCapSweep_mul_I hL_L hL_R hw_L hw_R hnorm h_R h_L]
+    have hwL_norm : (‖w_L‖ : ℂ) * Complex.exp ((w_L.arg : ℂ) * Complex.I) = w_L :=
+      Complex.norm_mul_exp_arg_mul_I w_L
+    calc
+      s + (‖w_L‖ : ℂ) *
+          (Complex.exp ((w_L.arg : ℂ) * Complex.I) * (w_R / w_L)) =
+          s + ((‖w_L‖ : ℂ) * Complex.exp ((w_L.arg : ℂ) * Complex.I)) *
+            (w_R / w_L) := by ring
+      _ = s + w_R := by rw [hwL_norm]; field_simp
+
+/-- Along the incoming side of a differentiable crossing, the boundary argument
+`arg (-L / (γ t - s))` tends to `0`.  Multiplication by the positive scalar `t₀ - t` removes the
+blow-up and exposes the limit `1`, without changing the argument. -/
+theorem tendsto_arg_neg_tangent_div_chord_nhdsLT (h_at : γ t₀ = s) (hL : L_L ≠ 0)
+    (h_deriv : HasDerivWithinAt γ L_L (Iio t₀) t₀) :
+    Tendsto (fun t => ((-L_L) / (γ t - s)).arg) (𝓝[<] t₀) (𝓝 0) := by
+  have hq := (chord_quotient_tendsto self_notMem_Iio h_deriv h_at).inv₀ hL
+  have hscaled : Tendsto (fun t => (((t₀ - t : ℝ) : ℂ) * ((-L_L) / (γ t - s))))
+      (𝓝[<] t₀) (𝓝 1) := by
+    convert hq.const_mul L_L using 1
+    · funext t
+      by_cases ht : t = t₀
+      · subst t
+        simp [h_at]
+      · field_simp
+        push_cast
+        ring
+    · field_simp
+  simpa using arg_tendsto_of_pos_mul_tendsto (by simp [Complex.mem_slitPlane_iff])
+    ((show ∀ᶠ t in 𝓝[<] t₀, t ∈ Iio t₀ from self_mem_nhdsWithin).mono
+      fun t ht => sub_pos.mpr ht) hscaled
+
+/-- Along the outgoing side of a differentiable crossing, the boundary argument
+`arg ((γ t - s) / L)` tends to `0`.  Dividing by the positive scalar `t - t₀` exposes the
+nonzero tangent limit and does not change the argument. -/
+theorem tendsto_arg_chord_div_tangent_nhdsGT (h_at : γ t₀ = s) (hL : L_R ≠ 0)
+    (h_deriv : HasDerivWithinAt γ L_R (Ioi t₀) t₀) :
+    Tendsto (fun t => ((γ t - s) / L_R).arg) (𝓝[>] t₀) (𝓝 0) := by
+  have hq := (chord_quotient_tendsto self_notMem_Ioi h_deriv h_at).div_const L_R
+  rw [div_self hL] at hq
+  have hscaled : Tendsto
+      (fun t => ((((t - t₀)⁻¹ : ℝ) : ℂ) * ((γ t - s) / L_R)))
+      (𝓝[>] t₀) (𝓝 1) := by
+    refine hq.congr' ?_
+    filter_upwards [self_mem_nhdsWithin] with t ht
+    have hne : t - t₀ ≠ 0 := sub_ne_zero.mpr ht.ne'
+    push_cast
+    field_simp
+  simpa using arg_tendsto_of_pos_mul_tendsto (by simp [Complex.mem_slitPlane_iff])
+    ((show ∀ᶠ t in 𝓝[>] t₀, t ∈ Ioi t₀ from self_mem_nhdsWithin).mono
+      fun t ht => inv_pos.mpr (sub_pos.mpr ht)) hscaled
+
+/-- **A local cap approaches the reverse model-sector arc.**  As its left and right endpoint
+parameters tend independently to `t₀`, `crossingCapSweep` tends to the negative crossing angle.
+Thus for a small window it chooses the local representative of the endpoint angle, not a cap with
+an additional full turn. -/
+theorem tendsto_crossingCapSweep (h_at : γ t₀ = s) (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0)
+    (h_deriv_L : HasDerivWithinAt γ L_L (Iio t₀) t₀)
+    (h_deriv_R : HasDerivWithinAt γ L_R (Ioi t₀) t₀) :
+    Tendsto (fun p : ℝ × ℝ => crossingCapSweep γ t₀ L_R L_L
+        (γ p.1 - s) (γ p.2 - s))
+      ((𝓝[<] t₀) ×ˢ (𝓝[>] t₀)) (𝓝 (-crossingAngle γ t₀)) := by
+  have hfst : Tendsto (fun p : ℝ × ℝ => p.1) ((𝓝[<] t₀) ×ˢ (𝓝[>] t₀)) (𝓝[<] t₀) :=
+    tendsto_fst
+  have hsnd : Tendsto (fun p : ℝ × ℝ => p.2) ((𝓝[<] t₀) ×ˢ (𝓝[>] t₀)) (𝓝[>] t₀) :=
+    tendsto_snd
+  have hleft := (tendsto_arg_neg_tangent_div_chord_nhdsLT h_at hL_L h_deriv_L).comp hfst
+  have hright := (tendsto_arg_chord_div_tangent_nhdsGT h_at hL_R h_deriv_R).comp hsnd
+  simpa only [crossingCapSweep, Function.comp_apply, zero_add, zero_sub] using
+    (hleft.add hright).sub tendsto_const_nhds
+
+/-- **The local crossing loop contributes exactly the crossing angle.**  Suppose the principal
+value on `[l, u]` is the standard pure-imaginary boundary-argument value
+`i · (arg (-L_L / w_L) + arg (w_R / L_R))`, as happens when the endpoint chords have equal norm.
+The winding number of the crossing window minus that of the circular cap with sweep
+`crossingCapSweep` is then exactly `crossingAngle γ t₀ / 2π`.
+
+Together with `circleMap_crossingCapSweep_endpoints`, this is the one-window local contribution in
+Hungerbühler–Wasem Proposition 2.2. -/
+theorem windingNumber_sub_circleCap_eq_crossingAngle_div_two_pi
+    (hw_L : w_L ≠ 0) (hlu : l ≠ u)
+    (hpv : HasCauchyPVAt γ l u (fun z => (z - s)⁻¹) s
+      (((((-L_L) / w_L).arg + (w_R / L_R).arg : ℝ) : ℂ) * Complex.I)) :
+    windingNumber γ l u s -
+        windingNumber (circleCap s ‖w_L‖ l u w_L.arg
+          (w_L.arg + crossingCapSweep γ t₀ L_R L_L w_L w_R)) l u s
+      = (crossingAngle γ t₀ : ℂ) / (2 * (Real.pi : ℂ)) := by
+  rw [windingNumber_eq_of_hasCauchyPVAt hpv,
+    windingNumber_circleCap (norm_ne_zero_iff.mpr hw_L) hlu w_L.arg
+      (w_L.arg + crossingCapSweep γ t₀ L_R L_L w_L w_R)]
+  simp only [add_sub_cancel_left, crossingCapSweep]
+  have hpi : (Real.pi : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr Real.pi_ne_zero
+  field_simp
+  push_cast
+  ring
+
+end TauCeti.Contour
+
+end
+
+end

--- a/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
@@ -10,7 +10,6 @@ public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.Analysis.Contour.RegularityConditions
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 import Mathlib.Analysis.SpecialFunctions.Complex.Circle
-import Mathlib.Analysis.SpecialFunctions.Complex.Log
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.InvSubCPVExistence
 import TauCeti.Analysis.Contour.PerWindow.CPV

--- a/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
@@ -9,7 +9,7 @@ public import TauCeti.Analysis.Contour.Crossing.Finiteness
 public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.Analysis.Contour.RegularityConditions
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
-import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+import TauCeti.Analysis.Contour.Argument.Lift
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.InvSubCPVExistence
 import TauCeti.Analysis.Contour.PerWindow.CPV
@@ -118,13 +118,7 @@ theorem exp_log_norm_add_arg_eq_mul_exp_crossingAngle {γ : ℝ → ℂ} {t₀ :
     congr 1
     push_cast
     ring
-  have hangle_exp := congrArg (fun z : Circle => (z : ℂ))
-    (congrArg Real.Angle.toCircle hangle)
-  rw [Complex.exp_add, show
-      Complex.exp ((((-L_L) / w_L).arg + (w_R / L_R).arg : ℝ) * Complex.I) =
-        Complex.exp ((crossingAngle γ t₀ + (w_R / w_L).arg : ℝ) * Complex.I) by
-          simpa only [Real.Angle.toCircle_coe, Circle.coe_exp] using hangle_exp,
-    hnorm, hsplit]
+  rw [Complex.exp_add, exp_mul_I_congr_angle hangle, hnorm, hsplit]
   calc ((‖w_R / w_L‖ : ℝ) : ℂ) * (Complex.exp ((crossingAngle γ t₀ : ℂ) * Complex.I) *
         Complex.exp ((((w_R / w_L).arg : ℝ) : ℂ) * Complex.I))
       = (((‖w_R / w_L‖ : ℝ) : ℂ) * Complex.exp ((((w_R / w_L).arg : ℝ) : ℂ) * Complex.I)) *

--- a/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
@@ -10,6 +10,7 @@ public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.Analysis.Contour.RegularityConditions
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 import Mathlib.Analysis.SpecialFunctions.Complex.Log
+import TauCeti.Analysis.Contour.Argument.Lift
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.InvSubCPVExistence
 import TauCeti.Analysis.Contour.PerWindow.CPV
@@ -82,22 +83,6 @@ noncomputable section
 open Filter MeasureTheory Set Topology
 
 namespace TauCeti.Contour
-
-/-- Two reals equal in `Real.Angle` have the same `exp (· * I)`: the multiple of `2π` between
-them is invisible to the complex exponential. -/
-private theorem exp_mul_I_congr_angle {x y : ℝ} (h : (x : Real.Angle) = (y : Real.Angle)) :
-    Complex.exp ((x : ℂ) * Complex.I) = Complex.exp ((y : ℂ) * Complex.I) := by
-  obtain ⟨k, hk⟩ := Real.Angle.angle_eq_iff_two_pi_dvd_sub.mp h
-  have hx : (x : ℂ) = (y : ℂ) + (k : ℂ) * (2 * (Real.pi : ℂ)) := by
-    have hxy : x = y + (k : ℝ) * (2 * Real.pi) := by linarith [hk]
-    rw [hxy]
-    push_cast
-    ring
-  have hk_exp : ((k : ℂ) * (2 * (Real.pi : ℂ))) * Complex.I
-      = (k : ℂ) * (2 * (Real.pi : ℂ) * Complex.I) := by
-    ring
-  rw [hx, add_mul, Complex.exp_add, hk_exp,
-    Complex.exp_int_mul_two_pi_mul_I, mul_one]
 
 /-- **The per-window principal value exponentiates to the chord ratio times the crossing angle.**
 `TauCeti.Contour.perWindow_truncated_integral_tendsto` evaluates the `ε`-truncated integral of

--- a/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
@@ -9,8 +9,8 @@ public import TauCeti.Analysis.Contour.Crossing.Finiteness
 public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.Analysis.Contour.RegularityConditions
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 import Mathlib.Analysis.SpecialFunctions.Complex.Log
-import TauCeti.Analysis.Contour.Argument.Lift
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.InvSubCPVExistence
 import TauCeti.Analysis.Contour.PerWindow.CPV
@@ -119,7 +119,13 @@ theorem exp_log_norm_add_arg_eq_mul_exp_crossingAngle {γ : ℝ → ℂ} {t₀ :
     congr 1
     push_cast
     ring
-  rw [Complex.exp_add, exp_mul_I_congr_angle hangle, hnorm, hsplit]
+  have hangle_exp := congrArg (fun z : Circle => (z : ℂ))
+    (congrArg Real.Angle.toCircle hangle)
+  rw [Complex.exp_add, show
+      Complex.exp ((((-L_L) / w_L).arg + (w_R / L_R).arg : ℝ) * Complex.I) =
+        Complex.exp ((crossingAngle γ t₀ + (w_R / w_L).arg : ℝ) * Complex.I) by
+          simpa only [Real.Angle.toCircle_coe, Circle.coe_exp] using hangle_exp,
+    hnorm, hsplit]
   calc ((‖w_R / w_L‖ : ℝ) : ℂ) * (Complex.exp ((crossingAngle γ t₀ : ℂ) * Complex.I) *
         Complex.exp ((((w_R / w_L).arg : ℝ) : ℂ) * Complex.I))
       = (((‖w_R / w_L‖ : ℝ) : ℂ) * Complex.exp ((((w_R / w_L).arg : ℝ) : ℂ) * Complex.I)) *


### PR DESCRIPTION
This PR identifies the signed circular-cap sweep at a transverse crossing and proves that it joins equal-radius endpoint chords while converging to the reverse model-sector angle. It then computes the local loop—crossing window minus cap—to have generalized winding number exactly `crossingAngle / 2π` whenever the window carries the standard boundary-argument principal value.

This advances ContourIntegration Layer 1, “HW Proposition 2.2 (finite crossings and the winding decomposition),” specifically the remaining identification of each local crossing contribution with `αₗ / 2π`. The new `Crossing/CapAngle.lean` supplies the branch-sensitive angle rather than only an equality modulo `1`: `crossingCapSweep` is congruent to the endpoint-chord angle, gives the required `circleMap` endpoints at equal radii, and tends to `-crossingAngle`, ruling out an unnoticed extra turn as the window shrinks. The final theorem combines that cap value with the explicit per-window PV value to obtain the exact local contribution.

After this PR, Proposition 2.2 still needs the standard per-window PV calculation specialized to an equal-radius exit-time window and the finite iteration of the resulting local excisions.

The generic lemma that equal `Real.Angle` representatives have equal complex exponentials is moved from a private proof in `Winding/CrossingAngleSum.lean` to the argument-lift API and reused by both consumers. The mathematics follows Hungerbühler–Wasem, *Non-integer valued winding numbers and a generalized Residue Theorem*, Proposition 2.2, cited in the module; no Mathlib infrastructure or external formalization is vendored.

Roadmap: ContourIntegration

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"local-crossing-angle"}-->

🤖 Prepared with Codex
