### PR TITLE
feat: bridge Lie isotypy to the enveloping algebra

### DIFF
--- a/TauCeti/Algebra/Lie/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/Isotypic.lean
@@ -43,6 +43,8 @@ def IsIsotypicOfType (S : Type*) [AddCommGroup S] [Module R S]
     [LieRingModule L S] : Prop :=
   ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], Nonempty (P ≃ₗ⁅R,L⁆ S)
 
+-- This private reduction is required by Lean's module system: an exported theorem cannot unfold
+-- the opaque exported definition directly while checking its public signature.
 private theorem isIsotypicOfType_iff_def
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] :
     IsIsotypicOfType R L M S ↔
@@ -61,6 +63,8 @@ theorem isIsotypicOfType_iff (S : Type*) [AddCommGroup S] [Module R S]
 def IsIsotypic : Prop :=
   ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], IsIsotypicOfType R L M P
 
+-- See `isIsotypicOfType_iff_def`: the private reduction keeps this exported characteristic
+-- theorem compatible with the module system.
 private theorem isIsotypic_iff_def :
     IsIsotypic R L M ↔
       ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], IsIsotypicOfType R L M P :=
@@ -89,6 +93,8 @@ noncomputable def isotypicComponent (S : Type*) [AddCommGroup S] [Module R S]
     [LieRingModule L S] : LieSubmodule R L M :=
   sSup {P | Nonempty (P ≃ₗ⁅R,L⁆ S)}
 
+-- See `isIsotypicOfType_iff_def`: the private reduction exposes the defining equation without
+-- asking an exported theorem to unfold an opaque exported definition.
 private theorem isotypicComponent_eq_sSup_def
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] :
     isotypicComponent R L M S =
@@ -102,6 +108,16 @@ theorem isotypicComponent_def (S : Type*) [AddCommGroup S] [Module R S]
       sSup {P : LieSubmodule R L M | Nonempty (P ≃ₗ⁅R,L⁆ S)} :=
   isotypicComponent_eq_sSup_def R L M S
 
+/-- The Lie isotypic component is below `N` exactly when every submodule equivalent to its type is
+below `N`. -/
+@[simp]
+theorem isotypicComponent_le_iff (S : Type*) [AddCommGroup S] [Module R S]
+    [LieRingModule L S] (N : LieSubmodule R L M) :
+    isotypicComponent R L M S ≤ N ↔
+      ∀ P : LieSubmodule R L M, Nonempty (P ≃ₗ⁅R,L⁆ S) → P ≤ N := by
+  rw [isotypicComponent_def, sSup_le_iff]
+  rfl
+
 end LieModule
 
 namespace LieSubmodule
@@ -110,10 +126,17 @@ variable (R : Type u) (L : Type v) (M : Type w)
 variable [CommRing R] [LieRing L]
 variable [AddCommGroup M] [Module R M] [LieRingModule L M]
 
+/-- A Lie submodule equivalent to `S` is contained in the Lie isotypic component of type `S`. -/
+theorem le_isotypicComponent_of_equiv (P : LieSubmodule R L M)
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S]
+    (h : Nonempty (P ≃ₗ⁅R,L⁆ S)) :
+    P ≤ LieModule.isotypicComponent R L M S := by
+  rw [LieModule.isotypicComponent_def]
+  exact le_sSup h
+
 /-- A Lie submodule is contained in its Lie isotypic component. -/
 theorem le_isotypicComponent (P : LieSubmodule R L M) :
     P ≤ LieModule.isotypicComponent R L M P := by
-  rw [LieModule.isotypicComponent_def]
-  exact le_sSup ⟨LieModuleEquiv.refl⟩
+  exact le_isotypicComponent_of_equiv R L M P P ⟨LieModuleEquiv.refl⟩
 
 end LieSubmodule

--- a/TauCeti/Algebra/Lie/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/Isotypic.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Semisimple.Defs
+
+/-!
+# Isotypic Lie modules
+
+This file defines isotypy for Lie modules over a commutative ring. It is the Lie-module analogue
+of Mathlib's module-theoretic `IsIsotypicOfType`, `IsIsotypic`, and `isotypicComponent` interface.
+The definitions here do not depend on a universal enveloping algebra; the comparison with
+Mathlib's module-theoretic interface lives in
+`TauCeti.Algebra.Lie.UniversalEnveloping.Isotypic`.
+
+## Main definitions
+
+* `LieModule.IsIsotypicOfType` and `LieModule.IsIsotypic`: Lie-module isotypy.
+* `LieModule.isotypicComponent`: the sum of Lie submodules equivalent to a fixed type.
+
+## Roadmap
+
+This is the generic Lie-isotypy interface used by Layer 6 of the Lie highest-weight roadmap and
+its universal-enveloping-algebra dictionary.
+-/
+
+public section
+
+universe u v w
+
+namespace LieModule
+
+variable (R : Type u) (L : Type v) (M : Type w)
+variable [CommRing R] [LieRing L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M]
+
+/-- A Lie module `M` is isotypic of type `S` if every irreducible Lie submodule of `M` is
+equivalent to `S`. -/
+def IsIsotypicOfType (S : Type*) [AddCommGroup S] [Module R S]
+    [LieRingModule L S] : Prop :=
+  ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], Nonempty (P ≃ₗ⁅R,L⁆ S)
+
+private theorem isIsotypicOfType_iff_def
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] :
+    IsIsotypicOfType R L M S ↔
+      ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], Nonempty (P ≃ₗ⁅R,L⁆ S) :=
+  Iff.rfl
+
+/-- Lie isotypy of a fixed type means that every irreducible Lie submodule is equivalent to that
+type. -/
+theorem isIsotypicOfType_iff (S : Type*) [AddCommGroup S] [Module R S]
+    [LieRingModule L S] :
+    IsIsotypicOfType R L M S ↔
+      ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], Nonempty (P ≃ₗ⁅R,L⁆ S) :=
+  isIsotypicOfType_iff_def R L M S
+
+/-- A Lie module is isotypic if all its irreducible Lie submodules are equivalent. -/
+def IsIsotypic : Prop :=
+  ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], IsIsotypicOfType R L M P
+
+private theorem isIsotypic_iff_def :
+    IsIsotypic R L M ↔
+      ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], IsIsotypicOfType R L M P :=
+  Iff.rfl
+
+/-- A Lie module is isotypic exactly when it is isotypic of the type of each irreducible Lie
+submodule. -/
+theorem isIsotypic_iff :
+    IsIsotypic R L M ↔
+      ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], IsIsotypicOfType R L M P :=
+  isIsotypic_iff_def R L M
+
+variable {R L M}
+
+/-- A fixed isotypic type makes every pair of irreducible Lie submodules equivalent. -/
+theorem IsIsotypicOfType.isIsotypic {S : Type*} [AddCommGroup S] [Module R S]
+    [LieRingModule L S] (h : IsIsotypicOfType R L M S) :
+    IsIsotypic R L M :=
+  fun P _ Q _ => ⟨(h Q).some.trans (h P).some.symm⟩
+
+variable (R L M)
+
+/-- The Lie isotypic component of type `S`, defined as the sum of all Lie submodules equivalent
+to `S`. -/
+noncomputable def isotypicComponent (S : Type*) [AddCommGroup S] [Module R S]
+    [LieRingModule L S] : LieSubmodule R L M :=
+  sSup {P | Nonempty (P ≃ₗ⁅R,L⁆ S)}
+
+private theorem isotypicComponent_eq_sSup_def
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] :
+    isotypicComponent R L M S =
+      sSup {P : LieSubmodule R L M | Nonempty (P ≃ₗ⁅R,L⁆ S)} :=
+  rfl
+
+/-- The Lie isotypic component is the sum of all Lie submodules equivalent to its type. -/
+theorem isotypicComponent_def (S : Type*) [AddCommGroup S] [Module R S]
+    [LieRingModule L S] :
+    isotypicComponent R L M S =
+      sSup {P : LieSubmodule R L M | Nonempty (P ≃ₗ⁅R,L⁆ S)} :=
+  isotypicComponent_eq_sSup_def R L M S
+
+end LieModule
+
+namespace LieSubmodule
+
+variable (R : Type u) (L : Type v) (M : Type w)
+variable [CommRing R] [LieRing L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M]
+
+/-- A Lie submodule is contained in its Lie isotypic component. -/
+theorem le_isotypicComponent (P : LieSubmodule R L M) :
+    P ≤ LieModule.isotypicComponent R L M P := by
+  rw [LieModule.isotypicComponent_def]
+  exact le_sSup ⟨LieModuleEquiv.refl⟩
+
+end LieSubmodule

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -5,27 +5,27 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Lie.Semisimple.Defs
 public import Mathlib.RingTheory.SimpleModule.Isotypic
+public import TauCeti.Algebra.Lie.Isotypic
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Module
 
 /-!
 # Isotypic Lie modules through the universal enveloping algebra
 
 This file transports Mathlib's isotypic-module interface across the universal-enveloping-algebra
-dictionary. The core definitions require only a commutative base ring. Semisimplicity enters only
-in the characterization of an isotypic module by its unique component.
+dictionary. Semisimplicity enters only in the characterization of an isotypic module by its
+unique component.
 
 The generic equivalence and submodule interfaces live with the rest of the enveloping-algebra
-dictionary in `TauCeti.Algebra.Lie.UniversalEnveloping.Module`. The Lie-level predicates and
-component below are direct transports of `IsIsotypicOfType`, `IsIsotypic`, and
-`isotypicComponent` through those interfaces.
+dictionary in `TauCeti.Algebra.Lie.UniversalEnveloping.Module`. The UEA-independent Lie-level
+predicates and component live in `TauCeti.Algebra.Lie.Isotypic`; this file identifies them with
+Mathlib's `IsIsotypicOfType`, `IsIsotypic`, and `isotypicComponent` through those interfaces.
 
 ## Main definitions
 
