### PR TITLE
feat: bridge normal Hopf ideals to categorical subgroups

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
@@ -6,14 +6,15 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Category.CommHopfAlgCat
+public import Mathlib.CategoryTheory.Monoidal.Cartesian.Grp
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
 public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 
 /-!
 # Commutative Hopf algebras and their functor of points
 
-This file packages the contravariant functor that sends a commutative coordinate Hopf algebra
-`H` over a commutative ring `R` to its group-valued functor of points `A ↦ Hom_R(H, A)`.
+This file packages the group object represented by a commutative coordinate Hopf algebra and the
+contravariant functor that sends it to its group-valued functor of points `A ↦ Hom_R(H, A)`.
 
 The category of commutative Hopf algebras is Mathlib's bundled `CommHopfAlgCat`; this file
 adds the functor-of-points stack on top of it.
@@ -31,6 +32,9 @@ coordinate Hopf algebras acts on points by pre-composition.
   of coordinate morphisms.
 * `CommHopfAlgCat.pointsFunctor`: the contravariant functor
   `(CommHopfAlgCat R)ᵒᵖ ⥤ CommAlgCat R ⥤ GrpCat`.
+* `CommHopfAlgCat.grpObj`: the underlying object of the represented group object.
+* `CommHopfAlgCat.grpObjMap`: the contravariant morphism of represented group objects induced by a
+  coordinate Hopf-algebra morphism.
 
 ## References
 
@@ -45,7 +49,7 @@ functoriality uses Mathlib's convolution monoid and bialgebra morphism API, in p
 
 public section
 
-open CategoryTheory WithConv
+open CategoryTheory Opposite WithConv
 
 namespace TauCeti
 
@@ -54,6 +58,44 @@ universe u v w
 namespace CommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
