### PR TITLE
feat: stabilize normal subgroup invariants

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
@@ -28,8 +28,8 @@ The definition deliberately says `pointFixedSubmodule`: without a point-separati
 base-valued points need not detect scheme-theoretic invariants. The normality and stability
 results require no reducedness, finite-type, or field hypotheses.
 
-The group-representation step is Mathlib's `Representation.le_comap_invariants`; this file adds
-the Hopf-ideal and comodule interface around it rather than repeating its conjugation argument.
+The group-representation step is Mathlib's `Representation.toInvariants`; this file adds the
+Hopf-ideal and comodule interface around it rather than repeating its conjugation argument.
 
 ## Main declarations
 
@@ -37,8 +37,8 @@ the Hopf-ideal and comodule interface around it rather than repeating its conjug
   ideal.
 * `TauCeti.HopfIdeal.mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one`: geometric-point
   detection identifies the pointwise and scheme-theoretic fixed-vector conditions.
-* `TauCeti.HopfIdeal.IsNormal.pointFixedSubrepresentation`: the ambient representation on those
-  fixed vectors when the Hopf ideal is normal.
+* `TauCeti.HopfIdeal.IsNormal.pointFixedSubrepresentation`: Mathlib's representation on the
+  invariants, specialized to the point subgroup cut out by a normal Hopf ideal.
 * `TauCeti.HopfIdeal.IsNormal.endOfPoint_tmul_mem_pointFixedSubmodule_baseChange`: pointwise
   stability in the scalar-extension form used to detect subcomodules.
 
@@ -67,7 +67,7 @@ variable [CommRing R] [CommRing H] [HopfAlgebra R H]
 variable [AddCommGroup M] [Module R M] [Comodule R H M]
 
 /-- The submodule fixed by all base-valued points of the closed subgroup cut out by `I`. -/
-def pointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
+@[expose] def pointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
   let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
     (CommAlgCat.of R R)
   Representation.invariants
@@ -76,7 +76,6 @@ def pointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
 
 /-- Membership in the point-fixed submodule means being fixed by every base-valued point cut out
 by the Hopf ideal. -/
-@[simp]
 theorem mem_pointFixedSubmodule (I : HopfIdeal R H) (m : M) :
     m ∈ I.pointFixedSubmodule (M := M) ↔
       ∀ n : CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
@@ -146,47 +145,35 @@ namespace IsNormal
 
 variable {I : HopfIdeal R H}
 
-/-- The point-fixed submodule of a normal closed subgroup is preserved by every base-valued
-ambient point. -/
-theorem pointFixedSubmodule_le_comap (hI : I.IsNormal) (g : HopfAlgebra.points
-    (R := R) (H := H) (CommAlgCat.of R R)) :
-    I.pointFixedSubmodule (M := M) ≤
-      (I.pointFixedSubmodule (M := M)).comap
-        (Comodule.basePointsRepresentation (R := R) (H := H) M g) := by
-  let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
-    (CommAlgCat.of R R)
-  let hN : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal
-    (_root_.CommHopfAlgCat.of R H) I hI (CommAlgCat.of R R)
-  let ρ : Representation R
-      (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) M :=
-    Comodule.basePointsRepresentation (R := R) (H := H) M
-  exact @Representation.le_comap_invariants R _ _ _ M _ _ ρ N hN g
-
-/-- The ambient base-point representation restricted to the vectors fixed by a normal closed
-subgroup. -/
-def pointFixedSubrepresentation (hI : I.IsNormal) :
+/-- Mathlib's representation on the invariants, specialized to the point subgroup cut out by a
+normal closed subgroup. -/
+abbrev pointFixedSubrepresentation (hI : I.IsNormal) :
     Representation R
       (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
       (I.pointFixedSubmodule (M := M)) :=
-  (Comodule.basePointsRepresentation (R := R) (H := H) M).subrepresentation
-    (I.pointFixedSubmodule (M := M)) (pointFixedSubmodule_le_comap hI)
-
-/-- The restricted point action agrees with the ambient base-point action after coercion. -/
-@[simp]
-theorem pointFixedSubrepresentation_apply (hI : I.IsNormal)
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (m : I.pointFixedSubmodule (M := M)) :
-    ((hI.pointFixedSubrepresentation g m : I.pointFixedSubmodule (M := M)) : M) =
-      Comodule.basePointsRepresentation (R := R) (H := H) M g m := by
-  rfl
+  let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
+    (CommAlgCat.of R R)
+  let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal
+    (_root_.CommHopfAlgCat.of R H) I hI (CommAlgCat.of R R)
+  (Comodule.basePointsRepresentation (R := R) (H := H) M).toInvariants N
 
 /-- Every ambient base-valued point sends a point-fixed vector to another point-fixed vector. -/
 theorem basePointsRepresentation_mem_pointFixedSubmodule (hI : I.IsNormal)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
     {m : M} (hm : m ∈ I.pointFixedSubmodule (M := M)) :
     Comodule.basePointsRepresentation (R := R) (H := H) M g m ∈
-      I.pointFixedSubmodule (M := M) :=
-  pointFixedSubmodule_le_comap hI g hm
+      I.pointFixedSubmodule (M := M) := by
+  let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
+    (CommAlgCat.of R R)
+  let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal
+    (_root_.CommHopfAlgCat.of R H) I hI (CommAlgCat.of R R)
+  change m ∈ Representation.invariants
+    ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp N.subtype) at hm
+  change Comodule.basePointsRepresentation (R := R) (H := H) M g m ∈
+    Representation.invariants
+      ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp N.subtype)
+  exact Representation.le_comap_invariants
+    (Comodule.basePointsRepresentation (R := R) (H := H) M) N g hm
 
 /-- Scalar-extension form of the stability of normal-subgroup fixed vectors. This is the shape
 needed by geometric point-separation criteria for promoting a submodule to a subcomodule. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
@@ -71,7 +71,7 @@ variable [AddCommGroup M] [Module R M] [Comodule R H M]
 
 variable (M) in
 /-- The submodule fixed by all base-valued points of the closed subgroup cut out by `I`. -/
-@[expose] def basePointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
+def basePointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
   Representation.invariants
     ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp
       (CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
@@ -201,6 +201,7 @@ noncomputable abbrev basePointFixedSubrepresentation (hI : I.IsNormal) :
     Representation R
       (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
       (I.basePointFixedSubmodule M) := by
+  rw [basePointFixedSubmodule_def]
   let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
     (CommAlgCat.of R R)
   let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
@@ -221,8 +221,7 @@ theorem endOfPoint_le_comap_pointFixedSubmodule_baseChange (hI : I.IsNormal)
   rw [Submodule.baseChange_eq_span]
   refine Submodule.span_le.2 ?_
   rintro _ ⟨m, hm, rfl⟩
-  change Comodule.endOfPoint M g.ofConv (1 ⊗ₜ[R] m) ∈
-    Submodule.span R ((I.pointFixedSubmodule M).map (TensorProduct.mk R R M 1))
+  rw [SetLike.mem_coe, Submodule.mem_comap, TensorProduct.mk_apply]
   rw [Comodule.endOfPoint_tmul, one_smul,
     Comodule.endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
   exact Submodule.subset_span ⟨_, basePointsRepresentation_mem_pointFixedSubmodule hI g hm, rfl⟩

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
@@ -33,7 +33,6 @@ the Hopf-ideal and comodule interface around it rather than repeating its conjug
 
 ## Main declarations
 
-* `TauCeti.Comodule.basePointsRepresentation`: the action of base-valued points on a comodule.
 * `TauCeti.HopfIdeal.pointFixedSubmodule`: the vectors fixed by the points cut out by a Hopf
   ideal.
 * `TauCeti.HopfIdeal.mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one`: geometric-point
@@ -60,104 +59,6 @@ open CategoryTheory WithConv
 universe u v w x
 
 noncomputable section
-
-namespace Comodule
-
-variable {R : Type u} {H : Type v}
-variable [CommRing R] [Semiring H] [HopfAlgebra R H]
-
-/-- The representation of the group of base-valued points on the original comodule.
-
-`pointsRepresentation` acts on `R ⊗[R] M`; this is its transport across the canonical
-equivalence `R ⊗[R] M ≃ₗ[R] M`. -/
-def basePointsRepresentation (M : Type w) [AddCommMonoid M] [Module R M] [Comodule R H M] :
-    Representation R (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) M where
-  toFun g :=
-    (TensorProduct.lid R M).toLinearMap ∘ₗ
-      pointsRepresentation M g ∘ₗ
-        (TensorProduct.lid R M).symm.toLinearMap
-  map_one' := by
-    rw [map_one]
-    ext m
-    simp
-  map_mul' g h := by
-    rw [map_mul]
-    ext m
-    simp only [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap, Module.End.mul_apply,
-      LinearEquiv.symm_apply_apply]
-
-variable {M : Type w} [AddCommMonoid M] [Module R M] [Comodule R H M]
-
-/-- A base-valued point acts on `m` by contracting the coefficient leg of its coaction. -/
-@[simp]
-theorem basePointsRepresentation_apply (g : HopfAlgebra.points
-    (R := R) (H := H) (CommAlgCat.of R R)) (m : M) :
-    basePointsRepresentation (H := H) M g m =
-      TensorProduct.lid R M (endOfPoint M g.ofConv (1 ⊗ₜ[R] m)) := by
-  -- Expose the transported action once so `pointsRepresentation_apply` can rewrite it.
-  change (TensorProduct.lid R M)
-    (pointsRepresentation M g ((TensorProduct.lid R M).symm m)) = _
-  rw [pointsRepresentation_apply]
-  simp
-
-/-- The scalar-extension action of a base-valued point is the pure tensor of its action on the
-original comodule. -/
-theorem endOfPoint_one_tmul_eq_tmul_basePointsRepresentation
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (m : M) :
-    endOfPoint M g.ofConv (1 ⊗ₜ[R] m) =
-      1 ⊗ₜ[R] basePointsRepresentation (H := H) M g m := by
-  apply (TensorProduct.lid R M).injective
-  rw [basePointsRepresentation_apply]
-  simp
-
-section Corestrict
-
-variable {H₁ : Type v} {H₂ : Type x} [Semiring H₁] [Semiring H₂]
-variable [HopfAlgebra R H₁] [HopfAlgebra R H₂]
-variable {M : Type w} [AddCommMonoid M] [Module R M] [Comodule R H₁ M]
-
-/-- Acting by a base-valued point on a corestricted comodule agrees with acting by the point
-precomposed with the bialgebra morphism. -/
-theorem basePointsRepresentation_corestrict (φ : H₁ →ₐc[R] H₂)
-    (g : HopfAlgebra.points (R := R) (H := H₂) (CommAlgCat.of R R)) :
-    (letI : Comodule R H₂ M := Corestrict φ.toCoalgHom
-     basePointsRepresentation (R := R) (H := H₂) M g) =
-      basePointsRepresentation (R := R) (H := H₁) M (AlgHom.mapDomain φ g) := by
-  let _ : Comodule R H₂ M := Corestrict φ.toCoalgHom
-  apply LinearMap.ext
-  intro m
-  rw [basePointsRepresentation_apply, basePointsRepresentation_apply]
-  congr 1
-  exact LinearMap.congr_fun (endOfPoint_corestrict φ g.ofConv) (1 ⊗ₜ[R] m)
-
-end Corestrict
-
-section GeometricDetection
-
-variable {k : Type u} {A : Type v} {M : Type w}
-variable [Field k] [CommRing A] [HopfAlgebra k A] [Algebra.FiniteType k A] [IsReduced A]
-variable [AddCommGroup M] [Module k M] [Comodule k A M] [IsAlgClosed k]
-
-/-- Over an algebraically closed base field, base-valued points detect fixed vectors of a
-reduced finite-type Hopf-algebra comodule. -/
-theorem coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq (m : M) :
-    coact (R := k) (C := A) m = m ⊗ₜ[k] (1 : A) ↔
-      ∀ g : HopfAlgebra.points (R := k) (H := A) (CommAlgCat.of k k),
-        basePointsRepresentation (R := k) (H := A) M g m = m := by
-  rw [coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (K := k)]
-  constructor
-  · intro h g
-    have hg := h g
-    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap] at hg
-    have := congrArg (TensorProduct.lid k M) hg
-    exact (basePointsRepresentation_apply g m).trans (by simpa using this)
-  · intro h g
-    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap,
-      endOfPoint_one_tmul_eq_tmul_basePointsRepresentation, h g]
-
-end GeometricDetection
-
-end Comodule
 
 namespace HopfIdeal
 
@@ -229,9 +130,10 @@ theorem mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one
   · intro hm
     rw [mem_pointFixedSubmodule]
     intro n
-    have hn := n.2
-    change n.1 ∈ Set.range
-      (CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k)) at hn
+    have hn : n.1 ∈ Set.range
+        (CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k)) :=
+      (CommHopfAlgCat.mem_range_quotientPointsHom_iff H I (CommAlgCat.of k k) n.1).2 <|
+        (CommHopfAlgCat.mem_quotientPointsSubgroup_iff H I (CommAlgCat.of k k) n.1).1 n.2
     obtain ⟨g, hg⟩ := hn
     have hq : AlgHom.mapDomain q g = n.1 := (hinclude g).trans hg
     have hfixed := hm g
