### PR TITLE
ci: retain verified artifacts across cache retries

### DIFF
--- a/scripts/lake-cache-get.sh
+++ b/scripts/lake-cache-get.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # lake-cache-get.sh — restore TauCeti's OWN root-package oleans from the public Lake
 # artifact cache, factored out of .github/workflows/pr-build.yml so ci.yml can use the
-# same logic. Both callers want identical semantics: a clean whole cache, or none at all.
+# same logic. Both callers want identical final semantics: a clean whole cache, or none at all.
 #
 # Usage: bash scripts/lake-cache-get.sh <project-dir>
 #
@@ -18,21 +18,13 @@
 # `lake exe cache get`.
 #
 # A TOTAL miss is non-fatal: the build just recompiles from scratch, as when the cache is off.
-# A PARTIAL fetch is a different matter. `lake cache get` continues past a failed download and
-# exits nonzero (see `lake cache help get`), leaving input-to-output mappings whose artifacts
-# never arrived. pr-build's sandboxed build is offline with no cache service configured, so it
-# cannot fetch them: Lake logs a warning per affected module and correctly rebuilds it from
-# source, but `lake build --iofail` is `--fail-level=info`, so those warnings fail a build in
-# which every module compiled. Partial fetches are routine: they cost about a third of
-# merge-group builds their cache. Fixed by https://github.com/leanprover/lean4/pull/14651,
-# landing in v4.34.0-rc1; see https://github.com/TauCetiProject/TauCeti/issues/2062.
-#
-# Hence: retry from an EMPTY cache each time, then fall back to no cache at all. Retrying over
-# the dirty cache a failed attempt left behind does not work: Lake skips any artifact already
-# on disk, so the retry re-fetches only what is still MISSING and never revisits what the failed
-# attempt got wrong. It then reports clean and the corruption survives into the build.
-# Discarding between attempts is what makes a clean verdict mean the cache is whole; it is
-# affordable because a failing attempt aborts in seconds and a full refetch is ~30s.
+# A PARTIAL fetch is non-fatal too, but must not reach the offline build. Since v4.34.0-rc1,
+# Lake downloads to temporary files, verifies their hashes, atomically installs only valid
+# artifacts, and returns failure when any transfer fails. A retry over the same cache therefore
+# preserves verified artifacts and fetches only those still missing. If every attempt fails, we
+# discard the partial cache before the build so its final behavior remains exactly the same as
+# when the cache is switched off. See https://github.com/leanprover/lean4/pull/14651 and
+# https://github.com/TauCetiProject/TauCeti/issues/2062.
 set -euo pipefail
 
 PROJECT_DIR="${1:?usage: lake-cache-get.sh <project-dir>}"
@@ -68,35 +60,15 @@ discard_cache() {
   return 0
 }
 
-# `lake cache get` cannot be judged by exit status alone. Lake accumulates transfer failures
-# into a local `didError` but then tests the stale `s.didError` (Lake/Config/Cache.lean,
-# `if s.didError then failure`), so it can log "failed to download some artifacts" and still
-# exit 0. An attempt therefore counts as clean only if it exits 0 AND logs no failure
-# diagnostic.
-# SIMPLIFY ON THE BUMP TO v4.34.0: that stale read is fixed by
-# https://github.com/leanprover/lean4/pull/14651 ("fix: lake: gracefully handle curl and IO
-# errors during transfer"), which missed v4.33.0-rc2 by hours and was not backported. From
-# v4.34.0-rc1 on, drop FAIL_RE and trust `rc` alone. The purge below outlives that bump: it is
-# for https://github.com/leanprover/lean4/issues/14670, still open.
-#
-# `downloaded artifact hash mismatch` must be here. Lake handles a mismatch by deleting the
-# artifact and setting `didError`, but the stale `didError` read means the process can still
-# exit 0, and the deletion leaves an input-to-output mapping whose artifact is gone. An offline
-# build cannot refetch it, so that entry becomes a build failure rather than a rebuild. Treat it
-# as unclean so the cache is refetched or dropped.
-FAIL_RE='failed to download|output lookup failed|curl exited with code|downloaded artifact hash mismatch'
+# Lake v4.34.0-rc1 and later correctly return failure when any transfer, lookup, or hash check
+# fails. Successful artifacts have already been verified and atomically installed, so they are
+# safe to retain for the next attempt.
 # A revision with no cached build at all is deterministic: retrying cannot change it, and there
 # is nothing partial to discard.
 MISS_RE='no outputs found'
