### PR TITLE
feat: detect trivial faithful subgroup actions

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
@@ -70,8 +70,7 @@ theorem augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one
     (hM : IsFaithful (k := R) (H := H) (V := M))
     (htrivial : ∀ m : M, coact (R := R) (C := H) m = m ⊗ₜ[R] (1 : H)) :
     HopfIdeal.augmentation R H = ⊥ := by
-  simp only [TauCeti.Comodule.IsFaithful] at hM
-  rcases hM with ⟨n, b, hb⟩
+  rcases isFaithful_def.mp hM with ⟨n, b, hb⟩
   apply le_bot_iff.mp
   intro x hx
   have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) := by

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
@@ -71,6 +71,7 @@ variable [AddCommMonoid M] [Module R M] [Comodule R H M]
 
 /-- The coordinate morphism of a comodule corestricted along a bialgebra morphism is the
 composite of the original coordinate morphism with that bialgebra morphism. -/
+@[simp]
 theorem coordinateBialgHom_corestrict (f : H →ₐc[R] K) (b : Basis (Fin n) R M) :
     letI : Comodule R K M := Corestrict f.toCoalgHom
     coordinateBialgHom (H := K) b = f.comp (coordinateBialgHom (H := H) b) := by
@@ -130,6 +131,7 @@ variable [AddCommMonoid M] [Module R M] [Comodule R H M]
 
 /-- If every vector has trivial coaction, the coordinate morphism of the representation factors
 through the counit of `O(GLₙ)` and the unit of the coefficient Hopf algebra. -/
+@[simp]
 theorem coordinateBialgHom_eq_unit_comp_counit_of_coact_eq_tmul_one
     (b : Basis (Fin n) R M)
     (htrivial : ∀ m : M, coact (R := R) (C := H) m = m ⊗ₜ[R] (1 : H)) :
@@ -207,7 +209,7 @@ theorem eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one
     isFaithful_corestrict_of_surjective q hq b hM
   have htrivialQ : ∀ m : M, coact (R := R) (C := Q) m = m ⊗ₜ[R] (1 : Q) := by
     intro m
