### PR TITLE
feat: the Hausdorff--Bernstein--Widder theorem in finite-difference form

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
@@ -6,12 +6,12 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.CompletelyMonotone.Laplace.Representation
--- Non-public: the metrizability class of the finite-set tightness lemmas.
-import Mathlib.Topology.Metrizable.CompletelyMetrizable
 -- Non-public: Bernstein's existence theorem supplies the representing measures of the shifts.
 import TauCeti.Analysis.CompletelyMonotone.Bernstein.Theorem
 -- Non-public: `finite_measure_cluster_limit` extracts the weak cluster point.
 import TauCeti.MeasureTheory.Measure.Prokhorov
+-- Non-public: tightness of the finitely many shifts that the uniform tail bound misses.
+import TauCeti.MeasureTheory.Measure.Tight
 
 /-!
 # Hausdorff--Bernstein--Widder theorem
@@ -53,29 +53,6 @@ namespace TauCeti
 
 /-! ## Hard direction: tightness of the shifted representing measures -/
 
-/-- A finite set of finite measures is tight: singletons are tight and tightness is closed
-under unions. (The empty case routes through an arbitrary singleton, as Mathlib has no
-dedicated empty-set tightness lemma.) -/
-private lemma isTightMeasureSet_of_finite {α : Type*} [MeasurableSpace α] [TopologicalSpace α]
-    [TopologicalSpace.IsCompletelyPseudoMetrizableSpace α] [SecondCountableTopology α]
-    [BorelSpace α] {S : Set (Measure α)} (hS : S.Finite)
-    (hfin : ∀ ν ∈ S, IsFiniteMeasure ν) : IsTightMeasureSet S := by
-  induction S, hS using Set.Finite.induction_on with
-  | empty => exact (isTightMeasureSet_singleton (μ := (0 : Measure α))).subset (empty_subset _)
-  | @insert ν S _ _ ih =>
-      have : IsFiniteMeasure ν := hfin ν (mem_insert _ _)
-      rw [insert_eq]
-      exact isTightMeasureSet_singleton.union (ih fun ρ hρ => hfin ρ (mem_insert_of_mem _ hρ))
-
-/-- A finite family of finite measures is tight. -/
-private lemma isTightMeasureSet_range_finite
-    {α ι : Type*} [MeasurableSpace α] [TopologicalSpace α]
-    [TopologicalSpace.IsCompletelyPseudoMetrizableSpace α] [SecondCountableTopology α]
-    [BorelSpace α] [Finite ι] (μ : ι → Measure α)
-    (hfin : ∀ i, IsFiniteMeasure (μ i)) :
-    IsTightMeasureSet (Set.range μ) :=
-  isTightMeasureSet_of_finite (finite_range μ) (by rintro ν ⟨i, rfl⟩; exact hfin i)
-
 /-- Along a positive null sequence `aₙ ↓ 0`, the values `f (c + aₙ)` of a function continuous
 within `[0, ∞)` converge to `f c`, for any `c ≥ 0`. -/
 private lemma tendsto_apply_add_of_continuousOn
@@ -88,101 +65,24 @@ private lemma tendsto_apply_add_of_continuousOn
         .of_forall fun n => mem_Ici.mpr (add_nonneg hc (ha_pos n).le)⟩
   exact (hf.continuousWithinAt (mem_Ici.mpr hc)).tendsto.comp hmem
 
-/-- The Markov denominator `1 - e^{-xR}` is positive for `x, R > 0`. -/
-private lemma one_sub_exp_neg_mul_pos {x R : ℝ} (hx : 0 < x) (hR : 0 < R) :
-    0 < 1 - Real.exp (-(x * R)) := by
-  have : Real.exp (-(x * R)) < 1 := Real.exp_lt_one_iff.mpr (by nlinarith)
-  linarith
-
-/-- The `∫⁻` of the bounded coordinate `p ↦ 1 - exp(-x·p)` against a measure that represents
-`t ↦ f (t + δ)` by its Laplace transform equals `f δ - f (x + δ)` (for `x > 0`). This is the
-Laplace-value identity behind the shifted-measure tail estimate. -/
-private lemma lintegral_ofReal_one_sub_exp_eq_of_representsLaplace
-    {f : ℝ → ℝ} {μ : Measure ℝ≥0}
-    {δ x : ℝ} (hμ : RepresentsLaplace μ (fun t : ℝ => f (t + δ))) (hx : 0 < x) :
-    ∫⁻ p : ℝ≥0, ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ)))) ∂μ
-      = ENNReal.ofReal (f δ - f (x + δ)) := by
-  have := hμ.isFiniteMeasure
-  have h_one : Integrable (fun _ : ℝ≥0 => (1 : ℝ)) μ := integrable_const 1
-  have h_exp : Integrable (fun p : ℝ≥0 => Real.exp (-(x * (p : ℝ)))) μ :=
-    integrable_exp_neg_mul μ hx.le
-  have h_nonneg : 0 ≤ᵐ[μ] fun p : ℝ≥0 => 1 - Real.exp (-(x * (p : ℝ))) := by
-    refine Filter.Eventually.of_forall fun p => ?_
-    exact sub_nonneg.mpr (exp_neg_mul_le_one hx.le p)
-  have hint : Integrable (fun p : ℝ≥0 => 1 - Real.exp (-(x * (p : ℝ)))) μ :=
-    h_one.sub h_exp
-  have h_int :
-      ∫ p : ℝ≥0, (1 - Real.exp (-(x * (p : ℝ)))) ∂μ = f δ - f (x + δ) := by
-    calc
-      ∫ p : ℝ≥0, (1 - Real.exp (-(x * (p : ℝ)))) ∂μ
-          = (∫ _p : ℝ≥0, (1 : ℝ) ∂μ) -
-              ∫ p : ℝ≥0, Real.exp (-(x * (p : ℝ))) ∂μ := by
-            rw [integral_sub h_one h_exp]
-      _ = μ.real univ - laplaceTransform μ x := by
-            simp [laplaceTransform_apply]
-      _ = f δ - f (x + δ) := by
-            have h0 := hμ.eq_laplaceTransform (t := 0) le_rfl
-            have hxrep := hμ.eq_laplaceTransform (t := x) hx.le
-            have h0' : f δ = μ.real univ := by
-              simpa [laplaceTransform_zero] using h0
-            rw [← h0', ← hxrep]
-  rw [← ofReal_integral_eq_lintegral_ofReal hint h_nonneg, h_int]
-
-/-- Markov tail bound: the mass outside the closed ball of radius `R` is controlled by the `∫⁻`
-of `p ↦ 1 - exp(-x·p)` divided by its boundary value `1 - exp(-x·R)` (for `x, R > 0`). -/
-private lemma measure_closedBall_compl_le_lintegral_div
-    {μ : Measure ℝ≥0} {x R : ℝ} (hx : 0 < x) (hR : 0 < R) :
-    μ (Metric.closedBall (0 : ℝ≥0) R)ᶜ ≤
-      (∫⁻ p : ℝ≥0, ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ)))) ∂μ)
-        / ENNReal.ofReal (1 - Real.exp (-(x * R))) := by
-  set c : ℝ := 1 - Real.exp (-(x * R)) with hc_def
-  have hc_pos : 0 < c := one_sub_exp_neg_mul_pos hx hR
-  have hc_ne_zero : ENNReal.ofReal c ≠ 0 := ENNReal.ofReal_ne_zero_iff.mpr hc_pos
-  have hc_ne_top : ENNReal.ofReal c ≠ (∞ : ENNReal) := ENNReal.ofReal_ne_top
-  have hcoord_meas :
-      AEMeasurable (fun p : ℝ≥0 => ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ))))) μ :=
-    (ENNReal.measurable_ofReal.comp
-      (by fun_prop : Measurable fun p : ℝ≥0 => 1 - Real.exp (-(x * (p : ℝ)))))
-        |>.aemeasurable
-  refine (measure_mono ?_).trans (meas_ge_le_lintegral_div hcoord_meas hc_ne_zero hc_ne_top)
-  intro p hp
-  have hpdist : R < dist p (0 : ℝ≥0) := by
-    simpa [Metric.mem_closedBall, not_le] using hp
-  have hdist : dist p (0 : ℝ≥0) = (p : ℝ) := by
-    simp [NNReal.dist_eq]
-  have hRp : R ≤ (p : ℝ) := by linarith
-  have hxp : x * R ≤ x * (p : ℝ) := mul_le_mul_of_nonneg_left hRp hx.le
-  have hexp_le : Real.exp (-(x * (p : ℝ))) ≤ Real.exp (-(x * R)) :=
-    Real.exp_le_exp.mpr (neg_le_neg hxp)
-  have hreal : c ≤ 1 - Real.exp (-(x * (p : ℝ))) := by
-    rw [hc_def]; linarith
-  exact ENNReal.ofReal_le_ofReal hreal
-
 /-- Tail bound for a Laplace-representing measure of a positive shift: the mass outside the
 ball of radius `R` is controlled by the Laplace gap `f δ - f (x + δ)`. This is the tightness
 input, not a decay rate in `R`: the denominator tends to `1` as `R → ∞`.
 
-The estimate is Markov's inequality on the bounded coordinate `p ↦ 1 - exp (-x * p)`, factored into
-`measure_closedBall_compl_le_lintegral_div` (the Markov bound) and
-`lintegral_ofReal_one_sub_exp_eq_of_representsLaplace` (the Laplace-value identity). It is the
-tightness input for shifting Bernstein's existence theorem back to the closed-half-line
-theorem. -/
+It is `TauCeti.measure_compl_closedBall_le_of_laplaceTransform` read through the representation,
+which turns the total mass into `f δ` and the Laplace transform at `x` into `f (x + δ)`. -/
 private lemma measure_closedBall_compl_le_of_representsLaplace_shift
     {f : ℝ → ℝ} {μ : Measure ℝ≥0}
     {δ x R : ℝ} (hμ : RepresentsLaplace μ (fun t : ℝ => f (t + δ)))
     (hx : 0 < x) (hR : 0 < R) :
     μ (Metric.closedBall (0 : ℝ≥0) R)ᶜ ≤
       ENNReal.ofReal ((f δ - f (x + δ)) / (1 - Real.exp (-(x * R)))) := by
-  have hc_pos : 0 < 1 - Real.exp (-(x * R)) := one_sub_exp_neg_mul_pos hx hR
-  calc
-    μ (Metric.closedBall (0 : ℝ≥0) R)ᶜ
-        ≤ (∫⁻ p : ℝ≥0, ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ)))) ∂μ)
-            / ENNReal.ofReal (1 - Real.exp (-(x * R))) :=
-          measure_closedBall_compl_le_lintegral_div hx hR
-    _ = ENNReal.ofReal (f δ - f (x + δ)) / ENNReal.ofReal (1 - Real.exp (-(x * R))) := by
-          rw [lintegral_ofReal_one_sub_exp_eq_of_representsLaplace hμ hx]
-    _ = ENNReal.ofReal ((f δ - f (x + δ)) / (1 - Real.exp (-(x * R)))) := by
-          rw [ENNReal.ofReal_div_of_pos hc_pos]
+  have := hμ.isFiniteMeasure
+  have hmass : μ.real univ = f δ := by
+    simpa [laplaceTransform_zero] using (hμ.eq_laplaceTransform (t := 0) le_rfl).symm
+  have hlap : laplaceTransform μ x = f (x + δ) := (hμ.eq_laplaceTransform hx.le).symm
+  rw [← hmass, ← hlap]
+  exact measure_compl_closedBall_le_of_laplaceTransform μ hx hR
 
 /-- The continuity-at-`0` step behind the tightness of the shifted representing measures: for any
 `η > 0` there is a positive shift `x` and an index `N` beyond which the Laplace gap-quotient

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/HausdorffBernsteinWidder.lean
@@ -5,13 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.CompletelyMonotone.Laplace.Representation
--- Non-public: Bernstein's existence theorem supplies the representing measures of the shifts.
-import TauCeti.Analysis.CompletelyMonotone.Bernstein.Theorem
--- Non-public: `finite_measure_cluster_limit` extracts the weak cluster point.
-import TauCeti.MeasureTheory.Measure.Prokhorov
--- Non-public: tightness of the finitely many shifts that the uniform tail bound misses.
-import TauCeti.MeasureTheory.Measure.Tight
+public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Laplace
 
 /-!
 # Hausdorff--Bernstein--Widder theorem
@@ -21,12 +15,10 @@ completely monotone functions on the closed half-line: a function is continuous 
 and completely monotone on `(0, ∞)` if and only if it is the Laplace transform of a (unique)
 finite positive measure on `ℝ≥0`.
 
-The hard direction applies Bernstein's existence theorem
-(`TauCeti.exists_representsLaplace_of_isCompletelyMonotone`) to the
-positive shifts `t ↦ f (t + a)`, which satisfy the strong `IsCompletelyMonotone` predicate,
-and passes to a weak cluster point of the representing measures as `a ↓ 0`; the tightness of
-that family is an elementary Laplace-kernel tail estimate. The easy direction and the
-uniqueness both live in `Laplace/Representation.lean`.
+The hard direction is a direct application of the finite-difference representation theorem in
+`FiniteDifference/Laplace.lean`: derivative complete monotonicity implies the mixed-difference
+condition, and continuity on `[0, ∞)` supplies right-continuity at zero. The easy direction and
+uniqueness live in `Laplace/Representation.lean`.
 
 ## Main declarations
 
@@ -51,203 +43,15 @@ open scoped BoundedContinuousFunction ContDiff ENNReal NNReal Topology
 
 namespace TauCeti
 
