### PR TITLE
feat: prove group-level half-spin irreducibility

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -9,7 +9,6 @@ public import Mathlib.FieldTheory.IsSepClosed
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Pin.Action
 -- Private: `Algebra.adjoin_eq_span` supplies multiplication closure for the Spin-group span.
-import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 
 /-!
 # Lifting reflections to the Pin and Spin groups

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -6,7 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.IsSepClosed
+public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Pin.Action
+-- Private: `Algebra.adjoin_eq_span` supplies multiplication closure for the Spin-group span.
+import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 
 /-!
 # Lifting reflections to the Pin and Spin groups
@@ -16,7 +19,8 @@ When the inverse negative norm of a vector is a square, the vector can be rescal
 reflection in the original vector. A pair of reflections needs only that the product of the
 inverse norms be a square: rescaling one vector then gives a unitary even product and hence a
 lift to the Spin group. Over a separably closed field, the required square conditions hold
-automatically.
+automatically. When the quadratic form is nondegenerate, the same lifts show that the Spin group
+linearly spans the even Clifford algebra.
 
 ## Main results
 
@@ -25,11 +29,14 @@ automatically.
 * `CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare`: a
   product of two reflections lifts through the Spin action when the product of its normalization
   scalars is a square. The version without the suffix is a separably closed-field corollary.
+* `CliffordAlgebra.span_spinGroup_eq_even`: the Spin group spans the even Clifford algebra over a
+  separably closed field.
 
 ## References
 
-This supplies the reflection-lift prerequisite for Layer 2's "The double cover (the summit of the
-layer), over ℂ" target in `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`.
+This supplies the reflection-lift prerequisite for Layer 2's double-cover target and the
+Spin-group spanning prerequisite for Layer 4's irreducibility target in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`.
 See H. B. Lawson and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
 -/
 
@@ -226,6 +233,132 @@ theorem reflection_mul_reflection_mem_range_spinToOrthogonal
         (spinToOrthogonal Q).range := by
   exact reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare Q v w
     (IsSepClosed.exists_eq_mul_self (⅟(Q v) * ⅟(Q w)))
+
+/-! ### Linear generation of the even Clifford algebra -/
+
+omit [IsSepClosed K] [Invertible (2 : K)] in
+private theorem mem_span_anisotropic [NeZero (2 : K)] (hQ : Q.Nondegenerate) (x : V) :
+    x ∈ Submodule.span K {v | Q v ≠ 0} := by
+  classical
+  let _ : Invertible (2 : K) := invertibleOfNonzero (NeZero.ne (2 : K))
+  rcases eq_or_ne x 0 with rfl | hx
+  · exact Submodule.zero_mem _
+  by_cases hxQ : Q x = 0
+  · have hxrad : x ∉ Q.radical := by
+      rw [hQ.radical_eq_bot, Submodule.mem_bot]
+      exact hx
+    have hxker : x ∉ Q.polarBilin.ker := by
+      rw [← Q.radical_eq_ker_polarBilin]
+      exact hxrad
+    obtain ⟨y, hxy⟩ : ∃ y, polar Q x y ≠ 0 := by
+      rw [LinearMap.mem_ker, LinearMap.ext_iff] at hxker
+      push Not at hxker
+      simpa only [QuadraticMap.polarBilin_apply_apply, LinearMap.zero_apply] using hxker
+    let y' := if _hy : Q y = 0 then x + y else y
+    have hy'Q : Q y' ≠ 0 := by
+      dsimp only [y']
+      split_ifs with hyQ
+      · simpa only [polar, hxQ, hyQ, sub_zero, sub_self] using hxy
+      · exact hyQ
+    have hxy' : polar Q x y' ≠ 0 := by
+      dsimp only [y']
+      split_ifs with hyQ
+      · simpa only [polar_add_right, polar_self, hxQ, smul_zero, zero_add] using hxy
+      · exact hxy
+    let a := polar Q x y' / Q y'
+    have ha : a ≠ 0 := div_ne_zero hxy' hy'Q
+    let z := x + a • y'
+    have hzQ_eq : Q z = 2 * (polar Q x y') ^ 2 / Q y' := by
+      dsimp only [z, a]
+      rw [QuadraticMap.map_add Q, Q.map_smul, polar_smul_right, hxQ, zero_add]
+      simp only [smul_eq_mul]
+      field_simp [hy'Q]
+      ring
+    have hzQ : Q z ≠ 0 := by
+      rw [hzQ_eq]
+      exact div_ne_zero (mul_ne_zero (NeZero.ne (2 : K)) (pow_ne_zero 2 hxy')) hy'Q
+    have hy'mem : y' ∈ Submodule.span K {v | Q v ≠ 0} :=
+      Submodule.subset_span hy'Q
+    have hzmem : z ∈ Submodule.span K {v | Q v ≠ 0} :=
+      Submodule.subset_span hzQ
+    have hsub := Submodule.sub_mem _ hzmem (Submodule.smul_mem _ a hy'mem)
+    simpa only [z, add_sub_cancel_right] using hsub
+  · exact Submodule.subset_span hxQ
+
+omit [IsSepClosed K] [Invertible (2 : K)] in
+private theorem mul_mem_span_spinGroup {x y : CliffordAlgebra Q}
+    (hx : x ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)))
+    (hy : y ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q))) :
+    x * y ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
+  rw [← Submonoid.closure_eq (spinGroup Q), ← Algebra.adjoin_eq_span] at hx hy ⊢
+  exact (Algebra.adjoin K (spinGroup Q : Set (CliffordAlgebra Q))).mul_mem hx hy
+
+omit [Invertible (2 : K)] in
+private theorem ι_mul_ι_mem_span_spinGroup_of_ne_zero [NeZero (2 : K)]
+    (v w : V) (hv : Q v ≠ 0)
+    (hw : Q w ≠ 0) :
+    ι Q v * ι Q w ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
+  let _ : Invertible (Q v) := invertibleOfNonzero hv
+  let _ : Invertible (Q w) := invertibleOfNonzero hw
+  let hsq : IsSquare (⅟(Q v) * ⅟(Q w)) :=
+    IsSepClosed.exists_eq_mul_self (⅟(Q v) * ⅟(Q w))
+  let a := sqrtOfIsSquare hsq
+  have ha : IsUnit a := isUnit_sqrtOfIsSquare Q v w hsq
+  let _ : Invertible a := ha.invertible
+  let g := spinReflectionPairLift Q v w hsq
+  have hg : (g : CliffordAlgebra Q) ∈
+      Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) :=
+    Submodule.subset_span g.2
+  have hcoe : (g : CliffordAlgebra Q) = a • (ι Q v * ι Q w) := by
+    simp only [g, spinReflectionPairLift, a, map_smul, smul_mul_assoc]
+  have := Submodule.smul_mem _ (⅟a) hg
+  rw [hcoe, invOf_smul_smul] at this
+  exact this
+
+omit [Invertible (2 : K)] in
+private theorem ι_mul_ι_mem_span_spinGroup [NeZero (2 : K)]
+    (hQ : Q.Nondegenerate) (v w : V) :
+    ι Q v * ι Q w ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
+  have hv := mem_span_anisotropic Q hQ v
+  have hw := mem_span_anisotropic Q hQ w
+  induction hv, hw using Submodule.span_induction₂ with
+  | mem_mem v w hv hw => exact ι_mul_ι_mem_span_spinGroup_of_ne_zero Q v w hv hw
+  | zero_left => simp
+  | zero_right => simp
+  | add_left x y z _ _ _ hx hy =>
+      simpa only [map_add, add_mul] using Submodule.add_mem _ hx hy
+  | add_right x y z _ _ _ hx hy =>
+      simpa only [map_add, mul_add] using Submodule.add_mem _ hx hy
+  | smul_left r x y _ _ h =>
+      simpa only [map_smul, smul_mul_assoc] using Submodule.smul_mem _ r h
+  | smul_right r x y _ _ h =>
+      simpa only [map_smul, mul_smul_comm] using Submodule.smul_mem _ r h
+
+omit [Invertible (2 : K)] in
+/-- **The Spin group linearly spans the even Clifford algebra** over a separably closed field.
+Every even Clifford element is a linear combination of repeated products of normalized
+anisotropic pairs. Each pair is a scalar multiple of a Spin element, and products of those
+elements remain in `spinGroup Q`. -/
+theorem span_spinGroup_eq_even [NeZero (2 : K)] (hQ : Q.Nondegenerate) :
+    Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) = (even Q).toSubmodule := by
+  apply le_antisymm
+  · exact Submodule.span_le.2 fun _ hx => spinGroup.mem_even hx
+  · rintro x hx
+    have hx' : x ∈ evenOdd Q 0 := by
+      rw [← even_toSubmodule Q]
+      exact hx
+    refine even_induction (Q := Q) (motive := fun x _ =>
+      x ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q))) ?_ ?_ ?_ x hx'
+    · intro r
+      have hone : (1 : CliffordAlgebra Q) ∈
+          Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) :=
+        Submodule.subset_span (one_mem (spinGroup Q))
+      simpa only [Algebra.smul_def, mul_one] using Submodule.smul_mem _ r hone
+    · intro x y hx hy ihx ihy
+      exact Submodule.add_mem _ ihx ihy
+    · intro v w x hx ih
+      exact mul_mem_span_spinGroup (Q := Q)
+        (ι_mul_ι_mem_span_spinGroup Q hQ v w) ih
 
 end IsSepClosed
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -20,7 +20,7 @@ reflection in the original vector. A pair of reflections needs only that the pro
 inverse norms be a square: rescaling one vector then gives a unitary even product and hence a
 lift to the Spin group. Over a separably closed field, the required square conditions hold
 automatically. When the quadratic form is nondegenerate, the same lifts show that the Spin group
-linearly spans the even Clifford algebra.
+linearly spans the even Clifford algebra, provided `2` is nonzero.
 
 ## Main results
 
@@ -29,8 +29,10 @@ linearly spans the even Clifford algebra.
 * `CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare`: a
   product of two reflections lifts through the Spin action when the product of its normalization
   scalars is a square. The version without the suffix is a separably closed-field corollary.
