### PR TITLE
feat: make Geck root subgroups closed

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Basic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Basic.lean
@@ -193,6 +193,16 @@ theorem mkQuotient_comp_kostantRootSubgroupToralCoordinateMap (i : I) :
   CommHopfAlgCat.mkQuotient_comp_commonKernelLift
     (kostantToralGeneratorMap e h ρ M hM hnil b wt) (.inl i)
 
+/-- A surjective root-subgroup coordinate map remains surjective after factoring through the
+toral closure. -/
+theorem kostantRootSubgroupToralCoordinateMap_surjective_of_surjective (i : I)
+    (hi : Function.Surjective
+      (kostantRootSubgroupCoordinateMap e h ρ M hM i (hnil i) b).hom) :
+    Function.Surjective
+      (kostantRootSubgroupToralCoordinateMap e h ρ M hM hnil b wt i).hom :=
+  CommHopfAlgCat.commonKernelLift_surjective_of_surjective
+    (kostantToralGeneratorMap e h ρ M hM hnil b wt) (.inl i) hi
+
 /-- The coordinate map through which the represented weight torus factors into the toral
 closure. -/
 noncomputable def kostantWeightTorusToralCoordinateMap :

--- a/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/DividedPower.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/DividedPower.lean
@@ -342,16 +342,9 @@ theorem dividedPower_e_apply_inl_inr_neg (s : b.support) (n : ℕ) :
   | 2 => simp [v]
   | n + 3 => simp
 
-/-- The distinguished raising coordinate, with root negation written without a local typeclass
-instance. -/
-theorem dividedPower_e_apply_inl_inr_reflectionPerm (s : b.support) (n : ℕ) :
-    TauCeti.Associative.dividedPower n (e s) (Sum.inl s)
-        (Sum.inr (P.reflectionPerm s s)) = if n = 1 then 1 else 0 := by
-  let _i := P.indexNeg
-  exact dividedPower_e_apply_inl_inr_neg s n
-
 /-- The distinguished upper-right coordinate of a divided power of a Geck lowering generator.
 It is `1` in degree one and vanishes in every other degree. -/
+@[simp]
 theorem dividedPower_f_apply_inl_inr (s : b.support) (n : ℕ) :
     TauCeti.Associative.dividedPower n (f s) (Sum.inl s) (Sum.inr (s : ι)) =
       if n = 1 then 1 else 0 := by

