### PR TITLE
feat: the symmetric Frobenius trace of a zigzag algebra

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Multiplication.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Multiplication.lean
@@ -155,7 +155,7 @@ theorem zigzagMk_ofArrow_mul_ofArrow_symm (d : G.Dart) :
     ofArrow_symm_mul_ofArrow G k d.symm.adj
   rw [← map_mul, key, zigzagMk_backtrackElem_eq_zigzagVolume]
   -- the backtrack is based at the tail of the reverse dart, which is the head of `d`
-  rfl
+  simp
 
 /-- **Two arrows that are not reverse to one another multiply to zero.** Either they do not meet, in
 which case the product already vanishes in the path algebra, or they meet and the composite is a
@@ -165,7 +165,7 @@ theorem zigzagMk_ofArrow_mul_ofArrow_of_ne {d e : G.Dart} (h : e ≠ d.symm) :
   obtain ⟨⟨i, j⟩, hd⟩ := d
   obtain ⟨⟨a, b⟩, he⟩ := e
   rcases eq_or_ne b i with rfl | hbi
-  · have hne : a ≠ j := fun hab => h (by subst hab; rfl)
+  · have hne : a ≠ j := fun hab => h (SimpleGraph.Dart.ext _ _ (by simp [hab]))
     rw [← map_mul]
     exact (zigzagMk_eq_zero_iff k G).2 (quadraticZigzagIdeal_le_zigzagIdeal k G
       (ofArrow_mul_ofArrow_mem_quadraticZigzagIdeal k G he hd hne))
@@ -173,17 +173,27 @@ theorem zigzagMk_ofArrow_mul_ofArrow_of_ne {d e : G.Dart} (h : e ≠ d.symm) :
 
 /-! ### Products reaching path length three -/
 
+/-- A product of two path classes vanishes when their total path length is at least three. -/
+theorem zigzagMk_ofPath_mul_ofPath_eq_zero_of_three_le
+    (x y : Quiver.TotalPath (DoubledQuiver G))
+    (h : 3 ≤ x.2.2.length + y.2.2.length) :
+    zigzagMk k G (ofPath x * ofPath y) = 0 := by
+  obtain ⟨a, b, p⟩ := x
+  obtain ⟨c, d, q⟩ := y
+  rcases eq_or_ne d a with rfl | hda
+  · rw [ofPath_mul_ofPath_of_comp]
+    exact zigzagMk_ofPath_eq_zero_of_three_le k G _
+      (by simpa only [_root_.Quiver.Path.length_comp, Nat.add_comm] using h)
+  · rw [ofPath_mul_ofPath_of_not_composable hda, map_zero]
+
 /-- An arrow times a volume class vanishes: the composite has path length three. -/
 theorem zigzagMk_ofArrow_mul_zigzagVolume (d : G.Dart) (i : V) :
     zigzagMk k G (ofArrow (arrow G d.adj)) * zigzagVolume k G i = 0 := by
   rcases em (∃ j, G.Adj i j) with ⟨j, hj⟩ | hn
   · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G hj, ← map_mul, backtrackElem_eq_ofPath,
       ofArrow_eq_ofPath_arrowPath]
-    rcases eq_or_ne i d.fst with rfl | hne
-    · rw [ofPath_mul_ofPath_of_comp]
-      exact zigzagMk_ofPath_eq_zero_of_three_le k G _
-        (by simp [_root_.Quiver.Path.length_comp, length_backtrackPath, length_arrowPath])
-    · rw [ofPath_mul_ofPath_of_not_composable ((vertex_injective G).ne hne), map_zero]
+    exact zigzagMk_ofPath_mul_ofPath_eq_zero_of_three_le k G _ _
+      (by simp [length_backtrackPath, length_arrowPath])
   · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, mul_zero]
 
 /-- A volume class times an arrow vanishes: the composite has path length three. -/
@@ -192,11 +202,8 @@ theorem zigzagVolume_mul_zigzagMk_ofArrow (i : V) (d : G.Dart) :
   rcases em (∃ j, G.Adj i j) with ⟨j, hj⟩ | hn
   · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G hj, ← map_mul, backtrackElem_eq_ofPath,
       ofArrow_eq_ofPath_arrowPath]
-    rcases eq_or_ne d.snd i with rfl | hne
-    · rw [ofPath_mul_ofPath_of_comp]
-      exact zigzagMk_ofPath_eq_zero_of_three_le k G _
-        (by simp [_root_.Quiver.Path.length_comp, length_backtrackPath, length_arrowPath])
-    · rw [ofPath_mul_ofPath_of_not_composable ((vertex_injective G).ne hne), map_zero]
+    exact zigzagMk_ofPath_mul_ofPath_eq_zero_of_three_le k G _ _
+      (by simp [length_backtrackPath, length_arrowPath])
   · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, zero_mul]
 
 /-- Two volume classes multiply to zero: they either do not meet or compose to path length four. -/
@@ -208,11 +215,8 @@ theorem zigzagVolume_mul_zigzagVolume (i j : V) :
     · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G hl,
         zigzagVolume_eq_zigzagMk_backtrackElem k G hm, ← map_mul, backtrackElem_eq_ofPath,
         backtrackElem_eq_ofPath]