@@ -268,6 +170,15 @@ def pointFixedSubrepresentation (hI : I.IsNormal) :
       (I.pointFixedSubmodule (M := M)) :=
   (Comodule.basePointsRepresentation (R := R) (H := H) M).subrepresentation
     (I.pointFixedSubmodule (M := M)) (pointFixedSubmodule_le_comap hI)
+
+/-- The restricted point action agrees with the ambient base-point action after coercion. -/
+@[simp]
+theorem pointFixedSubrepresentation_apply (hI : I.IsNormal)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (m : I.pointFixedSubmodule (M := M)) :
+    ((hI.pointFixedSubrepresentation g m : I.pointFixedSubmodule (M := M)) : M) =
+      Comodule.basePointsRepresentation (R := R) (H := H) M g m := by
+  rfl
 
 /-- Every ambient base-valued point sends a point-fixed vector to another point-fixed vector. -/
 theorem basePointsRepresentation_mem_pointFixedSubmodule (hI : I.IsNormal)

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
@@ -1,0 +1,297 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.Invariants
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
+import TauCeti.Algebra.Coalgebra.Comodule.PointAction
+
+/-!
+# Invariants of normal closed subgroups
+
+Let `H` be a commutative Hopf algebra and `M` an `H`-comodule. A point of the affine group
+represented by `H` acts naturally on `M` itself when its value algebra is the base ring. For a
+Hopf ideal `I`, this file defines the submodule fixed by the base-valued points of the closed
+subgroup cut out by `I`.
+
+When `I` is normal, its point subgroup is normal over every value algebra. The standard theorem
+that the invariants of a normal subgroup form a subrepresentation therefore shows that this
+fixed submodule is preserved by every ambient point. This is the pointwise algebraic-group input
+to the direct proof that `GLₙ` is reductive: the fixed vectors of a normal unipotent subgroup in
+the standard representation form an ambient subrepresentation.
+
+The definition deliberately says `pointFixedSubmodule`: without a point-separation hypothesis,
+base-valued points need not detect scheme-theoretic invariants. The normality and stability
+results require no reducedness, finite-type, or field hypotheses.
+
+The group-representation step is Mathlib's `Representation.le_comap_invariants`; this file adds
+the Hopf-ideal and comodule interface around it rather than repeating its conjugation argument.
+
+## Main declarations
+
+* `TauCeti.Comodule.basePointsRepresentation`: the action of base-valued points on a comodule.
+* `TauCeti.HopfIdeal.pointFixedSubmodule`: the vectors fixed by the points cut out by a Hopf
+  ideal.
+* `TauCeti.HopfIdeal.mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one`: geometric-point
+  detection identifies the pointwise and scheme-theoretic fixed-vector conditions.
+* `TauCeti.HopfIdeal.IsNormal.pointFixedSubrepresentation`: the ambient representation on those
+  fixed vectors when the Hopf ideal is normal.
+* `TauCeti.HopfIdeal.IsNormal.endOfPoint_tmul_mem_pointFixedSubmodule_baseChange`: pointwise
+  stability in the scalar-extension form used to detect subcomodules.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §2.2.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+open CategoryTheory WithConv
+
+universe u v w x
+
+noncomputable section
+
+namespace Comodule
+
+variable {R : Type u} {H : Type v}
+variable [CommRing R] [Semiring H] [HopfAlgebra R H]
+
+/-- The representation of the group of base-valued points on the original comodule.
+
+`pointsRepresentation` acts on `R ⊗[R] M`; this is its transport across the canonical
+equivalence `R ⊗[R] M ≃ₗ[R] M`. -/
+def basePointsRepresentation (M : Type w) [AddCommMonoid M] [Module R M] [Comodule R H M] :
+    Representation R (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) M where
+  toFun g :=
+    (TensorProduct.lid R M).toLinearMap ∘ₗ
+      pointsRepresentation M g ∘ₗ
+        (TensorProduct.lid R M).symm.toLinearMap
+  map_one' := by
+    rw [map_one]
+    ext m
+    simp
+  map_mul' g h := by
+    rw [map_mul]
+    ext m
+    simp only [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap, Module.End.mul_apply,
+      LinearEquiv.symm_apply_apply]
+
+variable {M : Type w} [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- A base-valued point acts on `m` by contracting the coefficient leg of its coaction. -/
+@[simp]
+theorem basePointsRepresentation_apply (g : HopfAlgebra.points
+    (R := R) (H := H) (CommAlgCat.of R R)) (m : M) :
+    basePointsRepresentation (H := H) M g m =
+      TensorProduct.lid R M (endOfPoint M g.ofConv (1 ⊗ₜ[R] m)) := by
+  -- Expose the transported action once so `pointsRepresentation_apply` can rewrite it.
+  change (TensorProduct.lid R M)
+    (pointsRepresentation M g ((TensorProduct.lid R M).symm m)) = _
+  rw [pointsRepresentation_apply]
+  simp
+
+/-- The scalar-extension action of a base-valued point is the pure tensor of its action on the
+original comodule. -/
+theorem endOfPoint_one_tmul_eq_tmul_basePointsRepresentation
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (m : M) :
+    endOfPoint M g.ofConv (1 ⊗ₜ[R] m) =
+      1 ⊗ₜ[R] basePointsRepresentation (H := H) M g m := by
+  apply (TensorProduct.lid R M).injective
+  rw [basePointsRepresentation_apply]
+  simp
+
+section Corestrict
+
+variable {H₁ : Type v} {H₂ : Type x} [Semiring H₁] [Semiring H₂]
+variable [HopfAlgebra R H₁] [HopfAlgebra R H₂]
+variable {M : Type w} [AddCommMonoid M] [Module R M] [Comodule R H₁ M]
+
+/-- Acting by a base-valued point on a corestricted comodule agrees with acting by the point
+precomposed with the bialgebra morphism. -/
+theorem basePointsRepresentation_corestrict (φ : H₁ →ₐc[R] H₂)
+    (g : HopfAlgebra.points (R := R) (H := H₂) (CommAlgCat.of R R)) :
+    (letI : Comodule R H₂ M := Corestrict φ.toCoalgHom
+     basePointsRepresentation (R := R) (H := H₂) M g) =
+      basePointsRepresentation (R := R) (H := H₁) M (AlgHom.mapDomain φ g) := by
+  let _ : Comodule R H₂ M := Corestrict φ.toCoalgHom
+  apply LinearMap.ext
+  intro m
+  rw [basePointsRepresentation_apply, basePointsRepresentation_apply]
+  congr 1
+  exact LinearMap.congr_fun (endOfPoint_corestrict φ g.ofConv) (1 ⊗ₜ[R] m)
+
+end Corestrict
+
+section GeometricDetection
+
+variable {k : Type u} {A : Type v} {M : Type w}
+variable [Field k] [CommRing A] [HopfAlgebra k A] [Algebra.FiniteType k A] [IsReduced A]
+variable [AddCommGroup M] [Module k M] [Comodule k A M] [IsAlgClosed k]
+
+/-- Over an algebraically closed base field, base-valued points detect fixed vectors of a
+reduced finite-type Hopf-algebra comodule. -/
+theorem coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq (m : M) :
+    coact (R := k) (C := A) m = m ⊗ₜ[k] (1 : A) ↔
+      ∀ g : HopfAlgebra.points (R := k) (H := A) (CommAlgCat.of k k),
+        basePointsRepresentation (R := k) (H := A) M g m = m := by
+  rw [coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (K := k)]
+  constructor
+  · intro h g
+    have hg := h g
+    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap] at hg
+    have := congrArg (TensorProduct.lid k M) hg
+    exact (basePointsRepresentation_apply g m).trans (by simpa using this)
+  · intro h g
+    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap,
+      endOfPoint_one_tmul_eq_tmul_basePointsRepresentation, h g]
+
+end GeometricDetection
+
+end Comodule
+
+namespace HopfIdeal
+
+variable {R : Type u} {H : Type v} {M : Type w}
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [AddCommGroup M] [Module R M] [Comodule R H M]
+
+/-- The submodule fixed by all base-valued points of the closed subgroup cut out by `I`. -/
+def pointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
+  let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
+    (CommAlgCat.of R R)
+  Representation.invariants
+    ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp N.subtype :
+      Representation R N M)
+
+/-- Membership in the point-fixed submodule means being fixed by every base-valued point cut out
+by the Hopf ideal. -/
+@[simp]
+theorem mem_pointFixedSubmodule (I : HopfIdeal R H) (m : M) :
+    m ∈ I.pointFixedSubmodule (M := M) ↔
+      ∀ n : CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
+          (CommAlgCat.of R R),
+        Comodule.basePointsRepresentation (R := R) (H := H) M
+          (n : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) m = m := by
+  rfl
+
+section GeometricDetection
+
+variable {k : Type u} {A : Type v} {M : Type w}
+variable [Field k] [CommRing A] [HopfAlgebra k A]
+variable [AddCommGroup M] [Module k M] [Comodule k A M] [IsAlgClosed k]
+
+/-- Over an algebraically closed field, if the quotient coordinate ring is reduced and of finite
+type, point-fixed vectors are exactly the vectors fixed by the restricted coaction of the closed
+subgroup scheme. -/
+theorem mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one
+    (I : HopfIdeal k A)
+    [Algebra.FiniteType k
+      (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k A) I)]
+    [IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k A) I)]
+    (m : M) :
+    m ∈ I.pointFixedSubmodule (M := M) ↔
+      TensorProduct.map LinearMap.id
+          (CommHopfAlgCat.mkQuotient (_root_.CommHopfAlgCat.of k A) I).hom.toLinearMap
+          (Comodule.coact (R := k) (C := A) m) =
+        m ⊗ₜ[k]
+          (1 : CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k A) I) := by
+  let H := _root_.CommHopfAlgCat.of k A
+  let Q := CommHopfAlgCat.quotient H I
+  let q : A →ₐc[k] Q := (CommHopfAlgCat.mkQuotient H I).hom
+  let _ : Comodule k Q M := Comodule.Corestrict q.toCoalgHom
+  -- The displayed tensor map is definitionally the coaction corestricted along `q`.
+  change m ∈ I.pointFixedSubmodule (M := M) ↔
+    Comodule.coact (R := k) (C := Q) m = m ⊗ₜ[k] (1 : Q)
+  rw [Comodule.coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq]
+  have hinclude (g : HopfAlgebra.points (R := k) (H := Q) (CommAlgCat.of k k)) :
+      AlgHom.mapDomain q g =
+        CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k) g := by
+    rw [CommHopfAlgCat.quotientPointsHom_apply, AlgHom.mapDomain_apply]
+  constructor
+  · intro hm g
+    let n := CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k) g
+    have hfixed := (mem_pointFixedSubmodule I m).mp hm
+      ⟨n, CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H I
+        (CommAlgCat.of k k) g⟩
+    rw [Comodule.basePointsRepresentation_corestrict q g]
+    rw [hinclude]
+    exact hfixed
+  · intro hm
+    rw [mem_pointFixedSubmodule]
+    intro n
+    have hn := n.2
+    change n.1 ∈ Set.range
+      (CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k)) at hn
+    obtain ⟨g, hg⟩ := hn
+    have hq : AlgHom.mapDomain q g = n.1 := (hinclude g).trans hg
+    have hfixed := hm g
+    rw [Comodule.basePointsRepresentation_corestrict q g, hq] at hfixed
+    exact hfixed
+
+end GeometricDetection
+
+namespace IsNormal
+
+variable {I : HopfIdeal R H}
+
+/-- The point-fixed submodule of a normal closed subgroup is preserved by every base-valued
+ambient point. -/
+theorem pointFixedSubmodule_le_comap (hI : I.IsNormal) (g : HopfAlgebra.points
+    (R := R) (H := H) (CommAlgCat.of R R)) :
+    I.pointFixedSubmodule (M := M) ≤
+      (I.pointFixedSubmodule (M := M)).comap
+        (Comodule.basePointsRepresentation (R := R) (H := H) M g) := by
+  let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
+    (CommAlgCat.of R R)
+  let hN : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal
+    (_root_.CommHopfAlgCat.of R H) I hI (CommAlgCat.of R R)
+  let ρ : Representation R
+      (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) M :=
+    Comodule.basePointsRepresentation (R := R) (H := H) M
+  exact @Representation.le_comap_invariants R _ _ _ M _ _ ρ N hN g
+
+/-- The ambient base-point representation restricted to the vectors fixed by a normal closed
+subgroup. -/
+def pointFixedSubrepresentation (hI : I.IsNormal) :
+    Representation R
+      (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+      (I.pointFixedSubmodule (M := M)) :=
+  (Comodule.basePointsRepresentation (R := R) (H := H) M).subrepresentation
+    (I.pointFixedSubmodule (M := M)) (pointFixedSubmodule_le_comap hI)
+
+/-- Every ambient base-valued point sends a point-fixed vector to another point-fixed vector. -/
+theorem basePointsRepresentation_mem_pointFixedSubmodule (hI : I.IsNormal)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    {m : M} (hm : m ∈ I.pointFixedSubmodule (M := M)) :
+    Comodule.basePointsRepresentation (R := R) (H := H) M g m ∈
+      I.pointFixedSubmodule (M := M) :=
+  pointFixedSubmodule_le_comap hI g hm
+
+/-- Scalar-extension form of the stability of normal-subgroup fixed vectors. This is the shape
+needed by geometric point-separation criteria for promoting a submodule to a subcomodule. -/
+theorem endOfPoint_tmul_mem_pointFixedSubmodule_baseChange (hI : I.IsNormal)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    {m : M} (hm : m ∈ I.pointFixedSubmodule (M := M)) :
+    Comodule.endOfPoint M g.ofConv (1 ⊗ₜ[R] m) ∈
+      (I.pointFixedSubmodule (M := M)).baseChange R := by
+  rw [Comodule.endOfPoint_one_tmul_eq_tmul_basePointsRepresentation]
+  exact Submodule.tmul_mem_baseChange_of_mem _
+    (basePointsRepresentation_mem_pointFixedSubmodule hI g hm)
+
+end IsNormal
+
+end HopfIdeal
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
@@ -223,7 +223,8 @@ theorem endOfPoint_le_comap_pointFixedSubmodule_baseChange (hI : I.IsNormal)
   rintro _ ⟨m, hm, rfl⟩
   change Comodule.endOfPoint M g.ofConv (1 ⊗ₜ[R] m) ∈
     Submodule.span R ((I.pointFixedSubmodule M).map (TensorProduct.mk R R M 1))
-  rw [Comodule.endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
+  rw [Comodule.endOfPoint_tmul, one_smul,
+    Comodule.endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
   exact Submodule.subset_span ⟨_, basePointsRepresentation_mem_pointFixedSubmodule hI g hm, rfl⟩
 
 /-- Scalar-extension form of the stability of normal-subgroup fixed vectors. This is the shape

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
@@ -23,25 +23,26 @@ fixed submodule is preserved by every ambient point. This is the pointwise algeb
 to the direct proof that `GLₙ` is reductive: the fixed vectors of a normal unipotent subgroup in
 the standard representation form an ambient subrepresentation.
 
-The definition deliberately says `pointFixedSubmodule`: without a point-separation hypothesis,
-base-valued points need not detect scheme-theoretic invariants. The normality and stability
-results require no reducedness, finite-type, or field hypotheses.
+The definition deliberately says `basePointFixedSubmodule`: without a point-separation
+hypothesis, base-valued points need not detect scheme-theoretic invariants. The normality and
+stability results require no reducedness, finite-type, or field hypotheses.
 
-The group-representation step is Mathlib's `Representation.le_comap_invariants`, packaged with
-`Representation.subrepresentation`; this file adds the Hopf-ideal and comodule interface around
-it rather than repeating the normal-subgroup conjugation argument.
+The group-representation step is Mathlib's `Representation.toInvariants`; this file adds the
+Hopf-ideal and comodule interface around it rather than repeating the normal-subgroup conjugation
+argument.
 
 ## Main declarations
 
-* `TauCeti.HopfIdeal.pointFixedSubmodule`: the vectors fixed by the points cut out by a Hopf
-  ideal.
-* `TauCeti.HopfIdeal.mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one`: geometric-point
+* `TauCeti.HopfIdeal.basePointFixedSubmodule`: the vectors fixed by the base-valued points cut out
+  by a Hopf ideal.
+* `TauCeti.HopfIdeal.mem_basePointFixedSubmodule_iff_quotient_coact_eq_tmul_one`: geometric-point
   detection identifies the pointwise and scheme-theoretic fixed-vector conditions.
-* `TauCeti.HopfIdeal.IsNormal.pointFixedSubrepresentation`: Mathlib's representation on the
+* `TauCeti.HopfIdeal.IsNormal.basePointFixedSubrepresentation`: Mathlib's representation on the
   invariants of the point subgroup cut out by a normal Hopf ideal.
-* `TauCeti.HopfIdeal.IsNormal.basePointsRepresentation_mem_pointFixedSubmodule`: the ambient
-  base-point action preserves the point-fixed submodule.
-* `TauCeti.HopfIdeal.IsNormal.endOfPoint_one_tmul_mem_pointFixedSubmodule_baseChange`: pointwise
+* `TauCeti.HopfIdeal.IsNormal.basePointsRepresentation_mem_basePointFixedSubmodule`: the ambient
+  base-point action preserves the base-point-fixed submodule.
+* `TauCeti.HopfIdeal.IsNormal.endOfPoint_one_tmul_mem_basePointFixedSubmodule_baseChange`:
+  pointwise
   stability in the scalar-extension form used to detect subcomodules.
 
 ## References
@@ -70,26 +71,27 @@ variable [AddCommGroup M] [Module R M] [Comodule R H M]
 
 variable (M) in
 /-- The submodule fixed by all base-valued points of the closed subgroup cut out by `I`. -/
-def pointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
+@[expose] def basePointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
   Representation.invariants
     ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp
       (CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
         (CommAlgCat.of R R)).subtype)
 
-/-- The point-fixed submodule as Mathlib's invariant submodule for the quotient point subgroup. -/
-theorem pointFixedSubmodule_def (I : HopfIdeal R H) :
-    I.pointFixedSubmodule M =
+/-- The base-point-fixed submodule as Mathlib's invariant submodule for the quotient point
+subgroup. -/
+theorem basePointFixedSubmodule_def (I : HopfIdeal R H) :
+    I.basePointFixedSubmodule M =
       Representation.invariants
         ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp
           (CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
             (CommAlgCat.of R R)).subtype) := by
   rfl
 
-/-- Membership in the point-fixed submodule means being fixed by every base-valued point cut out
-by the Hopf ideal. -/
+/-- Membership in the base-point-fixed submodule means being fixed by every base-valued point cut
+out by the Hopf ideal. -/
 @[simp]
-theorem mem_pointFixedSubmodule (I : HopfIdeal R H) (m : M) :
-    m ∈ I.pointFixedSubmodule M ↔
+theorem mem_basePointFixedSubmodule (I : HopfIdeal R H) (m : M) :
+    m ∈ I.basePointFixedSubmodule M ↔
       ∀ n : CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
           (CommAlgCat.of R R),
         Comodule.basePointsRepresentation (R := R) (H := H) M
@@ -98,20 +100,20 @@ theorem mem_pointFixedSubmodule (I : HopfIdeal R H) (m : M) :
 
 /-- A vector fixed by the quotient coaction is fixed by every base-valued point of the closed
 subgroup cut out by `I`. This direction requires no point-separation hypotheses. -/
-theorem mem_pointFixedSubmodule_of_quotient_coact_eq_tmul_one
+theorem mem_basePointFixedSubmodule_of_quotient_coact_eq_tmul_one
     (I : HopfIdeal R H) (m : M)
     (hm : TensorProduct.map LinearMap.id
         (CommHopfAlgCat.mkQuotient (_root_.CommHopfAlgCat.of R H) I).hom.toLinearMap
         (Comodule.coact (R := R) (C := H) m) =
       m ⊗ₜ[R] (1 : CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of R H) I)) :
