### PR TITLE
docs: describe the scoreboard-based merge gate

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,15 +2,14 @@ name: Auto-merge
 
 # Merge a PR automatically once it is genuinely ready, WITHOUT generating any reviews here (that is
 # expensive — it spends API budget — and is gated off in review.yml). Reviews are produced by people
-# running tauceti-review / tauceti locally, which push the verdict ledger to the reviews branch and
-# post the scoreboard comment. This workflow just reads that ledger and merges when ready.
+# running tauceti-review / tauceti locally and posting a head-pinned scoreboard comment. This workflow
+# reads the newest such scoreboard and merges when ready; TauCetiData is a separate analytics archive.
 #
 # It calls the lightweight TauCetiReview merge-only workflow, which mints no provider keys, runs no
 # reviewer, and merges only when the engine's own rule says so: build green on HEAD, every blocking
 # rubric green on HEAD, every changed path under TauCeti/ (plus the allowed root files), and bump-guard
-# green for any Lake-pin change. The decision is read from the real ledger, so a forged scoreboard
-# comment can only TRIGGER a re-check, never supply a verdict — which is why the triggers below can be
-# loose: an over-trigger is a cheap no-op, never a wrong merge.
+# green for any Lake-pin change. The scoreboard supplies the review verdict with no author-association
+# gate; trusted CI supplies the build, scope, axiom, path, and bump-guard boundaries.
 
 on:
   # Head is freshly green: re-check whether this PR is now mergeable.

--- a/scripts/housekeeping.py
+++ b/scripts/housekeeping.py
@@ -25,9 +25,10 @@ is never auto-closed. By design these jobs do NOT spare human-touched PRs — an
 adds `keep`. A failed close makes the job exit nonzero.
 
 A scoreboard is trusted only if it carries the `tauceti-scoreboard` marker AND its author is
-repo-associated (OWNER/MEMBER/COLLABORATOR) — the same trust the worker applies. The reviewer and the
-PR author are frequently the same account (the worker reviews its own roadmap PRs), so trust is by
-association, not by "not the author": an external author cannot forge a repo-associated comment.
+repo-associated (OWNER/MEMBER/COLLABORATOR). This destructive close policy is deliberately stricter
+than the worker and auto-merge scoreboard readers. The reviewer and the PR author are frequently the
+same account, so trust is by association, not by "not the author": an external author cannot forge a
+repo-associated comment that makes housekeeping close a PR.
 
 Env: GH_TOKEN (a token that can close PRs), REPO (owner/name), optional DRY_RUN=1, REVIEW_BUDGET,
 BUDGET_LABEL, STALE_DAYS, EMPTY_QUIET_MINUTES.

--- a/scripts/pr_status/README.md
+++ b/scripts/pr_status/README.md
@@ -9,7 +9,7 @@ source of truth:
   carrying emoji that track the same states at a glance.
 
 [`core.py`](core.py) is that source of truth. It derives a PR's status from