-      rcases eq_or_ne j i with rfl | hne
-      · rw [ofPath_mul_ofPath_of_comp]
-        exact zigzagMk_ofPath_eq_zero_of_three_le k G _
-          (by simp [_root_.Quiver.Path.length_comp, length_backtrackPath])
-      · rw [ofPath_mul_ofPath_of_not_composable ((vertex_injective G).ne hne), map_zero]
+      exact zigzagMk_ofPath_mul_ofPath_eq_zero_of_three_le k G _ _
+        (by simp [length_backtrackPath])
     · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn', mul_zero]
   · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, zero_mul]
 

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Multiplication.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Multiplication.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Basis
+
+/-!
+# The multiplication table of a zigzag algebra
+
+The zigzag relation quotient `TauCeti.nonisolatedZigzagQuotient` of a simple graph `G` is spanned by
+the vertex idempotents `e_i`, the oriented edges `a_d` of the darts of `G`, and the volume classes
+`x_i`; `TauCeti.zigzagBasis` shows these are a basis when no vertex is isolated. This file computes
+every product of two of them, which is what makes the algebra explicit.
+
+The table is short. The idempotents are orthogonal and act as the local units they are; an arrow is
+absorbed by the idempotent at its head on the left and by the one at its tail on the right; a volume
+class is absorbed by the idempotent at its base on either side. Two arrows multiply to a volume
+class exactly when the later factor is the reverse dart of the earlier one, since a length-two path
+survives the relations only if it returns to its source. Everything else vanishes: a product landing
+in path length at least three is killed by the long generators, and a product of two paths that do
+not meet is already zero in the path algebra.
+
+In Tau Ceti's *later-factor-first* convention the product `a_d * a_e` traverses `e` first, so it is
+nonzero exactly when `e = d.symm`, and then it is the volume class at `d.snd`, the vertex where the
+composite begins and ends.
+
+All the statements are unconditional: at an isolated vertex the volume class is the junk value `0`,
+and each identity below degenerates to a true statement about `0` there.
+
+## Main results
+
+* `TauCeti.zigzagMk_ofArrow_mul_ofArrow_symm` and `TauCeti.zigzagMk_ofArrow_mul_ofArrow_of_ne`: two
+  arrows multiply to a volume class when the second is the reverse of the first, and to zero
+  otherwise.
+* `TauCeti.zigzagMk_vertexIdempotent_mul_zigzagVolume` and its three companions: the idempotent at
+  the base of a volume class is a two-sided unit for it, and the other idempotents kill it.
+* `TauCeti.zigzagMk_ofArrow_mul_zigzagVolume`, `TauCeti.zigzagVolume_mul_zigzagMk_ofArrow` and
+  `TauCeti.zigzagVolume_mul_zigzagVolume`: every product reaching path length three vanishes.
+
+## References
+
+This is the multiplication table asked for by the first clause of Layer 2 of
+`TauCetiRoadmap/ZigzagPreprojective/README.md`. See Huerfano--Khovanov, *A category for the adjoint
+representation*, Section 3, and Ehrig--Tubbenhauer, *Algebraic properties of zigzag algebras*,
+Section 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open PathAlgebra DoubledQuiver
+
+universe u w
+
+variable (k : Type w) [CommRing k] {V : Type u} (G : SimpleGraph V) [Finite V]
+
+/-- The volume class of a vertex with no neighbour is zero: it carries no backtrack. This is the
+form of `TauCeti.zigzagVolume_eq_zero_of_isIsolated` that the case splits below produce. -/
+private theorem zigzagVolume_eq_zero_of_not_exists_adj {i : V} (h : ¬∃ j, G.Adj i j) :
+    zigzagVolume k G i = 0 :=
+  zigzagVolume_eq_zero_of_isIsolated k G fun w hw => h ⟨w, hw⟩
+
+/-! ### Products of vertex idempotents -/
+
+/-- A vertex idempotent is idempotent in the zigzag quotient. -/
+@[simp]
+theorem zigzagMk_vertexIdempotent_mul_self (i : V) :
+    zigzagMk k G (vertexIdempotent k (vertex G i)) * zigzagMk k G (vertexIdempotent k (vertex G i))
+      = zigzagMk k G (vertexIdempotent k (vertex G i)) := by
+  rw [← map_mul, vertexIdempotent_mul_self]
+
+/-- Distinct vertex idempotents are orthogonal in the zigzag quotient. -/
+@[simp]
+theorem zigzagMk_vertexIdempotent_mul_vertexIdempotent_of_ne {i j : V} (h : i ≠ j) :
+    zigzagMk k G (vertexIdempotent k (vertex G i)) * zigzagMk k G (vertexIdempotent k (vertex G j))
+      = 0 := by
+  rw [← map_mul, vertexIdempotent_mul_vertexIdempotent_of_ne ((vertex_injective G).ne h),
+    map_zero]
+
+/-! ### Products of a vertex idempotent and an arrow -/
+
+/-- The vertex idempotent at the head of a dart is a left unit for its arrow. -/
+theorem zigzagMk_vertexIdempotent_mul_ofArrow (d : G.Dart) :
+    zigzagMk k G (vertexIdempotent k (vertex G d.snd)) * zigzagMk k G (ofArrow (arrow G d.adj))
+      = zigzagMk k G (ofArrow (arrow G d.adj)) := by
+  rw [← map_mul, vertexIdempotent_mul_ofArrow]
+
+/-- A vertex idempotent away from the head of a dart kills its arrow on the left. -/
+theorem zigzagMk_vertexIdempotent_mul_ofArrow_of_ne {v : V} (d : G.Dart) (h : v ≠ d.snd) :
+    zigzagMk k G (vertexIdempotent k (vertex G v)) * zigzagMk k G (ofArrow (arrow G d.adj))
+      = 0 := by
+  rw [← map_mul, vertexIdempotent_mul_ofArrow_of_ne _ _ d.adj h, map_zero]
+
+/-- The vertex idempotent at the tail of a dart is a right unit for its arrow. -/
+theorem zigzagMk_ofArrow_mul_vertexIdempotent (d : G.Dart) :
+    zigzagMk k G (ofArrow (arrow G d.adj)) * zigzagMk k G (vertexIdempotent k (vertex G d.fst))
+      = zigzagMk k G (ofArrow (arrow G d.adj)) := by
+  rw [← map_mul, ofArrow_mul_vertexIdempotent]
+
+/-- A vertex idempotent away from the tail of a dart kills its arrow on the right. -/
+theorem zigzagMk_ofArrow_mul_vertexIdempotent_of_ne {v : V} (d : G.Dart) (h : v ≠ d.fst) :
+    zigzagMk k G (ofArrow (arrow G d.adj)) * zigzagMk k G (vertexIdempotent k (vertex G v))
+      = 0 := by
+  rw [← map_mul, ofArrow_mul_vertexIdempotent_of_ne _ _ d.adj h, map_zero]
+
+/-! ### Products of a vertex idempotent and a volume class -/
+
+/-- The vertex idempotent at the base of a volume class is a left unit for it. -/
+@[simp]
+theorem zigzagMk_vertexIdempotent_mul_zigzagVolume (i : V) :
+    zigzagMk k G (vertexIdempotent k (vertex G i)) * zigzagVolume k G i = zigzagVolume k G i := by
+  rcases em (∃ j, G.Adj i j) with ⟨j, h⟩ | hn
+  · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G h, ← map_mul, vertexIdempotent_mul_backtrackElem]
+  · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, mul_zero]
+
+/-- A vertex idempotent away from the base of a volume class kills it on the left. -/
+@[simp]
+theorem zigzagMk_vertexIdempotent_mul_zigzagVolume_of_ne {v i : V} (h : v ≠ i) :
+    zigzagMk k G (vertexIdempotent k (vertex G v)) * zigzagVolume k G i = 0 := by
+  rcases em (∃ j, G.Adj i j) with ⟨j, hj⟩ | hn
+  · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G hj, ← map_mul,
+      vertexIdempotent_mul_backtrackElem_of_ne _ _ hj h, map_zero]
+  · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, mul_zero]
+
+/-- The vertex idempotent at the base of a volume class is a right unit for it. -/
+@[simp]
+theorem zigzagVolume_mul_zigzagMk_vertexIdempotent (i : V) :
+    zigzagVolume k G i * zigzagMk k G (vertexIdempotent k (vertex G i)) = zigzagVolume k G i := by
+  rcases em (∃ j, G.Adj i j) with ⟨j, h⟩ | hn
+  · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G h, ← map_mul, backtrackElem_mul_vertexIdempotent]
+  · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, zero_mul]
+
+/-- A vertex idempotent away from the base of a volume class kills it on the right. -/
+@[simp]
+theorem zigzagVolume_mul_zigzagMk_vertexIdempotent_of_ne {v i : V} (h : v ≠ i) :
+    zigzagVolume k G i * zigzagMk k G (vertexIdempotent k (vertex G v)) = 0 := by
+  rcases em (∃ j, G.Adj i j) with ⟨j, hj⟩ | hn
+  · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G hj, ← map_mul,
+      backtrackElem_mul_vertexIdempotent_of_ne _ _ hj h, map_zero]
+  · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, zero_mul]
+
+/-! ### Products of two arrows -/
+
+/-- **Traversing a dart and returning is its volume class.** In the later-factor-first convention
+the reverse dart is traversed first, so the composite is the backtrack based at the head of `d`. -/
+theorem zigzagMk_ofArrow_mul_ofArrow_symm (d : G.Dart) :
+    zigzagMk k G (ofArrow (arrow G d.adj)) * zigzagMk k G (ofArrow (arrow G d.symm.adj))
+      = zigzagVolume k G d.snd := by
+  have key : (ofArrow (arrow G d.adj) : pathAlgebra k (DoubledQuiver G))
+      * ofArrow (arrow G d.symm.adj) = backtrackElem G k d.symm.adj :=
+    ofArrow_symm_mul_ofArrow G k d.symm.adj
+  rw [← map_mul, key, zigzagMk_backtrackElem_eq_zigzagVolume]
+  -- the backtrack is based at the tail of the reverse dart, which is the head of `d`
+  rfl
+
+/-- **Two arrows that are not reverse to one another multiply to zero.** Either they do not meet, in
+which case the product already vanishes in the path algebra, or they meet and the composite is a
+length-two path with distinct endpoints, which the zigzag relations kill. -/
+theorem zigzagMk_ofArrow_mul_ofArrow_of_ne {d e : G.Dart} (h : e ≠ d.symm) :
+    zigzagMk k G (ofArrow (arrow G d.adj)) * zigzagMk k G (ofArrow (arrow G e.adj)) = 0 := by
+  obtain ⟨⟨i, j⟩, hd⟩ := d
+  obtain ⟨⟨a, b⟩, he⟩ := e
+  rcases eq_or_ne b i with rfl | hbi
+  · have hne : a ≠ j := fun hab => h (by subst hab; rfl)
+    rw [← map_mul]
+    exact (zigzagMk_eq_zero_iff k G).2 (quadraticZigzagIdeal_le_zigzagIdeal k G
+      (ofArrow_mul_ofArrow_mem_quadraticZigzagIdeal k G he hd hne))
+  · rw [← map_mul, ofArrow_mul_ofArrow_of_ne G k he hd (Ne.symm hbi), map_zero]
+
+/-! ### Products reaching path length three -/
+
+/-- An arrow times a volume class vanishes: the composite has path length three. -/
+theorem zigzagMk_ofArrow_mul_zigzagVolume (d : G.Dart) (i : V) :
+    zigzagMk k G (ofArrow (arrow G d.adj)) * zigzagVolume k G i = 0 := by
+  rcases em (∃ j, G.Adj i j) with ⟨j, hj⟩ | hn
+  · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G hj, ← map_mul, backtrackElem_eq_ofPath,
+      ofArrow_eq_ofPath_arrowPath]
+    rcases eq_or_ne i d.fst with rfl | hne
+    · rw [ofPath_mul_ofPath_of_comp]
+      exact zigzagMk_ofPath_eq_zero_of_three_le k G _
+        (by simp [_root_.Quiver.Path.length_comp, length_backtrackPath, length_arrowPath])
+    · rw [ofPath_mul_ofPath_of_not_composable ((vertex_injective G).ne hne), map_zero]
+  · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, mul_zero]
+
+/-- A volume class times an arrow vanishes: the composite has path length three. -/
+theorem zigzagVolume_mul_zigzagMk_ofArrow (i : V) (d : G.Dart) :
+    zigzagVolume k G i * zigzagMk k G (ofArrow (arrow G d.adj)) = 0 := by
+  rcases em (∃ j, G.Adj i j) with ⟨j, hj⟩ | hn
+  · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G hj, ← map_mul, backtrackElem_eq_ofPath,
+      ofArrow_eq_ofPath_arrowPath]
+    rcases eq_or_ne d.snd i with rfl | hne
+    · rw [ofPath_mul_ofPath_of_comp]
+      exact zigzagMk_ofPath_eq_zero_of_three_le k G _
+        (by simp [_root_.Quiver.Path.length_comp, length_backtrackPath, length_arrowPath])
+    · rw [ofPath_mul_ofPath_of_not_composable ((vertex_injective G).ne hne), map_zero]
+  · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, zero_mul]
+
+/-- Two volume classes multiply to zero: they either do not meet or compose to path length four. -/
+@[simp]
+theorem zigzagVolume_mul_zigzagVolume (i j : V) :
+    zigzagVolume k G i * zigzagVolume k G j = 0 := by
+  rcases em (∃ l, G.Adj i l) with ⟨l, hl⟩ | hn
+  · rcases em (∃ m, G.Adj j m) with ⟨m, hm⟩ | hn'
+    · rw [zigzagVolume_eq_zigzagMk_backtrackElem k G hl,
+        zigzagVolume_eq_zigzagMk_backtrackElem k G hm, ← map_mul, backtrackElem_eq_ofPath,
+        backtrackElem_eq_ofPath]
+      rcases eq_or_ne j i with rfl | hne
+      · rw [ofPath_mul_ofPath_of_comp]
+        exact zigzagMk_ofPath_eq_zero_of_three_le k G _
+          (by simp [_root_.Quiver.Path.length_comp, length_backtrackPath])
+      · rw [ofPath_mul_ofPath_of_not_composable ((vertex_injective G).ne hne), map_zero]
+    · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn', mul_zero]
+  · rw [zigzagVolume_eq_zero_of_not_exists_adj k G hn, zero_mul]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Trace.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Trace.lean
@@ -15,7 +15,7 @@ public import TauCeti.RepresentationTheory.Quiver.Zigzag.Multiplication
 The zigzag algebra of a simple graph with no isolated vertex is a symmetric Frobenius algebra. This
 file constructs the trace that witnesses it: the linear functional `TauCeti.zigzagTrace` which is
 `1` on every volume class and `0` on the vertex idempotents and on the arrows, and proves that the
