### PR TITLE
feat(Multiquadratic): the 2-rank of Cl(ℚ(√-21)) is 2

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/Basic.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.AdjoinRoot
+public import Mathlib.NumberTheory.NumberField.Basic
+import TauCeti.NumberTheory.NumberField.IntegralSqrt
+import Mathlib.FieldTheory.KummerPolynomial
+
+/-!
+# The `AdjoinRoot (X² + 21)` model of `ℚ(√-21)`
+
+The concrete number field `AdjoinRoot (X² + 21)` serving as the canonical model of `ℚ(√-21)`,
+together with its integral generator. This presentation datum is foundational: it is shared by both
+the class-number and the `2`-rank worked examples for this field, so it lives here rather than in
+either of them.
+
+## Main results
+
+* `TauCeti.NumberField.exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top`: the model has an
+  integral generator with minimal polynomial `X² + 21` generating the field over `ℚ`.
+-/
+
+public section
+
+open NumberField Polynomial
+open scoped NumberField
+
+namespace TauCeti.NumberField
+
+/-- `X² + 21` is irreducible over `ℚ`, so `AdjoinRoot (X² + 21)` is a field. Declared once here (and
+reused via `public import` by both worked-example modules) with an explicit, field-specific name: an
+anonymous `Fact (Irreducible …)` instance receives an auto-generated name that ignores the radicand,
+so the `-21` and `-5` instances would collide under one name when the whole library is loaded for
+the axioms audit. -/
+instance irreducible_sqrt_neg_twenty_one : Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
+  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
+    (fun q _ => by nlinarith [sq_nonneg q])⟩
+
+/-- The concrete model `AdjoinRoot (X² + 21)` of `ℚ(√-21)` carries an integral generator with
+minimal polynomial `X² + 21` generating the field over `ℚ`: the presentation data shared by the
+class-number and `2`-rank worked examples for this field. -/
+theorem exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top :
+    ∃ θ : 𝓞 (AdjoinRoot (X ^ 2 - C (-21 : ℚ))),
+      minpoly ℤ θ = X ^ 2 - C (-21 : ℤ) ∧
+        Algebra.adjoin ℚ {(θ : AdjoinRoot (X ^ 2 - C (-21 : ℚ)))} = ⊤ := by
+  let K := AdjoinRoot (X ^ 2 - C (-21 : ℚ))
+  let x : K := AdjoinRoot.root (X ^ 2 - C (-21 : ℚ))
+  have hx : x ^ 2 = algebraMap ℤ K (-21 : ℤ) := by
+    have hroot := AdjoinRoot.eval₂_root (X ^ 2 - C (-21 : ℚ))
+    rw [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C, ← AdjoinRoot.algebraMap_eq, sub_eq_zero] at hroot
+    rw [hroot, IsScalarTower.algebraMap_apply ℤ ℚ K]
+    norm_num
+  refine ⟨integralSqrt hx, minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
+      norm_num at hq
+      nlinarith [mul_self_nonneg q]), ?_⟩
+  have hθx : ((integralSqrt hx : 𝓞 K) : K) = x := algebraMap_integralSqrt hx
+  rw [hθx]
+  exact AdjoinRoot.adjoinRoot_eq_top
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
@@ -6,11 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.NumberTheory.NumberField.ClassNumber
-public import Mathlib.RingTheory.AdjoinRoot
+public import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
 import Mathlib.Analysis.Real.Pi.Bounds
 import TauCeti.NumberTheory.Multiquadratic.Quadratic.RamifiedPrime.Independence
 import TauCeti.NumberTheory.NumberField.ClassGroupElementaryTwoQuotient
-import TauCeti.NumberTheory.NumberField.IntegralSqrt
 import TauCeti.NumberTheory.NumberField.PrimeIdeal
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 import TauCeti.NumberTheory.NumberField.Quadratic.RingOfIntegers
@@ -303,36 +302,12 @@ theorem classNumber_eq_four_of_minpoly_eq_X_sq_add_twenty_one
   obtain ⟨n, hn⟩ := hfourdvd
   omega
 
