### PR TITLE
feat: the Levi-Civita connection is smooth

### DIFF
--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Basic.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Basic.lean
@@ -38,8 +38,8 @@ endomorphism-valued one-form `CovariantDerivative.difference ∇ ∇'` vanishes.
 
 ## Main definitions and results
 
-* `TauCeti.Manifold.koszul`: the right-hand side of the Koszul formula, a function of the
-  Riemannian metric alone.
+* `TauCeti.Manifold.koszul` and `TauCeti.Manifold.koszul_apply`: the right-hand side of the Koszul
+  formula, a function of the Riemannian metric alone, and its defining formula.
 * `CovariantDerivative.IsLeviCivita`: a covariant derivative on the tangent bundle is
   torsion free and compatible with the metric.
 * `CovariantDerivative.IsLeviCivita.two_inner_eq_koszul`: the Koszul formula.
@@ -136,6 +136,17 @@ def koszul (X Y Z : Π x : M, TangentSpace I x) (x : M) : ℝ :=
     + inner ℝ (mlieBracket I X Y x) (Z x)
     - inner ℝ (mlieBracket I X Z x) (Y x)
     - inner ℝ (mlieBracket I Y Z x) (X x)
+
+/-- The defining formula for the Koszul expression, available outside the module where
+`TauCeti.Manifold.koszul` is defined. -/
+theorem koszul_apply (X Y Z : Π x : M, TangentSpace I x) (x : M) :
+    koszul I X Y Z x =
+      mvfderiv I (fun y ↦ inner ℝ (Y y) (Z y)) x (X x)
+        + mvfderiv I (fun y ↦ inner ℝ (Z y) (X y)) x (Y x)
+        - mvfderiv I (fun y ↦ inner ℝ (X y) (Y y)) x (Z x)
+        + inner ℝ (mlieBracket I X Y x) (Z x)
+        - inner ℝ (mlieBracket I X Z x) (Y x)
+        - inner ℝ (mlieBracket I Y Z x) (X x) := (rfl)
 
 variable {X Y Z : Π x : M, TangentSpace I x} {x : M}
 

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Regularity.lean
@@ -1,0 +1,234 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita.Existence
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LocalFrame
+public import TauCeti.Geometry.Manifold.VectorField.Regularity
+
+/-!
+# Regularity of the Levi-Civita connection
+
+On a `C^∞` manifold carrying a `C^∞` Riemannian metric, the Levi-Civita connection
+`CovariantDerivative.leviCivita` is `C^∞`: it sends a `C^∞` section of the tangent bundle to a
+`C^∞` section of `Hom(TM, TM)`. This file proves that, in the class form
+`ContMDiffCovariantDerivative` which Mathlib's covariant-derivative API consumes, together with
+the set-local form on an arbitrary open set.
+
+The proof follows the Koszul formula `2 ⟪∇_X Y, Z⟫ = koszul I X Y Z`. The right-hand side is built
+from derivatives of pointwise inner products and from Lie brackets, so it loses one degree of
+smoothness; that is why the metric and the manifold are assumed `C^∞` rather than `C^k` for the
+`C^k` conclusion. Concretely:
+
+* `TauCeti.Manifold.contMDiffOn_koszul` reads the Koszul expression as a sum of directional
+  derivatives of inner products (`ContMDiffOn.contMDiffOn_mvfderiv_apply`) and of inner products
+  with Lie brackets (`ContMDiffOn.mlieBracketWithin_vectorField`);
+* the fibrewise Riesz dual of `Riemannian.Tensor.contMDiffAt_rieszDual` turns smoothness of the
+  numbers `⟪∇_{e_j} σ, e_k⟫` into smoothness of the vector fields `∇_{e_j} σ`, for `e` the
+  chart-local frame;
+* `TauCeti.Manifold.contMDiffOn_hom_of_localFrame` assembles those directions into the hom-bundle
+  section `∇σ` demanded by `ContMDiffCovariantDerivativeOn`.
+
+With the class instance available, the local Christoffel data of
+`TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LocalFrame` becomes unconditional for
+the Levi-Civita connection: its scalar Christoffel symbols and its model-space Christoffel map are
+`C^∞` on the base set of every trivialization in the atlas.
+
+## Main results
+
+* `TauCeti.Manifold.contMDiffOn_koszul`: the Koszul expression of three `C^∞` sections is `C^∞`.
+* `CovariantDerivative.contMDiffOn_leviCivita`: on an open set, the Levi-Civita connection carries
+  a `C^∞` section to a `C^∞` section of `Hom(TM, TM)`.
+* `CovariantDerivative.contMDiffCovariantDerivativeOn_leviCivita` and the instance
+  `CovariantDerivative.instContMDiffCovariantDerivativeLeviCivita`: **the Levi-Civita connection
+  is `C^∞`.**
+* `CovariantDerivative.contMDiffOn_christoffelSymbol_leviCivita` and
+  `CovariantDerivative.contMDiffOn_christoffelMap_leviCivita`: its Christoffel symbols and its
+  model-space Christoffel map are `C^∞` on a trivialization base set.
+
+## References
+
+* [Geodesics, the exponential map, and the Hopf–Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "Regularity of the Levi-Civita connection".
+* M. P. do Carmo, *Riemannian Geometry*, Birkhäuser, 1992, Ch. 2, §3.
+* J. M. Lee, *Introduction to Riemannian Manifolds*, GTM 176, 2018, Thm. 5.10.
+-/
+
+public section
+
+open Bundle FiberBundle Module NormedSpace Set VectorField
+open scoped ContDiff Manifold Topology
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)] [IsManifold I ∞ M]
+  [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)]
+
+/-- **The Koszul expression of three `C^∞` sections is `C^∞`.** Both the derivative terms and the
+Lie-bracket terms lose one degree of smoothness, which is why the statement is made at `∞`. -/
+theorem contMDiffOn_koszul {s : Set M} (hs : IsOpen s) {X Y Z : Π x : M, TangentSpace I x}
+    (hX : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (X y)) s)
+    (hY : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (Y y)) s)
+    (hZ : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (Z y)) s) :
+    ContMDiffOn I 𝓘(ℝ) ∞ (koszul I X Y Z) s := by
+  have hbracket {U V : Π x : M, TangentSpace I x}
+      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (U y)) s)
+      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (V y)) s) :
+      ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+        (fun y ↦ TotalSpace.mk' E y (mlieBracket I U V y)) s := by
+    -- The two smoothness levels that Mathlib's Lie-bracket regularity asks of the manifold; over
+    -- `ℝ` the `minSmoothness` guard is the identity.
+    have hmin : IsManifold I (minSmoothness ℝ 2) M := IsManifold.of_le (n := ∞) (by simp)
+    have hsucc : IsManifold I ((∞ : ℕ∞ω) + 1) M := IsManifold.of_le (n := ∞) (by simp)
+    refine (ContMDiffOn.mlieBracketWithin_vectorField (I := I) (m := ⊤) (n := ⊤) hU hV
+      hs.uniqueMDiffOn (by simp)).congr fun y hy ↦ ?_
+    rw [mlieBracketWithin_of_isOpen hs hy]
+  have hinner {U V : Π x : M, TangentSpace I x}
+      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (U y)) s)
+      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (V y)) s) :
+      ContMDiffOn I 𝓘(ℝ) ∞ (fun y ↦ (inner ℝ (U y) (V y) : ℝ)) s :=
+    ContMDiffOn.inner_bundle (IB := I) (F := E) (E := fun x : M ↦ TangentSpace I x)
+      (b := id) hU hV
+  have hderiv {U V W : Π x : M, TangentSpace I x}
+      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (U y)) s)
+      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (V y)) s)
+      (hW : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (W y)) s) :
+      ContMDiffOn I 𝓘(ℝ) ∞
+        (fun y ↦ mvfderiv I (fun z ↦ (inner ℝ (U z) (V z) : ℝ)) y (W y)) s :=
+    ContMDiffOn.contMDiffOn_mvfderiv_apply (hinner hU hV) hs hW (by simp)
+  refine ContMDiffOn.congr ?_ fun y _ ↦ koszul_apply X Y Z y
+  exact (((hderiv hY hZ hX).add (hderiv hZ hX hY)).sub (hderiv hX hY hZ)).add
+    (hinner (hbracket hX hY) hZ) |>.sub (hinner (hbracket hX hZ) hY)
+      |>.sub (hinner (hbracket hY hZ) hX)
+
+end TauCeti.Manifold
+
+namespace CovariantDerivative
+
+open TauCeti TauCeti.Manifold Riemannian.Tensor
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)] [IsManifold I ∞ M]
+  [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)]
+
+/-- **The Levi-Civita connection differentiates smoothly.** On an open set `u`, a section of the
+tangent bundle which is `C^∞` on `u` has a covariant derivative which is `C^∞` on `u` as a section
+of `Hom(TM, TM)`. -/
+theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) {σ : Π x : M, TangentSpace I x}
+    (hσ : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (σ y)) u) :
+    ContMDiffOn I (I.prod 𝓘(ℝ, E →L[ℝ] E)) ∞
+      (fun y ↦ TotalSpace.mk' (E →L[ℝ] E)
+        (E := fun y : M ↦ (TangentSpace I y →L[ℝ] TangentSpace I y)) y (leviCivita I M σ y)) u := by
+  have hmetric : IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x) :=
+    IsContMDiffRiemannianBundle.of_le (n := ∞) (by simp)
+  have hplus : IsManifold I ((∞ : ℕ∞ω) + 1) M := IsManifold.of_le (n := ∞) (by simp)
+  intro x hx
+  -- Work on the intersection of `u` with the chart domain at `x`, where the chart-local frame
+  -- and the fibrewise Riesz dual are available.
+  set s : Set M := u ∩ (chartAt H x).source
+  have hsopen : IsOpen s := hu.inter (chartAt H x).open_source
+  have hsub : s ⊆ (chartAt H x).source := inter_subset_right
+  have hxs : x ∈ s := ⟨hx, mem_chart_source H x⟩
+  have hσs : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+      (fun y ↦ TotalSpace.mk' E y (σ y)) s := hσ.mono inter_subset_left
+  have hframe (i : Fin (finrank ℝ E)) : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+      (fun y ↦ TotalSpace.mk' E y (chartLocalFrame (I := I) x i y)) s :=
+    (contMDiffOn_chartLocalFrame (I := I) (n := ∞) x i).mono
+      (by rw [TangentBundle.trivializationAt_baseSet]; exact hsub)
+  have hσd {y : M} (hy : y ∈ s) : MDiffAt (T% σ) y :=
+    (hσs.mdifferentiableOn (by simp)).mdifferentiableAt (hsopen.mem_nhds hy)
+  have hframed (i : Fin (finrank ℝ E)) {y : M} (hy : y ∈ s) :
+      MDiffAt (T% (chartLocalFrame (I := I) x i)) y :=
+    ((hframe i).mdifferentiableOn (by simp)).mdifferentiableAt (hsopen.mem_nhds hy)
+  -- Each direction of the connection is the Riesz dual of half the Koszul functional.
+  have hdir (j : Fin (finrank ℝ E)) : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+      (fun y ↦ TotalSpace.mk' E y (leviCivita I M σ y (chartLocalFrame (I := I) x j y))) s := by
+    have hrepr (y : M) : rieszDual (I := I) y ((rieszDual (I := I) y).symm
+        (leviCivita I M σ y (chartLocalFrame (I := I) x j y))) =
+        leviCivita I M σ y (chartLocalFrame (I := I) x j y) :=
+      LinearIsometryEquiv.apply_symm_apply _ _
+    have hval (y : M) (w : TangentSpace I y) :
+        ((rieszDual (I := I) y).symm (leviCivita I M σ y (chartLocalFrame (I := I) x j y))) w =
+          inner ℝ (leviCivita I M σ y (chartLocalFrame (I := I) x j y)) w :=
+      (eq_rieszDual_iff_inner_eq.1 (hrepr y).symm w).symm
+    have heval (k : Fin (finrank ℝ E)) : ContMDiffOn I 𝓘(ℝ) ∞
+        (fun y ↦ ((rieszDual (I := I) y).symm
+          (leviCivita I M σ y (chartLocalFrame (I := I) x j y)))
+            (chartLocalFrame (I := I) x k y)) s := by
+      have hmul : ContMDiffOn I 𝓘(ℝ) ∞ (fun y ↦ (2 : ℝ)⁻¹ *
+          koszul I (chartLocalFrame (I := I) x j) σ (chartLocalFrame (I := I) x k) y) s :=
+        contMDiffOn_const.mul (contMDiffOn_koszul hsopen (hframe j) hσs (hframe k))
+      refine hmul.congr fun y hy ↦ ?_
+      have h := two_inner_leviCivita_eq_koszul (I := I) (M := M)
+        (hframed j hy) (hσd hy) (hframed k hy)
+      rw [hval y]
+      linarith
+    have hfun : (fun y : M ↦ TotalSpace.mk' E y
+        (leviCivita I M σ y (chartLocalFrame (I := I) x j y))) =
+        fun y : M ↦ TotalSpace.mk' E y (rieszDual (I := I) y
+          ((rieszDual (I := I) y).symm
+            (leviCivita I M σ y (chartLocalFrame (I := I) x j y)))) := by
+      funext y
+      rw [hrepr y]
+    rw [hfun]
+    exact fun y hy ↦ (contMDiffAt_rieszDual (I := I) (n := ∞) x (hsub hy)
+      (Φ := fun y ↦ (rieszDual (I := I) y).symm
+        (leviCivita I M σ y (chartLocalFrame (I := I) x j y)))
+      fun k ↦ (heval k).contMDiffAt (hsopen.mem_nhds hy)).contMDiffWithinAt
+  -- Testing the hom-bundle section on the chart-local frame gives smoothness at `x`.
+  have hhom := contMDiffOn_hom_of_localFrame (I := I) (n := ∞)
+    (e := trivializationAt E (TangentSpace I) x) (e' := trivializationAt E (TangentSpace I) x)
+    (finBasis ℝ E) hsopen
+    (by rw [TangentBundle.trivializationAt_baseSet, inter_self]; exact hsub)
+    (A := fun y ↦ leviCivita I M σ y)
+    (fun j ↦ by simpa only [← chartLocalFrame_eq] using hdir j)
+  exact (hhom.contMDiffAt (hsopen.mem_nhds hxs)).contMDiffWithinAt
+
+/-- **The Levi-Civita connection is `C^∞`**, in the set-local form used to read it in a local
+frame. -/
+theorem contMDiffCovariantDerivativeOn_leviCivita {u : Set M} (hu : IsOpen u) :
+    ContMDiffCovariantDerivativeOn E ∞ (leviCivita I M).toFun u where
+  contMDiff hσ := contMDiffOn_leviCivita hu hσ
+
+/-- **The Levi-Civita connection is `C^∞`.** -/
+instance instContMDiffCovariantDerivativeLeviCivita :
+    ContMDiffCovariantDerivative (leviCivita I M) ∞ where
+  contMDiff := contMDiffCovariantDerivativeOn_leviCivita isOpen_univ
+
+variable {ι : Type*} (b : Basis ι ℝ E)
+  {e : Trivialization E (TotalSpace.proj : TangentBundle I M → M)} [MemTrivializationAtlas e]
+
+/-- The scalar Christoffel symbols of the Levi-Civita connection in a local frame are `C^∞` on
+the base set of the trivialization defining the frame. -/
+theorem contMDiffOn_christoffelSymbol_leviCivita (i j k : ι) :
+    ContMDiffOn I 𝓘(ℝ) ∞
+      (christoffelSymbol I b e (leviCivita I M).toFun i j k) e.baseSet := by
+  have := contMDiffCovariantDerivativeOn_leviCivita (I := I) (M := M) e.open_baseSet
+  have : ContMDiffVectorBundle ((∞ : ℕ∞ω) + 1) E (TangentSpace I : M → Type _) I :=
+    inferInstanceAs (ContMDiffVectorBundle ∞ E (TangentSpace I : M → Type _) I)
+  exact contMDiffOn_christoffelSymbol b i j k
+
+/-- The model-space Christoffel map of the Levi-Civita connection is `C^∞` on the base set of the
+trivialization defining its coordinates. -/
+theorem contMDiffOn_christoffelMap_leviCivita [Fintype ι] :
+    ContMDiffOn I 𝓘(ℝ, E →L[ℝ] E →L[ℝ] E) ∞
+      (christoffelMap b ((leviCivita I M).isCovariantDerivativeOn (s := e.baseSet)))
+      e.baseSet := by
+  have := contMDiffCovariantDerivativeOn_leviCivita (I := I) (M := M) e.open_baseSet
+  have : ContMDiffVectorBundle ((∞ : ℕ∞ω) + 1) E (TangentSpace I : M → Type _) I :=
+    inferInstanceAs (ContMDiffVectorBundle ∞ E (TangentSpace I : M → Type _) I)
+  exact contMDiffOn_christoffelMap b _
+
+end CovariantDerivative

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Regularity.lean
@@ -233,7 +233,7 @@ theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) (hm : n + 2 ≤ m) (h
     (finBasis ℝ E) hsopen
     (by rw [TangentBundle.trivializationAt_baseSet, inter_self]; exact hsub)
     (A := fun y ↦ leviCivita I M σ y)
-    (fun j ↦ by simpa only [← chartLocalFrame_eq] using hdir j)
+    (fun j ↦ by simpa only [← chartLocalFrame_def] using hdir j)
   exact (hhom.contMDiffAt (hsopen.mem_nhds hxs)).contMDiffWithinAt
 
 /-- **The Levi-Civita connection is of class `C^n`**, in the set-local form used to read it in a
@@ -289,4 +289,3 @@ instance instContMDiffCovariantDerivativeLeviCivita [IsManifold I ∞ M]
     isOpen_univ le_rfl le_rfl
 
 end CovariantDerivative
-

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Regularity.lean
@@ -200,8 +200,9 @@ theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) (hm : n + 2 ≤ m) (h
       LinearIsometryEquiv.apply_symm_apply _ _
     have hval (y : M) (w : TangentSpace I y) :
         ((rieszDual (I := I) y).symm (leviCivita I M σ y (chartLocalFrame (I := I) x j y))) w =
-          inner ℝ (leviCivita I M σ y (chartLocalFrame (I := I) x j y)) w :=
-      (eq_rieszDual_iff_inner_eq.1 (hrepr y).symm w).symm
+          inner ℝ (leviCivita I M σ y (chartLocalFrame (I := I) x j y)) w := by
+      conv_rhs => rw [← hrepr y]
+      exact (inner_rieszDual _ w).symm
     have heval (l : Fin (finrank ℝ E)) : ContMDiffOn I 𝓘(ℝ) n
         (fun y ↦ ((rieszDual (I := I) y).symm
           (leviCivita I M σ y (chartLocalFrame (I := I) x j y)))

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LeviCivita/Regularity.lean
@@ -12,42 +12,55 @@ public import TauCeti.Geometry.Manifold.VectorField.Regularity
 /-!
 # Regularity of the Levi-Civita connection
 
-On a `C^∞` manifold carrying a `C^∞` Riemannian metric, the Levi-Civita connection
-`CovariantDerivative.leviCivita` is `C^∞`: it sends a `C^∞` section of the tangent bundle to a
-`C^∞` section of `Hom(TM, TM)`. This file proves that, in the class form
-`ContMDiffCovariantDerivative` which Mathlib's covariant-derivative API consumes, together with
-the set-local form on an arbitrary open set.
+On a `C^m` manifold carrying a `C^k` Riemannian metric, the Levi-Civita connection
+`CovariantDerivative.leviCivita` is `C^n` as soon as `n + 2 ≤ m` and `n + 1 ≤ k`: it sends a
+`C^(n+1)` section of the tangent bundle to a `C^n` section of `Hom(TM, TM)`. This file proves
+that, in the class form `ContMDiffCovariantDerivative` which Mathlib's covariant-derivative API
+consumes — a class which already carries that one-derivative loss, asking a `C^(n+1)` section to
+produce a `C^n` one — together with the set-local form on an arbitrary open set. Taking
+`n = m = k = ∞` the loss is invisible and **the Levi-Civita connection of a `C^∞` metric on a
+`C^∞` manifold is `C^∞`**, which is the instance
+`CovariantDerivative.instContMDiffCovariantDerivativeLeviCivita`.
 
 The proof follows the Koszul formula `2 ⟪∇_X Y, Z⟫ = koszul I X Y Z`. The right-hand side is built
-from derivatives of pointwise inner products and from Lie brackets, so it loses one degree of
-smoothness; that is why the metric and the manifold are assumed `C^∞` rather than `C^k` for the
-`C^k` conclusion. Concretely:
+from derivatives of pointwise inner products and from Lie brackets, so it loses exactly one degree
+of smoothness; that is where `n + 1 ≤ k` comes from, and the extra degree in `n + 2 ≤ m` is the
+one Mathlib's Lie-bracket regularity asks of the manifold. Concretely:
 
 * `TauCeti.Manifold.contMDiffOn_koszul` reads the Koszul expression as a sum of directional
   derivatives of inner products (`ContMDiffOn.contMDiffOn_mvfderiv_apply`) and of inner products
-  with Lie brackets (`ContMDiffOn.mlieBracketWithin_vectorField`);
+  with Lie brackets (`ContMDiffWithinAt.mlieBracketWithin_vectorField`);
 * the fibrewise Riesz dual of `Riemannian.Tensor.contMDiffAt_rieszDual` turns smoothness of the
   numbers `⟪∇_{e_j} σ, e_k⟫` into smoothness of the vector fields `∇_{e_j} σ`, for `e` the
   chart-local frame;
 * `TauCeti.Manifold.contMDiffOn_hom_of_localFrame` assembles those directions into the hom-bundle
   section `∇σ` demanded by `ContMDiffCovariantDerivativeOn`.
 
-With the class instance available, the local Christoffel data of
+With the class available, the local Christoffel data of
 `TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LocalFrame` becomes unconditional for
 the Levi-Civita connection: its scalar Christoffel symbols and its model-space Christoffel map are
-`C^∞` on the base set of every trivialization in the atlas.
+`C^n` on the base set of every trivialization in the atlas.
+
+The ambient orders `m` and `k` are carried as instance arguments and compared to the conclusion by
+the hypotheses `n + 2 ≤ m` and `n + 1 ≤ k`, rather than being spelled `n + 2` and `n + 1`
+outright, so that the `C^∞` case remains an instantiation: Mathlib's instance search derives
+`IsManifold I m M` from `IsManifold I ∞ M` for `m = ∞`, but not `IsManifold I (n + 2) M` for a
+variable `n`. The low-order hypotheses `[IsManifold I 2 M]` and
+`[IsContMDiffRiemannianBundle I 1 E _]`, which `CovariantDerivative.leviCivita` needs merely to be
+written down, are carried for the same reason.
 
 ## Main results
 
-* `TauCeti.Manifold.contMDiffOn_koszul`: the Koszul expression of three `C^∞` sections is `C^∞`.
+* `TauCeti.Manifold.contMDiffOn_koszul`: the Koszul expression of three `C^(n+1)` sections is
+  `C^n`.
 * `CovariantDerivative.contMDiffOn_leviCivita`: on an open set, the Levi-Civita connection carries
-  a `C^∞` section to a `C^∞` section of `Hom(TM, TM)`.
+  a `C^(n+1)` section to a `C^n` section of `Hom(TM, TM)`.
 * `CovariantDerivative.contMDiffCovariantDerivativeOn_leviCivita` and the instance
   `CovariantDerivative.instContMDiffCovariantDerivativeLeviCivita`: **the Levi-Civita connection
-  is `C^∞`.**
+  is of class `C^n`**, and in particular `C^∞` for a `C^∞` metric.
 * `CovariantDerivative.contMDiffOn_christoffelSymbol_leviCivita` and
   `CovariantDerivative.contMDiffOn_christoffelMap_leviCivita`: its Christoffel symbols and its
-  model-space Christoffel map are `C^∞` on a trivialization base set.
+  model-space Christoffel map are `C^n` on a trivialization base set.
 
 ## References
 
@@ -70,45 +83,60 @@ variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
-  [RiemannianBundle (fun x : M ↦ TangentSpace I x)] [IsManifold I ∞ M]
-  [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)] {n m k : ℕ∞ω}
+  [IsManifold I 1 M] [IsManifold I m M]
+  [IsContMDiffRiemannianBundle I k E (fun x : M ↦ TangentSpace I x)]
 
-/-- **The Koszul expression of three `C^∞` sections is `C^∞`.** Both the derivative terms and the
-Lie-bracket terms lose one degree of smoothness, which is why the statement is made at `∞`. -/
-theorem contMDiffOn_koszul {s : Set M} (hs : IsOpen s) {X Y Z : Π x : M, TangentSpace I x}
-    (hX : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (X y)) s)
-    (hY : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (Y y)) s)
-    (hZ : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (Z y)) s) :
-    ContMDiffOn I 𝓘(ℝ) ∞ (koszul I X Y Z) s := by
+/-- **The Koszul expression of three `C^(n+1)` sections is `C^n`.** Both the derivative terms and
+the Lie-bracket terms lose one degree of smoothness, whence the two hypotheses on the smoothness
+of the manifold and of the metric. -/
+theorem contMDiffOn_koszul {s : Set M} (hs : IsOpen s) (hm : n + 2 ≤ m) (hk : n + 1 ≤ k)
+    {X Y Z : Π x : M, TangentSpace I x}
+    (hX : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (X y)) s)
+    (hY : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (Y y)) s)
+    (hZ : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (Z y)) s) :
+    ContMDiffOn I 𝓘(ℝ) n (koszul I X Y Z) s := by
+  -- The two smoothness levels that Mathlib's Lie-bracket regularity asks of the manifold; over
+  -- `ℝ` the `minSmoothness` guard is the identity.
+  have hmin : IsManifold I (minSmoothness ℝ 2) M :=
+    IsManifold.of_le (n := m) (by simpa using le_add_self.trans hm)
+  have hsucc : IsManifold I (n + 1 + 1) M :=
+    IsManifold.of_le (n := m) (by rwa [add_assoc, one_add_one_eq_two])
+  -- The metric at the level of the sections, and at the level of the conclusion for the inner
+  -- products against a Lie bracket.
+  have hmetric : IsContMDiffRiemannianBundle I (n + 1) E (fun x : M ↦ TangentSpace I x) :=
+    IsContMDiffRiemannianBundle.of_le (n := k) hk
+  have hmetric' : IsContMDiffRiemannianBundle I n E (fun x : M ↦ TangentSpace I x) :=
+    IsContMDiffRiemannianBundle.of_le (n := k) (le_self_add.trans hk)
   have hbracket {U V : Π x : M, TangentSpace I x}
