### PR TITLE
feat: add the general-linear Clifford lift

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -1,0 +1,253 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.TraceForm
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
+import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
+import Mathlib.Algebra.Lie.Classical
+
+/-!
+# The quadratic Clifford lift of the general linear Lie algebra
+
+The adjoint action of `gl n K` preserves its trace form. Adding the central character
+`(card n / 2) trace` to its quadratic realization gives the normal-ordered quadratic lift in the
+corresponding Clifford algebra.
+
+## Main results
+
+* `TauCeti.glCliffordHom`: the normal-ordered Lie homomorphism from matrices to the Clifford
+  algebra of their trace quadratic form.
+* `TauCeti.glCliffordHom_lie_ι`: its commutator action on Clifford generators.
+* `TauCeti.glCliffordHom_single`: its formula on matrix units.
+* `TauCeti.glCliffordHom_normalOrdering`: its decomposition into bivectors and the central
+  normal-ordering constant.
+
+## References
+
+* [Tau Ceti Roadmap](https://github.com/TauCetiProject/TauCetiRoadmap), Representation Theory / Spin
+  Representations, Layer 9, “The worked instance: `gl_N` on `M_N(ℂ)` (the CAR algebra)”.
+-/
+
+public section
+
+namespace TauCeti
+
+open CliffordAlgebra
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {K n : Type*} [Field K] [Fintype n] [DecidableEq n] [Invertible (2 : K)]
+
+private noncomputable def traceQuadraticLift :
+    Matrix n n K →ₗ⁅K⁆ CliffordAlgebra (traceQuadraticForm K n) :=
+  CliffordAlgebra.quadraticLift (traceQuadraticForm K n)
+    (traceQuadraticForm_nondegenerate K n) (traceAdjointSO K n)
+
+private noncomputable def scalarTrace :
+    Matrix n n K →ₗ[K] CliffordAlgebra (traceQuadraticForm K n) :=
+  (Algebra.linearMap K (CliffordAlgebra (traceQuadraticForm K n))).comp <|
+    (Fintype.card n / 2 : K) • Matrix.traceLinearMap n K K
+
+private theorem traceQuadraticLift_lie_ι (X Y : Matrix n n K) :
+    ⁅traceQuadraticLift (K := K) (n := n) X, ι (traceQuadraticForm K n) Y⁆ =
+      ι (traceQuadraticForm K n) ⁅X, Y⁆ := by
+  rw [traceQuadraticLift, CliffordAlgebra.quadraticLift_apply,
+    soEquivQuadratic_lie_ι, coe_traceAdjointSO, _root_.LieAlgebra.ad_apply]
+
+omit [DecidableEq n] [Invertible (2 : K)] in
+private theorem scalarTrace_lie (X : Matrix n n K)
+    (c : CliffordAlgebra (traceQuadraticForm K n)) :
+    ⁅scalarTrace (K := K) (n := n) X, c⁆ = 0 := by
+  -- Expose the central scalar before using commutation with the algebra map.
+  change algebraMap K _ ((Fintype.card n / 2 : K) * X.trace) * c -
+    c * algebraMap K _ ((Fintype.card n / 2 : K) * X.trace) = 0
+  rw [Algebra.commutes]
+  simp
+
+/-- The normal-ordered quadratic Clifford lift of the general linear Lie algebra. -/
+noncomputable def glCliffordHom :
+    Matrix n n K →ₗ⁅K⁆ CliffordAlgebra (traceQuadraticForm K n) :=
+  { (traceQuadraticLift (K := K) (n := n)).toLinearMap + scalarTrace (K := K) (n := n) with
+    map_lie' := by
+      intro X Y
+      -- Expose the sum of the quadratic and central linear maps.
+      change traceQuadraticLift ⁅X, Y⁆ + scalarTrace ⁅X, Y⁆ =
+        ⁅traceQuadraticLift X + scalarTrace X, traceQuadraticLift Y + scalarTrace Y⁆
+      rw [LieHom.map_lie]
+      have hs : scalarTrace (K := K) (n := n) ⁅X, Y⁆ = 0 := by
+        simp [scalarTrace, LieAlgebra.matrix_trace_commutator_zero]
+      rw [hs]
+      simp only [add_zero, add_lie, lie_add]
+      rw [scalarTrace_lie, scalarTrace_lie]
+      have hright : ⁅traceQuadraticLift (K := K) (n := n) X, scalarTrace Y⁆ = 0 := by
+        rw [← lie_skew, scalarTrace_lie, neg_zero]
+      rw [hright]
+      simp }
+
+/-- The normal-ordered lift acts on Clifford generators by the matrix commutator. -/
+@[simp, grind =]
+theorem glCliffordHom_lie_ι (X Y : Matrix n n K) :
+    ⁅glCliffordHom (K := K) (n := n) X,
+        ι (traceQuadraticForm K n) Y⁆ =
+      ι (traceQuadraticForm K n) ⁅X, Y⁆ := by
+  -- Expose the two summands before applying bracket bilinearity.
+  change ⁅traceQuadraticLift X + scalarTrace X, ι (traceQuadraticForm K n) Y⁆ = _
+  rw [add_lie, traceQuadraticLift_lie_ι, scalarTrace_lie, add_zero]
+
+private theorem matrixUnit_ad_eq_bivector_sum (i j : n) (Y : Matrix n n K) :
+    (2⁻¹ : K) • ∑ k : n,
+        (QuadraticMap.polar (traceQuadraticForm K n) (Matrix.single k j 1) Y •
+            Matrix.single i k 1 -
+          QuadraticMap.polar (traceQuadraticForm K n) (Matrix.single i k 1) Y •
+            Matrix.single k j 1) =
+      ⁅Matrix.single i j (1 : K), Y⁆ := by
+  have hpolar₁ (k : n) :
+      QuadraticMap.polar (traceQuadraticForm K n) (Matrix.single k j 1) Y = 2 * Y j k := by
+    rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
+      Matrix.trace_single_mul]
+    simp
+  have hpolar₂ (k : n) :
+      QuadraticMap.polar (traceQuadraticForm K n) (Matrix.single i k 1) Y = 2 * Y k i := by
+    rw [← QuadraticMap.polarBilin_apply_apply, polarBilin_traceQuadraticForm,
+      Matrix.trace_single_mul]
+    simp
+  simp_rw [hpolar₁, hpolar₂]
+  ext a b
+  have h2 : (2 : K) ≠ 0 := Invertible.ne_zero _
+  by_cases hia : i = a <;> by_cases hjb : j = b <;>
+    simp +contextual [Ring.lie_def, Matrix.mul_apply, Matrix.sum_apply, Matrix.single,
+      hia, hjb, h2]
+  field_simp
+
+private noncomputable def matrixUnitBivectorSum (i j : n) :
+    CliffordAlgebra (traceQuadraticForm K n) :=
+  (2⁻¹ : K) • ∑ k : n,
+    bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1)
+
+private theorem matrixUnitBivectorSum_mem (i j : n) :
+    matrixUnitBivectorSum (K := K) i j ∈ quadraticLieSubalgebra (traceQuadraticForm K n) := by
+  rw [matrixUnitBivectorSum]
+  apply (quadraticLieSubalgebra (traceQuadraticForm K n)).smul_mem
+  exact (quadraticLieSubalgebra (traceQuadraticForm K n)).sum_mem fun k _ =>
+    bivector_mem_quadraticLieSubalgebra (traceQuadraticForm K n) (Matrix.single i k 1)
+      (Matrix.single k j 1)
+
+private noncomputable def matrixUnitQuadratic (i j : n) :
+    quadraticLieSubalgebra (traceQuadraticForm K n) :=
+  ⟨matrixUnitBivectorSum (K := K) i j, matrixUnitBivectorSum_mem i j⟩
+
+private theorem coe_matrixUnitQuadratic (i j : n) :
+    (matrixUnitQuadratic (K := K) i j : CliffordAlgebra (traceQuadraticForm K n)) =
+      matrixUnitBivectorSum (K := K) i j := rfl
+
+private theorem matrixUnitQuadratic_lie_ι (i j : n) (Y : Matrix n n K) :
+    ⁅(matrixUnitQuadratic (K := K) i j : CliffordAlgebra (traceQuadraticForm K n)),
+        ι (traceQuadraticForm K n) Y⁆ =
+      ι (traceQuadraticForm K n) ⁅Matrix.single i j (1 : K), Y⁆ := by
+  rw [coe_matrixUnitQuadratic, matrixUnitBivectorSum]
+  -- Expose scalar multiplication and the finite sum in the ambient Clifford algebra.
+  change ⁅(2⁻¹ : K) • ∑ k : n,
+      bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1),
+        ι (traceQuadraticForm K n) Y⁆ = _
+  rw [smul_lie, sum_lie]
+  simp_rw [bivector_lie_ι]
+  rw [← map_sum, ← map_smul, matrixUnit_ad_eq_bivector_sum]
+
+private theorem traceQuadraticLift_single (i j : n) :
+    traceQuadraticLift (K := K) (n := n) (Matrix.single i j 1) =
+      (matrixUnitQuadratic (K := K) i j : CliffordAlgebra (traceQuadraticForm K n)) := by
+  let Q := traceQuadraticForm K n
+  let hQ := traceQuadraticForm_nondegenerate K n
+  let e := soEquivQuadratic Q hQ
+  rw [traceQuadraticLift, CliffordAlgebra.quadraticLift_apply]
+  -- Expose the generic quadratic lift through the local equivalence `e`.
+  change (e (traceAdjointSO K n (Matrix.single i j 1)) : CliffordAlgebra Q) = _
+  have heq : e (traceAdjointSO K n (Matrix.single i j 1)) = matrixUnitQuadratic i j := by
+    apply e.symm.injective
+    -- Expose the inverse equivalence on both sides so its cancellation lemma applies.
+    change e.symm (e (traceAdjointSO K n (Matrix.single i j 1))) =
+      e.symm (matrixUnitQuadratic i j)
+    rw [e.symm_apply_apply]
+    apply Subtype.ext
+    apply LinearMap.ext
+    intro Y
+    apply ι_injective Q
+    rw [← soEquivQuadratic_lie_ι Q hQ (e.symm (matrixUnitQuadratic i j)) Y,
+      e.apply_symm_apply, matrixUnitQuadratic_lie_ι, coe_traceAdjointSO,
+      _root_.LieAlgebra.ad_apply]
+  exact congrArg Subtype.val heq
+
+omit [DecidableEq n] in
+private theorem ι_mul_eq_bivector_add (X Y : Matrix n n K) :
+    ι (traceQuadraticForm K n) X * ι (traceQuadraticForm K n) Y =
+      bivector (traceQuadraticForm K n) X Y +
+        (⅟ (2 : K)) • algebraMap K _
+          (QuadraticMap.polar (traceQuadraticForm K n) X Y) := by
+  have hcar := ι_mul_ι_add_swap (Q := traceQuadraticForm K n) X Y
+  symm
+  rw [bivector_def, invOf_eq_inv, ← smul_add, ← hcar]
+  match_scalars
+  · simpa only [one_add_one_eq_two] using inv_mul_cancel₀ (Invertible.ne_zero (2 : K))
+  · ring
+
+/-- The matrix-unit lift is its antisymmetrized quadratic part plus the central normal-ordering
+constant. -/
+theorem glCliffordHom_normalOrdering (i j : n) :
+    glCliffordHom (K := K) (n := n) (Matrix.single i j (1 : K)) =
+      (2⁻¹ : K) • ∑ k : n,
+          bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1) +
+        algebraMap K (CliffordAlgebra (traceQuadraticForm K n))
+          (if i = j then (Fintype.card n : K) / 2 else 0) := by
+  rw [glCliffordHom]
+  -- Expose the sum defining the underlying linear map.
+  change traceQuadraticLift (K := K) (n := n) (Matrix.single i j (1 : K)) +
+    scalarTrace (K := K) (n := n) (Matrix.single i j (1 : K)) = _
+  rw [traceQuadraticLift_single, coe_matrixUnitQuadratic, matrixUnitBivectorSum]
+  by_cases h : i = j
+  · subst j
+    simp [scalarTrace]
+  · simp [scalarTrace, h]
+
+private theorem matrixUnit_ι_mul_eq_bivector_add (i j k : n) :
+    ι (traceQuadraticForm K n) (Matrix.single i k 1) *
+        ι (traceQuadraticForm K n) (Matrix.single k j 1) =
+      bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1) +
+        algebraMap K (CliffordAlgebra (traceQuadraticForm K n)) (if i = j then 1 else 0) := by
+  rw [ι_mul_eq_bivector_add, invOf_eq_inv, ← QuadraticMap.polarBilin_apply_apply,
+    polarBilin_traceQuadraticForm, ← traceBilinForm_apply, traceBilinForm_single_single]
+  by_cases h : i = j
+  · subst j
+    simp only [Algebra.smul_def, and_self, ↓reduceIte, mul_one, map_one, add_right_inj]
+    rw [← map_mul, inv_mul_cancel₀ (Invertible.ne_zero (2 : K)), map_one]
+  · simp [eq_comm, h]
+
+/-- On a matrix unit, the lift is the normal-ordered quadratic sum
+`Eᵢⱼ ↦ 1/2 ∑ₖ dᵢₖ dₖⱼ`. -/
+@[simp, grind =]
+theorem glCliffordHom_single (i j : n) :
+    glCliffordHom (K := K) (n := n) (Matrix.single i j (1 : K)) =
+      (2⁻¹ : K) • ∑ k : n,
+        ι (traceQuadraticForm K n) (Matrix.single i k 1) *
+          ι (traceQuadraticForm K n) (Matrix.single k j 1) := by
+  rw [glCliffordHom_normalOrdering]
+  simp_rw [matrixUnit_ι_mul_eq_bivector_add]
+  by_cases h : i = j
+  · subst j
+    simp only [↓reduceIte, map_one]
+    have hcentral :
+        (2⁻¹ : K) • ∑ _ : n, (1 : CliffordAlgebra (traceQuadraticForm K n)) =
+          algebraMap K _ ((Fintype.card n : K) / 2) := by
+      rw [Finset.sum_const, ← Nat.cast_smul_eq_nsmul K, smul_smul,
+        Algebra.algebraMap_eq_smul_one]
+      rw [Finset.card_univ]
+      congr 1
+      ring_nf
+    rw [← hcentral]
+    rw [Finset.sum_add_distrib, smul_add]
+  · simp [h, Finset.smul_sum]
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -39,7 +39,9 @@ open CliffordAlgebra
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-variable {K n : Type*} [Field K] [Fintype n] [DecidableEq n] [Invertible (2 : K)]
+variable {K n : Type*} [Field K] [Fintype n] [Invertible (2 : K)]
+
+attribute [local instance] Classical.decEq
 
 private noncomputable def traceQuadraticLift :
     Matrix n n K →ₗ⁅K⁆ CliffordAlgebra (traceQuadraticForm K n) :=