-    exact htrivial m
+    simpa only [corestrict_coact_apply] using htrivial m
   have haugmentationQ : HopfIdeal.augmentation R Q = ⊥ :=
     augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one b hfaithfulQ htrivialQ
   have hcomapBot : (⊥ : HopfIdeal R Q).comap q hq = I := by

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
@@ -1,0 +1,226 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Faithful
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+
+/-!
+# Faithful representations of closed subgroups
+
+Let `M` be a finite free comodule over a commutative Hopf algebra `H`. Corestricting its coaction
+along a surjective bialgebra morphism `H ⟶ K` restricts the corresponding representation to the
+closed subgroup represented by `K`. Its coordinate morphism is the composite
+
+```text
+O(GL(M)) ⟶ H ⟶ K.
+```
+
+Consequently a faithful representation stays faithful after restriction to a closed subgroup. If
+that restricted representation is trivial, faithfulness forces the subgroup itself to be the
+identity subgroup. The final Hopf-ideal form says that a closed subgroup acting trivially through
+a faithful ambient representation is cut out by the augmentation ideal.
+
+This is the kernel-elimination input for the direct proof that `GLₙ` is reductive. For a connected
+normal smooth unipotent closed subgroup, the normal-invariants argument makes its fixed vectors an
+ambient subrepresentation; simplicity of the standard representation makes every vector fixed,
+and the result here then identifies the subgroup with the identity.
+
+## Main declarations
+
+* `TauCeti.Comodule.coordinateBialgHom_corestrict`: the coordinate morphism of a corestricted
+  comodule is the expected composite.
+* `TauCeti.Comodule.isFaithful_corestrict_of_surjective`: restriction to a closed subgroup
+  preserves faithfulness.
+* `TauCeti.Comodule.augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one`: a Hopf algebra with
+  a faithful trivial representation is trivial.
+* `TauCeti.Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one`: a closed
+  subgroup acting trivially in a faithful representation is the identity subgroup.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §4.a and §5.
+* T. A. Springer, *Linear Algebraic Groups*, §2.2.
+
+This advances the worked-example target `GLₙ` is reductive in Layer 6 of the ReductiveGroups
+roadmap. It supplies the faithful-representation step used after normal-subgroup invariants and
+Kolchin's fixed-vector theorem.
+-/
+
+public section
+
+open Module
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+universe u v w x
+
+noncomputable section
+
+section CoordinateCorestrict
+
+variable {R : Type u} {H : Type v} {K : Type w} {M : Type x} {n : ℕ}
+variable [CommRing R] [CommRing H] [CommRing K]
+variable [HopfAlgebra R H] [HopfAlgebra R K]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- The coordinate morphism of a comodule corestricted along a bialgebra morphism is the
+composite of the original coordinate morphism with that bialgebra morphism. -/
+theorem coordinateBialgHom_corestrict (f : H →ₐc[R] K) (b : Basis (Fin n) R M) :
+    letI : Comodule R K M := Corestrict f.toCoalgHom
+    coordinateBialgHom (H := K) b = f.comp (coordinateBialgHom (H := H) b) := by
+  let _ : Comodule R K M := Corestrict f.toCoalgHom
+  apply BialgHom.ext
+  intro z
+  have hAlg : (coordinateBialgHom (H := K) b).toAlgHom =
+      (f.comp (coordinateBialgHom (H := H) b)).toAlgHom := by
+    apply GeneralLinear.coordinateHopfAlgebra_algHom_ext R n
+    intro i j
+    rw [BialgHom.comp_toAlgHom, AlgHom.comp_apply]
+    erw [coordinateBialgHom_X (H := K), coordinateBialgHom_X (H := H)]
+    rw [coefficientMatrix_apply, coefficientMatrix_apply,
+      matrixCoefficient_def, matrixCoefficient_def, corestrict_coact_apply]
+    have h := LinearMap.congr_fun
+      (CoassocSimps.lid_comp_map (b.coord i) f.toLinearMap)
+      (coact (R := R) (C := H) (M := M) (b j))
+    rw [TensorProduct.map_map, LinearMap.id_comp, LinearMap.comp_id]
+    -- `lid_comp_map` states naturality for the underlying linear map; expose that coercion on
+    -- the right-hand side after tensor-map composition has been normalized.
+    change _ = f.toLinearMap _
+    exact h
+  exact DFunLike.congr_fun hAlg z
+
+end CoordinateCorestrict
+
+section FaithfulCorestrict
+
+variable {R H K M : Type u} {n : ℕ}
+variable [CommRing R] [CommRing H] [CommRing K]
+variable [HopfAlgebra R H] [HopfAlgebra R K]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- Corestricting a faithful finite free comodule along a surjective bialgebra morphism gives a
+faithful comodule over the codomain. Geometrically, restricting a faithful representation to a
+closed subgroup remains faithful. -/
+theorem isFaithful_corestrict_of_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
+    (b : Basis (Fin n) R M) (hM : IsFaithful (k := R) (H := H) (V := M)) :
+    letI : Comodule R K M := Corestrict f.toCoalgHom
+    IsFaithful (k := R) (H := K) (V := M) := by
+  let _ : Comodule R K M := Corestrict f.toCoalgHom
+  have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) := by
+    rw [← isClosedImmersion_coordinateGroupSchemeHom_iff,
+      ← isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom (b := b)]
+    exact hM
+  rw [isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom (b := b),
+    isClosedImmersion_coordinateGroupSchemeHom_iff, coordinateBialgHom_corestrict f b]
+  exact hf.comp hsurj
+
+end FaithfulCorestrict
+
+section TrivialCoordinate
+
+variable {R : Type u} {H : Type v} {M : Type w} {n : ℕ}
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- If every vector has trivial coaction, the coordinate morphism of the representation factors
+through the counit of `O(GLₙ)` and the unit of the coefficient Hopf algebra. -/
+theorem coordinateBialgHom_eq_unit_comp_counit_of_coact_eq_tmul_one
+    (b : Basis (Fin n) R M)
+    (htrivial : ∀ m : M, coact (R := R) (C := H) m = m ⊗ₜ[R] (1 : H)) :
+    coordinateBialgHom (H := H) b =
+      (Bialgebra.unitBialgHom R H).comp
+        (Bialgebra.counitBialgHom R (GeneralLinear.coordinateHopfAlgebra R n)) := by
+  apply BialgHom.ext
+  intro z
+  have hAlg : (coordinateBialgHom (H := H) b).toAlgHom =
+      ((Bialgebra.unitBialgHom R H).comp
+        (Bialgebra.counitBialgHom R
+          (GeneralLinear.coordinateHopfAlgebra R n))).toAlgHom := by
+    apply GeneralLinear.coordinateHopfAlgebra_algHom_ext R n
+    intro i j
+    rw [BialgHom.comp_toAlgHom, AlgHom.comp_apply]
+    erw [coordinateBialgHom_X]
+    rw [coefficientMatrix_apply, matrixCoefficient_def, htrivial]
+    by_cases hij : i = j <;> simp [hij]
+  exact DFunLike.congr_fun hAlg z
+
+end TrivialCoordinate
+
+section TrivialFaithful
+
+variable {R H M : Type u} {n : ℕ}
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+
+/-- A commutative Hopf algebra admitting a faithful finite free comodule with trivial coaction
+has zero augmentation ideal. Equivalently, the represented affine group is the identity group. -/
+theorem augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one
+    (b : Basis (Fin n) R M) (hM : IsFaithful (k := R) (H := H) (V := M))
+    (htrivial : ∀ m : M, coact (R := R) (C := H) m = m ⊗ₜ[R] (1 : H)) :
+    HopfIdeal.augmentation R H = ⊥ := by
+  apply le_bot_iff.mp
+  intro x hx
+  have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) := by
+    rw [← isClosedImmersion_coordinateGroupSchemeHom_iff,
+      ← isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom (b := b)]
+    exact hM
+  obtain ⟨z, rfl⟩ := hsurj x
+  have hcoordinate := DFunLike.congr_fun
+    (coordinateBialgHom_eq_unit_comp_counit_of_coact_eq_tmul_one b htrivial) z
+  rw [BialgHom.comp_apply] at hcoordinate
+  rw [hcoordinate]
+  have hcounit : Coalgebra.counit (R := R) (A := H)
+      (coordinateBialgHom (H := H) b z) = 0 :=
+    (HopfIdeal.mem_augmentation R H).mp hx
+  have hcounit_z : Coalgebra.counit (R := R) z = 0 :=
+    (CoalgHomClass.counit_comp_apply (coordinateBialgHom (H := H) b) z).symm.trans hcounit
+  rw [HopfIdeal.mem_bot]
+  -- The unit bialgebra morphism is the algebra structure map; expose its value after the
+  -- coordinate factorization has reduced the goal to a scalar.
+  change algebraMap R H (Coalgebra.counit (R := R) z) = 0
+  rw [hcounit_z, map_zero]
+
+/-- A closed subgroup acting trivially through a faithful finite free representation is the
+identity subgroup: its defining Hopf ideal is the augmentation ideal of the ambient group. -/
+theorem eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one
+    (I : HopfIdeal R H) (b : Basis (Fin n) R M)
+    (hM : IsFaithful (k := R) (H := H) (V := M))
+    (htrivial : ∀ m : M,
+      TensorProduct.map LinearMap.id
+          (CommHopfAlgCat.mkQuotient (_root_.CommHopfAlgCat.of R H) I).hom.toLinearMap
+          (coact (R := R) (C := H) m) =
+        m ⊗ₜ[R]
+          (1 : CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of R H) I)) :
+    I = HopfIdeal.augmentation R H := by
+  let q := (CommHopfAlgCat.mkQuotient (_root_.CommHopfAlgCat.of R H) I).hom
+  let Q := CommHopfAlgCat.quotient (_root_.CommHopfAlgCat.of R H) I
+  let _ : Comodule R Q M := Corestrict q.toCoalgHom
+  have hq : Function.Surjective q :=
+    CommHopfAlgCat.mkQuotient_surjective (_root_.CommHopfAlgCat.of R H) I
+  have hfaithfulQ : IsFaithful (k := R) (H := Q) (V := M) :=
+    isFaithful_corestrict_of_surjective q hq b hM
+  have htrivialQ : ∀ m : M, coact (R := R) (C := Q) m = m ⊗ₜ[R] (1 : Q) := by
+    intro m
+    exact htrivial m
+  have haugmentationQ : HopfIdeal.augmentation R Q = ⊥ :=
+    augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one b hfaithfulQ htrivialQ
+  have hcomapBot : (⊥ : HopfIdeal R Q).comap q hq = I := by
+    ext x
+    rw [HopfIdeal.mem_comap, HopfIdeal.mem_bot,
+      CommHopfAlgCat.mkQuotient_eq_zero_iff, HopfIdeal.mem_toIdeal]
+  calc
+    I = (⊥ : HopfIdeal R Q).comap q hq := hcomapBot.symm
+    _ = (HopfIdeal.augmentation R Q).comap q hq := by rw [haugmentationQ]
+    _ = HopfIdeal.augmentation R H := HopfIdeal.comap_augmentation q hq
+
+end TrivialFaithful
+
+end
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
@@ -116,9 +116,15 @@ theorem eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one
   have haugmentationQ : HopfIdeal.augmentation R Q = ⊥ :=
     augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one hfaithfulQ htrivialQ
   have hcomapBot : (⊥ : HopfIdeal R Q).comap q hq = I := by
