### PR TITLE
feat: glue two plans over a countable middle space

### DIFF
--- a/TauCeti/MeasureTheory/OptimalTransport/Gluing.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Gluing.lean
@@ -367,8 +367,11 @@ variable (π : Measure (X × Y)) (σ : Measure (Y × Z))
 /-- Gluing `π` against the conditional kernel of `σ` over a countable middle space recovers `σ` as
 the `(Y, Z)`-marginal, as soon as the two plans share their middle marginal. -/
 theorem snd_glue_countableCondKernel [Countable Y] [MeasurableSingletonClass Y] [Nonempty Z]
-    [SFinite π] [IsFiniteMeasure σ] (hπσ : π.snd = σ.fst) :
+    [IsFiniteMeasure σ] (hπσ : π.snd = σ.fst) :
     (Measure.glue π (countableCondKernel σ)).snd = σ := by
+  let _ : IsFiniteMeasure π := ⟨by
+    rw [← _root_.MeasureTheory.Measure.snd_univ, hπσ]
+    exact measure_lt_top _ _⟩
   rw [Measure.snd_glue, hπσ, _root_.MeasureTheory.Measure.disintegrate]
 
 /-- **The gluing lemma over a countable middle space.**

--- a/TauCeti/MeasureTheory/OptimalTransport/Gluing.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Gluing.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Probability.Kernel.Composition.MeasureComp
 public import Mathlib.Probability.Kernel.Disintegration.StandardBorel
 public import TauCeti.Probability.Kernel.Composition.MeasureCompProd
+public import TauCeti.Probability.Kernel.Disintegration.Countable
 
 /-!
 # Gluing transport plans
@@ -20,8 +21,12 @@ measure on `X × Y` whose second marginal agrees with the first marginal of a me
 the composition of couplings.
 
 The construction is a composition-product against a conditional kernel, so it needs a
-disintegration of one of the two plans, hence a standard Borel hypothesis on one of the two outer
-spaces. The middle space `Y` carries no hypothesis at all.
+disintegration of one of the two plans. There are two ways to obtain one. Mathlib's regular
+conditional kernel gives it under a standard Borel hypothesis on one of the two *outer* spaces,
+the middle space `Y` then carrying no hypothesis at all. Alternatively, when the *middle* space is
+countable with measurable singletons, `TauCeti.MeasureTheory.countableCondKernel` gives it with no
+hypothesis on either outer space — the regime the cut distance of the dense graph limit theory
+needs, since its two carriers are arbitrary probability spaces.
 
 ## Main definitions
 
@@ -40,9 +45,12 @@ spaces. The middle space `Y` carries no hypothesis at all.
   `TauCeti.Measure.exists_glue_of_standardBorel_left` — **the gluing lemma**, in the two regimes
   obtained by disintegrating `σ` over `Y` (which needs `Z` standard Borel) and by disintegrating
   `π` over `Y` (which needs `X` standard Borel);
+* `TauCeti.MeasureTheory.exists_glue_of_countable_middle` — **the gluing lemma over a countable
+  middle space**, which needs nothing of either outer space;
 * `TauCeti.Measure.exists_comp_of_exists_glue` — the composition of plans read off a glued measure,
-  with `TauCeti.Measure.exists_comp_of_standardBorel_right` and
-  `TauCeti.Measure.exists_comp_of_standardBorel_left` its two concrete forms;
+  with `TauCeti.Measure.exists_comp_of_standardBorel_right`,
+  `TauCeti.Measure.exists_comp_of_standardBorel_left` and
+  `TauCeti.MeasureTheory.exists_comp_of_countable_middle` its three concrete forms;
 * `TauCeti.Measure.lintegral_map_prodMap_id_snd_le` — the composition estimate: a cost on `X × Z`
   dominated by the sum of a cost on `X × Y` and a cost on `Y × Z` integrates against the composed
   plan to at most the sum of the two integrals. This is the mechanism behind the triangle
@@ -64,8 +72,11 @@ and stating it this way keeps the theorems usable by any packaging of couplings 
 * C. Villani, *Topics in Optimal Transportation*, Graduate Studies in Mathematics 58, 2003,
   Lemma 7.6 ("Gluing lemma"), and *Optimal Transport: Old and New*, Grundlehren 338, 2009,
   Chapter 1. Both state it for three Polish probability spaces; the versions here ask for a
-  standard Borel structure on one outer space only, nothing on the middle space `Y`, and no
-  normalisation of the plans.
+  standard Borel structure on one outer space only — or, in the countable-middle version, for
+  nothing at all on the outer spaces — and no normalisation of the plans.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, the design-validation milestone preceding
+  the arbitrary-carrier triangle inequality of Layer 1 — "finite coupling gluing with zero-mass
+  middle atoms explicit". `TauCeti.MeasureTheory.exists_glue_of_countable_middle` is that gluing.
 -/
 
 public section