-/-! ## Hard direction: tightness of the shifted representing measures -/
-
-/-- Along a positive null sequence `aₙ ↓ 0`, the values `f (c + aₙ)` of a function continuous
-within `[0, ∞)` converge to `f c`, for any `c ≥ 0`. -/
-private lemma tendsto_apply_add_of_continuousOn
-    {f : ℝ → ℝ} (hf : ContinuousOn f (Ici 0)) {c : ℝ} (hc : 0 ≤ c)
-    {a : ℕ → ℝ} (ha_pos : ∀ n, 0 < a n) (ha : Tendsto a atTop (𝓝 0)) :
-    Tendsto (fun n => f (c + a n)) atTop (𝓝 (f c)) := by
-  have hmem : Tendsto (fun n => c + a n) atTop (𝓝[Ici (0 : ℝ)] c) :=
-    tendsto_nhdsWithin_iff.mpr
-      ⟨by simpa using tendsto_const_nhds.add ha,
-        .of_forall fun n => mem_Ici.mpr (add_nonneg hc (ha_pos n).le)⟩
-  exact (hf.continuousWithinAt (mem_Ici.mpr hc)).tendsto.comp hmem
-
-/-- Tail bound for a Laplace-representing measure of a positive shift: the mass outside the
-ball of radius `R` is controlled by the Laplace gap `f δ - f (x + δ)`. This is the tightness
-input, not a decay rate in `R`: the denominator tends to `1` as `R → ∞`.
-
-It is `TauCeti.measure_compl_closedBall_le_of_laplaceTransform` read through the representation,
-which turns the total mass into `f δ` and the Laplace transform at `x` into `f (x + δ)`. -/
-private lemma measure_closedBall_compl_le_of_representsLaplace_shift
-    {f : ℝ → ℝ} {μ : Measure ℝ≥0}
-    {δ x R : ℝ} (hμ : RepresentsLaplace μ (fun t : ℝ => f (t + δ)))
-    (hx : 0 < x) (hR : 0 < R) :
-    μ (Metric.closedBall (0 : ℝ≥0) R)ᶜ ≤
-      ENNReal.ofReal ((f δ - f (x + δ)) / (1 - Real.exp (-(x * R)))) := by
-  have := hμ.isFiniteMeasure
-  have hmass : μ.real univ = f δ := by
-    simpa [laplaceTransform_zero] using (hμ.eq_laplaceTransform (t := 0) le_rfl).symm
-  have hlap : laplaceTransform μ x = f (x + δ) := (hμ.eq_laplaceTransform hx.le).symm
-  rw [← hmass, ← hlap]
-  exact measure_compl_closedBall_le_of_laplaceTransform μ hx hR
-
-/-- The continuity-at-`0` step behind the tightness of the shifted representing measures: for any
-`η > 0` there is a positive shift `x` and an index `N` beyond which the Laplace gap-quotient
-`(f (aₙ) - f (x + aₙ)) / (1 - e⁻¹)` is at most `η`: the uniform-tail input to the tightness
-of the shifted representing measures. The denominator `1 - e⁻¹` is the Markov constant
-`1 - exp (-(x * R))` of `measure_closedBall_compl_le_of_representsLaplace_shift` at the radius
-`R = x⁻¹` that the tightness proof chooses, so that `x * R = 1`. -/
-private lemma exists_shift_uniform_gap_bound
-    {f : ℝ → ℝ} (hf : ContinuousOn f (Ici 0))
-    {a : ℕ → ℝ} (ha_pos : ∀ n, 0 < a n)
-    (ha : Tendsto a atTop (𝓝 0))
-    {η : ℝ} (hη : 0 < η) :
-    ∃ x, 0 < x ∧ ∃ N, ∀ n, N ≤ n →
-      (f (a n) - f (x + a n)) / (1 - Real.exp (-1)) ≤ η := by
-  have hf_tendsto0 : Tendsto (fun n => f (a n)) atTop (𝓝 (f 0)) := by
-    simpa using tendsto_apply_add_of_continuousOn hf le_rfl ha_pos ha
-  let c0 : ℝ := 1 - Real.exp (-1)
-  have hc0_pos : 0 < c0 := by
-    have hexp_lt : Real.exp (-1) < 1 := Real.exp_lt_one_iff.mpr (by norm_num)
-    dsimp [c0]
-    linarith
-  have hetac : 0 < η * c0 := mul_pos hη hc0_pos
-  obtain ⟨m, hm⟩ :=
-    (hf_tendsto0.eventually (eventually_gt_nhds (by linarith : f 0 - η * c0 < f 0))).exists
-  let x : ℝ := a m
-  have hx_pos : 0 < x := ha_pos m
-  have hlim_lt : f 0 - f x < η * c0 := by
-    simpa [x, sub_lt_comm] using hm
-  have hfx_tendsto : Tendsto (fun n => f (x + a n)) atTop (𝓝 (f x)) :=
-    tendsto_apply_add_of_continuousOn hf hx_pos.le ha_pos ha
-  have hgap_tendsto :
-      Tendsto (fun n => f (a n) - f (x + a n)) atTop (𝓝 (f 0 - f x)) :=
-    hf_tendsto0.sub hfx_tendsto
-  have hgap_event :
-      ∀ᶠ n : ℕ in atTop, (f (a n) - f (x + a n)) / c0 ≤ η := by
-    filter_upwards [hgap_tendsto.eventually_lt_const hlim_lt] with n hn
-    rw [div_le_iff₀ hc0_pos]
-    exact le_of_lt hn
-  obtain ⟨N, hN⟩ := eventually_atTop.1 hgap_event
-  exact ⟨x, hx_pos, N, hN⟩
-
-/-- The representing measures of positive shifts of a closed-half-line completely monotone
-function are uniformly tight as the shifts tend to `0`.
-
-The proof combines the finite initial-segment tightness with a uniform tail estimate for the
-remaining shifts (`exists_shift_uniform_gap_bound`) and the Laplace-kernel tail bound
-`measure_closedBall_compl_le_of_representsLaplace_shift`. -/
-private lemma isTightMeasureSet_range_of_representsLaplace_shift
-    {f : ℝ → ℝ} (hf : ContinuousOn f (Ici 0))
-    {a : ℕ → ℝ} (ha_pos : ∀ n, 0 < a n)
-    (ha : Tendsto a atTop (𝓝 0))
-    {μ : ℕ → Measure ℝ≥0}
-    (hμ : ∀ n, RepresentsLaplace (μ n) (fun t : ℝ => f (t + a n))) :
-    IsTightMeasureSet (Set.range μ) := by
-  have hμ_fin : ∀ n, IsFiniteMeasure (μ n) := fun n => (hμ n).isFiniteMeasure
-  rw [isTightMeasureSet_iff_exists_isCompact_measure_compl_le]
-  intro ε hε
-  by_cases hε_top : ε = (∞ : ENNReal)
-  · refine ⟨∅, isCompact_empty, ?_⟩
-    intro ν _hν
-    rw [hε_top]
-    exact le_top
-  have hε_real_pos : 0 < ε.toReal := ENNReal.toReal_pos hε.ne' hε_top
-  obtain ⟨x, hx_pos, N, hN⟩ :=
-    exists_shift_uniform_gap_bound hf ha_pos ha hε_real_pos
-  let μfin : {n // n < N} → Measure ℝ≥0 := fun n => μ n
-  have hfin_tight : IsTightMeasureSet (Set.range μfin) :=
-    isTightMeasureSet_range_finite μfin (fun n => hμ_fin n)
-  obtain ⟨Kfin, hKfin_comp, hKfin_tail⟩ :=
-    isTightMeasureSet_iff_exists_isCompact_measure_compl_le.mp hfin_tight ε hε
-  -- The radius is tied to the shift so that `x * R = 1`, matching the `1 - e⁻¹` denominator
-  -- in the gap bound above.
-  let R : ℝ := x⁻¹
-  have hR_pos : 0 < R := inv_pos.mpr hx_pos
-  refine ⟨Kfin ∪ Metric.closedBall (0 : ℝ≥0) R,
-    hKfin_comp.union (isCompact_closedBall _ _), ?_⟩
-  intro ν hν
-  rcases hν with ⟨n, rfl⟩
-  by_cases hnlt : n < N
-  · have hmem_fin : μ n ∈ Set.range μfin := ⟨⟨n, hnlt⟩, rfl⟩
-    have hsubset : (Kfin ∪ Metric.closedBall (0 : ℝ≥0) R)ᶜ ⊆ Kfinᶜ :=
-      compl_subset_compl.mpr (subset_union_left)
-    exact (measure_mono hsubset).trans (hKfin_tail (μ n) hmem_fin)
-  · have hNn : N ≤ n := le_of_not_gt hnlt
-    have hball_subset :
-        (Kfin ∪ Metric.closedBall (0 : ℝ≥0) R)ᶜ ⊆
-          (Metric.closedBall (0 : ℝ≥0) R)ᶜ :=
-      compl_subset_compl.mpr (subset_union_right)
-    have htail :=
-      measure_closedBall_compl_le_of_representsLaplace_shift (hμ n) hx_pos hR_pos
-    have hden : 1 - Real.exp (-(x * R)) = 1 - Real.exp (-1) := by
-      dsimp [R]
-      rw [mul_inv_cancel₀ hx_pos.ne']
-    have hquot :
-        ENNReal.ofReal
-          ((f (a n) - f (x + a n)) / (1 - Real.exp (-(x * R)))) ≤ ε := by
-      rw [hden]
-      exact ENNReal.ofReal_le_of_le_toReal (hN n hNn)
-    calc
-      μ n (Kfin ∪ Metric.closedBall (0 : ℝ≥0) R)ᶜ
-          ≤ μ n (Metric.closedBall (0 : ℝ≥0) R)ᶜ := measure_mono hball_subset
-      _ ≤ ENNReal.ofReal
-            ((f (a n) - f (x + a n)) / (1 - Real.exp (-(x * R)))) := htail
-      _ ≤ ε := hquot
-
-/-- The representing measure of the positive shift `t ↦ f (t + δ)` has total mass
-`f δ ≤ f 0`. -/
-private lemma measure_univ_le_of_representsLaplace_shift
-    {f : ℝ → ℝ} (hf : IsContinuousCompletelyMonotoneOnIoi f) {δ : ℝ} (hδ : 0 ≤ δ)
-    {μ : Measure ℝ≥0} (hμ : RepresentsLaplace μ (fun t : ℝ => f (t + δ))) :
-    μ univ ≤ ENNReal.ofReal (f 0) := by
-  have := hμ.isFiniteMeasure
-  have hreal : μ.real univ = f δ := by
-    simpa [laplaceTransform_zero] using (hμ.eq_laplaceTransform (t := 0) le_rfl).symm
-  calc
-    μ univ = ENNReal.ofReal (μ.real univ) := by rw [ofReal_measureReal]
-    _ ≤ ENNReal.ofReal (f 0) :=
-        ENNReal.ofReal_le_ofReal (hreal ▸ hf.le_apply_zero hδ)
-
 /-- **Existence half of the Hausdorff--Bernstein--Widder theorem**: a function continuous on
 `[0, ∞)` and completely monotone on `(0, ∞)` is the Laplace transform of a finite positive
 measure on `ℝ≥0`. -/
 theorem exists_representsLaplace_of_isContinuousCompletelyMonotoneOnIoi
     {f : ℝ → ℝ} (hf : IsContinuousCompletelyMonotoneOnIoi f) :
-    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
-  classical
-  -- Stage 1: the positive null sequence of shifts `aₙ = 1/(n+1)`.
-  let a : ℕ → ℝ := fun n => 1 / ((n : ℝ) + 1)
-  have ha_pos : ∀ n, 0 < a n := by
-    intro n
-    dsimp [a]
-    positivity
-  have ha : Tendsto a atTop (𝓝 0) := by
-    simpa [a] using tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ)
-  -- Stage 2: representing measures for the shifted functions, from Bernstein's theorem.
-  have hshift_cm : ∀ n, IsCompletelyMonotone (fun t : ℝ => f (t + a n)) :=
-    fun n => hf.isCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const (ha_pos n)
-  choose μ hμ using fun n =>
-    exists_representsLaplace_of_isCompletelyMonotone (hshift_cm n)
-  -- Stage 3: a uniform mass bound and tightness give a weak cluster point.
-  let C : ℝ≥0 := ⟨f 0, hf.nonneg_zero⟩
-  have hmass : ∀ n, (μ n) univ ≤ (C : ENNReal) := fun n =>
-    calc
-      (μ n) univ ≤ ENNReal.ofReal (f 0) :=
-        measure_univ_le_of_representsLaplace_shift hf (ha_pos n).le (hμ n)
-      _ = (C : ENNReal) := ENNReal.ofReal_eq_coe_nnreal hf.nonneg_zero
-  have htight : IsTightMeasureSet (Set.range μ) :=
-    isTightMeasureSet_range_of_representsLaplace_shift hf.continuousOn ha_pos ha hμ
-  obtain ⟨μ₀, U, hUle, hμ₀_fin, _hmass₀, hweak⟩ :=
-    finite_measure_cluster_limit (σ := μ) C hmass htight
-  -- Stage 4: identify the cluster point as a representing measure via continuity at `0⁺`.
-  refine ⟨μ₀, representsLaplace_iff.mpr ⟨hμ₀_fin, fun t ht => ?_⟩⟩
-  have hf_arg_U : Tendsto (fun n => f (t + a n)) (U : Filter ℕ) (𝓝 (f t)) :=
-    (tendsto_apply_add_of_continuousOn hf.continuousOn ht ha_pos ha).mono_left hUle
-  have hshift_laplace :
-      Tendsto (fun n => ∫ p, Real.exp (-(t * (p : ℝ))) ∂(μ n)) (U : Filter ℕ)
-        (𝓝 (f t)) := by
-    refine Tendsto.congr (fun n => ?_) hf_arg_U
-    rw [(hμ n).eq_laplaceTransform (t := t) ht, laplaceTransform_apply]
-  have hweak_laplace :
-      Tendsto (fun n => ∫ p, Real.exp (-(t * (p : ℝ))) ∂(μ n)) (U : Filter ℕ)
-        (𝓝 (laplaceTransform μ₀ t)) := by
-    rw [laplaceTransform_apply]
-    simpa using hweak (laplaceKernelBoundedContinuous ht)
-  exact tendsto_nhds_unique hshift_laplace hweak_laplace
+    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f :=
+  exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt
+    hf.isDifferenceCompletelyMonotone
+    (hf.continuousOn.continuousWithinAt (mem_Ici.2 le_rfl))
 
 /-! ## Headline theorem -/
 

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
@@ -301,8 +301,8 @@ private lemma IsDifferenceCompletelyMonotone.continuousAt_of_pos
   have hq_nonneg : 0 ≤ (1 - c) * x := mul_nonneg (sub_nonneg.mpr hc_lt_one.le) hx.le
   have hy_nonneg : 0 ≤ y := hq_nonneg.trans hy_bounds.1.le
   have hr_nonneg : 0 ≤ (1 + c) * x := by positivity
-  have hq := hdyadic n
-  change f ((1 - c) * x) ≤ c * f 0 + (1 - c) * f x at hq
+  have hq : f ((1 - c) * x) ≤ c * f 0 + (1 - c) * f x := by
+    simpa only [c] using hdyadic n
   have hy_upper : f y < f x + ε := by
     have := hf.antitoneOn (mem_Ici.2 hq_nonneg) (mem_Ici.2 hy_nonneg) hy_bounds.1.le
     nlinarith

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
@@ -148,8 +148,9 @@ theorem RepresentsLaplace.isDifferenceCompletelyMonotone {μ : Measure ℝ≥0}
 
 /-! ## Tightness of the approximating measures -/
 
-/-- **The approximating measures of a continuous finite-difference completely monotone function
-are uniformly tight.** The mass a member of the family puts outside a large ball is bounded, by
+/-- **The approximating measures of a finite-difference completely monotone function that is
+right-continuous at zero are uniformly tight.** The mass a member of the family puts outside a
+large ball is bounded, by
 `TauCeti.measure_compl_closedBall_le_sub_laplaceTransform_div`, by its Laplace gap
 `μ.real univ - laplaceTransform μ x`, and the squeeze bounds that gap by `f 0 - f (x + aₙ)`.
 Choosing `x` so small that `f` has barely dropped by `2x` makes the estimate uniform over all

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
@@ -5,53 +5,98 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Theorem
+public import TauCeti.Analysis.CompletelyMonotone.Laplace.Representation
 public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Mollify
+-- Non-public: Bernstein's theorem supplies the representing measures of the smoothings, its
+-- closed-half-line strengthening turns the cluster point back into a statement about `f`, and
+-- Prokhorov extracts that cluster point from the tight family.
+import TauCeti.Analysis.CompletelyMonotone.Bernstein.Theorem
+import TauCeti.Analysis.CompletelyMonotone.Bernstein.HausdorffBernsteinWidder
+import TauCeti.MeasureTheory.Measure.Prokhorov
+import TauCeti.MeasureTheory.Measure.Tight
 
 /-!
-# Approximate Bernstein representation from finite differences
+# The Hausdorff--Bernstein--Widder theorem in finite-difference form
 
 Bernstein's theorem in the form
 `TauCeti.exists_representsLaplace_of_isCompletelyMonotone` takes a completely monotone function,
 that is a *smooth* one with alternating iterated derivatives, and produces a finite measure on
 `ℝ≥0` whose Laplace transform it is. The hypothesis available in applications is the
-finite-difference one of
-`TauCeti.IsDifferenceCompletelyMonotone`, which carries no smoothness.
+finite-difference one of `TauCeti.IsDifferenceCompletelyMonotone`, which carries no smoothness:
+what one can check about the mass of a family of measures, or about a function built from
+positive-definiteness data, is that its mixed forward differences alternate in sign.
+
+This file closes the gap between the two, in both directions.
 
 Feeding the smoothing of
 `TauCeti.IsDifferenceCompletelyMonotone.exists_isCompletelyMonotone_between_shift` into Bernstein's
-theorem bridges the two up to an arbitrarily small shift of the argument: a function on `[0, ∞)`
+theorem bridges them up to an arbitrarily small shift of the argument: a function on `[0, ∞)`
 all of whose mixed forward differences alternate is squeezed, for every `ε > 0`, between
-the shift `f (· + ε)` and `f` by the Laplace transform of a finite measure.
+the shift `f (· + ε)` and `f` by the Laplace transform of a finite measure
+(`TauCeti.IsDifferenceCompletelyMonotone.exists_isFiniteMeasure_laplaceTransform_between_shift`).
 
-What is *not* done here is the passage to the limit `ε → 0`, and compactness alone does not
-achieve it: the finite-difference hypothesis says nothing about the behaviour of `f` at the
-endpoint. The indicator `f 0 = 1`, `f t = 0` for `t ≠ 0` has every mixed difference with
-nonnegative steps of the required sign on `[0, ∞)` — with all steps positive, the only surviving
-term of `Δ_{h₁} ⋯ Δ_{hₙ} f` at a point of `[0, ∞)` is `(-1)ⁿ f 0` at the origin — while no finite
-positive measure has it as its Laplace transform. A full representation therefore needs
-right-continuity at `0` on top of the weak cluster point of the approximating measures, the
-compactness step that Bernstein's own existence proof performs for the Chafaï measures.
+Compactness alone does not remove the shift, because the finite-difference hypothesis says
+nothing about the behaviour of `f` at the endpoint: the indicator `f 0 = 1`, `f t = 0` for
+`t ≠ 0` has every mixed difference with nonnegative steps of the required sign on `[0, ∞)` —
+with all steps positive, the only surviving term of `Δ_{h₁} ⋯ Δ_{hₙ} f` at a point of `[0, ∞)` is
+`(-1)ⁿ f 0` at the origin — while no finite positive measure has it as its Laplace transform. With
+continuity of `f` on `[0, ∞)` added, however, the approximating measures are uniformly tight (a
+Markov bound on the coordinate `p ↦ 1 - e^{-xp}` against the Laplace gap
+`f 0 - f x`, which continuity at `0` makes uniformly small), so Prokhorov produces a weak cluster
+point, and the squeeze identifies its Laplace transform as `f`.
+
+Continuity is assumed on all of `[0, ∞)`, although right-continuity at `0` is the only part of it
+that is not automatic: taking two equal steps in the sign condition makes `f` midpoint convex on
+`[0, ∞)`, and it is bounded there by `f 0`, so Bernstein--Doetsch would give continuity on
+`(0, ∞)` for free. Mathlib has no midpoint-convexity regularity theory, so that strengthening is
+left out rather than assumed; every application here supplies continuity anyway.
+
+The converse is a direct computation: for a finite measure `μ` the mixed difference
+`Δ_{h₁} ⋯ Δ_{hₙ} (laplaceTransform μ)` at `t` is
+`(-1)ⁿ ∫ ∏ᵢ (1 - e^{-hᵢp}) · e^{-tp} ∂μ`, an integral of a nonnegative integrand.
+
+Together the two directions say that on functions continuous on `[0, ∞)` the finite-difference
+notion is *equivalent* to the derivative notion of
+`TauCeti.IsContinuousCompletelyMonotoneOnIoi` — no smoothness needs to be assumed, only
+concluded. `TauCeti.IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi` is the
+form in which applications use it, since the derivative predicate is what
+`TauCeti.bernsteinMeasure` and `TauCeti.bernsteinMeasureKernel` consume.
 
 ## Main declarations
 
 * `TauCeti.IsDifferenceCompletelyMonotone.exists_isFiniteMeasure_laplaceTransform_between_shift`:
-  the approximate
-  Laplace representation of a finite-difference completely monotone function.
+  the approximate Laplace representation of a finite-difference completely monotone function.
+* `TauCeti.isDifferenceCompletelyMonotone_laplaceTransform` and
+  `TauCeti.RepresentsLaplace.isDifferenceCompletelyMonotone`: the easy direction, that a Laplace
+  transform of a finite measure has alternating mixed differences.
+* `TauCeti.exists_representsLaplace_of_isDifferenceCompletelyMonotone`: **the representation
+  theorem**, that a continuous function with alternating mixed differences is the Laplace
+  transform of a finite measure.
+* `TauCeti.hausdorff_bernstein_widder_difference`: the resulting characterization of the
+  Laplace transforms of finite measures on `ℝ≥0`.
+* `TauCeti.isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone` and
+  `TauCeti.IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi`: the two notions
+  of complete monotonicity agree on functions continuous on `[0, ∞)`.
 
 ## References
 
 * D. V. Widder, *The Laplace Transform* (Princeton, 1941), Chapter IV.
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984).
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B (Bernstein theorem
+  milestone) and Part C, Milestone 2 (BCR semigroup--Bochner).
 -/
 
 public section
 
