### PR TITLE
feat: identify the spinor glue lattice D₈⁺ with the E₈ root lattice

### DIFF
--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Basic.lean
@@ -36,6 +36,8 @@ does not need a change of coordinates.
 * `TauCeti.IntegralLattice.mem_d8PlusCarrier_iff`: the formula
   `D₈⁺ = D₈ ∪ (s + D₈)`.
 * `TauCeti.IntegralLattice.d8PlusLattice`: the resulting even integral lattice.
+* `TauCeti.IntegralLattice.toIntegralLattice_eq_d8PlusLattice`: the general glued-overlattice
+  construction along the spinor subgroup is `d8PlusLattice`.
 * `TauCeti.IntegralLattice.isUnimodular_d8PlusLattice`: `D₈⁺` is unimodular.
 
 ## References
@@ -160,6 +162,14 @@ theorem isEven_d8PlusCarrier : IntermediateCarrier.IsEven d8PlusCarrier := by
 dot product as the checkerboard lattice. -/
 noncomputable def d8PlusLattice : IntegralLattice (Fin 8 → ℚ) :=
   isEven_d8PlusCarrier.isIntegral.toIntegralLattice
+
+/-- The even overlattice glued along the spinor subgroup is the `D₈⁺` lattice.  This exposes
+`d8PlusLattice` to the general overlattice theorems, which name the glued lattice through a proof
+of evenness of the inverse image. -/
+theorem toIntegralLattice_eq_d8PlusLattice
+    (h : IntermediateCarrier.IsEven
+      ((checkerboardLattice 8).intermediateCarrierOfDiscriminantSubgroup d8SpinorSubgroup)) :
+    h.isIntegral.toIntegralLattice = d8PlusLattice := (rfl)
 
 /-- The carrier of the `D₈⁺` lattice is the spinor glue carrier. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