-    m ∈ I.pointFixedSubmodule M := by
+    m ∈ I.basePointFixedSubmodule M := by
   let A := _root_.CommHopfAlgCat.of R H
   let Q := CommHopfAlgCat.quotient A I
   let q : H →ₐc[R] Q := (CommHopfAlgCat.mkQuotient A I).hom
   let _ : Comodule R Q M := Comodule.Corestrict q.toCoalgHom
   have hm' : Comodule.coact (R := R) (C := Q) m = m ⊗ₜ[R] (1 : Q) := by
     simpa only [Comodule.corestrict_coact_apply] using hm
-  rw [mem_pointFixedSubmodule]
+  rw [mem_basePointFixedSubmodule]
   intro n
   obtain ⟨g, hg⟩ := n.2
   have hfixed := Comodule.basePointsRepresentation_eq_of_coact_eq_tmul_one m hm' g
@@ -130,15 +132,15 @@ variable [Field k] [CommRing A] [HopfAlgebra k A]
 variable [AddCommGroup M] [Module k M] [Comodule k A M] [IsAlgClosed k]
 
 /-- Over an algebraically closed field, if the quotient coordinate ring is reduced and of finite
-type, point-fixed vectors are exactly the vectors fixed by the restricted coaction of the closed
-subgroup scheme. -/
-theorem mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one
+type, base-point-fixed vectors are exactly the vectors fixed by the restricted coaction of the
+closed subgroup scheme. -/
+theorem mem_basePointFixedSubmodule_iff_quotient_coact_eq_tmul_one
     (I : HopfIdeal k A)
     [Algebra.FiniteType k
       (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k A) I)]
     [IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k A) I)]
     (m : M) :
