### PR TITLE
fix(HeckeRing): state the Atkin–Lehner anti-involution where the Hecke triple is

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -199,13 +199,20 @@ private lemma atkinLehnerHom_mem_Delta0 [NeZero N] (g : GL (Fin 2) ℚ) (hg : g 
 `w` is the diagonal rescaling that repairs the transpose's failure to preserve `Γ₀(N)`. It is
 **not** the Atkin-Lehner matrix of the operator `𝒲_Q`, which is `!![0, -1; N, 0]`.
 
-Stated at `Gamma0Image N`, the spelling the `IsHeckeTriple (Delta0 N) (Gamma0Image N)
-(Gamma0Image N)` instance is found at, so `onHeckeCoset` and
-`HeckeCosetModule.mul_comm_of_antiInvolution` apply without an unfold. -/
+Stated at the **unfolded** `(Gamma0 N).map (mapGL ℚ)`, which is where
+`Gamma0/Basic.lean` puts the `IsHeckeTriple` instance. That matters and is not cosmetic:
+`HeckeCosetModule.mul_comm_of_antiInvolution` asks for a `HeckeAntiInvolution Δ H` together
+with `[IsHeckeTriple Δ H H]` at the *same* `H`, and instance search does not see through the
+sealed `Gamma0Image` definition. Stated at `Gamma0Image N` the two do not compose at all —
+the Hecke ring `𝕋 (Delta0 N) (Gamma0Image N) ℤ` does not even have a multiplication, since
+that too comes from the instance. Measured both ways. -/
 noncomputable def atkinLehnerAntiInvolution [NeZero N] :
-    HeckeAntiInvolution (Delta0 N) (Gamma0Image N) :=
+    HeckeAntiInvolution (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) :=
   HeckeAntiInvolution.ofAmbient (atkinLehnerHom N) (atkinLehnerHom_involutive N)
-    (atkinLehnerHom_mem_Gamma0Image N) (atkinLehnerHom_mem_Delta0 N)
+    (fun g hg ↦ by
+      rw [← Gamma0Image_def] at hg ⊢
+      exact atkinLehnerHom_mem_Gamma0Image N g hg)
+    (atkinLehnerHom_mem_Delta0 N)
 
 /-- The anti-involution acts by conjugating the transpose by `w`, unfolding the sealed
 definition. -/


### PR DESCRIPTION
Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"gamma0-antiinvolution-unfolded-spelling"}-->

`atkinLehnerAntiInvolution`'s docstring on `main` says why it is stated where it is:

> Stated at `Gamma0Image N`, the spelling the `IsHeckeTriple (Delta0 N) (Gamma0Image N)
> (Gamma0Image N)` instance is found at, so `onHeckeCoset` and
> `HeckeCosetModule.mul_comm_of_antiInvolution` apply without an unfold.

**That is not true of `main`.** `Gamma0/Basic.lean:123` states the instance at the *unfolded*
`((Gamma0 N).map (mapGL ℚ))`, not at `Gamma0Image N` — the restatement #4146 made — and
instance search does not see through the sealed `Gamma0Image` definition. So the declaration
sits at the one spelling where the thing its docstring promises cannot be done.

This restates it at the unfolded spelling and corrects the docstring.

## Measured, in both directions

`HeckeCosetModule.mul_comm_of_antiInvolution` wants a `HeckeAntiInvolution Δ H` together with
`[IsHeckeTriple Δ H H]` at the **same** `H`. Four probes, each a compiled file:

```
A  example (f g : 𝕋 (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ℤ) : Prop := f * g = g * f   rc=0
B  the same at 𝕋 (Delta0 N) (Gamma0Image N) ℤ                                          rc=1
     failed to synthesize  HMul (𝕋 (Delta0 N) (Gamma0Image N) ℤ) …
C  mul_comm_of_antiInvolution applied to atkinLehnerAntiInvolution, BEFORE                rc=1
     HMul unsynthesized, plus an application type mismatch on the involution argument
D  the same application, AFTER this change                                                rc=0
```

B is the sharp one: at `Gamma0Image N` the Hecke ring does not even have a multiplication,
because that also comes from the `IsHeckeTriple` instance. So this was never a cosmetic
choice of spelling.

## Why not a transport

The first attempt was `Gamma0Image_def N ▸ HeckeAntiInvolution.ofAmbient …`. It typechecks in
isolation, and it **breaks the two lemmas below it**: transporting a structure along an
equality stops its projections reducing, so `HeckeAntiInvolution.ofAmbient_bar` no longer
applies and both `atkinLehnerAntiInvolution_bar` and `atkinLehnerAntiInvolution_bar_val` fail
to elaborate. `lake build` caught exactly those two.

The shipped form applies `ofAmbient` **directly** at the unfolded `H`, discharging the
membership side condition with a two-line `rw [← Gamma0Image_def]`. Every projection still
reduces definitionally and neither `bar` lemma changes.

## Blast radius

`git grep -w -F atkinLehnerAntiInvolution origin/main` — five occurrences, **all inside
`AtkinLehner.lean`**: one docstring bullet, the definition, and three across the two `bar`
lemmas. No other file consumes it, so the retype is contained to this one file. (`-w` matters:
`_` is a word constituent, so it does not bleed into `atkinLehnerAntiInvolution_bar`.)

## What it unblocks

`instCommRing_Gamma0` — commutativity of the `Γ₀(N)` Hecke ring, Shimura Proposition 3.8 —
matches **0 files** on `main` (positive control: `IsHeckeTriple` matches 10 files under
`HeckeRing/`). AINTLIB assembles it as

```lean
instCommRing_of_antiInvolution (Gamma0_antiInvolution N) (Gamma0_onHeckeCoset_eq N)
```

and TauCeti already has both the anti-involution and the criterion — they simply could not be
applied to one another. With this change the only missing input is the coset-fixing lemma
(`Gamma0_AL_in_doubleCoset`, that the Atkin–Lehner image of a `Δ₀(N)` element lies in its own
double coset), which is **not** ported here and is the next PR.

Commutativity is in turn what the ring-side assembly `heckeRingDn` needs: its coprime
multiplicativity is a `Finsupp.prod` over the factorisation, and that requires a `CommMonoid`
instance which is currently unavailable — AINTLIB works around it with an explicit
`letI : CommRing … := instCommRing_Gamma0 N`.

## Scope

Fixing existing code — a declaration whose stated type defeats its documented purpose.
AGENTS.md places this in scope with no roadmap entry required: *"fixing or modestly
generalising an existing lemma … relocating a misplaced declaration … are all welcome at any
time."* The `Roadmap: ModularForms` line is attribution for the roadmap chiefly motivating it
(`TauCetiRoadmap/ModularForms/README.md:348`, Layer 2 — Hecke operators and the Hecke algebra;
note the **nested** path, `ModularForms/README.md` does not exist on `origin/main`). No
declaration is added or removed and no proof of any other declaration changes.
