### PR TITLE
feat: bound Lie rank by Cartan dimension

### DIFF
--- a/TauCeti/Algebra/Lie/Weights/Rank.lean
+++ b/TauCeti/Algebra/Lie/Weights/Rank.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Rank
+public import Mathlib.Algebra.Module.Submodule.Union
+public import Mathlib.Algebra.Lie.Weights.Killing
+
+public section
+
+/-!
+# A Cartan subalgebra contains a generic element
+
+Let `L` be a finite-dimensional Lie algebra over an infinite field, and let `H` be a Cartan
+subalgebra whose action on `L` is triangularizable with linear weights. This file chooses an
+element `h : H` on which no root vanishes and proves that its Engel subalgebra is exactly `H`.
+Mathlib's generic-element definition of `LieAlgebra.rank` then gives
+
+`LieAlgebra.rank K L ≤ Module.finrank K H`.
+
+The construction has two ingredients. First, finitely many nonzero linear functionals cannot
+cover a vector space over an infinite field, so there is an `h` outside every root hyperplane.
+Second, the generalized Cartan weight spaces span `L`. The generalized zero eigenspace of `ad h`
+therefore receives only the zero weight space: every nonzero weight is a root, and its value at `h`
+is nonzero by construction. The zero root space is the Cartan subalgebra.
+
+## Main results
+
+* `TauCeti.exists_cartan_avoiding_roots`: some element of `H` avoids every root hyperplane.
+* `TauCeti.engel_coe_eq_cartan_of_forall_root_apply_ne_zero`: any such element has Engel
+  subalgebra `H`.
+* `TauCeti.exists_engel_coe_eq_cartan`: a Cartan subalgebra is the Engel subalgebra of one of its
+  elements.
+* `TauCeti.rank_le_finrank_cartan`: the rank of `L` is at most the dimension of `H`.
+
+This is a direct prerequisite for the Layer 9 target `rank_eq_finrank_cartan` in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean`. It supplies only the
+`rank ≤ dim H` direction. The reverse inequality needs a separate minimal-centralizer or
+Cartan-dimension argument and is deliberately not asserted here.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Springer GTM 9
+  (1972), §8.1.
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule Module
+
+variable {K L : Type*} [Field K] [LieRing L] [LieAlgebra K L] [FiniteDimensional K L]
+  (H : LieSubalgebra K L) [H.IsCartanSubalgebra]
+
+/-- **A generic element of a Cartan subalgebra avoids every root hyperplane.** Since the root set
+is finite and each root is a nonzero linear functional, finite hyperplane avoidance over the
+infinite field `K` supplies one `h : H` on which every root is nonzero. -/
+theorem exists_cartan_avoiding_roots [Infinite K] [LieModule.LinearWeights K H L] :
+    ∃ h : H, ∀ α ∈ H.root, (α : H → K) h ≠ 0 := by
+  let f : H.root → Module.Dual K H := fun α ↦ (α.1 : H →ₗ[K] K)
+  obtain ⟨h, hh⟩ := Module.Dual.exists_forall_ne_zero_of_forall_exists f fun α ↦ by
+    simpa [f] using DFunLike.ne_iff.mp
+      (Weight.coe_toLinear_ne_zero_iff.mpr (H.isNonZero_coe_root α))
+  exact ⟨h, fun α hα ↦ hh ⟨α, hα⟩⟩
+
+/-- **A root-regular Cartan element has Engel subalgebra equal to the Cartan subalgebra.** The
+Engel subalgebra is the generalized zero eigenspace of `ad h`. Decomposing that eigenspace into
+Cartan weight spaces leaves only the zero weight: a nonzero weight is a root, and hence does not
+vanish at `h` by hypothesis. -/
+theorem engel_coe_eq_cartan_of_forall_root_apply_ne_zero {h : H}
+    [LieModule.IsTriangularizable K H L]
+    (hh : ∀ α ∈ H.root, (α : H → K) h ≠ 0) :
+    LieSubalgebra.engel K (h : L) = H := by
+  let N : LieSubmodule K H L := genWeightSpaceOf L 0 h
+  have hN_le : N ≤ rootSpace H 0 := by
+    rw [eq_iSup_inf_genWeightSpace K H L N]
+    refine iSup_le fun χ ↦ ?_
+    by_cases hχ : χ.IsZero
+    · rw [hχ.eq]
+      exact inf_le_right
+    · have hχroot : χ ∈ H.root := by
+        simpa [LieSubalgebra.root] using hχ
+      have hχh : χ h ≠ 0 := hh χ hχroot
+      have hdisj : Disjoint N (genWeightSpace L χ) :=
+        (disjoint_genWeightSpaceOf K H L hχh.symm).mono_right
+          (genWeightSpace_le_genWeightSpaceOf L h χ)
+      simp [hdisj.eq_bot]
+  have hN : N = rootSpace H 0 :=
+    le_antisymm hN_le (genWeightSpace_le_genWeightSpaceOf L h 0)
+  apply LieSubalgebra.toSubmodule_injective
+  calc
+    (LieSubalgebra.engel K (h : L)).toSubmodule = N.toSubmodule := rfl
+    _ = (rootSpace H 0).toSubmodule := congrArg LieSubmodule.toSubmodule hN
+    _ = H.toSubmodule := congrArg LieSubmodule.toSubmodule (rootSpace_zero_eq K L H)
+
+/-- **Every Cartan subalgebra is the Engel subalgebra of one of its elements** when its action has
+linear weights and is triangularizable over an infinite field. -/
+theorem exists_engel_coe_eq_cartan [Infinite K] [LieModule.LinearWeights K H L]
+    [LieModule.IsTriangularizable K H L] :
+    ∃ h : H, LieSubalgebra.engel K (h : L) = H := by
+  obtain ⟨h, hh⟩ := exists_cartan_avoiding_roots H
+  exact ⟨h, engel_coe_eq_cartan_of_forall_root_apply_ne_zero H hh⟩
+
+/-- **The rank is at most the dimension of a Cartan subalgebra.** Choose a root-regular Cartan
+element whose Engel subalgebra is `H`, then apply Mathlib's generic rank bound
+`LieAlgebra.rank_le_finrank_engel`. -/
+theorem rank_le_finrank_cartan [Infinite K] [LieModule.LinearWeights K H L]
+    [LieModule.IsTriangularizable K H L] :
+    LieAlgebra.rank K L ≤ finrank K H := by
+  obtain ⟨h, hh⟩ := exists_engel_coe_eq_cartan H
+  rw [← hh]
+  exact LieAlgebra.rank_le_finrank_engel K (h : L)
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Weights/Rank.lean
+++ b/TauCeti/Algebra/Lie/Weights/Rank.lean
@@ -65,6 +65,16 @@ theorem exists_cartan_avoiding_roots [Infinite K] [LieModule.LinearWeights K H L
       (Weight.coe_toLinear_ne_zero_iff.mpr (H.isNonZero_coe_root α))
   exact ⟨h, fun α hα ↦ hh ⟨α, hα⟩⟩
 
+omit [FiniteDimensional K L] in
+private theorem engel_toSubmodule_eq_genWeightSpaceOf_zero {h : H} :
+    (LieSubalgebra.engel K (h : L)).toSubmodule =
+      (genWeightSpaceOf L 0 h).toSubmodule := by
+  ext x
+  rw [LieSubalgebra.mem_toSubmodule, LieSubmodule.mem_toSubmodule,
+    LieSubalgebra.mem_engel_iff, LieModule.mem_genWeightSpaceOf]
+  simp only [zero_smul, sub_zero, LieSubalgebra.toEnd_eq]
+  rfl
+
 /-- **A root-regular Cartan element has Engel subalgebra equal to the Cartan subalgebra.** The
 Engel subalgebra is the generalized zero eigenspace of `ad h`. Decomposing that eigenspace into
 Cartan weight spaces leaves only the zero weight: a nonzero weight is a root, and hence does not
@@ -91,7 +101,8 @@ theorem engel_coe_eq_cartan_of_forall_root_apply_ne_zero {h : H}
     le_antisymm hN_le (genWeightSpace_le_genWeightSpaceOf L h 0)
   apply LieSubalgebra.toSubmodule_injective
   calc
-    (LieSubalgebra.engel K (h : L)).toSubmodule = N.toSubmodule := rfl
+    (LieSubalgebra.engel K (h : L)).toSubmodule = N.toSubmodule :=
+      engel_toSubmodule_eq_genWeightSpaceOf_zero H
     _ = (rootSpace H 0).toSubmodule := congrArg LieSubmodule.toSubmodule hN
     _ = H.toSubmodule := congrArg LieSubmodule.toSubmodule (rootSpace_zero_eq K L H)
 

--- a/TauCeti/Algebra/Lie/Weights/Rank.lean
+++ b/TauCeti/Algebra/Lie/Weights/Rank.lean
@@ -72,8 +72,7 @@ private theorem engel_toSubmodule_eq_genWeightSpaceOf_zero {h : H} :
   ext x
   rw [LieSubalgebra.mem_toSubmodule, LieSubmodule.mem_toSubmodule,
     LieSubalgebra.mem_engel_iff, LieModule.mem_genWeightSpaceOf]
-  simp only [zero_smul, sub_zero, LieSubalgebra.toEnd_eq]
-  rfl
+  simp only [zero_smul, sub_zero, LieAlgebra.ad, LieSubalgebra.toEnd_eq]
 
 /-- **A root-regular Cartan element has Engel subalgebra equal to the Cartan subalgebra.** The
 Engel subalgebra is the generalized zero eigenspace of `ad h`. Decomposing that eigenspace into

--- a/TauCeti/Algebra/Lie/Weights/Rank.lean
+++ b/TauCeti/Algebra/Lie/Weights/Rank.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Lie.Rank
-public import Mathlib.Algebra.Module.Submodule.Union
+import Mathlib.Algebra.Module.Submodule.Union
 public import Mathlib.Algebra.Lie.Weights.Killing
 
 public section

--- a/TauCeti/Algebra/Lie/Weights/Rank.lean
+++ b/TauCeti/Algebra/Lie/Weights/Rank.lean
@@ -17,7 +17,7 @@ public section
 Let `L` be a finite-dimensional Lie algebra over an infinite field, and let `H` be a Cartan
 subalgebra whose action on `L` is triangularizable with linear weights. This file chooses an
 element `h : H` on which no root vanishes and proves that its Engel subalgebra is exactly `H`.
-Mathlib's generic-element definition of `LieAlgebra.rank` then gives
+Mathlib's lower bound on the dimension of each Engel subalgebra then gives
 
 `LieAlgebra.rank K L ≤ Module.finrank K H`.
 
@@ -29,10 +29,10 @@ is nonzero by construction. The zero root space is the Cartan subalgebra.
 
 ## Main results
 
-* `TauCeti.exists_cartan_avoiding_roots`: some element of `H` avoids every root hyperplane.
-* `TauCeti.engel_coe_eq_cartan_of_forall_root_apply_ne_zero`: any such element has Engel
+* `TauCeti.exists_forall_root_apply_ne_zero`: some element of `H` is nonzero under every root.
+* `TauCeti.engel_eq_cartan_of_forall_root_apply_ne_zero`: any such element has Engel
   subalgebra `H`.
-* `TauCeti.exists_engel_coe_eq_cartan`: a Cartan subalgebra is the Engel subalgebra of one of its
+* `TauCeti.exists_engel_eq_cartan`: a Cartan subalgebra is the Engel subalgebra of one of its
   elements.
 * `TauCeti.rank_le_finrank_cartan`: the rank of `L` is at most the dimension of `H`.
 
@@ -44,7 +44,7 @@ Cartan-dimension argument and is deliberately not asserted here.
 ## References
 
 * J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Springer GTM 9
-  (1972), §8.1.
+  (1972), §15.1--15.3.
 -/
 
 namespace TauCeti
@@ -57,7 +57,7 @@ variable {K L : Type*} [Field K] [LieRing L] [LieAlgebra K L] [FiniteDimensional
 /-- **A generic element of a Cartan subalgebra avoids every root hyperplane.** Since the root set
 is finite and each root is a nonzero linear functional, finite hyperplane avoidance over the
 infinite field `K` supplies one `h : H` on which every root is nonzero. -/
-theorem exists_cartan_avoiding_roots [Infinite K] [LieModule.LinearWeights K H L] :
+theorem exists_forall_root_apply_ne_zero [Infinite K] [LieModule.LinearWeights K H L] :
     ∃ h : H, ∀ α ∈ H.root, (α : H → K) h ≠ 0 := by
   let f : H.root → Module.Dual K H := fun α ↦ (α.1 : H →ₗ[K] K)
   obtain ⟨h, hh⟩ := Module.Dual.exists_forall_ne_zero_of_forall_exists f fun α ↦ by
@@ -79,7 +79,7 @@ private theorem engel_toSubmodule_eq_genWeightSpaceOf_zero {h : H} :
 Engel subalgebra is the generalized zero eigenspace of `ad h`. Decomposing that eigenspace into
 Cartan weight spaces leaves only the zero weight: a nonzero weight is a root, and hence does not
 vanish at `h` by hypothesis. -/
-theorem engel_coe_eq_cartan_of_forall_root_apply_ne_zero {h : H}
+theorem engel_eq_cartan_of_forall_root_apply_ne_zero {h : H}
     [LieModule.IsTriangularizable K H L]
     (hh : ∀ α ∈ H.root, (α : H → K) h ≠ 0) :
     LieSubalgebra.engel K (h : L) = H := by
@@ -108,19 +108,19 @@ theorem engel_coe_eq_cartan_of_forall_root_apply_ne_zero {h : H}
 
 /-- **Every Cartan subalgebra is the Engel subalgebra of one of its elements** when its action has
 linear weights and is triangularizable over an infinite field. -/
-theorem exists_engel_coe_eq_cartan [Infinite K] [LieModule.LinearWeights K H L]
+theorem exists_engel_eq_cartan [Infinite K] [LieModule.LinearWeights K H L]
     [LieModule.IsTriangularizable K H L] :
     ∃ h : H, LieSubalgebra.engel K (h : L) = H := by
-  obtain ⟨h, hh⟩ := exists_cartan_avoiding_roots H
-  exact ⟨h, engel_coe_eq_cartan_of_forall_root_apply_ne_zero H hh⟩
+  obtain ⟨h, hh⟩ := exists_forall_root_apply_ne_zero H
+  exact ⟨h, engel_eq_cartan_of_forall_root_apply_ne_zero H hh⟩
 
 /-- **The rank is at most the dimension of a Cartan subalgebra.** Choose a root-regular Cartan
-element whose Engel subalgebra is `H`, then apply Mathlib's generic rank bound
+element whose Engel subalgebra is `H`, then apply Mathlib's Engel-subalgebra dimension bound
 `LieAlgebra.rank_le_finrank_engel`. -/
 theorem rank_le_finrank_cartan [Infinite K] [LieModule.LinearWeights K H L]
     [LieModule.IsTriangularizable K H L] :
     LieAlgebra.rank K L ≤ finrank K H := by
-  obtain ⟨h, hh⟩ := exists_engel_coe_eq_cartan H
+  obtain ⟨h, hh⟩ := exists_engel_eq_cartan H
   rw [← hh]
   exact LieAlgebra.rank_le_finrank_engel K (h : L)
 


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Bounds Lie algebra rank by Cartan dimension: choose a Cartan element avoiding every root, identify its Engel subalgebra with the Cartan subalgebra, then apply Mathlib's Engel rank bound.

## Roadmap target

Supplies one direction of [`rank_eq_finrank_cartan`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L465-L472).

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#rank_eq_finrank_cartan"}-->

## Verification

Exact-pinned repair validation, consumer probes, proof golf, and a fresh full-aggregate local `2+1` review pass at `c5cd241f72c40a9acbb38e58bda678e414742021`.

## Scale and generality

Adds 126 lines. Applies to finite-dimensional Lie algebras over an infinite field when the Cartan action has linear weights and is triangularizable.

## Scope

- **Consumes:** Cartan root decomposition and the Engel rank bound.
- **Provides:** root avoidance, Cartan–Engel identification, and `rank ≤ finrank H`.
- **Fits:** one half of the roadmap's Cartan-rank equality.
- **Boundary:** the reverse inequality and equality remain downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [f854a7e](https://github.com/TauCetiProject/TauCetiReview/commit/f854a7e1bf95d7182f672ea06e690d08b07e06a5) · local 2+1 review @ [ut-lean-review f2fc03b](https://github.com/utensil/formal-land/commit/f2fc03bbb24923dcfbd379183d3afeb7b26f1b12) fixed: proof-quality (1)</sub>