-    m ∈ I.pointFixedSubmodule M ↔
+    m ∈ I.basePointFixedSubmodule M ↔
       TensorProduct.map LinearMap.id
           (CommHopfAlgCat.mkQuotient (_root_.CommHopfAlgCat.of k A) I).hom.toLinearMap
           (Comodule.coact (R := k) (C := A) m) =
@@ -158,7 +160,7 @@ theorem mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one
         Comodule.basePointsRepresentation (R := k) (H := Q) M g m = m := by
       intro g
       let n := CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k) g
-      have hn := (mem_pointFixedSubmodule I m).mp hm
+      have hn := (mem_basePointFixedSubmodule I m).mp hm
         ⟨n, CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H I
           (CommAlgCat.of k k) g⟩
       rw [Comodule.basePointsRepresentation_corestrict q g, hinclude]
@@ -166,7 +168,7 @@ theorem mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one
     have hcoact :=
       (Comodule.coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq m).2 hfixed
     simpa only [Comodule.corestrict_coact_apply] using hcoact
-  · exact mem_pointFixedSubmodule_of_quotient_coact_eq_tmul_one I m
+  · exact mem_basePointFixedSubmodule_of_quotient_coact_eq_tmul_one I m
 
 end GeometricDetection
 
@@ -174,66 +176,62 @@ namespace IsNormal
 
 variable {I : HopfIdeal R H}
 
-/-- Every ambient base-valued point sends a point-fixed vector to another point-fixed vector. -/
-theorem basePointsRepresentation_mem_pointFixedSubmodule (hI : I.IsNormal)
+/-- Every ambient base-valued point sends a base-point-fixed vector to another base-point-fixed
+vector. -/
+theorem basePointsRepresentation_mem_basePointFixedSubmodule (hI : I.IsNormal)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    {m : M} (hm : m ∈ I.pointFixedSubmodule M) :
+    {m : M} (hm : m ∈ I.basePointFixedSubmodule M) :
     Comodule.basePointsRepresentation (R := R) (H := H) M g m ∈
-      I.pointFixedSubmodule M := by
+      I.basePointFixedSubmodule M := by
   let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
     (CommAlgCat.of R R)
   let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal
     (_root_.CommHopfAlgCat.of R H) I hI (CommAlgCat.of R R)
   have hm' : m ∈ Representation.invariants
       ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp N.subtype) := by
-    simpa only [pointFixedSubmodule_def] using hm
+    simpa only [basePointFixedSubmodule_def] using hm
   have hstable := Representation.le_comap_invariants
     (Comodule.basePointsRepresentation (R := R) (H := H) M) N g hm'
-  simpa only [Submodule.mem_comap, pointFixedSubmodule_def] using hstable
+  simpa only [Submodule.mem_comap, basePointFixedSubmodule_def] using hstable
 
 variable (M) in
 /-- The representation of the full group of base-valued points on the vectors fixed by the point
 subgroup cut out by the normal Hopf ideal `I`. Normality makes this submodule ambient-stable. -/