-      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (U y)) s)
-      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (V y)) s) :
-      ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (U y)) s)
+      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (V y)) s) :
+      ContMDiffOn I (I.prod 𝓘(ℝ, E)) n
         (fun y ↦ TotalSpace.mk' E y (mlieBracket I U V y)) s := by
-    -- The two smoothness levels that Mathlib's Lie-bracket regularity asks of the manifold; over
-    -- `ℝ` the `minSmoothness` guard is the identity.
-    have hmin : IsManifold I (minSmoothness ℝ 2) M := IsManifold.of_le (n := ∞) (by simp)
-    have hsucc : IsManifold I ((∞ : ℕ∞ω) + 1) M := IsManifold.of_le (n := ∞) (by simp)
-    refine (ContMDiffOn.mlieBracketWithin_vectorField (I := I) (m := ⊤) (n := ⊤) hU hV
-      hs.uniqueMDiffOn (by simp)).congr fun y hy ↦ ?_
+    have hbr : ContMDiffOn I (I.prod 𝓘(ℝ, E)) n
+        (fun y ↦ TotalSpace.mk' E y (mlieBracketWithin I U V s y)) s := fun y hy ↦
+      (hU y hy).mlieBracketWithin_vectorField (hV y hy) hs.uniqueMDiffOn hy (by simp)
+    refine hbr.congr fun y hy ↦ ?_
     rw [mlieBracketWithin_of_isOpen hs hy]
-  have hinner {U V : Π x : M, TangentSpace I x}
-      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (U y)) s)
-      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (V y)) s) :
-      ContMDiffOn I 𝓘(ℝ) ∞ (fun y ↦ (inner ℝ (U y) (V y) : ℝ)) s :=
+  have hinner {j : ℕ∞ω} [IsContMDiffRiemannianBundle I j E (fun x : M ↦ TangentSpace I x)]
+      {U V : Π x : M, TangentSpace I x}
+      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) j (fun y ↦ TotalSpace.mk' E y (U y)) s)
+      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) j (fun y ↦ TotalSpace.mk' E y (V y)) s) :
+      ContMDiffOn I 𝓘(ℝ) j (fun y ↦ (inner ℝ (U y) (V y) : ℝ)) s :=
     ContMDiffOn.inner_bundle (IB := I) (F := E) (E := fun x : M ↦ TangentSpace I x)
       (b := id) hU hV
   have hderiv {U V W : Π x : M, TangentSpace I x}
-      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (U y)) s)
-      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (V y)) s)
-      (hW : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (W y)) s) :
-      ContMDiffOn I 𝓘(ℝ) ∞
+      (hU : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (U y)) s)
+      (hV : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (V y)) s)
+      (hW : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (W y)) s) :
+      ContMDiffOn I 𝓘(ℝ) n
         (fun y ↦ mvfderiv I (fun z ↦ (inner ℝ (U z) (V z) : ℝ)) y (W y)) s :=