-GitHub (PR state, the `build` commit status, the canonical
+GitHub (PR state, the `build` commit status, the newest repo-associated
 `<!--tauceti-scoreboard-->` comment's meta JSON, and the review engine's
 `<!--tauceti-review-in-progress-->` marker) and returns a neutral
 `{lifecycle, ci, review, review_inprogress}`. It writes nothing. The two *sinks*
@@ -29,7 +29,9 @@ reactions can never disagree:
 
 Both review signals (the scoreboard meta and the in-progress marker) are read
 only from comments by a repo-associated author (OWNER/MEMBER/COLLABORATOR), from
-one comment fetch, so a fork PR author cannot forge review state. Every reconcile
+one comment fetch, so a fork PR author cannot forge status labels or housekeeping
+state. This status-sink policy is deliberately narrower than auto-merge's
+newest-scoreboard policy. Every reconcile
 reads GitHub afresh and drives the sink to the correct state, so the same command
 powers the event-driven workflows and a one-shot backfill, and a transient hiccup
 self-heals on the next event. The only dependencies are python3's standard library
@@ -57,9 +59,9 @@ clears the label once the marker expires even if no other event fires.
 The review verdict itself comes from the scoreboard's durable per-rubric `states`
 map, not the latest round's `runs`: a reply/partial round re-runs only some
 rubrics, so `runs` alone can show a green latest round while another rubric still
-blocks. This mirrors the worker's `ledger_blocking` and the signal CI's merge
-close reads (see [`core.review_state`](core.py)), and falls back to `runs` only
-for a legacy scoreboard without a `states` map.
+blocks. This mirrors the worker's `ledger_blocking` and the per-rubric state map
+auto-merge reads (see [`core.review_state`](core.py)), and falls back to `runs`
+only for a legacy scoreboard without a `states` map.
 
 [`pr-labels.yml`](../../.github/workflows/pr-labels.yml) drives it. A first
 `resolve` job resolves the PR number once; the `label` job then keys its

--- a/scripts/pr_status/core.py
+++ b/scripts/pr_status/core.py
@@ -3,7 +3,7 @@
 
 This is the single place that reads what a PR's status *is* -- its lifecycle
 (open / merged / closed), its `build` CI state, and its review state (from the
-canonical `<!--tauceti-scoreboard-->` comment's meta JSON), plus whether a review
+newest repo-associated `<!--tauceti-scoreboard-->` comment's meta JSON), plus whether a review
 is in flight right now (from the engine's `<!--tauceti-review-in-progress-->`
 marker). Every status *sink* imports it and renders that one truth its own way:
 
@@ -13,10 +13,11 @@ marker). Every status *sink* imports it and renders that one truth its own way:
 Keeping the derivation here means the two sinks can never disagree about what a
 PR's state is: they read the same `derive()` and only differ in how they show it.
 
-Everything here reads only trusted GitHub data. The two review signals -- the
-scoreboard meta and the in-progress marker -- are taken only from comments by a
-repo-associated author (OWNER/MEMBER/COLLABORATOR), so a fork PR author cannot
-forge review state. Both are extracted from ONE comment fetch.
+Everything here reads only trusted GitHub data. The two review signals -- the scoreboard meta and
+the in-progress marker -- are taken only from comments by a repo-associated author
+(OWNER/MEMBER/COLLABORATOR), so a fork PR author cannot forge status labels or housekeeping state.
+This status-sink policy is deliberately narrower than auto-merge's newest-scoreboard policy. Both
+signals are extracted from ONE comment fetch.
 
 The module is a pure library -- importing it has no side effects, writes nothing,
 and needs only python3's standard library plus an authenticated `gh` CLI (via
@@ -203,8 +204,9 @@ def review_state(meta, head):
     The authoritative signal is the durable per-rubric `states` map, NOT the latest round's `runs`:
     a reply/partial round re-runs only some rubrics, so `runs` can show an approve for one rubric
     while another is still blocking in `states`. This mirrors the worker's `ledger_blocking` and the
-    signal CI's merge close reads, so they agree. `runs` is used only as a fallback for a legacy
-    scoreboard with no `states` map. State not at the current head (a fix landed since the last
+    per-rubric state representation auto-merge reads, although auto-merge selects scoreboards under a
+    different author policy. `runs` is used only as a fallback for a legacy scoreboard with no `states`
+    map. State not at the current head (a fix landed since the last
     review) reads as "running, green so far".
 
         "none"     nothing posted yet          (no Zulip review emoji / label awaiting-review)

--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -472,11 +472,10 @@ def detect_stranded_prs():
         ready_since = min(hours_since(updated), hours_since(applied))
         if ready_since < STRANDED_HOURS:
             continue
-        # NOTE: scoreboard_meta is the trusted scoreboard comment auto-merge reads
-        # to TRIGGER a re-check; it is not the authoritative merge ledger, so this
-        # is best-effort and can lag. The mergeable + in-scope + quiet-window guards
-        # below keep the false-emergency rate low; a fully authoritative read of the
-        # TauCetiReview ledger is a possible future hardening.
+        # This detector deliberately uses the repo-associated scoreboard selected by the status
+        # sinks. Auto-merge instead reads the newest marked scoreboard from any author, so an
+        # external review may merge without this detector ever considering it approved. That makes
+        # the alert best-effort but cannot cause a wrong merge or close.
         if core.review_state(core.scoreboard_meta(pr["number"]), head) != "approved":
             continue
         # Filenames are bare strings, not JSON -- gh_lines, not gh_stream.


### PR DESCRIPTION
This PR corrects the workflow and status documentation to describe the scoreboard-based merge gate instead of the obsolete reviews-branch ledger. It also makes explicit that status labels and destructive housekeeping intentionally use the narrower repo-associated scoreboard policy, while auto-merge reads the newest marked scoreboard from any author. No workflow behavior, permissions, or pins change.

Tested with `python3 scripts/test_workflow_pins.py`, `python3 scripts/pr_status/test_pr_labels.py`, and `python3 scripts/pr_status/test_stuck_alerts.py`.

Roadmap: none

:robot: Prepared with OpenAI Codex
