### PR TITLE
feat(EllipticCurve): the Φ 2 division-polynomial identity and its Ψ₃ factorisation

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+
+/-!
+# Identities among the univariate division polynomials
+
+Mathlib gives the univariate polynomials `Φₙ` in two registers. `Φ_three` and `Φ_four` are stated
+through the division polynomials `Ψ₃`, `preΨ₄` and `Ψ₂Sq`; `Φ_two` is stated through the
+`b`-invariants, as `X ^ 4 - C b₄ * X ^ 2 - C (2 * b₆) * X - C b₈`. This file supplies the `n = 2`
+member of the first register, which Mathlib does not have.
+
+## Main results
+
+* `WeierstrassCurve.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃`: `Φ₂ = X · Ψ₂Sq - Ψ₃`.
+
+Unconditional: an identity in `R[X]` over an arbitrary commutative ring, with no point of a curve,
+no ellipticity and no hypothesis of any kind. Declarations here are stated in the root
+`WeierstrassCurve` namespace, not under `TauCeti`, because they extend Mathlib's own
+division-polynomial API and mention nothing of this repository's — the same call
+`DivisionPolynomial/Invariant.lean` makes for `invar`, `C_Ψ₃` and `preΨ₄_add_Ψ₂Sq_sq`, and what
+`scripts/lint-dot-notation.py` requires so that `W.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃` elaborates.
+
+## Roadmap
+
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz",
+names the discriminant half of the theorem twice: at `:827` as
+"`lutz_nagell_integrality_general`, with its discriminant companion", and in the Layer 6 note at
+`:1163`–`:1170` as "the `κ² ∣ 4Δ` discriminant form". The `Φ 2` identity is the step that turns the
+doubling formula for the `x`-coordinate into the factorisation `Ψ₃(x) = (x - x')·Ψ₂Sq(x)` that
+argument runs on. The rest of that route — the point-level doubling formula and
+`lutz_nagell_integrality_general` — is not in this repository yet, and nothing here assumes it.
+
+## Provenance
+
+Ported from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at `dev/modular-curves @
+9fec8eba7652`, the revision that roadmap pins for `projects/NagellLutz` (`:1071`).
+
+The identity is **unnamed** in the source. It appears only as the inner `show` of the `eval`-level
+wrapper `Phi2_eval_eq`, in two files and with byte-identical proofs:
+`LutzNagell/LutzNagellTheorem/PIDMain.lean:305` and
+`LutzNagell/LutzNagellTheorem/GeneralDiscriminant.lean:89`. Naming it at polynomial level is the
+adaptation; the tactic script is the source's, with its bare `simp` squeezed to `simp only`.
+
+The source's two `eval`-level wrappers are deliberately not ported. `Phi2_eval_eq` is this identity
+followed by `eval_sub, eval_mul, eval_X`, and `PsiSq_two_eval_eq` is Mathlib's `ΨSq_two` under
+`eval`; neither earns a declaration once the polynomial identity has one.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-- **`Φ 2` through the division polynomials**: `Φ₂ = X · Ψ₂Sq - Ψ₃`.
+
+The index-`2` companion to Mathlib's `Φ_three` and `Φ_four`, which are stated in the division
+polynomials where `Φ_two` is stated in the `b`-invariants. It is the shape the `x`-coordinate of a
+doubled point is read in, that coordinate being `Φ₂/ΨSq₂`. -/
+theorem Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃ : W.Φ 2 = X * W.Ψ₂Sq - W.Ψ₃ := by
+  -- `Φ n = X * ΨSq n - preΨ (n + 1) * preΨ (n - 1) * (if Even n then 1 else Ψ₂Sq)`; at `n = 2` the
+  -- three division polynomials involved are `ΨSq 2 = Ψ₂Sq`, `preΨ 3 = Ψ₃` and `preΨ 1 = 1`.
+  rw [WeierstrassCurve.Φ, ΨSq_two]
+  simp only [Int.reduceAdd, preΨ_three, Int.reduceSub, preΨ_one, mul_one, even_two, ↓reduceIte]
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -18,9 +18,12 @@ member of the first register, which Mathlib does not have.
 ## Main results
 
 * `WeierstrassCurve.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃`: `Φ₂ = X · Ψ₂Sq - Ψ₃`.
