### PR TITLE
refactor(DenseGraphLimits): replace two hand-built bridges with Sym2.forall and simp_rw

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/FiniteGraph/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/FiniteGraph/Basic.lean
@@ -189,15 +189,8 @@ theorem homDensity_finiteGraphGraphon (F : SimpleGraph V) [DecidableRel F.Adj] (
     have hp_iff : (∀ e ∈ F.edgeFinset, p e) ↔
         ∀ a b, F.Adj a b →
           (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b)) := by
-      constructor
-      · intro h a b hab
-        simpa only [p, Sym2.lift_mk] using h s(a, b) (by
-          simpa only [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet] using hab)
-      · intro h e he
-        induction e using Sym2.ind with
-        | _ a b =>
-          simpa only [p, Sym2.lift_mk] using h a b (by
-            simpa only [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet] using he)
+      simp only [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet, Sym2.forall, p,
+        Sym2.lift_mk]
     rw [Finset.prod_congr rfl fun e _ => hfac e, Finset.prod_boole]
     by_cases h : ∀ a b, F.Adj a b →
         (G.map Fin.valEmbedding).Adj (cellIdx m (x a)) (cellIdx m (x b))
@@ -207,14 +200,8 @@ theorem homDensity_finiteGraphGraphon (F : SimpleGraph V) [DecidableRel F.Adj] (
   have hsum : (∑ ψ : V → Fin m, if ∀ a b, F.Adj a b →
         (G.map Fin.valEmbedding).Adj ((ψ a : ℕ)) ((ψ b : ℕ)) then (1 : ℝ) else 0)
       = (Nat.card (F →g G) : ℝ) := by
-    have hcongr : ∀ ψ : V → Fin m,
-        (if ∀ a b, F.Adj a b → (G.map Fin.valEmbedding).Adj ((ψ a : ℕ)) ((ψ b : ℕ))
-          then (1 : ℝ) else 0)
-          = if ∀ a b, F.Adj a b → G.Adj (ψ a) (ψ b) then 1 else 0 := fun ψ =>
-      if_congr (forall_congr' fun a => forall_congr' fun b =>
-        imp_congr_right fun _ => map_valEmbedding_adj_iff G (ψ a) (ψ b)) rfl rfl
-    rw [Finset.sum_congr rfl fun ψ _ => hcongr ψ, Finset.sum_boole,
-      card_hom_eq_card_adjPreservingMaps,
+    simp_rw [map_valEmbedding_adj_iff G]
+    rw [Finset.sum_boole, card_hom_eq_card_adjPreservingMaps,
       Nat.card_eq_fintype_card, Fintype.card_subtype]
   have hpi : (∫ x : V → I,
         (if ∀ a b, F.Adj a b →


### PR DESCRIPTION
`homDensity_finiteGraphGraphon` built two bridges by hand that the simp set already knows. Both are
now one call each. **No declaration is added or removed** — the file's declaration count is 9 before
and after, and it is 13 lines shorter (235 → 222).

The theorem drops from **59 lines to 46**, under the 50-line guidance.

## The two bridges

`hp_iff` restated "every edge satisfies `p`" as a condition on adjacent pairs, direction by
direction: a `constructor`, then two branches each pairing a `simpa only [p, Sym2.lift_mk]` with an
edge-set membership rewrite, the second going through `induction e using Sym2.ind`. That is what
`Sym2.forall` says, so the whole thing is

```lean
simp only [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet, Sym2.forall, p, Sym2.lift_mk]
```

`hsum` proved a pointwise equality of summands with an explicit `if_congr` over two
`forall_congr'` layers and an `imp_congr_right`, then fed it to `Finset.sum_congr`. `simp_rw`
traverses those binders itself, so citing the adjacency lemma rewrites under them directly:

```lean
simp_rw [map_valEmbedding_adj_iff G]
```

`Sym2.forall` adds no new import — it replaces this proof's use of `Sym2.ind` — and Mathlib uses it
for exactly this shape at `Combinatorics/SimpleGraph/Basic.lean:559`.

## Roadmap

`TauCetiRoadmap/DenseGraphLimits/README.md` names this theorem once, under **Suggested signatures**,
as the finite-graph compatibility `finiteGraphGraphon` + `homDensity_finiteGraphGraphon` (with
`0 < m`). **Worked examples (acceptance gates)** states the same acceptance gate again and identifies
`W_G` with `finiteGraphGraphon G`, without naming the theorem itself.

This PR is a proof refactor, so it makes no new roadmap claim; the attribution names the roadmap
chiefly motivating the file.

Roadmap: DenseGraphLimits