-local instance irreducible_sqrt_neg_twenty_one :
-    Fact (Irreducible (X ^ 2 - C (-21 : ℚ))) := ⟨by
-  exact (X_pow_sub_C_irreducible_iff_of_prime Nat.prime_two).mpr
-    (fun q _ => by nlinarith [sq_nonneg q])⟩
-
 /-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`,
 has class number `4`. -/
 @[simp]
 theorem classNumber_adjoinRoot_sqrt_neg_twenty_one_eq_four :
     NumberField.classNumber (AdjoinRoot (X ^ 2 - C (-21 : ℚ))) = 4 := by
-  let K := AdjoinRoot (X ^ 2 - C (-21 : ℚ))
-  let x : K := AdjoinRoot.root (X ^ 2 - C (-21 : ℚ))
-  have hx : x ^ 2 = algebraMap ℤ K (-21 : ℤ) := by
-    have hroot := AdjoinRoot.eval₂_root (X ^ 2 - C (-21 : ℚ))
-    rw [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C, ← AdjoinRoot.algebraMap_eq, sub_eq_zero] at hroot
-    rw [hroot, IsScalarTower.algebraMap_apply ℤ ℚ K]
-    norm_num
-  let θ : 𝓞 K := integralSqrt hx
-  have hmin : minpoly ℤ θ = X ^ 2 - C (-21 : ℤ) :=
-    minpoly_integralSqrt hx (fun ⟨q, hq⟩ => by
-      norm_num at hq
-      nlinarith [mul_self_nonneg q])
-  have hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤ := by
-    have hfne : (X ^ 2 - C (-21 : ℚ)) ≠ 0 :=
-      (monic_X_pow_sub_C (-21 : ℚ) (by norm_num)).ne_zero
-    have hpb := (AdjoinRoot.powerBasis (f := X ^ 2 - C (-21 : ℚ)) hfne).adjoin_gen_eq_top
-    rw [AdjoinRoot.powerBasis_gen] at hpb
-    have hθx : (θ : K) = x := algebraMap_integralSqrt hx
-    rw [hθx]
-    exact hpb
+  obtain ⟨θ, hmin, hgen⟩ := exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top
   exact classNumber_eq_four_of_minpoly_eq_X_sq_add_twenty_one hmin hgen
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/TwoRank.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.TwoRank
+public import TauCeti.NumberTheory.Multiquadratic.MinusTwentyOne.Basic
+import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminants
+
+/-!
+# The `2`-rank of the class group of `ℚ(√-21)`
+
+Applying the genus-theoretic `2`-rank formula `2-rank Cl(K) = t - 1` to `K = ℚ(√-21)`. The
+fundamental discriminant is `-84 = (-4) · (-3) · (-7)`, a product of three prime discriminants, so
+`t = 3` rational primes ramify (`2`, `3` and `7`) and the `2`-rank of the class group is `2`.
+
+This corroborates the independently proved `NumberField.classNumber ℚ(√-21) = 4`
+(`MinusTwentyOne/ClassNumber.lean`): the class group is `(ℤ/2ℤ)²`, whose `2`-rank is indeed `2`, so
+genus theory (predicting `t - 1 = 2` purely from ramification) and the direct class-number
+computation agree.
+
+## Main results
+
+* `TauCeti.Multiquadratic.twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one`: the
+  presentation-independent statement.
+* `TauCeti.Multiquadratic.twoRank_adjoinRoot_sqrt_neg_twenty_one_eq_two`: on the concrete model
+  `AdjoinRoot (X² + 21)`.
+-/
+
+public section
+
+open Polynomial NumberField
+open scoped NumberField
+
+namespace TauCeti.Multiquadratic
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K}
+
+/-- **The `2`-rank of the class group of `ℚ(√-21)` is `2`.** Its fundamental discriminant `-84`
+factors as `(-4) · (-3) · (-7)` into three prime discriminants, so three rational primes ramify
+(`t = 3`) and `2-rank Cl = t - 1 = 2`. This corroborates `NumberField.classNumber ℚ(√-21) = 4`
+(`Cl ≅ (ℤ/2ℤ)²`). -/
+theorem twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one
+    (hmin : minpoly ℤ θ = X ^ 2 - C (-21 : ℤ)) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    TauCeti.ClassGroup.twoRank (𝓞 K) = 2 := by
+  have hsf : Squarefree (-21 : ℤ) := by
+    rw [← Int.squarefree_natAbs]
+    simpa using (Nat.squarefree_mul (by decide : Nat.Coprime 3 7)).mpr
+      ⟨(by decide : Nat.Prime 3).squarefree, (by decide : Nat.Prime 7).squarefree⟩
+  have hs : ∀ P ∈ ({-4, -3, -7} : Finset ℤ), IsPrimeDiscriminant P := by
+    intro P hP
+    fin_cases hP
+    · exact isPrimeDiscriminant_neg_four
+    · simpa [oddPrimeDiscriminant_of_mod_four_eq_three (by norm_num : 3 % 4 = 3)]
+        using isPrimeDiscriminant_oddPrimeDiscriminant (p := 3) (by decide) (by decide)
+    · simpa [oddPrimeDiscriminant_of_mod_four_eq_three (by norm_num : 7 % 4 = 3)]
+        using isPrimeDiscriminant_oddPrimeDiscriminant (p := 7) (by decide) (by decide)
+  have heven : ∀ P ∈ ({-4, -3, -7} : Finset ℤ), ∀ Q ∈ ({-4, -3, -7} : Finset ℤ),
+      IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant Q → P = Q := by
+    intro P hP Q hQ
+    fin_cases hP <;> fin_cases hQ <;> simp only [IsEvenPrimeDiscriminant] <;> decide
+  have hprod : ∏ P ∈ ({-4, -3, -7} : Finset ℤ), P = fundamentalDiscriminant (-21 : ℤ) := by
+    rw [Finset.prod_insert (by decide : (-4 : ℤ) ∉ ({-3, -7} : Finset ℤ)),
+      Finset.prod_insert (by decide : (-3 : ℤ) ∉ ({-7} : Finset ℤ)), Finset.prod_singleton,
+      fundamentalDiscriminant_of_mod_four_ne_one (by decide : (-21 : ℤ) % 4 ≠ 1)]
+    ring
+  have hncard : (ramifiedPrimes K).ncard = 3 := by
+    rw [ncard_ramifiedPrimes_eq_card hmin hgen hsf hs heven hprod,
+      Finset.card_insert_of_notMem (by decide : (-4 : ℤ) ∉ ({-3, -7} : Finset ℤ)),
+      Finset.card_insert_of_notMem (by decide : (-3 : ℤ) ∉ ({-7} : Finset ℤ)),
+      Finset.card_singleton]
+  rw [twoRank_eq_ncard_ramifiedPrimes_sub_one hmin hgen hsf (by norm_num), hncard]
+
+/-- **Worked example.** The concrete number field `AdjoinRoot (X² + 21)`, modelling `ℚ(√-21)`, has
+class-group `2`-rank `2`. Not `@[simp]`: the `@[simp]` lemma `twoRank_def` unfolds the left-hand
+side `twoRank _`, so this closed form is not in simp-normal form (`simpNF` rejects it), unlike the
+non-unfolded `classNumber` companion. -/
+theorem twoRank_adjoinRoot_sqrt_neg_twenty_one_eq_two :
+    TauCeti.ClassGroup.twoRank (𝓞 (AdjoinRoot (X ^ 2 - C (-21 : ℚ)))) = 2 := by
+  obtain ⟨θ, hmin, hgen⟩ := NumberField.exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top
+  exact twoRank_eq_two_of_minpoly_eq_X_sq_add_twenty_one hmin hgen
+
+end TauCeti.Multiquadratic


### PR DESCRIPTION
The second worked example of the genus-theoretic 2-rank formula `2-rank Cl(K) = t - 1` (`twoRank_eq_ncard_ramifiedPrimes_sub_one`): for `K = ℚ(√-21)`, the fundamental discriminant `-84 = (-4)·(-3)·(-7)` is a product of three prime discriminants, so `t = 3` rational primes ramify (`2`, `3`, `7`) and the class-group 2-rank is `2`.

This **corroborates** the independently proved `NumberField.classNumber ℚ(√-21) = 4` (`MinusTwentyOne/ClassNumber.lean`): `Cl ≅ (ℤ/2ℤ)²` has 2-rank exactly `2`. It is the exact analog, at the next radicand, of the ℚ(√-5) worked example.

**Refactor.** The shared `AdjoinRoot (X²+21)` integral generator (`exists_minpoly_eq_X_sq_add_twenty_one_and_adjoin_eq_top`) is extracted into a new foundational `MinusTwentyOne/Basic.lean`, reused by both `ClassNumber.lean` and the new `TwoRank.lean` via `public import`.

Resubmission of #4233, whose all-green content could not be merged because GitHub's mergeability computation for that PR became stuck at `null` (`mergeable_state: unknown`) after many pushes; this is a clean single-commit branch off current `main`.

**Roadmap node.** `TauCetiRoadmap/Multiquadratic/README.md`, heading *### Layer 3: the genus field and the 2-rank theorem (the summit)*, "Worked examples" — ℚ(√-21) (discriminant -84), the second application of the merged 2-rank theorem to a specific field. No new axioms.

Roadmap: Multiquadratic