-* `CliffordAlgebra.span_spinGroup_eq_even`: the Spin group spans the even Clifford algebra over a
-  separably closed field.
+* `CliffordAlgebra.span_spinGroup_eq_even_of_isSquare`: the Spin group spans the even Clifford
+  algebra when anisotropic pairs admit the required square normalization.
+* `CliffordAlgebra.span_spinGroup_eq_even`: the separably closed-field corollary, for a
+  nondegenerate form in characteristic different from two.
 
 ## References
 
@@ -293,19 +295,20 @@ private theorem mul_mem_span_spinGroup {x y : CliffordAlgebra Q}
   rw [← Submonoid.closure_eq (spinGroup Q), ← Algebra.adjoin_eq_span] at hx hy ⊢
   exact (Algebra.adjoin K (spinGroup Q : Set (CliffordAlgebra Q))).mul_mem hx hy
 
-omit [Invertible (2 : K)] in
-private theorem ι_mul_ι_mem_span_spinGroup_of_ne_zero [NeZero (2 : K)]
+omit [IsSepClosed K] [Invertible (2 : K)] in
+private theorem ι_mul_ι_mem_span_spinGroup_of_ne_zero
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
     (v w : V) (hv : Q v ≠ 0)
     (hw : Q w ≠ 0) :
     ι Q v * ι Q w ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
   let _ : Invertible (Q v) := invertibleOfNonzero hv
   let _ : Invertible (Q w) := invertibleOfNonzero hw
-  let hsq : IsSquare (⅟(Q v) * ⅟(Q w)) :=
-    IsSepClosed.exists_eq_mul_self (⅟(Q v) * ⅟(Q w))
-  let a := sqrtOfIsSquare hsq
-  have ha : IsUnit a := isUnit_sqrtOfIsSquare Q v w hsq
+  let h : IsSquare (⅟(Q v) * ⅟(Q w)) := by
+    simpa only [invOf_eq_inv] using hsq v w hv hw
+  let a := sqrtOfIsSquare h
+  have ha : IsUnit a := isUnit_sqrtOfIsSquare Q v w h
   let _ : Invertible a := ha.invertible
-  let g := spinReflectionPairLift Q v w hsq
+  let g := spinReflectionPairLift Q v w h
   have hg : (g : CliffordAlgebra Q) ∈
       Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) :=
     Submodule.subset_span g.2
@@ -315,14 +318,15 @@ private theorem ι_mul_ι_mem_span_spinGroup_of_ne_zero [NeZero (2 : K)]
   rw [hcoe, invOf_smul_smul] at this
   exact this
 
-omit [Invertible (2 : K)] in
+omit [IsSepClosed K] [Invertible (2 : K)] in
 private theorem ι_mul_ι_mem_span_spinGroup [NeZero (2 : K)]
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
     (hQ : Q.Nondegenerate) (v w : V) :
     ι Q v * ι Q w ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
   have hv := mem_span_anisotropic Q hQ v
   have hw := mem_span_anisotropic Q hQ w
   induction hv, hw using Submodule.span_induction₂ with
-  | mem_mem v w hv hw => exact ι_mul_ι_mem_span_spinGroup_of_ne_zero Q v w hv hw
+  | mem_mem v w hv hw => exact ι_mul_ι_mem_span_spinGroup_of_ne_zero Q hsq v w hv hw
   | zero_left => simp
   | zero_right => simp
   | add_left x y z _ _ _ hx hy =>
@@ -334,12 +338,11 @@ private theorem ι_mul_ι_mem_span_spinGroup [NeZero (2 : K)]
   | smul_right r x y _ _ h =>
       simpa only [map_smul, mul_smul_comm] using Submodule.smul_mem _ r h
 
-omit [Invertible (2 : K)] in
-/-- **The Spin group linearly spans the even Clifford algebra** over a separably closed field.
-Every even Clifford element is a linear combination of repeated products of normalized
-anisotropic pairs. Each pair is a scalar multiple of a Spin element, and products of those
-elements remain in `spinGroup Q`. -/
-theorem span_spinGroup_eq_even [NeZero (2 : K)] (hQ : Q.Nondegenerate) :
+omit [IsSepClosed K] [Invertible (2 : K)] in
+/-- **The Spin group linearly spans the even Clifford algebra** when every pair of anisotropic
+vectors admits the square normalization needed to lift it to the Spin group. -/
+theorem span_spinGroup_eq_even_of_isSquare [NeZero (2 : K)] (hQ : Q.Nondegenerate)
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹)) :
     Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) = (even Q).toSubmodule := by
   apply le_antisymm
   · exact Submodule.span_le.2 fun _ hx => spinGroup.mem_even hx
@@ -358,7 +361,15 @@ theorem span_spinGroup_eq_even [NeZero (2 : K)] (hQ : Q.Nondegenerate) :
       exact Submodule.add_mem _ ihx ihy
     · intro v w x hx ih
       exact mul_mem_span_spinGroup (Q := Q)
-        (ι_mul_ι_mem_span_spinGroup Q hQ v w) ih
+        (ι_mul_ι_mem_span_spinGroup Q hsq hQ v w) ih
+
+omit [Invertible (2 : K)] in
+/-- **The Spin group linearly spans the even Clifford algebra** for a nondegenerate quadratic
+form over a separably closed field of characteristic different from two. -/
+theorem span_spinGroup_eq_even [NeZero (2 : K)] (hQ : Q.Nondegenerate) :
+    Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) = (even Q).toSubmodule := by
+  exact span_spinGroup_eq_even_of_isSquare Q hQ fun v w _ _ =>
+    IsSepClosed.exists_eq_mul_self ((Q v)⁻¹ * (Q w)⁻¹)
 
 end IsSepClosed
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ReflectionLift.lean
@@ -28,8 +28,11 @@ linearly spans the even Clifford algebra, provided `2` is nonzero.
 * `CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare`: a
   product of two reflections lifts through the Spin action when the product of its normalization
   scalars is a square. The version without the suffix is a separably closed-field corollary.
-* `CliffordAlgebra.span_spinGroup_eq_even_of_isSquare`: the Spin group spans the even Clifford
-  algebra when anisotropic pairs admit the required square normalization.
+* `CliffordAlgebra.span_spinGroup_eq_even_of_span_anisotropic`: the Spin group spans the even
+  Clifford algebra when anisotropic vectors span and pairs admit the required square
+  normalization.
+* `CliffordAlgebra.span_spinGroup_eq_even_of_isSquare`: the nondegenerate,
+  characteristic-not-two corollary.
 * `CliffordAlgebra.span_spinGroup_eq_even`: the separably closed-field corollary, for a
   nondegenerate form in characteristic different from two.
 
@@ -318,12 +321,13 @@ private theorem ι_mul_ι_mem_span_spinGroup_of_ne_zero
   exact this
 
 omit [IsSepClosed K] [Invertible (2 : K)] in
-private theorem ι_mul_ι_mem_span_spinGroup [NeZero (2 : K)]
+private theorem ι_mul_ι_mem_span_spinGroup_of_span_anisotropic
+    (hspan : Submodule.span K {v | Q v ≠ 0} = ⊤)
     (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
-    (hQ : Q.Nondegenerate) (v w : V) :
+    (v w : V) :
     ι Q v * ι Q w ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
-  have hv := mem_span_anisotropic Q hQ v
-  have hw := mem_span_anisotropic Q hQ w
+  have hv : v ∈ Submodule.span K {x | Q x ≠ 0} := hspan.symm ▸ Submodule.mem_top
+  have hw : w ∈ Submodule.span K {x | Q x ≠ 0} := hspan.symm ▸ Submodule.mem_top
   induction hv, hw using Submodule.span_induction₂ with
   | mem_mem v w hv hw => exact ι_mul_ι_mem_span_spinGroup_of_ne_zero Q hsq v w hv hw
   | zero_left => simp
@@ -338,9 +342,10 @@ private theorem ι_mul_ι_mem_span_spinGroup [NeZero (2 : K)]
       simpa only [map_smul, mul_smul_comm] using Submodule.smul_mem _ r h
 
 omit [IsSepClosed K] [Invertible (2 : K)] in
-/-- **The Spin group linearly spans the even Clifford algebra** when every pair of anisotropic
-vectors admits the square normalization needed to lift it to the Spin group. -/
-theorem span_spinGroup_eq_even_of_isSquare [NeZero (2 : K)] (hQ : Q.Nondegenerate)
+/-- **The Spin group linearly spans the even Clifford algebra** when anisotropic vectors span and
+every pair of them admits the square normalization needed to lift it to the Spin group. -/
+theorem span_spinGroup_eq_even_of_span_anisotropic
+    (hspan : Submodule.span K {v | Q v ≠ 0} = ⊤)
     (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹)) :
     Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) = (even Q).toSubmodule := by
   apply le_antisymm
@@ -360,7 +365,16 @@ theorem span_spinGroup_eq_even_of_isSquare [NeZero (2 : K)] (hQ : Q.Nondegenerat
       exact Submodule.add_mem _ ihx ihy
     · intro v w x hx ih
       exact mul_mem_span_spinGroup (Q := Q)
-        (ι_mul_ι_mem_span_spinGroup Q hsq hQ v w) ih
+        (ι_mul_ι_mem_span_spinGroup_of_span_anisotropic Q hspan hsq v w) ih
+
+omit [IsSepClosed K] [Invertible (2 : K)] in
+/-- **The Spin group linearly spans the even Clifford algebra** when every pair of anisotropic
+vectors admits the square normalization, the form is nondegenerate, and `2` is nonzero. -/
+theorem span_spinGroup_eq_even_of_isSquare [NeZero (2 : K)] (hQ : Q.Nondegenerate)
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹)) :
+    Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) = (even Q).toSubmodule := by
+  apply span_spinGroup_eq_even_of_span_anisotropic Q _ hsq
+  exact eq_top_iff.2 fun x _ => mem_span_anisotropic Q hQ x
 
 omit [Invertible (2 : K)] in
 /-- **The Spin group linearly spans the even Clifford algebra** for a nondegenerate quadratic

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -83,13 +83,14 @@ central summands, for which the results here are the even-dimensional half.
   way intertwining the two actions, and hence
   `TauCeti.not_exists_equiv_intertwines_spinPlusAction_spinMinusAction`: **the half-spin summands
   are inequivalent.**