-    ext x
-    rw [HopfIdeal.mem_comap, HopfIdeal.mem_bot,
-      CommHopfAlgCat.mkQuotient_eq_zero_iff, HopfIdeal.mem_toIdeal]
+    rw [HopfIdeal.comap_bot]
+    apply HopfIdeal.ext
+    intro x
+    change x ∈ (HopfIdeal.kerOfSurjective q hq).toIdeal ↔ x ∈ I.toIdeal
+    rw [HopfIdeal.kerOfSurjective_toIdeal]
+    change x ∈ RingHom.ker q.toAlgHom.toRingHom ↔ x ∈ I.toIdeal
+    rw [show RingHom.ker q.toAlgHom.toRingHom = I.toIdeal by
+      simpa only [q] using
+        CommHopfAlgCat.mkQuotient_ker (_root_.CommHopfAlgCat.of R H) I]
   calc
     I = (⊥ : HopfIdeal R Q).comap q hq := hcomapBot.symm
     _ = (HopfIdeal.augmentation R Q).comap q hq := by rw [haugmentationQ]

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
@@ -32,10 +32,6 @@ and the result here then identifies the subgroup with the identity.
 
 ## Main declarations
 
-* `TauCeti.Comodule.coordinateBialgHom_corestrict`: the coordinate morphism of a corestricted
-  comodule is the expected composite.
-* `TauCeti.Comodule.isFaithful_corestrict_of_surjective`: restriction to a closed subgroup
-  preserves faithfulness.
 * `TauCeti.Comodule.augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one`: a Hopf algebra with
   a faithful trivial representation is trivial.
 * `TauCeti.Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one`: a closed