@@ -51,7 +53,7 @@ private noncomputable def scalarTrace :
   (Algebra.linearMap K (CliffordAlgebra (traceQuadraticForm K n))).comp <|
     (Fintype.card n / 2 : K) • Matrix.traceLinearMap n K K
 
-omit [DecidableEq n] [Invertible (2 : K)] in
+omit [Invertible (2 : K)] in
 private theorem scalarTrace_lie (X : Matrix n n K)
     (c : CliffordAlgebra (traceQuadraticForm K n)) :
     ⁅scalarTrace (K := K) (n := n) X, c⁆ = 0 := by

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -52,12 +52,6 @@ private noncomputable def scalarTrace :
   (Algebra.linearMap K (CliffordAlgebra (traceQuadraticForm K n))).comp <|
     (Fintype.card n / 2 : K) • Matrix.traceLinearMap n K K
 
-private theorem traceQuadraticLift_lie_ι (X Y : Matrix n n K) :
-    ⁅traceQuadraticLift (K := K) (n := n) X, ι (traceQuadraticForm K n) Y⁆ =
-      ι (traceQuadraticForm K n) ⁅X, Y⁆ := by
-  rw [traceQuadraticLift, CliffordAlgebra.quadraticLift_apply,
-    soEquivQuadratic_lie_ι, coe_traceAdjointSO, _root_.LieAlgebra.ad_apply]
-
 omit [DecidableEq n] [Invertible (2 : K)] in
 private theorem scalarTrace_lie (X : Matrix n n K)
     (c : CliffordAlgebra (traceQuadraticForm K n)) :
