### PR TITLE
feat: existence of the Levi-Civita connection

### DIFF
--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Basic.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Basic.lean
@@ -51,7 +51,7 @@ endomorphism-valued one-form `CovariantDerivative.difference ∇ ∇'` vanishes.
 * `TauCeti.Manifold.koszul_sub_koszul_swap_first_two` and
   `TauCeti.Manifold.koszul_add_koszul_swap_last_two`: the two symmetries of the Koszul expression
   from which the converse direction is read off.
-* `TauCeti.Manifold.tensorialAt_koszul` and `TauCeti.Manifold.tensorialAt_koszul_first`: the
+* `TauCeti.Manifold.tensorialAt_koszul_third` and `TauCeti.Manifold.tensorialAt_koszul_first`: the
   Koszul expression is tensorial in its last argument and in its first.
 * `TauCeti.Manifold.koszul_add_second` and `TauCeti.Manifold.koszul_smul_second`: additivity and
   the Leibniz rule in the middle argument, the slot which the connection differentiates.
@@ -62,6 +62,8 @@ endomorphism-valued one-form `CovariantDerivative.difference ∇ ∇'` vanishes.
 
 * [Geodesics, the exponential map, and the Hopf–Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
   Layer 1, "The Levi-Civita connection".
+* [mathlib4#36845](https://github.com/leanprover-community/mathlib4/pull/36845): the first-slot
+  tensoriality and second-slot Leibniz identities follow its design.
 * M. P. do Carmo, *Riemannian Geometry*, Birkhäuser, 1992, Ch. 2, Thm. 3.6.
 * J. M. Lee, *Introduction to Riemannian Manifolds*, GTM 176, 2018, Thm. 5.10.
 -/
@@ -84,7 +86,8 @@ variable
 
 section Nondegenerate
 
-variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+variable {F F' : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+  [NormedAddCommGroup F'] [NormedSpace ℝ F']
   {V : M → Type*} [TopologicalSpace (TotalSpace F V)]
   [∀ x, NormedAddCommGroup (V x)] [∀ x, InnerProductSpace ℝ (V x)] [FiberBundle F V]
 
@@ -96,6 +99,19 @@ theorem eq_of_forall_inner_section_eq {x : M} {u v : V x}
     (h : ∀ τ : Π y : M, V y, MDiffAt (T% τ) x → inner ℝ u (τ x) = inner ℝ v (τ x)) : u = v := by
   refine ext_inner_right ℝ fun w ↦ ?_
   simpa using h (extend F w) (mdifferentiableAt_extend I F w)
+
+variable {V' : M → Type*} [TopologicalSpace (TotalSpace F' V')]
+  [∀ x, NormedAddCommGroup (V' x)] [∀ x, NormedSpace ℝ (V' x)] [FiberBundle F' V']
+
+variable (F F') in
+/-- Two continuous linear maps between fibres are equal if their values on differentiable sections
+have the same inner products against every differentiable section of the target bundle. -/
+theorem continuousLinearMap_ext_of_forall_inner_section_eq {x : M} {A B : V' x →L[ℝ] V x}
+    (h : ∀ σ : ∀ y : M, V' y, MDiffAt (T% σ) x → ∀ τ : ∀ y : M, V y,
+      MDiffAt (T% τ) x → inner ℝ (A (σ x)) (τ x) = inner ℝ (B (σ x)) (τ x)) : A = B := by
+  refine VectorBundle.injective_eval_mdifferentiableAt_sec I F' V' (V x) x ?_
+  ext σ hσ
+  exact eq_of_forall_inner_section_eq (I := I) (V := V) F fun τ hτ ↦ h σ hσ τ hτ
 
 end Nondegenerate
 
@@ -180,39 +196,6 @@ out in `TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita.Ex
 
 variable {X' Y' : Π x : M, TangentSpace I x} {f : M → ℝ}
 
-/-- The Koszul expression is additive in its first argument. -/
-theorem koszul_add_first (hX : MDiffAt (T% X) x) (hX' : MDiffAt (T% X') x)
-    (hY : MDiffAt (T% Y) x) (hZ : MDiffAt (T% Z) x) :
-    koszul I (X + X') Y Z x = koszul I X Y Z x + koszul I X' Y Z x := by
-  have e₁ : (fun y ↦ inner ℝ (Z y) ((X + X') y)) =
-      fun y ↦ inner ℝ (Z y) (X y) + inner ℝ (Z y) (X' y) := funext fun _ ↦ inner_add_right ..
-  have e₂ : (fun y ↦ inner ℝ ((X + X') y) (Y y)) =
-      fun y ↦ inner ℝ (X y) (Y y) + inner ℝ (X' y) (Y y) := funext fun _ ↦ inner_add_left ..
-  have e₃ : (X + X') x = X x + X' x := rfl
-  rw [koszul, koszul, koszul, e₁, e₂, e₃,
-    mvfderiv_fun_add (mdifferentiableAt_inner hZ hX) (mdifferentiableAt_inner hZ hX'),
-    mvfderiv_fun_add (mdifferentiableAt_inner hX hY) (mdifferentiableAt_inner hX' hY),
-    mlieBracket_add_left hX hX', mlieBracket_add_left (W := Z) hX hX']
-  simp only [add_apply, map_add, inner_add_left, inner_add_right]
-  ring
-
-/-- The Koszul expression is tensorial in its first argument: replacing `X` by `f • X` multiplies
-it by `f x`. The four terms carrying a derivative of `f` cancel in pairs. -/
-theorem koszul_smul_first (hf : MDiffAt f x) (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
-    (hZ : MDiffAt (T% Z) x) : koszul I (f • X) Y Z x = f x * koszul I X Y Z x := by
-  have e₁ : (fun y ↦ inner ℝ (Z y) ((f • X) y)) = fun y ↦ f y * inner ℝ (Z y) (X y) :=
-    funext fun _ ↦ real_inner_smul_right ..
-  have e₂ : (fun y ↦ inner ℝ ((f • X) y) (Y y)) = fun y ↦ f y * inner ℝ (X y) (Y y) :=
-    funext fun _ ↦ real_inner_smul_left ..
-  have e₃ : (f • X) x = f x • X x := rfl
-  rw [koszul, koszul, e₁, e₂, e₃, mvfderiv_fun_mul hf (mdifferentiableAt_inner hZ hX),
-    mvfderiv_fun_mul hf (mdifferentiableAt_inner hX hY),
-    mlieBracket_smul_left hf hX, mlieBracket_smul_left (W := Z) hf hX]
-  simp only [add_apply, smul_apply, smul_eq_mul, map_smul, inner_add_left, neg_smul,
-    inner_neg_left, real_inner_smul_left, real_inner_smul_right]
-  rw [real_inner_comm (Z x) (X x)]
-  ring
-
 /-- The Koszul expression is additive in its second argument. -/
 theorem koszul_add_second (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
     (hY' : MDiffAt (T% Y') x) (hZ : MDiffAt (T% Z) x) :
@@ -249,9 +232,37 @@ theorem koszul_smul_second (hf : MDiffAt f x) (hX : MDiffAt (T% X) x) (hY : MDif
   rw [real_inner_comm (Y x) (X x)]
   ring
 
+/-- The Koszul expression is additive in its first argument. -/
+theorem koszul_add_first (hX : MDiffAt (T% X) x) (hX' : MDiffAt (T% X') x)
+    (hY : MDiffAt (T% Y) x) (hZ : MDiffAt (T% Z) x) :
+    koszul I (X + X') Y Z x = koszul I X Y Z x + koszul I X' Y Z x := by
+  have hsum := koszul_add_second (I := I) (X := Y) (Y := X) (Y' := X') (Z := Z)
+    hY hX hX' hZ
+  have hswap := koszul_sub_koszul_swap_first_two
+    (I := I) (X := X + X') (Y := Y) (Z := Z) (x := x)
+  have hswapX := koszul_sub_koszul_swap_first_two
+    (I := I) (X := X) (Y := Y) (Z := Z) (x := x)
+  have hswapX' := koszul_sub_koszul_swap_first_two
+    (I := I) (X := X') (Y := Y) (Z := Z) (x := x)
+  rw [mlieBracket_add_left hX hX', inner_add_left] at hswap
+  linarith
+
+/-- The Koszul expression is tensorial in its first argument: replacing `X` by `f • X` multiplies
+it by `f x`. This follows from the second-slot Leibniz rule and the swap identity. -/
+theorem koszul_smul_first (hf : MDiffAt f x) (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
+    (hZ : MDiffAt (T% Z) x) : koszul I (f • X) Y Z x = f x * koszul I X Y Z x := by
+  have hsmul := koszul_smul_second (I := I) (X := Y) (Y := X) (Z := Z) hf hY hX hZ
+  have hswap := koszul_sub_koszul_swap_first_two
+    (I := I) (X := f • X) (Y := Y) (Z := Z) (x := x)
+  have hswapX := koszul_sub_koszul_swap_first_two
+    (I := I) (X := X) (Y := Y) (Z := Z) (x := x)
+  rw [mlieBracket_smul_left hf hX] at hswap
+  simp only [inner_add_left, neg_smul, inner_neg_left, real_inner_smul_left] at hswap
+  linear_combination hswap + hsmul - f x * hswapX
+
 /-- The Koszul expression is tensorial in its first argument. Together with
-`TauCeti.Manifold.tensorialAt_koszul` this presents it as a continuous bilinear form on the tangent
-fibre, which is the shape in which the Levi-Civita connection gets built. -/
+`TauCeti.Manifold.tensorialAt_koszul_third` this presents it as a continuous bilinear form on the
+tangent fibre, which is the shape in which the Levi-Civita connection gets built. -/
 theorem tensorialAt_koszul_first (hY : MDiffAt (T% Y) x) (hZ : MDiffAt (T% Z) x) :
     TensorialAt I E (fun X : Π y : M, TangentSpace I y ↦ koszul I X Y Z x) x where
   smul hf hX := by simpa using koszul_smul_first hf hX hY hZ
@@ -261,7 +272,7 @@ theorem tensorialAt_koszul_first (hY : MDiffAt (T% Y) x) (hZ : MDiffAt (T% Z) x)
 it by `f x`, and it is additive in `Z`. Together with
 `CovariantDerivative.isLeviCivita_iff` this is what turns the Koszul formula from a
 characterisation of the Levi-Civita connection into a construction of it. -/
-theorem tensorialAt_koszul (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x) :
+theorem tensorialAt_koszul_third (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x) :
     TensorialAt I E (fun Z : Π y : M, TangentSpace I y ↦ koszul I X Y Z x) x where
   smul {f Z} hf hZ := by
     have e₁ : (fun y ↦ inner ℝ (Y y) ((f • Z) y)) = fun y ↦ f y * inner ℝ (Y y) (Z y) :=
@@ -383,11 +394,8 @@ theorem isLeviCivita_iff :
 section that is differentiable at the point under consideration. -/
 theorem IsLeviCivita.unique (h : IsLeviCivita cov) (h' : IsLeviCivita cov')
     (hY : MDiffAt (T% Y) x) : cov Y x = cov' Y x := by
-  refine VectorBundle.injective_eval_mdifferentiableAt_sec I E (fun x : M ↦ TangentSpace I x)
-    (TangentSpace I x) x ?_
-  ext X hX
-  refine TauCeti.eq_of_forall_inner_section_eq (I := I) (V := fun x : M ↦ TangentSpace I x) E
-    fun Z hZ ↦ ?_
+  refine TauCeti.continuousLinearMap_ext_of_forall_inner_section_eq (I := I)
+    (V := fun x : M ↦ TangentSpace I x) E E fun _ hX _ hZ ↦ ?_
   have h1 := h.two_inner_eq_koszul hX hY hZ
   have h2 := h'.two_inner_eq_koszul hX hY hZ
   linarith

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Basic.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Basic.lean
@@ -26,7 +26,9 @@ tensorial repackaging is `IsLeviCivita.difference_eq_zero`. The converse directi
 `isLeviCivita_iff` shows nothing is lost in the passage to `koszul`: a connection satisfying the
 Koszul formula is automatically torsion free and metric. Since `koszul I X Y · x` is moreover
 tensorial in its last slot, the Koszul formula is also the shape in which the Levi-Civita
-connection gets constructed; existence is left to a later file.
+connection gets constructed; that construction, together with the tensoriality in the first slot
+and the Leibniz rule in the second which it needs, is carried out in
+`TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita.Existence`.
 
 Two covariant derivatives can only be compared through sections that are differentiable at the
 point under consideration, because `CovariantDerivative` puts no constraint whatsoever on the
@@ -49,8 +51,10 @@ endomorphism-valued one-form `CovariantDerivative.difference ∇ ∇'` vanishes.
 * `TauCeti.Manifold.koszul_sub_koszul_swap_first_two` and
   `TauCeti.Manifold.koszul_add_koszul_swap_last_two`: the two symmetries of the Koszul expression
   from which the converse direction is read off.
-* `TauCeti.Manifold.tensorialAt_koszul`: the Koszul expression is tensorial in its last
-  argument.
+* `TauCeti.Manifold.tensorialAt_koszul` and `TauCeti.Manifold.tensorialAt_koszul_first`: the
+  Koszul expression is tensorial in its last argument and in its first.
+* `TauCeti.Manifold.koszul_add_second` and `TauCeti.Manifold.koszul_smul_second`: additivity and
+  the Leibniz rule in the middle argument, the slot which the connection differentiates.
 * `TauCeti.eq_of_forall_inner_section_eq`: a vector in a fibre of a Riemannian bundle is
   determined by its inner products against the differentiable sections.
 
@@ -165,6 +169,93 @@ section Tensorial
 
 variable [IsManifold I 2 M] [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
   [CompleteSpace E]
+
+/-! ### Behaviour in the first two arguments
+
+The Koszul expression is tensorial in its first argument, just as it is in its third, and obeys a
+Leibniz rule in its second. These are the identities which turn
+`CovariantDerivative.isLeviCivita_iff` into a construction of the Levi-Civita connection, carried
+out in `TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita.Existence`.
+-/
+
+variable {X' Y' : Π x : M, TangentSpace I x} {f : M → ℝ}
+
+/-- The Koszul expression is additive in its first argument. -/
+theorem koszul_add_first (hX : MDiffAt (T% X) x) (hX' : MDiffAt (T% X') x)
+    (hY : MDiffAt (T% Y) x) (hZ : MDiffAt (T% Z) x) :
+    koszul I (X + X') Y Z x = koszul I X Y Z x + koszul I X' Y Z x := by
+  have e₁ : (fun y ↦ inner ℝ (Z y) ((X + X') y)) =
+      fun y ↦ inner ℝ (Z y) (X y) + inner ℝ (Z y) (X' y) := funext fun _ ↦ inner_add_right ..
+  have e₂ : (fun y ↦ inner ℝ ((X + X') y) (Y y)) =
+      fun y ↦ inner ℝ (X y) (Y y) + inner ℝ (X' y) (Y y) := funext fun _ ↦ inner_add_left ..
+  have e₃ : (X + X') x = X x + X' x := rfl
+  rw [koszul, koszul, koszul, e₁, e₂, e₃,
+    mvfderiv_fun_add (mdifferentiableAt_inner hZ hX) (mdifferentiableAt_inner hZ hX'),
+    mvfderiv_fun_add (mdifferentiableAt_inner hX hY) (mdifferentiableAt_inner hX' hY),
+    mlieBracket_add_left hX hX', mlieBracket_add_left (W := Z) hX hX']
+  simp only [add_apply, map_add, inner_add_left, inner_add_right]
+  ring
+
+/-- The Koszul expression is tensorial in its first argument: replacing `X` by `f • X` multiplies
+it by `f x`. The four terms carrying a derivative of `f` cancel in pairs. -/
+theorem koszul_smul_first (hf : MDiffAt f x) (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
+    (hZ : MDiffAt (T% Z) x) : koszul I (f • X) Y Z x = f x * koszul I X Y Z x := by
+  have e₁ : (fun y ↦ inner ℝ (Z y) ((f • X) y)) = fun y ↦ f y * inner ℝ (Z y) (X y) :=
+    funext fun _ ↦ real_inner_smul_right ..
+  have e₂ : (fun y ↦ inner ℝ ((f • X) y) (Y y)) = fun y ↦ f y * inner ℝ (X y) (Y y) :=
+    funext fun _ ↦ real_inner_smul_left ..
+  have e₃ : (f • X) x = f x • X x := rfl
+  rw [koszul, koszul, e₁, e₂, e₃, mvfderiv_fun_mul hf (mdifferentiableAt_inner hZ hX),
+    mvfderiv_fun_mul hf (mdifferentiableAt_inner hX hY),
+    mlieBracket_smul_left hf hX, mlieBracket_smul_left (W := Z) hf hX]
+  simp only [add_apply, smul_apply, smul_eq_mul, map_smul, inner_add_left, neg_smul,
+    inner_neg_left, real_inner_smul_left, real_inner_smul_right]
+  rw [real_inner_comm (Z x) (X x)]
+  ring
+
+/-- The Koszul expression is additive in its second argument. -/
+theorem koszul_add_second (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
+    (hY' : MDiffAt (T% Y') x) (hZ : MDiffAt (T% Z) x) :
+    koszul I X (Y + Y') Z x = koszul I X Y Z x + koszul I X Y' Z x := by
+  have e₁ : (fun y ↦ inner ℝ ((Y + Y') y) (Z y)) =
+      fun y ↦ inner ℝ (Y y) (Z y) + inner ℝ (Y' y) (Z y) := funext fun _ ↦ inner_add_left ..
+  have e₂ : (fun y ↦ inner ℝ (X y) ((Y + Y') y)) =
+      fun y ↦ inner ℝ (X y) (Y y) + inner ℝ (X y) (Y' y) := funext fun _ ↦ inner_add_right ..
+  have e₃ : (Y + Y') x = Y x + Y' x := rfl
+  rw [koszul, koszul, koszul, e₁, e₂, e₃,
+    mvfderiv_fun_add (mdifferentiableAt_inner hY hZ) (mdifferentiableAt_inner hY' hZ),
+    mvfderiv_fun_add (mdifferentiableAt_inner hX hY) (mdifferentiableAt_inner hX hY'),
+    mlieBracket_add_right hY hY', mlieBracket_add_left hY hY']
+  simp only [add_apply, map_add, inner_add_left, inner_add_right]
+  ring
+
+/-- The Leibniz rule for the Koszul expression in its second argument: replacing `Y` by `f • Y`
+multiplies the expression by `f x` and adds `2 (df X) ⟪Y, Z⟫`. This is the identity behind the
+Leibniz axiom of the connection built from the Koszul formula. -/
+theorem koszul_smul_second (hf : MDiffAt f x) (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
+    (hZ : MDiffAt (T% Z) x) :
+    koszul I X (f • Y) Z x =
+      f x * koszul I X Y Z x + 2 * d% f x (X x) * inner ℝ (Y x) (Z x) := by
+  have e₁ : (fun y ↦ inner ℝ ((f • Y) y) (Z y)) = fun y ↦ f y * inner ℝ (Y y) (Z y) :=
+    funext fun _ ↦ real_inner_smul_left ..
+  have e₂ : (fun y ↦ inner ℝ (X y) ((f • Y) y)) = fun y ↦ f y * inner ℝ (X y) (Y y) :=
+    funext fun _ ↦ real_inner_smul_right ..
+  have e₃ : (f • Y) x = f x • Y x := rfl
+  rw [koszul, koszul, e₁, e₂, e₃, mvfderiv_fun_mul hf (mdifferentiableAt_inner hY hZ),
+    mvfderiv_fun_mul hf (mdifferentiableAt_inner hX hY),
+    mlieBracket_smul_right hf hY, mlieBracket_smul_left (W := Z) hf hY]
+  simp only [add_apply, smul_apply, smul_eq_mul, map_smul, inner_add_left, neg_smul,
+    inner_neg_left, real_inner_smul_left, real_inner_smul_right]
+  rw [real_inner_comm (Y x) (X x)]
+  ring
+
+/-- The Koszul expression is tensorial in its first argument. Together with
+`TauCeti.Manifold.tensorialAt_koszul` this presents it as a continuous bilinear form on the tangent
+fibre, which is the shape in which the Levi-Civita connection gets built. -/
+theorem tensorialAt_koszul_first (hY : MDiffAt (T% Y) x) (hZ : MDiffAt (T% Z) x) :
+    TensorialAt I E (fun X : Π y : M, TangentSpace I y ↦ koszul I X Y Z x) x where
+  smul hf hX := by simpa using koszul_smul_first hf hX hY hZ
+  add hX hX' := koszul_add_first hX hX' hY hZ
 
 /-- The Koszul expression is tensorial in its third argument: replacing `Z` by `f • Z` multiplies
 it by `f x`, and it is additive in `Z`. Together with

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Existence.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Existence.lean
@@ -39,13 +39,14 @@ vanishing of `CovariantDerivative.difference` rather than equality of bundled co
 * `CovariantDerivative.koszulHom`: the Koszul expression of a section differentiable at `x`, as a
   continuous bilinear form on `T_x M`.
 * `CovariantDerivative.leviCivitaFun` and `CovariantDerivative.leviCivita`: the Levi-Civita
-  connection of the canonical Riemannian bundle instance, unbundled and bundled.
-* `CovariantDerivative.two_inner_leviCivitaFun_eq_koszul`: it obeys the Koszul formula.
+  connection of the supplied Riemannian bundle instance, unbundled and bundled.
+* `CovariantDerivative.two_inner_leviCivita_eq_koszul`: it obeys the Koszul formula.
 * `CovariantDerivative.isLeviCivita_leviCivita`: it is torsion free and metric.
 * `CovariantDerivative.exists_isLeviCivita` and
-  `CovariantDerivative.existsUnique_isLeviCivita`: **existence and uniqueness of the Levi-Civita
-  connection**, the second in the form "a Levi-Civita connection exists, and every Levi-Civita
-  connection differs from it by the zero endomorphism-valued one-form".
+  `CovariantDerivative.exists_isLeviCivita_and_forall_difference_eq_zero`: **existence and
+  uniqueness of the Levi-Civita connection**, the second in the form "a Levi-Civita connection
+  exists, and every Levi-Civita connection differs from it by the zero endomorphism-valued
+  one-form".
 
 ## References
 
@@ -92,7 +93,7 @@ theorem koszulHom_apply (hY : MDiffAt (T% Y) x) (hX : MDiffAt (T% X) x)
 /-! ### The connection -/
 
 open scoped Classical in
-/-- The Levi-Civita connection of the canonical Riemannian bundle instance, as a function on
+/-- The Levi-Civita connection of the supplied Riemannian bundle instance, as a function on
 sections. At a section `Y` differentiable at `x` its value is the vector representing half the
 Koszul form, in accordance with the Koszul formula `2 ⟪∇_X Y, Z⟫ = koszul I X Y Z`; elsewhere it is
 the junk value `0`, which the covariant-derivative axioms never see. -/
@@ -103,8 +104,8 @@ def leviCivitaFun (Y : Π y : M, TangentSpace I y) (x : M) :
       koszulHom Y hY)
   else 0
 
-/-- **The Koszul formula** for the connection under construction. -/
-theorem two_inner_leviCivitaFun_eq_koszul (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
+private theorem two_inner_leviCivitaFun_eq_koszul (hX : MDiffAt (T% X) x)
+    (hY : MDiffAt (T% Y) x)
     (hZ : MDiffAt (T% Z) x) :
     2 * inner ℝ (leviCivitaFun Y x (X x)) (Z x) = koszul I X Y Z x := by
   rw [leviCivitaFun, dite_eq_left hY]
@@ -149,15 +150,21 @@ theorem isCovariantDerivativeOn_leviCivitaFun :
     linear_combination h₁ / 2 - (g x / 2) * h₂ + h₃ / 2
 
 variable (I M) in
-/-- **The Levi-Civita connection** of the canonical Riemannian bundle instance: the torsion-free
+/-- **The Levi-Civita connection** of the supplied Riemannian bundle instance: the torsion-free
 covariant derivative on the tangent bundle which is compatible with the metric. -/
 def leviCivita : CovariantDerivative I E (fun x : M ↦ TangentSpace I x) where
   toFun := leviCivitaFun
   isCovariantDerivativeOnUniv := isCovariantDerivativeOn_leviCivitaFun
 
-@[simp]
-theorem leviCivita_apply (Y : Π y : M, TangentSpace I y) (x : M) :
-    leviCivita I M Y x = leviCivitaFun Y x := (rfl)
+private theorem leviCivita_apply (Y : Π y : M, TangentSpace I y) (x : M) :
+    leviCivita I M Y x = leviCivitaFun Y x := rfl
+
+/-- **The Koszul formula** for the Levi-Civita connection. -/
+theorem two_inner_leviCivita_eq_koszul (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
+    (hZ : MDiffAt (T% Z) x) :
+    2 * inner ℝ (leviCivita I M Y x (X x)) (Z x) = koszul I X Y Z x := by
+  rw [leviCivita_apply]
+  exact two_inner_leviCivitaFun_eq_koszul hX hY hZ
 
 /-! ### Existence and uniqueness -/
 
@@ -165,8 +172,7 @@ theorem leviCivita_apply (Y : Π y : M, TangentSpace I y) (x : M) :
 torsion free and compatible with the metric. -/
 theorem isLeviCivita_leviCivita : IsLeviCivita (leviCivita I M) := by
   refine isLeviCivita_iff.mpr fun x X Y Z hX hY hZ ↦ ?_
-  rw [leviCivita_apply]
-  exact two_inner_leviCivitaFun_eq_koszul hX hY hZ
+  exact two_inner_leviCivita_eq_koszul hX hY hZ
 
 variable (I M) in
 /-- **Existence of the Levi-Civita connection**, in existential form. -/
@@ -174,29 +180,16 @@ theorem exists_isLeviCivita :
     ∃ cov : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov :=
   ⟨leviCivita I M, isLeviCivita_leviCivita⟩
 
-variable {cov : CovariantDerivative I E (fun x : M ↦ TangentSpace I x)}
-
-/-- Every Levi-Civita connection agrees with the canonical one on the sections which are
-differentiable at the point under consideration. -/
-theorem IsLeviCivita.eq_leviCivita (h : IsLeviCivita cov) (hY : MDiffAt (T% Y) x) :
-    cov Y x = leviCivita I M Y x :=
-  h.unique isLeviCivita_leviCivita hY
-
-/-- Every Levi-Civita connection differs from the canonical one by the zero endomorphism-valued
-one-form. -/
-theorem IsLeviCivita.difference_leviCivita_eq_zero (h : IsLeviCivita cov) :
-    cov.difference (leviCivita I M) = 0 :=
-  h.difference_eq_zero isLeviCivita_leviCivita
-
 variable (I M) in
 /-- **Existence and uniqueness of the Levi-Civita connection**: a torsion-free metric covariant
 derivative on the tangent bundle exists, and every one differs from it by the zero
 endomorphism-valued one-form. Uniqueness cannot be phrased as equality of the bundled connections,
 since a covariant derivative is unconstrained at sections which are nowhere differentiable. -/
-theorem existsUnique_isLeviCivita :
+theorem exists_isLeviCivita_and_forall_difference_eq_zero :
     ∃ cov : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov ∧
       ∀ cov' : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov' →
         cov'.difference cov = 0 :=
-  ⟨leviCivita I M, isLeviCivita_leviCivita, fun _ h ↦ h.difference_leviCivita_eq_zero⟩
+  ⟨leviCivita I M, isLeviCivita_leviCivita,
+    fun _ h ↦ h.difference_eq_zero isLeviCivita_leviCivita⟩
 
 end CovariantDerivative

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Existence.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Existence.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita.Basic
+public import TauCeti.Geometry.Manifold.VectorBundle.Riemannian.Riesz
+
+/-!
+# Existence of the Levi-Civita connection
+
+The Koszul formula `2 ⟪∇_X Y, Z⟫ = koszul I X Y Z` characterises the Levi-Civita connection of a
+Riemannian metric, and its right-hand side involves the metric alone. This file turns that
+characterisation into a construction: on a finite-dimensional Riemannian manifold there *is* a
+torsion-free metric covariant derivative on the tangent bundle, so that together with
+`CovariantDerivative.IsLeviCivita.difference_eq_zero` the Levi-Civita connection exists and is
+unique.
+
+The construction has three steps. The Koszul expression is tensorial in its first argument as
+well as in its third, so Mathlib's `TensorialAt.mkHom₂` packages `(X, Z) ↦ koszul I X Y Z x` as a
+continuous bilinear form `CovariantDerivative.koszulHom` on the fibre `T_x M`. The fibrewise
+Fréchet–Riesz equivalence `Riemannian.Tensor.rieszDual` then converts the last slot of that
+bilinear form into a vector, giving the candidate `CovariantDerivative.leviCivitaFun`. Finally the
+covariant-derivative axioms for the candidate are read off the behaviour of the Koszul expression
+in its *second* argument: `TauCeti.Manifold.koszul_add_second` gives additivity, and
+`TauCeti.Manifold.koszul_smul_second` — which says that replacing `Y` by `f • Y` adds
+`2 (df X) ⟪Y, Z⟫` — gives the Leibniz rule.
+
+Since a covariant derivative in Mathlib is a *total* function on sections, constrained only at
+sections which are differentiable at the point under consideration, `leviCivitaFun Y x` is given by
+the Koszul recipe when `Y` is differentiable at `x` and is the junk value `0` otherwise. Every
+theorem about its value accordingly carries a differentiability hypothesis, and uniqueness is the
+vanishing of `CovariantDerivative.difference` rather than equality of bundled connections.
+
+## Main definitions and results
+
+* `CovariantDerivative.koszulHom`: the Koszul expression of a section differentiable at `x`, as a
+  continuous bilinear form on `T_x M`.
+* `CovariantDerivative.leviCivitaFun` and `CovariantDerivative.leviCivita`: the Levi-Civita
+  connection of the canonical Riemannian bundle instance, unbundled and bundled.
+* `CovariantDerivative.two_inner_leviCivitaFun_eq_koszul`: it obeys the Koszul formula.
+* `CovariantDerivative.isLeviCivita_leviCivita`: it is torsion free and metric.
+* `CovariantDerivative.exists_isLeviCivita` and
+  `CovariantDerivative.existsUnique_isLeviCivita`: **existence and uniqueness of the Levi-Civita
+  connection**, the second in the form "a Levi-Civita connection exists, and every Levi-Civita
+  connection differs from it by the zero endomorphism-valued one-form".
+
+## References
+
+* [Geodesics, the exponential map, and the Hopf–Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "The Levi-Civita connection".
+* M. P. do Carmo, *Riemannian Geometry*, Birkhäuser, 1992, Ch. 2, Thm. 3.6.
+* J. M. Lee, *Introduction to Riemannian Manifolds*, GTM 176, 2018, Thm. 5.10.
+-/
+
+public section
+
+open Bundle FiberBundle NormedSpace VectorField
+open TauCeti TauCeti.Manifold
+open scoped Manifold ContDiff
+
+noncomputable section
+
+namespace CovariantDerivative
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [FiniteDimensional ℝ E] [IsManifold I 2 M]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+
+variable {X Y Z : Π x : M, TangentSpace I x} {x : M}
+
+/-! ### The Koszul form of a section -/
+
+/-- The Koszul expression of a section `Y` differentiable at `x`, as a continuous bilinear form on
+the tangent fibre at `x`: it sends `(X x, Z x)` to `koszul I X Y Z x`. -/
+def koszulHom (Y : Π y : M, TangentSpace I y) {x : M} (hY : MDiffAt (T% Y) x) :
+    TangentSpace I x →L[ℝ] TangentSpace I x →L[ℝ] ℝ :=
+  TensorialAt.mkHom₂ (fun X Z ↦ koszul I X Y Z x) x
+    (fun _ hZ ↦ tensorialAt_koszul_first hY hZ) (fun _ hX ↦ tensorialAt_koszul hX hY)
+
+@[simp]
+theorem koszulHom_apply (hY : MDiffAt (T% Y) x) (hX : MDiffAt (T% X) x)
+    (hZ : MDiffAt (T% Z) x) : koszulHom Y hY (X x) (Z x) = koszul I X Y Z x :=
+  TensorialAt.mkHom₂_apply _ _ hX hZ
+
+/-! ### The connection -/
+
+open scoped Classical in
+/-- The Levi-Civita connection of the canonical Riemannian bundle instance, as a function on
+sections. At a section `Y` differentiable at `x` its value is the vector representing half the
+Koszul form, in accordance with the Koszul formula `2 ⟪∇_X Y, Z⟫ = koszul I X Y Z`; elsewhere it is
+the junk value `0`, which the covariant-derivative axioms never see. -/
+def leviCivitaFun (Y : Π y : M, TangentSpace I y) (x : M) :
+    TangentSpace I x →L[ℝ] TangentSpace I x :=
+  if hY : MDiffAt (T% Y) x then
+    (2 : ℝ)⁻¹ • ((Riemannian.Tensor.rieszDual (I := I) x).toLinearIsometry.toContinuousLinearMap ∘L
+      koszulHom Y hY)
+  else 0
+
+/-- **The Koszul formula** for the connection under construction. -/
+theorem two_inner_leviCivitaFun_eq_koszul (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
+    (hZ : MDiffAt (T% Z) x) :
+    2 * inner ℝ (leviCivitaFun Y x (X x)) (Z x) = koszul I X Y Z x := by
+  rw [leviCivitaFun, dite_eq_left hY]
+  simp only [smul_apply, ContinuousLinearMap.coe_comp, Function.comp_apply,
+    LinearIsometry.coe_toContinuousLinearMap, LinearIsometryEquiv.coe_toLinearIsometry,
+    real_inner_smul_left, Riemannian.Tensor.inner_rieszDual, koszulHom_apply hY hX hZ]
+  ring
+
+omit [FiniteDimensional ℝ E] [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- Two endomorphisms of a tangent fibre which agree on all inner products of values at sections
+differentiable at the base point are equal. -/
+private theorem ext_of_forall_inner_eq {A B : TangentSpace I x →L[ℝ] TangentSpace I x}
+    (h : ∀ ⦃W Z : Π y : M, TangentSpace I y⦄, MDiffAt (T% W) x → MDiffAt (T% Z) x →
+      inner ℝ (A (W x)) (Z x) = inner ℝ (B (W x)) (Z x)) : A = B := by
+  refine VectorBundle.injective_eval_mdifferentiableAt_sec I E (fun x : M ↦ TangentSpace I x)
+    (TangentSpace I x) x ?_
+  ext W hW
+  exact eq_of_forall_inner_section_eq (I := I) (V := fun x : M ↦ TangentSpace I x) E
+    fun Z hZ ↦ h hW hZ
+
+/-- The Koszul recipe defines a covariant derivative on the tangent bundle: additivity comes from
+`TauCeti.Manifold.koszul_add_second` and the Leibniz rule from
+`TauCeti.Manifold.koszul_smul_second`. -/
+theorem isCovariantDerivativeOn_leviCivitaFun :
+    IsCovariantDerivativeOn (I := I) E (leviCivitaFun (M := M)) Set.univ := by
+  constructor
+  · intro σ σ' x hσ hσ' _
+    refine ext_of_forall_inner_eq fun W Z hW hZ ↦ ?_
+    have h₁ := two_inner_leviCivitaFun_eq_koszul hW (mdifferentiableAt_add_section hσ hσ') hZ
+    have h₂ := two_inner_leviCivitaFun_eq_koszul hW hσ hZ
+    have h₃ := two_inner_leviCivitaFun_eq_koszul hW hσ' hZ
+    have h₄ := koszul_add_second (X := W) (Y := σ) (Y' := σ') (Z := Z) hW hσ hσ' hZ
+    simp only [add_apply, inner_add_left]
+    linarith
+  · intro σ g x hσ hg _
+    refine ext_of_forall_inner_eq fun W Z hW hZ ↦ ?_
+    have h₁ := two_inner_leviCivitaFun_eq_koszul hW (hg.smul_section hσ) hZ
+    have h₂ := two_inner_leviCivitaFun_eq_koszul hW hσ hZ
+    have h₃ := koszul_smul_second (X := W) (Y := σ) (Z := Z) hg hW hσ hZ
+    simp only [add_apply, smul_apply, ContinuousLinearMap.smulRight_apply, inner_add_left,
+      real_inner_smul_left]
+    linear_combination h₁ / 2 - (g x / 2) * h₂ + h₃ / 2
+
+variable (I M) in
+/-- **The Levi-Civita connection** of the canonical Riemannian bundle instance: the torsion-free
+covariant derivative on the tangent bundle which is compatible with the metric. -/
+def leviCivita : CovariantDerivative I E (fun x : M ↦ TangentSpace I x) where
+  toFun := leviCivitaFun
+  isCovariantDerivativeOnUniv := isCovariantDerivativeOn_leviCivitaFun
+
+@[simp]
+theorem leviCivita_apply (Y : Π y : M, TangentSpace I y) (x : M) :
+    leviCivita I M Y x = leviCivitaFun Y x := (rfl)
+
+/-! ### Existence and uniqueness -/
+
+/-- **Existence of the Levi-Civita connection**: the connection built from the Koszul formula is
+torsion free and compatible with the metric. -/
+theorem isLeviCivita_leviCivita : IsLeviCivita (leviCivita I M) := by
+  refine isLeviCivita_iff.mpr fun x X Y Z hX hY hZ ↦ ?_
+  rw [leviCivita_apply]
+  exact two_inner_leviCivitaFun_eq_koszul hX hY hZ
+
+variable (I M) in
+/-- **Existence of the Levi-Civita connection**, in existential form. -/
+theorem exists_isLeviCivita :
+    ∃ cov : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov :=
+  ⟨leviCivita I M, isLeviCivita_leviCivita⟩
+
+variable {cov : CovariantDerivative I E (fun x : M ↦ TangentSpace I x)}
+
+/-- Every Levi-Civita connection agrees with the canonical one on the sections which are
+differentiable at the point under consideration. -/
+theorem IsLeviCivita.eq_leviCivita (h : IsLeviCivita cov) (hY : MDiffAt (T% Y) x) :
+    cov Y x = leviCivita I M Y x :=
+  h.unique isLeviCivita_leviCivita hY
+
+/-- Every Levi-Civita connection differs from the canonical one by the zero endomorphism-valued
+one-form. -/
+theorem IsLeviCivita.difference_leviCivita_eq_zero (h : IsLeviCivita cov) :
+    cov.difference (leviCivita I M) = 0 :=
+  h.difference_eq_zero isLeviCivita_leviCivita
+
+variable (I M) in
+/-- **Existence and uniqueness of the Levi-Civita connection**: a torsion-free metric covariant
+derivative on the tangent bundle exists, and every one differs from it by the zero
+endomorphism-valued one-form. Uniqueness cannot be phrased as equality of the bundled connections,
+since a covariant derivative is unconstrained at sections which are nowhere differentiable. -/
+theorem existsUnique_isLeviCivita :
+    ∃ cov : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov ∧
+      ∀ cov' : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov' →
+        cov'.difference cov = 0 :=
+  ⟨leviCivita I M, isLeviCivita_leviCivita, fun _ h ↦ h.difference_leviCivita_eq_zero⟩
+
+end CovariantDerivative

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Existence.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Existence.lean
@@ -20,7 +20,7 @@ unique.
 
 The construction has three steps. The Koszul expression is tensorial in its first argument as
 well as in its third, so Mathlib's `TensorialAt.mkHom₂` packages `(X, Z) ↦ koszul I X Y Z x` as a
-continuous bilinear form `CovariantDerivative.koszulHom` on the fibre `T_x M`. The fibrewise
+continuous bilinear form `TauCeti.Manifold.koszulHom` on the fibre `T_x M`. The fibrewise
 Fréchet–Riesz equivalence `Riemannian.Tensor.rieszDual` then converts the last slot of that
 bilinear form into a vector, giving the unbundled candidate. Finally the covariant-derivative
 axioms for the candidate are read off the behaviour of the Koszul expression in its *second*
@@ -36,7 +36,7 @@ is the vanishing of `CovariantDerivative.difference` rather than equality of bun
 
 ## Main definitions and results
 
-* `CovariantDerivative.koszulHom`: the Koszul expression of a section differentiable at `x`, as a
+* `TauCeti.Manifold.koszulHom`: the Koszul expression of a section differentiable at `x`, as a
   continuous bilinear form on `T_x M`.
 * `CovariantDerivative.leviCivita`: the Levi-Civita connection of the supplied Riemannian bundle
   instance.
@@ -62,7 +62,7 @@ open scoped Manifold ContDiff
 
 noncomputable section
 
-namespace CovariantDerivative
+namespace TauCeti.Manifold
 
 variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
@@ -77,16 +77,38 @@ variable {X Y Z : Π x : M, TangentSpace I x} {x : M}
 /-! ### The Koszul form of a section -/
 
 /-- The Koszul expression of a section `Y` differentiable at `x`, as a continuous bilinear form on
-the tangent fibre at `x`: it sends `(X x, Z x)` to `koszul I X Y Z x`. -/
+the tangent fibre at `x`. For sections `X` and `Z` differentiable at `x`, its value at
+`(X x, Z x)` is `koszul I X Y Z x`; see `koszulHom_apply`. -/
 def koszulHom (Y : Π y : M, TangentSpace I y) {x : M} (hY : MDiffAt (T% Y) x) :
     TangentSpace I x →L[ℝ] TangentSpace I x →L[ℝ] ℝ :=
   TensorialAt.mkHom₂ (fun X Z ↦ koszul I X Y Z x) x
-    (fun _ hZ ↦ tensorialAt_koszul_first hY hZ) (fun _ hX ↦ tensorialAt_koszul hX hY)
+    (fun _ hZ ↦ tensorialAt_koszul_first hY hZ) (fun _ hX ↦ tensorialAt_koszul_third hX hY)
 
 @[simp]
 theorem koszulHom_apply (hY : MDiffAt (T% Y) x) (hX : MDiffAt (T% X) x)
     (hZ : MDiffAt (T% Z) x) : koszulHom Y hY (X x) (Z x) = koszul I X Y Z x :=
   TensorialAt.mkHom₂_apply _ _ hX hZ
+
+/-- The Koszul form evaluated at arbitrary tangent vectors, expressed using their canonical local
+extensions. -/
+theorem koszulHom_apply_eq_extend (Y : Π y : M, TangentSpace I y)
+    (hY : MDiffAt (T% Y) x) (v w : TangentSpace I x) :
+    koszulHom Y hY v w = koszul I (extend E v) Y (extend E w) x :=
+  TensorialAt.mkHom₂_apply_eq_extend _ _ v w
+
+end TauCeti.Manifold
+
+namespace CovariantDerivative
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [FiniteDimensional ℝ E] [IsManifold I 2 M]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+
+variable {X Y Z : Π x : M, TangentSpace I x} {x : M}
 
 /-! ### The connection -/
 
@@ -99,7 +121,7 @@ private def leviCivitaFun (Y : Π y : M, TangentSpace I y) (x : M) :
     TangentSpace I x →L[ℝ] TangentSpace I x :=
   if hY : MDiffAt (T% Y) x then
     (2 : ℝ)⁻¹ • ((Riemannian.Tensor.rieszDual (I := I) x).toLinearIsometry.toContinuousLinearMap ∘L
-      koszulHom Y hY)
+      TauCeti.Manifold.koszulHom Y hY)
   else 0
 
 private theorem two_inner_leviCivitaFun_eq_koszul (hX : MDiffAt (T% X) x)
@@ -109,20 +131,9 @@ private theorem two_inner_leviCivitaFun_eq_koszul (hX : MDiffAt (T% X) x)
   rw [leviCivitaFun, dite_eq_left hY]
   simp only [smul_apply, ContinuousLinearMap.coe_comp, Function.comp_apply,
     LinearIsometry.coe_toContinuousLinearMap, LinearIsometryEquiv.coe_toLinearIsometry,
-    real_inner_smul_left, Riemannian.Tensor.inner_rieszDual, koszulHom_apply hY hX hZ]
+    real_inner_smul_left, Riemannian.Tensor.inner_rieszDual,
+    TauCeti.Manifold.koszulHom_apply hY hX hZ]
   ring
-
-omit [FiniteDimensional ℝ E] [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
-/-- Two endomorphisms of a tangent fibre which agree on all inner products of values at sections
-differentiable at the base point are equal. -/
-private theorem ext_of_forall_inner_eq {A B : TangentSpace I x →L[ℝ] TangentSpace I x}
-    (h : ∀ ⦃W Z : Π y : M, TangentSpace I y⦄, MDiffAt (T% W) x → MDiffAt (T% Z) x →
-      inner ℝ (A (W x)) (Z x) = inner ℝ (B (W x)) (Z x)) : A = B := by
-  refine VectorBundle.injective_eval_mdifferentiableAt_sec I E (fun x : M ↦ TangentSpace I x)
-    (TangentSpace I x) x ?_
-  ext W hW
-  exact eq_of_forall_inner_section_eq (I := I) (V := fun x : M ↦ TangentSpace I x) E
-    fun Z hZ ↦ h hW hZ
 
 /-- The Koszul recipe defines a covariant derivative on the tangent bundle: additivity comes from
 `TauCeti.Manifold.koszul_add_second` and the Leibniz rule from
@@ -131,7 +142,8 @@ private theorem isCovariantDerivativeOn_leviCivitaFun :
     IsCovariantDerivativeOn (I := I) E (leviCivitaFun (M := M)) Set.univ := by
   constructor
   · intro σ σ' x hσ hσ' _
-    refine ext_of_forall_inner_eq fun W Z hW hZ ↦ ?_
+    refine continuousLinearMap_ext_of_forall_inner_section_eq (I := I)
+      (V := fun x : M ↦ TangentSpace I x) E E fun W hW Z hZ ↦ ?_
     have h₁ := two_inner_leviCivitaFun_eq_koszul hW (mdifferentiableAt_add_section hσ hσ') hZ
     have h₂ := two_inner_leviCivitaFun_eq_koszul hW hσ hZ
     have h₃ := two_inner_leviCivitaFun_eq_koszul hW hσ' hZ
@@ -139,7 +151,8 @@ private theorem isCovariantDerivativeOn_leviCivitaFun :
     simp only [add_apply, inner_add_left]
     linarith
   · intro σ g x hσ hg _
-    refine ext_of_forall_inner_eq fun W Z hW hZ ↦ ?_
+    refine continuousLinearMap_ext_of_forall_inner_section_eq (I := I)
+      (V := fun x : M ↦ TangentSpace I x) E E fun W hW Z hZ ↦ ?_
     have h₁ := two_inner_leviCivitaFun_eq_koszul hW (hg.smul_section hσ) hZ
     have h₂ := two_inner_leviCivitaFun_eq_koszul hW hσ hZ
     have h₃ := koszul_smul_second (X := W) (Y := σ) (Z := Z) hg hW hσ hZ
@@ -157,14 +170,22 @@ def leviCivita : CovariantDerivative I E (fun x : M ↦ TangentSpace I x) where
 private theorem leviCivita_apply (Y : Π y : M, TangentSpace I y) (x : M) :
     leviCivita I M Y x = leviCivitaFun Y x := rfl
 
+/-- The defining identity for the Levi-Civita connection at arbitrary tangent vectors. -/
+theorem two_inner_leviCivita_apply (hY : MDiffAt (T% Y) x) (v w : TangentSpace I x) :
+    2 * inner ℝ (leviCivita I M Y x v) w = TauCeti.Manifold.koszulHom Y hY v w := by
+  rw [leviCivita_apply, leviCivitaFun, dite_eq_left hY]
+  simp only [smul_apply, ContinuousLinearMap.coe_comp, Function.comp_apply,
+    LinearIsometry.coe_toContinuousLinearMap, LinearIsometryEquiv.coe_toLinearIsometry,
+    real_inner_smul_left, Riemannian.Tensor.inner_rieszDual]
+  ring
+
 /-- **The Koszul formula** for the Levi-Civita connection. -/
 theorem two_inner_leviCivita_eq_koszul (hX : MDiffAt (T% X) x) (hY : MDiffAt (T% Y) x)
     (hZ : MDiffAt (T% Z) x) :
     2 * inner ℝ (leviCivita I M Y x (X x)) (Z x) = koszul I X Y Z x := by
-  rw [leviCivita_apply]
-  exact two_inner_leviCivitaFun_eq_koszul hX hY hZ
+  rw [two_inner_leviCivita_apply hY, TauCeti.Manifold.koszulHom_apply hY hX hZ]
 
-/-! ### Existence and uniqueness -/
+/-! ### Existence -/
 
 /-- **Existence of the Levi-Civita connection**: the connection built from the Koszul formula is
 torsion free and compatible with the metric. -/

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Existence.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Existence.lean
@@ -22,36 +22,34 @@ The construction has three steps. The Koszul expression is tensorial in its firs
 well as in its third, so Mathlib's `TensorialAt.mkHom₂` packages `(X, Z) ↦ koszul I X Y Z x` as a
 continuous bilinear form `CovariantDerivative.koszulHom` on the fibre `T_x M`. The fibrewise
 Fréchet–Riesz equivalence `Riemannian.Tensor.rieszDual` then converts the last slot of that
-bilinear form into a vector, giving the candidate `CovariantDerivative.leviCivitaFun`. Finally the
-covariant-derivative axioms for the candidate are read off the behaviour of the Koszul expression
-in its *second* argument: `TauCeti.Manifold.koszul_add_second` gives additivity, and
+bilinear form into a vector, giving the unbundled candidate. Finally the covariant-derivative
+axioms for the candidate are read off the behaviour of the Koszul expression in its *second*
+argument: `TauCeti.Manifold.koszul_add_second` gives additivity, and
 `TauCeti.Manifold.koszul_smul_second` — which says that replacing `Y` by `f • Y` adds
 `2 (df X) ⟪Y, Z⟫` — gives the Leibniz rule.
 
 Since a covariant derivative in Mathlib is a *total* function on sections, constrained only at
-sections which are differentiable at the point under consideration, `leviCivitaFun Y x` is given by
-the Koszul recipe when `Y` is differentiable at `x` and is the junk value `0` otherwise. Every
-theorem about its value accordingly carries a differentiability hypothesis, and uniqueness is the
-vanishing of `CovariantDerivative.difference` rather than equality of bundled connections.
+sections which are differentiable at the point under consideration, the unbundled candidate is
+given by the Koszul recipe when `Y` is differentiable at `x` and is the junk value `0` otherwise.
+Every theorem about its value accordingly carries a differentiability hypothesis, and uniqueness
+is the vanishing of `CovariantDerivative.difference` rather than equality of bundled connections.
 
 ## Main definitions and results
 
 * `CovariantDerivative.koszulHom`: the Koszul expression of a section differentiable at `x`, as a
   continuous bilinear form on `T_x M`.
-* `CovariantDerivative.leviCivitaFun` and `CovariantDerivative.leviCivita`: the Levi-Civita
-  connection of the supplied Riemannian bundle instance, unbundled and bundled.
+* `CovariantDerivative.leviCivita`: the Levi-Civita connection of the supplied Riemannian bundle
+  instance.
 * `CovariantDerivative.two_inner_leviCivita_eq_koszul`: it obeys the Koszul formula.
 * `CovariantDerivative.isLeviCivita_leviCivita`: it is torsion free and metric.
-* `CovariantDerivative.exists_isLeviCivita` and
-  `CovariantDerivative.exists_isLeviCivita_and_forall_difference_eq_zero`: **existence and
-  uniqueness of the Levi-Civita connection**, the second in the form "a Levi-Civita connection
-  exists, and every Levi-Civita connection differs from it by the zero endomorphism-valued
-  one-form".
+* `CovariantDerivative.exists_isLeviCivita`: **existence of the Levi-Civita connection**.
 
 ## References
 
 * [Geodesics, the exponential map, and the Hopf–Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
   Layer 1, "The Levi-Civita connection".
+* [mathlib4#36845](https://github.com/leanprover-community/mathlib4/pull/36845): this construction
+  follows its tensoriality-and-Riesz design, adapted to the APIs in Tau Ceti's Mathlib pin.
 * M. P. do Carmo, *Riemannian Geometry*, Birkhäuser, 1992, Ch. 2, Thm. 3.6.
 * J. M. Lee, *Introduction to Riemannian Manifolds*, GTM 176, 2018, Thm. 5.10.
 -/
@@ -97,7 +95,7 @@ open scoped Classical in
 sections. At a section `Y` differentiable at `x` its value is the vector representing half the
 Koszul form, in accordance with the Koszul formula `2 ⟪∇_X Y, Z⟫ = koszul I X Y Z`; elsewhere it is
 the junk value `0`, which the covariant-derivative axioms never see. -/
-def leviCivitaFun (Y : Π y : M, TangentSpace I y) (x : M) :
+private def leviCivitaFun (Y : Π y : M, TangentSpace I y) (x : M) :
     TangentSpace I x →L[ℝ] TangentSpace I x :=
   if hY : MDiffAt (T% Y) x then
     (2 : ℝ)⁻¹ • ((Riemannian.Tensor.rieszDual (I := I) x).toLinearIsometry.toContinuousLinearMap ∘L
@@ -129,7 +127,7 @@ private theorem ext_of_forall_inner_eq {A B : TangentSpace I x →L[ℝ] Tangent
 /-- The Koszul recipe defines a covariant derivative on the tangent bundle: additivity comes from
 `TauCeti.Manifold.koszul_add_second` and the Leibniz rule from
 `TauCeti.Manifold.koszul_smul_second`. -/
-theorem isCovariantDerivativeOn_leviCivitaFun :
+private theorem isCovariantDerivativeOn_leviCivitaFun :
     IsCovariantDerivativeOn (I := I) E (leviCivitaFun (M := M)) Set.univ := by
   constructor
   · intro σ σ' x hσ hσ' _
@@ -179,17 +177,5 @@ variable (I M) in
 theorem exists_isLeviCivita :
     ∃ cov : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov :=
   ⟨leviCivita I M, isLeviCivita_leviCivita⟩
-
-variable (I M) in
-/-- **Existence and uniqueness of the Levi-Civita connection**: a torsion-free metric covariant
-derivative on the tangent bundle exists, and every one differs from it by the zero
-endomorphism-valued one-form. Uniqueness cannot be phrased as equality of the bundled connections,
-since a covariant derivative is unconstrained at sections which are nowhere differentiable. -/
-theorem exists_isLeviCivita_and_forall_difference_eq_zero :
-    ∃ cov : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov ∧
-      ∀ cov' : CovariantDerivative I E (fun x : M ↦ TangentSpace I x), IsLeviCivita cov' →
-        cov'.difference cov = 0 :=
-  ⟨leviCivita I M, isLeviCivita_leviCivita,
-    fun _ h ↦ h.difference_eq_zero isLeviCivita_leviCivita⟩
 
 end CovariantDerivative


### PR DESCRIPTION
This PR constructs the Levi-Civita connection of a finite-dimensional Riemannian manifold, so that the connection promised by the HopfRinow roadmap's Layer 1 milestone "The Levi-Civita connection" — *prove existence and uniqueness of the torsion-free, metric-compatible connection* — now exists as well as being unique. `TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita.lean` already had the Koszul formula and the uniqueness half (`CovariantDerivative.IsLeviCivita.unique`, `.difference_eq_zero`), and its module docstring explicitly deferred existence to a later file; that file is added here.

The construction follows the shape the existing file set up. `TauCeti.Manifold.koszul_smul_first` derives tensoriality in the *first* argument from the second-slot Leibniz rule and the swap identity; together with `TauCeti.Manifold.tensorialAt_koszul_third`, this lets Mathlib's `TensorialAt.mkHom₂` package `(X, Z) ↦ koszul I X Y Z x` as a continuous bilinear form `TauCeti.Manifold.koszulHom` on the fibre `T_x M`. The fibrewise Fréchet–Riesz equivalence `Riemannian.Tensor.rieszDual`, whose module docstring already names this construction as its purpose, converts the last slot of that form into a vector, giving the unbundled candidate. The covariant-derivative axioms are then read off the behaviour of the Koszul expression in its second argument: `TauCeti.Manifold.koszul_add_second` gives additivity and `TauCeti.Manifold.koszul_smul_second` — replacing `Y` by `f • Y` adds `2 (df X) ⟪Y, Z⟫` — gives the Leibniz rule. `CovariantDerivative.isLeviCivita_leviCivita` then discharges torsion-freeness and metric compatibility through the existing `isLeviCivita_iff`, and `CovariantDerivative.exists_isLeviCivita` states existence; uniqueness is supplied by `CovariantDerivative.IsLeviCivita.difference_eq_zero`, in the only form available for a Mathlib covariant derivative, since a covariant derivative is unconstrained at sections which are nowhere differentiable.

Because a covariant derivative is a total function on sections, `leviCivitaFun Y x` is given by the Koszul recipe when `Y` is differentiable at `x` and takes the junk value `0` otherwise, and every theorem about its value carries the corresponding differentiability hypothesis.

Adding `LeviCivita/Existence.lean` would leave two flat `LeviCivita*.lean` siblings, so the topic becomes a directory in this same PR; the relocation changes only the module header and imports:

| old module | new module |
| --- | --- |
| `TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita` | `TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita.Basic` |

Nothing in the repository imported the old module path. The four new Koszul identities live in `Basic.lean` beside `TauCeti.Manifold.tensorialAt_koszul_third`, whose section hypotheses they share; only the construction itself is new material in `Existence.lean`.

The next unmet step on this milestone path is the following roadmap bullet, "Regularity of the Levi-Civita connection": `ContMDiffCovariantDerivative ∇ ∞` for the connection built here, together with `C^∞` Christoffel symbols in a tangent-bundle chart, which is the regularity input the geodesic spray needs.

No Mathlib infrastructure was vendored: the construction consumes Mathlib's `TensorialAt.mkHom₂`, `CovariantDerivative`, `IsMetricCompatible` and `mlieBracket` APIs directly, and is not adapted from the Poincare-Conjecture prior art named in the roadmap.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"existence-of-the-levi-civita-connection"}-->

🤖 Prepared with Claude Code