-open MeasureTheory Set
-open scoped NNReal
+open Filter MeasureTheory Set
+open scoped ENNReal NNReal Topology
 
 namespace TauCeti
 
 variable {f : ℝ → ℝ}
+
+/-! ## Approximate representation from the finite-difference hypothesis -/
 
 /-- **Approximate Bernstein representation.** A function that is completely monotone in the
 finite-difference sense is squeezed, for every `ε > 0`, between
@@ -59,7 +104,8 @@ finite-difference sense is squeezed, for every `ε > 0`, between
 
 A Bernstein representation of `f` itself does not follow from these measures by compactness
 alone: the hypothesis leaves the value at the endpoint free, so it needs right-continuity of `f`
-at `0` in addition to a weak cluster point as `ε → 0`. -/
+at `0`, which is what
+`TauCeti.exists_representsLaplace_of_isDifferenceCompletelyMonotone` adds. -/
 theorem IsDifferenceCompletelyMonotone.exists_isFiniteMeasure_laplaceTransform_between_shift
     (hf : IsDifferenceCompletelyMonotone f) {ε : ℝ} (hε : 0 < ε) :
     ∃ μ : Measure ℝ≥0, IsFiniteMeasure μ ∧ ∀ t : ℝ, 0 ≤ t →
@@ -70,4 +116,287 @@ theorem IsDifferenceCompletelyMonotone.exists_isFiniteMeasure_laplaceTransform_b
   rw [← hμ.eq_laplaceTransform ht]
   exact hgle t ht
 
