### PR TITLE
refactor(HeckeRing): move the Δ₀(N) positivity lemma out of the Γ₁(N) file

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Basic.lean
@@ -44,6 +44,9 @@ The Γ₀ pair corresponds to the AINTLIB
 * `HeckeRing.GL2.Gamma0Image_le_Delta0`: `Γ₀(N) ≤ Δ₀(N)`.
 * `HeckeRing.GL2.Delta0_le_commensurator_Gamma0Image`: `Δ₀(N)` lies in the commensurator of
   `Γ₀(N)`.
+* `HeckeRing.GL2.out_mem_glpos_of_delta0`: the chosen representative of a double coset of
+  `Δ₀(N)` has positive determinant, for *any* pair of flanking subgroups — the positivity
+  hypothesis every level's Hecke operators carry.
 * the `IsHeckeTriple (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))`
   instance, stated in the unfolded spelling that the modular-form side uses.
 
@@ -97,6 +100,21 @@ entry divisible by `N` and upper-left entry a unit because `ad ≡ 1`. -/
 lemma mapGL_mem_Delta0 (γ : Gamma0 N) :
     (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ) ∈ Delta0 N :=
   Gamma0Image_le_Delta0 N ((mem_Gamma0Image_iff N).mpr ⟨(γ : SL(2, ℤ)), γ.2, rfl⟩)
