### PR TITLE
feat: separate exchangeability of a block of a jointly exchangeable array

### DIFF
--- a/TauCeti/GroupTheory/Perm/Basic.lean
+++ b/TauCeti/GroupTheory/Perm/Basic.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Group.End
-public import Mathlib.GroupTheory.Perm.ViaEmbedding
+import Mathlib.GroupTheory.Perm.ViaEmbedding
 
 /-!
 # Elementary facts about permutations

--- a/TauCeti/GroupTheory/Perm/Basic.lean
+++ b/TauCeti/GroupTheory/Perm/Basic.lean
@@ -12,7 +12,8 @@ import Mathlib.GroupTheory.Perm.ViaEmbedding
 # Elementary facts about permutations
 
 This file records general-purpose facts about permutations: an identity between transpositions,
-and the combination of two permutations transported along injections with disjoint ranges.
+a permutation transported along an injection, and the combination of two permutations transported
+along injections with disjoint ranges.
 -/
 
 public section
@@ -34,6 +35,14 @@ theorem swap_braid {α : Type*} [DecidableEq α] {a b c : α} (hab : a ≠ b) (h
       _ = Equiv.swap c a := Equiv.swap_comm a c
       _ = Equiv.swap b c * Equiv.swap a b * Equiv.swap b c :=
           (Equiv.swap_mul_swap_mul_swap hab hac).symm
+
+/-- **A permutation along an injection extends to a permutation of the ambient type.** Given an
+injection `e : α → γ`, every permutation `σ` of `α` is realized along `e` by some
+`ρ : Equiv.Perm γ`. This is `Equiv.Perm.viaEmbedding` stated in terms of the underlying function
+of the injection, which is the form a consumer reindexing along `e` needs. -/
+theorem exists_perm_apply_eq {α γ : Type*} {e : α → γ} (he : Function.Injective e)
+    (σ : Equiv.Perm α) : ∃ ρ : Equiv.Perm γ, ∀ a, ρ (e a) = e (σ a) :=
+  ⟨σ.viaEmbedding ⟨e, he⟩, fun a => Equiv.Perm.viaEmbedding_apply (ι := ⟨e, he⟩) σ a⟩
 
 /-- **Two permutations along disjoint injections extend to one permutation of the ambient type.**
 Given injections `e : α → γ` and `f : β → γ` with disjoint ranges, every pair of permutations

--- a/TauCeti/GroupTheory/Perm/Basic.lean
+++ b/TauCeti/GroupTheory/Perm/Basic.lean
@@ -35,21 +35,10 @@ theorem swap_braid {α : Type*} [DecidableEq α] {a b c : α} (hab : a ≠ b) (h
       _ = Equiv.swap b c * Equiv.swap a b * Equiv.swap b c :=
           (Equiv.swap_mul_swap_mul_swap hab hac).symm
 
-/-- **A permutation transported along an injection extends to the ambient type.** The witness is
-`Equiv.Perm.viaEmbedding σ e`, the identity off the range of `e`; this restatement in terms of the
-underlying function of the injection is the form a consumer rewriting with it needs. -/
-theorem exists_perm_apply_eq {α γ : Type*} {e : α → γ} (he : Function.Injective e)
-    (σ : Equiv.Perm α) : ∃ ρ : Equiv.Perm γ, ∀ a, ρ (e a) = e (σ a) :=
-  ⟨σ.viaEmbedding ⟨e, he⟩, fun a => Equiv.Perm.viaEmbedding_apply (ι := ⟨e, he⟩) σ a⟩
-
 /-- **Two permutations along disjoint injections extend to one permutation of the ambient type.**
 Given injections `e : α → γ` and `f : β → γ` with disjoint ranges, every pair of permutations
 `σ` of `α` and `τ` of `β` is realized by a single `ρ : Equiv.Perm γ` which acts as `σ` along `e`
-and as `τ` along `f`.
-
-The witness is `Equiv.Perm.viaEmbedding σ e * Equiv.Perm.viaEmbedding τ f`, each factor being the
-identity off the range of its own injection; disjointness of the ranges is what keeps the two
-factors from interfering. -/
+and as `τ` along `f`. -/
 theorem exists_perm_apply_eq_of_disjoint_range {α β γ : Type*} {e : α → γ} {f : β → γ}
     (he : Function.Injective e) (hf : Function.Injective f)
     (hd : Disjoint (Set.range e) (Set.range f)) (σ : Equiv.Perm α) (τ : Equiv.Perm β) :

--- a/TauCeti/GroupTheory/Perm/Basic.lean
+++ b/TauCeti/GroupTheory/Perm/Basic.lean
@@ -52,8 +52,12 @@ theorem exists_perm_apply_eq_of_disjoint_range {α β γ : Type*} {e : α → γ
     (he : Function.Injective e) (hf : Function.Injective f)
     (hd : Disjoint (Set.range e) (Set.range f)) (σ : Equiv.Perm α) (τ : Equiv.Perm β) :
     ∃ ρ : Equiv.Perm γ, (∀ a, ρ (e a) = e (σ a)) ∧ ∀ b, ρ (f b) = f (τ b) := by
-  have hrange_e : Set.range (⟨e, he⟩ : α ↪ γ) = Set.range e := rfl
-  have hrange_f : Set.range (⟨f, hf⟩ : β ↪ γ) = Set.range f := rfl
+  -- `Function.Embedding.coeFn_mk` is what carries a statement about the bundled embedding
+  -- `⟨e, he⟩` over to the function `e` it is built from.
+  have hrange_e : Set.range (⟨e, he⟩ : α ↪ γ) = Set.range e := by
+    rw [Function.Embedding.coeFn_mk]
+  have hrange_f : Set.range (⟨f, hf⟩ : β ↪ γ) = Set.range f := by
+    rw [Function.Embedding.coeFn_mk]
   have hone : ∀ a, σ.viaEmbedding ⟨e, he⟩ (e a) = e (σ a) :=
     fun a => Equiv.Perm.viaEmbedding_apply (ι := ⟨e, he⟩) σ a
   have htwo : ∀ b, τ.viaEmbedding ⟨f, hf⟩ (f b) = f (τ b) :=

--- a/TauCeti/GroupTheory/Perm/Basic.lean
+++ b/TauCeti/GroupTheory/Perm/Basic.lean
@@ -6,11 +6,13 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Group.End
+public import Mathlib.GroupTheory.Perm.ViaEmbedding
 
 /-!
 # Elementary facts about permutations
 
-This file records general-purpose identities between transpositions.
+This file records general-purpose facts about permutations: an identity between transpositions,
+and the combination of two permutations transported along injections with disjoint ranges.
 -/
 
 public section
@@ -32,5 +34,40 @@ theorem swap_braid {α : Type*} [DecidableEq α] {a b c : α} (hab : a ≠ b) (h
       _ = Equiv.swap c a := Equiv.swap_comm a c
       _ = Equiv.swap b c * Equiv.swap a b * Equiv.swap b c :=
           (Equiv.swap_mul_swap_mul_swap hab hac).symm
+
+/-- **A permutation transported along an injection extends to the ambient type.** The witness is
+`Equiv.Perm.viaEmbedding σ e`, the identity off the range of `e`; this restatement in terms of the
+underlying function of the injection is the form a consumer rewriting with it needs. -/
+theorem exists_perm_apply_eq {α γ : Type*} {e : α → γ} (he : Function.Injective e)
+    (σ : Equiv.Perm α) : ∃ ρ : Equiv.Perm γ, ∀ a, ρ (e a) = e (σ a) :=
+  ⟨σ.viaEmbedding ⟨e, he⟩, fun a => Equiv.Perm.viaEmbedding_apply (ι := ⟨e, he⟩) σ a⟩
+
+/-- **Two permutations along disjoint injections extend to one permutation of the ambient type.**
+Given injections `e : α → γ` and `f : β → γ` with disjoint ranges, every pair of permutations
+`σ` of `α` and `τ` of `β` is realized by a single `ρ : Equiv.Perm γ` which acts as `σ` along `e`
+and as `τ` along `f`.
+
+The witness is `Equiv.Perm.viaEmbedding σ e * Equiv.Perm.viaEmbedding τ f`, each factor being the
+identity off the range of its own injection; disjointness of the ranges is what keeps the two
+factors from interfering. -/
+theorem exists_perm_apply_eq_of_disjoint_range {α β γ : Type*} {e : α → γ} {f : β → γ}
+    (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f)) (σ : Equiv.Perm α) (τ : Equiv.Perm β) :
+    ∃ ρ : Equiv.Perm γ, (∀ a, ρ (e a) = e (σ a)) ∧ ∀ b, ρ (f b) = f (τ b) := by
+  have hrange_e : Set.range (⟨e, he⟩ : α ↪ γ) = Set.range e := rfl
+  have hrange_f : Set.range (⟨f, hf⟩ : β ↪ γ) = Set.range f := rfl
+  have hone : ∀ a, σ.viaEmbedding ⟨e, he⟩ (e a) = e (σ a) :=
+    fun a => Equiv.Perm.viaEmbedding_apply (ι := ⟨e, he⟩) σ a
+  have htwo : ∀ b, τ.viaEmbedding ⟨f, hf⟩ (f b) = f (τ b) :=
+    fun b => Equiv.Perm.viaEmbedding_apply (ι := ⟨f, hf⟩) τ b
+  refine ⟨σ.viaEmbedding ⟨e, he⟩ * τ.viaEmbedding ⟨f, hf⟩, fun a => ?_, fun b => ?_⟩
+  · have hmem : e a ∉ Set.range (⟨f, hf⟩ : β ↪ γ) :=
+      hrange_f ▸ Set.disjoint_left.mp hd ⟨a, rfl⟩
+    rw [Equiv.Perm.mul_apply,
+      Equiv.Perm.viaEmbedding_apply_of_notMem (ι := ⟨f, hf⟩) _ _ hmem, hone]
+  · have hmem : f (τ b) ∉ Set.range (⟨e, he⟩ : α ↪ γ) :=
+      hrange_e ▸ Set.disjoint_right.mp hd ⟨τ b, rfl⟩
+    rw [Equiv.Perm.mul_apply, htwo,
+      Equiv.Perm.viaEmbedding_apply_of_notMem (ι := ⟨e, he⟩) _ _ hmem]
 
 end TauCeti

--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -60,8 +60,6 @@ hypothesis is needed beyond the ones de Finetti already asks of `α`.
   are conditionally i.i.d.
 * `TauCeti.Probability.JointlyExchangeable.fullyExchangeable_arrayDiag` — the diagonal of a jointly
   exchangeable array is a fully exchangeable sequence.
-* `TauCeti.Probability.JointlyExchangeable.map_entry_eq_of_ne_of_ne` — the off-diagonal entries of
-  a jointly exchangeable array are identically distributed.
 * `TauCeti.Probability.ExchangeableFamily.separatelyExchangeable` and
   `TauCeti.Probability.separatelyExchangeable_of_iIndepFun_identDistrib` — the sources: an
   exchangeable family indexed by `ℕ × ℕ`, in particular an i.i.d. array, is separately
@@ -346,27 +344,6 @@ theorem JointlyExchangeable.exchangeable_arrayDiag {μ : Measure Ω} {X : ℕ ×
     (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
     Exchangeable μ (arrayDiag X) :=
   FullyExchangeable.exchangeable (h.fullyExchangeable_arrayDiag hX) fun i => hX (i, i)
-
-/-! ## Off-diagonal entries -/
-
-/-- **The off-diagonal entries of a jointly exchangeable array are identically distributed.** -/
-theorem JointlyExchangeable.map_entry_eq_of_ne_of_ne {μ : Measure Ω}
-    {X : ℕ × ℕ → Ω → α} (h : JointlyExchangeable μ X)
-    (hX : ∀ p, AEMeasurable (X p) μ) {i j k l : ℕ} (hij : i ≠ j) (hkl : k ≠ l) :
-    μ.map (X (i, j)) = μ.map (X (k, l)) := by
-  classical
-  -- `Equiv.swap i k` sends `i` to `k`, and the second transposition then fixes `k` and moves the
-  -- image of `j` to `l`.
-  have hne : Equiv.swap i k j ≠ k := by
-    intro hk
-    have hji := congrArg (Equiv.swap i k) hk
-    rw [Equiv.swap_apply_self, Equiv.swap_apply_right] at hji
-    exact hij hji.symm
-  have key := h.map_comp hX (Equiv.swap (Equiv.swap i k j) l * Equiv.swap i k)
-    (F := fun x => x (i, j)) (measurable_pi_apply _)
-  simp only [Equiv.Perm.mul_apply, Equiv.swap_apply_left,
-    Equiv.swap_apply_of_ne_of_ne (Ne.symm hne) hkl] at key
-  simpa using key.symm
 
 /-! ## De Finetti for the rows -/
 

--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -60,6 +60,8 @@ hypothesis is needed beyond the ones de Finetti already asks of `α`.
   are conditionally i.i.d.
 * `TauCeti.Probability.JointlyExchangeable.fullyExchangeable_arrayDiag` — the diagonal of a jointly
   exchangeable array is a fully exchangeable sequence.
+* `TauCeti.Probability.JointlyExchangeable.map_entry_eq_of_ne_of_ne` — the off-diagonal entries of
+  a jointly exchangeable array are identically distributed.
 * `TauCeti.Probability.ExchangeableFamily.separatelyExchangeable` and
   `TauCeti.Probability.separatelyExchangeable_of_iIndepFun_identDistrib` — the sources: an
   exchangeable family indexed by `ℕ × ℕ`, in particular an i.i.d. array, is separately
@@ -344,6 +346,27 @@ theorem JointlyExchangeable.exchangeable_arrayDiag {μ : Measure Ω} {X : ℕ ×
     (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
     Exchangeable μ (arrayDiag X) :=
   FullyExchangeable.exchangeable (h.fullyExchangeable_arrayDiag hX) fun i => hX (i, i)
+
+/-! ## Off-diagonal entries -/
+
+/-- **The off-diagonal entries of a jointly exchangeable array are identically distributed.** -/
+theorem JointlyExchangeable.map_entry_eq_of_ne_of_ne {μ : Measure Ω}
+    {X : ℕ × ℕ → Ω → α} (h : JointlyExchangeable μ X)
+    (hX : ∀ p, AEMeasurable (X p) μ) {i j k l : ℕ} (hij : i ≠ j) (hkl : k ≠ l) :
+    μ.map (X (i, j)) = μ.map (X (k, l)) := by
+  classical
+  -- `Equiv.swap i k` sends `i` to `k`, and the second transposition then fixes `k` and moves the
+  -- image of `j` to `l`.
+  have hne : Equiv.swap i k j ≠ k := by
+    intro hk
+    have hji := congrArg (Equiv.swap i k) hk
+    rw [Equiv.swap_apply_self, Equiv.swap_apply_right] at hji
+    exact hij hji.symm
+  have key := h.map_comp hX (Equiv.swap (Equiv.swap i k j) l * Equiv.swap i k)
+    (F := fun x => x (i, j)) (measurable_pi_apply _)
+  simp only [Equiv.Perm.mul_apply, Equiv.swap_apply_left,
+    Equiv.swap_apply_of_ne_of_ne (Ne.symm hne) hkl] at key
+  simpa using key.symm
 
 /-! ## De Finetti for the rows -/
 

--- a/TauCeti/Probability/Exchangeability/Arrays/Block.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Block.lean
@@ -6,11 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Exchangeability.Arrays.Basic
--- Non-public: the permutations transported along injections, the permutation combining two
--- disjoint injections, and the reduction of an array law to its finite-dimensional marginals, are
--- used only inside proofs.
+-- Non-public: the permutation realizing one prescribed permutation along an injection, the one
+-- realizing two along injections with disjoint ranges, and the reduction of an array law to its
+-- finite-dimensional marginals, are used only inside proofs.
 import TauCeti.GroupTheory.Perm.Basic
-import Mathlib.GroupTheory.Perm.ViaEmbedding
 import Mathlib.Probability.Process.FiniteDimensionalLaws
 
 /-!
@@ -52,8 +51,8 @@ coordinates of each such pair agree.
   the block read together with its transpose;
 * `TauCeti.Probability.JointlyExchangeable.separatelyExchangeable_arrayBlock_evenOdd` — the
   canonical instance, along the even and the odd indices;
-* `TauCeti.Probability.not_separatelyExchangeable_arrayBlock_id_id` — the disjointness hypothesis
-  is necessary;
+* `TauCeti.Probability.not_separatelyExchangeable_arrayBlock_diagIndicatorArray` — the disjointness
+  hypothesis is necessary;
 * `TauCeti.Probability.JointlyExchangeable.map_arrayBlock_eq` — the block law does not depend on
   the chosen pair of index maps;
 * `TauCeti.Probability.JointlyExchangeable.map_arrayBlockPair_eq` — the corresponding canonical-law
@@ -106,16 +105,7 @@ theorem arrayBlockPair_apply (X : ℕ × ℕ → Ω → α) (e f : ℕ → ℕ) 
     arrayBlockPair X e f p ω = (X (e p.1, f p.2) ω, X (f p.2, e p.1) ω) :=
   (rfl)
 
-/-- The block along the identity index maps is the array itself. -/
-@[simp]
-theorem arrayBlock_id_id (X : ℕ × ℕ → Ω → α) : arrayBlock X id id = X :=
-  (rfl)
-
 variable [MeasurableSpace α] [MeasurableSpace Ω] {μ : Measure Ω} {X : ℕ × ℕ → Ω → α} {e f : ℕ → ℕ}
-
-theorem aemeasurable_arrayBlock (hX : ∀ p, AEMeasurable (X p) μ) (p : ℕ × ℕ) :
-    AEMeasurable (arrayBlock X e f p) μ :=
-  hX _
 
 theorem aemeasurable_arrayBlockPair (hX : ∀ p, AEMeasurable (X p) μ) (p : ℕ × ℕ) :
     AEMeasurable (arrayBlockPair X e f p) μ :=
@@ -139,39 +129,23 @@ theorem SeparatelyExchangeable.arrayBlock (h : SeparatelyExchangeable μ X)
     (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f) :
     SeparatelyExchangeable μ (arrayBlock X e f) := by
   refine separatelyExchangeable_iff.mpr fun σ τ => ?_
-  let ι : ℕ ↪ ℕ := ⟨e, he⟩
-  let κ : ℕ ↪ ℕ := ⟨f, hf⟩
-  have key := h.map_comp hX (σ.viaEmbedding ι) (τ.viaEmbedding κ)
-    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (ι p.1, κ p.2))
-    (measurable_blockReadOff ι κ)
-  have hσ : ∀ i, (σ.viaEmbedding ι) (ι i) = ι (σ i) :=
-    fun i => Equiv.Perm.viaEmbedding_apply (ι := ι) σ i
-  have hτ : ∀ j, (τ.viaEmbedding κ) (κ j) = κ (τ j) :=
-    fun j => Equiv.Perm.viaEmbedding_apply (ι := κ) τ j
-  have hfun : (fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
-      (τ.viaEmbedding κ) (κ p.2)) ω) = fun ω (p : ℕ × ℕ) => X (ι (σ p.1), κ (τ p.2)) ω := by
-    funext ω p
-    exact congrArg (fun q => X q ω) (Prod.ext (hσ p.1) (hτ p.2))
-  have key' := (congrArg (fun g => Measure.map g μ) hfun).symm.trans key
-  simpa [ι, κ, arrayBlock] using key'
+  obtain ⟨ρ, hρe⟩ := exists_perm_apply_eq he σ
+  obtain ⟨ρ', hρf⟩ := exists_perm_apply_eq hf τ
+  have key := h.map_comp hX ρ ρ' (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (e p.1, f p.2))
+    (measurable_blockReadOff e f)
+  simp only [hρe, hρf] at key
+  simpa only [arrayBlock_apply] using key
 
 /-- **Joint exchangeability passes to diagonal blocks along an injection.** -/
 theorem JointlyExchangeable.arrayBlock_diag (h : JointlyExchangeable μ X)
     (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) :
     JointlyExchangeable μ (arrayBlock X e e) := by
   refine jointlyExchangeable_iff.mpr fun σ => ?_
-  let ι : ℕ ↪ ℕ := ⟨e, he⟩
-  have key := h.map_comp hX (σ.viaEmbedding ι)
-    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (ι p.1, ι p.2))
-    (measurable_blockReadOff ι ι)
-  have hσ : ∀ i, (σ.viaEmbedding ι) (ι i) = ι (σ i) :=
-    fun i => Equiv.Perm.viaEmbedding_apply (ι := ι) σ i
-  have hfun : (fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
-      (σ.viaEmbedding ι) (ι p.2)) ω) = fun ω (p : ℕ × ℕ) => X (ι (σ p.1), ι (σ p.2)) ω := by
-    funext ω p
-    exact congrArg (fun q => X q ω) (Prod.ext (hσ p.1) (hσ p.2))
-  have key' := (congrArg (fun g => Measure.map g μ) hfun).symm.trans key
-  simpa [ι, arrayBlock] using key'
+  obtain ⟨ρ, hρe⟩ := exists_perm_apply_eq he σ
+  have key := h.map_comp hX ρ (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (e p.1, e p.2))
+    (measurable_blockReadOff e e)
+  simp only [hρe] at key
+  simpa only [arrayBlock_apply] using key
 
 /-- **A block of a jointly exchangeable array along injections with disjoint ranges is separately
 exchangeable.**
@@ -206,22 +180,15 @@ theorem JointlyExchangeable.separatelyExchangeable_arrayBlockPair (h : JointlyEx
 /-! ## The canonical block, along the even and the odd indices -/
 
 -- The parity facts instantiating the canonical block below; they carry no exchangeability content.
-private theorem injective_two_mul : Function.Injective fun i : ℕ => 2 * i := by
-  intro a b h
-  have h' : 2 * a = 2 * b := h
-  omega
+private theorem injective_two_mul : Function.Injective fun i : ℕ => 2 * i :=
+  mul_right_injective₀ two_ne_zero
 
-private theorem injective_two_mul_add_one : Function.Injective fun j : ℕ => 2 * j + 1 := by
-  intro a b h
-  have h' : 2 * a + 1 = 2 * b + 1 := h
-  omega
+private theorem injective_two_mul_add_one : Function.Injective fun j : ℕ => 2 * j + 1 :=
+  (add_left_injective 1).comp injective_two_mul
 
 private theorem disjoint_range_two_mul :
     Disjoint (Set.range fun i : ℕ => 2 * i) (Set.range fun j : ℕ => 2 * j + 1) := by
-  refine Set.disjoint_left.mpr ?_
-  rintro _ ⟨i, rfl⟩ ⟨j, hj⟩
-  have hj' : 2 * j + 1 = 2 * i := hj
-  omega
+  simp [Set.disjoint_left]
 
 /-- **The canonical separately exchangeable block of a jointly exchangeable array**: read the rows
 along the even indices and the columns along the odd ones. Any pair of injections with disjoint
@@ -241,10 +208,16 @@ theorem JointlyExchangeable.separatelyExchangeable_arrayBlockPair_evenOdd
     disjoint_range_two_mul
 
 /-- **The disjointness hypothesis of `JointlyExchangeable.separatelyExchangeable_arrayBlock` cannot
-be omitted.** With identity index maps, the diagonal-indicator array gives a counterexample. -/
-theorem not_separatelyExchangeable_arrayBlock_id_id (μ : Measure Ω) [IsProbabilityMeasure μ] :
-    ¬SeparatelyExchangeable μ (arrayBlock (diagIndicatorArray Ω) id id) := by
-  rw [arrayBlock_id_id]
+be omitted.** Reading both axes along one and the same injection — the extreme case of overlapping
+ranges — the diagonal-indicator array gives a counterexample: the block is again the
+diagonal-indicator array, whose rows are not exchangeable. -/
+theorem not_separatelyExchangeable_arrayBlock_diagIndicatorArray (μ : Measure Ω)
+    [IsProbabilityMeasure μ] (he : Function.Injective e) :
+    ¬SeparatelyExchangeable μ (arrayBlock (diagIndicatorArray Ω) e e) := by
+  have hblock : arrayBlock (diagIndicatorArray Ω) e e = diagIndicatorArray Ω := by
+    funext p ω
+    simp [he.eq_iff]
+  rw [hblock]
   exact not_separatelyExchangeable_diagIndicatorArray μ
 
 /-! ## The block law is canonical -/
@@ -351,8 +324,7 @@ theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock [StandardBorelS
     (he : Function.Injective e) (hf : Function.Injective f)
     (hd : Disjoint (Set.range e) (Set.range f)) :
     ConditionallyIID μ (arrayRow (arrayBlock X e f)) :=
-  (h.separatelyExchangeable_arrayBlock hX he hf hd).conditionallyIID_arrayRow
-    (aemeasurable_arrayBlock hX)
+  (h.separatelyExchangeable_arrayBlock hX he hf hd).conditionallyIID_arrayRow fun _ => hX _
 
 /-- **De Finetti's theorem for the rows of a block of pairs.** The conclusion simultaneously
 describes both orientations of the selected rectangular cross-block. -/

--- a/TauCeti/Probability/Exchangeability/Arrays/Block.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Block.lean
@@ -26,14 +26,11 @@ act differently on two disjoint sets — and the block is therefore *separately*
 exchangeable arrays is then available for it; in particular de Finetti's theorem makes the rows of
 the block conditionally i.i.d.
 
-The block only sees the entries `X (e i, f j)`, so a jointly exchangeable array that is not
-symmetric is not described by it: the transposed entries `X (f j, e i)` are lost. Reading the two
-together as one array of pairs repairs this, and the pair array is separately exchangeable for the
-same reason (`JointlyExchangeable.separatelyExchangeable_arrayBlockPair`). This is the form the
-Aldous–Hoover representation for jointly exchangeable arrays is proved in: the two triangles of the
-array are represented simultaneously, by the separately exchangeable theory applied to a block of
-pairs. For a *symmetric* array the two coordinates of a pair agree, and the plain block already
-carries the whole information.
+The block only sees the entries `X (e i, f j)`, so it omits the reverse-orientation entries
+`X (f j, e i)`. Reading the two together as an array of pairs retains both orientations of the
+selected rectangular cross-block, and the pair array is separately exchangeable
+(`JointlyExchangeable.separatelyExchangeable_arrayBlockPair`). For a *symmetric* array the two
+coordinates of each such pair agree.
 
 ## Main definitions
 
@@ -57,11 +54,11 @@ carries the whole information.
   is necessary;
 * `TauCeti.Probability.JointlyExchangeable.map_arrayBlock_eq` — the block law does not depend on
   the chosen pair of index maps;
+* `TauCeti.Probability.JointlyExchangeable.map_arrayBlockPair_eq` — the corresponding canonical-law
+  theorem for the pair-valued block;
 * `TauCeti.Probability.JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock` and
   `TauCeti.Probability.JointlyExchangeable.conditionallyIID_arrayRow_arrayBlockPair` — de Finetti
-  for the rows of a block of a jointly exchangeable array;
-* `TauCeti.Probability.JointlyExchangeable.map_entry_eq_of_ne` — the off-diagonal entries of a
-  jointly exchangeable array are identically distributed.
+  for the rows of a block of a jointly exchangeable array.
 
 ## References
 
@@ -134,43 +131,55 @@ theorem measurable_blockPairReadOff (e f : ℕ → ℕ) :
 
 /-! ## Blocks inherit the symmetry of the array -/
 
-/-- **Separate exchangeability passes to every block along injections.** Both axes are reindexed
-independently already, so a permutation of the block's rows is realized by a permutation of the
-array's rows through `Equiv.Perm.viaEmbedding`, and likewise for the columns. No relation between
-the two ranges is needed. -/
+/-- **Separate exchangeability passes to every block along injections.** No relation between the
+two ranges is needed. -/
 theorem SeparatelyExchangeable.arrayBlock (h : SeparatelyExchangeable μ X)
     (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f) :
     SeparatelyExchangeable μ (arrayBlock X e f) := by
   refine separatelyExchangeable_iff.mpr fun σ τ => ?_
-  obtain ⟨ρ, hρ⟩ := exists_perm_apply_eq he σ
-  obtain ⟨ρ', hρ'⟩ := exists_perm_apply_eq hf τ
-  have key := h.map_comp hX ρ ρ'
-    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (e p.1, f p.2)) (measurable_blockReadOff e f)
-  simp only [hρ, hρ'] at key
-  simpa only [arrayBlock_apply] using key
+  let ι : ℕ ↪ ℕ := ⟨e, he⟩
+  let κ : ℕ ↪ ℕ := ⟨f, hf⟩
+  have key := h.map_comp hX (σ.viaEmbedding ι) (τ.viaEmbedding κ)
+    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (ι p.1, κ p.2))
+    (measurable_blockReadOff ι κ)
+  change (μ.map fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
+    (τ.viaEmbedding κ) (κ p.2)) ω) = μ.map fun ω (p : ℕ × ℕ) => X (ι p.1, κ p.2) ω at key
+  have hσ : ∀ i, (σ.viaEmbedding ι) (ι i) = ι (σ i) :=
+    fun i => Equiv.Perm.viaEmbedding_apply (ι := ι) σ i
+  have hτ : ∀ j, (τ.viaEmbedding κ) (κ j) = κ (τ j) :=
+    fun j => Equiv.Perm.viaEmbedding_apply (ι := κ) τ j
+  have hfun : (fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
+      (τ.viaEmbedding κ) (κ p.2)) ω) = fun ω (p : ℕ × ℕ) => X (ι (σ p.1), κ (τ p.2)) ω := by
+    funext ω p
+    exact congrArg (fun q => X q ω) (Prod.ext (hσ p.1) (hτ p.2))
+  have key' := (congrArg (fun g => Measure.map g μ) hfun).symm.trans key
+  simpa [ι, κ, arrayBlock] using key'
 
-/-- **Joint exchangeability passes to the diagonal blocks.** One injection `e` is reindexed on both
-axes, so a permutation of the block's index set is realized by a permutation of `ℕ` acting along
-`e`. -/
+/-- **Joint exchangeability passes to diagonal blocks along an injection.** -/
 theorem JointlyExchangeable.arrayBlock_diag (h : JointlyExchangeable μ X)
     (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) :
     JointlyExchangeable μ (arrayBlock X e e) := by
   refine jointlyExchangeable_iff.mpr fun σ => ?_
-  obtain ⟨ρ, hρ⟩ := exists_perm_apply_eq he σ
-  have key := h.map_comp hX ρ
-    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (e p.1, e p.2)) (measurable_blockReadOff e e)
-  simp only [hρ] at key
-  simpa only [arrayBlock_apply] using key
+  let ι : ℕ ↪ ℕ := ⟨e, he⟩
+  have key := h.map_comp hX (σ.viaEmbedding ι)
+    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (ι p.1, ι p.2))
+    (measurable_blockReadOff ι ι)
+  change (μ.map fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
+    (σ.viaEmbedding ι) (ι p.2)) ω) = μ.map fun ω (p : ℕ × ℕ) => X (ι p.1, ι p.2) ω at key
+  have hσ : ∀ i, (σ.viaEmbedding ι) (ι i) = ι (σ i) :=
+    fun i => Equiv.Perm.viaEmbedding_apply (ι := ι) σ i
+  have hfun : (fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
+      (σ.viaEmbedding ι) (ι p.2)) ω) = fun ω (p : ℕ × ℕ) => X (ι (σ p.1), ι (σ p.2)) ω := by
+    funext ω p
+    exact congrArg (fun q => X q ω) (Prod.ext (hσ p.1) (hσ p.2))
+  have key' := (congrArg (fun g => Measure.map g μ) hfun).symm.trans key
+  simpa [ι, arrayBlock] using key'
 
 /-- **A block of a jointly exchangeable array along injections with disjoint ranges is separately
 exchangeable.**
 
