### PR TITLE
feat(EllipticCurve): 8y is integral where ψ₂ vanishes and 4x is

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -12,7 +12,7 @@ public import TauCeti.RingTheory.Polynomial.IsIntegral
 # Integrality of points on a Weierstrass curve over a unique factorization domain
 
 Let `R` be a unique factorization domain with fraction field `K` and let `W : WeierstrassCurve R`
-have coefficients in `R`. This file gives the two integrality steps of the Nagell–Lutz argument
+have coefficients in `R`. This file gives the three integrality steps of the Nagell–Lutz argument
 that do not mention torsion.
 
 The first is the rational-root step. If the `x`-coordinate of a `K`-point is a root of some
@@ -28,6 +28,12 @@ the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)` o
 arbitrary `R`-algebra, with the `IsLocalization.IsInteger` form as a corollary over any commutative
 `R`-algebra in which `R` is integrally closed.
 
+The third is the scaling that replaces integrality in the **order-two case**, the one case of
+Nagell–Lutz where the conclusion is weaker. Where the `Y`-derivative of the Weierstrass polynomial
+vanishes — `2y + a₁x + a₃ = 0`, which is what the division-polynomial API calls `ψ₂ = 0` — a bound
+`4x ∈ R` scales to `8y ∈ R`. Like the second step this needs no domain, fraction field or
+factorisation, only an `R`-algebra.
+
 ## Main results
 
 * `TauCeti.WeierstrassCurve.isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff`: the
@@ -38,11 +44,11 @@ arbitrary `R`-algebra, with the `IsLocalization.IsInteger` form as a corollary o
 * `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x`: its `IsLocalization.IsInteger`
   corollary over any commutative `R`-algebra in which `R` is integrally closed, the shape the
   Nagell–Lutz argument consumes.
-* `WeierstrassCurve.isInteger_eight_mul_y_of_ψ₂_eq_zero`: the third step, for the one point where
-  the first two do not apply. Where `ψ₂` vanishes — `2y + a₁x + a₃ = 0` — a bound `4x ∈ R` scales to
-  `8y ∈ R`. It is in the root `WeierstrassCurve` namespace, where `W.isInteger_eight_mul_y_…`
-  elaborates; the declarations above predate that convention and `scripts/lint-dot-notation.py`
-  carries them as grandfathered entries.
+* `WeierstrassCurve.isInteger_eight_mul_y_of_evalEval_polynomialY_eq_zero`: the third step, for the
+  **order-two case**, where the first two do not give integrality of `y`. It is in the root
+  `WeierstrassCurve` namespace, where `W.isInteger_eight_mul_y_…` elaborates; the declarations
+  above predate that convention and `scripts/lint-dot-notation.py` carries them as grandfathered
+  entries.
 
 All three are stated for an arbitrary point: no torsion, ellipticity or minimality hypothesis. In
 the Nagell–Lutz argument the polynomial `f` is a division polynomial, whose leading coefficient is
@@ -59,15 +65,15 @@ that roadmap at `dev/modular-curves @ 9fec8eba7652`:
 `isInteger_of_root_squarefree_leading_coeff` and `y_isInteger_of_x_isInteger_on_curve`. The latter
 is generalised here from the fraction field to an arbitrary `R`-algebra.
 
-`isInteger_eight_mul_y_of_ψ₂_eq_zero` is the `y` half of `bounded_den_of_order_two_general`
-(`LutzNagell/LutzNagellTheorem/GeneralPrimeOrder.lean:176` at
+`isInteger_eight_mul_y_of_evalEval_polynomialY_eq_zero` is the `y` half of
+`bounded_den_of_order_two_general` (`LutzNagell/LutzNagellTheorem/GeneralPrimeOrder.lean:176` at
 `main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), which states both halves together over `ℚ`/`ℤ`
 as `(∃ n : ℤ, (n : ℚ) = 4 * x) ∧ ∃ m : ℤ, (m : ℚ) = 8 * y` for a point of order two. Two departures:
 the conclusion is `IsLocalization.IsInteger` over general `R`/`K`, so the source's
 `isInteger_int_iff` bridge is not needed; and the two-torsion hypothesis is weakened to the
-vanishing of `ψ₂`, which is
-what the `y` half actually uses and which makes the statement independent of the point-level
-`[n]`-multiplication development. The `x` half is separately the merged `den_dvd_four_of_order_two`.
+vanishing of `polynomialY`, which is what the `y` half actually uses and which makes the statement
+independent of the point-level `[n]`-multiplication development. The `x` half is separately the
+merged `den_dvd_four_of_order_two`.
 -/
 
 public section