--- a/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/DividedPower.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/DividedPower.lean
@@ -322,6 +322,50 @@ private theorem exists_intCast_dividedPower_f_mulVec_single (s : b.support) (n :
 
 namespace RootPairing.GeckConstruction
 
+/-- The distinguished upper-right coordinate of a divided power of a Geck raising generator.
+It is `1` in degree one and vanishes in every other degree. -/
+theorem dividedPower_e_apply_inl_inr_neg (s : b.support) (n : ℕ) :
+    let _i := P.indexNeg
+    TauCeti.Associative.dividedPower n (e s) (Sum.inl s) (Sum.inr (-s : ι)) =
+      if n = 1 then 1 else 0 := by
+  dsimp only
+  let _i := P.indexNeg
+  have hcol : TauCeti.Associative.dividedPower n (e s) (Sum.inl s) (Sum.inr (-s : ι)) =
+      (TauCeti.Associative.dividedPower n (e s) *ᵥ
+        Pi.single (Sum.inr (-s : ι)) 1) (Sum.inl s) := by
+    rw [Matrix.mulVec_single_one, Matrix.col_apply]
+  rw [hcol]
+  rw [TauCeti.Associative.dividedPower_def, Matrix.smul_mulVec, e_pow_mulVec_v_neg]
+  match n with
+  | 0 => simp [v]
+  | 1 => simp [u]
+  | 2 => simp [v]
+  | n + 3 => simp
+
+/-- The distinguished raising coordinate, with root negation written without a local typeclass
+instance. -/
+theorem dividedPower_e_apply_inl_inr_reflectionPerm (s : b.support) (n : ℕ) :
+    TauCeti.Associative.dividedPower n (e s) (Sum.inl s)
+        (Sum.inr (P.reflectionPerm s s)) = if n = 1 then 1 else 0 := by
+  let _i := P.indexNeg
+  exact dividedPower_e_apply_inl_inr_neg s n
+
+/-- The distinguished upper-right coordinate of a divided power of a Geck lowering generator.
+It is `1` in degree one and vanishes in every other degree. -/
+theorem dividedPower_f_apply_inl_inr (s : b.support) (n : ℕ) :
+    TauCeti.Associative.dividedPower n (f s) (Sum.inl s) (Sum.inr (s : ι)) =
+      if n = 1 then 1 else 0 := by
+  let _i := P.indexNeg
+  have hcol : TauCeti.Associative.dividedPower n (f s) (Sum.inl s) (Sum.inr (s : ι)) =
+      (TauCeti.Associative.dividedPower n (f s) *ᵥ
+        Pi.single (Sum.inr (s : ι)) 1) (Sum.inl s) := by
+    rw [Matrix.mulVec_single_one, Matrix.col_apply]
+  rw [hcol, dividedPower_f_eq_omega_mul_dividedPower_e_mul_omega,
+    ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec, omega_mulVec_single, omega_mulVec_apply,
+    Matrix.mulVec_single_one]
+  simp only [Matrix.col_apply]
+  exact dividedPower_e_apply_inl_inr_neg s n
+
 /-- Every entry of a divided power of a numbered raising operator in Geck's representation is
 an integer. -/
 theorem exists_intCast_dividedPower_e_apply (s : b.support) (n : ℕ)

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
@@ -136,6 +136,9 @@ theorem intCast_geckCoordinateBasisFin_repr
   rw [Module.Basis.repr_reindex_apply]
   let v' : Submodule.span ℤ (Set.range (Pi.basisFun ℚ (t.GeckIndex ht))) :=
     ⟨v, v.property⟩
+  -- Unfolding identifies the coordinate lattice's additive-subgroup carrier with the span
+  -- carrier expected by `Basis.restrictScalars`; this is a definitional subtype equality, so
+  -- there is no propositional equality to rewrite with.
   change ((Module.Basis.restrictScalars ℤ (Pi.basisFun ℚ (t.GeckIndex ht))).repr v'
       ((Fintype.equivFin (t.GeckIndex ht)).symm i) : ℚ) = _
   rw [← eq_intCast (algebraMap ℤ ℚ) _, Module.Basis.restrictScalars_repr_apply]
@@ -324,9 +327,8 @@ theorem geckRepresentation_ringChoose_lieBasis_h_mem_geckCoordinateLattice
 
 /-! ## Divided powers of the numbered root generators -/
 
-/-- A divided power of a Lie generator acts through the divided power of its underlying matrix.
-Both transport steps are functoriality of `ℚ`-algebra homomorphisms
-(`TauCeti.Associative.map_dividedPower`). -/
+/-- The Geck representation sends the enveloping-algebra divided power of `ι x` to the matrix
+divided power of `x`, acting on `v`. -/
 theorem geckRepresentation_dividedPower_ι_apply (x : t.lieAlgebra ht) (n : ℕ)
     (v : t.GeckIndex ht → ℚ) :
     t.geckRepresentation ht

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
@@ -125,6 +125,22 @@ theorem coe_geckCoordinateBasisFin (i : Fin (t.geckDim ht)) :
       Pi.single ((Fintype.equivFin (t.GeckIndex ht)).symm i) 1 := by
   rw [geckCoordinateBasisFin, Module.Basis.reindex_apply, coe_geckCoordinateBasis]
 
+/-- Reading a lattice vector in the finite-ordinal Geck basis recovers its corresponding
+standard coordinate after extending the integral coefficient to `ℚ`. -/
+@[simp]
+theorem intCast_geckCoordinateBasisFin_repr
+    (v : (t.geckCoordinateLattice ht).toAddSubgroup) (i : Fin (t.geckDim ht)) :
+    ((t.geckCoordinateBasisFin ht).repr v i : ℚ) =
+      (v : t.GeckIndex ht → ℚ) ((Fintype.equivFin (t.GeckIndex ht)).symm i) := by
+  unfold geckCoordinateBasisFin geckCoordinateBasis geckCoordinateLattice at *
+  rw [Module.Basis.repr_reindex_apply]
+  let v' : Submodule.span ℤ (Set.range (Pi.basisFun ℚ (t.GeckIndex ht))) :=
+    ⟨v, v.property⟩
+  change ((Module.Basis.restrictScalars ℤ (Pi.basisFun ℚ (t.GeckIndex ht))).repr v'
+      ((Fintype.equivFin (t.GeckIndex ht)).symm i) : ℚ) = _
+  rw [← eq_intCast (algebraMap ℤ ℚ) _, Module.Basis.restrictScalars_repr_apply]
+  rfl
+
 /-- The integral weight of a finite-ordinal Geck coordinate basis vector. The Cartan argument uses
 the Bourbaki numbering, while the coordinate argument uses the `Fintype.equivFin` ordering of
 `GeckIndex`. -/
@@ -311,7 +327,7 @@ theorem geckRepresentation_ringChoose_lieBasis_h_mem_geckCoordinateLattice
 /-- A divided power of a Lie generator acts through the divided power of its underlying matrix.
 Both transport steps are functoriality of `ℚ`-algebra homomorphisms
 (`TauCeti.Associative.map_dividedPower`). -/
-private theorem geckRepresentation_dividedPower_ι_apply (x : t.lieAlgebra ht) (n : ℕ)
+theorem geckRepresentation_dividedPower_ι_apply (x : t.lieAlgebra ht) (n : ℕ)
     (v : t.GeckIndex ht → ℚ) :
     t.geckRepresentation ht
         (Associative.dividedPower n (_root_.UniversalEnvelopingAlgebra.ι ℚ x)) v =

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/ClosedRootSubgroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/ClosedRootSubgroup.lean
@@ -25,6 +25,8 @@ divided-power coefficient vanishes.
   numbered Geck root subgroup is surjective.
 * `TauCeti.DynkinType.isClosedImmersion_geckRootSubgroup`: every numbered root-subgroup map
   `𝔾ₐ → G` is a closed immersion.
+* `TauCeti.DynkinType.geckRootSubgroupClosedSubgroupIso`: the resulting closed subgroup is
+  canonically isomorphic to `𝔾ₐ`.
 
 ## References
 
@@ -274,6 +276,37 @@ theorem coe_geckRootSubgroupClosedSubgroup (i : Fin t.rank ⊕ Fin t.rank) :
       letI := t.mono_geckRootSubgroup ht i
       Subobject.mk (t.geckRootSubgroup ht i) := by
   exact ClosedSubgroupScheme.coe_mk _
+
+/-- The bundled numbered root subgroup is canonically isomorphic to the additive group scheme. -/
+noncomputable def geckRootSubgroupClosedSubgroupIso (i : Fin t.rank ⊕ Fin t.rank) :
+    ((t.geckRootSubgroupClosedSubgroup ht i).1 :
+      Grp (Over (Spec (CommRingCat.of ℤ)))) ≅ AdditiveGroup.groupScheme ℤ := by
+  exact eqToIso (congrArg
+      (fun P : Subobject (t.geckGroupScheme ht) =>
+        (P : Grp (Over (Spec (CommRingCat.of ℤ)))))
+      (t.coe_geckRootSubgroupClosedSubgroup ht i)) ≪≫
+    Subobject.underlyingIso (t.geckRootSubgroup ht i)
+
+/-- The canonical parametrization of the bundled closed subgroup followed by its inclusion is the
+numbered Geck root-subgroup map. -/
+@[simp]
+theorem geckRootSubgroupClosedSubgroupIso_inv_comp_arrow (i : Fin t.rank ⊕ Fin t.rank) :
+    (t.geckRootSubgroupClosedSubgroupIso ht i).inv ≫
+        (t.geckRootSubgroupClosedSubgroup ht i).1.arrow =
+      t.geckRootSubgroup ht i := by
+  have harrow :
+      (eqToIso (congrArg
+        (fun P : Subobject (t.geckGroupScheme ht) =>
+          (P : Grp (Over (Spec (CommRingCat.of ℤ)))))
+        (t.coe_geckRootSubgroupClosedSubgroup ht i))).inv ≫
+          (t.geckRootSubgroupClosedSubgroup ht i).1.arrow =
+        (Subobject.mk (t.geckRootSubgroup ht i)).arrow := by
+    exact Subobject.arrow_congr
+      (Subobject.mk (t.geckRootSubgroup ht i))
+      (t.geckRootSubgroupClosedSubgroup ht i).1
+      (t.coe_geckRootSubgroupClosedSubgroup ht i).symm
+  rw [geckRootSubgroupClosedSubgroupIso, Iso.trans_inv, Category.assoc, harrow,
+    Subobject.underlyingIso_arrow]
 
 end
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/ClosedRootSubgroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/ClosedRootSubgroup.lean
@@ -49,9 +49,11 @@ attribute [local instance] TauCeti.moduleNNRat
 
 variable (t : DynkinType) (ht : t.Valid)
 
+/-- The finite coordinate row corresponding to a numbered simple root. -/
 private abbrev geckRootRow (i : Fin t.rank) : Fin (t.geckDim ht) :=
   Fintype.equivFin (t.GeckIndex ht) (.inl (t.simpleSupportEquiv ht i))
 
+/-- The finite coordinate column that recovers a numbered root-subgroup parameter. -/
 private abbrev geckRootColumn (i : Fin t.rank ⊕ Fin t.rank) : Fin (t.geckDim ht) :=
   match i with
   | .inl i =>
@@ -84,22 +86,15 @@ private theorem geckRootSubgroup_dividedPower_repr
   | inl i =>
       rw [LieAlgebra.Basis.rootGenerator_inl, t.coe_lieBasis_e ht]
       simp only [geckRootRow, geckRootColumn, Equiv.symm_apply_apply, Sum.elim_inl]
-      change TauCeti.Associative.dividedPower n
-        (RootPairing.GeckConstruction.e (t.simpleSupportEquiv ht i))
-          (.inl (t.simpleSupportEquiv ht i))
-          (.inr ((t.rationalRootSystem ht).reflectionPerm
-            (t.simpleSupportEquiv ht i) (t.simpleSupportEquiv ht i))) = _
-      simpa only [Int.cast_ite, Int.cast_one, Int.cast_zero] using
-        RootPairing.GeckConstruction.dividedPower_e_apply_inl_inr_reflectionPerm
+      let _i := (t.rationalRootSystem ht).indexNeg
+      simpa only [id_eq, RootPairing.indexNeg_neg, Int.cast_ite, Int.cast_one,
+        Int.cast_zero] using
+        RootPairing.GeckConstruction.dividedPower_e_apply_inl_inr_neg
           (t.simpleSupportEquiv ht i) n
   | inr i =>
       rw [LieAlgebra.Basis.rootGenerator_inr, t.coe_lieBasis_f ht]
       simp only [geckRootRow, geckRootColumn, Equiv.symm_apply_apply, Sum.elim_inr]
-      change TauCeti.Associative.dividedPower n
-        (RootPairing.GeckConstruction.f (t.simpleSupportEquiv ht i))
-          (.inl (t.simpleSupportEquiv ht i))
-          (.inr (t.simpleSupportEquiv ht i : Fin t.numRoots)) = _
-      simpa only [Int.cast_ite, Int.cast_one, Int.cast_zero] using
+      simpa only [id_eq, Int.cast_ite, Int.cast_one, Int.cast_zero] using
         RootPairing.GeckConstruction.dividedPower_f_apply_inl_inr
           (t.simpleSupportEquiv ht i) n
 
@@ -155,6 +150,7 @@ private theorem geckRootSubgroupMatrix_apply (i : Fin t.rank ⊕ Fin t.rank)
     have htwo := t.two_le_nilpotencyClass_geckRootOperator ht i
     exact (hnot (Finset.mem_range.mpr htwo)).elim
 
+/-- The coordinate map of a numbered root subgroup before passage to the toral closure. -/
 private abbrev geckRepresentedRootCoordinateMap (i : Fin t.rank ⊕ Fin t.rank) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap
     (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/ClosedRootSubgroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/ClosedRootSubgroup.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ClosedImmersion
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.GroupScheme
+import TauCeti.CategoryTheory.Comma.Over
+
+/-!
+# Closed root subgroups of the Geck carrier
+
+The numbered raising and lowering maps into the pinned Geck carrier are closed copies of the
+additive group. The parameter is recovered from one explicit matrix coordinate: for a simple root
+`i`, the raising divided-power exponential sends the coordinate vector at `-i` toward the Cartan
+coordinate at `i`, while the lowering exponential does the same from `i`. In both cases that
+coordinate is exactly the parameter, since its degree-one coefficient is `1` and every other
+divided-power coefficient vanishes.
+
+## Main declarations
+
+* `TauCeti.DynkinType.geckRootSubgroupCoordinateMap_surjective`: the coordinate map of every
+  numbered Geck root subgroup is surjective.
+* `TauCeti.DynkinType.isClosedImmersion_geckRootSubgroup`: every numbered root-subgroup map
+  `𝔾ₐ → G` is a closed immersion.
+
+## References
+
+* M. Geck, *On the construction of semisimple Lie algebras and Chevalley groups*,
+  Proc. Amer. Math. Soc. **145** (2017), 3233--3247.
+* R. W. Carter, *Simple Groups of Lie Type*, §4.4.
+* J. E. Humphreys, *Linear Algebraic Groups*, §26.
+
+This supplies the closed-root-subgroup condition in the pinning target of Layer 9 of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory WithConv
+
+namespace TauCeti.DynkinType
+
+noncomputable section
+
+attribute [local instance] TauCeti.moduleNNRat
+
+variable (t : DynkinType) (ht : t.Valid)
+
+private abbrev geckRootRow (i : Fin t.rank) : Fin (t.geckDim ht) :=
+  Fintype.equivFin (t.GeckIndex ht) (.inl (t.simpleSupportEquiv ht i))
+
+private abbrev geckRootColumn (i : Fin t.rank ⊕ Fin t.rank) : Fin (t.geckDim ht) :=
+  match i with
+  | .inl i =>
+      Fintype.equivFin (t.GeckIndex ht)
+        (.inr ((t.rationalRootSystem ht).reflectionPerm
+          (t.simpleSupportEquiv ht i) (t.simpleSupportEquiv ht i)))
+  | .inr i => Fintype.equivFin (t.GeckIndex ht)
+      (.inr (t.simpleSupportEquiv ht i : Fin t.numRoots))
+
+private theorem geckRootSubgroup_dividedPower_repr
+    (i : Fin t.rank ⊕ Fin t.rank) (n : ℕ) :
+    (t.geckCoordinateBasisFin ht).repr
+        (TauCeti.integralDividedPower
+          (t.geckRepresentation ht
+            (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).rootGenerator i)))
+          (t.geckCoordinateLattice ht).toAddSubgroup n
+          (fun _ hv =>
+            TauCeti.UniversalEnvelopingAlgebra.dividedPower_apply_mem_of_kostantForm_apply_mem
+            (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)
+            (t.geckRepresentation_kostantForm_mem_geckCoordinateLattice ht) i n hv)
+          (t.geckCoordinateBasisFin ht (t.geckRootColumn ht i)))
+        (t.geckRootRow ht (Sum.elim id id i)) =
+      if n = 1 then 1 else 0 := by
+  apply Int.cast_injective (α := ℚ)
+  rw [t.intCast_geckCoordinateBasisFin_repr ht, TauCeti.coe_integralDividedPower_apply,
+    ← TauCeti.Associative.map_dividedPower, Module.End.smul_def,
+    t.geckRepresentation_dividedPower_ι_apply ht, t.coe_geckCoordinateBasisFin ht,
+    Matrix.mulVec_single_one, Matrix.col_apply]
+  cases i with
+  | inl i =>
+      rw [LieAlgebra.Basis.rootGenerator_inl, t.coe_lieBasis_e ht]
+      simp only [geckRootRow, geckRootColumn, Equiv.symm_apply_apply, Sum.elim_inl]
+      change TauCeti.Associative.dividedPower n
+        (RootPairing.GeckConstruction.e (t.simpleSupportEquiv ht i))
+          (.inl (t.simpleSupportEquiv ht i))
+          (.inr ((t.rationalRootSystem ht).reflectionPerm
+            (t.simpleSupportEquiv ht i) (t.simpleSupportEquiv ht i))) = _
+      simpa only [Int.cast_ite, Int.cast_one, Int.cast_zero] using
+        RootPairing.GeckConstruction.dividedPower_e_apply_inl_inr_reflectionPerm
+          (t.simpleSupportEquiv ht i) n
+  | inr i =>
+      rw [LieAlgebra.Basis.rootGenerator_inr, t.coe_lieBasis_f ht]
+      simp only [geckRootRow, geckRootColumn, Equiv.symm_apply_apply, Sum.elim_inr]
+      change TauCeti.Associative.dividedPower n
+        (RootPairing.GeckConstruction.f (t.simpleSupportEquiv ht i))
+          (.inl (t.simpleSupportEquiv ht i))
+          (.inr (t.simpleSupportEquiv ht i : Fin t.numRoots)) = _
+      simpa only [Int.cast_ite, Int.cast_one, Int.cast_zero] using
+        RootPairing.GeckConstruction.dividedPower_f_apply_inl_inr
+          (t.simpleSupportEquiv ht i) n
+
+private theorem two_le_nilpotencyClass_geckRootOperator
+    (i : Fin t.rank ⊕ Fin t.rank) :
+    2 ≤ nilpotencyClass (t.geckRepresentation ht
+      (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).rootGenerator i))) := by
+  have hrestricted : TauCeti.integralDividedPower
+      (t.geckRepresentation ht
+        (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).rootGenerator i)))
+      (t.geckCoordinateLattice ht).toAddSubgroup 1
+      (fun _ hv =>
+        TauCeti.UniversalEnvelopingAlgebra.dividedPower_apply_mem_of_kostantForm_apply_mem
+          (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)
+          (t.geckRepresentation_kostantForm_mem_geckCoordinateLattice ht) i 1 hv)
+      (t.geckCoordinateBasisFin ht (t.geckRootColumn ht i)) ≠ 0 := by
+    intro hzero
+    have hcoord := congrArg
+      (fun v => (t.geckCoordinateBasisFin ht).repr v
+        (t.geckRootRow ht (Sum.elim id id i))) hzero
+    rw [t.geckRootSubgroup_dividedPower_repr ht, map_zero] at hcoord
+    simp at hcoord
+  have hx : t.geckRepresentation ht
+      (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).rootGenerator i)) ≠ 0 := by
+    intro hzero
+    apply hrestricted
+    apply Subtype.ext
+    rw [TauCeti.coe_integralDividedPower_apply, TauCeti.Associative.dividedPower_one,
+      hzero, zero_smul]
+    rfl
+  by_contra hlt
+  have hone : (t.geckRepresentation ht
+      (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).rootGenerator i))) ^ 1 = 0 :=
+    pow_eq_zero_of_le (by omega)
+      (pow_nilpotencyClass (t.isNilpotent_geckRepresentation_rootGenerator ht i))
+  rw [pow_one] at hone
+  exact hx hone
+
+private theorem geckRootSubgroupMatrix_apply (i : Fin t.rank ⊕ Fin t.rank)
+    (A : Type) [CommRing A]
+    (q : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    t.geckRootSubgroupMatrix ht i q
+        (t.geckRootRow ht (Sum.elim id id i)) (t.geckRootColumn ht i) =
+      Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv q) := by
+  rw [TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_apply,
+    TauCeti.UniversalEnvelopingAlgebra.repr_kostantRootSubgroupPoints_baseChange]
+  simp_rw [t.geckRootSubgroup_dividedPower_repr ht]
+  rw [Finset.sum_eq_single 1]
+  · simp
+  · intro n hn hne
+    simp [hne]
+  · intro hnot
+    have htwo := t.two_le_nilpotencyClass_geckRootOperator ht i
+    exact (hnot (Finset.mem_range.mpr htwo)).elim
+
+private abbrev geckRepresentedRootCoordinateMap (i : Fin t.rank ⊕ Fin t.rank) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap
+    (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)
+    (t.geckCoordinateLattice ht).toAddSubgroup
+    (t.geckRepresentation_kostantForm_mem_geckCoordinateLattice ht) i
+    (t.isNilpotent_geckRepresentation_rootGenerator ht i) (t.geckCoordinateBasisFin ht)
+
+private theorem geckRepresentedRootCoordinateMap_X (i : Fin t.rank ⊕ Fin t.rank) :
+    (t.geckRepresentedRootCoordinateMap ht i).hom
+        (GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
+          (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
+            (MvPolynomial.X
+              (t.geckRootRow ht (Sum.elim id id i), t.geckRootColumn ht i)))) =
+      SymmetricAlgebra.ι ℤ ℤ 1 := by
+  have key :=
+    TauCeti.UniversalEnvelopingAlgebra.pointsMulEquiv_kostantRootSubgroupCoordinateMap_apply
+      (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)
+      (t.geckCoordinateLattice ht).toAddSubgroup
+      (t.geckRepresentation_kostantForm_mem_geckCoordinateLattice ht) i
+      (t.isNilpotent_geckRepresentation_rootGenerator ht i) (t.geckCoordinateBasisFin ht)
+      (SymmetricAlgebra ℤ ℤ) (toConv (AlgHom.id ℤ (SymmetricAlgebra ℤ ℤ)))
+      (t.geckRootRow ht (Sum.elim id id i)) (t.geckRootColumn ht i)
+  rw [GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointToGeneralLinear_apply] at key
+  calc
+    _ = t.geckRootSubgroupMatrix ht i
+        (toConv (AlgHom.id ℤ (SymmetricAlgebra ℤ ℤ)))
+        (t.geckRootRow ht (Sum.elim id id i)) (t.geckRootColumn ht i) := by
+          rw [TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_apply]
+          exact key
+    _ = Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv
+        (toConv (AlgHom.id ℤ (SymmetricAlgebra ℤ ℤ)))) :=
+      t.geckRootSubgroupMatrix_apply ht i _ _
+    _ = _ := by
+      rw [AdditiveGroup.toAdd_gaPointsMulEquiv, WithConv.ofConv_toConv]
+      rfl
+
+private theorem geckRepresentedRootCoordinateMap_surjective
+    (i : Fin t.rank ⊕ Fin t.rank) :
+    Function.Surjective (t.geckRepresentedRootCoordinateMap ht i).hom := by
+  have hgen : SymmetricAlgebra.ι ℤ ℤ 1 ∈
+      (t.geckRepresentedRootCoordinateMap ht i).hom.toAlgHom.range := by
+    exact (AlgHom.mem_range _).2
+      ⟨GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
+        (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
+          (MvPolynomial.X
+            (t.geckRootRow ht (Sum.elim id id i), t.geckRootColumn ht i))),
+        t.geckRepresentedRootCoordinateMap_X ht i⟩
+  intro y
+  have hy : y ∈ (t.geckRepresentedRootCoordinateMap ht i).hom.toAlgHom.range := by
+    induction y using SymmetricAlgebra.induction with
+    | algebraMap z => exact Subalgebra.algebraMap_mem _ z
+    | ι z =>
+        have hz : SymmetricAlgebra.ι ℤ ℤ z = z • SymmetricAlgebra.ι ℤ ℤ 1 := by
+          rw [← map_zsmul]
+          congr 1
+          simp
+        rw [hz]
+        exact zsmul_mem hgen z
+    | mul y z hy hz => exact mul_mem hy hz
+    | add y z hy hz => exact add_mem hy hz
+  obtain ⟨z, hz⟩ := (AlgHom.mem_range _).1 hy
+  exact ⟨z, hz⟩
+
+/-- The coordinate morphism of a numbered root subgroup after factorization through the Geck
+carrier. -/
+noncomputable abbrev geckRootSubgroupCoordinateMap (i : Fin t.rank ⊕ Fin t.rank) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap
+    (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)
+    (t.geckCoordinateLattice ht).toAddSubgroup
+    (t.geckRepresentation_kostantForm_mem_geckCoordinateLattice ht)
+    (t.isNilpotent_geckRepresentation_rootGenerator ht)
+    (t.geckCoordinateBasisFin ht) (t.geckWeightFin ht) i
+
+/-- **The coordinate morphism of every numbered Geck root subgroup is surjective.** The explicit
+Cartan/root matrix coordinate recovers the polynomial generator before and after factorization
+through the common-kernel quotient defining the carrier. -/
+theorem geckRootSubgroupCoordinateMap_surjective (i : Fin t.rank ⊕ Fin t.rank) :
+    Function.Surjective (t.geckRootSubgroupCoordinateMap ht i).hom :=
+  UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap_surjective_of_surjective
+      (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)
+      (t.geckCoordinateLattice ht).toAddSubgroup
+      (t.geckRepresentation_kostantForm_mem_geckCoordinateLattice ht)
+      (t.isNilpotent_geckRepresentation_rootGenerator ht)
+      (t.geckCoordinateBasisFin ht) (t.geckWeightFin ht) i
+      (t.geckRepresentedRootCoordinateMap_surjective ht i)
+
+/-- **Every numbered root-subgroup map into the Geck carrier is a closed immersion.** Thus its
+scheme-theoretic image is a closed copy of `𝔾ₐ`, as required of the root subgroups in a pinning. -/
+instance isClosedImmersion_geckRootSubgroup (i : Fin t.rank ⊕ Fin t.rank) :
+    IsClosedImmersion (t.geckRootSubgroup ht i).hom.hom.left := by
+  let e₁ := (eqToHom (AdditiveGroup.groupScheme_def ℤ)).hom.hom.left
+  let c := ((AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).map
+    (t.geckRootSubgroupCoordinateMap ht i).op).hom.hom.left
+  let e₂ := (eqToHom (t.geckGroupScheme_def ht).symm).hom.hom.left
+  have hc : IsClosedImmersion c :=
+    (CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _).2
+      (t.geckRootSubgroupCoordinateMap_surjective ht i)
+  have he₁c : IsClosedImmersion (e₁ ≫ c) :=
+    (MorphismProperty.cancel_left_of_respectsIso _ e₁ c).2 hc
+  have he₁ce₂ : IsClosedImmersion ((e₁ ≫ c) ≫ e₂) :=
+    (MorphismProperty.cancel_right_of_respectsIso _ (e₁ ≫ c) e₂).2 he₁c
+  rw [geckRootSubgroup_def,
+    TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_def]
+  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
+  exact he₁ce₂
+
+/-- Every numbered root-subgroup map into the Geck carrier is a monomorphism. -/
+theorem mono_geckRootSubgroup (i : Fin t.rank ⊕ Fin t.rank) :
+    Mono (t.geckRootSubgroup ht i) :=
+  mono_of_isClosedImmersion_underlying (t.geckRootSubgroup ht i)
+
+/-- **A numbered Geck root subgroup as a closed subgroup scheme of the carrier.** -/
+noncomputable def geckRootSubgroupClosedSubgroup (i : Fin t.rank ⊕ Fin t.rank) :
+    ClosedSubgroupScheme (t.geckGroupScheme ht) :=
+  ClosedSubgroupScheme.mk (t.geckRootSubgroup ht i)
+
+/-- The bundled closed root subgroup is represented by the numbered root-subgroup morphism. -/
+@[simp]
+theorem coe_geckRootSubgroupClosedSubgroup (i : Fin t.rank ⊕ Fin t.rank) :
+    (t.geckRootSubgroupClosedSubgroup ht i).1 =
+      letI := t.mono_geckRootSubgroup ht i
+      Subobject.mk (t.geckRootSubgroup ht i) := by
+  exact ClosedSubgroupScheme.coe_mk _
+
+end
+
+end TauCeti.DynkinType


### PR DESCRIPTION
This PR proves that every numbered Geck root-subgroup map is a closed immersion into the explicit Kostant toral-closure carrier, and packages its image as a closed subgroup scheme isomorphic to `𝔾ₐ`.

It advances the ReductiveGroups README's Layer 9 milestone “Pinnings,” specifically the “Root subgroup maps” target: the maps `x_α : 𝔾ₐ → G` must be genuine closed root subgroups before they can be assembled into pinned Chevalley–Demazure data. After this PR, split reductivity, the maximal torus and Borel, identification of the root datum, and the final pinning assembly remain.

The proof recovers the additive parameter from an explicit Cartan/root matrix coordinate for both raising and lowering divided-power exponentials, including type `A₁`, proves the coordinate Hopf map surjective, and transports surjectivity through the common-kernel quotient defining the carrier. It reuses Mathlib's `RootPairing.reflectionPerm` infrastructure and Tau Ceti's existing common-kernel Hopf quotient; no external implementation is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geck-root-subgroups-closed-immersions"}-->

🤖 Prepared with Codex
