### PR TITLE
feat(ModularForms): the character spaces under the cusp-form coercion

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -62,6 +62,13 @@ re-founded slash action with built-in character) and their names. The Hecke pair
 
 * Miyake, *Modular forms*, §4.5
 * Diamond–Shurman, *A first course in modular forms*, §5.1 and §5.3
+* `diamondOp_coe_cuspForm` and `coe_mem_modFormCharSpace_iff` adapt
+  [AINTLIB](https://github.com/CBirkbeck/AINTLIB) commit
+  `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck,
+  `LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean`, declarations
+  `cuspFormCharSpace_toModularForm'_mem` and `cuspFormCharSpace_of_toModularForm'_mem`. Those
+  are two one-way statements about AINTLIB's own `CuspForm.toModularForm'`; here they are one
+  `iff` through mathlib's coercion, which this repository uses instead.
 -/
 
 public section
@@ -438,8 +445,10 @@ theorem diamondOp_coe_cuspForm (k : ℤ) (d : (ZMod N)ˣ)
     (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
     diamondOp k d (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
       (diamondOpCusp k d f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
-  ext τ
-  rfl
+  obtain ⟨g, hg⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
+  refine DFunLike.coe_injective ?_
+  rw [coe_diamondOp k d g hg, ModularFormClass.coe_modularForm,
+    ModularFormClass.coe_modularForm, coe_diamondOpCusp k d g hg]
 
 /-- **A cusp form is a `χ`-form exactly when the modular form underlying it is.** Membership in
 either character space is the same family of diamond eigenvalue equations, and the coercion is

--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -54,6 +54,9 @@ re-founded slash action with built-in character) and their names. The Hecke pair
   suitable `Γ₀(N)` representative is the corresponding natural-indexed diamond operator;
   `slash_mapGL_gamma0Twist_eq_diamondOpNat` and its cusp counterpart specialize to the explicit
   Bézout representative.
+* `diamondOp_coe_cuspForm`, `coe_mem_modFormCharSpace_iff`: the diamond operators, and hence the
+  character spaces, commute with the coercion `S_k(Γ₁(N)) → M_k(Γ₁(N))`; a cusp form is a
+  `χ`-form exactly when the modular form underlying it is.
 
 ## References
 
@@ -425,3 +428,28 @@ theorem slash_mapGL_gamma0Twist_eq_diamondOpCuspNat {p : ℕ} (k : ℤ) (h : Nat
     ⇑f ∣[k] (mapGL ℚ (gamma0Twist N p h) : GL (Fin 2) ℚ) = ⇑(diamondOpCuspNat k p f) :=
   slash_mapGL_eq_diamondOpCuspNat k h ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩
     (Gamma0Map_toHomUnits_gamma0Twist h) f
+
+/-! ### The character spaces under the cusp-form coercion -/
+
+/-- The diamond operator commutes with the coercion `S_k(Γ) → M_k(Γ)`: `⟨d⟩` slashes by a
+representative of `d`, which does not see whether a form vanishes at the cusps. -/
+@[simp]
+theorem diamondOp_coe_cuspForm (k : ℤ) (d : (ZMod N)ˣ)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    diamondOp k d (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      (diamondOpCusp k d f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  ext τ
+  rfl
+
+/-- **A cusp form is a `χ`-form exactly when the modular form underlying it is.** Membership in
+either character space is the same family of diamond eigenvalue equations, and the coercion is
+pointwise, so the two conditions transport across it. -/
+theorem coe_mem_modFormCharSpace_iff (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) ∈ modFormCharSpace k χ ↔
+      f ∈ cuspFormCharSpace k χ := by
+  simp only [mem_modFormCharSpace_iff, mem_cuspFormCharSpace_iff, diamondOpHom_apply,
+    diamondOpCuspHom_apply, diamondOp_coe_cuspForm]
+  exact forall_congr' fun d ↦
+    ⟨fun h ↦ DFunLike.ext _ _ fun τ ↦ DFunLike.congr_fun h τ,
+      fun h ↦ DFunLike.ext _ _ fun τ ↦ DFunLike.congr_fun h τ⟩

--- a/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
+++ b/TauCeti/NumberTheory/ModularForms/DiamondOperators.lean
@@ -452,7 +452,12 @@ theorem diamondOp_coe_cuspForm (k : ℤ) (d : (ZMod N)ˣ)
 
 /-- **A cusp form is a `χ`-form exactly when the modular form underlying it is.** Membership in
 either character space is the same family of diamond eigenvalue equations, and the coercion is
-pointwise, so the two conditions transport across it. -/
+pointwise, so the two conditions transport across it.
+
+Not `@[simp]`: the left-hand side is itself simp-reducible — `mem_modFormCharSpace_iff` is
+`@[simp]` and rewrites it to the diamond eigenvalue equations — so this lemma could never fire
+as a rewrite rule, and tagging it makes the `simpNF` linter fail. Use it explicitly, as
+`Parity.lean` does. -/
 theorem coe_mem_modFormCharSpace_iff (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
     (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
     (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) ∈ modFormCharSpace k χ ↔

--- a/TauCeti/NumberTheory/ModularForms/Parity.lean
+++ b/TauCeti/NumberTheory/ModularForms/Parity.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.NumberTheory.ModularForms.CuspFormSubmodule
 public import TauCeti.NumberTheory.ModularForms.DiamondOperators
 
 /-!
@@ -107,10 +108,10 @@ theorem char_neg_one_of_mem_modFormCharSpace {f : ModularForm ((Gamma1 N).map (m
 /-- **The parity lemma for cusp forms.** If `S_k(Γ₁(N), χ)` contains a nonzero form then
 `χ(-1) = (-1)^k`. -/
 theorem char_neg_one_of_mem_cuspFormCharSpace {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
-    (hf : f ∈ cuspFormCharSpace k χ) (hf0 : f ≠ 0) : (χ (-1) : ℂ) = (-1 : ℂ) ^ k := by
-  refine char_neg_one_of_mem_modFormCharSpace ((coe_mem_modFormCharSpace_iff k χ f).mpr hf)
-    fun h ↦ hf0 (DFunLike.coe_injective ?_)
-  simpa using congrArg (DFunLike.coe (F := ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) h
+    (hf : f ∈ cuspFormCharSpace k χ) (hf0 : f ≠ 0) : (χ (-1) : ℂ) = (-1 : ℂ) ^ k :=
+  char_neg_one_of_mem_modFormCharSpace ((coe_mem_modFormCharSpace_iff k χ f).mpr hf)
+    fun h ↦ hf0 (CuspForm.toModularFormₗ_injective
+      (by rw [map_zero, CuspForm.toModularFormₗ_eq_coe]; exact h))
 
 /-! ### The emptiness criterion -/
 

--- a/TauCeti/NumberTheory/ModularForms/Parity.lean
+++ b/TauCeti/NumberTheory/ModularForms/Parity.lean
@@ -108,12 +108,9 @@ theorem char_neg_one_of_mem_modFormCharSpace {f : ModularForm ((Gamma1 N).map (m
 `χ(-1) = (-1)^k`. -/
 theorem char_neg_one_of_mem_cuspFormCharSpace {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
     (hf : f ∈ cuspFormCharSpace k χ) (hf0 : f ≠ 0) : (χ (-1) : ℂ) = (-1 : ℂ) ^ k := by
-  have hne : (⇑f : ℍ → ℂ) ≠ 0 := fun h ↦ hf0 (DFunLike.coe_injective (by simpa using h))
-  have h : ((-1 : ℂ) ^ k) • (⇑f : ℍ → ℂ) = (χ (-1) : ℂ) • (⇑f : ℍ → ℂ) := by
-    rw [← coe_diamondOpCusp_neg_one k f,
-      diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ (-1) hf]
-    simp
-  exact ((smul_left_inj hne).mp h).symm
+  refine char_neg_one_of_mem_modFormCharSpace ((coe_mem_modFormCharSpace_iff k χ f).mpr hf)
+    fun h ↦ hf0 (DFunLike.coe_injective ?_)
+  simpa using congrArg (DFunLike.coe (F := ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) h
 
 /-! ### The emptiness criterion -/
 


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"charspace-cuspform-coe"}-->

The diamond operators commute with the coercion `S_k(Γ₁(N)) → M_k(Γ₁(N))`, so the two nebentypus
character spaces agree across it:

```lean
@[simp] theorem diamondOp_coe_cuspForm (k : ℤ) (d : (ZMod N)ˣ) (f : CuspForm _ k) :
    diamondOp k d (f : ModularForm _ k) = (diamondOpCusp k d f : ModularForm _ k)

@[simp] theorem coe_mem_modFormCharSpace_iff (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) (f : CuspForm _ k) :
    (f : ModularForm _ k) ∈ modFormCharSpace k χ ↔ f ∈ cuspFormCharSpace k χ
```

A cusp form is a `χ`-form exactly when the modular form underlying it is.

## It has a consumer, and the consumer gets shorter

`char_neg_one_of_mem_cuspFormCharSpace` in `Parity.lean` was a near-verbatim copy of its modular
twin — the same five-line skeleton, differing only in which two diamond lemmas it named. It now
*derives* from the modular statement across the bridge, dropping from seven lines to three, with
no change to its statement:

```lean
theorem char_neg_one_of_mem_cuspFormCharSpace (hf : f ∈ cuspFormCharSpace k χ) (hf0 : f ≠ 0) :
    (χ (-1) : ℂ) = (-1 : ℂ) ^ k := by
  refine char_neg_one_of_mem_modFormCharSpace ((coe_mem_modFormCharSpace_iff k χ f).mpr hf)
    fun h ↦ hf0 (DFunLike.coe_injective ?_)
  simpa using congrArg (DFunLike.coe (F := ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) h
```

That is the pattern the bridge exists to remove: every fact about `modFormCharSpace` currently
needs a hand-written cusp twin. `Parity.lean` is the first; `Degeneracy.lean` and
`TrivialNebentypus.lean` carry the same duplication and can follow separately rather than
inflating this PR.

## Why the shape, and not AINTLIB's

AINTLIB states the two implications separately, as `cuspFormCharSpace_toModularForm'_mem` and
`cuspFormCharSpace_of_toModularForm'_mem`, because it carries its own `CuspForm.toModularForm'`.
This repository deliberately does not port that function —
`TauCeti/NumberTheory/ModularForms/HeckeSlash/ModularForm.lean:65` records the decision, since
mathlib already supplies the coercion as the `CoeTC` instance of `ModularFormClass`. Restating
through the mathlib coercion collapses the pair into one `iff`, matching the neighbouring
`mem_modFormCharSpace_iff` / `mem_cuspFormCharSpace_iff`.

The diamond bridge is separated out rather than inlined because it is the part that carries
content: `⟨d⟩` is slashing by a representative, and slashing does not see whether a form vanishes
at the cusps. It is proved through `coe_diamondOp`, `coe_diamondOpCusp` and
`ModularFormClass.coe_modularForm` at a representative obtained from
`Gamma0Map_toHomUnits_surjective` — not by `rfl`, so it does not rest on definitional equality
across the two operators and the coercion.

## Naming

`coe_` in `DiamondOperators.lean` already means the *function* coercion — `coe_diamondOp` and
`coe_diamondOpCusp` are the statements `⇑(diamondOp k d f) = ⇑f ∣[k] …`. The lemma added here is
about the `ModularForm`-valued coercion, a different one, so it is named for its left-hand head
symbol rather than given a clashing `coe_` prefix.

Both are `@[simp]`. An earlier revision left the `iff` unannotated on the reasoning that
`mem_modFormCharSpace_iff` is itself `@[simp]` and would rewrite both sides first, making the
annotation inert. That was asserted rather than measured, and it is not a good enough reason to
withhold the normal-form rule for a canonical coercion boundary; the whole-repo build is green
with both tagged.

## Absence

Neither half existed. `cuspFormCharSpace_toModularForm`, `cuspFormCharSpace_of_toModularForm`
and `toModularForm_mem_modFormCharSpace` are all zero across `TauCeti/`, and the search was run
by shape as well as by name: every declaration in each of the nine files mentioning
`cuspFormCharSpace` was listed, and none relates membership in one character space to membership
in the other. Positive controls: `mem_cuspFormCharSpace_iff` (DiamondOperators.lean:274),
`mem_modFormCharSpace_iff`, `diamondOpCusp` — all found by the same queries. The existing
`coe_diamondOp` / `coe_diamondOpCusp` are about `⇑`, not this coercion, and take an explicit
`Γ₀(N)` representative with a hypothesis, so they are neither duplicates nor usable here.

Both statements were compiled as `sorry`-bodied probes before either proof was written; the only
diagnostics were the two expected `declaration uses 'sorry'` errors, confirming that the coercion
and the instances elaborate as written.

## Placement

`DiamondOperators.lean` defines `diamondOp`, `diamondOpCusp`, `modFormCharSpace` and
`cuspFormCharSpace` and holds both `mem_*_iff` lemmas, so the bridge belongs there and needs no
new import. `Parity.lean` is edited only to consume it. Neither file is touched by any other open
PR (checked by file list across all open PRs, with a control confirming the sweep sees a true
case).

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
Apache-2.0,
`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Unified/NebentypusHeckeRingHom.lean`
lines 1331–1354, declarations `cuspFormCharSpace_toModularForm'_mem` and
`cuspFormCharSpace_of_toModularForm'_mem`. Restated as a single `iff` through mathlib's coercion,
with the diamond-operator step named separately. The same citation is in the file's References
section.

## Roadmap target

`TauCetiRoadmap/ModularForms/README.md:512` specifies `EigenformAwayFromLevel`'s `mem_charSpace`
field as `toCuspForm.toModularForm' ∈ modFormCharSpace k χ` — precisely "the modular form
underlying this cusp form lies in the character space" — and README:1449 already lists
`modFormCharSpace`/`cuspFormCharSpace` themselves as ported, so only the bridge between them was
missing. That is the later-layer motivation; the *present* justification does not rest on it,
since `char_neg_one_of_mem_cuspFormCharSpace` is a Layer-0 consumer already on `main` that this
PR shortens today.