-noncomputable def pointFixedSubrepresentation (hI : I.IsNormal) :
+noncomputable abbrev basePointFixedSubrepresentation (hI : I.IsNormal) :
     Representation R
       (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-      (I.pointFixedSubmodule M) :=
-  Representation.subrepresentation
+      (I.basePointFixedSubmodule M) := by
+  let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
+    (CommAlgCat.of R R)
+  let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal
+    (_root_.CommHopfAlgCat.of R H) I hI (CommAlgCat.of R R)
+  exact Representation.toInvariants
     (Comodule.basePointsRepresentation (R := R) (H := H) M)
-    (I.pointFixedSubmodule M) fun g _ hm =>
-        basePointsRepresentation_mem_pointFixedSubmodule hI g hm
+    N
 
-/-- The action on the point-fixed subrepresentation is the ambient base-point action. -/
-@[simp]
-theorem pointFixedSubrepresentation_apply_coe (hI : I.IsNormal)
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    (m : I.pointFixedSubmodule M) :
-    ((hI.pointFixedSubrepresentation M g m : I.pointFixedSubmodule M) : M) =
-      Comodule.basePointsRepresentation (R := R) (H := H) M g m := by
-  rfl
-
-/-- The scalar extension of the point-fixed submodule is stable under every ambient point
+/-- The scalar extension of the base-point-fixed submodule is stable under every ambient point
 endomorphism. -/
-theorem endOfPoint_le_comap_pointFixedSubmodule_baseChange (hI : I.IsNormal)
+theorem endOfPoint_le_comap_basePointFixedSubmodule_baseChange (hI : I.IsNormal)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
-    (I.pointFixedSubmodule M).baseChange R ≤
-      ((I.pointFixedSubmodule M).baseChange R).comap (Comodule.endOfPoint M g.ofConv) := by
+    (I.basePointFixedSubmodule M).baseChange R ≤
+      ((I.basePointFixedSubmodule M).baseChange R).comap (Comodule.endOfPoint M g.ofConv) := by
   rw [Submodule.baseChange_eq_span]
   refine Submodule.span_le.2 ?_
   rintro _ ⟨m, hm, rfl⟩
   rw [SetLike.mem_coe, Submodule.mem_comap, TensorProduct.mk_apply]
   rw [Comodule.endOfPoint_tmul, one_smul,
     Comodule.endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
-  exact Submodule.subset_span ⟨_, basePointsRepresentation_mem_pointFixedSubmodule hI g hm, rfl⟩
+  exact Submodule.subset_span
+    ⟨_, basePointsRepresentation_mem_basePointFixedSubmodule hI g hm, rfl⟩
 
 /-- Scalar-extension form of the stability of normal-subgroup fixed vectors. This is the shape
 needed by geometric point-separation criteria for promoting a submodule to a subcomodule. -/
-theorem endOfPoint_one_tmul_mem_pointFixedSubmodule_baseChange (hI : I.IsNormal)
+theorem endOfPoint_one_tmul_mem_basePointFixedSubmodule_baseChange (hI : I.IsNormal)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    {m : M} (hm : m ∈ I.pointFixedSubmodule M) :
+    {m : M} (hm : m ∈ I.basePointFixedSubmodule M) :
     Comodule.endOfPoint M g.ofConv (1 ⊗ₜ[R] m) ∈
-      (I.pointFixedSubmodule M).baseChange R :=
-  endOfPoint_le_comap_pointFixedSubmodule_baseChange hI g
+      (I.basePointFixedSubmodule M).baseChange R :=
+  endOfPoint_le_comap_basePointFixedSubmodule_baseChange hI g
     (Submodule.tmul_mem_baseChange_of_mem _ hm)
 
 end IsNormal

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.RepresentationTheory.Invariants
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
-import TauCeti.Algebra.Coalgebra.Comodule.PointAction
 
 /-!
 # Invariants of normal closed subgroups
@@ -28,8 +27,9 @@ The definition deliberately says `pointFixedSubmodule`: without a point-separati
 base-valued points need not detect scheme-theoretic invariants. The normality and stability
 results require no reducedness, finite-type, or field hypotheses.
 
-The group-representation step is Mathlib's `Representation.toInvariants`; this file adds the
-Hopf-ideal and comodule interface around it rather than repeating its conjugation argument.
+The group-representation step is Mathlib's `Representation.le_comap_invariants`, packaged with
+`Representation.subrepresentation`; this file adds the Hopf-ideal and comodule interface around
+it rather than repeating the normal-subgroup conjugation argument.
 
 ## Main declarations
 
@@ -38,8 +38,10 @@ Hopf-ideal and comodule interface around it rather than repeating its conjugatio
 * `TauCeti.HopfIdeal.mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one`: geometric-point
   detection identifies the pointwise and scheme-theoretic fixed-vector conditions.
 * `TauCeti.HopfIdeal.IsNormal.pointFixedSubrepresentation`: Mathlib's representation on the
-  invariants, specialized to the point subgroup cut out by a normal Hopf ideal.
-* `TauCeti.HopfIdeal.IsNormal.endOfPoint_tmul_mem_pointFixedSubmodule_baseChange`: pointwise
+  invariants of the point subgroup cut out by a normal Hopf ideal.
+* `TauCeti.HopfIdeal.IsNormal.basePointsRepresentation_mem_pointFixedSubmodule`: the ambient
+  base-point action preserves the point-fixed submodule.
+* `TauCeti.HopfIdeal.IsNormal.endOfPoint_one_tmul_mem_pointFixedSubmodule_baseChange`: pointwise
   stability in the scalar-extension form used to detect subcomodules.
 
 ## References
@@ -66,23 +68,60 @@ variable {R : Type u} {H : Type v} {M : Type w}
 variable [CommRing R] [CommRing H] [HopfAlgebra R H]
 variable [AddCommGroup M] [Module R M] [Comodule R H M]
 
+variable (M) in
 /-- The submodule fixed by all base-valued points of the closed subgroup cut out by `I`. -/
-@[expose] def pointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
-  let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
-    (CommAlgCat.of R R)
+def pointFixedSubmodule (I : HopfIdeal R H) : Submodule R M :=
   Representation.invariants
-    ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp N.subtype :
-      Representation R N M)
+    ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp
+      (CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
+        (CommAlgCat.of R R)).subtype)
+
+/-- The point-fixed submodule as Mathlib's invariant submodule for the quotient point subgroup. -/
+theorem pointFixedSubmodule_def (I : HopfIdeal R H) :
+    I.pointFixedSubmodule M =
+      Representation.invariants
+        ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp
+          (CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
+            (CommAlgCat.of R R)).subtype) := by
+  rfl
 
 /-- Membership in the point-fixed submodule means being fixed by every base-valued point cut out
 by the Hopf ideal. -/
+@[simp]
 theorem mem_pointFixedSubmodule (I : HopfIdeal R H) (m : M) :
-    m ∈ I.pointFixedSubmodule (M := M) ↔
+    m ∈ I.pointFixedSubmodule M ↔
       ∀ n : CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
           (CommAlgCat.of R R),
         Comodule.basePointsRepresentation (R := R) (H := H) M
           (n : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) m = m := by
   rfl
+
+/-- A vector fixed by the quotient coaction is fixed by every base-valued point of the closed
+subgroup cut out by `I`. This direction requires no point-separation hypotheses. -/
+theorem mem_pointFixedSubmodule_of_quotient_coact_eq_tmul_one
+    (I : HopfIdeal R H) (m : M)
+    (hm : TensorProduct.map LinearMap.id
+        (CommHopfAlgCat.mkQuotient (_root_.CommHopfAlgCat.of R H) I).hom.toLinearMap
+        (Comodule.coact (R := R) (C := H) m) =
+      m ⊗ₜ[R] (1 : CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of R H) I)) :
+    m ∈ I.pointFixedSubmodule M := by
+  let A := _root_.CommHopfAlgCat.of R H
+  let Q := CommHopfAlgCat.quotient A I
+  let q : H →ₐc[R] Q := (CommHopfAlgCat.mkQuotient A I).hom
+  let _ : Comodule R Q M := Comodule.Corestrict q.toCoalgHom
+  have hm' : Comodule.coact (R := R) (C := Q) m = m ⊗ₜ[R] (1 : Q) := by
+    simpa only [Comodule.corestrict_coact_apply] using hm
+  rw [mem_pointFixedSubmodule]
+  intro n
+  obtain ⟨g, hg⟩ := n.2
+  have hfixed := Comodule.basePointsRepresentation_eq_of_coact_eq_tmul_one m hm' g
+  have hinclude : AlgHom.mapDomain q g =
+      CommHopfAlgCat.quotientPointsHom A I (CommAlgCat.of R R) g := by
+    rw [CommHopfAlgCat.quotientPointsHom_apply, AlgHom.mapDomain_apply]
+  have hq : AlgHom.mapDomain q g = n.1 := by
+    exact hinclude.trans hg
+  rw [Comodule.basePointsRepresentation_corestrict q g, hq] at hfixed
+  exact hfixed
 
 section GeometricDetection
 
@@ -99,7 +138,7 @@ theorem mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one
       (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k A) I)]
     [IsReduced (CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of k A) I)]
     (m : M) :
-    m ∈ I.pointFixedSubmodule (M := M) ↔
+    m ∈ I.pointFixedSubmodule M ↔
       TensorProduct.map LinearMap.id
           (CommHopfAlgCat.mkQuotient (_root_.CommHopfAlgCat.of k A) I).hom.toLinearMap
           (Comodule.coact (R := k) (C := A) m) =
@@ -109,35 +148,25 @@ theorem mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one
   let Q := CommHopfAlgCat.quotient H I
   let q : A →ₐc[k] Q := (CommHopfAlgCat.mkQuotient H I).hom
   let _ : Comodule k Q M := Comodule.Corestrict q.toCoalgHom
-  -- The displayed tensor map is definitionally the coaction corestricted along `q`.
-  change m ∈ I.pointFixedSubmodule (M := M) ↔
-    Comodule.coact (R := k) (C := Q) m = m ⊗ₜ[k] (1 : Q)
-  rw [Comodule.coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq]
   have hinclude (g : HopfAlgebra.points (R := k) (H := Q) (CommAlgCat.of k k)) :
       AlgHom.mapDomain q g =
         CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k) g := by
     rw [CommHopfAlgCat.quotientPointsHom_apply, AlgHom.mapDomain_apply]
   constructor