-    ContMDiffOn.contMDiffOn_mvfderiv_apply (hinner hU hV) hs hW (by simp)
+    ContMDiffOn.contMDiffOn_mvfderiv_apply (hinner hU hV) hs (hW.of_le le_self_add) le_rfl
   refine ContMDiffOn.congr ?_ fun y _ ↦ koszul_apply X Y Z y
   exact (((hderiv hY hZ hX).add (hderiv hZ hX hY)).sub (hderiv hX hY hZ)).add
-    (hinner (hbracket hX hY) hZ) |>.sub (hinner (hbracket hX hZ) hY)
-      |>.sub (hinner (hbracket hY hZ) hX)
+    (hinner (hbracket hX hY) (hZ.of_le le_self_add))
+      |>.sub (hinner (hbracket hX hZ) (hY.of_le le_self_add))
+      |>.sub (hinner (hbracket hY hZ) (hX.of_le le_self_add))
 
 end TauCeti.Manifold
 
@@ -120,20 +148,31 @@ variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
-  [RiemannianBundle (fun x : M ↦ TangentSpace I x)] [IsManifold I ∞ M]
-  [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [IsManifold I 2 M] [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
 
-/-- **The Levi-Civita connection differentiates smoothly.** On an open set `u`, a section of the
-tangent bundle which is `C^∞` on `u` has a covariant derivative which is `C^∞` on `u` as a section
-of `Hom(TM, TM)`. -/
-theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) {σ : Π x : M, TangentSpace I x}
-    (hσ : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞ (fun y ↦ TotalSpace.mk' E y (σ y)) u) :
-    ContMDiffOn I (I.prod 𝓘(ℝ, E →L[ℝ] E)) ∞
+section Finite
+
+variable {n m k : ℕ∞ω} [IsManifold I m M]
+  [IsContMDiffRiemannianBundle I k E (fun x : M ↦ TangentSpace I x)]
+
+/-- **The Levi-Civita connection differentiates with one derivative lost.** On an open set `u`, a
+section of the tangent bundle which is `C^(n+1)` on `u` has a covariant derivative which is `C^n`
+on `u` as a section of `Hom(TM, TM)`. -/
+theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) (hm : n + 2 ≤ m) (hk : n + 1 ≤ k)
+    {σ : Π x : M, TangentSpace I x}
+    (hσ : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1) (fun y ↦ TotalSpace.mk' E y (σ y)) u) :
+    ContMDiffOn I (I.prod 𝓘(ℝ, E →L[ℝ] E)) n
       (fun y ↦ TotalSpace.mk' (E →L[ℝ] E)
         (E := fun y : M ↦ (TangentSpace I y →L[ℝ] TangentSpace I y)) y (leviCivita I M σ y)) u := by
-  have hmetric : IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x) :=
-    IsContMDiffRiemannianBundle.of_le (n := ∞) (by simp)
-  have hplus : IsManifold I ((∞ : ℕ∞ω) + 1) M := IsManifold.of_le (n := ∞) (by simp)
+  have hone : IsManifold I (n + 1) M :=
+    IsManifold.of_le (n := m) ((by gcongr; norm_num : n + 1 ≤ n + 2).trans hm)
+  have hsucc : IsManifold I (n + 1 + 1) M :=
+    IsManifold.of_le (n := m) (by rwa [add_assoc, one_add_one_eq_two])
+  have hmetric : IsContMDiffRiemannianBundle I n E (fun x : M ↦ TangentSpace I x) :=
+    IsContMDiffRiemannianBundle.of_le (n := k) (le_self_add.trans hk)
+  have hbundle : ContMDiffVectorBundle n E (TangentSpace I : M → Type _) I :=
+    TangentBundle.contMDiffVectorBundle
   intro x hx
   -- Work on the intersection of `u` with the chart domain at `x`, where the chart-local frame
   -- and the fibrewise Riesz dual are available.
@@ -141,11 +180,11 @@ theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) {σ : Π x : M, Tange
   have hsopen : IsOpen s := hu.inter (chartAt H x).open_source
   have hsub : s ⊆ (chartAt H x).source := inter_subset_right
   have hxs : x ∈ s := ⟨hx, mem_chart_source H x⟩
-  have hσs : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+  have hσs : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1)
       (fun y ↦ TotalSpace.mk' E y (σ y)) s := hσ.mono inter_subset_left
-  have hframe (i : Fin (finrank ℝ E)) : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+  have hframe (i : Fin (finrank ℝ E)) : ContMDiffOn I (I.prod 𝓘(ℝ, E)) (n + 1)
       (fun y ↦ TotalSpace.mk' E y (chartLocalFrame (I := I) x i y)) s :=
-    (contMDiffOn_chartLocalFrame (I := I) (n := ∞) x i).mono
+    (contMDiffOn_chartLocalFrame (I := I) (n := n + 1) x i).mono
       (by rw [TangentBundle.trivializationAt_baseSet]; exact hsub)
   have hσd {y : M} (hy : y ∈ s) : MDiffAt (T% σ) y :=
     (hσs.mdifferentiableOn (by simp)).mdifferentiableAt (hsopen.mem_nhds hy)
@@ -153,7 +192,7 @@ theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) {σ : Π x : M, Tange
       MDiffAt (T% (chartLocalFrame (I := I) x i)) y :=
     ((hframe i).mdifferentiableOn (by simp)).mdifferentiableAt (hsopen.mem_nhds hy)
   -- Each direction of the connection is the Riesz dual of half the Koszul functional.
-  have hdir (j : Fin (finrank ℝ E)) : ContMDiffOn I (I.prod 𝓘(ℝ, E)) ∞
+  have hdir (j : Fin (finrank ℝ E)) : ContMDiffOn I (I.prod 𝓘(ℝ, E)) n
       (fun y ↦ TotalSpace.mk' E y (leviCivita I M σ y (chartLocalFrame (I := I) x j y))) s := by
     have hrepr (y : M) : rieszDual (I := I) y ((rieszDual (I := I) y).symm
         (leviCivita I M σ y (chartLocalFrame (I := I) x j y))) =
@@ -163,16 +202,17 @@ theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) {σ : Π x : M, Tange
         ((rieszDual (I := I) y).symm (leviCivita I M σ y (chartLocalFrame (I := I) x j y))) w =
           inner ℝ (leviCivita I M σ y (chartLocalFrame (I := I) x j y)) w :=
       (eq_rieszDual_iff_inner_eq.1 (hrepr y).symm w).symm
-    have heval (k : Fin (finrank ℝ E)) : ContMDiffOn I 𝓘(ℝ) ∞
+    have heval (l : Fin (finrank ℝ E)) : ContMDiffOn I 𝓘(ℝ) n
         (fun y ↦ ((rieszDual (I := I) y).symm
           (leviCivita I M σ y (chartLocalFrame (I := I) x j y)))
-            (chartLocalFrame (I := I) x k y)) s := by
-      have hmul : ContMDiffOn I 𝓘(ℝ) ∞ (fun y ↦ (2 : ℝ)⁻¹ *
-          koszul I (chartLocalFrame (I := I) x j) σ (chartLocalFrame (I := I) x k) y) s :=
-        contMDiffOn_const.mul (contMDiffOn_koszul hsopen (hframe j) hσs (hframe k))
+            (chartLocalFrame (I := I) x l y)) s := by
+      have hmul : ContMDiffOn I 𝓘(ℝ) n (fun y ↦ (2 : ℝ)⁻¹ *
+          koszul I (chartLocalFrame (I := I) x j) σ (chartLocalFrame (I := I) x l) y) s :=
+        contMDiffOn_const.mul
+          (contMDiffOn_koszul hsopen hm hk (hframe j) hσs (hframe l))
       refine hmul.congr fun y hy ↦ ?_
       have h := two_inner_leviCivita_eq_koszul (I := I) (M := M)
-        (hframed j hy) (hσd hy) (hframed k hy)
+        (hframed j hy) (hσd hy) (hframed l hy)
       rw [hval y]
       linarith
     have hfun : (fun y : M ↦ TotalSpace.mk' E y
@@ -183,12 +223,12 @@ theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) {σ : Π x : M, Tange
       funext y
       rw [hrepr y]
     rw [hfun]
-    exact fun y hy ↦ (contMDiffAt_rieszDual (I := I) (n := ∞) x (hsub hy)
+    exact fun y hy ↦ (contMDiffAt_rieszDual (I := I) (n := n) x (hsub hy)
       (Φ := fun y ↦ (rieszDual (I := I) y).symm
         (leviCivita I M σ y (chartLocalFrame (I := I) x j y)))
-      fun k ↦ (heval k).contMDiffAt (hsopen.mem_nhds hy)).contMDiffWithinAt
+      fun l ↦ (heval l).contMDiffAt (hsopen.mem_nhds hy)).contMDiffWithinAt
   -- Testing the hom-bundle section on the chart-local frame gives smoothness at `x`.
-  have hhom := contMDiffOn_hom_of_localFrame (I := I) (n := ∞)
+  have hhom := contMDiffOn_hom_of_localFrame (I := I) (n := n)
     (e := trivializationAt E (TangentSpace I) x) (e' := trivializationAt E (TangentSpace I) x)
     (finBasis ℝ E) hsopen
     (by rw [TangentBundle.trivializationAt_baseSet, inter_self]; exact hsub)
@@ -196,39 +236,57 @@ theorem contMDiffOn_leviCivita {u : Set M} (hu : IsOpen u) {σ : Π x : M, Tange
     (fun j ↦ by simpa only [← chartLocalFrame_eq] using hdir j)
   exact (hhom.contMDiffAt (hsopen.mem_nhds hxs)).contMDiffWithinAt
 
-/-- **The Levi-Civita connection is `C^∞`**, in the set-local form used to read it in a local
-frame. -/
-theorem contMDiffCovariantDerivativeOn_leviCivita {u : Set M} (hu : IsOpen u) :
-    ContMDiffCovariantDerivativeOn E ∞ (leviCivita I M).toFun u where
-  contMDiff hσ := contMDiffOn_leviCivita hu hσ
-
-/-- **The Levi-Civita connection is `C^∞`.** -/
-instance instContMDiffCovariantDerivativeLeviCivita :
-    ContMDiffCovariantDerivative (leviCivita I M) ∞ where
-  contMDiff := contMDiffCovariantDerivativeOn_leviCivita isOpen_univ
+/-- **The Levi-Civita connection is of class `C^n`**, in the set-local form used to read it in a
+local frame. -/
+theorem contMDiffCovariantDerivativeOn_leviCivita {u : Set M} (hu : IsOpen u)
+    (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
+    ContMDiffCovariantDerivativeOn E n (leviCivita I M).toFun u where
+  contMDiff hσ := contMDiffOn_leviCivita hu hm hk hσ
 
 variable {ι : Type*} (b : Basis ι ℝ E)
   {e : Trivialization E (TotalSpace.proj : TangentBundle I M → M)} [MemTrivializationAtlas e]
 
-/-- The scalar Christoffel symbols of the Levi-Civita connection in a local frame are `C^∞` on
+/-- The scalar Christoffel symbols of the Levi-Civita connection in a local frame are `C^n` on
 the base set of the trivialization defining the frame. -/
-theorem contMDiffOn_christoffelSymbol_leviCivita (i j k : ι) :
-    ContMDiffOn I 𝓘(ℝ) ∞
-      (christoffelSymbol I b e (leviCivita I M).toFun i j k) e.baseSet := by
-  have := contMDiffCovariantDerivativeOn_leviCivita (I := I) (M := M) e.open_baseSet
-  have : ContMDiffVectorBundle ((∞ : ℕ∞ω) + 1) E (TangentSpace I : M → Type _) I :=
-    inferInstanceAs (ContMDiffVectorBundle ∞ E (TangentSpace I : M → Type _) I)
-  exact contMDiffOn_christoffelSymbol b i j k
+theorem contMDiffOn_christoffelSymbol_leviCivita (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) (i j l : ι) :
+    ContMDiffOn I 𝓘(ℝ) n
+      (christoffelSymbol I b e (leviCivita I M).toFun i j l) e.baseSet := by
+  have := contMDiffCovariantDerivativeOn_leviCivita (I := I) (M := M) e.open_baseSet hm hk
+  have hone : IsManifold I (n + 1) M :=
+    IsManifold.of_le (n := m) ((by gcongr; norm_num : n + 1 ≤ n + 2).trans hm)
+  have hsucc : IsManifold I (n + 1 + 1) M :=
+    IsManifold.of_le (n := m) (by rwa [add_assoc, one_add_one_eq_two])
+  have : ContMDiffVectorBundle n E (TangentSpace I : M → Type _) I :=
+    TangentBundle.contMDiffVectorBundle
+  have : ContMDiffVectorBundle (n + 1) E (TangentSpace I : M → Type _) I :=
+    TangentBundle.contMDiffVectorBundle
+  exact contMDiffOn_christoffelSymbol b i j l
 
-/-- The model-space Christoffel map of the Levi-Civita connection is `C^∞` on the base set of the
+/-- The model-space Christoffel map of the Levi-Civita connection is `C^n` on the base set of the
 trivialization defining its coordinates. -/
-theorem contMDiffOn_christoffelMap_leviCivita [Fintype ι] :
-    ContMDiffOn I 𝓘(ℝ, E →L[ℝ] E →L[ℝ] E) ∞
+theorem contMDiffOn_christoffelMap_leviCivita [Fintype ι] (hm : n + 2 ≤ m) (hk : n + 1 ≤ k) :
+    ContMDiffOn I 𝓘(ℝ, E →L[ℝ] E →L[ℝ] E) n
       (christoffelMap b ((leviCivita I M).isCovariantDerivativeOn (s := e.baseSet)))
       e.baseSet := by
-  have := contMDiffCovariantDerivativeOn_leviCivita (I := I) (M := M) e.open_baseSet
-  have : ContMDiffVectorBundle ((∞ : ℕ∞ω) + 1) E (TangentSpace I : M → Type _) I :=
-    inferInstanceAs (ContMDiffVectorBundle ∞ E (TangentSpace I : M → Type _) I)
+  have := contMDiffCovariantDerivativeOn_leviCivita (I := I) (M := M) e.open_baseSet hm hk
+  have hone : IsManifold I (n + 1) M :=
+    IsManifold.of_le (n := m) ((by gcongr; norm_num : n + 1 ≤ n + 2).trans hm)
+  have hsucc : IsManifold I (n + 1 + 1) M :=
+    IsManifold.of_le (n := m) (by rwa [add_assoc, one_add_one_eq_two])
+  have : ContMDiffVectorBundle n E (TangentSpace I : M → Type _) I :=
+    TangentBundle.contMDiffVectorBundle
+  have : ContMDiffVectorBundle (n + 1) E (TangentSpace I : M → Type _) I :=
+    TangentBundle.contMDiffVectorBundle
   exact contMDiffOn_christoffelMap b _
 
+end Finite
+
+/-- **The Levi-Civita connection of a `C^∞` metric on a `C^∞` manifold is `C^∞`.** -/
+instance instContMDiffCovariantDerivativeLeviCivita [IsManifold I ∞ M]
+    [IsContMDiffRiemannianBundle I ∞ E (fun x : M ↦ TangentSpace I x)] :
+    ContMDiffCovariantDerivative (leviCivita I M) ∞ where
+  contMDiff := contMDiffCovariantDerivativeOn_leviCivita (n := ∞) (m := ∞) (k := ∞)
+    isOpen_univ le_rfl le_rfl
+
 end CovariantDerivative
+

--- a/TauCeti/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -5,10 +5,11 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Geometry.Manifold.VectorBundle.Hom
 public import Mathlib.Geometry.Manifold.VectorBundle.LocalFrame
 
 /-!
-# A local frame is dual to its coefficient functionals
+# Local frames: duality with the coefficient functionals, and testing hom-bundle sections
 
 Let `V → M` be a smooth vector bundle, let `e` be a trivialization of `V` and let `b` be a basis
 of the model fibre, so that `e.localFrame b` is a local frame of `V` over `e.baseSet` with
@@ -16,12 +17,24 @@ coefficient functionals `e.localFrameCoeff I b`. This file records that over `e.
 and its coefficient functionals are dual to each other: the `i`-th functional takes the value `1`
 on the `i`-th frame vector and `0` on the others.
 
+It then uses a local frame of the *source* bundle to test smoothness of a section of a bundle of
+continuous linear maps: such a section is `C^n` on an open subset of the two base sets as soon as
+its evaluations on the frame sections are. Read through a trivialization, a continuous linear map
+out of a finite-dimensional space is recovered from its values on a basis by
+`T = ∑ j, (b.coord j).smulRight (T (b j))`, and each summand depends continuously linearly on
+`T (b j)`. This is the criterion through which a covariant derivative is proved to be `C^n`:
+`ContMDiffCovariantDerivativeOn` asks for smoothness of the hom-bundle section `∇σ`, while the
+constructions of connections produce smoothness of the vector fields `∇_X σ` one direction `X` at
+a time.
+
 ## Main results
 
 * `TauCeti.Manifold.localFrameCoeff_basisAt`: the coefficient functionals are dual to the basis
   `e.basisAt b hx` of the fibre at a point of `e.baseSet`.
 * `TauCeti.Manifold.localFrameCoeff_localFrame`: the same duality, stated for the frame sections
   themselves.
+* `TauCeti.Manifold.contMDiffOn_hom_of_localFrame`: a section of the bundle of continuous linear
+  maps is `C^n` once its evaluations on a local frame of the source bundle are.
 -/
 
 public section
@@ -58,5 +71,66 @@ theorem localFrameCoeff_basisAt [DecidableEq ι] (hx : x ∈ e.baseSet) (i j : �
 theorem localFrameCoeff_localFrame [DecidableEq ι] (hx : x ∈ e.baseSet) (i j : ι) :
     e.localFrameCoeff I b i x (e.localFrame b j x) = if i = j then 1 else 0 := by
   rw [e.localFrame_apply_of_mem_baseSet b hx, localFrameCoeff_basisAt b hx]
+
+/-! ### Testing a hom-bundle section on a local frame -/
+
+section Hom
+
+variable [Finite ι] [CompleteSpace 𝕜] [FiniteDimensional 𝕜 F]
+  {F' : Type*} [NormedAddCommGroup F'] [NormedSpace 𝕜 F']
+  {V' : M → Type*} [TopologicalSpace (TotalSpace F' V')]
+  [∀ x, AddCommGroup (V' x)] [∀ x, Module 𝕜 (V' x)] [∀ x, TopologicalSpace (V' x)]
+  [FiberBundle F' V'] [VectorBundle 𝕜 F' V']
+  {e' : Trivialization F' (TotalSpace.proj : TotalSpace F' V' → M)} [MemTrivializationAtlas e']
+  {n : ℕ∞ω} {u : Set M}
+
+omit [ContMDiffVectorBundle 1 F V I] [Finite ι] in
+/-- A continuous linear map out of a finite-dimensional space is the sum, over a basis of the
+source, of the `smulRight`s of its values on that basis. -/
+private theorem eq_sum_coord_smulRight [Fintype ι] (T : F →L[𝕜] F') :
+    T = ∑ j, (LinearMap.toContinuousLinearMap (b.coord j)).smulRight (T (b j)) := by
+  classical
+  refine ContinuousLinearMap.coe_injective (b.ext fun j ↦ ?_)
+  simp [Basis.coord_apply, Finsupp.single_apply]
+
+variable [∀ x, IsTopologicalAddGroup (V' x)] [∀ x, ContinuousSMul 𝕜 (V' x)]
+  [ContMDiffVectorBundle n F V I] [ContMDiffVectorBundle n F' V' I]
+
+omit [ContMDiffVectorBundle 1 F V I] in
+/-- **A hom-bundle section is tested on a local frame.** A section `A` of the bundle of continuous
+linear maps from `V` to `V'` is `C^n` on an open subset of `e.baseSet ∩ e'.baseSet` as soon as each
+of its evaluations `A (e.localFrame b j)` on the local frame of the source bundle is. -/
+theorem contMDiffOn_hom_of_localFrame (hu : IsOpen u)
+    (hu' : u ⊆ e.baseSet ∩ e'.baseSet) {A : Π y : M, V y →L[𝕜] V' y}
+    (hA : ∀ j : ι, ContMDiffOn I (I.prod 𝓘(𝕜, F')) n
+      (fun y ↦ TotalSpace.mk' F' y (A y (e.localFrame b j y))) u) :
+    ContMDiffOn I (I.prod 𝓘(𝕜, F →L[𝕜] F')) n
+      (fun y ↦ TotalSpace.mk' (F →L[𝕜] F') y (A y)) u := by
+  have : Fintype ι := Fintype.ofFinite ι
+  set eh := e.continuousLinearMap (RingHom.id 𝕜) e' with heh
+  rw [eh.contMDiffOn_section_iff hu hu']
+  -- The `j`-th coordinate of the trivialized section is the trivialized evaluation on the frame.
+  have key {y : M} (hy : y ∈ u) (j : ι) :
+      (eh ⟨y, A y⟩).2 (b j) = (e' ⟨y, A y (e.localFrame b j y)⟩).2 := by
+    rw [heh, Bundle.Trivialization.continuousLinearMap_apply]
+    simp only [ContinuousLinearMap.comp_apply]
+    rw [e.symmL_apply (hu' hy).1]
+    have hframe : e.symm y (b j) = e.localFrame b j y := by
+      simp [Bundle.Trivialization.localFrame_apply_of_mem_baseSet,
+        Bundle.Trivialization.basisAt, (hu' hy).1]
+    rw [hframe, Bundle.Trivialization.continuousLinearMapAt_apply_of_mem 𝕜 e' (hu' hy).2]
+  have hcoord (j : ι) : ContMDiffOn I 𝓘(𝕜, F') n (fun y ↦ (eh ⟨y, A y⟩).2 (b j)) u := by
+    refine ContMDiffOn.congr ?_ fun y hy ↦ key hy j
+    exact (e'.contMDiffOn_section_iff hu (hu'.trans inter_subset_right)).1 (hA j)
+  have hsum : ContMDiffOn I 𝓘(𝕜, F →L[𝕜] F') n
+      (fun y ↦ ∑ j, (LinearMap.toContinuousLinearMap (b.coord j)).smulRight
+        ((eh ⟨y, A y⟩).2 (b j))) u := by
+    refine contMDiffOn_finsetSum fun j _ ↦ ?_
+    exact ContMDiffOn.clm_apply
+      (g := fun _ ↦ ContinuousLinearMap.smulRightL 𝕜 F F'
+        (LinearMap.toContinuousLinearMap (b.coord j))) contMDiffOn_const (hcoord j)
+  exact hsum.congr fun y _ ↦ eq_sum_coord_smulRight b _
+
+end Hom
 
 end TauCeti.Manifold

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -72,7 +72,7 @@ def chartLocalFrame (α : M) :
   (trivializationAt E (TangentSpace I) α).localFrame (Module.finBasis ℝ E)
 
 /-- The chart-local frame is the local frame of the tangent trivialization at `α` for the
-`Module.finBasis` basis. This unfolds `TauCeti.Manifold.chartLocalFrame` outside the module where
+`Module.finBasis` basis. This unfolds `Riemannian.Tensor.chartLocalFrame` outside the module where
 it is defined. -/
 theorem chartLocalFrame_def (α : M) :
     chartLocalFrame (I := I) α =

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -31,8 +31,9 @@ API replace them.
 
 ## Main definitions and results
 
-* `Riemannian.Tensor.chartLocalFrame`: the frame induced by the tangent trivialization at a chart
-  centre and `Module.finBasis`.
+* `Riemannian.Tensor.chartLocalFrame` and `Riemannian.Tensor.chartLocalFrame_eq`: the frame
+  induced by the tangent trivialization at a chart centre and `Module.finBasis`, and its
+  identification with that trivialization's local frame.
 * `Riemannian.Tensor.chartGramMatrix`: the metric Gram matrix in this frame.
 * `Riemannian.Tensor.posDef_chartGramMatrix`: positive-definiteness on the base set.
 * `Riemannian.Tensor.chartGramMatrix_det_pos`: strict positivity of its determinant there.
@@ -69,6 +70,13 @@ Mathlib's standard junk value `0`. -/
 def chartLocalFrame (α : M) :
     Fin (Module.finrank ℝ E) → (x : M) → TangentSpace I x :=
   (trivializationAt E (TangentSpace I) α).localFrame (Module.finBasis ℝ E)
+
+/-- The chart-local frame is the local frame of the tangent trivialization at `α` for the
+`Module.finBasis` basis. This unfolds `TauCeti.Manifold.chartLocalFrame` outside the module where
+it is defined. -/
+theorem chartLocalFrame_eq (α : M) :
+    chartLocalFrame (I := I) α =
+      (trivializationAt E (TangentSpace I) α).localFrame (Module.finBasis ℝ E) := (rfl)
 
 /-- On the chart source, the local frame agrees with the basis supplied by the tangent
 trivialization. The source membership is the simplified form of the trivialization base set. -/

--- a/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/Riemannian/ChartGram.lean
@@ -31,7 +31,7 @@ API replace them.
 
 ## Main definitions and results
 
-* `Riemannian.Tensor.chartLocalFrame` and `Riemannian.Tensor.chartLocalFrame_eq`: the frame
+* `Riemannian.Tensor.chartLocalFrame` and `Riemannian.Tensor.chartLocalFrame_def`: the frame
   induced by the tangent trivialization at a chart centre and `Module.finBasis`, and its
   identification with that trivialization's local frame.
 * `Riemannian.Tensor.chartGramMatrix`: the metric Gram matrix in this frame.
@@ -74,7 +74,7 @@ def chartLocalFrame (α : M) :
 /-- The chart-local frame is the local frame of the tangent trivialization at `α` for the
 `Module.finBasis` basis. This unfolds `TauCeti.Manifold.chartLocalFrame` outside the module where
 it is defined. -/
-theorem chartLocalFrame_eq (α : M) :
+theorem chartLocalFrame_def (α : M) :
     chartLocalFrame (I := I) α =
       (trivializationAt E (TangentSpace I) α).localFrame (Module.finBasis ℝ E) := (rfl)
 

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -133,5 +133,6 @@ theorem ContMDiffOn.contMDiffOn_mvfderiv_apply {f : M → F} {s : Set M}
   refine hcomp.congr fun y hy ↦ ?_
   have hval : ((fun p : TangentBundle I M ↦ (tangentMapWithin I 𝓘(𝕜, F) f s p).2) ∘
       (fun y : M ↦ (TotalSpace.mk' E y (A y) : TangentBundle I M))) y
-      = mfderivWithin I 𝓘(𝕜, F) f s y (A y) := rfl
+      = mfderivWithin I 𝓘(𝕜, F) f s y (A y) := by
+    exact tangentMapWithin_snd
   rw [hval, mfderivWithin_of_isOpen hs hy, mvfderiv_apply_eq_mfderiv_apply]

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -134,5 +134,4 @@ theorem ContMDiffOn.contMDiffOn_mvfderiv_apply {f : M → F} {s : Set M}
   have hval : ((fun p : TangentBundle I M ↦ (tangentMapWithin I 𝓘(𝕜, F) f s p).2) ∘
       (fun y : M ↦ (TotalSpace.mk' E y (A y) : TangentBundle I M))) y
       = mfderivWithin I 𝓘(𝕜, F) f s y (A y) := rfl
-  rw [hval, mfderivWithin_of_isOpen hs hy]
-  rfl
+  rw [hval, mfderivWithin_of_isOpen hs hy, mvfderiv_apply_eq_mfderiv_apply]

--- a/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/Regularity.lean
@@ -22,6 +22,8 @@ manifold differential of a function to tangent vectors whose base point varies.
   normed vector space.
 * `ContMDiff.contMDiff_mvfderiv_apply`: applying the differential of a `C^n` function on the
   tangent bundle is `C^m` when `m + 1 ≤ n`.
+* `ContMDiffOn.contMDiffOn_mvfderiv_apply`: the derivative of a `C^n` function along a `C^m`
+  vector field is `C^m` on an open set, when `m + 1 ≤ n`.
 
 ## References
 
@@ -31,7 +33,7 @@ manifold differential of a function to tangent vectors whose base point varies.
 
 public section
 
-open Bundle Manifold
+open Bundle Manifold Set
 open scoped ContDiff Manifold
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
@@ -107,3 +109,30 @@ theorem ContMDiff.contMDiff_mvfderiv_apply {f : M → F}
   -- On a model vector space, `NormedSpace.fromTangentSpace` is the identity on the underlying
   -- type, so the second projection computed by `h` agrees definitionally with `mvfderiv`.
   exact h.congr fun p => (htangent p).symm
+
+/-- The derivative of a `C^n` function along a `C^m` vector field is `C^m` on an open set, when
+`m + 1 ≤ n`. This is the set-local form of `ContMDiff.contMDiff_mvfderiv_apply`: only the germ of
+`f` on the open set `s` enters, so it applies to functions built from sections that are smooth on
+a chart domain only. -/
+theorem ContMDiffOn.contMDiffOn_mvfderiv_apply {f : M → F} {s : Set M}
+    {A : Π y : M, TangentSpace I y}
+    (hf : ContMDiffOn I 𝓘(𝕜, F) n f s) (hs : IsOpen s)
+    (hA : ContMDiffOn I I.tangent m (fun y ↦ (TotalSpace.mk' E y (A y) : TangentBundle I M)) s)
+    (hmn : m + 1 ≤ n) :
+    ContMDiffOn I 𝓘(𝕜, F) m (fun y ↦ mvfderiv I f y (A y)) s := by
+  have htangent : ContMDiffOn I.tangent 𝓘(𝕜, F).tangent m (tangentMapWithin I 𝓘(𝕜, F) f s)
+      (π E (TangentSpace I) ⁻¹' s) :=
+    hf.contMDiffOn_tangentMapWithin hmn hs.uniqueMDiffOn
+  have hsnd : ContMDiff 𝓘(𝕜, F).tangent 𝓘(𝕜, F) m
+      (fun p : TangentBundle 𝓘(𝕜, F) F ↦ p.2) :=
+    contMDiff_snd_tangentBundle_modelSpace F 𝓘(𝕜, F)
+  have hproj : ContMDiffOn I.tangent 𝓘(𝕜, F) m
+      (fun p : TangentBundle I M ↦ (tangentMapWithin I 𝓘(𝕜, F) f s p).2)
+      (π E (TangentSpace I) ⁻¹' s) := hsnd.comp_contMDiffOn htangent
+  have hcomp := hproj.comp hA (fun y hy ↦ hy)
+  refine hcomp.congr fun y hy ↦ ?_
+  have hval : ((fun p : TangentBundle I M ↦ (tangentMapWithin I 𝓘(𝕜, F) f s p).2) ∘
+      (fun y : M ↦ (TotalSpace.mk' E y (A y) : TangentBundle I M))) y
+      = mfderivWithin I 𝓘(𝕜, F) f s y (A y) := rfl
+  rw [hval, mfderivWithin_of_isOpen hs hy]
+  rfl


### PR DESCRIPTION
This PR proves that the Levi-Civita connection is of class `C^n`, and in particular `C^∞`. On a
`C^m` manifold with a `C^k` Riemannian metric on a finite-dimensional real model, and whenever
`n + 2 ≤ m` and `n + 1 ≤ k`, `CovariantDerivative.leviCivita` — built in #4260 from the Koszul
formula — carries a `C^(n+1)` section of the tangent bundle to a `C^n` section of `Hom(TM, TM)`.
That is Mathlib's `ContMDiffCovariantDerivativeOn ∇ n`, a class which already builds in exactly
that one-derivative loss, and at `n = m = k = ∞` it is `ContMDiffCovariantDerivative ∇ ∞`. That is
the Layer 1 milestone "Regularity of the Levi-Civita connection" of the Hopf–Rinow roadmap, the
milestone the roadmap's ordering places between the construction of the connection and the
geodesic spray: it is named there as the milestone that "precedes and supplies the regularity
input for the geodesic-spray milestone below". The same milestone asks for the chart-level
Christoffel data, and this PR discharges that too, by making the conditional results of #4050
unconditional for the Levi-Civita connection: its scalar Christoffel symbols and its model-space
Christoffel map `x ↦ Γ_x : E →L[ℝ] E →L[ℝ] E` are `C^n` on the base set of every trivialization in
the atlas, which for the tangent trivialization at a point is the chart source.

The proof follows the Koszul formula `2 ⟪∇_X Y, Z⟫ = koszul I X Y Z`. Its right-hand side is built
from directional derivatives of pointwise inner products and from Lie brackets, each of which
costs one degree of smoothness; that is where `n + 1 ≤ k` comes from, and the extra degree in
`n + 2 ≤ m` is the one Mathlib's Lie-bracket regularity asks of the manifold.
`TauCeti.Manifold.contMDiffOn_koszul` assembles the six terms on an open set. The fibrewise Riesz
dual of #4001 then turns smoothness of the numbers `⟪∇_{e_j} σ, e_k⟫` into smoothness of the
vector fields `∇_{e_j} σ` along the chart-local frame of #3946, and a new local-frame criterion
`TauCeti.Manifold.contMDiffOn_hom_of_localFrame` assembles those directions back into the
hom-bundle section that `ContMDiffCovariantDerivativeOn` demands: a section of a bundle of
continuous linear maps is `C^n` on an open subset of the two base sets as soon as its evaluations
on a local frame of the source bundle are. That criterion is the missing link between how
connections are built (one direction at a time) and how Mathlib's regularity class is phrased, so
it is stated for a general pair of vector bundles.

The ambient orders `m` and `k` are carried as instance arguments and compared to the conclusion by
the hypotheses `n + 2 ≤ m` and `n + 1 ≤ k`, rather than being spelled `n + 2` and `n + 1`
outright. Mathlib's instance search derives `IsManifold I m M` from `IsManifold I ∞ M` for
`m = ∞`, but has no rule producing `IsManifold I (n + 2) M` for a variable `n`, so the literal
form would leave the `C^∞` case unusable without hand-supplied instances; with the `≤` form the
`C^∞` statements are plain instantiations at `n = m = k = ∞` with `le_rfl`.

Two supporting results are added to existing files. `ContMDiffOn.contMDiffOn_mvfderiv_apply`
is the set-local form of the existing `ContMDiff.contMDiff_mvfderiv_apply`: only the germ of the
function on an open set enters, so it applies to functions built from sections which are smooth on
a chart domain only, as the frame sections here are. `TauCeti.Manifold.koszul_apply` and
`Riemannian.Tensor.chartLocalFrame_eq` expose the defining equations of two existing definitions,
whose bodies are not visible outside their own modules under the module system.

The concrete statement of the milestone is `CovariantDerivative.contMDiffOn_leviCivita` and its
packaged forms `CovariantDerivative.contMDiffCovariantDerivativeOn_leviCivita` and the instance
`CovariantDerivative.instContMDiffCovariantDerivativeLeviCivita`; the chart-level results are
`CovariantDerivative.contMDiffOn_christoffelSymbol_leviCivita` and
`CovariantDerivative.contMDiffOn_christoffelMap_leviCivita`. With this milestone closed, the next
Layer 1 step on the roadmap's ordering is the covariant derivative along a curve — the pullback
connection and covariant acceleration — after which the geodesic spray can be constructed and fed
to Mathlib's integral-curve API.

Nothing is ported here: the argument is written against the pinned Mathlib and against the
Tau Ceti infrastructure already merged for this roadmap (#3946, #4001, #4050, #4260); no Mathlib
source is vendored and no external development is adapted.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"contmdiffcovariantderivative-levicivita"}-->

🤖 Prepared with Claude Code
