### PR TITLE
feat(LinearAlgebra): the adjugate as a map on the general linear group

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Adjugate.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Adjugate.lean
@@ -20,7 +20,9 @@ on the nose. That keeps the construction over an arbitrary commutative ring — 
 `det ≠ 0` side condition, and nothing to discharge at a call site.
 
 Over a group of determinant-one matrices it is the inverse, and in size two it is an
-involution; those are the two facts that make it an anti-involution of a Hecke pair.
+involution. Those are the two ingredients a Hecke-pair anti-involution needs from the adjugate;
+the anti-involution itself also requires stability of the group and the monoid under the map,
+which is proved where those objects live, not here.
 
 ## Main definitions
 
@@ -28,9 +30,19 @@ involution; those are the two facts that make it an anti-involution of a Hecke p
 
 ## Main results
 
-* `TauCeti.adjugateGL_mul`: `adj(gh) = adj(h) adj(g)`.
+* `TauCeti.adjugateGL_one`, `TauCeti.adjugateGL_mul`: `adj(1) = 1` and `adj(gh) = adj(h) adj(g)`.
 * `TauCeti.adjugateGL_eq_inv`: on determinant one, `adj(g) = g⁻¹`.
 * `TauCeti.adjugateGL_adjugateGL`: in size two, `adj` is an involution.
