### PR TITLE
feat: classify covering spaces by fundamental-group sets

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/FundamentalGroupAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/FundamentalGroupAction.lean
@@ -1,0 +1,274 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.Action.Concrete
+public import Mathlib.CategoryTheory.Whiskering
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.MonodromyEquivalence
+public import TauCeti.CategoryTheory.Groupoid.SingleObj
+public import TauCeti.Topology.Homotopy.Monodromy.Basic
+
+/-!
+# Covering spaces are classified by fundamental-group sets
+
+Let `X` be path connected, locally path connected and semilocally simply connected, and fix a
+basepoint `x₀`. This file proves that taking the fibre over `x₀` with its monodromy action is an
+equivalence of categories
+
+  `TauCeti.CoveringSpace.fiberActionEquivalence :`
+  `  CoveringSpace X ≌ Action (Type u) (FundamentalGroup X x₀)`,
+
+that is, covering spaces of `X` are the same thing as sets with an action of `π₁(X, x₀)`. It
+restricts to an equivalence
+
+  `TauCeti.ConnectedCoveringSpace.transitiveFiberActionEquivalence :`
+  `  ConnectedCoveringSpace X ≌ TransitiveAction (FundamentalGroup X x₀)`
+
+between *connected* covers and *transitive* `π₁(X, x₀)`-sets.
+
+This is the basepoint-based form of the classification. The basepoint-free form is already
+available: `TauCeti.CoveringSpace.monodromyEquivalence` identifies covering spaces with functors
+out of the fundamental groupoid. Passing from one to the other is pure category theory, and it
+is where the hypotheses on `X` are spent a second time: path connectedness makes the fundamental
+groupoid connected, and a connected groupoid is equivalent to the one-object category of its
+vertex group by `TauCeti.Groupoid.singleObjEquivalence`. Precomposing a fundamental-groupoid
+action with that equivalence, and reading a functor out of a one-object category as an action
+through Mathlib's `CategoryTheory.Action.functorCategoryEquivalence`, gives the statement above.
+
+No `ᵐᵒᵖ` intervenes. The vertex group of the fundamental groupoid at `x₀` *is* `π₁(X, x₀)`, since
+Mathlib defines the latter as `End (FundamentalGroupoid.mk x₀)`, and the composition convention
+of `CategoryTheory.SingleObj` is the one that matches `CategoryTheory.End`. The `ᵐᵒᵖ` in
+`TauCeti.UniversalCover.deckFundamentalGroupEquiv` comes from comparing monodromy with *deck
+transformations*, which is a different comparison and is unaffected.
+
+The action recovered here is the monodromy action of `Mathlib/Topology/Homotopy/Lifting.lean`:
+`fiberActionFunctor_obj_ρ_apply` and `fiberActionFunctor_obj_mulAction` record that the
+categorical action on the fibre is `IsCoveringMap.fundamentalGroupMulAction`, and
+`fiberActionFunctor_map_hom` records that a map of covers acts on fibres by restriction.
+
+## Main declarations
+
+* `TauCeti.CoveringSpace.fiberActionFunctor`: the functor sending a covering space to the fibre
+  over `x₀` with its monodromy action of `π₁(X, x₀)`.
+* `TauCeti.CoveringSpace.fiberActionFunctor_obj_V`,
+  `TauCeti.CoveringSpace.fiberActionFunctor_obj_ρ_apply`,
+  `TauCeti.CoveringSpace.fiberActionFunctor_obj_mulAction` and
+  `TauCeti.CoveringSpace.fiberActionFunctor_map_hom_apply_coe`: its values.
+* `TauCeti.CoveringSpace.fiberActionEquivalence`: **covering spaces of `X` are equivalent to
+  `π₁(X, x₀)`-sets.**
+* `TauCeti.CoveringSpace.isPretransitive_fiberAction`: the action attached to a connected cover
+  is transitive.
+
+## References
+
+This is the `π₁(X)`-set form of the alternative lens on Stage 2, item 8 of
+`TauCetiRoadmap/UniversalCovers/README.md`, which asks to "phrase the classification of
+connected covers via transitive `π₁(X)`-sets / the monodromy functor, with disconnected covers
+as functors out of the fundamental groupoid"; see Hatcher, *Algebraic Topology*, Section 1.3. It
+consumes the fundamental-groupoid classification of
+`TauCeti.AlgebraicTopology.UniversalCover.Classification.MonodromyEquivalence`, the
+stabiliser-cover reconstruction of
+`TauCeti.AlgebraicTopology.UniversalCover.Classification.Reconstruction`, and Mathlib's
+`CategoryTheory.Action.functorCategoryEquivalence`; no Mathlib proof is vendored.
+-/
+
+public section
+noncomputable section
+
+open CategoryTheory Topology
+
+universe u
+
+namespace TauCeti.CoveringSpace
+
+variable {X : TopCat.{u}} (x₀ : X)
+
+/-- The functor taking a covering space of `X` to the fibre over `x₀`, equipped with the
+monodromy action of `π₁(X, x₀)`.
+
+It is assembled from the monodromy functor by restricting a fundamental-groupoid action along
+the vertex-group inclusion `TauCeti.Groupoid.singleObjFunctor` and reading the result as an
+action. It is `@[expose]`d so that its values hold by `rfl` in downstream modules. -/
+@[expose] def fiberActionFunctor :
+    CoveringSpace X ⥤ Action (Type u) (FundamentalGroup X x₀) :=
+  monodromyFunctor X ⋙
+    (Functor.whiskeringLeft _ _ _).obj (Groupoid.singleObjFunctor (FundamentalGroupoid.mk x₀)) ⋙
+      Action.FunctorCategoryEquivalence.inverse
+
+/-- The underlying set of the fundamental-group set attached to a cover is the fibre over the
+basepoint. -/
+theorem fiberActionFunctor_obj_V (p : CoveringSpace X) :
+    ((fiberActionFunctor x₀).obj p).V = ↥(⇑p.proj ⁻¹' {x₀}) :=
+  (rfl)
+
+/-- A loop class acts on the fibre over the basepoint by monodromy. -/
+@[simp]
+theorem fiberActionFunctor_obj_ρ_apply (p : CoveringSpace X) (g : FundamentalGroup X x₀)
+    (e : ⇑p.proj ⁻¹' {x₀}) :
+    ((fiberActionFunctor x₀).obj p).ρ g e = p.isCoveringMap_proj.monodromy g e :=
+  (rfl)
+
+/-- The `MulAction` carried by the fundamental-group set attached to a cover is Mathlib's
+monodromy action on the fibre. -/
+theorem fiberActionFunctor_obj_mulAction (p : CoveringSpace X) :
+    Action.instMulAction ((fiberActionFunctor x₀).obj p) =
+      p.isCoveringMap_proj.fundamentalGroupMulAction x₀ :=
+  (rfl)
+
+/-- A map of covering spaces acts on the fibre over the basepoint by restriction. -/
+@[simp]
+theorem fiberActionFunctor_map_hom {p q : CoveringSpace X} (f : p ⟶ q) :
+    ((fiberActionFunctor x₀).map f).hom =
+      ↾(IsCoveringMap.fiberMap f.hom.left.hom (proj_hom_comp_hom_left_hom f) x₀) :=
+  IsCoveringMap.monodromyNatTrans_app p.isCoveringMap_proj q.isCoveringMap_proj
+    f.hom.left.hom (proj_hom_comp_hom_left_hom f) x₀
+
+section LocallyPathConnected
+
+variable [LocallyPathConnectedSpace X]
+
+/-- The monodromy action attached to a connected covering space is transitive on the fibre over
+the basepoint. -/
+theorem isPretransitive_fiberAction (p : ConnectedCoveringSpace X) :
+    letI := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
+    MulAction.IsPretransitive (FundamentalGroup X x₀) (⇑p.proj ⁻¹' {x₀}) := by
+  let := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
+  have h := ConnectedCoveringSpace.monodromy_isFiberwisePretransitive p
+  rw [FundamentalGroupoidAction.isFiberwisePretransitive_iff] at h
+  exact ⟨fun e e' => h (FundamentalGroupoid.mk x₀) e e'⟩
+
+end LocallyPathConnected
+
+section Classification
+
+variable [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+/-- The fibre-action functor is an equivalence: it is the composite of the monodromy equivalence,
+restriction along the connected groupoid's vertex-group inclusion, and Mathlib's identification
+of functors out of a one-object category with actions. -/
+instance fiberActionFunctor_isEquivalence : (fiberActionFunctor x₀).IsEquivalence := by
+  have := Groupoid.isEquivalence_singleObjFunctor (C := FundamentalGroupoid X)
+    (FundamentalGroupoid.mk x₀) (FundamentalGroupoid.nonempty_hom _)
+  unfold fiberActionFunctor
+  infer_instance
+
+/-- **Covering spaces of `X` are equivalent to `π₁(X, x₀)`-sets.**
+
+Over a path-connected, locally path-connected, semilocally simply connected base, taking the
+fibre over `x₀` with its monodromy action is an equivalence of categories. -/
+def fiberActionEquivalence : CoveringSpace X ≌ Action (Type u) (FundamentalGroup X x₀) :=
+  (fiberActionFunctor x₀).asEquivalence
+
+@[simp]
+theorem fiberActionEquivalence_functor :
+    (fiberActionEquivalence x₀).functor = fiberActionFunctor x₀ :=
+  (rfl)
+
+end Classification
+
+end TauCeti.CoveringSpace
+
+namespace TauCeti
+
+variable (G : Type u) [Monoid G]
+
+/-- A `G`-set is *transitive* when it is nonempty and `G` acts transitively on it.
+
+The action used is the one `CategoryTheory.Action.instMulAction` puts on the underlying type
+`ToType A`, so the two conjuncts are read through that instance rather than through `A.ρ`. -/
+def isTransitiveAction : ObjectProperty (Action (Type u) G) :=
+  fun A => MulAction.IsPretransitive G (ToType A) ∧ Nonempty (ToType A)
+
+instance : (isTransitiveAction G).IsClosedUnderIsomorphisms where
+  of_iso {A B} e h := by
+    obtain ⟨htrans, ⟨a⟩⟩ := h
+    refine ⟨⟨fun x y => ?_⟩, ⟨e.hom.hom a⟩⟩
+    -- Transport the two points back along `e`, move them there, and push the result forward.
+    obtain ⟨g, hg⟩ := htrans.exists_smul_eq (e.inv.hom x) (e.inv.hom y)
+    refine ⟨g, ?_⟩
+    have hcomm := ConcreteCategory.congr_hom (e.hom.comm g) (ConcreteCategory.hom e.inv.hom x)
+    have hx (z : ToType B) :
+        ConcreteCategory.hom e.hom.hom (ConcreteCategory.hom e.inv.hom z) = z :=
+      Iso.inv_hom_id_apply ((Action.forget (Type u) G).mapIso e) z
+    simp only [ConcreteCategory.comp_apply] at hcomm
+    have key := congrArg (ConcreteCategory.hom e.hom.hom) hg
+    simp only [show ∀ z : ToType A, g • z = ConcreteCategory.hom (A.ρ g) z from fun _ => rfl,
+      hcomm, hx] at key
+    exact key
+
+/-- Transitive `G`-sets, as a full subcategory of all `G`-sets. -/
+abbrev TransitiveAction : Type _ := (isTransitiveAction G).FullSubcategory
+
+namespace ConnectedCoveringSpace
+
+variable {X : TopCat.{u}} (x₀ : X) [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+omit [SemilocallySimplyConnectedSpace X] in
+/-- The fundamental-group set attached to a connected covering space is transitive. -/
+theorem isTransitiveAction_fiberAction (p : ConnectedCoveringSpace X) :
+    isTransitiveAction (FundamentalGroup X x₀)
+      ((CoveringSpace.fiberActionFunctor x₀).obj ((forget X).obj p)) :=
+  ⟨CoveringSpace.isPretransitive_fiberAction x₀ p, nonempty_fiber p x₀⟩
+
+/-- The fibre-action functor restricted to connected covering spaces and transitive
+fundamental-group sets. -/
+def transitiveFiberActionFunctor :
+    ConnectedCoveringSpace X ⥤ TransitiveAction (FundamentalGroup X x₀) :=
+  ObjectProperty.lift _ (forget X ⋙ CoveringSpace.fiberActionFunctor x₀)
+    (isTransitiveAction_fiberAction x₀)
+
+omit [SemilocallySimplyConnectedSpace X] in
+/-- The underlying fundamental-group set of a connected cover is the one attached to it as a
+cover. -/
+theorem transitiveFiberActionFunctor_obj_obj (p : ConnectedCoveringSpace X) :
+    ((transitiveFiberActionFunctor x₀).obj p).obj =
+      (CoveringSpace.fiberActionFunctor x₀).obj ((forget X).obj p) :=
+  (rfl)
+
+instance transitiveFiberActionFunctor_faithful :
+    (transitiveFiberActionFunctor x₀).Faithful :=
+  inferInstanceAs <| (ObjectProperty.lift _ _ _).Faithful
+
+instance transitiveFiberActionFunctor_full : (transitiveFiberActionFunctor x₀).Full :=
+  inferInstanceAs <| (ObjectProperty.lift _ _ _).Full
+
+/-- **Every transitive `π₁(X, x₀)`-set is the fibre action of a connected cover.** The cover is
+the quotient of the universal cover by the stabiliser of a point of the set. -/
+theorem exists_fiberAction_iso (A : Action (Type u) (FundamentalGroup X x₀))
+    (hA : isTransitiveAction (FundamentalGroup X x₀) A) :
+    ∃ p : ConnectedCoveringSpace X,
+      Nonempty ((CoveringSpace.fiberActionFunctor x₀).obj ((forget X).obj p) ≅ A) := by
+  obtain ⟨htrans, ⟨a⟩⟩ := hA
+  refine ⟨UniversalCover.stabilizerCover x₀ a, ⟨Action.mkIso
+    (Equiv.toIso (UniversalCover.transitiveActionFiberEquiv x₀ a)) fun g => ?_⟩⟩
+  refine ConcreteCategory.hom_ext _ _ fun e => ?_
+  simp only [types_comp_apply]
+  exact UniversalCover.transitiveActionFiberEquiv_apply_monodromy x₀ a g e
+
+instance transitiveFiberActionFunctor_essSurj :
+    (transitiveFiberActionFunctor x₀).EssSurj where
+  mem_essImage A := by
+    obtain ⟨p, ⟨e⟩⟩ := exists_fiberAction_iso x₀ A.obj A.property
+    exact ⟨p, ⟨ObjectProperty.isoMk _ e⟩⟩
+
+instance transitiveFiberActionFunctor_isEquivalence :
+    (transitiveFiberActionFunctor x₀).IsEquivalence where
+
+/-- **Connected covering spaces of `X` are equivalent to transitive `π₁(X, x₀)`-sets.** -/
+def transitiveFiberActionEquivalence :
+    ConnectedCoveringSpace X ≌ TransitiveAction (FundamentalGroup X x₀) :=
+  (transitiveFiberActionFunctor x₀).asEquivalence
+
+@[simp]
+theorem transitiveFiberActionEquivalence_functor :
+    (transitiveFiberActionEquivalence x₀).functor = transitiveFiberActionFunctor x₀ :=
+  (rfl)
+
+end ConnectedCoveringSpace
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/FundamentalGroupAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/FundamentalGroupAction.lean
@@ -226,7 +226,13 @@ theorem exists_fiberAction_iso (A : Action (Type u) (FundamentalGroup X x₀))
   refine ⟨UniversalCover.stabilizerCover x₀ a, ⟨Action.mkIso
     (Equiv.toIso (UniversalCover.transitiveActionFiberEquiv x₀ a)) fun g => ?_⟩⟩
   refine ConcreteCategory.hom_ext _ _ fun e => ?_
-  simp only [types_comp_apply]
+  -- The cover has to be spelled out for the rewrite: the type of `e` mentions it only under the
+  -- unfolding of `fiberActionFunctor`, so unification cannot read it off.
+  rw [types_comp_apply, types_comp_apply, CoveringSpace.fiberActionFunctor_obj_ρ_apply x₀
+    ((forget X).obj (UniversalCover.stabilizerCover x₀ a)) g e, ← smul_eq_ρ_apply A g]
+  -- The one step left is `Equiv.toIso_hom_hom_apply`, which `rw` refuses here: the type of `e`
+  -- is the `.V` projection rather than the fibre itself, so the rewritten target is not
+  -- type-correct at `implicit` transparency.
   exact UniversalCover.transitiveActionFiberEquiv_apply_monodromy x₀ a g e
 
 instance transitiveFiberActionFunctor_essSurj :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/FundamentalGroupAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/FundamentalGroupAction.lean
@@ -8,8 +8,8 @@ module
 public import Mathlib.CategoryTheory.Action.Concrete
 public import Mathlib.CategoryTheory.Whiskering
 public import TauCeti.AlgebraicTopology.UniversalCover.Classification.MonodromyEquivalence
+public import TauCeti.CategoryTheory.Action.Transitive
 public import TauCeti.CategoryTheory.Groupoid.SingleObj
-public import TauCeti.Topology.Homotopy.Monodromy.Basic
 
 /-!
 # Covering spaces are classified by fundamental-group sets
@@ -56,11 +56,18 @@ categorical action on the fibre is `IsCoveringMap.fundamentalGroupMulAction`, an
 * `TauCeti.CoveringSpace.fiberActionFunctor_obj_V`,
   `TauCeti.CoveringSpace.fiberActionFunctor_obj_ρ_apply`,
   `TauCeti.CoveringSpace.fiberActionFunctor_obj_mulAction` and
-  `TauCeti.CoveringSpace.fiberActionFunctor_map_hom_apply_coe`: its values.
+  `TauCeti.CoveringSpace.fiberActionFunctor_map_hom`: its values.
 * `TauCeti.CoveringSpace.fiberActionEquivalence`: **covering spaces of `X` are equivalent to
   `π₁(X, x₀)`-sets.**
-* `TauCeti.CoveringSpace.isPretransitive_fiberAction`: the action attached to a connected cover
-  is transitive.
+* `TauCeti.ConnectedCoveringSpace.isTransitiveAction_fiberAction`: the `π₁(X, x₀)`-set attached to a
+  connected cover is transitive, so the fibre-action functor restricts to a functor
+  `TauCeti.ConnectedCoveringSpace.transitiveFiberActionFunctor` into
+  `TauCeti.TransitiveAction (FundamentalGroup X x₀)`, with values given by
+  `transitiveFiberActionFunctor_obj_obj` and `transitiveFiberActionFunctor_map_hom`.
+* `TauCeti.ConnectedCoveringSpace.exists_fiberAction_iso`: every transitive `π₁(X, x₀)`-set is
+  the fibre action of a connected cover.
+* `TauCeti.ConnectedCoveringSpace.transitiveFiberActionEquivalence`: **connected covering spaces
+  of `X` are equivalent to transitive `π₁(X, x₀)`-sets.**
 
 ## References
 
@@ -71,7 +78,9 @@ as functors out of the fundamental groupoid"; see Hatcher, *Algebraic Topology*,
 consumes the fundamental-groupoid classification of
 `TauCeti.AlgebraicTopology.UniversalCover.Classification.MonodromyEquivalence`, the
 stabiliser-cover reconstruction of
-`TauCeti.AlgebraicTopology.UniversalCover.Classification.Reconstruction`, and Mathlib's
+`TauCeti.AlgebraicTopology.UniversalCover.Classification.Reconstruction`, which rests on the
+based-path universal cover adapted from Kim Morrison's
+[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292), and Mathlib's
 `CategoryTheory.Action.functorCategoryEquivalence`; no Mathlib proof is vendored.
 -/
 
@@ -100,6 +109,7 @@ action. It is `@[expose]`d so that its values hold by `rfl` in downstream module
 
 /-- The underlying set of the fundamental-group set attached to a cover is the fibre over the
 basepoint. -/
+@[simp]
 theorem fiberActionFunctor_obj_V (p : CoveringSpace X) :
     ((fiberActionFunctor x₀).obj p).V = ↥(⇑p.proj ⁻¹' {x₀}) :=
   (rfl)
@@ -125,22 +135,6 @@ theorem fiberActionFunctor_map_hom {p q : CoveringSpace X} (f : p ⟶ q) :
       ↾(IsCoveringMap.fiberMap f.hom.left.hom (proj_hom_comp_hom_left_hom f) x₀) :=
   IsCoveringMap.monodromyNatTrans_app p.isCoveringMap_proj q.isCoveringMap_proj
     f.hom.left.hom (proj_hom_comp_hom_left_hom f) x₀
-
-section LocallyPathConnected
-
-variable [LocallyPathConnectedSpace X]
-
-/-- The monodromy action attached to a connected covering space is transitive on the fibre over
-the basepoint. -/
-theorem isPretransitive_fiberAction (p : ConnectedCoveringSpace X) :
-    letI := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
-    MulAction.IsPretransitive (FundamentalGroup X x₀) (⇑p.proj ⁻¹' {x₀}) := by
-  let := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
-  have h := ConnectedCoveringSpace.monodromy_isFiberwisePretransitive p
-  rw [FundamentalGroupoidAction.isFiberwisePretransitive_iff] at h
-  exact ⟨fun e e' => h (FundamentalGroupoid.mk x₀) e e'⟩
-
-end LocallyPathConnected
 
 section Classification
 
@@ -172,38 +166,7 @@ end Classification
 
 end TauCeti.CoveringSpace
 
-namespace TauCeti
-
-variable (G : Type u) [Monoid G]
-
-/-- A `G`-set is *transitive* when it is nonempty and `G` acts transitively on it.
-
-The action used is the one `CategoryTheory.Action.instMulAction` puts on the underlying type
-`ToType A`, so the two conjuncts are read through that instance rather than through `A.ρ`. -/
-def isTransitiveAction : ObjectProperty (Action (Type u) G) :=
-  fun A => MulAction.IsPretransitive G (ToType A) ∧ Nonempty (ToType A)
-
-instance : (isTransitiveAction G).IsClosedUnderIsomorphisms where
-  of_iso {A B} e h := by
-    obtain ⟨htrans, ⟨a⟩⟩ := h
-    refine ⟨⟨fun x y => ?_⟩, ⟨e.hom.hom a⟩⟩
-    -- Transport the two points back along `e`, move them there, and push the result forward.
-    obtain ⟨g, hg⟩ := htrans.exists_smul_eq (e.inv.hom x) (e.inv.hom y)
-    refine ⟨g, ?_⟩
-    have hcomm := ConcreteCategory.congr_hom (e.hom.comm g) (ConcreteCategory.hom e.inv.hom x)
-    have hx (z : ToType B) :
-        ConcreteCategory.hom e.hom.hom (ConcreteCategory.hom e.inv.hom z) = z :=
-      Iso.inv_hom_id_apply ((Action.forget (Type u) G).mapIso e) z
-    simp only [ConcreteCategory.comp_apply] at hcomm
-    have key := congrArg (ConcreteCategory.hom e.hom.hom) hg
-    simp only [show ∀ z : ToType A, g • z = ConcreteCategory.hom (A.ρ g) z from fun _ => rfl,
-      hcomm, hx] at key
-    exact key
-
-/-- Transitive `G`-sets, as a full subcategory of all `G`-sets. -/
-abbrev TransitiveAction : Type _ := (isTransitiveAction G).FullSubcategory
-
-namespace ConnectedCoveringSpace
+namespace TauCeti.ConnectedCoveringSpace
 
 variable {X : TopCat.{u}} (x₀ : X) [PathConnectedSpace X] [LocallyPathConnectedSpace X]
   [SemilocallySimplyConnectedSpace X]
@@ -213,7 +176,7 @@ omit [SemilocallySimplyConnectedSpace X] in
 theorem isTransitiveAction_fiberAction (p : ConnectedCoveringSpace X) :
     isTransitiveAction (FundamentalGroup X x₀)
       ((CoveringSpace.fiberActionFunctor x₀).obj ((forget X).obj p)) :=
-  ⟨CoveringSpace.isPretransitive_fiberAction x₀ p, nonempty_fiber p x₀⟩
+  (isTransitiveAction_iff _).mpr ⟨isPretransitive_fiberAction p x₀, nonempty_fiber p x₀⟩
 
 /-- The fibre-action functor restricted to connected covering spaces and transitive
 fundamental-group sets. -/
@@ -225,10 +188,26 @@ def transitiveFiberActionFunctor :
 omit [SemilocallySimplyConnectedSpace X] in
 /-- The underlying fundamental-group set of a connected cover is the one attached to it as a
 cover. -/
+@[simp]
 theorem transitiveFiberActionFunctor_obj_obj (p : ConnectedCoveringSpace X) :
     ((transitiveFiberActionFunctor x₀).obj p).obj =
       (CoveringSpace.fiberActionFunctor x₀).obj ((forget X).obj p) :=
   (rfl)
+
+omit [SemilocallySimplyConnectedSpace X] in
+/-- The underlying map of fundamental-group sets assigned to a map of connected covers is the one
+assigned to it as a map of covers, hence restriction to the fibres over `x₀`. -/
+@[simp]
+theorem transitiveFiberActionFunctor_map_hom {p q : ConnectedCoveringSpace X} (f : p ⟶ q) :
+    ((transitiveFiberActionFunctor x₀).map f).hom =
+      eqToHom (transitiveFiberActionFunctor_obj_obj x₀ p) ≫
+        (CoveringSpace.fiberActionFunctor x₀).map ((forget X).map f) ≫
+        eqToHom (transitiveFiberActionFunctor_obj_obj x₀ q).symm :=
+  by
+    convert ObjectProperty.ι_obj_lift_map (isTransitiveAction (FundamentalGroup X x₀))
+        (forget X ⋙ CoveringSpace.fiberActionFunctor x₀) (isTransitiveAction_fiberAction x₀) f
+      using 1 <;>
+      rfl
 
 instance transitiveFiberActionFunctor_faithful :
     (transitiveFiberActionFunctor x₀).Faithful :=
@@ -243,7 +222,7 @@ theorem exists_fiberAction_iso (A : Action (Type u) (FundamentalGroup X x₀))
     (hA : isTransitiveAction (FundamentalGroup X x₀) A) :
     ∃ p : ConnectedCoveringSpace X,
       Nonempty ((CoveringSpace.fiberActionFunctor x₀).obj ((forget X).obj p) ≅ A) := by
-  obtain ⟨htrans, ⟨a⟩⟩ := hA
+  obtain ⟨htrans, ⟨a⟩⟩ := (isTransitiveAction_iff A).mp hA
   refine ⟨UniversalCover.stabilizerCover x₀ a, ⟨Action.mkIso
     (Equiv.toIso (UniversalCover.transitiveActionFiberEquiv x₀ a)) fun g => ?_⟩⟩
   refine ConcreteCategory.hom_ext _ _ fun e => ?_
@@ -253,7 +232,7 @@ theorem exists_fiberAction_iso (A : Action (Type u) (FundamentalGroup X x₀))
 instance transitiveFiberActionFunctor_essSurj :
     (transitiveFiberActionFunctor x₀).EssSurj where
   mem_essImage A := by
-    obtain ⟨p, ⟨e⟩⟩ := exists_fiberAction_iso x₀ A.obj A.property
+    obtain ⟨p, ⟨e⟩⟩ := exists_fiberAction_iso x₀ A.obj (TransitiveAction.isTransitiveAction A)
     exact ⟨p, ⟨ObjectProperty.isoMk _ e⟩⟩
 
 instance transitiveFiberActionFunctor_isEquivalence :
@@ -269,6 +248,4 @@ theorem transitiveFiberActionEquivalence_functor :
     (transitiveFiberActionEquivalence x₀).functor = transitiveFiberActionFunctor x₀ :=
   (rfl)
 
-end ConnectedCoveringSpace
-
-end TauCeti
+end TauCeti.ConnectedCoveringSpace

--- a/TauCeti/CategoryTheory/Action/Transitive.lean
+++ b/TauCeti/CategoryTheory/Action/Transitive.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.Action.Concrete
+public import Mathlib.GroupTheory.GroupAction.Transitive
+
+/-!
+# Transitive `G`-sets
+
+A `G`-set, in the categorical sense of an object of `Action (Type u) G`, is *transitive* when it
+is nonempty and `G` acts transitively on its underlying type. This file records that condition as
+an `ObjectProperty`, shows it is closed under isomorphisms, and names the resulting full
+subcategory.
+
+The action referred to is the one `Action.instMulAction` puts on the underlying type `ToType A`,
+so both conjuncts are read through that instance rather than through `A.ρ`.
+Following Mathlib's convention, `MulAction.IsPretransitive` allows the empty set, so nonemptiness
+is a genuine extra condition and is imposed separately.
+
+The property is named `TauCeti.isTransitiveAction` rather than being placed in a
+`TauCeti.Action` namespace: `Action` is a Mathlib type, and `scripts/lint-dot-notation.py`
+rejects a Mathlib type's namespace nested inside `namespace TauCeti`, because dot notation on
+that type then fails to elaborate.
+
+## Main declarations
+
+* `TauCeti.isTransitiveAction`: the property of being a transitive `G`-set.
+* `TauCeti.isTransitiveAction_iff`: its two conjuncts.
+* `TauCeti.TransitiveAction`: transitive `G`-sets as a full subcategory of all `G`-sets, with
+  `TauCeti.TransitiveAction.mk`, `TauCeti.TransitiveAction.forget`,
+  `TauCeti.TransitiveAction.isTransitiveAction` and
+  `TauCeti.TransitiveAction.fullyFaithfulForget`.
+-/
+
+public section
+
+open CategoryTheory
+
+universe u v
+
+namespace TauCeti
+
+variable (G : Type v) [Monoid G]
+
+/-- A `G`-set is *transitive* when `G` acts pretransitively on it and it is nonempty. -/
+def isTransitiveAction : ObjectProperty (Action (Type u) G) :=
+  fun A => MulAction.IsPretransitive G (ToType A) ∧ Nonempty (ToType A)
+
+/-- Transitivity of a `G`-set is preserved by isomorphisms of `G`-sets: an isomorphism is an
+equivariant bijection on underlying types. -/
+instance : (isTransitiveAction G).IsClosedUnderIsomorphisms where
+  of_iso {A B} e h :=
+    ⟨h.1.of_surjective_map
+        (f := (⟨ConcreteCategory.hom e.hom.hom, fun g x =>
+          ConcreteCategory.congr_hom (e.hom.comm g) x⟩ :
+            MulActionHom (id : G → G) (ToType A) (ToType B)))
+        ((Action.forget _ G).mapIso e).toEquiv.surjective,
+      ⟨ConcreteCategory.hom e.hom.hom h.2.some⟩⟩
+
+variable {G}
+
+/-- Membership in the transitivity property of `G`-sets. -/
+@[simp]
+theorem isTransitiveAction_iff (A : Action (Type u) G) :
+    isTransitiveAction G A ↔ MulAction.IsPretransitive G (ToType A) ∧ Nonempty (ToType A) :=
+  Iff.rfl
+
+variable (G)
+
+/-- Transitive `G`-sets, as a full subcategory of all `G`-sets. -/
+abbrev TransitiveAction : Type _ :=
+  (isTransitiveAction G).FullSubcategory
+
+namespace TransitiveAction
+
+/-- The fully faithful inclusion of transitive `G`-sets into all `G`-sets. -/
+abbrev forget : TransitiveAction G ⥤ Action (Type u) G :=
+  ObjectProperty.ι _
+
+/-- The inclusion of transitive `G`-sets into all `G`-sets is fully faithful. -/
+def fullyFaithfulForget : (forget G).FullyFaithful :=
+  ObjectProperty.fullyFaithfulι _
+
+variable {G}
+
+/-- Construct a transitive `G`-set from a `G`-set and a proof of transitivity. -/
+def mk (A : Action (Type u) G) (hA : isTransitiveAction G A) : TransitiveAction G :=
+  ⟨A, hA⟩
+
+/-- The underlying `G`-set of a transitive `G`-set is transitive. -/
+theorem isTransitiveAction (A : TransitiveAction G) : TauCeti.isTransitiveAction G A.obj :=
+  A.property
+
+end TransitiveAction
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Action/Transitive.lean
+++ b/TauCeti/CategoryTheory/Action/Transitive.lean
@@ -30,6 +30,8 @@ that type then fails to elaborate.
 
 * `TauCeti.isTransitiveAction`: the property of being a transitive `G`-set.
 * `TauCeti.isTransitiveAction_iff`: its two conjuncts.
+* `TauCeti.smul_eq_ρ_apply`: the scalar multiplication both conjuncts refer to is evaluation of
+  the representation.
 * `TauCeti.TransitiveAction`: transitive `G`-sets as a full subcategory of all `G`-sets, with
   `TauCeti.TransitiveAction.mk`, `TauCeti.TransitiveAction.forget`,
   `TauCeti.TransitiveAction.isTransitiveAction` and
@@ -50,13 +52,22 @@ variable (G : Type v) [Monoid G]
 def isTransitiveAction : ObjectProperty (Action (Type u) G) :=
   fun A => MulAction.IsPretransitive G (ToType A) ∧ Nonempty (ToType A)
 
+variable {G}
+
+/-- The scalar multiplication that `Action.instMulAction` puts on the underlying type of a `G`-set
+is evaluation of its representation. -/
+theorem smul_eq_ρ_apply (A : Action (Type u) G) (g : G) (x : ToType A) : g • x = A.ρ g x :=
+  rfl
+
+variable (G)
+
 /-- Transitivity of a `G`-set is preserved by isomorphisms of `G`-sets: an isomorphism is an
 equivariant bijection on underlying types. -/
 instance : (isTransitiveAction G).IsClosedUnderIsomorphisms where
   of_iso {A B} e h :=
     ⟨h.1.of_surjective_map
-        (f := (⟨ConcreteCategory.hom e.hom.hom, fun g x =>
-          ConcreteCategory.congr_hom (e.hom.comm g) x⟩ :
+        (f := (⟨ConcreteCategory.hom e.hom.hom, fun g x => by
+          simp only [id_eq, smul_eq_ρ_apply, ← types_comp_apply, e.hom.comm]⟩ :
             MulActionHom (id : G → G) (ToType A) (ToType B)))
         ((Action.forget _ G).mapIso e).toEquiv.surjective,
       ⟨ConcreteCategory.hom e.hom.hom h.2.some⟩⟩

--- a/TauCeti/CategoryTheory/Groupoid/ConnectedFunctor.lean
+++ b/TauCeti/CategoryTheory/Groupoid/ConnectedFunctor.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.CategoryTheory.Groupoid.SingleObj
+public import Mathlib.CategoryTheory.Groupoid
 
 /-!
 # Functors on a groupoid with a weakly initial object
@@ -16,13 +16,12 @@ functors `F G : C ⥤ D` to `x₀` produces objects of `D` with actions of the v
 actions extends to a natural isomorphism `F ≅ G`, and the extension has the given isomorphism
 as its component at `x₀`.
 
-Nothing has to be transported by hand. Restricting along the vertex-group inclusion
-`TauCeti.Groupoid.singleObjFunctor` is an equivalence of functor categories, because
-`TauCeti.Groupoid.singleObjFunctor` itself is one by
-`TauCeti.Groupoid.isEquivalence_singleObjFunctor`; the datum of an equivariant isomorphism
-`F.obj x₀ ≅ G.obj x₀` is exactly a natural isomorphism between the two restrictions, and the
-extension is its preimage under that equivalence. Being a preimage is also what pins down the
-component at `x₀`, and what makes the extension unique.
+The construction is the usual transport of structure. Choosing a morphism `γ x : x₀ ⟶ x` for
+every object, the component at `x` is `F.map (γ x)⁻¹ ≫ e ≫ G.map (γ x)`; naturality at
+`f : x ⟶ y` holds because the discrepancy `γ x ≫ f ≫ (γ y)⁻¹` between the two chosen morphisms
+is an endomorphism of `x₀`, so equivariance applies to it. Nothing depends on the choice, since
+the resulting natural transformation is determined by its component at `x₀`, and that component
+is `e` whatever `γ x₀` is.
 
 The hypothesis is exactly connectedness of the groupoid when `C` is nonempty, but is stated as
 the family of nonemptiness assertions `∀ x, Nonempty (x₀ ⟶ x)` rather than through
@@ -54,12 +53,11 @@ variable {C : Type u} [CategoryTheory.Groupoid.{v} C] {D : Type w} [Category.{t}
 
 include hconn in
 /-- A natural transformation between functors out of a groupoid is determined by its component at
-a weakly initial object: restricting along `TauCeti.Groupoid.singleObjFunctor` is faithful. -/
+a weakly initial object. -/
 theorem natTrans_ext {α β : F ⟶ G} (h : α.app x₀ = β.app x₀) : α = β := by
-  have := isEquivalence_singleObjFunctor x₀ hconn
-  refine ((Functor.whiskeringLeft _ _ D).obj (singleObjFunctor x₀)).map_injective ?_
-  ext _
-  exact h
+  ext x
+  obtain ⟨f⟩ := hconn x
+  rw [← cancel_epi (F.map f), α.naturality f, β.naturality f, h]
 
 include hconn in
 /-- A natural isomorphism between functors out of a groupoid is determined by its component at
@@ -67,31 +65,48 @@ a weakly initial object. -/
 theorem natIso_ext {α β : F ≅ G} (h : α.app x₀ = β.app x₀) : α = β :=
   Iso.ext (natTrans_ext hconn (by simpa using congrArg Iso.hom h))
 
+/-- A chosen isomorphism from the weakly initial object `x₀` to an arbitrary object. -/
+private def chosenIso (x : C) : x₀ ≅ x :=
+  (CategoryTheory.Groupoid.isoEquivHom x₀ x).symm (hconn x).some
+
 /-- An `End x₀`-equivariant isomorphism between the values of two functors at a
 weakly initial object of a groupoid extends to a natural isomorphism.
 
-It is the preimage of the given isomorphism, read as a natural isomorphism of the restrictions
-along `TauCeti.Groupoid.singleObjFunctor`, under the equivalence given by restriction. Its
-component at `x₀` is the given isomorphism, by `natIsoOfEnd_app_self`. -/
+Its component at `x₀` is the given isomorphism, by `natIsoOfEnd_app_self`. -/
 def natIsoOfEnd (e : F.obj x₀ ≅ G.obj x₀)
     (he : ∀ g : x₀ ⟶ x₀, F.map g ≫ e.hom = e.hom ≫ G.map g) :
     F ≅ G :=
-  haveI := isEquivalence_singleObjFunctor x₀ hconn
-  ((Functor.whiskeringLeft _ _ D).obj (singleObjFunctor x₀)).preimageIso
-    (NatIso.ofComponents (fun _ => e) fun g => he g)
+  NatIso.ofComponents
+    (fun x => (F.mapIso (chosenIso hconn x)).symm ≪≫ e ≪≫ G.mapIso (chosenIso hconn x))
+    (fun {x y} f => by
+      simp only [Iso.trans_hom, Iso.symm_hom, Functor.mapIso_hom, Functor.mapIso_inv,
+        Category.assoc]
+      -- Cancel the chosen transports, then apply equivariance to their discrepancy.
+      rw [← cancel_epi (F.mapIso (chosenIso hconn x)).hom,
+        ← cancel_mono (G.mapIso (chosenIso hconn y)).inv]
+      simp only [Functor.mapIso_hom, Functor.mapIso_inv]
+      rw [← F.map_comp_assoc, ← F.map_comp_assoc]
+      simp only [Category.assoc]
+      rw [reassoc_of% (he ((chosenIso hconn x).hom ≫ f ≫ (chosenIso hconn y).inv))]
+      rw [← F.map_comp_assoc, Iso.hom_inv_id, F.map_id, Category.id_comp]
+      simp only [G.map_comp, Category.assoc]
+      simp)
+
+private theorem natIsoOfEnd_hom_app (e : F.obj x₀ ≅ G.obj x₀)
+    (he : ∀ g : x₀ ⟶ x₀, F.map g ≫ e.hom = e.hom ≫ G.map g) (x : C) :
+    (natIsoOfEnd hconn e he).hom.app x =
+      F.map (chosenIso hconn x).inv ≫ e.hom ≫ G.map (chosenIso hconn x).hom := by
+  simp [natIsoOfEnd]
 
 /-- The extension of an equivariant isomorphism restricts to that isomorphism. -/
 @[simp]
 theorem natIsoOfEnd_app_self (e : F.obj x₀ ≅ G.obj x₀)
     (he : ∀ g : x₀ ⟶ x₀, F.map g ≫ e.hom = e.hom ≫ G.map g) :
     (natIsoOfEnd hconn e he).app x₀ = e := by
-  have := isEquivalence_singleObjFunctor x₀ hconn
-  refine Iso.ext ?_
-  -- The restriction of the extension is the isomorphism it was built from, and restricting a
-  -- natural transformation reads off its component at `x₀`.
-  exact congrArg (fun α => NatTrans.app α (SingleObj.star (End x₀)))
-    (((Functor.whiskeringLeft _ _ D).obj (singleObjFunctor x₀)).map_preimage
-      (NatIso.ofComponents (fun _ => e) fun g => he g).hom)
+  apply Iso.ext
+  -- Compare the hom components using the chosen transport formula.
+  rw [Iso.app_hom, natIsoOfEnd_hom_app, ← he (chosenIso hconn x₀).hom, ← Category.assoc,
+    ← F.map_comp, Iso.inv_hom_id, F.map_id, Category.id_comp]
 
 /-- The extension is the only natural isomorphism restricting to the given one at the weakly
 initial object. -/

--- a/TauCeti/CategoryTheory/Groupoid/ConnectedFunctor.lean
+++ b/TauCeti/CategoryTheory/Groupoid/ConnectedFunctor.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.CategoryTheory.Groupoid
+public import TauCeti.CategoryTheory.Groupoid.SingleObj
 
 /-!
 # Functors on a groupoid with a weakly initial object
@@ -16,12 +16,13 @@ functors `F G : C ⥤ D` to `x₀` produces objects of `D` with actions of the v
 actions extends to a natural isomorphism `F ≅ G`, and the extension has the given isomorphism
 as its component at `x₀`.
 
-The construction is the usual transport of structure. Choosing a morphism `γ x : x₀ ⟶ x` for
-every object, the component at `x` is `F.map (γ x)⁻¹ ≫ e ≫ G.map (γ x)`; naturality at
-`f : x ⟶ y` holds because the discrepancy `γ x ≫ f ≫ (γ y)⁻¹` between the two chosen morphisms
-is an endomorphism of `x₀`, so equivariance applies to it. Nothing depends on the choice, since
-the resulting natural transformation is determined by its component at `x₀`, and that component
-is `e` whatever `γ x₀` is.
+Nothing has to be transported by hand. Restricting along the vertex-group inclusion
+`TauCeti.Groupoid.singleObjFunctor` is an equivalence of functor categories, because
+`TauCeti.Groupoid.singleObjFunctor` itself is one by
+`TauCeti.Groupoid.isEquivalence_singleObjFunctor`; the datum of an equivariant isomorphism
+`F.obj x₀ ≅ G.obj x₀` is exactly a natural isomorphism between the two restrictions, and the
+extension is its preimage under that equivalence. Being a preimage is also what pins down the
+component at `x₀`, and what makes the extension unique.
 
 The hypothesis is exactly connectedness of the groupoid when `C` is nonempty, but is stated as
 the family of nonemptiness assertions `∀ x, Nonempty (x₀ ⟶ x)` rather than through
@@ -53,11 +54,12 @@ variable {C : Type u} [CategoryTheory.Groupoid.{v} C] {D : Type w} [Category.{t}
 
 include hconn in
 /-- A natural transformation between functors out of a groupoid is determined by its component at
-a weakly initial object. -/
+a weakly initial object: restricting along `TauCeti.Groupoid.singleObjFunctor` is faithful. -/
 theorem natTrans_ext {α β : F ⟶ G} (h : α.app x₀ = β.app x₀) : α = β := by
-  ext x
-  obtain ⟨f⟩ := hconn x
-  rw [← cancel_epi (F.map f), α.naturality f, β.naturality f, h]
+  have := isEquivalence_singleObjFunctor x₀ hconn
+  refine ((Functor.whiskeringLeft _ _ D).obj (singleObjFunctor x₀)).map_injective ?_
+  ext _
+  exact h
 
 include hconn in
 /-- A natural isomorphism between functors out of a groupoid is determined by its component at
@@ -65,48 +67,31 @@ a weakly initial object. -/
 theorem natIso_ext {α β : F ≅ G} (h : α.app x₀ = β.app x₀) : α = β :=
   Iso.ext (natTrans_ext hconn (by simpa using congrArg Iso.hom h))
 
-/-- A chosen isomorphism from the weakly initial object `x₀` to an arbitrary object. -/
-private def chosenIso (x : C) : x₀ ≅ x :=
-  (CategoryTheory.Groupoid.isoEquivHom x₀ x).symm (hconn x).some
-
 /-- An `End x₀`-equivariant isomorphism between the values of two functors at a
 weakly initial object of a groupoid extends to a natural isomorphism.
 
-Its component at `x₀` is the given isomorphism, by `natIsoOfEnd_app_self`. -/
+It is the preimage of the given isomorphism, read as a natural isomorphism of the restrictions
+along `TauCeti.Groupoid.singleObjFunctor`, under the equivalence given by restriction. Its
+component at `x₀` is the given isomorphism, by `natIsoOfEnd_app_self`. -/
 def natIsoOfEnd (e : F.obj x₀ ≅ G.obj x₀)
     (he : ∀ g : x₀ ⟶ x₀, F.map g ≫ e.hom = e.hom ≫ G.map g) :
     F ≅ G :=
-  NatIso.ofComponents
-    (fun x => (F.mapIso (chosenIso hconn x)).symm ≪≫ e ≪≫ G.mapIso (chosenIso hconn x))
-    (fun {x y} f => by
-      simp only [Iso.trans_hom, Iso.symm_hom, Functor.mapIso_hom, Functor.mapIso_inv,
-        Category.assoc]
-      -- Cancel the chosen transports, then apply equivariance to their discrepancy.
-      rw [← cancel_epi (F.mapIso (chosenIso hconn x)).hom,
-        ← cancel_mono (G.mapIso (chosenIso hconn y)).inv]
-      simp only [Functor.mapIso_hom, Functor.mapIso_inv]
-      rw [← F.map_comp_assoc, ← F.map_comp_assoc]
-      simp only [Category.assoc]
-      rw [reassoc_of% (he ((chosenIso hconn x).hom ≫ f ≫ (chosenIso hconn y).inv))]
-      rw [← F.map_comp_assoc, Iso.hom_inv_id, F.map_id, Category.id_comp]
-      simp only [G.map_comp, Category.assoc]
-      simp)
-
-private theorem natIsoOfEnd_hom_app (e : F.obj x₀ ≅ G.obj x₀)
-    (he : ∀ g : x₀ ⟶ x₀, F.map g ≫ e.hom = e.hom ≫ G.map g) (x : C) :
-    (natIsoOfEnd hconn e he).hom.app x =
-      F.map (chosenIso hconn x).inv ≫ e.hom ≫ G.map (chosenIso hconn x).hom := by
-  simp [natIsoOfEnd]
+  haveI := isEquivalence_singleObjFunctor x₀ hconn
+  ((Functor.whiskeringLeft _ _ D).obj (singleObjFunctor x₀)).preimageIso
+    (NatIso.ofComponents (fun _ => e) fun g => he g)
 
 /-- The extension of an equivariant isomorphism restricts to that isomorphism. -/
 @[simp]
 theorem natIsoOfEnd_app_self (e : F.obj x₀ ≅ G.obj x₀)
     (he : ∀ g : x₀ ⟶ x₀, F.map g ≫ e.hom = e.hom ≫ G.map g) :
     (natIsoOfEnd hconn e he).app x₀ = e := by
-  apply Iso.ext
-  -- Compare the hom components using the chosen transport formula.
-  rw [Iso.app_hom, natIsoOfEnd_hom_app, ← he (chosenIso hconn x₀).hom, ← Category.assoc,
-    ← F.map_comp, Iso.inv_hom_id, F.map_id, Category.id_comp]
+  have := isEquivalence_singleObjFunctor x₀ hconn
+  refine Iso.ext ?_
+  -- The restriction of the extension is the isomorphism it was built from, and restricting a
+  -- natural transformation reads off its component at `x₀`.
+  exact congrArg (fun α => NatTrans.app α (SingleObj.star (End x₀)))
+    (((Functor.whiskeringLeft _ _ D).obj (singleObjFunctor x₀)).map_preimage
+      (NatIso.ofComponents (fun _ => e) fun g => he g).hom)
 
 /-- The extension is the only natural isomorphism restricting to the given one at the weakly
 initial object. -/

--- a/TauCeti/CategoryTheory/Groupoid/SingleObj.lean
+++ b/TauCeti/CategoryTheory/Groupoid/SingleObj.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.Groupoid
+public import Mathlib.CategoryTheory.SingleObj
+
+/-!
+# A connected groupoid is equivalent to its vertex group
+
+Let `C` be a groupoid and `x₀ : C` an object which receives a morphism from every object. This
+file proves that the one-object category `SingleObj (End x₀)` of the vertex group at `x₀` is
+equivalent to `C`, through the functor sending the unique object to `x₀` and an endomorphism to
+itself.
+
+Both halves are immediate once the functor is written down. It is fully faithful because its
+action on the single hom-set is the identity of `End x₀`, and essentially surjective because in
+a groupoid a morphism `x₀ ⟶ x` is already an isomorphism. What the equivalence buys is a
+dictionary: functors out of `C` become functors out of `SingleObj (End x₀)`, that is, objects
+with an action of the vertex group, and the dictionary is natural in the target category.
+
+The connectedness hypothesis is stated as the family of nonemptiness assertions
+`∀ x, Nonempty (x₀ ⟶ x)` rather than through `CategoryTheory.IsConnected`, matching
+`TauCeti.Groupoid.natIsoOfEnd` in `TauCeti.CategoryTheory.Groupoid.ConnectedFunctor`: the
+intended source of that data is a path-connected topological space, whose fundamental groupoid
+comes with paths out of a chosen basepoint.
+
+## Main declarations
+
+* `TauCeti.Groupoid.singleObjFunctor`: the functor `SingleObj (End x₀) ⥤ C` picking out `x₀`.
+* `TauCeti.Groupoid.fullyFaithfulSingleObjFunctor`: it is fully faithful, without hypotheses.
+* `TauCeti.Groupoid.essSurj_singleObjFunctor` and
+  `TauCeti.Groupoid.isEquivalence_singleObjFunctor`: it is essentially surjective, hence an
+  equivalence, when every object receives a morphism from `x₀`.
+* `TauCeti.Groupoid.singleObjEquivalence`: **a connected groupoid is equivalent to the
+  one-object category of its vertex group.**
+-/
+
+public section
+
+universe v u
+
+open CategoryTheory
+
+namespace TauCeti.Groupoid
+
+variable {C : Type u} [CategoryTheory.Groupoid.{v} C] (x₀ : C)
+
+/-- The functor from the one-object category of the vertex group at `x₀` that sends the unique
+object to `x₀` and an endomorphism to itself.
+
+It is `@[expose]`d so that the object and morphism equations hold by `rfl` downstream. -/
+@[expose] def singleObjFunctor : SingleObj (End x₀) ⥤ C :=
+  SingleObj.functor (MonoidHom.id (End x₀))
+
+@[simp]
+theorem singleObjFunctor_obj (a : SingleObj (End x₀)) : (singleObjFunctor x₀).obj a = x₀ :=
+  (rfl)
+
+@[simp]
+theorem singleObjFunctor_map (g : End x₀) :
+    (singleObjFunctor x₀).map (X := SingleObj.star (End x₀)) (Y := SingleObj.star (End x₀)) g =
+      g :=
+  (rfl)
+
+/-- The functor out of the one-object category of the vertex group is fully faithful: on the
+single hom-set it is the identity of `End x₀`. -/
+def fullyFaithfulSingleObjFunctor : (singleObjFunctor x₀).FullyFaithful where
+  preimage f := f
+
+instance singleObjFunctor_full : (singleObjFunctor x₀).Full :=
+  (fullyFaithfulSingleObjFunctor x₀).full
+
+instance singleObjFunctor_faithful : (singleObjFunctor x₀).Faithful :=
+  (fullyFaithfulSingleObjFunctor x₀).faithful
+
+/-- If every object of the groupoid receives a morphism from `x₀`, then every object is
+isomorphic to `x₀`, so the functor out of the one-object category is essentially surjective. -/
+theorem essSurj_singleObjFunctor (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
+    (singleObjFunctor x₀).EssSurj where
+  mem_essImage x :=
+    ⟨SingleObj.star (End x₀),
+      ⟨(CategoryTheory.Groupoid.isoEquivHom x₀ x).symm (hconn x).some⟩⟩
+
+/-- If every object of the groupoid receives a morphism from `x₀`, the functor out of the
+one-object category of the vertex group is an equivalence. -/
+theorem isEquivalence_singleObjFunctor (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
+    (singleObjFunctor x₀).IsEquivalence :=
+  haveI := essSurj_singleObjFunctor x₀ hconn
+  { }
+
+/-- **A connected groupoid is equivalent to the one-object category of its vertex group.**
+
+The equivalence is induced by `TauCeti.Groupoid.singleObjFunctor`, so it sends the unique object
+to `x₀` and an endomorphism to itself. -/
+@[expose] noncomputable def singleObjEquivalence (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
+    SingleObj (End x₀) ≌ C :=
+  haveI := isEquivalence_singleObjFunctor x₀ hconn
+  (singleObjFunctor x₀).asEquivalence
+
+@[simp]
+theorem singleObjEquivalence_functor (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
+    (singleObjEquivalence x₀ hconn).functor = singleObjFunctor x₀ :=
+  (rfl)
+
+end TauCeti.Groupoid

--- a/TauCeti/CategoryTheory/Groupoid/SingleObj.lean
+++ b/TauCeti/CategoryTheory/Groupoid/SingleObj.lean
@@ -11,22 +11,23 @@ public import Mathlib.CategoryTheory.SingleObj
 /-!
 # A connected groupoid is equivalent to its vertex group
 
-Let `C` be a groupoid and `x₀ : C` an object which receives a morphism from every object. This
-file proves that the one-object category `SingleObj (End x₀)` of the vertex group at `x₀` is
-equivalent to `C`, through the functor sending the unique object to `x₀` and an endomorphism to
-itself.
+Let `C` be a groupoid and `x₀ : C` a *weakly initial* object, that is, one which admits a morphism
+to every object. This file proves that the one-object category `SingleObj (End x₀)` of the vertex
+group at `x₀` is equivalent to `C`, through the functor sending the unique object to `x₀` and an
+endomorphism to itself.
 
-Both halves are immediate once the functor is written down. It is fully faithful because its
-action on the single hom-set is the identity of `End x₀`, and essentially surjective because in
-a groupoid a morphism `x₀ ⟶ x` is already an isomorphism. What the equivalence buys is a
-dictionary: functors out of `C` become functors out of `SingleObj (End x₀)`, that is, objects
-with an action of the vertex group, and the dictionary is natural in the target category.
+Both halves are immediate once the functor is written down. It is fully faithful in any category,
+because its action on the single hom-set is the identity of `End x₀`, and it is essentially
+surjective because in a groupoid a morphism `x₀ ⟶ x` is already an isomorphism. What the
+equivalence buys is a dictionary: functors out of `C` become functors out of `SingleObj (End x₀)`,
+that is, objects with an action of the vertex group, and the dictionary is natural in the target
+category; `TauCeti.Groupoid.natIsoOfEnd` in `TauCeti.CategoryTheory.Groupoid.ConnectedFunctor` is
+that dictionary applied to isomorphisms.
 
-The connectedness hypothesis is stated as the family of nonemptiness assertions
-`∀ x, Nonempty (x₀ ⟶ x)` rather than through `CategoryTheory.IsConnected`, matching
-`TauCeti.Groupoid.natIsoOfEnd` in `TauCeti.CategoryTheory.Groupoid.ConnectedFunctor`: the
-intended source of that data is a path-connected topological space, whose fundamental groupoid
-comes with paths out of a chosen basepoint.
+The weak initiality hypothesis is stated as the family of nonemptiness assertions
+`∀ x, Nonempty (x₀ ⟶ x)` rather than through `CategoryTheory.IsConnected`: the intended source of
+that data is a path-connected topological space, whose fundamental groupoid comes with paths out
+of a chosen basepoint.
 
 ## Main declarations
 
@@ -34,7 +35,7 @@ comes with paths out of a chosen basepoint.
 * `TauCeti.Groupoid.fullyFaithfulSingleObjFunctor`: it is fully faithful, without hypotheses.
 * `TauCeti.Groupoid.essSurj_singleObjFunctor` and
   `TauCeti.Groupoid.isEquivalence_singleObjFunctor`: it is essentially surjective, hence an
-  equivalence, when every object receives a morphism from `x₀`.
+  equivalence, when `x₀` admits a morphism to every object.
 * `TauCeti.Groupoid.singleObjEquivalence`: **a connected groupoid is equivalent to the
   one-object category of its vertex group.**
 -/
@@ -47,7 +48,9 @@ open CategoryTheory
 
 namespace TauCeti.Groupoid
 
-variable {C : Type u} [CategoryTheory.Groupoid.{v} C] (x₀ : C)
+section Category
+
+variable {C : Type u} [Category.{v} C] (x₀ : C)
 
 /-- The functor from the one-object category of the vertex group at `x₀` that sends the unique
 object to `x₀` and an endomorphism to itself.
@@ -77,16 +80,22 @@ instance singleObjFunctor_full : (singleObjFunctor x₀).Full :=
 instance singleObjFunctor_faithful : (singleObjFunctor x₀).Faithful :=
   (fullyFaithfulSingleObjFunctor x₀).faithful
 
-/-- If every object of the groupoid receives a morphism from `x₀`, then every object is
-isomorphic to `x₀`, so the functor out of the one-object category is essentially surjective. -/
+end Category
+
+section Groupoid
+
+variable {C : Type u} [CategoryTheory.Groupoid.{v} C] (x₀ : C)
+
+/-- If `x₀` admits a morphism to every object of the groupoid, then every object is isomorphic to
+`x₀`, so the functor out of the one-object category is essentially surjective. -/
 theorem essSurj_singleObjFunctor (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
     (singleObjFunctor x₀).EssSurj where
   mem_essImage x :=
     ⟨SingleObj.star (End x₀),
       ⟨(CategoryTheory.Groupoid.isoEquivHom x₀ x).symm (hconn x).some⟩⟩
 
-/-- If every object of the groupoid receives a morphism from `x₀`, the functor out of the
-one-object category of the vertex group is an equivalence. -/
+/-- If `x₀` admits a morphism to every object of the groupoid, the functor out of the one-object
+category of the vertex group is an equivalence. -/
 theorem isEquivalence_singleObjFunctor (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
     (singleObjFunctor x₀).IsEquivalence :=
   haveI := essSurj_singleObjFunctor x₀ hconn
@@ -105,5 +114,7 @@ to `x₀` and an endomorphism to itself. -/
 theorem singleObjEquivalence_functor (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
     (singleObjEquivalence x₀ hconn).functor = singleObjFunctor x₀ :=
   (rfl)
+
+end Groupoid
 
 end TauCeti.Groupoid

--- a/TauCeti/CategoryTheory/Groupoid/SingleObj.lean
+++ b/TauCeti/CategoryTheory/Groupoid/SingleObj.lean
@@ -105,7 +105,7 @@ theorem isEquivalence_singleObjFunctor (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)
 
 The equivalence is induced by `TauCeti.Groupoid.singleObjFunctor`, so it sends the unique object
 to `x₀` and an endomorphism to itself. -/
-@[expose] noncomputable def singleObjEquivalence (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
+noncomputable def singleObjEquivalence (hconn : ∀ x : C, Nonempty (x₀ ⟶ x)) :
     SingleObj (End x₀) ≌ C :=
   haveI := isEquivalence_singleObjFunctor x₀ hconn
   (singleObjFunctor x₀).asEquivalence

--- a/TauCeti/Topology/Covering/Monodromy/Basic.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Basic.lean
@@ -59,10 +59,10 @@ variable {X : TopCat.{u}}
 groupoid of `X` to types.
 
 A covering space is sent to its own monodromy functor, and a map of covering spaces to the natural
-transformation restricting that map to every fibre. The definition is opaque; its object and map
-values are characterized by `monodromyFunctor_obj`, `monodromyFunctor_map`, and
-`monodromyFunctor_map_app`. -/
-noncomputable def monodromyFunctor (X : TopCat.{u}) :
+transformation restricting that map to every fibre. Its object and map values are characterized
+by `monodromyFunctor_obj`, `monodromyFunctor_map`, and `monodromyFunctor_map_app`; the
+definition is `@[expose]`d so that those equations also hold by `rfl` in downstream modules. -/
+@[expose] noncomputable def monodromyFunctor (X : TopCat.{u}) :
     CoveringSpace X ⥤ (FundamentalGroupoid X ⥤ Type u) where
   obj p := p.isCoveringMap_proj.monodromyFunctor
   map {p q} f := IsCoveringMap.monodromyNatTrans p.isCoveringMap_proj q.isCoveringMap_proj

--- a/TauCeti/Topology/Covering/Monodromy/Connected.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Connected.lean
@@ -28,6 +28,8 @@ the base is disconnected.
   morphisms at each object act pretransitively on that object's value.
 * `TauCeti.PretransitiveFundamentalGroupoidAction`: the full subcategory of functors satisfying
   that property.
+* `TauCeti.ConnectedCoveringSpace.isPretransitive_fiberAction`: the evaluation of that condition
+  at a basepoint, as transitivity of Mathlib's `IsCoveringMap.fundamentalGroupMulAction`.
 * `TauCeti.ConnectedCoveringSpace.monodromyFunctor`: monodromy of connected covers, valued in
   fibrewise pretransitive fundamental-groupoid actions.
 * `TauCeti.ConnectedCoveringSpace.monodromyFunctor_faithful` and
@@ -162,6 +164,24 @@ theorem monodromy_isFiberwisePretransitive [LocallyPathConnectedSpace X]
     locallyPathConnectedSpace_of_isLocalHomeomorph p.isCoveringMap_proj.isLocalHomeomorph
   let _ : PathConnectedSpace (p : TopCat) := PathConnectedSpace.of_locallyPathConnectedSpace
   exact IsCoveringMap.exists_monodromy_eq p.isCoveringMap_proj e e'
+
+/-- The fundamental group at `x₀` acts transitively on the fibre of a connected covering space
+over `x₀`.
+
+This is `monodromy_isFiberwisePretransitive` evaluated at one basepoint and read through Mathlib's
+`IsCoveringMap.fundamentalGroupMulAction`. -/
+theorem isPretransitive_fiberAction [LocallyPathConnectedSpace X] (p : ConnectedCoveringSpace X)
+    (x₀ : X) :
+    letI := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
+    MulAction.IsPretransitive (FundamentalGroup X x₀) (⇑p.proj ⁻¹' {x₀}) := by
+  let := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
+  have h := monodromy_isFiberwisePretransitive p
+  rw [FundamentalGroupoidAction.isFiberwisePretransitive_iff,
+    CoveringSpace.monodromyFunctor_obj] at h
+  simp only [IsCoveringMap.monodromyFunctor_map] at h
+  -- `IsCoveringMap.fundamentalGroupMulAction` is reducible, with `g • e` the monodromy of `e`
+  -- along `g`, so the loops at `x₀` are exactly the group elements.
+  exact ⟨fun e e' => h (FundamentalGroupoid.mk x₀) e e'⟩
 
 /-- Monodromy as a functor from connected covering spaces over `X` to fibrewise pretransitive
 fundamental-groupoid actions.

--- a/TauCeti/Topology/Covering/Monodromy/Connected.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Connected.lean
@@ -28,8 +28,8 @@ the base is disconnected.
   morphisms at each object act pretransitively on that object's value.
 * `TauCeti.PretransitiveFundamentalGroupoidAction`: the full subcategory of functors satisfying
   that property.
-* `TauCeti.ConnectedCoveringSpace.isPretransitive_fiberAction`: the evaluation of that condition
-  at a basepoint, as transitivity of Mathlib's `IsCoveringMap.fundamentalGroupMulAction`.
+* `TauCeti.ConnectedCoveringSpace.isPretransitive_fiberAction`: pretransitivity of Mathlib's
+  `IsCoveringMap.fundamentalGroupMulAction` on the fibre over a basepoint.
 * `TauCeti.ConnectedCoveringSpace.monodromyFunctor`: monodromy of connected covers, valued in
   fibrewise pretransitive fundamental-groupoid actions.
 * `TauCeti.ConnectedCoveringSpace.monodromyFunctor_faithful` and
@@ -165,23 +165,20 @@ theorem monodromy_isFiberwisePretransitive [LocallyPathConnectedSpace X]
   let _ : PathConnectedSpace (p : TopCat) := PathConnectedSpace.of_locallyPathConnectedSpace
   exact IsCoveringMap.exists_monodromy_eq p.isCoveringMap_proj e e'
 
-/-- The fundamental group at `x₀` acts transitively on the fibre of a connected covering space
-over `x₀`.
+/-- The fundamental group at `x₀` acts pretransitively on the fibre of a connected covering space
+over `x₀`; the fibre may be empty, when the base is disconnected.
 
-This is `monodromy_isFiberwisePretransitive` evaluated at one basepoint and read through Mathlib's
-`IsCoveringMap.fundamentalGroupMulAction`. -/
+This is `TauCeti.IsCoveringMap.monodromy_isPretransitive` applied to the total space, which is
+path connected because a connected cover of a locally path-connected base is connected and
+locally path connected. -/
 theorem isPretransitive_fiberAction [LocallyPathConnectedSpace X] (p : ConnectedCoveringSpace X)
     (x₀ : X) :
     letI := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
     MulAction.IsPretransitive (FundamentalGroup X x₀) (⇑p.proj ⁻¹' {x₀}) := by
-  let := p.isCoveringMap_proj.fundamentalGroupMulAction x₀
-  have h := monodromy_isFiberwisePretransitive p
-  rw [FundamentalGroupoidAction.isFiberwisePretransitive_iff,
-    CoveringSpace.monodromyFunctor_obj] at h
-  simp only [IsCoveringMap.monodromyFunctor_map] at h
-  -- `IsCoveringMap.fundamentalGroupMulAction` is reducible, with `g • e` the monodromy of `e`
-  -- along `g`, so the loops at `x₀` are exactly the group elements.
-  exact ⟨fun e e' => h (FundamentalGroupoid.mk x₀) e e'⟩
+  let _ : LocallyPathConnectedSpace (p : TopCat) :=
+    locallyPathConnectedSpace_of_isLocalHomeomorph p.isCoveringMap_proj.isLocalHomeomorph
+  let _ : PathConnectedSpace (p : TopCat) := PathConnectedSpace.of_locallyPathConnectedSpace
+  exact IsCoveringMap.monodromy_isPretransitive p.isCoveringMap_proj x₀
 
 /-- Monodromy as a functor from connected covering spaces over `X` to fibrewise pretransitive
 fundamental-groupoid actions.


### PR DESCRIPTION
This PR proves the `π₁(X)`-set form of the classification of covering spaces: over a path-connected, locally path-connected, semilocally simply connected base, taking the fibre over a basepoint `x₀` with its monodromy action is an equivalence of categories `TauCeti.CoveringSpace.fiberActionEquivalence : CoveringSpace X ≌ Action (Type u) (FundamentalGroup X x₀)`, and this restricts to `TauCeti.ConnectedCoveringSpace.transitiveFiberActionEquivalence : ConnectedCoveringSpace X ≌ TransitiveAction (FundamentalGroup X x₀)` between connected covers and transitive `π₁(X, x₀)`-sets.

This serves Stage 2, item 8 of `TauCetiRoadmap/UniversalCovers/README.md`, whose *alternative lens* asks to "phrase the classification of connected covers via transitive `π₁(X)`-sets / the monodromy functor, with disconnected covers as functors out of the fundamental groupoid". The fundamental-groupoid half of that sentence landed in TauCeti#4039 (`CoveringSpace.monodromyEquivalence` and `ConnectedCoveringSpace.monodromyEquivalence`); the `π₁(X)`-set half was still missing, since a fundamental-groupoid action is not literally a set with a fundamental-group action. What remains of that item after this PR is the third lens the same paragraph names, the Galois-category abstraction (`Mathlib/CategoryTheory/Galois/IsFundamentalgroup.lean`): finite covers of `X` as a `PreGaloisCategory` with the fibre at `x₀` as a `FiberFunctor`, which needs the finite-fibre subcategory and the transport of the Galois axioms that this equivalence does not by itself supply.

The bridge from the groupoid form to the group form is a general categorical fact that the repository did not have, so it is added first, in `TauCeti/CategoryTheory/Groupoid/SingleObj.lean`: for a groupoid `C` and an object `x₀` receiving a morphism from every object, the functor `SingleObj (End x₀) ⥤ C` picking out `x₀` is fully faithful (its action on the single hom-set is the identity of `End x₀`) and essentially surjective (in a groupoid a morphism out of `x₀` is already an isomorphism), hence an equivalence `TauCeti.Groupoid.singleObjEquivalence`. The connectedness hypothesis is spelled as `∀ x, Nonempty (x₀ ⟶ x)`, matching the existing `TauCeti.Groupoid.natIsoOfEnd` in the sibling `ConnectedFunctor` module, because the intended source of that data is a path-connected space. Composing this with the monodromy equivalence and with Mathlib's `CategoryTheory.Action.functorCategoryEquivalence` gives the fibre-action functor, and its values are pinned down by `rfl`: the underlying set is the fibre, a loop class acts by `IsCoveringMap.monodromy`, the `MulAction` it carries is Mathlib's `IsCoveringMap.fundamentalGroupMulAction`, and a map of covers acts by restriction to fibres.

No `ᵐᵒᵖ` appears, and the file says why: Mathlib defines `FundamentalGroup X x₀` as `End (FundamentalGroupoid.mk x₀)`, and the composition convention of `CategoryTheory.SingleObj` is the one matching `CategoryTheory.End`, so the vertex group is `π₁(X, x₀)` on the nose. The opposite group in `UniversalCover.deckFundamentalGroupEquiv` comes from comparing monodromy with deck transformations, a different comparison that is unaffected.

The connected/transitive restriction reuses what is already here rather than redoing it: transitivity of the fibre action comes from `ConnectedCoveringSpace.monodromy_isFiberwisePretransitive` and `nonempty_fiber`, and essential surjectivity is the stabiliser-cover reconstruction `UniversalCover.transitiveActionFiberEquiv` of `Classification/Reconstruction.lean`, whose equivariance statement is exactly the `Action.mkIso` commutation condition. `TauCeti.isTransitiveAction` is the corresponding `ObjectProperty` on `Action (Type u) G`, closed under isomorphisms.

The general `π₁(X)`-set-free part of the statement lives in its own module `TauCeti/CategoryTheory/Action/Transitive.lean`: `TauCeti.isTransitiveAction`, its `ObjectProperty.IsClosedUnderIsomorphisms` instance, and the full subcategory `TauCeti.TransitiveAction` with the `mk` / `forget` / property / `fullyFaithfulForget` accessors its sibling `TauCeti.PretransitiveFundamentalGroupoidAction` carries. It is stated for a monoid in its own universe. The predicate is *not* named `TauCeti.Action.isTransitive`: `Action` is a Mathlib type declared at the root, so that namespace is rejected by `scripts/lint-dot-notation.py`.

Three existing declarations change. `TauCeti.CoveringSpace.monodromyFunctor` gains `@[expose]`, so that the `rfl` equations characterising it also hold in downstream modules; its statement, proof, and API are untouched. `TauCeti.ConnectedCoveringSpace.isPretransitive_fiberAction` — transitivity of Mathlib's `IsCoveringMap.fundamentalGroupMulAction` for a connected cover — is stated in `TauCeti/Topology/Covering/Monodromy/Connected.lean`, next to the `monodromy_isFiberwisePretransitive` it is an evaluation of. And `TauCeti/CategoryTheory/Groupoid/ConnectedFunctor.lean` is deduplicated against the new equivalence: restriction along `singleObjFunctor` is an equivalence of functor categories, so `natTrans_ext` is its faithfulness and `natIsoOfEnd` is a `preimageIso`, and the hand-rolled `chosenIso` transport is deleted. Its four public declarations and their statements are unchanged.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"covering-spaces-equivalent-to-fundamental-group-sets"}-->

🤖 Prepared with Claude Code

