### PR TITLE
feat(Multiquadratic): the 2-rank of Cl(ℚ(√-5)) is 1

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/Basic.lean
@@ -6,7 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.AdjoinRoot
-public import TauCeti.NumberTheory.NumberField.IntegralSqrt
+public import Mathlib.NumberTheory.NumberField.Basic
+import TauCeti.NumberTheory.NumberField.IntegralSqrt
 import Mathlib.FieldTheory.KummerPolynomial
 
 /-!
@@ -30,7 +31,11 @@ open scoped NumberField
 
 namespace TauCeti.NumberField
 
-local instance : Fact (Irreducible (X ^ 2 - C (-5 : ℚ))) := ⟨by
+/-- `X² + 5` is irreducible over `ℚ`, so `AdjoinRoot (X² + 5)` is a field. The instance carries an
+explicit, field-specific name because an anonymous `Fact (Irreducible …)` instance receives an
+auto-generated name that ignores the radicand: the `-5` and `-21` instances would then collide under
+one name when the whole library is loaded for the axioms audit. -/
+instance irreducible_sqrt_neg_five : Fact (Irreducible (X ^ 2 - C (-5 : ℚ))) := ⟨by
   exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
     (fun q _ => by nlinarith [sq_nonneg q])⟩
 
@@ -51,12 +56,8 @@ theorem exists_minpoly_eq_X_sq_add_five_and_adjoin_eq_top :
   refine ⟨integralSqrt hx, minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
       norm_num at hq
       nlinarith [mul_self_nonneg q]), ?_⟩
-  have hfne : (X ^ 2 - C (-5 : ℚ)) ≠ 0 :=
-    (monic_X_pow_sub_C (-5 : ℚ) (by norm_num)).ne_zero
-  have hpb := (AdjoinRoot.powerBasis (f := X ^ 2 - C (-5 : ℚ)) hfne).adjoin_gen_eq_top
-  rw [AdjoinRoot.powerBasis_gen] at hpb
   have hθx : ((integralSqrt hx : 𝓞 K) : K) = x := algebraMap_integralSqrt hx
   rw [hθx]
-  exact hpb
+  exact AdjoinRoot.adjoinRoot_eq_top
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/Basic.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.AdjoinRoot
+public import TauCeti.NumberTheory.NumberField.IntegralSqrt
+import Mathlib.FieldTheory.KummerPolynomial
+
+/-!
+# The `AdjoinRoot (X² + 5)` model of `ℚ(√-5)`
+
+The concrete number field `AdjoinRoot (X² + 5)` serving as the canonical model of `ℚ(√-5)`, together
+with its integral generator. This presentation datum is foundational: it is shared by both the
+class-number and the `2`-rank worked examples for this field, so it lives here rather than in either
+of them.
+
+## Main results
+
+* `TauCeti.NumberField.exists_minpoly_eq_X_sq_add_five_and_adjoin_eq_top`: the model has an
+  integral generator with minimal polynomial `X² + 5` generating the field over `ℚ`.
+-/
+
+public section
+
+open NumberField Polynomial
+open scoped NumberField
+
+namespace TauCeti.NumberField
+
+local instance : Fact (Irreducible (X ^ 2 - C (-5 : ℚ))) := ⟨by
+  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+    (fun q _ => by nlinarith [sq_nonneg q])⟩
+
+/-- The concrete model `AdjoinRoot (X² + 5)` of `ℚ(√-5)` carries an integral generator with minimal
+polynomial `X² + 5` generating the field over `ℚ`: the presentation data shared by the class-number
+and `2`-rank worked examples for this field. -/
+theorem exists_minpoly_eq_X_sq_add_five_and_adjoin_eq_top :
+    ∃ θ : 𝓞 (AdjoinRoot (X ^ 2 - C (-5 : ℚ))),
+      minpoly ℤ θ = X ^ 2 - C (-5 : ℤ) ∧
+        Algebra.adjoin ℚ {(θ : AdjoinRoot (X ^ 2 - C (-5 : ℚ)))} = ⊤ := by
+  let K := AdjoinRoot (X ^ 2 - C (-5 : ℚ))
+  let x : K := AdjoinRoot.root (X ^ 2 - C (-5 : ℚ))
+  have hx : x ^ 2 = algebraMap ℤ K (-5 : ℤ) := by
+    have hroot := AdjoinRoot.eval₂_root (X ^ 2 - C (-5 : ℚ))
+    rw [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C, ← AdjoinRoot.algebraMap_eq, sub_eq_zero] at hroot
+    rw [hroot, IsScalarTower.algebraMap_apply ℤ ℚ K]
+    norm_num
+  refine ⟨integralSqrt hx, minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
+      norm_num at hq
+      nlinarith [mul_self_nonneg q]), ?_⟩
+  have hfne : (X ^ 2 - C (-5 : ℚ)) ≠ 0 :=
+    (monic_X_pow_sub_C (-5 : ℚ) (by norm_num)).ne_zero
+  have hpb := (AdjoinRoot.powerBasis (f := X ^ 2 - C (-5 : ℚ)) hfne).adjoin_gen_eq_top
+  rw [AdjoinRoot.powerBasis_gen] at hpb
+  have hθx : ((integralSqrt hx : 𝓞 K) : K) = x := algebraMap_integralSqrt hx
+  rw [hθx]
+  exact hpb
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.NumberTheory.NumberField.ClassNumber
 public import Mathlib.RingTheory.AdjoinRoot
