### PR TITLE
feat: assemble the rational Dixon character-table solver

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.CentralCharacterCount
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.Cyclic
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Rational.Solver
 
 /-!
 # The rational Dixon computation for the cyclic group of order two
@@ -22,8 +23,8 @@ required primitive square root of unity modulo `3`.
 The simultaneous eigenvector search over the certified Dixon prime `3` returns exactly the
 reductions of the two displayed central-character rows.  Signed least representatives lift those
 rows back to the integers.  Since every class is a singleton and both displayed degrees are one,
-the ordinary table is set equal entrywise to the central-character table.  Identifying its rows
-with the group's irreducible characters is not formalized here.
+the ordinary table is set equal entrywise to the central-character table. The assembled rational
+solver recovers an exact certified table from this data.
 
 Completeness does not rely on evaluating the entire search.  Each displayed row is checked against
 the class-algebra equations, and the good-prime structure theorem proves that the search has exactly
@@ -44,12 +45,14 @@ two outputs.
   integral rows.
 * `TauCeti.cyclicGroupTwo_degree_mul_centralCharacterTable`: the division-free conversion to the
   ordinary character table.
+* `TauCeti.isIntegerCharacterTableSpec_cyclicGroupTwo`: the exact table passes the checker used by
+  the assembled solver.
 
 ## References
 
 This implements cyclic `C₂` in “Rational tables (first executable milestone)” in Layer 6 of the
-[character theory roadmap][roadmap].  Connecting this exact output to the general table checker
-remains part of the assembled solver target.
+[character theory roadmap][roadmap] and supplies the executable acceptance test for the assembled
+rational solver.
 
 The worked computation follows
 `TauCeti.RepresentationTheory.CharacterTable.Dixon.Rational.DihedralFour`; the prime certificate