@@ -96,7 +90,8 @@ theorem glCliffordHom_lie_ι (X Y : Matrix n n K) :
       ι (traceQuadraticForm K n) ⁅X, Y⁆ := by
   -- Expose the two summands before applying bracket bilinearity.
   change ⁅traceQuadraticLift X + scalarTrace X, ι (traceQuadraticForm K n) Y⁆ = _
-  rw [add_lie, traceQuadraticLift_lie_ι, scalarTrace_lie, add_zero]
+  rw [add_lie, traceQuadraticLift, CliffordAlgebra.quadraticLift_lie_ι,
+    coe_traceAdjointSO, _root_.LieAlgebra.ad_apply, scalarTrace_lie, add_zero]
 
 private theorem matrixUnit_ad_eq_bivector_sum (i j : n) (Y : Matrix n n K) :
     (2⁻¹ : K) • ∑ k : n,
@@ -123,32 +118,19 @@ private theorem matrixUnit_ad_eq_bivector_sum (i j : n) (Y : Matrix n n K) :
       hia, hjb, h2]
   field_simp
 
-private noncomputable def matrixUnitBivectorSum (i j : n) :
-    CliffordAlgebra (traceQuadraticForm K n) :=
-  (2⁻¹ : K) • ∑ k : n,
-    bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1)
-
-private theorem matrixUnitBivectorSum_mem (i j : n) :
-    matrixUnitBivectorSum (K := K) i j ∈ quadraticLieSubalgebra (traceQuadraticForm K n) := by
-  rw [matrixUnitBivectorSum]
-  apply (quadraticLieSubalgebra (traceQuadraticForm K n)).smul_mem
-  exact (quadraticLieSubalgebra (traceQuadraticForm K n)).sum_mem fun k _ =>
-    bivector_mem_quadraticLieSubalgebra (traceQuadraticForm K n) (Matrix.single i k 1)
-      (Matrix.single k j 1)
-
 private noncomputable def matrixUnitQuadratic (i j : n) :
     quadraticLieSubalgebra (traceQuadraticForm K n) :=