+import TauCeti.NumberTheory.Multiquadratic.MinusFive.Basic
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 import TauCeti.NumberTheory.NumberField.Quadratic.RingOfIntegers
 import TauCeti.NumberTheory.NumberField.Quadratic.TotalRamification
@@ -274,26 +275,7 @@ has class number `2`. -/
 @[simp]
 theorem classNumber_adjoinRoot_sqrt_neg_five_eq_two :
     NumberField.classNumber (AdjoinRoot (X ^ 2 - C (-5 : ℚ))) = 2 := by
-  let K := AdjoinRoot (X ^ 2 - C (-5 : ℚ))
-  let x : K := AdjoinRoot.root (X ^ 2 - C (-5 : ℚ))
-  have hx : x ^ 2 = algebraMap ℤ K (-5 : ℤ) := by
-    have hroot := AdjoinRoot.eval₂_root (X ^ 2 - C (-5 : ℚ))
-    rw [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C, ← AdjoinRoot.algebraMap_eq, sub_eq_zero] at hroot
-    rw [hroot, IsScalarTower.algebraMap_apply ℤ ℚ K]
-    norm_num
-  let θ : 𝓞 K := integralSqrt hx
-  have hmin : minpoly ℤ θ = X ^ 2 - C (-5 : ℤ) :=
-    minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
-      norm_num at hq
-      nlinarith [mul_self_nonneg q])
-  have hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤ := by
-    have hfne : (X ^ 2 - C (-5 : ℚ)) ≠ 0 :=
-      (monic_X_pow_sub_C (-5 : ℚ) (by norm_num)).ne_zero
-    have hpb := (AdjoinRoot.powerBasis (f := X ^ 2 - C (-5 : ℚ)) hfne).adjoin_gen_eq_top
-    rw [AdjoinRoot.powerBasis_gen] at hpb
-    have hθx : (θ : K) = x := algebraMap_integralSqrt hx
-    rw [hθx]
-    exact hpb
+  obtain ⟨θ, hmin, hgen⟩ := exists_minpoly_eq_X_sq_add_five_and_adjoin_eq_top
   exact classNumber_eq_two_of_minpoly_eq_X_sq_add_five hmin hgen
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
@@ -6,12 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.NumberField.ClassNumber
-public import Mathlib.RingTheory.AdjoinRoot
-import TauCeti.NumberTheory.Multiquadratic.MinusFive.Basic
+public import TauCeti.NumberTheory.Multiquadratic.MinusFive.Basic
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 import TauCeti.NumberTheory.NumberField.Quadratic.RingOfIntegers
 import TauCeti.NumberTheory.NumberField.Quadratic.TotalRamification