@@ -153,22 +159,26 @@ namespace WeierstrassCurve
 variable {R : Type*} [CommRing R] {K : Type*} [CommRing K] [Algebra R K]
 variable (W : WeierstrassCurve R) {x y : K}
 
-/-- **Where `ψ₂` vanishes, a bound on `x` scales to one on `y`**: if `2y + a₁x + a₃ = 0` and `4x`
-is integral, then `8y` is integral.
+/-- **Where the `Y`-derivative vanishes, a bound on `x` scales to one on `y`**: if
+`polynomialY` vanishes at `(x, y)` and `4x` is integral, then `8y` is integral.
 
-This is the `y` half of the order-two exception in Nagell–Lutz — the one case where a torsion point
-need not have integral coordinates at all, and where `8y` rather than `y` is what lies in `R`. It is
-stated for the vanishing of `ψ₂` rather than for two-torsion, which is strictly more general and
-needs no field, no fraction ring and no point of the curve: a point of order two satisfies the
-hypothesis, but so does any `(x, y)` at which the `2`-division polynomial vanishes. -/
-theorem isInteger_eight_mul_y_of_ψ₂_eq_zero
-    (hψ : 2 * y + algebraMap R K W.a₁ * x + algebraMap R K W.a₃ = 0)
+This is the `y` half of the order-two exception in Nagell–Lutz — the case where a torsion point
+need not have integral coordinates at all, and where `8y` rather than `y` is what lies in `R`.
+`polynomialY` is `∂/∂Y` of the Weierstrass polynomial, evaluating to `2y + a₁x + a₃`, and is what
+the division-polynomial API calls `ψ₂`. Taking its vanishing as the hypothesis is strictly weaker
+than two-torsion and needs no field, no fraction ring and no `Nonsingular`: a point of order two
+satisfies it, and so does any pair at which `ψ₂` happens to vanish. -/
+theorem isInteger_eight_mul_y_of_evalEval_polynomialY_eq_zero
+    (hy : (W.baseChange K).toAffine.polynomialY.evalEval x y = 0)
     (hx : IsLocalization.IsInteger R (4 * x)) : IsLocalization.IsInteger R (8 * y) := by
-  -- Scaling `ψ₂ = 0` by `4` gives `8y = -(a₁ · 4x + 4a₃)`, whose right-hand side is integral
-  -- because `4x` is; `y` itself need not be.
+  -- Evaluated, the hypothesis is `2y + a₁x + a₃ = 0`; scaling by `4` gives `8y = -(a₁ · 4x + 4a₃)`,
+  -- whose right-hand side is integral because `4x` is. `y` itself need not be.
+  rw [_root_.WeierstrassCurve.Affine.evalEval_polynomialY] at hy
+  simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_a₁,
+    _root_.WeierstrassCurve.map_a₃] at hy
   obtain ⟨c, hc⟩ := hx
   refine ⟨-(W.a₁ * c + 4 * W.a₃), ?_⟩
   simp only [map_neg, map_add, map_mul, map_ofNat, hc]
-  linear_combination (-4) * hψ
+  linear_combination (-4) * hy
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -38,10 +38,15 @@ arbitrary `R`-algebra, with the `IsLocalization.IsInteger` form as a corollary o
 * `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x`: its `IsLocalization.IsInteger`
   corollary over any commutative `R`-algebra in which `R` is integrally closed, the shape the
   Nagell–Lutz argument consumes.
+* `WeierstrassCurve.isInteger_eight_mul_y_of_ψ₂_eq_zero`: the third step, for the one point where
+  the first two do not apply. Where `ψ₂` vanishes — `2y + a₁x + a₃ = 0` — a bound `4x ∈ R` scales to
+  `8y ∈ R`. It is in the root `WeierstrassCurve` namespace, where `W.isInteger_eight_mul_y_…`
+  elaborates; the declarations above predate that convention and `scripts/lint-dot-notation.py`
+  carries them as grandfathered entries.
 
