### PR TITLE
feat(HeckeRing): the Atkin-Lehner anti-involution of the Γ₀(N) Hecke pair

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, Claude
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Basic
+public import TauCeti.NumberTheory.HeckeRing.GLn.TransposeAntiInvolution
+
+/-!
+# The Atkin-Lehner anti-involution of the `Γ₀(N)` Hecke pair
+
+Placeholder; rewritten once the construction is settled.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup CongruenceSubgroup Subgroup HeckeRing.GLn
+
+open scoped MatrixGroups
+
+namespace HeckeRing.GL2
+
+variable (N : ℕ)
+
+/-- The Atkin-Lehner matrix `w = diag(1, N)`. -/
+noncomputable def atkinLehnerMatrix [NeZero N] : GL (Fin 2) ℚ :=
+  natDiagGL 2 ![1, N]
+
+/-- `ι(g) = w · gᵀ · w⁻¹`, as a homomorphism to the opposite group. -/
+noncomputable def atkinLehnerHom [NeZero N] : GL (Fin 2) ℚ →* (GL (Fin 2) ℚ)ᵐᵒᵖ where
+  toFun g := MulOpposite.op (atkinLehnerMatrix N *
+    (transposeGLEquiv 2 g).unop * (atkinLehnerMatrix N)⁻¹)
+  map_one' := by simp
+  map_mul' a b := by
+    apply MulOpposite.unop_injective
+    simp only [MulOpposite.unop_op, MulOpposite.unop_mul]
+    have h1 : (transposeGLEquiv 2 (a * b)).unop =
+        (transposeGLEquiv 2 b).unop * (transposeGLEquiv 2 a).unop := by
+      rw [map_mul]; rfl
+    rw [h1]; group
+
+/-- Transposition fixes `w`, because `w` is diagonal. -/
+private lemma transposeGLEquiv_atkinLehnerMatrix [NeZero N] :
+    (transposeGLEquiv 2 (atkinLehnerMatrix N)).unop = atkinLehnerMatrix N := by
+  rw [atkinLehnerMatrix]
+  exact transposeGLEquiv_natDiagGL 2 ![1, N]
+
+private lemma atkinLehner_involutive [NeZero N] (g : GL (Fin 2) ℚ) :
+    (atkinLehnerHom N (atkinLehnerHom N g).unop).unop = g := by
+  simp only [atkinLehnerHom, MonoidHom.coe_mk, OneHom.coe_mk, MulOpposite.unop_op]
+  have h_tr : (transposeGLEquiv 2 (atkinLehnerMatrix N *
+      (transposeGLEquiv 2 g).unop * (atkinLehnerMatrix N)⁻¹)).unop =
+      (transposeGLEquiv 2 (atkinLehnerMatrix N)⁻¹).unop *
+        (transposeGLEquiv 2 (transposeGLEquiv 2 g).unop).unop *
+        (transposeGLEquiv 2 (atkinLehnerMatrix N)).unop := by
+    rw [map_mul, map_mul]
+    simp only [MulOpposite.unop_mul]
+    group
+  have h_inv : (transposeGLEquiv 2 (atkinLehnerMatrix N)⁻¹).unop = (atkinLehnerMatrix N)⁻¹ := by
+    rw [map_inv, MulOpposite.unop_inv, transposeGLEquiv_atkinLehnerMatrix]
+  rw [h_tr, transposeGLEquiv_transposeGLEquiv, transposeGLEquiv_atkinLehnerMatrix, h_inv]
+  group
+
+private lemma atkinLehner_mem_Gamma0 [NeZero N] (g : GL (Fin 2) ℚ)
+    (hg : g ∈ (Gamma0 N).map (mapGL ℚ)) :
+    (atkinLehnerHom N g).unop ∈ (Gamma0 N).map (mapGL ℚ) := by
+  sorry
+
+private lemma atkinLehner_mem_Delta0 [NeZero N] (g : GL (Fin 2) ℚ) (hg : g ∈ Delta0 N) :
+    (atkinLehnerHom N g).unop ∈ Delta0 N := by
+  sorry
+
+/-- **The Atkin-Lehner anti-involution** of the `Γ₀(N)` Hecke pair. -/
+noncomputable def atkinLehnerAntiInvolution [NeZero N] :
+    HeckeAntiInvolution (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) :=
+  HeckeAntiInvolution.ofAmbient (atkinLehnerHom N) (atkinLehner_involutive N)
+    (atkinLehner_mem_Gamma0 N) (atkinLehner_mem_Delta0 N)
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -61,8 +61,10 @@ namespace HeckeRing.GL2
 
 variable (N : ℕ)
 
-/-- The Atkin-Lehner matrix `w = diag(1, N)`. -/
-noncomputable def atkinLehnerMatrix [NeZero N] : GL (Fin 2) ℚ :=
+/-- The Atkin-Lehner matrix `w = diag(1, N)`. No `NeZero N` is needed to write it down:
+`natDiagGL` takes the junk value `1` when an entry vanishes. The hypothesis appears only where
+the value of `w` is actually read off, from `atkinLehnerHom` onwards. -/
+noncomputable def atkinLehnerMatrix : GL (Fin 2) ℚ :=
   natDiagGL 2 ![1, N]
 
 /-- `ι(g) = w · gᵀ · w⁻¹`, as a homomorphism to the opposite group. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -45,6 +45,11 @@ and diagonal-matrix API; here those come from `GLn/TransposeAntiInvolution.lean`
 
 * `HeckeRing.GL2.atkinLehnerAntiInvolution`: the anti-involution of the `Γ₀(N)` Hecke pair.
 
