### PR TITLE
feat: integrability of an irreducible highest weight module

### DIFF
--- a/TauCeti/Algebra/Lie/HighestWeight/Integrable.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Integrable.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.HighestWeight.Integrability
+public import TauCeti.Algebra.Lie.Sl2.WeightString
 public import TauCeti.Algebra.Lie.Submodule.LocallyFinite
 
 public section
@@ -41,14 +42,14 @@ weight vector settles which.
 * For the **simple lowering** vector `fᵢ` the input is the integrability relation of
   `TauCeti/Algebra/Lie/HighestWeight/Integrability.lean`: in an irreducible highest weight module
   `fᵢ^{n + 1} v = 0`, where `n = lam (αᵢ^∨)`.
-* Local finiteness needs one explicit finite-dimensional subspace, and the same relation supplies
-  it: the span of `v, fᵢ v, …, fᵢ^n v` is stable under the `sl₂` triple of `αᵢ`, because the ladder
-  lemmas of Mathlib's `Sl2.lean` evaluate `hᵢ` and `eᵢ` on each `fᵢ^k v` as a multiple of `fᵢ^k v`
-  and of `fᵢ^{k - 1} v`, while `fᵢ` moves along the list and off its end into `0`.
+* Local finiteness uses finite-dimensionality of `L` and the explicit stable weight-string
+  submodule `TauCeti.weightStringSubmodule`; the integrability relation truncates its generating
+  string to `v, fᵢ v, …, fᵢ^n v`, so its underlying submodule is finitely generated.
 
-Both conclusions need `ad` of the root vector to be nilpotent, which is Mathlib's
+The local-nilpotence results also need `ad` of the root vector to be nilpotent, which is Mathlib's
 `LieAlgebra.isNilpotent_ad_of_mem_rootSpace`: a root vector moves the root spaces of `L` by a
-nonzero root, and `L` has only finitely many.
+nonzero root, and `L` has only finitely many. The local-finiteness result does not use this
+hypothesis.
 
 ## Main results
 
@@ -100,7 +101,8 @@ theorem exists_pow_toEnd_eq_zero_of_mem_posRoots [LieModule.IsIrreducible K L M]
   have hα : (i : Weight K H L).IsNonZero := H.isNonZero_coe_root i
   have had : IsNilpotent (ad K L e) :=
     LieAlgebra.isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(i : Weight K H L)) hα he
-  refine exists_pow_toEnd_eq_zero_of_isIrreducible had hv.ne_zero (k₀ := 1) ?_ m
+  refine exists_pow_toEnd_eq_zero_of_isIrreducible
+    (Module.End.isNilpotent_iff_of_finite.mp had) hv.ne_zero (k₀ := 1) ?_ m
   rw [pow_one]
   exact hv.lie_eq_zero_of_mem_rootSpace hi he
 
@@ -120,12 +122,14 @@ theorem exists_pow_toEnd_eq_zero_of_mem_rootSpace_neg [LieModule.IsIrreducible K
   have hα : (i : Weight K H L).IsNonZero := H.isNonZero_coe_root i
   have had : IsNilpotent (ad K L f) :=
     LieAlgebra.isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-(i : Weight K H L))) hα.neg hf
-  exact exists_pow_toEnd_eq_zero_of_isIrreducible had hv.ne_zero
+  exact exists_pow_toEnd_eq_zero_of_isIrreducible
+    (Module.End.isNilpotent_iff_of_finite.mp had) hv.ne_zero
     (pow_toEnd_eq_zero_of_isHighestWeightVector_of_isIrreducible hv hi hn hf) m
 
-/-- **Local nilpotence along a simple root, from dominance.** A dominant integral highest weight is
-integral along every simple root, so both root vectors of a simple root act locally nilpotently on
-an irreducible highest weight module of that weight. -/
+/-- **Local nilpotence of a lowering vector, from dominance.** A dominant integral highest weight
+is integral along every simple root, so each simple lowering vector acts locally nilpotently on an
+irreducible highest weight module of that weight. The positive-root half is
+`TauCeti.exists_pow_toEnd_eq_zero_of_mem_posRoots`. -/
 theorem exists_pow_toEnd_eq_zero_of_mem_rootSpace_neg_of_isDominantIntegral
     [LieModule.IsIrreducible K L M]
     (hv : IsHighestWeightVector b lam v) (hlam : IsDominantIntegral b lam) {i : H.root}
@@ -163,39 +167,30 @@ theorem locallyFiniteSubmodule_eq_top_of_isSl2Triple [LieModule.IsIrreducible K 
       lie_e := hv.lie_eq_zero_of_mem_rootSpace hipos he₀ }
   have hzero : ((toEnd K L M f₀) ^ (n + 1)) v = 0 :=
     pow_toEnd_eq_zero_of_isHighestWeightVector_of_isIrreducible hv hi hn hf₀
-  -- the span of the `αᵢ`-string below `v`
-  set N₀ : Submodule K M :=
-    Submodule.span K (Set.range fun k : Fin (n + 1) => ((toEnd K L M f₀) ^ (k : ℕ)) v) with hN₀
-  have hmemN₀ : ∀ k : Fin (n + 1), ((toEnd K L M f₀) ^ (k : ℕ)) v ∈ N₀ := fun k =>
-    Submodule.subset_span ⟨k, rfl⟩
-  -- it is stable under each member of the triple
-  have hgen : ∀ x ∈ ({e₀, f₀, h₀} : Set L), ∀ k : Fin (n + 1),
-      ⁅x, ((toEnd K L M f₀) ^ (k : ℕ)) v⁆ ∈ N₀ := by
-    rintro x (rfl | rfl | rfl) k
-    · rcases Nat.eq_zero_or_pos (k : ℕ) with hk | hk
-      · rw [hk, pow_zero, Module.End.one_apply, hP.lie_e]
-        exact zero_mem _
-      · obtain ⟨j, hj⟩ := Nat.exists_eq_add_of_lt hk
-        rw [show (k : ℕ) = j + 1 by lia, hP.lie_e_pow_succ_toEnd_f j]
-        exact Submodule.smul_mem _ _ (hmemN₀ ⟨j, by lia⟩)
-    · rw [hP.lie_f_pow_toEnd_f (k : ℕ)]
-      rcases eq_or_lt_of_le (Nat.lt_succ_iff.mp k.isLt) with hk | hk
-      · rw [hk, hzero]
-        exact zero_mem _
-      · exact hmemN₀ ⟨(k : ℕ) + 1, by lia⟩
-    · rw [hP.lie_h_pow_toEnd_f (k : ℕ)]
-      exact Submodule.smul_mem _ _ (hmemN₀ k)
-  have hst : ∀ x ∈ ({e₀, f₀, h₀} : Set L), ∀ u ∈ N₀, ⁅x, u⁆ ∈ N₀ := by
+  -- Reuse the stable weight-string submodule; `hzero` truncates its generators to a finite set.
+  set N₀ : Submodule K M := (weightStringSubmodule hP).toSubmodule with hN₀
+  have hspan : N₀ =
+      Submodule.span K (Set.range fun k : Fin (n + 1) => ((toEnd K L M f₀) ^ (k : ℕ)) v) := by
+    rw [hN₀, weightStringSubmodule_toSubmodule]
+    refine le_antisymm (Submodule.span_le.2 ?_) (Submodule.span_le.2 ?_)
+    · rintro _ ⟨k, rfl⟩
+      by_cases hk : k < n + 1
+      · exact Submodule.subset_span ⟨⟨k, hk⟩, rfl⟩
+      · have hkzero := Module.End.pow_map_zero_of_le (Nat.le_of_not_gt hk) hzero
+        dsimp only
+        rw [hkzero]
+        exact Submodule.zero_mem _
+    · rintro _ ⟨k, rfl⟩
+      exact Submodule.subset_span ⟨(k : ℕ), rfl⟩
+  have hfgN₀ : N₀.FG := hspan.symm ▸ Submodule.fg_span (Set.finite_range _)
+  have hst : ∀ x ∈ (t.toLieSubalgebra K : Set L), ∀ u ∈ N₀, ⁅x, u⁆ ∈ N₀ := by
     intro x hx u hu