-* `LieModule.IsIsotypicOfType` and `LieModule.IsIsotypic`: Lie-module isotypy.
-* `LieModule.isotypicComponent`: the Lie submodule underlying Mathlib's `U(L)`-isotypic
-  component.
+* `LieModule.isIsotypicOfType_iff_isIsotypicOfType_asModule`: fixed-type isotypy transport.
+* `LieModule.isIsotypic_iff_isIsotypic_asModule`: pairwise isotypy transport.
+* `LieModule.lieSubmoduleOrderIsoAsModule_isotypicComponent`: isotypic-component transport.
 
 ## Roadmap
 
@@ -53,30 +53,14 @@ local notation "U" => _root_.UniversalEnvelopingAlgebra R L
 
 attribute [local instance] asModule isScalarTower_asModule
 
-/-- A Lie module `M` is isotypic of type `S` if every irreducible Lie submodule of `M` is
-equivalent to `S`. -/
-def IsIsotypicOfType (S : Type*) [AddCommGroup S] [Module R S]
-    [LieRingModule L S] : Prop :=
-  ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], Nonempty (P ≃ₗ⁅R,L⁆ S)
-
-/-- A Lie module is isotypic if all its irreducible Lie submodules are equivalent. -/
-def IsIsotypic : Prop :=
-  ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], IsIsotypicOfType R L M P
-
 variable {R L M}
-
-omit [LieAlgebra R L] [LieModule R L M] in
-/-- A fixed isotypic type makes every pair of irreducible Lie submodules equivalent. -/
-theorem IsIsotypicOfType.isIsotypic {S : Type*} [AddCommGroup S] [Module R S]
-    [LieRingModule L S] (h : IsIsotypicOfType R L M S) :
-    IsIsotypic R L M :=
-  fun P _ Q _ => ⟨(h Q).some.trans (h P).some.symm⟩
 
 /-- Lie-module isotypy of a fixed type is exactly Mathlib's module isotypy for the canonical
 `U(L)`-actions. -/
 theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
     IsIsotypicOfType R L M S ↔ _root_.IsIsotypicOfType U M S := by
+  rw [isIsotypicOfType_iff]
   constructor
   · intro h Q hQ
     let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
@@ -86,7 +70,7 @@ theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
     let : IsIrreducible R L P :=
       (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
     exact (h P).map fun e => (lieSubmoduleLinearEquivAsModule R L M P).symm.trans
-      (lieModuleEquivEquiv (R := R) (L := L) (M := P) (N := S)
+      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
         (asModule_ι_smul R L P) (asModule_ι_smul R L S) e)
   · intro h P hP
     let Q := lieSubmoduleOrderIsoAsModule R L M P
@@ -95,14 +79,15 @@ theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
     let : IsSimpleModule U Q :=
       IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P).symm
     exact (h Q).map fun e =>
-      (lieModuleEquivEquiv (R := R) (L := L) (M := P) (N := S)
+      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
         (asModule_ι_smul R L P) (asModule_ι_smul R L S)).symm
         ((lieSubmoduleLinearEquivAsModule R L M P).trans e)
 
 /-- Lie-module isotypy is exactly Mathlib's module isotypy for the canonical `U(L)`-action. -/
 theorem isIsotypic_iff_isIsotypic_asModule :
     IsIsotypic R L M ↔ _root_.IsIsotypic U M := by
-  simp only [IsIsotypic, _root_.IsIsotypic]
+  rw [isIsotypic_iff]
+  simp only [_root_.IsIsotypic]
   constructor
   · intro h Q hQ
     let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
@@ -122,23 +107,30 @@ theorem isIsotypic_iff_isIsotypic_asModule :
     exact isIsotypicOfType_iff_isIsotypicOfType_asModule P |>.mpr
       ((h Q).of_linearEquiv_type (lieSubmoduleLinearEquivAsModule R L M P).symm)
 
-variable (R L M)
-
-/-- The Lie isotypic component of type `S`, obtained by transporting Mathlib's `U(L)`-isotypic
-component through the submodule dictionary. -/
-noncomputable def isotypicComponent (S : Type*) [AddCommGroup S] [Module R S]
-    [LieRingModule L S] [LieModule R L S] : LieSubmodule R L M :=
-  (lieSubmoduleOrderIsoAsModule R L M).symm (_root_.isotypicComponent U M S)
-
-variable {R L M}
-
 /-- The Lie isotypic component maps to Mathlib's `U(L)`-isotypic component. -/
 @[simp]
 theorem lieSubmoduleOrderIsoAsModule_isotypicComponent
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
     lieSubmoduleOrderIsoAsModule R L M (isotypicComponent R L M S) =