+* `WeierstrassCurve.eval_Ψ₃_eq_sub_mul_eval_Ψ₂Sq`: its consumer — from the cleared doubling
+  relation `x' · ΨSq₂(x) = Φ₂(x)`, the factorisation `Ψ₃(x) = (x - x') · Ψ₂Sq(x)`.
 
-Unconditional: an identity in `R[X]` over an arbitrary commutative ring, with no point of a curve,
-no ellipticity and no hypothesis of any kind. Declarations here are stated in the root
+Both hold over an arbitrary commutative ring, with no point of a curve, no ellipticity and no
+division; the first has no hypothesis at all and the second's is an equation between ring elements.
+Declarations here are stated in the root
 `WeierstrassCurve` namespace, not under `TauCeti`, because they extend Mathlib's own
 division-polynomial API and mention nothing of this repository's — the same call
 `DivisionPolynomial/Invariant.lean` makes for `invar`, `C_Ψ₃` and `preΨ₄_add_Ψ₂Sq_sq`, and what
@@ -41,15 +44,22 @@ argument runs on. The rest of that route — the point-level doubling formula an
 Ported from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at `dev/modular-curves @
 9fec8eba7652`, the revision that roadmap pins for `projects/NagellLutz` (`:1071`).
 
-The identity is **unnamed** in the source. It appears only as the inner `show` of the `eval`-level
-wrapper `Phi2_eval_eq`, in two files and with byte-identical proofs:
+The `Φ 2` identity is **unnamed** in the source. It appears only as the inner `show` of the
+`eval`-level wrapper `Phi2_eval_eq`, in two files and with byte-identical proofs:
 `LutzNagell/LutzNagellTheorem/PIDMain.lean:305` and
 `LutzNagell/LutzNagellTheorem/GeneralDiscriminant.lean:89`. Naming it at polynomial level is the
 adaptation; the tactic script is the source's, with its bare `simp` squeezed to `simp only`.
 
-The source's two `eval`-level wrappers are deliberately not ported. `Phi2_eval_eq` is this identity
-followed by `eval_sub, eval_mul, eval_X`, and `PsiSq_two_eval_eq` is Mathlib's `ΨSq_two` under
-`eval`; neither earns a declaration once the polynomial identity has one.
+The factorisation is also unnamed there: it is the anonymous
+`have hPsi3_eq : eval x Ψ₃ = (x - x') * eval x Ψ₂Sq := by linarith` inside
+`kappa_sq_dvd_four_Psi3` (`GeneralDiscriminant.lean:153`), stated over `ℚ` after both `eval`-level
+wrappers have fired. `PIDMain.lean:390` carries a variant of the same step with `κ₀ ^ 2` already
+substituted for `Ψ₂Sq(x)`. Here it is stated over any commutative ring, since nothing in it needs a
+field, and it takes the doubling relation as a hypothesis rather than reconstructing it.
+
+The source's two `eval`-level wrappers themselves are deliberately not ported. `Phi2_eval_eq` is
+the `Φ 2` identity followed by `eval_sub, eval_mul, eval_X`, and `PsiSq_two_eval_eq` is Mathlib's
+`ΨSq_two` under `eval`; neither earns a declaration once the polynomial identity has one.
 -/
 
 public section
@@ -70,5 +80,16 @@ theorem Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃ : W.Φ 2 = X * W.Ψ₂Sq - W.Ψ₃ := 
   -- three division polynomials involved are `ΨSq 2 = Ψ₂Sq`, `preΨ 3 = Ψ₃` and `preΨ 1 = 1`.
   rw [WeierstrassCurve.Φ, ΨSq_two]
   simp only [Int.reduceAdd, preΨ_three, Int.reduceSub, preΨ_one, mul_one, even_two, ↓reduceIte]
