### PR TITLE
feat: the standard representation of the general linear group

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
@@ -176,8 +176,7 @@ theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
     (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
   have h := N.rid_lTensor_coact_mem
     (generalLinearToPoint (R := R) n g).ofConv.toLinearMap hw
-  rw [show Comodule.coact (R := R) (C := coordinateHopfAlgebra R n) w = standardCoact R n w from
-    congrArg (fun p ↦ p w) (standardComodule_coact R n)] at h
+  rw [standardComodule_coact R n] at h
   have hf := DFunLike.congr_fun
     (rid_lTensor_comp_standardCoact R n (generalLinearToPoint (R := R) n g).ofConv.toLinearMap) w
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe] at hf
@@ -234,10 +233,11 @@ private theorem exists_generalLinearGroup_mulVec {v w : Fin m → k} (hv : v ≠
     have he : e ⟨w, Submodule.mem_span_singleton_self w⟩ =
         ⟨v, Submodule.mem_span_singleton_self v⟩ := by
       simp only [e, LinearEquiv.trans_apply]
-      rw [show (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) w hw).symm
-          ⟨w, Submodule.mem_span_singleton_self w⟩ = 1 from
-        (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) w hw).symm_apply_eq.mpr
-          (LinearEquiv.toSpanNonzeroSingleton_one k (Fin m → k) w hw).symm]
+      have hw_coord :
+          (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) w hw).symm
+              ⟨w, Submodule.mem_span_singleton_self w⟩ = 1 :=
+        LinearEquiv.coord_self k (Fin m → k) w hw
+      rw [hw_coord]
       exact LinearEquiv.toSpanNonzeroSingleton_one k (Fin m → k) v hv
     rw [he] at hone
     exact hone.symm

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
@@ -1,0 +1,280 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.FunctorOfPoints
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Faithful
+import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+
+/-!
+# The standard representation of the general linear group
+
+The generic matrix defines a coaction of the coordinate Hopf algebra `O(GLₙ)` on the column
+space `Rⁿ`: the `j`-th standard basis vector goes to the `j`-th column of the generic matrix.
+This is the standard representation of `GLₙ`, and this file constructs it and establishes the
+properties of it that the structure theory uses.
+
+It is **faithful**: its coefficient matrix is the generic matrix, so its coordinate morphism
+`O(GLₙ) ⟶ O(GLₙ)` is the identity, hence surjective, and the associated morphism of group
+schemes is a closed immersion.
+
+Over a field and for `n ≠ 0` it is **simple**: the only subcomodules of `kⁿ` are `0` and `kⁿ`.
+Contracting the coaction of a vector of a subcomodule against the linear functional given by a
+point of `GLₙ` valued in `k` shows that a subcomodule is stable under the action of every
+invertible matrix, and `GL(n, k)` is transitive on nonzero vectors.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.standardComodule`: the standard comodule of `O(GLₙ)` on `Rⁿ`.
+* `TauCeti.GeneralLinear.isFaithful_standardComodule`: the standard comodule is faithful.
+* `TauCeti.GeneralLinear.piScalarRight_comp_endOfPoint`: a point acts on the standard comodule
+  by the invertible matrix it names.
+* `TauCeti.GeneralLinear.mulVec_mem`: a subcomodule of the standard comodule is stable under
+  every invertible matrix.
+* `TauCeti.GeneralLinear.instIsSimpleOrderSubcomodule`: over a field and in
+  positive size, the standard comodule is simple.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §4.a and §5.
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+
+Faithfulness and simplicity of the standard representation are the two representation-theoretic
+inputs to the statement that `GLₙ` is reductive, which the ReductiveGroups roadmap asks for among
+the worked examples accompanying Layer 6, "Reductive and semisimple groups". The remaining input
+is that the invariants of a normal closed subgroup form a subrepresentation.
+
+The construction of the comodule follows the template of
+`TauCeti.Algebra.AlgebraicGroup.UpperUnitriangular.Unipotent`.
+-/
+
+public section
+
+open Module WithConv
+open scoped Matrix TensorProduct
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+variable (R : Type u) [CommRing R] (n : ℕ)
+
+/-- The standard coaction of `O(GLₙ)` on column vectors. On the `j`-th basis vector it is the
+`j`-th column of the generic matrix. -/
+noncomputable def standardCoact :
+    (Fin n → R) →ₗ[R] (Fin n → R) ⊗[R] coordinateHopfAlgebra R n :=
+  (Pi.basisFun R (Fin n)).constr R fun j ↦
+    ∑ i, (Pi.single i (1 : R) : Fin n → R) ⊗ₜ[R]
+      coordinateHopfAlgebraAlgEquiv R n (coordinateRingMap R n (MvPolynomial.X (i, j)))
+
+/-- The standard coaction on a basis vector is the corresponding column of the generic
+matrix. -/
+@[simp]
+theorem standardCoact_apply_basisFun (j : Fin n) :
+    standardCoact R n (Pi.single j 1) =
+      ∑ i, (Pi.single i (1 : R) : Fin n → R) ⊗ₜ[R]
+        coordinateHopfAlgebraAlgEquiv R n (coordinateRingMap R n (MvPolynomial.X (i, j))) := by
+  rw [standardCoact, ← Pi.basisFun_apply, Basis.constr_basis]
+
+/-- The standard right comodule of the general linear coordinate Hopf algebra. -/
+@[instance_reducible]
+noncomputable def standardComodule :
+    Comodule R (coordinateHopfAlgebra R n) (Fin n → R) where
+  coact := standardCoact R n
+  coassoc := by
+    apply (Pi.basisFun R (Fin n)).ext
+    intro j
+    simp only [LinearMap.coe_comp, Function.comp_apply]
+    rw [Pi.basisFun_apply, standardCoact_apply_basisFun]
+    simp only [map_sum, LinearMap.rTensor_tmul, standardCoact_apply_basisFun,
+      TensorProduct.sum_tmul, LinearEquiv.coe_coe, TensorProduct.assoc_tmul,
+      LinearMap.lTensor_tmul, coordinateHopfAlgebra_comul_X, TensorProduct.tmul_sum]
+    rw [Finset.sum_comm]
+  lTensor_counit_comp_coact := by
+    apply (Pi.basisFun R (Fin n)).ext
+    intro j
+    simp only [LinearMap.coe_comp, Function.comp_apply]
+    rw [Pi.basisFun_apply, standardCoact_apply_basisFun]
+    simp only [map_sum, LinearMap.lTensor_tmul, coordinateHopfAlgebra_counit_X]
+    rw [Finset.sum_eq_single j]
+    · simp
+    · intro i _ hij
+      simp [hij]
+    · simp
+
+/-- The coaction of the standard comodule is `standardCoact`. -/
+@[simp]
+theorem standardComodule_coact :
+    (standardComodule R n).coact = standardCoact R n :=
+  (rfl)
+
+attribute [local instance] standardComodule
+
+/-- The coefficient matrix of the standard comodule is the generic matrix. -/
+@[simp]
+theorem coefficientMatrix_basisFun :
+    Comodule.coefficientMatrix (C := coordinateHopfAlgebra R n)
+        (Pi.basisFun R (Fin n)) = fun i j ↦
+          coordinateHopfAlgebraAlgEquiv R n (coordinateRingMap R n (MvPolynomial.X (i, j))) := by
+  ext i j
+  rw [Comodule.coefficientMatrix_apply, Comodule.matrixCoefficient_def,
+    standardComodule_coact, Pi.basisFun_apply, standardCoact_apply_basisFun]
+  simp [Pi.single_apply]
+
+/-- The coordinate morphism of the standard comodule is the identity of `O(GLₙ)`. -/
+@[simp]
+theorem coordinateBialgHom_basisFun :
+    Comodule.coordinateBialgHom (H := coordinateHopfAlgebra R n)
+        (Pi.basisFun R (Fin n)) = BialgHom.id R (coordinateHopfAlgebra R n) := by
+  apply BialgHom.ext
+  intro x
+  have hAlg :
+      (Comodule.coordinateBialgHom (H := coordinateHopfAlgebra R n)
+          (Pi.basisFun R (Fin n))).toAlgHom =
+        (BialgHom.id R (coordinateHopfAlgebra R n)).toAlgHom := by
+    apply coordinateHopfAlgebra_algHom_ext
+    intro i j
+    calc
+      _ = Comodule.coefficientMatrix (C := coordinateHopfAlgebra R n)
+            (Pi.basisFun R (Fin n)) i j :=
+        Comodule.coordinateBialgHom_X (Pi.basisFun R (Fin n)) i j
+      _ = _ := by simp [coefficientMatrix_basisFun]
+  exact DFunLike.congr_fun hAlg x
+
+/-- **The standard comodule of `GLₙ` is faithful.** -/
+theorem isFaithful_standardComodule :
+    Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R n) (V := Fin n → R) := by
+  rw [Comodule.isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom
+      (b := Pi.basisFun R (Fin n)),
+    Comodule.isClosedImmersion_coordinateGroupSchemeHom_iff,
+    coordinateBialgHom_basisFun]
+  exact Function.surjective_id
+
+/-- Contracting the standard coaction against a linear functional on `O(GLₙ)` multiplies by the
+matrix of the functional's values on the generic entries. -/
+theorem rid_lTensor_comp_standardCoact (f : coordinateHopfAlgebra R n →ₗ[R] R) :
+    (TensorProduct.rid R (Fin n → R)).toLinearMap ∘ₗ
+        LinearMap.lTensor (Fin n → R) f ∘ₗ standardCoact R n =
+      Matrix.mulVecLin (Matrix.of fun i j ↦
+        f (coordinateHopfAlgebraAlgEquiv R n
+          (coordinateRingMap R n (MvPolynomial.X (i, j))))) := by
+  apply (Pi.basisFun R (Fin n)).ext
+  intro j
+  simp only [LinearMap.coe_comp, Function.comp_apply, Pi.basisFun_apply,
+    standardCoact_apply_basisFun, map_sum, LinearMap.lTensor_tmul,
+    LinearEquiv.coe_coe, TensorProduct.rid_tmul]
+  ext i
+  simp [Matrix.mulVec, dotProduct, Pi.single_apply, Finset.sum_ite_eq']
+
+/-- **A subcomodule of the standard comodule of `GLₙ` is stable under every invertible
+matrix.** -/
+theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
+    (g : Matrix.GeneralLinearGroup (Fin n) R) {w : Fin n → R} (hw : w ∈ N) :
+    (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
+  have h := N.rid_lTensor_coact_mem
+    (generalLinearToPoint (R := R) n g).ofConv.toLinearMap hw
+  rw [show Comodule.coact (R := R) (C := coordinateHopfAlgebra R n) w = standardCoact R n w from
+    congrArg (fun p ↦ p w) (standardComodule_coact R n)] at h
+  have hf := DFunLike.congr_fun
+    (rid_lTensor_comp_standardCoact R n (generalLinearToPoint (R := R) n g).ofConv.toLinearMap) w
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe] at hf
+  have hmat : (Matrix.of fun i j ↦ (generalLinearToPoint (R := R) n g).ofConv.toLinearMap
+        (coordinateHopfAlgebraAlgEquiv R n
+          (coordinateRingMap R n (MvPolynomial.X (i, j))))) =
+      (g : Matrix (Fin n) (Fin n) R) := by
+    ext i j
+    simp
+  rw [hf, hmat, Matrix.mulVecLin_apply] at h
+  exact h
+
+section PointAction
+
+variable {A : Type*} [CommRing A] [Algebra R A]
+
+/-- Under the canonical scalar-extension identification `A ⊗[R] Rⁿ ≃ Aⁿ`, a point of `GLₙ` acts
+on the standard comodule by multiplication with the invertible matrix it names. -/
+theorem piScalarRight_comp_endOfPoint (g : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    (TensorProduct.piScalarRight R A A (Fin n)).toLinearMap.comp
+        (Comodule.endOfPoint (Fin n → R) g.ofConv) =
+      (Matrix.GeneralLinearGroup.toLin (pointToGeneralLinear n g) :
+          (Fin n → A) →ₗ[A] Fin n → A).comp
+        (TensorProduct.piScalarRight R A A (Fin n)).toLinearMap := by
+  apply ((Pi.basisFun R (Fin n)).baseChange A).ext
+  intro j
+  simp only [LinearMap.comp_apply, Module.Basis.baseChange_apply]
+  rw [Comodule.endOfPoint_tmul, standardComodule_coact, Pi.basisFun_apply,
+    standardCoact_apply_basisFun]
+  simp only [map_sum, LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply,
+    TensorProduct.comm_tmul, one_smul, Matrix.GeneralLinearGroup.toLin_apply,
+    Matrix.mulVecLin_apply]
+  ext i
+  simp only [Finset.sum_apply, Matrix.mulVec, dotProduct]
+  simp [TensorProduct.piScalarRight_apply, TensorProduct.piScalarRightHom_tmul,
+    Pi.single_apply, pointToGeneralLinear_apply]
+
+end PointAction
+
+section Simple
+
+variable (k : Type u) [Field k] (m : ℕ) [NeZero m]
+
+omit [NeZero m] in
+/-- Every nonzero vector of `kᵐ` is the image of every other one under an invertible matrix. -/
+private theorem exists_generalLinearGroup_mulVec {v w : Fin m → k} (hv : v ≠ 0) (hw : w ≠ 0) :
+    ∃ g : Matrix.GeneralLinearGroup (Fin m) k, (g : Matrix (Fin m) (Fin m) k) *ᵥ w = v := by
+  let e : (k ∙ w) ≃ₗ[k] (k ∙ v) :=
+    (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) w hw).symm.trans
+      (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) v hv)
+  obtain ⟨φ, hφ⟩ := Submodule.exists_linearEquiv_restrict_eq e
+  have hφw : φ w = v := by
+    have hone := hφ ⟨w, Submodule.mem_span_singleton_self w⟩
+    have he : e ⟨w, Submodule.mem_span_singleton_self w⟩ =
+        ⟨v, Submodule.mem_span_singleton_self v⟩ := by
+      simp only [e, LinearEquiv.trans_apply]
+      rw [show (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) w hw).symm
+          ⟨w, Submodule.mem_span_singleton_self w⟩ = 1 from
+        (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) w hw).symm_apply_eq.mpr
+          (LinearEquiv.toSpanNonzeroSingleton_one k (Fin m → k) w hw).symm]
+      exact LinearEquiv.toSpanNonzeroSingleton_one k (Fin m → k) v hv
+    rw [he] at hone
+    exact hone.symm
+  refine ⟨⟨LinearMap.toMatrix' (φ : (Fin m → k) →ₗ[k] Fin m → k),
+    LinearMap.toMatrix' (φ.symm : (Fin m → k) →ₗ[k] Fin m → k), ?_, ?_⟩, ?_⟩
+  · rw [← LinearMap.toMatrix'_comp]
+    simp
+  · rw [← LinearMap.toMatrix'_comp]
+    simp
+  · rw [← Matrix.toLin'_apply, Matrix.toLin'_toMatrix']
+    exact hφw
+
+/-- **The standard comodule of `GLₘ` over a field is simple** for `m ≠ 0`: its only subcomodules
+are the zero comodule and the whole column space. -/
+instance instIsSimpleOrderSubcomodule :
+    IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) where
+  exists_pair_ne := by
+    refine ⟨⊥, ⊤, fun h ↦ ?_⟩
+    have hone : (Pi.single (0 : Fin m) (1 : k) : Fin m → k) ∈
+        (⊥ : Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) :=
+      h ▸ Subcomodule.mem_top _
+    rw [Subcomodule.mem_bot] at hone
+    simpa using congrFun hone (0 : Fin m)
+  eq_bot_or_eq_top N := by
+    by_cases hN : ∀ w ∈ N, w = 0
+    · left
+      exact Subcomodule.ext fun w ↦ ⟨fun hw ↦ Subcomodule.mem_bot.mpr (hN w hw),
+        fun hw ↦ Subcomodule.mem_bot.mp hw ▸ zero_mem N⟩
+    · right
+      simp only [not_forall] at hN
+      obtain ⟨w, hwN, hw⟩ := hN
+      refine Subcomodule.ext fun v ↦ ⟨fun _ ↦ Subcomodule.mem_top v, fun _ ↦ ?_⟩
+      by_cases hv : v = 0
+      · exact hv ▸ zero_mem N
+      · obtain ⟨g, hg⟩ := exists_generalLinearGroup_mulVec k m hv hw
+        exact hg ▸ mulVec_mem k m N g hwN
+
+end Simple
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
@@ -27,7 +27,9 @@ subcomodules and the fundamental theorem of comodules. Later work can use
 * `TauCeti.Subcomodule`: a submodule stable under the coaction.
 * `TauCeti.Subcomodule.toSubmodule`: the underlying submodule.
 * `TauCeti.Subcomodule.finite`: subcomodules of noetherian modules are finite.
-* `⊤` and `⊥`: the full and zero subcomodules.
+* `TauCeti.Subcomodule.rid_lTensor_coact_mem`: a subcomodule is stable under contracting the
+  coaction against a linear functional on the coalgebra.
+* `⊤` and `⊥`: the full and zero subcomodules, which bound the order of subcomodules.
 * `TauCeti.Subcomodule.map`: the image of a subcomodule under a comodule morphism.
 * `TauCeti.Subcomodule.map_finite`: images preserve finite generation of the underlying
   submodule.
@@ -131,6 +133,23 @@ theorem coact_mem (N : Subcomodule R C M) {m : M} (hm : m ∈ N) :
       LinearMap.range (TensorProduct.map N.carrier.subtype (LinearMap.id : C →ₗ[R] C)) :=
   N.coact_mem' hm
 
+/-- A subcomodule is stable under contracting the coaction against a linear functional on the
+coalgebra.
+
+For a comodule over a Hopf algebra the contractions along the algebra homomorphisms `C →ₐ[R] R`
+are the actions of the `R`-valued points of the represented affine group, so this is the
+statement that a subcomodule is a subrepresentation. -/
+theorem rid_lTensor_coact_mem (N : Subcomodule R C M) (f : C →ₗ[R] R) {m : M} (hm : m ∈ N) :
+    TensorProduct.rid R M
+        (LinearMap.lTensor M f (Comodule.coact (R := R) (C := C) (M := M) m)) ∈ N := by
+  obtain ⟨x, hx⟩ := N.coact_mem hm
+  rw [← hx]
+  clear hx hm
+  induction x with
+  | zero => simp
+  | tmul y c => simpa using N.carrier.smul_mem (f c) y.2
+  | add a b ha hb => simpa only [map_add] using add_mem ha hb
+
 /-- Constructor from a submodule and the tensor-product stability condition. -/
 @[expose] def ofSubmodule (N : Submodule R M) (hN :
       ∀ ⦃m : M⦄, m ∈ N →
@@ -208,6 +227,9 @@ instance : OrderBot (Subcomodule R C M) where
     rw [mem_bot] at hm
     rw [hm]
     exact zero_mem N
+
+/-- The zero and full subcomodules bound the order of subcomodules. -/
+instance : BoundedOrder (Subcomodule R C M) where
 
 variable {N : Type x} [AddCommMonoid N] [Module R N] [Comodule R C N]
 


### PR DESCRIPTION
This PR constructs the standard representation of `GLₙ` and proves the two properties of it that the structure theory of reductive groups consumes. The generic matrix gives a coaction of the coordinate Hopf algebra `O(GLₙ)` on the column space `Rⁿ`, sending the `j`-th standard basis vector to the `j`-th column (`TauCeti.GeneralLinear.standardComodule`). Its coefficient matrix in the standard basis is the generic matrix, so its coordinate morphism `O(GLₙ) ⟶ O(GLₙ)` is the identity and therefore surjective, which makes the representation faithful in the closed-immersion sense of `TauCeti.Comodule.IsFaithful` (`isFaithful_standardComodule`). Over a field and for `m ≠ 0` it is also simple: `instIsSimpleOrderSubcomodule` says the lattice `Subcomodule k (O(GLₘ)) (kᵐ)` is a simple order, so the only subrepresentations of `kᵐ` are `0` and `kᵐ`. The file additionally records that a point of `GLₙ` acts on the standard comodule by the invertible matrix it names, under the canonical identification `A ⊗[R] Rⁿ ≃ Aⁿ` (`piScalarRight_comp_endOfPoint`).

The milestone is Layer 6, "Reductive and semisimple groups", of `TauCetiRoadmap/ReductiveGroups/README.md`, together with the "Worked examples" section that asks for `GLₙ` to be proved reductive by the geometric condition `R_u = 1` that works in every characteristic. The roadmap's own status snapshot names "a group proved reductive" as a frontier: `TauCeti.reductiveCommHopfAlgProperty` and `TauCeti.torusCommHopfAlgProperty.reductive` are on `main`, but `GLₙ` and `SLₙ` are not known to be reductive. The standard argument for `GLₙ` is that a connected normal smooth unipotent closed subgroup `N` of the geometric fibre has a nonzero fixed vector in `kᵐ` by Kolchin (already available as `TauCeti.Comodule.hasNonzeroFixedVector_of_forall_isUnipotentPoint`), that the fixed vectors of a normal subgroup form a subrepresentation, that simplicity then forces `N` to act trivially on `kᵐ`, and that faithfulness makes `N` trivial. This PR supplies the two facts about `GLₙ` itself that the argument uses. What remains for the milestone after this PR is exactly the one general Hopf-algebra input that open PR #4240 also identifies as its own next step: that the invariants of a normal closed subgroup form a subcomodule of the ambient group's representation.

The simplicity proof runs through a new piece of general subcomodule API. `TauCeti.Subcomodule.rid_lTensor_coact_mem` in `TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean` says a subcomodule is stable under contracting the coaction against a linear functional on the coalgebra; over a Hopf algebra the contractions along the algebra homomorphisms `C →ₐ[R] R` are the actions of the `R`-valued points, so this is the statement that a subcomodule is a subrepresentation, and it belongs beside the `coact_mem` it is proved from rather than in this file. The same file gains the `BoundedOrder` instance that `IsSimpleOrder` needs, assembled from the `OrderTop` and `OrderBot` instances already there. Specialised to the standard comodule, the contraction against the point attached to an invertible matrix is multiplication by that matrix (`rid_lTensor_comp_standardCoact`, `mulVec_mem`), and transitivity of `GL(m, k)` on nonzero vectors finishes. That transitivity is a general linear-algebra fact that Mathlib has only for topological vector spaces (`SeparatingDual`), so it is proved here as a private lemma out of `Submodule.exists_linearEquiv_restrict_eq` and `LinearEquiv.toSpanNonzeroSingleton`; it is kept private rather than exported under `TauCeti.GeneralLinear`, where it would sit in the wrong namespace.

The comodule construction, its coefficient-matrix computation and the point-action formula follow the template of `TauCeti.Algebra.AlgebraicGroup.UpperUnitriangular.Unipotent`, which does the same for the upper-unitriangular group; the existing `O(GLₙ)` coordinate API (`coordinateHopfAlgebra_comul_X`, `coordinateHopfAlgebra_counit_X`, `coordinateHopfAlgebra_algHom_ext`, `generalLinearToPoint_apply`, `pointToGeneralLinear_apply`) is consumed unchanged. No Mathlib infrastructure or external formalization is vendored. The mathematics follows Milne, *Algebraic Groups* (2017), §4.a and §5, and Jantzen, *Representations of Algebraic Groups*, I.2, as cited in the module documentation.

Adds `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean` (280 lines) and 23 lines to `TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"standard-representation-of-gln-is-simple"}-->

🤖 Prepared with Claude Code