+/-! ## The easy direction: Laplace transforms have alternating mixed differences -/
+
+/-- The integrand computing a mixed forward difference of a Laplace transform: the product of the
+factors `1 - e^{-hp}` over the list `l` of steps, against the Laplace kernel `e^{-tp}`. -/
+private noncomputable def laplaceDiffIntegrand (l : List ℝ) (t : ℝ) (p : ℝ≥0) : ℝ :=
+  (l.map fun h => 1 - Real.exp (-(h * (p : ℝ)))).prod * Real.exp (-(t * (p : ℝ)))
+
+private lemma laplaceDiffIntegrand_nil (t : ℝ) (p : ℝ≥0) :
+    laplaceDiffIntegrand [] t p = Real.exp (-(t * (p : ℝ))) := by
+  simp [laplaceDiffIntegrand]
+
+private lemma laplaceDiffIntegrand_cons (a : ℝ) (l : List ℝ) (t : ℝ) (p : ℝ≥0) :
+    laplaceDiffIntegrand (a :: l) t p
+      = (1 - Real.exp (-(a * (p : ℝ)))) * laplaceDiffIntegrand l t p := by
+  simp [laplaceDiffIntegrand, mul_assoc]
+
+/-- Advancing the Laplace parameter by `a` multiplies the integrand by `e^{-ap}`; this is what
+turns a forward difference in `t` into one more factor of the product. -/
+private lemma laplaceDiffIntegrand_add (l : List ℝ) (t a : ℝ) (p : ℝ≥0) :
+    laplaceDiffIntegrand l (t + a) p
+      = Real.exp (-(a * (p : ℝ))) * laplaceDiffIntegrand l t p := by
+  simp only [laplaceDiffIntegrand]
+  rw [show -((t + a) * (p : ℝ)) = -(a * (p : ℝ)) + -(t * (p : ℝ)) by ring, Real.exp_add]
+  ring
+
+/-- Each factor of the integrand lies in `[0, 1]`, hence so does the integrand. -/
+private lemma laplaceDiffIntegrand_mem_Icc : ∀ (l : List ℝ), (∀ h ∈ l, 0 ≤ h) →
+    ∀ (t : ℝ), 0 ≤ t → ∀ p : ℝ≥0, laplaceDiffIntegrand l t p ∈ Icc (0 : ℝ) 1 := by
+  intro l
+  induction l with
+  | nil =>
+      intro _ t ht p
+      rw [laplaceDiffIntegrand_nil]
+      exact ⟨(Real.exp_pos _).le, exp_neg_mul_le_one ht p⟩
+  | cons a l ih =>
+      intro hl t ht p
+      have ha : 0 ≤ a := hl a (by simp)
+      obtain ⟨h0, h1⟩ := ih (fun h hh => hl h (by simp [hh])) t ht p
+      have hfac0 : 0 ≤ 1 - Real.exp (-(a * (p : ℝ))) :=
+        sub_nonneg.mpr (exp_neg_mul_le_one ha p)
+      have hfac1 : 1 - Real.exp (-(a * (p : ℝ))) ≤ 1 := by
+        have := (Real.exp_pos (-(a * (p : ℝ)))).le
+        linarith
+      rw [laplaceDiffIntegrand_cons]
+      exact ⟨mul_nonneg hfac0 h0, by simpa using mul_le_mul hfac1 h1 h0 zero_le_one⟩
+
+private lemma continuous_laplaceDiffIntegrand (l : List ℝ) (t : ℝ) :
+    Continuous (laplaceDiffIntegrand l t) := by
+  induction l with
+  | nil =>
+      have hfun : laplaceDiffIntegrand ([] : List ℝ) t
+          = fun p : ℝ≥0 => Real.exp (-(t * (p : ℝ))) := funext (laplaceDiffIntegrand_nil t)
+      rw [hfun]
+      exact continuous_exp_neg_mul t
+  | cons a l ih =>
+      have hfun : laplaceDiffIntegrand (a :: l) t
+          = fun p : ℝ≥0 => (1 - Real.exp (-(a * (p : ℝ)))) * laplaceDiffIntegrand l t p :=
+        funext (laplaceDiffIntegrand_cons a l t)
+      rw [hfun]
+      exact (continuous_const.sub (continuous_exp_neg_mul a)).mul ih
+
+private lemma integrable_laplaceDiffIntegrand (μ : Measure ℝ≥0) [IsFiniteMeasure μ] {l : List ℝ}
+    (hl : ∀ h ∈ l, 0 ≤ h) {t : ℝ} (ht : 0 ≤ t) : Integrable (laplaceDiffIntegrand l t) μ := by
+  refine (integrable_const (1 : ℝ)).mono'
+    (continuous_laplaceDiffIntegrand l t).aestronglyMeasurable (.of_forall fun p => ?_)
+  obtain ⟨h0, h1⟩ := laplaceDiffIntegrand_mem_Icc l hl t ht p
+  rw [Real.norm_eq_abs, abs_of_nonneg h0]
+  exact h1
+
+/-- **A mixed forward difference of a Laplace transform is an integral.** Differencing with the
+step `h` multiplies the integrand by `e^{-hp} - 1`, so a mixed difference along `l` accumulates
+the product of those factors; pulling out the sign leaves the nonnegative integrand
+`∏ᵢ (1 - e^{-hᵢp}) · e^{-tp}`. -/
+private lemma fwdDiffList_laplaceTransform (μ : Measure ℝ≥0) [IsFiniteMeasure μ] :
+    ∀ (l : List ℝ), (∀ h ∈ l, 0 ≤ h) → ∀ (t : ℝ), 0 ≤ t →
+      fwdDiffList l (laplaceTransform μ) t
+        = (-1) ^ l.length * ∫ p, laplaceDiffIntegrand l t p ∂μ := by
+  intro l
+  induction l with
+  | nil =>
+      intro _ t _
+      simp only [fwdDiffList_nil, List.length_nil, pow_zero, one_mul]
+      simp_rw [laplaceDiffIntegrand_nil]
+      exact laplaceTransform_apply μ t
+  | cons a l ih =>
+      intro hl t ht
+      have ha : 0 ≤ a := hl a (by simp)
+      have hl' : ∀ h ∈ l, 0 ≤ h := fun h hh => hl h (by simp [hh])
+      have hta : (0 : ℝ) ≤ t + a := by linarith
+      have hpt : ∀ p : ℝ≥0, laplaceDiffIntegrand l (t + a) p - laplaceDiffIntegrand l t p
+          = -laplaceDiffIntegrand (a :: l) t p := by
+        intro p
+        rw [laplaceDiffIntegrand_add, laplaceDiffIntegrand_cons]
+        ring
+      rw [fwdDiffList_cons, fwdDiff, ih hl' (t + a) hta, ih hl' t ht, ← mul_sub,
+        ← integral_sub (integrable_laplaceDiffIntegrand μ hl' hta)
+          (integrable_laplaceDiffIntegrand μ hl' ht)]
+      simp_rw [hpt]
+      rw [integral_neg, List.length_cons, pow_succ]
+      ring
+
+/-- **The Laplace transform of a finite measure is completely monotone in the finite-difference
+sense.** Every mixed forward difference with nonnegative steps has the sign `(-1)ⁿ`, because it
+is `(-1)ⁿ` times the integral of a nonnegative function. -/
+theorem isDifferenceCompletelyMonotone_laplaceTransform (μ : Measure ℝ≥0) [IsFiniteMeasure μ] :
+    IsDifferenceCompletelyMonotone (laplaceTransform μ) := by
+  refine isDifferenceCompletelyMonotone_iff.2 fun l hl t ht => ?_
+  rw [fwdDiffList_laplaceTransform μ l hl t ht, ← mul_assoc, ← pow_add, ← two_mul, pow_mul,
+    neg_one_sq, one_pow, one_mul]
+  exact integral_nonneg fun p => (laplaceDiffIntegrand_mem_Icc l hl t ht p).1
+
+/-- A function represented by a finite measure through its Laplace transform is completely
+monotone in the finite-difference sense. -/
+theorem RepresentsLaplace.isDifferenceCompletelyMonotone {μ : Measure ℝ≥0}
+    (h : RepresentsLaplace μ f) : IsDifferenceCompletelyMonotone f := by
+  have := h.isFiniteMeasure
+  exact (isDifferenceCompletelyMonotone_laplaceTransform μ).congr fun t ht =>
+    h.eq_laplaceTransform ht
+
+/-! ## Tightness of the approximating measures -/
+
+/-- **The approximating measures of a continuous finite-difference completely monotone function
+are uniformly tight.** The mass a member of the family puts outside a large ball is bounded, by
+`TauCeti.measure_compl_closedBall_le_of_laplaceTransform`, by its Laplace gap
+`μ.real univ - laplaceTransform μ x`, and the squeeze bounds that gap by `f 0 - f (x + aₙ)`.
+Choosing `x` so small that `f` has barely dropped by `2x` makes the estimate uniform over all
+shifts `aₙ ≤ x`; the finitely many larger shifts are handled by
+`TauCeti.isTightMeasureSet_range_finite`. -/
+private lemma isTightMeasureSet_range_of_laplaceTransform_between_shift
+    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousOn f (Ici 0))
+    {a : ℕ → ℝ} (ha_pos : ∀ n, 0 < a n) (ha : Tendsto a atTop (𝓝 0))
+    {μ : ℕ → Measure ℝ≥0} (hfin : ∀ n, IsFiniteMeasure (μ n))
+    (hlow : ∀ n, ∀ t : ℝ, 0 ≤ t → f (t + a n) ≤ laplaceTransform (μ n) t)
+    (hhigh : ∀ n, ∀ t : ℝ, 0 ≤ t → laplaceTransform (μ n) t ≤ f t) :
+    IsTightMeasureSet (range μ) := by
+  rw [isTightMeasureSet_iff_exists_isCompact_measure_compl_le]
+  intro ε hε
+  by_cases hε_top : ε = ∞
+  · exact ⟨∅, isCompact_empty, fun ν _ => by simp [hε_top]⟩
+  have hε_pos : 0 < ε.toReal := ENNReal.toReal_pos hε.ne' hε_top
+  have hc_pos : 0 < 1 - Real.exp (-1 : ℝ) := by
+    have : Real.exp (-1 : ℝ) < 1 := Real.exp_lt_one_iff.mpr (by norm_num)
+    linarith
+  -- A point `y > 0` at which `f` has dropped from `f 0` by less than `ε.toReal * (1 - e⁻¹)`.
+  have hcw : Tendsto f (𝓝[>] (0 : ℝ)) (𝓝 (f 0)) :=
+    (hcont.continuousWithinAt (mem_Ici.2 le_rfl)).tendsto.mono_left
+      (nhdsWithin_mono _ Ioi_subset_Ici_self)
+  obtain ⟨y, hy, hy_pos⟩ :=
+    ((hcw.eventually (eventually_gt_nhds
+      (show f 0 - ε.toReal * (1 - Real.exp (-1 : ℝ)) < f 0 by nlinarith))).and
+        self_mem_nhdsWithin).exists
+  -- The Markov parameter is `y / 2` and the radius its inverse, so that their product is `1`.
+  have hx_pos : 0 < y / 2 := by linarith
+  have hR_pos : 0 < (y / 2)⁻¹ := inv_pos.mpr hx_pos
+  have hden : 1 - Real.exp (-(y / 2 * (y / 2)⁻¹)) = 1 - Real.exp (-1 : ℝ) := by
+    rw [mul_inv_cancel₀ hx_pos.ne']
+  obtain ⟨N, hN⟩ := eventually_atTop.1 (ha.eventually (eventually_lt_nhds hx_pos))
+  -- The finitely many shifts larger than `x` are tight on their own.
+  obtain ⟨K, hK_compact, hK_tail⟩ :=
+    isTightMeasureSet_iff_exists_isCompact_measure_compl_le.mp
+      (isTightMeasureSet_range_finite (fun n : {n : ℕ // n < N} => μ n) fun n => hfin n) ε hε
+  refine ⟨K ∪ Metric.closedBall (0 : ℝ≥0) (y / 2)⁻¹,
+    hK_compact.union (isCompact_closedBall _ _), ?_⟩
+  rintro ν ⟨n, rfl⟩
+  by_cases hn : n < N
+  · exact (measure_mono (compl_subset_compl.mpr subset_union_left)).trans
+      (hK_tail (μ n) ⟨⟨n, hn⟩, rfl⟩)
+  -- Beyond the threshold the Markov bound applies with a uniform numerator.
+  have hnN : N ≤ n := le_of_not_gt hn
+  have hfin_n := hfin n
+  have hmass : (μ n).real univ ≤ f 0 := by
+    simpa [laplaceTransform_zero] using hhigh n 0 le_rfl
+  have han : a n < y / 2 := hN n hnN
+  have han_pos : 0 < a n := ha_pos n
+  have hgap : f y ≤ laplaceTransform (μ n) (y / 2) :=
+    le_trans (hf.antitoneOn (mem_Ici.2 (by linarith)) (mem_Ici.2 hy_pos.le) (by linarith))
+      (hlow n (y / 2) hx_pos.le)
+  have hnum : (μ n).real univ - laplaceTransform (μ n) (y / 2)
+      ≤ ε.toReal * (1 - Real.exp (-1 : ℝ)) := by linarith
+  calc
+    μ n (K ∪ Metric.closedBall (0 : ℝ≥0) (y / 2)⁻¹)ᶜ
+        ≤ μ n (Metric.closedBall (0 : ℝ≥0) (y / 2)⁻¹)ᶜ :=
+      measure_mono (compl_subset_compl.mpr subset_union_right)
+    _ ≤ ENNReal.ofReal (((μ n).real univ - laplaceTransform (μ n) (y / 2))
+          / (1 - Real.exp (-(y / 2 * (y / 2)⁻¹)))) :=
+      measure_compl_closedBall_le_of_laplaceTransform (μ n) hx_pos hR_pos
+    _ ≤ ENNReal.ofReal ε.toReal := by
+      rw [hden]
+      exact ENNReal.ofReal_le_ofReal ((div_le_iff₀ hc_pos).2 hnum)
+    _ ≤ ε := ENNReal.ofReal_le_of_le_toReal le_rfl
+
+/-! ## The representation theorem -/
+
+/-- **The existence half of the Hausdorff--Bernstein--Widder theorem in finite-difference form.**
+A function continuous on `[0, ∞)` all of whose mixed forward differences with nonnegative steps
+have the sign `(-1)ⁿ` is the Laplace transform of a finite positive measure on `ℝ≥0`.
+
+The smoothings of `f` at the shifts `aₙ = 1/(n+1)` have representing measures squeezing `f`
+between `f (· + aₙ)` and `f`; they are uniformly bounded in mass by `f 0` and uniformly tight, so
+Prokhorov supplies a weak cluster point `μ₀`. Continuity of `f` closes the squeeze: the Laplace
+transform of `μ₀` at `t` is at most `f t`, and at least `f s` for every `s > t`. -/
+theorem exists_representsLaplace_of_isDifferenceCompletelyMonotone
+    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousOn f (Ici 0)) :
+    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
+  classical
+  -- Stage 1: the positive null sequence of shifts and the approximating measures.
+  have ha_pos : ∀ n : ℕ, 0 < 1 / ((n : ℝ) + 1) := fun n => by positivity
+  have ha : Tendsto (fun n : ℕ => 1 / ((n : ℝ) + 1)) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat
+  choose μ hfin hbetween using fun n : ℕ =>
+    hf.exists_isFiniteMeasure_laplaceTransform_between_shift (ha_pos n)
+  have hlow : ∀ n : ℕ, ∀ t : ℝ, 0 ≤ t → f (t + 1 / ((n : ℝ) + 1)) ≤ laplaceTransform (μ n) t :=
+    fun n t ht => (hbetween n t ht).1
+  have hhigh : ∀ n : ℕ, ∀ t : ℝ, 0 ≤ t → laplaceTransform (μ n) t ≤ f t :=
+    fun n t ht => (hbetween n t ht).2
+  -- Stage 2: the uniform mass bound and tightness feed Prokhorov.
+  have hmass : ∀ n : ℕ, (μ n) univ ≤ (((f 0).toNNReal : ℝ≥0) : ℝ≥0∞) := by
+    intro n
+    have := hfin n
+    have hle : (μ n).real univ ≤ f 0 := by
+      simpa [laplaceTransform_zero] using hhigh n 0 le_rfl
+    calc (μ n) univ = ENNReal.ofReal ((μ n).real univ) :=
+        (ofReal_measureReal (measure_ne_top _ _)).symm
+      _ ≤ ENNReal.ofReal (f 0) := ENNReal.ofReal_le_ofReal hle
+      _ = (((f 0).toNNReal : ℝ≥0) : ℝ≥0∞) := rfl
+  obtain ⟨μ₀, U, hUle, hμ₀_fin, -, hweak⟩ :=
+    finite_measure_cluster_limit μ (f 0).toNNReal hmass
+      (isTightMeasureSet_range_of_laplaceTransform_between_shift hf hcont ha_pos ha hfin
+        hlow hhigh)
+  -- Stage 3: the squeeze identifies the Laplace transform of the cluster point as `f`.
+  refine ⟨μ₀, representsLaplace_iff.mpr ⟨hμ₀_fin, fun t ht => ?_⟩⟩
+  have hL : Tendsto (fun n => laplaceTransform (μ n) t) (U : Filter ℕ)
+      (𝓝 (laplaceTransform μ₀ t)) := by
+    have hw := hweak (laplaceKernelBoundedContinuous ht)
+    simp only [laplaceKernelBoundedContinuous_apply] at hw
+    simpa only [laplaceTransform_apply] using hw
+  have hupper : laplaceTransform μ₀ t ≤ f t :=
+    le_of_tendsto hL (.of_forall fun n => hhigh n t ht)
+  have hlower : ∀ s : ℝ, t < s → f s ≤ laplaceTransform μ₀ t := by
+    intro s hs
+    refine ge_of_tendsto hL (Eventually.filter_mono hUle ?_)
+    filter_upwards [ha.eventually (eventually_lt_nhds (by linarith : (0 : ℝ) < s - t))] with n hn
+    refine le_trans (hf.antitoneOn (mem_Ici.2 (by positivity)) (mem_Ici.2 (by linarith))
+      (by linarith)) (hlow n t ht)
+  have hcw : Tendsto f (𝓝[>] t) (𝓝 (f t)) :=
+    (hcont.continuousWithinAt (mem_Ici.2 ht)).tendsto.mono_left
+      (nhdsWithin_mono t fun s hs => mem_Ici.2 (ht.trans (le_of_lt hs)))
+  have hft : f t ≤ laplaceTransform μ₀ t :=
+    le_of_tendsto hcw (eventually_mem_nhdsWithin.mono fun s hs => hlower s hs)
+  exact le_antisymm hft hupper
+
+/-- **The Hausdorff--Bernstein--Widder theorem in finite-difference form.** A function is
+continuous on `[0, ∞)` with alternating mixed forward differences if and only if it is the
+Laplace transform of a finite positive measure on `ℝ≥0`. -/
+theorem hausdorff_bernstein_widder_difference (f : ℝ → ℝ) :
+    (IsDifferenceCompletelyMonotone f ∧ ContinuousOn f (Ici 0))
+      ↔ ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
+  refine ⟨fun ⟨hf, hcont⟩ => exists_representsLaplace_of_isDifferenceCompletelyMonotone hf hcont,
+    fun ⟨μ, hμ⟩ =>
+      ⟨hμ.isDifferenceCompletelyMonotone, hμ.isContinuousCompletelyMonotoneOnIoi.continuousOn⟩⟩
+
+/-- **The two notions of complete monotonicity agree on continuous functions.** For a function
+continuous on `[0, ∞)`, complete monotonicity in the derivative sense on `(0, ∞)` is equivalent
+to the sign condition on all mixed forward differences, which mentions no derivatives at all.
+Compare `TauCeti.isCompletelyMonotone_iff_isDifferenceCompletelyMonotone`, which assumes
+smoothness; here smoothness is a conclusion. -/
+theorem isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone (f : ℝ → ℝ) :
+    IsContinuousCompletelyMonotoneOnIoi f
+      ↔ IsDifferenceCompletelyMonotone f ∧ ContinuousOn f (Ici 0) := by
+  rw [hausdorff_bernstein_widder f]
+  exact (hausdorff_bernstein_widder_difference f).symm
+
+/-- **From finite differences to derivatives.** This is the form in which applications use the
+equivalence: the Bernstein measure and the Bernstein kernel take
+`TauCeti.IsContinuousCompletelyMonotoneOnIoi` as their hypothesis, while what is checkable in
+practice is the finite-difference condition. -/
+theorem IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi
+    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousOn f (Ici 0)) :
+    IsContinuousCompletelyMonotoneOnIoi f :=
+  (isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone f).2 ⟨hf, hcont⟩
+
 end TauCeti
+
+end

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
@@ -7,11 +7,10 @@ module
 
 public import TauCeti.Analysis.CompletelyMonotone.Laplace.Representation
 public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Mollify
--- Non-public: Bernstein's theorem supplies the representing measures of the smoothings, its
--- closed-half-line strengthening turns the cluster point back into a statement about `f`, and
--- Prokhorov extracts that cluster point from the tight family.
+-- Non-public: Bernstein's theorem supplies the representing measures of the smoothings,
+-- Prokhorov extracts their weak cluster point, and Tight handles the finitely many exceptional
+-- shifts outside the uniform tail estimate.
 import TauCeti.Analysis.CompletelyMonotone.Bernstein.Theorem
-import TauCeti.Analysis.CompletelyMonotone.Bernstein.HausdorffBernsteinWidder
 import TauCeti.MeasureTheory.Measure.Prokhorov
 import TauCeti.MeasureTheory.Measure.Tight
 
@@ -39,27 +38,22 @@ Compactness alone does not remove the shift, because the finite-difference hypot
 nothing about the behaviour of `f` at the endpoint: the indicator `f 0 = 1`, `f t = 0` for
 `t ≠ 0` has every mixed difference with nonnegative steps of the required sign on `[0, ∞)` —
 with all steps positive, the only surviving term of `Δ_{h₁} ⋯ Δ_{hₙ} f` at a point of `[0, ∞)` is
-`(-1)ⁿ f 0` at the origin — while no finite positive measure has it as its Laplace transform. With
-continuity of `f` on `[0, ∞)` added, however, the approximating measures are uniformly tight (a
-Markov bound on the coordinate `p ↦ 1 - e^{-xp}` against the Laplace gap
-`f 0 - f x`, which continuity at `0` makes uniformly small), so Prokhorov produces a weak cluster
-point, and the squeeze identifies its Laplace transform as `f`.
+`(-1)ⁿ f 0` at the origin — while no finite positive measure has it as its Laplace transform.
+Right-continuity at `0` is enough: it makes the Laplace gaps uniformly small, so Prokhorov gives a
+weak cluster point. The squeeze is closed at `0` by the assumed right-continuity and at positive
+parameters by continuity of the cluster point's Laplace transform.
 
-Right-continuity at `0` is the only continuity assumption needed: taking two equal steps in the
-sign condition makes `f` midpoint convex on `[0, ∞)`, while the one-step condition makes it
-antitone there. Iterating the midpoint inequality at dyadic points approaching any `t > 0`
-therefore squeezes `f` to continuity at `t`.
+For the converse, positive shifts of a continuous completely monotone function satisfy the
+finite-difference condition by the smooth equivalence in `FiniteDifference/Basic.lean`; closure
+under pointwise limits removes the shift. Applying this to a finite measure's Laplace transform
+gives the easy direction.
 
-The converse is a direct computation: for a finite measure `μ` the mixed difference
-`Δ_{h₁} ⋯ Δ_{hₙ} (laplaceTransform μ)` at `t` is
-`(-1)ⁿ ∫ ∏ᵢ (1 - e^{-hᵢp}) · e^{-tp} ∂μ`, an integral of a nonnegative integrand.
-
-Together the two directions say that on functions continuous on `[0, ∞)` the finite-difference
-notion is *equivalent* to the derivative notion of
+Together the two directions say that the finite-difference notion plus right-continuity at zero
+is *equivalent* to the derivative notion of
 `TauCeti.IsContinuousCompletelyMonotoneOnIoi` — no smoothness needs to be assumed, only
 concluded. `TauCeti.IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi` is the
-form in which applications use it, since the derivative predicate is what
-`TauCeti.bernsteinMeasure` and `TauCeti.bernsteinMeasureKernel` consume.
+form in which applications use it: `TauCeti.bernsteinMeasureKernel` takes the derivative
+predicate as a hypothesis, and the representation API for `TauCeti.bernsteinMeasure` uses it.
 
 ## Main declarations
 
@@ -73,10 +67,10 @@ form in which applications use it, since the derivative predicate is what
   differences is the Laplace transform of a finite measure.
 * `TauCeti.hausdorff_bernstein_widder_difference`: the resulting characterization of the
   Laplace transforms of finite measures on `ℝ≥0`.
-* `TauCeti.isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone_and_continuousOn`
-  and
+* `TauCeti.hausdorff_bernstein_widder_difference_existsUnique`: its unique-existence form.
+* The endpoint-continuity equivalence between the two complete-monotonicity predicates and
   `TauCeti.IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi`: the two notions
-  of complete monotonicity agree on functions continuous on `[0, ∞)`.
+  of complete monotonicity agree under right-continuity at zero.
 
 ## References
 
@@ -119,212 +113,48 @@ theorem IsDifferenceCompletelyMonotone.exists_isFiniteMeasure_laplaceTransform_b
 
 /-! ## The easy direction: Laplace transforms have alternating mixed differences -/
 
-/-- The integrand computing a mixed forward difference of a Laplace transform: the product of the
-factors `1 - e^{-hp}` over the list `l` of steps, against the Laplace kernel `e^{-tp}`. -/
-private noncomputable def laplaceDiffIntegrand (l : List ℝ) (t : ℝ) (p : ℝ≥0) : ℝ :=
-  (l.map fun h => 1 - Real.exp (-(h * (p : ℝ)))).prod * Real.exp (-(t * (p : ℝ)))
-
-private lemma laplaceDiffIntegrand_nil (t : ℝ) (p : ℝ≥0) :
-    laplaceDiffIntegrand [] t p = Real.exp (-(t * (p : ℝ))) := by
-  simp [laplaceDiffIntegrand]
-
-private lemma laplaceDiffIntegrand_cons (a : ℝ) (l : List ℝ) (t : ℝ) (p : ℝ≥0) :
-    laplaceDiffIntegrand (a :: l) t p
-      = (1 - Real.exp (-(a * (p : ℝ)))) * laplaceDiffIntegrand l t p := by
-  simp [laplaceDiffIntegrand, mul_assoc]
-
-/-- Advancing the Laplace parameter by `a` multiplies the integrand by `e^{-ap}`; this is what
-turns a forward difference in `t` into one more factor of the product. -/
-private lemma laplaceDiffIntegrand_add (l : List ℝ) (t a : ℝ) (p : ℝ≥0) :
-    laplaceDiffIntegrand l (t + a) p
-      = Real.exp (-(a * (p : ℝ))) * laplaceDiffIntegrand l t p := by
-  simp only [laplaceDiffIntegrand]
-  have hsplit : -((t + a) * (p : ℝ)) = -(a * (p : ℝ)) + -(t * (p : ℝ)) := by ring
-  rw [hsplit, Real.exp_add]
-  ring
-
-/-- Each factor of the integrand lies in `[0, 1]`, hence so does the integrand. -/
-private lemma laplaceDiffIntegrand_mem_Icc : ∀ (l : List ℝ), (∀ h ∈ l, 0 ≤ h) →
-    ∀ (t : ℝ), 0 ≤ t → ∀ p : ℝ≥0, laplaceDiffIntegrand l t p ∈ Icc (0 : ℝ) 1 := by
-  intro l
-  induction l with
-  | nil =>
-      intro _ t ht p
-      rw [laplaceDiffIntegrand_nil]
-      exact ⟨(Real.exp_pos _).le, exp_neg_mul_le_one ht p⟩
-  | cons a l ih =>
-      intro hl t ht p
-      have ha : 0 ≤ a := hl a (by simp)
-      obtain ⟨h0, h1⟩ := ih (fun h hh => hl h (by simp [hh])) t ht p
-      have hfac0 : 0 ≤ 1 - Real.exp (-(a * (p : ℝ))) :=
-        sub_nonneg.mpr (exp_neg_mul_le_one ha p)
-      have hfac1 : 1 - Real.exp (-(a * (p : ℝ))) ≤ 1 := by
-        have := (Real.exp_pos (-(a * (p : ℝ)))).le
-        linarith
-      rw [laplaceDiffIntegrand_cons]
-      exact ⟨mul_nonneg hfac0 h0, by simpa using mul_le_mul hfac1 h1 h0 zero_le_one⟩
-
-private lemma continuous_laplaceDiffIntegrand (l : List ℝ) (t : ℝ) :
-    Continuous (laplaceDiffIntegrand l t) := by
-  induction l with
-  | nil =>
-      have hfun : laplaceDiffIntegrand ([] : List ℝ) t
-          = fun p : ℝ≥0 => Real.exp (-(t * (p : ℝ))) := funext (laplaceDiffIntegrand_nil t)
-      rw [hfun]
-      exact continuous_exp_neg_mul t
-  | cons a l ih =>
-      have hfun : laplaceDiffIntegrand (a :: l) t
-          = fun p : ℝ≥0 => (1 - Real.exp (-(a * (p : ℝ)))) * laplaceDiffIntegrand l t p :=
-        funext (laplaceDiffIntegrand_cons a l t)
-      rw [hfun]
-      exact (continuous_const.sub (continuous_exp_neg_mul a)).mul ih
-
-private lemma integrable_laplaceDiffIntegrand (μ : Measure ℝ≥0) [IsFiniteMeasure μ] {l : List ℝ}
-    (hl : ∀ h ∈ l, 0 ≤ h) {t : ℝ} (ht : 0 ≤ t) : Integrable (laplaceDiffIntegrand l t) μ := by
-  refine (integrable_const (1 : ℝ)).mono'
-    (continuous_laplaceDiffIntegrand l t).aestronglyMeasurable (.of_forall fun p => ?_)
-  obtain ⟨h0, h1⟩ := laplaceDiffIntegrand_mem_Icc l hl t ht p
-  rw [Real.norm_eq_abs, abs_of_nonneg h0]
-  exact h1
-
-/-- **A mixed forward difference of a Laplace transform is an integral.** Differencing with the
-step `h` multiplies the integrand by `e^{-hp} - 1`, so a mixed difference along `l` accumulates
-the product of those factors; pulling out the sign leaves the nonnegative integrand
-`∏ᵢ (1 - e^{-hᵢp}) · e^{-tp}`. -/
-private lemma fwdDiffList_laplaceTransform (μ : Measure ℝ≥0) [IsFiniteMeasure μ] :
-    ∀ (l : List ℝ), (∀ h ∈ l, 0 ≤ h) → ∀ (t : ℝ), 0 ≤ t →
-      fwdDiffList l (laplaceTransform μ) t
-        = (-1) ^ l.length * ∫ p, laplaceDiffIntegrand l t p ∂μ := by
-  intro l
-  induction l with
-  | nil =>
-      intro _ t _
-      simp only [fwdDiffList_nil, List.length_nil, pow_zero, one_mul]
-      simp_rw [laplaceDiffIntegrand_nil]
-      exact laplaceTransform_apply μ t
-  | cons a l ih =>
-      intro hl t ht
-      have ha : 0 ≤ a := hl a (by simp)
-      have hl' : ∀ h ∈ l, 0 ≤ h := fun h hh => hl h (by simp [hh])
-      have hta : (0 : ℝ) ≤ t + a := by linarith
-      have hpt : ∀ p : ℝ≥0, laplaceDiffIntegrand l (t + a) p - laplaceDiffIntegrand l t p
-          = -laplaceDiffIntegrand (a :: l) t p := by
-        intro p
-        rw [laplaceDiffIntegrand_add, laplaceDiffIntegrand_cons]
-        ring
-      rw [fwdDiffList_cons, fwdDiff, ih hl' (t + a) hta, ih hl' t ht, ← mul_sub,
-        ← integral_sub (integrable_laplaceDiffIntegrand μ hl' hta)
-          (integrable_laplaceDiffIntegrand μ hl' ht)]
-      simp_rw [hpt]
-      rw [integral_neg, List.length_cons, pow_succ]
-      ring
+/-- A function continuous on `[0, ∞)` and completely monotone on `(0, ∞)` is completely monotone
+in the finite-difference sense. Positive shifts are smooth completely monotone functions, and the
+finite-difference predicate passes to their pointwise limit. -/
+theorem IsContinuousCompletelyMonotoneOnIoi.isDifferenceCompletelyMonotone
+    (hf : IsContinuousCompletelyMonotoneOnIoi f) : IsDifferenceCompletelyMonotone f := by
+  let F : ℕ → ℝ → ℝ := fun n t => f (t + 1 / ((n : ℝ) + 1))
+  refine isDifferenceCompletelyMonotone_of_tendsto (L := atTop) (F := F) (fun n => ?_) ?_
+  · have hshift : 0 < 1 / ((n : ℝ) + 1) := by positivity
+    exact IsCompletelyMonotone.isDifferenceCompletelyMonotone
+      (hf.isCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const hshift)
+  · intro u hu
+    have hzero : Tendsto (fun n : ℕ => 1 / ((n : ℝ) + 1)) atTop (𝓝 0) :=
+      tendsto_one_div_add_atTop_nhds_zero_nat
+    have ha : Tendsto (fun n : ℕ => u + 1 / ((n : ℝ) + 1)) atTop (𝓝[Ici (0 : ℝ)] u) :=
+      tendsto_nhdsWithin_iff.mpr
+        ⟨by simpa using tendsto_const_nhds.add hzero,
+          .of_forall fun n => mem_Ici.mpr (add_nonneg hu (by positivity))⟩
+    change Tendsto (f ∘ fun n : ℕ => u + 1 / ((n : ℝ) + 1)) atTop (𝓝 (f u))
+    exact (hf.continuousOn.continuousWithinAt (mem_Ici.mpr hu)).tendsto.comp ha
 
 /-- **The Laplace transform of a finite measure is completely monotone in the finite-difference
 sense.** Every mixed forward difference with nonnegative steps has the sign `(-1)ⁿ`, because it
 is `(-1)ⁿ` times the integral of a nonnegative function. -/
 theorem isDifferenceCompletelyMonotone_laplaceTransform (μ : Measure ℝ≥0) [IsFiniteMeasure μ] :
-    IsDifferenceCompletelyMonotone (laplaceTransform μ) := by
-  refine isDifferenceCompletelyMonotone_iff.2 fun l hl t ht => ?_
-  rw [fwdDiffList_laplaceTransform μ l hl t ht, ← mul_assoc, ← pow_add, ← two_mul, pow_mul,
-    neg_one_sq, one_pow, one_mul]
-  exact integral_nonneg fun p => (laplaceDiffIntegrand_mem_Icc l hl t ht p).1
+    IsDifferenceCompletelyMonotone (laplaceTransform μ) :=
+  (isContinuousCompletelyMonotoneOnIoi_laplaceTransform μ).isDifferenceCompletelyMonotone
 
 /-- A function represented by a finite measure through its Laplace transform is completely
 monotone in the finite-difference sense. -/
 theorem RepresentsLaplace.isDifferenceCompletelyMonotone {μ : Measure ℝ≥0}
-    (h : RepresentsLaplace μ f) : IsDifferenceCompletelyMonotone f := by
-  have := h.isFiniteMeasure
-  exact (isDifferenceCompletelyMonotone_laplaceTransform μ).congr fun t ht =>
-    h.eq_laplaceTransform ht
-
-/-- A finite-difference completely monotone function is automatically continuous away from the
-endpoint. The equal-step second-difference inequality gives the midpoint bound used below, while
-antitonicity turns its dyadic estimates into a two-sided squeeze. -/
-private lemma IsDifferenceCompletelyMonotone.continuousAt_of_pos
-    (hf : IsDifferenceCompletelyMonotone f) {x : ℝ} (hx : 0 < x) : ContinuousAt f x := by
-  have hmidpoint : ∀ {a h : ℝ}, 0 ≤ a → 0 ≤ h →
-      2 * f (a + h) ≤ f a + f (a + 2 * h) := by
-    intro a h ha hh
-    have hdiff := isDifferenceCompletelyMonotone_iff.mp hf [h, h] (by simpa using hh) a ha
-    simp only [List.length_cons, List.length_nil, fwdDiffList_cons, fwdDiffList_nil, fwdDiff,
-      zero_add, pow_succ, pow_zero] at hdiff
-    have hadd : a + h + h = a + 2 * h := by ring
-    rw [hadd] at hdiff
-    norm_num at hdiff
-    linarith
-  have hdyadic : ∀ n : ℕ,
-      f ((1 - (1 / 2 : ℝ) ^ n) * x) ≤
-        (1 / 2 : ℝ) ^ n * f 0 + (1 - (1 / 2 : ℝ) ^ n) * f x := by
-    intro n
-    induction n with
-    | zero => simp
-    | succ n ih =>
-        have hc_nonneg : 0 ≤ (1 / 2 : ℝ) ^ n := by positivity
-        have hc_le_one : (1 / 2 : ℝ) ^ n ≤ 1 := pow_le_one₀ (by norm_num) (by norm_num)
-        have hstep := hmidpoint (a := (1 - (1 / 2 : ℝ) ^ n) * x)
-          (h := (1 / 2 : ℝ) ^ n * x / 2) (by positivity) (by positivity)
-        have hhalf : (1 - (1 / 2 : ℝ) ^ n) * x + (1 / 2 : ℝ) ^ n * x / 2 =
-            (1 - (1 / 2 : ℝ) ^ n / 2) * x := by ring
-        have hend : (1 - (1 / 2 : ℝ) ^ n) * x +
-            2 * ((1 / 2 : ℝ) ^ n * x / 2) = x := by ring
-        rw [hhalf, hend] at hstep
-        have hpoint : (1 - (1 / 2 : ℝ) ^ n / 2) * x =
-            (1 - (1 / 2 : ℝ) ^ n * (1 / 2)) * x := by ring
-        rw [hpoint] at hstep
-        rw [pow_succ]
-        calc
-          f ((1 - (1 / 2 : ℝ) ^ n * (1 / 2)) * x)
-              ≤ (f ((1 - (1 / 2 : ℝ) ^ n) * x) + f x) / 2 := by
-                nlinarith
-          _ ≤ ((1 / 2 : ℝ) ^ n * f 0 + (1 - (1 / 2 : ℝ) ^ n) * f x + f x) / 2 :=
-            by linarith
-          _ = (1 / 2 : ℝ) ^ n * (1 / 2) * f 0 +
-              (1 - (1 / 2 : ℝ) ^ n * (1 / 2)) * f x := by ring
-  rw [Metric.continuousAt_iff]
-  intro ε hε
-  have hpow : Tendsto (fun n : ℕ => (1 / 2 : ℝ) ^ n * (f 0 - f x)) atTop (𝓝 0) := by
-    have hbase := tendsto_pow_atTop_nhds_zero_of_lt_one
-      (by norm_num : (0 : ℝ) ≤ 1 / 2) (by norm_num)
-    simpa using hbase.mul_const (f 0 - f x)
-  obtain ⟨n, hn, hsmall⟩ :=
-    ((eventually_ge_atTop 1).and (hpow.eventually (eventually_lt_nhds hε))).exists
-  let c : ℝ := (1 / 2 : ℝ) ^ n
-  have hc_pos : 0 < c := by positivity
-  have hc_lt_one : c < 1 := by
-    dsimp [c]
-    exact pow_lt_one₀ (by norm_num) (by norm_num) (Nat.ne_of_gt hn)
-  refine ⟨c * x, mul_pos hc_pos hx, ?_⟩
-  intro y hy
-  rw [Real.dist_eq] at hy ⊢
-  have hy_bounds : (1 - c) * x < y ∧ y < (1 + c) * x := by
-    constructor <;> nlinarith [abs_lt.mp hy]
-  have hq_nonneg : 0 ≤ (1 - c) * x := mul_nonneg (sub_nonneg.mpr hc_lt_one.le) hx.le
-  have hy_nonneg : 0 ≤ y := hq_nonneg.trans hy_bounds.1.le
-  have hr_nonneg : 0 ≤ (1 + c) * x := by positivity
-  have hq : f ((1 - c) * x) ≤ c * f 0 + (1 - c) * f x := by
-    simpa only [c] using hdyadic n
-  have hy_upper : f y < f x + ε := by
-    have := hf.antitoneOn (mem_Ici.2 hq_nonneg) (mem_Ici.2 hy_nonneg) hy_bounds.1.le
-    nlinarith
-  have hcenter := hmidpoint (a := (1 - c) * x) (h := c * x)
-    hq_nonneg (mul_nonneg hc_pos.le hx.le)
-  have hcenter_left : (1 - c) * x + c * x = x := by ring
-  have hcenter_right : (1 - c) * x + 2 * (c * x) = (1 + c) * x := by ring
-  rw [hcenter_left, hcenter_right] at hcenter
-  have hy_lower : f x - ε < f y := by
-    have := hf.antitoneOn (mem_Ici.2 hy_nonneg) (mem_Ici.2 hr_nonneg) hy_bounds.2.le
-    nlinarith
-  exact abs_lt.2 ⟨by linarith, by linarith⟩
+    (h : RepresentsLaplace μ f) : IsDifferenceCompletelyMonotone f :=
+  h.isContinuousCompletelyMonotoneOnIoi.isDifferenceCompletelyMonotone
 
 /-! ## Tightness of the approximating measures -/
 
 /-- **The approximating measures of a continuous finite-difference completely monotone function
 are uniformly tight.** The mass a member of the family puts outside a large ball is bounded, by
-`TauCeti.measure_compl_closedBall_le_of_laplaceTransform`, by its Laplace gap
+`TauCeti.measure_compl_closedBall_le_sub_laplaceTransform_div`, by its Laplace gap
 `μ.real univ - laplaceTransform μ x`, and the squeeze bounds that gap by `f 0 - f (x + aₙ)`.
 Choosing `x` so small that `f` has barely dropped by `2x` makes the estimate uniform over all
 shifts `aₙ ≤ x`; the finitely many larger shifts are handled by
-`TauCeti.isTightMeasureSet_range_finite`. -/
+`TauCeti.isTightMeasureSet_range_of_finite`. -/
 private lemma isTightMeasureSet_range_of_laplaceTransform_between_shift
     (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousWithinAt f (Ici 0) 0)
     {a : ℕ → ℝ} (ha_pos : ∀ n, 0 < a n) (ha : Tendsto a atTop (𝓝 0))
@@ -355,7 +185,7 @@ private lemma isTightMeasureSet_range_of_laplaceTransform_between_shift
   -- The finitely many shifts larger than `x` are tight on their own.
   obtain ⟨K, hK_compact, hK_tail⟩ :=
     isTightMeasureSet_iff_exists_isCompact_measure_compl_le.mp
-      (isTightMeasureSet_range_finite (fun n : {n : ℕ // n < N} => μ n) fun n => hfin n) ε hε
+      (isTightMeasureSet_range_of_finite (fun n : {n : ℕ // n < N} => μ n) fun n => hfin n) ε hε
   refine ⟨K ∪ Metric.closedBall (0 : ℝ≥0) (y / 2)⁻¹,
     hK_compact.union (isCompact_closedBall _ _), ?_⟩
   rintro ν ⟨n, rfl⟩
@@ -380,7 +210,7 @@ private lemma isTightMeasureSet_range_of_laplaceTransform_between_shift
       measure_mono (compl_subset_compl.mpr subset_union_right)
     _ ≤ ENNReal.ofReal (((μ n).real univ - laplaceTransform (μ n) (y / 2))
           / (1 - Real.exp (-(y / 2 * (y / 2)⁻¹)))) :=
-      measure_compl_closedBall_le_of_laplaceTransform (μ n) hx_pos hR_pos
+      measure_compl_closedBall_le_sub_laplaceTransform_div (μ n) hx_pos hR_pos
     _ ≤ ENNReal.ofReal ε.toReal := by
       rw [hden]
       exact ENNReal.ofReal_le_ofReal ((div_le_iff₀ hc_pos).2 hnum)
@@ -394,17 +224,13 @@ have the sign `(-1)ⁿ` is the Laplace transform of a finite positive measure on
 
 The smoothings of `f` at the shifts `aₙ = 1/(n+1)` have representing measures squeezing `f`
 between `f (· + aₙ)` and `f`; they are uniformly bounded in mass by `f 0` and uniformly tight, so
-Prokhorov supplies a weak cluster point `μ₀`. Continuity of `f` closes the squeeze: the Laplace
-transform of `μ₀` at `t` is at most `f t`, and at least `f s` for every `s > t`. -/
+Prokhorov supplies a weak cluster point `μ₀`. The Laplace transform of `μ₀` at `t` is at most
+`f t`; right-continuity of `f` closes the reverse inequality at zero, while continuity of the
+Laplace transform closes it at every positive parameter. -/
 theorem exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt
     (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousWithinAt f (Ici 0) 0) :
     ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
   classical
-  have hcontOn : ContinuousOn f (Ici 0) := by
-    intro t ht
-    rcases (mem_Ici.mp ht).eq_or_lt with rfl | ht
-    · exact hcont
-    · exact (hf.continuousAt_of_pos ht).continuousWithinAt
   -- Stage 1: the positive null sequence of shifts and the approximating measures.
   have ha_pos : ∀ n : ℕ, 0 < 1 / ((n : ℝ) + 1) := fun n => by positivity
   have ha : Tendsto (fun n : ℕ => 1 / ((n : ℝ) + 1)) atTop (𝓝 0) :=
@@ -424,44 +250,51 @@ theorem exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuous
     calc (μ n) univ = ENNReal.ofReal ((μ n).real univ) :=
         (ofReal_measureReal (measure_ne_top _ _)).symm
       _ ≤ ENNReal.ofReal (f 0) := ENNReal.ofReal_le_ofReal hle
-      _ = (((f 0).toNNReal : ℝ≥0) : ℝ≥0∞) := rfl
+      _ = (((f 0).toNNReal : ℝ≥0) : ℝ≥0∞) :=
+        (ENNReal.ofNNReal_toNNReal (f 0)).symm
   obtain ⟨μ₀, U, hUle, hμ₀_fin, -, hweak⟩ :=
     finite_measure_cluster_limit μ (f 0).toNNReal hmass
       (isTightMeasureSet_range_of_laplaceTransform_between_shift hf hcont ha_pos ha hfin
         hlow hhigh)
   -- Stage 3: the squeeze identifies the Laplace transform of the cluster point as `f`.
   refine ⟨μ₀, representsLaplace_iff.mpr ⟨hμ₀_fin, fun t ht => ?_⟩⟩
-  have hL : Tendsto (fun n => laplaceTransform (μ n) t) (U : Filter ℕ)
-      (𝓝 (laplaceTransform μ₀ t)) := by
-    have hw := hweak (laplaceKernelBoundedContinuous ht)
+  have hL (s : ℝ) (hs : 0 ≤ s) : Tendsto (fun n => laplaceTransform (μ n) s) (U : Filter ℕ)
+      (𝓝 (laplaceTransform μ₀ s)) := by
+    have hw := hweak (laplaceKernelBoundedContinuous hs)
     simp only [laplaceKernelBoundedContinuous_apply] at hw
     simpa only [laplaceTransform_apply] using hw
   have hupper : laplaceTransform μ₀ t ≤ f t :=
-    le_of_tendsto hL (.of_forall fun n => hhigh n t ht)
-  have hlower : ∀ s : ℝ, t < s → f s ≤ laplaceTransform μ₀ t := by
-    intro s hs
-    refine ge_of_tendsto hL (Eventually.filter_mono hUle ?_)
-    filter_upwards [ha.eventually (eventually_lt_nhds (by linarith : (0 : ℝ) < s - t))] with n hn
-    refine le_trans (hf.antitoneOn (mem_Ici.2 (by positivity)) (mem_Ici.2 (by linarith))
-      (by linarith)) (hlow n t ht)
-  have hcw : Tendsto f (𝓝[>] t) (𝓝 (f t)) :=
-    (hcontOn.continuousWithinAt (mem_Ici.2 ht)).tendsto.mono_left
-      (nhdsWithin_mono t fun s hs => mem_Ici.2 (ht.trans (le_of_lt hs)))
-  have hft : f t ≤ laplaceTransform μ₀ t :=
-    le_of_tendsto hcw (eventually_mem_nhdsWithin.mono fun s hs => hlower s hs)
+    le_of_tendsto (hL t ht) (.of_forall fun n => hhigh n t ht)
+  have hlower (s : ℝ) (hs : 0 ≤ s) (u : ℝ) (hsu : s < u) :
+      f u ≤ laplaceTransform μ₀ s := by
+    refine ge_of_tendsto (hL s hs) (Eventually.filter_mono hUle ?_)
+    filter_upwards [ha.eventually (eventually_lt_nhds (sub_pos.mpr hsu))] with n hn
+    refine le_trans (hf.antitoneOn (mem_Ici.2 (by positivity)) (mem_Ici.2 (hs.trans hsu.le))
+      (by linarith)) (hlow n s hs)
+  have hft : f t ≤ laplaceTransform μ₀ t := by
+    rcases ht.eq_or_lt with rfl | ht
+    · have hf_right : Tendsto f (𝓝[>] (0 : ℝ)) (𝓝 (f 0)) :=
+        hcont.tendsto.mono_left (nhdsWithin_mono _ Ioi_subset_Ici_self)
+      exact le_of_tendsto hf_right
+        (eventually_mem_nhdsWithin.mono fun u hu => hlower 0 le_rfl u hu)
+    · let _ := hμ₀_fin
+      let _ := right_nhdsWithin_Ico_neBot ht
+      have hfilter : 𝓝[Ico 0 t] t ≤ 𝓝 t := inf_le_left
+      have hlap : Tendsto (laplaceTransform μ₀) (𝓝[Ico 0 t] t)
+          (𝓝 (laplaceTransform μ₀ t)) :=
+        ((continuousOn_Ici_laplaceTransform μ₀).continuousAt (Ici_mem_nhds ht)).tendsto.mono_left
+          hfilter
+      exact ge_of_tendsto hlap
+        (eventually_mem_nhdsWithin.mono fun s (hs : s ∈ Ico (0 : ℝ) t) =>
+          hlower s hs.1 t hs.2)
   exact le_antisymm hft hupper
-
-/-- A continuous finite-difference completely monotone function is the Laplace transform of a
-finite positive measure. This is the continuous-on corollary of the endpoint-continuity theorem. -/
-theorem exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousOn
-    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousOn f (Ici 0)) :
-    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f :=
-  exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt hf
-    (hcont.continuousWithinAt (mem_Ici.2 le_rfl))
 
 /-- **The Hausdorff--Bernstein--Widder theorem in finite-difference form.** A function has
 alternating mixed forward differences and is right-continuous at zero if and only if it is the
-Laplace transform of a finite positive measure on `ℝ≥0`. -/
+Laplace transform of a finite positive measure on `ℝ≥0`.
+
+Compare `TauCeti.hausdorff_bernstein_widder`, which states the same representation equivalence
+using the derivative-based complete-monotonicity hypothesis. -/
 theorem hausdorff_bernstein_widder_difference (f : ℝ → ℝ) :
     (IsDifferenceCompletelyMonotone f ∧ ContinuousWithinAt f (Ici 0) 0)
       ↔ ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
@@ -472,25 +305,37 @@ theorem hausdorff_bernstein_widder_difference (f : ℝ → ℝ) :
         hμ.isContinuousCompletelyMonotoneOnIoi.continuousOn.continuousWithinAt
           (mem_Ici.2 le_rfl)⟩⟩
 
-/-- **The two notions of complete monotonicity agree on continuous functions.** For a function
-continuous on `[0, ∞)`, complete monotonicity in the derivative sense on `(0, ∞)` is equivalent
-to the sign condition on all mixed forward differences, which mentions no derivatives at all.
+/-- Unique-existence form of the Hausdorff--Bernstein--Widder theorem in finite-difference form. -/
+theorem hausdorff_bernstein_widder_difference_existsUnique (f : ℝ → ℝ) :
+    (IsDifferenceCompletelyMonotone f ∧ ContinuousWithinAt f (Ici 0) 0)
+      ↔ ∃! μ : Measure ℝ≥0, RepresentsLaplace μ f := by
+  rw [hausdorff_bernstein_widder_difference]
+  exact ⟨fun ⟨μ, hμ⟩ => ⟨μ, hμ, fun ν hν => hν.unique hμ⟩,
+    fun ⟨μ, hμ, _⟩ => ⟨μ, hμ⟩⟩
+
+/-- **The two notions of complete monotonicity agree under endpoint continuity.** Complete
+monotonicity in the derivative sense on `(0, ∞)`, together with continuity on `[0, ∞)`, is
+equivalent to the sign condition on all mixed forward differences plus right-continuity at zero.
 Compare `TauCeti.isCompletelyMonotone_iff_isDifferenceCompletelyMonotone`, which assumes
 smoothness; here smoothness is a conclusion. -/
-theorem isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone_and_continuousOn
+theorem
+    isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone_and_continuousWithinAt
     (f : ℝ → ℝ) :
     IsContinuousCompletelyMonotoneOnIoi f
-      ↔ IsDifferenceCompletelyMonotone f ∧ ContinuousOn f (Ici 0) := by
-  rw [hausdorff_bernstein_widder f]
-  refine ⟨fun ⟨μ, hμ⟩ =>
-      ⟨hμ.isDifferenceCompletelyMonotone, hμ.isContinuousCompletelyMonotoneOnIoi.continuousOn⟩,
-    fun ⟨hf, hcont⟩ =>
-      exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousOn hf hcont⟩
+      ↔ IsDifferenceCompletelyMonotone f ∧ ContinuousWithinAt f (Ici 0) 0 := by
+  refine ⟨fun hf => ⟨hf.isDifferenceCompletelyMonotone,
+      hf.continuousOn.continuousWithinAt (mem_Ici.2 le_rfl)⟩, ?_⟩
+  rintro ⟨hf, hcont⟩
+  obtain ⟨μ, hμ⟩ :=
+    exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt hf hcont
+  exact hμ.isContinuousCompletelyMonotoneOnIoi
 
 /-- **From finite differences to derivatives.** This is the form in which applications use the
-equivalence: the Bernstein measure and the Bernstein kernel take
-`TauCeti.IsContinuousCompletelyMonotoneOnIoi` as their hypothesis, while what is checkable in
-practice is the finite-difference condition. -/
+equivalence: `TauCeti.bernsteinMeasureKernel` takes
+`TauCeti.IsContinuousCompletelyMonotoneOnIoi` as a hypothesis, and the representation lemmas
+`TauCeti.representsLaplace_bernsteinMeasure` and `TauCeti.laplaceTransform_bernsteinMeasure` use
+it for `TauCeti.bernsteinMeasure`, while what is checkable in practice is the finite-difference
+condition. -/
 theorem IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi
     (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousWithinAt f (Ici 0) 0) :
     IsContinuousCompletelyMonotoneOnIoi f := by

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
@@ -45,11 +45,10 @@ Markov bound on the coordinate `p ↦ 1 - e^{-xp}` against the Laplace gap
 `f 0 - f x`, which continuity at `0` makes uniformly small), so Prokhorov produces a weak cluster
 point, and the squeeze identifies its Laplace transform as `f`.
 
-Continuity is assumed on all of `[0, ∞)`, although right-continuity at `0` is the only part of it
-that is not automatic: taking two equal steps in the sign condition makes `f` midpoint convex on
-`[0, ∞)`, and it is bounded there by `f 0`, so Bernstein--Doetsch would give continuity on
-`(0, ∞)` for free. Mathlib has no midpoint-convexity regularity theory, so that strengthening is
-left out rather than assumed; every application here supplies continuity anyway.
+Right-continuity at `0` is the only continuity assumption needed: taking two equal steps in the
+sign condition makes `f` midpoint convex on `[0, ∞)`, while the one-step condition makes it
+antitone there. Iterating the midpoint inequality at dyadic points approaching any `t > 0`
+therefore squeezes `f` to continuity at `t`.
 
 The converse is a direct computation: for a finite measure `μ` the mixed difference
 `Δ_{h₁} ⋯ Δ_{hₙ} (laplaceTransform μ)` at `t` is
@@ -69,12 +68,13 @@ form in which applications use it, since the derivative predicate is what
 * `TauCeti.isDifferenceCompletelyMonotone_laplaceTransform` and
   `TauCeti.RepresentsLaplace.isDifferenceCompletelyMonotone`: the easy direction, that a Laplace
   transform of a finite measure has alternating mixed differences.
-* `TauCeti.exists_representsLaplace_of_isDifferenceCompletelyMonotone`: **the representation
-  theorem**, that a continuous function with alternating mixed differences is the Laplace
-  transform of a finite measure.
+* `TauCeti.exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt`:
+  **the representation theorem**, that a function right-continuous at zero with alternating mixed
+  differences is the Laplace transform of a finite measure.
 * `TauCeti.hausdorff_bernstein_widder_difference`: the resulting characterization of the
   Laplace transforms of finite measures on `ℝ≥0`.
-* `TauCeti.isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone` and
+* `TauCeti.isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone_and_continuousOn`
+  and
   `TauCeti.IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi`: the two notions
   of complete monotonicity agree on functions continuous on `[0, ∞)`.
 
@@ -105,7 +105,8 @@ finite-difference sense is squeezed, for every `ε > 0`, between
 A Bernstein representation of `f` itself does not follow from these measures by compactness
 alone: the hypothesis leaves the value at the endpoint free, so it needs right-continuity of `f`
 at `0`, which is what
-`TauCeti.exists_representsLaplace_of_isDifferenceCompletelyMonotone` adds. -/
+`TauCeti.exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt`
+adds. -/
 theorem IsDifferenceCompletelyMonotone.exists_isFiniteMeasure_laplaceTransform_between_shift
     (hf : IsDifferenceCompletelyMonotone f) {ε : ℝ} (hε : 0 < ε) :
     ∃ μ : Measure ℝ≥0, IsFiniteMeasure μ ∧ ∀ t : ℝ, 0 ≤ t →
@@ -138,7 +139,8 @@ private lemma laplaceDiffIntegrand_add (l : List ℝ) (t a : ℝ) (p : ℝ≥0) 
     laplaceDiffIntegrand l (t + a) p
       = Real.exp (-(a * (p : ℝ))) * laplaceDiffIntegrand l t p := by
   simp only [laplaceDiffIntegrand]
-  rw [show -((t + a) * (p : ℝ)) = -(a * (p : ℝ)) + -(t * (p : ℝ)) by ring, Real.exp_add]
+  have hsplit : -((t + a) * (p : ℝ)) = -(a * (p : ℝ)) + -(t * (p : ℝ)) := by ring
+  rw [hsplit, Real.exp_add]
   ring
 
 /-- Each factor of the integrand lies in `[0, 1]`, hence so does the integrand. -/
@@ -235,6 +237,85 @@ theorem RepresentsLaplace.isDifferenceCompletelyMonotone {μ : Measure ℝ≥0}
   exact (isDifferenceCompletelyMonotone_laplaceTransform μ).congr fun t ht =>
     h.eq_laplaceTransform ht
 
+/-- A finite-difference completely monotone function is automatically continuous away from the
+endpoint. The equal-step second-difference inequality gives the midpoint bound used below, while
+antitonicity turns its dyadic estimates into a two-sided squeeze. -/
+private lemma IsDifferenceCompletelyMonotone.continuousAt_of_pos
+    (hf : IsDifferenceCompletelyMonotone f) {x : ℝ} (hx : 0 < x) : ContinuousAt f x := by
+  have hmidpoint : ∀ {a h : ℝ}, 0 ≤ a → 0 ≤ h →
+      2 * f (a + h) ≤ f a + f (a + 2 * h) := by
+    intro a h ha hh
+    have hdiff := isDifferenceCompletelyMonotone_iff.mp hf [h, h] (by simpa using hh) a ha
+    simp only [List.length_cons, List.length_nil, fwdDiffList_cons, fwdDiffList_nil, fwdDiff,
+      zero_add, pow_succ, pow_zero] at hdiff
+    have hadd : a + h + h = a + 2 * h := by ring
+    rw [hadd] at hdiff
+    norm_num at hdiff
+    linarith
+  have hdyadic : ∀ n : ℕ,
+      f ((1 - (1 / 2 : ℝ) ^ n) * x) ≤
+        (1 / 2 : ℝ) ^ n * f 0 + (1 - (1 / 2 : ℝ) ^ n) * f x := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+        have hc_nonneg : 0 ≤ (1 / 2 : ℝ) ^ n := by positivity
+        have hc_le_one : (1 / 2 : ℝ) ^ n ≤ 1 := pow_le_one₀ (by norm_num) (by norm_num)
+        have hstep := hmidpoint (a := (1 - (1 / 2 : ℝ) ^ n) * x)
+          (h := (1 / 2 : ℝ) ^ n * x / 2) (by positivity) (by positivity)
+        have hhalf : (1 - (1 / 2 : ℝ) ^ n) * x + (1 / 2 : ℝ) ^ n * x / 2 =
+            (1 - (1 / 2 : ℝ) ^ n / 2) * x := by ring
+        have hend : (1 - (1 / 2 : ℝ) ^ n) * x +
+            2 * ((1 / 2 : ℝ) ^ n * x / 2) = x := by ring
+        rw [hhalf, hend] at hstep
+        have hpoint : (1 - (1 / 2 : ℝ) ^ n / 2) * x =
+            (1 - (1 / 2 : ℝ) ^ n * (1 / 2)) * x := by ring
+        rw [hpoint] at hstep
+        rw [pow_succ]
+        calc
+          f ((1 - (1 / 2 : ℝ) ^ n * (1 / 2)) * x)
+              ≤ (f ((1 - (1 / 2 : ℝ) ^ n) * x) + f x) / 2 := by
+                nlinarith
+          _ ≤ ((1 / 2 : ℝ) ^ n * f 0 + (1 - (1 / 2 : ℝ) ^ n) * f x + f x) / 2 :=
+            by linarith
+          _ = (1 / 2 : ℝ) ^ n * (1 / 2) * f 0 +
+              (1 - (1 / 2 : ℝ) ^ n * (1 / 2)) * f x := by ring
+  rw [Metric.continuousAt_iff]
+  intro ε hε
+  have hpow : Tendsto (fun n : ℕ => (1 / 2 : ℝ) ^ n * (f 0 - f x)) atTop (𝓝 0) := by
+    have hbase := tendsto_pow_atTop_nhds_zero_of_lt_one
+      (by norm_num : (0 : ℝ) ≤ 1 / 2) (by norm_num)
+    simpa using hbase.mul_const (f 0 - f x)
+  obtain ⟨n, hn, hsmall⟩ :=
+    ((eventually_ge_atTop 1).and (hpow.eventually (eventually_lt_nhds hε))).exists
+  let c : ℝ := (1 / 2 : ℝ) ^ n
+  have hc_pos : 0 < c := by positivity
+  have hc_lt_one : c < 1 := by
+    dsimp [c]
+    exact pow_lt_one₀ (by norm_num) (by norm_num) (Nat.ne_of_gt hn)
+  refine ⟨c * x, mul_pos hc_pos hx, ?_⟩
+  intro y hy
+  rw [Real.dist_eq] at hy ⊢
+  have hy_bounds : (1 - c) * x < y ∧ y < (1 + c) * x := by
+    constructor <;> nlinarith [abs_lt.mp hy]
+  have hq_nonneg : 0 ≤ (1 - c) * x := mul_nonneg (sub_nonneg.mpr hc_lt_one.le) hx.le
+  have hy_nonneg : 0 ≤ y := hq_nonneg.trans hy_bounds.1.le
+  have hr_nonneg : 0 ≤ (1 + c) * x := by positivity
+  have hq := hdyadic n
+  change f ((1 - c) * x) ≤ c * f 0 + (1 - c) * f x at hq
+  have hy_upper : f y < f x + ε := by
+    have := hf.antitoneOn (mem_Ici.2 hq_nonneg) (mem_Ici.2 hy_nonneg) hy_bounds.1.le
+    nlinarith
+  have hcenter := hmidpoint (a := (1 - c) * x) (h := c * x)
+    hq_nonneg (mul_nonneg hc_pos.le hx.le)
+  have hcenter_left : (1 - c) * x + c * x = x := by ring
+  have hcenter_right : (1 - c) * x + 2 * (c * x) = (1 + c) * x := by ring
+  rw [hcenter_left, hcenter_right] at hcenter
+  have hy_lower : f x - ε < f y := by
+    have := hf.antitoneOn (mem_Ici.2 hy_nonneg) (mem_Ici.2 hr_nonneg) hy_bounds.2.le
+    nlinarith
+  exact abs_lt.2 ⟨by linarith, by linarith⟩
+
 /-! ## Tightness of the approximating measures -/
 
 /-- **The approximating measures of a continuous finite-difference completely monotone function
@@ -245,7 +326,7 @@ Choosing `x` so small that `f` has barely dropped by `2x` makes the estimate uni
 shifts `aₙ ≤ x`; the finitely many larger shifts are handled by
 `TauCeti.isTightMeasureSet_range_finite`. -/
 private lemma isTightMeasureSet_range_of_laplaceTransform_between_shift
-    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousOn f (Ici 0))
+    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousWithinAt f (Ici 0) 0)
     {a : ℕ → ℝ} (ha_pos : ∀ n, 0 < a n) (ha : Tendsto a atTop (𝓝 0))
     {μ : ℕ → Measure ℝ≥0} (hfin : ∀ n, IsFiniteMeasure (μ n))
     (hlow : ∀ n, ∀ t : ℝ, 0 ≤ t → f (t + a n) ≤ laplaceTransform (μ n) t)
@@ -261,12 +342,10 @@ private lemma isTightMeasureSet_range_of_laplaceTransform_between_shift
     linarith
   -- A point `y > 0` at which `f` has dropped from `f 0` by less than `ε.toReal * (1 - e⁻¹)`.
   have hcw : Tendsto f (𝓝[>] (0 : ℝ)) (𝓝 (f 0)) :=
-    (hcont.continuousWithinAt (mem_Ici.2 le_rfl)).tendsto.mono_left
-      (nhdsWithin_mono _ Ioi_subset_Ici_self)
+    hcont.tendsto.mono_left (nhdsWithin_mono _ Ioi_subset_Ici_self)
+  have hdrop : f 0 - ε.toReal * (1 - Real.exp (-1 : ℝ)) < f 0 := by nlinarith
   obtain ⟨y, hy, hy_pos⟩ :=
-    ((hcw.eventually (eventually_gt_nhds
-      (show f 0 - ε.toReal * (1 - Real.exp (-1 : ℝ)) < f 0 by nlinarith))).and
-        self_mem_nhdsWithin).exists
+    ((hcw.eventually (eventually_gt_nhds hdrop)).and self_mem_nhdsWithin).exists
   -- The Markov parameter is `y / 2` and the radius its inverse, so that their product is `1`.
   have hx_pos : 0 < y / 2 := by linarith
   have hR_pos : 0 < (y / 2)⁻¹ := inv_pos.mpr hx_pos
@@ -310,17 +389,22 @@ private lemma isTightMeasureSet_range_of_laplaceTransform_between_shift
 /-! ## The representation theorem -/
 
 /-- **The existence half of the Hausdorff--Bernstein--Widder theorem in finite-difference form.**
-A function continuous on `[0, ∞)` all of whose mixed forward differences with nonnegative steps
+A function right-continuous at zero all of whose mixed forward differences with nonnegative steps
 have the sign `(-1)ⁿ` is the Laplace transform of a finite positive measure on `ℝ≥0`.
 
 The smoothings of `f` at the shifts `aₙ = 1/(n+1)` have representing measures squeezing `f`
 between `f (· + aₙ)` and `f`; they are uniformly bounded in mass by `f 0` and uniformly tight, so
 Prokhorov supplies a weak cluster point `μ₀`. Continuity of `f` closes the squeeze: the Laplace
 transform of `μ₀` at `t` is at most `f t`, and at least `f s` for every `s > t`. -/
-theorem exists_representsLaplace_of_isDifferenceCompletelyMonotone
-    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousOn f (Ici 0)) :
+theorem exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt
+    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousWithinAt f (Ici 0) 0) :
     ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
   classical
+  have hcontOn : ContinuousOn f (Ici 0) := by
+    intro t ht
+    rcases (mem_Ici.mp ht).eq_or_lt with rfl | ht
+    · exact hcont
+    · exact (hf.continuousAt_of_pos ht).continuousWithinAt
   -- Stage 1: the positive null sequence of shifts and the approximating measures.
   have ha_pos : ∀ n : ℕ, 0 < 1 / ((n : ℝ) + 1) := fun n => by positivity
   have ha : Tendsto (fun n : ℕ => 1 / ((n : ℝ) + 1)) atTop (𝓝 0) :=
@@ -361,41 +445,58 @@ theorem exists_representsLaplace_of_isDifferenceCompletelyMonotone
     refine le_trans (hf.antitoneOn (mem_Ici.2 (by positivity)) (mem_Ici.2 (by linarith))
       (by linarith)) (hlow n t ht)
   have hcw : Tendsto f (𝓝[>] t) (𝓝 (f t)) :=
-    (hcont.continuousWithinAt (mem_Ici.2 ht)).tendsto.mono_left
+    (hcontOn.continuousWithinAt (mem_Ici.2 ht)).tendsto.mono_left
       (nhdsWithin_mono t fun s hs => mem_Ici.2 (ht.trans (le_of_lt hs)))
   have hft : f t ≤ laplaceTransform μ₀ t :=
     le_of_tendsto hcw (eventually_mem_nhdsWithin.mono fun s hs => hlower s hs)
   exact le_antisymm hft hupper
 
-/-- **The Hausdorff--Bernstein--Widder theorem in finite-difference form.** A function is
-continuous on `[0, ∞)` with alternating mixed forward differences if and only if it is the
+/-- A continuous finite-difference completely monotone function is the Laplace transform of a
+finite positive measure. This is the continuous-on corollary of the endpoint-continuity theorem. -/
+theorem exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousOn
+    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousOn f (Ici 0)) :
+    ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f :=
+  exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt hf
+    (hcont.continuousWithinAt (mem_Ici.2 le_rfl))
+
+/-- **The Hausdorff--Bernstein--Widder theorem in finite-difference form.** A function has
+alternating mixed forward differences and is right-continuous at zero if and only if it is the
 Laplace transform of a finite positive measure on `ℝ≥0`. -/
 theorem hausdorff_bernstein_widder_difference (f : ℝ → ℝ) :
-    (IsDifferenceCompletelyMonotone f ∧ ContinuousOn f (Ici 0))
+    (IsDifferenceCompletelyMonotone f ∧ ContinuousWithinAt f (Ici 0) 0)
       ↔ ∃ μ : Measure ℝ≥0, RepresentsLaplace μ f := by
-  refine ⟨fun ⟨hf, hcont⟩ => exists_representsLaplace_of_isDifferenceCompletelyMonotone hf hcont,
+  refine ⟨fun ⟨hf, hcont⟩ =>
+      exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt hf hcont,
     fun ⟨μ, hμ⟩ =>
-      ⟨hμ.isDifferenceCompletelyMonotone, hμ.isContinuousCompletelyMonotoneOnIoi.continuousOn⟩⟩
+      ⟨hμ.isDifferenceCompletelyMonotone,
+        hμ.isContinuousCompletelyMonotoneOnIoi.continuousOn.continuousWithinAt
+          (mem_Ici.2 le_rfl)⟩⟩
 
 /-- **The two notions of complete monotonicity agree on continuous functions.** For a function
 continuous on `[0, ∞)`, complete monotonicity in the derivative sense on `(0, ∞)` is equivalent
 to the sign condition on all mixed forward differences, which mentions no derivatives at all.
 Compare `TauCeti.isCompletelyMonotone_iff_isDifferenceCompletelyMonotone`, which assumes
 smoothness; here smoothness is a conclusion. -/
-theorem isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone (f : ℝ → ℝ) :
+theorem isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone_and_continuousOn
+    (f : ℝ → ℝ) :
     IsContinuousCompletelyMonotoneOnIoi f
       ↔ IsDifferenceCompletelyMonotone f ∧ ContinuousOn f (Ici 0) := by
   rw [hausdorff_bernstein_widder f]
-  exact (hausdorff_bernstein_widder_difference f).symm
+  refine ⟨fun ⟨μ, hμ⟩ =>
+      ⟨hμ.isDifferenceCompletelyMonotone, hμ.isContinuousCompletelyMonotoneOnIoi.continuousOn⟩,
+    fun ⟨hf, hcont⟩ =>
+      exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousOn hf hcont⟩
 
 /-- **From finite differences to derivatives.** This is the form in which applications use the
 equivalence: the Bernstein measure and the Bernstein kernel take
 `TauCeti.IsContinuousCompletelyMonotoneOnIoi` as their hypothesis, while what is checkable in
 practice is the finite-difference condition. -/
 theorem IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi
-    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousOn f (Ici 0)) :
-    IsContinuousCompletelyMonotoneOnIoi f :=
-  (isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone f).2 ⟨hf, hcont⟩
+    (hf : IsDifferenceCompletelyMonotone f) (hcont : ContinuousWithinAt f (Ici 0) 0) :
+    IsContinuousCompletelyMonotoneOnIoi f := by
+  obtain ⟨μ, hμ⟩ :=
+    exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt hf hcont
+  exact hμ.isContinuousCompletelyMonotoneOnIoi
 
 end TauCeti
 

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Laplace.lean
@@ -118,8 +118,8 @@ in the finite-difference sense. Positive shifts are smooth completely monotone f
 finite-difference predicate passes to their pointwise limit. -/
 theorem IsContinuousCompletelyMonotoneOnIoi.isDifferenceCompletelyMonotone
     (hf : IsContinuousCompletelyMonotoneOnIoi f) : IsDifferenceCompletelyMonotone f := by
-  let F : ℕ → ℝ → ℝ := fun n t => f (t + 1 / ((n : ℝ) + 1))
-  refine isDifferenceCompletelyMonotone_of_tendsto (L := atTop) (F := F) (fun n => ?_) ?_
+  refine isDifferenceCompletelyMonotone_of_tendsto (L := atTop)
+    (F := fun (n : ℕ) t => f (t + 1 / ((n : ℝ) + 1))) (fun n => ?_) ?_
   · have hshift : 0 < 1 / ((n : ℝ) + 1) := by positivity
     exact IsCompletelyMonotone.isDifferenceCompletelyMonotone
       (hf.isCompletelyMonotoneOnIoi.isCompletelyMonotone_comp_add_const hshift)
@@ -130,8 +130,8 @@ theorem IsContinuousCompletelyMonotoneOnIoi.isDifferenceCompletelyMonotone
       tendsto_nhdsWithin_iff.mpr
         ⟨by simpa using tendsto_const_nhds.add hzero,
           .of_forall fun n => mem_Ici.mpr (add_nonneg hu (by positivity))⟩
-    change Tendsto (f ∘ fun n : ℕ => u + 1 / ((n : ℝ) + 1)) atTop (𝓝 (f u))
-    exact (hf.continuousOn.continuousWithinAt (mem_Ici.mpr hu)).tendsto.comp ha
+    simpa only [Function.comp_def] using
+      (hf.continuousOn.continuousWithinAt (mem_Ici.mpr hu)).tendsto.comp ha
 
 /-- **The Laplace transform of a finite measure is completely monotone in the finite-difference
 sense.** Every mixed forward difference with nonnegative steps has the sign `(-1)ⁿ`, because it

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
@@ -15,6 +15,8 @@ import Mathlib.Probability.Moments.MGFAnalytic
 -- Non-public: `Measure.ext_of_forall_integral_exp_neg_natCast_mul_eq` supplies the
 -- Laplace-determinacy step in the uniqueness proof.
 import TauCeti.Probability.Moments.LaplaceDeterminacy
+-- Non-public: Markov's inequality supplies the Laplace tail bound.
+import Mathlib.MeasureTheory.Integral.Lebesgue.Markov
 
 /-!
 # Laplace representations for completely monotone functions
@@ -27,6 +29,9 @@ on `[0, ∞)`, and its possibly infinite-measure counterpart on `(0, ∞)`.
 
 * `TauCeti.laplaceTransform`: the Laplace transform of a measure on `ℝ≥0`, with its algebraic
   API and the bridge `TauCeti.laplaceTransform_eq_mgf` to Mathlib's moment-generating function.
+* `TauCeti.measure_compl_closedBall_le_of_laplaceTransform`: a Markov tail bound, controlling
+  the mass a finite measure puts far from the origin by the gap between its total mass and its
+  Laplace transform at a positive parameter.
 * `TauCeti.RepresentsLaplace`: the predicate that a finite measure represents a function by its
   Laplace transform on `[0, ∞)`, with `congr`/`add`/`smul`/`unique` API.
 * `TauCeti.representsLaplace_laplaceTransformENN`: every finite measure on `ℝ≥0` is represented
@@ -134,6 +139,64 @@ the point masses are the building blocks of the representing mixtures. -/
 lemma laplaceTransform_dirac (x₀ : ℝ≥0) (t : ℝ) :
     laplaceTransform (Measure.dirac x₀) t = Real.exp (-(t * (x₀ : ℝ))) := by
   rw [laplaceTransform_eq_mgf, mgf_dirac', mul_neg]
+
+/-! ## A Markov tail bound through the Laplace transform -/
+
+/-- The bounded coordinate `p ↦ 1 - e^{-xp}` integrates, against a finite measure, to the gap
+between the total mass and the Laplace transform at `x`. -/
+private lemma lintegral_ofReal_one_sub_exp_neg_mul (μ : Measure ℝ≥0) [IsFiniteMeasure μ] {x : ℝ}
+    (hx : 0 ≤ x) :
+    ∫⁻ p : ℝ≥0, ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ)))) ∂μ
+      = ENNReal.ofReal (μ.real univ - laplaceTransform μ x) := by
+  have hexp : Integrable (fun p : ℝ≥0 => Real.exp (-(x * (p : ℝ)))) μ :=
+    integrable_exp_neg_mul μ hx
+  have hint : Integrable (fun p : ℝ≥0 => 1 - Real.exp (-(x * (p : ℝ)))) μ :=
+    (integrable_const (1 : ℝ)).sub hexp
+  have hnonneg : 0 ≤ᵐ[μ] fun p : ℝ≥0 => 1 - Real.exp (-(x * (p : ℝ))) :=
+    .of_forall fun p => sub_nonneg.mpr (exp_neg_mul_le_one hx p)
+  rw [← ofReal_integral_eq_lintegral_ofReal hint hnonneg,
+    integral_sub (integrable_const (1 : ℝ)) hexp, ← laplaceTransform_apply]
+  simp
+
+/-- **A Markov tail bound through the Laplace transform.** For a finite measure on `ℝ≥0` and
+positive parameters `x` and `R`, the mass outside the closed ball of radius `R` is at most the
+Laplace gap `μ.real univ - laplaceTransform μ x` divided by `1 - e^{-xR}`.
+
+This is Markov's inequality applied to the bounded coordinate `p ↦ 1 - e^{-xp}`, which is at
+least `1 - e^{-xR}` outside the ball. It is a tightness input rather than a decay rate in `R`:
+the denominator only tends to `1` as `R → ∞`, and it is the numerator, made small by taking `x`
+small, that does the work. -/
+theorem measure_compl_closedBall_le_of_laplaceTransform (μ : Measure ℝ≥0) [IsFiniteMeasure μ]
+    {x R : ℝ} (hx : 0 < x) (hR : 0 < R) :
+    μ (Metric.closedBall (0 : ℝ≥0) R)ᶜ
+      ≤ ENNReal.ofReal ((μ.real univ - laplaceTransform μ x) / (1 - Real.exp (-(x * R)))) := by
+  set c : ℝ := 1 - Real.exp (-(x * R)) with hc_def
+  have hc_pos : 0 < c := by
+    have : Real.exp (-(x * R)) < 1 := Real.exp_lt_one_iff.mpr (by nlinarith)
+    rw [hc_def]; linarith
+  have hmeas : AEMeasurable
+      (fun p : ℝ≥0 => ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ))))) μ :=
+    (ENNReal.measurable_ofReal.comp
+      (by fun_prop : Measurable fun p : ℝ≥0 => 1 - Real.exp (-(x * (p : ℝ))))).aemeasurable
+  have hsubset : (Metric.closedBall (0 : ℝ≥0) R)ᶜ
+      ⊆ {p : ℝ≥0 | ENNReal.ofReal c ≤ ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ))))} := by
+    intro p hp
+    have hRp : R ≤ (p : ℝ) := by
+      have : R < dist p (0 : ℝ≥0) := by simpa [Metric.mem_closedBall, not_le] using hp
+      simpa [NNReal.dist_eq] using this.le
+    have : Real.exp (-(x * (p : ℝ))) ≤ Real.exp (-(x * R)) :=
+      Real.exp_le_exp.mpr (neg_le_neg (mul_le_mul_of_nonneg_left hRp hx.le))
+    exact ENNReal.ofReal_le_ofReal (by rw [hc_def]; linarith)
+  calc
+    μ (Metric.closedBall (0 : ℝ≥0) R)ᶜ
+        ≤ μ {p : ℝ≥0 | ENNReal.ofReal c ≤ ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ))))} :=
+      measure_mono hsubset
+    _ ≤ (∫⁻ p : ℝ≥0, ENNReal.ofReal (1 - Real.exp (-(x * (p : ℝ)))) ∂μ) / ENNReal.ofReal c :=
+      meas_ge_le_lintegral_div hmeas (ENNReal.ofReal_ne_zero_iff.mpr hc_pos) ENNReal.ofReal_ne_top
+    _ = ENNReal.ofReal (μ.real univ - laplaceTransform μ x) / ENNReal.ofReal c := by
+      rw [lintegral_ofReal_one_sub_exp_neg_mul μ hx.le]
+    _ = ENNReal.ofReal ((μ.real univ - laplaceTransform μ x) / c) :=
+      (ENNReal.ofReal_div_of_pos hc_pos).symm
 
 /-! ## Easy direction: finite measures give completely monotone Laplace transforms -/
 

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
@@ -29,7 +29,7 @@ on `[0, ∞)`, and its possibly infinite-measure counterpart on `(0, ∞)`.
 
 * `TauCeti.laplaceTransform`: the Laplace transform of a measure on `ℝ≥0`, with its algebraic
   API and the bridge `TauCeti.laplaceTransform_eq_mgf` to Mathlib's moment-generating function.