-    have hle : N₀ ≤ Submodule.comap (toEnd K L M x) N₀ := by
-      rw [hN₀, Submodule.span_le]
-      rintro _ ⟨k, rfl⟩
-      exact hgen x hx k
-    exact hle hu
+    rw [hN₀] at hu ⊢
+    exact (weightStringSubmodule hP).lie_mem (x := ⟨x, hx⟩) hu
   -- irreducibility spreads local finiteness from `v` to all of `M`
-  have htop : locallyFiniteSubmodule K M ({e₀, f₀, h₀} : Set L) = ⊤ :=
-    locallyFiniteSubmodule_eq_top_of_isIrreducible (Submodule.fg_span (Set.finite_range _)) hst
-      hv.ne_zero (by simpa using hmemN₀ ⟨0, Nat.succ_pos n⟩)
-  rwa [← locallyFiniteSubmodule_span] at htop
+  have hvN₀ : v ∈ N₀ := by
+    rw [hN₀]
+    exact mem_weightStringSubmodule hP
+  exact locallyFiniteSubmodule_eq_top_of_isIrreducible hfgN₀ hst hv.ne_zero hvN₀
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/HighestWeight/Integrable.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/Integrable.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.HighestWeight.Integrability
+public import TauCeti.Algebra.Lie.Submodule.LocallyFinite
+
+public section
+
+/-!
+# An irreducible highest weight module of dominant integral weight is integrable
+
+Let `L` be a finite-dimensional Lie algebra with non-degenerate Killing form over a field of
+characteristic zero, let `H` be a splitting Cartan subalgebra, let `b` be a base of its root system
+and let `M` be an irreducible `L`-module carrying a highest weight vector `v` of weight `lam`.
+This file proves that when `lam` is integral along a simple root `αᵢ` the module `M` is
+**integrable** in that direction:
+
+* both root vectors of `αᵢ` act **locally nilpotently** on the whole of `M`, and
+* every vector of `M` lies in a **finitely generated** subspace stable under the `sl₂` triple of
+  `αᵢ`, so that `M` is a locally finite module over that triple.
+
+Integrability is the property that turns the weight cone `lam - Q⁺` of
+`TauCeti/Algebra/Lie/HighestWeight/Module.lean` into a *finite* set: only for an integrable module
+is the set of weights stable under the Weyl group, and it is that stability, together with the
+cone, which bounds the weights and eventually makes `L(lam)` finite-dimensional.
+
+## The argument
+
+Both statements have the same shape. The condition in question — being annihilated by a power of a
+fixed element, or lying in a finitely generated subspace stable under a fixed set of elements —
+holds on a Lie submodule of `M`, by `TauCeti/Algebra/Lie/Submodule/LocallyFinite.lean`; an
+irreducible module is therefore either everywhere or nowhere in that condition, and the highest
+weight vector settles which.
+
+* For a **positive** root vector `e` nothing is needed beyond the definition of a highest weight
+  vector: `e` annihilates `v` outright. The relevant Lie submodule contains `v`, hence is `⊤`.
+* For the **simple lowering** vector `fᵢ` the input is the integrability relation of
+  `TauCeti/Algebra/Lie/HighestWeight/Integrability.lean`: in an irreducible highest weight module
+  `fᵢ^{n + 1} v = 0`, where `n = lam (αᵢ^∨)`.
+* Local finiteness needs one explicit finite-dimensional subspace, and the same relation supplies
+  it: the span of `v, fᵢ v, …, fᵢ^n v` is stable under the `sl₂` triple of `αᵢ`, because the ladder
+  lemmas of Mathlib's `Sl2.lean` evaluate `hᵢ` and `eᵢ` on each `fᵢ^k v` as a multiple of `fᵢ^k v`
+  and of `fᵢ^{k - 1} v`, while `fᵢ` moves along the list and off its end into `0`.
+
+Both conclusions need `ad` of the root vector to be nilpotent, which is Mathlib's
+`LieAlgebra.isNilpotent_ad_of_mem_rootSpace`: a root vector moves the root spaces of `L` by a
+nonzero root, and `L` has only finitely many.
+
+## Main results
+
+* `TauCeti.exists_pow_toEnd_eq_zero_of_mem_posRoots`: every positive root vector acts locally
+  nilpotently on an irreducible highest weight module.
+* `TauCeti.exists_pow_toEnd_eq_zero_of_mem_rootSpace_neg`: so does every lowering vector of a
+  simple root along which the highest weight is integral, and
+  `TauCeti.exists_pow_toEnd_eq_zero_of_mem_rootSpace_neg_of_isDominantIntegral` reads that off
+  dominance.
+* `TauCeti.locallyFiniteSubmodule_eq_top_of_isSl2Triple`: **integrability**, that every vector of
+  the module lies in a finitely generated subspace stable under the `sl₂` triple of such a simple
+  root.
+
+## References
+
+This is the local-nilpotence half of the "maximal integrable quotient and local nilpotence"
+milestone of Layer 4, "the classification of finite-dimensional irreducibles", of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §21.2.
+* V. G. Kac, *Infinite Dimensional Lie Algebras*, 3rd ed., §3.6.
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule Module
+
+universe u v w
+
+variable {K : Type u} {L : Type v} [Field K] [CharZero K] [LieRing L] [LieAlgebra K L]
+  [IsKilling K L] [FiniteDimensional K L]
+  {H : LieSubalgebra K L} [H.IsCartanSubalgebra] [IsTriangularizable K H L]
+  {M : Type w} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+  {b : (IsKilling.rootSystem H).Base} {lam : Dual K H} {v : M}
+
+/-! ### Local nilpotence of the root vectors -/
+
+/-- **A positive root vector acts locally nilpotently.** On an irreducible module carrying a
+highest weight vector, every element of a positive root space is annihilated on every vector by
+one of its powers.
+
+The positive root spaces annihilate the highest weight vector itself, and `ad` of a root vector is
+nilpotent, so the locally nilpotent vectors form a nonzero Lie submodule. -/
+theorem exists_pow_toEnd_eq_zero_of_mem_posRoots [LieModule.IsIrreducible K L M]
+    (hv : IsHighestWeightVector b lam v) {i : H.root}
+    (hi : i ∈ posRoots (IsKilling.rootSystem H) b)
+    {e : L} (he : e ∈ rootSpace H ((i : Weight K H L) : H → K)) (m : M) :
+    ∃ k : ℕ, ((toEnd K L M e) ^ k) m = 0 := by
+  have hα : (i : Weight K H L).IsNonZero := H.isNonZero_coe_root i
+  have had : IsNilpotent (ad K L e) :=
+    LieAlgebra.isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(i : Weight K H L)) hα he
+  refine exists_pow_toEnd_eq_zero_of_isIrreducible had hv.ne_zero (k₀ := 1) ?_ m
+  rw [pow_one]
+  exact hv.lie_eq_zero_of_mem_rootSpace hi he
+
+/-- **The lowering vector of a simple root acts locally nilpotently.** If the highest weight `lam`
+of an irreducible highest weight module takes the natural value `n` on the coroot of a simple root
+`αᵢ`, then every element of the `-αᵢ` root space is annihilated on every vector by one of its
+powers.
+
+The integrability relation `TauCeti.pow_toEnd_eq_zero_of_isHighestWeightVector_of_isIrreducible`
+makes `fᵢ^{n + 1}` annihilate the highest weight vector, and the locally nilpotent vectors form a
+Lie submodule. -/
+theorem exists_pow_toEnd_eq_zero_of_mem_rootSpace_neg [LieModule.IsIrreducible K L M]
+    (hv : IsHighestWeightVector b lam v) {i : H.root} (hi : i ∈ b.support) {n : ℕ}
+    (hn : lam ((IsKilling.rootSystem H).coroot i) = (n : K))
+    {f : L} (hf : f ∈ rootSpace H ((-(i : Weight K H L) : Weight K H L) : H → K)) (m : M) :
+    ∃ k : ℕ, ((toEnd K L M f) ^ k) m = 0 := by
+  have hα : (i : Weight K H L).IsNonZero := H.isNonZero_coe_root i
+  have had : IsNilpotent (ad K L f) :=
+    LieAlgebra.isNilpotent_ad_of_mem_rootSpace H (χ := ⇑(-(i : Weight K H L))) hα.neg hf
+  exact exists_pow_toEnd_eq_zero_of_isIrreducible had hv.ne_zero
+    (pow_toEnd_eq_zero_of_isHighestWeightVector_of_isIrreducible hv hi hn hf) m
+
+/-- **Local nilpotence along a simple root, from dominance.** A dominant integral highest weight is
+integral along every simple root, so both root vectors of a simple root act locally nilpotently on
+an irreducible highest weight module of that weight. -/
+theorem exists_pow_toEnd_eq_zero_of_mem_rootSpace_neg_of_isDominantIntegral
+    [LieModule.IsIrreducible K L M]
+    (hv : IsHighestWeightVector b lam v) (hlam : IsDominantIntegral b lam) {i : H.root}
+    (hi : i ∈ b.support)
+    {f : L} (hf : f ∈ rootSpace H ((-(i : Weight K H L) : Weight K H L) : H → K)) (m : M) :
+    ∃ k : ℕ, ((toEnd K L M f) ^ k) m = 0 := by
+  obtain ⟨n, hn⟩ := isDominantIntegral_iff.mp hlam i hi
+  exact exists_pow_toEnd_eq_zero_of_mem_rootSpace_neg hv hi hn hf m
+
+/-! ### Local finiteness over the `sl₂` triple of a simple root -/
+
+/-- **Integrability of an irreducible highest weight module along a simple root.** Let `M` be
+irreducible with a highest weight vector `v` of weight `lam`, let `αᵢ` be a simple root and suppose
+`lam (αᵢ^∨) = n` is a natural number. Then `M` is a locally finite module over the `sl₂` triple of
+`αᵢ`: every vector lies in a finitely generated subspace stable under that triple.
+
+The witness for `v` itself is the span of `v, fᵢ v, …, fᵢ^n v`: the ladder lemmas of Mathlib's
+`Sl2.lean` keep `hᵢ` and `eᵢ` inside it, and `fᵢ` walks along it and off its end into `0`, by the
+integrability relation. Local finiteness holds on a Lie submodule, so irreducibility spreads it
+from `v` to all of `M`. -/
+theorem locallyFiniteSubmodule_eq_top_of_isSl2Triple [LieModule.IsIrreducible K L M]
+    (hv : IsHighestWeightVector b lam v) {i : H.root} (hi : i ∈ b.support) {n : ℕ}
+    (hn : lam ((IsKilling.rootSystem H).coroot i) = (n : K)) {h₀ e₀ f₀ : L}
+    (t : IsSl2Triple h₀ e₀ f₀) (he₀ : e₀ ∈ rootSpace H ((i : Weight K H L) : H → K))
+    (hf₀ : f₀ ∈ rootSpace H ((-(i : Weight K H L) : Weight K H L) : H → K)) :
+    locallyFiniteSubmodule K M (t.toLieSubalgebra K : Set L) = ⊤ := by
+  have hα : (i : Weight K H L).IsNonZero := H.isNonZero_coe_root i
+  have hipos := support_subset_posRoots (IsKilling.rootSystem H) b hi
+  -- the generating vector is a primitive vector of eigenvalue `n` for the triple of `αᵢ`
+  have hP : t.HasPrimitiveVectorWith v (n : K) :=
+    { ne_zero := hv.ne_zero
+      lie_h := by
+        rw [t.h_eq_coroot hα he₀ hf₀, ← hn, IsKilling.rootSystem_coroot_apply]
+        exact hv.lie_eq_smul _
+      lie_e := hv.lie_eq_zero_of_mem_rootSpace hipos he₀ }
+  have hzero : ((toEnd K L M f₀) ^ (n + 1)) v = 0 :=
+    pow_toEnd_eq_zero_of_isHighestWeightVector_of_isIrreducible hv hi hn hf₀
+  -- the span of the `αᵢ`-string below `v`
+  set N₀ : Submodule K M :=
+    Submodule.span K (Set.range fun k : Fin (n + 1) => ((toEnd K L M f₀) ^ (k : ℕ)) v) with hN₀
+  have hmemN₀ : ∀ k : Fin (n + 1), ((toEnd K L M f₀) ^ (k : ℕ)) v ∈ N₀ := fun k =>
+    Submodule.subset_span ⟨k, rfl⟩
+  -- it is stable under each member of the triple
+  have hgen : ∀ x ∈ ({e₀, f₀, h₀} : Set L), ∀ k : Fin (n + 1),
+      ⁅x, ((toEnd K L M f₀) ^ (k : ℕ)) v⁆ ∈ N₀ := by
+    rintro x (rfl | rfl | rfl) k
+    · rcases Nat.eq_zero_or_pos (k : ℕ) with hk | hk
+      · rw [hk, pow_zero, Module.End.one_apply, hP.lie_e]
+        exact zero_mem _
+      · obtain ⟨j, hj⟩ := Nat.exists_eq_add_of_lt hk
+        rw [show (k : ℕ) = j + 1 by lia, hP.lie_e_pow_succ_toEnd_f j]
+        exact Submodule.smul_mem _ _ (hmemN₀ ⟨j, by lia⟩)
+    · rw [hP.lie_f_pow_toEnd_f (k : ℕ)]
+      rcases eq_or_lt_of_le (Nat.lt_succ_iff.mp k.isLt) with hk | hk
+      · rw [hk, hzero]
+        exact zero_mem _
+      · exact hmemN₀ ⟨(k : ℕ) + 1, by lia⟩
+    · rw [hP.lie_h_pow_toEnd_f (k : ℕ)]
+      exact Submodule.smul_mem _ _ (hmemN₀ k)
+  have hst : ∀ x ∈ ({e₀, f₀, h₀} : Set L), ∀ u ∈ N₀, ⁅x, u⁆ ∈ N₀ := by
+    intro x hx u hu
+    have hle : N₀ ≤ Submodule.comap (toEnd K L M x) N₀ := by
+      rw [hN₀, Submodule.span_le]
+      rintro _ ⟨k, rfl⟩
+      exact hgen x hx k
+    exact hle hu
+  -- irreducibility spreads local finiteness from `v` to all of `M`
+  have htop : locallyFiniteSubmodule K M ({e₀, f₀, h₀} : Set L) = ⊤ :=
+    locallyFiniteSubmodule_eq_top_of_isIrreducible (Submodule.fg_span (Set.finite_range _)) hst
+      hv.ne_zero (by simpa using hmemN₀ ⟨0, Nat.succ_pos n⟩)
+  rwa [← locallyFiniteSubmodule_span] at htop
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Submodule/LocallyFinite.lean
+++ b/TauCeti/Algebra/Lie/Submodule/LocallyFinite.lean
@@ -20,7 +20,7 @@ Lie submodule and are therefore either vacuous or universal on an irreducible mo
 
 * `x : L` acts **locally nilpotently** at `m` when `x^k` annihilates `m` for some `k`. The set of
   such `m` is the generalized `0`-eigenspace of the action of `x`, and it is a Lie submodule as