-      _root_.isotypicComponent U M S :=
-  (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply _
+      _root_.isotypicComponent U M S := by
+  rw [isotypicComponent_def, OrderIso.map_sSup, _root_.isotypicComponent]
+  apply le_antisymm
+  · refine iSup_le fun P => iSup_le fun hP => ?_
+    obtain ⟨e⟩ := hP
+    exact le_sSup ⟨(lieSubmoduleLinearEquivAsModule R L M P).symm.trans
+      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
+        (asModule_ι_smul R L P) (asModule_ι_smul R L S) e)⟩
+  · refine sSup_le fun Q hQ => ?_
+    obtain ⟨e⟩ := hQ
+    let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
+    have eq : lieSubmoduleOrderIsoAsModule R L M P = Q :=
+      (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply Q
+    rw [← eq] at e ⊢
+    have hP : Nonempty (P ≃ₗ⁅R,L⁆ S) :=
+      ⟨(lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
+        (asModule_ι_smul R L P) (asModule_ι_smul R L S)).symm
+        ((lieSubmoduleLinearEquivAsModule R L M P).trans e)⟩
+    exact le_iSup_of_le P (le_iSup_of_le hP le_rfl)
 
 /-- Membership in the Lie isotypic component is membership in the corresponding `U(L)`-isotypic
 component. -/
@@ -147,7 +139,8 @@ theorem mem_isotypicComponent_iff
     {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     {m : M} :
     m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S := by
-  rw [isotypicComponent, mem_lieSubmoduleOrderIsoAsModule_symm]
+  rw [← mem_lieSubmoduleOrderIsoAsModule,
+    lieSubmoduleOrderIsoAsModule_isotypicComponent]
 
 /-- In a completely reducible Lie module, the isotypic component of type `S` is the whole module
 exactly when the Lie module is isotypic of type `S`. -/

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Semisimple.Defs
+public import Mathlib.RingTheory.SimpleModule.Isotypic
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Module
+
+/-!
+# Isotypic Lie modules through the universal enveloping algebra
+
+This file transports Mathlib's isotypic-module interface across the universal-enveloping-algebra
+dictionary. The core definitions require only a commutative base ring. Semisimplicity enters only
+in the characterization of an isotypic module by its unique component.
+
+The transport has two small pieces. First, equivalences of Lie modules are exactly linear
+equivalences for compatible `U(L)`-actions. Second, a Lie submodule, with its canonical
+`U(L)`-action, is linearly equivalent by the identity map to the corresponding `U(L)`-submodule.
+The Lie-level predicates and component below are then direct transports of
+`IsIsotypicOfType`, `IsIsotypic`, and `isotypicComponent`.
+
+## Main definitions
+
+* `TauCeti.UniversalEnvelopingAlgebra.lieModuleEquivEquiv`: the equivalence dictionary for
+  compatible `U(L)`-actions.
+* `TauCeti.UniversalEnvelopingAlgebra.lieSubmoduleLinearEquivAsModule`: the identity equivalence
+  between a Lie submodule and its image under the canonical submodule dictionary.
+* `LieModule.IsIsotypicOfType` and `LieModule.IsIsotypic`: Lie-module isotypy.
+* `LieModule.isotypicComponent`: the Lie submodule underlying Mathlib's `U(L)`-isotypic
+  component.
+
+## Roadmap
+
+This is the universal-enveloping-algebra bridge for Layer 6 of the Lie highest-weight roadmap.
+It deliberately stops before highest-weight classification: consumers such as Kostant-form
+modules can state that all irreducible Lie submodules are equivalent without rebuilding ring-level
+isotypic machinery.
+-/
+
+public section
+
+open UniversalEnvelopingAlgebra
+
+universe u v w x
+
+namespace TauCeti.UniversalEnvelopingAlgebra
+
+variable (R : Type u) (L : Type v) (M : Type w) (N : Type x)
+variable [CommRing R] [LieRing L] [LieAlgebra R L]
+variable [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+local notation "U" => _root_.UniversalEnvelopingAlgebra R L
+
+section Equiv
+
+variable [LieRingModule L M] [LieModule R L M]
+variable [LieRingModule L N] [LieModule R L N]
+variable [Module (_root_.UniversalEnvelopingAlgebra R L) M]
+variable [IsScalarTower R (_root_.UniversalEnvelopingAlgebra R L) M]
+variable [Module (_root_.UniversalEnvelopingAlgebra R L) N]
+variable [IsScalarTower R (_root_.UniversalEnvelopingAlgebra R L) N]
+
+/-- **The enveloping-algebra dictionary for equivalences**: Lie module equivalences are exactly
+`U(L)`-linear equivalences when both actions are compatible with the canonical Lie generators.
+The correspondence is the identity on underlying functions. -/
+noncomputable def lieModuleEquivEquiv
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆) :
+    (M ≃ₗ⁅R,L⁆ N) ≃ (M ≃ₗ[U] N) where
+  toFun e :=
+    { lieModuleHomEquiv hM hN e.toLieModuleHom with
+      invFun := e.invFun
+      left_inv := fun m => by
+        change e.invFun ((lieModuleHomEquiv hM hN e.toLieModuleHom) m) = m
+        rw [show (lieModuleHomEquiv hM hN e.toLieModuleHom) m = e m by
+          exact congrFun (coe_lieModuleHomEquiv hM hN e.toLieModuleHom) m]
+        exact e.left_inv m
+      right_inv := fun n => by
+        change (lieModuleHomEquiv hM hN e.toLieModuleHom) (e.invFun n) = n
+        rw [show (lieModuleHomEquiv hM hN e.toLieModuleHom) (e.invFun n) = e (e.invFun n) by
+          exact congrFun (coe_lieModuleHomEquiv hM hN e.toLieModuleHom) (e.invFun n)]
+        exact e.right_inv n }
+  invFun e :=
+    { (lieModuleHomEquiv hM hN).symm e.toLinearMap with
+      invFun := e.invFun
+      left_inv := fun m => by
+        change e.invFun (((lieModuleHomEquiv hM hN).symm e.toLinearMap) m) = m
+        rw [show ((lieModuleHomEquiv hM hN).symm e.toLinearMap) m = e m by
+          exact congrFun (coe_lieModuleHomEquiv_symm hM hN e.toLinearMap) m]
+        exact e.left_inv m
+      right_inv := fun n => by
+        change ((lieModuleHomEquiv hM hN).symm e.toLinearMap) (e.invFun n) = n
+        rw [show ((lieModuleHomEquiv hM hN).symm e.toLinearMap) (e.invFun n) = e (e.invFun n) by
+          exact congrFun (coe_lieModuleHomEquiv_symm hM hN e.toLinearMap) (e.invFun n)]
+        exact e.right_inv n }
+  left_inv e := by
+    apply LieModuleEquiv.ext
+    intro m
+    change ((lieModuleHomEquiv hM hN).symm
+      (lieModuleHomEquiv hM hN e.toLieModuleHom)) m = e m
+    rw [(lieModuleHomEquiv hM hN).symm_apply_apply]
+    rfl
+  right_inv e := by
+    apply LinearEquiv.ext
+    intro m
+    change (lieModuleHomEquiv hM hN
+      ((lieModuleHomEquiv hM hN).symm e.toLinearMap)) m = e m
+    rw [(lieModuleHomEquiv hM hN).apply_symm_apply]
+    rfl
+
+omit [LieModule R L M] in
+/-- The forward equivalence dictionary does not change the underlying function. -/
+@[simp]
+theorem coe_lieModuleEquivEquiv
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
+    (e : M ≃ₗ⁅R,L⁆ N) :
+    ⇑(lieModuleEquivEquiv R L M N hM hN e) = ⇑e :=
+  coe_lieModuleHomEquiv hM hN e.toLieModuleHom
+
+omit [LieModule R L M] in
+/-- The inverse equivalence dictionary does not change the underlying function. -/
+@[simp]
+theorem coe_lieModuleEquivEquiv_symm
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
+    (e : M ≃ₗ[U] N) :
+    ⇑((lieModuleEquivEquiv R L M N hM hN).symm e) = ⇑e :=
+  coe_lieModuleHomEquiv_symm hM hN e.toLinearMap
+
+end Equiv
+
+section Submodule
+
+variable [LieRingModule L M] [LieModule R L M]
+
+attribute [local instance] asModule isScalarTower_asModule
+
+/-- The canonical `U(L)`-action on a Lie submodule agrees, after inclusion, with the canonical
+action on the ambient Lie module. -/
+theorem coe_asModule_smul_lieSubmodule (P : LieSubmodule R L M) (u : U) (p : P) :
+    ((u • p : P) : M) = u • (p : M) := by
+  revert p
+  induction u using induction_ι with
+  | ι x =>
+    intro p
+    rw [asModule_ι_smul R L P, asModule_ι_smul R L M]
+    rfl
+  | algebraMap r => intro p; simp only [algebraMap_smul, SetLike.val_smul]
+  | add u v hu hv =>
+    intro p
+    rw [add_smul, add_smul]
+    change ((u • p : P) : M) + ((v • p : P) : M) = u • (p : M) + v • (p : M)
+    rw [hu p, hv p]
+  | mul u v hu hv =>
+    intro p
+    rw [mul_smul, mul_smul, hu (v • p), hv p]
+
+/-- A Lie submodule with its canonical `U(L)`-action is linearly equivalent, by the identity map,
+to its image under `lieSubmoduleOrderIsoAsModule`. This is the subtype-level part of the
+submodule dictionary used when transporting isotypy. -/
+noncomputable def lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
+    P ≃ₗ[U] lieSubmoduleOrderIsoAsModule R L M P where
+  toFun p := ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩
+  invFun p := ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mp p.property⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+  map_smul' u p := by
+    ext
+    exact coe_asModule_smul_lieSubmodule R L M P u p
+
+@[simp]
+theorem coe_lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
+    ⇑(lieSubmoduleLinearEquivAsModule R L M P) =
+      fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩ :=
+  (rfl)
+
+@[simp]
+theorem coe_lieSubmoduleLinearEquivAsModule_symm (P : LieSubmodule R L M) :
+    ⇑(lieSubmoduleLinearEquivAsModule R L M P).symm =
+      fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mp p.property⟩ :=
+  (rfl)
+
+end Submodule
+
+end TauCeti.UniversalEnvelopingAlgebra
+
+namespace LieModule
+
+open TauCeti.UniversalEnvelopingAlgebra
+
+variable (R : Type u) (L : Type v) (M : Type w)
+variable [CommRing R] [LieRing L] [LieAlgebra R L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
+
+local notation "U" => _root_.UniversalEnvelopingAlgebra R L
+
+attribute [local instance] asModule isScalarTower_asModule
+
+/-- A Lie module `M` is isotypic of type `S` if every irreducible Lie submodule of `M` is
+equivalent to `S`. -/
+def IsIsotypicOfType (S : Type*) [AddCommGroup S] [Module R S]
+    [LieRingModule L S] [LieModule R L S] : Prop :=
+  ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], Nonempty (P ≃ₗ⁅R,L⁆ S)
+
+/-- A Lie module is isotypic if all its irreducible Lie submodules are equivalent. -/
+def IsIsotypic : Prop :=
+  ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], IsIsotypicOfType R L M P
+
+variable {R L M}
+
+/-- A fixed isotypic type makes every pair of irreducible Lie submodules equivalent. -/
+theorem IsIsotypicOfType.isIsotypic {S : Type*} [AddCommGroup S] [Module R S]
+    [LieRingModule L S] [LieModule R L S] (h : IsIsotypicOfType R L M S) :
+    IsIsotypic R L M :=
+  fun P _ Q _ => ⟨(h Q).some.trans (h P).some.symm⟩
+
+set_option linter.style.haveILetI false in
+/-- Lie-module isotypy of a fixed type is exactly Mathlib's module isotypy for the canonical
+`U(L)`-actions. -/
+theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
+    IsIsotypicOfType R L M S ↔ _root_.IsIsotypicOfType U M S := by
+  constructor
+  · intro h Q hQ
+    let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
+    rw [← (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply Q] at hQ ⊢
+    letI : IsSimpleModule U P :=
+      IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P)
+    letI : IsIrreducible R L P :=
+      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
+    exact (h P).map fun e => (lieSubmoduleLinearEquivAsModule R L M P).symm.trans
+      (lieModuleEquivEquiv R L P S (asModule_ι_smul R L P) (asModule_ι_smul R L S) e)
+  · intro h P hP
+    let Q := lieSubmoduleOrderIsoAsModule R L M P
+    letI : IsSimpleModule U P :=
+      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
+    letI : IsSimpleModule U Q :=
+      IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P).symm
+    exact (h Q).map fun e =>
+      (lieModuleEquivEquiv R L P S (asModule_ι_smul R L P) (asModule_ι_smul R L S)).symm
+        ((lieSubmoduleLinearEquivAsModule R L M P).trans e)
+
+set_option linter.style.haveILetI false in
+/-- Lie-module isotypy is exactly Mathlib's module isotypy for the canonical `U(L)`-action. -/
+theorem isIsotypic_iff_isIsotypic_asModule :
+    IsIsotypic R L M ↔ _root_.IsIsotypic U M := by
+  simp only [IsIsotypic, _root_.IsIsotypic]
+  constructor
+  · intro h Q hQ
+    let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
+    rw [← (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply Q] at hQ ⊢
+    letI : IsSimpleModule U P :=
+      IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P)
+    letI : IsIrreducible R L P :=
+      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
+    exact (isIsotypicOfType_iff_isIsotypicOfType_asModule P |>.mp (h P)).of_linearEquiv_type
+      (lieSubmoduleLinearEquivAsModule R L M P)
+  · intro h P hP
+    let Q := lieSubmoduleOrderIsoAsModule R L M P
+    letI : IsSimpleModule U P :=
+      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
+    letI : IsSimpleModule U Q :=
+      IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P).symm
+    exact isIsotypicOfType_iff_isIsotypicOfType_asModule P |>.mpr
+      ((h Q).of_linearEquiv_type (lieSubmoduleLinearEquivAsModule R L M P).symm)
+
+variable (R L M)
+
+/-- The Lie isotypic component of type `S`, obtained by transporting Mathlib's `U(L)`-isotypic
+component through the submodule dictionary. -/
+noncomputable def isotypicComponent (S : Type*) [AddCommGroup S] [Module R S]
+    [LieRingModule L S] [LieModule R L S] : LieSubmodule R L M :=
+  (lieSubmoduleOrderIsoAsModule R L M).symm (_root_.isotypicComponent U M S)
+
+variable {R L M}
+
+/-- The Lie isotypic component maps to Mathlib's `U(L)`-isotypic component. -/
+@[simp]
+theorem lieSubmoduleOrderIsoAsModule_isotypicComponent
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
+    lieSubmoduleOrderIsoAsModule R L M (isotypicComponent R L M S) =
+      _root_.isotypicComponent U M S :=
+  (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply _
+
+/-- Membership in the Lie isotypic component is membership in the corresponding `U(L)`-isotypic
+component. -/
+@[simp]
+theorem mem_isotypicComponent_iff
+    {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
+    {m : M} :
+    m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S := by
+  rw [isotypicComponent, mem_lieSubmoduleOrderIsoAsModule_symm]
+
+set_option linter.style.haveILetI false in
+/-- In a completely reducible Lie module, the isotypic component of type `S` is the whole module
+exactly when the Lie module is isotypic of type `S`. -/
+theorem isotypicComponent_eq_top_iff
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
+    [IsIrreducible R L S]
+    [ComplementedLattice (LieSubmodule R L M)] :
+    isotypicComponent R L M S = ⊤ ↔ IsIsotypicOfType R L M S := by
+  letI : IsSimpleModule U S :=
+    (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L S)).mp inferInstance
+  letI : IsSemisimpleModule U M :=
+    (complementedLattice_lieSubmodule_iff_isSemisimpleModule
+      (asModule_ι_smul R L M)).mp inferInstance
+  rw [isIsotypicOfType_iff_isIsotypicOfType_asModule]
+  constructor
+  · intro h
+    apply _root_.isotypicComponent_eq_top_iff.mp
+    rw [← lieSubmoduleOrderIsoAsModule_isotypicComponent S]
+    simpa using congrArg (lieSubmoduleOrderIsoAsModule R L M) h
+  · intro h
+    apply (lieSubmoduleOrderIsoAsModule R L M).injective
+    rw [lieSubmoduleOrderIsoAsModule_isotypicComponent S]
+    simpa using _root_.isotypicComponent_eq_top_iff.mpr h
+
+end LieModule

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -72,7 +72,6 @@ theorem IsIsotypicOfType.isIsotypic {S : Type*} [AddCommGroup S] [Module R S]
     IsIsotypic R L M :=
   fun P _ Q _ => ⟨(h Q).some.trans (h P).some.symm⟩
 
-set_option linter.style.haveILetI false in
 /-- Lie-module isotypy of a fixed type is exactly Mathlib's module isotypy for the canonical
 `U(L)`-actions. -/
 theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
@@ -82,25 +81,24 @@ theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
   · intro h Q hQ
     let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
     rw [← (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply Q] at hQ ⊢
-    letI : IsSimpleModule U P :=
+    let : IsSimpleModule U P :=
       IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P)
-    letI : IsIrreducible R L P :=
+    let : IsIrreducible R L P :=
       (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
     exact (h P).map fun e => (lieSubmoduleLinearEquivAsModule R L M P).symm.trans
       (lieModuleEquivEquiv (R := R) (L := L) (M := P) (N := S)
         (asModule_ι_smul R L P) (asModule_ι_smul R L S) e)
   · intro h P hP
     let Q := lieSubmoduleOrderIsoAsModule R L M P
-    letI : IsSimpleModule U P :=
+    let : IsSimpleModule U P :=
       (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
-    letI : IsSimpleModule U Q :=
+    let : IsSimpleModule U Q :=
       IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P).symm
     exact (h Q).map fun e =>
       (lieModuleEquivEquiv (R := R) (L := L) (M := P) (N := S)
         (asModule_ι_smul R L P) (asModule_ι_smul R L S)).symm
         ((lieSubmoduleLinearEquivAsModule R L M P).trans e)
 
-set_option linter.style.haveILetI false in
 /-- Lie-module isotypy is exactly Mathlib's module isotypy for the canonical `U(L)`-action. -/
 theorem isIsotypic_iff_isIsotypic_asModule :
     IsIsotypic R L M ↔ _root_.IsIsotypic U M := by
@@ -109,17 +107,17 @@ theorem isIsotypic_iff_isIsotypic_asModule :
   · intro h Q hQ
     let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
     rw [← (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply Q] at hQ ⊢
-    letI : IsSimpleModule U P :=
+    let : IsSimpleModule U P :=
       IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P)
-    letI : IsIrreducible R L P :=
+    let : IsIrreducible R L P :=
       (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
     exact (isIsotypicOfType_iff_isIsotypicOfType_asModule P |>.mp (h P)).of_linearEquiv_type
       (lieSubmoduleLinearEquivAsModule R L M P)
   · intro h P hP
     let Q := lieSubmoduleOrderIsoAsModule R L M P
-    letI : IsSimpleModule U P :=
+    let : IsSimpleModule U P :=
       (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
-    letI : IsSimpleModule U Q :=
+    let : IsSimpleModule U Q :=
       IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P).symm
     exact isIsotypicOfType_iff_isIsotypicOfType_asModule P |>.mpr
       ((h Q).of_linearEquiv_type (lieSubmoduleLinearEquivAsModule R L M P).symm)
@@ -151,7 +149,6 @@ theorem mem_isotypicComponent_iff
     m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S := by
   rw [isotypicComponent, mem_lieSubmoduleOrderIsoAsModule_symm]
 
-set_option linter.style.haveILetI false in
 /-- In a completely reducible Lie module, the isotypic component of type `S` is the whole module
 exactly when the Lie module is isotypic of type `S`. -/
 theorem isotypicComponent_eq_top_iff
@@ -159,9 +156,9 @@ theorem isotypicComponent_eq_top_iff
     [IsIrreducible R L S]
     [ComplementedLattice (LieSubmodule R L M)] :
     isotypicComponent R L M S = ⊤ ↔ IsIsotypicOfType R L M S := by
-  letI : IsSimpleModule U S :=
+  let : IsSimpleModule U S :=
     (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L S)).mp inferInstance
-  letI : IsSemisimpleModule U M :=
+  let : IsSemisimpleModule U M :=
     (complementedLattice_lieSubmodule_iff_isSemisimpleModule
       (asModule_ι_smul R L M)).mp inferInstance
   rw [← map_eq_top_iff (lieSubmoduleOrderIsoAsModule R L M),

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -75,26 +75,22 @@ noncomputable def lieModuleEquivEquiv
       invFun := e.invFun
       left_inv := fun m => by
         change e.invFun ((lieModuleHomEquiv hM hN e.toLieModuleHom) m) = m
-        rw [show (lieModuleHomEquiv hM hN e.toLieModuleHom) m = e m by
-          exact congrFun (coe_lieModuleHomEquiv hM hN e.toLieModuleHom) m]
+        rw [coe_lieModuleHomEquiv]
         exact e.left_inv m
       right_inv := fun n => by
         change (lieModuleHomEquiv hM hN e.toLieModuleHom) (e.invFun n) = n
-        rw [show (lieModuleHomEquiv hM hN e.toLieModuleHom) (e.invFun n) = e (e.invFun n) by
-          exact congrFun (coe_lieModuleHomEquiv hM hN e.toLieModuleHom) (e.invFun n)]
+        rw [coe_lieModuleHomEquiv]
         exact e.right_inv n }
   invFun e :=
     { (lieModuleHomEquiv hM hN).symm e.toLinearMap with
       invFun := e.invFun
       left_inv := fun m => by
         change e.invFun (((lieModuleHomEquiv hM hN).symm e.toLinearMap) m) = m
-        rw [show ((lieModuleHomEquiv hM hN).symm e.toLinearMap) m = e m by
-          exact congrFun (coe_lieModuleHomEquiv_symm hM hN e.toLinearMap) m]
+        rw [coe_lieModuleHomEquiv_symm]
         exact e.left_inv m
       right_inv := fun n => by
         change ((lieModuleHomEquiv hM hN).symm e.toLinearMap) (e.invFun n) = n
-        rw [show ((lieModuleHomEquiv hM hN).symm e.toLinearMap) (e.invFun n) = e (e.invFun n) by
-          exact congrFun (coe_lieModuleHomEquiv_symm hM hN e.toLinearMap) (e.invFun n)]
+        rw [coe_lieModuleHomEquiv_symm]
         exact e.right_inv n }
   left_inv e := by
     apply LieModuleEquiv.ext
@@ -204,7 +200,7 @@ attribute [local instance] asModule isScalarTower_asModule
 /-- A Lie module `M` is isotypic of type `S` if every irreducible Lie submodule of `M` is
 equivalent to `S`. -/
 def IsIsotypicOfType (S : Type*) [AddCommGroup S] [Module R S]
-    [LieRingModule L S] [LieModule R L S] : Prop :=
+    [LieRingModule L S] : Prop :=
   ∀ (P : LieSubmodule R L M) [IsIrreducible R L P], Nonempty (P ≃ₗ⁅R,L⁆ S)
 
 /-- A Lie module is isotypic if all its irreducible Lie submodules are equivalent. -/
@@ -213,9 +209,10 @@ def IsIsotypic : Prop :=
 
 variable {R L M}
 
+omit [LieAlgebra R L] [LieModule R L M] in
 /-- A fixed isotypic type makes every pair of irreducible Lie submodules equivalent. -/
 theorem IsIsotypicOfType.isIsotypic {S : Type*} [AddCommGroup S] [Module R S]
-    [LieRingModule L S] [LieModule R L S] (h : IsIsotypicOfType R L M S) :
+    [LieRingModule L S] (h : IsIsotypicOfType R L M S) :
     IsIsotypic R L M :=
   fun P _ Q _ => ⟨(h Q).some.trans (h P).some.symm⟩
 
@@ -309,15 +306,9 @@ theorem isotypicComponent_eq_top_iff
   letI : IsSemisimpleModule U M :=
     (complementedLattice_lieSubmodule_iff_isSemisimpleModule
       (asModule_ι_smul R L M)).mp inferInstance
-  rw [isIsotypicOfType_iff_isIsotypicOfType_asModule]
-  constructor
-  · intro h
-    apply _root_.isotypicComponent_eq_top_iff.mp
-    rw [← lieSubmoduleOrderIsoAsModule_isotypicComponent S]
-    simpa using congrArg (lieSubmoduleOrderIsoAsModule R L M) h
-  · intro h
-    apply (lieSubmoduleOrderIsoAsModule R L M).injective
-    rw [lieSubmoduleOrderIsoAsModule_isotypicComponent S]
-    simpa using _root_.isotypicComponent_eq_top_iff.mpr h
+  rw [← map_eq_top_iff (lieSubmoduleOrderIsoAsModule R L M),
+    lieSubmoduleOrderIsoAsModule_isotypicComponent,
+    _root_.isotypicComponent_eq_top_iff,
+    isIsotypicOfType_iff_isIsotypicOfType_asModule]
 
 end LieModule

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -51,6 +51,146 @@ variable [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M]
 
 local notation "U" => _root_.UniversalEnvelopingAlgebra R L
 
+section Compatible
+
+variable [Module (_root_.UniversalEnvelopingAlgebra R L) M]
+variable [IsScalarTower R (_root_.UniversalEnvelopingAlgebra R L) M]
+variable {R L M}
+
+/-- Lie-module isotypy of a fixed type is exactly Mathlib's module isotypy for compatible
+`U(L)`-actions. -/
+theorem isIsotypicOfType_iff_isIsotypicOfType_uea
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
+    [Module U S] [IsScalarTower R U S]
+    (hS : ∀ (x : L) (s : S), ι R x • s = ⁅x, s⁆) :
+    IsIsotypicOfType R L M S ↔ _root_.IsIsotypicOfType U M S := by
+  rw [isIsotypicOfType_iff]
+  constructor
+  · intro h Q hQ
+    let P := (lieSubmoduleOrderIso hM).symm Q
+    let : Module U P := asModule R L P
+    let : IsScalarTower R U P := isScalarTower_asModule R L P
+    rw [← (lieSubmoduleOrderIso hM).apply_symm_apply Q] at hQ ⊢
+    let : IsSimpleModule U P :=
+      IsSimpleModule.congr (lieSubmoduleLinearEquiv hM P)
+    let : IsIrreducible R L P :=
+      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
+    exact (h P).map fun e => (lieSubmoduleLinearEquiv hM P).symm.trans
+      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
+        (asModule_ι_smul R L P) hS e)
+  · intro h P hP
+    let : Module U P := asModule R L P
+    let : IsScalarTower R U P := isScalarTower_asModule R L P
+    let Q := lieSubmoduleOrderIso hM P
+    let : IsSimpleModule U P :=
+      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
+    let : IsSimpleModule U Q :=
+      IsSimpleModule.congr (lieSubmoduleLinearEquiv hM P).symm
+    exact (h Q).map fun e =>
+      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
+        (asModule_ι_smul R L P) hS).symm
+        ((lieSubmoduleLinearEquiv hM P).trans e)
+
+/-- Lie-module isotypy is exactly Mathlib's module isotypy for a compatible `U(L)`-action. -/
+theorem isIsotypic_iff_isIsotypic_uea
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆) :
+    IsIsotypic R L M ↔ _root_.IsIsotypic U M := by
+  rw [isIsotypic_iff]
+  simp only [_root_.IsIsotypic]
+  constructor
+  · intro h Q hQ
+    let P := (lieSubmoduleOrderIso hM).symm Q
+    let : Module U P := asModule R L P
+    let : IsScalarTower R U P := isScalarTower_asModule R L P
+    rw [← (lieSubmoduleOrderIso hM).apply_symm_apply Q] at hQ ⊢
+    let : IsSimpleModule U P :=
+      IsSimpleModule.congr (lieSubmoduleLinearEquiv hM P)
+    let : IsIrreducible R L P :=
+      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
+    exact (isIsotypicOfType_iff_isIsotypicOfType_uea hM P
+      (asModule_ι_smul R L P) |>.mp (h P)).of_linearEquiv_type
+      (lieSubmoduleLinearEquiv hM P)
+  · intro h P hP
+    let : Module U P := asModule R L P
+    let : IsScalarTower R U P := isScalarTower_asModule R L P
+    let Q := lieSubmoduleOrderIso hM P
+    let : IsSimpleModule U P :=
+      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
+    let : IsSimpleModule U Q :=
+      IsSimpleModule.congr (lieSubmoduleLinearEquiv hM P).symm
+    exact isIsotypicOfType_iff_isIsotypicOfType_uea hM P
+      (asModule_ι_smul R L P) |>.mpr
+      ((h Q).of_linearEquiv_type (lieSubmoduleLinearEquiv hM P).symm)
+
+/-- A compatible submodule dictionary maps the Lie isotypic component to Mathlib's
+`U(L)`-isotypic component. -/
+theorem lieSubmoduleOrderIso_isotypicComponent
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
+    [Module U S] [IsScalarTower R U S]
+    (hS : ∀ (x : L) (s : S), ι R x • s = ⁅x, s⁆) :
+    lieSubmoduleOrderIso hM (isotypicComponent R L M S) =
+      _root_.isotypicComponent U M S := by
+  rw [isotypicComponent_def,
+    (lieSubmoduleOrderIso hM).map_sSup_eq_sSup_symm_preimage,
+    _root_.isotypicComponent]
+  congr 1
+  ext Q
+  -- Membership in the inverse-image family expands to the two equivalence types compared below.
+  change Nonempty (((lieSubmoduleOrderIso hM).symm Q) ≃ₗ⁅R,L⁆ S) ↔
+    Nonempty (Q ≃ₗ[U] S)
+  let P := (lieSubmoduleOrderIso hM).symm Q
+  let : Module U P := asModule R L P
+  let : IsScalarTower R U P := isScalarTower_asModule R L P
+  constructor
+  · rintro ⟨e⟩
+    have e' := (lieSubmoduleLinearEquiv hM P).symm.trans
+      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
+        (asModule_ι_smul R L P) hS e)
+    exact ⟨(lieSubmoduleOrderIso hM).apply_symm_apply Q ▸ e'⟩
+  · rintro ⟨e⟩
+    have e' : P ≃ₗ[U] S :=
+      (lieSubmoduleLinearEquiv hM P).trans
+        ((lieSubmoduleOrderIso hM).apply_symm_apply Q ▸ e)
+    exact ⟨(lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
+      (asModule_ι_smul R L P) hS).symm e'⟩
+
+/-- Membership in the Lie isotypic component is membership in the corresponding isotypic component
+for compatible `U(L)`-actions. -/
+theorem mem_isotypicComponent_iff_uea
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
+    [Module U S] [IsScalarTower R U S]
+    (hS : ∀ (x : L) (s : S), ι R x • s = ⁅x, s⁆)
+    {m : M} :
+    m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S := by
+  rw [← mem_lieSubmoduleOrderIso hM,
+    lieSubmoduleOrderIso_isotypicComponent hM S hS]
+
+/-- For compatible `U(L)`-actions on a completely reducible Lie module, the isotypic component of
+type `S` is the whole module exactly when the Lie module is isotypic of type `S`. -/
+theorem isotypicComponent_eq_top_iff_uea
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
+    [Module U S] [IsScalarTower R U S]
+    (hS : ∀ (x : L) (s : S), ι R x • s = ⁅x, s⁆)
+    [IsIrreducible R L S]
+    [ComplementedLattice (LieSubmodule R L M)] :
+    isotypicComponent R L M S = ⊤ ↔ IsIsotypicOfType R L M S := by
+  let : IsSimpleModule U S :=
+    (isIrreducible_iff_isSimpleModule hS).mp inferInstance
+  let : IsSemisimpleModule U M :=
+    (complementedLattice_lieSubmodule_iff_isSemisimpleModule hM).mp inferInstance
+  rw [← map_eq_top_iff (lieSubmoduleOrderIso hM),
+    lieSubmoduleOrderIso_isotypicComponent hM S hS,
+    _root_.isotypicComponent_eq_top_iff,
+    isIsotypicOfType_iff_isIsotypicOfType_uea hM S hS]
+
+end Compatible
+
+section Canonical
+
 attribute [local instance] asModule isScalarTower_asModule
 
 variable {R L M}