-* `TauCeti.measure_compl_closedBall_le_of_laplaceTransform`: a Markov tail bound, controlling
+* `TauCeti.measure_compl_closedBall_le_sub_laplaceTransform_div`: a Markov tail bound, controlling
   the mass a finite measure puts far from the origin by the gap between its total mass and its
   Laplace transform at a positive parameter.
 * `TauCeti.RepresentsLaplace`: the predicate that a finite measure represents a function by its
@@ -166,7 +166,8 @@ This is Markov's inequality applied to the bounded coordinate `p ↦ 1 - e^{-xp}
 least `1 - e^{-xR}` outside the ball. It is a tightness input rather than a decay rate in `R`:
 the denominator only tends to `1` as `R → ∞`, and it is the numerator, made small by taking `x`
 small, that does the work. -/
-theorem measure_compl_closedBall_le_of_laplaceTransform (μ : Measure ℝ≥0) [IsFiniteMeasure μ]
+theorem measure_compl_closedBall_le_sub_laplaceTransform_div
+    (μ : Measure ℝ≥0) [IsFiniteMeasure μ]
     {x R : ℝ} (hx : 0 < x) (hR : 0 < R) :
     μ (Metric.closedBall (0 : ℝ≥0) R)ᶜ
       ≤ ENNReal.ofReal ((μ.real univ - laplaceTransform μ x) / (1 - Real.exp (-(x * R)))) := by