@@ -62,116 +58,25 @@ universe u v w x
 
 noncomputable section
 
-section CoordinateCorestrict
-
-variable {R : Type u} {H : Type v} {K : Type w} {M : Type x} {n : ℕ}
-variable [CommRing R] [CommRing H] [CommRing K]
-variable [HopfAlgebra R H] [HopfAlgebra R K]
-variable [AddCommMonoid M] [Module R M] [Comodule R H M]
-
-/-- The coordinate morphism of a comodule corestricted along a bialgebra morphism is the
-composite of the original coordinate morphism with that bialgebra morphism. -/
-@[simp]
-theorem coordinateBialgHom_corestrict (f : H →ₐc[R] K) (b : Basis (Fin n) R M) :
-    letI : Comodule R K M := Corestrict f.toCoalgHom
-    coordinateBialgHom (H := K) b = f.comp (coordinateBialgHom (H := H) b) := by
-  let _ : Comodule R K M := Corestrict f.toCoalgHom
-  apply BialgHom.ext
-  intro z
-  have hAlg : (coordinateBialgHom (H := K) b).toAlgHom =
-      (f.comp (coordinateBialgHom (H := H) b)).toAlgHom := by
-    apply GeneralLinear.coordinateHopfAlgebra_algHom_ext R n
-    intro i j
-    rw [BialgHom.comp_toAlgHom, AlgHom.comp_apply]
-    erw [coordinateBialgHom_X (H := K), coordinateBialgHom_X (H := H)]
-    rw [coefficientMatrix_apply, coefficientMatrix_apply,
-      matrixCoefficient_def, matrixCoefficient_def, corestrict_coact_apply]
-    have h := LinearMap.congr_fun
-      (CoassocSimps.lid_comp_map (b.coord i) f.toLinearMap)
-      (coact (R := R) (C := H) (M := M) (b j))
-    rw [TensorProduct.map_map, LinearMap.id_comp, LinearMap.comp_id]
-    -- `lid_comp_map` states naturality for the underlying linear map; expose that coercion on
-    -- the right-hand side after tensor-map composition has been normalized.
-    change _ = f.toLinearMap _
-    exact h
-  exact DFunLike.congr_fun hAlg z
-
-end CoordinateCorestrict
-
-section FaithfulCorestrict
-
-variable {R H K M : Type u} {n : ℕ}
-variable [CommRing R] [CommRing H] [CommRing K]
-variable [HopfAlgebra R H] [HopfAlgebra R K]
-variable [AddCommMonoid M] [Module R M] [Comodule R H M]
-
-/-- Corestricting a faithful finite free comodule along a surjective bialgebra morphism gives a
-faithful comodule over the codomain. Geometrically, restricting a faithful representation to a
-closed subgroup remains faithful. -/
-theorem isFaithful_corestrict_of_surjective (f : H →ₐc[R] K) (hf : Function.Surjective f)
-    (b : Basis (Fin n) R M) (hM : IsFaithful (k := R) (H := H) (V := M)) :
-    letI : Comodule R K M := Corestrict f.toCoalgHom
-    IsFaithful (k := R) (H := K) (V := M) := by
-  let _ : Comodule R K M := Corestrict f.toCoalgHom
-  have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) := by
-    rw [← isClosedImmersion_coordinateGroupSchemeHom_iff,
-      ← isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom (b := b)]
-    exact hM
-  rw [isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom (b := b),
-    isClosedImmersion_coordinateGroupSchemeHom_iff, coordinateBialgHom_corestrict f b]
-  exact hf.comp hsurj
-
-end FaithfulCorestrict
-
-section TrivialCoordinate
-
-variable {R : Type u} {H : Type v} {M : Type w} {n : ℕ}
-variable [CommRing R] [CommRing H] [HopfAlgebra R H]
-variable [AddCommMonoid M] [Module R M] [Comodule R H M]
-
-/-- If every vector has trivial coaction, the coordinate morphism of the representation factors
-through the counit of `O(GLₙ)` and the unit of the coefficient Hopf algebra. -/
-@[simp]
-theorem coordinateBialgHom_eq_unit_comp_counit_of_coact_eq_tmul_one
-    (b : Basis (Fin n) R M)
-    (htrivial : ∀ m : M, coact (R := R) (C := H) m = m ⊗ₜ[R] (1 : H)) :
-    coordinateBialgHom (H := H) b =
-      (Bialgebra.unitBialgHom R H).comp
-        (Bialgebra.counitBialgHom R (GeneralLinear.coordinateHopfAlgebra R n)) := by
-  apply BialgHom.ext
-  intro z
-  have hAlg : (coordinateBialgHom (H := H) b).toAlgHom =
-      ((Bialgebra.unitBialgHom R H).comp
-        (Bialgebra.counitBialgHom R
-          (GeneralLinear.coordinateHopfAlgebra R n))).toAlgHom := by
-    apply GeneralLinear.coordinateHopfAlgebra_algHom_ext R n
-    intro i j
-    rw [BialgHom.comp_toAlgHom, AlgHom.comp_apply]
-    erw [coordinateBialgHom_X]
-    rw [coefficientMatrix_apply, matrixCoefficient_def, htrivial]
-    by_cases hij : i = j <;> simp [hij]
-  exact DFunLike.congr_fun hAlg z
-
-end TrivialCoordinate
-
 section TrivialFaithful
 