-pairing `(x, y) ↦ tr (x * y)` is symmetric, associative and nondegenerate.
+pairing `(x, y) ↦ tr (x * y)` is symmetric, associative and perfect.
 
 Both the symmetry and the nondegeneracy come from one computation. Write `ι` for the involution
 `TauCeti.zigzagDualIndex` of the basis indices, which exchanges the idempotent and the volume class
@@ -23,15 +23,16 @@ at a vertex and reverses a dart. The multiplication table shows that the trace o
 basis classes is `1` when the second index is `ι` of the first and `0` otherwise: the only products
 with a volume component are `e_i x_i = x_i = x_i e_i` and `a_d a_{d.symm} = x_{d.snd}`. So the Gram
 matrix of the pairing in the vertex, arrow and volume basis is the permutation matrix of `ι`.
-Symmetry is then the fact that `ι` is an involution, and nondegeneracy is the fact that `ι` is a
-bijection: pairing an element against `ι b` reads off its `b`-th coordinate, so an element
-orthogonal to everything has all coordinates zero.
+Symmetry is then the fact that `ι` is an involution. The dual-basis identity
+`TauCeti.zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex` says that pairing an element
+against `ι b` reads off its `b`-th coordinate; equivalently, the pairing is perfect over the
+commutative base ring. It also implies `TauCeti.zigzagTracePairing_nondegenerate`, where Mathlib's
+`LinearMap.BilinForm.Nondegenerate` records the weaker separating condition.
 