@@ -59,88 +199,35 @@ variable {R L M}
 `U(L)`-actions. -/
 theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
-    IsIsotypicOfType R L M S ↔ _root_.IsIsotypicOfType U M S := by
-  rw [isIsotypicOfType_iff]
-  constructor
-  · intro h Q hQ
-    let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
-    rw [← (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply Q] at hQ ⊢
-    let : IsSimpleModule U P :=
-      IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P)
-    let : IsIrreducible R L P :=
-      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
-    exact (h P).map fun e => (lieSubmoduleLinearEquivAsModule R L M P).symm.trans
-      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
-        (asModule_ι_smul R L P) (asModule_ι_smul R L S) e)
-  · intro h P hP
-    let Q := lieSubmoduleOrderIsoAsModule R L M P
-    let : IsSimpleModule U P :=
-      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
-    let : IsSimpleModule U Q :=
-      IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P).symm
-    exact (h Q).map fun e =>
-      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
-        (asModule_ι_smul R L P) (asModule_ι_smul R L S)).symm
-        ((lieSubmoduleLinearEquivAsModule R L M P).trans e)
+    IsIsotypicOfType R L M S ↔ _root_.IsIsotypicOfType U M S :=
+  isIsotypicOfType_iff_isIsotypicOfType_uea
+    (asModule_ι_smul R L M) S (asModule_ι_smul R L S)
 
 /-- Lie-module isotypy is exactly Mathlib's module isotypy for the canonical `U(L)`-action. -/
 theorem isIsotypic_iff_isIsotypic_asModule :