@@ -1,0 +1,374 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient
+public import TauCeti.LinearAlgebra.IntegralLattice.RootLattice.D8Plus.Basic
+public import TauCeti.LinearAlgebra.IntegralLattice.RootLattice.TypeE
+
+/-!
+# The spinor glue lattice `D₈⁺` is the `E₈` root lattice
+
+The lattice `D₈⁺ = D₈ ∪ (s + D₈)` built by gluing the rank-eight checkerboard lattice along its
+spinor class is even and unimodular.  This file proves the sharper statement that it *is* the
+root lattice of type `E₈`, by exhibiting an explicit isometry
+
+```text
+E₈ ≃ D₈⁺.
+```
+
+The isometry is the rational linear map carrying the `i`-th standard coordinate vector of the
+simple-root model of `E₈` to the `i`-th vector of Bourbaki's plate VII, written in the
+Conway--Sloane coordinates of `D₈`:
+
+```text
+α₁ = (e₁ - e₂ - e₃ - e₄ - e₅ - e₆ - e₇ + e₈) / 2,
+α₂ = e₁ + e₂,   α₃ = e₂ - e₁,   α₄ = e₃ - e₂,   α₅ = e₄ - e₃,
+α₆ = e₅ - e₄,   α₇ = e₆ - e₅,   α₈ = e₇ - e₆.
+```
+
+Only `α₁` leaves the checkerboard lattice, and it does so by exactly the Conway--Sloane spinor
+vector `s = (e₁ + ⋯ + e₈) / 2`, so all eight vectors lie in `D₈⁺`.
+
+Three facts turn that list into an isometry of integral lattices.
+
+* Their Gram matrix for the standard dot product is `CartanMatrix.E 8`.  This is checked from
+  doubled integer coordinates, so the verification is a decidable statement about integer
+  matrices.
+* The associated linear map is injective, because the `E₈` form is nondegenerate and the map
+  intertwines the two forms; an injective endomorphism of `ℚ⁸` is bijective.
+* Its image is the whole of `D₈⁺`.  One inclusion is the membership check above.  For the other,
+  a vector `x ∈ D₈⁺` has a rational preimage `u`, and `⟨u, v⟩_{E₈} = ⟨x, Φ v⟩` is an integer for
+  every `v` in the `E₈` carrier because `D₈⁺` is integral; so `u` lies in the dual of the `E₈`
+  root lattice, which is the `E₈` root lattice itself.
+
+The last step is where unimodularity of `E₈` enters, and it is what makes the inclusion an
+equality without any determinant computation.  In particular the conclusion is a genuine lattice
+isometry and not the invalid inference that two even unimodular rank-eight lattices must be
+isometric.
+
+Being an isometry, it transports every invariant: `D₈⁺` inherits the `E₈` root system's
+determinant `1` and trivial discriminant group, which is also what the general overlattice
+comparison `A_{L_H} ≅ H⊥ / H` predicts for the order-two spinor glue subgroup `H`.
+
+## Main declarations
+
+* `TauCeti.IntegralLattice.e8GlueRoot`: the eight Bourbaki simple roots of `E₈`, in the
+  coordinates of the Conway--Sloane model of `D₈`.
+* `TauCeti.IntegralLattice.form_e8GlueRoot_e8GlueRoot`: their Gram matrix is `CartanMatrix.E 8`.
+* `TauCeti.IntegralLattice.e8GlueRoot_mem_d8PlusCarrier`: they lie in `D₈⁺`.
+* `TauCeti.IntegralLattice.span_range_e8GlueRoot`: they span `D₈⁺` over `ℤ`.
+* `TauCeti.IntegralLattice.e8GlueMap` and `TauCeti.IntegralLattice.e8GlueEquiv`: the rational
+  comparison map and the linear equivalence it underlies.
+* `TauCeti.IntegralLattice.typeE₈IsometryD8Plus` and
+  `TauCeti.IntegralLattice.d8PlusIsometryTypeE₈`: **the isometry `E₈ ≃ D₈⁺` and its inverse.**
+* `TauCeti.IntegralLattice.d8PlusDiscriminantQuadraticIsometry`: the discriminant quadratic form
+  of `D₈⁺` is that of `E₈`.
+* `TauCeti.IntegralLattice.natCard_orthogonalQuotient_d8SpinorSubgroup`: the general comparison
+  gives `H⊥ / H = 0`, agreeing with the direct `E₈` computation.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, plate VII.
+* J. H. Conway and N. J. A. Sloane, *Sphere Packings, Lattices and Groups*, §4.8.1.
+* W. Ebeling, *Lattices and Codes*, Chapter 3.
+* `TauCetiRoadmap/IntegralLattices/README.md`, Layer 5, the `D₈ ⊂ E₈` glue calculation.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace IntegralLattice
+
+open Module
+
+/-! ## The Bourbaki simple roots in Conway--Sloane coordinates -/
+
+/-- The doubled standard coordinates of the eight simple roots of `E₈`: row `i` of this integer
+matrix is `2αᵢ₊₁` in the Conway--Sloane coordinates of `D₈`, following Bourbaki's plate VII.
+
+Doubling clears the halves in `α₁`, so that every check on these vectors reduces to a decidable
+statement about integers. -/
+def e8GlueCoeff : Fin 8 → Fin 8 → ℤ :=
+  ![![ 1, -1, -1, -1, -1, -1, -1,  1],
+    ![ 2,  2,  0,  0,  0,  0,  0,  0],
+    ![-2,  2,  0,  0,  0,  0,  0,  0],
+    ![ 0, -2,  2,  0,  0,  0,  0,  0],
+    ![ 0,  0, -2,  2,  0,  0,  0,  0],
+    ![ 0,  0,  0, -2,  2,  0,  0,  0],
+    ![ 0,  0,  0,  0, -2,  2,  0,  0],
+    ![ 0,  0,  0,  0,  0, -2,  2,  0]]
+
+/-- The `i`-th simple root of `E₈` in Bourbaki's numbering, written in the standard coordinates of
+the Conway--Sloane model of `D₈`. -/
+def e8GlueRoot (i : Fin 8) : Fin 8 → ℚ := fun j ↦ (e8GlueCoeff i j : ℚ) / 2
+
+/-- The coordinates of a glue root are half the corresponding doubled integer coordinates. -/
+@[simp]
+theorem e8GlueRoot_apply (i j : Fin 8) :
+    e8GlueRoot i j = (e8GlueCoeff i j : ℚ) / 2 := by
+  rw [e8GlueRoot]
+
+/-! ## The Gram matrix -/
+
+/-- The doubled Gram matrix of the glue roots is four times `CartanMatrix.E 8`. -/
+private theorem sum_e8GlueCoeff_mul_e8GlueCoeff (i j : Fin 8) :
+    ∑ k, e8GlueCoeff i k * e8GlueCoeff j k = 4 * (CartanMatrix.E 8) i j := by
+  revert i j
+  decide
+
+/-- **The Gram matrix of the eight glue roots is the Cartan matrix of type `E₈`.** -/
+theorem form_e8GlueRoot_e8GlueRoot (i j : Fin 8) :
+    (checkerboardLattice 8).form (e8GlueRoot i) (e8GlueRoot j) =
+      (((CartanMatrix.E 8) i j : ℤ) : ℚ) := by
+  have hcast : ((∑ k, e8GlueCoeff i k * e8GlueCoeff j k : ℤ) : ℚ)
+      = ((4 * (CartanMatrix.E 8) i j : ℤ) : ℚ) := by
+    rw [sum_e8GlueCoeff_mul_e8GlueCoeff]
+  push_cast at hcast
+  rw [checkerboardLattice_form_apply]
+  have hsplit : ∑ k, e8GlueRoot i k * e8GlueRoot j k
+      = (∑ k, ((e8GlueCoeff i k : ℚ) * (e8GlueCoeff j k : ℚ))) / 4 := by
+    rw [Finset.sum_div]
+    exact Finset.sum_congr rfl fun k _ ↦ by rw [e8GlueRoot_apply, e8GlueRoot_apply]; ring
+  rw [hsplit, hcast]
+  ring
+
+/-! ## Membership in the glue lattice -/
+
+/-- The integer coordinates of the glue root `αᵢ₊₁`, after subtracting the spinor vector in the
+one case `i = 0` where the root is not already a checkerboard vector. -/
+private def e8GlueShift (i j : Fin 8) : ℤ :=
+  (e8GlueCoeff i j - if i = 0 then 1 else 0) / 2
+
+private theorem two_mul_e8GlueShift (i j : Fin 8) :
+    2 * e8GlueShift i j = e8GlueCoeff i j - if i = 0 then 1 else 0 := by
+  revert i j
+  decide
+
+/-- Half the coordinate sum of the shifted glue root `αᵢ₊₁`. -/
+private def e8GlueShiftHalf (i : Fin 8) : ℤ := (∑ j, e8GlueShift i j) / 2
+
+private theorem sum_e8GlueShift (i : Fin 8) :
+    ∑ j, e8GlueShift i j = 2 * e8GlueShiftHalf i := by
+  revert i
+  decide
+
+/-- Every shifted glue root is an integer vector of even coordinate sum, hence a checkerboard
+vector. -/
+private theorem e8GlueShift_mem_checkerboardLattice (i : Fin 8) :
+    (fun j ↦ ((e8GlueShift i j : ℤ) : ℚ)) ∈ (checkerboardLattice 8).carrier := by
+  refine (mem_checkerboardLattice_carrier_iff _).mpr
+    ⟨fun j ↦ ⟨e8GlueShift i j, rfl⟩, e8GlueShiftHalf i, ?_⟩
+  have hcast : ((∑ j, e8GlueShift i j : ℤ) : ℚ) = ((2 * e8GlueShiftHalf i : ℤ) : ℚ) := by
+    rw [sum_e8GlueShift]
+  push_cast at hcast
+  exact hcast
+
+/-- The first glue root differs from the spinor vector by a checkerboard vector. -/
+private theorem e8GlueRoot_zero_sub_spinor :
+    e8GlueRoot 0 - checkerboardSpinor 8 = fun j ↦ ((e8GlueShift 0 j : ℤ) : ℚ) := by
+  funext j
+  have h : ((2 * e8GlueShift 0 j : ℤ) : ℚ) = ((e8GlueCoeff 0 j - 1 : ℤ) : ℚ) := by
+    rw [two_mul_e8GlueShift]
+    simp
+  push_cast at h
+  rw [Pi.sub_apply, e8GlueRoot_apply, checkerboardSpinor_apply]
+  linarith
+
+/-- Every glue root other than the first is already a checkerboard vector. -/
+private theorem e8GlueRoot_of_ne_zero (i : Fin 8) (hi : i ≠ 0) :
+    e8GlueRoot i = fun j ↦ ((e8GlueShift i j : ℤ) : ℚ) := by
+  funext j
+  have h : ((2 * e8GlueShift i j : ℤ) : ℚ) = ((e8GlueCoeff i j : ℤ) : ℚ) := by
+    rw [two_mul_e8GlueShift]
+    simp [hi]
+  push_cast at h
+  rw [e8GlueRoot_apply]
+  linarith
+
+/-- **Every glue root lies in `D₈⁺`**: the first differs from the spinor vector by a checkerboard
+vector, and the other seven are checkerboard vectors. -/
+theorem e8GlueRoot_mem_d8PlusCarrier (i : Fin 8) : e8GlueRoot i ∈ d8PlusCarrier.1 := by
+  rw [mem_d8PlusCarrier_iff]
+  rcases eq_or_ne i 0 with rfl | hi
+  · exact Or.inr (e8GlueRoot_zero_sub_spinor ▸ e8GlueShift_mem_checkerboardLattice 0)
+  · exact Or.inl (e8GlueRoot_of_ne_zero i hi ▸ e8GlueShift_mem_checkerboardLattice i)
+
+/-! ## The comparison map -/
+
+/-- The simple roots of the `E₈` root lattice are the standard coordinate vectors. -/
+private theorem typeE₈SimpleRoot_eq_basisFun (i : Fin 8) :
+    typeE₈SimpleRoot i = Pi.basisFun ℚ (Fin 8) i := by
+  funext j
+  rw [typeE₈SimpleRoot_apply, Pi.basisFun_apply, Pi.single_apply]
+
+/-- The carrier of the `E₈` root lattice is the standard integral lattice `ℤ⁸`. -/
+private theorem carrier_typeE₈RootLattice :
+    typeE₈RootLattice.carrier = Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin 8))) := by
+  ext x
+  rw [mem_typeE₈RootLattice_carrier_iff, Module.Basis.mem_span_iff_repr_mem]
+  simp [Pi.basisFun_repr]
+
+/-- The rational linear map sending the `i`-th simple root of the `E₈` root lattice to the `i`-th
+glue root of `D₈⁺`. -/
+noncomputable def e8GlueMap : (Fin 8 → ℚ) →ₗ[ℚ] (Fin 8 → ℚ) :=
+  (Pi.basisFun ℚ (Fin 8)).constr ℚ e8GlueRoot
+
+/-- The comparison map sends the `i`-th standard coordinate vector to the `i`-th glue root. -/
+-- This is not a `simp` lemma because `Pi.basisFun_apply` rewrites beneath its left-hand side;
+-- the sealed simple-root form `e8GlueMap_typeE₈SimpleRoot` is the `simp` version.
+theorem e8GlueMap_basisFun (i : Fin 8) :
+    e8GlueMap (Pi.basisFun ℚ (Fin 8) i) = e8GlueRoot i := by
+  rw [e8GlueMap]
+  exact (Pi.basisFun ℚ (Fin 8)).constr_basis ℚ e8GlueRoot i
+
+/-- The comparison map sends the `i`-th simple root of `E₈` to the `i`-th glue root. -/
+@[simp]
+theorem e8GlueMap_typeE₈SimpleRoot (i : Fin 8) :
+    e8GlueMap (typeE₈SimpleRoot i) = e8GlueRoot i := by
+  rw [typeE₈SimpleRoot_eq_basisFun]
+  exact e8GlueMap_basisFun i
+
+/-- **The comparison map intertwines the two forms**: the standard dot product pulled back along
+it is the `E₈` form. -/
+theorem form_comp_e8GlueMap :
+    (checkerboardLattice 8).form.comp e8GlueMap e8GlueMap = typeE₈RootLattice.form := by
+  refine LinearMap.BilinForm.ext_basis (Pi.basisFun ℚ (Fin 8)) fun i j ↦ ?_
+  rw [LinearMap.BilinForm.comp_apply, e8GlueMap_basisFun, e8GlueMap_basisFun,
+    form_e8GlueRoot_e8GlueRoot, ← typeE₈SimpleRoot_eq_basisFun,
+    ← typeE₈SimpleRoot_eq_basisFun, form_typeE₈SimpleRoot_typeE₈SimpleRoot]
+
+/-- The comparison map carries the `E₈` form to the standard dot product. -/
+theorem form_e8GlueMap (x y : Fin 8 → ℚ) :
+    (checkerboardLattice 8).form (e8GlueMap x) (e8GlueMap y) = typeE₈RootLattice.form x y := by
+  conv_rhs => rw [← form_comp_e8GlueMap]
+  rw [LinearMap.BilinForm.comp_apply]
+
+/-- The comparison map is injective, because the `E₈` form is nondegenerate. -/
+private theorem e8GlueMap_injective : Function.Injective e8GlueMap := by
+  rw [← LinearMap.ker_eq_bot, LinearMap.ker_eq_bot']
+  intro x hx
+  refine typeE₈RootLattice.form_nondegenerate.1 x fun y ↦ ?_
+  rw [← form_e8GlueMap x y, hx]
+  simp
+
+/-- The comparison map as a rational linear equivalence: an injective endomorphism of a
+finite-dimensional space is bijective. -/
+noncomputable def e8GlueEquiv : (Fin 8 → ℚ) ≃ₗ[ℚ] (Fin 8 → ℚ) :=
+  LinearEquiv.ofBijective e8GlueMap
+    ⟨e8GlueMap_injective, LinearMap.injective_iff_surjective.mp e8GlueMap_injective⟩
+
+@[simp]
+theorem e8GlueEquiv_apply (x : Fin 8 → ℚ) : e8GlueEquiv x = e8GlueMap x := by
+  rw [e8GlueEquiv]
+  exact LinearEquiv.ofBijective_apply _ _
+
+/-! ## The image of the `E₈` carrier -/
+
+/-- The comparison equivalence carries the `E₈` carrier onto the integral span of the glue
+roots. -/
+theorem map_carrier_e8GlueEquiv :
+    typeE₈RootLattice.carrier.map (e8GlueEquiv.restrictScalars ℤ).toLinearMap =
+      Submodule.span ℤ (Set.range e8GlueRoot) := by
+  have hrange : ⇑(e8GlueEquiv.restrictScalars ℤ).toLinearMap ∘ ⇑(Pi.basisFun ℚ (Fin 8))
+      = e8GlueRoot := by
+    funext i
+    exact (e8GlueEquiv_apply _).trans (e8GlueMap_basisFun i)
+  rw [carrier_typeE₈RootLattice, Submodule.map_span, ← Set.range_comp, hrange]
+
+private theorem span_range_e8GlueRoot_le :
+    Submodule.span ℤ (Set.range e8GlueRoot) ≤ d8PlusCarrier.1 := by
+  rw [Submodule.span_le]
+  rintro _ ⟨i, rfl⟩
+  exact e8GlueRoot_mem_d8PlusCarrier i
+
+/-- **The glue roots span `D₈⁺` over `ℤ`.**
+
+One inclusion is the membership of each root.  For the other, the preimage of a vector of `D₈⁺`
+pairs integrally with the whole `E₈` carrier, because `D₈⁺` is an integral lattice containing the
+image of that carrier; so the preimage lies in the dual of the `E₈` root lattice, which by
+unimodularity is the `E₈` root lattice itself. -/
+theorem span_range_e8GlueRoot :
+    Submodule.span ℤ (Set.range e8GlueRoot) = d8PlusCarrier.1 := by
+  refine le_antisymm span_range_e8GlueRoot_le fun x hx ↦ ?_
+  have hxmem : x ∈ d8PlusLattice.carrier := by
+    rw [d8PlusLattice_carrier]
+    exact hx
+  have hxu : e8GlueMap (e8GlueEquiv.symm x) = x := by
+    rw [← e8GlueEquiv_apply]
+    exact e8GlueEquiv.apply_symm_apply x
+  have hdual : e8GlueEquiv.symm x ∈ typeE₈RootLattice.dualCarrier := by
+    intro v hv
+    have hv' : e8GlueMap v ∈ d8PlusLattice.carrier := by
+      rw [d8PlusLattice_carrier]
+      refine span_range_e8GlueRoot_le ?_
+      rw [← map_carrier_e8GlueEquiv]
+      exact ⟨v, hv, (e8GlueEquiv_apply v).symm ▸ rfl⟩
+    have hpair := d8PlusLattice.le_dual hxmem (e8GlueMap v) hv'
+    rw [d8PlusLattice_form] at hpair
+    rwa [← form_e8GlueMap _ v, hxu]
+  rw [dualCarrier_typeE₈RootLattice] at hdual
+  rw [← map_carrier_e8GlueEquiv]
+  exact ⟨e8GlueEquiv.symm x, hdual, (e8GlueEquiv_apply _).trans hxu⟩
+
+/-! ## The isometry -/
+
+/-- **The `E₈` root lattice is isometric to the spinor glue lattice `D₈⁺`.**
+
+The underlying rational equivalence sends the `i`-th simple root of `E₈` to the `i`-th vector of
+Bourbaki's plate VII in Conway--Sloane coordinates. -/
+noncomputable def typeE₈IsometryD8Plus : Isometry typeE₈RootLattice d8PlusLattice where
+  toIsometryEquiv :=
+    { toLinearEquiv := e8GlueEquiv
+      map_app' := fun x y ↦ by
+        rw [d8PlusLattice_form]
+        exact form_e8GlueMap x y }
+  map_carrier := by
+    rw [map_carrier_e8GlueEquiv, span_range_e8GlueRoot, d8PlusLattice_carrier]
+
+@[simp]
+theorem typeE₈IsometryD8Plus_apply (x : Fin 8 → ℚ) :
+    typeE₈IsometryD8Plus x = e8GlueMap x := by
+  rw [typeE₈IsometryD8Plus]
+  exact e8GlueEquiv_apply x
+
+/-- **The isometry sends the `i`-th `E₈` simple root to the `i`-th glue root.** -/
+theorem typeE₈IsometryD8Plus_typeE₈SimpleRoot (i : Fin 8) :
+    typeE₈IsometryD8Plus (typeE₈SimpleRoot i) = e8GlueRoot i := by
+  rw [typeE₈IsometryD8Plus_apply, e8GlueMap_typeE₈SimpleRoot]
+
+/-- **The spinor glue lattice `D₈⁺` is isometric to the `E₈` root lattice.** -/
+noncomputable def d8PlusIsometryTypeE₈ : Isometry d8PlusLattice typeE₈RootLattice :=
+  typeE₈IsometryD8Plus.symm
+
+/-! ## Agreement with the general overlattice comparison -/
+
+/-- **The discriminant quadratic form of `D₈⁺` is the discriminant quadratic form of `E₈`**, which
+is the trivial form on a trivial group. -/
+noncomputable def d8PlusDiscriminantQuadraticIsometry :
+    FiniteQuadraticModule.Isometry (d8PlusLattice.discriminantQuadraticModule isEven_d8PlusLattice)
+      (typeE₈RootLattice.discriminantQuadraticModule isEven_typeE₈RootLattice) :=
+  d8PlusIsometryTypeE₈.discriminantQuadraticIsometry isEven_d8PlusLattice
+
+/-- **The general overlattice comparison agrees with the direct `E₈` computation.**
+
+Nikulin's comparison identifies the discriminant group of the glued lattice `D₈⁺` with
+`H⊥ / H` for the order-two spinor glue subgroup `H`; the isometry above identifies it with the
+discriminant group of `E₈`.  Both are trivial. -/
+theorem natCard_orthogonalQuotient_d8SpinorSubgroup :
+    Nat.card (((checkerboardLattice 8).discriminantQuadraticModule
+      (isEven_checkerboardLattice 8)).orthogonalQuotient d8SpinorSubgroup
+        isIsotropic_d8SpinorSubgroup) = 1 := by
+  have hM := ((checkerboardLattice 8).isEven_intermediateCarrierOfDiscriminantSubgroup_iff
+    (isEven_checkerboardLattice 8) d8SpinorSubgroup).mpr isIsotropic_d8SpinorSubgroup
+  rw [natCard_orthogonalQuotient_of_subgroup (checkerboardLattice 8)
+    (isEven_checkerboardLattice 8) isIsotropic_d8SpinorSubgroup,
+    toIntegralLattice_eq_d8PlusLattice hM, discriminant_d8PlusLattice]
+
+end IntegralLattice
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.OrthogonalQuotient
 public import TauCeti.LinearAlgebra.IntegralLattice.RootLattice.D8Plus.Basic
 public import TauCeti.LinearAlgebra.IntegralLattice.RootLattice.TypeE
+public import TauCeti.LinearAlgebra.RootSystem.E8Coordinates
 
 /-!
 # The spinor glue lattice `D₈⁺` is the `E₈` root lattice
@@ -57,14 +58,15 @@ comparison `A_{L_H} ≅ H⊥ / H` predicts for the order-two spinor glue subgrou
 ## Main declarations
 
 * `TauCeti.IntegralLattice.e8GlueRoot`: the eight Bourbaki simple roots of `E₈`, in the
-  coordinates of the Conway--Sloane model of `D₈`.
+  coordinates of the Conway--Sloane model of `D₈`, read off the library's shared integral table
+  `TauCeti.DynkinType.e8DoubledSimpleRoot`.
 * `TauCeti.IntegralLattice.form_e8GlueRoot_e8GlueRoot`: their Gram matrix is `CartanMatrix.E 8`.
 * `TauCeti.IntegralLattice.e8GlueRoot_mem_d8PlusCarrier`: they lie in `D₈⁺`.
 * `TauCeti.IntegralLattice.span_range_e8GlueRoot`: they span `D₈⁺` over `ℤ`.
 * `TauCeti.IntegralLattice.e8GlueMap` and `TauCeti.IntegralLattice.e8GlueEquiv`: the rational
   comparison map and the linear equivalence it underlies.
-* `TauCeti.IntegralLattice.typeE₈IsometryD8Plus` and
-  `TauCeti.IntegralLattice.d8PlusIsometryTypeE₈`: **the isometry `E₈ ≃ D₈⁺` and its inverse.**
+* `TauCeti.IntegralLattice.typeE₈IsometryD8Plus`: **the isometry `E₈ ≃ D₈⁺`**, whose inverse
+  `typeE₈IsometryD8Plus.symm` is the isometry `D₈⁺ ≃ E₈`.
 * `TauCeti.IntegralLattice.d8PlusDiscriminantQuadraticIsometry`: the discriminant quadratic form
   of `D₈⁺` is that of `E₈`.
 * `TauCeti.IntegralLattice.natCard_orthogonalQuotient_d8SpinorSubgroup`: the general comparison
@@ -88,50 +90,35 @@ open Module
 
 /-! ## The Bourbaki simple roots in Conway--Sloane coordinates -/
 
-/-- The doubled standard coordinates of the eight simple roots of `E₈`: row `i` of this integer
-matrix is `2αᵢ₊₁` in the Conway--Sloane coordinates of `D₈`, following Bourbaki's plate VII.
-
-Doubling clears the halves in `α₁`, so that every check on these vectors reduces to a decidable
-statement about integers. -/
-def e8GlueCoeff : Fin 8 → Fin 8 → ℤ :=
-  ![![ 1, -1, -1, -1, -1, -1, -1,  1],
-    ![ 2,  2,  0,  0,  0,  0,  0,  0],
-    ![-2,  2,  0,  0,  0,  0,  0,  0],
-    ![ 0, -2,  2,  0,  0,  0,  0,  0],
-    ![ 0,  0, -2,  2,  0,  0,  0,  0],
-    ![ 0,  0,  0, -2,  2,  0,  0,  0],
-    ![ 0,  0,  0,  0, -2,  2,  0,  0],
-    ![ 0,  0,  0,  0,  0, -2,  2,  0]]
-
 /-- The `i`-th simple root of `E₈` in Bourbaki's numbering, written in the standard coordinates of
-the Conway--Sloane model of `D₈`. -/
-def e8GlueRoot (i : Fin 8) : Fin 8 → ℚ := fun j ↦ (e8GlueCoeff i j : ℚ) / 2
+the Conway--Sloane model of `D₈`.
+
+The coordinates are read off the library's shared integral table
+`TauCeti.DynkinType.e8DoubledSimpleRoot`, whose row `i` is `2αᵢ₊₁` in exactly these coordinates.
+The doubling there clears the halves in `α₁`, so that every check on these vectors reduces to a
+decidable statement about integers. -/
+def e8GlueRoot (i : Fin 8) : Fin 8 → ℚ :=
+  fun j ↦ (DynkinType.e8DoubledSimpleRoot i j : ℚ) / 2
 
 /-- The coordinates of a glue root are half the corresponding doubled integer coordinates. -/
 @[simp]
 theorem e8GlueRoot_apply (i j : Fin 8) :
-    e8GlueRoot i j = (e8GlueCoeff i j : ℚ) / 2 := by
+    e8GlueRoot i j = (DynkinType.e8DoubledSimpleRoot i j : ℚ) / 2 := by
   rw [e8GlueRoot]
 
 /-! ## The Gram matrix -/
-
-/-- The doubled Gram matrix of the glue roots is four times `CartanMatrix.E 8`. -/
-private theorem sum_e8GlueCoeff_mul_e8GlueCoeff (i j : Fin 8) :
-    ∑ k, e8GlueCoeff i k * e8GlueCoeff j k = 4 * (CartanMatrix.E 8) i j := by
-  revert i j
-  decide
 
 /-- **The Gram matrix of the eight glue roots is the Cartan matrix of type `E₈`.** -/
 theorem form_e8GlueRoot_e8GlueRoot (i j : Fin 8) :
     (checkerboardLattice 8).form (e8GlueRoot i) (e8GlueRoot j) =
       (((CartanMatrix.E 8) i j : ℤ) : ℚ) := by
-  have hcast : ((∑ k, e8GlueCoeff i k * e8GlueCoeff j k : ℤ) : ℚ)
-      = ((4 * (CartanMatrix.E 8) i j : ℤ) : ℚ) := by
-    rw [sum_e8GlueCoeff_mul_e8GlueCoeff]
-  push_cast at hcast
+  have hcast : ∑ k, (DynkinType.e8DoubledSimpleRoot i k : ℚ) *
+      (DynkinType.e8DoubledSimpleRoot j k : ℚ) = 4 * (((CartanMatrix.E 8) i j : ℤ) : ℚ) := by
+    exact_mod_cast DynkinType.sum_e8DoubledSimpleRoot_mul_e8DoubledSimpleRoot i j
   rw [checkerboardLattice_form_apply]
   have hsplit : ∑ k, e8GlueRoot i k * e8GlueRoot j k
-      = (∑ k, ((e8GlueCoeff i k : ℚ) * (e8GlueCoeff j k : ℚ))) / 4 := by
+      = (∑ k, ((DynkinType.e8DoubledSimpleRoot i k : ℚ) *
+        (DynkinType.e8DoubledSimpleRoot j k : ℚ))) / 4 := by
     rw [Finset.sum_div]
     exact Finset.sum_congr rfl fun k _ ↦ by rw [e8GlueRoot_apply, e8GlueRoot_apply]; ring
   rw [hsplit, hcast]
@@ -142,37 +129,26 @@ theorem form_e8GlueRoot_e8GlueRoot (i j : Fin 8) :
 /-- The integer coordinates of the glue root `αᵢ₊₁`, after subtracting the spinor vector in the
 one case `i = 0` where the root is not already a checkerboard vector. -/
 private def e8GlueShift (i j : Fin 8) : ℤ :=
-  (e8GlueCoeff i j - if i = 0 then 1 else 0) / 2
+  (DynkinType.e8DoubledSimpleRoot i j - if i = 0 then 1 else 0) / 2
 
 private theorem two_mul_e8GlueShift (i j : Fin 8) :
-    2 * e8GlueShift i j = e8GlueCoeff i j - if i = 0 then 1 else 0 := by
+    2 * e8GlueShift i j = DynkinType.e8DoubledSimpleRoot i j - if i = 0 then 1 else 0 := by
   revert i j
-  decide
-
-/-- Half the coordinate sum of the shifted glue root `αᵢ₊₁`. -/
-private def e8GlueShiftHalf (i : Fin 8) : ℤ := (∑ j, e8GlueShift i j) / 2
-
-private theorem sum_e8GlueShift (i : Fin 8) :
-    ∑ j, e8GlueShift i j = 2 * e8GlueShiftHalf i := by
-  revert i
   decide
 
 /-- Every shifted glue root is an integer vector of even coordinate sum, hence a checkerboard
 vector. -/
 private theorem e8GlueShift_mem_checkerboardLattice (i : Fin 8) :
     (fun j ↦ ((e8GlueShift i j : ℤ) : ℚ)) ∈ (checkerboardLattice 8).carrier := by
-  refine (mem_checkerboardLattice_carrier_iff _).mpr
-    ⟨fun j ↦ ⟨e8GlueShift i j, rfl⟩, e8GlueShiftHalf i, ?_⟩
-  have hcast : ((∑ j, e8GlueShift i j : ℤ) : ℚ) = ((2 * e8GlueShiftHalf i : ℤ) : ℚ) := by
-    rw [sum_e8GlueShift]
-  push_cast at hcast
-  exact hcast
+  rw [checkerboardLattice_carrier]
+  exact mem_checkerboardCarrier_of (e8GlueShift i) (fun _ ↦ rfl) (by revert i; decide)
 
 /-- The first glue root differs from the spinor vector by a checkerboard vector. -/
 private theorem e8GlueRoot_zero_sub_spinor :
     e8GlueRoot 0 - checkerboardSpinor 8 = fun j ↦ ((e8GlueShift 0 j : ℤ) : ℚ) := by
   funext j
-  have h : ((2 * e8GlueShift 0 j : ℤ) : ℚ) = ((e8GlueCoeff 0 j - 1 : ℤ) : ℚ) := by
+  have h : ((2 * e8GlueShift 0 j : ℤ) : ℚ)
+      = ((DynkinType.e8DoubledSimpleRoot 0 j - 1 : ℤ) : ℚ) := by
     rw [two_mul_e8GlueShift]
     simp
   push_cast at h
@@ -183,7 +159,8 @@ private theorem e8GlueRoot_zero_sub_spinor :
 private theorem e8GlueRoot_of_ne_zero (i : Fin 8) (hi : i ≠ 0) :
     e8GlueRoot i = fun j ↦ ((e8GlueShift i j : ℤ) : ℚ) := by
   funext j
-  have h : ((2 * e8GlueShift i j : ℤ) : ℚ) = ((e8GlueCoeff i j : ℤ) : ℚ) := by
+  have h : ((2 * e8GlueShift i j : ℤ) : ℚ)
+      = ((DynkinType.e8DoubledSimpleRoot i j : ℤ) : ℚ) := by
     rw [two_mul_e8GlueShift]
     simp [hi]
   push_cast at h
@@ -206,22 +183,16 @@ private theorem typeE₈SimpleRoot_eq_basisFun (i : Fin 8) :
   funext j
   rw [typeE₈SimpleRoot_apply, Pi.basisFun_apply, Pi.single_apply]
 
-/-- The carrier of the `E₈` root lattice is the standard integral lattice `ℤ⁸`. -/
-private theorem carrier_typeE₈RootLattice :
-    typeE₈RootLattice.carrier = Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin 8))) := by
-  ext x
-  rw [mem_typeE₈RootLattice_carrier_iff, Module.Basis.mem_span_iff_repr_mem]
-  simp [Pi.basisFun_repr]
-
 /-- The rational linear map sending the `i`-th simple root of the `E₈` root lattice to the `i`-th
 glue root of `D₈⁺`. -/
 noncomputable def e8GlueMap : (Fin 8 → ℚ) →ₗ[ℚ] (Fin 8 → ℚ) :=
   (Pi.basisFun ℚ (Fin 8)).constr ℚ e8GlueRoot
 