-import TauCeti.NumberTheory.NumberField.IntegralSqrt
 import TauCeti.RingTheory.Norm.Quadratic
 
 /-!
@@ -265,10 +263,6 @@ theorem classNumber_eq_two_of_minpoly_eq_X_sq_add_five
     rw [NumberField.classNumber]
     exact Fintype.one_lt_card
   omega
-
-local instance : Fact (Irreducible (X ^ 2 - C (-5 : ℚ))) := ⟨by
-  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
-    (fun q _ => by nlinarith [sq_nonneg q])⟩
 
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 5)`, modelling `ℚ(√-5)`,
 has class number `2`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/TwoRank.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
+import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminants
+import TauCeti.NumberTheory.Multiquadratic.MinusFive.Basic
+
+/-!
+# The `2`-rank of the class group of `ℚ(√-5)`
+
+Applying the genus-theoretic `2`-rank formula `2-rank Cl(K) = t - 1` to `K = ℚ(√-5)`. The
+fundamental discriminant is `-20 = (-4) · 5`, a product of two prime discriminants, so `t = 2`
+rational primes ramify (`2` and `5`) and the `2`-rank of the class group is `1`.
+
+This corroborates the independently proved `NumberField.classNumber ℚ(√-5) = 2`
+(`MinusFive/ClassNumber.lean`): the class group is `ℤ/2ℤ`, whose `2`-rank is indeed `1`, so genus
+theory (predicting `t - 1 = 1` purely from ramification) and the direct class-number computation
+agree.
+
+## Main results
+
+* `TauCeti.Multiquadratic.twoRank_eq_one_of_minpoly_eq_X_sq_add_five`: presentation-independent.
+* `TauCeti.Multiquadratic.twoRank_adjoinRoot_sqrt_neg_five_eq_one`: on the concrete model
+  `AdjoinRoot (X² + 5)`.
+-/
+
+public section
+
+open Polynomial NumberField
+open scoped NumberField
+
+namespace TauCeti.Multiquadratic
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K}
+
+/-- **The `2`-rank of the class group of `ℚ(√-5)` is `1`.** Its fundamental discriminant `-20`
+factors as `(-4) · 5` into two prime discriminants, so two rational primes ramify (`t = 2`) and
+`2-rank Cl = t - 1 = 1`. This corroborates `NumberField.classNumber ℚ(√-5) = 2` (`Cl ≅ ℤ/2ℤ`). -/
+theorem twoRank_eq_one_of_minpoly_eq_X_sq_add_five
+    (hmin : minpoly ℤ θ = X ^ 2 - C (-5 : ℤ)) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    TauCeti.ClassGroup.twoRank (𝓞 K) = 1 := by
+  have hsf : Squarefree (-5 : ℤ) := (Int.prime_iff_natAbs_prime.mpr (by decide)).squarefree
+  have hs : ∀ P ∈ ({-4, 5} : Finset ℤ), IsPrimeDiscriminant P := by
+    intro P hP
+    fin_cases hP
+    · exact isPrimeDiscriminant_neg_four
+    · simpa [oddPrimeDiscriminant_of_mod_four_eq_one (by norm_num : 5 % 4 = 1)]
+        using isPrimeDiscriminant_oddPrimeDiscriminant (p := 5) (by decide) (by decide)
+  have heven : ∀ P ∈ ({-4, 5} : Finset ℤ), ∀ Q ∈ ({-4, 5} : Finset ℤ),
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant Q → P = Q := by
+    intro P hP Q hQ
+    fin_cases hP <;> fin_cases hQ <;> simp only [IsEvenPrimeDiscriminant] <;> decide
+  have hprod : ∏ P ∈ ({-4, 5} : Finset ℤ), P = fundamentalDiscriminant (-5 : ℤ) := by
+    rw [Finset.prod_insert (by decide : (-4 : ℤ) ∉ ({5} : Finset ℤ)), Finset.prod_singleton,
+      fundamentalDiscriminant_of_mod_four_ne_one (by decide : (-5 : ℤ) % 4 ≠ 1)]
+    ring
+  have hncard : (ramifiedPrimes K).ncard = 2 := by
+    rw [ncard_ramifiedPrimes_eq_card hmin hgen hsf hs heven hprod,
+      Finset.card_pair (show (-4 : ℤ) ≠ 5 by decide)]
+  rw [twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf (by norm_num), hncard]
+
+local instance : Fact (Irreducible (X ^ 2 - C (-5 : ℚ))) := ⟨by
+  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+    (fun q _ => by nlinarith [sq_nonneg q])⟩
+
+/-- **Worked example.** The concrete number field `AdjoinRoot (X² + 5)`, modelling `ℚ(√-5)`, has
+class-group `2`-rank `1`. Not `@[simp]`: the `@[simp]` lemma `twoRank_def` unfolds the left-hand
+side `twoRank _`, so this closed form is not in simp-normal form (`simpNF` rejects it), unlike the
+non-unfolded `classNumber` companion. -/
+theorem twoRank_adjoinRoot_sqrt_neg_five_eq_one :
+    TauCeti.ClassGroup.twoRank (𝓞 (AdjoinRoot (X ^ 2 - C (-5 : ℚ)))) = 1 := by
+  obtain ⟨θ, hmin, hgen⟩ := NumberField.exists_minpoly_eq_X_sq_add_five_and_adjoin_eq_top
+  exact twoRank_eq_one_of_minpoly_eq_X_sq_add_five hmin hgen
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/TwoRank.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
+public import TauCeti.NumberTheory.Multiquadratic.MinusFive.Basic
 import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminants
-import TauCeti.NumberTheory.Multiquadratic.MinusFive.Basic
 
 /-!
 # The `2`-rank of the class group of `ℚ(√-5)`
@@ -62,10 +62,6 @@ theorem twoRank_eq_one_of_minpoly_eq_X_sq_add_five
     rw [ncard_ramifiedPrimes_eq_card hmin hgen hsf hs heven hprod,
       Finset.card_pair (show (-4 : ℤ) ≠ 5 by decide)]
   rw [twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf (by norm_num), hncard]
-
-local instance : Fact (Irreducible (X ^ 2 - C (-5 : ℚ))) := ⟨by
-  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
-    (fun q _ => by nlinarith [sq_nonneg q])⟩
 
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 5)`, modelling `ℚ(√-5)`, has
 class-group `2`-rank `1`. Not `@[simp]`: the `@[simp]` lemma `twoRank_def` unfolds the left-hand