@@ -339,5 +350,65 @@ theorem exists_comp_of_standardBorel_left [StandardBorelSpace X] [IsFiniteMeasur
 end Comp
 
 end Measure
+
+namespace MeasureTheory
+
+/-! ### Gluing over a countable middle space
+
+These live in `TauCeti.MeasureTheory` rather than alongside their standard Borel siblings in
+`TauCeti.Measure`: `scripts/lint-dot-notation.py` forbids a *new* declaration under
+`TauCeti.Measure` whose statement mentions `MeasureTheory.Measure`, because such a namespace
+blocks dot notation on Mathlib's type. `TauCeti.MeasureTheory` is the namespace of the
+conditional kernel these consume. -/
+
+variable {X Y Z : Type*} [MeasurableSpace X] [MeasurableSpace Y] [MeasurableSpace Z]
+variable (π : Measure (X × Y)) (σ : Measure (Y × Z))
+
+/-- Gluing `π` against the conditional kernel of `σ` over a countable middle space recovers `σ` as
+the `(Y, Z)`-marginal, as soon as the two plans share their middle marginal. -/
+theorem snd_glue_countableCondKernel [Countable Y] [MeasurableSingletonClass Y] [Nonempty Z]
+    [SFinite π] [IsFiniteMeasure σ] (hπσ : π.snd = σ.fst) :
+    (Measure.glue π (countableCondKernel σ)).snd = σ := by
+  rw [Measure.snd_glue, hπσ, _root_.MeasureTheory.Measure.disintegrate]
+
+/-- **The gluing lemma over a countable middle space.**
+
+Two plans sharing a middle marginal, `π.snd = σ.fst`, admit a joint law on `X × Y × Z` with `π`
+and `σ` as its two consecutive two-coordinate marginals, as soon as the middle space `Y` is
+countable with measurable singletons. Neither outer space carries any hypothesis — in particular
+neither is assumed standard Borel, so this is not a special case of either
+`TauCeti.Measure.exists_glue_of_standardBorel_right` or
+`TauCeti.Measure.exists_glue_of_standardBorel_left`, and conversely neither of those covers it.
+
+When `Z` is nonempty the explicit witness is `TauCeti.Measure.glue π (countableCondKernel σ)`; use
+it instead of this statement when the probability-measure or finiteness instances of the glued
+measure are needed. -/
+theorem exists_glue_of_countable_middle [Countable Y] [MeasurableSingletonClass Y]
+    [IsFiniteMeasure σ] (hπσ : π.snd = σ.fst) :
+    ∃ γ : Measure (X × Y × Z), γ.map (Prod.map id Prod.fst) = π ∧ γ.snd = σ := by
+  let _ : IsFiniteMeasure π := ⟨by
+    rw [← _root_.MeasureTheory.Measure.snd_univ, hπσ]
+    exact measure_lt_top _ _⟩
+  rcases isEmpty_or_nonempty Z with hZ | hZ
+  · let _ := hZ
+    have hσ : σ = 0 := _root_.MeasureTheory.Measure.eq_zero_of_isEmpty σ
+    have hπ : π = 0 := by
+      rw [← _root_.MeasureTheory.Measure.measure_univ_eq_zero,
+        ← _root_.MeasureTheory.Measure.snd_univ, hπσ, hσ]
+      simp
+    exact ⟨0, by simp [hπ], by simp [hσ]⟩
+  · let _ := hZ
+    exact ⟨Measure.glue π (countableCondKernel σ), Measure.map_prodMap_id_fst_glue π _,
+      snd_glue_countableCondKernel π σ hπσ⟩
+
+/-- Two plans sharing a middle marginal compose to a plan with the two outer marginals, when the
+middle space is countable. Unlike the two standard Borel forms, this asks nothing of either outer
+space. -/
+theorem exists_comp_of_countable_middle [Countable Y] [MeasurableSingletonClass Y]
+    [IsFiniteMeasure σ] (hπσ : π.snd = σ.fst) :
+    ∃ ζ : Measure (X × Z), ζ.fst = π.fst ∧ ζ.snd = σ.snd :=
+  Measure.exists_comp_of_exists_glue (exists_glue_of_countable_middle π σ hπσ)
+
+end MeasureTheory
 
 end TauCeti

--- a/TauCeti/Probability/Kernel/Disintegration/Countable.lean
+++ b/TauCeti/Probability/Kernel/Disintegration/Countable.lean
@@ -14,8 +14,8 @@ A measure `σ` on a product `Y × Z` disintegrates over `Y` when it is the compo
 `σ.fst ⊗ₘ κ` of its first marginal with a Markov kernel `κ : Kernel Y Z`. Mathlib supplies such a
 kernel when the *second* factor `Z` is standard Borel
 (`MeasureTheory.Measure.condKernel`). For a finite `σ`, this file supplies one in the complementary
-regime: when the *first* factor `Y` is countable with measurable singletons, and `Z` is an arbitrary
-measurable space.
+regime: when the *first* factor `Y` is countable with measurable singletons, and `Z` is any
+nonempty measurable space.
 
 On a countable `Y` no analytic input is needed — the disintegration is the elementary formula
 `κ y s = (σ.fst {y})⁻¹ * σ ({y} ×ˢ s)`, conditioning on the atom `{y}`. The one point that needs
@@ -111,8 +111,8 @@ finite, this is its conditional kernel over the first coordinate.
 
 At an atom `y` of positive first-marginal mass this is the normalised slice
 `s ↦ (σ.fst {y})⁻¹ * σ ({y} ×ˢ s)`; at a null atom, where `σ` prescribes nothing, it is a Dirac
-measure. Unlike `MeasureTheory.Measure.condKernel`, this needs no hypothesis whatsoever on the
-second factor `Z`. -/
+measure. Unlike `MeasureTheory.Measure.condKernel`, this needs no standard-Borel or other
+regularity hypothesis on the nonempty second factor `Z`. -/
 def countableCondKernel (σ : Measure (Y × Z)) : Kernel Y Z :=
   Kernel.ofFunOfCountable fun y =>
     if σ.fst {y} = 0 then Measure.dirac (Classical.arbitrary Z)

--- a/TauCeti/Probability/Kernel/Disintegration/Countable.lean
+++ b/TauCeti/Probability/Kernel/Disintegration/Countable.lean
@@ -1,0 +1,273 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Probability.Kernel.Disintegration.Basic
+
+/-!
+# Disintegrating a measure over a countable coordinate
+
+A measure `σ` on a product `Y × Z` disintegrates over `Y` when it is the composition-product
+`σ.fst ⊗ₘ κ` of its first marginal with a Markov kernel `κ : Kernel Y Z`. Mathlib supplies such a
+kernel when the *second* factor `Z` is standard Borel
+(`MeasureTheory.Measure.condKernel`). This file supplies one in the complementary regime: when the
+*first* factor `Y` is countable with measurable singletons, and `Z` is an arbitrary measurable
+space.
+
+On a countable `Y` no analytic input is needed — the disintegration is the elementary formula
+`κ y s = (σ.fst {y})⁻¹ * σ ({y} ×ˢ s)`, conditioning on the atom `{y}`. The one point that needs
+care is the atoms of zero mass, where that formula reads `∞ * 0` and carries no information: they
+are given a default value, and the disintegration still holds there because such an atom carries
+no `σ`-mass to begin with (`measure_prod_singleton_of_fst_eq_zero`).
+
+## Main definitions
+
+* `TauCeti.MeasureTheory.countableCondKernel` — the conditional kernel of a finite measure on
+  `Y × Z` over a countable `Y`.
+
+## Main results
+
+* `TauCeti.MeasureTheory.measure_eq_tsum_prod_singleton` — a measure on `Y × Z` is the sum of its
+  atomic slices, the elementary decomposition the construction rests on;
+* `TauCeti.MeasureTheory.measure_prod_singleton_of_fst_eq_zero` — an atom of zero first-marginal
+  mass carries no mass at all: the fact that makes the default value at such an atom harmless;
+* `TauCeti.MeasureTheory.countableCondKernel_apply_of_ne_zero` and
+  `TauCeti.MeasureTheory.countableCondKernel_apply_of_eq_zero` — the two branches of the
+  construction, made explicit;
+* `TauCeti.MeasureTheory.compProd_countableCondKernel` — **the disintegration**,
+  `σ.fst ⊗ₘ countableCondKernel σ = σ`, registered as a
+  `MeasureTheory.Measure.IsCondKernel` instance;
+* `TauCeti.MeasureTheory.eq_countableCondKernel_of_ne_zero` — every conditional kernel of `σ`
+  agrees with this one at every atom of positive mass;
+* `TauCeti.MeasureTheory.exists_isCondKernel_pair_ne`,
+  `TauCeti.MeasureTheory.not_isMarkovKernel_of_isEmpty` and
+  `TauCeti.MeasureTheory.exists_compProd_countableCondKernel_ne` — three regressions
+  showing that the contract cannot be strengthened and that its two hypotheses cannot be dropped.
+
+## Implementation notes
+
+The kernel is built with `ProbabilityTheory.Kernel.ofFunOfCountable`, which upgrades an arbitrary
+function on a countable space with measurable singletons to a kernel; the measurability of the
+disintegration, the only nontrivial requirement in the standard Borel setting, is free here.
+
+The value at an atom of zero mass is a Dirac measure at `Classical.arbitrary Z`, hence the
+`[Nonempty Z]` hypothesis. Some choice is forced: a Markov kernel must return a probability
+measure at every point of `Y`, `σ` prescribes none at a null atom, and
+`not_isMarkovKernel_of_isEmpty` shows no Markov kernel exists at all when `Z` is empty. The
+choice is deliberately *not* hidden — `countableCondKernel_apply_of_eq_zero` names it, and
+`exists_isCondKernel_pair_ne` exhibits two conditional kernels of one measure that differ at a
+null atom, so no strengthening of `eq_countableCondKernel_of_ne_zero` to all atoms is available.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, the design-validation milestone preceding
+  the arbitrary-carrier triangle inequality of Layer 1 — "finite coupling gluing with zero-mass
+  middle atoms explicit". This file is the disintegration half of that gluing; the gluing itself
+  is `TauCeti.MeasureTheory.exists_glue_of_countable_middle`.
+* S. Janson, *Graphons, cut norm and distance, couplings and rearrangements*, NYJM Monographs 4
+  (2013), Lemma 6.5 and its finite reduction.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+variable {Y Z : Type*} [MeasurableSpace Y] [MeasurableSpace Z]
+
+section Slices
+
+variable [MeasurableSingletonClass Y]
+
+/-- An atom of `Y` whose first-marginal mass vanishes carries no mass in any slice.
+
+This is the fact that makes the default value of `countableCondKernel` at a null atom harmless:
+such an atom contributes nothing to the disintegration, whatever the kernel does there. -/
+theorem measure_prod_singleton_of_fst_eq_zero (σ : Measure (Y × Z)) {y : Y}
+    (hy : σ.fst {y} = 0) (s : Set Z) : σ ({y} ×ˢ s) = 0 := by
+  have huniv : σ (({y} : Set Y) ×ˢ (Set.univ : Set Z)) = 0 := by
+    rw [Set.prod_univ, ← Measure.fst_apply (measurableSet_singleton y)]
+    exact hy
+  exact measure_mono_null (Set.prod_mono subset_rfl (Set.subset_univ s)) huniv
+
+variable [Countable Y]
+
+/-- A measure on `Y × Z` with `Y` countable is the sum of its atomic slices. -/
+theorem measure_eq_tsum_prod_singleton (σ : Measure (Y × Z)) {s : Set (Y × Z)}
+    (hs : MeasurableSet s) : σ s = ∑' y : Y, σ ({y} ×ˢ (Prod.mk y ⁻¹' s)) := by
+  have hmeas : ∀ y : Y, MeasurableSet (({y} : Set Y) ×ˢ (Prod.mk y ⁻¹' s)) := fun y =>
+    (measurableSet_singleton y).prod (hs.preimage measurable_prodMk_left)
+  have hdisj : Pairwise
+      (Function.onFun Disjoint fun y : Y => ({y} : Set Y) ×ˢ (Prod.mk y ⁻¹' s)) := by
+    intro y y' hyy'
+    refine Set.disjoint_left.2 fun p hp hp' => hyy' ?_
+    rw [← (Set.mem_prod.1 hp).1, ← (Set.mem_prod.1 hp').1]
+  have hcover : s = ⋃ y : Y, (({y} : Set Y) ×ˢ (Prod.mk y ⁻¹' s)) := by
+    ext p
+    simp only [Set.mem_iUnion, Set.singleton_prod, Set.mem_image, Set.mem_preimage]
+    exact ⟨fun hp => ⟨p.1, p.2, hp, rfl⟩, fun ⟨_, _, hp, hpe⟩ => hpe ▸ hp⟩
+  conv_lhs => rw [hcover]
+  exact measure_iUnion hdisj hmeas
+
+end Slices
+
+section CondKernel
+
+variable [Countable Y] [MeasurableSingletonClass Y] [Nonempty Z]
+
+/-- The **conditional kernel over a countable coordinate**: the measure `σ` on `Y × Z`
+conditioned on each atom of `Y`.
+
+At an atom `y` of positive first-marginal mass this is the normalised slice
+`s ↦ (σ.fst {y})⁻¹ * σ ({y} ×ˢ s)`; at a null atom, where `σ` prescribes nothing, it is a Dirac
+measure. Unlike `MeasureTheory.Measure.condKernel`, this needs no hypothesis whatsoever on the
+second factor `Z`. -/
+def countableCondKernel (σ : Measure (Y × Z)) : Kernel Y Z :=
+  Kernel.ofFunOfCountable fun y =>
+    if σ.fst {y} = 0 then Measure.dirac (Classical.arbitrary Z)
+    else ((σ.fst {y})⁻¹ • σ).comap (Prod.mk y)
+
+/-- The two branches of `countableCondKernel`, before either is evaluated. Kept private: the
+public API is the pair of branch lemmas below, neither of which mentions the `if`. -/
+private theorem countableCondKernel_apply (σ : Measure (Y × Z)) (y : Y) :
+    countableCondKernel σ y =
+      if σ.fst {y} = 0 then Measure.dirac (Classical.arbitrary Z)
+      else ((σ.fst {y})⁻¹ • σ).comap (Prod.mk y) := rfl
+
+/-- At a null atom the conditional kernel takes its default value. It is a genuine choice, not a
+quantity read off `σ`; see `exists_isCondKernel_pair_ne`. -/
+theorem countableCondKernel_apply_of_eq_zero {σ : Measure (Y × Z)} {y : Y}
+    (hy : σ.fst {y} = 0) : countableCondKernel σ y = Measure.dirac (Classical.arbitrary Z) := by
+  simp [countableCondKernel_apply, hy]
+
+/-- At an atom of positive mass the conditional kernel is the normalised slice. -/
+theorem countableCondKernel_apply_of_ne_zero {σ : Measure (Y × Z)} {y : Y}
+    (hy : σ.fst {y} ≠ 0) (s : Set Z) :
+    countableCondKernel σ y s = (σ.fst {y})⁻¹ * σ ({y} ×ˢ s) := by
+  rw [countableCondKernel_apply, ite_eq_right_of_eq_false _ _ (eq_false hy),
+    (measurableEmbedding_prodMk_left y).comap_apply, Measure.smul_apply, Set.singleton_prod,
+    smul_eq_mul]
+
+instance instIsMarkovKernelCountableCondKernel (σ : Measure (Y × Z)) [IsFiniteMeasure σ] :
+    IsMarkovKernel (countableCondKernel σ) := by
+  refine ⟨fun y => ?_⟩
+  by_cases hy : σ.fst {y} = 0
+  · rw [countableCondKernel_apply_of_eq_zero hy]
+    infer_instance
+  · refine ⟨?_⟩
+    rw [countableCondKernel_apply_of_ne_zero hy, Set.prod_univ,
+      ← Measure.fst_apply (measurableSet_singleton y),
+      ENNReal.inv_mul_cancel hy (measure_ne_top _ _)]
+
+/-- **The disintegration of a measure over a countable coordinate.** -/
+theorem compProd_countableCondKernel (σ : Measure (Y × Z)) [IsFiniteMeasure σ] :
+    σ.fst ⊗ₘ countableCondKernel σ = σ := by
+  ext s hs
+  rw [Measure.compProd_apply hs, lintegral_countable', measure_eq_tsum_prod_singleton σ hs]
+  refine tsum_congr fun y => ?_
+  by_cases hy : σ.fst {y} = 0
+  · rw [hy, mul_zero, measure_prod_singleton_of_fst_eq_zero σ hy]
+  · rw [countableCondKernel_apply_of_ne_zero hy, mul_comm, ← mul_assoc,
+      ENNReal.mul_inv_cancel hy (measure_ne_top _ _), one_mul]
+
+instance instIsCondKernelCountableCondKernel (σ : Measure (Y × Z)) [IsFiniteMeasure σ] :
+    σ.IsCondKernel (countableCondKernel σ) where
+  disintegrate := compProd_countableCondKernel σ
+
+/-- Any conditional kernel of `σ` agrees with `countableCondKernel σ` at every atom of positive
+mass. The restriction to such atoms is sharp: see `exists_isCondKernel_pair_ne`. -/
+theorem eq_countableCondKernel_of_ne_zero (σ : Measure (Y × Z)) [IsFiniteMeasure σ]
+    (κ : Kernel Y Z) [σ.IsCondKernel κ] {y : Y} (hy : σ.fst {y} ≠ 0) :
+    κ y = countableCondKernel σ y :=
+  Measure.ext fun s _ => by
+    rw [Measure.IsCondKernel.apply_of_ne_zero σ κ hy s, countableCondKernel_apply_of_ne_zero hy]
+
+end CondKernel
+
+section Regressions
+
+/-! ### Regressions
+
+Three examples that break the contract of `countableCondKernel` if it is read more strongly than
+it is stated. The first shows the conclusion of `eq_countableCondKernel_of_ne_zero` cannot be
+extended to null atoms; the other two show that neither of the construction's two hypotheses on
+the ambient data — `Nonempty Z` and `IsFiniteMeasure σ` — can be dropped. -/
+
+/-- **Uniqueness genuinely fails at a null atom.** The Dirac measure at `(true, true)` on
+`Bool × Bool` gives the atom `false` no mass, and the two kernels below both disintegrate it while
+differing there. So `eq_countableCondKernel_of_ne_zero` is sharp: a conditional kernel is pinned
+down exactly on the atoms of positive mass, and the default value `countableCondKernel` uses
+elsewhere is a choice, not a derived quantity. -/
+theorem exists_isCondKernel_pair_ne :
+    ∃ κ₁ κ₂ : Kernel Bool Bool,
+      (Measure.dirac ((true, true) : Bool × Bool)).IsCondKernel κ₁ ∧
+      (Measure.dirac ((true, true) : Bool × Bool)).IsCondKernel κ₂ ∧ κ₁ ≠ κ₂ := by
+  have hfst : (Measure.dirac ((true, true) : Bool × Bool)).fst = Measure.dirac true := by
+    rw [Measure.fst, Measure.map_dirac' measurable_fst]
+  -- Only the atom `true` carries mass, so any Markov kernel taking the value `dirac true` there
+  -- disintegrates the measure, whatever it does at `false`.
+  have key : ∀ κ : Kernel Bool Bool, IsMarkovKernel κ → κ true = Measure.dirac true →
+      (Measure.dirac ((true, true) : Bool × Bool)).fst ⊗ₘ κ
+        = Measure.dirac ((true, true) : Bool × Bool) := by
+    intro κ _ hκ
+    ext s hs
+    rw [hfst, Measure.compProd_apply hs, lintegral_dirac, hκ,
+      Measure.dirac_apply' _ (hs.preimage measurable_prodMk_left),
+      Measure.dirac_apply' _ hs]
+    rfl
+  refine ⟨Kernel.const Bool (Measure.dirac true), Kernel.deterministic id measurable_id,
+    ⟨key _ inferInstance (Kernel.const_apply _ _)⟩,
+    ⟨key _ inferInstance (Kernel.deterministic_apply measurable_id true)⟩, ?_⟩
+  intro h
+  have hfalse := congrArg (fun κ : Kernel Bool Bool => κ false {true}) h
+  simp [Kernel.const_apply, Kernel.deterministic_apply,
+    Measure.dirac_apply' _ (measurableSet_singleton true)] at hfalse
+
+/-- **`Nonempty Z` cannot be dropped.** A Markov kernel returns a probability measure at every
+point, and an empty target carries none, so on an empty `Z` no disintegration of the required
+shape exists at all — not merely no canonical one. -/
+theorem not_isMarkovKernel_of_isEmpty [Nonempty Y] [IsEmpty Z] (κ : Kernel Y Z) :
+    ¬ IsMarkovKernel κ := by
+  intro h
+  have h₁ : κ (Classical.arbitrary Y) Set.univ = 1 :=
+    (h.isProbabilityMeasure (Classical.arbitrary Y)).measure_univ
+  rw [Set.univ_eq_empty_iff.2 ‹IsEmpty Z›, measure_empty] at h₁
+  exact zero_ne_one h₁
+
+/-- **`IsFiniteMeasure σ` cannot be dropped.** At an atom of infinite mass the normalising factor
+`(σ.fst {y})⁻¹` is `0`, so the conditional kernel collapses to the zero measure and the
+composition-product loses all the mass it was meant to recover. -/
+theorem exists_compProd_countableCondKernel_ne :
+    ∃ σ : Measure (Unit × Unit), σ.fst ⊗ₘ countableCondKernel σ ≠ σ := by
+  refine ⟨(⊤ : ℝ≥0∞) • Measure.dirac ((), ()), ?_⟩
+  set σ : Measure (Unit × Unit) := (⊤ : ℝ≥0∞) • Measure.dirac ((), ()) with hσ
+  have hfst : σ.fst {()} = ⊤ := by
+    rw [hσ, Measure.fst, Measure.map_smul, Measure.map_dirac' measurable_fst]
+    simp
+  have hzero : countableCondKernel σ = 0 := by
+    ext y s
+    rw [countableCondKernel_apply_of_ne_zero (by rw [Subsingleton.elim y (), hfst]; simp)]
+    rw [Subsingleton.elim y (), hfst]
+    simp
+  have hne : σ ≠ 0 := by
+    intro h
+    rw [h] at hfst
+    simp at hfst
+  rw [hzero]
+  simpa using fun h => hne h.symm
+
+end Regressions
+
+end MeasureTheory
+
+end TauCeti

--- a/TauCeti/Probability/Kernel/Disintegration/Countable.lean
+++ b/TauCeti/Probability/Kernel/Disintegration/Countable.lean
@@ -127,12 +127,12 @@ theorem countableCondKernel_apply (σ : Measure (Y × Z)) (y : Y) :
 
 /-- At a null atom the conditional kernel takes its default value. It is a genuine choice, not a
 quantity read off `σ`; see the private uniqueness regression below. -/
-theorem countableCondKernel_apply_of_eq_zero {σ : Measure (Y × Z)} {y : Y}
+@[simp] theorem countableCondKernel_apply_of_eq_zero {σ : Measure (Y × Z)} {y : Y}
     (hy : σ.fst {y} = 0) : countableCondKernel σ y = Measure.dirac (Classical.arbitrary Z) := by
   simp [countableCondKernel_apply, hy]
 
 /-- At an atom of positive mass the conditional kernel is the normalised slice. -/
-theorem countableCondKernel_apply_of_ne_zero {σ : Measure (Y × Z)} {y : Y}
+@[simp] theorem countableCondKernel_apply_of_ne_zero {σ : Measure (Y × Z)} {y : Y}
     (hy : σ.fst {y} ≠ 0) (s : Set Z) :
     countableCondKernel σ y s = (σ.fst {y})⁻¹ * σ ({y} ×ˢ s) := by
   rw [countableCondKernel_apply, ite_eq_right_of_eq_false _ _ (eq_false hy),
@@ -151,7 +151,7 @@ instance instIsMarkovKernelCountableCondKernel (σ : Measure (Y × Z)) [IsFinite
       ENNReal.inv_mul_cancel hy (measure_ne_top _ _)]
 
 /-- **The disintegration of a measure over a countable coordinate.** -/
-theorem compProd_countableCondKernel (σ : Measure (Y × Z)) [IsFiniteMeasure σ] :
+@[simp] theorem compProd_countableCondKernel (σ : Measure (Y × Z)) [IsFiniteMeasure σ] :
     σ.fst ⊗ₘ countableCondKernel σ = σ := by
   ext s hs
   -- The atomic decomposition `σ s = ∑' y, σ ({y} ×ˢ (Prod.mk y ⁻¹' s))` is the fibre sum of
@@ -211,9 +211,9 @@ target.) -/
 
 /-- **Uniqueness genuinely fails at a null atom.** The Dirac measure at `(true, true)` on
 `Bool × Bool` gives the atom `false` no mass, and the two kernels below both disintegrate it while
-differing there. So `eq_countableCondKernel_of_ne_zero` is sharp: a conditional kernel is pinned
-down exactly on the atoms of positive mass, and the default value `countableCondKernel` uses
-elsewhere is a choice, not a derived quantity. -/
+differing there. Thus a conditional kernel is always pinned down on atoms of positive mass, while
+uniqueness can fail at null atoms; the default value `countableCondKernel` uses there is a choice,
+not a derived quantity. -/
 private theorem exists_isCondKernel_pair_ne :
     ∃ κ₁ κ₂ : Kernel Bool Bool,
       (Measure.dirac ((true, true) : Bool × Bool)).IsCondKernel κ₁ ∧

--- a/TauCeti/Probability/Kernel/Disintegration/Countable.lean
+++ b/TauCeti/Probability/Kernel/Disintegration/Countable.lean
@@ -187,7 +187,8 @@ instance instIsCondKernelCountableCondKernel (σ : Measure (Y × Z)) [IsFiniteMe
   disintegrate := compProd_countableCondKernel σ
 
 /-- Any conditional kernel of `σ` agrees with `countableCondKernel σ` at every atom of positive
-mass. The restriction to such atoms is sharp, as shown by the private regression below. -/
+mass. The restriction to such atoms is sharp, as shown by the first private regression below;
+global finiteness is necessary at infinite-mass atoms, as shown by the second. -/
 theorem eq_countableCondKernel_of_ne_zero (σ : Measure (Y × Z)) [IsFiniteMeasure σ]
     (κ : Kernel Y Z) [σ.IsCondKernel κ] {y : Y} (hy : σ.fst {y} ≠ 0) :
     κ y = countableCondKernel σ y :=

--- a/TauCeti/Probability/Kernel/Disintegration/Countable.lean
+++ b/TauCeti/Probability/Kernel/Disintegration/Countable.lean
@@ -30,8 +30,6 @@ no `σ`-mass to begin with (`measure_prod_singleton_of_fst_eq_zero`).
 
 ## Main results
 
-* `TauCeti.MeasureTheory.measure_eq_tsum_prod_singleton` — a measure on `Y × Z` is the sum of its
-  atomic slices, the elementary decomposition the construction rests on;
 * `TauCeti.MeasureTheory.measure_prod_singleton_of_fst_eq_zero` — an atom of zero first-marginal
   mass carries no mass at all: the fact that makes the default value at such an atom harmless;
 * `TauCeti.MeasureTheory.countableCondKernel_apply`,
@@ -43,10 +41,10 @@ no `σ`-mass to begin with (`measure_prod_singleton_of_fst_eq_zero`).
   `MeasureTheory.Measure.IsCondKernel` instance;
 * `TauCeti.MeasureTheory.eq_countableCondKernel_of_ne_zero` — every conditional kernel of `σ`
   agrees with this one at every atom of positive mass;
-* `TauCeti.MeasureTheory.exists_isCondKernel_pair_ne`,
-  `TauCeti.MeasureTheory.not_isMarkovKernel_of_isEmpty` and
-  `TauCeti.MeasureTheory.exists_compProd_countableCondKernel_ne` — three regressions
-  showing that the contract cannot be strengthened and that its two hypotheses cannot be dropped.
+* `TauCeti.MeasureTheory.exists_isCondKernel_pair_ne` and
+  `TauCeti.MeasureTheory.exists_compProd_countableCondKernel_ne` — two regressions
+  showing that the contract cannot be strengthened and that its finiteness hypothesis cannot be
+  dropped.
 
 ## Implementation notes
 
@@ -56,9 +54,10 @@ disintegration, the only nontrivial requirement in the standard Borel setting, i
 
 The value at an atom of zero mass is a Dirac measure at `Classical.arbitrary Z`, hence the
 `[Nonempty Z]` hypothesis. Some choice is forced: a Markov kernel must return a probability
-measure at every point of `Y`, `σ` prescribes none at a null atom, and
-`not_isMarkovKernel_of_isEmpty` shows no Markov kernel exists at all when `Z` is empty. The
-choice is deliberately *not* hidden — `countableCondKernel_apply_of_eq_zero` names it, and
+measure at every point of `Y`, `σ` prescribes none at a null atom, and on an empty `Z` no Markov
+kernel exists at all, by `ProbabilityTheory.Kernel.eq_zero_of_isEmpty_right` together with
+`ProbabilityTheory.Kernel.not_isMarkovKernel_zero`. The choice is deliberately *not* hidden —
+`countableCondKernel_apply_of_eq_zero` names it, and
 `exists_isCondKernel_pair_ne` exhibits two conditional kernels of one measure that differ at a
 null atom, so no strengthening of `eq_countableCondKernel_of_ne_zero` to all atoms is available.
 
@@ -100,25 +99,6 @@ theorem measure_prod_singleton_of_fst_eq_zero (σ : Measure (Y × Z)) {y : Y}
     rw [Set.prod_univ, ← Measure.fst_apply (measurableSet_singleton y)]
     exact hy
   exact measure_mono_null (Set.prod_mono subset_rfl (Set.subset_univ s)) huniv
-
-variable [Countable Y]
-
-/-- A measure on `Y × Z` with `Y` countable is the sum of its atomic slices. -/
-theorem measure_eq_tsum_prod_singleton (σ : Measure (Y × Z)) {s : Set (Y × Z)}
-    (hs : MeasurableSet s) : σ s = ∑' y : Y, σ ({y} ×ˢ (Prod.mk y ⁻¹' s)) := by
-  have hmeas : ∀ y : Y, MeasurableSet (({y} : Set Y) ×ˢ (Prod.mk y ⁻¹' s)) := fun y =>
-    (measurableSet_singleton y).prod (hs.preimage measurable_prodMk_left)
-  have hdisj : Pairwise
-      (Function.onFun Disjoint fun y : Y => ({y} : Set Y) ×ˢ (Prod.mk y ⁻¹' s)) := by
-    intro y y' hyy'
-    refine Set.disjoint_left.2 fun p hp hp' => hyy' ?_
-    rw [← (Set.mem_prod.1 hp).1, ← (Set.mem_prod.1 hp').1]
-  have hcover : s = ⋃ y : Y, (({y} : Set Y) ×ˢ (Prod.mk y ⁻¹' s)) := by
-    ext p
-    simp only [Set.mem_iUnion, Set.singleton_prod, Set.mem_image, Set.mem_preimage]
-    exact ⟨fun hp => ⟨p.1, p.2, hp, rfl⟩, fun ⟨_, _, hp, hpe⟩ => hpe ▸ hp⟩
-  conv_lhs => rw [hcover]
-  exact measure_iUnion hdisj hmeas
 
 end Slices
 
@@ -174,7 +154,28 @@ instance instIsMarkovKernelCountableCondKernel (σ : Measure (Y × Z)) [IsFinite
 theorem compProd_countableCondKernel (σ : Measure (Y × Z)) [IsFiniteMeasure σ] :
     σ.fst ⊗ₘ countableCondKernel σ = σ := by
   ext s hs
-  rw [Measure.compProd_apply hs, lintegral_countable', measure_eq_tsum_prod_singleton σ hs]
+  -- The atomic decomposition `σ s = ∑' y, σ ({y} ×ˢ (Prod.mk y ⁻¹' s))` is the fibre sum of
+  -- `σ.restrict s` along `Prod.fst`.
+  have hslice : ∀ y : Y,
+      σ.restrict s (Prod.fst ⁻¹' {y}) = σ (({y} : Set Y) ×ˢ (Prod.mk y ⁻¹' s)) := fun y => by
+    rw [Measure.restrict_apply (measurable_fst (measurableSet_singleton y))]
+    congr 1
+    ext p
+    simp only [Set.mem_inter_iff, Set.mem_preimage, Set.mem_singleton_iff, Set.mem_prod]
+    constructor
+    · rintro ⟨rfl, hp⟩
+      exact ⟨rfl, hp⟩
+    · rintro ⟨rfl, hp⟩
+      exact ⟨rfl, hp⟩
+  have hdecomp : σ s = ∑' y : Y, σ (({y} : Set Y) ×ˢ (Prod.mk y ⁻¹' s)) := by
+    have h := _root_.MeasureTheory.tsum_measure_preimage_singleton (μ := σ.restrict s)
+      (Set.countable_univ (α := Y)) (f := Prod.fst)
+      fun y _ => measurable_fst (measurableSet_singleton y)
+    rw [tsum_subtype Set.univ fun y => σ.restrict s (Prod.fst ⁻¹' {y}), Set.indicator_univ,
+      Set.preimage_univ, Measure.restrict_apply_univ] at h
+    rw [← h]
+    exact tsum_congr hslice
+  rw [Measure.compProd_apply hs, lintegral_countable', hdecomp]
   refine tsum_congr fun y => ?_
   by_cases hy : σ.fst {y} = 0
   · rw [hy, mul_zero, measure_prod_singleton_of_fst_eq_zero σ hy]
@@ -199,10 +200,13 @@ section Regressions
 
 /-! ### Regressions
 
-Three examples that break the contract of `countableCondKernel` if it is read more strongly than
-it is stated. The first shows the conclusion of `eq_countableCondKernel_of_ne_zero` cannot be
-extended to null atoms; the other two show that neither of the construction's two hypotheses on
-the ambient data — `Nonempty Z` and `IsFiniteMeasure σ` — can be dropped. -/
+Two examples that break the contract of `countableCondKernel` if it is read more strongly than it
+is stated. The first shows the conclusion of `eq_countableCondKernel_of_ne_zero` cannot be
+extended to null atoms; the second shows that `IsFiniteMeasure σ` cannot be dropped. (That
+`Nonempty Z` cannot be dropped either is immediate from Mathlib:
+`ProbabilityTheory.Kernel.eq_zero_of_isEmpty_right` and
+`ProbabilityTheory.Kernel.not_isMarkovKernel_zero` leave no Markov kernel at all on an empty
+target.) -/
 
 /-- **Uniqueness genuinely fails at a null atom.** The Dirac measure at `(true, true)` on
 `Bool × Bool` gives the atom `false` no mass, and the two kernels below both disintegrate it while
@@ -233,17 +237,6 @@ theorem exists_isCondKernel_pair_ne :
   have hfalse := congrArg (fun κ : Kernel Bool Bool => κ false {true}) h
   simp [Kernel.const_apply, Kernel.deterministic_apply,
     Measure.dirac_apply' _ (measurableSet_singleton true)] at hfalse
-
-/-- **`Nonempty Z` cannot be dropped.** A Markov kernel returns a probability measure at every
-point, and an empty target carries none, so on an empty `Z` no disintegration of the required
-shape exists at all — not merely no canonical one. -/
-theorem not_isMarkovKernel_of_isEmpty [Nonempty Y] [IsEmpty Z] (κ : Kernel Y Z) :
-    ¬ IsMarkovKernel κ := by
-  intro h
-  have h₁ : κ (Classical.arbitrary Y) Set.univ = 1 :=
-    (h.isProbabilityMeasure (Classical.arbitrary Y)).measure_univ
-  rw [Set.univ_eq_empty_iff.2 ‹IsEmpty Z›, measure_empty] at h₁
-  exact zero_ne_one h₁
 
 /-- **`IsFiniteMeasure σ` cannot be dropped.** At an atom of infinite mass the normalising factor
 `(σ.fst {y})⁻¹` is `0`, so the conditional kernel collapses to the zero measure and the

--- a/TauCeti/Probability/Kernel/Disintegration/Countable.lean
+++ b/TauCeti/Probability/Kernel/Disintegration/Countable.lean
@@ -13,15 +13,15 @@ public import Mathlib.Probability.Kernel.Disintegration.Basic
 A measure `σ` on a product `Y × Z` disintegrates over `Y` when it is the composition-product
 `σ.fst ⊗ₘ κ` of its first marginal with a Markov kernel `κ : Kernel Y Z`. Mathlib supplies such a
 kernel when the *second* factor `Z` is standard Borel
-(`MeasureTheory.Measure.condKernel`). This file supplies one in the complementary regime: when the
-*first* factor `Y` is countable with measurable singletons, and `Z` is an arbitrary measurable
-space.
+(`MeasureTheory.Measure.condKernel`). For a finite `σ`, this file supplies one in the complementary
+regime: when the *first* factor `Y` is countable with measurable singletons, and `Z` is an arbitrary
+measurable space.
 
 On a countable `Y` no analytic input is needed — the disintegration is the elementary formula
 `κ y s = (σ.fst {y})⁻¹ * σ ({y} ×ˢ s)`, conditioning on the atom `{y}`. The one point that needs
 care is the atoms of zero mass, where that formula reads `∞ * 0` and carries no information: they
 are given a default value, and the disintegration still holds there because such an atom carries
-no `σ`-mass to begin with (`measure_prod_singleton_of_fst_eq_zero`).
+no `σ`-mass to begin with (`measure_singleton_prod_eq_zero_of_fst_eq_zero`).
 
 ## Main definitions
 
@@ -30,7 +30,8 @@ no `σ`-mass to begin with (`measure_prod_singleton_of_fst_eq_zero`).
 
 ## Main results
 
-* `TauCeti.MeasureTheory.measure_prod_singleton_of_fst_eq_zero` — an atom of zero first-marginal
+* `TauCeti.MeasureTheory.measure_singleton_prod_eq_zero_of_fst_eq_zero` — an atom of zero
+  first-marginal
   mass carries no mass at all: the fact that makes the default value at such an atom harmless;
 * `TauCeti.MeasureTheory.countableCondKernel_apply`,
   `TauCeti.MeasureTheory.countableCondKernel_apply_of_ne_zero` and
@@ -41,10 +42,9 @@ no `σ`-mass to begin with (`measure_prod_singleton_of_fst_eq_zero`).
   `MeasureTheory.Measure.IsCondKernel` instance;
 * `TauCeti.MeasureTheory.eq_countableCondKernel_of_ne_zero` — every conditional kernel of `σ`
   agrees with this one at every atom of positive mass;
-* `TauCeti.MeasureTheory.exists_isCondKernel_pair_ne` and
-  `TauCeti.MeasureTheory.exists_compProd_countableCondKernel_ne` — two regressions
-  showing that the contract cannot be strengthened and that its finiteness hypothesis cannot be
-  dropped.
+
+The file also contains two private regression examples showing that the contract cannot be
+strengthened and that its finiteness hypothesis cannot be dropped.
 
 ## Implementation notes
 
@@ -57,9 +57,9 @@ The value at an atom of zero mass is a Dirac measure at `Classical.arbitrary Z`,
 measure at every point of `Y`, `σ` prescribes none at a null atom, and on an empty `Z` no Markov
 kernel exists at all, by `ProbabilityTheory.Kernel.eq_zero_of_isEmpty_right` together with
 `ProbabilityTheory.Kernel.not_isMarkovKernel_zero`. The choice is deliberately *not* hidden —
-`countableCondKernel_apply_of_eq_zero` names it, and
-`exists_isCondKernel_pair_ne` exhibits two conditional kernels of one measure that differ at a
-null atom, so no strengthening of `eq_countableCondKernel_of_ne_zero` to all atoms is available.
+`countableCondKernel_apply_of_eq_zero` names it. A private regression below exhibits two
+conditional kernels of one measure that differ at a null atom, so no strengthening of
+`eq_countableCondKernel_of_ne_zero` to all atoms is available.
 
 ## References
 
@@ -93,7 +93,7 @@ variable [MeasurableSingletonClass Y]
 
 This is the fact that makes the default value of `countableCondKernel` at a null atom harmless:
 such an atom contributes nothing to the disintegration, whatever the kernel does there. -/
-theorem measure_prod_singleton_of_fst_eq_zero (σ : Measure (Y × Z)) {y : Y}
+theorem measure_singleton_prod_eq_zero_of_fst_eq_zero (σ : Measure (Y × Z)) {y : Y}
     (hy : σ.fst {y} = 0) (s : Set Z) : σ ({y} ×ˢ s) = 0 := by
   have huniv : σ (({y} : Set Y) ×ˢ (Set.univ : Set Z)) = 0 := by
     rw [Set.prod_univ, ← Measure.fst_apply (measurableSet_singleton y)]
@@ -106,8 +106,8 @@ section CondKernel
 
 variable [Countable Y] [MeasurableSingletonClass Y] [Nonempty Z]
 
-/-- The **conditional kernel over a countable coordinate**: the measure `σ` on `Y × Z`
-conditioned on each atom of `Y`.
+/-- The **countable-coordinate kernel construction** for a measure `σ` on `Y × Z`. When `σ` is
+finite, this is its conditional kernel over the first coordinate.
 
 At an atom `y` of positive first-marginal mass this is the normalised slice
 `s ↦ (σ.fst {y})⁻¹ * σ ({y} ×ˢ s)`; at a null atom, where `σ` prescribes nothing, it is a Dirac
@@ -126,7 +126,7 @@ theorem countableCondKernel_apply (σ : Measure (Y × Z)) (y : Y) :
       else ((σ.fst {y})⁻¹ • σ).comap (Prod.mk y) := (rfl)
 
 /-- At a null atom the conditional kernel takes its default value. It is a genuine choice, not a
-quantity read off `σ`; see `exists_isCondKernel_pair_ne`. -/
+quantity read off `σ`; see the private uniqueness regression below. -/
 theorem countableCondKernel_apply_of_eq_zero {σ : Measure (Y × Z)} {y : Y}
     (hy : σ.fst {y} = 0) : countableCondKernel σ y = Measure.dirac (Classical.arbitrary Z) := by
   simp [countableCondKernel_apply, hy]
@@ -178,7 +178,7 @@ theorem compProd_countableCondKernel (σ : Measure (Y × Z)) [IsFiniteMeasure σ
   rw [Measure.compProd_apply hs, lintegral_countable', hdecomp]
   refine tsum_congr fun y => ?_
   by_cases hy : σ.fst {y} = 0
-  · rw [hy, mul_zero, measure_prod_singleton_of_fst_eq_zero σ hy]
+  · rw [hy, mul_zero, measure_singleton_prod_eq_zero_of_fst_eq_zero σ hy]
   · rw [countableCondKernel_apply_of_ne_zero hy, mul_comm, ← mul_assoc,
       ENNReal.mul_inv_cancel hy (measure_ne_top _ _), one_mul]
 
@@ -187,7 +187,7 @@ instance instIsCondKernelCountableCondKernel (σ : Measure (Y × Z)) [IsFiniteMe
   disintegrate := compProd_countableCondKernel σ
 
 /-- Any conditional kernel of `σ` agrees with `countableCondKernel σ` at every atom of positive
-mass. The restriction to such atoms is sharp: see `exists_isCondKernel_pair_ne`. -/
+mass. The restriction to such atoms is sharp, as shown by the private regression below. -/
 theorem eq_countableCondKernel_of_ne_zero (σ : Measure (Y × Z)) [IsFiniteMeasure σ]
     (κ : Kernel Y Z) [σ.IsCondKernel κ] {y : Y} (hy : σ.fst {y} ≠ 0) :
     κ y = countableCondKernel σ y :=
@@ -213,7 +213,7 @@ target.) -/
 differing there. So `eq_countableCondKernel_of_ne_zero` is sharp: a conditional kernel is pinned
 down exactly on the atoms of positive mass, and the default value `countableCondKernel` uses
 elsewhere is a choice, not a derived quantity. -/
-theorem exists_isCondKernel_pair_ne :
+private theorem exists_isCondKernel_pair_ne :
     ∃ κ₁ κ₂ : Kernel Bool Bool,
       (Measure.dirac ((true, true) : Bool × Bool)).IsCondKernel κ₁ ∧
       (Measure.dirac ((true, true) : Bool × Bool)).IsCondKernel κ₂ ∧ κ₁ ≠ κ₂ := by
@@ -226,7 +226,7 @@ theorem exists_isCondKernel_pair_ne :
         = Measure.dirac ((true, true) : Bool × Bool) := by
     intro κ _ hκ
     ext s hs
-    rw [hfst, Measure.compProd_apply hs, lintegral_dirac, hκ,
+    rw [hfst, Measure.dirac_compProd_apply hs, hκ,
       Measure.dirac_apply' _ (hs.preimage measurable_prodMk_left),
       Measure.dirac_apply' _ hs]
     rfl
@@ -241,7 +241,7 @@ theorem exists_isCondKernel_pair_ne :
 /-- **`IsFiniteMeasure σ` cannot be dropped.** At an atom of infinite mass the normalising factor
 `(σ.fst {y})⁻¹` is `0`, so the conditional kernel collapses to the zero measure and the
 composition-product loses all the mass it was meant to recover. -/
-theorem exists_compProd_countableCondKernel_ne :
+private theorem exists_compProd_countableCondKernel_ne :
     ∃ σ : Measure (Unit × Unit), σ.fst ⊗ₘ countableCondKernel σ ≠ σ := by
   refine ⟨(⊤ : ℝ≥0∞) • Measure.dirac ((), ()), ?_⟩
   set σ : Measure (Unit × Unit) := (⊤ : ℝ≥0∞) • Measure.dirac ((), ()) with hσ

--- a/TauCeti/Probability/Kernel/Disintegration/Countable.lean
+++ b/TauCeti/Probability/Kernel/Disintegration/Countable.lean
@@ -34,9 +34,10 @@ no `σ`-mass to begin with (`measure_prod_singleton_of_fst_eq_zero`).
   atomic slices, the elementary decomposition the construction rests on;
 * `TauCeti.MeasureTheory.measure_prod_singleton_of_fst_eq_zero` — an atom of zero first-marginal
   mass carries no mass at all: the fact that makes the default value at such an atom harmless;
-* `TauCeti.MeasureTheory.countableCondKernel_apply_of_ne_zero` and
-  `TauCeti.MeasureTheory.countableCondKernel_apply_of_eq_zero` — the two branches of the
-  construction, made explicit;
+* `TauCeti.MeasureTheory.countableCondKernel_apply`,
+  `TauCeti.MeasureTheory.countableCondKernel_apply_of_ne_zero` and
+  `TauCeti.MeasureTheory.countableCondKernel_apply_of_eq_zero` — the eliminator and the two
+  branches of the construction, made explicit;
 * `TauCeti.MeasureTheory.compProd_countableCondKernel` — **the disintegration**,
   `σ.fst ⊗ₘ countableCondKernel σ = σ`, registered as a
   `MeasureTheory.Measure.IsCondKernel` instance;
@@ -137,12 +138,12 @@ def countableCondKernel (σ : Measure (Y × Z)) : Kernel Y Z :=
     if σ.fst {y} = 0 then Measure.dirac (Classical.arbitrary Z)
     else ((σ.fst {y})⁻¹ • σ).comap (Prod.mk y)
 
-/-- The two branches of `countableCondKernel`, before either is evaluated. Kept private: the
-public API is the pair of branch lemmas below, neither of which mentions the `if`. -/
-private theorem countableCondKernel_apply (σ : Measure (Y × Z)) (y : Y) :
+/-- The two branches of `countableCondKernel`, before either is evaluated. The pair of branch
+lemmas below is the interface to prefer; neither of those mentions the `if`. -/
+theorem countableCondKernel_apply (σ : Measure (Y × Z)) (y : Y) :
     countableCondKernel σ y =
       if σ.fst {y} = 0 then Measure.dirac (Classical.arbitrary Z)
-      else ((σ.fst {y})⁻¹ • σ).comap (Prod.mk y) := rfl
+      else ((σ.fst {y})⁻¹ • σ).comap (Prod.mk y) := (rfl)
 
 /-- At a null atom the conditional kernel takes its default value. It is a genuine choice, not a
 quantity read off `σ`; see `exists_isCondKernel_pair_ne`. -/


### PR DESCRIPTION
This PR builds the disintegration of a finite measure on `Y × Z` over a **countable** first
coordinate `Y`, with no hypothesis whatsoever on `Z`, and uses it to glue two plans that share a
middle marginal without assuming anything of either outer space. It closes the design-validation
milestone that `TauCetiRoadmap/DenseGraphLimits/README.md` pins as "the definite first milestone of
its layer", preceding the arbitrary-carrier triangle inequality of Layer 1: *"before the
arbitrary-carrier triangle inequality (Janson 6.5): finite coupling gluing with zero-mass middle
atoms explicit, then stability of the reduction under step approximation — finite gluing alone does
not establish the arbitrary-carrier theorem."* After this PR the second half of that milestone —
stability of the step-graphon reduction, which transports the countable-middle gluing to arbitrary
carriers — is what remains before `cutDist` can be proved to satisfy the triangle inequality and
`GraphonSpace Ω μ` becomes expressible.

Why this and not the triangle inequality itself: `TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean`
already has `cutDist`, and the missing gluing is exactly what its docstring records as absent. The
coupling-primary `cutDist` compares graphons on *arbitrary* probability carriers, so the gluing it
needs may not assume either outer carrier standard Borel — which is precisely the regime the
existing `TauCeti.Measure.exists_glue_of_standardBorel_right` / `..._left` do not cover, since each
assumes one *outer* space standard Borel. Making the *middle* space countable is the other way to
obtain a disintegration, and it is the one Janson's step-function reduction produces.

Mathlib supplies the predicate `MeasureTheory.Measure.IsCondKernel` and the uniqueness formula
`IsCondKernel.apply_of_ne_zero`, but its only existence result (`Measure.condKernel`) needs the
*second* factor standard Borel and nonempty; there is no measure-level instance for a countable
first factor (`ProbabilityTheory.Kernel.condKernelCountable` disintegrates a kernel from a countable
index type, which is a different statement). So `TauCeti.MeasureTheory.countableCondKernel` fills a
genuine gap rather than restating one. It is assembled from `Kernel.ofFunOfCountable`,
`lintegral_countable'`, `MeasurableEmbedding.comap_apply` and — for the atomic decomposition —
Mathlib's generic fibre-sum theorem `MeasureTheory.tsum_measure_preimage_singleton`; nothing is
vendored from Mathlib.

The zero-mass middle atoms the milestone asks to be made explicit are handled in the open:
`measure_prod_singleton_of_fst_eq_zero` shows a null atom carries no mass in any slice, so the
default value the kernel takes there cannot affect the disintegration, and
`countableCondKernel_apply_of_eq_zero` names that default value instead of hiding it inside the
definition. `eq_countableCondKernel_of_ne_zero` pins the kernel down on every atom of positive mass,
and two adversarial regressions show that reading it more strongly is wrong:
`exists_isCondKernel_pair_ne` exhibits two conditional kernels of one measure that differ at a null
atom (so the uniqueness statement is sharp), and `exists_compProd_countableCondKernel_ne` shows
`[IsFiniteMeasure σ]` cannot be dropped because at an atom of infinite mass the normalising factor
is `0` and the composition-product loses everything. That `[Nonempty Z]` cannot be dropped either is
immediate from Mathlib — `Kernel.eq_zero_of_isEmpty_right` plus `Kernel.not_isMarkovKernel_zero`
leave no Markov kernel at all on an empty target — so the module cites those two lemmas instead of
carrying a regression theorem for it.

`TauCeti.MeasureTheory.exists_glue_of_countable_middle` is then the gluing lemma itself, and
`exists_comp_of_countable_middle` the induced composition of plans; both are stated through
`π.snd = σ.fst` rather than a coupling predicate, which is the convention
`TauCeti/MeasureTheory/OptimalTransport/Gluing.lean` fixes in its implementation notes so that any
packaging of couplings can consume them. A dense-graph-limit consumer holding
`hπ : IsCoupling μ₁ μ₂ π` and `hσ : IsCoupling μ₂ μ₃ σ` supplies that hypothesis as
`hπ.snd_eq.trans hσ.fst_eq.symm`, so no wrapper is added here.

Two notes on placement and namespace. The disintegration goes to
`TauCeti/Probability/Kernel/Disintegration/Countable.lean`, mirroring Mathlib's own arrangement, in
which `Mathlib/Probability/Kernel/Disintegration/Basic.lean` carries measure-level declarations; the
DenseGraphLimits README asks for exactly this, since it lists disintegration as an ingredient the
graphon modules consume and says its general-purpose prerequisites "belong in general `TauCeti/`
homes". The gluing goes next to its two standard Borel siblings in the existing `Gluing.lean`, but
in `namespace TauCeti.MeasureTheory` rather than `TauCeti.Measure`, because
`scripts/lint-dot-notation.py` turns CI red on a *new* declaration under `TauCeti.Measure` whose
statement mentions `MeasureTheory.Measure` — with the three theorems in `TauCeti.Measure` the script
reports `3 new`, exit 1, and with them in `TauCeti.MeasureTheory` it reports `0 new`, exit 0. The
existing `TauCeti.Measure.*` gluing family is grandfathered in
`scripts/lint-dot-notation-baseline.txt`, so it is precedent the ratchet does not extend. A file
comment records this.

`lake build`, `lake exe axioms`, `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` and
`scripts/lint-env.sh` are all green; the six ratchetable `lint-env` baseline entries it reports are
pre-existing on `main` and untouched here.

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"finite-coupling-gluing-zero-mass-middle-atoms"}-->

🤖 Prepared with Claude Code