-  ⟨matrixUnitBivectorSum (K := K) i j, matrixUnitBivectorSum_mem i j⟩
-
-private theorem coe_matrixUnitQuadratic (i j : n) :
-    (matrixUnitQuadratic (K := K) i j : CliffordAlgebra (traceQuadraticForm K n)) =
-      matrixUnitBivectorSum (K := K) i j := rfl
+  ⟨(2⁻¹ : K) • ∑ k : n,
+      bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1),
+    (quadraticLieSubalgebra (traceQuadraticForm K n)).smul_mem _ <|
+      (quadraticLieSubalgebra (traceQuadraticForm K n)).sum_mem fun k _ =>
+        bivector_mem_quadraticLieSubalgebra (traceQuadraticForm K n) (Matrix.single i k 1)
+          (Matrix.single k j 1)⟩
 
 private theorem matrixUnitQuadratic_lie_ι (i j : n) (Y : Matrix n n K) :
     ⁅(matrixUnitQuadratic (K := K) i j : CliffordAlgebra (traceQuadraticForm K n)),
         ι (traceQuadraticForm K n) Y⁆ =
       ι (traceQuadraticForm K n) ⁅Matrix.single i j (1 : K), Y⁆ := by
-  rw [coe_matrixUnitQuadratic, matrixUnitBivectorSum]
   -- Expose scalar multiplication and the finite sum in the ambient Clifford algebra.
   change ⁅(2⁻¹ : K) • ∑ k : n,
       bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1),