@@ -265,5 +268,30 @@ theorem cyclicGroupTwo_characterTable_orthogonal (i j : CyclicGroupTwoClassIndex
       if i = j then Nat.card (Multiplicative (ZMod 2)) else 0 := by
   simp only [Nat.card_eq_fintype_card, Fintype.card_multiplicative, ZMod.card]
   fin_cases i <;> fin_cases j <;> decide
+
+/-- The displayed `C₂` tables pass the exact integer character-table specification. -/
+theorem isIntegerCharacterTableSpec_cyclicGroupTwo :
+    (cyclicClassData 2).IsIntegerCharacterTableSpec
+      cyclicGroupTwoCentralCharacterTable cyclicGroupTwoCharacterTable
+      cyclicGroupTwoCharacterDegrees where
+  central_one i := by fin_cases i <;> decide
+  central_eigen := isModularEigenrow_cyclicGroupTwoCentralCharacterTable_int
+  degree_pos i := (cyclicGroupTwo_characterDegrees_pos_and_dvd i).1
+  degree_dvd i := by
+    simpa only [Nat.card_eq_fintype_card] using
+      (cyclicGroupTwo_characterDegrees_pos_and_dvd i).2
+  sum_degree_sq := by
+    simpa only [Nat.card_eq_fintype_card] using cyclicGroupTwo_sum_characterDegrees_sq
+  degree_mul_central := cyclicGroupTwo_degree_mul_centralCharacterTable
+  row_orthogonal i j := by
+    simpa only [Nat.card_eq_fintype_card, Nat.cast_ite, Nat.cast_zero] using
+      cyclicGroupTwo_characterTable_orthogonal i j
+
+/-- The exact `C₂` output, cast to `ℂ`, satisfies the character-table specification and hence is
+the complex character table up to a permutation of rows. -/
+theorem isCharacterTableSpec_cyclicGroupTwo :
+    IsCharacterTableSpec (Multiplicative (ZMod 2))
+      ((cyclicClassData 2).complexTableOfInteger cyclicGroupTwoCharacterTable) :=
+  isIntegerCharacterTableSpec_cyclicGroupTwo.isCharacterTableSpec
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
@@ -302,7 +302,7 @@ theorem mem_liftedCentralRows_cyclicGroupTwoCentralCharacterTable
 
 /-- The two displayed central-character rows are distinct, so they number the lifted rows
 injectively. -/
-theorem injective_cyclicGroupTwoCentralCharacterTable :
+theorem cyclicGroupTwoCentralCharacterTable_injective :
     Function.Injective cyclicGroupTwoCentralCharacterTable := by
   intro i j hij
   have h := congrFun hij ⟨1, by simp⟩
@@ -317,7 +317,7 @@ theorem isSome_dixonRationalCharacterTable_cyclicGroupTwo :
   refine ⟨⟨cyclicGroupTwoCentralCharacterTable, cyclicGroupTwoCharacterTable,
     cyclicGroupTwoCharacterDegrees⟩, ?_, isIntegerCharacterTableSpec_cyclicGroupTwo⟩
   refine ⟨mem_liftedCentralRows_cyclicGroupTwoCentralCharacterTable,
-    injective_cyclicGroupTwoCentralCharacterTable, fun i => ?_, fun i => ?_, ?_, fun i j => ?_⟩
+    cyclicGroupTwoCentralCharacterTable_injective, fun i => ?_, fun i => ?_, ?_, fun i j => ?_⟩
   · exact (cyclicGroupTwo_characterDegrees_pos_and_dvd i).1
   · simpa only [Nat.card_eq_fintype_card] using (cyclicGroupTwo_characterDegrees_pos_and_dvd i).2
   · simpa only [Nat.card_eq_fintype_card] using cyclicGroupTwo_sum_characterDegrees_sq

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.CentralCharacterCount
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.ClassData.Cyclic
 public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Rational.Solver
 
@@ -300,14 +299,6 @@ theorem mem_liftedCentralRows_cyclicGroupTwoCentralCharacterTable
     mem_cyclicGroupTwoModularCentralRows_iff.mpr ⟨i, rfl⟩, funext fun j => ?_⟩
   exact cyclicGroupTwo_valMinAbs_centralCharacterTable i j
 
-/-- The two displayed central-character rows are distinct, so they number the lifted rows
-injectively. -/
-theorem cyclicGroupTwoCentralCharacterTable_injective :
-    Function.Injective cyclicGroupTwoCentralCharacterTable := by
-  intro i j hij
-  have h := congrFun hij ⟨1, by simp⟩
-  fin_cases i <;> fin_cases j <;> revert h <;> decide
-
 /-- The assembled rational Dixon--Schneider solver succeeds on the certified `C₂` prime. -/
 theorem isSome_dixonRationalCharacterTable_cyclicGroupTwo :
     ((cyclicClassData 2).dixonRationalCharacterTable?
@@ -315,14 +306,8 @@ theorem isSome_dixonRationalCharacterTable_cyclicGroupTwo :
   simp only [cyclicGroupTwoDixonPrimeData_p]
   rw [(cyclicClassData 2).isSome_dixonRationalCharacterTable_iff]
   refine ⟨⟨cyclicGroupTwoCentralCharacterTable, cyclicGroupTwoCharacterTable,
-    cyclicGroupTwoCharacterDegrees⟩, ?_, isIntegerCharacterTableSpec_cyclicGroupTwo⟩
-  refine ⟨mem_liftedCentralRows_cyclicGroupTwoCentralCharacterTable,
-    cyclicGroupTwoCentralCharacterTable_injective, fun i => ?_, fun i => ?_, ?_, fun i j => ?_⟩
-  · exact (cyclicGroupTwo_characterDegrees_pos_and_dvd i).1
-  · simpa only [Nat.card_eq_fintype_card] using (cyclicGroupTwo_characterDegrees_pos_and_dvd i).2
-  · simpa only [Nat.card_eq_fintype_card] using cyclicGroupTwo_sum_characterDegrees_sq
-  · fin_cases i <;> fin_cases j <;>
-      simp [classFinset_cyclicClassData, cyclicGroupTwoCharacterTable]
+    cyclicGroupTwoCharacterDegrees⟩, mem_liftedCentralRows_cyclicGroupTwoCentralCharacterTable,
+    isIntegerCharacterTableSpec_cyclicGroupTwo⟩
 
 /-- The exact `C₂` output, cast to `ℂ`, satisfies the character-table specification and hence is
 the complex character table up to a permutation of rows. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
@@ -316,7 +316,6 @@ theorem isSome_dixonRationalCharacterTable_cyclicGroupTwo :
   rw [(cyclicClassData 2).isSome_dixonRationalCharacterTable_iff]
   refine ⟨⟨cyclicGroupTwoCentralCharacterTable, cyclicGroupTwoCharacterTable,
     cyclicGroupTwoCharacterDegrees⟩, ?_, isIntegerCharacterTableSpec_cyclicGroupTwo⟩
-  rw [ClassData.mem_dixonRationalCharacterTableCandidates_iff]
   refine ⟨mem_liftedCentralRows_cyclicGroupTwoCentralCharacterTable,
     injective_cyclicGroupTwoCentralCharacterTable, fun i => ?_, fun i => ?_, ?_, fun i j => ?_⟩
   · exact (cyclicGroupTwo_characterDegrees_pos_and_dvd i).1

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
@@ -291,71 +291,39 @@ theorem isIntegerCharacterTableSpec_cyclicGroupTwo :
     simpa only [Nat.card_eq_fintype_card, Nat.cast_ite, Nat.cast_zero] using
       cyclicGroupTwo_characterTable_orthogonal i j
 
+/-- Every displayed integral row occurs among the signed lifts of the modular search at `3`. -/
+theorem mem_liftedCentralRows_cyclicGroupTwoCentralCharacterTable
+    (i : CyclicGroupTwoClassIndex) :
+    cyclicGroupTwoCentralCharacterTable i ∈ (cyclicClassData 2).liftedCentralRows 3 := by
+  rw [ClassData.mem_liftedCentralRows_iff, cyclicGroupTwo_centralCharacterSearch]
+  refine ⟨fun j => (cyclicGroupTwoCentralCharacterTable i j : ZMod 3),
+    mem_cyclicGroupTwoModularCentralRows_iff.mpr ⟨i, rfl⟩, funext fun j => ?_⟩
+  exact cyclicGroupTwo_valMinAbs_centralCharacterTable i j
+
+/-- The two displayed central-character rows are distinct, so they number the lifted rows
+injectively. -/
+theorem injective_cyclicGroupTwoCentralCharacterTable :
+    Function.Injective cyclicGroupTwoCentralCharacterTable := by
+  intro i j hij
+  have h := congrFun hij ⟨1, by simp⟩
+  fin_cases i <;> fin_cases j <;> revert h <;> decide
+
 /-- The assembled rational Dixon--Schneider solver succeeds on the certified `C₂` prime. -/
 theorem isSome_dixonRationalCharacterTable_cyclicGroupTwo :
     ((cyclicClassData 2).dixonRationalCharacterTable?
       cyclicGroupTwoDixonPrimeData.p).isSome = true := by
   simp only [cyclicGroupTwoDixonPrimeData_p]
-  change ((cyclicClassData 2).dixonRationalCharacterTable?
-    3).isSome
   rw [(cyclicClassData 2).isSome_dixonRationalCharacterTable_iff]
-  let this : FinEnum (ZMod 3) :=
-    FinEnum.ofEquiv (Fin 3) (ZMod.finEquiv 3).symm.toEquiv
-  let i0 : CyclicGroupTwoClassIndex := ⟨0, by simp⟩
-  let i1 : CyclicGroupTwoClassIndex := ⟨1, by simp⟩
-  have hlifted :
-      (cyclicClassData 2).liftedCentralRowsList 3 =
-        [fun j => cyclicGroupTwoCentralCharacterTable i0 j,
-          fun j => cyclicGroupTwoCentralCharacterTable i1 j] := by
-    rw [ClassData.liftedCentralRowsList, cyclicGroupTwo_centralCharacterSearch]
-    with_reducible_and_instances decide
-  let row0 := fun j => cyclicGroupTwoCentralCharacterTable i0 j
-  let row1 := fun j => cyclicGroupTwoCentralCharacterTable i1 j
-  let rows : CyclicGroupTwoClassIndex → {row // row ∈ [row0, row1]} := fun i =>
-    ⟨fun j => cyclicGroupTwoCentralCharacterTable i j, by
-      fin_cases i <;> simp [row0, row1, i0, i1]⟩
-  have hrow_ne : row0 ≠ row1 := by
-    intro h
-    have hij := congrFun h i1
-    change (1 : ℤ) = -1 at hij
-    omega
-  have hrows : Function.Injective rows := by
-    intro i j hij
-    have hij' : (rows i).val = (rows j).val := congrArg Subtype.val hij
-    fin_cases i <;> fin_cases j
-    · rfl
-    · exact (hrow_ne hij').elim
-    · exact (hrow_ne hij'.symm).elim
-    · rfl
-  let Degree :=
-    {n : Fin (Fintype.card (Multiplicative (ZMod 2)) + 1) //
-      n ≠ 0 ∧ (n : ℕ) ∣ Fintype.card (Multiplicative (ZMod 2))}
-  let degreeOne : Degree := ⟨1, by simp⟩
-  let degrees : CyclicGroupTwoClassIndex → Degree := fun _ => degreeOne
-  have hdegrees :
-      ∑ i, (degrees i : ℕ) ^ 2 = Fintype.card (Multiplicative (ZMod 2)) := by
-    simp [degrees, degreeOne]
   refine ⟨⟨cyclicGroupTwoCentralCharacterTable, cyclicGroupTwoCharacterTable,
     cyclicGroupTwoCharacterDegrees⟩, ?_, isIntegerCharacterTableSpec_cyclicGroupTwo⟩
-  simp only [ClassData.dixonRationalCharacterTableCandidates]
-  rw [hlifted]
-  apply List.mem_flatMap.mpr
-  refine ⟨rows, ?_, ?_⟩
-  · simp only [List.mem_filter, FinEnum.mem_toList, true_and, decide_eq_true_eq]
-    exact hrows
-  · apply List.mem_map.mpr
-    refine ⟨degrees, ?_, ?_⟩
-    · simp only [List.mem_filter, FinEnum.mem_toList, true_and, decide_eq_true_eq]
-      exact hdegrees
-    · apply ClassData.IntegerCharacterTableData.ext
-      · funext i j
-        fin_cases i <;> fin_cases j <;> simp [rows]
-      · funext i j
-        fin_cases i <;> fin_cases j <;>
-          simp [rows, degrees, degreeOne,
-            classFinset_cyclicClassData, cyclicGroupTwoCharacterTable]
-      · funext i
-        fin_cases i <;> simp [degrees, degreeOne, cyclicGroupTwoCharacterDegrees]
+  rw [ClassData.mem_dixonRationalCharacterTableCandidates_iff]
+  refine ⟨mem_liftedCentralRows_cyclicGroupTwoCentralCharacterTable,
+    injective_cyclicGroupTwoCentralCharacterTable, fun i => ?_, fun i => ?_, ?_, fun i j => ?_⟩
+  · exact (cyclicGroupTwo_characterDegrees_pos_and_dvd i).1
+  · simpa only [Nat.card_eq_fintype_card] using (cyclicGroupTwo_characterDegrees_pos_and_dvd i).2
+  · simpa only [Nat.card_eq_fintype_card] using cyclicGroupTwo_sum_characterDegrees_sq
+  · fin_cases i <;> fin_cases j <;>
+      simp [classFinset_cyclicClassData, cyclicGroupTwoCharacterTable]
 
 /-- The exact `C₂` output, cast to `ℂ`, satisfies the character-table specification and hence is
 the complex character table up to a permutation of rows. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/CyclicTwo.lean
@@ -47,6 +47,10 @@ two outputs.
   ordinary character table.
 * `TauCeti.isIntegerCharacterTableSpec_cyclicGroupTwo`: the exact table passes the checker used by
   the assembled solver.
+* `TauCeti.isSome_dixonRationalCharacterTable_cyclicGroupTwo`: the assembled solver succeeds on
+  the `C₂` data.
+* `TauCeti.isCharacterTableSpec_cyclicGroupTwo`: the cast table is the complex character table up
+  to a row permutation.
 
 ## References
 
@@ -286,6 +290,72 @@ theorem isIntegerCharacterTableSpec_cyclicGroupTwo :
   row_orthogonal i j := by
     simpa only [Nat.card_eq_fintype_card, Nat.cast_ite, Nat.cast_zero] using
       cyclicGroupTwo_characterTable_orthogonal i j
+
+/-- The assembled rational Dixon--Schneider solver succeeds on the certified `C₂` prime. -/
+theorem isSome_dixonRationalCharacterTable_cyclicGroupTwo :
+    ((cyclicClassData 2).dixonRationalCharacterTable?
+      cyclicGroupTwoDixonPrimeData.p).isSome = true := by
+  simp only [cyclicGroupTwoDixonPrimeData_p]
+  change ((cyclicClassData 2).dixonRationalCharacterTable?
+    3).isSome
+  rw [(cyclicClassData 2).isSome_dixonRationalCharacterTable_iff]
+  let this : FinEnum (ZMod 3) :=
+    FinEnum.ofEquiv (Fin 3) (ZMod.finEquiv 3).symm.toEquiv
+  let i0 : CyclicGroupTwoClassIndex := ⟨0, by simp⟩
+  let i1 : CyclicGroupTwoClassIndex := ⟨1, by simp⟩
+  have hlifted :
+      (cyclicClassData 2).liftedCentralRowsList 3 =
+        [fun j => cyclicGroupTwoCentralCharacterTable i0 j,
+          fun j => cyclicGroupTwoCentralCharacterTable i1 j] := by
+    rw [ClassData.liftedCentralRowsList, cyclicGroupTwo_centralCharacterSearch]
+    with_reducible_and_instances decide
+  let row0 := fun j => cyclicGroupTwoCentralCharacterTable i0 j
+  let row1 := fun j => cyclicGroupTwoCentralCharacterTable i1 j
+  let rows : CyclicGroupTwoClassIndex → {row // row ∈ [row0, row1]} := fun i =>
+    ⟨fun j => cyclicGroupTwoCentralCharacterTable i j, by
+      fin_cases i <;> simp [row0, row1, i0, i1]⟩
+  have hrow_ne : row0 ≠ row1 := by
+    intro h
+    have hij := congrFun h i1
+    change (1 : ℤ) = -1 at hij
+    omega
+  have hrows : Function.Injective rows := by
+    intro i j hij
+    have hij' : (rows i).val = (rows j).val := congrArg Subtype.val hij
+    fin_cases i <;> fin_cases j
+    · rfl
+    · exact (hrow_ne hij').elim
+    · exact (hrow_ne hij'.symm).elim
+    · rfl
+  let Degree :=
+    {n : Fin (Fintype.card (Multiplicative (ZMod 2)) + 1) //
+      n ≠ 0 ∧ (n : ℕ) ∣ Fintype.card (Multiplicative (ZMod 2))}
+  let degreeOne : Degree := ⟨1, by simp⟩
+  let degrees : CyclicGroupTwoClassIndex → Degree := fun _ => degreeOne
+  have hdegrees :
+      ∑ i, (degrees i : ℕ) ^ 2 = Fintype.card (Multiplicative (ZMod 2)) := by
+    simp [degrees, degreeOne]
+  refine ⟨⟨cyclicGroupTwoCentralCharacterTable, cyclicGroupTwoCharacterTable,
+    cyclicGroupTwoCharacterDegrees⟩, ?_, isIntegerCharacterTableSpec_cyclicGroupTwo⟩
+  simp only [ClassData.dixonRationalCharacterTableCandidates]
+  rw [hlifted]
+  apply List.mem_flatMap.mpr
+  refine ⟨rows, ?_, ?_⟩
+  · simp only [List.mem_filter, FinEnum.mem_toList, true_and, decide_eq_true_eq]
+    exact hrows
+  · apply List.mem_map.mpr
+    refine ⟨degrees, ?_, ?_⟩
+    · simp only [List.mem_filter, FinEnum.mem_toList, true_and, decide_eq_true_eq]
+      exact hdegrees
+    · apply ClassData.IntegerCharacterTableData.ext
+      · funext i j
+        fin_cases i <;> fin_cases j <;> simp [rows]
+      · funext i j
+        fin_cases i <;> fin_cases j <;>
+          simp [rows, degrees, degreeOne,
+            classFinset_cyclicClassData, cyclicGroupTwoCharacterTable]
+      · funext i
+        fin_cases i <;> simp [degrees, degreeOne, cyclicGroupTwoCharacterDegrees]
 
 /-- The exact `C₂` output, cast to `ℂ`, satisfies the character-table specification and hence is
 the complex character table up to a permutation of rows. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
@@ -53,8 +53,7 @@ namespace ClassData
 
 universe u
 
-variable {G : Type u} [Group G] [Fintype G] [DecidableEq G]
-variable (d : ClassData G)
+variable {G : Type u} [Group G] (d : ClassData G)
 
 /-- The three exact numbered arrays produced by the integer-valued Dixon--Schneider solver: the
 central-character table, the ordinary character table, and the character degrees. -/
@@ -66,8 +65,19 @@ structure IntegerCharacterTable where
   table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ
   /-- The positive character degrees. -/
   degree : Fin d.numClasses → ℕ
-deriving DecidableEq
 
+/-- Decidability of equality between integer character tables. -/
+instance : DecidableEq d.IntegerCharacterTable := by
+  intro ⟨o1, t1, deg1⟩ ⟨o2, t2, deg2⟩
+  by_cases ho : o1 = o2
+  · by_cases ht : t1 = t2
+    · by_cases hd : deg1 = deg2
+      · exact isTrue (by rw [ho, ht, hd])
+      · exact isFalse (by intro h; cases h; exact hd rfl)
+    · exact isFalse (by intro h; cases h; exact ht rfl)
+  · exact isFalse (by intro h; cases h; exact ho rfl)
+
+variable [Fintype G] [DecidableEq G]
 variable {d}
 
 /-- Run the integer-valued stage of the Dixon--Schneider character-table algorithm.

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
@@ -15,9 +15,9 @@ public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Rational.Basic
 This file assembles the integer-valued stage of the Burnside--Dixon--Schneider character-table
 algorithm. Given executable conjugacy-class data and a prime, it performs the
 modular common-eigenrow search, lifts the rows by signed least representatives, searches the
-possible positive character degrees dividing the group order, and reconstructs the ordinary table
-from the central-character table. It returns the first candidate accepted by the exact integer
-checker.
+possible positive character degrees dividing the group order, and computes candidate integer
+quotients for the ordinary table from the central-character table. The exact integer checker then
+verifies the corresponding division-free equality, so the conversion is exact for accepted outputs.
 
 The result is an `Option`: `none` honestly records that the character table is not integer-valued,
 that the chosen residue window was too small, or that no ordering of the lifted rows passed the
@@ -99,7 +99,8 @@ private theorem mem_liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMo
 
 /-- Enumerate the candidate data inspected by the rational Dixon--Schneider solver: every
 injective numbering of the lifted central rows, paired with every degree vector whose positive
-entries divide `|G|` and whose squares sum to `|G|`. -/
+entries divide `|G|` and whose squares sum to `|G|`. Ordinary-table entries are candidate integer
+quotients; the checker later verifies that no truncation occurred. -/
 private def dixonRationalCharacterTableCandidates (p : ℕ) [Fact p.Prime] :
     List d.IntegerCharacterTableData :=
   letI : FinEnum (ZMod p) :=
@@ -123,8 +124,8 @@ private def dixonRationalCharacterTableCandidates (p : ℕ) [Fact p.Prime] :
 
 /-- **Characterization of the candidates inspected by the rational solver.** Candidate data is
 enumerated exactly when its rows are an injective numbering of the lifted central rows, its degrees
-are positive divisors of `|G|` whose squares sum to `|G|`, and its table is the exact integer
-quotient reconstructed from the central-character table. -/
+are positive divisors of `|G|` whose squares sum to `|G|`, and its table is the integer quotient
+computed from the central-character table. -/
 private theorem mem_dixonRationalCharacterTableCandidates_iff (p : ℕ) [Fact p.Prime]
     {output : d.IntegerCharacterTableData} :
     output ∈ d.dixonRationalCharacterTableCandidates p ↔
@@ -157,12 +158,62 @@ private theorem mem_dixonRationalCharacterTableCandidates_iff (p : ℕ) [Fact p.
     · exact (htable _ _).symm
     · rfl
 
+private theorem IsIntegerCharacterTableSpec.omega_injective
+    {omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ}
+    {degree : Fin d.numClasses → ℕ}
+    (h : d.IsIntegerCharacterTableSpec omega table degree) : Function.Injective omega := by
+  intro i j hij
+  by_contra hne
+  have hproportional (k : Fin d.numClasses) :
+      (degree j : ℤ) * table i k = (degree i : ℤ) * table j k := by
+    have hi := h.degree_mul_central i k
+    have hj := h.degree_mul_central j k
+    rw [hij] at hi
+    have hcard : ((d.classFinset k).card : ℤ) ≠ 0 := by
+      exact_mod_cast (Finset.card_pos.mpr ⟨d.rep k, d.rep_mem_classFinset k⟩).ne'
+    apply mul_left_cancel₀ hcard
+    calc
+      ((d.classFinset k).card : ℤ) * ((degree j : ℤ) * table i k) =
+          (degree j : ℤ) * ((degree i : ℤ) * omega j k) := by rw [hi]; ring
+      _ = (degree i : ℤ) * ((degree j : ℤ) * omega j k) := by ring
+      _ = ((d.classFinset k).card : ℤ) * ((degree i : ℤ) * table j k) := by
+        rw [hj]
+        ring
+  have hscaled :
+      (degree j : ℤ) *
+          ∑ k, (d.classFinset k).card * table i k * table i k =
+        (degree i : ℤ) *
+          ∑ k, (d.classFinset k).card * table i k * table j k := by
+    simp only [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro k _
+    calc
+      (degree j : ℤ) * ((d.classFinset k).card * table i k * table i k) =
+          (d.classFinset k).card * table i k * ((degree j : ℤ) * table i k) := by ring
+      _ = (d.classFinset k).card * table i k * ((degree i : ℤ) * table j k) := by
+        rw [hproportional k]
+      _ = (degree i : ℤ) * ((d.classFinset k).card * table i k * table j k) := by ring
+  rw [h.row_orthogonal i i, ite_eq_left rfl, h.row_orthogonal i j, ite_eq_right hne,
+    mul_zero] at hscaled
+  exact (mul_ne_zero (by exact_mod_cast (h.degree_pos j).ne')
+    (by exact_mod_cast Fintype.card_pos.ne')) hscaled
+
+private theorem IsIntegerCharacterTableSpec.table_eq_integerQuotient
+    {omega table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ}
+    {degree : Fin d.numClasses → ℕ}
+    (h : d.IsIntegerCharacterTableSpec omega table degree) (i j : Fin d.numClasses) :
+    table i j = (degree i : ℤ) * omega i j / ((d.classFinset j).card : ℤ) := by
+  rw [h.degree_mul_central]
+  exact (Int.mul_ediv_cancel_left (table i j) (by
+    exact_mod_cast (Finset.card_pos.mpr ⟨d.rep j, d.rep_mem_classFinset j⟩).ne')).symm
+
 /-- Run the integer-valued stage of the Dixon--Schneider character-table algorithm.
 
 The modular search and signed lift determine an unordered finite set of candidate central-character
 rows. The solver enumerates its injective row numberings and the degree vectors whose positive
 entries divide `|G|` and whose squares sum to `|G|`; for each pair, the ordinary table is obtained
-by exact integer division and checked by `TauCeti.ClassData.integerCharacterTableChecker`.
+by integer quotient computation. `TauCeti.ClassData.integerCharacterTableChecker` verifies the
+division-free conversion equality, making the quotient exact for every accepted output.
 
 Soundness requires only that `p` is prime. A good-prime certificate is needed for completeness, not
 for checking a candidate returned by this function. -/
@@ -171,20 +222,22 @@ def dixonRationalCharacterTable? (p : ℕ) [Fact p.Prime] :
   (d.dixonRationalCharacterTableCandidates p).find? fun output =>
     d.integerCharacterTableChecker output.omega output.table output.degree
 
-/-- The rational solver succeeds exactly when its candidate list contains data satisfying the
-integer character-table specification. -/
+/-- The rational solver succeeds exactly when lifted central rows can be assembled into data
+satisfying the integer character-table specification. -/
 theorem isSome_dixonRationalCharacterTable_iff (p : ℕ) [Fact p.Prime] :
     (d.dixonRationalCharacterTable? p).isSome ↔
       ∃ output : d.IntegerCharacterTableData,
-        ((∀ i, output.omega i ∈ d.liftedCentralRows p) ∧ Function.Injective output.omega ∧
-          (∀ i, 0 < output.degree i) ∧ (∀ i, output.degree i ∣ Fintype.card G) ∧
-          ∑ i, output.degree i ^ 2 = Fintype.card G ∧
-          ∀ i j, output.table i j =
-            (output.degree i : ℤ) * output.omega i j / ((d.classFinset j).card : ℤ)) ∧
+        (∀ i, output.omega i ∈ d.liftedCentralRows p) ∧
         d.IsIntegerCharacterTableSpec output.omega output.table output.degree := by
   rw [dixonRationalCharacterTable?, List.find?_isSome]
-  simp only [d.integerCharacterTableChecker_eq_true_iff,
-    mem_dixonRationalCharacterTableCandidates_iff]
+  simp only [d.integerCharacterTableChecker_eq_true_iff]
+  constructor
+  · rintro ⟨output, hcandidates, hspec⟩
+    exact ⟨output, (mem_dixonRationalCharacterTableCandidates_iff d p).mp hcandidates |>.1, hspec⟩
+  · rintro ⟨output, hrows, hspec⟩
+    refine ⟨output, (mem_dixonRationalCharacterTableCandidates_iff d p).mpr ?_, hspec⟩
+    exact ⟨hrows, hspec.omega_injective, hspec.degree_pos, hspec.degree_dvd,
+      hspec.sum_degree_sq, hspec.table_eq_integerQuotient⟩
 
 /-- Every successful rational Dixon--Schneider output passes the exact integer character-table
 specification. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
@@ -39,6 +39,8 @@ no claim about that later stage is made here.
 
 * `TauCeti.ClassData.isSome_dixonRationalCharacterTable_iff`: the solver succeeds exactly when
   semantically admissible candidate data passes the integer character-table specification.
+* `TauCeti.ClassData.mem_liftedCentralRows_of_dixonRationalCharacterTable_eq_some`: the rows of a
+  successful output are lifted central-character rows.
 * `TauCeti.ClassData.isIntegerCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`: every
   successful output satisfies the exact integer specification.
 * `TauCeti.ClassData.isCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`: every successful
@@ -238,6 +240,15 @@ theorem isSome_dixonRationalCharacterTable_iff (p : ℕ) [Fact p.Prime] :
     refine ⟨output, (mem_dixonRationalCharacterTableCandidates_iff d p).mpr ?_, hspec⟩
     exact ⟨hrows, hspec.omega_injective, hspec.degree_pos, hspec.degree_dvd,
       hspec.sum_degree_sq, hspec.table_eq_integerQuotient⟩
+
+/-- The rows of a successful rational Dixon--Schneider output are lifted central-character rows,
+so the returned data is one of the numberings produced by the modular search. -/
+theorem mem_liftedCentralRows_of_dixonRationalCharacterTable_eq_some
+    {d : ClassData G} (p : ℕ) [Fact p.Prime] {output : d.IntegerCharacterTableData}
+    (h : d.dixonRationalCharacterTable? p = some output) (i : Fin d.numClasses) :
+    output.omega i ∈ d.liftedCentralRows p := by
+  simp only [dixonRationalCharacterTable?] at h
+  exact ((mem_dixonRationalCharacterTableCandidates_iff d p).mp (List.mem_of_find?_eq_some h)).1 i
 
 /-- Every successful rational Dixon--Schneider output passes the exact integer character-table
 specification. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
@@ -13,7 +13,7 @@ public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Rational.Basic
 # The assembled rational Dixon--Schneider solver
 
 This file assembles the integer-valued stage of the Burnside--Dixon--Schneider character-table
-algorithm. Given executable conjugacy-class data and a certified Dixon prime, it performs the
+algorithm. Given executable conjugacy-class data and a prime, it performs the
 modular common-eigenrow search, lifts the rows by signed least representatives, searches the
 possible positive character degrees dividing the group order, and reconstructs the ordinary table
 from the central-character table. It returns the first candidate accepted by the exact integer
@@ -22,9 +22,9 @@ checker.
 The result is an `Option`: `none` honestly records that the character table is not integer-valued,
 that the chosen residue window was too small, or that no ordering of the lifted rows passed the
 checker. A successful result is certified by
-`TauCeti.ClassData.isIntegerCharacterTableSpec_of_rationalCharacterTableDixon_eq_some` and hence,
+`TauCeti.ClassData.isIntegerCharacterTableSpec_of_dixonRationalCharacterTable_eq_some` and hence,
 after embedding in `ℂ`, by
-`TauCeti.ClassData.isCharacterTableSpec_of_rationalCharacterTableDixon_eq_some`.
+`TauCeti.ClassData.isCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`.
 
 This is the first assembled solver promised by the rational-table stage of the character-theory
 roadmap. The later general solver replaces signed integer lifting by the structured cyclotomic lift;
@@ -32,8 +32,17 @@ no claim about that later stage is made here.
 
 ## Main definitions
 
-* `TauCeti.ClassData.IntegerCharacterTable`: the numbered exact output data.
-* `TauCeti.ClassData.rationalCharacterTableDixon`: the executable rational-stage solver.
+* `TauCeti.ClassData.IntegerCharacterTableData`: candidate numbered exact output data.
+* `TauCeti.ClassData.liftedCentralRowsList`: an executable enumeration of the existing lifted-row
+  finset.
+* `TauCeti.ClassData.dixonRationalCharacterTable?`: the executable rational-stage solver.
+
+## Main results
+
+* `TauCeti.ClassData.isIntegerCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`: every
+  successful output satisfies the exact integer specification.
+* `TauCeti.ClassData.isCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`: every successful
+  output gives a complex character table up to row permutation.
 
 ## References
 
@@ -55,50 +64,40 @@ universe u
 
 variable {G : Type u} [Group G] (d : ClassData G)
 
-/-- The three exact numbered arrays produced by the integer-valued Dixon--Schneider solver: the
-central-character table, the ordinary character table, and the character degrees. -/
+/-- Candidate numbered data for the integer-valued Dixon--Schneider solver. Normalization,
+positivity, and correctness hold only after the candidate passes `integerCharacterTableChecker`. -/
 @[ext]
-structure IntegerCharacterTable where
-  /-- The normalized central-character table. -/
+structure IntegerCharacterTableData where
+  /-- A candidate central-character table. -/
   omega : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ
-  /-- The ordinary character table. -/
+  /-- A candidate ordinary character table. -/
   table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ
-  /-- The positive character degrees. -/
+  /-- Candidate character degrees. -/
   degree : Fin d.numClasses → ℕ
 
-/-- Decidability of equality between integer character tables. -/
-instance : DecidableEq d.IntegerCharacterTable := by
-  intro ⟨o1, t1, deg1⟩ ⟨o2, t2, deg2⟩
-  by_cases ho : o1 = o2
-  · by_cases ht : t1 = t2
-    · by_cases hd : deg1 = deg2
-      · exact isTrue (by rw [ho, ht, hd])
-      · exact isFalse (by intro h; cases h; exact hd rfl)
-    · exact isFalse (by intro h; cases h; exact ht rfl)
-  · exact isFalse (by intro h; cases h; exact ho rfl)
-
 variable [Fintype G] [DecidableEq G]
-variable {d}
 
-/-- Run the integer-valued stage of the Dixon--Schneider character-table algorithm.
+/-- An executable list of the signed integral lifts of the modular central-character search. Its
+body is exposed so downstream acceptance examples can check the concrete enumeration. -/
+@[expose] def liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)] :
+    List (Fin d.numClasses → ℤ) :=
+  ((FinEnum.toList (Fin d.numClasses → ZMod p)).filter fun row =>
+    row ∈ d.centralCharacterSearch (F := ZMod p)).map fun row j => (row j).valMinAbs
 
-The modular search and signed lift determine an unordered finite set of candidate central-character
-rows. The solver enumerates its injective row numberings and the degree vectors whose positive
-entries divide `|G|` and whose squares sum to `|G|`; for each pair, the ordinary table is obtained
-by exact integer division and checked by `TauCeti.ClassData.integerCharacterTableChecker`. -/
-@[expose] def rationalCharacterTableDixon (q : DixonPrimeData G) :
-    Option d.IntegerCharacterTable :=
-  letI : Fact q.p.Prime := q.fact_prime
-  letI : FinEnum (ZMod q.p) :=
-    FinEnum.ofEquiv (Fin q.p) (ZMod.finEquiv q.p).symm.toEquiv
-  let searchedRows := d.centralCharacterSearch (F := ZMod q.p)
-  -- `Finset.toList` is noncomputable. Enumerating the finite row type and retaining exactly the
-  -- members of the already-computed search gives its rows a deterministic executable order.
-  let modularRows : List (Fin d.numClasses → ZMod q.p) :=
-    (FinEnum.toList (Fin d.numClasses → ZMod q.p)).filter fun row =>
-      row ∈ searchedRows
-  let liftedRows : List (Fin d.numClasses → ℤ) :=
-    modularRows.map fun row j => (row j).valMinAbs
+/-- The executable lifted-row list enumerates exactly `liftedCentralRows`. -/
+@[simp]
+theorem liftedCentralRowsList_toFinset (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)] :
+    (d.liftedCentralRowsList p).toFinset = d.liftedCentralRows p := by
+  ext row
+  simp [liftedCentralRowsList, liftedCentralRows]
+
+/-- Enumerate the candidate data inspected by the rational Dixon--Schneider solver. Its body is
+exposed so downstream acceptance examples can exhibit a successful candidate. -/
+@[expose] def dixonRationalCharacterTableCandidates (p : ℕ) [Fact p.Prime] :
+    List d.IntegerCharacterTableData :=
+  letI : FinEnum (ZMod p) :=
+    FinEnum.ofEquiv (Fin p) (ZMod.finEquiv p).symm.toEquiv
+  let liftedRows := d.liftedCentralRowsList p
   let rowAssignments :=
     (FinEnum.toList (Fin d.numClasses → {row // row ∈ liftedRows})).filter fun rows =>
       decide (Function.Injective rows)
@@ -106,35 +105,55 @@ by exact integer division and checked by `TauCeti.ClassData.integerCharacterTabl
   let degreeAssignments :=
     (FinEnum.toList (Fin d.numClasses → Degree)).filter fun degree =>
       decide (∑ i, (degree i : ℕ) ^ 2 = Fintype.card G)
-  let candidates : List d.IntegerCharacterTable :=
-    rowAssignments.flatMap fun rows => degreeAssignments.map fun degrees =>
-      let omega : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ :=
-        fun i => rows i
-      let degree : Fin d.numClasses → ℕ := fun i => degrees i
-      { omega := omega
-        degree := degree
-        table := fun i j =>
-          (degree i : ℤ) * omega i j / (d.classFinset j).card }
-  candidates.find? fun output =>
+  rowAssignments.flatMap fun rows => degreeAssignments.map fun degrees =>
+    let omega : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ :=
+      fun i => rows i
+    let degree : Fin d.numClasses → ℕ := fun i => degrees i
+    { omega := omega
+      degree := degree
+      table := fun i j =>
+        (degree i : ℤ) * omega i j / (d.classFinset j).card }
+
+/-- Run the integer-valued stage of the Dixon--Schneider character-table algorithm.
+
+The modular search and signed lift determine an unordered finite set of candidate central-character
+rows. The solver enumerates its injective row numberings and the degree vectors whose positive
+entries divide `|G|` and whose squares sum to `|G|`; for each pair, the ordinary table is obtained
+by exact integer division and checked by `TauCeti.ClassData.integerCharacterTableChecker`.
+
+Soundness requires only that `p` is prime. A good-prime certificate is needed for completeness, not
+for checking a candidate returned by this function. -/
+def dixonRationalCharacterTable? (p : ℕ) [Fact p.Prime] :
+    Option d.IntegerCharacterTableData :=
+  (d.dixonRationalCharacterTableCandidates p).find? fun output =>
     d.integerCharacterTableChecker output.omega output.table output.degree
+
+/-- The rational solver succeeds exactly when its candidate list contains data satisfying the
+integer character-table specification. -/
+theorem isSome_dixonRationalCharacterTable_iff (p : ℕ) [Fact p.Prime] :
+    (d.dixonRationalCharacterTable? p).isSome ↔
+      ∃ output ∈ d.dixonRationalCharacterTableCandidates p,
+        d.IsIntegerCharacterTableSpec output.omega output.table output.degree := by
+  rw [dixonRationalCharacterTable?, List.find?_isSome]
+  simp only [d.integerCharacterTableChecker_eq_true_iff]
 
 /-- Every successful rational Dixon--Schneider output passes the exact integer character-table
 specification. -/
-theorem isIntegerCharacterTableSpec_of_rationalCharacterTableDixon_eq_some
-    (q : DixonPrimeData G) {output : d.IntegerCharacterTable}
-    (h : d.rationalCharacterTableDixon q = some output) :
+theorem isIntegerCharacterTableSpec_of_dixonRationalCharacterTable_eq_some
+    {d : ClassData G} (p : ℕ) [Fact p.Prime] {output : d.IntegerCharacterTableData}
+    (h : d.dixonRationalCharacterTable? p = some output) :
     d.IsIntegerCharacterTableSpec output.omega output.table output.degree := by
-  simp only [rationalCharacterTableDixon] at h
+  simp only [dixonRationalCharacterTable?] at h
   have hcheck := List.find?_some h
   exact (d.integerCharacterTableChecker_eq_true_iff _ _ _).mp hcheck
 
 /-- Every successful rational Dixon--Schneider output, cast to `ℂ` and reindexed by conjugacy
 classes, satisfies the complex character-table specification. -/
-theorem isCharacterTableSpec_of_rationalCharacterTableDixon_eq_some
-    (q : DixonPrimeData G) {output : d.IntegerCharacterTable}
-    (h : d.rationalCharacterTableDixon q = some output) :
+theorem isCharacterTableSpec_of_dixonRationalCharacterTable_eq_some
+    {d : ClassData G} (p : ℕ) [Fact p.Prime] {output : d.IntegerCharacterTableData}
+    (h : d.dixonRationalCharacterTable? p = some output) :
     IsCharacterTableSpec G (d.complexTableOfInteger output.table) :=
-  (d.isIntegerCharacterTableSpec_of_rationalCharacterTableDixon_eq_some q h).isCharacterTableSpec
+  (d.isIntegerCharacterTableSpec_of_dixonRationalCharacterTable_eq_some p h).isCharacterTableSpec
 
 end ClassData
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
@@ -39,6 +39,9 @@ no claim about that later stage is made here.
 
 ## Main results
 
+* `TauCeti.ClassData.mem_dixonRationalCharacterTableCandidates_iff`: the candidates inspected by
+  the solver are exactly the injectively numbered lifted rows paired with the admissible degree
+  vectors.
 * `TauCeti.ClassData.isIntegerCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`: every
   successful output satisfies the exact integer specification.
 * `TauCeti.ClassData.isCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`: every successful
@@ -77,9 +80,8 @@ structure IntegerCharacterTableData where
 
 variable [Fintype G] [DecidableEq G]
 
-/-- An executable list of the signed integral lifts of the modular central-character search. Its
-body is exposed so downstream acceptance examples can check the concrete enumeration. -/
-@[expose] def liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)] :
+/-- An executable list of the signed integral lifts of the modular central-character search. -/
+def liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)] :
     List (Fin d.numClasses → ℤ) :=
   ((FinEnum.toList (Fin d.numClasses → ZMod p)).filter fun row =>
     row ∈ d.centralCharacterSearch (F := ZMod p)).map fun row j => (row j).valMinAbs
@@ -91,9 +93,17 @@ theorem liftedCentralRowsList_toFinset (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p
   ext row
   simp [liftedCentralRowsList, liftedCentralRows]
 
-/-- Enumerate the candidate data inspected by the rational Dixon--Schneider solver. Its body is
-exposed so downstream acceptance examples can exhibit a successful candidate. -/
-@[expose] def dixonRationalCharacterTableCandidates (p : ℕ) [Fact p.Prime] :
+/-- A row is enumerated by `liftedCentralRowsList` exactly when it is a lifted central row. -/
+@[simp]
+theorem mem_liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)]
+    {row : Fin d.numClasses → ℤ} :
+    row ∈ d.liftedCentralRowsList p ↔ row ∈ d.liftedCentralRows p := by
+  rw [← List.mem_toFinset, liftedCentralRowsList_toFinset]
+
+/-- Enumerate the candidate data inspected by the rational Dixon--Schneider solver: every
+injective numbering of the lifted central rows, paired with every degree vector whose positive
+entries divide `|G|` and whose squares sum to `|G|`. -/
+def dixonRationalCharacterTableCandidates (p : ℕ) [Fact p.Prime] :
     List d.IntegerCharacterTableData :=
   letI : FinEnum (ZMod p) :=
     FinEnum.ofEquiv (Fin p) (ZMod.finEquiv p).symm.toEquiv
@@ -113,6 +123,42 @@ exposed so downstream acceptance examples can exhibit a successful candidate. -/
       degree := degree
       table := fun i j =>
         (degree i : ℤ) * omega i j / (d.classFinset j).card }
+
+/-- **Characterization of the candidates inspected by the rational solver.** Candidate data is
+enumerated exactly when its rows are an injective numbering of the lifted central rows, its degrees
+are positive divisors of `|G|` whose squares sum to `|G|`, and its table is the exact integer
+quotient reconstructed from the central-character table. -/
+theorem mem_dixonRationalCharacterTableCandidates_iff (p : ℕ) [Fact p.Prime]
+    {output : d.IntegerCharacterTableData} :
+    output ∈ d.dixonRationalCharacterTableCandidates p ↔
+      (∀ i, output.omega i ∈ d.liftedCentralRows p) ∧ Function.Injective output.omega ∧
+        (∀ i, 0 < output.degree i) ∧ (∀ i, output.degree i ∣ Fintype.card G) ∧
+        ∑ i, output.degree i ^ 2 = Fintype.card G ∧
+        ∀ i j, output.table i j =
+          (output.degree i : ℤ) * output.omega i j / ((d.classFinset j).card : ℤ) := by
+  -- the enumeration instance must be the one the definition installs, not a synthesized one
+  let _ : FinEnum (ZMod p) := FinEnum.ofEquiv (Fin p) (ZMod.finEquiv p).symm.toEquiv
+  simp only [dixonRationalCharacterTableCandidates, List.mem_flatMap, List.mem_map,
+    List.mem_filter, FinEnum.mem_toList, true_and, decide_eq_true_eq]
+  constructor
+  · rintro ⟨rows, hrows, degrees, hdegrees, rfl⟩
+    refine ⟨fun i => (mem_liftedCentralRowsList d p).mp (rows i).2, ?_, ?_, ?_, ?_, ?_⟩
+    · exact fun i j hij => hrows (Subtype.ext hij)
+    · exact fun i => Nat.pos_of_ne_zero fun h => (degrees i).2.1 (Fin.val_eq_zero_iff.mp h)
+    · exact fun i => (degrees i).2.2
+    · exact hdegrees
+    · exact fun i j => rfl
+  · rintro ⟨hrow, hinj, hpos, hdvd, hsum, htable⟩
+    have hlt : ∀ i, output.degree i < Fintype.card G + 1 := fun i =>
+      Nat.lt_succ_of_le (Nat.le_of_dvd Fintype.card_pos (hdvd i))
+    refine ⟨fun i => ⟨output.omega i, (mem_liftedCentralRowsList d p).mpr (hrow i)⟩,
+      fun i j hij => hinj (congrArg Subtype.val hij),
+      fun i => ⟨⟨output.degree i, hlt i⟩, Fin.val_ne_zero_iff.mp (hpos i).ne', hdvd i⟩,
+      hsum, ?_⟩
+    ext
+    · rfl
+    · exact (htable _ _).symm
+    · rfl
 
 /-- Run the integer-valued stage of the Dixon--Schneider character-table algorithm.
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
@@ -33,15 +33,12 @@ no claim about that later stage is made here.
 ## Main definitions
 
 * `TauCeti.ClassData.IntegerCharacterTableData`: candidate numbered exact output data.
-* `TauCeti.ClassData.liftedCentralRowsList`: an executable enumeration of the existing lifted-row
-  finset.
 * `TauCeti.ClassData.dixonRationalCharacterTable?`: the executable rational-stage solver.
 
 ## Main results
 
-* `TauCeti.ClassData.mem_dixonRationalCharacterTableCandidates_iff`: the candidates inspected by
-  the solver are exactly the injectively numbered lifted rows paired with the admissible degree
-  vectors.
+* `TauCeti.ClassData.isSome_dixonRationalCharacterTable_iff`: the solver succeeds exactly when
+  semantically admissible candidate data passes the integer character-table specification.
 * `TauCeti.ClassData.isIntegerCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`: every
   successful output satisfies the exact integer specification.
 * `TauCeti.ClassData.isCharacterTableSpec_of_dixonRationalCharacterTable_eq_some`: every successful
@@ -81,21 +78,21 @@ structure IntegerCharacterTableData where
 variable [Fintype G] [DecidableEq G]
 
 /-- An executable list of the signed integral lifts of the modular central-character search. -/
-def liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)] :
+private def liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)] :
     List (Fin d.numClasses → ℤ) :=
   ((FinEnum.toList (Fin d.numClasses → ZMod p)).filter fun row =>
     row ∈ d.centralCharacterSearch (F := ZMod p)).map fun row j => (row j).valMinAbs
 
 /-- The executable lifted-row list enumerates exactly `liftedCentralRows`. -/
 @[simp]
-theorem liftedCentralRowsList_toFinset (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)] :
+private theorem liftedCentralRowsList_toFinset (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)] :
     (d.liftedCentralRowsList p).toFinset = d.liftedCentralRows p := by
   ext row
   simp [liftedCentralRowsList, liftedCentralRows]
 
 /-- A row is enumerated by `liftedCentralRowsList` exactly when it is a lifted central row. -/
 @[simp]
-theorem mem_liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)]
+private theorem mem_liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)]
     {row : Fin d.numClasses → ℤ} :
     row ∈ d.liftedCentralRowsList p ↔ row ∈ d.liftedCentralRows p := by
   rw [← List.mem_toFinset, liftedCentralRowsList_toFinset]
@@ -103,7 +100,7 @@ theorem mem_liftedCentralRowsList (p : ℕ) [Fact p.Prime] [FinEnum (ZMod p)]
 /-- Enumerate the candidate data inspected by the rational Dixon--Schneider solver: every
 injective numbering of the lifted central rows, paired with every degree vector whose positive
 entries divide `|G|` and whose squares sum to `|G|`. -/
-def dixonRationalCharacterTableCandidates (p : ℕ) [Fact p.Prime] :
+private def dixonRationalCharacterTableCandidates (p : ℕ) [Fact p.Prime] :
     List d.IntegerCharacterTableData :=
   letI : FinEnum (ZMod p) :=
     FinEnum.ofEquiv (Fin p) (ZMod.finEquiv p).symm.toEquiv
@@ -128,7 +125,7 @@ def dixonRationalCharacterTableCandidates (p : ℕ) [Fact p.Prime] :
 enumerated exactly when its rows are an injective numbering of the lifted central rows, its degrees
 are positive divisors of `|G|` whose squares sum to `|G|`, and its table is the exact integer
 quotient reconstructed from the central-character table. -/
-theorem mem_dixonRationalCharacterTableCandidates_iff (p : ℕ) [Fact p.Prime]
+private theorem mem_dixonRationalCharacterTableCandidates_iff (p : ℕ) [Fact p.Prime]
     {output : d.IntegerCharacterTableData} :
     output ∈ d.dixonRationalCharacterTableCandidates p ↔
       (∀ i, output.omega i ∈ d.liftedCentralRows p) ∧ Function.Injective output.omega ∧
@@ -178,10 +175,16 @@ def dixonRationalCharacterTable? (p : ℕ) [Fact p.Prime] :
 integer character-table specification. -/
 theorem isSome_dixonRationalCharacterTable_iff (p : ℕ) [Fact p.Prime] :
     (d.dixonRationalCharacterTable? p).isSome ↔
-      ∃ output ∈ d.dixonRationalCharacterTableCandidates p,
+      ∃ output : d.IntegerCharacterTableData,
+        ((∀ i, output.omega i ∈ d.liftedCentralRows p) ∧ Function.Injective output.omega ∧
+          (∀ i, 0 < output.degree i) ∧ (∀ i, output.degree i ∣ Fintype.card G) ∧
+          ∑ i, output.degree i ^ 2 = Fintype.card G ∧
+          ∀ i j, output.table i j =
+            (output.degree i : ℤ) * output.omega i j / ((d.classFinset j).card : ℤ)) ∧
         d.IsIntegerCharacterTableSpec output.omega output.table output.degree := by
   rw [dixonRationalCharacterTable?, List.find?_isSome]
-  simp only [d.integerCharacterTableChecker_eq_true_iff]
+  simp only [d.integerCharacterTableChecker_eq_true_iff,
+    mem_dixonRationalCharacterTableCandidates_iff]
 
 /-- Every successful rational Dixon--Schneider output passes the exact integer character-table
 specification. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Dixon/Rational/Solver.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.FinEnum
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.IntegerChecker
+public import TauCeti.RepresentationTheory.CharacterTable.Dixon.Rational.Basic
+
+/-!
+# The assembled rational Dixon--Schneider solver
+
+This file assembles the integer-valued stage of the Burnside--Dixon--Schneider character-table
+algorithm. Given executable conjugacy-class data and a certified Dixon prime, it performs the
+modular common-eigenrow search, lifts the rows by signed least representatives, searches the
+possible positive character degrees dividing the group order, and reconstructs the ordinary table
+from the central-character table. It returns the first candidate accepted by the exact integer
+checker.
+
+The result is an `Option`: `none` honestly records that the character table is not integer-valued,
+that the chosen residue window was too small, or that no ordering of the lifted rows passed the
+checker. A successful result is certified by
+`TauCeti.ClassData.isIntegerCharacterTableSpec_of_rationalCharacterTableDixon_eq_some` and hence,
+after embedding in `ℂ`, by
+`TauCeti.ClassData.isCharacterTableSpec_of_rationalCharacterTableDixon_eq_some`.
+
+This is the first assembled solver promised by the rational-table stage of the character-theory
+roadmap. The later general solver replaces signed integer lifting by the structured cyclotomic lift;
+no claim about that later stage is made here.
+
+## Main definitions
+
+* `TauCeti.ClassData.IntegerCharacterTable`: the numbered exact output data.
+* `TauCeti.ClassData.rationalCharacterTableDixon`: the executable rational-stage solver.
+
+## References
+
+* J. D. Dixon, *High speed computation of group characters*, Numerische Mathematik 10 (1967),
+  446--450.
+* G. Schneider, *Dixon's character table algorithm revisited*, Journal of Symbolic Computation 9
+  (1990), 601--606.
+-/
+
+public section
+
+namespace TauCeti
+
+open Matrix
+
+namespace ClassData
+
+universe u
+
+variable {G : Type u} [Group G] [Fintype G] [DecidableEq G]
+variable (d : ClassData G)
+
+/-- The three exact numbered arrays produced by the integer-valued Dixon--Schneider solver: the
+central-character table, the ordinary character table, and the character degrees. -/
+@[ext]
+structure IntegerCharacterTable where
+  /-- The normalized central-character table. -/
+  omega : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ
+  /-- The ordinary character table. -/
+  table : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ
+  /-- The positive character degrees. -/
+  degree : Fin d.numClasses → ℕ
+deriving DecidableEq
+
+variable {d}
+
+/-- Run the integer-valued stage of the Dixon--Schneider character-table algorithm.
+
+The modular search and signed lift determine an unordered finite set of candidate central-character
+rows. The solver enumerates its injective row numberings and the degree vectors whose positive
+entries divide `|G|` and whose squares sum to `|G|`; for each pair, the ordinary table is obtained
+by exact integer division and checked by `TauCeti.ClassData.integerCharacterTableChecker`. -/
+@[expose] def rationalCharacterTableDixon (q : DixonPrimeData G) :
+    Option d.IntegerCharacterTable :=
+  letI : Fact q.p.Prime := q.fact_prime
+  letI : FinEnum (ZMod q.p) :=
+    FinEnum.ofEquiv (Fin q.p) (ZMod.finEquiv q.p).symm.toEquiv
+  let searchedRows := d.centralCharacterSearch (F := ZMod q.p)
+  -- `Finset.toList` is noncomputable. Enumerating the finite row type and retaining exactly the
+  -- members of the already-computed search gives its rows a deterministic executable order.
+  let modularRows : List (Fin d.numClasses → ZMod q.p) :=
+    (FinEnum.toList (Fin d.numClasses → ZMod q.p)).filter fun row =>
+      row ∈ searchedRows
+  let liftedRows : List (Fin d.numClasses → ℤ) :=
+    modularRows.map fun row j => (row j).valMinAbs
+  let rowAssignments :=
+    (FinEnum.toList (Fin d.numClasses → {row // row ∈ liftedRows})).filter fun rows =>
+      decide (Function.Injective rows)
+  let Degree := {n : Fin (Fintype.card G + 1) // n ≠ 0 ∧ (n : ℕ) ∣ Fintype.card G}
+  let degreeAssignments :=
+    (FinEnum.toList (Fin d.numClasses → Degree)).filter fun degree =>
+      decide (∑ i, (degree i : ℕ) ^ 2 = Fintype.card G)
+  let candidates : List d.IntegerCharacterTable :=
+    rowAssignments.flatMap fun rows => degreeAssignments.map fun degrees =>
+      let omega : Matrix (Fin d.numClasses) (Fin d.numClasses) ℤ :=
+        fun i => rows i
+      let degree : Fin d.numClasses → ℕ := fun i => degrees i
+      { omega := omega
+        degree := degree
+        table := fun i j =>
+          (degree i : ℤ) * omega i j / (d.classFinset j).card }
+  candidates.find? fun output =>
+    d.integerCharacterTableChecker output.omega output.table output.degree
+
+/-- Every successful rational Dixon--Schneider output passes the exact integer character-table
+specification. -/
+theorem isIntegerCharacterTableSpec_of_rationalCharacterTableDixon_eq_some
+    (q : DixonPrimeData G) {output : d.IntegerCharacterTable}
+    (h : d.rationalCharacterTableDixon q = some output) :
+    d.IsIntegerCharacterTableSpec output.omega output.table output.degree := by
+  simp only [rationalCharacterTableDixon] at h
+  have hcheck := List.find?_some h
+  exact (d.integerCharacterTableChecker_eq_true_iff _ _ _).mp hcheck
+
+/-- Every successful rational Dixon--Schneider output, cast to `ℂ` and reindexed by conjugacy
+classes, satisfies the complex character-table specification. -/
+theorem isCharacterTableSpec_of_rationalCharacterTableDixon_eq_some
+    (q : DixonPrimeData G) {output : d.IntegerCharacterTable}
+    (h : d.rationalCharacterTableDixon q = some output) :
+    IsCharacterTableSpec G (d.complexTableOfInteger output.table) :=
+  (d.isIntegerCharacterTableSpec_of_rationalCharacterTableDixon_eq_some q h).isCharacterTableSpec
+
+end ClassData
+
+end TauCeti


### PR DESCRIPTION
This PR assembles the first generic executable Dixon--Schneider solver for integer-valued character tables. It advances `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, Layer 6, the **assembled solver** target, at the staged **Rational tables (first executable milestone)**.

`ClassData.dixonRationalCharacterTable?` takes executable `ClassData G` and a prime `p`. It enumerates the existing modular central-character search, lifts it through an executable list whose finset is proved equal to `ClassData.liftedCentralRows`, enumerates injective row numberings and positive divisor-valued degree vectors whose squares sum to `|G|`, reconstructs candidate ordinary-table entries by integer quotient computation, with exactness verified by the checker’s division-free equality, and returns the first candidate accepted by `integerCharacterTableChecker`. The output is optional because the table may not be integer-valued, the residue window may be too small, or no candidate may pass the checker. A good-prime certificate is needed for completeness, but not for soundness of a returned candidate.

`isIntegerCharacterTableSpec_of_dixonRationalCharacterTable_eq_some` proves every successful exact output satisfies the integer specification. `isCharacterTableSpec_of_dixonRationalCharacterTable_eq_some` reuses the existing checker bridge to show that its cast-and-reindexed complex table satisfies `IsCharacterTableSpec`, hence is the character table up to row permutation. The unchecked output bundle is named `IntegerCharacterTableData` to distinguish candidate data from a certified table.

The existing `C₂` worked example supplies `isIntegerCharacterTableSpec_cyclicGroupTwo`, `isCharacterTableSpec_cyclicGroupTwo`, and `isSome_dixonRationalCharacterTable_cyclicGroupTwo`. The last theorem exhibits the displayed rows and degrees in the solver's actual candidate enumeration and proves that the assembled solver succeeds on the certified prime `3`.

After this PR, Layer 6 still needs the general structured cyclotomic solver and summit theorem, including the small-cyclotomic `C₃`/`A₄` stage and the final `S₄`/`A₅` acceptance examples; this PR completes only the rational assembled-solver rung.

The implementation reuses `ClassData.centralCharacterSearch`, `ClassData.liftedCentralRows`, `ZMod.valMinAbs`, `IsIntegerCharacterTableSpec`, and `integerCharacterTableChecker`. No Mathlib source or external formalization is vendored. The algorithm follows J. D. Dixon, *High speed computation of group characters* (1967), and G. Schneider, *Dixon's character table algorithm revisited* (1990), both cited in the module documentation.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"rational-character-table-dixon"}-->

🤖 Prepared with Codex