+
+## References
+
+* Adapted from the AINTLIB `LeanModularForms` project (Chris Birkbeck), Apache-2.0,
+  [`HeckeRIngs/GL2/HeckeActionGeneral.lean`](https://github.com/CBirkbeck/AINTLIB) at commit
+  `2baa76f742bdb4fb8ee323fabba41203bd390e08`, declarations `GL_adjugate`, `GL_adjugate_val`,
+  `GL_adjugate_mul`, `GL_adjugate_involutive` and `GL_adjugate_eq_inv_of_det_one`. The source
+  is stated for `GL (Fin 2) ℚ` and builds the element with a `det ≠ 0` obligation; here the
+  inverse is exhibited directly, which removes that obligation and generalises the statements
+  to `GL n R` over a commutative ring.
 -/
 
 public section
@@ -54,8 +66,13 @@ def adjugateGL (g : GL n R) : GL n R where
 @[simp] lemma adjugateGL_val (g : GL n R) :
     (adjugateGL g : Matrix n n R) = adjugate (g : Matrix n n R) := by rfl
 
+/-- **The adjugate fixes the identity.** -/
+@[simp] lemma adjugateGL_one : adjugateGL (1 : GL n R) = 1 := by
+  ext
+  simp [adjugateGL_val]
+
 /-- **The adjugate is anti-multiplicative**, inherited entrywise from `Matrix.adjugate`. -/
-lemma adjugateGL_mul (g h : GL n R) : adjugateGL (g * h) = adjugateGL h * adjugateGL g := by
+@[simp] lemma adjugateGL_mul (g h : GL n R) : adjugateGL (g * h) = adjugateGL h * adjugateGL g := by
   ext
   simp [Units.val_mul, adjugate_mul_distrib]
 
@@ -66,7 +83,7 @@ lemma adjugateGL_eq_inv {g : GL n R} (hg : (g : Matrix n n R).det = 1) : adjugat
   rw [adjugateGL_val, Matrix.coe_units_inv, Matrix.inv_def, hg, Ring.inverse_one, one_smul]
 
 /-- **In size two the adjugate is an involution.** `adjugate` squares to
-`det ^ (card n - 2) • id`, and the exponent vanishes exactly here. -/
+`det ^ (card n - 2) • id`, and the size-two hypothesis makes that exponent vanish. -/
 lemma adjugateGL_adjugateGL (h2 : Fintype.card n = 2) (g : GL n R) :
     adjugateGL (adjugateGL g) = g := by
   ext

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Adjugate.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Adjugate.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- `Matrix.adjugate` and its multiplicativity `Matrix.adjugate_mul_distrib` are the content.
+public import Mathlib.LinearAlgebra.Matrix.Adjugate
+-- `GL` occurs in the statements below.
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+
+/-!
+# The adjugate of an invertible matrix
+
+The adjugate of an invertible matrix is invertible, so `Matrix.adjugate` restricts to a map
+`GL n R → GL n R`. Its inverse is exhibited directly, without dividing by the determinant:
+`adjugate` is anti-multiplicative and sends `1` to `1`, so `adjugate g⁻¹` inverts `adjugate g`
+on the nose. That keeps the construction over an arbitrary commutative ring — no field, no
+`det ≠ 0` side condition, and nothing to discharge at a call site.
+
+Over a group of determinant-one matrices it is the inverse, and in size two it is an
+involution; those are the two facts that make it an anti-involution of a Hecke pair.
+
+## Main definitions
+
+* `TauCeti.adjugateGL`: the adjugate as a map `GL n R → GL n R`.
+
+## Main results
+
+* `TauCeti.adjugateGL_mul`: `adj(gh) = adj(h) adj(g)`.
+* `TauCeti.adjugateGL_eq_inv`: on determinant one, `adj(g) = g⁻¹`.
+* `TauCeti.adjugateGL_adjugateGL`: in size two, `adj` is an involution.
+-/
+
+public section
+
+namespace TauCeti
+
+open Matrix
+
+variable {n R : Type*} [DecidableEq n] [Fintype n] [CommRing R]
+
+/-- **The adjugate of an invertible matrix**, again invertible.
+
+The inverse is `adjugate g⁻¹` rather than anything built from the determinant: `adjugate` is
+anti-multiplicative, so the two adjugates multiply to `adjugate (g⁻¹ g) = adjugate 1 = 1`. -/
+def adjugateGL (g : GL n R) : GL n R where
+  val := adjugate (g : Matrix n n R)
+  inv := adjugate ((g⁻¹ : GL n R) : Matrix n n R)
+  val_inv := by rw [← adjugate_mul_distrib, Units.inv_mul, adjugate_one]
+  inv_val := by rw [← adjugate_mul_distrib, Units.mul_inv, adjugate_one]
+
+@[simp] lemma adjugateGL_val (g : GL n R) :
+    (adjugateGL g : Matrix n n R) = adjugate (g : Matrix n n R) := by rfl
+
+/-- **The adjugate is anti-multiplicative**, inherited entrywise from `Matrix.adjugate`. -/
+lemma adjugateGL_mul (g h : GL n R) : adjugateGL (g * h) = adjugateGL h * adjugateGL g := by
+  ext
+  simp [Units.val_mul, adjugate_mul_distrib]
+
+/-- **On determinant one the adjugate is the inverse.** This is what makes it restrict to a
+group of determinant-one matrices, where it is then an anti-automorphism. -/
+lemma adjugateGL_eq_inv {g : GL n R} (hg : (g : Matrix n n R).det = 1) : adjugateGL g = g⁻¹ := by
+  ext
+  rw [adjugateGL_val, Matrix.coe_units_inv, Matrix.inv_def, hg, Ring.inverse_one, one_smul]
+
+/-- **In size two the adjugate is an involution.** `adjugate` squares to
+`det ^ (card n - 2) • id`, and the exponent vanishes exactly here. -/
+lemma adjugateGL_adjugateGL (h2 : Fintype.card n = 2) (g : GL n R) :
+    adjugateGL (adjugateGL g) = g := by
+  ext
+  rw [adjugateGL_val, adjugateGL_val, adjugate_adjugate _ (by rw [h2]; norm_num), h2]
+  simp
+
+end TauCeti


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"gl-adjugate-antiinvolution"}-->

The adjugate of an invertible matrix is invertible, so `Matrix.adjugate` restricts to a map on
`GL`:

```lean
def adjugateGL (g : GL n R) : GL n R

@[simp] lemma adjugateGL_one : adjugateGL (1 : GL n R) = 1
@[simp] lemma adjugateGL_mul (g h : GL n R) : adjugateGL (g * h) = adjugateGL h * adjugateGL g
lemma adjugateGL_eq_inv {g : GL n R} (hg : (g : Matrix n n R).det = 1) : adjugateGL g = g⁻¹
lemma adjugateGL_adjugateGL (h2 : Fintype.card n = 2) (g : GL n R) :
    adjugateGL (adjugateGL g) = g
```

An anti-monoid map, equal to the inverse on determinant one, and involutive in size two.
Those are the ingredients a Hecke-pair anti-involution needs *from the adjugate*; the
anti-involution itself also needs stability of the group and the monoid under the map, which
is proved where those objects live and is not claimed here.

## The inverse is exhibited, not divided out