-* `TauCeti.isIrreducible_spinPlusSubrep_of_isSquare` and
-  `TauCeti.isIrreducible_spinMinusSubrep_of_isSquare`: **the two half-spin group representations
-  are irreducible** under the square-normalization hypothesis, with `P.W ≠ ⊥` required for the
-  odd half. The versions without the suffix specialize to separably closed fields.
-* `TauCeti.isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_isSquare`: **the two half-spin group
-  representations are inequivalent** under the same hypothesis; the version without the suffix
-  is the separably closed specialization.
+* `TauCeti.isIrreducible_spinPlusSubrep_of_span` and
+  `TauCeti.isIrreducible_spinMinusSubrep_of_span`: **the two half-spin group representations are
+  irreducible** when the Spin group spans the even Clifford algebra, with `P.W ≠ ⊥` required for
+  the odd half. The `_of_isSquare` and suffix-free versions give progressively stronger sufficient
+  hypotheses.
+* `TauCeti.isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_span`: **the two half-spin group
+  representations are inequivalent** under the same spanning hypothesis, with analogous
+  corollaries.
 
 ## References
 
@@ -142,13 +143,14 @@ private noncomputable def spinGroupAlgebraHom {K : Type u} [Field K]
 
 private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V]
-    {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate)
-    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹)) :
+    {Q : QuadraticForm K V}
+    (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
+      (CliffordAlgebra.even Q).toSubmodule) :
     Function.Surjective (spinGroupAlgebraHom (K := K) (Q := Q)) := by
   intro x
   have hx : (x : CliffordAlgebra Q) ∈
       Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
-    rw [CliffordAlgebra.span_spinGroup_eq_even_of_isSquare Q hQ hsq]
+    rw [hspan]
     exact x.2
   obtain ⟨a, ha⟩ := (Finsupp.mem_span_iff_linearCombination K
     (spinGroup Q : Set (CliffordAlgebra Q)) x).1 hx
@@ -184,26 +186,28 @@ private theorem asAlgebraHom_spinGroupRepresentation {K : Type u} [Field K]
 
 private theorem isIrreducible_spinGroupRepresentation {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V]
-    {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate)
-    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+    {Q : QuadraticForm K V}
+    (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
+      (CliffordAlgebra.even Q).toSubmodule)
     {M : Type*} [AddCommGroup M] [Module K M] [Nontrivial M]
     (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M)
     (hF : Function.Surjective F) : (spinGroupRepresentation F).IsIrreducible := by
   apply Representation.isIrreducible_of_asAlgebraHom_surjective
   rw [asAlgebraHom_spinGroupRepresentation]
-  exact hF.comp (spinGroupAlgebraHom_surjective hQ hsq)
+  exact hF.comp (spinGroupAlgebraHom_surjective hspan)
 
 private theorem intertwines_even_of_intertwines_spinGroup {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V]
-    {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate)
-    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+    {Q : QuadraticForm K V}
+    (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
+      (CliffordAlgebra.even Q).toSubmodule)
     {M N : Type*} [AddCommGroup M] [Module K M] [AddCommGroup N] [Module K N]
     (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M)
     (G : CliffordAlgebra.even Q →ₐ[K] Module.End K N) (φ : M →ₗ[K] N)
     (hφ : ∀ (g : spinGroup Q) (m : M),
       φ (F ⟨g, spinGroup.mem_even g.2⟩ m) = G ⟨g, spinGroup.mem_even g.2⟩ (φ m))
     (x : CliffordAlgebra.even Q) (m : M) : φ (F x m) = G x (φ m) := by
-  obtain ⟨a, rfl⟩ := spinGroupAlgebraHom_surjective hQ hsq x
+  obtain ⟨a, rfl⟩ := spinGroupAlgebraHom_surjective hspan x
   let φ' : (spinGroupRepresentation F).IntertwiningMap (spinGroupRepresentation G) :=
     ⟨φ, fun g => LinearMap.ext fun m => hφ g m⟩
   have h := (Representation.IntertwiningMap.equivLinearMapAsModule
@@ -328,16 +332,16 @@ variable {K : Type u} [Field K]
   {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
   [Invertible (2 : K)] [FiniteDimensional K V] (P : SpinPolarizationData Q)
 
-/-- **The even half-spin representation of the Spin group is irreducible** when anisotropic pairs
-admit the square normalization needed to span the even Clifford algebra. -/
-theorem isIrreducible_spinPlusSubrep_of_isSquare
-    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+/-- **The even half-spin representation of the Spin group is irreducible** when the Spin group
+linearly spans the even Clifford algebra. -/
+theorem isIrreducible_spinPlusSubrep_of_span
+    (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
+      (CliffordAlgebra.even Q).toSubmodule)
     (hline : P.line = ⊥) :
     (spinPlusSubrep P hline).toRepresentation.IsIrreducible := by
-  have hQ := P.nondegenerate_of_line_eq_bot hline
   let _ : Nontrivial (spinPlus Q P) := nontrivial_spinPlus P
   have hρ : (spinGroupRepresentation (spinPlusAction Q P hline)).IsIrreducible :=
-    isIrreducible_spinGroupRepresentation hQ hsq (spinPlusAction Q P hline)
+    isIrreducible_spinGroupRepresentation hspan (spinPlusAction Q P hline)
       (spinPlusAction_surjective P hline)
   let e : spinPlus Q P ≃ₗ[K] (spinPlusSubrep P hline).toSubmodule :=
     LinearEquiv.ofEq _ _ (toSubmodule_spinPlusSubrep P hline).symm
@@ -347,15 +351,15 @@ theorem isIrreducible_spinPlusSubrep_of_isSquare
   exact coe_spinPlusAction_spinGroup_apply P hline g s
 
 /-- **The odd half-spin representation of the Spin group is irreducible** when the odd summand is
-nonzero and anisotropic pairs admit the required square normalization. -/
-theorem isIrreducible_spinMinusSubrep_of_isSquare
-    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+nonzero and the Spin group linearly spans the even Clifford algebra. -/
+theorem isIrreducible_spinMinusSubrep_of_span
+    (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
+      (CliffordAlgebra.even Q).toSubmodule)
     (hline : P.line = ⊥)
     (hW : P.W ≠ ⊥) : (spinMinusSubrep P hline).toRepresentation.IsIrreducible := by
-  have hQ := P.nondegenerate_of_line_eq_bot hline
   let _ : Nontrivial (spinMinus Q P) := nontrivial_spinMinus P hW
   have hρ : (spinGroupRepresentation (spinMinusAction Q P hline)).IsIrreducible :=
-    isIrreducible_spinGroupRepresentation hQ hsq (spinMinusAction Q P hline)
+    isIrreducible_spinGroupRepresentation hspan (spinMinusAction Q P hline)
       (spinMinusAction_surjective P hline)
   let e : spinMinus Q P ≃ₗ[K] (spinMinusSubrep P hline).toSubmodule :=
     LinearEquiv.ofEq _ _ (toSubmodule_spinMinusSubrep P hline).symm
@@ -364,14 +368,14 @@ theorem isIrreducible_spinMinusSubrep_of_isSquare
   apply Subtype.ext
   exact coe_spinMinusAction_spinGroup_apply P hline g s
 
-/-- **The two half-spin representations of the Spin group are inequivalent** when anisotropic
-pairs admit the square normalization needed to span the even Clifford algebra. -/
-theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_isSquare
-    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+/-- **The two half-spin representations of the Spin group are inequivalent** when the Spin group
+linearly spans the even Clifford algebra. -/
+theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_span
+    (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
+      (CliffordAlgebra.even Q).toSubmodule)
     (hline : P.line = ⊥) :
     IsEmpty ((spinPlusSubrep P hline).toRepresentation.Equiv
       (spinMinusSubrep P hline).toRepresentation) := by
-  have hQ := P.nondegenerate_of_line_eq_bot hline
   refine ⟨fun e => ?_⟩
   let ePlus : spinPlus Q P ≃ₗ[K] (spinPlusSubrep P hline).toSubmodule :=
     LinearEquiv.ofEq _ _ (toSubmodule_spinPlusSubrep P hline).symm
@@ -380,7 +384,7 @@ theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_isSquare
   let f : spinPlus Q P ≃ₗ[K] spinMinus Q P :=
     ePlus.trans (e.toLinearEquiv.trans eMinus.symm)
   apply not_exists_equiv_intertwines_spinPlusAction_spinMinusAction P hline
-  refine ⟨f, fun x s => intertwines_even_of_intertwines_spinGroup hQ hsq
+  refine ⟨f, fun x s => intertwines_even_of_intertwines_spinGroup hspan
     (spinPlusAction Q P hline) (spinMinusAction Q P hline) f.toLinearMap ?_ x s⟩
   intro g s
   have hPlus : ePlus ((spinGroupRepresentation (spinPlusAction Q P hline)) g s) =
@@ -413,6 +417,37 @@ theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_isSquare
       congrArg ((spinMinusSubrep P hline).toRepresentation g) (hef s)
     _ = eMinus ((spinGroupRepresentation (spinMinusAction Q P hline)) g (f s)) :=
       (hMinus (f s)).symm
+
+/-- **The even half-spin representation of the Spin group is irreducible** when anisotropic pairs
+admit the square normalization needed to span the even Clifford algebra. -/
+theorem isIrreducible_spinPlusSubrep_of_isSquare
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+    (hline : P.line = ⊥) :
+    (spinPlusSubrep P hline).toRepresentation.IsIrreducible :=
+  isIrreducible_spinPlusSubrep_of_span P
+    (CliffordAlgebra.span_spinGroup_eq_even_of_isSquare Q
+      (P.nondegenerate_of_line_eq_bot hline) hsq) hline
+
+/-- **The odd half-spin representation of the Spin group is irreducible** when the odd summand is
+nonzero and anisotropic pairs admit the required square normalization. -/
+theorem isIrreducible_spinMinusSubrep_of_isSquare
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+    (hline : P.line = ⊥)
+    (hW : P.W ≠ ⊥) : (spinMinusSubrep P hline).toRepresentation.IsIrreducible :=
+  isIrreducible_spinMinusSubrep_of_span P
+    (CliffordAlgebra.span_spinGroup_eq_even_of_isSquare Q
+      (P.nondegenerate_of_line_eq_bot hline) hsq) hline hW
+
+/-- **The two half-spin representations of the Spin group are inequivalent** when anisotropic
+pairs admit the square normalization needed to span the even Clifford algebra. -/
+theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_isSquare
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+    (hline : P.line = ⊥) :
+    IsEmpty ((spinPlusSubrep P hline).toRepresentation.Equiv
+      (spinMinusSubrep P hline).toRepresentation) :=
+  isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_span P
+    (CliffordAlgebra.span_spinGroup_eq_even_of_isSquare Q
+      (P.nondegenerate_of_line_eq_bot hline) hsq) hline
 
 /-- **The even half-spin representation of the Spin group is irreducible** over a separably
 closed field for polarization data without a line remainder. -/

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -83,10 +83,13 @@ central summands, for which the results here are the even-dimensional half.
   way intertwining the two actions, and hence
   `TauCeti.not_exists_equiv_intertwines_spinPlusAction_spinMinusAction`: **the half-spin summands
   are inequivalent.**
-* `TauCeti.isIrreducible_spinPlusSubrep` and `TauCeti.isIrreducible_spinMinusSubrep`: **the two
-  half-spin group representations are irreducible**, with `P.W ≠ ⊥` required for the odd half.
-* `TauCeti.isEmpty_equiv_spinPlusSubrep_spinMinusSubrep`: **the two half-spin group
-  representations are inequivalent.**
+* `TauCeti.isIrreducible_spinPlusSubrep_of_isSquare` and
+  `TauCeti.isIrreducible_spinMinusSubrep_of_isSquare`: **the two half-spin group representations
+  are irreducible** under the square-normalization hypothesis, with `P.W ≠ ⊥` required for the
+  odd half. The versions without the suffix specialize to separably closed fields.
+* `TauCeti.isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_isSquare`: **the two half-spin group
+  representations are inequivalent** under the same hypothesis; the version without the suffix
+  is the separably closed specialization.
 
 ## References
 
@@ -138,13 +141,14 @@ private noncomputable def spinGroupAlgebraHom {K : Type u} [Field K]
   MonoidAlgebra.lift K (CliffordAlgebra.even Q) (spinGroup Q) spinGroupToEven
 
 private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
-    [IsSepClosed K] {V : Type v} [AddCommGroup V] [Module K V]
-    {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate) :
+    {V : Type v} [AddCommGroup V] [Module K V]
+    {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate)
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹)) :
     Function.Surjective (spinGroupAlgebraHom (K := K) (Q := Q)) := by
   intro x
   have hx : (x : CliffordAlgebra Q) ∈
       Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