-    IsIsotypic R L M ↔ _root_.IsIsotypic U M := by
-  rw [isIsotypic_iff]
-  simp only [_root_.IsIsotypic]
-  constructor
-  · intro h Q hQ
-    let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
-    rw [← (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply Q] at hQ ⊢
-    let : IsSimpleModule U P :=
-      IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P)
-    let : IsIrreducible R L P :=
-      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
-    exact (isIsotypicOfType_iff_isIsotypicOfType_asModule P |>.mp (h P)).of_linearEquiv_type
-      (lieSubmoduleLinearEquivAsModule R L M P)
-  · intro h P hP
-    let Q := lieSubmoduleOrderIsoAsModule R L M P
-    let : IsSimpleModule U P :=
-      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
-    let : IsSimpleModule U Q :=
-      IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P).symm
-    exact isIsotypicOfType_iff_isIsotypicOfType_asModule P |>.mpr
-      ((h Q).of_linearEquiv_type (lieSubmoduleLinearEquivAsModule R L M P).symm)
+    IsIsotypic R L M ↔ _root_.IsIsotypic U M :=
+  isIsotypic_iff_isIsotypic_uea (asModule_ι_smul R L M)
 
-/-- The Lie isotypic component maps to Mathlib's `U(L)`-isotypic component. -/
+/-- The canonical submodule dictionary maps the Lie isotypic component to Mathlib's
+`U(L)`-isotypic component. -/
 @[simp]
 theorem lieSubmoduleOrderIsoAsModule_isotypicComponent
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
     lieSubmoduleOrderIsoAsModule R L M (isotypicComponent R L M S) =
       _root_.isotypicComponent U M S := by