--- a/TauCeti/MeasureTheory/Measure/Tight.lean
+++ b/TauCeti/MeasureTheory/Measure/Tight.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Tight
+public import Mathlib.Topology.Metrizable.CompletelyMetrizable
+
+/-!
+# Tightness of a finite family of finite measures
+
+Mathlib's `MeasureTheory.isTightMeasureSet_singleton` says that a single finite measure on a
+complete second-countable pseudo-metrizable space is tight, and `IsTightMeasureSet.union` says
+that tightness survives a binary union. Together they give tightness of any *finite* set of
+finite measures, which is the form the Prokhorov extraction arguments need in order to discard
+the finitely many exceptional members of a family for which a uniform tail bound is unavailable.
+
+## Main declarations
+
+* `TauCeti.isTightMeasureSet_of_finite`: a finite set of finite measures is tight.
+* `TauCeti.isTightMeasureSet_range_finite`: a family of finite measures indexed by a finite type
+  has tight range.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B (Bernstein theorem
+  milestone), "measure extraction via Prokhorov tightness".
+-/
+
+public section
+
+open MeasureTheory Set
+
+namespace TauCeti
+
+variable {α : Type*} [MeasurableSpace α] [TopologicalSpace α]
+  [TopologicalSpace.IsCompletelyPseudoMetrizableSpace α] [SecondCountableTopology α]
+  [BorelSpace α]
+
+/-- **A finite set of finite measures is tight.** Singletons are tight and tightness is closed
+under unions; the empty case routes through an arbitrary singleton, as Mathlib has no dedicated
+empty-set tightness lemma. -/
+theorem isTightMeasureSet_of_finite {S : Set (Measure α)} (hS : S.Finite)
+    (hfin : ∀ ν ∈ S, IsFiniteMeasure ν) : IsTightMeasureSet S := by
+  induction S, hS using Set.Finite.induction_on with
+  | empty => exact (isTightMeasureSet_singleton (μ := (0 : Measure α))).subset (empty_subset _)
+  | @insert ν S _ _ ih =>
+      have : IsFiniteMeasure ν := hfin ν (mem_insert _ _)
+      rw [insert_eq]
+      exact isTightMeasureSet_singleton.union (ih fun ρ hρ => hfin ρ (mem_insert_of_mem _ hρ))
+
+/-- **A family of finite measures indexed by a finite type has tight range.** -/
+theorem isTightMeasureSet_range_finite {ι : Type*} [Finite ι] (μ : ι → Measure α)
+    (hfin : ∀ i, IsFiniteMeasure (μ i)) : IsTightMeasureSet (range μ) :=
+  isTightMeasureSet_of_finite (finite_range μ) (by rintro ν ⟨i, rfl⟩; exact hfin i)
+
+end TauCeti
+
+end

