### PR TITLE
refactor(NumberField): name the sign fact behind norm_pos_of_isTotallyPositive

### DIFF
--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -47,10 +47,9 @@ the narrow class group finite (see `NarrowClassGroup.Finite`).
 * `NumberField.totallyPositiveIntegerUnits`: the corresponding subgroup of the arithmetic
   units `(𝓞 K)ˣ`, the preimage of `totallyPositiveUnits` under `(𝓞 K)ˣ → Kˣ`, with
   `mem_totallyPositiveIntegerUnits` and `sq_mem_totallyPositiveIntegerUnits`.
-* `NumberField.prod_eq_norm_of_isTotallyPositive`: for a totally positive element the
-  infinite-place product formula for the norm needs no absolute value, sharpening
-  `InfinitePlace.prod_eq_abs_norm`; hence `NumberField.norm_pos_of_isTotallyPositive`, the field
-  norm of a nonzero totally positive element is strictly positive.
+* `NumberField.norm_nonneg_of_isTotallyPositive`: the field norm of a totally positive element is
+  nonnegative, and `NumberField.norm_pos_of_isTotallyPositive`: for a nonzero such element it is
+  strictly positive.
 * `NumberField.finiteIndex_totallyPositiveUnits`: `totallyPositiveUnits` has finite index
   (via `Units.instFiniteIndexPosSubgroup` and the general `Subgroup.instFiniteIndexComap`).
 -/
@@ -177,16 +176,15 @@ omit [NumberField K] in
     totallyPositiveIntegerUnits (K := K) = ⊤ := by
   ext u; simp
 
-/-- For a **totally positive** element the infinite-place product formula for the norm holds without
-an absolute value: `∏ w, w x ^ mult w` is `Algebra.norm ℚ x` itself, where
-`InfinitePlace.prod_eq_abs_norm` gives only `|Algebra.norm ℚ x|` for a general `x`.
+/-- **The norm of a totally positive element is nonnegative.**
 
-Over a totally complex field the hypothesis is vacuous (`not_isReal_of_isTotallyComplex`), and the
-identity then holds for every `x`. -/
-theorem prod_eq_norm_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
-    ∏ w : InfinitePlace K, w x ^ mult w = ((Algebra.norm ℚ x : ℚ) : ℝ) := by
+Over a totally complex field the hypothesis is vacuous (`not_isReal_of_isTotallyComplex`), so the
+conclusion holds for every `x` there, including `x = 0` whose norm is `0`. -/
+theorem norm_nonneg_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
+    0 ≤ Algebra.norm ℚ x := by
   classical
-  -- Compare in `ℂ`, where the norm is the product over all the embeddings, then descend to `ℝ`.
+  -- Compare in `ℂ`, where the norm is the product over all the embeddings, then descend to `ℝ`;
+  -- against `prod_eq_abs_norm` this says the absolute value there costs nothing.
   have key : ((Algebra.norm ℚ x : ℚ) : ℂ) =
       ((∏ w : InfinitePlace K, w x ^ mult w : ℝ) : ℂ) := by
     rw [← eq_ratCast (algebraMap ℚ ℂ) (Algebra.norm ℚ x), Algebra.norm_eq_prod_embeddings ℚ ℂ x,
@@ -225,20 +223,20 @@ theorem prod_eq_norm_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
         Finset.prod_pair hne, ComplexEmbedding.conjugate_coe_eq, Complex.mul_conj,
         Complex.normSq_eq_norm_sq, norm_embedding_eq,
         (not_isReal_iff_isComplex.mp hw).mult_eq_two]
-  exact_mod_cast key.symm
+  have hreal : ((Algebra.norm ℚ x : ℚ) : ℝ) = ∏ w : InfinitePlace K, w x ^ mult w := by
+    exact_mod_cast key
+  rw [InfinitePlace.prod_eq_abs_norm] at hreal
+  have habs : |Algebra.norm ℚ x| = Algebra.norm ℚ x := by exact_mod_cast hreal.symm
+  exact abs_eq_self.mp habs
 