@@ -167,32 +149,11 @@ private theorem traceQuadraticLift_single (i j : n) :
   -- Expose the generic quadratic lift through the local equivalence `e`.
   change (e (traceAdjointSO K n (Matrix.single i j 1)) : CliffordAlgebra Q) = _
   have heq : e (traceAdjointSO K n (Matrix.single i j 1)) = matrixUnitQuadratic i j := by
-    apply e.symm.injective
-    -- Expose the inverse equivalence on both sides so its cancellation lemma applies.
-    change e.symm (e (traceAdjointSO K n (Matrix.single i j 1))) =
-      e.symm (matrixUnitQuadratic i j)
-    rw [e.symm_apply_apply]
-    apply Subtype.ext
-    apply LinearMap.ext
+    apply quadraticLieSubalgebra_ext_lie_ι Q hQ
     intro Y
-    apply ι_injective Q
-    rw [← soEquivQuadratic_lie_ι Q hQ (e.symm (matrixUnitQuadratic i j)) Y,
-      e.apply_symm_apply, matrixUnitQuadratic_lie_ι, coe_traceAdjointSO,
+    rw [soEquivQuadratic_lie_ι, matrixUnitQuadratic_lie_ι, coe_traceAdjointSO,
       _root_.LieAlgebra.ad_apply]
   exact congrArg Subtype.val heq
-
-omit [DecidableEq n] in
-private theorem ι_mul_eq_bivector_add (X Y : Matrix n n K) :
-    ι (traceQuadraticForm K n) X * ι (traceQuadraticForm K n) Y =
-      bivector (traceQuadraticForm K n) X Y +
-        (⅟ (2 : K)) • algebraMap K _
-          (QuadraticMap.polar (traceQuadraticForm K n) X Y) := by
-  have hcar := ι_mul_ι_add_swap (Q := traceQuadraticForm K n) X Y
-  symm
-  rw [bivector_def, invOf_eq_inv, ← smul_add, ← hcar]
-  match_scalars
-  · simpa only [one_add_one_eq_two] using inv_mul_cancel₀ (Invertible.ne_zero (2 : K))
-  · ring
 
 /-- The matrix-unit lift is its antisymmetrized quadratic part plus the central normal-ordering
 constant. -/
@@ -206,7 +167,10 @@ theorem glCliffordHom_normalOrdering (i j : n) :
   -- Expose the sum defining the underlying linear map.
   change traceQuadraticLift (K := K) (n := n) (Matrix.single i j (1 : K)) +
     scalarTrace (K := K) (n := n) (Matrix.single i j (1 : K)) = _
-  rw [traceQuadraticLift_single, coe_matrixUnitQuadratic, matrixUnitBivectorSum]
+  rw [traceQuadraticLift_single]
+  change (2⁻¹ : K) • ∑ k : n,
+      bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1) +
+        scalarTrace (K := K) (n := n) (Matrix.single i j (1 : K)) = _
   by_cases h : i = j
   · subst j
     simp [scalarTrace]
@@ -217,7 +181,7 @@ private theorem matrixUnit_ι_mul_eq_bivector_add (i j k : n) :
         ι (traceQuadraticForm K n) (Matrix.single k j 1) =
       bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1) +
         algebraMap K (CliffordAlgebra (traceQuadraticForm K n)) (if i = j then 1 else 0) := by
-  rw [ι_mul_eq_bivector_add, invOf_eq_inv, ← QuadraticMap.polarBilin_apply_apply,
+  rw [ι_mul_ι_eq_bivector_add, invOf_eq_inv, ← QuadraticMap.polarBilin_apply_apply,
     polarBilin_traceQuadraticForm, ← traceBilinForm_apply, traceBilinForm_single_single]
   by_cases h : i = j
   · subst j

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -81,6 +81,16 @@ noncomputable def glCliffordHom :
       rw [hright]
       simp }
 
+/-- The normal-ordered lift is the sum of the quadratic lift and its scalar trace correction. -/
+theorem glCliffordHom_apply (X : Matrix n n K) :
+    glCliffordHom X =
+      CliffordAlgebra.quadraticLift (traceQuadraticForm K n)
+          (traceQuadraticForm_nondegenerate K n) (traceAdjointSO K n) X +
+        algebraMap K _ ((Fintype.card n / 2 : K) * X.trace) := by
+  -- Expose the two private summands used to assemble the public homomorphism.
+  change traceQuadraticLift X + scalarTrace X = _
+  rfl
+
 /-- The normal-ordered lift acts on Clifford generators by the matrix commutator. -/
 @[simp, grind =]
 theorem glCliffordHom_lie_ι (X Y : Matrix n n K) :

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -148,7 +148,7 @@ private theorem traceQuadraticLift_single (i j : n) :
   -- Expose the generic quadratic lift through the local equivalence `e`.
   change (e (traceAdjointSO K n (Matrix.single i j 1)) : CliffordAlgebra Q) = _
   have heq : e (traceAdjointSO K n (Matrix.single i j 1)) = matrixUnitQuadratic i j := by