+
+/-- The chosen representative of a double coset of `Δ₀(N)` has positive determinant, whatever the
+two flanking subgroups: `Δ₀(N)` consists of integral matrices of positive determinant. This is the
+positivity hypothesis the Hecke operators on modular forms of level `N` carry, discharged once for
+this semigroup.
+
+Nothing here mentions `Γ₀(N)`: the lemma is about `Δ₀(N)` and is generic in both flanks. It sits
+in this file because this is the earliest point where `Δ₀(N)` and the double-coset API are both in
+scope, so every level — `Γ₀(N)`, `Γ₁(N)`, and any other flank — reaches it without importing a
+sibling level's file. It is stated above the `[NeZero N]` variable deliberately: the proof never
+needs `N` to be nonzero. -/
+lemma out_mem_glpos_of_delta0 {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
+    (D : HeckeCoset (Delta0 N) Γ₁ Γ₂) :
+    (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ :=
+  posDetInt_le_glpos 2 (Delta0_le_posDetInt N D.out.2)
 
 variable [NeZero N]
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/Basic.lean
@@ -42,8 +42,6 @@ Chris Birkbeck).
 
 * `HeckeRing.GL2.Gamma1Image_le_Gamma0Image`: `Γ₁(N) ≤ Γ₀(N)` in `GL₂(ℚ)`.
 * `HeckeRing.GL2.Gamma1Image_le_Delta0`: `Γ₁(N) ≤ Δ₀(N)`, the special case of the Γ₀ result.
-* `HeckeRing.GL2.out_mem_glpos_of_delta0`: the chosen representative of a double coset of
-  `Δ₀(N)` has positive determinant.
 * `HeckeRing.GL2.Delta0_le_commensurator_Gamma1Image`: `Δ₀(N)` lies in the commensurator
   of `Γ₁(N)`.
 * the `IsHeckeTriple (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))`
@@ -85,15 +83,6 @@ lemma Gamma1Image_le_Gamma0Image : Gamma1Image N ≤ Gamma0Image N := by
 `Γ₁(N) ≤ Γ₀(N)`. -/
 lemma Gamma1Image_le_Delta0 : (Gamma1Image N).toSubmonoid ≤ Delta0 N :=
   fun _ hg ↦ Gamma0Image_le_Delta0 N (Gamma1Image_le_Gamma0Image N hg)
-
-/-- The chosen representative of a double coset of `Δ₀(N)` has positive determinant, whatever the
-two flanking subgroups: `Δ₀(N)` consists of integral matrices of positive determinant. This is the
-positivity hypothesis the Hecke operators on modular forms of level `N` carry, discharged once for
-this semigroup. -/
-lemma out_mem_glpos_of_delta0 {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
-    (D : HeckeCoset (Delta0 N) Γ₁ Γ₂) :
-    (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ :=
-  posDetInt_le_glpos 2 (Delta0_le_posDetInt N D.out.2)
 
 variable [NeZero N]
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Gamma1.lean
@@ -19,7 +19,8 @@ discharges, once, the two side conditions the general construction carries.
 
 The Hecke triple itself is `HeckeRing/GL2/Gamma1.lean`'s instance, and the finiteness of the
 right-coset index follows from it. What is left is the positivity hypothesis, and that is
-`out_mem_glpos_of_delta0` from the same file: every element of `Δ₀(N)` has positive determinant
+`out_mem_glpos_of_delta0` from `HeckeRing/GL2/Gamma0/Basic.lean`, where it is stated for an
+arbitrary pair of flanks rather than for `Γ₁(N)`: every element of `Δ₀(N)` has positive determinant
 by definition, so no double coset of this triple ever fails it.
 
 The operators belong to the double coset itself, not to the representatives `heckeSlashSum` sums


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"delta0-glpos-placement"}-->

`out_mem_glpos_of_delta0` is stated for an arbitrary pair of flanking subgroups:

```lean
lemma out_mem_glpos_of_delta0 {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
    (D : HeckeCoset (Delta0 N) Γ₁ Γ₂) :
    (D.out : GL (Fin 2) ℚ) ∈ Matrix.GLPos (Fin 2) ℚ
```

Nothing in it mentions `Γ₁(N)`. It says that a chosen double-coset representative of `Δ₀(N)` has
positive determinant, and it is proved from `Delta0_le_posDetInt` alone. But it lives in
`HeckeRing/GL2/Gamma1/Basic.lean`, and `Gamma1/Basic.lean` **imports** `Gamma0/Basic.lean` — so
the dependency runs Γ₁ → Γ₀, and any consumer at a level other than `Γ₁(N)` has to import the
`Γ₁(N)` file to reach a fact that has nothing to do with `Γ₁(N)`.

This moves it to `HeckeRing/GL2/Gamma0/Basic.lean`, the earliest point where `Δ₀(N)` and the
double-coset API are both in scope. Statement and proof are byte-identical; only the file changes.

## No consumer has to move

All four call sites are in `HeckeSlash/Gamma1.lean` and are untouched — same name, same
`HeckeRing.GL2` namespace, and `Gamma1/Basic.lean` still imports `Gamma0/Basic.lean`, so the name
remains in scope exactly where it was. The only edits outside the two `Basic.lean` files are to
prose that the move falsifies: `HeckeSlash/Gamma1.lean`'s module docstring said the lemma came
"from the same file".

## The `[NeZero N]` trap, and how it was checked

`Gamma0/Basic.lean` has a `variable [NeZero N]` partway down. Placing the lemma below it would
have silently given it an `[NeZero N]` instance argument that its proof never uses — a quiet
generality regression, and one that reads identically in the source.

It is placed above that line, and the result was verified by elaborating the real signature from
a separate module rather than by reading the file:

```
out_mem_glpos_of_delta0 : ∀ (N : ℕ) {Γ₁ Γ₂ : Subgroup (GL (Fin 2) ℚ)}
  (D : HeckeCoset (Delta0 N) Γ₁ Γ₂), ↑(Quotient.out D) ∈ Matrix.GLPos (Fin 2) ℚ
```

No `NeZero`, identical to the pre-move signature. The docstring records why the position matters,
so a later edit does not undo it.

## Why not `Delta0.lean`

That was the first candidate, since the lemma is about `Δ₀(N)` and its proof is one step from
`Delta0_le_posDetInt`, which lives there. Rejected: `Delta0.lean` does not see `HeckeCoset`, so
hosting the lemma would add a `HeckeRing/Basic` import to a more foundational file purely to state
one lemma. `Gamma0/Basic.lean` already has the double-coset API in scope — it carries the
`IsHeckeTriple (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))` instance — so it
absorbs the lemma with no import change at all.

## What this unblocks

`HeckeSlash/Gamma1.lean` builds the Hecke operators on `M_k(Γ₁(N))` and `S_k(Γ₁(N))` from this
positivity hypothesis. The `Γ₀(N)` counterparts — `heckeSlashGamma0ModularFormEnd` and
`heckeSlashGamma0CuspFormEnd` — do not exist yet (0 files on `main`; the `Γ₁` analogues match 4
files, which is the positive control on that query), and the Γ₀ Hecke triple instance they need is
already on `main` at `Gamma0/Basic.lean`. Writing them today would mean a `HeckeSlash/Gamma0.lean`
importing `Gamma1/Basic.lean` for the positivity lemma, which is the wrong direction. This PR is
that prerequisite, shipped separately per AGENTS.md's "one topic per PR — ship a prerequisite
refactor as its own PR".

## Scope

Pure relocation of an existing declaration, which AGENTS.md places in scope with no roadmap entry
required: *"relocating a misplaced declaration ... are all welcome at any time"*. The
`Roadmap: ModularForms` line above is attribution — the roadmap chiefly motivating the move —
not a claim of new mathematics. No declaration is added, removed, renamed, generalised or
weakened, and no proof changes.