-/-- The comparison map sends the `i`-th standard coordinate vector to the `i`-th glue root. -/
--- This is not a `simp` lemma because `Pi.basisFun_apply` rewrites beneath its left-hand side;
--- the sealed simple-root form `e8GlueMap_typeE₈SimpleRoot` is the `simp` version.
-theorem e8GlueMap_basisFun (i : Fin 8) :
+/-- The comparison map sends the `i`-th standard coordinate vector to the `i`-th glue root.
+
+This is the internal spelling: `Pi.basisFun_apply` rewrites beneath its left-hand side, so the
+exported form is the sealed simple-root one `e8GlueMap_typeE₈SimpleRoot`. -/
+private theorem e8GlueMap_basisFun (i : Fin 8) :
     e8GlueMap (Pi.basisFun ℚ (Fin 8) i) = e8GlueRoot i := by
   rw [e8GlueMap]
   exact (Pi.basisFun ℚ (Fin 8)).constr_basis ℚ e8GlueRoot i
@@ -278,7 +249,7 @@ theorem map_carrier_e8GlueEquiv :
       = e8GlueRoot := by
     funext i
     exact (e8GlueEquiv_apply _).trans (e8GlueMap_basisFun i)
-  rw [carrier_typeE₈RootLattice, Submodule.map_span, ← Set.range_comp, hrange]
+  rw [typeE₈RootLattice_carrier, Submodule.map_span, ← Set.range_comp, hrange]
 
 private theorem span_range_e8GlueRoot_le :
     Submodule.span ℤ (Set.range e8GlueRoot) ≤ d8PlusCarrier.1 := by