-    apply quadraticLieSubalgebra_ext_lie_ι Q hQ
+    apply quadraticLieSubalgebra_ext Q hQ
     intro Y
     rw [soEquivQuadratic_lie_ι, matrixUnitQuadratic_lie_ι, coe_traceAdjointSO,
       _root_.LieAlgebra.ad_apply]

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -58,10 +58,8 @@ private theorem scalarTrace_lie (X : Matrix n n K)
     (c : CliffordAlgebra (traceQuadraticForm K n)) :
     ⁅scalarTrace (K := K) (n := n) X, c⁆ = 0 := by
   -- Expose the central scalar before using commutation with the algebra map.
-  change algebraMap K _ ((Fintype.card n / 2 : K) * X.trace) * c -
-    c * algebraMap K _ ((Fintype.card n / 2 : K) * X.trace) = 0
-  rw [Algebra.commutes]
-  simp
+  change ⁅algebraMap K _ ((Fintype.card n / 2 : K) * X.trace), c⁆ = 0
+  exact Commute.lie_eq (Algebra.commutes _ c)
 
 /-- The normal-ordered quadratic Clifford lift of the general linear Lie algebra. -/
 noncomputable def glCliffordHom :

--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.TraceForm
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
-import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
 import Mathlib.Algebra.Lie.Classical
 
 /-!
@@ -168,6 +167,7 @@ theorem glCliffordHom_normalOrdering (i j : n) :
   change traceQuadraticLift (K := K) (n := n) (Matrix.single i j (1 : K)) +
     scalarTrace (K := K) (n := n) (Matrix.single i j (1 : K)) = _
   rw [traceQuadraticLift_single]
+  -- Unfold the private matrix-unit value after rewriting the quadratic lift.
   change (2⁻¹ : K) • ∑ k : n,
       bivector (traceQuadraticForm K n) (Matrix.single i k 1) (Matrix.single k j 1) +
         scalarTrace (K := K) (n := n) (Matrix.single i j (1 : K)) = _

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -38,6 +38,8 @@ Layer 9 CAR worked instance.
 
 * `CliffordAlgebra.bivector_lie_ι`: its commutator action on a generator is the
   infinitesimal rotation determined by `QuadraticMap.polar`.
+* `CliffordAlgebra.ι_mul_ι_eq_bivector_add`: the product of two generators is
+  its Clifford bivector plus its scalar symmetric part.
 * `CliffordAlgebra.bivectorExterior_apply_ιMulti`: the exterior-square map on a
   decomposable bivector.
 * `CliffordAlgebra.equivExterior_bivector`,
@@ -78,6 +80,18 @@ noncomputable def bivector (a b : M) : CliffordAlgebra Q :=
 theorem bivector_def (a b : M) :
     bivector Q a b = (⅟ (2 : R)) • (ι Q a * ι Q b - ι Q b * ι Q a) := by
   rw [bivector]
+
+/-- The product of two Clifford generators is its bivector plus its scalar symmetric part. -/
+theorem ι_mul_ι_eq_bivector_add (a b : M) :
+    ι Q a * ι Q b =
+      bivector Q a b +
+        (⅟ (2 : R)) • algebraMap R (CliffordAlgebra Q) (QuadraticMap.polar Q a b) := by
+  have hcar := ι_mul_ι_add_swap (Q := Q) a b
+  symm
+  rw [bivector_def, ← smul_add, ← hcar]
+  match_scalars
+  · simpa only [one_add_one_eq_two] using invOf_mul_self (2 : R)
+  · ring
 
 /-- The alternating map whose value on two vectors is their half-normalized Clifford bivector. -/
 noncomputable def bivectorAlternating : M [⋀^Fin 2]→ₗ[R] CliffordAlgebra Q :=

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -56,7 +56,7 @@ noncomputable def quadraticLift {K : Type u} [Field K]
     (soEquivQuadratic Q hQ).toLieHom.comp θ
 
 /-- The quadratic lift is the quadratic realization of the supplied skew-adjoint action. -/
