### PR TITLE
feat: detect subcomodules on geometric points

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule.Evaluation
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Basic
+import Mathlib.LinearAlgebra.TensorProduct.Finiteness
+import Mathlib.LinearAlgebra.TensorProduct.RightExactness
+import TauCeti.RingTheory.FiniteType.PointSeparation
+
+/-!
+# Detecting subcomodules on geometric points
+
+Let `C` be a reduced commutative algebra of finite type over a field `k`, equipped with a
+coalgebra structure, and let `M` be a right `C`-comodule. A `k`-submodule `N` of `M` is a
+subcomodule if its scalar extension is
+preserved by every point of `C` valued in an algebraically closed extension of `k`.
+
+The substantive direction is descent from pointwise stability. For `m ∈ N`, apply the quotient
+map `M ⟶ M/N` to `coact m`. Every coordinate of the resulting tensor vanishes at every
+geometric point, because the corresponding point action preserves the scalar extension of `N`.
+Reduced finite-type point separation makes every coordinate zero. Right exactness of tensor
+product then identifies `coact m` with a tensor in `N ⊗ C`.
+
+## Main declarations
+
+* `TauCeti.Submodule.coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange`: pointwise
+  stability implies the tensor-product stability condition defining a subcomodule.
+* `TauCeti.Subcomodule.ofEndOfPointStable`: promote a point-stable submodule to a subcomodule.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.2.
+
+This supplies the point-separation step in Layer 6 of the ReductiveGroups roadmap: for a normal
+closed subgroup, pointwise normality makes its fixed subspace stable under the ambient group, and
+the result here promotes that stable subspace to an ambient-group subcomodule.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v w x
+
+noncomputable section
+
+namespace Submodule
+
+variable {k : Type u} {C : Type v} {M : Type w} {K : Type x}
+variable [Field k] [CommRing C] [Algebra k C] [Coalgebra k C]
+variable [Algebra.FiniteType k C] [IsReduced C]
+variable [AddCommGroup M] [Module k M] [Comodule k C M]
+variable [Field K] [Algebra k K] [IsAlgClosed K]
+
+/-- If every geometric point preserves the scalar extension of a submodule, the coaction of
+each element of that submodule belongs to its tensor product with the coefficient bialgebra.
+
+It is enough to test the pure tensors `1 ⊗ m`: the point action is linear over the value field,
+so this is equivalent to preservation of the whole scalar-extended submodule. -/
+theorem coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange
+    (N : Submodule k M)
+    (hN : ∀ (g : C →ₐ[k] K) {m : M}, m ∈ N →
+      Comodule.endOfPoint M g (1 ⊗ₜ[k] m) ∈ N.baseChange K)
+    {m : M} (hm : m ∈ N) :
+    Comodule.coact (R := k) (C := C) (M := M) m ∈
+      LinearMap.range (TensorProduct.map N.subtype (LinearMap.id : C →ₗ[k] C)) := by
+  let Q := M ⧸ N
+  let q : M →ₗ[k] Q := N.mkQ
+  let z : Q ⊗[k] C := LinearMap.rTensor C q (Comodule.coact (R := k) (C := C) m)
+  have hz : z = 0 := by
+    obtain ⟨Q', hQ', hzQ'⟩ := TensorProduct.exists_finite_submodule_left_of_setFinite
+      ({z} : Set (Q ⊗[k] C)) (Set.finite_singleton z)
+    obtain ⟨z', hz'⟩ := hzQ' (Set.mem_singleton z)
+    let _ : Module.Finite k Q' := hQ'
+    let b := Module.finBasis k Q'
+    have hz'zero : z' = 0 := by
+      apply (TensorProduct.equivFinsuppOfBasisLeft b).injective
+      ext i
+      rw [map_zero, Finsupp.zero_apply, TensorProduct.equivFinsuppOfBasisLeft_apply]
+      obtain ⟨φ, hφ⟩ := LinearMap.exists_extend (b.coord i)
+      apply TauCeti.eq_of_forall_algHom_apply_eq (k := k) (K := K)
+      intro g
+      obtain ⟨y, hy⟩ := hN g hm
+      have hyq : q.baseChange K (Comodule.endOfPoint M g (1 ⊗ₜ[k] m)) = 0 := by
+        rw [← hy]
+        rw [← LinearMap.comp_apply, ← LinearMap.baseChange_comp]
+        have hcomp : q.comp N.subtype = 0 := by
+          ext n
+          change N.mkQ (n : M) = 0
+          rw [N.mkQ_apply, Submodule.Quotient.mk_eq_zero]
+          exact n.2
+        rw [hcomp, LinearMap.baseChange_zero, LinearMap.zero_apply]
+      have heval := congrArg
+        (fun t ↦ TauCeti.Module.Dual.baseChangeEvaluation
+          (R := k) (M := Q) (A := K) (1 ⊗ₜ[k] φ) t) hyq
+      rw [map_zero] at heval
+      have heval_natural (t : K ⊗[k] M) :
+          TauCeti.Module.Dual.baseChangeEvaluation
+              (R := k) (M := Q) (A := K) (1 ⊗ₜ[k] φ) (q.baseChange K t) =
+            TauCeti.Module.Dual.baseChangeEvaluation
+              (R := k) (M := M) (A := K) (1 ⊗ₜ[k] (φ.comp q)) t := by
+        induction t using TensorProduct.induction_on with
+        | zero => simp
+        | add s t hs ht => simpa only [map_add] using congrArg₂ (· + ·) hs ht
+        | tmul a n => simp [TauCeti.Module.Dual.baseChangeEvaluation_tmul]
+      have hcoeff :
+          g (Comodule.matrixCoefficient (R := k) (C := C) (φ.comp q) m) = 0 := by
+        rw [heval_natural] at heval
+        simpa using heval
+      rw [map_zero]
+      rw [← hcoeff]
+      congr 1
+      rw [Comodule.matrixCoefficient_def]
+      calc
+        TensorProduct.lid k C (LinearMap.rTensor C (b.coord i) z') =
+            TensorProduct.lid k C (LinearMap.rTensor C (φ.comp Q'.subtype) z') := by
+              rw [hφ]
+        _ = TensorProduct.lid k C
+            (LinearMap.rTensor C φ (LinearMap.rTensor C Q'.subtype z')) := by
+              rw [LinearMap.rTensor_comp_apply]
+        _ = TensorProduct.lid k C (LinearMap.rTensor C φ z) := by rw [hz']
+        _ = TensorProduct.lid k C
+            (LinearMap.rTensor C φ
+              (LinearMap.rTensor C q (Comodule.coact (R := k) (C := C) m))) := rfl
+        _ = TensorProduct.lid k C
+            (LinearMap.rTensor C (φ.comp q) (Comodule.coact (R := k) (C := C) m)) := by
+              rw [LinearMap.rTensor_comp_apply]
+        _ = TensorProduct.lid k C
+            (TensorProduct.map (φ.comp q) LinearMap.id
+              (Comodule.coact (R := k) (C := C) m)) := by
+              rw [LinearMap.rTensor_def]
+    rw [← hz', hz'zero, map_zero]
+  have hzker : Comodule.coact (R := k) (C := C) (M := M) m ∈
+      LinearMap.ker (LinearMap.rTensor C q) := by
+    rw [LinearMap.mem_ker]
+    exact hz
+  have hexact : Function.Exact N.subtype q := LinearMap.exact_subtype_mkQ N
+  have hrange : LinearMap.ker (LinearMap.rTensor C q) =
+      LinearMap.range (LinearMap.rTensor C N.subtype) :=
+    Function.Exact.linearMap_ker_eq
+      (rTensor_exact C hexact (Submodule.mkQ_surjective N))
+  rw [hrange] at hzker
+  simpa [LinearMap.rTensor_def] using hzker
+
+end Submodule
+
+namespace Subcomodule
+
+section Preservation
+
+variable {R : Type u} {C : Type v} {M : Type w} {A : Type x}
+variable [CommSemiring R] [Semiring C] [Algebra R C] [Coalgebra R C]
+variable [AddCommMonoid M] [Module R M] [Comodule R C M]
+variable [CommSemiring A] [Algebra R A]
+
+/-- Every algebra-valued point preserves the scalar extension of a subcomodule. -/
+theorem endOfPoint_tmul_mem_baseChange (N : Subcomodule R C M) (g : C →ₐ[R] A)
+    (a : A) {m : M} (hm : m ∈ N) :
+    Comodule.endOfPoint M g (a ⊗ₜ[R] m) ∈ N.toSubmodule.baseChange A := by
+  have hmap (t : N.toSubmodule ⊗[R] C) :
+      a • TensorProduct.comm R M A
+          (LinearMap.lTensor M g.toLinearMap
+            (TensorProduct.map N.toSubmodule.subtype LinearMap.id t)) ∈
+        N.toSubmodule.baseChange A := by
+    induction t using TensorProduct.induction_on with
+    | zero => simp
+    | add s t hs ht => simpa only [map_add, smul_add] using add_mem hs ht
+    | tmul n c =>
+        simp only [TensorProduct.map_tmul, Submodule.coe_subtype, LinearMap.id_coe, id_eq,
+          LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, TensorProduct.comm_tmul]
+        exact Submodule.tmul_mem_baseChange_of_mem _ n.2
+  obtain ⟨t, ht⟩ := N.coact_mem hm
+  rw [Comodule.endOfPoint_tmul, ← ht]
+  exact hmap t
+
+end Preservation
+
+variable {k : Type u} {C : Type v} {M : Type w} {K : Type x}
+variable [Field k] [CommRing C] [Algebra k C] [Coalgebra k C]
+variable [Algebra.FiniteType k C] [IsReduced C]
+variable [AddCommGroup M] [Module k M] [Comodule k C M]
+variable [Field K] [Algebra k K] [IsAlgClosed K]
+
+/-- Promote a submodule whose scalar extension is preserved by every geometric point to a
+subcomodule. -/
+def ofEndOfPointStable (N : Submodule k M)
+    (hN : ∀ (g : C →ₐ[k] K) {m : M}, m ∈ N →
+      Comodule.endOfPoint M g (1 ⊗ₜ[k] m) ∈ N.baseChange K) :
+    Subcomodule k C M :=
+  ofSubmodule N
+    (fun _ hm ↦
+      TauCeti.Submodule.coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange N hN hm)
+
+/-- The point-stable subcomodule has the prescribed underlying submodule. -/
+@[simp]
+theorem ofEndOfPointStable_toSubmodule (N : Submodule k M)
+    (hN : ∀ (g : C →ₐ[k] K) {m : M}, m ∈ N →
+      Comodule.endOfPoint M g (1 ⊗ₜ[k] m) ∈ N.baseChange K) :
+    (ofEndOfPointStable N hN).toSubmodule = N :=
+  (rfl)
+
+end Subcomodule
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
@@ -95,10 +95,7 @@ theorem coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange
         rw [← hy]
         rw [← LinearMap.comp_apply, ← LinearMap.baseChange_comp]
         have hcomp : q.comp N.subtype = 0 := by
-          ext n
-          rw [LinearMap.comp_apply, LinearMap.zero_apply, Submodule.subtype_apply]
-          exact (N.mkQ_apply (n : M)).trans
-            ((Submodule.Quotient.mk_eq_zero N).mpr n.2)
+          simpa [q] using (LinearMap.exact_subtype_mkQ N).linearMap_comp_eq_zero
         rw [hcomp, LinearMap.baseChange_zero, LinearMap.zero_apply]
       have heval := congrArg
         (fun t ↦ TauCeti.Module.Dual.baseChangeEvaluation

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
@@ -28,7 +28,7 @@ product then identifies `coact m` with a tensor in `N ⊗ C`.
 
 ## Main declarations
 
-* `TauCeti.Submodule.coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange`: pointwise
+* `Submodule.coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange`: pointwise
   stability implies the tensor-product stability condition defining a subcomodule.
 * `TauCeti.Subcomodule.ofEndOfPointStable`: promote a point-stable submodule to a subcomodule.
 
@@ -46,13 +46,13 @@ public section
 
 open scoped TensorProduct
 
-namespace TauCeti
-
 universe u v w x
 
 noncomputable section
 
 namespace Submodule
+
+open TauCeti
 
 variable {k : Type u} {C : Type v} {M : Type w} {K : Type x}
 variable [Field k] [CommRing C] [Algebra k C] [Coalgebra k C]
@@ -152,6 +152,8 @@ theorem coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange
 
 end Submodule
 
+namespace TauCeti
+
 namespace Subcomodule
 
 section Preservation
@@ -197,7 +199,7 @@ def ofEndOfPointStable (N : Submodule k M)
     Subcomodule k C M :=
   ofSubmodule N
     (fun _ hm ↦
-      TauCeti.Submodule.coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange N hN hm)
+      Submodule.coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange N hN hm)
 
 /-- The point-stable subcomodule has the prescribed underlying submodule. -/
 @[simp]
@@ -209,6 +211,6 @@ theorem ofEndOfPointStable_toSubmodule (N : Submodule k M)
 
 end Subcomodule
 
-end
-
 end TauCeti
+
+end

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
@@ -106,7 +106,7 @@ theorem coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange
       rw [map_zero] at heval
       have hcoeff :
           g (Comodule.matrixCoefficient (R := k) (C := C) (φ.comp q) m) = 0 := by
-        rw [TauCeti.Module.Dual.baseChangeEvaluation_one_tmul_baseChange] at heval
+        rw [Module.Dual.baseChangeEvaluation_one_tmul_baseChange] at heval
         simpa only [Comodule.baseChangeEvaluation_endOfPoint_tmul, one_mul] using heval
       rw [map_zero]
       rw [← hcoeff]

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
@@ -104,7 +104,7 @@ theorem coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange
       rw [map_zero] at heval
       have hcoeff :
           g (Comodule.matrixCoefficient (R := k) (C := C) (φ.comp q) m) = 0 := by
-        rw [TauCeti.Module.Dual.baseChangeEvaluation_one_tmul_baseChange] at heval
+        rw [TauCeti.baseChangeEvaluation_one_tmul_baseChange] at heval
         simpa using heval
       rw [map_zero]
       rw [← hcoeff]

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
@@ -31,6 +31,8 @@ product then identifies `coact m` with a tensor in `N ⊗ C`.
 * `Submodule.coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange`: pointwise
   stability implies the tensor-product stability condition defining a subcomodule.
 * `TauCeti.Subcomodule.ofEndOfPointStable`: promote a point-stable submodule to a subcomodule.
+* `TauCeti.Subcomodule.endOfPoint_mapsTo_baseChange`: every algebra-valued point preserves
+  the scalar extension of a subcomodule.
 
 ## References
 
@@ -104,8 +106,8 @@ theorem coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange
       rw [map_zero] at heval
       have hcoeff :
           g (Comodule.matrixCoefficient (R := k) (C := C) (φ.comp q) m) = 0 := by
-        rw [TauCeti.baseChangeEvaluation_one_tmul_baseChange] at heval
-        simpa using heval
+        rw [TauCeti.Module.Dual.baseChangeEvaluation_one_tmul_baseChange] at heval
+        simpa only [Comodule.baseChangeEvaluation_endOfPoint_tmul, one_mul] using heval
       rw [map_zero]
       rw [← hcoeff]
       congr 1
@@ -133,12 +135,7 @@ theorem coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange
       LinearMap.ker (LinearMap.rTensor C q) := by
     rw [LinearMap.mem_ker]
     exact hz
-  have hexact : Function.Exact N.subtype q := LinearMap.exact_subtype_mkQ N
-  have hrange : LinearMap.ker (LinearMap.rTensor C q) =
-      LinearMap.range (LinearMap.rTensor C N.subtype) :=
-    Function.Exact.linearMap_ker_eq
-      (rTensor_exact C hexact (Submodule.mkQ_surjective N))
-  rw [hrange] at hzker
+  rw [rTensor_mkQ C N] at hzker
   simpa [LinearMap.rTensor_def] using hzker
 
 end Submodule
@@ -173,6 +170,22 @@ theorem endOfPoint_tmul_mem_baseChange (N : Subcomodule R C M) (g : C →ₐ[R] 
   obtain ⟨t, ht⟩ := N.coact_mem hm
   rw [Comodule.endOfPoint_tmul, ← ht]
   exact hmap t
+
+/-- Every algebra-valued point maps the scalar extension of a subcomodule into itself. -/
+theorem endOfPoint_mapsTo_baseChange (N : Subcomodule R C M) (g : C →ₐ[R] A) :
+    Set.MapsTo (Comodule.endOfPoint M g) (N.toSubmodule.baseChange A)
+      (N.toSubmodule.baseChange A) := by
+  intro x hx
+  rw [Submodule.baseChange] at hx
+  obtain ⟨t, rfl⟩ := hx
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | add s t hs ht =>
+      rw [map_add, map_add]
+      exact (N.toSubmodule.baseChange A).add_mem hs ht
+  | tmul a m =>
+      rw [LinearMap.baseChange_tmul]
+      exact N.endOfPoint_tmul_mem_baseChange g a m.2
 
 end Preservation
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean
@@ -61,7 +61,7 @@ variable [AddCommGroup M] [Module k M] [Comodule k C M]
 variable [Field K] [Algebra k K] [IsAlgClosed K]
 
 /-- If every geometric point preserves the scalar extension of a submodule, the coaction of
-each element of that submodule belongs to its tensor product with the coefficient bialgebra.
+each element of that submodule belongs to its tensor product with the coefficient coalgebra.
 
 It is enough to test the pure tensors `1 ⊗ m`: the point action is linear over the value field,
 so this is equivalent to preservation of the whole scalar-extended submodule. -/
@@ -94,26 +94,17 @@ theorem coact_mem_range_of_forall_endOfPoint_tmul_mem_baseChange
         rw [← LinearMap.comp_apply, ← LinearMap.baseChange_comp]
         have hcomp : q.comp N.subtype = 0 := by
           ext n
-          change N.mkQ (n : M) = 0
-          rw [N.mkQ_apply, Submodule.Quotient.mk_eq_zero]
-          exact n.2
+          rw [LinearMap.comp_apply, LinearMap.zero_apply, Submodule.subtype_apply]
+          exact (N.mkQ_apply (n : M)).trans
+            ((Submodule.Quotient.mk_eq_zero N).mpr n.2)
         rw [hcomp, LinearMap.baseChange_zero, LinearMap.zero_apply]
       have heval := congrArg
         (fun t ↦ TauCeti.Module.Dual.baseChangeEvaluation
           (R := k) (M := Q) (A := K) (1 ⊗ₜ[k] φ) t) hyq
       rw [map_zero] at heval
-      have heval_natural (t : K ⊗[k] M) :
-          TauCeti.Module.Dual.baseChangeEvaluation
-              (R := k) (M := Q) (A := K) (1 ⊗ₜ[k] φ) (q.baseChange K t) =
-            TauCeti.Module.Dual.baseChangeEvaluation
-              (R := k) (M := M) (A := K) (1 ⊗ₜ[k] (φ.comp q)) t := by
-        induction t using TensorProduct.induction_on with
-        | zero => simp
-        | add s t hs ht => simpa only [map_add] using congrArg₂ (· + ·) hs ht
-        | tmul a n => simp [TauCeti.Module.Dual.baseChangeEvaluation_tmul]
       have hcoeff :
           g (Comodule.matrixCoefficient (R := k) (C := C) (φ.comp q) m) = 0 := by
-        rw [heval_natural] at heval
+        rw [TauCeti.Module.Dual.baseChangeEvaluation_one_tmul_baseChange] at heval
         simpa using heval
       rw [map_zero]
       rw [← hcoeff]

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -21,7 +21,7 @@ on the scalar extension of its domain. For a finite projective module, this map 
 * `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul`: evaluation at a scalar-extended
   functional with coefficient one is its base change.
 * `TauCeti.Module.Dual.baseChangeEvaluation_tmul`: its value on two pure tensors.
-* `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul_baseChange`: naturality of evaluation
+* `TauCeti.baseChangeEvaluation_one_tmul_baseChange`: naturality of evaluation
   with respect to a base-changed linear map.
 * `TauCeti.Module.Dual.baseChangeEvaluationEquiv`: scalar extension commutes with the dual of a
   finite projective module.
@@ -76,7 +76,7 @@ theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
 
 /-- Evaluation against a base-changed functional is natural with respect to the base change of
 a linear map. -/
-theorem baseChangeEvaluation_one_tmul_baseChange
+theorem _root_.TauCeti.baseChangeEvaluation_one_tmul_baseChange
     {N : Type*} [AddCommMonoid N] [Module R N]
     (f : M →ₗ[R] N) (φ : Module.Dual R N) (t : A ⊗[R] M) :
     baseChangeEvaluation (R := R) (M := N) (A := A) (1 ⊗ₜ[R] φ) (f.baseChange A t) =

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -76,6 +76,7 @@ theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
 
 /-- Evaluation against a base-changed functional is natural with respect to the base change of
 a linear map. -/
+@[simp]
 theorem _root_.Module.Dual.baseChangeEvaluation_one_tmul_baseChange
     {N : Type*} [AddCommMonoid N] [Module R N]
     (f : M →ₗ[R] N) (φ : Module.Dual R N) (t : A ⊗[R] M) :

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -21,7 +21,7 @@ on the scalar extension of its domain. For a finite projective module, this map 
 * `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul`: evaluation at a scalar-extended
   functional with coefficient one is its base change.
 * `TauCeti.Module.Dual.baseChangeEvaluation_tmul`: its value on two pure tensors.
-* `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul_baseChange`: naturality of evaluation
+* `Module.Dual.baseChangeEvaluation_one_tmul_baseChange`: naturality of evaluation
   with respect to a base-changed linear map.
 * `TauCeti.Module.Dual.baseChangeEvaluationEquiv`: scalar extension commutes with the dual of a
   finite projective module.
@@ -76,7 +76,7 @@ theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
 
 /-- Evaluation against a base-changed functional is natural with respect to the base change of
 a linear map. -/
-theorem baseChangeEvaluation_one_tmul_baseChange
+theorem _root_.Module.Dual.baseChangeEvaluation_one_tmul_baseChange
     {N : Type*} [AddCommMonoid N] [Module R N]
     (f : M →ₗ[R] N) (φ : Module.Dual R N) (t : A ⊗[R] M) :
     baseChangeEvaluation (R := R) (M := N) (A := A) (1 ⊗ₜ[R] φ) (f.baseChange A t) =

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -21,7 +21,7 @@ on the scalar extension of its domain. For a finite projective module, this map 
 * `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul`: evaluation at a scalar-extended
   functional with coefficient one is its base change.
 * `TauCeti.Module.Dual.baseChangeEvaluation_tmul`: its value on two pure tensors.
-* `TauCeti.baseChangeEvaluation_one_tmul_baseChange`: naturality of evaluation
+* `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul_baseChange`: naturality of evaluation
   with respect to a base-changed linear map.
 * `TauCeti.Module.Dual.baseChangeEvaluationEquiv`: scalar extension commutes with the dual of a
   finite projective module.
@@ -76,7 +76,7 @@ theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
 
 /-- Evaluation against a base-changed functional is natural with respect to the base change of
 a linear map. -/
-theorem _root_.TauCeti.baseChangeEvaluation_one_tmul_baseChange
+theorem baseChangeEvaluation_one_tmul_baseChange
     {N : Type*} [AddCommMonoid N] [Module R N]
     (f : M →ₗ[R] N) (φ : Module.Dual R N) (t : A ⊗[R] M) :
     baseChangeEvaluation (R := R) (M := N) (A := A) (1 ⊗ₜ[R] φ) (f.baseChange A t) =

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -21,6 +21,8 @@ on the scalar extension of its domain. For a finite projective module, this map 
 * `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul`: evaluation at a scalar-extended
   functional with coefficient one is its base change.
 * `TauCeti.Module.Dual.baseChangeEvaluation_tmul`: its value on two pure tensors.
+* `TauCeti.Module.Dual.baseChangeEvaluation_one_tmul_baseChange`: naturality of evaluation
+  with respect to a base-changed linear map.
 * `TauCeti.Module.Dual.baseChangeEvaluationEquiv`: scalar extension commutes with the dual of a
   finite projective module.
 * `TauCeti.Module.Dual.baseChange_coord`: base-changed dual basis elements recover the
@@ -71,6 +73,18 @@ theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
     Module.Dual.baseChange_apply_tmul, Algebra.smul_def]
   rw [Algebra.algebraMap_self_apply]
   ac_rfl
+
+/-- Evaluation against a base-changed functional is natural with respect to the base change of
+a linear map. -/
+theorem baseChangeEvaluation_one_tmul_baseChange
+    {N : Type*} [AddCommMonoid N] [Module R N]
+    (f : M →ₗ[R] N) (φ : Module.Dual R N) (t : A ⊗[R] M) :
+    baseChangeEvaluation (R := R) (M := N) (A := A) (1 ⊗ₜ[R] φ) (f.baseChange A t) =
+      baseChangeEvaluation (R := R) (M := M) (A := A) (1 ⊗ₜ[R] (φ.comp f)) t := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | add s t hs ht => simpa only [map_add] using congrArg₂ (· + ·) hs ht
+  | tmul a m => simp [baseChangeEvaluation_tmul]
 
 section FiniteProjective
 


### PR DESCRIPTION
This PR promotes a `k`-submodule of a comodule to a subcomodule when every algebraically closed point preserves its scalar extension. For a vector in the submodule, it applies the quotient map `M ⟶ M/N` to the coaction, proves every coordinate of the resulting tensor vanishes on all geometric points, uses reduced finite-type point separation to make those coordinates zero in the coefficient algebra, and then uses tensor right-exactness to recover membership in `N ⊗ C`. The companion theorem proves the converse at the natural generality: every algebra-valued point preserves the scalar extension of any subcomodule.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, “Reductive and semisimple groups,” together with the worked-example target asking for `GLₙ` to be proved reductive. The current standard argument takes the fixed vectors of a normal smooth unipotent closed subgroup in the standard representation and needs them to form an ambient-`GLₙ` subrepresentation; pointwise normality supplies stability under all ambient geometric points, and `TauCeti.Subcomodule.ofEndOfPointStable` supplies precisely the missing point-to-comodule conversion. This is the most effective unclaimed step because open PRs #4240 and #4263 independently identify normal-subgroup invariants as their next input, while the other unipotent-radical assembly steps are already covered by open PRs #4139, #4154, and #4159.

After this PR, the milestone still needs the normal-subgroup fixed subspace defined and shown pointwise stable, followed by the application to prove `GLₙ` reductive and the remaining characteristic-zero comparison between reductivity and linear reductivity.

The change adds `TauCeti/Algebra/Coalgebra/Subcomodule/PointSeparation.lean` (214 lines). It reuses Mathlib’s `TensorProduct.exists_finite_submodule_left_of_setFinite`, `LinearMap.exists_extend`, `LinearMap.exact_subtype_mkQ`, and tensor right-exactness, together with Tau Ceti’s reduced finite-type point-separation theorem and scalar-extended evaluation API. No Mathlib infrastructure or external formalization is vendored. The mathematical organization follows Jantzen, *Representations of Algebraic Groups*, I.2, and Springer, *Linear Algebraic Groups*, §2.2, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"point-stable-submodules-are-subcomodules"}-->

🤖 Prepared with Codex