-variable {R H M : Type u} {n : ℕ}
+variable {R H M : Type u}
 variable [CommRing R] [CommRing H] [HopfAlgebra R H]
 variable [AddCommMonoid M] [Module R M] [Comodule R H M]
 
 /-- A commutative Hopf algebra admitting a faithful finite free comodule with trivial coaction
 has zero augmentation ideal. Equivalently, the represented affine group is the identity group. -/
 theorem augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one
-    (b : Basis (Fin n) R M) (hM : IsFaithful (k := R) (H := H) (V := M))
+    (hM : IsFaithful (k := R) (H := H) (V := M))
     (htrivial : ∀ m : M, coact (R := R) (C := H) m = m ⊗ₜ[R] (1 : H)) :
     HopfIdeal.augmentation R H = ⊥ := by
+  simp only [TauCeti.Comodule.IsFaithful] at hM
+  rcases hM with ⟨n, b, hb⟩
   apply le_bot_iff.mp
   intro x hx
   have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) := by
-    rw [← isClosedImmersion_coordinateGroupSchemeHom_iff,
-      ← isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom (b := b)]
-    exact hM
+    rw [← isClosedImmersion_coordinateGroupSchemeHom_iff]
+    exact hb
   obtain ⟨z, rfl⟩ := hsurj x
   have hcoordinate := DFunLike.congr_fun
     (coordinateBialgHom_eq_unit_comp_counit_of_coact_eq_tmul_one b htrivial) z
@@ -191,8 +96,7 @@ theorem augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one
 /-- A closed subgroup acting trivially through a faithful finite free representation is the
 identity subgroup: its defining Hopf ideal is the augmentation ideal of the ambient group. -/
 theorem eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one