-  rw [isotypicComponent_def, OrderIso.map_sSup, _root_.isotypicComponent]
-  apply le_antisymm
-  · refine iSup_le fun P => iSup_le fun hP => ?_
-    obtain ⟨e⟩ := hP
-    exact le_sSup ⟨(lieSubmoduleLinearEquivAsModule R L M P).symm.trans
-      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
-        (asModule_ι_smul R L P) (asModule_ι_smul R L S) e)⟩
-  · refine sSup_le fun Q hQ => ?_
-    obtain ⟨e⟩ := hQ
-    let P := (lieSubmoduleOrderIsoAsModule R L M).symm Q
-    have eq : lieSubmoduleOrderIsoAsModule R L M P = Q :=
-      (lieSubmoduleOrderIsoAsModule R L M).apply_symm_apply Q
-    rw [← eq] at e ⊢
-    have hP : Nonempty (P ≃ₗ⁅R,L⁆ S) :=
-      ⟨(lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
-        (asModule_ι_smul R L P) (asModule_ι_smul R L S)).symm
-        ((lieSubmoduleLinearEquivAsModule R L M P).trans e)⟩
-    exact le_iSup_of_le P (le_iSup_of_le hP le_rfl)
+  rw [lieSubmoduleOrderIsoAsModule_def]
+  exact lieSubmoduleOrderIso_isotypicComponent
+    (asModule_ι_smul R L M) S (asModule_ι_smul R L S)
 
-/-- Membership in the Lie isotypic component is membership in the corresponding `U(L)`-isotypic
-component. -/
+/-- Membership in the Lie isotypic component is membership in the corresponding canonical
+`U(L)`-isotypic component. -/
 @[simp]
 theorem mem_isotypicComponent_iff
     {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     {m : M} :
-    m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S := by
-  rw [← mem_lieSubmoduleOrderIsoAsModule,
-    lieSubmoduleOrderIsoAsModule_isotypicComponent]
+    m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S :=
+  mem_isotypicComponent_iff_uea
+    (asModule_ι_smul R L M) (asModule_ι_smul R L S)
 
 /-- In a completely reducible Lie module, the isotypic component of type `S` is the whole module
 exactly when the Lie module is isotypic of type `S`. -/
@@ -148,15 +235,10 @@ theorem isotypicComponent_eq_top_iff
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     [IsIrreducible R L S]
     [ComplementedLattice (LieSubmodule R L M)] :
-    isotypicComponent R L M S = ⊤ ↔ IsIsotypicOfType R L M S := by
-  let : IsSimpleModule U S :=
-    (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L S)).mp inferInstance
-  let : IsSemisimpleModule U M :=
-    (complementedLattice_lieSubmodule_iff_isSemisimpleModule
-      (asModule_ι_smul R L M)).mp inferInstance
-  rw [← map_eq_top_iff (lieSubmoduleOrderIsoAsModule R L M),
-    lieSubmoduleOrderIsoAsModule_isotypicComponent,
-    _root_.isotypicComponent_eq_top_iff,
-    isIsotypicOfType_iff_isIsotypicOfType_asModule]
+    isotypicComponent R L M S = ⊤ ↔ IsIsotypicOfType R L M S :=
+  isotypicComponent_eq_top_iff_uea
+    (asModule_ι_smul R L M) S (asModule_ι_smul R L S)
+
+end Canonical
 
 end LieModule

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -16,18 +16,13 @@ This file transports Mathlib's isotypic-module interface across the universal-en
 dictionary. The core definitions require only a commutative base ring. Semisimplicity enters only
 in the characterization of an isotypic module by its unique component.
 
-The transport has two small pieces. First, equivalences of Lie modules are exactly linear
-equivalences for compatible `U(L)`-actions. Second, a Lie submodule, with its canonical
-`U(L)`-action, is linearly equivalent by the identity map to the corresponding `U(L)`-submodule.
-The Lie-level predicates and component below are then direct transports of
-`IsIsotypicOfType`, `IsIsotypic`, and `isotypicComponent`.
+The generic equivalence and submodule interfaces live with the rest of the enveloping-algebra
+dictionary in `TauCeti.Algebra.Lie.UniversalEnveloping.Module`. The Lie-level predicates and
+component below are direct transports of `IsIsotypicOfType`, `IsIsotypic`, and
+`isotypicComponent` through those interfaces.
 
 ## Main definitions
 
-* `TauCeti.UniversalEnvelopingAlgebra.lieModuleEquivEquiv`: the equivalence dictionary for
-  compatible `U(L)`-actions.
-* `TauCeti.UniversalEnvelopingAlgebra.lieSubmoduleLinearEquivAsModule`: the identity equivalence
-  between a Lie submodule and its image under the canonical submodule dictionary.
 * `LieModule.IsIsotypicOfType` and `LieModule.IsIsotypic`: Lie-module isotypy.
 * `LieModule.isotypicComponent`: the Lie submodule underlying Mathlib's `U(L)`-isotypic
   component.
@@ -44,146 +39,7 @@ public section
 
 open UniversalEnvelopingAlgebra
 