-  · intro hm g
-    let n := CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k) g
-    have hfixed := (mem_pointFixedSubmodule I m).mp hm
-      ⟨n, CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H I
-        (CommAlgCat.of k k) g⟩
-    rw [Comodule.basePointsRepresentation_corestrict q g]
-    rw [hinclude]
-    exact hfixed
   · intro hm
-    rw [mem_pointFixedSubmodule]
-    intro n
-    have hn : n.1 ∈ Set.range
-        (CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k)) :=
-      (CommHopfAlgCat.mem_range_quotientPointsHom_iff H I (CommAlgCat.of k k) n.1).2 <|
-        (CommHopfAlgCat.mem_quotientPointsSubgroup_iff H I (CommAlgCat.of k k) n.1).1 n.2
-    obtain ⟨g, hg⟩ := hn
-    have hq : AlgHom.mapDomain q g = n.1 := (hinclude g).trans hg
-    have hfixed := hm g
-    rw [Comodule.basePointsRepresentation_corestrict q g, hq] at hfixed
-    exact hfixed
+    have hfixed : ∀ g : HopfAlgebra.points (R := k) (H := Q) (CommAlgCat.of k k),
+        Comodule.basePointsRepresentation (R := k) (H := Q) M g m = m := by
+      intro g
+      let n := CommHopfAlgCat.quotientPointsHom H I (CommAlgCat.of k k) g
+      have hn := (mem_pointFixedSubmodule I m).mp hm
+        ⟨n, CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H I
+          (CommAlgCat.of k k) g⟩
+      rw [Comodule.basePointsRepresentation_corestrict q g, hinclude]
+      exact hn
+    have hcoact :=
+      (Comodule.coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq m).2 hfixed
+    simpa only [Comodule.corestrict_coact_apply] using hcoact
+  · exact mem_pointFixedSubmodule_of_quotient_coact_eq_tmul_one I m
 
 end GeometricDetection
 
@@ -145,46 +174,67 @@ namespace IsNormal
 
 variable {I : HopfIdeal R H}
 
-/-- Mathlib's representation on the invariants, specialized to the point subgroup cut out by a
-normal closed subgroup. -/
-abbrev pointFixedSubrepresentation (hI : I.IsNormal) :
-    Representation R
-      (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-      (I.pointFixedSubmodule (M := M)) :=
-  let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
-    (CommAlgCat.of R R)
-  let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal
-    (_root_.CommHopfAlgCat.of R H) I hI (CommAlgCat.of R R)
-  (Comodule.basePointsRepresentation (R := R) (H := H) M).toInvariants N
-
 /-- Every ambient base-valued point sends a point-fixed vector to another point-fixed vector. -/
 theorem basePointsRepresentation_mem_pointFixedSubmodule (hI : I.IsNormal)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    {m : M} (hm : m ∈ I.pointFixedSubmodule (M := M)) :
+    {m : M} (hm : m ∈ I.pointFixedSubmodule M) :
     Comodule.basePointsRepresentation (R := R) (H := H) M g m ∈
-      I.pointFixedSubmodule (M := M) := by
+      I.pointFixedSubmodule M := by
   let N := CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H) I
     (CommAlgCat.of R R)
   let _ : N.Normal := CommHopfAlgCat.quotientPointsSubgroup_normal
     (_root_.CommHopfAlgCat.of R H) I hI (CommAlgCat.of R R)
-  change m ∈ Representation.invariants
-    ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp N.subtype) at hm
-  change Comodule.basePointsRepresentation (R := R) (H := H) M g m ∈
-    Representation.invariants
-      ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp N.subtype)
-  exact Representation.le_comap_invariants
-    (Comodule.basePointsRepresentation (R := R) (H := H) M) N g hm
+  have hm' : m ∈ Representation.invariants
+      ((Comodule.basePointsRepresentation (R := R) (H := H) M).comp N.subtype) := by
+    simpa only [pointFixedSubmodule_def] using hm
+  have hstable := Representation.le_comap_invariants
+    (Comodule.basePointsRepresentation (R := R) (H := H) M) N g hm'
+  simpa only [Submodule.mem_comap, pointFixedSubmodule_def] using hstable
+
+variable (M) in
+/-- The representation of the full group of base-valued points on the vectors fixed by the point
+subgroup cut out by the normal Hopf ideal `I`. Normality makes this submodule ambient-stable. -/
+noncomputable def pointFixedSubrepresentation (hI : I.IsNormal) :
+    Representation R
+      (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+      (I.pointFixedSubmodule M) :=
+  Representation.subrepresentation
+    (Comodule.basePointsRepresentation (R := R) (H := H) M)
+    (I.pointFixedSubmodule M) fun g _ hm =>
+        basePointsRepresentation_mem_pointFixedSubmodule hI g hm
+
+/-- The action on the point-fixed subrepresentation is the ambient base-point action. -/
+@[simp]
+theorem pointFixedSubrepresentation_apply_coe (hI : I.IsNormal)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
+    (m : I.pointFixedSubmodule M) :
+    ((hI.pointFixedSubrepresentation M g m : I.pointFixedSubmodule M) : M) =
+      Comodule.basePointsRepresentation (R := R) (H := H) M g m := by
+  rfl
+
+/-- The scalar extension of the point-fixed submodule is stable under every ambient point
+endomorphism. -/
+theorem endOfPoint_le_comap_pointFixedSubmodule_baseChange (hI : I.IsNormal)
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) :
+    (I.pointFixedSubmodule M).baseChange R ≤
+      ((I.pointFixedSubmodule M).baseChange R).comap (Comodule.endOfPoint M g.ofConv) := by
+  rw [Submodule.baseChange_eq_span]
+  refine Submodule.span_le.2 ?_
+  rintro _ ⟨m, hm, rfl⟩
+  change Comodule.endOfPoint M g.ofConv (1 ⊗ₜ[R] m) ∈
+    Submodule.span R ((I.pointFixedSubmodule M).map (TensorProduct.mk R R M 1))
+  rw [Comodule.endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation]
+  exact Submodule.subset_span ⟨_, basePointsRepresentation_mem_pointFixedSubmodule hI g hm, rfl⟩
 
 /-- Scalar-extension form of the stability of normal-subgroup fixed vectors. This is the shape
 needed by geometric point-separation criteria for promoting a submodule to a subcomodule. -/
-theorem endOfPoint_tmul_mem_pointFixedSubmodule_baseChange (hI : I.IsNormal)
+theorem endOfPoint_one_tmul_mem_pointFixedSubmodule_baseChange (hI : I.IsNormal)
     (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R))
-    {m : M} (hm : m ∈ I.pointFixedSubmodule (M := M)) :
+    {m : M} (hm : m ∈ I.pointFixedSubmodule M) :
     Comodule.endOfPoint M g.ofConv (1 ⊗ₜ[R] m) ∈
-      (I.pointFixedSubmodule (M := M)).baseChange R := by
-  rw [Comodule.endOfPoint_one_tmul_eq_tmul_basePointsRepresentation]
-  exact Submodule.tmul_mem_baseChange_of_mem _
-    (basePointsRepresentation_mem_pointFixedSubmodule hI g hm)
+      (I.pointFixedSubmodule M).baseChange R :=
+  endOfPoint_le_comap_pointFixedSubmodule_baseChange hI g
+    (Submodule.tmul_mem_baseChange_of_mem _ hm)
 
 end IsNormal
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
+public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.PointsAction
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
@@ -20,7 +21,8 @@ a comodule (`TauCeti.Comodule.endOfPoint`,
 `TauCeti.Comodule.pointsRepresentation`) lands in the units of the endomorphism
 monoid: the action upgrades to linear automorphisms of the scalar extension via
 `Representation.asGroupHom`, with inverses provided by the group structure rather
-than by an antipode computation.
+than by an antipode computation. For points valued in the base ring, the scalar-extension
+action transports across `R ⊗[R] V ≃ₗ[R] V` to a representation on `V` itself.
 
 ## Main declarations
 
@@ -29,9 +31,13 @@ than by an antipode computation.
 * `TauCeti.Comodule.pointsAction_corestrict`: compatibility of point actions with
   corestriction and precomposition, also provided for bundled finite comodules by
   `TauCeti.Comodule.pointsAction_corestrict_obj`.
+* `TauCeti.Comodule.basePointsRepresentation`: the action of base-valued points on the original
+  comodule.
 -/
 
 public section
+
+open scoped TensorProduct
 
 namespace TauCeti
 
@@ -64,6 +70,80 @@ lemma pointsAction_toLinearMap (g : WithConv (H →ₐ[R] A)) :
     Representation.asGroupHom_apply, pointsRepresentation_apply]
 
 universe u v w x y