-    rw [CliffordAlgebra.span_spinGroup_eq_even Q hQ]
+    rw [CliffordAlgebra.span_spinGroup_eq_even_of_isSquare Q hQ hsq]
     exact x.2
   obtain ⟨a, ha⟩ := (Finsupp.mem_span_iff_linearCombination K
     (spinGroup Q : Set (CliffordAlgebra Q)) x).1 hx
@@ -179,25 +183,27 @@ private theorem asAlgebraHom_spinGroupRepresentation {K : Type u} [Field K]
   · ext
 
 private theorem isIrreducible_spinGroupRepresentation {K : Type u} [Field K]
-    [IsSepClosed K] {V : Type v} [AddCommGroup V] [Module K V]
+    {V : Type v} [AddCommGroup V] [Module K V]
     {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate)
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
     {M : Type*} [AddCommGroup M] [Module K M] [Nontrivial M]
     (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M)
     (hF : Function.Surjective F) : (spinGroupRepresentation F).IsIrreducible := by
   apply Representation.isIrreducible_of_asAlgebraHom_surjective
   rw [asAlgebraHom_spinGroupRepresentation]
-  exact hF.comp (spinGroupAlgebraHom_surjective hQ)
+  exact hF.comp (spinGroupAlgebraHom_surjective hQ hsq)
 
 private theorem intertwines_even_of_intertwines_spinGroup {K : Type u} [Field K]
-    [IsSepClosed K] {V : Type v} [AddCommGroup V] [Module K V]
+    {V : Type v} [AddCommGroup V] [Module K V]
     {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate)
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
     {M N : Type*} [AddCommGroup M] [Module K M] [AddCommGroup N] [Module K N]
     (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M)
     (G : CliffordAlgebra.even Q →ₐ[K] Module.End K N) (φ : M →ₗ[K] N)
     (hφ : ∀ (g : spinGroup Q) (m : M),
       φ (F ⟨g, spinGroup.mem_even g.2⟩ m) = G ⟨g, spinGroup.mem_even g.2⟩ (φ m))
     (x : CliffordAlgebra.even Q) (m : M) : φ (F x m) = G x (φ m) := by
