### PR TITLE
feat: the ramification index and relative degree of an extension of places

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
+++ b/TauCeti/FieldTheory/FunctionField/AffineModel/Place.lean
@@ -32,8 +32,6 @@ integrally closed, then swallows everything integral over `k[x]`.
 
 ## Main results
 
-* `TauCeti.Place.mem_integers_of_isIntegral`: the valuation ring of a place is integrally closed,
-  so it contains everything integral over a subring it contains.
 * `TauCeti.Place.adjoin_le_integers_iff`: `k[x] ⊆ 𝒪_P` exactly when `x ∈ 𝒪_P`.
 * `TauCeti.Place.center`: the height one prime of an affine model below a place finite on it,
   with `TauCeti.Place.valuation_center` identifying the adic valuation of that prime with the
@@ -65,18 +63,6 @@ universe u v w
 variable {k : Type u} {F : Type v} [Field k] [Field F] [Algebra k F] (P : Place k F)
 
 section Integers
-
-/-- The valuation ring of a place is integrally closed in `F`: an element of `F` integral over a
-`k`-algebra whose image lies in `𝒪_P` lies in `𝒪_P`. -/
-theorem mem_integers_of_isIntegral {R : Type w} [CommRing R] [Algebra R F]
-    (hR : ∀ r : R, algebraMap R F r ∈ P.integers) {y : F} (hy : IsIntegral R y) :
-    y ∈ P.integers := by
-  have hR' : ∀ r : R, algebraMap R F r ∈ P.valuation.valuationSubring :=
-    fun r ↦ P.mem_integers_iff.mp (hR r)
-  let : Algebra R P.valuation.valuationSubring := ((algebraMap R F).codRestrict _ hR').toAlgebra
-  have : IsScalarTower R P.valuation.valuationSubring F := .of_algebraMap_eq fun _ ↦ rfl
-  exact P.mem_integers_iff.mpr
-    ((Valuation.valuationSubring.integers P.valuation).isIntegral_iff_v_le_one.mp hy.tower_top)
 
 /-- **`k[x]` lies in the valuation ring of `P` exactly when `x` has no pole at `P`**: the
 criterion selecting the places on the finite chart of `x`. Its additive form is obtained from

--- a/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.AlgebraicClosure
+public import Mathlib.RingTheory.Valuation.Integral
 public import Mathlib.RingTheory.Valuation.IsTrivialOn
 public import TauCeti.RingTheory.Valuation.Discrete.Order
 
@@ -44,7 +45,11 @@ equivalence is needed and equality of places *is* equality of valuations
   `algebraicClosure k F` is contained in `𝒪_P`
   (`TauCeti.Place.mem_integers_of_mem_algebraicClosure`).
 * `TauCeti.Place.integers_injective`: a place is determined by its valuation ring
-  (Stichtenoth, Theorem 1.1.13).
+  (Stichtenoth, Theorem 1.1.13), and `TauCeti.Place.eq_of_integers_le`: the valuation ring of a
+  place is a maximal proper subring of `F`, so a place whose valuation ring contains that of
+  another place is that place (Stichtenoth, Theorem 1.1.13(d)).
+* `TauCeti.Place.mem_integers_of_isIntegral`: the valuation ring of a place is integrally closed
+  in `F`.
 * `TauCeti.Place.degree_eq_one_iff_algebraMap_surjective` and
   `TauCeti.Place.degree_eq_one_iff_forall_exists_valuation_sub_lt_one`: the rational places are
   those whose residue field is exhausted by the constants, equivalently those at which every
@@ -301,6 +306,46 @@ theorem valuation_isEquiv_iff {P Q : Place k F} : P.valuation.IsEquiv Q.valuatio
 /-- A place is determined by its valuation ring (Stichtenoth, Theorem 1.1.13). -/
 theorem integers_injective : Function.Injective (integers : Place k F → ValuationSubring F) :=
   fun _ _ h => eq_of_isEquiv ((Valuation.isEquiv_iff_valuationSubring _ _).mpr h)
+
+/-- **The valuation ring of a place is a maximal proper subring of `F`** (Stichtenoth,
+Theorem 1.1.13(d)), in the form used to recognize a place from a containment of valuation
+rings: a place whose valuation ring contains the valuation ring of another place is that
+place. -/
+theorem eq_of_integers_le {P Q : Place k F} (h : P.integers ≤ Q.integers) : P = Q := by
+  refine integers_injective (le_antisymm h ?_)
+  by_contra hle
+  obtain ⟨f, hfQ, hfP⟩ := SetLike.not_le_iff_exists.mp hle
+  rw [mem_integers_iff_ord_nonneg] at hfQ
+  rw [mem_integers_iff_ord_nonneg, not_le] at hfP
+  have hf0 : f ≠ 0 := by rintro rfl; simp at hfP
+  have hgP : 0 < P.ord f⁻¹ := by rw [ord_inv]; omega
+  have hgQ : 0 ≤ Q.ord f⁻¹ := by
+    rw [← mem_integers_iff_ord_nonneg]
+    exact h (P.mem_integers_iff_ord_nonneg.mpr hgP.le)
+  have hgQ0 : Q.ord f⁻¹ = 0 := by rw [ord_inv] at hgQ ⊢; omega
+  refine Q.integers_ne_top (top_unique fun y _ ↦ ?_)
+  rcases eq_or_ne y 0 with rfl | hy0
+  · exact zero_mem _
+  set n := (max 0 (-P.ord y)).toNat with hn
+  have hmem : y * f⁻¹ ^ n ∈ P.integers := by
+    rw [mem_integers_iff_ord_nonneg, ord_mul _ hy0 (pow_ne_zero _ (inv_ne_zero hf0)), ord_pow]
+    have : (1 : ℤ) ≤ P.ord f⁻¹ := hgP
+    nlinarith [Int.toNat_of_nonneg (le_max_left 0 (-P.ord y)), le_max_right 0 (-P.ord y)]
+  have := Q.mem_integers_iff_ord_nonneg.mp (h hmem)
+  rw [ord_mul _ hy0 (pow_ne_zero _ (inv_ne_zero hf0)), ord_pow, hgQ0] at this
+  exact Q.mem_integers_iff_ord_nonneg.mpr (by omega)
+
+/-- The valuation ring of a place is integrally closed in `F`: an element of `F` integral over a
+`k`-algebra whose image lies in `𝒪_P` lies in `𝒪_P`. -/
+theorem mem_integers_of_isIntegral {R : Type*} [CommRing R] [Algebra R F]
+    (hR : ∀ r : R, algebraMap R F r ∈ P.integers) {y : F} (hy : IsIntegral R y) :
+    y ∈ P.integers := by
+  have hR' : ∀ r : R, algebraMap R F r ∈ P.valuation.valuationSubring :=
+    fun r ↦ P.mem_integers_iff.mp (hR r)
+  let : Algebra R P.valuation.valuationSubring := ((algebraMap R F).codRestrict _ hR').toAlgebra
+  have : IsScalarTower R P.valuation.valuationSubring F := .of_algebraMap_eq fun _ ↦ rfl
+  exact P.mem_integers_iff.mpr
+    ((Valuation.valuationSubring.integers P.valuation).isIntegral_iff_v_le_one.mp hy.tower_top)
 
 end IntegersOrder
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
@@ -261,6 +261,11 @@ place `P` of `F / k` it lies over (Stichtenoth, Definition 3.1.5). -/
 noncomputable def relativeDegree : ℕ :=
   Module.finrank (P'.restrict k F).ResidueField P'.ResidueField
 
+/-- The relative degree is the finrank of the extension of residue fields. -/
+theorem relativeDegree_def :
+    relativeDegree k F P' = Module.finrank (P'.restrict k F).ResidueField P'.ResidueField := by
+  rw [relativeDegree]
+
 end ResidueField
 
 section Independence

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
@@ -118,6 +118,7 @@ at `P` (Stichtenoth, Definition 3.1.5). -/
 noncomputable def ramificationIdx : ℕ :=
   Valuation.ordIndex (P'.valuation.comap (algebraMap F F'))
 
+/-- The ramification index of a restricted place is positive. -/
 theorem ramificationIdx_pos : 0 < ramificationIdx F P' :=
   Nat.pos_of_ne_zero (ordIndex_comap_ne_zero F P')
 
@@ -230,7 +231,8 @@ instance : IsLocalHom (algebraMap (P'.restrict k F).integers P'.integers) where
   map_nonunit a ha := by
     have ha0 : (a : F) ≠ 0 := by
       rintro h
-      rw [show a = 0 from Subtype.ext h] at ha
+      have ha_eq_zero : a = 0 := Subtype.ext h
+      rw [ha_eq_zero] at ha
       simp at ha
     have hmap0 : algebraMap F F' (a : F) ≠ 0 := by simpa using ha0
     have h1 : P'.ord (algebraMap F F' (a : F)) = 0 :=
@@ -295,7 +297,8 @@ private theorem ord_sum_eq_zero {ι : Type*} [Fintype ι] (s : ι → P'.integer
     rw [IsLocalRing.residue_eq_zero_iff, IsLocalRing.mem_maximalIdeal, mem_nonunits_iff] at hz
     exact hz hb₀
   have hB0 : (B : F') ≠ 0 := fun h ↦ hne (by
-    rw [show B = 0 from Subtype.ext h, map_zero])
+    have hB_eq_zero : B = 0 := Subtype.ext h
+    rw [hB_eq_zero, map_zero])
   have hunit : IsUnit B := by
     by_contra hu
     exact hne (by
@@ -329,7 +332,8 @@ private theorem exists_ord_sum_eq_mul {ι : Type*} [Fintype ι] (s : ι → P'.i
       omega
   set b : ι → P.integers := fun i ↦ ⟨c i / c i₀, hb i⟩ with hbdef
   have hb₀ : IsUnit (b i₀) := by
-    rw [show b i₀ = 1 from Subtype.ext (by simp [hbdef, div_self hd])]
+    have hb_eq_one : b i₀ = 1 := Subtype.ext (by simp [hbdef, div_self hd])
+    rw [hb_eq_one]
     exact isUnit_one
   have hsum : ∑ i, algebraMap F F' (c i) * (s i : F') =
       algebraMap F F' (c i₀) * ∑ i, algebraMap F F' (b i : F) * (s i : F') := by
@@ -416,6 +420,70 @@ theorem linearIndependent_mul_pow_of_linearIndependent_residue {ι : Type*} [Fin
 
 end Independence
 
+section RamificationIdxBound
+
+variable (F) (P' : Place k' F')
+
+private theorem linearIndependent_pow_fin_ramificationIdx {t : F'} (ht : P'.ord t = 1) :
+    LinearIndependent F fun j : Fin (ramificationIdx F P') ↦ t ^ (j : ℕ) := by
+  classical
+  have ht0 : t ≠ 0 := by rintro rfl; simp at ht
+  set e := ramificationIdx F P' with he
+  rw [Fintype.linearIndependent_iff]
+  intro c hc
+  by_contra hex
+  rw [not_forall] at hex
+  obtain ⟨j₁, hj₁⟩ := hex
+  set A : Fin e → F' := fun j ↦ algebraMap F F' (c j) * t ^ (j : ℕ) with hA
+  have hsum : ∑ j, A j = 0 := by
+    simpa only [hA, Algebra.smul_def] using hc
+  have hAord : ∀ j : Fin e, c j ≠ 0 →
+      ∃ m : ℤ, P'.ord (A j) = (e : ℤ) * m + (j : ℕ) := by
+    intro j hj
+    obtain ⟨m, hm⟩ := Valuation.ordIndex_dvd_ord
+      (P'.valuation.comap (algebraMap F F')) (c j)
+    have hmap : algebraMap F F' (c j) ≠ 0 := by simpa using hj
+    refine ⟨m, ?_⟩
+    rw [hA, P'.ord_mul hmap (pow_ne_zero _ ht0), P'.ord_pow, ht, mul_one,
+      ← ord_comap F P' (c j), hm]
+    have hidx : Valuation.ordIndex (P'.valuation.comap (algebraMap F F')) = e :=
+      rfl.trans he.symm
+    have hidx' : (Valuation.ordIndex (P'.valuation.comap (algebraMap F F')) : ℤ) = e := by
+      exact_mod_cast hidx
+    rw [hidx']
+  set J : Finset (Fin e) := {j | c j ≠ 0} with hJdef
+  have hJ : J.Nonempty := ⟨j₁, by simp [hJdef, hj₁]⟩
+  obtain ⟨j₀, hj₀J, hj₀⟩ := J.exists_min_image (fun j ↦ P'.ord (A j)) hJ
+  have hj₀c : c j₀ ≠ 0 := by simpa [hJdef] using hj₀J
+  have hj₀A : A j₀ ≠ 0 := by simp [hA, hj₀c, ht0]
+  have hlt : ∀ j ∈ (Finset.univ : Finset (Fin e)) \ {j₀},
+      P'.valuation (A j) < P'.valuation (A j₀) := by
+    intro j hj
+    simp only [Finset.mem_sdiff, Finset.mem_singleton] at hj
+    by_cases hjc : c j = 0
+    · simp only [hA, hjc, map_zero, zero_mul]
+      exact zero_lt_iff.mpr ((Valuation.ne_zero_iff _).mpr hj₀A)
+    · obtain ⟨m, hm⟩ := hAord j hjc
+      obtain ⟨m₀, hm₀⟩ := hAord j₀ hj₀c
+      have hne : P'.ord (A j) ≠ P'.ord (A j₀) := by
+        rw [hm, hm₀]
+        exact fun hcontra ↦ hj.2 (eq_of_mul_add_natCast_eq hcontra)
+      have hge := hj₀ j (by simp [hJdef, hjc])
+      exact valuation_lt_of_ord_lt P' (by simp [hA, hjc, ht0]) hj₀A (by omega)
+  have hval := P'.valuation.map_sum_eq_of_lt (Finset.mem_univ j₀) hlt
+  rw [hsum, map_zero] at hval
+  exact (Valuation.ne_zero_iff _).mpr hj₀A hval.symm
+
+variable [FiniteDimensional F F']
+
+/-- The ramification index of a place is at most the degree of the field extension. -/
+theorem ramificationIdx_le_finrank : ramificationIdx F P' ≤ Module.finrank F F' := by
+  obtain ⟨t, ht⟩ := P'.exists_isUniformizer
+  rw [P'.isUniformizer_iff_ord_eq_one] at ht
+  simpa using (linearIndependent_pow_fin_ramificationIdx F P' ht).fintype_card_le_finrank
+
+end RamificationIdxBound
+
 section Bound
 
 variable (k F) (P' : Place k' F') [Algebra.IsIntegral F F'] [FiniteDimensional F F']
@@ -443,6 +511,7 @@ instance finiteDimensional_residueField_restrict :
   Module.rank_lt_aleph0_iff.mp
     (lt_of_le_of_lt (rank_residueField_le k F P') (Cardinal.natCast_lt_aleph0))
 
+/-- The relative degree is positive because a residue field extension is nontrivial. -/
 theorem one_le_relativeDegree : 1 ≤ relativeDegree k F P' :=
   Module.finrank_pos
 
@@ -458,13 +527,9 @@ theorem ramificationIdx_mul_relativeDegree_le_finrank :
         rw [mul_comm]
         exact Nat.div_mul_le_self _ _
 
+/-- The relative degree of a place is at most the degree of the field extension. -/
 theorem relativeDegree_le_finrank : relativeDegree k F P' ≤ Module.finrank F F' :=
   le_trans (Nat.le_mul_of_pos_left _ (ramificationIdx_pos F P'))
-    (ramificationIdx_mul_relativeDegree_le_finrank k F P')
-
-include k in
-theorem ramificationIdx_le_finrank : ramificationIdx F P' ≤ Module.finrank F F' :=
-  le_trans (Nat.le_mul_of_pos_right _ (one_le_relativeDegree k F P'))
     (ramificationIdx_mul_relativeDegree_le_finrank k F P')
 
 end Bound
@@ -472,4 +537,3 @@ end Bound
 end Place
 
 end TauCeti
-

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
@@ -270,6 +270,33 @@ private theorem eq_of_mul_add_natCast_eq {e : ℕ} {j j' : Fin e} {a b : ℤ}
   simp only [key] at h'
   exact Fin.ext (by exact_mod_cast h')
 
+private theorem sum_ne_zero_of_ord_eq_mul_add_natCast {e : ℕ} (A : Fin e → F')
+    (hAord : ∀ j, A j ≠ 0 → ∃ m : ℤ, P'.ord (A j) = (e : ℤ) * m + (j : ℕ))
+    {j₁ : Fin e} (hj₁ : A j₁ ≠ 0) : ∑ j, A j ≠ 0 := by
+  classical
+  set J : Finset (Fin e) := {j | A j ≠ 0} with hJdef
+  have hJ : J.Nonempty := ⟨j₁, by simp [hJdef, hj₁]⟩
+  obtain ⟨j₀, hj₀J, hj₀⟩ := J.exists_min_image (fun j ↦ P'.ord (A j)) hJ
+  have hj₀A : A j₀ ≠ 0 := by simpa [hJdef] using hj₀J
+  have hlt : ∀ j ∈ (Finset.univ : Finset (Fin e)) \ {j₀},
+      P'.valuation (A j) < P'.valuation (A j₀) := by
+    intro j hj
+    simp only [Finset.mem_sdiff, Finset.mem_singleton] at hj
+    by_cases hAj : A j = 0
+    · rw [hAj, map_zero]
+      exact zero_lt_iff.mpr ((Valuation.ne_zero_iff _).mpr hj₀A)
+    · obtain ⟨m, hm⟩ := hAord j hAj
+      obtain ⟨m₀, hm₀⟩ := hAord j₀ hj₀A
+      have hne : P'.ord (A j) ≠ P'.ord (A j₀) := by
+        rw [hm, hm₀]
+        exact fun hcontra ↦ hj.2 (eq_of_mul_add_natCast_eq hcontra)
+      have hge := hj₀ j (by simp [hJdef, hAj])
+      exact valuation_lt_of_ord_lt P' hAj hj₀A (by omega)
+  intro hsum
+  have hval := P'.valuation.map_sum_eq_of_lt (Finset.mem_univ j₀) hlt
+  rw [hsum, map_zero] at hval
+  exact (Valuation.ne_zero_iff _).mpr hj₀A hval.symm
+
 /-- A combination of elements of `𝒪_{P'}` with coefficients in `𝒪_P`, one of them a unit, is a
 unit at `P'` as soon as the residues of the elements are independent over the residue field of
 `P`: its residue is the corresponding nontrivial combination of the residues. -/
@@ -386,37 +413,16 @@ theorem linearIndependent_mul_pow_of_linearIndependent_residue {ι : Type*} [Fin
     · exact absurd (by simp [hA, hall]) hj
     · obtain ⟨i, hi⟩ := not_forall.mp hall
       exact (exists_ord_sum_eq_mul k F P' s hind (fun i ↦ c (i, j)) hi).2
-  have hTord : ∀ j : Fin e, A j ≠ 0 →
+  have hTord : ∀ j : Fin e, A j * t ^ (j : ℕ) ≠ 0 →
       ∃ m : ℤ, P'.ord (A j * t ^ (j : ℕ)) = (e : ℤ) * m + (j : ℕ) := by
     intro j hj
-    obtain ⟨m, hm⟩ := hAord j hj
-    exact ⟨m, by rw [P'.ord_mul hj (pow_ne_zero _ ht0), P'.ord_pow, ht, hm, mul_one]⟩
+    have hAj : A j ≠ 0 := fun h ↦ hj (by simp [h])
+    obtain ⟨m, hm⟩ := hAord j hAj
+    exact ⟨m, by rw [P'.ord_mul hAj (pow_ne_zero _ ht0), P'.ord_pow, ht, hm, mul_one]⟩
   have hA₁ : A j₁ ≠ 0 :=
     (exists_ord_sum_eq_mul k F P' s hind (fun i ↦ c (i, j₁)) (i₁ := i₁) hp₁).1
-  set J : Finset (Fin e) := {j | A j ≠ 0} with hJdef
-  have hJ : J.Nonempty := ⟨j₁, by simp [hJdef, hA₁]⟩
-  obtain ⟨j₀, hj₀J, hj₀⟩ := J.exists_min_image (fun j ↦ P'.ord (A j * t ^ (j : ℕ))) hJ
-  have hj₀A : A j₀ ≠ 0 := by simpa [hJdef] using hj₀J
-  have hj₀ne : A j₀ * t ^ (j₀ : ℕ) ≠ 0 := mul_ne_zero hj₀A (pow_ne_zero _ ht0)
-  have hlt : ∀ j ∈ (Finset.univ : Finset (Fin e)) \ {j₀},
-      P'.valuation (A j * t ^ (j : ℕ)) < P'.valuation (A j₀ * t ^ (j₀ : ℕ)) := by
-    intro j hj
-    simp only [Finset.mem_sdiff, Finset.mem_singleton] at hj
-    by_cases hAj : A j = 0
-    · rw [hAj, zero_mul, map_zero]
-      exact zero_lt_iff.mpr ((Valuation.ne_zero_iff _).mpr hj₀ne)
-    · have hjJ : j ∈ J := by simp [hJdef, hAj]
-      obtain ⟨m, hm⟩ := hTord j hAj
-      obtain ⟨m₀, hm₀⟩ := hTord j₀ hj₀A
-      have hne : P'.ord (A j * t ^ (j : ℕ)) ≠ P'.ord (A j₀ * t ^ (j₀ : ℕ)) := by
-        rw [hm, hm₀]
-        exact fun hcontra ↦ hj.2 (eq_of_mul_add_natCast_eq hcontra)
-      have hge := hj₀ j hjJ
-      exact valuation_lt_of_ord_lt P' (mul_ne_zero hAj (pow_ne_zero _ ht0)) hj₀ne
-        (by omega)
-  have hval := P'.valuation.map_sum_eq_of_lt (Finset.mem_univ j₀) hlt
-  rw [hkey, map_zero] at hval
-  exact (Valuation.ne_zero_iff _).mpr hj₀ne hval.symm
+  exact (sum_ne_zero_of_ord_eq_mul_add_natCast P' (fun j ↦ A j * t ^ (j : ℕ)) hTord
+    (mul_ne_zero hA₁ (pow_ne_zero _ ht0))) hkey
 
 end Independence
 
@@ -437,12 +443,13 @@ private theorem linearIndependent_pow_fin_ramificationIdx {t : F'} (ht : P'.ord 
   set A : Fin e → F' := fun j ↦ algebraMap F F' (c j) * t ^ (j : ℕ) with hA
   have hsum : ∑ j, A j = 0 := by
     simpa only [hA, Algebra.smul_def] using hc
-  have hAord : ∀ j : Fin e, c j ≠ 0 →
+  have hAord : ∀ j : Fin e, A j ≠ 0 →
       ∃ m : ℤ, P'.ord (A j) = (e : ℤ) * m + (j : ℕ) := by
     intro j hj
+    have hjc : c j ≠ 0 := fun h ↦ hj (by simp [hA, h])
     obtain ⟨m, hm⟩ := Valuation.ordIndex_dvd_ord
       (P'.valuation.comap (algebraMap F F')) (c j)
-    have hmap : algebraMap F F' (c j) ≠ 0 := by simpa using hj
+    have hmap : algebraMap F F' (c j) ≠ 0 := by simpa using hjc
     refine ⟨m, ?_⟩
     rw [hA, P'.ord_mul hmap (pow_ne_zero _ ht0), P'.ord_pow, ht, mul_one,
       ← ord_comap F P' (c j), hm]
@@ -451,28 +458,8 @@ private theorem linearIndependent_pow_fin_ramificationIdx {t : F'} (ht : P'.ord 
     have hidx' : (Valuation.ordIndex (P'.valuation.comap (algebraMap F F')) : ℤ) = e := by
       exact_mod_cast hidx
     rw [hidx']
-  set J : Finset (Fin e) := {j | c j ≠ 0} with hJdef
-  have hJ : J.Nonempty := ⟨j₁, by simp [hJdef, hj₁]⟩
-  obtain ⟨j₀, hj₀J, hj₀⟩ := J.exists_min_image (fun j ↦ P'.ord (A j)) hJ
-  have hj₀c : c j₀ ≠ 0 := by simpa [hJdef] using hj₀J
-  have hj₀A : A j₀ ≠ 0 := by simp [hA, hj₀c, ht0]
-  have hlt : ∀ j ∈ (Finset.univ : Finset (Fin e)) \ {j₀},
-      P'.valuation (A j) < P'.valuation (A j₀) := by
-    intro j hj
-    simp only [Finset.mem_sdiff, Finset.mem_singleton] at hj
-    by_cases hjc : c j = 0
-    · simp only [hA, hjc, map_zero, zero_mul]
-      exact zero_lt_iff.mpr ((Valuation.ne_zero_iff _).mpr hj₀A)
-    · obtain ⟨m, hm⟩ := hAord j hjc
-      obtain ⟨m₀, hm₀⟩ := hAord j₀ hj₀c
-      have hne : P'.ord (A j) ≠ P'.ord (A j₀) := by
-        rw [hm, hm₀]
-        exact fun hcontra ↦ hj.2 (eq_of_mul_add_natCast_eq hcontra)
-      have hge := hj₀ j (by simp [hJdef, hjc])
-      exact valuation_lt_of_ord_lt P' (by simp [hA, hjc, ht0]) hj₀A (by omega)
-  have hval := P'.valuation.map_sum_eq_of_lt (Finset.mem_univ j₀) hlt
-  rw [hsum, map_zero] at hval
-  exact (Valuation.ne_zero_iff _).mpr hj₀A hval.symm
+  have hA₁ : A j₁ ≠ 0 := by simp [hA, hj₁, ht0]
+  exact (sum_ne_zero_of_ord_eq_mul_add_natCast P' A hAord hA₁) hsum
 
 variable [FiniteDimensional F F']
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
@@ -74,7 +74,7 @@ section Restrict
 variable (k F) (P' : Place k' F')
 
 /-- The valuation of `P'` restricted to `F` is trivial on the constants of `F`. -/
-theorem isTrivialOn_comap : (P'.valuation.comap (algebraMap F F')).IsTrivialOn k where
+private theorem isTrivialOn_comap : (P'.valuation.comap (algebraMap F F')).IsTrivialOn k where
   eq_one c hc := by
     have hmap : algebraMap F F' (algebraMap k F c) = algebraMap k' F' (algebraMap k k' c) := by
       rw [← IsScalarTower.algebraMap_apply k F F', IsScalarTower.algebraMap_apply k k' F']
@@ -84,14 +84,14 @@ theorem isTrivialOn_comap : (P'.valuation.comap (algebraMap F F')).IsTrivialOn k
 
 /-- The order function of `P'` restricted to `F` is the order function of the restricted
 valuation. -/
-theorem ord_comap (f : F) :
+private theorem ord_comap (f : F) :
     Valuation.ord (P'.valuation.comap (algebraMap F F')) f = P'.ord (algebraMap F F' f) := by
   rw [Valuation.ord_def, ord_def, Valuation.comap_apply]
 
 /-- The valuation of `P'` restricted to `F` is nontrivial: an algebraic extension of a field
 contained in a valuation ring is contained in that valuation ring, so a place of `F'` trivial on
 `F` would have all of `F'` as its valuation ring. -/
-theorem ordIndex_comap_ne_zero [Algebra.IsIntegral F F'] :
+private theorem ordIndex_comap_ne_zero [Algebra.IsIntegral F F'] :
     Valuation.ordIndex (P'.valuation.comap (algebraMap F F')) ≠ 0 := fun h ↦ by
   have hall := (Valuation.ordIndex_eq_zero_iff _).mp h
   refine P'.integers_ne_top (top_unique fun y _ ↦ ?_)
@@ -122,7 +122,7 @@ noncomputable def ramificationIdx : ℕ :=
 theorem ramificationIdx_pos : 0 < ramificationIdx F P' :=
   Nat.pos_of_ne_zero (ordIndex_comap_ne_zero F P')
 
-theorem valuation_restrict :
+private theorem valuation_restrict :
     (P'.restrict k F).valuation = (P'.valuation.comap (algebraMap F F')).normalization := (rfl)
 
 /-- **The defining property of the ramification index** (Stichtenoth, Definition 3.1.5): on `F`
@@ -216,6 +216,15 @@ section ResidueField
 
 variable (k F) (P' : Place k' F') [Algebra.IsIntegral F F']
 
+/-- The valuation of the restricted place extends along `F → F'`; hence Mathlib's generic
+valuation-extension API supplies the valuation-ring algebra map, its locality, and the induced
+residue-field extension. -/
+instance instHasExtensionValuation :
+    Valuation.HasExtension (P'.restrict k F).valuation P'.valuation where
+  val_isEquiv_comap := by
+    rw [valuation_restrict]
+    exact Valuation.isEquiv_normalization _
+
 /-- The valuation ring of the restriction is carried into the valuation ring of `P'`, so the
 latter is an algebra over the former. -/
 noncomputable instance instAlgebraIntegers : Algebra (P'.restrict k F).integers P'.integers :=
@@ -227,7 +236,10 @@ theorem coe_algebraMap_integers (x : (P'.restrict k F).integers) :
     ((algebraMap (P'.restrict k F).integers P'.integers x : P'.integers) : F') =
       algebraMap F F' (x : F) := (rfl)
 
-instance : IsLocalHom (algebraMap (P'.restrict k F).integers P'.integers) where
+/-- The valuation-ring algebra map is local, so it induces the residue-field extension used by
+`relativeDegree`. -/
+instance instIsLocalHomIntegers :
+    IsLocalHom (algebraMap (P'.restrict k F).integers P'.integers) where
   map_nonunit a ha := by
     have ha0 : (a : F) ≠ 0 := by
       rintro h
@@ -473,7 +485,7 @@ end RamificationIdxBound
 
 section Bound
 
-variable (k F) (P' : Place k' F') [Algebra.IsIntegral F F'] [FiniteDimensional F F']
+variable (k F) (P' : Place k' F') [FiniteDimensional F F']
 
 private theorem rank_residueField_le :
     Module.rank (P'.restrict k F).ResidueField P'.ResidueField ≤

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension.lean
@@ -1,0 +1,475 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Valuation.Extension
+public import TauCeti.FieldTheory.FunctionField.Place.Basic
+public import TauCeti.RingTheory.Valuation.Discrete.Normalize
+
+/-!
+# Extensions of places: the ramification index and the relative degree
+
+Let `F' / k'` be a field extension lying over `F / k`, with `F'` algebraic over `F`. Restricting
+the valuation of a place `P'` of `F' / k'` to `F` gives a valuation of `F` that is trivial on the
+constants and — because `F'` is algebraic over `F`, so that a valuation ring of `F'` containing
+`F` would be all of `F'` — nontrivial. Normalizing it produces a place `P = P'.restrict k F` of
+`F / k`, the place of `F` that `P'` *lies over*, and the index divided out in the normalization
+is the **ramification index** `e(P' | P)`. The residue field of `P` embeds in the residue field
+of `P'`, and the degree of that extension is the **relative degree** `f(P' | P)`.
+
+The main theorem is the bound `e(P' | P) · f(P' | P) ≤ [F' : F]`: residues of elements of `𝒪_{P'}`
+that are independent over `F_P`, multiplied by the powers `t^j` of a prime element for `P'` with
+`0 ≤ j < e`, are independent over `F`, because the orders of the resulting blocks are pairwise
+distinct modulo `e`.
+
+## Main definitions
+
+* `TauCeti.Place.restrict`: the place of `F / k` that a place of `F' / k'` lies over.
+* `TauCeti.Place.ramificationIdx`: the ramification index `e(P' | P)`.
+* `TauCeti.Place.relativeDegree`: the relative degree `f(P' | P) = [F'_{P'} : F_P]`.
+
+## Main results
+
+* `TauCeti.Place.ord_algebraMap_restrict`: the defining property `ord_{P'} = e · ord_P` on `F`.
+* `TauCeti.Place.restrict_eq_iff_integers_le`, `TauCeti.Place.restrict_eq_iff_forall_ord_pos`
+  and `TauCeti.Place.restrict_eq_iff_exists_ord_eq`: the three characterizations of `P' ∣ P`
+  (Stichtenoth, Proposition 3.1.4), by the containment of valuation rings, by the containment of
+  maximal ideals, and by the scaling of the order functions. Together with
+  `TauCeti.Place.restrict` they say that every place of `F'` lies over exactly one place of `F`.
+* `TauCeti.Place.linearIndependent_mul_pow_of_linearIndependent_residue`: the independence
+  statement carrying the fundamental inequality.
+* `TauCeti.Place.ramificationIdx_mul_relativeDegree_le_finrank`: `e(P' ∣ P) · f(P' ∣ P) ≤
+  [F' : F]`, with `TauCeti.Place.ramificationIdx_le_finrank` and
+  `TauCeti.Place.relativeDegree_le_finrank` its two halves (Stichtenoth, Corollary 3.1.12).
+* `TauCeti.Place.finiteDimensional_residueField_restrict`: the relative degree is finite, so it
+  is not the junk value of `Module.finrank`; `TauCeti.Place.one_le_relativeDegree` and
+  `TauCeti.Place.ramificationIdx_pos` are the matching lower bounds.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Section III.1.
+-/
+
+public section
+
+open scoped WithZero
+
+namespace TauCeti
+
+namespace Place
+
+universe u u' v v'
+
+variable {k : Type u} {k' : Type u'} {F : Type v} {F' : Type v'}
+variable [Field k] [Field k'] [Field F] [Field F']
+variable [Algebra k k'] [Algebra k F] [Algebra k' F'] [Algebra F F'] [Algebra k F']
+variable [IsScalarTower k k' F'] [IsScalarTower k F F']
+
+section Restrict
+
+variable (k F) (P' : Place k' F')
+
+/-- The valuation of `P'` restricted to `F` is trivial on the constants of `F`. -/
+theorem isTrivialOn_comap : (P'.valuation.comap (algebraMap F F')).IsTrivialOn k where
+  eq_one c hc := by
+    have hmap : algebraMap F F' (algebraMap k F c) = algebraMap k' F' (algebraMap k k' c) := by
+      rw [← IsScalarTower.algebraMap_apply k F F', IsScalarTower.algebraMap_apply k k' F']
+    have hc' : algebraMap k k' c ≠ 0 := fun h ↦ hc
+      ((algebraMap k k').injective (by rw [h, map_zero]))
+    simpa only [Valuation.comap_apply, hmap] using P'.isTrivialOn.eq_one _ hc'
+
+/-- The order function of `P'` restricted to `F` is the order function of the restricted
+valuation. -/
+theorem ord_comap (f : F) :
+    Valuation.ord (P'.valuation.comap (algebraMap F F')) f = P'.ord (algebraMap F F' f) := by
+  rw [Valuation.ord_def, ord_def, Valuation.comap_apply]
+
+/-- The valuation of `P'` restricted to `F` is nontrivial: an algebraic extension of a field
+contained in a valuation ring is contained in that valuation ring, so a place of `F'` trivial on
+`F` would have all of `F'` as its valuation ring. -/
+theorem ordIndex_comap_ne_zero [Algebra.IsIntegral F F'] :
+    Valuation.ordIndex (P'.valuation.comap (algebraMap F F')) ≠ 0 := fun h ↦ by
+  have hall := (Valuation.ordIndex_eq_zero_iff _).mp h
+  refine P'.integers_ne_top (top_unique fun y _ ↦ ?_)
+  refine P'.mem_integers_of_isIntegral (R := F) (fun f ↦ ?_) (Algebra.IsIntegral.isIntegral y)
+  exact P'.mem_integers_iff_ord_nonneg.mpr (by rw [← ord_comap F P' f, hall f])
+
+variable [Algebra.IsIntegral F F']
+
+/-- **The place of `F / k` that a place of `F' / k'` lies over**: the normalization of the
+restriction of its valuation to `F` (Stichtenoth, Definition 3.1.2). Every place of `F'` lies
+over exactly one place of `F`; which place is characterized in
+`TauCeti.Place.restrict_eq_iff_integers_le`. -/
+noncomputable def restrict : Place k F where
+  valuation := (P'.valuation.comap (algebraMap F F')).normalization
+  valuation_surjective :=
+    Valuation.normalization_surjective _ (ordIndex_comap_ne_zero F P')
+  isTrivialOn := by
+    have := isTrivialOn_comap k F P'
+    exact Valuation.IsTrivialOn.normalization _
+
+/-- **The ramification index** `e(P' ∣ P)` of a place `P'` of `F' / k'` over the place `P` of
+`F / k` it lies over: the factor by which the order function at `P'` scales the order function
+at `P` (Stichtenoth, Definition 3.1.5). -/
+noncomputable def ramificationIdx : ℕ :=
+  Valuation.ordIndex (P'.valuation.comap (algebraMap F F'))
+
+theorem ramificationIdx_pos : 0 < ramificationIdx F P' :=
+  Nat.pos_of_ne_zero (ordIndex_comap_ne_zero F P')
+
+theorem valuation_restrict :
+    (P'.restrict k F).valuation = (P'.valuation.comap (algebraMap F F')).normalization := (rfl)
+
+/-- **The defining property of the ramification index** (Stichtenoth, Definition 3.1.5): on `F`
+the order function at `P'` is `e(P' ∣ P)` times the order function at `P`. -/
+theorem ord_algebraMap_restrict (f : F) :
+    P'.ord (algebraMap F F' f) = ramificationIdx F P' * (P'.restrict k F).ord f := by
+  have key : (P'.restrict k F).ord f =
+      Valuation.ord (P'.valuation.comap (algebraMap F F')).normalization f := by
+    rw [ord_def, valuation_restrict, Valuation.ord_def]
+  rw [← ord_comap F P' f, ramificationIdx, key,
+    ← Valuation.ord_normalization_mul_ordIndex _ f, mul_comm]
+
+/-- An element of `F` is integral at the restriction exactly when it is integral at `P'`. -/
+theorem mem_integers_restrict_iff (f : F) :
+    f ∈ (P'.restrict k F).integers ↔ algebraMap F F' f ∈ P'.integers := by
+  rw [mem_integers_iff_ord_nonneg, mem_integers_iff_ord_nonneg, ord_algebraMap_restrict k F P' f]
+  exact ⟨fun h ↦ mul_nonneg (by positivity) h,
+    fun h ↦ nonneg_of_mul_nonneg_right h (by exact_mod_cast ramificationIdx_pos F P')⟩
+
+
+/-- **`P' ∣ P` by valuation rings** (Stichtenoth, Proposition 3.1.4): the place of `F / k` that
+`P'` lies over is the unique place whose valuation ring is carried into the valuation ring of
+`P'`. -/
+theorem restrict_eq_iff_integers_le (P : Place k F) :
+    P'.restrict k F = P ↔ ∀ f ∈ P.integers, algebraMap F F' f ∈ P'.integers := by
+  refine ⟨?_, fun h ↦ ?_⟩
+  · rintro rfl f hf
+    exact (mem_integers_restrict_iff k F P' f).mp hf
+  · refine (eq_of_integers_le (SetLike.le_def.mpr fun f hf ↦ ?_)).symm
+    exact (mem_integers_restrict_iff k F P' f).mpr (h f hf)
+
+/-- **`P' ∣ P` by maximal ideals** (Stichtenoth, Proposition 3.1.4): it is enough that the
+functions vanishing at `P` vanish at `P'`. -/
+theorem restrict_eq_iff_forall_ord_pos (P : Place k F) :
+    P'.restrict k F = P ↔ ∀ f : F, 0 < P.ord f → 0 < P'.ord (algebraMap F F' f) := by
+  refine ⟨?_, fun h ↦ ?_⟩
+  · rintro rfl f hf
+    rw [ord_algebraMap_restrict k F P' f]
+    exact mul_pos (by exact_mod_cast ramificationIdx_pos F P') hf
+  rw [restrict_eq_iff_integers_le]
+  intro f hf
+  rcases eq_or_ne f 0 with rfl | hf0
+  · simp
+  obtain ⟨t, ht⟩ := P.exists_isUniformizer
+  rw [P.isUniformizer_iff_ord_eq_one] at ht
+  have ht0 : t ≠ 0 := by rintro rfl; simp at ht
+  have hb : 0 < P'.ord (algebraMap F F' t) := h t (by omega)
+  have hmap0 : algebraMap F F' f ≠ 0 := by simpa using hf0
+  have hmapt0 : algebraMap F F' t ≠ 0 := by simpa using ht0
+  refine P'.mem_integers_iff_ord_nonneg.mpr ?_
+  by_contra hneg
+  rw [not_le] at hneg
+  set m := (P'.ord (algebraMap F F' t)).toNat with hm
+  have hpos := h (f ^ m * t) (by
+    rw [P.ord_mul (pow_ne_zero _ hf0) ht0, P.ord_pow, ht]
+    have := P.mem_integers_iff_ord_nonneg.mp hf
+    positivity)
+  rw [map_mul, map_pow, P'.ord_mul (pow_ne_zero _ hmap0) hmapt0, P'.ord_pow] at hpos
+  have hle : (m : ℤ) * P'.ord (algebraMap F F' f) ≤ -(m : ℤ) := by
+    have : P'.ord (algebraMap F F' f) ≤ -1 := by omega
+    nlinarith [Int.natCast_nonneg m]
+  omega
+
+/-- **`P' ∣ P` by the scaling of orders** (Stichtenoth, Proposition 3.1.4): the place `P'` lies
+over `P` exactly when the order function at `P'` is a positive multiple of the order function at
+`P` along `F`, and the multiple is then the ramification index. -/
+theorem restrict_eq_iff_exists_ord_eq (P : Place k F) :
+    P'.restrict k F = P ↔
+      ∃ e : ℕ, 0 < e ∧ ∀ f : F, P'.ord (algebraMap F F' f) = e * P.ord f := by
+  refine ⟨fun h ↦ ⟨ramificationIdx F P', ramificationIdx_pos F P', fun f ↦ ?_⟩, ?_⟩
+  · rw [ord_algebraMap_restrict k F P' f, h]
+  · rintro ⟨e, he, h⟩
+    rw [restrict_eq_iff_forall_ord_pos]
+    intro f hf
+    rw [h f]
+    exact mul_pos (by exact_mod_cast he) hf
+
+/-- The ramification index is the only positive scaling factor between the two order
+functions. -/
+theorem ramificationIdx_eq_of_forall_ord_eq {e : ℕ}
+    (h : ∀ f : F, P'.ord (algebraMap F F' f) = e * (P'.restrict k F).ord f) :
+    ramificationIdx F P' = e := by
+  obtain ⟨f, hf⟩ := (P'.restrict k F).ord_surjective 1
+  have h1 := h f
+  rw [ord_algebraMap_restrict k F P' f, hf] at h1
+  exact_mod_cast by omega
+
+end Restrict
+
+section ResidueField
+
+variable (k F) (P' : Place k' F') [Algebra.IsIntegral F F']
+
+/-- The valuation ring of the restriction is carried into the valuation ring of `P'`, so the
+latter is an algebra over the former. -/
+noncomputable instance instAlgebraIntegers : Algebra (P'.restrict k F).integers P'.integers :=
+  (((algebraMap F F').comp (algebraMap (P'.restrict k F).integers F)).codRestrict
+    P'.integers fun x ↦ (mem_integers_restrict_iff k F P' (x : F)).mp x.2).toAlgebra
+
+@[simp]
+theorem coe_algebraMap_integers (x : (P'.restrict k F).integers) :
+    ((algebraMap (P'.restrict k F).integers P'.integers x : P'.integers) : F') =
+      algebraMap F F' (x : F) := (rfl)
+
+instance : IsLocalHom (algebraMap (P'.restrict k F).integers P'.integers) where
+  map_nonunit a ha := by
+    have ha0 : (a : F) ≠ 0 := by
+      rintro h
+      rw [show a = 0 from Subtype.ext h] at ha
+      simp at ha
+    have hmap0 : algebraMap F F' (a : F) ≠ 0 := by simpa using ha0
+    have h1 : P'.ord (algebraMap F F' (a : F)) = 0 :=
+      (P'.isUnit_iff_ord_eq_zero (x := algebraMap _ P'.integers a) (by simpa using hmap0)).mp ha
+    rw [ord_algebraMap_restrict k F P' (a : F)] at h1
+    have he : (ramificationIdx F P' : ℤ) ≠ 0 := by
+      have := ramificationIdx_pos F P'
+      omega
+    exact ((P'.restrict k F).isUnit_iff_ord_eq_zero ha0).mpr
+      ((mul_eq_zero.mp h1).resolve_left he)
+
+/-- The **relative degree** `f(P' ∣ P) = [F'_{P'} : F_P]` of a place `P'` of `F' / k'` over the
+place `P` of `F / k` it lies over (Stichtenoth, Definition 3.1.5). -/
+noncomputable def relativeDegree : ℕ :=
+  Module.finrank (P'.restrict k F).ResidueField P'.ResidueField
+
+end ResidueField
+
+section Independence
+
+variable (k F) (P' : Place k' F') [Algebra.IsIntegral F F']
+
+private theorem valuation_lt_of_ord_lt {x y : F'} (hx : x ≠ 0) (hy : y ≠ 0)
+    (h : P'.ord y < P'.ord x) : P'.valuation x < P'.valuation y := by
+  rw [P'.valuation_eq_exp_neg_ord hx, P'.valuation_eq_exp_neg_ord hy, WithZero.exp_lt_exp]
+  omega
+
+private theorem eq_of_mul_add_natCast_eq {e : ℕ} {j j' : Fin e} {a b : ℤ}
+    (h : (e : ℤ) * a + (j : ℕ) = (e : ℤ) * b + (j' : ℕ)) : j = j' := by
+  have key : ∀ (m : ℤ) (l : Fin e), ((e : ℤ) * m + (l : ℕ)) % (e : ℤ) = (l : ℕ) := by
+    intro m l
+    rw [add_comm, Int.add_mul_emod_self_left]
+    exact Int.emod_eq_of_lt (Int.natCast_nonneg _) (by exact_mod_cast l.2)
+  have h' := congrArg (· % (e : ℤ)) h
+  simp only [key] at h'
+  exact Fin.ext (by exact_mod_cast h')
+
+/-- A combination of elements of `𝒪_{P'}` with coefficients in `𝒪_P`, one of them a unit, is a
+unit at `P'` as soon as the residues of the elements are independent over the residue field of
+`P`: its residue is the corresponding nontrivial combination of the residues. -/
+private theorem ord_sum_eq_zero {ι : Type*} [Fintype ι] (s : ι → P'.integers)
+    (hind : LinearIndependent (P'.restrict k F).ResidueField
+      fun i ↦ IsLocalRing.residue P'.integers (s i))
+    (b : ι → (P'.restrict k F).integers) {i₀ : ι} (hb₀ : IsUnit (b i₀)) :
+    (∑ i, algebraMap F F' (b i : F) * (s i : F')) ≠ 0 ∧
+      P'.ord (∑ i, algebraMap F F' (b i : F) * (s i : F')) = 0 := by
+  classical
+  set B : P'.integers := ∑ i, algebraMap _ P'.integers (b i) * s i with hB
+  have hcoe : (B : F') = ∑ i, algebraMap F F' (b i : F) * (s i : F') := by
+    rw [hB]
+    push_cast
+    simp
+  have hres : IsLocalRing.residue P'.integers B =
+      ∑ i, IsLocalRing.residue _ (b i) • IsLocalRing.residue P'.integers (s i) := by
+    rw [hB, map_sum]
+    refine Finset.sum_congr rfl fun i _ ↦ ?_
+    rw [map_mul, Algebra.smul_def, IsLocalRing.ResidueField.algebraMap_residue]
+  have hne : IsLocalRing.residue P'.integers B ≠ 0 := by
+    rw [hres]
+    intro h
+    have hz := Fintype.linearIndependent_iff.mp hind _ h i₀
+    rw [IsLocalRing.residue_eq_zero_iff, IsLocalRing.mem_maximalIdeal, mem_nonunits_iff] at hz
+    exact hz hb₀
+  have hB0 : (B : F') ≠ 0 := fun h ↦ hne (by
+    rw [show B = 0 from Subtype.ext h, map_zero])
+  have hunit : IsUnit B := by
+    by_contra hu
+    exact hne (by
+      rw [IsLocalRing.residue_eq_zero_iff, IsLocalRing.mem_maximalIdeal, mem_nonunits_iff]
+      exact hu)
+  refine ⟨hcoe ▸ hB0, ?_⟩
+  rw [← hcoe]
+  exact (P'.isUnit_iff_ord_eq_zero hB0).mp hunit
+
+/-- The order at `P'` of a nontrivial `F`-combination of elements of `𝒪_{P'}` with independent
+residues is a multiple of the ramification index: dividing by the coefficient of least order
+leaves a unit. -/
+private theorem exists_ord_sum_eq_mul {ι : Type*} [Fintype ι] (s : ι → P'.integers)
+    (hind : LinearIndependent (P'.restrict k F).ResidueField
+      fun i ↦ IsLocalRing.residue P'.integers (s i))
+    (c : ι → F) {i₁ : ι} (hi₁ : c i₁ ≠ 0) :
+    (∑ i, algebraMap F F' (c i) * (s i : F')) ≠ 0 ∧
+      ∃ m : ℤ, P'.ord (∑ i, algebraMap F F' (c i) * (s i : F')) = ramificationIdx F P' * m := by
+  classical
+  set P := P'.restrict k F with hP
+  set S : Finset ι := {i | c i ≠ 0} with hS
+  have hSne : S.Nonempty := ⟨i₁, by simp [hS, hi₁]⟩
+  obtain ⟨i₀, hi₀S, hi₀⟩ := S.exists_min_image (fun i ↦ P.ord (c i)) hSne
+  have hd : c i₀ ≠ 0 := by simpa [hS] using hi₀S
+  have hb : ∀ i, c i / c i₀ ∈ P.integers := by
+    intro i
+    rcases eq_or_ne (c i) 0 with h | h
+    · simp [h]
+    · rw [P.mem_integers_iff_ord_nonneg, P.ord_div h hd]
+      have := hi₀ i (by simp [hS, h])
+      omega
+  set b : ι → P.integers := fun i ↦ ⟨c i / c i₀, hb i⟩ with hbdef
+  have hb₀ : IsUnit (b i₀) := by
+    rw [show b i₀ = 1 from Subtype.ext (by simp [hbdef, div_self hd])]
+    exact isUnit_one
+  have hsum : ∑ i, algebraMap F F' (c i) * (s i : F') =
+      algebraMap F F' (c i₀) * ∑ i, algebraMap F F' (b i : F) * (s i : F') := by
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun i _ ↦ ?_
+    rw [← mul_assoc, ← map_mul]
+    congr 2
+    have hbi : ((b i : F)) = c i / c i₀ := rfl
+    rw [hbi]
+    field_simp
+  obtain ⟨hne, hord⟩ := ord_sum_eq_zero k F P' s hind b hb₀
+  have hd' : algebraMap F F' (c i₀) ≠ 0 := by simpa using hd
+  refine ⟨by rw [hsum]; exact mul_ne_zero hd' hne, ⟨P.ord (c i₀), ?_⟩⟩
+  rw [hsum, P'.ord_mul hd' hne, hord, add_zero, ord_algebraMap_restrict k F P' (c i₀)]
+
+/-- **The independence statement behind the fundamental inequality** (Stichtenoth,
+Theorem 3.1.11): if the residues at `P'` of finitely many elements of `𝒪_{P'}` are independent
+over the residue field of the place `P` below, and `t` is a prime element for `P'`, then the
+products of those elements with `t ^ j` for `0 ≤ j < e(P' ∣ P)` are independent over `F`. The
+reason is that the order at `P'` of an `F`-combination of the given elements is a multiple of
+`e(P' ∣ P)`, so the `e(P' ∣ P)` blocks have pairwise distinct orders. -/
+theorem linearIndependent_mul_pow_of_linearIndependent_residue {ι : Type*} [Finite ι]
+    (s : ι → P'.integers)
+    (hind : LinearIndependent (P'.restrict k F).ResidueField
+      fun i ↦ IsLocalRing.residue P'.integers (s i))
+    {t : F'} (ht : P'.ord t = 1) :
+    LinearIndependent F fun p : ι × Fin (ramificationIdx F P') ↦ (s p.1 : F') * t ^ (p.2 : ℕ) := by
+  classical
+  have _ : Fintype ι := Fintype.ofFinite ι
+  have ht0 : t ≠ 0 := by rintro rfl; simp at ht
+  set e := ramificationIdx F P' with he
+  rw [Fintype.linearIndependent_iff]
+  intro c hc
+  by_contra hex
+  rw [not_forall] at hex
+  obtain ⟨⟨i₁, j₁⟩, hp₁⟩ := hex
+  set A : Fin e → F' := fun j ↦ ∑ i, algebraMap F F' (c (i, j)) * (s i : F') with hA
+  have hkey : ∑ j : Fin e, A j * t ^ (j : ℕ) = 0 := by
+    rw [Fintype.sum_prod_type] at hc
+    have hstep : ∀ j : Fin e, A j * t ^ (j : ℕ) = ∑ i, c (i, j) • ((s i : F') * t ^ (j : ℕ)) := by
+      intro j
+      rw [hA, Finset.sum_mul]
+      exact Finset.sum_congr rfl fun i _ ↦ by rw [Algebra.smul_def, mul_assoc]
+    simp_rw [hstep]
+    rw [Finset.sum_comm]
+    simpa using hc
+  have hAord : ∀ j : Fin e, A j ≠ 0 → ∃ m : ℤ, P'.ord (A j) = (e : ℤ) * m := by
+    intro j hj
+    by_cases hall : ∀ i, c (i, j) = 0
+    · exact absurd (by simp [hA, hall]) hj
+    · obtain ⟨i, hi⟩ := not_forall.mp hall
+      exact (exists_ord_sum_eq_mul k F P' s hind (fun i ↦ c (i, j)) hi).2
+  have hTord : ∀ j : Fin e, A j ≠ 0 →
+      ∃ m : ℤ, P'.ord (A j * t ^ (j : ℕ)) = (e : ℤ) * m + (j : ℕ) := by
+    intro j hj
+    obtain ⟨m, hm⟩ := hAord j hj
+    exact ⟨m, by rw [P'.ord_mul hj (pow_ne_zero _ ht0), P'.ord_pow, ht, hm, mul_one]⟩
+  have hA₁ : A j₁ ≠ 0 :=
+    (exists_ord_sum_eq_mul k F P' s hind (fun i ↦ c (i, j₁)) (i₁ := i₁) hp₁).1
+  set J : Finset (Fin e) := {j | A j ≠ 0} with hJdef
+  have hJ : J.Nonempty := ⟨j₁, by simp [hJdef, hA₁]⟩
+  obtain ⟨j₀, hj₀J, hj₀⟩ := J.exists_min_image (fun j ↦ P'.ord (A j * t ^ (j : ℕ))) hJ
+  have hj₀A : A j₀ ≠ 0 := by simpa [hJdef] using hj₀J
+  have hj₀ne : A j₀ * t ^ (j₀ : ℕ) ≠ 0 := mul_ne_zero hj₀A (pow_ne_zero _ ht0)
+  have hlt : ∀ j ∈ (Finset.univ : Finset (Fin e)) \ {j₀},
+      P'.valuation (A j * t ^ (j : ℕ)) < P'.valuation (A j₀ * t ^ (j₀ : ℕ)) := by
+    intro j hj
+    simp only [Finset.mem_sdiff, Finset.mem_singleton] at hj
+    by_cases hAj : A j = 0
+    · rw [hAj, zero_mul, map_zero]
+      exact zero_lt_iff.mpr ((Valuation.ne_zero_iff _).mpr hj₀ne)
+    · have hjJ : j ∈ J := by simp [hJdef, hAj]
+      obtain ⟨m, hm⟩ := hTord j hAj
+      obtain ⟨m₀, hm₀⟩ := hTord j₀ hj₀A
+      have hne : P'.ord (A j * t ^ (j : ℕ)) ≠ P'.ord (A j₀ * t ^ (j₀ : ℕ)) := by
+        rw [hm, hm₀]
+        exact fun hcontra ↦ hj.2 (eq_of_mul_add_natCast_eq hcontra)
+      have hge := hj₀ j hjJ
+      exact valuation_lt_of_ord_lt P' (mul_ne_zero hAj (pow_ne_zero _ ht0)) hj₀ne
+        (by omega)
+  have hval := P'.valuation.map_sum_eq_of_lt (Finset.mem_univ j₀) hlt
+  rw [hkey, map_zero] at hval
+  exact (Valuation.ne_zero_iff _).mpr hj₀ne hval.symm
+
+end Independence
+
+section Bound
+
+variable (k F) (P' : Place k' F') [Algebra.IsIntegral F F'] [FiniteDimensional F F']
+
+private theorem rank_residueField_le :
+    Module.rank (P'.restrict k F).ResidueField P'.ResidueField ≤
+      (Module.finrank F F' / ramificationIdx F P' : ℕ) := by
+  classical
+  obtain ⟨t, ht⟩ := P'.exists_isUniformizer
+  rw [P'.isUniformizer_iff_ord_eq_one] at ht
+  refine rank_le fun S hS ↦ ?_
+  choose y hy using fun x : S ↦
+    IsLocalRing.residue_surjective (R := P'.integers) (x : P'.ResidueField)
+  have hind : LinearIndependent (P'.restrict k F).ResidueField
+      fun x : S ↦ IsLocalRing.residue P'.integers (y x) := by
+    simpa only [hy] using hS
+  have hcard := (linearIndependent_mul_pow_of_linearIndependent_residue k F P' y hind
+    ht).fintype_card_le_finrank
+  rw [Fintype.card_prod, Fintype.card_coe, Fintype.card_fin] at hcard
+  exact (Nat.le_div_iff_mul_le (ramificationIdx_pos F P')).mpr hcard
+
+/-- The residue field of a place is finite over the residue field of the place below it. -/
+instance finiteDimensional_residueField_restrict :
+    FiniteDimensional (P'.restrict k F).ResidueField P'.ResidueField :=
+  Module.rank_lt_aleph0_iff.mp
+    (lt_of_le_of_lt (rank_residueField_le k F P') (Cardinal.natCast_lt_aleph0))
+
+theorem one_le_relativeDegree : 1 ≤ relativeDegree k F P' :=
+  Module.finrank_pos
+
+/-- **The fundamental inequality at a single place** (Stichtenoth, Theorem 3.1.11 and
+Corollary 3.1.12): the ramification index times the relative degree of a place `P'` of `F' / k'`
+over the place of `F / k` it lies over is at most the degree of the extension. -/
+theorem ramificationIdx_mul_relativeDegree_le_finrank :
+    ramificationIdx F P' * relativeDegree k F P' ≤ Module.finrank F F' := by
+  calc ramificationIdx F P' * relativeDegree k F P'
+      ≤ ramificationIdx F P' * (Module.finrank F F' / ramificationIdx F P') :=
+        Nat.mul_le_mul_left _ (Module.finrank_le_of_rank_le (rank_residueField_le k F P'))
+    _ ≤ Module.finrank F F' := by
+        rw [mul_comm]
+        exact Nat.div_mul_le_self _ _
+
+theorem relativeDegree_le_finrank : relativeDegree k F P' ≤ Module.finrank F F' :=
+  le_trans (Nat.le_mul_of_pos_left _ (ramificationIdx_pos F P'))
+    (ramificationIdx_mul_relativeDegree_le_finrank k F P')
+
+include k in
+theorem ramificationIdx_le_finrank : ramificationIdx F P' ≤ Module.finrank F F' :=
+  le_trans (Nat.le_mul_of_pos_right _ (one_le_relativeDegree k F P'))
+    (ramificationIdx_mul_relativeDegree_le_finrank k F P')
+
+end Bound
+
+end Place
+
+end TauCeti
+

--- a/TauCeti/RingTheory/Valuation/Discrete/Normalize.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Normalize.lean
@@ -1,0 +1,247 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Valuation.Discrete.Order
+
+/-!
+# Normalizing a `ℤᵐ⁰`-valued valuation of a field
+
+The orders `ord_v f` attained by a `ℤᵐ⁰`-valued valuation `v` of a field form a subgroup of `ℤ`,
+so they are the multiples of a single natural number, the *index* `Valuation.ordIndex v`; it is
+zero exactly when `v` is trivial. Dividing the order by the index produces the *normalization*
+`Valuation.normalization v`: the valuation equivalent to `v` whose value group is all of `ℤᵐ⁰`
+(the trivial valuation, when `v` is trivial).
+
+This is the operation that turns the restriction of a discrete valuation along a field extension
+back into a normalized one, and the index it divides by is the ramification index of that
+extension.
+
+## Main definitions
+
+* `Valuation.ordIndex`: the least positive order attained by `v`, and `0` if there is none.
+* `Valuation.normalization`: the normalization of `v`.
+
+## Main results
+
+* `Valuation.ordIndex_dvd_ord`: every order attained by `v` is a multiple of the index.
+* `Valuation.ord_normalization_mul_ordIndex`: the order function of `v` is the index times the
+  order function of its normalization — the defining relation between the two.
+* `Valuation.isEquiv_normalization`: a valuation is equivalent to its normalization; in
+  particular the two have the same valuation subring.
+* `Valuation.normalization_surjective`: the normalization of a nontrivial valuation is
+  surjective.
+* `Valuation.IsTrivialOn.normalization`: normalization preserves triviality on a base ring.
+-/
+
+public section
+
+open scoped WithZero
+
+namespace Valuation
+
+variable {F : Type*} [Field F]
+
+section OrdIndex
+
+/-- The **index** of a `ℤᵐ⁰`-valued valuation of a field: the least positive order it attains,
+and `0` when the valuation is trivial. The orders attained by `v` are exactly the multiples of
+the index (`Valuation.ordIndex_dvd_ord` and `Valuation.exists_ord_eq_ordIndex`). -/
+noncomputable def ordIndex (v : _root_.Valuation F ℤᵐ⁰) : ℕ :=
+  sInf {n : ℕ | 0 < n ∧ ∃ f : F, ord v f = n}
+
+variable (v : _root_.Valuation F ℤᵐ⁰)
+
+theorem ordIndex_le {n : ℕ} (hn : 0 < n) {f : F} (hf : ord v f = n) : ordIndex v ≤ n :=
+  Nat.sInf_le ⟨hn, f, hf⟩
+
+private theorem ordSet_nonempty {f : F} (hf : ord v f ≠ 0) :
+    {n : ℕ | 0 < n ∧ ∃ g : F, ord v g = n}.Nonempty := by
+  rcases lt_or_gt_of_ne hf with h | h
+  · exact ⟨(-ord v f).toNat, by omega, f⁻¹, by rw [ord_inv]; omega⟩
+  · exact ⟨(ord v f).toNat, by omega, f, by omega⟩
+
+/-- A valuation attaining a nonzero order has positive index. -/
+theorem ordIndex_pos {f : F} (hf : ord v f ≠ 0) : 0 < ordIndex v :=
+  (Nat.sInf_mem (ordSet_nonempty v hf)).1
+
+/-- A nontrivial valuation attains its index as an order. -/
+theorem exists_ord_eq_ordIndex (hv : ordIndex v ≠ 0) : ∃ f : F, ord v f = ordIndex v := by
+  have hS : {n : ℕ | 0 < n ∧ ∃ g : F, ord v g = n}.Nonempty := by
+    by_contra h
+    rw [Set.not_nonempty_iff_eq_empty] at h
+    exact hv (by rw [ordIndex, h, Nat.sInf_empty])
+  exact (Nat.sInf_mem hS).2
+
+/-- The index vanishes exactly for the trivial valuations. -/
+theorem ordIndex_eq_zero_iff : ordIndex v = 0 ↔ ∀ f : F, ord v f = 0 := by
+  refine ⟨fun h f ↦ ?_, fun h ↦ ?_⟩
+  · by_contra hf
+    have := ordIndex_pos v hf
+    omega
+  · by_contra hne
+    obtain ⟨f, hf⟩ := exists_ord_eq_ordIndex v hne
+    rw [h f] at hf
+    omega
+
+/-- **Every order attained by a valuation is a multiple of its index.** -/
+theorem ordIndex_dvd_ord (f : F) : (ordIndex v : ℤ) ∣ ord v f := by
+  rcases eq_or_ne (ordIndex v) 0 with h | h
+  · simp [h, (ordIndex_eq_zero_iff v).mp h f]
+  obtain ⟨t, ht⟩ := exists_ord_eq_ordIndex v h
+  have ht0 : t ≠ 0 := by
+    rintro rfl
+    rw [ord_zero] at ht
+    omega
+  have he : (0 : ℤ) < (ordIndex v : ℤ) := by omega
+  refine Int.dvd_of_emod_eq_zero (by_contra fun hr ↦ ?_)
+  have hr0 : 0 < ord v f % (ordIndex v : ℤ) :=
+    lt_of_le_of_ne (Int.emod_nonneg _ (by omega)) (Ne.symm hr)
+  have hrlt : ord v f % (ordIndex v : ℤ) < (ordIndex v : ℤ) := Int.emod_lt_of_pos _ he
+  have hf0 : f ≠ 0 := by
+    rintro rfl
+    rw [ord_zero] at hr0
+    simp at hr0
+  have hord : ord v (f / t ^ (ord v f / (ordIndex v : ℤ))) = ord v f % (ordIndex v : ℤ) := by
+    rw [ord_div_zpow v hf0 ht0, ht, Int.emod_def]
+    ring
+  have := ordIndex_le v (n := (ord v f % (ordIndex v : ℤ)).toNat) (by omega)
+    (f := f / t ^ (ord v f / (ordIndex v : ℤ))) (by rw [hord]; omega)
+  omega
+
+end OrdIndex
+
+section Normalization
+
+variable (v : _root_.Valuation F ℤᵐ⁰)
+
+private theorem ediv_ordIndex_add (f g : F) :
+    (ord v f + ord v g) / (ordIndex v : ℤ) =
+      ord v f / (ordIndex v : ℤ) + ord v g / (ordIndex v : ℤ) := by
+  rcases eq_or_ne (ordIndex v) 0 with h | h
+  · simp [h]
+  · have he : (ordIndex v : ℤ) ≠ 0 := by exact_mod_cast h
+    obtain ⟨a, ha⟩ := ordIndex_dvd_ord v f
+    obtain ⟨b, hb⟩ := ordIndex_dvd_ord v g
+    rw [ha, hb, ← mul_add, Int.mul_ediv_cancel_left _ he, Int.mul_ediv_cancel_left _ he,
+      Int.mul_ediv_cancel_left _ he]
+
+private theorem ediv_ordIndex_mono {a b : ℤ} (h : a ≤ b) :
+    a / (ordIndex v : ℤ) ≤ b / (ordIndex v : ℤ) := by
+  rcases eq_or_ne (ordIndex v) 0 with h0 | h0
+  · simp [h0]
+  · exact Int.ediv_le_ediv (by omega) h
+
+open scoped Classical in
+/-- The **normalization** of a `ℤᵐ⁰`-valued valuation of a field: the valuation whose order
+function is the order function of `v` divided by the index `Valuation.ordIndex v`. It is
+equivalent to `v` and, as soon as `v` is nontrivial, surjective. -/
+noncomputable def normalization : _root_.Valuation F ℤᵐ⁰ where
+  toFun f := if f = 0 then 0 else WithZero.exp (-(ord v f / (ordIndex v : ℤ)))
+  map_zero' := by simp
+  map_one' := by simp
+  map_mul' f g := by
+    rcases eq_or_ne f 0 with rfl | hf
+    · simp
+    rcases eq_or_ne g 0 with rfl | hg
+    · simp
+    have hfg : f * g ≠ 0 := mul_ne_zero hf hg
+    rw [ord_mul v hf hg, ediv_ordIndex_add, neg_add, WithZero.exp_add]
+    simp [hf, hg, hfg]
+  map_add_le_max' f g := by
+    rcases eq_or_ne f 0 with rfl | hf
+    · simp
+    rcases eq_or_ne g 0 with rfl | hg
+    · simp
+    rcases eq_or_ne (f + g) 0 with h0 | h0
+    · simp [h0]
+    have hmin := min_ord_le_ord_add v h0
+    simp only [hf, hg, h0, ite_false]
+    rcases le_total (ord v f) (ord v g) with h | h
+    · refine le_trans ?_ (le_max_left _ _)
+      rw [WithZero.exp_le_exp, neg_le_neg_iff]
+      refine ediv_ordIndex_mono v ?_
+      rw [← min_eq_left h]
+      exact hmin
+    · refine le_trans ?_ (le_max_right _ _)
+      rw [WithZero.exp_le_exp, neg_le_neg_iff]
+      refine ediv_ordIndex_mono v ?_
+      rw [← min_eq_right h]
+      exact hmin
+
+theorem normalization_apply {f : F} (hf : f ≠ 0) :
+    normalization v f = WithZero.exp (-(ord v f / (ordIndex v : ℤ))) := by
+  classical
+  simp only [normalization, Valuation.coe_mk, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk, hf,
+    ite_false]
+
+@[simp]
+theorem ord_normalization (f : F) : ord (normalization v) f = ord v f / (ordIndex v : ℤ) := by
+  rcases eq_or_ne f 0 with rfl | hf
+  · simp
+  · rw [ord_def, normalization_apply v hf, WithZero.log_exp, neg_neg]
+
+/-- **The defining relation between a valuation and its normalization**: the order function of
+`v` is the index times the order function of `normalization v`. -/
+theorem ord_normalization_mul_ordIndex (f : F) :
+    ord (normalization v) f * (ordIndex v : ℤ) = ord v f := by
+  rw [ord_normalization]
+  rcases eq_or_ne (ordIndex v) 0 with h | h
+  · simp [h, (ordIndex_eq_zero_iff v).mp h f]
+  · exact Int.ediv_mul_cancel (ordIndex_dvd_ord v f)
+
+theorem ord_normalization_nonneg_iff {f : F} : 0 ≤ ord (normalization v) f ↔ 0 ≤ ord v f := by
+  rcases eq_or_ne (ordIndex v) 0 with h | h
+  · simp [h, (ordIndex_eq_zero_iff v).mp h f]
+  · rw [← ord_normalization_mul_ordIndex v f]
+    exact (mul_nonneg_iff_of_pos_right (by omega)).symm
+
+/-- A valuation is equivalent to its normalization. -/
+theorem isEquiv_normalization : (normalization v).IsEquiv v := by
+  rw [isEquiv_iff_val_le_one]
+  intro f
+  rw [← _root_.Valuation.mem_valuationSubring_iff, ← _root_.Valuation.mem_valuationSubring_iff,
+    mem_valuationSubring_iff_ord_nonneg, mem_valuationSubring_iff_ord_nonneg]
+  exact ord_normalization_nonneg_iff v
+
+@[simp]
+theorem valuationSubring_normalization :
+    (normalization v).valuationSubring = v.valuationSubring :=
+  (isEquiv_iff_valuationSubring _ _).mp (isEquiv_normalization v)
+
+/-- The normalization of a nontrivial valuation is surjective: its value group is all of
+`ℤᵐ⁰`. -/
+theorem normalization_surjective (hv : ordIndex v ≠ 0) :
+    Function.Surjective (normalization v) := by
+  obtain ⟨t, ht⟩ := exists_ord_eq_ordIndex v hv
+  have ht0 : t ≠ 0 := by
+    rintro rfl
+    rw [ord_zero] at ht
+    omega
+  have he : (ordIndex v : ℤ) ≠ 0 := by exact_mod_cast hv
+  intro x
+  induction x using WithZero.expRecOn with
+  | zero => exact ⟨0, map_zero _⟩
+  | exp n =>
+    refine ⟨t ^ (-n), ?_⟩
+    rw [normalization_apply v (zpow_ne_zero _ ht0), ord_zpow, ht,
+      Int.mul_ediv_cancel _ he, neg_neg]
+
+/-- Normalization preserves triviality on a base ring. -/
+theorem IsTrivialOn.normalization {A : Type*} [CommRing A] [Algebra A F]
+    [v.IsTrivialOn A] : (_root_.Valuation.normalization v).IsTrivialOn A where
+  eq_one a ha := by
+    have h1 : v (algebraMap A F a) = 1 := IsTrivialOn.eq_one a ha
+    have h0 : algebraMap A F a ≠ 0 := by
+      rintro h
+      rw [h, map_zero] at h1
+      exact zero_ne_one h1
+    rw [normalization_apply v h0, ord_def, h1]
+    simp
+
+end Normalization
+
+end Valuation


### PR DESCRIPTION
This PR opens the extension theory of places of algebraic function fields: it restricts a place of `F' / k'` to a subfield `F`, defines the ramification index `e(P' ∣ P)` and the relative degree `f(P' ∣ P) = [F'_{P'} : F_P]`, characterizes `P' ∣ P` in the three equivalent ways of the source, and proves the bound `e(P' ∣ P) · f(P' ∣ P) ≤ [F' : F]`.

The roadmap target is `TauCetiRoadmap/AlgebraicCurves/README.md`, Layer 6, "Extensions of function fields", first bullet ("Setup"): "`P′ ∣ P` characterized three ways (Prop. 3.1.4: `P ⊆ P′` ⟺ `𝒪_P ⊆ 𝒪_{P′}` ⟺ `v_{P′}|_F = e · v_P`), defining `e(P′∣P)` and `f(P′∣P)` (Def. 3.1.5)", together with "each place of `F′` lies over exactly one place of `F`" from that bullet's Proposition 3.1.7 and the per-place half of "Corollaries: `#{P′ ∣ P}, e, f ≤ [F′ : F]` (Cor. 3.1.12)". The milestone this serves is Layer 6 itself, whose summit is the fundamental identity `∑_{P′ ∣ P} e(P′∣P) · f(P′∣P) = [F′ : F]` (Stichtenoth Theorem 3.1.11): after this PR the identity's two sides are both expressible and the inequality holds one place at a time, and what remains for the identity is the summation over the places above a fixed `P` — for which the roadmap prescribes the affine-model reconciliation `e = Ideal.ramificationIdx`, `f = Ideal.inertiaDeg` and `Ideal.sum_ramification_inertia` — together with Proposition 3.1.7's existence half (a place of `F` has at least one extension to `F'`), which needs the Zorn-theoretic Theorem 1.1.19 of the open PR #4213.

Why this step now. The AlgebraicCurves critical path runs Layer 3 → Layer 4 (Riemann–Roch), and Layer 3's own gate, the divisor type `Divisor k F` and the finiteness of zeros and poles, is in flight in #4272 and #4249; every Layer-3 statement needs those types, so nothing there can be written against current `main` without duplicating them. Layer 6 is the roadmap's designated parallel branch ("Layer 6 (extensions) needs Layers 0–3 but **not** RR, so it can proceed in parallel"), and this particular part of its Setup bullet needs only Layer 0 — places, orders, residue fields — all of which is on `main`. Nothing in the open-PR list touches extensions of places, ramification indices, or relative degrees.

Relation to #4249, stated explicitly because the mathematics is adjacent. That PR proves Stichtenoth Proposition 1.3.3, `∑ᵢ ord_{Pᵢ}(x) · deg Pᵢ ≤ [F : k(x)]`, which is the *summed* form of the present inequality over the places above the zero place of `k(x)`. The statements here are different — a single place `P'` over an arbitrary base place, rather than a finite family over a place of a rational function field — and neither is used in the other's proof; the shared ingredient is only Stichtenoth's linear-independence device, which each PR runs in its own setting. Once both have landed, the natural follow-up is to derive the general summed inequality and specialize it back.

Added, in `TauCeti/FieldTheory/FunctionField/Place/Extension.lean` (476 lines): `TauCeti.Place.restrict`, the place of `F / k` that `P'` lies over, resting on `TauCeti.Place.isTrivialOn_comap` and `TauCeti.Place.ordIndex_comap_ne_zero` (a valuation ring of `F'` containing `F` would be all of `F'`, because it is integrally closed and `F'` is algebraic over `F`); `TauCeti.Place.ramificationIdx` with its defining property `TauCeti.Place.ord_algebraMap_restrict` and its uniqueness `TauCeti.Place.ramificationIdx_eq_of_forall_ord_eq`; the three characterizations `TauCeti.Place.restrict_eq_iff_integers_le`, `TauCeti.Place.restrict_eq_iff_forall_ord_pos` and `TauCeti.Place.restrict_eq_iff_exists_ord_eq` (Proposition 3.1.4), which say in particular that `P'` lies over exactly one place of `F`; the algebra `𝒪_P → 𝒪_{P'}` with its `IsLocalHom` instance, whence Mathlib's residue-field algebra and the definition `TauCeti.Place.relativeDegree`; `TauCeti.Place.linearIndependent_mul_pow_of_linearIndependent_residue`, the independence statement — elements of `𝒪_{P'}` with `F_P`-independent residues, times `t ^ j` for `0 ≤ j < e` and `t` a prime element for `P'`, are independent over `F`, because an `F`-combination of the given elements has order divisible by `e` at `P'` (divide by the coefficient of least order; what remains is a unit, since its residue is a nontrivial `F_P`-combination of independent residues), so the `e` blocks have pairwise distinct orders modulo `e`; and finally `TauCeti.Place.ramificationIdx_mul_relativeDegree_le_finrank` with `TauCeti.Place.ramificationIdx_le_finrank`, `TauCeti.Place.relativeDegree_le_finrank`, and the instance `TauCeti.Place.finiteDimensional_residueField_restrict` that keeps `relativeDegree` clear of the junk value of `Module.finrank`.

Added, in `TauCeti/RingTheory/Valuation/Discrete/Normalize.lean` (247 lines): the normalization operation the restriction needs, stated where it belongs, about valuations rather than about places. The orders attained by a `ℤᵐ⁰`-valued valuation of a field form a subgroup of `ℤ`, so `Valuation.ordIndex v`, the least positive order attained (and `0` for a trivial valuation), divides every order (`Valuation.ordIndex_dvd_ord`); `Valuation.normalization v` divides the order function by it, and `Valuation.ord_normalization_mul_ordIndex`, `Valuation.isEquiv_normalization`, `Valuation.normalization_surjective` and `Valuation.IsTrivialOn.normalization` are what a `TauCeti.Place` asks for. This sits beside the existing `TauCeti/RingTheory/Valuation/Discrete/Order.lean`, whose `Valuation.ord` API it extends; a place-theoretic home would have hidden a general fact about discrete valuations inside the function-field theory.

Two changes to existing files, both relocations rather than new mathematics. `TauCeti.Place.mem_integers_of_isIntegral` — the valuation ring of a place is integrally closed in `F` — moves from `AffineModel/Place.lean` to `Place/Basic.lean`: it mentions no affine model, and the nontriviality of a restricted valuation consumes it, so leaving it where it was would have forced the extension theory to import the Dedekind-domain layer. `Place/Basic.lean` also gains `TauCeti.Place.eq_of_integers_le`, the containment form of Stichtenoth Theorem 1.1.13(d) — a place whose valuation ring contains the valuation ring of another place is that place, because a valuation ring properly containing one is all of `F` — which is the Layer-0 statement "valuation rings are maximal proper subrings of `F`" listed in that layer's places bullet, and is what turns the containment `𝒪_P ⊆ 𝒪_{P'}` into the equality `P = P'.restrict k F`.

No Mathlib source is vendored, and no code is adapted from any external formalization; the roadmap's coordination section records that this roadmap specifies the mathematics rather than the code of `vaca22/riemann-roch-function-fields`. The valuation-theoretic inputs are Mathlib's `Valuation.HasExtension` (which supplies the residue-field algebra once the restriction is known to be equivalent to the comap), `Valuation.map_sum_eq_of_lt`, `IsLocalRing.ResidueField.algebraMap_residue`, `Module.rank_le` and `Module.rank_lt_aleph0_iff`.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"place-ramification-index-relative-degree"}-->

🤖 Prepared with Claude Code