-# Six attempts, not three. Losing every attempt discards the whole cache and forces a ~22 minute
-# full rebuild, which was happening on 4 of 18 sampled builds (the other 14 took 2-3 minutes).
-# The cause is lean4#14698: one unreadable artifact throws out of `computeFileHash`, which has
-# no try/catch, so a single ENOENT aborts the entire fetch and discards every artifact already
-# downloaded. Which artifact trips it varies between attempts, so re-fetching genuinely tends to
-# succeed; at the observed per-attempt failure rate six attempts take whole-cache loss from
-# roughly 22% to roughly 5%. Reduce this again once the fix (lean4#14651) reaches a released
-# toolchain: it is on master only, and v4.33.0-rc2 was branched before it landed.
-ATTEMPTS=6
+# Three attempts are enough now that each retry fetches only artifacts still missing rather than
+# throwing away and redownloading the whole cache.
+ATTEMPTS=3
 clean=0
 for attempt in $(seq 1 $ATTEMPTS); do
   LOG="${RUNNER_TEMP:-/tmp}/cache-get-$attempt.log"
@@ -104,23 +76,15 @@ for attempt in $(seq 1 $ATTEMPTS); do
   ( cd "$PROJECT_DIR" && LAKE_CONFIG="$CFG" lake cache get --service tauceti-public \
       --repo TauCetiProject/TauCeti ) > "$LOG" 2>&1 || rc=$?
   cat "$LOG"
-  if [ "$rc" = 0 ] && ! grep -qE "$FAIL_RE" "$LOG"; then clean=1; break; fi
+  if [ "$rc" = 0 ]; then clean=1; break; fi
   if grep -qE "$MISS_RE" "$LOG"; then break; fi
   # `[ ... ] && sleep` would abort the script under `bash -e` on the last attempt, when the
   # test is false and the whole list returns nonzero. Use a plain `if`.
   if [ "$attempt" != "$ATTEMPTS" ]; then
-    echo "::notice::lake cache get attempt $attempt of $ATTEMPTS did not complete cleanly; discarding the partial cache and retrying"
-    # Sleep BEFORE discarding. A failed `lake cache get` returns as soon as one transfer errors,
-    # while its sibling curl/leantar processes are still writing into the cache dir; discarding
-    # at that instant races them. This is not a throttling backoff: the read endpoint serves
-    # these artifacts byte-identically under 48-way concurrency, so the failures are the Lake bug
-    # above rather than rate limiting, and a short fixed pause is enough to let the stragglers
-    # finish.
-    sleep 10
-    # Must precede the retry: see the header. Without this, attempt N+1 skips every artifact this
-    # attempt already wrote, including the broken ones, and a clean exit from it says nothing
-    # about the entries that made this attempt fail.
-    discard_cache
+    echo "::notice::lake cache get attempt $attempt of $ATTEMPTS did not complete cleanly; retaining verified artifacts and retrying missing ones"
+    # Give a transient connection failure a brief backoff. Lake has waited for curl to exit and
+    # has removed or left uninstalled any invalid temporary artifacts before returning.
+    sleep 2
   fi
 done
 


### PR DESCRIPTION
## Summary

- rely on the Lake v4.34 cache fixes and its corrected exit status
- retain hash-verified, atomically installed artifacts between attempts so retries fetch only missing artifacts
- reduce whole-operation retries from six to three and the transient backoff from ten seconds to two
- preserve the conservative behavior of discarding any partial cache before the source-build fallback

This updates the workaround introduced for #2062 now that Tau Ceti is on v4.34.0-rc1. The script remains fail-safe for the offline build: a cache is either restored cleanly or disabled and removed.

## Testing

- bash syntax check
- git diff whitespace check
- real public-cache restore through cache.taucetiproject.org: 3,098 artifacts restored successfully
- simulated first-attempt connection reset: verified artifact survived and the second attempt recovered
- simulated persistent connection resets: three attempts, partial cache removed, and all three cache-disable environment entries written

This intentionally changes a human-owned scripts path and therefore requires human review.