### PR TITLE
feat: normalize quadratic forms over separably closed fields

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/SepClosed.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/SepClosed.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.IsSepClosed
+public import Mathlib.LinearAlgebra.QuadraticForm.IsometryEquiv
+
+/-!
+# Quadratic forms over a separably closed field
+
+This file proves that a finite-dimensional nondegenerate quadratic form over a separably closed
+field of characteristic different from two is equivalent to a sum of squares.
+
+## Main result
+
+* `QuadraticForm.equivalent_weightedSumSquares_of_isSepClosed`: a nondegenerate quadratic form is
+  equivalent to the standard sum of squares.
+
+## References
+
+* [Tau Ceti Roadmap](https://github.com/TauCetiProject/TauCetiRoadmap), Representation Theory /
+  Spin Representations, Layer 4, "The spin module".
+* Mathlib's `QuadraticForm.isometryEquivSumSquaresUnits` and
+  `QuadraticForm.equivalent_weightedSumSquares_of_isAlgClosed` supply the normalization argument
+  adapted here from algebraically closed to separably closed fields.
+-/
+
+public section
+
+open QuadraticMap
+
+namespace QuadraticForm
+
+variable {ι : Type*} [Fintype ι] {K : Type*} [Field K] [IsSepClosed K]
+
+private noncomputable def isometryEquivSumSquaresUnits [NeZero (2 : K)] (w : ι → Kˣ) :
+    IsometryEquiv (weightedSumSquares K fun i ↦ (w i : K))
+      (weightedSumSquares K (1 : ι → K)) := by
+  classical
+  refine isometryEquivWeightedSumSquaresWeightedSumSquares
+    (fun i ↦ Units.mk0 (IsSepClosed.exists_eq_mul_self (w i : K)).choose ?_) ?_
+  · rw [← mul_self_eq_zero.ne, ← (IsSepClosed.exists_eq_mul_self (w i : K)).choose_spec]
+    exact (w i).ne_zero
+  · intro i
+    simp [pow_two, ← (IsSepClosed.exists_eq_mul_self (w i : K)).choose_spec]
+
+/-- A finite-dimensional nondegenerate quadratic form over a separably closed field of
+characteristic different from two is equivalent to the standard sum of squares. -/
+theorem equivalent_weightedSumSquares_of_isSepClosed [Invertible (2 : K)] {M : Type*}
+    [AddCommGroup M] [Module K M] [FiniteDimensional K M]
+    (Q : QuadraticForm K M) (hQ : (associated Q).SeparatingLeft) :
+    Equivalent Q (weightedSumSquares K (1 : Fin (Module.finrank K M) → K)) := by
+  classical
+  let ⟨w, ⟨e⟩⟩ := Q.equivalent_weightedSumSquares_units_of_nondegenerate' hQ
+  exact ⟨e.trans (isometryEquivSumSquaresUnits w)⟩
+
+end QuadraticForm

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Exists.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Exists.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.Spin.Polarization.Basic
-public import Mathlib.FieldTheory.IsSepClosed
+public import TauCeti.LinearAlgebra.QuadraticForm.SepClosed
 import Mathlib.LinearAlgebra.QuadraticForm.Dual
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 import Mathlib.RingTheory.Finiteness.Prod
@@ -27,9 +27,7 @@ quadratic spaces over separably closed fields of characteristic different from t
 
 * [Tau Ceti Roadmap](https://github.com/TauCetiProject/TauCetiRoadmap), Representation Theory /
   Spin Representations, Layer 4, "The spin module".
-* Mathlib's `QuadraticForm.isometryEquivSumSquaresUnits` and
-  `QuadraticForm.equivalent_weightedSumSquares_of_isAlgClosed` supply the normalization argument
-  adapted below from algebraically closed to separably closed fields.
+* `QuadraticForm.equivalent_weightedSumSquares_of_isSepClosed` supplies the normalization argument.
 -/
 
 public section
@@ -405,27 +403,6 @@ private noncomputable def pullback {V V' : Type*} [AddCommGroup V] [Module K V]
     rw [hpolar]
     exact P.line_orthogonal_W' (eLine z) (eW' y)
 
-private def isometryEquivSumSquaresUnits {F : Type*} [Field F] [NeZero (2 : F)]
-    [IsSepClosed F]
-    {I : Type*} [Fintype I] (w : I → Fˣ) :
-    (QuadraticMap.weightedSumSquares F fun i ↦ (w i : F)).IsometryEquiv
-      (QuadraticMap.weightedSumSquares F (1 : I → F)) := by
-  classical
-  refine QuadraticForm.isometryEquivWeightedSumSquaresWeightedSumSquares
-    (fun i ↦ Units.mk0 (IsSepClosed.exists_eq_mul_self (w i : F)).choose ?_) ?_
-  · rw [← mul_self_eq_zero.ne, ← (IsSepClosed.exists_eq_mul_self (w i : F)).choose_spec]
-    exact (w i).ne_zero
-  · intro i
-    simp [pow_two, ← (IsSepClosed.exists_eq_mul_self (w i : F)).choose_spec]
-
-private theorem equivalent_weightedSumSquares {F X : Type*} [Field F] [Invertible (2 : F)]
-    [IsSepClosed F] [AddCommGroup X] [Module F X] [FiniteDimensional F X]
-    (Q : QuadraticForm F X) (hQ : (QuadraticMap.associated Q).SeparatingLeft) :
-    Q.Equivalent (QuadraticMap.weightedSumSquares F (1 : Fin (Module.finrank F X) → F)) := by
-  classical
-  let ⟨w, ⟨e⟩⟩ := Q.equivalent_weightedSumSquares_units_of_nondegenerate' hQ
-  exact ⟨e.trans (isometryEquivSumSquaresUnits w)⟩
-
 private theorem finrank_splitModel {R : Type*} [CommRing R] [Nontrivial R] (n : ℕ) :
     Module.finrank R (SplitModel R n) = n := by
   let _ : Module.Free R (SplitHalf R n) := Module.Free.pi R _
@@ -440,13 +417,12 @@ private noncomputable def isometryEquivSplitModel {F X : Type*} [Field F]
     [Invertible (2 : F)] [IsSepClosed F] [AddCommGroup X] [Module F X]
     [FiniteDimensional F X] (Q : QuadraticForm F X) (hQ : Q.Nondegenerate) :
     Q.IsometryEquiv (splitModelForm F (Module.finrank F X)) := by
-  have hQ' := equivalent_weightedSumSquares Q
+  have hQ' := Q.equivalent_weightedSumSquares_of_isSepClosed
     ((QuadraticMap.nondegenerate_associated_iff (Q := Q)).2 hQ).1
   have hModel' :
       (splitModelForm F (Module.finrank F X)).Equivalent
         (QuadraticMap.weightedSumSquares F (1 : Fin (Module.finrank F X) → F)) := by
-    have h := equivalent_weightedSumSquares
-      (splitModelForm F (Module.finrank F X))
+    have h := (splitModelForm F (Module.finrank F X)).equivalent_weightedSumSquares_of_isSepClosed
       (associated_splitModelForm_separatingLeft (R := F) (Module.finrank F X))
     rw [finrank_splitModel] at h
     exact h


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the quadratic-form normalization used by the Spin polarization construction.

- Proves that a finite-dimensional nondegenerate form over a separably closed field is equivalent to the unit-weight sum of squares.
- Reuses the generic result at both polarization normalization sites.

## Roadmap target

Supplies the normalization step used by [SpinRepresentations Layer 4](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-4-the-spin-and-half-spin-representations).

## Verification

Full gates, consumers, import probes, golf, and aggregate `2+1` pass at `089ed41e4926dc3115a30850e96b131d6a0d7443`.

## Scale and generality

Changes two files by +64/−28 lines. The theorem applies to finite-dimensional nondegenerate quadratic forms over separably closed fields with invertible `2`.

## Scope

- **Consumes:** Mathlib’s sum-of-squares normalization and separably closed square roots.
- **Provides:** the unit-weight normalization theorem.
- **Fits:** removes duplicate normalization machinery from the Spin polarization constructor.
- **Boundary:** split-model construction and odd-dimensional Clifford structure remain separate.

<sub>🤖 GPT-5.6 Sol high · local aggregate `2+1` fixed: attribution (1)</sub>