-  soon as `ad x` is a nilpotent endomorphism of `L`: this is Mathlib's
+  soon as `ad x` acts locally nilpotently on `L`: this is Mathlib's
   `LieModule.lie_mem_maxGenEigenspace_toEnd` at the eigenvalue `0 + 0`.
 * A set `S ⊆ L` acts **locally finitely** at `m` when `m` lies in a finitely generated
   `R`-submodule of `M` stable under bracketing with every element of `S`. The set of such `m` is a
@@ -35,15 +35,16 @@ annihilated by a power of each simple root vector; see
 
 ## Main definitions
 
-* `TauCeti.locallyNilpotentSubmodule`: the vectors annihilated by a power of a fixed `ad`-nilpotent
-  element, as a Lie submodule.
+* `TauCeti.locallyNilpotentSubmodule`: the vectors annihilated by a power of a fixed element whose
+  adjoint action is locally nilpotent, as a Lie submodule.
 * `TauCeti.locallyFiniteSubmodule`: the vectors lying in a finitely generated subspace stable under
   a fixed set of elements, as a Lie submodule.
 
 ## Main results
 
-* `TauCeti.exists_pow_toEnd_eq_zero_of_isIrreducible`: on an irreducible module, an `ad`-nilpotent
-  element that is locally nilpotent at one nonzero vector is locally nilpotent everywhere.
+* `TauCeti.exists_pow_toEnd_eq_zero_of_isIrreducible`: on an irreducible module, an element whose
+  adjoint action is locally nilpotent and which is locally nilpotent at one nonzero vector is
+  locally nilpotent everywhere.
 * `TauCeti.locallyFiniteSubmodule_span`: only the span of `S` matters, so the condition may be
   stated against a generating set and consumed against the subalgebra it generates.
 * `TauCeti.locallyFiniteSubmodule_eq_top_of_isIrreducible`: on an irreducible module, a set that