### PR DESCRIPTION
The first worked example of the genus-theoretic 2-rank formula `2-rank Cl(K) = t - 1` (`twoRank_eq_ncard_ramifiedPrimes_sub_one`): for `K = ℚ(√-5)`, the fundamental discriminant `-20 = (-4)·5` is a product of two prime discriminants, so `t = 2` rational primes ramify (`2` and `5`) and the class-group 2-rank is `1`.

This **corroborates** the independently proved `NumberField.classNumber ℚ(√-5) = 2` (`MinusFive/ClassNumber.lean`): `Cl ≅ ℤ/2ℤ` has 2-rank exactly `1`, so genus theory (predicting `t - 1 = 1` purely from ramification) and the direct class-number computation agree.

**Refactor.** The shared `AdjoinRoot (X²+5)` integral generator (`exists_minpoly_eq_X_sq_add_five_and_adjoin_eq_top`) is extracted into a new foundational `MinusFive/Basic.lean`, imported by both `ClassNumber.lean` and the new `TwoRank.lean`.

Resubmission of #4223, whose all-green content could not be merged because GitHub's mergeability computation for that PR was stuck at `null` (`mergeable_state: unknown`) across reruns; this is a clean branch off current `main`.

**Roadmap node.** `TauCetiRoadmap/Multiquadratic/README.md`, heading *### Layer 3: the genus field and the 2-rank theorem (the summit)*, "Worked examples" — ℚ(√-5) (discriminant -20). First application of the merged 2-rank theorem to a specific field. No new axioms.

Roadmap: Multiquadratic