-universe u v w x
-
-namespace TauCeti.UniversalEnvelopingAlgebra
-
-variable (R : Type u) (L : Type v) (M : Type w) (N : Type x)
-variable [CommRing R] [LieRing L] [LieAlgebra R L]
-variable [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-
-local notation "U" => _root_.UniversalEnvelopingAlgebra R L
-
-section Equiv
-
-variable [LieRingModule L M] [LieModule R L M]
-variable [LieRingModule L N] [LieModule R L N]
-variable [Module (_root_.UniversalEnvelopingAlgebra R L) M]
-variable [IsScalarTower R (_root_.UniversalEnvelopingAlgebra R L) M]
-variable [Module (_root_.UniversalEnvelopingAlgebra R L) N]
-variable [IsScalarTower R (_root_.UniversalEnvelopingAlgebra R L) N]
-
-/-- **The enveloping-algebra dictionary for equivalences**: Lie module equivalences are exactly
-`U(L)`-linear equivalences when both actions are compatible with the canonical Lie generators.
-The correspondence is the identity on underlying functions. -/
-noncomputable def lieModuleEquivEquiv
-    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
-    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆) :
-    (M ≃ₗ⁅R,L⁆ N) ≃ (M ≃ₗ[U] N) where
-  toFun e :=
-    { lieModuleHomEquiv hM hN e.toLieModuleHom with
-      invFun := e.invFun
-      left_inv := fun m => by
-        change e.invFun ((lieModuleHomEquiv hM hN e.toLieModuleHom) m) = m
-        rw [coe_lieModuleHomEquiv]
-        exact e.left_inv m
-      right_inv := fun n => by
-        change (lieModuleHomEquiv hM hN e.toLieModuleHom) (e.invFun n) = n
-        rw [coe_lieModuleHomEquiv]
-        exact e.right_inv n }
-  invFun e :=
-    { (lieModuleHomEquiv hM hN).symm e.toLinearMap with
-      invFun := e.invFun
-      left_inv := fun m => by
-        change e.invFun (((lieModuleHomEquiv hM hN).symm e.toLinearMap) m) = m
-        rw [coe_lieModuleHomEquiv_symm]
-        exact e.left_inv m
-      right_inv := fun n => by
-        change ((lieModuleHomEquiv hM hN).symm e.toLinearMap) (e.invFun n) = n
-        rw [coe_lieModuleHomEquiv_symm]
-        exact e.right_inv n }
-  left_inv e := by
-    apply LieModuleEquiv.ext
-    intro m
-    change ((lieModuleHomEquiv hM hN).symm
-      (lieModuleHomEquiv hM hN e.toLieModuleHom)) m = e m
-    rw [(lieModuleHomEquiv hM hN).symm_apply_apply]
-    rfl
-  right_inv e := by
-    apply LinearEquiv.ext
-    intro m
-    change (lieModuleHomEquiv hM hN
-      ((lieModuleHomEquiv hM hN).symm e.toLinearMap)) m = e m
-    rw [(lieModuleHomEquiv hM hN).apply_symm_apply]
-    rfl
-
-omit [LieModule R L M] in
-/-- The forward equivalence dictionary does not change the underlying function. -/
-@[simp]
-theorem coe_lieModuleEquivEquiv
-    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
-    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
-    (e : M ≃ₗ⁅R,L⁆ N) :
-    ⇑(lieModuleEquivEquiv R L M N hM hN e) = ⇑e :=
-  coe_lieModuleHomEquiv hM hN e.toLieModuleHom
-
-omit [LieModule R L M] in
-/-- The inverse equivalence dictionary does not change the underlying function. -/
-@[simp]
-theorem coe_lieModuleEquivEquiv_symm
-    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
-    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
-    (e : M ≃ₗ[U] N) :
-    ⇑((lieModuleEquivEquiv R L M N hM hN).symm e) = ⇑e :=
-  coe_lieModuleHomEquiv_symm hM hN e.toLinearMap
-
-end Equiv
-
-section Submodule
-
-variable [LieRingModule L M] [LieModule R L M]
-
-attribute [local instance] asModule isScalarTower_asModule
-
-/-- The canonical `U(L)`-action on a Lie submodule agrees, after inclusion, with the canonical
-action on the ambient Lie module. -/
-theorem coe_asModule_smul_lieSubmodule (P : LieSubmodule R L M) (u : U) (p : P) :
-    ((u • p : P) : M) = u • (p : M) := by
-  revert p
-  induction u using induction_ι with
-  | ι x =>
-    intro p
-    rw [asModule_ι_smul R L P, asModule_ι_smul R L M]
-    rfl
-  | algebraMap r => intro p; simp only [algebraMap_smul, SetLike.val_smul]
-  | add u v hu hv =>
-    intro p
-    rw [add_smul, add_smul]
-    change ((u • p : P) : M) + ((v • p : P) : M) = u • (p : M) + v • (p : M)
-    rw [hu p, hv p]
-  | mul u v hu hv =>
-    intro p
-    rw [mul_smul, mul_smul, hu (v • p), hv p]
-
-/-- A Lie submodule with its canonical `U(L)`-action is linearly equivalent, by the identity map,
-to its image under `lieSubmoduleOrderIsoAsModule`. This is the subtype-level part of the
-submodule dictionary used when transporting isotypy. -/
-noncomputable def lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
-    P ≃ₗ[U] lieSubmoduleOrderIsoAsModule R L M P where
-  toFun p := ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩
-  invFun p := ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mp p.property⟩
-  left_inv _ := rfl
-  right_inv _ := rfl
-  map_add' _ _ := rfl
-  map_smul' u p := by
-    ext
-    exact coe_asModule_smul_lieSubmodule R L M P u p
-
-@[simp]
-theorem coe_lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
-    ⇑(lieSubmoduleLinearEquivAsModule R L M P) =
-      fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩ :=
-  (rfl)
-
-@[simp]
-theorem coe_lieSubmoduleLinearEquivAsModule_symm (P : LieSubmodule R L M) :
-    ⇑(lieSubmoduleLinearEquivAsModule R L M P).symm =
-      fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mp p.property⟩ :=
-  (rfl)
-
-end Submodule
-
-end TauCeti.UniversalEnvelopingAlgebra
+universe u v w
 
 namespace LieModule
 
@@ -231,7 +87,8 @@ theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
     letI : IsIrreducible R L P :=
       (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
     exact (h P).map fun e => (lieSubmoduleLinearEquivAsModule R L M P).symm.trans
-      (lieModuleEquivEquiv R L P S (asModule_ι_smul R L P) (asModule_ι_smul R L S) e)
+      (lieModuleEquivEquiv (R := R) (L := L) (M := P) (N := S)
+        (asModule_ι_smul R L P) (asModule_ι_smul R L S) e)
   · intro h P hP
     let Q := lieSubmoduleOrderIsoAsModule R L M P
     letI : IsSimpleModule U P :=
@@ -239,7 +96,8 @@ theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
     letI : IsSimpleModule U Q :=
       IsSimpleModule.congr (lieSubmoduleLinearEquivAsModule R L M P).symm
     exact (h Q).map fun e =>
-      (lieModuleEquivEquiv R L P S (asModule_ι_smul R L P) (asModule_ι_smul R L S)).symm
+      (lieModuleEquivEquiv (R := R) (L := L) (M := P) (N := S)
+        (asModule_ι_smul R L P) (asModule_ι_smul R L S)).symm
         ((lieSubmoduleLinearEquivAsModule R L M P).trans e)
 
 set_option linter.style.haveILetI false in

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
@@ -453,6 +453,48 @@ end Equiv
 
 end Hom
 
+/-! #### Submodule equivalences -/
+
+/-- A Lie submodule with its canonical `U(L)`-action is linearly equivalent, by the identity map,
+to its image under an arbitrary compatible enveloping-algebra submodule dictionary. -/
+noncomputable def lieSubmoduleLinearEquiv
+    [LieModule R L M]
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆) (P : LieSubmodule R L M) :
+    letI := asModule R L P
+    P ≃ₗ[U] lieSubmoduleOrderIso hM P := by
+  letI := asModule R L P
+  letI := isScalarTower_asModule R L P
+  exact
+    { toFun := fun p => ⟨p, (mem_lieSubmoduleOrderIso hM).mpr p.property⟩
+      invFun := fun p => ⟨p, (mem_lieSubmoduleOrderIso hM).mp p.property⟩
+      left_inv := fun _ => rfl
+      right_inv := fun _ => rfl
+      map_add' := fun _ _ => rfl
+      map_smul' := fun u p => by
+        ext
+        exact map_smul_of_map_ι_smul (R := R) (L := L) (M := P) (N := M) P.subtype
+          (fun x p => by rw [asModule_ι_smul R L P, hM]; rfl) u p }
+
+/-- The compatible-action submodule equivalence preserves the underlying ambient element. -/
+@[simp]
+theorem coe_lieSubmoduleLinearEquiv
+    [LieModule R L M]
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆) (P : LieSubmodule R L M) :
+    letI := asModule R L P
+    ⇑(lieSubmoduleLinearEquiv hM P) =
+      fun p => ⟨p, (mem_lieSubmoduleOrderIso hM).mpr p.property⟩ :=
+  (rfl)
+
+/-- The inverse compatible-action submodule equivalence preserves the underlying ambient element. -/
+@[simp]
+theorem coe_lieSubmoduleLinearEquiv_symm
+    [LieModule R L M]
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆) (P : LieSubmodule R L M) :
+    letI := asModule R L P
+    ⇑(lieSubmoduleLinearEquiv hM P).symm =
+      fun p => ⟨p, (mem_lieSubmoduleOrderIso hM).mp p.property⟩ :=
+  (rfl)
+
 end Dictionary
 
 /-! ### The dictionary for the canonical enveloping-algebra module structure
@@ -505,22 +547,17 @@ theorem coe_asModule_smul_lieSubmodule (P : LieSubmodule R L M) (u : U) (p : P) 
 to its image under `lieSubmoduleOrderIsoAsModule`. This is the subtype-level interface for
 transporting module-theoretic properties through the submodule dictionary. -/
 noncomputable def lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
-    P ≃ₗ[U] lieSubmoduleOrderIsoAsModule R L M P where
-  toFun p := ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩
-  invFun p := ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mp p.property⟩
-  left_inv _ := rfl
-  right_inv _ := rfl
-  map_add' _ _ := rfl
-  map_smul' u p := by
-    ext
-    exact coe_asModule_smul_lieSubmodule R L M P u p
+    P ≃ₗ[U] lieSubmoduleOrderIsoAsModule R L M P :=
+  lieSubmoduleLinearEquiv (asModule_ι_smul R L M) P
 
+/-- The canonical forward submodule equivalence preserves the underlying ambient element. -/
 @[simp]
 theorem coe_lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
     ⇑(lieSubmoduleLinearEquivAsModule R L M P) =
       fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩ :=
   (rfl)
 
+/-- The canonical inverse submodule equivalence preserves the underlying ambient element. -/
 @[simp]
 theorem coe_lieSubmoduleLinearEquivAsModule_symm (P : LieSubmodule R L M) :
     ⇑(lieSubmoduleLinearEquivAsModule R L M P).symm =

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.SimpleModule.Basic
+public import TauCeti.Algebra.Lie.Basic
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Basic
 
 /-!
@@ -54,6 +55,10 @@ below is named after its counterparts there wherever one exists.
   canonical structure `TauCeti.UniversalEnvelopingAlgebra.asModule`.
 * `TauCeti.UniversalEnvelopingAlgebra.lieModuleHomEquiv`: **the dictionary for homomorphisms**, an
   `R`-linear equivalence between Lie module homomorphisms and `U(L)`-linear maps.
+* `TauCeti.UniversalEnvelopingAlgebra.lieModuleEquivEquiv`: the corresponding dictionary for
+  equivalences of compatible modules.
+* `TauCeti.UniversalEnvelopingAlgebra.lieSubmoduleLinearEquivAsModule`: the identity equivalence
+  between a Lie submodule and its image under the canonical submodule dictionary.
 
 ## Main results
 
@@ -387,6 +392,64 @@ theorem coe_lieModuleHomEquiv_symm
     ⇑((lieModuleHomEquiv hM hN).symm g) = ⇑g :=
   (rfl)
 
