### PR TITLE
feat: the pure Hodge structure on a complex graded piece

### DIFF
--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -230,6 +230,18 @@ theorem latticeConj_rationalToComplexLinearEquiv_one_tmul (hℚ : IsBaseChange �
   | add x y hx hy =>
       simpa only [TensorProduct.tmul_add, map_add] using congrArg₂ (fun a b ↦ a + b) hx hy
 
+/-- Lattice conjugation of the image in `Vℂ` of a pure tensor `z ⊗ₜ x` with `x` rational
+conjugates the scalar. -/
+theorem latticeConj_rationalToComplexLinearEquiv_tmul (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) (z : ℂ) (x : Vℚ) :
+    latticeConj hℂ (rationalToComplexLinearEquiv hℚ hℂ (z ⊗ₜ[ℚ] x)) =
+      rationalToComplexLinearEquiv hℚ hℂ ((starRingEnd ℂ) z ⊗ₜ[ℚ] x) := by
+  have hz : ∀ w : ℂ, w ⊗ₜ[ℚ] x = w • (1 : ℂ) ⊗ₜ[ℚ] x := by
+    intro w
+    rw [TensorProduct.smul_tmul', smul_eq_mul, mul_one]
+  rw [hz z, hz ((starRingEnd ℂ) z), map_smul, map_smulₛₗ, map_smul,
+    latticeConj_rationalToComplexLinearEquiv_one_tmul]
+
 /-- The complexification of a rational subspace is stable under lattice-induced conjugation. -/
 @[simp]
 theorem rationalToComplexSubmodule_conj (hℚ : IsBaseChange ℚ ιℚ)
@@ -248,6 +260,14 @@ theorem rationalToComplexSubmodule_conj (hℚ : IsBaseChange ℚ ιℚ)
   intro x hx
   refine ⟨latticeConj hℂ x, hle ⟨x, hx, rfl⟩, ?_⟩
   simp
+
+/-- Elementwise form of the stability of a complexified rational subspace under lattice-induced
+conjugation. -/
+theorem latticeConj_mem_rationalToComplexSubmodule (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) (W : Submodule ℚ Vℚ) {x : Vℂ}
+    (hx : x ∈ rationalToComplexSubmodule hℚ hℂ W) :
+    latticeConj hℂ x ∈ rationalToComplexSubmodule hℚ hℂ W :=
+  (rationalToComplexSubmodule_conj hℚ hℂ W).le ⟨x, hx, rfl⟩
 
 section Map
 

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -261,14 +261,6 @@ theorem rationalToComplexSubmodule_conj (hℚ : IsBaseChange ℚ ιℚ)
   refine ⟨latticeConj hℂ x, hle ⟨x, hx, rfl⟩, ?_⟩
   simp
 
-/-- Elementwise form of the stability of a complexified rational subspace under lattice-induced
-conjugation. -/
-theorem latticeConj_mem_rationalToComplexSubmodule (hℚ : IsBaseChange ℚ ιℚ)
-    (hℂ : IsBaseChange ℂ ιℂ) (W : Submodule ℚ Vℚ) {x : Vℂ}
-    (hx : x ∈ rationalToComplexSubmodule hℚ hℂ W) :
-    latticeConj hℂ x ∈ rationalToComplexSubmodule hℚ hℂ W :=
-  (rationalToComplexSubmodule_conj hℚ hℂ W).le ⟨x, hx, rfl⟩
-
 section Map
 
 variable {V'ℤ : Type u'} {V'ℚ : Type v'} {V'ℂ : Type w'}

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Module.Submodule.Map
 public import Mathlib.Data.Complex.Basic
+public import Mathlib.LinearAlgebra.Quotient.Basic
 public import Mathlib.LinearAlgebra.TensorProduct.Map
 public import Mathlib.RingTheory.IsTensorProduct
 
@@ -28,6 +29,10 @@ complexification models.
 * `TauCeti.Hodge.latticeConj_unique`: uniqueness among conjugate-linear maps fixing the integral
   module.
 * `TauCeti.Hodge.Conjugation.restrict`: the conjugation induced on a stable complex subspace.
+* `TauCeti.Hodge.Conjugation.quotient`: the conjugation induced on the quotient by a stable
+  complex subspace.
+* `TauCeti.Hodge.Conjugation.map_comap_eq_comap_map`: an equivalence intertwining two conjugations
+  exchanges conjugation with taking preimages of subspaces.
 * `TauCeti.Hodge.latticeConjugation`: the abstract map bundled as a `Conjugation`.
 * `TauCeti.Hodge.integralMapToComplex`: complexification of an integral linear map between abstract
   complexification models.
@@ -78,18 +83,16 @@ theorem map_map_eq_self (ω : Conjugation W) (U : Submodule ℂ W) :
     (Submodule.map_symm_eq_iff ω.toEquiv).2 rfl
   simpa only [ω.toEquiv_symm] using h
 
-/-- A conjugation restricted to a stable complex subspace is involutive. -/
-private theorem restrict_involutive (ω : Conjugation W) {U : Submodule ℂ W}
-    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) :
-    Function.Involutive (ω.toEquiv.toLinearMap.restrict hU) := fun x ↦ by
-  ext
-  simp
+/-- The conjugation induced on a complex subspace stable under a given conjugation.
 
-/-- The conjugation induced on a complex subspace stable under a given conjugation. -/
+It is `@[expose]`d so that a conjugation built from it — such as the one induced on a graded
+piece of a filtration — remains definitionally the ambient one on representatives. -/
+@[expose]
 noncomputable def restrict (ω : Conjugation W) {U : Submodule ℂ W}
     (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) : Conjugation U where
-  toEquiv := LinearEquiv.ofInvolutive _ (ω.restrict_involutive hU)
-  involutive := ω.restrict_involutive hU
+  toEquiv := LinearEquiv.ofInvolutive (ω.toEquiv.toLinearMap.restrict hU)
+    fun x ↦ Subtype.ext (ω.apply_apply (x : W))
+  involutive x := Subtype.ext (ω.apply_apply (x : W))
 
 /-- A restricted conjugation acts as the ambient one. -/
 @[simp]
@@ -108,6 +111,44 @@ theorem map_restrict_comap_subtype (ω : Conjugation W) {U : Submodule ℂ W}
       (A.map ω.toEquiv.toLinearMap).comap U.subtype := by
   ext x
   simp
+
+/-- A linear equivalence intertwining two conjugations exchanges conjugating a preimage with
+taking the preimage of the conjugate. -/
+theorem map_comap_eq_comap_map {W' : Type v} [AddCommGroup W'] [Module ℂ W']
+    (ω : Conjugation W) (ω' : Conjugation W') (e : W ≃ₗ[ℂ] W')
+    (he : ∀ x, e (ω.toEquiv x) = ω'.toEquiv (e x)) (A : Submodule ℂ W') :
+    (A.comap e.toLinearMap).map ω.toEquiv.toLinearMap =
+      (A.map ω'.toEquiv.toLinearMap).comap e.toLinearMap := by
+  ext y
+  simp only [Submodule.mem_map, Submodule.mem_comap, LinearEquiv.coe_coe]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨e x, hx, (he x).symm⟩
+  · rintro ⟨z, hz, hzy⟩
+    refine ⟨ω.toEquiv y, ?_, ω.apply_apply y⟩
+    rw [he y, ← hzy, ω'.apply_apply]
+    exact hz
+
+/-- The conjugation induced on the quotient of a complex vector space by a stable subspace.
+
+It is `@[expose]`d for the same reason as `TauCeti.Hodge.Conjugation.restrict`: a conjugation
+assembled from it must still compute on classes of representatives. -/
+@[expose]
+noncomputable def quotient (ω : Conjugation W) {U : Submodule ℂ W}
+    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) : Conjugation (W ⧸ U) where
+  toEquiv := LinearEquiv.ofInvolutive (U.mapQ U ω.toEquiv.toLinearMap fun x hx ↦ hU x hx)
+    fun x ↦ Submodule.Quotient.induction_on _ x fun y ↦
+      congrArg Submodule.Quotient.mk (ω.apply_apply y)
+  involutive x := Submodule.Quotient.induction_on _ x fun y ↦
+    congrArg Submodule.Quotient.mk (ω.apply_apply y)
+
+/-- The induced conjugation on a quotient acts on classes through the ambient conjugation. -/
+@[simp]
+theorem quotient_toEquiv_mk (ω : Conjugation W) {U : Submodule ℂ W}
+    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) (x : W) :
+    (ω.quotient hU).toEquiv (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (ω.toEquiv x) :=
+  (rfl)
 
 end Conjugation
 

--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -83,16 +83,18 @@ theorem map_map_eq_self (ω : Conjugation W) (U : Submodule ℂ W) :
     (Submodule.map_symm_eq_iff ω.toEquiv).2 rfl
   simpa only [ω.toEquiv_symm] using h
 
-/-- The conjugation induced on a complex subspace stable under a given conjugation.
+/-- A conjugation restricted to a stable complex subspace is involutive. -/
+private theorem restrict_involutive (ω : Conjugation W) {U : Submodule ℂ W}
+    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) :
+    Function.Involutive (ω.toEquiv.toLinearMap.restrict hU) := fun x ↦ by
+  ext
+  simp
 
-It is `@[expose]`d so that a conjugation built from it — such as the one induced on a graded
-piece of a filtration — remains definitionally the ambient one on representatives. -/
-@[expose]
+/-- The conjugation induced on a complex subspace stable under a given conjugation. -/
 noncomputable def restrict (ω : Conjugation W) {U : Submodule ℂ W}
     (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) : Conjugation U where
-  toEquiv := LinearEquiv.ofInvolutive (ω.toEquiv.toLinearMap.restrict hU)
-    fun x ↦ Subtype.ext (ω.apply_apply (x : W))
-  involutive x := Subtype.ext (ω.apply_apply (x : W))
+  toEquiv := LinearEquiv.ofInvolutive _ (ω.restrict_involutive hU)
+  involutive := ω.restrict_involutive hU
 
 /-- A restricted conjugation acts as the ambient one. -/
 @[simp]
@@ -129,18 +131,18 @@ theorem map_comap_eq_comap_map {W' : Type v} [AddCommGroup W'] [Module ℂ W']
     rw [he y, ← hzy, ω'.apply_apply]
     exact hz
 
-/-- The conjugation induced on the quotient of a complex vector space by a stable subspace.
+/-- The conjugation induced on a quotient by a stable complex subspace is involutive. -/
+private theorem quotient_involutive (ω : Conjugation W) {U : Submodule ℂ W}
+    (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) :
+    Function.Involutive (U.mapQ U ω.toEquiv.toLinearMap fun x hx ↦ hU x hx) := fun x ↦
+  Submodule.Quotient.induction_on _ x fun y ↦
+    congrArg Submodule.Quotient.mk (ω.apply_apply y)
 
-It is `@[expose]`d for the same reason as `TauCeti.Hodge.Conjugation.restrict`: a conjugation
-assembled from it must still compute on classes of representatives. -/
-@[expose]
+/-- The conjugation induced on the quotient of a complex vector space by a stable subspace. -/
 noncomputable def quotient (ω : Conjugation W) {U : Submodule ℂ W}
     (hU : ∀ x ∈ U, ω.toEquiv x ∈ U) : Conjugation (W ⧸ U) where
-  toEquiv := LinearEquiv.ofInvolutive (U.mapQ U ω.toEquiv.toLinearMap fun x hx ↦ hU x hx)
-    fun x ↦ Submodule.Quotient.induction_on _ x fun y ↦
-      congrArg Submodule.Quotient.mk (ω.apply_apply y)
-  involutive x := Submodule.Quotient.induction_on _ x fun y ↦
-    congrArg Submodule.Quotient.mk (ω.apply_apply y)
+  toEquiv := LinearEquiv.ofInvolutive _ (ω.quotient_involutive hU)
+  involutive := ω.quotient_involutive hU
 
 /-- The induced conjugation on a quotient acts on classes through the ambient conjugation. -/
 @[simp]

--- a/TauCeti/Geometry/Hodge/Graded.lean
+++ b/TauCeti/Geometry/Hodge/Graded.lean
@@ -35,8 +35,9 @@ quotient, and the Hodge filtration is transported across that identification.
 * `TauCeti.Hodge.complexGradedF`, `TauCeti.Hodge.gradedF`: the Hodge filtration induced on the
   complex graded piece and on the complexified rational graded piece.
 * `TauCeti.Hodge.complexGradedConjugation`, `TauCeti.Hodge.gradedComplexConjugation`: the
-  conjugation induced on a complex graded piece by a conjugation stabilising the filtration, and
-  its instance for a complexified rational filtration and lattice conjugation.
+  conjugation induced on a complex graded piece by a conjugation stabilising the two filtration
+  steps it is built from, and its instance for a complexified rational filtration and lattice
+  conjugation.
 * `TauCeti.Hodge.gradedComplexEquiv_latticeConj`: the comparison of the two graded models
   intertwines those conjugations.
 * `TauCeti.Hodge.gradedEquivOfEqBotOfEqTop`: across a step where the weight filtration jumps from
@@ -346,27 +347,34 @@ theorem gradedF_of_eq_bot (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange �
 
 section GradedConjugation
 
-variable (WC : ℤ → Submodule ℂ Vℂ) (ω : Conjugation Vℂ)
-  (hWC : ∀ j, ∀ x ∈ WC j, ω.toEquiv x ∈ WC j)
+variable (WC : ℤ → Submodule ℂ Vℂ) (ω : Conjugation Vℂ) (k : ℤ)
 
 /-- The conjugation induced on the `k`-th complex graded piece by a conjugation of the ambient
-space that stabilises every step of the filtration. -/
-noncomputable def complexGradedConjugation (k : ℤ) :
+space that stabilises the two steps `WC k` and `WC (k - 1)` the piece is built from. -/
+noncomputable def complexGradedConjugation (hk : ∀ x ∈ WC k, ω.toEquiv x ∈ WC k)
+    (hk₁ : ∀ x ∈ WC (k - 1), ω.toEquiv x ∈ WC (k - 1)) :
     Conjugation (weightGradedComplex WC k) :=
-  (ω.restrict (hWC k)).quotient fun x hx ↦ hWC (k - 1) (x : Vℂ) hx
+  (ω.restrict hk).quotient fun x hx ↦ by
+    simpa only [Submodule.submoduleOf, Submodule.mem_comap, Submodule.subtype_apply,
+      Conjugation.restrict_toEquiv_apply] using hk₁ (x : Vℂ) hx
 
 /-- The induced conjugation on a complex graded piece acts on classes through the ambient
 conjugation. -/
 @[simp]
-theorem complexGradedConjugation_mk (k : ℤ) (x : WC k) :
-    (complexGradedConjugation WC ω hWC k).toEquiv (Submodule.Quotient.mk x) =
-      Submodule.Quotient.mk ⟨ω.toEquiv (x : Vℂ), hWC k (x : Vℂ) x.2⟩ :=
-  (rfl)
+theorem complexGradedConjugation_mk (hk : ∀ x ∈ WC k, ω.toEquiv x ∈ WC k)
+    (hk₁ : ∀ x ∈ WC (k - 1), ω.toEquiv x ∈ WC (k - 1)) (x : WC k) :
+    (complexGradedConjugation WC ω k hk hk₁).toEquiv (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk ⟨ω.toEquiv (x : Vℂ), hk (x : Vℂ) x.2⟩ := by
+  rw [complexGradedConjugation, Conjugation.quotient_toEquiv_mk]
+  exact congrArg Submodule.Quotient.mk (Subtype.ext (ω.restrict_toEquiv_apply hk x))
 
 /-- Conjugating the filtration induced on a complex graded piece is inducing the conjugate
 filtration. -/
-theorem map_complexGradedConjugation_complexGradedF (F : ℤ → Submodule ℂ Vℂ) (k p : ℤ) :
-    (complexGradedF WC F k p).map (complexGradedConjugation WC ω hWC k).toEquiv.toLinearMap =
+theorem map_complexGradedConjugation_complexGradedF
+    (hk : ∀ x ∈ WC k, ω.toEquiv x ∈ WC k)
+    (hk₁ : ∀ x ∈ WC (k - 1), ω.toEquiv x ∈ WC (k - 1)) (F : ℤ → Submodule ℂ Vℂ) (p : ℤ) :
+    (complexGradedF WC F k p).map
+        (complexGradedConjugation WC ω k hk hk₁).toEquiv.toLinearMap =
       complexGradedF WC (fun q ↦ (F q).map ω.toEquiv.toLinearMap) k p := by
   refine le_antisymm ?_ ?_
   · rw [Submodule.map_le_iff_le_comap]
@@ -379,7 +387,7 @@ theorem map_complexGradedConjugation_complexGradedF (F : ℤ → Submodule ℂ V
     obtain ⟨y, hy, rfl⟩ :=
       (mem_complexGradedF_iff WC (fun q ↦ (F q).map ω.toEquiv.toLinearMap) k p u).1 hu
     obtain ⟨w, hw, hwy⟩ := hy
-    refine ⟨Submodule.Quotient.mk ⟨ω.toEquiv (y : Vℂ), hWC k (y : Vℂ) y.2⟩, ?_, ?_⟩
+    refine ⟨Submodule.Quotient.mk ⟨ω.toEquiv (y : Vℂ), hk (y : Vℂ) y.2⟩, ?_, ?_⟩
     · simp only [SetLike.mem_coe, mem_complexGradedF_iff]
       refine ⟨_, ?_, rfl⟩
       simpa only [← hwy, LinearEquiv.coe_coe, ω.apply_apply, SetLike.mem_coe] using hw
@@ -397,10 +405,14 @@ filtration by lattice conjugation. Every step of the filtration is the complexif
 rational subspace, hence conjugation-stable. -/
 noncomputable def gradedComplexConjugation (k : ℤ) :
     Conjugation (weightGradedComplex (fun j ↦ rationalToComplexSubmodule hℚ hℂ (WQ j)) k) :=
-  complexGradedConjugation _ (latticeConjugation hℂ)
-    (fun j _ hx ↦ by
+  complexGradedConjugation (fun j ↦ rationalToComplexSubmodule hℚ hℂ (WQ j))
+    (latticeConjugation hℂ) k
+    (fun x hx ↦ by
       simpa only [latticeConjugation_toEquiv_apply] using
-        latticeConj_mem_rationalToComplexSubmodule hℚ hℂ (WQ j) hx) k
+        (rationalToComplexSubmodule_conj hℚ hℂ (WQ k)).le ⟨x, hx, rfl⟩)
+    (fun x hx ↦ by
+      simpa only [latticeConjugation_toEquiv_apply] using
+        (rationalToComplexSubmodule_conj hℚ hℂ (WQ (k - 1))).le ⟨x, hx, rfl⟩)
 
 /-- The induced conjugation on the graded piece of a complexified rational filtration acts on a
 class through lattice conjugation of a representative. -/
@@ -409,7 +421,7 @@ theorem gradedComplexConjugation_mk (k : ℤ)
     (x : rationalToComplexSubmodule hℚ hℂ (WQ k)) :
     (gradedComplexConjugation hℚ hℂ WQ k).toEquiv (Submodule.Quotient.mk x) =
       Submodule.Quotient.mk ⟨latticeConj hℂ (x : Vℂ),
-        latticeConj_mem_rationalToComplexSubmodule hℚ hℂ (WQ k) x.2⟩ := by
+        (rationalToComplexSubmodule_conj hℚ hℂ (WQ k)).le ⟨x, x.2, rfl⟩⟩ := by
   rw [gradedComplexConjugation, complexGradedConjugation_mk]
   exact congrArg Submodule.Quotient.mk (Subtype.ext (latticeConjugation_toEquiv_apply hℂ _))
 
@@ -458,15 +470,6 @@ theorem gradedComplexEquiv_symm_latticeConj (hWQ : Monotone WQ) (k : ℤ)
   apply (gradedComplexEquiv hℚ hℂ WQ hWQ k).injective
   rw [LinearEquiv.apply_symm_apply, latticeConjugation_toEquiv_apply,
     gradedComplexEquiv_latticeConj hℚ hℂ WQ hWQ k, LinearEquiv.apply_symm_apply]
-
-/-- The filtration `TauCeti.Hodge.gradedF` transported back to the complex graded piece is the
-filtration `TauCeti.Hodge.complexGradedF` it was transported from. -/
-theorem comap_symm_gradedF (hWQ : Monotone WQ) (F : ℤ → Submodule ℂ Vℂ) (k p : ℤ) :
-    (gradedF hℚ hℂ WQ hWQ F k p).comap (gradedComplexEquiv hℚ hℂ WQ hWQ k).symm.toLinearMap =
-      complexGradedF (fun j ↦ rationalToComplexSubmodule hℚ hℂ (WQ j)) F k p := by
-  rw [gradedF]
-  ext y
-  simp
 
 end RationalGradedConjugation
 

--- a/TauCeti/Geometry/Hodge/Graded.lean
+++ b/TauCeti/Geometry/Hodge/Graded.lean
@@ -34,6 +34,11 @@ quotient, and the Hodge filtration is transported across that identification.
   functoriality and the naturality of `TauCeti.Hodge.gradedComplexEquiv` in that map.
 * `TauCeti.Hodge.complexGradedF`, `TauCeti.Hodge.gradedF`: the Hodge filtration induced on the
   complex graded piece and on the complexified rational graded piece.
+* `TauCeti.Hodge.complexGradedConjugation`, `TauCeti.Hodge.gradedComplexConjugation`: the
+  conjugation induced on a complex graded piece by a conjugation stabilising the filtration, and
+  its instance for a complexified rational filtration and lattice conjugation.
+* `TauCeti.Hodge.gradedComplexEquiv_latticeConj`: the comparison of the two graded models
+  intertwines those conjugations.
 * `TauCeti.Hodge.gradedEquivOfEqBotOfEqTop`: across a step where the weight filtration jumps from
   zero to everything, the complexified graded piece is the whole complex model, compatibly with
   the conjugations and with the induced filtration.
@@ -338,6 +343,132 @@ theorem gradedF_of_eq_bot (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange �
     (hp : F p = ⊥) : gradedF hℚ hℂ WQ hWQ F k p = ⊥ := by
   rw [gradedF, complexGradedF_of_eq_bot _ F hp, Submodule.comap_bot, LinearMap.ker_eq_bot]
   exact (gradedComplexEquiv hℚ hℂ WQ hWQ k).injective
+
+section GradedConjugation
+
+variable (WC : ℤ → Submodule ℂ Vℂ) (ω : Conjugation Vℂ)
+  (hWC : ∀ j, ∀ x ∈ WC j, ω.toEquiv x ∈ WC j)
+
+/-- The conjugation induced on the `k`-th complex graded piece by a conjugation of the ambient
+space that stabilises every step of the filtration. -/
+noncomputable def complexGradedConjugation (k : ℤ) :
+    Conjugation (weightGradedComplex WC k) :=
+  (ω.restrict (hWC k)).quotient fun x hx ↦ hWC (k - 1) (x : Vℂ) hx
+
+/-- The induced conjugation on a complex graded piece acts on classes through the ambient
+conjugation. -/
+@[simp]
+theorem complexGradedConjugation_mk (k : ℤ) (x : WC k) :
+    (complexGradedConjugation WC ω hWC k).toEquiv (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk ⟨ω.toEquiv (x : Vℂ), hWC k (x : Vℂ) x.2⟩ :=
+  (rfl)
+
+/-- Conjugating the filtration induced on a complex graded piece is inducing the conjugate
+filtration. -/
+theorem map_complexGradedConjugation_complexGradedF (F : ℤ → Submodule ℂ Vℂ) (k p : ℤ) :
+    (complexGradedF WC F k p).map (complexGradedConjugation WC ω hWC k).toEquiv.toLinearMap =
+      complexGradedF WC (fun q ↦ (F q).map ω.toEquiv.toLinearMap) k p := by
+  refine le_antisymm ?_ ?_
+  · rw [Submodule.map_le_iff_le_comap]
+    intro u hu
+    obtain ⟨z, hz, rfl⟩ := (mem_complexGradedF_iff WC F k p u).1 hu
+    rw [Submodule.mem_comap, LinearEquiv.coe_coe, complexGradedConjugation_mk,
+      mem_complexGradedF_iff]
+    exact ⟨_, ⟨z, hz, rfl⟩, rfl⟩
+  · intro u hu
+    obtain ⟨y, hy, rfl⟩ :=
+      (mem_complexGradedF_iff WC (fun q ↦ (F q).map ω.toEquiv.toLinearMap) k p u).1 hu
+    obtain ⟨w, hw, hwy⟩ := hy
+    refine ⟨Submodule.Quotient.mk ⟨ω.toEquiv (y : Vℂ), hWC k (y : Vℂ) y.2⟩, ?_, ?_⟩
+    · simp only [SetLike.mem_coe, mem_complexGradedF_iff]
+      refine ⟨_, ?_, rfl⟩
+      simpa only [← hwy, LinearEquiv.coe_coe, ω.apply_apply, SetLike.mem_coe] using hw
+    · rw [LinearEquiv.coe_coe, complexGradedConjugation_mk]
+      exact congrArg Submodule.Quotient.mk (Subtype.ext (ω.apply_apply (y : Vℂ)))
+
+end GradedConjugation
+
+section RationalGradedConjugation
+
+variable (hℚ : IsBaseChange ℚ ιℚ) (hℂ : IsBaseChange ℂ ιℂ) (WQ : ℤ → Submodule ℚ Vℚ)
+
+/-- The conjugation induced on the `k`-th graded piece of a complexified rational weight
+filtration by lattice conjugation. Every step of the filtration is the complexification of a
+rational subspace, hence conjugation-stable. -/
+noncomputable def gradedComplexConjugation (k : ℤ) :
+    Conjugation (weightGradedComplex (fun j ↦ rationalToComplexSubmodule hℚ hℂ (WQ j)) k) :=
+  complexGradedConjugation _ (latticeConjugation hℂ)
+    (fun j _ hx ↦ by
+      simpa only [latticeConjugation_toEquiv_apply] using
+        latticeConj_mem_rationalToComplexSubmodule hℚ hℂ (WQ j) hx) k
+
+/-- The induced conjugation on the graded piece of a complexified rational filtration acts on a
+class through lattice conjugation of a representative. -/
+@[simp]
+theorem gradedComplexConjugation_mk (k : ℤ)
+    (x : rationalToComplexSubmodule hℚ hℂ (WQ k)) :
+    (gradedComplexConjugation hℚ hℂ WQ k).toEquiv (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk ⟨latticeConj hℂ (x : Vℂ),
+        latticeConj_mem_rationalToComplexSubmodule hℚ hℂ (WQ k) x.2⟩ := by
+  rw [gradedComplexConjugation, complexGradedConjugation_mk]
+  exact congrArg Submodule.Quotient.mk (Subtype.ext (latticeConjugation_toEquiv_apply hℂ _))
+
+/-- Conjugating the filtration induced on the graded piece of a complexified rational filtration
+is inducing the conjugate filtration. -/
+theorem map_gradedComplexConjugation_complexGradedF (F : ℤ → Submodule ℂ Vℂ) (k p : ℤ) :
+    (complexGradedF (fun j ↦ rationalToComplexSubmodule hℚ hℂ (WQ j)) F k p).map
+        (gradedComplexConjugation hℚ hℂ WQ k).toEquiv.toLinearMap =
+      complexGradedF (fun j ↦ rationalToComplexSubmodule hℚ hℂ (WQ j))
+        (fun q ↦ (F q).map (latticeConj hℂ)) k p := by
+  rw [gradedComplexConjugation, map_complexGradedConjugation_complexGradedF]
+  simp only [latticeConjugation_toLinearMap]
+
+/-- **The comparison `TauCeti.Hodge.gradedComplexEquiv` intertwines the conjugations**: the
+canonical conjugation of the complexified rational graded piece corresponds to the conjugation
+that lattice conjugation induces on the complex graded piece.
+
+This is what makes the pure Hodge structure carried by `ℂ ⊗[ℚ] grᵂ_k` transportable to the
+complex graded piece `(W_k)_ℂ / (W_{k-1})_ℂ`, where the Hodge filtration of a mixed Hodge
+structure lives. -/
+theorem gradedComplexEquiv_latticeConj (hWQ : Monotone WQ) (k : ℤ)
+    (x : ℂ ⊗[ℚ] weightGradedRat WQ k) :
+    gradedComplexEquiv hℚ hℂ WQ hWQ k
+        (latticeConj (isBaseChange_ratTensorMap ℂ (weightGradedRat WQ k)) x) =
+      (gradedComplexConjugation hℚ hℂ WQ k).toEquiv (gradedComplexEquiv hℚ hℂ WQ hWQ k x) := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul z y =>
+      induction y using Submodule.Quotient.induction_on with
+      | _ y =>
+        rw [latticeConj_ratTensorMap_tmul, gradedComplexEquiv_tmul_mk, gradedComplexEquiv_tmul_mk,
+          gradedComplexConjugation, complexGradedConjugation_mk]
+        refine congrArg Submodule.Quotient.mk (Subtype.ext ?_)
+        simp only [coe_rationalToComplexSubmoduleEquiv, LinearMap.baseChange_tmul,
+          Submodule.subtype_apply, latticeConjugation_toEquiv_apply]
+        rw [latticeConj_rationalToComplexLinearEquiv_tmul]
+  | add x y hx hy => simp only [map_add, hx, hy]
+
+/-- The inverse of the comparison intertwines the conjugations, in the form in which transport of
+a pure Hodge structure onto the complex graded piece consumes it. -/
+theorem gradedComplexEquiv_symm_latticeConj (hWQ : Monotone WQ) (k : ℤ)
+    (y : weightGradedComplex (fun j ↦ rationalToComplexSubmodule hℚ hℂ (WQ j)) k) :
+    (gradedComplexEquiv hℚ hℂ WQ hWQ k).symm ((gradedComplexConjugation hℚ hℂ WQ k).toEquiv y) =
+      (latticeConjugation (isBaseChange_ratTensorMap ℂ (weightGradedRat WQ k))).toEquiv
+        ((gradedComplexEquiv hℚ hℂ WQ hWQ k).symm y) := by
+  apply (gradedComplexEquiv hℚ hℂ WQ hWQ k).injective
+  rw [LinearEquiv.apply_symm_apply, latticeConjugation_toEquiv_apply,
+    gradedComplexEquiv_latticeConj hℚ hℂ WQ hWQ k, LinearEquiv.apply_symm_apply]
+
+/-- The filtration `TauCeti.Hodge.gradedF` transported back to the complex graded piece is the
+filtration `TauCeti.Hodge.complexGradedF` it was transported from. -/
+theorem comap_symm_gradedF (hWQ : Monotone WQ) (F : ℤ → Submodule ℂ Vℂ) (k p : ℤ) :
+    (gradedF hℚ hℂ WQ hWQ F k p).comap (gradedComplexEquiv hℚ hℂ WQ hWQ k).symm.toLinearMap =
+      complexGradedF (fun j ↦ rationalToComplexSubmodule hℚ hℂ (WQ j)) F k p := by
+  rw [gradedF]
+  ext y
+  simp
+
+end RationalGradedConjugation
 
 section Concentrated
 

--- a/TauCeti/Geometry/Hodge/Mixed/Basic.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Basic.lean
@@ -95,8 +95,12 @@ namespace MixedHodgeStructure
 
 variable {hℚ : IsBaseChange ℚ ιℚ} {hℂ : IsBaseChange ℂ ιℂ} (mhs : MixedHodgeStructure hℚ hℂ)
 
-/-- The complexified weight filtration of a mixed Hodge structure. -/
-noncomputable def WC (k : ℤ) : Submodule ℂ Vℂ :=
+/-- The complexified weight filtration of a mixed Hodge structure.
+
+It is an `abbrev` because it is a name for the complexification of `WQ` rather than a new
+construction: the graded pieces of `WC` have to be *definitionally* those of the complexified
+rational filtration for the pure structure on a graded piece to transport onto them. -/
+noncomputable abbrev WC (k : ℤ) : Submodule ℂ Vℂ :=
   rationalToComplexSubmodule hℚ hℂ (mhs.WQ k)
 
 /-- The complex weight filtration is obtained by complexifying the rational weight filtration. -/

--- a/TauCeti/Geometry/Hodge/Mixed/Graded.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Graded.lean
@@ -65,12 +65,6 @@ namespace MixedHodgeStructure
 
 variable (mhs : MixedHodgeStructure hℚ hℂ)
 
-/-- Lattice conjugation preserves every step of the complexified weight filtration, since each
-step is the complexification of a rational subspace. -/
-theorem latticeConj_mem_WC (k : ℤ) {x : Vℂ} (hx : x ∈ mhs.WC k) :
-    latticeConj hℂ x ∈ mhs.WC k :=
-  latticeConj_mem_rationalToComplexSubmodule hℚ hℂ (mhs.WQ k) hx
-
 /-- The conjugation induced by lattice conjugation on the `k`-th graded piece of the complexified
 weight filtration. -/
 noncomputable def gradedConjugation (k : ℤ) : Conjugation (weightGradedComplex mhs.WC k) :=
@@ -80,7 +74,8 @@ noncomputable def gradedConjugation (k : ℤ) : Conjugation (weightGradedComplex
 @[simp]
 theorem gradedConjugation_mk (k : ℤ) (x : mhs.WC k) :
     (mhs.gradedConjugation k).toEquiv (Submodule.Quotient.mk x) =
-      Submodule.Quotient.mk ⟨latticeConj hℂ (x : Vℂ), mhs.latticeConj_mem_WC k x.2⟩ :=
+      Submodule.Quotient.mk ⟨latticeConj hℂ (x : Vℂ),
+        (rationalToComplexSubmodule_conj hℚ hℂ (mhs.WQ k)).le ⟨x, x.2, rfl⟩⟩ :=
   gradedComplexConjugation_mk hℚ hℂ mhs.WQ k x
 
 /-- The comparison of the rational and complex models of the `k`-th graded piece intertwines the
@@ -119,7 +114,8 @@ graded piece, on the nose. -/
 theorem complexGradedHodgeStructure_F (k p : ℤ) :
     (mhs.complexGradedHodgeStructure k).F p = complexGradedF mhs.WC mhs.F k p := by
   rw [complexGradedHodgeStructure, HodgeStructureOn.comap_F, gradedHodgeStructure_F]
-  exact comap_symm_gradedF hℚ hℂ mhs.WQ mhs.WQ_monotone mhs.F k p
+  ext y
+  simp
 
 /-- The conjugate filtration of the graded pure structure is the filtration induced by the
 conjugate of `F`. -/

--- a/TauCeti/Geometry/Hodge/Mixed/Graded.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Graded.lean
@@ -1,0 +1,216 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Hodge.Mixed.Basic
+
+/-!
+# The pure Hodge structure on a complex graded piece
+
+The purity axiom of a mixed Hodge structure is imposed on the *rational* graded pieces: the
+complexification `ℂ ⊗[ℚ] grᵂ_k` of `grᵂ_k = W_k / W_{k-1}` carries a pure Hodge structure of
+weight `k`. The mixed theory itself, however, runs inside the complex model: Deligne's bigrading
+`I^{p,q}` is built from the Hodge filtration `F`, its conjugate, and the complexified weight
+filtration `WC`, and its elements are compared with the Hodge components of
+`WC_k / WC_{k-1}`. This file moves the pure structure from the first model to the second.
+
+The transport is the identification `TauCeti.Hodge.gradedComplexEquiv`, and what makes it
+legitimate is that this identification intertwines the two conjugations
+(`TauCeti.Hodge.gradedComplexEquiv_latticeConj`): the canonical conjugation of a complexified
+rational space on the left, and on the right the conjugation that lattice conjugation induces on
+the complex graded piece, each step of `WC` being the complexification of a rational subspace and
+therefore conjugation-stable.
+
+## Main declarations
+
+* `TauCeti.Hodge.MixedHodgeStructure.gradedConjugation`: the conjugation induced by lattice
+  conjugation on the `k`-th complex graded piece.
+* `TauCeti.Hodge.MixedHodgeStructure.complexGradedHodgeStructure`: the pure Hodge structure of
+  weight `k` carried by `WC_k / WC_{k-1}`, with its filtration
+  `TauCeti.Hodge.complexGradedF` and its Hodge components computed.
+* `TauCeti.Hodge.MixedHodgeStructure.isInternal_complexGradedHodgeStructure_piece`: the Hodge
+  decomposition of a complex graded piece.
+* `TauCeti.Hodge.MixedHodgeStructure.mk_mem_complexGradedHodgeStructure_piece`: a vector of `W_k`
+  that lies in `F^p` and lies in `conj F^{k-p}` modulo `W_{k-1}` has its class in the Hodge
+  component `H^{p,k-p}` of the graded piece. This is the form in which the pieces of Deligne's
+  bigrading meet the graded Hodge structure, and
+  `TauCeti.Hodge.MixedHodgeStructure.mem_complexGradedHodgeStructure_piece_iff` shows the
+  criterion is exact.
+
+## References
+
+The graded-piece comparison and the bidegree bookkeeping follow Peters–Steenbrink, *Mixed Hodge
+Structures*, Ch. 3, and Deligne, *Théorie de Hodge II*, §1.2.1 and 1.2.10.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+open scoped TensorProduct
+
+universe u v w
+
+variable {Vℤ : Type u} {Vℚ : Type v} {Vℂ : Type w}
+variable [AddCommGroup Vℤ]
+variable [AddCommGroup Vℚ] [Module ℚ Vℚ]
+variable [AddCommGroup Vℂ] [Module ℂ Vℂ]
+variable {ιℚ : Vℤ →ₗ[ℤ] Vℚ} {ιℂ : Vℤ →ₗ[ℤ] Vℂ}
+variable {hℚ : IsBaseChange ℚ ιℚ} {hℂ : IsBaseChange ℂ ιℂ}
+
+namespace MixedHodgeStructure
+
+variable (mhs : MixedHodgeStructure hℚ hℂ)
+
+/-- Lattice conjugation preserves every step of the complexified weight filtration, since each
+step is the complexification of a rational subspace. -/
+theorem latticeConj_mem_WC (k : ℤ) {x : Vℂ} (hx : x ∈ mhs.WC k) :
+    latticeConj hℂ x ∈ mhs.WC k :=
+  latticeConj_mem_rationalToComplexSubmodule hℚ hℂ (mhs.WQ k) hx
+
+/-- The conjugation induced by lattice conjugation on the `k`-th graded piece of the complexified
+weight filtration. -/
+noncomputable def gradedConjugation (k : ℤ) : Conjugation (weightGradedComplex mhs.WC k) :=
+  gradedComplexConjugation hℚ hℂ mhs.WQ k
+
+/-- The induced conjugation acts on a class through lattice conjugation of a representative. -/
+@[simp]
+theorem gradedConjugation_mk (k : ℤ) (x : mhs.WC k) :
+    (mhs.gradedConjugation k).toEquiv (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk ⟨latticeConj hℂ (x : Vℂ), mhs.latticeConj_mem_WC k x.2⟩ :=
+  gradedComplexConjugation_mk hℚ hℂ mhs.WQ k x
+
+/-- The comparison of the rational and complex models of the `k`-th graded piece intertwines the
+canonical conjugation of the former with the induced conjugation of the latter. -/
+theorem gradedComplexEquiv_gradedConjugation (k : ℤ)
+    (x : ℂ ⊗[ℚ] weightGradedRat mhs.WQ k) :
+    gradedComplexEquiv hℚ hℂ mhs.WQ mhs.WQ_monotone k
+        (latticeConj (isBaseChange_ratTensorMap ℂ (weightGradedRat mhs.WQ k)) x) =
+      (mhs.gradedConjugation k).toEquiv
+        (gradedComplexEquiv hℚ hℂ mhs.WQ mhs.WQ_monotone k x) :=
+  gradedComplexEquiv_latticeConj hℚ hℂ mhs.WQ mhs.WQ_monotone k x
+
+/-- The inverse comparison intertwines the conjugations, in the form the transport of a Hodge
+structure consumes. -/
+theorem gradedComplexEquiv_symm_gradedConjugation (k : ℤ)
+    (y : weightGradedComplex mhs.WC k) :
+    (gradedComplexEquiv hℚ hℂ mhs.WQ mhs.WQ_monotone k).symm
+        ((mhs.gradedConjugation k).toEquiv y) =
+      (latticeConjugation (isBaseChange_ratTensorMap ℂ (weightGradedRat mhs.WQ k))).toEquiv
+        ((gradedComplexEquiv hℚ hℂ mhs.WQ mhs.WQ_monotone k).symm y) :=
+  gradedComplexEquiv_symm_latticeConj hℚ hℂ mhs.WQ mhs.WQ_monotone k y
+
+/-- **The `k`-th complex graded piece of a mixed Hodge structure is a pure Hodge structure of
+weight `k`.** Its conjugation is the one lattice conjugation induces on `WC_k / WC_{k-1}`, and its
+filtration is the one the Hodge filtration induces there; purity is transported from the rational
+graded piece along `TauCeti.Hodge.gradedComplexEquiv`, which is legitimate because that
+identification intertwines the conjugations. -/
+noncomputable def complexGradedHodgeStructure (k : ℤ) :
+    HodgeStructureOn (weightGradedComplex mhs.WC k) (mhs.gradedConjugation k) k :=
+  HodgeStructureOn.comap (gradedComplexEquiv hℚ hℂ mhs.WQ mhs.WQ_monotone k).symm
+    (mhs.gradedComplexEquiv_symm_gradedConjugation k) (mhs.gradedHodgeStructure k)
+
+/-- The filtration of the graded pure structure is the filtration induced by `F` on the complex
+graded piece, on the nose. -/
+@[simp]
+theorem complexGradedHodgeStructure_F (k p : ℤ) :
+    (mhs.complexGradedHodgeStructure k).F p = complexGradedF mhs.WC mhs.F k p := by
+  rw [complexGradedHodgeStructure, HodgeStructureOn.comap_F, gradedHodgeStructure_F]
+  exact comap_symm_gradedF hℚ hℂ mhs.WQ mhs.WQ_monotone mhs.F k p
+
+/-- The conjugate filtration of the graded pure structure is the filtration induced by the
+conjugate of `F`. -/
+@[simp]
+theorem complexGradedHodgeStructure_conjF (k p : ℤ) :
+    (mhs.complexGradedHodgeStructure k).conjF p =
+      complexGradedF mhs.WC (fun q ↦ (mhs.F q).map (latticeConj hℂ)) k p := by
+  rw [HodgeStructureOn.conjF_def, complexGradedHodgeStructure_F, gradedConjugation]
+  exact map_gradedComplexConjugation_complexGradedF hℚ hℂ mhs.WQ mhs.F k p
+
+/-- The Hodge components of the graded pure structure, spelled out in terms of the Hodge
+filtration and its conjugate. -/
+theorem complexGradedHodgeStructure_piece (k p : ℤ) :
+    (mhs.complexGradedHodgeStructure k).piece p =
+      complexGradedF mhs.WC mhs.F k p ⊓
+        complexGradedF mhs.WC (fun q ↦ (mhs.F q).map (latticeConj hℂ)) k (k - p) := by
+  rw [HodgeStructureOn.piece_def, complexGradedHodgeStructure_F,
+    complexGradedHodgeStructure_conjF]
+
+/-- The comparison of the two models of a graded piece carries Hodge components to Hodge
+components. -/
+theorem map_gradedHodgeStructure_piece (k p : ℤ) :
+    ((mhs.gradedHodgeStructure k).piece p).map
+        (gradedComplexEquiv hℚ hℂ mhs.WQ mhs.WQ_monotone k).toLinearMap =
+      (mhs.complexGradedHodgeStructure k).piece p := by
+  rw [complexGradedHodgeStructure, HodgeStructureOn.comap_piece,
+    Submodule.comap_equiv_eq_map_symm, LinearEquiv.symm_symm]
+
+/-- **The Hodge decomposition of a complex graded piece**: the Hodge components of
+`WC_k / WC_{k-1}` are an internal direct sum. -/
+theorem isInternal_complexGradedHodgeStructure_piece (k : ℤ) :
+    DirectSum.IsInternal (mhs.complexGradedHodgeStructure k).piece :=
+  HodgeStructureOn.isInternal_piece _
+
+/-- **A representative criterion for the Hodge components of a complex graded piece.** A vector of
+`W_k` that lies in `F^p`, and that lies in the conjugate `conj F^{k-p}` modulo `W_{k-1}`, has its
+class in the Hodge component `H^{p,k-p}` of the graded piece.
+
+The second hypothesis is weaker than membership of `conj F^{k-p}`, and the weakening is what makes
+the criterion usable: in the mixed theory the conjugation relations hold only modulo lower steps
+of the weight filtration, which is exactly the shape in which the pieces of Deligne's bigrading
+`I^{p,q}` present themselves. -/
+theorem mk_mem_complexGradedHodgeStructure_piece (k p : ℤ) (y : mhs.WC k)
+    (hF : (y : Vℂ) ∈ mhs.F p)
+    (hconj : (y : Vℂ) ∈ (mhs.F (k - p)).map (latticeConj hℂ) ⊔ mhs.WC (k - 1)) :
+    Submodule.Quotient.mk y ∈ (mhs.complexGradedHodgeStructure k).piece p := by
+  rw [complexGradedHodgeStructure_piece]
+  refine ⟨(mem_complexGradedF_iff mhs.WC mhs.F k p _).2 ⟨y, hF, rfl⟩, ?_⟩
+  obtain ⟨a, ha, b, hb, hab⟩ := Submodule.mem_sup.1 hconj
+  have hbk : b ∈ mhs.WC k := mhs.WC_monotone (by omega) hb
+  have hak : a ∈ mhs.WC k := by
+    have hay : a = (y : Vℂ) - b := eq_sub_of_add_eq hab
+    rw [hay]
+    exact Submodule.sub_mem _ y.2 hbk
+  refine (mem_complexGradedF_iff mhs.WC _ k (k - p) _).2 ⟨⟨a, hak⟩, ha, ?_⟩
+  refine (Submodule.Quotient.eq _).2 ?_
+  have hay : a - (y : Vℂ) = -b := by rw [← hab]; abel
+  have hsub : a - (y : Vℂ) ∈ mhs.WC (k - 1) := by
+    rw [hay]
+    exact Submodule.neg_mem _ hb
+  exact hsub
+
+/-- **The Hodge components of a complex graded piece, by representatives.** A class lies in the
+component `H^{p,k-p}` exactly when it has a representative in `W_k` that lies in `F^p` and lies in
+`conj F^{k-p}` modulo `W_{k-1}`.
+
+The forward direction is what turns a statement about the graded piece back into one about
+representatives in `W_k`; the backward direction is
+`TauCeti.Hodge.MixedHodgeStructure.mk_mem_complexGradedHodgeStructure_piece`. -/
+theorem mem_complexGradedHodgeStructure_piece_iff (k p : ℤ)
+    (u : weightGradedComplex mhs.WC k) :
+    u ∈ (mhs.complexGradedHodgeStructure k).piece p ↔
+      ∃ y : mhs.WC k, (y : Vℂ) ∈ mhs.F p ∧
+        (y : Vℂ) ∈ (mhs.F (k - p)).map (latticeConj hℂ) ⊔ mhs.WC (k - 1) ∧
+        Submodule.Quotient.mk y = u := by
+  constructor
+  · intro hu
+    rw [complexGradedHodgeStructure_piece] at hu
+    obtain ⟨y₁, hy₁, hy₁u⟩ := (mem_complexGradedF_iff mhs.WC mhs.F k p u).1 hu.1
+    obtain ⟨y₂, hy₂, hy₂u⟩ :=
+      (mem_complexGradedF_iff mhs.WC _ k (k - p) u).1 hu.2
+    refine ⟨y₁, hy₁, ?_, hy₁u⟩
+    have hdiff : (y₁ : Vℂ) - (y₂ : Vℂ) ∈ mhs.WC (k - 1) :=
+      (Submodule.Quotient.eq ((mhs.WC (k - 1)).submoduleOf (mhs.WC k))).1
+        (hy₁u.trans hy₂u.symm)
+    have hsplit : (y₁ : Vℂ) = (y₂ : Vℂ) + ((y₁ : Vℂ) - (y₂ : Vℂ)) := by abel
+    rw [hsplit]
+    exact Submodule.add_mem_sup hy₂ hdiff
+  · rintro ⟨y, hF, hconj, rfl⟩
+    exact mhs.mk_mem_complexGradedHodgeStructure_piece k p y hF hconj
+
+end MixedHodgeStructure
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Structure.lean
+++ b/TauCeti/Geometry/Hodge/Structure.lean
@@ -40,7 +40,8 @@ Buzzard, and Joël Riou.
 * `TauCeti.Hodge.HodgeStructureOn.finite_setOf_piece_ne_bot`: only finitely many Hodge components
   are nonzero, because the filtration is bounded.
 * `TauCeti.Hodge.HodgeStructureOn.comap`: transport of a Hodge structure along a linear
-  equivalence intertwining the conjugations.
+  equivalence intertwining the conjugations, with the transport of its Hodge components
+  `TauCeti.Hodge.HodgeStructureOn.comap_piece`.
 * `TauCeti.Hodge.HodgeStructureOn.IsEffective`: the filtration is supported in bidegrees with
   both indices nonnegative.
 -/
@@ -256,18 +257,7 @@ noncomputable def comap (e : W ≃ₗ[ℂ] W')
     obtain ⟨p, hp⟩ := hs.F_top
     exact ⟨p, by rw [hp, Submodule.comap_top]⟩
   opposed p := by
-    have hmap : ((hs.F (n + 1 - p)).comap e.toLinearMap).map ω.toEquiv.toLinearMap =
-        ((hs.F (n + 1 - p)).map ω'.toEquiv.toLinearMap).comap e.toLinearMap := by
-      ext y
-      simp only [Submodule.mem_map, Submodule.mem_comap, LinearEquiv.coe_coe]
-      constructor
-      · rintro ⟨x, hx, rfl⟩
-        exact ⟨e x, hx, (he x).symm⟩
-      · rintro ⟨z, hz, hzy⟩
-        refine ⟨ω.toEquiv y, ?_, ω.apply_apply y⟩
-        rw [he y, ← hzy, ω'.apply_apply]
-        exact hz
-    rw [hmap]
+    rw [Conjugation.map_comap_eq_comap_map ω ω' e he]
     refine ⟨?_, ?_⟩
     · rw [disjoint_iff, ← Submodule.comap_inf, (hs.opposed p).disjoint.eq_bot,
         Submodule.comap_bot, LinearMap.ker_eq_bot]
@@ -281,6 +271,18 @@ noncomputable def comap (e : W ≃ₗ[ℂ] W')
 theorem comap_F (e : W ≃ₗ[ℂ] W') (he : ∀ x, e (ω.toEquiv x) = ω'.toEquiv (e x))
     (hs : HodgeStructureOn W' ω' n) (p : ℤ) :
     (hs.comap e he).F p = (hs.F p).comap e.toLinearMap := (rfl)
+
+@[simp]
+theorem comap_conjF (e : W ≃ₗ[ℂ] W') (he : ∀ x, e (ω.toEquiv x) = ω'.toEquiv (e x))
+    (hs : HodgeStructureOn W' ω' n) (p : ℤ) :
+    (hs.comap e he).conjF p = (hs.conjF p).comap e.toLinearMap := by
+  rw [conjF_def, comap_F, Conjugation.map_comap_eq_comap_map ω ω' e he, conjF_def]
+
+@[simp]
+theorem comap_piece (e : W ≃ₗ[ℂ] W') (he : ∀ x, e (ω.toEquiv x) = ω'.toEquiv (e x))
+    (hs : HodgeStructureOn W' ω' n) (p : ℤ) :
+    (hs.comap e he).piece p = (hs.piece p).comap e.toLinearMap := by
+  rw [piece_def, comap_F, comap_conjF, piece_def, Submodule.comap_inf]
 
 end Comap
 

--- a/TauCeti/Geometry/Hodge/Structure.lean
+++ b/TauCeti/Geometry/Hodge/Structure.lean
@@ -272,12 +272,16 @@ theorem comap_F (e : W ≃ₗ[ℂ] W') (he : ∀ x, e (ω.toEquiv x) = ω'.toEqu
     (hs : HodgeStructureOn W' ω' n) (p : ℤ) :
     (hs.comap e he).F p = (hs.F p).comap e.toLinearMap := (rfl)
 
+/-- Transport along an equivalence intertwining the conjugations takes the conjugate filtration
+to the preimage of the conjugate filtration. -/
 @[simp]
 theorem comap_conjF (e : W ≃ₗ[ℂ] W') (he : ∀ x, e (ω.toEquiv x) = ω'.toEquiv (e x))
     (hs : HodgeStructureOn W' ω' n) (p : ℤ) :
     (hs.comap e he).conjF p = (hs.conjF p).comap e.toLinearMap := by
   rw [conjF_def, comap_F, Conjugation.map_comap_eq_comap_map ω ω' e he, conjF_def]
 
+/-- Transport along an equivalence intertwining the conjugations takes each Hodge component to
+the preimage of the corresponding Hodge component. -/
 @[simp]
 theorem comap_piece (e : W ≃ₗ[ℂ] W') (he : ∀ x, e (ω.toEquiv x) = ω'.toEquiv (e x))
     (hs : HodgeStructureOn W' ω' n) (p : ℤ) :


### PR DESCRIPTION
This PR moves the pure Hodge structure of a mixed Hodge structure's graded piece from the rational model to the complex one: it proves that `TauCeti.Hodge.gradedComplexEquiv` intertwines the canonical conjugation of `ℂ ⊗[ℚ] grᵂ_k` with the conjugation lattice conjugation induces on `WC_k / WC_{k-1}`, and uses that to build `MixedHodgeStructure.complexGradedHodgeStructure`, a `HodgeStructureOn (weightGradedComplex mhs.WC k) _ k` whose filtration is `complexGradedF` on the nose. It serves layer **L2 — Mixed Hodge structures; strictness (Deligne)** of the `HodgeStructures` roadmap, the only milestone of that roadmap still open (L0's `isInternal_piece`, L1's `exists_isCompl_of_isPolarizable` and L3's `finsum_hodgeNumber_eq_finrank` are already on `main`).

L2's discharge runs through Deligne's bigrading `I^{p,q}`, and the first step of the induction that establishes `DirectSum.IsInternal` for it is that the image of `I^{p,q}` in `grᵂ_{p+q}` lies in the `(p,q)` Hodge component of that graded piece. That step could not be stated before this PR. The purity axiom of `MixedHodgeStructure` is imposed rationally — the Hodge structure lives on `ℂ ⊗[ℚ] grᵂ_k`, chosen because a complexified rational space carries a conjugation for free — whereas `I^{p,q}` is a submodule of `Vℂ` built from `F`, `conj F` and `WC`, so its image lands in the *complex* graded piece `WC_k / WC_{k-1}`. Nothing said that the complex graded piece carries a Hodge structure at all: the only conjugation comparison available was `gradedEquivOfEqBotOfEqTop_latticeConj`, for the degenerate step where the weight filtration jumps straight from zero to everything. The general comparison is what this PR supplies, and the transported structure is what the induction is stated against.

The new file `TauCeti/Geometry/Hodge/Mixed/Graded.lean` (218 lines) adds, on `TauCeti.Hodge.MixedHodgeStructure`:

- `latticeConj_mem_WC` and `gradedConjugation`, the conjugation induced on `WC_k / WC_{k-1}`, with `gradedConjugation_mk` computing it on classes;
- `gradedComplexEquiv_gradedConjugation` and its inverse form, the intertwining statement in the shape transport consumes;
- `complexGradedHodgeStructure`, the pure Hodge structure of weight `k` on the complex graded piece, with `complexGradedHodgeStructure_F`, `…_conjF`, `…_piece` and `map_gradedHodgeStructure_piece` identifying its filtration, conjugate filtration and Hodge components, and `isInternal_complexGradedHodgeStructure_piece` its Hodge decomposition;
- `mk_mem_complexGradedHodgeStructure_piece` and `mem_complexGradedHodgeStructure_piece_iff`: a class lies in `H^{p,k-p}` exactly when it has a representative in `W_k` lying in `F^p` and lying in `conj F^{k-p}` **modulo `W_{k-1}`**. The modular weakening is the point: in the mixed theory conjugation symmetry holds only up to strictly lower weight, and this is precisely the shape in which the pieces of Deligne's bigrading present themselves.

The supporting API lands where it belongs rather than in the new file. `Conjugation.quotient` (the conjugation induced on a quotient by a stable subspace) and `Conjugation.map_comap_eq_comap_map` join `Conjugation.restrict` in `Conjugation.lean`; the latter also shortens the existing `HodgeStructureOn.comap`, which gains `comap_conjF` and `comap_piece`. `Graded.lean` gains `complexGradedConjugation` for an arbitrary stabilising conjugation, its specialization `gradedComplexConjugation`, the conjugation of an induced filtration, and the comparison theorem `gradedComplexEquiv_latticeConj`. `BaseChange.lean` gains the pure-tensor form of `latticeConj_rationalToComplexLinearEquiv_one_tmul` and an elementwise spelling of `rationalToComplexSubmodule_conj`. `MixedHodgeStructure.WC` becomes an `abbrev`, because the graded pieces of `WC` must be definitionally those of the complexified rational filtration for the transport to typecheck; no declaration is renamed or removed.

What remains for the L2 milestone after this PR: `DirectSum.IsInternal` for the bigrading of an arbitrary mixed Hodge structure (Deligne's induction on the length of `W`, whose first step is now statable), the recovery of `F` and `W` from the bigrading, the conjugation relation `I^{p,q} ≡ conj I^{q,p}` modulo strictly lower bidegree, and strictness of a morphism for both filtrations. The bigrading itself is defined in #4312; this PR is independent of it and touches no file it adds.

No Mathlib infrastructure was vendored; the new material is built on the pinned Mathlib's `Submodule` quotient, map and lattice API and on the existing `TauCeti/Geometry/Hodge/` base-change, pure-structure and mixed-structure files. Conventions follow Peters–Steenbrink, *Mixed Hodge Structures*, Ch. 3, and Deligne, *Théorie de Hodge II*, §1.2.1 and 1.2.10.

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"complex-graded-hodge-structure"}-->

🤖 Prepared with Claude Code