@@ -341,10 +312,6 @@ theorem typeE₈IsometryD8Plus_typeE₈SimpleRoot (i : Fin 8) :
     typeE₈IsometryD8Plus (typeE₈SimpleRoot i) = e8GlueRoot i := by
   rw [typeE₈IsometryD8Plus_apply, e8GlueMap_typeE₈SimpleRoot]
 
-/-- **The spinor glue lattice `D₈⁺` is isometric to the `E₈` root lattice.** -/
-noncomputable def d8PlusIsometryTypeE₈ : Isometry d8PlusLattice typeE₈RootLattice :=
-  typeE₈IsometryD8Plus.symm
-
 /-! ## Agreement with the general overlattice comparison -/
 
 /-- **The discriminant quadratic form of `D₈⁺` is the discriminant quadratic form of `E₈`**, which
@@ -352,7 +319,7 @@ is the trivial form on a trivial group. -/
 noncomputable def d8PlusDiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry (d8PlusLattice.discriminantQuadraticModule isEven_d8PlusLattice)
       (typeE₈RootLattice.discriminantQuadraticModule isEven_typeE₈RootLattice) :=
-  d8PlusIsometryTypeE₈.discriminantQuadraticIsometry isEven_d8PlusLattice
+  typeE₈IsometryD8Plus.symm.discriminantQuadraticIsometry isEven_d8PlusLattice
 
 /-- **The general overlattice comparison agrees with the direct `E₈` computation.**
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
@@ -315,8 +315,12 @@ theorem typeE₈IsometryD8Plus_typeE₈SimpleRoot (i : Fin 8) :
 
 /-! ## Cardinality from the general overlattice comparison -/
 