+## Main results
+
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar`: how it acts, `g ↦ w · gᵀ · w⁻¹`. The bundle
+  itself is opaque, so this is the elimination rule a consumer works with.
+
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
@@ -61,45 +66,53 @@ namespace HeckeRing.GL2
 
 variable (N : ℕ)
 
-/-- The Atkin-Lehner matrix `w = diag(1, N)`. No `NeZero N` is needed to write it down:
-`natDiagGL` takes the junk value `1` when an entry vanishes. The hypothesis appears only where
-the value of `w` is actually read off, from `atkinLehnerHom` onwards. -/
-noncomputable def atkinLehnerMatrix : GL (Fin 2) ℚ :=
+/-- The scaling matrix `w = diag(1, N)` by which the transpose is conjugated.
+
+This is **not** the Atkin-Lehner matrix of the operator `𝒲_Q`, which is `!![0, -1; N, 0]`; it is
+only the diagonal rescaling that repairs the transpose's failure to preserve `Γ₀(N)`.
+
+No `NeZero N` is needed to write it down — `natDiagGL` takes the junk value `1` when an entry
+vanishes. The hypothesis first appears at `atkinLehner_unop_val`, where the entries of `w` are
+evaluated. -/
+private noncomputable def atkinLehnerScaleMatrix : GL (Fin 2) ℚ :=
   natDiagGL 2 ![1, N]
 
 /-- `ι(g) = w · gᵀ · w⁻¹`, as a homomorphism to the opposite group. -/
-noncomputable def atkinLehnerHom : GL (Fin 2) ℚ →* (GL (Fin 2) ℚ)ᵐᵒᵖ where
-  toFun g := MulOpposite.op (atkinLehnerMatrix N *
-    (transposeGLEquiv 2 g).unop * (atkinLehnerMatrix N)⁻¹)
+private noncomputable def atkinLehnerHom : GL (Fin 2) ℚ →* (GL (Fin 2) ℚ)ᵐᵒᵖ where
+  toFun g := MulOpposite.op (atkinLehnerScaleMatrix N *
+    (transposeGLEquiv 2 g).unop * (atkinLehnerScaleMatrix N)⁻¹)
   map_one' := by simp
   map_mul' a b := by
     apply MulOpposite.unop_injective
     simp only [MulOpposite.unop_op, MulOpposite.unop_mul]
     have h1 : (transposeGLEquiv 2 (a * b)).unop =
         (transposeGLEquiv 2 b).unop * (transposeGLEquiv 2 a).unop := by
-      rw [map_mul]; rfl
+      simp only [map_mul, MulOpposite.unop_mul]
     rw [h1]; group
 
 /-- Transposition fixes `w`, because `w` is diagonal. -/
-private lemma transposeGLEquiv_atkinLehnerMatrix :
-    (transposeGLEquiv 2 (atkinLehnerMatrix N)).unop = atkinLehnerMatrix N := by
-  rw [atkinLehnerMatrix]
+private lemma transposeGLEquiv_atkinLehnerScaleMatrix :
+    (transposeGLEquiv 2 (atkinLehnerScaleMatrix N)).unop = atkinLehnerScaleMatrix N := by
+  rw [atkinLehnerScaleMatrix]
   exact transposeGLEquiv_natDiagGL 2 ![1, N]
 
+/-- `ι` is involutive: transposition is, and the two conjugations by `w` cancel because
+transposition fixes `w`. -/
 private lemma atkinLehner_involutive (g : GL (Fin 2) ℚ) :
     (atkinLehnerHom N (atkinLehnerHom N g).unop).unop = g := by
   simp only [atkinLehnerHom, MonoidHom.coe_mk, OneHom.coe_mk, MulOpposite.unop_op]
-  have h_tr : (transposeGLEquiv 2 (atkinLehnerMatrix N *
-      (transposeGLEquiv 2 g).unop * (atkinLehnerMatrix N)⁻¹)).unop =
-      (transposeGLEquiv 2 (atkinLehnerMatrix N)⁻¹).unop *
+  have h_tr : (transposeGLEquiv 2 (atkinLehnerScaleMatrix N *
+      (transposeGLEquiv 2 g).unop * (atkinLehnerScaleMatrix N)⁻¹)).unop =
+      (transposeGLEquiv 2 (atkinLehnerScaleMatrix N)⁻¹).unop *
         (transposeGLEquiv 2 (transposeGLEquiv 2 g).unop).unop *
-        (transposeGLEquiv 2 (atkinLehnerMatrix N)).unop := by
+        (transposeGLEquiv 2 (atkinLehnerScaleMatrix N)).unop := by
     rw [map_mul, map_mul]
     simp only [MulOpposite.unop_mul]
     group
-  have h_inv : (transposeGLEquiv 2 (atkinLehnerMatrix N)⁻¹).unop = (atkinLehnerMatrix N)⁻¹ := by
-    rw [map_inv, MulOpposite.unop_inv, transposeGLEquiv_atkinLehnerMatrix]
-  rw [h_tr, transposeGLEquiv_transposeGLEquiv, transposeGLEquiv_atkinLehnerMatrix, h_inv]
+  have h_inv : (transposeGLEquiv 2 (atkinLehnerScaleMatrix N)⁻¹).unop =
+      (atkinLehnerScaleMatrix N)⁻¹ := by
+    rw [map_inv, MulOpposite.unop_inv, transposeGLEquiv_atkinLehnerScaleMatrix]
+  rw [h_tr, transposeGLEquiv_transposeGLEquiv, transposeGLEquiv_atkinLehnerScaleMatrix, h_inv]
   group
 
 /-- The integral matrix of `ι(g)`. Conjugating the transpose by `w = diag(1, N)` divides the
@@ -117,12 +130,12 @@ private lemma atkinLehner_unop_val [NeZero N] (g : GL (Fin 2) ℚ)
   have hpos : ∀ i : Fin 2, 0 < (![1, N]) i := by
     intro i; fin_cases i <;> simp [NeZero.pos]
   have hNe : (N : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne N)
-  have hw : ((atkinLehnerMatrix N : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+  have hw : ((atkinLehnerScaleMatrix N : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
       Matrix.diagonal ![1, (N : ℚ)] := by
-    rw [atkinLehnerMatrix, natDiagGL_coe 2 _ hpos]
+    rw [atkinLehnerScaleMatrix, natDiagGL_coe 2 _ hpos]
     ext i j
     fin_cases i <;> fin_cases j <;> simp
-  have hwinv : (((atkinLehnerMatrix N)⁻¹ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+  have hwinv : (((atkinLehnerScaleMatrix N)⁻¹ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
       Matrix.diagonal ![1, (N : ℚ)⁻¹] := by
     rw [Matrix.coe_units_inv, hw]
     refine Matrix.inv_eq_right_inv ?_
@@ -139,11 +152,12 @@ private lemma atkinLehner_unop_val [NeZero N] (g : GL (Fin 2) ℚ)
       Matrix.transpose_apply, hcast] <;>
     field_simp
 
-/-- The rational matrix of an integral special-linear element is its entrywise cast. -/
-private lemma mapGL_val_eq_map_intCast (τ : SpecialLinearGroup (Fin 2) ℤ) :
-    ((mapGL ℚ τ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      (τ : Matrix (Fin 2) (Fin 2) ℤ).map (Int.cast : ℤ → ℚ) := by
-  simp [mapGL_coe_matrix, algebraMap_int_eq, RingHom.mapMatrix_apply]
+/-- Conjugating the transpose by `w` swaps which off-diagonal entry carries the factor `N`, so
+the determinant is unchanged. Both membership proofs need this, at different right-hand sides. -/
+private lemma det_swapEntries (A : Matrix (Fin 2) (Fin 2) ℤ) (c : ℤ) (hc : A 1 0 = (N : ℤ) * c) :
+    (Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]]).det = A.det := by
+  simp only [Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one]
+  linarith [show c * ((N : ℤ) * A 0 1) = A 0 1 * A 1 0 by rw [hc]; ring]
 
 /-- `ι` preserves the image of `Γ₀(N)`: the transported matrix again has determinant one and
 lower-left entry divisible by `N`. -/
@@ -156,17 +170,18 @@ private lemma atkinLehner_mem_Gamma0 [NeZero N] (g : GL (Fin 2) ℚ)
   obtain ⟨c, hc⟩ := hσ_mem
   set A := (σ : Matrix (Fin 2) (Fin 2) ℤ) with hA_def
   set B : Matrix (Fin 2) (Fin 2) ℤ := Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]] with hB
-  have hB_det : B.det = 1 := by
-    have hdetA : A.det = A 0 0 * A 1 1 - A 0 1 * A 1 0 := Matrix.det_fin_two A
-    rw [σ.2] at hdetA
-    simp only [hB, Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one]
-    linarith [show c * ((N : ℤ) * A 0 1) = A 0 1 * A 1 0 by rw [hc]; ring]
+  have hB_det : B.det = 1 := by rw [hB, det_swapEntries N A c hc, hA_def, σ.2]
   refine ⟨⟨B, hB_det⟩, Gamma0_mem.mpr ?_, Units.ext ?_⟩
   · simp only [hB, Matrix.of_apply, Matrix.cons_val_one, Matrix.cons_val_zero]
     rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
     exact dvd_mul_right _ _
-  · rw [atkinLehner_unop_val N _ A (mapGL_val_eq_map_intCast σ) c hc,
-      mapGL_val_eq_map_intCast ⟨B, hB_det⟩]
+  · -- the entrywise cast of an integral special-linear element, inlined as at
+    -- `GL2/DiagonalCosetDegree.lean`
+    have hval : ∀ μ : SpecialLinearGroup (Fin 2) ℤ,
+        ((mapGL ℚ μ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+          (μ : Matrix (Fin 2) (Fin 2) ℤ).map (Int.cast : ℤ → ℚ) :=
+      fun μ ↦ by simp [mapGL_coe_matrix, algebraMap_int_eq, RingHom.mapMatrix_apply]
+    rw [atkinLehner_unop_val N _ A (hval σ) c hc, hval ⟨B, hB_det⟩]
 
 /-- `ι` preserves `Δ₀(N)`: the determinant and the upper-left entry are unchanged, and the new
 lower-left entry `N · A 0 1` is visibly divisible by `N`. -/
@@ -176,10 +191,7 @@ private lemma atkinLehner_mem_Delta0 [NeZero N] (g : GL (Fin 2) ℚ) (hg : g ∈
   obtain ⟨c, hc⟩ := hAN
   set B : Matrix (Fin 2) (Fin 2) ℤ := Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]] with hB
   have hval := atkinLehner_unop_val N g A hA c hc
-  have hB_det : B.det = A.det := by
-    have hdetA : A.det = A 0 0 * A 1 1 - A 0 1 * A 1 0 := Matrix.det_fin_two A
-    simp only [hB, Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one]
-    linarith [show c * ((N : ℤ) * A 0 1) = A 0 1 * A 1 0 by rw [hc]; ring]
+  have hB_det : B.det = A.det := by rw [hB, det_swapEntries N A c hc]
   refine (mem_Delta0_iff N).mpr ⟨B, hval, ?_, ⟨A 0 1, by simp [hB]⟩, ?_⟩
   · rw [hval, ← Int.cast_det, hB_det, Int.cast_det, ← hA]
     exact hdet
@@ -190,5 +202,12 @@ noncomputable def atkinLehnerAntiInvolution [NeZero N] :
     HeckeAntiInvolution (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) :=
   HeckeAntiInvolution.ofAmbient (atkinLehnerHom N) (atkinLehner_involutive N)
     (atkinLehner_mem_Gamma0 N) (atkinLehner_mem_Delta0 N)
+
+/-- The anti-involution acts by conjugating the transpose by `w`, unfolding the sealed
+definition. -/
+@[simp] lemma atkinLehnerAntiInvolution_bar [NeZero N] {x : GL (Fin 2) ℚ} (hx : x ∈ Delta0 N) :
+    (atkinLehnerAntiInvolution N).bar x hx =
+      natDiagGL 2 ![1, N] * (transposeGLEquiv 2 x).unop * (natDiagGL 2 ![1, N])⁻¹ :=
+  HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -104,13 +104,11 @@ private lemma atkinLehnerHom_involutive (g : GL (Fin 2) ℚ) :
   rw [h_tr, transposeGLEquiv_transposeGLEquiv, transposeGLEquiv_natDiagGL 2 ![1, N], h_inv]
   group
 
-/-- **The entries of `ι(g)`**: `(a, b; N c, e) ↦ (a, c; N b, e)`, as an integral matrix.
-
-Public because it is the characteristic property of the map — `atkinLehnerAntiInvolution_bar_val`
-states the action in these terms, and a consumer reading entries off a `Δ₀(N)` element needs the
-name. Internally it also gives the value lemma, the determinant lemma and the two membership
-proofs one spelling instead of four copies of the literal. -/
-def atkinLehnerEntries (A : Matrix (Fin 2) (Fin 2) ℤ) (c : ℤ) :
+/-- The entries of `ι(g)`: `(a, b; N c, e) ↦ (a, c; N b, e)`, as an integral matrix. Gives the
+value lemma, the determinant lemma and the two membership proofs one spelling instead of four
+copies of the literal; the public `atkinLehnerAntiInvolution_bar_val` writes the matrix out
+rather than exposing this constructor. -/
+private def atkinLehnerEntries (A : Matrix (Fin 2) (Fin 2) ℤ) (c : ℤ) :
     Matrix (Fin 2) (Fin 2) ℤ :=
   !![A 0 0, c; (N : ℤ) * A 0 1, A 1 1]
 
@@ -223,7 +221,7 @@ lemma atkinLehnerAntiInvolution_bar_val [NeZero N] {x : GL (Fin 2) ℚ} (hx : x 
     (A : Matrix (Fin 2) (Fin 2) ℤ) (hA : (x : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (c : ℤ) (hc : A 1 0 = (N : ℤ) * c) :
     (((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      (atkinLehnerEntries N A c).map (Int.cast : ℤ → ℚ) := by
+      (!![A 0 0, c; (N : ℤ) * A 0 1, A 1 1]).map (Int.cast : ℤ → ℚ) := by
   have hbar : ((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) = (atkinLehnerHom N x).unop :=
     HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
   rw [hbar]

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -63,14 +63,65 @@ private lemma atkinLehner_involutive [NeZero N] (g : GL (Fin 2) ℚ) :
   rw [h_tr, transposeGLEquiv_transposeGLEquiv, transposeGLEquiv_atkinLehnerMatrix, h_inv]
   group
 
+/-- The integral matrix of `ι(g)`. Conjugating the transpose by `w = diag(1, N)` divides the
+upper-right entry by `N` and multiplies the lower-left by `N`; the first is integral exactly
+because `N ∣ A 1 0`, which is the `Δ₀(N)` shape. The two diagonal entries are untouched — in
+particular the upper-left one, which is why every coprimality hypothesis about it survives.
+
+This is the one computation both membership proofs below need, so it is done once here. -/
+private lemma atkinLehner_unop_val [NeZero N] (g : GL (Fin 2) ℚ)
+    (A : Matrix (Fin 2) (Fin 2) ℤ)
+    (hA : (g : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
+    (c : ℤ) (hc : A 1 0 = (N : ℤ) * c) :
+    (((atkinLehnerHom N g).unop : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      (Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]]).map (Int.cast : ℤ → ℚ) := by
+  sorry
+
+/-- The rational matrix of an integral special-linear element is its entrywise cast. -/
+private lemma mapGL_val_eq_map_intCast (τ : SpecialLinearGroup (Fin 2) ℤ) :
+    ((mapGL ℚ τ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      (τ : Matrix (Fin 2) (Fin 2) ℤ).map (Int.cast : ℤ → ℚ) := by
+  simp [mapGL_coe_matrix, algebraMap_int_eq, RingHom.mapMatrix_apply]
+
+/-- `ι` preserves the image of `Γ₀(N)`: the transported matrix again has determinant one and
+lower-left entry divisible by `N`. -/
 private lemma atkinLehner_mem_Gamma0 [NeZero N] (g : GL (Fin 2) ℚ)
     (hg : g ∈ (Gamma0 N).map (mapGL ℚ)) :
     (atkinLehnerHom N g).unop ∈ (Gamma0 N).map (mapGL ℚ) := by
-  sorry
+  rw [Subgroup.mem_map] at hg ⊢
+  obtain ⟨σ, hσ_mem, rfl⟩ := hg
+  rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at hσ_mem
+  obtain ⟨c, hc⟩ := hσ_mem
+  set A := (σ : Matrix (Fin 2) (Fin 2) ℤ) with hA_def
+  set B : Matrix (Fin 2) (Fin 2) ℤ := Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]] with hB
+  have hB_det : B.det = 1 := by
+    have hdetA : A.det = A 0 0 * A 1 1 - A 0 1 * A 1 0 := Matrix.det_fin_two A
+    rw [σ.2] at hdetA
+    simp only [hB, Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one]
+    linarith [show c * ((N : ℤ) * A 0 1) = A 0 1 * A 1 0 by rw [hc]; ring]
+  refine ⟨⟨B, hB_det⟩, Gamma0_mem.mpr ?_, Units.ext ?_⟩
+  · simp only [hB, Matrix.of_apply, Matrix.cons_val_one, Matrix.cons_val_zero]
+    rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
+    exact dvd_mul_right _ _
+  · rw [atkinLehner_unop_val N _ A (mapGL_val_eq_map_intCast σ) c hc,
+      mapGL_val_eq_map_intCast ⟨B, hB_det⟩]
 
+/-- `ι` preserves `Δ₀(N)`: the determinant and the upper-left entry are unchanged, and the new
+lower-left entry `N · A 0 1` is visibly divisible by `N`. -/
 private lemma atkinLehner_mem_Delta0 [NeZero N] (g : GL (Fin 2) ℚ) (hg : g ∈ Delta0 N) :
     (atkinLehnerHom N g).unop ∈ Delta0 N := by
-  sorry
+  obtain ⟨A, hA, hdet, hAN, hAunit⟩ := (mem_Delta0_iff N).mp hg
+  obtain ⟨c, hc⟩ := hAN
+  set B : Matrix (Fin 2) (Fin 2) ℤ := Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]] with hB
+  have hval := atkinLehner_unop_val N g A hA c hc
+  have hB_det : B.det = A.det := by
+    have hdetA : A.det = A 0 0 * A 1 1 - A 0 1 * A 1 0 := Matrix.det_fin_two A
+    simp only [hB, Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one]
+    linarith [show c * ((N : ℤ) * A 0 1) = A 0 1 * A 1 0 by rw [hc]; ring]
+  refine (mem_Delta0_iff N).mpr ⟨B, hval, ?_, ⟨A 0 1, by simp [hB]⟩, ?_⟩
+  · rw [hval, ← Int.cast_det, hB_det, Int.cast_det, ← hA]
+    exact hdet
+  · simpa [hB] using hAunit
 
 /-- **The Atkin-Lehner anti-involution** of the `Γ₀(N)` Hecke pair. -/
 noncomputable def atkinLehnerAntiInvolution [NeZero N] :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -157,7 +157,8 @@ the determinant is unchanged. Both membership proofs need this, at different rig
 private lemma det_swapEntries (A : Matrix (Fin 2) (Fin 2) ℤ) (c : ℤ) (hc : A 1 0 = (N : ℤ) * c) :
     (Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]]).det = A.det := by
   simp only [Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one]
-  linarith [show c * ((N : ℤ) * A 0 1) = A 0 1 * A 1 0 by rw [hc]; ring]
+  rw [hc]
+  ring
 
 /-- `ι` preserves the image of `Γ₀(N)`: the transported matrix again has determinant one and
 lower-left entry divisible by `N`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -75,7 +75,30 @@ private lemma atkinLehner_unop_val [NeZero N] (g : GL (Fin 2) ℚ)
     (c : ℤ) (hc : A 1 0 = (N : ℤ) * c) :
     (((atkinLehnerHom N g).unop : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
       (Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]]).map (Int.cast : ℤ → ℚ) := by
-  sorry
+  have hpos : ∀ i : Fin 2, 0 < (![1, N]) i := by
+    intro i; fin_cases i <;> simp [NeZero.pos]
+  have hNe : (N : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne N)
+  have hw : ((atkinLehnerMatrix N : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      Matrix.diagonal ![1, (N : ℚ)] := by
+    rw [atkinLehnerMatrix, natDiagGL_coe 2 _ hpos]
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp
+  have hwinv : (((atkinLehnerMatrix N)⁻¹ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      Matrix.diagonal ![1, (N : ℚ)⁻¹] := by
+    rw [Matrix.coe_units_inv, hw]
+    refine Matrix.inv_eq_right_inv ?_
+    rw [Matrix.diagonal_mul_diagonal]
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp [hNe]
+  have hcast : ((A 1 0 : ℤ) : ℚ) = (N : ℚ) * ((c : ℤ) : ℚ) := by
+    exact_mod_cast congrArg (Int.cast : ℤ → ℚ) hc
+  simp only [atkinLehnerHom, MonoidHom.coe_mk, OneHom.coe_mk, MulOpposite.unop_op,
+    Units.val_mul, hw, hwinv, transposeGLEquiv_coe, hA]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Matrix.diagonal_apply, Matrix.map_apply,
+      Matrix.transpose_apply, hcast] <;>
+    field_simp
 
 /-- The rational matrix of an integral special-linear element is its entrywise cast. -/
 private lemma mapGL_val_eq_map_intCast (τ : SpecialLinearGroup (Fin 2) ℤ) :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -11,7 +11,44 @@ public import TauCeti.NumberTheory.HeckeRing.GLn.TransposeAntiInvolution
 /-!
 # The Atkin-Lehner anti-involution of the `Γ₀(N)` Hecke pair
 
-Placeholder; rewritten once the construction is settled.
+Conjugating the transpose by `w = diag(1, N)`,
+```
+ι(g) = w · gᵀ · w⁻¹,
+```
+is an anti-automorphism of `GL₂(ℚ)` preserving both the image of `Γ₀(N)` and the submonoid
+`Δ₀(N)`, so it restricts to a `HeckeAntiInvolution` of the `Γ₀(N)` Hecke datum.
+
+At level one the transpose alone already does this — that is
+`HeckeRing.GLn.transposeAntiInvolution`, and it is why the `GL_n` Hecke ring is commutative.
+It does **not** survive the congruence condition: transposition carries `Γ₀(N)` to `Γ⁰(N)`,
+swapping which off-diagonal entry is divisible by `N`. Conjugating by `w` swaps it back, which
+is exactly what the Atkin-Lehner twist buys.
+
+On entries the map is `(a, b; N c, e) ↦ (a, c; N b, e)`: the lower-left entry stays divisible
+by `N`, the determinant is unchanged, and — the point of the construction — the upper-left
+entry is untouched, so the coprimality condition cutting out `Δ₀(N)` transfers with no work.
+Integrality of the new upper-right entry is precisely the hypothesis `N ∣ A 1 0`.
+
+This file builds the anti-involution only. Commutativity of `R(Γ₀(N), Δ₀(N))` needs the further
+input that `ι` fixes every double coset, which `HeckeCosetModule.mul_comm_of_antiInvolution`
+takes as a separate hypothesis (Shimura, Proposition 3.8).
+
+Ported from the AINTLIB `LeanModularForms` project (Chris Birkbeck),
+[`HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean`](https://github.com/CBirkbeck/AINTLIB),
+declarations `wN`, `Gamma0_AL_hom`, `Gamma0_AL_involutive`, `Gamma0_AL_map_H`,
+`Gamma0_AL_map_Δ` and `Gamma0_antiInvolution`. The source states its own transpose equivalence
+and diagonal-matrix API; here those come from `GLn/TransposeAntiInvolution.lean` and
+`GLn/DiagonalCosets.lean` instead, and the four-field bundle is assembled by
+`HeckeAntiInvolution.ofAmbient`.
+
+## Main definitions
+
+* `HeckeRing.GL2.atkinLehnerAntiInvolution`: the anti-involution of the `Γ₀(N)` Hecke pair.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Proposition 3.8.
 -/
 
 public section

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -66,21 +66,10 @@ namespace HeckeRing.GL2
 
 variable (N : ℕ)
 
-/-- The scaling matrix `w = diag(1, N)` by which the transpose is conjugated.
-
-This is **not** the Atkin-Lehner matrix of the operator `𝒲_Q`, which is `!![0, -1; N, 0]`; it is
-only the diagonal rescaling that repairs the transpose's failure to preserve `Γ₀(N)`.
-
-No `NeZero N` is needed to write it down — `natDiagGL` takes the junk value `1` when an entry
-vanishes. The hypothesis first appears at `atkinLehner_unop_val`, where the entries of `w` are
-evaluated. -/
-private noncomputable def atkinLehnerScaleMatrix : GL (Fin 2) ℚ :=
-  natDiagGL 2 ![1, N]
-
 /-- `ι(g) = w · gᵀ · w⁻¹`, as a homomorphism to the opposite group. -/
 private noncomputable def atkinLehnerHom : GL (Fin 2) ℚ →* (GL (Fin 2) ℚ)ᵐᵒᵖ where
-  toFun g := MulOpposite.op (atkinLehnerScaleMatrix N *
-    (transposeGLEquiv 2 g).unop * (atkinLehnerScaleMatrix N)⁻¹)
+  toFun g := MulOpposite.op (natDiagGL 2 ![1, N] *
+    (transposeGLEquiv 2 g).unop * (natDiagGL 2 ![1, N])⁻¹)
   map_one' := by simp
   map_mul' a b := by
     apply MulOpposite.unop_injective
@@ -90,30 +79,40 @@ private noncomputable def atkinLehnerHom : GL (Fin 2) ℚ →* (GL (Fin 2) ℚ)�
       simp only [map_mul, MulOpposite.unop_mul]
     rw [h1]; group
 
-/-- Transposition fixes `w`, because `w` is diagonal. -/
-private lemma transposeGLEquiv_atkinLehnerScaleMatrix :
-    (transposeGLEquiv 2 (atkinLehnerScaleMatrix N)).unop = atkinLehnerScaleMatrix N := by
-  rw [atkinLehnerScaleMatrix]
-  exact transposeGLEquiv_natDiagGL 2 ![1, N]
+/-- **The value of `ι`**, stated once so the three consumers below and the public `bar`
+lemma do not each rely on unfolding the definition. -/
+@[simp] private lemma atkinLehnerHom_unop (g : GL (Fin 2) ℚ) :
+    (atkinLehnerHom N g).unop =
+      natDiagGL 2 ![1, N] * (transposeGLEquiv 2 g).unop * (natDiagGL 2 ![1, N])⁻¹ := (rfl)
 
 /-- `ι` is involutive: transposition is, and the two conjugations by `w` cancel because
 transposition fixes `w`. -/
-private lemma atkinLehner_involutive (g : GL (Fin 2) ℚ) :
+private lemma atkinLehnerHom_involutive (g : GL (Fin 2) ℚ) :
     (atkinLehnerHom N (atkinLehnerHom N g).unop).unop = g := by
-  simp only [atkinLehnerHom, MonoidHom.coe_mk, OneHom.coe_mk, MulOpposite.unop_op]
-  have h_tr : (transposeGLEquiv 2 (atkinLehnerScaleMatrix N *
-      (transposeGLEquiv 2 g).unop * (atkinLehnerScaleMatrix N)⁻¹)).unop =
-      (transposeGLEquiv 2 (atkinLehnerScaleMatrix N)⁻¹).unop *
+  simp only [atkinLehnerHom_unop]
+  have h_tr : (transposeGLEquiv 2 (natDiagGL 2 ![1, N] *
+      (transposeGLEquiv 2 g).unop * (natDiagGL 2 ![1, N])⁻¹)).unop =
+      (transposeGLEquiv 2 (natDiagGL 2 ![1, N])⁻¹).unop *
         (transposeGLEquiv 2 (transposeGLEquiv 2 g).unop).unop *
-        (transposeGLEquiv 2 (atkinLehnerScaleMatrix N)).unop := by
+        (transposeGLEquiv 2 (natDiagGL 2 ![1, N])).unop := by
     rw [map_mul, map_mul]
     simp only [MulOpposite.unop_mul]
     group
-  have h_inv : (transposeGLEquiv 2 (atkinLehnerScaleMatrix N)⁻¹).unop =
-      (atkinLehnerScaleMatrix N)⁻¹ := by
-    rw [map_inv, MulOpposite.unop_inv, transposeGLEquiv_atkinLehnerScaleMatrix]
-  rw [h_tr, transposeGLEquiv_transposeGLEquiv, transposeGLEquiv_atkinLehnerScaleMatrix, h_inv]
+  have h_inv : (transposeGLEquiv 2 (natDiagGL 2 ![1, N])⁻¹).unop =
+      (natDiagGL 2 ![1, N])⁻¹ := by
+    rw [map_inv, MulOpposite.unop_inv, transposeGLEquiv_natDiagGL 2 ![1, N]]
+  rw [h_tr, transposeGLEquiv_transposeGLEquiv, transposeGLEquiv_natDiagGL 2 ![1, N], h_inv]
   group
+
+/-- **The entries of `ι(g)`**: `(a, b; N c, e) ↦ (a, c; N b, e)`, as an integral matrix.
+
+Public because it is the characteristic property of the map — `atkinLehnerAntiInvolution_bar_val`
+states the action in these terms, and a consumer reading entries off a `Δ₀(N)` element needs the
+name. Internally it also gives the value lemma, the determinant lemma and the two membership
+proofs one spelling instead of four copies of the literal. -/
+def atkinLehnerEntries (A : Matrix (Fin 2) (Fin 2) ℤ) (c : ℤ) :
+    Matrix (Fin 2) (Fin 2) ℤ :=
+  !![A 0 0, c; (N : ℤ) * A 0 1, A 1 1]
 
 /-- The integral matrix of `ι(g)`. Conjugating the transpose by `w = diag(1, N)` divides the
 upper-right entry by `N` and multiplies the lower-left by `N`; the first is integral exactly
@@ -121,21 +120,21 @@ because `N ∣ A 1 0`, which is the `Δ₀(N)` shape. The two diagonal entries a
 particular the upper-left one, which is why every coprimality hypothesis about it survives.
 
 This is the one computation both membership proofs below need, so it is done once here. -/
-private lemma atkinLehner_unop_val [NeZero N] (g : GL (Fin 2) ℚ)
+private lemma atkinLehnerHom_unop_val [NeZero N] (g : GL (Fin 2) ℚ)
     (A : Matrix (Fin 2) (Fin 2) ℤ)
     (hA : (g : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
     (c : ℤ) (hc : A 1 0 = (N : ℤ) * c) :
     (((atkinLehnerHom N g).unop : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      (Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]]).map (Int.cast : ℤ → ℚ) := by
+      (atkinLehnerEntries N A c).map (Int.cast : ℤ → ℚ) := by
   have hpos : ∀ i : Fin 2, 0 < (![1, N]) i := by
     intro i; fin_cases i <;> simp [NeZero.pos]
   have hNe : (N : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne N)
-  have hw : ((atkinLehnerScaleMatrix N : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+  have hw : ((natDiagGL 2 ![1, N] : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
       Matrix.diagonal ![1, (N : ℚ)] := by
-    rw [atkinLehnerScaleMatrix, natDiagGL_coe 2 _ hpos]
+    rw [natDiagGL_coe 2 _ hpos]
     ext i j
     fin_cases i <;> fin_cases j <;> simp
-  have hwinv : (((atkinLehnerScaleMatrix N)⁻¹ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+  have hwinv : (((natDiagGL 2 ![1, N])⁻¹ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
       Matrix.diagonal ![1, (N : ℚ)⁻¹] := by
     rw [Matrix.coe_units_inv, hw]
     refine Matrix.inv_eq_right_inv ?_
@@ -144,8 +143,8 @@ private lemma atkinLehner_unop_val [NeZero N] (g : GL (Fin 2) ℚ)
     fin_cases i <;> fin_cases j <;> simp [hNe]
   have hcast : ((A 1 0 : ℤ) : ℚ) = (N : ℚ) * ((c : ℤ) : ℚ) := by
     exact_mod_cast congrArg (Int.cast : ℤ → ℚ) hc
-  simp only [atkinLehnerHom, MonoidHom.coe_mk, OneHom.coe_mk, MulOpposite.unop_op,
-    Units.val_mul, hw, hwinv, transposeGLEquiv_coe, hA]
+  simp only [atkinLehnerHom_unop, atkinLehnerEntries, Units.val_mul, hw, hwinv,
+    transposeGLEquiv_coe, hA]
   ext i j
   fin_cases i <;> fin_cases j <;>
     simp [Matrix.mul_apply, Matrix.diagonal_apply, Matrix.map_apply,
@@ -154,26 +153,24 @@ private lemma atkinLehner_unop_val [NeZero N] (g : GL (Fin 2) ℚ)
 
 /-- Conjugating the transpose by `w` swaps which off-diagonal entry carries the factor `N`, so
 the determinant is unchanged. Both membership proofs need this, at different right-hand sides. -/
-private lemma det_swapEntries (A : Matrix (Fin 2) (Fin 2) ℤ) (c : ℤ) (hc : A 1 0 = (N : ℤ) * c) :
-    (Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]]).det = A.det := by
-  simp only [Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one]
-  rw [hc]
+private lemma atkinLehnerEntries_det (A : Matrix (Fin 2) (Fin 2) ℤ) (c : ℤ)
+    (hc : A 1 0 = (N : ℤ) * c) : (atkinLehnerEntries N A c).det = A.det := by
+  rw [atkinLehnerEntries, Matrix.det_fin_two_of, Matrix.det_fin_two, hc]
   ring
 
 /-- `ι` preserves the image of `Γ₀(N)`: the transported matrix again has determinant one and
 lower-left entry divisible by `N`. -/
-private lemma atkinLehner_mem_Gamma0 [NeZero N] (g : GL (Fin 2) ℚ)
-    (hg : g ∈ (Gamma0 N).map (mapGL ℚ)) :
-    (atkinLehnerHom N g).unop ∈ (Gamma0 N).map (mapGL ℚ) := by
-  rw [Subgroup.mem_map] at hg ⊢
+private lemma atkinLehnerHom_mem_Gamma0Image [NeZero N] (g : GL (Fin 2) ℚ)
+    (hg : g ∈ Gamma0Image N) : (atkinLehnerHom N g).unop ∈ Gamma0Image N := by
+  rw [mem_Gamma0Image_iff] at hg ⊢
   obtain ⟨σ, hσ_mem, rfl⟩ := hg
   rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at hσ_mem
   obtain ⟨c, hc⟩ := hσ_mem
   set A := (σ : Matrix (Fin 2) (Fin 2) ℤ) with hA_def
-  set B : Matrix (Fin 2) (Fin 2) ℤ := Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]] with hB
-  have hB_det : B.det = 1 := by rw [hB, det_swapEntries N A c hc, hA_def, σ.2]
+  set B : Matrix (Fin 2) (Fin 2) ℤ := atkinLehnerEntries N A c with hB
+  have hB_det : B.det = 1 := by rw [hB, atkinLehnerEntries_det N A c hc, hA_def, σ.2]
   refine ⟨⟨B, hB_det⟩, Gamma0_mem.mpr ?_, Units.ext ?_⟩
-  · simp only [hB, Matrix.of_apply, Matrix.cons_val_one, Matrix.cons_val_zero]
+  · simp only [hB, atkinLehnerEntries]
     rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
     exact dvd_mul_right _ _
   · -- the entrywise cast of an integral special-linear element, inlined as at
@@ -182,27 +179,35 @@ private lemma atkinLehner_mem_Gamma0 [NeZero N] (g : GL (Fin 2) ℚ)
         ((mapGL ℚ μ : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
           (μ : Matrix (Fin 2) (Fin 2) ℤ).map (Int.cast : ℤ → ℚ) :=
       fun μ ↦ by simp [mapGL_coe_matrix, algebraMap_int_eq, RingHom.mapMatrix_apply]
-    rw [atkinLehner_unop_val N _ A (hval σ) c hc, hval ⟨B, hB_det⟩]
+    rw [atkinLehnerHom_unop_val N _ A (hval σ) c hc, hval ⟨B, hB_det⟩]
 
 /-- `ι` preserves `Δ₀(N)`: the determinant and the upper-left entry are unchanged, and the new
 lower-left entry `N · A 0 1` is visibly divisible by `N`. -/
-private lemma atkinLehner_mem_Delta0 [NeZero N] (g : GL (Fin 2) ℚ) (hg : g ∈ Delta0 N) :
+private lemma atkinLehnerHom_mem_Delta0 [NeZero N] (g : GL (Fin 2) ℚ) (hg : g ∈ Delta0 N) :
     (atkinLehnerHom N g).unop ∈ Delta0 N := by
   obtain ⟨A, hA, hdet, hAN, hAunit⟩ := (mem_Delta0_iff N).mp hg
   obtain ⟨c, hc⟩ := hAN
-  set B : Matrix (Fin 2) (Fin 2) ℤ := Matrix.of ![![A 0 0, c], ![(N : ℤ) * A 0 1, A 1 1]] with hB
-  have hval := atkinLehner_unop_val N g A hA c hc
-  have hB_det : B.det = A.det := by rw [hB, det_swapEntries N A c hc]
-  refine (mem_Delta0_iff N).mpr ⟨B, hval, ?_, ⟨A 0 1, by simp [hB]⟩, ?_⟩
+  set B : Matrix (Fin 2) (Fin 2) ℤ := atkinLehnerEntries N A c with hB
+  have hval := atkinLehnerHom_unop_val N g A hA c hc
+  have hB_det : B.det = A.det := by rw [hB, atkinLehnerEntries_det N A c hc]
+  refine (mem_Delta0_iff N).mpr ⟨B, hval, ?_, ⟨A 0 1, by simp [hB, atkinLehnerEntries]⟩, ?_⟩
   · rw [hval, ← Int.cast_det, hB_det, Int.cast_det, ← hA]
     exact hdet
-  · simpa [hB] using hAunit
+  · simpa [hB, atkinLehnerEntries] using hAunit
 
-/-- **The Atkin-Lehner anti-involution** of the `Γ₀(N)` Hecke pair. -/
+/-- **The Atkin-Lehner anti-involution** `g ↦ w · gᵀ · w⁻¹` of the `Γ₀(N)` Hecke pair, where
+`w = diag(1, N)`.
+
+`w` is the diagonal rescaling that repairs the transpose's failure to preserve `Γ₀(N)`. It is
+**not** the Atkin-Lehner matrix of the operator `𝒲_Q`, which is `!![0, -1; N, 0]`.
+
+Stated at `Gamma0Image N`, the spelling the `IsHeckeTriple (Delta0 N) (Gamma0Image N)
+(Gamma0Image N)` instance is found at, so `onHeckeCoset` and
+`HeckeCosetModule.mul_comm_of_antiInvolution` apply without an unfold. -/
 noncomputable def atkinLehnerAntiInvolution [NeZero N] :
-    HeckeAntiInvolution (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) :=
-  HeckeAntiInvolution.ofAmbient (atkinLehnerHom N) (atkinLehner_involutive N)
-    (atkinLehner_mem_Gamma0 N) (atkinLehner_mem_Delta0 N)
+    HeckeAntiInvolution (Delta0 N) (Gamma0Image N) :=
+  HeckeAntiInvolution.ofAmbient (atkinLehnerHom N) (atkinLehnerHom_involutive N)
+    (atkinLehnerHom_mem_Gamma0Image N) (atkinLehnerHom_mem_Delta0 N)
 
 /-- The anti-involution acts by conjugating the transpose by `w`, unfolding the sealed
 definition. -/
@@ -210,5 +215,18 @@ definition. -/
     (atkinLehnerAntiInvolution N).bar x hx =
       natDiagGL 2 ![1, N] * (transposeGLEquiv 2 x).unop * (natDiagGL 2 ![1, N])⁻¹ :=
   HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
+
+/-- **The entrywise action**, on the bundle: `(a, b; N c, e) ↦ (a, c; N b, e)`. This is the
+form a consumer of `Δ₀(N)` elements needs; without it the entries can only be recovered by
+redoing the diagonal-conjugation computation. -/
+lemma atkinLehnerAntiInvolution_bar_val [NeZero N] {x : GL (Fin 2) ℚ} (hx : x ∈ Delta0 N)
+    (A : Matrix (Fin 2) (Fin 2) ℤ) (hA : (x : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ))
+    (c : ℤ) (hc : A 1 0 = (N : ℤ) * c) :
+    (((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      (atkinLehnerEntries N A c).map (Int.cast : ℤ → ℚ) := by
+  have hbar : ((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) = (atkinLehnerHom N x).unop :=
+    HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
+  rw [hbar]
+  exact atkinLehnerHom_unop_val N x A hA c hc
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -68,7 +68,7 @@ noncomputable def atkinLehnerMatrix : GL (Fin 2) ℚ :=
   natDiagGL 2 ![1, N]
 
 /-- `ι(g) = w · gᵀ · w⁻¹`, as a homomorphism to the opposite group. -/
-noncomputable def atkinLehnerHom [NeZero N] : GL (Fin 2) ℚ →* (GL (Fin 2) ℚ)ᵐᵒᵖ where
+noncomputable def atkinLehnerHom : GL (Fin 2) ℚ →* (GL (Fin 2) ℚ)ᵐᵒᵖ where
   toFun g := MulOpposite.op (atkinLehnerMatrix N *
     (transposeGLEquiv 2 g).unop * (atkinLehnerMatrix N)⁻¹)
   map_one' := by simp
@@ -81,12 +81,12 @@ noncomputable def atkinLehnerHom [NeZero N] : GL (Fin 2) ℚ →* (GL (Fin 2) �
     rw [h1]; group
 
 /-- Transposition fixes `w`, because `w` is diagonal. -/
-private lemma transposeGLEquiv_atkinLehnerMatrix [NeZero N] :
+private lemma transposeGLEquiv_atkinLehnerMatrix :
     (transposeGLEquiv 2 (atkinLehnerMatrix N)).unop = atkinLehnerMatrix N := by
   rw [atkinLehnerMatrix]
   exact transposeGLEquiv_natDiagGL 2 ![1, N]
 
-private lemma atkinLehner_involutive [NeZero N] (g : GL (Fin 2) ℚ) :
+private lemma atkinLehner_involutive (g : GL (Fin 2) ℚ) :
     (atkinLehnerHom N (atkinLehnerHom N g).unop).unop = g := by
   simp only [atkinLehnerHom, MonoidHom.coe_mk, OneHom.coe_mk, MulOpposite.unop_op]
   have h_tr : (transposeGLEquiv 2 (atkinLehnerMatrix N *


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"gamma0-atkin-lehner-antiinvolution"}-->

Conjugating the transpose by `w = diag(1, N)` gives an anti-automorphism of `GL₂(ℚ)` that
preserves both the image of `Γ₀(N)` and the submonoid `Δ₀(N)`, so it restricts to a
`HeckeAntiInvolution` of the `Γ₀(N)` Hecke datum.

```lean
noncomputable def atkinLehnerAntiInvolution (N : ℕ) [NeZero N] :
    HeckeAntiInvolution (Delta0 N) ((Gamma0 N).map (mapGL ℚ))