-/-- **The norm of a totally positive element is positive.**
+/-- **The norm of a nonzero totally positive element is positive.**
 
 Over a totally complex field the hypothesis `IsTotallyPositive x` is vacuous
 (`not_isReal_of_isTotallyComplex`), so this covers imaginary quadratic fields as a special case. -/
 theorem norm_pos_of_isTotallyPositive {x : K} (hx : x ≠ 0) (hpos : IsTotallyPositive x) :
-    0 < Algebra.norm ℚ x := by
-  have habs : |Algebra.norm ℚ x| = Algebra.norm ℚ x := by
-    exact_mod_cast (InfinitePlace.prod_eq_abs_norm x).symm.trans
-      (prod_eq_norm_of_isTotallyPositive hpos)
-  have hne : Algebra.norm ℚ x ≠ 0 :=
-    (Algebra.norm_ne_zero_iff_of_basis (Module.finBasis ℚ K)).mpr hx
-  exact lt_of_le_of_ne (abs_eq_self.mp habs) (Ne.symm hne)
+    0 < Algebra.norm ℚ x :=
+  lt_of_le_of_ne (norm_nonneg_of_isTotallyPositive hpos)
+    (Ne.symm ((Algebra.norm_ne_zero_iff_of_basis (Module.finBasis ℚ K)).mpr hx))
 
 /-- `totallyPositiveUnits` has **finite index** in `Kˣ`: it is a finite intersection, over the real
 infinite places, of the finite-index preimages of the positive units of `ℝ` (via the general

--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -47,8 +47,10 @@ the narrow class group finite (see `NarrowClassGroup.Finite`).
 * `NumberField.totallyPositiveIntegerUnits`: the corresponding subgroup of the arithmetic
   units `(𝓞 K)ˣ`, the preimage of `totallyPositiveUnits` under `(𝓞 K)ˣ → Kˣ`, with
   `mem_totallyPositiveIntegerUnits` and `sq_mem_totallyPositiveIntegerUnits`.
-* `NumberField.norm_pos_of_isTotallyPositive`: the field norm of a nonzero totally positive
-  element is strictly positive.
+* `NumberField.prod_eq_norm_of_isTotallyPositive`: for a totally positive element the
+  infinite-place product formula for the norm needs no absolute value, sharpening
+  `InfinitePlace.prod_eq_abs_norm`; hence `NumberField.norm_pos_of_isTotallyPositive`, the field
+  norm of a nonzero totally positive element is strictly positive.
 * `NumberField.finiteIndex_totallyPositiveUnits`: `totallyPositiveUnits` has finite index
   (via `Units.instFiniteIndexPosSubgroup` and the general `Subgroup.instFiniteIndexComap`).
 -/
@@ -175,19 +177,16 @@ omit [NumberField K] in
     totallyPositiveIntegerUnits (K := K) = ⊤ := by
   ext u; simp
 
-/-- **The norm of a totally positive element is positive.** Group the complex embeddings of `K` by
-the infinite place they define. A real place contributes the single factor
-`embedding_of_isReal hw x`, which total positivity makes equal to `w x`; a complex place contributes
-a conjugate pair `φ x · conj (φ x) = (w x) ^ 2`. So `Algebra.norm ℚ x` equals the product
-`∏ w, w x ^ mult w`, which is `|Algebra.norm ℚ x|` by `InfinitePlace.prod_eq_abs_norm`; being
-nonzero, it is positive.
+/-- For a **totally positive** element the infinite-place product formula for the norm holds without
+an absolute value: `∏ w, w x ^ mult w` is `Algebra.norm ℚ x` itself, where
+`InfinitePlace.prod_eq_abs_norm` gives only `|Algebra.norm ℚ x|` for a general `x`.
 
-Over a totally complex field the hypothesis `IsTotallyPositive x` is vacuous
-(`not_isReal_of_isTotallyComplex`), so this covers imaginary quadratic fields as a special case. -/
-theorem norm_pos_of_isTotallyPositive {x : K} (hx : x ≠ 0) (hpos : IsTotallyPositive x) :
-    0 < Algebra.norm ℚ x := by
+Over a totally complex field the hypothesis is vacuous (`not_isReal_of_isTotallyComplex`), and the
+identity then holds for every `x`. -/
+theorem prod_eq_norm_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
+    ∏ w : InfinitePlace K, w x ^ mult w = ((Algebra.norm ℚ x : ℚ) : ℝ) := by
   classical
-  -- Each infinite place contributes `w x ^ mult w`, with no sign lost at the real places.
+  -- Compare in `ℂ`, where the norm is the product over all the embeddings, then descend to `ℝ`.
   have key : ((Algebra.norm ℚ x : ℚ) : ℂ) =
       ((∏ w : InfinitePlace K, w x ^ mult w : ℝ) : ℂ) := by
     rw [← eq_ratCast (algebraMap ℚ ℂ) (Algebra.norm ℚ x), Algebra.norm_eq_prod_embeddings ℚ ℂ x,
@@ -226,10 +225,17 @@ theorem norm_pos_of_isTotallyPositive {x : K} (hx : x ≠ 0) (hpos : IsTotallyPo
         Finset.prod_pair hne, ComplexEmbedding.conjugate_coe_eq, Complex.mul_conj,
         Complex.normSq_eq_norm_sq, norm_embedding_eq,
         (not_isReal_iff_isComplex.mp hw).mult_eq_two]
-  have hreal : ((Algebra.norm ℚ x : ℚ) : ℝ) = ∏ w : InfinitePlace K, w x ^ mult w := by
-    exact_mod_cast key
-  rw [InfinitePlace.prod_eq_abs_norm] at hreal
-  have habs : |Algebra.norm ℚ x| = Algebra.norm ℚ x := by exact_mod_cast hreal.symm
+  exact_mod_cast key.symm
+
+/-- **The norm of a totally positive element is positive.**
+
+Over a totally complex field the hypothesis `IsTotallyPositive x` is vacuous
+(`not_isReal_of_isTotallyComplex`), so this covers imaginary quadratic fields as a special case. -/
+theorem norm_pos_of_isTotallyPositive {x : K} (hx : x ≠ 0) (hpos : IsTotallyPositive x) :
+    0 < Algebra.norm ℚ x := by
+  have habs : |Algebra.norm ℚ x| = Algebra.norm ℚ x := by
+    exact_mod_cast (InfinitePlace.prod_eq_abs_norm x).symm.trans
+      (prod_eq_norm_of_isTotallyPositive hpos)
   have hne : Algebra.norm ℚ x ≠ 0 :=
     (Algebra.norm_ne_zero_iff_of_basis (Module.finBasis ℚ K)).mpr hx
   exact lt_of_le_of_ne (abs_eq_self.mp habs) (Ne.symm hne)


### PR DESCRIPTION
Extracts the infinite-place computation out of `NumberField.norm_pos_of_isTotallyPositive`, whose
proof body was 47 lines, and names the fact it was really establishing.

Mathlib proves the infinite-place product formula with an absolute value:

```
InfinitePlace.prod_eq_abs_norm (x : K) : ∏ w : InfinitePlace K, w x ^ mult w = |Algebra.norm ℚ x|
```

Total positivity is exactly the hypothesis under which that absolute value costs nothing, and the
38-line block inside `norm_pos_of_isTotallyPositive` was establishing precisely that before
discarding it. Composed with the Mathlib lemma the content is a statement about the **sign**, so
that is what is stated:

```
theorem norm_nonneg_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
    0 ≤ Algebra.norm ℚ x
```

Strict positivity is then a three-line term from that plus `Algebra.norm_ne_zero_iff_of_basis`.

| declaration | before | after |
|---|---|---|
| `norm_pos_of_isTotallyPositive` | 47 | 2 (a term, no tactic block) |
| `norm_nonneg_of_isTotallyPositive` | — | 46 |

The moved computation is unchanged; only its concluding cast and the surrounding statement differ.

The new lemma takes exactly the two inputs the block used, `x` and `hpos`; the parent's `hx : x ≠ 0`
stays in the parent, where it is used only to rule out a zero norm. It is listed in the module
docstring's results.

Degenerate end: over a totally complex field `IsTotallyPositive x` is vacuous, so the conclusion is
asserted for every `x`, including `x = 0`, whose norm is `0`. That is sound rather than vacuous
because `InfinitePlace K` is nonempty for a number field — an empty index would make the product `1`
against a norm of `0`. The totally complex case is noted in the docstring.

Roadmap: Multiquadratic