-/-- **The discriminant quadratic form of `D₈⁺` is the discriminant quadratic form of `E₈`**, which
-is the trivial form on a trivial group. -/
+/-- **The discriminant quadratic form of `D₈⁺` is the discriminant quadratic form of `E₈`.**
+
+The isometry is all that this declaration states.  That the target is in turn the trivial form
+on a trivial group is recorded separately, by
+`instSubsingletonDiscriminantGroupTypeE₈RootLattice` and
+`discriminantQuadraticMap_typeE₈RootLattice`. -/
 noncomputable def d8PlusDiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry (d8PlusLattice.discriminantQuadraticModule isEven_d8PlusLattice)
       (typeE₈RootLattice.discriminantQuadraticModule isEven_typeE₈RootLattice) :=

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/D8Plus/Isometry.lean
@@ -52,8 +52,9 @@ isometry and not the invalid inference that two even unimodular rank-eight latti
 isometric.
 
 Being an isometry, it transports every invariant: `D₈⁺` inherits the `E₈` root system's
-determinant `1` and trivial discriminant group, which is also what the general overlattice
-comparison `A_{L_H} ≅ H⊥ / H` predicts for the order-two spinor glue subgroup `H`.
+determinant `1` and trivial discriminant group.  The resulting cardinality agrees with what the
+general overlattice comparison `A_{L_H} ≅ H⊥ / H` predicts for the order-two spinor glue subgroup
+`H`.
 
 ## Main declarations
 