--- a/TauCeti/MeasureTheory/Measure/Tight.lean
+++ b/TauCeti/MeasureTheory/Measure/Tight.lean
@@ -20,7 +20,7 @@ the finitely many exceptional members of a family for which a uniform tail bound
 ## Main declarations
 
 * `TauCeti.isTightMeasureSet_of_finite`: a finite set of finite measures is tight.
-* `TauCeti.isTightMeasureSet_range_finite`: a family of finite measures indexed by a finite type
+* `TauCeti.isTightMeasureSet_range_of_finite`: a family of finite measures indexed by a finite type
   has tight range.
 
 ## References
@@ -52,7 +52,7 @@ theorem isTightMeasureSet_of_finite {S : Set (Measure α)} (hS : S.Finite)
       exact isTightMeasureSet_singleton.union (ih fun ρ hρ => hfin ρ (mem_insert_of_mem _ hρ))
 
 /-- **A family of finite measures indexed by a finite type has tight range.** -/
-theorem isTightMeasureSet_range_finite {ι : Type*} [Finite ι] (μ : ι → Measure α)
+theorem isTightMeasureSet_range_of_finite {ι : Type*} [Finite ι] (μ : ι → Measure α)
     (hfin : ∀ i, IsFiniteMeasure (μ i)) : IsTightMeasureSet (range μ) :=
   isTightMeasureSet_of_finite (finite_range μ) (by rintro ν ⟨i, rfl⟩; exact hfin i)
 