-Both are stated for an arbitrary point: no torsion, ellipticity or minimality hypothesis. In the
-Nagell–Lutz argument the polynomial `f` is a division polynomial, whose leading coefficient is the
-order of the torsion point.
+All three are stated for an arbitrary point: no torsion, ellipticity or minimality hypothesis. In
+the Nagell–Lutz argument the polynomial `f` is a division polynomial, whose leading coefficient is
+the order of the torsion point, and `ψ₂` vanishes exactly at the points of order two.
 
 This advances the Nagell–Lutz integrality milestone of
 `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz".
@@ -53,6 +58,16 @@ that roadmap at `dev/modular-curves @ 9fec8eba7652`:
 `LutzNagell/LutzNagellTheorem/PIDPrimeOrder.lean`, declarations
 `isInteger_of_root_squarefree_leading_coeff` and `y_isInteger_of_x_isInteger_on_curve`. The latter
 is generalised here from the fraction field to an arbitrary `R`-algebra.
+
+`isInteger_eight_mul_y_of_ψ₂_eq_zero` is the `y` half of `bounded_den_of_order_two_general`
+(`LutzNagell/LutzNagellTheorem/GeneralPrimeOrder.lean:176` at
+`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), which states both halves together over `ℚ`/`ℤ`
+as `(∃ n : ℤ, (n : ℚ) = 4 * x) ∧ ∃ m : ℤ, (m : ℚ) = 8 * y` for a point of order two. Two departures:
+the conclusion is `IsLocalization.IsInteger` over general `R`/`K`, so the source's
+`isInteger_int_iff` bridge is not needed; and the two-torsion hypothesis is weakened to the
+vanishing of `ψ₂`, which is
+what the `y` half actually uses and which makes the statement independent of the point-level
+`[n]`-multiplication development. The `x` half is separately the merged `den_dvd_four_of_order_two`.
 -/
 
 public section
@@ -132,3 +147,28 @@ end IntegrallyClosedIn
 end WeierstrassCurve
 
 end TauCeti
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] {K : Type*} [CommRing K] [Algebra R K]
+variable (W : WeierstrassCurve R) {x y : K}
+
+/-- **Where `ψ₂` vanishes, a bound on `x` scales to one on `y`**: if `2y + a₁x + a₃ = 0` and `4x`
+is integral, then `8y` is integral.
+
+This is the `y` half of the order-two exception in Nagell–Lutz — the one case where a torsion point
+need not have integral coordinates at all, and where `8y` rather than `y` is what lies in `R`. It is
+stated for the vanishing of `ψ₂` rather than for two-torsion, which is strictly more general and
+needs no field, no fraction ring and no point of the curve: a point of order two satisfies the
+hypothesis, but so does any `(x, y)` at which the `2`-division polynomial vanishes. -/
+theorem isInteger_eight_mul_y_of_ψ₂_eq_zero
+    (hψ : 2 * y + algebraMap R K W.a₁ * x + algebraMap R K W.a₃ = 0)
+    (hx : IsLocalization.IsInteger R (4 * x)) : IsLocalization.IsInteger R (8 * y) := by
+  -- Scaling `ψ₂ = 0` by `4` gives `8y = -(a₁ · 4x + 4a₃)`, whose right-hand side is integral
+  -- because `4x` is; `y` itself need not be.
+  obtain ⟨c, hc⟩ := hx
+  refine ⟨-(W.a₁ * c + 4 * W.a₃), ?_⟩
+  simp only [map_neg, map_add, map_mul, map_ofNat, hc]
+  linear_combination (-4) * hψ
+
+end WeierstrassCurve


### PR DESCRIPTION
**Rebuilt from scratch on `main`. One declaration, one file, `+43 −3`.** The previous head carried
four files and 33 new declarations; this one carries this:

```lean
theorem WeierstrassCurve.isInteger_eight_mul_y_of_ψ₂_eq_zero (W : WeierstrassCurve R) {x y : K}
    (hψ : 2 * y + algebraMap R K W.a₁ * x + algebraMap R K W.a₃ = 0)
    (hx : IsLocalization.IsInteger R (4 * x)) : IsLocalization.IsInteger R (8 * y)
```

The `y` half of the order-two exception in Nagell–Lutz: the one case where a torsion point need not
have integral coordinates, and where `8y` rather than `y` is what lies in `R`.

## What the two findings asked for, and what happened

**`scope` (block)** — *"the PR combines it with substantial prerequisite and separate torsion work
that must be split."* Correct, and the split is now complete rather than promised. The old head was
not stacked on #4084; it re-added #4084's development from an independent base, so its diff against
`main` carried the whole scalar-multiplication layer.

**`reuse` (changes requested)** — *"The composite order-two theorem duplicates the newly provided
component API and has no consumers."* `isInteger_four_mul_x_and_eight_mul_y_of_order_two` is
deleted. The same finding was taken on #4084 in an earlier round for the same reason.

## Declaration-set accounting for the rewrite

Measured, not asserted: the old head `a52355be0` added **33** declarations against its merge-base;
this head adds **1**. Every one of the 33 is accounted for.

| dropped | where it is now |
|---|---|
| 30 declarations (`Torsion.lean`, `ZSMul.lean`, `Universal.lean`) | **#4084** — present at its head `a3777e81a`, board 10/10, merge queue position 37 |
| `isInteger_mul_of_den_dvd` | **#4261**, renamed `IsFractionRing.isInteger_mul_of_den_dvd` and moved to `RingTheory/Localization/DenIdeal.lean` (`DenIdeal.lean:89` at head `cce19f4e1`) |
| `isInteger_four_mul_x_and_eight_mul_y_of_order_two` | **deleted**, per the `reuse` finding |
| `isInteger_eight_mul_y_of_order_two` | **superseded** by the declaration above |