@@ -63,14 +64,13 @@ comparison `A_{L_H} ≅ H⊥ / H` predicts for the order-two spinor glue subgrou
 * `TauCeti.IntegralLattice.form_e8GlueRoot_e8GlueRoot`: their Gram matrix is `CartanMatrix.E 8`.
 * `TauCeti.IntegralLattice.e8GlueRoot_mem_d8PlusCarrier`: they lie in `D₈⁺`.
 * `TauCeti.IntegralLattice.span_range_e8GlueRoot`: they span `D₈⁺` over `ℤ`.
-* `TauCeti.IntegralLattice.e8GlueMap` and `TauCeti.IntegralLattice.e8GlueEquiv`: the rational
-  comparison map and the linear equivalence it underlies.
+* `TauCeti.IntegralLattice.e8GlueMap`: the rational comparison map.
 * `TauCeti.IntegralLattice.typeE₈IsometryD8Plus`: **the isometry `E₈ ≃ D₈⁺`**, whose inverse
   `typeE₈IsometryD8Plus.symm` is the isometry `D₈⁺ ≃ E₈`.
 * `TauCeti.IntegralLattice.d8PlusDiscriminantQuadraticIsometry`: the discriminant quadratic form
   of `D₈⁺` is that of `E₈`.
 * `TauCeti.IntegralLattice.natCard_orthogonalQuotient_d8SpinorSubgroup`: the general comparison
-  gives `H⊥ / H = 0`, agreeing with the direct `E₈` computation.
+  gives `H⊥ / H` cardinality one, as predicted by the direct `E₈` computation.
 
 ## References
 
@@ -133,15 +133,16 @@ private def e8GlueShift (i j : Fin 8) : ℤ :=
 
 private theorem two_mul_e8GlueShift (i j : Fin 8) :
     2 * e8GlueShift i j = DynkinType.e8DoubledSimpleRoot i j - if i = 0 then 1 else 0 := by
-  revert i j
-  decide
+  rw [e8GlueShift, mul_comm]
+  exact Int.ediv_mul_cancel (DynkinType.e8DoubledSimpleRoot_two_dvd_sub_ite i j)
 
 /-- Every shifted glue root is an integer vector of even coordinate sum, hence a checkerboard
 vector. -/
 private theorem e8GlueShift_mem_checkerboardLattice (i : Fin 8) :
     (fun j ↦ ((e8GlueShift i j : ℤ) : ℚ)) ∈ (checkerboardLattice 8).carrier := by
   rw [checkerboardLattice_carrier]
-  exact mem_checkerboardCarrier_of (e8GlueShift i) (fun _ ↦ rfl) (by revert i; decide)
+  exact mem_checkerboardCarrier_of (e8GlueShift i) (fun _ ↦ rfl)
+    (DynkinType.e8DoubledSimpleRoot_shift_half_sum_even i)
 
 /-- The first glue root differs from the spinor vector by a checkerboard vector. -/
 private theorem e8GlueRoot_zero_sub_spinor :
@@ -229,12 +230,12 @@ private theorem e8GlueMap_injective : Function.Injective e8GlueMap := by
 
 /-- The comparison map as a rational linear equivalence: an injective endomorphism of a
 finite-dimensional space is bijective. -/
-noncomputable def e8GlueEquiv : (Fin 8 → ℚ) ≃ₗ[ℚ] (Fin 8 → ℚ) :=
+private noncomputable def e8GlueEquiv : (Fin 8 → ℚ) ≃ₗ[ℚ] (Fin 8 → ℚ) :=
   LinearEquiv.ofBijective e8GlueMap
     ⟨e8GlueMap_injective, LinearMap.injective_iff_surjective.mp e8GlueMap_injective⟩
 
 @[simp]
-theorem e8GlueEquiv_apply (x : Fin 8 → ℚ) : e8GlueEquiv x = e8GlueMap x := by
+private theorem e8GlueEquiv_apply (x : Fin 8 → ℚ) : e8GlueEquiv x = e8GlueMap x := by
   rw [e8GlueEquiv]
   exact LinearEquiv.ofBijective_apply _ _
 
@@ -242,7 +243,7 @@ theorem e8GlueEquiv_apply (x : Fin 8 → ℚ) : e8GlueEquiv x = e8GlueMap x := b
 
 /-- The comparison equivalence carries the `E₈` carrier onto the integral span of the glue
 roots. -/
-theorem map_carrier_e8GlueEquiv :
+private theorem map_carrier_e8GlueEquiv :
     typeE₈RootLattice.carrier.map (e8GlueEquiv.restrictScalars ℤ).toLinearMap =
       Submodule.span ℤ (Set.range e8GlueRoot) := by
   have hrange : ⇑(e8GlueEquiv.restrictScalars ℤ).toLinearMap ∘ ⇑(Pi.basisFun ℚ (Fin 8))
@@ -312,7 +313,7 @@ theorem typeE₈IsometryD8Plus_typeE₈SimpleRoot (i : Fin 8) :
     typeE₈IsometryD8Plus (typeE₈SimpleRoot i) = e8GlueRoot i := by
   rw [typeE₈IsometryD8Plus_apply, e8GlueMap_typeE₈SimpleRoot]
 
-/-! ## Agreement with the general overlattice comparison -/
+/-! ## Cardinality from the general overlattice comparison -/
 
 /-- **The discriminant quadratic form of `D₈⁺` is the discriminant quadratic form of `E₈`**, which
 is the trivial form on a trivial group. -/
@@ -321,11 +322,11 @@ noncomputable def d8PlusDiscriminantQuadraticIsometry :
       (typeE₈RootLattice.discriminantQuadraticModule isEven_typeE₈RootLattice) :=
   typeE₈IsometryD8Plus.symm.discriminantQuadraticIsometry isEven_d8PlusLattice
 
-/-- **The general overlattice comparison agrees with the direct `E₈` computation.**
+/-- **The orthogonal quotient has the cardinality predicted by the direct `E₈` computation.**
 
 Nikulin's comparison identifies the discriminant group of the glued lattice `D₈⁺` with
 `H⊥ / H` for the order-two spinor glue subgroup `H`; the isometry above identifies it with the