-    (I : HopfIdeal R H) (b : Basis (Fin n) R M)
-    (hM : IsFaithful (k := R) (H := H) (V := M))
+    (I : HopfIdeal R H) (hM : IsFaithful (k := R) (H := H) (V := M))
     (htrivial : ∀ m : M,
       TensorProduct.map LinearMap.id
           (CommHopfAlgCat.mkQuotient (_root_.CommHopfAlgCat.of R H) I).hom.toLinearMap
@@ -206,12 +110,12 @@ theorem eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one
   have hq : Function.Surjective q :=
     CommHopfAlgCat.mkQuotient_surjective (_root_.CommHopfAlgCat.of R H) I
   have hfaithfulQ : IsFaithful (k := R) (H := Q) (V := M) :=
-    isFaithful_corestrict_of_surjective q hq b hM
+    isFaithful_corestrict_of_surjective q hq hM
   have htrivialQ : ∀ m : M, coact (R := R) (C := Q) m = m ⊗ₜ[R] (1 : Q) := by
     intro m
     simpa only [corestrict_coact_apply] using htrivial m
   have haugmentationQ : HopfIdeal.augmentation R Q = ⊥ :=
-    augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one b hfaithfulQ htrivialQ
+    augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one hfaithfulQ htrivialQ
   have hcomapBot : (⊥ : HopfIdeal R Q).comap q hq = I := by
     ext x
     rw [HopfIdeal.mem_comap, HopfIdeal.mem_bot,

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean
@@ -116,15 +116,9 @@ theorem eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one
   have haugmentationQ : HopfIdeal.augmentation R Q = ⊥ :=
     augmentation_eq_bot_of_isFaithful_of_coact_eq_tmul_one hfaithfulQ htrivialQ
   have hcomapBot : (⊥ : HopfIdeal R Q).comap q hq = I := by
-    rw [HopfIdeal.comap_bot]
-    apply HopfIdeal.ext
-    intro x
-    change x ∈ (HopfIdeal.kerOfSurjective q hq).toIdeal ↔ x ∈ I.toIdeal
-    rw [HopfIdeal.kerOfSurjective_toIdeal]
-    change x ∈ RingHom.ker q.toAlgHom.toRingHom ↔ x ∈ I.toIdeal
-    rw [show RingHom.ker q.toAlgHom.toRingHom = I.toIdeal by
-      simpa only [q] using
-        CommHopfAlgCat.mkQuotient_ker (_root_.CommHopfAlgCat.of R H) I]
+    ext x
+    rw [HopfIdeal.mem_comap, HopfIdeal.mem_bot,
+      CommHopfAlgCat.mkQuotient_eq_zero_iff, HopfIdeal.mem_toIdeal]
   calc
     I = (⊥ : HopfIdeal R Q).comap q hq := hcomapBot.symm
     _ = (HopfIdeal.augmentation R Q).comap q hq := by rw [haugmentationQ]

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Coordinate.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Coordinate.lean
@@ -5,7 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import Mathlib.RingTheory.Coalgebra.CoassocSimps
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.HopfAlgebra
+public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.Matrix
 import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.FunctorOfPoints
 import TauCeti.Algebra.HopfAlgebra.Basic
@@ -34,6 +36,9 @@ faithful-representation criterion identifies with a closed immersion into `GLₙ
 * `TauCeti.Comodule.coordinateBialgHom_X`: the coordinate morphism sends the generic entry
   `Xᵢⱼ` to the corresponding coefficient-matrix entry.
 * `TauCeti.Comodule.coordinateBialgHom_antipode_X`: its value on the antipode generators.
+* `TauCeti.Comodule.coordinateBialgHom_corestrict`: its compatibility with corestriction.
+* `TauCeti.Comodule.coordinateBialgHom_eq_unit_comp_counit_of_coact_eq_tmul_one`: its value for
+  a trivial coaction.
 
 ## References
 
@@ -49,7 +54,7 @@ open Coalgebra Module WithConv
 
 namespace TauCeti.Comodule
 
-universe u v w
+universe u v w x
 
 noncomputable section
 
@@ -58,6 +63,7 @@ variable [CommRing R] [CommRing H] [HopfAlgebra R H]
 variable [AddCommMonoid M] [Module R M] [Comodule R H M]
 variable {n : ℕ}
 
+/-- The algebra morphism underlying the coordinate bialgebra morphism. -/
 private def coordinateAlgHom (b : Basis (Fin n) R M) :
     GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] H :=
   (GeneralLinear.generalLinearToPoint (R := R) n
@@ -123,6 +129,62 @@ theorem coordinateBialgHom_antipode_X (b : Basis (Fin n) R M) (i j : Fin n) :
       HopfAlgebra.antipode R (coefficientMatrix (C := H) b i j) := by
   rw [← GeneralLinear.coordinateHopfAlgebra_antipode_X, BialgHomClass.map_antipode,
     coordinateBialgHom_X]
+
+section Corestrict
+
+variable {K : Type x} [CommRing K] [HopfAlgebra R K]
+
+/-- The coordinate morphism of a comodule corestricted along a bialgebra morphism is the
+composite of the original coordinate morphism with that bialgebra morphism. -/
+@[simp]
+theorem coordinateBialgHom_corestrict (f : H →ₐc[R] K) (b : Basis (Fin n) R M) :
+    letI : Comodule R K M := Corestrict f.toCoalgHom
+    coordinateBialgHom (H := K) b = f.comp (coordinateBialgHom (H := H) b) := by
+  let _ : Comodule R K M := Corestrict f.toCoalgHom
+  apply BialgHom.ext
+  intro z
+  have hAlg : (coordinateBialgHom (H := K) b).toAlgHom =
+      (f.comp (coordinateBialgHom (H := H) b)).toAlgHom := by
+    apply GeneralLinear.coordinateHopfAlgebra_algHom_ext R n
+    intro i j
+    rw [BialgHom.comp_toAlgHom, AlgHom.comp_apply]
+    erw [coordinateBialgHom_X (H := K), coordinateBialgHom_X (H := H)]
+    rw [coefficientMatrix_apply, coefficientMatrix_apply,
+      matrixCoefficient_def, matrixCoefficient_def, corestrict_coact_apply]
+    have h := LinearMap.congr_fun
+      (CoassocSimps.lid_comp_map (b.coord i) f.toLinearMap)
+      (coact (R := R) (C := H) (M := M) (b j))
+    rw [TensorProduct.map_map, LinearMap.id_comp, LinearMap.comp_id]
+    -- `lid_comp_map` states naturality for the underlying linear map; expose that coercion on
+    -- the right-hand side after tensor-map composition has been normalized.
+    change _ = f.toLinearMap _
+    exact h
+  exact DFunLike.congr_fun hAlg z
+
+end Corestrict
+
+/-- If every vector has trivial coaction, the coordinate morphism of the representation factors
+through the counit of `O(GLₙ)` and the unit of the coefficient Hopf algebra. -/
+@[simp]
+theorem coordinateBialgHom_eq_unit_comp_counit_of_coact_eq_tmul_one
+    (b : Basis (Fin n) R M)
+    (htrivial : ∀ m : M, coact (R := R) (C := H) m = m ⊗ₜ[R] (1 : H)) :
+    coordinateBialgHom (H := H) b =
+      (Bialgebra.unitBialgHom R H).comp
+        (Bialgebra.counitBialgHom R (GeneralLinear.coordinateHopfAlgebra R n)) := by
+  apply BialgHom.ext
+  intro z
+  have hAlg : (coordinateBialgHom (H := H) b).toAlgHom =
+      ((Bialgebra.unitBialgHom R H).comp
+        (Bialgebra.counitBialgHom R
+          (GeneralLinear.coordinateHopfAlgebra R n))).toAlgHom := by
+    apply GeneralLinear.coordinateHopfAlgebra_algHom_ext R n
+    intro i j
+    rw [BialgHom.comp_toAlgHom, AlgHom.comp_apply]
+    erw [coordinateBialgHom_X]
+    rw [coefficientMatrix_apply, matrixCoefficient_def, htrivial]
+    by_cases hij : i = j <;> simp [hij]
+  exact DFunLike.congr_fun hAlg z
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Faithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Faithful.lean
@@ -218,10 +218,17 @@ variable [AddCommMonoid V] [Module k V] [Comodule k H V]
 
 /-- A comodule is faithful if its representation morphism into a general linear group is a
 closed immersion for some finite basis. This property is independent of the witnessing basis. -/
-@[expose]
 def IsFaithful : Prop :=
   ∃ (d : ℕ) (b : Basis (Fin d) k V),
     IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left
+
+/-- Faithfulness restated as the existence of a finite basis whose representation morphism is a
+closed immersion. -/
+theorem isFaithful_def :
+    IsFaithful (k := k) (H := H) (V := V) ↔
+      ∃ (d : ℕ) (b : Basis (Fin d) k V),
+        IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left :=
+  Iff.rfl
 
 /-- **Faithfulness is generation by matrix coefficients.** The affine group-scheme morphism
 associated to a finite free comodule is a closed immersion if and only if the coefficients of
@@ -268,7 +275,7 @@ theorem isFaithful_corestrict_of_surjective
     (hV : IsFaithful (k := k) (H := H) (V := V)) :
     letI : Comodule k K V := Corestrict f.toCoalgHom
     IsFaithful (k := k) (H := K) (V := V) := by
-  rcases hV with ⟨d, b, hb⟩
+  rcases isFaithful_def.mp hV with ⟨d, b, hb⟩
   let _ : Comodule k K V := Corestrict f.toCoalgHom
   have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) := by
     rw [← isClosedImmersion_coordinateGroupSchemeHom_iff]

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Faithful.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Faithful.lean
@@ -40,6 +40,8 @@ equivalent to generation of the coordinate ring by matrix coefficients and their
 * `TauCeti.Comodule.IsFaithful`: the basis-independent predicate for a faithful comodule.
 * `TauCeti.Comodule.isFaithful_iff_matrixCoefficientSubalgebra_sup_antipode_eq_top`: the
   matrix-coefficient criterion for faithfulness.
+* `TauCeti.Comodule.isFaithful_corestrict_of_surjective`: corestriction along a surjective
+  bialgebra morphism preserves faithfulness.
 * `TauCeti.Comodule.pointsAction_injective_of_isFaithful`: a faithful comodule separates
   algebra-valued points.
 * `TauCeti.Comodule.isClosedImmersion_coordinateGroupSchemeHom_iff_of_bases`: faithfulness is
@@ -216,6 +218,7 @@ variable [AddCommMonoid V] [Module k V] [Comodule k H V]
 
 /-- A comodule is faithful if its representation morphism into a general linear group is a
 closed immersion for some finite basis. This property is independent of the witnessing basis. -/
+@[expose]
 def IsFaithful : Prop :=
   ∃ (d : ℕ) (b : Basis (Fin d) k V),
     IsClosedImmersion (coordinateGroupSchemeHom (H := H) b).hom.hom.left
@@ -255,6 +258,24 @@ theorem isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom
     exact (isClosedImmersion_coordinateGroupSchemeHom_iff_of_bases c b).mp hc
   · intro hb
     exact ⟨d, b, hb⟩
+
+/-- Corestricting a faithful finite free comodule along a surjective bialgebra morphism gives a
+faithful comodule over the codomain. Geometrically, restricting a faithful representation to a
+closed subgroup remains faithful. -/
+theorem isFaithful_corestrict_of_surjective
+    {K : Type u} [CommRing K] [HopfAlgebra k K]
+    (f : H →ₐc[k] K) (hf : Function.Surjective f)
+    (hV : IsFaithful (k := k) (H := H) (V := V)) :
+    letI : Comodule k K V := Corestrict f.toCoalgHom
+    IsFaithful (k := k) (H := K) (V := V) := by
+  rcases hV with ⟨d, b, hb⟩
+  let _ : Comodule k K V := Corestrict f.toCoalgHom
+  have hsurj : Function.Surjective (coordinateBialgHom (H := H) b) := by
+    rw [← isClosedImmersion_coordinateGroupSchemeHom_iff]
+    exact hb
+  rw [isFaithful_iff_isClosedImmersion_coordinateGroupSchemeHom (b := b),
+    isClosedImmersion_coordinateGroupSchemeHom_iff, coordinateBialgHom_corestrict f b]
+  exact hf.comp hsurj
 
 /-- A finite free comodule is faithful exactly when its matrix coefficients together with their
 antipode images generate the coordinate Hopf algebra. -/


### PR DESCRIPTION
This PR makes faithful finite free representations detect the identity closed subgroup. It proves that corestriction along a surjective bialgebra morphism composes the representation coordinate map and preserves faithfulness, then shows that a faithful trivial coaction forces the augmentation ideal to be zero. In Hopf-ideal form, a closed subgroup acting trivially through a faithful ambient representation is therefore cut out by the ambient augmentation ideal.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Reductive and semisimple groups,” specifically the worked-example instruction to prove `GLₙ` reductive using the geometric unipotent-radical definition. The dependency edge is `GLₙ` reductive ← a connected normal smooth unipotent subgroup fixes the standard representation ← a faithfully represented closed subgroup acting trivially is the identity subgroup. This is the most effective distinct current step because the faithful simple standard comodule and geometric subcomodule detection are on `main`, while open #4277 supplies the complementary normal-invariants argument but not the kernel-elimination result here.

Add `TauCeti/Algebra/AlgebraicGroup/Representation/ClosedSubgroup.lean` (226 lines). Its five theorems work over a commutative base ring; field, finite-type, reducedness, smoothness, connectedness, and unipotence enter only when the later `GLₙ` application establishes that every vector is fixed. The proof reuses `Comodule.coordinateBialgHom`, its closed-immersion/surjectivity characterization of `Comodule.IsFaithful`, corestriction, the Hopf-ideal quotient API, and `HopfIdeal.comap_augmentation`. No Mathlib infrastructure or external formalization is vendored. The mathematical organization follows Milne, *Algebraic Groups* (2017), §4.a and §5, and Springer, *Linear Algebraic Groups*, §2.2, as cited in the module documentation.

After this PR, the Layer 6 worked example still needs #4277 to land and the existing Kolchin fixed-vector, point-detection, simplicity, and faithful-trivial-action results to be assembled into `reductiveCommHopfAlgProperty` for `GLₙ`; the characteristic-zero comparison between reductivity and linear reductivity also remains.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"faithful-trivial-action-subgroup"}-->

🤖 Prepared with Codex