Nothing is lost. The name comparison is by declaration name across the union of both heads' touched
files, which is why the `IsFractionRing.` rename shows as "elsewhere" rather than as a match — the
check reports it explicitly rather than silently.

## The generalisation, which is what unblocks this

The old statement took `(2 : ℤ) • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns) = 0` — a
two-torsion hypothesis — and so needed `evalEval_ψ_eq_zero_of_zsmul_eq_zero` (#4040), `Torsion.lean`
(#4084) and the `baseChange`/`Nonsingular` plumbing that comes with them. All of that is in the
merge queue, and none of it is used by the mathematics.

What the proof actually uses is the **vanishing of `ψ₂`**: from `2y + a₁x + a₃ = 0`, scaling by `4`
gives `8y = -(a₁ · 4x + 4a₃)`, and the right-hand side is integral because `4x` is. So the
hypothesis is now that equation. The result is strictly stronger — it holds at any point where the
`2`-division polynomial vanishes, on any commutative `R`-algebra `K`, with no field, no fraction
ring, no nonsingularity and no point of the curve — and it depends on nothing outside `main`.

A caller with a two-torsion point discharges the hypothesis in three lines, exactly as the old proof
opened: `evalEval_ψ_eq_zero_of_zsmul_eq_zero`, then `ψ_two`, `ψ₂`, `Affine.evalEval_polynomialY`,
then the `baseChange` coefficient `simp`. That is #4040's material and stays on #4040's side of the
split.

## Namespace

Root `WeierstrassCurve`, not `TauCeti.WeierstrassCurve` like the rest of the file. This is forced:
`scripts/lint-dot-notation.py` reports a **new** violation for any fresh declaration in a Mathlib
type's namespace nested under `TauCeti`, because `W.isInteger_eight_mul_y_of_ψ₂_eq_zero` cannot
elaborate there. Measured both ways on this branch — `1154 total, 1293 grandfathered, 1 new` in
`TauCeti.WeierstrassCurve`, and `0 new` in the root namespace. #4084's `Torsion.lean` makes the same
call. The file's existing declarations are grandfathered baseline entries, not a precedent to copy,
and the module docstring now says so.

## Gates

All three, against pin `e310d5e` matching `main`:

- `lake build` — `BUILD_EXIT=0`, zero `error` and zero `warning` lines in the whole log. (One
  intermediate failure worth recording: the style linter rejected a 102-codepoint docstring line as
  an **error**, and that in turn made `lint-env.sh` report a driver failure rather than a lint
  result — a broken build makes gate 2 uninformative, not green.)
- `scripts/lint-env.sh` — PASS, 64 grandfathered / 6 ratchetable, unchanged.
- `scripts/lint-dot-notation.py` — `EXIT=0`, `0 new`.

Line width re-measured in codepoints rather than bytes: widest line 100.

`/cleanup` on `Integrality.lean`: per-declaration pass on the added theorem; dead-binding check
clean (`c` and `hc` both feed the witness and the `simp only`); docstring states the result with the
scaling mechanics in a `--` comment; module docstring's *Main results*, the "all three are stated
for an arbitrary point" paragraph and the provenance section all extended so none of them describes
only the two older declarations. `/buzz` **skipped** — one 4-line proof, no elaboration cost to
profile. `/decompose-proof` **n/a** — 4 lines against a 30-line flag. No other file touched.

Roadmap: EllipticCurves

New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821`–`:830`, "**The torsion subgroup and
Nagell–Lutz**", which names this bound verbatim at `:826` — "a nonzero torsion point has `x, y ∈ ℤ`
unless it has order exactly `2`, where the honest bound is `4x, 8y ∈ ℤ`".

Provenance: `github.com/CBirkbeck/AINTLIB`, Apache-2.0,
`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`,
`projects/NagellLutz/LutzNagell/LutzNagellTheorem/GeneralPrimeOrder.lean`,
`bounded_den_of_order_two_general` (`:176`). Stated there over `ℚ`/`ℤ` as
`(∃ n : ℤ, (n : ℚ) = 4 * x) ∧ ∃ m : ℤ, (m : ℚ) = 8 * y` for a point of order two. Two departures,
both recorded in the module docstring: the conclusion is `IsLocalization.IsInteger` over general
`R`/`K`, so the source's `isInteger_int_iff` bridge is not ported; and the two-torsion hypothesis is
weakened to the vanishing of `ψ₂`. The `x` half is the merged `den_dvd_four_of_order_two`, so only
the `y` half is here.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"nagell-lutz-order-two-bound"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