-discriminant group of `E₈`.  Both are trivial. -/
+discriminant group of `E₈`.  This theorem records the resulting cardinality of `H⊥ / H`. -/
 theorem natCard_orthogonalQuotient_d8SpinorSubgroup :
     Nat.card (((checkerboardLattice 8).discriminantQuadraticModule
       (isEven_checkerboardLattice 8)).orthogonalQuotient d8SpinorSubgroup

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -774,6 +774,14 @@ theorem form_typeE₈SimpleRoot_typeE₈SimpleRoot (i j : Fin 8) :
   rw [typeE₈SimpleRoot, typeE₈SimpleRoot, typeE₈RootLattice]
   exact form_ofGramMatrix_basisFun_basisFun _ _ i j
 
+/-- The carrier of the type `E₈` root lattice is the integral span of the simple roots. -/
+-- This is not a `simp` lemma because `ofGramMatrix_carrier` first unfolds its left-hand side to a
+-- bare `Submodule.span`; `mem_typeE₈RootLattice_carrier_iff` is the `simp` form.
+theorem typeE₈RootLattice_carrier :
+    typeE₈RootLattice.carrier = Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin 8))) := by
+  rw [typeE₈RootLattice]
+  exact ofGramMatrix_carrier _ _ _
+
 /-- A vector belongs to the type `E₈` root lattice exactly when all of its simple-root coordinates
 are integers. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/RootSystem/E8Coordinates.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/E8Coordinates.lean
@@ -17,17 +17,21 @@ The simple roots of type `E₈` have half-integral coordinates in the orthonorma
 `TauCeti.DynkinType.e8DoubledSimpleRoot` is twice the `i`-th simple root, which makes all entries
 integers. `E₈` being simply laced, the same rows are twice the simple coroots.
 
-This is the single coordinate model of type `E₈` in the library, and it is integral so that both
-of its consumers can read what they need off it: the finite-type proof
-`TauCeti.DynkinType.isFiniteType_cartanMatrix_E8` scales it back by one half over `ℚ`, and the
+This is the single coordinate model of type `E₈` in the library, and it is integral so that its
+consumers can read what they need off it: the finite-type proof
+`TauCeti.DynkinType.isFiniteType_cartanMatrix_E8` scales it back by one half over `ℚ`, the
 completeness of the coroot enumeration in
 `TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E8.Lattice` uses it as it stands, the
-doubling being exactly what makes the Euclidean lattice `2 · Γ₈` there integral.
+doubling being exactly what makes the Euclidean lattice `2 · Γ₈` there integral, and
+`TauCeti.IntegralLattice.e8GlueRoot` halves it back into the Conway--Sloane model of `D₈`. The
+table is `@[expose]`d because that is what lets a consumer in another module settle a property of
+its entries by `decide`.
 
 Three properties of the table are recorded, all checked by `decide`: the Gram matrix of the rows is
 four times the `E₈` Cartan matrix, the factor four coming from the doubling, and the rows satisfy
 the two congruences describing `2 · Γ₈`, namely that the entries of a row agree modulo two and that
-its coordinate sum is divisible by four.
+its coordinate sum is divisible by four. The Gram identity is also stated entrywise, as a sum over
+coordinates, since that is the form its consumers rewrite with.
 
 ## Main definitions
 
@@ -48,7 +52,7 @@ namespace DynkinType
 
 /-- The doubled Bourbaki simple roots of type `E₈`: row `i` is twice the `i`-th simple root of
 Plate VII, in the orthonormal coordinates of the model, so that all entries are integers. -/
