### PR TITLE
feat: extend a W^{1,p}_0 function by zero

### DIFF
--- a/TauCeti/Analysis/Sobolev/W1p/Basic.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Basic.lean
@@ -48,7 +48,8 @@ boundary regularity of `Ω` is used.
 * `TauCeti.mem_w1pSubmodule_iff_hasWeakFDerivOn`: membership is exactly weak
   differentiability of the value component with the recorded gradient.
 * `TauCeti.W1p.valueL` and `TauCeti.W1p.gradientL`: the two components as continuous linear
-  projections from the Sobolev space.
+  projections from the Sobolev space, with `TauCeti.W1p.value_coe` and
+  `TauCeti.W1p.gradient_coe` identifying them with the components of the ambient jet.
 
 ## References
 
@@ -371,17 +372,25 @@ omit [FiniteDimensional ℝ E] in
 theorem W1p.gradientL_apply (u : W1p mu Omega p) : W1p.gradientL u = W1p.gradient u := (rfl)
 
 omit [FiniteDimensional ℝ E] in
+/-- `W1p.valueL` is the ambient jet projection precomposed with the inclusion, so the Sobolev
+value component *is* the value component of the underlying ambient jet. -/
+theorem W1p.value_coe (u : W1p mu Omega p) :
+    W1p.value u = Sobolev1JetLp.value (u : Sobolev1JetLp mu Omega p) := (rfl)
+
+omit [FiniteDimensional ℝ E] in
 /-- The Sobolev value component agrees almost everywhere with the first component of its
 ambient value-gradient jet. -/
 theorem W1p.value_apply_ae (u : W1p mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
       W1p.value u x = WithLp.fst ((u : Sobolev1JetLp mu Omega p) x) := by
-  -- `W1p.valueL` is the ambient jet projection precomposed with the inclusion, so the two
-  -- value components are the same `Lᵖ` class; name that equation instead of relying on it
-  -- silently.
-  have hvalue : W1p.value u = Sobolev1JetLp.value (u : Sobolev1JetLp mu Omega p) := (rfl)
-  rw [hvalue]
+  rw [W1p.value_coe]
   exact Sobolev1JetLp.value_apply_ae (u : Sobolev1JetLp mu Omega p)
+
+omit [FiniteDimensional ℝ E] in
+/-- As for `TauCeti.W1p.value_coe`: the Sobolev gradient component is the gradient component of
+the underlying ambient jet. -/
+theorem W1p.gradient_coe (u : W1p mu Omega p) :
+    W1p.gradient u = Sobolev1JetLp.gradient (u : Sobolev1JetLp mu Omega p) := (rfl)
 
 omit [FiniteDimensional ℝ E] in
 /-- The Sobolev gradient component agrees almost everywhere with the second component of its
@@ -389,11 +398,7 @@ ambient value-gradient jet. -/
 theorem W1p.gradient_apply_ae (u : W1p mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
       W1p.gradient u x = WithLp.snd ((u : Sobolev1JetLp mu Omega p) x) := by
-  -- As for `W1p.value_apply_ae`: the Sobolev gradient is the ambient jet gradient of the
-  -- underlying jet, so record that equation before appealing to the ambient lemma.
-  have hgradient : W1p.gradient u = Sobolev1JetLp.gradient (u : Sobolev1JetLp mu Omega p) :=
-    (rfl)
-  rw [hgradient]
+  rw [W1p.gradient_coe]
   exact Sobolev1JetLp.gradient_apply_ae (u : Sobolev1JetLp mu Omega p)
 
 omit [InnerProductSpace ℝ E] [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure]

--- a/TauCeti/Analysis/Sobolev/W1p/Extension.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Extension.lean
@@ -47,7 +47,7 @@ isometry of `Lᵖ` spaces, so the extension operator is an isometry of Sobolev s
   `TauCeti.W1p0.norm_extendByZeroL` and its value and gradient components; it is functorial in
   `Ω` by `TauCeti.W1p0.extendByZeroL_self` and
   `TauCeti.W1p0.extendByZeroL_extendByZeroL`.
-* `TauCeti.hasWeakFDerivOn_indicator_of_mem_w1p0Submodule`: the analytic content, that the
+* `TauCeti.W1p0.hasWeakFDerivOn_indicator`: the analytic content, that the
   zero-extension of `u` is weakly differentiable on `Ω'` with the zero-extension of `∇u` as its
   weak gradient.
 
@@ -277,7 +277,7 @@ is weakly differentiable on the larger open set `Ω'`, with weak gradient the ze
 weak gradient of `u`.  This is the statement that can *fail* for a general `u ∈ W^{1,p}(Ω)`: with
 no condition forcing `u` to vanish towards `∂Ω`, its zero-extension need not be weakly
 differentiable on `Ω'` at all. -/
-theorem hasWeakFDerivOn_indicator_of_mem_w1p0Submodule (hsub : Omega ≤ Omega')
+theorem W1p0.hasWeakFDerivOn_indicator (hsub : Omega ≤ Omega')
     (u : W1p0 mu Omega p) :
     HasWeakFDerivOn mu Omega'
       ((Omega : Set E).indicator (W1p.value (u : W1p mu Omega p) : E → ℝ))

--- a/TauCeti/Analysis/Sobolev/W1p/Extension.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Extension.lean
@@ -172,15 +172,8 @@ theorem Sobolev1JetLp.extendByZeroₗᵢ_ofTestFunctionₗ (hsub : Omega ≤ Ome
 
 /-! ### The extension theorem -/
 
-/-- The closed-set argument behind the extension theorem.  It runs in the ambient jet space, so
-its conclusion is membership in the *image* of `W^{1,p}_0(Ω')` there; the two usable forms are
-`TauCeti.Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule` and
-`TauCeti.mem_w1p0Submodule_of_coe_eq`, the latter being what makes
-`TauCeti.W1p0.extendByZeroL` land in `W^{1,p}_0(Ω')`.
-
-Being closed is what the image contributes: `W^{1,p}_0(Ω')` is closed in `W^{1,p}(Ω')`, which is
-closed in the jet space, so the image is closed and its preimage under the (continuous) extension
-contains the whole of `W^{1,p}_0(Ω)` as soon as it contains every test function. -/
+/-- The zero-extension of a `W^{1,p}_0(Ω)` function belongs to the image of
+`W^{1,p}_0(Ω')` in the ambient jet space. -/
 private theorem extendByZero_mem_image (hsub : Omega ≤ Omega') {u : W1p mu Omega p}
     (hu : u ∈ w1p0Submodule mu Omega p) :
     Sobolev1JetLp.extendByZeroₗᵢ hsub (u : Sobolev1JetLp mu Omega p) ∈
@@ -257,6 +250,7 @@ theorem W1p0.extendByZeroL_extendByZeroL (hsub : Omega ≤ Omega') (hsub' : Omeg
 /-- **Extension by zero is an isometry of Sobolev spaces.**  The `W^{1,p}` norm — the `Lᵖ` norm
 of the value-gradient jet — is unchanged; the extension adds a region on which both components
 vanish. -/
+@[simp]
 theorem W1p0.norm_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
     ‖W1p0.extendByZeroL hsub u‖ = ‖u‖ :=
   (Sobolev1JetLp.extendByZeroₗᵢ hsub).norm_map _

--- a/TauCeti/Analysis/Sobolev/W1p/Extension.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Extension.lean
@@ -1,0 +1,303 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.W1p.Zero
+public import TauCeti.MeasureTheory.Function.Lp.ExtendByZero
+
+/-!
+# Extending a `W^{1,p}_0` function by zero
+
+A function in `W^{1,p}(Ω)` has no reason to stay Sobolev when it is extended by zero across `∂Ω`:
+the extension acquires a jump there, whose distributional derivative is a surface measure, not an
+`Lᵖ` function.  For `W^{1,p}_0(Ω)`, the closure of `C_c^∞(Ω)`, that obstruction disappears, and
+this file proves it: the zero-extension of a `W^{1,p}_0(Ω)` function to any larger open set `Ω'`
+lies in `W^{1,p}(Ω')` — indeed in `W^{1,p}_0(Ω')` — and its weak gradient is the zero-extension of
+the original weak gradient.
+
+This is the boundary-regularity-free half of Lane A.6 of `TauCetiRoadmap/PDE/README.md`.  Taking
+`Ω' = ⊤` gives the extension operator `W^{1,p}_0(Ω) → W^{1,p}(ℝⁿ)` that lane asks for, which is
+what lets whole-space statements (Gagliardo--Nirenberg--Sobolev, translation estimates, and
+through them Rellich--Kondrachov) be applied to functions given on a domain.  The extension
+operator for `W^{1,p}(Ω)` itself is a genuinely harder theorem needing Lipschitz `∂Ω`, and is not
+proved here.
+
+## The argument
+
+Everything rests on `TauCeti.w1p0Submodule_subset_of_isClosed`: the zero-extension map is
+continuous, and the property "the extension is a test-function limit on `Ω'`" is closed, so it is
+enough to check it on test functions.  For a test function it is immediate, because a test
+function on `Ω` *is* a test function on `Ω'` — `TestFunction.monoCLM` — and extending it by zero
+does not change it at all: it already vanished off `Ω`, as did its gradient.
+
+The zero-extension itself is `TauCeti.extendByZeroLpₗᵢ`, applied once to the value component,
+once to the gradient component, and once to the value-gradient jet that carries both.  It is an
+isometry of `Lᵖ` spaces, so the extension operator is an isometry of Sobolev spaces:
+`TauCeti.W1p0.norm_extendByZeroL`.
+
+## Main declarations
+
+* `TauCeti.Sobolev1JetLp.extendByZeroₗᵢ`: extension by zero of an `Lᵖ` value-gradient jet.
+* `TauCeti.extendByZero_mem_w1p0Submodule`: the zero-extension of a `W^{1,p}_0(Ω)` function lies
+  in `W^{1,p}_0(Ω')`, hence in `W^{1,p}(Ω')`.
+* `TauCeti.W1p0.extendByZeroL`: the extension operator `W^{1,p}_0(Ω) →L[ℝ] W^{1,p}(Ω')`, with
+  `TauCeti.W1p0.norm_extendByZeroL` and its value and gradient components.
+* `TauCeti.hasWeakFDerivOn_indicator_of_mem_w1p0Submodule`: the analytic content, that the
+  zero-extension of `u` is weakly differentiable on `Ω'` with the zero-extension of `∇u` as its
+  weak gradient.
+
+## References
+
+Lane A.6 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans, *Partial Differential Equations*,
+Section 5.5, and H. Brezis, *Functional Analysis, Sobolev Spaces and Partial Differential
+Equations*, Lemma 9.5.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open MeasureTheory Set TopologicalSpace
+
+open scoped Distributions ENNReal Gradient InnerProductSpace
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
+  {Omega Omega' : Opens E} {p : ENNReal} [Fact (1 ≤ p)]
+
+/-! ### Extension by zero of `Lᵖ` jets -/
+
+omit [mu.IsAddHaarMeasure] in
+/-- **Extension by zero of an `Lᵖ` value-gradient jet** from `Ω` to a larger open set `Ω'`: both
+components are declared zero on `Ω' \ Ω`.  It is an isometry, since the added region contributes
+nothing to either `Lᵖ` norm. -/
+def Sobolev1JetLp.extendByZeroₗᵢ (hsub : Omega ≤ Omega') :
+    Sobolev1JetLp mu Omega p →ₗᵢ[ℝ] Sobolev1JetLp mu Omega' p :=
+  extendByZeroLpₗᵢ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+
+omit [FiniteDimensional ℝ E] [mu.IsAddHaarMeasure] in
+/-- The extension of a jet is the indicator of the original jet. -/
+theorem Sobolev1JetLp.coeFn_extendByZeroₗᵢ (hsub : Omega ≤ Omega')
+    (J : Sobolev1JetLp mu Omega p) :
+    (Sobolev1JetLp.extendByZeroₗᵢ hsub J : E → Sobolev1Jet E) =ᵐ[mu.restrict Omega']
+      (Omega : Set E).indicator (J : E → Sobolev1Jet E) :=
+  coeFn_extendByZeroLpₗᵢ _ _ _
+
+omit [FiniteDimensional ℝ E] [mu.IsAddHaarMeasure] in
+/-- The value component of an extended jet is the extension of the value component. -/
+theorem Sobolev1JetLp.value_extendByZeroₗᵢ (hsub : Omega ≤ Omega')
+    (J : Sobolev1JetLp mu Omega p) :
+    Sobolev1JetLp.value (Sobolev1JetLp.extendByZeroₗᵢ hsub J) =
+      extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+        (Sobolev1JetLp.value J) := by
+  refine Lp.ext ?_
+  filter_upwards [Sobolev1JetLp.value_apply_ae (Sobolev1JetLp.extendByZeroₗᵢ hsub J),
+    Sobolev1JetLp.coeFn_extendByZeroₗᵢ hsub J,
+    coeFn_extendByZeroLpₗᵢ (𝕜 := ℝ) Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+      (Sobolev1JetLp.value J),
+    indicator_ae_eq_indicator_of_restrict Omega.isOpen.measurableSet
+      (Sobolev1JetLp.value_apply_ae J) (Omega' : Set E)] with x h1 h2 h3 h4
+  rw [h1, h2, h3, h4]
+  by_cases hx : x ∈ (Omega : Set E) <;> simp [hx]
+
+omit [FiniteDimensional ℝ E] [mu.IsAddHaarMeasure] in
+/-- The gradient component of an extended jet is the extension of the gradient component. -/
+theorem Sobolev1JetLp.gradient_extendByZeroₗᵢ (hsub : Omega ≤ Omega')
+    (J : Sobolev1JetLp mu Omega p) :
+    Sobolev1JetLp.gradient (Sobolev1JetLp.extendByZeroₗᵢ hsub J) =
+      extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+        (Sobolev1JetLp.gradient J) := by
+  refine Lp.ext ?_
+  filter_upwards [Sobolev1JetLp.gradient_apply_ae (Sobolev1JetLp.extendByZeroₗᵢ hsub J),
+    Sobolev1JetLp.coeFn_extendByZeroₗᵢ hsub J,
+    coeFn_extendByZeroLpₗᵢ (𝕜 := ℝ) Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+      (Sobolev1JetLp.gradient J),
+    indicator_ae_eq_indicator_of_restrict Omega.isOpen.measurableSet
+      (Sobolev1JetLp.gradient_apply_ae J) (Omega' : Set E)] with x h1 h2 h3 h4
+  rw [h1, h2, h3, h4]
+  by_cases hx : x ∈ (Omega : Set E) <;> simp [hx]
+
+/-! ### Test functions extend to test functions -/
+
+omit [MeasurableSpace E] [FiniteDimensional ℝ E] [BorelSpace E] [mu.IsAddHaarMeasure] in
+/-- A test function on `Ω`, viewed on the larger open set `Ω'`, is the same function. -/
+private theorem coe_monoCLM (hsub : Omega ≤ Omega') (phi : 𝓓(Omega, ℝ)) :
+    ((TestFunction.monoCLM ℝ phi : 𝓓(Omega', ℝ)) : E → ℝ) = (phi : E → ℝ) := by
+  rw [TestFunction.monoCLM_apply]
+  simp [hsub]
+
+omit [FiniteDimensional ℝ E] in
+/-- Extending a test function's `Lᵖ` class by zero gives the class of the same test function on
+the larger open set: it already vanished outside `Ω`. -/
+private theorem extendByZeroLpₗᵢ_testFunctionLp (hsub : Omega ≤ Omega') (phi : 𝓓(Omega, ℝ)) :
+    extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+        (testFunctionLp p phi) =
+      testFunctionLp (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi) := by
+  refine Lp.ext ?_
+  filter_upwards [coeFn_extendByZeroLpₗᵢ (𝕜 := ℝ) Omega.isOpen.measurableSet
+      (SetLike.coe_subset_coe.mpr hsub) (testFunctionLp (mu := mu) p phi),
+    indicator_ae_eq_indicator_of_restrict Omega.isOpen.measurableSet
+      (testFunctionLp_apply_ae (mu := mu) p phi) (Omega' : Set E),
+    testFunctionLp_apply_ae (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi)]
+    with x h1 h2 h3
+  rw [h1, h2, h3, coe_monoCLM hsub phi]
+  by_cases hx : x ∈ (Omega : Set E)
+  · rw [indicator_of_mem hx]
+  · rw [indicator_of_notMem hx]
+    exact (image_eq_zero_of_notMem_tsupport fun hc => hx (phi.tsupport_subset hc)).symm
+
+/-- Extending a test function's gradient by zero gives the gradient of the same test function on
+the larger open set. -/
+private theorem extendByZeroLpₗᵢ_gradientTestFunctionLp (hsub : Omega ≤ Omega')
+    (phi : 𝓓(Omega, ℝ)) :
+    extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+        (gradientTestFunctionLp p phi) =
+      gradientTestFunctionLp (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi) := by
+  refine Lp.ext ?_
+  filter_upwards [coeFn_extendByZeroLpₗᵢ (𝕜 := ℝ) Omega.isOpen.measurableSet
+      (SetLike.coe_subset_coe.mpr hsub) (gradientTestFunctionLp (mu := mu) p phi),
+    indicator_ae_eq_indicator_of_restrict Omega.isOpen.measurableSet
+      (gradientTestFunctionLp_apply_ae (mu := mu) p phi) (Omega' : Set E),
+    gradientTestFunctionLp_apply_ae (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi)]
+    with x h1 h2 h3
+  rw [h1, h2, h3, coe_monoCLM hsub phi]
+  by_cases hx : x ∈ (Omega : Set E)
+  · rw [indicator_of_mem hx]
+  · rw [indicator_of_notMem hx]
+    exact (Function.notMem_support.mp
+      fun hc => hx (support_gradient_testFunction_subset phi hc)).symm
+
+/-- The zero-extension of a test-function jet is the jet of the same test function on the larger
+open set. -/
+theorem Sobolev1JetLp.extendByZeroₗᵢ_ofTestFunctionₗ (hsub : Omega ≤ Omega')
+    (phi : 𝓓(Omega, ℝ)) :
+    Sobolev1JetLp.extendByZeroₗᵢ hsub
+        (W1p.ofTestFunctionₗ mu Omega p phi : Sobolev1JetLp mu Omega p) =
+      (W1p.ofTestFunctionₗ mu Omega' p (TestFunction.monoCLM ℝ phi) :
+        Sobolev1JetLp mu Omega' p) := by
+  refine Sobolev1JetLp.ext ?_ ?_
+  · rw [Sobolev1JetLp.value_extendByZeroₗᵢ, ← W1p.value_coe, ← W1p.value_coe,
+      W1p.value_ofTestFunctionₗ, W1p.value_ofTestFunctionₗ]
+    exact extendByZeroLpₗᵢ_testFunctionLp hsub phi
+  · rw [Sobolev1JetLp.gradient_extendByZeroₗᵢ, ← W1p.gradient_coe, ← W1p.gradient_coe,
+      W1p.gradient_ofTestFunctionₗ, W1p.gradient_ofTestFunctionₗ]
+    exact extendByZeroLpₗᵢ_gradientTestFunctionLp hsub phi
+
+/-! ### The extension theorem -/
+
+/-- The closed-set argument behind the extension theorem.  It runs in the ambient jet space, so
+its conclusion is membership in the *image* of `W^{1,p}_0(Ω')` there; the two usable forms are
+`TauCeti.extendByZero_mem_w1pSubmodule` and `TauCeti.extendByZero_mem_w1p0Submodule`.
+
+Being closed is what the image contributes: `W^{1,p}_0(Ω')` is closed in `W^{1,p}(Ω')`, which is
+closed in the jet space, so the image is closed and its preimage under the (continuous) extension
+contains the whole of `W^{1,p}_0(Ω)` as soon as it contains every test function. -/
+private theorem extendByZero_mem_image (hsub : Omega ≤ Omega') {u : W1p mu Omega p}
+    (hu : u ∈ w1p0Submodule mu Omega p) :
+    Sobolev1JetLp.extendByZeroₗᵢ hsub (u : Sobolev1JetLp mu Omega p) ∈
+      Subtype.val '' (w1p0Submodule mu Omega' p : Set (W1p mu Omega' p)) := by
+  have hclosed : IsClosed
+      (Subtype.val '' (w1p0Submodule mu Omega' p : Set (W1p mu Omega' p))) :=
+    ((w1pSubmodule mu Omega' p).isClosed.isClosedEmbedding_subtypeVal).isClosedMap _
+      (w1p0Submodule mu Omega' p).isClosed
+  have hcont : Continuous fun v : W1p mu Omega p =>
+      Sobolev1JetLp.extendByZeroₗᵢ (mu := mu) (p := p) hsub (v : Sobolev1JetLp mu Omega p) :=
+    (Sobolev1JetLp.extendByZeroₗᵢ hsub).continuous.comp continuous_subtype_val
+  refine w1p0Submodule_subset_of_isClosed (hclosed.preimage hcont) (fun phi => ?_) hu
+  exact ⟨W1p.ofTestFunctionₗ mu Omega' p (TestFunction.monoCLM ℝ phi),
+    W1p.ofTestFunctionₗ_mem_w1p0Submodule _,
+    (Sobolev1JetLp.extendByZeroₗᵢ_ofTestFunctionₗ hsub phi).symm⟩
+
+/-- **The zero-extension of a `W^{1,p}_0(Ω)` function is a Sobolev function on `Ω'`.**  No
+regularity of `∂Ω` is needed, and no boundedness of either open set; the boundary condition
+carried by membership in `W^{1,p}_0(Ω)` is what makes the extension weakly differentiable. -/
+theorem extendByZero_mem_w1pSubmodule (hsub : Omega ≤ Omega') {u : W1p mu Omega p}
+    (hu : u ∈ w1p0Submodule mu Omega p) :
+    Sobolev1JetLp.extendByZeroₗᵢ hsub (u : Sobolev1JetLp mu Omega p) ∈
+      w1pSubmodule mu Omega' p := by
+  obtain ⟨v, -, hv⟩ := extendByZero_mem_image hsub hu
+  exact hv ▸ v.2
+
+/-- **Extension by zero as an operator `W^{1,p}_0(Ω) →L[ℝ] W^{1,p}(Ω')`.**  Taking `Ω' = ⊤`, that
+is `hsub = le_top`, gives the extension operator to the whole space. -/
+def W1p0.extendByZeroL (hsub : Omega ≤ Omega') :
+    W1p0 mu Omega p →L[ℝ] W1p mu Omega' p :=
+  ContinuousLinearMap.codRestrict
+    ((Sobolev1JetLp.extendByZeroₗᵢ (mu := mu) (p := p) hsub).toContinuousLinearMap.comp
+      ((w1pSubmodule mu Omega p).toSubmodule.subtypeL.comp
+        (w1p0Submodule mu Omega p).toSubmodule.subtypeL))
+    (w1pSubmodule mu Omega' p).toSubmodule
+    fun u => extendByZero_mem_w1pSubmodule hsub u.2
+
+@[simp]
+theorem W1p0.coe_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
+    (W1p0.extendByZeroL hsub u : Sobolev1JetLp mu Omega' p) =
+      Sobolev1JetLp.extendByZeroₗᵢ hsub ((u : W1p mu Omega p) : Sobolev1JetLp mu Omega p) :=
+  (rfl)
+
+/-- **The zero-extension of a `W^{1,p}_0(Ω)` function lies in `W^{1,p}_0(Ω')`**, not merely in
+`W^{1,p}(Ω')`: a limit of test functions on `Ω` extends to a limit of test functions on `Ω'`. -/
+theorem extendByZero_mem_w1p0Submodule (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
+    W1p0.extendByZeroL hsub u ∈ w1p0Submodule mu Omega' p := by
+  obtain ⟨v, hv, hval⟩ := extendByZero_mem_image hsub u.2
+  have : W1p0.extendByZeroL hsub u = v := Subtype.ext hval.symm
+  rw [this]
+  exact hv
+
+/-- **Extension by zero is an isometry of Sobolev spaces.**  Both the `Lᵖ` norm of the function
+and that of its weak gradient are unchanged. -/
+theorem W1p0.norm_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
+    ‖W1p0.extendByZeroL hsub u‖ = ‖u‖ :=
+  (Sobolev1JetLp.extendByZeroₗᵢ hsub).norm_map _
+
+/-- The value component of the extension is the zero-extension of the value component. -/
+theorem W1p0.value_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
+    W1p.value (W1p0.extendByZeroL hsub u) =
+      extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+        (W1p.value (u : W1p mu Omega p)) := by
+  rw [W1p.value_coe, W1p.value_coe, W1p0.coe_extendByZeroL,
+    Sobolev1JetLp.value_extendByZeroₗᵢ]
+
+/-- The gradient component of the extension is the zero-extension of the gradient component. -/
+theorem W1p0.gradient_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
+    W1p.gradient (W1p0.extendByZeroL hsub u) =
+      extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+        (W1p.gradient (u : W1p mu Omega p)) := by
+  rw [W1p.gradient_coe, W1p.gradient_coe, W1p0.coe_extendByZeroL,
+    Sobolev1JetLp.gradient_extendByZeroₗᵢ]
+
+/-- **The analytic content of the extension theorem.**  The zero-extension of `u ∈ W^{1,p}_0(Ω)`
+is weakly differentiable on the larger open set `Ω'`, with weak gradient the zero-extension of the
+weak gradient of `u`.  This is the statement that *fails* for a general `u ∈ W^{1,p}(Ω)`: the
+extension then has a jump across `∂Ω`, whose distributional derivative is not a function. -/
+theorem hasWeakFDerivOn_indicator_of_mem_w1p0Submodule (hsub : Omega ≤ Omega')
+    (u : W1p0 mu Omega p) :
+    HasWeakFDerivOn mu Omega'
+      ((Omega : Set E).indicator (W1p.value (u : W1p mu Omega p) : E → ℝ))
+      fun x => innerSL ℝ
+        ((Omega : Set E).indicator (W1p.gradient (u : W1p mu Omega p) : E → E) x) := by
+  have hbridge := (W1p.value_coe (W1p0.extendByZeroL hsub u)).symm
+  have hmem := (mem_w1pSubmodule_iff_hasWeakFDerivOn
+    ((W1p0.extendByZeroL hsub u : W1p mu Omega' p) : Sobolev1JetLp mu Omega' p)).mp
+      (W1p0.extendByZeroL hsub u).2
+  rw [hbridge] at hmem
+  have hvalue : (W1p.value (W1p0.extendByZeroL hsub u) : E → ℝ) =ᵐ[mu.restrict Omega']
+      (Omega : Set E).indicator (W1p.value (u : W1p mu Omega p) : E → ℝ) := by
+    rw [W1p0.value_extendByZeroL]
+    exact coeFn_extendByZeroLpₗᵢ _ _ _
+  have hgradient : (W1p.gradient (W1p0.extendByZeroL hsub u) : E → E) =ᵐ[mu.restrict Omega']
+      (Omega : Set E).indicator (W1p.gradient (u : W1p mu Omega p) : E → E) := by
+    rw [W1p0.gradient_extendByZeroL]
+    exact coeFn_extendByZeroLpₗᵢ _ _ _
+  refine (hmem.congr_ae hvalue).congr_ae_deriv ?_
+  filter_upwards [hgradient] with x hx
+  refine ContinuousLinearMap.ext fun v => ?_
+  rw [Sobolev1JetLp.candidateWeakFDeriv_apply, innerSL_apply_apply, ← W1p.gradient_coe, hx]
+  exact real_inner_comm _ _
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/Extension.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Extension.lean
@@ -12,11 +12,11 @@ public import TauCeti.MeasureTheory.Function.Lp.ExtendByZero
 # Extending a `W^{1,p}_0` function by zero
 
 A function in `W^{1,p}(Ω)` has no reason to stay Sobolev when it is extended by zero across `∂Ω`:
-the extension acquires a jump there, whose distributional derivative is a surface measure, not an
-`Lᵖ` function.  For `W^{1,p}_0(Ω)`, the closure of `C_c^∞(Ω)`, that obstruction disappears, and
-this file proves it: the zero-extension of a `W^{1,p}_0(Ω)` function to any larger open set `Ω'`
-lies in `W^{1,p}(Ω')` — indeed in `W^{1,p}_0(Ω')` — and its weak gradient is the zero-extension of
-the original weak gradient.
+without some condition forcing it to vanish towards the boundary, the extension can fail to be
+weakly differentiable on the larger set at all.  For `W^{1,p}_0(Ω)`, the closure of `C_c^∞(Ω)`,
+that obstruction disappears, and this file proves it: the zero-extension of a `W^{1,p}_0(Ω)`
+function to any larger open set `Ω'` lies in `W^{1,p}_0(Ω')`, and its weak gradient is the
+zero-extension of the original weak gradient.
 
 This is the boundary-regularity-free half of Lane A.6 of `TauCetiRoadmap/PDE/README.md`.  Taking
 `Ω' = ⊤` gives the extension operator `W^{1,p}_0(Ω) → W^{1,p}(ℝⁿ)` that lane asks for, which is
@@ -41,10 +41,12 @@ isometry of `Lᵖ` spaces, so the extension operator is an isometry of Sobolev s
 ## Main declarations
 
 * `TauCeti.Sobolev1JetLp.extendByZeroₗᵢ`: extension by zero of an `Lᵖ` value-gradient jet.
-* `TauCeti.W1p0.extendByZeroL_mem_w1p0Submodule`: the zero-extension of a `W^{1,p}_0(Ω)`
-  function lies in `W^{1,p}_0(Ω')`, hence in `W^{1,p}(Ω')`.
-* `TauCeti.W1p0.extendByZeroL`: the extension operator `W^{1,p}_0(Ω) →L[ℝ] W^{1,p}(Ω')`, with
-  `TauCeti.W1p0.norm_extendByZeroL` and its value and gradient components.
+* `TauCeti.Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule`: the zero-extension of a `W^{1,p}_0(Ω)`
+  function is a Sobolev function on `Ω'`.
+* `TauCeti.W1p0.extendByZeroL`: the extension operator `W^{1,p}_0(Ω) →L[ℝ] W^{1,p}_0(Ω')`, with
+  `TauCeti.W1p0.norm_extendByZeroL` and its value and gradient components; it is functorial in
+  `Ω` by `TauCeti.W1p0.extendByZeroL_self` and
+  `TauCeti.W1p0.extendByZeroL_extendByZeroL`.
 * `TauCeti.hasWeakFDerivOn_indicator_of_mem_w1p0Submodule`: the analytic content, that the
   zero-extension of `u` is weakly differentiable on `Ω'` with the zero-extension of `∇u` as its
   weak gradient.
@@ -68,7 +70,7 @@ open scoped Distributions ENNReal Gradient InnerProductSpace
 
 variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
   [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
-  {Omega Omega' : Opens E} {p : ENNReal} [Fact (1 ≤ p)]
+  {Omega Omega' Omega'' : Opens E} {p : ENNReal} [Fact (1 ≤ p)]
 
 /-! ### Extension by zero of `Lᵖ` jets -/
 
@@ -173,7 +175,8 @@ theorem Sobolev1JetLp.extendByZeroₗᵢ_ofTestFunctionₗ (hsub : Omega ≤ Ome
 /-- The closed-set argument behind the extension theorem.  It runs in the ambient jet space, so
 its conclusion is membership in the *image* of `W^{1,p}_0(Ω')` there; the two usable forms are
 `TauCeti.Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule` and
-`TauCeti.W1p0.extendByZeroL_mem_w1p0Submodule`.
+`TauCeti.mem_w1p0Submodule_of_coe_eq`, the latter being what makes
+`TauCeti.W1p0.extendByZeroL` land in `W^{1,p}_0(Ω')`.
 
 Being closed is what the image contributes: `W^{1,p}_0(Ω')` is closed in `W^{1,p}(Ω')`, which is
 closed in the jet space, so the image is closed and its preimage under the (continuous) extension
@@ -194,6 +197,16 @@ private theorem extendByZero_mem_image (hsub : Omega ≤ Omega') {u : W1p mu Ome
     W1p.ofTestFunctionₗ_mem_w1p0Submodule _,
     (Sobolev1JetLp.extendByZeroₗᵢ_ofTestFunctionₗ hsub phi).symm⟩
 
+/-- Transporting `TauCeti.extendByZero_mem_image` to any Sobolev function on `Ω'` whose ambient
+jet is the zero-extension. -/
+private theorem mem_w1p0Submodule_of_coe_eq (hsub : Omega ≤ Omega') {u : W1p mu Omega p}
+    (hu : u ∈ w1p0Submodule mu Omega p) {v : W1p mu Omega' p}
+    (hv : (v : Sobolev1JetLp mu Omega' p) =
+      Sobolev1JetLp.extendByZeroₗᵢ hsub (u : Sobolev1JetLp mu Omega p)) :
+    v ∈ w1p0Submodule mu Omega' p := by
+  obtain ⟨w, hw, hwval⟩ := extendByZero_mem_image hsub hu
+  exact Subtype.ext (hwval.trans hv.symm) ▸ hw
+
 /-- **The zero-extension of a `W^{1,p}_0(Ω)` function is a Sobolev function on `Ω'`.**  No
 regularity of `∂Ω` is needed, and no boundedness of either open set; the boundary condition
 carried by membership in `W^{1,p}_0(Ω)` is what makes the extension weakly differentiable. -/
@@ -204,31 +217,42 @@ theorem Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule (hsub : Omega ≤ Omeg
   obtain ⟨v, -, hv⟩ := extendByZero_mem_image hsub hu
   exact hv ▸ v.2
 
-/-- **Extension by zero as an operator `W^{1,p}_0(Ω) →L[ℝ] W^{1,p}(Ω')`.**  Taking `Ω' = ⊤`, that
-is `hsub = le_top`, gives the extension operator to the whole space. -/
+/-- **Extension by zero as an operator `W^{1,p}_0(Ω) →L[ℝ] W^{1,p}_0(Ω')`.**  The extension of a
+limit of test functions on `Ω` is again a limit of test functions, on `Ω'`, so the operator lands
+in `W^{1,p}_0(Ω')` and not merely in `W^{1,p}(Ω')`; compose with
+`(TauCeti.w1p0Submodule mu Omega' p).toSubmodule.subtypeL` for the `W^{1,p}(Ω')`-valued map.
+Taking `Ω' = ⊤`, that is `hsub = le_top`, gives the extension operator to the whole space. -/
 def W1p0.extendByZeroL (hsub : Omega ≤ Omega') :
-    W1p0 mu Omega p →L[ℝ] W1p mu Omega' p :=
+    W1p0 mu Omega p →L[ℝ] W1p0 mu Omega' p :=
   ContinuousLinearMap.codRestrict
-    ((Sobolev1JetLp.extendByZeroₗᵢ (mu := mu) (p := p) hsub).toContinuousLinearMap.comp
-      ((w1pSubmodule mu Omega p).toSubmodule.subtypeL.comp
-        (w1p0Submodule mu Omega p).toSubmodule.subtypeL))
-    (w1pSubmodule mu Omega' p).toSubmodule
-    fun u => Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule hsub u.2
+    (ContinuousLinearMap.codRestrict
+      ((Sobolev1JetLp.extendByZeroₗᵢ (mu := mu) (p := p) hsub).toContinuousLinearMap.comp
+        ((w1pSubmodule mu Omega p).toSubmodule.subtypeL.comp
+          (w1p0Submodule mu Omega p).toSubmodule.subtypeL))
+      (w1pSubmodule mu Omega' p).toSubmodule
+      fun u => Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule hsub u.2)
+    (w1p0Submodule mu Omega' p).toSubmodule
+    fun u => mem_w1p0Submodule_of_coe_eq hsub u.2 rfl
 
+/-- The ambient jet of the extension is the extension of the ambient jet. -/
 @[simp]
 theorem W1p0.coe_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
-    (W1p0.extendByZeroL hsub u : Sobolev1JetLp mu Omega' p) =
+    ((W1p0.extendByZeroL hsub u : W1p mu Omega' p) : Sobolev1JetLp mu Omega' p) =
       Sobolev1JetLp.extendByZeroₗᵢ hsub ((u : W1p mu Omega p) : Sobolev1JetLp mu Omega p) :=
   (rfl)
 
-/-- **The zero-extension of a `W^{1,p}_0(Ω)` function lies in `W^{1,p}_0(Ω')`**, not merely in
-`W^{1,p}(Ω')`: a limit of test functions on `Ω` extends to a limit of test functions on `Ω'`. -/
-theorem W1p0.extendByZeroL_mem_w1p0Submodule (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
-    W1p0.extendByZeroL hsub u ∈ w1p0Submodule mu Omega' p := by
-  obtain ⟨v, hv, hval⟩ := extendByZero_mem_image hsub u.2
-  have : W1p0.extendByZeroL hsub u = v := Subtype.ext hval.symm
-  rw [this]
-  exact hv
+/-- **Extending by zero from `Ω` to `Ω` does nothing.** -/
+@[simp]
+theorem W1p0.extendByZeroL_self (u : W1p0 mu Omega p) : W1p0.extendByZeroL le_rfl u = u :=
+  Subtype.ext (Subtype.ext (extendByZeroLpₗᵢ_self ℝ _ _))
+
+/-- **Extending by zero twice is extending by zero once.** -/
+@[simp]
+theorem W1p0.extendByZeroL_extendByZeroL (hsub : Omega ≤ Omega') (hsub' : Omega' ≤ Omega'')
+    (u : W1p0 mu Omega p) :
+    W1p0.extendByZeroL hsub' (W1p0.extendByZeroL hsub u) =
+      W1p0.extendByZeroL (hsub.trans hsub') u :=
+  Subtype.ext (Subtype.ext (extendByZeroLpₗᵢ_extendByZeroLpₗᵢ ℝ _ _ _ _ _))
 
 /-- **Extension by zero is an isometry of Sobolev spaces.**  The `W^{1,p}` norm — the `Lᵖ` norm
 of the value-gradient jet — is unchanged; the extension adds a region on which both components
@@ -240,7 +264,7 @@ theorem W1p0.norm_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) 
 /-- The value component of the extension is the zero-extension of the value component. -/
 @[simp]
 theorem W1p0.value_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
-    W1p.value (W1p0.extendByZeroL hsub u) =
+    W1p.value (W1p0.extendByZeroL hsub u : W1p mu Omega' p) =
       extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
         (W1p.value (u : W1p mu Omega p)) := by
   rw [W1p.value_coe, W1p.value_coe, W1p0.coe_extendByZeroL,
@@ -249,7 +273,7 @@ theorem W1p0.value_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p)
 /-- The gradient component of the extension is the zero-extension of the gradient component. -/
 @[simp]
 theorem W1p0.gradient_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
-    W1p.gradient (W1p0.extendByZeroL hsub u) =
+    W1p.gradient (W1p0.extendByZeroL hsub u : W1p mu Omega' p) =
       extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
         (W1p.gradient (u : W1p mu Omega p)) := by
   rw [W1p.gradient_coe, W1p.gradient_coe, W1p0.coe_extendByZeroL,
@@ -257,24 +281,28 @@ theorem W1p0.gradient_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega
 
 /-- **The analytic content of the extension theorem.**  The zero-extension of `u ∈ W^{1,p}_0(Ω)`
 is weakly differentiable on the larger open set `Ω'`, with weak gradient the zero-extension of the
-weak gradient of `u`.  This is the statement that *fails* for a general `u ∈ W^{1,p}(Ω)`: the
-extension then has a jump across `∂Ω`, whose distributional derivative is not a function. -/
+weak gradient of `u`.  This is the statement that can *fail* for a general `u ∈ W^{1,p}(Ω)`: with
+no condition forcing `u` to vanish towards `∂Ω`, its zero-extension need not be weakly
+differentiable on `Ω'` at all. -/
 theorem hasWeakFDerivOn_indicator_of_mem_w1p0Submodule (hsub : Omega ≤ Omega')
     (u : W1p0 mu Omega p) :
     HasWeakFDerivOn mu Omega'
       ((Omega : Set E).indicator (W1p.value (u : W1p mu Omega p) : E → ℝ))
       fun x => innerSL ℝ
         ((Omega : Set E).indicator (W1p.gradient (u : W1p mu Omega p) : E → E) x) := by
-  have hbridge := (W1p.value_coe (W1p0.extendByZeroL hsub u)).symm
+  have hbridge :=
+    (W1p.value_coe (W1p0.extendByZeroL hsub u : W1p mu Omega' p)).symm
   have hmem := (mem_w1pSubmodule_iff_hasWeakFDerivOn
     ((W1p0.extendByZeroL hsub u : W1p mu Omega' p) : Sobolev1JetLp mu Omega' p)).mp
-      (W1p0.extendByZeroL hsub u).2
+      (W1p0.extendByZeroL hsub u : W1p mu Omega' p).2
   rw [hbridge] at hmem
-  have hvalue : (W1p.value (W1p0.extendByZeroL hsub u) : E → ℝ) =ᵐ[mu.restrict Omega']
+  have hvalue : (W1p.value (W1p0.extendByZeroL hsub u : W1p mu Omega' p) : E → ℝ)
+      =ᵐ[mu.restrict Omega']
       (Omega : Set E).indicator (W1p.value (u : W1p mu Omega p) : E → ℝ) := by
     rw [W1p0.value_extendByZeroL]
     exact coeFn_extendByZeroLpₗᵢ _ _ _ _
-  have hgradient : (W1p.gradient (W1p0.extendByZeroL hsub u) : E → E) =ᵐ[mu.restrict Omega']
+  have hgradient : (W1p.gradient (W1p0.extendByZeroL hsub u : W1p mu Omega' p) : E → E)
+      =ᵐ[mu.restrict Omega']
       (Omega : Set E).indicator (W1p.gradient (u : W1p mu Omega p) : E → E) := by
     rw [W1p0.gradient_extendByZeroL]
     exact coeFn_extendByZeroLpₗᵢ _ _ _ _

--- a/TauCeti/Analysis/Sobolev/W1p/Extension.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Extension.lean
@@ -250,7 +250,6 @@ theorem W1p0.extendByZeroL_extendByZeroL (hsub : Omega ≤ Omega') (hsub' : Omeg
 /-- **Extension by zero is an isometry of Sobolev spaces.**  The `W^{1,p}` norm — the `Lᵖ` norm
 of the value-gradient jet — is unchanged; the extension adds a region on which both components
 vanish. -/
-@[simp]
 theorem W1p0.norm_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
     ‖W1p0.extendByZeroL hsub u‖ = ‖u‖ :=
   (Sobolev1JetLp.extendByZeroₗᵢ hsub).norm_map _

--- a/TauCeti/Analysis/Sobolev/W1p/Extension.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Extension.lean
@@ -41,8 +41,8 @@ isometry of `Lᵖ` spaces, so the extension operator is an isometry of Sobolev s
 ## Main declarations
 
 * `TauCeti.Sobolev1JetLp.extendByZeroₗᵢ`: extension by zero of an `Lᵖ` value-gradient jet.
-* `TauCeti.extendByZero_mem_w1p0Submodule`: the zero-extension of a `W^{1,p}_0(Ω)` function lies
-  in `W^{1,p}_0(Ω')`, hence in `W^{1,p}(Ω')`.
+* `TauCeti.W1p0.extendByZeroL_mem_w1p0Submodule`: the zero-extension of a `W^{1,p}_0(Ω)`
+  function lies in `W^{1,p}_0(Ω')`, hence in `W^{1,p}(Ω')`.
 * `TauCeti.W1p0.extendByZeroL`: the extension operator `W^{1,p}_0(Ω) →L[ℝ] W^{1,p}(Ω')`, with
   `TauCeti.W1p0.norm_extendByZeroL` and its value and gradient components.
 * `TauCeti.hasWeakFDerivOn_indicator_of_mem_w1p0Submodule`: the analytic content, that the
@@ -75,10 +75,10 @@ variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpa
 omit [mu.IsAddHaarMeasure] in
 /-- **Extension by zero of an `Lᵖ` value-gradient jet** from `Ω` to a larger open set `Ω'`: both
 components are declared zero on `Ω' \ Ω`.  It is an isometry, since the added region contributes
-nothing to either `Lᵖ` norm. -/
+nothing to the `Lᵖ` norm of the jet: both of its components vanish there. -/
 def Sobolev1JetLp.extendByZeroₗᵢ (hsub : Omega ≤ Omega') :
     Sobolev1JetLp mu Omega p →ₗᵢ[ℝ] Sobolev1JetLp mu Omega' p :=
-  extendByZeroLpₗᵢ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+  extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
 
 omit [FiniteDimensional ℝ E] [mu.IsAddHaarMeasure] in
 /-- The extension of a jet is the indicator of the original jet. -/
@@ -86,41 +86,34 @@ theorem Sobolev1JetLp.coeFn_extendByZeroₗᵢ (hsub : Omega ≤ Omega')
     (J : Sobolev1JetLp mu Omega p) :
     (Sobolev1JetLp.extendByZeroₗᵢ hsub J : E → Sobolev1Jet E) =ᵐ[mu.restrict Omega']
       (Omega : Set E).indicator (J : E → Sobolev1Jet E) :=
-  coeFn_extendByZeroLpₗᵢ _ _ _
+  coeFn_extendByZeroLpₗᵢ _ _ _ _
 
 omit [FiniteDimensional ℝ E] [mu.IsAddHaarMeasure] in
-/-- The value component of an extended jet is the extension of the value component. -/
+/-- The value component of an extended jet is the extension of the value component: taking a
+component is a pointwise postcomposition, and `TauCeti.coeFn_extendByZeroLpₗᵢ_comp` says that
+those commute with extension by zero. -/
+@[simp]
 theorem Sobolev1JetLp.value_extendByZeroₗᵢ (hsub : Omega ≤ Omega')
     (J : Sobolev1JetLp mu Omega p) :
     Sobolev1JetLp.value (Sobolev1JetLp.extendByZeroₗᵢ hsub J) =
-      extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
-        (Sobolev1JetLp.value J) := by
-  refine Lp.ext ?_
-  filter_upwards [Sobolev1JetLp.value_apply_ae (Sobolev1JetLp.extendByZeroₗᵢ hsub J),
-    Sobolev1JetLp.coeFn_extendByZeroₗᵢ hsub J,
-    coeFn_extendByZeroLpₗᵢ (𝕜 := ℝ) Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
-      (Sobolev1JetLp.value J),
-    indicator_ae_eq_indicator_of_restrict Omega.isOpen.measurableSet
-      (Sobolev1JetLp.value_apply_ae J) (Omega' : Set E)] with x h1 h2 h3 h4
-  rw [h1, h2, h3, h4]
-  by_cases hx : x ∈ (Omega : Set E) <;> simp [hx]
+      extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+        (Sobolev1JetLp.value J) :=
+  (Lp.ext ((coeFn_extendByZeroLpₗᵢ_comp ℝ Omega.isOpen.measurableSet
+    (SetLike.coe_subset_coe.mpr hsub) WithLp.fst rfl (Sobolev1JetLp.value_apply_ae J)).trans
+      (Filter.EventuallyEq.symm (Sobolev1JetLp.value_apply_ae _)))).symm
 
 omit [FiniteDimensional ℝ E] [mu.IsAddHaarMeasure] in
-/-- The gradient component of an extended jet is the extension of the gradient component. -/
+/-- The gradient component of an extended jet is the extension of the gradient component; as for
+`TauCeti.Sobolev1JetLp.value_extendByZeroₗᵢ`, this is postcomposition commuting with extension. -/
+@[simp]
 theorem Sobolev1JetLp.gradient_extendByZeroₗᵢ (hsub : Omega ≤ Omega')
     (J : Sobolev1JetLp mu Omega p) :
     Sobolev1JetLp.gradient (Sobolev1JetLp.extendByZeroₗᵢ hsub J) =
-      extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
-        (Sobolev1JetLp.gradient J) := by
-  refine Lp.ext ?_
-  filter_upwards [Sobolev1JetLp.gradient_apply_ae (Sobolev1JetLp.extendByZeroₗᵢ hsub J),
-    Sobolev1JetLp.coeFn_extendByZeroₗᵢ hsub J,
-    coeFn_extendByZeroLpₗᵢ (𝕜 := ℝ) Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
-      (Sobolev1JetLp.gradient J),
-    indicator_ae_eq_indicator_of_restrict Omega.isOpen.measurableSet
-      (Sobolev1JetLp.gradient_apply_ae J) (Omega' : Set E)] with x h1 h2 h3 h4
-  rw [h1, h2, h3, h4]
-  by_cases hx : x ∈ (Omega : Set E) <;> simp [hx]
+      extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+        (Sobolev1JetLp.gradient J) :=
+  (Lp.ext ((coeFn_extendByZeroLpₗᵢ_comp ℝ Omega.isOpen.measurableSet
+    (SetLike.coe_subset_coe.mpr hsub) WithLp.snd rfl (Sobolev1JetLp.gradient_apply_ae J)).trans
+      (Filter.EventuallyEq.symm (Sobolev1JetLp.gradient_apply_ae _)))).symm
 
 /-! ### Test functions extend to test functions -/
 
@@ -135,45 +128,32 @@ omit [FiniteDimensional ℝ E] in
 /-- Extending a test function's `Lᵖ` class by zero gives the class of the same test function on
 the larger open set: it already vanished outside `Ω`. -/
 private theorem extendByZeroLpₗᵢ_testFunctionLp (hsub : Omega ≤ Omega') (phi : 𝓓(Omega, ℝ)) :
-    extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+    extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
         (testFunctionLp p phi) =
-      testFunctionLp (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi) := by
-  refine Lp.ext ?_
-  filter_upwards [coeFn_extendByZeroLpₗᵢ (𝕜 := ℝ) Omega.isOpen.measurableSet
-      (SetLike.coe_subset_coe.mpr hsub) (testFunctionLp (mu := mu) p phi),
-    indicator_ae_eq_indicator_of_restrict Omega.isOpen.measurableSet
-      (testFunctionLp_apply_ae (mu := mu) p phi) (Omega' : Set E),
-    testFunctionLp_apply_ae (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi)]
-    with x h1 h2 h3
-  rw [h1, h2, h3, coe_monoCLM hsub phi]
-  by_cases hx : x ∈ (Omega : Set E)
-  · rw [indicator_of_mem hx]
-  · rw [indicator_of_notMem hx]
-    exact (image_eq_zero_of_notMem_tsupport fun hc => hx (phi.tsupport_subset hc)).symm
+      testFunctionLp (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi) :=
+  extendByZeroLpₗᵢ_eq_of_ae_eq ℝ Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+    ((subset_tsupport _).trans phi.tsupport_subset) (testFunctionLp_apply_ae (mu := mu) p phi) <| by
+      filter_upwards [testFunctionLp_apply_ae (mu := mu) (Omega := Omega') p
+        (TestFunction.monoCLM ℝ phi)] with x hx
+      rw [hx, coe_monoCLM hsub phi]
 
 /-- Extending a test function's gradient by zero gives the gradient of the same test function on
 the larger open set. -/
 private theorem extendByZeroLpₗᵢ_gradientTestFunctionLp (hsub : Omega ≤ Omega')
     (phi : 𝓓(Omega, ℝ)) :
-    extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+    extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
         (gradientTestFunctionLp p phi) =
-      gradientTestFunctionLp (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi) := by
-  refine Lp.ext ?_
-  filter_upwards [coeFn_extendByZeroLpₗᵢ (𝕜 := ℝ) Omega.isOpen.measurableSet
-      (SetLike.coe_subset_coe.mpr hsub) (gradientTestFunctionLp (mu := mu) p phi),
-    indicator_ae_eq_indicator_of_restrict Omega.isOpen.measurableSet
-      (gradientTestFunctionLp_apply_ae (mu := mu) p phi) (Omega' : Set E),
-    gradientTestFunctionLp_apply_ae (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi)]
-    with x h1 h2 h3
-  rw [h1, h2, h3, coe_monoCLM hsub phi]
-  by_cases hx : x ∈ (Omega : Set E)
-  · rw [indicator_of_mem hx]
-  · rw [indicator_of_notMem hx]
-    exact (Function.notMem_support.mp
-      fun hc => hx (support_gradient_testFunction_subset phi hc)).symm
+      gradientTestFunctionLp (mu := mu) (Omega := Omega') p (TestFunction.monoCLM ℝ phi) :=
+  extendByZeroLpₗᵢ_eq_of_ae_eq ℝ Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+    (support_gradient_testFunction_subset phi)
+    (gradientTestFunctionLp_apply_ae (mu := mu) p phi) <| by
+      filter_upwards [gradientTestFunctionLp_apply_ae (mu := mu) (Omega := Omega') p
+        (TestFunction.monoCLM ℝ phi)] with x hx
+      rw [hx, coe_monoCLM hsub phi]
 
 /-- The zero-extension of a test-function jet is the jet of the same test function on the larger
 open set. -/
+@[simp]
 theorem Sobolev1JetLp.extendByZeroₗᵢ_ofTestFunctionₗ (hsub : Omega ≤ Omega')
     (phi : 𝓓(Omega, ℝ)) :
     Sobolev1JetLp.extendByZeroₗᵢ hsub
@@ -192,7 +172,8 @@ theorem Sobolev1JetLp.extendByZeroₗᵢ_ofTestFunctionₗ (hsub : Omega ≤ Ome
 
 /-- The closed-set argument behind the extension theorem.  It runs in the ambient jet space, so
 its conclusion is membership in the *image* of `W^{1,p}_0(Ω')` there; the two usable forms are
-`TauCeti.extendByZero_mem_w1pSubmodule` and `TauCeti.extendByZero_mem_w1p0Submodule`.
+`TauCeti.Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule` and
+`TauCeti.W1p0.extendByZeroL_mem_w1p0Submodule`.
 
 Being closed is what the image contributes: `W^{1,p}_0(Ω')` is closed in `W^{1,p}(Ω')`, which is
 closed in the jet space, so the image is closed and its preimage under the (continuous) extension
@@ -216,8 +197,8 @@ private theorem extendByZero_mem_image (hsub : Omega ≤ Omega') {u : W1p mu Ome
 /-- **The zero-extension of a `W^{1,p}_0(Ω)` function is a Sobolev function on `Ω'`.**  No
 regularity of `∂Ω` is needed, and no boundedness of either open set; the boundary condition
 carried by membership in `W^{1,p}_0(Ω)` is what makes the extension weakly differentiable. -/
-theorem extendByZero_mem_w1pSubmodule (hsub : Omega ≤ Omega') {u : W1p mu Omega p}
-    (hu : u ∈ w1p0Submodule mu Omega p) :
+theorem Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule (hsub : Omega ≤ Omega')
+    {u : W1p mu Omega p} (hu : u ∈ w1p0Submodule mu Omega p) :
     Sobolev1JetLp.extendByZeroₗᵢ hsub (u : Sobolev1JetLp mu Omega p) ∈
       w1pSubmodule mu Omega' p := by
   obtain ⟨v, -, hv⟩ := extendByZero_mem_image hsub hu
@@ -232,7 +213,7 @@ def W1p0.extendByZeroL (hsub : Omega ≤ Omega') :
       ((w1pSubmodule mu Omega p).toSubmodule.subtypeL.comp
         (w1p0Submodule mu Omega p).toSubmodule.subtypeL))
     (w1pSubmodule mu Omega' p).toSubmodule
-    fun u => extendByZero_mem_w1pSubmodule hsub u.2
+    fun u => Sobolev1JetLp.extendByZeroₗᵢ_mem_w1pSubmodule hsub u.2
 
 @[simp]
 theorem W1p0.coe_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
@@ -242,31 +223,34 @@ theorem W1p0.coe_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
 
 /-- **The zero-extension of a `W^{1,p}_0(Ω)` function lies in `W^{1,p}_0(Ω')`**, not merely in
 `W^{1,p}(Ω')`: a limit of test functions on `Ω` extends to a limit of test functions on `Ω'`. -/
-theorem extendByZero_mem_w1p0Submodule (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
+theorem W1p0.extendByZeroL_mem_w1p0Submodule (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
     W1p0.extendByZeroL hsub u ∈ w1p0Submodule mu Omega' p := by
   obtain ⟨v, hv, hval⟩ := extendByZero_mem_image hsub u.2
   have : W1p0.extendByZeroL hsub u = v := Subtype.ext hval.symm
   rw [this]
   exact hv
 
-/-- **Extension by zero is an isometry of Sobolev spaces.**  Both the `Lᵖ` norm of the function
-and that of its weak gradient are unchanged. -/
+/-- **Extension by zero is an isometry of Sobolev spaces.**  The `W^{1,p}` norm — the `Lᵖ` norm
+of the value-gradient jet — is unchanged; the extension adds a region on which both components
+vanish. -/
 theorem W1p0.norm_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
     ‖W1p0.extendByZeroL hsub u‖ = ‖u‖ :=
   (Sobolev1JetLp.extendByZeroₗᵢ hsub).norm_map _
 
 /-- The value component of the extension is the zero-extension of the value component. -/
+@[simp]
 theorem W1p0.value_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
     W1p.value (W1p0.extendByZeroL hsub u) =
-      extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+      extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
         (W1p.value (u : W1p mu Omega p)) := by
   rw [W1p.value_coe, W1p.value_coe, W1p0.coe_extendByZeroL,
     Sobolev1JetLp.value_extendByZeroₗᵢ]
 
 /-- The gradient component of the extension is the zero-extension of the gradient component. -/
+@[simp]
 theorem W1p0.gradient_extendByZeroL (hsub : Omega ≤ Omega') (u : W1p0 mu Omega p) :
     W1p.gradient (W1p0.extendByZeroL hsub u) =
-      extendByZeroLpₗᵢ (𝕜 := ℝ) mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
+      extendByZeroLpₗᵢ ℝ mu Omega.isOpen.measurableSet (SetLike.coe_subset_coe.mpr hsub)
         (W1p.gradient (u : W1p mu Omega p)) := by
   rw [W1p.gradient_coe, W1p.gradient_coe, W1p0.coe_extendByZeroL,
     Sobolev1JetLp.gradient_extendByZeroₗᵢ]
@@ -289,11 +273,11 @@ theorem hasWeakFDerivOn_indicator_of_mem_w1p0Submodule (hsub : Omega ≤ Omega')
   have hvalue : (W1p.value (W1p0.extendByZeroL hsub u) : E → ℝ) =ᵐ[mu.restrict Omega']
       (Omega : Set E).indicator (W1p.value (u : W1p mu Omega p) : E → ℝ) := by
     rw [W1p0.value_extendByZeroL]
-    exact coeFn_extendByZeroLpₗᵢ _ _ _
+    exact coeFn_extendByZeroLpₗᵢ _ _ _ _
   have hgradient : (W1p.gradient (W1p0.extendByZeroL hsub u) : E → E) =ᵐ[mu.restrict Omega']
       (Omega : Set E).indicator (W1p.gradient (u : W1p mu Omega p) : E → E) := by
     rw [W1p0.gradient_extendByZeroL]
-    exact coeFn_extendByZeroLpₗᵢ _ _ _
+    exact coeFn_extendByZeroLpₗᵢ _ _ _ _
   refine (hmem.congr_ae hvalue).congr_ae_deriv ?_
   filter_upwards [hgradient] with x hx
   refine ContinuousLinearMap.ext fun v => ?_

--- a/TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean
@@ -15,26 +15,28 @@ An `Lᵖ` function on a measurable set `s` extends by zero to any larger set `t 
 extension has the *same* `Lᵖ` norm, because the added region contributes nothing.  This file
 bundles that extension as a linear isometry
 
-`TauCeti.extendByZeroLpₗᵢ μ hs hst : Lp F p (μ.restrict s) →ₗᵢ[𝕜] Lp F p (μ.restrict t)`,
+`TauCeti.extendByZeroLpₗᵢ 𝕜 μ hs hst : Lp F p (μ.restrict s) →ₗᵢ[𝕜] Lp F p (μ.restrict t)`,
 
 together with the almost-everywhere description of its values, `TauCeti.coeFn_extendByZeroLpₗᵢ`.
 
 The one point that needs care is that `Lᵖ` elements are equivalence classes: `s.indicator ⇑f`
 depends on the chosen representative `⇑f`, which is only pinned down `μ.restrict s`-almost
-everywhere, whereas the answer must be pinned down `μ.restrict t`-almost everywhere.  The two are
-reconciled by `TauCeti.indicator_ae_eq_indicator_of_restrict`: an identity holding
-`μ.restrict s`-almost everywhere survives multiplication by the indicator of `s` and passes to any
-restriction of `μ`, because the set where it can fail meets `s` in a `μ`-null set.
+everywhere, whereas the answer must be pinned down `μ.restrict t`-almost everywhere.  Mathlib's
+`MeasureTheory.ae_eq_restrict_iff_indicator_ae_eq` reconciles the two: an identity holding
+`μ.restrict s`-almost everywhere survives multiplication by the indicator of `s` as an identity
+against `μ`, hence against every restriction of `μ`.
 
 ## Main declarations
 
-* `TauCeti.indicator_ae_eq_indicator_of_restrict`: transporting an almost-everywhere identity on
-  `s` to the indicators, against any restriction of `μ`.
-* `TauCeti.eLpNorm_indicator_restrict` and `TauCeti.memLp_indicator_restrict`: extension by zero
-  preserves the `Lᵖ` seminorm and hence `Lᵖ` membership.
+* `TauCeti.eLpNorm_indicator_restrict_eq_eLpNorm_restrict` and
+  `TauCeti.memLp_indicator_restrict_of_memLp_restrict`: extension by zero preserves the `Lᵖ`
+  seminorm, and hence `Lᵖ` membership.
 * `TauCeti.extendByZeroLpₗᵢ`: extension by zero as a linear isometry.
-* `TauCeti.coeFn_extendByZeroLpₗᵢ` and `TauCeti.extendByZeroLpₗᵢ_ae_eq_of_restrict`: the values of
+* `TauCeti.coeFn_extendByZeroLpₗᵢ` and `TauCeti.coeFn_extendByZeroLpₗᵢ_restrict`: the values of
   the extension, on `t` and back on `s`.
+* `TauCeti.extendByZeroLpₗᵢ_eq_of_ae_eq` and `TauCeti.coeFn_extendByZeroLpₗᵢ_comp`: the two ways
+  an extension is recognised in practice — from a representative that already vanishes off `s`,
+  and through pointwise postcomposition by a map fixing `0`.
 -/
 
 public section
@@ -47,65 +49,42 @@ open MeasureTheory Set
 
 open scoped ENNReal
 
-variable {α F 𝕜 : Type*} [MeasurableSpace α] [NormedAddCommGroup F] {p : ℝ≥0∞} {μ : Measure α}
-  {s t : Set α}
-
-/-- **Almost-everywhere identities on `s` survive extension by zero.**  If `g` and `h` agree
-`μ.restrict s`-almost everywhere then their zero-extensions agree almost everywhere for *any*
-restriction of `μ`: outside `s` both vanish, and inside `s` they can differ only on a `μ`-null
-set. -/
-theorem indicator_ae_eq_indicator_of_restrict (hs : MeasurableSet s) {g h : α → F}
-    (hgh : g =ᵐ[μ.restrict s] h) (t : Set α) :
-    s.indicator g =ᵐ[μ.restrict t] s.indicator h := by
-  have hmu : μ ({x | ¬ g x = h x} ∩ s) = 0 := by
-    rw [← Measure.restrict_apply' hs]
-    exact ae_iff.mp hgh
-  have hnu : μ.restrict t ({x | ¬ g x = h x} ∩ s) = 0 :=
-    Measure.absolutelyContinuous_of_le Measure.restrict_le_self hmu
-  rw [Filter.EventuallyEq, ae_iff]
-  refine measure_mono_null (fun x hx => ?_) hnu
-  by_cases hxs : x ∈ s
-  · exact ⟨fun hgx => hx (by rw [indicator_of_mem hxs, indicator_of_mem hxs, hgx]), hxs⟩
-  · exact absurd (by rw [indicator_of_notMem hxs, indicator_of_notMem hxs]) hx
+variable {α : Type*} [MeasurableSpace α] {F : Type*} [NormedAddCommGroup F] (𝕜 : Type*)
+  [NormedRing 𝕜] [Module 𝕜 F] [IsBoundedSMul 𝕜 F] {p : ℝ≥0∞} {μ : Measure α} {s t : Set α}
 
 /-- **Extension by zero preserves the `Lᵖ` seminorm.**  Enlarging the domain from `s` to `t ⊇ s`
 adds only a region on which the extended function vanishes. -/
-theorem eLpNorm_indicator_restrict (hs : MeasurableSet s) (hst : s ⊆ t) (g : α → F) :
+theorem eLpNorm_indicator_restrict_eq_eLpNorm_restrict (hs : MeasurableSet s) (hst : s ⊆ t)
+    (g : α → F) :
     eLpNorm (s.indicator g) p (μ.restrict t) = eLpNorm g p (μ.restrict s) := by
   rw [eLpNorm_indicator_eq_eLpNorm_restrict hs, Measure.restrict_restrict_of_subset hst]
 
 /-- **Extension by zero preserves `Lᵖ` membership.** -/
-theorem memLp_indicator_restrict (hs : MeasurableSet s) (hst : s ⊆ t) {g : α → F}
-    (hg : MemLp g p (μ.restrict s)) : MemLp (s.indicator g) p (μ.restrict t) := by
+theorem memLp_indicator_restrict_of_memLp_restrict (hs : MeasurableSet s) (hst : s ⊆ t)
+    {g : α → F} (hg : MemLp g p (μ.restrict s)) : MemLp (s.indicator g) p (μ.restrict t) := by
   rw [memLp_indicator_iff_restrict hs, Measure.restrict_restrict_of_subset hst]
   exact hg
 
+/-- Transporting an almost-everywhere identity on `s` to the indicators, against `μ.restrict t`:
+Mathlib's `MeasureTheory.ae_eq_restrict_iff_indicator_ae_eq` gives the identity against `μ`, and
+`μ.restrict t` is absolutely continuous with respect to `μ`. -/
+private theorem indicator_ae_eq (hs : MeasurableSet s) {g h : α → F}
+    (hgh : g =ᵐ[μ.restrict s] h) : s.indicator g =ᵐ[μ.restrict t] s.indicator h :=
+  ((ae_eq_restrict_iff_indicator_ae_eq hs).mp hgh).filter_mono (ae_mono Measure.restrict_le_self)
+
 variable (μ) in
 /-- Extension by zero as a linear map; `TauCeti.extendByZeroLpₗᵢ` upgrades it to an isometry. -/
-private def extendByZeroLpₗ [NormedField 𝕜] [NormedSpace 𝕜 F]
-    (hs : MeasurableSet s) (hst : s ⊆ t) :
+private def extendByZeroLpₗ (hs : MeasurableSet s) (hst : s ⊆ t) :
     Lp F p (μ.restrict s) →ₗ[𝕜] Lp F p (μ.restrict t) where
-  toFun f := (memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _
+  toFun f := (memLp_indicator_restrict_of_memLp_restrict hs hst (Lp.memLp f)).toLp _
   map_add' f g := by
-    refine Lp.ext ?_
-    filter_upwards [MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp (f + g))),
-      Lp.coeFn_add ((memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _)
-        ((memLp_indicator_restrict hs hst (Lp.memLp g)).toLp _),
-      MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp f)),
-      MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp g)),
-      indicator_ae_eq_indicator_of_restrict hs (Lp.coeFn_add f g) t] with x h1 h2 h3 h4 h5
-    rw [h1, h5, h2]
-    simp only [Pi.add_apply, h3, h4]
-    by_cases hxs : x ∈ s <;> simp [hxs]
+    rw [← MemLp.toLp_add]
+    exact MemLp.toLp_congr _ _
+      ((indicator_ae_eq hs (Lp.coeFn_add f g)).trans (.of_eq (indicator_add' s _ _)))
   map_smul' c f := by
-    refine Lp.ext ?_
-    filter_upwards [MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp (c • f))),
-      Lp.coeFn_smul c ((memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _),
-      MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp f)),
-      indicator_ae_eq_indicator_of_restrict hs (Lp.coeFn_smul c f) t] with x h1 h2 h3 h4
-    rw [h1, h4, RingHom.id_apply, h2]
-    simp only [Pi.smul_apply, h3]
-    by_cases hxs : x ∈ s <;> simp [hxs]
+    rw [RingHom.id_apply, ← MemLp.toLp_const_smul]
+    exact MemLp.toLp_congr _ _
+      ((indicator_ae_eq hs (Lp.coeFn_smul c f)).trans (.of_eq (indicator_const_smul s c _)))
 
 variable (μ) in
 /-- **Extension by zero as a linear isometry** `Lᵖ(s) → Lᵖ(t)` for a measurable `s ⊆ t`: a
@@ -114,25 +93,51 @@ function on `s` is regarded as a function on the larger set `t` by declaring it 
 It is an isometry, not merely a bounded map, because the enlarged region contributes nothing to
 the `Lᵖ` norm; in particular the extension is injective, so `Lᵖ(s)` really does sit inside
 `Lᵖ(t)`. -/
-def extendByZeroLpₗᵢ [NormedField 𝕜] [NormedSpace 𝕜 F] [Fact (1 ≤ p)] (hs : MeasurableSet s)
-    (hst : s ⊆ t) : Lp F p (μ.restrict s) →ₗᵢ[𝕜] Lp F p (μ.restrict t) where
-  toLinearMap := extendByZeroLpₗ μ hs hst
+def extendByZeroLpₗᵢ [Fact (1 ≤ p)] (hs : MeasurableSet s) (hst : s ⊆ t) :
+    Lp F p (μ.restrict s) →ₗᵢ[𝕜] Lp F p (μ.restrict t) where
+  toLinearMap := extendByZeroLpₗ 𝕜 μ hs hst
   norm_map' f := by
-    change ‖(memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _‖ = ‖f‖
-    rw [Lp.norm_toLp, eLpNorm_indicator_restrict hs hst, ← Lp.norm_def]
+    -- `Lp.norm_toLp` is stated for the unbundled `MemLp.toLp`; expose that implementation of
+    -- `extendByZeroLpₗ`, which the bundled `toLinearMap` field hides.
+    change ‖(memLp_indicator_restrict_of_memLp_restrict hs hst (Lp.memLp f)).toLp _‖ = ‖f‖
+    rw [Lp.norm_toLp, eLpNorm_indicator_restrict_eq_eLpNorm_restrict hs hst, ← Lp.norm_def]
 
 /-- **The extension by zero is the indicator of the original representative.** -/
-theorem coeFn_extendByZeroLpₗᵢ [NormedField 𝕜] [NormedSpace 𝕜 F] [Fact (1 ≤ p)]
-    (hs : MeasurableSet s) (hst : s ⊆ t) (f : Lp F p (μ.restrict s)) :
-    (extendByZeroLpₗᵢ (𝕜 := 𝕜) μ hs hst f : α → F) =ᵐ[μ.restrict t] s.indicator (f : α → F) :=
-  MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp f))
+theorem coeFn_extendByZeroLpₗᵢ [Fact (1 ≤ p)] (hs : MeasurableSet s) (hst : s ⊆ t)
+    (f : Lp F p (μ.restrict s)) :
+    (extendByZeroLpₗᵢ 𝕜 μ hs hst f : α → F) =ᵐ[μ.restrict t] s.indicator (f : α → F) :=
+  MemLp.coeFn_toLp (memLp_indicator_restrict_of_memLp_restrict hs hst (Lp.memLp f))
 
 /-- **The extension by zero restricts back to the original function.** -/
-theorem extendByZeroLpₗᵢ_ae_eq_of_restrict [NormedField 𝕜] [NormedSpace 𝕜 F] [Fact (1 ≤ p)]
-    (hs : MeasurableSet s) (hst : s ⊆ t) (f : Lp F p (μ.restrict s)) :
-    (extendByZeroLpₗᵢ (𝕜 := 𝕜) μ hs hst f : α → F) =ᵐ[μ.restrict s] (f : α → F) := by
-  have hle : μ.restrict s ≤ μ.restrict t := Measure.restrict_mono hst le_rfl
-  exact ((coeFn_extendByZeroLpₗᵢ (𝕜 := 𝕜) hs hst f).filter_mono
-    (ae_mono hle)).trans (indicator_ae_eq_restrict hs)
+theorem coeFn_extendByZeroLpₗᵢ_restrict [Fact (1 ≤ p)] (hs : MeasurableSet s) (hst : s ⊆ t)
+    (f : Lp F p (μ.restrict s)) :
+    (extendByZeroLpₗᵢ 𝕜 μ hs hst f : α → F) =ᵐ[μ.restrict s] (f : α → F) :=
+  ((coeFn_extendByZeroLpₗᵢ 𝕜 hs hst f).filter_mono
+    (ae_mono (Measure.restrict_mono hst le_rfl))).trans (indicator_ae_eq_restrict hs)
+
+/-- **Recognising an extension by zero from a common representative.**  A function `h` supported
+in `s` that represents `f` on `s` and `g` on `t` exhibits `g` as the zero-extension of `f`; this
+is how a function already known to vanish off `s` is transported from `Lᵖ(s)` to `Lᵖ(t)`. -/
+theorem extendByZeroLpₗᵢ_eq_of_ae_eq [Fact (1 ≤ p)] (hs : MeasurableSet s) (hst : s ⊆ t)
+    {h : α → F} (hsupp : Function.support h ⊆ s) {f : Lp F p (μ.restrict s)}
+    {g : Lp F p (μ.restrict t)} (hf : ∀ᵐ x ∂μ.restrict s, f x = h x)
+    (hg : ∀ᵐ x ∂μ.restrict t, g x = h x) : extendByZeroLpₗᵢ 𝕜 μ hs hst f = g :=
+  Lp.ext <| ((coeFn_extendByZeroLpₗᵢ 𝕜 hs hst f).trans
+    ((indicator_ae_eq hs hf).trans (.of_eq (indicator_eq_self.2 hsupp)))).trans
+    (Filter.EventuallyEq.symm hg)
+
+/-- **Extension by zero commutes with pointwise postcomposition by a map fixing `0`.**  If `g'` is
+the pointwise image of `f` under `L`, then the extension of `g'` is the pointwise image under `L`
+of the extension of `f`: off `s` both sides are `L 0 = 0`. -/
+theorem coeFn_extendByZeroLpₗᵢ_comp {G : Type*} [NormedAddCommGroup G] [Module 𝕜 G]
+    [IsBoundedSMul 𝕜 G] [Fact (1 ≤ p)] (hs : MeasurableSet s) (hst : s ⊆ t) (L : F → G)
+    (hL : L 0 = 0) {f : Lp F p (μ.restrict s)} {g' : Lp G p (μ.restrict s)}
+    (hg' : ∀ᵐ x ∂μ.restrict s, g' x = L (f x)) :
+    (extendByZeroLpₗᵢ 𝕜 μ hs hst g' : α → G) =ᵐ[μ.restrict t]
+      fun x => L (extendByZeroLpₗᵢ 𝕜 μ hs hst f x) := by
+  filter_upwards [coeFn_extendByZeroLpₗᵢ 𝕜 hs hst g', coeFn_extendByZeroLpₗᵢ 𝕜 hs hst f,
+    indicator_ae_eq (t := t) hs hg'] with x h1 h2 h3
+  rw [h1, h3, h2]
+  by_cases hx : x ∈ s <;> simp [hx, hL]
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean
@@ -28,12 +28,11 @@ against `μ`, hence against every restriction of `μ`.
 
 ## Main declarations
 
-* `TauCeti.eLpNorm_indicator_restrict_eq_eLpNorm_restrict` and
-  `TauCeti.memLp_indicator_restrict_of_memLp_restrict`: extension by zero preserves the `Lᵖ`
-  seminorm, and hence `Lᵖ` membership.
 * `TauCeti.extendByZeroLpₗᵢ`: extension by zero as a linear isometry.
 * `TauCeti.coeFn_extendByZeroLpₗᵢ` and `TauCeti.coeFn_extendByZeroLpₗᵢ_restrict`: the values of
   the extension, on `t` and back on `s`.
+* `TauCeti.extendByZeroLpₗᵢ_self` and `TauCeti.extendByZeroLpₗᵢ_extendByZeroLpₗᵢ`: extending
+  along `s ⊆ s` is the identity, and extending twice is extending once.
 * `TauCeti.extendByZeroLpₗᵢ_eq_of_ae_eq` and `TauCeti.coeFn_extendByZeroLpₗᵢ_comp`: the two ways
   an extension is recognised in practice — from a representative that already vanishes off `s`,
   and through pointwise postcomposition by a map fixing `0`.
@@ -52,15 +51,11 @@ open scoped ENNReal
 variable {α : Type*} [MeasurableSpace α] {F : Type*} [NormedAddCommGroup F] (𝕜 : Type*)
   [NormedRing 𝕜] [Module 𝕜 F] [IsBoundedSMul 𝕜 F] {p : ℝ≥0∞} {μ : Measure α} {s t : Set α}
 
-/-- **Extension by zero preserves the `Lᵖ` seminorm.**  Enlarging the domain from `s` to `t ⊇ s`
-adds only a region on which the extended function vanishes. -/
-theorem eLpNorm_indicator_restrict_eq_eLpNorm_restrict (hs : MeasurableSet s) (hst : s ⊆ t)
-    (g : α → F) :
-    eLpNorm (s.indicator g) p (μ.restrict t) = eLpNorm g p (μ.restrict s) := by
-  rw [eLpNorm_indicator_eq_eLpNorm_restrict hs, Measure.restrict_restrict_of_subset hst]
-
-/-- **Extension by zero preserves `Lᵖ` membership.** -/
-theorem memLp_indicator_restrict_of_memLp_restrict (hs : MeasurableSet s) (hst : s ⊆ t)
+/-- **Extension by zero preserves `Lᵖ` membership**: Mathlib's
+`MeasureTheory.memLp_indicator_iff_restrict` against `μ.restrict t`, followed by
+`MeasureTheory.Measure.restrict_restrict_of_subset`.  It is needed as a *term* at each of the
+three places where the extension is built or computed, so it is named rather than inlined. -/
+private theorem memLp_indicator_restrict (hs : MeasurableSet s) (hst : s ⊆ t)
     {g : α → F} (hg : MemLp g p (μ.restrict s)) : MemLp (s.indicator g) p (μ.restrict t) := by
   rw [memLp_indicator_iff_restrict hs, Measure.restrict_restrict_of_subset hst]
   exact hg
@@ -76,7 +71,7 @@ variable (μ) in
 /-- Extension by zero as a linear map; `TauCeti.extendByZeroLpₗᵢ` upgrades it to an isometry. -/
 private def extendByZeroLpₗ (hs : MeasurableSet s) (hst : s ⊆ t) :
     Lp F p (μ.restrict s) →ₗ[𝕜] Lp F p (μ.restrict t) where
-  toFun f := (memLp_indicator_restrict_of_memLp_restrict hs hst (Lp.memLp f)).toLp _
+  toFun f := (memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _
   map_add' f g := by
     rw [← MemLp.toLp_add]
     exact MemLp.toLp_congr _ _
@@ -99,14 +94,15 @@ def extendByZeroLpₗᵢ [Fact (1 ≤ p)] (hs : MeasurableSet s) (hst : s ⊆ t)
   norm_map' f := by
     -- `Lp.norm_toLp` is stated for the unbundled `MemLp.toLp`; expose that implementation of
     -- `extendByZeroLpₗ`, which the bundled `toLinearMap` field hides.
-    change ‖(memLp_indicator_restrict_of_memLp_restrict hs hst (Lp.memLp f)).toLp _‖ = ‖f‖
-    rw [Lp.norm_toLp, eLpNorm_indicator_restrict_eq_eLpNorm_restrict hs hst, ← Lp.norm_def]
+    change ‖(memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _‖ = ‖f‖
+    rw [Lp.norm_toLp, eLpNorm_indicator_eq_eLpNorm_restrict hs,
+      Measure.restrict_restrict_of_subset hst, ← Lp.norm_def]
 
 /-- **The extension by zero is the indicator of the original representative.** -/
 theorem coeFn_extendByZeroLpₗᵢ [Fact (1 ≤ p)] (hs : MeasurableSet s) (hst : s ⊆ t)
     (f : Lp F p (μ.restrict s)) :
     (extendByZeroLpₗᵢ 𝕜 μ hs hst f : α → F) =ᵐ[μ.restrict t] s.indicator (f : α → F) :=
-  MemLp.coeFn_toLp (memLp_indicator_restrict_of_memLp_restrict hs hst (Lp.memLp f))
+  MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp f))
 
 /-- **The extension by zero restricts back to the original function.** -/
 theorem coeFn_extendByZeroLpₗᵢ_restrict [Fact (1 ≤ p)] (hs : MeasurableSet s) (hst : s ⊆ t)
@@ -114,6 +110,25 @@ theorem coeFn_extendByZeroLpₗᵢ_restrict [Fact (1 ≤ p)] (hs : MeasurableSet
     (extendByZeroLpₗᵢ 𝕜 μ hs hst f : α → F) =ᵐ[μ.restrict s] (f : α → F) :=
   ((coeFn_extendByZeroLpₗᵢ 𝕜 hs hst f).filter_mono
     (ae_mono (Measure.restrict_mono hst le_rfl))).trans (indicator_ae_eq_restrict hs)
+
+/-- **Extending by zero along `s ⊆ s` does nothing.** -/
+@[simp]
+theorem extendByZeroLpₗᵢ_self [Fact (1 ≤ p)] (hs : MeasurableSet s)
+    (f : Lp F p (μ.restrict s)) : extendByZeroLpₗᵢ 𝕜 μ hs Subset.rfl f = f :=
+  Lp.ext (coeFn_extendByZeroLpₗᵢ_restrict 𝕜 hs Subset.rfl f)
+
+/-- **Extending by zero twice is extending by zero once.**  Zero-extending from `s` to `t` and
+then from `t` to `u` is the zero-extension from `s` to `u`. -/
+@[simp]
+theorem extendByZeroLpₗᵢ_extendByZeroLpₗᵢ [Fact (1 ≤ p)] {u : Set α} (hs : MeasurableSet s)
+    (ht : MeasurableSet t) (hst : s ⊆ t) (htu : t ⊆ u) (f : Lp F p (μ.restrict s)) :
+    extendByZeroLpₗᵢ 𝕜 μ ht htu (extendByZeroLpₗᵢ 𝕜 μ hs hst f) =
+      extendByZeroLpₗᵢ 𝕜 μ hs (hst.trans htu) f := by
+  refine Lp.ext ?_
+  filter_upwards [coeFn_extendByZeroLpₗᵢ 𝕜 ht htu (extendByZeroLpₗᵢ 𝕜 μ hs hst f),
+    indicator_ae_eq (t := u) ht (coeFn_extendByZeroLpₗᵢ 𝕜 hs hst f),
+    coeFn_extendByZeroLpₗᵢ 𝕜 hs (hst.trans htu) f] with x h1 h2 h3
+  rw [h1, h2, h3, indicator_indicator, inter_eq_self_of_subset_right hst]
 
 /-- **Recognising an extension by zero from a common representative.**  A function `h` supported
 in `s` that represents `f` on `s` and `g` on `t` exhibits `g` as the zero-extension of `f`; this

--- a/TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Function.LpSpace.Basic
+public import Mathlib.MeasureTheory.Function.LpSeminorm.Indicator
+
+/-!
+# Extension by zero between restricted `Lᵖ` spaces
+
+An `Lᵖ` function on a measurable set `s` extends by zero to any larger set `t ⊇ s`, and the
+extension has the *same* `Lᵖ` norm, because the added region contributes nothing.  This file
+bundles that extension as a linear isometry
+
+`TauCeti.extendByZeroLpₗᵢ μ hs hst : Lp F p (μ.restrict s) →ₗᵢ[𝕜] Lp F p (μ.restrict t)`,
+
+together with the almost-everywhere description of its values, `TauCeti.coeFn_extendByZeroLpₗᵢ`.
+
+The one point that needs care is that `Lᵖ` elements are equivalence classes: `s.indicator ⇑f`
+depends on the chosen representative `⇑f`, which is only pinned down `μ.restrict s`-almost
+everywhere, whereas the answer must be pinned down `μ.restrict t`-almost everywhere.  The two are
+reconciled by `TauCeti.indicator_ae_eq_indicator_of_restrict`: an identity holding
+`μ.restrict s`-almost everywhere survives multiplication by the indicator of `s` and passes to any
+restriction of `μ`, because the set where it can fail meets `s` in a `μ`-null set.
+
+## Main declarations
+
+* `TauCeti.indicator_ae_eq_indicator_of_restrict`: transporting an almost-everywhere identity on
+  `s` to the indicators, against any restriction of `μ`.
+* `TauCeti.eLpNorm_indicator_restrict` and `TauCeti.memLp_indicator_restrict`: extension by zero
+  preserves the `Lᵖ` seminorm and hence `Lᵖ` membership.
+* `TauCeti.extendByZeroLpₗᵢ`: extension by zero as a linear isometry.
+* `TauCeti.coeFn_extendByZeroLpₗᵢ` and `TauCeti.extendByZeroLpₗᵢ_ae_eq_of_restrict`: the values of
+  the extension, on `t` and back on `s`.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open MeasureTheory Set
+
+open scoped ENNReal
+
+variable {α F 𝕜 : Type*} [MeasurableSpace α] [NormedAddCommGroup F] {p : ℝ≥0∞} {μ : Measure α}
+  {s t : Set α}
+
+/-- **Almost-everywhere identities on `s` survive extension by zero.**  If `g` and `h` agree
+`μ.restrict s`-almost everywhere then their zero-extensions agree almost everywhere for *any*
+restriction of `μ`: outside `s` both vanish, and inside `s` they can differ only on a `μ`-null
+set. -/
+theorem indicator_ae_eq_indicator_of_restrict (hs : MeasurableSet s) {g h : α → F}
+    (hgh : g =ᵐ[μ.restrict s] h) (t : Set α) :
+    s.indicator g =ᵐ[μ.restrict t] s.indicator h := by
+  have hmu : μ ({x | ¬ g x = h x} ∩ s) = 0 := by
+    rw [← Measure.restrict_apply' hs]
+    exact ae_iff.mp hgh
+  have hnu : μ.restrict t ({x | ¬ g x = h x} ∩ s) = 0 :=
+    Measure.absolutelyContinuous_of_le Measure.restrict_le_self hmu
+  rw [Filter.EventuallyEq, ae_iff]
+  refine measure_mono_null (fun x hx => ?_) hnu
+  by_cases hxs : x ∈ s
+  · exact ⟨fun hgx => hx (by rw [indicator_of_mem hxs, indicator_of_mem hxs, hgx]), hxs⟩
+  · exact absurd (by rw [indicator_of_notMem hxs, indicator_of_notMem hxs]) hx
+
+/-- **Extension by zero preserves the `Lᵖ` seminorm.**  Enlarging the domain from `s` to `t ⊇ s`
+adds only a region on which the extended function vanishes. -/
+theorem eLpNorm_indicator_restrict (hs : MeasurableSet s) (hst : s ⊆ t) (g : α → F) :
+    eLpNorm (s.indicator g) p (μ.restrict t) = eLpNorm g p (μ.restrict s) := by
+  rw [eLpNorm_indicator_eq_eLpNorm_restrict hs, Measure.restrict_restrict_of_subset hst]
+
+/-- **Extension by zero preserves `Lᵖ` membership.** -/
+theorem memLp_indicator_restrict (hs : MeasurableSet s) (hst : s ⊆ t) {g : α → F}
+    (hg : MemLp g p (μ.restrict s)) : MemLp (s.indicator g) p (μ.restrict t) := by
+  rw [memLp_indicator_iff_restrict hs, Measure.restrict_restrict_of_subset hst]
+  exact hg
+
+variable (μ) in
+/-- Extension by zero as a linear map; `TauCeti.extendByZeroLpₗᵢ` upgrades it to an isometry. -/
+private def extendByZeroLpₗ [NormedField 𝕜] [NormedSpace 𝕜 F]
+    (hs : MeasurableSet s) (hst : s ⊆ t) :
+    Lp F p (μ.restrict s) →ₗ[𝕜] Lp F p (μ.restrict t) where
+  toFun f := (memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _
+  map_add' f g := by
+    refine Lp.ext ?_
+    filter_upwards [MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp (f + g))),
+      Lp.coeFn_add ((memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _)
+        ((memLp_indicator_restrict hs hst (Lp.memLp g)).toLp _),
+      MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp f)),
+      MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp g)),
+      indicator_ae_eq_indicator_of_restrict hs (Lp.coeFn_add f g) t] with x h1 h2 h3 h4 h5
+    rw [h1, h5, h2]
+    simp only [Pi.add_apply, h3, h4]
+    by_cases hxs : x ∈ s <;> simp [hxs]
+  map_smul' c f := by
+    refine Lp.ext ?_
+    filter_upwards [MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp (c • f))),
+      Lp.coeFn_smul c ((memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _),
+      MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp f)),
+      indicator_ae_eq_indicator_of_restrict hs (Lp.coeFn_smul c f) t] with x h1 h2 h3 h4
+    rw [h1, h4, RingHom.id_apply, h2]
+    simp only [Pi.smul_apply, h3]
+    by_cases hxs : x ∈ s <;> simp [hxs]
+
+variable (μ) in
+/-- **Extension by zero as a linear isometry** `Lᵖ(s) → Lᵖ(t)` for a measurable `s ⊆ t`: a
+function on `s` is regarded as a function on the larger set `t` by declaring it zero on `t \ s`.
+
+It is an isometry, not merely a bounded map, because the enlarged region contributes nothing to
+the `Lᵖ` norm; in particular the extension is injective, so `Lᵖ(s)` really does sit inside
+`Lᵖ(t)`. -/
+def extendByZeroLpₗᵢ [NormedField 𝕜] [NormedSpace 𝕜 F] [Fact (1 ≤ p)] (hs : MeasurableSet s)
+    (hst : s ⊆ t) : Lp F p (μ.restrict s) →ₗᵢ[𝕜] Lp F p (μ.restrict t) where
+  toLinearMap := extendByZeroLpₗ μ hs hst
+  norm_map' f := by
+    change ‖(memLp_indicator_restrict hs hst (Lp.memLp f)).toLp _‖ = ‖f‖
+    rw [Lp.norm_toLp, eLpNorm_indicator_restrict hs hst, ← Lp.norm_def]
+
+/-- **The extension by zero is the indicator of the original representative.** -/
+theorem coeFn_extendByZeroLpₗᵢ [NormedField 𝕜] [NormedSpace 𝕜 F] [Fact (1 ≤ p)]
+    (hs : MeasurableSet s) (hst : s ⊆ t) (f : Lp F p (μ.restrict s)) :
+    (extendByZeroLpₗᵢ (𝕜 := 𝕜) μ hs hst f : α → F) =ᵐ[μ.restrict t] s.indicator (f : α → F) :=
+  MemLp.coeFn_toLp (memLp_indicator_restrict hs hst (Lp.memLp f))
+
+/-- **The extension by zero restricts back to the original function.** -/
+theorem extendByZeroLpₗᵢ_ae_eq_of_restrict [NormedField 𝕜] [NormedSpace 𝕜 F] [Fact (1 ≤ p)]
+    (hs : MeasurableSet s) (hst : s ⊆ t) (f : Lp F p (μ.restrict s)) :
+    (extendByZeroLpₗᵢ (𝕜 := 𝕜) μ hs hst f : α → F) =ᵐ[μ.restrict s] (f : α → F) := by
+  have hle : μ.restrict s ≤ μ.restrict t := Measure.restrict_mono hst le_rfl
+  exact ((coeFn_extendByZeroLpₗᵢ (𝕜 := 𝕜) hs hst f).filter_mono
+    (ae_mono hle)).trans (indicator_ae_eq_restrict hs)
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean
@@ -51,18 +51,14 @@ open scoped ENNReal
 variable {α : Type*} [MeasurableSpace α] {F : Type*} [NormedAddCommGroup F] (𝕜 : Type*)
   [NormedRing 𝕜] [Module 𝕜 F] [IsBoundedSMul 𝕜 F] {p : ℝ≥0∞} {μ : Measure α} {s t : Set α}
 
-/-- **Extension by zero preserves `Lᵖ` membership**: Mathlib's
-`MeasureTheory.memLp_indicator_iff_restrict` against `μ.restrict t`, followed by
-`MeasureTheory.Measure.restrict_restrict_of_subset`.  It is needed as a *term* at each of the
-three places where the extension is built or computed, so it is named rather than inlined. -/
+/-- Extending by zero from `s` to `t` preserves `Lᵖ` membership when `s ⊆ t`. -/
 private theorem memLp_indicator_restrict (hs : MeasurableSet s) (hst : s ⊆ t)
     {g : α → F} (hg : MemLp g p (μ.restrict s)) : MemLp (s.indicator g) p (μ.restrict t) := by
   rw [memLp_indicator_iff_restrict hs, Measure.restrict_restrict_of_subset hst]
   exact hg
 
-/-- Transporting an almost-everywhere identity on `s` to the indicators, against `μ.restrict t`:
-Mathlib's `MeasureTheory.ae_eq_restrict_iff_indicator_ae_eq` gives the identity against `μ`, and
-`μ.restrict t` is absolutely continuous with respect to `μ`. -/
+/-- An almost-everywhere identity on `s` remains true after taking indicators, against
+`μ.restrict t`. -/
 private theorem indicator_ae_eq (hs : MeasurableSet s) {g h : α → F}
     (hgh : g =ᵐ[μ.restrict s] h) : s.indicator g =ᵐ[μ.restrict t] s.indicator h :=
   ((ae_eq_restrict_iff_indicator_ae_eq hs).mp hgh).filter_mono (ae_mono Measure.restrict_le_self)


### PR DESCRIPTION
This PR extends a `W^{1,p}_0(Ω)` function by zero across `∂Ω`, and proves that the extension is
still a Sobolev function: for open sets `Ω ≤ Ω'` in a finite-dimensional real inner product space
with an additive Haar measure, `TauCeti.W1p0.extendByZeroL` is an operator
`W^{1,p}_0(Ω) →L[ℝ] W^{1,p}_0(Ω')` — the zero-extension of a `W^{1,p}_0(Ω)` function lies in
`W^{1,p}_0(Ω')`, not merely in `W^{1,p}(Ω')` — and
`TauCeti.W1p0.hasWeakFDerivOn_indicator` states the analytic content directly: the
extension is weakly differentiable on `Ω'` with the zero-extension of `∇u` as its weak gradient.
That is exactly what can fail for a general `u ∈ W^{1,p}(Ω)`, whose zero-extension need not be
weakly differentiable on the larger set at all without some condition forcing `u` to vanish
towards `∂Ω`; the boundary condition carried by `W^{1,p}_0(Ω)` is the whole hypothesis, and no
regularity of `∂Ω` and no boundedness of either set is used. The operator is an isometry
(`TauCeti.W1p0.norm_extendByZeroL`) whose value and gradient components are computed and which is
functorial in `Ω` (`TauCeti.W1p0.extendByZeroL_self`,
`TauCeti.W1p0.extendByZeroL_extendByZeroL`); taking `Ω' = ⊤` is the extension operator
`W^{1,p}_0(Ω) → W^{1,p}(ℝⁿ)`.

This is Lane A, item 6 of `TauCetiRoadmap/PDE/README.md` — "an **extension operator**
`W^{1,p}(Ω) → W^{1,p}(ℝⁿ)`" — in the case that needs no boundary regularity, serving the milestone
that lane exists for: **Rellich–Kondrachov compactness `W^{1,p}(Ω) ↪↪ L^p(Ω)`**, which the README
calls "the keystone for Lane D and the eigenvalue theory" and which Lane D.18 (the Fredholm
alternative for `L u = f`, the next unmet milestone after the Dirichlet existence theorem that
landed in #4188) consumes. Rellich is proved through Fréchet–Kolmogorov on functions living on all
of `ℝⁿ`, so the zero-extension is what lets a bound on a domain be turned into one on the whole
space; the same operator is what will let Mathlib's whole-space
`eLpNorm_le_eLpNorm_fderiv_of_eq` (Gagliardo–Nirenberg–Sobolev) be applied to a function given on
`Ω`. What remains for Rellich after this PR is the translation estimate
`‖u(· + h) − u‖_p ≤ ‖h‖ ‖∇u‖_p` on `W^{1,p}_0` and the Fréchet–Kolmogorov compactness criterion in
`L^p`, neither of which is in Mathlib.

The proof is the density argument. `TauCeti.w1p0Submodule_subset_of_isClosed` reduces everything to
test functions, because the extension map is continuous and "the extension is a test-function limit
on `Ω'`" is a closed condition — the image of `W^{1,p}_0(Ω')` in the ambient jet space is closed,
being a closed subspace of a closed subspace. On a test function the claim is immediate: a test
function on `Ω` *is* a test function on `Ω'` (Mathlib's `TestFunction.monoCLM`), and extending it by
zero changes neither it nor its gradient, both of which already vanished off `Ω`.

The underlying `Lᵖ` construction is `TauCeti.extendByZeroLpₗᵢ` in the new file
`TauCeti/MeasureTheory/Function/Lp/ExtendByZero.lean`: extension by zero as a linear isometry
`Lp F p (μ.restrict s) →ₗᵢ[𝕜] Lp F p (μ.restrict t)` for measurable `s ⊆ t`. Its seminorm and
membership steps are Mathlib's `eLpNorm_indicator_eq_eLpNorm_restrict`,
`memLp_indicator_iff_restrict` and `Measure.restrict_restrict_of_subset`. The one point needing
care — that `s.indicator ⇑f` depends on a representative pinned down only `μ.restrict s`-almost
everywhere, while the answer must be pinned down `μ.restrict t`-almost everywhere — is Mathlib's
`ae_eq_restrict_iff_indicator_ae_eq` transported along `Measure.restrict_le_self`. On top of it
sit the two lemmas by which an extension is recognised in practice:
`TauCeti.extendByZeroLpₗᵢ_eq_of_ae_eq`, from a representative already supported in `s`, and
`TauCeti.coeFn_extendByZeroLpₗᵢ_comp`, extension by zero commuting with pointwise postcomposition
by a map fixing `0`. The jet-component and test-function computations in the Sobolev file are
instances of those two. `TauCeti.extendByZeroLpₗᵢ_self` and
`TauCeti.extendByZeroLpₗᵢ_extendByZeroLpₗᵢ` record that extension along `s ⊆ s` is the identity
and that extending twice is extending once.

`TauCeti/Analysis/Sobolev/W1p/Basic.lean` gains `TauCeti.W1p.value_coe` and
`TauCeti.W1p.gradient_coe`, naming the definitional identification of a Sobolev function's
components with those of its ambient jet. That equation was already being re-proved inline twice in
that file, as an anonymous `have ... := (rfl)`; both `apply_ae` lemmas now cite it instead, and it
is needed here because `W1p.value` does not unfold across module boundaries. No Mathlib
infrastructure was vendored.

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"extend-by-zero-w1p0"}-->

🤖 Prepared with Claude Code