+
+section BasePointsRepresentation
+
+variable {R : Type u} {H : Type v}
+variable [CommRing R] [Semiring H] [HopfAlgebra R H]
+
+/-- The representation of the group of base-valued points on the original comodule.
+
+`pointsRepresentation` acts on `R ⊗[R] M`; this is its transport across the canonical
+equivalence `R ⊗[R] M ≃ₗ[R] M`. -/
+noncomputable def basePointsRepresentation
+    (M : Type w) [AddCommMonoid M] [Module R M] [Comodule R H M] :
+    Representation R (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) M where
+  toFun g :=
+    (TensorProduct.lid R M).toLinearMap ∘ₗ
+      pointsRepresentation M g ∘ₗ
+        (TensorProduct.lid R M).symm.toLinearMap
+  map_one' := by
+    rw [map_one]
+    ext m
+    simp
+  map_mul' g h := by
+    rw [map_mul]
+    ext m
+    simp only [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap, Module.End.mul_apply,
+      LinearEquiv.symm_apply_apply]
+
+variable {M : Type w} [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- A base-valued point acts on `m` by contracting the coefficient leg of its coaction. -/
+@[simp]
+theorem basePointsRepresentation_apply (g : HopfAlgebra.points
+    (R := R) (H := H) (CommAlgCat.of R R)) (m : M) :
+    basePointsRepresentation (H := H) M g m =
+      TensorProduct.lid R M (endOfPoint M g.ofConv (1 ⊗ₜ[R] m)) := by
+  -- Expose the transported action once so `pointsRepresentation_apply` can rewrite it.
+  change (TensorProduct.lid R M)
+    (pointsRepresentation M g ((TensorProduct.lid R M).symm m)) = _
+  rw [pointsRepresentation_apply]
+  simp
+
+/-- The scalar-extension action of a base-valued point is the pure tensor of its action on the
+original comodule. -/
+theorem endOfPoint_one_tmul_eq_tmul_basePointsRepresentation
+    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (m : M) :
+    endOfPoint M g.ofConv (1 ⊗ₜ[R] m) =
+      1 ⊗ₜ[R] basePointsRepresentation (H := H) M g m := by
+  apply (TensorProduct.lid R M).injective
+  rw [basePointsRepresentation_apply]
+  simp
+
+section Corestrict
+
+variable {H₁ : Type v} {H₂ : Type x} [Semiring H₁] [Semiring H₂]
+variable [HopfAlgebra R H₁] [HopfAlgebra R H₂]
+variable {M : Type w} [AddCommMonoid M] [Module R M] [Comodule R H₁ M]
+
+/-- Acting by a base-valued point on a corestricted comodule agrees with acting by the point
+precomposed with the bialgebra morphism. -/
+theorem basePointsRepresentation_corestrict (φ : H₁ →ₐc[R] H₂)
+    (g : HopfAlgebra.points (R := R) (H := H₂) (CommAlgCat.of R R)) :
+    (letI : Comodule R H₂ M := Corestrict φ.toCoalgHom
+     basePointsRepresentation (R := R) (H := H₂) M g) =
+      basePointsRepresentation (R := R) (H := H₁) M (AlgHom.mapDomain φ g) := by
+  let _ : Comodule R H₂ M := Corestrict φ.toCoalgHom
+  apply LinearMap.ext
+  intro m
+  rw [basePointsRepresentation_apply, basePointsRepresentation_apply]
+  congr 1
+  exact LinearMap.congr_fun (endOfPoint_corestrict φ g.ofConv) (1 ⊗ₜ[R] m)
+
+end Corestrict
+
+end BasePointsRepresentation
 
 section Corestrict
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -9,7 +9,7 @@ public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
 public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Corestrict
-public import TauCeti.Algebra.Coalgebra.Comodule.PointsAction
+public import TauCeti.Algebra.Coalgebra.Comodule.PointAction
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 
 /-!
@@ -33,6 +33,10 @@ action transports across `R ⊗[R] V ≃ₗ[R] V` to a representation on `V` its
   `TauCeti.Comodule.pointsAction_corestrict_obj`.
 * `TauCeti.Comodule.basePointsRepresentation`: the action of base-valued points on the original
   comodule.
+* `TauCeti.Comodule.coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq`: geometric fixed-vector
+  detection in terms of the convolution-group action.
+* `TauCeti.Comodule.coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq`: base-valued points
+  detect fixed vectors over an algebraically closed base field.
 -/
 
 public section
@@ -74,47 +78,34 @@ universe u v w x y
 section BasePointsRepresentation
 
 variable {R : Type u} {H : Type v}
-variable [CommRing R] [Semiring H] [HopfAlgebra R H]
+variable [CommSemiring R] [Semiring H] [HopfAlgebra R H]
 
 /-- The representation of the group of base-valued points on the original comodule.
 
 `pointsRepresentation` acts on `R ⊗[R] M`; this is its transport across the canonical
 equivalence `R ⊗[R] M ≃ₗ[R] M`. -/
 noncomputable def basePointsRepresentation
-    (M : Type w) [AddCommMonoid M] [Module R M] [Comodule R H M] :
-    Representation R (HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) M where
-  toFun g :=
-    (TensorProduct.lid R M).toLinearMap ∘ₗ
-      pointsRepresentation M g ∘ₗ
-        (TensorProduct.lid R M).symm.toLinearMap
-  map_one' := by
-    rw [map_one]
-    ext m
-    simp
-  map_mul' g h := by
-    rw [map_mul]
-    ext m
-    simp only [LinearMap.comp_apply, LinearEquiv.coe_toLinearMap, Module.End.mul_apply,
-      LinearEquiv.symm_apply_apply]
+    (M : Type w) [AddCommMonoid M] [Module R M] [Comodule R H M] :=
+  (TensorProduct.lid R M).conjRingEquiv.toMonoidHom.comp
+    (pointsRepresentation (R := R) (H := H) (A := R) M)
 
 variable {M : Type w} [AddCommMonoid M] [Module R M] [Comodule R H M]
 
 /-- A base-valued point acts on `m` by contracting the coefficient leg of its coaction. -/
-@[simp]
-theorem basePointsRepresentation_apply (g : HopfAlgebra.points
-    (R := R) (H := H) (CommAlgCat.of R R)) (m : M) :
+theorem basePointsRepresentation_apply (g : WithConv (H →ₐ[R] R)) (m : M) :
     basePointsRepresentation (H := H) M g m =
       TensorProduct.lid R M (endOfPoint M g.ofConv (1 ⊗ₜ[R] m)) := by
-  -- Expose the transported action once so `pointsRepresentation_apply` can rewrite it.
-  change (TensorProduct.lid R M)
-    (pointsRepresentation M g ((TensorProduct.lid R M).symm m)) = _
-  rw [pointsRepresentation_apply]
+  -- Unpack the `conjRingEquiv` transport to apply its characteristic evaluation lemma.
+  change (TensorProduct.lid R M).conj
+    (pointsRepresentation (R := R) (H := H) (A := R) M g) m = _
+  rw [LinearEquiv.conj_apply_apply, pointsRepresentation_apply]
   simp
 
 /-- The scalar-extension action of a base-valued point is the pure tensor of its action on the
 original comodule. -/
-theorem endOfPoint_one_tmul_eq_tmul_basePointsRepresentation
-    (g : HopfAlgebra.points (R := R) (H := H) (CommAlgCat.of R R)) (m : M) :
+@[simp]
+theorem endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation
+    (g : WithConv (H →ₐ[R] R)) (m : M) :
     endOfPoint M g.ofConv (1 ⊗ₜ[R] m) =
       1 ⊗ₜ[R] basePointsRepresentation (H := H) M g m := by
   apply (TensorProduct.lid R M).injective
@@ -129,8 +120,9 @@ variable {M : Type w} [AddCommMonoid M] [Module R M] [Comodule R H₁ M]
 
 /-- Acting by a base-valued point on a corestricted comodule agrees with acting by the point
 precomposed with the bialgebra morphism. -/
+@[simp]
 theorem basePointsRepresentation_corestrict (φ : H₁ →ₐc[R] H₂)
-    (g : HopfAlgebra.points (R := R) (H := H₂) (CommAlgCat.of R R)) :
+    (g : WithConv (H₂ →ₐ[R] R)) :
     (letI : Comodule R H₂ M := Corestrict φ.toCoalgHom
      basePointsRepresentation (R := R) (H := H₂) M g) =
       basePointsRepresentation (R := R) (H := H₁) M (AlgHom.mapDomain φ g) := by
@@ -144,6 +136,62 @@ theorem basePointsRepresentation_corestrict (φ : H₁ →ₐc[R] H₂)
 end Corestrict
 
 end BasePointsRepresentation
+
+section BasePointsFixed
+
+variable {R : Type u} {H : Type v} {M : Type w}
+variable [CommSemiring R] [Semiring H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- A vector fixed by the coaction is fixed by every base-valued point. -/
+theorem basePointsRepresentation_eq_of_coact_eq_tmul_one
+    (m : M) (hm : coact (R := R) (C := H) m = m ⊗ₜ[R] (1 : H))
+    (g : WithConv (H →ₐ[R] R)) :
+    basePointsRepresentation (R := R) (H := H) M g m = m := by
+  rw [basePointsRepresentation_apply, endOfPoint_tmul, hm]
+  simp
+
+end BasePointsFixed
+
+section FixedVectorDetection
+
+variable {k : Type u} {H : Type v} {M : Type w} {K : Type x}
+variable [Field k] [CommRing H] [HopfAlgebra k H] [Algebra.FiniteType k H] [IsReduced H]
+variable [AddCommGroup M] [Module k M] [Comodule k H M]
+variable [Field K] [Algebra k K] [IsAlgClosed K]
+
+/-- For a Hopf-algebra comodule, a vector is fixed by the coaction exactly when every point in the
+convolution group fixes its scalar extension. -/
+theorem coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (m : M) :
+    coact (R := k) (C := H) m = m ⊗ₜ[k] (1 : H) ↔
+      ∀ g : WithConv (H →ₐ[k] K),
+        pointsAction M g ((1 : K) ⊗ₜ[k] m) = (1 : K) ⊗ₜ[k] m := by
+  rw [coact_eq_tmul_one_iff_forall_endOfPoint_tmul_eq (K := K)]
+  constructor
+  · intro h g
+    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap]
+    exact h g.ofConv
+  · intro h g
+    have hg := h (toConv g)
+    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap] at hg
+    simpa only [ofConv_toConv] using hg
+
+/-- Over an algebraically closed base field, base-valued points detect fixed vectors of a
+reduced finite-type Hopf-algebra comodule. -/
+theorem coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq [IsAlgClosed k] (m : M) :
+    coact (R := k) (C := H) m = m ⊗ₜ[k] (1 : H) ↔
+      ∀ g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k),
+        basePointsRepresentation (R := k) (H := H) M g m = m := by
+  constructor
+  · intro hm g
+    exact basePointsRepresentation_eq_of_coact_eq_tmul_one m hm g
+  · intro h
+    rw [coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (K := k)]
+    intro g
+    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap,
+      endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation, h g]
+
+end FixedVectorDetection
 
 section Corestrict
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -106,7 +106,8 @@ original comodule. -/
 @[simp]
 theorem endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation
     (g : WithConv (H →ₐ[R] R)) (m : M) :
