### PR TITLE
feat(ShortNagellLutz): the Nagell–Lutz theorem for a short Weierstrass model

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -9,7 +9,10 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
 public import Mathlib.AlgebraicGeometry.EllipticCurve.NormalForms
 
 /-!
-# Identities among the univariate division polynomials
+# Identities among the division polynomials
+
+Two identities the Nagell–Lutz route needs and Mathlib lacks — one univariate, one bivariate —
+and the consumer the univariate one exists for.
 
 Mathlib gives the univariate polynomials `Φₙ` in two registers. `Φ_three` and `Φ_four` are stated
 through the division polynomials `Ψ₃`, `preΨ₄` and `Ψ₂Sq`; `Φ_two` is stated through the
@@ -29,8 +32,13 @@ a curve in characteristic-≠-2 normal form.
   polynomials over any commutative ring — the same reason as the two above — and because a
   consumer-side home would tie its availability to torsion imports it does not need.
 
-Both hold over an arbitrary commutative ring, with no point of a curve, no ellipticity and no
-division; the first has no hypothesis at all and the second's is an equation between ring elements.
+All three hold over an arbitrary commutative ring, with no ellipticity and no division. The first
+has no hypothesis at all; the second's is an equation between ring elements; the third's is
+Mathlib's `IsCharNeTwoNF` instance, which is a condition on the curve's coefficients rather than on
+a point. The first two are statements about univariate polynomials and mention no point at all; the
+third evaluates the bivariate `ψ₂`, but at an arbitrary `(x, y)` — it does not ask that the pair lie
+on the curve.
+
 Declarations here are stated in the root
 `WeierstrassCurve` namespace, not under `TauCeti`, because they extend Mathlib's own
 division-polynomial API and mention nothing of this repository's — the same call

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import Mathlib.AlgebraicGeometry.EllipticCurve.NormalForms
 
 /-!
 # Identities among the univariate division polynomials
