### PR TITLE
feat: represent the GL2 dynamic subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Functor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Functor.lean
@@ -50,21 +50,21 @@ variable {R : Type u} [CommRing R]
 variable {H : Type v} [CommRing H] [HopfAlgebra R H]
 
 /-- Change of value algebra, restricted to a dynamic parabolic subgroup. -/
-@[expose] noncomputable def mapParabolic (l : H →ₐc[R] LaurentPolynomial R)
+noncomputable def mapParabolic (l : H →ₐc[R] LaurentPolynomial R)
     {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     parabolic A l →* parabolic B l :=
   ((AlgHom.mapValue (H := H) φ.hom).domRestrict (parabolic A l)).codRestrict
     (parabolic B l) fun g ↦ parabolic_le_comap φ.hom g.2
 
 /-- Change of value algebra, restricted to a dynamic Levi subgroup. -/
-@[expose] noncomputable def mapLevi (l : H →ₐc[R] LaurentPolynomial R)
+noncomputable def mapLevi (l : H →ₐc[R] LaurentPolynomial R)
     {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     levi A l →* levi B l :=
   ((AlgHom.mapValue (H := H) φ.hom).domRestrict (levi A l)).codRestrict
     (levi B l) fun g ↦ levi_le_comap φ.hom g.2
 
 /-- Change of value algebra, restricted to a dynamic unipotent subgroup. -/
-@[expose] noncomputable def mapUnipotent (l : H →ₐc[R] LaurentPolynomial R)
+noncomputable def mapUnipotent (l : H →ₐc[R] LaurentPolynomial R)
     {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
     unipotent A l →* unipotent B l :=
   ((AlgHom.mapValue (H := H) φ.hom).domRestrict (unipotent A l)).codRestrict
@@ -74,21 +74,22 @@ variable {H : Type v} [CommRing H] [HopfAlgebra R H]
 theorem coe_mapParabolic_apply (l : H →ₐc[R] LaurentPolynomial R)
     {A B : CommAlgCat.{w} R} (φ : A ⟶ B) (g : parabolic A l) :
     (mapParabolic l φ g : WithConv (H →ₐ[R] B)) = AlgHom.mapValue φ.hom g :=
-  rfl
+  by unfold mapParabolic; rfl
 
 @[simp]
 theorem coe_mapLevi_apply (l : H →ₐc[R] LaurentPolynomial R)
     {A B : CommAlgCat.{w} R} (φ : A ⟶ B) (g : levi A l) :
     (mapLevi l φ g : WithConv (H →ₐ[R] B)) = AlgHom.mapValue φ.hom g :=
-  rfl
+  by unfold mapLevi; rfl
 
 @[simp]
 theorem coe_mapUnipotent_apply (l : H →ₐc[R] LaurentPolynomial R)
     {A B : CommAlgCat.{w} R} (φ : A ⟶ B) (g : unipotent A l) :
     (mapUnipotent l φ g : WithConv (H →ₐ[R] B)) = AlgHom.mapValue φ.hom g :=
-  rfl
+  by unfold mapUnipotent; rfl
 
 /-- The dynamic parabolic attached to a cocharacter, as a group-valued functor. -/
+-- The object carrier must unfold when downstream modules construct natural transformations.
 @[expose] noncomputable def parabolicFunctor (l : H →ₐc[R] LaurentPolynomial R) :
     CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := GrpCat.of (parabolic A l)
@@ -97,6 +98,7 @@ theorem coe_mapUnipotent_apply (l : H →ₐc[R] LaurentPolynomial R)
   map_comp _ _ := by ext; rfl
 
 /-- The dynamic Levi attached to a cocharacter, as a group-valued functor. -/
+-- The object carrier must unfold when downstream modules construct natural transformations.
 @[expose] noncomputable def leviFunctor (l : H →ₐc[R] LaurentPolynomial R) :
     CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := GrpCat.of (levi A l)
@@ -105,6 +107,7 @@ theorem coe_mapUnipotent_apply (l : H →ₐc[R] LaurentPolynomial R)
   map_comp _ _ := by ext; rfl
 
 /-- The dynamic unipotent subgroup attached to a cocharacter, as a group-valued functor. -/
+-- The object carrier must unfold when downstream modules construct natural transformations.
 @[expose] noncomputable def unipotentFunctor (l : H →ₐc[R] LaurentPolynomial R) :
     CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := GrpCat.of (unipotent A l)
@@ -112,17 +115,14 @@ theorem coe_mapUnipotent_apply (l : H →ₐc[R] LaurentPolynomial R)
   map_id _ := by ext; rfl
   map_comp _ _ := by ext; rfl
 
-@[simp]
 theorem parabolicFunctor_obj (l : H →ₐc[R] LaurentPolynomial R) (A : CommAlgCat.{w} R) :
     (parabolicFunctor l).obj A = GrpCat.of (parabolic A l) :=
   rfl
 
-@[simp]
 theorem leviFunctor_obj (l : H →ₐc[R] LaurentPolynomial R) (A : CommAlgCat.{w} R) :
     (leviFunctor l).obj A = GrpCat.of (levi A l) :=
   rfl
 
-@[simp]
 theorem unipotentFunctor_obj (l : H →ₐc[R] LaurentPolynomial R)
     (A : CommAlgCat.{w} R) :
     (unipotentFunctor l).obj A = GrpCat.of (unipotent A l) :=
@@ -147,39 +147,57 @@ theorem unipotentFunctor_map (l : H →ₐc[R] LaurentPolynomial R)
   rfl
 
 /-- The dynamic parabolic functor includes naturally into the ambient functor of points. -/
-@[expose] noncomputable def parabolicFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
+noncomputable def parabolicFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
     parabolicFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
   app A := GrpCat.ofHom (parabolic A l).subtype
-  naturality _ _ _ := by ext; rfl
+  naturality {A B} φ := by
+    change GrpCat.ofHom (mapParabolic l φ) ≫ GrpCat.ofHom (parabolic B l).subtype =
+      GrpCat.ofHom (parabolic A l).subtype ≫ HopfAlgebra.mapPoints (H := H) φ
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    exact coe_mapParabolic_apply l φ g
 
 /-- The dynamic Levi functor includes naturally into the ambient functor of points. -/
-@[expose] noncomputable def leviFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
+noncomputable def leviFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
     leviFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
   app A := GrpCat.ofHom (levi A l).subtype
-  naturality _ _ _ := by ext; rfl
+  naturality {A B} φ := by
+    change GrpCat.ofHom (mapLevi l φ) ≫ GrpCat.ofHom (levi B l).subtype =
+      GrpCat.ofHom (levi A l).subtype ≫ HopfAlgebra.mapPoints (H := H) φ
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    exact coe_mapLevi_apply l φ g
 
 /-- The dynamic unipotent functor includes naturally into the ambient functor of points. -/
-@[expose] noncomputable def unipotentFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
+noncomputable def unipotentFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
     unipotentFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
   app A := GrpCat.ofHom (unipotent A l).subtype
-  naturality _ _ _ := by ext; rfl
+  naturality {A B} φ := by
+    change GrpCat.ofHom (mapUnipotent l φ) ≫ GrpCat.ofHom (unipotent B l).subtype =
+      GrpCat.ofHom (unipotent A l).subtype ≫ HopfAlgebra.mapPoints (H := H) φ
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    exact coe_mapUnipotent_apply l φ g
 
 @[simp]
 theorem parabolicFunctorIncl_app (l : H →ₐc[R] LaurentPolynomial R)
     (A : CommAlgCat.{w} R) :
     (parabolicFunctorIncl l).app A = GrpCat.ofHom (parabolic A l).subtype :=
-  rfl
+  by unfold parabolicFunctorIncl; rfl
 
 @[simp]
 theorem leviFunctorIncl_app (l : H →ₐc[R] LaurentPolynomial R)
     (A : CommAlgCat.{w} R) :
     (leviFunctorIncl l).app A = GrpCat.ofHom (levi A l).subtype :=
-  rfl
+  by unfold leviFunctorIncl; rfl
 
 @[simp]
 theorem unipotentFunctorIncl_app (l : H →ₐc[R] LaurentPolynomial R)
     (A : CommAlgCat.{w} R) :
     (unipotentFunctorIncl l).app A = GrpCat.ofHom (unipotent A l).subtype :=
-  rfl
+  by unfold unipotentFunctorIncl; rfl
 
 end TauCeti.Cocharacter

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Functor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Functor.lean
@@ -151,6 +151,7 @@ noncomputable def parabolicFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
     parabolicFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
   app A := GrpCat.ofHom (parabolic A l).subtype
   naturality {A B} φ := by
+    -- Expose the restricted point map and subgroup inclusion beneath `GrpCat` composition.
     change GrpCat.ofHom (mapParabolic l φ) ≫ GrpCat.ofHom (parabolic B l).subtype =
       GrpCat.ofHom (parabolic A l).subtype ≫ HopfAlgebra.mapPoints (H := H) φ
     apply GrpCat.hom_ext
@@ -163,6 +164,7 @@ noncomputable def leviFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
     leviFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
   app A := GrpCat.ofHom (levi A l).subtype
   naturality {A B} φ := by
+    -- Expose the restricted point map and subgroup inclusion beneath `GrpCat` composition.
     change GrpCat.ofHom (mapLevi l φ) ≫ GrpCat.ofHom (levi B l).subtype =
       GrpCat.ofHom (levi A l).subtype ≫ HopfAlgebra.mapPoints (H := H) φ
     apply GrpCat.hom_ext
@@ -175,6 +177,7 @@ noncomputable def unipotentFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
     unipotentFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
   app A := GrpCat.ofHom (unipotent A l).subtype
   naturality {A B} φ := by
+    -- Expose the restricted point map and subgroup inclusion beneath `GrpCat` composition.
     change GrpCat.ofHom (mapUnipotent l φ) ≫ GrpCat.ofHom (unipotent B l).subtype =
       GrpCat.ofHom (unipotent A l).subtype ≫ HopfAlgebra.mapPoints (H := H) φ
     apply GrpCat.hom_ext

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Functor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Functor.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Dynamic.Parabolic
+public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
+
+/-!
+# Dynamic subgroup functors
+
+The dynamic parabolic, Levi, and unipotent subgroups attached to a cocharacter are defined on
+points in `TauCeti.Algebra.AlgebraicGroup.Dynamic.Parabolic`. Their change-of-value-algebra
+theorems make these families into group-valued functors. This file packages those functors and
+their natural inclusions into the ambient functor of points.
+
+The packaging is the interface needed to state representability. In particular, a dynamic
+subgroup is represented by an affine group scheme precisely when its functor below is naturally
+isomorphic to the functor of points of a commutative Hopf algebra.
+
+## Main declarations
+
+* `TauCeti.Cocharacter.parabolicFunctor`: the dynamic parabolic as a group-valued functor.
+* `TauCeti.Cocharacter.leviFunctor`: the dynamic Levi as a group-valued functor.
+* `TauCeti.Cocharacter.unipotentFunctor`: the dynamic unipotent subgroup as a group-valued
+  functor.
+* `TauCeti.Cocharacter.parabolicFunctorIncl`, `leviFunctorIncl`, and `unipotentFunctorIncl`:
+  their natural inclusions into the ambient functor of points.
+
+## References
+
+* G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 13.
+
+This is the functorial interface for the dynamic approach to parabolic, Levi, and unipotent
+subgroups in Layer 7, "Structure theory", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.Cocharacter
+
+universe u v w
+
+variable {R : Type u} [CommRing R]
+variable {H : Type v} [CommRing H] [HopfAlgebra R H]
+
+/-- Change of value algebra, restricted to a dynamic parabolic subgroup. -/
+@[expose] noncomputable def mapParabolic (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    parabolic A l →* parabolic B l :=
+  ((AlgHom.mapValue (H := H) φ.hom).domRestrict (parabolic A l)).codRestrict
+    (parabolic B l) fun g ↦ parabolic_le_comap φ.hom g.2
+
+/-- Change of value algebra, restricted to a dynamic Levi subgroup. -/
+@[expose] noncomputable def mapLevi (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    levi A l →* levi B l :=
+  ((AlgHom.mapValue (H := H) φ.hom).domRestrict (levi A l)).codRestrict
+    (levi B l) fun g ↦ levi_le_comap φ.hom g.2
+
+/-- Change of value algebra, restricted to a dynamic unipotent subgroup. -/
+@[expose] noncomputable def mapUnipotent (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    unipotent A l →* unipotent B l :=
+  ((AlgHom.mapValue (H := H) φ.hom).domRestrict (unipotent A l)).codRestrict
+    (unipotent B l) fun g ↦ unipotent_le_comap φ.hom g.2
+
+@[simp]
+theorem coe_mapParabolic_apply (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) (g : parabolic A l) :
+    (mapParabolic l φ g : WithConv (H →ₐ[R] B)) = AlgHom.mapValue φ.hom g :=
+  rfl
+
+@[simp]
+theorem coe_mapLevi_apply (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) (g : levi A l) :
+    (mapLevi l φ g : WithConv (H →ₐ[R] B)) = AlgHom.mapValue φ.hom g :=
+  rfl
+
+@[simp]
+theorem coe_mapUnipotent_apply (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) (g : unipotent A l) :
+    (mapUnipotent l φ g : WithConv (H →ₐ[R] B)) = AlgHom.mapValue φ.hom g :=
+  rfl
+
+/-- The dynamic parabolic attached to a cocharacter, as a group-valued functor. -/
+@[expose] noncomputable def parabolicFunctor (l : H →ₐc[R] LaurentPolynomial R) :
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
+  obj A := GrpCat.of (parabolic A l)
+  map φ := GrpCat.ofHom (mapParabolic l φ)
+  map_id _ := by ext; rfl
+  map_comp _ _ := by ext; rfl
+
+/-- The dynamic Levi attached to a cocharacter, as a group-valued functor. -/
+@[expose] noncomputable def leviFunctor (l : H →ₐc[R] LaurentPolynomial R) :
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
+  obj A := GrpCat.of (levi A l)
+  map φ := GrpCat.ofHom (mapLevi l φ)
+  map_id _ := by ext; rfl
+  map_comp _ _ := by ext; rfl
+
+/-- The dynamic unipotent subgroup attached to a cocharacter, as a group-valued functor. -/
+@[expose] noncomputable def unipotentFunctor (l : H →ₐc[R] LaurentPolynomial R) :
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
+  obj A := GrpCat.of (unipotent A l)
+  map φ := GrpCat.ofHom (mapUnipotent l φ)
+  map_id _ := by ext; rfl
+  map_comp _ _ := by ext; rfl
+
+@[simp]
+theorem parabolicFunctor_obj (l : H →ₐc[R] LaurentPolynomial R) (A : CommAlgCat.{w} R) :
+    (parabolicFunctor l).obj A = GrpCat.of (parabolic A l) :=
+  rfl
+
+@[simp]
+theorem leviFunctor_obj (l : H →ₐc[R] LaurentPolynomial R) (A : CommAlgCat.{w} R) :
+    (leviFunctor l).obj A = GrpCat.of (levi A l) :=
+  rfl
+
+@[simp]
+theorem unipotentFunctor_obj (l : H →ₐc[R] LaurentPolynomial R)
+    (A : CommAlgCat.{w} R) :
+    (unipotentFunctor l).obj A = GrpCat.of (unipotent A l) :=
+  rfl
+
+@[simp]
+theorem parabolicFunctor_map (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    (parabolicFunctor l).map φ = GrpCat.ofHom (mapParabolic l φ) :=
+  rfl
+
+@[simp]
+theorem leviFunctor_map (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    (leviFunctor l).map φ = GrpCat.ofHom (mapLevi l φ) :=
+  rfl
+
+@[simp]
+theorem unipotentFunctor_map (l : H →ₐc[R] LaurentPolynomial R)
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    (unipotentFunctor l).map φ = GrpCat.ofHom (mapUnipotent l φ) :=
+  rfl
+
+/-- The dynamic parabolic functor includes naturally into the ambient functor of points. -/
+@[expose] noncomputable def parabolicFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
+    parabolicFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
+  app A := GrpCat.ofHom (parabolic A l).subtype
+  naturality _ _ _ := by ext; rfl
+
+/-- The dynamic Levi functor includes naturally into the ambient functor of points. -/
+@[expose] noncomputable def leviFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
+    leviFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
+  app A := GrpCat.ofHom (levi A l).subtype
+  naturality _ _ _ := by ext; rfl
+
+/-- The dynamic unipotent functor includes naturally into the ambient functor of points. -/
+@[expose] noncomputable def unipotentFunctorIncl (l : H →ₐc[R] LaurentPolynomial R) :
+    unipotentFunctor l ⟶ HopfAlgebra.pointsFunctor (R := R) (H := H) where
+  app A := GrpCat.ofHom (unipotent A l).subtype
+  naturality _ _ _ := by ext; rfl
+
+@[simp]
+theorem parabolicFunctorIncl_app (l : H →ₐc[R] LaurentPolynomial R)
+    (A : CommAlgCat.{w} R) :
+    (parabolicFunctorIncl l).app A = GrpCat.ofHom (parabolic A l).subtype :=
+  rfl
+
+@[simp]
+theorem leviFunctorIncl_app (l : H →ₐc[R] LaurentPolynomial R)
+    (A : CommAlgCat.{w} R) :
+    (leviFunctorIncl l).app A = GrpCat.ofHom (levi A l).subtype :=
+  rfl
+
+@[simp]
+theorem unipotentFunctorIncl_app (l : H →ₐc[R] LaurentPolynomial R)
+    (A : CommAlgCat.{w} R) :
+    (unipotentFunctorIncl l).app A = GrpCat.ofHom (unipotent A l).subtype :=
+  rfl
+
+end TauCeti.Cocharacter

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Representable.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Dynamic.Functor
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Borel
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Subgroups
+
+/-!
+# Representability of the dynamic subgroups of `GL₂`
+
+For the cocharacter `t ↦ diag(t, 1)`, the dynamic parabolic, Levi, and unipotent subgroup
+functors are represented by the standard upper-triangular Borel, diagonal torus, and positive
+root subgroup. This upgrades the pointwise calculations in
+`TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Subgroups` to natural isomorphisms of
+group-valued functors.
+
+Concretely, the three representing coordinate Hopf algebras are
+
+* `Borel.coordinateHopfAlgebra R` for the dynamic parabolic;
+* the rank-two split-torus group algebra for the dynamic Levi;
+* `AdditiveGroup.coordinateHopfAlgebra R` for the dynamic unipotent subgroup.
+
+The natural isomorphisms commute with the inclusions into `GL₂`: on every value algebra their
+components are the existing Borel point equivalence, diagonal-torus point map, and positive
+root-subgroup point map.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.Dynamic.GL2.borelPointsIsoParabolicFunctor` represents the dynamic
+  parabolic functor by the Borel coordinate Hopf algebra.
+* `TauCeti.GeneralLinear.Dynamic.GL2.splitTorusPointsIsoLeviFunctor` represents the dynamic
+  Levi functor by the rank-two split torus.
+* `TauCeti.GeneralLinear.Dynamic.GL2.additivePointsIsoUnipotentFunctor` represents the dynamic
+  unipotent functor by the additive group.
+
+## References
+
+* G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 13.
+
+This supplies scheme-level representability for the rank-one dynamic-parabolic route in Layer 7,
+"Structure theory", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.GeneralLinear.Dynamic.GL2
+
+universe u w
+
+variable {R : Type u} [CommRing R]
+
+/-- The pointwise equivalence from the dynamic parabolic to the upper-triangular Borel. -/
+@[expose] noncomputable def parabolicBorelMulEquiv (A : CommAlgCat.{w} R) :
+    Cocharacter.parabolic A (dynamicCocharacter (R := R)) ≃* GL2Borel A where
+  toFun g := ⟨pointsMulEquiv (R := R) (A := A) 2 g,
+    (mem_dynamicParabolic_iff (R := R) (A := A) g).mp g.2⟩
+  invFun g := ⟨(pointsMulEquiv (R := R) (A := A) 2).symm g,
+    (mem_dynamicParabolic_iff (R := R) (A := A) _).mpr (by
+      rw [(pointsMulEquiv (R := R) (A := A) 2).apply_symm_apply]
+      exact g.2)⟩
+  left_inv g := Subtype.ext
+    ((pointsMulEquiv (R := R) (A := A) 2).symm_apply_apply
+      (g : WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)))
+  right_inv g := Subtype.ext
+    ((pointsMulEquiv (R := R) (A := A) 2).apply_symm_apply (g : GL (Fin 2) A))
+  map_mul' g h := Subtype.ext
+    (map_mul (pointsMulEquiv (R := R) (A := A) 2)
+      (g : WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) h)
+
+@[simp]
+theorem coe_parabolicBorelMulEquiv_apply (A : CommAlgCat.{w} R)
+    (g : Cocharacter.parabolic A (dynamicCocharacter (R := R))) :
+    ((parabolicBorelMulEquiv A g : GL2Borel A) : GL (Fin 2) A) =
+      pointsMulEquiv 2 (g : WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) := by
+  -- The exposed equivalence stores this map under the `GL2Borel` subtype coercion.
+  change pointsMulEquiv 2 (g : WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) = _
+  rfl
+
+@[simp]
+theorem pointToGeneralLinear_parabolicBorelMulEquiv_symm_apply (A : CommAlgCat.{w} R)
+    (g : GL2Borel A) :
+    pointToGeneralLinear 2
+        (((parabolicBorelMulEquiv A).symm g :
+          Cocharacter.parabolic A (dynamicCocharacter (R := R))) :
+            WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) =
+      (g : GL (Fin 2) A) := by
+  -- The inverse field is the ambient inverse point equivalence, restricted to the subgroup.
+  rw [← pointsMulEquiv_apply]
+  change pointsMulEquiv 2 ((pointsMulEquiv 2).symm (g : GL (Fin 2) A)) = _
+  exact (pointsMulEquiv 2).apply_symm_apply (g : GL (Fin 2) A)
+
+/-- The Borel coordinate Hopf algebra represents the dynamic parabolic functor for
+`t ↦ diag(t, 1)`. -/
+noncomputable def borelPointsIsoParabolicFunctor :
+    HopfAlgebra.pointsFunctor (R := R) (H := Borel.coordinateHopfAlgebra R) ≅
+      Cocharacter.parabolicFunctor (dynamicCocharacter (R := R)) :=
+  NatIso.ofComponents
+    (fun A ↦ ((Borel.pointsMulEquiv (R := R) (A := A)).trans
+      (parabolicBorelMulEquiv A).symm).toGrpIso)
+    (by
+      intro A B φ
+      ext f
+      apply Subtype.ext
+      apply (pointsMulEquiv (R := R) (A := B) 2).injective
+      -- `NatIso.ofComponents` expands the categorical compositions but leaves the subgroup
+      -- coercions opaque; the next `change` states their pointwise content.
+      change pointsMulEquiv 2
+          (((parabolicBorelMulEquiv B).symm
+            (Borel.pointsMulEquiv (R := R) (A := B)
+              (HopfAlgebra.mapPoints (H := Borel.coordinateHopfAlgebra R) φ f)) :
+                Cocharacter.parabolic B (dynamicCocharacter (R := R))) :
+            WithConv (coordinateHopfAlgebra R 2 →ₐ[R] B)) =
+        pointsMulEquiv 2
+          ((Cocharacter.mapParabolic (dynamicCocharacter (R := R)) φ
+            ((parabolicBorelMulEquiv A).symm
+              (Borel.pointsMulEquiv (R := R) (A := A) f)) :
+                Cocharacter.parabolic B (dynamicCocharacter (R := R))) :
+            WithConv (coordinateHopfAlgebra R 2 →ₐ[R] B))
+      rw [pointsMulEquiv_apply,
+        pointToGeneralLinear_parabolicBorelMulEquiv_symm_apply,
+        Cocharacter.coe_mapParabolic_apply, pointsMulEquiv_apply,
+        pointToGeneralLinear_mapValue,
+        pointToGeneralLinear_parabolicBorelMulEquiv_symm_apply]
+      simpa only [Borel.coe_mapBorel, CommAlgCat.hom_ofHom, CommAlgCat.ofHom_hom] using
+        congrArg Subtype.val
+          (Borel.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) φ.hom f))
+
+/-! ## The dynamic Levi -/
+
+/-- The diagonal-torus point map, with codomain restricted to the dynamic Levi. -/
+@[expose] noncomputable def splitTorusToLevi (A : CommAlgCat.{w} R) :
+    HopfAlgebra.points
+        (R := R)
+        (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) A →*
+      Cocharacter.levi A (dynamicCocharacter (R := R)) :=
+  (diagonalTorusPoints (R := R) (N := 2) (A := A)).codRestrict _ fun f ↦
+    (mem_dynamicLevi_iff_exists_diagonalTorusPoint
+      (R := R) (A := A) (diagonalTorusPoints f)).mpr ⟨f, rfl⟩
+
+/-- The pointwise equivalence from the rank-two split torus to the dynamic Levi. -/
+noncomputable def splitTorusLeviMulEquiv (A : CommAlgCat.{w} R) :
+    HopfAlgebra.points
+        (R := R)
+        (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) A ≃*
+      Cocharacter.levi A (dynamicCocharacter (R := R)) :=
+  MulEquiv.ofBijective (splitTorusToLevi A) ⟨
+    fun _ _ h ↦ diagonalTorusPoints_injective (congrArg Subtype.val h),
+    fun g ↦ by
+      obtain ⟨f, hf⟩ :=
+        (mem_dynamicLevi_iff_exists_diagonalTorusPoint (R := R) (A := A) g).mp g.2
+      exact ⟨f, Subtype.ext hf⟩⟩
+
+@[simp]
+theorem coe_splitTorusLeviMulEquiv_apply (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points
+      (R := R)
+      (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) A) :
+    ((splitTorusLeviMulEquiv A f :
+        Cocharacter.levi A (dynamicCocharacter (R := R))) :
+      WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) =
+      diagonalTorusPoints f := by
+  rfl
+
+/-- The rank-two split-torus coordinate Hopf algebra represents the dynamic Levi functor for
+`t ↦ diag(t, 1)`. -/
+noncomputable def splitTorusPointsIsoLeviFunctor :
+    HopfAlgebra.pointsFunctor
+        (R := R)
+        (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) ≅
+      Cocharacter.leviFunctor (dynamicCocharacter (R := R)) :=
+  NatIso.ofComponents
+    (fun A ↦ (splitTorusLeviMulEquiv A).toGrpIso)
+    (by
+      intro A B φ
+      ext f
+      apply Subtype.ext
+      -- Both component maps are restrictions of the corresponding ambient point maps.
+      change diagonalTorusPoints
+          (HopfAlgebra.mapPoints
+            (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) φ f) =
+        AlgHom.mapValue φ.hom (diagonalTorusPoints f)
+      exact (mapValue_diagonalTorusPoints φ.hom f).symm)
+
+/-! ## The dynamic unipotent subgroup -/
+
+/-- The positive root-subgroup point map, with codomain restricted to the dynamic unipotent
+subgroup. -/
+@[expose] noncomputable def additiveToUnipotent (A : CommAlgCat.{w} R) :
+    HopfAlgebra.points (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) A →*
+      Cocharacter.unipotent A (dynamicCocharacter (R := R)) :=
+  (rootSubgroupPoints (R := R) (N := 2) (A := A)
+    (by decide : (0 : Fin 2) ≠ 1)).codRestrict _ fun f ↦
+      (mem_dynamicUnipotent_iff_exists_rootSubgroupPoint
+        (R := R) (A := A) (rootSubgroupPoints (by decide) f)).mpr ⟨f, rfl⟩
+
+/-- The pointwise equivalence from the additive group to the dynamic unipotent subgroup. -/
+noncomputable def additiveUnipotentMulEquiv (A : CommAlgCat.{w} R) :
+    HopfAlgebra.points (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) A ≃*
+      Cocharacter.unipotent A (dynamicCocharacter (R := R)) :=
+  MulEquiv.ofBijective (additiveToUnipotent A) ⟨
+    fun _ _ h ↦ rootSubgroupPoints_injective (by decide) (congrArg Subtype.val h),
+    fun g ↦ by
+      obtain ⟨f, hf⟩ :=
+        (mem_dynamicUnipotent_iff_exists_rootSubgroupPoint (R := R) (A := A) g).mp g.2
+      exact ⟨f, Subtype.ext hf⟩⟩
+
+@[simp]
+theorem coe_additiveUnipotentMulEquiv_apply (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) A) :
+    ((additiveUnipotentMulEquiv A f :
+        Cocharacter.unipotent A (dynamicCocharacter (R := R))) :
+      WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) =
+      rootSubgroupPoints (by decide : (0 : Fin 2) ≠ 1) f := by
+  rfl
+
+/-- The additive-group coordinate Hopf algebra represents the dynamic unipotent functor for
+`t ↦ diag(t, 1)`. -/
+noncomputable def additivePointsIsoUnipotentFunctor :
+    HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ≅
+      Cocharacter.unipotentFunctor (dynamicCocharacter (R := R)) :=
+  NatIso.ofComponents
+    (fun A ↦ (additiveUnipotentMulEquiv A).toGrpIso)
+    (by
+      intro A B φ
+      ext f
+      apply Subtype.ext
+      -- Both component maps are restrictions of the corresponding ambient point maps.
+      change rootSubgroupPoints (by decide : (0 : Fin 2) ≠ 1)
+          (HopfAlgebra.mapPoints (H := AdditiveGroup.coordinateHopfAlgebra R) φ f) =
+        AlgHom.mapValue φ.hom (rootSubgroupPoints (by decide) f)
+      exact (mapValue_rootSubgroupPoints φ.hom (by decide) f).symm)
+
+end TauCeti.GeneralLinear.Dynamic.GL2

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Representable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Representable.lean
@@ -57,7 +57,7 @@ universe u w
 variable {R : Type u} [CommRing R]
 
 /-- The pointwise equivalence from the dynamic parabolic to the upper-triangular Borel. -/
-@[expose] noncomputable def parabolicBorelMulEquiv (A : CommAlgCat.{w} R) :
+noncomputable def parabolicBorelMulEquiv (A : CommAlgCat.{w} R) :
     Cocharacter.parabolic A (dynamicCocharacter (R := R)) ≃* GL2Borel A where
   toFun g := ⟨pointsMulEquiv (R := R) (A := A) 2 g,
     (mem_dynamicParabolic_iff (R := R) (A := A) g).mp g.2⟩
@@ -79,7 +79,8 @@ theorem coe_parabolicBorelMulEquiv_apply (A : CommAlgCat.{w} R)
     (g : Cocharacter.parabolic A (dynamicCocharacter (R := R))) :
     ((parabolicBorelMulEquiv A g : GL2Borel A) : GL (Fin 2) A) =
       pointsMulEquiv 2 (g : WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) := by
-  -- The exposed equivalence stores this map under the `GL2Borel` subtype coercion.
+  unfold parabolicBorelMulEquiv
+  -- The equivalence stores this map under the `GL2Borel` subtype coercion.
   change pointsMulEquiv 2 (g : WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) = _
   rfl
 
@@ -91,6 +92,7 @@ theorem pointToGeneralLinear_parabolicBorelMulEquiv_symm_apply (A : CommAlgCat.{
           Cocharacter.parabolic A (dynamicCocharacter (R := R))) :
             WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) =
       (g : GL (Fin 2) A) := by
+  unfold parabolicBorelMulEquiv
   -- The inverse field is the ambient inverse point equivalence, restricted to the subgroup.
   rw [← pointsMulEquiv_apply]
   change pointsMulEquiv 2 ((pointsMulEquiv 2).symm (g : GL (Fin 2) A)) = _
@@ -132,10 +134,30 @@ noncomputable def borelPointsIsoParabolicFunctor :
         congrArg Subtype.val
           (Borel.pointsMulEquiv_mapValue (R := R) (A := A) (B := B) φ.hom f))
 
+/-- The forward component of `borelPointsIsoParabolicFunctor` is the composite of the
+Borel point equivalence with the inverse pointwise parabolic equivalence. -/
+@[simp]
+theorem borelPointsIsoParabolicFunctor_hom_app_apply (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := Borel.coordinateHopfAlgebra R) A) :
+    (borelPointsIsoParabolicFunctor (R := R)).hom.app A f =
+      (parabolicBorelMulEquiv A).symm (Borel.pointsMulEquiv (R := R) (A := A) f) := by
+  unfold borelPointsIsoParabolicFunctor
+  rfl
+
+/-- The inverse component of `borelPointsIsoParabolicFunctor` is the composite of the
+pointwise parabolic equivalence with the inverse Borel point equivalence. -/
+@[simp]
+theorem borelPointsIsoParabolicFunctor_inv_app_apply (A : CommAlgCat.{w} R)
+    (g : Cocharacter.parabolic A (dynamicCocharacter (R := R))) :
+    (borelPointsIsoParabolicFunctor (R := R)).inv.app A g =
+      (Borel.pointsMulEquiv (R := R) (A := A)).symm (parabolicBorelMulEquiv A g) := by
+  unfold borelPointsIsoParabolicFunctor
+  rfl
+
 /-! ## The dynamic Levi -/
 
 /-- The diagonal-torus point map, with codomain restricted to the dynamic Levi. -/
-@[expose] noncomputable def splitTorusToLevi (A : CommAlgCat.{w} R) :
+noncomputable def splitTorusToLevi (A : CommAlgCat.{w} R) :
     HopfAlgebra.points
         (R := R)
         (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) A →*
@@ -166,6 +188,7 @@ theorem coe_splitTorusLeviMulEquiv_apply (A : CommAlgCat.{w} R)
         Cocharacter.levi A (dynamicCocharacter (R := R))) :
       WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) =
       diagonalTorusPoints f := by
+  unfold splitTorusLeviMulEquiv splitTorusToLevi
   rfl
 
 /-- The rank-two split-torus coordinate Hopf algebra represents the dynamic Levi functor for
@@ -179,20 +202,54 @@ noncomputable def splitTorusPointsIsoLeviFunctor :
     (fun A ↦ (splitTorusLeviMulEquiv A).toGrpIso)
     (by
       intro A B φ
-      ext f
+      apply GrpCat.hom_ext
+      apply MonoidHom.ext
+      intro (f : HopfAlgebra.points
+        (R := R)
+        (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) A)
       apply Subtype.ext
       -- Both component maps are restrictions of the corresponding ambient point maps.
-      change diagonalTorusPoints
+      unfold HopfAlgebra.pointsFunctor Cocharacter.leviFunctor
+      change ((splitTorusLeviMulEquiv B
           (HopfAlgebra.mapPoints
-            (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) φ f) =
-        AlgHom.mapValue φ.hom (diagonalTorusPoints f)
+            (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) φ f) :
+              Cocharacter.levi B (dynamicCocharacter (R := R))) :
+            WithConv (coordinateHopfAlgebra R 2 →ₐ[R] B)) =
+        ((Cocharacter.mapLevi (dynamicCocharacter (R := R)) φ
+            (splitTorusLeviMulEquiv A f) :
+              Cocharacter.levi B (dynamicCocharacter (R := R))) :
+            WithConv (coordinateHopfAlgebra R 2 →ₐ[R] B))
+      rw [coe_splitTorusLeviMulEquiv_apply, Cocharacter.coe_mapLevi_apply,
+        coe_splitTorusLeviMulEquiv_apply]
       exact (mapValue_diagonalTorusPoints φ.hom f).symm)
+
+/-- The forward component of `splitTorusPointsIsoLeviFunctor` is the pointwise split-torus
+equivalence. -/
+@[simp]
+theorem splitTorusPointsIsoLeviFunctor_hom_app_apply (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points
+      (R := R)
+      (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin 2) →₀ ℤ))) A) :
+    (splitTorusPointsIsoLeviFunctor (R := R)).hom.app A f =
+      splitTorusLeviMulEquiv A f := by
+  unfold splitTorusPointsIsoLeviFunctor
+  rfl
+
+/-- The inverse component of `splitTorusPointsIsoLeviFunctor` is the inverse pointwise
+split-torus equivalence. -/
+@[simp]
+theorem splitTorusPointsIsoLeviFunctor_inv_app_apply (A : CommAlgCat.{w} R)
+    (g : Cocharacter.levi A (dynamicCocharacter (R := R))) :
+    (splitTorusPointsIsoLeviFunctor (R := R)).inv.app A g =
+      (splitTorusLeviMulEquiv A).symm g := by
+  unfold splitTorusPointsIsoLeviFunctor
+  rfl
 
 /-! ## The dynamic unipotent subgroup -/
 
 /-- The positive root-subgroup point map, with codomain restricted to the dynamic unipotent
 subgroup. -/
-@[expose] noncomputable def additiveToUnipotent (A : CommAlgCat.{w} R) :
+noncomputable def additiveToUnipotent (A : CommAlgCat.{w} R) :
     HopfAlgebra.points (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) A →*
       Cocharacter.unipotent A (dynamicCocharacter (R := R)) :=
   (rootSubgroupPoints (R := R) (N := 2) (A := A)
@@ -218,6 +275,7 @@ theorem coe_additiveUnipotentMulEquiv_apply (A : CommAlgCat.{w} R)
         Cocharacter.unipotent A (dynamicCocharacter (R := R))) :
       WithConv (coordinateHopfAlgebra R 2 →ₐ[R] A)) =
       rootSubgroupPoints (by decide : (0 : Fin 2) ≠ 1) f := by
+  unfold additiveUnipotentMulEquiv additiveToUnipotent
   rfl
 
 /-- The additive-group coordinate Hopf algebra represents the dynamic unipotent functor for
@@ -229,12 +287,43 @@ noncomputable def additivePointsIsoUnipotentFunctor :
     (fun A ↦ (additiveUnipotentMulEquiv A).toGrpIso)
     (by
       intro A B φ
-      ext f
+      apply GrpCat.hom_ext
+      apply MonoidHom.ext
+      intro (f : HopfAlgebra.points
+        (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) A)
       apply Subtype.ext
       -- Both component maps are restrictions of the corresponding ambient point maps.
-      change rootSubgroupPoints (by decide : (0 : Fin 2) ≠ 1)
-          (HopfAlgebra.mapPoints (H := AdditiveGroup.coordinateHopfAlgebra R) φ f) =
-        AlgHom.mapValue φ.hom (rootSubgroupPoints (by decide) f)
+      unfold HopfAlgebra.pointsFunctor Cocharacter.unipotentFunctor
+      change ((additiveUnipotentMulEquiv B
+          (HopfAlgebra.mapPoints (H := AdditiveGroup.coordinateHopfAlgebra R) φ f) :
+            Cocharacter.unipotent B (dynamicCocharacter (R := R))) :
+          WithConv (coordinateHopfAlgebra R 2 →ₐ[R] B)) =
+        ((Cocharacter.mapUnipotent (dynamicCocharacter (R := R)) φ
+            (additiveUnipotentMulEquiv A f) :
+              Cocharacter.unipotent B (dynamicCocharacter (R := R))) :
+            WithConv (coordinateHopfAlgebra R 2 →ₐ[R] B))
+      rw [coe_additiveUnipotentMulEquiv_apply, Cocharacter.coe_mapUnipotent_apply,
+        coe_additiveUnipotentMulEquiv_apply]
       exact (mapValue_rootSubgroupPoints φ.hom (by decide) f).symm)
+
+/-- The forward component of `additivePointsIsoUnipotentFunctor` is the pointwise additive
+equivalence. -/
+@[simp]
+theorem additivePointsIsoUnipotentFunctor_hom_app_apply (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) A) :
+    (additivePointsIsoUnipotentFunctor (R := R)).hom.app A f =
+      additiveUnipotentMulEquiv A f := by
+  unfold additivePointsIsoUnipotentFunctor
+  rfl
+
+/-- The inverse component of `additivePointsIsoUnipotentFunctor` is the inverse pointwise
+additive equivalence. -/
+@[simp]
+theorem additivePointsIsoUnipotentFunctor_inv_app_apply (A : CommAlgCat.{w} R)
+    (g : Cocharacter.unipotent A (dynamicCocharacter (R := R))) :
+    (additivePointsIsoUnipotentFunctor (R := R)).inv.app A g =
+      (additiveUnipotentMulEquiv A).symm g := by
+  unfold additivePointsIsoUnipotentFunctor
+  rfl
 
 end TauCeti.GeneralLinear.Dynamic.GL2


### PR DESCRIPTION
This PR packages the dynamic parabolic, Levi, and unipotent subgroup families of a cocharacter as group-valued functors, then represents the three subgroups attached to `t ↦ diag(t, 1)` in `GL₂` by the standard Borel, rank-two split torus, and additive group coordinate Hopf algebras. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 7, milestone “Borel subgroups, maximal tori, and their conjugacy; parabolic subgroups and Levi decomposition,” specifically the instruction to keep the dynamic approach to parabolics, Levi subgroups, and unipotent radicals as a parallel route avoiding full root data.

Add `TauCeti.Cocharacter.parabolicFunctor`, `leviFunctor`, and `unipotentFunctor`, together with their restricted value-algebra maps and natural inclusions into the ambient Hopf-algebra points functor. These definitions turn the existing pointwise change-of-algebra lemmas into the reusable interface needed to state representability for any cocharacter.

Add three natural isomorphisms for the rank-one `GL₂` calculation on `main`: `borelPointsIsoParabolicFunctor`, `splitTorusPointsIsoLeviFunctor`, and `additivePointsIsoUnipotentFunctor`. Their components reuse the existing pointwise classifications, the Borel points equivalence, the diagonal-torus point map, and the positive root-subgroup point map; naturality follows from the corresponding existing scalar-extension theorems. No Mathlib infrastructure is vendored: the construction reuses `NatIso.ofComponents`, `MulEquiv.ofBijective`, `MonoidHom.codRestrict`, and the categorical group API.

This is the most effective distinct current step because the merged `GL₂` computations identify all three subgroup families only pointwise, while open #4298 generalizes the matrix computation to arbitrary weights and explicitly leaves representability outstanding. After this PR, the milestone still needs representability for the arbitrary-weight block subgroups computed by #4298, followed by Borel/maximal-torus conjugacy and the general parabolic/Levi theory.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"gl2-dynamic-subgroups-representable"}-->

🤖 Prepared with Codex