### PR DESCRIPTION
This PR proves the Hausdorff--Bernstein--Widder theorem in finite-difference form: a function `f : ℝ → ℝ` that is right-continuous at `0` and whose mixed forward differences with nonnegative steps carry the sign `(-1)ⁿ` is the Laplace transform of a unique finite positive measure on `ℝ≥0`, and conversely. It advances Part C, Milestone 2 of `TauCetiRoadmap/OneParameterSemigroups/README.md` by supplying the bridge from the finite-difference hypotheses produced by the BCR time-slice pipeline to `IsContinuousCompletelyMonotoneOnIoi`.

The hard direction applies Bernstein representation to smoothings that squeeze `f`, proves their measures uniformly tight via a Laplace-gap Markov bound, and extracts one weak cluster point with Prokhorov. Only right-continuity at zero is assumed: it controls tightness and closes the squeeze at zero, while continuity of the cluster point Laplace transform closes the squeeze at positive parameters. The derivative-form Hausdorff--Bernstein--Widder theorem now delegates to this single compactness proof.

The easy direction reuses the existing smooth equivalence `IsCompletelyMonotone.isDifferenceCompletelyMonotone`: positive shifts of an `IsContinuousCompletelyMonotoneOnIoi` function satisfy the finite-difference predicate, and `isDifferenceCompletelyMonotone_of_tendsto` removes the shift. Applying this to `laplaceTransform μ` yields `isDifferenceCompletelyMonotone_laplaceTransform` and `RepresentsLaplace.isDifferenceCompletelyMonotone`.

The public API includes:

- `exists_representsLaplace_of_isDifferenceCompletelyMonotone_of_continuousWithinAt`;
- `hausdorff_bernstein_widder_difference` and `hausdorff_bernstein_widder_difference_existsUnique`;
- `isContinuousCompletelyMonotoneOnIoi_iff_isDifferenceCompletelyMonotone_and_continuousWithinAt`;
- `IsDifferenceCompletelyMonotone.isContinuousCompletelyMonotoneOnIoi`;
- `measure_compl_closedBall_le_sub_laplaceTransform_div`;
- `isTightMeasureSet_of_finite` and `isTightMeasureSet_range_of_finite`.

`bernsteinMeasureKernel` takes `IsContinuousCompletelyMonotoneOnIoi` as a hypothesis; the representation lemmas `representsLaplace_bernsteinMeasure` and `laplaceTransform_bernsteinMeasure` use that predicate for the canonical `bernsteinMeasure`.

No Mathlib infrastructure was vendored.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"hausdorff-bernstein-widder-difference-form"}-->