@@ -91,5 +92,18 @@ theorem eval_Ψ₃_eq_sub_mul_eval_Ψ₂Sq {x x' : R} (h : x' * (W.ΨSq 2).eval 
     (W.Ψ₃).eval x = (x - x') * (W.Ψ₂Sq).eval x := by
   rw [ΨSq_two, W.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃, eval_sub, eval_mul, eval_X] at h
   linear_combination h
+
+/-- **In characteristic-≠-2 normal form, `ψ₂` is `2y`.** The two-division polynomial is
+`2y + a₁x + a₃`, so `a₁ = a₃ = 0` collapses it — and that collapse is what turns the long model's
+order-two exception into the classical `y = 0`.
+
+Stated at `IsCharNeTwoNF` rather than at `shortCurve`, which is the weakest hypothesis the one-line
+proof uses: `y² = x³ + a₂x² + a₄x + a₆` needs no `a₂ = 0`. Mathlib's
+`isCharNeTwoNF_of_isShortNF` hands the instance to `shortCurve` for free, so the short-model call
+sites are unchanged. Over any commutative ring, because both `ℤ` (for the integral conclusion) and
+`ℚ` (for the point) need it. -/
+@[simp] lemma evalEval_ψ₂_of_isCharNeTwoNF {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+    [W.IsCharNeTwoNF] (x y : R) : W.ψ₂.evalEval x y = 2 * y := by
+  simp [WeierstrassCurve.ψ₂, Affine.polynomialY, evalEval]
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -14,13 +14,20 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.NormalForms
 Mathlib gives the univariate polynomials `Φₙ` in two registers. `Φ_three` and `Φ_four` are stated
 through the division polynomials `Ψ₃`, `preΨ₄` and `Ψ₂Sq`; `Φ_two` is stated through the
 `b`-invariants, as `X ^ 4 - C b₄ * X ^ 2 - C (2 * b₆) * X - C b₈`. This file supplies the `n = 2`
-member of the first register, which Mathlib does not have.
+member of the first register, which Mathlib does not have, together with the one evaluation
+identity that the same Nagell–Lutz route needs and Mathlib likewise lacks: what `ψ₂` reduces to on
+a curve in characteristic-≠-2 normal form.
 
 ## Main results
 
 * `WeierstrassCurve.Φ_two_eq_X_mul_Ψ₂Sq_sub_Ψ₃`: `Φ₂ = X · Ψ₂Sq - Ψ₃`.
 * `WeierstrassCurve.eval_Ψ₃_eq_sub_mul_eval_Ψ₂Sq`: its consumer — from the cleared doubling
   relation `x' · ΨSq₂(x) = Φ₂(x)`, the factorisation `Ψ₃(x) = (x - x') · Ψ₂Sq(x)`.
+* `WeierstrassCurve.evalEval_ψ₂_of_isCharNeTwoNF`: `ψ₂(x, y) = 2y` whenever `a₁ = a₃ = 0`. The
+  two-division polynomial is `2y + a₁x + a₃`, so Mathlib's `IsCharNeTwoNF` collapses it. It sits
+  here rather than with its consumer because it is a plain identity among Mathlib's division
+  polynomials over any commutative ring — the same reason as the two above — and because a
+  consumer-side home would tie its availability to torsion imports it does not need.
 
 Both hold over an arbitrary commutative ring, with no point of a curve, no ellipticity and no
 division; the first has no hypothesis at all and the second's is an equation between ring elements.
@@ -37,8 +44,11 @@ names the discriminant half of the theorem twice: at `:827` as
 "`lutz_nagell_integrality_general`, with its discriminant companion", and in the Layer 6 note at
 `:1163`–`:1170` as "the `κ² ∣ 4Δ` discriminant form". The `Φ 2` identity is the step that turns the
 doubling formula for the `x`-coordinate into the factorisation `Ψ₃(x) = (x - x')·Ψ₂Sq(x)` that
-argument runs on. The rest of that route — the point-level doubling formula and
-`lutz_nagell_integrality_general` — is not in this repository yet, and nothing here assumes it.
+argument runs on, and `evalEval_ψ₂_of_isCharNeTwoNF` is what turns `ψ₂` into `2y` once the model
+is short. The rest of that route has since landed — the point-level doubling formula in
+`DivisionPolynomial/Descent.lean` and the integrality theorem as
+`isInteger_or_order_two_of_torsion` — so the consumers named above now exist. Nothing in this file
+assumes them: every declaration here is a statement about polynomials.
 
 ## Provenance
 
@@ -57,6 +67,11 @@ The factorisation is also unnamed there: it is the anonymous
 wrappers have fired. `PIDMain.lean:390` carries a variant of the same step with `κ₀ ^ 2` already
 substituted for `Ψ₂Sq(x)`. Here it is stated over any commutative ring, since nothing in it needs a
 field, and it takes the doubling relation as a hypothesis rather than reconstructing it.
+
+`evalEval_ψ₂_of_isCharNeTwoNF` is **not** from that source. It began as a `shortCurve`-specific
+identity in the short-model port and was generalised to `IsCharNeTwoNF` when review observed that
+its one-line proof never uses `a₂ = 0`; `shortCurve` picks it up through Mathlib's
+`isCharNeTwoNF_of_isShortNF`.
 
 The source's two `eval`-level wrappers themselves are deliberately not ported. `Phi2_eval_eq` is
 the `Φ 2` identity followed by `eval_sub, eval_mul, eval_X`, and `PsiSq_two_eval_eq` is Mathlib's

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
@@ -9,6 +9,7 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Torsion
 -- Proof-only, and not reachable transitively: `Torsion/Discriminant.lean` imports this
 -- module non-publicly, so `evalEval_ψ₂_of_isCharNeTwoNF` is not re-exported through it.
 import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.NormalForms
 public import TauCeti.AlgebraicGeometry.EllipticCurve.ShortWeierstrass
 
 /-!
@@ -34,12 +35,18 @@ is elliptic. See the Provenance note.
 
 ## Main results
 
-* `WeierstrassCurve.lutz_nagell`: the theorem — integral coordinates together with
-  `y₀ = 0 ∨ y₀² ∣ Δ`.
-* `WeierstrassCurve.isInteger_of_torsion_short`: the integrality half on its own, with no
-  order-two exception.
-* `WeierstrassCurve.y_eq_zero_or_sq_dvd_Δ_of_torsion_short`: the discriminant half on its own.
-* `WeierstrassCurve.y_eq_zero_of_order_two_short`: the collapse — order two forces `y = 0`.
+* `WeierstrassCurve.lutz_nagell`: the theorem at the roadmap's explicit short model
+  `y² = x³ + Ax + B` — integral coordinates together with `y₀ = 0 ∨ y₀² ∣ Δ`.
+* `WeierstrassCurve.isInteger_of_torsion`: the integrality half, with no order-two exception, for
+  any integral model in characteristic-≠-2 normal form.
+* `WeierstrassCurve.y_eq_zero_or_sq_dvd_Δ_of_torsion`: the discriminant half, likewise.
+* `WeierstrassCurve.y_eq_zero_of_order_two`: the collapse — order two forces `y = 0` — over any
+  field in which `2` is invertible.
+
+The three results above `lutz_nagell` are stated at `[W.IsCharNeTwoNF]`, i.e. `a₁ = a₃ = 0`, not
+at `shortCurve`: no step uses `a₂ = 0`, and the cubic `X³ + a₂X² + a₄X + a₆` is monic either way.
+`lutz_nagell` is their specialisation, and costs nothing to obtain — Mathlib's
+`isCharNeTwoNF_of_isShortNF` supplies the instance.
 
 ## Roadmap
 
@@ -83,18 +90,33 @@ namespace WeierstrassCurve
 
 open TauCeti.WeierstrassCurve
 
-variable (A B : ℤ)
+variable {W : WeierstrassCurve ℤ} [W.IsCharNeTwoNF]
 
-/-- **Nagell–Lutz, discriminant half, short model.** For a torsion point with integral coordinates
-on `y² = x³ + Ax + B`, either `y₀ = 0` or `y₀²` divides the discriminant.
+/-- **In characteristic-≠-2 normal form, a two-torsion point has `y = 0`.** Order two makes `ψ₂`
+vanish, and `a₁ = a₃ = 0` makes `ψ₂` equal `2y`; cancelling `2` finishes it.
+
+Nothing here sees `ℤ` or `ℚ`, and nothing needs `a₂ = 0`: the argument is the normal-form identity
+plus the ability to cancel `2` in the point's own field, so those are exactly the hypotheses. -/
+lemma y_eq_zero_of_order_two {F : Type*} [Field F] [DecidableEq F]
+    {E : WeierstrassCurve F} [E.IsCharNeTwoNF] (h2F : (2 : F) ≠ 0)
+    {x y : F} (hns : E.toAffine.Nonsingular x y)
+    (h2 : addOrderOf (Affine.Point.some _ _ hns) = 2) : y = 0 := by
+  have hψ : E.ψ₂.evalEval x y = 0 :=
+    (addOrderOf_eq_two_iff_evalEval_ψ₂_eq_zero _ hns).mp h2
+  rw [evalEval_ψ₂_of_isCharNeTwoNF] at hψ
+  exact (mul_eq_zero.mp hψ).resolve_left h2F
+
+/-- **Nagell–Lutz, discriminant half.** For a torsion point with integral coordinates on an
+integral model in characteristic-≠-2 normal form, either `y₀ = 0` or `y₀²` divides the
+discriminant.
 
 The general companion gives `ψ₂ = 0 ∨ ψ₂² ∣ 4Δ`; here `ψ₂ = 2y₀`, so the first disjunct is
 `2y₀ = 0` and the second is `4y₀² ∣ 4Δ`, and the `4` cancels on both sides. -/
-theorem y_eq_zero_or_sq_dvd_Δ_of_torsion_short {x y : ℚ}
-    (hns : ((shortCurve A B).baseChange ℚ).toAffine.Nonsingular x y)
+theorem y_eq_zero_or_sq_dvd_Δ_of_torsion {x y : ℚ}
+    (hns : (W.baseChange ℚ).toAffine.Nonsingular x y)
     (htor : IsOfFinAddOrder (Affine.Point.some _ _ hns))
     {x₀ y₀ : ℤ} (hx : algebraMap ℤ ℚ x₀ = x) (hy : algebraMap ℤ ℚ y₀ = y) :
-    y₀ = 0 ∨ y₀ ^ 2 ∣ (shortCurve A B).Δ := by
+    y₀ = 0 ∨ y₀ ^ 2 ∣ W.Δ := by
   rcases evalEval_ψ₂_eq_zero_or_sq_dvd_four_mul_Δ_rat hns htor hx hy with hκ | hdvd
   · rw [evalEval_ψ₂_of_isCharNeTwoNF] at hκ
     exact Or.inl (by omega)
@@ -103,66 +125,52 @@ theorem y_eq_zero_or_sq_dvd_Δ_of_torsion_short {x y : ℚ}
     ring_nf at hdvd
     exact (mul_dvd_mul_iff_right (by norm_num : (4 : ℤ) ≠ 0)).mp hdvd
 
-/-- **For a short model, a two-torsion point has `y = 0`.** Order two makes `ψ₂` vanish, and on a
-short model `ψ₂` is `2y`. This is exactly what collapses the long model's `4x, 8y` exception into
-the classical statement.
-
-Nothing here sees `ℤ` or `ℚ`: the argument needs the short-model identity and the ability to
-cancel `2` in the point's own field, so those are the hypotheses. The curve is taken up to
-equality with a short model rather than as one, which is what lets a caller holding a
-*base-changed* short curve apply it — `baseChange_shortCurve` is the equality, and `subst`
-transports the point and its order along with it. -/
-lemma y_eq_zero_of_order_two_short {F : Type*} [Field F] [DecidableEq F]
-    {W : WeierstrassCurve F} {a b : F} (hW : W = shortCurve a b) (h2F : (2 : F) ≠ 0)
-    {x y : F} (hns : W.toAffine.Nonsingular x y)
-    (h2 : addOrderOf (Affine.Point.some _ _ hns) = 2) : y = 0 := by
-  subst hW
-  have hψ : (shortCurve a b).ψ₂.evalEval x y = 0 :=
-    (addOrderOf_eq_two_iff_evalEval_ψ₂_eq_zero _ hns).mp h2
-  rw [evalEval_ψ₂_of_isCharNeTwoNF] at hψ
-  exact (mul_eq_zero.mp hψ).resolve_left h2F
-
-/-- **Nagell–Lutz, integrality half, short model.** On `y² = x³ + Ax + B` a nonzero torsion point
-has integral coordinates — with *no* order-two exception.
+/-- **Nagell–Lutz, integrality half.** On an integral model in characteristic-≠-2 normal form a
+nonzero torsion point has integral coordinates — with *no* order-two exception.
 
 The long-model theorem leaves order two aside with only `4x, 8y ∈ ℤ`. Here that case collapses:
-`ψ₂ = 2y`, so order two forces `y = 0`, and then `x` is a rational root of the monic
-`X³ + AX + B`, hence an integer. -/
-theorem isInteger_of_torsion_short {x y : ℚ}
-    (hns : ((shortCurve A B).baseChange ℚ).toAffine.Nonsingular x y)
+`ψ₂ = 2y`, so order two forces `y = 0`, and the curve equation then exhibits `x` as a rational root
+of the monic `X³ + a₂X² + a₄X + a₆`. The `a₂` term costs nothing — the cubic is monic either
+way. -/
+theorem isInteger_of_torsion {x y : ℚ}
+    (hns : (W.baseChange ℚ).toAffine.Nonsingular x y)
     (htor : IsOfFinAddOrder (Affine.Point.some _ _ hns)) :
     IsLocalization.IsInteger ℤ x ∧ IsLocalization.IsInteger ℤ y := by
   rcases isInteger_or_order_two_of_torsion_rat hns htor with h | ⟨h2, -, -⟩
   · exact h
-  · have hy : y = 0 := y_eq_zero_of_order_two_short (baseChange_shortCurve A B) two_ne_zero hns h2
+  · have hy : y = 0 := y_eq_zero_of_order_two two_ne_zero hns h2
     refine ⟨?_, hy ▸ ⟨0, by simp⟩⟩
-    -- With `y = 0` the curve equation exhibits `x` as a rational root of the monic `X³ + AX + B`,
-    -- and Mathlib's integral root theorem over the UFD `ℤ` finishes.
-    have hmonic : (X ^ 3 + C A * X + C B : ℤ[X]).Monic := by
+    have hmonic : (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆ : ℤ[X]).Monic := by
       simpa [add_assoc] using monic_X_pow_add (n := 3) (by compute_degree!)
     have heq := hns.left
-    -- `baseChange_shortCurve` leaves the coefficients as `algebraMap ℤ ℚ`, where `aeval` reads
-    -- them as `Int.cast`, so normalise before transferring.
-    rw [baseChange_shortCurve, shortCurve_equation_iff] at heq
+    rw [Affine.equation_iff] at heq
+    simp only [a₁_of_isCharNeTwoNF, a₃_of_isCharNeTwoNF, WeierstrassCurve.baseChange, map_a₂,
+      map_a₄, map_a₆, algebraMap_int_eq, eq_intCast, zero_mul, add_zero] at heq
     rw [hy] at heq
-    simp only [algebraMap_int_eq, eq_intCast] at heq
-    exact isInteger_of_is_root_of_monic hmonic
-      (by simpa using (by linarith : x ^ 3 + (A : ℚ) * x + (B : ℚ) = 0))
+    refine isInteger_of_is_root_of_monic hmonic ?_
+    -- `aeval_C` must fire before the casts are normalised: `eq_intCast` would otherwise rewrite
+    -- `C W.a₂` to an `ℤ[X]` cast, which `aeval_C` no longer matches.
+    simp only [map_add, map_mul, map_pow, aeval_X, aeval_C]
+    simp only [algebraMap_int_eq, eq_intCast]
+    linarith
+
+variable (A B : ℤ)
 
 /-- **The Nagell–Lutz theorem.** Let `A B : ℤ` and let `(x, y)` be a nonzero rational point of
 finite order on `y² = x³ + Ax + B`. Then `x` and `y` are integers, and either `y = 0` or
 `y² ∣ Δ`.
 
-This is the classical statement, and the form
-`TauCetiRoadmap/EllipticCurves/README.md:830` names `lutz_nagell`. No hypothesis `Δ ≠ 0` is
-needed — see the module docstring. -/
+This is the classical statement, and the form `TauCetiRoadmap/EllipticCurves/README.md:830` names
+`lutz_nagell`. It is the specialisation of the two theorems above at a short model: Mathlib's
+`isCharNeTwoNF_of_isShortNF` supplies the instance, so there is nothing to discharge. No hypothesis
+`Δ ≠ 0` is needed — see the module docstring. -/
 theorem lutz_nagell {x y : ℚ}
     (hns : ((shortCurve A B).baseChange ℚ).toAffine.Nonsingular x y)
     (htor : IsOfFinAddOrder (Affine.Point.some _ _ hns)) :
     ∃ x₀ y₀ : ℤ, (x₀ : ℚ) = x ∧ (y₀ : ℚ) = y ∧
       (y₀ = 0 ∨ y₀ ^ 2 ∣ (shortCurve A B).Δ) := by
-  obtain ⟨⟨x₀, hx₀⟩, ⟨y₀, hy₀⟩⟩ := isInteger_of_torsion_short A B hns htor
+  obtain ⟨⟨x₀, hx₀⟩, ⟨y₀, hy₀⟩⟩ := isInteger_of_torsion hns htor
   exact ⟨x₀, y₀, by simpa using hx₀, by simpa using hy₀,
-    y_eq_zero_or_sq_dvd_Δ_of_torsion_short A B hns htor hx₀ hy₀⟩
+    y_eq_zero_or_sq_dvd_Δ_of_torsion hns htor hx₀ hy₀⟩
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
@@ -6,6 +6,9 @@ Authors: The Tau Ceti contributors, Chris Birkbeck
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Torsion.Discriminant
+-- Proof-only, and not reachable transitively: `Torsion/Discriminant.lean` imports this
+-- module non-publicly, so `evalEval_ψ₂_of_isCharNeTwoNF` is not re-exported through it.
+import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
 public import TauCeti.AlgebraicGeometry.EllipticCurve.ShortWeierstrass
 
 /-!
@@ -37,8 +40,6 @@ is elliptic. See the Provenance note.
   order-two exception.
 * `WeierstrassCurve.y_eq_zero_or_sq_dvd_Δ_of_torsion_short`: the discriminant half on its own.
 * `WeierstrassCurve.y_eq_zero_of_order_two_short`: the collapse — order two forces `y = 0`.
-* `WeierstrassCurve.evalEval_ψ₂_of_isCharNeTwoNF`: `ψ₂ = 2y` whenever `a₁ = a₃ = 0`, over any
-  commutative ring — the short model gets it through Mathlib's `isCharNeTwoNF_of_isShortNF`.
 
 ## Roadmap
 
@@ -81,19 +82,6 @@ open Polynomial
 namespace WeierstrassCurve
 
 open TauCeti.WeierstrassCurve
-
-/-- **In characteristic-≠-2 normal form, `ψ₂` is `2y`.** The two-division polynomial is
-`2y + a₁x + a₃`, so `a₁ = a₃ = 0` collapses it — and that collapse is what turns the long model's
-order-two exception into the classical `y = 0`.
-
-Stated at `IsCharNeTwoNF` rather than at `shortCurve`, which is the weakest hypothesis the one-line
-proof uses: `y² = x³ + a₂x² + a₄x + a₆` needs no `a₂ = 0`. Mathlib's
-`isCharNeTwoNF_of_isShortNF` hands the instance to `shortCurve` for free, so the short-model call
-sites are unchanged. Over any commutative ring, because both `ℤ` (for the integral conclusion) and
-`ℚ` (for the point) need it. -/
-@[simp] lemma evalEval_ψ₂_of_isCharNeTwoNF {R : Type*} [CommRing R] (W : WeierstrassCurve R)
-    [W.IsCharNeTwoNF] (x y : R) : W.ψ₂.evalEval x y = 2 * y := by
-  simp [WeierstrassCurve.ψ₂, Affine.polynomialY, evalEval]
 
 variable (A B : ℤ)
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors, Chris Birkbeck
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Torsion.Discriminant
+public import TauCeti.AlgebraicGeometry.EllipticCurve.ShortWeierstrass
+
+/-!
+# The Nagell–Lutz theorem for a short Weierstrass model
+
+For `A B : ℤ`, a nonzero rational point of finite order on `y² = x³ + Ax + B` has **integral**
+coordinates, and its `y`-coordinate satisfies `y = 0` or `y² ∣ Δ`. That is the classical
+statement, and unlike the long-model theorem it has no order-two exception.
+
+The exception disappears for a computable reason rather than by assumption. On a short model
+`a₁ = a₃ = 0`, so `ψ₂ = 2y`; a point of order two makes `ψ₂` vanish, hence `y = 0`, and then the
+curve equation exhibits `x` as a rational root of the **monic** `X³ + AX + B`, so `x` is an
+integer too. The long model's honest bound `4x, 8y ∈ ℤ` therefore sharpens to full integrality
+exactly here.
+
+The same collapse turns the discriminant companion into its classical form: it gives
+`ψ₂ = 0 ∨ ψ₂² ∣ 4Δ`, and substituting `ψ₂ = 2y₀` yields `2y₀ = 0 ∨ 4y₀² ∣ 4Δ`, from which the `4`
+cancels on both sides.
+
+**No `Δ ≠ 0` hypothesis.** The source carries one on all three of its headline theorems and uses
+it in none of them; what the argument needs is that the *point* is nonsingular, not that the curve
+is elliptic. See the Provenance note.
+
+## Main results
+
+* `WeierstrassCurve.lutz_nagell`: the theorem — integral coordinates together with
+  `y₀ = 0 ∨ y₀² ∣ Δ`.
+* `WeierstrassCurve.isInteger_of_torsion_short`: the integrality half on its own, with no
+  order-two exception.
+* `WeierstrassCurve.y_eq_zero_or_sq_dvd_Δ_of_torsion_short`: the discriminant half on its own.
+* `WeierstrassCurve.y_eq_zero_of_order_two_short`: the collapse — order two forces `y = 0`.
+* `WeierstrassCurve.evalEval_ψ₂_of_isCharNeTwoNF`: `ψ₂ = 2y` whenever `a₁ = a₃ = 0`, over any
+  commutative ring — the short model gets it through Mathlib's `isCharNeTwoNF_of_isShortNF`.
+
+## Roadmap
+
+New mathematics: `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
+Nagell–Lutz**". Lines `:828`–`:830` name this target: for an integral **short** model
+`y² = x³ + Ax + B`, "the classical full form — `x, y ∈ ℤ` and `y = 0` or `y² ∣ Δ`
+(`lutz_nagell`; AEC VIII.7)".
+
+## Provenance
+
+Ported from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
+`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), from two files whose authorship differs and is
+credited separately.
+
+**`LutzNagellTheorem/Main.lean` — `Authors: Chris Birkbeck`.** All three headline theorems come
+from it: `lutz_nagell_integrality` (`:40`), `lutz_nagell_discriminant` (`:53`) and `lutz_nagell`
+(`:71`). That file carries its own author header, so it is credited to Chris Birkbeck rather than
+to the project's usual pair, and the header of this file names them accordingly.
+
+**`LutzNagellTheorem/GeneralMain.lean` — no author header.** Its
+`lutz_nagell_integrality_short` (`:155`) is where the order-two collapse is carried out; with no
+header to go on it is credited to the project, as the sibling ports in this chain are.
+
+**The `Δ ≠ 0` hypothesis is dropped.** All three source theorems take
+`hΔ : (shortCurveZ A B).Δ ≠ 0`; none uses it. It occurs in the three signatures and twice in the
+bodies, both times in `lutz_nagell` forwarding it to the two theorems whose proofs never mention
+it — a pass-through of a hypothesis nothing consumes, which this repository's `unusedArguments`
+linter would reject in any case.
+
+One further adaptation: `ψ₂ = 2y` is stated over an arbitrary commutative ring, since the point
+lives over `ℚ` while the conclusion is over `ℤ` and both need it. The monic-root step follows the
+source and goes through `isInteger_of_is_root_of_monic` — Mathlib's, which is what the source's
+own lemma of that name restates.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve
+
+open TauCeti.WeierstrassCurve
+
+/-- **In characteristic-≠-2 normal form, `ψ₂` is `2y`.** The two-division polynomial is
+`2y + a₁x + a₃`, so `a₁ = a₃ = 0` collapses it — and that collapse is what turns the long model's
+order-two exception into the classical `y = 0`.
+
+Stated at `IsCharNeTwoNF` rather than at `shortCurve`, which is the weakest hypothesis the one-line
+proof uses: `y² = x³ + a₂x² + a₄x + a₆` needs no `a₂ = 0`. Mathlib's
+`isCharNeTwoNF_of_isShortNF` hands the instance to `shortCurve` for free, so the short-model call
+sites are unchanged. Over any commutative ring, because both `ℤ` (for the integral conclusion) and
+`ℚ` (for the point) need it. -/
+@[simp] lemma evalEval_ψ₂_of_isCharNeTwoNF {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+    [W.IsCharNeTwoNF] (x y : R) : W.ψ₂.evalEval x y = 2 * y := by
+  simp [WeierstrassCurve.ψ₂, Affine.polynomialY, evalEval]
+
+variable (A B : ℤ)
+
+/-- **Nagell–Lutz, discriminant half, short model.** For a torsion point with integral coordinates
+on `y² = x³ + Ax + B`, either `y₀ = 0` or `y₀²` divides the discriminant.
+
+The general companion gives `ψ₂ = 0 ∨ ψ₂² ∣ 4Δ`; here `ψ₂ = 2y₀`, so the first disjunct is
+`2y₀ = 0` and the second is `4y₀² ∣ 4Δ`, and the `4` cancels on both sides. -/
+theorem y_eq_zero_or_sq_dvd_Δ_of_torsion_short {x y : ℚ}
+    (hns : ((shortCurve A B).baseChange ℚ).toAffine.Nonsingular x y)
+    (htor : IsOfFinAddOrder (Affine.Point.some _ _ hns))
+    {x₀ y₀ : ℤ} (hx : algebraMap ℤ ℚ x₀ = x) (hy : algebraMap ℤ ℚ y₀ = y) :
+    y₀ = 0 ∨ y₀ ^ 2 ∣ (shortCurve A B).Δ := by
+  rcases evalEval_ψ₂_eq_zero_or_sq_dvd_four_mul_Δ_rat hns htor hx hy with hκ | hdvd
+  · rw [evalEval_ψ₂_of_isCharNeTwoNF] at hκ
+    exact Or.inl (by omega)
+  · refine Or.inr ?_
+    rw [evalEval_ψ₂_of_isCharNeTwoNF] at hdvd
+    ring_nf at hdvd
+    exact (mul_dvd_mul_iff_right (by norm_num : (4 : ℤ) ≠ 0)).mp hdvd
+
+/-- **For a short model, a two-torsion point has `y = 0`.** Order two makes `ψ₂` vanish, and on a
+short model `ψ₂` is `2y`. This is exactly what collapses the long model's `4x, 8y` exception into
+the classical statement.
+
+Nothing here sees `ℤ` or `ℚ`: the argument needs the short-model identity and the ability to
+cancel `2` in the point's own field, so those are the hypotheses. The curve is taken up to
+equality with a short model rather than as one, which is what lets a caller holding a
+*base-changed* short curve apply it — `baseChange_shortCurve` is the equality, and `subst`
+transports the point and its order along with it. -/
+lemma y_eq_zero_of_order_two_short {F : Type*} [Field F] [DecidableEq F]
+    {W : WeierstrassCurve F} {a b : F} (hW : W = shortCurve a b) (h2F : (2 : F) ≠ 0)
+    {x y : F} (hns : W.toAffine.Nonsingular x y)
+    (h2 : addOrderOf (Affine.Point.some _ _ hns) = 2) : y = 0 := by
+  subst hW
+  have hψ : (shortCurve a b).ψ₂.evalEval x y = 0 :=
+    (addOrderOf_eq_two_iff_evalEval_ψ₂_eq_zero _ hns).mp h2
+  rw [evalEval_ψ₂_of_isCharNeTwoNF] at hψ
+  exact (mul_eq_zero.mp hψ).resolve_left h2F
+
+/-- **Nagell–Lutz, integrality half, short model.** On `y² = x³ + Ax + B` a nonzero torsion point
+has integral coordinates — with *no* order-two exception.
+
+The long-model theorem leaves order two aside with only `4x, 8y ∈ ℤ`. Here that case collapses:
+`ψ₂ = 2y`, so order two forces `y = 0`, and then `x` is a rational root of the monic
+`X³ + AX + B`, hence an integer. -/
+theorem isInteger_of_torsion_short {x y : ℚ}
+    (hns : ((shortCurve A B).baseChange ℚ).toAffine.Nonsingular x y)
+    (htor : IsOfFinAddOrder (Affine.Point.some _ _ hns)) :
+    IsLocalization.IsInteger ℤ x ∧ IsLocalization.IsInteger ℤ y := by
+  rcases isInteger_or_order_two_of_torsion_rat hns htor with h | ⟨h2, -, -⟩
+  · exact h
+  · have hy : y = 0 := y_eq_zero_of_order_two_short (baseChange_shortCurve A B) two_ne_zero hns h2
+    refine ⟨?_, hy ▸ ⟨0, by simp⟩⟩
+    -- With `y = 0` the curve equation exhibits `x` as a rational root of the monic `X³ + AX + B`,
+    -- and Mathlib's integral root theorem over the UFD `ℤ` finishes.
+    have hmonic : (X ^ 3 + C A * X + C B : ℤ[X]).Monic := by
+      simpa [add_assoc] using monic_X_pow_add (n := 3) (by compute_degree!)
+    have heq := hns.left
+    -- `baseChange_shortCurve` leaves the coefficients as `algebraMap ℤ ℚ`, where `aeval` reads
+    -- them as `Int.cast`, so normalise before transferring.
+    rw [baseChange_shortCurve, shortCurve_equation_iff] at heq
+    rw [hy] at heq
+    simp only [algebraMap_int_eq, eq_intCast] at heq
+    exact isInteger_of_is_root_of_monic hmonic
+      (by simpa using (by linarith : x ^ 3 + (A : ℚ) * x + (B : ℚ) = 0))
+
+/-- **The Nagell–Lutz theorem.** Let `A B : ℤ` and let `(x, y)` be a nonzero rational point of
+finite order on `y² = x³ + Ax + B`. Then `x` and `y` are integers, and either `y = 0` or
+`y² ∣ Δ`.
+
+This is the classical statement, and the form
+`TauCetiRoadmap/EllipticCurves/README.md:830` names `lutz_nagell`. No hypothesis `Δ ≠ 0` is
+needed — see the module docstring. -/
+theorem lutz_nagell {x y : ℚ}
+    (hns : ((shortCurve A B).baseChange ℚ).toAffine.Nonsingular x y)
+    (htor : IsOfFinAddOrder (Affine.Point.some _ _ hns)) :
+    ∃ x₀ y₀ : ℤ, (x₀ : ℚ) = x ∧ (y₀ : ℚ) = y ∧
+      (y₀ = 0 ∨ y₀ ^ 2 ∣ (shortCurve A B).Δ) := by
+  obtain ⟨⟨x₀, hx₀⟩, ⟨y₀, hy₀⟩⟩ := isInteger_of_torsion_short A B hns htor
+  exact ⟨x₀, y₀, by simpa using hx₀, by simpa using hy₀,
+    y_eq_zero_or_sq_dvd_Δ_of_torsion_short A B hns htor hx₀ hy₀⟩
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.NormalForms
+
+/-!
+# Weierstrass normal forms survive a base change
+
+Mathlib's `WeierstrassCurve.IsCharNeTwoNF` asserts `a₁ = a₃ = 0`, and its `NormalForms` file
+proves a great deal from that hypothesis. What it does not record is that the condition is
+preserved by `map` and `baseChange` — the coefficients of `W.map f` are the images of `W`'s, so a
+vanishing coefficient stays vanishing.
+
+That gap matters as soon as a statement is about a curve over `ℤ` and a point over `ℚ`, which is
+the shape of the classical Nagell–Lutz theorem: the hypothesis is natural on the integral model,
+while the point lives on the base change, and without these instances the class has to be
+re-established by hand at every such crossing.
+
+## Main results
+
+* `WeierstrassCurve.isCharNeTwoNF_map`: `a₁ = a₃ = 0` is preserved by a ring hom.
+* `WeierstrassCurve.isCharNeTwoNF_baseChange`: the same for a base change, which is the spelling
+  consumers hold. Both are instances, so the crossing is silent.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+variable {R S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve R)
+
+/-- **Characteristic-≠-2 normal form is preserved by a ring hom.** `(W.map f).a₁` is `f W.a₁`, and
+a hom sends `0` to `0`. Both steps are already `simp` lemmas — `map_a₁` and
+`a₁_of_isCharNeTwoNF` — so naming them is redundant and the linter says so. -/
+instance isCharNeTwoNF_map (f : R →+* S) [W.IsCharNeTwoNF] : (W.map f).IsCharNeTwoNF :=
+  ⟨by simp, by simp⟩
+
+/-- **Characteristic-≠-2 normal form is preserved by a base change.** This is
+`isCharNeTwoNF_map` at `algebraMap R S`, stated separately because `baseChange` is the spelling a
+caller holds and instance search does not unfold it. -/
+instance isCharNeTwoNF_baseChange [Algebra R S] [W.IsCharNeTwoNF] :
+    (W.baseChange S).IsCharNeTwoNF :=
+  W.isCharNeTwoNF_map (algebraMap R S)
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean
@@ -34,8 +34,10 @@ namespace WeierstrassCurve
 variable {R S : Type*} [CommRing R] [CommRing S] (W : WeierstrassCurve R)
 
 /-- **Characteristic-≠-2 normal form is preserved by a ring hom.** `(W.map f).a₁` is `f W.a₁`, and
-a hom sends `0` to `0`. Both steps are already `simp` lemmas — `map_a₁` and
-`a₁_of_isCharNeTwoNF` — so naming them is redundant and the linter says so. -/
+a hom sends `0` to `0`, so the vanishing survives.
+
+As an `instance`, this is what lets typeclass search carry `IsCharNeTwoNF` across `W.map f`: a
+caller who has the hypothesis on `W` and a statement about `W.map f` needs no bridging term. -/
 instance isCharNeTwoNF_map (f : R →+* S) [W.IsCharNeTwoNF] : (W.map f).IsCharNeTwoNF :=
   ⟨by simp, by simp⟩
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/ShortWeierstrass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/ShortWeierstrass.lean
@@ -38,7 +38,7 @@ reduce a projection of the opaque constructor. Every other fact about `shortCurv
   curve over `ℤ` be base changed to `ℚ` and stay recognisably short.
 * `WeierstrassCurve.baseChange_shortCurve`: the same for a base change, which is the spelling
   consumers actually hold. It follows definitionally from `map_shortCurve`, but `simp` does not
-  unfold the plain `def` `baseChange`, so that lemma never fires on this spelling by itself.
+  automatically unfold `baseChange`, so that lemma never fires on this spelling by itself.
 * `WeierstrassCurve.shortCurve_equation_iff`: a point lies on it exactly when
   `y² = x³ + Ax + B`.
 
@@ -114,10 +114,10 @@ the classical Nagell–Lutz statement — recognisably in short form. -/
 `baseChange` *is* `map (algebraMap R S)` by definition, which is why the proof below is just
 `map_shortCurve` at that hom.
 
-It is nonetheless worth stating and tagging `@[simp]`. Definitional equality is not what `simp`
-works up to: `WeierstrassCurve.baseChange` is a plain `def`, neither reducible nor a simp lemma, so
-`simp` will not rewrite a `baseChange` spelling into a `map` one and `map_shortCurve` never fires
-on it. This lemma is that missing normalisation step, not a wrapper to name by hand. -/
+It is nonetheless worth stating and tagging `@[simp]`: `simp` does not automatically unfold
+`baseChange`, which carries no simp lemma of its own, so `map_shortCurve` never fires on a
+`baseChange` spelling. This lemma is that missing normalisation step, not a wrapper to name by
+hand. -/
 @[simp] lemma baseChange_shortCurve [Algebra R S] :
     (shortCurve A B).baseChange S = shortCurve (algebraMap R S A) (algebraMap R S B) :=
   map_shortCurve A B _

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/ShortWeierstrass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/ShortWeierstrass.lean
@@ -36,6 +36,9 @@ reduce a projection of the opaque constructor. Every other fact about `shortCurv
 * `WeierstrassCurve.map_shortCurve`: short form is preserved by a ring hom, and the
   coefficients transport. Mathlib has no `IsShortNF`-under-`map` instance, so this is what lets a
   curve over `ℤ` be base changed to `ℚ` and stay recognisably short.
+* `WeierstrassCurve.baseChange_shortCurve`: the same for a base change, which is the spelling
+  consumers actually hold. It follows definitionally from `map_shortCurve`, but `simp` does not
+  unfold the plain `def` `baseChange`, so that lemma never fires on this spelling by itself.
 * `WeierstrassCurve.shortCurve_equation_iff`: a point lies on it exactly when
   `y² = x³ + Ax + B`.
 
@@ -106,6 +109,18 @@ no instance propagating `IsShortNF` along `map`, so this is what keeps a base ch
 the classical Nagell–Lutz statement — recognisably in short form. -/
 @[simp] lemma map_shortCurve (f : R →+* S) : (shortCurve A B).map f = shortCurve (f A) (f B) := by
   ext <;> simp [shortCurve, WeierstrassCurve.map]
+
+/-- The same statement for a base change, which is the spelling consumers actually meet.
+`baseChange` *is* `map (algebraMap R S)` by definition, which is why the proof below is just
+`map_shortCurve` at that hom.
+
+It is nonetheless worth stating and tagging `@[simp]`. Definitional equality is not what `simp`
+works up to: `WeierstrassCurve.baseChange` is a plain `def`, neither reducible nor a simp lemma, so
+`simp` will not rewrite a `baseChange` spelling into a `map` one and `map_shortCurve` never fires
+on it. This lemma is that missing normalisation step, not a wrapper to name by hand. -/
+@[simp] lemma baseChange_shortCurve [Algebra R S] :
+    (shortCurve A B).baseChange S = shortCurve (algebraMap R S A) (algebraMap R S B) :=
+  map_shortCurve A B _
 
 /-- A point lies on `y² = x³ + Ax + B` exactly when it satisfies that equation. -/
 @[simp] lemma shortCurve_equation_iff (x y : R) :


### PR DESCRIPTION
The Nagell–Lutz theorem for a short Weierstrass model. For `A B : ℤ`, a nonzero rational point of
finite order on `y² = x³ + Ax + B` has **integral** coordinates, and its `y`-coordinate satisfies
`y = 0` or `y² ∣ Δ`.

```lean
theorem lutz_nagell {x y : ℚ}
    (hns : ((shortCurve A B).baseChange ℚ).toAffine.Nonsingular x y)
    (htor : IsOfFinAddOrder (Affine.Point.some _ _ hns)) :
    ∃ x₀ y₀ : ℤ, (x₀ : ℚ) = x ∧ (y₀ : ℚ) = y ∧
      (y₀ = 0 ∨ y₀ ^ 2 ∣ (shortCurve A B).Δ)
```

`#print axioms WeierstrassCurve.lutz_nagell` → `[propext, Classical.choice, Quot.sound]`.

## Why the order-two exception disappears

The long-model theorem (`isInteger_or_order_two_of_torsion`) cannot claim full integrality: a
two-torsion point need only satisfy `4x, 8y ∈ ℤ`. On a short model that case **collapses**, and
for a computable reason rather than by adding a hypothesis:

`a₁ = a₃ = 0`, so `ψ₂ = 2y`. A point of order two makes `ψ₂` vanish, hence `y = 0`; the curve
equation then exhibits `x` as a rational root of the **monic** `X³ + AX + B`, so `x ∈ ℤ` as well.
The same substitution turns the discriminant companion's `ψ₂ = 0 ∨ ψ₂² ∣ 4Δ` into
`2y₀ = 0 ∨ 4y₀² ∣ 4Δ`, and the `4` cancels on both sides.

That single identity, `evalEval_ψ₂_shortCurve`, is the whole difference between the two registers,
and it is stated over an arbitrary commutative ring because the point lives over `ℚ` while the
conclusion is over `ℤ`.

## `Δ ≠ 0` is not needed, and this is measured

All three source theorems take `hΔ : (shortCurveZ A B).Δ ≠ 0`. **None of them uses it.** `hΔ`
occurs in the three signatures and exactly twice in the bodies — both times in `lutz_nagell`
forwarding it to the two theorems whose proofs never mention it. It is a pass-through of a
hypothesis nothing consumes, which this repository's `unusedArguments` linter would reject.

Mathematically that is the right reading: integrality and the divisibility bound need the *point*
to be nonsingular; `Δ ≠ 0` is the ellipticity condition and does no work here. So this port states
all of it without `hΔ`.

Roadmap: EllipticCurves

New mathematics. `TauCetiRoadmap/EllipticCurves/README.md:821` — "**The torsion subgroup and
Nagell–Lutz**". Lines `:828`–`:830` name this target exactly: for an integral **short** model
`y² = x³ + Ax + B`, "the classical full form — `x, y ∈ ℤ` and `y = 0` or `y² ∣ Δ`
(`lutz_nagell`; AEC VIII.7)". With this, every item the roadmap lists for Layer 6 Nagell–Lutz
(`:1163`–`:1172`) is covered.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"nagell-lutz-short-model"}-->

## Provenance

From AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), `projects/NagellLutz/LutzNagell/`:

* **`LutzNagellTheorem/Main.lean`** — `lutz_nagell_integrality` (`:40`),
  `lutz_nagell_discriminant` (`:53`), `lutz_nagell` (`:71`). This file carries its own header,
  **`Authors: Chris Birkbeck`**, and is credited accordingly rather than to the project's usual
  pair.
* **`LutzNagellTheorem/GeneralMain.lean`** — `lutz_nagell_integrality_short` (`:155`), where the
  order-two collapse is carried out. That file has no author header; it is credited to the project
  as the sibling ports in this chain are.

**A pin caveat, stated because it does not match the sibling PRs.** `GeneralMain.lean` is
byte-identical at `9fec8eba7652`, the revision the roadmap pins for this project (`README:1072`),
verified by blob hash. **`Main.lean` is not** — it differs between the two revisions. The
difference is *only* the five-line copyright header added at `1c1c7466`; all three cited theorems
are unchanged, verified by diff. So the citations hold at either pin, but "byte-identical" would
have been false and is not claimed.

Two adaptations beyond dropping `hΔ`. The monic-root step goes through
`IsIntegrallyClosed.isIntegral_iff` directly, matching `Integrality.lean`'s existing idiom, where
the source routes via its own `isInteger_of_is_root_of_monic`. And `ψ₂ = 2y` is stated over an
arbitrary commutative ring rather than fixed at `ℤ`, since both `ℤ` and `ℚ` instances are needed.