@@ -55,9 +56,9 @@ The underlying subspace of `TauCeti.locallyNilpotentSubmodule` is Mathlib's
 `Module.End.maxGenEigenspace` of the action of `x` at the eigenvalue `0`, which Mathlib itself
 promotes to a Lie submodule only as `LieModule.genWeightSpaceOf`, under the hypothesis that `L` is
 a *nilpotent* Lie algebra. That hypothesis fails for the semisimple Lie algebras this file is
-written for, and the nilpotence of `ad x` replaces it: it is what makes every element of `L` lie
-in the generalized `0`-eigenspace of `ad x`, which is all the argument of `genWeightSpaceOf` ever
-uses.
+written for, and the local nilpotence of `ad x` replaces it: it is what makes every element of `L`
+lie in the generalized `0`-eigenspace of `ad x`, which is all the argument of `genWeightSpaceOf`
+ever uses.
 
 ## References
 
@@ -81,31 +82,34 @@ variable (R M) in
 /-- The vectors of `M` annihilated by some power of the action of `x`, as a Lie submodule.
 
 The underlying subspace is the generalized `0`-eigenspace of `x` acting on `M`; it is stable under
-all of `L` because `ad x` is assumed nilpotent, so that every element of `L` lies in the
+all of `L` because `ad x` is assumed locally nilpotent, so that every element of `L` lies in the
 generalized `0`-eigenspace of `ad x`. -/