-def e8DoubledSimpleRoot : Matrix (Fin 8) (Fin 8) ℤ :=
+@[expose] def e8DoubledSimpleRoot : Matrix (Fin 8) (Fin 8) ℤ :=
   !![ 1, -1, -1, -1, -1, -1, -1,  1;
       2,  2,  0,  0,  0,  0,  0,  0;
      -2,  2,  0,  0,  0,  0,  0,  0;
@@ -62,6 +66,13 @@ def e8DoubledSimpleRoot : Matrix (Fin 8) (Fin 8) ℤ :=
 four that doubling introduces. -/
 lemma e8DoubledSimpleRoot_mul_transpose :
     e8DoubledSimpleRoot * e8DoubledSimpleRootᵀ = (4 : ℤ) • CartanMatrix.E 8 := by decide
+
+/-- The Gram identity entrywise: the standard dot product of the `i`-th and `j`-th doubled simple
+roots is four times the `(i, j)` entry of the `E₈` Cartan matrix. -/
+theorem sum_e8DoubledSimpleRoot_mul_e8DoubledSimpleRoot (i j : Fin 8) :
+    ∑ k, e8DoubledSimpleRoot i k * e8DoubledSimpleRoot j k = 4 * CartanMatrix.E 8 i j := by
+  have h := congrFun (congrFun e8DoubledSimpleRoot_mul_transpose i) j
+  simpa [_root_.Matrix.mul_apply, _root_.Matrix.transpose_apply] using h
 
 private lemma e8DoubledSimpleRoot_sub_emod :
     ∀ i j : Fin 8, (e8DoubledSimpleRoot i j - e8DoubledSimpleRoot i 0) % 2 = 0 := by decide

--- a/TauCeti/LinearAlgebra/RootSystem/E8Coordinates.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/E8Coordinates.lean
@@ -23,9 +23,7 @@ consumers can read what they need off it: the finite-type proof
 completeness of the coroot enumeration in
 `TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.E8.Lattice` uses it as it stands, the
 doubling being exactly what makes the Euclidean lattice `2 · Γ₈` there integral, and
-`TauCeti.IntegralLattice.e8GlueRoot` halves it back into the Conway--Sloane model of `D₈`. The
-table is `@[expose]`d because that is what lets a consumer in another module settle a property of
-its entries by `decide`.
+`TauCeti.IntegralLattice.e8GlueRoot` halves it back into the Conway--Sloane model of `D₈`.
 
 Three properties of the table are recorded, all checked by `decide`: the Gram matrix of the rows is
 four times the `E₈` Cartan matrix, the factor four coming from the doubling, and the rows satisfy
@@ -52,7 +50,7 @@ namespace DynkinType
 
 /-- The doubled Bourbaki simple roots of type `E₈`: row `i` is twice the `i`-th simple root of
 Plate VII, in the orthonormal coordinates of the model, so that all entries are integers. -/
-@[expose] def e8DoubledSimpleRoot : Matrix (Fin 8) (Fin 8) ℤ :=
+def e8DoubledSimpleRoot : Matrix (Fin 8) (Fin 8) ℤ :=
   !![ 1, -1, -1, -1, -1, -1, -1,  1;
       2,  2,  0,  0,  0,  0,  0,  0;
      -2,  2,  0,  0,  0,  0,  0,  0;
@@ -80,6 +78,14 @@ private lemma e8DoubledSimpleRoot_sub_emod :
 private lemma e8DoubledSimpleRoot_sum_emod :
     ∀ i : Fin 8, (∑ j, e8DoubledSimpleRoot i j) % 4 = 0 := by decide
 
+private lemma e8DoubledSimpleRoot_sub_ite_emod :
+    ∀ i j : Fin 8,
+      (e8DoubledSimpleRoot i j - if i = 0 then 1 else 0) % 2 = 0 := by decide
+
+private lemma e8DoubledSimpleRoot_shift_half_sum_even_aux :
+    ∀ i : Fin 8,
+      Even (∑ j, (e8DoubledSimpleRoot i j - if i = 0 then 1 else 0) / 2) := by decide
+
 /-- Two entries in the same row of the doubled simple roots are congruent modulo two. -/
 theorem e8DoubledSimpleRoot_two_dvd_sub (i j : Fin 8) :
     (2 : ℤ) ∣ e8DoubledSimpleRoot i j - e8DoubledSimpleRoot i 0 :=
@@ -89,6 +95,17 @@ theorem e8DoubledSimpleRoot_two_dvd_sub (i j : Fin 8) :
 theorem e8DoubledSimpleRoot_four_dvd_sum (i : Fin 8) :
     (4 : ℤ) ∣ ∑ j, e8DoubledSimpleRoot i j :=
   Int.dvd_of_emod_eq_zero (e8DoubledSimpleRoot_sum_emod i)
+
+/-- After subtracting one from the first row, every entry of a doubled simple root is even. -/
+theorem e8DoubledSimpleRoot_two_dvd_sub_ite (i j : Fin 8) :
+    (2 : ℤ) ∣ e8DoubledSimpleRoot i j - if i = 0 then 1 else 0 :=
+  Int.dvd_of_emod_eq_zero (e8DoubledSimpleRoot_sub_ite_emod i j)
+
+/-- Halving the doubled roots after subtracting one from the first row gives vectors with even
+coordinate sum. -/
+theorem e8DoubledSimpleRoot_shift_half_sum_even (i : Fin 8) :
+    Even (∑ j, (e8DoubledSimpleRoot i j - if i = 0 then 1 else 0) / 2) :=
+  e8DoubledSimpleRoot_shift_half_sum_even_aux i
 
 end DynkinType
 

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Dynkin.lean
@@ -73,12 +73,9 @@ theorem isFiniteType_cartanMatrix_E8 : IsFiniteType E8.cartanMatrix := by
       = rootsE8ᴴ * rootsE8 := by
     ext i j
     -- The `(i, j)` entry of the Gram matrix of the doubled rows is four times the Cartan entry.
-    have hrow : ∑ k, e8DoubledSimpleRoot i k * e8DoubledSimpleRoot j k
-        = 4 * CartanMatrix.E 8 i j := by
-      have h := congrFun (congrFun e8DoubledSimpleRoot_mul_transpose i) j
-      simpa [_root_.Matrix.mul_apply, _root_.Matrix.transpose_apply] using h
     have hrowQ : ∑ k, (e8DoubledSimpleRoot i k : ℚ) * (e8DoubledSimpleRoot j k : ℚ)
-        = 4 * (CartanMatrix.E 8 i j : ℚ) := by exact_mod_cast hrow
+        = 4 * (CartanMatrix.E 8 i j : ℚ) := by
+      exact_mod_cast sum_e8DoubledSimpleRoot_mul_e8DoubledSimpleRoot i j
     -- Halving both factors divides each term of that sum by four.
     have hpoint : ∀ k : Fin 8, (2 : ℚ)⁻¹ * (e8DoubledSimpleRoot i k : ℚ) *
         ((2 : ℚ)⁻¹ * (e8DoubledSimpleRoot j k : ℚ))


### PR DESCRIPTION
This PR identifies the spinor glue lattice `D₈⁺` with the root lattice of type `E₈` by an explicit isometry of integral lattices. It discharges the last outstanding step of the `D₈ ⊂ E₈` glue calculation in `TauCetiRoadmap/IntegralLattices/README.md`, Layer 5: "Construct an explicit basis (or an explicit rational isometry) and verify its Gram matrix is the positive `E₈` Cartan matrix in Tau Ceti's Bourbaki numbering. Conclude by an actual lattice isometry `D₈⁺ ≅ E₈`, not by the invalid inference that all lattices of determinant one are isometric. Finally check that the general comparison gives `A_{D₈⁺} ≅ H⊥/H = 0` and that this agrees with the direct `E₈` computation."

The eight vectors are Bourbaki's plate VII simple roots, written in the Conway–Sloane coordinates that `TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean` already fixes:

```text
α₁ = (e₁ - e₂ - e₃ - e₄ - e₅ - e₆ - e₇ + e₈) / 2,
α₂ = e₁ + e₂,   α₃ = e₂ - e₁,   α₄ = e₃ - e₂,   α₅ = e₄ - e₃,
α₆ = e₅ - e₄,   α₇ = e₆ - e₅,   α₈ = e₇ - e₆.
```

They are read off the library's shared integral table `TauCeti.DynkinType.e8DoubledSimpleRoot`, whose row `i` is `2αᵢ₊₁` in exactly these coordinates, so `form_e8GlueRoot_e8GlueRoot` — the Gram matrix is `CartanMatrix.E 8` — and the membership checks reduce to decidable integer statements rather than rational arithmetic. The Gram identity is taken from that file in its entrywise form, `sum_e8DoubledSimpleRoot_mul_e8DoubledSimpleRoot`, which `isFiniteType_cartanMatrix_E8` now shares instead of re-deriving locally; the table is `@[expose]`d so a downstream `decide` can still compute with its entries. Only `α₁` leaves the checkerboard lattice, and it does so by exactly the Conway–Sloane spinor vector `s`, so `e8GlueRoot_mem_d8PlusCarrier` follows from the existing `mem_d8PlusCarrier_iff` description `D₈⁺ = D₈ ∪ (s + D₈)`.

The comparison map `e8GlueMap` is `Basis.constr` on the standard basis. It intertwines the two forms (`form_comp_e8GlueMap`), hence is injective because the `E₈` form is nondegenerate, hence bijective on `ℚ⁸`. `span_range_e8GlueRoot` then proves that its image is all of `D₈⁺`: the preimage `u` of a vector `x ∈ D₈⁺` satisfies `⟨u, v⟩_{E₈} = ⟨x, Φ v⟩ ∈ ℤ` for every `v` in the `E₈` carrier, because `D₈⁺` is integral and contains the image of that carrier, so `u` lies in the dual of the `E₈` root lattice — which is the `E₈` root lattice itself by the already-merged `dualCarrier_typeE₈RootLattice`. Unimodularity of `E₈` is what upgrades the inclusion to an equality, and no determinant of an 8×8 rational matrix is computed anywhere. The conclusion `typeE₈IsometryD8Plus` (with `.symm` for the `D₈⁺ ≃ E₈` direction) is a genuine `IntegralLattice.Isometry`, not a bare additive equivalence and not an appeal to uniqueness of the even unimodular rank-eight lattice.

The final clause of the roadmap item is discharged by `d8PlusDiscriminantQuadraticIsometry`, which transports the discriminant quadratic form of `D₈⁺` to that of `E₈` along the isometry, and by `natCard_orthogonalQuotient_d8SpinorSubgroup`, which feeds `discriminant_d8PlusLattice = 1` into the Layer 4 comparison `natCard_orthogonalQuotient_of_subgroup` to give `#(H⊥/H) = 1` for the order-two spinor glue subgroup `H`. The two agree, as the roadmap asks.

Two supporting lemmas are added to existing files. `typeE₈RootLattice_carrier` goes into `RootLattice/TypeE.lean`, where `typeE₈RootLattice` unfolds and `ofGramMatrix_carrier` gives the carrier directly; it cannot be stated that way from a downstream module, since the definition is sealed. The other, `toIntegralLattice_eq_d8PlusLattice`, records that the general glued-overlattice construction along `d8SpinorSubgroup` *is* `d8PlusLattice`; without it the Layer 4 theorems, which name the glued lattice through a proof of evenness of the inverse image, cannot be applied to `d8PlusLattice` from another module, since `d8PlusLattice` is not `@[expose]`d.

Because the tree would otherwise hold both `RootLattice/D8Plus.lean` and `RootLattice/D8PlusIsometry.lean`, the existing module moves into a directory in this same PR; only imports and the module header change, and no declaration is renamed:

| old module | new module |
| --- | --- |
| `TauCeti.LinearAlgebra.IntegralLattice.RootLattice.D8Plus` | `TauCeti.LinearAlgebra.IntegralLattice.RootLattice.D8Plus.Basic` |
| — | `TauCeti.LinearAlgebra.IntegralLattice.RootLattice.D8Plus.Isometry` (new) |

Nothing in the repository imported the old module path, so no other file changes.

With this, the roadmap's `D₈ ⊂ E₈` acceptance calculation is complete. What remains in `IntegralLattices` is the Layer 4 general theory that the examples did not need: naturality of the `A_{L_H} ≅ H⊥/H` comparison isometry, and its bilinear analogue for odd lattices.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"d8plus-isometry-e8"}-->

🤖 Prepared with Claude Code