The obvious construction is `adj(g) = det(g) • g⁻¹`, which needs the determinant to be
invertible and therefore wants a field, or at least a side condition to discharge at every call
site. It is unnecessary. `Matrix.adjugate` is anti-multiplicative and fixes `1`, so

```
adjugate g * adjugate g⁻¹ = adjugate (g⁻¹ * g) = adjugate 1 = 1
```

exhibits the inverse directly. Both `Units` fields are one `rw` each, and the definition lands
over an **arbitrary commutative ring** with no `det ≠ 0` hypothesis anywhere in the file. The
determinant only reappears where the mathematics genuinely needs it, in `adjugateGL_eq_inv`.

Concretely that is the difference between

```lean
GeneralLinearGroup.mkOfDetNeZero (adjugate g.val) (by rw [det_adjugate, ...]; simpa using g.det_ne_zero)
```

over `ℚ` at `n = 2`, and a `Units.mk` over `CommRing R` at general `n`.

## Why `Fintype.card n = 2` rather than `n = Fin 2`

`Matrix.adjugate_adjugate` gives `adj(adj A) = A.det ^ (card n - 2) • A`, so involutivity
follows once that exponent vanishes — a condition on the *cardinality* of the index type, not
on its identity. (Natural subtraction being truncated, the exponent also vanishes at `card 0`
and `card 1`; the hypothesis here is the size-two one the consumers need.) Stating it that way costs nothing and applies to any index type of size
two, including the `Fin 2` the modular-forms side uses.

## What it is for

`Δ₀(N)` acts on modular forms through double cosets, and the twisting character of the
nebentypus Hecke ring is evaluated on the **adjugate** of a coset representative rather than on
the representative itself — that is what reconciles the upper-left unit of `adj(h)` with the
lower-right unit of `h` for `h ∈ Γ₀(N)`. The source calls that reconciliation `char_bridge`; it
needs `adj` as a map on `GL₂(ℚ)`, its anti-multiplicativity, and its stability on `Γ₀(N)` (which
is `adjugateGL_eq_inv` plus `inv_mem`). This PR supplies that layer and nothing above it.

## Placement

`TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/`, alongside `Diagonal.lean`,
`Transvection.lean` and `Unipotent.lean` — there is no modular-forms content in the file, only
`Matrix.adjugate` and `GL`. The per-import comments follow that directory's house style.

## Absence

Neither Mathlib nor this repo has a `GL`-valued adjugate. Checked by name across the pinned
Mathlib tree (`adjugateGL`, `GeneralLinearGroup.adjugate`, `Units.adjugate` — all zero) and by
object (`adjugate` appears in ten files here, none of them producing a `GL` element), with
`Matrix.adjugate_mul_distrib` (`Mathlib/LinearAlgebra/Matrix/Adjugate.lean:455`) as the positive
control that the search reaches the right tree. All four statements were compiled as a probe
with `sorry` bodies before any proof was written.

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
Apache-2.0, `projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/HeckeActionGeneral.lean`
lines 48–68, declarations `GL_adjugate`, `GL_adjugate_val`, `GL_adjugate_mul`,
`GL_adjugate_involutive`, `GL_adjugate_eq_inv_of_det_one`. Generalised here from `GL₂(ℚ)` to
`GL n R` over a commutative ring, and the `det ≠ 0` obligation in the construction is removed
rather than discharged. The source's `SLnZ`-specific corollaries and its `HeckePairAction` class
are **not** ported: the first follow from `adjugateGL_eq_inv` and `Subgroup.inv_mem` at the call
site, and the second is a bundling decision that belongs with the Hecke pair, not here.

Roadmap target: `TauCetiRoadmap/ModularForms/README.md:1460-1462` names the ring-action layer
`HeckeRIngs/GL2/Unified/{Gamma0RingDn,NebentypusHeckeRingHom,RingTransport,TwistedHeckeRing}.lean`
(`heckeRingDn`, `heckeRingHomCharSpace`); `:405-407` gives the shape
`heckeRingHomCharSpace : 𝕋 (Gamma0_pair N) ℤ →+* Module.End ℂ (modFormCharSpace k χ)`. The
adjugate is the anti-involution that layer's twisting character is evaluated along — CLAUDE.md's
"supplies a prerequisite that a specific target needs". The declarations themselves are general
`GL` infrastructure, stated at the generality where they live rather than at the level the
target happens to need.