-This is the device that makes the separately exchangeable theory — de Finetti for the rows, and the
-representations built on it — available to a jointly exchangeable array. Joint exchangeability
-supplies only one permutation for both axes, but a permutation of `ℕ` may act as one prescribed
-permutation on the range of `e` and as an unrelated one on the disjoint range of `f`
-(`TauCeti.exists_perm_apply_eq_of_disjoint_range`); on the block those two halves are exactly a
-permutation of the rows and an independent permutation of the columns. -/
+This makes separately exchangeable results, including de Finetti's theorem for the rows, available
+to the selected block. -/
 theorem JointlyExchangeable.separatelyExchangeable_arrayBlock (h : JointlyExchangeable μ X)
     (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f)
     (hd : Disjoint (Set.range e) (Set.range f)) :
@@ -182,10 +191,8 @@ theorem JointlyExchangeable.separatelyExchangeable_arrayBlock (h : JointlyExchan
   simp only [hρe, hρf] at key
   simpa only [arrayBlock_apply] using key
 
-/-- **A block of a jointly exchangeable array, read together with its transpose, is separately
-exchangeable.** The read-off is the pair `(X (e i, f j), X (f j, e i))`, so the block retains both
-triangles of the array; the proof is that of
-`JointlyExchangeable.separatelyExchangeable_arrayBlock` with this pair-valued read-off. -/
+/-- **A block of a jointly exchangeable array, read in both orientations, is separately
+exchangeable.** Its `(i, j)`-entry is `(X (e i, f j), X (f j, e i))`. -/
 theorem JointlyExchangeable.separatelyExchangeable_arrayBlockPair (h : JointlyExchangeable μ X)
     (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f)
     (hd : Disjoint (Set.range e) (Set.range f)) :
@@ -235,11 +242,8 @@ theorem JointlyExchangeable.separatelyExchangeable_arrayBlockPair_evenOdd
   h.separatelyExchangeable_arrayBlockPair hX injective_two_mul injective_two_mul_add_one
     disjoint_range_two_mul
 
-/-- **The disjointness hypothesis of `JointlyExchangeable.separatelyExchangeable_arrayBlock` is
-necessary**, and not merely an artefact of the proof. The identity index maps have equal, hence
-non-disjoint, ranges, and read a jointly exchangeable array as itself; the diagonal-indicator array
-of `TauCeti.Probability.diagIndicatorArray` is then a jointly exchangeable array whose block is not
-separately exchangeable. -/
+/-- **The disjointness hypothesis of `JointlyExchangeable.separatelyExchangeable_arrayBlock` cannot
+be omitted.** With identity index maps, the diagonal-indicator array gives a counterexample. -/
 theorem not_separatelyExchangeable_arrayBlock_id_id (μ : Measure Ω) [IsProbabilityMeasure μ] :
     ¬SeparatelyExchangeable μ (arrayBlock (diagIndicatorArray Ω) id id) := by
   rw [arrayBlock_id_id]
@@ -248,14 +252,8 @@ theorem not_separatelyExchangeable_arrayBlock_id_id (μ : Measure Ω) [IsProbabi
 /-! ## The block law is canonical -/
 
 /-- **The law of a block does not depend on the chosen pair of index maps.** Any two pairs of
-injections with disjoint ranges read the same array law off a jointly exchangeable array, so
-"the block law" is an invariant of the array rather than an artefact of the indexing, and the
-canonical even-odd block computes it.
-
-A single permutation of `ℕ` need not carry one pair of index maps to the other — the two ranges may
-have complements of different sizes — so the two blocks are compared one finite-dimensional
-marginal at a time, where `Equiv.Perm.exists_extending_pair` does supply a permutation, and
-Mathlib's `ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq` assembles the marginals. -/
+injections with disjoint ranges give the same law; in particular, the canonical even-odd block
+computes it. -/
 theorem JointlyExchangeable.map_arrayBlock_eq [IsFiniteMeasure μ] {e' f' : ℕ → ℕ}
     (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
     (he : Function.Injective e) (hf : Function.Injective f)
@@ -296,14 +294,58 @@ theorem JointlyExchangeable.map_arrayBlock_eq [IsFiniteMeasure μ] {e' f' : ℕ 
       (Prod.ext (hσe ⟨(p : ℕ × ℕ).1, hp₁⟩) (hσf ⟨(p : ℕ × ℕ).2, hp₂⟩))
   exact key.symm.trans (congrArg (fun g => Measure.map g μ) (funext hrew))
 
+/-- **The law of a pair-valued block does not depend on the chosen pair of index maps.** Any two
+pairs of injections with disjoint ranges give the same law. -/
+theorem JointlyExchangeable.map_arrayBlockPair_eq [IsFiniteMeasure μ] {e' f' : ℕ → ℕ}
+    (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f))
+    (he' : Function.Injective e') (hf' : Function.Injective f')
+    (hd' : Disjoint (Set.range e') (Set.range f')) :
+    (μ.map fun ω p => arrayBlockPair X e f p ω) =
+      μ.map fun ω p => arrayBlockPair X e' f' p ω := by
+  have hmeas : ∀ u v : ℕ → ℕ, AEMeasurable (fun ω p => arrayBlockPair X u v p ω) μ :=
+    fun _ _ => aemeasurable_pi_lambda _ fun _ => (hX _).prodMk (hX _)
+  refine (ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq
+    (hmeas e f) (hmeas e' f')).mpr fun I => ?_
+  obtain ⟨n, hbound⟩ : ∃ n : ℕ, ∀ p ∈ I, p.1 < n ∧ p.2 < n := by
+    refine ⟨(I.sup fun p => max p.1 p.2) + 1, fun p hp => ?_⟩
+    have hle := Finset.le_sup (f := fun p : ℕ × ℕ => max p.1 p.2) hp
+    omega
+  have hg₁ : Function.Injective
+      (Sum.elim (fun i : Fin n => e i.val) fun j : Fin n => f j.val) :=
+    (he.comp Fin.val_injective).sumElim (hf.comp Fin.val_injective)
+      fun a b hab => Set.disjoint_left.mp hd ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
+  have hg₂ : Function.Injective
+      (Sum.elim (fun i : Fin n => e' i.val) fun j : Fin n => f' j.val) :=
+    (he'.comp Fin.val_injective).sumElim (hf'.comp Fin.val_injective)
+      fun a b hab => Set.disjoint_left.mp hd' ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair _ _ hg₁ hg₂
+  have hσe : ∀ i : Fin n, σ (e i.val) = e' i.val := fun i => hσ (Sum.inl i)
+  have hσf : ∀ j : Fin n, σ (f j.val) = f' j.val := fun j => hσ (Sum.inr j)
+  have key := h.map_comp hX σ
+    (F := fun x : ℕ × ℕ → α =>
+      I.restrict fun p : ℕ × ℕ => (x (e p.1, f p.2), x (f p.2, e p.1)))
+    ((Finset.measurable_restrict I).comp (measurable_blockPairReadOff e f))
+  have hrew : ∀ ω : Ω,
+      (I.restrict fun p : ℕ × ℕ =>
+        (X (σ (e p.1), σ (f p.2)) ω, X (σ (f p.2), σ (e p.1)) ω)) =
+        I.restrict fun p : ℕ × ℕ => (X (e' p.1, f' p.2) ω, X (f' p.2, e' p.1) ω) := by
+    intro ω
+    funext p
+    obtain ⟨hp₁, hp₂⟩ := hbound p.1 p.2
+    exact Prod.ext
+      (congrArg (fun q => X q ω)
+        (Prod.ext (hσe ⟨(p : ℕ × ℕ).1, hp₁⟩) (hσf ⟨(p : ℕ × ℕ).2, hp₂⟩)))
+      (congrArg (fun q => X q ω)
+        (Prod.ext (hσf ⟨(p : ℕ × ℕ).2, hp₂⟩) (hσe ⟨(p : ℕ × ℕ).1, hp₁⟩)))
+  exact key.symm.trans (congrArg (fun g => Measure.map g μ) (funext hrew))
+
 /-! ## De Finetti for the rows of a block -/
 
 /-- **De Finetti's theorem for the rows of a block of a jointly exchangeable array.** Over a
 nonempty standard Borel state space, the rows of a block along injections with disjoint ranges are
-conditionally i.i.d. as random elements of path space.
-
-This is the first step of the route to the Aldous–Hoover representation, transported from the
-separately exchangeable case to the jointly exchangeable one. -/
+conditionally i.i.d. as random elements of path space. -/
 theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock [StandardBorelSpace α] [Nonempty α]
     [IsFiniteMeasure μ] (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
     (he : Function.Injective e) (hf : Function.Injective f)
@@ -312,9 +354,8 @@ theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock [StandardBorelS
   (h.separatelyExchangeable_arrayBlock hX he hf hd).conditionallyIID_arrayRow
     (aemeasurable_arrayBlock hX)
 
-/-- **De Finetti's theorem for the rows of a block of pairs.** The value space is `α × α`, which is
-standard Borel and nonempty whenever `α` is, so no new hypothesis is needed; the conclusion
-describes both triangles of the array at once. -/
+/-- **De Finetti's theorem for the rows of a block of pairs.** The conclusion simultaneously
+describes both orientations of the selected rectangular cross-block. -/
 theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlockPair [StandardBorelSpace α]
     [Nonempty α] [IsFiniteMeasure μ] (h : JointlyExchangeable μ X)
     (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f)
@@ -322,29 +363,6 @@ theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlockPair [StandardBo
     ConditionallyIID μ (arrayRow (arrayBlockPair X e f)) :=
   (h.separatelyExchangeable_arrayBlockPair hX he hf hd).conditionallyIID_arrayRow
     (aemeasurable_arrayBlockPair hX)
-
-/-! ## Off-diagonal entries -/
-
-/-- **The off-diagonal entries of a jointly exchangeable array are identically distributed.** Two
-ordered pairs of distinct indices are carried to one another by a single permutation of `ℕ`, which
-is all joint exchangeability offers; the diagonal entries form their own identically distributed
-family, through `JointlyExchangeable.fullyExchangeable_arrayDiag`. -/
-theorem JointlyExchangeable.map_entry_eq_of_ne (h : JointlyExchangeable μ X)
-    (hX : ∀ p, AEMeasurable (X p) μ) {i j k l : ℕ} (hij : i ≠ j) (hkl : k ≠ l) :
-    μ.map (X (i, j)) = μ.map (X (k, l)) := by
-  classical
-  -- `Equiv.swap i k` sends `i` to `k`, and the second transposition then fixes `k` and moves the
-  -- image of `j` to `l`.
-  have hne : Equiv.swap i k j ≠ k := by
-    intro hk
-    have hji := congrArg (Equiv.swap i k) hk
-    rw [Equiv.swap_apply_self, Equiv.swap_apply_right] at hji
-    exact hij hji.symm
-  have key := h.map_comp hX (Equiv.swap (Equiv.swap i k j) l * Equiv.swap i k)
-    (F := fun x => x (i, j)) (measurable_pi_apply _)
-  simp only [Equiv.Perm.mul_apply, Equiv.swap_apply_left,
-    Equiv.swap_apply_of_ne_of_ne (Ne.symm hne) hkl] at key
-  simpa using key.symm
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Arrays/Block.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Block.lean
@@ -15,14 +15,15 @@ import Mathlib.Probability.Process.FiniteDimensionalLaws
 /-!
 # Rectangular blocks of an exchangeable array
 
-A **jointly** exchangeable array is invariant only under the diagonal reindexing
-`(i, j) ↦ (σ i, σ j)`, so its rows are not exchangeable and none of the separately exchangeable
-theory applies to it directly. This file supplies the standard device that repairs this: read the
-array on a **rectangular block** `arrayBlock X e f`, whose `(i, j)`-entry is `X (e i, f j)`, along
-two injections `e, f : ℕ → ℕ` **with disjoint ranges**. On such a block the single permutation the
-array is invariant under has two independent halves — one permutation may be prescribed on the
-range of `e` and another, unrelated one on the range of `f`, because a permutation of `ℕ` is free to
-act differently on two disjoint sets — and the block is therefore *separately* exchangeable
+Joint exchangeability alone guarantees only invariance under the diagonal reindexing
+`(i, j) ↦ (σ i, σ j)`, so the rows of a jointly exchangeable array need not be exchangeable and the
+separately exchangeable theory does not apply to it in general. This file supplies the standard
+device that repairs this: read the array on a **rectangular block** `arrayBlock X e f`, whose
+`(i, j)`-entry is `X (e i, f j)`, along two injections `e, f : ℕ → ℕ` **with disjoint ranges**. On
+such a block the single permutation the array is invariant under has two independent halves — one
+permutation may be prescribed on the range of `e` and another, unrelated one on the range of `f`,
+because a permutation of `ℕ` is free to act differently on two disjoint sets — and the block is
+therefore *separately* exchangeable
 (`JointlyExchangeable.separatelyExchangeable_arrayBlock`). Every theorem about separately
 exchangeable arrays is then available for it; in particular de Finetti's theorem makes the rows of
 the block conditionally i.i.d.
@@ -107,6 +108,15 @@ theorem arrayBlockPair_apply (X : ℕ × ℕ → Ω → α) (e f : ℕ → ℕ) 
 
 variable [MeasurableSpace α] [MeasurableSpace Ω] {μ : Measure Ω} {X : ℕ × ℕ → Ω → α} {e f : ℕ → ℕ}
 
+/-- Entrywise measurability passes to a block: the `p`-entry of `arrayBlock X e f` is the
+`(e p.1, f p.2)`-entry of `X`. A consumer cannot read this off the hypothesis on its own, since
+`arrayBlock` does not unfold outside this file. -/
+theorem aemeasurable_arrayBlock (hX : ∀ p, AEMeasurable (X p) μ) (p : ℕ × ℕ) :
+    AEMeasurable (arrayBlock X e f p) μ :=
+  hX _
+
+/-- Entrywise measurability passes to a block read together with its transpose: the `p`-entry of
+`arrayBlockPair X e f` pairs two entries of `X`. -/
 theorem aemeasurable_arrayBlockPair (hX : ∀ p, AEMeasurable (X p) μ) (p : ℕ × ℕ) :
     AEMeasurable (arrayBlockPair X e f p) μ :=
   (hX _).prodMk (hX _)
@@ -324,7 +334,8 @@ theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock [StandardBorelS
     (he : Function.Injective e) (hf : Function.Injective f)
     (hd : Disjoint (Set.range e) (Set.range f)) :
     ConditionallyIID μ (arrayRow (arrayBlock X e f)) :=
-  (h.separatelyExchangeable_arrayBlock hX he hf hd).conditionallyIID_arrayRow fun _ => hX _
+  (h.separatelyExchangeable_arrayBlock hX he hf hd).conditionallyIID_arrayRow
+    (aemeasurable_arrayBlock hX)
 
 /-- **De Finetti's theorem for the rows of a block of pairs.** The conclusion simultaneously
 describes both orientations of the selected rectangular cross-block. -/

--- a/TauCeti/Probability/Exchangeability/Arrays/Block.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Block.lean
@@ -144,8 +144,6 @@ theorem SeparatelyExchangeable.arrayBlock (h : SeparatelyExchangeable μ X)
   have key := h.map_comp hX (σ.viaEmbedding ι) (τ.viaEmbedding κ)
     (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (ι p.1, κ p.2))
     (measurable_blockReadOff ι κ)
-  change (μ.map fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
-    (τ.viaEmbedding κ) (κ p.2)) ω) = μ.map fun ω (p : ℕ × ℕ) => X (ι p.1, κ p.2) ω at key
   have hσ : ∀ i, (σ.viaEmbedding ι) (ι i) = ι (σ i) :=
     fun i => Equiv.Perm.viaEmbedding_apply (ι := ι) σ i
   have hτ : ∀ j, (τ.viaEmbedding κ) (κ j) = κ (τ j) :=
@@ -166,8 +164,6 @@ theorem JointlyExchangeable.arrayBlock_diag (h : JointlyExchangeable μ X)
   have key := h.map_comp hX (σ.viaEmbedding ι)
     (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (ι p.1, ι p.2))
     (measurable_blockReadOff ι ι)
-  change (μ.map fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
-    (σ.viaEmbedding ι) (ι p.2)) ω) = μ.map fun ω (p : ℕ × ℕ) => X (ι p.1, ι p.2) ω at key
   have hσ : ∀ i, (σ.viaEmbedding ι) (ι i) = ι (σ i) :=
     fun i => Equiv.Perm.viaEmbedding_apply (ι := ι) σ i
   have hfun : (fun ω (p : ℕ × ℕ) => X ((σ.viaEmbedding ι) (ι p.1),
@@ -253,6 +249,68 @@ theorem not_separatelyExchangeable_arrayBlock_id_id (μ : Measure Ω) [IsProbabi
 
 /-! ## The block law is canonical -/
 
+/-- **Below any bound, one permutation carries a pair of injections with disjoint ranges to
+another such pair.** The agreement is only finite by necessity: a single permutation need not
+carry one pair of index maps to another globally, since their ranges may have complements of
+different sizes, as `(2 · , 2 · + 1)` and `(4 · , 4 · + 1)` do. -/
+private theorem exists_perm_apply_eq_of_lt {e' f' : ℕ → ℕ} (n : ℕ)
+    (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f))
+    (he' : Function.Injective e') (hf' : Function.Injective f')
+    (hd' : Disjoint (Set.range e') (Set.range f')) :
+    ∃ σ : Equiv.Perm ℕ, (∀ i < n, σ (e i) = e' i) ∧ ∀ j < n, σ (f j) = f' j := by
+  have hg : Function.Injective (Sum.elim (fun i : Fin n => e i.val) fun j : Fin n => f j.val) :=
+    (he.comp Fin.val_injective).sumElim (hf.comp Fin.val_injective)
+      fun a b hab => Set.disjoint_left.mp hd ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
+  have hg' : Function.Injective (Sum.elim (fun i : Fin n => e' i.val) fun j : Fin n => f' j.val) :=
+    (he'.comp Fin.val_injective).sumElim (hf'.comp Fin.val_injective)
+      fun a b hab => Set.disjoint_left.mp hd' ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair _ _ hg hg'
+  exact ⟨σ, fun i hi => hσ (Sum.inl ⟨i, hi⟩), fun j hj => hσ (Sum.inr ⟨j, hj⟩)⟩
+
+/-- The common argument behind the two canonical-law theorems below, stated for an arbitrary
+read-off `B u v` of the array's sample path along the index maps `u` and `v`. Besides being
+measurable, `B` has to commute with a permutation of both axes (`hBperm`) and to read the entry at
+`p` through the index maps only at `p.1` and `p.2` (`hBapply`); the block and the block of pairs
+both satisfy these by `rfl` and by congruence.
+
+The two laws are compared one finite-dimensional marginal at a time, because a single permutation
+matches the two pairs of index maps only below a finite bound (`exists_perm_apply_eq_of_lt`). -/
+private theorem map_blockReadOff_eq {β : Type*} [MeasurableSpace β] [IsFiniteMeasure μ]
+    {e' f' : ℕ → ℕ} {B : (ℕ → ℕ) → (ℕ → ℕ) → (ℕ × ℕ → α) → ℕ × ℕ → β}
+    (hBmeas : ∀ u v, Measurable (B u v))
+    (hBperm : ∀ (σ : Equiv.Perm ℕ) (u v : ℕ → ℕ) (x : ℕ × ℕ → α),
+      (B u v fun q => x (σ q.1, σ q.2)) = B (fun i => σ (u i)) (fun j => σ (v j)) x)
+    (hBapply : ∀ (u v u' v' : ℕ → ℕ) (x : ℕ × ℕ → α) (p : ℕ × ℕ),
+      u p.1 = u' p.1 → v p.2 = v' p.2 → B u v x p = B u' v' x p)
+    (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f))
+    (he' : Function.Injective e') (hf' : Function.Injective f')
+    (hd' : Disjoint (Set.range e') (Set.range f')) :
+    (μ.map fun ω => B e f fun q => X q ω) = μ.map fun ω => B e' f' fun q => X q ω := by
+  have hmeas : ∀ u v : ℕ → ℕ, AEMeasurable (fun ω => B u v fun q => X q ω) μ :=
+    fun u v => (hBmeas u v).comp_aemeasurable (aemeasurable_pi_lambda _ hX)
+  refine (ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq
+    (hmeas e f) (hmeas e' f')).mpr fun I => ?_
+  -- Every index occurring in `I` is below `n`, so a permutation matching the two pairs of index
+  -- maps below `n` already matches the marginal.
+  obtain ⟨n, hbound⟩ : ∃ n : ℕ, ∀ p ∈ I, p.1 < n ∧ p.2 < n := by
+    refine ⟨(I.sup fun p => max p.1 p.2) + 1, fun p hp => ?_⟩
+    have hle := Finset.le_sup (f := fun p : ℕ × ℕ => max p.1 p.2) hp
+    omega
+  obtain ⟨σ, hσe, hσf⟩ := exists_perm_apply_eq_of_lt n he hf hd he' hf' hd'
+  have key := h.map_comp hX σ (F := fun x : ℕ × ℕ → α => I.restrict (B e f x))
+    ((Finset.measurable_restrict I).comp (hBmeas e f))
+  have hrew : ∀ ω : Ω, (I.restrict (B e f fun q => X (σ q.1, σ q.2) ω))
+      = I.restrict (B e' f' fun q => X q ω) := by
+    intro ω
+    funext p
+    obtain ⟨hp₁, hp₂⟩ := hbound p.1 p.2
+    exact (congrFun (hBperm σ e f fun q => X q ω) _).trans
+      (hBapply _ _ _ _ _ _ (hσe _ hp₁) (hσf _ hp₂))
+  exact key.symm.trans (congrArg (fun g => Measure.map g μ) (funext hrew))
+
 /-- **The law of a block does not depend on the chosen pair of index maps.** Any two pairs of
 injections with disjoint ranges give the same law; in particular, the canonical even-odd block
 computes it. -/
@@ -262,39 +320,10 @@ theorem JointlyExchangeable.map_arrayBlock_eq [IsFiniteMeasure μ] {e' f' : ℕ 
     (hd : Disjoint (Set.range e) (Set.range f))
     (he' : Function.Injective e') (hf' : Function.Injective f')
     (hd' : Disjoint (Set.range e') (Set.range f')) :
-    (μ.map fun ω p => arrayBlock X e f p ω) = μ.map fun ω p => arrayBlock X e' f' p ω := by
-  have hmeas : ∀ u v : ℕ → ℕ, AEMeasurable (fun ω p => arrayBlock X u v p ω) μ :=
-    fun _ _ => aemeasurable_pi_lambda _ fun _ => hX _
-  refine (ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq
-    (hmeas e f) (hmeas e' f')).mpr fun I => ?_
-  -- Every index occurring in `I` is below `n`, so a permutation matching the two pairs of index
-  -- maps below `n` already matches the marginal.
-  obtain ⟨n, hbound⟩ : ∃ n : ℕ, ∀ p ∈ I, p.1 < n ∧ p.2 < n := by
-    refine ⟨(I.sup fun p => max p.1 p.2) + 1, fun p hp => ?_⟩
-    have hle := Finset.le_sup (f := fun p : ℕ × ℕ => max p.1 p.2) hp
-    omega
-  have hg₁ : Function.Injective
-      (Sum.elim (fun i : Fin n => e i.val) fun j : Fin n => f j.val) :=
-    (he.comp Fin.val_injective).sumElim (hf.comp Fin.val_injective)
-      fun a b hab => Set.disjoint_left.mp hd ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
-  have hg₂ : Function.Injective
-      (Sum.elim (fun i : Fin n => e' i.val) fun j : Fin n => f' j.val) :=
-    (he'.comp Fin.val_injective).sumElim (hf'.comp Fin.val_injective)
-      fun a b hab => Set.disjoint_left.mp hd' ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
-  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair _ _ hg₁ hg₂
-  have hσe : ∀ i : Fin n, σ (e i.val) = e' i.val := fun i => hσ (Sum.inl i)
-  have hσf : ∀ j : Fin n, σ (f j.val) = f' j.val := fun j => hσ (Sum.inr j)
-  have key := h.map_comp hX σ
-    (F := fun x : ℕ × ℕ → α => I.restrict fun p : ℕ × ℕ => x (e p.1, f p.2))
-    ((Finset.measurable_restrict I).comp (measurable_blockReadOff e f))
-  have hrew : ∀ ω : Ω, (I.restrict fun p : ℕ × ℕ => X (σ (e p.1), σ (f p.2)) ω)
-      = I.restrict fun p : ℕ × ℕ => X (e' p.1, f' p.2) ω := by
-    intro ω
-    funext p
-    obtain ⟨hp₁, hp₂⟩ := hbound p.1 p.2
-    exact congrArg (fun q => X q ω)
-      (Prod.ext (hσe ⟨(p : ℕ × ℕ).1, hp₁⟩) (hσf ⟨(p : ℕ × ℕ).2, hp₂⟩))
-  exact key.symm.trans (congrArg (fun g => Measure.map g μ) (funext hrew))
+    (μ.map fun ω p => arrayBlock X e f p ω) = μ.map fun ω p => arrayBlock X e' f' p ω :=
+  map_blockReadOff_eq (B := fun u v x p => x (u p.1, v p.2)) measurable_blockReadOff
+    (fun _ _ _ _ => rfl) (fun _ _ _ _ x _ hu hv => congrArg x (Prod.ext hu hv))
+    h hX he hf hd he' hf' hd'
 
 /-- **The law of a pair-valued block does not depend on the chosen pair of index maps.** Any two
 pairs of injections with disjoint ranges give the same law. -/
@@ -305,43 +334,12 @@ theorem JointlyExchangeable.map_arrayBlockPair_eq [IsFiniteMeasure μ] {e' f' : 
     (he' : Function.Injective e') (hf' : Function.Injective f')
     (hd' : Disjoint (Set.range e') (Set.range f')) :
     (μ.map fun ω p => arrayBlockPair X e f p ω) =
-      μ.map fun ω p => arrayBlockPair X e' f' p ω := by
-  have hmeas : ∀ u v : ℕ → ℕ, AEMeasurable (fun ω p => arrayBlockPair X u v p ω) μ :=
-    fun _ _ => aemeasurable_pi_lambda _ fun _ => (hX _).prodMk (hX _)
-  refine (ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq
-    (hmeas e f) (hmeas e' f')).mpr fun I => ?_
-  obtain ⟨n, hbound⟩ : ∃ n : ℕ, ∀ p ∈ I, p.1 < n ∧ p.2 < n := by
-    refine ⟨(I.sup fun p => max p.1 p.2) + 1, fun p hp => ?_⟩
-    have hle := Finset.le_sup (f := fun p : ℕ × ℕ => max p.1 p.2) hp
-    omega
-  have hg₁ : Function.Injective
-      (Sum.elim (fun i : Fin n => e i.val) fun j : Fin n => f j.val) :=
-    (he.comp Fin.val_injective).sumElim (hf.comp Fin.val_injective)
-      fun a b hab => Set.disjoint_left.mp hd ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
-  have hg₂ : Function.Injective
-      (Sum.elim (fun i : Fin n => e' i.val) fun j : Fin n => f' j.val) :=
-    (he'.comp Fin.val_injective).sumElim (hf'.comp Fin.val_injective)
-      fun a b hab => Set.disjoint_left.mp hd' ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
-  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair _ _ hg₁ hg₂
-  have hσe : ∀ i : Fin n, σ (e i.val) = e' i.val := fun i => hσ (Sum.inl i)
-  have hσf : ∀ j : Fin n, σ (f j.val) = f' j.val := fun j => hσ (Sum.inr j)
-  have key := h.map_comp hX σ
-    (F := fun x : ℕ × ℕ → α =>
-      I.restrict fun p : ℕ × ℕ => (x (e p.1, f p.2), x (f p.2, e p.1)))
-    ((Finset.measurable_restrict I).comp (measurable_blockPairReadOff e f))
-  have hrew : ∀ ω : Ω,
-      (I.restrict fun p : ℕ × ℕ =>
-        (X (σ (e p.1), σ (f p.2)) ω, X (σ (f p.2), σ (e p.1)) ω)) =
-        I.restrict fun p : ℕ × ℕ => (X (e' p.1, f' p.2) ω, X (f' p.2, e' p.1) ω) := by
-    intro ω
-    funext p
-    obtain ⟨hp₁, hp₂⟩ := hbound p.1 p.2
-    exact Prod.ext
-      (congrArg (fun q => X q ω)
-        (Prod.ext (hσe ⟨(p : ℕ × ℕ).1, hp₁⟩) (hσf ⟨(p : ℕ × ℕ).2, hp₂⟩)))
-      (congrArg (fun q => X q ω)
-        (Prod.ext (hσf ⟨(p : ℕ × ℕ).2, hp₂⟩) (hσe ⟨(p : ℕ × ℕ).1, hp₁⟩)))
-  exact key.symm.trans (congrArg (fun g => Measure.map g μ) (funext hrew))
+      μ.map fun ω p => arrayBlockPair X e' f' p ω :=
+  map_blockReadOff_eq (B := fun u v x p => (x (u p.1, v p.2), x (v p.2, u p.1)))
+    measurable_blockPairReadOff (fun _ _ _ _ => rfl)
+    (fun _ _ _ _ x _ hu hv =>
+      Prod.ext (congrArg x (Prod.ext hu hv)) (congrArg x (Prod.ext hv hu)))
+    h hX he hf hd he' hf' hd'
 
 /-! ## De Finetti for the rows of a block -/
 

--- a/TauCeti/Probability/Exchangeability/Arrays/Block.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Block.lean
@@ -1,0 +1,351 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.Arrays.Basic
+-- Non-public: the permutation combining two disjoint injections, and the reduction of an array law
+-- to its finite-dimensional marginals, are used only inside proofs.
+import TauCeti.GroupTheory.Perm.Basic
+import Mathlib.Probability.Process.FiniteDimensionalLaws
+
+/-!
+# Rectangular blocks of an exchangeable array
+
+A **jointly** exchangeable array is invariant only under the diagonal reindexing
+`(i, j) ↦ (σ i, σ j)`, so its rows are not exchangeable and none of the separately exchangeable
+theory applies to it directly. This file supplies the standard device that repairs this: read the
+array on a **rectangular block** `arrayBlock X e f`, whose `(i, j)`-entry is `X (e i, f j)`, along
+two injections `e, f : ℕ → ℕ` **with disjoint ranges**. On such a block the single permutation the
+array is invariant under has two independent halves — one permutation may be prescribed on the
+range of `e` and another, unrelated one on the range of `f`, because a permutation of `ℕ` is free to
+act differently on two disjoint sets — and the block is therefore *separately* exchangeable
+(`JointlyExchangeable.separatelyExchangeable_arrayBlock`). Every theorem about separately
+exchangeable arrays is then available for it; in particular de Finetti's theorem makes the rows of
+the block conditionally i.i.d.
+
+The block only sees the entries `X (e i, f j)`, so a jointly exchangeable array that is not
+symmetric is not described by it: the transposed entries `X (f j, e i)` are lost. Reading the two
+together as one array of pairs repairs this, and the pair array is separately exchangeable for the
+same reason (`JointlyExchangeable.separatelyExchangeable_arrayBlockPair`). This is the form the
+Aldous–Hoover representation for jointly exchangeable arrays is proved in: the two triangles of the
+array are represented simultaneously, by the separately exchangeable theory applied to a block of
+pairs. For a *symmetric* array the two coordinates of a pair agree, and the plain block already
+carries the whole information.
+
+## Main definitions
+
+* `TauCeti.Probability.arrayBlock` — the rectangular block of an array along two index maps;
+* `TauCeti.Probability.arrayBlockPair` — the same block, read together with its transpose.
+
+## Main results
+
+* `TauCeti.Probability.SeparatelyExchangeable.arrayBlock` — separate exchangeability passes to
+  every block along injections, no disjointness needed;
+* `TauCeti.Probability.JointlyExchangeable.arrayBlock_diag` — joint exchangeability passes to the
+  diagonal blocks `arrayBlock X e e`;
+* `TauCeti.Probability.JointlyExchangeable.separatelyExchangeable_arrayBlock` — **the block
+  theorem**: a block of a jointly exchangeable array along injections with disjoint ranges is
+  separately exchangeable;
+* `TauCeti.Probability.JointlyExchangeable.separatelyExchangeable_arrayBlockPair` — the same for
+  the block read together with its transpose;
+* `TauCeti.Probability.JointlyExchangeable.separatelyExchangeable_arrayBlock_evenOdd` — the
+  canonical instance, along the even and the odd indices;
+* `TauCeti.Probability.not_separatelyExchangeable_arrayBlock_id_id` — the disjointness hypothesis
+  is necessary;
+* `TauCeti.Probability.JointlyExchangeable.map_arrayBlock_eq` — the block law does not depend on
+  the chosen pair of index maps;
+* `TauCeti.Probability.JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock` and
+  `TauCeti.Probability.JointlyExchangeable.conditionallyIID_arrayRow_arrayBlockPair` — de Finetti
+  for the rows of a block of a jointly exchangeable array;
+* `TauCeti.Probability.JointlyExchangeable.map_entry_eq_of_ne` — the off-diagonal entries of a
+  jointly exchangeable array are identically distributed.
+
+## References
+
+* O. Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005, Chapter 7.
+* D. Aldous, *Representations for partially exchangeable arrays of random variables*, Journal of
+  Multivariate Analysis 11 (1981), 581–598.
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable sequences
+rather than exchangeable arrays.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α Ω : Type*}
+
+/-! ## Blocks of an array -/
+
+/-- The rectangular block of the array `X` along the index maps `e` and `f`: its `(i, j)`-entry is
+the `(e i, f j)`-entry of `X`. -/
+def arrayBlock (X : ℕ × ℕ → Ω → α) (e f : ℕ → ℕ) : ℕ × ℕ → Ω → α :=
+  fun p => X (e p.1, f p.2)
+
+@[simp]
+theorem arrayBlock_apply (X : ℕ × ℕ → Ω → α) (e f : ℕ → ℕ) (p : ℕ × ℕ) :
+    arrayBlock X e f p = X (e p.1, f p.2) :=
+  (rfl)
+
+/-- The rectangular block of `X` along `e` and `f`, read together with its transpose: its
+`(i, j)`-entry is the pair of the `(e i, f j)`-entry and the `(f j, e i)`-entry of `X`. -/
+def arrayBlockPair (X : ℕ × ℕ → Ω → α) (e f : ℕ → ℕ) : ℕ × ℕ → Ω → α × α :=
+  fun p ω => (X (e p.1, f p.2) ω, X (f p.2, e p.1) ω)
+
+@[simp]
+theorem arrayBlockPair_apply (X : ℕ × ℕ → Ω → α) (e f : ℕ → ℕ) (p : ℕ × ℕ) (ω : Ω) :
+    arrayBlockPair X e f p ω = (X (e p.1, f p.2) ω, X (f p.2, e p.1) ω) :=
+  (rfl)
+
+/-- The block along the identity index maps is the array itself. -/
+@[simp]
+theorem arrayBlock_id_id (X : ℕ × ℕ → Ω → α) : arrayBlock X id id = X :=
+  (rfl)
+
+variable [MeasurableSpace α] [MeasurableSpace Ω] {μ : Measure Ω} {X : ℕ × ℕ → Ω → α} {e f : ℕ → ℕ}
+
+theorem aemeasurable_arrayBlock (hX : ∀ p, AEMeasurable (X p) μ) (p : ℕ × ℕ) :
+    AEMeasurable (arrayBlock X e f p) μ :=
+  hX _
+
+theorem aemeasurable_arrayBlockPair (hX : ∀ p, AEMeasurable (X p) μ) (p : ℕ × ℕ) :
+    AEMeasurable (arrayBlockPair X e f p) μ :=
+  (hX _).prodMk (hX _)
+
+/-- Reading a block off an array's sample path is measurable. -/
+theorem measurable_blockReadOff (e f : ℕ → ℕ) :
+    Measurable fun x : ℕ × ℕ → α => fun p : ℕ × ℕ => x (e p.1, f p.2) :=
+  measurable_pi_lambda _ fun _ => measurable_pi_apply _
+
+/-- Reading a block together with its transpose off an array's sample path is measurable. -/
+theorem measurable_blockPairReadOff (e f : ℕ → ℕ) :
+    Measurable fun x : ℕ × ℕ → α => fun p : ℕ × ℕ => (x (e p.1, f p.2), x (f p.2, e p.1)) :=
+  measurable_pi_lambda _ fun _ => (measurable_pi_apply _).prodMk (measurable_pi_apply _)
+
+/-! ## Blocks inherit the symmetry of the array -/
+
+/-- **Separate exchangeability passes to every block along injections.** Both axes are reindexed
+independently already, so a permutation of the block's rows is realized by a permutation of the
+array's rows through `Equiv.Perm.viaEmbedding`, and likewise for the columns. No relation between
+the two ranges is needed. -/
+theorem SeparatelyExchangeable.arrayBlock (h : SeparatelyExchangeable μ X)
+    (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f) :
+    SeparatelyExchangeable μ (arrayBlock X e f) := by
+  refine separatelyExchangeable_iff.mpr fun σ τ => ?_
+  obtain ⟨ρ, hρ⟩ := exists_perm_apply_eq he σ
+  obtain ⟨ρ', hρ'⟩ := exists_perm_apply_eq hf τ
+  have key := h.map_comp hX ρ ρ'
+    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (e p.1, f p.2)) (measurable_blockReadOff e f)
+  simp only [hρ, hρ'] at key
+  simpa only [arrayBlock_apply] using key
+
+/-- **Joint exchangeability passes to the diagonal blocks.** One injection `e` is reindexed on both
+axes, so a permutation of the block's index set is realized by a permutation of `ℕ` acting along
+`e`. -/
+theorem JointlyExchangeable.arrayBlock_diag (h : JointlyExchangeable μ X)
+    (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) :
+    JointlyExchangeable μ (arrayBlock X e e) := by
+  refine jointlyExchangeable_iff.mpr fun σ => ?_
+  obtain ⟨ρ, hρ⟩ := exists_perm_apply_eq he σ
+  have key := h.map_comp hX ρ
+    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (e p.1, e p.2)) (measurable_blockReadOff e e)
+  simp only [hρ] at key
+  simpa only [arrayBlock_apply] using key
+
+/-- **A block of a jointly exchangeable array along injections with disjoint ranges is separately
+exchangeable.**
+
+This is the device that makes the separately exchangeable theory — de Finetti for the rows, and the
+representations built on it — available to a jointly exchangeable array. Joint exchangeability
+supplies only one permutation for both axes, but a permutation of `ℕ` may act as one prescribed
+permutation on the range of `e` and as an unrelated one on the disjoint range of `f`
+(`TauCeti.exists_perm_apply_eq_of_disjoint_range`); on the block those two halves are exactly a
+permutation of the rows and an independent permutation of the columns. -/
+theorem JointlyExchangeable.separatelyExchangeable_arrayBlock (h : JointlyExchangeable μ X)
+    (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f)) :
+    SeparatelyExchangeable μ (arrayBlock X e f) := by
+  refine separatelyExchangeable_iff.mpr fun σ τ => ?_
+  obtain ⟨ρ, hρe, hρf⟩ := exists_perm_apply_eq_of_disjoint_range he hf hd σ τ
+  have key := h.map_comp hX ρ (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => x (e p.1, f p.2))
+    (measurable_blockReadOff e f)
+  simp only [hρe, hρf] at key
+  simpa only [arrayBlock_apply] using key
+
+/-- **A block of a jointly exchangeable array, read together with its transpose, is separately
+exchangeable.** The read-off is the pair `(X (e i, f j), X (f j, e i))`, so the block retains both
+triangles of the array; the proof is that of
+`JointlyExchangeable.separatelyExchangeable_arrayBlock` with this pair-valued read-off. -/
+theorem JointlyExchangeable.separatelyExchangeable_arrayBlockPair (h : JointlyExchangeable μ X)
+    (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f)) :
+    SeparatelyExchangeable μ (arrayBlockPair X e f) := by
+  refine separatelyExchangeable_iff.mpr fun σ τ => ?_
+  obtain ⟨ρ, hρe, hρf⟩ := exists_perm_apply_eq_of_disjoint_range he hf hd σ τ
+  have key := h.map_comp hX ρ
+    (F := fun (x : ℕ × ℕ → α) (p : ℕ × ℕ) => (x (e p.1, f p.2), x (f p.2, e p.1)))
+    (measurable_blockPairReadOff e f)
+  simp only [hρe, hρf] at key
+  simpa only [arrayBlockPair_apply] using key
+
+/-! ## The canonical block, along the even and the odd indices -/
+
+-- The parity facts instantiating the canonical block below; they carry no exchangeability content.
+private theorem injective_two_mul : Function.Injective fun i : ℕ => 2 * i := by
+  intro a b h
+  have h' : 2 * a = 2 * b := h
+  omega
+
+private theorem injective_two_mul_add_one : Function.Injective fun j : ℕ => 2 * j + 1 := by
+  intro a b h
+  have h' : 2 * a + 1 = 2 * b + 1 := h
+  omega
+
+private theorem disjoint_range_two_mul :
+    Disjoint (Set.range fun i : ℕ => 2 * i) (Set.range fun j : ℕ => 2 * j + 1) := by
+  refine Set.disjoint_left.mpr ?_
+  rintro _ ⟨i, rfl⟩ ⟨j, hj⟩
+  have hj' : 2 * j + 1 = 2 * i := hj
+  omega
+
+/-- **The canonical separately exchangeable block of a jointly exchangeable array**: read the rows
+along the even indices and the columns along the odd ones. Any pair of injections with disjoint
+ranges would do; this one exists without further data, so it is the block a consumer with no
+preferred index sets should use. -/
+theorem JointlyExchangeable.separatelyExchangeable_arrayBlock_evenOdd
+    (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    SeparatelyExchangeable μ (arrayBlock X (fun i => 2 * i) fun j => 2 * j + 1) :=
+  h.separatelyExchangeable_arrayBlock hX injective_two_mul injective_two_mul_add_one
+    disjoint_range_two_mul
+
+/-- **The canonical block of pairs of a jointly exchangeable array.** -/
+theorem JointlyExchangeable.separatelyExchangeable_arrayBlockPair_evenOdd
+    (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    SeparatelyExchangeable μ (arrayBlockPair X (fun i => 2 * i) fun j => 2 * j + 1) :=
+  h.separatelyExchangeable_arrayBlockPair hX injective_two_mul injective_two_mul_add_one
+    disjoint_range_two_mul
+
+/-- **The disjointness hypothesis of `JointlyExchangeable.separatelyExchangeable_arrayBlock` is
+necessary**, and not merely an artefact of the proof. The identity index maps have equal, hence
+non-disjoint, ranges, and read a jointly exchangeable array as itself; the diagonal-indicator array
+of `TauCeti.Probability.diagIndicatorArray` is then a jointly exchangeable array whose block is not
+separately exchangeable. -/
+theorem not_separatelyExchangeable_arrayBlock_id_id (μ : Measure Ω) [IsProbabilityMeasure μ] :
+    ¬SeparatelyExchangeable μ (arrayBlock (diagIndicatorArray Ω) id id) := by
+  rw [arrayBlock_id_id]
+  exact not_separatelyExchangeable_diagIndicatorArray μ
+
+/-! ## The block law is canonical -/
+
+/-- **The law of a block does not depend on the chosen pair of index maps.** Any two pairs of
+injections with disjoint ranges read the same array law off a jointly exchangeable array, so
+"the block law" is an invariant of the array rather than an artefact of the indexing, and the
+canonical even-odd block computes it.
+
+A single permutation of `ℕ` need not carry one pair of index maps to the other — the two ranges may
+have complements of different sizes — so the two blocks are compared one finite-dimensional
+marginal at a time, where `Equiv.Perm.exists_extending_pair` does supply a permutation, and
+Mathlib's `ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq` assembles the marginals. -/
+theorem JointlyExchangeable.map_arrayBlock_eq [IsFiniteMeasure μ] {e' f' : ℕ → ℕ}
+    (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f))
+    (he' : Function.Injective e') (hf' : Function.Injective f')
+    (hd' : Disjoint (Set.range e') (Set.range f')) :
+    (μ.map fun ω p => arrayBlock X e f p ω) = μ.map fun ω p => arrayBlock X e' f' p ω := by
+  have hmeas : ∀ u v : ℕ → ℕ, AEMeasurable (fun ω p => arrayBlock X u v p ω) μ :=
+    fun _ _ => aemeasurable_pi_lambda _ fun _ => hX _
+  refine (ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq
+    (hmeas e f) (hmeas e' f')).mpr fun I => ?_
+  -- Every index occurring in `I` is below `n`, so a permutation matching the two pairs of index
+  -- maps below `n` already matches the marginal.
+  obtain ⟨n, hbound⟩ : ∃ n : ℕ, ∀ p ∈ I, p.1 < n ∧ p.2 < n := by
+    refine ⟨(I.sup fun p => max p.1 p.2) + 1, fun p hp => ?_⟩
+    have hle := Finset.le_sup (f := fun p : ℕ × ℕ => max p.1 p.2) hp
+    omega
+  have hg₁ : Function.Injective
+      (Sum.elim (fun i : Fin n => e i.val) fun j : Fin n => f j.val) :=
+    (he.comp Fin.val_injective).sumElim (hf.comp Fin.val_injective)
+      fun a b hab => Set.disjoint_left.mp hd ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
+  have hg₂ : Function.Injective
+      (Sum.elim (fun i : Fin n => e' i.val) fun j : Fin n => f' j.val) :=
+    (he'.comp Fin.val_injective).sumElim (hf'.comp Fin.val_injective)
+      fun a b hab => Set.disjoint_left.mp hd' ⟨a.val, rfl⟩ ⟨b.val, hab.symm⟩
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair _ _ hg₁ hg₂
+  have hσe : ∀ i : Fin n, σ (e i.val) = e' i.val := fun i => hσ (Sum.inl i)
+  have hσf : ∀ j : Fin n, σ (f j.val) = f' j.val := fun j => hσ (Sum.inr j)
+  have key := h.map_comp hX σ
+    (F := fun x : ℕ × ℕ → α => I.restrict fun p : ℕ × ℕ => x (e p.1, f p.2))
+    ((Finset.measurable_restrict I).comp (measurable_blockReadOff e f))
+  have hrew : ∀ ω : Ω, (I.restrict fun p : ℕ × ℕ => X (σ (e p.1), σ (f p.2)) ω)
+      = I.restrict fun p : ℕ × ℕ => X (e' p.1, f' p.2) ω := by
+    intro ω
+    funext p
+    obtain ⟨hp₁, hp₂⟩ := hbound p.1 p.2
+    exact congrArg (fun q => X q ω)
+      (Prod.ext (hσe ⟨(p : ℕ × ℕ).1, hp₁⟩) (hσf ⟨(p : ℕ × ℕ).2, hp₂⟩))
+  exact key.symm.trans (congrArg (fun g => Measure.map g μ) (funext hrew))
+
+/-! ## De Finetti for the rows of a block -/
+
+/-- **De Finetti's theorem for the rows of a block of a jointly exchangeable array.** Over a
+nonempty standard Borel state space, the rows of a block along injections with disjoint ranges are
+conditionally i.i.d. as random elements of path space.
+
+This is the first step of the route to the Aldous–Hoover representation, transported from the
+separately exchangeable case to the jointly exchangeable one. -/
+theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock [StandardBorelSpace α] [Nonempty α]
+    [IsFiniteMeasure μ] (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f)) :
+    ConditionallyIID μ (arrayRow (arrayBlock X e f)) :=
+  (h.separatelyExchangeable_arrayBlock hX he hf hd).conditionallyIID_arrayRow
+    (aemeasurable_arrayBlock hX)
+
+/-- **De Finetti's theorem for the rows of a block of pairs.** The value space is `α × α`, which is
+standard Borel and nonempty whenever `α` is, so no new hypothesis is needed; the conclusion
+describes both triangles of the array at once. -/
+theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlockPair [StandardBorelSpace α]
+    [Nonempty α] [IsFiniteMeasure μ] (h : JointlyExchangeable μ X)
+    (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f)) :
+    ConditionallyIID μ (arrayRow (arrayBlockPair X e f)) :=
+  (h.separatelyExchangeable_arrayBlockPair hX he hf hd).conditionallyIID_arrayRow
+    (aemeasurable_arrayBlockPair hX)
+
+/-! ## Off-diagonal entries -/
+
+/-- **The off-diagonal entries of a jointly exchangeable array are identically distributed.** Two
+ordered pairs of distinct indices are carried to one another by a single permutation of `ℕ`, which
+is all joint exchangeability offers; the diagonal entries form their own identically distributed
+family, through `JointlyExchangeable.fullyExchangeable_arrayDiag`. -/
+theorem JointlyExchangeable.map_entry_eq_of_ne (h : JointlyExchangeable μ X)
+    (hX : ∀ p, AEMeasurable (X p) μ) {i j k l : ℕ} (hij : i ≠ j) (hkl : k ≠ l) :
+    μ.map (X (i, j)) = μ.map (X (k, l)) := by
+  classical
+  -- `Equiv.swap i k` sends `i` to `k`, and the second transposition then fixes `k` and moves the
+  -- image of `j` to `l`.
+  have hne : Equiv.swap i k j ≠ k := by
+    intro hk
+    have hji := congrArg (Equiv.swap i k) hk
+    rw [Equiv.swap_apply_self, Equiv.swap_apply_right] at hji
+    exact hij hji.symm
+  have key := h.map_comp hX (Equiv.swap (Equiv.swap i k j) l * Equiv.swap i k)
+    (F := fun x => x (i, j)) (measurable_pi_apply _)
+  simp only [Equiv.Perm.mul_apply, Equiv.swap_apply_left,
+    Equiv.swap_apply_of_ne_of_ne (Ne.symm hne) hkl] at key
+  simpa using key.symm
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/Arrays/Block.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Block.lean
@@ -6,9 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Probability.Exchangeability.Arrays.Basic
--- Non-public: the permutation combining two disjoint injections, and the reduction of an array law
--- to its finite-dimensional marginals, are used only inside proofs.
+-- Non-public: the permutations transported along injections, the permutation combining two
+-- disjoint injections, and the reduction of an array law to its finite-dimensional marginals, are
+-- used only inside proofs.
 import TauCeti.GroupTheory.Perm.Basic
+import Mathlib.GroupTheory.Perm.ViaEmbedding
 import Mathlib.Probability.Process.FiniteDimensionalLaws
 
 /-!


### PR DESCRIPTION
This PR reads a jointly exchangeable array on a **rectangular block** and proves that the block is separately exchangeable, which is what makes the separately exchangeable theory — and de Finetti's theorem for the rows — available to a jointly exchangeable array. For injections `e, f : ℕ → ℕ` with disjoint ranges, `arrayBlock X e f` has `(i, j)`-entry `X (e i, f j)`; joint exchangeability supplies only one permutation for both axes, but a permutation of `ℕ` may act as one prescribed permutation on the range of `e` and as an unrelated one on the disjoint range of `f`, and on the block those two halves are exactly a permutation of the rows and an independent permutation of the columns. The PR also covers the block read together with its transpose (`arrayBlockPair`, the form in which a non-symmetric array is represented, since a plain block loses the entries `X (f j, e i)`), the canonical instance along the even and the odd indices, the fact that the block law does not depend on the chosen pair of index maps, and the necessity of the disjointness hypothesis.

This advances the Layer 8 milestone "exchangeable arrays and the Aldous–Hoover representation" of `TauCetiRoadmap/Exchangeability/README.md`. `TauCeti/Probability/Exchangeability/Arrays/Basic.lean` defines both array symmetries and takes the separately exchangeable case as far as `SeparatelyExchangeable.conditionallyIID_arrayRow`, while the jointly exchangeable case — the symmetry of a symmetric array, hence of an exchangeable random graph — carried only its definition and `JointlyExchangeable.fullyExchangeable_arrayDiag`, because its rows are genuinely not exchangeable (`not_fullyExchangeable_arrayRow_diagIndicatorArray`). The block device is the standard bridge between the two cases, and `JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock` is the resulting first step of the Aldous–Hoover route in the joint case. What remains for that milestone is the representation itself: the coding of a block's rows (in flight for the separately exchangeable case as TauCeti#4232), the resolution of a coded row into per-column and per-cell randomness, and the transfer of a block representation back to the whole array.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"jointlyexchangeable-separatelyexchangeable-arrayblock"}-->

The new module is `TauCeti/Probability/Exchangeability/Arrays/Block.lean`, joining the existing `Arrays/` subdirectory beside `Basic.lean` and `MixingLaw.lean`; no module is moved or renamed. It adds `arrayBlock` and `arrayBlockPair` with their evaluation and measurability lemmas, `SeparatelyExchangeable.arrayBlock` and `JointlyExchangeable.arrayBlock_diag` (a block of an array inherits the array's own symmetry, needing no disjointness), the block theorem `JointlyExchangeable.separatelyExchangeable_arrayBlock` and its pair form, the even-odd corollaries, `not_separatelyExchangeable_arrayBlock_diagIndicatorArray` (read along one and the same injection on both axes, the diagonal-indicator array of `Arrays/Basic.lean` is a counterexample, so disjointness is not an artefact of the proof), `JointlyExchangeable.map_arrayBlock_eq`, and the two de Finetti corollaries. `Arrays/Basic.lean` itself is unchanged: the off-diagonal-entry theorem that used to accompany this development was an independent statement about individual entries and has been split out of this PR.

One prerequisite goes to its canonical home rather than into the new file: `TauCeti.exists_perm_apply_eq` and `TauCeti.exists_perm_apply_eq_of_disjoint_range` in `TauCeti/GroupTheory/Perm/Basic.lean`, which say that a permutation transported along an injection, and a pair of permutations transported along injections with disjoint ranges, are realized by a permutation of the ambient type. These are pure permutation theory with no probability in their statements; both are Mathlib's `Equiv.Perm.viaEmbedding` restated in terms of the underlying function of the injection, which is the form a consumer rewriting with them needs, and the disjoint case is the product of the two `viaEmbedding` factors, each the identity off the range of its own injection.

`JointlyExchangeable.map_arrayBlock_eq` is the one statement whose proof is not a single read-off. A single permutation of `ℕ` need not carry one pair of index maps to another — their ranges may have complements of different sizes, as the even-odd pair and the pair `4 · , 4 · + 1` do — so the two block laws are compared one finite-dimensional marginal at a time. On a marginal only finitely many indices matter, where `Equiv.Perm.exists_extending_pair` does supply a permutation matching the two pairs of index maps, and Mathlib's `ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq` assembles the marginals back into the array law.

The mathematics follows Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Chapter 7, and Aldous, "Representations for partially exchangeable arrays of random variables" (1981). No Mathlib PR material is vendored, and no material is adapted from `cameronfreer/exchangeability`, which treats exchangeable sequences rather than exchangeable arrays.

🤖 Prepared with Claude Code

