### PR TITLE
feat: relate continuous and algebraic intertwiners

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
@@ -159,7 +159,8 @@ theorem exists_forall_inner_matrixCoeffLp_eq [IsAlgClosed 𝕜] (hunitary : IsUn
   refine ⟨c, fun v w ↦ ?_⟩
   have hTv : T v = c • v := by
     calc
-      T v = f v := rfl
+      T v = f v :=
+        (LinearMap.toIntertwiningMap π.toRepresentation π.toRepresentation T hcomm v).symm
       _ = f' v :=
         (_root_.ContRepresentation.intertwiningMapEquiv_symm_apply_apply f v).symm
       _ = (c • (1 : ContIntertwiningMap π π)) v :=

--- a/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Basis.lean
@@ -151,14 +151,21 @@ theorem exists_forall_inner_matrixCoeffLp_eq [IsAlgClosed 𝕜] (hunitary : IsUn
   have hcomm : ∀ (g : G) (v : V), T (π g v) = π g (T v) :=
     (isIntertwiningMap_of_inner_matrixCoeffLp_eq hπ hunitary hf T hT).isIntertwining
   -- Schur's lemma turns it into a scalar.
-  obtain ⟨c, hc⟩ := exists_eq_smul_one_of_irreducible π hirr
-    { toContinuousLinearMap := LinearMap.toContinuousLinearMap T
-      isIntertwining' := fun g ↦ by ext v; simpa using hcomm g v }
-  have hc' := congrArg ContIntertwiningMap.toContinuousLinearMap hc
-  simp only [ContIntertwiningMap.toContinuousLinearMap_smul,
-    ContIntertwiningMap.toContinuousLinearMap_one, ContinuousLinearMap.one_def] at hc'
+  let f : Representation.IntertwiningMap π.toRepresentation π.toRepresentation :=
+    T.intertwiningMap_of_isIntertwiningMap π.toRepresentation π.toRepresentation hcomm
+  let f' : ContIntertwiningMap π π :=
+    (_root_.ContRepresentation.intertwiningMapEquiv (π := π) (ρ := π)).symm f
+  obtain ⟨c, hc⟩ := exists_eq_smul_one_of_irreducible π hirr f'
   refine ⟨c, fun v w ↦ ?_⟩
-  have hTv : T v = c • v := by simpa using congrArg (fun F : V →L[𝕜] V ↦ F v) hc'
+  have hTv : T v = c • v := by
+    calc
+      T v = f v := rfl
+      _ = f' v :=
+        (_root_.ContRepresentation.intertwiningMapEquiv_symm_apply_apply f v).symm
+      _ = (c • (1 : ContIntertwiningMap π π)) v :=
+        congrArg (fun g : ContIntertwiningMap π π ↦ g v) hc
+      _ = c • v := by
+        rw [ContIntertwiningMap.smul_apply, ContIntertwiningMap.one_apply]
   rw [← hT v w, hTv, inner_smul_right]
 
 end Scalar

--- a/TauCeti/RepresentationTheory/Continuous/Intertwining.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Intertwining.lean
@@ -79,6 +79,12 @@ theorem intertwiningMapEquiv_apply (f : ContIntertwiningMap π ρ) :
     intertwiningMapEquiv f = f.toIntertwiningMap :=
   (rfl)
 
+/-- The forward intertwiner identification preserves pointwise evaluation. -/
+@[simp]
+theorem intertwiningMapEquiv_apply_apply (f : ContIntertwiningMap π ρ) (v : V) :
+    intertwiningMapEquiv f v = f v :=
+  (rfl)
+
 /-- The inverse intertwiner identification preserves pointwise evaluation. -/
 @[simp]
 theorem intertwiningMapEquiv_symm_apply_apply

--- a/TauCeti/RepresentationTheory/Continuous/Intertwining.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Intertwining.lean
@@ -11,10 +11,11 @@ public import Mathlib.Topology.Algebra.Module.FiniteDimension
 /-!
 # Continuous and algebraic intertwiners
 
-For finite-dimensional normed spaces, automatic continuity identifies continuous intertwiners and
-equivalences with their algebraic counterparts. The object and character side is already supplied
-by the universe-polymorphic `FDRep.ofShrink`, `FDRep.ofShrinkEquiv`, and
-`FDRep.character_ofShrink`; this file adds only the missing intertwiner side.
+For finite-dimensional Hausdorff topological vector spaces, automatic continuity identifies
+continuous intertwiners and equivalences with their algebraic counterparts. The object and
+character side is already supplied by the universe-polymorphic `FDRep.ofShrink`,
+`FDRep.ofShrinkEquiv`, and `FDRep.character_ofShrink`; this file adds only the missing intertwiner
+side.
 
 ## Main declarations
 
@@ -35,13 +36,18 @@ namespace ContRepresentation
 
 section Intertwiners
 
-universe u v w x
+universe u v w x y
 
 variable {𝕜 : Type u} {G : Type v} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜] [Monoid G]
-  {V : Type w} {W : Type x}
-  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
-  [NormedAddCommGroup W] [NormedSpace 𝕜 W]
+  {V : Type w} {W : Type x} {U : Type y}
+  [AddCommGroup V] [Module 𝕜 V] [TopologicalSpace V] [IsTopologicalAddGroup V]
+  [ContinuousSMul 𝕜 V] [T2Space V] [FiniteDimensional 𝕜 V]
+  [AddCommGroup W] [Module 𝕜 W] [TopologicalSpace W] [IsTopologicalAddGroup W]
+  [ContinuousSMul 𝕜 W]
+  [AddCommGroup U] [Module 𝕜 U] [TopologicalSpace U] [IsTopologicalAddGroup U]
+  [ContinuousSMul 𝕜 U]
   {π : ContRepresentation 𝕜 G V} {ρ : ContRepresentation 𝕜 G W}
+  {τ : ContRepresentation 𝕜 G U}
 
 /-- In finite dimensions, forgetting continuity identifies continuous intertwining maps with
 algebraic intertwining maps. The inverse equips the underlying linear map with its automatic
@@ -69,7 +75,6 @@ noncomputable def intertwiningMapEquiv :
     rfl
 
 /-- The forward intertwiner identification is the existing forgetful map. -/
-@[simp]
 theorem intertwiningMapEquiv_apply (f : ContIntertwiningMap π ρ) :
     intertwiningMapEquiv f = f.toIntertwiningMap :=
   (rfl)
@@ -81,17 +86,52 @@ theorem intertwiningMapEquiv_symm_apply_apply
     intertwiningMapEquiv.symm f v = f v :=
   (rfl)
 
+/-- The intertwiner identification preserves identity maps. -/
+@[simp high]
+theorem intertwiningMapEquiv_id :
+    intertwiningMapEquiv (ContIntertwiningMap.id : ContIntertwiningMap π π) =
+      Representation.IntertwiningMap.id π.toRepresentation :=
+  (rfl)
+
+/-- The intertwiner identification preserves composition. -/
+@[simp high]
+theorem intertwiningMapEquiv_comp [T2Space W] [FiniteDimensional 𝕜 W]
+    (f : ContIntertwiningMap ρ τ) (g : ContIntertwiningMap π ρ) :
+    intertwiningMapEquiv (f.comp g) =
+      (intertwiningMapEquiv f).comp (intertwiningMapEquiv g) :=
+  (rfl)
+
+/-- The inverse intertwiner identification preserves identity maps. -/
+@[simp high]
+theorem intertwiningMapEquiv_symm_id :
+    intertwiningMapEquiv.symm (Representation.IntertwiningMap.id π.toRepresentation) =
+      (ContIntertwiningMap.id : ContIntertwiningMap π π) := by
+  apply ContIntertwiningMap.ext
+  rfl
+
+/-- The inverse intertwiner identification preserves composition. -/
+@[simp high]
+theorem intertwiningMapEquiv_symm_comp [T2Space W] [FiniteDimensional 𝕜 W]
+    (f : Representation.IntertwiningMap ρ.toRepresentation τ.toRepresentation)
+    (g : Representation.IntertwiningMap π.toRepresentation ρ.toRepresentation) :
+    intertwiningMapEquiv.symm (f.comp g) =
+      (intertwiningMapEquiv.symm f).comp (intertwiningMapEquiv.symm g) := by
+  apply ContIntertwiningMap.ext
+  rfl
+
 end Intertwiners
 
 section Equivalence
 
 variable {𝕜 G V W : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜] [Monoid G]
-  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
-  [NormedAddCommGroup W] [NormedSpace 𝕜 W]
+  [AddCommGroup V] [Module 𝕜 V] [TopologicalSpace V] [IsTopologicalAddGroup V]
+  [ContinuousSMul 𝕜 V] [T2Space V] [FiniteDimensional 𝕜 V]
+  [AddCommGroup W] [Module 𝕜 W] [TopologicalSpace W] [IsTopologicalAddGroup W]
+  [ContinuousSMul 𝕜 W] [T2Space W]
   {π : ContRepresentation 𝕜 G V} {ρ : ContRepresentation 𝕜 G W}
 
-/-- Two finite-dimensional continuous representations over a complete field are continuously
-equivalent exactly when their underlying algebraic representations are equivalent. -/
+/-- Two finite-dimensional Hausdorff continuous representations over a complete field are
+continuously equivalent exactly when their underlying algebraic representations are equivalent. -/
 theorem nonempty_equiv_iff :
     Nonempty (_root_.ContRepresentation.Equiv π ρ) ↔
       Nonempty (Representation.Equiv π.toRepresentation ρ.toRepresentation) := by

--- a/TauCeti/RepresentationTheory/Continuous/Intertwining.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Intertwining.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.Continuous.Basic
+public import Mathlib.Topology.Algebra.Module.FiniteDimension
+
+/-!
+# Continuous and algebraic intertwiners
+
+For finite-dimensional normed spaces, automatic continuity identifies continuous intertwiners and
+equivalences with their algebraic counterparts. The object and character side is already supplied
+by the universe-polymorphic `FDRep.ofShrink`, `FDRep.ofShrinkEquiv`, and
+`FDRep.character_ofShrink`; this file adds only the missing intertwiner side.
+
+## Main declarations
+
+* `ContRepresentation.intertwiningMapEquiv`: continuous intertwiners are linearly equivalent to
+  algebraic intertwiners.
+* `ContRepresentation.nonempty_equiv_iff`: continuous and algebraic representation equivalence
+  agree.
+
+## References
+
+* [Representations of compact groups and the Peter-Weyl theorem](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
+  continuous-representation-to-`FDRep` correspondence.
+-/
+
+public section
+
+namespace ContRepresentation
+
+section Intertwiners
+
+universe u v w x
+
+variable {𝕜 : Type u} {G : Type v} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜] [Monoid G]
+  {V : Type w} {W : Type x}
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+  [NormedAddCommGroup W] [NormedSpace 𝕜 W]
+  {π : ContRepresentation 𝕜 G V} {ρ : ContRepresentation 𝕜 G W}
+
+/-- In finite dimensions, forgetting continuity identifies continuous intertwining maps with
+algebraic intertwining maps. The inverse equips the underlying linear map with its automatic
+continuity. -/
+noncomputable def intertwiningMapEquiv :
+    ContIntertwiningMap π ρ ≃ₗ[𝕜]
+      Representation.IntertwiningMap π.toRepresentation ρ.toRepresentation where
+  toFun f := f.toIntertwiningMap
+  invFun f :=
+    { toContinuousLinearMap := LinearMap.toContinuousLinearMap f.toLinearMap
+      isIntertwining' := fun g => by
+        ext v
+        exact Representation.IntertwiningMap.isIntertwining _ _ f g v }
+  left_inv f := by
+    apply ContIntertwiningMap.ext
+    rfl
+  right_inv f := by
+    apply Representation.IntertwiningMap.ext
+    rfl
+  map_add' f g := by
+    apply Representation.IntertwiningMap.ext
+    rfl
+  map_smul' c f := by
+    apply Representation.IntertwiningMap.ext
+    rfl
+
+/-- The forward intertwiner identification is the existing forgetful map. -/
+@[simp]
+theorem intertwiningMapEquiv_apply (f : ContIntertwiningMap π ρ) :
+    intertwiningMapEquiv f = f.toIntertwiningMap :=
+  (rfl)
+
+/-- The inverse intertwiner identification preserves pointwise evaluation. -/
+@[simp]
+theorem intertwiningMapEquiv_symm_apply_apply
+    (f : Representation.IntertwiningMap π.toRepresentation ρ.toRepresentation) (v : V) :
+    intertwiningMapEquiv.symm f v = f v :=
+  (rfl)
+
+end Intertwiners
+
+section Equivalence
+
+variable {𝕜 G V W : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜] [Monoid G]
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+  [NormedAddCommGroup W] [NormedSpace 𝕜 W]
+  {π : ContRepresentation 𝕜 G V} {ρ : ContRepresentation 𝕜 G W}
+
+/-- Two finite-dimensional continuous representations over a complete field are continuously
+equivalent exactly when their underlying algebraic representations are equivalent. -/
+theorem nonempty_equiv_iff :
+    Nonempty (_root_.ContRepresentation.Equiv π ρ) ↔
+      Nonempty (Representation.Equiv π.toRepresentation ρ.toRepresentation) := by
+  constructor
+  · rintro ⟨φ⟩
+    refine ⟨Representation.Equiv.mk φ.toContinuousLinearEquiv.toLinearEquiv fun g ↦ ?_⟩
+    ext v
+    exact congr($(φ.isIntertwining g) v)
+  · rintro ⟨φ⟩
+    refine ⟨_root_.ContRepresentation.Equiv.mk φ.toLinearEquiv.toContinuousLinearEquiv fun g ↦ ?_⟩
+    ext v
+    exact congr($(φ.isIntertwining' g) v)
+
+end Equivalence
+
+end ContRepresentation

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -28,7 +28,8 @@ Forgetting continuity is only sound in the direction "continuous intertwiner ↦
 hypothesis of the vanishing half is inequivalence as *continuous* representations, which is the
 weaker of the two hypotheses to discharge. `ContRepresentation.nonempty_equiv_iff` is what
 closes the gap: in finite dimensions over a complete field the two notions of equivalence agree,
-because every linear map out of a finite-dimensional normed space is continuous.
+because every linear map out of a finite-dimensional Hausdorff topological vector space is
+continuous.
 
 ## Main statements
 

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -7,9 +7,8 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.LinearAlgebra.Trace
-public import Mathlib.RepresentationTheory.Continuous.Basic
 public import Mathlib.RepresentationTheory.Irreducible
-public import Mathlib.Topology.Algebra.Module.FiniteDimension
+public import TauCeti.RepresentationTheory.Continuous.Intertwining
 
 /-!
 # Schur's lemma for continuous intertwiners
@@ -27,15 +26,12 @@ half.
 
 Forgetting continuity is only sound in the direction "continuous intertwiner ↦ intertwiner"; the
 hypothesis of the vanishing half is inequivalence as *continuous* representations, which is the
-weaker of the two hypotheses to discharge. `TauCeti.ContRepresentation.nonempty_equiv_iff` is what
+weaker of the two hypotheses to discharge. `ContRepresentation.nonempty_equiv_iff` is what
 closes the gap: in finite dimensions over a complete field the two notions of equivalence agree,
 because every linear map out of a finite-dimensional normed space is continuous.
 
 ## Main statements
 
-* `TauCeti.ContRepresentation.nonempty_equiv_iff`: two finite-dimensional continuous
-  representations are equivalent as continuous representations if and only if they are equivalent
-  as abstract representations.
 * `TauCeti.ContRepresentation.eq_zero_of_isEmpty_equiv`: every continuous intertwiner between
   inequivalent irreducible finite-dimensional representations is zero.
 * `TauCeti.ContRepresentation.exists_eq_smul_one_of_irreducible`: every continuous self-intertwiner
@@ -62,26 +58,6 @@ variable {𝕜 G V W : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜
 
 variable {π : ContRepresentation 𝕜 G V} {ρ : ContRepresentation 𝕜 G W}
 
-/-- **Continuity is automatic for finite-dimensional representations.** Two finite-dimensional
-continuous representations over a complete field are equivalent as continuous representations
-exactly when their underlying abstract representations are equivalent.
-
-The forward direction forgets continuity. The reverse direction is where the finite-dimensionality
-is used: a linear equivalence of finite-dimensional normed spaces is a homeomorphism, so an
-abstract equivalence carries no extra data. -/
-theorem nonempty_equiv_iff :
-    Nonempty (_root_.ContRepresentation.Equiv π ρ) ↔
-      Nonempty (Representation.Equiv π.toRepresentation ρ.toRepresentation) := by
-  constructor
-  · rintro ⟨φ⟩
-    refine ⟨Representation.Equiv.mk φ.toContinuousLinearEquiv.toLinearEquiv fun g ↦ ?_⟩
-    ext v
-    exact congr($(φ.isIntertwining g) v)
-  · rintro ⟨φ⟩
-    refine ⟨_root_.ContRepresentation.Equiv.mk φ.toLinearEquiv.toContinuousLinearEquiv fun g ↦ ?_⟩
-    ext v
-    exact congr($(φ.isIntertwining' g) v)
-
 /-- **Schur's lemma, vanishing half.** A continuous intertwiner between inequivalent irreducible
 finite-dimensional continuous representations is zero.
 
@@ -96,7 +72,7 @@ theorem eq_zero_of_isEmpty_equiv (hπ : Representation.IsIrreducible π.toRepres
   let : Representation.IsIrreducible π.toRepresentation := hπ
   let : Representation.IsIrreducible ρ.toRepresentation := hρ
   have : IsEmpty (Representation.Equiv π.toRepresentation ρ.toRepresentation) :=
-    ⟨fun φ ↦ hne.false (nonempty_equiv_iff.2 ⟨φ⟩).some⟩
+    ⟨fun φ ↦ hne.false (_root_.ContRepresentation.nonempty_equiv_iff.2 ⟨φ⟩).some⟩
   exact ContIntertwiningMap.toIntertwiningMap_injective (Subsingleton.elim _ _)
 
 end Vanishing

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.LinearAlgebra.Trace
 public import Mathlib.RepresentationTheory.Irreducible
 public import TauCeti.RepresentationTheory.Continuous.Intertwining

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -61,7 +61,8 @@ variable {π : ContRepresentation 𝕜 G V} {ρ : ContRepresentation 𝕜 G W}
 /-- **Schur's lemma, vanishing half.** A continuous intertwiner between inequivalent irreducible
 finite-dimensional continuous representations is zero.
 
-Inequivalence is asked of the continuous representations, which by `nonempty_equiv_iff` is the same
+Inequivalence is asked of the continuous representations, which by
+`_root_.ContRepresentation.nonempty_equiv_iff` is the same
 condition as inequivalence of the underlying abstract representations. No hypothesis on the field
 beyond completeness is needed: this half of Schur's lemma does not need eigenvalues, so it does not
 need algebraic closedness. -/


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Relates continuous and algebraic intertwiners for finite-dimensional representations.

- Identifies continuous intertwining maps with linear intertwining maps.
- Records identity and composition laws in both directions.
- Reuses the bridge in continuous Schur's lemma and a compact-character proof.

## Roadmap target

Supplies the missing intertwiner part of the [continuous-to-`FDRep` correspondence](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md#what-is-not-consumable-and-is-a-build-item-here).

## Verification

The source-equivalent five-commit rebase onto current `main` passes patch-identity, diff-check, and public-history gates at `d9030997` (base `c4594881`).

## Scale and generality

Changes three files by +178/−37 lines. The bridge works for finite-dimensional Hausdorff topological vector spaces over a complete nondiscrete normed field.

## Scope

- **Consumes:** continuous representations, `FDRep.ofShrink`, and finite-dimensional automatic continuity.
- **Provides:** the continuous/algebraic intertwiner equivalence, its evaluation rule, and identity/composition laws.
- **Fits:** supplies the missing dictionary used by compact-group Schur and character arguments.
- **Boundary:** object and character transport remain owned by `FDRep.ofShrink`; averaging and Peter–Weyl remain downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [465c9e7](https://github.com/utensil/TauCetiReview/commit/465c9e7f030871aa0d5fbc533ada5219e9a96f2c) · API-design contest retained; pointwise simp interface preserved</sub>