@[simp] lemma atkinLehnerAntiInvolution_bar [NeZero N] {x : GL (Fin 2) ℚ} (hx : x ∈ Delta0 N) :
    (atkinLehnerAntiInvolution N).bar x hx =
      natDiagGL 2 ![1, N] * (transposeGLEquiv 2 x).unop * (natDiagGL 2 ![1, N])⁻¹
```

Those two declarations are the whole public surface: the bundle, and the elimination rule that
says what it does. Everything reaching inside — the scaling matrix, the underlying homomorphism,
the involutivity and the two membership proofs — is `private`, so a consumer never has to unfold
the `ofAmbient` construction to compute with `ι`.

## Why the level-one transpose is not enough

`HeckeRing.GLn.transposeAntiInvolution` already gives commutativity of the `GL_n` Hecke ring,
and transposition is exactly what Shimura uses at level one. It does **not** survive the
congruence condition: transposition carries `Γ₀(N)` to `Γ⁰(N)`, swapping which off-diagonal
entry is divisible by `N`. Conjugating by `w` swaps it back. That is the whole content of the
Atkin–Lehner twist, and it is why level `N` needs its own anti-involution rather than a reuse
of the transpose one.

On entries the map is `(a, b; N c, e) ↦ (a, c; N b, e)`. Three things fall out and are worth
naming, because they are what make the two membership proofs short:

* the lower-left entry stays divisible by `N`;
* the determinant is unchanged — proved once as the private `det_swapEntries` and used by both
  membership lemmas, which need it at different right-hand sides (`= 1` and `= A.det`);
* the **upper-left entry is untouched**, so the coprimality condition cutting out `Δ₀(N)`
  transfers with no work at all.

Integrality of the new upper-right entry is precisely the hypothesis `N ∣ A 1 0`.

## A naming caveat worth stating

`w = diag(1, N)` is **not** the Atkin–Lehner matrix of the operator `𝒲_Q`, which is
`!![0, -1; N, 0]`. It is only the diagonal rescaling that repairs the transpose's failure to
preserve `Γ₀(N)`. The private definition is therefore called `atkinLehnerScaleMatrix`, and its
docstring says so, so that a later PR introducing the genuine `𝒲_Q` does not collide with a name
that promised to be it.

## What this reuses rather than ports

The AINTLIB source states its own transpose equivalence, its own diagonal-matrix API and its own
four-field `AntiInvolution` structure. None of that is ported. This repo already has all three,
and every one of them was located by *object* rather than by name — the source's names have zero
hits here:

| AINTLIB | used here instead |
|---|---|
| `AntiInvolution` (4 fields) | `HeckeAntiInvolution.ofAmbient` — a field-for-field match |
| `GL_transposeEquiv` | `transposeGLEquiv` |
| `GL_transposeEquiv_involutive` | `transposeGLEquiv_transposeGLEquiv` |
| `diagMat_GL_transpose_eq` | `transposeGLEquiv_natDiagGL` |
| `diagMat` | `natDiagGL` |

So `w` is `natDiagGL 2 ![1, N]`, and the bundle is four lines, assembled exactly as
`transposeAntiInvolution` is.

`NeZero N` appears only where `w`'s entries are actually computed — first at
`atkinLehner_unop_val`. Writing `w` down, forming the homomorphism, showing transposition fixes
`w`, and involutivity all hold without it, because `natDiagGL` takes a junk value when an entry
vanishes.

## The `mapGL` entrywise cast: an inline `have`, matching main

The fact that `(mapGL ℚ μ : Matrix _ _ ℚ)` is the entrywise cast of `(μ : Matrix _ _ ℤ)` is
needed twice inside `atkinLehner_mem_Gamma0`, and it is spelled as one local
`have hval : ∀ μ, …` rather than a file-private lemma. That is the idiom already on main at
`GL2/DiagonalCosetDegree.lean:85`.

The same fact is stated in four places across the repo: that inline `have`, the private
`mapGL_mul_coe_eq_intMatrix` at `Gamma0/DoubleCoset.lean:119`, `mapGL_mul_mul_coe` in my
in-flight #4270, and this one. Consolidating them into a single public lemma is the right end
state, and it is a refactor of files that two in-flight PRs are currently changing — so it wants
its own PR after they land, not a fold-in here.

## Scope: why the double-coset half is not here

`TransposeAntiInvolution.lean` ships its anti-involution together with the fixing lemma and the
`CommSemiring` instance in one file, so the natural question is why this one stops at the
anti-involution.

`HeckeCosetModule.mul_comm_of_antiInvolution` takes the fixing hypothesis
(`∀ D, ι.onHeckeCoset D = D`) as a **separate argument**, so the two halves are genuinely
independent inputs. At level one the fixing half is four lines
(`transposeAntiInvolution_onHeckeCoset_eq_self`) — every double coset has a diagonal
representative and transposition fixes diagonal matrices, so it costs almost nothing to carry in
the same file. At level `N` it is not: it needs Smith normal form for `2 × 2` integer matrices,
the content quotient, and coprime two-sided representatives — roughly two hundred further lines,
and it consumes a separate in-flight PR of mine. Bundling them would produce one PR that could
not be reviewed as a unit.

## Not a duplicate of `conjScale`

`ModularForms/Degeneracy.lean:309` has `conjScale` with the identical hypothesis shape
`γ 1 0 = d * c`, and `:324` `mapGL_conjScale` conjugates by `diag(d, 1)`. Its output is the
**transpose** of this file's. It is not reusable here for three independent reasons: it is stated
over `ℝ` and this layer is over `ℚ`; it maps `SL(2, ℤ) → SL(2, ℤ)`, so it cannot serve the
`Δ₀(N)` case, which is about integral matrices of positive determinant; and Atkin–Lehner composes
the conjugation with a transpose, which `conjScale` does not. A shared generalisation would have
to be stated over an arbitrary field and for general integral matrices, which is a refactor of
`Degeneracy.lean` rather than part of this PR.

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0,
`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean`
lines 36–165, declarations `wN`, `Gamma0_AL_hom`, `Gamma0_AL_involutive`, `Gamma0_AL_map_H`,
`Gamma0_AL_map_Δ`, `Gamma0_antiInvolution` — all private upstream, and kept private here except
the bundled anti-involution. `atkinLehnerAntiInvolution_bar` and `det_swapEntries` have no
upstream counterpart; they are this port's own API and factoring.

Roadmap target: `TauCetiRoadmap/ModularForms/README.md:374-375` names it directly — "the pairs
`(Γ₀(N), Δ₀(N))`, `Γ₁(N)` … and commutativity at level `N` by the Atkin–Lehner anti-involution".
Downstream, Layer 5 at `:603-625` (`strongMultiplicityOne`,
`StrongMultiplicityOne/ConstantMultiple.lean`).