+
+/-- **`Ψ₃` factorises through the doubling formula**: if `x'` and `x` satisfy the `x`-coordinate
+doubling relation in its cleared form `x' · ΨSq₂(x) = Φ₂(x)`, then `Ψ₃(x) = (x - x') · Ψ₂Sq(x)`.
+
+The hypothesis is an equation between ring elements rather than the quotient `x' = Φ₂(x)/ΨSq₂(x)`,
+so this holds over an arbitrary commutative ring, with no division and no hypothesis that
+`ΨSq₂(x)` is a non-zero-divisor. -/
+theorem eval_Ψ₃_eq_sub_mul_eval_Ψ₂Sq {x x' : R} (h : x' * (W.ΨSq 2).eval x = (W.Φ 2).eval x) :
+    (W.Ψ₃).eval x = (x - x') * (W.Ψ₂Sq).eval x := by
+  rw [ΨSq_two, W.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃, eval_sub, eval_mul, eval_X] at h
+  linear_combination h
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Discriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Discriminant.lean
@@ -33,17 +33,13 @@ should export. For a short model (`a₁ = a₃ = 0`, so `κ = 2y`) that future c
 * `TauCeti.WeierstrassCurve.dvd_four_mul_Δ_of_dvd_Ψ₂Sq_of_dvd_four_mul_Ψ₃`: over any commutative
   ring, a common divisor of `Ψ₂Sq(x)` and `4·Ψ₃(x)` divides `4Δ`.
 * `TauCeti.WeierstrassCurve.evalEval_ψ₂_sq`: on the curve, `ψ₂(x, y)² = Ψ₂Sq(x)`.
-* `WeierstrassCurve.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃`: `Φ₂ = X · Ψ₂Sq - Ψ₃`, the division-polynomial
-  form of `Φ 2` that Mathlib states only through the `b`-invariants. It extends Mathlib's own
-  `Φ_two`/`Φ_three`/`Φ_four` family and mentions nothing of this repository's, so it is stated in
-  the root `WeierstrassCurve` namespace where `W.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃` elaborates.
 
 Stated over an arbitrary commutative ring: no domain, integrality or ellipticity hypothesis.
 
 ⚠ **No torsion hypothesis appears here, and no part of `lutz_nagell` is proved.** Nothing in this
 file takes a premise that awaits absent material: the headline is a statement about polynomials,
-usable by any caller with a common divisor in hand, and `evalEval_ψ₂_sq` and
-`Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃` are unconditional identities.
+usable by any caller with a common divisor in hand, and `evalEval_ψ₂_sq` is an unconditional
+on-curve evaluation.
 
 This is an ingredient for the Nagell–Lutz milestone of `TauCetiRoadmap/EllipticCurves/README.md`,
 Layer 6, item "The torsion subgroup and Nagell–Lutz", whose short-model target `lutz_nagell` asks
@@ -69,23 +65,6 @@ public section
 open Polynomial
 
 open scoped Polynomial.Bivariate
-
-namespace WeierstrassCurve
-
-variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
-
-/-- **`Φ 2` through the division polynomials**: `Φ₂ = X · Ψ₂Sq - Ψ₃`.
-
-Mathlib gives `Φ 3` and `Φ 4` in terms of `Ψ₃`, `preΨ₄` and `Ψ₂Sq`, but `Φ 2` only through the
-`b`-invariants (`Φ_two`); this is the degree-`2` member of that first family. It is the shape the
-`x`-coordinate of a doubled point is read in, that coordinate being `Φ₂/ΨSq₂`. -/
-theorem Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃ : W.Φ 2 = X * W.Ψ₂Sq - W.Ψ₃ := by
-  -- `Φ n = X * ΨSq n - preΨ (n + 1) * preΨ (n - 1) * (if Even n then 1 else Ψ₂Sq)`; at `n = 2` the
-  -- three division polynomials involved are `ΨSq 2 = Ψ₂Sq`, `preΨ 3 = Ψ₃` and `preΨ 1 = 1`.
-  rw [WeierstrassCurve.Φ, ΨSq_two]
-  simp only [Int.reduceAdd, preΨ_three, Int.reduceSub, preΨ_one, mul_one, even_two, ↓reduceIte]
-
-end WeierstrassCurve
 
 namespace TauCeti
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Discriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Discriminant.lean
@@ -33,13 +33,17 @@ should export. For a short model (`a₁ = a₃ = 0`, so `κ = 2y`) that future c
 * `TauCeti.WeierstrassCurve.dvd_four_mul_Δ_of_dvd_Ψ₂Sq_of_dvd_four_mul_Ψ₃`: over any commutative
   ring, a common divisor of `Ψ₂Sq(x)` and `4·Ψ₃(x)` divides `4Δ`.
 * `TauCeti.WeierstrassCurve.evalEval_ψ₂_sq`: on the curve, `ψ₂(x, y)² = Ψ₂Sq(x)`.
+* `WeierstrassCurve.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃`: `Φ₂ = X · Ψ₂Sq - Ψ₃`, the division-polynomial
+  form of `Φ 2` that Mathlib states only through the `b`-invariants. It extends Mathlib's own
+  `Φ_two`/`Φ_three`/`Φ_four` family and mentions nothing of this repository's, so it is stated in
+  the root `WeierstrassCurve` namespace where `W.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃` elaborates.
 
 Stated over an arbitrary commutative ring: no domain, integrality or ellipticity hypothesis.
 
 ⚠ **No torsion hypothesis appears here, and no part of `lutz_nagell` is proved.** Nothing in this
 file takes a premise that awaits absent material: the headline is a statement about polynomials,
-usable by any caller with a common divisor in hand, and `evalEval_ψ₂_sq` is an unconditional
-on-curve evaluation.
+usable by any caller with a common divisor in hand, and `evalEval_ψ₂_sq` and
+`Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃` are unconditional identities.
 
 This is an ingredient for the Nagell–Lutz milestone of `TauCetiRoadmap/EllipticCurves/README.md`,
 Layer 6, item "The torsion subgroup and Nagell–Lutz", whose short-model target `lutz_nagell` asks
@@ -65,6 +69,23 @@ public section
 open Polynomial
 
 open scoped Polynomial.Bivariate
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-- **`Φ 2` through the division polynomials**: `Φ₂ = X · Ψ₂Sq - Ψ₃`.
+
+Mathlib gives `Φ 3` and `Φ 4` in terms of `Ψ₃`, `preΨ₄` and `Ψ₂Sq`, but `Φ 2` only through the
+`b`-invariants (`Φ_two`); this is the degree-`2` member of that first family. It is the shape the
+`x`-coordinate of a doubled point is read in, that coordinate being `Φ₂/ΨSq₂`. -/
+theorem Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃ : W.Φ 2 = X * W.Ψ₂Sq - W.Ψ₃ := by
+  -- `Φ n = X * ΨSq n - preΨ (n + 1) * preΨ (n - 1) * (if Even n then 1 else Ψ₂Sq)`; at `n = 2` the
+  -- three division polynomials involved are `ΨSq 2 = Ψ₂Sq`, `preΨ 3 = Ψ₃` and `preΨ 1 = 1`.
+  rw [WeierstrassCurve.Φ, ΨSq_two]
+  simp only [Int.reduceAdd, preΨ_three, Int.reduceSub, preΨ_one, mul_one, even_two, ↓reduceIte]
+
+end WeierstrassCurve
 
 namespace TauCeti
 


### PR DESCRIPTION
A new module, `TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean`, with the
degree-`2` gap in Mathlib's `Φₙ` API and the one step that consumes it:

```lean
theorem WeierstrassCurve.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃ (W : WeierstrassCurve R) :
    W.Φ 2 = X * W.Ψ₂Sq - W.Ψ₃

theorem WeierstrassCurve.eval_Ψ₃_eq_sub_mul_eval_Ψ₂Sq (W : WeierstrassCurve R) {x x' : R}
    (h : x' * (W.ΨSq 2).eval x = (W.Φ 2).eval x) :
    (W.Ψ₃).eval x = (x - x') * (W.Ψ₂Sq).eval x
```

Over any commutative ring. The first has no hypothesis at all; the second's is an equation between
ring elements, so there is no division and no nondegeneracy condition on `ΨSq₂(x)`.

## Round 2 — all four findings taken

**`placement`.** Round 1 put the identity in `DivisionPolynomial/Discriminant.lean`. The finding is
right that it mentions no discriminant material and depends only on Mathlib's basic
division-polynomial API, and its `_Fix:` names the destination: *"Move the theorem to a TauCeti
division-polynomial `Basic.lean` extension importing Mathlib's `DivisionPolynomial.Basic`."* Done —
that is the new module, and `Discriminant.lean` is now **byte-identical to `main`** (`git diff
origin/main -- …/Discriminant.lean` is empty). It does not need to import the new module, since
nothing in it consumes the identity yet.

**`documentation`.** *"'degree-`2` member' is misleading: `Φ 2` has index 2, while Mathlib's
`Φ_two` expansion has leading term `X ^ 4`."* Correct, and my error — `Φ 2` has degree 4. The
docstring now says "the index-`2` companion".

**`attribution`.** The provenance is now in the module docstring, not only in this description, and
it is more specific than round 1's. Every line number re-measured at the pin:

| | source | line |
|---|---|---|
| `Φ 2` identity, as the inner `show` of `Phi2_eval_eq` | `LutzNagellTheorem/PIDMain.lean` | `:305` |
| the same, byte-identical | `LutzNagellTheorem/GeneralDiscriminant.lean` | `:89` |
| the factorisation, as an anonymous `have … := by linarith` | `LutzNagellTheorem/GeneralDiscriminant.lean` | `:153` |
| a variant with `κ₀ ^ 2` already substituted | `LutzNagellTheorem/PIDMain.lean` | `:390` |

**`scope`.** *"Land this identity with the point-level doubling/factorisation consumer or with a
Nagell–Lutz declaration that uses it."* The **factorisation consumer** is now in the PR:
`eval_Ψ₃_eq_sub_mul_eval_Ψ₂Sq` is precisely the step `Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃` exists to enable,
and it is the source's own next line. So the identity is no longer unused — it has its consumer in
the same module, and the module is a coherent unit rather than a satellite.

What is **not** in this PR is the *point-level* consumer, and that is a queue fact rather than a
design choice. `kappa_sq_dvd_four_Psi3` needs `lutz_nagell_integrality_general`, and the doubling
relation that discharges `eval_Ψ₃_eq_sub_mul_eval_Ψ₂Sq`'s hypothesis is
`mul_eval_ΨSq_eq_eval_Φ_of_zsmul` in **#4088**, currently at position 17 in the merge queue. Nothing
in this repository can supply that hypothesis today — measured, not assumed: `grep -rn x_coord_nsmul
TauCeti/` on `origin/main` returns 0 files, as does the concept search for an `n`-multiple
`x`-coordinate formula.

Worth naming the tension so it can be adjudicated rather than re-fired: `scope` **blocked #4259**
for the opposite reason — *"the PR combines it with substantial prerequisite and separate torsion
work that must be split."* A prerequisite cannot both be split out of its consumer's PR and be
forbidden from standing alone. The reading that satisfies both, and the one this round implements,
is that a prerequisite may land with **its own immediate consumer** and without the whole downstream
development.

## Reuse

Mathlib states the `Φₙ` in two registers and the `n = 2` member is missing from one:

| | Mathlib's form | file |
|---|---|---|
| `Φ_two` | `X ^ 4 - C b₄ * X ^ 2 - C (2 * b₆) * X - C b₈` — `b`-invariants | `DivisionPolynomial/Basic.lean:371` |
| `Φ_three` | `X * Ψ₃ ^ 2 - preΨ₄ * Ψ₂Sq` — division polynomials | `:378` |
| `Φ_four` | `X * preΨ₄ ^ 2 * Ψ₂Sq - Ψ₃ * (…)` — division polynomials | `:383` |

```
grep -rn "Φ_two\|Φ 2 ="  .lake/packages/mathlib/Mathlib/   -> 1 hit, the b-invariant form above
grep -rn "Ψ₂Sq" …/Mathlib/ | grep -i eval                  -> 0 hits (no eval-level Ψ₂Sq API at all)
grep -rn "Φ 2\|Φ_two"     TauCeti/                         -> 4 hits, all Φ_two_mem_range_expand
```

Positive control on the same corpus: `grep -rn "Φ_three"` returns the declaration, so the queries
reach the file that would hold the answer.

**Why the identity is named rather than inlined.** The source needs it in two different files and
inlines it *both* times, as an anonymous `show` nested inside an `eval`-level wrapper. Two inline
copies in the source is the evidence that one named lemma is the right shape.

## Namespace

Root `WeierstrassCurve`, not `TauCeti.WeierstrassCurve`. Two reasons that agree: these extend
Mathlib's own division-polynomial API and mention nothing of this repository's, which is the call
`DivisionPolynomial/Invariant.lean` already makes for `invar`, `C_Ψ₃` and `preΨ₄_add_Ψ₂Sq_sq`; and
`scripts/lint-dot-notation.py` requires it — in round 1 the `TauCeti.WeierstrassCurve` form was a
**new** violation (`1154 total, 1293 grandfathered, 1 new`) because `W.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃`
cannot elaborate from a Mathlib type's namespace nested inside `TauCeti`.

## Gates

Re-run in full after every change, all three, against pin `e310d5e` matching `main`:

- `lake build` — `BUILD_EXIT=0`, zero `error` and zero `warning` lines in the whole log.
- `scripts/lint-env.sh` — PASS, 64 grandfathered / 6 ratchetable, unchanged.
- `scripts/lint-dot-notation.py` — `EXIT=0`, `0 new` (`1153 total, 1293 grandfathered`).

Line width re-measured in **codepoints** rather than bytes (the file is dense in `Ψ`, `Φ`, `₂`, so a
byte count over-reports by ~10 per line): widest line 99.

`/cleanup` on the new module: per-declaration pass on both theorems; simp squeezed (`simp?` → the
seven-lemma `simp only`, replacing the source's bare `simp`); docstrings state results with the
`Φ`-unfolding mechanics in a `--` comment; module docstring carries Main results, the namespace
rationale, the roadmap citation and provenance. `Discriminant.lean` needs **no** `/cleanup` entry —
it is byte-identical to `main`, the round-1 edit having been fully reverted. `/buzz` **skipped** —
two proofs of two tactics each, no elaboration cost to profile. `/decompose-proof` **n/a** — longest
proof is 3 lines against a 30-line flag.

Roadmap: EllipticCurves

New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821`–`:830`, "**The torsion subgroup and
Nagell–Lutz**", which names the discriminant half at `:827` — "`lutz_nagell_integrality_general`,
with its discriminant companion" — and again in the Layer 6 note at `:1163`–`:1170`, "the `κ² ∣ 4Δ`
discriminant form".

Provenance: `github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/modular-curves @ 9fec8eba7652` — the
revision the roadmap pins for `projects/NagellLutz` at `:1071`. Both results are **unnamed** in the
source; the table above gives each site. The source's `eval`-level wrappers `Phi2_eval_eq` and
`PsiSq_two_eval_eq` are deliberately not ported — the first is the `Φ 2` identity plus
`eval_sub, eval_mul, eval_X`, the second is Mathlib's `ΨSq_two` under `eval`.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"phi-two-division-polynomial-form"}-->

🤖 Prepared with Claude Code (Claude Opus 5)