-That the pairing is symmetric, associative and nondegenerate is exactly the statement that the
-zigzag algebra is a symmetric Frobenius algebra; no `k` is assumed beyond a commutative ring, since
-the Gram matrix argument never inverts a scalar. What is *not* proved here is self-injectivity,
-which needs the induced isomorphism onto the dual bimodule and an injectivity criterion for modules
-over a general base.
+Thus the dual-basis identity together with symmetry and associativity gives the symmetric Frobenius
+property over an arbitrary commutative ring; the permutation Gram matrix requires no scalar to be
+inverted. What is *not* proved here is self-injectivity, which needs the induced isomorphism onto
+the dual bimodule and an injectivity criterion for modules over a general base.
 
 ## Main definitions
 
@@ -45,7 +46,7 @@ over a general base.
 * `TauCeti.zigzagTrace_mul_comm`: the trace is a trace, `tr (x * y) = tr (y * x)`.
 * `TauCeti.zigzagTracePairing_isSymm` and `TauCeti.zigzagTracePairing_nondegenerate`: the pairing is
   symmetric and nondegenerate.
-* `TauCeti.zigzagTracePairing_mul_left`: the pairing is associative, `(xy, z) = (x, yz)`.
+* `TauCeti.zigzagTracePairing_mul_assoc`: the pairing is associative, `(xy, z) = (x, yz)`.
 * `TauCeti.zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex`: the classes indexed by `ι` are
   the dual basis of the pairing.
 
@@ -104,11 +105,6 @@ theorem zigzagDualIndex_involutive : Function.Involutive (zigzagDualIndex G) :=
 theorem zigzagDualIndex_injective : Function.Injective (zigzagDualIndex G) :=
   (zigzagDualIndex_involutive G).injective
 
-/-- Naming the dual index is a symmetric relation, because it is an involution. -/
-theorem eq_zigzagDualIndex_comm {b c : ZigzagBasisIndex G} :
-    c = zigzagDualIndex G b ↔ b = zigzagDualIndex G c := by
-  constructor <;> · rintro rfl; rw [zigzagDualIndex_zigzagDualIndex]
-
 /-! ### The trace -/
 
 variable [Finite V] (hns : ∀ i : V, ∃ j, G.Adj i j)