+
+/-- The underlying object `op (CommAlgCat.of R H)` of the group object represented by the
+commutative Hopf algebra `H`, carrying the induced `GrpObj` structure. -/
+noncomputable abbrev grpObj (H : _root_.CommHopfAlgCat.{u} R) :
+    (CommAlgCat.{u} R)ᵒᵖ :=
+  op (CommAlgCat.of R H)
+
+/-- The morphism of underlying group objects represented contravariantly by a morphism of
+commutative Hopf algebras. -/
+noncomputable def grpObjMap {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    grpObj K ⟶ grpObj H :=
+  (CommAlgCat.ofHom f.hom).op
+
+/-- Unopping `grpObjMap f` gives the underlying commutative-algebra morphism of `f`. -/
+@[simp]
+theorem grpObjMap_unop {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    (grpObjMap f).unop = CommAlgCat.ofHom f.hom := (rfl)
+
+/-- The identity coordinate morphism represents the identity group-object morphism. -/
+@[simp]
+theorem grpObjMap_id (H : _root_.CommHopfAlgCat.{u} R) :
+    grpObjMap (𝟙 H) = 𝟙 (grpObj H) := by
+  rfl
+
+/-- Composition of coordinate morphisms is represented contravariantly. -/
+@[simp]
+theorem grpObjMap_comp {H K L : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) (g : K ⟶ L) :
+    grpObjMap (f ≫ g) = grpObjMap g ≫ grpObjMap f := by
+  rfl
+
+/-- A morphism represented by a commutative Hopf-algebra morphism preserves the group-object
+multiplication. -/
+noncomputable instance grpObjMap_isMonHom {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    IsMonHom (grpObjMap f) := by
+  -- `grpObjMap` uses the concrete opposite-algebra spelling, whereas Mathlib registers the
+  -- `IsMonHom` instance on the definitionally equal morphism transported by the equivalence.
+  change IsMonHom (((commHopfAlgCatEquivCogrpCommAlgCat R).functor.map f).unop.hom.hom)
+  infer_instance
 
 /-- A morphism of coordinate commutative Hopf algebras induces a natural transformation
 between their group-valued points functors, contravariantly in the coordinate algebra.

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.CategoryTheory.Monoidal.Cartesian.Grp
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
 
 /-!
@@ -44,10 +43,6 @@ shrinking part.
   functor of points.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsHomEquiv`: the carrier equivalence from the opaque
   group-Yoneda model to algebra morphisms.
-* `TauCeti.CommHopfAlgCat.grpObj`: the underlying object of the group object represented by a
-  commutative Hopf algebra.
-* `TauCeti.CommHopfAlgCat.grpObjMap`: the morphism of underlying group objects represented by a
-  morphism of commutative Hopf algebras.
 * `TauCeti.CommHopfAlgCat.grpObjPointsMulEquiv`: generalized points of the represented group
   object are its convolution points.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsFunctorIso`: the group-valued Yoneda model is
@@ -310,30 +305,6 @@ theorem groupYonedaPointsHomEquiv_map_app
   unfold groupYonedaPointsHomEquiv groupYonedaPointsFunctor
   rfl
 
-/-- The underlying object `op (CommAlgCat.of R H)` of the group object represented by the
-commutative Hopf algebra `H`, carrying the induced `GrpObj` structure. -/
-noncomputable abbrev grpObj (H : _root_.CommHopfAlgCat.{u} R) :
-    (CommAlgCat.{u} R)ᵒᵖ :=
-  op (CommAlgCat.of R H)
-
-/-- The morphism of underlying group objects represented contravariantly by a morphism of
-commutative Hopf algebras. -/
-noncomputable def grpObjMap {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
-    grpObj K ⟶ grpObj H :=
-  (CommAlgCat.ofHom f.hom).op
-
-/-- Unopping `grpObjMap f` gives the underlying commutative-algebra morphism of `f`. -/
-@[simp]
-theorem grpObjMap_unop {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
-    (grpObjMap f).unop = CommAlgCat.ofHom f.hom := (rfl)
-
-/-- A morphism represented by a commutative Hopf-algebra morphism preserves the group-object
-multiplication. -/
-noncomputable instance grpObjMap_isMonHom {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
-    IsMonHom (grpObjMap f) := by
-  change IsMonHom (((commHopfAlgCatEquivCogrpCommAlgCat R).functor.map f).unop.hom.hom)
-  infer_instance
-
 /-- Generalized points of the group object represented by `H` are the convolution group of
 algebra-valued points of `H`. It sends the categorical multiplication `lift f g ≫ μ` to
 the convolution product of the underlying algebra morphisms. -/
@@ -368,11 +339,14 @@ theorem grpObjPointsMulEquiv_symm_apply (H : _root_.CommHopfAlgCat.{u} R)
     (X : (CommAlgCat.{u} R)ᵒᵖ) (p : HopfAlgebra.points (R := R) (H := H) X.unop) :
     (grpObjPointsMulEquiv H X).symm p =
       (opEquiv X (grpObj H)).symm (CommAlgCat.ofHom p.ofConv) := by
+  -- The inverse of the composite carrier equivalence reduces definitionally to the composite
+  -- of the inverse opposite-hom equivalence and `pointsHomEquiv.symm`.
   change (opEquiv X (grpObj H)).symm ((HopfAlgebra.pointsHomEquiv H X.unop).symm p) = _
   rw [HopfAlgebra.pointsHomEquiv_symm_apply]
 
 /-- Under the group-object point equivalences, composition with the morphism represented by `f`
 is precomposition of algebra-valued points with `f`. -/
+@[simp]
 theorem grpObjPointsMulEquiv_comp_grpObjMap {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K)
     (X : (CommAlgCat.{u} R)ᵒᵖ) (q : X ⟶ grpObj K) :
     grpObjPointsMulEquiv H X (q ≫ grpObjMap f) =

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -44,9 +44,12 @@ shrinking part.
   functor of points.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsHomEquiv`: the carrier equivalence from the opaque
   group-Yoneda model to algebra morphisms.
-* `TauCeti.CommHopfAlgCat.cogrpObj`: the represented cogroup's underlying group object.
-* `TauCeti.CommHopfAlgCat.cogrpPointsMulEquiv`: generalized points of the cogroup represented by
-  a commutative Hopf algebra are its convolution points.
+* `TauCeti.CommHopfAlgCat.grpObj`: the underlying object of the group object represented by a
+  commutative Hopf algebra.
+* `TauCeti.CommHopfAlgCat.grpObjMap`: the morphism of underlying group objects represented by a
+  morphism of commutative Hopf algebras.
+* `TauCeti.CommHopfAlgCat.grpObjPointsMulEquiv`: generalized points of the represented group
+  object are its convolution points.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsFunctorIso`: the group-valued Yoneda model is
   naturally isomorphic to the existing points functor.
 * `TauCeti.CommHopfAlgCat.pointsFunctor_faithful` and
@@ -282,24 +285,6 @@ noncomputable def groupYonedaPointsHomEquiv
   unfold groupYonedaPointsFunctor
   exact opEquiv _ _
 
-/-- On a Hopf algebra `H` and a value algebra `A`, a group-Yoneda element is a point after
-unopping its underlying morphism. -/
-private noncomputable def groupYonedaPointsEquiv
-    (H : (_root_.CommHopfAlgCat.{u} R)ᵒᵖ) (A : CommAlgCat.{u} R) :
-    ((groupYonedaPointsFunctor (R := R)).obj H).obj A ≃
-      ((pointsFunctor (R := R) :
-        (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).obj H).obj A :=
-  (groupYonedaPointsHomEquiv H A).trans (HopfAlgebra.pointsHomEquiv H.unop A)
-
-/-- The point obtained from a group-Yoneda element is the convolution wrapper of its
-underlying algebra morphism. -/
-private theorem groupYonedaPointsEquiv_apply
-    (H : (_root_.CommHopfAlgCat.{u} R)ᵒᵖ) (A : CommAlgCat.{u} R)
-    (f : ((groupYonedaPointsFunctor (R := R)).obj H).obj A) :
-    groupYonedaPointsEquiv H A f =
-      toConv ((groupYonedaPointsHomEquiv H A) f).hom := by
-  exact HopfAlgebra.pointsHomEquiv_apply H.unop (groupYonedaPointsHomEquiv H A f)
-
 /-- Under a map of value algebras, the algebra morphism underlying a group-Yoneda element
 is postcomposed with that map. -/
 @[simp]
@@ -325,26 +310,41 @@ theorem groupYonedaPointsHomEquiv_map_app
   unfold groupYonedaPointsHomEquiv groupYonedaPointsFunctor
   rfl
 
-/-- The group object in the opposite category of commutative `R`-algebras represented by a
-commutative Hopf algebra. -/
-noncomputable abbrev cogrpObj (H : _root_.CommHopfAlgCat.{u} R) :
+/-- The underlying object `op (CommAlgCat.of R H)` of the group object represented by the
+commutative Hopf algebra `H`, carrying the induced `GrpObj` structure. -/
+noncomputable abbrev grpObj (H : _root_.CommHopfAlgCat.{u} R) :
     (CommAlgCat.{u} R)ᵒᵖ :=
-  ((commHopfAlgCatEquivCogrpCommAlgCat R).functor.obj H).unop.X
+  op (CommAlgCat.of R H)
 
-/-- Generalized points of the cogroup represented by `H` are the convolution group of
-algebra-valued points of `H`. This is the raw-hom multiplication bridge underlying
-`groupYonedaPointsMulEquiv`, independent of the opaque `groupYonedaPointsFunctor`. -/
-noncomputable def cogrpPointsMulEquiv (H : _root_.CommHopfAlgCat.{u} R)
-    (A : CommAlgCat.{u} R) :
-    (op A ⟶ cogrpObj H) ≃* HopfAlgebra.points (R := R) (H := H) A where
-  toFun g := toConv g.unop.hom
-  invFun p := op (CommAlgCat.ofHom p.ofConv)
-  left_inv g := by
-    apply Quiver.Hom.unop_inj
-    exact CommAlgCat.hom_ext rfl
-  right_inv p := WithConv.toConv_ofConv p
+/-- The morphism of underlying group objects represented contravariantly by a morphism of
+commutative Hopf algebras. -/
+noncomputable def grpObjMap {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    grpObj K ⟶ grpObj H :=
+  (CommAlgCat.ofHom f.hom).op
+
+/-- Unopping `grpObjMap f` gives the underlying commutative-algebra morphism of `f`. -/
+@[simp]
+theorem grpObjMap_unop {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    (grpObjMap f).unop = CommAlgCat.ofHom f.hom := (rfl)
+
+/-- A morphism represented by a commutative Hopf-algebra morphism preserves the group-object
+multiplication. -/
+noncomputable instance grpObjMap_isMonHom {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    IsMonHom (grpObjMap f) := by
+  change IsMonHom (((commHopfAlgCatEquivCogrpCommAlgCat R).functor.map f).unop.hom.hom)
+  infer_instance
+
+/-- Generalized points of the group object represented by `H` are the convolution group of
+algebra-valued points of `H`. It sends the categorical multiplication `lift f g ≫ μ` to
+the convolution product of the underlying algebra morphisms. -/
+noncomputable def grpObjPointsMulEquiv (H : _root_.CommHopfAlgCat.{u} R)
+    (X : (CommAlgCat.{u} R)ᵒᵖ) :
+    (X ⟶ grpObj H) ≃* HopfAlgebra.points (R := R) (H := H) X.unop where
+  toEquiv := (opEquiv X (grpObj H)).trans (HopfAlgebra.pointsHomEquiv H X.unop)
   map_mul' f g := by
     apply WithConv.ofConv_injective
+    -- Exposing the hom type also exposes the group-object multiplication induced by the Hopf
+    -- comultiplication.
     change (CartesianMonoidalCategory.lift f g ≫ μ).unop.hom =
       (toConv f.unop.hom * toConv g.unop.hom).ofConv
     apply AlgHom.ext
@@ -353,12 +353,38 @@ noncomputable def cogrpPointsMulEquiv (H : _root_.CommHopfAlgCat.{u} R)
       AlgHom.comp_apply, AlgHom.convMul_apply]
     exact congrArg _ (Bialgebra.comulAlgHom_apply R H h)
 
-/-- The generalized-point equivalence regards a categorical point as the convolution wrapper
-of its underlying algebra morphism. -/
+/-- The group-object point equivalence regards a categorical point as the convolution wrapper of
+its underlying algebra morphism. -/
 @[simp]
-theorem cogrpPointsMulEquiv_apply (H : _root_.CommHopfAlgCat.{u} R)
-    (A : CommAlgCat.{u} R) (g : op A ⟶ cogrpObj H) :
-    cogrpPointsMulEquiv H A g = toConv g.unop.hom := (rfl)
+theorem grpObjPointsMulEquiv_apply (H : _root_.CommHopfAlgCat.{u} R)
+    (X : (CommAlgCat.{u} R)ᵒᵖ) (g : X ⟶ grpObj H) :
+    grpObjPointsMulEquiv H X g = toConv g.unop.hom := by
+  exact HopfAlgebra.pointsHomEquiv_apply H g.unop
+
+/-- The inverse point equivalence bundles a convolution point as a morphism in the opposite
+category of commutative algebras. -/
+@[simp]
+theorem grpObjPointsMulEquiv_symm_apply (H : _root_.CommHopfAlgCat.{u} R)
+    (X : (CommAlgCat.{u} R)ᵒᵖ) (p : HopfAlgebra.points (R := R) (H := H) X.unop) :
+    (grpObjPointsMulEquiv H X).symm p =
+      (opEquiv X (grpObj H)).symm (CommAlgCat.ofHom p.ofConv) := by
+  change (opEquiv X (grpObj H)).symm ((HopfAlgebra.pointsHomEquiv H X.unop).symm p) = _
+  rw [HopfAlgebra.pointsHomEquiv_symm_apply]
+
+/-- Under the group-object point equivalences, composition with the morphism represented by `f`
+is precomposition of algebra-valued points with `f`. -/
+theorem grpObjPointsMulEquiv_comp_grpObjMap {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K)
+    (X : (CommAlgCat.{u} R)ᵒᵖ) (q : X ⟶ grpObj K) :
+    grpObjPointsMulEquiv H X (q ≫ grpObjMap f) =
+      (mapPointsFunctor f).app X.unop (grpObjPointsMulEquiv K X q) := by
+  apply WithConv.ofConv_injective
+  -- The public application rules expose both categorical points as their underlying algebra
+  -- morphisms before the functorial action is computed.
+  change (q ≫ grpObjMap f).unop.hom =
+    ((mapPointsFunctor f).app X.unop (toConv q.unop.hom)).ofConv
+  rw [mapPointsFunctor_app_apply, WithConv.ofConv_toConv]
+  rw [unop_comp, grpObjMap_unop, CommAlgCat.hom_comp]
+  rfl
 
 /-- The tautological carrier equivalence respects group-Yoneda multiplication: unopping
 `lift f g ≫ μ` gives comultiplication followed by `f` and `g`, which is convolution. -/
@@ -366,11 +392,8 @@ private noncomputable def groupYonedaPointsMulEquiv
     (H : (_root_.CommHopfAlgCat.{u} R)ᵒᵖ) (A : CommAlgCat.{u} R) :
     ((groupYonedaPointsFunctor (R := R)).obj H).obj A ≃*
       ((pointsFunctor (R := R) :
-        (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).obj H).obj A where
-  toEquiv := groupYonedaPointsEquiv H A
-  map_mul' f g := by
-    change (op A ⟶ cogrpObj H.unop) at f g
-    exact (cogrpPointsMulEquiv H.unop A).map_mul f g
+        (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).obj H).obj A :=
+  grpObjPointsMulEquiv H.unop (op A)
 
 /-- The forward homomorphism of the pointwise group equivalence is computed by the carrier
 equivalence followed by the convolution wrapper. -/
@@ -378,8 +401,8 @@ private theorem groupYonedaPointsMulEquiv_apply
     (H : (_root_.CommHopfAlgCat.{u} R)ᵒᵖ) (A : CommAlgCat.{u} R)
     (f : ((groupYonedaPointsFunctor (R := R)).obj H).obj A) :
     (groupYonedaPointsMulEquiv H A).toGrpIso.hom f =
-      toConv ((groupYonedaPointsHomEquiv H A) f).hom :=
-  groupYonedaPointsEquiv_apply H A f
+      toConv ((groupYonedaPointsHomEquiv H A) f).hom := by
+  exact grpObjPointsMulEquiv_apply H.unop (op A) f
 
 /-- The pointwise group equivalences are natural in the value algebra. -/
 private noncomputable def groupYonedaPointsObjIso

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -44,6 +44,9 @@ shrinking part.
   functor of points.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsHomEquiv`: the carrier equivalence from the opaque
   group-Yoneda model to algebra morphisms.
+* `TauCeti.CommHopfAlgCat.cogrpObj`: the represented cogroup's underlying group object.
+* `TauCeti.CommHopfAlgCat.cogrpPointsMulEquiv`: generalized points of the cogroup represented by
+  a commutative Hopf algebra are its convolution points.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsFunctorIso`: the group-valued Yoneda model is
   naturally isomorphic to the existing points functor.
 * `TauCeti.CommHopfAlgCat.pointsFunctor_faithful` and
@@ -322,6 +325,41 @@ theorem groupYonedaPointsHomEquiv_map_app
   unfold groupYonedaPointsHomEquiv groupYonedaPointsFunctor
   rfl
 
+/-- The group object in the opposite category of commutative `R`-algebras represented by a
+commutative Hopf algebra. -/
+noncomputable abbrev cogrpObj (H : _root_.CommHopfAlgCat.{u} R) :
+    (CommAlgCat.{u} R)ᵒᵖ :=
+  ((commHopfAlgCatEquivCogrpCommAlgCat R).functor.obj H).unop.X
+
+/-- Generalized points of the cogroup represented by `H` are the convolution group of
+algebra-valued points of `H`. This is the raw-hom multiplication bridge underlying
+`groupYonedaPointsMulEquiv`, independent of the opaque `groupYonedaPointsFunctor`. -/
+noncomputable def cogrpPointsMulEquiv (H : _root_.CommHopfAlgCat.{u} R)
+    (A : CommAlgCat.{u} R) :
+    (op A ⟶ cogrpObj H) ≃* HopfAlgebra.points (R := R) (H := H) A where
+  toFun g := toConv g.unop.hom
+  invFun p := op (CommAlgCat.ofHom p.ofConv)
+  left_inv g := by
+    apply Quiver.Hom.unop_inj
+    exact CommAlgCat.hom_ext rfl
+  right_inv p := WithConv.toConv_ofConv p
+  map_mul' f g := by
+    apply WithConv.ofConv_injective
+    change (CartesianMonoidalCategory.lift f g ≫ μ).unop.hom =
+      (toConv f.unop.hom * toConv g.unop.hom).ofConv
+    apply AlgHom.ext
+    intro h
+    simp only [unop_comp, CommAlgCat.hom_comp, CommAlgCat.lift_unop_hom,
+      AlgHom.comp_apply, AlgHom.convMul_apply]
+    exact congrArg _ (Bialgebra.comulAlgHom_apply R H h)
+
+/-- The generalized-point equivalence regards a categorical point as the convolution wrapper
+of its underlying algebra morphism. -/
+@[simp]
+theorem cogrpPointsMulEquiv_apply (H : _root_.CommHopfAlgCat.{u} R)
+    (A : CommAlgCat.{u} R) (g : op A ⟶ cogrpObj H) :
+    cogrpPointsMulEquiv H A g = toConv g.unop.hom := (rfl)
+
 /-- The tautological carrier equivalence respects group-Yoneda multiplication: unopping
 `lift f g ≫ μ` gives comultiplication followed by `f` and `g`, which is convolution. -/
 private noncomputable def groupYonedaPointsMulEquiv
@@ -331,19 +369,8 @@ private noncomputable def groupYonedaPointsMulEquiv
         (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).obj H).obj A where
   toEquiv := groupYonedaPointsEquiv H A
   map_mul' f g := by
-    -- Exposing the hom type also exposes the canonical cogroup structure on `op H`, whose
-    -- multiplication is the opposite of the Hopf comultiplication.
-    change (op A ⟶ op (CommAlgCat.of R H.unop)) at f g
-    change toConv (f * g).unop.hom =
-      toConv f.unop.hom * toConv g.unop.hom
-    apply WithConv.ofConv_injective
-    change (CartesianMonoidalCategory.lift f g ≫ μ).unop.hom =
-      (toConv f.unop.hom * toConv g.unop.hom).ofConv
-    apply AlgHom.ext
-    intro (h : H.unop)
-    simp only [unop_comp, CommAlgCat.hom_comp, CommAlgCat.lift_unop_hom,
-      CommAlgCat.mul_op_of_unop_hom, AlgHom.comp_apply, AlgHom.convMul_apply]
-    exact congrArg _ (Bialgebra.comulAlgHom_apply R H.unop h)
+    change (op A ⟶ cogrpObj H.unop) at f g
+    exact (cogrpPointsMulEquiv H.unop A).map_mul f g
 
 /-- The forward homomorphism of the pointwise group equivalence is computed by the carrier
 equivalence followed by the convolution wrapper. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
 public import TauCeti.CategoryTheory.Monoidal.Normal
 import Mathlib.Algebra.Category.CommAlgCat.Monoidal
 
@@ -24,6 +25,10 @@ algebra-valued points.
 The result is the bridge needed to apply the internal semidirect-product construction to two
 normal closed affine subgroup schemes. Its multiplication map and scheme-theoretic image are the
 binary product used in the maximal-dimension construction of the unipotent radical.
+
+The formal source for the generalized-point multiplication bridge is
+`TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda.groupYonedaPointsMulEquiv`; this file uses
+the public raw-hom factor `TauCeti.CommHopfAlgCat.cogrpPointsMulEquiv` extracted from it.
 
 ## Main declarations
 
@@ -56,40 +61,6 @@ namespace TauCeti.CommHopfAlgCat
 universe u
 
 variable {R : Type u} [CommRing R]
-
-/-- The group object in the opposite category of commutative `R`-algebras represented by a
-commutative Hopf algebra. -/
-noncomputable abbrev cogrpObj (H : _root_.CommHopfAlgCat.{u} R) :
-    (CommAlgCat.{u} R)ᵒᵖ :=
-  ((commHopfAlgCatEquivCogrpCommAlgCat R).functor.obj H).unop.X
-
-/-- Generalized points of the group object represented by `H` are the convolution group of
-algebra-valued points of `H`. -/
-noncomputable def cogrpPointsMulEquiv (H : _root_.CommHopfAlgCat.{u} R)
-    (A : CommAlgCat.{u} R) :
-    (op A ⟶ cogrpObj H) ≃* HopfAlgebra.points (R := R) (H := H) A where
-  toFun g := toConv g.unop.hom
-  invFun p := op (CommAlgCat.ofHom p.ofConv)
-  left_inv g := by
-    apply Quiver.Hom.unop_inj
-    exact CommAlgCat.hom_ext rfl
-  right_inv p := WithConv.toConv_ofConv p
-  map_mul' f g := by
-    apply WithConv.ofConv_injective
-    change (CartesianMonoidalCategory.lift f g ≫ μ).unop.hom =
-      (toConv f.unop.hom * toConv g.unop.hom).ofConv
-    apply AlgHom.ext
-    intro h
-    simp only [unop_comp, CommAlgCat.hom_comp, CommAlgCat.lift_unop_hom,
-      AlgHom.comp_apply, AlgHom.convMul_apply]
-    exact congrArg _ (Bialgebra.comulAlgHom_apply R H h)
-
-/-- The generalized-point equivalence regards a categorical point as the convolution wrapper
-of its underlying algebra morphism. -/
-@[simp]
-theorem cogrpPointsMulEquiv_apply (H : _root_.CommHopfAlgCat.{u} R)
-    (A : CommAlgCat.{u} R) (g : op A ⟶ cogrpObj H) :
-    cogrpPointsMulEquiv H A g = toConv g.unop.hom := (rfl)
 
 /-- The categorical closed-subgroup inclusion represented contravariantly by the quotient map
 `H ⟶ H/I`. -/
@@ -168,8 +139,10 @@ theorem quotientCogrpInclusion_normal (H : _root_.CommHopfAlgCat.{u} R)
   have hqCatPoint : cogrpPointsMulEquiv (quotient H I) A.unop qCat = q' := by
     dsimp only [qCat]
     exact (cogrpPointsMulEquiv (quotient H I) A.unop).apply_symm_apply q'
-  have hqPoint' : cogrpPointsMulEquiv (quotient H I) A.unop q = qPoint := (rfl)
-  have hgPoint : cogrpPointsMulEquiv H A.unop g = gPoint := (rfl)
+  have hqPoint' : cogrpPointsMulEquiv (quotient H I) A.unop q = qPoint := by
+    exact cogrpPointsMulEquiv_apply (quotient H I) A.unop q
+  have hgPoint : cogrpPointsMulEquiv H A.unop g = gPoint := by
+    exact cogrpPointsMulEquiv_apply H A.unop g
   rw [hqCatPoint, hqPoint', hgPoint]
   exact hq'
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Categorical
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Yoneda
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.Normal
 
 /-!
@@ -65,26 +65,20 @@ private theorem quotientGrpObjInclusion_range_map
     (IsMonHom.monoidHom (quotientGrpObjInclusion H I) X).range.map
         (grpObjPointsMulEquiv H X).toMonoidHom =
       quotientPointsSubgroup H I X.unop := by
-  rw [quotientPointsSubgroup_eq_range]
-  ext p
-  constructor
-  · rintro ⟨n, ⟨q, hq⟩, hn⟩
-    refine ⟨grpObjPointsMulEquiv (quotient H I) X q, ?_⟩
-    calc
-      quotientPointsHom H I X.unop (grpObjPointsMulEquiv (quotient H I) X q) =
-          grpObjPointsMulEquiv H X (q ≫ quotientGrpObjInclusion H I) :=
-        (grpObjPointsMulEquiv_comp_quotientGrpObjInclusion H I X q).symm
-      _ = grpObjPointsMulEquiv H X n := congrArg (grpObjPointsMulEquiv H X) hq
-      _ = p := hn
-  · rintro ⟨q, hq⟩
-    refine ⟨(grpObjPointsMulEquiv H X).symm p, ?_,
-      (grpObjPointsMulEquiv H X).apply_symm_apply p⟩
-    refine ⟨(grpObjPointsMulEquiv (quotient H I) X).symm q, ?_⟩
-    apply (grpObjPointsMulEquiv H X).injective
-    simp only [IsMonHom.monoidHom_apply]
-    rw [grpObjPointsMulEquiv_comp_quotientGrpObjInclusion,
-      (grpObjPointsMulEquiv (quotient H I) X).apply_symm_apply,
-      (grpObjPointsMulEquiv H X).apply_symm_apply, hq]
+  rw [quotientPointsSubgroup_def, MonoidHom.map_range]
+  have hcomp :
+      (grpObjPointsMulEquiv H X).toMonoidHom.comp
+          (IsMonHom.monoidHom (quotientGrpObjInclusion H I) X) =
+        (quotientPointsHom H I X.unop).hom.comp
+          (grpObjPointsMulEquiv (quotient H I) X).toMonoidHom := by
+    apply MonoidHom.ext
+    intro q
+    simpa only [MonoidHom.comp_apply, IsMonHom.monoidHom_apply,
+      MulEquiv.coe_toMonoidHom] using
+      grpObjPointsMulEquiv_comp_quotientGrpObjInclusion H I X q
+  rw [hcomp, MonoidHom.range_comp,
+    MonoidHom.range_eq_top_of_surjective _ (grpObjPointsMulEquiv (quotient H I) X).surjective]
+  exact (MonoidHom.range_eq_map _).symm
 
 /-- Pointwise normality of the categorical inclusion is equivalent to normality of the
 corresponding quotient-points subgroup. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
+public import TauCeti.CategoryTheory.Monoidal.Normal
+import Mathlib.Algebra.Category.CommAlgCat.Monoidal
+
+/-!
+# Normal Hopf ideals as categorical normal subgroups
+
+A commutative Hopf algebra is equivalently a group object in the opposite category of
+commutative algebras. Under this equivalence, a Hopf-ideal quotient `H ⟶ H/I` represents the
+closed-subgroup inclusion `Spec(H/I) ⟶ Spec H`.
+
+This file proves that normality of the Hopf ideal makes this inclusion a normal subgroup object
+in Mathlib's sense. The proof uses the generalized-point criterion for categorical normality and
+the existing characterization of normal Hopf ideals by normality of their subgroups of
+algebra-valued points.
+
+The result is the bridge needed to apply the internal semidirect-product construction to two
+normal closed affine subgroup schemes. Its multiplication map and scheme-theoretic image are the
+binary product used in the maximal-dimension construction of the unipotent radical.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.cogrpObj`: the group object in `(CommAlgCat R)ᵒᵖ` represented by a
+  commutative Hopf algebra.
+* `TauCeti.CommHopfAlgCat.cogrpPointsMulEquiv`: generalized points of the represented group
+  object are convolution points.
+* `TauCeti.CommHopfAlgCat.quotientCogrpInclusion`: the categorical closed-subgroup inclusion
+  represented by a Hopf-ideal quotient.
+* `TauCeti.CommHopfAlgCat.quotientCogrpInclusion_normal`: a normal Hopf ideal represents a normal
+  subgroup object.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §§15–17.
+* J. S. Milne, *Algebraic Groups* (2017), §§6.a and 10.20.
+
+This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap. It connects the
+coordinate normality API to the categorical semidirect-product API used to form the product of
+two normal unipotent-radical candidates.
+-/
+
+public section
+
+open CategoryTheory Opposite WithConv
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u
+
+variable {R : Type u} [CommRing R]
+
+/-- The group object in the opposite category of commutative `R`-algebras represented by a
+commutative Hopf algebra. -/
+noncomputable abbrev cogrpObj (H : _root_.CommHopfAlgCat.{u} R) :
+    (CommAlgCat.{u} R)ᵒᵖ :=
+  ((commHopfAlgCatEquivCogrpCommAlgCat R).functor.obj H).unop.X
+
+/-- Generalized points of the group object represented by `H` are the convolution group of
+algebra-valued points of `H`. -/
+noncomputable def cogrpPointsMulEquiv (H : _root_.CommHopfAlgCat.{u} R)
+    (A : CommAlgCat.{u} R) :
+    (op A ⟶ cogrpObj H) ≃* HopfAlgebra.points (R := R) (H := H) A where
+  toFun g := toConv g.unop.hom
+  invFun p := op (CommAlgCat.ofHom p.ofConv)
+  left_inv g := by
+    apply Quiver.Hom.unop_inj
+    exact CommAlgCat.hom_ext rfl
+  right_inv p := WithConv.toConv_ofConv p
+  map_mul' f g := by
+    apply WithConv.ofConv_injective
+    change (CartesianMonoidalCategory.lift f g ≫ μ).unop.hom =
+      (toConv f.unop.hom * toConv g.unop.hom).ofConv
+    apply AlgHom.ext
+    intro h
+    simp only [unop_comp, CommAlgCat.hom_comp, CommAlgCat.lift_unop_hom,
+      AlgHom.comp_apply, AlgHom.convMul_apply]
+    exact congrArg _ (Bialgebra.comulAlgHom_apply R H h)
+
+/-- The generalized-point equivalence regards a categorical point as the convolution wrapper
+of its underlying algebra morphism. -/
+@[simp]
+theorem cogrpPointsMulEquiv_apply (H : _root_.CommHopfAlgCat.{u} R)
+    (A : CommAlgCat.{u} R) (g : op A ⟶ cogrpObj H) :
+    cogrpPointsMulEquiv H A g = toConv g.unop.hom := (rfl)
+
+/-- The categorical closed-subgroup inclusion represented contravariantly by the quotient map
+`H ⟶ H/I`. -/
+noncomputable def quotientCogrpInclusion (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) : cogrpObj (quotient H I) ⟶ cogrpObj H :=
+  ((commHopfAlgCatEquivCogrpCommAlgCat R).functor.map (mkQuotient H I)).unop.hom.hom
+
+/-- The categorical quotient inclusion is the opposite of the coordinate quotient map. -/
+theorem quotientCogrpInclusion_unop (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) :
+    (quotientCogrpInclusion H I).unop = CommAlgCat.ofHom (mkQuotient H I).hom := (rfl)
+
+/-- Under `cogrpPointsMulEquiv`, composition with the categorical quotient inclusion is the
+usual quotient-points homomorphism. -/
+@[simp]
+theorem cogrpPointsMulEquiv_comp_quotientCogrpInclusion
+    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) (A : CommAlgCat.{u} R)
+    (q : op A ⟶ cogrpObj (quotient H I)) :
+    cogrpPointsMulEquiv H A (q ≫ quotientCogrpInclusion H I) =
+      quotientPointsHom H I A (cogrpPointsMulEquiv (quotient H I) A q) := by
+  rw [cogrpPointsMulEquiv_apply, cogrpPointsMulEquiv_apply]
+  apply WithConv.ofConv_injective
+  change (q ≫ quotientCogrpInclusion H I).unop.hom =
+    (quotientPointsHom H I A (toConv q.unop.hom)).ofConv
+  rw [quotientPointsHom_apply]
+  rw [unop_comp, quotientCogrpInclusion_unop]
+  rfl
+
+/-- A normal Hopf ideal represents a normal subgroup object in the opposite category of
+commutative algebras. -/
+theorem quotientCogrpInclusion_normal (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) (hI : I.IsNormal) :
+    IsMonHom.Normal (quotientCogrpInclusion H I) := by
+  let i := quotientCogrpInclusion H I
+  let q : CommAlgCat.of R H ⟶ CommAlgCat.of R (quotient H I) :=
+    CommAlgCat.ofHom (mkQuotient H I).hom
+  let _ : Epi q := ConcreteCategory.epi_of_surjective q (by
+    intro x
+    obtain ⟨y, hy⟩ := mkQuotient_surjective H I x
+    exact ⟨y, hy⟩)
+  let _ : Mono i := ⟨fun {Z} a b hab ↦ by
+    apply Quiver.Hom.unop_inj
+    apply (cancel_epi q).1
+    have hab' := congrArg Quiver.Hom.unop hab
+    change (quotientCogrpInclusion H I).unop ≫ a.unop =
+      (quotientCogrpInclusion H I).unop ≫ b.unop at hab'
+    rw [quotientCogrpInclusion_unop] at hab'
+    exact hab'⟩
+  let _ : IsMonHom i := by
+    dsimp only [i, quotientCogrpInclusion]
+    infer_instance
+  rw [IsMonHom.normal_iff_normal_monoidHom]
+  intro A
+  let hnormal := quotientPointsSubgroup_normal H I hI A.unop
+  constructor
+  rintro n ⟨q, rfl⟩ g
+  let qPoint : HopfAlgebra.points (R := R) (H := quotient H I) A.unop :=
+    toConv q.unop.hom
+  let gPoint : HopfAlgebra.points (R := R) (H := H) A.unop :=
+    toConv g.unop.hom
+  have hq : quotientPointsHom H I A.unop qPoint ∈ quotientPointsSubgroup H I A.unop :=
+    quotientPointsHom_mem_quotientPointsSubgroup H I A.unop qPoint
+  have hconj := hnormal.conj_mem (quotientPointsHom H I A.unop qPoint) hq gPoint
+  change _ ∈ (quotientPointsHom H I A.unop).hom.range at hconj
+  obtain ⟨q', hq'⟩ := hconj
+  let qCat : A ⟶ cogrpObj (quotient H I) :=
+    (cogrpPointsMulEquiv (quotient H I) A.unop).symm q'
+  refine ⟨qCat, ?_⟩
+  apply (cogrpPointsMulEquiv H A.unop).injective
+  change cogrpPointsMulEquiv H A.unop (qCat ≫ i) =
+    cogrpPointsMulEquiv H A.unop (g * (q ≫ i) * g⁻¹)
+  dsimp only [i]
+  rw [map_mul, map_mul, map_inv,
+    cogrpPointsMulEquiv_comp_quotientCogrpInclusion,
+    cogrpPointsMulEquiv_comp_quotientCogrpInclusion]
+  have hqCatPoint : cogrpPointsMulEquiv (quotient H I) A.unop qCat = q' := by
+    dsimp only [qCat]
+    exact (cogrpPointsMulEquiv (quotient H I) A.unop).apply_symm_apply q'
+  have hqPoint' : cogrpPointsMulEquiv (quotient H I) A.unop q = qPoint := (rfl)
+  have hgPoint : cogrpPointsMulEquiv H A.unop g = gPoint := (rfl)
+  rw [hqCatPoint, hqPoint', hgPoint]
+  exact hq'
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
@@ -6,9 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
-public import TauCeti.CategoryTheory.Monoidal.Normal
-import Mathlib.Algebra.Category.CommAlgCat.Monoidal
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Categorical
+public import Mathlib.CategoryTheory.Monoidal.Cartesian.Normal
 
 /-!
 # Normal Hopf ideals as categorical normal subgroups
@@ -26,25 +25,21 @@ The result is the bridge needed to apply the internal semidirect-product constru
 normal closed affine subgroup schemes. Its multiplication map and scheme-theoretic image are the
 binary product used in the maximal-dimension construction of the unipotent radical.
 
-The formal source for the generalized-point multiplication bridge is
-`TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda.groupYonedaPointsMulEquiv`; this file uses
-the public raw-hom factor `TauCeti.CommHopfAlgCat.cogrpPointsMulEquiv` extracted from it.
+The multiplication bridge used here is `TauCeti.CommHopfAlgCat.grpObjPointsMulEquiv` from
+`TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda`.
 
 ## Main declarations
 
-* `TauCeti.CommHopfAlgCat.cogrpObj`: the group object in `(CommAlgCat R)ᵒᵖ` represented by a
-  commutative Hopf algebra.
-* `TauCeti.CommHopfAlgCat.cogrpPointsMulEquiv`: generalized points of the represented group
-  object are convolution points.
-* `TauCeti.CommHopfAlgCat.quotientCogrpInclusion`: the categorical closed-subgroup inclusion
-  represented by a Hopf-ideal quotient.
-* `TauCeti.CommHopfAlgCat.quotientCogrpInclusion_normal`: a normal Hopf ideal represents a normal
-  subgroup object.
+* `TauCeti.CommHopfAlgCat.quotientGrpObjInclusion_normal_iff`: a Hopf ideal is normal exactly
+  when its categorical inclusion is a normal subgroup object.
 
 ## References
 
 * W. C. Waterhouse, *Introduction to Affine Group Schemes*, §§15–17.
 * J. S. Milne, *Algebraic Groups* (2017), §§6.a and 10.20.
+* Mathlib's `commHopfAlgCatEquivCogrpCommAlgCat` and
+  `CategoryTheory.IsMonHom.normal_iff_normal_monoidHom`; the latter follows Görtz–Wedhorn,
+  *Algebraic Geometry II*, Definition 27.3.
 
 This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap. It connects the
 coordinate normality API to the categorical semidirect-product API used to form the product of
@@ -62,88 +57,63 @@ universe u
 
 variable {R : Type u} [CommRing R]
 
-/-- The categorical closed-subgroup inclusion represented contravariantly by the quotient map
-`H ⟶ H/I`. -/
-noncomputable def quotientCogrpInclusion (H : _root_.CommHopfAlgCat.{u} R)
-    (I : HopfIdeal R H) : cogrpObj (quotient H I) ⟶ cogrpObj H :=
-  ((commHopfAlgCatEquivCogrpCommAlgCat R).functor.map (mkQuotient H I)).unop.hom.hom
-
-/-- The categorical quotient inclusion is the opposite of the coordinate quotient map. -/
-theorem quotientCogrpInclusion_unop (H : _root_.CommHopfAlgCat.{u} R)
-    (I : HopfIdeal R H) :
-    (quotientCogrpInclusion H I).unop = CommAlgCat.ofHom (mkQuotient H I).hom := (rfl)
-
-/-- Under `cogrpPointsMulEquiv`, composition with the categorical quotient inclusion is the
-usual quotient-points homomorphism. -/
-@[simp]
-theorem cogrpPointsMulEquiv_comp_quotientCogrpInclusion
-    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) (A : CommAlgCat.{u} R)
-    (q : op A ⟶ cogrpObj (quotient H I)) :
-    cogrpPointsMulEquiv H A (q ≫ quotientCogrpInclusion H I) =
-      quotientPointsHom H I A (cogrpPointsMulEquiv (quotient H I) A q) := by
-  rw [cogrpPointsMulEquiv_apply, cogrpPointsMulEquiv_apply]
-  apply WithConv.ofConv_injective
-  change (q ≫ quotientCogrpInclusion H I).unop.hom =
-    (quotientPointsHom H I A (toConv q.unop.hom)).ofConv
-  rw [quotientPointsHom_apply]
-  rw [unop_comp, quotientCogrpInclusion_unop]
-  rfl
-
-/-- A normal Hopf ideal represents a normal subgroup object in the opposite category of
-commutative algebras. -/
-theorem quotientCogrpInclusion_normal (H : _root_.CommHopfAlgCat.{u} R)
-    (I : HopfIdeal R H) (hI : I.IsNormal) :
-    IsMonHom.Normal (quotientCogrpInclusion H I) := by
-  let i := quotientCogrpInclusion H I
-  let q : CommAlgCat.of R H ⟶ CommAlgCat.of R (quotient H I) :=
-    CommAlgCat.ofHom (mkQuotient H I).hom
-  let _ : Epi q := ConcreteCategory.epi_of_surjective q (by
-    intro x
-    obtain ⟨y, hy⟩ := mkQuotient_surjective H I x
-    exact ⟨y, hy⟩)
-  let _ : Mono i := ⟨fun {Z} a b hab ↦ by
-    apply Quiver.Hom.unop_inj
-    apply (cancel_epi q).1
-    have hab' := congrArg Quiver.Hom.unop hab
-    change (quotientCogrpInclusion H I).unop ≫ a.unop =
-      (quotientCogrpInclusion H I).unop ≫ b.unop at hab'
-    rw [quotientCogrpInclusion_unop] at hab'
-    exact hab'⟩
-  let _ : IsMonHom i := by
-    dsimp only [i, quotientCogrpInclusion]
-    infer_instance
-  rw [IsMonHom.normal_iff_normal_monoidHom]
-  intro A
-  let hnormal := quotientPointsSubgroup_normal H I hI A.unop
+/-- Mapping the range of a categorical quotient inclusion through the generalized-point
+equivalence gives the subgroup cut out by the Hopf ideal. -/
+private theorem quotientGrpObjInclusion_range_map
+    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H)
+    (X : (CommAlgCat.{u} R)ᵒᵖ) :
+    (IsMonHom.monoidHom (quotientGrpObjInclusion H I) X).range.map
+        (grpObjPointsMulEquiv H X).toMonoidHom =
+      quotientPointsSubgroup H I X.unop := by
+  rw [quotientPointsSubgroup_eq_range]
+  ext p
   constructor
-  rintro n ⟨q, rfl⟩ g
-  let qPoint : HopfAlgebra.points (R := R) (H := quotient H I) A.unop :=
-    toConv q.unop.hom
-  let gPoint : HopfAlgebra.points (R := R) (H := H) A.unop :=
-    toConv g.unop.hom
-  have hq : quotientPointsHom H I A.unop qPoint ∈ quotientPointsSubgroup H I A.unop :=
-    quotientPointsHom_mem_quotientPointsSubgroup H I A.unop qPoint
-  have hconj := hnormal.conj_mem (quotientPointsHom H I A.unop qPoint) hq gPoint
-  change _ ∈ (quotientPointsHom H I A.unop).hom.range at hconj
-  obtain ⟨q', hq'⟩ := hconj
-  let qCat : A ⟶ cogrpObj (quotient H I) :=
-    (cogrpPointsMulEquiv (quotient H I) A.unop).symm q'
-  refine ⟨qCat, ?_⟩
-  apply (cogrpPointsMulEquiv H A.unop).injective
-  change cogrpPointsMulEquiv H A.unop (qCat ≫ i) =
-    cogrpPointsMulEquiv H A.unop (g * (q ≫ i) * g⁻¹)
-  dsimp only [i]
-  rw [map_mul, map_mul, map_inv,
-    cogrpPointsMulEquiv_comp_quotientCogrpInclusion,
-    cogrpPointsMulEquiv_comp_quotientCogrpInclusion]
-  have hqCatPoint : cogrpPointsMulEquiv (quotient H I) A.unop qCat = q' := by
-    dsimp only [qCat]
-    exact (cogrpPointsMulEquiv (quotient H I) A.unop).apply_symm_apply q'
-  have hqPoint' : cogrpPointsMulEquiv (quotient H I) A.unop q = qPoint := by
-    exact cogrpPointsMulEquiv_apply (quotient H I) A.unop q
-  have hgPoint : cogrpPointsMulEquiv H A.unop g = gPoint := by
-    exact cogrpPointsMulEquiv_apply H A.unop g
-  rw [hqCatPoint, hqPoint', hgPoint]
-  exact hq'
+  · rintro ⟨n, ⟨q, hq⟩, hn⟩
+    refine ⟨grpObjPointsMulEquiv (quotient H I) X q, ?_⟩
+    calc
+      quotientPointsHom H I X.unop (grpObjPointsMulEquiv (quotient H I) X q) =
+          grpObjPointsMulEquiv H X (q ≫ quotientGrpObjInclusion H I) :=
+        (grpObjPointsMulEquiv_comp_quotientGrpObjInclusion H I X q).symm
+      _ = grpObjPointsMulEquiv H X n := congrArg (grpObjPointsMulEquiv H X) hq
+      _ = p := hn
+  · rintro ⟨q, hq⟩
+    refine ⟨(grpObjPointsMulEquiv H X).symm p, ?_,
+      (grpObjPointsMulEquiv H X).apply_symm_apply p⟩
+    refine ⟨(grpObjPointsMulEquiv (quotient H I) X).symm q, ?_⟩
+    apply (grpObjPointsMulEquiv H X).injective
+    simp only [IsMonHom.monoidHom_apply]
+    rw [grpObjPointsMulEquiv_comp_quotientGrpObjInclusion,
+      (grpObjPointsMulEquiv (quotient H I) X).apply_symm_apply,
+      (grpObjPointsMulEquiv H X).apply_symm_apply, hq]
+
+/-- Pointwise normality of the categorical inclusion is equivalent to normality of the
+corresponding quotient-points subgroup. -/
+private theorem quotientGrpObjInclusion_range_normal_iff
+    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H)
+    (X : (CommAlgCat.{u} R)ᵒᵖ) :
+    (IsMonHom.monoidHom (quotientGrpObjInclusion H I) X).range.Normal ↔
+      (quotientPointsSubgroup H I X.unop).Normal := by
+  let e := grpObjPointsMulEquiv H X
+  have hrange := quotientGrpObjInclusion_range_map H I X
+  constructor
+  · intro h
+    rw [← hrange]
+    exact h.map e.toMonoidHom e.surjective
+  · intro h
+    rw [← hrange] at h
+    exact e.normal_map_iff.mp h
+
+/-- A Hopf ideal is normal if and only if its categorical closed-subgroup inclusion is a normal
+subgroup object in the opposite category of commutative algebras. -/
+theorem quotientGrpObjInclusion_normal_iff (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) :
+    IsMonHom.Normal (quotientGrpObjInclusion H I) ↔ I.IsNormal := by
+  rw [IsMonHom.normal_iff_normal_monoidHom,
+    isNormal_iff_quotientPointsSubgroup_normal]
+  constructor
+  · intro h A
+    exact (quotientGrpObjInclusion_range_normal_iff H I (op A)).mp (h (op A))
+  · intro h X
+    exact (quotientGrpObjInclusion_range_normal_iff H I X).mpr (h X.unop)
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
@@ -65,7 +65,9 @@ private theorem quotientGrpObjInclusion_range_map
     (IsMonHom.monoidHom (quotientGrpObjInclusion H I) X).range.map
         (grpObjPointsMulEquiv H X).toMonoidHom =
       quotientPointsSubgroup H I X.unop := by
-  rw [quotientPointsSubgroup_def, MonoidHom.map_range]
+  -- Expose the range definition locally without adding a duplicate public API theorem.
+  change _ = (quotientPointsHom H I X.unop).hom.range
+  rw [MonoidHom.map_range]
   have hcomp :
       (grpObjPointsMulEquiv H X).toMonoidHom.comp
           (IsMonHom.monoidHom (quotientGrpObjInclusion H I) X) =

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -148,12 +148,6 @@ point-level closed subgroup represented by the quotient coordinate Hopf algebra 
     Subgroup (HopfAlgebra.points (R := R) (H := H) A) :=
   (quotientPointsHom H I A).hom.range
 
-/-- The subgroup cut out by a Hopf ideal is the range of the quotient-points homomorphism. -/
-theorem quotientPointsSubgroup_def (H : _root_.CommHopfAlgCat.{v} R)
-    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
-    quotientPointsSubgroup H I A = (quotientPointsHom H I A).hom.range :=
-  rfl
-
 /-- The points cut out by `I` form a commutative group whenever the quotient coordinate Hopf
 algebra is cocommutative. -/
 noncomputable instance instIsMulCommutativeQuotientPointsSubgroup

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -149,7 +149,7 @@ point-level closed subgroup represented by the quotient coordinate Hopf algebra 
   (quotientPointsHom H I A).hom.range
 
 /-- The subgroup cut out by a Hopf ideal is the range of the quotient-points homomorphism. -/
-theorem quotientPointsSubgroup_eq_range (H : _root_.CommHopfAlgCat.{v} R)
+theorem quotientPointsSubgroup_def (H : _root_.CommHopfAlgCat.{v} R)
     (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
     quotientPointsSubgroup H I A = (quotientPointsHom H I A).hom.range :=
   rfl

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Basic.lean
@@ -148,6 +148,12 @@ point-level closed subgroup represented by the quotient coordinate Hopf algebra 
     Subgroup (HopfAlgebra.points (R := R) (H := H) A) :=
   (quotientPointsHom H I A).hom.range
 
+/-- The subgroup cut out by a Hopf ideal is the range of the quotient-points homomorphism. -/
+theorem quotientPointsSubgroup_eq_range (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
+    quotientPointsSubgroup H I A = (quotientPointsHom H I A).hom.range :=
+  rfl
+
 /-- The points cut out by `I` form a commutative group whenever the quotient coordinate Hopf
 algebra is cocommutative. -/
 noncomputable instance instIsMulCommutativeQuotientPointsSubgroup

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Categorical.lean
@@ -48,12 +48,6 @@ variable {R : Type u} [CommRing R]
     (I : HopfIdeal R H) : grpObj (quotient H I) ⟶ grpObj H :=
   grpObjMap (mkQuotient H I)
 
-/-- The quotient group-object inclusion is represented by the coordinate quotient map. -/
-theorem quotientGrpObjInclusion_def (H : _root_.CommHopfAlgCat.{u} R)
-    (I : HopfIdeal R H) :
-    quotientGrpObjInclusion H I = grpObjMap (mkQuotient H I) :=
-  rfl
-
 /-- The categorical quotient inclusion is the opposite of the coordinate quotient map. -/
 @[simp]
 theorem quotientGrpObjInclusion_unop (H : _root_.CommHopfAlgCat.{u} R)

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Categorical.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
+
+/-!
+# Hopf-ideal quotients as categorical subgroup inclusions
+
+A morphism of commutative Hopf algebras represents a morphism in the opposite category of
+commutative algebras. In particular, the quotient map `H ⟶ H/I` represents the closed-subgroup
+inclusion `Spec(H/I) ⟶ Spec H`. This file supplies that normality-free categorical inclusion,
+its monomorphism and monoid-homomorphism instances, and its action on generalized points.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.quotientGrpObjInclusion`: the categorical closed-subgroup inclusion
+  represented by a Hopf-ideal quotient.
+* `TauCeti.CommHopfAlgCat.quotientGrpObjInclusion_mono`: the inclusion is a monomorphism.
+* `TauCeti.CommHopfAlgCat.quotientGrpObjInclusion_isMonHom`: the inclusion preserves the
+  group-object multiplication.
+
+## References
+
+This is the categorical form of the Layer 3 Hopf-ideal/closed-subgroup dictionary in the
+ReductiveGroups roadmap. It uses Mathlib's `commHopfAlgCatEquivCogrpCommAlgCat` and
+`CategoryTheory.op_mono_of_epi` together with the point-level quotient API in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic`.
+-/
+
+public section
+
+open CategoryTheory Opposite
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u
+
+variable {R : Type u} [CommRing R]
+
+/-- The categorical closed-subgroup inclusion represented contravariantly by the quotient map
+`H ⟶ H/I`. -/
+noncomputable def quotientGrpObjInclusion (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) : grpObj (quotient H I) ⟶ grpObj H :=
+  grpObjMap (mkQuotient H I)
+
+/-- The categorical quotient inclusion is the opposite of the coordinate quotient map. -/
+@[simp]
+theorem quotientGrpObjInclusion_unop (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) :
+    (quotientGrpObjInclusion H I).unop = CommAlgCat.ofHom (mkQuotient H I).hom := by
+  exact grpObjMap_unop (mkQuotient H I)
+
+/-- A quotient group-object inclusion preserves multiplication. -/
+noncomputable instance quotientGrpObjInclusion_isMonHom
+    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) :
+    IsMonHom (quotientGrpObjInclusion H I) := by
+  change IsMonHom (grpObjMap (mkQuotient H I))
+  infer_instance
+
+/-- A quotient group-object inclusion is a monomorphism. -/
+noncomputable instance quotientGrpObjInclusion_mono
+    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) :
+    Mono (quotientGrpObjInclusion H I) := by
+  let q : CommAlgCat.of R H ⟶ CommAlgCat.of R (quotient H I) :=
+    CommAlgCat.ofHom (mkQuotient H I).hom
+  let _ : Epi q := ConcreteCategory.epi_of_surjective q (mkQuotient_surjective H I)
+  apply (unop_epi_iff (quotientGrpObjInclusion H I)).mp
+  rw [quotientGrpObjInclusion_unop]
+  exact ‹Epi q›
+
+/-- Under the group-object point equivalences, composition with the categorical quotient
+inclusion is the usual quotient-points homomorphism. -/
+theorem grpObjPointsMulEquiv_comp_quotientGrpObjInclusion
+    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H)
+    (X : (CommAlgCat.{u} R)ᵒᵖ) (q : X ⟶ grpObj (quotient H I)) :
+    grpObjPointsMulEquiv H X (q ≫ quotientGrpObjInclusion H I) =
+      quotientPointsHom H I X.unop (grpObjPointsMulEquiv (quotient H I) X q) := by
+  exact grpObjPointsMulEquiv_comp_grpObjMap (mkQuotient H I) X q
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Categorical.lean
@@ -5,16 +5,16 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
 
 /-!
 # Hopf-ideal quotients as categorical subgroup inclusions
 
 A morphism of commutative Hopf algebras represents a morphism in the opposite category of
 commutative algebras. In particular, the quotient map `H ⟶ H/I` represents the closed-subgroup
-inclusion `Spec(H/I) ⟶ Spec H`. This file supplies that normality-free categorical inclusion,
-its monomorphism and monoid-homomorphism instances, and its action on generalized points.
+inclusion `Spec(H/I) ⟶ Spec H`. This file supplies that normality-free categorical inclusion
+and its monomorphism and monoid-homomorphism instances.
 
 ## Main declarations
 
@@ -28,8 +28,8 @@ its monomorphism and monoid-homomorphism instances, and its action on generalize
 
 This is the categorical form of the Layer 3 Hopf-ideal/closed-subgroup dictionary in the
 ReductiveGroups roadmap. It uses Mathlib's `commHopfAlgCatEquivCogrpCommAlgCat` and
-`CategoryTheory.op_mono_of_epi` together with the point-level quotient API in
-`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic`.
+`CategoryTheory.op_mono_of_epi` together with the quotient API in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic`.
 -/
 
 public section
@@ -44,9 +44,15 @@ variable {R : Type u} [CommRing R]
 
 /-- The categorical closed-subgroup inclusion represented contravariantly by the quotient map
 `H ⟶ H/I`. -/
-noncomputable def quotientGrpObjInclusion (H : _root_.CommHopfAlgCat.{u} R)
+@[expose] noncomputable def quotientGrpObjInclusion (H : _root_.CommHopfAlgCat.{u} R)
     (I : HopfIdeal R H) : grpObj (quotient H I) ⟶ grpObj H :=
   grpObjMap (mkQuotient H I)
+
+/-- The quotient group-object inclusion is represented by the coordinate quotient map. -/
+theorem quotientGrpObjInclusion_def (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) :
+    quotientGrpObjInclusion H I = grpObjMap (mkQuotient H I) :=
+  rfl
 
 /-- The categorical quotient inclusion is the opposite of the coordinate quotient map. -/
 @[simp]
@@ -59,8 +65,7 @@ theorem quotientGrpObjInclusion_unop (H : _root_.CommHopfAlgCat.{u} R)
 noncomputable instance quotientGrpObjInclusion_isMonHom
     (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) :
     IsMonHom (quotientGrpObjInclusion H I) := by
-  change IsMonHom (grpObjMap (mkQuotient H I))
-  infer_instance
+  exact grpObjMap_isMonHom (mkQuotient H I)
 
 /-- A quotient group-object inclusion is a monomorphism. -/
 noncomputable instance quotientGrpObjInclusion_mono
@@ -72,14 +77,5 @@ noncomputable instance quotientGrpObjInclusion_mono
   apply (unop_epi_iff (quotientGrpObjInclusion H I)).mp
   rw [quotientGrpObjInclusion_unop]
   exact ‹Epi q›
-
-/-- Under the group-object point equivalences, composition with the categorical quotient
-inclusion is the usual quotient-points homomorphism. -/
-theorem grpObjPointsMulEquiv_comp_quotientGrpObjInclusion
-    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H)
-    (X : (CommAlgCat.{u} R)ᵒᵖ) (q : X ⟶ grpObj (quotient H I)) :
-    grpObjPointsMulEquiv H X (q ≫ quotientGrpObjInclusion H I) =
-      quotientPointsHom H I X.unop (grpObjPointsMulEquiv (quotient H I) X q) := by
-  exact grpObjPointsMulEquiv_comp_grpObjMap (mkQuotient H I) X q
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Categorical.lean
@@ -44,21 +44,29 @@ variable {R : Type u} [CommRing R]
 
 /-- The categorical closed-subgroup inclusion represented contravariantly by the quotient map
 `H ⟶ H/I`. -/
-@[expose] noncomputable def quotientGrpObjInclusion (H : _root_.CommHopfAlgCat.{u} R)
+noncomputable def quotientGrpObjInclusion (H : _root_.CommHopfAlgCat.{u} R)
     (I : HopfIdeal R H) : grpObj (quotient H I) ⟶ grpObj H :=
   grpObjMap (mkQuotient H I)
+
+/-- The categorical quotient inclusion is represented by the group-object map induced by the
+coordinate quotient morphism. -/
+theorem quotientGrpObjInclusion_def (H : _root_.CommHopfAlgCat.{u} R)
+    (I : HopfIdeal R H) :
+    quotientGrpObjInclusion H I = grpObjMap (mkQuotient H I) := (rfl)
 
 /-- The categorical quotient inclusion is the opposite of the coordinate quotient map. -/
 @[simp]
 theorem quotientGrpObjInclusion_unop (H : _root_.CommHopfAlgCat.{u} R)
     (I : HopfIdeal R H) :
     (quotientGrpObjInclusion H I).unop = CommAlgCat.ofHom (mkQuotient H I).hom := by
+  rw [quotientGrpObjInclusion_def]
   exact grpObjMap_unop (mkQuotient H I)
 
 /-- A quotient group-object inclusion preserves multiplication. -/
 noncomputable instance quotientGrpObjInclusion_isMonHom
     (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H) :
     IsMonHom (quotientGrpObjInclusion H I) := by
+  rw [quotientGrpObjInclusion_def]
   exact grpObjMap_isMonHom (mkQuotient H I)
 
 /-- A quotient group-object inclusion is a monomorphism. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Yoneda.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Categorical
+
+/-!
+# Generalized points of Hopf-ideal quotient inclusions
+
+This file identifies composition with the categorical closed-subgroup inclusion represented by a
+Hopf-ideal quotient with the usual precomposition map on algebra-valued points.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.grpObjPointsMulEquiv_comp_quotientGrpObjInclusion`: the represented
+  quotient inclusion acts on generalized points by the quotient-points homomorphism.
+
+## References
+
+This is the generalized-point form of the Layer 3 Hopf-ideal/closed-subgroup dictionary in the
+ReductiveGroups roadmap. It combines the represented group-object Yoneda equivalence with the
+point-level quotient API.
+-/
+
+public section
+
+open CategoryTheory Opposite
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u
+
+variable {R : Type u} [CommRing R]
+
+/-- Under the group-object point equivalences, composition with the categorical quotient
+inclusion is the usual quotient-points homomorphism. -/
+@[simp]
+theorem grpObjPointsMulEquiv_comp_quotientGrpObjInclusion
+    (H : _root_.CommHopfAlgCat.{u} R) (I : HopfIdeal R H)
+    (X : (CommAlgCat.{u} R)ᵒᵖ) (q : X ⟶ grpObj (quotient H I)) :
+    grpObjPointsMulEquiv H X (q ≫ quotientGrpObjInclusion H I) =
+      quotientPointsHom H I X.unop (grpObjPointsMulEquiv (quotient H I) X q) := by
+  rw [quotientGrpObjInclusion_def]
+  exact grpObjPointsMulEquiv_comp_grpObjMap (mkQuotient H I) X q
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Yoneda.lean
@@ -45,7 +45,8 @@ theorem grpObjPointsMulEquiv_comp_quotientGrpObjInclusion
     (X : (CommAlgCat.{u} R)ᵒᵖ) (q : X ⟶ grpObj (quotient H I)) :
     grpObjPointsMulEquiv H X (q ≫ quotientGrpObjInclusion H I) =
       quotientPointsHom H I X.unop (grpObjPointsMulEquiv (quotient H I) X q) := by
-  rw [quotientGrpObjInclusion_def]
+  -- Expose the represented inclusion locally without adding a duplicate public API theorem.
+  change grpObjPointsMulEquiv H X (q ≫ grpObjMap (mkQuotient H I)) = _
   exact grpObjPointsMulEquiv_comp_grpObjMap (mkQuotient H I) X q
 
 end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Yoneda.lean
@@ -45,8 +45,7 @@ theorem grpObjPointsMulEquiv_comp_quotientGrpObjInclusion
     (X : (CommAlgCat.{u} R)ᵒᵖ) (q : X ⟶ grpObj (quotient H I)) :
     grpObjPointsMulEquiv H X (q ≫ quotientGrpObjInclusion H I) =
       quotientPointsHom H I X.unop (grpObjPointsMulEquiv (quotient H I) X q) := by
-  -- Expose the represented inclusion locally without adding a duplicate public API theorem.
-  change grpObjPointsMulEquiv H X (q ≫ grpObjMap (mkQuotient H I)) = _
+  rw [quotientGrpObjInclusion_def]
   exact grpObjPointsMulEquiv_comp_grpObjMap (mkQuotient H I) X q
 
 end TauCeti.CommHopfAlgCat


### PR DESCRIPTION
This PR identifies algebra-valued generalized points of the cogroup represented by a commutative Hopf algebra with its convolution-point group, proves compatibility with Hopf-ideal quotient inclusions, and proves that the quotient inclusion attached to a normal Hopf ideal is a normal subgroup object in Mathlib's `IsMonHom.Normal` sense.

This advances the ReductiveGroups Layer 5 milestone “The unipotent radical `R_u(G)`” at its next explicit target, binary-product closure for connected normal smooth unipotent subgroup candidates. The dependency edge is: the candidate-product construction consumes categorical normality of each quotient inclusion to instantiate the normal-conjugation action and internal semidirect product whose multiplication image represents the subgroup product. After this PR, constructing that multiplication image and proving it connected, smooth, and unipotent remain; the unipotence step still needs the documented theorem that an affine-group homomorphism is faithfully flat onto its scheme-theoretic image.

The implementation reuses Mathlib's commutative-Hopf-algebra/cogroup equivalence and categorical normality criterion, together with Tau Ceti's normality theorem for quotient-point subgroups. It introduces no vendored infrastructure.

Validation completed with the targeted module build, the changed-declaration axiom audit, and the changed-module environment linter.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"normal-hopf-ideal-categorical-subgroup"}-->

🤖 Prepared with Codex