-@[grind =]
+@[simp, grind =]
 theorem quadraticLift_apply {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
     [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
@@ -66,7 +66,7 @@ theorem quadraticLift_apply {K : Type u} [Field K]
   rfl
 
 /-- The quadratic lift acts on Clifford generators through the supplied skew-adjoint action. -/
-@[simp, grind =]
+@[grind =]
 theorem quadraticLift_lie_ι {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
     [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -66,7 +66,6 @@ theorem quadraticLift_apply {K : Type u} [Field K]
   rfl
 
 /-- Values of the quadratic lift lie in the quadratic Lie subalgebra. -/
-@[simp]
 theorem quadraticLift_mem_quadraticLieSubalgebra {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
     [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -17,6 +17,7 @@ Clifford action makes the target Clifford module a module for the original Lie a
 
 ## Main results
 
+* `CliffordAlgebra.quadraticLift`: the quadratic realization of a skew-adjoint Lie action.
 * `CliffordAlgebra.cliffordInducedRep`: the induced Lie representation on a Clifford
   module.
 * `CliffordAlgebra.cliffordInducedRep_apply`: its defining equation.
@@ -43,7 +44,8 @@ namespace CliffordAlgebra
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-private noncomputable def quadraticLift {K : Type u} [Field K]
+/-- Lift a skew-adjoint Lie action through the quadratic realization in the Clifford algebra. -/
+noncomputable def quadraticLift {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
     [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     {L : Type w} [LieRing L] [LieAlgebra K L]
@@ -51,6 +53,16 @@ private noncomputable def quadraticLift {K : Type u} [Field K]
     L →ₗ⁅K⁆ CliffordAlgebra Q :=
   (quadraticLieSubalgebra Q).incl.comp <|
     (soEquivQuadratic Q hQ).toLieHom.comp θ
+
+/-- The quadratic lift is the quadratic realization of the supplied skew-adjoint action. -/
+@[simp, grind =]
+theorem quadraticLift_apply {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+    [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    {L : Type w} [LieRing L] [LieAlgebra K L]
+    (θ : L →ₗ⁅K⁆ skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q)) (x : L) :
+    quadraticLift Q hQ θ x = (soEquivQuadratic Q hQ (θ x) : CliffordAlgebra Q) := by
+  rfl
 
 /-- The Lie representation on a Clifford module induced through the quadratic realization. -/
 noncomputable def cliffordInducedRep {K : Type u} [Field K] {V : Type v} [AddCommGroup V]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -65,6 +65,16 @@ theorem quadraticLift_apply {K : Type u} [Field K]
     quadraticLift Q hQ θ x = (soEquivQuadratic Q hQ (θ x) : CliffordAlgebra Q) := by
   rfl
 
+/-- Values of the quadratic lift lie in the quadratic Lie subalgebra. -/
+@[simp]
+theorem quadraticLift_mem_quadraticLieSubalgebra {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+    [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    {L : Type w} [LieRing L] [LieAlgebra K L]
+    (θ : L →ₗ⁅K⁆ skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q)) (x : L) :
+    quadraticLift Q hQ θ x ∈ quadraticLieSubalgebra Q :=
+  (soEquivQuadratic Q hQ (θ x)).property
+
 /-- The quadratic lift acts on Clifford generators through the supplied skew-adjoint action. -/
 @[grind =]
 theorem quadraticLift_lie_ι {K : Type u} [Field K]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -18,6 +18,7 @@ Clifford action makes the target Clifford module a module for the original Lie a
 ## Main results
 
 * `CliffordAlgebra.quadraticLift`: the quadratic realization of a skew-adjoint Lie action.
+* `CliffordAlgebra.quadraticLift_lie_ι`: its defining action on Clifford generators.
 * `CliffordAlgebra.cliffordInducedRep`: the induced Lie representation on a Clifford
   module.
 * `CliffordAlgebra.cliffordInducedRep_apply`: its defining equation.
@@ -55,7 +56,7 @@ noncomputable def quadraticLift {K : Type u} [Field K]
     (soEquivQuadratic Q hQ).toLieHom.comp θ
 
 /-- The quadratic lift is the quadratic realization of the supplied skew-adjoint action. -/
-@[simp, grind =]
+@[grind =]
 theorem quadraticLift_apply {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
     [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
@@ -63,6 +64,16 @@ theorem quadraticLift_apply {K : Type u} [Field K]
     (θ : L →ₗ⁅K⁆ skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q)) (x : L) :
     quadraticLift Q hQ θ x = (soEquivQuadratic Q hQ (θ x) : CliffordAlgebra Q) := by
   rfl
+
+/-- The quadratic lift acts on Clifford generators through the supplied skew-adjoint action. -/
+@[simp, grind =]
+theorem quadraticLift_lie_ι {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+    [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    {L : Type w} [LieRing L] [LieAlgebra K L]
+    (θ : L →ₗ⁅K⁆ skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q)) (x : L) (v : V) :
+    ⁅quadraticLift Q hQ θ x, ι Q v⁆ = ι Q ((θ x : Module.End K V) v) := by
+  rw [quadraticLift_apply, soEquivQuadratic_lie_ι]
 
 /-- The Lie representation on a Clifford module induced through the quadratic realization. -/
 noncomputable def cliffordInducedRep {K : Type u} [Field K] {V : Type v} [AddCommGroup V]
@@ -125,8 +136,7 @@ theorem adjointCliffordHom_lie_ι (K : Type u) (L : Type v) [Field K]
     ⁅adjointCliffordHom K L x,
         CliffordAlgebra.ι (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) y⁆ =
       CliffordAlgebra.ι (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) ⁅x, y⁆ := by
-  simp only [adjointCliffordHom, quadraticLift, LieHom.comp_apply,
-    LieSubalgebra.coe_incl, LieEquiv.coe_toLieHom, soEquivQuadratic_lie_ι,
+  rw [adjointCliffordHom, quadraticLift_lie_ι,
     _root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply]
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
@@ -177,6 +177,7 @@ theorem soEquivQuadratic_lie_ι (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
 
 /-- Two quadratic Clifford elements are equal when their commutator actions agree on every
 generator. -/
+@[ext]
 theorem quadraticLieSubalgebra_ext_lie_ι (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     {a b : quadraticLieSubalgebra Q}
     (h : ∀ x : V, ⁅(a : CliffordAlgebra Q), ι Q x⁆ = ⁅(b : CliffordAlgebra Q), ι Q x⁆) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
@@ -22,7 +22,7 @@ canonical bivector action rather than from a basis-dependent inverse.
 
 * `CliffordAlgebra.soEquivQuadratic`: the quadratic realization Lie equivalence.
 * `CliffordAlgebra.soEquivQuadratic_lie_ι`: its defining generator-action equation.
-* `CliffordAlgebra.quadraticLieSubalgebra_ext_lie_ι`: quadratic elements are
+* `CliffordAlgebra.quadraticLieSubalgebra_ext`: quadratic elements are
   determined by their commutator action on Clifford generators.
 
 ## References
@@ -178,7 +178,7 @@ theorem soEquivQuadratic_lie_ι (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
 /-- Two quadratic Clifford elements are equal when their commutator actions agree on every
 generator. -/
 @[ext]
-theorem quadraticLieSubalgebra_ext_lie_ι (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+theorem quadraticLieSubalgebra_ext (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
     {a b : quadraticLieSubalgebra Q}
     (h : ∀ x : V, ⁅(a : CliffordAlgebra Q), ι Q x⁆ = ⁅(b : CliffordAlgebra Q), ι Q x⁆) :
     a = b := by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
@@ -22,6 +22,8 @@ canonical bivector action rather than from a basis-dependent inverse.
 
 * `CliffordAlgebra.soEquivQuadratic`: the quadratic realization Lie equivalence.
 * `CliffordAlgebra.soEquivQuadratic_lie_ι`: its defining generator-action equation.
+* `CliffordAlgebra.quadraticLieSubalgebra_ext_lie_ι`: quadratic elements are
+  determined by their commutator action on Clifford generators.
 
 ## References
 
@@ -172,5 +174,22 @@ theorem soEquivQuadratic_lie_ι (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
   change ⁅((soToQuadraticLinearEquiv Q hQ f : quadraticLieSubalgebra Q) :
       CliffordAlgebra Q), ι Q x⁆ = _
   exact soToQuadraticLinearEquiv_lie_ι Q hQ f x
+
+/-- Two quadratic Clifford elements are equal when their commutator actions agree on every
+generator. -/
+theorem quadraticLieSubalgebra_ext_lie_ι (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    {a b : quadraticLieSubalgebra Q}
+    (h : ∀ x : V, ⁅(a : CliffordAlgebra Q), ι Q x⁆ = ⁅(b : CliffordAlgebra Q), ι Q x⁆) :
+    a = b := by
+  let e := soEquivQuadratic Q hQ
+  apply e.symm.injective
+  apply Subtype.ext
+  apply LinearMap.ext
+  intro x
+  apply ι_injective Q
+  have ha := soEquivQuadratic_lie_ι Q hQ (e.symm a) x
+  have hb := soEquivQuadratic_lie_ι Q hQ (e.symm b) x
+  rw [e.apply_symm_apply] at ha hb
+  exact ha.symm.trans ((h x).trans hb)
 
 end CliffordAlgebra


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the normal-ordered quadratic lift of the general linear Lie algebra into a Clifford algebra.

- Constructs the generic quadratic lift and generator equation.
- Computes matrix units for the trace quadratic form.
- Proves the generator action and normal-ordering constant.

## Roadmap target

Advances the [Layer 9 CAR instance](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L608-L640).

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#glCliffordHom"}-->

## Verification

Full gates, consumers, golf, and fresh aggregate `2+1` pass at `4f8069db9dd8e8158e2fdfd12733280bec80f4fd`.

## Scale and generality

Changes 4 files by +295/−3. Generic over a field, finite index type, and invertible `2`.

## Scope

- **Consumes:** trace form, adjoint action, quadratic realization.
- **Provides:** quadratic lift, `glCliffordHom`, characteristic equations.
- **Fits:** supplies the lift for the CAR module and isotypy arguments.
- **Boundary:** CAR module, isotypy, multiplicity, and highest weight stay downstream.

<sub>🤖 GPT-5.6 Sol high · [rubrics](https://github.com/TauCetiProject/TauCetiReview/commit/f854a7e1bf95d7182f672ea06e690d08b07e06a5) · [2+1](https://github.com/utensil/formal-land/commit/f698b01bc3f15c8fcea1663ab333b8899093530c) fixed: api-design (1), attribution (1), documentation (1), proof-quality (8), reuse (2)</sub>