-def locallyNilpotentSubmodule (x : L) (hx : IsNilpotent (ad R L x)) : LieSubmodule R L M where
+def locallyNilpotentSubmodule (x : L)
+    (hx : ∀ y : L, ∃ k : ℕ, ((ad R L x) ^ k) y = 0) : LieSubmodule R L M where
   __ := (toEnd R L M x).maxGenEigenspace 0
   lie_mem {y m} hm := by
     have hy : y ∈ (ad R L x).maxGenEigenspace 0 := by
-      obtain ⟨k, hk⟩ := hx
       simp only [Module.End.mem_maxGenEigenspace, zero_smul, sub_zero]
-      exact ⟨k, by rw [hk]; rfl⟩
+      exact hx y
     simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
       Submodule.mem_toAddSubmonoid] at hm ⊢
     rw [← zero_add (0 : R)]
     exact LieModule.lie_mem_maxGenEigenspace_toEnd hy hm
 
 @[simp]
-theorem mem_locallyNilpotentSubmodule {x : L} {hx : IsNilpotent (ad R L x)} {m : M} :
+theorem mem_locallyNilpotentSubmodule {x : L}
+    {hx : ∀ y : L, ∃ k : ℕ, ((ad R L x) ^ k) y = 0} {m : M} :
     m ∈ locallyNilpotentSubmodule R M x hx ↔ ∃ k : ℕ, ((toEnd R L M x) ^ k) m = 0 := by
+  -- The constructor has no named lemma for its inherited carrier, so expose the definitionally
+  -- equal generalized eigenspace before applying its membership simp lemma.
   change m ∈ (toEnd R L M x).maxGenEigenspace 0 ↔ _
   simp
 
-/-- **Local nilpotence spreads over an irreducible module.** If `ad x` is nilpotent and some
-nonzero vector of an irreducible module `M` is annihilated by a power of `x`, then every vector of
-`M` is. -/
+/-- **Local nilpotence spreads over an irreducible module.** If `ad x` is locally nilpotent and
+some nonzero vector of an irreducible module `M` is annihilated by a power of `x`, then every
+vector of `M` is. -/
 theorem exists_pow_toEnd_eq_zero_of_isIrreducible [LieModule.IsIrreducible R L M] {x : L}
-    (hx : IsNilpotent (ad R L x)) {m₀ : M} (hm₀ : m₀ ≠ 0) {k₀ : ℕ}
+    (hx : ∀ y : L, ∃ k : ℕ, ((ad R L x) ^ k) y = 0) {m₀ : M} (hm₀ : m₀ ≠ 0) {k₀ : ℕ}
     (hk₀ : ((toEnd R L M x) ^ k₀) m₀ = 0) (m : M) :
     ∃ k : ℕ, ((toEnd R L M x) ^ k) m = 0 := by
   have : Nontrivial (locallyNilpotentSubmodule R M x hx) :=
@@ -156,6 +160,8 @@ def locallyFiniteSubmodule [Module.Finite R L] (S : Set L) : LieSubmodule R L M 
     refine sup_le (((map_toEnd_le_iff).mpr (hst x hx)).trans le_sup_left) ?_
     rw [hQ, Submodule.map_le_iff_le_comap, Submodule.map₂_le]
     intro z _ u hu
+    -- `Submodule.map₂_le` exposes the locally defined bilinear map `br`; unfold its
+    -- definitional action to put the Jacobi identity into bracket notation.
     change ⁅x, ⁅z, u⁆⁆ ∈ N ⊔ Q
     rw [leibniz_lie]
     exact add_mem (Submodule.mem_sup_right (hbr ⁅x, z⁆ hu))
@@ -169,6 +175,7 @@ theorem mem_locallyFiniteSubmodule [Module.Finite R L] {S : Set L} {m : M} :
 
 /-- Only the span of `S` matters: a subspace stable under `S` is stable under the `R`-submodule
 that `S` generates, the stability condition being linear in the bracketing element. -/
+@[simp]
 theorem locallyFiniteSubmodule_span [Module.Finite R L] (S : Set L) :
     locallyFiniteSubmodule R M (Submodule.span R S : Set L) = locallyFiniteSubmodule R M S := by
   refine le_antisymm ?_ ?_

--- a/TauCeti/Algebra/Lie/Submodule/LocallyFinite.lean
+++ b/TauCeti/Algebra/Lie/Submodule/LocallyFinite.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Lie.Semisimple.Defs
 public import Mathlib.Algebra.Lie.Weights.Basic
-public import Mathlib.Algebra.Module.Submodule.Bilinear
+public import Mathlib.RingTheory.Finiteness.Bilinear
 
 public section
 