+/-! #### Equivalences -/
+
+section Equiv
+
+/-- **The enveloping-algebra dictionary for equivalences**: Lie module equivalences are exactly
+`U(L)`-linear equivalences when both actions are compatible with the canonical Lie generators.
+The correspondence is the identity on underlying functions. -/
+noncomputable def lieModuleEquivEquiv
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆) :
+    (M ≃ₗ⁅R,L⁆ N) ≃ (M ≃ₗ[U] N) where
+  toFun e := LinearEquiv.ofBijective (lieModuleHomEquiv hM hN e.toLieModuleHom) (by
+    rw [coe_lieModuleHomEquiv]
+    exact ⟨e.injective, e.surjective⟩)
+  invFun e := LieModuleEquiv.ofBijective ((lieModuleHomEquiv hM hN).symm e.toLinearMap)
+    (by
+      rw [coe_lieModuleHomEquiv_symm]
+      exact e.bijective)
+  left_inv e := by
+    apply LieModuleEquiv.ext
+    intro m
+    simp only [LieModuleEquiv.ofBijective_apply, coe_lieModuleHomEquiv_symm,
+      LinearEquiv.coe_toLinearMap, LinearEquiv.ofBijective_apply, coe_lieModuleHomEquiv,
+      LieModuleEquiv.coe_toLieModuleHom]
+  right_inv e := by
+    apply LinearEquiv.ext
+    intro m
+    simp only [LinearEquiv.ofBijective_apply, coe_lieModuleHomEquiv,
+      LieModuleEquiv.coe_toLieModuleHom, LieModuleEquiv.ofBijective_apply,
+      coe_lieModuleHomEquiv_symm, LinearEquiv.coe_toLinearMap]
+
+/-- The forward equivalence dictionary does not change the underlying function. -/
+@[simp]
+theorem coe_lieModuleEquivEquiv
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
+    (e : M ≃ₗ⁅R,L⁆ N) :
+    ⇑(lieModuleEquivEquiv (R := R) (L := L) (M := M) (N := N) hM hN e) = ⇑e :=
+  by
+    ext m
+    simp only [lieModuleEquivEquiv, Equiv.coe_fn_mk, LinearEquiv.ofBijective_apply,
+      coe_lieModuleHomEquiv, LieModuleEquiv.coe_toLieModuleHom]
+
+/-- The inverse equivalence dictionary does not change the underlying function. -/
+@[simp]
+theorem coe_lieModuleEquivEquiv_symm
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
+    (e : M ≃ₗ[U] N) :
+    ⇑((lieModuleEquivEquiv (R := R) (L := L) (M := M) (N := N) hM hN).symm e) = ⇑e :=
+  by
+    ext n
+    simp only [lieModuleEquivEquiv, Equiv.coe_fn_symm_mk,
+      LieModuleEquiv.ofBijective_apply, coe_lieModuleHomEquiv_symm,
+      LinearEquiv.coe_toLinearMap]
+
+end Equiv
+
 end Hom
 
 end Dictionary
@@ -428,6 +491,40 @@ theorem mem_lieSubmoduleOrderIsoAsModule {P : LieSubmodule R L M} {m : M} :
 theorem mem_lieSubmoduleOrderIsoAsModule_symm {Q : Submodule U M} {m : M} :
     m ∈ (lieSubmoduleOrderIsoAsModule R L M).symm Q ↔ m ∈ Q :=
   (Iff.rfl)
+
+/-- The canonical `U(L)`-action on a Lie submodule agrees, after inclusion, with the canonical
+action on the ambient Lie module. -/
+@[simp]
+theorem coe_asModule_smul_lieSubmodule (P : LieSubmodule R L M) (u : U) (p : P) :
+    ((u • p : P) : M) = u • (p : M) := by
+  exact map_smul_of_map_ι_smul (R := R) (L := L) (M := P) (N := M) P.subtype
+    (fun x p => by rw [asModule_ι_smul R L P, asModule_ι_smul R L M]; rfl) u p
+
+/-- A Lie submodule with its canonical `U(L)`-action is linearly equivalent, by the identity map,
+to its image under `lieSubmoduleOrderIsoAsModule`. This is the subtype-level interface for
+transporting module-theoretic properties through the submodule dictionary. -/
+noncomputable def lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
+    P ≃ₗ[U] lieSubmoduleOrderIsoAsModule R L M P where
+  toFun p := ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩
+  invFun p := ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mp p.property⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+  map_smul' u p := by
+    ext
+    exact coe_asModule_smul_lieSubmodule R L M P u p
+
+@[simp]
+theorem coe_lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
+    ⇑(lieSubmoduleLinearEquivAsModule R L M P) =
+      fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩ :=
+  (rfl)
+
+@[simp]
+theorem coe_lieSubmoduleLinearEquivAsModule_symm (P : LieSubmodule R L M) :
+    ⇑(lieSubmoduleLinearEquivAsModule R L M P).symm =
+      fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mp p.property⟩ :=
+  (rfl)
 
 end Canonical
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
@@ -55,8 +55,8 @@ below is named after its counterparts there wherever one exists.
   canonical structure `TauCeti.UniversalEnvelopingAlgebra.asModule`.
 * `TauCeti.UniversalEnvelopingAlgebra.lieModuleHomEquiv`: **the dictionary for homomorphisms**, an
   `R`-linear equivalence between Lie module homomorphisms and `U(L)`-linear maps.
-* `TauCeti.UniversalEnvelopingAlgebra.lieModuleEquivEquiv`: the corresponding dictionary for
-  equivalences of compatible modules.
+* `TauCeti.UniversalEnvelopingAlgebra.lieModuleEquivEquivLinearEquiv`: the corresponding
+  dictionary from Lie-module equivalences to `U(L)`-linear equivalences.
 * `TauCeti.UniversalEnvelopingAlgebra.lieSubmoduleLinearEquivAsModule`: the identity equivalence
   between a Lie submodule and its image under the canonical submodule dictionary.
 
@@ -399,7 +399,7 @@ section Equiv
 /-- **The enveloping-algebra dictionary for equivalences**: Lie module equivalences are exactly
 `U(L)`-linear equivalences when both actions are compatible with the canonical Lie generators.
 The correspondence is the identity on underlying functions. -/
-noncomputable def lieModuleEquivEquiv
+noncomputable def lieModuleEquivEquivLinearEquiv
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆) :
     (M ≃ₗ⁅R,L⁆ N) ≃ (M ≃ₗ[U] N) where
@@ -425,26 +425,27 @@ noncomputable def lieModuleEquivEquiv
 
 /-- The forward equivalence dictionary does not change the underlying function. -/
 @[simp]
-theorem coe_lieModuleEquivEquiv
+theorem coe_lieModuleEquivEquivLinearEquiv
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
     (e : M ≃ₗ⁅R,L⁆ N) :
-    ⇑(lieModuleEquivEquiv (R := R) (L := L) (M := M) (N := N) hM hN e) = ⇑e :=
+    ⇑(lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := M) (N := N) hM hN e) = ⇑e :=
   by
     ext m
-    simp only [lieModuleEquivEquiv, Equiv.coe_fn_mk, LinearEquiv.ofBijective_apply,
+    simp only [lieModuleEquivEquivLinearEquiv, Equiv.coe_fn_mk, LinearEquiv.ofBijective_apply,
       coe_lieModuleHomEquiv, LieModuleEquiv.coe_toLieModuleHom]
 
 /-- The inverse equivalence dictionary does not change the underlying function. -/
 @[simp]
-theorem coe_lieModuleEquivEquiv_symm
+theorem coe_lieModuleEquivEquivLinearEquiv_symm
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
     (e : M ≃ₗ[U] N) :
-    ⇑((lieModuleEquivEquiv (R := R) (L := L) (M := M) (N := N) hM hN).symm e) = ⇑e :=
+    ⇑((lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := M) (N := N) hM hN).symm e) =
+      ⇑e :=
   by
     ext n
-    simp only [lieModuleEquivEquiv, Equiv.coe_fn_symm_mk,
+    simp only [lieModuleEquivEquivLinearEquiv, Equiv.coe_fn_symm_mk,
       LieModuleEquiv.ofBijective_apply, coe_lieModuleHomEquiv_symm,
       LinearEquiv.coe_toLinearMap]
 


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Bridges Lie-module isotypy to modules over the universal enveloping algebra.

- Defines Lie isotypic predicates and components.
- Identifies Lie equivalences and submodules with their enveloping-algebra counterparts.
- Transports isotypy through arbitrary compatible UEA actions, with canonical specializations.
- Exposes component, membership, coercion, and top equations.

## Roadmap target

Supplies the UEA dictionary for the [LieHighestWeight Layer 6 isotypic toolkit](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/Suggested.lean#L469-L529).

## Verification

Full gates, compatible and canonical consumers, structural golf, and a fresh context-clean full-aggregate 2+1 review pass at `cd85e81494a69130a6d107f01e4ac6d00020d48a`.

## Scale and generality

Adds 521 lines in three files. Predicates need a commutative ring and Lie-ring modules. Generic transport accepts arbitrary compatible UEA actions; canonical specializations use the standard `asModule` action. Only the top criterion adds irreducibility and complementability.

## Scope

- **Consumes:** Lie/UEA hom and submodule dictionaries plus Mathlib isotypy.
- **Provides:** Lie isotypic predicates/components and compatible UEA transport with canonical specializations.
- **Fits:** supplies Layer 6 decomposition and single-weight criteria.
- **Boundary:** multiplicities, decompositions, and highest-weight specialization remain downstream.

<sub>🤖 GPT-5.6 Sol high · [rubrics](https://github.com/TauCetiProject/TauCetiReview/commit/465c9e7f) · fresh full-aggregate 2+1 approved at `cd85e814`</sub>