-    endOfPoint M g.ofConv (1 ⊗ₜ[R] m) =
+    (TensorProduct.comm R M R)
+        ((LinearMap.lTensor M g.ofConv.toLinearMap) (coact (R := R) (C := H) m)) =
       1 ⊗ₜ[R] basePointsRepresentation (H := H) M g m := by
   apply (TensorProduct.lid R M).injective
   rw [basePointsRepresentation_apply]
@@ -189,6 +190,7 @@ theorem coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq [IsAlgClosed k]
     rw [coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (K := k)]
     intro g
     rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap,
+      endOfPoint_tmul, one_smul,
       endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation, h g]
 
 end FixedVectorDetection

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointAction.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
-public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
+public import TauCeti.Algebra.Coalgebra.Comodule.PointsAction
 import TauCeti.Algebra.Coalgebra.Comodule.Evaluation
 import TauCeti.RingTheory.FiniteType.PointSeparation
 
@@ -23,19 +23,15 @@ coefficient of `m` to its trivial-comodule value. Reduced finite-type point sepa
 identifies those coefficients in `H`. A finite-dimensional subspace containing the single tensor
 `coact m - m ⊗ 1` has enough coordinate functionals to show that this tensor vanishes.
 
-For a Hopf algebra this is restated using the group action of its convolution group of points.
-This is the bridge in the Kolchin induction for Layer 5 of the ReductiveGroups roadmap: a common
-fixed vector obtained from the geometric point representation is thereby promoted to a fixed
-vector of the comodule itself.
+The representation-level restatements live in
+`TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction`. This criterion is the bridge in the
+Kolchin induction for Layer 5 of the ReductiveGroups roadmap: a common fixed vector obtained from
+the geometric point representation is thereby promoted to a fixed vector of the comodule itself.
 
 ## Main declarations
 
 * `TauCeti.Comodule.coact_eq_tmul_one_iff_forall_endOfPoint_tmul_eq`: geometric-point detection of
   a fixed vector for a bialgebra comodule.
-* `TauCeti.Comodule.coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq`: the same criterion for the
-  convolution-group action of a Hopf algebra.
-* `TauCeti.Comodule.coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq`: base-valued points
-  detect fixed vectors over an algebraically closed base field.
 
 ## References
 
@@ -98,56 +94,6 @@ theorem coact_eq_tmul_one_iff_forall_endOfPoint_tmul_eq (m : M) :
     rw [← hz', hz'zero, map_zero]
 
 end Bialgebra
-
-section HopfAlgebra
-
-variable {k : Type u} {H : Type v} {M : Type w} {K : Type x}
-variable [Field k] [CommRing H] [HopfAlgebra k H] [Algebra.FiniteType k H] [IsReduced H]
-variable [AddCommGroup M] [Module k M] [Comodule k H M]
-variable [Field K] [Algebra k K] [IsAlgClosed K]
-
-/-- For a Hopf-algebra comodule, a vector is fixed by the coaction exactly when every point in the
-convolution group fixes its scalar extension. -/
-theorem coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (m : M) :
-    coact (R := k) (C := H) m = m ⊗ₜ[k] (1 : H) ↔
-      ∀ g : WithConv (H →ₐ[k] K),
-        pointsAction M g ((1 : K) ⊗ₜ[k] m) = (1 : K) ⊗ₜ[k] m := by
-  rw [coact_eq_tmul_one_iff_forall_endOfPoint_tmul_eq (K := K)]
-  constructor
-  · intro h g
-    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap]
-    exact h g.ofConv
-  · intro h g
-    have hg := h (toConv g)
-    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap] at hg
-    simpa only [ofConv_toConv] using hg
-
-end HopfAlgebra
-
-section BasePointsRepresentation
-
-variable {k : Type u} {H : Type v} {M : Type w}
-variable [Field k] [CommRing H] [HopfAlgebra k H] [Algebra.FiniteType k H] [IsReduced H]
-variable [AddCommGroup M] [Module k M] [Comodule k H M] [IsAlgClosed k]
-
-/-- Over an algebraically closed base field, base-valued points detect fixed vectors of a
-reduced finite-type Hopf-algebra comodule. -/
-theorem coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq (m : M) :
-    coact (R := k) (C := H) m = m ⊗ₜ[k] (1 : H) ↔
-      ∀ g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k),
-        basePointsRepresentation (R := k) (H := H) M g m = m := by
-  rw [coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (K := k)]
-  constructor
-  · intro h g
-    have hg := h g
-    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap] at hg
-    have := congrArg (TensorProduct.lid k M) hg
-    exact (basePointsRepresentation_apply g m).trans (by simpa using this)
-  · intro h g
-    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap,
-      endOfPoint_one_tmul_eq_tmul_basePointsRepresentation, h g]
-
-end BasePointsRepresentation
 
 end
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointAction.lean
@@ -34,6 +34,8 @@ vector of the comodule itself.
   a fixed vector for a bialgebra comodule.
 * `TauCeti.Comodule.coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq`: the same criterion for the
   convolution-group action of a Hopf algebra.
+* `TauCeti.Comodule.coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq`: base-valued points
+  detect fixed vectors over an algebraically closed base field.
 
 ## References
 
@@ -121,6 +123,31 @@ theorem coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (m : M) :
     simpa only [ofConv_toConv] using hg
 
 end HopfAlgebra
+
+section BasePointsRepresentation
+
+variable {k : Type u} {H : Type v} {M : Type w}
+variable [Field k] [CommRing H] [HopfAlgebra k H] [Algebra.FiniteType k H] [IsReduced H]
+variable [AddCommGroup M] [Module k M] [Comodule k H M] [IsAlgClosed k]
+
+/-- Over an algebraically closed base field, base-valued points detect fixed vectors of a
+reduced finite-type Hopf-algebra comodule. -/
+theorem coact_eq_tmul_one_iff_forall_basePointsRepresentation_eq (m : M) :
+    coact (R := k) (C := H) m = m ⊗ₜ[k] (1 : H) ↔
+      ∀ g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k),
+        basePointsRepresentation (R := k) (H := H) M g m = m := by
+  rw [coact_eq_tmul_one_iff_forall_pointsAction_tmul_eq (K := k)]
+  constructor
+  · intro h g
+    have hg := h g
+    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap] at hg
+    have := congrArg (TensorProduct.lid k M) hg
+    exact (basePointsRepresentation_apply g m).trans (by simpa using this)
+  · intro h g
+    rw [← LinearEquiv.coe_toLinearMap, pointsAction_toLinearMap,
+      endOfPoint_one_tmul_eq_tmul_basePointsRepresentation, h g]
+
+end BasePointsRepresentation
 
 end
 


### PR DESCRIPTION
This PR equips the fixed vectors of a normal closed subgroup with the ambient base-point representation. For a comodule `M` over a commutative Hopf algebra `H`, `TauCeti.Comodule.basePointsRepresentation` transports the existing action of `H(R)` from `R ⊗[R] M` back to `M`, and `TauCeti.HopfIdeal.pointFixedSubmodule` takes the invariants of the point subgroup cut out by a Hopf ideal `I`. If `I` is normal, `TauCeti.HopfIdeal.IsNormal.pointFixedSubrepresentation` restricts the full ambient action to this submodule, with elementwise and scalar-extension stability lemmas for downstream use.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, “Reductive and semisimple groups,” together with the worked-example target to prove `GLₙ` reductive by the geometric condition that it has no nontrivial connected normal smooth unipotent subgroup. The standard direct argument takes the fixed vectors of such a subgroup in the standard representation; normality must make that fixed space an ambient `GLₙ`-subrepresentation before simplicity and faithfulness can force the subgroup to be trivial. This is the most effective distinct step because open PR #4263 supplies the faithful simple standard comodule and open PR #4266 supplies the point-separation promotion of a stable submodule to a subcomodule, while neither supplies the normality-to-stability argument here.

Over an algebraically closed field, `mem_pointFixedSubmodule_iff_quotient_coact_eq_tmul_one` proves that the pointwise definition agrees with the scheme-theoretic fixed-vector condition when the quotient coordinate ring is reduced and of finite type. Thus the interface does not identify rational-point invariants with subgroup-scheme invariants without the hypotheses that make point separation valid.

After this PR, the Layer 6 worked example still needs the open point-separation and standard-comodule work to land, then their combination with this module and the existing Kolchin fixed-vector theorem to prove `GLₙ` reductive; the characteristic-zero comparison between reductivity and linear reductivity also remains.

The implementation reuses Mathlib’s `Representation.invariants` and `Representation.le_comap_invariants` for the abstract normal-subgroup theorem, Tau Ceti’s `CommHopfAlgCat.quotientPointsSubgroup_normal` for pointwise normality, and the existing comodule point-action and geometric point-separation APIs. No Mathlib source or external formalization is vendored. The mathematical organization follows Jantzen, *Representations of Algebraic Groups*, I.2, and Springer, *Linear Algebraic Groups*, §2.2, as cited in the module documentation.

Adds `TauCeti/Algebra/AlgebraicGroup/Representation/NormalInvariants.lean` (297 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"normal-subgroup-invariants-subrepresentation"}-->

🤖 Prepared with Codex