@@ -101,13 +101,6 @@ theorem mem_locallyNilpotentSubmodule {x : L} {hx : IsNilpotent (ad R L x)} {m :
   change m ∈ (toEnd R L M x).maxGenEigenspace 0 ↔ _
   simp
 
-omit [LieAlgebra R L] [LieModule R L M] in
-/-- A Lie submodule of an irreducible module that contains a nonzero vector is everything. -/
-private theorem eq_top_of_isIrreducible [LieModule.IsIrreducible R L M] {N : LieSubmodule R L M}
-    {m₀ : M} (hm₀ : m₀ ≠ 0) (hmem₀ : m₀ ∈ N) : N = ⊤ :=
-  (IsSimpleOrder.eq_bot_or_eq_top N).resolve_left fun h => hm₀ <| by
-    rw [h] at hmem₀; simpa using hmem₀
-
 /-- **Local nilpotence spreads over an irreducible module.** If `ad x` is nilpotent and some
 nonzero vector of an irreducible module `M` is annihilated by a power of `x`, then every vector of
 `M` is. -/
@@ -115,8 +108,10 @@ theorem exists_pow_toEnd_eq_zero_of_isIrreducible [LieModule.IsIrreducible R L M
     (hx : IsNilpotent (ad R L x)) {m₀ : M} (hm₀ : m₀ ≠ 0) {k₀ : ℕ}
     (hk₀ : ((toEnd R L M x) ^ k₀) m₀ = 0) (m : M) :
     ∃ k : ℕ, ((toEnd R L M x) ^ k) m = 0 := by
-  have htop := eq_top_of_isIrreducible (N := locallyNilpotentSubmodule R M x hx) hm₀
-    (mem_locallyNilpotentSubmodule.mpr ⟨k₀, hk₀⟩)
+  have : Nontrivial (locallyNilpotentSubmodule R M x hx) :=
+    nontrivial_of_ne ⟨m₀, mem_locallyNilpotentSubmodule.mpr ⟨k₀, hk₀⟩⟩ 0
+      (by simpa [Subtype.ext_iff] using hm₀)
+  have htop := (locallyNilpotentSubmodule R M x hx).eq_top_of_isIrreducible R L M
   exact mem_locallyNilpotentSubmodule.mp (htop ▸ LieSubmodule.mem_top m)
 
 /-! ### Locally finite vectors -/
@@ -148,17 +143,14 @@ def locallyFiniteSubmodule [Module.Finite R L] (S : Set L) : LieSubmodule R L M 
     exact ⟨N, hfg, hst, N.smul_mem c ha⟩
   lie_mem := by
     rintro y m ⟨N, hfg, hst, hm⟩
-    classical
-    obtain ⟨sL, hsL⟩ := (Module.finite_def (R := R) (M := L)).mp ‹_›
-    obtain ⟨sM, hsM⟩ := id hfg
     let br : L →ₗ[R] M →ₗ[R] M :=
       LinearMap.mk₂ R (fun (z : L) (u : M) => ⁅z, u⁆) add_lie smul_lie lie_add lie_smul
     set Q : Submodule R M := Submodule.map₂ br ⊤ N with hQ
     have hbr : ∀ (z : L) {u : M}, u ∈ N → ⁅z, u⁆ ∈ Q := fun z u hu =>
       Submodule.apply_mem_map₂ br Submodule.mem_top hu
     have hQfg : Q.FG := by
-      rw [hQ, ← hsL, ← hsM, Submodule.map₂_span_span]
-      exact Submodule.fg_span (Set.Finite.image2 _ sL.finite_toSet sM.finite_toSet)
+      rw [hQ]
+      exact Module.Finite.fg_top.map₂ br hfg
     refine ⟨N ⊔ Q, hfg.sup hQfg, fun x hx => ?_, Submodule.mem_sup_right (hbr y hm)⟩
     rw [← map_toEnd_le_iff, Submodule.map_sup]
     refine sup_le (((map_toEnd_le_iff).mpr (hst x hx)).trans le_sup_left) ?_
@@ -196,6 +188,9 @@ theorem locallyFiniteSubmodule_eq_top_of_isIrreducible [Module.Finite R L]
     [LieModule.IsIrreducible R L M] {S : Set L} {N₀ : Submodule R M} (hfg₀ : N₀.FG)
     (hst₀ : ∀ x ∈ S, ∀ u ∈ N₀, ⁅x, u⁆ ∈ N₀) {m₀ : M} (hm₀ : m₀ ≠ 0) (hmem₀ : m₀ ∈ N₀) :
     locallyFiniteSubmodule R M S = ⊤ :=
-  eq_top_of_isIrreducible hm₀ (mem_locallyFiniteSubmodule.mpr ⟨N₀, hfg₀, hst₀, hmem₀⟩)
+  have : Nontrivial (locallyFiniteSubmodule R M S) :=
+    nontrivial_of_ne ⟨m₀, mem_locallyFiniteSubmodule.mpr ⟨N₀, hfg₀, hst₀, hmem₀⟩⟩ 0
+      (by simpa [Subtype.ext_iff] using hm₀)
+  (locallyFiniteSubmodule R M S).eq_top_of_isIrreducible R L M
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/Submodule/LocallyFinite.lean
+++ b/TauCeti/Algebra/Lie/Submodule/LocallyFinite.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Semisimple.Defs
+public import Mathlib.Algebra.Lie.Weights.Basic
+public import Mathlib.Algebra.Module.Submodule.Bilinear
+
+public section
+
+/-!
+# Locally nilpotent and locally finite vectors of a Lie module
+
+Let `L` be a Lie algebra over a commutative ring `R` and let `M` be an `L`-module. Two
+finiteness conditions on a vector of `M` are collected here, both of them conditions that hold on a
+Lie submodule and are therefore either vacuous or universal on an irreducible module.
+
+* `x : L` acts **locally nilpotently** at `m` when `x^k` annihilates `m` for some `k`. The set of
+  such `m` is the generalized `0`-eigenspace of the action of `x`, and it is a Lie submodule as
+  soon as `ad x` is a nilpotent endomorphism of `L`: this is Mathlib's
+  `LieModule.lie_mem_maxGenEigenspace_toEnd` at the eigenvalue `0 + 0`.
+* A set `S ⊆ L` acts **locally finitely** at `m` when `m` lies in a finitely generated
+  `R`-submodule of `M` stable under bracketing with every element of `S`. The set of such `m` is a
+  Lie submodule whenever `L` itself is a finite `R`-module: if `N` is finitely generated and
+  `S`-stable then so is `N + ⁅L, N⁆`, and the latter contains `⁅y, m⁆` for every `y : L`.
+
+Both statements are the mechanism behind an "integrability" argument: an irreducible module
+containing a *single* vector with the finiteness property has the property everywhere. The
+motivating instance is the highest weight vector of an irreducible highest weight module, which is
+annihilated by a power of each simple root vector; see
+`TauCeti/Algebra/Lie/HighestWeight/Integrable.lean`.
+
+## Main definitions
+
+* `TauCeti.locallyNilpotentSubmodule`: the vectors annihilated by a power of a fixed `ad`-nilpotent
+  element, as a Lie submodule.
+* `TauCeti.locallyFiniteSubmodule`: the vectors lying in a finitely generated subspace stable under
+  a fixed set of elements, as a Lie submodule.
+
+## Main results
+
+* `TauCeti.exists_pow_toEnd_eq_zero_of_isIrreducible`: on an irreducible module, an `ad`-nilpotent
+  element that is locally nilpotent at one nonzero vector is locally nilpotent everywhere.
+* `TauCeti.locallyFiniteSubmodule_span`: only the span of `S` matters, so the condition may be
+  stated against a generating set and consumed against the subalgebra it generates.
+* `TauCeti.locallyFiniteSubmodule_eq_top_of_isIrreducible`: on an irreducible module, a set that
+  acts locally finitely at one nonzero vector acts locally finitely everywhere.
+
+## Implementation notes
+
+The underlying subspace of `TauCeti.locallyNilpotentSubmodule` is Mathlib's
+`Module.End.maxGenEigenspace` of the action of `x` at the eigenvalue `0`, which Mathlib itself
+promotes to a Lie submodule only as `LieModule.genWeightSpaceOf`, under the hypothesis that `L` is
+a *nilpotent* Lie algebra. That hypothesis fails for the semisimple Lie algebras this file is
+written for, and the nilpotence of `ad x` replaces it: it is what makes every element of `L` lie
+in the generalized `0`-eigenspace of `ad x`, which is all the argument of `genWeightSpaceOf` ever
+uses.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §21.2.
+* V. G. Kac, *Infinite Dimensional Lie Algebras*, 3rd ed., §3.6.
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule Module
+
+universe u v w
+
+variable {R : Type u} {L : Type v} {M : Type w}
+variable [CommRing R] [LieRing L] [LieAlgebra R L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
+
+/-! ### Locally nilpotent vectors -/
+
+variable (R M) in
+/-- The vectors of `M` annihilated by some power of the action of `x`, as a Lie submodule.
+
+The underlying subspace is the generalized `0`-eigenspace of `x` acting on `M`; it is stable under
+all of `L` because `ad x` is assumed nilpotent, so that every element of `L` lies in the
+generalized `0`-eigenspace of `ad x`. -/
+def locallyNilpotentSubmodule (x : L) (hx : IsNilpotent (ad R L x)) : LieSubmodule R L M where
+  __ := (toEnd R L M x).maxGenEigenspace 0
+  lie_mem {y m} hm := by
+    have hy : y ∈ (ad R L x).maxGenEigenspace 0 := by
+      obtain ⟨k, hk⟩ := hx
+      simp only [Module.End.mem_maxGenEigenspace, zero_smul, sub_zero]
+      exact ⟨k, by rw [hk]; rfl⟩
+    simp only [AddSubsemigroup.mem_carrier, AddSubmonoid.mem_toSubsemigroup,
+      Submodule.mem_toAddSubmonoid] at hm ⊢
+    rw [← zero_add (0 : R)]
+    exact LieModule.lie_mem_maxGenEigenspace_toEnd hy hm
+
+@[simp]
+theorem mem_locallyNilpotentSubmodule {x : L} {hx : IsNilpotent (ad R L x)} {m : M} :
+    m ∈ locallyNilpotentSubmodule R M x hx ↔ ∃ k : ℕ, ((toEnd R L M x) ^ k) m = 0 := by
+  change m ∈ (toEnd R L M x).maxGenEigenspace 0 ↔ _
+  simp
+
+omit [LieAlgebra R L] [LieModule R L M] in
+/-- A Lie submodule of an irreducible module that contains a nonzero vector is everything. -/
+private theorem eq_top_of_isIrreducible [LieModule.IsIrreducible R L M] {N : LieSubmodule R L M}
+    {m₀ : M} (hm₀ : m₀ ≠ 0) (hmem₀ : m₀ ∈ N) : N = ⊤ :=
+  (IsSimpleOrder.eq_bot_or_eq_top N).resolve_left fun h => hm₀ <| by
+    rw [h] at hmem₀; simpa using hmem₀
+
+/-- **Local nilpotence spreads over an irreducible module.** If `ad x` is nilpotent and some
+nonzero vector of an irreducible module `M` is annihilated by a power of `x`, then every vector of
+`M` is. -/
+theorem exists_pow_toEnd_eq_zero_of_isIrreducible [LieModule.IsIrreducible R L M] {x : L}
+    (hx : IsNilpotent (ad R L x)) {m₀ : M} (hm₀ : m₀ ≠ 0) {k₀ : ℕ}
+    (hk₀ : ((toEnd R L M x) ^ k₀) m₀ = 0) (m : M) :
+    ∃ k : ℕ, ((toEnd R L M x) ^ k) m = 0 := by
+  have htop := eq_top_of_isIrreducible (N := locallyNilpotentSubmodule R M x hx) hm₀
+    (mem_locallyNilpotentSubmodule.mpr ⟨k₀, hk₀⟩)
+  exact mem_locallyNilpotentSubmodule.mp (htop ▸ LieSubmodule.mem_top m)
+
+/-! ### Locally finite vectors -/
+
+/-- A subspace is stable under bracketing with `x` exactly when its image under the action of `x`
+is contained in it. -/
+private theorem map_toEnd_le_iff {x : L} {N : Submodule R M} :
+    N.map (toEnd R L M x) ≤ N ↔ ∀ u ∈ N, ⁅x, u⁆ ∈ N := by
+  simp [SetLike.le_def]
+
+variable (R M) in
+/-- The vectors of `M` lying in some finitely generated `R`-submodule stable under bracketing with
+every element of `S`, as a Lie submodule of `M`.
+
+Stability under all of `L` uses that `L` is a finite `R`-module: if `N` is finitely generated and
+`S`-stable, then `N + ⁅L, N⁆` is again finitely generated and `S`-stable, and it contains `⁅y, m⁆`
+for every `y : L` and `m ∈ N`. -/
+def locallyFiniteSubmodule [Module.Finite R L] (S : Set L) : LieSubmodule R L M where
+  carrier := {m | ∃ N : Submodule R M, N.FG ∧ (∀ x ∈ S, ∀ u ∈ N, ⁅x, u⁆ ∈ N) ∧ m ∈ N}
+  zero_mem' := ⟨⊥, Submodule.fg_bot, by simp, Submodule.zero_mem ⊥⟩
+  add_mem' := by
+    rintro a c ⟨N₁, hfg₁, hst₁, ha⟩ ⟨N₂, hfg₂, hst₂, hc⟩
+    refine ⟨N₁ ⊔ N₂, hfg₁.sup hfg₂, fun x hx => ?_,
+      add_mem (Submodule.mem_sup_left ha) (Submodule.mem_sup_right hc)⟩
+    rw [← map_toEnd_le_iff, Submodule.map_sup]
+    exact sup_le_sup ((map_toEnd_le_iff).mpr (hst₁ x hx)) ((map_toEnd_le_iff).mpr (hst₂ x hx))
+  smul_mem' := by
+    rintro c a ⟨N, hfg, hst, ha⟩
+    exact ⟨N, hfg, hst, N.smul_mem c ha⟩
+  lie_mem := by
+    rintro y m ⟨N, hfg, hst, hm⟩
+    classical
+    obtain ⟨sL, hsL⟩ := (Module.finite_def (R := R) (M := L)).mp ‹_›
+    obtain ⟨sM, hsM⟩ := id hfg
+    let br : L →ₗ[R] M →ₗ[R] M :=
+      LinearMap.mk₂ R (fun (z : L) (u : M) => ⁅z, u⁆) add_lie smul_lie lie_add lie_smul
+    set Q : Submodule R M := Submodule.map₂ br ⊤ N with hQ
+    have hbr : ∀ (z : L) {u : M}, u ∈ N → ⁅z, u⁆ ∈ Q := fun z u hu =>
+      Submodule.apply_mem_map₂ br Submodule.mem_top hu
+    have hQfg : Q.FG := by
+      rw [hQ, ← hsL, ← hsM, Submodule.map₂_span_span]
+      exact Submodule.fg_span (Set.Finite.image2 _ sL.finite_toSet sM.finite_toSet)
+    refine ⟨N ⊔ Q, hfg.sup hQfg, fun x hx => ?_, Submodule.mem_sup_right (hbr y hm)⟩
+    rw [← map_toEnd_le_iff, Submodule.map_sup]
+    refine sup_le (((map_toEnd_le_iff).mpr (hst x hx)).trans le_sup_left) ?_
+    rw [hQ, Submodule.map_le_iff_le_comap, Submodule.map₂_le]
+    intro z _ u hu
+    change ⁅x, ⁅z, u⁆⁆ ∈ N ⊔ Q
+    rw [leibniz_lie]
+    exact add_mem (Submodule.mem_sup_right (hbr ⁅x, z⁆ hu))
+      (Submodule.mem_sup_right (hbr z (hst x hx u hu)))
+
+@[simp]
+theorem mem_locallyFiniteSubmodule [Module.Finite R L] {S : Set L} {m : M} :
+    m ∈ locallyFiniteSubmodule R M S ↔
+      ∃ N : Submodule R M, N.FG ∧ (∀ x ∈ S, ∀ u ∈ N, ⁅x, u⁆ ∈ N) ∧ m ∈ N :=
+  Iff.rfl
+
+/-- Only the span of `S` matters: a subspace stable under `S` is stable under the `R`-submodule
+that `S` generates, the stability condition being linear in the bracketing element. -/
+theorem locallyFiniteSubmodule_span [Module.Finite R L] (S : Set L) :
+    locallyFiniteSubmodule R M (Submodule.span R S : Set L) = locallyFiniteSubmodule R M S := by
+  refine le_antisymm ?_ ?_
+  · rintro m ⟨N, hfg, hst, hm⟩
+    exact ⟨N, hfg, fun x hx => hst x (Submodule.subset_span hx), hm⟩
+  · rintro m ⟨N, hfg, hst, hm⟩
+    refine ⟨N, hfg, fun x hx => ?_, hm⟩
+    induction hx using Submodule.span_induction with
+    | mem z hz => exact hst z hz
+    | zero => simp
+    | add a c _ _ ha hc => exact fun u hu => by rw [add_lie]; exact add_mem (ha u hu) (hc u hu)
+    | smul c a _ ha => exact fun u hu => by rw [smul_lie]; exact N.smul_mem c (ha u hu)
+
+/-- **Local finiteness spreads over an irreducible module.** If some nonzero vector of an
+irreducible module lies in a finitely generated `S`-stable subspace, then every vector does. -/
+theorem locallyFiniteSubmodule_eq_top_of_isIrreducible [Module.Finite R L]
+    [LieModule.IsIrreducible R L M] {S : Set L} {N₀ : Submodule R M} (hfg₀ : N₀.FG)
+    (hst₀ : ∀ x ∈ S, ∀ u ∈ N₀, ⁅x, u⁆ ∈ N₀) {m₀ : M} (hm₀ : m₀ ≠ 0) (hmem₀ : m₀ ∈ N₀) :
+    locallyFiniteSubmodule R M S = ⊤ :=
+  eq_top_of_isIrreducible hm₀ (mem_locallyFiniteSubmodule.mpr ⟨N₀, hfg₀, hst₀, hmem₀⟩)
+
+end TauCeti


### PR DESCRIPTION
This PR proves that an irreducible highest weight module whose highest weight is integral along a simple root `αᵢ` is **integrable** in that direction: both root vectors of `αᵢ` act locally nilpotently on the whole module, and every vector of the module lies in a finitely generated subspace stable under the `sl₂` triple of `αᵢ`, so the module is locally finite over that triple. The exact target is the "maximal integrable quotient and local nilpotence" milestone of Layer 4, "the classification of finite-dimensional irreducibles", of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, whose enclosing milestone is "`L(λ)` is finite-dimensional iff `λ` is dominant integral".

This is the next step on that milestone. Its predecessor, the integrability relation `fᵢ^{n+1} v = 0` in an irreducible highest weight module, landed in TauCeti#4179 (`TauCeti/Algebra/Lie/HighestWeight/Integrability.lean`), and the README's own ordering puts local nilpotence immediately after it; no open or merged PR supplies it. Integrability is what turns the weight cone `lam - Q⁺` of `TauCeti/Algebra/Lie/HighestWeight/Module.lean` into a *finite* set, since only for an integrable module is the weight support stable under the Weyl group, so it is the input the remaining Layer 4 steps consume.

Both halves rest on the same observation, which is the content of the first new file. Being annihilated by a power of a fixed `x : L`, and lying in a finitely generated subspace stable under a fixed set `S ⊆ L`, are both conditions that hold on a *Lie submodule* of the module, so on an irreducible module each holds either everywhere or nowhere, and the highest weight vector decides which. For local nilpotence the relevant subspace is the generalized `0`-eigenspace of `x`, and it is `L`-stable as soon as `ad x` is nilpotent: that is Mathlib's `LieModule.lie_mem_maxGenEigenspace_toEnd` read at the eigenvalue `0 + 0`. Mathlib promotes the same subspace to a Lie submodule only as `LieModule.genWeightSpaceOf`, under the hypothesis that `L` itself is nilpotent, which is exactly what a semisimple `L` fails; the nilpotence of `ad x` — Mathlib's `LieAlgebra.isNilpotent_ad_of_mem_rootSpace` for a root vector — replaces it. For local finiteness the point is that when `L` is a finite module, `N + ⁅L, N⁆` is again finitely generated and `S`-stable, which is `Submodule.map₂` against the bracket plus `Submodule.map₂_span_span` for the finiteness.

The application then needs one explicit finite-dimensional subspace, and the integrability relation supplies it: the span of `v, fᵢ v, …, fᵢ^n v` is stable under the triple, because Mathlib's ladder lemmas `lie_h_pow_toEnd_f` and `lie_e_pow_succ_toEnd_f` evaluate `hᵢ` and `eᵢ` on each `fᵢ^k v` as a multiple of `fᵢ^k v` and of `fᵢ^{k-1} v`, while `fᵢ` moves along the list and off its end into `0`. Local nilpotence of a *positive* root vector needs nothing beyond the definition of a highest weight vector, so it is proved for every positive root rather than only the simple ones.

The two new files are `TauCeti/Algebra/Lie/Submodule/LocallyFinite.lean` (201 lines), which is stated over a commutative ring and an arbitrary Lie module because neither construction uses the field or the root system, and `TauCeti/Algebra/Lie/HighestWeight/Integrable.lean` (201 lines). No existing file changes, and no Mathlib infrastructure or supplementary snapshot material is vendored or adapted; the mathematics follows Humphreys, *Introduction to Lie Algebras and Representation Theory*, §21.2, and Kac, *Infinite Dimensional Lie Algebras*, §3.6, both credited in the module documentation.

After this PR the Layer 4 milestone still needs the propagation of local nilpotence from the simple root vectors to the root vectors of every root, the resulting Weyl stability of the weight support and the weight-cone bound that makes it finite, and the finite-dimensionality of the individual weight spaces from the PBW spanning theorem; together those give `dim L(λ) < ∞` for dominant integral `λ`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"integrable-irreducible-highest-weight-module"}-->

🤖 Prepared with Claude Code
