### PR TITLE
feat: prove the Sard--Smale theorem

### DIFF
--- a/TauCeti/Analysis/Calculus/Sard/OutermostStratum.lean
+++ b/TauCeti/Analysis/Calculus/Sard/OutermostStratum.lean
@@ -382,6 +382,27 @@ theorem ContDiff.dense_compl_image_criticalPoints {n : ℕ∞ω} (hf : ContDiff 
 
 end MorseSard
 
+section EmptyInterior
+
+variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {F : Type v} [NormedAddCommGroup F] [NormedSpace ℝ F] [FiniteDimensional ℝ F]
+  {U : Set E} {f : E → F}
+
+/-- **The Morse--Sard theorem**, in the form that carries no measure-theoretic data: the critical
+values taken on an open set have empty interior. The measure structure used to prove it is chosen
+inside the proof, so the target here carries no `MeasurableSpace` instance; this is the shape in
+which Sard is fed to the fibrewise step of the Sard--Smale theorem, where the target is a
+complement subspace with no measurable structure of its own. -/
+theorem interior_image_criticalPoints_eq_empty {n : ℕ∞ω} (hU : IsOpen U)
+    (hf : ∀ x ∈ U, ContDiffAt ℝ n f x)
+    (hk : ((finrank ℝ E * finrank ℝ E + 1 : ℕ) : ℕ∞ω) ≤ n) :
+    interior (f '' (U ∩ {x | ¬ Surjective (fderiv ℝ f x)})) = ∅ := by
+  borelize F
+  exact Measure.interior_eq_empty_of_null
+    (TauCeti.addHaar_image_criticalPoints_eq_zero (ν := addHaar) hU hf hk)
+
+end EmptyInterior
+
 end TauCeti
 
 end

--- a/TauCeti/Analysis/Calculus/Sard/OutermostStratum.lean
+++ b/TauCeti/Analysis/Calculus/Sard/OutermostStratum.lean
@@ -18,7 +18,9 @@ import TauCeti.MeasureTheory.Measure.LocallyNull
 
 The critical values of a sufficiently smooth map between finite-dimensional real normed spaces
 form a set of additive Haar measure zero, and its regular values are therefore dense. A point is
-critical when the Fréchet derivative there fails to be surjective.
+critical when the Fréchet derivative there fails to be surjective. The conclusion is recorded here
+in a measure-free form as well -- the critical values have empty interior -- for use where the
+target carries no measurable structure of its own.
 
 The strata of the critical set are handled in the neighbouring files, and this one supplies the
 outermost stratum, where the derivative is nonzero but not surjective, together with the assembly
@@ -58,6 +60,8 @@ in the descent, since the inverse function theorem returns a local inverse as sm
 * `TauCeti.ContDiff.addHaar_image_criticalPoints_eq_zero`: **the Morse--Sard theorem**, its global
   form.
 * `TauCeti.ContDiff.dense_compl_image_criticalPoints`: the regular values are dense.
+* `TauCeti.interior_image_criticalPoints_eq_empty`: the measure-free restatement, that the
+  critical values taken on an open set have empty interior.
 
 This is Lane F0 of the analytic Heegaard Floer roadmap, where finite-dimensional Sard is the
 prerequisite for Sard--Smale and hence for every transversality argument downstream.

--- a/TauCeti/Analysis/Fredholm/SardSmale.lean
+++ b/TauCeti/Analysis/Fredholm/SardSmale.lean
@@ -121,14 +121,16 @@ private theorem surjective_add_coe_iff {X₁ Y₀ : Submodule ℝ F} (h : Submod
     obtain ⟨⟨p₁, p₂⟩, hp⟩ := (Submodule.prodEquivOfIsTopCompl X₁ Y₀ h).surjective y
     obtain ⟨z, hz⟩ := hs (p₂ - D (p₁, 0))
     have hz' : D (0, z) = p₂ - D (p₁, 0) := hz
-    refine ⟨(p₁, z), ?_⟩
-    change ((p₁ : F) + (D (p₁, z) : F)) = y
-    rw [hu p₁ z, ← hp]
-    congr 1
-    rw [Prod.mk.injEq]
-    refine ⟨rfl, ?_⟩
-    rw [hsplit, hz']
-    abel
+    -- The goal is the value of the displayed function at `(p₁, z)`; state that value as a typed
+    -- `have`, which is rewritable, and let `exact` cross the beta reduction.
+    have hval : ((p₁ : F) + (D (p₁, z) : F)) = y := by
+      rw [hu p₁ z, ← hp]
+      congr 1
+      rw [Prod.mk.injEq]
+      refine ⟨rfl, ?_⟩
+      rw [hsplit, hz']
+      abel
+    exact ⟨(p₁, z), hval⟩
 
 /-- The inclusion of the inessential domain summand as the second factor of the normal-form
 coordinates. Slicing the obstruction map through a fixed essential coordinate differentiates along
@@ -137,9 +139,6 @@ private noncomputable def sliceIncl {T : E →L[ℝ] F}
     (pkg : ContinuousLinearMap.FredholmPackage T) :
     pkg.decDom.X₀ →L[ℝ] (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
   (0 : pkg.decDom.X₀ →L[ℝ] pkg.decCodom.X₁).prod (ContinuousLinearMap.id ℝ pkg.decDom.X₀)
-
-private theorem sliceIncl_apply {T : E →L[ℝ] F} (pkg : ContinuousLinearMap.FredholmPackage T)
-    (z : pkg.decDom.X₀) : sliceIncl pkg z = (0, z) := rfl
 
 section Local
 
@@ -208,7 +207,7 @@ private theorem surjective_fderiv_iff_slice (pkg : ContinuousLinearMap.FredholmP
       (hasFDerivAt_const y.1 y.2).prodMk (hasFDerivAt_id y.2)
     exact hq.hasFDerivAt.comp y.2 h0
   rw [hstep₁, hufun, surjective_add_coe_iff pkg.decCodom.isTopCompl, hslice.fderiv]
-  simp only [ContinuousLinearMap.coe_comp, Function.comp_def, sliceIncl_apply]
+  simp [ContinuousLinearMap.coe_comp, Function.comp_def, sliceIncl]
 
 /-- **Sard--Smale, locally.** Near a point where a sufficiently smooth map has Fredholm
 derivative there is a neighbourhood on which the critical values form a closed nowhere dense set.
@@ -349,8 +348,6 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
       rw [← h2, hAint, Set.image_empty]
     exact Set.eq_empty_of_subset_empty (h1 ▸ interior_mono himg)
   -- The critical locus is relatively closed in `N`, again read off the finite-dimensional slice.
-  set R := (ContinuousLinearMap.compL ℝ pkg.decDom.X₀ (pkg.decCodom.X₁ × pkg.decDom.X₀)
-    pkg.decCodom.X₀).flip (sliceIncl pkg) with hRdef
   have hWopen : IsOpen {y | y ∈ V ∧ Surjective ((fderiv ℝ q y).comp (sliceIncl pkg))} := by
     rw [isOpen_iff_mem_nhds]
     rintro y ⟨hyV, hys⟩
@@ -430,20 +427,26 @@ section Global
 variable [CompleteSpace E] [CompleteSpace F] [SecondCountableTopology E]
   {U : Set E} {f : E → F}
 
-/-- **The Sard--Smale theorem.** The critical values of a smooth Fredholm map on an open subset of
-a separable Banach space form a meagre set.
+/-- **The Sard--Smale theorem.** The critical values of a sufficiently smooth Fredholm map on an
+open subset of a separable Banach space form a meagre set.
 
 Sard's theorem itself is false in infinite dimensions, and "measure zero" has no meaning there;
 what survives is that the Fredholm condition confines the failure of regularity to a
-finite-dimensional direction, in which the finite-dimensional theorem applies fibrewise. -/
-theorem isMeagre_image_criticalPoints_of_isFredholm (hU : IsOpen U)
-    (hf : ∀ x ∈ U, ContDiffAt ℝ ∞ f x) (hFred : ∀ x ∈ U, (fderiv ℝ f x).IsFredholm) :
+finite-dimensional direction, in which the finite-dimensional theorem applies fibrewise.
+
+The regularity threshold is the pointwise one of
+`TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`: at each point `C^k` with
+`k ≥ (dim ker)² + 1`. In particular `n = ∞` needs no side condition. -/
+theorem isMeagre_image_criticalPoints_of_isFredholm {n : ℕ∞ω} (hU : IsOpen U)
+    (hf : ∀ x ∈ U, ContDiffAt ℝ n f x) (hFred : ∀ x ∈ U, (fderiv ℝ f x).IsFredholm)
+    (hn : ∀ x ∈ U, ((finrank ℝ (fderiv ℝ f x).ker * finrank ℝ (fderiv ℝ f x).ker + 1 : ℕ) : ℕ∞ω)
+      ≤ n) :
     IsMeagre (f '' (U ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
   have hloc : ∀ x ∈ U, ∃ N ⊆ U, N ∈ 𝓝 x ∧
       IsNowhereDense (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
     intro x hx
     obtain ⟨N, hN, -, hNnd⟩ := exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
-      (hf x hx) (hFred x hx) (by exact_mod_cast le_top)
+      (hf x hx) (hFred x hx) (hn x hx)
     refine ⟨N ∩ U, Set.inter_subset_right, Filter.inter_mem hN (hU.mem_nhds hx), ?_⟩
     exact hNnd.mono (Set.image_mono (Set.inter_subset_inter Set.inter_subset_left le_rfl))
   choose! N hNU hNnhds hNnd using hloc
@@ -456,12 +459,16 @@ theorem isMeagre_image_criticalPoints_of_isFredholm (hU : IsOpen U)
     exact Set.mem_iUnion₂.2 ⟨x, hx, ⟨z, ⟨hzN, hzc⟩, rfl⟩⟩
   exact IsMeagre.mono hsub (isMeagre_biUnion htc fun x hx ↦ (hNnd x (htU hx)).isMeagre)
 
-/-- **Sard--Smale**, in the form transversality arguments consume: the regular values of a smooth
-Fredholm map are dense, being the complement of a meagre set in a Baire space. -/
-theorem dense_compl_image_criticalPoints_of_isFredholm (hU : IsOpen U)
-    (hf : ∀ x ∈ U, ContDiffAt ℝ ∞ f x) (hFred : ∀ x ∈ U, (fderiv ℝ f x).IsFredholm) :
+/-- **Sard--Smale**, in the form transversality arguments consume: the regular values of a
+sufficiently smooth Fredholm map are dense, being the complement of a meagre set in a Baire
+space. The regularity threshold is that of
+`TauCeti.isMeagre_image_criticalPoints_of_isFredholm`. -/
+theorem dense_compl_image_criticalPoints_of_isFredholm {n : ℕ∞ω} (hU : IsOpen U)
+    (hf : ∀ x ∈ U, ContDiffAt ℝ n f x) (hFred : ∀ x ∈ U, (fderiv ℝ f x).IsFredholm)
+    (hn : ∀ x ∈ U, ((finrank ℝ (fderiv ℝ f x).ker * finrank ℝ (fderiv ℝ f x).ker + 1 : ℕ) : ℕ∞ω)
+      ≤ n) :
     Dense (f '' (U ∩ {x | ¬ Surjective (fderiv ℝ f x)}))ᶜ :=
-  dense_of_mem_residual (isMeagre_image_criticalPoints_of_isFredholm hU hf hFred)
+  dense_of_mem_residual (isMeagre_image_criticalPoints_of_isFredholm hU hf hFred hn)
 
 end Global
 

--- a/TauCeti/Analysis/Fredholm/SardSmale.lean
+++ b/TauCeti/Analysis/Fredholm/SardSmale.lean
@@ -1,0 +1,470 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Calculus.Sard.OutermostStratum
+public import TauCeti.Analysis.Fredholm.NormalForm
+public import TauCeti.Analysis.Fredholm.Proper
+public import TauCeti.Analysis.Normed.Operator.Surjective
+public import Mathlib.Topology.Baire.Lemmas
+public import Mathlib.Topology.GDelta.Basic
+
+/-!
+# The Sard--Smale theorem
+
+A **Fredholm map** between Banach spaces is one whose Fréchet derivative is a Fredholm operator at
+every point. Sard's theorem fails outright in infinite dimensions -- there is no Haar measure to
+be null for, and the critical values of a smooth map on a Hilbert space can be everything -- but
+Smale observed that a Fredholm map is finite-dimensional in the only direction that matters, and
+that the finite-dimensional theorem therefore survives with "measure zero" replaced by "meagre":
+
+> **Sard--Smale.** The critical values of a sufficiently smooth Fredholm map are meagre, so its
+> regular values are residual, and in particular dense.
+
+This file proves that, in the local form
+`TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints` first and then in the
+global forms `TauCeti.isMeagre_image_criticalPoints_of_isFredholm` and
+`TauCeti.dense_compl_image_criticalPoints_of_isFredholm`.
+
+## The proof
+
+The two halves of the local statement are proved from the two halves of the substrate already in
+place over the linear Fredholm theory.
+
+*Empty interior* comes from the Lyapunov--Schmidt normal form of
+`TauCeti.Analysis.Fredholm.NormalForm`. In the normal-form chart `Φ` at a point `a`, the map
+reads `y ↦ y.1 + q y` where the **obstruction** `q` takes values in the finite-dimensional
+complement `pkg.decCodom.X₀` of the range; the first coordinate is therefore free, and the
+derivative at `Φ.symm y` is surjective exactly when the derivative of the *slice*
+`z ↦ q (y.1, z)` is, a map between the two finite-dimensional spaces `pkg.decDom.X₀ = ker` and
+`pkg.decCodom.X₀ = coker`. Finite-dimensional Morse--Sard
+(`TauCeti.interior_image_criticalPoints_eq_empty`) applies to each slice, so the image of the
+critical set meets every fibre of the product `pkg.decCodom.X₁ × pkg.decCodom.X₀` in a set with
+empty interior. A set whose fibres over the second factor all have empty interior has empty
+interior, because an interior point would supply a whole box; this is where the infinite
+dimension of the first factor is harmless.
+
+*Closedness* comes from Smale's local properness lemma in `TauCeti.Analysis.Fredholm.Proper`: on a
+small closed ball `N` the preimage of a compact set is compact, and the critical locus is
+relatively closed there -- again read off the slice, whose target is finite dimensional, where
+`TauCeti.isOpen_setOf_surjective` applies. A convergent sequence of critical values then has its
+sources in a compact set, and a subsequential limit produces the missing critical point. Without
+this half only density, not residuality, would follow, since a countable union of sets with empty
+interior need not be meagre.
+
+The global statement follows by covering: a second-countable domain is Lindelöf, so countably many
+of these balls suffice, and a countable union of closed nowhere dense sets is meagre. Density of
+the regular values is then the Baire category theorem in the complete space `F`.
+
+The regularity threshold is inherited unchanged from the finite-dimensional theorem: `C^k` with
+`k ≥ (dim ker)² + 1`, rather than Smale's sharp `k > index`, because the underlying
+`TauCeti.addHaar_image_criticalPoints_eq_zero` is proved with the cruder bound.
+
+## Main results
+
+* `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`: the local form -- near a
+  point with Fredholm derivative there is a neighbourhood whose critical values are closed and
+  nowhere dense.
+* `TauCeti.isMeagre_image_criticalPoints_of_isFredholm`: **the Sard--Smale theorem**.
+* `TauCeti.dense_compl_image_criticalPoints_of_isFredholm`: the regular values of a Fredholm map
+  are dense, the form transversality arguments consume.
+
+This is Lane F0 of the analytic Heegaard Floer roadmap, where Sard--Smale is the gateway to every
+transversality argument downstream.
+
+## References
+
+* S. Smale, *An infinite dimensional version of Sard's theorem*, Amer. J. Math. 87 (1965),
+  861--866.
+* D. McDuff, D. Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., Appendix A.
+-/
+
+public section
+
+open Filter Function MeasureTheory Module Set
+
+open scoped ContDiff Topology
+
+namespace TauCeti
+
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+/-- Surjectivity of `w ↦ w.1 + D w`, where `D` takes values in a topological complement of the
+subspace `w.1` ranges over, is decided by the partial map `z ↦ D (0, z)`: the first coordinate is
+free, so only the complementary direction can obstruct. This is the linear core of the
+Lyapunov--Schmidt reduction of surjectivity to a finite-dimensional condition. -/
+private theorem surjective_add_coe_iff {X₁ Y₀ : Submodule ℝ F} (h : Submodule.IsTopCompl X₁ Y₀)
+    {Z : Type*} [NormedAddCommGroup Z] [NormedSpace ℝ Z] (D : (X₁ × Z) →L[ℝ] Y₀) :
+    Surjective (fun w : X₁ × Z ↦ ((w.1 : F) + (D w : F))) ↔ Surjective fun z : Z ↦ D (0, z) := by
+  have hu : ∀ (w₁ : X₁) (w₂ : Z), ((w₁ : F) + (D (w₁, w₂) : F)) =
+      Submodule.prodEquivOfIsTopCompl X₁ Y₀ h (w₁, D (w₁, w₂)) :=
+    fun w₁ w₂ ↦ (Submodule.prodEquivOfIsTopCompl_apply h (w₁, D (w₁, w₂))).symm
+  have hsplit : ∀ (w₁ : X₁) (w₂ : Z), D (w₁, w₂) = D (w₁, 0) + D (0, w₂) := by
+    intro w₁ w₂
+    rw [← map_add]
+    congr 1
+    simp
+  constructor
+  · intro hs v
+    obtain ⟨⟨w₁, w₂⟩, hw⟩ := hs (Submodule.prodEquivOfIsTopCompl X₁ Y₀ h (0, v))
+    have hw' : ((w₁ : F) + (D (w₁, w₂) : F)) =
+        Submodule.prodEquivOfIsTopCompl X₁ Y₀ h (0, v) := hw
+    rw [hu w₁ w₂] at hw'
+    have hpair := (Submodule.prodEquivOfIsTopCompl X₁ Y₀ h).injective hw'
+    rw [Prod.mk.injEq] at hpair
+    exact ⟨w₂, by rw [← hpair.2, hpair.1]⟩
+  · intro hs y
+    obtain ⟨⟨p₁, p₂⟩, hp⟩ := (Submodule.prodEquivOfIsTopCompl X₁ Y₀ h).surjective y
+    obtain ⟨z, hz⟩ := hs (p₂ - D (p₁, 0))
+    have hz' : D (0, z) = p₂ - D (p₁, 0) := hz
+    refine ⟨(p₁, z), ?_⟩
+    change ((p₁ : F) + (D (p₁, z) : F)) = y
+    rw [hu p₁ z, ← hp]
+    congr 1
+    rw [Prod.mk.injEq]
+    refine ⟨rfl, ?_⟩
+    rw [hsplit, hz']
+    abel
+
+/-- The inclusion of the inessential domain summand as the second factor of the normal-form
+coordinates. Slicing the obstruction map through a fixed essential coordinate differentiates along
+this inclusion. -/
+private noncomputable def sliceIncl {T : E →L[ℝ] F}
+    (pkg : ContinuousLinearMap.FredholmPackage T) :
+    pkg.decDom.X₀ →L[ℝ] (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
+  (0 : pkg.decDom.X₀ →L[ℝ] pkg.decCodom.X₁).prod (ContinuousLinearMap.id ℝ pkg.decDom.X₀)
+
+private theorem sliceIncl_apply {T : E →L[ℝ] F} (pkg : ContinuousLinearMap.FredholmPackage T)
+    (z : pkg.decDom.X₀) : sliceIncl pkg z = (0, z) := rfl
+
+section Local
+
+variable [CompleteSpace E] [CompleteSpace F] {T : E →L[ℝ] F} {f : E → F} {a : E}
+
+omit [CompleteSpace F] in
+/-- **Lyapunov--Schmidt reduction of regularity.** At a point of the normal-form chart where the
+chart, the obstruction and the map itself are all differentiable and the chart has invertible
+derivative, the derivative of `f` is surjective exactly when the derivative of the
+finite-dimensional obstruction slice is. -/
+private theorem surjective_fderiv_iff_slice (pkg : ContinuousLinearMap.FredholmPackage T)
+    (hT : HasStrictFDerivAt f T a)
+    {y : pkg.decCodom.X₁ × pkg.decDom.X₀}
+    (hy : y ∈ (pkg.normalFormOpenPartialHomeomorph hT).target)
+    (hq : DifferentiableAt ℝ (pkg.obstructionMap hT) y)
+    (hinv : ∃ e : (pkg.decCodom.X₁ × pkg.decDom.X₀) ≃L[ℝ] E,
+      (e : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[ℝ] E) =
+        fderiv ℝ (pkg.normalFormOpenPartialHomeomorph hT).symm y)
+    (hsym : DifferentiableAt ℝ (pkg.normalFormOpenPartialHomeomorph hT).symm y)
+    (hfd : DifferentiableAt ℝ f ((pkg.normalFormOpenPartialHomeomorph hT).symm y)) :
+    Surjective (fderiv ℝ f ((pkg.normalFormOpenPartialHomeomorph hT).symm y)) ↔
+      Surjective (fderiv ℝ (fun z ↦ pkg.obstructionMap hT (y.1, z)) y.2) := by
+  obtain ⟨e, he⟩ := hinv
+  set Φ := pkg.normalFormOpenPartialHomeomorph hT with hΦ
+  set q := pkg.obstructionMap hT with hqdef
+  have hsym' : HasFDerivAt Φ.symm (e : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[ℝ] E) y := by
+    rw [he]; exact hsym.hasFDerivAt
+  -- The derivative of `f ∘ Φ.symm` at `y`, computed through the chart.
+  have h1 : HasFDerivAt (fun y' ↦ f (Φ.symm y'))
+      ((fderiv ℝ f (Φ.symm y)).comp (e : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[ℝ] E)) y :=
+    hfd.hasFDerivAt.comp y hsym'
+  -- The same derivative, computed through the normal form `y' ↦ y'.1 + q y'`.
+  set u : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[ℝ] F :=
+    (pkg.decCodom.X₁.subtypeL.comp (ContinuousLinearMap.fst ℝ _ _)) +
+      (pkg.decCodom.X₀.subtypeL.comp (fderiv ℝ q y)) with hudef
+  have hufun : ⇑u =
+      fun w : pkg.decCodom.X₁ × pkg.decDom.X₀ ↦ ((w.1 : F) + ((fderiv ℝ q y) w : F)) := by
+    funext w
+    simp [hudef]
+  have h2 : HasFDerivAt (fun y' ↦ f (Φ.symm y')) u y := by
+    have hfst : HasFDerivAt
+        (fun y' : pkg.decCodom.X₁ × pkg.decDom.X₀ ↦ ((y'.1 : F)))
+        (pkg.decCodom.X₁.subtypeL.comp (ContinuousLinearMap.fst ℝ _ _)) y :=
+      pkg.decCodom.X₁.subtypeL.hasFDerivAt.comp y hasFDerivAt_fst
+    have hsnd : HasFDerivAt (fun y' ↦ ((q y' : F)))
+        (pkg.decCodom.X₀.subtypeL.comp (fderiv ℝ q y)) y :=
+      pkg.decCodom.X₀.subtypeL.hasFDerivAt.comp y hq.hasFDerivAt
+    refine (hfst.add hsnd).congr_of_eventuallyEq ?_
+    filter_upwards [Φ.open_target.mem_nhds hy] with y' hy'
+    exact pkg.apply_normalFormOpenPartialHomeomorph_symm hT hy'
+  have heq := h1.unique h2
+  -- Precomposition with an equivalence does not change surjectivity.
+  have hstep₁ : Surjective (fderiv ℝ f (Φ.symm y)) ↔ Surjective ⇑u := by
+    rw [← heq]
+    constructor
+    · intro hs
+      exact hs.comp e.surjective
+    · intro hs
+      have hs' : Surjective (⇑(fderiv ℝ f (Φ.symm y)) ∘ ⇑e) := hs
+      exact hs'.of_comp
+  -- The slice derivative is the restriction of `fderiv q` to the second factor.
+  have hslice : HasFDerivAt (fun z ↦ q (y.1, z)) ((fderiv ℝ q y).comp (sliceIncl pkg)) y.2 := by
+    have h0 : HasFDerivAt
+        (fun z : pkg.decDom.X₀ ↦ ((y.1, z) : pkg.decCodom.X₁ × pkg.decDom.X₀))
+        (sliceIncl pkg) y.2 :=
+      (hasFDerivAt_const y.1 y.2).prodMk (hasFDerivAt_id y.2)
+    exact hq.hasFDerivAt.comp y.2 h0
+  rw [hstep₁, hufun, surjective_add_coe_iff pkg.decCodom.isTopCompl, hslice.fderiv]
+  simp only [ContinuousLinearMap.coe_comp, Function.comp_def, sliceIncl_apply]
+
+/-- **Sard--Smale, locally.** Near a point where a sufficiently smooth map has Fredholm
+derivative there is a neighbourhood on which the critical values form a closed nowhere dense set.
+
+The regularity threshold `(dim ker)² + 1` is the one inherited from the finite-dimensional
+Morse--Sard theorem `TauCeti.interior_image_criticalPoints_eq_empty`, which the fibrewise step
+applies to the obstruction slice, a map out of `ker (fderiv ℝ f a)`. -/
+theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
+    {f : E → F} {a : E} {n : ℕ∞ω} (hf : ContDiffAt ℝ n f a)
+    (hFred : (fderiv ℝ f a).IsFredholm)
+    (hn : ((finrank ℝ (fderiv ℝ f a).ker * finrank ℝ (fderiv ℝ f a).ker + 1 : ℕ) : ℕ∞ω) ≤ n) :
+    ∃ N ∈ 𝓝 a, IsClosed (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) ∧
+      IsNowhereDense (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
+  set T := fderiv ℝ f a with hTdef
+  set k : ℕ := finrank ℝ T.ker * finrank ℝ T.ker + 1 with hkdef
+  have hk1 : (1 : ℕ∞ω) ≤ (k : ℕ∞ω) := by
+    have : (1 : ℕ) ≤ k := by omega
+    exact_mod_cast this
+  have hk0 : ((k : ℕ∞ω)) ≠ 0 := by
+    intro h
+    exact absurd (h ▸ hk1) (by simp)
+  have hkω : ((k : ℕ∞ω)) ≠ ∞ := by simp
+  replace hf : ContDiffAt ℝ (k : ℕ∞ω) f a := hf.of_le hn
+  have hT : HasStrictFDerivAt f T a := hf.hasStrictFDerivAt hk0
+  obtain ⟨pkg⟩ := hFred.nonempty_fredholmPackage
+  have : CompleteSpace pkg.decDom.X₀ := pkg.decDom.isTopCompl.isClosed'.completeSpace_coe
+  have : CompleteSpace pkg.decDom.X₁ := pkg.decDom.isTopCompl.isClosed.completeSpace_coe
+  have : CompleteSpace pkg.decCodom.X₁ :=
+    (pkg.equiv.isUniformEmbedding.completeSpace_congr pkg.equiv.surjective).mp inferInstance
+  have : FiniteDimensional ℝ pkg.decDom.X₀ := pkg.decDom.finite_X₀
+  have : FiniteDimensional ℝ pkg.decCodom.X₀ := pkg.decCodom.finite_X₀
+  have hkbound :
+      ((finrank ℝ pkg.decDom.X₀ * finrank ℝ pkg.decDom.X₀ + 1 : ℕ) : ℕ∞ω) ≤ (k : ℕ∞ω) := by
+    have hker : finrank ℝ T.ker = finrank ℝ pkg.decDom.X₀ := by rw [pkg.ker_eq]
+    rw [hkdef, hker]
+  set Φ := pkg.normalFormOpenPartialHomeomorph hT with hΦdef
+  set q := pkg.obstructionMap hT with hqdef
+  set y₀ : pkg.decCodom.X₁ × pkg.decDom.X₀ := (pkg.decCodom.proj (f a), 0) with hy₀def
+  have hy₀ : y₀ ∈ Φ.target := pkg.normalFormOpenPartialHomeomorph_self_mem_target hT
+  have ha : a ∈ Φ.source := pkg.mem_normalFormOpenPartialHomeomorph_source hT
+  have hΦa : Φ a = y₀ := by
+    rw [hΦdef, pkg.normalFormOpenPartialHomeomorph_apply hT, pkg.normalFormMap_self]
+  have hsymy₀ : Φ.symm y₀ = a := by
+    rw [hy₀def, hΦdef]
+    simpa only [Submodule.coe_projectionOntoL] using
+      pkg.normalFormOpenPartialHomeomorph_symm_self hT
+  -- A neighbourhood of the base coordinate on which the chart, the obstruction and the map are
+  -- all as smooth as `f` and the chart has invertible derivative.
+  have hgood : ∀ᶠ y in 𝓝 y₀, y ∈ Φ.target ∧ ContDiffAt ℝ (k : ℕ∞ω) q y ∧
+      ContDiffAt ℝ (k : ℕ∞ω) Φ.symm y ∧
+      (∃ e : (pkg.decCodom.X₁ × pkg.decDom.X₀) ≃L[ℝ] E,
+        (e : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[ℝ] E) = fderiv ℝ Φ.symm y) ∧
+      ContDiffAt ℝ (k : ℕ∞ω) f (Φ.symm y) := by
+    have hqC : ContDiffAt ℝ (k : ℕ∞ω) q y₀ := pkg.contDiffAt_obstructionMap_self hT hf
+    have hsymC : ContDiffAt ℝ (k : ℕ∞ω) Φ.symm y₀ :=
+      pkg.contDiffAt_normalFormOpenPartialHomeomorph_symm_self hT hf
+    have h₄ : ∀ᶠ y in 𝓝 y₀, ∃ e : (pkg.decCodom.X₁ × pkg.decDom.X₀) ≃L[ℝ] E,
+        (e : (pkg.decCodom.X₁ × pkg.decDom.X₀) →L[ℝ] E) = fderiv ℝ Φ.symm y := by
+      have hcont : ContinuousAt (fderiv ℝ Φ.symm) y₀ := hsymC.continuousAt_fderiv hk0
+      have hmem : Set.range ((↑) : ((pkg.decCodom.X₁ × pkg.decDom.X₀) ≃L[ℝ] E) →
+          ((pkg.decCodom.X₁ × pkg.decDom.X₀) →L[ℝ] E)) ∈ 𝓝 (fderiv ℝ Φ.symm y₀) := by
+        rw [(pkg.hasStrictFDerivAt_normalFormOpenPartialHomeomorph_symm_self hT).hasFDerivAt.fderiv]
+        exact ContinuousLinearEquiv.nhds _
+      exact hcont hmem
+    have h₅ : ∀ᶠ y in 𝓝 y₀, ContDiffAt ℝ (k : ℕ∞ω) f (Φ.symm y) := by
+      have hev := hf.eventually hkω
+      rw [← hsymy₀] at hev
+      exact hsymC.continuousAt hev
+    filter_upwards [Φ.open_target.mem_nhds hy₀, hqC.eventually hkω, hsymC.eventually hkω, h₄, h₅]
+      with y c₁ c₂ c₃ c₄ c₅ using ⟨c₁, c₂, c₃, c₄, c₅⟩
+  rw [Filter.eventually_iff_exists_mem] at hgood
+  obtain ⟨V₀, hV₀, hV₀P⟩ := hgood
+  obtain ⟨V, hVV₀, hVopen, hy₀V⟩ := mem_nhds_iff.1 hV₀
+  have hVP := fun y (hy : y ∈ V) ↦ hV₀P y (hVV₀ hy)
+  set N : Set E := Φ.source ∩ Φ ⁻¹' V with hNdef
+  have hNopen : IsOpen N := Φ.isOpen_inter_preimage hVopen
+  have haN : a ∈ N := ⟨ha, by rw [Set.mem_preimage, hΦa]; exact hy₀V⟩
+  have hNV : ∀ x ∈ N, Φ x ∈ V := fun x hx ↦ hx.2
+  have hNsymm : ∀ x ∈ N, Φ.symm (Φ x) = x := fun x hx ↦ Φ.left_inv hx.1
+  have hfN : ∀ x ∈ N, ContDiffAt ℝ (k : ℕ∞ω) f x := by
+    intro x hx
+    have := (hVP (Φ x) (hNV x hx)).2.2.2.2
+    rwa [hNsymm x hx] at this
+  -- The slice derivative is the restriction of the derivative of the obstruction.
+  have hsliceD : ∀ y ∈ V,
+      fderiv ℝ (fun z ↦ q (y.1, z)) y.2 = (fderiv ℝ q y).comp (sliceIncl pkg) := by
+    intro y hy
+    exact (((hVP y hy).2.1.differentiableAt hk0).hasFDerivAt.comp y.2
+      ((hasFDerivAt_const y.1 y.2).prodMk (hasFDerivAt_id y.2))).fderiv
+  -- Regularity of `f` on `N` is regularity of the finite-dimensional obstruction slice.
+  have hcrit : ∀ x ∈ N, (Surjective (fderiv ℝ f x) ↔
+      Surjective (fderiv ℝ (fun z ↦ q ((Φ x).1, z)) (Φ x).2)) := by
+    intro x hx
+    obtain ⟨c₁, c₂, c₃, c₄, c₅⟩ := hVP (Φ x) (hNV x hx)
+    have hiff := surjective_fderiv_iff_slice pkg hT c₁ (c₂.differentiableAt hk0) c₄
+      (c₃.differentiableAt hk0) (c₅.differentiableAt hk0)
+    rwa [hNsymm x hx] at hiff
+  -- The image of the critical set of `N` has empty interior, fibrewise by Morse--Sard.
+  set Λ := Submodule.prodEquivOfIsTopCompl pkg.decCodom.X₁ pkg.decCodom.X₀
+    pkg.decCodom.isTopCompl with hΛdef
+  set A : Set (pkg.decCodom.X₁ × pkg.decCodom.X₀) :=
+    {p | p.2 ∈ (fun z ↦ q (p.1, z)) ''
+      ({z | (p.1, z) ∈ V} ∩ {z | ¬ Surjective (fderiv ℝ (fun z ↦ q (p.1, z)) z)})} with hAdef
+  have hAint : interior A = ∅ := by
+    rw [Set.eq_empty_iff_forall_notMem]
+    rintro ⟨p₁, p₂⟩ hp
+    have hnhds : A ∈ 𝓝 ((p₁, p₂) : pkg.decCodom.X₁ × pkg.decCodom.X₀) :=
+      mem_interior_iff_mem_nhds.1 hp
+    rw [nhds_prod_eq, Filter.mem_prod_iff] at hnhds
+    obtain ⟨V₁, hV₁, W, hW, hsub⟩ := hnhds
+    have hWsub : W ⊆ (fun z ↦ q (p₁, z)) ''
+        ({z | (p₁, z) ∈ V} ∩ {z | ¬ Surjective (fderiv ℝ (fun z ↦ q (p₁, z)) z)}) := by
+      intro w hw
+      exact hsub (Set.mk_mem_prod (mem_of_mem_nhds hV₁) hw)
+    have hUopen : IsOpen {z : pkg.decDom.X₀ | (p₁, z) ∈ V} :=
+      hVopen.preimage (by fun_prop)
+    have hUC : ∀ z ∈ {z : pkg.decDom.X₀ | (p₁, z) ∈ V},
+        ContDiffAt ℝ (k : ℕ∞ω) (fun z ↦ q (p₁, z)) z := fun z hz ↦
+      ((hVP _ hz).2.1).comp z (contDiffAt_const.prodMk contDiffAt_id)
+    have hSard := interior_image_criticalPoints_eq_empty hUopen hUC hkbound
+    have hmem : p₂ ∈ interior ((fun z ↦ q (p₁, z)) ''
+        ({z | (p₁, z) ∈ V} ∩ {z | ¬ Surjective (fderiv ℝ (fun z ↦ q (p₁, z)) z)})) :=
+      mem_interior_iff_mem_nhds.2 (Filter.mem_of_superset hW hWsub)
+    rw [hSard] at hmem
+    exact hmem
+  have himg : f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)}) ⊆ Λ '' A := by
+    rintro _ ⟨x, ⟨hxN, hxc⟩, rfl⟩
+    obtain ⟨c₁, -, -, -, -⟩ := hVP (Φ x) (hNV x hxN)
+    refine ⟨((Φ x).1, q (Φ x)), ⟨(Φ x).2, ⟨hNV x hxN, ?_⟩, rfl⟩, ?_⟩
+    · exact fun hs ↦ hxc ((hcrit x hxN).2 hs)
+    · rw [hΛdef, Submodule.prodEquivOfIsTopCompl_apply]
+      conv_rhs => rw [← hNsymm x hxN]
+      exact (pkg.apply_normalFormOpenPartialHomeomorph_symm hT c₁).symm
+  have hNint : interior (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) = ∅ := by
+    have h1 : interior (Λ '' A) = ∅ := by
+      have h2 := Λ.toHomeomorph.image_interior A
+      simp only [ContinuousLinearEquiv.coe_toHomeomorph] at h2
+      rw [← h2, hAint, Set.image_empty]
+    exact Set.eq_empty_of_subset_empty (h1 ▸ interior_mono himg)
+  -- The critical locus is relatively closed in `N`, again read off the finite-dimensional slice.
+  set R := (ContinuousLinearMap.compL ℝ pkg.decDom.X₀ (pkg.decCodom.X₁ × pkg.decDom.X₀)
+    pkg.decCodom.X₀).flip (sliceIncl pkg) with hRdef
+  have hWopen : IsOpen {y | y ∈ V ∧ Surjective ((fderiv ℝ q y).comp (sliceIncl pkg))} := by
+    rw [isOpen_iff_mem_nhds]
+    rintro y ⟨hyV, hys⟩
+    have hcont : ContinuousAt (fderiv ℝ q) y := ((hVP y hyV).2.1).continuousAt_fderiv hk0
+    have hmap : ContinuousAt (fun y' ↦ (fderiv ℝ q y').comp (sliceIncl pkg)) y :=
+      hcont.clm_comp continuousAt_const
+    filter_upwards [hVopen.mem_nhds hyV,
+      hmap (IsOpen.mem_nhds isOpen_setOf_surjective hys)] with y' d₁ d₂
+    exact ⟨d₁, d₂⟩
+  have hregopen : IsOpen {x | x ∈ N ∧ Surjective (fderiv ℝ f x)} := by
+    have heq : {x | x ∈ N ∧ Surjective (fderiv ℝ f x)} =
+        N ∩ (Φ.source ∩ Φ ⁻¹' {y | y ∈ V ∧ Surjective ((fderiv ℝ q y).comp (sliceIncl pkg))}) := by
+      ext x
+      constructor
+      · rintro ⟨hxN, hxs⟩
+        have h1 : Surjective ((fderiv ℝ q (Φ x)).comp (sliceIncl pkg)) := by
+          rw [← hsliceD (Φ x) (hNV x hxN)]
+          exact (hcrit x hxN).1 hxs
+        exact ⟨hxN, hxN.1, hNV x hxN, h1⟩
+      · rintro ⟨hxN, -, -, hs⟩
+        have h2 : Surjective (fderiv ℝ (fun z ↦ q ((Φ x).1, z)) (Φ x).2) := by
+          rw [hsliceD (Φ x) (hNV x hxN)]
+          exact hs
+        exact ⟨hxN, (hcrit x hxN).2 h2⟩
+    rw [heq]
+    exact hNopen.inter (Φ.isOpen_inter_preimage hWopen)
+  -- Smale's local properness, on a closed ball inside `N`.
+  obtain ⟨N₂, hN₂, hprop⟩ := hT.exists_mem_nhds_forall_isCompact_inter_preimage
+    hFred.isClosed_range hFred.finite_ker hFred.closedComplemented_ker
+  obtain ⟨r, hr, hball⟩ := Metric.mem_nhds_iff.1 (Filter.inter_mem (hNopen.mem_nhds haN) hN₂)
+  set N' : Set E := Metric.closedBall a (r / 2) with hN'def
+  have hN'ball : N' ⊆ N ∩ N₂ := (Metric.closedBall_subset_ball (by linarith)).trans hball
+  have hN'nhds : N' ∈ 𝓝 a := Metric.closedBall_mem_nhds a (by linarith)
+  have hcritclosed : IsClosed (N' ∩ {x | ¬ Surjective (fderiv ℝ f x)}) := by
+    have heq : N' ∩ {x | ¬ Surjective (fderiv ℝ f x)} =
+        N' ∩ {x | x ∈ N ∧ Surjective (fderiv ℝ f x)}ᶜ := by
+      ext x
+      refine ⟨fun hx ↦ ⟨hx.1, fun hc ↦ hx.2 hc.2⟩, fun hx ↦ ⟨hx.1, fun hc ↦ hx.2 ⟨?_, hc⟩⟩⟩
+      exact (hN'ball hx.1).1
+    rw [heq]
+    exact Metric.isClosed_closedBall.inter hregopen.isClosed_compl
+  have hclosedimg : IsClosed (f '' (N' ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
+    apply IsSeqClosed.isClosed
+    intro u y hu huy
+    choose x hx hfx using hu
+    have hLcpt : IsCompact (insert y (Set.range u)) := huy.isCompact_insert_range
+    have hK : IsCompact (N' ∩ f ⁻¹' (insert y (Set.range u))) := by
+      have heq : N' ∩ f ⁻¹' (insert y (Set.range u)) =
+          N' ∩ (N₂ ∩ f ⁻¹' (insert y (Set.range u))) :=
+        Set.ext fun z ↦ ⟨fun h ↦ ⟨h.1, (hN'ball h.1).2, h.2⟩, fun h ↦ ⟨h.1, h.2.2⟩⟩
+      rw [heq]
+      exact (hprop _ hLcpt).inter_left Metric.isClosed_closedBall
+    have hxmem : ∀ m, x m ∈ N' ∩ f ⁻¹' (insert y (Set.range u)) := fun m ↦
+      ⟨(hx m).1, by rw [Set.mem_preimage, hfx m]; exact Set.mem_insert_of_mem _ ⟨m, rfl⟩⟩
+    obtain ⟨z, -, φ, hφmono, hφtend⟩ := hK.tendsto_subseq hxmem
+    have hzc : z ∈ N' ∩ {x | ¬ Surjective (fderiv ℝ f x)} :=
+      hcritclosed.mem_of_tendsto hφtend (Filter.Eventually.of_forall fun m ↦ hx (φ m))
+    refine ⟨z, hzc, ?_⟩
+    have hfcont : ContinuousAt f z := (hfN z (hN'ball hzc.1).1).continuousAt
+    have h1 : Filter.Tendsto (fun m ↦ f (x (φ m))) Filter.atTop (𝓝 (f z)) :=
+      hfcont.tendsto.comp hφtend
+    have h2 : Filter.Tendsto (fun m ↦ f (x (φ m))) Filter.atTop (𝓝 y) := by
+      simp_rw [hfx]
+      exact huy.comp hφmono.tendsto_atTop
+    exact tendsto_nhds_unique h1 h2
+  refine ⟨N', hN'nhds, hclosedimg, ?_⟩
+  rw [hclosedimg.isNowhereDense_iff]
+  refine Set.eq_empty_of_subset_empty ?_
+  rw [← hNint]
+  exact interior_mono (Set.image_mono
+    (Set.inter_subset_inter (fun z hz ↦ (hN'ball hz).1) (subset_refl _)))
+
+end Local
+
+section Global
+
+variable [CompleteSpace E] [CompleteSpace F] [SecondCountableTopology E]
+  {U : Set E} {f : E → F}
+
+/-- **The Sard--Smale theorem.** The critical values of a smooth Fredholm map on an open subset of
+a separable Banach space form a meagre set.
+
+Sard's theorem itself is false in infinite dimensions, and "measure zero" has no meaning there;
+what survives is that the Fredholm condition confines the failure of regularity to a
+finite-dimensional direction, in which the finite-dimensional theorem applies fibrewise. -/
+theorem isMeagre_image_criticalPoints_of_isFredholm (hU : IsOpen U)
+    (hf : ∀ x ∈ U, ContDiffAt ℝ ∞ f x) (hFred : ∀ x ∈ U, (fderiv ℝ f x).IsFredholm) :
+    IsMeagre (f '' (U ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
+  have hloc : ∀ x ∈ U, ∃ N ⊆ U, N ∈ 𝓝 x ∧
+      IsNowhereDense (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
+    intro x hx
+    obtain ⟨N, hN, -, hNnd⟩ := exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
+      (hf x hx) (hFred x hx) (by exact_mod_cast le_top)
+    refine ⟨N ∩ U, Set.inter_subset_right, Filter.inter_mem hN (hU.mem_nhds hx), ?_⟩
+    exact hNnd.mono (Set.image_mono (Set.inter_subset_inter Set.inter_subset_left le_rfl))
+  choose! N hNU hNnhds hNnd using hloc
+  obtain ⟨t, htU, htc, htcover⟩ := TopologicalSpace.countable_cover_nhdsWithin
+    (f := N) (s := U) fun x hx ↦ nhdsWithin_le_nhds (hNnhds x hx)
+  have hsub : f '' (U ∩ {x | ¬ Surjective (fderiv ℝ f x)}) ⊆
+      ⋃ x ∈ t, f '' (N x ∩ {x | ¬ Surjective (fderiv ℝ f x)}) := by
+    rintro _ ⟨z, ⟨hzU, hzc⟩, rfl⟩
+    obtain ⟨x, hx, hzN⟩ := Set.mem_iUnion₂.1 (htcover hzU)
+    exact Set.mem_iUnion₂.2 ⟨x, hx, ⟨z, ⟨hzN, hzc⟩, rfl⟩⟩
+  exact IsMeagre.mono hsub (isMeagre_biUnion htc fun x hx ↦ (hNnd x (htU hx)).isMeagre)
+
+/-- **Sard--Smale**, in the form transversality arguments consume: the regular values of a smooth
+Fredholm map are dense, being the complement of a meagre set in a Baire space. -/
+theorem dense_compl_image_criticalPoints_of_isFredholm (hU : IsOpen U)
+    (hf : ∀ x ∈ U, ContDiffAt ℝ ∞ f x) (hFred : ∀ x ∈ U, (fderiv ℝ f x).IsFredholm) :
+    Dense (f '' (U ∩ {x | ¬ Surjective (fderiv ℝ f x)}))ᶜ :=
+  dense_of_mem_residual (isMeagre_image_criticalPoints_of_isFredholm hU hf hFred)
+
+end Global
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Fredholm/SardSmale.lean
+++ b/TauCeti/Analysis/Fredholm/SardSmale.lean
@@ -5,12 +5,14 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.Calculus.Sard.OutermostStratum
-public import TauCeti.Analysis.Fredholm.NormalForm
-public import TauCeti.Analysis.Fredholm.Proper
-public import TauCeti.Analysis.Normed.Operator.Surjective
-public import Mathlib.Topology.Baire.Lemmas
+public import Mathlib.Analysis.Calculus.ContDiff.Defs
+public import Mathlib.Analysis.Normed.Operator.Fredholm.Basic
 public import Mathlib.Topology.GDelta.Basic
+import Mathlib.Topology.Baire.Lemmas
+import TauCeti.Analysis.Calculus.Sard.OutermostStratum
+import TauCeti.Analysis.Fredholm.NormalForm
+import TauCeti.Analysis.Fredholm.Proper
+import TauCeti.Analysis.Normed.Operator.Surjective
 
 /-!
 # The Sard--Smale theorem
@@ -92,6 +94,22 @@ namespace TauCeti
 
 variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+/-- A subset of a product has empty interior as soon as all of its vertical fibres do: an
+interior point of the subset would supply a whole box, whose second factor is an open subset of a
+fibre. This is the step of the Sard--Smale argument where the infinite dimension of the first
+factor is harmless. -/
+private theorem interior_eq_empty_of_forall_interior_fiber_eq_empty {X Z : Type*}
+    [TopologicalSpace X] [TopologicalSpace Z] {A : Set (X × Z)}
+    (h : ∀ x : X, interior {z | (x, z) ∈ A} = ∅) : interior A = ∅ := by
+  rw [Set.eq_empty_iff_forall_notMem]
+  rintro ⟨x, z⟩ hxz
+  have hopen : IsOpen {z' : Z | (x, z') ∈ interior A} := isOpen_interior.preimage (by fun_prop)
+  have hsub : {z' : Z | (x, z') ∈ interior A} ⊆ {z' : Z | (x, z') ∈ A} :=
+    fun _ hz' ↦ interior_subset (s := A) hz'
+  have hz : z ∈ interior {z' : Z | (x, z') ∈ A} := interior_maximal hsub hopen hxz
+  rw [h x] at hz
+  exact hz
 
 /-- Surjectivity of `w ↦ w.1 + D w`, where `D` takes values in a topological complement of the
 subspace `w.1` ranges over, is decided by the partial map `z ↦ D (0, z)`: the first coordinate is
@@ -312,27 +330,20 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
     {p | p.2 ∈ (fun z ↦ q (p.1, z)) ''
       ({z | (p.1, z) ∈ V} ∩ {z | ¬ Surjective (fderiv ℝ (fun z ↦ q (p.1, z)) z)})} with hAdef
   have hAint : interior A = ∅ := by
-    rw [Set.eq_empty_iff_forall_notMem]
-    rintro ⟨p₁, p₂⟩ hp
-    have hnhds : A ∈ 𝓝 ((p₁, p₂) : pkg.decCodom.X₁ × pkg.decCodom.X₀) :=
-      mem_interior_iff_mem_nhds.1 hp
-    rw [nhds_prod_eq, Filter.mem_prod_iff] at hnhds
-    obtain ⟨V₁, hV₁, W, hW, hsub⟩ := hnhds
-    have hWsub : W ⊆ (fun z ↦ q (p₁, z)) ''
+    refine interior_eq_empty_of_forall_interior_fiber_eq_empty fun p₁ ↦ ?_
+    -- The fibre of `A` over `p₁` is the image of the critical set of the slice at `p₁`.
+    have hfiber : {z | (p₁, z) ∈ A} = (fun z ↦ q (p₁, z)) ''
         ({z | (p₁, z) ∈ V} ∩ {z | ¬ Surjective (fderiv ℝ (fun z ↦ q (p₁, z)) z)}) := by
-      intro w hw
-      exact hsub (Set.mk_mem_prod (mem_of_mem_nhds hV₁) hw)
+      rw [hAdef]
+      ext z
+      simp only [Set.mem_ofPred_eq]
+    rw [hfiber]
     have hUopen : IsOpen {z : pkg.decDom.X₀ | (p₁, z) ∈ V} :=
       hVopen.preimage (by fun_prop)
     have hUC : ∀ z ∈ {z : pkg.decDom.X₀ | (p₁, z) ∈ V},
         ContDiffAt ℝ (k : ℕ∞ω) (fun z ↦ q (p₁, z)) z := fun z hz ↦
       ((hVP _ hz).2.1).comp z (contDiffAt_const.prodMk contDiffAt_id)
-    have hSard := interior_image_criticalPoints_eq_empty hUopen hUC hkbound
-    have hmem : p₂ ∈ interior ((fun z ↦ q (p₁, z)) ''
-        ({z | (p₁, z) ∈ V} ∩ {z | ¬ Surjective (fderiv ℝ (fun z ↦ q (p₁, z)) z)})) :=
-      mem_interior_iff_mem_nhds.2 (Filter.mem_of_superset hW hWsub)
-    rw [hSard] at hmem
-    exact hmem
+    exact interior_image_criticalPoints_eq_empty hUopen hUC hkbound
   have himg : f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)}) ⊆ Λ '' A := by
     rintro _ ⟨x, ⟨hxN, hxc⟩, rfl⟩
     obtain ⟨c₁, -, -, -, -⟩ := hVP (Φ x) (hNV x hxN)

--- a/TauCeti/Analysis/Fredholm/SardSmale.lean
+++ b/TauCeti/Analysis/Fredholm/SardSmale.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.Calculus.ContDiff.Defs
 public import Mathlib.Analysis.Normed.Operator.Fredholm.Basic
 public import Mathlib.Topology.GDelta.Basic
 import Mathlib.Topology.Baire.Lemmas
+import Mathlib.Topology.Maps.Proper.CompactlyGenerated
 import TauCeti.Analysis.Calculus.Sard.OutermostStratum
 import TauCeti.Analysis.Fredholm.NormalForm
 import TauCeti.Analysis.Fredholm.Proper
@@ -23,13 +24,16 @@ be null for, and the critical values of a smooth map on a Hilbert space can be e
 Smale observed that a Fredholm map is finite-dimensional in the only direction that matters, and
 that the finite-dimensional theorem therefore survives with "measure zero" replaced by "meagre":
 
-> **Sard--Smale.** The critical values of a sufficiently smooth Fredholm map are meagre, so its
-> regular values are residual, and in particular dense.
+> **Sard--Smale.** The critical values of a sufficiently smooth Fredholm map on an open subset of
+> a separable Banach space are meagre, so its regular values are residual, and in particular
+> dense.
 
 This file proves that, in the local form
 `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints` first and then in the
 global forms `TauCeti.isMeagre_image_criticalPoints_of_isFredholm` and
-`TauCeti.dense_compl_image_criticalPoints_of_isFredholm`.
+`TauCeti.dense_compl_image_criticalPoints_of_isFredholm`. The local form needs no separability;
+the global ones assume the domain second countable, since their proof covers it by countably many
+of the local neighbourhoods.
 
 ## The proof
 
@@ -151,17 +155,23 @@ private theorem surjective_add_coe_iff {X₁ Y₀ : Submodule ℝ F} (h : Submod
       abel
     exact ⟨(p₁, z), hval⟩
 
-/-- The inclusion of the inessential domain summand as the second factor of the normal-form
-coordinates. Slicing the obstruction map through a fixed essential coordinate differentiates along
-this inclusion. -/
-private noncomputable def sliceIncl {T : E →L[ℝ] F}
-    (pkg : ContinuousLinearMap.FredholmPackage T) :
-    pkg.decDom.X₀ →L[ℝ] (pkg.decCodom.X₁ × pkg.decDom.X₀) :=
-  (0 : pkg.decDom.X₀ →L[ℝ] pkg.decCodom.X₁).prod (ContinuousLinearMap.id ℝ pkg.decDom.X₀)
-
 section Local
 
 variable [CompleteSpace E] [CompleteSpace F] {T : E →L[ℝ] F} {f : E → F} {a : E}
+
+omit [CompleteSpace F] in
+/-- Fixing the essential coordinate differentiates the obstruction along the inclusion of the
+inessential domain summand as the second normal-form factor: the derivative of
+`ContinuousLinearMap.FredholmPackage.obstructionSlice` is the derivative of the obstruction map
+precomposed with `ContinuousLinearMap.inr`. -/
+private theorem hasFDerivAt_obstructionSlice (pkg : ContinuousLinearMap.FredholmPackage T)
+    (hT : HasStrictFDerivAt f T a) {y : pkg.decCodom.X₁ × pkg.decDom.X₀}
+    (hq : DifferentiableAt ℝ (pkg.obstructionMap hT) y) :
+    HasFDerivAt (pkg.obstructionSlice hT y.1)
+      ((fderiv ℝ (pkg.obstructionMap hT) y).comp
+        (ContinuousLinearMap.inr ℝ pkg.decCodom.X₁ pkg.decDom.X₀)) y.2 := by
+  rw [funext (pkg.obstructionSlice_apply hT y.1)]
+  exact hq.hasFDerivAt.comp y.2 ((hasFDerivAt_const y.1 y.2).prodMk (hasFDerivAt_id y.2))
 
 omit [CompleteSpace F] in
 /-- **Lyapunov--Schmidt reduction of regularity.** At a point of the normal-form chart where the
@@ -179,7 +189,7 @@ private theorem surjective_fderiv_iff_slice (pkg : ContinuousLinearMap.FredholmP
     (hsym : DifferentiableAt ℝ (pkg.normalFormOpenPartialHomeomorph hT).symm y)
     (hfd : DifferentiableAt ℝ f ((pkg.normalFormOpenPartialHomeomorph hT).symm y)) :
     Surjective (fderiv ℝ f ((pkg.normalFormOpenPartialHomeomorph hT).symm y)) ↔
-      Surjective (fderiv ℝ (fun z ↦ pkg.obstructionMap hT (y.1, z)) y.2) := by
+      Surjective (fderiv ℝ (pkg.obstructionSlice hT y.1) y.2) := by
   obtain ⟨e, he⟩ := hinv
   set Φ := pkg.normalFormOpenPartialHomeomorph hT with hΦ
   set q := pkg.obstructionMap hT with hqdef
@@ -212,21 +222,15 @@ private theorem surjective_fderiv_iff_slice (pkg : ContinuousLinearMap.FredholmP
   -- Precomposition with an equivalence does not change surjectivity.
   have hstep₁ : Surjective (fderiv ℝ f (Φ.symm y)) ↔ Surjective ⇑u := by
     rw [← heq]
-    constructor
-    · intro hs
-      exact hs.comp e.surjective
-    · intro hs
-      have hs' : Surjective (⇑(fderiv ℝ f (Φ.symm y)) ∘ ⇑e) := hs
-      exact hs'.of_comp
+    simp only [ContinuousLinearMap.coe_comp, ContinuousLinearEquiv.coe_coe]
+    exact (EquivLike.surjective_comp e _).symm
   -- The slice derivative is the restriction of `fderiv q` to the second factor.
-  have hslice : HasFDerivAt (fun z ↦ q (y.1, z)) ((fderiv ℝ q y).comp (sliceIncl pkg)) y.2 := by
-    have h0 : HasFDerivAt
-        (fun z : pkg.decDom.X₀ ↦ ((y.1, z) : pkg.decCodom.X₁ × pkg.decDom.X₀))
-        (sliceIncl pkg) y.2 :=
-      (hasFDerivAt_const y.1 y.2).prodMk (hasFDerivAt_id y.2)
-    exact hq.hasFDerivAt.comp y.2 h0
+  have hslice : HasFDerivAt (pkg.obstructionSlice hT y.1)
+      ((fderiv ℝ q y).comp (ContinuousLinearMap.inr ℝ pkg.decCodom.X₁ pkg.decDom.X₀)) y.2 := by
+    rw [hqdef]
+    exact hasFDerivAt_obstructionSlice pkg hT hq
   rw [hstep₁, hufun, surjective_add_coe_iff pkg.decCodom.isTopCompl, hslice.fderiv]
-  simp [ContinuousLinearMap.coe_comp, Function.comp_def, sliceIncl]
+  simp [ContinuousLinearMap.coe_comp, Function.comp_def]
 
 /-- **Sard--Smale, locally.** Near a point where a sufficiently smooth map has Fredholm
 derivative there is a neighbourhood on which the critical values form a closed nowhere dense set.
@@ -267,6 +271,8 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
     rw [hkdef, hker]
   set Φ := pkg.normalFormOpenPartialHomeomorph hT with hΦdef
   set q := pkg.obstructionMap hT with hqdef
+  -- The inclusion of the inessential domain summand as the second normal-form factor.
+  set ι := ContinuousLinearMap.inr ℝ pkg.decCodom.X₁ pkg.decDom.X₀ with hιdef
   set y₀ : pkg.decCodom.X₁ × pkg.decDom.X₀ := (pkg.decCodom.proj (f a), 0) with hy₀def
   have hy₀ : y₀ ∈ Φ.target := pkg.normalFormOpenPartialHomeomorph_self_mem_target hT
   have ha : a ∈ Φ.source := pkg.mem_normalFormOpenPartialHomeomorph_source hT
@@ -315,13 +321,13 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
     rwa [hNsymm x hx] at this
   -- The slice derivative is the restriction of the derivative of the obstruction.
   have hsliceD : ∀ y ∈ V,
-      fderiv ℝ (fun z ↦ q (y.1, z)) y.2 = (fderiv ℝ q y).comp (sliceIncl pkg) := by
+      fderiv ℝ (pkg.obstructionSlice hT y.1) y.2 = (fderiv ℝ q y).comp ι := by
     intro y hy
-    exact (((hVP y hy).2.1.differentiableAt hk0).hasFDerivAt.comp y.2
-      ((hasFDerivAt_const y.1 y.2).prodMk (hasFDerivAt_id y.2))).fderiv
+    rw [hqdef, hιdef]
+    exact (hasFDerivAt_obstructionSlice pkg hT ((hVP y hy).2.1.differentiableAt hk0)).fderiv
   -- Regularity of `f` on `N` is regularity of the finite-dimensional obstruction slice.
   have hcrit : ∀ x ∈ N, (Surjective (fderiv ℝ f x) ↔
-      Surjective (fderiv ℝ (fun z ↦ q ((Φ x).1, z)) (Φ x).2)) := by
+      Surjective (fderiv ℝ (pkg.obstructionSlice hT (Φ x).1) (Φ x).2)) := by
     intro x hx
     obtain ⟨c₁, c₂, c₃, c₄, c₅⟩ := hVP (Φ x) (hNV x hx)
     have hiff := surjective_fderiv_iff_slice pkg hT c₁ (c₂.differentiableAt hk0) c₄
@@ -331,13 +337,15 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
   set Λ := Submodule.prodEquivOfIsTopCompl pkg.decCodom.X₁ pkg.decCodom.X₀
     pkg.decCodom.isTopCompl with hΛdef
   set A : Set (pkg.decCodom.X₁ × pkg.decCodom.X₀) :=
-    {p | p.2 ∈ (fun z ↦ q (p.1, z)) ''
-      ({z | (p.1, z) ∈ V} ∩ {z | ¬ Surjective (fderiv ℝ (fun z ↦ q (p.1, z)) z)})} with hAdef
+    {p | p.2 ∈ pkg.obstructionSlice hT p.1 ''
+      ({z | (p.1, z) ∈ V} ∩
+        {z | ¬ Surjective (fderiv ℝ (pkg.obstructionSlice hT p.1) z)})} with hAdef
   have hAint : interior A = ∅ := by
     refine interior_eq_empty_of_forall_interior_fiber_eq_empty fun p₁ ↦ ?_
     -- The fibre of `A` over `p₁` is the image of the critical set of the slice at `p₁`.
-    have hfiber : {z | (p₁, z) ∈ A} = (fun z ↦ q (p₁, z)) ''
-        ({z | (p₁, z) ∈ V} ∩ {z | ¬ Surjective (fderiv ℝ (fun z ↦ q (p₁, z)) z)}) := by
+    have hfiber : {z | (p₁, z) ∈ A} = pkg.obstructionSlice hT p₁ ''
+        ({z | (p₁, z) ∈ V} ∩
+          {z | ¬ Surjective (fderiv ℝ (pkg.obstructionSlice hT p₁) z)}) := by
       rw [hAdef]
       ext z
       simp only [Set.mem_ofPred_eq]
@@ -345,14 +353,18 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
     have hUopen : IsOpen {z : pkg.decDom.X₀ | (p₁, z) ∈ V} :=
       hVopen.preimage (by fun_prop)
     have hUC : ∀ z ∈ {z : pkg.decDom.X₀ | (p₁, z) ∈ V},
-        ContDiffAt ℝ (k : ℕ∞ω) (fun z ↦ q (p₁, z)) z := fun z hz ↦
-      ((hVP _ hz).2.1).comp z (contDiffAt_const.prodMk contDiffAt_id)
+        ContDiffAt ℝ (k : ℕ∞ω) (pkg.obstructionSlice hT p₁) z := by
+      intro z hz
+      rw [funext (pkg.obstructionSlice_apply hT p₁), ← hqdef]
+      exact ((hVP _ hz).2.1).comp z (contDiffAt_const.prodMk contDiffAt_id)
     exact interior_image_criticalPoints_eq_empty hUopen hUC hkbound
   have himg : f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)}) ⊆ Λ '' A := by
     rintro _ ⟨x, ⟨hxN, hxc⟩, rfl⟩
     obtain ⟨c₁, -, -, -, -⟩ := hVP (Φ x) (hNV x hxN)
-    refine ⟨((Φ x).1, q (Φ x)), ⟨(Φ x).2, ⟨hNV x hxN, ?_⟩, rfl⟩, ?_⟩
+    refine ⟨((Φ x).1, q (Φ x)), ⟨(Φ x).2, ⟨hNV x hxN, ?_⟩, ?_⟩, ?_⟩
     · exact fun hs ↦ hxc ((hcrit x hxN).2 hs)
+    · rw [hqdef]
+      exact pkg.obstructionSlice_apply hT (Φ x).1 (Φ x).2
     · rw [hΛdef, Submodule.prodEquivOfIsTopCompl_apply]
       conv_rhs => rw [← hNsymm x hxN]
       exact (pkg.apply_normalFormOpenPartialHomeomorph_symm hT c₁).symm
@@ -363,27 +375,27 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
       rw [← h2, hAint, Set.image_empty]
     exact Set.eq_empty_of_subset_empty (h1 ▸ interior_mono himg)
   -- The critical locus is relatively closed in `N`, again read off the finite-dimensional slice.
-  have hWopen : IsOpen {y | y ∈ V ∧ Surjective ((fderiv ℝ q y).comp (sliceIncl pkg))} := by
+  have hWopen : IsOpen {y | y ∈ V ∧ Surjective ((fderiv ℝ q y).comp ι)} := by
     rw [isOpen_iff_mem_nhds]
     rintro y ⟨hyV, hys⟩
     have hcont : ContinuousAt (fderiv ℝ q) y := ((hVP y hyV).2.1).continuousAt_fderiv hk0
-    have hmap : ContinuousAt (fun y' ↦ (fderiv ℝ q y').comp (sliceIncl pkg)) y :=
+    have hmap : ContinuousAt (fun y' ↦ (fderiv ℝ q y').comp ι) y :=
       hcont.clm_comp continuousAt_const
     filter_upwards [hVopen.mem_nhds hyV,
       hmap (IsOpen.mem_nhds isOpen_setOf_surjective hys)] with y' d₁ d₂
     exact ⟨d₁, d₂⟩
   have hregopen : IsOpen {x | x ∈ N ∧ Surjective (fderiv ℝ f x)} := by
     have heq : {x | x ∈ N ∧ Surjective (fderiv ℝ f x)} =
-        N ∩ (Φ.source ∩ Φ ⁻¹' {y | y ∈ V ∧ Surjective ((fderiv ℝ q y).comp (sliceIncl pkg))}) := by
+        N ∩ (Φ.source ∩ Φ ⁻¹' {y | y ∈ V ∧ Surjective ((fderiv ℝ q y).comp ι)}) := by
       ext x
       constructor
       · rintro ⟨hxN, hxs⟩
-        have h1 : Surjective ((fderiv ℝ q (Φ x)).comp (sliceIncl pkg)) := by
+        have h1 : Surjective ((fderiv ℝ q (Φ x)).comp ι) := by
           rw [← hsliceD (Φ x) (hNV x hxN)]
           exact (hcrit x hxN).1 hxs
         exact ⟨hxN, hxN.1, hNV x hxN, h1⟩
       · rintro ⟨hxN, -, -, hs⟩
-        have h2 : Surjective (fderiv ℝ (fun z ↦ q ((Φ x).1, z)) (Φ x).2) := by
+        have h2 : Surjective (fderiv ℝ (pkg.obstructionSlice hT (Φ x).1) (Φ x).2) := by
           rw [hsliceD (Φ x) (hNV x hxN)]
           exact hs
         exact ⟨hxN, (hcrit x hxN).2 h2⟩
@@ -404,30 +416,27 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
       exact (hN'ball hx.1).1
     rw [heq]
     exact Metric.isClosed_closedBall.inter hregopen.isClosed_compl
+  -- Restricted to that closed critical locus, `f` has compact preimages of compact sets, so it is
+  -- a proper map and its image is closed.
   have hclosedimg : IsClosed (f '' (N' ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
-    apply IsSeqClosed.isClosed
-    intro u y hu huy
-    choose x hx hfx using hu
-    have hLcpt : IsCompact (insert y (Set.range u)) := huy.isCompact_insert_range
-    have hK : IsCompact (N' ∩ f ⁻¹' (insert y (Set.range u))) := by
-      have heq : N' ∩ f ⁻¹' (insert y (Set.range u)) =
-          N' ∩ (N₂ ∩ f ⁻¹' (insert y (Set.range u))) :=
-        Set.ext fun z ↦ ⟨fun h ↦ ⟨h.1, (hN'ball h.1).2, h.2⟩, fun h ↦ ⟨h.1, h.2.2⟩⟩
-      rw [heq]
-      exact (hprop _ hLcpt).inter_left Metric.isClosed_closedBall
-    have hxmem : ∀ m, x m ∈ N' ∩ f ⁻¹' (insert y (Set.range u)) := fun m ↦
-      ⟨(hx m).1, by rw [Set.mem_preimage, hfx m]; exact Set.mem_insert_of_mem _ ⟨m, rfl⟩⟩
-    obtain ⟨z, -, φ, hφmono, hφtend⟩ := hK.tendsto_subseq hxmem
-    have hzc : z ∈ N' ∩ {x | ¬ Surjective (fderiv ℝ f x)} :=
-      hcritclosed.mem_of_tendsto hφtend (Filter.Eventually.of_forall fun m ↦ hx (φ m))
-    refine ⟨z, hzc, ?_⟩
-    have hfcont : ContinuousAt f z := (hfN z (hN'ball hzc.1).1).continuousAt
-    have h1 : Filter.Tendsto (fun m ↦ f (x (φ m))) Filter.atTop (𝓝 (f z)) :=
-      hfcont.tendsto.comp hφtend
-    have h2 : Filter.Tendsto (fun m ↦ f (x (φ m))) Filter.atTop (𝓝 y) := by
-      simp_rw [hfx]
-      exact huy.comp hφmono.tendsto_atTop
-    exact tendsto_nhds_unique h1 h2
+    set S : Set E := N' ∩ {x | ¬ Surjective (fderiv ℝ f x)}
+    have hcontOn : ContinuousOn f S := fun x hx ↦
+      (hfN x (hN'ball hx.1).1).continuousAt.continuousWithinAt
+    have hpre : ∀ K : Set F, IsCompact K → IsCompact (S.domRestrict f ⁻¹' K) := by
+      intro K hK
+      rw [Subtype.isCompact_iff]
+      have himg : ((↑) : S → E) '' (S.domRestrict f ⁻¹' K) = S ∩ (N₂ ∩ f ⁻¹' K) := by
+        ext z
+        constructor
+        · rintro ⟨⟨z, hz⟩, hzK, rfl⟩
+          exact ⟨hz, (hN'ball hz.1).2, hzK⟩
+        · rintro ⟨hz, -, hzK⟩
+          exact ⟨⟨z, hz⟩, hzK, rfl⟩
+      rw [himg]
+      exact (hprop K hK).inter_left hcritclosed
+    have himgclosed := (isProperMap_iff_isCompact_preimage.2
+      ⟨hcontOn.domRestrict, fun K hK ↦ hpre K hK⟩).isClosedMap _ isClosed_univ
+    rwa [Set.image_univ, Set.range_domRestrict] at himgclosed
   refine ⟨N', hN'nhds, hclosedimg, ?_⟩
   rw [hclosedimg.isNowhereDense_iff]
   refine Set.eq_empty_of_subset_empty ?_

--- a/TauCeti/Analysis/Fredholm/SardSmale.lean
+++ b/TauCeti/Analysis/Fredholm/SardSmale.lean
@@ -59,7 +59,8 @@ interior need not be meagre.
 
 The global statement follows by covering: a second-countable domain is Lindelöf, so countably many
 of these balls suffice, and a countable union of closed nowhere dense sets is meagre. Density of
-the regular values is then the Baire category theorem in the complete space `F`.
+the regular values is then the Baire category theorem. The `CompleteSpace F` assumption supplies
+both the Baire instance and the local properness used above to prove closedness.
 
 The regularity threshold is inherited unchanged from the finite-dimensional theorem: `C^k` with
 `k ≥ (dim ker)² + 1`, rather than Smale's sharp `k > index`, because the underlying
@@ -229,6 +230,9 @@ private theorem surjective_fderiv_iff_slice (pkg : ContinuousLinearMap.FredholmP
 
 /-- **Sard--Smale, locally.** Near a point where a sufficiently smooth map has Fredholm
 derivative there is a neighbourhood on which the critical values form a closed nowhere dense set.
+
+Completeness of the target enters through Smale's local properness lemma, which supplies the
+compactness used to prove that the local critical-value image is closed.
 
 The regularity threshold `(dim ker)² + 1` is the one inherited from the finite-dimensional
 Morse--Sard theorem `TauCeti.interior_image_criticalPoints_eq_empty`, which the fibrewise step


### PR DESCRIPTION
This PR proves the **Sard--Smale theorem**: the critical values of a smooth Fredholm map between real Banach spaces form a meagre set, so its regular values are residual and, the target being complete, dense. The exact roadmap target is `TauCetiRoadmap/HeegaardFloer/README.md`, **Lane F0 ("the nonlinear-analysis substrate")**, whose bullet list names "**Sard--Smale** (Smale 1965)" alongside finite-dimensional Sard, Fredholm operators and the Fredholm-section package; `HeegaardFloer/STATUS.md` records that "the transversality half has not started", and `SardSmale` grepped to zero in `TauCeti/` before this PR. The milestone this serves is Lane F0 itself, the substrate every later lane consumes: the roadmap says Sard--Smale "blocks Morse--Smale transversality in Lane M, Sard--Smale in F0, and every transversality argument downstream". After this PR, Lane F0 still needs the Fredholm property of the strip operator `d/ds + A(s)` with invertible asymptotics, and the universal-moduli form of transversality (a Fredholm section of a Banach bundle over a Banach space of parameters, cut out generically as a manifold of dimension the index) that Lanes F2.4 and F4.3 actually apply; the linear half, the normal form, local properness and the regular-level-set charts were already in place.

This was the most effective current step because every ingredient Smale's proof needs had just landed and nothing consumed them. Finite-dimensional Morse--Sard is on `main` as `TauCeti.ContDiff.addHaar_image_criticalPoints_eq_zero` (TauCeti#4125), the Lyapunov--Schmidt reduction with its `C^k` obstruction slice is `TauCeti/Analysis/Fredholm/NormalForm.lean` (whose docstring calls itself "the normal-form ingredient of the Sard--Smale argument"), and Smale's local properness lemma is `TauCeti/Analysis/Fredholm/Proper.lean` (whose docstring calls itself "the geometric half of the input to the Sard--Smale theorem"). The two open HeegaardFloer pull requests, TauCeti#4189 and TauCeti#4254, are both Lane M (the Morse index and negative-gradient trajectories) and do not touch this.

The proof runs in two halves. Empty interior: in the normal-form chart `Φ` at a point `a` the map reads `y ↦ y.1 + q y` with the obstruction `q` valued in the finite-dimensional complement of the range, so the derivative at `Φ.symm y` is surjective exactly when the derivative of the slice `z ↦ q (y.1, z)` is -- a map between `ker` and `coker`. Finite-dimensional Morse--Sard applies to each slice, so the image of the critical set meets each fibre of `X₁ × X₀` in a set with empty interior, and a set all of whose fibres over a finite-dimensional factor have empty interior has empty interior, an interior point supplying a whole box. Closedness: on a small closed ball the preimage of a compact set is compact, and the critical locus is relatively closed there because surjectivity is again read off the finite-dimensional slice, where `TauCeti.isOpen_setOf_surjective` applies; a convergent sequence of critical values then has a subsequentially convergent sequence of sources. Without that half only density, not residuality, would follow, since a countable union of sets with empty interior need not be meagre. Globally, a second-countable domain is Lindelöf, so countably many balls suffice, and Baire in the complete target gives density. The chart is shown to be a local diffeomorphism near the base point using Mathlib's `ContinuousLinearEquiv.isOpen` (invertible operators are open) together with continuity of `fderiv` of the inverse chart, so `OpenPartialHomeomorph.hasStrictFDerivAt_symm` is never needed away from `a`.

The regularity threshold is `C^k` with `k ≥ (dim ker)² + 1` rather than Smale's sharp `k > index`, stated honestly as such in the module docstring: it is inherited unchanged from `TauCeti.addHaar_image_criticalPoints_eq_zero`, which is itself proved with that cruder bound rather than the sharp Morse--Sard exponent. Sharpening it is a change to the finite-dimensional theorem, not to this file.

Adds `TauCeti/Analysis/Fredholm/SardSmale.lean` (470 lines), beside the existing `NormalForm.lean` and `Proper.lean` it consumes; the roadmap's suggested home for the analytic lanes is `TauCeti/Analysis/`, and `HeegaardFloer/Suggested.lean` carries no compiled targets to state against. Also adds `TauCeti.interior_image_criticalPoints_eq_empty` (21 lines) to `TauCeti/Analysis/Calculus/Sard/OutermostStratum.lean`, the measure-free restatement of Morse--Sard that the fibrewise step consumes: the slice target is a complement subspace of an arbitrary Banach space and carries no `MeasurableSpace` instance, so the Haar measure is chosen inside the proof with `borelize`. No Mathlib source and no external formalization is vendored; Mathlib's `FredholmPackage`, implicit function theorem, `ContinuousLinearEquiv.isOpen`, `IsNowhereDense`/`IsMeagre` and Baire category theorem are reused directly. The mathematics follows S. Smale, *An infinite dimensional version of Sard's theorem*, Amer. J. Math. 87 (1965), 861--866, and McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., Appendix A, both cited in the module documentation.

I was assigned `CFSGStatement` as a preference. It again has no advanceable milestone: `ClassificationStatement`, `simpleRootSubgroup` and `SplitReductive` all still grep to zero in `TauCeti/`, so L0--L4 wait on ReductiveGroups Layer 9 (24 open pull requests this round, the most contested roadmap by a wide margin), I0/S0/S1 are complete, and A0's universe-descent half was closed rather than merged. This is a substitution under the "choose another roadmap directory" rule, not a prerequisite chain, so there is no consumer edge to declare.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"sard-smale"}-->

🤖 Prepared with Claude Code