@@ -147,18 +143,15 @@ theorem zigzagTrace_zigzagVolume (i : V) : zigzagTrace k G hns (zigzagVolume k G
 
 /-- **The Frobenius pairing of a zigzag algebra**, `(x, y) ↦ tr (x * y)`. -/
 noncomputable def zigzagTracePairing : LinearMap.BilinForm k (nonisolatedZigzagQuotient k G) :=
-  LinearMap.mk₂ k (fun x y => zigzagTrace k G hns (x * y))
-    (fun _ _ _ => by rw [add_mul, map_add]) (fun _ _ _ => by rw [smul_mul_assoc, map_smul])
-    (fun _ _ _ => by rw [mul_add, map_add]) (fun _ _ _ => by rw [mul_smul_comm, map_smul])
+  (LinearMap.mul k (nonisolatedZigzagQuotient k G)).compr₂ (zigzagTrace k G hns)
 
 @[simp]
 theorem zigzagTracePairing_apply (x y : nonisolatedZigzagQuotient k G) :
     zigzagTracePairing k G hns x y = zigzagTrace k G hns (x * y) := (rfl)
 
 /-- **The trace pairing is associative**: it is computed from the product of all three factors, so
-the bracketing is immaterial. Together with symmetry and nondegeneracy this is what makes the
-zigzag algebra a symmetric Frobenius algebra. -/
-theorem zigzagTracePairing_mul_left (x y z : nonisolatedZigzagQuotient k G) :
+the bracketing is immaterial. -/
+theorem zigzagTracePairing_mul_assoc (x y z : nonisolatedZigzagQuotient k G) :
     zigzagTracePairing k G hns (x * y) z = zigzagTracePairing k G hns x (y * z) := by
   rw [zigzagTracePairing_apply, zigzagTracePairing_apply, mul_assoc]
 
@@ -214,24 +207,20 @@ theorem zigzagTracePairing_zigzagBasisFun (b c : ZigzagBasisIndex G) :
 
 /-! ### Symmetry, the dual basis, and nondegeneracy -/
 
+/-- **The trace pairing is symmetric.** Its Gram matrix is the permutation matrix of an
+involution. -/
+theorem zigzagTracePairing_isSymm : (zigzagTracePairing k G hns).IsSymm :=
+  (LinearMap.BilinForm.isSymm_iff_basis (zigzagBasis k G hns)).2 fun b c => by
+    classical
+    rw [zigzagBasis_apply, zigzagBasis_apply, zigzagTracePairing_zigzagBasisFun,
+      zigzagTracePairing_zigzagBasisFun]
+    exact if_congr (eq_comm.trans (zigzagDualIndex_involutive G).eq_iff) rfl rfl
+
 /-- **The trace is a trace**: `tr (x * y) = tr (y * x)`. The Gram matrix of the pairing is the
 permutation matrix of an involution, hence symmetric. -/
 theorem zigzagTrace_mul_comm (x y : nonisolatedZigzagQuotient k G) :
     zigzagTrace k G hns (x * y) = zigzagTrace k G hns (y * x) := by
-  classical
-  have key : zigzagTracePairing k G hns = (zigzagTracePairing k G hns).flip := by
-    refine (zigzagBasis k G hns).ext fun b => (zigzagBasis k G hns).ext fun c => ?_
-    have hflip : (zigzagTracePairing k G hns).flip (zigzagBasis k G hns b)
-          (zigzagBasis k G hns c)
-        = zigzagTracePairing k G hns (zigzagBasis k G hns c) (zigzagBasis k G hns b) := rfl
-    rw [hflip, zigzagBasis_apply, zigzagBasis_apply, zigzagTracePairing_zigzagBasisFun,
-      zigzagTracePairing_zigzagBasisFun]
-    exact if_congr (eq_zigzagDualIndex_comm G) rfl rfl
-  exact LinearMap.congr_fun₂ key x y
-
-/-- **The trace pairing is symmetric.** -/
-theorem zigzagTracePairing_isSymm : (zigzagTracePairing k G hns).IsSymm :=
-  ⟨fun x y => zigzagTrace_mul_comm k G hns x y⟩
+  exact (zigzagTracePairing_isSymm k G hns).eq x y
 
 /-- **The dual basis of the trace pairing.** Pairing an element against the basis class of the dual
 index of `b` reads off its `b`-th coordinate. -/
@@ -240,15 +229,11 @@ theorem zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex
     zigzagTracePairing k G hns x (zigzagBasisFun k G (zigzagDualIndex G b))
       = (zigzagBasis k G hns).repr x b := by
   classical
-  have key : (zigzagTracePairing k G hns).flip (zigzagBasisFun k G (zigzagDualIndex G b))
-      = (zigzagBasis k G hns).coord b := by
+  have key : LinearMap.BilinForm.flipHom (zigzagTracePairing k G hns)
+      (zigzagBasisFun k G (zigzagDualIndex G b)) = (zigzagBasis k G hns).coord b := by
     refine (zigzagBasis k G hns).ext fun c => ?_
-    have hflip : (zigzagTracePairing k G hns).flip
-          (zigzagBasisFun k G (zigzagDualIndex G b)) (zigzagBasis k G hns c)
-        = zigzagTracePairing k G hns (zigzagBasis k G hns c)
-            (zigzagBasisFun k G (zigzagDualIndex G b)) := rfl
-    rw [hflip, Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply,
-      zigzagBasis_apply, zigzagTracePairing_zigzagBasisFun]
+    rw [LinearMap.BilinForm.flip_apply, Module.Basis.coord_apply, Module.Basis.repr_self,
+      Finsupp.single_apply, zigzagBasis_apply, zigzagTracePairing_zigzagBasisFun]
     refine if_congr ?_ rfl rfl
     rw [(zigzagDualIndex_injective G).eq_iff]
     exact eq_comm
@@ -264,8 +249,7 @@ theorem zigzagTracePairing_nondegenerate : (zigzagTracePairing k G hns).Nondegen
     refine (zigzagBasis k G hns).forall_coord_eq_zero_iff.mp fun b => ?_
     rw [Module.Basis.coord_apply, ← zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex]
     exact hx _
-  refine ⟨hleft, fun y hy => hleft y fun x => ?_⟩
-  rw [zigzagTracePairing_apply, zigzagTrace_mul_comm, ← zigzagTracePairing_apply]
-  exact hy x
+  exact (LinearMap.IsRefl.nondegenerate_iff_separatingLeft
+    (zigzagTracePairing_isSymm k G hns).isRefl).mpr hleft
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Trace.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Trace.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Algebra.Bilinear
 public import Mathlib.LinearAlgebra.BilinearForm.Properties
+public import Mathlib.LinearAlgebra.PerfectPairing.Basic
 public import TauCeti.RepresentationTheory.Quiver.Zigzag.Multiplication
 
 /-!
@@ -25,14 +26,17 @@ with a volume component are `e_i x_i = x_i = x_i e_i` and `a_d a_{d.symm} = x_{d
 matrix of the pairing in the vertex, arrow and volume basis is the permutation matrix of `ι`.
 Symmetry is then the fact that `ι` is an involution. The dual-basis identity
 `TauCeti.zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex` says that pairing an element
-against `ι b` reads off its `b`-th coordinate; equivalently, the pairing is perfect over the
-commutative base ring. It also implies `TauCeti.zigzagTracePairing_nondegenerate`, where Mathlib's
+against `ι b` reads off its `b`-th coordinate. Since `ι` is a bijection, the pairing therefore
+carries the vertex, arrow and volume basis to the dual basis reindexed along `ι`, so it is perfect
+over the commutative base ring: `TauCeti.zigzagTracePairing_isPerfPair`, whence the isomorphism
+`LinearMap.toPerfPair (TauCeti.zigzagTracePairing k G hns) : Z(G) ≃ₗ[k] Module.Dual k Z(G)` onto the
+dual. It also implies `TauCeti.zigzagTracePairing_nondegenerate`, where Mathlib's
 `LinearMap.BilinForm.Nondegenerate` records the weaker separating condition.
 
-Thus the dual-basis identity together with symmetry and associativity gives the symmetric Frobenius
-property over an arbitrary commutative ring; the permutation Gram matrix requires no scalar to be
-inverted. What is *not* proved here is self-injectivity, which needs the induced isomorphism onto
-the dual bimodule and an injectivity criterion for modules over a general base.
+Thus perfectness together with symmetry and associativity gives the symmetric Frobenius property
+over an arbitrary commutative ring; the permutation Gram matrix requires no scalar to be inverted.
+What is *not* proved here is self-injectivity, which needs that isomorphism onto the dual promoted
+to one of bimodules and an injectivity criterion for modules over a general base.
 
 ## Main definitions
 
@@ -49,6 +53,8 @@ the dual bimodule and an injectivity criterion for modules over a general base.
 * `TauCeti.zigzagTracePairing_mul_assoc`: the pairing is associative, `(xy, z) = (x, yz)`.
 * `TauCeti.zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex`: the classes indexed by `ι` are
   the dual basis of the pairing.
+* `TauCeti.zigzagTracePairing_isPerfPair`: the pairing is perfect, so `LinearMap.toPerfPair` is an
+  isomorphism of the zigzag algebra onto its `k`-linear dual.
 
 ## References
 
@@ -251,5 +257,30 @@ theorem zigzagTracePairing_nondegenerate : (zigzagTracePairing k G hns).Nondegen
     exact hx _
   exact (LinearMap.IsRefl.nondegenerate_iff_separatingLeft
     (zigzagTracePairing_isSymm k G hns).isRefl).mpr hleft
+
+/-! ### The isomorphism onto the dual -/
+
+/-- **The trace pairing is perfect.** It carries the vertex, arrow and volume basis to the dual
+basis reindexed along the involution `zigzagDualIndex`, so both of its induced maps to the dual are
+bijective; no scalar is inverted, so a commutative base ring suffices. The isomorphism onto the
+dual this gives, the packaging the Frobenius property is used through, is Mathlib's
+`LinearMap.toPerfPair (zigzagTracePairing k G hns) : _ ≃ₗ[k] Module.Dual k _`, evaluated by
+`LinearMap.toPerfPair_apply`. -/
+instance zigzagTracePairing_isPerfPair : (zigzagTracePairing k G hns).IsPerfPair := by
+  classical
+  have : Finite G.Dart := Finite.of_injective _ (SimpleGraph.Dart.toProd_injective (G := G))
+  have key : zigzagTracePairing k G hns
+      = ((zigzagBasis k G hns).equiv (zigzagBasis k G hns).dualBasis
+          (zigzagDualIndex_involutive G).toPerm).toLinearMap := by
+    refine (zigzagBasis k G hns).ext fun b => (zigzagBasis k G hns).ext fun c => ?_
+    rw [LinearEquiv.coe_coe, Module.Basis.equiv_apply, Function.Involutive.coe_toPerm,
+      Module.Basis.dualBasis_apply_self, zigzagBasis_apply, zigzagBasis_apply,
+      zigzagTracePairing_zigzagBasisFun]
+  have hbij : Function.Bijective ⇑(zigzagTracePairing k G hns) := by
+    rw [key]
+    exact LinearEquiv.bijective _
+  have hflip : LinearMap.flip (zigzagTracePairing k G hns) = zigzagTracePairing k G hns :=
+    LinearMap.ext fun x => LinearMap.ext fun y => (zigzagTracePairing_isSymm k G hns).eq y x
+  exact ⟨hbij, by rw [hflip]; exact hbij⟩
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Zigzag/Trace.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Zigzag/Trace.lean
@@ -1,0 +1,271 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Bilinear
+public import Mathlib.LinearAlgebra.BilinearForm.Properties
+public import TauCeti.RepresentationTheory.Quiver.Zigzag.Multiplication
+
+/-!
+# The symmetric Frobenius trace of a zigzag algebra
+
+The zigzag algebra of a simple graph with no isolated vertex is a symmetric Frobenius algebra. This
+file constructs the trace that witnesses it: the linear functional `TauCeti.zigzagTrace` which is
+`1` on every volume class and `0` on the vertex idempotents and on the arrows, and proves that the
+pairing `(x, y) ↦ tr (x * y)` is symmetric, associative and nondegenerate.
+
+Both the symmetry and the nondegeneracy come from one computation. Write `ι` for the involution
+`TauCeti.zigzagDualIndex` of the basis indices, which exchanges the idempotent and the volume class
+at a vertex and reverses a dart. The multiplication table shows that the trace of a product of two
+basis classes is `1` when the second index is `ι` of the first and `0` otherwise: the only products
+with a volume component are `e_i x_i = x_i = x_i e_i` and `a_d a_{d.symm} = x_{d.snd}`. So the Gram
+matrix of the pairing in the vertex, arrow and volume basis is the permutation matrix of `ι`.
+Symmetry is then the fact that `ι` is an involution, and nondegeneracy is the fact that `ι` is a
+bijection: pairing an element against `ι b` reads off its `b`-th coordinate, so an element
+orthogonal to everything has all coordinates zero.
+
+That the pairing is symmetric, associative and nondegenerate is exactly the statement that the
+zigzag algebra is a symmetric Frobenius algebra; no `k` is assumed beyond a commutative ring, since
+the Gram matrix argument never inverts a scalar. What is *not* proved here is self-injectivity,
+which needs the induced isomorphism onto the dual bimodule and an injectivity criterion for modules
+over a general base.
+
+## Main definitions
+
+* `TauCeti.zigzagDualIndex`: the involution of the basis indices pairing an idempotent with a volume
+  class and a dart with its reverse.
+* `TauCeti.zigzagTrace`: the Frobenius trace, the sum of the volume coordinates.
+* `TauCeti.zigzagTracePairing`: the bilinear form `(x, y) ↦ tr (x * y)`.
+
+## Main results
+
+* `TauCeti.zigzagTrace_mul_comm`: the trace is a trace, `tr (x * y) = tr (y * x)`.
+* `TauCeti.zigzagTracePairing_isSymm` and `TauCeti.zigzagTracePairing_nondegenerate`: the pairing is
+  symmetric and nondegenerate.
+* `TauCeti.zigzagTracePairing_mul_left`: the pairing is associative, `(xy, z) = (x, yz)`.
+* `TauCeti.zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex`: the classes indexed by `ι` are
+  the dual basis of the pairing.
+
+## References
+
+This is the third clause of Layer 2 of `TauCetiRoadmap/ZigzagPreprojective/README.md`, whose target
+signatures `zigzagTrace`, `zigzagTracePairing`, `zigzagTracePairing_isSymm` and
+`zigzagTracePairing_nondegenerate` appear in `TauCetiRoadmap/ZigzagPreprojective/Suggested.lean`.
+See Huerfano--Khovanov, *A category for the adjoint representation*, Section 3, and
+Ehrig--Tubbenhauer, *Algebraic properties of zigzag algebras*, Section 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open PathAlgebra DoubledQuiver
+
+universe u w
+
+variable (k : Type w) [CommRing k] {V : Type u} (G : SimpleGraph V)
+
+/-! ### The pairing involution of the basis indices -/
+
+/-- The involution of the zigzag basis indices under which the trace pairing is a permutation
+matrix: it exchanges the idempotent and the volume class at a vertex, and sends a dart to its
+reverse. The basis class it names is the one pairing to `1` with the given basis class. -/
+def zigzagDualIndex : ZigzagBasisIndex G → ZigzagBasisIndex G
+  | .inl i => .inr (.inr i)
+  | .inr (.inl d) => .inr (.inl d.symm)
+  | .inr (.inr i) => .inl i
+
+@[simp]
+theorem zigzagDualIndex_inl (i : V) :
+    zigzagDualIndex G (.inl i) = .inr (.inr i) := (rfl)
+
+@[simp]
+theorem zigzagDualIndex_inr_inl (d : G.Dart) :
+    zigzagDualIndex G (.inr (.inl d)) = .inr (.inl d.symm) := (rfl)
+
+@[simp]
+theorem zigzagDualIndex_inr_inr (i : V) :
+    zigzagDualIndex G (.inr (.inr i)) = .inl i := (rfl)
+
+@[simp]
+theorem zigzagDualIndex_zigzagDualIndex (b : ZigzagBasisIndex G) :
+    zigzagDualIndex G (zigzagDualIndex G b) = b := by
+  rcases b with i | d | i
+  · rfl
+  · rw [zigzagDualIndex_inr_inl, zigzagDualIndex_inr_inl, SimpleGraph.Dart.symm_symm]
+  · rfl
+
+theorem zigzagDualIndex_involutive : Function.Involutive (zigzagDualIndex G) :=
+  zigzagDualIndex_zigzagDualIndex G
+
+theorem zigzagDualIndex_injective : Function.Injective (zigzagDualIndex G) :=
+  (zigzagDualIndex_involutive G).injective
+
+/-- Naming the dual index is a symmetric relation, because it is an involution. -/
+theorem eq_zigzagDualIndex_comm {b c : ZigzagBasisIndex G} :
+    c = zigzagDualIndex G b ↔ b = zigzagDualIndex G c := by
+  constructor <;> · rintro rfl; rw [zigzagDualIndex_zigzagDualIndex]
+
+/-! ### The trace -/
+
+variable [Finite V] (hns : ∀ i : V, ∃ j, G.Adj i j)
+
+/-- **The Frobenius trace of a zigzag algebra**: the sum of the coordinates of an element in the
+volume classes. It is `1` on each volume class and `0` on the vertex idempotents and the arrows. -/
+noncomputable def zigzagTrace : nonisolatedZigzagQuotient k G →ₗ[k] k :=
+  (zigzagBasis k G hns).constr k (Sum.elim (fun _ => 0) (Sum.elim (fun _ => 0) fun _ => 1))
+
+/-- The trace on the vertex, arrow and volume basis: it is `1` on the volume block and `0` on the
+other two. -/
+theorem zigzagTrace_zigzagBasisFun (b : ZigzagBasisIndex G) :
+    zigzagTrace k G hns (zigzagBasisFun k G b)
+      = Sum.elim (fun _ => 0) (Sum.elim (fun _ => 0) fun _ => 1) b := by
+  rw [← zigzagBasis_apply k G hns b]
+  exact (zigzagBasis k G hns).constr_basis k
+    (Sum.elim (fun _ => 0) (Sum.elim (fun _ => 0) fun _ => 1)) b
+
+/-- The trace vanishes on a vertex idempotent. -/
+@[simp]
+theorem zigzagTrace_zigzagMk_vertexIdempotent (i : V) :
+    zigzagTrace k G hns (zigzagMk k G (vertexIdempotent k (vertex G i))) = 0 := by
+  simpa using zigzagTrace_zigzagBasisFun k G hns (.inl i)
+
+/-- The trace vanishes on an arrow. -/
+theorem zigzagTrace_zigzagMk_ofArrow (d : G.Dart) :
+    zigzagTrace k G hns (zigzagMk k G (ofArrow (arrow G d.adj))) = 0 := by
+  simpa using zigzagTrace_zigzagBasisFun k G hns (.inr (.inl d))
+
+/-- The trace is one on every volume class. -/
+@[simp]
+theorem zigzagTrace_zigzagVolume (i : V) : zigzagTrace k G hns (zigzagVolume k G i) = 1 := by
+  simpa using zigzagTrace_zigzagBasisFun k G hns (.inr (.inr i))
+
+/-! ### The trace pairing -/
+
+/-- **The Frobenius pairing of a zigzag algebra**, `(x, y) ↦ tr (x * y)`. -/
+noncomputable def zigzagTracePairing : LinearMap.BilinForm k (nonisolatedZigzagQuotient k G) :=
+  LinearMap.mk₂ k (fun x y => zigzagTrace k G hns (x * y))
+    (fun _ _ _ => by rw [add_mul, map_add]) (fun _ _ _ => by rw [smul_mul_assoc, map_smul])
+    (fun _ _ _ => by rw [mul_add, map_add]) (fun _ _ _ => by rw [mul_smul_comm, map_smul])
+
+@[simp]
+theorem zigzagTracePairing_apply (x y : nonisolatedZigzagQuotient k G) :
+    zigzagTracePairing k G hns x y = zigzagTrace k G hns (x * y) := (rfl)
+
+/-- **The trace pairing is associative**: it is computed from the product of all three factors, so
+the bracketing is immaterial. Together with symmetry and nondegeneracy this is what makes the
+zigzag algebra a symmetric Frobenius algebra. -/
+theorem zigzagTracePairing_mul_left (x y z : nonisolatedZigzagQuotient k G) :
+    zigzagTracePairing k G hns (x * y) z = zigzagTracePairing k G hns x (y * z) := by
+  rw [zigzagTracePairing_apply, zigzagTracePairing_apply, mul_assoc]
+
+/-! ### The Gram matrix of the pairing -/
+
+open scoped Classical in
+/-- **The Gram matrix of the trace pairing is the permutation matrix of `zigzagDualIndex`.** The
+trace of a product of two basis classes is `1` exactly when the second index is the dual of the
+first, and `0` otherwise. -/
+theorem zigzagTracePairing_zigzagBasisFun (b c : ZigzagBasisIndex G) :
+    zigzagTracePairing k G hns (zigzagBasisFun k G b) (zigzagBasisFun k G c)
+      = if c = zigzagDualIndex G b then 1 else 0 := by
+  rw [zigzagTracePairing_apply]
+  rcases b with i | d | i <;> rcases c with i' | d' | i' <;>
+    simp only [zigzagBasisFun_inl, zigzagBasisFun_inr_inl, zigzagBasisFun_inr_inr,
+      zigzagDualIndex_inl, zigzagDualIndex_inr_inl, zigzagDualIndex_inr_inr]
+  · rcases eq_or_ne i i' with rfl | h
+    · rw [zigzagMk_vertexIdempotent_mul_self, zigzagTrace_zigzagMk_vertexIdempotent]
+      simp
+    · rw [zigzagMk_vertexIdempotent_mul_vertexIdempotent_of_ne k G h, map_zero]
+      simp
+  · rcases eq_or_ne i d'.snd with rfl | h
+    · rw [zigzagMk_vertexIdempotent_mul_ofArrow, zigzagTrace_zigzagMk_ofArrow]
+      simp
+    · rw [zigzagMk_vertexIdempotent_mul_ofArrow_of_ne k G d' h, map_zero]
+      simp
+  · rcases eq_or_ne i i' with rfl | h
+    · rw [zigzagMk_vertexIdempotent_mul_zigzagVolume, zigzagTrace_zigzagVolume]
+      simp
+    · rw [zigzagMk_vertexIdempotent_mul_zigzagVolume_of_ne k G h, map_zero]
+      simp [Ne.symm h]
+  · rcases eq_or_ne i' d.fst with rfl | h
+    · rw [zigzagMk_ofArrow_mul_vertexIdempotent, zigzagTrace_zigzagMk_ofArrow]
+      simp
+    · rw [zigzagMk_ofArrow_mul_vertexIdempotent_of_ne k G d h, map_zero]
+      simp
+  · rcases eq_or_ne d' d.symm with rfl | h
+    · rw [zigzagMk_ofArrow_mul_ofArrow_symm, zigzagTrace_zigzagVolume]
+      simp
+    · rw [zigzagMk_ofArrow_mul_ofArrow_of_ne k G h, map_zero]
+      simp [h]
+  · rw [zigzagMk_ofArrow_mul_zigzagVolume, map_zero]
+    simp
+  · rcases eq_or_ne i' i with rfl | h
+    · rw [zigzagVolume_mul_zigzagMk_vertexIdempotent, zigzagTrace_zigzagVolume]
+      simp
+    · rw [zigzagVolume_mul_zigzagMk_vertexIdempotent_of_ne k G h, map_zero]
+      simp [h]
+  · rw [zigzagVolume_mul_zigzagMk_ofArrow, map_zero]
+    simp
+  · rw [zigzagVolume_mul_zigzagVolume, map_zero]
+    simp
+
+/-! ### Symmetry, the dual basis, and nondegeneracy -/
+
+/-- **The trace is a trace**: `tr (x * y) = tr (y * x)`. The Gram matrix of the pairing is the
+permutation matrix of an involution, hence symmetric. -/
+theorem zigzagTrace_mul_comm (x y : nonisolatedZigzagQuotient k G) :
+    zigzagTrace k G hns (x * y) = zigzagTrace k G hns (y * x) := by
+  classical
+  have key : zigzagTracePairing k G hns = (zigzagTracePairing k G hns).flip := by
+    refine (zigzagBasis k G hns).ext fun b => (zigzagBasis k G hns).ext fun c => ?_
+    have hflip : (zigzagTracePairing k G hns).flip (zigzagBasis k G hns b)
+          (zigzagBasis k G hns c)
+        = zigzagTracePairing k G hns (zigzagBasis k G hns c) (zigzagBasis k G hns b) := rfl
+    rw [hflip, zigzagBasis_apply, zigzagBasis_apply, zigzagTracePairing_zigzagBasisFun,
+      zigzagTracePairing_zigzagBasisFun]
+    exact if_congr (eq_zigzagDualIndex_comm G) rfl rfl
+  exact LinearMap.congr_fun₂ key x y
+
+/-- **The trace pairing is symmetric.** -/
+theorem zigzagTracePairing_isSymm : (zigzagTracePairing k G hns).IsSymm :=
+  ⟨fun x y => zigzagTrace_mul_comm k G hns x y⟩
+
+/-- **The dual basis of the trace pairing.** Pairing an element against the basis class of the dual
+index of `b` reads off its `b`-th coordinate. -/
+theorem zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex
+    (x : nonisolatedZigzagQuotient k G) (b : ZigzagBasisIndex G) :
+    zigzagTracePairing k G hns x (zigzagBasisFun k G (zigzagDualIndex G b))
+      = (zigzagBasis k G hns).repr x b := by
+  classical
+  have key : (zigzagTracePairing k G hns).flip (zigzagBasisFun k G (zigzagDualIndex G b))
+      = (zigzagBasis k G hns).coord b := by
+    refine (zigzagBasis k G hns).ext fun c => ?_
+    have hflip : (zigzagTracePairing k G hns).flip
+          (zigzagBasisFun k G (zigzagDualIndex G b)) (zigzagBasis k G hns c)
+        = zigzagTracePairing k G hns (zigzagBasis k G hns c)
+            (zigzagBasisFun k G (zigzagDualIndex G b)) := rfl
+    rw [hflip, Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply,
+      zigzagBasis_apply, zigzagTracePairing_zigzagBasisFun]
+    refine if_congr ?_ rfl rfl
+    rw [(zigzagDualIndex_injective G).eq_iff]
+    exact eq_comm
+  have hx := LinearMap.congr_fun key x
+  rw [Module.Basis.coord_apply] at hx
+  exact hx
+
+/-- **The trace pairing is nondegenerate.** Its Gram matrix is the permutation matrix of a
+bijection, so an element orthogonal to every basis class has every coordinate zero. -/
+theorem zigzagTracePairing_nondegenerate : (zigzagTracePairing k G hns).Nondegenerate := by
+  have hleft : (zigzagTracePairing k G hns).SeparatingLeft := by
+    intro x hx
+    refine (zigzagBasis k G hns).forall_coord_eq_zero_iff.mp fun b => ?_
+    rw [Module.Basis.coord_apply, ← zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex]
+    exact hx _
+  refine ⟨hleft, fun y hy => hleft y fun x => ?_⟩
+  rw [zigzagTracePairing_apply, zigzagTrace_mul_comm, ← zigzagTracePairing_apply]
+  exact hy x
+
+end TauCeti


### PR DESCRIPTION
This PR constructs the symmetric Frobenius trace of a zigzag algebra, together with the
multiplication table of its basis that the trace is computed from. It serves the third clause of
Layer 2 of `TauCetiRoadmap/ZigzagPreprojective/README.md`, which asks to "Define `tr(e_i)=0`,
`tr(a)=0`, and `tr(x_i)=1`. Prove that `tr(xy)=tr(yx)` and that `(x,y) ↦ tr(xy)` is a symmetric
nondegenerate bilinear form. Package the resulting symmetric Frobenius and self-injective algebra
structures." Everything up to and including nondegeneracy is proved here; the target signatures
`zigzagTrace`, `zigzagTracePairing`, `zigzagTracePairing_isSymm` and
`zigzagTracePairing_nondegenerate` in `TauCetiRoadmap/ZigzagPreprojective/Suggested.lean` are all
supplied, under the hypothesis that no vertex is isolated rather than connectedness plus at least
two vertices, so that the statements match the already-merged `TauCeti.zigzagBasis` of #4156 exactly.
Both new files go in `TauCeti/RepresentationTheory/Quiver/Zigzag/`, the home the roadmap's opening
section nominates for strict zigzag algebras.

The prerequisite half is `TauCeti/RepresentationTheory/Quiver/Zigzag/Multiplication.lean`, the
"complete multiplication table" of the roadmap's first Layer 2 clause. The path algebra of the
doubled quiver already knows every product of two short paths, so each entry of the table is that
product pushed through the quotient map: the vertex idempotents are orthogonal idempotents, an
arrow is absorbed by the idempotent at its head on the left and at its tail on the right, and a
volume class is absorbed by the idempotent at its base on either side. The two substantive entries
are `TauCeti.zigzagMk_ofArrow_mul_ofArrow_symm`, that traversing a dart after its reverse is the
volume class at the head — in Tau Ceti's later-factor-first convention `a_d * a_e` traces `e` first,
so the composite is the backtrack based at `d.snd` — and
`TauCeti.zigzagMk_ofArrow_mul_ofArrow_of_ne`, that two arrows which are not reverse to one another
die, because they either fail to meet, killing the product already in the path algebra, or meet in a
length-two path with distinct endpoints, which is a quadratic zigzag relator. Everything reaching
path length three vanishes by the long generators:
`TauCeti.zigzagMk_ofArrow_mul_zigzagVolume`, `TauCeti.zigzagVolume_mul_zigzagMk_ofArrow` and
`TauCeti.zigzagVolume_mul_zigzagVolume`. The entries are stated unconditionally, with no
no-isolated-vertex hypothesis: at an isolated vertex the volume class is the junk value `0` already
fixed by `TauCeti.zigzagVolume`, and each identity degenerates to a true statement about `0` there.
Only the entries whose left-hand side avoids `TauCeti.PathAlgebra.ofArrow` are tagged `@[simp]`,
following the convention of the merged `Zigzag/PathAlgebra.lean`, since `ofArrow_eq_ofPath` is
itself a simp lemma.

`TauCeti/RepresentationTheory/Quiver/Zigzag/Trace.lean` reads the Frobenius structure off that
table. `TauCeti.zigzagTrace` is defined through the universal property of the basis, as the map
sending the volume block to `1` and the other two blocks to `0`; it is the sum of the volume
coordinates, and no separate graded or filtered structure is needed to define it. The one
computation the file rests on is `TauCeti.zigzagTracePairing_zigzagBasisFun`: the Gram matrix of
`(x, y) ↦ tr (x * y)` in the vertex, arrow and volume basis is the permutation matrix of the
involution `TauCeti.zigzagDualIndex`, which exchanges the idempotent and the volume class at a
vertex and reverses a dart. That is exactly the table above read for its volume component, since
the only products with one are `e_i x_i = x_i = x_i e_i` and `a_d a_{d.symm} = x_{d.snd}`. Symmetry
of the pairing, `TauCeti.zigzagTracePairing_isSymm`, is then the fact that `zigzagDualIndex` is an
involution, and `TauCeti.zigzagTrace_mul_comm` is its element form `tr (x * y) = tr (y * x)`;
nondegeneracy, `TauCeti.zigzagTracePairing_nondegenerate`, is the fact that it is a bijection, in
the sharper form `TauCeti.zigzagTracePairing_apply_zigzagBasisFun_zigzagDualIndex` which exhibits
the dual basis: pairing an element against the class of `zigzagDualIndex b` reads off its `b`-th
coordinate. `TauCeti.zigzagTracePairing_mul_assoc` records associativity, `(xy, z) = (x, yz)`, which
is `mul_assoc`; symmetric, associative and perfect together give a symmetric Frobenius algebra.
Perfectness is `TauCeti.zigzagTracePairing_isPerfPair`, an instance of Mathlib's
`LinearMap.IsPerfPair`: the dual-basis identity says the pairing carries the vertex, arrow and
volume basis to the dual basis reindexed along `zigzagDualIndex`, so it is bijective in both slots,
and `LinearMap.toPerfPair (TauCeti.zigzagTracePairing k G hns)` is the resulting isomorphism
`Z(G) ≃ₗ[k] Hom_k(Z(G), k)`, evaluated by `LinearMap.toPerfPair_apply`; that isomorphism is how
downstream consumers use the Frobenius property, so no wrapper of it is added here. Mathlib's
`Nondegenerate`, which `TauCeti.zigzagTracePairing_nondegenerate` records, is only the weaker
separating condition, and Mathlib has no class bundling the three properties together — there is no
`FrobeniusAlgebra` anywhere in it, only the unrelated `RingTheory/Frobenius.lean` on the
characteristic-`p` endomorphism. Because the permutation-matrix argument never inverts a scalar,
all of this is proved over an arbitrary commutative ring rather than the field the roadmap's
suggested signature assumes.

What remains of that clause after this PR is its last sentence, the self-injective structure. That
needs the `k`-linear isomorphism onto the dual `Hom_k(Z(G), k)` proved here promoted to one of
`Z(G)`-bimodules, and an injectivity criterion for the dual of a module over a general base, neither
of which is in this repository or in Mathlib; it is left to its own PR rather than doubled onto this one. Layer 2
then still needs the radical filtration, socle and top of the first clause, the centre of the
fourth, and the skew-parameter versions of the fifth. No Mathlib infrastructure is vendored.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"zigzagtrace"}-->

🤖 Prepared with Claude Code