-  obtain ⟨a, rfl⟩ := spinGroupAlgebraHom_surjective hQ x
+  obtain ⟨a, rfl⟩ := spinGroupAlgebraHom_surjective hQ hsq x
   let φ' : (spinGroupRepresentation F).IntertwiningMap (spinGroupRepresentation G) :=
     ⟨φ, fun g => LinearMap.ext fun m => hφ g m⟩
   have h := (Representation.IntertwiningMap.equivLinearMapAsModule
@@ -318,18 +324,20 @@ end Even
 
 section SpinGroup
 
-variable {K : Type u} [Field K] [IsSepClosed K]
+variable {K : Type u} [Field K]
   {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
   [Invertible (2 : K)] [FiniteDimensional K V] (P : SpinPolarizationData Q)
 
-/-- **The even half-spin representation of the Spin group is irreducible** for polarization data
-without a line remainder. -/
-theorem isIrreducible_spinPlusSubrep (hline : P.line = ⊥) :
+/-- **The even half-spin representation of the Spin group is irreducible** when anisotropic pairs
+admit the square normalization needed to span the even Clifford algebra. -/
+theorem isIrreducible_spinPlusSubrep_of_isSquare
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+    (hline : P.line = ⊥) :
     (spinPlusSubrep P hline).toRepresentation.IsIrreducible := by
   have hQ := P.nondegenerate_of_line_eq_bot hline
   let _ : Nontrivial (spinPlus Q P) := nontrivial_spinPlus P
   have hρ : (spinGroupRepresentation (spinPlusAction Q P hline)).IsIrreducible :=
-    isIrreducible_spinGroupRepresentation hQ (spinPlusAction Q P hline)
+    isIrreducible_spinGroupRepresentation hQ hsq (spinPlusAction Q P hline)
       (spinPlusAction_surjective P hline)
   let e : spinPlus Q P ≃ₗ[K] (spinPlusSubrep P hline).toSubmodule :=
     LinearEquiv.ofEq _ _ (toSubmodule_spinPlusSubrep P hline).symm
@@ -339,13 +347,15 @@ theorem isIrreducible_spinPlusSubrep (hline : P.line = ⊥) :
   exact coe_spinPlusAction_spinGroup_apply P hline g s
 
 /-- **The odd half-spin representation of the Spin group is irreducible** when the odd summand is
-nonzero. -/
-theorem isIrreducible_spinMinusSubrep (hline : P.line = ⊥)
+nonzero and anisotropic pairs admit the required square normalization. -/
+theorem isIrreducible_spinMinusSubrep_of_isSquare
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+    (hline : P.line = ⊥)
     (hW : P.W ≠ ⊥) : (spinMinusSubrep P hline).toRepresentation.IsIrreducible := by
   have hQ := P.nondegenerate_of_line_eq_bot hline
   let _ : Nontrivial (spinMinus Q P) := nontrivial_spinMinus P hW
   have hρ : (spinGroupRepresentation (spinMinusAction Q P hline)).IsIrreducible :=
-    isIrreducible_spinGroupRepresentation hQ (spinMinusAction Q P hline)
+    isIrreducible_spinGroupRepresentation hQ hsq (spinMinusAction Q P hline)
       (spinMinusAction_surjective P hline)
   let e : spinMinus Q P ≃ₗ[K] (spinMinusSubrep P hline).toSubmodule :=
     LinearEquiv.ofEq _ _ (toSubmodule_spinMinusSubrep P hline).symm
@@ -354,8 +364,10 @@ theorem isIrreducible_spinMinusSubrep (hline : P.line = ⊥)
   apply Subtype.ext
   exact coe_spinMinusAction_spinGroup_apply P hline g s
 
-/-- **The two half-spin representations of the Spin group are inequivalent.** -/
-theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep
+/-- **The two half-spin representations of the Spin group are inequivalent** when anisotropic
+pairs admit the square normalization needed to span the even Clifford algebra. -/
+theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_isSquare
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
     (hline : P.line = ⊥) :
     IsEmpty ((spinPlusSubrep P hline).toRepresentation.Equiv
       (spinMinusSubrep P hline).toRepresentation) := by
@@ -368,7 +380,7 @@ theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep
   let f : spinPlus Q P ≃ₗ[K] spinMinus Q P :=
     ePlus.trans (e.toLinearEquiv.trans eMinus.symm)
   apply not_exists_equiv_intertwines_spinPlusAction_spinMinusAction P hline
-  refine ⟨f, fun x s => intertwines_even_of_intertwines_spinGroup hQ
+  refine ⟨f, fun x s => intertwines_even_of_intertwines_spinGroup hQ hsq
     (spinPlusAction Q P hline) (spinMinusAction Q P hline) f.toLinearMap ?_ x s⟩
   intro g s
   have hPlus : ePlus ((spinGroupRepresentation (spinPlusAction Q P hline)) g s) =
@@ -401,6 +413,29 @@ theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep
       congrArg ((spinMinusSubrep P hline).toRepresentation g) (hef s)
     _ = eMinus ((spinGroupRepresentation (spinMinusAction Q P hline)) g (f s)) :=
       (hMinus (f s)).symm
+
+/-- **The even half-spin representation of the Spin group is irreducible** over a separably
+closed field for polarization data without a line remainder. -/
+theorem isIrreducible_spinPlusSubrep [IsSepClosed K] (hline : P.line = ⊥) :
+    (spinPlusSubrep P hline).toRepresentation.IsIrreducible :=
+  isIrreducible_spinPlusSubrep_of_isSquare P
+    (fun v w _ _ ↦ IsSepClosed.exists_eq_mul_self ((Q v)⁻¹ * (Q w)⁻¹)) hline
+
+/-- **The odd half-spin representation of the Spin group is irreducible** over a separably closed
+field when the odd summand is nonzero. -/
+theorem isIrreducible_spinMinusSubrep [IsSepClosed K] (hline : P.line = ⊥)
+    (hW : P.W ≠ ⊥) : (spinMinusSubrep P hline).toRepresentation.IsIrreducible :=
+  isIrreducible_spinMinusSubrep_of_isSquare P
+    (fun v w _ _ ↦ IsSepClosed.exists_eq_mul_self ((Q v)⁻¹ * (Q w)⁻¹)) hline hW
+
+/-- **The two half-spin representations of the Spin group are inequivalent** over a separably
+closed field. -/
+theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep [IsSepClosed K]
+    (hline : P.line = ⊥) :
+    IsEmpty ((spinPlusSubrep P hline).toRepresentation.Equiv
+      (spinMinusSubrep P hline).toRepresentation) :=
+  isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_isSquare P
+    (fun v w _ _ ↦ IsSepClosed.exists_eq_mul_self ((Q v)⁻¹ * (Q w)⁻¹)) hline
 
 end SpinGroup
 

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -147,31 +147,24 @@ private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
     (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
       (CliffordAlgebra.even Q).toSubmodule) :
     Function.Surjective (spinGroupAlgebraHom (K := K) (Q := Q)) := by
-  intro x
-  have hx : (x : CliffordAlgebra Q) ∈
-      Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
-    rw [hspan]
-    exact x.2
-  obtain ⟨a, ha⟩ := (Finsupp.mem_span_iff_linearCombination K
-    (spinGroup Q : Set (CliffordAlgebra Q)) x).1 hx
-  refine ⟨(MonoidAlgebra.coeffLinearEquiv K).symm a, Subtype.ext ?_⟩
-  rw [spinGroupAlgebraHom, MonoidAlgebra.lift_apply]
-  have hcoeff : ((MonoidAlgebra.coeffLinearEquiv K).symm a).coeff = a :=
-    (MonoidAlgebra.coeffLinearEquiv K).apply_symm_apply a
-  rw [hcoeff]
-  -- `lift_apply` leaves the finite sum in the even subtype. Expose the subtype map so
-  -- `map_sum` can compare it with the ambient Clifford-algebra linear combination.
-  change (CliffordAlgebra.even Q).subtype (a.sum fun g r => r • spinGroupToEven g) =
-    (x : CliffordAlgebra Q)
-  rw [Finsupp.sum, map_sum]
-  rw [Finsupp.linearCombination_apply, Finsupp.sum] at ha
-  calc
-    ∑ g ∈ a.support, (CliffordAlgebra.even Q).subtype (a g • spinGroupToEven g) =
-        ∑ g ∈ a.support, a g • (g : CliffordAlgebra Q) := by
-      apply Finset.sum_congr rfl
-      intro g _
-      rfl
-    _ = (x : CliffordAlgebra Q) := ha
+  -- Expose the algebra homomorphism's underlying linear map so its range can be calculated.
+  change Function.Surjective (spinGroupAlgebraHom (K := K) (Q := Q)).toLinearMap
+  rw [← LinearMap.range_eq_top]
+  rw [show (spinGroupAlgebraHom (K := K) (Q := Q)).toLinearMap =
+      (Finsupp.linearCombination K spinGroupToEven).comp
+        (MonoidAlgebra.coeffLinearEquiv K).toLinearMap by
+    ext g
+    simp [spinGroupAlgebraHom, spinGroupToEven]]
+  rw [LinearMap.range_comp_of_range_eq_top _ (LinearEquiv.range _),
+    Finsupp.range_linearCombination]
+  apply (Submodule.span_range_subtype_eq_top_iff
+    (CliffordAlgebra.even Q).toSubmodule
+      (fun g : spinGroup Q ↦ spinGroup.mem_even g.2)).2
+  -- Return to the ambient Clifford algebra, where `hspan` states the spanning result.
+  change Submodule.span K
+    (Set.range (Subtype.val : spinGroup Q → CliffordAlgebra Q)) = _
+  rw [Subtype.range_val]
+  exact hspan
 
 private theorem asAlgebraHom_spinGroupRepresentation {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -46,8 +46,9 @@ The invariant-subspace conclusions for the even Clifford algebra are stated in l
 "an invariant subspace is `⊥` or everything", rather than as `IsSimpleModule`: `S⁺` and `S⁻`
 carry no `Module (even Q)` instance, and manufacturing one would mean a type synonym for a
 statement that reads no better through it. Over a separably closed field, the Spin group linearly
-spans the even Clifford algebra. The same dichotomies therefore prove that the two half-spin
-subrepresentations carry irreducible and inequivalent group representations.
+spans the even Clifford algebra when the quadratic form is nondegenerate and the characteristic
+is not two. The same dichotomies therefore prove that the even half-spin subrepresentation is
+irreducible, that the odd half is irreducible when `P.W ≠ ⊥`, and that the two are inequivalent.
 
 The actions themselves — `TauCeti.spinPlusAction`, `TauCeti.spinMinusAction` and their pair
 `TauCeti.evenSpinActionProd` — are defined in
@@ -82,10 +83,8 @@ central summands, for which the results here are the even-dimensional half.
   way intertwining the two actions, and hence
   `TauCeti.not_exists_equiv_intertwines_spinPlusAction_spinMinusAction`: **the half-spin summands
   are inequivalent.**
-* `CliffordAlgebra.span_spinGroup_eq_even`: **the Spin group linearly spans the even Clifford
-  algebra** over a separably closed field.
 * `TauCeti.isIrreducible_spinPlusSubrep` and `TauCeti.isIrreducible_spinMinusSubrep`: **the two
-  half-spin group representations are irreducible.**
+  half-spin group representations are irreducible**, with `P.W ≠ ⊥` required for the odd half.
 * `TauCeti.isEmpty_equiv_spinPlusSubrep_spinMinusSubrep`: **the two half-spin group
   representations are inequivalent.**
 
@@ -125,9 +124,7 @@ private theorem eq_bot_or_eq_top_of_surjective_action {K : Type u} [Field K]
 private def spinGroupToEven {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} :
     spinGroup Q →* CliffordAlgebra.even Q :=
-    { toFun := fun g => ⟨g, spinGroup.mem_even g.2⟩
-      map_one' := rfl
-      map_mul' := fun _ _ => rfl }
+  Submonoid.inclusion fun _ hx => spinGroup.mem_even hx
 
 private def spinGroupRepresentation {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
@@ -140,13 +137,6 @@ private noncomputable def spinGroupAlgebraHom {K : Type u} [Field K]
     MonoidAlgebra K (spinGroup Q) →ₐ[K] CliffordAlgebra.even Q :=
   MonoidAlgebra.lift K (CliffordAlgebra.even Q) (spinGroup Q) spinGroupToEven
 
-private theorem spinGroupAlgebraHom_of {K : Type u} [Field K]
-    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
-    (g : spinGroup Q) :
-    spinGroupAlgebraHom (K := K) (Q := Q) (MonoidAlgebra.of K (spinGroup Q) g) =
-      spinGroupToEven g := by
-  exact MonoidAlgebra.lift_of spinGroupToEven g
-
 private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
     [IsSepClosed K] {V : Type v} [AddCommGroup V] [Module K V]
     {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate) :
@@ -156,31 +146,26 @@ private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
       Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
     rw [CliffordAlgebra.span_spinGroup_eq_even Q hQ]
     exact x.2
-  have hpre : ∀ z : CliffordAlgebra Q,
-      z ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) →
-        ∃ a : MonoidAlgebra K (spinGroup Q),
-          ((spinGroupAlgebraHom (K := K) (Q := Q) a : CliffordAlgebra.even Q) :
-            CliffordAlgebra Q) = z := by
-    intro z hz
-    induction hz using Submodule.span_induction with
-    | mem z hz =>
-        refine ⟨MonoidAlgebra.of K (spinGroup Q) ⟨z, hz⟩, ?_⟩
-        rw [spinGroupAlgebraHom_of]
-        rfl
-    | zero => exact ⟨0, by simp only [map_zero, Subalgebra.coe_zero]⟩
-    | add y z _ _ hy hz =>
-        obtain ⟨a, ha⟩ := hy
-        obtain ⟨b, hb⟩ := hz
-        exact ⟨a + b, by
-          simpa only [map_add, Subalgebra.coe_add] using
-            congrArg₂ (fun y z : CliffordAlgebra Q => y + z) ha hb⟩
-    | smul r z _ hz =>
-        obtain ⟨a, ha⟩ := hz
-        exact ⟨r • a, by
-          simpa only [map_smul, Subalgebra.coe_smul] using
-            congrArg (fun z : CliffordAlgebra Q => r • z) ha⟩
-  obtain ⟨a, ha⟩ := hpre x hx
-  exact ⟨a, Subtype.ext ha⟩
+  obtain ⟨a, ha⟩ := (Finsupp.mem_span_iff_linearCombination K
+    (spinGroup Q : Set (CliffordAlgebra Q)) x).1 hx
+  refine ⟨(MonoidAlgebra.coeffLinearEquiv K).symm a, Subtype.ext ?_⟩
+  rw [spinGroupAlgebraHom, MonoidAlgebra.lift_apply]
+  have hcoeff : ((MonoidAlgebra.coeffLinearEquiv K).symm a).coeff = a :=
+    (MonoidAlgebra.coeffLinearEquiv K).apply_symm_apply a
+  rw [hcoeff]
+  -- `lift_apply` leaves the finite sum in the even subtype. Expose the subtype map so
+  -- `map_sum` can compare it with the ambient Clifford-algebra linear combination.
+  change (CliffordAlgebra.even Q).subtype (a.sum fun g r => r • spinGroupToEven g) =
+    (x : CliffordAlgebra Q)
+  rw [Finsupp.sum, map_sum]
+  rw [Finsupp.linearCombination_apply, Finsupp.sum] at ha
+  calc
+    ∑ g ∈ a.support, (CliffordAlgebra.even Q).subtype (a g • spinGroupToEven g) =
+        ∑ g ∈ a.support, a g • (g : CliffordAlgebra Q) := by
+      apply Finset.sum_congr rfl
+      intro g _
+      rfl
+    _ = (x : CliffordAlgebra Q) := ha
 
 private theorem asAlgebraHom_spinGroupRepresentation {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
@@ -188,14 +173,10 @@ private theorem asAlgebraHom_spinGroupRepresentation {K : Type u} [Field K]
     (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M) :
     (spinGroupRepresentation F).asAlgebraHom =
       F.comp (spinGroupAlgebraHom (K := K) (Q := Q)) := by
-  refine AlgHom.ext fun a => ?_
-  induction a using MonoidAlgebra.induction_on with
-  | of g =>
-      rw [Representation.asAlgebraHom_of, AlgHom.comp_apply]
-      rw [spinGroupAlgebraHom_of]
-      rfl
-  | add x y hx hy => rw [map_add, map_add, hx, hy]
-  | smul r x hx => rw [map_smul, map_smul, hx]
+  apply MonoidAlgebra.algHom_ext
+  · intro g
+    simp [spinGroupRepresentation, spinGroupAlgebraHom]
+  · ext
 
 private theorem isIrreducible_spinGroupRepresentation {K : Type u} [Field K]
     [IsSepClosed K] {V : Type v} [AddCommGroup V] [Module K V]
@@ -217,14 +198,15 @@ private theorem intertwines_even_of_intertwines_spinGroup {K : Type u} [Field K]
       φ (F ⟨g, spinGroup.mem_even g.2⟩ m) = G ⟨g, spinGroup.mem_even g.2⟩ (φ m))
     (x : CliffordAlgebra.even Q) (m : M) : φ (F x m) = G x (φ m) := by
   obtain ⟨a, rfl⟩ := spinGroupAlgebraHom_surjective hQ x
-  induction a using MonoidAlgebra.induction_on with
-  | of g =>
-      rw [spinGroupAlgebraHom_of]
-      convert hφ g m using 1 <;> rfl
-  | add y z hy hz =>
-      simp only [map_add, LinearMap.add_apply, φ.map_add, hy, hz]
-  | smul r z hz =>
-      simp only [map_smul, LinearMap.smul_apply, φ.map_smul, hz]
+  let φ' : (spinGroupRepresentation F).IntertwiningMap (spinGroupRepresentation G) :=
+    ⟨φ, fun g => LinearMap.ext fun m => hφ g m⟩
+  have h := (Representation.IntertwiningMap.equivLinearMapAsModule
+    (spinGroupRepresentation F) (spinGroupRepresentation G) φ').map_smul' a m
+  -- The module equivalence is definitionally the identity on carriers. Expose the algebra
+  -- actions so the two `asAlgebraHom_spinGroupRepresentation` rewrites can be applied.
+  change φ ((spinGroupRepresentation F).asAlgebraHom a m) =
+    (spinGroupRepresentation G).asAlgebraHom a (φ m) at h
+  simpa only [asAlgebraHom_spinGroupRepresentation, AlgHom.comp_apply] using h
 
 /-! ### The spinor module is a simple Clifford module
 
@@ -340,11 +322,11 @@ variable {K : Type u} [Field K] [IsSepClosed K]
   {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
   [Invertible (2 : K)] [FiniteDimensional K V] (P : SpinPolarizationData Q)
 
-/-- **The even half-spin representation of the Spin group is irreducible.** The Spin group spans
-the even Clifford algebra, whose action on the even half-spin summand is the full endomorphism
-algebra. -/
-theorem isIrreducible_spinPlusSubrep (hQ : Q.Nondegenerate) (hline : P.line = ⊥) :
+/-- **The even half-spin representation of the Spin group is irreducible** for polarization data
+without a line remainder. -/
+theorem isIrreducible_spinPlusSubrep (hline : P.line = ⊥) :
     (spinPlusSubrep P hline).toRepresentation.IsIrreducible := by
+  have hQ := P.nondegenerate_of_line_eq_bot hline
   let _ : Nontrivial (spinPlus Q P) := nontrivial_spinPlus P
   have hρ : (spinGroupRepresentation (spinPlusAction Q P hline)).IsIrreducible :=
     isIrreducible_spinGroupRepresentation hQ (spinPlusAction Q P hline)
@@ -358,8 +340,9 @@ theorem isIrreducible_spinPlusSubrep (hQ : Q.Nondegenerate) (hline : P.line = �
 
 /-- **The odd half-spin representation of the Spin group is irreducible** when the odd summand is
 nonzero. -/
-theorem isIrreducible_spinMinusSubrep (hQ : Q.Nondegenerate) (hline : P.line = ⊥)
+theorem isIrreducible_spinMinusSubrep (hline : P.line = ⊥)
     (hW : P.W ≠ ⊥) : (spinMinusSubrep P hline).toRepresentation.IsIrreducible := by
+  have hQ := P.nondegenerate_of_line_eq_bot hline
   let _ : Nontrivial (spinMinus Q P) := nontrivial_spinMinus P hW
   have hρ : (spinGroupRepresentation (spinMinusAction Q P hline)).IsIrreducible :=
     isIrreducible_spinGroupRepresentation hQ (spinMinusAction Q P hline)
@@ -373,9 +356,10 @@ theorem isIrreducible_spinMinusSubrep (hQ : Q.Nondegenerate) (hline : P.line = �
 
 /-- **The two half-spin representations of the Spin group are inequivalent.** -/
 theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep
-    (hQ : Q.Nondegenerate) (hline : P.line = ⊥) :
+    (hline : P.line = ⊥) :
     IsEmpty ((spinPlusSubrep P hline).toRepresentation.Equiv
       (spinMinusSubrep P hline).toRepresentation) := by
+  have hQ := P.nondegenerate_of_line_eq_bot hline
   refine ⟨fun e => ?_⟩
   let ePlus : spinPlus Q P ≃ₗ[K] (spinPlusSubrep P hline).toSubmodule :=
     LinearEquiv.ofEq _ _ (toSubmodule_spinPlusSubrep P hline).symm

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -6,8 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.Spin.Structure
+public import TauCeti.RepresentationTheory.Irreducible
 -- Private: `IsSimpleModule.toSpanSingleton_surjective` is used only inside proofs.
 import Mathlib.RingTheory.SimpleModule.Basic
+-- Private: the span theorem is used only to pass from group invariance to even-Clifford invariance.
+import TauCeti.LinearAlgebra.CliffordAlgebra.ReflectionLift
 
 /-!
 # Invariant subspaces and intertwiners for the spinor and half-spin actions
@@ -39,9 +42,12 @@ subspace because its factor is a full endomorphism algebra, and the two even-Cli
 element of `even Q` acting as the identity on `S⁺` and as zero on `S⁻` kills any map that
 intertwines them.
 
-The invariant-subspace conclusions are stated in lattice form, as "an invariant subspace is `⊥`
-or everything", rather than as `IsSimpleModule`: `S⁺` and `S⁻` carry no `Module (even Q)` instance,
-and manufacturing one would mean a type synonym for a statement that reads no better through it.
+The invariant-subspace conclusions for the even Clifford algebra are stated in lattice form, as
+"an invariant subspace is `⊥` or everything", rather than as `IsSimpleModule`: `S⁺` and `S⁻`
+carry no `Module (even Q)` instance, and manufacturing one would mean a type synonym for a
+statement that reads no better through it. Over a separably closed field, the Spin group linearly
+spans the even Clifford algebra. The same dichotomies therefore prove that the two half-spin
+subrepresentations carry irreducible and inequivalent group representations.
 
 The actions themselves — `TauCeti.spinPlusAction`, `TauCeti.spinMinusAction` and their pair
 `TauCeti.evenSpinActionProd` — are defined in
@@ -58,10 +64,8 @@ theorem is stated with, so no separate parity hypothesis is carried. The lattice
 only the zero-dimensional quadratic space: there `S = K` is entirely even and `S⁻` is zero. `S⁺`
 always contains the scalars, so it needs no such hypothesis, and neither does the inequivalence.
 
-What is *not* proved here is irreducibility of the group representation `TauCeti.spinRep`, which
-asks more: that the `K`-span of `spinGroup Q` inside `even Q` is all of it. Nor is the
-odd-dimensional splitting of `CliffordAlgebra Q` into its two central summands, for which the
-results here are the even-dimensional half.
+What is not proved here is the odd-dimensional splitting of `CliffordAlgebra Q` into its two
+central summands, for which the results here are the even-dimensional half.
 
 ## Main results
 
@@ -78,6 +82,12 @@ results here are the even-dimensional half.
   way intertwining the two actions, and hence
   `TauCeti.not_exists_equiv_intertwines_spinPlusAction_spinMinusAction`: **the half-spin summands
   are inequivalent.**
+* `CliffordAlgebra.span_spinGroup_eq_even`: **the Spin group linearly spans the even Clifford
+  algebra** over a separably closed field.
+* `TauCeti.isIrreducible_spinPlusSubrep` and `TauCeti.isIrreducible_spinMinusSubrep`: **the two
+  half-spin group representations are irreducible.**
+* `TauCeti.isEmpty_equiv_spinPlusSubrep_spinMinusSubrep`: **the two half-spin group
+  representations are inequivalent.**
 
 ## References
 
@@ -87,7 +97,7 @@ results here are the even-dimensional half.
   the two half-spin modules are irreducible and inequivalent.
 * C. Chevalley, *The Algebraic Theory of Spinors* (1954), Chapter II.
 * [Spin-representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
-  Layer 1, "The even-dimensional case".
+  Layers 1 and 4, "the structure theorem" and "the spin and half-spin representations".
 -/
 
 public section
@@ -111,6 +121,110 @@ private theorem eq_bot_or_eq_top_of_surjective_action {K : Type u} [Field K]
   rw [LinearMap.toSpanSingleton_apply, Module.End.smul_def] at hg
   obtain ⟨a, rfl⟩ := hF g
   exact hg ▸ hN a ⟨s, hs, rfl⟩
+
+private def spinGroupToEven {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} :
+    spinGroup Q →* CliffordAlgebra.even Q :=
+    { toFun := fun g => ⟨g, spinGroup.mem_even g.2⟩
+      map_one' := rfl
+      map_mul' := fun _ _ => rfl }
+
+private def spinGroupRepresentation {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+    {M : Type*} [AddCommGroup M] [Module K M]
+    (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M) : Representation K (spinGroup Q) M :=
+  F.toMonoidHom.comp spinGroupToEven
+
+private noncomputable def spinGroupAlgebraHom {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} :
+    MonoidAlgebra K (spinGroup Q) →ₐ[K] CliffordAlgebra.even Q :=
+  MonoidAlgebra.lift K (CliffordAlgebra.even Q) (spinGroup Q) spinGroupToEven
+
+private theorem spinGroupAlgebraHom_of {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+    (g : spinGroup Q) :
+    spinGroupAlgebraHom (K := K) (Q := Q) (MonoidAlgebra.of K (spinGroup Q) g) =
+      spinGroupToEven g := by
+  exact MonoidAlgebra.lift_of spinGroupToEven g
+
+private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
+    [IsSepClosed K] {V : Type v} [AddCommGroup V] [Module K V]
+    {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate) :
+    Function.Surjective (spinGroupAlgebraHom (K := K) (Q := Q)) := by
+  intro x
+  have hx : (x : CliffordAlgebra Q) ∈
+      Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) := by
+    rw [CliffordAlgebra.span_spinGroup_eq_even Q hQ]
+    exact x.2
+  have hpre : ∀ z : CliffordAlgebra Q,
+      z ∈ Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) →
+        ∃ a : MonoidAlgebra K (spinGroup Q),
+          ((spinGroupAlgebraHom (K := K) (Q := Q) a : CliffordAlgebra.even Q) :
+            CliffordAlgebra Q) = z := by
+    intro z hz
+    induction hz using Submodule.span_induction with
+    | mem z hz =>
+        refine ⟨MonoidAlgebra.of K (spinGroup Q) ⟨z, hz⟩, ?_⟩
+        rw [spinGroupAlgebraHom_of]
+        rfl
+    | zero => exact ⟨0, by simp only [map_zero, Subalgebra.coe_zero]⟩
+    | add y z _ _ hy hz =>
+        obtain ⟨a, ha⟩ := hy
+        obtain ⟨b, hb⟩ := hz
+        exact ⟨a + b, by
+          simpa only [map_add, Subalgebra.coe_add] using
+            congrArg₂ (fun y z : CliffordAlgebra Q => y + z) ha hb⟩
+    | smul r z _ hz =>
+        obtain ⟨a, ha⟩ := hz
+        exact ⟨r • a, by
+          simpa only [map_smul, Subalgebra.coe_smul] using
+            congrArg (fun z : CliffordAlgebra Q => r • z) ha⟩
+  obtain ⟨a, ha⟩ := hpre x hx
+  exact ⟨a, Subtype.ext ha⟩
+
+private theorem asAlgebraHom_spinGroupRepresentation {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+    {M : Type*} [AddCommGroup M] [Module K M]
+    (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M) :
+    (spinGroupRepresentation F).asAlgebraHom =
+      F.comp (spinGroupAlgebraHom (K := K) (Q := Q)) := by
+  refine AlgHom.ext fun a => ?_
+  induction a using MonoidAlgebra.induction_on with
+  | of g =>
+      rw [Representation.asAlgebraHom_of, AlgHom.comp_apply]
+      rw [spinGroupAlgebraHom_of]
+      rfl
+  | add x y hx hy => rw [map_add, map_add, hx, hy]
+  | smul r x hx => rw [map_smul, map_smul, hx]
+
+private theorem isIrreducible_spinGroupRepresentation {K : Type u} [Field K]
+    [IsSepClosed K] {V : Type v} [AddCommGroup V] [Module K V]
+    {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate)
+    {M : Type*} [AddCommGroup M] [Module K M] [Nontrivial M]
+    (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M)
+    (hF : Function.Surjective F) : (spinGroupRepresentation F).IsIrreducible := by
+  apply Representation.isIrreducible_of_asAlgebraHom_surjective
+  rw [asAlgebraHom_spinGroupRepresentation]
+  exact hF.comp (spinGroupAlgebraHom_surjective hQ)
+
+private theorem intertwines_even_of_intertwines_spinGroup {K : Type u} [Field K]
+    [IsSepClosed K] {V : Type v} [AddCommGroup V] [Module K V]
+    {Q : QuadraticForm K V} [Invertible (2 : K)] (hQ : Q.Nondegenerate)
+    {M N : Type*} [AddCommGroup M] [Module K M] [AddCommGroup N] [Module K N]
+    (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M)
+    (G : CliffordAlgebra.even Q →ₐ[K] Module.End K N) (φ : M →ₗ[K] N)
+    (hφ : ∀ (g : spinGroup Q) (m : M),
+      φ (F ⟨g, spinGroup.mem_even g.2⟩ m) = G ⟨g, spinGroup.mem_even g.2⟩ (φ m))
+    (x : CliffordAlgebra.even Q) (m : M) : φ (F x m) = G x (φ m) := by
+  obtain ⟨a, rfl⟩ := spinGroupAlgebraHom_surjective hQ x
+  induction a using MonoidAlgebra.induction_on with
+  | of g =>
+      rw [spinGroupAlgebraHom_of]
+      convert hφ g m using 1 <;> rfl
+  | add y z hy hz =>
+      simp only [map_add, LinearMap.add_apply, φ.map_add, hy, hz]
+  | smul r z hz =>
+      simp only [map_smul, LinearMap.smul_apply, φ.map_smul, hz]
 
 /-! ### The spinor module is a simple Clifford module
 
@@ -217,5 +331,93 @@ theorem not_exists_equiv_intertwines_spinPlusAction_spinMinusAction (hline : P.l
   exact hs (e.injective (hes.trans (map_zero e).symm))
 
 end Even
+
+/-! ### Irreducibility of the half-spin group representations -/
+
+section SpinGroup
+
+variable {K : Type u} [Field K] [IsSepClosed K]
+  {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+  [Invertible (2 : K)] [FiniteDimensional K V] (P : SpinPolarizationData Q)
+
+/-- **The even half-spin representation of the Spin group is irreducible.** The Spin group spans
+the even Clifford algebra, whose action on the even half-spin summand is the full endomorphism
+algebra. -/
+theorem isIrreducible_spinPlusSubrep (hQ : Q.Nondegenerate) (hline : P.line = ⊥) :
+    (spinPlusSubrep P hline).toRepresentation.IsIrreducible := by
+  let _ : Nontrivial (spinPlus Q P) := nontrivial_spinPlus P
+  have hρ : (spinGroupRepresentation (spinPlusAction Q P hline)).IsIrreducible :=
+    isIrreducible_spinGroupRepresentation hQ (spinPlusAction Q P hline)
+      (spinPlusAction_surjective P hline)
+  let e : spinPlus Q P ≃ₗ[K] (spinPlusSubrep P hline).toSubmodule :=
+    LinearEquiv.ofEq _ _ (toSubmodule_spinPlusSubrep P hline).symm
+  refine Representation.isIrreducible_of_linearEquiv e ?_ hρ
+  intro g s
+  apply Subtype.ext
+  exact coe_spinPlusAction_spinGroup_apply P hline g s
+
+/-- **The odd half-spin representation of the Spin group is irreducible** when the odd summand is
+nonzero. -/
+theorem isIrreducible_spinMinusSubrep (hQ : Q.Nondegenerate) (hline : P.line = ⊥)
+    (hW : P.W ≠ ⊥) : (spinMinusSubrep P hline).toRepresentation.IsIrreducible := by
+  let _ : Nontrivial (spinMinus Q P) := nontrivial_spinMinus P hW
+  have hρ : (spinGroupRepresentation (spinMinusAction Q P hline)).IsIrreducible :=
+    isIrreducible_spinGroupRepresentation hQ (spinMinusAction Q P hline)
+      (spinMinusAction_surjective P hline)
+  let e : spinMinus Q P ≃ₗ[K] (spinMinusSubrep P hline).toSubmodule :=
+    LinearEquiv.ofEq _ _ (toSubmodule_spinMinusSubrep P hline).symm
+  refine Representation.isIrreducible_of_linearEquiv e ?_ hρ
+  intro g s
+  apply Subtype.ext
+  exact coe_spinMinusAction_spinGroup_apply P hline g s
+
+/-- **The two half-spin representations of the Spin group are inequivalent.** -/
+theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep
+    (hQ : Q.Nondegenerate) (hline : P.line = ⊥) :
+    IsEmpty ((spinPlusSubrep P hline).toRepresentation.Equiv
+      (spinMinusSubrep P hline).toRepresentation) := by
+  refine ⟨fun e => ?_⟩
+  let ePlus : spinPlus Q P ≃ₗ[K] (spinPlusSubrep P hline).toSubmodule :=
+    LinearEquiv.ofEq _ _ (toSubmodule_spinPlusSubrep P hline).symm
+  let eMinus : spinMinus Q P ≃ₗ[K] (spinMinusSubrep P hline).toSubmodule :=
+    LinearEquiv.ofEq _ _ (toSubmodule_spinMinusSubrep P hline).symm
+  let f : spinPlus Q P ≃ₗ[K] spinMinus Q P :=
+    ePlus.trans (e.toLinearEquiv.trans eMinus.symm)
+  apply not_exists_equiv_intertwines_spinPlusAction_spinMinusAction P hline
+  refine ⟨f, fun x s => intertwines_even_of_intertwines_spinGroup hQ
+    (spinPlusAction Q P hline) (spinMinusAction Q P hline) f.toLinearMap ?_ x s⟩
+  intro g s
+  have hPlus : ePlus ((spinGroupRepresentation (spinPlusAction Q P hline)) g s) =
+      (spinPlusSubrep P hline).toRepresentation g (ePlus s) := by
+    apply Subtype.ext
+    exact coe_spinPlusAction_spinGroup_apply P hline g s
+  have hMinus (t : spinMinus Q P) :
+      eMinus ((spinGroupRepresentation (spinMinusAction Q P hline)) g t) =
+        (spinMinusSubrep P hline).toRepresentation g (eMinus t) := by
+    apply Subtype.ext
+    exact coe_spinMinusAction_spinGroup_apply P hline g t
+  have hef (t : spinPlus Q P) : e.toIntertwiningMap (ePlus t) = eMinus (f t) := by
+    rw [← e.toLinearEquiv_apply]
+    simp only [f, LinearEquiv.trans_apply, LinearEquiv.apply_symm_apply]
+  apply eMinus.injective
+  calc
+    eMinus (f ((spinGroupRepresentation (spinPlusAction Q P hline)) g s)) =
+        e.toIntertwiningMap
+          (ePlus ((spinGroupRepresentation (spinPlusAction Q P hline)) g s)) :=
+      (hef _).symm
+    _ = e.toIntertwiningMap
+        ((spinPlusSubrep P hline).toRepresentation g (ePlus s)) :=
+      congrArg e.toIntertwiningMap hPlus
+    _ = (spinMinusSubrep P hline).toRepresentation g
+        (e.toIntertwiningMap (ePlus s)) :=
+      Representation.IntertwiningMap.isIntertwining
+        (spinPlusSubrep P hline).toRepresentation
+        (spinMinusSubrep P hline).toRepresentation e.toIntertwiningMap g (ePlus s)
+    _ = (spinMinusSubrep P hline).toRepresentation g (eMinus (f s)) :=
+      congrArg ((spinMinusSubrep P hline).toRepresentation g) (hef s)
+    _ = eMinus ((spinGroupRepresentation (spinMinusAction Q P hline)) g (f s)) :=
+      (hMinus (f s)).symm
+
+end SpinGroup
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -140,40 +140,44 @@ theorem pairing_separatingRight {K : Type u} [CommRing K] {V : Type v}
 
 /-- A polarization without an orthogonal remainder has nondegenerate quadratic form. -/
 theorem nondegenerate_of_line_eq_bot {K : Type u} [CommRing K] {V : Type v}
-    [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} [Invertible (2 : K)]
+    [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
     (P : SpinPolarizationData Q) (hline : P.line = ⊥) : Q.Nondegenerate := by
-  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot,
-    QuadraticMap.radical_eq_ker_polarBilin, LinearMap.ker_eq_bot']
-  intro v hv
-  let x := (P.decompositionEquiv.symm v).1.1
-  let y := (P.decompositionEquiv.symm v).1.2
-  let z := (P.decompositionEquiv.symm v).2
-  have hz : z = 0 := by
-    apply Subtype.ext
-    simpa [hline] using z.property
-  have hdecomp : (x : V) + (y : V) + (z : V) = v := by
-    rw [← P.decompositionEquiv_apply]
-    exact P.decompositionEquiv.apply_symm_apply v
-  have hWW (a b : P.W) : QuadraticMap.polar Q (a : V) b = 0 := by
-    simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W, sub_self]
-  have hW'W' (a b : P.W') : QuadraticMap.polar Q (a : V) b = 0 := by
-    simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W', sub_self]
-  have hx : x = 0 := by
-    apply P.pairing_separatingLeft
-    intro b
-    have h := LinearMap.congr_fun hv (b : V)
-    simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
-      QuadraticMap.polar_add_left, hW'W', P.line_orthogonal_W', LinearMap.zero_apply,
-      add_zero] using h
-  have hy : y = 0 := by
-    apply P.pairing_separatingRight
-    intro a
-    have h := LinearMap.congr_fun hv (a : V)
-    simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
-      QuadraticMap.polar_add_left, hWW, P.line_orthogonal_W, LinearMap.zero_apply,
-      add_zero, zero_add, QuadraticMap.polar_comm Q y a] using h
-  rw [← hdecomp, hx, hy, hz]
-  simp
+  have hker : Q.polarBilin.ker = ⊥ := by
+    rw [LinearMap.ker_eq_bot']
+    intro v hv
+    let x := (P.decompositionEquiv.symm v).1.1
+    let y := (P.decompositionEquiv.symm v).1.2
+    let z := (P.decompositionEquiv.symm v).2
+    have hz : z = 0 := by
+      apply Subtype.ext
+      simpa [hline] using z.property
+    have hdecomp : (x : V) + (y : V) + (z : V) = v := by
+      rw [← P.decompositionEquiv_apply]
+      exact P.decompositionEquiv.apply_symm_apply v
+    have hWW (a b : P.W) : QuadraticMap.polar Q (a : V) b = 0 := by
+      simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W, sub_self]
+    have hW'W' (a b : P.W') : QuadraticMap.polar Q (a : V) b = 0 := by
+      simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W', sub_self]
+    have hx : x = 0 := by
+      apply P.pairing_separatingLeft
+      intro b
+      have h := LinearMap.congr_fun hv (b : V)
+      simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
+        QuadraticMap.polar_add_left, hW'W', P.line_orthogonal_W', LinearMap.zero_apply,
+        add_zero] using h
+    have hy : y = 0 := by
+      apply P.pairing_separatingRight
+      intro a
+      have h := LinearMap.congr_fun hv (a : V)
+      simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
+        QuadraticMap.polar_add_left, hWW, P.line_orthogonal_W, LinearMap.zero_apply,
+        add_zero, zero_add, QuadraticMap.polar_comm Q y a] using h
+    rw [← hdecomp, hx, hy, hz]
+    simp
+  refine ⟨le_antisymm (Q.radical_le_ker_polarBilin.trans hker.le) bot_le, ?_⟩
+  rw [hker]
+  nontriviality K
+  simp only [rank_subsingleton', zero_le]
 
 section Dimension
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.QuadraticForm.Basic
+public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 
 -- Private: `Subspace.dual_finrank_eq`, `Module.finrank_prod` and
 -- `LinearMap.finrank_le_finrank_of_injective` occur only inside the proofs of the dimension
@@ -137,6 +137,43 @@ theorem pairing_separatingRight {K : Type u} [CommRing K] {V : Type v}
   apply P.pairingEquiv.injective
   ext x
   simp only [P.pairingEquiv_apply, hy x, map_zero, LinearMap.zero_apply]
+
+/-- A polarization without an orthogonal remainder has nondegenerate quadratic form. -/
+theorem nondegenerate_of_line_eq_bot {K : Type u} [CommRing K] {V : Type v}
+    [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} [Invertible (2 : K)]
+    (P : SpinPolarizationData Q) (hline : P.line = ⊥) : Q.Nondegenerate := by
+  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot,
+    QuadraticMap.radical_eq_ker_polarBilin, LinearMap.ker_eq_bot']
+  intro v hv
+  let x := (P.decompositionEquiv.symm v).1.1
+  let y := (P.decompositionEquiv.symm v).1.2
+  let z := (P.decompositionEquiv.symm v).2
+  have hz : z = 0 := by
+    apply Subtype.ext
+    simpa [hline] using z.property
+  have hdecomp : (x : V) + (y : V) + (z : V) = v := by
+    rw [← P.decompositionEquiv_apply]
+    exact P.decompositionEquiv.apply_symm_apply v
+  have hWW (a b : P.W) : QuadraticMap.polar Q (a : V) b = 0 := by
+    simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W, sub_self]
+  have hW'W' (a b : P.W') : QuadraticMap.polar Q (a : V) b = 0 := by
+    simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W', sub_self]
+  have hx : x = 0 := by
+    apply P.pairing_separatingLeft
+    intro b
+    have h := LinearMap.congr_fun hv (b : V)
+    simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
+      QuadraticMap.polar_add_left, hW'W', P.line_orthogonal_W', LinearMap.zero_apply,
+      add_zero] using h
+  have hy : y = 0 := by
+    apply P.pairing_separatingRight
+    intro a
+    have h := LinearMap.congr_fun hv (a : V)
+    simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
+      QuadraticMap.polar_add_left, hWW, P.line_orthogonal_W, LinearMap.zero_apply,
+      add_zero, zero_add, QuadraticMap.polar_comm Q y a] using h
+  rw [← hdecomp, hx, hy, hz]
+  simp
 
 section Dimension
 


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Proves group-level irreducibility and inequivalence of the half-spin representations.

- Shows that the Spin group spans the even Clifford algebra.
- Derives irreducibility of both half-spin subrepresentations.
- States their inequivalence through representation equivalences.

## Roadmap target

Advances [Layer 4 irreducibility](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-4-the-spin-and-half-spin-representations).

## Verification

Full gates, focused consumer probes, exact API checks, style checks, structural golf, and a fresh full-aggregate 2+1 review pass at `3e3368fee6e85a20f2ef369ac43c6d480031ff30`.

## Scale and generality

Changes three files by +459/−12. The characteristic-free core accepts an exact anisotropic-span equality plus pairwise square normalization; the three group-level endpoints accept the exact Spin-span equality. The nondegenerate characteristic-not-two and separably closed statements remain corollaries, and the finite-dimensional half-spin assumptions are unchanged.

## Scope

- **Consumes:** reflection lifts and half-spin action surjectivity.
- **Provides:** Spin span, half-spin irreducibility, and inequivalence.
- **Fits:** completes the even-dimensional Layer 4 simplicity boundary.
- **Boundary:** odd-dimensional irreducibility and highest weights remain downstream.
